### PR TITLE
feat(bin): Unify Reth

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14306,10 +14306,22 @@ checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 name = "unified"
 version = "0.0.0"
 dependencies = [
+ "alloy-rpc-types-engine",
  "base-cli-utils",
+ "base-client-node",
  "clap",
  "eyre",
+ "futures-util",
  "metrics",
+ "reth-chainspec",
+ "reth-cli-util",
+ "reth-node-core",
+ "reth-optimism-chainspec",
+ "reth-optimism-cli",
+ "reth-optimism-node",
+ "tokio",
+ "tracing",
+ "url",
  "vergen",
  "vergen-git2",
 ]

--- a/bin/unified/Cargo.toml
+++ b/bin/unified/Cargo.toml
@@ -15,10 +15,30 @@ workspace = true
 [dependencies]
 # Workspace
 base-cli-utils.workspace = true
+base-client-node.workspace = true
+
+# reth
+reth-chainspec.workspace = true
+reth-optimism-node.workspace = true
+reth-optimism-cli.workspace = true
+reth-optimism-chainspec.workspace = true
+reth-node-core.workspace = true
+reth-cli-util.workspace = true
+
+# Alloy
+alloy-rpc-types-engine.workspace = true
+
+# Async
+tokio.workspace = true
+futures-util.workspace = true
 
 # CLI
 clap.workspace = true
 eyre.workspace = true
+url.workspace = true
+
+# Tracing
+tracing.workspace = true
 
 # Metrics
 metrics.workspace = true

--- a/bin/unified/src/cli.rs
+++ b/bin/unified/src/cli.rs
@@ -1,30 +1,17 @@
-//! Contains the CLI entry point for the Base unified binary.
+//! CLI arguments for the unified binary.
 
-use base_cli_utils::{CliStyles, GlobalArgs};
-use clap::Parser;
+use base_cli_utils::GlobalArgs;
+use clap::Args;
+use reth_optimism_node::args::RollupArgs;
 
-use crate::version;
-
-/// The Base Consensus CLI.
-#[derive(Parser, Clone, Debug)]
-#[command(
-    author,
-    version = version::SHORT_VERSION,
-    long_version = version::LONG_VERSION,
-    styles = CliStyles::init(),
-    about,
-    long_about = None
-)]
-pub struct Cli {
-    /// Global arguments for the Base Consensus CLI.
+/// CLI arguments for the unified binary.
+#[derive(Debug, Clone, Args)]
+pub struct UnifiedArgs {
+    /// Global logging and metrics arguments.
     #[command(flatten)]
     pub global: GlobalArgs,
-}
 
-impl Cli {
-    /// Runs the CLI.
-    pub fn run(self) -> eyre::Result<()> {
-        println!("Base Unified CLI");
-        Err(eyre::eyre!("Not yet implemented"))
-    }
+    /// Rollup arguments for the execution client.
+    #[command(flatten)]
+    pub rollup_args: RollupArgs,
 }

--- a/bin/unified/src/consensus.rs
+++ b/bin/unified/src/consensus.rs
@@ -1,0 +1,71 @@
+//! Consensus client wrapper.
+
+use std::{
+    fmt,
+    future::Future,
+    pin::Pin,
+    task::{Context, Poll},
+    time::Duration,
+};
+
+use futures_util::{FutureExt, future::BoxFuture};
+use tracing::info;
+
+use crate::engine::EngineEndpoint;
+
+/// Handle to a running consensus client.
+#[must_use = "Dropping the handle will stop the consensus client"]
+pub struct ConsensusHandle {
+    fut: BoxFuture<'static, eyre::Result<()>>,
+}
+
+impl fmt::Debug for ConsensusHandle {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ConsensusHandle").finish_non_exhaustive()
+    }
+}
+
+impl ConsensusHandle {
+    /// Creates a new [`ConsensusHandle`] from a future.
+    pub fn new(fut: impl Future<Output = eyre::Result<()>> + Send + 'static) -> Self {
+        Self { fut: fut.boxed() }
+    }
+}
+
+impl Future for ConsensusHandle {
+    type Output = eyre::Result<()>;
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        self.fut.as_mut().poll(cx)
+    }
+}
+
+/// Wrapper around the consensus client.
+#[derive(Debug, Clone)]
+pub struct Consensus {
+    engine_endpoint: EngineEndpoint,
+    chain_id: u64,
+}
+
+impl Consensus {
+    /// Creates a new [`Consensus`] instance.
+    pub const fn new(engine_endpoint: EngineEndpoint, chain_id: u64) -> Self {
+        Self { engine_endpoint, chain_id }
+    }
+
+    /// Runs the consensus client, returning a [`ConsensusHandle`].
+    pub fn run(self) -> ConsensusHandle {
+        ConsensusHandle::new(async move {
+            info!(
+                target: "unified",
+                endpoint = %self.engine_endpoint.url,
+                chain_id = %self.chain_id,
+                "[STUB] Consensus node is running"
+            );
+
+            loop {
+                tokio::time::sleep(Duration::from_secs(60)).await;
+            }
+        })
+    }
+}

