### PR TITLE
fix:  moved a one-time operation outside of a for loop 

### DIFF
--- a/crates/flashblocks-rpc/src/state.rs
+++ b/crates/flashblocks-rpc/src/state.rs
@@ -605,9 +605,9 @@ where
                             move_precompile_to: None,
                         };
                         state_cache_builder = state_cache_builder.append(*addr, acc_override);
-                        pending_blocks_builder
-                            .with_transaction_state(transaction.tx_hash(), state.clone());
                     }
+                    pending_blocks_builder
+                        .with_transaction_state(transaction.tx_hash(), state.clone());
                     evm.db_mut().commit(state);
                 }
             }


### PR DESCRIPTION
#109

- The operation seems that it should be a one-time operation, and should be moved outside of the for loop.