### PR TITLE
feat: remove metadata receipts and account balances

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1501,7 +1501,6 @@ dependencies = [
  "brotli",
  "bytes",
  "derive_more",
- "reth-optimism-primitives",
  "rstest",
  "serde",
  "serde_json",
@@ -1524,6 +1523,7 @@ version = "0.2.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
+ "alloy-op-evm",
  "alloy-primitives",
  "alloy-provider",
  "alloy-rpc-client",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -116,6 +116,7 @@ alloy-rpc-types-eth = "1.0.41"
 alloy-rpc-types-engine = "1.0.41"
 
 # op-alloy
+alloy-op-evm = { version = "0.23.3", default-features = false }
 op-alloy-network = "0.22.0"
 op-alloy-rpc-types = "0.22.0"
 op-alloy-consensus = "0.22.0"

--- a/crates/flashblocks/Cargo.toml
+++ b/crates/flashblocks/Cargo.toml
@@ -32,6 +32,7 @@ alloy-provider.workspace = true
 alloy-rpc-types.workspace = true
 alloy-consensus.workspace = true
 alloy-primitives.workspace = true
+alloy-op-evm.workspace = true
 alloy-rpc-types-eth.workspace = true
 alloy-rpc-types-engine.workspace = true
 

--- a/crates/flashblocks/benches/pending_state.rs
+++ b/crates/flashblocks/benches/pending_state.rs
@@ -5,9 +5,8 @@ use std::{
     time::{Duration, Instant},
 };
 
-use alloy_consensus::Receipt;
 use alloy_eips::{BlockHashOrNumber, Encodable2718};
-use alloy_primitives::{Address, B256, BlockNumber, Bytes, U256, b256, bytes, hex::FromHex};
+use alloy_primitives::{Address, B256, BlockNumber, Bytes, U256, bytes, hex::FromHex};
 use alloy_rpc_types_engine::PayloadId;
 use base_flashtypes::{
     ExecutionPayloadBaseV1, ExecutionPayloadFlashblockDeltaV1, Flashblock, Metadata,
@@ -15,13 +14,12 @@ use base_flashtypes::{
 use base_reth_flashblocks::{FlashblocksAPI, FlashblocksReceiver, FlashblocksState};
 use base_reth_test_utils::{LocalNodeProvider, TestAccounts, TestHarness};
 use criterion::{BatchSize, Criterion, Throughput, criterion_group, criterion_main};
-use op_alloy_consensus::OpDepositReceipt;
 use reth::{
     chainspec::{ChainSpecProvider, EthChainSpec},
     providers::BlockReader,
     transaction_pool::test_utils::TransactionBuilder,
 };
-use reth_optimism_primitives::{OpBlock, OpReceipt, OpTransactionSigned};
+use reth_optimism_primitives::{OpBlock, OpTransactionSigned};
 use reth_primitives_traits::{Block as BlockT, RecoveredBlock};
 use tokio::{runtime::Runtime, time::sleep};
 use tracing_subscriber::{EnvFilter, filter::LevelFilter};
@@ -33,8 +31,6 @@ const CHUNK_SIZE: usize = 10;
 const BLOCK_INFO_TXN: Bytes = bytes!(
     "0x7ef90104a06c0c775b6b492bab9d7e81abdf27f77cafb698551226455a82f559e0f93fea3794deaddeaddeaddeaddeaddeaddeaddeaddead00019442000000000000000000000000000000000000158080830f424080b8b0098999be000008dd00101c1200000000000000020000000068869d6300000000015f277f000000000000000000000000000000000000000000000000000000000d42ac290000000000000000000000000000000000000000000000000000000000000001abf52777e63959936b1bf633a2a643f0da38d63deffe49452fed1bf8a44975d50000000000000000000000005050f69a9786f081509234f1a7f4684b5e5b76c9000000000000000000000000"
 );
-const BLOCK_INFO_TXN_HASH: B256 =
-    b256!("0xba56c8b0deb460ff070f8fca8e2ee01e51a3db27841cc862fdd94cc1a47662b6");
 
 struct BenchSetup {
     provider: LocalNodeProvider,
@@ -203,20 +199,6 @@ fn base_flashblock(
     canonical_block: &RecoveredBlock<OpBlock>,
     block_number: BlockNumber,
 ) -> Flashblock {
-    let mut receipts = alloy_primitives::map::HashMap::default();
-    receipts.insert(
-        BLOCK_INFO_TXN_HASH,
-        OpReceipt::Deposit(OpDepositReceipt {
-            inner: Receipt {
-                status: true.into(),
-                cumulative_gas_used: DEPOSIT_GAS_USED,
-                logs: vec![],
-            },
-            deposit_nonce: Some(0),
-            deposit_receipt_version: None,
-        }),
-    );
-
     Flashblock {
         payload_id: PayloadId::default(),
         index: 0,
@@ -242,7 +224,7 @@ fn base_flashblock(
             transactions: vec![BLOCK_INFO_TXN.clone()],
             blob_gas_used: Default::default(),
         },
-        metadata: Metadata { block_number, receipts, new_account_balances: Default::default() },
+        metadata: Metadata { block_number },
     }
 }
 
@@ -252,20 +234,11 @@ fn transaction_flashblock(
     transactions: &[OpTransactionSigned],
     gas_used: &mut u64,
 ) -> Flashblock {
-    let mut tx_receipts = alloy_primitives::map::HashMap::default();
     let mut tx_bytes = Vec::with_capacity(transactions.len());
 
     for tx in transactions {
         *gas_used += TX_GAS_USED;
         tx_bytes.push(tx.encoded_2718().into());
-        tx_receipts.insert(
-            tx.hash().clone(),
-            OpReceipt::Eip1559(Receipt {
-                status: true.into(),
-                cumulative_gas_used: *gas_used,
-                logs: vec![],
-            }),
-        );
     }
 
     Flashblock {
@@ -283,11 +256,7 @@ fn transaction_flashblock(
             transactions: tx_bytes,
             blob_gas_used: Default::default(),
         },
-        metadata: Metadata {
-            block_number,
-            receipts: tx_receipts,
-            new_account_balances: Default::default(),
-        },
+        metadata: Metadata { block_number },
     }
 }
 

--- a/crates/flashblocks/src/processor.rs
+++ b/crates/flashblocks/src/processor.rs
@@ -7,18 +7,19 @@ use std::{
 };
 
 use alloy_consensus::{
-    Header, TxReceipt,
+    Eip658Value, Header, TxReceipt,
     transaction::{Recovered, SignerRecoverable, TransactionMeta},
 };
 use alloy_eips::BlockNumberOrTag;
-use alloy_primitives::{Address, B256, BlockNumber, Bytes, Sealable, map::foldhash::HashMap};
+use alloy_op_evm::block::receipt_builder::OpReceiptBuilder;
+use alloy_primitives::{Address, B256, BlockNumber, Bytes, Sealable};
 use alloy_rpc_types::{TransactionTrait, Withdrawal};
 use alloy_rpc_types_engine::{ExecutionPayloadV1, ExecutionPayloadV2, ExecutionPayloadV3};
 use alloy_rpc_types_eth::state::StateOverride;
 use arc_swap::ArcSwapOption;
 use base_flashtypes::Flashblock;
 use eyre::eyre;
-use op_alloy_consensus::OpTxEnvelope;
+use op_alloy_consensus::{OpDepositReceipt, OpTxEnvelope};
 use op_alloy_network::TransactionResponse;
 use op_alloy_rpc_types::Transaction;
 use rayon::prelude::*;
@@ -30,11 +31,11 @@ use reth::{
         db::CacheDB,
     },
 };
-use reth_evm::{ConfigureEvm, Evm};
+use reth_evm::{ConfigureEvm, Evm, eth::receipt_builder::ReceiptBuilderCtx};
 use reth_optimism_chainspec::OpHardforks;
 use reth_optimism_evm::{OpEvmConfig, OpNextBlockEnvAttributes};
-use reth_optimism_primitives::{DepositReceipt, OpBlock, OpPrimitives};
-use reth_optimism_rpc::OpReceiptBuilder;
+use reth_optimism_primitives::{OpBlock, OpPrimitives};
+use reth_optimism_rpc::OpReceiptBuilder as OpRpcReceiptBuilder;
 use reth_primitives::RecoveredBlock;
 use reth_rpc_convert::transaction::ConvertReceiptInput;
 use tokio::sync::{Mutex, broadcast::Sender, mpsc::UnboundedReceiver};
@@ -330,22 +331,6 @@ where
                 .flat_map(|flashblock| flashblock.diff.withdrawals.clone())
                 .collect();
 
-            let receipt_by_hash = flashblocks
-                .iter()
-                .map(|flashblock| flashblock.metadata.receipts.clone())
-                .fold(HashMap::default(), |mut acc, receipts| {
-                    acc.extend(receipts);
-                    acc
-                });
-
-            let updated_balances = flashblocks
-                .iter()
-                .map(|flashblock| flashblock.metadata.new_account_balances.clone())
-                .fold(HashMap::default(), |mut acc, balances| {
-                    acc.extend(balances);
-                    acc
-                });
-
             pending_blocks_builder.with_flashblocks(
                 flashblocks.iter().map(|&x| x.clone()).collect::<Vec<Flashblock>>(),
             );
@@ -391,7 +376,7 @@ where
             let evm_env = evm_config.next_evm_env(&last_block_header, &block_env_attributes)?;
             let mut evm = evm_config.evm_with_env(db, evm_env);
 
-            let mut gas_used = 0;
+            let mut cumulative_gas_used: u64 = 0;
             let mut next_log_index = 0;
 
             // Parallel sender recovery - batch all ECDSA operations upfront
@@ -420,24 +405,7 @@ where
                 pending_blocks_builder.with_transaction_sender(tx_hash, sender);
                 pending_blocks_builder.increment_nonce(sender);
 
-                let receipt = receipt_by_hash
-                    .get(&tx_hash)
-                    .cloned()
-                    .ok_or(eyre!("missing receipt for {:?}", tx_hash))?;
-
                 let recovered_transaction = Recovered::new_unchecked(transaction.clone(), sender);
-                let envelope = recovered_transaction.clone().convert::<OpTxEnvelope>();
-
-                // Build Transaction
-                let (deposit_receipt_version, deposit_nonce) = if transaction.is_deposit() {
-                    let deposit_receipt = receipt
-                        .as_deposit_receipt()
-                        .ok_or(eyre!("deposit transaction, non deposit receipt"))?;
-
-                    (deposit_receipt.deposit_receipt_version, deposit_receipt.deposit_nonce)
-                } else {
-                    (None, None)
-                };
 
                 let effective_gas_price = if transaction.is_deposit() {
                     0
@@ -451,68 +419,70 @@ where
                         .unwrap_or_else(|| transaction.max_fee_per_gas())
                 };
 
-                let rpc_txn = Transaction {
-                    inner: alloy_rpc_types_eth::Transaction {
-                        inner: envelope,
-                        block_hash: Some(header.hash()),
-                        block_number: Some(base.block_number),
-                        transaction_index: Some(idx as u64),
-                        effective_gas_price: Some(effective_gas_price),
-                    },
-                    deposit_nonce,
-                    deposit_receipt_version,
-                };
+                // Check if we have all the data we need (receipt + state)
+                let cached_data = prev_pending_blocks.as_ref().and_then(|p| {
+                    let receipt = p.get_receipt(tx_hash)?;
+                    let state = p.get_transaction_state(&tx_hash)?;
+                    Some((receipt, state))
+                });
 
-                pending_blocks_builder.with_transaction(rpc_txn);
+                // If cached, we can fill out pending block data using previous execution results
+                // If not cached, we need to execute the transaction and build pending block data from scratch
+                // The `pending_blocks_builder.with*` calls should fill out the same data in both cases
+                // We also need to update the cumulative gas used and next log index in both cases
+                if let Some((receipt, state)) = cached_data {
+                    let (deposit_receipt_version, deposit_nonce) = if transaction.is_deposit() {
+                        let deposit_receipt = receipt
+                            .inner
+                            .inner
+                            .as_deposit_receipt()
+                            .ok_or(eyre!("deposit transaction, non deposit receipt"))?;
 
-                // Receipt Generation
-                let op_receipt = prev_pending_blocks
-                    .as_ref()
-                    .and_then(|pending_blocks| pending_blocks.get_receipt(tx_hash))
-                    .unwrap_or_else(|| {
-                        let meta = TransactionMeta {
-                            tx_hash,
-                            index: idx as u64,
-                            block_hash: header.hash(),
-                            block_number: block.number,
-                            base_fee: block.base_fee_per_gas,
-                            excess_blob_gas: block.excess_blob_gas,
-                            timestamp: block.timestamp,
-                        };
+                        (deposit_receipt.deposit_receipt_version, deposit_receipt.deposit_nonce)
+                    } else {
+                        (None, None)
+                    };
 
-                        let input: ConvertReceiptInput<'_, OpPrimitives> = ConvertReceiptInput {
-                            receipt: receipt.clone(),
-                            tx: Recovered::new_unchecked(transaction, sender),
-                            gas_used: receipt.cumulative_gas_used() - gas_used,
-                            next_log_index,
-                            meta,
-                        };
+                    let envelope = recovered_transaction.clone().convert::<OpTxEnvelope>();
+                    let rpc_txn = Transaction {
+                        inner: alloy_rpc_types_eth::Transaction {
+                            inner: envelope,
+                            block_hash: Some(header.hash()),
+                            block_number: Some(base.block_number),
+                            transaction_index: Some(idx as u64),
+                            effective_gas_price: Some(effective_gas_price),
+                        },
+                        deposit_nonce,
+                        deposit_receipt_version,
+                    };
 
-                        OpReceiptBuilder::new(
-                            self.client.chain_spec().as_ref(),
-                            input,
-                            &mut l1_block_info,
-                        )
-                        .unwrap()
-                        .build()
-                    });
+                    pending_blocks_builder.with_transaction(rpc_txn);
+                    pending_blocks_builder.with_receipt(tx_hash, receipt.clone());
 
-                pending_blocks_builder.with_receipt(tx_hash, op_receipt);
-                gas_used = receipt.cumulative_gas_used();
-                next_log_index += receipt.logs().len();
-
-                let mut should_execute_transaction = true;
-                if let Some(state) =
-                    prev_pending_blocks.as_ref().and_then(|p| p.get_transaction_state(&tx_hash))
-                {
+                    for (address, account) in state.iter() {
+                        if account.is_touched() {
+                            pending_blocks_builder
+                                .with_account_balance(*address, account.info.balance);
+                        }
+                    }
                     pending_blocks_builder.with_transaction_state(tx_hash, state);
-                    should_execute_transaction = false;
-                }
 
-                if should_execute_transaction {
-                    match evm.transact(recovered_transaction) {
-                        Ok(ResultAndState { state, .. }) => {
+                    cumulative_gas_used = cumulative_gas_used
+                        .checked_add(receipt.inner.gas_used)
+                        .ok_or(eyre!("cumulative gas used overflow"))?;
+                    next_log_index += receipt.inner.logs().len();
+                } else {
+                    let envelope = recovered_transaction.clone().convert::<OpTxEnvelope>();
+
+                    match evm.transact(recovered_transaction.clone()) {
+                        Ok(ResultAndState { state, result }) => {
+                            let gas_used = result.gas_used();
                             for (addr, acc) in &state {
+                                if acc.is_touched() {
+                                    pending_blocks_builder
+                                        .with_account_balance(*addr, acc.info.balance);
+                                }
+
                                 let existing_override = state_overrides.entry(*addr).or_default();
                                 existing_override.balance = Some(acc.info.balance);
                                 existing_override.nonce = Some(acc.info.nonce);
@@ -527,6 +497,117 @@ where
 
                                 existing.extend(changed_slots);
                             }
+
+                            cumulative_gas_used = cumulative_gas_used
+                                .checked_add(gas_used)
+                                .ok_or(eyre!("cumulative gas used overflow"))?;
+
+                            let receipt_builder =
+                                evm_config.block_executor_factory().receipt_builder();
+
+                            let is_canyon_active = self
+                                .client
+                                .chain_spec()
+                                .is_canyon_active_at_timestamp(block.timestamp);
+
+                            let is_regolith_active = self
+                                .client
+                                .chain_spec()
+                                .is_regolith_active_at_timestamp(block.timestamp);
+
+                            let receipt = match receipt_builder.build_receipt(ReceiptBuilderCtx {
+                                tx: &recovered_transaction,
+                                evm: &evm,
+                                result,
+                                state: &state,
+                                cumulative_gas_used,
+                            }) {
+                                Ok(receipt) => receipt,
+                                Err(ctx) => {
+                                    // This is a deposit transaction, so build the receipt from the context
+                                    let receipt = alloy_consensus::Receipt {
+                                        status: Eip658Value::Eip658(ctx.result.is_success()),
+                                        cumulative_gas_used: ctx.cumulative_gas_used,
+                                        logs: ctx.result.into_logs(),
+                                    };
+
+                                    let deposit_nonce = (is_regolith_active
+                                        && transaction.is_deposit())
+                                    .then(|| {
+                                        evm.db_mut()
+                                            .load_account(recovered_transaction.signer())
+                                            .map(|acc| acc.info.nonce)
+                                    })
+                                    .transpose()
+                                    .map_err(|_| {
+                                        eyre!("failed to load cache account for depositor")
+                                    })?;
+
+                                    receipt_builder.build_deposit_receipt(OpDepositReceipt {
+                                        inner: receipt,
+                                        deposit_nonce,
+                                        deposit_receipt_version: is_canyon_active.then_some(1),
+                                    })
+                                }
+                            };
+
+                            let meta = TransactionMeta {
+                                tx_hash,
+                                index: idx as u64,
+                                block_hash: header.hash(),
+                                block_number: block.number,
+                                base_fee: block.base_fee_per_gas,
+                                excess_blob_gas: block.excess_blob_gas,
+                                timestamp: block.timestamp,
+                            };
+
+                            let input: ConvertReceiptInput<'_, OpPrimitives> =
+                                ConvertReceiptInput {
+                                    receipt: receipt.clone(),
+                                    tx: Recovered::new_unchecked(transaction, sender),
+                                    gas_used,
+                                    next_log_index,
+                                    meta,
+                                };
+
+                            let op_receipt = OpRpcReceiptBuilder::new(
+                                self.client.chain_spec().as_ref(),
+                                input,
+                                &mut l1_block_info,
+                            )
+                            .unwrap()
+                            .build();
+                            next_log_index += receipt.logs().len();
+
+                            let (deposit_receipt_version, deposit_nonce) =
+                                if transaction.is_deposit() {
+                                    let deposit_receipt =
+                                        op_receipt.inner.inner.as_deposit_receipt().ok_or(
+                                            eyre!("deposit transaction, non deposit receipt"),
+                                        )?;
+
+                                    (
+                                        deposit_receipt.deposit_receipt_version,
+                                        deposit_receipt.deposit_nonce,
+                                    )
+                                } else {
+                                    (None, None)
+                                };
+
+                            let rpc_txn = Transaction {
+                                inner: alloy_rpc_types_eth::Transaction {
+                                    inner: envelope,
+                                    block_hash: Some(header.hash()),
+                                    block_number: Some(base.block_number),
+                                    transaction_index: Some(idx as u64),
+                                    effective_gas_price: Some(effective_gas_price),
+                                },
+                                deposit_nonce,
+                                deposit_receipt_version,
+                            };
+
+                            pending_blocks_builder.with_transaction(rpc_txn);
+                            pending_blocks_builder.with_receipt(tx_hash, op_receipt);
                             pending_blocks_builder.with_transaction_state(tx_hash, state.clone());
                             evm.db_mut().commit(state);
                         }
@@ -540,10 +621,6 @@ where
                         }
                     }
                 }
-            }
-
-            for (address, balance) in updated_balances {
-                pending_blocks_builder.with_account_balance(address, balance);
             }
 
             db = evm.into_db();

--- a/crates/flashtypes/Cargo.toml
+++ b/crates/flashtypes/Cargo.toml
@@ -18,9 +18,6 @@ alloy-primitives.workspace = true
 alloy-rpc-types-eth.workspace = true
 alloy-rpc-types-engine.workspace = true
 
-# reth
-reth-optimism-primitives.workspace = true
-
 # misc
 bytes.workspace = true
 serde.workspace = true

--- a/crates/flashtypes/src/block.rs
+++ b/crates/flashtypes/src/block.rs
@@ -79,8 +79,6 @@ mod tests {
         #[case] encoder: fn(&FlashblocksPayloadV1) -> Bytes,
     ) {
         let payload = sample_payload(json!({
-            "receipts": {},
-            "new_account_balances": {},
             "block_number": 1234u64
         }));
 
@@ -92,15 +90,11 @@ mod tests {
         assert_eq!(decoded.base, payload.base);
         assert_eq!(decoded.diff, payload.diff);
         assert_eq!(decoded.metadata.block_number, 1234);
-        assert!(decoded.metadata.receipts.is_empty());
-        assert!(decoded.metadata.new_account_balances.is_empty());
     }
 
     #[rstest]
     #[case::invalid_brotli(Bytes::from_static(b"not brotli data"))]
     #[case::missing_metadata(encode_plain(&sample_payload(json!({
-        "receipts": {},
-        "new_account_balances": {}
     }))))] // missing block_number in metadata
     fn try_decode_message_rejects_invalid_data(#[case] bytes: Bytes) {
         assert!(Flashblock::try_decode_message(bytes).is_err());

--- a/crates/flashtypes/src/metadata.rs
+++ b/crates/flashtypes/src/metadata.rs
@@ -1,16 +1,10 @@
 //! Contains the [`Metadata`] type used in Flashblocks.
 
-use alloy_primitives::{Address, B256, U256, map::foldhash::HashMap};
-use reth_optimism_primitives::OpReceipt;
 use serde::{Deserialize, Serialize};
 
 /// Metadata associated with a flashblock.
 #[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Default)]
 pub struct Metadata {
-    /// Transaction receipts indexed by hash.
-    pub receipts: HashMap<B256, OpReceipt>,
-    /// Updated account balances.
-    pub new_account_balances: HashMap<Address, U256>,
     /// Block number this flashblock belongs to.
     pub block_number: u64,
 }

--- a/crates/rpc/tests/eth_call_erc20.rs
+++ b/crates/rpc/tests/eth_call_erc20.rs
@@ -11,9 +11,8 @@
 //! - MockERC20: Solmate's MockERC20 (lib/solmate)
 //! - TransparentUpgradeableProxy: OpenZeppelin's proxy (lib/openzeppelin-contracts)
 
-use alloy_consensus::Receipt;
 use alloy_eips::BlockNumberOrTag;
-use alloy_primitives::{Address, B256, Bytes, LogData, TxHash, U256, map::HashMap};
+use alloy_primitives::{Address, B256, Bytes, U256};
 use alloy_provider::Provider;
 use alloy_rpc_types_engine::PayloadId;
 use alloy_sol_types::{SolConstructor, SolValue};
@@ -21,25 +20,15 @@ use base_flashtypes::{
     ExecutionPayloadBaseV1, ExecutionPayloadFlashblockDeltaV1, Flashblock, Metadata,
 };
 use base_reth_test_utils::{
-    FlashblocksHarness, L1_BLOCK_INFO_DEPOSIT_TX, L1_BLOCK_INFO_DEPOSIT_TX_HASH, MockERC20,
-    TransparentUpgradeableProxy,
+    FlashblocksHarness, L1_BLOCK_INFO_DEPOSIT_TX, MockERC20, TransparentUpgradeableProxy,
 };
 use eyre::Result;
-use op_alloy_consensus::OpDepositReceipt;
-use reth_optimism_primitives::OpReceipt;
-
-/// ERC-20 Transfer event topic (keccak256("Transfer(address,address,uint256)"))
-const TRANSFER_EVENT_TOPIC: B256 =
-    alloy_primitives::b256!("ddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef");
-
 struct Erc20TestSetup {
     harness: FlashblocksHarness,
     token_address: Address,
     token_deploy_tx: Bytes,
-    token_deploy_hash: TxHash,
     proxy_address: Option<Address>,
     proxy_deploy_tx: Option<Bytes>,
-    proxy_deploy_hash: Option<TxHash>,
 }
 
 impl Erc20TestSetup {
@@ -55,10 +44,10 @@ impl Erc20TestSetup {
         };
         let token_deploy_data =
             [MockERC20::BYTECODE.to_vec(), token_constructor.abi_encode()].concat();
-        let (token_deploy_tx, token_address, token_deploy_hash) =
+        let (token_deploy_tx, token_address, _) =
             deployer.create_deployment_tx(Bytes::from(token_deploy_data), 0)?;
 
-        let (proxy_address, proxy_deploy_tx, proxy_deploy_hash) = if with_proxy {
+        let (proxy_address, proxy_deploy_tx, _) = if with_proxy {
             // Deploy TransparentUpgradeableProxy from OpenZeppelin
             // Constructor: (implementation, initialOwner, data)
             let proxy_constructor = TransparentUpgradeableProxy::constructorCall {
@@ -77,25 +66,11 @@ impl Erc20TestSetup {
             (None, None, None)
         };
 
-        Ok(Self {
-            harness,
-            token_address,
-            token_deploy_tx,
-            token_deploy_hash,
-            proxy_address,
-            proxy_deploy_tx,
-            proxy_deploy_hash,
-        })
-    }
-
-    fn interaction_address(&self) -> Address {
-        self.proxy_address.unwrap_or(self.token_address)
+        Ok(Self { harness, token_address, token_deploy_tx, proxy_address, proxy_deploy_tx })
     }
 
     /// Create the base flashblock payload (block info only)
     fn create_base_payload(&self) -> Flashblock {
-        let deployer_address = self.harness.accounts().deployer.address;
-
         Flashblock {
             payload_id: PayloadId::new([0; 8]),
             index: 0,
@@ -115,61 +90,12 @@ impl Erc20TestSetup {
                 transactions: vec![L1_BLOCK_INFO_DEPOSIT_TX],
                 ..Default::default()
             },
-            metadata: Metadata {
-                block_number: 1,
-                receipts: {
-                    let mut receipts = HashMap::default();
-                    receipts.insert(
-                        L1_BLOCK_INFO_DEPOSIT_TX_HASH,
-                        OpReceipt::Deposit(OpDepositReceipt {
-                            inner: Receipt {
-                                status: true.into(),
-                                cumulative_gas_used: 10000,
-                                logs: vec![],
-                            },
-                            deposit_nonce: Some(4012991u64),
-                            deposit_receipt_version: None,
-                        }),
-                    );
-                    receipts
-                },
-                new_account_balances: {
-                    // Give deployer enough ETH for contract deployments
-                    let mut balances = HashMap::default();
-                    balances
-                        .insert(deployer_address, U256::from(10_000_000_000_000_000_000_000u128)); // 10000 ETH
-                    balances
-                },
-            },
+            metadata: Metadata { block_number: 1 },
         }
     }
 
     /// Create flashblock payload with token deployment
     fn create_deploy_payload(&self) -> Flashblock {
-        let mut receipts = HashMap::default();
-
-        // Token deployment receipt
-        receipts.insert(
-            self.token_deploy_hash,
-            OpReceipt::Legacy(Receipt {
-                status: true.into(),
-                cumulative_gas_used: 500_000, // Approximate gas for ERC-20 deployment
-                logs: vec![],
-            }),
-        );
-
-        // Add proxy deployment if present
-        if let (Some(proxy_hash), Some(_)) = (self.proxy_deploy_hash, &self.proxy_deploy_tx) {
-            receipts.insert(
-                proxy_hash,
-                OpReceipt::Legacy(Receipt {
-                    status: true.into(),
-                    cumulative_gas_used: 700_000, // Token + proxy deployment
-                    logs: vec![],
-                }),
-            );
-        }
-
         let mut transactions = vec![self.token_deploy_tx.clone()];
         if let Some(proxy_tx) = &self.proxy_deploy_tx {
             transactions.push(proxy_tx.clone());
@@ -190,49 +116,12 @@ impl Erc20TestSetup {
                 logs_bloom: Default::default(),
                 withdrawals_root: Default::default(),
             },
-            metadata: Metadata {
-                block_number: 1,
-                receipts,
-                new_account_balances: HashMap::default(),
-            },
+            metadata: Metadata { block_number: 1 },
         }
     }
 
     /// Create flashblock payload with mint transaction
-    fn create_mint_payload(
-        &self,
-        mint_tx: Bytes,
-        mint_hash: TxHash,
-        to: Address,
-        amount: U256,
-    ) -> Flashblock {
-        let mut receipts = HashMap::default();
-
-        // Create Transfer event log (from address(0) for mint)
-        let transfer_log = alloy_primitives::Log {
-            address: self.interaction_address(),
-            data: LogData::new(
-                vec![
-                    TRANSFER_EVENT_TOPIC,
-                    B256::left_padding_from(&Address::ZERO.0.0), // from = address(0)
-                    B256::left_padding_from(&to.0.0),            // to
-                ],
-                amount.to_be_bytes_vec().into(),
-            )
-            .unwrap(),
-        };
-
-        // cumulative_gas_used must be greater than previous transactions
-        // Base payload: 10_000, Deploy payload: 700_000, so mint must be > 700_000
-        receipts.insert(
-            mint_hash,
-            OpReceipt::Legacy(Receipt {
-                status: true.into(),
-                cumulative_gas_used: 750_000, // 700_000 (deploy) + 50_000 (mint)
-                logs: vec![transfer_log],
-            }),
-        );
-
+    fn create_mint_payload(&self, mint_tx: Bytes) -> Flashblock {
         Flashblock {
             payload_id: PayloadId::new([0; 8]),
             index: 2,
@@ -248,11 +137,7 @@ impl Erc20TestSetup {
                 logs_bloom: Default::default(),
                 withdrawals_root: Default::default(),
             },
-            metadata: Metadata {
-                block_number: 1,
-                receipts,
-                new_account_balances: HashMap::default(),
-            },
+            metadata: Metadata { block_number: 1 },
         }
     }
 
@@ -344,11 +229,10 @@ async fn test_erc20_mint() -> Result<()> {
     let mint_amount = U256::from(1000u64);
     let mint_tx_request =
         token.mint(accounts.alice.address, mint_amount).into_transaction_request();
-    let (mint_tx, mint_hash) = accounts.deployer.sign_txn_request(mint_tx_request.nonce(1))?;
+    let (mint_tx, _) = accounts.deployer.sign_txn_request(mint_tx_request.nonce(1))?;
 
     // Send mint flashblock
-    let mint_payload =
-        setup.create_mint_payload(mint_tx, mint_hash, accounts.alice.address, mint_amount);
+    let mint_payload = setup.create_mint_payload(mint_tx);
     setup.harness.send_flashblock(mint_payload).await?;
 
     // Verify balance after mint
@@ -382,11 +266,10 @@ async fn test_proxy_erc20_mint() -> Result<()> {
     let mint_amount = U256::from(5000u64);
     let mint_tx_request =
         token_via_proxy.mint(accounts.alice.address, mint_amount).into_transaction_request();
-    let (mint_tx, mint_hash) = accounts.deployer.sign_txn_request(mint_tx_request.nonce(2))?;
+    let (mint_tx, _) = accounts.deployer.sign_txn_request(mint_tx_request.nonce(2))?;
 
     // Send mint flashblock (note: interaction_address returns proxy)
-    let mint_payload =
-        setup.create_mint_payload(mint_tx, mint_hash, accounts.alice.address, mint_amount);
+    let mint_payload = setup.create_mint_payload(mint_tx);
     setup.harness.send_flashblock(mint_payload).await?;
 
     // Verify balance after mint through proxy


### PR DESCRIPTION
The metadata field used to contain receipts and changed account balances as a performance optimization to be able to serve RPC requests without actually executing the block, but we still need to execute the block in most cases anyway. This removes the `receipts` and `changed_account_balances` fields from the response.

These are generated during flashblock execution instead.

This still preserves skipping execution of transactions that were executed in previous flashblocks as long as we have the receipt and state from the previous execution. In either the cached or executed path, `cumulative_gas` and `next_log_index` are updated.

The tests also needed to be fixed since they relied on the receipts for logs and the changed balances. Now, since the transactions are actually executed, we need to actually emit logs from the contracts when executed and send balance to the address rather than relying on `changed_account_balances`.

Fixes CHAIN-2657