### PR TITLE
perf: Make bundle max_timestamp validation window configurable

### DIFF
--- a/crates/infra/ingress-rpc/src/lib.rs
+++ b/crates/infra/ingress-rpc/src/lib.rs
@@ -167,6 +167,10 @@ pub struct Config {
     #[arg(long, env = "TIPS_INGRESS_RAW_TX_FORWARD_RPC")]
     pub raw_tx_forward_rpc: Option<Url>,
 
+    /// Maximum time window (in seconds) into the future that a bundle's max_timestamp is allowed
+    #[arg(long, env = "TIPS_INGRESS_BUNDLE_MAX_TIMESTAMP_WINDOW_SECONDS", default_value = "3600")]
+    pub bundle_max_timestamp_window_seconds: u64,
+
     /// TTL for bundle cache in seconds
     #[arg(long, env = "TIPS_INGRESS_BUNDLE_CACHE_TTL", default_value = "20")]
     pub bundle_cache_ttl: u64,

--- a/crates/infra/ingress-rpc/src/lib.rs
+++ b/crates/infra/ingress-rpc/src/lib.rs
@@ -167,7 +167,7 @@ pub struct Config {
     #[arg(long, env = "TIPS_INGRESS_RAW_TX_FORWARD_RPC")]
     pub raw_tx_forward_rpc: Option<Url>,
 
-    /// Maximum time window (in seconds) into the future that a bundle's max_timestamp is allowed
+    /// Maximum time window (in seconds) into the future that a bundle's `max_timestamp` is allowed
     #[arg(long, env = "TIPS_INGRESS_BUNDLE_MAX_TIMESTAMP_WINDOW_SECONDS", default_value = "3600")]
     pub bundle_max_timestamp_window_seconds: u64,
 

--- a/crates/infra/ingress-rpc/src/service.rs
+++ b/crates/infra/ingress-rpc/src/service.rs
@@ -383,7 +383,7 @@ impl<Q: MessageQueue> IngressService<Q> {
             total_gas = total_gas.saturating_add(transaction.gas_limit());
             tx_hashes.push(transaction.tx_hash());
         }
-        validate_bundle(bundle, total_gas, tx_hashes)?;
+        validate_bundle(bundle, total_gas, tx_hashes, 3600)?;
 
         self.metrics.validate_bundle_duration.record(start.elapsed().as_secs_f64());
         Ok(())

--- a/crates/infra/ingress-rpc/src/validation.rs
+++ b/crates/infra/ingress-rpc/src/validation.rs
@@ -1,6 +1,6 @@
 use std::{
     collections::HashSet,
-    time::{Duration, SystemTime, UNIX_EPOCH},
+    time::{SystemTime, UNIX_EPOCH},
 };
 
 use alloy_consensus::private::alloy_eips::{BlockId, BlockNumberOrTag};
@@ -96,7 +96,7 @@ impl L1BlockInfoLookup for RootProvider<Optimism> {
 }
 
 /// Helper function to validate properties of a bundle. A bundle is valid if it satisfies the following criteria:
-/// - The bundle's `max_timestamp` is not more than 1 hour in the future
+/// - The bundle's `max_timestamp` is not more than `max_timestamp_window_secs` seconds in the future
 /// - The bundle's gas limit is not greater than the maximum allowed gas limit
 /// - The bundle can only contain 3 transactions at once
 /// - Partial transaction dropping is not supported, `dropping_tx_hashes` must be empty
@@ -113,9 +113,9 @@ pub fn validate_bundle(
     if let Some(max_timestamp) = bundle.max_timestamp
         && max_timestamp > valid_timestamp_window
     {
-        return Err(EthApiError::InvalidParams(
-            "Bundle cannot be more than 1 hour in the future".into(),
-        )
+        return Err(EthApiError::InvalidParams(format!(
+            "Bundle cannot be more than {max_timestamp_window_secs} seconds in the future",
+        ))
         .into_rpc_err());
     }
 
@@ -177,7 +177,7 @@ mod tests {
         assert_eq!(
             validate_bundle(&bundle, 0, vec![], 3600),
             Err(EthApiError::InvalidParams(
-                "Bundle cannot be more than 1 hour in the future".into()
+                "Bundle cannot be more than 3600 seconds in the future".into()
             )
             .into_rpc_err())
         );

--- a/crates/infra/ingress-rpc/src/validation.rs
+++ b/crates/infra/ingress-rpc/src/validation.rs
@@ -108,8 +108,8 @@ pub fn validate_bundle(
     max_timestamp_window_secs: u64,
 ) -> RpcResult<()> {
     // Don't allow bundles to be submitted too far into the future
-    let valid_timestamp_window = SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_secs()
-        + max_timestamp_window_secs;
+    let valid_timestamp_window =
+        SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_secs() + max_timestamp_window_secs;
     if let Some(max_timestamp) = bundle.max_timestamp
         && max_timestamp > valid_timestamp_window
     {


### PR DESCRIPTION
The 1-hour window for bundle `max_timestamp` validation was hardcoded. This adds a `bundle_max_timestamp_window_seconds` config (env `TIPS_INGRESS_BUNDLE_MAX_TIMESTAMP_WINDOW_SECONDS`, defaults to 3600) so it can be tuned per deployment. Resolves the TODO in `validate_bundle`.