### PR TITLE
Override nonce rpc

### DIFF
--- a/src/flashblocks.rs
+++ b/src/flashblocks.rs
@@ -349,6 +349,22 @@ fn get_and_set_txs_and_receipts(
                 error!("Failed to set transaction index in cache: {}", e);
                 continue;
             }
+
+            // update tx count for each from address
+            if let Ok(from) = transaction.recover_signer() {
+                // Get current tx count, default to 0 if not found
+                let current_count = cache
+                    .get::<u64>(&format!("tx_count:{}:{}", from, block_number))
+                    .unwrap_or(0);
+                // Increment tx count by 1
+                if let Err(e) = cache.set(
+                    &format!("tx_count:{}:{}", from, block_number),
+                    &(current_count + 1),
+                    Some(10),
+                ) {
+                    error!("Failed to set transaction count in cache: {}", e);
+                }
+            }
         }
 
         // TODO: move this into the transaction check

--- a/src/integration/integration_test.rs
+++ b/src/integration/integration_test.rs
@@ -255,6 +255,21 @@ mod tests {
         let nonce = U256::from_str(response["result"].as_str().unwrap()).unwrap();
         assert_eq!(nonce, U256::from_str("0x1").unwrap());
 
+        // check latest nonce, should still be 0
+        let output = std::process::Command::new("curl")
+        .arg("http://localhost:1238")
+        .arg("-X")
+        .arg("POST")
+        .arg("-H")
+        .arg("Content-Type: application/json")
+        .arg("-d")
+        .arg(r#"{"jsonrpc":"2.0","method":"eth_getTransactionCount","params":["0x6e5e56b972374e4fde8390df0033397df931a49d","latest"],"id":1}"#)
+        .output()?;
+
+        let response: serde_json::Value = serde_json::from_slice(&output.stdout)?;
+        let nonce = U256::from_str(response["result"].as_str().unwrap()).unwrap();
+        assert_eq!(nonce, U256::from_str("0x0").unwrap());
+
         // Don't forget to cleanup
         ws_server.abort();
         Ok(())

--- a/src/integration/integration_test.rs
+++ b/src/integration/integration_test.rs
@@ -7,7 +7,6 @@ mod tests {
     use alloy_primitives::{Address, Bytes, B256, U256};
     use alloy_provider::Identity;
     use alloy_provider::{Provider, ProviderBuilder};
-    use alloy_rpc_types::BlockTransactionsKind;
     use alloy_rpc_types_engine::PayloadId;
     use futures::SinkExt;
     use futures_util::StreamExt;
@@ -240,6 +239,21 @@ mod tests {
         let response: serde_json::Value = serde_json::from_slice(&output.stdout)?;
         let balance = U256::from_str(response["result"].as_str().unwrap()).unwrap();
         assert_eq!(balance, U256::from_str("0x1234").unwrap());
+
+        // check nonce
+        let output = std::process::Command::new("curl")
+        .arg("http://localhost:1238")
+        .arg("-X")
+        .arg("POST")
+        .arg("-H")
+        .arg("Content-Type: application/json")
+        .arg("-d")
+        .arg(r#"{"jsonrpc":"2.0","method":"eth_getTransactionCount","params":["0x6e5e56b972374e4fde8390df0033397df931a49d","pending"],"id":1}"#)
+        .output()?;
+
+        let response: serde_json::Value = serde_json::from_slice(&output.stdout)?;
+        let nonce = U256::from_str(response["result"].as_str().unwrap()).unwrap();
+        assert_eq!(nonce, U256::from_str("0x1").unwrap());
 
         // Don't forget to cleanup
         ws_server.abort();


### PR DESCRIPTION
Currently when users try to send a transaction right after preconf it would error because the nonce isn't updated. Thus overriding the nonce rpc so that users can also get the correct nonce (with "pending" tag) that takes account of the flashblock txs.

Tested in sepolia-alpha