### PR TITLE
feat: introduce `base_transactionLifecycle` API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2188,6 +2188,7 @@ dependencies = [
  "lru 0.16.3",
  "metrics",
  "metrics-derive",
+ "moka",
  "op-alloy-consensus",
  "op-alloy-rpc-types",
  "reth-node-api",

--- a/crates/client/txpool/Cargo.toml
+++ b/crates/client/txpool/Cargo.toml
@@ -42,6 +42,8 @@ derive_more = { workspace = true, features = ["display"] }
 tracing.workspace = true
 serde.workspace = true
 metrics-derive.workspace = true
+moka.workspace = true
+eyre.workspace = true
 
 [dev-dependencies]
 base-client-node = { workspace = true, features = ["test-utils"] }

--- a/crates/client/txpool/src/events.rs
+++ b/crates/client/txpool/src/events.rs
@@ -4,9 +4,10 @@ use std::time::Instant;
 
 use chrono::{DateTime, Local};
 use derive_more::Display;
+use serde::{Deserialize, Serialize};
 
 /// Types of transaction events to track.
-#[derive(Debug, Display, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Display, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum TxEvent {
     /// Transaction dropped from the pool.
     #[display("dropped")]

--- a/crates/client/txpool/src/extension.rs
+++ b/crates/client/txpool/src/extension.rs
@@ -3,9 +3,9 @@
 
 use std::sync::Arc;
 
+use alloy_primitives::TxHash;
 use base_client_node::{BaseBuilder, BaseNodeExtension, FromExtensionConfig};
 use base_flashblocks::{FlashblocksConfig, FlashblocksState};
-use alloy_primitives::TxHash;
 use reth_provider::CanonStateSubscriptions;
 use tokio_stream::wrappers::BroadcastStream;
 use tracing::info;
@@ -54,8 +54,9 @@ impl BaseNodeExtension for TxPoolExtension {
             info!(message = "Starting Transaction Status RPC");
             let (tx_send, tx_recv) = tokio::sync::mpsc::channel::<(TxHash, Vec<String>)>(1000);
 
-            let proxy_api = TransactionStatusApiImpl::new(sequencer_rpc, ctx.pool().clone(), tx_recv)
-                .expect("Failed to create transaction status proxy");
+            let proxy_api =
+                TransactionStatusApiImpl::new(sequencer_rpc, ctx.pool().clone(), tx_recv)
+                    .expect("Failed to create transaction status proxy");
             ctx.modules.merge_configured(proxy_api.into_rpc())?;
 
             // Start the tracing subscription if enabled
@@ -68,7 +69,13 @@ impl BaseNodeExtension for TxPoolExtension {
                 let fb_state: Arc<FlashblocksState> =
                     flashblocks_config.as_ref().map(|cfg| cfg.state.clone()).unwrap_or_default();
 
-                tokio::spawn(tracex_subscription(canonical_stream, fb_state, pool, logs_enabled, tx_send));
+                tokio::spawn(tracex_subscription(
+                    canonical_stream,
+                    fb_state,
+                    pool,
+                    logs_enabled,
+                    tx_send,
+                ));
             }
 
             Ok(())

--- a/crates/client/txpool/src/lib.rs
+++ b/crates/client/txpool/src/lib.rs
@@ -12,6 +12,7 @@ pub use subscription::tracex_subscription;
 mod rpc;
 pub use rpc::{
     Status, TransactionStatusApiImpl, TransactionStatusApiServer, TransactionStatusResponse,
+    TransactionLifecycleResponse,
 };
 
 mod tracker;

--- a/crates/client/txpool/src/lib.rs
+++ b/crates/client/txpool/src/lib.rs
@@ -11,8 +11,8 @@ pub use subscription::tracex_subscription;
 
 mod rpc;
 pub use rpc::{
-    Status, TransactionStatusApiImpl, TransactionStatusApiServer, TransactionStatusResponse,
-    TransactionLifecycleResponse,
+    Status, TransactionLifecycleResponse, TransactionStatusApiImpl, TransactionStatusApiServer,
+    TransactionStatusResponse,
 };
 
 mod tracker;

--- a/crates/client/txpool/src/subscription.rs
+++ b/crates/client/txpool/src/subscription.rs
@@ -2,13 +2,14 @@
 
 use std::sync::Arc;
 
+use alloy_primitives::TxHash;
 use base_flashblocks::{FlashblocksAPI, PendingBlocks};
 use futures::StreamExt;
 use reth_node_api::NodePrimitives;
 use reth_provider::CanonStateNotification;
-use reth_tracing::tracing::debug;
+use reth_tracing::tracing::{debug, error};
 use reth_transaction_pool::TransactionPool;
-use tokio::sync::broadcast::Receiver;
+use tokio::sync::{broadcast::Receiver, mpsc::Sender};
 use tokio_stream::wrappers::BroadcastStream;
 
 use crate::tracker::Tracker;
@@ -22,13 +23,14 @@ pub async fn tracex_subscription<N, Pool, FB>(
     flashblocks_api: Arc<FB>,
     pool: Pool,
     enable_logs: bool,
+    tx_send: Sender<(TxHash, Vec<String>)>,
 ) where
     N: NodePrimitives,
     Pool: TransactionPool + 'static,
     FB: FlashblocksAPI + 'static,
 {
     debug!(target: "tracex", "Starting transaction tracking subscription");
-    let mut tracker = Tracker::new(enable_logs);
+    let mut tracker = Tracker::new(enable_logs, tx_send);
 
     // Subscribe to events from the mempool.
     let mut all_events_stream = pool.all_transactions_event_listener();
@@ -41,11 +43,17 @@ pub async fn tracex_subscription<N, Pool, FB>(
     loop {
         tokio::select! {
             // Track # of transactions dropped and replaced.
-            Some(full_event) = all_events_stream.next() => tracker.handle_event(full_event),
+            Some(full_event) = all_events_stream.next() => {
+                if let Err(e) = tracker.handle_event(full_event).await {
+                    error!(target: "tracex", "Error handling transaction event: {}", e);
+                }
+            },
 
             // Use canonical state notifications to track time to inclusion.
             Some(Ok(notification)) = canonical_stream.next() => {
-                tracker.handle_canon_state_notification(notification);
+                if let Err(e) = tracker.handle_canon_state_notification(notification).await {
+                    error!(target: "tracex", "Error handling canonical state notification: {}", e);
+                }
             }
 
             // Track flashblock inclusion timing.

--- a/crates/client/txpool/src/tracker.rs
+++ b/crates/client/txpool/src/tracker.rs
@@ -50,7 +50,10 @@ impl Tracker {
     }
 
     /// Parse [`FullTransactionEvent`]s and update the tracker.
-    pub async fn handle_event<T: PoolTransaction>(&mut self, event: FullTransactionEvent<T>) -> eyre::Result<()> {
+    pub async fn handle_event<T: PoolTransaction>(
+        &mut self,
+        event: FullTransactionEvent<T>,
+    ) -> eyre::Result<()> {
         match event {
             FullTransactionEvent::Pending(tx_hash) => {
                 self.transaction_inserted(tx_hash, TxEvent::Pending).await?;
@@ -88,7 +91,10 @@ impl Tracker {
         self.track_flashblock_transactions(&pending_blocks);
     }
 
-    async fn track_committed_chain<N: NodePrimitives>(&mut self, chain: &Chain<N>) -> eyre::Result<()> {
+    async fn track_committed_chain<N: NodePrimitives>(
+        &mut self,
+        chain: &Chain<N>,
+    ) -> eyre::Result<()> {
         for block in chain.blocks().values() {
             for transaction in block.body().transactions() {
                 self.transaction_completed(*transaction.tx_hash(), TxEvent::BlockInclusion).await?;
@@ -106,7 +112,11 @@ impl Tracker {
     }
 
     /// Track the first time we see a transaction in the mempool.
-    pub async fn transaction_inserted(&mut self, tx_hash: TxHash, event: TxEvent) -> eyre::Result<()> {
+    pub async fn transaction_inserted(
+        &mut self,
+        tx_hash: TxHash,
+        event: TxEvent,
+    ) -> eyre::Result<()> {
         // If we've seen the tx before, don't track it again. For example,
         // if a tx was pending then moved to queued, we don't want to update the timestamp
         // with the queued timestamp.
@@ -168,7 +178,11 @@ impl Tracker {
     }
 
     /// Track a transaction being included in a block or dropped.
-    pub async fn transaction_completed(&mut self, tx_hash: TxHash, event: TxEvent) -> eyre::Result<()> {
+    pub async fn transaction_completed(
+        &mut self,
+        tx_hash: TxHash,
+        event: TxEvent,
+    ) -> eyre::Result<()> {
         if let Some(mut event_log) = self.txs.pop(&tx_hash) {
             let mempool_time = event_log.mempool_time;
             let time_in_mempool = Instant::now().duration_since(mempool_time);
@@ -222,7 +236,11 @@ impl Tracker {
     }
 
     /// Track a transaction being replaced by removing it from the cache and adding the new tx.
-    pub async fn transaction_replaced(&mut self, tx_hash: TxHash, replaced_by: TxHash) -> eyre::Result<()> {
+    pub async fn transaction_replaced(
+        &mut self,
+        tx_hash: TxHash,
+        replaced_by: TxHash,
+    ) -> eyre::Result<()> {
         if let Some(mut event_log) = self.txs.pop(&tx_hash) {
             let mempool_time = event_log.mempool_time;
             let time_in_mempool = Instant::now().duration_since(mempool_time);


### PR DESCRIPTION
## Motivation

- We currently have a `Tracker` ExEx that measures the inclusion time of a transaction and also the different states that it moves between (i.e., Pending, Queued, Included, etc.)
- This `Tracker` emits an `info!` log, which we can see in DataDog

## Problem
- We have been and will experience more sampling of logs on DataDog
- Sometimes a `TxHash` is not there to look up on the DD widget

## Solution
- Provide a self-served API for us (Base folks) and for third-parties to use

## Changes
- Introduces a new RPC called `base_transactionLifecycle`
- The RPC contains a TTL cache (2min expiry)
- The cache is updated when it receives a tx update from the Tracker
- Added a unit test to verify behaviour