### PR TITLE
fix: correct type name in BlockPayloadJobGenerator comments

### DIFF
--- a/crates/builder/op-rbuilder/src/flashblocks/generator.rs
+++ b/crates/builder/op-rbuilder/src/flashblocks/generator.rs
@@ -81,10 +81,10 @@ pub(super) struct BlockPayloadJobGenerator<Client, Tasks, Builder> {
     pre_cached: Option<PrecachedState>,
 }
 
-// === impl EmptyBlockPayloadJobGenerator ===
+// === impl BlockPayloadJobGenerator ===
 
 impl<Client, Tasks, Builder> BlockPayloadJobGenerator<Client, Tasks, Builder> {
-    /// Creates a new [EmptyBlockPayloadJobGenerator] with the given config and custom
+    /// Creates a new [BlockPayloadJobGenerator] with the given config and custom
     /// [PayloadBuilder]
     pub(super) fn with_builder(
         client: Client,


### PR DESCRIPTION
Comments referenced `EmptyBlockPayloadJobGenerator` which doesn't exist. 
The actual type is `BlockPayloadJobGenerator`. Looks like the type was renamed during refactoring but the comments were missed.