--- a/bin/unified/src/engine.rs
+++ b/bin/unified/src/engine.rs
@@ -1,0 +1,59 @@
+//! Engine API endpoint configuration.
+
+use std::{net::SocketAddr, path::Path};
+
+use alloy_rpc_types_engine::JwtSecret;
+use eyre::Result;
+use reth_node_core::node_config::NodeConfig;
+use reth_optimism_chainspec::OpChainSpec;
+use tracing::info;
+use url::Url;
+
+/// Engine API endpoint with URL and JWT authentication.
+#[derive(Debug, Clone)]
+pub struct EngineEndpoint {
+    /// Engine API URL.
+    pub url: Url,
+    /// JWT secret for authentication.
+    pub jwt_secret: JwtSecret,
+}
+
+impl EngineEndpoint {
+    /// Extracts endpoint configuration from [`NodeConfig`].
+    pub fn from_reth_config(config: &NodeConfig<OpChainSpec>) -> Result<Self> {
+        let addr = SocketAddr::new(config.rpc.auth_addr, config.rpc.auth_port);
+        let url = Url::parse(&format!("http://{}", addr))
+            .map_err(|e| eyre::eyre!("Failed to parse engine URL: {e}"))?;
+
+        let jwt_secret = Self::resolve_jwt_secret(config)?;
+
+        Ok(Self { url, jwt_secret })
+    }
+
+    /// Resolves JWT secret from config (inline, file path, default path, or random).
+    fn resolve_jwt_secret(config: &NodeConfig<OpChainSpec>) -> Result<JwtSecret> {
+        if let Some(secret) = &config.rpc.rpc_jwtsecret {
+            return Ok(*secret);
+        }
+
+        if let Some(path) = &config.rpc.auth_jwtsecret {
+            return Self::read_jwt_from_path(path);
+        }
+
+        let default_path = config.datadir().jwt();
+        if default_path.exists() {
+            return Self::read_jwt_from_path(&default_path);
+        }
+
+        info!(target: "unified", "No JWT secret found, generating random one");
+        Ok(JwtSecret::random())
+    }
+
+    /// Reads and parses a JWT secret from a file.
+    fn read_jwt_from_path(path: &Path) -> Result<JwtSecret> {
+        let hex = std::fs::read_to_string(path)
+            .map_err(|e| eyre::eyre!("Failed to read JWT secret from {:?}: {e}", path))?;
+
+        JwtSecret::from_hex(hex.trim()).map_err(|e| eyre::eyre!("Failed to parse JWT secret: {e}"))
+    }
+}

--- a/bin/unified/src/execution.rs
+++ b/bin/unified/src/execution.rs
@@ -1,0 +1,23 @@
+//! Execution client wrapper.
+
+use base_client_node::{BaseNodeBuilder, BaseNodeHandle, BaseNodeRunner};
+use reth_optimism_node::args::RollupArgs;
+
+/// Wrapper around the reth execution client.
+#[derive(Debug, Clone)]
+pub struct Execution {
+    rollup_args: RollupArgs,
+}
+
+impl Execution {
+    /// Creates a new [`Execution`] instance.
+    pub const fn new(rollup_args: RollupArgs) -> Self {
+        Self { rollup_args }
+    }
+
+    /// Runs the execution client, returning a [`BaseNodeHandle`].
+    pub fn run(self, builder: BaseNodeBuilder) -> BaseNodeHandle {
+        let runner = BaseNodeRunner::new(self.rollup_args);
+        runner.run(builder)
+    }
+}

--- a/bin/unified/src/main.rs
+++ b/bin/unified/src/main.rs
@@ -3,17 +3,55 @@
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
 
+#[macro_use]
+extern crate tracing;
+
 pub mod cli;
+pub mod consensus;
+pub mod engine;
+pub mod execution;
+pub mod setup;
 pub mod version;
 
