### PR TITLE
feat(shared): In Process Engine Extension

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1931,6 +1931,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "base-engine-ext"
+version = "0.0.0"
+dependencies = [
+ "alloy-eips",
+ "alloy-primitives",
+ "alloy-rpc-types-engine",
+ "op-alloy-rpc-types-engine",
+ "reth-engine-primitives",
+ "reth-optimism-node",
+ "reth-payload-builder",
+ "reth-payload-primitives",
+ "thiserror 2.0.17",
+ "tracing",
+]
+
+[[package]]
 name = "base-flashblocks"
 version = "0.0.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,6 +60,7 @@ base-primitives = { path = "crates/shared/primitives" }
 base-access-lists = { path = "crates/shared/access-lists" }
 base-reth-rpc-types = { path = "crates/shared/reth-rpc-types" }
 base-jwt = { path = "crates/shared/jwt" }
+base-engine-ext = { path = "crates/shared/engine-ext" }
 base-flashblocks-node = { path = "crates/client/flashblocks-node" }
 
 # Client

--- a/crates/shared/engine-ext/Cargo.toml
+++ b/crates/shared/engine-ext/Cargo.toml
@@ -1,0 +1,31 @@
+[package]
+name = "base-engine-ext"
+description = "In-process engine client for direct reth communication"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+
+[lints]
+workspace = true
+
+[dependencies]
+# reth
+reth-engine-primitives.workspace = true
+reth-optimism-node.workspace = true
+reth-payload-builder.workspace = true
+reth-payload-primitives.workspace = true
+
+# alloy
+alloy-eips.workspace = true
+alloy-primitives.workspace = true
+alloy-rpc-types-engine.workspace = true
+
+# op-alloy
+op-alloy-rpc-types-engine.workspace = true
+
+# misc
+thiserror.workspace = true
+tracing.workspace = true

--- a/crates/shared/engine-ext/README.md
+++ b/crates/shared/engine-ext/README.md
@@ -1,0 +1,19 @@
+# base-engine-ext
+
+In-process engine client for direct reth communication.
+
+## Overview
+
+This crate provides `InProcessEngineClient`, which bypasses the RPC layer
+to communicate directly with reth's consensus engine via channels.
+
+## Architecture
+
+```text
+┌─────────────────┐     ┌──────────────────────────┐     ┌─────────────────────────┐
+│  Consensus      │     │ InProcessEngineClient    │     │  reth Engine            │
+│  (kona-node)    │────▶│ (channel-based)          │────▶│  (EngineApiTreeHandler) │
+└─────────────────┘     └──────────────────────────┘     └─────────────────────────┘
+```
+
+This enables latency reduction from ~1-5ms (HTTP) to ~1μs (channel).

