### PR TITLE
feat: rustfmt config update

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
           egress-policy: audit
 
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - uses: dtolnay/rust-toolchain@4305c38b25d97ef35a8ad1f985ccf2d2242004f2 # stable
+      - uses: dtolnay/rust-toolchain@nightly
         with:
           components: rustfmt
       - run: cargo fmt --all -- --check

--- a/crates/flashblocks-rpc/src/pending_blocks.rs
+++ b/crates/flashblocks-rpc/src/pending_blocks.rs
@@ -1,11 +1,11 @@
 use alloy_consensus::{Header, Sealed};
 use alloy_eips::BlockNumberOrTag;
 use alloy_primitives::{
-    Address, B256, BlockNumber, TxHash, U256,
     map::foldhash::{HashMap, HashMapExt},
+    Address, BlockNumber, TxHash, B256, U256,
 };
 use alloy_provider::network::TransactionResponse;
-use alloy_rpc_types::{BlockTransactions, state::StateOverride};
+use alloy_rpc_types::{state::StateOverride, BlockTransactions};
 use alloy_rpc_types_eth::{Filter, Header as RPCHeader, Log};
 use eyre::eyre;
 use op_alloy_network::Optimism;
@@ -60,8 +60,7 @@ impl PendingBlocksBuilder {
 
     #[inline]
     pub(crate) fn with_transaction(&mut self, transaction: Transaction) -> &Self {
-        self.transactions_by_hash
-            .insert(transaction.tx_hash(), transaction.clone());
+        self.transactions_by_hash.insert(transaction.tx_hash(), transaction.clone());
         self.transactions.push(transaction);
         self
     }
@@ -83,9 +82,7 @@ impl PendingBlocksBuilder {
         let zero = U256::from(0);
         let current_count = self.transaction_count.get(&sender).unwrap_or(&zero);
 
-        _ = self
-            .transaction_count
-            .insert(sender, *current_count + U256::from(1));
+        _ = self.transaction_count.insert(sender, *current_count + U256::from(1));
         self
     }
 
@@ -213,10 +210,7 @@ impl PendingBlocks {
     }
 
     pub fn get_transaction_count(&self, address: Address) -> U256 {
-        self.transaction_count
-            .get(&address)
-            .cloned()
-            .unwrap_or(U256::from(0))
+        self.transaction_count.get(&address).cloned().unwrap_or(U256::from(0))
     }
 
     pub fn get_balance(&self, address: Address) -> Option<U256> {

--- a/crates/flashblocks-rpc/src/rpc.rs
+++ b/crates/flashblocks-rpc/src/rpc.rs
@@ -1,38 +1,40 @@
-use std::sync::Arc;
-use std::time::Duration;
+use std::{sync::Arc, time::Duration};
 
-use crate::metrics::Metrics;
-use crate::pending_blocks::PendingBlocks;
 use alloy_eips::{BlockId, BlockNumberOrTag};
-use alloy_primitives::map::foldhash::{HashSet, HashSetExt};
-use alloy_primitives::{Address, TxHash, U256};
-use alloy_rpc_types::BlockOverrides;
-use alloy_rpc_types::simulate::{SimBlock, SimulatePayload, SimulatedBlock};
-use alloy_rpc_types::state::{EvmOverrides, StateOverride, StateOverridesBuilder};
+use alloy_primitives::{
+    map::foldhash::{HashSet, HashSetExt},
+    Address, TxHash, U256,
+};
+use alloy_rpc_types::{
+    simulate::{SimBlock, SimulatePayload, SimulatedBlock},
+    state::{EvmOverrides, StateOverride, StateOverridesBuilder},
+    BlockOverrides,
+};
 use alloy_rpc_types_eth::{Filter, Log};
 use arc_swap::Guard;
 use jsonrpsee::{
-    core::{RpcResult, async_trait},
+    core::{async_trait, RpcResult},
     proc_macros::rpc,
 };
-use jsonrpsee_types::ErrorObjectOwned;
-use jsonrpsee_types::error::INVALID_PARAMS_CODE;
+use jsonrpsee_types::{error::INVALID_PARAMS_CODE, ErrorObjectOwned};
 use op_alloy_network::Optimism;
 use op_alloy_rpc_types::OpTransactionRequest;
-use reth::providers::CanonStateSubscriptions;
-use reth::rpc::eth::EthFilter;
-use reth::rpc::server_types::eth::EthApiError;
-use reth_rpc_eth_api::helpers::EthState;
-use reth_rpc_eth_api::helpers::EthTransactions;
-use reth_rpc_eth_api::helpers::{EthBlocks, EthCall};
-use reth_rpc_eth_api::{EthApiTypes, EthFilterApiServer, RpcBlock, helpers::FullEthApi};
-use reth_rpc_eth_api::{RpcReceipt, RpcTransaction};
-use tokio::sync::broadcast;
-use tokio::sync::broadcast::error::RecvError;
-use tokio::time;
-use tokio_stream::StreamExt;
-use tokio_stream::wrappers::BroadcastStream;
+use reth::{
+    providers::CanonStateSubscriptions,
+    rpc::{eth::EthFilter, server_types::eth::EthApiError},
+};
+use reth_rpc_eth_api::{
+    helpers::{EthBlocks, EthCall, EthState, EthTransactions, FullEthApi},
+    EthApiTypes, EthFilterApiServer, RpcBlock, RpcReceipt, RpcTransaction,
+};
+use tokio::{
+    sync::{broadcast, broadcast::error::RecvError},
+    time,
+};
+use tokio_stream::{wrappers::BroadcastStream, StreamExt};
 use tracing::{debug, trace, warn};
+
+use crate::{metrics::Metrics, pending_blocks::PendingBlocks};
 
 /// Max configured timeout for `eth_sendRawTransactionSync` in milliseconds.
 pub const MAX_TIMEOUT_SEND_RAW_TX_SYNC_MS: u64 = 6_000;
@@ -89,7 +91,7 @@ pub trait EthApiOverride {
 
     #[method(name = "getBalance")]
     async fn get_balance(&self, address: Address, block_number: Option<BlockId>)
-    -> RpcResult<U256>;
+        -> RpcResult<U256>;
 
     #[method(name = "getTransactionCount")]
     async fn get_transaction_count(
@@ -149,12 +151,7 @@ pub struct EthApiExt<Eth: EthApiTypes, FB> {
 
 impl<Eth: EthApiTypes, FB> EthApiExt<Eth, FB> {
     pub fn new(eth_api: Eth, eth_filter: EthFilter<Eth>, flashblocks_state: Arc<FB>) -> Self {
-        Self {
-            eth_api,
-            eth_filter,
-            flashblocks_state,
-            metrics: Metrics::default(),
-        }
+        Self { eth_api, eth_filter, flashblocks_state, metrics: Metrics::default() }
     }
 }
 
@@ -180,9 +177,7 @@ where
             let pending_blocks = self.flashblocks_state.get_pending_blocks();
             Ok(pending_blocks.get_block(full))
         } else {
-            EthBlocks::rpc_block(&self.eth_api, number.into(), full)
-                .await
-                .map_err(Into::into)
+            EthBlocks::rpc_block(&self.eth_api, number.into(), full).await.map_err(Into::into)
         }
     }
 
@@ -201,9 +196,7 @@ where
             return Ok(Some(fb_receipt));
         }
 
-        EthTransactions::transaction_receipt(&self.eth_api, tx_hash)
-            .await
-            .map_err(Into::into)
+        EthTransactions::transaction_receipt(&self.eth_api, tx_hash).await.map_err(Into::into)
     }
 
     async fn get_balance(
@@ -224,9 +217,7 @@ where
             }
         }
 
