### PR TITLE
feat(rpc): add newFlashblockTransactions subscription type

### DIFF
--- a/crates/flashblocks/src/pending_blocks.rs
+++ b/crates/flashblocks/src/pending_blocks.rs
@@ -280,6 +280,16 @@ impl PendingBlocks {
 
         logs
     }
+
+    /// Returns all pending transactions from flashblocks.
+    pub fn get_pending_transactions(&self) -> Vec<Transaction> {
+        self.transactions.clone()
+    }
+
+    /// Returns the hashes of all pending transactions from flashblocks.
+    pub fn get_pending_transaction_hashes(&self) -> Vec<B256> {
+        self.transactions.iter().map(|tx| tx.tx_hash()).collect()
+    }
 }
 
 impl PendingBlocksAPI for Guard<Option<Arc<PendingBlocks>>> {

--- a/crates/rpc/src/base/types.rs
+++ b/crates/rpc/src/base/types.rs
@@ -57,6 +57,16 @@ pub enum BaseSubscriptionKind {
     /// Unlike standard `logs` subscription which only includes logs from confirmed blocks,
     /// this includes logs from the current pending flashblock state.
     PendingLogs,
+    /// New flashblock transactions subscription.
+    ///
+    /// Returns transactions from flashblocks as they are sequenced, providing higher inclusion
+    /// confidence than standard `newPendingTransactions` which returns mempool transactions.
+    /// Flashblock transactions have been included by the sequencer and are effectively preconfirmed.
+    ///
+    /// Accepts an optional boolean parameter:
+    /// - `true`: Returns full transaction objects
+    /// - `false` (default): Returns only transaction hashes
+    NewFlashblockTransactions,
 }
 
 impl ExtendedSubscriptionKind {


### PR DESCRIPTION
## Summary
- Adds `newFlashblockTransactions` subscription to `eth_subscribe` for streaming transactions from flashblocks as they're sequenced
- Higher inclusion confidence than `newPendingTransactions` since transactions are already included by the sequencer
- Supports optional boolean param: `true` for full tx objects, `false`/omitted for hashes only

## Changes
- `NewFlashblockTransactions` variant in `BaseSubscriptionKind`
- `get_pending_transactions()` / `get_pending_transaction_hashes()` on `PendingBlocks`
- Stream functions and subscription handler in pubsub
- Tests for both modes

## Test plan
- [x] `test_eth_subscribe_new_flashblock_transactions_hashes` - verifies hash-only mode
- [x] `test_eth_subscribe_new_flashblock_transactions_full` - verifies full transaction mode
- [x] All existing flashblocks RPC tests pass

Closes #280