### PR TITLE
chore: fix solidity warning

### DIFF
--- a/crates/shared/access-lists/tests/builder/storage.rs
+++ b/crates/shared/access-lists/tests/builder/storage.rs
@@ -142,14 +142,14 @@ fn test_multi_sload_same_slot() {
             .with_code(Bytecode::new_raw(AccessListContract::DEPLOYED_BYTECODE.clone())),
     );
 
-    // getAB reads both `a` and `b` which are packed in slot 1
+    // getAb reads both `a` and `b` which are packed in slot 1
     let tx = OpTransaction::builder()
         .base(
             TxEnv::builder()
                 .caller(sender)
                 .chain_id(Some(DEVNET_CHAIN_ID))
                 .kind(TxKind::Call(contract))
-                .data(AccessListContract::getABCall {}.abi_encode().into())
+                .data(AccessListContract::getAbCall {}.abi_encode().into())
                 .nonce(0)
                 .gas_price(0)
                 .gas_priority_fee(None)

--- a/crates/shared/primitives/contracts/src/AccessList.sol
+++ b/crates/shared/primitives/contracts/src/AccessList.sol
@@ -34,7 +34,7 @@ contract AccessList {
         }
     }
 
-    function getAB() public view returns (uint128, uint128) {
+    function getAb() public view returns (uint128, uint128) {
         return (a, b);
     }
 


### PR DESCRIPTION
### Description
Fix the solidity warning that appears when running just ci.

```
No files changed, compilation skipped
note[mixed-case-function]: function names should use mixedCase
  --> src/AccessList.sol:37:14
   |
37 |     function getAB() public view returns (uint128, uint128) {
   |              ^^^^^ help: consider using: `getAb`
   |
   = help: https://book.getfoundry.sh/reference/forge/forge-lint#mixed-case-function
 ```