### PR TITLE
fix: handle empty flashblocks array in build_pending_state

### DIFF
--- a/crates/client/flashblocks/src/processor.rs
+++ b/crates/client/flashblocks/src/processor.rs
@@ -287,7 +287,10 @@ where
                 .push(flashblock.clone());
         }
 
-        let earliest_block_number = flashblocks_per_block.keys().min().unwrap();
+        let earliest_block_number = match flashblocks_per_block.keys().min() {
+            Some(num) => num,
+            None => return Ok(None),
+        };
         let canonical_block = earliest_block_number - 1;
         let mut last_block_header = self
             .client


### PR DESCRIPTION
Fixes a potential panic when `flashblocks_per_block` is empty.

After `retain()` filters out flashblocks (lines 176/186), the array can become empty if all flashblocks belong to blocks <= current block number. Previously this would panic on `.unwrap()` when calling `keys().min()` on an empty HashMap.

Now returns `Ok(None)` instead, which is the correct behavior — no flashblocks means no pending state to build.