### PR TITLE
fix(alloy): Double Panic in RPC Types

### DIFF
--- a/crates/alloy/rpc-types/src/receipt.rs
+++ b/crates/alloy/rpc-types/src/receipt.rs
@@ -129,9 +129,11 @@ mod l1_fee_scalar_serde {
     }
 }
 
-impl From<OpTransactionReceiptFields> for OtherFields {
-    fn from(value: OpTransactionReceiptFields) -> Self {
-        serde_json::to_value(value).unwrap().try_into().unwrap()
+impl TryFrom<OpTransactionReceiptFields> for OtherFields {
+    type Error = serde_json::Error;
+
+    fn try_from(value: OpTransactionReceiptFields) -> Result<Self, Self::Error> {
+        serde_json::to_value(value)?.try_into()
     }
 }
 

--- a/crates/alloy/rpc-types/src/transaction.rs
+++ b/crates/alloy/rpc-types/src/transaction.rs
@@ -187,9 +187,11 @@ pub struct OpTransactionFields {
     pub deposit_receipt_version: Option<u64>,
 }
 
-impl From<OpTransactionFields> for OtherFields {
-    fn from(value: OpTransactionFields) -> Self {
-        serde_json::to_value(value).unwrap().try_into().unwrap()
+impl TryFrom<OpTransactionFields> for OtherFields {
+    type Error = serde_json::Error;
+
+    fn try_from(value: OpTransactionFields) -> Result<Self, Self::Error> {
+        serde_json::to_value(value)?.try_into()
     }
 }
 


### PR DESCRIPTION
## Summary

As [identified by github-actions bot](https://github.com/base/base/pull/753#discussion_r2824730951), there was a double unwrap in rpc-types conversion. Regardless of whether this was in the hot path previously or not, this PR fixes it to use a proper `TryFrom` impl.