### PR TITLE
chore: cargo deny root reth repo

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -202,3 +202,23 @@ jobs:
       - name: Install just
         uses: extractions/setup-just@e33e0265a09d6d736e2ee1e0eb685ef1de4669ff # v3
       - run: just check-crate-deps
+
+  deny:
+    name: Cargo Deny
+    runs-on: ubuntu-latest
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@002fdce3c6a235733a90a27c80493a3241e56863 # v2.12.1
+        with:
+          egress-policy: audit
+
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: dtolnay/rust-toolchain@4305c38b25d97ef35a8ad1f985ccf2d2242004f2 # stable
+      - uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2.8.2
+        with:
+          cache-on-failure: true
+          add-rust-environment-hash-key: "false"
+          key: stable-${{ hashFiles('Cargo.lock') }}
+      - name: Install just
+        uses: extractions/setup-just@e33e0265a09d6d736e2ee1e0eb685ef1de4669ff # v3
+      - run: just check-deny

--- a/Justfile
+++ b/Justfile
@@ -22,7 +22,12 @@ lychee:
   lychee --config ./lychee.toml .
 
 # Checks formatting, udeps, clippy, and tests
-check: check-format check-udeps check-clippy test
+check: check-format check-udeps check-clippy test check-deny
+
+# Runs cargo deny to check dependencies
+check-deny:
+  @command -v cargo-deny >/dev/null 2>&1 || cargo install cargo-deny
+  cargo deny check bans --hide-inclusion-graph
 
 # Fixes formatting and clippy issues
 fix: format-fix clippy-fix zepter-fix

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,3 @@
+[bans]
+deny = ["reth"]
+multiple-versions = "allow"


### PR DESCRIPTION
Adds a cargo deny lint and config to deny importing reth directly.