### PR TITLE
feat(builder): state trie cache warming with channel-based streaming

### DIFF
--- a/bin/builder/src/cli.rs
+++ b/bin/builder/src/cli.rs
@@ -34,6 +34,16 @@ pub struct FlashblocksArgs {
     /// building time before calculating number of fbs.
     #[arg(long = "flashblocks.leeway-time", default_value = "75", env = "FLASHBLOCK_LEEWAY_TIME")]
     pub flashblocks_leeway_time: u64,
+
+    /// Whether to enable background state trie warming during block building.
+    /// When enabled, state root calculations are performed in the background
+    /// to warm OS/DB caches, improving final state root computation performance.
+    #[arg(
+        long = "flashblocks.enable-state-trie-warming",
+        default_value = "false",
+        env = "FLASHBLOCKS_ENABLE_STATE_TRIE_WARMING"
+    )]
+    pub flashblocks_enable_state_trie_warming: bool,
 }
 
 impl Default for FlashblocksArgs {
@@ -43,6 +53,7 @@ impl Default for FlashblocksArgs {
             flashblocks_addr: "127.0.0.1".to_string(),
             flashblocks_block_time: 250,
             flashblocks_leeway_time: 75,
+            flashblocks_enable_state_trie_warming: false,
         }
     }
 }
@@ -198,6 +209,7 @@ impl Args {
                 self.rejection_cache_max_capacity,
                 Duration::from_secs(self.rejection_cache_ttl_secs),
             ),
+            enable_state_trie_warming: self.flashblocks.flashblocks_enable_state_trie_warming,
         })
     }
 }

--- a/crates/builder/core/src/config.rs
+++ b/crates/builder/core/src/config.rs
@@ -83,6 +83,9 @@ pub struct BuilderConfig {
     /// Cache of permanently rejected transaction hashes, shared across blocks.
     /// Transactions in this cache are skipped by the iterator without re-evaluation.
     pub rejection_cache: RejectionCache,
+
+    /// Whether to enable background state trie cache warming via state root calculation.
+    pub enable_state_trie_warming: bool,
 }
 
 impl BuilderConfig {
@@ -117,6 +120,7 @@ impl core::fmt::Debug for BuilderConfig {
             .field("metering_wait_duration", &self.metering_wait_duration)
             .field("metering_provider", &self.metering_provider)
             .field("rejection_cache_size", &self.rejection_cache.entry_count())
+            .field("enable_state_trie_warming", &self.enable_state_trie_warming)
             .finish()
     }
 }
@@ -143,6 +147,7 @@ impl Default for BuilderConfig {
             metering_wait_duration: None,
             metering_provider: Arc::new(NoopMeteringProvider),
             rejection_cache: RejectionCache::new(100_000, Duration::from_secs(1800)),
+            enable_state_trie_warming: false,
         }
     }
 }

--- a/crates/builder/core/src/flashblocks/context.rs
+++ b/crates/builder/core/src/flashblocks/context.rs
@@ -39,6 +39,7 @@ use tracing::{debug, error, trace, warn};
 use crate::{
     BuilderConfig, BuilderMetrics, ExecutionInfo, ExecutionMeteringLimitExceeded, PayloadTxsBounds,
     ResourceLimits, TxResources, TxnExecutionError, TxnOutcome,
+    flashblocks::state_trie_warmer::StateTrieHook,
 };
 
 /// Records the priority fee of a rejected transaction with the given reason as a label.
