### PR TITLE
chore(builder): port op-rbuilder timing fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14776,7 +14776,9 @@ checksum = "d25a406cddcc431a75d3d9afc6a7c0f7428d4891dd973e4d54c56b46127bf857"
 dependencies = [
  "futures-util",
  "log",
+ "native-tls",
  "tokio",
+ "tokio-native-tls",
  "tungstenite 0.28.0",
 ]
 
@@ -15289,6 +15291,7 @@ dependencies = [
  "http",
  "httparse",
  "log",
+ "native-tls",
  "rand 0.9.2",
  "sha1",
  "thiserror 2.0.17",

--- a/bin/consensus/README.md
+++ b/bin/consensus/README.md
@@ -2,4 +2,4 @@
 
 The canonical entrypoint for the Base Stack.
 
-Under the hood, `base-consensus` runs a [kona](https://github.com/ethereum-optimism/optimism/tree/develop/kona) node.
+Under the hood, `base-consensus` runs a [kona](https://github.com/op-rs/kona) node.

--- a/crates/builder/core/src/flashblocks/payload.rs
+++ b/crates/builder/core/src/flashblocks/payload.rs
@@ -733,7 +733,11 @@ where
         let target_time = std::time::SystemTime::UNIX_EPOCH + Duration::from_secs(timestamp)
             - self.config.flashblocks.leeway_time;
         let now = std::time::SystemTime::now();
-        let Ok(time_drift) = target_time.duration_since(now) else {
+        let Some(time_drift) = target_time
+            .duration_since(now)
+            .ok()
+            .filter(|duration| duration.as_millis() > 0)
+        else {
             error!(
                 target: "payload_builder",
                 message = "FCU arrived too late or system clock are unsynced",

--- a/crates/builder/core/src/flashblocks/payload.rs
+++ b/crates/builder/core/src/flashblocks/payload.rs
@@ -733,10 +733,8 @@ where
         let target_time = std::time::SystemTime::UNIX_EPOCH + Duration::from_secs(timestamp)
             - self.config.flashblocks.leeway_time;
         let now = std::time::SystemTime::now();
-        let Some(time_drift) = target_time
-            .duration_since(now)
-            .ok()
-            .filter(|duration| duration.as_millis() > 0)
+        let Some(time_drift) =
+            target_time.duration_since(now).ok().filter(|duration| duration.as_millis() > 0)
         else {
             error!(
                 target: "payload_builder",


### PR DESCRIPTION
## Summary

Ports flashbots/op-rbuilder#342 (included in `op-rbuilder/v0.3.0`) which fixes a division-by-zero panic in calculate_flashblocks. When FCU arrives at exactly target_time - leeway_time, time_drift is zero, producing zero flashblocks and a subsequent div-zero on gas limit calculation. The fix filters out zero-duration time drifts so they fall through to the default flashblock count.