### PR TITLE
chore(builder): move op-rbuilder primitives into shared base-primitives crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2113,6 +2113,8 @@ dependencies = [
  "alloy-eips",
  "alloy-genesis",
  "alloy-primitives",
+ "alloy-rpc-types-eth",
+ "alloy-serde",
  "alloy-signer",
  "alloy-signer-local",
  "alloy-sol-macro",
@@ -2120,7 +2122,9 @@ dependencies = [
  "eyre",
  "op-alloy-network",
  "op-alloy-rpc-types",
+ "serde",
  "serde_json",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
@@ -7372,6 +7376,7 @@ dependencies = [
  "base-builder-cli",
  "base-bundles",
  "base-flashtypes",
+ "base-primitives",
  "chrono",
  "clap",
  "clap_builder",

--- a/crates/builder/op-rbuilder/Cargo.toml
+++ b/crates/builder/op-rbuilder/Cargo.toml
@@ -14,6 +14,7 @@ workspace = true
 base-builder-cli.workspace = true
 base-bundles.workspace = true
 base-flashtypes.workspace = true
+base-primitives.workspace = true
 
 reth-optimism-node.workspace = true
 reth-optimism-cli.workspace = true

--- a/crates/builder/op-rbuilder/src/primitives/mod.rs
+++ b/crates/builder/op-rbuilder/src/primitives/mod.rs
@@ -1,3 +1,2 @@
-pub mod bundle;
 pub mod reth;
 pub mod telemetry;

--- a/crates/builder/op-rbuilder/src/tests/framework/txs.rs
+++ b/crates/builder/op-rbuilder/src/tests/framework/txs.rs
@@ -5,6 +5,7 @@ use alloy_consensus::TxEip1559;
 use alloy_eips::{BlockNumberOrTag, eip1559::MIN_PROTOCOL_BASE_FEE, eip2718::Encodable2718};
 use alloy_primitives::{Address, Bytes, TxHash, TxKind, U256, hex};
 use alloy_provider::{PendingTransactionBuilder, Provider, RootProvider};
+use base_primitives::bundle::{Bundle, BundleResult};
 use dashmap::DashMap;
 use futures::StreamExt;
 use op_alloy_consensus::{OpTxEnvelope, OpTypedTransaction};
@@ -15,11 +16,7 @@ use reth_transaction_pool::{AllTransactionsEvents, FullTransactionEvent, Transac
 use tokio::sync::watch;
 use tracing::debug;
 
-use crate::{
-    primitives::bundle::{Bundle, BundleResult},
-    tests::funded_signer,
-    tx_signer::Signer,
-};
+use crate::{tests::funded_signer, tx_signer::Signer};
 
 #[derive(Clone, Copy, Default, Debug)]
 pub struct BundleOpts {

--- a/crates/shared/primitives/Cargo.toml
+++ b/crates/shared/primitives/Cargo.toml
@@ -12,6 +12,11 @@ repository.workspace = true
 workspace = true
 
 [dependencies]
+alloy-primitives = { workspace = true, features = ["serde"] }
+alloy-rpc-types-eth = { workspace = true }
+alloy-serde = { workspace = true }
+serde = { workspace = true }
+thiserror = { workspace = true }
 eyre = { workspace = true, optional = true }
 serde_json = { workspace = true, optional = true }
 alloy-eips = { workspace = true, optional = true }
@@ -21,7 +26,6 @@ alloy-contract = { workspace = true, optional = true }
 alloy-sol-macro = { workspace = true, features = ["json"], optional = true }
 alloy-sol-types = { workspace = true, optional = true }
 alloy-consensus = { workspace = true, features = ["std"], optional = true }
-alloy-primitives = { workspace = true, features = ["serde"], optional = true }
 op-alloy-network = { workspace = true, optional = true }
 alloy-signer-local = { workspace = true, optional = true }
 op-alloy-rpc-types = { workspace = true, optional = true }
@@ -33,7 +37,6 @@ test-utils = [
 	"dep:alloy-contract",
 	"dep:alloy-eips",
 	"dep:alloy-genesis",
-	"dep:alloy-primitives",
 	"dep:alloy-signer",
 	"dep:alloy-signer-local",
 	"dep:alloy-sol-macro",

--- a/crates/shared/primitives/src/lib.rs
+++ b/crates/shared/primitives/src/lib.rs
@@ -6,6 +6,9 @@
 #[cfg(feature = "test-utils")]
 pub mod test_utils;
 
+/// Bundle types for MEV transaction execution.
+pub mod bundle;
+
 // These dependencies are only used in test-utils feature
 #[cfg(feature = "test-utils")]
 pub use test_utils::*;


### PR DESCRIPTION
This PR moves the op-rbuilder primitives into the shared `base-primitives` crate, de-duplicating the Bundle type and aligning with the current builder structure.

### Summary
- Moved op-rbuilder primitives into `crates/shared/primitives/src/op_rbuilder`
- Re-exported primitives via `base-primitives` and added `op-rbuilder` feature
- Updated op-rbuilder imports to use `base_primitives::op_rbuilder`
- De-duplicated `Bundle` in favor of the existing `base-bundles` crate
- Gated OTLP telemetry behind the `telemetry` feature and updated call sites

### Testing
- `cargo check -p op-rbuilder`
- `cargo check -p op-rbuilder --features telemetry`

This is a clean PR rebased on the latest `main` to avoid the conflicts in the previous one.
Closes #370