--- a/crates/shared/engine-ext/README.md
+++ b/crates/shared/engine-ext/README.md
@@ -17,3 +17,73 @@ to communicate directly with reth's consensus engine via channels.
 ```
 
 This enables latency reduction from ~1-5ms (HTTP) to ~1μs (channel).
+
+## Usage
+
+The `InProcessEngineClient` requires a `ConsensusEngineHandle` and `PayloadStore`,
+which can be extracted from a fully-launched reth node.
+
+### Extracting from FullNode
+
+When using `NodeBuilder::with_add_ons`, you can access the engine handle from
+the `AddOnsContext`:
+
+```rust,ignore
+use base_engine_ext::{InProcessEngineClient, PayloadStore};
+
+// In a node add-ons hook or started hook:
+let engine_handle = full_node.add_ons_handle.beacon_engine_handle.clone();
+let payload_store = PayloadStore::new(full_node.payload_builder_handle.clone());
+
+let client = InProcessEngineClient::new(engine_handle, payload_store);
+```
+
+### Using with node_started_hook
+
+For unified binaries, use the `add_node_started_hook` to extract components
+after the node is fully launched:
+
+```rust,ignore
+use base_engine_ext::{InProcessEngineClient, PayloadStore};
+use tokio::sync::oneshot;
+
+let (tx, rx) = oneshot::channel();
+
+let builder = node_builder.add_node_started_hook(move |full_node| {
+    let engine_handle = full_node.add_ons_handle.beacon_engine_handle.clone();
+    let payload_store = PayloadStore::new(full_node.payload_builder_handle.clone());
+    let client = InProcessEngineClient::new(engine_handle, payload_store);
+    let _ = tx.send(client);
+});
+
+// Later, receive the client:
+let client = rx.await?;
+```
+
+### Engine API Methods
+
+Once constructed, the client provides direct access to Engine API methods:
+
+```rust,ignore
+// Send a new payload (no RPC serialization overhead)
+let status = client.new_payload_v3(payload, versioned_hashes, parent_root).await?;
+
+// Update fork choice state
+let response = client.fork_choice_updated_v3(state, Some(attributes)).await?;
+
+// Retrieve a built payload
+let envelope = client.get_payload_v3(payload_id).await?;
+```
+
+## Supported Methods
+
+| Method | Description |
+|--------|-------------|
+| `new_payload_v2` | Engine API v2 new payload |
+| `new_payload_v3` | Engine API v3 new payload (Cancun) |
+| `new_payload_v4` | Engine API v4 new payload (Isthmus) |
+| `fork_choice_updated_v2` | Engine API v2 fork choice update |
+| `fork_choice_updated_v3` | Engine API v3 fork choice update |
+| `get_payload_v2` | Retrieve payload by ID (v2 envelope) |
+| `get_payload_v3` | Retrieve payload by ID (v3 envelope) |
+| `get_payload_v4` | Retrieve payload by ID (v4 envelope) |

--- a/crates/shared/engine-ext/src/client.rs
+++ b/crates/shared/engine-ext/src/client.rs
@@ -1,0 +1,73 @@
+//! In-process engine client implementation.
+
+use reth_engine_primitives::ConsensusEngineHandle;
+use reth_optimism_node::OpEngineTypes;
+use reth_payload_builder::PayloadStore;
+
+/// In-process engine client that bypasses RPC for direct channel communication.
+///
+/// This client uses reth's internal [`ConsensusEngineHandle`] and [`PayloadStore`]
+/// to communicate with the engine, avoiding JSON-RPC serialization overhead.
+///
+/// # Architecture
+///
+/// ```text
+/// ┌─────────────────────────────────────────────────────────────────────────┐
+/// │                           RPC Layer (bypassed)                          │
+/// └─────────────────────────────────────────────────────────────────────────┘
+///                                      │
+///                                      │ (skipped)
+///                                      ▼
+/// ┌─────────────────────────────────────────────────────────────────────────┐
+/// │                   InProcessEngineClient                                 │
+/// │    - new_payload(), fork_choice_updated() methods                       │
+/// │    - get_payload() via PayloadStore                                     │
+/// └─────────────────────────────────────────────────────────────────────────┘
+///                                      │
+///                                      │ unbounded channel
+///                                      ▼
+/// ┌─────────────────────────────────────────────────────────────────────────┐
+/// │                    EngineApiTreeHandler                                 │
+/// │    - Runs in its own std::thread                                        │
+/// │    - Processes EngineApiRequest variants                                │
+/// └─────────────────────────────────────────────────────────────────────────┘
+/// ```
+#[derive(Debug)]
+pub struct InProcessEngineClient {
+    /// Handle for standard newPayload/FCU calls.
+    pub(crate) consensus_handle: ConsensusEngineHandle<OpEngineTypes>,
+    /// Store for retrieving built payloads.
+    pub(crate) payload_store: PayloadStore<OpEngineTypes>,
+}
+
+impl InProcessEngineClient {
+    /// Creates a new in-process engine client.
+    ///
+    /// # Arguments
+    ///
+    /// * `consensus_handle` - Handle to reth's consensus engine
+    ///   (from `AddOnsContext::beacon_engine_handle`)
+    /// * `payload_store` - Store for built payloads
+    ///   (from `PayloadStore::new(ctx.node.payload_builder_handle())`)
+    pub const fn new(
+        consensus_handle: ConsensusEngineHandle<OpEngineTypes>,
+        payload_store: PayloadStore<OpEngineTypes>,
+    ) -> Self {
+        Self { consensus_handle, payload_store }
+    }
+
+    /// Returns a reference to the consensus engine handle.
+    pub const fn consensus_handle(&self) -> &ConsensusEngineHandle<OpEngineTypes> {
+        &self.consensus_handle
+    }
+
+    /// Returns a reference to the payload store.
+    pub const fn payload_store(&self) -> &PayloadStore<OpEngineTypes> {
+        &self.payload_store
+    }
+
+    /// Consumes the client and returns the inner components.
+    pub fn into_parts(self) -> (ConsensusEngineHandle<OpEngineTypes>, PayloadStore<OpEngineTypes>) {
+        (self.consensus_handle, self.payload_store)
+    }
+}

