### PR TITLE
Avoid cloning bundle state in block metering

### DIFF
--- a/crates/client/metering/src/block.rs
+++ b/crates/client/metering/src/block.rs
@@ -115,8 +115,7 @@ where
 
     // Calculate state root and measure time
     let state_root_start = Instant::now();
-    let bundle_state = db.bundle_state.clone();
-    let hashed_state = state_provider.hashed_post_state(&bundle_state);
+    let hashed_state = state_provider.hashed_post_state(&db.bundle_state);
     let _state_root = state_provider
         .state_root(hashed_state)
         .map_err(|e| eyre!("Failed to calculate state root: {}", e))?;


### PR DESCRIPTION
Use the bundle_state reference directly when computing the hashed post state to remove an unnecessary deep clone and reduce memory overhead without changing behavior.