### PR TITLE
fix(engine): use default launch to respect all options

### DIFF
--- a/crates/client/node/src/builder.rs
+++ b/crates/client/node/src/builder.rs
@@ -5,13 +5,14 @@ use std::fmt;
 use eyre::Result;
 use reth_exex::ExExContext;
 use reth_node_builder::{
-    NodeAdapter, NodeComponentsBuilder,
+    NodeAdapter, NodeComponentsBuilder, NodeHandleFor,
     node::FullNode,
     rpc::{RethRpcAddOns, RpcContext},
 };
 
 use crate::{
     OpBuilder,
+    node::BaseNode,
     types::{OpAddOns, OpComponentsBuilder, OpNodeTypes},
 };
 
@@ -112,6 +113,11 @@ impl BaseBuilder {
         L: FnOnce(OpBuilder) -> R,
     {
         launcher(self.build())
+    }
+
+    /// Launches the node using the default Reth launcher.
+    pub async fn launch(self) -> eyre::Result<NodeHandleFor<BaseNode>> {
+        self.build().launch().await
     }
 
     /// Installs an `ExEx` extension with the given name and closure.

--- a/crates/client/node/src/runner.rs
+++ b/crates/client/node/src/runner.rs
@@ -1,7 +1,7 @@
 //! Contains the [`BaseNodeRunner`], which is responsible for configuring and launching a Base node.
 
 use eyre::Result;
-use reth_node_builder::{EngineNodeLauncher, Node, NodeHandleFor, TreeConfig};
+use reth_node_builder::{Node, NodeHandleFor};
 use reth_optimism_node::args::RollupArgs;
 use reth_provider::providers::BlockchainProvider;
 use tracing::info;
@@ -61,22 +61,6 @@ impl BaseNodeRunner {
                 Ok(())
             });
 
-        builder
-            .launch_with_fn(|builder| {
-                let engine_tree_config = TreeConfig::default()
-                    .with_persistence_threshold(builder.config().engine.persistence_threshold)
-                    .with_memory_block_buffer_target(
-                        builder.config().engine.memory_block_buffer_target,
-                    );
-
-                let launcher = EngineNodeLauncher::new(
-                    builder.task_executor().clone(),
-                    builder.config().datadir(),
-                    engine_tree_config,
-                );
-
-                builder.launch_with(launcher)
-            })
-            .await
+        builder.launch_with_fn(|builder| builder.launch()).await
     }
 }

--- a/crates/client/node/src/runner.rs
+++ b/crates/client/node/src/runner.rs
@@ -61,6 +61,6 @@ impl BaseNodeRunner {
                 Ok(())
             });
 
-        builder.launch_with_fn(|builder| builder.launch()).await
+        builder.launch().await
     }
 }

--- a/crates/client/node/src/test_utils/node.rs
+++ b/crates/client/node/src/test_utils/node.rs
@@ -9,9 +9,7 @@ use op_alloy_network::Optimism;
 use reth_db::{
     ClientVersion, DatabaseEnv, init_db, mdbx::DatabaseArguments, test_utils::tempdir_path,
 };
-use reth_node_builder::{
-    EngineNodeLauncher, Node, NodeBuilder, NodeConfig, NodeHandle, TreeConfig,
-};
+use reth_node_builder::{Node, NodeBuilder, NodeConfig, NodeHandle};
 use reth_node_core::{
     args::{DatadirArgs, DiscoveryArgs, NetworkArgs, RpcServerArgs},
     dirs::{DataDirPath, MaybePlatformPath},
@@ -109,24 +107,7 @@ impl LocalNode {
             .into_iter()
             .fold(BaseBuilder::new(builder), |builder, extension| extension.apply(builder));
 
-        // Launch with EngineNodeLauncher
-        let NodeHandle { node: node_handle, node_exit_future } = builder
-            .launch_with_fn(|builder| {
-                let engine_tree_config = TreeConfig::default()
-                    .with_persistence_threshold(builder.config().engine.persistence_threshold)
-                    .with_memory_block_buffer_target(
-                        builder.config().engine.memory_block_buffer_target,
-                    );
-
-                let launcher = EngineNodeLauncher::new(
-                    builder.task_executor().clone(),
-                    builder.config().datadir(),
-                    engine_tree_config,
-                );
-
-                builder.launch_with(launcher)
-            })
-            .await?;
+        let NodeHandle { node: node_handle, node_exit_future } = builder.launch().await?;
 
         let http_api_addr = node_handle
             .rpc_server_handle()

--- a/devnet/src/l2/in_process_builder.rs
+++ b/devnet/src/l2/in_process_builder.rs
@@ -20,7 +20,7 @@ use reth_db::{
     mdbx::{DatabaseArguments, KILOBYTE, MEGABYTE, MaxReadTransactionDuration},
     test_utils::TempDatabase,
 };
-use reth_node_builder::{EngineNodeLauncher, NodeBuilder, NodeConfig, NodeHandle, TreeConfig};
+use reth_node_builder::{NodeBuilder, NodeConfig, NodeHandle};
 use reth_node_core::{
     args::{DatadirArgs, NetworkArgs, RpcServerArgs},
     dirs::{DataDirPath, MaybePlatformPath},
@@ -153,24 +153,8 @@ impl InProcessBuilder {
             .with_add_ons(addons)
             .on_component_initialized(move |_ctx| Ok(()));
 
-        let NodeHandle { node: node_handle, node_exit_future } = node_builder
-            .launch_with_fn(|builder| {
-                let engine_tree_config = TreeConfig::default()
-                    .with_persistence_threshold(builder.config().engine.persistence_threshold)
-                    .with_memory_block_buffer_target(
-                        builder.config().engine.memory_block_buffer_target,
-                    );
-
-                let launcher = EngineNodeLauncher::new(
-                    builder.task_executor().clone(),
-                    builder.config().datadir(),
-                    engine_tree_config,
-                );
-
-                builder.launch_with(launcher)
-            })
-            .await
-            .wrap_err("Failed to launch builder node")?;
+        let NodeHandle { node: node_handle, node_exit_future } =
+            node_builder.launch().await.wrap_err("Failed to launch builder node")?;
 
         let http_api_addr = node_handle
             .rpc_server_handle()


### PR DESCRIPTION
### Description
Our current launch function doesn't respect all the properties. We should use the upstream version instead. See the implementation:

* [launch()](https://github.com/paradigmxyz/reth/blob/v1.10.2/crates/node/builder/src/builder/mod.rs#L682)
* [engine_api_launcher()](https://github.com/paradigmxyz/reth/blob/v1.10.2/crates/node/builder/src/builder/mod.rs#L717)
* [tree_config()](https://github.com/paradigmxyz/reth/blob/v1.10.2/crates/node/core/src/args/engine.rs#L380)

The tree config loads all the options, whereas we're currently only loading a subset.