### PR TITLE
fix(ci): Properly Use Docker Cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,6 +92,8 @@ jobs:
         with:
           context: .
           push: false
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
   udeps:
     name: udeps


### PR DESCRIPTION
### Description

Updates the docker github action workflow to re-use cached dependency builds if possible. This should _actually_ speed up docker ci builds when dependencies are **not** changed since the workflow will re-use github's action cache.

We should not expect to see a speedup in this pr since it will populate the cache. In future runs, we should expect to see significant speedups on the docker ci job.