### PR TITLE
(fix): Preload txn receipt from eth_api for historical deposit txns

### DIFF
--- a/crates/flashblocks-rpc/src/rpc.rs
+++ b/crates/flashblocks-rpc/src/rpc.rs
@@ -13,6 +13,7 @@ use jsonrpsee::{
     proc_macros::rpc,
 };
 use op_alloy_consensus::OpTxEnvelope;
+use op_alloy_consensus::{OpDepositReceipt, OpReceiptEnvelope};
 use op_alloy_network::Optimism;
 use op_alloy_rpc_types::Transaction;
 use reth::providers::TransactionsProvider;
@@ -102,7 +103,7 @@ impl<E> EthApiExt<E> {
                         index: Some(idx as u64),
                         base_fee: block.base_fee_per_gas,
                     };
-                    self.transform_tx(signed_tx_ec_recovered, tx_info)
+                    self.transform_tx(signed_tx_ec_recovered, tx_info, None)
                 })
                 .collect();
             RpcBlock::<Optimism> {
@@ -126,19 +127,26 @@ impl<E> EthApiExt<E> {
         &self,
         tx: Recovered<OpTransactionSigned>,
         tx_info: TransactionInfo,
+        deposit_receipt: Option<OpDepositReceipt>,
     ) -> Transaction {
         let tx = tx.convert::<OpTxEnvelope>();
         let mut deposit_receipt_version = None;
         let mut deposit_nonce = None;
 
         if tx.is_deposit() {
-            let receipt = self
-                .cache
-                .get::<OpReceipt>(&format!("receipt:{:?}", tx_info.hash.unwrap().to_string()))
-                .unwrap();
-            if let OpReceipt::Deposit(receipt) = receipt {
+            if let Some(receipt) = deposit_receipt {
                 deposit_receipt_version = receipt.deposit_receipt_version;
                 deposit_nonce = receipt.deposit_nonce;
+            } else {
+                let cached_receipt = self
+                    .cache
+                    .get::<OpReceipt>(&format!("receipt:{:?}", tx_info.hash.unwrap().to_string()))
+                    .unwrap();
+
+                if let OpReceipt::Deposit(receipt) = cached_receipt {
+                    deposit_receipt_version = receipt.deposit_receipt_version;
+                    deposit_nonce = receipt.deposit_nonce;
+                }
             }
         }
 
@@ -370,7 +378,7 @@ where
                 TransactionSource::Pool(tx) => {
                     // Convert the pool transaction
                     let tx_info = TransactionInfo::default();
-                    Ok(Some(self.transform_tx(tx, tx_info)))
+                    Ok(Some(self.transform_tx(tx, tx_info, None)))
                 }
                 TransactionSource::Block {
                     transaction,
@@ -387,7 +395,23 @@ where
                         block_number: Some(block_number),
                         base_fee,
                     };
-                    Ok(Some(self.transform_tx(transaction, tx_info)))
+                    // preload transaction receipt if it's a deposit transaction
+                    if transaction.is_deposit() {
+                        let receipt =
+                            EthTransactions::transaction_receipt(&self.eth_api, tx_hash).await;
+
+                        // since this txn hash exists in a block, we should always be able to fetch a receipt for it
+                        let envelope: OpReceiptEnvelope = receipt.unwrap().unwrap().into();
+
+                        if let OpReceiptEnvelope::Deposit(deposit_receipt) = envelope {
+                            return Ok(Some(self.transform_tx(
+                                transaction,
+                                tx_info,
+                                Some(deposit_receipt.receipt),
+                            )));
+                        }
+                    }
+                    Ok(Some(self.transform_tx(transaction, tx_info, None)))
                 }
             }
         } else {
@@ -417,7 +441,7 @@ where
                     base_fee: block.base_fee_per_gas,
                 };
                 let tx = Recovered::new_unchecked(tx, sender);
-                Ok(Some(self.transform_tx(tx, tx_info)))
+                Ok(Some(self.transform_tx(tx, tx_info, None)))
             } else {
                 Ok(None)
             }


### PR DESCRIPTION
The Flashblocks RPC had a bug where it would panic if `getTransactionByHash` was used to load  historical deposit transactions.

These transactions did not exist in the mempool (system transaction) and did not exist in the cache (historical transaction) but in the case of deposit transactions we would always try to fetch a receipt from the cache to populate `deposit_receipt_version` and `deposit_nonce`.

Since we did `unwrap()` without an error check in that path, it would cause a panic.

This PR attempts to fix that by pre-loading the deposit transaction receipt from `eth_api` in case a historical deposit transaction is attempted to be fetched via `getTransactionByHash`.

Edit; ignore the branch name. i thought the root cause was a race condition, it was not.