### PR TITLE
feat: move state/receipt building to new method

### DIFF
--- a/crates/flashblocks/src/lib.rs
+++ b/crates/flashblocks/src/lib.rs
@@ -20,3 +20,6 @@ pub use subscription::FlashblocksSubscriber;
 
 mod traits;
 pub use traits::{FlashblocksAPI, FlashblocksReceiver, PendingBlocksAPI};
+
+mod state_builder;
+pub use state_builder::{ExecutedPendingTransaction, PendingStateBuilder};

--- a/crates/flashblocks/src/processor.rs
+++ b/crates/flashblocks/src/processor.rs
@@ -200,7 +200,7 @@ where
     ) -> eyre::Result<ExecutedPendingTransaction> {
         let tx_hash = transaction.tx_hash();
 
-        match self.evm.transact(transaction.clone()) {
+        match self.evm.transact(&transaction) {
             Ok(ResultAndState { state, result }) => {
                 let gas_used = result.gas_used();
                 let mut touched_balances = HashMap::default();

--- a/crates/flashblocks/src/processor.rs
+++ b/crates/flashblocks/src/processor.rs
@@ -7,44 +7,34 @@ use std::{
 };
 
 use alloy_consensus::{
-    Block, Eip658Value, Header, TxReceipt,
-    transaction::{Recovered, SignerRecoverable, TransactionMeta},
+    Header,
+    transaction::{Recovered, SignerRecoverable},
 };
 use alloy_eips::BlockNumberOrTag;
-use alloy_op_evm::block::receipt_builder::OpReceiptBuilder;
-use alloy_primitives::{Address, B256, BlockNumber, Bytes, U256, map::HashMap};
-use alloy_rpc_types::{TransactionTrait, Withdrawal};
+use alloy_primitives::{Address, B256, BlockNumber, Bytes};
+use alloy_rpc_types::Withdrawal;
 use alloy_rpc_types_engine::{ExecutionPayloadV1, ExecutionPayloadV2, ExecutionPayloadV3};
 use alloy_rpc_types_eth::state::StateOverride;
 use arc_swap::ArcSwapOption;
 use base_flashtypes::Flashblock;
 use eyre::eyre;
-use op_alloy_consensus::{OpDepositReceipt, OpTxEnvelope};
+use op_alloy_consensus::OpTxEnvelope;
 use op_alloy_network::TransactionResponse;
-use op_alloy_rpc_types::{OpTransactionReceipt, Transaction};
 use rayon::prelude::*;
 use reth::{
     chainspec::{ChainSpecProvider, EthChainSpec},
     providers::{BlockReaderIdExt, StateProviderFactory},
-    revm::{
-        Database, DatabaseCommit, State, context::result::ResultAndState,
-        database::StateProviderDatabase, db::CacheDB, state::EvmState,
-    },
+    revm::{State, database::StateProviderDatabase, db::CacheDB},
 };
-use reth_evm::{
-    ConfigureEvm, Evm, FromRecoveredTx, eth::receipt_builder::ReceiptBuilderCtx,
-    op_revm::L1BlockInfo,
-};
+use reth_evm::ConfigureEvm;
 use reth_optimism_chainspec::OpHardforks;
-use reth_optimism_evm::{OpEvmConfig, OpNextBlockEnvAttributes, OpRethReceiptBuilder};
-use reth_optimism_primitives::{OpBlock, OpPrimitives};
-use reth_optimism_rpc::OpReceiptBuilder as OpRpcReceiptBuilder;
+use reth_optimism_evm::{OpEvmConfig, OpNextBlockEnvAttributes};
+use reth_optimism_primitives::OpBlock;
 use reth_primitives::RecoveredBlock;
-use reth_rpc_convert::transaction::ConvertReceiptInput;
 use tokio::sync::{Mutex, broadcast::Sender, mpsc::UnboundedReceiver};
 use tracing::{debug, error, info, warn};
 
-use crate::{Metrics, PendingBlocks, PendingBlocksBuilder};
+use crate::{Metrics, PendingBlocks, PendingBlocksBuilder, PendingStateBuilder};
 
 /// Messages consumed by the state processor.
 #[derive(Debug, Clone)]
@@ -53,286 +43,6 @@ pub enum StateUpdate {
     Canonical(RecoveredBlock<OpBlock>),
     /// Incoming flashblock payload to extend pending state.
     Flashblock(Flashblock),
-}
-
-struct ExecutedPendingTransaction {
-    rpc_transaction: Transaction,
-    receipt: OpTransactionReceipt,
-    state: EvmState,
-    touched_balances: HashMap<Address, U256>,
-}
-
-/// Executes or fetches cached values for transactions in a flashblock.
-struct PendingStateBuilder<E, ChainSpec> {
-    cumulative_gas_used: u64,
-    next_log_index: usize,
-
-    evm: E,
-    pending_block: Block<OpTxEnvelope, Header>,
-    l1_block_info: L1BlockInfo,
-    chain_spec: ChainSpec,
-    receipt_builder: OpRethReceiptBuilder,
-
-    prev_pending_blocks: Option<Arc<PendingBlocks>>,
-    state_overrides: StateOverride,
-}
-
-impl<E, ChainSpec> PendingStateBuilder<E, ChainSpec>
-where
-    E: Evm,
-    E::DB: DatabaseCommit + Database,
-    E::Tx: FromRecoveredTx<OpTxEnvelope>,
-    ChainSpec: OpHardforks,
-{
-    const fn new(
-        chain_spec: ChainSpec,
-        evm: E,
-        pending_block: Block<OpTxEnvelope, Header>,
-        prev_pending_blocks: Option<Arc<PendingBlocks>>,
-        l1_block_info: L1BlockInfo,
-        state_overrides: StateOverride,
-        receipt_builder: OpRethReceiptBuilder,
-    ) -> Self {
-        Self {
-            pending_block,
-            evm,
-            cumulative_gas_used: 0,
-            next_log_index: 0,
-            prev_pending_blocks,
-            l1_block_info,
-            state_overrides,
-            chain_spec,
-            receipt_builder,
-        }
-    }
-
-    fn execute_transaction(
-        &mut self,
-        idx: usize,
-        transaction: Recovered<OpTxEnvelope>,
-    ) -> eyre::Result<ExecutedPendingTransaction> {
-        let tx_hash = transaction.tx_hash();
-
-        let effective_gas_price = if transaction.is_deposit() {
-            0
-        } else {
-            self.pending_block
-                .base_fee_per_gas
-                .map(|base_fee| {
-                    transaction.effective_tip_per_gas(base_fee).unwrap_or_default()
-                        + base_fee as u128
-                })
-                .unwrap_or_else(|| transaction.max_fee_per_gas())
-        };
-
-        // Check if we have all the data we need (receipt + state)
-        let cached_data = self.prev_pending_blocks.as_ref().and_then(|p| {
-            let receipt = p.get_receipt(tx_hash)?;
-            let state = p.get_transaction_state(&tx_hash)?;
-            Some((receipt, state))
-        });
-
-        // If cached, we can fill out pending block data using previous execution results
-        // If not cached, we need to execute the transaction and build pending block data from scratch
-        if let Some((receipt, state)) = cached_data {
-            self.execute_with_cached_data(transaction, receipt, state, idx, effective_gas_price)
-        } else {
-            self.execute_with_evm(transaction, idx, effective_gas_price)
-        }
-    }
-
-    /// Builds transaction result from cached receipt and state data.
-    fn execute_with_cached_data(
-        &mut self,
-        transaction: Recovered<OpTxEnvelope>,
-        receipt: OpTransactionReceipt,
-        state: EvmState,
-        idx: usize,
-        effective_gas_price: u128,
-    ) -> eyre::Result<ExecutedPendingTransaction> {
-        let (deposit_receipt_version, deposit_nonce) = if transaction.is_deposit() {
-            let deposit_receipt = receipt
-                .inner
-                .inner
-                .as_deposit_receipt()
-                .ok_or(eyre!("deposit transaction, non deposit receipt"))?;
-
-            (deposit_receipt.deposit_receipt_version, deposit_receipt.deposit_nonce)
-        } else {
-            (None, None)
-        };
-
-        let rpc_transaction = Transaction {
-            inner: alloy_rpc_types_eth::Transaction {
-                inner: transaction,
-                block_hash: None,
-                block_number: Some(self.pending_block.number),
-                transaction_index: Some(idx as u64),
-                effective_gas_price: Some(effective_gas_price),
-            },
-            deposit_nonce,
-            deposit_receipt_version,
-        };
-
-        let mut touched_balances = HashMap::default();
-
-        for (address, account) in state.iter() {
-            if account.is_touched() {
-                touched_balances.insert(*address, account.info.balance);
-            }
-        }
-
-        self.cumulative_gas_used = self
-            .cumulative_gas_used
-            .checked_add(receipt.inner.gas_used)
-            .ok_or(eyre!("cumulative gas used overflow"))?;
-        self.next_log_index += receipt.inner.logs().len();
-
-        Ok(ExecutedPendingTransaction { rpc_transaction, receipt, state, touched_balances })
-    }
-
-    /// Executes the transaction through the EVM and builds the result from scratch.
-    fn execute_with_evm(
-        &mut self,
-        transaction: Recovered<OpTxEnvelope>,
-        idx: usize,
-        effective_gas_price: u128,
-    ) -> eyre::Result<ExecutedPendingTransaction> {
-        let tx_hash = transaction.tx_hash();
-
-        match self.evm.transact(&transaction) {
-            Ok(ResultAndState { state, result }) => {
-                let gas_used = result.gas_used();
-                let mut touched_balances = HashMap::default();
-                for (addr, acc) in &state {
-                    if acc.is_touched() {
-                        touched_balances.insert(*addr, acc.info.balance);
-                    }
-
-                    let existing_override = self.state_overrides.entry(*addr).or_default();
-                    existing_override.balance = Some(acc.info.balance);
-                    existing_override.nonce = Some(acc.info.nonce);
-                    existing_override.code = acc.info.code.clone().map(|code| code.bytes());
-
-                    let existing = existing_override.state_diff.get_or_insert(Default::default());
-                    let changed_slots = acc
-                        .storage
-                        .iter()
-                        .map(|(&key, slot)| (B256::from(key), B256::from(slot.present_value)));
-
-                    existing.extend(changed_slots);
-                }
-
-                self.cumulative_gas_used = self
-                    .cumulative_gas_used
-                    .checked_add(gas_used)
-                    .ok_or(eyre!("cumulative gas used overflow"))?;
-
-                let is_canyon_active =
-                    self.chain_spec.is_canyon_active_at_timestamp(self.pending_block.timestamp);
-
-                let is_regolith_active =
-                    self.chain_spec.is_regolith_active_at_timestamp(self.pending_block.timestamp);
-
-                let receipt = match self.receipt_builder.build_receipt(ReceiptBuilderCtx {
-                    tx: &transaction,
-                    evm: &mut self.evm,
-                    result,
-                    state: &state,
-                    cumulative_gas_used: self.cumulative_gas_used,
-                }) {
-                    Ok(receipt) => receipt,
-                    Err(ctx) => {
-                        // This is a deposit transaction, so build the receipt from the context
-                        let receipt = alloy_consensus::Receipt {
-                            status: Eip658Value::Eip658(ctx.result.is_success()),
-                            cumulative_gas_used: ctx.cumulative_gas_used,
-                            logs: ctx.result.into_logs(),
-                        };
-
-                        let deposit_nonce = (is_regolith_active && transaction.is_deposit())
-                            .then(|| {
-                                self.evm
-                                    .db_mut()
-                                    .basic(transaction.signer())
-                                    .map(|acc| acc.unwrap_or_default().nonce)
-                            })
-                            .transpose()
-                            .map_err(|_| eyre!("failed to load cache account for depositor"))?;
-
-                        self.receipt_builder.build_deposit_receipt(OpDepositReceipt {
-                            inner: receipt,
-                            deposit_nonce,
-                            deposit_receipt_version: is_canyon_active.then_some(1),
-                        })
-                    }
-                };
-
-                let meta = TransactionMeta {
-                    tx_hash,
-                    index: idx as u64,
-                    block_hash: B256::ZERO, // block hash is not available yet for flashblocks
-                    block_number: self.pending_block.number,
-                    base_fee: self.pending_block.base_fee_per_gas,
-                    excess_blob_gas: self.pending_block.excess_blob_gas,
-                    timestamp: self.pending_block.timestamp,
-                };
-
-                let sender = transaction.signer();
-                let input: ConvertReceiptInput<'_, OpPrimitives> = ConvertReceiptInput {
-                    receipt: receipt.clone(),
-                    tx: Recovered::new_unchecked(&transaction, sender),
-                    gas_used,
-                    next_log_index: self.next_log_index,
-                    meta,
-                };
-
-                let op_receipt =
-                    OpRpcReceiptBuilder::new(&self.chain_spec, input, &mut self.l1_block_info)
-                        .unwrap()
-                        .build();
-                self.next_log_index += receipt.logs().len();
-
-                let (deposit_receipt_version, deposit_nonce) = if transaction.is_deposit() {
-                    let deposit_receipt = op_receipt
-                        .inner
-                        .inner
-                        .as_deposit_receipt()
-                        .ok_or(eyre!("deposit transaction, non deposit receipt"))?;
-
-                    (deposit_receipt.deposit_receipt_version, deposit_receipt.deposit_nonce)
-                } else {
-                    (None, None)
-                };
-
-                let rpc_transaction = Transaction {
-                    inner: alloy_rpc_types_eth::Transaction {
-                        inner: transaction,
-                        block_hash: None,
-                        block_number: Some(self.pending_block.number),
-                        transaction_index: Some(idx as u64),
-                        effective_gas_price: Some(effective_gas_price),
-                    },
-                    deposit_nonce,
-                    deposit_receipt_version,
-                };
-                self.evm.db_mut().commit(state.clone());
-
-                Ok(ExecutedPendingTransaction {
-                    rpc_transaction,
-                    receipt: op_receipt,
-                    state,
-                    touched_balances,
-                })
-            }
-            Err(e) => Err(eyre!(
-                "failed to execute transaction: {:?} tx_hash: {:?} sender: {:?}",
-                e,
-                tx_hash,
-                transaction.signer()
-            )),
-        }
-    }
 }
 
 /// Processes flashblocks and canonical blocks to keep pending state updated.
@@ -702,18 +412,19 @@ where
                 let executed_transaction =
                     pending_state_builder.execute_transaction(idx, recovered_transaction)?;
 
+                for (address, account) in executed_transaction.state.iter() {
+                    if account.is_touched() {
+                        pending_blocks_builder.with_account_balance(*address, account.info.balance);
+                    }
+                }
+
                 pending_blocks_builder.with_transaction(executed_transaction.rpc_transaction);
                 pending_blocks_builder.with_receipt(tx_hash, executed_transaction.receipt);
                 pending_blocks_builder.with_transaction_state(tx_hash, executed_transaction.state);
-
-                for (address, balance) in executed_transaction.touched_balances {
-                    pending_blocks_builder.with_account_balance(address, balance);
-                }
             }
 
-            db = pending_state_builder.evm.into_db();
+            (db, state_overrides) = pending_state_builder.into_db_and_state_overrides();
             last_block_header = block_header;
-            state_overrides = pending_state_builder.state_overrides;
         }
 
         pending_blocks_builder.with_state_overrides(state_overrides);

--- a/crates/flashblocks/src/state_builder.rs
+++ b/crates/flashblocks/src/state_builder.rs
@@ -1,0 +1,299 @@
+use std::sync::Arc;
+
+use alloy_consensus::{
+    Block, Eip658Value, Header, TxReceipt,
+    transaction::{Recovered, TransactionMeta},
+};
+use alloy_op_evm::block::receipt_builder::OpReceiptBuilder;
+use alloy_primitives::B256;
+use alloy_rpc_types::TransactionTrait;
+use alloy_rpc_types_eth::state::StateOverride;
+use eyre::eyre;
+use op_alloy_consensus::{OpDepositReceipt, OpTxEnvelope};
+use op_alloy_rpc_types::{OpTransactionReceipt, Transaction};
+use reth::revm::{Database, DatabaseCommit, context::result::ResultAndState, state::EvmState};
+use reth_evm::{
+    Evm, FromRecoveredTx, eth::receipt_builder::ReceiptBuilderCtx, op_revm::L1BlockInfo,
+};
+use reth_optimism_chainspec::OpHardforks;
+use reth_optimism_evm::OpRethReceiptBuilder;
+use reth_optimism_primitives::OpPrimitives;
+use reth_optimism_rpc::OpReceiptBuilder as OpRpcReceiptBuilder;
+use reth_rpc_convert::transaction::ConvertReceiptInput;
+
+use crate::PendingBlocks;
+
+/// Represents the result of executing or fetching a cached pending transaction.
+#[derive(Debug, Clone)]
+pub struct ExecutedPendingTransaction {
+    /// The RPC transaction.
+    pub rpc_transaction: Transaction,
+    /// The receipt of the transaction.
+    pub receipt: OpTransactionReceipt,
+    /// The updated EVM state.
+    pub state: EvmState,
+}
+
+/// Executes or fetches cached values for transactions in a flashblock.
+#[derive(Debug)]
+pub struct PendingStateBuilder<E, ChainSpec> {
+    cumulative_gas_used: u64,
+    next_log_index: usize,
+
+    evm: E,
+    pending_block: Block<OpTxEnvelope, Header>,
+    l1_block_info: L1BlockInfo,
+    chain_spec: ChainSpec,
+    receipt_builder: OpRethReceiptBuilder,
+
+    prev_pending_blocks: Option<Arc<PendingBlocks>>,
+    state_overrides: StateOverride,
+}
+
+impl<E, ChainSpec, DB> PendingStateBuilder<E, ChainSpec>
+where
+    E: Evm<DB = DB>,
+    DB: Database + DatabaseCommit,
+    E::Tx: FromRecoveredTx<OpTxEnvelope>,
+    ChainSpec: OpHardforks,
+{
+    /// Creates a new pending state builder.
+    pub const fn new(
+        chain_spec: ChainSpec,
+        evm: E,
+        pending_block: Block<OpTxEnvelope, Header>,
+        prev_pending_blocks: Option<Arc<PendingBlocks>>,
+        l1_block_info: L1BlockInfo,
+        state_overrides: StateOverride,
+        receipt_builder: OpRethReceiptBuilder,
+    ) -> Self {
+        Self {
+            pending_block,
+            evm,
+            cumulative_gas_used: 0,
+            next_log_index: 0,
+            prev_pending_blocks,
+            l1_block_info,
+            state_overrides,
+            chain_spec,
+            receipt_builder,
+        }
+    }
+
+    /// Consumes the builder and returns the database and state overrides.
+    pub fn into_db_and_state_overrides(self) -> (DB, StateOverride) {
+        (self.evm.into_db(), self.state_overrides)
+    }
+
+    /// Executes a single transaction and updates internal state.
+    /// Should be called in order for each transaction.
+    pub fn execute_transaction(
+        &mut self,
+        idx: usize,
+        transaction: Recovered<OpTxEnvelope>,
+    ) -> eyre::Result<ExecutedPendingTransaction> {
+        let tx_hash = transaction.tx_hash();
+
+        let effective_gas_price = if transaction.is_deposit() {
+            0
+        } else {
+            self.pending_block
+                .base_fee_per_gas
+                .map(|base_fee| {
+                    transaction.effective_tip_per_gas(base_fee).unwrap_or_default()
+                        + base_fee as u128
+                })
+                .unwrap_or_else(|| transaction.max_fee_per_gas())
+        };
+
+        // Check if we have all the data we need (receipt + state)
+        let cached_data = self.prev_pending_blocks.as_ref().and_then(|p| {
+            let receipt = p.get_receipt(tx_hash)?;
+            let state = p.get_transaction_state(&tx_hash)?;
+            Some((receipt, state))
+        });
+
+        // If cached, we can fill out pending block data using previous execution results
+        // If not cached, we need to execute the transaction and build pending block data from scratch
+        if let Some((receipt, state)) = cached_data {
+            self.execute_with_cached_data(transaction, receipt, state, idx, effective_gas_price)
+        } else {
+            self.execute_with_evm(transaction, idx, effective_gas_price)
+        }
+    }
+
+    /// Builds transaction result from cached receipt and state data.
+    fn execute_with_cached_data(
+        &mut self,
+        transaction: Recovered<OpTxEnvelope>,
+        receipt: OpTransactionReceipt,
+        state: EvmState,
+        idx: usize,
+        effective_gas_price: u128,
+    ) -> eyre::Result<ExecutedPendingTransaction> {
+        let (deposit_receipt_version, deposit_nonce) = if transaction.is_deposit() {
+            let deposit_receipt = receipt
+                .inner
+                .inner
+                .as_deposit_receipt()
+                .ok_or(eyre!("deposit transaction, non deposit receipt"))?;
+
+            (deposit_receipt.deposit_receipt_version, deposit_receipt.deposit_nonce)
+        } else {
+            (None, None)
+        };
+
+        let rpc_transaction = Transaction {
+            inner: alloy_rpc_types_eth::Transaction {
+                inner: transaction,
+                block_hash: None,
+                block_number: Some(self.pending_block.number),
+                transaction_index: Some(idx as u64),
+                effective_gas_price: Some(effective_gas_price),
+            },
+            deposit_nonce,
+            deposit_receipt_version,
+        };
+
+        self.cumulative_gas_used = self
+            .cumulative_gas_used
+            .checked_add(receipt.inner.gas_used)
+            .ok_or(eyre!("cumulative gas used overflow"))?;
+        self.next_log_index += receipt.inner.logs().len();
+
+        Ok(ExecutedPendingTransaction { rpc_transaction, receipt, state })
+    }
+
+    /// Executes the transaction through the EVM and builds the result from scratch.
+    fn execute_with_evm(
+        &mut self,
+        transaction: Recovered<OpTxEnvelope>,
+        idx: usize,
+        effective_gas_price: u128,
+    ) -> eyre::Result<ExecutedPendingTransaction> {
+        let tx_hash = transaction.tx_hash();
+
+        match self.evm.transact(&transaction) {
+            Ok(ResultAndState { state, result }) => {
+                let gas_used = result.gas_used();
+                for (addr, acc) in &state {
+                    let existing_override = self.state_overrides.entry(*addr).or_default();
+                    existing_override.balance = Some(acc.info.balance);
+                    existing_override.nonce = Some(acc.info.nonce);
+                    existing_override.code = acc.info.code.clone().map(|code| code.bytes());
+
+                    let existing = existing_override.state_diff.get_or_insert(Default::default());
+                    let changed_slots = acc
+                        .storage
+                        .iter()
+                        .map(|(&key, slot)| (B256::from(key), B256::from(slot.present_value)));
+
+                    existing.extend(changed_slots);
+                }
+
+                self.cumulative_gas_used = self
+                    .cumulative_gas_used
+                    .checked_add(gas_used)
+                    .ok_or(eyre!("cumulative gas used overflow"))?;
+
+                let is_canyon_active =
+                    self.chain_spec.is_canyon_active_at_timestamp(self.pending_block.timestamp);
+
+                let is_regolith_active =
+                    self.chain_spec.is_regolith_active_at_timestamp(self.pending_block.timestamp);
+
+                let receipt = match self.receipt_builder.build_receipt(ReceiptBuilderCtx {
+                    tx: &transaction,
+                    evm: &mut self.evm,
+                    result,
+                    state: &state,
+                    cumulative_gas_used: self.cumulative_gas_used,
+                }) {
+                    Ok(receipt) => receipt,
+                    Err(ctx) => {
+                        // This is a deposit transaction, so build the receipt from the context
+                        let receipt = alloy_consensus::Receipt {
+                            status: Eip658Value::Eip658(ctx.result.is_success()),
+                            cumulative_gas_used: ctx.cumulative_gas_used,
+                            logs: ctx.result.into_logs(),
+                        };
+
+                        let deposit_nonce = (is_regolith_active && transaction.is_deposit())
+                            .then(|| {
+                                self.evm
+                                    .db_mut()
+                                    .basic(transaction.signer())
+                                    .map(|acc| acc.unwrap_or_default().nonce)
+                            })
+                            .transpose()
+                            .map_err(|_| eyre!("failed to load cache account for depositor"))?;
+
+                        self.receipt_builder.build_deposit_receipt(OpDepositReceipt {
+                            inner: receipt,
+                            deposit_nonce,
+                            deposit_receipt_version: is_canyon_active.then_some(1),
+                        })
+                    }
+                };
+
+                let meta = TransactionMeta {
+                    tx_hash,
+                    index: idx as u64,
+                    block_hash: B256::ZERO, // block hash is not available yet for flashblocks
+                    block_number: self.pending_block.number,
+                    base_fee: self.pending_block.base_fee_per_gas,
+                    excess_blob_gas: self.pending_block.excess_blob_gas,
+                    timestamp: self.pending_block.timestamp,
+                };
+
+                let sender = transaction.signer();
+                let input: ConvertReceiptInput<'_, OpPrimitives> = ConvertReceiptInput {
+                    receipt: receipt.clone(),
+                    tx: Recovered::new_unchecked(&transaction, sender),
+                    gas_used,
+                    next_log_index: self.next_log_index,
+                    meta,
+                };
+
+                let op_receipt =
+                    OpRpcReceiptBuilder::new(&self.chain_spec, input, &mut self.l1_block_info)
+                        .unwrap()
+                        .build();
+                self.next_log_index += receipt.logs().len();
+
+                let (deposit_receipt_version, deposit_nonce) = if transaction.is_deposit() {
+                    let deposit_receipt = op_receipt
+                        .inner
+                        .inner
+                        .as_deposit_receipt()
+                        .ok_or(eyre!("deposit transaction, non deposit receipt"))?;
+
+                    (deposit_receipt.deposit_receipt_version, deposit_receipt.deposit_nonce)
+                } else {
+                    (None, None)
+                };
+
+                let rpc_transaction = Transaction {
+                    inner: alloy_rpc_types_eth::Transaction {
+                        inner: transaction,
+                        block_hash: None,
+                        block_number: Some(self.pending_block.number),
+                        transaction_index: Some(idx as u64),
+                        effective_gas_price: Some(effective_gas_price),
+                    },
+                    deposit_nonce,
+                    deposit_receipt_version,
+                };
+                self.evm.db_mut().commit(state.clone());
+
+                Ok(ExecutedPendingTransaction { rpc_transaction, receipt: op_receipt, state })
+            }
+            Err(e) => Err(eyre!(
+                "failed to execute transaction: {:?} tx_hash: {:?} sender: {:?}",
+                e,
+                tx_hash,
+                transaction.signer()
+            )),
+        }
+    }
+}


### PR DESCRIPTION
Moves transaction processing logic of build_pending_state to a new struct. Also separates out reusing a cached execution from executing using the EVM.

This also removes block_hash from receipts and transactions which matches the spec and removes the need for calculating a useless block hash for every flashblock.

The next step is to move the for loop into this struct which will return an iterator of results.

Using this, we'll be able to prewarm accessed addresses using FALs and eventually process transactions in parallel. Moving execution to a new struct allows us to implement a trait for building flashblocks and switch out different implementations (prewarming, parallel, sequential).