### PR TITLE
chore(transaction-status): Flat Crate Exports

### DIFF
--- a/bin/node/src/main.rs
+++ b/bin/node/src/main.rs
@@ -11,7 +11,7 @@ use base_reth_flashblocks_rpc::{
     subscription::FlashblocksSubscriber,
 };
 use base_reth_metering::{MeteringApiImpl, MeteringApiServer};
-use base_reth_transaction_status::rpc::{TransactionStatusApiImpl, TransactionStatusApiServer};
+use base_reth_transaction_status::{TransactionStatusApiImpl, TransactionStatusApiServer};
 use base_reth_transaction_tracing::transaction_tracing_exex;
 use clap::Parser;
 use futures_util::TryStreamExt;

--- a/crates/transaction-status/src/lib.rs
+++ b/crates/transaction-status/src/lib.rs
@@ -3,23 +3,11 @@
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
 
-/// RPC implementation for transaction status queries.
-pub mod rpc;
+mod traits;
+pub use traits::TransactionStatusApiServer;
 
-use serde::{Deserialize, Serialize};
+mod rpc;
+pub use rpc::TransactionStatusApiImpl;
 
-/// The status of a transaction.
-#[derive(Clone, Serialize, Deserialize, PartialEq, Debug)]
-pub enum Status {
-    /// Transaction is not known to the node.
-    Unknown,
-    /// Transaction is known to the node (in mempool or confirmed).
-    Known,
-}
-
-/// Response containing the status of a transaction.
-#[derive(Clone, Serialize, Deserialize, PartialEq, Debug)]
-pub struct TransactionStatusResponse {
-    /// The status of the queried transaction.
-    pub status: Status,
-}
+mod types;
+pub use types::{Status, TransactionStatusResponse};

--- a/crates/transaction-status/src/traits.rs
+++ b/crates/transaction-status/src/traits.rs
@@ -1,0 +1,14 @@
+//! Traits for the transaction status module.
+
+use alloy_primitives::TxHash;
+use jsonrpsee::{core::RpcResult, proc_macros::rpc};
+
+use crate::TransactionStatusResponse;
+
+/// RPC API for transaction status
+#[rpc(server, namespace = "base")]
+pub trait TransactionStatusApi {
+    /// Gets the status of a transaction
+    #[method(name = "transactionStatus")]
+    async fn transaction_status(&self, tx_hash: TxHash) -> RpcResult<TransactionStatusResponse>;
+}

--- a/crates/transaction-status/src/types.rs
+++ b/crates/transaction-status/src/types.rs
@@ -1,0 +1,19 @@
+//! Types for the transaction status rpc
+
+use serde::{Deserialize, Serialize};
+
+/// The status of a transaction.
+#[derive(Clone, Serialize, Deserialize, PartialEq, Debug)]
+pub enum Status {
+    /// Transaction is not known to the node.
+    Unknown,
+    /// Transaction is known to the node (in mempool or confirmed).
+    Known,
+}
+
+/// Response containing the status of a transaction.
+#[derive(Clone, Serialize, Deserialize, PartialEq, Debug)]
+pub struct TransactionStatusResponse {
+    /// The status of the queried transaction.
+    pub status: Status,
+}


### PR DESCRIPTION
### Description

Small PR to export types at the root crate level for `transaction-status`. This makes it easier to navigate and discover types avoiding the need to specify module paths for imports.