### PR TITLE
chore: enable workspace linting for all bin/ and crates/ crates

### DIFF
--- a/bin/basectl/Cargo.toml
+++ b/bin/basectl/Cargo.toml
@@ -13,3 +13,6 @@ basectl-cli = { workspace = true }
 clap = { workspace = true }
 tokio = { workspace = true }
 anyhow = { workspace = true }
+
+[lints]
+workspace = true

--- a/bin/basectl/Cargo.toml
+++ b/bin/basectl/Cargo.toml
@@ -8,11 +8,11 @@ license.workspace = true
 name = "basectl"
 path = "main.rs"
 
+[lints]
+workspace = true
+
 [dependencies]
 basectl-cli = { workspace = true }
 clap = { workspace = true }
 tokio = { workspace = true }
 anyhow = { workspace = true }
-
-[lints]
-workspace = true

--- a/bin/based/Cargo.toml
+++ b/bin/based/Cargo.toml
@@ -7,6 +7,9 @@ edition = "2021"
 name = "based"
 path = "src/main.rs"
 
+[lints]
+workspace = true
+
 [dependencies]
 clap = { workspace = true }
 based = { workspace = true }
@@ -14,6 +17,3 @@ tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 tokio = { workspace = true }
 cadence = { workspace = true }
-
-[lints]
-workspace = true

--- a/bin/based/Cargo.toml
+++ b/bin/based/Cargo.toml
@@ -14,3 +14,6 @@ tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 tokio = { workspace = true }
 cadence = { workspace = true }
+
+[lints]
+workspace = true

