### PR TITLE
docs: Fix binary name in README

### DIFF
--- a/crates/flashblocks-rpc/README.md
+++ b/crates/flashblocks-rpc/README.md
@@ -3,7 +3,7 @@ To include integration tests when testing, run:
 
 ```bash
 # Must be run in the root of the repo
-# Build the op-rbuilder binary
+# Build the base-reth-node binary
 cargo build --bin base-reth-node
 
 # Must be run in the crate


### PR DESCRIPTION
## Description

The README in crates/flashblocks-rpc referred to “op-rbuilder” while the actual build command uses the binary name “base-reth-node”. This change aligns the instruction with the real binary:

- Before: “Build the op-rbuilder binary”
- After:  “Build the base-reth-node binary”