### PR TITLE
feat: add devnet binary for local testing

### DIFF
--- a/bin/devnet/Cargo.toml
+++ b/bin/devnet/Cargo.toml
@@ -1,0 +1,57 @@
+[package]
+name = "base-devnet"
+description = "Base Devnet - Local testing network for base-builder and base-client"
+
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+
+[lints]
+workspace = true
+
+[dependencies]
+# Workspace - shared utilities
+base-cli-utils.workspace = true
+base-primitives = { workspace = true, features = ["test-utils"] }
+base-client-node = { workspace = true, features = ["test-utils"] }
+
+# async - note: tokio features used via std::process, not tokio-process
+
+# cli
+clap = { workspace = true, features = ["derive", "env"] }
+
+# misc
+eyre.workspace = true
+tracing.workspace = true
+tracing-subscriber = { workspace = true, features = ["env-filter"] }
+tempfile.workspace = true
+serde_json.workspace = true
+ctrlc = "3.4"
+
+# Block driver (async runtime for Engine API)
+tokio = { workspace = true, features = ["rt-multi-thread", "macros", "time"] }
+alloy-primitives.workspace = true
+alloy-provider.workspace = true
+alloy-rpc-types.workspace = true
+alloy-rpc-types-engine.workspace = true
+alloy-eips.workspace = true
+op-alloy-network.workspace = true
+op-alloy-rpc-types-engine.workspace = true
+url.workspace = true
+
+# TUI (optional)
+ratatui = { version = "0.29", optional = true }
+crossterm = { version = "0.28", optional = true }
+chrono = { version = "0.4", optional = true }
+libc = { version = "0.2", optional = true }
+
+[build-dependencies]
+vergen = { workspace = true, features = ["build", "cargo", "emit_and_set"] }
+vergen-git2.workspace = true
+
+[features]
+default = ["tui"]
+tui = ["dep:ratatui", "dep:crossterm", "dep:chrono", "dep:libc"]

