### PR TITLE
feat: new erc20 transfer tests

### DIFF
--- a/crates/flashblocks-rpc/tests/assets/genesis.json
+++ b/crates/flashblocks-rpc/tests/assets/genesis.json
@@ -1,0 +1,100 @@
+{
+    "config": {
+        "chainId": 8453,
+        "homesteadBlock": 0,
+        "eip150Block": 0,
+        "eip155Block": 0,
+        "eip158Block": 0,
+        "byzantiumBlock": 0,
+        "constantinopleBlock": 0,
+        "petersburgBlock": 0,
+        "istanbulBlock": 0,
+        "muirGlacierBlock": 0,
+        "berlinBlock": 0,
+        "londonBlock": 0,
+        "arrowGlacierBlock": 0,
+        "grayGlacierBlock": 0,
+        "mergeNetsplitBlock": 0,
+        "bedrockBlock": 0,
+        "regolithTime": 0,
+        "terminalTotalDifficulty": 0,
+        "terminalTotalDifficultyPassed": true,
+        "optimism": {
+            "eip1559Elasticity": 6,
+            "eip1559Denominator": 50
+        }
+    },
+    "nonce": "0x0",
+    "timestamp": "0x0",
+    "extraData": "0x00",
+    "gasLimit": "0x1c9c380",
+    "difficulty": "0x0",
+    "mixHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+    "coinbase": "0x0000000000000000000000000000000000000000",
+    "alloc": {
+        "0x14dc79964da2c08b23698b3d3cc7ca32193d9955": {
+            "balance": "0xd3c21bcecceda1000000"
+        },
+        "0x15d34aaf54267db7d7c367839aaf71a00a2c6a65": {
+            "balance": "0xd3c21bcecceda1000000"
+        },
+        "0x1cbd3b2770909d4e10f157cabc84c7264073c9ec": {
+            "balance": "0xd3c21bcecceda1000000"
+        },
+        "0x23618e81e3f5cdf7f54c3d65f7fbc0abf5b21e8f": {
+            "balance": "0xd3c21bcecceda1000000"
+        },
+        "0x2546bcd3c84621e976d8185a91a922ae77ecec30": {
+            "balance": "0xd3c21bcecceda1000000"
+        },
+        "0x3c44cdddb6a900fa2b585dd299e03d12fa4293bc": {
+            "balance": "0xd3c21bcecceda1000000"
+        },
+        "0x70997970c51812dc3a010c7d01b50e0d17dc79c8": {
+            "balance": "0xd3c21bcecceda1000000"
+        },
+        "0x71be63f3384f5fb98995898a86b02fb2426c5788": {
+            "balance": "0xd3c21bcecceda1000000"
+        },
+        "0x8626f6940e2eb28930efb4cef49b2d1f2c9c1199": {
+            "balance": "0xd3c21bcecceda1000000"
+        },
+        "0x90f79bf6eb2c4f870365e785982e1f101e93b906": {
+            "balance": "0xd3c21bcecceda1000000"
+        },
+        "0x976ea74026e726554db657fa54763abd0c3a0aa9": {
+            "balance": "0xd3c21bcecceda1000000"
+        },
+        "0x9965507d1a55bcc2695c58ba16fb37d819b0a4dc": {
+            "balance": "0xd3c21bcecceda1000000"
+        },
+        "0x9c41de96b2088cdc640c6182dfcf5491dc574a57": {
+            "balance": "0xd3c21bcecceda1000000"
+        },
+        "0xa0ee7a142d267c1f36714e4a8f75612f20a79720": {
+            "balance": "0xd3c21bcecceda1000000"
+        },
+        "0xbcd4042de499d14e55001ccbb24a551f3b954096": {
+            "balance": "0xd3c21bcecceda1000000"
+        },
+        "0xbda5747bfd65f08deb54cb465eb87d40e51b197e": {
+            "balance": "0xd3c21bcecceda1000000"
+        },
+        "0xcd3b766ccdd6ae721141f452c550ca635964ce71": {
+            "balance": "0xd3c21bcecceda1000000"
+        },
+        "0xdd2fd4581271e230360230f9337d5c0430bf44c0": {
+            "balance": "0xd3c21bcecceda1000000"
+        },
+        "0xdf3e18d64bc6a983f673ab319ccae4f1a57c7097": {
+            "balance": "0xd3c21bcecceda1000000"
+        },
+        "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266": {
+            "balance": "0xd3c21bcecceda1000000"
+        },
+        "0xfabb0ac9d68b0b445fb7357272ff202c5651694a": {
+            "balance": "0xd3c21bcecceda1000000"
+        }
+    },
+    "number": "0x0"
+}

