### PR TITLE
chore(workspace): Exempt Base Folks from Stale Tags

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -30,5 +30,5 @@ jobs:
           close-pr-message: 'This pull request was closed because it has been inactive for 5 days since being marked as stale.'
           exempt-issue-labels: keep-open
           exempt-pr-labels: keep-open
-          exempt-issue-authors: refcell,danyalprout,cody-wang-cb,haardikk21,meyer9,wlawt,niran
-          exempt-authors: refcell,danyalprout,cody-wang-cb,haardikk21,meyer9,wlawt,niran
+          exempt-issue-authors: refcell,danyalprout,cody-wang-cb,haardikk21,meyer9,wlawt,niran,mw2000
+          exempt-authors: refcell,danyalprout,cody-wang-cb,haardikk21,meyer9,wlawt,niran,mw2000

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -30,3 +30,5 @@ jobs:
           close-pr-message: 'This pull request was closed because it has been inactive for 5 days since being marked as stale.'
           exempt-issue-labels: keep-open
           exempt-pr-labels: keep-open
+          exempt-issue-authors: refcell,danyalprout,cody-wang-cb,haardikk21,meyer9,wlawt,niran
+          exempt-authors: refcell,danyalprout,cody-wang-cb,haardikk21,meyer9,wlawt,niran


### PR DESCRIPTION
## Summary

Previously, all issues and PRs were getting marked as `Stale` if they didn't have activity after a period of time. Then after another period of time, they would be automatically closed.

This PR updates that github action workflow to exempt issues & PRs from Base folks (as defined in the workflow).