### PR TITLE
feat: introduce contender for devnet

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -147,7 +147,7 @@ devnet-checks: devnet-status devnet-smoke
 
 # Starts the contender load generator
 devnet-load:
-    docker compose up -d --no-deps contender
+    docker compose -f docker/docker-compose.yml up -d --no-deps contender
 
 # Stream FB's from the builder via websocket
 devnet-flashblocks:

--- a/Justfile
+++ b/Justfile
@@ -123,7 +123,7 @@ bench-flashblocks:
 
 # Stops devnet, deletes data, and starts fresh
 devnet: devnet-down
-    docker compose --env-file .env.devnet -f docker/docker-compose.yml up -d --build
+    docker compose --env-file .env.devnet -f docker/docker-compose.yml up -d --build --scale contender=0
 
 # Stops devnet and deletes all data
 devnet-down:
@@ -144,6 +144,10 @@ devnet-smoke:
 
 # Runs full devnet checks (status + smoke tests)
 devnet-checks: devnet-status devnet-smoke
+
+# Starts the contender load generator
+devnet-load:
+    docker compose up -d contender
 
 # Stream FB's from the builder via websocket
 devnet-flashblocks:

--- a/Justfile
+++ b/Justfile
@@ -147,7 +147,7 @@ devnet-checks: devnet-status devnet-smoke
 
 # Starts the contender load generator
 devnet-load:
-    docker compose up -d contender
+    docker compose up -d --no-deps contender
 
 # Stream FB's from the builder via websocket
 devnet-flashblocks:

--- a/crates/shared/primitives/contracts/.gitignore
+++ b/crates/shared/primitives/contracts/.gitignore
@@ -13,6 +13,8 @@ docs/
 # Dotenv file
 .env
 
