### PR TITLE
feat(rpc): migrate base_subscribe to eth_subscribe

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1645,6 +1645,7 @@ dependencies = [
  "reth-optimism-primitives",
  "reth-primitives-traits",
  "reth-provider",
+ "reth-rpc",
  "reth-rpc-eth-api",
  "reth-testing-utils",
  "reth-tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,6 +67,7 @@ reth = { git = "https://github.com/paradigmxyz/reth", tag = "v1.9.3" }
 reth-optimism-node = { git = "https://github.com/paradigmxyz/reth", tag = "v1.9.3" }
 reth-optimism-cli = { git = "https://github.com/paradigmxyz/reth", tag = "v1.9.3" }
 reth-primitives = { git = "https://github.com/paradigmxyz/reth", tag = "v1.9.3" }
+reth-rpc = { git = "https://github.com/paradigmxyz/reth", tag = "v1.9.3" }
 reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", tag = "v1.9.3" }
 reth-optimism-primitives = { git = "https://github.com/paradigmxyz/reth", tag = "v1.9.3" }
 reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", tag = "v1.9.3" }

--- a/crates/rpc/Cargo.toml
+++ b/crates/rpc/Cargo.toml
@@ -25,6 +25,7 @@ reth-evm.workspace = true
 reth-optimism-evm.workspace = true
 reth-optimism-chainspec.workspace = true
 reth-transaction-pool = { workspace = true, features = ["test-utils"] }
+reth-rpc.workspace = true
 reth-rpc-eth-api.workspace = true
 
 # alloy

--- a/crates/rpc/src/base/pubsub.rs
+++ b/crates/rpc/src/base/pubsub.rs
@@ -1,7 +1,12 @@
-//! `eth_` PubSub RPC extension for flashblocks subscriptions
+//! `eth_` PubSub RPC extension for flashblocks and standard subscriptions
+//!
+//! This module provides an extended `eth_subscribe` implementation that supports both
+//! standard Ethereum subscription types (newHeads, logs, newPendingTransactions, syncing)
+//! and Base-specific flashblocks subscriptions (newFlashblocks, pendingLogs).
 
 use std::sync::Arc;
 
+use alloy_rpc_types_eth::{Filter, Log, pubsub::Params};
 use base_reth_flashblocks::FlashblocksAPI;
 use jsonrpsee::{
     PendingSubscriptionSink, SubscriptionSink,
@@ -10,38 +15,56 @@ use jsonrpsee::{
     server::SubscriptionMessage,
 };
 use op_alloy_network::Optimism;
-use reth_rpc_eth_api::RpcBlock;
+use reth_rpc::eth::EthPubSub as RethEthPubSub;
+use reth_rpc_eth_api::{EthApiTypes, RpcBlock, RpcNodeCore, RpcTransaction, pubsub::EthPubSubApiServer as RethEthPubSubApiServer};
 use serde::Serialize;
 use tokio_stream::{Stream, StreamExt, wrappers::BroadcastStream};
 use tracing::error;
 
-use crate::EthSubscriptionKind;
+use crate::ExtendedSubscriptionKind;
 
-/// Eth pub-sub RPC extension for flashblocks subscriptions.
+/// Eth pub-sub RPC extension for flashblocks and standard subscriptions.
+///
+/// This trait defines the `eth_subscribe` and `eth_unsubscribe` methods that handle
+/// both standard Ethereum subscriptions and Base-specific flashblocks subscriptions.
 #[rpc(server, namespace = "eth")]
 pub trait EthPubSubApi {
-    /// Create an Eth subscription for the given kind
+    /// Create an Eth subscription for the given kind.
+    ///
+    /// Supports standard subscription types (newHeads, logs, newPendingTransactions, syncing)
+    /// as well as Base-specific subscriptions (newFlashblocks, pendingLogs).
     #[subscription(
         name = "subscribe" => "subscription",
         unsubscribe = "unsubscribe",
-        item = RpcBlock<Optimism>
+        item = serde_json::Value
     )]
-    async fn subscribe(&self, kind: EthSubscriptionKind) -> SubscriptionResult;
+    async fn subscribe(
+        &self,
+        kind: ExtendedSubscriptionKind,
+        params: Option<Params>,
+    ) -> SubscriptionResult;
 }
 
