### PR TITLE
chore(rpc): Properly Extend Subscription Kind

### DIFF
--- a/crates/rpc/src/lib.rs
+++ b/crates/rpc/src/lib.rs
@@ -13,7 +13,7 @@ pub use base::{
     pubsub::{EthPubSub, EthPubSubApiServer},
     traits::{MeteringApiServer, TransactionStatusApiServer},
     transaction_rpc::TransactionStatusApiImpl,
-    types::{ExtendedSubscriptionKind, Status, TransactionStatusResponse},
+    types::{BaseSubscriptionKind, ExtendedSubscriptionKind, Status, TransactionStatusResponse},
 };
 
 mod eth;


### PR DESCRIPTION
### Description

Refactors ExtendedSubscriptionKind to encapsulate the SubscriptionKind enum from alloy rather than redefining its variants. This ensures we automatically inherit support for any new subscription types added upstream, or get a compile error if the signature changes. Addresses feedback from #272.