### PR TITLE
docs: Add EIP references

### DIFF
--- a/docs/specs/access-lists.md
+++ b/docs/specs/access-lists.md
@@ -578,6 +578,7 @@ Increased flashblock size impacts propagation. Average overhead can be reasonabl
 
 - [EIP-7928: Block-Level Access Lists](https://eips.ethereum.org/EIPS/eip-7928) - The original BAL specification for Ethereum L1
 - [EIP-2930: Optional Access Lists](https://eips.ethereum.org/EIPS/eip-2930) - Transaction-level access lists
+- [EIP-2935: Block Hash Storage](https://eips.ethereum.org/EIPS/eip-2935) - Provides a mechanism for storing historical block hashes in state, used for L2 compatibility and OP Stack integration
 - [EIP-4895: Beacon Chain Push Withdrawals](https://eips.ethereum.org/EIPS/eip-4895) - Enables validator withdrawals from the Beacon Chain to the execution layer
 - [EIP-4788: Beacon Block Root in the EVM](https://eips.ethereum.org/EIPS/eip-4788) - Exposes the Beacon Chain block root to the EVM via a system contract
 - [EIP-7002: Execution Layer Triggerable Withdrawals](https://eips.ethereum.org/EIPS/eip-7002) - Allows validators to trigger withdrawals directly from the execution layer

--- a/docs/specs/access-lists.md
+++ b/docs/specs/access-lists.md
@@ -20,7 +20,7 @@ FAL adapts the BAL specification for chains that produce flashblocks—increment
 
 1. **Flashblock Delta Structure**: FAL operates on flashblock deltas that contain incremental changes, not complete canonical blocks
 2. **Metadata Storage**: FAL hash is stored in the flashblock metadata field, not a block header field
-3. **No Beacon Chain Features**: FAL omits EIP-4895 (withdrawals), EIP-4788 (beacon root), EIP-7002 (withdrawal requests), and EIP-7251 (consolidations)
+3. **No Beacon Chain Features**: FAL omits [EIP-4895](https://eips.ethereum.org/EIPS/eip-4895) (withdrawals), [EIP-4788](https://eips.ethereum.org/EIPS/eip-4788) (beacon root), [EIP-7002](https://eips.ethereum.org/EIPS/eip-7002) (withdrawal requests), and [EIP-7251](https://eips.ethereum.org/EIPS/eip-7251) (consolidations)
 
 ### Fee Distribution
 
@@ -143,7 +143,7 @@ It **MUST** include:
 
 Addresses with no state changes **MUST** still be present with empty change lists.
 
-Entries from an EIP-2930 access list **MUST NOT** be included automatically. Only addresses and storage slots that are actually touched or changed during execution are recorded.
+Entries from an [EIP-2930](https://eips.ethereum.org/EIPS/eip-2930) access list **MUST NOT** be included automatically. Only addresses and storage slots that are actually touched or changed during execution are recorded.
 
 ### Ordering and Determinism
 
@@ -578,6 +578,11 @@ Increased flashblock size impacts propagation. Average overhead can be reasonabl
 
 - [EIP-7928: Block-Level Access Lists](https://eips.ethereum.org/EIPS/eip-7928) - The original BAL specification for Ethereum L1
 - [EIP-2930: Optional Access Lists](https://eips.ethereum.org/EIPS/eip-2930) - Transaction-level access lists
+- [EIP-4895: Beacon Chain Push Withdrawals](https://eips.ethereum.org/EIPS/eip-4895) - Enables validator withdrawals from the Beacon Chain to the execution layer
+- [EIP-4788: Beacon Block Root in the EVM](https://eips.ethereum.org/EIPS/eip-4788) - Exposes the Beacon Chain block root to the EVM via a system contract
+- [EIP-7002: Execution Layer Triggerable Withdrawals](https://eips.ethereum.org/EIPS/eip-7002) - Allows validators to trigger withdrawals directly from the execution layer
+- [EIP-7251: Increase the MAX_EFFECTIVE_BALANCE](https://eips.ethereum.org/EIPS/eip-7251) - Increases the maximum effective balance for Ethereum validators
+- [EIP-7702: Set EOA Account Code](https://eips.ethereum.org/EIPS/eip-7702) - Allows externally owned accounts (EOAs) to temporarily set executable code
 - [OP Stack Specification](https://specs.optimism.io/) - OP Stack technical specifications
 
 ## Copyright

--- a/docs/specs/access-lists.md
+++ b/docs/specs/access-lists.md
@@ -243,7 +243,7 @@ The **L1 attributes transaction** (deposited transaction at index 0):
 
 Record system contract storage diffs of the **single** updated storage slot in the ring buffer.
 
-**OP Stack Note:** Block hash storage may use the same EIP-2935 mechanism or a modified version. Record whatever storage changes actually occur.
+**OP Stack Note:** Block hash storage may use the same [EIP-2935](https://specs.optimism.io/protocol/isthmus/derivation.html#eip-2935-contract-deployment) mechanism or a modified version. Record whatever storage changes actually occur. See [OP Stack Specification](https://eips.ethereum.org/EIPS/eip-2935?utm_source=chatgpt.com) for details on block hash storage implementation.
 
 ### Edge Cases (General, inherited from BAL)
 

--- a/docs/specs/access-lists.md
+++ b/docs/specs/access-lists.md
@@ -243,7 +243,7 @@ The **L1 attributes transaction** (deposited transaction at index 0):
 
 Record system contract storage diffs of the **single** updated storage slot in the ring buffer.
 
-**OP Stack Note:** Block hash storage may use the same [EIP-2935](https://specs.optimism.io/protocol/isthmus/derivation.html#eip-2935-contract-deployment) mechanism or a modified version. Record whatever storage changes actually occur. See [OP Stack Specification](https://eips.ethereum.org/EIPS/eip-2935?utm_source=chatgpt.com) for details on block hash storage implementation.
+**OP Stack Note:** Block hash storage may use the same [EIP-2935](https://eips.ethereum.org/EIPS/eip-2935) mechanism or a modified version. Record whatever storage changes actually occur.
 
 ### Edge Cases (General, inherited from BAL)
 


### PR DESCRIPTION
## **Changes:**
Added inline references to all relevant Ethereum EIPs mentioned in the document for clarity:

- EIP-7928: Block-Level Access Lists
- EIP-2930: Optional Access Lists
- EIP-4895: Beacon Chain Push Withdrawals
- EIP-4788: Beacon Block Root in the EVM
- EIP-7002: Execution Layer Triggerable Withdrawals
- EIP-7251: Increase the MAX_EFFECTIVE_BALANCE
- EIP-7702: Set EOA Account Code
- EIP-2935: Block Hash Storage

## **Why?**
- This improves the Access Lists specification by providing **clear references to all relevant sources**, allowing readers to explore the topic in more detail.
- It ensures consistency in the documentation style throughout the document.

## **Notes:**
The existing References section at the end of the document has been updated to include all mentioned EIPs and the OP Stack specification. After reading the article, this section helps readers quickly locate the original specifications and related materials for deeper study.