### PR TITLE
[logs] emit `info!` on a tx's `TxEvents`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1701,6 +1701,7 @@ name = "base-reth-transaction-tracing"
 version = "0.1.0"
 dependencies = [
  "alloy-primitives",
+ "chrono",
  "eyre",
  "futures",
  "lru 0.16.1",

--- a/crates/node/src/main.rs
+++ b/crates/node/src/main.rs
@@ -38,6 +38,13 @@ struct Args {
         value_name = "ENABLE_TRANSACTION_TRACING"
     )]
     pub enable_transaction_tracing: bool,
+
+    /// Enable `info` logs for transaction tracing
+    #[arg(
+        long = "enable-transaction-tracing-logs",
+        value_name = "ENABLE_TRANSACTION_TRACING_LOGS"
+    )]
+    pub enable_transaction_tracing_logs: bool,
 }
 
 impl Args {
@@ -65,7 +72,12 @@ fn main() {
                 .install_exex_if(
                     transaction_tracing_enabled,
                     "transaction-tracing",
-                    |ctx| async move { Ok(transaction_tracing_exex(ctx)) },
+                    move |ctx| async move {
+                        Ok(transaction_tracing_exex(
+                            ctx,
+                            args.enable_transaction_tracing_logs,
+                        ))
+                    },
                 )
                 .install_exex_if(flashblocks_enabled, "flashblocks-canon", {
                     let fb_cell = fb_cell.clone();

--- a/crates/transaction-tracing/Cargo.toml
+++ b/crates/transaction-tracing/Cargo.toml
@@ -32,3 +32,4 @@ eyre.workspace = true
 lru = "0.16.1"
 metrics.workspace = true
 metrics-derive.workspace = true
+chrono.workspace = true

--- a/crates/transaction-tracing/Cargo.toml
+++ b/crates/transaction-tracing/Cargo.toml
@@ -32,4 +32,3 @@ eyre.workspace = true
 lru = "0.16.1"
 metrics.workspace = true
 metrics-derive.workspace = true
-chrono.workspace = true

--- a/crates/transaction-tracing/src/lib.rs
+++ b/crates/transaction-tracing/src/lib.rs
@@ -1,3 +1,4 @@
 pub mod tracing;
+mod types;
 
 pub use tracing::transaction_tracing_exex;

--- a/crates/transaction-tracing/src/tracing.rs
+++ b/crates/transaction-tracing/src/tracing.rs
@@ -104,7 +104,7 @@ impl Tracker {
 
             // if a tx is included/dropped, log it and don't add it back to LRU so that we keep the LRU cache size small
             // which will help longer-lived txs.
-            self.log(&tx_hash, &event_log, &format!("Transaction {}", event));
+            self.log(&tx_hash, &event_log, &format!("Transaction {event}"));
             record_histogram(time_in_mempool, event);
         }
     }
@@ -149,7 +149,7 @@ impl Tracker {
             "Transaction removed from cache due to limit",
         );
         record_histogram(event_log.mempool_time.elapsed(), TxEvent::Overflowed);
-        return true;
+        true
     }
 }
 

--- a/crates/transaction-tracing/src/tracing.rs
+++ b/crates/transaction-tracing/src/tracing.rs
@@ -1,4 +1,5 @@
 use alloy_primitives::TxHash;
+use chrono::{DateTime, Local};
 use eyre::Result;
 use futures::StreamExt;
 use lru::LruCache;
@@ -11,10 +12,12 @@ use std::num::NonZeroUsize;
 use std::time::Instant;
 
 /// Types of transaction events to track
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy)]
 enum TxEvent {
     Dropped,
     Replaced,
+    Pending,
+    Queued,
     BlockInclusion,
     PendingToQueued,
     QueuedToPending,
@@ -27,10 +30,13 @@ enum Pool {
     Queued,
 }
 
+/// History of events for a transaction
+type EventLog = Vec<(DateTime<Local>, TxEvent, Instant)>;
+
 /// Simple ExEx that tracks transaction timing from mempool to inclusion
 struct Tracker {
     /// Map of transaction hash to timestamp when first seen in mempool
-    txs: LruCache<TxHash, Instant>,
+    txs: LruCache<TxHash, EventLog>,
     /// Map of transaction hash to current state
     tx_states: LruCache<TxHash, Pool>,
 }
@@ -44,8 +50,19 @@ impl Tracker {
         }
     }
 
+    /// Get the event log for a transaction
+    pub fn get_event_log(&self, tx_hash: TxHash) -> Option<String> {
+        self.txs.peek(&tx_hash).map(|event_log| {
+            event_log
+                .iter()
+                .map(|(timestamp, event, _)| format!("{:?} {:?}", timestamp, event))
+                .collect::<Vec<_>>()
+                .join("\n")
+        })
+    }
+
     /// Track the first time we see a transaction in the mempool
