### PR TITLE
chore(gha): auto-create issue for release

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -16,8 +16,12 @@ on:
           - final
         default: rc
 
+# Permissions:
+# - contents:write is required to push tags (create-tag.sh)
+# - issues:write is required to create release tracking issues (create-issue.sh)
 permissions:
   contents: write
+  issues: write
 
 jobs:
   create-tag:
@@ -52,3 +56,7 @@ jobs:
             echo "" >> $GITHUB_STEP_SUMMARY
             echo "The [Release workflow](../actions/workflows/release.yml) will now build and publish this release." >> $GITHUB_STEP_SUMMARY
           fi
+
+      - name: Create release tracking issue
+        run: |
+          ./scripts/release/create-issue.sh "${{ inputs.release_branch }}"

--- a/scripts/release/create-issue.sh
+++ b/scripts/release/create-issue.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# create-issue.sh - Create a release tracking issue on GitHub
+#
+# Usage: ./create-issue.sh <release_branch>
+# Example: ./create-issue.sh releases/v1.0.0
+
+# shellcheck source=common.sh
+source "$(dirname "${BASH_SOURCE[0]}")/common.sh"
+
+RELEASE_BRANCH="${1:-}"
+
+if [[ -z "$RELEASE_BRANCH" ]]; then
+    echo "Usage: $0 <release_branch>"
+    echo "  release_branch: e.g., releases/v1.0.0"
+    exit 1
+fi
+
+VERSION=$(parse_branch_version "$RELEASE_BRANCH")
+
+echo "=== Create Release Tracking Issue ==="
+echo "Branch: $RELEASE_BRANCH"
+echo "Version: $VERSION"
+
+BODY="## Release Checklist for v${VERSION}
+
+- [ ] Create RC
+- [ ] Deploy to devnet
+- [ ] Deploy to testnet
+- [ ] Deploy to mainnet
+- [ ] Create final release
+
+---
+*This issue was automatically created by the release workflow.*"
+
+ASSIGNEE="${GITHUB_ACTOR:-}"
+ASSIGNEE_FLAG=""
+if [[ -n "$ASSIGNEE" ]]; then
+    ASSIGNEE_FLAG="--assignee $ASSIGNEE"
+fi
+
+ISSUE_URL=$(gh issue create \
+    --title "chore(release): create v${VERSION} release" \
+    --body "$BODY" \
+    $ASSIGNEE_FLAG)
+
+ISSUE_NUMBER=$(echo "$ISSUE_URL" | grep -oE '[0-9]+$')
+
+echo ""
+echo "=== Issue Created ==="
+echo "Issue: #${ISSUE_NUMBER}"
+echo "URL: ${ISSUE_URL}"
+
+if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
+    {
+        echo ""
+        echo "## Release Issue Created"
+        echo ""
+        echo "**Issue**: #${ISSUE_NUMBER}"
+        echo "**Assignee**: @${ASSIGNEE:-N/A}"
+    } >> "$GITHUB_STEP_SUMMARY"
+fi


### PR DESCRIPTION
## Summary
- Auto-create tracking issue when release workflow runs
- Issue includes checklist (RC, devnet, testnet, mainnet, final release)
- Auto-assign to whoever triggered the workflow

## Changes
- Added `issues: write` permission
- Added `Create release tracking issue` step using `actions/github-script`

Closes #437