@@ -485,6 +486,7 @@ impl OpPayloadBuilderCtx {
     pub(super) fn execute_sequencer_transactions(
         &self,
         db: &mut State<impl Database>,
+        state_hook: &StateTrieHook,
     ) -> Result<ExecutionInfo, PayloadBuilderError> {
         let mut info = ExecutionInfo::with_capacity(self.attributes().transactions.len());
 
@@ -561,6 +563,9 @@ impl OpPayloadBuilderCtx {
 
             info.receipts.push(self.build_receipt(ctx, depositor_nonce));
 
+            // Send state to warming task before commit
+            state_hook.send_state_update(&state);
+
             // commit changes
             evm.db_mut().commit(state);
 
@@ -600,6 +605,7 @@ impl OpPayloadBuilderCtx {
         db: &mut State<impl Database>,
         best_txs: &mut impl PayloadTxsBounds,
         limits: &ResourceLimits,
+        state_hook: &StateTrieHook,
     ) -> Result<FlashblockDiagnostics, PayloadBuilderError> {
         let execute_txs_start_time = Instant::now();
         let mut num_txs_considered = 0;
@@ -935,6 +941,9 @@ impl OpPayloadBuilderCtx {
                 cumulative_gas_used: info.cumulative_gas_used,
             };
             info.receipts.push(self.build_receipt(ctx, None));
+
+            // Send state to warming task before commit
+            state_hook.send_state_update(&state);
 
             // commit changes
             evm.db_mut().commit(state);

--- a/crates/builder/core/src/flashblocks/mod.rs
+++ b/crates/builder/core/src/flashblocks/mod.rs
@@ -25,3 +25,5 @@ pub use payload::FlashblocksExecutionInfo;
 
 mod service;
 pub use service::FlashblocksServiceBuilder;
+
+pub(crate) mod state_trie_warmer;

--- a/crates/builder/core/src/flashblocks/payload.rs
+++ b/crates/builder/core/src/flashblocks/payload.rs
@@ -1,7 +1,10 @@
 use core::time::Duration;
 use std::{
     ops::{Div, Rem},
-    sync::Arc,
+    sync::{
+        Arc,
+        atomic::{AtomicBool, Ordering},
+    },
     time::Instant,
 };
 
@@ -54,6 +57,7 @@ use crate::{
         best_txs::BestFlashblocksTxs,
         context::OpPayloadBuilderCtx,
         generator::{BlockCell, BuildArguments},
+        state_trie_warmer::{StateTrieHook, StateTrieWarmerTask},
     },
     traits::{ClientBounds, PoolBounds},
 };
@@ -250,12 +254,44 @@ where
         let state_provider = self.client.state_by_block_hash(ctx.parent().hash())?;
         let db = StateProviderDatabase::new(state_provider);
 
+        // Create state trie warming channel and task
+        let state_hook = if self.config.enable_state_trie_warming {
+            let warming_provider = self.client.state_by_block_hash(ctx.parent().hash())?;
+            let (warming_tx, warming_rx) = std::sync::mpsc::sync_channel(32);
+
+            // Bridge tokio CancellationToken → Arc<AtomicBool> for the blocking task.
+            let cancelled = Arc::new(AtomicBool::new(false));
+            let cancelled_flag = Arc::clone(&cancelled);
+            let cancel_token = block_cancel.clone();
+            tokio::spawn(async move {
+                cancel_token.cancelled().await;
+                cancelled_flag.store(true, Ordering::Relaxed);
+            });
+
+            let warming_task = StateTrieWarmerTask::new(
+                warming_rx,
+                warming_provider,
+                ctx.block_number(),
+                cancelled,
+            );
+            tokio::task::spawn_blocking(move || {
+                if let Err(e) = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                    warming_task.run();
+                })) {
+                    tracing::error!(error = ?e, "State trie warming task panicked");
+                }
+            });
+            StateTrieHook::new(warming_tx)
+        } else {
+            StateTrieHook::noop()
+        };
+
         // 1. execute the pre steps and seal an early block with that
         let sequencer_tx_start_time = Instant::now();
         let mut state =
             State::builder().with_database(cached_reads.as_db_mut(db)).with_bundle_update().build();
 
-        let mut info = execute_pre_steps(&mut state, &ctx)?;
+        let mut info = execute_pre_steps(&mut state, &ctx, &state_hook)?;
         let sequencer_tx_time = sequencer_tx_start_time.elapsed();
         BuilderMetrics::sequencer_tx_duration().record(sequencer_tx_time);
         BuilderMetrics::sequencer_tx_gauge().set(sequencer_tx_time);
@@ -460,6 +496,7 @@ where
                     &publish_guard,
                     &fb_span,
                     &mut executed_sender_nonces,
+                    &state_hook,
                 )
                 .await
             {
@@ -521,6 +558,7 @@ where
         publish_guard: &parking_lot::Mutex<()>,
         span: &tracing::Span,
         executed_sender_nonces: &mut HashMap<Address, u64>,
+        state_hook: &StateTrieHook,
     ) -> eyre::Result<Option<FlashblocksExtraCtx>> {
         let flashblock_index = ctx.flashblock_index();
         let target_gas_for_batch = ctx.extra.target_gas_for_batch;
@@ -590,7 +628,7 @@ where
             block_uncompressed_size_limit: ctx.builder_config.max_uncompressed_block_size,
         };
         let diag = ctx
-            .execute_best_transactions(info, state, best_txs, &limits)
+            .execute_best_transactions(info, state, best_txs, &limits, state_hook)
             .wrap_err("failed to execute best transactions")?;
 
         // Evict permanently rejected transactions from the iterator and pool.
