### PR TITLE
chore(builder): Fix priority fee ordering violations in flashblocks block building

### DIFF
--- a/crates/builder/op-rbuilder/src/args/op.rs
+++ b/crates/builder/op-rbuilder/src/args/op.rs
@@ -113,6 +113,16 @@ pub struct FlashblocksArgs {
         env = "FLASHBLOCKS_DISABLE_STATE_ROOT"
     )]
     pub flashblocks_disable_state_root: bool,
+
+    /// Whether to enforce priority fee ordering within flashblocks.
+    /// When enabled, transactions that would violate descending priority fee order are skipped
+    /// and deferred to the next flashblock.
+    #[arg(
+        long = "flashblocks.enforce-priority-fee-ordering",
+        default_value = "true",
+        env = "FLASHBLOCKS_ENFORCE_PRIORITY_FEE_ORDERING"
+    )]
+    pub flashblocks_enforce_priority_fee_ordering: bool,
 }
 
 impl Default for FlashblocksArgs {

--- a/crates/builder/op-rbuilder/src/flashblocks/config.rs
+++ b/crates/builder/op-rbuilder/src/flashblocks/config.rs
@@ -33,6 +33,9 @@ pub struct FlashblocksConfig {
 
     /// Should we disable state root calculation for each flashblock
     pub disable_state_root: bool,
+
+    /// Whether to enforce priority fee ordering within flashblocks
+    pub enforce_priority_fee_ordering: bool,
 }
 
 impl Default for FlashblocksConfig {
@@ -43,6 +46,7 @@ impl Default for FlashblocksConfig {
             leeway_time: Duration::from_millis(50),
             fixed: false,
             disable_state_root: false,
+            enforce_priority_fee_ordering: true,
         }
     }
 }
@@ -64,7 +68,17 @@ impl TryFrom<OpRbuilderArgs> for FlashblocksConfig {
 
         let disable_state_root = args.flashblocks.flashblocks_disable_state_root;
 
-        Ok(Self { ws_addr, interval, leeway_time, fixed, disable_state_root })
+        let enforce_priority_fee_ordering =
+            args.flashblocks.flashblocks_enforce_priority_fee_ordering;
+
+        Ok(Self {
+            ws_addr,
+            interval,
+            leeway_time,
+            fixed,
+            disable_state_root,
+            enforce_priority_fee_ordering,
+        })
     }
 }
 

