### PR TITLE
refactor : parse websocket url via clop instead of runtime

### DIFF
--- a/crates/node/src/main.rs
+++ b/crates/node/src/main.rs
@@ -29,7 +29,6 @@ struct Args {
     #[command(flatten)]
     pub rollup_args: RollupArgs,
 
-    /// W endpoint for Flashblocks 
     #[arg(
         long = "websocket-url", 
         value_name = "WEBSOCKET_URL", 

--- a/crates/node/src/main.rs
+++ b/crates/node/src/main.rs
@@ -49,6 +49,7 @@ struct Args {
 }
 
 impl Args {
+    #[inline]
     fn flashblocks_enabled(&self) -> bool {
         self.websocket_url.is_some()
     }

--- a/crates/node/src/main.rs
+++ b/crates/node/src/main.rs
@@ -29,7 +29,7 @@ struct Args {
     #[command(flatten)]
     pub rollup_args: RollupArgs,
 
-    /// WS endpoint for Flashblocks 
+    /// W endpoint for Flashblocks 
     #[arg(
         long = "websocket-url", 
         value_name = "WEBSOCKET_URL", 

--- a/crates/node/src/main.rs
+++ b/crates/node/src/main.rs
@@ -29,8 +29,9 @@ struct Args {
     #[command(flatten)]
     pub rollup_args: RollupArgs,
 
-    #[arg(long = "websocket-url", value_name = "WEBSOCKET_URL")]
-    pub websocket_url: Option<String>,
+    /// WS endpoint for Flashblocks 
+    #[arg(long = "websocket-url", value_name = "WEBSOCKET_URL", value_parser = clap::value_parser!(Url))]
+    pub websocket_url: Option<Url>,
 
     /// Enable transaction tracing ExEx for mempool-to-block timing analysis
     #[arg(

--- a/crates/node/src/main.rs
+++ b/crates/node/src/main.rs
@@ -30,7 +30,11 @@ struct Args {
     pub rollup_args: RollupArgs,
 
     /// WS endpoint for Flashblocks 
-    #[arg(long = "websocket-url", value_name = "WEBSOCKET_URL", value_parser = clap::value_parser!(Url))]
+    #[arg(
+        long = "websocket-url", 
+        value_name = "WEBSOCKET_URL", 
+        value_parser = clap::value_parser!(Url)
+    )]
     pub websocket_url: Option<Url>,
 
     /// Enable transaction tracing ExEx for mempool-to-block timing analysis


### PR DESCRIPTION
parse `websocket_url` as a `Url` directly