### PR TITLE
fix: build node-reth in release mode

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,19 +1,22 @@
-FROM rust:1.85 AS build
+FROM rust:1.87 AS build
 
 WORKDIR /app
 
-RUN apt-get update && apt-get -y upgrade && apt-get install -y git libclang-dev pkg-config curl build-essential
+RUN apt-get update && \
+    apt-get -y upgrade && \
+    apt-get install -y git libclang-dev pkg-config curl build-essential && \
+    rm -rf /var/lib/apt/lists/*
 
 COPY ./ .
 
-RUN cargo build --bin base-reth-node
+RUN cargo build --release --bin base-reth-node
 
 FROM ubuntu:22.04
 
 RUN apt-get update && \
     apt-get install -y jq curl && \
-    rm -rf /var/lib/apt/lists
+    rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app
 
-COPY --from=build /app/target/debug/base-reth-node ./
+COPY --from=build /app/target/release/base-reth-node ./


### PR DESCRIPTION
### Description
Switch the binary from debug to release mode in the docker file