### PR TITLE
chore(builder): Cleans Up Builder

### DIFF
--- a/crates/builder/core/src/flashblocks/args.rs
+++ b/crates/builder/core/src/flashblocks/args.rs
@@ -1,0 +1,27 @@
+use std::sync::Arc;
+
+use parking_lot::Mutex;
+use reth_basic_payload_builder::PayloadConfig;
+use reth_payload_primitives::BuiltPayload;
+use reth_primitives_traits::HeaderTy;
+use reth_revm::cached::CachedReads;
+use tokio_util::sync::CancellationToken;
+
+use crate::BlockCell;
+
+/// Build arguments
+#[derive(Debug)]
+pub struct BuildArguments<Attributes, Payload: BuiltPayload> {
+    /// Previously cached disk reads
+    pub cached_reads: CachedReads,
+    /// How to configure the payload.
+    pub config: PayloadConfig<Attributes, HeaderTy<Payload::Primitives>>,
+    /// A marker that can be used to cancel the job.
+    pub cancel: CancellationToken,
+    /// Mutex to synchronize cancellation with payload publishing.
+    pub publish_guard: Arc<Mutex<()>>,
+    /// Cell to store the finalized payload with state root.
+    pub finalized_cell: BlockCell<Payload>,
+    /// Whether to compute state root only on finalization (when `get_payload` is called).
+    pub compute_state_root_on_finalize: bool,
+}

