### PR TITLE
chore(workspace): remove legacy tips-core dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -120,9 +120,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-chains"
-version = "0.2.25"
+version = "0.2.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd208e8a87fbc2ca1a3822dd1ea03b0a7a4a841e6fa70db2c236dd30ae2e7018"
+checksum = "25db5bcdd086f0b1b9610140a12c59b757397be90bd130d8d836fc8da0815a34"
 dependencies = [
  "alloy-primitives 1.5.2",
  "alloy-rlp",
@@ -1032,7 +1032,7 @@ dependencies = [
  "serde_json",
  "tower 0.5.2",
  "tracing",
- "tracing-opentelemetry 0.32.0",
+ "tracing-opentelemetry 0.32.1",
  "url",
 ]
 
@@ -4418,9 +4418,9 @@ checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
 
 [[package]]
 name = "flate2"
-version = "1.1.5"
+version = "1.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfe33edd8e85a12a67454e37f8c75e730830d83e313556ab9ebf9ee7fbeb3bfb"
+checksum = "b375d6465b98090a5f25b1c7703f3859783755aa9a80433b36e0379a3ec2f369"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
@@ -7547,6 +7547,7 @@ dependencies = [
  "alloy-transport-http",
  "anyhow",
  "async-trait",
+ "base-bundles",
  "chrono",
  "clap",
  "clap_builder",
@@ -7645,7 +7646,6 @@ dependencies = [
  "thiserror 2.0.17",
  "tikv-jemallocator",
  "time",
- "tips-core",
  "tokio",
  "tokio-tungstenite 0.26.2",
  "tokio-util",
@@ -8737,7 +8737,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
  "rand_chacha 0.9.0",
- "rand_core 0.9.3",
+ "rand_core 0.9.4",
  "serde",
 ]
 
@@ -8758,7 +8758,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.9.3",
+ "rand_core 0.9.4",
 ]
 
 [[package]]
@@ -8772,9 +8772,9 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.9.3"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
+checksum = "4f1b3bc831f92381018fd9c6350b917c7b21f1eed35a65a51900e0e55a3d7afa"
 dependencies = [
  "getrandom 0.3.4",
  "serde",
@@ -8786,7 +8786,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
 dependencies = [
- "rand_core 0.9.3",
+ "rand_core 0.9.4",
 ]
 
 [[package]]
@@ -8795,7 +8795,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f703f4665700daf5512dcca5f43afa6af89f09db47fb56be587f80636bda2d41"
 dependencies = [
- "rand_core 0.9.3",
+ "rand_core 0.9.4",
 ]
 
 [[package]]
@@ -11951,7 +11951,7 @@ dependencies = [
  "opentelemetry-semantic-conventions",
  "opentelemetry_sdk 0.31.0",
  "tracing",
- "tracing-opentelemetry 0.32.0",
+ "tracing-opentelemetry 0.32.1",
  "tracing-subscriber 0.3.22",
  "url",
 ]
@@ -13982,23 +13982,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
-name = "tips-core"
-version = "0.1.0"
-source = "git+https://github.com/base/tips?rev=c08eaa4fe10c26de8911609b41ddab4918698325#c08eaa4fe10c26de8911609b41ddab4918698325"
-dependencies = [
- "alloy-consensus",
- "alloy-primitives 1.5.2",
- "alloy-provider",
- "alloy-serde",
- "op-alloy-consensus",
- "op-alloy-flz",
- "serde",
- "tracing",
- "tracing-subscriber 0.3.22",
- "uuid",
-]
-
-[[package]]
 name = "tokio"
 version = "1.49.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -14472,16 +14455,13 @@ dependencies = [
 
 [[package]]
 name = "tracing-opentelemetry"
-version = "0.32.0"
+version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e6e5658463dd88089aba75c7791e1d3120633b1bfde22478b28f625a9bb1b8e"
+checksum = "1ac28f2d093c6c477eaa76b23525478f38de514fa9aeb1285738d4b97a9552fc"
 dependencies = [
  "js-sys",
  "opentelemetry 0.31.0",
- "opentelemetry_sdk 0.31.0",
- "rustversion",
  "smallvec",
- "thiserror 2.0.17",
  "tracing",
  "tracing-core",
  "tracing-log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -250,4 +250,3 @@ ethereum_ssz_derive = "0.9.0"
 
 # base
 concurrent-queue = "2.5.0"
-tips-core = { git = "https://github.com/base/tips", rev = "c08eaa4fe10c26de8911609b41ddab4918698325", default-features = false }

--- a/crates/builder/op-rbuilder/Cargo.toml
+++ b/crates/builder/op-rbuilder/Cargo.toml
@@ -18,7 +18,7 @@ unused_async = "warn"
 [dependencies]
 p2p = { path = "../p2p" }
 
-tips-core.workspace = true
+base-bundles.workspace = true
 
 reth.workspace = true
 reth-optimism-node.workspace = true

--- a/crates/builder/op-rbuilder/src/tests/backrun.rs
+++ b/crates/builder/op-rbuilder/src/tests/backrun.rs
@@ -3,7 +3,7 @@ use alloy_eips::eip2718::Encodable2718;
 use alloy_primitives::{TxHash, U256};
 use alloy_provider::Provider;
 use macros::rb_test;
-use tips_core::{AcceptedBundle, MeterBundleResponse};
+use base_bundles::{AcceptedBundle, MeterBundleResponse};
 use uuid::Uuid;
 
 /// Tests that backrun bundles are all-or-nothing:

--- a/crates/builder/op-rbuilder/src/tx_data_store.rs
+++ b/crates/builder/op-rbuilder/src/tx_data_store.rs
@@ -16,7 +16,7 @@ use std::{
     },
     time::Instant,
 };
-use tips_core::{AcceptedBundle, MeterBundleResponse};
+use base_bundles::{AcceptedBundle, MeterBundleResponse};
 use tracing::{debug, info, warn};
 use uuid::Uuid;
 


### PR DESCRIPTION
Replace tips-core with base-bundles for AcceptedBundle and MeterBundleResponse types.

  Closes #361