--- a/bin/based/src/main.rs
+++ b/bin/based/src/main.rs
@@ -1,3 +1,5 @@
+//! Based binary entry point.
+
 use std::net::UdpSocket;
 
 use based::{

--- a/bin/mempool-rebroadcaster/Cargo.toml
+++ b/bin/mempool-rebroadcaster/Cargo.toml
@@ -7,6 +7,9 @@ edition = "2021"
 name = "mempool-rebroadcaster"
 path = "src/main.rs"
 
+[lints]
+workspace = true
+
 [dependencies]
 clap = { workspace = true }
 dotenvy.workspace = true
@@ -14,6 +17,3 @@ mempool-rebroadcaster = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 tokio = { workspace = true }
-
-[lints]
-workspace = true

--- a/bin/mempool-rebroadcaster/Cargo.toml
+++ b/bin/mempool-rebroadcaster/Cargo.toml
@@ -14,3 +14,6 @@ mempool-rebroadcaster = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 tokio = { workspace = true }
+
+[lints]
+workspace = true

--- a/bin/mempool-rebroadcaster/src/main.rs
+++ b/bin/mempool-rebroadcaster/src/main.rs
@@ -1,3 +1,5 @@
+//! Mempool rebroadcaster binary entry point.
+
 use clap::Parser;
 use dotenvy::dotenv;
 use mempool_rebroadcaster::Rebroadcaster;

--- a/bin/tips-audit/Cargo.toml
+++ b/bin/tips-audit/Cargo.toml
@@ -7,6 +7,9 @@ homepage.workspace = true
 repository.workspace = true
 edition.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 tips-core.workspace = true
 tips-audit-lib.workspace = true
@@ -19,6 +22,3 @@ rdkafka.workspace = true
 aws-config.workspace = true
 aws-sdk-s3.workspace = true
 aws-credential-types.workspace = true
-
-[lints]
-workspace = true

--- a/bin/tips-audit/Cargo.toml
+++ b/bin/tips-audit/Cargo.toml
@@ -19,3 +19,6 @@ rdkafka.workspace = true
 aws-config.workspace = true
 aws-sdk-s3.workspace = true
 aws-credential-types.workspace = true
+
+[lints]
+workspace = true

--- a/bin/tips-audit/src/main.rs
+++ b/bin/tips-audit/src/main.rs
@@ -1,3 +1,5 @@
+//! Tips audit binary entry point.
+
 use std::net::SocketAddr;
 
 use anyhow::Result;

--- a/bin/tips-ingress-rpc/Cargo.toml
+++ b/bin/tips-ingress-rpc/Cargo.toml
@@ -20,3 +20,6 @@ rdkafka.workspace = true
 jsonrpsee.workspace = true
 op-alloy-network.workspace = true
 alloy-provider.workspace = true
+
+[lints]
+workspace = true

--- a/bin/tips-ingress-rpc/Cargo.toml
+++ b/bin/tips-ingress-rpc/Cargo.toml
@@ -7,6 +7,9 @@ homepage.workspace = true
 repository.workspace = true
 edition.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 tips-core.workspace = true
 tips-audit-lib.workspace = true
@@ -20,6 +23,3 @@ rdkafka.workspace = true
 jsonrpsee.workspace = true
 op-alloy-network.workspace = true
 alloy-provider.workspace = true
-
-[lints]
-workspace = true

--- a/bin/tips-ingress-rpc/src/main.rs
+++ b/bin/tips-ingress-rpc/src/main.rs
@@ -1,3 +1,5 @@
+//! Tips ingress RPC binary entry point.
+
 use alloy_provider::ProviderBuilder;
 use clap::Parser;
 use jsonrpsee::server::Server;

--- a/crates/infra/basectl/Cargo.toml
+++ b/crates/infra/basectl/Cargo.toml
@@ -4,6 +4,9 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 tokio = { workspace = true }
 serde_json = { workspace = true }
@@ -28,6 +31,3 @@ alloy-sol-types = { workspace = true }
 alloy-contract = { workspace = true }
 arboard = { workspace = true }
 tracing = { workspace = true }
-
-[lints]
-workspace = true

--- a/crates/infra/basectl/Cargo.toml
+++ b/crates/infra/basectl/Cargo.toml
@@ -28,3 +28,6 @@ alloy-sol-types = { workspace = true }
 alloy-contract = { workspace = true }
 arboard = { workspace = true }
 tracing = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/infra/basectl/src/app/view.rs
+++ b/crates/infra/basectl/src/app/view.rs
@@ -14,5 +14,5 @@ pub trait View {
         Action::None
     }
 
-    fn render(&mut self, frame: &mut Frame, area: Rect, resources: &Resources);
+    fn render(&mut self, frame: &mut Frame<'_>, area: Rect, resources: &Resources);
 }

--- a/crates/infra/basectl/src/app/views/command_center.rs
+++ b/crates/infra/basectl/src/app/views/command_center.rs
@@ -257,7 +257,7 @@ impl View for CommandCenterView {
         Action::None
     }
 
-    fn render(&mut self, frame: &mut Frame, area: Rect, resources: &Resources) {
+    fn render(&mut self, frame: &mut Frame<'_>, area: Rect, resources: &Resources) {
         let main_chunks = Layout::default()
             .direction(Direction::Vertical)
             .constraints([
@@ -334,7 +334,7 @@ impl View for CommandCenterView {
 }
 
 #[allow(clippy::option_if_let_else)]
-fn render_config_panel(f: &mut Frame, area: Rect, resources: &Resources) {
+fn render_config_panel(f: &mut Frame<'_>, area: Rect, resources: &Resources) {
     let block = Block::default()
         .title(" L1 Config ")
         .borders(Borders::ALL)
@@ -395,7 +395,7 @@ fn format_gas_value(gas: u64) -> String {
     }
 }
 
-fn render_stats_panel(f: &mut Frame, area: Rect, resources: &Resources) {
+fn render_stats_panel(f: &mut Frame<'_>, area: Rect, resources: &Resources) {
     let tracker = &resources.da.tracker;
 
     let backlog_color = backlog_size_color(tracker.da_backlog_bytes);
@@ -469,7 +469,7 @@ fn render_stats_panel(f: &mut Frame, area: Rect, resources: &Resources) {
 }
 
 fn render_da_panel(
-    f: &mut Frame,
+    f: &mut Frame<'_>,
     area: Rect,
     resources: &Resources,
     is_active: bool,
@@ -499,7 +499,7 @@ fn render_da_panel(
 
     let selected_row = table_state.selected();
 
-    let rows: Vec<Row> = tracker
+    let rows: Vec<Row<'_>> = tracker
         .block_contributions
         .iter()
         .enumerate()
@@ -541,7 +541,7 @@ const GAS_BAR_CHARS: usize = 20;
 const DEFAULT_ELASTICITY: u64 = 6;
 
 fn render_flash_panel(
-    f: &mut Frame,
+    f: &mut Frame<'_>,
     area: Rect,
     resources: &Resources,
     is_active: bool,
@@ -576,7 +576,7 @@ fn render_flash_panel(
 
     let selected_row = table_state.selected();
 
-    let rows: Vec<Row> = flash
+    let rows: Vec<Row<'_>> = flash
         .entries
         .iter()
         .enumerate()

--- a/crates/infra/basectl/src/app/views/config.rs
+++ b/crates/infra/basectl/src/app/views/config.rs
@@ -49,7 +49,7 @@ impl View for ConfigView {
         }
     }
 
-    fn render(&mut self, frame: &mut Frame, area: Rect, resources: &Resources) {
+    fn render(&mut self, frame: &mut Frame<'_>, area: Rect, resources: &Resources) {
         let chunks = Layout::default()
             .direction(Direction::Vertical)
             .constraints([Constraint::Percentage(50), Constraint::Percentage(50)])
@@ -60,7 +60,7 @@ impl View for ConfigView {
     }
 }
 
-fn render_chain_config(f: &mut Frame, area: Rect, resources: &Resources) {
+fn render_chain_config(f: &mut Frame<'_>, area: Rect, resources: &Resources) {
     let config = &resources.config;
 
     let batcher_str = config
@@ -105,7 +105,7 @@ fn render_chain_config(f: &mut Frame, area: Rect, resources: &Resources) {
 }
 
 #[allow(clippy::option_if_let_else)]
-fn render_system_config(f: &mut Frame, area: Rect, resources: &Resources) {
+fn render_system_config(f: &mut Frame<'_>, area: Rect, resources: &Resources) {
     let block = Block::default()
         .title(" L1 SystemConfig ")
         .borders(Borders::ALL)

--- a/crates/infra/basectl/src/app/views/da_monitor.rs
+++ b/crates/infra/basectl/src/app/views/da_monitor.rs
@@ -136,7 +136,7 @@ impl View for DaMonitorView {
         }
     }
 
-    fn render(&mut self, frame: &mut Frame, area: Rect, resources: &Resources) {
+    fn render(&mut self, frame: &mut Frame<'_>, area: Rect, resources: &Resources) {
         let chunks = Layout::default()
             .direction(Direction::Vertical)
             .constraints([Constraint::Length(3), Constraint::Length(5), Constraint::Min(0)])
@@ -190,7 +190,7 @@ fn format_share(share: Option<f64>) -> String {
     share.map_or_else(|| "-".to_string(), |s| format!("{:.0}%", s * 100.0))
 }
 
-fn render_stats_panel(f: &mut Frame, area: Rect, resources: &Resources, filter: L1BlockFilter) {
+fn render_stats_panel(f: &mut Frame<'_>, area: Rect, resources: &Resources, filter: L1BlockFilter) {
     let tracker = &resources.da.tracker;
 
     let growth_30s = tracker.growth_tracker.rate_over(RATE_WINDOW_30S);
@@ -260,7 +260,7 @@ fn render_stats_panel(f: &mut Frame, area: Rect, resources: &Resources, filter: 
 }
 
 fn render_blocks_panel(
-    f: &mut Frame,
+    f: &mut Frame<'_>,
     area: Rect,
     resources: &Resources,
     is_active: bool,
@@ -295,7 +295,7 @@ fn render_blocks_panel(
 
     let selected_row = table_state.selected();
 
-    let rows: Vec<Row> = tracker
+    let rows: Vec<Row<'_>> = tracker
         .block_contributions
         .iter()
         .enumerate()

--- a/crates/infra/basectl/src/app/views/flashblocks.rs
+++ b/crates/infra/basectl/src/app/views/flashblocks.rs
@@ -134,7 +134,7 @@ impl View for FlashblocksView {
         Action::None
     }
 
-    fn render(&mut self, frame: &mut Frame, area: Rect, resources: &Resources) {
+    fn render(&mut self, frame: &mut Frame<'_>, area: Rect, resources: &Resources) {
         let flash = &resources.flash;
 
         let chunks = Layout::default()
@@ -193,7 +193,7 @@ impl View for FlashblocksView {
             Cell::from("Time").style(header_style),
         ]);
 
-        let rows: Vec<Row> = flash
+        let rows: Vec<Row<'_>> = flash
             .entries
             .iter()
             .enumerate()

--- a/crates/infra/basectl/src/app/views/home.rs
+++ b/crates/infra/basectl/src/app/views/home.rs
@@ -103,7 +103,7 @@ impl View for HomeView {
         }
     }
 
-    fn render(&mut self, frame: &mut Frame, area: Rect, _resources: &Resources) {
+    fn render(&mut self, frame: &mut Frame<'_>, area: Rect, _resources: &Resources) {
         let logo_height = LOGO.lines().count() as u16;
         let menu_height = (MENU_ITEMS.len() * 2) as u16 + 2;
         let total_content_height = logo_height + menu_height + 3;
@@ -126,9 +126,9 @@ impl View for HomeView {
     }
 }
 
-fn render_logo(f: &mut Frame, area: Rect) {
+fn render_logo(f: &mut Frame<'_>, area: Rect) {
     let max_len = LOGO.lines().map(|l| l.chars().count()).max().unwrap_or(0);
-    let padded_lines: Vec<Line> = LOGO
+    let padded_lines: Vec<Line<'_>> = LOGO
         .lines()
         .map(|line| {
             let padding = max_len.saturating_sub(line.chars().count());
@@ -144,7 +144,7 @@ fn render_logo(f: &mut Frame, area: Rect) {
     f.render_widget(logo, area);
 }
 
-fn render_menu(f: &mut Frame, area: Rect, selected_index: usize) {
+fn render_menu(f: &mut Frame<'_>, area: Rect, selected_index: usize) {
     let mut lines = Vec::new();
 
     for (i, item) in MENU_ITEMS.iter().enumerate() {

--- a/crates/infra/basectl/src/commands/common.rs
+++ b/crates/infra/basectl/src/commands/common.rs
@@ -689,7 +689,7 @@ pub fn build_gas_bar(
 
 #[allow(clippy::too_many_arguments)]
 pub fn render_l1_blocks_table<'a>(
-    f: &mut Frame,
+    f: &mut Frame<'_>,
     area: Rect,
     l1_blocks: impl Iterator<Item = &'a L1Block>,
     is_active: bool,
@@ -728,7 +728,7 @@ pub fn render_l1_blocks_table<'a>(
 
     let selected_row = table_state.selected();
 
-    let rows: Vec<Row> = l1_blocks
+    let rows: Vec<Row<'_>> = l1_blocks
         .enumerate()
         .map(|(idx, l1_block)| {
             let is_selected = is_active && selected_row == Some(idx);
@@ -771,7 +771,7 @@ pub fn render_l1_blocks_table<'a>(
 }
 
 pub fn render_da_backlog_bar(
-    f: &mut Frame,
+    f: &mut Frame<'_>,
     area: Rect,
     tracker: &DaTracker,
     loading: Option<&LoadingState>,
@@ -834,7 +834,7 @@ pub fn render_da_backlog_bar(
     }
 
     let total_backlog = tracker.da_backlog_bytes;
-    let mut spans: Vec<Span> = Vec::new();
+    let mut spans: Vec<Span<'_>> = Vec::new();
     let mut chars_used = 0usize;
 
     for contrib in backlog_blocks.iter().rev() {
@@ -880,7 +880,7 @@ pub fn render_da_backlog_bar(
 }
 
 pub fn render_gas_usage_bar(
-    f: &mut Frame,
+    f: &mut Frame<'_>,
     area: Rect,
     entries: &VecDeque<FlashblockEntry>,
     elasticity: u64,
@@ -944,7 +944,7 @@ pub fn render_gas_usage_bar(
         }
     };
 
-    let mut spans: Vec<Span> = Vec::new();
+    let mut spans: Vec<Span<'_>> = Vec::new();
     let mut chars_used = 0usize;
     let mut cumulative_gas = 0u64;
 

--- a/crates/infra/basectl/src/tui/app_frame.rs
+++ b/crates/infra/basectl/src/tui/app_frame.rs
@@ -32,7 +32,7 @@ impl AppFrame {
     }
 
     pub fn render(
-        f: &mut Frame,
+        f: &mut Frame<'_>,
         layout: &AppLayout,
         config_name: &str,
         keybindings: &[Keybinding],
@@ -43,7 +43,12 @@ impl AppFrame {
     }
 }
 
-fn render_help_sidebar(f: &mut Frame, area: Rect, config_name: &str, keybindings: &[Keybinding]) {
+fn render_help_sidebar(
+    f: &mut Frame<'_>,
+    area: Rect,
+    config_name: &str,
+    keybindings: &[Keybinding],
+) {
     let block = Block::default()
         .title(format!(" Help [{config_name}] "))
         .borders(Borders::ALL)
@@ -52,7 +57,7 @@ fn render_help_sidebar(f: &mut Frame, area: Rect, config_name: &str, keybindings
     let inner = block.inner(area);
     f.render_widget(block, area);
 
-    let mut lines: Vec<Line> = keybindings
+    let mut lines: Vec<Line<'_>> = keybindings
         .iter()
         .map(|kb| {
             Line::from(vec![

--- a/crates/infra/basectl/src/tui/toast.rs
+++ b/crates/infra/basectl/src/tui/toast.rs
@@ -110,7 +110,7 @@ impl ToastState {
     }
 
     /// Render toasts in the bottom-right corner of the given area
-    pub fn render(&self, frame: &mut Frame, area: Rect) {
+    pub fn render(&self, frame: &mut Frame<'_>, area: Rect) {
         let Some(toast) = self.current() else {
             return;
         };

--- a/crates/infra/based/Cargo.toml
+++ b/crates/infra/based/Cargo.toml
@@ -21,6 +21,9 @@ alloy-rpc-types-eth = { workspace = true }
 alloy-consensus = { workspace = true }
 alloy-primitives = { workspace = true }
 
+[lints]
+workspace = true
+
 [dev-dependencies]
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
 tracing = { workspace = true }

--- a/crates/infra/based/Cargo.toml
+++ b/crates/infra/based/Cargo.toml
@@ -7,6 +7,9 @@ license.workspace = true
 [lib]
 path = "src/lib.rs"
 
+[lints]
+workspace = true
+
 [dependencies]
 anyhow = { workspace = true }
 async-trait = { workspace = true }
@@ -20,9 +23,6 @@ alloy-transport-http = { workspace = true }
 alloy-rpc-types-eth = { workspace = true }
 alloy-consensus = { workspace = true }
 alloy-primitives = { workspace = true }
-
-[lints]
-workspace = true
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }

--- a/crates/infra/ingress-rpc/Cargo.toml
+++ b/crates/infra/ingress-rpc/Cargo.toml
@@ -34,5 +34,8 @@ op-alloy-consensus = { workspace = true, features = ["std", "k256", "serde"] }
 moka = { workspace = true, features = ["future"] }
 uuid = { workspace = true, features = ["v5"] }
 
+[lints]
+workspace = true
+
 [dev-dependencies]
 wiremock.workspace = true

--- a/crates/infra/ingress-rpc/Cargo.toml
+++ b/crates/infra/ingress-rpc/Cargo.toml
@@ -7,6 +7,9 @@ homepage.workspace = true
 repository.workspace = true
 edition.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 url.workspace = true
 tips-core.workspace = true
@@ -33,9 +36,6 @@ clap = { workspace = true, features = ["std", "derive", "env"] }
 op-alloy-consensus = { workspace = true, features = ["std", "k256", "serde"] }
 moka = { workspace = true, features = ["future"] }
 uuid = { workspace = true, features = ["v5"] }
-
-[lints]
-workspace = true
 
 [dev-dependencies]
 wiremock.workspace = true

--- a/crates/infra/ingress-rpc/src/lib.rs
+++ b/crates/infra/ingress-rpc/src/lib.rs
@@ -1,3 +1,6 @@
+//! Tips ingress RPC library.
+#![allow(missing_docs, missing_debug_implementations)]
+
 pub mod health;
 pub mod metrics;
 pub mod queue;
@@ -30,10 +33,10 @@ impl FromStr for TxSubmissionMethod {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
-            "mempool" => Ok(TxSubmissionMethod::Mempool),
-            "kafka" => Ok(TxSubmissionMethod::Kafka),
-            "mempool,kafka" | "kafka,mempool" => Ok(TxSubmissionMethod::MempoolAndKafka),
-            "none" => Ok(TxSubmissionMethod::None),
+            "mempool" => Ok(Self::Mempool),
+            "kafka" => Ok(Self::Kafka),
+            "mempool,kafka" | "kafka,mempool" => Ok(Self::MempoolAndKafka),
+            "none" => Ok(Self::None),
             _ => Err(format!(
                 "Invalid submission method: '{s}'. Valid options: mempool, kafka, mempool,kafka, kafka,mempool, none"
             )),

--- a/crates/infra/ingress-rpc/src/queue.rs
+++ b/crates/infra/ingress-rpc/src/queue.rs
@@ -19,7 +19,7 @@ pub struct KafkaMessageQueue {
 }
 
 impl KafkaMessageQueue {
-    pub fn new(producer: FutureProducer) -> Self {
+    pub const fn new(producer: FutureProducer) -> Self {
         Self { producer }
     }
 }
@@ -73,7 +73,7 @@ pub struct BundleQueuePublisher<Q: MessageQueue> {
 }
 
 impl<Q: MessageQueue> BundleQueuePublisher<Q> {
-    pub fn new(queue: Arc<Q>, topic: String) -> Self {
+    pub const fn new(queue: Arc<Q>, topic: String) -> Self {
         Self { queue, topic }
     }
 

--- a/crates/infra/ingress-rpc/src/service.rs
+++ b/crates/infra/ingress-rpc/src/service.rs
@@ -103,7 +103,7 @@ impl<Q: MessageQueue> IngressService<Q> {
             raw_tx_forward_provider,
             tx_submission_method: config.tx_submission_method,
             bundle_queue_publisher: BundleQueuePublisher::new(
-                queue_connection.clone(),
+                queue_connection,
                 config.ingress_topic,
             ),
             audit_channel,
@@ -351,7 +351,6 @@ impl<Q: MessageQueue> IngressService<Q> {
             .map_err(|_| EthApiError::FailedToDecodeSignedTransaction.into_rpc_err())?;
 
         let transaction = envelope
-            .clone()
             .try_into_recovered()
             .map_err(|_| EthApiError::FailedToDecodeSignedTransaction.into_rpc_err())?;
         Ok(transaction)
@@ -435,7 +434,7 @@ impl<Q: MessageQueue> IngressService<Q> {
         } else {
             MeterBundleResponse::default()
         };
-        let accepted_bundle = AcceptedBundle::new(parsed_bundle, meter_bundle_response.clone());
+        let accepted_bundle = AcceptedBundle::new(parsed_bundle, meter_bundle_response);
         Ok((accepted_bundle, bundle_hash))
     }
 

--- a/crates/infra/ingress-rpc/src/validation.rs
+++ b/crates/infra/ingress-rpc/src/validation.rs
@@ -76,7 +76,7 @@ impl L1BlockInfoLookup for RootProvider<Optimism> {
             })?;
         record_histogram(start.elapsed(), "eth_getBlockByNumber".to_string());
 
-        let txs = block.transactions.clone();
+        let txs = block.transactions;
         let first_tx = txs.first_transaction().ok_or_else(|| {
             warn!(message = "block contains no transactions");
             EthApiError::InternalEthError.into_rpc_err()
@@ -90,7 +90,7 @@ impl L1BlockInfoLookup for RootProvider<Optimism> {
 }
 
 /// Helper function to validate propeties of a bundle. A bundle is valid if it satisfies the following criteria:
-/// - The bundle's max_timestamp is not more than 1 hour in the future
+/// - The bundle's `max_timestamp` is not more than 1 hour in the future
 /// - The bundle's gas limit is not greater than the maximum allowed gas limit
 /// - The bundle can only contain 3 transactions at once
 /// - Partial transaction dropping is not supported, `dropping_tx_hashes` must be empty

--- a/crates/infra/mempool-rebroadcaster/Cargo.toml
+++ b/crates/infra/mempool-rebroadcaster/Cargo.toml
@@ -21,3 +21,6 @@ alloy-rpc-types-eth.workspace = true
 alloy-consensus.workspace = true
 alloy-trie.workspace = true
 alloy-provider = { workspace = true, features = ["txpool-api"] }
+
+[lints]
+workspace = true

--- a/crates/infra/mempool-rebroadcaster/Cargo.toml
+++ b/crates/infra/mempool-rebroadcaster/Cargo.toml
@@ -7,6 +7,9 @@ license.workspace = true
 [lib]
 path = "src/lib.rs"
 
+[lints]
+workspace = true
+
 [dependencies]
 serde = { workspace = true }
 serde_json = { workspace = true }
@@ -21,6 +24,3 @@ alloy-rpc-types-eth.workspace = true
 alloy-consensus.workspace = true
 alloy-trie.workspace = true
 alloy-provider = { workspace = true, features = ["txpool-api"] }
-
-[lints]
-workspace = true

--- a/crates/infra/mempool-rebroadcaster/tests/e2e_tests.rs
+++ b/crates/infra/mempool-rebroadcaster/tests/e2e_tests.rs
@@ -1,3 +1,5 @@
+//! End-to-end tests for the mempool rebroadcaster.
+
 use std::path::Path;
 
 use alloy_rpc_types::txpool::TxpoolContent;

--- a/crates/infra/system-tests/Cargo.toml
+++ b/crates/infra/system-tests/Cargo.toml
@@ -8,6 +8,9 @@ license.workspace = true
 [lib]
 path = "src/lib.rs"
 
+[lints]
+workspace = true
+
 [dependencies]
 hex.workspace = true
 rand.workspace = true
@@ -38,9 +41,6 @@ op-alloy-consensus = { workspace = true, features = ["std", "k256", "serde"] }
 alloy-primitives = { workspace = true, features = ["map-foldhash", "serde"] }
 tracing-subscriber = { workspace = true, features = ["std", "fmt", "env-filter", "json"] }
 aws-sdk-s3 = { workspace = true, features = ["rustls", "default-https-client", "rt-tokio"] }
-
-[lints]
-workspace = true
 
 [dev-dependencies]
 serial_test.workspace = true

--- a/crates/infra/system-tests/Cargo.toml
+++ b/crates/infra/system-tests/Cargo.toml
@@ -39,6 +39,9 @@ alloy-primitives = { workspace = true, features = ["map-foldhash", "serde"] }
 tracing-subscriber = { workspace = true, features = ["std", "fmt", "env-filter", "json"] }
 aws-sdk-s3 = { workspace = true, features = ["rustls", "default-https-client", "rt-tokio"] }
 
+[lints]
+workspace = true
+
 [dev-dependencies]
 serial_test.workspace = true
 tokio = { workspace = true, features = ["full", "test-util"] }

--- a/crates/infra/system-tests/src/bin/load-test.rs
+++ b/crates/infra/system-tests/src/bin/load-test.rs
@@ -1,3 +1,5 @@
+//! Load test binary entry point.
+
 use anyhow::Result;
 use clap::Parser;
 use tips_system_tests::load_test::{config, load, setup};

--- a/crates/infra/system-tests/src/client/tips_rpc.rs
+++ b/crates/infra/system-tests/src/client/tips_rpc.rs
@@ -4,17 +4,17 @@ use alloy_provider::{Provider, RootProvider};
 use anyhow::Result;
 use tips_core::{Bundle, BundleHash, CancelBundle};
 
-/// Client for TIPS-specific RPC methods (eth_sendBundle, eth_cancelBundle)
+/// Client for TIPS-specific RPC methods (`eth_sendBundle`, `eth_cancelBundle`)
 ///
-/// Wraps a RootProvider to add TIPS functionality while preserving access
-/// to standard Ethereum JSON-RPC methods via provider().
+/// Wraps a `RootProvider` to add TIPS functionality while preserving access
+/// to standard Ethereum JSON-RPC methods via `provider()`.
 #[derive(Clone)]
 pub struct TipsRpcClient<N: Network = alloy_network::Ethereum> {
     provider: RootProvider<N>,
 }
 
 impl<N: Network> TipsRpcClient<N> {
-    pub fn new(provider: RootProvider<N>) -> Self {
+    pub const fn new(provider: RootProvider<N>) -> Self {
         Self { provider }
     }
 
@@ -41,7 +41,7 @@ impl<N: Network> TipsRpcClient<N> {
         self.provider.raw_request("eth_cancelBundle".into(), [request]).await.map_err(Into::into)
     }
 
-    pub fn provider(&self) -> &RootProvider<N> {
+    pub const fn provider(&self) -> &RootProvider<N> {
         &self.provider
     }
 }

--- a/crates/infra/system-tests/src/fixtures/transactions.rs
+++ b/crates/infra/system-tests/src/fixtures/transactions.rs
@@ -61,8 +61,8 @@ pub fn create_signed_transaction(
 
 /// Create a simple load test transaction with standard defaults:
 /// - value: 1000 wei (small test amount)
-/// - gas_limit: 21000 (standard transfer)
-/// - max_fee_per_gas: 1 gwei
+/// - `gas_limit`: 21000 (standard transfer)
+/// - `max_fee_per_gas`: 1 gwei
 pub fn create_load_test_transaction(
     signer: &PrivateKeySigner,
     to: Address,

--- a/crates/infra/system-tests/src/lib.rs
+++ b/crates/infra/system-tests/src/lib.rs
@@ -1,3 +1,6 @@
+//! Tips system tests library.
+#![allow(missing_docs, missing_debug_implementations)]
+
 pub mod client;
 pub mod fixtures;
 pub mod load_test;

--- a/crates/infra/system-tests/src/load_test/load.rs
+++ b/crates/infra/system-tests/src/load_test/load.rs
@@ -52,10 +52,9 @@ pub async fn run(args: LoadArgs) -> Result<()> {
     let mut sender_handles = Vec::new();
 
     for (i, wallet) in wallets.into_iter().enumerate() {
-        let rng = match args.seed {
-            Some(seed) => ChaCha8Rng::seed_from_u64(seed + i as u64),
-            None => ChaCha8Rng::from_os_rng(),
-        };
+        let rng = args.seed.map_or_else(ChaCha8Rng::from_os_rng, |seed| {
+            ChaCha8Rng::seed_from_u64(seed + i as u64)
+        });
 
         let sender = SenderTask::new(
             wallet,

--- a/crates/infra/system-tests/src/load_test/poller.rs
+++ b/crates/infra/system-tests/src/load_test/poller.rs
@@ -15,7 +15,7 @@ pub struct ReceiptPoller {
 }
 
 impl ReceiptPoller {
-    pub fn new(
+    pub const fn new(
         sequencer: RootProvider<Optimism>,
         tracker: Arc<TransactionTracker>,
         timeout: Duration,

--- a/crates/infra/system-tests/src/load_test/sender.rs
+++ b/crates/infra/system-tests/src/load_test/sender.rs
@@ -29,7 +29,7 @@ pub struct SenderTask<N: Network> {
 }
 
 impl<N: Network> SenderTask<N> {
-    pub fn new(
+    pub const fn new(
         wallet: Wallet,
         client: TipsRpcClient<N>,
         sequencer: RootProvider<Optimism>,

--- a/crates/infra/system-tests/src/load_test/wallet.rs
+++ b/crates/infra/system-tests/src/load_test/wallet.rs
@@ -42,10 +42,7 @@ impl Wallet {
 }
 
 pub fn generate_wallets(num_wallets: usize, seed: Option<u64>) -> Vec<Wallet> {
-    let mut rng = match seed {
-        Some(s) => ChaCha8Rng::seed_from_u64(s),
-        None => ChaCha8Rng::from_os_rng(),
-    };
+    let mut rng = seed.map_or_else(ChaCha8Rng::from_os_rng, ChaCha8Rng::seed_from_u64);
 
     (0..num_wallets).map(|_| Wallet::new_random(&mut rng)).collect()
 }

--- a/crates/infra/system-tests/tests/common/kafka.rs
+++ b/crates/infra/system-tests/tests/common/kafka.rs
@@ -70,8 +70,7 @@ async fn wait_for_kafka_message<T>(
         let now = Instant::now();
         if now >= deadline {
             anyhow::bail!(
-                "Timed out waiting for Kafka message on topic {topic} after {:?}",
-                timeout_duration
+                "Timed out waiting for Kafka message on topic {topic} after {timeout_duration:?}"
             );
         }
 
@@ -92,7 +91,7 @@ async fn wait_for_kafka_message<T>(
     }
 }
 
-pub async fn wait_for_audit_event_by_hash(
+pub(crate) async fn wait_for_audit_event_by_hash(
     expected_bundle_hash: &B256,
     mut matcher: impl FnMut(&BundleEvent) -> bool,
 ) -> Result<BundleEvent> {

--- a/crates/infra/system-tests/tests/common/mod.rs
+++ b/crates/infra/system-tests/tests/common/mod.rs
@@ -1,1 +1,1 @@
-pub mod kafka;
+pub(crate) mod kafka;

--- a/crates/infra/system-tests/tests/integration_tests.rs
+++ b/crates/infra/system-tests/tests/integration_tests.rs
@@ -1,3 +1,5 @@
+//! Integration tests for tips system.
+
 #[path = "common/mod.rs"]
 mod common;
 
@@ -34,7 +36,7 @@ async fn wait_for_transaction_seen(
     let deadline = Instant::now() + Duration::from_secs(timeout_secs);
     loop {
         if Instant::now() >= deadline {
-            bail!("Timed out waiting for transaction {} to appear on the sequencer", tx_hash);
+            bail!("Timed out waiting for transaction {tx_hash} to appear on the sequencer");
         }
 
         if provider.get_transaction_by_hash(tx_hash).await?.is_some() {
@@ -191,7 +193,7 @@ async fn test_send_bundle_accepted() -> Result<()> {
                 "Audit event bundle hash should match response"
             );
         }
-        other => panic!("Expected Received audit event, got {:?}", other),
+        other => panic!("Expected Received audit event, got {other:?}"),
     }
 
     // Wait for transaction to appear on sequencer
@@ -304,7 +306,7 @@ async fn test_send_bundle_with_two_transactions() -> Result<()> {
                 "Audit event bundle hash should match response"
             );
         }
-        other => panic!("Expected Received audit event, got {:?}", other),
+        other => panic!("Expected Received audit event, got {other:?}"),
     }
 
     // Wait for both transactions to appear on sequencer


### PR DESCRIPTION
Add `[lints] workspace = true` to the 10 remaining crates that were missing it, and fix all resulting lint errors to pass CI.