### PR TITLE
feat(engine): extract engine validator to customize

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1678,6 +1678,48 @@ dependencies = [
 ]
 
 [[package]]
+name = "base-client-engine"
+version = "0.0.0"
+dependencies = [
+ "alloy-consensus",
+ "alloy-eips",
+ "alloy-evm",
+ "alloy-primitives",
+ "alloy-rpc-types",
+ "alloy-rpc-types-engine",
+ "derive_more",
+ "eyre",
+ "jsonrpsee",
+ "rayon",
+ "reth-chain-state",
+ "reth-chainspec",
+ "reth-consensus",
+ "reth-engine-primitives",
+ "reth-engine-tree",
+ "reth-errors",
+ "reth-evm",
+ "reth-node-api",
+ "reth-node-builder",
+ "reth-node-core",
+ "reth-payload-builder",
+ "reth-payload-primitives",
+ "reth-primitives-traits",
+ "reth-provider",
+ "reth-revm",
+ "reth-rpc",
+ "reth-rpc-api",
+ "reth-rpc-builder",
+ "reth-rpc-engine-api",
+ "reth-rpc-eth-types",
+ "reth-tokio-util",
+ "reth-tracing",
+ "reth-trie",
+ "reth-trie-parallel",
+ "revm-primitives 21.0.2",
+ "tracing",
+]
+
+[[package]]
 name = "base-client-node"
 version = "0.0.0"
 dependencies = [
@@ -1690,6 +1732,7 @@ dependencies = [
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
  "alloy-signer",
+ "base-client-engine",
  "base-primitives",
  "chrono",
  "derive_more",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,6 +63,7 @@ base-jwt = { path = "crates/shared/jwt" }
 
 # Client
 base-client-cli = { path = "crates/client/cli" }
+base-client-engine = { path = "crates/client/engine" }
 base-client-node = { path = "crates/client/node" }
 base-metering = { path = "crates/client/metering" }
 base-txpool = { path = "crates/client/txpool" }

--- a/crates/client/engine/Cargo.toml
+++ b/crates/client/engine/Cargo.toml
@@ -1,0 +1,50 @@
+[package]
+name = "base-client-engine"
+description = "Engine validator for Base Node"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+
+[lints]
+workspace = true
+
+[dependencies]
+alloy-consensus.workspace = true
+alloy-eips.workspace = true
+alloy-evm.workspace = true
+alloy-primitives.workspace = true
+alloy-rpc-types.workspace = true
+alloy-rpc-types-engine.workspace = true
+jsonrpsee.workspace = true
+rayon.workspace = true
+reth-chain-state.workspace = true
+reth-chainspec.workspace = true
+reth-consensus.workspace = true
+reth-engine-primitives.workspace = true
+reth-engine-tree.workspace = true
+reth-errors.workspace = true
+reth-evm.workspace = true
+reth-node-api.workspace = true
+reth-node-builder.workspace = true
+reth-node-core.workspace = true
+reth-payload-builder.workspace = true
+reth-payload-primitives.workspace = true
+reth-primitives-traits.workspace = true
+reth-provider.workspace = true
+reth-revm.workspace = true
+reth-rpc.workspace = true
+reth-rpc-api.workspace = true
+reth-rpc-builder.workspace = true
+reth-rpc-engine-api.workspace = true
+reth-rpc-eth-types.workspace = true
+reth-tokio-util.workspace = true
+reth-tracing.workspace = true
+reth-trie.workspace = true
+reth-trie-parallel.workspace = true
+revm-primitives.workspace = true
+tracing.workspace = true
+eyre.workspace = true
+derive_more.workspace = true

--- a/crates/client/engine/README.md
+++ b/crates/client/engine/README.md
@@ -1,0 +1,106 @@
+# `base-client-engine`
+
+<a href="https://github.com/base/node-reth/actions/workflows/ci.yml"><img src="https://github.com/base/node-reth/actions/workflows/ci.yml/badge.svg?label=ci" alt="CI"></a>
+<a href="https://github.com/base/node-reth/blob/main/LICENSE"><img src="https://img.shields.io/badge/License-MIT-d1d1f6.svg?label=license&labelColor=2a2f35" alt="MIT License"></a>
+
+Custom engine validator implementation optimized for validating canonical blocks in the Base node.
+
+## Overview
+
+This crate provides a specialized engine validator that integrates with Reth's engine tree and consensus system. It is optimized for validating canonical blocks after flashblock validation and serves as a building block for Base-specific consensus and execution logic.
+
+### Key Components
+
+- **`BaseEngineValidator`**: A wrapper around Reth's `BasicEngineValidator` that provides reusable payload validation logic. It handles:
+  - Consensus validation
+  - Block execution
+  - State root computation
+  - Fork detection
+
+- **`BaseEngineValidatorBuilder`**: A builder that constructs `BaseEngineValidator` instances with the necessary context (provider, consensus engine, EVM config, payload validator, and invalid block hooks).
+
+## Features
+
+- **Payload Validation**: Validates execution payloads from the Engine API against the current chain state
+- **Block Validation**: Validates pre-constructed blocks (e.g., from flashblocks) efficiently
+- **State Management**: Computes and verifies state roots during block execution
+- **Invalid Block Handling**: Integrates with Reth's invalid block hooks for debugging and analysis
+
+## Usage
+
+Add the dependency to your `Cargo.toml`:
+
+```toml
+[dependencies]
+base-client-engine = { git = "https://github.com/base/node-reth" }
+```
+
+### Using with Node Builder
+
+The validator builder integrates with Reth's node builder pattern:
+
+```rust,ignore
+use base_client_engine::BaseEngineValidatorBuilder;
+use reth_node_builder::NodeBuilder;
+
+// Create a validator builder with your custom payload validator
+let validator_builder = BaseEngineValidatorBuilder::new(my_payload_validator_builder);
+
+// The node builder will automatically use this to construct the engine validator
+let node = NodeBuilder::new()
+    .with_engine_validator_builder(validator_builder)
+    .build()
+    .await?;
+```
+
+### Custom Payload Validation
+
+Implement custom payload validation logic by providing your own `PayloadValidatorBuilder`:
+
+```rust,ignore
+use base_client_engine::BaseEngineValidatorBuilder;
+use reth_engine_primitives::PayloadValidator;
+use reth_node_builder::rpc::PayloadValidatorBuilder;
+
+#[derive(Debug, Clone)]
+struct MyPayloadValidatorBuilder;
+
+impl<Node> PayloadValidatorBuilder<Node> for MyPayloadValidatorBuilder
+where
+    Node: FullNodeComponents,
+{
+    type Validator = MyPayloadValidator;
+
+    async fn build(self, ctx: &AddOnsContext<'_, Node>) -> eyre::Result<Self::Validator> {
+        Ok(MyPayloadValidator::new(/* ... */))
+    }
+}
+
+// Use with the base engine validator builder
+let engine_validator_builder = BaseEngineValidatorBuilder::new(MyPayloadValidatorBuilder);
+```
+
+## Architecture
+
+The validator follows a layered architecture:
+
+1. **Builder Layer** (`BaseEngineValidatorBuilder`): Constructs validators with the necessary dependencies
+2. **Validation Layer** (`BaseEngineValidator`): Coordinates validation, execution, and state computation
+3. **Integration Layer**: Implements `EngineValidator` trait to work with Reth's engine tree
+
+This design allows for composable, network-specific validation logic while reusing common execution and state management code.
+
+## Dependencies
+
+This crate builds on top of several Reth components:
+- `reth-engine-tree`: Engine tree primitives and traits
+- `reth-consensus`: Consensus validation
+- `reth-evm`: EVM execution configuration
+- `reth-provider`: State and storage access
+- `reth-payload-primitives`: Payload types and validation
+
+## Related Crates
+
+- **`base-flashblocks`**: Provides optimized block building that works with this validator
+- **`base-client-node`**: Node builder extensions that integrate this validator
+- **`reth-engine-tree`**: Core engine tree implementation

--- a/crates/client/engine/src/lib.rs
+++ b/crates/client/engine/src/lib.rs
@@ -1,0 +1,5 @@
+//! Implements custom engine validator that is optimized for validating canonical blocks
+//! after flashblock validation.
+
+pub mod validator;
+pub use validator::{BaseEngineValidator, BaseEngineValidatorBuilder};

--- a/crates/client/engine/src/validator.rs
+++ b/crates/client/engine/src/validator.rs
@@ -1,0 +1,213 @@
+//! Implements custom engine validator that is optimized for validating canonical blocks
+
+use std::{fmt::Debug, sync::Arc};
+
+use reth_chainspec::EthChainSpec;
+use reth_consensus::{ConsensusError, FullConsensus};
+use reth_engine_primitives::{ConfigureEngineEvm, InvalidBlockHook, PayloadValidator};
+use reth_engine_tree::tree::{
+    BasicEngineValidator, EngineValidator,
+    error::InsertPayloadError,
+    payload_validator::{BlockOrPayload, TreeCtx, ValidationOutcome},
+};
+use reth_evm::ConfigureEvm;
+use reth_node_api::{
+    AddOnsContext, BlockTy, FullNodeComponents, InvalidPayloadAttributesError, NodeTypes,
+    PayloadTypes, TreeConfig,
+};
+use reth_node_builder::{
+    invalid_block_hook::InvalidBlockHookExt,
+    rpc::{EngineValidatorBuilder, PayloadValidatorBuilder},
+};
+use reth_payload_primitives::{BuiltPayload, NewPayloadError};
+use reth_primitives_traits::{NodePrimitives, RecoveredBlock};
+use reth_provider::{
+    BlockReader, DatabaseProviderFactory, HashedPostStateProvider, PruneCheckpointReader,
+    StageCheckpointReader, StateProviderFactory, StateReader, TrieReader,
+};
+use tracing::instrument;
+/// Basic implementation of [`EngineValidatorBuilder`].
+///
+/// This builder creates a [`BasicEngineValidator`] using the provided payload validator builder.
+#[derive(Debug, Clone)]
+pub struct BaseEngineValidatorBuilder<EV> {
+    /// The payload validator builder used to create the engine validator.
+    payload_validator_builder: EV,
+}
+
+impl<EV> BaseEngineValidatorBuilder<EV> {
+    /// Creates a new instance with the given payload validator builder.
+    pub const fn new(payload_validator_builder: EV) -> Self {
+        Self { payload_validator_builder }
+    }
+}
+
+impl<EV> Default for BaseEngineValidatorBuilder<EV>
+where
+    EV: Default,
+{
+    fn default() -> Self {
+        Self::new(EV::default())
+    }
+}
+
+impl<Node, EV> EngineValidatorBuilder<Node> for BaseEngineValidatorBuilder<EV>
+where
+    Node: FullNodeComponents<
+        Evm: ConfigureEngineEvm<
+            <<Node::Types as NodeTypes>::Payload as PayloadTypes>::ExecutionData,
+        >,
+    >,
+    EV: PayloadValidatorBuilder<Node>,
+    EV::Validator: reth_engine_primitives::PayloadValidator<
+            <Node::Types as NodeTypes>::Payload,
+            Block = BlockTy<Node::Types>,
+        >,
+{
+    type EngineValidator = BaseEngineValidator<Node::Provider, Node::Evm, EV::Validator>;
+
+    async fn build_tree_validator(
+        self,
+        ctx: &AddOnsContext<'_, Node>,
+        tree_config: TreeConfig,
+    ) -> eyre::Result<Self::EngineValidator> {
+        let validator = self.payload_validator_builder.build(ctx).await?;
+        let data_dir = ctx.config.datadir.clone().resolve_datadir(ctx.config.chain.chain());
+        let invalid_block_hook = ctx.create_invalid_block_hook(&data_dir).await?;
+        Ok(BaseEngineValidator::new(
+            ctx.node.provider().clone(),
+            std::sync::Arc::new(ctx.node.consensus().clone()),
+            ctx.node.evm_config().clone(),
+            validator,
+            tree_config,
+            invalid_block_hook,
+        ))
+    }
+}
+
+/// A helper type that provides reusable payload validation logic for network-specific validators.
+///
+/// This type satisfies [`EngineValidator`] and is responsible for executing blocks/payloads.
+///
+/// This type contains common validation, execution, and state root computation logic that can be
+/// used by network-specific payload validators (e.g., Ethereum, Optimism). It is not meant to be
+/// used as a standalone component, but rather as a building block for concrete implementations.
+#[derive(derive_more::Debug)]
+pub struct BaseEngineValidator<P, Evm, V>
+where
+    Evm: ConfigureEvm,
+{
+    inner: BasicEngineValidator<P, Evm, V>,
+}
+
+impl<N, P, Evm, V> BaseEngineValidator<P, Evm, V>
+where
+    N: NodePrimitives,
+    P: DatabaseProviderFactory<
+            Provider: BlockReader + TrieReader + StageCheckpointReader + PruneCheckpointReader,
+        > + BlockReader<Header = N::BlockHeader>
+        + StateProviderFactory
+        + StateReader
+        + HashedPostStateProvider
+        + Clone
+        + 'static,
+    Evm: ConfigureEvm<Primitives = N> + 'static,
+{
+    /// Creates a new `TreePayloadValidator`.
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        provider: P,
+        consensus: Arc<dyn FullConsensus<N, Error = ConsensusError>>,
+        evm_config: Evm,
+        validator: V,
+        config: TreeConfig,
+        invalid_block_hook: Box<dyn InvalidBlockHook<N>>,
+    ) -> Self {
+        Self {
+            inner: BasicEngineValidator::new(
+                provider,
+                consensus,
+                evm_config,
+                validator,
+                config,
+                invalid_block_hook,
+            ),
+        }
+    }
+
+    /// Validates a block that has already been converted from a payload.
+    ///
+    /// This method performs:
+    /// - Consensus validation
+    /// - Block execution
+    /// - State root computation
+    /// - Fork detection
+    #[instrument(
+        level = "debug",
+        target = "engine::tree::payload_validator",
+        skip_all,
+        fields(
+            parent = ?input.parent_hash(),
+            type_name = ?input.type_name(),
+        )
+    )]
+    pub fn validate_block_with_state<T: PayloadTypes<BuiltPayload: BuiltPayload<Primitives = N>>>(
+        &mut self,
+        input: BlockOrPayload<T>,
+        ctx: TreeCtx<'_, N>,
+    ) -> ValidationOutcome<N, InsertPayloadError<N::Block>>
+    where
+        V: PayloadValidator<T, Block = N::Block>,
+        Evm: ConfigureEngineEvm<T::ExecutionData, Primitives = N>,
+    {
+        self.inner.validate_block_with_state(input, ctx)
+    }
+}
+
+impl<N, Types, P, Evm, V> EngineValidator<Types> for BaseEngineValidator<P, Evm, V>
+where
+    P: DatabaseProviderFactory<
+            Provider: BlockReader + TrieReader + StageCheckpointReader + PruneCheckpointReader,
+        > + BlockReader<Header = N::BlockHeader>
+        + StateProviderFactory
+        + StateReader
+        + HashedPostStateProvider
+        + Clone
+        + 'static,
+    N: NodePrimitives,
+    V: PayloadValidator<Types, Block = N::Block>,
+    Evm: ConfigureEngineEvm<Types::ExecutionData, Primitives = N> + 'static,
+    Types: PayloadTypes<BuiltPayload: BuiltPayload<Primitives = N>>,
+{
+    fn validate_payload_attributes_against_header(
+        &self,
+        attr: &Types::PayloadAttributes,
+        header: &N::BlockHeader,
+    ) -> Result<(), InvalidPayloadAttributesError> {
+        self.inner.validate_payload_attributes_against_header(attr, header)
+    }
+
+    fn ensure_well_formed_payload(
+        &self,
+        payload: Types::ExecutionData,
+    ) -> Result<RecoveredBlock<N::Block>, NewPayloadError> {
+        let block = self.inner.ensure_well_formed_payload(payload)?;
+        Ok(block)
+    }
+
+    fn validate_payload(
+        &mut self,
+        payload: Types::ExecutionData,
+        ctx: TreeCtx<'_, N>,
+    ) -> ValidationOutcome<N> {
+        self.validate_block_with_state(BlockOrPayload::Payload(payload), ctx)
+    }
+
+    fn validate_block(
+        &mut self,
+        block: RecoveredBlock<N::Block>,
+        ctx: TreeCtx<'_, N>,
+    ) -> ValidationOutcome<N> {
+        self.validate_block_with_state(BlockOrPayload::Block(block), ctx)
+    }
+}

