### PR TITLE
fix(websocket-proxy): bypass filter for non-data messages

### DIFF
--- a/crates/infra/websocket-proxy/src/registry.rs
+++ b/crates/infra/websocket-proxy/src/registry.rs
@@ -63,11 +63,12 @@ impl Registry {
                 broadcast_result = receiver.recv() => {
                     match broadcast_result {
                         Ok(msg) => {
+                            let is_data_message = matches!(&msg, Message::Binary(_) | Message::Text(_));
                             let msg_bytes = match &msg {
                                 Message::Binary(data) => data.as_ref(),
                                 _ => &[],
                             };
-                            if filter.matches(msg_bytes, compressed) {
+                            if !is_data_message || filter.matches(msg_bytes, compressed) {
                                 trace!(message = "filter matched for client", client = client_id, filter = ?filter);
 
                                 let send_start = Instant::now();


### PR DESCRIPTION
## Summary
- Ping/Pong/Close frames sent through the broadcast channel were being passed through `filter.matches()`, which parses the payload as JSON
- For non-Binary messages the payload is empty, so `filter.matches()` returns `false` and the frame is silently dropped
- Filtered clients never receive Ping frames, never send Pong, and get disconnected after `pong_timeout_ms` when `client_ping_enabled=true`
- Skip the filter check for non-data messages so control frames always reach clients

Fixes #784