### PR TITLE
Fix minor wording in CONTRIBUTING and consensus README

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 Thanks for your interest in improving Base.
 
-This document will help you get started. **Do not let this document intimidate you**. It should be considered as a guide to help you navigate the process.
+This document will help you get started. **Do not let this document intimidate you**. It should be considered a guide to help you navigate the process.
 
 ## Ways to Contribute
 

--- a/bin/consensus/README.md
+++ b/bin/consensus/README.md
@@ -1,5 +1,5 @@
 # `base-consensus`
 
-The canonical entrypoint for the Base Stack.
+The canonical entry point for the Base Stack.
 
 Under the hood, `base-consensus` runs a [kona](https://github.com/ethereum-optimism/optimism/tree/develop/kona) node.


### PR DESCRIPTION

- Remove redundant preposition in CONTRIBUTING guide (“considered a guide”).
- Correct “entrypoint” to “entry point” in consensus README.