### PR TITLE
fix: typo in Base node CLI pending blocks description

### DIFF
--- a/bin/node/src/cli.rs
+++ b/bin/node/src/cli.rs
@@ -18,7 +18,7 @@ pub struct Args {
     #[arg(long = "websocket-url", value_name = "WEBSOCKET_URL")]
     pub websocket_url: Option<String>,
 
-    /// The mac pending blocks depth.
+    /// The max pending blocks depth.
     #[arg(
         long = "max-pending-blocks-depth",
         value_name = "MAX_PENDING_BLOCKS_DEPTH",


### PR DESCRIPTION
Corrects a typo in the CLI argument documentation for `max_pending_blocks_depth` in `bin/node/src/cli.rs` (`mac` → `max`).  
