### PR TITLE
fix(cli-utils): Sigsegv Lint Warning

### DIFF
--- a/crates/shared/cli-utils/src/sigsegv.rs
+++ b/crates/shared/cli-utils/src/sigsegv.rs
@@ -26,7 +26,7 @@ impl SigsegvHandler {
             libc::sigaltstack(&alt_stack, ptr::null_mut());
 
             let mut sa: libc::sigaction = mem::zeroed();
-            sa.sa_sigaction = print_stack_trace as libc::sighandler_t;
+            sa.sa_sigaction = print_stack_trace as *const () as libc::sighandler_t;
             sa.sa_flags = libc::SA_NODEFER | libc::SA_RESETHAND | libc::SA_ONSTACK;
             libc::sigemptyset(&mut sa.sa_mask);
             libc::sigaction(libc::SIGSEGV, &sa, ptr::null_mut());


### PR DESCRIPTION
### Description

Small PR to fix the sigsegv lint warning