### PR TITLE
transaction-tracing: fix EventLog limit to enable overflow path

### DIFF
--- a/crates/transaction-tracing/src/types.rs
+++ b/crates/transaction-tracing/src/types.rs
@@ -56,7 +56,6 @@ impl EventLog {
 
     pub fn push(&mut self, t: DateTime<Local>, event: TxEvent) {
         self.events.push((t, event));
-        self.limit += 1;
     }
 
     pub fn to_vec(&self) -> Vec<String> {


### PR DESCRIPTION
- Make EventLog.limit a fixed cap by not increasing it on push
- Unblocks overflow handling in Tracker::is_overflowed
- Ensures Overflowed metric is emitted when the per-tx history reaches the cap
- No behavioral changes elsewhere; only affects overflow triggering