### PR TITLE
docs: update README terminology to match FAL specs

### DIFF
--- a/crates/shared/access-lists/README.md
+++ b/crates/shared/access-lists/README.md
@@ -1,6 +1,6 @@
 # `base-fbal`
 
-A library to build and process Flashblock-level Access Lists (FBALs).
+A library to build and process Flashblock-level Access Lists (FALs).
 
 See the [spec](../../../docs/specs/access-lists.md) for more details.
 


### PR DESCRIPTION
### Description
This PR updates the terminology in `crates/shared/access-lists/README.md` to match the official specification defined in `docs/specs/access-lists.md`.

The specification consistently refers to "Flashblock-Level Access Lists" as **FAL**, whereas the README previously referred to them as **FBAL**.

### Changes
- Updated `crates/shared/access-lists/README.md`: Changed text `(FBALs)` to `(FALs)`.

### Note to Maintainers
I noticed that the crate name itself is still `base-fbal` (and the struct `FBALBuilderDb`). I deliberately restricted this PR to a **documentation-only update** to avoid breaking changes or refactoring overhead at this stage. 

However, it might be worth considering a rename of the crate/structs to `base-fal` / `FALBuilderDb` in a future refactor to fully align with the specs.