### PR TITLE
fix(ci): Rust Cache Fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,8 @@ jobs:
       - uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2.8.2
         with:
           cache-on-failure: true
+          add-rust-environment-hash-key: 'false'
+          key: stable-${{ hashFiles('Cargo.lock') }}
       - name: Install just
         uses: extractions/setup-just@e33e0265a09d6d736e2ee1e0eb685ef1de4669ff # v3
       - run: just build-all-targets
@@ -45,6 +47,8 @@ jobs:
       - uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2.8.2
         with:
           cache-on-failure: true
+          add-rust-environment-hash-key: 'false'
+          key: stable-${{ hashFiles('Cargo.lock') }}
       - name: Install just
         uses: extractions/setup-just@e33e0265a09d6d736e2ee1e0eb685ef1de4669ff # v3
       - name: Build reth-node
@@ -68,6 +72,8 @@ jobs:
       - uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2.8.2
         with:
           cache-on-failure: true
+          add-rust-environment-hash-key: 'false'
+          key: nightly-${{ hashFiles('Cargo.lock') }}
       - name: Install just
         uses: extractions/setup-just@e33e0265a09d6d736e2ee1e0eb685ef1de4669ff # v3
       - run: just check-format
@@ -88,6 +94,8 @@ jobs:
       - uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2.8.2
         with:
           cache-on-failure: true
+          add-rust-environment-hash-key: 'false'
+          key: stable-${{ hashFiles('Cargo.lock') }}
       - name: Install just
         uses: extractions/setup-just@e33e0265a09d6d736e2ee1e0eb685ef1de4669ff # v3
       - run: just check-clippy
@@ -131,6 +139,8 @@ jobs:
       - uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2.8.2
         with:
           cache-on-failure: true
+          add-rust-environment-hash-key: 'false'
+          key: nightly-${{ hashFiles('Cargo.lock') }}
       - uses: taiki-e/install-action@3575e532701a5fc614b0c842e4119af4cc5fd16d # v2.62.60
         with: 
           tool: cargo-udeps


### PR DESCRIPTION
### Description

Adjusted every Swatinem/rust-cache invocation to disable the automatic environment/manifest hash and to key the cache explicitly off of Cargo.lock, so non-dependency tweaks (profiles, metadata, etc.) no longer invalidate the cache unexpectedly for the build/test/clippy jobs.