-        EthState::balance(&self.eth_api, address, block_number)
-            .await
-            .map_err(Into::into)
+        EthState::balance(&self.eth_api, address, block_number).await.map_err(Into::into)
     }
 
     async fn get_transaction_count(
@@ -254,9 +245,7 @@ where
             return Ok(canon_count + fb_count);
         }
 
-        EthState::transaction_count(&self.eth_api, address, block_number)
-            .await
-            .map_err(Into::into)
+        EthState::transaction_count(&self.eth_api, address, block_number).await.map_err(Into::into)
     }
 
     async fn transaction_by_hash(
@@ -447,21 +436,13 @@ where
                 state_overrides_builder.extend(sim_block.state_overrides.unwrap_or_default());
             let final_overrides = state_overrides_builder.build();
 
-            let block_state_call = SimBlock {
-                state_overrides: Some(final_overrides),
-                ..sim_block
-            };
+            let block_state_call = SimBlock { state_overrides: Some(final_overrides), ..sim_block };
             block_state_calls.push(block_state_call);
         }
 
-        let payload = SimulatePayload {
-            block_state_calls,
-            ..opts
-        };
+        let payload = SimulatePayload { block_state_calls, ..opts };
 
-        EthCall::simulate_v1(&self.eth_api, payload, Some(block_id))
-            .await
-            .map_err(Into::into)
+        EthCall::simulate_v1(&self.eth_api, payload, Some(block_id)).await.map_err(Into::into)
     }
 
     async fn get_logs(&self, filter: Filter) -> RpcResult<Vec<Log>> {
@@ -472,10 +453,9 @@ where
 
         // Check if this is a mixed query (toBlock is pending)
         let (from_block, to_block) = match &filter.block_option {
-            alloy_rpc_types_eth::FilterBlockOption::Range {
-                from_block,
-                to_block,
-            } => (*from_block, *to_block),
+            alloy_rpc_types_eth::FilterBlockOption::Range { from_block, to_block } => {
+                (*from_block, *to_block)
+            }
             _ => {
                 // Block hash queries or other formats - delegate to eth API
                 return self.eth_filter.logs(filter).await;

--- a/crates/flashblocks-rpc/src/subscription.rs
+++ b/crates/flashblocks-rpc/src/subscription.rs
@@ -1,7 +1,6 @@
 use std::{io::Read, sync::Arc, time::Duration};
 
-use alloy_primitives::map::foldhash::HashMap;
-use alloy_primitives::{Address, B256, U256};
+use alloy_primitives::{map::foldhash::HashMap, Address, B256, U256};
 use alloy_rpc_types_engine::PayloadId;
 use futures_util::{SinkExt as _, StreamExt};
 use reth_optimism_primitives::OpReceipt;
@@ -9,8 +8,7 @@ use rollup_boost::{
     ExecutionPayloadBaseV1, ExecutionPayloadFlashblockDeltaV1, FlashblocksPayloadV1,
 };
 use serde::{Deserialize, Serialize};
-use tokio::sync::mpsc;
-use tokio::time::interval;
+use tokio::{sync::mpsc, time::interval};
 use tokio_tungstenite::{connect_async, tungstenite::protocol::Message};
 use tracing::{error, info, trace, warn};
 use url::Url;
@@ -60,11 +58,7 @@ where
     Receiver: FlashblocksReceiver + Send + Sync + 'static,
 {
     pub fn new(flashblocks_state: Arc<Receiver>, ws_url: Url) -> Self {
-        Self {
-            ws_url,
-            flashblocks_state,
-            metrics: Metrics::default(),
-        }
+        Self { ws_url, flashblocks_state, metrics: Metrics::default() }
     }
 
     pub fn start(&mut self) {

--- a/crates/flashblocks-rpc/src/tests/mod.rs
+++ b/crates/flashblocks-rpc/src/tests/mod.rs
@@ -1,4 +1,4 @@
-use alloy_primitives::{B256, Bytes, b256, bytes};
+use alloy_primitives::{b256, bytes, Bytes, B256};
 
 mod rpc;
 mod state;

--- a/crates/flashblocks-rpc/src/tests/rpc.rs
+++ b/crates/flashblocks-rpc/src/tests/rpc.rs
@@ -1,42 +1,43 @@
 #[cfg(test)]
 mod tests {
-    use crate::rpc::{EthApiExt, EthApiOverrideServer};
-    use crate::state::FlashblocksState;
-    use crate::subscription::{Flashblock, FlashblocksReceiver, Metadata};
-    use crate::tests::{BLOCK_INFO_TXN, BLOCK_INFO_TXN_HASH};
+    use std::{any::Any, net::SocketAddr, str::FromStr, sync::Arc};
+
     use alloy_consensus::Receipt;
     use alloy_eips::BlockNumberOrTag;
     use alloy_genesis::Genesis;
-    use alloy_primitives::map::HashMap;
-    use alloy_primitives::{Address, B256, Bytes, LogData, TxHash, U256, address, b256, bytes};
-    use alloy_provider::Provider;
-    use alloy_provider::RootProvider;
+    use alloy_primitives::{
+        address, b256, bytes, map::HashMap, Address, Bytes, LogData, TxHash, B256, U256,
+    };
+    use alloy_provider::{Provider, RootProvider};
     use alloy_rpc_client::RpcClient;
     use alloy_rpc_types::simulate::{SimBlock, SimulatePayload};
     use alloy_rpc_types_engine::PayloadId;
-    use alloy_rpc_types_eth::TransactionInput;
-    use alloy_rpc_types_eth::error::EthRpcErrorCode;
+    use alloy_rpc_types_eth::{error::EthRpcErrorCode, TransactionInput};
     use op_alloy_consensus::OpDepositReceipt;
     use op_alloy_network::{Optimism, ReceiptResponse, TransactionResponse};
     use op_alloy_rpc_types::OpTransactionRequest;
-    use reth::args::{DiscoveryArgs, NetworkArgs, RpcServerArgs};
-    use reth::builder::{Node, NodeBuilder, NodeConfig, NodeHandle};
-    use reth::chainspec::Chain;
-    use reth::core::exit::NodeExitFuture;
-    use reth::tasks::TaskManager;
+    use reth::{
+        args::{DiscoveryArgs, NetworkArgs, RpcServerArgs},
+        builder::{Node, NodeBuilder, NodeConfig, NodeHandle},
+        chainspec::Chain,
+        core::exit::NodeExitFuture,
+        tasks::TaskManager,
+    };
     use reth_optimism_chainspec::OpChainSpecBuilder;
-    use reth_optimism_node::OpNode;
-    use reth_optimism_node::args::RollupArgs;
+    use reth_optimism_node::{args::RollupArgs, OpNode};
     use reth_optimism_primitives::OpReceipt;
     use reth_provider::providers::BlockchainProvider;
     use reth_rpc_eth_api::RpcReceipt;
     use rollup_boost::{ExecutionPayloadBaseV1, ExecutionPayloadFlashblockDeltaV1};
     use serde_json;
-    use std::any::Any;
-    use std::net::SocketAddr;
-    use std::str::FromStr;
-    use std::sync::Arc;
     use tokio::sync::{mpsc, oneshot};
+
+    use crate::{
+        rpc::{EthApiExt, EthApiOverrideServer},
+        state::FlashblocksState,
+        subscription::{Flashblock, FlashblocksReceiver, Metadata},
+        tests::{BLOCK_INFO_TXN, BLOCK_INFO_TXN_HASH},
+    };
 
     pub struct NodeContext {
         sender: mpsc::Sender<(Flashblock, oneshot::Sender<()>)>,
@@ -102,10 +103,7 @@ mod tests {
         );
 
         let network_config = NetworkArgs {
-            discovery: DiscoveryArgs {
-                disable_discovery: true,
-                ..DiscoveryArgs::default()
-            },
+            discovery: DiscoveryArgs { disable_discovery: true, ..DiscoveryArgs::default() },
             ..NetworkArgs::default()
         };
 
@@ -120,10 +118,7 @@ mod tests {
         // Start websocket server to simulate the builder and send payloads back to the node
         let (sender, mut receiver) = mpsc::channel::<(Flashblock, oneshot::Sender<()>)>(100);
 
-        let NodeHandle {
-            node,
-            node_exit_future,
-        } = NodeBuilder::new(node_config.clone())
+        let NodeHandle { node, node_exit_future } = NodeBuilder::new(node_config.clone())
             .testing_node(exec.clone())
             .with_types_and_provider::<OpNode, BlockchainProvider<_>>()
             .with_components(node.components_builder())
@@ -389,9 +384,8 @@ mod tests {
         assert_eq!(latest_block.number(), 0);
 
         // Querying pending block when it does not exist yet
-        let pending_block = provider
-            .get_block_by_number(alloy_eips::BlockNumberOrTag::Pending)
-            .await?;
+        let pending_block =
+            provider.get_block_by_number(alloy_eips::BlockNumberOrTag::Pending).await?;
         assert_eq!(pending_block.is_none(), true);
 
         let base_payload = create_first_payload();
@@ -443,32 +437,16 @@ mod tests {
         let node = setup_node().await?;
         let provider = node.provider().await?;
 
-        assert!(
-            provider
-                .get_transaction_by_hash(DEPOSIT_TX_HASH)
-                .await?
-                .is_none()
-        );
-        assert!(
-            provider
-                .get_transaction_by_hash(TRANSFER_ETH_HASH)
-                .await?
-                .is_none()
-        );
+        assert!(provider.get_transaction_by_hash(DEPOSIT_TX_HASH).await?.is_none());
+        assert!(provider.get_transaction_by_hash(TRANSFER_ETH_HASH).await?.is_none());
 
         node.send_test_payloads().await?;
 
-        let tx1 = provider
-            .get_transaction_by_hash(DEPOSIT_TX_HASH)
-            .await?
-            .expect("tx1 expected");
+        let tx1 = provider.get_transaction_by_hash(DEPOSIT_TX_HASH).await?.expect("tx1 expected");
         assert_eq!(tx1.tx_hash(), DEPOSIT_TX_HASH);
         assert_eq!(tx1.from(), DEPOSIT_SENDER);
 
-        let tx2 = provider
-            .get_transaction_by_hash(TRANSFER_ETH_HASH)
-            .await?
-            .expect("tx2 expected");
+        let tx2 = provider.get_transaction_by_hash(TRANSFER_ETH_HASH).await?.expect("tx2 expected");
         assert_eq!(tx2.tx_hash(), TRANSFER_ETH_HASH);
         assert_eq!(tx2.from(), TX_SENDER);
 
@@ -488,16 +466,12 @@ mod tests {
 
         node.send_test_payloads().await?;
 
-        let receipt = provider
-            .get_transaction_receipt(DEPOSIT_TX_HASH)
-            .await?
-            .expect("receipt expected");
+        let receipt =
+            provider.get_transaction_receipt(DEPOSIT_TX_HASH).await?.expect("receipt expected");
         assert_eq!(receipt.gas_used(), 21000);
 
-        let receipt = provider
-            .get_transaction_receipt(TRANSFER_ETH_HASH)
-            .await?
-            .expect("receipt expected");
+        let receipt =
+            provider.get_transaction_receipt(TRANSFER_ETH_HASH).await?.expect("receipt expected");
         assert_eq!(receipt.gas_used(), 24000); // 45000 - 21000
 
         // TODO: Add a new payload and validate that the receipts from the previous payload
@@ -513,18 +487,12 @@ mod tests {
         let provider = node.provider().await?;
 
         assert_eq!(provider.get_transaction_count(DEPOSIT_SENDER).await?, 0);
-        assert_eq!(
-            provider.get_transaction_count(TX_SENDER).pending().await?,
-            0
-        );
+        assert_eq!(provider.get_transaction_count(TX_SENDER).pending().await?, 0);
 
         node.send_test_payloads().await?;
 
         assert_eq!(provider.get_transaction_count(DEPOSIT_SENDER).await?, 0);
-        assert_eq!(
-            provider.get_transaction_count(TX_SENDER).pending().await?,
-            4
-        );
+        assert_eq!(provider.get_transaction_count(TX_SENDER).pending().await?, 4);
 
         Ok(())
     }
@@ -546,10 +514,8 @@ mod tests {
             .value(U256::from(9999999999849942300000u128))
             .input(TransactionInput::new(bytes!("0x")));
 
-        let res = provider
-            .call(send_eth_call.clone())
-            .block(BlockNumberOrTag::Pending.into())
-            .await;
+        let res =
+            provider.call(send_eth_call.clone()).block(BlockNumberOrTag::Pending.into()).await;
 
         assert!(res.is_ok());
 
@@ -557,19 +523,16 @@ mod tests {
 
         // We included a heavy spending transaction and now don't have enough funds for this request, so
         // this eth_call with fail
-        let res = provider
-            .call(send_eth_call.nonce(4))
-            .block(BlockNumberOrTag::Pending.into())
-            .await;
+        let res =
+            provider.call(send_eth_call.nonce(4)).block(BlockNumberOrTag::Pending.into()).await;
 
         assert!(res.is_err());
-        assert!(
-            res.unwrap_err()
-                .as_error_resp()
-                .unwrap()
-                .message
-                .contains("insufficient funds for gas")
-        );
+        assert!(res
+            .unwrap_err()
+            .as_error_resp()
+            .unwrap()
+            .message
+            .contains("insufficient funds for gas"));
 
         // read count1 from counter contract
         let eth_call_count1 = OpTransactionRequest::default()
@@ -640,13 +603,12 @@ mod tests {
             .await;
 
         assert!(res.is_err());
-        assert!(
-            res.unwrap_err()
-                .as_error_resp()
-                .unwrap()
-                .message
-                .contains("insufficient funds for gas")
-        );
+        assert!(res
+            .unwrap_err()
+            .as_error_resp()
+            .unwrap()
+            .message
+            .contains("insufficient funds for gas"));
 
         Ok(())
     }
@@ -695,10 +657,8 @@ mod tests {
             validation: true,
             return_full_transactions: true,
         };
-        let simulate_res = provider
-            .simulate(&simulate_call)
-            .block_id(BlockNumberOrTag::Pending.into())
-            .await;
+        let simulate_res =
+            provider.simulate(&simulate_call).block_id(BlockNumberOrTag::Pending.into()).await;
         assert!(simulate_res.is_ok());
         let block = simulate_res.unwrap();
         assert_eq!(block.len(), 1);
@@ -724,13 +684,11 @@ mod tests {
         node.send_payload(create_first_payload()).await?;
 
         // run the Tx sync and, in parallel, deliver the payload that contains the Tx
-        let (receipt_result, payload_result) = tokio::join!(
-            node.send_raw_transaction_sync(TRANSFER_ETH_TX, None),
-            async {
+        let (receipt_result, payload_result) =
+            tokio::join!(node.send_raw_transaction_sync(TRANSFER_ETH_TX, None), async {
                 tokio::time::sleep(std::time::Duration::from_millis(100)).await;
                 node.send_payload(create_second_payload()).await
-            }
-        );
+            });
 
         payload_result?;
         let receipt = receipt_result?;
@@ -745,18 +703,14 @@ mod tests {
         let node = setup_node().await.unwrap();
 
         // fail request immediately by passing a timeout of 0 ms
-        let receipt_result = node
-            .send_raw_transaction_sync(TRANSFER_ETH_TX, Some(0))
-            .await;
+        let receipt_result = node.send_raw_transaction_sync(TRANSFER_ETH_TX, Some(0)).await;
 
         let error_code = EthRpcErrorCode::TransactionConfirmationTimeout.code();
-        assert!(
-            receipt_result
-                .err()
-                .unwrap()
-                .to_string()
-                .contains(format!("{}", error_code).as_str())
-        );
+        assert!(receipt_result
+            .err()
+            .unwrap()
+            .to_string()
+            .contains(format!("{}", error_code).as_str()));
     }
 
     #[tokio::test]
@@ -898,10 +852,7 @@ mod tests {
 
         // Should now include pending logs (2 logs from our test setup)
         assert_eq!(logs.len(), 2);
-        assert!(
-            logs.iter()
-                .all(|log| log.transaction_hash == Some(INCREMENT_HASH))
-        );
+        assert!(logs.iter().all(|log| log.transaction_hash == Some(INCREMENT_HASH)));
 
         // Test fromBlock: latest, toBlock: pending
         let logs = provider
@@ -914,10 +865,7 @@ mod tests {
 
         // Should include pending logs (historical part is empty in our test setup)
         assert_eq!(logs.len(), 2);
-        assert!(
-            logs.iter()
-                .all(|log| log.transaction_hash == Some(INCREMENT_HASH))
-        );
+        assert!(logs.iter().all(|log| log.transaction_hash == Some(INCREMENT_HASH)));
 
         // Test fromBlock: earliest, toBlock: pending
         let logs = provider
@@ -930,10 +878,7 @@ mod tests {
 
         // Should include pending logs (historical part is empty in our test setup)
         assert_eq!(logs.len(), 2);
-        assert!(
-            logs.iter()
-                .all(|log| log.transaction_hash == Some(INCREMENT_HASH))
-        );
+        assert!(logs.iter().all(|log| log.transaction_hash == Some(INCREMENT_HASH)));
 
         Ok(())
     }

--- a/crates/flashblocks-rpc/src/tests/utils.rs
+++ b/crates/flashblocks-rpc/src/tests/utils.rs
@@ -2,12 +2,12 @@ use std::sync::Arc;
 
 use reth::api::{NodeTypes, NodeTypesWithDBAdapter};
 use reth_db::{
-    ClientVersion, DatabaseEnv, init_db,
-    mdbx::{DatabaseArguments, KILOBYTE, MEGABYTE, MaxReadTransactionDuration},
-    test_utils::{ERROR_DB_CREATION, TempDatabase, create_test_static_files_dir, tempdir_path},
+    init_db,
+    mdbx::{DatabaseArguments, MaxReadTransactionDuration, KILOBYTE, MEGABYTE},
+    test_utils::{create_test_static_files_dir, tempdir_path, TempDatabase, ERROR_DB_CREATION},
+    ClientVersion, DatabaseEnv,
 };
-
-use reth_provider::{ProviderFactory, providers::StaticFileProvider};
+use reth_provider::{providers::StaticFileProvider, ProviderFactory};
 
 pub fn create_test_provider_factory<N: NodeTypes>(
     chain_spec: Arc<N::ChainSpec>,

--- a/crates/metering/src/rpc.rs
+++ b/crates/metering/src/rpc.rs
@@ -2,7 +2,7 @@ use alloy_consensus::Header;
 use alloy_eips::BlockNumberOrTag;
 use alloy_primitives::U256;
 use jsonrpsee::{
-    core::{RpcResult, async_trait},
+    core::{async_trait, RpcResult},
     proc_macros::rpc,
 };
 use reth::providers::BlockReaderIdExt;
@@ -85,17 +85,14 @@ where
         })?;
 
         // Get state provider for the block
-        let state_provider = self
-            .provider
-            .state_by_block_hash(header.hash())
-            .map_err(|e| {
-                error!(error = %e, "Failed to get state provider");
-                jsonrpsee::types::ErrorObjectOwned::owned(
-                    jsonrpsee::types::ErrorCode::InternalError.code(),
-                    format!("Failed to get state provider: {}", e),
-                    None::<()>,
-                )
-            })?;
+        let state_provider = self.provider.state_by_block_hash(header.hash()).map_err(|e| {
+            error!(error = %e, "Failed to get state provider");
+            jsonrpsee::types::ErrorObjectOwned::owned(
+                jsonrpsee::types::ErrorCode::InternalError.code(),
+                format!("Failed to get state provider: {}", e),
+                None::<()>,
+            )
+        })?;
 
         // Meter bundle using utility function
         let (results, total_gas_used, total_gas_fees, bundle_hash, total_execution_time) =

--- a/crates/metering/src/tests/rpc.rs
+++ b/crates/metering/src/tests/rpc.rs
@@ -1,28 +1,28 @@
 #[cfg(test)]
 mod tests {
-    use crate::rpc::{MeteringApiImpl, MeteringApiServer};
+    use std::{any::Any, net::SocketAddr, sync::Arc};
+
     use alloy_eips::Encodable2718;
     use alloy_genesis::Genesis;
-    use alloy_primitives::bytes;
-    use alloy_primitives::{Bytes, U256, address, b256};
+    use alloy_primitives::{address, b256, bytes, Bytes, U256};
     use alloy_rpc_client::RpcClient;
     use op_alloy_consensus::OpTxEnvelope;
-    use reth::args::{DiscoveryArgs, NetworkArgs, RpcServerArgs};
-    use reth::builder::{Node, NodeBuilder, NodeConfig, NodeHandle};
-    use reth::chainspec::Chain;
-    use reth::core::exit::NodeExitFuture;
-    use reth::tasks::TaskManager;
+    use reth::{
+        args::{DiscoveryArgs, NetworkArgs, RpcServerArgs},
+        builder::{Node, NodeBuilder, NodeConfig, NodeHandle},
+        chainspec::Chain,
+        core::exit::NodeExitFuture,
+        tasks::TaskManager,
+    };
     use reth_optimism_chainspec::OpChainSpecBuilder;
-    use reth_optimism_node::OpNode;
-    use reth_optimism_node::args::RollupArgs;
+    use reth_optimism_node::{args::RollupArgs, OpNode};
     use reth_optimism_primitives::OpTransactionSigned;
     use reth_provider::providers::BlockchainProvider;
     use reth_transaction_pool::test_utils::TransactionBuilder;
     use serde_json;
-    use std::any::Any;
-    use std::net::SocketAddr;
-    use std::sync::Arc;
     use tips_core::types::Bundle;
+
+    use crate::rpc::{MeteringApiImpl, MeteringApiServer};
 
     pub struct NodeContext {
         http_api_addr: SocketAddr,
@@ -68,10 +68,7 @@ mod tests {
         );
 
         let network_config = NetworkArgs {
-            discovery: DiscoveryArgs {
-                disable_discovery: true,
-                ..DiscoveryArgs::default()
-            },
+            discovery: DiscoveryArgs { disable_discovery: true, ..DiscoveryArgs::default() },
             ..NetworkArgs::default()
         };
 
@@ -82,10 +79,7 @@ mod tests {
 
         let node = OpNode::new(RollupArgs::default());
 
-        let NodeHandle {
-            node,
-            node_exit_future,
-        } = NodeBuilder::new(node_config.clone())
+        let NodeHandle { node, node_exit_future } = NodeBuilder::new(node_config.clone())
             .testing_node(exec.clone())
             .with_types_and_provider::<OpNode, BlockchainProvider<_>>()
             .with_components(node.components_builder())
@@ -172,10 +166,7 @@ mod tests {
 
         let result = &response.results[0];
         assert_eq!(result.from_address, sender_address);
-        assert_eq!(
-            result.to_address,
-            Some(address!("0x1111111111111111111111111111111111111111"))
-        );
+        assert_eq!(result.to_address, Some(address!("0x1111111111111111111111111111111111111111")));
         assert_eq!(result.gas_used, 21_000);
         assert_eq!(result.gas_price, "1000000000");
         assert!(result.execution_time_us > 0);

--- a/crates/metering/src/tests/utils.rs
+++ b/crates/metering/src/tests/utils.rs
@@ -2,11 +2,12 @@ use std::sync::Arc;
 
 use reth::api::{NodeTypes, NodeTypesWithDBAdapter};
 use reth_db::{
-    ClientVersion, DatabaseEnv, init_db,
-    mdbx::{DatabaseArguments, KILOBYTE, MEGABYTE, MaxReadTransactionDuration},
-    test_utils::{ERROR_DB_CREATION, TempDatabase, create_test_static_files_dir, tempdir_path},
+    init_db,
+    mdbx::{DatabaseArguments, MaxReadTransactionDuration, KILOBYTE, MEGABYTE},
+    test_utils::{create_test_static_files_dir, tempdir_path, TempDatabase, ERROR_DB_CREATION},
+    ClientVersion, DatabaseEnv,
 };
-use reth_provider::{ProviderFactory, providers::StaticFileProvider};
+use reth_provider::{providers::StaticFileProvider, ProviderFactory};
 
 pub fn create_provider_factory<N: NodeTypes>(
     chain_spec: Arc<N::ChainSpec>,

--- a/crates/transaction-tracing/src/tracing.rs
+++ b/crates/transaction-tracing/src/tracing.rs
@@ -1,15 +1,20 @@
+use std::{
+    num::NonZeroUsize,
+    time::{Duration, Instant},
+};
+
 use alloy_primitives::TxHash;
 use chrono::Local;
 use eyre::Result;
 use futures::StreamExt;
 use lru::LruCache;
-use reth::api::{BlockBody, FullNodeComponents};
-use reth::core::primitives::{AlloyBlockHeader, transaction::TxHashRef};
-use reth::transaction_pool::{FullTransactionEvent, TransactionPool};
+use reth::{
+    api::{BlockBody, FullNodeComponents},
+    core::primitives::{transaction::TxHashRef, AlloyBlockHeader},
+    transaction_pool::{FullTransactionEvent, TransactionPool},
+};
 use reth_exex::{ExExContext, ExExEvent, ExExNotification};
 use reth_tracing::tracing::{debug, info};
-use std::num::NonZeroUsize;
-use std::time::{Duration, Instant};
 
 use crate::types::{EventLog, Pool, TxEvent};
 
@@ -151,11 +156,7 @@ impl Tracker {
             return false;
         }
 
-        self.log(
-            tx_hash,
-            event_log,
-            "Transaction removed from cache due to limit",
-        );
+        self.log(tx_hash, event_log, "Transaction removed from cache due to limit");
         record_histogram(event_log.mempool_time.elapsed(), TxEvent::Overflowed);
         true
     }

--- a/crates/transaction-tracing/src/types.rs
+++ b/crates/transaction-tracing/src/types.rs
@@ -1,6 +1,9 @@
+use std::{
+    fmt::{self, Display},
+    time::Instant,
+};
+
 use chrono::{DateTime, Local};
-use std::fmt::{self, Display};
-use std::time::Instant;
 
 /// Types of transaction events to track
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -47,11 +50,7 @@ pub struct EventLog {
 
 impl EventLog {
     pub fn new(t: DateTime<Local>, event: TxEvent) -> Self {
-        Self {
-            mempool_time: Instant::now(),
-            events: vec![(t, event)],
-            limit: 10,
-        }
+        Self { mempool_time: Instant::now(), events: vec![(t, event)], limit: 10 }
     }
 
     pub fn push(&mut self, t: DateTime<Local>, event: TxEvent) {

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,6 @@
+style_edition = "2021"
+imports_granularity = "Crate"
+group_imports = "StdExternalCrate"
+use_small_heuristics = "Max"
+trailing_comma = "Vertical"
+use_field_init_shorthand = true


### PR DESCRIPTION
Closes #181

A few rustfmt features (`imports_granularity`, `group_imports`, `trailing_comma`) require nightly since they're still unstable.

I updated the fmt job in CI to use nightly to support these features - hope that's okay. This matches what reth does in their CI. All other jobs (build, test, clippy, docker) remain on stable.
