### PR TITLE
docs: fix incorrect type reference in add_ons_builder comment

### DIFF
--- a/crates/client/node/src/node.rs
+++ b/crates/client/node/src/node.rs
@@ -86,7 +86,7 @@ impl BaseNode {
             .consensus(OpConsensusBuilder::default())
     }
 
-    /// Returns [`OpAddOnsBuilder`] with configured arguments.
+    /// Returns [`BaseAddOnsBuilder`] with configured arguments.
     pub fn add_ons_builder<NetworkT: RpcTypes>(&self) -> BaseAddOnsBuilder<NetworkT> {
         BaseAddOnsBuilder::default()
             .with_sequencer(self.args.sequencer.clone())


### PR DESCRIPTION
The doc comment for `add_ons_builder` method referenced `OpAddOnsBuilder` but the function actually returns `BaseAddOnsBuilder`. Updated the comment to match the actual return type.