### PR TITLE
feat(builder): resource metering for transaction time limits

### DIFF
--- a/bin/builder/src/cli.rs
+++ b/bin/builder/src/cli.rs
@@ -2,7 +2,7 @@
 
 use core::{convert::TryFrom, net::SocketAddr, time::Duration};
 
-use base_builder_core::{BuilderConfig, FlashblocksConfig, ResourceMeteringMode, TxDataStore};
+use base_builder_core::{BuilderConfig, ExecutionMeteringMode, FlashblocksConfig, TxDataStore};
 use reth_optimism_node::args::RollupArgs;
 
 /// Parameters for Flashblocks configuration.
@@ -104,9 +104,9 @@ pub struct Args {
     #[arg(long = "builder.block-state-root-time-budget-us")]
     pub block_state_root_time_budget_us: Option<u128>,
 
-    /// Resource metering mode: off, dry-run, or enforce
-    #[arg(long = "builder.resource-metering-mode", value_enum, default_value = "off")]
-    pub resource_metering_mode: ResourceMeteringMode,
+    /// Execution metering mode: off, dry-run, or enforce
+    #[arg(long = "builder.execution-metering-mode", value_enum, default_value = "off")]
+    pub execution_metering_mode: ExecutionMeteringMode,
 
     /// How much extra time to wait for the block building job to complete and not get garbage collected
     #[arg(long = "builder.extra-block-deadline-secs", default_value = "20")]
@@ -139,7 +139,7 @@ impl Default for Args {
             max_state_root_time_per_tx_us: None,
             flashblock_execution_time_budget_us: None,
             block_state_root_time_budget_us: None,
-            resource_metering_mode: ResourceMeteringMode::Off,
+            execution_metering_mode: ExecutionMeteringMode::Off,
             extra_block_deadline_secs: 20,
             enable_resource_metering: false,
             tx_data_store_buffer_size: 10000,
@@ -165,9 +165,9 @@ impl TryFrom<Args> for BuilderConfig {
             max_state_root_time_per_tx_us: args.max_state_root_time_per_tx_us,
             flashblock_execution_time_budget_us: args.flashblock_execution_time_budget_us,
             block_state_root_time_budget_us: args.block_state_root_time_budget_us,
-            resource_metering_mode: args.resource_metering_mode,
+            execution_metering_mode: args.execution_metering_mode,
             tx_data_store: TxDataStore::new(
-                args.enable_resource_metering || args.resource_metering_mode.is_enabled(),
+                args.enable_resource_metering || args.execution_metering_mode.is_enabled(),
                 args.tx_data_store_buffer_size,
             ),
             flashblocks,

--- a/crates/builder/core/src/config.rs
+++ b/crates/builder/core/src/config.rs
@@ -4,7 +4,7 @@ use core::time::Duration;
 
 use reth_optimism_payload_builder::config::{OpDAConfig, OpGasLimitConfig};
 
-use crate::{FlashblocksConfig, TxDataStore};
+use crate::{FlashblocksConfig, ResourceMeteringMode, TxDataStore};
 
 /// Configuration values for the flashblocks builder.
 #[derive(Clone)]
@@ -33,6 +33,21 @@ pub struct BuilderConfig {
     /// Maximum gas a transaction can use before being excluded.
     pub max_gas_per_txn: Option<u64>,
 
+    /// Maximum execution time per transaction in microseconds.
+    pub max_execution_time_per_tx_us: Option<u128>,
+
+    /// Maximum state root calculation time per transaction in microseconds.
+    pub max_state_root_time_per_tx_us: Option<u128>,
+
+    /// Flashblock-level execution time budget in microseconds.
+    pub flashblock_execution_time_budget_us: Option<u128>,
+
+    /// Block-level state root calculation time budget in microseconds.
+    pub block_state_root_time_budget_us: Option<u128>,
+
+    /// Resource metering mode: off, dry-run, or enforce.
+    pub resource_metering_mode: ResourceMeteringMode,
+
     /// Transaction data store for resource metering
     pub tx_data_store: TxDataStore,
 }
@@ -47,6 +62,11 @@ impl core::fmt::Debug for BuilderConfig {
             .field("sampling_ratio", &self.sampling_ratio)
             .field("flashblocks", &self.flashblocks)
             .field("max_gas_per_txn", &self.max_gas_per_txn)
+            .field("max_execution_time_per_tx_us", &self.max_execution_time_per_tx_us)
+            .field("max_state_root_time_per_tx_us", &self.max_state_root_time_per_tx_us)
+            .field("flashblock_execution_time_budget_us", &self.flashblock_execution_time_budget_us)
+            .field("block_state_root_time_budget_us", &self.block_state_root_time_budget_us)
+            .field("resource_metering_mode", &self.resource_metering_mode)
             .field("tx_data_store", &self.tx_data_store)
             .finish()
     }
@@ -62,6 +82,11 @@ impl Default for BuilderConfig {
             flashblocks: FlashblocksConfig::default(),
             sampling_ratio: 100,
             max_gas_per_txn: None,
+            max_execution_time_per_tx_us: None,
+            max_state_root_time_per_tx_us: None,
+            flashblock_execution_time_budget_us: None,
+            block_state_root_time_budget_us: None,
+            resource_metering_mode: ResourceMeteringMode::Off,
             tx_data_store: TxDataStore::default(),
         }
     }

--- a/crates/builder/core/src/config.rs
+++ b/crates/builder/core/src/config.rs
@@ -4,7 +4,7 @@ use core::time::Duration;
 
 use reth_optimism_payload_builder::config::{OpDAConfig, OpGasLimitConfig};
 
-use crate::{FlashblocksConfig, ResourceMeteringMode, TxDataStore};
+use crate::{ExecutionMeteringMode, FlashblocksConfig, TxDataStore};
 
 /// Configuration values for the flashblocks builder.
 #[derive(Clone)]
@@ -45,8 +45,8 @@ pub struct BuilderConfig {
     /// Block-level state root calculation time budget in microseconds.
     pub block_state_root_time_budget_us: Option<u128>,
 
-    /// Resource metering mode: off, dry-run, or enforce.
-    pub resource_metering_mode: ResourceMeteringMode,
+    /// Execution metering mode: off, dry-run, or enforce.
+    pub execution_metering_mode: ExecutionMeteringMode,
 
     /// Transaction data store for resource metering
     pub tx_data_store: TxDataStore,
@@ -66,7 +66,7 @@ impl core::fmt::Debug for BuilderConfig {
             .field("max_state_root_time_per_tx_us", &self.max_state_root_time_per_tx_us)
             .field("flashblock_execution_time_budget_us", &self.flashblock_execution_time_budget_us)
             .field("block_state_root_time_budget_us", &self.block_state_root_time_budget_us)
-            .field("resource_metering_mode", &self.resource_metering_mode)
+            .field("execution_metering_mode", &self.execution_metering_mode)
             .field("tx_data_store", &self.tx_data_store)
             .finish()
     }
@@ -86,7 +86,7 @@ impl Default for BuilderConfig {
             max_state_root_time_per_tx_us: None,
             flashblock_execution_time_budget_us: None,
             block_state_root_time_budget_us: None,
-            resource_metering_mode: ResourceMeteringMode::Off,
+            execution_metering_mode: ExecutionMeteringMode::Off,
             tx_data_store: TxDataStore::default(),
         }
     }

--- a/crates/builder/core/src/execution_metering_mode.rs
+++ b/crates/builder/core/src/execution_metering_mode.rs
@@ -1,12 +1,13 @@
 use clap::ValueEnum;
 
-/// Resource metering mode for transaction time limits.
+/// Mode for execution metering limits (execution time and state root time).
 ///
-/// Controls how the builder handles time-based resource limits
-/// (execution time and state root calculation time).
+/// Controls how the builder handles execution metering limits that depend on
+/// metering service predictions. These limits can be gradually rolled out
+/// via dry-run mode before enforcement.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, ValueEnum)]
-pub enum ResourceMeteringMode {
-    /// Resource metering is disabled. No time limit checks are performed.
+pub enum ExecutionMeteringMode {
+    /// Execution metering limits are disabled. No time limit checks are performed.
     #[default]
     Off,
     /// Dry-run mode: collect metrics about transactions that would exceed time limits,
@@ -16,7 +17,7 @@ pub enum ResourceMeteringMode {
     Enforce,
 }
 
-impl ResourceMeteringMode {
+impl ExecutionMeteringMode {
     /// Returns true if metering data should be collected (dry-run or enforce mode).
     pub const fn is_enabled(&self) -> bool {
         matches!(self, Self::DryRun | Self::Enforce)

--- a/crates/builder/core/src/flashblocks/context.rs
+++ b/crates/builder/core/src/flashblocks/context.rs
@@ -35,11 +35,11 @@ use reth_revm::{State, context::Block};
 use reth_transaction_pool::{BestTransactionsAttributes, PoolTransaction};
 use revm::{DatabaseCommit, context::result::ResultAndState, interpreter::as_u64_saturated};
 use tokio_util::sync::CancellationToken;
-use tracing::{debug, error, info, trace};
+use tracing::{debug, error, info, trace, warn};
 
 use crate::{
-    BuilderMetrics, ExecutionInfo, PayloadTxsBounds, TxData, TxDataStore, TxnExecutionError,
-    TxnOutcome,
+    BuilderMetrics, ExecutionInfo, PayloadTxsBounds, ResourceLimits, ResourceMeteringLimitExceeded,
+    ResourceMeteringMode, TxData, TxDataStore, TxResources, TxnExecutionError, TxnOutcome,
 };
 
 /// Records the priority fee of a rejected transaction with the given reason as a label.
@@ -48,6 +48,20 @@ fn record_rejected_tx_priority_fee(reason: &TxnExecutionError, priority_fee: f64
         TxnExecutionError::TransactionDALimitExceeded => "transaction_da_limit_exceeded",
         TxnExecutionError::BlockDALimitExceeded { .. } => "block_da_limit_exceeded",
         TxnExecutionError::TransactionGasLimitExceeded { .. } => "transaction_gas_limit_exceeded",
+        TxnExecutionError::ResourceMeteringLimitExceeded(inner) => match inner {
+            ResourceMeteringLimitExceeded::TransactionExecutionTime(_, _) => {
+                "tx_execution_time_exceeded"
+            }
+            ResourceMeteringLimitExceeded::FlashblockExecutionTime(_, _, _) => {
+                "flashblock_execution_time_exceeded"
+            }
+            ResourceMeteringLimitExceeded::TransactionStateRootTime(_, _) => {
+                "tx_state_root_time_exceeded"
+            }
+            ResourceMeteringLimitExceeded::BlockStateRootTime(_, _, _) => {
+                "block_state_root_time_exceeded"
+            }
+        },
         _ => "unknown",
     };
     reth_metrics::metrics::histogram!("base_builder_rejected_tx_priority_fee", "reason" => r)
@@ -70,12 +84,20 @@ pub struct FlashblocksExtraCtx {
     pub target_da_for_batch: Option<u64>,
     /// Total DA footprint left for the current flashblock
     pub target_da_footprint_for_batch: Option<u64>,
+    /// Target execution time for the current flashblock in microseconds
+    pub target_execution_time_for_batch_us: Option<u128>,
+    /// Target state root time for the current flashblock in microseconds
+    pub target_state_root_time_for_batch_us: Option<u128>,
     /// Gas limit per flashblock
     pub gas_per_batch: u64,
     /// DA bytes limit per flashblock
     pub da_per_batch: Option<u64>,
     /// DA footprint limit per flashblock
     pub da_footprint_per_batch: Option<u64>,
+    /// Execution time limit per flashblock in microseconds
+    pub execution_time_per_batch_us: Option<u128>,
+    /// State root time limit per flashblock in microseconds
+    pub state_root_time_per_batch_us: Option<u128>,
     /// Whether to disable state root calculation for each flashblock
     pub disable_state_root: bool,
 }
@@ -90,12 +112,16 @@ impl FlashblocksExtraCtx {
         target_gas_for_batch: u64,
         target_da_for_batch: Option<u64>,
         target_da_footprint_for_batch: Option<u64>,
+        target_execution_time_for_batch_us: Option<u128>,
+        target_state_root_time_for_batch_us: Option<u128>,
     ) -> Self {
         Self {
             flashblock_index: self.flashblock_index + 1,
             target_gas_for_batch,
             target_da_for_batch,
             target_da_footprint_for_batch,
+            target_execution_time_for_batch_us,
+            target_state_root_time_for_batch_us,
             ..self
         }
     }
@@ -126,6 +152,16 @@ pub struct OpPayloadBuilderCtx {
     pub extra: FlashblocksExtraCtx,
     /// Max gas that can be used by a transaction.
     pub max_gas_per_txn: Option<u64>,
+    /// Max execution time per transaction in microseconds.
+    pub max_execution_time_per_tx_us: Option<u128>,
+    /// Max state root calculation time per transaction in microseconds.
+    pub max_state_root_time_per_tx_us: Option<u128>,
+    /// Flashblock-level execution time budget in microseconds.
+    pub flashblock_execution_time_budget_us: Option<u128>,
+    /// Block-level state root calculation time budget in microseconds.
+    pub block_state_root_time_budget_us: Option<u128>,
+    /// Resource metering mode: off, dry-run, or enforce.
+    pub resource_metering_mode: ResourceMeteringMode,
     /// Transaction data store for resource metering
     pub tx_data_store: TxDataStore,
 }
@@ -430,6 +466,7 @@ impl OpPayloadBuilderCtx {
     /// Executes the given best transactions and updates the execution info.
     ///
     /// Returns `Ok(Some(())` if the job was cancelled.
+    #[allow(clippy::too_many_arguments)]
     pub(super) fn execute_best_transactions(
         &self,
         info: &mut ExecutionInfo,
@@ -438,6 +475,8 @@ impl OpPayloadBuilderCtx {
         block_gas_limit: u64,
         block_da_limit: Option<u64>,
         block_da_footprint_limit: Option<u64>,
+        flashblock_execution_time_limit_us: Option<u128>,
+        block_state_root_time_limit_us: Option<u128>,
     ) -> Result<Option<()>, PayloadBuilderError> {
         let execute_txs_start_time = Instant::now();
         let mut num_txs_considered = 0;
@@ -453,12 +492,28 @@ impl OpPayloadBuilderCtx {
         fbal_db.set_index(min_tx_index);
         let mut evm = self.evm_config.evm_with_env(&mut fbal_db, self.evm_env.clone());
 
+        // Build resource limits struct for limit checking
+        let limits = ResourceLimits {
+            block_gas_limit,
+            tx_data_limit: tx_da_limit,
+            block_data_limit: block_da_limit,
+            da_footprint_gas_scalar: info.da_footprint_scalar,
+            block_da_footprint_limit,
+            tx_execution_time_limit_us: self.max_execution_time_per_tx_us,
+            flashblock_execution_time_limit_us,
+            tx_state_root_time_limit_us: self.max_state_root_time_per_tx_us,
+            block_state_root_time_limit_us,
+        };
+
         debug!(
             target: "payload_builder",
             message = "Executing best transactions",
             block_da_limit = ?block_da_limit,
             tx_da_limit = ?tx_da_limit,
             block_gas_limit = ?block_gas_limit,
+            flashblock_execution_time_limit_us = ?flashblock_execution_time_limit_us,
+            block_state_root_time_limit_us = ?block_state_root_time_limit_us,
+            resource_metering_mode = ?self.resource_metering_mode,
         );
 
         while let Some(tx) = best_txs.next(()) {
@@ -482,27 +537,65 @@ impl OpPayloadBuilderCtx {
 
             num_txs_considered += 1;
 
-            let TxData { metering: _resource_usage } = self.tx_data_store.get(&tx_hash);
+            let TxData { metering: resource_usage, .. } = self.tx_data_store.get(&tx_hash);
+
+            // Extract predicted execution and state root times from metering data
+            let predicted_execution_time_us =
+                resource_usage.as_ref().map(|m| m.total_execution_time_us);
+            let predicted_state_root_time_us =
+                resource_usage.as_ref().map(|m| m.state_root_time_us);
+
+            // Build tx resources struct
+            let tx_resources = TxResources {
+                da_size: tx_da_size,
+                gas_limit: tx.gas_limit(),
+                execution_time_us: predicted_execution_time_us,
+                state_root_time_us: predicted_state_root_time_us,
+            };
 
             // ensure we still have capacity for this transaction
-            if let Err(err) = info.is_tx_over_limits(
-                tx_da_size,
-                block_gas_limit,
-                tx_da_limit,
-                block_da_limit,
-                tx.gas_limit(),
-                info.da_footprint_scalar,
-                block_da_footprint_limit,
-            ) {
-                // we can't fit this transaction into the block, so we need to mark it as
-                // invalid which also removes all dependent transaction from
-                // the iterator before we can continue
-                let priority_fee = tx.effective_tip_per_gas(base_fee).unwrap_or(0) as f64;
-                record_rejected_tx_priority_fee(&err, priority_fee);
+            if let Err(err) = info.is_tx_over_limits(&tx_resources, &limits) {
+                // Check if this is a resource metering limit that should be handled
+                // according to the metering mode (dry-run vs enforce)
+                if let TxnExecutionError::ResourceMeteringLimitExceeded(ref limit_err) = err {
+                    // Record metrics for the exceeded limit
+                    self.record_resource_limit_exceeded(limit_err);
 
-                log_txn(Err(err));
-                best_txs.mark_invalid(tx.signer(), tx.nonce());
-                continue;
+                    if self.resource_metering_mode.is_dry_run() {
+                        // In dry-run mode, log but don't reject
+                        warn!(
+                            target: "payload_builder",
+                            message = "Resource metering limit would reject transaction (dry-run mode)",
+                            tx_hash = ?tx_hash,
+                            limit = %limit_err,
+                        );
+                        // Don't skip - continue to simulate the transaction
+                    } else {
+                        // Enforce mode: reject the transaction
+                        let priority_fee = tx.effective_tip_per_gas(base_fee).unwrap_or(0) as f64;
+                        record_rejected_tx_priority_fee(&err, priority_fee);
+
+                        log_txn(Err(err));
+                        best_txs.mark_invalid(tx.signer(), tx.nonce());
+                        continue;
+                    }
+                } else {
+                    // Protocol-enforced limits (DA, gas) are always enforced
+                    let priority_fee = tx.effective_tip_per_gas(base_fee).unwrap_or(0) as f64;
+                    record_rejected_tx_priority_fee(&err, priority_fee);
+
+                    log_txn(Err(err));
+                    best_txs.mark_invalid(tx.signer(), tx.nonce());
+                    continue;
+                }
+            }
+
+            // Record execution time prediction accuracy metrics
+            if let Some(predicted_us) = predicted_execution_time_us {
+                self.metrics.tx_predicted_execution_time_us.record(predicted_us as f64);
+            }
+            if let Some(predicted_us) = predicted_state_root_time_us {
+                self.metrics.tx_predicted_state_root_time_us.record(predicted_us as f64);
             }
 
             // A sequencer's block should never contain blob or deposit transactions from the pool.
@@ -542,9 +635,18 @@ impl OpPayloadBuilderCtx {
                 }
             };
 
+            let actual_execution_time_us = tx_simulation_start_time.elapsed().as_micros();
+
             self.metrics.tx_simulation_duration.record(tx_simulation_start_time.elapsed());
             self.metrics.tx_byte_size.record(tx.inner().size() as f64);
+            self.metrics.tx_actual_execution_time_us.record(actual_execution_time_us as f64);
             num_txs_simulated += 1;
+
+            // Record prediction accuracy
+            if let Some(predicted_us) = predicted_execution_time_us {
+                let error = predicted_us as f64 - actual_execution_time_us as f64;
+                self.metrics.execution_time_prediction_error_us.record(error);
+            }
 
             let gas_used = result.gas_used();
             let is_success = result.is_success();
@@ -572,6 +674,19 @@ impl OpPayloadBuilderCtx {
             info.cumulative_gas_used += gas_used;
             // record tx da size
             info.cumulative_da_bytes_used += tx_da_size;
+            // record execution time (use predicted time if available, fall back to actual)
+            info.flashblock_execution_time_us +=
+                predicted_execution_time_us.unwrap_or(actual_execution_time_us);
+            // record state root time (only from predictions)
+            if let Some(state_root_time) = predicted_state_root_time_us {
+                info.cumulative_state_root_time_us += state_root_time;
+
+                // Record state root time / gas ratio for anomaly detection
+                if gas_used > 0 {
+                    let ratio = state_root_time as f64 / gas_used as f64;
+                    self.metrics.state_root_time_per_gas_ratio.record(ratio);
+                }
+            }
 
             // Push transaction changeset and calculate header bloom filter for receipt.
             let ctx = ReceiptBuilderCtx {
@@ -608,6 +723,13 @@ impl OpPayloadBuilderCtx {
             }
         }
 
+        // Record cumulative predicted state root time for the block
+        if info.cumulative_state_root_time_us > 0 {
+            self.metrics
+                .block_predicted_state_root_time_us
+                .record(info.cumulative_state_root_time_us as f64);
+        }
+
         let payload_transaction_simulation_time = execute_txs_start_time.elapsed();
         self.metrics.set_payload_builder_metrics(
             payload_transaction_simulation_time,
@@ -626,5 +748,24 @@ impl OpPayloadBuilderCtx {
             txs_rejected = num_txs_simulated_fail,
         );
         Ok(None)
+    }
+
+    /// Record metrics for a resource metering limit that was exceeded.
+    fn record_resource_limit_exceeded(&self, limit: &ResourceMeteringLimitExceeded) {
+        self.metrics.resource_limit_would_reject_total.increment(1);
+        match limit {
+            ResourceMeteringLimitExceeded::TransactionExecutionTime(_, _) => {
+                self.metrics.tx_execution_time_exceeded_total.increment(1);
+            }
+            ResourceMeteringLimitExceeded::FlashblockExecutionTime(_, _, _) => {
+                self.metrics.flashblock_execution_time_exceeded_total.increment(1);
+            }
+            ResourceMeteringLimitExceeded::TransactionStateRootTime(_, _) => {
+                self.metrics.tx_state_root_time_exceeded_total.increment(1);
+            }
+            ResourceMeteringLimitExceeded::BlockStateRootTime(_, _, _) => {
+                self.metrics.block_state_root_time_exceeded_total.increment(1);
+            }
+        }
     }
 }

--- a/crates/builder/core/src/flashblocks/payload.rs
+++ b/crates/builder/core/src/flashblocks/payload.rs
@@ -209,7 +209,7 @@ where
             max_state_root_time_per_tx_us: self.config.max_state_root_time_per_tx_us,
             flashblock_execution_time_budget_us: self.config.flashblock_execution_time_budget_us,
             block_state_root_time_budget_us: self.config.block_state_root_time_budget_us,
-            resource_metering_mode: self.config.resource_metering_mode,
+            execution_metering_mode: self.config.execution_metering_mode,
             tx_data_store: self.config.tx_data_store.clone(),
         })
     }

--- a/crates/builder/core/src/flashblocks/payload.rs
+++ b/crates/builder/core/src/flashblocks/payload.rs
@@ -205,6 +205,11 @@ where
             metrics: Default::default(),
             extra,
             max_gas_per_txn: self.config.max_gas_per_txn,
+            max_execution_time_per_tx_us: self.config.max_execution_time_per_tx_us,
+            max_state_root_time_per_tx_us: self.config.max_state_root_time_per_tx_us,
+            flashblock_execution_time_budget_us: self.config.flashblock_execution_time_budget_us,
+            block_state_root_time_budget_us: self.config.block_state_root_time_budget_us,
+            resource_metering_mode: self.config.resource_metering_mode,
             tx_data_store: self.config.tx_data_store.clone(),
         })
     }
@@ -326,17 +331,25 @@ where
             ctx.da_config.max_da_block_size().map(|da_limit| da_limit / flashblocks_per_block);
         let da_footprint_per_batch =
             info.da_footprint_scalar.map(|_| ctx.block_gas_limit() / flashblocks_per_block);
+        let execution_time_per_batch_us = ctx.flashblock_execution_time_budget_us;
+        let state_root_time_per_batch_us = ctx
+            .block_state_root_time_budget_us
+            .map(|budget| budget / flashblocks_per_block as u128);
 
         let extra = FlashblocksExtraCtx {
             flashblock_index: 1,
             target_flashblock_count: flashblocks_per_block,
             target_gas_for_batch: gas_per_batch,
             target_da_for_batch: da_per_batch,
+            target_da_footprint_for_batch: da_footprint_per_batch,
+            target_execution_time_for_batch_us: execution_time_per_batch_us,
+            target_state_root_time_for_batch_us: state_root_time_per_batch_us,
             gas_per_batch,
             da_per_batch,
             da_footprint_per_batch,
+            execution_time_per_batch_us,
+            state_root_time_per_batch_us,
             disable_state_root,
-            target_da_footprint_for_batch: da_footprint_per_batch,
         };
 
         let mut fb_cancel = block_cancel.child_token();
@@ -493,6 +506,9 @@ where
         let target_gas_for_batch = ctx.extra.target_gas_for_batch;
         let mut target_da_for_batch = ctx.extra.target_da_for_batch;
         let mut target_da_footprint_for_batch = ctx.extra.target_da_footprint_for_batch;
+        let mut target_state_root_time_for_batch_us = ctx.extra.target_state_root_time_for_batch_us;
+        let flashblock_execution_time_limit_us = ctx.extra.execution_time_per_batch_us;
+        let block_state_root_time_limit_us = target_state_root_time_for_batch_us;
 
         info!(
             target: "payload_builder",
@@ -504,9 +520,13 @@ where
             da_used = info.cumulative_da_bytes_used,
             block_gas_used = ctx.block_gas_limit(),
             target_da_footprint = target_da_footprint_for_batch,
+            flashblock_execution_time_limit_us = ?flashblock_execution_time_limit_us,
+            target_state_root_time_for_batch_us = ?target_state_root_time_for_batch_us,
             "Building flashblock",
         );
         let flashblock_build_start_time = Instant::now();
+
+        info.reset_flashblock_execution_time();
 
         let best_txs_start_time = Instant::now();
         best_txs.refresh_iterator(BestPayloadTransactions::new(
@@ -524,6 +544,8 @@ where
             target_gas_for_batch.min(ctx.block_gas_limit()),
             target_da_for_batch,
             target_da_footprint_for_batch,
+            flashblock_execution_time_limit_us,
+            block_state_root_time_limit_us,
         )
         .wrap_err("failed to execute best transactions")?;
         // Extract last transactions
@@ -635,10 +657,19 @@ where
                     *footprint += da_footprint_limit;
                 }
 
+                if let (Some(time), Some(time_per_batch)) = (
+                    target_state_root_time_for_batch_us.as_mut(),
+                    ctx.extra.state_root_time_per_batch_us,
+                ) {
+                    *time += time_per_batch;
+                }
+
                 let next_extra = ctx.extra.clone().next(
                     target_gas_for_batch,
                     target_da_for_batch,
                     target_da_footprint_for_batch,
+                    ctx.extra.execution_time_per_batch_us,
+                    target_state_root_time_for_batch_us,
                 );
 
                 info!(
@@ -671,6 +702,13 @@ where
             .record(flashblocks_per_block.saturating_sub(ctx.flashblock_index()) as f64);
         ctx.metrics.payload_num_tx.record(info.executed_transactions.len() as f64);
         ctx.metrics.payload_num_tx_gauge.set(info.executed_transactions.len() as f64);
+
+        // Record cumulative predicted state root time for the block (observation metric)
+        if info.cumulative_state_root_time_us > 0 {
+            ctx.metrics
+                .block_predicted_state_root_time_us
+                .record(info.cumulative_state_root_time_us as f64);
+        }
 
         debug!(
             target: "payload_builder",

--- a/crates/builder/core/src/lib.rs
+++ b/crates/builder/core/src/lib.rs
@@ -15,12 +15,12 @@ pub use metrics::BuilderMetrics;
 
 mod execution;
 pub use execution::{
-    ExecutionInfo, ResourceLimits, ResourceMeteringLimitExceeded, TxResources, TxnExecutionError,
+    ExecutionInfo, ExecutionMeteringLimitExceeded, ResourceLimits, TxResources, TxnExecutionError,
     TxnOutcome,
 };
 
-mod resource_metering_mode;
-pub use resource_metering_mode::ResourceMeteringMode;
+mod execution_metering_mode;
+pub use execution_metering_mode::ExecutionMeteringMode;
 
 mod traits;
 pub use traits::{ClientBounds, NodeBounds, NodeComponents, PayloadTxsBounds, PoolBounds};

--- a/crates/builder/core/src/lib.rs
+++ b/crates/builder/core/src/lib.rs
@@ -14,7 +14,13 @@ mod metrics;
 pub use metrics::BuilderMetrics;
 
 mod execution;
-pub use execution::{ExecutionInfo, TxnExecutionError, TxnOutcome};
+pub use execution::{
+    ExecutionInfo, ResourceLimits, ResourceMeteringLimitExceeded, TxResources, TxnExecutionError,
+    TxnOutcome,
+};
+
+mod resource_metering_mode;
+pub use resource_metering_mode::ResourceMeteringMode;
 
 mod traits;
 pub use traits::{ClientBounds, NodeBounds, NodeComponents, PayloadTxsBounds, PoolBounds};

--- a/crates/builder/core/src/metrics.rs
+++ b/crates/builder/core/src/metrics.rs
@@ -100,6 +100,36 @@ pub struct BuilderMetrics {
     pub metering_unknown_transaction: Counter,
     /// Count of the number of times we were unable to resolve metering information due to locking
     pub metering_locked_transaction: Counter,
+
+    // === Resource Metering Observation Metrics ===
+    /// Transactions that would be rejected by time-based resource limits
+    pub resource_limit_would_reject_total: Counter,
+    /// Transactions that exceeded per-tx execution time limit
+    pub tx_execution_time_exceeded_total: Counter,
+    /// Transactions that exceeded flashblock execution time budget
+    pub flashblock_execution_time_exceeded_total: Counter,
+    /// Transactions that exceeded per-tx state root time limit
+    pub tx_state_root_time_exceeded_total: Counter,
+    /// Transactions that exceeded block state root time budget
+    pub block_state_root_time_exceeded_total: Counter,
+
+    // === Execution Time Prediction Accuracy ===
+    /// Histogram of (predicted - actual) execution time per transaction in microseconds.
+    pub execution_time_prediction_error_us: Histogram,
+    /// Distribution of predicted execution times from metering service (microseconds)
+    pub tx_predicted_execution_time_us: Histogram,
+    /// Distribution of actual execution times (microseconds)
+    pub tx_actual_execution_time_us: Histogram,
+
+    // === State Root Time Prediction Distribution ===
+    /// Distribution of predicted state root times from metering service (microseconds)
+    pub tx_predicted_state_root_time_us: Histogram,
+    /// Cumulative predicted state root time per block (microseconds)
+    pub block_predicted_state_root_time_us: Histogram,
+
+    // === State Root Time / Gas Ratio (Anomaly Detection) ===
+    /// Ratio of state_root_time_us / gas_used for each transaction.
+    pub state_root_time_per_gas_ratio: Histogram,
 }
 
 impl BuilderMetrics {

--- a/crates/builder/core/src/metrics.rs
+++ b/crates/builder/core/src/metrics.rs
@@ -101,8 +101,20 @@ pub struct BuilderMetrics {
     /// Count of the number of times we were unable to resolve metering information due to locking
     pub metering_locked_transaction: Counter,
 
-    // === Resource Metering Observation Metrics ===
-    /// Transactions that would be rejected by time-based resource limits
+    // === DA Size Limit Metrics (always enforced, operator-configured) ===
+    /// Transactions rejected by per-tx DA size limit
+    pub tx_da_size_exceeded_total: Counter,
+    /// Transactions rejected by block DA size limit
+    pub block_da_size_exceeded_total: Counter,
+
+    // === Protocol-Enforced Limit Metrics ===
+    /// Transactions rejected by DA footprint limit (post-Jovian, protocol-enforced)
+    pub da_footprint_exceeded_total: Counter,
+    /// Transactions rejected by gas limit (protocol-enforced)
+    pub gas_limit_exceeded_total: Counter,
+
+    // === Execution Metering Limit Metrics (metering-service-dependent) ===
+    /// Transactions that would be rejected by execution metering limits
     pub resource_limit_would_reject_total: Counter,
     /// Transactions that exceeded per-tx execution time limit
     pub tx_execution_time_exceeded_total: Counter,
@@ -128,7 +140,7 @@ pub struct BuilderMetrics {
     pub block_predicted_state_root_time_us: Histogram,
 
     // === State Root Time / Gas Ratio (Anomaly Detection) ===
-    /// Ratio of state_root_time_us / gas_used for each transaction.
+    /// Ratio of `state_root_time_us` / `gas_used` for each transaction.
     pub state_root_time_per_gas_ratio: Histogram,
 }
 

--- a/crates/builder/core/src/resource_metering_mode.rs
+++ b/crates/builder/core/src/resource_metering_mode.rs
@@ -1,0 +1,29 @@
+use clap::ValueEnum;
+
+/// Resource metering mode for transaction time limits.
+///
+/// Controls how the builder handles time-based resource limits
+/// (execution time and state root calculation time).
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, ValueEnum)]
+pub enum ResourceMeteringMode {
+    /// Resource metering is disabled. No time limit checks are performed.
+    #[default]
+    Off,
+    /// Dry-run mode: collect metrics about transactions that would exceed time limits,
+    /// but don't actually reject them. Useful for gathering data before enforcement.
+    DryRun,
+    /// Enforce mode: reject transactions that exceed time limits.
+    Enforce,
+}
+
+impl ResourceMeteringMode {
+    /// Returns true if metering data should be collected (dry-run or enforce mode).
+    pub const fn is_enabled(&self) -> bool {
+        matches!(self, Self::DryRun | Self::Enforce)
+    }
+
+    /// Returns true if limits should only be observed in dry-run mode, not enforced.
+    pub const fn is_dry_run(&self) -> bool {
+        matches!(self, Self::DryRun)
+    }
+}


### PR DESCRIPTION
## Summary

- Add execution time and state root time metering for transactions
- Introduce `ResourceMeteringMode` enum with three modes: `off`, `dry-run`, `enforce`
- Integrate with metering data from `base_meterBundle` RPC via `TxDataStore`
- Add metrics to monitor metering accuracy before enforcement

## Changes

### New CLI Flag
```bash
--builder.resource-metering-mode=off|dry-run|enforce
```

- **off** (default): Resource metering disabled
- **dry-run**: Log and collect metrics without enforcing limits (for validation)
- **enforce**: Reject transactions exceeding time limits

### Resource Limits
- Per-transaction execution time limit
- Per-flashblock execution time budget (use it or lose it)
- Per-transaction state root time limit
- Per-block state root time budget (cumulative)

### Metrics
- Rejection counters by limit type
- `metering_known_transaction` / `metering_unknown_transaction` counters
- Time exceeded counters: `tx_execution_time_exceeded`, `flashblock_execution_time_exceeded`, `tx_state_root_time_exceeded`, `block_state_root_time_exceeded`

## Test Plan
- [x] Unit tests for resource limit checking logic
- [x] Integration tested with local devnet in dry-run and enforce modes