--- a/crates/builder/op-rbuilder/src/flashblocks/context.rs
+++ b/crates/builder/op-rbuilder/src/flashblocks/context.rs
@@ -473,24 +473,24 @@ impl OpPayloadBuilderCtx {
             num_txs_considered += 1;
 
             // Check priority fee ordering - skip if current tx has higher priority than last.
-            if self.enforce_priority_fee_ordering {
-                if let Some(current_priority) = tx.effective_tip_per_gas(base_fee) {
-                    if let Some(last_priority) = last_priority_fee
-                        && current_priority > last_priority
-                    {
-                        warn!(
-                            target: "payload_builder",
-                            tx_hash = ?tx_hash,
-                            current_priority = current_priority,
-                            last_priority = last_priority,
-                            "Skipping transaction due to priority fee ordering violation"
-                        );
-                        self.metrics.priority_fee_ordering_violations.increment(1);
-                        best_txs.mark_invalid(tx.signer(), tx.nonce());
-                        continue;
-                    }
-                    last_priority_fee = Some(current_priority);
+            if self.enforce_priority_fee_ordering
+                && let Some(current_priority) = tx.effective_tip_per_gas(base_fee)
+            {
+                if let Some(last_priority) = last_priority_fee
+                    && current_priority > last_priority
+                {
+                    warn!(
+                        target: "payload_builder",
+                        tx_hash = ?tx_hash,
+                        current_priority = current_priority,
+                        last_priority = last_priority,
+                        "Skipping transaction due to priority fee ordering violation"
+                    );
+                    self.metrics.priority_fee_ordering_violations.increment(1);
+                    best_txs.mark_invalid(tx.signer(), tx.nonce());
+                    continue;
                 }
+                last_priority_fee = Some(current_priority);
             }
 
             let TxData { metering: _resource_usage, backrun_bundles } =

--- a/crates/builder/op-rbuilder/src/flashblocks/context.rs
+++ b/crates/builder/op-rbuilder/src/flashblocks/context.rs
@@ -482,6 +482,7 @@ impl OpPayloadBuilderCtx {
                         last_priority = last_priority,
                         "Skipping transaction due to priority fee ordering violation"
                     );
+                    self.metrics.priority_fee_ordering_violations.increment(1);
                     best_txs.mark_invalid(tx.signer(), tx.nonce());
                     continue;
                 }

--- a/crates/builder/op-rbuilder/src/flashblocks/context.rs
+++ b/crates/builder/op-rbuilder/src/flashblocks/context.rs
@@ -472,18 +472,18 @@ impl OpPayloadBuilderCtx {
 
             // Check priority fee ordering - skip if current tx has higher priority than last.
             if let Some(current_priority) = tx.effective_tip_per_gas(base_fee) {
-                if let Some(last_priority) = last_priority_fee {
-                    if current_priority > last_priority {
-                        warn!(
-                            target: "payload_builder",
-                            tx_hash = ?tx_hash,
-                            current_priority = current_priority,
-                            last_priority = last_priority,
-                            "Skipping transaction due to priority fee ordering violation"
-                        );
-                        best_txs.mark_invalid(tx.signer(), tx.nonce());
-                        continue;
-                    }
+                if let Some(last_priority) = last_priority_fee
+                    && current_priority > last_priority
+                {
+                    warn!(
+                        target: "payload_builder",
+                        tx_hash = ?tx_hash,
+                        current_priority = current_priority,
+                        last_priority = last_priority,
+                        "Skipping transaction due to priority fee ordering violation"
+                    );
+                    best_txs.mark_invalid(tx.signer(), tx.nonce());
+                    continue;
                 }
                 last_priority_fee = Some(current_priority);
             }

--- a/crates/builder/op-rbuilder/src/flashblocks/ctx.rs
+++ b/crates/builder/op-rbuilder/src/flashblocks/ctx.rs
@@ -88,6 +88,7 @@ impl OpPayloadSyncerCtx {
             max_gas_per_txn: self.max_gas_per_txn,
             address_gas_limiter: AddressGasLimiter::new(GasLimiterArgs::default()),
             tx_data_store: self.tx_data_store,
+            enforce_priority_fee_ordering: true, // default to enabled for tests
         }
     }
 }

--- a/crates/builder/op-rbuilder/src/flashblocks/payload.rs
+++ b/crates/builder/op-rbuilder/src/flashblocks/payload.rs
@@ -201,6 +201,10 @@ where
             max_gas_per_txn: self.config.max_gas_per_txn,
             address_gas_limiter: self.address_gas_limiter.clone(),
             tx_data_store: self.config.tx_data_store.clone(),
+            enforce_priority_fee_ordering: self
+                .config
+                .flashblocks
+                .enforce_priority_fee_ordering,
         })
     }
 

--- a/crates/builder/op-rbuilder/src/flashblocks/payload.rs
+++ b/crates/builder/op-rbuilder/src/flashblocks/payload.rs
@@ -201,10 +201,7 @@ where
             max_gas_per_txn: self.config.max_gas_per_txn,
             address_gas_limiter: self.address_gas_limiter.clone(),
             tx_data_store: self.config.tx_data_store.clone(),
-            enforce_priority_fee_ordering: self
-                .config
-                .flashblocks
-                .enforce_priority_fee_ordering,
+            enforce_priority_fee_ordering: self.config.flashblocks.enforce_priority_fee_ordering,
         })
     }
 

--- a/crates/builder/op-rbuilder/src/metrics.rs
+++ b/crates/builder/op-rbuilder/src/metrics.rs
@@ -181,6 +181,8 @@ pub struct OpRBuilderMetrics {
     pub backrun_bundle_insert_duration: Histogram,
     /// Duration of executing all backrun bundles for a target transaction
     pub backrun_bundle_execution_duration: Histogram,
+    /// Number of transactions skipped due to priority fee ordering violations
+    pub priority_fee_ordering_violations: Counter,
 }
 
 impl OpRBuilderMetrics {

--- a/crates/builder/op-rbuilder/src/tests/flashblocks.rs
+++ b/crates/builder/op-rbuilder/src/tests/flashblocks.rs
@@ -228,6 +228,7 @@ async fn test_flashblocks_no_state_root_calculation() -> eyre::Result<()> {
             flashblocks_leeway_time: 100,
             flashblocks_fixed: false,
             flashblocks_disable_state_root: true,
+            flashblocks_enforce_priority_fee_ordering: true,
         },
         ..Default::default()
     };


### PR DESCRIPTION
We see a bunch of fee violation these days, from our internal monitoring and reported by others

There's a possible fix but not released yet (https://github.com/paradigmxyz/reth/pull/19940) where blocked transactions break nonce chain tracking.

Rather than waiting for the official release (which requires baking and unsure about the release schedule), doing a workaround now is to check at the execution level for violation, and skip the txn when found

slack context: https://coinbase.slack.com/archives/C06RRAWRCTX/p1768415995939549?thread_ts=1768403579.942579&cid=C06RRAWRCTX