### PR TITLE
fix(client): Flashblocks WS RPC Subscriptions

### DIFF
--- a/crates/client/flashblocks-node/tests/flashblocks_rpc.rs
+++ b/crates/client/flashblocks-node/tests/flashblocks_rpc.rs
@@ -1159,11 +1159,12 @@ async fn test_eth_subscribe_new_flashblock_transactions_full() -> eyre::Result<(
     assert_eq!(notif["method"], "eth_subscription");
     assert_eq!(notif["params"]["subscription"], subscription_id);
 
-    // Result should be a single full transaction object, not an array
+    // Result should be a single full transaction object with logs, not an array
     let tx = &notif["params"]["result"];
     assert!(tx.is_object(), "Expected transaction object, got: {:?}", tx);
     assert!(tx["hash"].is_string(), "Expected full tx with hash field");
     assert!(tx["blockNumber"].is_string(), "Expected full tx with blockNumber field");
+    assert!(tx["logs"].is_array(), "Expected logs array in full transaction");
 
     // Send second flashblock with 9 more transactions (10 total cumulative)
     setup.send_flashblock(setup.create_second_payload()).await?;
@@ -1176,6 +1177,7 @@ async fn test_eth_subscribe_new_flashblock_transactions_full() -> eyre::Result<(
         assert_eq!(notif["params"]["subscription"], subscription_id);
         let tx = &notif["params"]["result"];
         assert!(tx["hash"].is_string() && tx["blockNumber"].is_string());
+        assert!(tx["logs"].is_array(), "Expected logs array in full transaction");
         received_count += 1;
     }
     assert_eq!(received_count, 10);

--- a/crates/client/flashblocks-node/tests/flashblocks_rpc.rs
+++ b/crates/client/flashblocks-node/tests/flashblocks_rpc.rs
@@ -1106,19 +1106,19 @@ async fn test_eth_subscribe_new_flashblock_transactions_hashes() -> eyre::Result
     let tx_hash = &notif["params"]["result"];
     assert!(tx_hash.is_string(), "Expected hash string, got: {:?}", tx_hash);
 
-    // Send second flashblock with 9 more transactions (10 total cumulative)
+    // Send second flashblock with 9 more transactions (delta only, not cumulative)
     setup.send_flashblock(setup.create_second_payload()).await?;
 
-    // Receive 10 separate messages (one per transaction)
+    // Receive 9 separate messages (one per transaction in the delta)
     let mut received_hashes = Vec::new();
-    for _ in 0..10 {
+    for _ in 0..9 {
         let notification = ws_stream.next().await.unwrap()?;
         let notif: serde_json::Value = serde_json::from_str(notification.to_text()?)?;
         assert_eq!(notif["params"]["subscription"], subscription_id);
         let tx_hash = notif["params"]["result"].as_str().expect("expected hash string");
         received_hashes.push(tx_hash.to_string());
     }
-    assert_eq!(received_hashes.len(), 10);
+    assert_eq!(received_hashes.len(), 9);
 
     Ok(())
 }
@@ -1166,12 +1166,12 @@ async fn test_eth_subscribe_new_flashblock_transactions_full() -> eyre::Result<(
     assert!(tx["blockNumber"].is_string(), "Expected full tx with blockNumber field");
     assert!(tx["logs"].is_array(), "Expected logs array in full transaction");
 
-    // Send second flashblock with 9 more transactions (10 total cumulative)
+    // Send second flashblock with 9 more transactions (delta only, not cumulative)
     setup.send_flashblock(setup.create_second_payload()).await?;
 
-    // Receive 10 separate messages (one per transaction)
+    // Receive 9 separate messages (one per transaction in the delta)
     let mut received_count = 0;
-    for _ in 0..10 {
+    for _ in 0..9 {
         let notification = ws_stream.next().await.unwrap()?;
         let notif: serde_json::Value = serde_json::from_str(notification.to_text()?)?;
         assert_eq!(notif["params"]["subscription"], subscription_id);
@@ -1180,7 +1180,7 @@ async fn test_eth_subscribe_new_flashblock_transactions_full() -> eyre::Result<(
         assert!(tx["logs"].is_array(), "Expected logs array in full transaction");
         received_count += 1;
     }
-    assert_eq!(received_count, 10);
+    assert_eq!(received_count, 9);
 
     Ok(())
 }

--- a/crates/client/flashblocks-node/tests/flashblocks_rpc.rs
+++ b/crates/client/flashblocks-node/tests/flashblocks_rpc.rs
@@ -1096,24 +1096,29 @@ async fn test_eth_subscribe_new_flashblock_transactions_hashes() -> eyre::Result
     // Send first flashblock with L1 deposit tx
     setup.send_flashblock(setup.create_first_payload()).await?;
 
+    // Each transaction is now sent as a separate message (one tx per message)
     let notification = ws_stream.next().await.unwrap()?;
     let notif: serde_json::Value = serde_json::from_str(notification.to_text()?)?;
     assert_eq!(notif["method"], "eth_subscription");
     assert_eq!(notif["params"]["subscription"], subscription_id);
 
-    // Result should be an array of transaction hashes (strings)
-    let txs = notif["params"]["result"].as_array().expect("expected array of tx hashes");
-    assert_eq!(txs.len(), 1);
-    assert!(txs[0].is_string(), "Expected hash string, got: {:?}", txs[0]);
+    // Result should be a single transaction hash (string), not an array
+    let tx_hash = &notif["params"]["result"];
+    assert!(tx_hash.is_string(), "Expected hash string, got: {:?}", tx_hash);
 
-    // Send second flashblock with more transactions
+    // Send second flashblock with 9 more transactions (10 total cumulative)
     setup.send_flashblock(setup.create_second_payload()).await?;
 
-    let notification2 = ws_stream.next().await.unwrap()?;
-    let notif2: serde_json::Value = serde_json::from_str(notification2.to_text()?)?;
-    let txs2 = notif2["params"]["result"].as_array().expect("expected array of tx hashes");
-    assert_eq!(txs2.len(), 10); // 1 from first flashblock + 9 from second = 10 total
-    assert!(txs2.iter().all(|tx| tx.is_string()));
+    // Receive 10 separate messages (one per transaction)
+    let mut received_hashes = Vec::new();
+    for _ in 0..10 {
+        let notification = ws_stream.next().await.unwrap()?;
+        let notif: serde_json::Value = serde_json::from_str(notification.to_text()?)?;
+        assert_eq!(notif["params"]["subscription"], subscription_id);
+        let tx_hash = notif["params"]["result"].as_str().expect("expected hash string");
+        received_hashes.push(tx_hash.to_string());
+    }
+    assert_eq!(received_hashes.len(), 10);
 
     Ok(())
 }
@@ -1148,26 +1153,32 @@ async fn test_eth_subscribe_new_flashblock_transactions_full() -> eyre::Result<(
     // Send flashblocks
     setup.send_flashblock(setup.create_first_payload()).await?;
 
+    // Each transaction is now sent as a separate message (one tx per message)
     let notification = ws_stream.next().await.unwrap()?;
     let notif: serde_json::Value = serde_json::from_str(notification.to_text()?)?;
     assert_eq!(notif["method"], "eth_subscription");
     assert_eq!(notif["params"]["subscription"], subscription_id);
 
-    // Result should be an array of full transaction objects
-    let txs = notif["params"]["result"].as_array().expect("expected array of transactions");
-    assert_eq!(txs.len(), 1);
-    // Full transaction objects have fields like "hash", "from", "to", etc.
-    assert!(txs[0]["hash"].is_string(), "Expected full tx with hash field");
-    assert!(txs[0]["blockNumber"].is_string(), "Expected full tx with blockNumber field");
+    // Result should be a single full transaction object, not an array
+    let tx = &notif["params"]["result"];
+    assert!(tx.is_object(), "Expected transaction object, got: {:?}", tx);
+    assert!(tx["hash"].is_string(), "Expected full tx with hash field");
+    assert!(tx["blockNumber"].is_string(), "Expected full tx with blockNumber field");
 
-    // Send second flashblock with more transactions
+    // Send second flashblock with 9 more transactions (10 total cumulative)
     setup.send_flashblock(setup.create_second_payload()).await?;
 
-    let notification2 = ws_stream.next().await.unwrap()?;
-    let notif2: serde_json::Value = serde_json::from_str(notification2.to_text()?)?;
-    let txs2 = notif2["params"]["result"].as_array().expect("expected array of transactions");
-    assert_eq!(txs2.len(), 10); // 1 from first flashblock + 9 from second = 10 total
-    assert!(txs2.iter().all(|tx| tx["hash"].is_string() && tx["blockNumber"].is_string()));
+    // Receive 10 separate messages (one per transaction)
+    let mut received_count = 0;
+    for _ in 0..10 {
+        let notification = ws_stream.next().await.unwrap()?;
+        let notif: serde_json::Value = serde_json::from_str(notification.to_text()?)?;
+        assert_eq!(notif["params"]["subscription"], subscription_id);
+        let tx = &notif["params"]["result"];
+        assert!(tx["hash"].is_string() && tx["blockNumber"].is_string());
+        received_count += 1;
+    }
+    assert_eq!(received_count, 10);
 
     Ok(())
 }

--- a/crates/client/flashblocks-node/tests/flashblocks_rpc.rs
+++ b/crates/client/flashblocks-node/tests/flashblocks_rpc.rs
@@ -1104,7 +1104,7 @@ async fn test_eth_subscribe_new_flashblock_transactions_hashes() -> eyre::Result
 
     // Result should be a single transaction hash (string), not an array
     let tx_hash = &notif["params"]["result"];
-    assert!(tx_hash.is_string(), "Expected hash string, got: {:?}", tx_hash);
+    assert!(tx_hash.is_string(), "Expected hash string, got: {tx_hash:?}");
 
     // Send second flashblock with 9 more transactions (delta only, not cumulative)
     setup.send_flashblock(setup.create_second_payload()).await?;
@@ -1161,7 +1161,7 @@ async fn test_eth_subscribe_new_flashblock_transactions_full() -> eyre::Result<(
 
     // Result should be a single full transaction object with logs, not an array
     let tx = &notif["params"]["result"];
-    assert!(tx.is_object(), "Expected transaction object, got: {:?}", tx);
+    assert!(tx.is_object(), "Expected transaction object, got: {tx:?}");
     assert!(tx["hash"].is_string(), "Expected full tx with hash field");
     assert!(tx["blockNumber"].is_string(), "Expected full tx with blockNumber field");
     assert!(tx["logs"].is_array(), "Expected logs array in full transaction");

--- a/crates/client/flashblocks/src/lib.rs
+++ b/crates/client/flashblocks/src/lib.rs
@@ -50,5 +50,5 @@ pub use config::FlashblocksConfig;
 mod rpc;
 pub use rpc::{
     BaseSubscriptionKind, EthApiExt, EthApiOverrideServer, EthPubSub, EthPubSubApiServer,
-    ExtendedSubscriptionKind,
+    ExtendedSubscriptionKind, TransactionWithLogs,
 };

--- a/crates/client/flashblocks/src/pending_blocks.rs
+++ b/crates/client/flashblocks/src/pending_blocks.rs
@@ -318,6 +318,73 @@ impl PendingBlocks {
     pub fn get_pending_transaction_hashes(&self) -> Vec<B256> {
         self.transactions.iter().map(|tx| tx.tx_hash()).collect()
     }
+
+    /// Returns the number of transactions in all flashblocks except the latest one.
+    /// This is used to compute the delta (transactions only in the latest flashblock).
+    fn previous_flashblocks_tx_count(&self) -> usize {
+        if self.flashblocks.len() <= 1 {
+            return 0;
+        }
+        self.flashblocks[..self.flashblocks.len() - 1]
+            .iter()
+            .map(|fb| fb.diff.transactions.len())
+            .sum()
+    }
+
+    /// Returns logs matching the filter from only the latest flashblock (delta).
+    ///
+    /// Unlike `get_pending_logs`, this returns only logs from transactions
+    /// that were added in the most recent flashblock, avoiding duplicates
+    /// when streaming via WebSocket subscriptions.
+    pub fn get_latest_flashblock_logs(&self, filter: &Filter) -> Vec<Log> {
+        let prev_count = self.previous_flashblocks_tx_count();
+        let mut logs = Vec::new();
+
+        for tx in self.transactions.iter().skip(prev_count) {
+            if let Some(receipt) = self.transaction_receipts.get(&tx.tx_hash()) {
+                for log in receipt.inner.logs() {
+                    if filter.matches(&log.inner) {
+                        logs.push(log.clone());
+                    }
+                }
+            }
+        }
+
+        logs
+    }
+
+    /// Returns transactions with their associated logs from only the latest flashblock (delta).
+    ///
+    /// Unlike `get_pending_transactions_with_logs`, this returns only transactions
+    /// that were added in the most recent flashblock, avoiding duplicates
+    /// when streaming via WebSocket subscriptions.
+    pub fn get_latest_flashblock_transactions_with_logs(&self) -> Vec<TransactionWithLogs> {
+        let prev_count = self.previous_flashblocks_tx_count();
+
+        self.transactions
+            .iter()
+            .skip(prev_count)
+            .map(|tx| {
+                let tx_hash = tx.tx_hash();
+                let logs = self
+                    .transaction_receipts
+                    .get(&tx_hash)
+                    .map(|receipt| receipt.inner.logs().to_vec())
+                    .unwrap_or_default();
+                TransactionWithLogs { transaction: tx.clone(), logs }
+            })
+            .collect()
+    }
+
+    /// Returns the hashes of transactions from only the latest flashblock (delta).
+    ///
+    /// Unlike `get_pending_transaction_hashes`, this returns only hashes
+    /// of transactions that were added in the most recent flashblock,
+    /// avoiding duplicates when streaming via WebSocket subscriptions.
+    pub fn get_latest_flashblock_transaction_hashes(&self) -> Vec<B256> {
+        let prev_count = self.previous_flashblocks_tx_count();
+        self.transactions.iter().skip(prev_count).map(|tx| tx.tx_hash()).collect()
+    }
 }
 
 impl PendingBlocksAPI for Guard<Option<Arc<PendingBlocks>>> {

--- a/crates/client/flashblocks/src/pending_blocks.rs
+++ b/crates/client/flashblocks/src/pending_blocks.rs
@@ -18,7 +18,7 @@ use reth_rpc_convert::RpcTransaction;
 use reth_rpc_eth_api::{RpcBlock, RpcReceipt};
 use revm::state::EvmState;
 
-use crate::{BuildError, Metrics, PendingBlocksAPI, StateProcessorError};
+use crate::{BuildError, Metrics, PendingBlocksAPI, StateProcessorError, TransactionWithLogs};
 
 /// Builder for [`PendingBlocks`].
 #[derive(Debug)]
@@ -296,6 +296,22 @@ impl PendingBlocks {
     /// Returns all pending transactions from flashblocks.
     pub fn get_pending_transactions(&self) -> Vec<Transaction> {
         self.transactions.clone()
+    }
+
+    /// Returns all pending transactions with their associated logs from flashblocks.
+    pub fn get_pending_transactions_with_logs(&self) -> Vec<TransactionWithLogs> {
+        self.transactions
+            .iter()
+            .map(|tx| {
+                let tx_hash = tx.tx_hash();
+                let logs = self
+                    .transaction_receipts
+                    .get(&tx_hash)
+                    .map(|receipt| receipt.inner.logs().to_vec())
+                    .unwrap_or_default();
+                TransactionWithLogs { transaction: tx.clone(), logs }
+            })
+            .collect()
     }
 
     /// Returns the hashes of all pending transactions from flashblocks.

--- a/crates/client/flashblocks/src/rpc/mod.rs
+++ b/crates/client/flashblocks/src/rpc/mod.rs
@@ -6,4 +6,4 @@ mod types;
 
 pub use eth::{EthApiExt, EthApiOverrideServer};
 pub use pubsub::{EthPubSub, EthPubSubApiServer};
-pub use types::{BaseSubscriptionKind, ExtendedSubscriptionKind};
+pub use types::{BaseSubscriptionKind, ExtendedSubscriptionKind, TransactionWithLogs};

--- a/crates/client/flashblocks/src/rpc/pubsub.rs
+++ b/crates/client/flashblocks/src/rpc/pubsub.rs
@@ -91,9 +91,11 @@ impl<Eth, FB> EthPubSub<Eth, FB> {
         })
     }
 
-    /// Returns a stream that yields individual logs from pending flashblocks matching the filter.
+    /// Returns a stream that yields individual logs from only the latest flashblock matching the
+    /// filter.
     ///
     /// Each matching log is emitted as a separate stream item (one log per WebSocket message).
+    /// Only logs from the most recent flashblock are emitted to avoid duplicates.
     fn pending_logs_stream(flashblocks_state: Arc<FB>, filter: Filter) -> impl Stream<Item = Log>
     where
         FB: FlashblocksAPI + Send + Sync + 'static,
@@ -112,7 +114,7 @@ impl<Eth, FB> EthPubSub<Eth, FB> {
                             return None;
                         }
                     };
-                    let logs = pending_blocks.get_pending_logs(&filter);
+                    let logs = pending_blocks.get_latest_flashblock_logs(&filter);
                     if logs.is_empty() { None } else { Some(logs) }
                 },
             ),
