### PR TITLE
chore(aa): We move account abstraction types from base/tips

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1723,13 +1723,11 @@ version = "0.0.0"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types",
- "alloy-serde",
  "alloy-sol-types",
  "anyhow",
  "async-trait",
  "serde",
  "serde_json",
- "tracing",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1718,6 +1718,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "base-account-abstraction"
+version = "0.0.0"
+dependencies = [
+ "alloy-primitives",
+ "alloy-rpc-types",
+ "alloy-serde",
+ "alloy-sol-types",
+ "anyhow",
+ "async-trait",
+ "serde",
+ "serde_json",
+ "tracing",
+]
+
+[[package]]
 name = "base-builder"
 version = "0.0.0"
 dependencies = [
@@ -7478,6 +7493,7 @@ dependencies = [
  "alloy-rlp",
  "alloy-rpc-types-engine",
  "alloy-serde",
+ "arbitrary",
  "derive_more",
  "ethereum_ssz",
  "ethereum_ssz_derive",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -91,28 +91,29 @@ codegen-units = 1
 
 [workspace.dependencies]
 # Shared
-base-jwt = { path = "crates/shared/jwt" }
+base-access-lists = { path = "crates/shared/access-lists" }
+base-account-abstraction = { path = "crates/shared/account-abstraction" }
 base-bundles = { path = "crates/shared/bundles" }
 base-cli-utils = { path = "crates/shared/cli-utils" }
-base-flashtypes = { path = "crates/shared/flashtypes" }
-base-primitives = { path = "crates/shared/primitives" }
 base-engine-ext = { path = "crates/shared/engine-ext" }
-base-access-lists = { path = "crates/shared/access-lists" }
-base-reth-rpc-types = { path = "crates/shared/reth-rpc-types" }
 base-flashblocks-node = { path = "crates/client/flashblocks-node" }
+base-flashtypes = { path = "crates/shared/flashtypes" }
+base-jwt = { path = "crates/shared/jwt" }
+base-primitives = { path = "crates/shared/primitives" }
 base-proofs-extension = { path = "crates/client/proofs" }
+base-reth-rpc-types = { path = "crates/shared/reth-rpc-types" }
 
 # Client
-base-txpool = { path = "crates/client/txpool" }
 base-client-cli = { path = "crates/client/cli" }
-base-client-node = { path = "crates/client/node" }
-base-metering = { path = "crates/client/metering" }
 base-client-engine = { path = "crates/client/engine" }
+base-client-node = { path = "crates/client/node" }
 base-flashblocks = { path = "crates/client/flashblocks" }
+base-metering = { path = "crates/client/metering" }
+base-txpool = { path = "crates/client/txpool" }
 
 # Builder
-op-rbuilder = { path = "crates/builder/op-rbuilder" }
 base-builder-cli = { path = "crates/builder/base-builder-cli" }
+op-rbuilder = { path = "crates/builder/op-rbuilder" }
 
 # Kona
 kona-cli = { git = "https://github.com/ethereum-optimism/optimism", rev = "238012d2d96d5cebbdc390c9199bd63722115a42", default-features = false }

--- a/crates/consensus/protocol/Cargo.toml
+++ b/crates/consensus/protocol/Cargo.toml
@@ -13,14 +13,27 @@ workspace = true
 
 [features]
 default = [ "std" ]
-std = [ "alloy-consensus/std", "alloy-eips/std", "alloy-primitives/std" ]
+std = [
+	"alloy-consensus/std",
+	"alloy-eips/std",
+	"alloy-primitives/std",
+	"op-alloy-rpc-types-engine/std",
+]
 serde = [
 	"alloy-consensus/serde",
 	"alloy-eips/serde",
 	"alloy-primitives/serde",
 	"dep:serde",
+	"op-alloy-rpc-types-engine/serde",
 ]
-arbitrary = [ "dep:arbitrary" ]
+arbitrary = [
+	"alloy-consensus/arbitrary",
+	"alloy-eips/arbitrary",
+	"alloy-primitives/arbitrary",
+	"alloy-rpc-types-eth/arbitrary",
+	"dep:arbitrary",
+	"op-alloy-rpc-types-engine/arbitrary",
+]
 
 [dependencies]
 # Alloy

--- a/crates/shared/account-abstraction/Cargo.toml
+++ b/crates/shared/account-abstraction/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "base-account-abstraction"
+description = "Base account abstraction types"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+
+[lints]
+workspace = true
+
+[dependencies]
+alloy-serde.workspace = true
+async-trait.workspace = true
+alloy-sol-types.workspace = true
+serde = { workspace = true, features = ["std", "derive"] }
+tracing = { workspace = true, features = ["std"] }
+anyhow = { workspace = true, features = ["std"] }
+serde_json = { workspace = true, features = ["std"] }
+alloy-rpc-types = { workspace = true, features = ["eth"] }
+alloy-primitives = { workspace = true, features = ["map-foldhash", "serde"] }
+
+[dev-dependencies]
+alloy-primitives = { workspace = true, features = ["map-foldhash", "serde"] }

--- a/crates/shared/account-abstraction/Cargo.toml
+++ b/crates/shared/account-abstraction/Cargo.toml
@@ -21,6 +21,3 @@ anyhow = { workspace = true, features = ["std"] }
 serde_json = { workspace = true, features = ["std"] }
 alloy-rpc-types = { workspace = true, features = ["eth"] }
 alloy-primitives = { workspace = true, features = ["map-foldhash", "serde"] }
-
-[dev-dependencies]
-alloy-primitives = { workspace = true, features = ["map-foldhash", "serde"] }

--- a/crates/shared/account-abstraction/Cargo.toml
+++ b/crates/shared/account-abstraction/Cargo.toml
@@ -12,12 +12,12 @@ repository.workspace = true
 workspace = true
 
 [dependencies]
-alloy-serde.workspace = true
-async-trait.workspace = true
-alloy-sol-types.workspace = true
-serde = { workspace = true, features = ["std", "derive"] }
-tracing = { workspace = true, features = ["std"] }
-anyhow = { workspace = true, features = ["std"] }
-serde_json = { workspace = true, features = ["std"] }
-alloy-rpc-types = { workspace = true, features = ["eth"] }
 alloy-primitives = { workspace = true, features = ["map-foldhash", "serde"] }
+alloy-rpc-types = { workspace = true, features = ["eth"] }
+alloy-sol-types.workspace = true
+anyhow = { workspace = true, features = ["std"] }
+async-trait.workspace = true
+serde = { workspace = true, features = ["std", "derive"] }
+
+[dev-dependencies]
+serde_json = { workspace = true, features = ["std"] }

--- a/crates/shared/account-abstraction/README.md
+++ b/crates/shared/account-abstraction/README.md
@@ -1,0 +1,1 @@
+# `base-account-abstraction`

--- a/crates/shared/account-abstraction/README.md
+++ b/crates/shared/account-abstraction/README.md
@@ -1,1 +1,84 @@
 # `base-account-abstraction`
+
+<a href="https://github.com/base/base/actions/workflows/ci.yml"><img src="https://github.com/base/base/actions/workflows/ci.yml/badge.svg?label=ci" alt="CI"></a>
+<a href="https://github.com/base/base/blob/main/LICENSE"><img src="https://img.shields.io/badge/License-MIT-d1d1f6.svg?label=license&labelColor=2a2f35" alt="MIT License"></a>
+
+Types and utilities for ERC-4337 account abstraction. Provides types for user operations (v0.6 and v0.7), mempool management, validation, and reputation tracking.
+
+## Overview
+
+- **`VersionedUserOperation`**: Enum supporting both ERC-4337 v0.6 `UserOperation` and v0.7 `PackedUserOperation` formats.
+- **`UserOperationRequest`**: A user operation with its associated entry point address and chain ID.
+- **`WrappedUserOperation`**: A user operation paired with its computed hash for mempool storage.
+- **`Mempool`**: Trait for managing user operations in a mempool.
+- **`ReputationService`**: Trait for querying entity reputation status (Ok, Throttled, Banned).
+- **`MempoolEvent`**: Events emitted when user operations are added, included, or dropped.
+- **`EntryPointVersion`**: Version detection for v0.6 and v0.7 entry point contracts.
+
+## Usage
+
+Add the dependency to your `Cargo.toml`:
+
+```toml
+[dependencies]
+base-account-abstraction = { git = "https://github.com/base/base" }
+```
+
+Parse and hash a user operation:
+
+```rust,ignore
+use base_account_abstraction::{UserOperationRequest, VersionedUserOperation, WrappedUserOperation};
+
+// Deserialize a user operation (automatically detects v0.6 or v0.7 format)
+let user_op: VersionedUserOperation = serde_json::from_str(json)?;
+
+// Create a request with entry point and chain ID
+let request = UserOperationRequest {
+    user_operation: user_op,
+    entry_point: entry_point_address,
+    chain_id: 8453, // Base mainnet
+};
+
+// Compute the user operation hash
+let hash = request.hash()?;
+
+// Wrap for mempool storage
+let wrapped = WrappedUserOperation {
+    operation: request.user_operation,
+    hash,
+};
+```
+
+Implement a mempool:
+
+```rust,ignore
+use base_account_abstraction::{Mempool, PoolConfig, WrappedUserOperation, UserOpHash};
+use std::{collections::{BTreeSet, HashMap}, sync::Arc};
+
+pub struct InMemoryMempool {
+    config: PoolConfig,
+    by_priority: BTreeSet<PriorityOp>,
+    by_hash: HashMap<UserOpHash, WrappedUserOperation>,
+}
+
+impl Mempool for InMemoryMempool {
+    fn add_operation(&mut self, operation: &WrappedUserOperation) -> Result<(), anyhow::Error> {
+        // Validate minimum gas price
+        if operation.operation.max_fee_per_gas() < self.config.minimum_max_fee_per_gas {
+            return Err(anyhow::anyhow!("Gas price below minimum"));
+        }
+        // Add to indexes
+        self.by_hash.insert(operation.hash, operation.clone());
+        Ok(())
+    }
+
+    fn get_top_operations(&self, n: usize) -> impl Iterator<Item = Arc<WrappedUserOperation>> {
+        // Return top N operations ordered by max_priority_fee_per_gas (descending)
+        self.by_priority.iter().take(n).map(|op| Arc::new(op.inner.clone()))
+    }
+
+    fn remove_operation(&mut self, hash: &UserOpHash) -> Result<Option<WrappedUserOperation>, anyhow::Error> {
+        Ok(self.by_hash.remove(hash))
+    }
+}
+```

--- a/crates/shared/account-abstraction/src/entrypoints/mod.rs
+++ b/crates/shared/account-abstraction/src/entrypoints/mod.rs
@@ -1,8 +1,10 @@
 //! `EntryPoint` contract definitions for ERC-4337 versions.
 
-/// ERC-4337 v0.6 user operation hash calculation.
 pub mod v06;
-/// ERC-4337 v0.7 packed user operation hash calculation.
+pub use v06::hash_user_operation as hash_user_operation_v06;
+
 pub mod v07;
-/// `EntryPoint` version detection and addresses.
+pub use v07::hash_user_operation as hash_user_operation_v07;
+
 pub mod version;
+pub use version::{EntryPointVersion, UnknownEntryPointAddress};

--- a/crates/shared/account-abstraction/src/entrypoints/mod.rs
+++ b/crates/shared/account-abstraction/src/entrypoints/mod.rs
@@ -1,0 +1,8 @@
+//! `EntryPoint` contract definitions for ERC-4337 versions.
+
+/// ERC-4337 v0.6 user operation hash calculation.
+pub mod v06;
+/// ERC-4337 v0.7 packed user operation hash calculation.
+pub mod v07;
+/// `EntryPoint` version detection and addresses.
+pub mod version;

--- a/crates/shared/account-abstraction/src/entrypoints/v06.rs
+++ b/crates/shared/account-abstraction/src/entrypoints/v06.rs
@@ -1,13 +1,11 @@
-/*
- * ERC-4337 v0.6 UserOperation Hash Calculation
- *
- * 1. Hash variable-length fields: initCode, callData, paymasterAndData
- * 2. Pack all fields into struct (using hashes from step 1, gas values as uint256)
- * 3. encodedHash = keccak256(abi.encode(packed struct))
- * 4. final hash = keccak256(abi.encode(encodedHash, entryPoint, chainId))
- *
- * Reference: rundler/crates/types/src/user_operation/v0_6.rs:927-934
- */
+//! ERC-4337 v0.6 `UserOperation` Hash Calculation
+//!
+//! 1. Hash variable-length fields: initCode, callData, paymasterAndData
+//! 2. Pack all fields into struct (using hashes from step 1, gas values as uint256)
+//! 3. encodedHash = keccak256(abi.encode(packed struct))
+//! 4. final hash = keccak256(abi.encode(encodedHash, entryPoint, chainId))
+//!
+//! Reference: rundler/crates/types/src/user_operation/v0_6.rs:927-934
 use alloy_primitives::{ChainId, U256};
 use alloy_rpc_types::erc4337;
 use alloy_sol_types::{SolValue, sol};

--- a/crates/shared/account-abstraction/src/entrypoints/v06.rs
+++ b/crates/shared/account-abstraction/src/entrypoints/v06.rs
@@ -1,0 +1,131 @@
+/*
+ * ERC-4337 v0.6 UserOperation Hash Calculation
+ *
+ * 1. Hash variable-length fields: initCode, callData, paymasterAndData
+ * 2. Pack all fields into struct (using hashes from step 1, gas values as uint256)
+ * 3. encodedHash = keccak256(abi.encode(packed struct))
+ * 4. final hash = keccak256(abi.encode(encodedHash, entryPoint, chainId))
+ *
+ * Reference: rundler/crates/types/src/user_operation/v0_6.rs:927-934
+ */
+use alloy_primitives::{ChainId, U256};
+use alloy_rpc_types::erc4337;
+use alloy_sol_types::{SolValue, sol};
+sol! {
+    #[allow(missing_docs)]
+    #[derive(Default, Debug, PartialEq, Eq)]
+    struct UserOperationHashEncoded {
+        bytes32 encodedHash;
+        address entryPoint;
+        uint256 chainId;
+    }
+
+    #[allow(missing_docs)]
+    #[derive(Default, Debug, PartialEq, Eq)]
+    struct UserOperationPackedForHash {
+        address sender;
+        uint256 nonce;
+        bytes32 hashInitCode;
+        bytes32 hashCallData;
+        uint256 callGasLimit;
+        uint256 verificationGasLimit;
+        uint256 preVerificationGas;
+        uint256 maxFeePerGas;
+        uint256 maxPriorityFeePerGas;
+        bytes32 hashPaymasterAndData;
+    }
+}
+
+impl From<erc4337::UserOperation> for UserOperationPackedForHash {
+    fn from(op: erc4337::UserOperation) -> Self {
+        Self {
+            sender: op.sender,
+            nonce: op.nonce,
+            hashInitCode: alloy_primitives::keccak256(op.init_code),
+            hashCallData: alloy_primitives::keccak256(op.call_data),
+            callGasLimit: U256::from(op.call_gas_limit),
+            verificationGasLimit: U256::from(op.verification_gas_limit),
+            preVerificationGas: U256::from(op.pre_verification_gas),
+            maxFeePerGas: U256::from(op.max_fee_per_gas),
+            maxPriorityFeePerGas: U256::from(op.max_priority_fee_per_gas),
+            hashPaymasterAndData: alloy_primitives::keccak256(op.paymaster_and_data),
+        }
+    }
+}
+
+/// Computes the hash of a v0.6 user operation as defined by ERC-4337.
+///
+/// The hash is computed by packing the operation fields, hashing the packed data,
+/// and then encoding with the entry point address and chain ID.
+pub fn hash_user_operation(
+    user_operation: &erc4337::UserOperation,
+    entry_point: alloy_primitives::Address,
+    chain_id: ChainId,
+) -> alloy_primitives::B256 {
+    let packed = UserOperationPackedForHash::from(user_operation.clone());
+    let encoded = UserOperationHashEncoded {
+        encodedHash: alloy_primitives::keccak256(packed.abi_encode()),
+        entryPoint: entry_point,
+        chainId: U256::from(chain_id),
+    };
+    alloy_primitives::keccak256(encoded.abi_encode())
+}
+
+#[cfg(test)]
+mod tests {
+    use alloy_primitives::{Bytes, U256, address, b256, bytes};
+    use alloy_rpc_types::erc4337;
+
+    use super::*;
+
+    #[test]
+    fn test_hash_zeroed() {
+        let entry_point_address_v0_6 = address!("66a15edcc3b50a663e72f1457ffd49b9ae284ddc");
+        let chain_id = 1337;
+        let user_op_with_zeroed_init_code = erc4337::UserOperation {
+            sender: address!("0x0000000000000000000000000000000000000000"),
+            nonce: U256::ZERO,
+            init_code: Bytes::default(),
+            call_data: Bytes::default(),
+            call_gas_limit: U256::from(0),
+            verification_gas_limit: U256::from(0),
+            pre_verification_gas: U256::from(0),
+            max_fee_per_gas: U256::from(0),
+            max_priority_fee_per_gas: U256::from(0),
+            paymaster_and_data: Bytes::default(),
+            signature: Bytes::default(),
+        };
+
+        let hash =
+            hash_user_operation(&user_op_with_zeroed_init_code, entry_point_address_v0_6, chain_id);
+        assert_eq!(hash, b256!("dca97c3b49558ab360659f6ead939773be8bf26631e61bb17045bb70dc983b2d"));
+    }
+
+    #[test]
+    fn test_hash_non_zeroed() {
+        let entry_point_address_v0_6 = address!("66a15edcc3b50a663e72f1457ffd49b9ae284ddc");
+        let chain_id = 1337;
+        let user_op_with_non_zeroed_init_code = erc4337::UserOperation {
+            sender: address!("0x1306b01bc3e4ad202612d3843387e94737673f53"),
+            nonce: U256::from(8942),
+            init_code: "0x6942069420694206942069420694206942069420".parse().unwrap(),
+            call_data: "0x0000000000000000000000000000000000000000080085".parse().unwrap(),
+            call_gas_limit: U256::from(10_000),
+            verification_gas_limit: U256::from(100_000),
+            pre_verification_gas: U256::from(100),
+            max_fee_per_gas: U256::from(99_999),
+            max_priority_fee_per_gas: U256::from(9_999_999),
+            paymaster_and_data: bytes!(
+                "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+            ),
+            signature: bytes!("da0929f527cded8d0a1eaf2e8861d7f7e2d8160b7b13942f99dd367df4473a"),
+        };
+
+        let hash = hash_user_operation(
+            &user_op_with_non_zeroed_init_code,
+            entry_point_address_v0_6,
+            chain_id,
+        );
+        assert_eq!(hash, b256!("484add9e4d8c3172d11b5feb6a3cc712280e176d278027cfa02ee396eb28afa1"));
+    }
+}

--- a/crates/shared/account-abstraction/src/entrypoints/v07.rs
+++ b/crates/shared/account-abstraction/src/entrypoints/v07.rs
@@ -1,0 +1,177 @@
+/*
+ * ERC-4337 v0.7 UserOperation Hash Calculation
+ *
+ * 1. Hash variable-length fields: initCode, callData, paymasterAndData
+ * 2. Pack all fields into struct (using hashes from step 1, gas values as bytes32)
+ * 3. encodedHash = keccak256(abi.encode(packed struct))
+ * 4. final hash = keccak256(abi.encode(encodedHash, entryPoint, chainId))
+ *
+ * Reference: rundler/crates/types/src/user_operation/v0_7.rs:1094-1123
+ */
+use alloy_primitives::{Address, Bytes, ChainId, FixedBytes, U256, keccak256};
+use alloy_rpc_types::erc4337;
+use alloy_sol_types::{SolValue, sol};
+
+sol!(
+    #[allow(missing_docs)]
+    #[derive(Default, Debug, PartialEq, Eq)]
+    struct PackedUserOperation {
+        address sender;
+        uint256 nonce;
+        bytes initCode;
+        bytes callData;
+        bytes32 accountGasLimits;
+        uint256 preVerificationGas;
+        bytes32 gasFees;
+        bytes paymasterAndData;
+        bytes signature;
+    }
+
+    #[derive(Default, Debug, PartialEq, Eq)]
+    struct UserOperationHashEncoded {
+        bytes32 encodedHash;
+        address entryPoint;
+        uint256 chainId;
+    }
+
+    #[derive(Default, Debug, PartialEq, Eq)]
+    struct UserOperationPackedForHash {
+        address sender;
+        uint256 nonce;
+        bytes32 hashInitCode;
+        bytes32 hashCallData;
+        bytes32 accountGasLimits;
+        uint256 preVerificationGas;
+        bytes32 gasFees;
+        bytes32 hashPaymasterAndData;
+    }
+);
+
+impl From<erc4337::PackedUserOperation> for PackedUserOperation {
+    fn from(uo: erc4337::PackedUserOperation) -> Self {
+        let init_code = if let Some(factory) = uo.factory {
+            let mut init_code = factory.to_vec();
+            init_code.extend_from_slice(&uo.factory_data.clone().unwrap_or_default());
+            Bytes::from(init_code)
+        } else {
+            Bytes::new()
+        };
+        let account_gas_limits =
+            pack_u256_pair_to_bytes32(uo.verification_gas_limit, uo.call_gas_limit);
+        let gas_fees = pack_u256_pair_to_bytes32(uo.max_priority_fee_per_gas, uo.max_fee_per_gas);
+        let pvgl: [u8; 16] =
+            uo.paymaster_verification_gas_limit.unwrap_or_default().to::<u128>().to_be_bytes();
+        let pogl: [u8; 16] =
+            uo.paymaster_post_op_gas_limit.unwrap_or_default().to::<u128>().to_be_bytes();
+        let paymaster_and_data = if let Some(paymaster) = uo.paymaster {
+            let mut paymaster_and_data = paymaster.to_vec();
+            paymaster_and_data.extend_from_slice(&pvgl);
+            paymaster_and_data.extend_from_slice(&pogl);
+            paymaster_and_data.extend_from_slice(&uo.paymaster_data.unwrap());
+            Bytes::from(paymaster_and_data)
+        } else {
+            Bytes::new()
+        };
+        Self {
+            sender: uo.sender,
+            nonce: uo.nonce,
+            initCode: init_code,
+            callData: uo.call_data.clone(),
+            accountGasLimits: account_gas_limits,
+            preVerificationGas: U256::from(uo.pre_verification_gas),
+            gasFees: gas_fees,
+            paymasterAndData: paymaster_and_data,
+            signature: uo.signature,
+        }
+    }
+}
+fn pack_u256_pair_to_bytes32(high: U256, low: U256) -> FixedBytes<32> {
+    let mask = (U256::from(1u64) << 128) - U256::from(1u64);
+    let hi = high & mask;
+    let lo = low & mask;
+    let combined: U256 = (hi << 128) | lo;
+    FixedBytes::from(combined.to_be_bytes::<32>())
+}
+
+fn hash_packed_user_operation(
+    puo: &PackedUserOperation,
+    entry_point: Address,
+    chain_id: u64,
+) -> FixedBytes<32> {
+    let hash_init_code = alloy_primitives::keccak256(&puo.initCode);
+    let hash_call_data = alloy_primitives::keccak256(&puo.callData);
+    let hash_paymaster_and_data = alloy_primitives::keccak256(&puo.paymasterAndData);
+
+    let packed_for_hash = UserOperationPackedForHash {
+        sender: puo.sender,
+        nonce: puo.nonce,
+        hashInitCode: hash_init_code,
+        hashCallData: hash_call_data,
+        accountGasLimits: puo.accountGasLimits,
+        preVerificationGas: puo.preVerificationGas,
+        gasFees: puo.gasFees,
+        hashPaymasterAndData: hash_paymaster_and_data,
+    };
+
+    let hashed = alloy_primitives::keccak256(packed_for_hash.abi_encode());
+
+    let encoded = UserOperationHashEncoded {
+        encodedHash: hashed,
+        entryPoint: entry_point,
+        chainId: U256::from(chain_id),
+    };
+
+    keccak256(encoded.abi_encode())
+}
+
+/// Computes the hash of a v0.7 packed user operation as defined by ERC-4337.
+///
+/// The hash is computed by packing the operation fields, hashing the packed data,
+/// and then encoding with the entry point address and chain ID.
+pub fn hash_user_operation(
+    user_operation: &erc4337::PackedUserOperation,
+    entry_point: Address,
+    chain_id: ChainId,
+) -> FixedBytes<32> {
+    let packed = PackedUserOperation::from(user_operation.clone());
+    hash_packed_user_operation(&packed, entry_point, chain_id)
+}
+
+#[cfg(test)]
+mod test {
+    use alloy_primitives::{Bytes, U256, address, b256, bytes, uint};
+
+    use super::*;
+
+    #[test]
+    fn test_hash() {
+        let puo = PackedUserOperation {
+            sender: address!("b292Cf4a8E1fF21Ac27C4f94071Cd02C022C414b"),
+            nonce: uint!(0xF83D07238A7C8814A48535035602123AD6DBFA63000000000000000000000001_U256),
+            initCode: Bytes::default(),  // Empty
+            callData:
+    bytes!("e9ae5c53000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000400000000000000000000000000
+    0000000000000000000000000000000000001d8b292cf4a8e1ff21ac27c4f94071cd02c022c414b00000000000000000000000000000000000000000000000000000000000000009517e29f000000000000000000
+    0000000000000000000000000000000000000000000002000000000000000000000000ad6330089d9a1fe89f4020292e1afe9969a5a2fc00000000000000000000000000000000000000000000000000000000000
+    0006000000000000000000000000000000000000000000000000000000000000001200000000000000000000000000000000000000000000000000000000000015180000000000000000000000000000000000000
+    00000000000000000000000000000000000000000000000000000000000000000000000000000000018e2fbe898000000000000000000000000000000000000000000000000000000000000000800000000000000
+    0000000000000000000000000000000000000000000000000800000000000000000000000002372912728f93ab3daaaebea4f87e6e28476d987000000000000000000000000000000000000000000000000002386
+    f26fc10000000000000000000000000000000000000000000000000000000000000000006000000000000000000000000000000000000000000000000000000000000000000000000000000000"),
+            accountGasLimits: b256!("000000000000000000000000000114fc0000000000000000000000000012c9b5"),
+            preVerificationGas: U256::from(48916),
+            gasFees: b256!("000000000000000000000000524121000000000000000000000000109a4a441a"),
+            paymasterAndData: Bytes::default(),  // Empty
+            signature: bytes!("3c7bfe22c9c2ef8994a9637bcc4df1741c5dc0c25b209545a7aeb20f7770f351479b683bd17c4d55bc32e2a649c8d2dff49dcfcc1f3fd837bcd88d1e69a434cf1c"),
+        };
+
+        let expected_hash =
+            b256!("e486401370d145766c3cf7ba089553214a1230d38662ae532c9b62eb6dadcf7e");
+        let uo = hash_packed_user_operation(
+            &puo,
+            address!("0x0000000071727De22E5E9d8BAf0edAc6f37da032"),
+            11155111,
+        );
+
+        assert_eq!(uo, expected_hash);
+    }
+}

--- a/crates/shared/account-abstraction/src/entrypoints/v07.rs
+++ b/crates/shared/account-abstraction/src/entrypoints/v07.rs
@@ -1,13 +1,11 @@
-/*
- * ERC-4337 v0.7 UserOperation Hash Calculation
- *
- * 1. Hash variable-length fields: initCode, callData, paymasterAndData
- * 2. Pack all fields into struct (using hashes from step 1, gas values as bytes32)
- * 3. encodedHash = keccak256(abi.encode(packed struct))
- * 4. final hash = keccak256(abi.encode(encodedHash, entryPoint, chainId))
- *
- * Reference: rundler/crates/types/src/user_operation/v0_7.rs:1094-1123
- */
+//! ERC-4337 v0.7 `UserOperation` Hash Calculation
+//!
+//! 1. Hash variable-length fields: initCode, callData, paymasterAndData
+//! 2. Pack all fields into struct (using hashes from step 1, gas values as bytes32)
+//! 3. encodedHash = keccak256(abi.encode(packed struct))
+//! 4. final hash = keccak256(abi.encode(encodedHash, entryPoint, chainId))
+//!
+//! Reference: rundler/crates/types/src/user_operation/v0_7.rs:1094-1123
 use alloy_primitives::{Address, Bytes, ChainId, FixedBytes, U256, keccak256};
 use alloy_rpc_types::erc4337;
 use alloy_sol_types::{SolValue, sol};

--- a/crates/shared/account-abstraction/src/entrypoints/version.rs
+++ b/crates/shared/account-abstraction/src/entrypoints/version.rs
@@ -1,0 +1,40 @@
+//! `EntryPoint` version detection and canonical addresses.
+
+use alloy_primitives::{Address, address};
+
+/// The version of the ERC-4337 `EntryPoint` contract.
+#[derive(Debug, Clone)]
+pub enum EntryPointVersion {
+    /// ERC-4337 v0.6 `EntryPoint`.
+    V06,
+    /// ERC-4337 v0.7 `EntryPoint`.
+    V07,
+}
+
+impl EntryPointVersion {
+    /// The canonical address of the v0.6 `EntryPoint` contract.
+    pub const V06_ADDRESS: Address = address!("0x5FF137D4b0FDCD49DcA30c7CF57E578a026d2789");
+    /// The canonical address of the v0.7 `EntryPoint` contract.
+    pub const V07_ADDRESS: Address = address!("0x0000000071727De22E5E9d8BAf0edAc6f37da032");
+}
+
+/// Error returned when an address does not match any known `EntryPoint` version.
+#[derive(Debug)]
+pub struct UnknownEntryPointAddress {
+    /// The unknown address that was provided.
+    pub address: Address,
+}
+
+impl TryFrom<Address> for EntryPointVersion {
+    type Error = UnknownEntryPointAddress;
+
+    fn try_from(addr: Address) -> Result<Self, Self::Error> {
+        if addr == Self::V06_ADDRESS {
+            Ok(Self::V06)
+        } else if addr == Self::V07_ADDRESS {
+            Ok(Self::V07)
+        } else {
+            Err(UnknownEntryPointAddress { address: addr })
+        }
+    }
+}

--- a/crates/shared/account-abstraction/src/events.rs
+++ b/crates/shared/account-abstraction/src/events.rs
@@ -1,0 +1,28 @@
+//! Events emitted by the user operation mempool.
+
+use serde::{Deserialize, Serialize};
+
+use crate::types::WrappedUserOperation;
+
+/// Events that can be emitted by the mempool.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "event", content = "data")]
+pub enum MempoolEvent {
+    /// A user operation was added to the mempool.
+    UserOpAdded {
+        /// The user operation that was added.
+        user_op: WrappedUserOperation,
+    },
+    /// A user operation was included in a block.
+    UserOpIncluded {
+        /// The user operation that was included.
+        user_op: WrappedUserOperation,
+    },
+    /// A user operation was dropped from the mempool.
+    UserOpDropped {
+        /// The user operation that was dropped.
+        user_op: WrappedUserOperation,
+        /// The reason the operation was dropped.
+        reason: String,
+    },
+}

--- a/crates/shared/account-abstraction/src/lib.rs
+++ b/crates/shared/account-abstraction/src/lib.rs
@@ -1,0 +1,23 @@
+//! Account abstraction types and utilities for ERC-4337.
+//!
+//! This crate provides types and utilities for working with ERC-4337 account abstraction,
+//! including user operations, mempools, and reputation services.
+
+/// `EntryPoint` contract definitions and hash calculation for different ERC-4337 versions.
+pub mod entrypoints;
+/// Events emitted by the mempool.
+pub mod events;
+/// Mempool trait and configuration for user operations.
+pub mod mempool;
+/// Reputation tracking for entity behavior.
+pub mod reputation;
+/// Core types for user operations and validation.
+pub mod types;
+
+pub use events::MempoolEvent;
+pub use mempool::{Mempool, PoolConfig};
+pub use reputation::{ReputationService, ReputationStatus};
+pub use types::{
+    UserOpHash, UserOperationRequest, ValidationResult, VersionedUserOperation,
+    WrappedUserOperation,
+};

--- a/crates/shared/account-abstraction/src/lib.rs
+++ b/crates/shared/account-abstraction/src/lib.rs
@@ -1,22 +1,20 @@
-//! Account abstraction types and utilities for ERC-4337.
-//!
-//! This crate provides types and utilities for working with ERC-4337 account abstraction,
-//! including user operations, mempools, and reputation services.
+#![doc = include_str!("../README.md")]
+#![doc(issue_tracker_base_url = "https://github.com/base/base/issues/")]
+#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
+#![cfg_attr(not(test), warn(unused_crate_dependencies))]
 
-/// `EntryPoint` contract definitions and hash calculation for different ERC-4337 versions.
 pub mod entrypoints;
-/// Events emitted by the mempool.
-pub mod events;
-/// Mempool trait and configuration for user operations.
-pub mod mempool;
-/// Reputation tracking for entity behavior.
-pub mod reputation;
-/// Core types for user operations and validation.
-pub mod types;
 
+pub mod events;
 pub use events::MempoolEvent;
+
+pub mod mempool;
 pub use mempool::{Mempool, PoolConfig};
+
+pub mod reputation;
 pub use reputation::{ReputationService, ReputationStatus};
+
+pub mod types;
 pub use types::{
     UserOpHash, UserOperationRequest, ValidationResult, VersionedUserOperation,
     WrappedUserOperation,

--- a/crates/shared/account-abstraction/src/mempool.rs
+++ b/crates/shared/account-abstraction/src/mempool.rs
@@ -1,0 +1,27 @@
+//! Mempool trait and configuration for user operations.
+
+use std::sync::Arc;
+
+use crate::types::{UserOpHash, WrappedUserOperation};
+
+/// Configuration for the user operation mempool.
+#[derive(Debug, Default)]
+pub struct PoolConfig {
+    /// The minimum max fee per gas required for a user operation to be accepted.
+    pub minimum_max_fee_per_gas: u128,
+}
+
+/// A mempool for storing and managing user operations.
+pub trait Mempool: Send + Sync {
+    /// Adds a user operation to the mempool.
+    fn add_operation(&mut self, operation: &WrappedUserOperation) -> Result<(), anyhow::Error>;
+
+    /// Returns an iterator over the top `n` user operations by priority.
+    fn get_top_operations(&self, n: usize) -> impl Iterator<Item = Arc<WrappedUserOperation>>;
+
+    /// Removes a user operation from the mempool by its hash.
+    fn remove_operation(
+        &mut self,
+        operation_hash: &UserOpHash,
+    ) -> Result<Option<WrappedUserOperation>, anyhow::Error>;
+}

--- a/crates/shared/account-abstraction/src/reputation.rs
+++ b/crates/shared/account-abstraction/src/reputation.rs
@@ -1,0 +1,22 @@
+//! Reputation tracking for entities in ERC-4337.
+
+use alloy_primitives::Address;
+use async_trait::async_trait;
+
+/// Reputation status for an entity.
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub enum ReputationStatus {
+    /// Entity is not throttled or banned.
+    Ok,
+    /// Entity is throttled.
+    Throttled,
+    /// Entity is banned.
+    Banned,
+}
+
+/// A trait for querying the reputation status of entities.
+#[async_trait]
+pub trait ReputationService: Send + Sync {
+    /// Returns the reputation status of the given entity address.
+    async fn get_reputation(&self, entity: &Address) -> ReputationStatus;
+}

--- a/crates/shared/account-abstraction/src/types.rs
+++ b/crates/shared/account-abstraction/src/types.rs
@@ -1,0 +1,251 @@
+//! Core types for ERC-4337 user operations and validation.
+
+use alloy_primitives::{Address, B256, ChainId, FixedBytes, U256};
+use alloy_rpc_types::erc4337;
+pub use alloy_rpc_types::erc4337::SendUserOperationResponse;
+use anyhow::Result;
+use serde::{Deserialize, Serialize};
+
+use super::entrypoints::{v06, v07, version::EntryPointVersion};
+
+/// A user operation that can be either v0.6 or v0.7 format.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(untagged)]
+pub enum VersionedUserOperation {
+    /// ERC-4337 v0.6 user operation.
+    UserOperation(erc4337::UserOperation),
+    /// ERC-4337 v0.7 packed user operation.
+    PackedUserOperation(erc4337::PackedUserOperation),
+}
+
+impl VersionedUserOperation {
+    /// Returns the max fee per gas for this user operation.
+    pub const fn max_fee_per_gas(&self) -> U256 {
+        match self {
+            Self::UserOperation(op) => op.max_fee_per_gas,
+            Self::PackedUserOperation(op) => op.max_fee_per_gas,
+        }
+    }
+
+    /// Returns the max priority fee per gas for this user operation.
+    pub const fn max_priority_fee_per_gas(&self) -> U256 {
+        match self {
+            Self::UserOperation(op) => op.max_priority_fee_per_gas,
+            Self::PackedUserOperation(op) => op.max_priority_fee_per_gas,
+        }
+    }
+
+    /// Returns the nonce of this user operation.
+    pub const fn nonce(&self) -> U256 {
+        match self {
+            Self::UserOperation(op) => op.nonce,
+            Self::PackedUserOperation(op) => op.nonce,
+        }
+    }
+
+    /// Returns the sender address of this user operation.
+    pub const fn sender(&self) -> Address {
+        match self {
+            Self::UserOperation(op) => op.sender,
+            Self::PackedUserOperation(op) => op.sender,
+        }
+    }
+}
+
+/// A request to submit a user operation to the mempool.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct UserOperationRequest {
+    /// The user operation to submit.
+    pub user_operation: VersionedUserOperation,
+    /// The address of the `EntryPoint` contract.
+    pub entry_point: Address,
+    /// The chain ID for the operation.
+    pub chain_id: ChainId,
+}
+
+impl UserOperationRequest {
+    /// Computes the hash of this user operation request.
+    pub fn hash(&self) -> Result<B256> {
+        let entry_point_version = EntryPointVersion::try_from(self.entry_point)
+            .map_err(|_| anyhow::anyhow!("Unknown entry point version: {:#x}", self.entry_point))?;
+
+        match (&self.user_operation, entry_point_version) {
+            (VersionedUserOperation::UserOperation(op), EntryPointVersion::V06) => {
+                Ok(v06::hash_user_operation(op, self.entry_point, self.chain_id))
+            }
+            (VersionedUserOperation::PackedUserOperation(op), EntryPointVersion::V07) => {
+                Ok(v07::hash_user_operation(op, self.entry_point, self.chain_id))
+            }
+            _ => Err(anyhow::anyhow!("Mismatched operation type and entry point version")),
+        }
+    }
+}
+
+/// The result of validating a user operation request.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct UserOperationRequestValidationResult {
+    /// The timestamp at which the validation expires.
+    pub expiration_timestamp: u64,
+    /// The amount of gas used during validation.
+    pub gas_used: U256,
+}
+
+/// The result of validating a user operation.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ValidationResult {
+    /// Whether the user operation is valid.
+    pub valid: bool,
+    /// The reason for validation failure, if any.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reason: Option<String>,
+    /// The timestamp until which the validation is valid.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub valid_until: Option<u64>,
+    /// The timestamp after which the validation is valid.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub valid_after: Option<u64>,
+    /// Additional context about the validation.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub context: Option<ValidationContext>,
+}
+
+/// Context information gathered during validation.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ValidationContext {
+    /// Stake information for the sender.
+    pub sender_info: EntityStakeInfo,
+    /// Stake information for the factory, if any.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub factory_info: Option<EntityStakeInfo>,
+    /// Stake information for the paymaster, if any.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub paymaster_info: Option<EntityStakeInfo>,
+    /// Information about the aggregator, if any.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub aggregator_info: Option<AggregatorInfo>,
+}
+
+/// Stake information for an entity.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct EntityStakeInfo {
+    /// The address of the entity.
+    pub address: Address,
+    /// The amount staked by the entity.
+    pub stake: U256,
+    /// The delay in seconds before the stake can be withdrawn.
+    pub unstake_delay_sec: u64,
+    /// The deposit amount held by the `EntryPoint`.
+    pub deposit: U256,
+    /// Whether the entity meets the staking requirements.
+    pub is_staked: bool,
+}
+
+/// Information about a signature aggregator.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AggregatorInfo {
+    /// The address of the aggregator contract.
+    pub aggregator: Address,
+    /// Stake information for the aggregator.
+    pub stake_info: EntityStakeInfo,
+}
+
+/// A 32-byte hash identifying a user operation.
+pub type UserOpHash = FixedBytes<32>;
+
+/// A user operation wrapped with its computed hash.
+#[derive(Eq, PartialEq, Clone, Debug, Serialize, Deserialize)]
+pub struct WrappedUserOperation {
+    /// The underlying user operation.
+    pub operation: VersionedUserOperation,
+    /// The hash of the user operation.
+    pub hash: UserOpHash,
+}
+
+impl WrappedUserOperation {
+    /// Returns true if this operation has a higher max fee than another.
+    pub fn has_higher_max_fee(&self, other: &Self) -> bool {
+        self.operation.max_fee_per_gas() > other.operation.max_fee_per_gas()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::str::FromStr;
+
+    use alloy_primitives::{Address, Uint};
+
+    use super::*;
+
+    #[test]
+    fn deser_untagged_user_operation_without_type_field() {
+        let json = r#"
+        {
+            "sender": "0x1111111111111111111111111111111111111111",
+            "nonce": "0x0",
+            "initCode": "0x",
+            "callData": "0x",
+            "callGasLimit": "0x5208",
+            "verificationGasLimit": "0x100000",
+            "preVerificationGas": "0x10000",
+            "maxFeePerGas": "0x59682f10",
+            "maxPriorityFeePerGas": "0x3b9aca00",
+            "paymasterAndData": "0x",
+            "signature": "0x01"
+        }
+        "#;
+
+        let parsed: VersionedUserOperation =
+            serde_json::from_str(json).expect("should deserialize as v0.6");
+        match parsed {
+            VersionedUserOperation::UserOperation(op) => {
+                assert_eq!(
+                    op.sender,
+                    Address::from_str("0x1111111111111111111111111111111111111111").unwrap()
+                );
+                assert_eq!(op.nonce, Uint::from(0));
+            }
+            other => panic!("expected UserOperation, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn deser_untagged_packed_user_operation_without_type_field() {
+        let json = r#"
+        {
+            "sender": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+            "nonce": "0x1",
+            "factory": "0x2222222222222222222222222222222222222222",
+            "factoryData": "0xabcdef1234560000000000000000000000000000000000000000000000000000",
+            "callData": "0xb61d27f600000000000000000000000000000000000000000000000000000000000000c8",
+            "callGasLimit": "0x2dc6c0",
+            "verificationGasLimit": "0x1e8480",
+            "preVerificationGas": "0x186a0",
+            "maxFeePerGas": "0x77359400",
+            "maxPriorityFeePerGas": "0x3b9aca00",
+            "paymaster": "0x3333333333333333333333333333333333333333",
+            "paymasterVerificationGasLimit": "0x186a0",
+            "paymasterPostOpGasLimit": "0x27100",
+            "paymasterData": "0xfafb00000000000000000000000000000000000000000000000000000000000064",
+            "signature": "0xa3c5f1b90014e68abbbdc42e4b77b9accc0b7e1c5d0b5bcde1a47ba8faba00ff55c9a7de12e98b731766e35f6c51ab25c9b58cc0e7c4a33f25e75c51c6ad3c3a"
+        }
+        "#;
+
+        let parsed: VersionedUserOperation =
+            serde_json::from_str(json).expect("should deserialize as v0.7 packed");
+        match parsed {
+            VersionedUserOperation::PackedUserOperation(op) => {
+                assert_eq!(
+                    op.sender,
+                    Address::from_str("0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48").unwrap()
+                );
+                assert_eq!(op.nonce, Uint::from(1));
+            }
+            other => panic!("expected PackedUserOperation, got {other:?}"),
+        }
+    }
+}

--- a/crates/shared/account-abstraction/src/types.rs
+++ b/crates/shared/account-abstraction/src/types.rs
@@ -1,21 +1,20 @@
 //! Core types for ERC-4337 user operations and validation.
 
 use alloy_primitives::{Address, B256, ChainId, FixedBytes, U256};
-use alloy_rpc_types::erc4337;
-pub use alloy_rpc_types::erc4337::SendUserOperationResponse;
+use alloy_rpc_types::erc4337::{PackedUserOperation, UserOperation};
 use anyhow::Result;
 use serde::{Deserialize, Serialize};
 
-use super::entrypoints::{v06, v07, version::EntryPointVersion};
+use super::entrypoints::{EntryPointVersion, hash_user_operation_v06, hash_user_operation_v07};
 
 /// A user operation that can be either v0.6 or v0.7 format.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(untagged)]
 pub enum VersionedUserOperation {
     /// ERC-4337 v0.6 user operation.
-    UserOperation(erc4337::UserOperation),
+    UserOperation(UserOperation),
     /// ERC-4337 v0.7 packed user operation.
-    PackedUserOperation(erc4337::PackedUserOperation),
+    PackedUserOperation(PackedUserOperation),
 }
 
 impl VersionedUserOperation {
@@ -71,10 +70,10 @@ impl UserOperationRequest {
 
         match (&self.user_operation, entry_point_version) {
             (VersionedUserOperation::UserOperation(op), EntryPointVersion::V06) => {
-                Ok(v06::hash_user_operation(op, self.entry_point, self.chain_id))
+                Ok(hash_user_operation_v06(op, self.entry_point, self.chain_id))
             }
             (VersionedUserOperation::PackedUserOperation(op), EntryPointVersion::V07) => {
-                Ok(v07::hash_user_operation(op, self.entry_point, self.chain_id))
+                Ok(hash_user_operation_v07(op, self.entry_point, self.chain_id))
             }
             _ => Err(anyhow::anyhow!("Mismatched operation type and entry point version")),
         }


### PR DESCRIPTION
Account abstraction types would be useful to have in the b`ase/base` crate as we will likely reuse them and the tips services moving to `base/infra` can also use them.

Most of this is code is from `base/tips` in [`crates/account-abstraction-core/src/domain`](https://github.com/base/tips/tree/master/crates/account-abstraction-core/src/domain)