### PR TITLE
fix(basectl): add native-tls for wss:// flashblocks connections

### DIFF
--- a/crates/infra/basectl/Cargo.toml
+++ b/crates/infra/basectl/Cargo.toml
@@ -26,7 +26,7 @@ alloy-contract = { workspace = true }
 alloy-sol-types = { workspace = true }
 op-alloy-network = { workspace = true }
 alloy-primitives = { workspace = true }
-tokio-tungstenite = { workspace = true,features = ["native-tls"] }
+tokio-tungstenite = { workspace = true, features = ["native-tls"] }
 op-alloy-consensus = { workspace = true }
 alloy-rpc-types-eth = { workspace = true }
 url = { workspace = true, features = ["serde"] }

--- a/crates/infra/basectl/Cargo.toml
+++ b/crates/infra/basectl/Cargo.toml
@@ -26,7 +26,7 @@ alloy-contract = { workspace = true }
 alloy-sol-types = { workspace = true }
 op-alloy-network = { workspace = true }
 alloy-primitives = { workspace = true }
-tokio-tungstenite = { workspace = true }
+tokio-tungstenite = { workspace = true,features = ["native-tls"] }
 op-alloy-consensus = { workspace = true }
 alloy-rpc-types-eth = { workspace = true }
 url = { workspace = true, features = ["serde"] }


### PR DESCRIPTION
basectl can't connect to flashblocks on mainnet/sepolia — `tokio-tungstenite` is missing `native-tls`, so `connect_async("wss://...")` just errors out. You can repro by running basectl against mainnet, the flashblocks websocket fails immediately instead of streaming blocks.

The devnet and flashblocks crates already have `features = ["native-tls"]` on their `tokio-tungstenite` dep, this one just got missed.

Fix: enable `native-tls` in basectl's Cargo.toml to match the other crates.