### PR TITLE
chore: enable clippy on builder

### DIFF
--- a/crates/builder/op-rbuilder/Cargo.toml
+++ b/crates/builder/op-rbuilder/Cargo.toml
@@ -7,12 +7,8 @@ license.workspace = true
 homepage.workspace = true
 repository.workspace = true
 
-[lints.rust]
-unreachable_pub = "deny"
-dead_code = "allow"
-
-[lints.clippy]
-unused_async = "warn"
+[lints]
+workspace = true
 
 [dependencies]
 base-bundles.workspace = true

--- a/crates/builder/op-rbuilder/build.rs
+++ b/crates/builder/op-rbuilder/build.rs
@@ -1,3 +1,4 @@
+#![allow(missing_docs)]
 // Taken from reth [https://github.com/paradigmxyz/reth/blob/main/crates/node/core/build.rs]
 // The MIT License (MIT)
 //

--- a/crates/builder/op-rbuilder/src/args/mod.rs
+++ b/crates/builder/op-rbuilder/src/args/mod.rs
@@ -63,7 +63,7 @@ impl CliExt for Cli {
     }
 
     fn parsed() -> Self {
-        Cli::set_version().populate_defaults()
+        Self::set_version().populate_defaults()
     }
 
     /// Returns the type of builder implementation that the node is started with.
@@ -83,7 +83,7 @@ impl CliExt for Cli {
             .map(|root| root.join("op-rbuilder/logs"))
             .unwrap()
             .into_os_string();
-        let matches = Cli::command()
+        let matches = Self::command()
             .version(SHORT_VERSION)
             .long_version(LONG_VERSION)
             .about("Block builder designed for the Optimism stack")
@@ -91,7 +91,7 @@ impl CliExt for Cli {
             .name("op-rbuilder")
             .mut_arg("log_file_directory", |arg| arg.default_value(logs_dir))
             .get_matches();
-        Cli::from_arg_matches(&matches).expect("Parsing args")
+        Self::from_arg_matches(&matches).expect("Parsing args")
     }
 }
 

--- a/crates/builder/op-rbuilder/src/bin/tester/main.rs
+++ b/crates/builder/op-rbuilder/src/bin/tester/main.rs
@@ -1,3 +1,5 @@
+#![allow(missing_docs)]
+
 use alloy_primitives::Address;
 use alloy_provider::{Identity, ProviderBuilder};
 use clap::Parser;

