### PR TITLE
metrics: builder priority fee metrics 

### DIFF
--- a/crates/builder/op-rbuilder/src/flashblocks/context.rs
+++ b/crates/builder/op-rbuilder/src/flashblocks/context.rs
@@ -566,6 +566,7 @@ impl OpPayloadBuilderCtx {
             let miner_fee = tx
                 .effective_tip_per_gas(base_fee)
                 .expect("fee is always valid; execution succeeded");
+            self.metrics.tx_priority_fee.record(miner_fee as f64);
             info.total_fees += U256::from(miner_fee) * U256::from(gas_used);
 
             // append sender and transaction to the respective lists

--- a/crates/builder/op-rbuilder/src/flashblocks/context.rs
+++ b/crates/builder/op-rbuilder/src/flashblocks/context.rs
@@ -48,11 +48,12 @@ fn record_rejected_tx_priority_fee(reason: TxnExecutionResult, priority_fee: f64
     let r = match reason {
         TxnExecutionResult::TransactionDALimitExceeded => "transaction_da_limit_exceeded",
         TxnExecutionResult::BlockDALimitExceeded(_, _, _) => "block_da_limit_exceeded",
-        TxnExecutionResult::TransactionGasLimitExceeded(_, _, _) => "transaction_gas_limit_exceeded",
+        TxnExecutionResult::TransactionGasLimitExceeded(_, _, _) => {
+            "transaction_gas_limit_exceeded"
+        }
         _ => "unknown",
     };
-    metrics::histogram!("op_rbuilder_rejected_tx_priority_fee", "reason" => r)
-        .record(priority_fee);
+    metrics::histogram!("op_rbuilder_rejected_tx_priority_fee", "reason" => r).record(priority_fee);
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/builder/op-rbuilder/src/flashblocks/context.rs
+++ b/crates/builder/op-rbuilder/src/flashblocks/context.rs
@@ -520,13 +520,17 @@ impl OpPayloadBuilderCtx {
 
                         if err.is_nonce_too_low() {
                             // if the nonce is too low, we can skip this transaction
-                            self.metrics.rejected_tx_priority_fee_nonce_too_low.record(priority_fee);
+                            self.metrics
+                                .rejected_tx_priority_fee_nonce_too_low
+                                .record(priority_fee);
                             log_txn(TxnExecutionResult::NonceTooLow);
                             trace!(target: "payload_builder", %err, ?tx, "skipping nonce too low transaction");
                         } else {
                             // if the transaction is invalid, we can skip it and all of its
                             // descendants
-                            self.metrics.rejected_tx_priority_fee_internal_error.record(priority_fee);
+                            self.metrics
+                                .rejected_tx_priority_fee_internal_error
+                                .record(priority_fee);
                             log_txn(TxnExecutionResult::InternalError(err.clone()));
                             trace!(target: "payload_builder", %err, ?tx, "skipping invalid transaction and its descendants");
                             best_txs.mark_invalid(tx.signer(), tx.nonce());

--- a/crates/builder/op-rbuilder/src/flashblocks/context.rs
+++ b/crates/builder/op-rbuilder/src/flashblocks/context.rs
@@ -44,6 +44,7 @@ use crate::{
     tx_data_store::{TxData, TxDataStore},
 };
 
+/// Records the priority fee of a rejected transaction with the given reason as a label.
 fn record_rejected_tx_priority_fee(reason: TxnExecutionResult, priority_fee: f64) {
     let r = match reason {
         TxnExecutionResult::TransactionDALimitExceeded => "transaction_da_limit_exceeded",

--- a/crates/builder/op-rbuilder/src/flashblocks/context.rs
+++ b/crates/builder/op-rbuilder/src/flashblocks/context.rs
@@ -515,9 +515,8 @@ impl OpPayloadBuilderCtx {
             let ResultAndState { result, state } = match evm.transact(&tx) {
                 Ok(res) => res,
                 Err(err) => {
+                    let priority_fee = tx.effective_tip_per_gas(base_fee).unwrap_or(0) as f64;
                     if let Some(err) = err.as_invalid_tx_err() {
-                        let priority_fee = tx.effective_tip_per_gas(base_fee).unwrap_or(0) as f64;
-
                         if err.is_nonce_too_low() {
                             // if the nonce is too low, we can skip this transaction
                             self.metrics
@@ -539,6 +538,7 @@ impl OpPayloadBuilderCtx {
                         continue;
                     }
                     // this is an error that we should treat as fatal for this attempt
+                    self.metrics.rejected_tx_priority_fee_evm_error.record(priority_fee);
                     log_txn(TxnExecutionResult::EvmError);
                     return Err(PayloadBuilderError::evm(err));
                 }

--- a/crates/builder/op-rbuilder/src/flashblocks/context.rs
+++ b/crates/builder/op-rbuilder/src/flashblocks/context.rs
@@ -53,7 +53,7 @@ fn record_rejected_tx_priority_fee(reason: TxnExecutionResult, priority_fee: f64
         }
         _ => "unknown",
     };
-    metrics::histogram!("op_rbuilder_rejected_tx_priority_fee", "reason" => r).record(priority_fee);
+    reth_metrics::metrics::histogram!("op_rbuilder_rejected_tx_priority_fee", "reason" => r).record(priority_fee);
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/builder/op-rbuilder/src/flashblocks/context.rs
+++ b/crates/builder/op-rbuilder/src/flashblocks/context.rs
@@ -53,7 +53,8 @@ fn record_rejected_tx_priority_fee(reason: TxnExecutionResult, priority_fee: f64
         }
         _ => "unknown",
     };
-    reth_metrics::metrics::histogram!("op_rbuilder_rejected_tx_priority_fee", "reason" => r).record(priority_fee);
+    reth_metrics::metrics::histogram!("op_rbuilder_rejected_tx_priority_fee", "reason" => r)
+        .record(priority_fee);
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/builder/op-rbuilder/src/flashblocks/context.rs
+++ b/crates/builder/op-rbuilder/src/flashblocks/context.rs
@@ -595,7 +595,6 @@ impl OpPayloadBuilderCtx {
             let miner_fee = tx
                 .effective_tip_per_gas(base_fee)
                 .expect("fee is always valid; execution succeeded");
-            self.metrics.tx_priority_fee.record(miner_fee as f64);
             info.total_fees += U256::from(miner_fee) * U256::from(gas_used);
 
             // append sender and transaction to the respective lists

--- a/crates/builder/op-rbuilder/src/metrics.rs
+++ b/crates/builder/op-rbuilder/src/metrics.rs
@@ -151,6 +151,8 @@ pub struct OpRBuilderMetrics {
     pub rejected_tx_priority_fee_internal_error: Histogram,
     /// Priority fee of rejected transactions: Max gas per transaction exceeded
     pub rejected_tx_priority_fee_max_gas_exceeded: Histogram,
+    /// Priority fee of rejected transactions: EVM error
+    pub rejected_tx_priority_fee_evm_error: Histogram,
     /// How much less flashblocks we issue to be on time with block construction
     pub reduced_flashblocks_number: Histogram,
     /// How much less flashblocks we issued in reality, comparing to calculated number for block

--- a/crates/builder/op-rbuilder/src/metrics.rs
+++ b/crates/builder/op-rbuilder/src/metrics.rs
@@ -139,6 +139,20 @@ pub struct OpRBuilderMetrics {
     pub tx_byte_size: Histogram,
     /// Priority fee of transactions
     pub tx_priority_fee: Histogram,
+    /// Priority fee of rejected transactions: Transaction DA limit exceeded
+    pub rejected_tx_priority_fee_da_limit: Histogram,
+    /// Priority fee of rejected transactions: Block DA limit exceeded
+    pub rejected_tx_priority_fee_block_da_limit: Histogram,
+    /// Priority fee of rejected transactions: Block gas limit exceeded
+    pub rejected_tx_priority_fee_block_gas_limit: Histogram,
+    /// Priority fee of rejected transactions: Invalid transaction type (blob/deposit)
+    pub rejected_tx_priority_fee_sequencer_type: Histogram,
+    /// Priority fee of rejected transactions: Nonce too low
+    pub rejected_tx_priority_fee_nonce_too_low: Histogram,
+    /// Priority fee of rejected transactions: Internal error (invalid signature, etc.)
+    pub rejected_tx_priority_fee_internal_error: Histogram,
+    /// Priority fee of rejected transactions: Max gas per transaction exceeded
+    pub rejected_tx_priority_fee_max_gas_exceeded: Histogram,
     /// How much less flashblocks we issue to be on time with block construction
     pub reduced_flashblocks_number: Histogram,
     /// How much less flashblocks we issued in reality, comparing to calculated number for block

--- a/crates/builder/op-rbuilder/src/metrics.rs
+++ b/crates/builder/op-rbuilder/src/metrics.rs
@@ -143,16 +143,10 @@ pub struct OpRBuilderMetrics {
     pub rejected_tx_priority_fee_block_da_limit: Histogram,
     /// Priority fee of rejected transactions: Block gas limit exceeded
     pub rejected_tx_priority_fee_block_gas_limit: Histogram,
-    /// Priority fee of rejected transactions: Invalid transaction type (blob/deposit)
-    pub rejected_tx_priority_fee_sequencer_type: Histogram,
-    /// Priority fee of rejected transactions: Nonce too low
-    pub rejected_tx_priority_fee_nonce_too_low: Histogram,
     /// Priority fee of rejected transactions: Internal error (invalid signature, etc.)
     pub rejected_tx_priority_fee_internal_error: Histogram,
     /// Priority fee of rejected transactions: Max gas per transaction exceeded
     pub rejected_tx_priority_fee_max_gas_exceeded: Histogram,
-    /// Priority fee of rejected transactions: EVM error
-    pub rejected_tx_priority_fee_evm_error: Histogram,
     /// How much less flashblocks we issue to be on time with block construction
     pub reduced_flashblocks_number: Histogram,
     /// How much less flashblocks we issued in reality, comparing to calculated number for block

--- a/crates/builder/op-rbuilder/src/metrics.rs
+++ b/crates/builder/op-rbuilder/src/metrics.rs
@@ -137,12 +137,6 @@ pub struct OpRBuilderMetrics {
     pub tx_simulation_duration: Histogram,
     /// Byte size of transactions
     pub tx_byte_size: Histogram,
-    /// Priority fee of rejected transactions: Transaction DA limit exceeded
-    pub rejected_tx_priority_fee_da_limit: Histogram,
-    /// Priority fee of rejected transactions: Block DA limit exceeded
-    pub rejected_tx_priority_fee_block_da_limit: Histogram,
-    /// Priority fee of rejected transactions: Block gas limit exceeded
-    pub rejected_tx_priority_fee_block_gas_limit: Histogram,
     /// How much less flashblocks we issue to be on time with block construction
     pub reduced_flashblocks_number: Histogram,
     /// How much less flashblocks we issued in reality, comparing to calculated number for block

--- a/crates/builder/op-rbuilder/src/metrics.rs
+++ b/crates/builder/op-rbuilder/src/metrics.rs
@@ -137,8 +137,6 @@ pub struct OpRBuilderMetrics {
     pub tx_simulation_duration: Histogram,
     /// Byte size of transactions
     pub tx_byte_size: Histogram,
-    /// Priority fee of transactions
-    pub tx_priority_fee: Histogram,
     /// Priority fee of rejected transactions: Transaction DA limit exceeded
     pub rejected_tx_priority_fee_da_limit: Histogram,
     /// Priority fee of rejected transactions: Block DA limit exceeded

--- a/crates/builder/op-rbuilder/src/metrics.rs
+++ b/crates/builder/op-rbuilder/src/metrics.rs
@@ -143,10 +143,6 @@ pub struct OpRBuilderMetrics {
     pub rejected_tx_priority_fee_block_da_limit: Histogram,
     /// Priority fee of rejected transactions: Block gas limit exceeded
     pub rejected_tx_priority_fee_block_gas_limit: Histogram,
-    /// Priority fee of rejected transactions: Internal error (invalid signature, etc.)
-    pub rejected_tx_priority_fee_internal_error: Histogram,
-    /// Priority fee of rejected transactions: Max gas per transaction exceeded
-    pub rejected_tx_priority_fee_max_gas_exceeded: Histogram,
     /// How much less flashblocks we issue to be on time with block construction
     pub reduced_flashblocks_number: Histogram,
     /// How much less flashblocks we issued in reality, comparing to calculated number for block

--- a/crates/builder/op-rbuilder/src/metrics.rs
+++ b/crates/builder/op-rbuilder/src/metrics.rs
@@ -137,6 +137,8 @@ pub struct OpRBuilderMetrics {
     pub tx_simulation_duration: Histogram,
     /// Byte size of transactions
     pub tx_byte_size: Histogram,
+    /// Priority fee of transactions
+    pub tx_priority_fee: Histogram,
     /// How much less flashblocks we issue to be on time with block construction
     pub reduced_flashblocks_number: Histogram,
     /// How much less flashblocks we issued in reality, comparing to calculated number for block

--- a/crates/builder/op-rbuilder/src/primitives/reth/execution.rs
+++ b/crates/builder/op-rbuilder/src/primitives/reth/execution.rs
@@ -8,7 +8,7 @@ use reth_optimism_primitives::{OpReceipt, OpTransactionSigned};
 
 use crate::flashblocks::FlashblocksExecutionInfo;
 
-#[derive(Debug, Display)]
+#[derive(Debug, Display, Clone)]
 pub enum TxnExecutionResult {
     TransactionDALimitExceeded,
     #[display("BlockDALimitExceeded: total_da_used={_0} tx_da_size={_1} block_da_limit={_2}")]


### PR DESCRIPTION
Adds metrics for rejected transactions that didn't make it into the FB with the priority fee passed in, along with the rejected reason