### PR TITLE
test(client): add integration test for RPC hook accumulation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2152,15 +2152,21 @@ dependencies = [
 name = "base-reth-node"
 version = "0.0.0"
 dependencies = [
+ "alloy-primitives",
  "base-cli-utils",
  "base-client-node",
  "base-flashblocks-node",
  "base-metering",
  "base-txpool",
  "clap",
+ "eyre",
+ "jsonrpsee",
+ "jsonrpsee-types",
  "reth-cli-util",
  "reth-optimism-cli",
  "reth-optimism-node",
+ "serde_json",
+ "tokio",
 ]
 
 [[package]]

--- a/bin/node/Cargo.toml
+++ b/bin/node/Cargo.toml
@@ -38,6 +38,7 @@ base-metering.workspace = true
 base-txpool.workspace = true
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
 eyre.workspace = true
-jsonrpsee = { workspace = true, features = ["http-client", "types"] }
+jsonrpsee = { workspace = true, features = ["http-client"] }
+jsonrpsee-types.workspace = true
 serde_json.workspace = true
 alloy-primitives.workspace = true

--- a/bin/node/Cargo.toml
+++ b/bin/node/Cargo.toml
@@ -31,3 +31,13 @@ clap.workspace = true
 [features]
 default = []
 jemalloc = [ "reth-cli-util/jemalloc", "reth-optimism-cli/jemalloc" ]
+
+[dev-dependencies]
+base-client-node = { workspace = true, features = ["test-utils"] }
+base-metering.workspace = true
+base-txpool.workspace = true
+tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
+eyre.workspace = true
+jsonrpsee = { workspace = true, features = ["http-client", "types"] }
+serde_json.workspace = true
+alloy-primitives.workspace = true

--- a/bin/node/tests/rpc_hooks.rs
+++ b/bin/node/tests/rpc_hooks.rs
@@ -1,0 +1,76 @@
+//! Integration tests for RPC hook accumulation.
+//!
+//! This test verifies that multiple RPC-providing extensions are all accessible
+//! when installed together, ensuring that the `BaseBuilder` properly accumulates
+//! RPC hooks instead of replacing them.
+//!
+//! Related issues:
+//! - Fixes verification for #438
+//! - Discussed in #446
+
+use std::sync::Arc;
+
+use alloy_primitives::TxHash;
+use base_client_node::{BaseNodeExtension, test_utils::load_chain_spec};
+use base_metering::MeteringExtension;
+use base_txpool::{Status, TransactionStatusResponse, TxPoolExtension, TxpoolConfig};
+use eyre::Result;
+use jsonrpsee::{core::client::ClientT, http_client::HttpClientBuilder, rpc_params};
+
+/// Test that multiple RPC-providing extensions are all accessible when installed together.
+///
+/// This verifies that:
+/// 1. TxPool RPC (`base_transactionStatus`) is reachable
+/// 2. Metering RPC (`base_meterBlockByNumber`) is reachable
+///
+/// Both should work simultaneously when both extensions are installed.
+#[tokio::test(flavor = "multi_thread")]
+async fn rpc_hooks_accumulate_across_extensions() -> Result<()> {
+    // Initialize tracing for better test output
+    base_client_node::test_utils::init_silenced_tracing();
+
+    let chain_spec = load_chain_spec();
+
+    // Install multiple RPC-providing extensions
+    let mut extensions: Vec<Box<dyn BaseNodeExtension>> = Vec::new();
+    extensions.push(Box::new(TxPoolExtension::new(TxpoolConfig {
+        tracing_enabled: false,
+        tracing_logs_enabled: false,
+        sequencer_rpc: None,
+        flashblocks_config: None,
+    })));
+    extensions.push(Box::new(MeteringExtension::new(true, None)));
+
+    let node =
+        base_client_node::test_utils::LocalNode::new(extensions, Arc::clone(&chain_spec)).await?;
+
+    let client = HttpClientBuilder::default().build(format!("http://{}", node.http_addr()))?;
+
+    // TxPool RPC should be reachable
+    let status: TransactionStatusResponse =
+        client.request("base_transactionStatus", rpc_params![TxHash::ZERO]).await?;
+    assert_eq!(Status::Unknown, status.status);
+
+    // Metering RPC should also be reachable
+    // Note: This may return an error (e.g., block not found) but should NOT return MethodNotFound
+    let meter_result = client
+        .request::<serde_json::Value, _>("base_meterBlockByNumber", rpc_params!["latest"])
+        .await;
+
+    match meter_result {
+        Ok(_) => {
+            // Method exists and returned successfully
+        }
+        Err(jsonrpsee::core::ClientError::Call(err)) => {
+            // Method exists but returned an error - this is fine as long as it's not MethodNotFound
+            assert_ne!(
+                err.code(),
+                jsonrpsee::types::ErrorCode::MethodNotFound.code(),
+                "metering RPC missing - RPC hooks are not accumulating properly"
+            );
+        }
+        Err(err) => panic!("unexpected error from metering RPC: {err}"),
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
Add integration test verifying multiple RPC extensions work together.                                                                                                                                                             
                                                                                                                                                                                                                                    
  Tests that both `TxPoolExtension` and `MeteringExtension` RPCs are                                                                                                                                                                
  accessible when installed simultaneously.

Closes #458