### PR TITLE
feat(CHAIN-837): Add 'call' metric to Metrics struct and implement EthApiOverride::call method

### DIFF
--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -26,4 +26,7 @@ pub struct Metrics {
 
     #[metric(describe = "Count of times flashblocks get_block_by_number is called")]
     pub get_block_by_number: Counter,
+
+    #[metric(describe = "Count of times flashblocks call is called")]
+    pub call: Counter,
 }


### PR DESCRIPTION
This commit introduces a new metric for tracking the count of times the 'call' method is invoked. Additionally, the EthApiOverride trait is updated to include the 'call' method, which processes transaction requests and interacts with the pending block state.


TODO: Write test