### PR TITLE
fix(flashblocks): add missing fields to rpc

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1969,6 +1969,7 @@ dependencies = [
  "op-alloy-consensus",
  "op-alloy-network",
  "op-alloy-rpc-types",
+ "op-alloy-rpc-types-engine",
  "rayon",
  "reth-chainspec",
  "reth-evm",

--- a/crates/client/flashblocks/Cargo.toml
+++ b/crates/client/flashblocks/Cargo.toml
@@ -42,6 +42,7 @@ alloy-rpc-types-engine.workspace = true
 # op-alloy
 op-alloy-network.workspace = true
 op-alloy-rpc-types.workspace = true
+op-alloy-rpc-types-engine.workspace = true
 op-alloy-consensus.workspace = true
 
 # tokio

--- a/crates/client/flashblocks/src/pending_blocks.rs
+++ b/crates/client/flashblocks/src/pending_blocks.rs
@@ -7,7 +7,7 @@ use alloy_primitives::{
     map::foldhash::{HashMap, HashMapExt},
 };
 use alloy_provider::network::TransactionResponse;
-use alloy_rpc_types::{BlockTransactions, state::StateOverride};
+use alloy_rpc_types::{BlockTransactions, Withdrawal, state::StateOverride};
 use alloy_rpc_types_eth::{Filter, Header as RPCHeader, Log};
 use arc_swap::Guard;
 use base_flashtypes::Flashblock;
@@ -231,6 +231,11 @@ impl PendingBlocks {
             .collect()
     }
 
+    /// Returns all withdrawals collected from flashblocks.
+    fn get_withdrawals(&self) -> Vec<Withdrawal> {
+        self.flashblocks.iter().flat_map(|fb| fb.diff.withdrawals.clone()).collect()
+    }
+
     /// Returns the latest block, optionally with full transaction details.
     pub fn get_latest_block(&self, full: bool) -> RpcBlock<Optimism> {
         let header = self.latest_header();
@@ -248,7 +253,7 @@ impl PendingBlocks {
             header: RPCHeader::from_consensus(header, None, None),
             transactions,
             uncles: Vec::new(),
-            withdrawals: None,
+            withdrawals: Some(self.get_withdrawals().into()),
         }
     }
 


### PR DESCRIPTION
### Description
Add the missing fields to pending blocks. These are:

1. Withdrawals, should always be empty array (but derived from FB's)
2. Parent beacon block root, passed from builder
3. Requests hash, should always be the empty hash


### Context
Diff between op-reth and base-node-reth
<img width="3394" height="1796" alt="image" src="https://github.com/user-attachments/assets/1f442720-2886-4f41-8a3c-cc9af0482995" />