### PR TITLE
chore(workspace): Enables Stricter Clippy Lints

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,13 +27,43 @@ unnameable-types = "warn"
 all = "warn"
 
 [workspace.lints.clippy]
+# Baseline - enable all default clippy lints
 all = { level = "warn", priority = -1 }
+
+# === Performance & Cloning ===
 missing-const-for-fn = "warn"
-use-self = "warn"
-option-if-let-else = "warn"
 redundant-clone = "warn"
 clone-on-ref-ptr = "warn"
 unnecessary-to-owned = "warn"
+cloned-instead-of-copied = "warn"
+flat-map-option = "warn"
+implicit-clone = "warn"
+or-fun-call = "warn"
+
+# === Code Style ===
+use-self = "warn"
+option-if-let-else = "warn"
+uninlined-format-args = "warn"
+manual-string-new = "warn"
+single-char-pattern = "warn"
+redundant-else = "warn"
+match-same-arms = "warn"
+
+# === Safety & Documentation ===
+undocumented-unsafe-blocks = "warn"
+doc-markdown = "warn"
+
+# === Debugging Artifacts ===
+dbg-macro = "warn"
+
+# === Code Quality ===
+branches-sharing-code = "warn"
+derive-partial-eq-without-eq = "warn"
+explicit-into-iter-loop = "warn"
+explicit-iter-loop = "warn"
+iter-with-drain = "warn"
+needless-pass-by-ref-mut = "warn"
+string-lit-as-bytes = "warn"
 
 [profile.dev]
 debug = "line-tables-only"

--- a/bin/consensus/src/metrics.rs
+++ b/bin/consensus/src/metrics.rs
@@ -3,7 +3,7 @@
 use kona_genesis::RollupConfig;
 
 /// Metrics to record various CLI options.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CliMetrics;
 
 impl CliMetrics {

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,0 +1,26 @@
+allow-dbg-in-tests = true
+allow-print-in-tests = true
+too-large-for-stack = 256
+doc-valid-idents = [
+    "L1",
+    "L2",
+    "RPC",
+    "EVM",
+    "EIP",
+    "Flashblocks",
+    "Reth",
+    "Kona",
+    "geth",
+    "SSZ",
+    "JWT",
+    "API",
+    "URL",
+    "URI",
+    "HTTP",
+    "HTTPS",
+    "WebSocket",
+    "JSON",
+    "MEV",
+    "OP",
+    "Optimism",
+]

--- a/crates/builder/base-builder-cli/README.md
+++ b/crates/builder/base-builder-cli/README.md
@@ -8,7 +8,7 @@ This crate provides reusable CLI argument types for configuring the OP builder:
 
 - **`OpRbuilderArgs`**: Main builder configuration including rollup, flashblocks, and telemetry settings
 - **`FlashblocksArgs`**: Flashblocks-specific configuration (ports, timing, state root)
-- **`TelemetryArgs`**: OpenTelemetry configuration for tracing
+- **`TelemetryArgs`**: `OpenTelemetry` configuration for tracing
 
 ## Usage
 

--- a/crates/builder/base-builder-cli/src/flashblocks.rs
+++ b/crates/builder/base-builder-cli/src/flashblocks.rs
@@ -43,9 +43,9 @@ pub struct FlashblocksArgs {
     )]
     pub flashblocks_disable_state_root: bool,
 
-    /// Whether to compute state root only when get_payload is called (finalization).
+    /// Whether to compute state root only when `get_payload` is called (finalization).
     /// When enabled, flashblocks are built without state root, but the final payload
-    /// returned by get_payload will have the state root computed.
+    /// returned by `get_payload` will have the state root computed.
     /// Requires --flashblocks.disable-state-root to be effective.
     #[arg(
         long = "flashblocks.compute-state-root-on-finalize",

--- a/crates/builder/base-builder-cli/src/op.rs
+++ b/crates/builder/base-builder-cli/src/op.rs
@@ -1,6 +1,6 @@
 //! Additional Node command arguments for the OP builder.
 //!
-//! Copied from OptimismNode to allow easy extension.
+//! Copied from `OptimismNode` to allow easy extension.
 
 use reth_optimism_node::args::RollupArgs;
 

