### PR TITLE
chore(workspace): Justfile Cleanup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,9 @@ jobs:
 
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: dtolnay/rust-toolchain@4305c38b25d97ef35a8ad1f985ccf2d2242004f2 # stable
-      - run: cargo build --all-targets
+      - name: Install just
+        uses: extractions/setup-just@e33e0265a09d6d736e2ee1e0eb685ef1de4669ff # v3
+      - run: just build-all-targets
 
   test:
     name: Test
@@ -37,10 +39,12 @@ jobs:
 
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: dtolnay/rust-toolchain@4305c38b25d97ef35a8ad1f985ccf2d2242004f2 # stable
+      - name: Install just
+        uses: extractions/setup-just@e33e0265a09d6d736e2ee1e0eb685ef1de4669ff # v3
       - name: Build reth-node
-        run: cargo build --bin base-reth-node
+        run: just build-node
       - name: Run tests
-        run: cargo test --workspace --all-features
+        run: just test
 
   fmt:
     name: Format
@@ -55,7 +59,9 @@ jobs:
       - uses: dtolnay/rust-toolchain@0c3131df9e5407c0c36352032d04af846dbe0fb7 # nightly
         with:
           components: rustfmt
-      - run: cargo fmt --all -- --check
+      - name: Install just
+        uses: extractions/setup-just@e33e0265a09d6d736e2ee1e0eb685ef1de4669ff # v3
+      - run: just check-format
 
   clippy:
     name: Clippy
@@ -70,7 +76,9 @@ jobs:
       - uses: dtolnay/rust-toolchain@4305c38b25d97ef35a8ad1f985ccf2d2242004f2 # stable
         with:
           components: clippy
-      - run: cargo clippy -- -D warnings
+      - name: Install just
+        uses: extractions/setup-just@e33e0265a09d6d736e2ee1e0eb685ef1de4669ff # v3
+      - run: just check-clippy
 
   docker:
     name: Docker
@@ -112,4 +120,6 @@ jobs:
       - uses: taiki-e/install-action@3575e532701a5fc614b0c842e4119af4cc5fd16d # v2.62.60
         with: 
           tool: cargo-udeps
-      - run: cargo udeps --workspace --lib --tests --all-features
+      - name: Install just
+        uses: extractions/setup-just@e33e0265a09d6d736e2ee1e0eb685ef1de4669ff # v3
+      - run: just check-udeps

--- a/justfile
+++ b/justfile
@@ -1,37 +1,69 @@
+set positional-arguments
+alias t := test
+alias f := fix
+alias b := build
+alias c := clean
+alias h := hack
+alias u := check-udeps
+alias wt := watch-test
+alias wc := watch-check
+
+# Default to display help menu
 default:
     @just --list
 
+# Checks formatting, clippy, and tests
 check: check-format check-clippy test
 
+# Fixes formatting and clippy issues
 fix: fix-format fix-clippy
 
+# Runs tests across workspace with all features enabled
 test:
     cargo test --workspace --all-features
 
+# Runs cargo hack against the workspace
+hack:
+  cargo hack check --feature-powerset --no-dev-deps
+
+# Checks formatting
 check-format:
     cargo +nightly fmt --all -- --check
 
+# Fixes any formatting issues
 fix-format:
     cargo fix --allow-dirty --allow-staged
     cargo +nightly fmt --all
 
+# Checks clippy
 check-clippy:
     cargo clippy --all-targets -- -D warnings
 
+# Fixes any clippy issues
 fix-clippy:
     cargo clippy --all-targets --fix --allow-dirty --allow-staged
 
+# Builds the workspace with release
 build:
     cargo build --release
 
+# Builds the workspace with maxperf
 build-maxperf:
     cargo build --profile maxperf --features jemalloc
 
+# Cleans the workspace
 clean:
     cargo clean
 
+# Checks if there are any unused dependencies
+check-udeps:
+  @command -v cargo-udeps >/dev/null 2>&1 || cargo install cargo-udeps
+  cargo +nightly udeps --workspace --all-features --all-targets
+
+# Watches tests
 watch-test:
     cargo watch -x test
 
+# Watches checks
 watch-check:
     cargo watch -x "fmt --all -- --check" -x "clippy --all-targets -- -D warnings" -x test

--- a/justfile
+++ b/justfile
@@ -47,9 +47,17 @@ fix-clippy:
 build:
     cargo build --release
 
+# Builds all targets in debug mode
+build-all-targets:
+    cargo build --all-targets
+
 # Builds the workspace with maxperf
 build-maxperf:
     cargo build --profile maxperf --features jemalloc
+
+# Builds the base node binary
+build-node:
+    cargo build --bin base-reth-node
 
 # Cleans the workspace
 clean:


### PR DESCRIPTION
### Description

Small PR to cleanup the justfile.

Adds two checks that will be added to ci in future PRs.
- **`check-udeps`**: which verifies that all dependencies are used.
- **`hack`**: runs the feature powerset which ensures features properly work together.