### PR TITLE
Add websocket message processing duration metric

### DIFF
--- a/src/flashblocks.rs
+++ b/src/flashblocks.rs
@@ -78,6 +78,8 @@ impl FlashblocksClient {
                         // Handle incoming messages
                         while let Some(msg) = read.next().await {
                             metrics.upstream_messages.increment(1);
+                            let msg_start_time = Instant::now();
+
                             match msg {
                                 Ok(Message::Binary(bytes)) => {
                                     // Decode binary message to string first
@@ -101,6 +103,9 @@ impl FlashblocksClient {
 
                                     let _ =
                                         sender.send(ActorMessage::BestPayload { payload }).await;
+                                    metrics
+                                        .websocket_processing_duration
+                                        .record(msg_start_time.elapsed());
                                 }
                                 Ok(Message::Close(_)) => break,
                                 Err(e) => {

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -12,6 +12,9 @@ pub struct Metrics {
     #[metric(describe = "Time taken to process a message")]
     pub block_processing_duration: Histogram,
 
+    #[metric(describe = "Time taken to process a websocket message")]
+    pub websocket_processing_duration: Histogram,
+
     #[metric(describe = "Count of times flashblocks get_transaction_count is called")]
     pub get_transaction_count: Counter,
 


### PR DESCRIPTION
- Introduced a new metric to track the time taken to process websocket messages in the FlashblocksClient.
- Updated the metrics struct to include websocket_processing_duration.
- Recorded processing duration in the message handling logic.