### PR TITLE
chore(builder): README.md Update

### DIFF
--- a/crates/builder/op-rbuilder/README.md
+++ b/crates/builder/op-rbuilder/README.md
@@ -3,29 +3,20 @@
 <a href="https://github.com/base/base/actions/workflows/ci.yml"><img src="https://github.com/base/base/actions/workflows/ci.yml/badge.svg?label=ci" alt="CI"></a>
 <a href="https://github.com/base/base/blob/main/LICENSE"><img src="https://img.shields.io/badge/License-MIT-d1d1f6.svg?label=license&labelColor=2a2f35" alt="MIT License"></a>
 
-Optimism block builder for Base. Provides payload building infrastructure with support for standard block production and flashblocks, which progressively builds block chunks at sub-second intervals.
+Optimism block builder library for Base. Provides flashblocks payload building infrastructure, which progressively builds block chunks at sub-second intervals.
 
 ## Overview
 
-- **`FlashblocksBuilder`**: Progressive block builder that produces block chunks at short intervals, publishing them via WebSocket before merging into full blocks.
-- **`StandardBuilder`**: Traditional block builder that produces complete blocks at each chain block time.
-- **`BuilderMode`**: Configuration enum to select between `Standard` and `Flashblocks` modes.
-- **`RevertProtection`**: RPC extension for protecting transactions from reverts.
-- **`TxDataStore`**: Transaction data storage and retrieval service.
-- **`Signer`**: Transaction signing utilities for builder operations.
-
-## Binaries
-
-- **`op-rbuilder`**: Main builder binary with full node capabilities.
-- **`tester`**: Testing utility binary (requires `testing` feature).
+- **`flashblocks`**: Progressive block builder that produces block chunks at short intervals, publishing them via WebSocket before merging into full blocks.
+- **`launcher`**: Node launcher utilities for starting the builder.
+- **`tx_data_store`**: Transaction data storage and retrieval service with RPC extensions.
+- **`tx_signer`**: Transaction signing utilities.
 
 ## Features
 
 - `jemalloc`: Use jemalloc allocator (default).
+- `jemalloc-prof`: Enable jemalloc profiling.
 - `testing`: Enable testing utilities and framework.
-- `telemetry`: Enable `OpenTelemetry` integration.
-- `interop`: Enable interoperability features.
-- `custom-engine-api`: Enable custom engine API extensions.
 
 ## Usage
 
@@ -36,15 +27,7 @@ Add the dependency to your `Cargo.toml`:
 op-rbuilder = { git = "https://github.com/base/base" }
 ```
 
-Run the builder:
-
-```bash
-# Standard mode
-op-rbuilder node --builder.mode standard
-
-# Flashblocks mode
-op-rbuilder node --builder.mode flashblocks
-```
+To run the builder, use the [`base-builder`](../../../bin/builder/) binary.
 
 ## License
 


### PR DESCRIPTION
## Summary

The `README.md` in the `op-rbuilder` crate was quite out of date since the great migration.

This PR cleans up the builder's `README.md` to accurately reflect the crate contents.