### PR TITLE
chore: move FB state to config

### DIFF
--- a/bin/node/src/cli.rs
+++ b/bin/node/src/cli.rs
@@ -50,10 +50,7 @@ impl Args {
 
 impl From<Args> for Option<FlashblocksConfig> {
     fn from(args: Args) -> Self {
-        args.websocket_url.map(|url| FlashblocksConfig {
-            websocket_url: url,
-            max_pending_blocks_depth: args.max_pending_blocks_depth,
-        })
+        args.websocket_url.map(|url| FlashblocksConfig::new(url, args.max_pending_blocks_depth))
     }
 }
 

--- a/crates/client/flashblocks/Cargo.toml
+++ b/crates/client/flashblocks/Cargo.toml
@@ -79,7 +79,6 @@ serde.workspace = true
 revm-database.workspace = true
 
 # misc
-once_cell.workspace = true
 url.workspace = true
 thiserror.workspace = true
 tracing.workspace = true

--- a/crates/client/flashblocks/benches/pending_state.rs
+++ b/crates/client/flashblocks/benches/pending_state.rs
@@ -114,8 +114,8 @@ fn pending_state_benches(c: &mut Criterion) {
 }
 
 async fn build_pending_state(input: BenchInput) {
-    let state = FlashblocksState::new(input.provider, 5);
-    state.start();
+    let state = FlashblocksState::new(5);
+    state.start(input.provider);
     state.on_canonical_block_received(input.canonical_block);
 
     for flashblock in input.flashblocks {
@@ -148,7 +148,7 @@ fn init_bench_tracing() {
 }
 
 async fn wait_for_pending_state(
-    state: &FlashblocksState<LocalNodeProvider>,
+    state: &FlashblocksState,
     target_block: BlockNumber,
     expected_index: u64,
 ) {

--- a/crates/client/flashblocks/src/extension.rs
+++ b/crates/client/flashblocks/src/extension.rs
@@ -3,9 +3,8 @@
 
 use std::sync::Arc;
 
-use base_client_node::{BaseNodeExtension, FromExtensionConfig, OpBuilder, OpProvider};
+use base_client_node::{BaseNodeExtension, FromExtensionConfig, OpBuilder};
 use futures_util::TryStreamExt;
-use once_cell::sync::OnceCell;
 use reth_exex::ExExEvent;
 use tracing::info;
 use url::Url;
@@ -15,34 +14,37 @@ use crate::{
     FlashblocksSubscriber,
 };
 
-/// The flashblocks cell holds a shared state reference.
-pub type FlashblocksCell<T> = Arc<OnceCell<Arc<T>>>;
-
 /// Flashblocks-specific configuration knobs.
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct FlashblocksConfig {
     /// The websocket endpoint that streams flashblock updates.
-    pub websocket_url: String,
+    pub websocket_url: Url,
     /// Maximum number of pending flashblocks to retain in memory.
     pub max_pending_blocks_depth: u64,
+    /// Shared Flashblocks state.
+    pub state: Arc<FlashblocksState>,
+}
+
+impl FlashblocksConfig {
+    /// Create a new Flashblocks configuration.
+    pub fn new(websocket_url: String, max_pending_blocks_depth: u64) -> Self {
+        let state = Arc::new(FlashblocksState::new(max_pending_blocks_depth));
+        let ws_url = Url::parse(&websocket_url).expect("valid websocket URL");
+        Self { websocket_url: ws_url, max_pending_blocks_depth, state }
+    }
 }
 
 /// Helper struct that wires the Flashblocks feature (canon ExEx and RPC) into the node builder.
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct FlashblocksExtension {
-    /// Shared Flashblocks state cache.
-    cell: FlashblocksCell<FlashblocksState<OpProvider>>,
-    /// Optional Flashblocks configuration.
+    /// Optional Flashblocks configuration (includes state).
     config: Option<FlashblocksConfig>,
 }
 
 impl FlashblocksExtension {
     /// Create a new Flashblocks extension helper.
-    pub const fn new(
-        cell: FlashblocksCell<FlashblocksState<OpProvider>>,
-        config: Option<FlashblocksConfig>,
-    ) -> Self {
-        Self { cell, config }
+    pub const fn new(config: Option<FlashblocksConfig>) -> Self {
+        Self { config }
     }
 }
 
@@ -54,23 +56,17 @@ impl BaseNodeExtension for FlashblocksExtension {
             return builder;
         };
 
-        let flashblocks_cell = self.cell;
-        let cfg_for_rpc = cfg.clone();
-        let flashblocks_cell_for_rpc = flashblocks_cell.clone();
+        let state = cfg.state;
+        let mut subscriber = FlashblocksSubscriber::new(state.clone(), cfg.websocket_url);
+
+        let state_for_exex = state.clone();
+        let state_for_rpc = state.clone();
+        let state_for_start = state;
 
         // Install the canon ExEx
         let builder = builder.install_exex("flashblocks-canon", move |mut ctx| {
-            let flashblocks_cell = flashblocks_cell.clone();
+            let fb = state_for_exex;
             async move {
-                let fb = flashblocks_cell
-                    .get_or_init(|| {
-                        Arc::new(FlashblocksState::new(
-                            ctx.provider().clone(),
-                            cfg.max_pending_blocks_depth,
-                        ))
-                    })
-                    .clone();
-
                 Ok(async move {
                     while let Some(note) = ctx.notifications.try_next().await? {
                         if let Some(committed) = note.committed_chain() {
@@ -87,23 +83,19 @@ impl BaseNodeExtension for FlashblocksExtension {
             }
         });
 
+        // Start state processor and subscriber after node is started
+        let builder = builder.on_node_started(move |ctx| {
+            info!(message = "Starting Flashblocks state processor");
+            state_for_start.start(ctx.provider().clone());
+            subscriber.start();
+            Ok(())
+        });
+
         // Extend with RPC modules
         builder.extend_rpc_modules(move |ctx| {
             info!(message = "Starting Flashblocks RPC");
 
-            let ws_url = Url::parse(cfg_for_rpc.websocket_url.as_str())?;
-            let fb = flashblocks_cell_for_rpc
-                .get_or_init(|| {
-                    Arc::new(FlashblocksState::new(
-                        ctx.provider().clone(),
-                        cfg_for_rpc.max_pending_blocks_depth,
-                    ))
-                })
-                .clone();
-            fb.start();
-
-            let mut flashblocks_client = FlashblocksSubscriber::new(fb.clone(), ws_url);
-            flashblocks_client.start();
+            let fb = state_for_rpc;
 
             let api_ext = EthApiExt::new(
                 ctx.registry.eth_api().clone(),
@@ -127,6 +119,6 @@ impl FromExtensionConfig for FlashblocksExtension {
     type Config = Option<FlashblocksConfig>;
 
     fn from_config(config: Self::Config) -> Self {
-        Self::new(Arc::new(OnceCell::new()), config)
+        Self::new(config)
     }
 }

--- a/crates/client/flashblocks/src/lib.rs
+++ b/crates/client/flashblocks/src/lib.rs
@@ -45,7 +45,7 @@ pub use rpc::{
 };
 
 mod extension;
-pub use extension::{FlashblocksCell, FlashblocksConfig, FlashblocksExtension};
+pub use extension::{FlashblocksConfig, FlashblocksExtension};
 
 #[cfg(any(test, feature = "test-utils"))]
 pub mod test_harness;

--- a/crates/client/flashblocks/tests/state.rs
+++ b/crates/client/flashblocks/tests/state.rs
@@ -31,7 +31,7 @@ const SLEEP_TIME: u64 = 10;
 
 struct TestHarness {
     node: FlashblocksHarness,
-    flashblocks: Arc<FlashblocksState<LocalNodeProvider>>,
+    flashblocks: Arc<FlashblocksState>,
     provider: LocalNodeProvider,
 }
 


### PR DESCRIPTION
### Description
Migrate the FB State to the FB config so it can be accessed by other extensions that need it. 