### PR TITLE
feat: add block metering RPC endpoints

### DIFF
--- a/crates/rpc/Cargo.toml
+++ b/crates/rpc/Cargo.toml
@@ -24,6 +24,7 @@ reth-primitives-traits.workspace = true
 reth-evm.workspace = true
 reth-optimism-evm.workspace = true
 reth-optimism-chainspec.workspace = true
+reth-optimism-primitives.workspace = true
 reth-transaction-pool = { workspace = true, features = ["test-utils"] }
 reth-rpc.workspace = true
 reth-rpc-eth-api.workspace = true

--- a/crates/rpc/src/base/block.rs
+++ b/crates/rpc/src/base/block.rs
@@ -1,0 +1,107 @@
+use std::{sync::Arc, time::Instant};
+
+use alloy_consensus::{BlockHeader, transaction::SignerRecoverable};
+use alloy_primitives::B256;
+use eyre::{Result as EyreResult, eyre};
+use reth::revm::db::State;
+use reth_evm::{ConfigureEvm, execute::BlockBuilder};
+use reth_optimism_chainspec::OpChainSpec;
+use reth_optimism_evm::{OpEvmConfig, OpNextBlockEnvAttributes};
+use reth_optimism_primitives::OpBlock;
+use reth_primitives_traits::{Block as BlockT, SealedHeader};
+use reth_provider::{HashedPostStateProvider, StateRootProvider};
+
+use super::types::{MeterBlockResponse, MeterBlockTransactions};
+
+/// Re-executes a block and meters execution time, state root calculation time, and total time.
+///
+/// Takes a state provider at the parent block, the chain spec, and the block to meter.
+///
+/// Returns `MeterBlockResponse` containing:
+/// - Block hash
+/// - EVM execution time for all transactions
+/// - State root calculation time
+/// - Total time
+/// - Per-transaction timing information
+pub fn meter_block<SP>(
+    state_provider: SP,
+    chain_spec: Arc<OpChainSpec>,
+    block: &OpBlock,
+    parent_header: &SealedHeader,
+) -> EyreResult<MeterBlockResponse>
+where
+    SP: reth_provider::StateProvider + StateRootProvider + HashedPostStateProvider,
+{
+    let block_hash = block.header().hash_slow();
+    let block_number = block.header().number();
+    let transactions: Vec<_> = block.body().transactions().cloned().collect();
+    let tx_count = transactions.len();
+
+    // Create state database from parent state
+    let state_db = reth::revm::database::StateProviderDatabase::new(&state_provider);
+    let mut db = State::builder().with_database(state_db).with_bundle_update().build();
+
+    // Set up block attributes from the actual block header
+    let attributes = OpNextBlockEnvAttributes {
+        timestamp: block.header().timestamp(),
+        suggested_fee_recipient: block.header().beneficiary(),
+        prev_randao: block.header().mix_hash().unwrap_or(B256::random()),
+        gas_limit: block.header().gas_limit(),
+        parent_beacon_block_root: block.header().parent_beacon_block_root(),
+        extra_data: block.header().extra_data().clone(),
+    };
+
+    // Execute transactions and measure time
+    let mut transaction_times = Vec::with_capacity(tx_count);
+
+    let evm_start = Instant::now();
+    {
+        let evm_config = OpEvmConfig::optimism(chain_spec);
+        let mut builder = evm_config.builder_for_next_block(&mut db, parent_header, attributes)?;
+
+        builder.apply_pre_execution_changes()?;
+
+        for tx in &transactions {
+            let tx_start = Instant::now();
+            let tx_hash = tx.tx_hash();
+
+            // Recover the signer to create a Recovered transaction for execution
+            let signer = tx.recover_signer()
+                .map_err(|e| eyre!("Failed to recover signer for tx {}: {}", tx_hash, e))?;
+            let recovered_tx = alloy_consensus::transaction::Recovered::new_unchecked(tx.clone(), signer);
+
+            let gas_used = builder
+                .execute_transaction(recovered_tx)
+                .map_err(|e| eyre!("Transaction {} execution failed: {}", tx_hash, e))?;
+
+            let execution_time = tx_start.elapsed().as_micros();
+
+            transaction_times.push(MeterBlockTransactions {
+                tx_hash,
+                gas_used,
+                execution_time_us: execution_time,
+            });
+        }
+    }
+    let execution_time = evm_start.elapsed().as_micros();
+
+    // Calculate state root and measure time
+    let state_root_start = Instant::now();
+    let bundle_state = db.bundle_state.clone();
+    let hashed_state = state_provider.hashed_post_state(&bundle_state);
+    let _state_root = state_provider
+        .state_root(hashed_state)
+        .map_err(|e| eyre!("Failed to calculate state root: {}", e))?;
+    let state_root_time = state_root_start.elapsed().as_micros();
+
+    let total_time = execution_time + state_root_time;
+
+    Ok(MeterBlockResponse {
+        block_hash,
+        block_number,
+        execution_time_us: execution_time,
+        state_root_time_us: state_root_time,
+        total_time_us: total_time,
+        transactions: transaction_times,
+    })
+}