--- a/crates/builder/core/src/flashblocks/cell.rs
+++ b/crates/builder/core/src/flashblocks/cell.rs
@@ -1,0 +1,72 @@
+use std::{
+    pin::Pin,
+    sync::Arc,
+    task::{Context, Poll},
+};
+
+use futures_util::Future;
+use parking_lot::Mutex;
+use tokio::sync::Notify;
+
+/// A cell that holds a value and allows waiting for it to be set.
+///
+/// Values can be overwritten by calling [`BlockCell::set`] multiple times.
+#[derive(Clone, Debug)]
+pub struct BlockCell<T> {
+    pub inner: Arc<Mutex<Option<T>>>,
+    pub notify: Arc<Notify>,
+}
+
+impl<T: Clone> BlockCell<T> {
+    pub fn new() -> Self {
+        Self { inner: Arc::new(Mutex::new(None)), notify: Arc::new(Notify::new()) }
+    }
+
+    pub fn set(&self, value: T) {
+        let mut inner = self.inner.lock();
+        *inner = Some(value);
+        self.notify.notify_one();
+    }
+
+    pub fn get(&self) -> Option<T> {
+        let inner = self.inner.lock();
+        inner.clone()
+    }
+
+    /// Return a future that resolves when a value is set.
+    pub fn wait_for_value(&self) -> WaitForValue<T> {
+        WaitForValue { cell: self.clone() }
+    }
+}
+
+/// Future that resolves when a value is set in [`BlockCell`].
+#[derive(Clone)]
+pub struct WaitForValue<T> {
+    pub cell: BlockCell<T>,
+}
+
+impl<T> std::fmt::Debug for WaitForValue<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("WaitForValue").finish_non_exhaustive()
+    }
+}
+
+impl<T: Clone> Future for WaitForValue<T> {
+    type Output = T;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        self.cell.get().map_or_else(
+            || {
+                cx.waker().wake_by_ref();
+                Poll::Pending
+            },
+            Poll::Ready,
+        )
+    }
+}
+
+impl<T: Clone> Default for BlockCell<T> {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/builder/core/src/flashblocks/info.rs
+++ b/crates/builder/core/src/flashblocks/info.rs
@@ -1,0 +1,16 @@
+//! Contains flashblocks execution info.
+
+use base_access_lists::FlashblockAccessListBuilder;
+
+/// Execution information specific to flashblocks.
+///
+/// Tracks the last consumed flashblock index and manages the
+/// flashblock-level access list builder for progressive block construction.
+#[derive(Debug, Default, Clone)]
+pub struct FlashblocksExecutionInfo {
+    /// Index of the last consumed flashblock
+    pub last_flashblock_index: usize,
+
+    /// Flashblock-level access list builder
+    pub access_list_builder: FlashblockAccessListBuilder,
+}

--- a/crates/builder/core/src/flashblocks/job.rs
+++ b/crates/builder/core/src/flashblocks/job.rs
@@ -1,0 +1,168 @@
+use std::{
+    pin::Pin,
+    sync::Arc,
+    task::{Context, Poll},
+};
+
+use futures_util::Future;
+use parking_lot::Mutex;
+use reth_basic_payload_builder::{HeaderForPayload, PayloadConfig};
+use reth_node_api::PayloadKind;
+use reth_payload_builder::{KeepPayloadJobAlive, PayloadBuilderError, PayloadJob};
+use reth_revm::cached::CachedReads;
+use reth_tasks::TaskSpawner;
+use tokio::{sync::oneshot, time::Sleep};
+use tokio_util::sync::CancellationToken;
+
+use crate::{BlockCell, BuildArguments, PayloadBuilder, ResolvePayload};
+
+/// A [`PayloadJob`] that builds empty blocks.
+pub struct BlockPayloadJob<Tasks, Builder>
+where
+    Builder: PayloadBuilder,
+{
+    /// The configuration for how the payload will be created.
+    pub config: PayloadConfig<Builder::Attributes, HeaderForPayload<Builder::BuiltPayload>>,
+    /// How to spawn building tasks
+    pub executor: Tasks,
+    /// The type responsible for building payloads.
+    ///
+    /// See [`PayloadBuilder`]
+    pub builder: Builder,
+    /// The cell that holds the built payload (intermediate flashblocks, may not have state root).
+    pub cell: BlockCell<Builder::BuiltPayload>,
+    /// The cell that holds the finalized payload with state root computed.
+    pub finalized_cell: BlockCell<Builder::BuiltPayload>,
+    /// Whether to compute state root only on finalization (when `get_payload` is called).
+    pub compute_state_root_on_finalize: bool,
+    /// Cancellation token for the running job
+    pub cancel: CancellationToken,
+    /// Mutex to synchronize cancellation with payload publishing.
+    pub publish_guard: Arc<Mutex<()>>,
+    pub deadline: Pin<Box<Sleep>>, // Add deadline
+    pub build_complete: Option<oneshot::Receiver<Result<(), PayloadBuilderError>>>,
+    /// Caches all disk reads for the state the new payloads build on
+    ///
+    /// This is used to avoid reading the same state over and over again when new attempts are
+    /// triggered, because during the building process we'll repeatedly execute the transactions.
+    pub cached_reads: Option<CachedReads>,
+}
+
+impl<Tasks, Builder> std::fmt::Debug for BlockPayloadJob<Tasks, Builder>
+where
+    Builder: PayloadBuilder,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("BlockPayloadJob")
+            .field("compute_state_root_on_finalize", &self.compute_state_root_on_finalize)
+            .finish_non_exhaustive()
+    }
+}
+
+impl<Tasks, Builder> PayloadJob for BlockPayloadJob<Tasks, Builder>
+where
+    Tasks: TaskSpawner + Clone + 'static,
+    Builder: PayloadBuilder + Unpin + 'static,
+    Builder::Attributes: Unpin + Clone,
+    Builder::BuiltPayload: Unpin + Clone,
+{
+    type PayloadAttributes = Builder::Attributes;
+    type ResolvePayloadFuture = ResolvePayload<Self::BuiltPayload>;
+    type BuiltPayload = Builder::BuiltPayload;
+
+    fn best_payload(&self) -> Result<Self::BuiltPayload, PayloadBuilderError> {
+        self.cell.get().ok_or_else(|| PayloadBuilderError::MissingPayload)
+    }
+
+    fn payload_attributes(&self) -> Result<Self::PayloadAttributes, PayloadBuilderError> {
+        Ok(self.config.attributes.clone())
+    }
+
+    fn resolve_kind(
+        &mut self,
+        kind: PayloadKind,
+    ) -> (Self::ResolvePayloadFuture, KeepPayloadJobAlive) {
+        tracing::info!("Resolve kind {:?}", kind);
+
+        // Acquire mutex before cancelling to synchronize with payload publishing.
+        {
+            let _guard = self.publish_guard.lock();
+            self.cancel.cancel();
+        }
+
+        let resolve_future = if self.compute_state_root_on_finalize {
+            ResolvePayload::new(self.finalized_cell.wait_for_value())
+        } else {
+            ResolvePayload::new(self.cell.wait_for_value())
+        };
+
+        (resolve_future, KeepPayloadJobAlive::No)
+    }
+}
+
+/// A [`PayloadJob`] is a future that's being polled by the `PayloadBuilderService`
+impl<Tasks, Builder> BlockPayloadJob<Tasks, Builder>
+where
+    Tasks: TaskSpawner + Clone + 'static,
+    Builder: PayloadBuilder + Unpin + 'static,
+    Builder::Attributes: Unpin + Clone,
+    Builder::BuiltPayload: Unpin + Clone,
+{
+    pub fn spawn_build_job(&mut self) {
+        let builder = self.builder.clone();
+        let payload_config = self.config.clone();
+        let cell = self.cell.clone();
+        let cancel = self.cancel.clone();
+        let publish_guard = Arc::clone(&self.publish_guard);
+        let finalized_cell = self.finalized_cell.clone();
+        let compute_state_root_on_finalize = self.compute_state_root_on_finalize;
+
+        let (tx, rx) = oneshot::channel();
+        self.build_complete = Some(rx);
+        let cached_reads = self.cached_reads.take().unwrap_or_default();
+        self.executor.spawn_blocking(Box::pin(async move {
+            let args = BuildArguments {
+                cached_reads,
+                config: payload_config,
+                cancel,
+                publish_guard,
+                finalized_cell,
+                compute_state_root_on_finalize,
+            };
+
+            let result = builder.try_build(args, cell).await;
+            let _ = tx.send(result);
+        }));
+    }
+}
+
+/// A [`PayloadJob`] is a future that's being polled by the `PayloadBuilderService`
+impl<Tasks, Builder> Future for BlockPayloadJob<Tasks, Builder>
+where
+    Tasks: TaskSpawner + Clone + 'static,
+    Builder: PayloadBuilder + Unpin + 'static,
+    Builder::Attributes: Unpin + Clone,
+    Builder::BuiltPayload: Unpin + Clone,
+{
+    type Output = Result<(), PayloadBuilderError>;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        tracing::trace!("Polling job");
+        let this = self.get_mut();
+
+        // Check if deadline is reached
+        if this.deadline.as_mut().poll(cx).is_ready() {
+            this.cancel.cancel();
+            tracing::debug!("Deadline reached");
+            return Poll::Ready(Ok(()));
+        }
+
+        // If cancelled via resolve_kind()
+        if this.cancel.is_cancelled() {
+            tracing::debug!("Job cancelled");
+            return Poll::Ready(Ok(()));
+        }
+
+        Poll::Pending
+    }
+}

