### PR TITLE
fix(rpc): remove incorrect metrics increment in transaction_by_hash

### DIFF
--- a/crates/flashblocks-rpc/src/rpc.rs
+++ b/crates/flashblocks-rpc/src/rpc.rs
@@ -270,7 +270,6 @@ where
         let pending_blocks = self.flashblocks_state.get_pending_blocks();
 
         if let Some(fb_transaction) = pending_blocks.get_transaction_by_hash(tx_hash) {
-            self.metrics.get_transaction_receipt.increment(1);
             return Ok(Some(fb_transaction));
         }
 


### PR DESCRIPTION

### Problem
The `getTransactionByHash` RPC method was incorrectly incrementing the `get_transaction_receipt` metric when returning transactions from flashblocks cache. This caused metric pollution and reduced observability accuracy.

### Solution
- Removed the erroneous `get_transaction_receipt.increment(1)` call from the flashblocks cache path in `transaction_by_hash`
- This ensures metrics accurately reflect actual RPC method usage

