### PR TITLE
chore(flashblocks): Modularize Types

### DIFF
--- a/crates/flashblocks/src/blocks.rs
+++ b/crates/flashblocks/src/blocks.rs
@@ -1,0 +1,33 @@
+//! Contains the [`Flashblock`] and [`Metadata`] types used in Flashblocks.
+
+use alloy_primitives::{Address, B256, U256, map::foldhash::HashMap};
+use alloy_rpc_types_engine::PayloadId;
+use reth_optimism_primitives::OpReceipt;
+use rollup_boost::{ExecutionPayloadBaseV1, ExecutionPayloadFlashblockDeltaV1};
+use serde::{Deserialize, Serialize};
+
+/// Metadata associated with a flashblock.
+#[derive(Debug, Deserialize, Serialize, Clone, Default)]
+pub struct Metadata {
+    /// Transaction receipts indexed by hash.
+    pub receipts: HashMap<B256, OpReceipt>,
+    /// Updated account balances.
+    pub new_account_balances: HashMap<Address, U256>,
+    /// Block number this flashblock belongs to.
+    pub block_number: u64,
+}
+
+/// A flashblock containing partial block data.
+#[derive(Debug, Clone)]
+pub struct Flashblock {
+    /// Unique payload identifier.
+    pub payload_id: PayloadId,
+    /// Index of this flashblock within the block.
+    pub index: u64,
+    /// Base payload data (only present on first flashblock).
+    pub base: Option<ExecutionPayloadBaseV1>,
+    /// Delta containing transactions and state changes.
+    pub diff: ExecutionPayloadFlashblockDeltaV1,
+    /// Associated metadata.
+    pub metadata: Metadata,
+}

--- a/crates/flashblocks/src/lib.rs
+++ b/crates/flashblocks/src/lib.rs
@@ -4,13 +4,19 @@
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
 
 mod metrics;
-pub(crate) use metrics::Metrics;
+pub use metrics::Metrics;
 
 mod pending_blocks;
+pub use pending_blocks::{PendingBlocks, PendingBlocksBuilder};
 
-pub mod state;
+mod state;
+pub use state::FlashblocksState;
 
-pub mod subscription;
-pub mod traits;
+mod subscription;
+pub use subscription::{FlashblocksReceiver, FlashblocksSubscriber};
 
-pub use pending_blocks::PendingBlocks;
+mod traits;
+pub use traits::{FlashblocksAPI, PendingBlocksAPI};
+
+mod blocks;
+pub use blocks::{Flashblock, Metadata};

--- a/crates/flashblocks/src/metrics.rs
+++ b/crates/flashblocks/src/metrics.rs
@@ -1,5 +1,8 @@
+//! Metrics for flashblocks.
+
 use metrics::{Counter, Gauge, Histogram};
 use metrics_derive::Metrics;
+
 /// Metrics for the `reth_flashblocks` component.
 /// Conventions:
 /// - Durations are recorded in seconds (histograms).
@@ -7,39 +10,50 @@ use metrics_derive::Metrics;
 /// - Gauges reflect the current value/state.
 #[derive(Metrics, Clone)]
 #[metrics(scope = "reth_flashblocks")]
-pub(crate) struct Metrics {
+pub struct Metrics {
+    /// Count of times upstream receiver was closed/errored.
     #[metric(describe = "Count of times upstream receiver was closed/errored")]
     pub upstream_errors: Counter,
 
+    /// Count of messages received from the upstream source.
     #[metric(describe = "Count of messages received from the upstream source")]
     pub upstream_messages: Counter,
 
+    /// Time taken to process a message.
     #[metric(describe = "Time taken to process a message")]
     pub block_processing_duration: Histogram,
 
+    /// Number of Flashblocks that arrive in an unexpected order.
     #[metric(describe = "Number of Flashblocks that arrive in an unexpected order")]
     pub unexpected_block_order: Counter,
 
+    /// Number of flashblocks contained within a single block.
     #[metric(describe = "Number of flashblocks in a block")]
     pub flashblocks_in_block: Histogram,
 
+    /// Count of times flashblocks are unable to be converted to blocks.
     #[metric(describe = "Count of times flashblocks are unable to be converted to blocks")]
     pub block_processing_error: Counter,
 
+    /// Count of times pending snapshot was cleared because canonical caught up.
     #[metric(
         describe = "Number of times pending snapshot was cleared because canonical caught up"
     )]
     pub pending_clear_catchup: Counter,
 
