### PR TITLE
Fix typos: remove duplicate word and missing preposition

### DIFF
--- a/crates/builder/op-rbuilder/src/flashblocks/generator.rs
+++ b/crates/builder/op-rbuilder/src/flashblocks/generator.rs
@@ -210,7 +210,7 @@ where
         let new_execution_outcome = committed.execution_outcome();
         for (addr, acc) in new_execution_outcome.bundle_accounts_iter() {
             if let Some(info) = acc.info.clone() {
-                // we want pre cache existing accounts and their storage
+                // we want to pre-cache existing accounts and their storage
                 // this only includes changed accounts and storage but is better than nothing
                 let storage =
                     acc.storage.iter().map(|(key, slot)| (*key, slot.present_value)).collect();
@@ -321,7 +321,7 @@ where
     }
 }
 
-/// A [PayloadJob] is a a future that's being polled by the `PayloadBuilderService`
+/// A [PayloadJob] is a future that's being polled by the `PayloadBuilderService`
 impl<Tasks, Builder> Future for BlockPayloadJob<Tasks, Builder>
 where
     Tasks: TaskSpawner + Clone + 'static,


### PR DESCRIPTION

- Remove duplicate "a a" in doc comment 
- Add missing "to" before infinitive in comment 

