### PR TITLE
refactor(cli-utils): RuntimeManager API Updates

### DIFF
--- a/crates/shared/cli-utils/README.md
+++ b/crates/shared/cli-utils/README.md
@@ -20,8 +20,7 @@ base-cli-utils = { git = "https://github.com/base/node-reth" }
 ```
 
 ```rust,ignore
-use base_cli_utils::{GlobalArgs, Version};
-use base_cli_utils::runtime::{build_runtime, run_until_ctrl_c};
+use base_cli_utils::{GlobalArgs, RuntimeManager, Version};
 use clap::Parser;
 
 #[derive(Parser)]
@@ -32,10 +31,12 @@ struct MyCli {
 
 fn main() -> eyre::Result<()> {
     Version::init();
-    let cli = MyCli::parse();
+    let _cli = MyCli::parse();
 
-    let runtime = build_runtime()?;
-    runtime.block_on(run_until_ctrl_c(async { /* ... */ }))
+    RuntimeManager::run_until_ctrl_c(async {
+        // ... your async code ...
+        Ok(())
+    })
 }
 ```
 

--- a/crates/shared/cli-utils/src/runtime.rs
+++ b/crates/shared/cli-utils/src/runtime.rs
@@ -21,11 +21,12 @@ impl RuntimeManager {
         let rt = Self::tokio_runtime().map_err(|e| eyre::eyre!(e))?;
         rt.block_on(async move {
             tokio::select! {
-                res = fut => res,
+                biased;
                 _ = tokio::signal::ctrl_c() => {
                     tracing::info!(target: "cli", "Received Ctrl-C, shutting down...");
                     Ok(())
                 }
+                res = fut => res,
             }
         })
     }


### PR DESCRIPTION
## Summary

Ported from #395.

Consolidate runtime utilities by replacing separate `build_runtime()`, `run_until_ctrl_c()`, and `run_until_ctrl_c_fallible()` methods with a simpler `tokio_runtime()` and unified `run_until_ctrl_c()` that handles runtime creation internally.
