### PR TITLE
chore(workspace): Clippy Lint Clones

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,8 @@ missing-const-for-fn = "warn"
 use-self = "warn"
 option-if-let-else = "warn"
 redundant-clone = "warn"
+clone-on-ref-ptr = "warn"
+unnecessary-to-owned = "warn"
 
 [profile.dev]
 debug = "line-tables-only"

--- a/crates/builder/op-rbuilder/src/flashblocks/generator.rs
+++ b/crates/builder/op-rbuilder/src/flashblocks/generator.rs
@@ -338,7 +338,7 @@ where
         let payload_config = self.config.clone();
         let cell = self.cell.clone();
         let cancel = self.cancel.clone();
-        let publish_guard = self.publish_guard.clone();
+        let publish_guard = Arc::clone(&self.publish_guard);
         let finalized_cell = self.finalized_cell.clone();
         let compute_state_root_on_finalize = self.compute_state_root_on_finalize;
 

--- a/crates/builder/op-rbuilder/src/flashblocks/service.rs
+++ b/crates/builder/op-rbuilder/src/flashblocks/service.rs
@@ -34,7 +34,7 @@ impl FlashblocksServiceBuilder {
         let (built_payload_tx, built_payload_rx) = tokio::sync::mpsc::channel(16);
 
         let ws_pub: Arc<WebSocketPublisher> =
-            WebSocketPublisher::new(self.0.flashblocks.ws_addr, metrics.clone())?.into();
+            WebSocketPublisher::new(self.0.flashblocks.ws_addr, Arc::clone(&metrics))?.into();
         let payload_builder = OpPayloadBuilder::new(
             OpEvmConfig::optimism(ctx.chain_spec()),
             pool,

--- a/crates/builder/op-rbuilder/src/primitives/reth/engine_api_builder.rs
+++ b/crates/builder/op-rbuilder/src/primitives/reth/engine_api_builder.rs
@@ -1,5 +1,7 @@
 //! RPC component builder
 
+use std::sync::Arc;
+
 use alloy_eips::eip7685::Requests;
 use alloy_primitives::{B256, BlockHash, U64};
 use alloy_rpc_types_engine::{
@@ -62,7 +64,7 @@ where
         };
         let inner = reth_rpc_engine_api::EngineApi::new(
             ctx.node.provider().clone(),
-            ctx.config.chain.clone(),
+            Arc::clone(&ctx.config.chain),
             ctx.beacon_engine_handle.clone(),
             PayloadStore::new(ctx.node.payload_builder_handle().clone()),
             ctx.node.pool().clone(),

--- a/crates/builder/op-rbuilder/src/tests/framework/instance.rs
+++ b/crates/builder/op-rbuilder/src/tests/framework/instance.rs
@@ -335,7 +335,7 @@ impl FlashblocksListener {
         let flashblocks = Arc::new(Mutex::new(Vec::new()));
         let cancellation_token = CancellationToken::new();
 
-        let flashblocks_clone = flashblocks.clone();
+        let flashblocks_clone = Arc::clone(&flashblocks);
         let cancellation_token_clone = cancellation_token.clone();
 
         let handle = tokio::spawn(async move {

--- a/crates/client/flashblocks-node/src/test_harness.rs
+++ b/crates/client/flashblocks-node/src/test_harness.rs
@@ -69,7 +69,7 @@ impl fmt::Debug for FlashblocksParts {
 impl FlashblocksParts {
     /// Clone the shared [`FlashblocksState`] handle.
     pub fn state(&self) -> Arc<FlashblocksState> {
-        self.state.clone()
+        Arc::clone(&self.state)
     }
 
     /// Send a flashblock to the background processor and wait until it is handled.
@@ -124,17 +124,20 @@ impl FlashblocksTestExtension {
 
     /// Get the flashblocks parts after the node has been launched.
     pub fn parts(&self) -> Result<FlashblocksParts> {
-        Ok(FlashblocksParts { sender: self.inner.sender.clone(), state: self.inner.state.clone() })
+        Ok(FlashblocksParts {
+            sender: self.inner.sender.clone(),
+            state: Arc::clone(&self.inner.state),
+        })
     }
 }
 
 impl BaseNodeExtension for FlashblocksTestExtension {
     fn apply(self: Box<Self>, builder: BaseBuilder) -> BaseBuilder {
-        let state = self.inner.state.clone();
-        let receiver = self.inner.receiver.clone();
+        let state = Arc::clone(&self.inner.state);
+        let receiver = Arc::clone(&self.inner.receiver);
         let process_canonical = self.inner.process_canonical;
 
-        let state_for_start = state.clone();
+        let state_for_start = Arc::clone(&state);
         let state_for_rpc = state;
 
         // Start state processor and subscriptions after node is started
@@ -180,14 +183,14 @@ impl BaseNodeExtension for FlashblocksTestExtension {
             let api_ext = EthApiExt::new(
                 ctx.registry.eth_api().clone(),
                 ctx.registry.eth_handlers().filter.clone(),
-                fb.clone(),
+                Arc::clone(&fb),
             );
             ctx.modules.replace_configured(api_ext.into_rpc())?;
 
             // Register eth_subscribe subscription endpoint for flashblocks
             // Uses replace_configured since eth_subscribe already exists from reth's standard module
             // Pass eth_api to enable proxying standard subscription types to reth's implementation
-            let eth_pubsub = EthPubSub::new(ctx.registry.eth_api().clone(), fb.clone());
+            let eth_pubsub = EthPubSub::new(ctx.registry.eth_api().clone(), Arc::clone(&fb));
             ctx.modules.replace_configured(eth_pubsub.into_rpc())?;
 
             let fb_for_task = fb;

--- a/crates/client/flashblocks/src/receipt_builder.rs
+++ b/crates/client/flashblocks/src/receipt_builder.rs
@@ -188,7 +188,7 @@ mod tests {
     #[test]
     fn test_unified_receipt_builder_creation() {
         let chain_spec = Arc::new(OpChainSpecBuilder::base_mainnet().build());
-        let builder = UnifiedReceiptBuilder::new(chain_spec.clone());
+        let builder = UnifiedReceiptBuilder::new(Arc::clone(&chain_spec));
         assert!(Arc::ptr_eq(builder.chain_spec(), &chain_spec));
     }
 
@@ -258,7 +258,7 @@ mod tests {
     fn test_build_legacy_receipt() {
         let chain_spec = Arc::new(OpChainSpecBuilder::base_mainnet().build());
         let mut db = InMemoryDB::default();
-        let mut evm = create_test_evm(chain_spec.clone(), &mut db);
+        let mut evm = create_test_evm(Arc::clone(&chain_spec), &mut db);
 
         let builder = UnifiedReceiptBuilder::new(chain_spec);
         let tx = create_legacy_tx();
@@ -277,7 +277,7 @@ mod tests {
     fn test_build_deposit_receipt() {
         let chain_spec = Arc::new(OpChainSpecBuilder::base_mainnet().build());
         let mut db = InMemoryDB::default();
-        let mut evm = create_test_evm(chain_spec.clone(), &mut db);
+        let mut evm = create_test_evm(Arc::clone(&chain_spec), &mut db);
 
         let builder = UnifiedReceiptBuilder::new(chain_spec);
         let tx = create_deposit_tx();
@@ -297,7 +297,7 @@ mod tests {
         // Canyon activates deposit_receipt_version
         let chain_spec = Arc::new(OpChainSpecBuilder::base_mainnet().build());
         let mut db = InMemoryDB::default();
-        let mut evm = create_test_evm(chain_spec.clone(), &mut db);
+        let mut evm = create_test_evm(Arc::clone(&chain_spec), &mut db);
 
         let builder = UnifiedReceiptBuilder::new(chain_spec);
         let tx = create_deposit_tx();
@@ -320,7 +320,7 @@ mod tests {
     fn test_build_failed_transaction_receipt() {
         let chain_spec = Arc::new(OpChainSpecBuilder::base_mainnet().build());
         let mut db = InMemoryDB::default();
-        let mut evm = create_test_evm(chain_spec.clone(), &mut db);
+        let mut evm = create_test_evm(Arc::clone(&chain_spec), &mut db);
 
         let builder = UnifiedReceiptBuilder::new(chain_spec);
         let tx = create_legacy_tx();

--- a/crates/client/flashblocks/src/state.rs
+++ b/crates/client/flashblocks/src/state.rs
@@ -67,9 +67,9 @@ impl FlashblocksState {
     {
         let state_processor = StateProcessor::new(
             client,
-            self.pending_blocks.clone(),
+            Arc::clone(&self.pending_blocks),
             self.max_pending_blocks_depth,
-            self.rx.clone(),
+            Arc::clone(&self.rx),
             self.flashblock_sender.clone(),
         );
 

--- a/crates/client/flashblocks/src/subscription.rs
+++ b/crates/client/flashblocks/src/subscription.rs
@@ -156,7 +156,7 @@ where
             }
         });
 
-        let flashblocks_state = self.flashblocks_state.clone();
+        let flashblocks_state = Arc::clone(&self.flashblocks_state);
         tokio::spawn(async move {
             while let Some(message) = mailbox.recv().await {
                 match message {

--- a/crates/client/metering/src/extension.rs
+++ b/crates/client/metering/src/extension.rs
@@ -39,7 +39,7 @@ impl BaseNodeExtension for MeteringExtension {
 
             // Get flashblocks state from config, or create a default one if not configured
             let fb_state: Arc<FlashblocksState> =
-                flashblocks_config.as_ref().map(|cfg| cfg.state.clone()).unwrap_or_default();
+                flashblocks_config.as_ref().map(|cfg| Arc::clone(&cfg.state)).unwrap_or_default();
 
             let metering_api = MeteringApiImpl::new(ctx.provider().clone(), fb_state);
             ctx.modules.merge_configured(metering_api.into_rpc())?;

--- a/crates/client/node/src/test_utils/node.rs
+++ b/crates/client/node/src/test_utils/node.rs
@@ -87,7 +87,7 @@ impl LocalNode {
 
         let (db, db_path) = Self::create_test_database()?;
 
-        let mut node_config = NodeConfig::new(chain_spec.clone())
+        let mut node_config = NodeConfig::new(Arc::clone(&chain_spec))
             .with_network(network_config)
             .with_rpc(rpc_args)
             .with_unused_ports();

--- a/crates/client/proofs/src/proofs.rs
+++ b/crates/client/proofs/src/proofs.rs
@@ -57,7 +57,7 @@ impl BaseNodeExtension for ProofsHistoryExtension {
                 }
             };
             let mdbx = Arc::new(mdbx);
-            let storage: OpProofsStorage<Arc<MdbxProofsStorage>> = mdbx.clone().into();
+            let storage: OpProofsStorage<Arc<MdbxProofsStorage>> = Arc::clone(&mdbx).into();
 
             let storage_exec = storage.clone();
 

--- a/crates/client/txpool/src/extension.rs
+++ b/crates/client/txpool/src/extension.rs
@@ -62,8 +62,10 @@ impl BaseNodeExtension for TxPoolExtension {
                 let pool = ctx.pool().clone();
 
                 // Get flashblocks state from config, or create a default one if not configured
-                let fb_state: Arc<FlashblocksState> =
-                    flashblocks_config.as_ref().map(|cfg| cfg.state.clone()).unwrap_or_default();
+                let fb_state: Arc<FlashblocksState> = flashblocks_config
+                    .as_ref()
+                    .map(|cfg| Arc::clone(&cfg.state))
+                    .unwrap_or_default();
 
                 tokio::spawn(tracex_subscription(canonical_stream, fb_state, pool, logs_enabled));
             }

--- a/crates/shared/access-lists/tests/builder/main.rs
+++ b/crates/shared/access-lists/tests/builder/main.rs
@@ -44,7 +44,7 @@ pub fn execute_txns_build_access_list(
     storage_overrides: Option<HashMap<Address, HashMap<U256, B256>>>,
 ) -> Result<FlashblockAccessList> {
     let chain_spec = load_chain_spec();
-    let evm_config = OpEvmConfig::optimism(chain_spec.clone());
+    let evm_config = OpEvmConfig::optimism(Arc::clone(&chain_spec));
     let header = Header { base_fee_per_gas: Some(0), ..chain_spec.genesis_header().clone() };
 
     // Set up the underlying InMemoryDB with any overrides


### PR DESCRIPTION
## Summary

Enables new clippy lints in `Cargo.toml`.
   - clone-on-ref-ptr = "warn" - catches .clone() on Arc/Rc where Arc::clone(&x) is clearer
   - unnecessary-to-owned = "warn" - catches .to_owned()/.clone() when borrowing suffices

Fixes issues identified by these lints across the workspace.