### PR TITLE
fix: use canon block instead of latest in rpcs

### DIFF
--- a/crates/flashblocks-rpc/src/pending_blocks.rs
+++ b/crates/flashblocks-rpc/src/pending_blocks.rs
@@ -1,4 +1,5 @@
 use alloy_consensus::{Header, Sealed};
+use alloy_eips::BlockNumberOrTag;
 use alloy_primitives::{
     map::foldhash::{HashMap, HashMapExt},
     Address, BlockNumber, TxHash, B256, U256,
@@ -149,6 +150,10 @@ pub struct PendingBlocks {
 impl PendingBlocks {
     pub fn latest_block_number(&self) -> BlockNumber {
         self.headers.last().unwrap().number
+    }
+
+    pub fn canonical_block_number(&self) -> BlockNumberOrTag {
+        BlockNumberOrTag::Number(self.headers.first().unwrap().number - 1)
     }
 
     pub fn latest_flashblock_index(&self) -> u64 {

--- a/crates/flashblocks-rpc/src/rpc.rs
+++ b/crates/flashblocks-rpc/src/rpc.rs
@@ -9,6 +9,7 @@ use alloy_primitives::{Address, TxHash, U256};
 use alloy_rpc_types::simulate::{SimBlock, SimulatePayload, SimulatedBlock};
 use alloy_rpc_types::state::{EvmOverrides, StateOverride, StateOverridesBuilder};
 use alloy_rpc_types::BlockOverrides;
+use arc_swap::Guard;
 use jsonrpsee::{
     core::{async_trait, RpcResult},
     proc_macros::rpc,
@@ -37,10 +38,32 @@ pub const MAX_TIMEOUT_SEND_RAW_TX_SYNC_MS: u64 = 6_000;
 /// Core API for accessing flashblock state and data.
 pub trait FlashblocksAPI {
     /// Retrieves the pending blocks.
-    fn get_pending_blocks(&self) -> Option<Arc<PendingBlocks>>;
+    fn get_pending_blocks(&self) -> Guard<Option<Arc<PendingBlocks>>>;
 
-    /// Creates a subscription to receive flashblock updates.
     fn subscribe_to_flashblocks(&self) -> broadcast::Receiver<Flashblock>;
+}
+
+pub trait PendingBlocksAPI {
+    /// Get the canonical block number on top of which all pending state is built
+    fn get_canonical_block_number(&self) -> BlockNumberOrTag;
+
+    /// Get the pending transactions count for an address
+    fn get_transaction_count(&self, address: Address) -> U256;
+
+    /// Retrieves the current block. If `full` is true, includes full transaction details.
+    fn get_block(&self, full: bool) -> Option<RpcBlock<Optimism>>;
+
+    /// Gets transaction receipt by hash.
+    fn get_transaction_receipt(&self, tx_hash: TxHash) -> Option<RpcReceipt<Optimism>>;
+
+    /// Gets transaction details by hash.
+    fn get_transaction_by_hash(&self, tx_hash: TxHash) -> Option<RpcTransaction<Optimism>>;
+
+    /// Gets balance for an address. Returns None if address not updated in flashblocks.
+    fn get_balance(&self, address: Address) -> Option<U256>;
+
+    /// Gets the state overrides for the pending blocks
+    fn get_state_overrides(&self) -> Option<StateOverride>;
 }
 
 #[cfg_attr(not(test), rpc(server, namespace = "eth"))]
@@ -145,7 +168,7 @@ where
         if number.is_pending() {
             self.metrics.get_block_by_number.increment(1);
             let pending_blocks = self.flashblocks_state.get_pending_blocks();
-            Ok(pending_blocks.as_ref().map(|pb| pb.get_latest_block(full)))
+            Ok(pending_blocks.get_block(full))
         } else {
             EthBlocks::rpc_block(&self.eth_api, number.into(), full)
                 .await
@@ -163,10 +186,7 @@ where
         );
 
         let pending_blocks = self.flashblocks_state.get_pending_blocks();
-        if let Some(fb_receipt) = pending_blocks
-            .as_ref()
-            .and_then(|pb| pb.get_receipt(tx_hash))
-        {
+        if let Some(fb_receipt) = pending_blocks.get_transaction_receipt(tx_hash) {
             self.metrics.get_transaction_receipt.increment(1);
             return Ok(Some(fb_receipt));
         }
@@ -189,10 +209,7 @@ where
         if block_id.is_pending() {
             self.metrics.get_balance.increment(1);
             let pending_blocks = self.flashblocks_state.get_pending_blocks();
-            if let Some(balance) = pending_blocks
-                .as_ref()
-                .and_then(|pb| pb.get_balance(address))
-            {
+            if let Some(balance) = pending_blocks.get_balance(address) {
                 return Ok(balance);
             }
         }
@@ -216,14 +233,8 @@ where
         if block_id.is_pending() {
             self.metrics.get_transaction_count.increment(1);
             let pending_blocks = self.flashblocks_state.get_pending_blocks();
-            let canon_block = pending_blocks
-                .as_ref()
-                .map(|pb| pb.canonical_block_number())
-                .unwrap_or(BlockNumberOrTag::Latest);
-            let fb_count = pending_blocks
-                .as_ref()
-                .map(|pb| pb.get_transaction_count(address))
-                .unwrap_or_else(|| U256::from(0));
+            let canon_block = pending_blocks.get_canonical_block_number();
+            let fb_count = pending_blocks.get_transaction_count(address);
 
             let canon_count =
                 EthState::transaction_count(&self.eth_api, address, Some(canon_block.into()))
@@ -249,10 +260,7 @@ where
 
         let pending_blocks = self.flashblocks_state.get_pending_blocks();
 
-        if let Some(fb_transaction) = pending_blocks
-            .as_ref()
-            .and_then(|pb| pb.get_transaction_by_hash(tx_hash))
-        {
+        if let Some(fb_transaction) = pending_blocks.get_transaction_by_hash(tx_hash) {
             self.metrics.get_transaction_receipt.increment(1);
             return Ok(Some(fb_transaction));
         }
@@ -342,15 +350,8 @@ where
         if block_id.is_pending() {
             self.metrics.call.increment(1);
             let pending_blocks = self.flashblocks_state.get_pending_blocks();
-            block_id = pending_blocks
-                .as_ref()
-                .map(|pb| pb.canonical_block_number())
-                .unwrap_or(BlockNumberOrTag::Latest)
-                .into();
-            pending_overrides.state = pending_blocks
-                .as_ref()
-                .map(|pb| pb.get_state_overrides())
-                .unwrap_or_default();
+            block_id = pending_blocks.get_canonical_block_number().into();
+            pending_overrides.state = pending_blocks.get_state_overrides();
         }
 
         // Apply user's overrides on top
@@ -390,15 +391,8 @@ where
         if block_id.is_pending() {
             self.metrics.estimate_gas.increment(1);
             let pending_blocks = self.flashblocks_state.get_pending_blocks();
-            block_id = pending_blocks
-                .as_ref()
-                .map(|pb| pb.canonical_block_number())
-                .unwrap_or(BlockNumberOrTag::Latest)
-                .into();
-            pending_overrides.state = pending_blocks
-                .as_ref()
-                .map(|pb| pb.get_state_overrides())
-                .unwrap_or_default();
+            block_id = pending_blocks.get_canonical_block_number().into();
+            pending_overrides.state = pending_blocks.get_state_overrides();
         }
 
         let mut state_overrides_builder =
@@ -428,15 +422,8 @@ where
         if block_id.is_pending() {
             self.metrics.simulate_v1.increment(1);
             let pending_blocks = self.flashblocks_state.get_pending_blocks();
-            block_id = pending_blocks
-                .as_ref()
-                .map(|pb| pb.canonical_block_number())
-                .unwrap_or(BlockNumberOrTag::Latest)
-                .into();
-            pending_overrides.state = pending_blocks
-                .as_ref()
-                .map(|pb| pb.get_state_overrides())
-                .unwrap_or_default();
+            block_id = pending_blocks.get_canonical_block_number().into();
+            pending_overrides.state = pending_blocks.get_state_overrides();
         }
 
         // Prepend flashblocks pending overrides to the block state calls
@@ -479,9 +466,7 @@ where
                 Ok(flashblock) if flashblock.metadata.receipts.contains_key(&tx_hash) => {
                     debug!(message = "found receipt in flashblock", tx_hash = %tx_hash);
                     let pending_blocks = self.flashblocks_state.get_pending_blocks();
-                    return pending_blocks
-                        .as_ref()
-                        .and_then(|pb| pb.get_receipt(tx_hash));
+                    return pending_blocks.get_transaction_receipt(tx_hash);
                 }
                 Ok(_) => {
                     trace!(message = "flashblock does not contain receipt", tx_hash = %tx_hash);

--- a/crates/flashblocks-rpc/src/state.rs
+++ b/crates/flashblocks-rpc/src/state.rs
@@ -1,20 +1,20 @@
 use crate::metrics::Metrics;
 use crate::pending_blocks::{PendingBlocks, PendingBlocksBuilder};
-use crate::rpc::FlashblocksAPI;
+use crate::rpc::{FlashblocksAPI, PendingBlocksAPI};
 use crate::subscription::{Flashblock, FlashblocksReceiver};
 use alloy_consensus::transaction::{Recovered, SignerRecoverable, TransactionMeta};
 use alloy_consensus::{Header, TxReceipt};
 use alloy_eips::BlockNumberOrTag;
 use alloy_primitives::map::foldhash::HashMap;
 use alloy_primitives::map::B256HashMap;
-use alloy_primitives::{BlockNumber, Bytes, Sealable, B256};
-use alloy_rpc_types::{TransactionTrait, Withdrawal};
+use alloy_primitives::{Address, BlockNumber, Bytes, Sealable, B256, U256};
+use alloy_rpc_types::{state::StateOverride, TransactionTrait, Withdrawal};
 use alloy_rpc_types_engine::{ExecutionPayloadV1, ExecutionPayloadV2, ExecutionPayloadV3};
 use alloy_rpc_types_eth::state::{AccountOverride, StateOverridesBuilder};
-use arc_swap::ArcSwapOption;
+use arc_swap::{ArcSwapOption, Guard};
 use eyre::eyre;
 use op_alloy_consensus::OpTxEnvelope;
-use op_alloy_network::TransactionResponse;
+use op_alloy_network::{Optimism, TransactionResponse};
 use op_alloy_rpc_types::Transaction;
 use reth::chainspec::{ChainSpecProvider, EthChainSpec};
 use reth::providers::{BlockReaderIdExt, StateProviderFactory};
@@ -28,7 +28,8 @@ use reth_optimism_evm::{OpEvmConfig, OpNextBlockEnvAttributes};
 use reth_optimism_primitives::{DepositReceipt, OpBlock, OpPrimitives};
 use reth_optimism_rpc::OpReceiptBuilder;
 use reth_primitives::RecoveredBlock;
-use reth_rpc_convert::transaction::ConvertReceiptInput;
+use reth_rpc_convert::{transaction::ConvertReceiptInput, RpcTransaction};
+use reth_rpc_eth_api::{RpcBlock, RpcReceipt};
 use std::collections::{BTreeMap, HashSet};
 use std::sync::Arc;
 use std::time::Instant;
@@ -117,12 +118,55 @@ impl<Client> FlashblocksReceiver for FlashblocksState<Client> {
 }
 
 impl<Client> FlashblocksAPI for FlashblocksState<Client> {
-    fn get_pending_blocks(&self) -> Option<Arc<PendingBlocks>> {
-        self.pending_blocks.load_full()
+    fn get_pending_blocks(&self) -> Guard<Option<Arc<PendingBlocks>>> {
+        self.pending_blocks.load()
     }
 
     fn subscribe_to_flashblocks(&self) -> tokio::sync::broadcast::Receiver<Flashblock> {
         self.flashblock_sender.subscribe()
+    }
+}
+
+impl PendingBlocksAPI for Guard<Option<Arc<PendingBlocks>>> {
+    fn get_canonical_block_number(&self) -> BlockNumberOrTag {
+        self.as_ref()
+            .map(|pb| pb.canonical_block_number())
+            .unwrap_or(BlockNumberOrTag::Latest)
+    }
+
+    fn get_transaction_count(&self, address: Address) -> U256 {
+        self.as_ref()
+            .map(|pb| pb.get_transaction_count(address))
+            .unwrap_or_else(|| U256::from(0))
+    }
+
+    fn get_block(&self, full: bool) -> Option<RpcBlock<Optimism>> {
+        self.as_ref().map(|pb| pb.get_latest_block(full))
+    }
+
+    fn get_transaction_receipt(
+        &self,
+        tx_hash: alloy_primitives::TxHash,
+    ) -> Option<RpcReceipt<Optimism>> {
+        self.as_ref().and_then(|pb| pb.get_receipt(tx_hash))
+    }
+
+    fn get_transaction_by_hash(
+        &self,
+        tx_hash: alloy_primitives::TxHash,
+    ) -> Option<RpcTransaction<Optimism>> {
+        self.as_ref()
+            .and_then(|pb| pb.get_transaction_by_hash(tx_hash))
+    }
+
+    fn get_balance(&self, address: Address) -> Option<U256> {
+        self.as_ref().and_then(|pb| pb.get_balance(address))
+    }
+
+    fn get_state_overrides(&self) -> Option<StateOverride> {
+        self.as_ref()
+            .map(|pb| pb.get_state_overrides())
+            .unwrap_or_default()
     }
 }
 

--- a/crates/flashblocks-rpc/src/state.rs
+++ b/crates/flashblocks-rpc/src/state.rs
@@ -120,6 +120,14 @@ impl<Client> FlashblocksReceiver for FlashblocksState<Client> {
 }
 
 impl<Client> FlashblocksAPI for FlashblocksState<Client> {
+    fn get_canonical_block_number(&self) -> BlockNumberOrTag {
+        self.pending_blocks
+            .load()
+            .as_ref()
+            .map(|pb| pb.canonical_block_number())
+            .unwrap_or(BlockNumberOrTag::Latest)
+    }
+
     fn get_block(&self, full: bool) -> Option<RpcBlock<Optimism>> {
         self.pending_blocks
             .load()


### PR DESCRIPTION
Solves the race condition which could result in double-counting when fetching nonce or apply unnecessary overrides in `eth_call`, `eth_estimateGas` or `eth_simluateV1`