@@ -120,11 +122,12 @@ impl<Eth, FB> EthPubSub<Eth, FB> {
         )
     }
 
-    /// Returns a stream that yields individual full transactions with logs from pending
-    /// flashblocks.
+    /// Returns a stream that yields individual full transactions with logs from only the latest
+    /// flashblock.
     ///
     /// Each transaction (with its associated logs) is emitted as a separate stream item
-    /// (one transaction per WebSocket message).
+    /// (one transaction per WebSocket message). Only transactions from the most recent
+    /// flashblock are emitted to avoid duplicates.
     fn new_flashblock_transactions_full_stream(
         flashblocks_state: Arc<FB>,
     ) -> impl Stream<Item = TransactionWithLogs>
@@ -145,7 +148,7 @@ impl<Eth, FB> EthPubSub<Eth, FB> {
                             return None;
                         }
                     };
-                    let txs = pending_blocks.get_pending_transactions_with_logs();
+                    let txs = pending_blocks.get_latest_flashblock_transactions_with_logs();
                     if txs.is_empty() { None } else { Some(txs) }
                 },
             ),
@@ -153,9 +156,10 @@ impl<Eth, FB> EthPubSub<Eth, FB> {
         )
     }
 
-    /// Returns a stream that yields individual transaction hashes from pending flashblocks.
+    /// Returns a stream that yields individual transaction hashes from only the latest flashblock.
     ///
     /// Each hash is emitted as a separate stream item (one hash per WebSocket message).
