### PR TITLE
fix(flashblocks): correct doc comment for is_jovian_active method

### DIFF
--- a/crates/builder/op-rbuilder/src/flashblocks/context.rs
+++ b/crates/builder/op-rbuilder/src/flashblocks/context.rs
@@ -259,7 +259,7 @@ impl OpPayloadBuilderCtx {
         self.chain_spec.is_isthmus_active_at_timestamp(self.attributes().timestamp())
     }
 
-    /// Returns true if isthmus is active for the payload.
+    /// Returns true if jovian is active for the payload.
     pub fn is_jovian_active(&self) -> bool {
         self.chain_spec.is_jovian_active_at_timestamp(self.attributes().timestamp())
     }


### PR DESCRIPTION
Fix copy-paste error in documentation comment for `is_jovian_active` method in OpPayloadBuilderCtx. The comment incorrectly stated "Returns true if isthmus  is active" instead of "Returns true if jovian is active".