### PR TITLE
feat: flamegraphs for devnet containers

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,6 +86,7 @@ string-lit-as-bytes = "warn"
 debug = "line-tables-only"
 split-debuginfo = "packed"
 incremental = false
+force-frame-pointers = true
 
 [profile.release]
 opt-level = 3
@@ -94,11 +95,18 @@ debug = "none"
 strip = "symbols"
 panic = "unwind"
 codegen-units = 16
+force-frame-pointers = true
 
 [profile.maxperf]
 inherits = "release"
 lto = "fat"
 codegen-units = 1
+
+[profile.profiling]
+inherits = "release"
+debug = 2
+strip = "none"
+force-frame-pointers = true
 
 # CI profile: optimized for minimal disk usage in CI environments
 # - Inherits from dev for fast compilation

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,7 +86,6 @@ string-lit-as-bytes = "warn"
 debug = "line-tables-only"
 split-debuginfo = "packed"
 incremental = false
-force-frame-pointers = true
 
 [profile.release]
 opt-level = 3
@@ -95,7 +94,6 @@ debug = "none"
 strip = "symbols"
 panic = "unwind"
 codegen-units = 16
-force-frame-pointers = true
 
 [profile.maxperf]
 inherits = "release"
@@ -104,7 +102,8 @@ codegen-units = 1
 
 [profile.profiling]
 inherits = "release"
-debug = 2
+lto = false
+debug = "line-tables-only"
 strip = "none"
 force-frame-pointers = true
 

--- a/Justfile
+++ b/Justfile
@@ -156,6 +156,10 @@ bench-flashblocks:
 devnet: devnet-down
     docker compose --env-file etc/docker/devnet-env -f etc/docker/docker-compose.yml up -d --build --scale contender=0
 
+# Stops devnet, deletes data, and starts fresh with profiling (Pyroscope + optimized builds)
+devnet-profiling: devnet-down
+    CARGO_PROFILE=profiling docker compose --env-file etc/docker/devnet-env -f etc/docker/docker-compose.yml --profile profiling up -d --build --scale contender=0
+
 # Stops devnet and deletes all data
 devnet-down:
     -docker compose --env-file etc/docker/devnet-env -f etc/docker/docker-compose.yml down

--- a/Justfile
+++ b/Justfile
@@ -162,7 +162,7 @@ devnet-profiling: devnet-down
 
 # Stops devnet and deletes all data
 devnet-down:
-    -docker compose --env-file etc/docker/devnet-env -f etc/docker/docker-compose.yml down
+    -docker compose --env-file etc/docker/devnet-env -f etc/docker/docker-compose.yml --profile profiling down
     rm -rf .devnet
 
 # Shows devnet block numbers and sync status

--- a/etc/docker/docker-compose.yml
+++ b/etc/docker/docker-compose.yml
@@ -159,7 +159,7 @@ services:
       context: ../..
       dockerfile: etc/docker/Dockerfile.builder
       args:
-        - PROFILE=dev
+        - PROFILE=profiling
     container_name: base-builder
     depends_on:
       setup-l2:
@@ -319,7 +319,7 @@ services:
       context: ../..
       dockerfile: etc/docker/Dockerfile.client
       args:
-        - PROFILE=dev
+        - PROFILE=profiling
     container_name: base-client
     depends_on:
       setup-l2:

--- a/etc/docker/docker-compose.yml
+++ b/etc/docker/docker-compose.yml
@@ -462,7 +462,7 @@ services:
     restart: unless-stopped
 
   pyroscope:
-    image: grafana/pyroscope:latest
+    image: grafana/pyroscope:1.18.1
     container_name: pyroscope
     ports:
       - "4040:4040"
@@ -471,7 +471,7 @@ services:
     restart: unless-stopped
 
   alloy:
-    image: grafana/alloy:latest
+    image: grafana/alloy:v1.13.1
     container_name: alloy
     privileged: true
     pid: host

--- a/etc/docker/docker-compose.yml
+++ b/etc/docker/docker-compose.yml
@@ -159,7 +159,7 @@ services:
       context: ../..
       dockerfile: etc/docker/Dockerfile.builder
       args:
-        - PROFILE=profiling
+        - PROFILE=${CARGO_PROFILE:-dev}
     container_name: base-builder
     depends_on:
       setup-l2:
