### PR TITLE
Fix:  Use Counter for upstream_messages

### DIFF
--- a/crates/flashblocks-rpc/src/metrics.rs
+++ b/crates/flashblocks-rpc/src/metrics.rs
@@ -1,5 +1,11 @@
 use metrics::{Counter, Gauge, Histogram};
 use metrics_derive::Metrics;
+
+/// Metrics for the `reth_flashblocks` component.
+/// Conventions:
+/// - Durations are recorded in seconds (histograms).
+/// - Counters are monotonic event counts.
+/// - Gauges reflect the current value/state.
 #[derive(Metrics, Clone)]
 #[metrics(scope = "reth_flashblocks")]
 pub struct Metrics {

--- a/crates/flashblocks-rpc/src/metrics.rs
+++ b/crates/flashblocks-rpc/src/metrics.rs
@@ -13,7 +13,7 @@ pub struct Metrics {
     pub upstream_errors: Counter,
 
     #[metric(describe = "Count of messages received from the upstream source")]
-    pub upstream_messages: Gauge,
+    pub upstream_messages: Counter,
 
     #[metric(describe = "Time taken to process a message")]
     pub block_processing_duration: Histogram,

--- a/crates/flashblocks-rpc/src/metrics.rs
+++ b/crates/flashblocks-rpc/src/metrics.rs
@@ -1,6 +1,5 @@
 use metrics::{Counter, Gauge, Histogram};
 use metrics_derive::Metrics;
-
 /// Metrics for the `reth_flashblocks` component.
 /// Conventions:
 /// - Durations are recorded in seconds (histograms).


### PR DESCRIPTION
The  PR changes the type of the `upstream_messages` metric from a Gauge to a Counter.

Since it represents the total number of messages received. 