### PR TITLE
chore(workspace): Remove Last ExEx Remnants

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7519,7 +7519,6 @@ dependencies = [
  "reth-db",
  "reth-evm",
  "reth-execution-types",
- "reth-exex",
  "reth-ipc",
  "reth-metrics",
  "reth-network-peers",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,7 +92,6 @@ kona-providers-alloy = { git = "https://github.com/ethereum-optimism/optimism", 
 # reth
 reth-ipc = { git = "https://github.com/paradigmxyz/reth", tag = "v1.10.2" }
 reth-evm = { git = "https://github.com/paradigmxyz/reth", tag = "v1.10.2" }
-reth-exex = { git = "https://github.com/paradigmxyz/reth", tag = "v1.10.2" }
 reth-tracing = { git = "https://github.com/paradigmxyz/reth", tag = "v1.10.2" }
 reth-cli = { git = "https://github.com/paradigmxyz/reth", tag = "v1.10.2" }
 reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", tag = "v1.10.2" }

--- a/bin/node/src/cli.rs
+++ b/bin/node/src/cli.rs
@@ -19,7 +19,7 @@ pub struct Args {
     )]
     pub max_pending_blocks_depth: u64,
 
-    /// Enable transaction tracing ExEx for mempool-to-block timing analysis
+    /// Enable transaction tracing for mempool-to-block timing analysis
     #[arg(long = "enable-transaction-tracing", value_name = "ENABLE_TRANSACTION_TRACING")]
     pub enable_transaction_tracing: bool,
 

--- a/crates/builder/op-rbuilder/Cargo.toml
+++ b/crates/builder/op-rbuilder/Cargo.toml
@@ -29,7 +29,6 @@ reth-cli-util.workspace = true
 reth-db.workspace = true
 reth-payload-primitives.workspace = true
 reth-evm.workspace = true
-reth-exex.workspace = true
 reth-chainspec.workspace = true
 reth-primitives.workspace = true
 reth-primitives-traits.workspace = true

--- a/crates/client/txpool/README.md
+++ b/crates/client/txpool/README.md
@@ -9,7 +9,7 @@ Base-specific transaction pool extensions for `reth`, including transaction trac
 
 This crate provides:
 
-- **Transaction Tracing ExEx**: An execution extension that subscribes to mempool events and chain notifications to track how long a transaction spends in each stage of the lifecycle before it is included, dropped, or replaced.
+- **Transaction Tracing**: Subscribes to mempool events and chain notifications to track how long a transaction spends in each stage of the lifecycle before it is included, dropped, or replaced.
 - **Transaction Status RPC**: An RPC API (`txpool_transactionStatus`) to query the current status and lifecycle events of a transaction by hash.
 - **Tracker**: Core tracking logic for recording pending/queued transitions, replacements, drops, and block inclusion.
 - **Metrics**: Histogram metrics for mempool residency by event type to help spot latency regressions.

--- a/crates/client/txpool/src/extension.rs
+++ b/crates/client/txpool/src/extension.rs
@@ -14,9 +14,9 @@ use crate::{TransactionStatusApiImpl, TransactionStatusApiServer, tracex_subscri
 /// Transaction pool configuration.
 #[derive(Debug, Clone)]
 pub struct TxpoolConfig {
-    /// Enables the transaction tracing ExEx.
+    /// Enables transaction tracing.
     pub tracing_enabled: bool,
-    /// Emits `info`-level logs for the tracing ExEx when enabled.
+    /// Emits `info`-level logs for transaction tracing when enabled.
     pub tracing_logs_enabled: bool,
     /// Sequencer RPC endpoint for transaction status proxying.
     pub sequencer_rpc: Option<String>,


### PR DESCRIPTION
## Summary

#403 finished migrating the `base-node` off the exex framework, using subscriptions directly.

This PR cleans up the base repo to remove the last bit of exex remnants, including removing the `reth-exex` workspace dependency that is unused.