### PR TITLE
fix: validate_tx logic for 7702

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2801,6 +2801,7 @@ dependencies = [
  "reth-revm",
  "reth-transaction-pool",
  "reth-trie-common",
+ "revm-bytecode 8.0.0",
  "revm-context-interface 14.0.0",
  "revm-database 10.0.0",
  "serde",

--- a/crates/client/metering/Cargo.toml
+++ b/crates/client/metering/Cargo.toml
@@ -68,6 +68,7 @@ reth-db = { workspace = true, features = ["op", "test-utils"] }
 reth-transaction-pool = { workspace = true, features = ["test-utils"] }
 
 # revm
+revm-bytecode.workspace = true
 revm-context-interface.workspace = true
 
 # alloy

--- a/crates/client/metering/src/meter.rs
+++ b/crates/client/metering/src/meter.rs
@@ -10,7 +10,7 @@ use op_revm::l1block::L1BlockInfo;
 use reth_evm::{ConfigureEvm, execute::BlockBuilder};
 use reth_optimism_chainspec::OpChainSpec;
 use reth_optimism_evm::{OpEvmConfig, OpNextBlockEnvAttributes};
-use reth_primitives_traits::{Bytecode, Account, SealedHeader};
+use reth_primitives_traits::{Account, Bytecode, SealedHeader};
 use reth_revm::{database::StateProviderDatabase, db::State};
 use reth_trie_common::TrieInput;
 use revm_database::states::{BundleState, bundle_state::BundleRetention};
@@ -190,6 +190,7 @@ where
                 .get(&from)
                 .ok_or_else(|| eyre!("Sender code not found in HashMap for address: {}", from))?;
 
+            // Don't waste resources metering invalid transactions
             validate_tx(account, sender_code.as_ref(), tx, &mut l1_block_info)
                 .map_err(|e| eyre!("Transaction {} validation failed: {}", tx_hash, e))?;
 

--- a/crates/client/metering/src/meter.rs
+++ b/crates/client/metering/src/meter.rs
@@ -153,14 +153,12 @@ where
 
     // Pre-fetch account information for all transactions before creating builder. The
     // account information is used to validate the transaction.
-    let mut accounts: HashMap<Address, Option<Account>> = HashMap::new();
-    let mut sender_codes: HashMap<Address, Option<Bytecode>> = HashMap::new();
+    let mut account_infos: HashMap<Address, (Option<Account>, Option<Bytecode>)> = HashMap::new();
     for tx in bundle.transactions() {
         let from = tx.recover_signer()?;
         let account = db.database.basic_account(&from)?;
         let code = db.database.account_code(&from)?;
-        accounts.insert(from, account);
-        sender_codes.insert(from, code);
+        account_infos.insert(from, (account, code));
     }
 
     // Execute transactions
@@ -182,13 +180,10 @@ where
             let to = tx.to();
             let value = tx.value();
             let gas_price = tx.max_fee_per_gas();
-            let account = accounts
+            let (account, sender_code) = account_infos
                 .get(&from)
-                .ok_or_else(|| eyre!("Account not found in HashMap for address: {}", from))?
-                .ok_or_else(|| eyre!("Account is none for tx: {}", tx_hash))?;
-            let sender_code = sender_codes
-                .get(&from)
-                .ok_or_else(|| eyre!("Sender code not found in HashMap for address: {}", from))?;
+                .ok_or_else(|| eyre!("Account not found in HashMap for address: {}", from))?;
+            let account = account.ok_or_else(|| eyre!("Account is none for tx: {}", tx_hash))?;
 
             // Don't waste resources metering invalid transactions
             validate_tx(account, sender_code.as_ref(), tx, &mut l1_block_info)


### PR DESCRIPTION
The previous implementation where "if the account is 7702, then the tx type must be 7702" is not correct.

This PR fixes that implementation/assumption and follows how Reth implements this where:
- If the account has bytecode, then it must be 7702 bytecode. This ensures that contracts can't send txns
- If the tx is 7702, then it must have an authorization list

Added unit tests to reflect this