### PR TITLE
chore(builder): Update bundle execution to execute single bundle only for backruns

### DIFF
--- a/crates/builder/op-rbuilder/src/flashblocks/context.rs
+++ b/crates/builder/op-rbuilder/src/flashblocks/context.rs
@@ -682,6 +682,7 @@ impl OpPayloadBuilderCtx {
                     }
 
                     self.metrics.backrun_bundles_landed_total.increment(1);
+                    break 'bundle_loop;
                 }
 
                 self.metrics.backrun_bundle_execution_duration.record(backrun_start_time.elapsed());


### PR DESCRIPTION
Adds a break statement to ensure only one backrun bundle is executed per target transaction, fixing the current behavior where all bundles are attempted.