-fn main() {
-    use clap::Parser;
+use clap::Parser;
+use reth_chainspec::EthChainSpec;
+use reth_optimism_cli::{Cli, chainspec::OpChainSpecParser};
 
+#[global_allocator]
+static ALLOC: reth_cli_util::allocator::Allocator = reth_cli_util::allocator::new_allocator();
+
+fn main() {
     base_cli_utils::Backtracing::enable();
     base_cli_utils::SigsegvHandler::install();
 
-    if let Err(err) = cli::Cli::parse().run() {
-        eprintln!("Error: {err:?}");
-        std::process::exit(1);
-    }
+    Cli::<OpChainSpecParser, cli::UnifiedArgs>::parse()
+        .run(|builder, args| async move {
+            // Setup tracing and metrics.
+            setup::Setup::init(&args)?;
+
+            // Grab the engine endpoint and chain ID from the builder config.
+            let chain_id = builder.config().chain.chain().id();
+            let engine_endpoint = engine::EngineEndpoint::from_reth_config(builder.config())?;
+
+            // Start reth and get its handle.
+            let execution = execution::Execution::new(args.rollup_args);
+            let exec_handle = execution.run(builder);
+
+            // Start consensus and get its handle.
+            let consensus = consensus::Consensus::new(engine_endpoint, chain_id);
+            let consensus_handle = consensus.run();
+
+            // Wait for either to exit.
+            tokio::select! {
+                res = exec_handle => {
+                    info!(target: "unified", "Execution client exited");
+                    res
+                }
+                res = consensus_handle => {
+                    info!(target: "unified", "Consensus client exited");
+                    res
+                }
+            }
+        })
+        .unwrap();
 }

--- a/bin/unified/src/setup.rs
+++ b/bin/unified/src/setup.rs
@@ -1,0 +1,20 @@
+//! Logging and metrics initialization.
+
+use crate::{cli::UnifiedArgs, version::VersionInfo};
+
+/// Initializer for logging and metrics.
+#[derive(Debug, Clone)]
+pub struct Setup;
+
+impl Setup {
+    /// Initializes logging and metrics from [`UnifiedArgs`].
+    pub fn init(args: &UnifiedArgs) -> eyre::Result<()> {
+        base_cli_utils::LogConfig::from(args.global.logging.clone()).init_tracing_subscriber()?;
+
+        args.global.metrics.init_with(|| {
+            VersionInfo::from_build().register_version_metrics();
+        })?;
+
+        Ok(())
+    }
+}

--- a/bin/unified/src/version.rs
+++ b/bin/unified/src/version.rs
@@ -1,35 +1,22 @@
-//! Version information for the Base binary.
-//!
-//! [`VersionInfo`] metrics.
-//!
-//! Derived from [`reth-node-core`'s type][reth-version-info]
-//!
-//! [reth-version-info]: https://github.com/paradigmxyz/reth/blob/805fb1012cd1601c3b4fe9e8ca2d97c96f61355b/crates/node/metrics/src/version.rs#L6
+//! Build version information and metrics.
 
 use metrics::gauge;
 
 /// Cargo package version.
 pub const CARGO_PKG_VERSION: &str = env!("CARGO_PKG_VERSION");
-
-/// Build timestamp from vergen.
+/// Build timestamp.
 pub const VERGEN_BUILD_TIMESTAMP: &str = env!("VERGEN_BUILD_TIMESTAMP");
-
-/// Cargo features from vergen.
+/// Enabled cargo features.
 pub const VERGEN_CARGO_FEATURES: &str = env!("VERGEN_CARGO_FEATURES");
-
-/// Git SHA from vergen.
+/// Git commit SHA.
 pub const VERGEN_GIT_SHA: &str = env!("VERGEN_GIT_SHA");
-
-/// Cargo target triple from vergen.
+/// Target triple.
 pub const VERGEN_CARGO_TARGET_TRIPLE: &str = env!("VERGEN_CARGO_TARGET_TRIPLE");
-
-/// Build profile name.
+/// Build profile (debug/release).
 pub const BUILD_PROFILE_NAME: &str = env!("BASE_UNIFIED_BUILD_PROFILE");
-
 /// Short version string.
 pub const SHORT_VERSION: &str = env!("BASE_UNIFIED_SHORT_VERSION");
-
-/// Long version string with additional build info.
+/// Long version string with build info.
 pub const LONG_VERSION: &str = concat!(
     env!("BASE_UNIFIED_LONG_VERSION_0"),
     "\n",
@@ -42,27 +29,25 @@ pub const LONG_VERSION: &str = concat!(
     env!("BASE_UNIFIED_LONG_VERSION_4")
 );
 
-/// Contains version information for the application and allows for exposing the contained
-/// information as a prometheus metric.
+/// Build version info for prometheus metrics.
 #[derive(Debug, Clone)]
 pub struct VersionInfo {
-    /// The version of the application.
+    /// Application version.
     pub version: &'static str,
-    /// The build timestamp of the application.
+    /// Build timestamp.
     pub build_timestamp: &'static str,
-    /// The cargo features enabled for the build.
+    /// Enabled cargo features.
     pub cargo_features: &'static str,
-    /// The Git SHA of the build.
+    /// Git commit SHA.
     pub git_sha: &'static str,
-    /// The target triple for the build.
+    /// Target triple.
     pub target_triple: &'static str,
-    /// The build profile (e.g., debug or release).
+    /// Build profile.
     pub build_profile: &'static str,
 }
 
 impl VersionInfo {
-    /// Creates a new instance of [`VersionInfo`] from the constants defined in [`crate::version`]
-    /// at compile time.
+    /// Creates [`VersionInfo`] from compile-time constants.
     pub const fn from_build() -> Self {
         Self {
             version: CARGO_PKG_VERSION,
@@ -74,10 +59,8 @@ impl VersionInfo {
         }
     }
 
-    /// Exposes version information over prometheus.
+    /// Registers version info as prometheus metrics.
     pub fn register_version_metrics(&self) {
-        // If no features are enabled, the string will be empty, and the metric will not be
-        // reported. Report "none" if the string is empty.
         let features = if self.cargo_features.is_empty() { "none" } else { self.cargo_features };
 
         let labels: [(&str, &str); 6] = [


### PR DESCRIPTION
## Summary

> [!WARNING]
>
> Stacked on top of #557 

Creates a unified binary that doesn't do anything more than run both op-reth and kona-node in the same binary.

This is a step in the direction towards simplifying the interface between the two components.