--- a/bin/devnet/README.md
+++ b/bin/devnet/README.md
@@ -1,0 +1,185 @@
+# Base Devnet
+
+A local development network that launches both `base-builder` and `base-client` nodes configured for testing.
+
+## Quick Start
+
+```bash
+# Build all binaries
+cargo build --release -p base-devnet -p base-builder -p base-reth-node
+
+# Run devnet
+./target/release/base-devnet
+```
+
+## Features
+
+- **Pre-configured Genesis**: Uses a test genesis with pre-funded accounts
+- **Auto-discovery Disabled**: No P2P networking, purely local
+- **Deterministic JWT**: Uses a fixed JWT secret for easy scripting
+- **Flashblocks Support**: Optional flashblocks mode for testing real-time updates
+
+## CLI Options
+
+```
+USAGE:
+    base-devnet [OPTIONS]
+
+OPTIONS:
+    -d, --datadir <PATH>              Data directory for devnet state
+        --http-port <PORT>            Client HTTP RPC port [default: 8545]
+        --ws-port <PORT>              Client WebSocket port [default: 8546]
+        --engine-port <PORT>          Client Engine API port [default: 8551]
+        --builder-http-port <PORT>    Builder HTTP RPC port [default: 8645]
+        --builder-engine-port <PORT>  Builder Engine API port [default: 8651]
+        --block-time-ms <MS>          Block time in milliseconds [default: 2000]
+        --flashblocks                 Enable flashblocks support [default: true]
+        --no-builder                  Don't start the builder (client-only)
+        --no-client                   Don't start the client (builder-only)
+        --no-driver                   Don't start block driver (for external consensus)
+    -v, --log-level <LEVEL>           Log level [default: info]
+    -h, --help                        Print help
+```
+
+## Pre-funded Test Accounts
+
+All accounts have 1,000,000 ETH:
+
+| Name    | Address                                    | Private Key                                                        |
+|---------|--------------------------------------------|--------------------------------------------------------------------|
+| Alice   | 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266 | 0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80 |
+| Bob     | 0x70997970C51812dc3A010C7d01b50e0d17dc79C8 | 0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d |
+| Charlie | 0x3C44CdDdB6a900fa2b585dd299e03d12FA4293BC | 0x5de4111afa1a4b94908f83103eb1f1706367c2e68ca870fc3fb9a804cdab365a |
+
+## Example Usage
+
+### Basic Development
+
+```bash
+# Start devnet with defaults
+base-devnet
+
+# In another terminal, interact via cast
+cast chain-id --rpc-url http://localhost:8545
+cast balance 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266 --rpc-url http://localhost:8545
+```
+
+### Custom Configuration
+
+```bash
+# Custom ports and persistent data
+base-devnet \
+    --datadir ./my-devnet \
+    --http-port 9545 \
+    --block-time-ms 1000
+
+# Client-only mode (for external builder testing)
+base-devnet --no-builder
+
+# Builder-only mode
+base-devnet --no-client
+
+# External consensus mode (plug in your own op-node/Kona)
+base-devnet --no-driver
+```
+
+## Architecture
+
+```
+┌─────────────────┐         ┌─────────────────┐
+│  base-builder   │◄───────►│ base-reth-node  │
+│   (block prod)  │ Engine  │    (client)     │
+│                 │   API   │                 │
+│  :8645 HTTP     │         │  :8545 HTTP     │
+│  :8651 Engine   │         │  :8546 WS       │
+│  :9002 Metrics  │         │  :8551 Engine   │
+│                 │         │  :9001 Metrics  │
+└─────────────────┘         └─────────────────┘
+```
+
+## Chain Configuration
+
+- **Chain ID**: 84538453
+- **Block Gas Limit**: 100,000,000
+- **EIP-1559 Elasticity**: 6
+- **EIP-1559 Denominator**: 50
+- **All Hardforks**: Enabled from genesis (including Prague, Isthmus, Jovian)
+
+## TUI Controls
+
+The devnet includes an interactive terminal UI for monitoring both nodes.
+
+| Key | Action |
+|-----|--------|
+| `q` / `Esc` | Quit |
+| `r` | Restart nodes |
+| `s` | Save logs to file |
+| `Tab` | Switch panel focus (Client ↔ Builder) |
+| `↑` / `k` | Scroll up |
+| `↓` / `j` | Scroll down |
+| `PgUp` / `PgDn` | Page up/down |
+| `Home` / `g` | Scroll to top |
+| `End` / `G` | Scroll to bottom |
+| `f` | Toggle auto-scroll |
+
+### Visual Indicators
+
+- **◆ Green line** - Block contains user transaction(s)
+- **✓** - Node running
+- **✖** - Node stopped
+- **Block #N** - Current block number (header)
+- **Chain ID** - Network identifier (header)
+- **AUTO/MANUAL** - Scroll mode indicator
+
+### Disabling TUI
+
+Run without TUI for CI/scripting:
+
+```bash
+cargo build --release -p base-devnet --no-default-features
+```
+
+## Troubleshooting
+
+### "Failed to start base-reth-node"
+
+Ensure binaries are built:
+```bash
+cargo build --release -p base-reth-node -p base-builder
+```
+
+### Port already in use
+
+Another devnet or node is running. Kill it or use custom ports:
+```bash
+base-devnet --http-port 9545 --engine-port 9551
+```
+
+### Transactions not being included
+
+1. Check the block driver is running (don't use `--no-driver`)
+2. Verify you're using a pre-funded account
+3. Check gas price isn't below base fee
+
+### JWT authentication errors
+
+The devnet uses a deterministic all-zeros JWT secret. If connecting external tools, use:
+```
+0000000000000000000000000000000000000000000000000000000000000000
+```
+
+## Testing Transactions
+
+```bash
+# Send ETH
+cast send 0x70997970C51812dc3A010C7d01b50e0d17dc79C8 \
+  --value 0.1ether \
+  --rpc-url http://localhost:8545 \
+  --private-key 0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80
+
+# Check balance
+cast balance 0x70997970C51812dc3A010C7d01b50e0d17dc79C8 --rpc-url http://localhost:8545
+
+# Get block info
+cast block latest --rpc-url http://localhost:8545
+```

--- a/bin/devnet/build.rs
+++ b/bin/devnet/build.rs
@@ -1,0 +1,31 @@
+//! Build script for the base-devnet binary that generates version information.
+
+use std::{env, error::Error};
+
+use vergen::{BuildBuilder, CargoBuilder, Emitter};
+use vergen_git2::Git2Builder;
+
+fn main() -> Result<(), Box<dyn Error>> {
+    let mut emitter = Emitter::default();
+
+    let build_builder = BuildBuilder::default().build_timestamp(true).build()?;
+    emitter.add_instructions(&build_builder)?;
+
+    let cargo_builder = CargoBuilder::default().features(true).target_triple(true).build()?;
+    emitter.add_instructions(&cargo_builder)?;
+
+    let git_builder =
+        Git2Builder::default().describe(false, true, None).dirty(true).sha(false).build()?;
+    emitter.add_instructions(&git_builder)?;
+
+    emitter.emit_and_set()?;
+
+    let sha = env::var("VERGEN_GIT_SHA")?;
+    let sha_short = &sha[0..7];
+    println!("cargo:rustc-env=VERGEN_GIT_SHA_SHORT={sha_short}");
+
+    let pkg_version = env!("CARGO_PKG_VERSION");
+    println!("cargo:rustc-env=BASE_DEVNET_VERSION={pkg_version} ({sha_short})");
+
+    Ok(())
+}

--- a/bin/devnet/src/block_driver.rs
+++ b/bin/devnet/src/block_driver.rs
@@ -1,0 +1,168 @@
+//! Block driver for the devnet.
+//!
+//! Drives block production via Engine API, similar to what op-node/base-consensus does,
+//! but simplified for local testing without requiring an L1 connection.
+
+use std::time::Duration;
+
+use alloy_eips::eip7685::Requests;
+use alloy_primitives::{B64, B256, Bytes};
+use alloy_provider::{Provider, RootProvider};
+use alloy_rpc_types::BlockNumberOrTag;
+use alloy_rpc_types_engine::PayloadAttributes;
+use base_client_node::test_utils::{
+    BLOCK_BUILD_DELAY_MS, EngineApi, GAS_LIMIT, HttpEngine, L1_BLOCK_INFO_DEPOSIT_TX,
+};
+use eyre::{Result, eyre};
+use op_alloy_network::Optimism;
+use op_alloy_rpc_types_engine::OpPayloadAttributes;
+use tokio::time::sleep;
+use tracing::{debug, info, warn};
+
+/// Configuration for the block driver.
+#[derive(Debug, Clone)]
+pub(crate) struct BlockDriverConfig {
+    /// Engine API URL for the client node.
+    pub engine_url: String,
+    /// HTTP RPC URL for the client node (to query latest block).
+    pub rpc_url: String,
+    /// Block time in milliseconds.
+    pub block_time_ms: u64,
+}
+
+/// Runs the block driver loop, producing blocks at the configured interval.
+pub(crate) async fn run_block_driver(config: BlockDriverConfig) -> Result<()> {
+    info!("Starting block driver with {}ms block time", config.block_time_ms);
+
+    // Wait for nodes to be ready
+    sleep(Duration::from_secs(3)).await;
+
+    // Create Engine API client
+    let engine = EngineApi::<HttpEngine>::new(config.engine_url.clone())?;
+
+    // Create RPC provider for querying latest block
+    let rpc_url: url::Url = config.rpc_url.parse()?;
+    let provider = RootProvider::<Optimism>::new_http(rpc_url);
+
+    // Wait for the node to be responsive
+    let mut retries = 0;
+    loop {
+        match provider.get_chain_id().await {
+            Ok(chain_id) => {
+                info!("Block driver connected to chain {}", chain_id);
+                break;
+            }
+            Err(e) => {
+                retries += 1;
+                if retries > 30 {
+                    return Err(eyre!("Failed to connect to node after 30 retries: {}", e));
+                }
+                debug!("Waiting for node to be ready... (attempt {})", retries);
+                sleep(Duration::from_millis(500)).await;
+            }
+        }
+    }
+
+    // Main block production loop
+    let block_interval = Duration::from_millis(config.block_time_ms);
+
+    loop {
+        match produce_block(&engine, &provider).await {
+            Ok(block_number) => {
+                debug!("Produced block {}", block_number);
+            }
+            Err(e) => {
+                warn!("Failed to produce block: {}", e);
+            }
+        }
+
+        sleep(block_interval).await;
+    }
+}
+
+/// Produces a single block using the Engine API.
+async fn produce_block(
+    engine: &EngineApi<HttpEngine>,
+    provider: &RootProvider<Optimism>,
+) -> Result<u64> {
+    // Get latest block
+    let latest_block = provider
+        .get_block_by_number(BlockNumberOrTag::Latest)
+        .await?
+        .ok_or_else(|| eyre!("No latest block found"))?;
+
+    let parent_hash = latest_block.header.hash;
+    let parent_beacon_block_root =
+        latest_block.header.parent_beacon_block_root.unwrap_or(B256::ZERO);
+    let next_timestamp = latest_block.header.timestamp + 2; // 2 second block time
+
+    // Build payload attributes with L1 deposit tx
+    let transactions: Vec<Bytes> = vec![L1_BLOCK_INFO_DEPOSIT_TX];
+
+    // Get base fee from parent block
+    let min_base_fee = latest_block.header.base_fee_per_gas.unwrap_or(1);
+
+    // EIP-1559 params: elasticity=6, denominator=50 (matching our genesis)
+    // Format: (denominator << 32) | elasticity
+    let eip_1559_params: u64 = (50 << 32) | 6;
+
+    let payload_attributes = OpPayloadAttributes {
+        payload_attributes: PayloadAttributes {
+            timestamp: next_timestamp,
+            parent_beacon_block_root: Some(parent_beacon_block_root),
+            withdrawals: Some(vec![]),
+            ..Default::default()
+        },
+        transactions: Some(transactions),
+        gas_limit: Some(GAS_LIMIT),
+        no_tx_pool: Some(false), // Include txpool transactions
+        min_base_fee: Some(min_base_fee),
+        eip_1559_params: Some(B64::from(eip_1559_params)),
+    };
+
+    // Start building block
+    let forkchoice_result =
+        engine.update_forkchoice(parent_hash, parent_hash, Some(payload_attributes)).await?;
+
+    let payload_id = forkchoice_result
+        .payload_id
+        .ok_or_else(|| eyre!("Forkchoice update did not return payload ID"))?;
+
+    // Wait for block to be built
+    sleep(Duration::from_millis(BLOCK_BUILD_DELAY_MS)).await;
+
+    // Get the built payload
+    let payload_envelope = engine.get_payload(payload_id).await?;
+
+    // Submit the payload
+    let execution_requests = if payload_envelope.execution_requests.is_empty() {
+        Requests::default()
+    } else {
+        Requests::new(payload_envelope.execution_requests)
+    };
+
+    let payload_status = engine
+        .new_payload(
+            payload_envelope.execution_payload.clone(),
+            vec![],
+            payload_envelope.parent_beacon_block_root,
+            execution_requests,
+        )
+        .await?;
+
+    if payload_status.status.is_invalid() {
+        return Err(eyre!("Engine rejected payload: {:?}", payload_status));
+    }
+
+    let new_block_hash = payload_status
+        .latest_valid_hash
+        .ok_or_else(|| eyre!("Payload status missing latest_valid_hash"))?;
+
+    // Finalize the block
+    engine.update_forkchoice(new_block_hash, new_block_hash, None).await?;
+
+    // Return the new block number (parent + 1)
+    let new_block_number = latest_block.header.number + 1;
+
+    Ok(new_block_number)
+}

--- a/bin/devnet/src/cli.rs
+++ b/bin/devnet/src/cli.rs
@@ -1,0 +1,108 @@
+//! CLI argument definitions for the devnet binary.
+
+use std::path::PathBuf;
+
+use clap::Parser;
+
+/// Base Devnet - launches a local base-builder and base-client network for testing.
+#[derive(Debug, Clone, Parser)]
+#[command(name = "base-devnet", about = "Launch a local Base devnet for testing")]
+pub(crate) struct DevnetArgs {
+    /// Data directory for devnet state.
+    ///
+    /// Stores blockchain data for both builder and client nodes.
+    /// If not specified, uses a temporary directory.
+    #[arg(long, short = 'd', value_name = "PATH")]
+    pub datadir: Option<PathBuf>,
+
+    /// HTTP RPC port for the client node.
+    #[arg(long, default_value = "8545")]
+    pub http_port: u16,
+
+    /// WebSocket RPC port for the client node.
+    #[arg(long, default_value = "8546")]
+    pub ws_port: u16,
+
+    /// Engine API port for consensus layer communication.
+    #[arg(long, default_value = "8551")]
+    pub engine_port: u16,
+
+    /// Builder HTTP RPC port.
+    #[arg(long, default_value = "8645")]
+    pub builder_http_port: u16,
+
+    /// Builder Engine API port.
+    #[arg(long, default_value = "8651")]
+    pub builder_engine_port: u16,
+
+    /// Metrics port for the client node.
+    #[arg(long, default_value = "9001")]
+    pub metrics_port: u16,
+
+    /// Builder metrics port.
+    #[arg(long, default_value = "9002")]
+    pub builder_metrics_port: u16,
+
+    /// P2P port for the client node.
+    #[arg(long, default_value = "30303")]
+    pub p2p_port: u16,
+
+    /// P2P port for the builder node.
+    #[arg(long, default_value = "30304")]
+    pub builder_p2p_port: u16,
+
+    /// Block time in milliseconds.
+    #[arg(long, default_value = "2000")]
+    pub block_time_ms: u64,
+
+    /// Enable flashblocks support.
+    #[arg(long, default_value = "true")]
+    pub flashblocks: bool,
+
+    /// Log level (error, warn, info, debug, trace).
+    #[arg(long, short = 'v', default_value = "info")]
+    pub log_level: String,
+
+    /// Don't start the builder (client-only mode).
+    #[arg(long)]
+    pub no_builder: bool,
+
+    /// Don't start the client (builder-only mode).
+    #[arg(long)]
+    pub no_client: bool,
+
+    /// Don't start the block driver (for plugging in external consensus).
+    ///
+    /// Use this when you want to connect your own consensus client (op-node, Kona, etc.)
+    /// to drive block production instead of the built-in driver.
+    #[arg(long)]
+    pub no_driver: bool,
+
+    /// Disable terminal UI mode (use plain console logging).
+    #[cfg(feature = "tui")]
+    #[arg(long)]
+    pub no_tui: bool,
+}
+
+impl DevnetArgs {
+    /// Returns the data directory, creating a temp dir if not specified.
+    pub(crate) fn data_dir(&self) -> PathBuf {
+        self.datadir.clone().unwrap_or_else(|| {
+            let temp = tempfile::tempdir().expect("failed to create temp directory");
+            let path = temp.path().to_path_buf();
+            // Keep the temp directory so it doesn't get deleted
+            std::mem::forget(temp);
+            path
+        })
+    }
+
+    /// Returns the client data directory.
+    pub(crate) fn client_datadir(&self) -> PathBuf {
+        self.data_dir().join("client")
+    }
+
+    /// Returns the builder data directory.
+    pub(crate) fn builder_datadir(&self) -> PathBuf {
+        self.data_dir().join("builder")
+    }
+}

--- a/bin/devnet/src/main.rs
+++ b/bin/devnet/src/main.rs
@@ -1,0 +1,685 @@
+#![doc = include_str!("../README.md")]
+#![doc(issue_tracker_base_url = "https://github.com/base/node-reth/issues/")]
+#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
+#![cfg_attr(not(test), warn(unused_crate_dependencies))]
+
+mod block_driver;
+mod cli;
+
+#[cfg(feature = "tui")]
+mod tui;
+
+use std::{
+    fs,
+    io::{BufRead, BufReader},
+    path::PathBuf,
+    process::{Child, Command, Stdio},
+    sync::{
+        Arc,
+        atomic::{AtomicBool, Ordering},
+    },
+    thread,
+    time::Duration,
+};
+
+#[cfg(feature = "tui")]
+use std::sync::Mutex;
+
+use base_primitives::{DEVNET_CHAIN_ID, build_test_genesis};
+use clap::Parser;
+use cli::DevnetArgs;
+use eyre::{Result, eyre};
+use tracing::{error, info, warn};
+
+#[cfg(feature = "tui")]
+use tui::{App, LogState, TuiResult, init_terminal, restore_terminal, run_tui};
+
+/// Version string set by build.rs
+const VERSION: &str = env!("BASE_DEVNET_VERSION");
+
+fn main() -> Result<()> {
+    // Initialize version info
+    base_cli_utils::Version::init();
+
+    let args = DevnetArgs::parse();
+
+    // TUI mode vs standard logging mode
+    #[cfg(feature = "tui")]
+    if args.no_tui {
+        run_standard(args)
+    } else {
+        run_with_tui(args)
+    }
+
+    #[cfg(not(feature = "tui"))]
+    run_standard(args)
+}
+
+/// Run devnet with TUI interface.
+#[cfg(feature = "tui")]
+fn run_with_tui(args: DevnetArgs) -> Result<()> {
+    // Create data directories
+    let data_dir = args.data_dir();
+    fs::create_dir_all(&data_dir)?;
+    fs::create_dir_all(args.client_datadir())?;
+    fs::create_dir_all(args.builder_datadir())?;
+
+    // Generate and write genesis file
+    let genesis_path = data_dir.join("genesis.json");
+    write_genesis(&genesis_path)?;
+
+    // Generate JWT secret for Engine API auth
+    let jwt_path = data_dir.join("jwt.hex");
+    write_jwt_secret(&jwt_path)?;
+
+    // Initialize terminal once
+    let mut terminal = init_terminal()?;
+
+    // Setup shutdown signal (only once, before the loop)
+    let ctrl_c_pressed = Arc::new(AtomicBool::new(false));
+    let ctrl_c_flag = Arc::clone(&ctrl_c_pressed);
+    ctrlc_handler(move || {
+        ctrl_c_flag.store(true, Ordering::SeqCst);
+    });
+
+    // Main loop (supports restart)
+    loop {
+        // Reset ctrl-c flag for this run
+        ctrl_c_pressed.store(false, Ordering::SeqCst);
+
+        // Create fresh log state for each run
+        let log_state = Arc::new(Mutex::new(LogState::new()));
+
+        let mut processes: Vec<Child> = Vec::new();
+
+        // Launch client node with TUI log capture
+        if !args.no_client {
+            match launch_client_tui(&args, &genesis_path, &jwt_path, Arc::clone(&log_state)) {
+                Ok(client) => {
+                    let mut state = log_state.lock().unwrap();
+                    state.client_pid = Some(client.id());
+                    state.client_running = true;
+                    drop(state);
+                    processes.push(client);
+                }
+                Err(e) => {
+                    log_state
+                        .lock()
+                        .unwrap()
+                        .push_client_log(format!("[ERR] Failed to start: {e}"));
+                }
+            }
+        }
+
+        // Give the client time to start
+        if !args.no_client && !args.no_builder {
+            thread::sleep(Duration::from_secs(2));
+        }
+
+        // Launch builder node with TUI log capture
+        if !args.no_builder {
+            match launch_builder_tui(&args, &genesis_path, &jwt_path, Arc::clone(&log_state)) {
+                Ok(builder) => {
+                    let mut state = log_state.lock().unwrap();
+                    state.builder_pid = Some(builder.id());
+                    state.builder_running = true;
+                    drop(state);
+                    processes.push(builder);
+                }
+                Err(e) => {
+                    log_state
+                        .lock()
+                        .unwrap()
+                        .push_builder_log(format!("[ERR] Failed to start: {e}"));
+                }
+            }
+        }
+
+        // Start block driver in background (unless --no-driver)
+        if !args.no_driver {
+            let block_driver_config = block_driver::BlockDriverConfig {
+                engine_url: format!("http://127.0.0.1:{}", args.engine_port),
+                rpc_url: format!("http://127.0.0.1:{}", args.http_port),
+                block_time_ms: args.block_time_ms,
+            };
+
+            let log_state_driver = Arc::clone(&log_state);
+            std::thread::spawn(move || {
+                let rt = tokio::runtime::Runtime::new().expect("Failed to create tokio runtime");
+                rt.block_on(async {
+                    if let Err(e) = block_driver::run_block_driver(block_driver_config).await {
+                        log_state_driver
+                            .lock()
+                            .unwrap()
+                            .push_client_log(format!("[DRIVER] Error: {e}"));
+                    }
+                });
+            });
+        } else {
+            info!(
+                "Block driver disabled (--no-driver). Connect external consensus to drive blocks."
+            );
+        }
+
+        // Create fresh app state
+        let mut app =
+            App::new(Arc::clone(&log_state), DEVNET_CHAIN_ID, args.http_port, args.ws_port);
+
+        // Run TUI event loop
+        let result = run_tui(&mut terminal, &mut app)?;
+
+        // Shutdown all processes
+        for mut proc in processes {
+            let _ = proc.kill();
+            let _ = proc.wait();
+        }
+
+        // Check if we should restart or quit
+        match result {
+            TuiResult::Restart => {
+                // Small delay to ensure ports are released
+                thread::sleep(Duration::from_millis(500));
+                continue;
+            }
+            TuiResult::Quit => {
+                break;
+            }
+        }
+    }
+
+    // Restore terminal
+    restore_terminal(&mut terminal)?;
+
+    Ok(())
+}
+
+/// Run devnet with standard console logging.
+fn run_standard(args: DevnetArgs) -> Result<()> {
+    // Setup logging
+    setup_logging(&args.log_level);
+
+    info!("Starting Base Devnet v{VERSION}");
+    info!("Chain ID: {DEVNET_CHAIN_ID}");
+
+    // Create data directories
+    let data_dir = args.data_dir();
+    fs::create_dir_all(&data_dir)?;
+    fs::create_dir_all(args.client_datadir())?;
+    fs::create_dir_all(args.builder_datadir())?;
+
+    // Generate and write genesis file
+    let genesis_path = data_dir.join("genesis.json");
+    write_genesis(&genesis_path)?;
+    info!("Genesis written to: {}", genesis_path.display());
+
+    // Generate JWT secret for Engine API auth
+    let jwt_path = data_dir.join("jwt.hex");
+    write_jwt_secret(&jwt_path)?;
+
+    // Setup shutdown signal handler
+    let running = Arc::new(AtomicBool::new(true));
+    let r = running.clone();
+    ctrlc_handler(move || {
+        r.store(false, Ordering::SeqCst);
+    });
+
+    let mut processes: Vec<Child> = Vec::new();
+
+    // Launch client node
+    if !args.no_client {
+        info!("Starting base-reth-node (client)...");
+        let client = launch_client(&args, &genesis_path, &jwt_path)?;
+        processes.push(client);
+    }
+
+    // Give the client time to start before launching builder
+    if !args.no_client && !args.no_builder {
+        thread::sleep(Duration::from_secs(3));
+    }
+
+    // Launch builder node
+    if !args.no_builder {
+        info!("Starting base-builder...");
+        let builder = launch_builder(&args, &genesis_path, &jwt_path)?;
+        processes.push(builder);
+    }
+
+    // Print connection info
+    print_connection_info(&args);
+
+    // Start block driver in background (unless --no-driver)
+    if !args.no_driver {
+        let block_driver_config = block_driver::BlockDriverConfig {
+            engine_url: format!("http://127.0.0.1:{}", args.engine_port),
+            rpc_url: format!("http://127.0.0.1:{}", args.http_port),
+            block_time_ms: args.block_time_ms,
+        };
+
+        std::thread::spawn(move || {
+            let rt = tokio::runtime::Runtime::new().expect("Failed to create tokio runtime");
+            rt.block_on(async {
+                if let Err(e) = block_driver::run_block_driver(block_driver_config).await {
+                    error!("Block driver error: {}", e);
+                }
+            });
+        });
+    } else {
+        info!("Block driver disabled (--no-driver). Connect external consensus to drive blocks.");
+    }
+
+    // Wait for shutdown signal or process exit
+    info!("Devnet running. Press Ctrl+C to stop.");
+    while running.load(Ordering::SeqCst) {
+        // Check if any process has exited unexpectedly
+        for (i, proc) in processes.iter_mut().enumerate() {
+            match proc.try_wait() {
+                Ok(Some(status)) => {
+                    warn!("Process {i} exited with status: {status}");
+                    running.store(false, Ordering::SeqCst);
+                    break;
+                }
+                Ok(None) => {} // Still running
+                Err(e) => {
+                    error!("Error checking process {i}: {e}");
+                }
+            }
+        }
+        thread::sleep(Duration::from_millis(500));
+    }
+
+    // Shutdown all processes
+    info!("Shutting down devnet...");
+    for mut proc in processes {
+        if let Err(e) = proc.kill() {
+            warn!("Failed to kill process: {e}");
+        }
+        let _ = proc.wait();
+    }
+
+    info!("Devnet stopped.");
+    Ok(())
+}
+
+fn setup_logging(level: &str) {
+    use tracing_subscriber::{EnvFilter, fmt, prelude::*};
+
+    let filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new(level));
+
+    tracing_subscriber::registry().with(fmt::layer().with_target(true)).with(filter).init();
+}
+
+fn ctrlc_handler<F: FnOnce() + Send + 'static>(handler: F) {
+    let handler = std::sync::Mutex::new(Some(handler));
+    ctrlc::set_handler(move || {
+        if let Some(h) = handler.lock().unwrap().take() {
+            h();
+        }
+    })
+    .expect("Error setting Ctrl-C handler");
+}
+
+fn write_genesis(path: &PathBuf) -> Result<()> {
+    let genesis = build_test_genesis();
+    let genesis_json = serde_json::to_string_pretty(&genesis)?;
+    fs::write(path, genesis_json)?;
+    Ok(())
+}
+
+fn write_jwt_secret(path: &PathBuf) -> Result<()> {
+    // Use all-zeros JWT secret to match DEFAULT_JWT_SECRET in test_utils
+    let jwt_secret = "0000000000000000000000000000000000000000000000000000000000000000";
+    fs::write(path, jwt_secret)?;
+    Ok(())
+}
+
+/// Find a binary, checking ./target/release/ first, then PATH.
+fn find_binary(name: &str) -> PathBuf {
+    let release_path = PathBuf::from("./target/release").join(name);
+    if release_path.exists() { release_path } else { PathBuf::from(name) }
+}
+
+fn launch_client(args: &DevnetArgs, genesis_path: &PathBuf, jwt_path: &PathBuf) -> Result<Child> {
+    let mut cmd = Command::new(find_binary("base-reth-node"));
+
+    // Reduce log noise - filter out repetitive forkchoice/payload messages
+    cmd.env("RUST_LOG", "info,reth_engine_util::engine_store=warn,reth::consensus::engine=warn");
+
+    cmd.arg("node")
+        .arg("--chain")
+        .arg(genesis_path)
+        .arg("--datadir")
+        .arg(args.client_datadir())
+        .arg("--http")
+        .arg("--http.addr")
+        .arg("0.0.0.0")
+        .arg("--http.port")
+        .arg(args.http_port.to_string())
+        .arg("--http.api")
+        .arg("eth,net,web3,debug,trace,txpool")
+        .arg("--ws")
+        .arg("--ws.addr")
+        .arg("0.0.0.0")
+        .arg("--ws.port")
+        .arg(args.ws_port.to_string())
+        .arg("--ws.api")
+        .arg("eth,net,web3,debug,trace,txpool")
+        .arg("--authrpc.addr")
+        .arg("127.0.0.1")
+        .arg("--authrpc.port")
+        .arg(args.engine_port.to_string())
+        .arg("--authrpc.jwtsecret")
+        .arg(jwt_path)
+        .arg("--metrics")
+        .arg(format!("127.0.0.1:{}", args.metrics_port))
+        // Disable discovery for local devnet
+        .arg("--disable-discovery")
+        .arg("--nat")
+        .arg("none")
+        // P2P port
+        .arg("--port")
+        .arg(args.p2p_port.to_string())
+        // Enable dev mode for auto-mining etc
+        .arg("--dev");
+
+    if args.flashblocks {
+        cmd.arg("--enable-metering");
+    }
+
+    cmd.stdout(Stdio::piped()).stderr(Stdio::piped());
+
+    let mut child = cmd.spawn().map_err(|e| {
+        eyre!(
+            "Failed to start base-reth-node. Is it in your PATH? Error: {e}\n\
+             Try running: cargo build --release -p base-reth-node"
+        )
+    })?;
+
+    // Spawn thread to forward stdout
+    if let Some(stdout) = child.stdout.take() {
+        thread::spawn(move || {
+            let reader = BufReader::new(stdout);
+            for line in reader.lines().map_while(Result::ok) {
+                info!(target: "client", "{line}");
+            }
+        });
+    }
+
+    // Spawn thread to forward stderr
+    if let Some(stderr) = child.stderr.take() {
+        thread::spawn(move || {
+            let reader = BufReader::new(stderr);
+            for line in reader.lines().map_while(Result::ok) {
+                warn!(target: "client", "{line}");
+            }
+        });
+    }
+
+    Ok(child)
+}
+
+fn launch_builder(args: &DevnetArgs, genesis_path: &PathBuf, jwt_path: &PathBuf) -> Result<Child> {
+    let mut cmd = Command::new(find_binary("base-builder"));
+
+    // Reduce log noise - filter out repetitive forkchoice/payload messages
+    cmd.env("RUST_LOG", "info,reth_engine_util::engine_store=warn,reth::consensus::engine=warn");
+
+    cmd.arg("node")
+        .arg("--chain")
+        .arg(genesis_path)
+        .arg("--datadir")
+        .arg(args.builder_datadir())
+        .arg("--http")
+        .arg("--http.addr")
+        .arg("0.0.0.0")
+        .arg("--http.port")
+        .arg(args.builder_http_port.to_string())
+        .arg("--http.api")
+        .arg("eth,net,web3,debug,txpool")
+        .arg("--authrpc.addr")
+        .arg("127.0.0.1")
+        .arg("--authrpc.port")
+        .arg(args.builder_engine_port.to_string())
+        .arg("--authrpc.jwtsecret")
+        .arg(jwt_path)
+        .arg("--metrics")
+        .arg(format!("127.0.0.1:{}", args.builder_metrics_port))
+        // Disable discovery for local devnet
+        .arg("--disable-discovery")
+        .arg("--nat")
+        .arg("none")
+        // P2P port
+        .arg("--port")
+        .arg(args.builder_p2p_port.to_string())
+        // Builder-specific args
+        .arg("--rollup.chain-block-time")
+        .arg(args.block_time_ms.to_string());
+
+    // Note: flashblocks is always enabled on builder
+
+    cmd.stdout(Stdio::piped()).stderr(Stdio::piped());
+
+    let mut child = cmd.spawn().map_err(|e| {
+        eyre!(
+            "Failed to start base-builder. Is it in your PATH? Error: {e}\n\
+             Try running: cargo build --release -p base-builder"
+        )
+    })?;
+
+    // Spawn thread to forward stdout
+    if let Some(stdout) = child.stdout.take() {
+        thread::spawn(move || {
+            let reader = BufReader::new(stdout);
+            for line in reader.lines().map_while(Result::ok) {
+                info!(target: "builder", "{line}");
+            }
+        });
+    }
+
+    // Spawn thread to forward stderr
+    if let Some(stderr) = child.stderr.take() {
+        thread::spawn(move || {
+            let reader = BufReader::new(stderr);
+            for line in reader.lines().map_while(Result::ok) {
+                warn!(target: "builder", "{line}");
+            }
+        });
+    }
+
+    Ok(child)
+}
+
+/// Launch client with TUI log capture.
+#[cfg(feature = "tui")]
+fn launch_client_tui(
+    args: &DevnetArgs,
+    genesis_path: &PathBuf,
+    jwt_path: &PathBuf,
+    log_state: Arc<Mutex<LogState>>,
+) -> Result<Child> {
+    let mut cmd = Command::new(find_binary("base-reth-node"));
+
+    // Reduce log noise - filter out repetitive forkchoice/payload messages
+    cmd.env("RUST_LOG", "info,reth_engine_util::engine_store=warn,reth::consensus::engine=warn");
+
+    cmd.arg("node")
+        .arg("--chain")
+        .arg(genesis_path)
+        .arg("--datadir")
+        .arg(args.client_datadir())
+        .arg("--http")
+        .arg("--http.addr")
+        .arg("0.0.0.0")
+        .arg("--http.port")
+        .arg(args.http_port.to_string())
+        .arg("--http.api")
+        .arg("eth,net,web3,debug,trace,txpool")
+        .arg("--ws")
+        .arg("--ws.addr")
+        .arg("0.0.0.0")
+        .arg("--ws.port")
+        .arg(args.ws_port.to_string())
+        .arg("--ws.api")
+        .arg("eth,net,web3,debug,trace,txpool")
+        .arg("--authrpc.addr")
+        .arg("127.0.0.1")
+        .arg("--authrpc.port")
+        .arg(args.engine_port.to_string())
+        .arg("--authrpc.jwtsecret")
+        .arg(jwt_path)
+        .arg("--metrics")
+        .arg(format!("127.0.0.1:{}", args.metrics_port))
+        .arg("--disable-discovery")
+        .arg("--nat")
+        .arg("none")
+        .arg("--port")
+        .arg(args.p2p_port.to_string())
+        .arg("--dev");
+
+    if args.flashblocks {
+        cmd.arg("--enable-metering");
+    }
+
+    cmd.stdout(Stdio::piped()).stderr(Stdio::piped());
+
+    let mut child = cmd.spawn().map_err(|e| {
+        eyre!(
+            "Failed to start base-reth-node. Is it in your PATH? Error: {e}\n\
+             Try running: cargo build --release -p base-reth-node"
+        )
+    })?;
+
+    // Capture stdout to TUI
+    if let Some(stdout) = child.stdout.take() {
+        let state = Arc::clone(&log_state);
+        thread::spawn(move || {
+            let reader = BufReader::new(stdout);
+            for line in reader.lines().map_while(Result::ok) {
+                state.lock().unwrap().push_client_log(line);
+            }
+        });
+    }
+
+    // Capture stderr to TUI
+    if let Some(stderr) = child.stderr.take() {
+        let state = Arc::clone(&log_state);
+        thread::spawn(move || {
+            let reader = BufReader::new(stderr);
+            for line in reader.lines().map_while(Result::ok) {
+                state.lock().unwrap().push_client_log(format!("[ERR] {line}"));
+            }
+        });
+    }
+
+    Ok(child)
+}
+
+/// Launch builder with TUI log capture.
+#[cfg(feature = "tui")]
+fn launch_builder_tui(
+    args: &DevnetArgs,
+    genesis_path: &PathBuf,
+    jwt_path: &PathBuf,
+    log_state: Arc<Mutex<LogState>>,
+) -> Result<Child> {
+    let mut cmd = Command::new(find_binary("base-builder"));
+
+    // Reduce log noise - filter out repetitive forkchoice/payload messages
+    cmd.env("RUST_LOG", "info,reth_engine_util::engine_store=warn,reth::consensus::engine=warn");
+
+    cmd.arg("node")
+        .arg("--chain")
+        .arg(genesis_path)
+        .arg("--datadir")
+        .arg(args.builder_datadir())
+        .arg("--http")
+        .arg("--http.addr")
+        .arg("0.0.0.0")
+        .arg("--http.port")
+        .arg(args.builder_http_port.to_string())
+        .arg("--http.api")
+        .arg("eth,net,web3,debug,txpool")
+        .arg("--authrpc.addr")
+        .arg("127.0.0.1")
+        .arg("--authrpc.port")
+        .arg(args.builder_engine_port.to_string())
+        .arg("--authrpc.jwtsecret")
+        .arg(jwt_path)
+        .arg("--metrics")
+        .arg(format!("127.0.0.1:{}", args.builder_metrics_port))
+        .arg("--disable-discovery")
+        .arg("--nat")
+        .arg("none")
+        .arg("--port")
+        .arg(args.builder_p2p_port.to_string())
+        .arg("--rollup.chain-block-time")
+        .arg(args.block_time_ms.to_string());
+
+    // Note: flashblocks is always enabled on builder
+
+    cmd.stdout(Stdio::piped()).stderr(Stdio::piped());
+
+    let mut child = cmd.spawn().map_err(|e| {
+        eyre!(
+            "Failed to start base-builder. Is it in your PATH? Error: {e}\n\
+             Try running: cargo build --release -p base-builder"
+        )
+    })?;
+
+    // Capture stdout to TUI
+    if let Some(stdout) = child.stdout.take() {
+        let state = Arc::clone(&log_state);
+        thread::spawn(move || {
+            let reader = BufReader::new(stdout);
+            for line in reader.lines().map_while(Result::ok) {
+                state.lock().unwrap().push_builder_log(line);
+            }
+        });
+    }
+
+    // Capture stderr to TUI
+    if let Some(stderr) = child.stderr.take() {
+        let state = Arc::clone(&log_state);
+        thread::spawn(move || {
+            let reader = BufReader::new(stderr);
+            for line in reader.lines().map_while(Result::ok) {
+                state.lock().unwrap().push_builder_log(format!("[ERR] {line}"));
+            }
+        });
+    }
+
+    Ok(child)
+}
+
+fn print_connection_info(args: &DevnetArgs) {
+    info!("═══════════════════════════════════════════════════════════════");
+    info!("                    Base Devnet Running                        ");
+    info!("═══════════════════════════════════════════════════════════════");
+    info!("");
+    info!("  Chain ID:       {DEVNET_CHAIN_ID}");
+    info!("  Block Time:     {}ms", args.block_time_ms);
+    info!("");
+
+    if !args.no_client {
+        info!("  Client RPC:");
+        info!("    HTTP:         http://127.0.0.1:{}", args.http_port);
+        info!("    WebSocket:    ws://127.0.0.1:{}", args.ws_port);
+        info!("    Engine API:   http://127.0.0.1:{}", args.engine_port);
+        info!("    Metrics:      http://127.0.0.1:{}/metrics", args.metrics_port);
+        info!("");
+    }
+
+    if !args.no_builder {
+        info!("  Builder RPC:");
+        info!("    HTTP:         http://127.0.0.1:{}", args.builder_http_port);
+        info!("    Engine API:   http://127.0.0.1:{}", args.builder_engine_port);
+        info!("    Metrics:      http://127.0.0.1:{}/metrics", args.builder_metrics_port);
+        info!("");
+    }
+
+    info!("  Test Accounts (1M ETH each):");
+    info!("    Alice:   0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266");
+    info!("    Bob:     0x70997970C51812dc3A010C7d01b50e0d17dc79C8");
+    info!("    Charlie: 0x3C44CdDdB6a900fa2b585dd299e03d12FA4293BC");
+    info!("");
+    info!("═══════════════════════════════════════════════════════════════");
+}