+    /// Number of times pending snapshot was cleared because of reorg.
     #[metric(describe = "Number of times pending snapshot was cleared because of reorg")]
     pub pending_clear_reorg: Counter,
 
+    /// Pending snapshot flashblock index (current).
     #[metric(describe = "Pending snapshot flashblock index (current)")]
     pub pending_snapshot_fb_index: Gauge,
 
+    /// Pending snapshot block number (current).
     #[metric(describe = "Pending snapshot block number (current)")]
     pub pending_snapshot_height: Gauge,
 
+    /// Total number of WebSocket reconnection attempts.
     #[metric(describe = "Total number of WebSocket reconnection attempts")]
     pub reconnect_attempts: Counter,
 }

--- a/crates/flashblocks/src/pending_blocks.rs
+++ b/crates/flashblocks/src/pending_blocks.rs
@@ -17,9 +17,11 @@ use reth::revm::{db::Cache, state::EvmState};
 use reth_rpc_convert::RpcTransaction;
 use reth_rpc_eth_api::{RpcBlock, RpcReceipt};
 
-use crate::{subscription::Flashblock, traits::PendingBlocksAPI};
+use crate::{Flashblock, PendingBlocksAPI};
 
-pub(crate) struct PendingBlocksBuilder {
+/// Builder for [`PendingBlocks`].
+#[derive(Debug)]
+pub struct PendingBlocksBuilder {
     flashblocks: Vec<Flashblock>,
     headers: Vec<Sealed<Header>>,
 

--- a/crates/flashblocks/src/state.rs
+++ b/crates/flashblocks/src/state.rs
@@ -43,11 +43,7 @@ use tokio::sync::{
 use tracing::{debug, error, info, warn};
 
 use crate::{
-    PendingBlocks,
-    metrics::Metrics,
-    pending_blocks::PendingBlocksBuilder,
-    subscription::{Flashblock, FlashblocksReceiver},
-    traits::FlashblocksAPI,
+    Flashblock, FlashblocksAPI, FlashblocksReceiver, Metrics, PendingBlocks, PendingBlocksBuilder,
 };
 
 // Buffer 4s of flashblocks for flashblock_sender

--- a/crates/flashblocks/tests/state.rs
+++ b/crates/flashblocks/tests/state.rs
@@ -9,9 +9,7 @@ use alloy_eips::{BlockHashOrNumber, Encodable2718};
 use alloy_primitives::{Address, B256, BlockNumber, Bytes, U256, hex, map::foldhash::HashMap};
 use alloy_rpc_types_engine::PayloadId;
 use base_reth_flashblocks::{
-    state::FlashblocksState,
-    subscription::{Flashblock, Metadata},
-    traits::{FlashblocksAPI, PendingBlocksAPI},
+    Flashblock, FlashblocksAPI, FlashblocksState, Metadata, PendingBlocksAPI,
 };
 use base_reth_test_utils::{
     accounts::TestAccounts, flashblocks_harness::FlashblocksHarness, node::LocalNodeProvider,

--- a/crates/rpc/src/base/pubsub.rs
+++ b/crates/rpc/src/base/pubsub.rs
@@ -2,7 +2,7 @@
 
 use std::sync::Arc;
 
-use base_reth_flashblocks::traits::FlashblocksAPI;
+use base_reth_flashblocks::FlashblocksAPI;
 use jsonrpsee::{
     PendingSubscriptionSink, SubscriptionSink,
     core::{SubscriptionResult, async_trait},

--- a/crates/rpc/src/eth/rpc.rs
+++ b/crates/rpc/src/eth/rpc.rs
@@ -13,7 +13,7 @@ use alloy_rpc_types::{
     state::{EvmOverrides, StateOverride, StateOverridesBuilder},
 };
 use alloy_rpc_types_eth::{Filter, Log};
-use base_reth_flashblocks::traits::{FlashblocksAPI, PendingBlocksAPI};
+use base_reth_flashblocks::{FlashblocksAPI, PendingBlocksAPI};
 use jsonrpsee::{
     core::{RpcResult, async_trait},
     proc_macros::rpc,

--- a/crates/rpc/tests/flashblocks_rpc.rs
+++ b/crates/rpc/tests/flashblocks_rpc.rs
@@ -14,7 +14,7 @@ use alloy_rpc_client::RpcClient;
 use alloy_rpc_types::simulate::{SimBlock, SimulatePayload};
 use alloy_rpc_types_engine::PayloadId;
 use alloy_rpc_types_eth::{TransactionInput, error::EthRpcErrorCode};
-use base_reth_flashblocks::subscription::{Flashblock, Metadata};
+use base_reth_flashblocks::{Flashblock, Metadata};
 use base_reth_test_utils::flashblocks_harness::FlashblocksHarness;
 use common::{BLOCK_INFO_TXN, BLOCK_INFO_TXN_HASH};
 use eyre::Result;

--- a/crates/runner/src/extensions/canon.rs
+++ b/crates/runner/src/extensions/canon.rs
@@ -3,7 +3,7 @@
 
 use std::sync::Arc;
 
-use base_reth_flashblocks::state::FlashblocksState;
+use base_reth_flashblocks::FlashblocksState;
 use futures_util::TryStreamExt;
 use reth_exex::ExExEvent;
 

--- a/crates/runner/src/extensions/rpc.rs
+++ b/crates/runner/src/extensions/rpc.rs
@@ -2,7 +2,7 @@
 
 use std::sync::Arc;
 
-use base_reth_flashblocks::{state::FlashblocksState, subscription::FlashblocksSubscriber};
+use base_reth_flashblocks::{FlashblocksState, FlashblocksSubscriber};
 use base_reth_rpc::{
     BasePubSub, BasePubSubApiServer, EthApiExt, EthApiOverrideServer, MeteringApiImpl,
     MeteringApiServer, TransactionStatusApiImpl, TransactionStatusApiServer,

--- a/crates/runner/src/extensions/types.rs
+++ b/crates/runner/src/extensions/types.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use base_reth_flashblocks::state::FlashblocksState;
+use base_reth_flashblocks::FlashblocksState;
 use once_cell::sync::OnceCell;
 use reth::{
     api::{FullNodeTypesAdapter, NodeTypesWithDBAdapter},

--- a/crates/test-utils/src/flashblocks_harness.rs
+++ b/crates/test-utils/src/flashblocks_harness.rs
@@ -2,7 +2,7 @@
 
 use std::sync::Arc;
 
-use base_reth_flashblocks::subscription::Flashblock;
+use base_reth_flashblocks::Flashblock;
 use derive_more::Deref;
 use eyre::Result;
 use futures_util::Future;

--- a/crates/test-utils/src/node.rs
+++ b/crates/test-utils/src/node.rs
@@ -10,10 +10,7 @@ use std::{
 use alloy_genesis::Genesis;
 use alloy_provider::RootProvider;
 use alloy_rpc_client::RpcClient;
-use base_reth_flashblocks::{
-    state::FlashblocksState,
-    subscription::{Flashblock, FlashblocksReceiver},
-};
+use base_reth_flashblocks::{Flashblock, FlashblocksReceiver, FlashblocksState};
 use base_reth_rpc::{BasePubSub, BasePubSubApiServer, EthApiExt, EthApiOverrideServer};
 use eyre::Result;
 use futures_util::Future;

--- a/lychee.toml
+++ b/lychee.toml
@@ -7,4 +7,5 @@ exclude = [
     'localhost',
     'https://img.shields.io/github/commit-activity/w/base/node-reth',
     'https://img.shields.io/github/issues-pr-raw/base/node-reth',
+    'https://rustup.rs/',
 ]


### PR DESCRIPTION
### Description

Pulls subscription types into a separate module with top-level crate exports. Avoids the need to specify `subscription` path on imports + makes progress on simplifying modules.