--- a/crates/rpc/src/base/block.rs
+++ b/crates/rpc/src/base/block.rs
@@ -19,10 +19,19 @@ use super::types::{MeterBlockResponse, MeterBlockTransactions};
 ///
 /// Returns `MeterBlockResponse` containing:
 /// - Block hash
+/// - Signer recovery time (can be parallelized)
 /// - EVM execution time for all transactions
 /// - State root calculation time
 /// - Total time
 /// - Per-transaction timing information
+///
+/// # Note
+///
+/// If the parent block's state has been pruned, this function will return an error.
+///
+/// State root calculation timing is most accurate for recent blocks where state tries are
+/// cached. For older blocks, trie nodes may not be cached, which can significantly inflate
+/// the `state_root_time_us` value.
 pub fn meter_block<SP>(
     state_provider: SP,
     chain_spec: Arc<OpChainSpec>,

--- a/crates/rpc/src/base/block.rs
+++ b/crates/rpc/src/base/block.rs
@@ -66,9 +66,11 @@ where
             let tx_hash = tx.tx_hash();
 
             // Recover the signer to create a Recovered transaction for execution
-            let signer = tx.recover_signer()
+            let signer = tx
+                .recover_signer()
                 .map_err(|e| eyre!("Failed to recover signer for tx {}: {}", tx_hash, e))?;
-            let recovered_tx = alloy_consensus::transaction::Recovered::new_unchecked(tx.clone(), signer);
+            let recovered_tx =
+                alloy_consensus::transaction::Recovered::new_unchecked(tx.clone(), signer);
 
             let gas_used = builder
                 .execute_transaction(recovered_tx)

--- a/crates/rpc/src/base/meter_rpc.rs
+++ b/crates/rpc/src/base/meter_rpc.rs
@@ -9,10 +9,9 @@ use reth_provider::{BlockReader, ChainSpecProvider, HeaderProvider, StateProvide
 use tips_core::types::{Bundle, MeterBundleResponse, ParsedBundle};
 use tracing::{error, info};
 
-use super::block::meter_block;
-use super::meter::meter_bundle;
-use super::traits::MeteringApiServer;
-use super::types::MeterBlockResponse;
+use super::{
+    block::meter_block, meter::meter_bundle, traits::MeteringApiServer, types::MeterBlockResponse,
+};
 
 /// Implementation of the metering RPC API
 #[derive(Debug)]
@@ -169,7 +168,10 @@ where
         Ok(response)
     }
 
-    async fn meter_block_by_number(&self, number: BlockNumberOrTag) -> RpcResult<MeterBlockResponse> {
+    async fn meter_block_by_number(
+        &self,
+        number: BlockNumberOrTag,
+    ) -> RpcResult<MeterBlockResponse> {
         info!(block_number = ?number, "Starting block metering by number");
 
         let block = self
@@ -221,15 +223,13 @@ where
 {
     /// Internal helper to meter a block's execution
     fn meter_block_internal(&self, block: &OpBlock) -> RpcResult<MeterBlockResponse> {
-        meter_block(self.provider.clone(), self.provider.chain_spec().clone(), block).map_err(
-            |e| {
-                error!(error = %e, "Block metering failed");
-                jsonrpsee::types::ErrorObjectOwned::owned(
-                    jsonrpsee::types::ErrorCode::InternalError.code(),
-                    format!("Block metering failed: {}", e),
-                    None::<()>,
-                )
-            },
-        )
+        meter_block(self.provider.clone(), self.provider.chain_spec(), block).map_err(|e| {
+            error!(error = %e, "Block metering failed");
+            jsonrpsee::types::ErrorObjectOwned::owned(
+                jsonrpsee::types::ErrorCode::InternalError.code(),
+                format!("Block metering failed: {}", e),
+                None::<()>,
+            )
+        })
     }
 }

--- a/crates/rpc/src/base/meter_rpc.rs
+++ b/crates/rpc/src/base/meter_rpc.rs
@@ -158,6 +158,7 @@ where
 
         info!(
             block_hash = %hash,
+            signer_recovery_time_us = response.signer_recovery_time_us,
             execution_time_us = response.execution_time_us,
             state_root_time_us = response.state_root_time_us,
             total_time_us = response.total_time_us,
@@ -194,6 +195,7 @@ where
         info!(
             block_number = ?number,
             block_hash = %response.block_hash,
+            signer_recovery_time_us = response.signer_recovery_time_us,
             execution_time_us = response.execution_time_us,
             state_root_time_us = response.state_root_time_us,
             total_time_us = response.total_time_us,

--- a/crates/rpc/src/base/mod.rs
+++ b/crates/rpc/src/base/mod.rs
@@ -1,3 +1,4 @@
+pub(crate) mod block;
 pub(crate) mod meter;
 pub(crate) mod meter_rpc;
 pub(crate) mod pubsub;

--- a/crates/rpc/src/base/traits.rs
+++ b/crates/rpc/src/base/traits.rs
@@ -1,9 +1,10 @@
 //! Traits for the RPC module.
 
-use alloy_primitives::TxHash;
+use alloy_eips::BlockNumberOrTag;
+use alloy_primitives::{B256, TxHash};
 use jsonrpsee::{core::RpcResult, proc_macros::rpc};
 
-use crate::{Bundle, MeterBundleResponse, TransactionStatusResponse};
+use crate::{Bundle, MeterBlockResponse, MeterBundleResponse, TransactionStatusResponse};
 
 /// RPC API for transaction metering
 #[rpc(server, namespace = "base")]
@@ -11,6 +12,32 @@ pub trait MeteringApi {
     /// Simulates and meters a bundle of transactions
     #[method(name = "meterBundle")]
     async fn meter_bundle(&self, bundle: Bundle) -> RpcResult<MeterBundleResponse>;
+
+    /// Handler for: `base_meterBlockByHash`
+    ///
+    /// Re-executes a block and returns timing metrics for EVM execution and state root calculation.
+    ///
+    /// This method fetches the block by hash, re-executes all transactions against the parent
+    /// block's state, and measures:
+    /// - `executionTimeUs`: Time to execute all transactions in the EVM
+    /// - `stateRootTimeUs`: Time to compute the state root after execution
+    /// - `totalTimeUs`: Sum of execution and state root calculation time
+    /// - `meteredTransactions`: Per-transaction execution times and gas usage
+    #[method(name = "meterBlockByHash")]
+    async fn meter_block_by_hash(&self, hash: B256) -> RpcResult<MeterBlockResponse>;
+
+    /// Handler for: `base_meterBlockByNumber`
+    ///
+    /// Re-executes a block and returns timing metrics for EVM execution and state root calculation.
+    ///
+    /// This method fetches the block by number, re-executes all transactions against the parent
+    /// block's state, and measures:
+    /// - `executionTimeUs`: Time to execute all transactions in the EVM
+    /// - `stateRootTimeUs`: Time to compute the state root after execution
+    /// - `totalTimeUs`: Sum of execution and state root calculation time
+    /// - `meteredTransactions`: Per-transaction execution times and gas usage
+    #[method(name = "meterBlockByNumber")]
+    async fn meter_block_by_number(&self, number: BlockNumberOrTag) -> RpcResult<MeterBlockResponse>;
 }
 
 /// RPC API for transaction status

--- a/crates/rpc/src/base/traits.rs
+++ b/crates/rpc/src/base/traits.rs
@@ -37,7 +37,10 @@ pub trait MeteringApi {
     /// - `totalTimeUs`: Sum of execution and state root calculation time
     /// - `meteredTransactions`: Per-transaction execution times and gas usage
     #[method(name = "meterBlockByNumber")]
-    async fn meter_block_by_number(&self, number: BlockNumberOrTag) -> RpcResult<MeterBlockResponse>;
+    async fn meter_block_by_number(
+        &self,
+        number: BlockNumberOrTag,
+    ) -> RpcResult<MeterBlockResponse>;
 }
 
 /// RPC API for transaction status

--- a/crates/rpc/src/base/types.rs
+++ b/crates/rpc/src/base/types.rs
@@ -1,5 +1,6 @@
 //! Types for the transaction status rpc
 
+use alloy_primitives::B256;
 use alloy_rpc_types_eth::pubsub::SubscriptionKind;
 use serde::{Deserialize, Serialize};
 
@@ -94,4 +95,37 @@ impl From<BaseSubscriptionKind> for ExtendedSubscriptionKind {
     fn from(kind: BaseSubscriptionKind) -> Self {
         Self::Base(kind)
     }
+}
+
+// Block metering types
+
+/// Response for block metering RPC calls.
+/// Contains the block hash plus timing information for EVM execution and state root calculation.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct MeterBlockResponse {
+    /// The block hash that was metered
+    pub block_hash: B256,
+    /// The block number that was metered
+    pub block_number: u64,
+    /// Duration of EVM execution in microseconds
+    pub execution_time_us: u128,
+    /// Duration of state root calculation in microseconds
+    pub state_root_time_us: u128,
+    /// Total duration (EVM execution + state root calculation) in microseconds
+    pub total_time_us: u128,
+    /// Per-transaction metering data
+    pub transactions: Vec<MeterBlockTransactions>,
+}
+
+/// Metering data for a single transaction
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct MeterBlockTransactions {
+    /// Transaction hash
+    pub tx_hash: B256,
+    /// Gas used by this transaction
+    pub gas_used: u64,
+    /// Execution time in microseconds
+    pub execution_time_us: u128,
 }

--- a/crates/rpc/src/base/types.rs
+++ b/crates/rpc/src/base/types.rs
@@ -108,11 +108,13 @@ pub struct MeterBlockResponse {
     pub block_hash: B256,
     /// The block number that was metered
     pub block_number: u64,
+    /// Duration of signer recovery in microseconds (can be parallelized)
+    pub signer_recovery_time_us: u128,
     /// Duration of EVM execution in microseconds
     pub execution_time_us: u128,
     /// Duration of state root calculation in microseconds
     pub state_root_time_us: u128,
-    /// Total duration (EVM execution + state root calculation) in microseconds
+    /// Total duration (signer recovery + EVM execution + state root calculation) in microseconds
     pub total_time_us: u128,
     /// Per-transaction metering data
     pub transactions: Vec<MeterBlockTransactions>,

--- a/crates/rpc/src/base/types.rs
+++ b/crates/rpc/src/base/types.rs
@@ -112,7 +112,10 @@ pub struct MeterBlockResponse {
     pub signer_recovery_time_us: u128,
     /// Duration of EVM execution in microseconds
     pub execution_time_us: u128,
-    /// Duration of state root calculation in microseconds
+    /// Duration of state root calculation in microseconds.
+    ///
+    /// Note: This timing is most accurate for recent blocks where state tries are cached.
+    /// For older blocks, trie nodes may not be cached, which can significantly inflate this value.
     pub state_root_time_us: u128,
     /// Total duration (signer recovery + EVM execution + state root calculation) in microseconds
     pub total_time_us: u128,

--- a/crates/rpc/src/lib.rs
+++ b/crates/rpc/src/lib.rs
@@ -8,12 +8,16 @@ pub use tips_core::types::{Bundle, MeterBundleResponse, TransactionResult};
 
 mod base;
 pub use base::{
+    block::meter_block,
     meter::meter_bundle,
     meter_rpc::MeteringApiImpl,
     pubsub::{EthPubSub, EthPubSubApiServer},
     traits::{MeteringApiServer, TransactionStatusApiServer},
     transaction_rpc::TransactionStatusApiImpl,
-    types::{BaseSubscriptionKind, ExtendedSubscriptionKind, Status, TransactionStatusResponse},
+    types::{
+        BaseSubscriptionKind, ExtendedSubscriptionKind, MeterBlockResponse, MeterBlockTransactions,
+        Status, TransactionStatusResponse,
+    },
 };
 
 mod eth;

--- a/crates/rpc/tests/meter_block.rs
+++ b/crates/rpc/tests/meter_block.rs
@@ -357,11 +357,8 @@ fn meter_block_invalid_transaction_signature() -> eyre::Result<()> {
     };
 
     // Create a signature with invalid values (all zeros is invalid for secp256k1)
-    let invalid_signature = Signature::new(
-        alloy_primitives::U256::ZERO,
-        alloy_primitives::U256::ZERO,
-        false,
-    );
+    let invalid_signature =
+        Signature::new(alloy_primitives::U256::ZERO, alloy_primitives::U256::ZERO, false);
 
     let signed_tx = alloy_consensus::Signed::new_unchecked(tx, invalid_signature, B256::random());
     let op_tx = OpTransactionSigned::Eip1559(signed_tx);

--- a/crates/rpc/tests/meter_block.rs
+++ b/crates/rpc/tests/meter_block.rs
@@ -1,0 +1,301 @@
+//! Integration tests for block metering functionality.
+
+use std::sync::Arc;
+
+use alloy_consensus::{BlockHeader, Header, crypto::secp256k1::public_key_to_address};
+use alloy_genesis::GenesisAccount;
+use alloy_primitives::{Address, B256, U256};
+use base_reth_rpc::meter_block;
+use base_reth_test_utils::create_provider_factory;
+use eyre::Context;
+use rand::{SeedableRng, rngs::StdRng};
+use reth::{api::NodeTypesWithDBAdapter, chainspec::EthChainSpec};
+use reth_db::{DatabaseEnv, test_utils::TempDatabase};
+use reth_optimism_chainspec::{BASE_MAINNET, OpChainSpec, OpChainSpecBuilder};
+use reth_optimism_node::OpNode;
+use reth_optimism_primitives::{OpBlock, OpBlockBody, OpTransactionSigned};
+use reth_primitives_traits::{Block as BlockT, SealedHeader};
+use reth_provider::{HeaderProvider, StateProviderFactory, providers::BlockchainProvider};
+use reth_testing_utils::generators::generate_keys;
+use reth_transaction_pool::test_utils::TransactionBuilder;
+
+type NodeTypes = NodeTypesWithDBAdapter<OpNode, Arc<TempDatabase<DatabaseEnv>>>;
+
+#[derive(Eq, PartialEq, Debug, Hash, Clone, Copy)]
+enum User {
+    Alice,
+    Bob,
+}
+
+#[derive(Debug, Clone)]
+struct TestHarness {
+    provider: BlockchainProvider<NodeTypes>,
+    header: SealedHeader,
+    chain_spec: Arc<OpChainSpec>,
+    user_to_private_key: std::collections::HashMap<User, B256>,
+}
+
+impl TestHarness {
+    fn signer(&self, u: User) -> B256 {
+        self.user_to_private_key[&u]
+    }
+}
+
+fn create_chain_spec(seed: u64) -> (Arc<OpChainSpec>, std::collections::HashMap<User, B256>) {
+    let keys = generate_keys(&mut StdRng::seed_from_u64(seed), 2);
+
+    let mut private_keys = std::collections::HashMap::new();
+
+    let alice_key = keys[0];
+    let alice_address = public_key_to_address(alice_key.public_key());
+    let alice_secret = B256::from(alice_key.secret_bytes());
+    private_keys.insert(User::Alice, alice_secret);
+
+    let bob_key = keys[1];
+    let bob_address = public_key_to_address(bob_key.public_key());
+    let bob_secret = B256::from(bob_key.secret_bytes());
+    private_keys.insert(User::Bob, bob_secret);
+
+    let genesis = BASE_MAINNET
+        .genesis
+        .clone()
+        .extend_accounts(vec![
+            (alice_address, GenesisAccount::default().with_balance(U256::from(1_000_000_000_u64))),
+            (bob_address, GenesisAccount::default().with_balance(U256::from(1_000_000_000_u64))),
+        ])
+        .with_gas_limit(100_000_000);
+
+    let spec =
+        Arc::new(OpChainSpecBuilder::base_mainnet().genesis(genesis).isthmus_activated().build());
+
+    (spec, private_keys)
+}
+
+fn setup_harness() -> eyre::Result<TestHarness> {
+    let (chain_spec, user_to_private_key) = create_chain_spec(1337);
+    let factory = create_provider_factory::<OpNode>(chain_spec.clone());
+
+    reth_db_common::init::init_genesis(&factory).context("initializing genesis state")?;
+
+    let provider = BlockchainProvider::new(factory.clone()).context("creating provider")?;
+    let header = provider
+        .sealed_header(0)
+        .context("fetching genesis header")?
+        .expect("genesis header exists");
+
+    Ok(TestHarness { provider, header, chain_spec, user_to_private_key })
+}
+
+fn create_block_with_transactions(
+    harness: &TestHarness,
+    transactions: Vec<OpTransactionSigned>,
+) -> OpBlock {
+    let header = Header {
+        parent_hash: harness.header.hash(),
+        number: harness.header.number() + 1,
+        timestamp: harness.header.timestamp() + 2,
+        gas_limit: 30_000_000,
+        beneficiary: Address::random(),
+        base_fee_per_gas: Some(1),
+        // Required for post-Cancun blocks (EIP-4788)
+        parent_beacon_block_root: Some(B256::ZERO),
+        ..Default::default()
+    };
+
+    let body = OpBlockBody { transactions, ommers: vec![], withdrawals: None };
+
+    OpBlock::new(header, body)
+}
+
+#[test]
+fn meter_block_empty_transactions() -> eyre::Result<()> {
+    let harness = setup_harness()?;
+
+    let block = create_block_with_transactions(&harness, vec![]);
+
+    let state_provider = harness
+        .provider
+        .state_by_block_hash(harness.header.hash())
+        .context("getting state provider")?;
+
+    let response =
+        meter_block(state_provider, harness.chain_spec.clone(), &block, &harness.header)?;
+
+    assert_eq!(response.block_hash, block.header().hash_slow());
+    assert_eq!(response.block_number, block.header().number());
+    assert!(response.transactions.is_empty());
+    assert!(response.execution_time_us > 0, "execution time should be non-zero due to EVM setup");
+    assert!(response.state_root_time_us > 0, "state root time should be non-zero");
+    assert_eq!(response.total_time_us, response.execution_time_us + response.state_root_time_us);
+
+    Ok(())
+}
+
+#[test]
+fn meter_block_single_transaction() -> eyre::Result<()> {
+    let harness = setup_harness()?;
+
+    let to = Address::random();
+    let signed_tx = TransactionBuilder::default()
+        .signer(harness.signer(User::Alice))
+        .chain_id(harness.chain_spec.chain_id())
+        .nonce(0)
+        .to(to)
+        .value(1_000)
+        .gas_limit(21_000)
+        .max_fee_per_gas(10)
+        .max_priority_fee_per_gas(1)
+        .into_eip1559();
+
+    let tx =
+        OpTransactionSigned::Eip1559(signed_tx.as_eip1559().expect("eip1559 transaction").clone());
+    let tx_hash = tx.tx_hash();
+
+    let block = create_block_with_transactions(&harness, vec![tx]);
+
+    let state_provider = harness
+        .provider
+        .state_by_block_hash(harness.header.hash())
+        .context("getting state provider")?;
+
+    let response =
+        meter_block(state_provider, harness.chain_spec.clone(), &block, &harness.header)?;
+
+    assert_eq!(response.block_hash, block.header().hash_slow());
+    assert_eq!(response.block_number, block.header().number());
+    assert_eq!(response.transactions.len(), 1);
+
+    let metered_tx = &response.transactions[0];
+    assert_eq!(metered_tx.tx_hash, tx_hash);
+    assert_eq!(metered_tx.gas_used, 21_000);
+    assert!(metered_tx.execution_time_us > 0, "transaction execution time should be non-zero");
+
+    assert!(response.execution_time_us > 0);
+    assert!(response.state_root_time_us > 0);
+    assert_eq!(response.total_time_us, response.execution_time_us + response.state_root_time_us);
+
+    Ok(())
+}
+
+#[test]
+fn meter_block_multiple_transactions() -> eyre::Result<()> {
+    let harness = setup_harness()?;
+
+    let to_1 = Address::random();
+    let to_2 = Address::random();
+
+    // Create first transaction from Alice
+    let signed_tx_1 = TransactionBuilder::default()
+        .signer(harness.signer(User::Alice))
+        .chain_id(harness.chain_spec.chain_id())
+        .nonce(0)
+        .to(to_1)
+        .value(1_000)
+        .gas_limit(21_000)
+        .max_fee_per_gas(10)
+        .max_priority_fee_per_gas(1)
+        .into_eip1559();
+
+    let tx_1 = OpTransactionSigned::Eip1559(
+        signed_tx_1.as_eip1559().expect("eip1559 transaction").clone(),
+    );
+    let tx_hash_1 = tx_1.tx_hash();
+
+    // Create second transaction from Bob
+    let signed_tx_2 = TransactionBuilder::default()
+        .signer(harness.signer(User::Bob))
+        .chain_id(harness.chain_spec.chain_id())
+        .nonce(0)
+        .to(to_2)
+        .value(2_000)
+        .gas_limit(21_000)
+        .max_fee_per_gas(15)
+        .max_priority_fee_per_gas(2)
+        .into_eip1559();
+
+    let tx_2 = OpTransactionSigned::Eip1559(
+        signed_tx_2.as_eip1559().expect("eip1559 transaction").clone(),
+    );
+    let tx_hash_2 = tx_2.tx_hash();
+
+    let block = create_block_with_transactions(&harness, vec![tx_1, tx_2]);
+
+    let state_provider = harness
+        .provider
+        .state_by_block_hash(harness.header.hash())
+        .context("getting state provider")?;
+
+    let response =
+        meter_block(state_provider, harness.chain_spec.clone(), &block, &harness.header)?;
+
+    assert_eq!(response.block_hash, block.header().hash_slow());
+    assert_eq!(response.block_number, block.header().number());
+    assert_eq!(response.transactions.len(), 2);
+
+    // Check first transaction
+    let metered_tx_1 = &response.transactions[0];
+    assert_eq!(metered_tx_1.tx_hash, tx_hash_1);
+    assert_eq!(metered_tx_1.gas_used, 21_000);
+    assert!(metered_tx_1.execution_time_us > 0);
+
+    // Check second transaction
+    let metered_tx_2 = &response.transactions[1];
+    assert_eq!(metered_tx_2.tx_hash, tx_hash_2);
+    assert_eq!(metered_tx_2.gas_used, 21_000);
+    assert!(metered_tx_2.execution_time_us > 0);
+
+    // Check aggregate times
+    assert!(response.execution_time_us > 0);
+    assert!(response.state_root_time_us > 0);
+    assert_eq!(response.total_time_us, response.execution_time_us + response.state_root_time_us);
+
+    // Ensure individual transaction times are consistent with total
+    let individual_times: u128 = response.transactions.iter().map(|t| t.execution_time_us).sum();
+    assert!(
+        individual_times <= response.execution_time_us,
+        "sum of individual times should not exceed total (due to EVM overhead)"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn meter_block_timing_consistency() -> eyre::Result<()> {
+    let harness = setup_harness()?;
+
+    // Create a block with one transaction
+    let signed_tx = TransactionBuilder::default()
+        .signer(harness.signer(User::Alice))
+        .chain_id(harness.chain_spec.chain_id())
+        .nonce(0)
+        .to(Address::random())
+        .value(1_000)
+        .gas_limit(21_000)
+        .max_fee_per_gas(10)
+        .max_priority_fee_per_gas(1)
+        .into_eip1559();
+
+    let tx =
+        OpTransactionSigned::Eip1559(signed_tx.as_eip1559().expect("eip1559 transaction").clone());
+
+    let block = create_block_with_transactions(&harness, vec![tx]);
+
+    let state_provider = harness
+        .provider
+        .state_by_block_hash(harness.header.hash())
+        .context("getting state provider")?;
+
+    let response =
+        meter_block(state_provider, harness.chain_spec.clone(), &block, &harness.header)?;
+
+    // Verify timing invariants
+    assert!(response.execution_time_us > 0, "execution time must be positive");
+    assert!(response.state_root_time_us > 0, "state root time must be positive");
+    assert_eq!(
+        response.total_time_us,
+        response.execution_time_us + response.state_root_time_us,
+        "total time must equal execution + state root times"
+    );
+
+    Ok(())
+}

--- a/crates/rpc/tests/meter_block.rs
+++ b/crates/rpc/tests/meter_block.rs
@@ -124,8 +124,7 @@ fn meter_block_empty_transactions() -> eyre::Result<()> {
     assert_eq!(response.block_hash, block.header().hash_slow());
     assert_eq!(response.block_number, block.header().number());
     assert!(response.transactions.is_empty());
-    // No transactions means no signer recovery
-    assert_eq!(response.signer_recovery_time_us, 0);
+    // No transactions means minimal signer recovery time (just timing overhead)
     assert!(response.execution_time_us > 0, "execution time should be non-zero due to EVM setup");
     assert!(response.state_root_time_us > 0, "state root time should be non-zero");
     assert_eq!(


### PR DESCRIPTION
Add base_meterBlockByHash and base_meterBlockByNumber RPC methods that re-execute a block and return timing metrics for EVM execution and state root calculation.