+# lib
+lib/**
 
 # Soldeer
 /dependencies

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -426,16 +426,16 @@ services:
       base-builder:
         condition: service_healthy
     volumes:
-      - ./scenarios:/scenarios:ro
+      - ./scripts/devnet/load/:/load:ro
       - ./.devnet/contender:/root/.contender
-    entrypoint: /bin/sh
     command:
-      - -c
-      - |
-        echo "Starting contender with continuous load generation..."
-        while true; do
-          echo "Running campaign at $$(date)"
-          contender campaign /scripts/devnet/load/campaign.toml -r http://base-builder:${L2_BUILDER_HTTP_PORT} -p ${ANVIL_ACCOUNT_2_KEY} --timeout 0 --min-balance 1234000000000000000 || echo "Campaign ended, restarting..."
-          sleep 1
-        done
+      - campaign
+      - /load/campaign.toml
+      - -r
+      - http://base-builder:${L2_BUILDER_HTTP_PORT}
+      - -p
+      - ${ANVIL_ACCOUNT_9_KEY}
+      - --min-balance
+      - "1234000000000000000"
+      - --forever
     restart: unless-stopped

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -426,8 +426,8 @@ services:
       base-builder:
         condition: service_healthy
     volumes:
-      - ./scripts/devnet/load/:/load:ro
-      - ./.devnet/contender:/root/.contender
+      - ../scripts/devnet/load/:/load:ro
+      - ../.devnet/contender:/root/.contender
     command:
       - campaign
       - /load/campaign.toml
@@ -437,5 +437,4 @@ services:
       - ${ANVIL_ACCOUNT_9_KEY}
       - --min-balance
       - "1234000000000000000"
-      - --forever
     restart: unless-stopped

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -418,3 +418,24 @@ services:
       retries: 240
       start_period: 250ms
     restart: unless-stopped
+
+  contender:
+    image: flashbots/contender:latest
+    container_name: contender
+    depends_on:
+      base-builder:
+        condition: service_healthy
+    volumes:
+      - ./scenarios:/scenarios:ro
+      - ./.devnet/contender:/root/.contender
+    entrypoint: /bin/sh
+    command:
+      - -c
+      - |
+        echo "Starting contender with continuous load generation..."
+        while true; do
+          echo "Running campaign at $$(date)"
+          contender campaign /scripts/devnet/load/campaign.toml -r http://base-builder:${L2_BUILDER_HTTP_PORT} -p ${ANVIL_ACCOUNT_2_KEY} --timeout 0 --min-balance 1234000000000000000 || echo "Campaign ended, restarting..."
+          sleep 1
+        done
+    restart: unless-stopped

--- a/scripts/devnet/load/campaign.toml
+++ b/scripts/devnet/load/campaign.toml
@@ -7,10 +7,10 @@ scenarios = [
 ]
 
 [spam]
-mode = "tps"         # or "tpb"
-rate = 20            # default rate if a stage omits one (TPS or TPB via mode)
-duration = 3000      # default duration (seconds if tps, blocks if tpb)
-seed = 42            # optional; falls back to CLI --seed or seed file
+mode = "tps"
+rate = 10
+duration = 3000
+seed = 1
 
 [[spam.stage]]
 name = "steady"

--- a/scripts/devnet/load/campaign.toml
+++ b/scripts/devnet/load/campaign.toml
@@ -9,6 +9,7 @@ scenarios = [
 [spam]
 mode = "tps"
 rate = 10
+duration = 300
 seed = 1
 
 [[spam.stage]]

--- a/scripts/devnet/load/campaign.toml
+++ b/scripts/devnet/load/campaign.toml
@@ -1,0 +1,20 @@
+name = "load"
+description = "Continuous baseline load generation"
+
+[setup]
+scenarios = [
+  "scenario:simple.toml",
+]
+
+[spam]
+mode = "tps"         # or "tpb"
+rate = 20            # default rate if a stage omits one (TPS or TPB via mode)
+duration = 3000      # default duration (seconds if tps, blocks if tpb)
+seed = 42            # optional; falls back to CLI --seed or seed file
+
+[[spam.stage]]
+name = "steady"
+duration_secs = 600
+  [[spam.stage.mix]]
+  scenario  = "scenario:simple.toml"
+  share_pct = 100.0

--- a/scripts/devnet/load/campaign.toml
+++ b/scripts/devnet/load/campaign.toml
@@ -9,12 +9,11 @@ scenarios = [
 [spam]
 mode = "tps"
 rate = 10
-duration = 3000
 seed = 1
 
 [[spam.stage]]
 name = "steady"
-duration_secs = 600
+duration_secs = 300
   [[spam.stage.mix]]
   scenario  = "scenario:simple.toml"
   share_pct = 100.0


### PR DESCRIPTION
Adds [contender](https://github.com/flashbots/contender) as a docker container to the devnet that runs a simple load on the network to give a baseline throughput to the chain. 

- The contender runs a campaign that has 1 scenario
- We can add / remove scenarios to mimic different traffic patterns

## Test:
- Run `just devnet`
- Run `just devnet-logs contender`. Should see logs like:
```
contender  | 2026-01-29T19:05:09.019093Z  INFO prepared 10 payloads
contender  | 2026-01-29T19:05:09.631319Z  INFO unconfirmed txs: 25
contender  | 2026-01-29T19:05:09.636049Z  INFO found 11 receipts for block 27
contender  | 2026-01-29T19:05:10.042723Z  INFO [10] executed 10 spam tasks
contender  | 2026-01-29T19:05:10.042735Z  INFO all spam txs sent successfully
contender  | 2026-01-29T19:05:11.045189Z  INFO preparing 10 spam payloads
contender  | 2026-01-29T19:05:11.045695Z  INFO prepared 10 payloads
contender  | 2026-01-29T19:05:11.631200Z  INFO unconfirmed txs: 25
contender  | 2026-01-29T19:05:11.634236Z  INFO found 11 receipts for block 28
```
- Run `just devnet-flashblocks` you should see TxHashes in `transactions` field


## Use cases
- We can load test the devnet on different workloads by adding more `scenarios` to the campaign 
- We can use `just devnet-load` to generate a minimal load while stress testing other features (i.e., metering stress testing on DA/state root calculation/exec time etc.)