### PR TITLE
fix(ci): Cache Re-use

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,8 +40,8 @@ jobs:
       - uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2.8.2
         with:
           cache-on-failure: true
-          add-rust-environment-hash-key: "false"
-          key: stable-${{ hashFiles('Cargo.lock') }}
+          shared-key: "stable"
+          save-if: ${{ github.ref == 'refs/heads/main' }}
       - name: Install just
         uses: extractions/setup-just@e33e0265a09d6d736e2ee1e0eb685ef1de4669ff # v3
       - name: Install Foundry
@@ -74,8 +74,8 @@ jobs:
       - uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2.8.2
         with:
           cache-on-failure: true
-          add-rust-environment-hash-key: "false"
-          key: stable-${{ hashFiles('Cargo.lock') }}
+          shared-key: "stable"
+          save-if: false
       - name: Install just
         uses: extractions/setup-just@e33e0265a09d6d736e2ee1e0eb685ef1de4669ff # v3
       - name: Install cargo-nextest
@@ -105,8 +105,8 @@ jobs:
       - uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2.8.2
         with:
           cache-on-failure: true
-          add-rust-environment-hash-key: "false"
-          key: nightly-${{ hashFiles('Cargo.lock') }}
+          shared-key: "nightly"
+          save-if: ${{ github.ref == 'refs/heads/main' }}
       - name: Install just
         uses: extractions/setup-just@e33e0265a09d6d736e2ee1e0eb685ef1de4669ff # v3
       - run: just check-format
@@ -136,8 +136,8 @@ jobs:
       - uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2.8.2
         with:
           cache-on-failure: true
-          add-rust-environment-hash-key: "false"
-          key: stable-${{ hashFiles('Cargo.lock') }}
+          shared-key: "stable"
+          save-if: false
       - name: Install just
         uses: extractions/setup-just@e33e0265a09d6d736e2ee1e0eb685ef1de4669ff # v3
       - name: Install Foundry
@@ -167,8 +167,8 @@ jobs:
           context: .
           file: docker/Dockerfile.client
           push: false
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=gha,scope=ci-docker
+          cache-to: type=gha,mode=max,scope=ci-docker
 
   udeps:
     name: udeps
@@ -193,8 +193,8 @@ jobs:
       - uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2.8.2
         with:
           cache-on-failure: true
-          add-rust-environment-hash-key: "false"
-          key: nightly-${{ hashFiles('Cargo.lock') }}
+          shared-key: "nightly"
+          save-if: false
       - uses: taiki-e/install-action@3575e532701a5fc614b0c842e4119af4cc5fd16d # v2.62.60
         with:
           tool: cargo-udeps
@@ -235,8 +235,8 @@ jobs:
       - uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2.8.2
         with:
           cache-on-failure: true
-          add-rust-environment-hash-key: "false"
-          key: stable-${{ hashFiles('Cargo.lock') }}
+          shared-key: "stable"
+          save-if: false
       - name: Install just
         uses: extractions/setup-just@e33e0265a09d6d736e2ee1e0eb685ef1de4669ff # v3
       - run: just check-deny

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -67,8 +67,8 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           platforms: ${{ matrix.settings.arch }}
           outputs: type=image,push-by-digest=true,name-canonical=true,push=true
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=gha,scope=docker-dev
+          cache-to: type=gha,mode=max,scope=docker-dev
 
       - name: Export digest
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,8 +29,8 @@ jobs:
       - uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2.8.2
         with:
           cache-on-failure: true
-          add-rust-environment-hash-key: "false"
-          key: stable-${{ hashFiles('Cargo.lock') }}
+          shared-key: "stable"
+          save-if: false
       - name: Install just
         uses: extractions/setup-just@e33e0265a09d6d736e2ee1e0eb685ef1de4669ff # v3
       - run: just build-all-targets
@@ -52,8 +52,8 @@ jobs:
       - uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2.8.2
         with:
           cache-on-failure: true
-          add-rust-environment-hash-key: "false"
-          key: stable-${{ hashFiles('Cargo.lock') }}
+          shared-key: "stable"
+          save-if: false
       - name: Install just
         uses: extractions/setup-just@e33e0265a09d6d736e2ee1e0eb685ef1de4669ff # v3
       - name: Install cargo-nextest
@@ -88,8 +88,8 @@ jobs:
           context: .
           file: docker/Dockerfile.client
           push: false
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=gha,scope=release-docker
+          cache-to: type=gha,mode=max,scope=release-docker
 
   # Build multi-arch Docker images
   build-and-push:
@@ -144,8 +144,8 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           platforms: ${{ matrix.settings.arch }}
           outputs: type=image,push-by-digest=true,name-canonical=true,push=true
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=gha,scope=release-docker
+          cache-to: type=gha,mode=max,scope=release-docker
 
       - name: Export digest
         run: |


### PR DESCRIPTION
## Summary

Optimize GitHub Actions cache usage to eliminate round-robin cache eviction caused by the 10GB free tier limit.

Add `shared-key` to rust-cache steps so jobs share caches by toolchain instead of each creating their own. Add save-if: main so only main branch saves caches and PRs restore without polluting. Scope Docker BuildKit caches by workflow to prevent cross-workflow eviction.

Reduces cache usage from `~18-20GB` to `~8-10GB` and ensures consistent cache hits across runs.