### PR TITLE
fix(flashblocks): enable TLS for websocket connections

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11612,7 +11612,9 @@ checksum = "d25a406cddcc431a75d3d9afc6a7c0f7428d4891dd973e4d54c56b46127bf857"
 dependencies = [
  "futures-util",
  "log",
+ "native-tls",
  "tokio",
+ "tokio-native-tls",
  "tungstenite 0.28.0",
 ]
 
@@ -12027,6 +12029,7 @@ dependencies = [
  "http",
  "httparse",
  "log",
+ "native-tls",
  "rand 0.9.2",
  "sha1",
  "thiserror 2.0.17",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -125,7 +125,7 @@ op-alloy-rpc-types-engine = "0.22.0"
 # tokio
 tokio = "1.48.0"
 tokio-stream = "0.1.17"
-tokio-tungstenite = "0.28.0"
+tokio-tungstenite = { version = "0.28.0", features = ["native-tls"] }
 
 # async
 futures = "0.3.31"


### PR DESCRIPTION
### Description
Ensure the Flashblocks websocket subscription can support TLS connections. Previously we inherited this from rollup-boost. 