### PR TITLE
fix(metering): prevent cross-block trie cache pollution from zero-hash flashblock headers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2885,6 +2885,7 @@ dependencies = [
  "alloy-genesis",
  "alloy-primitives",
  "alloy-rpc-client",
+ "alloy-rpc-types-engine",
  "arc-swap",
  "base-bundles",
  "base-client-node",

--- a/crates/client/flashblocks/src/pending_blocks.rs
+++ b/crates/client/flashblocks/src/pending_blocks.rs
@@ -18,6 +18,8 @@ use reth_rpc_convert::RpcTransaction;
 use reth_rpc_eth_api::{RpcBlock, RpcReceipt};
 use revm::state::EvmState;
 
+use alloy_rpc_types_engine::PayloadId;
+
 use crate::{BuildError, Metrics, PendingBlocksAPI, StateProcessorError, TransactionWithLogs};
 
 /// Builder for [`PendingBlocks`].
@@ -191,6 +193,12 @@ impl PendingBlocks {
     #[inline]
     pub fn earliest_block_number(&self) -> BlockNumber {
         self.earliest_header.number
+    }
+
+    /// Returns the payload ID for the current build attempt.
+    #[inline]
+    pub fn payload_id(&self) -> PayloadId {
+        self.flashblocks.first().map(|fb| fb.payload_id).unwrap_or_default()
     }
 
     /// Returns the index of the latest flashblock.

--- a/crates/client/flashblocks/src/pending_blocks.rs
+++ b/crates/client/flashblocks/src/pending_blocks.rs
@@ -8,6 +8,7 @@ use alloy_primitives::{
 };
 use alloy_provider::network::TransactionResponse;
 use alloy_rpc_types::{BlockTransactions, Withdrawal, state::StateOverride};
+use alloy_rpc_types_engine::PayloadId;
 use alloy_rpc_types_eth::{Filter, Header as RPCHeader, Log};
 use arc_swap::Guard;
 use base_primitives::Flashblock;
@@ -17,8 +18,6 @@ use reth_revm::db::BundleState;
 use reth_rpc_convert::RpcTransaction;
 use reth_rpc_eth_api::{RpcBlock, RpcReceipt};
 use revm::state::EvmState;
-
-use alloy_rpc_types_engine::PayloadId;
 
 use crate::{BuildError, Metrics, PendingBlocksAPI, StateProcessorError, TransactionWithLogs};
 

--- a/crates/client/metering/Cargo.toml
+++ b/crates/client/metering/Cargo.toml
@@ -37,6 +37,7 @@ op-revm.workspace = true
 alloy-eips.workspace = true
 alloy-consensus.workspace = true
 alloy-primitives.workspace = true
+alloy-rpc-types-engine.workspace = true
 
 # op-alloy
 op-alloy-consensus.workspace = true

--- a/crates/client/metering/src/rpc.rs
+++ b/crates/client/metering/src/rpc.rs
@@ -151,10 +151,11 @@ where
             let temp_state = PendingState { bundle_state: bundle_state.clone(), trie_input: None };
 
             // Ensure the pending trie input is cached for reuse across bundle simulations
+            let payload_id = pb.payload_id();
             let fb_index = state_flashblock_index.unwrap();
             let trie_input = self
                 .pending_trie_cache
-                .ensure_cached(header.number, fb_index, &temp_state, &*state_provider)
+                .ensure_cached(payload_id, fb_index, &temp_state, &*state_provider)
                 .map_err(|e| {
                     error!(error = %e, "Failed to cache pending trie input");
                     jsonrpsee::types::ErrorObjectOwned::owned(

--- a/crates/client/metering/src/rpc.rs
+++ b/crates/client/metering/src/rpc.rs
@@ -154,7 +154,7 @@ where
             let fb_index = state_flashblock_index.unwrap();
             let trie_input = self
                 .pending_trie_cache
-                .ensure_cached(header.hash(), fb_index, &temp_state, &*state_provider)
+                .ensure_cached(header.number, fb_index, &temp_state, &*state_provider)
                 .map_err(|e| {
                     error!(error = %e, "Failed to cache pending trie input");
                     jsonrpsee::types::ErrorObjectOwned::owned(

--- a/crates/client/metering/src/trie_cache.rs
+++ b/crates/client/metering/src/trie_cache.rs
@@ -126,8 +126,7 @@ mod tests {
     async fn ensure_cached_misses_on_different_payload_id() -> eyre::Result<()> {
         let harness = TestHarness::new().await?;
         let latest = harness.latest_block();
-        let state_provider =
-            harness.blockchain_provider().state_by_block_hash(latest.hash())?;
+        let state_provider = harness.blockchain_provider().state_by_block_hash(latest.hash())?;
 
         let alice = Account::Alice.address();
         let flashblock_index = 0;


### PR DESCRIPTION
Flashblock headers are sealed with `B256::ZERO`, so `header.hash()` always returns zero. This makes the trie cache key degenerate to `(0x00..00, flashblock_index)`, meaning different canonical blocks with the same flashblock index share the same cache entry.

Example: canonical block 1 produces flashblock 0, trie gets cached with key `(0x00..00, 0)`. Canonical block 2 also produces flashblock 0 — cache hits on the stale entry from block 1, bundle simulation runs against wrong state.

Fix: use `header.number` (which is unique per pending block) instead of `header.hash()` as cache key.
