### PR TITLE
fix(docker): update runtime image to 24.04

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ COPY . .
 RUN cargo build --release --bin base-reth-node
 
 # --- Runtime image ---
-FROM ubuntu:22.04
+FROM ubuntu:24.04
 
 RUN apt-get update && \
     apt-get install -y jq curl && \


### PR DESCRIPTION
Previous Dockerfile had a discrepancy between the builder image and the runtime image using different `libc` versions that were incompatible, making running the image not possible:

```bash
sha-64f964b8d904782489c470890c5d1b5c2dd4b31e: Pulling from base/node-reth-dev
0ec3d8645767: Pull complete
d4b2972eb5b3: Pull complete
c03222be4b75: Pull complete
5d50291df17c: Pull complete
Digest: sha256:76d5c97a202db2f34c886fb35adba0059779521b01b83c02cbe05036fda351e2
Status: Downloaded newer image for ghcr.io/base/node-reth-dev:sha-64f964b8d904782489c470890c5d1b5c2dd4b31e
./base-reth-node: /lib/aarch64-linux-gnu/libc.so.6: version `GLIBC_2.39' not found (required by ./base-reth-node)
./base-reth-node: /lib/aarch64-linux-gnu/libc.so.6: version `GLIBC_2.38' not found (required by ./base-reth-node)
```

Updating the runtime image to `ubuntu:24.04` fixes it 

Sidenote: should we be producing a statically linked binary instead?