--- a/crates/client/node/Cargo.toml
+++ b/crates/client/node/Cargo.toml
@@ -43,6 +43,7 @@ test-utils = [
 
 [dependencies]
 # Project
+base-client-engine.workspace = true
 base-primitives = { workspace = true, optional = true }
 
 # reth

--- a/crates/client/node/src/node.rs
+++ b/crates/client/node/src/node.rs
@@ -2,6 +2,7 @@
 
 use std::{marker::PhantomData, sync::Arc};
 
+use base_client_engine::BaseEngineValidatorBuilder;
 use reth_chainspec::ChainSpecProvider;
 use reth_engine_local::LocalPayloadAttributesBuilder;
 use reth_evm::ConfigureEvm;
@@ -14,9 +15,9 @@ use reth_node_builder::{
     components::{BasicPayloadServiceBuilder, ComponentsBuilder},
     node::{FullNodeTypes, NodeTypes},
     rpc::{
-        BasicEngineValidatorBuilder, EngineApiBuilder, EngineValidatorAddOn,
-        EngineValidatorBuilder, EthApiBuilder, Identity, PayloadValidatorBuilder, RethRpcAddOns,
-        RethRpcMiddleware, RethRpcServerHandles, RpcAddOns, RpcContext, RpcHandle,
+        EngineApiBuilder, EngineValidatorAddOn, EngineValidatorBuilder, EthApiBuilder, Identity,
+        PayloadValidatorBuilder, RethRpcAddOns, RethRpcMiddleware, RethRpcServerHandles, RpcAddOns,
+        RpcContext, RpcHandle,
     },
 };
 use reth_optimism_chainspec::OpChainSpec;
@@ -185,7 +186,7 @@ where
         OpEthApiBuilder,
         OpEngineValidatorBuilder,
         OpEngineApiBuilder<OpEngineValidatorBuilder>,
-        BasicEngineValidatorBuilder<OpEngineValidatorBuilder>,
+        BaseEngineValidatorBuilder<OpEngineValidatorBuilder>,
     >;
 
     fn components_builder(&self) -> Self::ComponentsBuilder {
@@ -231,7 +232,7 @@ pub struct BaseAddOns<
     EthB: EthApiBuilder<N>,
     PVB,
     EB = OpEngineApiBuilder<PVB>,
-    EVB = BasicEngineValidatorBuilder<PVB>,
+    EVB = BaseEngineValidatorBuilder<PVB>,
     RpcMiddleware = Identity,
 > {
     /// Rpc add-ons responsible for launching the RPC servers and instantiating the RPC handlers


### PR DESCRIPTION
Currently, the base version just wraps the existing engine validator, but this is where we can add cached state from executing flashblocks.