### PR TITLE
fix(metering): avoid duplicate block tx cloning

### DIFF
--- a/crates/client/metering/src/block.rs
+++ b/crates/client/metering/src/block.rs
@@ -44,8 +44,7 @@ where
 {
     let block_hash = block.header().hash_slow();
     let block_number = block.header().number();
-    let transactions: Vec<_> = block.body().transactions().cloned().collect();
-    let tx_count = transactions.len();
+    let transactions = block.body().transactions();
 
     // Get parent header
     let parent_hash = block.header().parent_hash();
@@ -73,7 +72,6 @@ where
     // Recover signers first (this can be parallelized in production)
     let signer_recovery_start = Instant::now();
     let recovered_transactions: Vec<_> = transactions
-        .iter()
         .map(|tx| {
             let tx_hash = tx.tx_hash();
             let signer = tx
@@ -82,6 +80,7 @@ where
             Ok(alloy_consensus::transaction::Recovered::new_unchecked(tx.clone(), signer))
         })
         .collect::<EyreResult<Vec<_>>>()?;
+    let tx_count = recovered_transactions.len();
     let signer_recovery_time = signer_recovery_start.elapsed().as_micros();
 
     // Execute transactions and measure time


### PR DESCRIPTION
In meter_block, the transaction list was first cloned in its entirety, and then each transaction was cloned again when Recovered was created, resulting in unnecessary duplicate copies.
Preliminary cloning of the transaction list has been removed; iteration proceeds directly through the slice, leaving a single clone for transferring ownership to Recovered.