--- a/crates/builder/op-rbuilder/src/builders/builder_tx.rs
+++ b/crates/builder/op-rbuilder/src/builders/builder_tx.rs
@@ -55,12 +55,12 @@ pub struct BuilderTransactionCtx {
 }
 
 impl BuilderTransactionCtx {
-    pub fn set_top_of_block(mut self) -> Self {
+    pub const fn set_top_of_block(mut self) -> Self {
         self.is_top_of_block = true;
         self
     }
 
-    pub fn set_bottom_of_block(mut self) -> Self {
+    pub const fn set_bottom_of_block(mut self) -> Self {
         self.is_top_of_block = false;
         self
     }
@@ -105,36 +105,34 @@ pub enum BuilderTransactionError {
 
 impl From<secp256k1::Error> for BuilderTransactionError {
     fn from(error: secp256k1::Error) -> Self {
-        BuilderTransactionError::SigningError(error)
+        Self::SigningError(error)
     }
 }
 
 impl From<EVMError<ProviderError, OpTransactionError>> for BuilderTransactionError {
     fn from(error: EVMError<ProviderError, OpTransactionError>) -> Self {
-        BuilderTransactionError::EvmExecutionError(Box::new(error))
+        Self::EvmExecutionError(Box::new(error))
     }
 }
 
 impl From<EthTxEnvError> for BuilderTransactionError {
     fn from(error: EthTxEnvError) -> Self {
-        BuilderTransactionError::EvmExecutionError(Box::new(error))
+        Self::EvmExecutionError(Box::new(error))
     }
 }
 
 impl From<BuilderTransactionError> for PayloadBuilderError {
     fn from(error: BuilderTransactionError) -> Self {
         match error {
-            BuilderTransactionError::EvmExecutionError(e) => {
-                PayloadBuilderError::EvmExecutionError(e)
-            }
-            _ => PayloadBuilderError::other(error),
+            BuilderTransactionError::EvmExecutionError(e) => Self::EvmExecutionError(e),
+            _ => Self::other(error),
         }
     }
 }
 
 impl BuilderTransactionError {
     pub fn other(error: impl core::error::Error + Send + Sync + 'static) -> Self {
-        BuilderTransactionError::Other(Box::new(error))
+        Self::Other(Box::new(error))
     }
 
     pub fn msg(msg: impl core::fmt::Display) -> Self {
@@ -378,7 +376,7 @@ pub(super) struct BuilderTxBase<ExtraCtx = ()> {
 }
 
 impl<ExtraCtx: Debug + Default> BuilderTxBase<ExtraCtx> {
-    pub(super) fn new(signer: Option<Signer>) -> Self {
+    pub(super) const fn new(signer: Option<Signer>) -> Self {
         Self { signer, _marker: std::marker::PhantomData }
     }
 

--- a/crates/builder/op-rbuilder/src/builders/context.rs
+++ b/crates/builder/op-rbuilder/src/builders/context.rs
@@ -84,10 +84,12 @@ pub struct OpPayloadBuilderCtx<ExtraCtx: Debug + Default = ()> {
 }
 
 impl<ExtraCtx: Debug + Default> OpPayloadBuilderCtx<ExtraCtx> {
+    #[allow(clippy::missing_const_for_fn)]
     pub(super) fn with_cancel(self, cancel: CancellationToken) -> Self {
         Self { cancel, ..self }
     }
 
+    #[allow(clippy::missing_const_for_fn)]
     pub(super) fn with_extra_ctx(self, extra_ctx: ExtraCtx) -> Self {
         Self { extra_ctx, ..self }
     }
@@ -121,19 +123,18 @@ impl<ExtraCtx: Debug + Default> OpPayloadBuilderCtx<ExtraCtx> {
 
     /// Returns the block gas limit to target.
     pub fn block_gas_limit(&self) -> u64 {
-        match self.gas_limit_config.gas_limit() {
-            Some(gas_limit) => gas_limit,
-            None => self.attributes().gas_limit.unwrap_or(self.evm_env.block_env.gas_limit),
-        }
+        self.gas_limit_config.gas_limit().unwrap_or_else(|| {
+            self.attributes().gas_limit.unwrap_or(self.evm_env.block_env.gas_limit)
+        })
     }
 
     /// Returns the block number for the block.
-    pub fn block_number(&self) -> u64 {
+    pub const fn block_number(&self) -> u64 {
         as_u64_saturated!(self.evm_env.block_env.number)
     }
 
     /// Returns the current base fee
-    pub fn base_fee(&self) -> u64 {
+    pub const fn base_fee(&self) -> u64 {
         self.evm_env.block_env.basefee
     }
 

--- a/crates/builder/op-rbuilder/src/builders/flashblocks/builder_tx.rs
+++ b/crates/builder/op-rbuilder/src/builders/flashblocks/builder_tx.rs
@@ -64,7 +64,7 @@ pub(super) struct FlashblocksBuilderTx {
 }
 
 impl FlashblocksBuilderTx {
-    pub(super) fn new(
+    pub(super) const fn new(
         signer: Option<Signer>,
         flashtestations_builder_tx: Option<
             FlashtestationsBuilderTx<FlashblocksExtraCtx, FlashblocksExecutionInfo>,
@@ -88,7 +88,7 @@ impl BuilderTransactions<FlashblocksExtraCtx, FlashblocksExecutionInfo> for Flas
 
         if ctx.is_first_flashblock() {
             let flashblocks_builder_tx = self.base_builder_tx.simulate_builder_tx(ctx, &mut *db)?;
-            builder_txs.extend(flashblocks_builder_tx.clone());
+            builder_txs.extend(flashblocks_builder_tx);
         }
 
         if ctx.is_last_flashblock() {
@@ -133,7 +133,7 @@ pub(super) struct FlashblocksNumberBuilderTx {
 }
 
 impl FlashblocksNumberBuilderTx {
-    pub(super) fn new(
+    pub(super) const fn new(
         signer: Signer,
         flashblock_number_address: Address,
         use_permit: bool,

--- a/crates/builder/op-rbuilder/src/builders/flashblocks/config.rs
+++ b/crates/builder/op-rbuilder/src/builders/flashblocks/config.rs
@@ -8,6 +8,7 @@ use alloy_primitives::Address;
 use crate::{args::OpRbuilderArgs, builders::BuilderConfig};
 
 /// Configuration values that are specific to the flashblocks builder.
+#[allow(unnameable_types)]
 #[derive(Debug, Clone)]
 pub struct FlashblocksConfig {
     /// The address of the websockets endpoint that listens for subscriptions to

--- a/crates/builder/op-rbuilder/src/builders/flashblocks/ctx.rs
+++ b/crates/builder/op-rbuilder/src/builders/flashblocks/ctx.rs
@@ -59,11 +59,11 @@ impl OpPayloadSyncerCtx {
         })
     }
 
-    pub(super) fn evm_config(&self) -> &OpEvmConfig {
+    pub(super) const fn evm_config(&self) -> &OpEvmConfig {
         &self.evm_config
     }
 
-    pub(super) fn max_gas_per_txn(&self) -> Option<u64> {
+    pub(super) const fn max_gas_per_txn(&self) -> Option<u64> {
         self.max_gas_per_txn
     }
 
@@ -88,7 +88,7 @@ impl OpPayloadSyncerCtx {
             extra_ctx: (),
             max_gas_per_txn: self.max_gas_per_txn,
             address_gas_limiter: AddressGasLimiter::new(GasLimiterArgs::default()),
-            tx_data_store: self.tx_data_store.clone(),
+            tx_data_store: self.tx_data_store,
         }
     }
 }

--- a/crates/builder/op-rbuilder/src/builders/flashblocks/ctx.rs
+++ b/crates/builder/op-rbuilder/src/builders/flashblocks/ctx.rs
@@ -20,6 +20,7 @@ use crate::{
     tx_data_store::TxDataStore,
 };
 
+#[allow(dead_code)]
 #[derive(Debug, Clone)]
 pub(super) struct OpPayloadSyncerCtx {
     /// The type that knows how to perform system calls and configure the evm.
@@ -36,6 +37,7 @@ pub(super) struct OpPayloadSyncerCtx {
     tx_data_store: TxDataStore,
 }
 
+#[allow(dead_code)]
 impl OpPayloadSyncerCtx {
     pub(super) fn new<Client>(
         client: &Client,

--- a/crates/builder/op-rbuilder/src/builders/flashblocks/mod.rs
+++ b/crates/builder/op-rbuilder/src/builders/flashblocks/mod.rs
@@ -15,6 +15,7 @@ mod wspub;
 
 /// Block building strategy that progressively builds chunks of a block and makes them available
 /// through a websocket update, then merges them into a full block every chain block time.
+#[derive(Debug)]
 pub struct FlashblocksBuilder;
 
 impl super::PayloadBuilder for FlashblocksBuilder {

--- a/crates/builder/op-rbuilder/src/builders/flashblocks/payload.rs
+++ b/crates/builder/op-rbuilder/src/builders/flashblocks/payload.rs
@@ -100,7 +100,7 @@ pub struct FlashblocksExtraCtx {
 }
 
 impl FlashblocksExtraCtx {
-    fn next(
+    const fn next(
         self,
         target_gas_for_batch: u64,
         target_da_for_batch: Option<u64>,
@@ -118,22 +118,22 @@ impl FlashblocksExtraCtx {
 
 impl OpPayloadBuilderCtx<FlashblocksExtraCtx> {
     /// Returns the current flashblock index
-    pub(crate) fn flashblock_index(&self) -> u64 {
+    pub(crate) const fn flashblock_index(&self) -> u64 {
         self.extra_ctx.flashblock_index
     }
 
     /// Returns the target flashblock count
-    pub(crate) fn target_flashblock_count(&self) -> u64 {
+    pub(crate) const fn target_flashblock_count(&self) -> u64 {
         self.extra_ctx.target_flashblock_count
     }
 
     /// Returns if the flashblock is the first fallback block
-    pub(crate) fn is_first_flashblock(&self) -> bool {
+    pub(crate) const fn is_first_flashblock(&self) -> bool {
         self.flashblock_index() == 0
     }
 
     /// Returns if the flashblock is the last one
-    pub(crate) fn is_last_flashblock(&self) -> bool {
+    pub(crate) const fn is_last_flashblock(&self) -> bool {
         self.flashblock_index() == self.target_flashblock_count()
     }
 }

--- a/crates/builder/op-rbuilder/src/builders/flashblocks/payload.rs
+++ b/crates/builder/op-rbuilder/src/builders/flashblocks/payload.rs
@@ -76,6 +76,7 @@ pub(super) struct FlashblocksExecutionInfo {
     last_flashblock_index: usize,
 }
 
+#[allow(unnameable_types)]
 #[derive(Debug, Default, Clone)]
 pub struct FlashblocksExtraCtx {
     /// Current flashblock index

--- a/crates/builder/op-rbuilder/src/builders/flashblocks/payload_handler.rs
+++ b/crates/builder/op-rbuilder/src/builders/flashblocks/payload_handler.rs
@@ -25,7 +25,7 @@ impl<Client> PayloadHandler<Client>
 where
     Client: ClientBounds + 'static,
 {
-    pub(crate) fn new(
+    pub(crate) const fn new(
         built_rx: mpsc::Receiver<OpBuiltPayload>,
         payload_events_handle: tokio::sync::broadcast::Sender<Events<OpEngineTypes>>,
         ctx: OpPayloadSyncerCtx,

--- a/crates/builder/op-rbuilder/src/builders/flashblocks/service.rs
+++ b/crates/builder/op-rbuilder/src/builders/flashblocks/service.rs
@@ -65,7 +65,7 @@ impl FlashblocksServiceBuilder {
             self.0.clone(),
             builder_tx,
             built_payload_tx,
-            ws_pub.clone(),
+            ws_pub,
             metrics.clone(),
         );
         let payload_job_config = BasicPayloadJobGeneratorConfig::default();
@@ -86,7 +86,7 @@ impl FlashblocksServiceBuilder {
             &ctx.provider().clone(),
             self.0,
             OpEvmConfig::optimism(ctx.chain_spec()),
-            metrics.clone(),
+            metrics,
         )
         .wrap_err("failed to create flashblocks payload builder context")?;
 

--- a/crates/builder/op-rbuilder/src/builders/flashblocks/service.rs
+++ b/crates/builder/op-rbuilder/src/builders/flashblocks/service.rs
@@ -26,6 +26,8 @@ use crate::{
     traits::{NodeBounds, PoolBounds},
 };
 
+#[allow(unnameable_types)]
+#[derive(Debug)]
 pub struct FlashblocksServiceBuilder(pub BuilderConfig<FlashblocksConfig>);
 
 impl FlashblocksServiceBuilder {

--- a/crates/builder/op-rbuilder/src/builders/mod.rs
+++ b/crates/builder/op-rbuilder/src/builders/mod.rs
@@ -139,10 +139,10 @@ impl<S: Debug + Clone> core::fmt::Debug for BuilderConfig<S> {
         f.debug_struct("Config")
             .field(
                 "builder_signer",
-                &match self.builder_signer.as_ref() {
-                    Some(signer) => signer.address.to_string(),
-                    None => "None".into(),
-                },
+                &self
+                    .builder_signer
+                    .as_ref()
+                    .map_or_else(|| "None".into(), |signer| signer.address.to_string()),
             )
             .field("revert_protection", &self.revert_protection)
             .field("flashtestations", &self.flashtestations_config)

--- a/crates/builder/op-rbuilder/src/builders/standard/mod.rs
+++ b/crates/builder/op-rbuilder/src/builders/standard/mod.rs
@@ -10,6 +10,7 @@ mod service;
 
 /// Block building strategy that builds blocks using the standard approach by
 /// producing blocks every chain block time.
+#[derive(Debug)]
 pub struct StandardBuilder;
 
 impl super::PayloadBuilder for StandardBuilder {

--- a/crates/builder/op-rbuilder/src/builders/standard/service.rs
+++ b/crates/builder/op-rbuilder/src/builders/standard/service.rs
@@ -14,6 +14,8 @@ use crate::{
     traits::{NodeBounds, PoolBounds},
 };
 
+#[allow(unnameable_types)]
+#[derive(Debug)]
 pub struct StandardServiceBuilder(pub BuilderConfig<()>);
 
 impl StandardServiceBuilder {

--- a/crates/builder/op-rbuilder/src/builders/standard/service.rs
+++ b/crates/builder/op-rbuilder/src/builders/standard/service.rs
@@ -35,7 +35,7 @@ impl StandardServiceBuilder {
             evm_config,
             pool,
             ctx.provider().clone(),
-            self.0.clone(),
+            self.0,
             builder_tx,
         );
 

--- a/crates/builder/op-rbuilder/src/flashtestations/attestation.rs
+++ b/crates/builder/op-rbuilder/src/flashtestations/attestation.rs
@@ -42,7 +42,7 @@ pub struct ParsedQuote {
 }
 
 /// Configuration for attestation
-#[derive(Default)]
+#[derive(Default, Debug)]
 pub struct AttestationConfig {
     /// If true, uses the debug HTTP service instead of real TDX hardware
     pub debug: bool,

--- a/crates/builder/op-rbuilder/src/flashtestations/builder_tx.rs
+++ b/crates/builder/op-rbuilder/src/flashtestations/builder_tx.rs
@@ -30,6 +30,7 @@ use crate::{
     tx_signer::Signer,
 };
 
+#[derive(Debug)]
 pub struct FlashtestationsBuilderTxArgs {
     pub attestation: Vec<u8>,
     pub extra_registration_data: Bytes,

--- a/crates/builder/op-rbuilder/src/flashtestations/builder_tx.rs
+++ b/crates/builder/op-rbuilder/src/flashtestations/builder_tx.rs
@@ -91,7 +91,7 @@ where
         }
     }
 
-    pub fn tee_signer(&self) -> &Signer {
+    pub const fn tee_signer(&self) -> &Signer {
         &self.tee_service_signer
     }
 
@@ -132,7 +132,7 @@ where
         state_provider: impl StateProvider + Clone,
         ctx: &OpPayloadBuilderCtx<ExtraCtx>,
     ) -> Result<(), BuilderTransactionError> {
-        let state = StateProviderDatabase::new(state_provider.clone());
+        let state = StateProviderDatabase::new(state_provider);
         let mut simulation_state =
             State::builder().with_database(state).with_bundle_update().build();
         let mut evm = ctx.evm_config.evm_with_env(&mut simulation_state, ctx.evm_env.clone());

--- a/crates/builder/op-rbuilder/src/flashtestations/tx_manager.rs
+++ b/crates/builder/op-rbuilder/src/flashtestations/tx_manager.rs
@@ -47,7 +47,7 @@ pub struct TxManager {
 }
 
 impl TxManager {
-    pub fn new(
+    pub const fn new(
         tee_service_signer: Signer,
         builder_signer: Signer,
         rpc_url: String,

--- a/crates/builder/op-rbuilder/src/gas_limiter/mod.rs
+++ b/crates/builder/op-rbuilder/src/gas_limiter/mod.rs
@@ -37,9 +37,7 @@ impl AddressGasLimiter {
     /// Check if there's enough gas for this address and consume it. Returns
     /// Ok(()) if there's enough otherwise returns an error.
     pub fn consume_gas(&self, address: Address, gas_requested: u64) -> Result<(), GasLimitError> {
-        self.inner
-            .as_ref()
-            .map_or(Ok(()), |inner| inner.consume_gas(address, gas_requested))
+        self.inner.as_ref().map_or(Ok(()), |inner| inner.consume_gas(address, gas_requested))
     }
 
     /// Should be called upon each new block. Refills buckets/Garbage collection

--- a/crates/builder/op-rbuilder/src/gas_limiter/mod.rs
+++ b/crates/builder/op-rbuilder/src/gas_limiter/mod.rs
@@ -37,11 +37,9 @@ impl AddressGasLimiter {
     /// Check if there's enough gas for this address and consume it. Returns
     /// Ok(()) if there's enough otherwise returns an error.
     pub fn consume_gas(&self, address: Address, gas_requested: u64) -> Result<(), GasLimitError> {
-        if let Some(inner) = &self.inner {
-            inner.consume_gas(address, gas_requested)
-        } else {
-            Ok(())
-        }
+        self.inner
+            .as_ref()
+            .map_or(Ok(()), |inner| inner.consume_gas(address, gas_requested))
     }
 
     /// Should be called upon each new block. Refills buckets/Garbage collection
@@ -123,7 +121,7 @@ impl AddressGasLimiterInner {
 }
 
 impl TokenBucket {
-    fn new(capacity: u64) -> Self {
+    const fn new(capacity: u64) -> Self {
         Self { capacity, available: capacity }
     }
 }

--- a/crates/builder/op-rbuilder/src/launcher.rs
+++ b/crates/builder/op-rbuilder/src/launcher.rs
@@ -36,7 +36,7 @@ impl<B> BuilderLauncher<B>
 where
     B: PayloadBuilder,
 {
-    pub fn new() -> Self {
+    pub const fn new() -> Self {
         Self { _builder: PhantomData }
     }
 }

--- a/crates/builder/op-rbuilder/src/launcher.rs
+++ b/crates/builder/op-rbuilder/src/launcher.rs
@@ -27,6 +27,7 @@ use crate::{
 };
 
 /// Launcher for the OP builder node.
+#[derive(Debug)]
 pub struct BuilderLauncher<B> {
     _builder: PhantomData<B>,
 }

--- a/crates/builder/op-rbuilder/src/lib.rs
+++ b/crates/builder/op-rbuilder/src/lib.rs
@@ -1,3 +1,5 @@
+#![allow(missing_docs)]
+
 pub mod args;
 pub mod builders;
 pub mod flashtestations;

--- a/crates/builder/op-rbuilder/src/primitives/bundle.rs
+++ b/crates/builder/op-rbuilder/src/primitives/bundle.rs
@@ -146,6 +146,7 @@ pub enum BundleConditionalError {
     FlashblockMinGreaterThanMax { min: u64, max: u64 },
 }
 
+#[derive(Debug)]
 pub struct BundleConditional {
     pub transaction_conditional: TransactionConditional,
     pub flashblock_number_min: Option<u64>,

--- a/crates/builder/op-rbuilder/src/primitives/bundle.rs
+++ b/crates/builder/op-rbuilder/src/primitives/bundle.rs
@@ -118,7 +118,7 @@ pub struct Bundle {
 
 impl From<BundleConditionalError> for EthApiError {
     fn from(err: BundleConditionalError) -> Self {
-        EthApiError::InvalidParams(err.to_string())
+        Self::InvalidParams(err.to_string())
     }
 }
 

--- a/crates/builder/op-rbuilder/src/primitives/reth/engine_api_builder.rs
+++ b/crates/builder/op-rbuilder/src/primitives/reth/engine_api_builder.rs
@@ -77,6 +77,7 @@ where
     }
 }
 
+#[derive(Debug)]
 pub struct OpEngineApiExt<Provider, Pool, Validator> {
     inner: OpEngineApi<Provider, OpEngineTypes, Pool, Validator, OpChainSpec>,
 }

--- a/crates/builder/op-rbuilder/src/primitives/reth/engine_api_builder.rs
+++ b/crates/builder/op-rbuilder/src/primitives/reth/engine_api_builder.rs
@@ -88,7 +88,9 @@ where
     Pool: TransactionPool + 'static,
     Validator: EngineApiValidator<OpEngineTypes>,
 {
-    pub const fn new(engine: OpEngineApi<Provider, OpEngineTypes, Pool, Validator, OpChainSpec>) -> Self {
+    pub const fn new(
+        engine: OpEngineApi<Provider, OpEngineTypes, Pool, Validator, OpChainSpec>,
+    ) -> Self {
         Self { inner: engine }
     }
 }

--- a/crates/builder/op-rbuilder/src/primitives/reth/engine_api_builder.rs
+++ b/crates/builder/op-rbuilder/src/primitives/reth/engine_api_builder.rs
@@ -88,7 +88,7 @@ where
     Pool: TransactionPool + 'static,
     Validator: EngineApiValidator<OpEngineTypes>,
 {
-    pub fn new(engine: OpEngineApi<Provider, OpEngineTypes, Pool, Validator, OpChainSpec>) -> Self {
+    pub const fn new(engine: OpEngineApi<Provider, OpEngineTypes, Pool, Validator, OpChainSpec>) -> Self {
         Self { inner: engine }
     }
 }

--- a/crates/builder/op-rbuilder/src/revert_protection.rs
+++ b/crates/builder/op-rbuilder/src/revert_protection.rs
@@ -31,6 +31,7 @@ pub trait EthApiExt<R: RpcObject> {
     async fn transaction_receipt(&self, hash: B256) -> RpcResult<Option<R>>;
 }
 
+#[derive(Debug)]
 pub struct RevertProtectionExt<Pool, Provider, Eth> {
     pool: Pool,
     provider: Provider,

--- a/crates/builder/op-rbuilder/src/tests/framework/apis.rs
+++ b/crates/builder/op-rbuilder/src/tests/framework/apis.rs
@@ -31,6 +31,7 @@ pub trait Protocol {
     ) -> impl Future<Output = impl SubscriptionClientT + Send + Sync + Unpin + 'static>;
 }
 
+#[derive(Debug)]
 pub struct Http;
 impl Protocol for Http {
     async fn client(
@@ -50,6 +51,7 @@ impl Protocol for Http {
     }
 }
 
+#[derive(Debug)]
 pub struct Ipc;
 impl Protocol for Ipc {
     async fn client(
@@ -67,6 +69,7 @@ impl Protocol for Ipc {
 }
 
 /// Helper for engine api operations
+#[derive(Debug)]
 pub struct EngineApi<P: Protocol = Ipc> {
     address: Address,
     jwt_secret: JwtSecret,

--- a/crates/builder/op-rbuilder/src/tests/framework/apis.rs
+++ b/crates/builder/op-rbuilder/src/tests/framework/apis.rs
@@ -84,16 +84,16 @@ impl<P: Protocol> EngineApi<P> {
 
 // http specific
 impl EngineApi<Http> {
-    pub fn with_http(url: &str) -> EngineApi<Http> {
-        EngineApi::<Http> {
+    pub fn with_http(url: &str) -> Self {
+        Self {
             address: Address::Http(url.parse().expect("Invalid URL")),
             jwt_secret: DEFAULT_JWT_TOKEN.parse().expect("Invalid JWT"),
             _tag: PhantomData,
         }
     }
 
-    pub fn with_localhost_port(port: u16) -> EngineApi<Http> {
-        EngineApi::<Http> {
+    pub fn with_localhost_port(port: u16) -> Self {
+        Self {
             address: Address::Http(
                 format!("http://localhost:{port}").parse().expect("Invalid URL"),
             ),
@@ -126,8 +126,8 @@ impl EngineApi<Http> {
 
 // ipc specific
 impl EngineApi<Ipc> {
-    pub fn with_ipc(path: &str) -> EngineApi<Ipc> {
-        EngineApi::<Ipc> {
+    pub fn with_ipc(path: &str) -> Self {
+        Self {
             address: Address::Ipc(path.into()),
             jwt_secret: DEFAULT_JWT_TOKEN.parse().expect("Invalid JWT"),
             _tag: PhantomData,

--- a/crates/builder/op-rbuilder/src/tests/framework/driver.rs
+++ b/crates/builder/op-rbuilder/src/tests/framework/driver.rs
@@ -23,6 +23,7 @@ use crate::{
 /// The ChainDriver is a type that allows driving the op builder node to build new blocks manually
 /// by calling the `build_new_block` method. It uses the Engine API to interact with the node
 /// and the provider to fetch blocks and transactions.
+#[derive(Debug)]
 pub struct ChainDriver<RpcProtocol: Protocol = Ipc> {
     engine_api: EngineApi<RpcProtocol>,
     provider: RootProvider<Optimism>,

--- a/crates/builder/op-rbuilder/src/tests/framework/driver.rs
+++ b/crates/builder/op-rbuilder/src/tests/framework/driver.rs
@@ -54,8 +54,8 @@ impl<RpcProtocol: Protocol> ChainDriver<RpcProtocol> {
     pub fn remote(
         provider: RootProvider<Optimism>,
         engine_api: EngineApi<RpcProtocol>,
-    ) -> ChainDriver<RpcProtocol> {
-        ChainDriver {
+    ) -> Self {
+        Self {
             engine_api,
             provider,
             signer: Default::default(),
@@ -67,14 +67,14 @@ impl<RpcProtocol: Protocol> ChainDriver<RpcProtocol> {
 
     /// Specifies the block builder signing key used to sign builder transactions.
     /// If not specified, a random signer will be used.
-    pub fn with_signer(mut self, signer: Signer) -> Self {
+    pub const fn with_signer(mut self, signer: Signer) -> Self {
         self.signer = Some(signer);
         self
     }
 
     /// Specifies a custom gas limit for blocks being built, otherwise the limit is
     /// set to a default value of 10_000_000.
-    pub fn with_gas_limit(mut self, gas_limit: u64) -> Self {
+    pub const fn with_gas_limit(mut self, gas_limit: u64) -> Self {
         self.gas_limit = Some(gas_limit);
         self
     }
@@ -151,17 +151,18 @@ impl<RpcProtocol: Protocol> ChainDriver<RpcProtocol> {
 
         let mut wait_until = None;
         // If block_timestamp we need to produce new timestamp according to current clocks
-        let block_timestamp = if let Some(block_timestamp) = block_timestamp {
-            block_timestamp.as_secs()
-        } else {
-            // We take the following second, until which we will need to wait before issuing FCU
-            let latest_timestamp = (chrono::Utc::now().timestamp() + 1) as u64;
-            wait_until = Some(latest_timestamp);
-            latest_timestamp
-                + Duration::from_millis(self.args.chain_block_time)
-                    .as_secs()
-                    .max(Self::MIN_BLOCK_TIME.as_secs())
-        };
+        let block_timestamp = block_timestamp.map_or_else(
+            || {
+                // We take the following second, until which we will need to wait before issuing FCU
+                let latest_timestamp = (chrono::Utc::now().timestamp() + 1) as u64;
+                wait_until = Some(latest_timestamp);
+                latest_timestamp
+                    + Duration::from_millis(self.args.chain_block_time)
+                        .as_secs()
+                        .max(Self::MIN_BLOCK_TIME.as_secs())
+            },
+            |ts| ts.as_secs(),
+        );
 
         // This step will alight time at which we send FCU. ideally we must send FCU and the beginning of the second.
         if let Some(wait_until) = wait_until {

--- a/crates/builder/op-rbuilder/src/tests/framework/driver.rs
+++ b/crates/builder/op-rbuilder/src/tests/framework/driver.rs
@@ -51,10 +51,7 @@ impl<RpcProtocol: Protocol> ChainDriver<RpcProtocol> {
     }
 
     /// Creates a new ChainDriver for some EL node instance.
-    pub fn remote(
-        provider: RootProvider<Optimism>,
-        engine_api: EngineApi<RpcProtocol>,
-    ) -> Self {
+    pub fn remote(provider: RootProvider<Optimism>, engine_api: EngineApi<RpcProtocol>) -> Self {
         Self {
             engine_api,
             provider,

--- a/crates/builder/op-rbuilder/src/tests/framework/external.rs
+++ b/crates/builder/op-rbuilder/src/tests/framework/external.rs
@@ -110,12 +110,12 @@ impl ExternalNode {
 
 impl ExternalNode {
     /// Access to the RPC API of the validation node.
-    pub fn provider(&self) -> &RootProvider<Optimism> {
+    pub const fn provider(&self) -> &RootProvider<Optimism> {
         &self.provider
     }
 
     /// Access to the Engine API of the validation node.
-    pub fn engine_api(&self) -> &EngineApi<Ipc> {
+    pub const fn engine_api(&self) -> &EngineApi<Ipc> {
         &self.engine_api
     }
 }

--- a/crates/builder/op-rbuilder/src/tests/framework/external.rs
+++ b/crates/builder/op-rbuilder/src/tests/framework/external.rs
@@ -37,6 +37,7 @@ const RPC_CONTAINER_IPC_PATH: &str = "/home/op-reth-shared/rpc.ipc";
 ///
 /// If the built payload fails to validate, then the driver block production function will
 /// return an error during `ChainDriver::build_new_block`.
+#[derive(Debug)]
 pub struct ExternalNode {
     engine_api: EngineApi<Ipc>,
     provider: RootProvider<Optimism>,

--- a/crates/builder/op-rbuilder/src/tests/framework/instance.rs
+++ b/crates/builder/op-rbuilder/src/tests/framework/instance.rs
@@ -77,6 +77,7 @@ fn clear_otel_env_vars() {
 
 /// Represents a type that emulates a local in-process instance of the OP builder node.
 /// This node uses IPC as the communication channel for the RPC server Engine API.
+#[derive(Debug)]
 pub struct LocalInstance {
     signer: Signer,
     config: NodeConfig<OpChainSpec>,
@@ -388,6 +389,7 @@ async fn spawn_attestation_provider() -> eyre::Result<AttestationServer> {
 ///
 /// This provides a reusable way to capture and inspect flashblocks that are produced
 /// during test execution, eliminating the need for duplicate WebSocket listening code.
+#[derive(Debug)]
 pub struct FlashblocksListener {
     pub flashblocks: Arc<Mutex<Vec<FlashblocksPayloadV1>>>,
     pub cancellation_token: CancellationToken,
@@ -470,6 +472,7 @@ impl FlashblocksListener {
 }
 
 /// A utility service to spawn a server that returns a mock quote for an attestation request
+#[derive(Debug)]
 pub struct AttestationServer {
     tee_address: Address,
     extra_registration_data: Bytes,

--- a/crates/builder/op-rbuilder/src/tests/framework/instance.rs
+++ b/crates/builder/op-rbuilder/src/tests/framework/instance.rs
@@ -284,7 +284,7 @@ impl LocalInstance {
         &self.attestation_server
     }
 
-    pub fn tx_data_store(&self) -> &TxDataStore {
+    pub const fn tx_data_store(&self) -> &TxDataStore {
         &self.tx_data_store
     }
 
@@ -323,13 +323,13 @@ pub fn default_node_config() -> NodeConfig<OpChainSpec> {
     let tempdir = std::env::temp_dir();
     let random_id = nanoid!();
 
-    let data_path = tempdir.join(format!("rbuilder.{random_id}.datadir")).to_path_buf();
+    let data_path = tempdir.join(format!("rbuilder.{random_id}.datadir"));
 
     std::fs::create_dir_all(&data_path).expect("Failed to create temporary data directory");
 
-    let rpc_ipc_path = tempdir.join(format!("rbuilder.{random_id}.rpc-ipc")).to_path_buf();
+    let rpc_ipc_path = tempdir.join(format!("rbuilder.{random_id}.rpc-ipc"));
 
-    let auth_ipc_path = tempdir.join(format!("rbuilder.{random_id}.auth-ipc")).to_path_buf();
+    let auth_ipc_path = tempdir.join(format!("rbuilder.{random_id}.auth-ipc"));
 
     let mut rpc = RpcServerArgs::default().with_auth_ipc();
     rpc.ws = false;
@@ -484,12 +484,12 @@ pub struct AttestationServer {
 }
 
 impl AttestationServer {
-    pub fn new(
+    pub const fn new(
         tee_address: Address,
         extra_registration_data: Bytes,
         mock_attestation: Bytes,
     ) -> Self {
-        AttestationServer {
+        Self {
             tee_address,
             extra_registration_data,
             mock_attestation,
@@ -500,7 +500,7 @@ impl AttestationServer {
         }
     }
 
-    pub fn set_error(&mut self, error: bool) {
+    pub const fn set_error(&mut self, error: bool) {
         self.error_on_request = error;
     }
 

--- a/crates/builder/op-rbuilder/src/tests/framework/txs.rs
+++ b/crates/builder/op-rbuilder/src/tests/framework/txs.rs
@@ -33,32 +33,32 @@ pub struct BundleOpts {
 }
 
 impl BundleOpts {
-    pub fn with_block_number_min(mut self, block_number_min: u64) -> Self {
+    pub const fn with_block_number_min(mut self, block_number_min: u64) -> Self {
         self.block_number_min = Some(block_number_min);
         self
     }
 
-    pub fn with_block_number_max(mut self, block_number_max: u64) -> Self {
+    pub const fn with_block_number_max(mut self, block_number_max: u64) -> Self {
         self.block_number_max = Some(block_number_max);
         self
     }
 
-    pub fn with_flashblock_number_min(mut self, flashblock_number_min: u64) -> Self {
+    pub const fn with_flashblock_number_min(mut self, flashblock_number_min: u64) -> Self {
         self.flashblock_number_min = Some(flashblock_number_min);
         self
     }
 
-    pub fn with_flashblock_number_max(mut self, flashblock_number_max: u64) -> Self {
+    pub const fn with_flashblock_number_max(mut self, flashblock_number_max: u64) -> Self {
         self.flashblock_number_max = Some(flashblock_number_max);
         self
     }
 
-    pub fn with_min_timestamp(mut self, min_timestamp: u64) -> Self {
+    pub const fn with_min_timestamp(mut self, min_timestamp: u64) -> Self {
         self.min_timestamp = Some(min_timestamp);
         self
     }
 
-    pub fn with_max_timestamp(mut self, max_timestamp: u64) -> Self {
+    pub const fn with_max_timestamp(mut self, max_timestamp: u64) -> Self {
         self.max_timestamp = Some(max_timestamp);
         self
     }
@@ -88,12 +88,12 @@ impl TransactionBuilder {
         }
     }
 
-    pub fn with_to(mut self, to: Address) -> Self {
+    pub const fn with_to(mut self, to: Address) -> Self {
         self.tx.to = TxKind::Call(to);
         self
     }
 
-    pub fn with_create(mut self) -> Self {
+    pub const fn with_create(mut self) -> Self {
         self.tx.to = TxKind::Create;
         self
     }
@@ -103,32 +103,32 @@ impl TransactionBuilder {
         self
     }
 
-    pub fn with_signer(mut self, signer: Signer) -> Self {
+    pub const fn with_signer(mut self, signer: Signer) -> Self {
         self.signer = Some(signer);
         self
     }
 
-    pub fn with_chain_id(mut self, chain_id: u64) -> Self {
+    pub const fn with_chain_id(mut self, chain_id: u64) -> Self {
         self.tx.chain_id = chain_id;
         self
     }
 
-    pub fn with_nonce(mut self, nonce: u64) -> Self {
+    pub const fn with_nonce(mut self, nonce: u64) -> Self {
         self.tx.nonce = nonce;
         self
     }
 
-    pub fn with_gas_limit(mut self, gas_limit: u64) -> Self {
+    pub const fn with_gas_limit(mut self, gas_limit: u64) -> Self {
         self.tx.gas_limit = gas_limit;
         self
     }
 
-    pub fn with_max_fee_per_gas(mut self, max_fee_per_gas: u128) -> Self {
+    pub const fn with_max_fee_per_gas(mut self, max_fee_per_gas: u128) -> Self {
         self.tx.max_fee_per_gas = max_fee_per_gas;
         self
     }
 
-    pub fn with_max_priority_fee_per_gas(mut self, max_priority_fee_per_gas: u128) -> Self {
+    pub const fn with_max_priority_fee_per_gas(mut self, max_priority_fee_per_gas: u128) -> Self {
         self.tx.max_priority_fee_per_gas = max_priority_fee_per_gas;
         self
     }
@@ -138,12 +138,12 @@ impl TransactionBuilder {
         self
     }
 
-    pub fn with_bundle(mut self, bundle_opts: BundleOpts) -> Self {
+    pub const fn with_bundle(mut self, bundle_opts: BundleOpts) -> Self {
         self.bundle_opts = Some(bundle_opts);
         self
     }
 
-    pub fn with_reverted_hash(mut self) -> Self {
+    pub const fn with_reverted_hash(mut self) -> Self {
         self.with_reverted_hash = true;
         self
     }

--- a/crates/builder/op-rbuilder/src/tests/framework/txs.rs
+++ b/crates/builder/op-rbuilder/src/tests/framework/txs.rs
@@ -22,7 +22,7 @@ use crate::{
     tx_signer::Signer,
 };
 
-#[derive(Clone, Copy, Default)]
+#[derive(Clone, Copy, Default, Debug)]
 pub struct BundleOpts {
     block_number_min: Option<u64>,
     block_number_max: Option<u64>,
@@ -64,7 +64,7 @@ impl BundleOpts {
     }
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct TransactionBuilder {
     provider: RootProvider<Optimism>,
     signer: Option<Signer>,
@@ -225,6 +225,7 @@ impl TransactionBuilder {
 
 type ObservationsMap = DashMap<TxHash, VecDeque<TransactionEvent>>;
 
+#[derive(Debug)]
 pub struct TransactionPoolObserver {
     /// Stores a mapping of all observed transactions to their history of events.
     observations: Arc<ObservationsMap>,

--- a/crates/builder/op-rbuilder/src/tx.rs
+++ b/crates/builder/op-rbuilder/src/tx.rs
@@ -288,7 +288,7 @@ impl MaybeConditionalTransaction for FBPooledTransaction {
     where
         Self: Sized,
     {
-        FBPooledTransaction {
+        Self {
             inner: self.inner.with_conditional(conditional),
             reverted_hashes: self.reverted_hashes,
             flashblock_number_min: self.flashblock_number_min,

--- a/crates/builder/op-rbuilder/src/tx_data_store.rs
+++ b/crates/builder/op-rbuilder/src/tx_data_store.rs
@@ -22,7 +22,7 @@ use uuid::Uuid;
 
 use crate::{metrics::OpRBuilderMetrics, tx::FBPooledTransaction};
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct StoredBackrunBundle {
     pub bundle_id: Uuid,
     pub sender: Address,
@@ -30,7 +30,7 @@ pub struct StoredBackrunBundle {
     pub total_priority_fee: u128,
 }
 
-#[derive(Clone, Default)]
+#[derive(Clone, Default, Debug)]
 pub struct TxData {
     pub metering: Option<MeterBundleResponse>,
     pub backrun_bundles: Vec<StoredBackrunBundle>,
@@ -260,6 +260,7 @@ pub trait BaseApiExt {
     async fn clear_metering_information(&self) -> RpcResult<()>;
 }
 
+#[derive(Debug)]
 pub struct TxDataStoreExt {
     store: TxDataStore,
     metrics: OpRBuilderMetrics,


### PR DESCRIPTION
Enable workspace linting on the builder, ignore lots of errors for now.