### PR TITLE
feat(alloy-consensus): re-enable InMemorySize impls for OP types

### DIFF
--- a/crates/alloy/consensus/src/lib.rs
+++ b/crates/alloy/consensus/src/lib.rs
@@ -32,8 +32,7 @@ pub use eip1559::{
 mod source;
 pub use source::*;
 
-// TODO: re-enable once alloy-consensus exports `InMemorySize`
-// mod size;
+mod size;
 
 mod block;
 pub use block::OpBlock;


### PR DESCRIPTION
impl todo

alloy-consensus 1.7.3 now exports `InMemorySize`, so the size module can be re-enabled.