### PR TITLE
Implement eth_call via overrides

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1512,6 +1512,7 @@ dependencies = [
  "op-alloy-rpc-types-engine 0.18.13",
  "reqwest",
  "reth",
+ "reth-evm",
  "reth-optimism-chainspec",
  "reth-optimism-cli",
  "reth-optimism-evm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ reth-optimism-rpc = { git = "https://github.com/paradigmxyz/reth", tag = "v1.6.0
 reth-optimism-evm = { git = "https://github.com/paradigmxyz/reth", tag = "v1.6.0" }
 reth-optimism-chainspec = { git = "https://github.com/paradigmxyz/reth", tag = "v1.6.0" }
 reth-provider = { git = "https://github.com/paradigmxyz/reth", tag = "v1.6.0" }
+reth-evm = { git = "https://github.com/paradigmxyz/reth", tag = "v1.6.0" }
 
 # revm
 revm = { version = "27.0.3", default-features = false }

--- a/crates/flashblocks-rpc/Cargo.toml
+++ b/crates/flashblocks-rpc/Cargo.toml
@@ -18,6 +18,7 @@ reth-optimism-node.workspace = true
 reth-optimism-cli.workspace = true
 reth-primitives.workspace = true
 reth-rpc-eth-api.workspace = true
+reth-evm.workspace = true
 reth-optimism-primitives.workspace = true
 reth-rpc-convert.workspace = true
 reth-optimism-rpc.workspace = true

--- a/crates/flashblocks-rpc/src/cache.rs
+++ b/crates/flashblocks-rpc/src/cache.rs
@@ -21,6 +21,8 @@ pub enum CacheKey {
     DiffTransactions(u64),                                    // diff:transactions:block_number
     AccountBalance(Address),                                  // address
     HighestPayloadIndex,                                      // highest_payload_index
+    // Overrides for eth_call based on flashblocks executed txs
+    PendingOverrides, // pending
 }
 
 impl Display for CacheKey {
@@ -45,6 +47,7 @@ impl Display for CacheKey {
             CacheKey::DiffTransactions(number) => write!(f, "diff:transactions:{number:?}"),
             CacheKey::AccountBalance(addr) => write!(f, "{addr:?}"),
             CacheKey::HighestPayloadIndex => write!(f, "highest_payload_index"),
+            CacheKey::PendingOverrides => write!(f, "pending_storage_slots"),
         }
     }
 }

--- a/crates/flashblocks-rpc/src/cache.rs
+++ b/crates/flashblocks-rpc/src/cache.rs
@@ -47,7 +47,7 @@ impl Display for CacheKey {
             CacheKey::DiffTransactions(number) => write!(f, "diff:transactions:{number:?}"),
             CacheKey::AccountBalance(addr) => write!(f, "{addr:?}"),
             CacheKey::HighestPayloadIndex => write!(f, "highest_payload_index"),
-            CacheKey::PendingOverrides => write!(f, "pending_storage_slots"),
+            CacheKey::PendingOverrides => write!(f, "pending_eth_overrides"),
         }
     }
 }

--- a/crates/flashblocks-rpc/src/flashblocks.rs
+++ b/crates/flashblocks-rpc/src/flashblocks.rs
@@ -1157,35 +1157,4 @@ mod tests {
         let highest = cache.get::<u64>(&CacheKey::HighestPayloadIndex).unwrap();
         assert_eq!(highest, 0);
     }
-
-    // /// Create provide and push 1 block with transaction
-    // fn get_mock_provider() -> MockEthProvider<EthPrimitives, OpChainSpec> {
-    //     let chain_spec = OpChainSpecBuilder::base_mainnet().build();
-    //     let client = NoopProvider::eth(Arc::new(chain_spec));
-    //     let mut parent_hash = B256::default();
-    //     let header = Header {
-    //         number: 1,
-    //         gas_limit: 60_000_000,
-    //         gas_used: 0,
-    //         base_fee_per_gas: Some(1000),
-    //         parent_hash,
-    //         ..Default::default()
-    //     };
-    //     let transaction = TransactionSigned::new_unhashed(
-    //         Transaction::Legacy(Default::default()),
-    //         Signature::test_signature(),
-    //     );
-    //     let transactions = vec![transaction];
-    //     client.add_block(
-    //         parent_hash,
-    //         Block {
-    //             header: header.clone(),
-    //             body: BlockBody {
-    //                 transactions,
-    //                 ..Default::default()
-    //             },
-    //         },
-    //     );
-    //     client
-    // }
 }

