### PR TITLE
metrics: add num of storage slots modified when simulating

### DIFF
--- a/crates/client/metering/src/meter.rs
+++ b/crates/client/metering/src/meter.rs
@@ -223,6 +223,10 @@ where
         bundle_update.state().values().map(|account| account.storage.len()).sum();
     metrics.storage_slots_modified.record(storage_slots_modified as f64);
 
+    // Gets the number of accounts modified
+    let accounts_modified: usize = bundle_update.state().len();
+    metrics.accounts_modified.record(accounts_modified as f64);
+
     let state_provider = db.database.as_ref();
 
     let state_root_start = Instant::now();

--- a/crates/client/metering/src/meter.rs
+++ b/crates/client/metering/src/meter.rs
@@ -217,6 +217,12 @@ where
     // pending state if it was provided via with_bundle_prestate.
     db.merge_transitions(BundleRetention::Reverts);
     let bundle_update = db.take_bundle();
+
+    // Gets the number of storage slots modified from every account
+    let storage_slots_modified: usize =
+        bundle_update.state().values().map(|account| account.storage.len()).sum();
+    metrics.storage_slots_modified.record(storage_slots_modified as f64);
+
     let state_provider = db.database.as_ref();
 
     let state_root_start = Instant::now();

--- a/crates/client/metering/src/metrics.rs
+++ b/crates/client/metering/src/metrics.rs
@@ -21,4 +21,8 @@ pub(crate) struct Metrics {
     /// Time taken to compute pending trie (cache miss).
     #[metric(describe = "Time taken to compute pending trie on cache miss")]
     pub pending_trie_compute_duration: Histogram,
+
+    /// Number of storage slots modified.
+    #[metric(describe = "Number of storage slots modified")]
+    pub storage_slots_modified: Histogram,
 }

--- a/crates/client/metering/src/metrics.rs
+++ b/crates/client/metering/src/metrics.rs
@@ -25,4 +25,8 @@ pub(crate) struct Metrics {
     /// Number of storage slots modified.
     #[metric(describe = "Number of storage slots modified")]
     pub storage_slots_modified: Histogram,
+
+    /// Number of accounts modified.
+    #[metric(describe = "Number of accounts modified")]
+    pub accounts_modified: Histogram,
 }


### PR DESCRIPTION
It might be of interest to see the number of storage slots that each account touches when simulating a transaction. 

It could be insightful when tuning the resource metering parameters (i.e., `ResourceLimits::tx_state_root_time_limit_us`)