@@ -319,7 +319,7 @@ services:
       context: ../..
       dockerfile: etc/docker/Dockerfile.client
       args:
-        - PROFILE=profiling
+        - PROFILE=${CARGO_PROFILE:-dev}
     container_name: base-client
     depends_on:
       setup-l2:
@@ -464,6 +464,7 @@ services:
   pyroscope:
     image: grafana/pyroscope:1.18.1
     container_name: pyroscope
+    profiles: ["profiling"]
     ports:
       - "4040:4040"
     command:
@@ -473,6 +474,7 @@ services:
   alloy:
     image: grafana/alloy:v1.13.1
     container_name: alloy
+    profiles: ["profiling"]
     privileged: true
     pid: host
     volumes:
@@ -514,6 +516,5 @@ services:
       - ../scripts/devnet/grafana/dashboards:/var/lib/grafana/dashboards:ro
     depends_on:
       - prometheus
-      - pyroscope
       - jaeger
     restart: unless-stopped

--- a/etc/docker/docker-compose.yml
+++ b/etc/docker/docker-compose.yml
@@ -461,6 +461,31 @@ services:
       - COLLECTOR_OTLP_ENABLED=true
     restart: unless-stopped
 
+  pyroscope:
+    image: grafana/pyroscope:latest
+    container_name: pyroscope
+    ports:
+      - "4040:4040"
+    command:
+      - "server"
+    restart: unless-stopped
+
+  alloy:
+    image: grafana/alloy:latest
+    container_name: alloy
+    privileged: true
+    pid: host
+    volumes:
+      - ../scripts/devnet/alloy.config:/etc/alloy/config.alloy:ro
+      - /var/run/docker.sock:/var/run/docker.sock
+    command:
+      - run
+      - --server.http.listen-addr=0.0.0.0:12345
+      - /etc/alloy/config.alloy
+    depends_on:
+      - pyroscope
+    restart: unless-stopped
+
   prometheus:
     image: prom/prometheus:v2.51.0
     container_name: prometheus
@@ -483,10 +508,12 @@ services:
       - GF_AUTH_ANONYMOUS_ENABLED=true
       - GF_AUTH_ANONYMOUS_ORG_ROLE=Admin
       - GF_AUTH_DISABLE_LOGIN_FORM=true
+      - GF_INSTALL_PLUGINS=grafana-pyroscope-app
     volumes:
       - ../scripts/devnet/grafana/provisioning:/etc/grafana/provisioning:ro
       - ../scripts/devnet/grafana/dashboards:/var/lib/grafana/dashboards:ro
     depends_on:
       - prometheus
+      - pyroscope
       - jaeger
     restart: unless-stopped

--- a/etc/scripts/devnet/alloy.config
+++ b/etc/scripts/devnet/alloy.config
@@ -1,0 +1,29 @@
+discovery.docker "local_containers" {
+  host = "unix:///var/run/docker.sock"
+}
+
+discovery.relabel "local_containers" {
+  targets = discovery.docker.local_containers.targets
+
+  rule {
+    source_labels = ["__meta_docker_container_name"]
+    target_label  = "service_name"
+  }
+
+  rule {
+    source_labels = ["__meta_docker_container_id"]
+    target_label  = "__container_id__"
+  }
+}
+
+pyroscope.ebpf "instance" {
+  forward_to = [pyroscope.write.endpoint.receiver]
+  targets    = discovery.relabel.local_containers.output
+  demangle   = "rust"
+}
+
+pyroscope.write "endpoint" {
+  endpoint {
+    url = "http://pyroscope:4040"
+  }
+}

--- a/etc/scripts/devnet/grafana/provisioning/datasources/pyroscope.yml
+++ b/etc/scripts/devnet/grafana/provisioning/datasources/pyroscope.yml
@@ -1,0 +1,9 @@
+apiVersion: 1
+
+datasources:
+  - name: Pyroscope
+    type: grafana-pyroscope-datasource
+    uid: pyroscope
+    access: proxy
+    url: http://pyroscope:4040
+    editable: false


### PR DESCRIPTION
We add the ability to have continuous profiling for binaries used in our devnet setup using grafana pyroscope and alloy.

<img width="1725" height="965" alt="Screenshot 2026-02-18 at 1 25 35 AM" src="https://github.com/user-attachments/assets/baf020f8-c824-453f-be70-7e5117be40f0" />

