### PR TITLE
fix: Preload txn receipt from eth_api for historical deposit txns

### DIFF
--- a/crates/flashblocks-rpc/src/rpc.rs
+++ b/crates/flashblocks-rpc/src/rpc.rs
@@ -397,11 +397,12 @@ where
                     };
                     // preload transaction receipt if it's a deposit transaction
                     if transaction.is_deposit() {
-                        let receipt =
-                            EthTransactions::transaction_receipt(&self.eth_api, tx_hash).await;
+                        let receipt = EthTransactions::transaction_receipt(&self.eth_api, tx_hash)
+                            .await
+                            .map_err(Into::into)?;
 
                         match receipt {
-                            Ok(Some(txn_receipt)) => {
+                            Some(txn_receipt) => {
                                 let envelope: OpReceiptEnvelope = txn_receipt.into();
 
                                 if let OpReceiptEnvelope::Deposit(deposit_receipt) = envelope {
@@ -412,19 +413,12 @@ where
                                     )));
                                 }
                             }
-                            Ok(None) => {
+                            None => {
                                 error!(
                                     "could not find receipt for block transaction: {:?}",
                                     tx_hash
                                 );
                                 return Ok(None);
-                            }
-                            Err(e) => {
-                                error!(
-                                    "unable to fetch receipt for block transaction: {:?} error: {:?}",
-                                    tx_hash, e
-                                );
-                                return Err(e.into());
                             }
                         }
                     }

--- a/crates/flashblocks-rpc/src/rpc.rs
+++ b/crates/flashblocks-rpc/src/rpc.rs
@@ -413,12 +413,19 @@ where
                                 }
                             }
                             // Ok(None) or Err(e)
-                            _ => {
+                            Ok(None) => {
                                 error!(
-                                    "unable to fetch receipt for block transaction: {:?}",
+                                    "could not find receipt for block transaction: {:?}",
                                     tx_hash
                                 );
                                 return Ok(None);
+                            }
+                            Err(e) => {
+                                error!(
+                                    "unable to fetch receipt for block transaction: {:?} error: {:?}",
+                                    tx_hash, e
+                                );
+                                return Err(e.into());
                             }
                         }
                     }

--- a/crates/flashblocks-rpc/src/rpc.rs
+++ b/crates/flashblocks-rpc/src/rpc.rs
@@ -429,6 +429,7 @@ where
                             }
                         }
                     }
+
                     Ok(Some(self.transform_tx(transaction, tx_info, None)))
                 }
             }

--- a/crates/flashblocks-rpc/src/rpc.rs
+++ b/crates/flashblocks-rpc/src/rpc.rs
@@ -140,7 +140,7 @@ impl<E> EthApiExt<E> {
             } else {
                 let cached_receipt = self
                     .cache
-                    .get::<OpReceipt>(&format!("receipt:{:?}", tx_info.hash.unwrap().to_string()))
+                    .get::<OpReceipt>(&CacheKey::Receipt(tx_info.hash.unwrap()))
                     .unwrap();
 
                 if let OpReceipt::Deposit(receipt) = cached_receipt {

--- a/crates/flashblocks-rpc/src/rpc.rs
+++ b/crates/flashblocks-rpc/src/rpc.rs
@@ -412,7 +412,6 @@ where
                                     )));
                                 }
                             }
-                            // Ok(None) or Err(e)
                             Ok(None) => {
                                 error!(
                                     "could not find receipt for block transaction: {:?}",


### PR DESCRIPTION
The Flashblocks RPC had a bug where it would panic if `getTransactionByHash` was used to load  historical deposit transactions.

These transactions did not exist in the mempool (system transaction) and did not exist in the cache (historical transaction) but in the case of deposit transactions we would always try to fetch a receipt from the cache to populate `deposit_receipt_version` and `deposit_nonce`.

Since we did `unwrap()` without an error check in that path, it would cause a panic.

This PR attempts to fix that by pre-loading the deposit transaction receipt from `eth_api` in case a historical deposit transaction is attempted to be fetched via `getTransactionByHash`.

---

P.S. Opened this PR as the forked repo PR did not allow me to trigger a `base-builds` sepolia alpha deployment to test without more changes than necessary to those Dockerfiles.

Edit; ignore the branch name. i thought the root cause was a race condition, it was not.