### PR TITLE
chore(workspace): Remove tips-core

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1614,6 +1614,7 @@ dependencies = [
  "alloy-rpc-types-eth",
  "alloy-sol-macro",
  "alloy-sol-types",
+ "base-bundles",
  "base-flashtypes",
  "base-reth-flashblocks",
  "base-reth-test-utils",
@@ -1646,7 +1647,6 @@ dependencies = [
  "reth-transaction-pool",
  "serde",
  "serde_json",
- "tips-core",
  "tokio",
  "tokio-stream",
  "tokio-tungstenite 0.28.0",
@@ -11528,24 +11528,6 @@ name = "tinyvec_macros"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
-
-[[package]]
-name = "tips-core"
-version = "0.1.0"
-source = "git+https://github.com/base/tips?rev=b1dfde6a5c8f603f19f9309ca6dc015bad260b44#b1dfde6a5c8f603f19f9309ca6dc015bad260b44"
-dependencies = [
- "alloy-consensus",
- "alloy-primitives",
- "alloy-provider",
- "alloy-rpc-types",
- "alloy-serde",
- "op-alloy-consensus",
- "op-alloy-flz",
- "serde",
- "tracing",
- "tracing-subscriber 0.3.22",
- "uuid",
-]
 
 [[package]]
 name = "tokio"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,9 +62,6 @@ base-flashtypes = { path = "crates/flashtypes" }
 base-reth-test-utils = { path = "crates/test-utils" }
 base-reth-flashblocks = { path = "crates/flashblocks" }
 
-# base/tips
-tips-core = { git = "https://github.com/base/tips", rev = "b1dfde6a5c8f603f19f9309ca6dc015bad260b44" }
-
 # reth
 reth = { git = "https://github.com/paradigmxyz/reth", tag = "v1.9.3" }
 reth-ipc = { git = "https://github.com/paradigmxyz/reth", tag = "v1.9.3" }

--- a/crates/rpc/Cargo.toml
+++ b/crates/rpc/Cargo.toml
@@ -12,10 +12,8 @@ workspace = true
 
 [dependencies]
 # workspace
+base-bundles.workspace = true
 base-reth-flashblocks.workspace = true
-
-# base/tips
-tips-core.workspace = true
 
 # reth
 reth.workspace = true

--- a/crates/rpc/src/base/meter.rs
+++ b/crates/rpc/src/base/meter.rs
@@ -2,15 +2,13 @@ use std::{sync::Arc, time::Instant};
 
 use alloy_consensus::{BlockHeader, Transaction as _, transaction::SignerRecoverable};
 use alloy_primitives::{B256, U256};
+use base_bundles::{BundleExtensions, BundleTxs, ParsedBundle, TransactionResult};
 use eyre::{Result as EyreResult, eyre};
 use reth::revm::db::State;
 use reth_evm::{ConfigureEvm, execute::BlockBuilder};
 use reth_optimism_chainspec::OpChainSpec;
 use reth_optimism_evm::{OpEvmConfig, OpNextBlockEnvAttributes};
 use reth_primitives_traits::SealedHeader;
-use tips_core::types::{BundleExtensions, BundleTxs, ParsedBundle};
-
-use crate::TransactionResult;
 
 const BLOCK_TIME: u64 = 2; // 2 seconds per block
 

--- a/crates/rpc/src/base/meter_rpc.rs
+++ b/crates/rpc/src/base/meter_rpc.rs
@@ -1,12 +1,12 @@
 use alloy_consensus::Header;
 use alloy_eips::BlockNumberOrTag;
 use alloy_primitives::{B256, U256};
+use base_bundles::{Bundle, MeterBundleResponse, ParsedBundle};
 use jsonrpsee::core::{RpcResult, async_trait};
 use reth::providers::BlockReaderIdExt;
 use reth_optimism_chainspec::OpChainSpec;
 use reth_optimism_primitives::OpBlock;
 use reth_provider::{BlockReader, ChainSpecProvider, HeaderProvider, StateProviderFactory};
-use tips_core::types::{Bundle, MeterBundleResponse, ParsedBundle};
 use tracing::{error, info};
 
 use super::{

--- a/crates/rpc/src/base/traits.rs
+++ b/crates/rpc/src/base/traits.rs
@@ -2,9 +2,10 @@
 
 use alloy_eips::BlockNumberOrTag;
 use alloy_primitives::{B256, TxHash};
+use base_bundles::{Bundle, MeterBundleResponse};
 use jsonrpsee::{core::RpcResult, proc_macros::rpc};
 
-use crate::{Bundle, MeterBlockResponse, MeterBundleResponse, TransactionStatusResponse};
+use crate::{MeterBlockResponse, TransactionStatusResponse};
 
 /// RPC API for transaction metering
 #[rpc(server, namespace = "base")]

--- a/crates/rpc/src/lib.rs
+++ b/crates/rpc/src/lib.rs
@@ -3,9 +3,6 @@
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
 
-// Re-export tips core types
-pub use tips_core::types::{Bundle, MeterBundleResponse, TransactionResult};
-
 mod base;
 pub use base::{
     block::meter_block,

--- a/crates/rpc/tests/meter.rs
+++ b/crates/rpc/tests/meter.rs
@@ -6,6 +6,7 @@ use alloy_consensus::crypto::secp256k1::public_key_to_address;
 use alloy_eips::Encodable2718;
 use alloy_genesis::GenesisAccount;
 use alloy_primitives::{Address, B256, Bytes, U256, keccak256};
+use base_bundles::{Bundle, ParsedBundle};
 use base_reth_rpc::meter_bundle;
 use base_reth_test_utils::create_provider_factory;
 use eyre::Context;
@@ -20,7 +21,6 @@ use reth_primitives_traits::SealedHeader;
 use reth_provider::{HeaderProvider, StateProviderFactory, providers::BlockchainProvider};
 use reth_testing_utils::generators::generate_keys;
 use reth_transaction_pool::test_utils::TransactionBuilder;
-use tips_core::types::{Bundle, ParsedBundle};
 
 type NodeTypes = NodeTypesWithDBAdapter<OpNode, Arc<TempDatabase<DatabaseEnv>>>;
 

--- a/crates/rpc/tests/meter_rpc.rs
+++ b/crates/rpc/tests/meter_rpc.rs
@@ -5,7 +5,8 @@ use std::{any::Any, net::SocketAddr, sync::Arc};
 use alloy_eips::Encodable2718;
 use alloy_primitives::{Bytes, U256, address, b256, bytes};
 use alloy_rpc_client::RpcClient;
-use base_reth_rpc::{MeterBundleResponse, MeteringApiImpl, MeteringApiServer};
+use base_bundles::{Bundle, MeterBundleResponse};
+use base_reth_rpc::{MeteringApiImpl, MeteringApiServer};
 use base_reth_test_utils::{init_silenced_tracing, load_genesis};
 use op_alloy_consensus::OpTxEnvelope;
 use reth::{
@@ -20,7 +21,6 @@ use reth_optimism_node::{OpNode, args::RollupArgs};
 use reth_optimism_primitives::OpTransactionSigned;
 use reth_provider::providers::BlockchainProvider;
 use reth_transaction_pool::test_utils::TransactionBuilder;
-use tips_core::types::Bundle;
 
 struct NodeContext {
     http_api_addr: SocketAddr,


### PR DESCRIPTION
### Description

In #303, the core types from `tips-core` were ported to a new `base-bundles` crate in this repository. This makes progress on setting up this repository as `base/base`.

This PR follows up on that work by removing the `tips-core` dependency, using the local `base-bundles` types instead.