### PR TITLE
fix: add tls feature for wss connections

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -280,7 +280,7 @@ op-revm = { version = "15.0.0", default-features = false }
 tokio = "1.48.0"
 tokio-util = "0.7.4"
 tokio-stream = "0.1.17"
-tokio-tungstenite = "0.28.0"
+tokio-tungstenite = { version = "0.28.0", features = ["native-tls"] }
 
 # async
 futures = "0.3.31"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -280,7 +280,7 @@ op-revm = { version = "15.0.0", default-features = false }
 tokio = "1.48.0"
 tokio-util = "0.7.4"
 tokio-stream = "0.1.17"
-tokio-tungstenite = { version = "0.28.0", features = ["native-tls"] }
+tokio-tungstenite = "0.28.0"
 
 # async
 futures = "0.3.31"

--- a/crates/client/flashblocks/Cargo.toml
+++ b/crates/client/flashblocks/Cargo.toml
@@ -47,7 +47,7 @@ op-alloy-consensus.workspace = true
 
 # tokio
 tokio.workspace = true
-tokio-tungstenite.workspace = true
+tokio-tungstenite = { workspace = true, features = ["native-tls"] }
 tokio-stream.workspace = true
 
 # async


### PR DESCRIPTION
### Description
Re-add the TLS feature. This is required to connect to `wss://` websockets.