### PR TITLE
attempt brotli decompression on messages if required

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1482,6 +1482,7 @@ dependencies = [
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
  "alloy-trie",
+ "brotli",
  "chrono",
  "clap",
  "eyre",
@@ -1923,9 +1924,9 @@ dependencies = [
 
 [[package]]
 name = "brotli"
-version = "8.0.0"
+version = "8.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf19e729cdbd51af9a397fb9ef8ac8378007b797f8273cfbfdf45dcaa316167b"
+checksum = "9991eea70ea4f293524138648e41ee89b0b2b12ddef3b255effa43c8056e0e0d"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,10 +8,7 @@ repository = "https://github.com/base/reth"
 
 [workspace]
 resolver = "2"
-members = [
-    "crates/flashblocks-rpc",
-    "crates/node"
-]
+members = ["crates/flashblocks-rpc", "crates/node"]
 
 default-members = ["crates/node"]
 
@@ -39,7 +36,9 @@ revm = { version = "23.0.0", default-features = false }
 revm-bytecode = { version = "4.0.1", default-features = false }
 
 # alloy
-alloy-primitives = { version = "1.0.0", default-features = false, features = ["map-foldhash"] }
+alloy-primitives = { version = "1.0.0", default-features = false, features = [
+    "map-foldhash",
+] }
 alloy-eips = { version = "1.0.3", default-features = false }
 alloy-rpc-types = { version = "1.0.3", default-features = false }
 alloy-rpc-types-engine = { version = "1.0.3", default-features = false }
@@ -86,3 +85,4 @@ eyre = { version = "0.6.12" }
 uuid = { version = "1.6.1", features = ["serde", "v5", "v4"] }
 time = { version = "0.3.36", features = ["macros", "formatting", "parsing"] }
 chrono = "0.4"
+brotli = "8.0.1"

--- a/crates/flashblocks-rpc/Cargo.toml
+++ b/crates/flashblocks-rpc/Cargo.toml
@@ -79,4 +79,4 @@ eyre.workspace = true
 uuid.workspace = true
 time.workspace = true
 chrono.workspace = true
-brotli = "8.0.1"
+brotli.workspace = true

--- a/crates/flashblocks-rpc/Cargo.toml
+++ b/crates/flashblocks-rpc/Cargo.toml
@@ -79,3 +79,4 @@ eyre.workspace = true
 uuid.workspace = true
 time.workspace = true
 chrono.workspace = true
+brotli = "8.0.1"


### PR DESCRIPTION
See https://github.com/flashbots/rollup-boost/pull/309 for context

WS Proxy is going to switch to sending brotli compressed messages. This updates the node to be able to handle that.