### PR TITLE
docs: refine runner and flashblocks READMEs

### DIFF
--- a/crates/flashblocks/README.md
+++ b/crates/flashblocks/README.md
@@ -1,6 +1,6 @@
 # Flashblocks State
 
-This crate subscribes to Flashblocks & combines the state
+This crate subscribes to Flashblocks and combines the state
 with the canonical block stream, to keep a consistent view
 of pending transactions, blocks, and receipts before
 they are finalized on-chain.

--- a/crates/runner/README.md
+++ b/crates/runner/README.md
@@ -2,5 +2,5 @@
 
 This crate hosts the Base-specific node launcher that wires together the Optimism node
 components, execution extensions, and RPC add-ons that run inside the Base node binary.
-It exposes the types that the CLI uses to build a node and hand those pieces to Optimism's
+It exposes the types that the CLI uses to build a node and pass those pieces to Optimism's
 `Cli` runner.


### PR DESCRIPTION

Polish wording and clarity in `crates/runner/README.md` and `crates/flashblocks/README.md`.

- `crates/flashblocks/README.md`: Replace `&` with `and` for clearer, more formal wording.
- `crates/runner/README.md`: Improve phrasing ("hand those pieces" → "pass those pieces") for better readability.

