### PR TITLE
fix(rpc): check canonical chain first in tx lookups

### DIFF
--- a/crates/rpc/src/metrics.rs
+++ b/crates/rpc/src/metrics.rs
@@ -14,6 +14,9 @@ pub(crate) struct Metrics {
     #[metric(describe = "Count of times flashblocks get_transaction_receipt is called")]
     pub get_transaction_receipt: Counter,
 
+    #[metric(describe = "Count of times flashblocks get_transaction_by_hash is called")]
+    pub get_transaction_by_hash: Counter,
+
     #[metric(describe = "Count of times flashblocks get_balance is called")]
     pub get_balance: Counter,
 


### PR DESCRIPTION
## Root Cause
When canonical block commits, `newHeads` fires immediately. But StateProcessor hasn't cleared flashblock state yet, so tx lookups return stale data with flashblock's computed hash (from `seal_slow()`) instead of canonical hash.

## Fix
Check canonical chain first. If tx exists there, return authoritative version. Fall back to flashblocks only for truly pending transactions.

## Trade-off
Adds one DB lookup for pending tx queries, but ensures consistency.

Closes #251