### PR TITLE
feat(metering): Add state root timing to bundle metering

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2058,6 +2058,7 @@ dependencies = [
  "reth-primitives-traits",
  "reth-provider",
  "reth-transaction-pool",
+ "revm-database",
  "serde",
  "tokio",
  "tracing",

--- a/crates/builder/op-rbuilder/src/tests/backrun.rs
+++ b/crates/builder/op-rbuilder/src/tests/backrun.rs
@@ -74,6 +74,7 @@ async fn backrun_bundle_all_or_nothing_revert(rbuilder: LocalInstance) -> eyre::
             state_flashblock_index: None,
             total_gas_used: 0,
             total_execution_time_us: 0,
+            state_root_time_us: 0,
         },
     };
 
@@ -193,6 +194,7 @@ async fn backrun_bundles_sorted_by_total_fee(rbuilder: LocalInstance) -> eyre::R
             state_flashblock_index: None,
             total_gas_used: 0,
             total_execution_time_us: 0,
+            state_root_time_us: 0,
         },
     };
 
@@ -218,6 +220,7 @@ async fn backrun_bundles_sorted_by_total_fee(rbuilder: LocalInstance) -> eyre::R
             state_flashblock_index: None,
             total_gas_used: 0,
             total_execution_time_us: 0,
+            state_root_time_us: 0,
         },
     };
 
@@ -358,6 +361,7 @@ async fn backrun_bundle_rejected_low_total_fee(rbuilder: LocalInstance) -> eyre:
             state_flashblock_index: None,
             total_gas_used: 0,
             total_execution_time_us: 0,
+            state_root_time_us: 0,
         },
     };
 
@@ -451,6 +455,7 @@ async fn backrun_bundle_rejected_exceeds_gas_limit(rbuilder: LocalInstance) -> e
             state_flashblock_index: None,
             total_gas_used: 0,
             total_execution_time_us: 0,
+            state_root_time_us: 0,
         },
     };
 
@@ -535,6 +540,7 @@ async fn backrun_bundle_rejected_exceeds_da_limit(rbuilder: LocalInstance) -> ey
             state_flashblock_index: None,
             total_gas_used: 0,
             total_execution_time_us: 0,
+            state_root_time_us: 0,
         },
     };
 
@@ -621,6 +627,7 @@ async fn backrun_bundle_invalid_tx_skipped(rbuilder: LocalInstance) -> eyre::Res
             state_flashblock_index: None,
             total_gas_used: 0,
             total_execution_time_us: 0,
+            state_root_time_us: 0,
         },
     };
 

--- a/crates/builder/op-rbuilder/src/tx_data_store.rs
+++ b/crates/builder/op-rbuilder/src/tx_data_store.rs
@@ -386,6 +386,7 @@ mod tests {
                 state_flashblock_index: None,
                 total_gas_used: 0,
                 total_execution_time_us: 0,
+                state_root_time_us: 0,
             },
         }
     }
@@ -402,6 +403,7 @@ mod tests {
             state_flashblock_index: None,
             total_gas_used: gas_used,
             total_execution_time_us: 533,
+            state_root_time_us: 0,
         }
     }
 

--- a/crates/client/metering/Cargo.toml
+++ b/crates/client/metering/Cargo.toml
@@ -25,6 +25,9 @@ reth-optimism-evm.workspace = true
 reth-optimism-chainspec.workspace = true
 reth-optimism-primitives.workspace = true
 
+# revm
+revm-database.workspace = true
+
 # alloy
 alloy-primitives.workspace = true
 alloy-consensus.workspace = true

--- a/crates/client/metering/src/lib.rs
+++ b/crates/client/metering/src/lib.rs
@@ -10,7 +10,7 @@ mod extension;
 pub use extension::MeteringExtension;
 
 mod meter;
-pub use meter::meter_bundle;
+pub use meter::{MeterBundleOutput, meter_bundle};
 
 mod rpc;
 pub use rpc::MeteringApiImpl;

--- a/crates/shared/bundles/src/meter.rs
+++ b/crates/shared/bundles/src/meter.rs
@@ -58,6 +58,9 @@ pub struct MeterBundleResponse {
     pub total_gas_used: u64,
     /// Total execution time in microseconds.
     pub total_execution_time_us: u128,
+    /// Time spent calculating state root in microseconds.
+    #[serde(default)]
+    pub state_root_time_us: u128,
 }
 
 #[cfg(test)]
@@ -136,11 +139,13 @@ mod tests {
             state_flashblock_index: Some(42),
             total_gas_used: 21000,
             total_execution_time_us: 1000,
+            state_root_time_us: 500,
         };
 
         let json = serde_json::to_string(&response).unwrap();
         assert!(json.contains("\"stateFlashblockIndex\":42"));
         assert!(json.contains("\"stateBlockNumber\":12345"));
+        assert!(json.contains("\"stateRootTimeUs\":500"));
 
         let deserialized: MeterBundleResponse = serde_json::from_str(&json).unwrap();
         assert_eq!(deserialized.state_flashblock_index, Some(42));
@@ -160,6 +165,7 @@ mod tests {
             state_flashblock_index: None,
             total_gas_used: 21000,
             total_execution_time_us: 1000,
+            state_root_time_us: 0,
         };
 
         let json = serde_json::to_string(&response).unwrap();

--- a/crates/shared/bundles/src/test_utils.rs
+++ b/crates/shared/bundles/src/test_utils.rs
@@ -84,6 +84,7 @@ pub fn create_test_meter_bundle_response() -> MeterBundleResponse {
         state_flashblock_index: None,
         total_gas_used: 0,
         total_execution_time_us: 0,
+        state_root_time_us: 0,
     }
 }
 


### PR DESCRIPTION
## Summary

Add timing measurement for state root calculation in bundle metering. This provides visibility into the I/O cost of computing state roots, which is critical for understanding the full execution costs of a given bundle.

Key changes:
- Add `MeterBundleOutput` struct to replace tuple return type with named fields
- Add `state_root_time_us` field to measure state root calculation time separately
- Add `total_time_us` field for overall metering time (includes tx execution + state root)
- Calculate state root after transaction execution using `hashed_post_state` and `state_root_with_updates`
- Add `meter_bundle_state_root_time_invariant` test to verify timing consistency

## Test plan

- [x] `cargo test -p base-reth-metering` - all 20 tests pass
- [x] `cargo +nightly fmt --all -- --check` - passes
- [x] `cargo +nightly clippy --all-targets --all-features -- -D warnings` - passes
