### PR TITLE
docs: clarify zero-hash wording

### DIFF
--- a/crates/flashblocks-rpc/spec.md
+++ b/crates/flashblocks-rpc/spec.md
@@ -113,7 +113,7 @@ Returns the receipt for a transaction.
 
 **Fields:**
 - `transactionHash`: Hash of the transaction
-- `blockHash`: Always `0x0` for preconfirmed transactions
+- `blockHash`: zero hash (`0x000...000`) for preconfirmed transactions
 - `blockNumber`: Block number containing the transaction
 - `transactionIndex`: Index of transaction in block
 - `from`: Sender address


### PR DESCRIPTION
Replaces “Always `0x0`” with “zero hash (`0x000...000`)” in `crates/flashblocks-rpc/spec.md` for `eth_getTransactionReceipt`.

- Evidence: spec’s example response already uses a 32-byte zero hash (`0x000...000`) for `blockHash`.
- Rationale: avoids ambiguity between a single zero and a 32-byte zero; aligns with Ethereum conventions.