### PR TITLE
fix: align eth RPC doc comments with canonical-first lookup

### DIFF
--- a/crates/client/flashblocks/src/rpc/eth.rs
+++ b/crates/client/flashblocks/src/rpc/eth.rs
@@ -48,7 +48,7 @@ pub trait EthApiOverride {
         full: bool,
     ) -> RpcResult<Option<RpcBlock<Optimism>>>;
 
-    /// Returns transaction receipt, checking flashblocks first.
+    /// Returns transaction receipt, checking canonical chain first, then flashblocks.
     #[method(name = "getTransactionReceipt")]
     async fn get_transaction_receipt(
         &self,
@@ -68,7 +68,7 @@ pub trait EthApiOverride {
         block_number: Option<BlockId>,
     ) -> RpcResult<U256>;
 
-    /// Returns transaction by hash, checking flashblocks first.
+    /// Returns transaction by hash, checking canonical chain first, then flashblocks.
     #[method(name = "getTransactionByHash")]
     async fn transaction_by_hash(
         &self,


### PR DESCRIPTION
The public RPC trait documentation claimed we check flashblocks first for transaction receipts and transactions, but the implementation intentionally checks the canonical chain first to avoid a race condition. This mismatch could mislead users and maintainers.
Updated the doc comments for getTransactionReceipt and getTransactionByHash to accurately describe the canonical‑first lookup behavior.