### PR TITLE
fix(flashblocks): improve logging for missing canonical header during sync

### DIFF
--- a/crates/client/flashblocks/src/error.rs
+++ b/crates/client/flashblocks/src/error.rs
@@ -24,9 +24,8 @@ pub enum ProtocolError {
 #[derive(Debug, Clone, Eq, PartialEq, Error)]
 pub enum ProviderError {
     /// Missing canonical header for a given block number.
-    #[error(
-        "missing canonical header for block {block_number}. This can be ignored if the node has recently restarted, restored from a snapshot or is still syncing."
-    )]
+    /// This typically occurs during node startup, snapshot restore, or while syncing.
+    #[error("missing canonical header for block {block_number}")]
     MissingCanonicalHeader {
         /// The block number for which the header is missing.
         block_number: u64,
@@ -169,7 +168,7 @@ mod tests {
     #[rstest]
     #[case::missing_canonical_header(
         ProviderError::MissingCanonicalHeader { block_number: 12345 },
-        "missing canonical header for block 12345. This can be ignored if the node has recently restarted, restored from a snapshot or is still syncing."
+        "missing canonical header for block 12345"
     )]
     #[case::state_provider(
         ProviderError::StateProvider("connection failed".to_string()),

--- a/crates/client/flashblocks/src/metrics.rs
+++ b/crates/client/flashblocks/src/metrics.rs
@@ -39,6 +39,12 @@ pub struct Metrics {
     #[metric(describe = "Count of times flashblocks are unable to be converted to blocks")]
     pub block_processing_error: Counter,
 
+    /// Count of times Flashblock processing was paused waiting for canonical chain sync.
+    #[metric(
+        describe = "Count of times Flashblock processing was paused waiting for canonical chain sync"
+    )]
+    pub canonical_sync_wait: Counter,
+
     /// Count of times pending snapshot was cleared because canonical caught up.
     #[metric(
         describe = "Number of times pending snapshot was cleared because canonical caught up"


### PR DESCRIPTION
## Summary
- Log `MissingCanonicalHeader` errors at INFO level instead of ERROR during node startup, snapshot restore, or sync
- Reduces log noise for expected conditions while preserving ERROR level for actual issues

Closes #398