### PR TITLE
chore(devnet): Bumps Devnet Load

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -438,5 +438,7 @@ services:
       - --min-balance
       - ${CONTENDER_MIN_BALANCE}
       - --optimistic-nonces
-      - ${CONTENDER_GEN_REPORT:+--gen-report} 
-    restart: no
+      - --ignore-receipts
+      - --forever
+      - ${CONTENDER_GEN_REPORT:+--gen-report}
+    restart: always

--- a/scripts/devnet/load/campaign.toml
+++ b/scripts/devnet/load/campaign.toml
@@ -11,46 +11,57 @@ seed = 1
 #
 # The main components of the contract include initializing storage/accounts,
 # load/update/delete/create storage slots and accounts, and precompiles.
+# Includes simple transfers for consistent baseline load.
 [[spam.stage]]
 name = "simulator-load"
 rate = 200
 duration = 600
   [[spam.stage.mix]]
+  scenario  = "/load/scenarios/transfers.toml"
+  share_pct = 20.0
+  [[spam.stage.mix]]
   scenario  = "erc20"
-  share_pct = 25.0
+  share_pct = 20.0
   [[spam.stage.mix]]
   scenario  = "/load/scenarios/create_slots.toml"
-  share_pct = 25.0
+  share_pct = 20.0
   [[spam.stage.mix]]
   scenario  = "/load/scenarios/precompiles.toml"
-  share_pct = 25.0
+  share_pct = 20.0
   [[spam.stage.mix]]
   scenario  = "/load/scenarios/slot_contention.toml"
-  share_pct = 25.0
+  share_pct = 20.0
 
 
 # This load attempts to mimic what a trading volume would look like by interacting
-# with Uniswap pools, transferring tokens, and interacting with the mempool
+# with Uniswap pools, transferring tokens, and interacting with the mempool.
+# Includes simple transfers for consistent baseline load.
 [[spam.stage]]
 name = "trading-load"
 rate = 200
 duration = 600
   [[spam.stage.mix]]
+  scenario  = "/load/scenarios/transfers.toml"
+  share_pct = 25.0
+  [[spam.stage.mix]]
   scenario  = "erc20"
-  share_pct = 30.0
+  share_pct = 25.0
   [[spam.stage.mix]]
   scenario  = "scenario:uniV3.toml"
-  share_pct = 40.0
+  share_pct = 25.0
   [[spam.stage.mix]]
   scenario  = "scenario:mempool.toml"
-  share_pct = 30.0
+  share_pct = 25.0
 
 
-# This load is just a pure spam (i.e., XEN).
+# This load is just a pure spam (i.e., XEN) with baseline transfers.
 [[spam.stage]]
 name = "spam-load"
 rate = 200
 duration = 600
   [[spam.stage.mix]]
+  scenario  = "/load/scenarios/transfers.toml"
+  share_pct = 30.0
+  [[spam.stage.mix]]
   scenario  = "scenario:xen.toml"
-  share_pct = 100.0
+  share_pct = 70.0

--- a/scripts/devnet/load/campaign.toml
+++ b/scripts/devnet/load/campaign.toml
@@ -1,17 +1,56 @@
 name = "load"
-description = "Flashblock-aligned load generation - ~10-50 txs per 200ms"
+description = "Sequential load generation based on different workloads"
 
 [spam]
 mode = "tps"
-rate = 200        # 200 txs per second
-duration = 3600   # 1 hour
+rate = 200
+duration = 600
 seed = 1
 
-# Simple ERC20 transfers for consistent load
+# This load attempts to mimic the `Simulator.sol` contract in `base/benchmark`
+#
+# The main components of the contract include initializing storage/accounts,
+# load/update/delete/create storage slots and accounts, and precompiles.
 [[spam.stage]]
-name = "flashblock-load"
+name = "simulator-load"
 rate = 200
-duration = 3600
+duration = 600
   [[spam.stage.mix]]
   scenario  = "erc20"
+  share_pct = 25.0
+  [[spam.stage.mix]]
+  scenario  = "/load/scenarios/create_slots.toml"
+  share_pct = 25.0
+  [[spam.stage.mix]]
+  scenario  = "/load/scenarios/precompiles.toml"
+  share_pct = 25.0
+  [[spam.stage.mix]]
+  scenario  = "/load/scenarios/slot_contention.toml"
+  share_pct = 25.0
+
+
+# This load attempts to mimic what a trading volume would look like by interacting
+# with Uniswap pools, transferring tokens, and interacting with the mempool
+[[spam.stage]]
+name = "trading-load"
+rate = 200
+duration = 600
+  [[spam.stage.mix]]
+  scenario  = "erc20"
+  share_pct = 30.0
+  [[spam.stage.mix]]
+  scenario  = "scenario:uniV3.toml"
+  share_pct = 40.0
+  [[spam.stage.mix]]
+  scenario  = "scenario:mempool.toml"
+  share_pct = 30.0
+
+
+# This load is just a pure spam (i.e., XEN).
+[[spam.stage]]
+name = "spam-load"
+rate = 200
+duration = 600
+  [[spam.stage.mix]]
+  scenario  = "scenario:xen.toml"
   share_pct = 100.0