+    /// Only hashes from the most recent flashblock are emitted to avoid duplicates.
     fn new_flashblock_transactions_hash_stream(
         flashblocks_state: Arc<FB>,
     ) -> impl Stream<Item = B256>
@@ -176,7 +180,7 @@ impl<Eth, FB> EthPubSub<Eth, FB> {
                             return None;
                         }
                     };
-                    let hashes = pending_blocks.get_pending_transaction_hashes();
+                    let hashes = pending_blocks.get_latest_flashblock_transaction_hashes();
                     if hashes.is_empty() { None } else { Some(hashes) }
                 },
             ),

--- a/crates/client/flashblocks/src/rpc/types.rs
+++ b/crates/client/flashblocks/src/rpc/types.rs
@@ -1,7 +1,22 @@
 //! Subscription types for the `eth_` `PubSub` RPC extension
 
-use alloy_rpc_types_eth::pubsub::SubscriptionKind;
+use alloy_rpc_types_eth::{Log, pubsub::SubscriptionKind};
+use op_alloy_rpc_types::Transaction;
 use serde::{Deserialize, Serialize};
+
+/// A full transaction object with its associated logs.
+///
+/// This is returned by `newFlashblockTransactions` subscription when `full = true`,
+/// providing both the transaction details and logs emitted by its execution.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TransactionWithLogs {
+    /// The full transaction object.
+    #[serde(flatten)]
+    pub transaction: Transaction,
+    /// Logs emitted by this transaction.
+    pub logs: Vec<Log>,
+}
 
 /// Extended subscription kind that includes both standard Ethereum subscription types
 /// and flashblocks-specific types.
@@ -48,7 +63,8 @@ pub enum BaseSubscriptionKind {
     /// Flashblock transactions have been included by the sequencer and are effectively preconfirmed.
     ///
     /// Accepts an optional boolean parameter:
-    /// - `true`: Returns full transaction objects
+    /// - `true`: Returns full transaction objects with their associated logs (as
+    ///   [`TransactionWithLogs`])
     /// - `false` (default): Returns only transaction hashes
     NewFlashblockTransactions,
 }


### PR DESCRIPTION
## Summary

Closes #613

This PR fixes the flashblocks WebSocket subscription RPCs to emit one item per message instead of arrays, aligning with how standard Ethereum subscription variants work -- `newFlashblockTransactions` (both hash-only and full) and `pendingLogs` now stream individual transactions/logs per WebSocket message by flat-mapping the internal batch streams, with corresponding test updates to validate the new per-item format.

This change also needs to be backported to `0.3.0` I believe.