### PR TITLE
chore(ci): Lychee Link Checks

### DIFF
--- a/.github/workflows/lychee.yml
+++ b/.github/workflows/lychee.yml
@@ -1,0 +1,24 @@
+name: Lychee Checks
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  lychee-checks:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@002fdce3c6a235733a90a27c80493a3241e56863 # v2.12.1
+        with:
+          egress-policy: audit
+      - uses: actions/checkout@v5
+      - uses: lycheeverse/lychee-action@v2
+        with:
+          args: --config ./lychee.toml --cache-exclude-status 429 '**/README.md' './docs/**/*.md' './docs/**/*.mdx' './docs/**/*.html' './docs/**/*.json'
+          fail: true

--- a/lychee.toml
+++ b/lychee.toml
@@ -1,0 +1,8 @@
+verbose = "debug"
+no_progress = false
+exclude_all_private = false
+accept = [200, 403] # 403 status code is often returned by private repos instead of 404
+exclude = [
+    'foo.bar',
+    'localhost',
+]


### PR DESCRIPTION
### Description

CI now runs Lychee link checks on every push, PR, or manual trigger via `lychee.yml`, using the Lychee action to fail on  broken links across README/docs. A new `lychee.toml` supplies repo-specific settings (debug verbosity, allowed status codes, and false-positive exclusions) so the workflow has consistent behavior.