### PR TITLE
chore(workspace): Adds and Repairs Linting

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,26 @@ resolver = "2"
 members = ["bin/*", "crates/*"]
 default-members = ["bin/node"]
 
-[workspace.lints]
+[workspace.metadata.cargo-udeps.ignore]
+normal = ["rustls-platform-verifier"]
+
+[workspace.lints.rust]
+missing-debug-implementations = "warn"
+missing-docs = "warn"
+unreachable-pub = "warn"
+unused-must-use = "deny"
+rust-2018-idioms = "deny"
+unnameable-types = "warn"
+
+[workspace.lints.rustdoc]
+all = "warn"
+
+[workspace.lints.clippy]
+all = { level = "warn", priority = -1 }
+missing-const-for-fn = "warn"
+use-self = "warn"
+option-if-let-else = "warn"
+redundant-clone = "warn"
 
 [profile.dev]
 debug = "line-tables-only"

--- a/bin/node/src/cli.rs
+++ b/bin/node/src/cli.rs
@@ -41,7 +41,7 @@ pub struct Args {
 impl Args {
     /// Returns if flashblocks is enabled.
     /// If the websocket url is specified through the CLI.
-    pub fn flashblocks_enabled(&self) -> bool {
+    pub const fn flashblocks_enabled(&self) -> bool {
         self.websocket_url.is_some()
     }
 }

--- a/bin/node/src/main.rs
+++ b/bin/node/src/main.rs
@@ -1,3 +1,8 @@
+//! Base Reth Node binary.
+//!
+//! This is the main entry point for running a Base node with Reth,
+//! including support for flashblocks, transaction tracing, and metering.
+
 use std::sync::Arc;
 
 use base_reth_flashblocks_rpc::{
@@ -25,6 +30,7 @@ use url::Url;
 pub mod cli;
 pub use cli::Args;
 
+/// The client version string for the Base Reth node.
 pub const NODE_RETH_CLIENT_VERSION: &str = concat!("base/v", env!("CARGO_PKG_VERSION"));
 
 #[global_allocator]

--- a/crates/flashblocks-rpc/src/lib.rs
+++ b/crates/flashblocks-rpc/src/lib.rs
@@ -1,5 +1,16 @@
+//! Flashblocks RPC extension for Base Reth.
+//!
+//! This crate provides RPC APIs for accessing flashblock state,
+//! including pending transactions, blocks, and receipts before
+//! they are finalized on-chain.
+
 mod metrics;
 mod pending_blocks;
+/// RPC trait definitions and implementations for flashblocks.
 pub mod rpc;
+/// Flashblocks state management.
 pub mod state;
+/// WebSocket subscription handling for flashblocks.
 pub mod subscription;
+
+pub use pending_blocks::PendingBlocks;

--- a/crates/flashblocks-rpc/src/metrics.rs
+++ b/crates/flashblocks-rpc/src/metrics.rs
@@ -7,7 +7,7 @@ use metrics_derive::Metrics;
 /// - Gauges reflect the current value/state.
 #[derive(Metrics, Clone)]
 #[metrics(scope = "reth_flashblocks")]
-pub struct Metrics {
+pub(crate) struct Metrics {
     #[metric(describe = "Count of times upstream receiver was closed/errored")]
     pub upstream_errors: Counter,
 

--- a/crates/flashblocks-rpc/src/pending_blocks.rs
+++ b/crates/flashblocks-rpc/src/pending_blocks.rs
@@ -19,7 +19,7 @@ use reth_rpc_eth_api::{RpcBlock, RpcReceipt};
 
 use crate::{rpc::PendingBlocksAPI, subscription::Flashblock};
 
-pub struct PendingBlocksBuilder {
+pub(crate) struct PendingBlocksBuilder {
     flashblocks: Vec<Flashblock>,
     headers: Vec<Sealed<Header>>,
 
@@ -36,7 +36,7 @@ pub struct PendingBlocksBuilder {
 }
 
 impl PendingBlocksBuilder {
-    pub fn new() -> Self {
+    pub(crate) fn new() -> Self {
         Self {
             flashblocks: Vec::new(),
             headers: Vec::new(),
@@ -53,13 +53,13 @@ impl PendingBlocksBuilder {
     }
 
     #[inline]
-    pub fn with_flashblocks(&mut self, flashblocks: Vec<Flashblock>) -> &Self {
+    pub(crate) fn with_flashblocks(&mut self, flashblocks: Vec<Flashblock>) -> &Self {
         self.flashblocks.extend(flashblocks);
         self
     }
 
     #[inline]
-    pub fn with_header(&mut self, header: Sealed<Header>) -> &Self {
+    pub(crate) fn with_header(&mut self, header: Sealed<Header>) -> &Self {
         self.headers.push(header);
         self
     }
@@ -141,6 +141,7 @@ impl PendingBlocksBuilder {
     }
 }
 
+/// Aggregated pending block state from flashblocks.
 #[derive(Debug, Clone)]
 pub struct PendingBlocks {
     flashblocks: Vec<Flashblock>,
@@ -159,42 +160,52 @@ pub struct PendingBlocks {
 }
 
 impl PendingBlocks {
+    /// Returns the latest block number in the pending state.
     pub fn latest_block_number(&self) -> BlockNumber {
         self.headers.last().unwrap().number
     }
 
+    /// Returns the canonical block number (the block before pending).
     pub fn canonical_block_number(&self) -> BlockNumberOrTag {
         BlockNumberOrTag::Number(self.headers.first().unwrap().number - 1)
     }
 
+    /// Returns the earliest block number in the pending state.
     pub fn earliest_block_number(&self) -> BlockNumber {
         self.headers.first().unwrap().number
     }
 
+    /// Returns the index of the latest flashblock.
     pub fn latest_flashblock_index(&self) -> u64 {
         self.flashblocks.last().unwrap().index
     }
 
+    /// Returns the latest header.
     pub fn latest_header(&self) -> Sealed<Header> {
         self.headers.last().unwrap().clone()
     }
 
+    /// Returns all flashblocks.
     pub fn get_flashblocks(&self) -> Vec<Flashblock> {
         self.flashblocks.clone()
     }
 
+    /// Returns the EVM state for a transaction.
     pub fn get_transaction_state(&self, hash: &B256) -> Option<EvmState> {
         self.transaction_state.get(hash).cloned()
     }
 
+    /// Returns the sender of a transaction.
     pub fn get_transaction_sender(&self, tx_hash: &B256) -> Option<Address> {
         self.transaction_senders.get(tx_hash).cloned()
     }
 
+    /// Returns the database cache.
     pub fn get_db_cache(&self) -> Cache {
         self.db_cache.clone()
     }
 
+    /// Returns all transactions for a specific block number.
     pub fn get_transactions_for_block(&self, block_number: BlockNumber) -> Vec<Transaction> {
         self.transactions
             .iter()
@@ -203,6 +214,7 @@ impl PendingBlocks {
             .collect()
     }
 
+    /// Returns the latest block, optionally with full transaction details.
     pub fn get_latest_block(&self, full: bool) -> RpcBlock<Optimism> {
         let header = self.latest_header();
         let block_number = header.number;
@@ -216,33 +228,39 @@ impl PendingBlocks {
         };
 
         RpcBlock::<Optimism> {
-            header: RPCHeader::from_consensus(header.clone(), None, None),
+            header: RPCHeader::from_consensus(header, None, None),
             transactions,
             uncles: Vec::new(),
             withdrawals: None,
         }
     }
 
+    /// Returns the receipt for a transaction.
     pub fn get_receipt(&self, tx_hash: TxHash) -> Option<OpTransactionReceipt> {
         self.transaction_receipts.get(&tx_hash).cloned()
     }
 
+    /// Returns a transaction by its hash.
     pub fn get_transaction_by_hash(&self, tx_hash: TxHash) -> Option<Transaction> {
         self.transactions_by_hash.get(&tx_hash).cloned()
     }
 
+    /// Returns the transaction count for an address in pending state.
     pub fn get_transaction_count(&self, address: Address) -> U256 {
         self.transaction_count.get(&address).cloned().unwrap_or(U256::from(0))
     }
 
+    /// Returns the balance for an address in pending state.
     pub fn get_balance(&self, address: Address) -> Option<U256> {
         self.account_balances.get(&address).cloned()
     }
 
+    /// Returns the state overrides for the pending state.
     pub fn get_state_overrides(&self) -> Option<StateOverride> {
         self.state_overrides.clone()
     }
 
+    /// Returns logs matching the filter from pending state.
     pub fn get_pending_logs(&self, filter: &Filter) -> Vec<Log> {
         let mut logs = Vec::new();
 

--- a/crates/flashblocks-rpc/src/state.rs
+++ b/crates/flashblocks-rpc/src/state.rs
@@ -41,8 +41,9 @@ use tokio::sync::{
 use tracing::{debug, error, info, warn};
 
 use crate::{
+    PendingBlocks,
     metrics::Metrics,
-    pending_blocks::{PendingBlocks, PendingBlocksBuilder},
+    pending_blocks::PendingBlocksBuilder,
     rpc::FlashblocksAPI,
     subscription::{Flashblock, FlashblocksReceiver},
 };
@@ -55,6 +56,7 @@ enum StateUpdate {
     Flashblock(Flashblock),
 }
 
+/// Manages the pending flashblock state and processes incoming updates.
 #[derive(Debug, Clone)]
 pub struct FlashblocksState<Client> {
     pending_blocks: Arc<ArcSwapOption<PendingBlocks>>,
@@ -71,6 +73,7 @@ where
         + Clone
         + 'static,
 {
+    /// Creates a new flashblocks state manager.
     pub fn new(client: Client, max_pending_blocks_depth: u64) -> Self {
         let (tx, rx) = mpsc::unbounded_channel::<StateUpdate>();
         let pending_blocks: Arc<ArcSwapOption<PendingBlocks>> = Arc::new(ArcSwapOption::new(None));
@@ -86,6 +89,7 @@ where
         Self { pending_blocks, queue: tx, flashblock_sender, state_processor }
     }
 
+    /// Starts the flashblocks state processor.
     pub fn start(&self) {
         let sp = self.state_processor.clone();
         tokio::spawn(async move {
@@ -93,6 +97,7 @@ where
         });
     }
 
+    /// Handles a canonical block being received.
     pub fn on_canonical_block_received(&self, block: &RecoveredBlock<OpBlock>) {
         match self.queue.send(StateUpdate::Canonical(block.clone())) {
             Ok(_) => {
@@ -383,10 +388,10 @@ where
             None => CacheDB::new(state),
         };
 
-        let mut state_overrides = match &prev_pending_blocks {
-            Some(pending_blocks) => pending_blocks.get_state_overrides().unwrap_or_default(),
-            None => StateOverride::default(),
-        };
+        let mut state_overrides =
+            prev_pending_blocks.as_ref().map_or_else(StateOverride::default, |pending_blocks| {
+                pending_blocks.get_state_overrides().unwrap_or_default()
+            });
 
         for (_block_number, flashblocks) in flashblocks_per_block {
             let base = flashblocks

--- a/crates/flashblocks-rpc/src/state.rs
+++ b/crates/flashblocks-rpc/src/state.rs
@@ -587,8 +587,7 @@ where
                     match evm.transact(recovered_transaction) {
                         Ok(ResultAndState { state, .. }) => {
                             for (addr, acc) in &state {
-                                let existing_override =
-                                    state_overrides.entry(*addr).or_insert(Default::default());
+                                let existing_override = state_overrides.entry(*addr).or_default();
                                 existing_override.balance = Some(acc.info.balance);
                                 existing_override.nonce = Some(acc.info.nonce);
                                 existing_override.code =

--- a/crates/metering/src/lib.rs
+++ b/crates/metering/src/lib.rs
@@ -1,3 +1,7 @@
+//! Transaction metering utilities for Base Reth.
+//!
+//! This crate provides RPC APIs and utilities for metering transaction bundles.
+
 mod meter;
 mod rpc;
 #[cfg(test)]

--- a/crates/metering/src/rpc.rs
+++ b/crates/metering/src/rpc.rs
@@ -22,6 +22,7 @@ pub trait MeteringApi {
 }
 
 /// Implementation of the metering RPC API
+#[derive(Debug)]
 pub struct MeteringApiImpl<Provider> {
     provider: Provider,
 }
@@ -34,7 +35,7 @@ where
         + Clone,
 {
     /// Creates a new instance of MeteringApi
-    pub fn new(provider: Provider) -> Self {
+    pub const fn new(provider: Provider) -> Self {
         Self { provider }
     }
 }
@@ -96,20 +97,15 @@ where
 
         // Meter bundle using utility function
         let (results, total_gas_used, total_gas_fees, bundle_hash, total_execution_time) =
-            meter_bundle(
-                state_provider,
-                self.provider.chain_spec().clone(),
-                parsed_bundle,
-                &header,
-            )
-            .map_err(|e| {
-                error!(error = %e, "Bundle metering failed");
-                jsonrpsee::types::ErrorObjectOwned::owned(
-                    jsonrpsee::types::ErrorCode::InternalError.code(),
-                    format!("Bundle metering failed: {}", e),
-                    None::<()>,
-                )
-            })?;
+            meter_bundle(state_provider, self.provider.chain_spec(), parsed_bundle, &header)
+                .map_err(|e| {
+                    error!(error = %e, "Bundle metering failed");
+                    jsonrpsee::types::ErrorObjectOwned::owned(
+                        jsonrpsee::types::ErrorCode::InternalError.code(),
+                        format!("Bundle metering failed: {}", e),
+                        None::<()>,
+                    )
+                })?;
 
         // Calculate average gas price
         let bundle_gas_price = if total_gas_used > 0 {

--- a/crates/transaction-status/src/lib.rs
+++ b/crates/transaction-status/src/lib.rs
@@ -1,14 +1,25 @@
+//! Transaction status API for Base Reth.
+//!
+//! This crate provides an RPC API for querying transaction status
+//! from the local mempool or a remote sequencer.
+
+/// RPC implementation for transaction status queries.
 pub mod rpc;
 
 use serde::{Deserialize, Serialize};
 
+/// The status of a transaction.
 #[derive(Clone, Serialize, Deserialize, PartialEq, Debug)]
 pub enum Status {
+    /// Transaction is not known to the node.
     Unknown,
+    /// Transaction is known to the node (in mempool or confirmed).
     Known,
 }
 
+/// Response containing the status of a transaction.
 #[derive(Clone, Serialize, Deserialize, PartialEq, Debug)]
 pub struct TransactionStatusResponse {
+    /// The status of the queried transaction.
     pub status: Status,
 }

--- a/crates/transaction-status/src/rpc.rs
+++ b/crates/transaction-status/src/rpc.rs
@@ -19,12 +19,18 @@ pub trait TransactionStatusApi {
     async fn transaction_status(&self, tx_hash: TxHash) -> RpcResult<TransactionStatusResponse>;
 }
 
+/// Implementation of the transaction status RPC API.
+#[derive(Debug)]
 pub struct TransactionStatusApiImpl<Pool: TransactionPool> {
     sequencer_client: Option<HttpClient>,
     pool: Pool,
 }
 
 impl<Pool: TransactionPool + 'static> TransactionStatusApiImpl<Pool> {
+    /// Creates a new transaction status API instance.
+    ///
+    /// If `sequencer_url` is provided, status queries will be forwarded to the sequencer.
+    /// Otherwise, the local transaction pool will be queried.
     pub fn new(
         sequencer_url: Option<String>,
         pool: Pool,

--- a/crates/transaction-tracing/src/lib.rs
+++ b/crates/transaction-tracing/src/lib.rs
@@ -1,3 +1,9 @@
+//! Transaction tracing utilities for Base Reth.
+//!
+//! This crate provides an ExEx for tracking transaction lifecycle events
+//! from mempool insertion to block inclusion.
+
+/// Transaction tracing execution extension.
 pub mod tracing;
 mod types;
 

--- a/crates/transaction-tracing/src/tracing.rs
+++ b/crates/transaction-tracing/src/tracing.rs
@@ -162,6 +162,9 @@ impl Tracker {
     }
 }
 
+/// Execution extension that tracks transaction timing from mempool to inclusion.
+///
+/// Monitors transaction lifecycle events and records timing metrics.
 pub async fn transaction_tracing_exex<Node: FullNodeComponents>(
     mut ctx: ExExContext<Node>,
     enable_logs: bool,

--- a/crates/transaction-tracing/src/types.rs
+++ b/crates/transaction-tracing/src/types.rs
@@ -7,7 +7,7 @@ use chrono::{DateTime, Local};
 
 /// Types of transaction events to track
 #[derive(Debug, Clone, Copy, PartialEq)]
-pub enum TxEvent {
+pub(crate) enum TxEvent {
     Dropped,
     Replaced,
     Pending,
@@ -21,14 +21,14 @@ pub enum TxEvent {
 impl Display for TxEvent {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let s = match self {
-            TxEvent::Dropped => "dropped",
-            TxEvent::Replaced => "replaced",
-            TxEvent::Pending => "pending",
-            TxEvent::Queued => "queued",
-            TxEvent::BlockInclusion => "block_inclusion",
-            TxEvent::PendingToQueued => "pending_to_queued",
-            TxEvent::QueuedToPending => "queued_to_pending",
-            TxEvent::Overflowed => "overflowed",
+            Self::Dropped => "dropped",
+            Self::Replaced => "replaced",
+            Self::Pending => "pending",
+            Self::Queued => "queued",
+            Self::BlockInclusion => "block_inclusion",
+            Self::PendingToQueued => "pending_to_queued",
+            Self::QueuedToPending => "queued_to_pending",
+            Self::Overflowed => "overflowed",
         };
         write!(f, "{s}")
     }
@@ -36,28 +36,28 @@ impl Display for TxEvent {
 
 /// Types of pools a transaction can be in
 #[derive(Debug, Clone, PartialEq)]
-pub enum Pool {
+pub(crate) enum Pool {
     Pending,
     Queued,
 }
 
 /// History of events for a transaction
-pub struct EventLog {
-    pub mempool_time: Instant,
-    pub events: Vec<(DateTime<Local>, TxEvent)>,
-    pub limit: usize,
+pub(crate) struct EventLog {
+    pub(crate) mempool_time: Instant,
+    pub(crate) events: Vec<(DateTime<Local>, TxEvent)>,
+    pub(crate) limit: usize,
 }
 
 impl EventLog {
-    pub fn new(t: DateTime<Local>, event: TxEvent) -> Self {
+    pub(crate) fn new(t: DateTime<Local>, event: TxEvent) -> Self {
         Self { mempool_time: Instant::now(), events: vec![(t, event)], limit: 10 }
     }
 
-    pub fn push(&mut self, t: DateTime<Local>, event: TxEvent) {
+    pub(crate) fn push(&mut self, t: DateTime<Local>, event: TxEvent) {
         self.events.push((t, event));
     }
 
-    pub fn to_vec(&self) -> Vec<String> {
+    pub(crate) fn to_vec(&self) -> Vec<String> {
         self.events
             .iter()
             .map(|(t, event)| {


### PR DESCRIPTION
### Description

Previously, linting was foregone in the workspace manifest. The `[workspace.lints]` toml table was empty.

This PR adds proper linting to `node-reth` and repairs missing lint issues.