### PR TITLE
chore: update rollup-boost types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10444,7 +10444,7 @@ dependencies = [
 [[package]]
 name = "rollup-boost"
 version = "0.1.0"
-source = "git+http://github.com/flashbots/rollup-boost?rev=v0.7.10#501ae74cf6d93ae4ff0d7454ca7b36827fd1e135"
+source = "git+http://github.com/flashbots/rollup-boost?rev=v0.7.11#196237bab2a02298de994b439e0455abb1ac512f"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-engine",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -98,7 +98,7 @@ op-alloy-network = { version = "0.22.0", default-features = false }
 op-alloy-consensus = { version = "0.22.0", default-features = false }
 
 # rollup-boost
-rollup-boost = { git = "http://github.com/flashbots/rollup-boost", rev = "v0.7.10" }
+rollup-boost = { git = "http://github.com/flashbots/rollup-boost", rev = "v0.7.11" }
 rustls = "0.23.23"
 
 # tokio

--- a/crates/flashblocks-rpc/src/tests/rpc.rs
+++ b/crates/flashblocks-rpc/src/tests/rpc.rs
@@ -308,6 +308,7 @@ mod tests {
                 withdrawals: Vec::new(),
                 logs_bloom: Default::default(),
                 withdrawals_root: Default::default(),
+                blob_gas_used: Default::default(),
             },
             metadata: Metadata {
                 block_number: 1,

--- a/crates/flashblocks-rpc/src/tests/state.rs
+++ b/crates/flashblocks-rpc/src/tests/state.rs
@@ -390,6 +390,7 @@ mod tests {
                     logs_bloom: Default::default(),
                     withdrawals_root: Default::default(),
                     transactions: self.transactions.clone(),
+                    blob_gas_used: Default::default(),
                 },
                 metadata: Metadata {
                     block_number: canonical_block_num,


### PR DESCRIPTION
### Description
Update the flashblock type to include blob_gas_used, this isn't used when processing Flashblocks, so is fine to be ignored throughout the rest of the client.