### PR TITLE
docs: fix doc link in BaseAddOns builder method

### DIFF
--- a/crates/shared/node/src/add_ons.rs
+++ b/crates/shared/node/src/add_ons.rs
@@ -88,7 +88,7 @@ where
     N: FullNodeComponents<Types: OpNodeTypes>,
     OpEthApiBuilder<NetworkT>: EthApiBuilder<N>,
 {
-    /// Build a [`OpAddOns`] using [`OpAddOnsBuilder`].
+    /// Build a [`OpAddOns`] using [`BaseAddOnsBuilder`].
     pub fn builder() -> BaseAddOnsBuilder<NetworkT> {
         BaseAddOnsBuilder::default()
     }


### PR DESCRIPTION
Corrects the builder type reference from `OpAddOnsBuilder` to `BaseAddOnsBuilder`.