### PR TITLE
fix(bin): Consensus Binary Logging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1926,7 +1926,6 @@ dependencies = [
  "rollup-boost",
  "strum 0.27.2",
  "tracing",
- "tracing-subscriber 0.3.22",
  "url",
  "vergen",
  "vergen-git2",

--- a/bin/consensus/Cargo.toml
+++ b/bin/consensus/Cargo.toml
@@ -43,7 +43,6 @@ strum.workspace = true
 
 # Tracing
 tracing.workspace = true
-tracing-subscriber = { workspace = true, features = ["fmt", "env-filter"] }
 
 # Metrics
 metrics.workspace = true

--- a/bin/consensus/src/cli.rs
+++ b/bin/consensus/src/cli.rs
@@ -75,8 +75,8 @@ pub struct Cli {
 impl Cli {
     /// Runs the CLI.
     pub fn run(self) -> eyre::Result<()> {
-        // Initialize telemetry - allow subcommands to customize the filter.
-        Self::init_logs(&self.global)?;
+        // Initialize logging from global arguments.
+        LogConfig::from(self.global.logging.clone()).init_tracing_subscriber()?;
 
         // Initialize unified metrics
         self.global.metrics.init_with(|| {
@@ -175,15 +175,5 @@ impl Cli {
         })?;
 
         Ok(())
-    }
-
-    /// Initializes the logging system based on global arguments.
-    pub fn init_logs(args: &GlobalArgs) -> eyre::Result<()> {
-        // Filter out discovery warnings since they're very very noisy.
-        let filter = tracing_subscriber::EnvFilter::from_default_env()
-            .add_directive("discv5=error".parse()?);
-
-        let config: LogConfig = args.logging.clone().into();
-        config.init_tracing_subscriber_with_filter(filter)
     }
 }

--- a/crates/shared/cli-utils/src/tracing.rs
+++ b/crates/shared/cli-utils/src/tracing.rs
@@ -73,10 +73,15 @@ impl LogConfig {
     /// Initialize the tracing subscriber with the configured options.
     ///
     /// This sets the global default subscriber. Should only be called once.
+    ///
+    /// Includes default noise suppression for overly verbose crates (e.g., `discv5=error`).
     pub fn init_tracing_subscriber(&self) -> eyre::Result<()> {
         // Build base filter from config, allowing env override
-        let filter =
-            EnvFilter::builder().with_default_directive(self.global_level.into()).from_env_lossy();
+        let filter = EnvFilter::builder()
+            .with_default_directive(self.global_level.into())
+            .from_env_lossy()
+            // Suppress noisy discovery logs by default
+            .add_directive("discv5=error".parse().expect("valid directive"));
 
         self.init_tracing_subscriber_with_filter(filter)
     }


### PR DESCRIPTION
## Summary

> [!WARNING]
>
> Stacked ontop of #549 

Fixes logging to use the cli-utils tracing logic which was being overridden by custom directive parsing in the binary.