### PR TITLE
fix(flashblocks): Increase Flashblocks Broadcast Buffer Size

### DIFF
--- a/crates/flashblocks/src/state.rs
+++ b/crates/flashblocks/src/state.rs
@@ -24,8 +24,8 @@ use crate::{
     processor::{StateProcessor, StateUpdate},
 };
 
-// Buffer 4s of flashblocks for flashblock_sender
-const BUFFER_SIZE: usize = 20;
+// Buffer for flashblock_sender - large enough to handle processing lag
+const BUFFER_SIZE: usize = 1000;
 
 /// Manages the pending flashblock state and processes incoming updates.
 #[derive(Debug, Clone)]


### PR DESCRIPTION
### Description

Increases the broadcast channel buffer from 20 to 1000 to prevent RecvError::Lagged errors when flashblock processing falls behind.

#### Problem

Nodes with flashblocks enabled show "WAL containing too many blocks" warnings every ~6 minutes, with flashblocks-canon lagging ~400 blocks behind (#316). The 20-message buffer overflows when processing can't keep up with incoming flashblocks.

#### Fix

Increase buffer to 1000 messages (~200s of headroom), preventing subscriber lag during temporary processing delays.


> [!NOTE]
>
> Makes progress on #316.