### PR TITLE
fix: remove intermediate .to_vec() in flashblock tx hash collection

### DIFF
--- a/crates/builder/core/src/flashblocks/payload.rs
+++ b/crates/builder/core/src/flashblocks/payload.rs
@@ -550,7 +550,6 @@ where
         .wrap_err("failed to execute best transactions")?;
         // Extract last transactions
         let new_transactions = info.executed_transactions[info.extra.last_flashblock_index..]
-            .to_vec()
             .iter()
             .map(|tx| tx.tx_hash())
             .collect::<Vec<_>>();


### PR DESCRIPTION
Spotted a redundant .to_vec() while reading through build_next_flashblock — we slice into executed_transactions, clone everything into a new Vec, then immediately iterate to pull out tx hashes. Just using .iter() directly on the slice does the same thing without the extra allocation.