### PR TITLE
chore(docker): Docker Dependency Caching

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-FROM rust:1.88 AS build
-
+# --- Chef base image ---
+FROM lukemathwalker/cargo-chef:latest-rust-1.88-trixie AS chef
 WORKDIR /app
 
 RUN apt-get update && \
@@ -7,10 +7,25 @@ RUN apt-get update && \
     apt-get install -y git libclang-dev pkg-config curl build-essential && \
     rm -rf /var/lib/apt/lists/*
 
-COPY ./ .
+# --- Planner: analyze dependencies ---
+FROM chef AS planner
+COPY . .
+RUN cargo chef prepare --recipe-path recipe.json
 
+# --- Builder: cook dependencies, then build ---
+FROM chef AS builder
+
+# Copy ONLY the recipe (dependency metadata)
+COPY --from=planner /app/recipe.json recipe.json
+
+# Build dependencies - THIS LAYER IS CACHED until Cargo.toml/Cargo.lock change
+RUN cargo chef cook --release --recipe-path recipe.json
+
+# Now copy source and build (only your code compiles here)
+COPY . .
 RUN cargo build --release --bin base-reth-node
 
+# --- Runtime image ---
 FROM ubuntu:22.04
 
 RUN apt-get update && \
@@ -19,6 +34,6 @@ RUN apt-get update && \
 
 WORKDIR /app
 
-ENTRYPOINT [ "./base-reth-node" ]
+COPY --from=builder /app/target/release/base-reth-node ./
 
-COPY --from=build /app/target/release/base-reth-node ./
+ENTRYPOINT ["./base-reth-node"]


### PR DESCRIPTION
### Overview

Switches the Dockerfile to use [cargo-chef](https://github.com/LukeMathWalker/cargo-chef), which splits the build into stages that cache Rust dependencies separately from our application code.

### Benefits

Right now, any code change triggers a full rebuild of all dependencies including reth, which takes a while. With cargo-chef, dependencies only rebuild when `Cargo.toml` or `Cargo.lock` files change. For typical code-only changes, Docker reuses the cached dependencies and just compiles our code, which should cut incremental build times from 20+ minutes down to a few minutes.