### PR TITLE
chore: use workspace edition for sidecrush and mempool-rebroadcaster

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3009,7 +3009,7 @@ dependencies = [
 
 [[package]]
 name = "based-bin"
-version = "0.1.0"
+version = "0.0.0"
 dependencies = [
  "based",
  "cadence",
@@ -8071,7 +8071,7 @@ dependencies = [
 
 [[package]]
 name = "mempool-rebroadcaster-bin"
-version = "0.1.0"
+version = "0.0.0"
 dependencies = [
  "clap",
  "dotenvy",

--- a/bin/based/Cargo.toml
+++ b/bin/based/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "based-bin"
-version = "0.1.0"
-edition = "2021"
+version.workspace = true
+edition.workspace = true
 
 [[bin]]
 name = "based"

--- a/bin/mempool-rebroadcaster/Cargo.toml
+++ b/bin/mempool-rebroadcaster/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mempool-rebroadcaster-bin"
-version = "0.1.0"
-edition = "2021"
+version.workspace = true
+edition.workspace = true
 
 [[bin]]
 name = "mempool-rebroadcaster"

--- a/deny.toml
+++ b/deny.toml
@@ -160,9 +160,6 @@ skip = [
     "if-addrs",
     "yamux",
 
-    # jsonrpsee (older rustc-hash) vs other deps (newer rustc-hash)
-    "rustc-hash",
-
     # mach2 version mismatch: tracing-samply uses 0.5.0, metrics-process uses 0.6.0
     "mach2",
 


### PR DESCRIPTION
Use workspace edition and version for `sidecrush-bin` and `mempool-rebroadcaster-bin`.