--- a/crates/shared/engine-ext/src/error.rs
+++ b/crates/shared/engine-ext/src/error.rs
@@ -1,0 +1,19 @@
+//! Error types for in-process engine operations.
+
+use thiserror::Error;
+
+/// Errors that can occur when interacting with the engine.
+#[derive(Debug, Error)]
+pub enum EngineError {
+    /// Payload not found in the store.
+    #[error("payload not found: {0}")]
+    PayloadNotFound(String),
+
+    /// Failed to resolve payload from the store.
+    #[error("payload resolution failed: {0}")]
+    PayloadResolution(String),
+
+    /// Engine communication failed.
+    #[error("engine error: {0}")]
+    Engine(String),
+}

--- a/crates/shared/engine-ext/src/forkchoice.rs
+++ b/crates/shared/engine-ext/src/forkchoice.rs
@@ -1,0 +1,36 @@
+//! Fork choice update methods.
+
+use alloy_rpc_types_engine::{ForkchoiceState, ForkchoiceUpdated};
+use op_alloy_rpc_types_engine::OpPayloadAttributes;
+use reth_payload_primitives::EngineApiMessageVersion;
+use tracing::debug;
+
+use crate::{EngineError, InProcessEngineClient};
+
+impl InProcessEngineClient {
+    /// Updates the fork choice state (Engine API v2).
+    pub async fn fork_choice_updated_v2(
+        &self,
+        state: ForkchoiceState,
+        payload_attributes: Option<OpPayloadAttributes>,
+    ) -> Result<ForkchoiceUpdated, EngineError> {
+        debug!(head = ?state.head_block_hash, "Sending fork_choice_updated_v2 via channel");
+        self.consensus_handle
+            .fork_choice_updated(state, payload_attributes, EngineApiMessageVersion::V2)
+            .await
+            .map_err(|e| EngineError::Engine(e.to_string()))
+    }
+
+    /// Updates the fork choice state (Engine API v3).
+    pub async fn fork_choice_updated_v3(
+        &self,
+        state: ForkchoiceState,
+        payload_attributes: Option<OpPayloadAttributes>,
+    ) -> Result<ForkchoiceUpdated, EngineError> {
+        debug!(head = ?state.head_block_hash, "Sending fork_choice_updated_v3 via channel");
+        self.consensus_handle
+            .fork_choice_updated(state, payload_attributes, EngineApiMessageVersion::V3)
+            .await
+            .map_err(|e| EngineError::Engine(e.to_string()))
+    }
+}

--- a/crates/shared/engine-ext/src/lib.rs
+++ b/crates/shared/engine-ext/src/lib.rs
@@ -1,0 +1,18 @@
+#![doc = include_str!("../README.md")]
+#![doc(issue_tracker_base_url = "https://github.com/base/base/issues/")]
+#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
+#![cfg_attr(not(test), warn(unused_crate_dependencies))]
+
+mod client;
+pub use client::InProcessEngineClient;
+
+mod error;
+pub use error::EngineError;
+
+mod forkchoice;
+mod payload;
+
+// Re-export types needed to construct the client
+pub use reth_engine_primitives::ConsensusEngineHandle;
+pub use reth_optimism_node::OpEngineTypes;
+pub use reth_payload_builder::PayloadStore;

