### PR TITLE
chore(ci): De-Duplicate CI Jobs

### DIFF
--- a/.github/workflows/builder.yml
+++ b/.github/workflows/builder.yml
@@ -2,8 +2,13 @@ name: Builder CI
 
 on:
   push:
+    branches: [main]
   pull_request:
   merge_group:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,8 +2,13 @@ name: CI
 
 on:
   push:
+    branches: [main]
   pull_request:
   merge_group:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
## Summary

- Restrict `push` trigger to `main` branch only in CI workflows
- Add concurrency control to cancel in-progress runs on new pushes

## Why

Previously, PRs triggered both `pull_request` and `push` events, causing duplicate CI runs. Now PRs only trigger `pull_request`, and `push` only runs on merges to `main`. The concurrency group also cancels stale runs when new commits are pushed, saving CI resources.