### PR TITLE
fix: nonce gap in metering causing failed sims

### DIFF
--- a/crates/rpc/src/base/meter.rs
+++ b/crates/rpc/src/base/meter.rs
@@ -2,6 +2,7 @@ use std::{sync::Arc, time::Instant};
 
 use alloy_consensus::{BlockHeader, Transaction as _, transaction::SignerRecoverable};
 use alloy_primitives::{B256, U256};
+use alloy_rpc_types::state::StateOverride;
 use base_bundles::{BundleExtensions, BundleTxs, ParsedBundle, TransactionResult};
 use eyre::{Result as EyreResult, eyre};
 use reth::revm::db::State;
@@ -14,8 +15,12 @@ const BLOCK_TIME: u64 = 2; // 2 seconds per block
 
 /// Simulates and meters a bundle of transactions
 ///
-/// Takes a state provider, chain spec, decoded transactions, block header, and bundle metadata,
+/// Takes a state provider, chain spec, decoded transactions, block header, bundle metadata, and optional state overrides,
 /// and executes transactions in sequence to measure gas usage and execution time.
+///
+/// Note: The state_overrides parameter is currently unused. The correct approach is to use the header
+/// from the latest pending flashblock, which ensures the state provider already includes all committed
+/// flashblock transactions (including updated nonces).
 ///
 /// Returns a tuple of:
 /// - Vector of transaction results
@@ -28,6 +33,7 @@ pub fn meter_bundle<SP>(
     chain_spec: Arc<OpChainSpec>,
     bundle: ParsedBundle,
     header: &SealedHeader,
+    _state_overrides: Option<StateOverride>,
 ) -> EyreResult<(Vec<TransactionResult>, u64, U256, B256, u128)>
 where
     SP: reth_provider::StateProvider,

--- a/crates/rpc/tests/meter.rs
+++ b/crates/rpc/tests/meter.rs
@@ -137,7 +137,13 @@ fn meter_bundle_empty_transactions() -> eyre::Result<()> {
     let parsed_bundle = create_parsed_bundle(Vec::new())?;
 
     let (results, total_gas_used, total_gas_fees, bundle_hash, total_execution_time) =
-        meter_bundle(state_provider, harness.chain_spec.clone(), parsed_bundle, &harness.header)?;
+        meter_bundle(
+            state_provider,
+            harness.chain_spec.clone(),
+            parsed_bundle,
+            &harness.header,
+            None,
+        )?;
 
     assert!(results.is_empty());
     assert_eq!(total_gas_used, 0);
@@ -179,7 +185,13 @@ fn meter_bundle_single_transaction() -> eyre::Result<()> {
     let parsed_bundle = create_parsed_bundle(vec![envelope.clone()])?;
 
     let (results, total_gas_used, total_gas_fees, bundle_hash, total_execution_time) =
-        meter_bundle(state_provider, harness.chain_spec.clone(), parsed_bundle, &harness.header)?;
+        meter_bundle(
+            state_provider,
+            harness.chain_spec.clone(),
+            parsed_bundle,
+            &harness.header,
+            None,
+        )?;
 
     assert_eq!(results.len(), 1);
     let result = &results[0];
@@ -256,7 +268,13 @@ fn meter_bundle_multiple_transactions() -> eyre::Result<()> {
     let parsed_bundle = create_parsed_bundle(vec![envelope_1.clone(), envelope_2.clone()])?;
 
     let (results, total_gas_used, total_gas_fees, bundle_hash, total_execution_time) =
-        meter_bundle(state_provider, harness.chain_spec.clone(), parsed_bundle, &harness.header)?;
+        meter_bundle(
+            state_provider,
+            harness.chain_spec.clone(),
+            parsed_bundle,
+            &harness.header,
+            None,
+        )?;
 
     assert_eq!(results.len(), 2);
     assert!(total_execution_time > 0);


### PR DESCRIPTION
**problem:**
- some txns were not getting metered / showing up in the TIPS UI
- after logging out the `MeterBundleResponse`, found:
```
ErrorObject { code: InvalidParams, message: "server returned an error response: error code -32603: Bundle metering failed: Transaction 0xab7b1a00a35400345fde0e5083c8bd895f52898d8c19182d5dc21e673115faa0 execution failed: EVM reported invalid transaction (0xab7b1a00a35400345fde0e5083c8bd895f52898d8c19182d5dc21e673115faa0): nonce 996095 too high, expected 996091", data: None }
```

**changes:**
- TODO (after going through claude's diffs)