### PR TITLE
chore(builder): removes telemetry feature flag

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1617,7 +1617,6 @@ dependencies = [
  "base-cli-utils",
  "op-rbuilder",
  "reth-cli-util",
- "reth-optimism-cli",
  "vergen",
  "vergen-git2",
 ]

--- a/bin/builder/Cargo.toml
+++ b/bin/builder/Cargo.toml
@@ -19,7 +19,6 @@ op-rbuilder.workspace = true
 
 # reth
 reth-cli-util.workspace = true
-reth-optimism-cli = { workspace = true, optional = true }
 
 [build-dependencies]
 vergen = { workspace = true, features = ["build", "cargo", "emit_and_set"] }
@@ -28,4 +27,3 @@ vergen-git2.workspace = true
 [features]
 default = [ "jemalloc" ]
 jemalloc = [ "op-rbuilder/jemalloc", "reth-cli-util/jemalloc" ]
-telemetry = [ "op-rbuilder/telemetry", "reth-optimism-cli" ]

--- a/crates/builder/op-rbuilder/Cargo.toml
+++ b/crates/builder/op-rbuilder/Cargo.toml
@@ -57,7 +57,7 @@ reth-rpc-api.workspace = true
 reth-rpc-eth-types.workspace = true
 reth-optimism-rpc.workspace = true
 reth-tasks.workspace = true
-reth-tracing-otlp = { workspace = true, optional = true }
+reth-tracing-otlp.workspace = true
 
 alloy-primitives.workspace = true
 alloy-consensus.workspace = true
@@ -110,7 +110,7 @@ thiserror.workspace = true
 parking_lot.workspace = true
 url.workspace = true
 anyhow = "1"
-opentelemetry = { workspace = true, optional = true }
+opentelemetry.workspace = true
 dashmap.workspace = true
 concurrent-queue.workspace = true
 hex = { workspace = true }
@@ -196,8 +196,6 @@ testing = [
 ]
 
 interop = []
-
-telemetry = [ "opentelemetry", "reth-tracing-otlp" ]
 
 custom-engine-api = []
 

--- a/crates/builder/op-rbuilder/src/flashblocks/payload.rs
+++ b/crates/builder/op-rbuilder/src/flashblocks/payload.rs
@@ -220,10 +220,8 @@ where
         let block_build_start_time = Instant::now();
         let BuildArguments { mut cached_reads, config, cancel: block_cancel } = args;
 
-        // We log only every 100th block to reduce usage
-        let span = if cfg!(feature = "telemetry")
-            && config.parent_header.number.is_multiple_of(self.config.sampling_ratio)
-        {
+        // We log only every Nth block based on sampling ratio to reduce usage
+        let span = if config.parent_header.number.is_multiple_of(self.config.sampling_ratio) {
             span!(Level::INFO, "build_payload")
         } else {
             tracing::Span::none()

--- a/crates/builder/op-rbuilder/src/launcher.rs
+++ b/crates/builder/op-rbuilder/src/launcher.rs
@@ -24,7 +24,6 @@ use crate::{
 pub fn launch() -> Result<()> {
     let cli = Cli::parsed();
 
-    #[cfg(feature = "telemetry")]
     let telemetry_args = match &cli.command {
         reth_optimism_cli::commands::Commands::Node(node_command) => {
             node_command.ext.telemetry.clone()
@@ -32,13 +31,10 @@ pub fn launch() -> Result<()> {
         _ => Default::default(),
     };
 
-    #[cfg(not(feature = "telemetry"))]
-    let cli_app = cli.configure();
-
-    #[cfg(feature = "telemetry")]
     let mut cli_app = cli.configure();
-    #[cfg(feature = "telemetry")]
-    {
+
+    // Only setup telemetry if an OTLP endpoint is provided
+    if telemetry_args.otlp_endpoint.is_some() {
         use crate::primitives::telemetry::setup_telemetry_layer;
         let telemetry_layer = setup_telemetry_layer(&telemetry_args)?;
         cli_app.access_tracing_layers()?.add_layer(telemetry_layer);

--- a/crates/builder/op-rbuilder/src/primitives/mod.rs
+++ b/crates/builder/op-rbuilder/src/primitives/mod.rs
@@ -1,4 +1,3 @@
 pub mod bundle;
 pub mod reth;
-#[cfg(feature = "telemetry")]
 pub mod telemetry;

--- a/crates/client/node/Cargo.toml
+++ b/crates/client/node/Cargo.toml
@@ -34,11 +34,14 @@ test-utils = [
 	"dep:reth-tasks",
 	"dep:tower",
 	"dep:tracing-subscriber",
+	"reth-chainspec/test-utils",
 	"reth-db/test-utils",
+	"reth-evm/test-utils",
 	"reth-node-builder/test-utils",
 	"reth-optimism-node/test-utils",
 	"reth-primitives-traits?/test-utils",
 	"reth-provider/test-utils",
+	"reth-transaction-pool/test-utils",
 ]
 
 [dependencies]


### PR DESCRIPTION
Currently, telemetry is gated behind a compile-time feature flag (telemetry). The CLI arguments for telemetry configuration already exist (TelemetryArgs). This task removes the feature flag and makes telemetry always available, but optionally enabled at runtime based on CLI arguments.

Fixes #440 