--- a/crates/flashblocks-rpc/src/metrics.rs
+++ b/crates/flashblocks-rpc/src/metrics.rs
@@ -29,4 +29,7 @@ pub struct Metrics {
 
     #[metric(describe = "Number of flashblocks in a block")]
     pub flashblocks_in_block: Histogram,
+
+    #[metric(describe = "Count of times flashblocks call is called")]
+    pub call: Counter,
 }

--- a/crates/flashblocks-rpc/src/tests/integration_test.rs
+++ b/crates/flashblocks-rpc/src/tests/integration_test.rs
@@ -138,7 +138,7 @@ mod tests {
                 new_account_balances: {
                     let mut map = HashMap::default();
                     map.insert(
-                        "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266".to_string(),
+                        "0x1234567890123456789012345678901234567890".to_string(),
                         "0x1234".to_string(),
                     );
                     map.insert(
@@ -332,7 +332,7 @@ mod tests {
         .arg("-H")
         .arg("Content-Type: application/json")
         .arg("-d")
-        .arg(r#"{"jsonrpc":"2.0","method":"eth_getBalance","params":["0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266","pending"],"id":1}"#)
+        .arg(r#"{"jsonrpc":"2.0","method":"eth_getBalance","params":["0x1234567890123456789012345678901234567890","pending"],"id":1}"#)
         .output()?;
 
         let response: serde_json::Value = serde_json::from_slice(&output.stdout)?;

--- a/crates/flashblocks-rpc/src/tests/integration_test.rs
+++ b/crates/flashblocks-rpc/src/tests/integration_test.rs
@@ -62,8 +62,25 @@ mod tests {
         // Create second payload (index 1) with transactions
         // tx1 hash: 0x2be2e6f8b01b03b87ae9f0ebca8bbd420f174bef0fbcc18c7802c5378b78f548 (deposit transaction)
         // tx2 hash: 0xbb079fbde7d12fd01664483cd810e91014113e405247479e5615974ebca93e4a
-        let tx1 = Bytes::from_str("0x7ef8f8a042a8ae5ec231af3d0f90f68543ec8bca1da4f7edd712d5b51b490688355a6db794deaddeaddeaddeaddeaddeaddeaddeaddead00019442000000000000000000000000000000000000158080830f424080b8a4440a5e200000044d000a118b00000000000000040000000067cb7cb0000000000077dbd4000000000000000000000000000000000000000000000000000000000000000a00000000000000000000000000000000000000000000000000000000000000014edd27304108914dd6503b19b9eeb9956982ef197febbeeed8a9eac3dbaaabdf000000000000000000000000fc56e7272eebbba5bc6c544e159483c4a38f8ba3").unwrap();
-        let tx2 = Bytes::from_str("0x02f87383014a3480808449504f80830186a094deaddeaddeaddeaddeaddeaddeaddeaddead00018ad3c21bcb3f6efc39800080c0019f5a6fe2065583f4f3730e82e5725f651cbbaf11dc1f82c8d29ba1f3f99e5383a061e0bf5dfff4a9bc521ad426eee593d3653c5c330ae8a65fad3175d30f291d31").unwrap();
+        let deposit_tx = Bytes::from_str("0x7ef8f8a042a8ae5ec231af3d0f90f68543ec8bca1da4f7edd712d5b51b490688355a6db794deaddeaddeaddeaddeaddeaddeaddeaddead00019442000000000000000000000000000000000000158080830f424080b8a4440a5e200000044d000a118b00000000000000040000000067cb7cb0000000000077dbd4000000000000000000000000000000000000000000000000000000000000000a00000000000000000000000000000000000000000000000000000000000000014edd27304108914dd6503b19b9eeb9956982ef197febbeeed8a9eac3dbaaabdf000000000000000000000000fc56e7272eebbba5bc6c544e159483c4a38f8ba3").unwrap();
+        let transfer_eth_tx = Bytes::from_str("0x02f87383014a3480808449504f80830186a094deaddeaddeaddeaddeaddeaddeaddeaddead00018ad3c21bcb3f6efc39800080c0019f5a6fe2065583f4f3730e82e5725f651cbbaf11dc1f82c8d29ba1f3f99e5383a061e0bf5dfff4a9bc521ad426eee593d3653c5c330ae8a65fad3175d30f291d31").unwrap();
+
+        let deposit_tx_hash = "0x2be2e6f8b01b03b87ae9f0ebca8bbd420f174bef0fbcc18c7802c5378b78f548";
+        let transfer_eth_tx_hash =
+            "0xbb079fbde7d12fd01664483cd810e91014113e405247479e5615974ebca93e4a";
+        let deployment_tx_hash =
+            "0xa9353897b4ab350ae717eefdad4c9cb613e684f5a490c82a44387d8d5a2f8197";
+        let increment_tx_hash =
+            "0x993ad6a332752f6748636ce899b3791e4a33f7eece82c0db4556c7339c1b2929";
+
+        // NOTE:
+        // Following txns deploy a simple Counter contract (Compiled with solc 0.8.13)
+        // Only contains a `uin256 public number` and a function increment() { number++ };
+        // Following txn calls increment once, so number should be 1
+        // Raw Bytecode: 0x608060405234801561001057600080fd5b50610163806100206000396000f3fe608060405234801561001057600080fd5b50600436106100365760003560e01c80638381f58a1461003b578063d09de08a14610059575b600080fd5b610043610063565b604051610050919061009b565b60405180910390f35b610061610069565b005b60005481565b60008081548092919061007b906100e5565b9190505550565b6000819050919050565b61009581610082565b82525050565b60006020820190506100b0600083018461008c565b92915050565b7f4e487b7100000000000000000000000000000000000000000000000000000000600052601160045260246000fd5b60006100f082610082565b91507fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff8203610122576101216100b6565b5b60018201905091905056fea2646970667358221220a0719cefc3439563ff433fc58f8ffb66e1b639119206276d3bdac5d2e2b6f2fa64736f6c634300080d0033
+        let deployment_tx = Bytes::from_str("0x02f901db83014a3401808449504f8083030d408080b90183608060405234801561001057600080fd5b50610163806100206000396000f3fe608060405234801561001057600080fd5b50600436106100365760003560e01c80638381f58a1461003b578063d09de08a14610059575b600080fd5b610043610063565b604051610050919061009b565b60405180910390f35b610061610069565b005b60005481565b60008081548092919061007b906100e5565b9190505550565b6000819050919050565b61009581610082565b82525050565b60006020820190506100b0600083018461008c565b92915050565b7f4e487b7100000000000000000000000000000000000000000000000000000000600052601160045260246000fd5b60006100f082610082565b91507fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff8203610122576101216100b6565b5b60018201905091905056fea2646970667358221220a0719cefc3439563ff433fc58f8ffb66e1b639119206276d3bdac5d2e2b6f2fa64736f6c634300080d0033c080a034278436b367f7b73ab6dc7c7cc09f8880104513f8b8fb691b498257de97a5bca05cb702ebad2aadf9f225bf5f8685ea03d194bf7a2ea05b1d27a1bd33169f9fe0").unwrap();
+        // Increment tx: call increment()
+        let increment_tx = Bytes::from_str("0x02f86d83014a3402808449504f8082abe094e7f1725e7734ce288f8367e1bb143e90bb3f05128084d09de08ac080a0a9c1a565668084d4052bbd9bc3abce8555a06aed6651c82c2756ac8a83a79fa2a03427f440ce4910a5227ea0cedb60b06cf0bea2dbbac93bd37efa91a474c29d89").unwrap();
         // Send another test flashblock payload
         let payload = FlashblocksPayloadV1 {
             payload_id: PayloadId::new([0; 8]),
@@ -74,7 +91,7 @@ mod tests {
                 receipts_root: B256::default(),
                 gas_used: 0,
                 block_hash: B256::default(),
-                transactions: vec![tx1, tx2],
+                transactions: vec![deposit_tx, transfer_eth_tx, deployment_tx, increment_tx],
                 withdrawals: Vec::new(),
                 logs_bloom: Default::default(),
                 withdrawals_root: Default::default(),
@@ -84,8 +101,7 @@ mod tests {
                 receipts: {
                     let mut receipts = HashMap::default();
                     receipts.insert(
-                        "0x2be2e6f8b01b03b87ae9f0ebca8bbd420f174bef0fbcc18c7802c5378b78f548"
-                            .to_string(), // transaction hash as string
+                        deposit_tx_hash.to_string(), // transaction hash as string
                         OpReceipt::Legacy(Receipt {
                             status: true.into(),
                             cumulative_gas_used: 21000,
@@ -93,14 +109,30 @@ mod tests {
                         }),
                     );
                     receipts.insert(
-                        "0xbb079fbde7d12fd01664483cd810e91014113e405247479e5615974ebca93e4a"
-                            .to_string(), // transaction hash as string
+                        transfer_eth_tx_hash.to_string(), // transaction hash as string
                         OpReceipt::Legacy(Receipt {
                             status: true.into(),
                             cumulative_gas_used: 45000,
                             logs: vec![],
                         }),
                     );
+                    receipts.insert(
+                        deployment_tx_hash.to_string(), // transaction hash as string
+                        OpReceipt::Legacy(Receipt {
+                            status: true.into(),
+                            cumulative_gas_used: 172279,
+                            logs: vec![],
+                        }),
+                    );
+                    receipts.insert(
+                        increment_tx_hash.to_string(), // transaction hash as string
+                        OpReceipt::Legacy(Receipt {
+                            status: true.into(),
+                            cumulative_gas_used: 172279 + 44000,
+                            logs: vec![],
+                        }),
+                    );
+
                     receipts
                 },
                 new_account_balances: {
@@ -108,6 +140,11 @@ mod tests {
                     map.insert(
                         "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266".to_string(),
                         "0x1234".to_string(),
+                    );
+                    map.insert(
+                        // deployed contract address
+                        "0xe7f1725E7734CE288F8367e1Bb143E90bb3F0512".to_string(),
+                        "0x0".to_string(),
                     );
                     map
                 },
@@ -209,14 +246,14 @@ mod tests {
         assert!(res.is_ok());
 
         tokio::time::sleep(Duration::from_secs(3)).await;
-        // Query second subblock, now there should be 2 transactions
+        // Query second subblock, now there should be 4 transactions
         if let Some(block) = provider
             .get_block_by_number(BlockNumberOrTag::Pending)
             .await?
         {
             // Verify block properties
             assert_eq!(block.header.number, 1);
-            assert_eq!(block.transactions.len(), 2);
+            assert_eq!(block.transactions.len(), 4);
         } else {
             assert!(false, "no block found");
         }
@@ -273,7 +310,7 @@ mod tests {
             .from(address!("0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266"))
             .transaction_type(0)
             .gas_limit(20000000)
-            .nonce(1)
+            .nonce(4)
             .to(address!("0xf39635f2adf40608255779ff742afe13de31f577"))
             .value(U256::from(9999999999849942300000u128))
             .input(TransactionInput::new(bytes!("0x")));
@@ -315,7 +352,7 @@ mod tests {
 
         let response: serde_json::Value = serde_json::from_slice(&output.stdout)?;
         let nonce = U256::from_str(response["result"].as_str().unwrap()).unwrap();
-        assert_eq!(nonce, U256::from_str("0x1").unwrap());
+        assert_eq!(nonce, U256::from_str("0x3").unwrap());
 
         // check latest nonce, should still be 0
         let output = std::process::Command::new("curl")
@@ -331,6 +368,70 @@ mod tests {
         let response: serde_json::Value = serde_json::from_slice(&output.stdout)?;
         let nonce = U256::from_str(response["result"].as_str().unwrap()).unwrap();
         assert_eq!(nonce, U256::from_str("0x0").unwrap());
+
+        // Counter contract checks
+
+        // check transaction receipt
+        let receipt = provider
+            .get_transaction_receipt(
+                B256::from_str(
+                    "0xa9353897b4ab350ae717eefdad4c9cb613e684f5a490c82a44387d8d5a2f8197",
+                )
+                .unwrap(),
+            )
+            .await?;
+        assert!(receipt.is_some());
+        let receipt = receipt.unwrap();
+        assert_eq!(receipt.gas_used(), 127279);
+
+        // check transaction receipt
+        let receipt = provider
+            .get_transaction_receipt(
+                B256::from_str(
+                    "0x993ad6a332752f6748636ce899b3791e4a33f7eece82c0db4556c7339c1b2929",
+                )
+                .unwrap(),
+            )
+            .await?;
+        assert!(receipt.is_some());
+        assert_eq!(receipt.unwrap().gas_used(), 44000);
+
+        // check transaction by hash
+        let tx = provider
+            .get_transaction_by_hash(
+                B256::from_str(
+                    "0xa9353897b4ab350ae717eefdad4c9cb613e684f5a490c82a44387d8d5a2f8197",
+                )
+                .unwrap(),
+            )
+            .await?;
+        assert!(tx.is_some());
+
+        let tx = provider
+            .get_transaction_by_hash(
+                B256::from_str(
+                    "0x993ad6a332752f6748636ce899b3791e4a33f7eece82c0db4556c7339c1b2929",
+                )
+                .unwrap(),
+            )
+            .await?;
+        assert!(tx.is_some());
+
+        // read number from counter contract
+        let eth_call = OpTransactionRequest::default()
+            .from(address!("0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266"))
+            .transaction_type(0)
+            .gas_limit(20000000)
+            .nonce(4)
+            .to(address!("0xe7f1725E7734CE288F8367e1Bb143E90bb3F0512"))
+            .value(U256::ZERO)
+            .input(TransactionInput::new(bytes!("0x8381f58a")));
+        let res = provider.call(eth_call).await;
+        assert!(res.is_ok());
+        assert_eq!(
+            U256::from_str(res.unwrap().to_string().as_str()).unwrap(),
+            U256::from(1)
+        );
 
         // Don't forget to cleanup
         ws_server.abort();

--- a/crates/flashblocks-rpc/src/tests/integration_test.rs
+++ b/crates/flashblocks-rpc/src/tests/integration_test.rs
@@ -40,7 +40,7 @@ mod tests {
                 fee_recipient: Address::ZERO,
                 prev_randao: B256::default(),
                 block_number: 1,
-                gas_limit: 60_000_000,
+                gas_limit: 30_000_000,
                 timestamp: 0,
                 extra_data: Bytes::new(),
                 base_fee_per_gas: U256::ZERO,
@@ -61,9 +61,9 @@ mod tests {
         // Example: `cast mktx --private-key 0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80 --nonce 1 --gas-limit 100000 --gas-price 1499576 --chain 84532 --value 0 --priority-gas-price 0 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266 0x`
         // Create second payload (index 1) with transactions
         // tx1 hash: 0x2be2e6f8b01b03b87ae9f0ebca8bbd420f174bef0fbcc18c7802c5378b78f548 (deposit transaction)
-        // tx2 hash: 0xf1846b9cb3a6d3e6f4345dd4f55243e553379464d2e7d0de1dbc44337d6b86d3
+        // tx2 hash: 0xbb079fbde7d12fd01664483cd810e91014113e405247479e5615974ebca93e4a
         let tx1 = Bytes::from_str("0x7ef8f8a042a8ae5ec231af3d0f90f68543ec8bca1da4f7edd712d5b51b490688355a6db794deaddeaddeaddeaddeaddeaddeaddeaddead00019442000000000000000000000000000000000000158080830f424080b8a4440a5e200000044d000a118b00000000000000040000000067cb7cb0000000000077dbd4000000000000000000000000000000000000000000000000000000000000000a00000000000000000000000000000000000000000000000000000000000000014edd27304108914dd6503b19b9eeb9956982ef197febbeeed8a9eac3dbaaabdf000000000000000000000000fc56e7272eebbba5bc6c544e159483c4a38f8ba3").unwrap();
-        let tx2 = Bytes::from_str("0x02f87383014a3480808316e1b8830186a094deaddeaddeaddeaddeaddeaddeaddeaddead00018a021e19e0c997c21d356080c001a0550a5dcf4dcab7151142a0c76cb46ea185962c74c61372ee67ae165820274df7a04c93fc2001bc726136d4342c220128573b1542a550d015b937be5ac11ff54046").unwrap();
+        let tx2 = Bytes::from_str("0x02f87383014a3480808449504f80830186a094deaddeaddeaddeaddeaddeaddeaddeaddead00018ad3c21bcb3f6efc39800080c0019f5a6fe2065583f4f3730e82e5725f651cbbaf11dc1f82c8d29ba1f3f99e5383a061e0bf5dfff4a9bc521ad426eee593d3653c5c330ae8a65fad3175d30f291d31").unwrap();
         // Send another test flashblock payload
         let payload = FlashblocksPayloadV1 {
             payload_id: PayloadId::new([0; 8]),
@@ -93,7 +93,7 @@ mod tests {
                         }),
                     );
                     receipts.insert(
-                        "0xf1846b9cb3a6d3e6f4345dd4f55243e553379464d2e7d0de1dbc44337d6b86d3"
+                        "0xbb079fbde7d12fd01664483cd810e91014113e405247479e5615974ebca93e4a"
                             .to_string(), // transaction hash as string
                         OpReceipt::Legacy(Receipt {
                             status: true.into(),
@@ -238,7 +238,7 @@ mod tests {
         let receipt = provider
             .get_transaction_receipt(
                 B256::from_str(
-                    "0xf1846b9cb3a6d3e6f4345dd4f55243e553379464d2e7d0de1dbc44337d6b86d3",
+                    "0xbb079fbde7d12fd01664483cd810e91014113e405247479e5615974ebca93e4a",
                 )
                 .unwrap(),
             )
@@ -260,7 +260,7 @@ mod tests {
         let tx = provider
             .get_transaction_by_hash(
                 B256::from_str(
-                    "0xf1846b9cb3a6d3e6f4345dd4f55243e553379464d2e7d0de1dbc44337d6b86d3",
+                    "0xbb079fbde7d12fd01664483cd810e91014113e405247479e5615974ebca93e4a",
                 )
                 .unwrap(),
             )

--- a/crates/node/src/main.rs
+++ b/crates/node/src/main.rs
@@ -67,13 +67,15 @@ fn main() {
                 .extend_rpc_modules(move |ctx| {
                     if flashblocks_enabled {
                         info!(message = "starting flashblocks integration");
-                        let mut flashblocks_client =
-                            FlashblocksClient::new(cache.clone(), receipt_buffer_size);
+                        let mut flashblocks_client = FlashblocksClient::new(
+                            cache.clone(),
+                            receipt_buffer_size,
+                            ctx.provider().clone(),
+                        );
 
                         flashblocks_client
                             .init(flashblocks_rollup_args.websocket_url.unwrap().clone())
                             .unwrap();
-
                         let api_ext = EthApiExt::new(
                             ctx.registry.eth_api().clone(),
                             cache.clone(),


### PR DESCRIPTION
Implement eth_call
We build up EthOverride structure from execution flashblocks transaction that we are using when execution eth_call. 