### PR TITLE
cargo: correct homepage/repository links

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,8 +3,8 @@ version = "0.1.0"
 edition = "2021"
 rust-version = "1.85"
 license = "MIT"
-homepage = "https://github.com/base/reth"
-repository = "https://github.com/base/reth"
+homepage = "https://github.com/base/node-reth"
+repository = "https://github.com/base/node-reth"
 
 [workspace]
 resolver = "2"


### PR DESCRIPTION
Corrects `[workspace.package]` `homepage` and `repository` to this repo (`https://github.com/base/node-reth`). They previously pointed to `base/reth`, which misdirects cargo metadata consumers (crates.io pages, SBOM/audit tools) and conflicted with the README badges referencing `base/node-reth`. Verified via `cargo metadata` and manual link checks. Docs-only metadata change; no code or behavior impact.