### PR TITLE
bump dockerfile rust base image to 1.88

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.87 AS build
+FROM rust:1.88 AS build
 
 WORKDIR /app
 


### PR DESCRIPTION
Signed-off-by: Yashvardhan Kukreja <yashvardhan@oplabs.co>

Currently, the rust:1.87 base image causes the docker build process to fail with the following error hinting the need of underlying rustc to have a version >=1.88.0

```
163.9   revm-inspector@10.0.1 requires rustc 1.88.0
163.9   revm-interpreter@25.0.3 requires rustc 1.88.0
163.9   revm-precompile@27.0.0 requires rustc 1.88.0
163.9   revm-primitives@20.2.1 requires rustc 1.88.0
163.9   revm-state@7.0.5 requires rustc 1.88.0
163.9 Either upgrade rustc or select compatible dependency versions with
163.9 `cargo update <name>@<current-ver> --precise <compatible-ver>`
163.9 where `<compatible-ver>` is the latest version supporting rustc 1.87.0
```

This PR fixes that.