--- a/crates/shared/engine-ext/src/payload.rs
+++ b/crates/shared/engine-ext/src/payload.rs
@@ -1,0 +1,115 @@
+//! Payload-related engine methods.
+
+use alloy_eips::eip7685::Requests;
+use alloy_primitives::B256;
+use alloy_rpc_types_engine::{
+    ExecutionPayloadEnvelopeV2, ExecutionPayloadInputV2, ExecutionPayloadV3, PayloadId,
+    PayloadStatus,
+};
+use op_alloy_rpc_types_engine::{
+    OpExecutionData, OpExecutionPayloadEnvelopeV3, OpExecutionPayloadEnvelopeV4,
+    OpExecutionPayloadV4,
+};
+use tracing::debug;
+
+use crate::{EngineError, InProcessEngineClient};
+
+impl InProcessEngineClient {
+    /// Sends a new payload to the execution layer (Engine API v2).
+    pub async fn new_payload_v2(
+        &self,
+        payload: ExecutionPayloadInputV2,
+    ) -> Result<PayloadStatus, EngineError> {
+        debug!("Sending new_payload_v2 via channel");
+        let execution_data = OpExecutionData::v2(payload);
+        self.consensus_handle
+            .new_payload(execution_data)
+            .await
+            .map_err(|e| EngineError::Engine(e.to_string()))
+    }
+
+    /// Sends a new payload to the execution layer (Engine API v3).
+    pub async fn new_payload_v3(
+        &self,
+        payload: ExecutionPayloadV3,
+        versioned_hashes: Vec<B256>,
+        parent_beacon_block_root: B256,
+    ) -> Result<PayloadStatus, EngineError> {
+        debug!(
+            block_hash = ?payload.payload_inner.payload_inner.block_hash,
+            "Sending new_payload_v3 via channel"
+        );
+        let execution_data =
+            OpExecutionData::v3(payload, versioned_hashes, parent_beacon_block_root);
+        self.consensus_handle
+            .new_payload(execution_data)
+            .await
+            .map_err(|e| EngineError::Engine(e.to_string()))
+    }
+
+    /// Sends a new payload to the execution layer (Engine API v4).
+    pub async fn new_payload_v4(
+        &self,
+        payload: OpExecutionPayloadV4,
+        versioned_hashes: Vec<B256>,
+        parent_beacon_block_root: B256,
+        execution_requests: Requests,
+    ) -> Result<PayloadStatus, EngineError> {
+        debug!(
+            block_hash = ?payload.payload_inner.payload_inner.payload_inner.block_hash,
+            "Sending new_payload_v4 via channel"
+        );
+        let execution_data = OpExecutionData::v4(
+            payload,
+            versioned_hashes,
+            parent_beacon_block_root,
+            execution_requests,
+        );
+        self.consensus_handle
+            .new_payload(execution_data)
+            .await
+            .map_err(|e| EngineError::Engine(e.to_string()))
+    }
+
+    /// Retrieves a payload by ID (Engine API v2).
+    pub async fn get_payload_v2(
+        &self,
+        payload_id: PayloadId,
+    ) -> Result<ExecutionPayloadEnvelopeV2, EngineError> {
+        debug!(%payload_id, "Resolving payload via PayloadStore");
+        self.payload_store
+            .resolve(payload_id)
+            .await
+            .ok_or_else(|| EngineError::PayloadNotFound(payload_id.to_string()))?
+            .map(Into::into)
+            .map_err(|e| EngineError::PayloadResolution(e.to_string()))
+    }
+
+    /// Retrieves a payload by ID (Engine API v3).
+    pub async fn get_payload_v3(
+        &self,
+        payload_id: PayloadId,
+    ) -> Result<OpExecutionPayloadEnvelopeV3, EngineError> {
+        debug!(%payload_id, "Resolving payload via PayloadStore");
+        self.payload_store
+            .resolve(payload_id)
+            .await
+            .ok_or_else(|| EngineError::PayloadNotFound(payload_id.to_string()))?
+            .map(Into::into)
+            .map_err(|e| EngineError::PayloadResolution(e.to_string()))
+    }
+
+    /// Retrieves a payload by ID (Engine API v4).
+    pub async fn get_payload_v4(
+        &self,
+        payload_id: PayloadId,
+    ) -> Result<OpExecutionPayloadEnvelopeV4, EngineError> {
+        debug!(%payload_id, "Resolving payload via PayloadStore");
+        self.payload_store
+            .resolve(payload_id)
+            .await
+            .ok_or_else(|| EngineError::PayloadNotFound(payload_id.to_string()))?
+            .map(Into::into)
+            .map_err(|e| EngineError::PayloadResolution(e.to_string()))
+    }
+}


### PR DESCRIPTION
## Summary

> [!NOTE]
>
> Closes CHAIN-2840

In order for the consensus client to be able to communicate in-process with reth's engine task, it effectively needs a `ConsensusEngineHandle`.

This PR introduces the `base-engine-ext` crate, which provides the glue for kona to communicate through an in-process engine actor to reth. The core type is `InProcessEngineClient`, which wraps reth's `ConsensusEngineHandle<OpEngineTypes>` and `PayloadStore<OpEngineTypes>` to enable direct channel-based Engine API communication.

### Construction

The client can be constructed from a fully-launched reth node using the `add_node_started_hook`:

```rust
use base_engine_ext::{InProcessEngineClient, PayloadStore};

let builder = node_builder.add_node_started_hook(move |full_node| {
    let engine_handle = full_node.add_ons_handle.beacon_engine_handle.clone();
    let payload_store = PayloadStore::new(full_node.payload_builder_handle.clone());
    let client = InProcessEngineClient::new(engine_handle, payload_store);
    // Send client to consensus layer via oneshot channel
});
```