### PR TITLE
fix: Replace RPC's with RPCs in README

### DIFF
--- a/crates/rpc/README.md
+++ b/crates/rpc/README.md
@@ -1,7 +1,7 @@
 ## Base Reth Node RPC
 
 This crate provides all the extensions and modifications
-to the RPC's for Base Reth Nodes.
+to the RPCs for Base Reth Nodes.
 
 ### Base
 


### PR DESCRIPTION

## Summary
Fixed grammatical error in `crates/rpc/README.md` by replacing `RPC's` with `RPCs`.