--- a/crates/flashblocks-rpc/tests/common/mod.rs
+++ b/crates/flashblocks-rpc/tests/common/mod.rs
@@ -1,0 +1,190 @@
+use alloy_consensus::Receipt;
+use alloy_genesis::Genesis;
+use alloy_primitives::map::HashMap;
+use alloy_primitives::{address, b256, bytes, Address, Bytes, B256};
+use alloy_provider::RootProvider;
+use alloy_rpc_client::RpcClient;
+use alloy_rpc_types_engine::PayloadId;
+use base_reth_flashblocks_rpc::rpc::{EthApiExt, EthApiOverrideServer};
+use base_reth_flashblocks_rpc::state::FlashblocksState;
+use base_reth_flashblocks_rpc::subscription::{Flashblock, FlashblocksReceiver, Metadata};
+use op_alloy_consensus::OpDepositReceipt;
+use op_alloy_network::Optimism;
+use reth::args::{DiscoveryArgs, NetworkArgs, RpcServerArgs};
+use reth::builder::{Node, NodeBuilder, NodeConfig, NodeHandle};
+use reth::chainspec::Chain;
+use reth::core::exit::NodeExitFuture;
+use reth::tasks::TaskManager;
+use reth_optimism_chainspec::OpChainSpecBuilder;
+use reth_optimism_node::args::RollupArgs;
+use reth_optimism_node::OpNode;
+use reth_optimism_primitives::OpReceipt;
+use reth_provider::providers::BlockchainProvider;
+use rollup_boost::{ExecutionPayloadBaseV1, ExecutionPayloadFlashblockDeltaV1};
+use std::any::Any;
+use std::net::SocketAddr;
+use std::sync::{Arc, Once};
+use tokio::sync::{mpsc, oneshot};
+
+pub const ALICE: Address = address!("0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266");
+pub const BOB: Address = address!("0x70997970C51812dc3A010C7d01b50e0d17dc79C8");
+pub const CHARLIE: Address = address!("0x3C44CdDdB6a900fa2b585dd299e03d12FA4293BC");
+
+pub const BLOCK_INFO_TXN: Bytes = bytes!("0x7ef90104a06c0c775b6b492bab9d7e81abdf27f77cafb698551226455a82f559e0f93fea3794deaddeaddeaddeaddeaddeaddeaddeaddead00019442000000000000000000000000000000000000158080830f424080b8b0098999be000008dd00101c1200000000000000020000000068869d6300000000015f277f000000000000000000000000000000000000000000000000000000000d42ac290000000000000000000000000000000000000000000000000000000000000001abf52777e63959936b1bf633a2a643f0da38d63deffe49452fed1bf8a44975d50000000000000000000000005050f69a9786f081509234f1a7f4684b5e5b76c9000000000000000000000000");
+pub const BLOCK_INFO_TXN_HASH: B256 =
+    b256!("0xba56c8b0deb460ff070f8fca8e2ee01e51a3db27841cc862fdd94cc1a47662b6");
+
+pub struct NodeContext {
+    sender: mpsc::Sender<(Flashblock, oneshot::Sender<()>)>,
+    http_api_addr: SocketAddr,
+    _node_exit_future: NodeExitFuture,
+    _node: Box<dyn Any + Sync + Send>,
+    _task_manager: TaskManager,
+}
+
+impl NodeContext {
+    pub async fn send_payload(&self, payload: Flashblock) -> eyre::Result<()> {
+        let (tx, rx) = oneshot::channel();
+        self.sender.send((payload, tx)).await?;
+        rx.await?;
+        Ok(())
+    }
+
+    pub async fn provider(&self) -> eyre::Result<RootProvider<Optimism>> {
+        let url = format!("http://{}", self.http_api_addr);
+        let client = RpcClient::builder().http(url.parse()?);
+        Ok(RootProvider::<Optimism>::new(client))
+    }
+}
+
+static INIT_TRACING: Once = Once::new();
+
+fn init_logging_once() {
+    INIT_TRACING.call_once(|| {
+        reth_tracing::init_test_tracing();
+    });
+}
+
+pub async fn setup_node() -> eyre::Result<NodeContext> {
+    init_logging_once();
+    let tasks = TaskManager::current();
+    let exec = tasks.executor();
+    const BASE_SEPOLIA_CHAIN_ID: u64 = 84532;
+
+    let genesis: Genesis = serde_json::from_str(include_str!("../assets/genesis.json"))
+        .expect("Genesis object can't be constructed from file ../assets/genesis.json");
+    let chain_spec = Arc::new(
+        OpChainSpecBuilder::base_mainnet()
+            .genesis(genesis)
+            .ecotone_activated()
+            .chain(Chain::from(BASE_SEPOLIA_CHAIN_ID))
+            .build(),
+    );
+
+    let network_config = NetworkArgs {
+        discovery: DiscoveryArgs {
+            disable_discovery: true,
+            ..DiscoveryArgs::default()
+        },
+        ..NetworkArgs::default()
+    };
+
+    let node_config = NodeConfig::new(chain_spec.clone())
+        .with_network(network_config.clone())
+        .with_rpc(RpcServerArgs::default().with_unused_ports().with_http())
+        .with_unused_ports();
+
+    let node = OpNode::new(RollupArgs::default());
+
+    let (sender, mut receiver) = mpsc::channel::<(Flashblock, oneshot::Sender<()>)>(100);
+
+    let NodeHandle {
+        node,
+        node_exit_future,
+    } = NodeBuilder::new(node_config.clone())
+        .testing_node(exec.clone())
+        .with_types_and_provider::<OpNode, BlockchainProvider<_>>()
+        .with_components(node.components_builder())
+        .with_add_ons(node.add_ons())
+        .extend_rpc_modules(move |ctx| {
+            let flashblocks_state = Arc::new(FlashblocksState::new(ctx.provider().clone()));
+            flashblocks_state.start();
+
+            let api_ext = EthApiExt::new(
+                ctx.registry.eth_api().clone(),
+                ctx.registry.eth_handlers().filter.clone(),
+                flashblocks_state.clone(),
+            );
+
+            ctx.modules.replace_configured(api_ext.into_rpc())?;
+
+            tokio::spawn(async move {
+                while let Some((payload, tx)) = receiver.recv().await {
+                    flashblocks_state.on_flashblock_received(payload);
+                    tx.send(()).unwrap();
+                }
+            });
+
+            Ok(())
+        })
+        .launch()
+        .await?;
+
+    let http_api_addr = node
+        .rpc_server_handle()
+        .http_local_addr()
+        .ok_or_else(|| eyre::eyre!("Failed to get http api address"))?;
+
+    Ok(NodeContext {
+        sender,
+        http_api_addr,
+        _node_exit_future: node_exit_future,
+        _node: Box::new(node),
+        _task_manager: tasks,
+    })
+}
+
+pub fn create_base_flashblock(block_number: u64, transactions: Vec<Bytes>) -> Flashblock {
+    let mut receipts = HashMap::default();
+    receipts.insert(
+        BLOCK_INFO_TXN_HASH,
+        OpReceipt::Deposit(OpDepositReceipt {
+            inner: Receipt {
+                status: true.into(),
+                cumulative_gas_used: 21000,
+                logs: vec![],
+            },
+            deposit_nonce: Some(4012992u64),
+            deposit_receipt_version: None,
+        }),
+    );
+
+    Flashblock {
+        payload_id: PayloadId::new([0; 8]),
+        index: block_number,
+        base: Some(ExecutionPayloadBaseV1 {
+            parent_beacon_block_root: B256::default(),
+            parent_hash: B256::default(),
+            fee_recipient: Address::ZERO,
+            prev_randao: B256::default(),
+            block_number,
+            gas_limit: 30_000_000,
+            timestamp: block_number,
+            extra_data: Bytes::new(),
+            base_fee_per_gas: alloy_primitives::U256::ZERO,
+        }),
+        diff: ExecutionPayloadFlashblockDeltaV1 {
+            transactions: {
+                let mut txs = vec![BLOCK_INFO_TXN];
+                txs.extend(transactions);
+                txs
+            },
+            ..Default::default()
+        },
+        metadata: Metadata {
+            block_number,
+            receipts,
+            ..Default::default()
+        },
+    }
+}