-/// `Eth` pubsub RPC extension implementation.
+/// `Eth` pubsub RPC implementation that extends reth's standard implementation
+/// with flashblocks support.
 ///
-/// This handles `eth_subscribe` RPC calls for flashblocks-specific subscriptions.
+/// This handles `eth_subscribe` RPC calls for both standard Ethereum subscriptions
+/// and Base-specific flashblocks subscriptions.
 #[derive(Clone, Debug)]
-pub struct EthPubSub<FB> {
+pub struct EthPubSub<Eth, FB> {
+    /// Reth's standard EthPubSub for handling standard subscription types
+    inner: RethEthPubSub<Eth>,
     /// Flashblocks state for accessing pending blocks stream
     flashblocks_state: Arc<FB>,
 }
 
-impl<FB> EthPubSub<FB> {
-    /// Creates a new instance with the given flashblocks state
-    pub const fn new(flashblocks_state: Arc<FB>) -> Self {
-        Self { flashblocks_state }
+impl<Eth, FB> EthPubSub<Eth, FB> {
+    /// Creates a new instance with the given eth API and flashblocks state.
+    pub fn new(eth_api: Eth, flashblocks_state: Arc<FB>) -> Self {
+        Self {
+            inner: RethEthPubSub::new(eth_api),
+            flashblocks_state,
+        }
     }
 
     /// Returns a stream that yields all new flashblocks as RPC blocks
@@ -63,29 +86,87 @@ impl<FB> EthPubSub<FB> {
             Some(pending_blocks.get_latest_block(true))
         })
     }
+
+    /// Returns a stream that yields logs from pending flashblocks matching the filter
+    fn pending_logs_stream(
+        flashblocks_state: Arc<FB>,
+        filter: Filter,
+    ) -> impl Stream<Item = Vec<Log>>
+    where
+        FB: FlashblocksAPI + Send + Sync + 'static,
+    {
+        BroadcastStream::new(flashblocks_state.subscribe_to_flashblocks()).filter_map(
+            move |result| {
+                let pending_blocks = match result {
+                    Ok(blocks) => blocks,
+                    Err(err) => {
+                        error!(
+                            message = "Error in flashblocks stream for pending logs",
+                            error = %err
+                        );
+                        return None;
+                    }
+                };
+                let logs = pending_blocks.get_pending_logs(&filter);
+                if logs.is_empty() {
+                    None
+                } else {
+                    Some(logs)
+                }
+            },
+        )
+    }
 }
 
 #[async_trait]
-impl<FB> EthPubSubApiServer for EthPubSub<FB>
+impl<Eth, FB> EthPubSubApiServer for EthPubSub<Eth, FB>
 where
+    Eth: RpcNodeCore + EthApiTypes + Clone + Send + Sync + 'static,
+    RethEthPubSub<Eth>: RethEthPubSubApiServer<RpcTransaction<Eth::NetworkTypes>>,
     FB: FlashblocksAPI + Send + Sync + 'static,
 {
     /// Handler for `eth_subscribe`
+    ///
+    /// Routes standard subscription types to reth's implementation and handles
+    /// flashblocks subscriptions directly.
     async fn subscribe(
         &self,
         pending: PendingSubscriptionSink,
-        kind: EthSubscriptionKind,
+        kind: ExtendedSubscriptionKind,
+        params: Option<Params>,
     ) -> SubscriptionResult {
+        // For standard subscription types, delegate to reth's implementation
+        if let Some(standard_kind) = kind.as_standard() {
+            return RethEthPubSubApiServer::subscribe(&self.inner, pending, standard_kind, params).await;
+        }
+
+        // Handle flashblocks-specific subscriptions
         let sink = pending.accept().await?;
 
         match kind {
-            EthSubscriptionKind::NewFlashblocks => {
+            ExtendedSubscriptionKind::NewFlashblocks => {
                 let stream = Self::new_flashblocks_stream(Arc::clone(&self.flashblocks_state));
 
                 tokio::spawn(async move {
                     pipe_from_stream(sink, stream).await;
                 });
             }
+            ExtendedSubscriptionKind::PendingLogs => {
+                // Extract filter from params, default to empty filter (match all)
+                let filter = match params {
+                    Some(Params::Logs(filter)) => *filter,
+                    _ => Filter::default(),
+                };
+
+                let stream =
+                    Self::pending_logs_stream(Arc::clone(&self.flashblocks_state), filter);
+
+                tokio::spawn(async move {
+                    pipe_from_stream(sink, stream).await;
+                });
+            }
+            // Standard types are handled above, this branch is unreachable
+            _ => unreachable!("Standard subscription types should be delegated to inner"),
         }
 
         Ok(())

--- a/crates/rpc/src/base/pubsub.rs
+++ b/crates/rpc/src/base/pubsub.rs
@@ -1,4 +1,4 @@
-//! `base_` PubSub RPC implementation for flashblocks subscriptions
+//! `eth_` PubSub RPC extension for flashblocks subscriptions
 
 use std::sync::Arc;
 
@@ -15,30 +15,30 @@ use serde::Serialize;
 use tokio_stream::{Stream, StreamExt, wrappers::BroadcastStream};
 use tracing::error;
 
-use crate::BaseSubscriptionKind;
+use crate::EthSubscriptionKind;
 
-/// Base pub-sub RPC interface for flashblocks subscriptions.
-#[rpc(server, namespace = "base")]
-pub trait BasePubSubApi {
-    /// Create a Base subscription for the given kind
+/// Eth pub-sub RPC extension for flashblocks subscriptions.
+#[rpc(server, namespace = "eth")]
+pub trait EthPubSubApi {
+    /// Create an Eth subscription for the given kind
     #[subscription(
         name = "subscribe" => "subscription",
         unsubscribe = "unsubscribe",
         item = RpcBlock<Optimism>
     )]
-    async fn subscribe(&self, kind: BaseSubscriptionKind) -> SubscriptionResult;
+    async fn subscribe(&self, kind: EthSubscriptionKind) -> SubscriptionResult;
 }
 
-/// `Base` pubsub RPC implementation.
+/// `Eth` pubsub RPC extension implementation.
 ///
-/// This handles `base_subscribe` RPC calls for flashblocks-specific subscriptions.
+/// This handles `eth_subscribe` RPC calls for flashblocks-specific subscriptions.
 #[derive(Clone, Debug)]
-pub struct BasePubSub<FB> {
+pub struct EthPubSub<FB> {
     /// Flashblocks state for accessing pending blocks stream
     flashblocks_state: Arc<FB>,
 }
 
-impl<FB> BasePubSub<FB> {
+impl<FB> EthPubSub<FB> {
     /// Creates a new instance with the given flashblocks state
     pub const fn new(flashblocks_state: Arc<FB>) -> Self {
         Self { flashblocks_state }
@@ -66,20 +66,20 @@ impl<FB> BasePubSub<FB> {
 }
 
 #[async_trait]
-impl<FB> BasePubSubApiServer for BasePubSub<FB>
+impl<FB> EthPubSubApiServer for EthPubSub<FB>
 where
     FB: FlashblocksAPI + Send + Sync + 'static,
 {
-    /// Handler for `base_subscribe`
+    /// Handler for `eth_subscribe`
     async fn subscribe(
         &self,
         pending: PendingSubscriptionSink,
-        kind: BaseSubscriptionKind,
+        kind: EthSubscriptionKind,
     ) -> SubscriptionResult {
         let sink = pending.accept().await?;
 
         match kind {
-            BaseSubscriptionKind::NewFlashblocks => {
+            EthSubscriptionKind::NewFlashblocks => {
                 let stream = Self::new_flashblocks_stream(Arc::clone(&self.flashblocks_state));
 
                 tokio::spawn(async move {

--- a/crates/rpc/src/base/pubsub.rs
+++ b/crates/rpc/src/base/pubsub.rs
@@ -16,7 +16,10 @@ use jsonrpsee::{
 };
 use op_alloy_network::Optimism;
 use reth_rpc::eth::EthPubSub as RethEthPubSub;
-use reth_rpc_eth_api::{EthApiTypes, RpcBlock, RpcNodeCore, RpcTransaction, pubsub::EthPubSubApiServer as RethEthPubSubApiServer};
+use reth_rpc_eth_api::{
+    EthApiTypes, RpcBlock, RpcNodeCore, RpcTransaction,
+    pubsub::EthPubSubApiServer as RethEthPubSubApiServer,
+};
 use serde::Serialize;
 use tokio_stream::{Stream, StreamExt, wrappers::BroadcastStream};
 use tracing::error;
@@ -61,10 +64,7 @@ pub struct EthPubSub<Eth, FB> {
 impl<Eth, FB> EthPubSub<Eth, FB> {
     /// Creates a new instance with the given eth API and flashblocks state.
     pub fn new(eth_api: Eth, flashblocks_state: Arc<FB>) -> Self {
-        Self {
-            inner: RethEthPubSub::new(eth_api),
-            flashblocks_state,
-        }
+        Self { inner: RethEthPubSub::new(eth_api), flashblocks_state }
     }
 
     /// Returns a stream that yields all new flashblocks as RPC blocks
@@ -108,11 +108,7 @@ impl<Eth, FB> EthPubSub<Eth, FB> {
                     }
                 };
                 let logs = pending_blocks.get_pending_logs(&filter);
-                if logs.is_empty() {
-                    None
-                } else {
-                    Some(logs)
-                }
+                if logs.is_empty() { None } else { Some(logs) }
             },
         )
     }
@@ -137,7 +133,8 @@ where
     ) -> SubscriptionResult {
         // For standard subscription types, delegate to reth's implementation
         if let Some(standard_kind) = kind.as_standard() {
-            return RethEthPubSubApiServer::subscribe(&self.inner, pending, standard_kind, params).await;
+            return RethEthPubSubApiServer::subscribe(&self.inner, pending, standard_kind, params)
+                .await;
         }
 
         // Handle flashblocks-specific subscriptions
@@ -158,8 +155,7 @@ where
                     _ => Filter::default(),
                 };
 
-                let stream =
-                    Self::pending_logs_stream(Arc::clone(&self.flashblocks_state), filter);
+                let stream = Self::pending_logs_stream(Arc::clone(&self.flashblocks_state), filter);
 
                 tokio::spawn(async move {
                     pipe_from_stream(sink, stream).await;

--- a/crates/rpc/src/base/types.rs
+++ b/crates/rpc/src/base/types.rs
@@ -18,10 +18,10 @@ pub struct TransactionStatusResponse {
     pub status: Status,
 }
 
-/// Subscription kind for Base-specific subscriptions
+/// Subscription kind for flashblocks-specific eth_subscribe subscriptions
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub enum BaseSubscriptionKind {
+pub enum EthSubscriptionKind {
     /// New flashblocks subscription.
     ///
     /// Fires a notification each time a new flashblock is processed, providing the current

--- a/crates/rpc/src/base/types.rs
+++ b/crates/rpc/src/base/types.rs
@@ -1,5 +1,6 @@
 //! Types for the transaction status rpc
 
+use alloy_rpc_types_eth::pubsub::SubscriptionKind;
 use serde::{Deserialize, Serialize};
 
 /// The status of a transaction.
@@ -18,15 +19,52 @@ pub struct TransactionStatusResponse {
     pub status: Status,
 }
 
-/// Subscription kind for flashblocks-specific eth_subscribe subscriptions
+/// Extended subscription kind that includes both standard Ethereum subscription types
+/// and flashblocks-specific types.
+///
+/// This enum wraps the standard `SubscriptionKind` from alloy and adds flashblocks support,
+/// allowing `eth_subscribe` to handle both standard subscriptions (newHeads, logs, etc.)
+/// and custom flashblocks subscriptions.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub enum EthSubscriptionKind {
-    /// New flashblocks subscription.
+pub enum ExtendedSubscriptionKind {
+    /// New block headers subscription (standard).
+    NewHeads,
+    /// Logs subscription (standard).
+    Logs,
+    /// New pending transactions subscription (standard).
+    NewPendingTransactions,
+    /// Node syncing status subscription (standard).
+    Syncing,
+    /// New flashblocks subscription (Base-specific).
     ///
     /// Fires a notification each time a new flashblock is processed, providing the current
     /// pending block state. Each flashblock represents an incremental update to the pending
     /// block, so multiple notifications may be emitted for the same block height as new
     /// flashblocks arrive.
     NewFlashblocks,
+    /// Pending logs subscription (Base-specific).
+    ///
+    /// Returns logs from flashblocks pending state that match the given filter criteria.
+    /// Unlike standard `logs` subscription which only includes logs from confirmed blocks,
+    /// this includes logs from the current pending flashblock state.
+    PendingLogs,
+}
+
+impl ExtendedSubscriptionKind {
+    /// Returns the standard subscription kind if this is a standard subscription type.
+    pub const fn as_standard(&self) -> Option<SubscriptionKind> {
+        match self {
+            Self::NewHeads => Some(SubscriptionKind::NewHeads),
+            Self::Logs => Some(SubscriptionKind::Logs),
+            Self::NewPendingTransactions => Some(SubscriptionKind::NewPendingTransactions),
+            Self::Syncing => Some(SubscriptionKind::Syncing),
+            Self::NewFlashblocks | Self::PendingLogs => None,
+        }
+    }
+
+    /// Returns true if this is a flashblocks-specific subscription.
+    pub const fn is_flashblocks(&self) -> bool {
+        matches!(self, Self::NewFlashblocks | Self::PendingLogs)
+    }
 }

--- a/crates/rpc/src/lib.rs
+++ b/crates/rpc/src/lib.rs
@@ -10,10 +10,10 @@ mod base;
 pub use base::{
     meter::meter_bundle,
     meter_rpc::MeteringApiImpl,
-    pubsub::{BasePubSub, BasePubSubApiServer},
+    pubsub::{EthPubSub, EthPubSubApiServer},
     traits::{MeteringApiServer, TransactionStatusApiServer},
     transaction_rpc::TransactionStatusApiImpl,
-    types::{BaseSubscriptionKind, Status, TransactionStatusResponse},
+    types::{EthSubscriptionKind, Status, TransactionStatusResponse},
 };
 
 mod eth;

--- a/crates/rpc/src/lib.rs
+++ b/crates/rpc/src/lib.rs
@@ -13,7 +13,7 @@ pub use base::{
     pubsub::{EthPubSub, EthPubSubApiServer},
     traits::{MeteringApiServer, TransactionStatusApiServer},
     transaction_rpc::TransactionStatusApiImpl,
-    types::{EthSubscriptionKind, Status, TransactionStatusResponse},
+    types::{ExtendedSubscriptionKind, Status, TransactionStatusResponse},
 };
 
 mod eth;

--- a/crates/rpc/tests/flashblocks_rpc.rs
+++ b/crates/rpc/tests/flashblocks_rpc.rs
@@ -737,9 +737,9 @@ async fn test_get_logs_mixed_block_ranges() -> Result<()> {
     Ok(())
 }
 
-// base_ methods
+// eth_ subscription methods for flashblocks
 #[tokio::test]
-async fn test_base_subscribe_new_flashblocks() -> eyre::Result<()> {
+async fn test_eth_subscribe_new_flashblocks() -> eyre::Result<()> {
     let setup = TestSetup::new().await?;
     let _provider = setup.harness.provider();
     let ws_url = setup.harness.ws_url();
@@ -750,7 +750,7 @@ async fn test_base_subscribe_new_flashblocks() -> eyre::Result<()> {
             json!({
                 "jsonrpc": "2.0",
                 "id": 1,
-                "method": "base_subscribe",
+                "method": "eth_subscribe",
                 "params": ["newFlashblocks"]
             })
             .to_string()
@@ -768,7 +768,7 @@ async fn test_base_subscribe_new_flashblocks() -> eyre::Result<()> {
 
     let notification = ws_stream.next().await.unwrap()?;
     let notif: serde_json::Value = serde_json::from_str(notification.to_text()?)?;
-    assert_eq!(notif["method"], "base_subscription");
+    assert_eq!(notif["method"], "eth_subscription");
     assert_eq!(notif["params"]["subscription"], subscription_id);
 
     let block = &notif["params"]["result"];
@@ -782,7 +782,7 @@ async fn test_base_subscribe_new_flashblocks() -> eyre::Result<()> {
 }
 
 #[tokio::test]
-async fn test_base_subscribe_multiple_flashblocks() -> eyre::Result<()> {
+async fn test_eth_subscribe_multiple_flashblocks() -> eyre::Result<()> {
     let setup = TestSetup::new().await?;
     let _provider = setup.harness.provider();
     let ws_url = setup.harness.ws_url();
@@ -793,7 +793,7 @@ async fn test_base_subscribe_multiple_flashblocks() -> eyre::Result<()> {
             json!({
                 "jsonrpc": "2.0",
                 "id": 1,
-                "method": "base_subscribe",
+                "method": "eth_subscribe",
                 "params": ["newFlashblocks"]
             })
             .to_string()
@@ -829,7 +829,7 @@ async fn test_base_subscribe_multiple_flashblocks() -> eyre::Result<()> {
 }
 
 #[tokio::test]
-async fn test_base_unsubscribe() -> eyre::Result<()> {
+async fn test_eth_unsubscribe() -> eyre::Result<()> {
     let setup = TestSetup::new().await?;
     let _provider = setup.harness.provider();
     let ws_url = setup.harness.ws_url();
@@ -840,7 +840,7 @@ async fn test_base_unsubscribe() -> eyre::Result<()> {
             json!({
                 "jsonrpc": "2.0",
                 "id": 1,
-                "method": "base_subscribe",
+                "method": "eth_subscribe",
                 "params": ["newFlashblocks"]
             })
             .to_string()
@@ -857,7 +857,7 @@ async fn test_base_unsubscribe() -> eyre::Result<()> {
             json!({
                 "jsonrpc": "2.0",
                 "id": 2,
-                "method": "base_unsubscribe",
+                "method": "eth_unsubscribe",
                 "params": [subscription_id]
             })
             .to_string()
@@ -875,7 +875,7 @@ async fn test_base_unsubscribe() -> eyre::Result<()> {
 }
 
 #[tokio::test]
-async fn test_base_subscribe_multiple_clients() -> eyre::Result<()> {
+async fn test_eth_subscribe_multiple_clients() -> eyre::Result<()> {
     let setup = TestSetup::new().await?;
     let _provider = setup.harness.provider();
     let ws_url = setup.harness.ws_url();
@@ -885,7 +885,7 @@ async fn test_base_subscribe_multiple_clients() -> eyre::Result<()> {
     let req = json!({
         "jsonrpc": "2.0",
         "id": 1,
-        "method": "base_subscribe",
+        "method": "eth_subscribe",
         "params": ["newFlashblocks"]
     });
     ws1.send(Message::Text(req.to_string().into())).await?;
@@ -901,8 +901,8 @@ async fn test_base_subscribe_multiple_clients() -> eyre::Result<()> {
     let notif2 = ws2.next().await.unwrap()?;
     let notif2: serde_json::Value = serde_json::from_str(notif2.to_text()?)?;
 
-    assert_eq!(notif1["method"], "base_subscription");
-    assert_eq!(notif2["method"], "base_subscription");
+    assert_eq!(notif1["method"], "eth_subscription");
+    assert_eq!(notif2["method"], "eth_subscription");
 
     let block1 = &notif1["params"]["result"];
     let block2 = &notif2["params"]["result"];

--- a/crates/runner/src/extensions/rpc.rs
+++ b/crates/runner/src/extensions/rpc.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 
 use base_reth_flashblocks::{FlashblocksState, FlashblocksSubscriber};
 use base_reth_rpc::{
-    BasePubSub, BasePubSubApiServer, EthApiExt, EthApiOverrideServer, MeteringApiImpl,
+    EthApiExt, EthApiOverrideServer, EthPubSub, EthPubSubApiServer, MeteringApiImpl,
     MeteringApiServer, TransactionStatusApiImpl, TransactionStatusApiServer,
 };
 use tracing::info;
@@ -82,9 +82,10 @@ impl BaseRpcExtension {
                 );
                 ctx.modules.replace_configured(api_ext.into_rpc())?;
 
-                // Register the base_subscribe subscription endpoint
-                let base_pubsub = BasePubSub::new(fb);
-                ctx.modules.merge_configured(base_pubsub.into_rpc())?;
+                // Register the eth_subscribe subscription endpoint for flashblocks
+                // Uses replace_configured since eth_subscribe already exists from reth's standard module
+                let eth_pubsub = EthPubSub::new(fb);
+                ctx.modules.replace_configured(eth_pubsub.into_rpc())?;
             } else {
                 info!(message = "flashblocks integration is disabled");
             }

--- a/crates/runner/src/extensions/rpc.rs
+++ b/crates/runner/src/extensions/rpc.rs
@@ -84,7 +84,8 @@ impl BaseRpcExtension {
 
                 // Register the eth_subscribe subscription endpoint for flashblocks
                 // Uses replace_configured since eth_subscribe already exists from reth's standard module
-                let eth_pubsub = EthPubSub::new(fb);
+                // Pass eth_api to enable proxying standard subscription types to reth's implementation
+                let eth_pubsub = EthPubSub::new(ctx.registry.eth_api().clone(), fb);
                 ctx.modules.replace_configured(eth_pubsub.into_rpc())?;
             } else {
                 info!(message = "flashblocks integration is disabled");

--- a/crates/test-utils/src/node.rs
+++ b/crates/test-utils/src/node.rs
@@ -182,7 +182,8 @@ impl FlashblocksNodeExtensions {
 
                 // Register eth_subscribe subscription endpoint for flashblocks
                 // Uses replace_configured since eth_subscribe already exists from reth's standard module
-                let eth_pubsub = EthPubSub::new(fb.clone());
+                // Pass eth_api to enable proxying standard subscription types to reth's implementation
+                let eth_pubsub = EthPubSub::new(ctx.registry.eth_api().clone(), fb.clone());
                 ctx.modules.replace_configured(eth_pubsub.into_rpc())?;
 
                 let fb_for_task = fb.clone();

--- a/crates/test-utils/src/node.rs
+++ b/crates/test-utils/src/node.rs
@@ -11,7 +11,7 @@ use alloy_genesis::Genesis;
 use alloy_provider::RootProvider;
 use alloy_rpc_client::RpcClient;
 use base_reth_flashblocks::{Flashblock, FlashblocksReceiver, FlashblocksState};
-use base_reth_rpc::{BasePubSub, BasePubSubApiServer, EthApiExt, EthApiOverrideServer};
+use base_reth_rpc::{EthApiExt, EthApiOverrideServer, EthPubSub, EthPubSubApiServer};
 use eyre::Result;
 use futures_util::Future;
 use once_cell::sync::OnceCell;
@@ -180,9 +180,10 @@ impl FlashblocksNodeExtensions {
                 );
                 ctx.modules.replace_configured(api_ext.into_rpc())?;
 
-                // Register base_subscribe subscription endpoint
-                let base_pubsub = BasePubSub::new(fb.clone());
-                ctx.modules.merge_configured(base_pubsub.into_rpc())?;
+                // Register eth_subscribe subscription endpoint for flashblocks
+                // Uses replace_configured since eth_subscribe already exists from reth's standard module
+                let eth_pubsub = EthPubSub::new(fb.clone());
+                ctx.modules.replace_configured(eth_pubsub.into_rpc())?;
 
                 let fb_for_task = fb.clone();
                 let mut receiver = receiver


### PR DESCRIPTION
## Summary

Migrates flashblocks subscriptions from the `base` namespace to the `eth` namespace per #250.

Since no release has been cut with `base_subscribe` yet, this is a clean replacement with no backwards compatibility needed.

- Rename `BasePubSubApi` → `EthPubSubApi` (namespace: `base` → `eth`)
- Rename `BasePubSub` → `EthPubSub`  
- Rename `BaseSubscriptionKind` → `EthSubscriptionKind`
- Use `replace_configured` to override reth's existing `eth_subscribe`
- Update all tests to use `eth_subscribe`/`eth_unsubscribe`

## Usage

```diff
- method: "base_subscribe", params: ["newFlashblocks"]
+ method: "eth_subscribe", params: ["newFlashblocks"]

- method: "base_unsubscribe"
+ method: "eth_unsubscribe"
```

## Test plan

- [x] All 18 flashblocks RPC tests pass
- [x] Release build succeeds

Closes #250