--- a/bin/devnet/src/main.rs
+++ b/bin/devnet/src/main.rs
@@ -9,6 +9,8 @@ mod cli;
 #[cfg(feature = "tui")]
 mod tui;
 
+#[cfg(feature = "tui")]
+use std::sync::Mutex;
 use std::{
     fs,
     io::{BufRead, BufReader},
@@ -22,15 +24,11 @@ use std::{
     time::Duration,
 };
 
-#[cfg(feature = "tui")]
-use std::sync::Mutex;
-
 use base_primitives::{DEVNET_CHAIN_ID, build_test_genesis};
 use clap::Parser;
 use cli::DevnetArgs;
 use eyre::{Result, eyre};
 use tracing::{error, info, warn};
-
 #[cfg(feature = "tui")]
 use tui::{App, LogState, TuiResult, init_terminal, restore_terminal, run_tui};
 

--- a/bin/devnet/src/tui.rs
+++ b/bin/devnet/src/tui.rs
@@ -91,15 +91,17 @@ impl LogState {
     /// Check if processes are still alive and update running status.
     pub(crate) fn update_process_status(&mut self) {
         if let Some(pid) = self.client_pid
-            && !is_process_alive(pid) {
-                self.client_running = false;
-                self.client_pid = None; // Clear so we don't keep checking
-            }
+            && !is_process_alive(pid)
+        {
+            self.client_running = false;
+            self.client_pid = None; // Clear so we don't keep checking
+        }
         if let Some(pid) = self.builder_pid
-            && !is_process_alive(pid) {
-                self.builder_running = false;
-                self.builder_pid = None;
-            }
+            && !is_process_alive(pid)
+        {
+            self.builder_running = false;
+            self.builder_pid = None;
+        }
     }
 }
 
@@ -387,9 +389,10 @@ impl App {
     /// Clear expired status messages.
     fn clear_expired_status(&mut self) {
         if let Some((_, time)) = &self.status_message
-            && time.elapsed() > Duration::from_secs(5) {
-                self.status_message = None;
-            }
+            && time.elapsed() > Duration::from_secs(5)
+        {
+            self.status_message = None;
+        }
     }
 
     /// Auto-scroll to bottom if enabled.
@@ -419,7 +422,9 @@ pub(crate) fn init_terminal() -> io::Result<Terminal<CrosstermBackend<Stdout>>> 
 }
 
 /// Restore the terminal to normal mode.
-pub(crate) fn restore_terminal(terminal: &mut Terminal<CrosstermBackend<Stdout>>) -> io::Result<()> {
+pub(crate) fn restore_terminal(
+    terminal: &mut Terminal<CrosstermBackend<Stdout>>,
+) -> io::Result<()> {
     disable_raw_mode()?;
     execute!(terminal.backend_mut(), LeaveAlternateScreen, DisableMouseCapture)?;
     terminal.show_cursor()?;
@@ -659,50 +664,49 @@ fn styled_log_line(line: &str, has_user_tx: bool) -> Line<'static> {
             && first.chars().next().map(|c| c.is_ascii_digit()).unwrap_or(false)
             && first.contains('T');
 
-        if is_timestamp
-            && let Some(level_str) = parts.next() {
-                let level_upper = level_str.to_uppercase();
+        if is_timestamp && let Some(level_str) = parts.next() {
+            let level_upper = level_str.to_uppercase();
 
-                // Determine level color
-                let level_color = if level_upper.contains("ERR") {
-                    Color::LightRed
-                } else if level_upper.contains("WARN") {
-                    Color::Yellow
-                } else if level_upper.contains("INFO") {
-                    Color::Cyan
-                } else if level_upper.contains("DEBUG") {
-                    Color::Blue
-                } else if level_upper.contains("TRACE") {
-                    Color::Magenta
-                } else {
-                    Color::White
-                };
+            // Determine level color
+            let level_color = if level_upper.contains("ERR") {
+                Color::LightRed
+            } else if level_upper.contains("WARN") {
+                Color::Yellow
+            } else if level_upper.contains("INFO") {
+                Color::Cyan
+            } else if level_upper.contains("DEBUG") {
+                Color::Blue
+            } else if level_upper.contains("TRACE") {
+                Color::Magenta
+            } else {
+                Color::White
+            };
 
-                // Collect remaining parts as message
-                let message: String = parts.collect::<Vec<&str>>().join(" ");
+            // Collect remaining parts as message
+            let message: String = parts.collect::<Vec<&str>>().join(" ");
 
-                // Highlight blocks with user transactions
-                let msg_style = if has_user_tx {
-                    Style::default().fg(Color::LightGreen).add_modifier(Modifier::BOLD)
-                } else {
-                    Style::default().fg(Color::White)
-                };
+            // Highlight blocks with user transactions
+            let msg_style = if has_user_tx {
+                Style::default().fg(Color::LightGreen).add_modifier(Modifier::BOLD)
+            } else {
+                Style::default().fg(Color::White)
+            };
 
-                let mut spans = vec![
-                    Span::styled(format!("{} ", first), Style::default().fg(Color::DarkGray)),
-                    Span::styled(format!("{} ", level_str), Style::default().fg(level_color)),
-                ];
+            let mut spans = vec![
+                Span::styled(format!("{} ", first), Style::default().fg(Color::DarkGray)),
+                Span::styled(format!("{} ", level_str), Style::default().fg(level_color)),
+            ];
 
-                if !message.is_empty() {
-                    if has_user_tx {
-                        // Add a tx indicator
-                        spans.push(Span::styled("◆ ", Style::default().fg(Color::LightGreen)));
-                    }
-                    spans.push(Span::styled(message, msg_style));
+            if !message.is_empty() {
+                if has_user_tx {
+                    // Add a tx indicator
+                    spans.push(Span::styled("◆ ", Style::default().fg(Color::LightGreen)));
                 }
-
-                return Line::from(spans);
+                spans.push(Span::styled(message, msg_style));
             }
+
+            return Line::from(spans);
+        }
     }
 
     // Fallback: plain white
@@ -747,9 +751,10 @@ pub(crate) fn run_tui(
         // Poll for events with a short timeout to allow log updates
         if event::poll(Duration::from_millis(100))?
             && let Event::Key(key) = event::read()?
-                && key.kind == KeyEventKind::Press {
-                    app.handle_key(key.code);
-                }
+            && key.kind == KeyEventKind::Press
+        {
+            app.handle_key(key.code);
+        }
 
         if app.should_quit {
             return Ok(TuiResult::Quit);

--- a/bin/devnet/src/tui.rs
+++ b/bin/devnet/src/tui.rs
@@ -1,0 +1,761 @@
+//! Terminal UI for the devnet using ratatui.
+//!
+//! Provides a Montana-style interface with:
+//! - Split log panels for client and builder
+//! - Status bar with network info
+//! - Real-time log streaming
+
+use std::{
+    collections::VecDeque,
+    fs,
+    io::{self, Stdout},
+    path::PathBuf,
+    sync::{Arc, Mutex},
+    time::{Duration, Instant},
+};
+
+use crossterm::{
+    event::{self, DisableMouseCapture, EnableMouseCapture, Event, KeyCode, KeyEventKind},
+    execute,
+    terminal::{EnterAlternateScreen, LeaveAlternateScreen, disable_raw_mode, enable_raw_mode},
+};
+use ratatui::{
+    Frame, Terminal,
+    backend::CrosstermBackend,
+    layout::{Constraint, Direction, Layout, Rect},
+    style::{Color, Modifier, Style},
+    text::{Line, Span},
+    widgets::{Block, Borders, List, ListItem, ListState, Paragraph},
+};
+
+/// Maximum number of log lines to keep per panel.
+const MAX_LOG_LINES: usize = 1000;
+
+/// Shared state for log lines from processes.
+#[derive(Debug, Default)]
+pub(crate) struct LogState {
+    pub client_logs: VecDeque<String>,
+    pub builder_logs: VecDeque<String>,
+    pub client_running: bool,
+    pub builder_running: bool,
+    pub client_pid: Option<u32>,
+    pub builder_pid: Option<u32>,
+    pub start_time: Option<Instant>,
+    pub latest_block: Option<u64>,
+}
+
+impl LogState {
+    pub(crate) fn new() -> Self {
+        Self {
+            client_logs: VecDeque::with_capacity(MAX_LOG_LINES),
+            builder_logs: VecDeque::with_capacity(MAX_LOG_LINES),
+            client_running: false,
+            builder_running: false,
+            client_pid: None,
+            builder_pid: None,
+            start_time: Some(Instant::now()),
+            latest_block: None,
+        }
+    }
+
+    pub(crate) fn push_client_log(&mut self, line: String) {
+        // Parse block number from log lines like "Produced block 23" or "block_number=23"
+        if let Some(block_num) = parse_block_number(&line) {
+            self.latest_block = Some(block_num);
+        }
+        // Filter out noisy repetitive messages
+        if is_noisy_log(&line) {
+            return;
+        }
+        if self.client_logs.len() >= MAX_LOG_LINES {
+            self.client_logs.pop_front();
+        }
+        self.client_logs.push_back(line);
+    }
+
+    pub(crate) fn push_builder_log(&mut self, line: String) {
+        // Filter out noisy repetitive messages
+        if is_noisy_log(&line) {
+            return;
+        }
+        if self.builder_logs.len() >= MAX_LOG_LINES {
+            self.builder_logs.pop_front();
+        }
+        self.builder_logs.push_back(line);
+    }
+
+    pub(crate) fn uptime(&self) -> Duration {
+        self.start_time.map(|t| t.elapsed()).unwrap_or_default()
+    }
+
+    /// Check if processes are still alive and update running status.
+    pub(crate) fn update_process_status(&mut self) {
+        if let Some(pid) = self.client_pid
+            && !is_process_alive(pid) {
+                self.client_running = false;
+                self.client_pid = None; // Clear so we don't keep checking
+            }
+        if let Some(pid) = self.builder_pid
+            && !is_process_alive(pid) {
+                self.builder_running = false;
+                self.builder_pid = None;
+            }
+    }
+}
+
+/// Check if a log line is noisy/repetitive and should be filtered out.
+fn is_noisy_log(line: &str) -> bool {
+    let dominated_patterns = [
+        "Forkchoice updated",
+        "forkchoice_updated",
+        "New payload job created",
+        "Received block from consensus",
+        "Canonical chain committed",
+    ];
+    for pattern in dominated_patterns {
+        if line.contains(pattern) {
+            return true;
+        }
+    }
+    false
+}
+
+/// Parse block number from log lines.
+/// Looks for patterns like "Block added to canonical chain number=N" or "Produced block N"
+fn parse_block_number(line: &str) -> Option<u64> {
+    // Strip ANSI codes first - logs contain escape sequences like [3m, [0m, etc.
+    let clean = strip_ansi(line);
+
+    // Pattern: "number=N" (reth log format, e.g., "Block added to canonical chain number=11")
+    if let Some(idx) = clean.find("number=") {
+        let rest = &clean[idx + 7..];
+        let num_str: String = rest.chars().take_while(|c| c.is_ascii_digit()).collect();
+        if let Ok(n) = num_str.parse() {
+            return Some(n);
+        }
+    }
+    // Pattern: "Produced block N" (block driver debug output)
+    if let Some(idx) = clean.find("Produced block ") {
+        let rest = &clean[idx + 15..];
+        let num_str: String = rest.chars().take_while(|c| c.is_ascii_digit()).collect();
+        if let Ok(n) = num_str.parse() {
+            return Some(n);
+        }
+    }
+    None
+}
+
+/// Strip ANSI escape sequences from a string.
+fn strip_ansi(s: &str) -> String {
+    let mut result = String::with_capacity(s.len());
+    let mut chars = s.chars().peekable();
+    while let Some(c) = chars.next() {
+        if c == '\x1b' {
+            // Skip escape sequence
+            if chars.peek() == Some(&'[') {
+                chars.next();
+                while let Some(&nc) = chars.peek() {
+                    chars.next();
+                    if nc.is_ascii_alphabetic() {
+                        break;
+                    }
+                }
+            }
+        } else {
+            result.push(c);
+        }
+    }
+    result
+}
+
+/// Check if a process with the given PID is still alive.
+#[cfg(unix)]
+fn is_process_alive(pid: u32) -> bool {
+    // kill(pid, 0) checks if process exists without sending a signal
+    // Returns 0 if process exists, -1 with ESRCH if not
+    unsafe { libc::kill(pid as libc::pid_t, 0) == 0 }
+}
+
+#[cfg(not(unix))]
+fn is_process_alive(_pid: u32) -> bool {
+    // Can't easily check on non-Unix, assume alive
+    true
+}
+
+/// Which panel is currently focused.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum Focus {
+    Client,
+    Builder,
+}
+
+impl Focus {
+    pub(crate) const fn toggle(self) -> Self {
+        match self {
+            Self::Client => Self::Builder,
+            Self::Builder => Self::Client,
+        }
+    }
+}
+
+/// TUI application state.
+pub(crate) struct App {
+    pub log_state: Arc<Mutex<LogState>>,
+    pub focus: Focus,
+    pub client_list_state: ListState,
+    pub builder_list_state: ListState,
+    pub should_quit: bool,
+    pub should_restart: bool,
+    pub chain_id: u64,
+    #[allow(dead_code)] // Reserved for future RPC info display
+    pub http_port: u16,
+    #[allow(dead_code)] // Reserved for future RPC info display
+    pub ws_port: u16,
+    pub auto_scroll: bool,
+    pub status_message: Option<(String, Instant)>,
+}
+
+impl App {
+    pub(crate) fn new(
+        log_state: Arc<Mutex<LogState>>,
+        chain_id: u64,
+        http_port: u16,
+        ws_port: u16,
+    ) -> Self {
+        Self {
+            log_state,
+            focus: Focus::Client,
+            client_list_state: ListState::default(),
+            builder_list_state: ListState::default(),
+            should_quit: false,
+            should_restart: false,
+            chain_id,
+            http_port,
+            ws_port,
+            auto_scroll: true,
+            status_message: None,
+        }
+    }
+
+    /// Handle keyboard input.
+    pub(crate) fn handle_key(&mut self, key: KeyCode) {
+        match key {
+            KeyCode::Char('q') | KeyCode::Esc => self.should_quit = true,
+            KeyCode::Tab => self.focus = self.focus.toggle(),
+            KeyCode::Up | KeyCode::Char('k') => {
+                self.auto_scroll = false;
+                self.scroll_up();
+            }
+            KeyCode::Down | KeyCode::Char('j') => {
+                self.scroll_down();
+            }
+            KeyCode::PageUp => {
+                self.auto_scroll = false;
+                self.page_up();
+            }
+            KeyCode::PageDown => {
+                self.page_down();
+            }
+            KeyCode::Home | KeyCode::Char('g') => {
+                self.auto_scroll = false;
+                self.scroll_to_top();
+            }
+            KeyCode::End | KeyCode::Char('G') => {
+                self.auto_scroll = true;
+                self.scroll_to_bottom();
+            }
+            KeyCode::Char('f') => {
+                self.auto_scroll = !self.auto_scroll;
+            }
+            KeyCode::Char('r') => {
+                self.should_restart = true;
+            }
+            KeyCode::Char('s') => {
+                self.save_logs();
+            }
+            _ => {}
+        }
+    }
+
+    fn scroll_up(&mut self) {
+        let state = match self.focus {
+            Focus::Client => &mut self.client_list_state,
+            Focus::Builder => &mut self.builder_list_state,
+        };
+        let i = state.selected().unwrap_or(0);
+        state.select(Some(i.saturating_sub(1)));
+    }
+
+    fn scroll_down(&mut self) {
+        let log_len = {
+            let state = self.log_state.lock().unwrap();
+            match self.focus {
+                Focus::Client => state.client_logs.len(),
+                Focus::Builder => state.builder_logs.len(),
+            }
+        };
+        let list_state = match self.focus {
+            Focus::Client => &mut self.client_list_state,
+            Focus::Builder => &mut self.builder_list_state,
+        };
+        let i = list_state.selected().unwrap_or(0);
+        if i < log_len.saturating_sub(1) {
+            list_state.select(Some(i + 1));
+        }
+    }
+
+    fn page_up(&mut self) {
+        let state = match self.focus {
+            Focus::Client => &mut self.client_list_state,
+            Focus::Builder => &mut self.builder_list_state,
+        };
+        let i = state.selected().unwrap_or(0);
+        state.select(Some(i.saturating_sub(20)));
+    }
+
+    fn page_down(&mut self) {
+        let log_len = {
+            let state = self.log_state.lock().unwrap();
+            match self.focus {
+                Focus::Client => state.client_logs.len(),
+                Focus::Builder => state.builder_logs.len(),
+            }
+        };
+        let list_state = match self.focus {
+            Focus::Client => &mut self.client_list_state,
+            Focus::Builder => &mut self.builder_list_state,
+        };
+        let i = list_state.selected().unwrap_or(0);
+        let new_i = (i + 20).min(log_len.saturating_sub(1));
+        list_state.select(Some(new_i));
+    }
+
+    fn scroll_to_top(&mut self) {
+        let state = match self.focus {
+            Focus::Client => &mut self.client_list_state,
+            Focus::Builder => &mut self.builder_list_state,
+        };
+        state.select(Some(0));
+    }
+
+    fn scroll_to_bottom(&mut self) {
+        let log_len = {
+            let state = self.log_state.lock().unwrap();
+            match self.focus {
+                Focus::Client => state.client_logs.len(),
+                Focus::Builder => state.builder_logs.len(),
+            }
+        };
+        let list_state = match self.focus {
+            Focus::Client => &mut self.client_list_state,
+            Focus::Builder => &mut self.builder_list_state,
+        };
+        if log_len > 0 {
+            list_state.select(Some(log_len - 1));
+        }
+    }
+
+    /// Save logs to files.
+    fn save_logs(&mut self) {
+        let timestamp = chrono::Local::now().format("%Y%m%d_%H%M%S");
+        let client_path = PathBuf::from(format!("devnet_client_{}.log", timestamp));
+        let builder_path = PathBuf::from(format!("devnet_builder_{}.log", timestamp));
+
+        let state = self.log_state.lock().unwrap();
+
+        // Save client logs
+        let client_content: String = state.client_logs.iter().map(|s| format!("{}\n", s)).collect();
+        let builder_content: String =
+            state.builder_logs.iter().map(|s| format!("{}\n", s)).collect();
+        drop(state);
+
+        let mut messages = Vec::new();
+
+        match fs::write(&client_path, client_content) {
+            Ok(_) => messages.push(format!("client: {}", client_path.display())),
+            Err(e) => messages.push(format!("client err: {}", e)),
+        }
+
+        match fs::write(&builder_path, builder_content) {
+            Ok(_) => messages.push(format!("builder: {}", builder_path.display())),
+            Err(e) => messages.push(format!("builder err: {}", e)),
+        }
+
+        self.status_message = Some((format!("Saved {}", messages.join(", ")), Instant::now()));
+    }
+
+    /// Clear expired status messages.
+    fn clear_expired_status(&mut self) {
+        if let Some((_, time)) = &self.status_message
+            && time.elapsed() > Duration::from_secs(5) {
+                self.status_message = None;
+            }
+    }
+
+    /// Auto-scroll to bottom if enabled.
+    pub(crate) fn maybe_auto_scroll(&mut self) {
+        if self.auto_scroll {
+            let (client_len, builder_len) = {
+                let state = self.log_state.lock().unwrap();
+                (state.client_logs.len(), state.builder_logs.len())
+            };
+            if client_len > 0 {
+                self.client_list_state.select(Some(client_len - 1));
+            }
+            if builder_len > 0 {
+                self.builder_list_state.select(Some(builder_len - 1));
+            }
+        }
+    }
+}
+
+/// Initialize the terminal for TUI mode.
+pub(crate) fn init_terminal() -> io::Result<Terminal<CrosstermBackend<Stdout>>> {
+    enable_raw_mode()?;
+    let mut stdout = io::stdout();
+    execute!(stdout, EnterAlternateScreen, EnableMouseCapture)?;
+    let backend = CrosstermBackend::new(stdout);
+    Terminal::new(backend)
+}
+
+/// Restore the terminal to normal mode.
+pub(crate) fn restore_terminal(terminal: &mut Terminal<CrosstermBackend<Stdout>>) -> io::Result<()> {
+    disable_raw_mode()?;
+    execute!(terminal.backend_mut(), LeaveAlternateScreen, DisableMouseCapture)?;
+    terminal.show_cursor()?;
+    Ok(())
+}
+
+/// Draw the TUI frame.
+pub(crate) fn draw(frame: &mut Frame<'_>, app: &mut App) {
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Length(3), // Header
+            Constraint::Min(10),   // Log panels
+            Constraint::Length(3), // Footer/help
+        ])
+        .split(frame.area());
+
+    draw_header(frame, chunks[0], app);
+    draw_logs(frame, chunks[1], app);
+    draw_footer(frame, chunks[2], app);
+}
+
+fn draw_header(frame: &mut Frame<'_>, area: Rect, app: &App) {
+    let state = app.log_state.lock().unwrap();
+    let uptime = state.uptime();
+    let uptime_str = format!(
+        "{:02}:{:02}:{:02}",
+        uptime.as_secs() / 3600,
+        (uptime.as_secs() % 3600) / 60,
+        uptime.as_secs() % 60
+    );
+
+    // Status icons: ✓ running, ✖ stopped
+    let client_status = if state.client_running { "✓" } else { "✖" };
+    let builder_status = if state.builder_running { "✓" } else { "✖" };
+    let client_color = if state.client_running { Color::Green } else { Color::Red };
+    let builder_color = if state.builder_running { Color::Green } else { Color::Red };
+
+    // Block number
+    let block_str =
+        state.latest_block.map(|n| format!("#{}", n)).unwrap_or_else(|| "#-".to_string());
+    drop(state);
+
+    let auto_scroll_indicator = if app.auto_scroll { "AUTO" } else { "MANUAL" };
+    let scroll_color = if app.auto_scroll { Color::Green } else { Color::Yellow };
+
+    let mut spans = vec![
+        Span::styled(
+            " BASE DEVNET ",
+            Style::default().fg(Color::Cyan).add_modifier(Modifier::BOLD),
+        ),
+        Span::raw(" │ "),
+        Span::styled(client_status, Style::default().fg(client_color)),
+        Span::styled(" Client ", Style::default().fg(Color::DarkGray)),
+        Span::styled(builder_status, Style::default().fg(builder_color)),
+        Span::styled(" Builder ", Style::default().fg(Color::DarkGray)),
+        Span::raw(" │ "),
+        // Stats: Block #, Chain ID, Block Time
+        Span::styled("Block ", Style::default().fg(Color::DarkGray)),
+        Span::styled(block_str, Style::default().fg(Color::White).add_modifier(Modifier::BOLD)),
+        Span::raw("  "),
+        Span::styled("Chain ", Style::default().fg(Color::DarkGray)),
+        Span::styled(format!("{}", app.chain_id), Style::default().fg(Color::Yellow)),
+        Span::raw("  "),
+        Span::styled("2s", Style::default().fg(Color::DarkGray)),
+        Span::raw(" │ "),
+        Span::styled("⏱ ", Style::default().fg(Color::DarkGray)),
+        Span::styled(uptime_str, Style::default().fg(Color::White)),
+        Span::raw(" │ "),
+        Span::styled(auto_scroll_indicator, Style::default().fg(scroll_color)),
+    ];
+
+    // Show status message if present
+    if let Some((msg, _)) = &app.status_message {
+        spans.push(Span::raw(" │ "));
+        spans.push(Span::styled(msg.as_str(), Style::default().fg(Color::Green)));
+    }
+
+    let header = Paragraph::new(Line::from(spans)).block(
+        Block::default().borders(Borders::ALL).border_style(Style::default().fg(Color::DarkGray)),
+    );
+
+    frame.render_widget(header, area);
+}
+
+fn draw_logs(frame: &mut Frame<'_>, area: Rect, app: &mut App) {
+    let chunks = Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints([Constraint::Percentage(50), Constraint::Percentage(50)])
+        .split(area);
+
+    // Calculate max width for log lines (panel width minus borders)
+    let panel_width = chunks[0].width.saturating_sub(2) as usize;
+
+    let state = app.log_state.lock().unwrap();
+
+    // Client logs
+    let client_border_color =
+        if app.focus == Focus::Client { Color::Cyan } else { Color::DarkGray };
+    let client_items: Vec<ListItem<'_>> = state
+        .client_logs
+        .iter()
+        .map(|log| {
+            let has_tx = has_user_transactions(log); // Check BEFORE truncating
+            let truncated = truncate_line(log, panel_width);
+            ListItem::new(styled_log_line(&truncated, has_tx))
+        })
+        .collect();
+    let client_list = List::new(client_items)
+        .block(
+            Block::default()
+                .title(Span::styled(
+                    " Client Logs ",
+                    Style::default().fg(Color::Cyan).add_modifier(Modifier::BOLD),
+                ))
+                .borders(Borders::ALL)
+                .border_style(Style::default().fg(client_border_color)),
+        )
+        .highlight_style(Style::default().bg(Color::DarkGray));
+
+    // Need to drop the lock before rendering
+    drop(state);
+
+    frame.render_stateful_widget(client_list, chunks[0], &mut app.client_list_state);
+
+    // Re-acquire lock for builder logs
+    let state = app.log_state.lock().unwrap();
+
+    // Builder logs
+    let builder_border_color =
+        if app.focus == Focus::Builder { Color::Magenta } else { Color::DarkGray };
+    let builder_items: Vec<ListItem<'_>> = state
+        .builder_logs
+        .iter()
+        .map(|log| {
+            let has_tx = has_user_transactions(log); // Check BEFORE truncating
+            let truncated = truncate_line(log, panel_width);
+            ListItem::new(styled_log_line(&truncated, has_tx))
+        })
+        .collect();
+    let builder_list = List::new(builder_items)
+        .block(
+            Block::default()
+                .title(Span::styled(
+                    " Builder Logs ",
+                    Style::default().fg(Color::Magenta).add_modifier(Modifier::BOLD),
+                ))
+                .borders(Borders::ALL)
+                .border_style(Style::default().fg(builder_border_color)),
+        )
+        .highlight_style(Style::default().bg(Color::DarkGray));
+
+    drop(state);
+
+    frame.render_stateful_widget(builder_list, chunks[1], &mut app.builder_list_state);
+}
+
+/// Strip ANSI escape sequences and truncate to max_width visible characters.
+/// ratatui doesn't interpret ANSI codes, so we strip them and use Style instead.
+fn truncate_line(line: &str, max_width: usize) -> String {
+    if max_width == 0 {
+        return String::new();
+    }
+
+    let mut result = String::with_capacity(max_width);
+    let mut chars = line.chars().peekable();
+
+    while let Some(c) = chars.next() {
+        if c == '\x1b' {
+            // Skip ANSI escape sequence
+            if chars.peek() == Some(&'[') {
+                chars.next(); // Skip '['
+                // Skip until we hit a letter (end of CSI sequence)
+                while let Some(&nc) = chars.peek() {
+                    chars.next();
+                    if nc.is_ascii_alphabetic() {
+                        break;
+                    }
+                }
+            }
+        } else {
+            // Regular visible character
+            result.push(c);
+            if result.len() >= max_width.saturating_sub(3) && chars.peek().is_some() {
+                // Check if there's more content after stripping ANSI
+                let has_more = chars.clone().any(|ch| ch != '\x1b');
+                if has_more {
+                    result.push_str("...");
+                    break;
+                }
+            }
+        }
+    }
+
+    result
+}
+
+fn draw_footer(frame: &mut Frame<'_>, area: Rect, _app: &App) {
+    let help = Paragraph::new(Line::from(vec![
+        Span::styled(" q", Style::default().fg(Color::Yellow).add_modifier(Modifier::BOLD)),
+        Span::styled(" quit ", Style::default().fg(Color::DarkGray)),
+        Span::styled("│", Style::default().fg(Color::DarkGray)),
+        Span::styled(" r", Style::default().fg(Color::Red).add_modifier(Modifier::BOLD)),
+        Span::styled(" restart ", Style::default().fg(Color::DarkGray)),
+        Span::styled("│", Style::default().fg(Color::DarkGray)),
+        Span::styled(" s", Style::default().fg(Color::Green).add_modifier(Modifier::BOLD)),
+        Span::styled(" save logs ", Style::default().fg(Color::DarkGray)),
+        Span::styled("│", Style::default().fg(Color::DarkGray)),
+        Span::styled(" Tab", Style::default().fg(Color::Yellow).add_modifier(Modifier::BOLD)),
+        Span::styled(" switch ", Style::default().fg(Color::DarkGray)),
+        Span::styled("│", Style::default().fg(Color::DarkGray)),
+        Span::styled(" ↑↓/jk", Style::default().fg(Color::Yellow).add_modifier(Modifier::BOLD)),
+        Span::styled(" scroll ", Style::default().fg(Color::DarkGray)),
+        Span::styled("│", Style::default().fg(Color::DarkGray)),
+        Span::styled(" f", Style::default().fg(Color::Yellow).add_modifier(Modifier::BOLD)),
+        Span::styled(" auto-scroll ", Style::default().fg(Color::DarkGray)),
+    ]))
+    .block(
+        Block::default().borders(Borders::ALL).border_style(Style::default().fg(Color::DarkGray)),
+    );
+
+    frame.render_widget(help, area);
+}
+
+/// Parse a log line into styled spans.
+/// Timestamp = dim gray, Level = colored, Message = white.
+/// Blocks with user txs (txs > 1) are highlighted in green.
+fn styled_log_line(line: &str, has_user_tx: bool) -> Line<'static> {
+    // Format: "2026-01-16T02:19:55.123456Z INFO message here"
+    // Use split_whitespace to handle irregular spacing from ANSI stripping
+
+    let mut parts = line.split_whitespace();
+
+    if let Some(first) = parts.next() {
+        // Check if first part looks like ISO timestamp
+        let is_timestamp = first.len() > 10
+            && first.chars().next().map(|c| c.is_ascii_digit()).unwrap_or(false)
+            && first.contains('T');
+
+        if is_timestamp
+            && let Some(level_str) = parts.next() {
+                let level_upper = level_str.to_uppercase();
+
+                // Determine level color
+                let level_color = if level_upper.contains("ERR") {
+                    Color::LightRed
+                } else if level_upper.contains("WARN") {
+                    Color::Yellow
+                } else if level_upper.contains("INFO") {
+                    Color::Cyan
+                } else if level_upper.contains("DEBUG") {
+                    Color::Blue
+                } else if level_upper.contains("TRACE") {
+                    Color::Magenta
+                } else {
+                    Color::White
+                };
+
+                // Collect remaining parts as message
+                let message: String = parts.collect::<Vec<&str>>().join(" ");
+
+                // Highlight blocks with user transactions
+                let msg_style = if has_user_tx {
+                    Style::default().fg(Color::LightGreen).add_modifier(Modifier::BOLD)
+                } else {
+                    Style::default().fg(Color::White)
+                };
+
+                let mut spans = vec![
+                    Span::styled(format!("{} ", first), Style::default().fg(Color::DarkGray)),
+                    Span::styled(format!("{} ", level_str), Style::default().fg(level_color)),
+                ];
+
+                if !message.is_empty() {
+                    if has_user_tx {
+                        // Add a tx indicator
+                        spans.push(Span::styled("◆ ", Style::default().fg(Color::LightGreen)));
+                    }
+                    spans.push(Span::styled(message, msg_style));
+                }
+
+                return Line::from(spans);
+            }
+    }
+
+    // Fallback: plain white
+    Line::from(Span::styled(line.to_string(), Style::default().fg(Color::White)))
+}
+
+/// Check if a log line represents a block with user transactions (txs > 1).
+fn has_user_transactions(line: &str) -> bool {
+    let clean = strip_ansi(line);
+    if let Some(idx) = clean.find("txs=") {
+        let rest = &clean[idx + 4..];
+        let num_str: String = rest.chars().take_while(|c| c.is_ascii_digit()).collect();
+        if let Ok(n) = num_str.parse::<u32>() {
+            return n > 1;
+        }
+    }
+    false
+}
+
+/// Result of the TUI event loop.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum TuiResult {
+    Quit,
+    Restart,
+}
+
+/// Run the TUI event loop.
+pub(crate) fn run_tui(
+    terminal: &mut Terminal<CrosstermBackend<Stdout>>,
+    app: &mut App,
+) -> io::Result<TuiResult> {
+    loop {
+        // Auto-scroll before drawing
+        app.maybe_auto_scroll();
+        // Clear expired status messages
+        app.clear_expired_status();
+        // Check if processes are still alive
+        app.log_state.lock().unwrap().update_process_status();
+
+        terminal.draw(|f| draw(f, app))?;
+
+        // Poll for events with a short timeout to allow log updates
+        if event::poll(Duration::from_millis(100))?
+            && let Event::Key(key) = event::read()?
+                && key.kind == KeyEventKind::Press {
+                    app.handle_key(key.code);
+                }
+
+        if app.should_quit {
+            return Ok(TuiResult::Quit);
+        }
+        if app.should_restart {
+            return Ok(TuiResult::Restart);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
Adds `base-devnet` binary for local development and testing. Launches both base-builder and base-client with a pre-configured genesis, [Montana](https://github.com/refcell/montana)-style interactive TUI, and built-in block driver.

## Getting Started

### Prerequisites
- Rust toolchain
- [Foundry](https://book.getfoundry.sh/getting-started/installation) (for `cast`)

### Run

```bash
# Checkout this PR
gh pr checkout 505

# Build all binaries
cargo build --release -p base-devnet -p base-builder -p base-reth-node

# Run devnet
./target/release/base-devnet
```

### Test

```bash
# Send a test transaction (Alice → Bob)
cast send 0x70997970C51812dc3A010C7d01b50e0d17dc79C8 \
  --value 0.1ether \
  --rpc-url http://localhost:8545 \
  --private-key 0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80
```

### Endpoints
- HTTP RPC: `http://localhost:8545`
- WebSocket: `ws://localhost:8546`

### Test Accounts (1M ETH each)
| Name | Address | Private Key |
|------|---------|-------------|
| Alice | `0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266` | `0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80` |
| Bob | `0x70997970C51812dc3A010C7d01b50e0d17dc79C8` | `0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d` |
| Charlie | `0x3C44CdDdB6a900fa2b585dd299e03d12FA4293BC` | `0x5de4111afa1a4b94908f83103eb1f1706367c2e68ca870fc3fb9a804cdab365a` |

## Features
- [Montana](https://github.com/refcell/montana)-style TUI with split log panels for client/builder
- Keyboard shortcuts: q=quit, r=restart, s=save logs, Tab=switch panel
- Transaction highlighting (blocks with user txs shown in green)
- `--no-driver` flag for plugging in external consensus (op-node/Kona)

## Test Plan
- [x] `cargo fmt`
- [x] `cargo clippy` - 0 warnings
- [x] `cargo test` - passes
- [x] Manual testing: send transactions, verify block inclusion

Closes #382