@@ -924,6 +962,7 @@ struct FlashblocksMetadata {
 pub(crate) fn execute_pre_steps<DB>(
     state: &mut State<DB>,
     ctx: &OpPayloadBuilderCtx,
+    state_hook: &StateTrieHook,
 ) -> Result<ExecutionInfo, PayloadBuilderError>
 where
     DB: Database<Error = ProviderError> + std::fmt::Debug + revm::Database,
@@ -935,7 +974,7 @@ where
         .apply_pre_execution_changes()?;
 
     // 2. execute sequencer transactions
-    let info = ctx.execute_sequencer_transactions(state)?;
+    let info = ctx.execute_sequencer_transactions(state, state_hook)?;
 
     Ok(info)
 }

--- a/crates/builder/core/src/flashblocks/state_trie_warmer.rs
+++ b/crates/builder/core/src/flashblocks/state_trie_warmer.rs
@@ -1,0 +1,570 @@
+use std::{
+    sync::{
+        Arc,
+        atomic::{AtomicBool, Ordering},
+        mpsc,
+    },
+    time::{Duration, Instant},
+};
+
+use alloy_primitives::{B256, keccak256};
+use reth_provider::StateRootProvider;
+use reth_trie::{HashedPostState, HashedStorage};
+use revm::state::EvmState;
+use tracing::{debug, trace, warn};
+
+use crate::metrics::BuilderMetrics;
+
+/// Messages sent from execution to the state trie warming task.
+/// Mirrors the subset of reth's `MultiProofMessage` relevant for warming.
+pub(crate) enum StateTrieMessage {
+    /// Raw per-transaction EVM state diff. Hashing is deferred to the
+    /// background warming task to keep the execution thread fast.
+    StateUpdate(EvmState),
+    /// Signals that all transactions have been executed (block complete).
+    FinishedStateUpdates,
+}
+
+/// Sender wrapper that sends state updates to the warming task.
+/// Automatically sends `FinishedStateUpdates` on drop, mirroring
+/// reth's `StateHookSender` pattern.
+///
+/// Uses a bounded `SyncSender` so that producers block when the warming
+/// task falls behind, providing natural backpressure and capping memory.
+pub(crate) struct StateTrieHook {
+    tx: Option<mpsc::SyncSender<StateTrieMessage>>,
+}
+
+impl StateTrieHook {
+    /// Create a new hook that sends to the warming task.
+    pub(crate) const fn new(tx: mpsc::SyncSender<StateTrieMessage>) -> Self {
+        Self { tx: Some(tx) }
+    }
+
+    /// Create a no-op hook for when warming is disabled.
+    pub(crate) const fn noop() -> Self {
+        Self { tx: None }
+    }
+
+    /// Send a state update to the warming task.
+    /// Uses `try_send` to avoid blocking the execution thread if the
+    /// bounded channel is full — a dropped update is acceptable since
+    /// warming is best-effort.
+    pub(crate) fn send_state_update(&self, state: &EvmState) {
+        if let Some(tx) = &self.tx {
+            let _ = tx.try_send(StateTrieMessage::StateUpdate(state.clone()));
+        }
+    }
+}
+
+impl Drop for StateTrieHook {
+    fn drop(&mut self) {
+        if let Some(tx) = self.tx.take() {
+            let _ = tx.send(StateTrieMessage::FinishedStateUpdates);
+        }
+    }
+}
+
+/// Background task that receives per-transaction state updates and
+/// continuously warms the state trie cache by computing state roots.
+///
+/// Algorithm:
+/// 1. Block on `recv()` for first `StateUpdate`, accumulate into `HashedPostState`
+/// 2. Debounce: `recv_timeout(10ms)` to drain more updates
+/// 3. Compute `state_root_with_updates(accumulated.clone())` to warm caches
+/// 4. `try_recv()` non-blocking drain of messages queued during computation
+/// 5. If new messages arrived -> go to 3 (skip debounce)
+/// 6. If no new messages -> go to 1 (back to blocking wait)
+/// 7. `FinishedStateUpdates` at any step -> final warming, then exit
+pub(crate) struct StateTrieWarmerTask<P> {
+    rx: mpsc::Receiver<StateTrieMessage>,
+    provider: P,
+    block_number: u64,
+    cancelled: Arc<AtomicBool>,
+}
+
+impl<P> StateTrieWarmerTask<P>
+where
+    P: StateRootProvider,
+{
+    /// Create a new warming task with a shared cancellation flag.
+    pub(crate) const fn new(
+        rx: mpsc::Receiver<StateTrieMessage>,
+        provider: P,
+        block_number: u64,
+        cancelled: Arc<AtomicBool>,
+    ) -> Self {
+        Self { rx, provider, block_number, cancelled }
+    }
+
+    /// Run the warming task to completion.
+    /// This method blocks and should be called on a blocking thread.
+    /// Exits early if the cancellation flag is set (e.g. block was cancelled).
+    pub(crate) fn run(self) {
+        let Self { rx, provider, block_number, cancelled } = self;
+        let mut accumulated = HashedPostState::default();
+        let mut has_unwarmed_state = false;
+
+        debug!(
+            target: "state_trie_warming",
+            block_number,
+            "State trie warming task started"
+        );
+
+        loop {
+            if cancelled.load(Ordering::Relaxed) {
+                debug!(
+                    target: "state_trie_warming",
+                    block_number,
+                    "Cancelled before recv, exiting"
+                );
+                return;
+            }
+
+            // Step 1: Wait for first message (blocking)
+            let msg = match rx.recv() {
+                Ok(msg) => msg,
+                Err(_) => {
+                    // Channel closed without FinishedStateUpdates
+                    debug!(
+                        target: "state_trie_warming",
+                        block_number,
+                        "Channel closed, warming task exiting"
+                    );
+                    if has_unwarmed_state && !cancelled.load(Ordering::Relaxed) {
+                        run_warming(&provider, &accumulated, block_number);
+                    }
+                    return;
+                }
+            };
+
+            match msg {
+                StateTrieMessage::FinishedStateUpdates => {
+                    debug!(
+                        target: "state_trie_warming",
+                        block_number,
+                        "Received FinishedStateUpdates"
+                    );
+                    if has_unwarmed_state {
+                        run_warming(&provider, &accumulated, block_number);
+                    }
+                    return;
+                }
+                StateTrieMessage::StateUpdate(evm_state) => {
+                    accumulated.extend(evm_state_to_hashed_post_state(evm_state));
+                    has_unwarmed_state = true;
+                }
+            }
+
+            // Step 2: Debounce - drain for 10ms
+            if drain_messages(
+                &rx,
+                &mut accumulated,
+                &mut has_unwarmed_state,
+                Some(Duration::from_millis(10)),
+            ) {
+                // Received FinishedStateUpdates during debounce
+                if has_unwarmed_state {
+                    run_warming(&provider, &accumulated, block_number);
+                }
+                return;
+            }
+
+            // Step 3-6: Warming loop
+            loop {
+                if !has_unwarmed_state || cancelled.load(Ordering::Relaxed) {
+                    break; // Go back to blocking recv (or exit on next iteration)
+                }
+
+                // Step 3: Compute state root to warm caches
+                run_warming(&provider, &accumulated, block_number);
+                has_unwarmed_state = false;
+
+                // Step 4: Non-blocking drain of messages queued during computation
+                if drain_messages(&rx, &mut accumulated, &mut has_unwarmed_state, None) {
+                    // Received FinishedStateUpdates
+                    if has_unwarmed_state {
+                        run_warming(&provider, &accumulated, block_number);
+                    }
+                    return;
+                }
+
+                // Step 5: If new messages arrived, loop back to step 3
+                // Step 6: If no new messages, break to step 1
+                if !has_unwarmed_state {
+                    break;
+                }
+            }
+        }
+    }
+}
+
+/// Drain messages from the channel, accumulating state updates.
+/// If `timeout` is Some, uses `recv_timeout` for the first message then `try_recv` for the rest.
+/// If `timeout` is None, only uses `try_recv` (non-blocking).
+/// Returns true if `FinishedStateUpdates` was received.
+fn drain_messages(
+    rx: &mpsc::Receiver<StateTrieMessage>,
+    accumulated: &mut HashedPostState,
+    has_unwarmed_state: &mut bool,
+    timeout: Option<Duration>,
+) -> bool {
+    // First phase: drain with an absolute deadline so sustained
+    // throughput cannot starve the warming computation indefinitely.
+    if let Some(timeout) = timeout {
+        let deadline = Instant::now() + timeout;
+        while let Some(remaining) = deadline.checked_duration_since(Instant::now()) {
+            match rx.recv_timeout(remaining) {
+                Ok(StateTrieMessage::FinishedStateUpdates) => return true,
+                Ok(StateTrieMessage::StateUpdate(evm_state)) => {
+                    accumulated.extend(evm_state_to_hashed_post_state(evm_state));
+                    *has_unwarmed_state = true;
+                }
+                Err(_) => break, // Timeout or disconnected
+            }
+        }
+    }
+
+    // Remaining messages: non-blocking
+    loop {
+        match rx.try_recv() {
+            Ok(StateTrieMessage::FinishedStateUpdates) => return true,
+            Ok(StateTrieMessage::StateUpdate(evm_state)) => {
+                accumulated.extend(evm_state_to_hashed_post_state(evm_state));
+                *has_unwarmed_state = true;
+            }
+            Err(_) => break, // Empty or disconnected
+        }
+    }
+
+    false
+}
+
+/// Run a single state root computation to warm the trie cache.
+/// Note: `accumulated` is cloned because `state_root_with_updates`
+/// takes ownership, but we need to keep accumulating for future rounds.
+fn run_warming<P: StateRootProvider>(
+    provider: &P,
+    accumulated: &HashedPostState,
+    block_number: u64,
+) {
+    let start_time = Instant::now();
+    BuilderMetrics::state_trie_warming_started_count().increment(1);
+
+    match provider.state_root_with_updates(accumulated.clone()) {
+        Ok(_) => {
+            let duration = start_time.elapsed();
+            BuilderMetrics::state_trie_warming_completed_count().increment(1);
+            BuilderMetrics::state_trie_warming_duration().record(duration);
+            debug!(
+                target: "state_trie_warming",
+                block_number,
+                duration_ms = duration.as_millis(),
+                "State trie warming completed successfully"
+            );
+        }
+        Err(err) => {
+            warn!(
+                target: "state_trie_warming",
+                block_number,
+                error = %err,
+                "State trie warming state root calculation failed"
+            );
+            BuilderMetrics::state_trie_warming_error_count().increment(1);
+        }
+    }
+}
+
+/// Convert per-transaction EVM state diff to hashed post state.
+/// Runs on the background warming thread to keep keccak256 hashing
+/// off the hot execution path.
+fn evm_state_to_hashed_post_state(update: EvmState) -> HashedPostState {
+    let mut hashed_state = HashedPostState::with_capacity(update.len());
+
+    for (address, account) in update {
+        if account.is_touched() {
+            let hashed_address = keccak256(address);
+            trace!(target: "state_trie_warming", ?address, ?hashed_address, "Adding account to state update");
+
+            let destroyed = account.is_selfdestructed();
+            let info = if destroyed { None } else { Some(account.info.into()) };
+            hashed_state.accounts.insert(hashed_address, info);
+
+            let mut changed_storage_iter = account
+                .storage
+                .into_iter()
+                .filter(|(_slot, value)| value.is_changed())
+                .map(|(slot, value)| (keccak256(B256::from(slot)), value.present_value))
+                .peekable();
+
+            if destroyed {
+                hashed_state.storages.insert(hashed_address, HashedStorage::new(true));
+            } else if changed_storage_iter.peek().is_some() {
+                hashed_state
+                    .storages
+                    .insert(hashed_address, HashedStorage::from_iter(false, changed_storage_iter));
+            }
+        }
+    }
+
+    hashed_state
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use alloy_primitives::B256;
+    use reth_provider::ProviderError;
+    use reth_trie::{HashedPostState, updates::TrieUpdates};
+
+    use super::*;
+
+    #[test]
+    fn noop_hook_does_not_panic() {
+        let hook = StateTrieHook::noop();
+        hook.send_state_update(&EvmState::default());
+        drop(hook);
+    }
+
+    #[test]
+    fn hook_sends_finished_on_drop() {
+        let (tx, rx) = mpsc::sync_channel(32);
+        {
+            let hook = StateTrieHook::new(tx);
+            hook.send_state_update(&EvmState::default());
+        } // hook dropped here
+
+        // Should have received StateUpdate then FinishedStateUpdates
+        let msg1 = rx.recv().unwrap();
+        assert!(matches!(msg1, StateTrieMessage::StateUpdate(_)));
+        let msg2 = rx.recv().unwrap();
+        assert!(matches!(msg2, StateTrieMessage::FinishedStateUpdates));
+    }
+
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    /// Mock provider that tracks how many times `state_root_with_updates` is called.
+    struct CountingProvider {
+        call_count: Arc<AtomicU64>,
+    }
+
+    impl CountingProvider {
+        fn new() -> (Self, Arc<AtomicU64>) {
+            let count = Arc::new(AtomicU64::new(0));
+            (Self { call_count: Arc::clone(&count) }, count)
+        }
+    }
+
+    impl StateRootProvider for CountingProvider {
+        fn state_root(&self, _state: HashedPostState) -> Result<B256, ProviderError> {
+            Ok(B256::ZERO)
+        }
+
+        fn state_root_from_nodes(
+            &self,
+            _input: reth_trie::TrieInput,
+        ) -> Result<B256, ProviderError> {
+            Ok(B256::ZERO)
+        }
+
+        fn state_root_with_updates(
+            &self,
+            _state: HashedPostState,
+        ) -> Result<(B256, TrieUpdates), ProviderError> {
+            self.call_count.fetch_add(1, Ordering::SeqCst);
+            Ok((B256::ZERO, TrieUpdates::default()))
+        }
+
+        fn state_root_from_nodes_with_updates(
+            &self,
+            _input: reth_trie::TrieInput,
+        ) -> Result<(B256, TrieUpdates), ProviderError> {
+            Ok((B256::ZERO, TrieUpdates::default()))
+        }
+    }
+
+    #[test]
+    fn task_runs_to_completion() {
+        let (tx, rx) = mpsc::channel();
+        let (provider, call_count) = CountingProvider::new();
+
+        let task = StateTrieWarmerTask::new(rx, provider, 1, Arc::new(AtomicBool::new(false)));
+
+        // Send some updates then finish
+        tx.send(StateTrieMessage::StateUpdate(EvmState::default())).unwrap();
+        tx.send(StateTrieMessage::FinishedStateUpdates).unwrap();
+
+        // Run on current thread (it's synchronous)
+        task.run();
+
+        // Verify warming was attempted
+        assert!(call_count.load(Ordering::SeqCst) > 0);
+    }
+
+    #[test]
+    fn task_handles_channel_close() {
+        let (tx, rx) = mpsc::channel();
+        let (provider, call_count) = CountingProvider::new();
+
+        let task = StateTrieWarmerTask::new(rx, provider, 1, Arc::new(AtomicBool::new(false)));
+
+        // Send an update then drop sender (no FinishedStateUpdates)
+        tx.send(StateTrieMessage::StateUpdate(EvmState::default())).unwrap();
+        drop(tx);
+
+        task.run();
+
+        // Should still have warmed
+        assert!(call_count.load(Ordering::SeqCst) > 0);
+    }
+
+    #[test]
+    fn task_with_no_updates_exits_cleanly() {
+        let (tx, rx) = mpsc::channel();
+        let (provider, call_count) = CountingProvider::new();
+
+        let task = StateTrieWarmerTask::new(rx, provider, 1, Arc::new(AtomicBool::new(false)));
+
+        // Immediately finish
+        tx.send(StateTrieMessage::FinishedStateUpdates).unwrap();
+
+        task.run();
+
+        // No warming should have been started (no state updates)
+        assert_eq!(call_count.load(Ordering::SeqCst), 0);
+    }
+
+    #[test]
+    fn task_accumulates_multiple_updates() {
+        let (tx, rx) = mpsc::channel();
+        let (provider, call_count) = CountingProvider::new();
+
+        let task = StateTrieWarmerTask::new(rx, provider, 1, Arc::new(AtomicBool::new(false)));
+
+        // Send multiple updates
+        for _ in 0..5 {
+            tx.send(StateTrieMessage::StateUpdate(EvmState::default())).unwrap();
+        }
+        tx.send(StateTrieMessage::FinishedStateUpdates).unwrap();
+
+        task.run();
+
+        // Warming should have been performed at least once
+        assert!(call_count.load(Ordering::SeqCst) >= 1);
+    }
+
+    /// Mock provider that sleeps on each `state_root_with_updates` call,
+    /// simulating a slow trie computation. Used to verify that bounded
+    /// channels with `try_send` correctly drop updates when the consumer
+    /// cannot keep up.
+    struct SlowCountingProvider {
+        call_count: Arc<AtomicU64>,
+        delay: Duration,
+    }
+
+    impl SlowCountingProvider {
+        fn new(delay: Duration) -> (Self, Arc<AtomicU64>) {
+            let count = Arc::new(AtomicU64::new(0));
+            (Self { call_count: Arc::clone(&count), delay }, count)
+        }
+    }
+
+    impl StateRootProvider for SlowCountingProvider {
+        fn state_root(&self, _state: HashedPostState) -> Result<B256, ProviderError> {
+            Ok(B256::ZERO)
+        }
+
+        fn state_root_from_nodes(
+            &self,
+            _input: reth_trie::TrieInput,
+        ) -> Result<B256, ProviderError> {
+            Ok(B256::ZERO)
+        }
+
+        fn state_root_with_updates(
+            &self,
+            _state: HashedPostState,
+        ) -> Result<(B256, TrieUpdates), ProviderError> {
+            std::thread::sleep(self.delay);
+            self.call_count.fetch_add(1, Ordering::SeqCst);
+            Ok((B256::ZERO, TrieUpdates::default()))
+        }
+
+        fn state_root_from_nodes_with_updates(
+            &self,
+            _input: reth_trie::TrieInput,
+        ) -> Result<(B256, TrieUpdates), ProviderError> {
+            Ok((B256::ZERO, TrieUpdates::default()))
+        }
+    }
+
+    #[test]
+    fn bounded_channel_drops_when_full() {
+        // Use a small bounded channel (capacity 2) with a slow provider.
+        // Send many updates rapidly — some must be dropped by try_send.
+        let (tx, rx) = mpsc::sync_channel(2);
+        let (provider, call_count) = SlowCountingProvider::new(Duration::from_millis(50));
+        let cancelled = Arc::new(AtomicBool::new(false));
+
+        let task = StateTrieWarmerTask::new(rx, provider, 1, cancelled);
+
+        let handle = std::thread::spawn(move || {
+            task.run();
+        });
+
+        // Flood the channel — with capacity 2 and a slow consumer, some
+        // try_send calls must fail, which is the correct best-effort behaviour.
+        let mut sent = 0u64;
+        let mut dropped = 0u64;
+        for _ in 0..20 {
+            match tx.try_send(StateTrieMessage::StateUpdate(EvmState::default())) {
+                Ok(()) => sent += 1,
+                Err(mpsc::TrySendError::Full(_)) => dropped += 1,
+                Err(mpsc::TrySendError::Disconnected(_)) => break,
+            }
+            // Small delay to let the consumer make some progress
+            std::thread::sleep(Duration::from_millis(5));
+        }
+        // Signal completion (blocking send so the consumer definitely gets it)
+        let _ = tx.send(StateTrieMessage::FinishedStateUpdates);
+
+        handle.join().expect("warming task panicked");
+
+        // At least some updates should have been sent and some dropped
+        assert!(sent > 0, "expected at least one sent update");
+        assert!(dropped > 0, "expected at least one dropped update with slow consumer");
+        assert!(call_count.load(Ordering::SeqCst) > 0, "expected at least one warming call");
+    }
+
+    #[test]
+    fn task_exits_early_on_cancellation() {
+        let (tx, rx) = mpsc::channel();
+        let (provider, call_count) = SlowCountingProvider::new(Duration::from_millis(200));
+        let cancelled = Arc::new(AtomicBool::new(false));
+        let cancelled_clone = Arc::clone(&cancelled);
+
+        let task = StateTrieWarmerTask::new(rx, provider, 1, cancelled);
+
+        // Send an update so the task has work to do
+        tx.send(StateTrieMessage::StateUpdate(EvmState::default())).unwrap();
+
+        let handle = std::thread::spawn(move || {
+            task.run();
+        });
+
+        // Cancel immediately — the task should exit without completing
+        // the slow warming computation (or at least exit promptly after).
+        cancelled_clone.store(true, Ordering::Relaxed);
+
+        // Also drop sender so recv() unblocks if the task is waiting
+        drop(tx);
+
+        // Task should finish quickly despite the 200ms sleep in the provider
+        handle.join().expect("warming task panicked");
+
+        // The task may have started one warming call before seeing the flag,
+        // but it should not have done many.
+        assert!(call_count.load(Ordering::SeqCst) <= 1);
+    }
+}

