### PR TITLE
chore(flashblocks): Remove Config Export

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2220,6 +2220,7 @@ version = "0.0.0"
 dependencies = [
  "base-cli-utils",
  "base-client-node",
+ "base-flashblocks",
  "base-flashblocks-node",
  "base-metering",
  "base-proofs-extension",

--- a/bin/node/Cargo.toml
+++ b/bin/node/Cargo.toml
@@ -16,6 +16,7 @@ workspace = true
 # internal
 base-cli-utils.workspace = true
 base-client-node.workspace = true
+base-flashblocks.workspace = true
 base-flashblocks-node.workspace = true
 base-metering.workspace = true
 base-txpool.workspace = true

--- a/bin/node/src/cli.rs
+++ b/bin/node/src/cli.rs
@@ -1,6 +1,6 @@
 //! Contains the CLI arguments
 
-use base_flashblocks_node::FlashblocksConfig;
+use base_flashblocks::FlashblocksConfig;
 use reth_optimism_node::args::RollupArgs;
 
 /// CLI Arguments

--- a/bin/node/src/main.rs
+++ b/bin/node/src/main.rs
@@ -6,7 +6,8 @@
 pub mod cli;
 
 use base_client_node::BaseNodeRunner;
-use base_flashblocks_node::{FlashblocksConfig, FlashblocksExtension};
+use base_flashblocks::FlashblocksConfig;
+use base_flashblocks_node::FlashblocksExtension;
 use base_metering::{MeteringConfig, MeteringExtension};
 use base_proofs_extension::ProofsHistoryExtension;
 use base_txpool::{TxPoolExtension, TxpoolConfig};

--- a/crates/client/flashblocks-node/src/lib.rs
+++ b/crates/client/flashblocks-node/src/lib.rs
@@ -4,7 +4,6 @@
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
 
 mod extension;
-pub use base_flashblocks::FlashblocksConfig;
 pub use extension::FlashblocksExtension;
 
 #[cfg(any(test, feature = "test-utils"))]


### PR DESCRIPTION
## Summary

Re-exports should be avoided if possible for workspace crates. Keeps our workspace hygienic