### PR TITLE
perf(flashblocks): Remove Clones

### DIFF
--- a/crates/flashblocks/src/state.rs
+++ b/crates/flashblocks/src/state.rs
@@ -68,16 +68,14 @@ where
     }
 
     /// Handles a canonical block being received.
-    pub fn on_canonical_block_received(&self, block: &RecoveredBlock<OpBlock>) {
-        match self.queue.send(StateUpdate::Canonical(block.clone())) {
+    pub fn on_canonical_block_received(&self, block: RecoveredBlock<OpBlock>) {
+        let block_number = block.number;
+        match self.queue.send(StateUpdate::Canonical(block)) {
             Ok(_) => {
-                info!(
-                    message = "added canonical block to processing queue",
-                    block_number = block.number
-                )
+                info!(message = "added canonical block to processing queue", block_number)
             }
             Err(e) => {
-                error!(message = "could not add canonical block to processing queue", block_number = block.number, error = %e);
+                error!(message = "could not add canonical block to processing queue", block_number, error = %e);
             }
         }
     }
@@ -85,16 +83,17 @@ where
 
 impl<Client> FlashblocksReceiver for FlashblocksState<Client> {
     fn on_flashblock_received(&self, flashblock: Flashblock) {
-        match self.queue.send(StateUpdate::Flashblock(flashblock.clone())) {
+        let flashblock_index = flashblock.index;
+        let block_number = flashblock.metadata.block_number;
+        match self.queue.send(StateUpdate::Flashblock(flashblock)) {
             Ok(_) => {
                 info!(
                     message = "added flashblock to processing queue",
-                    block_number = flashblock.metadata.block_number,
-                    flashblock_index = flashblock.index
+                    block_number, flashblock_index,
                 );
             }
             Err(e) => {
-                error!(message = "could not add flashblock to processing queue", block_number = flashblock.metadata.block_number, flashblock_index = flashblock.index, error = %e);
+                error!(message = "could not add flashblock to processing queue", block_number, flashblock_index, error = %e);
             }
         }
     }

--- a/crates/flashblocks/tests/state.rs
+++ b/crates/flashblocks/tests/state.rs
@@ -62,7 +62,7 @@ impl TestHarness {
             .expect("block exists")
             .try_into_recovered()
             .expect("able to recover block");
-        flashblocks.on_canonical_block_received(&genesis_block);
+        flashblocks.on_canonical_block_received(genesis_block);
 
         let accounts: TestAccounts = node.accounts().clone();
 
@@ -209,7 +209,7 @@ impl TestHarness {
 
     async fn new_canonical_block(&mut self, user_transactions: Vec<OpTransactionSigned>) {
         let block = self.new_canonical_block_without_processing(user_transactions).await;
-        self.flashblocks.on_canonical_block_received(&block);
+        self.flashblocks.on_canonical_block_received(block);
         sleep(Duration::from_millis(SLEEP_TIME)).await;
     }
 }

--- a/crates/runner/src/extensions/canon.rs
+++ b/crates/runner/src/extensions/canon.rs
@@ -52,12 +52,12 @@ impl BaseNodeExtension for FlashblocksCanonExtension {
                 Ok(async move {
                     while let Some(note) = ctx.notifications.try_next().await? {
                         if let Some(committed) = note.committed_chain() {
-                            for block in committed.blocks_iter() {
+                            let tip = committed.tip().num_hash();
+                            let chain = Arc::unwrap_or_clone(committed);
+                            for (_, block) in chain.into_blocks() {
                                 fb.on_canonical_block_received(block);
                             }
-                            let _ = ctx
-                                .events
-                                .send(ExExEvent::FinishedHeight(committed.tip().num_hash()));
+                            let _ = ctx.events.send(ExExEvent::FinishedHeight(tip));
                         }
                     }
                     Ok(())


### PR DESCRIPTION
### Description

Removes unnecessary clones in flashblocks state handling to reduce memory allocations.

Changed the `on_canonical_block_received` method to accept `RecoveredBlock` by value instead of by reference, avoiding a clone before sending it to the queue. Similarly, `on_flashblock_received` now extracts metadata fields before moving the flashblocks into the queue. The canon extension uses `Arc::unwrap_or_clone` with `into_blocks` to take ownership of blocks from the committed chain rather than iterating by reference and cloning each block.