--- a/crates/builder/core/src/metrics.rs
+++ b/crates/builder/core/src/metrics.rs
@@ -199,6 +199,14 @@ base_metrics::define_metrics! {
     tx_accounts_modified: histogram,
     #[describe("Number of storage slots modified by a transaction (from EVM post-state)")]
     tx_storage_slots_modified: histogram,
+    #[describe("Number of state trie warming tasks started")]
+    state_trie_warming_started_count: counter,
+    #[describe("Number of state trie warming tasks completed successfully")]
+    state_trie_warming_completed_count: counter,
+    #[describe("Number of state trie warming tasks that encountered errors")]
+    state_trie_warming_error_count: counter,
+    #[describe("Histogram of state trie warming duration (completed tasks only)")]
+    state_trie_warming_duration: histogram,
 }
 
 impl BuilderMetrics {


### PR DESCRIPTION
## Overview

Add background state trie cache warming that continuously warms caches during block building by streaming per-transaction state updates over a channel — matching reth's state root task pattern for future swapability.

## Problem Statement

When the builder runs with `disable_state_root: true`, witness generation for the state trie uses cold caches, causing slow performance. This can contribute to missed blocks during high-load periods.

## Solution

Stream per-transaction `EvmState` diffs to a background `StateTrieWarmerTask` that incrementally accumulates `HashedPostState` and continuously computes state roots to warm OS/DB caches. The channel-based design mirrors reth's parallel state root system (`MultiProofMessage` / `StateHookSender`) so the warming task can be swapped for the real state root task later without changing execution code.

## Architecture

```
Execution: evm.transact() → EvmState
    ↓ (StateTrieHook — mpsc channel)
StateTrieWarmerTask: receives StateUpdate(EvmState)
    → evm_state_to_hashed_post_state() → HashedPostState
    → accumulates incrementally per-tx
    → debounced state_root_with_updates() (10ms after first tx)
    → re-schedules if new txs arrive during computation
    ↓ (on Drop)
StateTrieHook sends FinishedStateUpdates → final warming → task exits
```

### Key types (mirrors reth's state root task interface)
- **`StateTrieMessage`** — `StateUpdate(EvmState)` | `FinishedStateUpdates` (mirrors `MultiProofMessage`)
- **`StateTrieHook`** — sender wrapper with auto-finish on `Drop` (mirrors `StateHookSender`)
- **`StateTrieWarmerTask`** — background task on `spawn_blocking` with continuous warming algorithm
- **`evm_state_to_hashed_post_state()`** — converts per-tx EVM state to hashed form (copied from reth `multiproof.rs`)

### Continuous warming algorithm
1. Block on `recv()` for first `StateUpdate`, accumulate into `HashedPostState`
2. Debounce: `recv_timeout(10ms)` to drain more updates
3. Compute `state_root_with_updates(accumulated.clone())` to warm caches
4. `try_recv()` non-blocking drain of messages queued during computation
5. If new messages arrived → go to 3 (skip debounce, immediate re-computation)
6. If no new messages → go to 1 (back to blocking wait)
7. `FinishedStateUpdates` at any step → final warming if needed, then exit

### Lifecycle
- **Block start**: create channel, spawn task with provider
- **During execution**: hook sends state after each `evm.transact()` (before `commit`)
- **Block end**: hook dropped → `FinishedStateUpdates` → task runs final warming → exits

## Configuration

```bash
--flashblocks.enable-state-trie-warming  # (default: false)
FLASHBLOCKS_ENABLE_STATE_TRIE_WARMING=true
```

## Metrics

- `base_builder_state_trie_warming_started_count` — warming computations started
- `base_builder_state_trie_warming_completed_count` — warming computations completed
- `base_builder_state_trie_warming_duration` — duration histogram
- `base_builder_state_trie_warming_error_count` — error count

## Test Plan

- [x] Unit tests for `StateTrieHook` (noop, drop semantics)
- [x] Unit tests for `StateTrieWarmerTask` (completion, channel close, no-update exit, accumulation)
- [ ] Deploy to Sepolia Alpha with `FLASHBLOCKS_ENABLE_STATE_TRIE_WARMING=true`
- [ ] Validate warming metrics are recorded
- [ ] Measure witness generation latency with warming enabled vs disabled
- [ ] Verify no regression in flashblock build times

## Files Changed

- `bin/builder/src/cli.rs` — CLI flag
- `crates/builder/core/src/flashblocks/state_trie_warmer.rs` — `StateTrieMessage`, `StateTrieHook`, `StateTrieWarmerTask`, `evm_state_to_hashed_post_state()`, tests
- `crates/builder/core/src/flashblocks/context.rs` — `state_hook` parameter, `send_state_update()` calls after each `evm.transact()`
- `crates/builder/core/src/flashblocks/payload.rs` — channel+task creation, hook threading, removed per-flashblock `start_warming` calls
- `crates/builder/core/src/flashblocks/config.rs` — `enable_state_trie_warming` config field
- `crates/builder/core/src/flashblocks/mod.rs` — module exports
- `crates/builder/core/src/metrics.rs` — warming metrics