-    fn transaction_inserted(&mut self, tx_hash: TxHash) {
+    fn transaction_inserted(&mut self, tx_hash: TxHash, event: TxEvent) {
         // if we've seen the tx before, don't track it again. for example,
         // if a tx was pending then moved to queued, we don't want to update the timestamp
         // with the queued timestamp.
@@ -53,8 +70,9 @@ impl Tracker {
             return;
         }
 
-        let now = Instant::now();
-        self.txs.put(tx_hash, now);
+        let mut event_log = EventLog::new();
+        event_log.push((Local::now(), event, Instant::now()));
+        self.txs.put(tx_hash, event_log);
     }
 
     /// Track a transaction moving from one pool to another
@@ -68,7 +86,7 @@ impl Tracker {
                     _ => None,
                 };
                 if let Some(tx_event) = event {
-                    self.transaction_event(tx_hash, tx_event);
+                    self.transaction_event(tx_hash, tx_event, Instant::now());
                 }
             }
         }
@@ -79,14 +97,21 @@ impl Tracker {
     }
 
     /// Track a transaction event
-    fn transaction_event(&mut self, tx_hash: TxHash, event: TxEvent) {
-        if let Some(mempool_time) = self.txs.pop(&tx_hash) {
+    fn transaction_event(&mut self, tx_hash: TxHash, event: TxEvent, event_timestamp: Instant) {
+        if let Some(mut event_log) = self.txs.pop(&tx_hash) {
+            let mempool_time = event_log.first().unwrap().2;
             let time_in_mempool = Instant::now().duration_since(mempool_time);
+
+            // Update the change log with the new event
+            event_log.push((Local::now(), event, event_timestamp));
+            self.txs.put(tx_hash, event_log);
 
             // Record histogram with event label
             let event_label = match event {
                 TxEvent::Dropped => "dropped",
                 TxEvent::Replaced => "replaced",
+                TxEvent::Pending => "pending",
+                TxEvent::Queued => "queued",
                 TxEvent::BlockInclusion => "block_inclusion",
                 TxEvent::PendingToQueued => "pending_to_queued",
                 TxEvent::QueuedToPending => "queued_to_pending",
@@ -127,19 +152,19 @@ pub async fn transaction_tracing_exex<Node: FullNodeComponents>(
             Some(full_event) = all_events_stream.next() => {
                 match full_event {
                     FullTransactionEvent::Pending(tx_hash) => {
-                        track.transaction_inserted(tx_hash);
+                        track.transaction_inserted(tx_hash, TxEvent::Pending);
                         track.transaction_moved(tx_hash, Pool::Pending);
                     }
                     FullTransactionEvent::Queued(tx_hash) => {
-                        track.transaction_inserted(tx_hash);
+                        track.transaction_inserted(tx_hash, TxEvent::Queued);
                         track.transaction_moved(tx_hash, Pool::Queued);
                     }
                     FullTransactionEvent::Discarded(tx_hash) => {
-                        track.transaction_event(tx_hash, TxEvent::Dropped);
+                        track.transaction_event(tx_hash, TxEvent::Dropped, Instant::now());
                     }
                     FullTransactionEvent::Replaced{transaction, replaced_by: _} => {
                         let tx_hash = transaction.hash();
-                        track.transaction_event(*tx_hash, TxEvent::Replaced);
+                        track.transaction_event(*tx_hash, TxEvent::Replaced, Instant::now());
                     }
                     _ => {
                         // Other events
@@ -154,7 +179,7 @@ pub async fn transaction_tracing_exex<Node: FullNodeComponents>(
                         // Process all transactions in committed chain
                         for block in new.blocks().values() {
                             for transaction in block.body().transactions() {
-                                track.transaction_event(*transaction.tx_hash(), TxEvent::BlockInclusion);
+                                track.transaction_event(*transaction.tx_hash(), TxEvent::BlockInclusion, Instant::now());
                             }
                         }
                         ctx.events.send(ExExEvent::FinishedHeight(new.tip().num_hash()))?;
@@ -163,7 +188,7 @@ pub async fn transaction_tracing_exex<Node: FullNodeComponents>(
                         debug!(target: "transaction-tracing", tip = ?new.tip().number(), "Chain reorg detected");
                         for block in new.blocks().values() {
                             for transaction in block.body().transactions() {
-                                track.transaction_event(*transaction.tx_hash(), TxEvent::BlockInclusion);
+                                track.transaction_event(*transaction.tx_hash(), TxEvent::BlockInclusion, Instant::now());
                             }
                         }
                         ctx.events.send(ExExEvent::FinishedHeight(new.tip().num_hash()))?;

--- a/crates/transaction-tracing/src/tracing.rs
+++ b/crates/transaction-tracing/src/tracing.rs
@@ -144,6 +144,8 @@ impl Tracker {
         }
     }
 
+    // if `is_overflowed` is true then we record an overflowed metric and log the event log
+    // and don't record the other event that was supposed to be recorded
     fn is_overflowed(&self, tx_hash: &TxHash, event_log: &EventLog) -> bool {
         if event_log.events.len() < event_log.limit {
             return false;

--- a/crates/transaction-tracing/src/types.rs
+++ b/crates/transaction-tracing/src/types.rs
@@ -1,3 +1,4 @@
+use chrono::{DateTime, Local};
 use std::fmt::{self, Display};
 use std::time::Instant;
 
@@ -30,29 +31,31 @@ pub enum Pool {
 /// History of events for a transaction
 pub struct EventLog {
     pub mempool_time: Instant,
-    pub events: Vec<TxEvent>,
+    pub events: Vec<(DateTime<Local>, TxEvent)>,
     pub limit: usize,
 }
 
 impl EventLog {
-    pub fn new(event: TxEvent) -> Self {
+    pub fn new(t: DateTime<Local>, event: TxEvent) -> Self {
         Self {
             mempool_time: Instant::now(),
-            events: vec![event],
+            events: vec![(t, event)],
             limit: 10,
         }
     }
 
-    pub fn push(&mut self, event: TxEvent) {
-        self.events.push(event);
+    pub fn push(&mut self, t: DateTime<Local>, event: TxEvent) {
+        self.events.push((t, event));
         self.limit += 1;
     }
 
-    pub fn to_string(&self) -> String {
+    pub fn to_vec(&self) -> Vec<String> {
         self.events
             .iter()
-            .map(|event| event.to_string())
+            .map(|(t, event)| {
+                // example: 2025-09-18 08:57:37.979 pm - Pending
+                format!("{} - {}", t.format("%Y-%m-%d %H:%M:%S%.3f"), event)
+            })
             .collect::<Vec<_>>()
-            .join("\n")
     }
 }

--- a/crates/transaction-tracing/src/types.rs
+++ b/crates/transaction-tracing/src/types.rs
@@ -11,6 +11,7 @@ pub enum TxEvent {
     BlockInclusion,
     PendingToQueued,
     QueuedToPending,
+    Overflowed,
 }
 
 impl Display for TxEvent {
@@ -31,4 +32,27 @@ pub struct EventLog {
     pub mempool_time: Instant,
     pub events: Vec<TxEvent>,
     pub limit: usize,
+}
+
+impl EventLog {
+    pub fn new(event: TxEvent) -> Self {
+        Self {
+            mempool_time: Instant::now(),
+            events: vec![event],
+            limit: 10,
+        }
+    }
+
+    pub fn push(&mut self, event: TxEvent) {
+        self.events.push(event);
+        self.limit += 1;
+    }
+
+    pub fn to_string(&self) -> String {
+        self.events
+            .iter()
+            .map(|event| event.to_string())
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
 }

--- a/crates/transaction-tracing/src/types.rs
+++ b/crates/transaction-tracing/src/types.rs
@@ -1,0 +1,34 @@
+use std::fmt::{self, Display};
+use std::time::Instant;
+
+/// Types of transaction events to track
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum TxEvent {
+    Dropped,
+    Replaced,
+    Pending,
+    Queued,
+    BlockInclusion,
+    PendingToQueued,
+    QueuedToPending,
+}
+
+impl Display for TxEvent {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{:?}", self)
+    }
+}
+
+/// Types of pools a transaction can be in
+#[derive(Debug, Clone, PartialEq)]
+pub enum Pool {
+    Pending,
+    Queued,
+}
+
+/// History of events for a transaction
+pub struct EventLog {
+    pub mempool_time: Instant,
+    pub events: Vec<TxEvent>,
+    pub limit: usize,
+}

--- a/crates/transaction-tracing/src/types.rs
+++ b/crates/transaction-tracing/src/types.rs
@@ -17,7 +17,7 @@ pub enum TxEvent {
 
 impl Display for TxEvent {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{:?}", self)
+        write!(f, "{self:?}")
     }
 }
 
@@ -53,8 +53,8 @@ impl EventLog {
         self.events
             .iter()
             .map(|(t, event)| {
-                // example: 2025-09-18 08:57:37.979 pm - Pending
-                format!("{} - {}", t.format("%Y-%m-%d %H:%M:%S%.3f"), event)
+                // example: 08:57:37.979 pm - Pending
+                format!("{} - {}", t.format("%H:%M:%S%.3f"), event)
             })
             .collect::<Vec<_>>()
     }


### PR DESCRIPTION
On cache eviction in the ExEx's LRU cache, we should log the `TxEvents` a transaction went through. 

This could provide insight in the lifecycle state a transaction is in after being submitted successfully. 

The eviction should happen on a `block_inclusion` event since that would be last event a transaction would experience and it would eventually become the oldest entry. There might be other cases where it got moved from `Pending` to `Queued` and then never made it to inclusion in the time newer entries were added to the LRU cache, so it would be good here to record this event log.

