### PR TITLE
docs: fix incorrect type references in add_ons and README

### DIFF
--- a/crates/client/node/README.md
+++ b/crates/client/node/README.md
@@ -37,7 +37,7 @@ struct MyExtension {
 }
 
 impl BaseNodeExtension for MyExtension {
-    fn apply(self: Box<Self>, builder: OpBuilder) -> OpBuilder {
+    fn apply(self: Box<Self>, builder: BaseBuilder) -> BaseBuilder {
         // Apply custom wiring to the builder
         builder
     }

--- a/crates/client/node/src/add_ons.rs
+++ b/crates/client/node/src/add_ons.rs
@@ -91,7 +91,7 @@ where
     N: FullNodeComponents<Types: OpNodeTypes>,
     OpEthApiBuilder<NetworkT>: EthApiBuilder<N>,
 {
-    /// Build a [`OpAddOns`] using [`OpAddOnsBuilder`].
+    /// Build a [`OpAddOns`] using [`BaseAddOnsBuilder`].
     pub fn builder() -> BaseAddOnsBuilder<NetworkT> {
         BaseAddOnsBuilder::default()
     }


### PR DESCRIPTION
Doc comments referenced non-existent `OpAddOnsBuilder` and README example used wrong `OpBuilder` type, corrected to `BaseAddOnsBuilder` and `BaseBuilder` respectively.