### PR TITLE
fix(gas-limiter): correct bucket cleanup condition

### DIFF
--- a/crates/builder/op-rbuilder/src/gas_limiter/mod.rs
+++ b/crates/builder/op-rbuilder/src/gas_limiter/mod.rs
@@ -104,7 +104,7 @@ impl AddressGasLimiterInner {
 
         // Only clean up stale buckets every `cleanup_interval` blocks
         if block_number.is_multiple_of(self.config.cleanup_interval) {
-            self.address_buckets.retain(|_, bucket| bucket.available <= bucket.capacity);
+            self.address_buckets.retain(|_, bucket| bucket.available < bucket.capacity);
         }
 
         active_addresses - self.address_buckets.len()


### PR DESCRIPTION
The garbage collection in AddressGasLimiter never removed any buckets because the retain condition `bucket.available <= bucket.capacity` was always true after the refill operation (which uses `min(capacity, available + refill_rate)`).

Changed condition from `<=` to `<` so that fully refilled buckets (available == capacity) are properly removed during cleanup intervals.