### PR TITLE
chore(tx-tracer): improve tx tracer timing of inclusion metrics

### DIFF
--- a/crates/client/txpool-tracing/src/subscription.rs
+++ b/crates/client/txpool-tracing/src/subscription.rs
@@ -1,6 +1,6 @@
 //! Tracex canonical block subscription.
 
-use std::sync::Arc;
+use std::{sync::Arc, time::Instant};
 
 use base_flashblocks::{FlashblocksAPI, PendingBlocks};
 use futures::StreamExt;
@@ -45,12 +45,14 @@ pub async fn tracex_subscription<N, Pool, FB>(
 
             // Use canonical state notifications to track time to inclusion.
             Some(Ok(notification)) = canonical_stream.next() => {
-                tracker.handle_canon_state_notification(notification);
+                let received_at = Instant::now();
+                tracker.handle_canon_state_notification(notification, received_at);
             }
 
             // Track flashblock inclusion timing.
             Ok(pending_blocks) = flashblock_stream.recv() => {
-                tracker.handle_flashblock_notification(pending_blocks);
+                let received_at = Instant::now();
+                tracker.handle_flashblock_notification(pending_blocks, received_at);
             }
         }
     }

--- a/crates/client/txpool-tracing/src/tracker.rs
+++ b/crates/client/txpool-tracing/src/tracker.rs
@@ -90,12 +90,20 @@ impl Tracker {
     fn track_committed_chain<N: NodePrimitives>(&mut self, chain: &Chain<N>, received_at: Instant) {
         for block in chain.blocks().values() {
             for transaction in block.body().transactions() {
-                self.transaction_completed(*transaction.tx_hash(), TxEvent::BlockInclusion, received_at);
+                self.transaction_completed(
+                    *transaction.tx_hash(),
+                    TxEvent::BlockInclusion,
+                    received_at,
+                );
             }
         }
     }
 
-    fn track_flashblock_transactions(&mut self, pending_blocks: &PendingBlocks, received_at: Instant) {
+    fn track_flashblock_transactions(
+        &mut self,
+        pending_blocks: &PendingBlocks,
+        received_at: Instant,
+    ) {
         // Get all transaction hashes from pending blocks
         for tx_hash in pending_blocks.get_pending_transaction_hashes() {
             self.transaction_fb_included(tx_hash, received_at);


### PR DESCRIPTION
Small Improvement to the accuracy of tx inclusion metrics emitted from txpool tracer, by capturing the timestamp a block or flashblock was received, rather than when the tx was processed by the tracer.