### PR TITLE
chore: minor logging changes

### DIFF
--- a/crates/flashblocks-rpc/src/state.rs
+++ b/crates/flashblocks-rpc/src/state.rs
@@ -37,7 +37,7 @@ use std::time::Instant;
 use tokio::sync::broadcast::{self, Sender};
 use tokio::sync::mpsc::{self, UnboundedReceiver};
 use tokio::sync::Mutex;
-use tracing::{debug, error, info, warn};
+use tracing::{debug, error, info};
 
 // Buffer 4s of flashblocks for flashblock_sender
 const BUFFER_SIZE: usize = 20;

--- a/crates/flashblocks-rpc/src/state.rs
+++ b/crates/flashblocks-rpc/src/state.rs
@@ -288,7 +288,7 @@ where
                     if tracked_txn_hashes.len() != block_txn_hashes.len()
                         || tracked_txn_hashes != block_txn_hashes
                     {
-                        warn!(
+                        debug!(
                             message = "reorg detected, recomputing pending flashblocks going ahead of reorg",
                             latest_pending_block = pending_blocks.latest_block_number(),
                             canonical_block = block.number,
@@ -375,7 +375,7 @@ where
         let earliest_block_number = flashblocks_per_block.keys().min().unwrap();
         let canonical_block = earliest_block_number - 1;
         let mut last_block_header = self.client.header_by_number(canonical_block)?.ok_or(eyre!(
-            "Failed to extract header for canonical block number {}",
+            "Failed to extract header for canonical block number {}. This is okay if your node is not fully synced to tip yet.",
             canonical_block
         ))?;
 


### PR DESCRIPTION
Minor logging changes to reduce spam by bumping down a log from warn to debug. Also let people know that `failed to extract header` is fine if your node isn't fully synced to tip yet - which seems to be the issue in #105 