--- a/crates/builder/core/src/flashblocks/mod.rs
+++ b/crates/builder/core/src/flashblocks/mod.rs
@@ -3,11 +3,20 @@
 mod best_txs;
 pub use best_txs::BestFlashblocksTxs;
 
+mod cell;
+pub use cell::{BlockCell, WaitForValue};
+
+mod resolve;
+pub use resolve::ResolvePayload;
+
+mod args;
+pub use args::BuildArguments;
+
+mod job;
+pub use job::BlockPayloadJob;
+
 mod generator;
-pub use generator::{
-    BlockCell, BlockPayloadJob, BlockPayloadJobGenerator, BuildArguments, ResolvePayload,
-    WaitForValue,
-};
+pub use generator::BlockPayloadJobGenerator;
 
 mod traits;
 pub use traits::PayloadBuilder;
@@ -21,8 +30,11 @@ pub use config::FlashblocksConfig;
 mod context;
 pub use context::{FlashblocksExtraCtx, OpPayloadBuilderCtx};
 
+mod info;
+pub use info::FlashblocksExecutionInfo;
+
 mod payload;
-pub use payload::FlashblocksExecutionInfo;
+pub use payload::OpPayloadBuilder;
 
 mod service;
 pub use service::FlashblocksServiceBuilder;

--- a/crates/builder/core/src/flashblocks/resolve.rs
+++ b/crates/builder/core/src/flashblocks/resolve.rs
@@ -1,0 +1,37 @@
+use std::{
+    pin::Pin,
+    task::{Context, Poll},
+};
+
+use futures_util::FutureExt;
+use reth_payload_builder::PayloadBuilderError;
+
+use crate::flashblocks::cell::WaitForValue;
+
+/// A future that resolves when a payload becomes available in the [`BlockCell`].
+pub struct ResolvePayload<T> {
+    pub future: WaitForValue<T>,
+}
+
+impl<T> std::fmt::Debug for ResolvePayload<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ResolvePayload").finish_non_exhaustive()
+    }
+}
+
+impl<T> ResolvePayload<T> {
+    pub const fn new(future: WaitForValue<T>) -> Self {
+        Self { future }
+    }
+}
+
+impl<T: Clone> Future for ResolvePayload<T> {
+    type Output = Result<T, PayloadBuilderError>;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        match self.get_mut().future.poll_unpin(cx) {
+            Poll::Ready(value) => Poll::Ready(Ok(value)),
+            Poll::Pending => Poll::Pending,
+        }
+    }
+}

--- a/crates/builder/core/src/flashblocks/service.rs
+++ b/crates/builder/core/src/flashblocks/service.rs
@@ -16,11 +16,9 @@ use reth_optimism_node::{
 use reth_payload_builder::{PayloadBuilderHandle, PayloadBuilderService};
 use reth_provider::CanonStateSubscriptions;
 
-use super::{PayloadHandler, generator::BlockPayloadJobGenerator, payload::OpPayloadBuilder};
 use crate::{
-    BuilderConfig,
-    metrics::BuilderMetrics,
-    traits::{NodeBounds, PoolBounds},
+    BlockPayloadJobGenerator, BuilderConfig, BuilderMetrics, NodeBounds, OpPayloadBuilder,
+    PayloadHandler, PoolBounds,
 };
 
 /// Builder for the flashblocks payload service.

--- a/crates/builder/core/src/lib.rs
+++ b/crates/builder/core/src/lib.rs
@@ -29,7 +29,8 @@ mod flashblocks;
 pub use flashblocks::{
     BestFlashblocksTxs, BlockCell, BlockPayloadJob, BlockPayloadJobGenerator, BuildArguments,
     FlashblocksConfig, FlashblocksExecutionInfo, FlashblocksExtraCtx, FlashblocksServiceBuilder,
-    OpPayloadBuilderCtx, PayloadBuilder, PayloadHandler, ResolvePayload, WaitForValue,
+    OpPayloadBuilder, OpPayloadBuilderCtx, PayloadBuilder, PayloadHandler, ResolvePayload,
+    WaitForValue,
 };
 
 #[cfg(any(test, feature = "test-utils"))]


### PR DESCRIPTION
## Summary

Small PR to refactor out some builder code to make it easier to decompose. This makes progress on refactoring out the builder logic to make each part testable.