### PR TITLE
docs(txpool-rpc): add README and cleanup exports

### DIFF
--- a/crates/shared/txpool-rpc/README.md
+++ b/crates/shared/txpool-rpc/README.md
@@ -1,0 +1,20 @@
+# base-txpool-rpc
+
+Transaction pool RPC extension for Base node. Enables transaction status queries and pool management.
+
+## Overview
+This extension provides the RPC modules `TransactionStatusApiImpl` and `TxPoolManagementApiImpl` for 
+getting tranasaction status through the sequencer URL (if configured) or a local transaction pool.
+It also extends the node with additional RPC methods for removing transaction(s), filtering by its hash,
+sender or all transactions from its local transaction pool.
+
+
+## Configuration
+
+The extension is configured through `RollupArgs`:
+
+- `sequencer`: Sequencer URL for forwarding state queries, otherwise default to local transaction pool
+
+## Usage
+
+The extension is installed as part of the node builder.

--- a/crates/shared/txpool-rpc/src/extension.rs
+++ b/crates/shared/txpool-rpc/src/extension.rs
@@ -3,7 +3,7 @@
 use base_client_node::{BaseNodeExtension, BaseRpcContext, FromExtensionConfig, NodeHooks};
 
 use crate::{
-    TransactionStatusApiImpl, TransactionStatusApiServer, TxPoolManagementApiImpl,
+    rpc::{TransactionStatusApiImpl, TxPoolManagementApiImpl}, TransactionStatusApiServer,
     TxPoolManagementApiServer,
 };
 

--- a/crates/shared/txpool-rpc/src/lib.rs
+++ b/crates/shared/txpool-rpc/src/lib.rs
@@ -2,14 +2,14 @@
 //!
 //! Provides RPC endpoints for querying transaction status and managing the transaction pool.
 
+#![doc = include_str!("../README.md")]
 #![doc(issue_tracker_base_url = "https://github.com/base/base/issues/")]
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
 
 mod rpc;
 pub use rpc::{
-    Status, TransactionStatusApiImpl, TransactionStatusApiServer, TransactionStatusResponse,
-    TxPoolManagementApiImpl, TxPoolManagementApiServer,
+    Status, TransactionStatusApiServer, TransactionStatusResponse, TxPoolManagementApiServer,
 };
 
 mod extension;

--- a/crates/shared/txpool-rpc/src/rpc.rs
+++ b/crates/shared/txpool-rpc/src/rpc.rs
@@ -54,7 +54,7 @@ pub trait TxPoolManagementApi {
 
 /// Implementation of the transaction status RPC API.
 #[derive(Debug)]
-pub struct TransactionStatusApiImpl<Pool: TransactionPool> {
+pub(crate) struct TransactionStatusApiImpl<Pool: TransactionPool> {
     sequencer_client: Option<HttpClient>,
     pool: Pool,
 }
@@ -64,7 +64,7 @@ impl<Pool: TransactionPool + 'static> TransactionStatusApiImpl<Pool> {
     ///
     /// If `sequencer_url` is provided, status queries will be forwarded to the sequencer.
     /// Otherwise, the local transaction pool will be queried.
-    pub fn new(
+    pub(crate) fn new(
         sequencer_url: Option<String>,
         pool: Pool,
     ) -> Result<Self, Box<dyn std::error::Error + Send + Sync>> {
@@ -111,13 +111,13 @@ impl<Pool: TransactionPool + 'static> TransactionStatusApiServer
 
 /// Implementation of the transaction pool management RPC API.
 #[derive(Debug)]
-pub struct TxPoolManagementApiImpl<Pool: TransactionPool> {
+pub(crate) struct TxPoolManagementApiImpl<Pool: TransactionPool> {
     pool: Pool,
 }
 
 impl<Pool: TransactionPool + 'static> TxPoolManagementApiImpl<Pool> {
     /// Creates a new transaction pool management API instance.
-    pub const fn new(pool: Pool) -> Self {
+    pub(crate) const fn new(pool: Pool) -> Self {
         Self { pool }
     }
 }


### PR DESCRIPTION
This PR removes `TransactionStatusApiImpl` and `TxPoolManagementApiImpl` exports from `lib.rs` as both are
not meant to be initialized outside the `txpool-rpc` crate.