### PR TITLE
docs: clarify repository name vs product name in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 ![Base](docs/assets/logo.png)
 
-# Base Reth Node
+# Base
 
 > [!WARNING]
 > This repository is for development purposes. For production deployments, please use the releases referenced in [base/node](https://github.com/base/node/releases).
 
-Base Reth Node is a Reth-based Ethereum node implementation, specifically tailored for the Base L2 network. It integrates Flashblocks capabilities and leverages Optimism components from Reth (see the version pinned in [Cargo.toml](Cargo.toml)). This node is designed to provide a robust and efficient solution for interacting with the Base network.
+This repository (`base/base`, previously `base/node-reth`) contains **Base Reth Node**: a Reth-based Ethereum node implementation tailored for the Base L2 network. It integrates Flashblocks capabilities and leverages Optimism components from Reth (see the version pinned in [Cargo.toml](Cargo.toml)). This node is designed to provide a robust and efficient solution for interacting with the Base network.
 
 <!-- Badge row 1 - status -->
 


### PR DESCRIPTION


Updated README to clarify that this repository (`base/base`) contains **Base Reth Node**, rather than being named "Base Reth Node" itself.

