### PR TITLE
docs: add Foundry to prerequisites

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Base Reth Node is a Reth-based Ethereum node implementation, specifically tailor
 
 - **Rust:** Version 1.88 or later (matches the `rust-version` in `Cargo.toml`). You can install Rust using [rustup](https://rustup.rs/).
 - **Just:** A command runner. Installation instructions can be found [here](https://github.com/casey/just#installation).
+- **Foundry:** Required for compiling Solidity test contracts (`just build-contracts`). Install via [foundry.sh](https://getfoundry.sh/).
 - **Docker:** (Optional) For building and running the node in a container. See [Docker installation guide](https://docs.docker.com/get-docker/).
 - **Build Essentials:** `git`, `libclang-dev`, `pkg-config`, `curl`, `build-essential` (these are installed in the Docker build process and may be needed for local builds on some systems).
 

--- a/crates/client/engine/src/lib.rs
+++ b/crates/client/engine/src/lib.rs
@@ -1,5 +1,6 @@
-//! Implements custom engine validator that is optimized for validating canonical blocks
-//! after flashblock validation.
+#![doc = include_str!("../README.md")]
+#![doc(issue_tracker_base_url = "https://github.com/base/base/issues/")]
+#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 
-pub mod validator;
+mod validator;
 pub use validator::{BaseEngineValidator, BaseEngineValidatorBuilder};


### PR DESCRIPTION
While working on #777, `cargo check --workspace` failed with a cryptic `failed to canonicalize path` error pointing at missing JSON files in `contracts/out/`. Turns out the `sol!()` macro in `test_utils/contracts.rs` needs compiled Solidity artifacts, which are generated by `just build-contracts` — but Foundry wasn't listed as a prerequisite in the README. Added it so new contributors don't hit the same wall.
