### PR TITLE
fix(flashblocks): avoid clone on websocket payload

### DIFF
--- a/crates/client/flashblocks/src/subscription.rs
+++ b/crates/client/flashblocks/src/subscription.rs
@@ -73,7 +73,7 @@ where
                                     match msg {
                                         Ok(Message::Binary(bytes)) => match Flashblock::try_decode_message(bytes) {
                                             Ok(payload) => {
-                                                let _ = sender.send(ActorMessage::BestPayload { payload: payload.clone() }).await.map_err(|e| {
+                                                let _ = sender.send(ActorMessage::BestPayload { payload }).await.map_err(|e| {
                                                     error!(message = "Failed to publish message to channel", error = %e);
                                                 });
                                             }


### PR DESCRIPTION
Removed the redundant Flashblock clone before sending it through the channel since the value is only used once and can be moved, which avoids an unnecessary allocation and copy in the hot path.