### PR TITLE
refactor: migrate VersionInfo to builder binary

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1615,6 +1615,7 @@ name = "base-builder"
 version = "0.0.0"
 dependencies = [
  "base-cli-utils",
+ "metrics",
  "op-rbuilder",
  "reth-cli-util",
  "reth-optimism-cli",

--- a/bin/builder/Cargo.toml
+++ b/bin/builder/Cargo.toml
@@ -16,6 +16,7 @@ workspace = true
 # Workspace
 base-cli-utils.workspace = true
 op-rbuilder.workspace = true
+metrics.workspace = true
 
 # reth
 reth-cli-util.workspace = true

--- a/bin/builder/src/main.rs
+++ b/bin/builder/src/main.rs
@@ -3,6 +3,8 @@
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
 
+pub mod version;
+
 #[global_allocator]
 static ALLOC: reth_cli_util::allocator::Allocator = reth_cli_util::allocator::new_allocator();
 
@@ -10,7 +12,9 @@ fn main() {
     base_cli_utils::Backtracing::enable();
     base_cli_utils::SigsegvHandler::install();
 
-    if let Err(err) = op_rbuilder::launcher::launch() {
+    if let Err(err) = op_rbuilder::launcher::launch(|| {
+        version::VERSION.register_version_metrics();
+    }) {
         eprintln!("Error: {err:?}");
         std::process::exit(1);
     }

--- a/bin/builder/src/version.rs
+++ b/bin/builder/src/version.rs
@@ -1,0 +1,104 @@
+//! Version information for the op-rbuilder binary.
+//!
+//! Contains [`VersionInfo`] and version-related constants.
+//!
+//! Derived from [`reth-node-core`'s type][reth-version-info]
+//!
+//! [reth-version-info]: https://github.com/paradigmxyz/reth/blob/805fb1012cd1601c3b4fe9e8ca2d97c96f61355b/crates/node/metrics/src/version.rs#L6
+
+use metrics::gauge;
+
+/// Cargo package version.
+pub const CARGO_PKG_VERSION: &str = env!("CARGO_PKG_VERSION");
+
+/// Build timestamp from vergen.
+pub const VERGEN_BUILD_TIMESTAMP: &str = env!("VERGEN_BUILD_TIMESTAMP");
+
+/// Cargo features from vergen.
+pub const VERGEN_CARGO_FEATURES: &str = env!("VERGEN_CARGO_FEATURES");
+
+/// Git SHA (short) from vergen.
+pub const VERGEN_GIT_SHA: &str = env!("VERGEN_GIT_SHA_SHORT");
+
+/// Cargo target triple from vergen.
+pub const VERGEN_CARGO_TARGET_TRIPLE: &str = env!("VERGEN_CARGO_TARGET_TRIPLE");
+
+/// Build profile name.
+pub const BUILD_PROFILE_NAME: &str = env!("OP_RBUILDER_BUILD_PROFILE");
+
+/// The latest commit author.
+pub const VERGEN_GIT_AUTHOR: &str = env!("VERGEN_GIT_COMMIT_AUTHOR");
+
+/// The latest commit message.
+pub const VERGEN_GIT_COMMIT_MESSAGE: &str = env!("VERGEN_GIT_COMMIT_MESSAGE");
+
+/// Short version string.
+pub const SHORT_VERSION: &str = env!("OP_RBUILDER_SHORT_VERSION");
+
+/// Long version string with additional build info.
+pub const LONG_VERSION: &str = concat!(
+    env!("OP_RBUILDER_LONG_VERSION_0"),
+    "\n",
+    env!("OP_RBUILDER_LONG_VERSION_1"),
+    "\n",
+    env!("OP_RBUILDER_LONG_VERSION_2"),
+    "\n",
+    env!("OP_RBUILDER_LONG_VERSION_3"),
+    "\n",
+    env!("OP_RBUILDER_LONG_VERSION_4"),
+    "\n",
+    env!("OP_RBUILDER_LONG_VERSION_5"),
+);
+
+/// Contains version information for the application and allows for exposing the contained
+/// information as a prometheus metric.
+#[derive(Debug, Clone)]
+pub struct VersionInfo {
+    /// The version of the application.
+    pub version: &'static str,
+    /// The build timestamp of the application.
+    pub build_timestamp: &'static str,
+    /// The cargo features enabled for the build.
+    pub cargo_features: &'static str,
+    /// The Git SHA of the build.
+    pub git_sha: &'static str,
+    /// The target triple for the build.
+    pub target_triple: &'static str,
+    /// The build profile (e.g., debug or release).
+    pub build_profile: &'static str,
+    /// The author of the latest commit.
+    pub commit_author: &'static str,
+    /// The message of the latest commit.
+    pub commit_message: &'static str,
+}
+
+/// The version information for op-rbuilder.
+pub const VERSION: VersionInfo = VersionInfo {
+    version: CARGO_PKG_VERSION,
+    build_timestamp: VERGEN_BUILD_TIMESTAMP,
+    cargo_features: VERGEN_CARGO_FEATURES,
+    git_sha: VERGEN_GIT_SHA,
+    target_triple: VERGEN_CARGO_TARGET_TRIPLE,
+    build_profile: BUILD_PROFILE_NAME,
+    commit_author: VERGEN_GIT_AUTHOR,
+    commit_message: VERGEN_GIT_COMMIT_MESSAGE,
+};
+
+impl VersionInfo {
+    /// This exposes op-rbuilder's version information over prometheus.
+    pub fn register_version_metrics(&self) {
+        let labels: [(&str, &str); 8] = [
+            ("version", self.version),
+            ("build_timestamp", self.build_timestamp),
+            ("cargo_features", self.cargo_features),
+            ("git_sha", self.git_sha),
+            ("target_triple", self.target_triple),
+            ("build_profile", self.build_profile),
+            ("commit_author", self.commit_author),
+            ("commit_message", self.commit_message),
+        ];
+
+        let gauge = gauge!("builder_info", &labels);
+        gauge.set(1);
+    }
+}

--- a/crates/builder/op-rbuilder/src/args/mod.rs
+++ b/crates/builder/op-rbuilder/src/args/mod.rs
@@ -3,7 +3,23 @@ pub use op::{FlashblocksArgs, OpRbuilderArgs, TelemetryArgs};
 use playground::PlaygroundOptions;
 use reth_optimism_cli::{chainspec::OpChainSpecParser, commands::Commands};
 
-use crate::metrics::{LONG_VERSION, SHORT_VERSION};
+/// Short version string.
+pub const SHORT_VERSION: &str = env!("OP_RBUILDER_SHORT_VERSION");
+
+/// Long version string with additional build info.
+pub const LONG_VERSION: &str = concat!(
+    env!("OP_RBUILDER_LONG_VERSION_0"),
+    "\n",
+    env!("OP_RBUILDER_LONG_VERSION_1"),
+    "\n",
+    env!("OP_RBUILDER_LONG_VERSION_2"),
+    "\n",
+    env!("OP_RBUILDER_LONG_VERSION_3"),
+    "\n",
+    env!("OP_RBUILDER_LONG_VERSION_4"),
+    "\n",
+    env!("OP_RBUILDER_LONG_VERSION_5"),
+);
 
 mod op;
 mod playground;

--- a/crates/builder/op-rbuilder/src/metrics.rs
+++ b/crates/builder/op-rbuilder/src/metrics.rs
@@ -1,58 +1,7 @@
 use metrics::IntoF64;
 use reth_metrics::{
     Metrics,
-    metrics::{Counter, Gauge, Histogram, gauge},
-};
-
-/// The latest version from Cargo.toml.
-pub const CARGO_PKG_VERSION: &str = env!("CARGO_PKG_VERSION");
-
-/// The 8 character short SHA of the latest commit.
-pub const VERGEN_GIT_SHA: &str = env!("VERGEN_GIT_SHA_SHORT");
-
-/// The build timestamp.
-pub const VERGEN_BUILD_TIMESTAMP: &str = env!("VERGEN_BUILD_TIMESTAMP");
-
-/// The target triple.
-pub const VERGEN_CARGO_TARGET_TRIPLE: &str = env!("VERGEN_CARGO_TARGET_TRIPLE");
-
-/// The build features.
-pub const VERGEN_CARGO_FEATURES: &str = env!("VERGEN_CARGO_FEATURES");
-
-/// The latest commit message and author name and email.
-pub const VERGEN_GIT_AUTHOR: &str = env!("VERGEN_GIT_COMMIT_AUTHOR");
-pub const VERGEN_GIT_COMMIT_MESSAGE: &str = env!("VERGEN_GIT_COMMIT_MESSAGE");
-
-/// The build profile name.
-pub const BUILD_PROFILE_NAME: &str = env!("OP_RBUILDER_BUILD_PROFILE");
-
-/// The short version information for op-rbuilder.
-pub const SHORT_VERSION: &str = env!("OP_RBUILDER_SHORT_VERSION");
-
-/// The long version information for op-rbuilder.
-pub const LONG_VERSION: &str = concat!(
-    env!("OP_RBUILDER_LONG_VERSION_0"),
-    "\n",
-    env!("OP_RBUILDER_LONG_VERSION_1"),
-    "\n",
-    env!("OP_RBUILDER_LONG_VERSION_2"),
-    "\n",
-    env!("OP_RBUILDER_LONG_VERSION_3"),
-    "\n",
-    env!("OP_RBUILDER_LONG_VERSION_4"),
-    "\n",
-    env!("OP_RBUILDER_LONG_VERSION_5"),
-);
-
-pub const VERSION: VersionInfo = VersionInfo {
-    version: CARGO_PKG_VERSION,
-    build_timestamp: VERGEN_BUILD_TIMESTAMP,
-    cargo_features: VERGEN_CARGO_FEATURES,
-    git_sha: VERGEN_GIT_SHA,
-    target_triple: VERGEN_CARGO_TARGET_TRIPLE,
-    build_profile: BUILD_PROFILE_NAME,
-    commit_author: VERGEN_GIT_AUTHOR,
-    commit_message: VERGEN_GIT_COMMIT_MESSAGE,
+    metrics::{Counter, Gauge, Histogram},
 };
 
 /// op-rbuilder metrics
@@ -204,45 +153,5 @@ impl OpRBuilderMetrics {
         self.payload_num_tx_simulated_fail.record(num_txs_simulated_fail);
         self.payload_num_tx_simulated_fail_gauge.set(num_txs_simulated_fail);
         self.payload_reverted_tx_gas_used.set(reverted_gas_used);
-    }
-}
-
-/// Contains version information for the application.
-#[derive(Debug, Clone)]
-pub struct VersionInfo {
-    /// The version of the application.
-    pub version: &'static str,
-    /// The build timestamp of the application.
-    pub build_timestamp: &'static str,
-    /// The cargo features enabled for the build.
-    pub cargo_features: &'static str,
-    /// The Git SHA of the build.
-    pub git_sha: &'static str,
-    /// The target triple for the build.
-    pub target_triple: &'static str,
-    /// The build profile (e.g., debug or release).
-    pub build_profile: &'static str,
-    /// The author of the latest commit.
-    pub commit_author: &'static str,
-    /// The message of the latest commit.
-    pub commit_message: &'static str,
-}
-
-impl VersionInfo {
-    /// This exposes op-rbuilder's version information over prometheus.
-    pub fn register_version_metrics(&self) {
-        let labels: [(&str, &str); 8] = [
-            ("version", self.version),
-            ("build_timestamp", self.build_timestamp),
-            ("cargo_features", self.cargo_features),
-            ("git_sha", self.git_sha),
-            ("target_triple", self.target_triple),
-            ("build_profile", self.build_profile),
-            ("commit_author", self.commit_author),
-            ("commit_message", self.commit_message),
-        ];
-
-        let gauge = gauge!("builder_info", &labels);
-        gauge.set(1);
     }
 }


### PR DESCRIPTION
## Summary
Move VersionInfo struct and register_version_metrics from op-rbuilder crate to the builder binary. This decouples version metrics registration from the crate, allowing binaries to control their own version reporting.

## Changes
- Add bin/builder/src/version.rs with VersionInfo and metrics registration
- Update launcher to accept on_node_started callback
- Move SHORT_VERSION/LONG_VERSION constants to args/mod.rs
- Simplify op-rbuilder build.rs to only generate CLI version env vars
- Remove VersionInfo from metrics.rs

Closes #396