### PR TITLE
feat(runner): Node Builder Extensions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,7 +82,7 @@ reth-primitives-traits = { git = "https://github.com/paradigmxyz/reth", tag = "v
 reth-evm = { git = "https://github.com/paradigmxyz/reth", tag = "v1.9.3" }
 reth-cli-util = { git = "https://github.com/paradigmxyz/reth", tag = "v1.9.3" }
 reth-exex = { git = "https://github.com/paradigmxyz/reth", tag = "v1.9.3" }
-reth-db = { git = "https://github.com/paradigmxyz/reth", tag = "v1.9.3" }
+reth-db = { git = "https://github.com/paradigmxyz/reth", tag = "v1.9.3", features = ["op"] }
 reth-testing-utils = { git = "https://github.com/paradigmxyz/reth", tag = "v1.9.3" }
 reth-db-common = { git = "https://github.com/paradigmxyz/reth", tag = "v1.9.3" }
 reth-rpc-layer = { git = "https://github.com/paradigmxyz/reth", tag = "v1.9.3" }

--- a/bin/node/src/main.rs
+++ b/bin/node/src/main.rs
@@ -5,7 +5,7 @@
 
 pub mod cli;
 
-use base_reth_runner::BaseNodeLauncher;
+use base_reth_runner::BaseNodeRunner;
 
 #[global_allocator]
 static ALLOC: reth_cli_util::allocator::Allocator = reth_cli_util::allocator::new_allocator();
@@ -20,8 +20,10 @@ fn main() {
     let cli = Cli::<OpChainSpecParser, cli::Args>::parse();
 
     // Step 3: Hand the parsed CLI to the node runner so it can build and launch the Base node.
-    cli.run(
-        |builder, args| async move { BaseNodeLauncher::new(args).build_and_run(builder).await },
-    )
+    cli.run(|builder, args| async move {
+        let runner = BaseNodeRunner::new(args);
+        let handle = runner.build(builder).await?;
+        runner.run(handle).await
+    })
     .unwrap();
 }

--- a/crates/runner/src/extensions/canon.rs
+++ b/crates/runner/src/extensions/canon.rs
@@ -5,15 +5,12 @@ use std::sync::Arc;
 
 use base_reth_flashblocks_rpc::state::FlashblocksState;
 use futures_util::TryStreamExt;
-use once_cell::sync::OnceCell;
 use reth_exex::ExExEvent;
 
 use crate::{
     FlashblocksConfig,
-    extensions::{OpBuilder, OpProvider},
+    extensions::{FlashblocksCell, OpBuilder},
 };
-
-type FlashblocksCell = Arc<OnceCell<Arc<FlashblocksState<OpProvider>>>>;
 
 /// Helper struct that wires the Flashblocks canon ExEx into the node builder.
 #[derive(Debug, Clone)]

--- a/crates/runner/src/extensions/canon.rs
+++ b/crates/runner/src/extensions/canon.rs
@@ -1,0 +1,69 @@
+//! Contains the [FlashblocksCanonExtension] which wires up the `flashblocks-canon`
+//! execution extension on the Base node builder.
+
+use std::sync::Arc;
+
+use base_reth_flashblocks_rpc::state::FlashblocksState;
+use futures_util::TryStreamExt;
+use once_cell::sync::OnceCell;
+use reth_exex::ExExEvent;
+
+use crate::{
+    FlashblocksConfig,
+    extensions::{OpBuilder, OpProvider},
+};
+
+type FlashblocksCell = Arc<OnceCell<Arc<FlashblocksState<OpProvider>>>>;
+
+/// Helper struct that wires the Flashblocks canon ExEx into the node builder.
+#[derive(Debug, Clone)]
+pub struct FlashblocksCanonExtension {
+    /// Shared Flashblocks state cache.
+    pub cell: FlashblocksCell,
+    /// Optional Flashblocks configuration.
+    pub config: Option<FlashblocksConfig>,
+}
+
+impl FlashblocksCanonExtension {
+    /// Create a new Flashblocks canon extension helper.
+    pub const fn new(cell: FlashblocksCell, config: Option<FlashblocksConfig>) -> Self {
+        Self { cell, config }
+    }
+
+    /// Applies the extension to the supplied builder.
+    pub fn apply(&self, builder: OpBuilder) -> OpBuilder {
+        let flashblocks = self.config.clone();
+        let flashblocks_enabled = flashblocks.is_some();
+        let flashblocks_cell = self.cell.clone();
+
+        builder.install_exex_if(flashblocks_enabled, "flashblocks-canon", move |mut ctx| {
+            let flashblocks_cell = flashblocks_cell.clone();
+            async move {
+                let fb_config =
+                    flashblocks.as_ref().expect("flashblocks config checked above").clone();
+                let fb = flashblocks_cell
+                    .get_or_init(|| {
+                        Arc::new(FlashblocksState::new(
+                            ctx.provider().clone(),
+                            fb_config.max_pending_blocks_depth,
+                        ))
+                    })
+                    .clone();
+
+                Ok(async move {
+                    while let Some(note) = ctx.notifications.try_next().await? {
+                        if let Some(committed) = note.committed_chain() {
+                            for block in committed.blocks_iter() {
+                                fb.on_canonical_block_received(block);
+                            }
+                            let _ = ctx
+                                .events
+                                .send(ExExEvent::FinishedHeight(committed.tip().num_hash()));
+                        }
+                    }
+                    Ok(())
+                })
+            }
+        })
+    }
+}

--- a/crates/runner/src/extensions/mod.rs
+++ b/crates/runner/src/extensions/mod.rs
@@ -1,0 +1,12 @@
+//! Node Builder Extensions
+//!
+//! Builder extensions for the node nicely modularizes parts
+//! of the node building process.
+
+mod canon;
+mod tracing;
+mod types;
+
+pub use canon::FlashblocksCanonExtension;
+pub use tracing::TransactionTracingExtension;
+pub(crate) use types::{OpBuilder, OpProvider};

--- a/crates/runner/src/extensions/mod.rs
+++ b/crates/runner/src/extensions/mod.rs
@@ -4,9 +4,11 @@
 //! of the node building process.
 
 mod canon;
+mod rpc;
 mod tracing;
 mod types;
 
 pub use canon::FlashblocksCanonExtension;
+pub use rpc::BaseRpcExtension;
 pub use tracing::TransactionTracingExtension;
-pub(crate) use types::{OpBuilder, OpProvider};
+pub(crate) use types::{FlashblocksCell, OpBuilder};

--- a/crates/runner/src/extensions/rpc.rs
+++ b/crates/runner/src/extensions/rpc.rs
@@ -1,0 +1,98 @@
+//! Contains the [BaseRpcExtension] which wires up the custom Base RPC modules on the node builder.
+
+use std::sync::Arc;
+
+use base_reth_flashblocks_rpc::{
+    pubsub::{BasePubSub, BasePubSubApiServer},
+    rpc::{EthApiExt, EthApiOverrideServer},
+    state::FlashblocksState,
+    subscription::FlashblocksSubscriber,
+};
+use base_reth_metering::{MeteringApiImpl, MeteringApiServer};
+use base_reth_transaction_status::{TransactionStatusApiImpl, TransactionStatusApiServer};
+use tracing::info;
+use url::Url;
+
+use crate::{
+    FlashblocksConfig,
+    extensions::{FlashblocksCell, OpBuilder},
+};
+
+/// Helper struct that wires the custom RPC modules into the node builder.
+#[derive(Debug, Clone)]
+pub struct BaseRpcExtension {
+    /// Shared Flashblocks state cache.
+    pub flashblocks_cell: FlashblocksCell,
+    /// Optional Flashblocks configuration.
+    pub flashblocks: Option<FlashblocksConfig>,
+    /// Indicates whether the metering RPC surface should be installed.
+    pub metering_enabled: bool,
+    /// Sequencer RPC endpoint for transaction status proxying.
+    pub sequencer_rpc: Option<String>,
+}
+
+impl BaseRpcExtension {
+    /// Creates a new RPC extension helper.
+    pub const fn new(
+        flashblocks_cell: FlashblocksCell,
+        flashblocks: Option<FlashblocksConfig>,
+        metering_enabled: bool,
+        sequencer_rpc: Option<String>,
+    ) -> Self {
+        Self { flashblocks_cell, flashblocks, metering_enabled, sequencer_rpc }
+    }
+
+    /// Applies the extension to the supplied builder.
+    pub fn apply(&self, builder: OpBuilder) -> OpBuilder {
+        let flashblocks_cell = self.flashblocks_cell.clone();
+        let flashblocks = self.flashblocks.clone();
+        let metering_enabled = self.metering_enabled;
+        let sequencer_rpc = self.sequencer_rpc.clone();
+
+        builder.extend_rpc_modules(move |ctx| {
+            if metering_enabled {
+                info!(message = "Starting Metering RPC");
+                let metering_api = MeteringApiImpl::new(ctx.provider().clone());
+                ctx.modules.merge_configured(metering_api.into_rpc())?;
+            }
+
+            let proxy_api =
+                TransactionStatusApiImpl::new(sequencer_rpc.clone(), ctx.pool().clone())
+                    .expect("Failed to create transaction status proxy");
+            ctx.modules.merge_configured(proxy_api.into_rpc())?;
+
+            if let Some(cfg) = flashblocks.clone() {
+                info!(message = "Starting Flashblocks");
+
+                let ws_url = Url::parse(cfg.websocket_url.as_str())?;
+                let fb = flashblocks_cell
+                    .get_or_init(|| {
+                        Arc::new(FlashblocksState::new(
+                            ctx.provider().clone(),
+                            cfg.max_pending_blocks_depth,
+                        ))
+                    })
+                    .clone();
+                fb.start();
+
+                let mut flashblocks_client = FlashblocksSubscriber::new(fb.clone(), ws_url);
+                flashblocks_client.start();
+
+                let api_ext = EthApiExt::new(
+                    ctx.registry.eth_api().clone(),
+                    ctx.registry.eth_handlers().filter.clone(),
+                    fb.clone(),
+                );
+                ctx.modules.replace_configured(api_ext.into_rpc())?;
+
+                // Register the base_subscribe subscription endpoint
+                let base_pubsub = BasePubSub::new(fb);
+                ctx.modules.merge_configured(base_pubsub.into_rpc())?;
+            } else {
+                info!(message = "flashblocks integration is disabled");
+            }
+
+            Ok(())
+        })
+    }
+}

--- a/crates/runner/src/extensions/tracing.rs
+++ b/crates/runner/src/extensions/tracing.rs
@@ -1,0 +1,28 @@
+//! Contains the [TransactionTracingExtension] which wires up the `transaction-tracing`
+//! execution extension on the Base node builder.
+
+use base_reth_transaction_tracing::transaction_tracing_exex;
+
+use crate::{TracingConfig, extensions::OpBuilder};
+
+/// Helper struct that wires the transaction tracing ExEx into the node builder.
+#[derive(Debug, Clone, Copy)]
+pub struct TransactionTracingExtension {
+    /// Transaction tracing configuration flags.
+    pub config: TracingConfig,
+}
+
+impl TransactionTracingExtension {
+    /// Creates a new transaction tracing extension helper.
+    pub const fn new(config: TracingConfig) -> Self {
+        Self { config }
+    }
+
+    /// Applies the extension to the supplied builder.
+    pub fn apply(&self, builder: OpBuilder) -> OpBuilder {
+        let tracing = self.config;
+        builder.install_exex_if(tracing.enabled, "transaction-tracing", move |ctx| async move {
+            Ok(transaction_tracing_exex(ctx, tracing.logs_enabled))
+        })
+    }
+}

--- a/crates/runner/src/extensions/types.rs
+++ b/crates/runner/src/extensions/types.rs
@@ -1,5 +1,7 @@
 use std::sync::Arc;
 
+use base_reth_flashblocks_rpc::state::FlashblocksState;
+use once_cell::sync::OnceCell;
 use reth::{
     api::{FullNodeTypesAdapter, NodeTypesWithDBAdapter},
     builder::{Node, NodeBuilderWithComponents, WithLaunchContext},
@@ -14,3 +16,5 @@ type OpComponentsBuilder = <OpNode as Node<OpNodeTypes>>::ComponentsBuilder;
 type OpAddOns = <OpNode as Node<OpNodeTypes>>::AddOns;
 pub(crate) type OpBuilder =
     WithLaunchContext<NodeBuilderWithComponents<OpNodeTypes, OpComponentsBuilder, OpAddOns>>;
+
+pub(crate) type FlashblocksCell = Arc<OnceCell<Arc<FlashblocksState<OpProvider>>>>;

--- a/crates/runner/src/extensions/types.rs
+++ b/crates/runner/src/extensions/types.rs
@@ -1,0 +1,16 @@
+use std::sync::Arc;
+
+use reth::{
+    api::{FullNodeTypesAdapter, NodeTypesWithDBAdapter},
+    builder::{Node, NodeBuilderWithComponents, WithLaunchContext},
+    providers::providers::BlockchainProvider,
+};
+use reth_db::DatabaseEnv;
+use reth_optimism_node::OpNode;
+
+pub(crate) type OpProvider = BlockchainProvider<NodeTypesWithDBAdapter<OpNode, Arc<DatabaseEnv>>>;
+type OpNodeTypes = FullNodeTypesAdapter<OpNode, Arc<DatabaseEnv>, OpProvider>;
+type OpComponentsBuilder = <OpNode as Node<OpNodeTypes>>::ComponentsBuilder;
+type OpAddOns = <OpNode as Node<OpNodeTypes>>::AddOns;
+pub(crate) type OpBuilder =
+    WithLaunchContext<NodeBuilderWithComponents<OpNodeTypes, OpComponentsBuilder, OpAddOns>>;

--- a/crates/runner/src/lib.rs
+++ b/crates/runner/src/lib.rs
@@ -9,3 +9,6 @@ pub use builder::BaseNodeLauncher;
 
 mod config;
 pub use config::{BaseNodeConfig, FlashblocksConfig, TracingConfig};
+
+mod extensions;
+pub use extensions::{FlashblocksCanonExtension, TransactionTracingExtension};

--- a/crates/runner/src/lib.rs
+++ b/crates/runner/src/lib.rs
@@ -11,4 +11,4 @@ mod config;
 pub use config::{BaseNodeConfig, FlashblocksConfig, TracingConfig};
 
 mod extensions;
-pub use extensions::{FlashblocksCanonExtension, TransactionTracingExtension};
+pub use extensions::{BaseRpcExtension, FlashblocksCanonExtension, TransactionTracingExtension};

--- a/crates/runner/src/lib.rs
+++ b/crates/runner/src/lib.rs
@@ -4,8 +4,8 @@
 mod context;
 pub use context::BaseNodeBuilder;
 
-mod builder;
-pub use builder::BaseNodeLauncher;
+mod runner;
+pub use runner::BaseNodeRunner;
 
 mod config;
 pub use config::{BaseNodeConfig, FlashblocksConfig, TracingConfig};


### PR DESCRIPTION
### Description

Introduces extensions as a type. Instead of applying node builder methods directly on the builder, refactor the logic into "extensions". Extensions define node builder logic - for example execution extension installs - in a custom type. This opens the door to configuring the node builder through types rather than functional logic, improving modularization and testability. You can imagine down the road we further refactor the `BaseNodeRunner` to apply an arbitrary trait-abstracted list of typed extensions to the node builder. Then, hooking up a new extension can be done programmatically without needing to add inline code to the runner. It's not there yet but this is a step in a more programmatic direction.