### PR TITLE
feat(runner): Generic Extensions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1635,6 +1635,7 @@ dependencies = [
  "base-reth-cli",
  "base-reth-runner",
  "clap",
+ "once_cell",
  "reth-cli-util",
  "reth-optimism-cli",
  "reth-optimism-node",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1701,6 +1701,7 @@ dependencies = [
  "base-reth-flashblocks",
  "base-reth-rpc",
  "base-tracex",
+ "derive_more",
  "eyre",
  "futures-util",
  "once_cell",

--- a/bin/node/Cargo.toml
+++ b/bin/node/Cargo.toml
@@ -24,6 +24,7 @@ reth-cli-util.workspace = true
 
 # misc
 clap.workspace = true
+once_cell.workspace = true
 
 [features]
 default = []

--- a/bin/node/src/cli.rs
+++ b/bin/node/src/cli.rs
@@ -1,6 +1,9 @@
 //! Contains the CLI arguments
 
-use base_reth_runner::{BaseNodeConfig, FlashblocksConfig, TracingConfig};
+use std::sync::Arc;
+
+use base_reth_runner::{BaseNodeConfig, FlashblocksCell, FlashblocksConfig, TracingConfig};
+use once_cell::sync::OnceCell;
 use reth_optimism_node::args::RollupArgs;
 
 /// CLI Arguments
@@ -49,6 +52,7 @@ impl Args {
 
 impl From<Args> for BaseNodeConfig {
     fn from(args: Args) -> Self {
+        let flashblocks_cell: FlashblocksCell = Arc::new(OnceCell::new());
         let flashblocks = args.websocket_url.map(|websocket_url| FlashblocksConfig {
             websocket_url,
             max_pending_blocks_depth: args.max_pending_blocks_depth,
@@ -62,6 +66,7 @@ impl From<Args> for BaseNodeConfig {
                 logs_enabled: args.enable_transaction_tracing_logs,
             },
             metering_enabled: args.enable_metering,
+            flashblocks_cell,
         }
     }
 }

--- a/bin/node/src/main.rs
+++ b/bin/node/src/main.rs
@@ -5,7 +5,9 @@
 
 pub mod cli;
 
-use base_reth_runner::BaseNodeRunner;
+use base_reth_runner::{
+    BaseNodeRunner, BaseRpcExtension, FlashblocksCanonExtension, TransactionTracingExtension,
+};
 
 #[global_allocator]
 static ALLOC: reth_cli_util::allocator::Allocator = reth_cli_util::allocator::new_allocator();
@@ -21,7 +23,10 @@ fn main() {
 
     // Step 3: Hand the parsed CLI to the node runner so it can build and launch the Base node.
     cli.run(|builder, args| async move {
-        let runner = BaseNodeRunner::new(args);
+        let mut runner = BaseNodeRunner::new(args);
+        runner.install_ext::<FlashblocksCanonExtension>()?;
+        runner.install_ext::<TransactionTracingExtension>()?;
+        runner.install_ext::<BaseRpcExtension>()?;
         let handle = runner.run(builder);
         handle.await
     })

--- a/bin/node/src/main.rs
+++ b/bin/node/src/main.rs
@@ -22,8 +22,8 @@ fn main() {
     // Step 3: Hand the parsed CLI to the node runner so it can build and launch the Base node.
     cli.run(|builder, args| async move {
         let runner = BaseNodeRunner::new(args);
-        let handle = runner.build(builder).await?;
-        runner.run(handle).await
+        let handle = runner.run(builder);
+        handle.await
     })
     .unwrap();
 }

--- a/crates/runner/Cargo.toml
+++ b/crates/runner/Cargo.toml
@@ -30,3 +30,4 @@ futures-util.workspace = true
 once_cell.workspace = true
 tracing.workspace = true
 url.workspace = true
+derive_more = { workspace = true, features = ["debug"] }

--- a/crates/runner/src/config.rs
+++ b/crates/runner/src/config.rs
@@ -2,6 +2,8 @@
 
 use reth_optimism_node::args::RollupArgs;
 
+use crate::extensions::FlashblocksCell;
+
 /// Captures the pieces of CLI configuration that the node logic cares about.
 #[derive(Debug, Clone)]
 pub struct BaseNodeConfig {
@@ -13,6 +15,8 @@ pub struct BaseNodeConfig {
     pub tracing: TracingConfig,
     /// Indicates whether the metering RPC surface should be installed.
     pub metering_enabled: bool,
+    /// Shared Flashblocks state cache.
+    pub flashblocks_cell: FlashblocksCell,
 }
 
 impl BaseNodeConfig {

--- a/crates/runner/src/extensions/canon.rs
+++ b/crates/runner/src/extensions/canon.rs
@@ -8,8 +8,8 @@ use futures_util::TryStreamExt;
 use reth_exex::ExExEvent;
 
 use crate::{
-    FlashblocksConfig,
-    extensions::{FlashblocksCell, OpBuilder},
+    BaseNodeConfig, FlashblocksConfig,
+    extensions::{BaseNodeExtension, ConfigurableBaseNodeExtension, FlashblocksCell, OpBuilder},
 };
 
 /// Helper struct that wires the Flashblocks canon ExEx into the node builder.
@@ -23,12 +23,14 @@ pub struct FlashblocksCanonExtension {
 
 impl FlashblocksCanonExtension {
     /// Create a new Flashblocks canon extension helper.
-    pub const fn new(cell: FlashblocksCell, config: Option<FlashblocksConfig>) -> Self {
-        Self { cell, config }
+    pub fn new(config: &BaseNodeConfig) -> Self {
+        Self { cell: config.flashblocks_cell.clone(), config: config.flashblocks.clone() }
     }
+}
 
+impl BaseNodeExtension for FlashblocksCanonExtension {
     /// Applies the extension to the supplied builder.
-    pub fn apply(&self, builder: OpBuilder) -> OpBuilder {
+    fn apply(&self, builder: OpBuilder) -> OpBuilder {
         let flashblocks = self.config.clone();
         let flashblocks_enabled = flashblocks.is_some();
         let flashblocks_cell = self.cell.clone();
@@ -62,5 +64,11 @@ impl FlashblocksCanonExtension {
                 })
             }
         })
+    }
+}
+
+impl ConfigurableBaseNodeExtension for FlashblocksCanonExtension {
+    fn build(config: &BaseNodeConfig) -> eyre::Result<Self> {
+        Ok(Self::new(config))
     }
 }

--- a/crates/runner/src/extensions/extension.rs
+++ b/crates/runner/src/extensions/extension.rs
@@ -1,0 +1,19 @@
+//! Traits describing configurable node builder extensions.
+
+use std::fmt::Debug;
+
+use eyre::Result;
+
+use crate::{BaseNodeConfig, extensions::OpBuilder};
+
+/// A node builder extension that can apply additional wiring to the builder.
+pub trait BaseNodeExtension: Send + Sync + Debug {
+    /// Applies the extension to the supplied builder.
+    fn apply(&self, builder: OpBuilder) -> OpBuilder;
+}
+
+/// An extension that can be constructed from [`BaseNodeConfig`].
+pub trait ConfigurableBaseNodeExtension: BaseNodeExtension + Sized + 'static {
+    /// Builds the extension from the node config.
+    fn build(config: &BaseNodeConfig) -> Result<Self>;
+}

--- a/crates/runner/src/extensions/mod.rs
+++ b/crates/runner/src/extensions/mod.rs
@@ -3,6 +3,9 @@
 //! Builder extensions for the node nicely modularizes parts
 //! of the node building process.
 
+mod extension;
+pub use extension::{BaseNodeExtension, ConfigurableBaseNodeExtension};
+
 mod canon;
 pub use canon::FlashblocksCanonExtension;
 

--- a/crates/runner/src/handle.rs
+++ b/crates/runner/src/handle.rs
@@ -1,0 +1,66 @@
+use std::{
+    future::Future,
+    pin::Pin,
+    task::{Context, Poll},
+};
+
+use derive_more::Debug;
+use eyre::Result;
+use futures_util::{FutureExt, future::BoxFuture};
+use reth::builder::NodeHandleFor;
+use reth_optimism_node::OpNode;
+
+/// Handle to a launched Base node.
+///
+/// This wraps the underlying [`NodeHandleFor`] so callers can await it directly to wait for node
+/// shutdown.
+#[must_use = "Dropping the handle will stop the node immediately"]
+#[derive(Debug, Default)]
+pub struct BaseNodeHandle {
+    #[debug(skip)]
+    build_fut: Option<BoxFuture<'static, Result<NodeHandleFor<OpNode>>>>,
+    #[debug(skip)]
+    handle: Option<Box<NodeHandleFor<OpNode>>>,
+}
+
+impl BaseNodeHandle {
+    pub(crate) fn new(
+        fut: impl Future<Output = Result<NodeHandleFor<OpNode>>> + Send + 'static,
+    ) -> Self {
+        Self { build_fut: Some(fut.boxed()), handle: None }
+    }
+}
+
+impl Future for BaseNodeHandle {
+    type Output = Result<()>;
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        if let Some(build_fut) = self.build_fut.as_mut() {
+            match build_fut.as_mut().poll(cx) {
+                Poll::Pending => return Poll::Pending,
+                Poll::Ready(Ok(handle)) => {
+                    self.handle = Some(Box::new(handle));
+                    self.build_fut = None;
+                }
+                Poll::Ready(Err(err)) => {
+                    self.build_fut = None;
+                    return Poll::Ready(Err(err));
+                }
+            }
+        }
+
+        if let Some(handle) = self.handle.as_mut() {
+            // SAFETY: The handle is stored on the heap so its address is stable; we never move the
+            // inner value after taking this reference.
+            let node_exit_future = unsafe { Pin::new_unchecked(&mut handle.node_exit_future) };
+            let poll = node_exit_future.poll(cx);
+            if poll.is_ready() {
+                self.handle = None;
+            }
+            return poll;
+        }
+
+        // If neither future is present we completed successfully and have nothing left to drive.
+        Poll::Ready(Ok(()))
+    }
+}

--- a/crates/runner/src/lib.rs
+++ b/crates/runner/src/lib.rs
@@ -6,6 +6,9 @@
 mod context;
 pub use context::BaseNodeBuilder;
 
+mod handle;
+pub use handle::BaseNodeHandle;
+
 mod runner;
 pub use runner::BaseNodeRunner;
 

--- a/crates/runner/src/lib.rs
+++ b/crates/runner/src/lib.rs
@@ -17,6 +17,6 @@ pub use config::{BaseNodeConfig, FlashblocksConfig, TracingConfig};
 
 mod extensions;
 pub use extensions::{
-    BaseRpcExtension, FlashblocksCanonExtension, FlashblocksCell, OpBuilder, OpProvider,
-    TransactionTracingExtension,
+    BaseNodeExtension, BaseRpcExtension, ConfigurableBaseNodeExtension, FlashblocksCanonExtension,
+    FlashblocksCell, OpBuilder, OpProvider, TransactionTracingExtension,
 };

--- a/crates/runner/src/runner.rs
+++ b/crates/runner/src/runner.rs
@@ -1,9 +1,6 @@
 //! Contains the [`BaseNodeRunner`], which is responsible for configuring and launching a Base node.
 
-use std::sync::Arc;
-
 use eyre::Result;
-use once_cell::sync::OnceCell;
 use reth::{
     builder::{EngineNodeLauncher, Node, NodeHandleFor, TreeConfig},
     providers::providers::BlockchainProvider,
@@ -12,21 +9,23 @@ use reth_optimism_node::OpNode;
 use tracing::info;
 
 use crate::{
-    BaseNodeBuilder, BaseNodeConfig, BaseNodeHandle, BaseRpcExtension, FlashblocksCanonExtension,
-    TransactionTracingExtension,
+    BaseNodeBuilder, BaseNodeConfig, BaseNodeHandle,
+    extensions::{BaseNodeExtension, ConfigurableBaseNodeExtension},
 };
 
 /// Wraps the Base node configuration and orchestrates builder wiring.
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct BaseNodeRunner {
     /// Contains the configuration for the Base node.
     config: BaseNodeConfig,
+    /// Registered builder extensions.
+    extensions: Vec<Box<dyn BaseNodeExtension>>,
 }
 
 impl BaseNodeRunner {
     /// Creates a new launcher using the provided configuration.
     pub fn new(config: impl Into<BaseNodeConfig>) -> Self {
-        Self { config: config.into() }
+        Self { config: config.into(), extensions: Vec::new() }
     }
 
     /// Returns the underlying configuration, primarily for testing.
@@ -34,21 +33,30 @@ impl BaseNodeRunner {
         &self.config
     }
 
+    /// Registers a new builder extension constructed from the node configuration.
+    pub fn install_ext<E>(&mut self) -> Result<()>
+    where
+        E: ConfigurableBaseNodeExtension,
+    {
+        let extension = E::build(&self.config)?;
+        self.extensions.push(Box::new(extension));
+        Ok(())
+    }
+
     /// Applies all Base-specific wiring to the supplied builder, launches the node, and returns a handle that can be awaited.
-    pub fn run(&self, builder: BaseNodeBuilder) -> BaseNodeHandle {
-        BaseNodeHandle::new(Self::launch_node(self.config.clone(), builder))
+    pub fn run(self, builder: BaseNodeBuilder) -> BaseNodeHandle {
+        let Self { config, extensions } = self;
+        BaseNodeHandle::new(Self::launch_node(config, extensions, builder))
     }
 
     async fn launch_node(
         config: BaseNodeConfig,
+        extensions: Vec<Box<dyn BaseNodeExtension>>,
         builder: BaseNodeBuilder,
     ) -> Result<NodeHandleFor<OpNode>> {
         info!(target: "base-runner", "starting custom Base node");
 
         let op_node = OpNode::new(config.rollup_args.clone());
-
-        let flashblocks_cell = Arc::new(OnceCell::new());
-        let flashblocks_config = config.flashblocks.clone();
 
         let builder = builder
             .with_types_and_provider::<OpNode, BlockchainProvider<_>>()
@@ -56,22 +64,8 @@ impl BaseNodeRunner {
             .with_add_ons(op_node.add_ons())
             .on_component_initialized(move |_ctx| Ok(()));
 
-        // Apply the Flashblocks Canon extension
-        let flashblocks_extension =
-            FlashblocksCanonExtension::new(flashblocks_cell.clone(), flashblocks_config.clone());
-        let builder = flashblocks_extension.apply(builder);
-
-        // Apply the Transaction Tracing extension
-        let tracing_extension = TransactionTracingExtension::new(config.tracing);
-        let builder = tracing_extension.apply(builder);
-
-        let rpc_extension = BaseRpcExtension::new(
-            flashblocks_cell.clone(),
-            flashblocks_config.clone(),
-            config.metering_enabled,
-            config.rollup_args.sequencer.clone(),
-        );
-        let builder = rpc_extension.apply(builder);
+        let builder =
+            extensions.into_iter().fold(builder, |builder, extension| extension.apply(builder));
 
         builder
             .launch_with_fn(|builder| {


### PR DESCRIPTION
### Description

Refactored the runner to make extensions type-driven using newly created extension traits built from the `BaseNodeConfig`. Extensions can now be installed via a generic method: `install_ext::<T>()` (in the code snippet below we show this API change). In the node binary entrypoint, we now install extensions in this way - programmatically.

```rust
// bin/node/src/main.rs
cli.run(|builder, args| async move {
    let mut runner = BaseNodeRunner::new(args);
    runner.install_ext::<FlashblocksCanonExtension>()?;
    runner.install_ext::<TransactionTracingExtension>()?;
    runner.install_ext::<BaseRpcExtension>()?;
    runner.run(builder).await
})?;
```

To allow the flashblocks state to be shared through a `OnceCell`, we moved this instantiation into the `BaseNodeConfig`, so this type can be cloned by the extensions during construction. This is a temporary solution which should be improved down the road.