### PR TITLE
chore: enable jemalloc by default

### DIFF
--- a/bin/node/Cargo.toml
+++ b/bin/node/Cargo.toml
@@ -29,5 +29,5 @@ reth-cli-util.workspace = true
 clap.workspace = true
 
 [features]
-default = []
+default = [ "jemalloc" ]
 jemalloc = [ "reth-cli-util/jemalloc", "reth-optimism-cli/jemalloc" ]


### PR DESCRIPTION
### Description
Enable jemalloc on the base client by default (we already have this on the builder).