### PR TITLE
chore(workspace): Reduce target directory bloat

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,8 @@ redundant-clone = "warn"
 
 [profile.dev]
 debug = "line-tables-only"
-split-debuginfo = "unpacked"
+split-debuginfo = "packed"
+incremental = false
 
 [profile.release]
 opt-level = 3


### PR DESCRIPTION
### Description

Changes `split-debuginfo` from "unpacked" to "packed" and disables incremental compilation in dev profile.

### Why

The target/ directory grows unboundedly over time (200GB+) due to:

1. Unpacked debug info creates thousands of loose `.o`/`.dwo` files that accumulate
2. Incremental compilation cache retains ~20+ versions of build artifacts with no garbage collection

### Tradeoffs

- Slightly slower rebuilds without incremental compilation (~15-20% overhead on from-scratch builds)
- Debug info still available, just bundled into binaries instead of separate files