### PR TITLE
docs: fix multiple typos

### DIFF
--- a/crates/builder/op-rbuilder/src/flashblocks/context.rs
+++ b/crates/builder/op-rbuilder/src/flashblocks/context.rs
@@ -83,7 +83,7 @@ impl FlashblocksExtraCtx {
     }
 }
 
-/// Container type that holds all necessities to build a new payload.
+/// Container type that holds all the necessities to build a new payload.
 #[derive(Debug)]
 pub struct OpPayloadBuilderCtx {
     /// The type that knows how to perform system calls and configure the evm.
@@ -129,7 +129,7 @@ impl OpPayloadBuilderCtx {
         self.extra.target_flashblock_count
     }
 
-    /// Returns the parent block the payload will be build on.
+    /// Returns the parent block the payload will be built on.
     pub fn parent(&self) -> &SealedHeader {
         &self.config.parent_header
     }
@@ -180,7 +180,7 @@ impl OpPayloadBuilderCtx {
 
     /// Returns the blob fields for the header.
     ///
-    /// This will return the culmative DA bytes * scalar after Jovian
+    /// This will return the cumulative DA bytes * scalar after Jovian
     /// after Ecotone, this will always return Some(0) as blobs aren't supported
     /// pre Ecotone, these fields aren't used.
     pub fn blob_fields<Extra: Debug + Default>(

--- a/crates/builder/op-rbuilder/src/flashblocks/generator.rs
+++ b/crates/builder/op-rbuilder/src/flashblocks/generator.rs
@@ -58,7 +58,7 @@ pub(super) trait PayloadBuilder: Send + Sync + Clone {
     ) -> Result<(), PayloadBuilderError>;
 }
 
-/// The generator type that creates new jobs that builds empty blocks.
+/// The generator type that creates new jobs that build empty blocks.
 #[derive(Debug)]
 pub(super) struct BlockPayloadJobGenerator<Client, Tasks, Builder> {
     /// The client that can interact with the chain.
@@ -246,7 +246,7 @@ where
     pub(crate) cancel: CancellationToken,
     pub(crate) deadline: Pin<Box<Sleep>>, // Add deadline
     pub(crate) build_complete: Option<oneshot::Receiver<Result<(), PayloadBuilderError>>>,
-    /// Caches all disk reads for the state the new payloads builds on
+    /// Caches all disk reads for the state the new payloads build on
     ///
     /// This is used to avoid reading the same state over and over again when new attempts are
     /// triggered, because during the building process we'll repeatedly execute the transactions.


### PR DESCRIPTION
mostly grammar and just one typo