### PR TITLE
fix(ingress-rpc): correct test for reverting_tx_hashes validation

### DIFF
--- a/crates/infra/ingress-rpc/src/validation.rs
+++ b/crates/infra/ingress-rpc/src/validation.rs
@@ -302,7 +302,7 @@ mod tests {
 
         let gas = 4_000_000;
         let mut total_gas = 0u64;
-        for _ in 0..4 {
+        for _ in 0..3 {
             let mut tx = TxEip1559 {
                 chain_id: 1,
                 nonce: 0,
@@ -336,12 +336,12 @@ mod tests {
             ..Default::default()
         };
 
-        // Test should fail due to exceeding gas limit
+        // Test should fail due to mismatched reverting_tx_hashes
         let result = validate_bundle(&bundle, total_gas, tx_hashes);
         assert!(result.is_err());
         if let Err(e) = result {
             let error_message = format!("{e:?}");
-            assert!(error_message.contains("Bundle can only contain 3 transactions"));
+            assert!(error_message.contains("reverting_tx_hashes must include all hashes"));
         }
     }
 


### PR DESCRIPTION
`test_err_bundle_not_all_tx_hashes_in_reverting_tx_hashes` creates 4 transactions, which trips the tx count limit (`bundle.txs.len() > 3`) before ever reaching the `reverting_tx_hashes` check. The test passes but asserts the wrong error.

Reduced to 3 transactions so validation actually hits the `reverting_tx_hashes` path. Fixed the assertion and a copy-pasted comment.