### PR TITLE
Fix/readme badges

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,1 +1,27 @@
+# Git
+.git/
+.github/
+.gitignore
+.gitmodules
+
+# Build artifacts
 target/
+integration_logs/
+
+# IDE
+.idea/
+.vscode/
+.DS_Store
+
+# Documentation
+*.md
+assets/
+
+# CI/Dev tools
+.config/
+Justfile
+lychee.toml
+rustfmt.toml
+
+# Misc
+.dockerignore

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 target/
 .idea/
+.vscode/
 integration_logs/
 .DS_Store

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 # Base Reth Node
 
+![CI](https://github.com/base/node-reth/actions/workflows/ci.yml/badge.svg)
+
 > [!WARNING]
 > This repository is for development purposes. For production deployments, please use the releases referenced in [base/node](https://github.com/base/node/releases).
 

--- a/crates/client/metering/README.md
+++ b/crates/client/metering/README.md
@@ -1,4 +1,7 @@
-# base-reth-metering
+# `base-reth-metering`
+
+<a href="https://github.com/base/node-reth/actions/workflows/ci.yml"><img src="https://github.com/base/node-reth/actions/workflows/ci.yml/badge.svg?label=ci" alt="CI"></a>
+<a href="https://github.com/base/node-reth/blob/main/LICENSE"><img src="https://img.shields.io/badge/License-MIT-d1d1f6.svg?label=license&labelColor=2a2f35" alt="MIT License"></a>
 
 Metering RPC for Base node. Provides RPC methods for measuring transaction and block execution timing.
 

--- a/crates/shared/access-lists/README.md
+++ b/crates/shared/access-lists/README.md
@@ -1,5 +1,8 @@
 # `base-fbal`
 
+<a href="https://github.com/base/node-reth/actions/workflows/ci.yml"><img src="https://github.com/base/node-reth/actions/workflows/ci.yml/badge.svg?label=ci" alt="CI"></a>
+<a href="https://github.com/base/node-reth/blob/main/LICENSE"><img src="https://img.shields.io/badge/License-MIT-d1d1f6.svg?label=license&labelColor=2a2f35" alt="MIT License"></a>
+
 A library to build and process Flashblock-level Access Lists (FBALs).
 
 See the [spec](../../../docs/specs/access-lists.md) for more details.


### PR DESCRIPTION
This PR adds the CI status and MIT license badges to the `base-reth-metering` and `base-fbal` crate README files for consistency with other crates in the repository.

Changes:
- `crates/client/metering/README.md`: Added badges and wrapped title in backticks
- `crates/shared/access-lists/README.md`: Added badges