--- a/crates/builder/base-builder-cli/src/telemetry.rs
+++ b/crates/builder/base-builder-cli/src/telemetry.rs
@@ -5,11 +5,11 @@ use clap::Args;
 /// Parameters for telemetry configuration.
 #[derive(Debug, Clone, Default, PartialEq, Eq, Args)]
 pub struct TelemetryArgs {
-    /// OpenTelemetry endpoint for traces
+    /// `OpenTelemetry` endpoint for traces
     #[arg(long = "telemetry.otlp-endpoint", env = "OTEL_EXPORTER_OTLP_ENDPOINT")]
     pub otlp_endpoint: Option<String>,
 
-    /// OpenTelemetry headers for authentication
+    /// `OpenTelemetry` headers for authentication
     #[arg(long = "telemetry.otlp-headers", env = "OTEL_EXPORTER_OTLP_HEADERS")]
     pub otlp_headers: Option<String>,
 

--- a/crates/builder/op-rbuilder/README.md
+++ b/crates/builder/op-rbuilder/README.md
@@ -23,7 +23,7 @@ Optimism block builder for Base. Provides payload building infrastructure with s
 
 - `jemalloc`: Use jemalloc allocator (default).
 - `testing`: Enable testing utilities and framework.
-- `telemetry`: Enable OpenTelemetry integration.
+- `telemetry`: Enable `OpenTelemetry` integration.
 - `interop`: Enable interoperability features.
 - `custom-engine-api`: Enable custom engine API extensions.
 

--- a/crates/builder/op-rbuilder/src/flashblocks/config.rs
+++ b/crates/builder/op-rbuilder/src/flashblocks/config.rs
@@ -23,10 +23,10 @@ pub struct FlashblocksConfig {
     /// How much time would be deducted from block build time to account for latencies in
     /// milliseconds.
     ///
-    /// If dynamic_adjustment is false this value would be deducted from first flashblock and
+    /// If `dynamic_adjustment` is false this value would be deducted from first flashblock and
     /// it shouldn't be more than interval
     ///
-    /// If dynamic_adjustment is true this value would be deducted from first flashblock and
+    /// If `dynamic_adjustment` is true this value would be deducted from first flashblock and
     /// it shouldn't be more than interval
     pub leeway_time: Duration,
 
@@ -36,9 +36,9 @@ pub struct FlashblocksConfig {
     /// Should we disable state root calculation for each flashblock
     pub disable_state_root: bool,
 
-    /// Whether to compute state root only when get_payload is called (finalization).
+    /// Whether to compute state root only when `get_payload` is called (finalization).
     /// When enabled, flashblocks are built without state root, but the final payload
-    /// returned by get_payload will have the state root computed.
+    /// returned by `get_payload` will have the state root computed.
     pub compute_state_root_on_finalize: bool,
 }
 

--- a/crates/builder/op-rbuilder/src/flashblocks/generator.rs
+++ b/crates/builder/op-rbuilder/src/flashblocks/generator.rs
@@ -69,7 +69,7 @@ pub(super) struct BlockPayloadJobGenerator<Client, Tasks, Builder> {
     _config: BasicPayloadJobGeneratorConfig,
     /// The type responsible for building payloads.
     ///
-    /// See [PayloadBuilder]
+    /// See [`PayloadBuilder`]
     builder: Builder,
     /// Whether to ensure only one payload is being processed at a time
     ensure_only_one_payload: bool,
@@ -79,15 +79,15 @@ pub(super) struct BlockPayloadJobGenerator<Client, Tasks, Builder> {
     extra_block_deadline: std::time::Duration,
     /// Stored `cached_reads` for new payload jobs.
     pre_cached: Option<PrecachedState>,
-    /// Whether to compute state root only on finalization (when get_payload is called).
+    /// Whether to compute state root only on finalization (when `get_payload` is called).
     compute_state_root_on_finalize: bool,
 }
 
 // === impl BlockPayloadJobGenerator ===
 
 impl<Client, Tasks, Builder> BlockPayloadJobGenerator<Client, Tasks, Builder> {
-    /// Creates a new [BlockPayloadJobGenerator] with the given config and custom
-    /// [PayloadBuilder]
+    /// Creates a new [`BlockPayloadJobGenerator`] with the given config and custom
+    /// [`PayloadBuilder`]
     pub(super) fn with_builder(
         client: Client,
         executor: Tasks,
@@ -240,7 +240,7 @@ use std::{
     task::{Context, Poll},
 };
 
-/// A [PayloadJob] that builds empty blocks.
+/// A [`PayloadJob`] that builds empty blocks.
 pub(super) struct BlockPayloadJob<Tasks, Builder>
 where
     Builder: PayloadBuilder,
@@ -251,13 +251,13 @@ where
     pub(crate) executor: Tasks,
     /// The type responsible for building payloads.
     ///
-    /// See [PayloadBuilder]
+    /// See [`PayloadBuilder`]
     pub(crate) builder: Builder,
     /// The cell that holds the built payload (intermediate flashblocks, may not have state root).
     pub(crate) cell: BlockCell<Builder::BuiltPayload>,
     /// The cell that holds the finalized payload with state root computed.
     pub(crate) finalized_cell: BlockCell<Builder::BuiltPayload>,
-    /// Whether to compute state root only on finalization (when get_payload is called).
+    /// Whether to compute state root only on finalization (when `get_payload` is called).
     pub(crate) compute_state_root_on_finalize: bool,
     /// Cancellation token for the running job
     pub(crate) cancel: CancellationToken,
@@ -324,11 +324,11 @@ pub(super) struct BuildArguments<Attributes, Payload: BuiltPayload> {
     pub publish_guard: Arc<Mutex<()>>,
     /// Cell to store the finalized payload with state root.
     pub finalized_cell: BlockCell<Payload>,
-    /// Whether to compute state root only on finalization (when get_payload is called).
+    /// Whether to compute state root only on finalization (when `get_payload` is called).
     pub compute_state_root_on_finalize: bool,
 }
 
-/// A [PayloadJob] is a future that's being polled by the `PayloadBuilderService`
+/// A [`PayloadJob`] is a future that's being polled by the `PayloadBuilderService`
 impl<Tasks, Builder> BlockPayloadJob<Tasks, Builder>
 where
     Tasks: TaskSpawner + Clone + 'static,
@@ -364,7 +364,7 @@ where
     }
 }
 
-/// A [PayloadJob] is a future that's being polled by the `PayloadBuilderService`
+/// A [`PayloadJob`] is a future that's being polled by the `PayloadBuilderService`
 impl<Tasks, Builder> Future for BlockPayloadJob<Tasks, Builder>
 where
     Tasks: TaskSpawner + Clone + 'static,

--- a/crates/builder/op-rbuilder/src/flashblocks/wspub.rs
+++ b/crates/builder/op-rbuilder/src/flashblocks/wspub.rs
@@ -23,7 +23,7 @@ use tracing::{debug, warn};
 
 use crate::metrics::OpRBuilderMetrics;
 
-/// A WebSockets publisher that accepts connections from client websockets and broadcasts to them
+/// A `WebSockets` publisher that accepts connections from client websockets and broadcasts to them
 /// updates about new flashblocks. It maintains a count of sent messages and active subscriptions.
 ///
 /// This is modelled as a `futures::Sink` that can be used to send `FlashblocksPayloadV1` messages.

--- a/crates/builder/op-rbuilder/src/primitives/reth/engine_api_builder.rs
+++ b/crates/builder/op-rbuilder/src/primitives/reth/engine_api_builder.rs
@@ -369,7 +369,7 @@ pub trait OpRbuilderEngineApi<Engine: EngineTypes> {
     /// Returns the execution payload bodies by the range starting at `start`, containing `count`
     /// blocks.
     ///
-    /// WARNING: This method is associated with the BeaconBlocksByRange message in the consensus
+    /// WARNING: This method is associated with the `BeaconBlocksByRange` message in the consensus
     /// layer p2p specification, meaning the input should be treated as untrusted or potentially
     /// adversarial.
     ///

--- a/crates/builder/op-rbuilder/src/primitives/telemetry.rs
+++ b/crates/builder/op-rbuilder/src/primitives/telemetry.rs
@@ -16,6 +16,8 @@ pub fn setup_telemetry_layer(
     // Otlp uses evn vars inside
 
     if let Some(headers) = &args.otlp_headers {
+        // SAFETY: This is called early during initialization before spawning async tasks.
+        // The OTLP library reads this environment variable during setup.
         unsafe { std::env::set_var("OTEL_EXPORTER_OTLP_HEADERS", headers) };
     }
 

--- a/crates/builder/op-rbuilder/src/tests/data_availability.rs
+++ b/crates/builder/op-rbuilder/src/tests/data_availability.rs
@@ -91,7 +91,7 @@ async fn block_fill() -> eyre::Result<()> {
 
 /// This test ensures that the DA footprint limit (Jovian) is respected and the block fills
 /// to the DA footprint limit. The DA footprint is calculated as:
-/// total_da_bytes_used * da_footprint_gas_scalar (stored in blob_gas_used).
+/// `total_da_bytes_used` * `da_footprint_gas_scalar` (stored in `blob_gas_used`).
 /// This must not exceed the block gas limit.
 #[tokio::test]
 async fn da_footprint_fills_to_limit() -> eyre::Result<()> {
@@ -144,15 +144,13 @@ async fn da_footprint_fills_to_limit() -> eyre::Result<()> {
     // The DA footprint must not exceed the block gas limit
     assert!(
         blob_gas == gas_limit,
-        "DA footprint (blob_gas_used={}) must not exceed block gas limit ({})",
-        blob_gas,
-        gas_limit
+        "DA footprint (blob_gas_used={blob_gas}) must not exceed block gas limit ({gas_limit})"
     );
 
     // Verify the block fills up to the DA footprint limit (flashblocks mode)
     // With more capacity now (no builder tx), more txs can fit
     for (i, tx_hash) in tx_hashes.iter().enumerate().take(9) {
-        assert!(block.includes(tx_hash), "tx {} should be included in the block", i);
+        assert!(block.includes(tx_hash), "tx {i} should be included in the block");
     }
 
     // Verify some txs don't fit due to DA footprint limit

--- a/crates/builder/op-rbuilder/src/tests/flashblocks.rs
+++ b/crates/builder/op-rbuilder/src/tests/flashblocks.rs
@@ -6,8 +6,8 @@ use base_builder_cli::{FlashblocksArgs, OpRbuilderArgs};
 use crate::tests::{TransactionBuilderExt, setup_test_instance_with_args};
 
 /// Test that when `compute_state_root_on_finalize` is enabled:
-/// 1. Flashblocks are built without state root (state_root = ZERO in intermediate blocks)
-/// 2. The final payload returned by get_payload has a valid state root (non-zero)
+/// 1. Flashblocks are built without state root (`state_root` = ZERO in intermediate blocks)
+/// 2. The final payload returned by `get_payload` has a valid state root (non-zero)
 #[tokio::test]
 async fn test_state_root_computed_on_finalize() -> eyre::Result<()> {
     let args = OpRbuilderArgs {

--- a/crates/builder/op-rbuilder/src/tests/framework/driver.rs
+++ b/crates/builder/op-rbuilder/src/tests/framework/driver.rs
@@ -20,7 +20,7 @@ use crate::{
     tx_signer::Signer,
 };
 
-/// The ChainDriver is a type that allows driving the op builder node to build new blocks manually
+/// The `ChainDriver` is a type that allows driving the op builder node to build new blocks manually
 /// by calling the `build_new_block` method. It uses the Engine API to interact with the node
 /// and the provider to fetch blocks and transactions.
 #[derive(Debug)]
@@ -37,7 +37,7 @@ pub struct ChainDriver<RpcProtocol: Protocol = Ipc> {
 impl<RpcProtocol: Protocol> ChainDriver<RpcProtocol> {
     const MIN_BLOCK_TIME: Duration = Duration::from_secs(1);
 
-    /// Creates a new ChainDriver instance for a local instance of RBuilder running in-process
+    /// Creates a new `ChainDriver` instance for a local instance of `RBuilder` running in-process
     /// communicating over IPC.
     pub async fn local(instance: &LocalInstance) -> eyre::Result<ChainDriver<Ipc>> {
         Ok(ChainDriver::<Ipc> {
@@ -50,7 +50,7 @@ impl<RpcProtocol: Protocol> ChainDriver<RpcProtocol> {
         })
     }
 
-    /// Creates a new ChainDriver for some EL node instance.
+    /// Creates a new `ChainDriver` for some EL node instance.
     pub fn remote(provider: RootProvider<Optimism>, engine_api: EngineApi<RpcProtocol>) -> Self {
         Self {
             engine_api,
@@ -70,7 +70,7 @@ impl<RpcProtocol: Protocol> ChainDriver<RpcProtocol> {
     }
 
     /// Specifies a custom gas limit for blocks being built, otherwise the limit is
-    /// set to a default value of 10_000_000.
+    /// set to a default value of `10_000_000`.
     pub const fn with_gas_limit(mut self, gas_limit: u64) -> Self {
         self.gas_limit = Some(gas_limit);
         self
@@ -101,7 +101,7 @@ impl<RpcProtocol: Protocol> ChainDriver<RpcProtocol> {
         self.build_new_block_with_txs(vec![]).await
     }
 
-    /// Builds a new block with block_timestamp calculated as block time right before sending FCU
+    /// Builds a new block with `block_timestamp` calculated as block time right before sending FCU
     pub async fn build_new_block_with_current_timestamp(
         &self,
         timestamp_jitter: Option<Duration>,

--- a/crates/builder/op-rbuilder/src/tests/framework/instance.rs
+++ b/crates/builder/op-rbuilder/src/tests/framework/instance.rs
@@ -330,7 +330,7 @@ pub struct FlashblocksListener {
 impl FlashblocksListener {
     /// Create a new flashblocks listener that connects to the given WebSocket URL.
     ///
-    /// The listener will automatically parse incoming messages as FlashblocksPayloadV1.
+    /// The listener will automatically parse incoming messages as `FlashblocksPayloadV1`.
     fn new(flashblocks_ws_url: String) -> Self {
         let flashblocks = Arc::new(Mutex::new(Vec::new()));
         let cancellation_token = CancellationToken::new();

--- a/crates/builder/op-rbuilder/src/tests/framework/mod.rs
+++ b/crates/builder/op-rbuilder/src/tests/framework/mod.rs
@@ -18,14 +18,14 @@ pub use txs::*;
 pub use utils::*;
 
 /// Sets up a test instance with default flashblocks configuration.
-/// This is the simplified replacement for the rb_test macro.
+/// This is the simplified replacement for the `rb_test` macro.
 pub async fn setup_test_instance() -> eyre::Result<LocalInstance> {
     clear_otel_env_vars();
     LocalInstance::flashblocks().await
 }
 
-/// Sets up a test instance with custom OpRbuilderArgs.
-/// The flashblocks_port will be automatically set to an available port.
+/// Sets up a test instance with custom `OpRbuilderArgs`.
+/// The `flashblocks_port` will be automatically set to an available port.
 pub async fn setup_test_instance_with_args(
     mut args: OpRbuilderArgs,
 ) -> eyre::Result<LocalInstance> {
@@ -34,8 +34,8 @@ pub async fn setup_test_instance_with_args(
     LocalInstance::new(args).await
 }
 
-/// Sets up a test instance with custom OpRbuilderArgs and NodeConfig.
-/// The flashblocks_port will be automatically set to an available port.
+/// Sets up a test instance with custom `OpRbuilderArgs` and `NodeConfig`.
+/// The `flashblocks_port` will be automatically set to an available port.
 pub async fn setup_test_instance_with_config(
     mut args: OpRbuilderArgs,
     config: NodeConfig<OpChainSpec>,
@@ -75,7 +75,6 @@ fn init_tests() {
     use tracing_subscriber::{filter::filter_fn, prelude::*};
     if let Ok(v) = std::env::var("TEST_TRACE") {
         let level = match v.as_str() {
-            "false" | "off" => return,
             "true" | "debug" | "on" => tracing::Level::DEBUG,
             "trace" => tracing::Level::TRACE,
             "info" => tracing::Level::INFO,

--- a/crates/builder/op-rbuilder/src/tests/framework/txs.rs
+++ b/crates/builder/op-rbuilder/src/tests/framework/txs.rs
@@ -93,7 +93,7 @@ impl TransactionBuilder {
     }
 
     pub async fn build(mut self) -> Recovered<OpTxEnvelope> {
-        let signer = self.signer.unwrap_or(funded_signer());
+        let signer = self.signer.unwrap_or_else(funded_signer);
 
         let nonce = match self.nonce {
             Some(nonce) => nonce,
@@ -205,8 +205,7 @@ impl TransactionPoolObserver {
                                 tracing::debug!("Transaction invalid: {hash}");
                                 observations.entry(hash).or_default().push_back(TransactionEvent::Invalid);
                             },
-                            Some(FullTransactionEvent::Propagated(_)) => {},
-                            None => {},
+                            Some(FullTransactionEvent::Propagated(_)) | None => {},
                         }
                     }
                 }

--- a/crates/builder/op-rbuilder/src/tests/miner_gas_limit.rs
+++ b/crates/builder/op-rbuilder/src/tests/miner_gas_limit.rs
@@ -61,7 +61,7 @@ async fn block_fill() -> eyre::Result<()> {
     let block = driver.build_new_block().await?;
 
     for (i, tx_hash) in tx_hashes.iter().enumerate() {
-        assert!(block.includes(tx_hash), "tx i={} hash={} should be in block", i, tx_hash);
+        assert!(block.includes(tx_hash), "tx i={i} hash={tx_hash} should be in block");
     }
     assert!(!block.includes(unfit_tx.tx_hash()), "unfit tx should not be in block");
 

--- a/crates/builder/op-rbuilder/src/tests/smoke.rs
+++ b/crates/builder/op-rbuilder/src/tests/smoke.rs
@@ -66,8 +66,7 @@ async fn chain_produces_blocks() -> eyre::Result<()> {
         for tx_hash in tx_hashes {
             assert!(
                 txs.hashes().any(|hash| hash == tx_hash),
-                "Transaction {} should be included in the block",
-                tx_hash
+                "Transaction {tx_hash} should be included in the block"
             );
         }
     }

--- a/crates/client/cli/src/p2p.rs
+++ b/crates/client/cli/src/p2p.rs
@@ -531,7 +531,7 @@ mod tests {
 
     use super::*;
 
-    /// A mock command that uses the P2PArgs.
+    /// A mock command that uses the `P2PArgs`.
     #[derive(Parser, Debug, Clone)]
     #[command(about = "Mock command")]
     struct MockCommand {

--- a/crates/client/cli/src/p2p.rs
+++ b/crates/client/cli/src/p2p.rs
@@ -33,7 +33,7 @@ use crate::signer::{SignerArgs, SignerArgsParseError};
 /// Resolves a hostname or IP address string to an [`IpAddr`].
 ///
 /// Accepts either:
-/// - A valid IP address string (e.g., "127.0.0.1", "::1")
+/// - A valid IP address string (e.g., "127.0.0.1", "`::1`")
 /// - A DNS hostname (e.g., "node1.example.com")
 ///
 /// For DNS hostnames, this performs synchronous DNS resolution and returns the first
@@ -95,7 +95,7 @@ pub struct P2PArgs {
     /// "node1.example.com"). DNS hostnames are resolved to IP addresses at startup.
     #[arg(long = "p2p.listen.ip", default_value = "0.0.0.0", env = "BASE_NODE_P2P_LISTEN_IP", value_parser = resolve_host)]
     pub listen_ip: IpAddr,
-    /// TCP port to bind LibP2P to. Any available system port if set to 0.
+    /// TCP port to bind `LibP2P` to. Any available system port if set to 0.
     #[arg(long = "p2p.listen.tcp", default_value = "9222", env = "BASE_NODE_P2P_LISTEN_TCP_PORT")]
     pub listen_tcp_port: u16,
     /// UDP port to bind Discv5 to. Same as TCP port if left 0.
@@ -117,15 +117,15 @@ pub struct P2PArgs {
         value_parser = |arg: &str| -> Result<Duration, ParseIntError> {Ok(Duration::from_secs(arg.parse()?))}
     )]
     pub peers_grace: Duration,
-    /// Configure GossipSub topic stable mesh target count.
+    /// Configure `GossipSub` topic stable mesh target count.
     /// Aka: The desired outbound degree (numbers of peers to gossip to).
     #[arg(long = "p2p.gossip.mesh.d", default_value = "8", env = "BASE_NODE_P2P_GOSSIP_MESH_D")]
     pub gossip_mesh_d: usize,
-    /// Configure GossipSub topic stable mesh low watermark.
+    /// Configure `GossipSub` topic stable mesh low watermark.
     /// Aka: The lower bound of outbound degree.
     #[arg(long = "p2p.gossip.mesh.lo", default_value = "6", env = "BASE_NODE_P2P_GOSSIP_MESH_DLO")]
     pub gossip_mesh_dlo: usize,
-    /// Configure GossipSub topic stable mesh high watermark.
+    /// Configure `GossipSub` topic stable mesh high watermark.
     /// Aka: The upper bound of outbound degree (additional peers will not receive gossip).
     #[arg(
         long = "p2p.gossip.mesh.dhi",
@@ -133,7 +133,7 @@ pub struct P2PArgs {
         env = "BASE_NODE_P2P_GOSSIP_MESH_DHI"
     )]
     pub gossip_mesh_dhi: usize,
-    /// Configure GossipSub gossip target.
+    /// Configure `GossipSub` gossip target.
     /// Aka: The target degree for gossip only (not messaging like p2p.gossip.mesh.d, just
     /// announcements of IHAVE).
     #[arg(
@@ -142,7 +142,7 @@ pub struct P2PArgs {
         env = "BASE_NODE_P2P_GOSSIP_MESH_DLAZY"
     )]
     pub gossip_mesh_dlazy: usize,
-    /// Configure GossipSub to publish messages to all known peers on the topic, outside of the
+    /// Configure `GossipSub` to publish messages to all known peers on the topic, outside of the
     /// mesh. Also see Dlazy as less aggressive alternative.
     #[arg(
         long = "p2p.gossip.mesh.floodpublish",

--- a/crates/client/cli/src/sequencer.rs
+++ b/crates/client/cli/src/sequencer.rs
@@ -14,7 +14,7 @@ use url::Url;
 #[derive(Parser, Clone, Debug, PartialEq, Eq)]
 pub struct SequencerArgs {
     /// Initialize the sequencer in a stopped state. The sequencer can be started using the
-    /// admin_startSequencer RPC.
+    /// `admin_startSequencer` RPC.
     #[arg(
         long = "sequencer.stopped",
         default_value = "false",

--- a/crates/client/flashblocks-node/benches/pending_state.rs
+++ b/crates/client/flashblocks-node/benches/pending_state.rs
@@ -57,7 +57,7 @@ impl BenchSetup {
             .map(|count| {
                 let txs = sample_transactions(&provider, *count);
                 let blocks = build_flashblocks(&canonical_block, &txs);
-                (format!("pending_state_{}_txs", count), blocks)
+                (format!("pending_state_{count}_txs"), blocks)
             })
             .collect();
 
@@ -137,7 +137,7 @@ fn init_bench_tracing() {
         let mut filter =
             EnvFilter::builder().with_default_directive(default_level.into()).from_env_lossy();
 
-        for directive in ["reth_tasks=off", "reth_node_builder::launch::common=off"].into_iter() {
+        for directive in ["reth_tasks=off", "reth_node_builder::launch::common=off"] {
             if let Ok(directive) = directive.parse() {
                 filter = filter.add_directive(directive);
             }

--- a/crates/client/flashblocks-node/benches/sender_recovery.rs
+++ b/crates/client/flashblocks-node/benches/sender_recovery.rs
@@ -3,7 +3,7 @@
 //! Benchmark for sender recovery performance.
 //!
 //! Compares sequential vs parallel ECDSA sender recovery
-//! as requested in https://github.com/base/base/issues/282
+//! as requested in <https://github.com/base/base/issues/282>
 
 use alloy_consensus::transaction::SignerRecoverable;
 use alloy_primitives::{Address, B256};

--- a/crates/client/flashblocks-node/src/test_harness.rs
+++ b/crates/client/flashblocks-node/src/test_harness.rs
@@ -552,7 +552,7 @@ impl<'a> FlashblockBuilder<'a> {
         self.transactions.clear();
 
         let mut cumulative_gas_used = 0;
-        for txn in transactions.iter() {
+        for txn in &transactions {
             cumulative_gas_used += txn.gas_limit();
             self.transactions.push(txn.encoded_2718().into());
             if let Some(ref mut receipts) = self.receipts {

--- a/crates/client/flashblocks-node/tests/eth_call_erc20.rs
+++ b/crates/client/flashblocks-node/tests/eth_call_erc20.rs
@@ -2,14 +2,14 @@
 //!
 //! Tests cover:
 //! - Basic ERC-20 functionality (transfer, mint, burn, approve, transferFrom)
-//! - TransparentUpgradeableProxy with ERC-20 (USDC-style delegatecall patterns)
+//! - `TransparentUpgradeableProxy` with ERC-20 (USDC-style delegatecall patterns)
 //!
-//! These tests use FlashblocksHarness with manually constructed flashblock payloads
-//! to properly test eth_call against contract state.
+//! These tests use `FlashblocksHarness` with manually constructed flashblock payloads
+//! to properly test `eth_call` against contract state.
 //!
 //! Contract sources:
-//! - MockERC20: Solmate's MockERC20 (lib/solmate)
-//! - TransparentUpgradeableProxy: OpenZeppelin's proxy (lib/openzeppelin-contracts)
+//! - `MockERC20`: Solmate's `MockERC20` (lib/solmate)
+//! - `TransparentUpgradeableProxy`: `OpenZeppelin`'s proxy (lib/openzeppelin-contracts)
 
 use alloy_eips::BlockNumberOrTag;
 use alloy_primitives::{Address, B256, Bytes, U256};
@@ -181,7 +181,7 @@ async fn test_erc20_deployment() -> Result<()> {
     Ok(())
 }
 
-/// Test ERC-20 token deployment with TransparentUpgradeableProxy
+/// Test ERC-20 token deployment with `TransparentUpgradeableProxy`
 #[tokio::test]
 async fn test_proxy_erc20_deployment() -> Result<()> {
     let setup = Erc20TestSetup::new(true).await?;
@@ -243,7 +243,7 @@ async fn test_erc20_mint() -> Result<()> {
     Ok(())
 }
 
-/// Test ERC-20 mint through TransparentUpgradeableProxy
+/// Test ERC-20 mint through `TransparentUpgradeableProxy`
 #[tokio::test]
 async fn test_proxy_erc20_mint() -> Result<()> {
     let setup = Erc20TestSetup::new(true).await?;

--- a/crates/client/flashblocks-node/tests/flashblocks_rpc.rs
+++ b/crates/client/flashblocks-node/tests/flashblocks_rpc.rs
@@ -70,7 +70,7 @@ const LOG_EMITTER_B_RUNTIME: &str = concat!(
 //   STOP
 fn log_emitter_a_runtime(log_emitter_b_addr: Address) -> String {
     // Convert address to hex without 0x prefix
-    let addr_hex = format!("{:040x}", log_emitter_b_addr);
+    let addr_hex = format!("{log_emitter_b_addr:040x}");
     format!(
         concat!(
             "7f",
@@ -683,7 +683,7 @@ async fn test_send_raw_transaction_sync_timeout() {
         .await;
 
     let error_code = EthRpcErrorCode::TransactionConfirmationTimeout.code();
-    assert!(receipt_result.err().unwrap().to_string().contains(format!("{}", error_code).as_str()));
+    assert!(receipt_result.err().unwrap().to_string().contains(format!("{error_code}").as_str()));
 }
 
 #[tokio::test]
@@ -1034,7 +1034,7 @@ async fn test_eth_subscribe_multiple_clients() -> eyre::Result<()> {
 }
 
 /// Test that standard subscription types (newHeads) work correctly.
-/// This verifies that our ExtendedSubscriptionKind properly proxies to reth's implementation.
+/// This verifies that our `ExtendedSubscriptionKind` properly proxies to reth's implementation.
 #[tokio::test]
 async fn test_eth_subscribe_new_heads() -> eyre::Result<()> {
     let setup = TestSetup::new().await?;
@@ -1061,7 +1061,7 @@ async fn test_eth_subscribe_new_heads() -> eyre::Result<()> {
     assert_eq!(sub["jsonrpc"], "2.0");
     assert_eq!(sub["id"], 1);
     // Should return a subscription ID, confirming the subscription was accepted
-    assert!(sub["result"].is_string(), "Expected subscription ID, got: {:?}", sub);
+    assert!(sub["result"].is_string(), "Expected subscription ID, got: {sub:?}");
 
     Ok(())
 }

--- a/crates/client/flashblocks-node/tests/state.rs
+++ b/crates/client/flashblocks-node/tests/state.rs
@@ -510,11 +510,11 @@ async fn test_duplicate_flashblock_ignored() {
     assert_eq!(block, block_two);
 }
 
-/// Verifies that eth_call targeting pending block sees flashblock state changes.
+/// Verifies that `eth_call` targeting pending block sees flashblock state changes.
 ///
 /// This test catches database layering bugs where pending state from flashblocks
 /// isn't visible to RPC callers. After a flashblock transfers ETH to Bob, an
-/// eth_call simulating a transfer FROM Bob should succeed because Bob now has
+/// `eth_call` simulating a transfer FROM Bob should succeed because Bob now has
 /// more funds from the flashblock.
 #[tokio::test]
 async fn test_eth_call_sees_flashblock_state_changes() {

--- a/crates/client/flashblocks/src/error.rs
+++ b/crates/client/flashblocks/src/error.rs
@@ -250,7 +250,7 @@ mod tests {
     #[case::execution(StateProcessorError::from(ExecutionError::GasOverflow))]
     #[case::build(StateProcessorError::from(BuildError::MissingHeaders))]
     fn test_state_processor_error_from_variants(#[case] error: StateProcessorError) {
-        let debug_str = format!("{:?}", error);
+        let debug_str = format!("{error:?}");
         assert!(!debug_str.is_empty());
         let display_str = error.to_string();
         assert!(!display_str.is_empty());

--- a/crates/client/flashblocks/src/metrics.rs
+++ b/crates/client/flashblocks/src/metrics.rs
@@ -62,23 +62,23 @@ pub struct Metrics {
     pub reconnect_attempts: Counter,
 
     // RPC metrics
-    /// Count of times flashblocks get_transaction_count is called.
+    /// Count of times flashblocks `get_transaction_count` is called.
     #[metric(describe = "Count of times flashblocks get_transaction_count is called")]
     pub rpc_get_transaction_count: Counter,
 
-    /// Count of times flashblocks get_transaction_receipt is called.
+    /// Count of times flashblocks `get_transaction_receipt` is called.
     #[metric(describe = "Count of times flashblocks get_transaction_receipt is called")]
     pub rpc_get_transaction_receipt: Counter,
 
-    /// Count of times flashblocks get_transaction_by_hash is called.
+    /// Count of times flashblocks `get_transaction_by_hash` is called.
     #[metric(describe = "Count of times flashblocks get_transaction_by_hash is called")]
     pub rpc_get_transaction_by_hash: Counter,
 
-    /// Count of times flashblocks get_balance is called.
+    /// Count of times flashblocks `get_balance` is called.
     #[metric(describe = "Count of times flashblocks get_balance is called")]
     pub rpc_get_balance: Counter,
 
-    /// Count of times flashblocks get_block_by_number is called.
+    /// Count of times flashblocks `get_block_by_number` is called.
     #[metric(describe = "Count of times flashblocks get_block_by_number is called")]
     pub rpc_get_block_by_number: Counter,
 
@@ -86,19 +86,19 @@ pub struct Metrics {
     #[metric(describe = "Count of times flashblocks call is called")]
     pub rpc_call: Counter,
 
-    /// Count of times flashblocks estimate_gas is called.
+    /// Count of times flashblocks `estimate_gas` is called.
     #[metric(describe = "Count of times flashblocks estimate_gas is called")]
     pub rpc_estimate_gas: Counter,
 
-    /// Count of times flashblocks simulate_v1 is called.
+    /// Count of times flashblocks `simulate_v1` is called.
     #[metric(describe = "Count of times flashblocks simulate_v1 is called")]
     pub rpc_simulate_v1: Counter,
 
-    /// Count of times flashblocks get_logs is called.
+    /// Count of times flashblocks `get_logs` is called.
     #[metric(describe = "Count of times flashblocks get_logs is called")]
     pub rpc_get_logs: Counter,
 
-    /// Count of times flashblocks get_block_transaction_count_by_number is called.
+    /// Count of times flashblocks `get_block_transaction_count_by_number` is called.
     #[metric(
         describe = "Count of times flashblocks get_block_transaction_count_by_number is called"
     )]

--- a/crates/client/flashblocks/src/pending_blocks.rs
+++ b/crates/client/flashblocks/src/pending_blocks.rs
@@ -203,12 +203,12 @@ impl PendingBlocks {
 
     /// Returns the sender of a transaction.
     pub fn get_transaction_sender(&self, tx_hash: &B256) -> Option<Address> {
-        self.transaction_senders.get(tx_hash).cloned()
+        self.transaction_senders.get(tx_hash).copied()
     }
 
     /// Returns a clone of the bundle state.
     ///
-    /// NOTE: This clones the entire BundleState, which contains a HashMap of all touched
+    /// NOTE: This clones the entire `BundleState`, which contains a `HashMap` of all touched
     /// accounts and their storage slots. The cost scales with the number of accounts and
     /// storage slots modified in the flashblock. Monitor `bundle_state_clone_duration` and
     /// `bundle_state_clone_size` metrics to track if this becomes a bottleneck.
@@ -264,12 +264,12 @@ impl PendingBlocks {
 
     /// Returns the transaction count for an address in pending state.
     pub fn get_transaction_count(&self, address: Address) -> U256 {
-        self.transaction_count.get(&address).cloned().unwrap_or(U256::from(0))
+        self.transaction_count.get(&address).copied().unwrap_or_else(|| U256::from(0))
     }
 
     /// Returns the balance for an address in pending state.
     pub fn get_balance(&self, address: Address) -> Option<U256> {
-        self.account_balances.get(&address).cloned()
+        self.account_balances.get(&address).copied()
     }
 
     /// Returns the state overrides for the pending state.

--- a/crates/client/flashblocks/src/processor.rs
+++ b/crates/client/flashblocks/src/processor.rs
@@ -217,10 +217,9 @@ where
             None => {
                 if flashblock.index == 0 {
                     return self.build_pending_state(None, &[flashblock]);
-                } else {
-                    info!(message = "waiting for first Flashblock");
-                    return Ok(None);
                 }
+                info!(message = "waiting for first Flashblock");
+                return Ok(None);
             }
         };
 
@@ -388,7 +387,7 @@ where
                 let executed_transaction =
                     pending_state_builder.execute_transaction(idx, recovered_transaction)?;
 
-                for (address, account) in executed_transaction.state.iter() {
+                for (address, account) in &executed_transaction.state {
                     if account.is_touched() {
                         pending_blocks_builder.with_account_balance(*address, account.info.balance);
                     }

--- a/crates/client/flashblocks/src/rpc/eth.rs
+++ b/crates/client/flashblocks/src/rpc/eth.rs
@@ -315,16 +315,14 @@ where
                 receipt = self.wait_for_flashblocks_receipt(tx_hash) => {
                     if let Some(receipt) = receipt {
                         return Ok(receipt);
-                    } else {
-                        continue
                     }
+                    continue
                 }
                 receipt = self.wait_for_canonical_receipt(tx_hash) => {
                         if let Some(receipt) = receipt {
                             return Ok(receipt);
-                        } else {
-                            continue
                         }
+                        continue
                     }
                 _ = time::sleep(timeout) => {
                     return Err(EthApiError::TransactionConfirmationTimeout {

--- a/crates/client/flashblocks/src/rpc/pubsub.rs
+++ b/crates/client/flashblocks/src/rpc/pubsub.rs
@@ -1,4 +1,4 @@
-//! `eth_` PubSub RPC extension for flashblocks and standard subscriptions
+//! `eth_` `PubSub` RPC extension for flashblocks and standard subscriptions
 //!
 //! This module provides an extended `eth_subscribe` implementation that supports both
 //! standard Ethereum subscription types (newHeads, logs, newPendingTransactions, syncing)
@@ -59,7 +59,7 @@ pub trait EthPubSubApi {
 /// and Base-specific flashblocks subscriptions.
 #[derive(Clone, Debug)]
 pub struct EthPubSub<Eth, FB> {
-    /// Reth's standard EthPubSub for handling standard subscription types
+    /// Reth's standard `EthPubSub` for handling standard subscription types
     inner: RethEthPubSub<Eth>,
     /// Flashblocks state for accessing pending blocks stream
     flashblocks_state: Arc<FB>,

--- a/crates/client/flashblocks/src/rpc/types.rs
+++ b/crates/client/flashblocks/src/rpc/types.rs
@@ -1,4 +1,4 @@
-//! Subscription types for the `eth_` PubSub RPC extension
+//! Subscription types for the `eth_` `PubSub` RPC extension
 
 use alloy_rpc_types_eth::pubsub::SubscriptionKind;
 use serde::{Deserialize, Serialize};

--- a/crates/client/flashblocks/src/state_builder.rs
+++ b/crates/client/flashblocks/src/state_builder.rs
@@ -172,7 +172,8 @@ where
                     existing_override.nonce = Some(acc.info.nonce);
                     existing_override.code = acc.info.code.clone().map(|code| code.bytes());
 
-                    let existing = existing_override.state_diff.get_or_insert(Default::default());
+                    let existing =
+                        existing_override.state_diff.get_or_insert_with(Default::default);
                     let changed_slots = acc
                         .storage
                         .iter()
@@ -253,7 +254,7 @@ where
             Err(e) => Err(ExecutionError::TransactionFailed {
                 tx_hash,
                 sender: transaction.signer(),
-                reason: format!("{:?}", e),
+                reason: format!("{e:?}"),
             }
             .into()),
         }

--- a/crates/client/metering/src/block.rs
+++ b/crates/client/metering/src/block.rs
@@ -394,8 +394,7 @@ mod tests {
         let err_str = err.to_string();
         assert!(
             err_str.contains("Parent header not found") || err_str.contains("not found"),
-            "error should indicate parent header not found: {}",
-            err_str
+            "error should indicate parent header not found: {err_str}"
         );
 
         Ok(())
@@ -435,8 +434,7 @@ mod tests {
         let err_str = err.to_string();
         assert!(
             err_str.contains("recover signer") || err_str.contains("signature"),
-            "error should indicate signer recovery failure: {}",
-            err_str
+            "error should indicate signer recovery failure: {err_str}"
         );
 
         Ok(())

--- a/crates/client/metering/src/block.rs
+++ b/crates/client/metering/src/block.rs
@@ -63,7 +63,7 @@ where
     let attributes = OpNextBlockEnvAttributes {
         timestamp: block.header().timestamp(),
         suggested_fee_recipient: block.header().beneficiary(),
-        prev_randao: block.header().mix_hash().unwrap_or(B256::random()),
+        prev_randao: block.header().mix_hash().unwrap_or_else(B256::random),
         gas_limit: block.header().gas_limit(),
         parent_beacon_block_root: block.header().parent_beacon_block_root(),
         extra_data: block.header().extra_data().clone(),

--- a/crates/client/metering/src/meter.rs
+++ b/crates/client/metering/src/meter.rs
@@ -532,7 +532,7 @@ mod tests {
         Ok(())
     }
 
-    /// Test that state_root_time_us is always <= total_time_us
+    /// Test that `state_root_time_us` is always <= `total_time_us`
     #[tokio::test]
     async fn meter_bundle_state_root_time_invariant() -> eyre::Result<()> {
         let harness = TestHarness::new().await?;
@@ -586,7 +586,7 @@ mod tests {
         Ok(())
     }
 
-    /// Integration test: verifies meter_bundle uses flashblocks state correctly.
+    /// Integration test: verifies `meter_bundle` uses flashblocks state correctly.
     ///
     /// A transaction using nonce=1 should fail without flashblocks state (since
     /// canonical nonce is 0), but succeed when flashblocks state indicates nonce=1.

--- a/crates/client/metering/src/meter.rs
+++ b/crates/client/metering/src/meter.rs
@@ -144,7 +144,7 @@ where
     let attributes = OpNextBlockEnvAttributes {
         timestamp,
         suggested_fee_recipient: header.beneficiary(),
-        prev_randao: header.mix_hash().unwrap_or(B256::random()),
+        prev_randao: header.mix_hash().unwrap_or_else(B256::random),
         gas_limit: header.gas_limit(),
         parent_beacon_block_root: parent_beacon_block_root
             .or_else(|| header.parent_beacon_block_root()),

--- a/crates/client/metering/src/rpc.rs
+++ b/crates/client/metering/src/rpc.rs
@@ -43,7 +43,7 @@ where
         + Clone,
     FB: FlashblocksAPI,
 {
-    /// Creates a new instance of MeteringApi.
+    /// Creates a new instance of `MeteringApi`.
     pub fn new(provider: Provider, flashblocks_api: Arc<FB>) -> Self {
         Self { provider, flashblocks_api, pending_trie_cache: PendingTrieCache::new() }
     }
@@ -101,7 +101,7 @@ where
                     .map_err(|e| {
                         jsonrpsee::types::ErrorObjectOwned::owned(
                             jsonrpsee::types::ErrorCode::InternalError.code(),
-                            format!("Failed to get canonical block header: {}", e),
+                            format!("Failed to get canonical block header: {e}"),
                             None::<()>,
                         )
                     })?
@@ -124,7 +124,7 @@ where
         let parsed_bundle = ParsedBundle::try_from(bundle).map_err(|e| {
             jsonrpsee::types::ErrorObjectOwned::owned(
                 jsonrpsee::types::ErrorCode::InvalidParams.code(),
-                format!("Failed to parse bundle: {}", e),
+                format!("Failed to parse bundle: {e}"),
                 None::<()>,
             )
         })?;
@@ -135,7 +135,7 @@ where
                 error!(error = %e, "Failed to get state provider");
                 jsonrpsee::types::ErrorObjectOwned::owned(
                     jsonrpsee::types::ErrorCode::InternalError.code(),
-                    format!("Failed to get state provider: {}", e),
+                    format!("Failed to get state provider: {e}"),
                     None::<()>,
                 )
             })?;
@@ -159,7 +159,7 @@ where
                     error!(error = %e, "Failed to cache pending trie input");
                     jsonrpsee::types::ErrorObjectOwned::owned(
                         jsonrpsee::types::ErrorCode::InternalError.code(),
-                        format!("Failed to cache pending trie input: {}", e),
+                        format!("Failed to cache pending trie input: {e}"),
                         None::<()>,
                     )
                 })?;
@@ -202,7 +202,7 @@ where
             }
             jsonrpsee::types::ErrorObjectOwned::owned(
                 jsonrpsee::types::ErrorCode::InternalError.code(),
-                format!("Bundle metering failed: {}", e),
+                format!("Bundle metering failed: {e}"),
                 None::<()>,
             )
         })?;
@@ -249,14 +249,14 @@ where
                 error!(error = %e, "Failed to get block by hash");
                 jsonrpsee::types::ErrorObjectOwned::owned(
                     jsonrpsee::types::ErrorCode::InternalError.code(),
-                    format!("Failed to get block: {}", e),
+                    format!("Failed to get block: {e}"),
                     None::<()>,
                 )
             })?
             .ok_or_else(|| {
                 jsonrpsee::types::ErrorObjectOwned::owned(
                     jsonrpsee::types::ErrorCode::InvalidParams.code(),
-                    format!("Block not found: {}", hash),
+                    format!("Block not found: {hash}"),
                     None::<()>,
                 )
             })?;
@@ -288,14 +288,14 @@ where
                 error!(error = %e, "Failed to get block by number");
                 jsonrpsee::types::ErrorObjectOwned::owned(
                     jsonrpsee::types::ErrorCode::InternalError.code(),
-                    format!("Failed to get block: {}", e),
+                    format!("Failed to get block: {e}"),
                     None::<()>,
                 )
             })?
             .ok_or_else(|| {
                 jsonrpsee::types::ErrorObjectOwned::owned(
                     jsonrpsee::types::ErrorCode::InvalidParams.code(),
-                    format!("Block not found: {:?}", number),
+                    format!("Block not found: {number:?}"),
                     None::<()>,
                 )
             })?;
@@ -338,7 +338,7 @@ where
                 error!(error = %e, "Failed to get block by hash");
                 jsonrpsee::types::ErrorObjectOwned::owned(
                     jsonrpsee::types::ErrorCode::InternalError.code(),
-                    format!("Failed to get block: {}", e),
+                    format!("Failed to get block: {e}"),
                     None::<()>,
                 )
             })?
@@ -364,7 +364,7 @@ where
         extract_l1_info_from_tx(&first_tx).map_err(|e| {
             jsonrpsee::types::ErrorObjectOwned::owned(
                 jsonrpsee::types::ErrorCode::InvalidParams.code(),
-                format!("Failed to extract L1 block info from transaction: {}", e),
+                format!("Failed to extract L1 block info from transaction: {e}"),
                 None::<()>,
             )
         })
@@ -376,7 +376,7 @@ where
             error!(error = %e, "Block metering failed");
             jsonrpsee::types::ErrorObjectOwned::owned(
                 jsonrpsee::types::ErrorCode::InternalError.code(),
-                format!("Block metering failed: {}", e),
+                format!("Block metering failed: {e}"),
                 None::<()>,
             )
         })

--- a/crates/client/metering/src/transaction.rs
+++ b/crates/client/metering/src/transaction.rs
@@ -8,7 +8,7 @@ use reth_primitives_traits::Account;
 use tracing::warn;
 
 /// Errors that can occur when validating a transaction.
-#[derive(Debug, PartialEq, Display)]
+#[derive(Debug, PartialEq, Eq, Display)]
 pub enum TxValidationError {
     /// Interop transactions are not supported
     #[display("Interop transactions are not supported")]

--- a/crates/client/node/src/builder.rs
+++ b/crates/client/node/src/builder.rs
@@ -44,7 +44,7 @@ pub struct BaseBuilder {
 }
 
 impl BaseBuilder {
-    /// Create a new BaseBuilder wrapping the provided OP builder.
+    /// Create a new `BaseBuilder` wrapping the provided OP builder.
     pub const fn new(builder: OpBuilder) -> Self {
         Self { builder, rpc_hooks: Vec::new(), node_started_hooks: Vec::new() }
     }
@@ -55,7 +55,7 @@ impl BaseBuilder {
 
         if !rpc_hooks.is_empty() {
             builder = builder.extend_rpc_modules(move |mut ctx: BaseRpcContext<'_>| {
-                for hook in rpc_hooks.iter_mut() {
+                for hook in &mut rpc_hooks {
                     hook(&mut ctx)?;
                 }
 
@@ -66,7 +66,7 @@ impl BaseBuilder {
         if !node_started_hooks.is_empty() {
             builder = builder.on_node_started(move |full_node: OpFullNode| {
                 let mut hooks = node_started_hooks;
-                for hook in hooks.iter_mut() {
+                for hook in &mut hooks {
                     hook(full_node.clone())?;
                 }
                 Ok(())
@@ -114,7 +114,7 @@ impl BaseBuilder {
         launcher(self.build())
     }
 
-    /// Installs an ExEx extension with the given name and closure.
+    /// Installs an `ExEx` extension with the given name and closure.
     pub fn install_exex<F, R, E>(mut self, exex_id: impl Into<String>, exex: F) -> Self
     where
         F: FnOnce(ExExContext<OpNodeAdapter>) -> R + Send + 'static,

--- a/crates/client/node/src/test_utils/engine.rs
+++ b/crates/client/node/src/test_utils/engine.rs
@@ -1,7 +1,7 @@
 //! Engine API integration for canonical block production.
 //!
 //! This module provides a typed, type-safe Engine API client based on
-//! reth's OpEngineApiClient trait instead of raw string-based RPC calls.
+//! reth's `OpEngineApiClient` trait instead of raw string-based RPC calls.
 
 use std::{fmt, marker::PhantomData, time::Duration};
 

--- a/crates/client/node/src/test_utils/tracing.rs
+++ b/crates/client/node/src/test_utils/tracing.rs
@@ -15,7 +15,7 @@ pub fn init_silenced_tracing() {
         let mut filter =
             EnvFilter::builder().with_default_directive(LevelFilter::INFO.into()).from_env_lossy();
 
-        for directive in ["reth_tasks=off", "reth_node_builder::launch::common=off"].into_iter() {
+        for directive in ["reth_tasks=off", "reth_node_builder::launch::common=off"] {
             if let Ok(directive) = directive.parse() {
                 filter = filter.add_directive(directive);
             }

--- a/crates/client/proofs/README.md
+++ b/crates/client/proofs/README.md
@@ -4,7 +4,7 @@ Proofs history extension for Base node. Enables on-disk storage and retrieval of
 
 ## Overview
 
-This extension provides the infrastructure for maintaining a historical record of Merkle proofs, allowing clients to verify the state of the blockchain at any point within the configured retention window. It extends the node with an Execution Extension (ExEx) and additional RPC methods for proof retrieval.
+This extension provides the infrastructure for maintaining a historical record of Merkle proofs, allowing clients to verify the state of the blockchain at any point within the configured retention window. It extends the node with an Execution Extension (`ExEx`) and additional RPC methods for proof retrieval.
 
 ## Features
 

--- a/crates/client/txpool/src/rpc.rs
+++ b/crates/client/txpool/src/rpc.rs
@@ -13,7 +13,7 @@ use serde::{Deserialize, Serialize};
 use tracing::{info, warn};
 
 /// The status of a transaction.
-#[derive(Clone, Serialize, Deserialize, PartialEq, Debug)]
+#[derive(Clone, Serialize, Deserialize, PartialEq, Eq, Debug)]
 pub enum Status {
     /// Transaction is not known to the node.
     Unknown,
@@ -22,7 +22,7 @@ pub enum Status {
 }
 
 /// Response containing the status of a transaction.
-#[derive(Clone, Serialize, Deserialize, PartialEq, Debug)]
+#[derive(Clone, Serialize, Deserialize, PartialEq, Eq, Debug)]
 pub struct TransactionStatusResponse {
     /// The status of the queried transaction.
     pub status: Status,

--- a/crates/shared/access-lists/src/builder.rs
+++ b/crates/shared/access-lists/src/builder.rs
@@ -24,7 +24,7 @@ impl FlashblockAccessListBuilder {
 
     /// Merges another [`FlashblockAccessListBuilder`] with this one
     pub fn merge(&mut self, other: Self) {
-        for (address, changes) in other.changes.into_iter() {
+        for (address, changes) in other.changes {
             self.changes
                 .entry(address)
                 .and_modify(|prev| prev.merge(changes.clone()))

--- a/crates/shared/access-lists/src/db.rs
+++ b/crates/shared/access-lists/src/db.rs
@@ -15,7 +15,7 @@ pub struct FBALBuilderDb<DB>
 where
     DB: DatabaseCommit + Database,
 {
-    /// Underlying CacheDB
+    /// Underlying `CacheDB`
     db: DB,
     /// Transaction index of the transaction currently being executed
     index: u64,
@@ -63,7 +63,7 @@ where
         &mut self,
         changes: HashMap<Address, Account>,
     ) -> Result<(), <DB as Database>::Error> {
-        for (address, account) in changes.iter() {
+        for (address, account) in &changes {
             let account_changes = self.access_list.changes.entry(*address).or_default();
 
             // Update balance, nonce, and code
@@ -105,7 +105,7 @@ where
             }
 
             // Update storage
-            for (slot, value) in account.storage.iter() {
+            for (slot, value) in &account.storage {
                 let prev = value.original_value;
                 let new = value.present_value;
 

--- a/crates/shared/access-lists/src/types.rs
+++ b/crates/shared/access-lists/src/types.rs
@@ -3,8 +3,8 @@ use alloy_primitives::{B256, keccak256};
 use alloy_rlp::{Encodable, RlpDecodable, RlpEncodable};
 use serde::{Deserialize, Serialize};
 
-#[derive(Clone, Debug, PartialEq, Default, Deserialize, Serialize, RlpEncodable, RlpDecodable)]
-/// FlashblockAccessList represents the access list for a single flashblock
+#[derive(Clone, Debug, PartialEq, Eq, Default, Deserialize, Serialize, RlpEncodable, RlpDecodable)]
+/// `FlashblockAccessList` represents the access list for a single flashblock
 pub struct FlashblockAccessList {
     /// All the account changes in this access list
     pub account_changes: Vec<AccountChanges>,
@@ -17,7 +17,7 @@ pub struct FlashblockAccessList {
 }
 
 impl FlashblockAccessList {
-    /// Builds a new FlashblockAccessList from the given account changes
+    /// Builds a new `FlashblockAccessList` from the given account changes
     pub fn build(
         account_changes: Vec<AccountChanges>,
         min_tx_index: u64,

--- a/crates/shared/access-lists/src/types.rs
+++ b/crates/shared/access-lists/src/types.rs
@@ -3,7 +3,9 @@ use alloy_primitives::{B256, keccak256};
 use alloy_rlp::{Encodable, RlpDecodable, RlpEncodable};
 use serde::{Deserialize, Serialize};
 
-#[derive(Clone, Debug, PartialEq, Eq, Default, Deserialize, Serialize, RlpEncodable, RlpDecodable)]
+#[derive(
+    Clone, Debug, PartialEq, Eq, Default, Deserialize, Serialize, RlpEncodable, RlpDecodable,
+)]
 /// `FlashblockAccessList` represents the access list for a single flashblock
 pub struct FlashblockAccessList {
     /// All the account changes in this access list

--- a/crates/shared/access-lists/tests/builder/main.rs
+++ b/crates/shared/access-lists/tests/builder/main.rs
@@ -34,11 +34,11 @@ fn load_chain_spec() -> Arc<OpChainSpec> {
     Arc::new(OpChainSpec::from_genesis(build_test_genesis()))
 }
 
-/// Executes a list of transactions and builds a FlashblockAccessList tracking all
+/// Executes a list of transactions and builds a `FlashblockAccessList` tracking all
 /// account and storage changes across all transactions.
 ///
-/// Uses a single FBALBuilderDb instance that wraps the underlying InMemoryDB,
-/// calling set_index() before each transaction to track which txn caused which change.
+/// Uses a single `FBALBuilderDb` instance that wraps the underlying `InMemoryDB`,
+/// calling `set_index()` before each transaction to track which txn caused which change.
 pub fn execute_txns_build_access_list(
     txs: Vec<OpTransaction<TxEnv>>,
     acc_overrides: Option<HashMap<Address, AccountInfo>>,

--- a/crates/shared/access-lists/tests/builder/transfers.rs
+++ b/crates/shared/access-lists/tests/builder/transfers.rs
@@ -162,6 +162,6 @@ fn test_multiple_transfers() {
     let tx_indices: Vec<_> =
         sender_changes.nonce_changes.iter().map(|nc| nc.block_access_index).collect();
     for i in 0..10u64 {
-        assert!(tx_indices.contains(&i), "Tx index {} should be present in nonce changes", i);
+        assert!(tx_indices.contains(&i), "Tx index {i} should be present in nonce changes");
     }
 }

--- a/crates/shared/bundles/src/cancel.rs
+++ b/crates/shared/bundles/src/cancel.rs
@@ -74,14 +74,14 @@ mod tests {
     #[test]
     fn test_bundle_hash_debug() {
         let hash = BundleHash { bundle_hash: B256::default() };
-        let debug = format!("{:?}", hash);
+        let debug = format!("{hash:?}");
         assert!(debug.contains("BundleHash"));
     }
 
     #[test]
     fn test_cancel_bundle_debug() {
         let cancel = CancelBundle { replacement_uuid: "test".to_string() };
-        let debug = format!("{:?}", cancel);
+        let debug = format!("{cancel:?}");
         assert!(debug.contains("CancelBundle"));
         assert!(debug.contains("test"));
     }

--- a/crates/shared/cli-utils/src/args.rs
+++ b/crates/shared/cli-utils/src/args.rs
@@ -116,12 +116,12 @@ impl GlobalArgs {
         let id = self.l2_chain_id;
         OPCHAINS
             .get(&id.id())
-            .ok_or(eyre::eyre!("No chain config found for chain ID: {id}"))?
+            .ok_or_else(|| eyre::eyre!("No chain config found for chain ID: {id}"))?
             .roles
             .as_ref()
-            .ok_or(eyre::eyre!("No roles found for chain ID: {id}"))?
+            .ok_or_else(|| eyre::eyre!("No roles found for chain ID: {id}"))?
             .unsafe_block_signer
-            .ok_or(eyre::eyre!("No unsafe block signer found for chain ID: {id}"))
+            .ok_or_else(|| eyre::eyre!("No unsafe block signer found for chain ID: {id}"))
     }
 }
 
@@ -256,7 +256,7 @@ mod tests {
     mod env_vars {
         use super::*;
 
-        /// Verify that LogArgs fields have the expected env var names.
+        /// Verify that `LogArgs` fields have the expected env var names.
         /// This is done by checking the clap metadata.
         #[test]
         fn log_args_env_var_names() {

--- a/crates/shared/cli-utils/src/backtrace.rs
+++ b/crates/shared/cli-utils/src/backtrace.rs
@@ -5,10 +5,11 @@
 pub struct Backtracing;
 
 impl Backtracing {
-    /// Sets the RUST_BACKTRACE environment variable to 1 if it is not already set.
+    /// Sets the `RUST_BACKTRACE` environment variable to 1 if it is not already set.
     pub fn enable() {
         // Enable backtraces unless a RUST_BACKTRACE value has already been explicitly provided.
         if std::env::var_os("RUST_BACKTRACE").is_none() {
+            // SAFETY: This is called early in main before spawning threads.
             // We accept the risk that another process may set RUST_BACKTRACE at the same time.
             unsafe { std::env::set_var("RUST_BACKTRACE", "1") };
         }

--- a/crates/shared/cli-utils/src/metrics.rs
+++ b/crates/shared/cli-utils/src/metrics.rs
@@ -1,4 +1,4 @@
-//! Utility module to house implementation and declaration of MetricsArgs since it's being used in
+//! Utility module to house implementation and declaration of `MetricsArgs` since it's being used in
 //! multiple places, it's just being referenced from this module.
 
 use std::net::IpAddr;
@@ -82,7 +82,7 @@ mod tests {
 
     use super::*;
 
-    /// Helper struct to parse MetricsArgs within a test CLI structure.
+    /// Helper struct to parse `MetricsArgs` within a test CLI structure.
     #[derive(Parser, Debug)]
     struct TestCli {
         #[command(flatten)]

--- a/crates/shared/cli-utils/src/sigsegv.rs
+++ b/crates/shared/cli-utils/src/sigsegv.rs
@@ -151,6 +151,9 @@ extern "C" fn print_stack_trace(_: libc::c_int) {
 #[cfg(any(target_os = "linux", target_os = "android"))]
 fn min_sigstack_size() -> usize {
     const AT_MINSIGSTKSZ: core::ffi::c_ulong = 51;
+    // SAFETY: `getauxval` is a standard libc function that retrieves values from
+    // the auxiliary vector. AT_MINSIGSTKSZ is a valid key, and the function
+    // returns 0 if the key is not found, which is handled below.
     let dynamic_sigstksz = unsafe { libc::getauxval(AT_MINSIGSTKSZ) };
     // If getauxval couldn't find the entry, it returns 0,
     // so take the higher of the "constant" and auxval.

--- a/crates/shared/cli-utils/src/sigsegv.rs
+++ b/crates/shared/cli-utils/src/sigsegv.rs
@@ -18,6 +18,9 @@ impl SigsegvHandler {
     ///
     /// When SIGSEGV is delivered to the process, print a stack trace and then exit.
     pub fn install() {
+        // SAFETY: We allocate a fresh stack for the signal handler and configure
+        // sigaction with valid parameters. The signal handler only writes to stderr
+        // and does not access any shared mutable state.
         unsafe {
             let alt_stack_size: usize = min_sigstack_size() + 64 * 1024;
             let mut alt_stack: libc::stack_t = mem::zeroed();
@@ -40,6 +43,9 @@ unsafe extern "C" {
 
 fn backtrace_stderr(buffer: &[*mut libc::c_void]) {
     let size = buffer.len().try_into().unwrap_or_default();
+    // SAFETY: backtrace_symbols_fd is a standard libc function that writes symbol
+    // information to the given file descriptor. The buffer contains valid pointers
+    // from libc::backtrace, and STDERR_FILENO is always valid.
     unsafe { backtrace_symbols_fd(buffer.as_ptr(), size, libc::STDERR_FILENO) };
 }
 
@@ -50,6 +56,8 @@ struct RawStderr(());
 
 impl fmt::Write for RawStderr {
     fn write_str(&mut self, s: &str) -> Result<(), fmt::Error> {
+        // SAFETY: libc::write is a standard syscall. STDERR_FILENO is always valid,
+        // and we pass a valid pointer and length from the string slice.
         let ret = unsafe { libc::write(libc::STDERR_FILENO, s.as_ptr().cast(), s.len()) };
         if ret == -1 { Err(fmt::Error) } else { Ok(()) }
     }
@@ -68,6 +76,8 @@ macro_rules! raw_errln {
 extern "C" fn print_stack_trace(_: libc::c_int) {
     const MAX_FRAMES: usize = 256;
     let mut stack_trace: [*mut libc::c_void; MAX_FRAMES] = [ptr::null_mut(); MAX_FRAMES];
+    // SAFETY: libc::backtrace fills the provided buffer with return addresses
+    // from the call stack. The buffer is valid and properly sized.
     let stack = unsafe {
         // Collect return addresses
         let depth = libc::backtrace(stack_trace.as_mut_ptr(), MAX_FRAMES as i32);

--- a/crates/shared/cli-utils/src/tracing.rs
+++ b/crates/shared/cli-utils/src/tracing.rs
@@ -59,7 +59,7 @@ where
             for span in scope.from_root() {
                 write!(writer, " {}={{", span.name())?;
                 if let Some(fields) = span.extensions().get::<FormattedFields<N>>() {
-                    write!(writer, "{}", fields)?;
+                    write!(writer, "{fields}")?;
                 }
                 write!(writer, "}}")?;
             }

--- a/crates/shared/engine-ext/README.md
+++ b/crates/shared/engine-ext/README.md
@@ -23,7 +23,7 @@ This enables latency reduction from ~1-5ms (HTTP) to ~1μs (channel).
 The `InProcessEngineClient` requires a `ConsensusEngineHandle` and `PayloadStore`,
 which can be extracted from a fully-launched reth node.
 
-### Extracting from FullNode
+### Extracting from `FullNode`
 
 When using `NodeBuilder::with_add_ons`, you can access the engine handle from
 the `AddOnsContext`:
@@ -38,7 +38,7 @@ let payload_store = PayloadStore::new(full_node.payload_builder_handle.clone());
 let client = InProcessEngineClient::new(engine_handle, payload_store);
 ```
 
-### Using with node_started_hook
+### Using with `node_started_hook`
 
 For unified binaries, use the `add_node_started_hook` to extract components
 after the node is fully launched:

--- a/crates/shared/flashtypes/src/block.rs
+++ b/crates/shared/flashtypes/src/block.rs
@@ -12,7 +12,7 @@ use crate::{
 };
 
 /// A flashblock containing partial block data.
-#[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone)]
 pub struct Flashblock {
     /// Unique payload identifier.
     pub payload_id: PayloadId,

--- a/crates/shared/flashtypes/src/error.rs
+++ b/crates/shared/flashtypes/src/error.rs
@@ -34,7 +34,7 @@ mod tests {
     #[case::decompress(FlashblockDecodeError::Decompress(std::io::Error::other("test")))]
     #[case::utf8(FlashblockDecodeError::Utf8(String::from_utf8(vec![0xff, 0xfe]).unwrap_err()))]
     fn test_flashblock_decode_error_display(#[case] error: FlashblockDecodeError) {
-        let display = format!("{}", error);
+        let display = format!("{error}");
         assert!(!display.is_empty());
     }
 }

--- a/crates/shared/flashtypes/src/metadata.rs
+++ b/crates/shared/flashtypes/src/metadata.rs
@@ -3,7 +3,7 @@
 use serde::{Deserialize, Serialize};
 
 /// Metadata associated with a flashblock.
-#[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Default)]
+#[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Eq, Default)]
 pub struct Metadata {
     /// Block number this flashblock belongs to.
     pub block_number: u64,

--- a/crates/shared/flashtypes/src/payload.rs
+++ b/crates/shared/flashtypes/src/payload.rs
@@ -11,7 +11,7 @@ use serde_json::Value;
 /// such as state root, receipts, logs, and new transactions. Other immutable block fields
 /// like parent hash and block number are excluded since they remain constant throughout
 /// the block's construction.
-#[derive(Clone, Debug, PartialEq, Default, Deserialize, Serialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Default, Deserialize, Serialize)]
 pub struct ExecutionPayloadFlashblockDeltaV1 {
     /// The state root of the block.
     pub state_root: B256,
@@ -39,7 +39,7 @@ pub struct ExecutionPayloadFlashblockDeltaV1 {
 /// throughout block construction. This includes fundamental block properties like
 /// parent hash, block number, and other header fields that are determined at
 /// block creation and cannot be modified.
-#[derive(Clone, Debug, PartialEq, Default, Deserialize, Serialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Default, Deserialize, Serialize)]
 pub struct ExecutionPayloadBaseV1 {
     /// Ecotone parent beacon block root
     pub parent_beacon_block_root: B256,
@@ -65,7 +65,7 @@ pub struct ExecutionPayloadBaseV1 {
 }
 
 /// Represents a flashblock payload containing the base execution payload configuration,
-#[derive(Clone, Debug, PartialEq, Default, Deserialize, Serialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Default, Deserialize, Serialize)]
 pub struct FlashblocksPayloadV1 {
     /// The payload id of the flashblock
     pub payload_id: PayloadId,

--- a/crates/shared/jwt/src/secret.rs
+++ b/crates/shared/jwt/src/secret.rs
@@ -19,7 +19,7 @@ pub fn read_jwt_secret(path: impl AsRef<Path>) -> Result<JwtSecret, JwtError> {
 /// Creates a new random secret if the file doesn't exist.
 ///
 /// # Arguments
-/// * `file_name` - The name of the JWT file (e.g., "jwt.hex", "l2_jwt.hex")
+/// * `file_name` - The name of the JWT file (e.g., "jwt.hex", "`l2_jwt.hex`")
 pub fn default_jwt_secret(file_name: &str) -> Result<JwtSecret, JwtError> {
     let cur_dir = std::env::current_dir()
         .map_err(|e| JwtError::IoError(format!("Failed to get current directory: {e}")))?;
@@ -48,7 +48,7 @@ pub fn default_jwt_secret(file_name: &str) -> Result<JwtSecret, JwtError> {
 ///
 /// # Arguments
 /// * `file_path` - Optional path to a JWT file
-/// * `encoded` - Optional pre-parsed JwtSecret
+/// * `encoded` - Optional pre-parsed `JwtSecret`
 /// * `default_file` - Fallback file name in current directory
 pub fn resolve_jwt_secret(
     file_path: Option<&Path>,

--- a/crates/shared/jwt/src/validator.rs
+++ b/crates/shared/jwt/src/validator.rs
@@ -47,7 +47,7 @@ impl JwtValidator {
         false
     }
 
-    /// Helper to check JWT signature error from eyre::Error (for retry condition).
+    /// Helper to check JWT signature error from `eyre::Error` (for retry condition).
     #[cfg(feature = "engine-validation")]
     pub fn is_jwt_signature_error_from_eyre(error: &eyre::Error) -> bool {
         Self::is_jwt_signature_error(error.as_ref() as &dyn std::error::Error)
@@ -164,8 +164,7 @@ impl JwtValidator {
                 Ok(url)
             }
             scheme => Err(JwtValidationError::CapabilityExchange(format!(
-                "Unsupported URL scheme '{}'. Expected http, https, ws, or wss",
-                scheme
+                "Unsupported URL scheme '{scheme}'. Expected http, https, ws, or wss"
             ))),
         }
     }

--- a/crates/shared/primitives/src/test_utils/accounts.rs
+++ b/crates/shared/primitives/src/test_utils/accounts.rs
@@ -54,7 +54,7 @@ impl Account {
         [Self::Alice, Self::Bob, Self::Charlie, Self::Deployer]
     }
 
-    /// Constructs and returns a PrivateKeySigner for this account.
+    /// Constructs and returns a `PrivateKeySigner` for this account.
     pub fn signer(&self) -> PrivateKeySigner {
         let key_bytes =
             hex::decode(self.private_key()).expect("should be able to decode private key");
@@ -63,7 +63,7 @@ impl Account {
             .expect("should be able to build the PrivateKeySigner")
     }
 
-    /// Returns the private key as a B256 for use with TransactionBuilder.
+    /// Returns the private key as a B256 for use with `TransactionBuilder`.
     pub fn signer_b256(&self) -> B256 {
         let key_bytes =
             hex::decode(self.private_key()).expect("should be able to decode private key");
@@ -96,7 +96,7 @@ impl Account {
         Ok((signed_tx_bytes, contract_address, *signed_tx.hash()))
     }
 
-    /// Sign a TransactionRequest and return the signed bytes.
+    /// Sign a `TransactionRequest` and return the signed bytes.
     pub fn sign_txn_request(&self, tx_request: OpTransactionRequest) -> Result<(Bytes, TxHash)> {
         let tx_request = tx_request
             .from(self.address())


### PR DESCRIPTION
## Summary

Enables stricter clippy lints to help ensure contributions meet a certain quality.

The added lints are essentially the most common/popular lints across the protocol rust repositories as well as the broader rust ecosystem.