### PR TITLE
Enable client feature for reth-optimism-rpc in dev-dependencies

### DIFF
--- a/crates/builder/core/Cargo.toml
+++ b/crates/builder/core/Cargo.toml
@@ -157,6 +157,7 @@ tempfile.workspace = true
 nanoid.workspace = true
 reth-ipc.workspace = true
 reth-node-builder = { workspace = true, features = ["test-utils"] }
+reth-optimism-rpc = { workspace = true, features = ["client"] }
 ctor.workspace = true
 rlimit.workspace = true
 hyper.workspace = true

--- a/deny.toml
+++ b/deny.toml
@@ -100,6 +100,7 @@ skip = [
     "itertools",
     "lru",
     "dashmap",
+    "rustc-hash",
 
     # System/platform crates
     "rustix",
@@ -150,6 +151,7 @@ skip = [
     "tracing-opentelemetry",
     "unicode-width",
     "webpki-roots",
+    "webpki-root-certs",
 
     # libp2p dependency chain version mismatch
     "unsigned-varint",


### PR DESCRIPTION
Fixes test compilation by enabling the `client` feature for `reth-optimism-rpc` in dev-dependencies. This is required because `OpEngineApiClient` is only exported when this feature is enabled.