--- a/crates/flashblocks-rpc/tests/erc20.rs
+++ b/crates/flashblocks-rpc/tests/erc20.rs
@@ -1,0 +1,245 @@
+mod common;
+
+use alloy_consensus::Receipt;
+use alloy_primitives::{address, b256, bytes, map::HashMap, Address, Bytes, B256, U256};
+use alloy_provider::{Provider, RootProvider};
+use alloy_rpc_types_engine::PayloadId;
+use alloy_rpc_types_eth::TransactionInput;
+use base_reth_flashblocks_rpc::subscription::{Flashblock, Metadata};
+use common::{create_base_flashblock, setup_node, ALICE, BOB, CHARLIE};
+use op_alloy_network::Optimism;
+use op_alloy_rpc_types::OpTransactionRequest;
+use reth_optimism_primitives::OpReceipt;
+use rollup_boost::ExecutionPayloadFlashblockDeltaV1;
+
+const ERC20_ADDRESS: Address = address!("0x5FbDB2315678afecb367f032d93F642f64180aa3");
+
+// 1. deployment: Alice deploys SimpleToken contract, receives 1000 tokens
+const DEPLOYMENT_TX: Bytes = bytes!("0x02f905df83014a34800184773594018305d2228080b905876080604052348015600e575f5ffd5b506103e86001819055506103e85f5f3373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff1681526020019081526020015f208190555061051f806100685f395ff3fe608060405234801561000f575f5ffd5b506004361061004a575f3560e01c806318160ddd1461004e57806327e235e31461006c57806370a082311461009c578063a9059cbb146100cc575b5f5ffd5b6100566100fc565b60405161006391906102a1565b60405180910390f35b61008660048036038101906100819190610318565b610102565b60405161009391906102a1565b60405180910390f35b6100b660048036038101906100b19190610318565b610116565b6040516100c391906102a1565b60405180910390f35b6100e660048036038101906100e1919061036d565b61015b565b6040516100f391906103c5565b60405180910390f35b60015481565b5f602052805f5260405f205f915090505481565b5f5f5f8373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff1681526020019081526020015f20549050919050565b5f815f5f3373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff1681526020019081526020015f205410156101db576040517f08c379a00000000000000000000000000000000000000000000000000000000081526004016101d290610438565b60405180910390fd5b815f5f3373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff1681526020019081526020015f205f8282546102269190610483565b92505081905550815f5f8573ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff1681526020019081526020015f205f82825461027891906104b6565b925050819055506001905092915050565b5f819050919050565b61029b81610289565b82525050565b5f6020820190506102b45f830184610292565b92915050565b5f5ffd5b5f73ffffffffffffffffffffffffffffffffffffffff82169050919050565b5f6102e7826102be565b9050919050565b6102f7816102dd565b8114610301575f5ffd5b50565b5f81359050610312816102ee565b92915050565b5f6020828403121561032d5761032c6102ba565b5b5f61033a84828501610304565b91505092915050565b61034c81610289565b8114610356575f5ffd5b50565b5f8135905061036781610343565b92915050565b5f5f60408385031215610383576103826102ba565b5b5f61039085828601610304565b92505060206103a185828601610359565b9150509250929050565b5f8115159050919050565b6103bf816103ab565b82525050565b5f6020820190506103d85f8301846103b6565b92915050565b5f82825260208201905092915050565b7f496e73756666696369656e742062616c616e63650000000000000000000000005f82015250565b5f6104226014836103de565b915061042d826103ee565b602082019050919050565b5f6020820190508181035f83015261044f81610416565b9050919050565b7f4e487b71000000000000000000000000000000000000000000000000000000005f52601160045260245ffd5b5f61048d82610289565b915061049883610289565b92508282039050818111156104b0576104af610456565b5b92915050565b5f6104c082610289565b91506104cb83610289565b92508282019050808211156104e3576104e2610456565b5b9291505056fea2646970667358221220451e82a180ed304d8b01f029cf6b2976b0cc2d03eb535a89648a4ef6a6d6a73664736f6c634300081e0033c001a0416acd3bfefd89cbe25745ef8752be3de00f4db63be0a3429300d2c75812fdafa01609998d8d0be85169a023581dc0bcc7352e83d4ead44b669de6c944409f8b82");
+const DEPLOYMENT_TX_HASH: B256 =
+    b256!("0xdad2b96d4c535d23274b675e05238197b92e34d2d7545a8401a5faaba36d8318");
+
+// 2. transfer: Alice transfers 100 tokens to Bob (nonce 1)
+const TRANSFER_TO_BOB_TX: Bytes = bytes!("0x02f8ae83014a340101847735940182c4a4945fbdb2315678afecb367f032d93f642f64180aa380b844a9059cbb00000000000000000000000070997970c51812dc3a010c7d01b50e0d17dc79c80000000000000000000000000000000000000000000000000000000000000064c001a09c79ed17167e13a7850dd0c22a02a2327e6bc13e923b0e40c79ddfa089f90311a03246cebb13a7c70b31c2af87d3d85ad6b40fc5404c127bb7e5efd545ba63fc68");
+const TRANSFER_TO_BOB_TX_HASH: B256 =
+    b256!("0xaad9de702ede9dfff3c97331b42baf3c98b2a6ca5411547072b9c7befefd563e");
+
+// 3. transfer: Alice transfers 50 tokens to Charlie (nonce 2)
+const TRANSFER_TO_CHARLIE_TX: Bytes = bytes!("0x02f8ae83014a3402018468afe50d82c498945fbdb2315678afecb367f032d93f642f64180aa380b844a9059cbb0000000000000000000000003c44cdddb6a900fa2b585dd299e03d12fa4293bc0000000000000000000000000000000000000000000000000000000000000032c080a0e81e5ff1e174b27905fabb9f02ba425f5ca0b2af6b50c2f9e32fdc4fa7df4e46a04018b7cd35a7cc9823c0c63c6e785e99fb1e38925c25b49417246729b9c7c387");
+const TRANSFER_TO_CHARLIE_TX_HASH: B256 =
+    b256!("0xac46da5c2d18b51782a857ef594efe854109c022f2ccfc47e6f648b8a87c3343");
+
+// balanceOf(address): 0x70a08231
+// transfer(address,uint256): 0xa9059cbb
+// totalSupply(): 0x18160ddd
+
+fn encode_balance_of(account: Address) -> TransactionInput {
+    let mut data = Vec::with_capacity(36);
+    data.extend_from_slice(&[0x70, 0xa0, 0x82, 0x31]); // balanceOf selector
+    data.extend_from_slice(&[0; 12]); // padding
+    data.extend_from_slice(account.as_slice());
+    TransactionInput::new(Bytes::from(data))
+}
+
+fn parse_uint256(result: Bytes) -> U256 {
+    if result.len() >= 32 {
+        U256::from_be_slice(&result[result.len() - 32..])
+    } else {
+        U256::ZERO
+    }
+}
+
+fn create_erc20_flashblock_delta(
+    flashblock_index: u64,
+    tx_hash: B256,
+    tx: Bytes,
+    cumulative_gas_used: u64,
+) -> Flashblock {
+    let mut receipts = HashMap::default();
+
+    receipts.insert(
+        tx_hash,
+        OpReceipt::Eip1559(Receipt {
+            status: true.into(),
+            cumulative_gas_used, // all txs in block
+            logs: vec![],
+        }),
+    );
+
+    Flashblock {
+        payload_id: PayloadId::new([0; 8]),
+        index: flashblock_index,
+        base: None, // no base
+        diff: ExecutionPayloadFlashblockDeltaV1 {
+            transactions: vec![tx],
+            ..Default::default()
+        },
+        metadata: Metadata {
+            block_number: 1,
+            receipts,
+            ..Default::default()
+        },
+    }
+}
+
+#[tokio::test]
+async fn test_erc20_multi_user_balances() -> eyre::Result<()> {
+    let node = setup_node().await?;
+    let provider = node.provider().await?;
+
+    let mut base_flashblock = create_base_flashblock(1, vec![]);
+    base_flashblock.index = 0;
+    node.send_payload(base_flashblock).await?;
+
+    // gas = BLOCK_INFO (21000) + DEPLOYMENT (380000) = 401000
+    let flashblock1 = create_erc20_flashblock_delta(1, DEPLOYMENT_TX_HASH, DEPLOYMENT_TX, 401000);
+    node.send_payload(flashblock1).await?;
+
+    let alice_balance = get_balance(&provider, ALICE).await?;
+    assert_eq!(
+        alice_balance,
+        U256::from(1000),
+        "Alice should have 1000 tokens after deployment"
+    );
+
+    let bob_balance = get_balance(&provider, BOB).await?;
+    assert_eq!(
+        bob_balance,
+        U256::ZERO,
+        "Bob should have 0 tokens initially"
+    );
+    let charlie_balance = get_balance(&provider, CHARLIE).await?;
+    assert_eq!(
+        charlie_balance,
+        U256::ZERO,
+        "Charlie should have 0 tokens initially"
+    );
+
+    // gas = BLOCK_INFO (21000) + DEPLOYMENT (380000) + TRANSFER_BOB (50000) = 451000
+    let flashblock2 =
+        create_erc20_flashblock_delta(2, TRANSFER_TO_BOB_TX_HASH, TRANSFER_TO_BOB_TX, 451000);
+    node.send_payload(flashblock2).await?;
+
+    let alice_balance = get_balance(&provider, ALICE).await?;
+    assert_eq!(
+        alice_balance,
+        U256::from(900),
+        "Alice should have 900 tokens after transfer to Bob"
+    );
+
+    let bob_balance = get_balance(&provider, BOB).await?;
+    assert_eq!(bob_balance, U256::from(100), "Bob should have 100 tokens");
+
+    // gas = BLOCK_INFO (21000) + DEPLOYMENT (380000) + TRANSFER_BOB (50000) + TRANSFER_CHARLIE (50000) = 501000
+    let flashblock3 = create_erc20_flashblock_delta(
+        3,
+        TRANSFER_TO_CHARLIE_TX_HASH,
+        TRANSFER_TO_CHARLIE_TX,
+        501000,
+    );
+    node.send_payload(flashblock3).await?;
+
+    let alice_balance = get_balance(&provider, ALICE).await?;
+    assert_eq!(
+        alice_balance,
+        U256::from(850),
+        "Alice should have 850 tokens after both transfers"
+    );
+
+    let bob_balance = get_balance(&provider, BOB).await?;
+    assert_eq!(
+        bob_balance,
+        U256::from(100),
+        "Bob should still have 100 tokens"
+    );
+
+    let charlie_balance = get_balance(&provider, CHARLIE).await?;
+    assert_eq!(
+        charlie_balance,
+        U256::from(50),
+        "Charlie should have 50 tokens"
+    );
+
+    Ok(())
+}
+
+async fn get_balance(provider: &RootProvider<Optimism>, account: Address) -> eyre::Result<U256> {
+    let call = OpTransactionRequest::default()
+        .from(ALICE)
+        .to(ERC20_ADDRESS)
+        .gas_limit(100_000)
+        .input(encode_balance_of(account));
+
+    let result = provider.call(call.into()).await?;
+    Ok(parse_uint256(result))
+}
+
+#[tokio::test]
+async fn test_basic_eth_call_with_flashblocks() -> eyre::Result<()> {
+    let node = setup_node().await?;
+    let provider = node.provider().await?;
+
+    let flashblock = create_base_flashblock(1, vec![]);
+    node.send_payload(flashblock).await?;
+
+    let call = OpTransactionRequest::default()
+        .from(ALICE)
+        .to(BOB)
+        .gas_limit(21_000);
+
+    let result = provider.call(call).await;
+    assert!(result.is_ok(), "eth_call should work with flashblocks");
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_erc20_balance_progression() -> eyre::Result<()> {
+    let node = setup_node().await?;
+    let provider = node.provider().await?;
+
+    let mut base_flashblock = create_base_flashblock(1, vec![]);
+    base_flashblock.index = 0;
+    node.send_payload(base_flashblock).await?;
+
+    // gas = BLOCK_INFO (21000) + DEPLOYMENT (380000) = 401000
+    let flashblock1 = create_erc20_flashblock_delta(1, DEPLOYMENT_TX_HASH, DEPLOYMENT_TX, 401000);
+    node.send_payload(flashblock1).await?;
+
+    let balance = get_balance(&provider, ALICE).await?;
+    assert_eq!(
+        balance,
+        U256::from(1000),
+        "After deployment: Alice should have 1000"
+    );
+
+    // gas = BLOCK_INFO (21000) + DEPLOYMENT (380000) + TRANSFER_BOB (50000) = 451000
+    let flashblock2 =
+        create_erc20_flashblock_delta(2, TRANSFER_TO_BOB_TX_HASH, TRANSFER_TO_BOB_TX, 451000);
+    node.send_payload(flashblock2).await?;
+
+    let balance = get_balance(&provider, ALICE).await?;
+    assert_eq!(
+        balance,
+        U256::from(900),
+        "After transfer to Bob: Alice should have 900"
+    );
+
+    // gas = BLOCK_INFO (21000) + DEPLOYMENT (380000) + TRANSFER_BOB (50000) + TRANSFER_CHARLIE (50000) = 501000
+    let flashblock3 = create_erc20_flashblock_delta(
+        3,
+        TRANSFER_TO_CHARLIE_TX_HASH,
+        TRANSFER_TO_CHARLIE_TX,
+        501000,
+    );
+    node.send_payload(flashblock3).await?;
+
+    let balance = get_balance(&provider, ALICE).await?;
+    assert_eq!(
+        balance,
+        U256::from(850),
+        "After transfer to Charlie: Alice should have 850"
+    );
+
+    Ok(())
+}

--- a/justfile
+++ b/justfile
@@ -5,8 +5,9 @@ check: check-format check-clippy test
 
 fix: fix-format fix-clippy
 
+# RUST_LOG=off to disable "ERROR reth_tasks: Global executor already set"
 test:
-    cargo test --workspace --all-features
+    RUST_LOG=off cargo test --workspace --all-features
 
 check-format:
     cargo fmt --all -- --check


### PR DESCRIPTION
Partly covers #151; new test environment from #160

I had to copy some code to new test env (`flashblocks-rpc/tests`).

Needs to be added to close #151 completely:
- [ ] ERC-20 with a TransparentProxy wrapper (e.g. USDC token)