### PR TITLE
build(s): standardize short SHA to 8 chars and make build scripts fail gracefully

### DIFF
--- a/bin/builder/build.rs
+++ b/bin/builder/build.rs
@@ -1,3 +1,4 @@
+#![allow(missing_docs)]
 // Taken from reth [https://github.com/paradigmxyz/reth/blob/main/crates/node/core/build.rs]
 // The MIT License (MIT)
 //
@@ -5,7 +6,7 @@
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
-// in the Software without restriction, including without limitation the rights
+// with and without restriction, including without limitation the rights
 // to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 // copies of the Software, and to permit persons to whom the Software is
 // furnished to do so, subject to the following conditions:
@@ -20,8 +21,6 @@
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
-
-//! Build script for the op-rbuilder binary that generates version information.
 
 use std::{env, error::Error};
 
@@ -52,10 +51,11 @@ fn main() -> Result<(), Box<dyn Error>> {
 
     emitter.emit_and_set()?;
     let sha = env::var("VERGEN_GIT_SHA")?;
-    let sha_short = &sha[0..7];
+    // Use 8 chars for the short SHA consistently (first 8 hex chars)
+    let sha_short = &sha[..8];
 
     // Set short SHA
-    println!("cargo:rustc-env=VERGEN_GIT_SHA_SHORT={}", &sha[..8]);
+    println!("cargo:rustc-env=VERGEN_GIT_SHA_SHORT={sha_short}");
 
     let author_name = env::var("VERGEN_GIT_COMMIT_AUTHOR_NAME")?;
     let author_email = env::var("VERGEN_GIT_COMMIT_AUTHOR_EMAIL")?;
@@ -73,8 +73,11 @@ fn main() -> Result<(), Box<dyn Error>> {
     println!("cargo:rustc-env=OP_RBUILDER_VERSION_SUFFIX={version_suffix}");
 
     // Set the build profile
-    let out_dir = env::var("OUT_DIR").unwrap();
-    let profile = out_dir.rsplit(std::path::MAIN_SEPARATOR).nth(3).unwrap();
+    let out_dir = env::var("OUT_DIR")?;
+    let profile = out_dir
+        .rsplit(std::path::MAIN_SEPARATOR)
+        .nth(3)
+        .ok_or("Failed to determine build profile from OUT_DIR")?;
     println!("cargo:rustc-env=OP_RBUILDER_BUILD_PROFILE={profile}");
 
     // Set formatted version strings

--- a/bin/consensus/build.rs
+++ b/bin/consensus/build.rs
@@ -1,7 +1,6 @@
 //! Derived from [`reth-node-core`][reth-build-script]
 //!
 //! [reth-build-script]: https://github.com/paradigmxyz/reth/blob/805fb1012cd1601c3b4fe9e8ca2d97c96f61355b/crates/node/core/build.rs
-
 #![allow(missing_docs)]
 
 use std::{env, error::Error};
@@ -30,7 +29,7 @@ fn main() -> Result<(), Box<dyn Error>> {
 
     emitter.emit_and_set()?;
     let sha = env::var("VERGEN_GIT_SHA")?;
-    let sha_short = &sha[0..8];
+    let sha_short = &sha[..8];
 
     let is_dirty = env::var("VERGEN_GIT_DIRTY")? == "true";
     // > git describe --always --tags
@@ -44,8 +43,11 @@ fn main() -> Result<(), Box<dyn Error>> {
     println!("cargo:rustc-env=VERGEN_GIT_SHA_SHORT={sha_short}");
 
     // Set the build profile
-    let out_dir = env::var("OUT_DIR").unwrap();
-    let profile = out_dir.rsplit(std::path::MAIN_SEPARATOR).nth(3).unwrap();
+    let out_dir = env::var("OUT_DIR")?;
+    let profile = out_dir
+        .rsplit(std::path::MAIN_SEPARATOR)
+        .nth(3)
+        .ok_or("Failed to determine build profile from OUT_DIR")?;
     println!("cargo:rustc-env=BASE_CONSENSUS_BUILD_PROFILE={profile}");
 
     // Set formatted version strings

--- a/crates/builder/op-rbuilder/build.rs
+++ b/crates/builder/op-rbuilder/build.rs
@@ -6,7 +6,7 @@
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
-// in the Software without restriction, including without limitation the rights
+// with and without restriction, including without limitation the rights
 // to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 // copies of the Software, and to permit persons to whom the Software is
 // furnished to do so, subject to the following conditions:
@@ -51,10 +51,11 @@ fn main() -> Result<(), Box<dyn Error>> {
 
     emitter.emit_and_set()?;
     let sha = env::var("VERGEN_GIT_SHA")?;
-    let sha_short = &sha[0..7];
+    // standardize to 8 chars for the short sha
+    let sha_short = &sha[..8];
 
     // Set short SHA
-    println!("cargo:rustc-env=VERGEN_GIT_SHA_SHORT={}", &sha[..8]);
+    println!("cargo:rustc-env=VERGEN_GIT_SHA_SHORT={sha_short}");
 
     let author_name = env::var("VERGEN_GIT_COMMIT_AUTHOR_NAME")?;
     let author_email = env::var("VERGEN_GIT_COMMIT_AUTHOR_EMAIL")?;
@@ -72,8 +73,11 @@ fn main() -> Result<(), Box<dyn Error>> {
     println!("cargo:rustc-env=OP_RBUILDER_VERSION_SUFFIX={version_suffix}");
 
     // Set the build profile
-    let out_dir = env::var("OUT_DIR").unwrap();
-    let profile = out_dir.rsplit(std::path::MAIN_SEPARATOR).nth(3).unwrap();
+    let out_dir = env::var("OUT_DIR")?;
+    let profile = out_dir
+        .rsplit(std::path::MAIN_SEPARATOR)
+        .nth(3)
+        .ok_or("Failed to determine build profile from OUT_DIR")?;
     println!("cargo:rustc-env=OP_RBUILDER_BUILD_PROFILE={profile}");
 
     // Set formatted version strings


### PR DESCRIPTION
This PR standardizes short-git-SHA handling across build scripts and removes panic-inducing unwraps when reading build-environment values, replacing them with proper error propagation so build scripts return clear errors instead of panicking.

What I changed

- Normalize short SHA to the first 8 characters everywhere and use a single sha_short variable.

- Replace .unwrap() on environment-derived values (e.g. OUT_DIR, rsplit(...).nth(3)) with ? / .ok_or(...) so build scripts return a helpful error instead of panicking.

- No runtime or public API changes — only build-time behavior.

Files modified

- bin/builder/build.rs

- crates/builder/op-rbuilder/build.rs

- bin/consensus/build.rs

Rationale

- Short-SHA length was inconsistent between build scripts (7 vs 8 chars and mismatched slices). Standardizing to 8 chars avoids confusing/incorrect environment values.

- Build scripts previously panicked in non-standard environments (CI, local testing, or incorrect OUT_DIR layout). Returning a descriptive error is safer and easier to diagnose.

Testing

- Build the affected crates locally (or run a cargo build in a CI-like environment that sets vergen variables) and verify the env variables emitted by the build script:

                          VERGEN_GIT_SHA_SHORT contains the first 8 chars of VERGEN_GIT_SHA

                        OP_RBUILDER_* and BASE_CONSENSUS_* env variables still appear, and build scripts surface readable  
                        errors if OUT_DIR or expected env variables are missing.
Notes

- These changes are build-time only and non-breaking for consumers.

- If you prefer 7-char short SHAs instead of 8, we can switch to that consistently; 8 was chosen because it's a common convention.