### PR TITLE
refactor(flashblocks-rpc): reorg into state/ dir and types.rs, optimizations

### DIFF
--- a/crates/flashblocks-rpc/src/lib.rs
+++ b/crates/flashblocks-rpc/src/lib.rs
@@ -1,7 +1,7 @@
 mod metrics;
-mod pending_blocks;
 pub mod rpc;
 pub mod state;
 pub mod subscription;
 #[cfg(test)]
 mod tests;
+pub mod types;

--- a/crates/flashblocks-rpc/src/rpc.rs
+++ b/crates/flashblocks-rpc/src/rpc.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use crate::metrics::Metrics;
-use crate::pending_blocks::PendingBlocks;
+use crate::state::PendingBlocks;
 use alloy_eips::{BlockId, BlockNumberOrTag};
 use alloy_primitives::map::foldhash::{HashSet, HashSetExt};
 use alloy_primitives::{Address, TxHash, U256};

--- a/crates/flashblocks-rpc/src/state/mod.rs
+++ b/crates/flashblocks-rpc/src/state/mod.rs
@@ -1,7 +1,10 @@
+mod pending_blocks;
+
+pub(crate) use pending_blocks::{PendingBlocks, PendingBlocksBuilder};
+
 use crate::metrics::Metrics;
-use crate::pending_blocks::{PendingBlocks, PendingBlocksBuilder};
 use crate::rpc::{FlashblocksAPI, PendingBlocksAPI};
-use crate::subscription::{Flashblock, FlashblocksReceiver};
+use crate::types::{Flashblock, FlashblocksReceiver};
 use alloy_consensus::transaction::{Recovered, SignerRecoverable, TransactionMeta};
 use alloy_consensus::{Header, TxReceipt};
 use alloy_eips::BlockNumberOrTag;

--- a/crates/flashblocks-rpc/src/state/pending_blocks.rs
+++ b/crates/flashblocks-rpc/src/state/pending_blocks.rs
@@ -13,7 +13,7 @@ use op_alloy_rpc_types::{OpTransactionReceipt, Transaction};
 use reth::revm::{db::Cache, state::EvmState};
 use reth_rpc_eth_api::RpcBlock;
 
