### PR TITLE
chore: remove reth barrel imports

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -66,15 +66,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "aligned-vec"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc890384c8602f339876ded803c97ad529f3842aba97f6392b3dba0dd171769b"
-dependencies = [
- "equator",
-]
-
-[[package]]
 name = "alloc-no-stdlib"
 version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1896,7 +1887,7 @@ dependencies = [
  "clap",
  "eyre",
  "libc",
- "reth",
+ "reth-node-core",
  "tokio",
  "tracing",
 ]
@@ -1921,9 +1912,10 @@ dependencies = [
  "jsonrpsee",
  "op-alloy-network",
  "op-alloy-rpc-types-engine",
- "reth",
+ "reth-chainspec",
  "reth-db",
  "reth-ipc",
+ "reth-node-builder",
  "reth-node-core",
  "reth-optimism-chainspec",
  "reth-optimism-node",
@@ -1932,6 +1924,7 @@ dependencies = [
  "reth-primitives-traits",
  "reth-provider",
  "reth-rpc-layer",
+ "reth-tasks",
  "reth-tracing",
  "tokio",
  "tower",
@@ -1986,7 +1979,7 @@ dependencies = [
  "op-alloy-rpc-types",
  "rand 0.9.2",
  "rayon",
- "reth",
+ "reth-chainspec",
  "reth-db",
  "reth-db-common",
  "reth-evm",
@@ -1999,12 +1992,15 @@ dependencies = [
  "reth-primitives",
  "reth-primitives-traits",
  "reth-provider",
+ "reth-revm",
  "reth-rpc",
  "reth-rpc-convert",
  "reth-rpc-eth-api",
+ "reth-rpc-eth-types",
  "reth-testing-utils",
  "reth-tracing",
  "reth-transaction-pool",
+ "revm",
  "revm-database",
  "rstest",
  "serde",
@@ -2049,7 +2045,6 @@ dependencies = [
  "jsonrpsee",
  "op-alloy-consensus",
  "rand 0.9.2",
- "reth",
  "reth-db",
  "reth-db-common",
  "reth-evm",
@@ -2059,6 +2054,7 @@ dependencies = [
  "reth-optimism-primitives",
  "reth-primitives-traits",
  "reth-provider",
+ "reth-revm",
  "reth-transaction-pool",
  "revm-database",
  "serde",
@@ -2122,8 +2118,10 @@ dependencies = [
  "jsonrpsee",
  "lru 0.16.3",
  "metrics",
- "reth",
  "reth-exex",
+ "reth-node-api",
+ "reth-primitives-traits",
+ "reth-provider",
  "reth-tracing",
  "reth-transaction-pool",
  "serde",
@@ -2386,147 +2384,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "boa_ast"
-version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc119a5ad34c3f459062a96907f53358989b173d104258891bb74f95d93747e8"
-dependencies = [
- "bitflags 2.10.0",
- "boa_interner",
- "boa_macros",
- "boa_string",
- "indexmap 2.13.0",
- "num-bigint",
- "rustc-hash 2.1.1",
-]
-
-[[package]]
-name = "boa_engine"
-version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e637ec52ea66d76b0ca86180c259d6c7bb6e6a6e14b2f36b85099306d8b00cc3"
-dependencies = [
- "aligned-vec",
- "arrayvec",
- "bitflags 2.10.0",
- "boa_ast",
- "boa_gc",
- "boa_interner",
- "boa_macros",
- "boa_parser",
- "boa_string",
- "bytemuck",
- "cfg-if",
- "cow-utils",
- "dashmap 6.1.0",
- "dynify",
- "fast-float2",
- "float16",
- "futures-channel",
- "futures-concurrency",
- "futures-lite",
- "hashbrown 0.16.1",
- "icu_normalizer",
- "indexmap 2.13.0",
- "intrusive-collections",
- "itertools 0.14.0",
- "num-bigint",
- "num-integer",
- "num-traits",
- "num_enum",
- "paste",
- "portable-atomic",
- "rand 0.9.2",
- "regress",
- "rustc-hash 2.1.1",
- "ryu-js",
- "serde",
- "serde_json",
- "small_btree",
- "static_assertions",
- "tag_ptr",
- "tap",
- "thin-vec",
- "thiserror 2.0.17",
- "time",
- "xsum",
-]
-
-[[package]]
-name = "boa_gc"
-version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1179f690cbfcbe5364cceee5f1cb577265bb6f07b0be6f210aabe270adcf9da"
-dependencies = [
- "boa_macros",
- "boa_string",
- "hashbrown 0.16.1",
- "thin-vec",
-]
-
-[[package]]
-name = "boa_interner"
-version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9626505d33dc63d349662437297df1d3afd9d5fc4a2b3ad34e5e1ce879a78848"
-dependencies = [
- "boa_gc",
- "boa_macros",
- "hashbrown 0.16.1",
- "indexmap 2.13.0",
- "once_cell",
- "phf",
- "rustc-hash 2.1.1",
- "static_assertions",
-]
-
-[[package]]
-name = "boa_macros"
-version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f36418a46544b152632c141b0a0b7a453cd69ca150caeef83aee9e2f4b48b7d"
-dependencies = [
- "cfg-if",
- "cow-utils",
- "proc-macro2",
- "quote",
- "syn 2.0.114",
- "synstructure 0.13.2",
-]
-
-[[package]]
-name = "boa_parser"
-version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02f99bf5b684f0de946378fcfe5f38c3a0fbd51cbf83a0f39ff773a0e218541f"
-dependencies = [
- "bitflags 2.10.0",
- "boa_ast",
- "boa_interner",
- "boa_macros",
- "fast-float2",
- "icu_properties",
- "num-bigint",
- "num-traits",
- "regress",
- "rustc-hash 2.1.1",
-]
-
-[[package]]
-name = "boa_string"
-version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45ce9d7aa5563a2e14eab111e2ae1a06a69a812f6c0c3d843196c9d03fbef440"
-dependencies = [
- "fast-float2",
- "itoa",
- "paste",
- "rustc-hash 2.1.1",
- "ryu-js",
- "static_assertions",
-]
-
-[[package]]
 name = "bollard"
 version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2662,20 +2519,6 @@ name = "bytemuck"
 version = "1.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fbdf580320f38b612e485521afda1ee26d10cc9884efaaa750d383e13e3c5f4"
-dependencies = [
- "bytemuck_derive",
-]
-
-[[package]]
-name = "bytemuck_derive"
-version = "1.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9abbd1bc6865053c427f7198e6af43bfdedc55ab791faed4fbd361d789575ff"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.114",
-]
 
 [[package]]
 name = "byteorder"
@@ -3212,12 +3055,6 @@ checksum = "b49ba7ef1ad6107f8824dbe97de947cbaac53c44e7f9756a1fba0d37c1eec505"
 dependencies = [
  "memchr",
 ]
-
-[[package]]
-name = "cow-utils"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "417bef24afe1460300965a25ff4a24b8b45ad011948302ec221e8a0a81eb2c79"
 
 [[package]]
 name = "cpufeatures"
@@ -3957,26 +3794,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
-name = "dynify"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81acb15628a3e22358bf73de5e7e62360b8a777dbcb5fc9ac7dfa9ae73723747"
-dependencies = [
- "dynify-macros",
-]
-
-[[package]]
-name = "dynify-macros"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ec431cd708430d5029356535259c5d645d60edd3d39c54e5eea9782d46caa7d"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.114",
-]
-
-[[package]]
 name = "ecdsa"
 version = "0.16.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4140,26 +3957,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "equator"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4711b213838dfee0117e3be6ac926007d7f433d7bbe33595975d4190cb07e6fc"
-dependencies = [
- "equator-macro",
-]
-
-[[package]]
-name = "equator-macro"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44f23cf4b44bfce11a86ace86f8a73ffdec849c9fd00a386a53d278bd9e81fb3"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.114",
-]
-
-[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4278,12 +4075,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fast-float2"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8eb564c5c7423d25c886fb561d1e4ee69f72354d16918afa32c08811f6b6a55"
-
-[[package]]
 name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4362,12 +4153,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fixedbitset"
-version = "0.5.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
-
-[[package]]
 name = "flate2"
 version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4375,16 +4160,6 @@ checksum = "bfe33edd8e85a12a67454e37f8c75e730830d83e313556ab9ebf9ee7fbeb3bfb"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
-]
-
-[[package]]
-name = "float16"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7bffafbd079d520191c7c2779ae9cf757601266cf4167d3f659ff09617ff8483"
-dependencies = [
- "cfg-if",
- "rustc_version 0.2.3",
 ]
 
 [[package]]
@@ -4486,19 +4261,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "futures-concurrency"
-version = "7.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69a9561702beff46b705a8ac9c0803ec4c7fc5d01330a99b1feaf86e206e92ba"
-dependencies = [
- "fixedbitset",
- "futures-core",
- "futures-lite",
- "pin-project",
- "smallvec",
-]
-
-[[package]]
 name = "futures-core"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4528,10 +4290,7 @@ version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f78e10609fe0e0b3f4157ffab1876319b5b0db102a2c60dc4626306dc46b44ad"
 dependencies = [
- "fastrand",
  "futures-core",
- "futures-io",
- "parking",
  "pin-project-lite",
 ]
 
@@ -5268,8 +5027,6 @@ dependencies = [
  "icu_properties",
  "icu_provider",
  "smallvec",
- "utf16_iter",
- "write16",
  "zerovec",
 ]
 
@@ -5543,15 +5300,6 @@ dependencies = [
  "tokio",
  "widestring",
  "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "intrusive-collections"
-version = "0.9.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "189d0897e4cbe8c75efedf3502c18c887b05046e59d28404d4d8e46cbc4d1e86"
-dependencies = [
- "memoffset",
 ]
 
 [[package]]
@@ -6588,15 +6336,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "memoffset"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
-dependencies = [
- "autocfg",
-]
-
-[[package]]
 name = "metrics"
 version = "0.24.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7043,7 +6782,6 @@ checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
 dependencies = [
  "num-integer",
  "num-traits",
- "serde",
 ]
 
 [[package]]
@@ -7391,7 +7129,6 @@ dependencies = [
  "parking_lot",
  "rand 0.9.2",
  "reqwest",
- "reth",
  "reth-basic-payload-builder",
  "reth-chain-state",
  "reth-chainspec",
@@ -8654,16 +8391,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
 
 [[package]]
-name = "regress"
-version = "0.10.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2057b2325e68a893284d1538021ab90279adac1139957ca2a74426c6f118fb48"
-dependencies = [
- "hashbrown 0.16.1",
- "memchr",
-]
-
-[[package]]
 name = "relative-path"
 version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8723,52 +8450,6 @@ name = "resolv-conf"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
-
-[[package]]
-name = "reth"
-version = "1.9.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.3#27a8c0f5a6dfb27dea84c5751776ecabdd069646"
-dependencies = [
- "alloy-rpc-types",
- "aquamarine",
- "clap",
- "eyre",
- "reth-chainspec",
- "reth-cli-runner",
- "reth-cli-util",
- "reth-consensus",
- "reth-consensus-common",
- "reth-db",
- "reth-ethereum-cli",
- "reth-ethereum-payload-builder",
- "reth-ethereum-primitives",
- "reth-evm",
- "reth-network",
- "reth-network-api",
- "reth-node-api",
- "reth-node-builder",
- "reth-node-core",
- "reth-node-ethereum",
- "reth-node-metrics",
- "reth-payload-builder",
- "reth-payload-primitives",
- "reth-primitives",
- "reth-provider",
- "reth-ress-protocol",
- "reth-ress-provider",
- "reth-revm",
- "reth-rpc",
- "reth-rpc-api",
- "reth-rpc-builder",
- "reth-rpc-convert",
- "reth-rpc-eth-types",
- "reth-rpc-server-types",
- "reth-tasks",
- "reth-tokio-util",
- "reth-transaction-pool",
- "tokio",
- "tracing",
-]
 
 [[package]]
 name = "reth-basic-payload-builder"
@@ -9619,30 +9300,6 @@ dependencies = [
  "reth-primitives-traits",
  "serde",
  "thiserror 2.0.17",
-]
-
-[[package]]
-name = "reth-ethereum-cli"
-version = "1.9.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.3#27a8c0f5a6dfb27dea84c5751776ecabdd069646"
-dependencies = [
- "clap",
- "eyre",
- "reth-chainspec",
- "reth-cli",
- "reth-cli-commands",
- "reth-cli-runner",
- "reth-db",
- "reth-node-api",
- "reth-node-builder",
- "reth-node-core",
- "reth-node-ethereum",
- "reth-node-metrics",
- "reth-rpc-server-types",
- "reth-tracing",
- "reth-tracing-otlp",
- "tracing",
- "url",
 ]
 
 [[package]]
@@ -11014,52 +10671,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "reth-ress-protocol"
-version = "1.9.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.3#27a8c0f5a6dfb27dea84c5751776ecabdd069646"
-dependencies = [
- "alloy-consensus",
- "alloy-primitives 1.5.2",
- "alloy-rlp",
- "futures",
- "reth-eth-wire",
- "reth-ethereum-primitives",
- "reth-network",
- "reth-network-api",
- "reth-storage-errors",
- "tokio",
- "tokio-stream",
- "tracing",
-]
-
-[[package]]
-name = "reth-ress-provider"
-version = "1.9.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.3#27a8c0f5a6dfb27dea84c5751776ecabdd069646"
-dependencies = [
- "alloy-consensus",
- "alloy-primitives 1.5.2",
- "eyre",
- "futures",
- "parking_lot",
- "reth-chain-state",
- "reth-errors",
- "reth-ethereum-primitives",
- "reth-evm",
- "reth-node-api",
- "reth-primitives-traits",
- "reth-ress-protocol",
- "reth-revm",
- "reth-storage-api",
- "reth-tasks",
- "reth-tokio-util",
- "reth-trie",
- "schnellru",
- "tokio",
- "tracing",
-]
-
-[[package]]
 name = "reth-revm"
 version = "1.9.3"
 source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.3#27a8c0f5a6dfb27dea84c5751776ecabdd069646"
@@ -11949,8 +11560,6 @@ dependencies = [
  "alloy-rpc-types-trace",
  "alloy-sol-types 1.5.2",
  "anstyle",
- "boa_engine",
- "boa_gc",
  "colorchoice",
  "revm",
  "serde",
@@ -12239,15 +11848,6 @@ checksum = "3e75f6a532d0fd9f7f13144f392b6ad56a32696bfcd9c78f797f16bbb6f072d6"
 
 [[package]]
 name = "rustc_version"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
-dependencies = [
- "semver 0.9.0",
-]
-
-[[package]]
-name = "rustc_version"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0dfe2087c51c460008730de8b57e6a320782fbfb312e1f4d520e6c6fae155ee"
@@ -12421,12 +12021,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a50f4cf475b65d88e057964e0e9bb1f0aa9bbb2036dc65c64596b42932536984"
 
 [[package]]
-name = "ryu-js"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd29631678d6fb0903b69223673e122c32e9ae559d0960a38d574695ebc0ea15"
-
-[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12579,20 +12173,11 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
-dependencies = [
- "semver-parser 0.7.0",
-]
-
-[[package]]
-name = "semver"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f301af10236f6df4160f7c3f04eec6dbc70ace82d23326abad5edee88801c6b6"
 dependencies = [
- "semver-parser 0.10.3",
+ "semver-parser",
 ]
 
 [[package]]
@@ -12604,12 +12189,6 @@ dependencies = [
  "serde",
  "serde_core",
 ]
-
-[[package]]
-name = "semver-parser"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "semver-parser"
@@ -12982,15 +12561,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
 
 [[package]]
-name = "small_btree"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ba60d2df92ba73864714808ca68c059734853e6ab722b40e1cf543ebb3a057a"
-dependencies = [
- "arrayvec",
-]
-
-[[package]]
 name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -13301,12 +12871,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tag_ptr"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0e973b34477b7823833469eb0f5a3a60370fef7a453e02d751b59180d0a5a05"
-
-[[package]]
 name = "tagptr"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -13432,12 +12996,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "thin-vec"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "144f754d318415ac792f9d69fc87abbbfc043ce2ef041c60f16ad828f638717d"
-
-[[package]]
 name = "thiserror"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -13534,7 +13092,6 @@ checksum = "91e7d9e3bb61134e77bde20dd4825b97c010155709965fedf0f49bb138e52a9d"
 dependencies = [
  "deranged",
  "itoa",
- "js-sys",
  "libc",
  "num-conv",
  "num_threads",
@@ -14342,12 +13899,6 @@ name = "utf-8"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
-
-[[package]]
-name = "utf16_iter"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8232dd3cdaed5356e0f716d285e4b40b932ac434100fe9b7e0e8e935b9e6246"
 
 [[package]]
 name = "utf8_iter"
@@ -15283,12 +14834,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
 
 [[package]]
-name = "write16"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1890f4022759daae28ed4fe62859b1236caebfc61ede2f63ed4e695f3f6d936"
-
-[[package]]
 name = "writeable"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -15392,12 +14937,6 @@ checksum = "d7d8a75eaf6557bb84a65ace8609883db44a29951042ada9b393151532e41fcb"
 dependencies = [
  "xml-rs",
 ]
-
-[[package]]
-name = "xsum"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0637d3a5566a82fa5214bae89087bc8c9fb94cd8e8a3c07feb691bb8d9c632db"
 
 [[package]]
 name = "yamux"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,7 +66,6 @@ base-txpool = { path = "crates/client/txpool" }
 base-flashblocks = { path = "crates/client/flashblocks" }
 
 # reth
-reth = { git = "https://github.com/paradigmxyz/reth", tag = "v1.9.3" }
 reth-ipc = { git = "https://github.com/paradigmxyz/reth", tag = "v1.9.3" }
 reth-evm = { git = "https://github.com/paradigmxyz/reth", tag = "v1.9.3" }
 reth-exex = { git = "https://github.com/paradigmxyz/reth", tag = "v1.9.3" }

--- a/crates/builder/op-rbuilder/Cargo.toml
+++ b/crates/builder/op-rbuilder/Cargo.toml
@@ -21,7 +21,6 @@ p2p = { path = "../p2p" }
 base-bundles.workspace = true
 base-flashtypes.workspace = true
 
-reth.workspace = true
 reth-optimism-node.workspace = true
 reth-optimism-cli.workspace = true
 reth-optimism-chainspec.workspace = true
@@ -184,7 +183,6 @@ jemalloc = [
 jemalloc-prof = [
 	"jemalloc",
 	"reth-cli-util/jemalloc-prof",
-	"reth/jemalloc-prof",
 	"tikv-jemallocator?/profiling",
 ]
 

--- a/crates/builder/op-rbuilder/src/builders/context.rs
+++ b/crates/builder/op-rbuilder/src/builders/context.rs
@@ -7,7 +7,6 @@ use alloy_rpc_types_eth::Withdrawals;
 use core::fmt::Debug;
 use op_alloy_consensus::OpDepositReceipt;
 use op_revm::OpSpecId;
-use reth::payload::PayloadBuilderAttributes;
 use reth_basic_payload_builder::PayloadConfig;
 use reth_chainspec::{EthChainSpec, EthereumHardforks};
 use reth_evm::{
@@ -30,6 +29,7 @@ use reth_optimism_txpool::{
     interop::{MaybeInteropTransaction, is_valid_interop},
 };
 use reth_payload_builder::PayloadId;
+use reth_payload_primitives::PayloadBuilderAttributes;
 use reth_primitives::SealedHeader;
 use reth_primitives_traits::{InMemorySize, SignedTransaction};
 use reth_revm::{State, context::Block};

--- a/crates/builder/op-rbuilder/src/builders/flashblocks/p2p.rs
+++ b/crates/builder/op-rbuilder/src/builders/flashblocks/p2p.rs
@@ -1,7 +1,8 @@
 use alloy_primitives::U256;
-use reth::{core::primitives::SealedBlock, payload::PayloadId};
 use reth_optimism_payload_builder::OpBuiltPayload as RethOpBuiltPayload;
 use reth_optimism_primitives::OpBlock;
+use reth_payload_builder::PayloadId;
+use reth_primitives_traits::SealedBlock;
 use serde::{Deserialize, Serialize};
 
 pub(super) const AGENT_VERSION: &str = "op-rbuilder/1.0.0";

--- a/crates/builder/op-rbuilder/src/builders/flashblocks/payload.rs
+++ b/crates/builder/op-rbuilder/src/builders/flashblocks/payload.rs
@@ -19,7 +19,6 @@ use alloy_eips::{Encodable2718, eip7685::EMPTY_REQUESTS_HASH, merge::BEACON_NONC
 use alloy_primitives::{Address, B256, U256, map::foldhash::HashMap};
 use core::time::Duration;
 use eyre::WrapErr as _;
-use reth::payload::PayloadBuilderAttributes;
 use reth_basic_payload_builder::BuildOutcome;
 use reth_chain_state::ExecutedBlock;
 use reth_chainspec::EthChainSpec;
@@ -30,11 +29,11 @@ use reth_optimism_evm::{OpEvmConfig, OpNextBlockEnvAttributes};
 use reth_optimism_forks::OpHardforks;
 use reth_optimism_node::{OpBuiltPayload, OpPayloadBuilderAttributes};
 use reth_optimism_primitives::{OpPrimitives, OpReceipt, OpTransactionSigned};
+use reth_payload_primitives::PayloadBuilderAttributes;
 use reth_payload_util::BestPayloadTransactions;
 use reth_primitives_traits::RecoveredBlock;
 use reth_provider::{
-    ExecutionOutcome, HashedPostStateProvider, ProviderError, StateRootProvider,
-    StorageRootProvider,
+    ExecutionOutcome, HashedPostStateProvider, ProviderError, StateProvider, StateRootProvider, StorageRootProvider
 };
 use reth_revm::{
     State, database::StateProviderDatabase, db::states::bundle_state::BundleRetention,
@@ -601,7 +600,7 @@ where
         ctx: &OpPayloadBuilderCtx<FlashblocksExtraCtx>,
         info: &mut ExecutionInfo<FlashblocksExecutionInfo>,
         state: &mut State<DB>,
-        state_provider: impl reth::providers::StateProvider + Clone,
+        state_provider: impl StateProvider + Clone,
         best_txs: &mut NextBestFlashblocksTxs<Pool>,
         block_cancel: &CancellationToken,
         best_payload: &BlockCell<OpBuiltPayload>,

--- a/crates/builder/op-rbuilder/src/builders/generator.rs
+++ b/crates/builder/op-rbuilder/src/builders/generator.rs
@@ -1,9 +1,5 @@
 use alloy_primitives::B256;
 use futures_util::{Future, FutureExt};
-use reth::{
-    providers::{BlockReaderIdExt, StateProviderFactory},
-    tasks::TaskSpawner,
-};
 use reth_basic_payload_builder::{
     BasicPayloadJobGeneratorConfig, HeaderForPayload, PayloadConfig, PrecachedState,
 };
@@ -13,8 +9,9 @@ use reth_payload_builder::{
 };
 use reth_payload_primitives::BuiltPayload;
 use reth_primitives_traits::HeaderTy;
-use reth_provider::CanonStateNotification;
+use reth_provider::{BlockReaderIdExt, CanonStateNotification, StateProviderFactory};
 use reth_revm::cached::CachedReads;
+use reth_tasks::TaskSpawner;
 use std::{
     sync::{Arc, Mutex},
     time::{SystemTime, UNIX_EPOCH},
@@ -469,7 +466,7 @@ mod tests {
     use alloy_eips::eip7685::Requests;
     use alloy_primitives::U256;
     use rand::rng;
-    use reth::tasks::TokioTaskExecutor;
+    use reth_tasks::TokioTaskExecutor;
     use reth_chain_state::ExecutedBlock;
     use reth_node_api::NodePrimitives;
     use reth_optimism_payload_builder::{OpPayloadPrimitives, payload::OpPayloadBuilderAttributes};

--- a/crates/builder/op-rbuilder/src/builders/standard/payload.rs
+++ b/crates/builder/op-rbuilder/src/builders/standard/payload.rs
@@ -12,7 +12,6 @@ use alloy_consensus::{
 use alloy_eips::{eip7685::EMPTY_REQUESTS_HASH, merge::BEACON_NONCE};
 use alloy_evm::Database;
 use alloy_primitives::U256;
-use reth::payload::PayloadBuilderAttributes;
 use reth_basic_payload_builder::{BuildOutcome, BuildOutcomeKind, MissingPayloadBehaviour};
 use reth_chain_state::ExecutedBlock;
 use reth_evm::{ConfigureEvm, execute::BlockBuilder};
@@ -22,6 +21,7 @@ use reth_optimism_evm::{OpEvmConfig, OpNextBlockEnvAttributes};
 use reth_optimism_forks::OpHardforks;
 use reth_optimism_node::{OpBuiltPayload, OpPayloadBuilderAttributes};
 use reth_optimism_primitives::OpTransactionSigned;
+use reth_payload_primitives::PayloadBuilderAttributes;
 use reth_payload_util::{BestPayloadTransactions, NoopPayloadTransactions, PayloadTransactions};
 use reth_primitives::RecoveredBlock;
 use reth_primitives_traits::InMemorySize;

--- a/crates/builder/op-rbuilder/src/launcher.rs
+++ b/crates/builder/op-rbuilder/src/launcher.rs
@@ -1,4 +1,5 @@
 use eyre::Result;
+use reth_node_builder::WithLaunchContext;
 use reth_optimism_rpc::OpEthApiBuilder;
 
 use crate::{
@@ -13,11 +14,11 @@ use crate::{
 };
 use core::fmt::Debug;
 use moka::future::Cache;
-use reth::builder::{NodeBuilder, WithLaunchContext};
 use reth_cli_commands::launcher::Launcher;
 use reth_db::mdbx::DatabaseEnv;
 use reth_optimism_chainspec::OpChainSpec;
 use reth_optimism_cli::chainspec::OpChainSpecParser;
+use reth_node_builder::NodeBuilder;
 use reth_optimism_node::{
     OpNode,
     node::{OpAddOns, OpAddOnsBuilder, OpEngineValidatorBuilder, OpPoolBuilder},

--- a/crates/builder/op-rbuilder/src/mock_tx.rs
+++ b/crates/builder/op-rbuilder/src/mock_tx.rs
@@ -11,7 +11,7 @@ use alloy_eips::{
     eip7702::SignedAuthorization,
 };
 use alloy_primitives::{Address, B256, Bytes, TxHash, TxKind, U256};
-use reth::primitives::TransactionSigned;
+use reth_primitives::TransactionSigned;
 use reth_primitives_traits::{InMemorySize, SignedTransaction};
 use reth_transaction_pool::{
     EthBlobTransactionSidecar, EthPoolTransaction, PoolTransaction, TransactionOrigin,

--- a/crates/builder/op-rbuilder/src/primitives/reth/engine_api_builder.rs
+++ b/crates/builder/op-rbuilder/src/primitives/reth/engine_api_builder.rs
@@ -1,6 +1,6 @@
 //! RPC component builder
 
-use reth_node_api::AddOnsContext;
+use reth_node_api::{AddOnsContext, NodeTypes};
 use reth_node_builder::rpc::{EngineApiBuilder, PayloadValidatorBuilder};
 use reth_node_core::version::{CLIENT_CODE, version_metadata};
 use reth_optimism_node::OpEngineTypes;
@@ -22,7 +22,6 @@ use op_alloy_rpc_types_engine::{
     OpExecutionPayloadEnvelopeV3, OpExecutionPayloadEnvelopeV4, OpExecutionPayloadV4,
     OpPayloadAttributes, ProtocolVersion, SuperchainSignal,
 };
-use reth::builder::NodeTypes;
 use reth_node_api::{EngineApiValidator, EngineTypes};
 use reth_optimism_chainspec::OpChainSpec;
 use reth_optimism_rpc::OpEngineApiServer;

--- a/crates/builder/op-rbuilder/src/revert_protection.rs
+++ b/crates/builder/op-rbuilder/src/revert_protection.rs
@@ -12,9 +12,9 @@ use jsonrpsee::{
     proc_macros::rpc,
 };
 use moka::future::Cache;
-use reth::rpc::api::eth::{RpcReceipt, helpers::FullEthApi};
 use reth_optimism_txpool::{OpPooledTransaction, conditional::MaybeConditionalTransaction};
 use reth_provider::StateProviderFactory;
+use reth_rpc_api::eth::{RpcReceipt, helpers::FullEthApi};
 use reth_rpc_eth_types::{EthApiError, utils::recover_raw_transaction};
 use reth_transaction_pool::{PoolTransaction, TransactionOrigin, TransactionPool};
 use tracing::error;

--- a/crates/builder/op-rbuilder/src/tests/framework/apis.rs
+++ b/crates/builder/op-rbuilder/src/tests/framework/apis.rs
@@ -2,14 +2,13 @@ use super::DEFAULT_JWT_TOKEN;
 use alloy_eips::{BlockNumberOrTag, eip7685::Requests};
 use alloy_primitives::B256;
 
-use alloy_rpc_types_engine::{ForkchoiceUpdated, PayloadStatus};
+use alloy_rpc_types_engine::{ForkchoiceState, ForkchoiceUpdated, PayloadStatus};
 use core::{future::Future, marker::PhantomData};
 use jsonrpsee::{
     core::{RpcResult, client::SubscriptionClientT},
     proc_macros::rpc,
 };
 use op_alloy_rpc_types_engine::OpExecutionPayloadV4;
-use reth::rpc::types::engine::ForkchoiceState;
 use reth_node_api::{EngineTypes, PayloadTypes};
 use reth_optimism_node::OpEngineTypes;
 use reth_optimism_rpc::engine::OpEngineApiClient;

--- a/crates/builder/op-rbuilder/src/tests/framework/instance.rs
+++ b/crates/builder/op-rbuilder/src/tests/framework/instance.rs
@@ -14,6 +14,8 @@ use crate::{
 use alloy_primitives::{Address, B256, Bytes, hex, keccak256};
 use alloy_provider::{Identity, ProviderBuilder, RootProvider};
 use clap::Parser;
+use reth_node_core::{args::{DatadirArgs, NetworkArgs, RpcServerArgs}, exit::NodeExitFuture};
+use reth_tasks::TaskManager;
 use core::{
     any::Any,
     future::Future,
@@ -31,11 +33,6 @@ use moka::future::Cache;
 use nanoid::nanoid;
 use op_alloy_network::Optimism;
 use parking_lot::Mutex;
-use reth::{
-    args::{DatadirArgs, NetworkArgs, RpcServerArgs},
-    core::exit::NodeExitFuture,
-    tasks::TaskManager,
-};
 use reth_node_builder::{NodeBuilder, NodeConfig};
 use reth_optimism_chainspec::OpChainSpec;
 use reth_optimism_cli::commands::Commands;

--- a/crates/builder/op-rbuilder/src/tests/txpool.rs
+++ b/crates/builder/op-rbuilder/src/tests/txpool.rs
@@ -2,8 +2,8 @@ use crate::tests::{
     BlockTransactionsExt, ChainDriverExt, LocalInstance, ONE_ETH, default_node_config,
 };
 use macros::rb_test;
-use reth::args::TxPoolArgs;
 use reth_node_builder::NodeConfig;
+use reth_node_core::args::TxPoolArgs;
 use reth_optimism_chainspec::OpChainSpec;
 
 /// This test ensures that pending pool custom limit is respected and priority tx would be included even when pool if full.

--- a/crates/client/flashblocks/Cargo.toml
+++ b/crates/client/flashblocks/Cargo.toml
@@ -26,7 +26,6 @@ base-flashtypes.workspace = true
 base-client-node.workspace = true
 
 # reth
-reth.workspace = true
 reth-exex.workspace = true
 reth-evm.workspace = true
 reth-primitives.workspace = true
@@ -37,6 +36,10 @@ reth-optimism-rpc.workspace = true
 reth-optimism-evm.workspace = true
 reth-optimism-chainspec.workspace = true
 reth-optimism-primitives.workspace = true
+reth-provider.workspace = true
+reth-chainspec.workspace = true
+reth-revm.workspace = true
+reth-rpc-eth-types.workspace = true
 
 # alloy
 alloy-eips.workspace = true
@@ -60,6 +63,9 @@ tokio-stream.workspace = true
 
 # async
 futures-util.workspace = true
+
+# revm
+revm.workspace = true
 
 # rpc
 jsonrpsee.workspace = true

--- a/crates/client/flashblocks/benches/pending_state.rs
+++ b/crates/client/flashblocks/benches/pending_state.rs
@@ -14,13 +14,11 @@ use base_flashtypes::{
     ExecutionPayloadBaseV1, ExecutionPayloadFlashblockDeltaV1, Flashblock, Metadata,
 };
 use criterion::{BatchSize, Criterion, Throughput, criterion_group, criterion_main};
-use reth::{
-    chainspec::{ChainSpecProvider, EthChainSpec},
-    providers::BlockReader,
-    transaction_pool::test_utils::TransactionBuilder,
-};
+use reth_chainspec::{ChainSpecProvider, EthChainSpec};
 use reth_optimism_primitives::{OpBlock, OpTransactionSigned};
 use reth_primitives_traits::{Block as BlockT, RecoveredBlock};
+use reth_provider::BlockReader;
+use reth_transaction_pool::test_utils::TransactionBuilder;
 use tokio::{runtime::Runtime, time::sleep};
 use tracing_subscriber::{EnvFilter, filter::LevelFilter};
 

--- a/crates/client/flashblocks/src/pending_blocks.rs
+++ b/crates/client/flashblocks/src/pending_blocks.rs
@@ -13,9 +13,10 @@ use arc_swap::Guard;
 use base_flashtypes::Flashblock;
 use op_alloy_network::Optimism;
 use op_alloy_rpc_types::{OpTransactionReceipt, Transaction};
-use reth::revm::{db::BundleState, state::EvmState};
+use reth_revm::db::BundleState;
 use reth_rpc_convert::RpcTransaction;
 use reth_rpc_eth_api::{RpcBlock, RpcReceipt};
+use revm::state::EvmState;
 
 use crate::{BuildError, Metrics, PendingBlocksAPI, StateProcessorError};
 

--- a/crates/client/flashblocks/src/processor.rs
+++ b/crates/client/flashblocks/src/processor.rs
@@ -16,16 +16,14 @@ use base_flashtypes::Flashblock;
 use op_alloy_consensus::OpTxEnvelope;
 use op_alloy_network::TransactionResponse;
 use rayon::prelude::*;
-use reth::{
-    chainspec::{ChainSpecProvider, EthChainSpec},
-    providers::{BlockReaderIdExt, StateProviderFactory},
-    revm::{State, database::StateProviderDatabase},
-};
+use reth_chainspec::{ChainSpecProvider, EthChainSpec};
 use reth_evm::ConfigureEvm;
 use reth_optimism_chainspec::OpHardforks;
 use reth_optimism_evm::{OpEvmConfig, OpNextBlockEnvAttributes};
 use reth_optimism_primitives::OpBlock;
 use reth_primitives::RecoveredBlock;
+use reth_provider::{BlockReaderIdExt, StateProviderFactory};
+use reth_revm::{State, database::StateProviderDatabase};
 use revm_database::states::bundle_state::BundleRetention;
 use tokio::sync::{Mutex, broadcast::Sender, mpsc::UnboundedReceiver};
 

--- a/crates/client/flashblocks/src/rpc/eth.rs
+++ b/crates/client/flashblocks/src/rpc/eth.rs
@@ -20,14 +20,13 @@ use jsonrpsee::{
 use jsonrpsee_types::{ErrorObjectOwned, error::INVALID_PARAMS_CODE};
 use op_alloy_network::Optimism;
 use op_alloy_rpc_types::OpTransactionRequest;
-use reth::{
-    providers::CanonStateSubscriptions,
-    rpc::{eth::EthFilter, server_types::eth::EthApiError},
-};
+use reth_provider::CanonStateSubscriptions;
+use reth_rpc::eth::EthFilter;
 use reth_rpc_eth_api::{
     EthApiTypes, EthFilterApiServer, RpcBlock, RpcReceipt, RpcTransaction,
     helpers::{EthBlocks, EthCall, EthState, EthTransactions, FullEthApi},
 };
+use reth_rpc_eth_types::EthApiError;
 use tokio::{sync::broadcast::error::RecvError, time};
 use tokio_stream::{StreamExt, wrappers::BroadcastStream};
 use tracing::{debug, trace, warn};

--- a/crates/client/flashblocks/src/state.rs
+++ b/crates/client/flashblocks/src/state.rs
@@ -5,13 +5,11 @@ use std::sync::Arc;
 use alloy_consensus::Header;
 use arc_swap::{ArcSwapOption, Guard};
 use base_flashtypes::Flashblock;
-use reth::{
-    chainspec::{ChainSpecProvider, EthChainSpec},
-    providers::{BlockReaderIdExt, StateProviderFactory},
-};
+use reth_chainspec::{ChainSpecProvider, EthChainSpec};
 use reth_optimism_chainspec::OpHardforks;
 use reth_optimism_primitives::OpBlock;
 use reth_primitives::RecoveredBlock;
+use reth_provider::{BlockReaderIdExt, StateProviderFactory};
 use tokio::sync::{
     Mutex,
     broadcast::{self, Sender},

--- a/crates/client/flashblocks/src/state_builder.rs
+++ b/crates/client/flashblocks/src/state_builder.rs
@@ -10,7 +10,6 @@ use alloy_rpc_types::TransactionTrait;
 use alloy_rpc_types_eth::state::StateOverride;
 use op_alloy_consensus::{OpDepositReceipt, OpTxEnvelope};
 use op_alloy_rpc_types::{OpTransactionReceipt, Transaction};
-use reth::revm::{Database, DatabaseCommit, context::result::ResultAndState, state::EvmState};
 use reth_evm::{
     Evm, FromRecoveredTx, eth::receipt_builder::ReceiptBuilderCtx, op_revm::L1BlockInfo,
 };
@@ -19,6 +18,7 @@ use reth_optimism_evm::OpRethReceiptBuilder;
 use reth_optimism_primitives::OpPrimitives;
 use reth_optimism_rpc::OpReceiptBuilder as OpRpcReceiptBuilder;
 use reth_rpc_convert::transaction::ConvertReceiptInput;
+use revm::{Database, DatabaseCommit, context::result::ResultAndState, state::EvmState};
 
 use crate::{ExecutionError, PendingBlocks, StateProcessorError};
 

--- a/crates/client/flashblocks/src/test_harness.rs
+++ b/crates/client/flashblocks/src/test_harness.rs
@@ -23,8 +23,8 @@ use base_flashtypes::Flashblock;
 use derive_more::Deref;
 use eyre::Result;
 use once_cell::sync::OnceCell;
-use reth::providers::CanonStateSubscriptions;
 use reth_optimism_chainspec::OpChainSpec;
+use reth_provider::CanonStateSubscriptions;
 use tokio::sync::{mpsc, oneshot};
 use tokio_stream::StreamExt;
 

--- a/crates/client/flashblocks/tests/flashblocks_rpc.rs
+++ b/crates/client/flashblocks/tests/flashblocks_rpc.rs
@@ -20,7 +20,7 @@ use eyre::Result;
 use futures_util::{SinkExt, StreamExt};
 use op_alloy_network::{Optimism, ReceiptResponse, TransactionResponse};
 use op_alloy_rpc_types::OpTransactionRequest;
-use reth::revm::context::TransactionType;
+use reth_revm::context::TransactionType;
 use reth_rpc_eth_api::RpcReceipt;
 use serde_json::json;
 use tokio_tungstenite::{connect_async, tungstenite::Message};

--- a/crates/client/flashblocks/tests/state.rs
+++ b/crates/client/flashblocks/tests/state.rs
@@ -17,14 +17,13 @@ use base_flashtypes::{
 };
 use op_alloy_consensus::OpDepositReceipt;
 use op_alloy_network::BlockResponse;
-use reth::{
-    chainspec::EthChainSpec,
-    providers::{AccountReader, BlockNumReader, BlockReader},
-    transaction_pool::test_utils::TransactionBuilder,
-};
+use reth_chainspec::EthChainSpec;
 use reth_optimism_primitives::{OpBlock, OpReceipt, OpTransactionSigned};
 use reth_primitives_traits::{Account as RethAccount, Block as BlockT, RecoveredBlock};
-use reth_provider::{ChainSpecProvider, StateProviderFactory};
+use reth_provider::{
+    AccountReader, BlockNumReader, BlockReader, ChainSpecProvider, StateProviderFactory,
+};
+use reth_transaction_pool::test_utils::TransactionBuilder;
 use tokio::time::sleep;
 // The amount of time to wait (in milliseconds) after sending a new flashblock or canonical block
 // so it can be processed by the state processor

--- a/crates/client/metering/Cargo.toml
+++ b/crates/client/metering/Cargo.toml
@@ -17,13 +17,13 @@ base-bundles.workspace = true
 base-client-node.workspace = true
 
 # reth
-reth.workspace = true
 reth-provider.workspace = true
 reth-primitives-traits.workspace = true
 reth-evm.workspace = true
 reth-optimism-evm.workspace = true
 reth-optimism-chainspec.workspace = true
 reth-optimism-primitives.workspace = true
+reth-revm.workspace = true
 
 # revm
 revm-database.workspace = true

--- a/crates/client/metering/src/block.rs
+++ b/crates/client/metering/src/block.rs
@@ -5,13 +5,13 @@ use std::{sync::Arc, time::Instant};
 use alloy_consensus::{BlockHeader, Header, transaction::SignerRecoverable};
 use alloy_primitives::B256;
 use eyre::{Result as EyreResult, eyre};
-use reth::revm::db::State;
 use reth_evm::{ConfigureEvm, execute::BlockBuilder};
 use reth_optimism_chainspec::OpChainSpec;
 use reth_optimism_evm::{OpEvmConfig, OpNextBlockEnvAttributes};
 use reth_optimism_primitives::OpBlock;
 use reth_primitives_traits::Block as BlockT;
 use reth_provider::{HeaderProvider, StateProviderFactory};
+use reth_revm::{database::StateProviderDatabase, db::State};
 
 use crate::types::{MeterBlockResponse, MeterBlockTransactions};
 
@@ -57,7 +57,7 @@ where
     let state_provider = provider.state_by_block_hash(parent_hash)?;
 
     // Create state database from parent state
-    let state_db = reth::revm::database::StateProviderDatabase::new(&state_provider);
+    let state_db = StateProviderDatabase::new(&state_provider);
     let mut db = State::builder().with_database(state_db).with_bundle_update().build();
 
     // Set up block attributes from the actual block header

--- a/crates/client/metering/src/meter.rs
+++ b/crates/client/metering/src/meter.rs
@@ -6,11 +6,11 @@ use alloy_consensus::{BlockHeader, Transaction as _, transaction::SignerRecovera
 use alloy_primitives::{B256, U256};
 use base_bundles::{BundleExtensions, BundleTxs, ParsedBundle, TransactionResult};
 use eyre::{Result as EyreResult, eyre};
-use reth::revm::db::State;
 use reth_evm::{ConfigureEvm, execute::BlockBuilder};
 use reth_optimism_chainspec::OpChainSpec;
 use reth_optimism_evm::{OpEvmConfig, OpNextBlockEnvAttributes};
 use reth_primitives_traits::SealedHeader;
+use reth_revm::{database::StateProviderDatabase, db::State};
 use revm_database::states::bundle_state::BundleRetention;
 
 const BLOCK_TIME: u64 = 2; // 2 seconds per block
@@ -52,7 +52,7 @@ where
     let bundle_hash = bundle.bundle_hash();
 
     // Create state database
-    let state_db = reth::revm::database::StateProviderDatabase::new(state_provider);
+    let state_db = StateProviderDatabase::new(state_provider);
     let mut db = State::builder().with_database(state_db).with_bundle_update().build();
 
     // Set up next block attributes

--- a/crates/client/metering/src/rpc.rs
+++ b/crates/client/metering/src/rpc.rs
@@ -5,10 +5,11 @@ use alloy_eips::BlockNumberOrTag;
 use alloy_primitives::{B256, U256};
 use base_bundles::{Bundle, MeterBundleResponse, ParsedBundle};
 use jsonrpsee::core::{RpcResult, async_trait};
-use reth::providers::BlockReaderIdExt;
 use reth_optimism_chainspec::OpChainSpec;
 use reth_optimism_primitives::OpBlock;
-use reth_provider::{BlockReader, ChainSpecProvider, HeaderProvider, StateProviderFactory};
+use reth_provider::{
+    BlockReader, BlockReaderIdExt, ChainSpecProvider, HeaderProvider, StateProviderFactory,
+};
 use tracing::{error, info};
 
 use crate::{

--- a/crates/client/node/Cargo.toml
+++ b/crates/client/node/Cargo.toml
@@ -27,13 +27,14 @@ test-utils = [
 	"dep:jsonrpsee",
 	"dep:op-alloy-network",
 	"dep:op-alloy-rpc-types-engine",
+	"dep:reth-chainspec",
 	"dep:reth-ipc",
 	"dep:reth-node-core",
 	"dep:reth-optimism-primitives",
 	"dep:reth-optimism-rpc",
 	"dep:reth-primitives-traits",
-	"dep:reth-provider",
 	"dep:reth-rpc-layer",
+	"dep:reth-tasks",
 	"dep:reth-tracing",
 	"dep:tokio",
 	"dep:tower",
@@ -42,7 +43,7 @@ test-utils = [
 	"reth-db/test-utils",
 	"reth-optimism-node/test-utils",
 	"reth-primitives-traits?/test-utils",
-	"reth-provider?/test-utils",
+	"reth-provider/test-utils",
 ]
 
 [dependencies]
@@ -50,18 +51,20 @@ test-utils = [
 base-primitives = { workspace = true, optional = true }
 
 # reth
-reth.workspace = true
 reth-db.workspace = true
 reth-optimism-node.workspace = true
 reth-optimism-chainspec.workspace = true
 reth-ipc = { workspace = true, optional = true }
 reth-tracing = { workspace = true, optional = true }
 reth-rpc-layer = { workspace = true, optional = true }
-reth-provider = { workspace = true, optional = true }
+reth-provider = { workspace = true }
+reth-node-builder = { workspace = true }
 reth-node-core = { workspace = true, optional = true }
 reth-primitives-traits = { workspace = true, optional = true }
 reth-optimism-rpc = { workspace = true, features = ["client"], optional = true }
 reth-optimism-primitives = { workspace = true, optional = true }
+reth-chainspec = { workspace = true, optional = true }
+reth-tasks = { workspace = true, optional = true }
 
 # alloy
 alloy-primitives = { workspace = true, optional = true }

--- a/crates/client/node/src/handle.rs
+++ b/crates/client/node/src/handle.rs
@@ -9,7 +9,7 @@ use std::{
 use derive_more::Debug;
 use eyre::Result;
 use futures_util::{FutureExt, future::BoxFuture};
-use reth::builder::NodeHandleFor;
+use reth_node_builder::NodeHandleFor;
 use reth_optimism_node::OpNode;
 
 /// Handle to a launched Base node.

--- a/crates/client/node/src/runner.rs
+++ b/crates/client/node/src/runner.rs
@@ -1,11 +1,9 @@
 //! Contains the [`BaseNodeRunner`], which is responsible for configuring and launching a Base node.
 
 use eyre::Result;
-use reth::{
-    builder::{EngineNodeLauncher, Node, NodeHandleFor, TreeConfig},
-    providers::providers::BlockchainProvider,
-};
+use reth_node_builder::{EngineNodeLauncher, Node, NodeHandleFor, TreeConfig};
 use reth_optimism_node::{OpNode, args::RollupArgs};
+use reth_provider::providers::BlockchainProvider;
 use tracing::info;
 
 use crate::{BaseNodeBuilder, BaseNodeExtension, BaseNodeHandle, FromExtensionConfig};

--- a/crates/client/node/src/test_utils/constants.rs
+++ b/crates/client/node/src/test_utils/constants.rs
@@ -1,7 +1,7 @@
 //! Shared constants used across integration tests.
 
 use alloy_primitives::{B256, Bytes, b256, bytes};
-pub use reth::chainspec::NamedChain;
+pub use reth_chainspec::NamedChain;
 
 // Block Building
 

--- a/crates/client/node/src/test_utils/engine.rs
+++ b/crates/client/node/src/test_utils/engine.rs
@@ -7,14 +7,11 @@ use std::{fmt, marker::PhantomData, time::Duration};
 
 use alloy_eips::eip7685::Requests;
 use alloy_primitives::B256;
-use alloy_rpc_types_engine::{ForkchoiceUpdated, PayloadId, PayloadStatus};
+use alloy_rpc_types_engine::{ForkchoiceState, ForkchoiceUpdated, PayloadId, PayloadStatus};
 use eyre::Result;
 use jsonrpsee::core::client::SubscriptionClientT;
 use op_alloy_rpc_types_engine::OpExecutionPayloadV4;
-use reth::{
-    api::{EngineTypes, PayloadTypes},
-    rpc::types::engine::ForkchoiceState,
-};
+use reth_node_builder::{EngineTypes, PayloadTypes};
 use reth_optimism_node::OpEngineTypes;
 use reth_optimism_rpc::OpEngineApiClient;
 use reth_rpc_layer::{AuthClientLayer, JwtSecret};

--- a/crates/client/node/src/test_utils/fixtures.rs
+++ b/crates/client/node/src/test_utils/fixtures.rs
@@ -5,12 +5,12 @@ use std::sync::Arc;
 use alloy_genesis::GenesisAccount;
 use alloy_primitives::{U256, utils::Unit};
 use base_primitives::{Account, build_test_genesis};
-use reth::api::{NodeTypes, NodeTypesWithDBAdapter};
 use reth_db::{
     ClientVersion, DatabaseEnv, init_db,
     mdbx::{DatabaseArguments, KILOBYTE, MEGABYTE, MaxReadTransactionDuration},
     test_utils::{ERROR_DB_CREATION, TempDatabase, create_test_static_files_dir, tempdir_path},
 };
+use reth_node_builder::{NodeTypes, NodeTypesWithDBAdapter};
 use reth_optimism_chainspec::OpChainSpec;
 use reth_provider::{ProviderFactory, providers::StaticFileProvider};
 

--- a/crates/client/node/src/test_utils/harness.rs
+++ b/crates/client/node/src/test_utils/harness.rs
@@ -11,10 +11,11 @@ use alloy_rpc_types_engine::PayloadAttributes;
 use eyre::{Result, eyre};
 use op_alloy_network::Optimism;
 use op_alloy_rpc_types_engine::OpPayloadAttributes;
-use reth::providers::{BlockNumReader, BlockReader, ChainSpecProvider};
+use reth_chainspec::ChainSpecProvider;
 use reth_optimism_chainspec::OpChainSpec;
 use reth_optimism_primitives::OpBlock;
 use reth_primitives_traits::{Block as BlockT, RecoveredBlock};
+use reth_provider::{BlockNumReader, BlockReader};
 use tokio::time::sleep;
 
 use crate::{

--- a/crates/client/node/src/test_utils/node.rs
+++ b/crates/client/node/src/test_utils/node.rs
@@ -6,22 +6,21 @@ use alloy_provider::RootProvider;
 use alloy_rpc_client::RpcClient;
 use eyre::Result;
 use op_alloy_network::Optimism;
-use reth::{
-    args::{DiscoveryArgs, NetworkArgs, RpcServerArgs},
-    builder::{EngineNodeLauncher, Node, NodeBuilder, NodeConfig, NodeHandle, TreeConfig},
-    core::exit::NodeExitFuture,
-    providers::providers::BlockchainProvider,
-    tasks::TaskManager,
-};
 use reth_db::{
     ClientVersion, DatabaseEnv, init_db, mdbx::DatabaseArguments, test_utils::tempdir_path,
 };
+use reth_node_builder::{
+    EngineNodeLauncher, Node, NodeBuilder, NodeConfig, NodeHandle, TreeConfig,
+};
 use reth_node_core::{
-    args::DatadirArgs,
+    args::{DatadirArgs, DiscoveryArgs, NetworkArgs, RpcServerArgs},
     dirs::{DataDirPath, MaybePlatformPath},
+    exit::NodeExitFuture,
 };
 use reth_optimism_chainspec::OpChainSpec;
 use reth_optimism_node::{OpNode, args::RollupArgs};
+use reth_provider::providers::BlockchainProvider;
+use reth_tasks::TaskManager;
 
 use crate::{BaseNodeExtension, OpProvider, test_utils::engine::EngineApi};
 

--- a/crates/client/node/src/types.rs
+++ b/crates/client/node/src/types.rs
@@ -2,14 +2,14 @@
 
 use std::sync::Arc;
 
-use reth::{
-    api::{FullNodeTypesAdapter, NodeTypesWithDBAdapter},
-    builder::{Node, NodeBuilder, NodeBuilderWithComponents, WithLaunchContext},
-    providers::providers::BlockchainProvider,
-};
 use reth_db::DatabaseEnv;
+use reth_node_builder::{
+    FullNodeTypesAdapter, Node, NodeBuilder, NodeBuilderWithComponents, NodeTypesWithDBAdapter,
+    WithLaunchContext,
+};
 use reth_optimism_chainspec::OpChainSpec;
 use reth_optimism_node::OpNode;
+use reth_provider::providers::BlockchainProvider;
 
 type OpNodeTypes = FullNodeTypesAdapter<OpNode, Arc<DatabaseEnv>, OpProvider>;
 type OpComponentsBuilder = <OpNode as Node<OpNodeTypes>>::ComponentsBuilder;

--- a/crates/client/txpool/Cargo.toml
+++ b/crates/client/txpool/Cargo.toml
@@ -16,10 +16,12 @@ workspace = true
 base-client-node.workspace = true
 
 # reth
-reth.workspace = true
 reth-exex.workspace = true
 reth-tracing.workspace = true
 reth-transaction-pool.workspace = true
+reth-node-api.workspace = true
+reth-primitives-traits.workspace = true
+reth-provider.workspace = true
 
 # alloy
 alloy-primitives.workspace = true

--- a/crates/client/txpool/src/exex.rs
+++ b/crates/client/txpool/src/exex.rs
@@ -2,9 +2,10 @@
 
 use eyre::Result;
 use futures::StreamExt;
-use reth::{api::FullNodeComponents, transaction_pool::TransactionPool};
 use reth_exex::ExExContext;
+use reth_node_api::FullNodeComponents;
 use reth_tracing::tracing::debug;
+use reth_transaction_pool::TransactionPool;
 
 use crate::tracker::Tracker;
 

--- a/crates/client/txpool/src/tracker.rs
+++ b/crates/client/txpool/src/tracker.rs
@@ -8,14 +8,12 @@ use std::{
 use alloy_primitives::TxHash;
 use chrono::Local;
 use lru::LruCache;
-use reth::{
-    api::{BlockBody, NodePrimitives},
-    core::primitives::{AlloyBlockHeader, transaction::TxHashRef},
-    providers::Chain,
-    transaction_pool::{FullTransactionEvent, PoolTransaction},
-};
 use reth_exex::{ExExEvent, ExExNotification};
+use reth_node_api::{BlockBody, NodePrimitives};
+use reth_primitives_traits::{AlloyBlockHeader, transaction::TxHashRef};
+use reth_provider::Chain;
 use reth_tracing::tracing::{debug, info};
+use reth_transaction_pool::{FullTransactionEvent, PoolTransaction};
 
 use crate::{EventLog, Pool, TxEvent};
 

--- a/crates/shared/cli-utils/Cargo.toml
+++ b/crates/shared/cli-utils/Cargo.toml
@@ -12,11 +12,11 @@ description = "CLI Utilities"
 workspace = true
 
 [dependencies]
-reth.workspace = true
 tokio = { workspace = true, features = ["full"] }
 eyre.workspace = true
 clap = { workspace = true, features = ["derive"] }
 tracing.workspace = true
+reth-node-core.workspace = true
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"

--- a/crates/shared/cli-utils/src/version.rs
+++ b/crates/shared/cli-utils/src/version.rs
@@ -1,6 +1,6 @@
 //! Contains node versioning info.
 
-use reth::version::{
+use reth_node_core::version::{
     RethCliVersionConsts, default_reth_version_metadata, try_init_version_metadata,
 };
 


### PR DESCRIPTION
I think importing from individual crates is better than importing from `reth` and really seems to have a positive impact on compilation times and editor features. Anecdotally, editing the project seems much faster.

Ran `just build` after a `cargo clean` before and after


## With barrel imports
```
$ time just build
    Finished `release` profile [optimized] target(s) in 2m 37s
    
real    2m37.869s
user    48m44.659s
sys     5m29.438s
```

## Without barrel imports

```
$ time just build
    Finished `release` profile [optimized] target(s) in 2m 07s

real    2m7.848s
user    39m32.286s
sys     4m29.309s
```

(roughly 20% faster with these changes)