### PR TITLE
chore: demote bundle meter failed logs to debug in certain situations

### DIFF
--- a/crates/client/metering/src/rpc.rs
+++ b/crates/client/metering/src/rpc.rs
@@ -14,7 +14,7 @@ use reth_primitives_traits::SealedHeader;
 use reth_provider::{
     BlockReader, BlockReaderIdExt, ChainSpecProvider, HeaderProvider, StateProviderFactory,
 };
-use tracing::{error, info};
+use tracing::{debug, error, info};
 
 use crate::{
     MeterBlockResponse, PendingState, PendingTrieCache, block::meter_block, meter::meter_bundle,
@@ -187,7 +187,14 @@ where
             pending_state,
         )
         .map_err(|e| {
-            error!(error = %e, "Bundle metering failed");
+            // Sample error msg:
+            // Transaction $TX_HASH execution failed: EVM reported invalid transaction ($TX_HASH): nonce $EXPECTED_NONCE too high, expected $EXPECTED_NONCE"
+            let error_msg = e.to_string();
+            if error_msg.contains("nonce") {
+                debug!(error = %e, "Bundle metering failed");
+            } else {
+                error!(error = %e, "Bundle metering failed");
+            }
             jsonrpsee::types::ErrorObjectOwned::owned(
                 jsonrpsee::types::ErrorCode::InternalError.code(),
                 format!("Bundle metering failed: {}", e),


### PR DESCRIPTION
- Right now, every unsuccessful metering is logged as an error
- Because v0.3.0 isn't live yet on Mainnet that makes the meter simulation FB-aware, we're getting a ton of "nonce too high" issues and it's getting picked up in DataDog. 
- Since the "nonce too high" is largely addressed, we can demote it to debug
- Although it will be heavily sampled by DataDog, it will still be useful every so often to have a sample tx with this issue, instead of _every_ "nonce too high" issue being recorded