### PR TITLE
feat(builder): Generate and broadcast FALs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7473,6 +7473,7 @@ dependencies = [
  "alloy-transport-http",
  "anyhow",
  "async-trait",
+ "base-access-lists",
  "base-builder-cli",
  "base-bundles",
  "base-flashtypes",

--- a/crates/builder/op-rbuilder/Cargo.toml
+++ b/crates/builder/op-rbuilder/Cargo.toml
@@ -14,6 +14,7 @@ workspace = true
 base-builder-cli.workspace = true
 base-bundles.workspace = true
 base-flashtypes.workspace = true
+base-access-lists.workspace = true
 
 reth-optimism-node.workspace = true
 reth-optimism-cli.workspace = true

--- a/crates/builder/op-rbuilder/src/flashblocks/payload.rs
+++ b/crates/builder/op-rbuilder/src/flashblocks/payload.rs
@@ -679,7 +679,7 @@ where
         &self,
         state: &mut State<DB>,
         ctx: &OpPayloadBuilderCtx,
-        info: &mut ExecutionInfo<FlashblocksExecutionInfo>,
+        info: &mut ExecutionInfo,
         finalized_cell: &BlockCell<OpBuiltPayload>,
     ) -> Result<(), PayloadBuilderError>
     where

--- a/crates/builder/op-rbuilder/src/primitives/reth/execution.rs
+++ b/crates/builder/op-rbuilder/src/primitives/reth/execution.rs
@@ -6,6 +6,8 @@ use derive_more::Display;
 use op_revm::OpTransactionError;
 use reth_optimism_primitives::{OpReceipt, OpTransactionSigned};
 
+use crate::flashblocks::FlashblocksExecutionInfo;
+
 #[derive(Debug, Display)]
 pub enum TxnExecutionResult {
     TransactionDALimitExceeded,
@@ -26,7 +28,7 @@ pub enum TxnExecutionResult {
 }
 
 #[derive(Default, Debug)]
-pub struct ExecutionInfo<Extra: Debug + Default = ()> {
+pub struct ExecutionInfo {
     /// All executed transactions (unrecovered).
     pub executed_transactions: Vec<OpTransactionSigned>,
     /// The recovered senders for the executed transactions.
@@ -39,13 +41,13 @@ pub struct ExecutionInfo<Extra: Debug + Default = ()> {
     pub cumulative_da_bytes_used: u64,
     /// Tracks fees from executed mempool transactions
     pub total_fees: U256,
-    /// Extra execution information that can be attached by individual builders.
-    pub extra: Extra,
+    /// Extra execution information for the Flashblocks builder
+    pub extra: FlashblocksExecutionInfo,
     /// DA Footprint Scalar for Jovian
     pub da_footprint_scalar: Option<u16>,
 }
 
-impl<T: Debug + Default> ExecutionInfo<T> {
+impl ExecutionInfo {
     /// Create a new instance with allocated slots.
     pub fn with_capacity(capacity: usize) -> Self {
         Self {

--- a/crates/builder/op-rbuilder/src/tests/flashblocks.rs
+++ b/crates/builder/op-rbuilder/src/tests/flashblocks.rs
@@ -97,6 +97,8 @@ async fn smoke_dynamic_base() -> eyre::Result<()> {
     let flashblocks = flashblocks_listener.get_flashblocks();
     assert_eq!(110, flashblocks.len());
 
+    dbg!(flashblocks);
+
     flashblocks_listener.stop().await
 }
 

--- a/crates/builder/op-rbuilder/src/tests/flashblocks.rs
+++ b/crates/builder/op-rbuilder/src/tests/flashblocks.rs
@@ -97,8 +97,6 @@ async fn smoke_dynamic_base() -> eyre::Result<()> {
     let flashblocks = flashblocks_listener.get_flashblocks();
     assert_eq!(110, flashblocks.len());
 
-    dbg!(flashblocks);
-
     flashblocks_listener.stop().await
 }
 

--- a/crates/shared/access-lists/src/db.rs
+++ b/crates/shared/access-lists/src/db.rs
@@ -52,6 +52,11 @@ where
         self.index = index;
     }
 
+    /// Increments the transaction index of the transaction currently being executed
+    pub const fn inc_index(&mut self) {
+        self.index += 1;
+    }
+
     /// Attempts to commit the changes to the underlying database
     /// as well as applies account/storage changes to the access list builder
     fn try_commit(


### PR DESCRIPTION
## Summary

This PR integrates Flashblock Access List (FAL) generation into the builder's block construction flow:

- **Adds `base-access-lists` dependency** to `op-rbuilder` to use the `FBALBuilderDb` wrapper
- **Wraps the EVM database** with `FBALBuilderDb` during both sequencer and best transaction execution to track storage/account access patterns per transaction
- **Tracks transaction indices** by calling `set_index()` before execution and `inc_index()` after each transaction commits
- **Builds and attaches FALs to flashblocks** - after transaction execution, the access list builder is finalized and included in the `FlashblocksMetadata` that gets broadcast
- **Simplifies `ExecutionInfo`** by removing the generic `Extra` parameter and directly embedding `FlashblocksExecutionInfo`

Closes #379