### PR TITLE
feat(consensus): Custom Engine Actor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1931,17 +1931,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "base-engine-actor"
+version = "0.0.0"
+dependencies = [
+ "alloy-primitives",
+ "alloy-rpc-types-engine",
+ "async-trait",
+ "base-engine-ext",
+ "kona-genesis",
+ "kona-node-service",
+ "kona-protocol",
+ "op-alloy-rpc-types-engine",
+ "parking_lot",
+ "reth-provider",
+ "reth-storage-api",
+ "thiserror 2.0.17",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "base-engine-ext"
 version = "0.0.0"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
  "alloy-rpc-types-engine",
+ "kona-protocol",
  "op-alloy-rpc-types-engine",
+ "parking_lot",
  "reth-engine-primitives",
  "reth-optimism-node",
  "reth-payload-builder",
  "reth-payload-primitives",
+ "reth-primitives-traits",
+ "reth-provider",
+ "reth-storage-api",
  "thiserror 2.0.17",
  "tracing",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1958,6 +1958,7 @@ dependencies = [
  "alloy-eips",
  "alloy-primitives",
  "alloy-rpc-types-engine",
+ "base-primitives",
  "kona-protocol",
  "op-alloy-rpc-types-engine",
  "parking_lot",
@@ -2162,14 +2163,11 @@ dependencies = [
  "alloy-signer-local",
  "alloy-sol-macro",
  "alloy-sol-types",
- "alloy-transport",
- "alloy-transport-http",
  "eyre",
- "kona-engine",
  "kona-genesis",
  "op-alloy-network",
- "op-alloy-provider",
  "op-alloy-rpc-types",
+ "op-alloy-rpc-types-engine",
  "serde_json",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ exclude = [".github/"]
 
 [workspace]
 resolver = "2"
-members = ["bin/*", "crates/client/*", "crates/shared/*", "crates/builder/*"]
+members = ["bin/*", "crates/client/*", "crates/shared/*", "crates/builder/*", "crates/consensus/*"]
 default-members = ["bin/node", "bin/consensus"]
 
 [workspace.metadata.cargo-udeps.ignore]
@@ -61,6 +61,7 @@ base-access-lists = { path = "crates/shared/access-lists" }
 base-reth-rpc-types = { path = "crates/shared/reth-rpc-types" }
 base-jwt = { path = "crates/shared/jwt" }
 base-engine-ext = { path = "crates/shared/engine-ext" }
+base-engine-actor = { path = "crates/consensus/engine-actor" }
 base-flashblocks-node = { path = "crates/client/flashblocks-node" }
 
 # Client
@@ -87,6 +88,7 @@ kona-genesis = { git = "https://github.com/ethereum-optimism/optimism", rev = "1
 kona-sources = { git = "https://github.com/ethereum-optimism/optimism", rev = "1a8048a34f2650ec43fd5e2c947d03b2dd0cda3e" }
 kona-registry = { git = "https://github.com/ethereum-optimism/optimism", rev = "1a8048a34f2650ec43fd5e2c947d03b2dd0cda3e" }
 kona-node-service = { git = "https://github.com/ethereum-optimism/optimism", rev = "1a8048a34f2650ec43fd5e2c947d03b2dd0cda3e" }
+kona-protocol = { git = "https://github.com/ethereum-optimism/optimism", rev = "1a8048a34f2650ec43fd5e2c947d03b2dd0cda3e" }
 kona-providers-alloy = { git = "https://github.com/ethereum-optimism/optimism", rev = "1a8048a34f2650ec43fd5e2c947d03b2dd0cda3e" }
 
 # reth

--- a/crates/consensus/engine-actor/Cargo.toml
+++ b/crates/consensus/engine-actor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
-name = "base-engine-ext"
-description = "In-process engine client for direct reth communication"
+name = "base-engine-actor"
+description = "Engine actor for direct reth communication via in-process channels"
 version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
@@ -12,25 +12,29 @@ repository.workspace = true
 workspace = true
 
 [dependencies]
-# kona
+# Workspace
+base-engine-ext.workspace = true
+
+# Kona
+kona-genesis.workspace = true
+kona-node-service.workspace = true
 kona-protocol.workspace = true
 
 # reth
-reth-engine-primitives.workspace = true
-reth-optimism-node.workspace = true
-reth-payload-builder.workspace = true
-reth-payload-primitives.workspace = true
-reth-primitives-traits.workspace = true
 reth-provider.workspace = true
 reth-storage-api.workspace = true
 
 # alloy
-alloy-eips.workspace = true
 alloy-primitives.workspace = true
 alloy-rpc-types-engine.workspace = true
 
 # op-alloy
 op-alloy-rpc-types-engine.workspace = true
+
+# async
+async-trait.workspace = true
+tokio.workspace = true
+tokio-util.workspace = true
 
 # misc
 parking_lot.workspace = true

--- a/crates/consensus/engine-actor/README.md
+++ b/crates/consensus/engine-actor/README.md
@@ -1,0 +1,86 @@
+# base-engine-actor
+
+Engine actor for direct reth communication via in-process channels.
+
+## Overview
+
+This crate provides `DirectEngineActor`, which implements kona's `NodeActor` trait
+to integrate with kona-node-service. It uses `InProcessEngineClient` from
+`base-engine-ext` to communicate directly with reth's consensus engine.
+
+## Architecture
+
+```text
+┌─────────────────────────────────────────────────────────────────────────────────┐
+│                           kona-node-service                                     │
+│                                                                                 │
+│  ┌───────────────────┐  ┌───────────────────┐  ┌────────────────────────────┐  │
+│  │  DerivationActor  │  │    SyncActor      │  │     DirectEngineActor      │  │
+│  └─────────┬─────────┘  └─────────┬─────────┘  └──────────────┬─────────────┘  │
+│            │                      │                           │                │
+│            └──────────────────────┼───────────────────────────┘                │
+│                                   │                                            │
+│                          EngineActorRequest                                    │
+│                                   │                                            │
+└───────────────────────────────────┼────────────────────────────────────────────┘
+                                    │
+                                    ▼
+                    ┌───────────────────────────────┐
+                    │   DirectEngineProcessor       │
+                    │                               │
+                    │  ┌─────────────────────────┐  │
+                    │  │ BuildHandler            │  │
+                    │  │ SealHandler             │  │
+                    │  │ ConsolidationHandler    │  │
+                    │  │ FinalizationHandler     │  │
+                    │  │ UnsafeBlockHandler      │  │
+                    │  │ ResetHandler            │  │
+                    │  └─────────────────────────┘  │
+                    └───────────────┬───────────────┘
+                                    │
+                                    ▼
+                    ┌───────────────────────────────┐
+                    │   InProcessEngineClient<P>    │
+                    │   (from base-engine-ext)      │
+                    └───────────────┬───────────────┘
+                                    │
+                                    │ unbounded channel
+                                    ▼
+                    ┌───────────────────────────────┐
+                    │   reth EngineApiTreeHandler   │
+                    └───────────────────────────────┘
+```
+
+## Request Types
+
+The actor handles several request types from kona-node-service:
+
+| Request | Description |
+|---------|-------------|
+| `Build` | Initiates payload building via FCU with attributes |
+| `Seal` | Gets and inserts the built payload |
+| `ProcessSafeL2Signal` | Updates the safe head |
+| `ProcessFinalizedL2BlockNumber` | Updates the finalized head |
+| `ProcessUnsafeL2Block` | Inserts an unsafe block received from gossip |
+| `Reset` | Resets to the finalized head |
+
+## Usage
+
+```rust,ignore
+use base_engine_actor::DirectEngineActor;
+use base_engine_ext::InProcessEngineClient;
+use tokio::sync::mpsc;
+use tokio_util::sync::CancellationToken;
+
+// Create the engine client
+let client = InProcessEngineClient::new(engine_handle, payload_store, provider);
+
+// Create request channel
+let (tx, rx) = mpsc::channel(256);
+
+// Create the actor
+let actor = DirectEngineActor::new(client, rx, CancellationToken::new());
+
+// Start the actor (implements NodeActor)
+actor.start(rollup_config).await?;
+```

--- a/crates/consensus/engine-actor/src/actor.rs
+++ b/crates/consensus/engine-actor/src/actor.rs
@@ -1,0 +1,81 @@
+//! Direct engine actor implementing kona's `NodeActor` trait.
+
+use std::{fmt, sync::Arc};
+
+use async_trait::async_trait;
+use base_engine_ext::InProcessEngineClient;
+use kona_genesis::RollupConfig;
+use kona_node_service::NodeActor;
+use reth_provider::BlockNumReader;
+use reth_storage_api::{BlockHashReader, HeaderProvider};
+use tokio::sync::mpsc;
+use tokio_util::sync::CancellationToken;
+use tracing::info;
+
+use crate::{DirectEngineProcessor, EngineActorError, EngineActorRequest, EngineSyncState};
+
+/// Direct engine actor that communicates with reth via in-process channels.
+///
+/// This actor implements kona's `NodeActor` trait and processes engine requests
+/// from the derivation pipeline and sync actors.
+pub struct DirectEngineActor<P> {
+    /// The in-process engine client.
+    client: InProcessEngineClient<P>,
+    /// The request receiver.
+    rx: mpsc::Receiver<EngineActorRequest>,
+    /// Cancellation token for graceful shutdown.
+    cancel: CancellationToken,
+    /// Optional pre-initialized sync state.
+    sync_state: Option<EngineSyncState>,
+}
+
+impl<P> fmt::Debug for DirectEngineActor<P> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("DirectEngineActor").field("sync_state", &self.sync_state).finish()
+    }
+}
+
+impl<P> DirectEngineActor<P> {
+    /// Creates a new direct engine actor.
+    pub const fn new(
+        client: InProcessEngineClient<P>,
+        rx: mpsc::Receiver<EngineActorRequest>,
+        cancel: CancellationToken,
+    ) -> Self {
+        Self { client, rx, cancel, sync_state: None }
+    }
+
+    /// Creates a new direct engine actor with an existing sync state.
+    pub const fn with_sync_state(
+        client: InProcessEngineClient<P>,
+        rx: mpsc::Receiver<EngineActorRequest>,
+        cancel: CancellationToken,
+        sync_state: EngineSyncState,
+    ) -> Self {
+        Self { client, rx, cancel, sync_state: Some(sync_state) }
+    }
+}
+
+#[async_trait]
+impl<P> NodeActor for DirectEngineActor<P>
+where
+    P: BlockNumReader + BlockHashReader + HeaderProvider + Send + Sync + 'static,
+{
+    type Error = EngineActorError;
+    type StartData = Arc<RollupConfig>;
+
+    async fn start(self, config: Self::StartData) -> Result<(), Self::Error> {
+        info!(
+            chain_id = ?config.l2_chain_id,
+            "Starting DirectEngineActor"
+        );
+
+        let processor = if let Some(sync_state) = self.sync_state {
+            DirectEngineProcessor::with_sync_state(self.client, self.rx, self.cancel, sync_state)
+        } else {
+            DirectEngineProcessor::new(self.client, self.rx, self.cancel)
+        };
+
+        processor.run().await
+    }
+}

--- a/crates/consensus/engine-actor/src/error.rs
+++ b/crates/consensus/engine-actor/src/error.rs
@@ -1,0 +1,60 @@
+//! Error types for the engine actor.
+
+use base_engine_ext::EngineError;
+use thiserror::Error;
+
+/// Errors that can occur in the engine actor.
+#[derive(Debug, Error)]
+pub enum EngineActorError {
+    /// The request channel was closed.
+    #[error("request channel closed")]
+    ChannelClosed,
+
+    /// The actor was cancelled.
+    #[error("actor cancelled")]
+    Cancelled,
+
+    /// Processor error.
+    #[error("processor error: {0}")]
+    Processor(#[from] ProcessorError),
+}
+
+/// Errors that can occur during request processing.
+#[derive(Debug, Error)]
+pub enum ProcessorError {
+    /// Build request failed.
+    #[error("build failed: {0}")]
+    Build(String),
+
+    /// Seal request failed.
+    #[error("seal failed: {0}")]
+    Seal(String),
+
+    /// Consolidation request failed.
+    #[error("consolidation failed: {0}")]
+    Consolidation(String),
+
+    /// Finalization request failed.
+    #[error("finalization failed: {0}")]
+    Finalization(String),
+
+    /// Unsafe block processing failed.
+    #[error("unsafe block processing failed: {0}")]
+    UnsafeBlock(String),
+
+    /// Reset request failed.
+    #[error("reset failed: {0}")]
+    Reset(String),
+
+    /// Engine error.
+    #[error("engine error: {0}")]
+    Engine(#[from] EngineError),
+
+    /// Missing payload ID after FCU.
+    #[error("missing payload ID after fork choice update")]
+    MissingPayloadId,
+
+    /// Invalid payload status.
+    #[error("invalid payload status: {0}")]
+    InvalidPayloadStatus(String),
+}

--- a/crates/consensus/engine-actor/src/handlers/build.rs
+++ b/crates/consensus/engine-actor/src/handlers/build.rs
@@ -1,0 +1,60 @@
+//! Build request handler.
+
+use alloy_primitives::B256;
+use alloy_rpc_types_engine::{ForkchoiceState, PayloadId, PayloadStatusEnum};
+use base_engine_ext::InProcessEngineClient;
+use op_alloy_rpc_types_engine::OpPayloadAttributes;
+use reth_provider::BlockNumReader;
+use reth_storage_api::{BlockHashReader, HeaderProvider};
+use tracing::{debug, warn};
+
+use crate::{EngineSyncState, ProcessorError};
+
+/// Handler for build requests.
+#[derive(Debug)]
+pub struct BuildHandler;
+
+impl BuildHandler {
+    /// Handles a build request by calling `fork_choice_updated_v3` with attributes.
+    ///
+    /// This initiates payload building in the execution layer.
+    pub async fn handle<P>(
+        client: &InProcessEngineClient<P>,
+        sync_state: &EngineSyncState,
+        parent_hash: B256,
+        attributes: OpPayloadAttributes,
+    ) -> Result<PayloadId, ProcessorError>
+    where
+        P: BlockNumReader + BlockHashReader + HeaderProvider,
+    {
+        debug!(?parent_hash, "Handling build request");
+
+        // Build forkchoice state from current sync state.
+        let safe_hash = sync_state.safe_head_hash().unwrap_or(parent_hash);
+        let finalized_hash = sync_state.finalized_head_hash().unwrap_or(parent_hash);
+
+        let state = ForkchoiceState {
+            head_block_hash: parent_hash,
+            safe_block_hash: safe_hash,
+            finalized_block_hash: finalized_hash,
+        };
+
+        let response = client
+            .fork_choice_updated_v3(state, Some(attributes))
+            .await
+            .map_err(ProcessorError::Engine)?;
+
+        // Validate payload status.
+        match response.payload_status.status {
+            PayloadStatusEnum::Valid | PayloadStatusEnum::Syncing => {}
+            PayloadStatusEnum::Invalid { validation_error } => {
+                return Err(ProcessorError::InvalidPayloadStatus(validation_error));
+            }
+            PayloadStatusEnum::Accepted => {
+                warn!("FCU returned ACCEPTED status, expected VALID or SYNCING");
+            }
+        }
+
+        response.payload_id.ok_or(ProcessorError::MissingPayloadId)
+    }
+}

--- a/crates/consensus/engine-actor/src/handlers/consolidation.rs
+++ b/crates/consensus/engine-actor/src/handlers/consolidation.rs
@@ -1,0 +1,62 @@
+//! Consolidation (safe L2 signal) request handler.
+
+use alloy_rpc_types_engine::{ForkchoiceState, PayloadStatusEnum};
+use base_engine_ext::InProcessEngineClient;
+use kona_protocol::L2BlockInfo;
+use reth_provider::BlockNumReader;
+use reth_storage_api::{BlockHashReader, HeaderProvider};
+use tracing::{debug, warn};
+
+use crate::{EngineSyncState, ProcessorError};
+
+/// Handler for consolidation (ProcessSafeL2Signal) requests.
+#[derive(Debug)]
+pub struct ConsolidationHandler;
+
+impl ConsolidationHandler {
+    /// Handles a safe L2 signal by updating the safe head in the fork choice state.
+    pub async fn handle<P>(
+        client: &InProcessEngineClient<P>,
+        sync_state: &EngineSyncState,
+        safe_head: L2BlockInfo,
+    ) -> Result<(), ProcessorError>
+    where
+        P: BlockNumReader + BlockHashReader + HeaderProvider,
+    {
+        debug!(
+            safe_hash = ?safe_head.block_info.hash,
+            safe_number = safe_head.block_info.number,
+            "Handling consolidation request"
+        );
+
+        // Get current heads.
+        let unsafe_hash = sync_state.unsafe_head_hash().unwrap_or(safe_head.block_info.hash);
+        let finalized_hash = sync_state.finalized_head_hash().unwrap_or(safe_head.block_info.hash);
+
+        // Update fork choice with new safe head.
+        let state = ForkchoiceState {
+            head_block_hash: unsafe_hash,
+            safe_block_hash: safe_head.block_info.hash,
+            finalized_block_hash: finalized_hash,
+        };
+
+        let response =
+            client.fork_choice_updated_v3(state, None).await.map_err(ProcessorError::Engine)?;
+
+        // Validate response.
+        match response.payload_status.status {
+            PayloadStatusEnum::Valid | PayloadStatusEnum::Syncing => {}
+            PayloadStatusEnum::Invalid { validation_error } => {
+                return Err(ProcessorError::InvalidPayloadStatus(validation_error));
+            }
+            PayloadStatusEnum::Accepted => {
+                warn!("FCU for consolidation returned ACCEPTED status");
+            }
+        }
+
+        // Update sync state.
+        sync_state.set_safe_head(safe_head);
+
+        Ok(())
+    }
+}

--- a/crates/consensus/engine-actor/src/handlers/finalization.rs
+++ b/crates/consensus/engine-actor/src/handlers/finalization.rs
@@ -1,0 +1,61 @@
+//! Finalization request handler.
+
+use alloy_rpc_types_engine::{ForkchoiceState, PayloadStatusEnum};
+use base_engine_ext::InProcessEngineClient;
+use reth_provider::BlockNumReader;
+use reth_storage_api::{BlockHashReader, HeaderProvider};
+use tracing::{debug, warn};
+
+use crate::{EngineSyncState, ProcessorError};
+
+/// Handler for finalization (ProcessFinalizedL2BlockNumber) requests.
+#[derive(Debug)]
+pub struct FinalizationHandler;
+
+impl FinalizationHandler {
+    /// Handles a finalized L2 block number by updating the finalized head.
+    pub async fn handle<P>(
+        client: &InProcessEngineClient<P>,
+        sync_state: &EngineSyncState,
+        finalized_number: u64,
+    ) -> Result<(), ProcessorError>
+    where
+        P: BlockNumReader + BlockHashReader + HeaderProvider,
+    {
+        debug!(finalized_number, "Handling finalization request");
+
+        // Get the block info for the finalized number.
+        let finalized_info =
+            client.l2_block_info_by_number(finalized_number).map_err(ProcessorError::Engine)?;
+
+        // Get current heads.
+        let unsafe_hash = sync_state.unsafe_head_hash().unwrap_or(finalized_info.block_info.hash);
+        let safe_hash = sync_state.safe_head_hash().unwrap_or(finalized_info.block_info.hash);
+
+        // Update fork choice with new finalized head.
+        let state = ForkchoiceState {
+            head_block_hash: unsafe_hash,
+            safe_block_hash: safe_hash,
+            finalized_block_hash: finalized_info.block_info.hash,
+        };
+
+        let response =
+            client.fork_choice_updated_v3(state, None).await.map_err(ProcessorError::Engine)?;
+
+        // Validate response.
+        match response.payload_status.status {
+            PayloadStatusEnum::Valid | PayloadStatusEnum::Syncing => {}
+            PayloadStatusEnum::Invalid { validation_error } => {
+                return Err(ProcessorError::InvalidPayloadStatus(validation_error));
+            }
+            PayloadStatusEnum::Accepted => {
+                warn!("FCU for finalization returned ACCEPTED status");
+            }
+        }
+
+        // Update sync state.
+        sync_state.set_finalized_head(finalized_info);
+
+        Ok(())
+    }
+}

--- a/crates/consensus/engine-actor/src/handlers/mod.rs
+++ b/crates/consensus/engine-actor/src/handlers/mod.rs
@@ -1,0 +1,19 @@
+//! Request handlers for the engine actor.
+
+mod build;
+pub use build::BuildHandler;
+
+mod consolidation;
+pub use consolidation::ConsolidationHandler;
+
+mod finalization;
+pub use finalization::FinalizationHandler;
+
+mod reset;
+pub use reset::ResetHandler;
+
+mod seal;
+pub use seal::SealHandler;
+
+mod unsafe_block;
+pub use unsafe_block::UnsafeBlockHandler;

--- a/crates/consensus/engine-actor/src/handlers/reset.rs
+++ b/crates/consensus/engine-actor/src/handlers/reset.rs
@@ -1,0 +1,61 @@
+//! Reset request handler.
+
+use alloy_rpc_types_engine::{ForkchoiceState, PayloadStatusEnum};
+use base_engine_ext::InProcessEngineClient;
+use kona_protocol::L2BlockInfo;
+use reth_provider::BlockNumReader;
+use reth_storage_api::{BlockHashReader, HeaderProvider};
+use tracing::{debug, warn};
+
+use crate::{EngineSyncState, ProcessorError};
+
+/// Handler for reset requests.
+#[derive(Debug)]
+pub struct ResetHandler;
+
+impl ResetHandler {
+    /// Handles a reset request by resetting to the finalized head.
+    ///
+    /// This is used when the derivation pipeline needs to be reset,
+    /// typically after detecting a reorg or invalid state.
+    pub async fn handle<P>(
+        client: &InProcessEngineClient<P>,
+        sync_state: &EngineSyncState,
+    ) -> Result<L2BlockInfo, ProcessorError>
+    where
+        P: BlockNumReader + BlockHashReader + HeaderProvider,
+    {
+        debug!("Handling reset request");
+
+        // Get the finalized head from the engine client.
+        let finalized = client.l2_finalized_head().map_err(ProcessorError::Engine)?;
+
+        // Update fork choice to the finalized head.
+        let state = ForkchoiceState {
+            head_block_hash: finalized.block_info.hash,
+            safe_block_hash: finalized.block_info.hash,
+            finalized_block_hash: finalized.block_info.hash,
+        };
+
+        let response =
+            client.fork_choice_updated_v3(state, None).await.map_err(ProcessorError::Engine)?;
+
+        // Validate response.
+        match response.payload_status.status {
+            PayloadStatusEnum::Valid | PayloadStatusEnum::Syncing => {}
+            PayloadStatusEnum::Invalid { validation_error } => {
+                return Err(ProcessorError::InvalidPayloadStatus(validation_error));
+            }
+            PayloadStatusEnum::Accepted => {
+                warn!("FCU for reset returned ACCEPTED status");
+            }
+        }
+
+        // Reset sync state to finalized head.
+        sync_state.set_unsafe_head(finalized);
+        sync_state.set_safe_head(finalized);
+        sync_state.set_finalized_head(finalized);
+
+        Ok(finalized)
+    }
+}

--- a/crates/consensus/engine-actor/src/handlers/seal.rs
+++ b/crates/consensus/engine-actor/src/handlers/seal.rs
@@ -1,0 +1,88 @@
+//! Seal request handler.
+
+use alloy_rpc_types_engine::{ForkchoiceState, PayloadId, PayloadStatusEnum};
+use base_engine_ext::InProcessEngineClient;
+use op_alloy_rpc_types_engine::OpExecutionPayloadEnvelopeV3;
+use reth_provider::BlockNumReader;
+use reth_storage_api::{BlockHashReader, HeaderProvider};
+use tracing::{debug, warn};
+
+use crate::{EngineSyncState, ProcessorError};
+
+/// Handler for seal requests.
+#[derive(Debug)]
+pub struct SealHandler;
+
+impl SealHandler {
+    /// Handles a seal request by getting the payload and inserting it via `new_payload`.
+    ///
+    /// This retrieves the built payload, inserts it into the execution layer,
+    /// and updates the fork choice to make it canonical.
+    pub async fn handle<P>(
+        client: &InProcessEngineClient<P>,
+        sync_state: &EngineSyncState,
+        payload_id: PayloadId,
+    ) -> Result<OpExecutionPayloadEnvelopeV3, ProcessorError>
+    where
+        P: BlockNumReader + BlockHashReader + HeaderProvider,
+    {
+        debug!(%payload_id, "Handling seal request");
+
+        // Get the payload from the store.
+        let envelope = client.get_payload_v3(payload_id).await.map_err(ProcessorError::Engine)?;
+
+        let block_hash = envelope.execution_payload.payload_inner.payload_inner.block_hash;
+
+        // Insert the payload via new_payload.
+        let status = client
+            .new_payload_v3(
+                envelope.execution_payload.clone(),
+                vec![], // No blob versioned hashes for OP.
+                envelope.parent_beacon_block_root,
+            )
+            .await
+            .map_err(ProcessorError::Engine)?;
+
+        // Validate payload status.
+        match status.status {
+            PayloadStatusEnum::Valid | PayloadStatusEnum::Syncing => {}
+            PayloadStatusEnum::Invalid { validation_error } => {
+                return Err(ProcessorError::InvalidPayloadStatus(validation_error));
+            }
+            PayloadStatusEnum::Accepted => {
+                warn!("new_payload returned ACCEPTED status, expected VALID or SYNCING");
+            }
+        }
+
+        // Update fork choice to make the block canonical.
+        let safe_hash = sync_state.safe_head_hash().unwrap_or(block_hash);
+        let finalized_hash = sync_state.finalized_head_hash().unwrap_or(block_hash);
+
+        let state = ForkchoiceState {
+            head_block_hash: block_hash,
+            safe_block_hash: safe_hash,
+            finalized_block_hash: finalized_hash,
+        };
+
+        let fcu_response =
+            client.fork_choice_updated_v3(state, None).await.map_err(ProcessorError::Engine)?;
+
+        // Validate FCU response.
+        match fcu_response.payload_status.status {
+            PayloadStatusEnum::Valid | PayloadStatusEnum::Syncing => {}
+            PayloadStatusEnum::Invalid { validation_error } => {
+                return Err(ProcessorError::InvalidPayloadStatus(validation_error));
+            }
+            PayloadStatusEnum::Accepted => {
+                warn!("FCU after seal returned ACCEPTED status");
+            }
+        }
+
+        // Update the sync state with the new unsafe head.
+        if let Ok(block_info) = client.l2_block_info_by_hash(block_hash) {
+            sync_state.set_unsafe_head(block_info);
+        }
+
+        Ok(envelope)
+    }
+}

--- a/crates/consensus/engine-actor/src/handlers/unsafe_block.rs
+++ b/crates/consensus/engine-actor/src/handlers/unsafe_block.rs
@@ -1,0 +1,86 @@
+//! Unsafe block processing handler.
+
+use alloy_rpc_types_engine::{ForkchoiceState, PayloadStatusEnum};
+use base_engine_ext::InProcessEngineClient;
+use op_alloy_rpc_types_engine::OpExecutionPayloadEnvelopeV3;
+use reth_provider::BlockNumReader;
+use reth_storage_api::{BlockHashReader, HeaderProvider};
+use tracing::{debug, warn};
+
+use crate::{EngineSyncState, ProcessorError};
+
+/// Handler for unsafe block (ProcessUnsafeL2Block) requests.
+#[derive(Debug)]
+pub struct UnsafeBlockHandler;
+
+impl UnsafeBlockHandler {
+    /// Handles an unsafe L2 block by inserting it via `new_payload`.
+    ///
+    /// This is used for blocks received from gossip that haven't been derived yet.
+    pub async fn handle<P>(
+        client: &InProcessEngineClient<P>,
+        sync_state: &EngineSyncState,
+        envelope: OpExecutionPayloadEnvelopeV3,
+    ) -> Result<(), ProcessorError>
+    where
+        P: BlockNumReader + BlockHashReader + HeaderProvider,
+    {
+        let block_hash = envelope.execution_payload.payload_inner.payload_inner.block_hash;
+        let block_number = envelope.execution_payload.payload_inner.payload_inner.block_number;
+
+        debug!(?block_hash, block_number, "Handling unsafe block request");
+
+        // Insert the payload via new_payload.
+        let status = client
+            .new_payload_v3(
+                envelope.execution_payload,
+                vec![], // No blob versioned hashes for OP.
+                envelope.parent_beacon_block_root,
+            )
+            .await
+            .map_err(ProcessorError::Engine)?;
+
+        // Validate payload status.
+        match status.status {
+            PayloadStatusEnum::Valid | PayloadStatusEnum::Syncing => {}
+            PayloadStatusEnum::Invalid { validation_error } => {
+                return Err(ProcessorError::InvalidPayloadStatus(validation_error));
+            }
+            PayloadStatusEnum::Accepted => {
+                // ACCEPTED is fine for unsafe blocks that extend the chain.
+                debug!("new_payload returned ACCEPTED for unsafe block");
+            }
+        }
+
+        // Update fork choice to make the block the new unsafe head.
+        let safe_hash = sync_state.safe_head_hash().unwrap_or(block_hash);
+        let finalized_hash = sync_state.finalized_head_hash().unwrap_or(block_hash);
+
+        let state = ForkchoiceState {
+            head_block_hash: block_hash,
+            safe_block_hash: safe_hash,
+            finalized_block_hash: finalized_hash,
+        };
+
+        let response =
+            client.fork_choice_updated_v3(state, None).await.map_err(ProcessorError::Engine)?;
+
+        // Validate FCU response.
+        match response.payload_status.status {
+            PayloadStatusEnum::Valid | PayloadStatusEnum::Syncing => {}
+            PayloadStatusEnum::Invalid { validation_error } => {
+                return Err(ProcessorError::InvalidPayloadStatus(validation_error));
+            }
+            PayloadStatusEnum::Accepted => {
+                warn!("FCU for unsafe block returned ACCEPTED status");
+            }
+        }
+
+        // Update the sync state with the new unsafe head.
+        if let Ok(block_info) = client.l2_block_info_by_hash(block_hash) {
+            sync_state.set_unsafe_head(block_info);
+        }
+
+        Ok(())
+    }
+}

--- a/crates/consensus/engine-actor/src/lib.rs
+++ b/crates/consensus/engine-actor/src/lib.rs
@@ -1,0 +1,24 @@
+#![doc = include_str!("../README.md")]
+#![doc(issue_tracker_base_url = "https://github.com/base/base/issues/")]
+#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
+#![cfg_attr(not(test), warn(unused_crate_dependencies))]
+
+mod actor;
+pub use actor::DirectEngineActor;
+
+mod error;
+pub use error::{EngineActorError, ProcessorError};
+
+pub mod handlers;
+
+mod processor;
+pub use processor::DirectEngineProcessor;
+
+mod request;
+pub use request::{
+    BuildRequest, EngineActorRequest, ProcessFinalizedL2BlockNumberRequest,
+    ProcessSafeL2SignalRequest, ProcessUnsafeL2BlockRequest, ResetRequest, SealRequest,
+};
+
+mod state;
+pub use state::EngineSyncState;

--- a/crates/consensus/engine-actor/src/processor.rs
+++ b/crates/consensus/engine-actor/src/processor.rs
@@ -1,0 +1,156 @@
+//! Request processor for the engine actor.
+
+use std::fmt;
+
+use base_engine_ext::InProcessEngineClient;
+use reth_provider::BlockNumReader;
+use reth_storage_api::{BlockHashReader, HeaderProvider};
+use tokio::sync::mpsc;
+use tokio_util::sync::CancellationToken;
+use tracing::{debug, error, trace, warn};
+
+use crate::{
+    EngineActorError, EngineActorRequest, EngineSyncState,
+    handlers::{
+        BuildHandler, ConsolidationHandler, FinalizationHandler, ResetHandler, SealHandler,
+        UnsafeBlockHandler,
+    },
+};
+
+/// Processes engine actor requests.
+///
+/// This struct runs the main request processing loop, dispatching
+/// requests to the appropriate handlers.
+pub struct DirectEngineProcessor<P> {
+    /// The in-process engine client.
+    client: InProcessEngineClient<P>,
+    /// The request receiver.
+    rx: mpsc::Receiver<EngineActorRequest>,
+    /// Cancellation token for graceful shutdown.
+    cancel: CancellationToken,
+    /// The engine sync state.
+    sync_state: EngineSyncState,
+}
+
+impl<P> fmt::Debug for DirectEngineProcessor<P> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("DirectEngineProcessor").field("sync_state", &self.sync_state).finish()
+    }
+}
+
+impl<P> DirectEngineProcessor<P>
+where
+    P: BlockNumReader + BlockHashReader + HeaderProvider + Send + Sync + 'static,
+{
+    /// Creates a new processor.
+    pub fn new(
+        client: InProcessEngineClient<P>,
+        rx: mpsc::Receiver<EngineActorRequest>,
+        cancel: CancellationToken,
+    ) -> Self {
+        Self { client, rx, cancel, sync_state: EngineSyncState::new() }
+    }
+
+    /// Creates a new processor with an existing sync state.
+    pub const fn with_sync_state(
+        client: InProcessEngineClient<P>,
+        rx: mpsc::Receiver<EngineActorRequest>,
+        cancel: CancellationToken,
+        sync_state: EngineSyncState,
+    ) -> Self {
+        Self { client, rx, cancel, sync_state }
+    }
+
+    /// Returns a reference to the sync state.
+    pub const fn sync_state(&self) -> &EngineSyncState {
+        &self.sync_state
+    }
+
+    /// Runs the request processing loop.
+    pub async fn run(mut self) -> Result<(), EngineActorError> {
+        debug!("Starting engine processor");
+
+        loop {
+            tokio::select! {
+                () = self.cancel.cancelled() => {
+                    debug!("Processor cancelled");
+                    return Err(EngineActorError::Cancelled);
+                }
+                request = self.rx.recv() => {
+                    match request {
+                        Some(req) => self.handle_request(req).await,
+                        None => {
+                            debug!("Request channel closed");
+                            return Err(EngineActorError::ChannelClosed);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    /// Handles a single request.
+    async fn handle_request(&self, request: EngineActorRequest) {
+        trace!("Processing request");
+
+        match request {
+            EngineActorRequest::Build(req) => {
+                let result = BuildHandler::handle(
+                    &self.client,
+                    &self.sync_state,
+                    req.parent_hash,
+                    req.attributes,
+                )
+                .await;
+                if let Err(e) = &result {
+                    warn!("Build request failed: {e}");
+                }
+                let _ = req.response.send(result);
+            }
+            EngineActorRequest::Seal(req) => {
+                let result =
+                    SealHandler::handle(&self.client, &self.sync_state, req.payload_id).await;
+                if let Err(e) = &result {
+                    warn!("Seal request failed: {e}");
+                }
+                let _ = req.response.send(result);
+            }
+            EngineActorRequest::ProcessSafeL2Signal(req) => {
+                let result =
+                    ConsolidationHandler::handle(&self.client, &self.sync_state, req.safe_head)
+                        .await;
+                if let Err(e) = &result {
+                    warn!("Consolidation request failed: {e}");
+                }
+                let _ = req.response.send(result);
+            }
+            EngineActorRequest::ProcessFinalizedL2BlockNumber(req) => {
+                let result = FinalizationHandler::handle(
+                    &self.client,
+                    &self.sync_state,
+                    req.finalized_number,
+                )
+                .await;
+                if let Err(e) = &result {
+                    warn!("Finalization request failed: {e}");
+                }
+                let _ = req.response.send(result);
+            }
+            EngineActorRequest::ProcessUnsafeL2Block(req) => {
+                let result =
+                    UnsafeBlockHandler::handle(&self.client, &self.sync_state, req.envelope).await;
+                if let Err(e) = &result {
+                    warn!("Unsafe block request failed: {e}");
+                }
+                let _ = req.response.send(result);
+            }
+            EngineActorRequest::Reset(req) => {
+                let result = ResetHandler::handle(&self.client, &self.sync_state).await;
+                if let Err(e) = &result {
+                    error!("Reset request failed: {e}");
+                }
+                let _ = req.response.send(result);
+            }
+        }
+    }
+}

--- a/crates/consensus/engine-actor/src/request.rs
+++ b/crates/consensus/engine-actor/src/request.rs
@@ -1,0 +1,141 @@
+//! Request types for the engine actor.
+
+use alloy_primitives::B256;
+use alloy_rpc_types_engine::PayloadId;
+use kona_protocol::L2BlockInfo;
+use op_alloy_rpc_types_engine::{OpExecutionPayloadEnvelopeV3, OpPayloadAttributes};
+use tokio::sync::oneshot;
+
+use crate::ProcessorError;
+
+/// Top-level request type for the engine actor.
+#[derive(Debug)]
+pub enum EngineActorRequest {
+    /// Build a new payload.
+    Build(BuildRequest),
+    /// Seal the current payload.
+    Seal(SealRequest),
+    /// Process a safe L2 signal (consolidation).
+    ProcessSafeL2Signal(ProcessSafeL2SignalRequest),
+    /// Process a finalized L2 block number.
+    ProcessFinalizedL2BlockNumber(ProcessFinalizedL2BlockNumberRequest),
+    /// Process an unsafe L2 block.
+    ProcessUnsafeL2Block(Box<ProcessUnsafeL2BlockRequest>),
+    /// Reset to the finalized head.
+    Reset(ResetRequest),
+}
+
+/// Request to build a new payload.
+#[derive(Debug)]
+pub struct BuildRequest {
+    /// The parent block hash to build on.
+    pub parent_hash: B256,
+    /// The payload attributes for the new block.
+    pub attributes: OpPayloadAttributes,
+    /// Channel to send the response.
+    pub response: oneshot::Sender<Result<PayloadId, ProcessorError>>,
+}
+
+impl BuildRequest {
+    /// Creates a new build request.
+    pub fn new(
+        parent_hash: B256,
+        attributes: OpPayloadAttributes,
+    ) -> (Self, oneshot::Receiver<Result<PayloadId, ProcessorError>>) {
+        let (tx, rx) = oneshot::channel();
+        (Self { parent_hash, attributes, response: tx }, rx)
+    }
+}
+
+/// Request to seal the current payload.
+#[derive(Debug)]
+pub struct SealRequest {
+    /// The payload ID to seal.
+    pub payload_id: PayloadId,
+    /// Channel to send the response.
+    pub response: oneshot::Sender<Result<OpExecutionPayloadEnvelopeV3, ProcessorError>>,
+}
+
+impl SealRequest {
+    /// Creates a new seal request.
+    pub fn new(
+        payload_id: PayloadId,
+    ) -> (Self, oneshot::Receiver<Result<OpExecutionPayloadEnvelopeV3, ProcessorError>>) {
+        let (tx, rx) = oneshot::channel();
+        (Self { payload_id, response: tx }, rx)
+    }
+}
+
+/// Request to process a safe L2 signal (consolidation).
+#[derive(Debug)]
+pub struct ProcessSafeL2SignalRequest {
+    /// The safe L2 block info.
+    pub safe_head: L2BlockInfo,
+    /// Channel to send the response.
+    pub response: oneshot::Sender<Result<(), ProcessorError>>,
+}
+
+impl ProcessSafeL2SignalRequest {
+    /// Creates a new safe L2 signal request.
+    pub fn new(safe_head: L2BlockInfo) -> (Self, oneshot::Receiver<Result<(), ProcessorError>>) {
+        let (tx, rx) = oneshot::channel();
+        (Self { safe_head, response: tx }, rx)
+    }
+}
+
+/// Request to process a finalized L2 block number.
+#[derive(Debug)]
+pub struct ProcessFinalizedL2BlockNumberRequest {
+    /// The finalized L2 block number.
+    pub finalized_number: u64,
+    /// Channel to send the response.
+    pub response: oneshot::Sender<Result<(), ProcessorError>>,
+}
+
+impl ProcessFinalizedL2BlockNumberRequest {
+    /// Creates a new finalized L2 block number request.
+    pub fn new(finalized_number: u64) -> (Self, oneshot::Receiver<Result<(), ProcessorError>>) {
+        let (tx, rx) = oneshot::channel();
+        (Self { finalized_number, response: tx }, rx)
+    }
+}
+
+/// Request to process an unsafe L2 block.
+#[derive(Debug)]
+pub struct ProcessUnsafeL2BlockRequest {
+    /// The unsafe block envelope.
+    pub envelope: OpExecutionPayloadEnvelopeV3,
+    /// Channel to send the response.
+    pub response: oneshot::Sender<Result<(), ProcessorError>>,
+}
+
+impl ProcessUnsafeL2BlockRequest {
+    /// Creates a new unsafe block request.
+    pub fn new(
+        envelope: OpExecutionPayloadEnvelopeV3,
+    ) -> (Self, oneshot::Receiver<Result<(), ProcessorError>>) {
+        let (tx, rx) = oneshot::channel();
+        (Self { envelope, response: tx }, rx)
+    }
+}
+
+/// Request to reset to the finalized head.
+#[derive(Debug)]
+pub struct ResetRequest {
+    /// Channel to send the response.
+    pub response: oneshot::Sender<Result<L2BlockInfo, ProcessorError>>,
+}
+
+impl ResetRequest {
+    /// Creates a new reset request.
+    pub fn new() -> (Self, oneshot::Receiver<Result<L2BlockInfo, ProcessorError>>) {
+        let (tx, rx) = oneshot::channel();
+        (Self { response: tx }, rx)
+    }
+}
+
+impl Default for ResetRequest {
+    fn default() -> Self {
+        Self::new().0
+    }
+}

--- a/crates/consensus/engine-actor/src/state.rs
+++ b/crates/consensus/engine-actor/src/state.rs
@@ -1,0 +1,91 @@
+//! Engine sync state tracking.
+
+use std::sync::Arc;
+
+use alloy_primitives::B256;
+use kona_protocol::L2BlockInfo;
+use parking_lot::RwLock;
+
+/// Tracks the engine synchronization state.
+///
+/// This maintains the current unsafe, safe, and finalized heads,
+/// which are updated as the engine processes blocks.
+#[derive(Debug, Clone)]
+pub struct EngineSyncState {
+    inner: Arc<RwLock<EngineSyncStateInner>>,
+}
+
+/// Inner state for the engine sync state.
+#[derive(Debug, Default)]
+struct EngineSyncStateInner {
+    /// The current unsafe head.
+    unsafe_head: Option<L2BlockInfo>,
+    /// The current safe head.
+    safe_head: Option<L2BlockInfo>,
+    /// The current finalized head.
+    finalized_head: Option<L2BlockInfo>,
+}
+
+impl Default for EngineSyncState {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl EngineSyncState {
+    /// Creates a new engine sync state.
+    pub fn new() -> Self {
+        Self { inner: Arc::new(RwLock::new(EngineSyncStateInner::default())) }
+    }
+
+    /// Sets the unsafe head.
+    pub fn set_unsafe_head(&self, head: L2BlockInfo) {
+        self.inner.write().unsafe_head = Some(head);
+    }
+
+    /// Sets the safe head.
+    pub fn set_safe_head(&self, head: L2BlockInfo) {
+        self.inner.write().safe_head = Some(head);
+    }
+
+    /// Sets the finalized head.
+    pub fn set_finalized_head(&self, head: L2BlockInfo) {
+        self.inner.write().finalized_head = Some(head);
+    }
+
+    /// Returns the current unsafe head.
+    pub fn unsafe_head(&self) -> Option<L2BlockInfo> {
+        self.inner.read().unsafe_head
+    }
+
+    /// Returns the current safe head.
+    pub fn safe_head(&self) -> Option<L2BlockInfo> {
+        self.inner.read().safe_head
+    }
+
+    /// Returns the current finalized head.
+    pub fn finalized_head(&self) -> Option<L2BlockInfo> {
+        self.inner.read().finalized_head
+    }
+
+    /// Returns the unsafe head block hash.
+    pub fn unsafe_head_hash(&self) -> Option<B256> {
+        self.inner.read().unsafe_head.map(|h| h.block_info.hash)
+    }
+
+    /// Returns the safe head block hash.
+    pub fn safe_head_hash(&self) -> Option<B256> {
+        self.inner.read().safe_head.map(|h| h.block_info.hash)
+    }
+
+    /// Returns the finalized head block hash.
+    pub fn finalized_head_hash(&self) -> Option<B256> {
+        self.inner.read().finalized_head.map(|h| h.block_info.hash)
+    }
+
+    /// Returns `true` if the sync state has been initialized.
+    pub fn is_initialized(&self) -> bool {
+        let inner = self.inner.read();
+        inner.unsafe_head.is_some() && inner.safe_head.is_some() && inner.finalized_head.is_some()
+    }
+}

--- a/crates/shared/engine-ext/Cargo.toml
+++ b/crates/shared/engine-ext/Cargo.toml
@@ -12,6 +12,9 @@ repository.workspace = true
 workspace = true
 
 [dependencies]
+# base
+base-primitives = { path = "../primitives", features = ["engine"] }
+
 # kona
 kona-protocol.workspace = true
 

--- a/crates/shared/engine-ext/src/api.rs
+++ b/crates/shared/engine-ext/src/api.rs
@@ -1,0 +1,213 @@
+//! [`EngineApiClient`] trait implementation for [`InProcessEngineClient`].
+
+use alloy_primitives::B256;
+use alloy_rpc_types_engine::{
+    ClientCode, ClientVersionV1, ExecutionPayloadBodiesV1, ExecutionPayloadEnvelopeV2,
+    ExecutionPayloadInputV2, ExecutionPayloadV3, ForkchoiceState, ForkchoiceUpdated, PayloadId,
+    PayloadStatus,
+};
+use base_primitives::{EngineApiClient, EngineApiError, EngineApiResult};
+use op_alloy_rpc_types_engine::{
+    OpExecutionData, OpExecutionPayloadEnvelopeV3, OpExecutionPayloadEnvelopeV4,
+    OpExecutionPayloadV4, OpPayloadAttributes, ProtocolVersion,
+};
+use reth_payload_primitives::EngineApiMessageVersion;
+use tracing::debug;
+
+use crate::InProcessEngineClient;
+
+impl<P: Send + Sync> EngineApiClient for InProcessEngineClient<P> {
+    async fn new_payload_v2(
+        &self,
+        payload: ExecutionPayloadInputV2,
+    ) -> EngineApiResult<PayloadStatus> {
+        debug!("Sending new_payload_v2 via channel");
+        let execution_data = OpExecutionData::v2(payload);
+        self.consensus_handle
+            .new_payload(execution_data)
+            .await
+            .map_err(|e| EngineApiError::new(e.to_string()))
+    }
+
+    async fn new_payload_v3(
+        &self,
+        payload: ExecutionPayloadV3,
+        parent_beacon_block_root: B256,
+    ) -> EngineApiResult<PayloadStatus> {
+        debug!(
+            block_hash = ?payload.payload_inner.payload_inner.block_hash,
+            "Sending new_payload_v3 via channel"
+        );
+        // OP Stack chains always use empty versioned hashes
+        let versioned_hashes: Vec<B256> = vec![];
+        let execution_data =
+            OpExecutionData::v3(payload, versioned_hashes, parent_beacon_block_root);
+        self.consensus_handle
+            .new_payload(execution_data)
+            .await
+            .map_err(|e| EngineApiError::new(e.to_string()))
+    }
+
+    async fn new_payload_v4(
+        &self,
+        payload: OpExecutionPayloadV4,
+        parent_beacon_block_root: B256,
+    ) -> EngineApiResult<PayloadStatus> {
+        debug!(
+            block_hash = ?payload.payload_inner.payload_inner.payload_inner.block_hash,
+            "Sending new_payload_v4 via channel"
+        );
+        // OP Stack chains always use empty versioned hashes and execution requests
+        let versioned_hashes: Vec<B256> = vec![];
+        let execution_requests = Default::default();
+        let execution_data = OpExecutionData::v4(
+            payload,
+            versioned_hashes,
+            parent_beacon_block_root,
+            execution_requests,
+        );
+        self.consensus_handle
+            .new_payload(execution_data)
+            .await
+            .map_err(|e| EngineApiError::new(e.to_string()))
+    }
+
+    async fn fork_choice_updated_v2(
+        &self,
+        fork_choice_state: ForkchoiceState,
+        payload_attributes: Option<OpPayloadAttributes>,
+    ) -> EngineApiResult<ForkchoiceUpdated> {
+        debug!(head = ?fork_choice_state.head_block_hash, "Sending fork_choice_updated_v2 via channel");
+        let result = self
+            .consensus_handle
+            .fork_choice_updated(fork_choice_state, payload_attributes, EngineApiMessageVersion::V2)
+            .await
+            .map_err(|e| EngineApiError::new(e.to_string()))?;
+
+        // Update the forkchoice tracker with the new state.
+        self.forkchoice.update(fork_choice_state);
+
+        Ok(result)
+    }
+
+    async fn fork_choice_updated_v3(
+        &self,
+        fork_choice_state: ForkchoiceState,
+        payload_attributes: Option<OpPayloadAttributes>,
+    ) -> EngineApiResult<ForkchoiceUpdated> {
+        debug!(head = ?fork_choice_state.head_block_hash, "Sending fork_choice_updated_v3 via channel");
+        let result = self
+            .consensus_handle
+            .fork_choice_updated(fork_choice_state, payload_attributes, EngineApiMessageVersion::V3)
+            .await
+            .map_err(|e| EngineApiError::new(e.to_string()))?;
+
+        // Update the forkchoice tracker with the new state.
+        self.forkchoice.update(fork_choice_state);
+
+        Ok(result)
+    }
+
+    async fn get_payload_v2(
+        &self,
+        payload_id: PayloadId,
+    ) -> EngineApiResult<ExecutionPayloadEnvelopeV2> {
+        debug!(%payload_id, "Resolving payload via PayloadStore");
+        self.payload_store
+            .resolve(payload_id)
+            .await
+            .ok_or_else(|| EngineApiError::new(format!("payload not found: {payload_id}")))?
+            .map(Into::into)
+            .map_err(|e| EngineApiError::new(format!("payload resolution failed: {e}")))
+    }
+
+    async fn get_payload_v3(
+        &self,
+        payload_id: PayloadId,
+    ) -> EngineApiResult<OpExecutionPayloadEnvelopeV3> {
+        debug!(%payload_id, "Resolving payload via PayloadStore");
+        self.payload_store
+            .resolve(payload_id)
+            .await
+            .ok_or_else(|| EngineApiError::new(format!("payload not found: {payload_id}")))?
+            .map(Into::into)
+            .map_err(|e| EngineApiError::new(format!("payload resolution failed: {e}")))
+    }
+
+    async fn get_payload_v4(
+        &self,
+        payload_id: PayloadId,
+    ) -> EngineApiResult<OpExecutionPayloadEnvelopeV4> {
+        debug!(%payload_id, "Resolving payload via PayloadStore");
+        self.payload_store
+            .resolve(payload_id)
+            .await
+            .ok_or_else(|| EngineApiError::new(format!("payload not found: {payload_id}")))?
+            .map(Into::into)
+            .map_err(|e| EngineApiError::new(format!("payload resolution failed: {e}")))
+    }
+
+    async fn get_payload_bodies_by_hash_v1(
+        &self,
+        _block_hashes: Vec<B256>,
+    ) -> EngineApiResult<ExecutionPayloadBodiesV1> {
+        // TODO: Implement via provider
+        Err(EngineApiError::new(
+            "get_payload_bodies_by_hash_v1 not yet implemented for in-process client",
+        ))
+    }
+
+    async fn get_payload_bodies_by_range_v1(
+        &self,
+        _start: u64,
+        _count: u64,
+    ) -> EngineApiResult<ExecutionPayloadBodiesV1> {
+        // TODO: Implement via provider
+        Err(EngineApiError::new(
+            "get_payload_bodies_by_range_v1 not yet implemented for in-process client",
+        ))
+    }
+
+    async fn get_client_version_v1(
+        &self,
+        _client_version: ClientVersionV1,
+    ) -> EngineApiResult<Vec<ClientVersionV1>> {
+        // Return a basic client version for in-process communication
+        // We use RH (Reth) since Base is built on top of Reth
+        Ok(vec![ClientVersionV1 {
+            code: ClientCode::RH,
+            name: "base-node".to_string(),
+            version: env!("CARGO_PKG_VERSION").to_string(),
+            commit: "in-process".to_string(),
+        }])
+    }
+
+    async fn signal_superchain_v1(
+        &self,
+        _recommended: ProtocolVersion,
+        required: ProtocolVersion,
+    ) -> EngineApiResult<ProtocolVersion> {
+        // For in-process communication, we just echo back the required version
+        // as we're always in sync with ourselves
+        Ok(required)
+    }
+
+    async fn exchange_capabilities(
+        &self,
+        _capabilities: Vec<String>,
+    ) -> EngineApiResult<Vec<String>> {
+        // Return the capabilities supported by this in-process client
+        Ok(vec![
+            "engine_newPayloadV2".to_string(),
+            "engine_newPayloadV3".to_string(),
+            "engine_newPayloadV4".to_string(),
+            "engine_forkchoiceUpdatedV2".to_string(),
+            "engine_forkchoiceUpdatedV3".to_string(),
+            "engine_getPayloadV2".to_string(),
+            "engine_getPayloadV3".to_string(),
+            "engine_getPayloadV4".to_string(),
+            "engine_getClientVersionV1".to_string(),
+            "engine_signalSuperchainV1".to_string(),
+        ])
+    }
+}

--- a/crates/shared/engine-ext/src/client.rs
+++ b/crates/shared/engine-ext/src/client.rs
@@ -4,10 +4,16 @@ use reth_engine_primitives::ConsensusEngineHandle;
 use reth_optimism_node::OpEngineTypes;
 use reth_payload_builder::PayloadStore;
 
+use crate::ForkchoiceTracker;
+
 /// In-process engine client that bypasses RPC for direct channel communication.
 ///
 /// This client uses reth's internal [`ConsensusEngineHandle`] and [`PayloadStore`]
 /// to communicate with the engine, avoiding JSON-RPC serialization overhead.
+///
+/// # Type Parameters
+///
+/// * `P` - The provider type used for querying L2 chain state.
 ///
 /// # Architecture
 ///
@@ -19,9 +25,10 @@ use reth_payload_builder::PayloadStore;
 ///                                      │ (skipped)
 ///                                      ▼
 /// ┌─────────────────────────────────────────────────────────────────────────┐
-/// │                   InProcessEngineClient                                 │
+/// │                   InProcessEngineClient<P>                              │
 /// │    - new_payload(), fork_choice_updated() methods                       │
 /// │    - get_payload() via PayloadStore                                     │
+/// │    - l2_block_info_*() via Provider                                     │
 /// └─────────────────────────────────────────────────────────────────────────┘
 ///                                      │
 ///                                      │ unbounded channel
@@ -33,14 +40,18 @@ use reth_payload_builder::PayloadStore;
 /// └─────────────────────────────────────────────────────────────────────────┘
 /// ```
 #[derive(Debug)]
-pub struct InProcessEngineClient {
+pub struct InProcessEngineClient<P> {
     /// Handle for standard newPayload/FCU calls.
     pub(crate) consensus_handle: ConsensusEngineHandle<OpEngineTypes>,
     /// Store for retrieving built payloads.
     pub(crate) payload_store: PayloadStore<OpEngineTypes>,
+    /// Provider for querying L2 chain state.
+    pub(crate) provider: P,
+    /// Forkchoice state tracker.
+    pub(crate) forkchoice: ForkchoiceTracker,
 }
 
-impl InProcessEngineClient {
+impl<P> InProcessEngineClient<P> {
     /// Creates a new in-process engine client.
     ///
     /// # Arguments
@@ -49,11 +60,25 @@ impl InProcessEngineClient {
     ///   (from `AddOnsContext::beacon_engine_handle`)
     /// * `payload_store` - Store for built payloads
     ///   (from `PayloadStore::new(ctx.node.payload_builder_handle())`)
-    pub const fn new(
+    /// * `provider` - Provider for querying L2 chain state
+    pub fn new(
         consensus_handle: ConsensusEngineHandle<OpEngineTypes>,
         payload_store: PayloadStore<OpEngineTypes>,
+        provider: P,
     ) -> Self {
-        Self { consensus_handle, payload_store }
+        Self { consensus_handle, payload_store, provider, forkchoice: ForkchoiceTracker::new() }
+    }
+
+    /// Creates a new in-process engine client with an existing forkchoice tracker.
+    ///
+    /// This is useful when you want to share the forkchoice tracker with other components.
+    pub const fn with_forkchoice(
+        consensus_handle: ConsensusEngineHandle<OpEngineTypes>,
+        payload_store: PayloadStore<OpEngineTypes>,
+        provider: P,
+        forkchoice: ForkchoiceTracker,
+    ) -> Self {
+        Self { consensus_handle, payload_store, provider, forkchoice }
     }
 
     /// Returns a reference to the consensus engine handle.
@@ -66,8 +91,21 @@ impl InProcessEngineClient {
         &self.payload_store
     }
 
+    /// Returns a reference to the provider.
+    pub const fn provider(&self) -> &P {
+        &self.provider
+    }
+
+    /// Returns a reference to the forkchoice tracker.
+    pub const fn forkchoice(&self) -> &ForkchoiceTracker {
+        &self.forkchoice
+    }
+
     /// Consumes the client and returns the inner components.
-    pub fn into_parts(self) -> (ConsensusEngineHandle<OpEngineTypes>, PayloadStore<OpEngineTypes>) {
-        (self.consensus_handle, self.payload_store)
+    pub fn into_parts(
+        self,
+    ) -> (ConsensusEngineHandle<OpEngineTypes>, PayloadStore<OpEngineTypes>, P, ForkchoiceTracker)
+    {
+        (self.consensus_handle, self.payload_store, self.provider, self.forkchoice)
     }
 }

--- a/crates/shared/engine-ext/src/error.rs
+++ b/crates/shared/engine-ext/src/error.rs
@@ -16,4 +16,16 @@ pub enum EngineError {
     /// Engine communication failed.
     #[error("engine error: {0}")]
     Engine(String),
+
+    /// Provider query failed.
+    #[error("provider error: {0}")]
+    Provider(String),
+
+    /// Block not found during lookup.
+    #[error("block not found: {0}")]
+    BlockNotFound(String),
+
+    /// Forkchoice state has not been initialized.
+    #[error("forkchoice state not initialized")]
+    ForkchoiceNotInitialized,
 }

--- a/crates/shared/engine-ext/src/lib.rs
+++ b/crates/shared/engine-ext/src/lib.rs
@@ -11,8 +11,11 @@ pub use error::EngineError;
 
 mod forkchoice;
 mod payload;
+mod query;
 
+mod state;
 // Re-export types needed to construct the client
 pub use reth_engine_primitives::ConsensusEngineHandle;
 pub use reth_optimism_node::OpEngineTypes;
 pub use reth_payload_builder::PayloadStore;
+pub use state::ForkchoiceTracker;

--- a/crates/shared/engine-ext/src/lib.rs
+++ b/crates/shared/engine-ext/src/lib.rs
@@ -3,6 +3,8 @@
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
 
+mod api;
+
 mod client;
 pub use client::InProcessEngineClient;
 

--- a/crates/shared/engine-ext/src/payload.rs
+++ b/crates/shared/engine-ext/src/payload.rs
@@ -14,7 +14,7 @@ use tracing::debug;
 
 use crate::{EngineError, InProcessEngineClient};
 
-impl InProcessEngineClient {
+impl<P> InProcessEngineClient<P> {
     /// Sends a new payload to the execution layer (Engine API v2).
     pub async fn new_payload_v2(
         &self,

--- a/crates/shared/engine-ext/src/query.rs
+++ b/crates/shared/engine-ext/src/query.rs
@@ -1,0 +1,101 @@
+//! Query methods for L2 chain state.
+
+use alloy_eips::BlockNumHash;
+use alloy_primitives::B256;
+use kona_protocol::{BlockInfo, L2BlockInfo};
+use reth_primitives_traits::{AlloyBlockHeader as _, SealedHeader};
+use reth_provider::{BlockNumReader, ProviderError};
+use reth_storage_api::{BlockHashReader, HeaderProvider};
+use tracing::trace;
+
+use crate::{EngineError, InProcessEngineClient};
+
+impl<P> InProcessEngineClient<P>
+where
+    P: BlockNumReader + BlockHashReader + HeaderProvider,
+{
+    /// Returns the L2 block info for a given block number.
+    pub fn l2_block_info_by_number(&self, number: u64) -> Result<L2BlockInfo, EngineError> {
+        trace!(number, "Querying L2 block info by number");
+
+        let header = self
+            .provider
+            .header_by_number(number)
+            .map_err(|e: ProviderError| EngineError::Provider(e.to_string()))?
+            .ok_or_else(|| EngineError::BlockNotFound(format!("block number {number}")))?;
+
+        let sealed = SealedHeader::seal_slow(header);
+
+        let parent_header = if number > 0 {
+            self.provider
+                .header_by_number(number - 1)
+                .map_err(|e: ProviderError| EngineError::Provider(e.to_string()))?
+                .map(SealedHeader::seal_slow)
+        } else {
+            None
+        };
+
+        // Extract L1 origin from the parent block's timestamp (if available).
+        // In OP Stack, the L1 origin is encoded in the L1 attributes transaction.
+        // For simplicity, we use the parent block info as a placeholder.
+        let l1_origin_num = parent_header.as_ref().map(|h| h.number()).unwrap_or(0);
+        let l1_origin_hash = parent_header.as_ref().map(|h| h.hash()).unwrap_or_default();
+
+        Ok(L2BlockInfo {
+            block_info: BlockInfo {
+                hash: sealed.hash(),
+                number: sealed.number(),
+                parent_hash: sealed.parent_hash(),
+                timestamp: sealed.timestamp(),
+            },
+            l1_origin: BlockNumHash { number: l1_origin_num, hash: l1_origin_hash },
+            seq_num: 0, // Sequence number would be extracted from L1 attributes transaction.
+        })
+    }
+
+    /// Returns the L2 block info for the latest block.
+    pub fn l2_block_info_latest(&self) -> Result<L2BlockInfo, EngineError> {
+        let number =
+            self.provider.last_block_number().map_err(|e| EngineError::Provider(e.to_string()))?;
+        self.l2_block_info_by_number(number)
+    }
+
+    /// Returns the L2 block info for a given block hash.
+    pub fn l2_block_info_by_hash(&self, hash: B256) -> Result<L2BlockInfo, EngineError> {
+        trace!(?hash, "Querying L2 block info by hash");
+
+        let number = self
+            .provider
+            .block_number(hash)
+            .map_err(|e| EngineError::Provider(e.to_string()))?
+            .ok_or_else(|| EngineError::BlockNotFound(format!("block hash {hash}")))?;
+
+        self.l2_block_info_by_number(number)
+    }
+
+    /// Returns the L2 safe head block info.
+    ///
+    /// This relies on the forkchoice tracker being updated with FCU responses.
+    pub fn l2_safe_head(&self) -> Result<L2BlockInfo, EngineError> {
+        let safe_hash = self.forkchoice.safe_head().ok_or(EngineError::ForkchoiceNotInitialized)?;
+        self.l2_block_info_by_hash(safe_hash)
+    }
+
+    /// Returns the L2 finalized head block info.
+    ///
+    /// This relies on the forkchoice tracker being updated with FCU responses.
+    pub fn l2_finalized_head(&self) -> Result<L2BlockInfo, EngineError> {
+        let finalized_hash =
+            self.forkchoice.finalized_head().ok_or(EngineError::ForkchoiceNotInitialized)?;
+        self.l2_block_info_by_hash(finalized_hash)
+    }
+
+    /// Returns the L2 unsafe head block info.
+    ///
+    /// This relies on the forkchoice tracker being updated with FCU responses.
+    pub fn l2_unsafe_head(&self) -> Result<L2BlockInfo, EngineError> {
+        let unsafe_hash =
+            self.forkchoice.unsafe_head().ok_or(EngineError::ForkchoiceNotInitialized)?;
+        self.l2_block_info_by_hash(unsafe_hash)
+    }
+}

--- a/crates/shared/engine-ext/src/state.rs
+++ b/crates/shared/engine-ext/src/state.rs
@@ -1,0 +1,67 @@
+//! Forkchoice state tracking.
+
+use std::sync::Arc;
+
+use alloy_primitives::B256;
+use alloy_rpc_types_engine::ForkchoiceState;
+use parking_lot::RwLock;
+
+/// Tracks the current forkchoice state (unsafe, safe, finalized heads).
+///
+/// This struct maintains the latest forkchoice state received from FCU responses,
+/// allowing query methods to return the current L2 chain state.
+#[derive(Debug, Clone)]
+pub struct ForkchoiceTracker {
+    inner: Arc<RwLock<ForkchoiceStateInner>>,
+}
+
+/// Inner state for the forkchoice tracker.
+#[derive(Debug, Default)]
+struct ForkchoiceStateInner {
+    /// The current forkchoice state.
+    state: Option<ForkchoiceState>,
+}
+
+impl Default for ForkchoiceTracker {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl ForkchoiceTracker {
+    /// Creates a new forkchoice tracker.
+    pub fn new() -> Self {
+        Self { inner: Arc::new(RwLock::new(ForkchoiceStateInner::default())) }
+    }
+
+    /// Updates the forkchoice state.
+    pub fn update(&self, state: ForkchoiceState) {
+        let mut inner = self.inner.write();
+        inner.state = Some(state);
+    }
+
+    /// Returns the current forkchoice state, if set.
+    pub fn state(&self) -> Option<ForkchoiceState> {
+        self.inner.read().state
+    }
+
+    /// Returns the unsafe head block hash.
+    pub fn unsafe_head(&self) -> Option<B256> {
+        self.inner.read().state.map(|s| s.head_block_hash)
+    }
+
+    /// Returns the safe head block hash.
+    pub fn safe_head(&self) -> Option<B256> {
+        self.inner.read().state.map(|s| s.safe_block_hash)
+    }
+
+    /// Returns the finalized head block hash.
+    pub fn finalized_head(&self) -> Option<B256> {
+        self.inner.read().state.map(|s| s.finalized_block_hash)
+    }
+
+    /// Returns `true` if the forkchoice state has been initialized.
+    pub fn is_initialized(&self) -> bool {
+        self.inner.read().state.is_some()
+    }
+}

--- a/crates/shared/primitives/Cargo.toml
+++ b/crates/shared/primitives/Cargo.toml
@@ -28,13 +28,10 @@ op-alloy-rpc-types = { workspace = true, optional = true }
 
 # Engine API dependencies
 alloy-provider = { workspace = true, optional = true }
-alloy-transport = { workspace = true, optional = true }
-alloy-transport-http = { workspace = true, optional = true }
 alloy-rpc-types-engine = { workspace = true, optional = true }
 alloy-rpc-types-eth = { workspace = true, optional = true }
-op-alloy-provider = { workspace = true, optional = true }
 kona-genesis = { workspace = true, optional = true }
-kona-engine = { workspace = true, optional = true }
+op-alloy-rpc-types-engine = { workspace = true, optional = true }
 
 [features]
 default = []
@@ -44,12 +41,9 @@ engine = [
 	"dep:alloy-provider",
 	"dep:alloy-rpc-types-engine",
 	"dep:alloy-rpc-types-eth",
-	"dep:alloy-transport",
-	"dep:alloy-transport-http",
-	"dep:kona-engine",
 	"dep:kona-genesis",
 	"dep:op-alloy-network",
-	"dep:op-alloy-provider",
+	"dep:op-alloy-rpc-types-engine",
 ]
 test-utils = [
 	"dep:alloy-consensus",
@@ -65,5 +59,4 @@ test-utils = [
 	"dep:op-alloy-network",
 	"dep:op-alloy-rpc-types",
 	"dep:serde_json",
-	"kona-engine?/test-utils",
 ]

--- a/crates/shared/primitives/src/engine.rs
+++ b/crates/shared/primitives/src/engine.rs
@@ -6,7 +6,7 @@
 //! - [`BlockProvider`] - L1 and L2 block fetching
 //! - [`ProofProvider`] - Account and storage proof retrieval
 //! - [`LegacyPayloadSupport`] - Legacy v1 payload submission
-//! - [`DirectEngineApi`] - Composed trait combining all of the above with [`OpEngineApi`]
+//! - [`DirectEngineApi`] - Composed trait combining all of the above with [`EngineApiClient`]
 //!
 //! The trait composition follows the pattern established by kona's `EngineClient`
 //! trait, enabling flexible implementation where components can be used independently
@@ -15,19 +15,56 @@
 use alloy_eips::BlockId;
 use alloy_primitives::{Address, B256};
 use alloy_provider::{EthGetBlock, Network, RpcWithBlock, network::Ethereum};
-use alloy_rpc_types_engine::{ExecutionPayloadV1, PayloadStatus};
+use alloy_rpc_types_engine::{
+    ClientVersionV1, ExecutionPayloadBodiesV1, ExecutionPayloadEnvelopeV2, ExecutionPayloadInputV2,
+    ExecutionPayloadV1, ExecutionPayloadV3, ForkchoiceState, ForkchoiceUpdated, PayloadId,
+    PayloadStatus,
+};
 /// Response type for EIP-1186 account proofs.
 ///
 /// Re-exported from `alloy_rpc_types_eth` for convenience.
 pub use alloy_rpc_types_eth::EIP1186AccountProofResponse;
-use alloy_transport::TransportResult;
-use kona_engine::HyperAuthClient;
 use kona_genesis::RollupConfig;
 use op_alloy_network::Optimism;
-use op_alloy_provider::ext::engine::OpEngineApi;
+use op_alloy_rpc_types_engine::{
+    OpExecutionPayloadEnvelopeV3, OpExecutionPayloadEnvelopeV4, OpExecutionPayloadV4,
+    OpPayloadAttributes, ProtocolVersion,
+};
 
 /// A storage key for proof queries.
 pub type StorageKey = B256;
+
+// ============================================================================
+// EngineApiError
+// ============================================================================
+
+/// Engine API client result type.
+pub type EngineApiResult<T> = Result<T, EngineApiError>;
+
+/// Engine API error type.
+///
+/// This is a transport-agnostic error type that can wrap errors from different
+/// transport implementations (HTTP, in-process channels, etc.).
+#[derive(Debug, Clone)]
+pub struct EngineApiError {
+    /// The error message.
+    pub message: String,
+}
+
+impl std::fmt::Display for EngineApiError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.message)
+    }
+}
+
+impl std::error::Error for EngineApiError {}
+
+impl EngineApiError {
+    /// Creates a new engine API error.
+    pub fn new(message: impl Into<String>) -> Self {
+        Self { message: message.into() }
+    }
+}
 
 // ============================================================================
 // RollupConfigProvider
@@ -179,7 +216,7 @@ pub trait ProofProvider {
 ///     println!("Payload status: {:?}", status);
 /// }
 /// ```
-pub trait LegacyPayloadSupport {
+pub trait LegacyPayloadSupport: Send + Sync {
     /// Sends the given payload to the execution layer client (Paris fork, v1).
     ///
     /// This is the legacy payload submission method from the Paris (Merge) fork.
@@ -196,7 +233,116 @@ pub trait LegacyPayloadSupport {
     fn new_payload_v1(
         &self,
         payload: ExecutionPayloadV1,
-    ) -> impl std::future::Future<Output = TransportResult<PayloadStatus>> + Send;
+    ) -> impl std::future::Future<Output = EngineApiResult<PayloadStatus>> + Send;
+}
+
+// ============================================================================
+// EngineApiClient
+// ============================================================================
+
+/// Transport-agnostic Engine API client trait.
+///
+/// This trait provides the core Engine API methods without requiring a specific
+/// transport implementation. It mirrors [`op_alloy_provider::ext::engine::OpEngineApi`]
+/// but uses a generic error type instead of `TransportResult`.
+///
+/// # Example
+///
+/// ```ignore
+/// use base_primitives::EngineApiClient;
+///
+/// async fn submit_payload<E: EngineApiClient>(engine: &E, payload: ExecutionPayloadV3) {
+///     let status = engine.new_payload_v3(payload, parent_root).await?;
+///     println!("Payload status: {:?}", status);
+/// }
+/// ```
+pub trait EngineApiClient: Send + Sync {
+    /// Sends the given payload to the execution layer client (Engine API v2).
+    fn new_payload_v2(
+        &self,
+        payload: ExecutionPayloadInputV2,
+    ) -> impl std::future::Future<Output = EngineApiResult<PayloadStatus>> + Send;
+
+    /// Sends the given payload to the execution layer client (Engine API v3).
+    ///
+    /// For OP Stack chains, versioned hashes are always empty.
+    fn new_payload_v3(
+        &self,
+        payload: ExecutionPayloadV3,
+        parent_beacon_block_root: B256,
+    ) -> impl std::future::Future<Output = EngineApiResult<PayloadStatus>> + Send;
+
+    /// Sends the given payload to the execution layer client (Engine API v4).
+    fn new_payload_v4(
+        &self,
+        payload: OpExecutionPayloadV4,
+        parent_beacon_block_root: B256,
+    ) -> impl std::future::Future<Output = EngineApiResult<PayloadStatus>> + Send;
+
+    /// Updates the fork choice state (Engine API v2).
+    fn fork_choice_updated_v2(
+        &self,
+        fork_choice_state: ForkchoiceState,
+        payload_attributes: Option<OpPayloadAttributes>,
+    ) -> impl std::future::Future<Output = EngineApiResult<ForkchoiceUpdated>> + Send;
+
+    /// Updates the fork choice state (Engine API v3).
+    fn fork_choice_updated_v3(
+        &self,
+        fork_choice_state: ForkchoiceState,
+        payload_attributes: Option<OpPayloadAttributes>,
+    ) -> impl std::future::Future<Output = EngineApiResult<ForkchoiceUpdated>> + Send;
+
+    /// Retrieves an execution payload from a previously started build process (v2).
+    fn get_payload_v2(
+        &self,
+        payload_id: PayloadId,
+    ) -> impl std::future::Future<Output = EngineApiResult<ExecutionPayloadEnvelopeV2>> + Send;
+
+    /// Retrieves an execution payload from a previously started build process (v3).
+    fn get_payload_v3(
+        &self,
+        payload_id: PayloadId,
+    ) -> impl std::future::Future<Output = EngineApiResult<OpExecutionPayloadEnvelopeV3>> + Send;
+
+    /// Retrieves an execution payload from a previously started build process (v4).
+    fn get_payload_v4(
+        &self,
+        payload_id: PayloadId,
+    ) -> impl std::future::Future<Output = EngineApiResult<OpExecutionPayloadEnvelopeV4>> + Send;
+
+    /// Returns the execution payload bodies by the given hash.
+    fn get_payload_bodies_by_hash_v1(
+        &self,
+        block_hashes: Vec<B256>,
+    ) -> impl std::future::Future<Output = EngineApiResult<ExecutionPayloadBodiesV1>> + Send;
+
+    /// Returns the execution payload bodies by the range starting at `start`, containing `count`
+    /// blocks.
+    fn get_payload_bodies_by_range_v1(
+        &self,
+        start: u64,
+        count: u64,
+    ) -> impl std::future::Future<Output = EngineApiResult<ExecutionPayloadBodiesV1>> + Send;
+
+    /// Returns the execution client version information.
+    fn get_client_version_v1(
+        &self,
+        client_version: ClientVersionV1,
+    ) -> impl std::future::Future<Output = EngineApiResult<Vec<ClientVersionV1>>> + Send;
+
+    /// Signals superchain information to the Engine.
+    fn signal_superchain_v1(
+        &self,
+        recommended: ProtocolVersion,
+        required: ProtocolVersion,
+    ) -> impl std::future::Future<Output = EngineApiResult<ProtocolVersion>> + Send;
+
+    /// Returns the list of Engine API methods supported by the execution layer client software.
+    fn exchange_capabilities(
+        &self,
+        capabilities: Vec<String>,
+    ) -> impl std::future::Future<Output = EngineApiResult<Vec<String>>> + Send;
 }
 
 // ============================================================================
@@ -206,8 +352,8 @@ pub trait LegacyPayloadSupport {
 /// Direct Engine API trait that composes all engine capabilities.
 ///
 /// This trait combines:
-/// - [`OpEngineApi`] - Core OP Stack Engine API methods (new_payload_v2/v3/v4,
-///   fork_choice_updated_v2/v3, get_payload_v2/v3/v4, etc.)
+/// - [`EngineApiClient`] - Core Engine API methods (new_payload, fork_choice_updated,
+///   get_payload, etc.)
 /// - [`RollupConfigProvider`] - Access to rollup configuration
 /// - [`BlockProvider`] - L1 and L2 block fetching
 /// - [`ProofProvider`] - Account and storage proof retrieval
@@ -226,8 +372,8 @@ pub trait LegacyPayloadSupport {
 ///     // Query L2 block (from BlockProvider)
 ///     let block = engine.get_l2_block(BlockId::latest()).await;
 ///
-///     // Use inherited OpEngineApi methods
-///     let status = engine.new_payload_v3(payload, parent_root).await;
+///     // Use EngineApiClient methods
+///     let status = engine.new_payload_v3(payload, parent_root).await?;
 /// }
 /// ```
 ///
@@ -240,25 +386,17 @@ pub trait LegacyPayloadSupport {
 /// - Derivation engines that process L1 data
 /// - Validation engines that verify state transitions
 pub trait DirectEngineApi:
-    OpEngineApi<Optimism, alloy_transport_http::Http<HyperAuthClient>>
-    + RollupConfigProvider
-    + BlockProvider
-    + ProofProvider
-    + LegacyPayloadSupport
-    + Send
-    + Sync
+    EngineApiClient + RollupConfigProvider + BlockProvider + ProofProvider + LegacyPayloadSupport
 {
 }
 
 // Blanket implementation for any type that implements all component traits
 impl<T> DirectEngineApi for T where
-    T: OpEngineApi<Optimism, alloy_transport_http::Http<HyperAuthClient>>
+    T: EngineApiClient
         + RollupConfigProvider
         + BlockProvider
         + ProofProvider
         + LegacyPayloadSupport
-        + Send
-        + Sync
 {
 }
 
@@ -285,11 +423,8 @@ const _: () = {
     /// Asserts that `T: DirectEngineApi` implies `T: LegacyPayloadSupport`.
     const fn assert_implies_legacy_payload_support<T: DirectEngineApi + LegacyPayloadSupport>() {}
 
-    /// Asserts that `T: DirectEngineApi` implies `T: OpEngineApi`.
-    const fn assert_implies_op_engine_api<
-        T: DirectEngineApi + OpEngineApi<Optimism, alloy_transport_http::Http<HyperAuthClient>>,
-    >() {
-    }
+    /// Asserts that `T: DirectEngineApi` implies `T: EngineApiClient`.
+    const fn assert_implies_engine_api_client<T: DirectEngineApi + EngineApiClient>() {}
 
     /// Asserts that `T: DirectEngineApi` implies `T: Send`.
     const fn assert_implies_send<T: DirectEngineApi + Send>() {}
@@ -306,7 +441,7 @@ const _: () = {
         assert_implies_block_provider::<T>();
         assert_implies_proof_provider::<T>();
         assert_implies_legacy_payload_support::<T>();
-        assert_implies_op_engine_api::<T>();
+        assert_implies_engine_api_client::<T>();
         assert_implies_send::<T>();
         assert_implies_sync::<T>();
     }

--- a/crates/shared/primitives/src/lib.rs
+++ b/crates/shared/primitives/src/lib.rs
@@ -7,8 +7,8 @@
 pub mod engine;
 #[cfg(feature = "engine")]
 pub use engine::{
-    BlockProvider, DirectEngineApi, EIP1186AccountProofResponse, LegacyPayloadSupport,
-    ProofProvider, RollupConfigProvider, StorageKey,
+    BlockProvider, DirectEngineApi, EIP1186AccountProofResponse, EngineApiClient, EngineApiError,
+    EngineApiResult, LegacyPayloadSupport, ProofProvider, RollupConfigProvider, StorageKey,
 };
 
 #[cfg(feature = "test-utils")]


### PR DESCRIPTION
## Summary

> [!WARNING]
>
> Stacked ontop of #535 

This PR does two things.
- Extends `base-engine-ext` to provide l2 chain state queries.
- Creates a new `base-engine-actor` crate with a `DirectEngineActor` which implements kona's `NodeActor` trait.

> [!NOTE]
>
> Closes CHAIN-2842