--- a/scripts/devnet/load/campaign.toml
+++ b/scripts/devnet/load/campaign.toml
@@ -1,58 +1,17 @@
 name = "load"
-description = "Sequential load generation based on different workloads"
+description = "Flashblock-aligned load generation - ~10-50 txs per 200ms"
 
 [spam]
 mode = "tps"
-rate = 100        # default rate if a stage omits one
-duration = 60     # default duration per stage (seconds)
+rate = 200        # 200 txs per second
+duration = 3600   # 1 hour
 seed = 1
 
-# This load attempts to mimic the `Simulator.sol` contract in `base/benchmark`
-#
-# The main components of the contract include initializing storage/accounts,
-# load/update/delete/create storage slots and accounts, and precompiles.
+# Simple ERC20 transfers for consistent load
 [[spam.stage]]
-name = "simulator-load"
-
-# 100 * 0.25 = 25 TPS per scenario over 10s
-rate = 60
-duration = 10
+name = "flashblock-load"
+rate = 200
+duration = 3600
   [[spam.stage.mix]]
   scenario  = "erc20"
-  share_pct = 25.0
-  [[spam.stage.mix]]
-  scenario  = "/load/scenarios/create_slots.toml"
-  share_pct = 25.0
-  [[spam.stage.mix]]
-  scenario  = "/load/scenarios/precompiles.toml"
-  share_pct = 25.0
-  [[spam.stage.mix]]
-  scenario  = "/load/scenarios/slot_contention.toml"
-  share_pct = 25.0
-
-
-# This load attempts to mimic what a trading volume would look like by interacting
-# with Uniswap pools, transferring tokens, and interacting with the mempool
-[[spam.stage]]
-name = "trading-load"
-rate = 60
-duration = 10
-  [[spam.stage.mix]]
-  scenario  = "erc20"
-  share_pct = 30.0
-  [[spam.stage.mix]]
-  scenario  = "scenario:uniV3.toml"
-  share_pct = 40.0
-  [[spam.stage.mix]]
-  scenario  = "scenario:mempool.toml"
-  share_pct = 30.0  
-  
-
-# This load is just a pure spam (i.e., XEN).
-[[spam.stage]]
-name = "spam-load"
-rate = 20
-duration = 10
-  [[spam.stage.mix]]
-  scenario  = "scenario:xen.toml"
   share_pct = 100.0

--- a/scripts/devnet/load/consistent-sender.sh
+++ b/scripts/devnet/load/consistent-sender.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+# Sends consistent transactions every 100-200ms to fill gaps between contender bursts
+
+RPC_URL="${RPC_URL:-http://localhost:7545}"
+PRIVATE_KEY="${PRIVATE_KEY:-0x2a871d0798f97d79848a013d4936a73bf4cc922c825d33c1cf7073dff6d409c6}"
+TO_ADDRESS="${TO_ADDRESS:-0x0000000000000000000000000000000000000001}"
+
+echo "Starting consistent transaction sender..."
+echo "RPC: $RPC_URL"
+
+while true; do
+    # Send a simple ETH transfer with random value (1-100 wei)
+    VALUE=$((RANDOM % 100 + 1))
+
+    # Send async (don't wait for receipt)
+    cast send --async \
+        --rpc-url "$RPC_URL" \
+        --private-key "$PRIVATE_KEY" \
+        "$TO_ADDRESS" \
+        --value "${VALUE}wei" \
+        2>/dev/null &
+
+    # Random sleep between 100-200ms
+    SLEEP_MS=$((100 + RANDOM % 100))
+    sleep "0.${SLEEP_MS}"
+done

--- a/scripts/devnet/load/scenarios/transfers.toml
+++ b/scripts/devnet/load/scenarios/transfers.toml
@@ -1,0 +1,9 @@
+# Simple ETH transfers for consistent baseline load
+# No contract deployment required - just direct ETH transfers
+
+[[spam]]
+[spam.tx]
+kind = "transfer"
+to = "0x0000000000000000000000000000000000000001"
+value = "0.0001 ether"
+from_pool = "signers"


### PR DESCRIPTION
## Summary

The devnet-load command was producing very few transactions because the campaign only ran for 30 seconds total with low TPS rates (60/60/20 across three stages).

Increased TPS from 60 to 200 per stage and duration from 10 seconds to 10 minutes per stage. Added --ignore-receipts and --forever flags for continuous load, and changed the container restart policy to always. All original scenarios (simulator-load, trading-load, spam-load) are preserved. The load generator now sends 200 txs/second continuously through diverse workloads instead of ~1,400 txs total over 30 seconds.

Now the devnet looks like this:

https://github.com/user-attachments/assets/0c021f8e-a3a0-4c26-ae76-75240e56cd74