### PR TITLE
fix(client): accumulate RPC extension hooks instead of replacing

### DIFF
--- a/crates/client/flashblocks/src/test_harness.rs
+++ b/crates/client/flashblocks/src/test_harness.rs
@@ -13,7 +13,7 @@ use std::{
 };
 
 use base_client_node::{
-    BaseNodeExtension,
+    BaseBuilder, BaseNodeExtension,
     test_utils::{
         LocalNode, NODE_STARTUP_DELAY_MS, TestHarness, build_test_genesis, init_silenced_tracing,
     },
@@ -107,7 +107,7 @@ impl FlashblocksTestExtension {
 }
 
 impl BaseNodeExtension for FlashblocksTestExtension {
-    fn apply(self: Box<Self>, builder: base_client_node::OpBuilder) -> base_client_node::OpBuilder {
+    fn apply(self: Box<Self>, builder: BaseBuilder) -> BaseBuilder {
         let state = self.inner.state.clone();
         let receiver = self.inner.receiver.clone();
         let process_canonical = self.inner.process_canonical;
@@ -116,7 +116,7 @@ impl BaseNodeExtension for FlashblocksTestExtension {
         let state_for_rpc = state.clone();
 
         // Start state processor and subscriptions after node is started
-        let builder = builder.on_node_started(move |ctx| {
+        let builder = builder.add_node_started_hook(move |ctx| {
             let provider = ctx.provider().clone();
 
             // Start the state processor with the provider
@@ -152,7 +152,7 @@ impl BaseNodeExtension for FlashblocksTestExtension {
             Ok(())
         });
 
-        builder.extend_rpc_modules(move |ctx| {
+        builder.add_rpc_module(move |ctx| {
             let fb = state_for_rpc;
 
             let api_ext = EthApiExt::new(

--- a/crates/client/metering/src/extension.rs
+++ b/crates/client/metering/src/extension.rs
@@ -3,7 +3,7 @@
 
 use std::sync::Arc;
 
-use base_client_node::{BaseNodeExtension, FromExtensionConfig, OpBuilder};
+use base_client_node::{BaseBuilder, BaseNodeExtension, FromExtensionConfig};
 use base_flashblocks::{FlashblocksConfig, FlashblocksState};
 use tracing::info;
 
@@ -27,14 +27,14 @@ impl MeteringExtension {
 
 impl BaseNodeExtension for MeteringExtension {
     /// Applies the extension to the supplied builder.
-    fn apply(self: Box<Self>, builder: OpBuilder) -> OpBuilder {
+    fn apply(self: Box<Self>, builder: BaseBuilder) -> BaseBuilder {
         if !self.enabled {
             return builder;
         }
 
         let flashblocks_config = self.flashblocks_config;
 
-        builder.extend_rpc_modules(move |ctx| {
+        builder.add_rpc_module(move |ctx| {
             info!(message = "Starting Metering RPC");
 
             // Get flashblocks state from config, or create a default one if not configured

--- a/crates/client/node/src/builder.rs
+++ b/crates/client/node/src/builder.rs
@@ -1,0 +1,121 @@
+//! Wrapper around the OP node builder that accumulates hooks instead of replacing them.
+
+use std::fmt;
+
+use eyre::Result;
+use reth_node_builder::{
+    NodeAdapter, NodeComponentsBuilder,
+    node::FullNode,
+    rpc::{RethRpcAddOns, RpcContext},
+};
+
+use crate::{
+    OpBuilder,
+    types::{OpAddOns, OpComponentsBuilder, OpNodeTypes},
+};
+
+/// Convenience alias for the OP node adapter type used by the reth builder.
+pub(crate) type OpNodeAdapter = NodeAdapter<
+    OpNodeTypes,
+    <OpComponentsBuilder as NodeComponentsBuilder<OpNodeTypes>>::Components,
+>;
+
+/// Convenience alias for the OP Eth API type exposed by the reth RPC add-ons.
+type OpEthApi = <OpAddOns as RethRpcAddOns<OpNodeAdapter>>::EthApi;
+
+/// Convenience alias for the full OP node handle produced after launch.
+type OpFullNode = FullNode<OpNodeAdapter, OpAddOns>;
+
+/// Alias for the RPC context used by Base extensions.
+pub type BaseRpcContext<'a> = RpcContext<'a, OpNodeAdapter, OpEthApi>;
+
+/// Hook type for extending RPC modules.
+type RpcModuleHook = Box<dyn FnMut(&mut BaseRpcContext<'_>) -> Result<()> + Send + 'static>;
+
+/// Hook type for node-started callbacks.
+type NodeStartedHook = Box<dyn FnMut(OpFullNode) -> Result<()> + Send + 'static>;
+
+/// A thin wrapper over [`OpBuilder`] that accumulates RPC and node-start hooks.
+pub struct BaseBuilder {
+    builder: OpBuilder,
+    rpc_hooks: Vec<RpcModuleHook>,
+    node_started_hooks: Vec<NodeStartedHook>,
+}
+
+impl BaseBuilder {
+    /// Create a new BaseBuilder wrapping the provided OP builder.
+    pub const fn new(builder: OpBuilder) -> Self {
+        Self { builder, rpc_hooks: Vec::new(), node_started_hooks: Vec::new() }
+    }
+
+    /// Consumes the wrapper and returns the inner builder after installing the accumulated hooks.
+    pub fn build(self) -> OpBuilder {
+        let Self { mut builder, mut rpc_hooks, node_started_hooks } = self;
+
+        if !rpc_hooks.is_empty() {
+            builder = builder.extend_rpc_modules(move |mut ctx: BaseRpcContext<'_>| {
+                for hook in rpc_hooks.iter_mut() {
+                    hook(&mut ctx)?;
+                }
+
+                Ok(())
+            });
+        }
+
+        if !node_started_hooks.is_empty() {
+            builder = builder.on_node_started(move |full_node: OpFullNode| {
+                let mut hooks = node_started_hooks;
+                for hook in hooks.iter_mut() {
+                    hook(full_node.clone())?;
+                }
+                Ok(())
+            });
+        }
+
+        builder
+    }
+
+    /// Adds an RPC hook that will run when RPC modules are configured.
+    pub fn add_rpc_module<F>(mut self, hook: F) -> Self
+    where
+        F: FnOnce(&mut BaseRpcContext<'_>) -> Result<()> + Send + 'static,
+    {
+        let mut hook = Some(hook);
+        self.rpc_hooks.push(Box::new(move |ctx| {
+            if let Some(hook) = hook.take() {
+                hook(ctx)?;
+            }
+            Ok(())
+        }));
+        self
+    }
+
+    /// Adds a node-started hook that will run after the node has started.
+    pub fn add_node_started_hook<F>(mut self, hook: F) -> Self
+    where
+        F: FnOnce(OpFullNode) -> Result<()> + Send + 'static,
+    {
+        let mut hook = Some(hook);
+        self.node_started_hooks.push(Box::new(move |node| {
+            if let Some(hook) = hook.take() {
+                hook(node)?;
+            }
+            Ok(())
+        }));
+        self
+    }
+
+    /// Launches the node after applying accumulated hooks, delegating to the provided closure.
+    pub fn launch_with_fn<L, R>(self, launcher: L) -> R
+    where
+        L: FnOnce(OpBuilder) -> R,
+    {
+        launcher(self.build())
+    }
+}
+
+impl fmt::Debug for BaseBuilder {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("BaseBuilder").finish_non_exhaustive()
+    }
+}

--- a/crates/client/node/src/extension.rs
+++ b/crates/client/node/src/extension.rs
@@ -2,14 +2,14 @@
 
 use std::fmt::Debug;
 
-use crate::OpBuilder;
+use crate::BaseBuilder;
 
 /// Customizes the node builder before launch.
 ///
 /// Register extensions via [`BaseNodeRunner::install_ext`].
 pub trait BaseNodeExtension: Send + Sync + Debug {
     /// Applies the extension to the supplied builder.
-    fn apply(self: Box<Self>, builder: OpBuilder) -> OpBuilder;
+    fn apply(self: Box<Self>, builder: BaseBuilder) -> BaseBuilder;
 }
 
 /// An extension that can be built from a config.

--- a/crates/client/node/src/lib.rs
+++ b/crates/client/node/src/lib.rs
@@ -3,6 +3,9 @@
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
 
+mod builder;
+pub use builder::{BaseBuilder, BaseRpcContext};
+
 mod extension;
 pub use extension::{BaseNodeExtension, FromExtensionConfig};
 

--- a/crates/client/node/src/runner.rs
+++ b/crates/client/node/src/runner.rs
@@ -6,7 +6,7 @@ use reth_optimism_node::{OpNode, args::RollupArgs};
 use reth_provider::providers::BlockchainProvider;
 use tracing::info;
 
-use crate::{BaseNodeBuilder, BaseNodeExtension, BaseNodeHandle, FromExtensionConfig};
+use crate::{BaseBuilder, BaseNodeBuilder, BaseNodeExtension, BaseNodeHandle, FromExtensionConfig};
 
 /// Wraps the Base node configuration and orchestrates builder wiring.
 #[derive(Debug)]
@@ -50,8 +50,9 @@ impl BaseNodeRunner {
             .with_add_ons(op_node.add_ons())
             .on_component_initialized(move |_ctx| Ok(()));
 
-        let builder =
-            extensions.into_iter().fold(builder, |builder, extension| extension.apply(builder));
+        let builder = extensions
+            .into_iter()
+            .fold(BaseBuilder::new(builder), |builder, extension| extension.apply(builder));
 
         builder
             .launch_with_fn(|builder| {

--- a/crates/client/node/src/test_utils/node.rs
+++ b/crates/client/node/src/test_utils/node.rs
@@ -22,7 +22,7 @@ use reth_optimism_node::{OpNode, args::RollupArgs};
 use reth_provider::providers::BlockchainProvider;
 use reth_tasks::TaskManager;
 
-use crate::{BaseNodeExtension, OpProvider, test_utils::engine::EngineApi};
+use crate::{BaseBuilder, BaseNodeExtension, OpProvider, test_utils::engine::EngineApi};
 
 /// Convenience alias for the local blockchain provider type.
 pub type LocalNodeProvider = OpProvider;
@@ -103,8 +103,9 @@ impl LocalNode {
             .on_component_initialized(move |_ctx| Ok(()));
 
         // Apply all extensions
-        let builder =
-            extensions.into_iter().fold(builder, |builder, extension| extension.apply(builder));
+        let builder = extensions
+            .into_iter()
+            .fold(BaseBuilder::new(builder), |builder, extension| extension.apply(builder));
 
         // Launch with EngineNodeLauncher
         let NodeHandle { node: node_handle, node_exit_future } = builder
@@ -164,6 +165,11 @@ impl LocalNode {
         let url = format!("http://{}", self.http_api_addr);
         let client = RpcClient::builder().http(url.parse()?);
         Ok(RootProvider::<Optimism>::new(client))
+    }
+
+    /// HTTP RPC address for the local node.
+    pub const fn http_addr(&self) -> SocketAddr {
+        self.http_api_addr
     }
 
     /// Build an Engine API client that talks to the node's IPC endpoint.

--- a/crates/client/node/src/types.rs
+++ b/crates/client/node/src/types.rs
@@ -11,9 +11,12 @@ use reth_optimism_chainspec::OpChainSpec;
 use reth_optimism_node::OpNode;
 use reth_provider::providers::BlockchainProvider;
 
-type OpNodeTypes = FullNodeTypesAdapter<OpNode, Arc<DatabaseEnv>, OpProvider>;
-type OpComponentsBuilder = <OpNode as Node<OpNodeTypes>>::ComponentsBuilder;
-type OpAddOns = <OpNode as Node<OpNodeTypes>>::AddOns;
+/// Internal alias for the OP node type adapter.
+pub(crate) type OpNodeTypes = FullNodeTypesAdapter<OpNode, Arc<DatabaseEnv>, OpProvider>;
+/// Internal alias for the OP node components builder.
+pub(crate) type OpComponentsBuilder = <OpNode as Node<OpNodeTypes>>::ComponentsBuilder;
+/// Internal alias for the OP node add-ons.
+pub(crate) type OpAddOns = <OpNode as Node<OpNodeTypes>>::AddOns;
 
 /// A [`BlockchainProvider`] instance.
 pub type OpProvider = BlockchainProvider<NodeTypesWithDBAdapter<OpNode, Arc<DatabaseEnv>>>;

--- a/crates/client/txpool/src/extension.rs
+++ b/crates/client/txpool/src/extension.rs
@@ -1,7 +1,7 @@
 //! Contains the [`TxPoolExtension`] which wires up the transaction pool features
 //! (tracing subscription and status RPC) on the Base node builder.
 
-use base_client_node::{BaseNodeExtension, FromExtensionConfig, OpBuilder};
+use base_client_node::{BaseBuilder, BaseNodeExtension, FromExtensionConfig};
 use reth_provider::CanonStateSubscriptions;
 use tokio_stream::wrappers::BroadcastStream;
 use tracing::info;
@@ -35,7 +35,7 @@ impl TxPoolExtension {
 
 impl BaseNodeExtension for TxPoolExtension {
     /// Applies the extension to the supplied builder.
-    fn apply(self: Box<Self>, builder: OpBuilder) -> OpBuilder {
+    fn apply(self: Box<Self>, builder: BaseBuilder) -> BaseBuilder {
         let config = self.config;
 
         // Extend with RPC modules and optionally start tracing subscription
@@ -43,7 +43,7 @@ impl BaseNodeExtension for TxPoolExtension {
         let tracing_enabled = config.tracing_enabled;
         let logs_enabled = config.tracing_logs_enabled;
 
-        builder.extend_rpc_modules(move |ctx| {
+        builder.add_rpc_module(move |ctx| {
             info!(message = "Starting Transaction Status RPC");
             let proxy_api = TransactionStatusApiImpl::new(sequencer_rpc, ctx.pool().clone())
                 .expect("Failed to create transaction status proxy");


### PR DESCRIPTION
## Summary

- Introduces `BaseBuilder` wrapper that accumulates `extend_rpc_modules` and `on_node_started` hooks in vectors instead of replacing them
- Updates all extensions (`TxPoolExtension`, `MeteringExtension`, `FlashblocksExtension`) to use new `add_rpc_module()` and `add_node_started_hook()` methods
- Adds integration test verifying multiple RPC extensions are accessible simultaneously

## Problem

Reth's `extend_rpc_modules` and `on_node_started` use a replacement model—each call overwrites the previous hook. This caused only the last extension's hooks to execute, making endpoints like `base_meterBundle` and `base_transactionStatus` unavailable even when their respective extensions were enabled.

## Solution

The new `BaseBuilder` wrapper collects all hooks during extension setup, then applies them all in a single reth call when launching. This maintains the existing extension API while fixing the accumulation issue.

Closes #438

## Test plan

- [ ] Verify `cargo test --package base-client-node --features test-utils` passes
- [ ] Confirm all RPC endpoints (`base_transactionStatus`, `base_meterBundle`, flashblocks) are accessible when multiple extensions are enabled