-use crate::subscription::Flashblock;
+use crate::types::Flashblock;
 
 pub struct PendingBlocksBuilder {
     flashblocks: Vec<Flashblock>,

--- a/crates/flashblocks-rpc/src/tests/rpc.rs
+++ b/crates/flashblocks-rpc/src/tests/rpc.rs
@@ -2,8 +2,8 @@
 mod tests {
     use crate::rpc::{EthApiExt, EthApiOverrideServer};
     use crate::state::FlashblocksState;
-    use crate::subscription::{Flashblock, FlashblocksReceiver, Metadata};
     use crate::tests::{BLOCK_INFO_TXN, BLOCK_INFO_TXN_HASH};
+    use crate::types::{Flashblock, FlashblocksReceiver, Metadata};
     use alloy_consensus::Receipt;
     use alloy_eips::BlockNumberOrTag;
     use alloy_genesis::Genesis;
@@ -31,7 +31,7 @@ mod tests {
     use reth_provider::providers::BlockchainProvider;
     use reth_rpc_eth_api::RpcReceipt;
     use rollup_boost::{ExecutionPayloadBaseV1, ExecutionPayloadFlashblockDeltaV1};
-    use serde_json;
+
     use std::any::Any;
     use std::net::SocketAddr;
     use std::str::FromStr;
@@ -245,8 +245,7 @@ mod tests {
                 address: COUNTER_ADDRESS,
                 data: LogData::new(
                     vec![TEST_LOG_TOPIC_0, TEST_LOG_TOPIC_1, TEST_LOG_TOPIC_2],
-                    bytes!("0x0000000000000000000000000000000000000000000000000de0b6b3a7640000")
-                        .into(), // 1 ETH in wei
+                    bytes!("0x0000000000000000000000000000000000000000000000000de0b6b3a7640000"), // 1 ETH in wei
                 )
                 .unwrap(),
             },
@@ -254,8 +253,7 @@ mod tests {
                 address: TEST_ADDRESS,
                 data: LogData::new(
                     vec![TEST_LOG_TOPIC_0],
-                    bytes!("0x0000000000000000000000000000000000000000000000000000000000000001")
-                        .into(), // Value: 1
+                    bytes!("0x0000000000000000000000000000000000000000000000000000000000000001"), // Value: 1
                 )
                 .unwrap(),
             },
@@ -294,7 +292,7 @@ mod tests {
     );
 
     fn create_second_payload() -> Flashblock {
-        let payload = Flashblock {
+        Flashblock {
             payload_id: PayloadId::new([0; 8]),
             index: 1,
             base: None,
@@ -371,9 +369,7 @@ mod tests {
                     map
                 },
             },
-        };
-
-        payload
+        }
     }
 
     #[tokio::test]
@@ -392,7 +388,7 @@ mod tests {
         let pending_block = provider
             .get_block_by_number(alloy_eips::BlockNumberOrTag::Pending)
             .await?;
-        assert_eq!(pending_block.is_none(), true);
+        assert!(pending_block.is_none());
 
         let base_payload = create_first_payload();
         node.send_payload(base_payload).await?;
@@ -484,7 +480,7 @@ mod tests {
         let provider = node.provider().await?;
 
         let receipt = provider.get_transaction_receipt(DEPOSIT_TX_HASH).await?;
-        assert_eq!(receipt.is_none(), true);
+        assert!(receipt.is_none());
 
         node.send_test_payloads().await?;
 

--- a/crates/flashblocks-rpc/src/tests/state.rs
+++ b/crates/flashblocks-rpc/src/tests/state.rs
@@ -2,9 +2,9 @@
 mod tests {
     use crate::rpc::{FlashblocksAPI, PendingBlocksAPI};
     use crate::state::FlashblocksState;
-    use crate::subscription::{Flashblock, FlashblocksReceiver, Metadata};
     use crate::tests::utils::create_test_provider_factory;
     use crate::tests::{BLOCK_INFO_TXN, BLOCK_INFO_TXN_HASH};
+    use crate::types::{Flashblock, FlashblocksReceiver, Metadata};
     use alloy_consensus::crypto::secp256k1::public_key_to_address;
     use alloy_consensus::{BlockHeader, Receipt};
     use alloy_consensus::{Header, Transaction};
@@ -166,7 +166,7 @@ mod tests {
             let current_tip = self.current_canonical_block();
 
             let deposit_transaction =
-                OpTransactionSigned::decode_2718_exact(&BLOCK_INFO_TXN.iter().as_slice()).unwrap();
+                OpTransactionSigned::decode_2718_exact(BLOCK_INFO_TXN.iter().as_slice()).unwrap();
 
             let mut transactions: Vec<OpTransactionSigned> = vec![deposit_transaction];
             transactions.append(&mut user_transactions);
@@ -360,10 +360,10 @@ mod tests {
 
             let mut cumulative_gas_used = 0;
             for txn in transactions.iter() {
-                cumulative_gas_used = cumulative_gas_used + txn.gas_limit();
+                cumulative_gas_used += txn.gas_limit();
                 self.transactions.push(txn.encoded_2718().into());
                 self.receipts.insert(
-                    txn.hash().clone(),
+                    *txn.hash(),
                     OpReceipt::Eip1559(Receipt {
                         status: true.into(),
                         cumulative_gas_used,
@@ -479,7 +479,7 @@ mod tests {
             .get_state_overrides()
             .expect("should be set from txn execution");
 
-        assert!(overrides.get(&test.address(User::Alice)).is_some());
+        assert!(overrides.contains_key(&test.address(User::Alice)));
         assert_eq!(
             overrides
                 .get(&test.address(User::Bob))
@@ -498,7 +498,7 @@ mod tests {
             .get_state_overrides()
             .expect("should be set from txn execution in flashblock index 1");
 
-        assert!(overrides.get(&test.address(User::Alice)).is_some());
+        assert!(overrides.contains_key(&test.address(User::Alice)));
         assert_eq!(
             overrides
                 .get(&test.address(User::Bob))
@@ -564,7 +564,7 @@ mod tests {
             .get_state_overrides()
             .expect("should be set from txn execution");
 
-        assert!(overrides.get(&test.address(User::Alice)).is_some());
+        assert!(overrides.contains_key(&test.address(User::Alice)));
         assert_eq!(
             overrides
                 .get(&test.address(User::Bob))
@@ -632,7 +632,7 @@ mod tests {
             .get_state_overrides()
             .expect("should be set from txn execution");
 
-        assert!(overrides.get(&test.address(User::Alice)).is_some());
+        assert!(overrides.contains_key(&test.address(User::Alice)));
         assert_eq!(
             overrides
                 .get(&test.address(User::Bob))
@@ -695,7 +695,7 @@ mod tests {
             .get_state_overrides()
             .expect("should be set from txn execution");
 
-        assert!(overrides.get(&test.address(User::Alice)).is_some());
+        assert!(overrides.contains_key(&test.address(User::Alice)));
         assert_eq!(
             overrides
                 .get(&test.address(User::Bob))
@@ -733,7 +733,7 @@ mod tests {
             .get_state_overrides()
             .expect("should be set from txn execution");
 
-        assert!(overrides.get(&test.address(User::Alice)).is_some());
+        assert!(overrides.contains_key(&test.address(User::Alice)));
         assert_eq!(
             overrides
                 .get(&test.address(User::Bob))
@@ -762,7 +762,7 @@ mod tests {
             .get_state_overrides()
             .expect("should be set from txn execution");
 
-        assert!(overrides.get(&test.address(User::Alice)).is_some());
+        assert!(overrides.contains_key(&test.address(User::Alice)));
         assert_eq!(
             overrides
                 .get(&test.address(User::Bob))
@@ -983,7 +983,7 @@ mod tests {
         )
         .await;
 
-        assert_eq!(test.flashblocks.get_pending_blocks().is_none(), true);
+        assert!(test.flashblocks.get_pending_blocks().is_none());
     }
 
     #[tokio::test]

--- a/crates/flashblocks-rpc/src/types.rs
+++ b/crates/flashblocks-rpc/src/types.rs
@@ -1,0 +1,46 @@
+use alloy_primitives::map::foldhash::HashMap;
+use alloy_primitives::{Address, B256, U256};
+use alloy_rpc_types_engine::PayloadId;
+use eyre::Context;
+use reth_optimism_primitives::OpReceipt;
+use rollup_boost::{
+    ExecutionPayloadBaseV1, ExecutionPayloadFlashblockDeltaV1, FlashblocksPayloadV1,
+};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Deserialize, Serialize, Clone, Default)]
+pub struct Metadata {
+    pub receipts: HashMap<B256, OpReceipt>,
+    pub new_account_balances: HashMap<Address, U256>,
+    pub block_number: u64,
+}
+
+#[derive(Debug, Clone)]
+pub struct Flashblock {
+    pub payload_id: PayloadId,
+    pub index: u64,
+    pub base: Option<ExecutionPayloadBaseV1>,
+    pub diff: ExecutionPayloadFlashblockDeltaV1,
+    pub metadata: Metadata,
+}
+
+impl TryFrom<FlashblocksPayloadV1> for Flashblock {
+    type Error = eyre::Report;
+
+    fn try_from(payload: FlashblocksPayloadV1) -> Result<Self, Self::Error> {
+        let metadata: Metadata = serde_json::from_value(payload.metadata)
+            .context("failed to parse flashblock metadata")?;
+
+        Ok(Self {
+            payload_id: payload.payload_id,
+            index: payload.index,
+            base: payload.base,
+            diff: payload.diff,
+            metadata,
+        })
+    }
+}
+
+pub trait FlashblocksReceiver {
+    fn on_flashblock_received(&self, flashblock: Flashblock);
+}


### PR DESCRIPTION
### Changes
- create `types.rs` for core data types (`Metadata`, `Flashblock`, `FlashblocksReceiver`)
- move state logic into `state/` directory (`mod.rs`, `pending_blocks.rs`)
- simplify `subscription.rs`: merge helpers, optimize zero-copy parsing

and a few more nits

