### PR TITLE
fix: eth_getBlockByNumber should return Latest if Pending is None

### DIFF
--- a/crates/flashblocks-rpc/src/rpc.rs
+++ b/crates/flashblocks-rpc/src/rpc.rs
@@ -178,7 +178,14 @@ where
         if number.is_pending() {
             self.metrics.get_block_by_number.increment(1);
             let pending_blocks = self.flashblocks_state.get_pending_blocks();
-            Ok(pending_blocks.get_block(full))
+            if pending_blocks.as_ref().is_some() {
+                Ok(pending_blocks.get_block(full))
+            } else {
+                // No pending state available — treat `pending` as `latest`
+                return EthBlocks::rpc_block(&self.eth_api, BlockNumberOrTag::Latest.into(), full)
+                    .await
+                    .map_err(Into::into);
+            }
         } else {
             EthBlocks::rpc_block(&self.eth_api, number.into(), full)
                 .await

--- a/crates/flashblocks-rpc/src/rpc.rs
+++ b/crates/flashblocks-rpc/src/rpc.rs
@@ -179,13 +179,12 @@ where
             self.metrics.get_block_by_number.increment(1);
             let pending_blocks = self.flashblocks_state.get_pending_blocks();
             if pending_blocks.as_ref().is_some() {
-                Ok(pending_blocks.get_block(full))
-            } else {
-                // No pending state available — treat `pending` as `latest`
-                return EthBlocks::rpc_block(&self.eth_api, BlockNumberOrTag::Latest.into(), full)
-                    .await
-                    .map_err(Into::into);
+                return Ok(pending_blocks.get_block(full));
             }
+            // No pending state available — treat `pending` as `latest`
+            EthBlocks::rpc_block(&self.eth_api, BlockNumberOrTag::Latest.into(), full)
+                .await
+                .map_err(Into::into)
         } else {
             EthBlocks::rpc_block(&self.eth_api, number.into(), full)
                 .await

--- a/crates/flashblocks-rpc/src/tests/rpc.rs
+++ b/crates/flashblocks-rpc/src/tests/rpc.rs
@@ -391,8 +391,11 @@ mod tests {
         // Querying pending block when it does not exist yet
         let pending_block = provider
             .get_block_by_number(alloy_eips::BlockNumberOrTag::Pending)
-            .await?;
-        assert_eq!(pending_block.is_none(), true);
+            .await?
+            .expect("latest block expected");
+
+        assert_eq!(pending_block.number(), latest_block.number());
+        assert_eq!(pending_block.hash(), latest_block.hash());
 
         let base_payload = create_first_payload();
         node.send_payload(base_payload).await?;

--- a/crates/flashblocks-rpc/src/tests/rpc.rs
+++ b/crates/flashblocks-rpc/src/tests/rpc.rs
@@ -392,7 +392,6 @@ mod tests {
         assert_eq!(pending_block.number(), latest_block.number());
         assert_eq!(pending_block.hash(), latest_block.hash());
 
-
         let base_payload = create_first_payload();
         node.send_payload(base_payload).await?;
 


### PR DESCRIPTION
Closes #178 

get_block_by_number() function is updated to match the Geth's behaviour of returning Latest Block. 