### PR TITLE
chore: Add entrypoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,4 +19,6 @@ RUN apt-get update && \
 
 WORKDIR /app
 
+ENTRYPOINT [ "./base-reth-node" ]
+
 COPY --from=build /app/target/release/base-reth-node ./


### PR DESCRIPTION
**Description**

Adds `ENTRYPOINT` to the `Dockerfile` for ease of use and easy interchangeability with the `reth` image.

This would help us a lot when integrating `node-reth` into our kurtosis-based dev tooling as the executable inconsistency is not easily treatable and makes for ugly downstream code.