### PR TITLE
docs(README): reference Cargo.toml version

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 > [!WARNING]
 > This repository is for development purposes. For production deployments, please use the releases referenced in [base/node](https://github.com/base/node/releases).
 
-Base Reth Node is an implementation of a Reth Ethereum node, specifically tailored for the Base L2 network. It integrates Flashblocks capabilities and leverages Optimism components from Reth `v1.8.1`. This node is designed to provide a robust and efficient solution for interacting with the Base network.
+Base Reth Node is an implementation of a Reth Ethereum node, specifically tailored for the Base L2 network. It integrates Flashblocks capabilities and leverages Optimism components from Reth (see version pinned in [Cargo.toml](Cargo.toml)). This node is designed to provide a robust and efficient solution for interacting with the Base network.
 
 <!-- Badge row 1 - status -->
 
@@ -32,7 +32,7 @@ Base Reth Node is an implementation of a Reth Ethereum node, specifically tailor
 
 - **Base L2 Support:** Optimized for the Base Layer 2 network.
 - **Flashblocks RPC:** Includes a `flashblocks-rpc` crate for Flashblocks.
-- **Reth Based:** Built upon Reth `v1.8.1`, incorporating its Optimism features.
+- **Reth Based:** Built upon Reth, see version pinned in [Cargo.toml](Cargo.toml).
 - **Dockerized:** Comes with a `Dockerfile` for easy containerization and deployment.
 - **Development Toolkit:** Includes a `justfile` for streamlined build, test, and linting workflows.
 


### PR DESCRIPTION
README referenced Reth v1.8.1 while the workspace pins Reth to v1.8.2 in Cargo.toml so I replaced the two README occurrences of v1.8.1 with v1.8.2.