### PR TITLE
fix: typos, grammar errors, and missing prepositions

### DIFF
--- a/crates/consensus/derive/src/stages/batch/batch_queue.rs
+++ b/crates/consensus/derive/src/stages/batch/batch_queue.rs
@@ -28,7 +28,7 @@ use crate::{
 /// block inside that range have been added to the stage by the time that it attempts to advance a
 /// full epoch.
 ///
-/// It is internally responsible for making sure that batches with L1 inclusions block outside it's
+/// It is internally responsible for making sure that batches with L1 inclusions block outside its
 /// working range are not considered or pruned.
 #[derive(Debug)]
 pub struct BatchQueue<P, BF>

--- a/crates/consensus/hardforks/README.md
+++ b/crates/consensus/hardforks/README.md
@@ -9,6 +9,6 @@ Consensus layer hardfork types for the OP Stack including network upgrade transa
 
 ### Provenance
 
-This code was ported [op-alloy] as part of `kona` monorepo migrations.
+This code was ported from [op-alloy] as part of `kona` monorepo migrations.
 
 [op-alloy]: https://github.com/alloy-rs/op-alloy

--- a/crates/execution/payload/src/builder.rs
+++ b/crates/execution/payload/src/builder.rs
@@ -443,7 +443,7 @@ impl<Txs> OpBuilder<'_, Txs> {
     }
 }
 
-/// A type that returns a the [`PayloadTransactions`] that should be included in the pool.
+/// A type that returns the [`PayloadTransactions`] that should be included in the pool.
 pub trait OpPayloadTransactions<Transaction>: Clone + Send + Sync + Unpin + 'static {
     /// Returns an iterator that yields the transaction in the order they should get included in the
     /// new payload.
@@ -662,7 +662,7 @@ where
 
     /// Executes the given best transactions and updates the execution info.
     ///
-    /// Returns `Ok(Some(())` if the job was cancelled.
+    /// Returns `Ok(Some(()))` if the job was cancelled.
     pub fn execute_best_transactions<Builder>(
         &self,
         info: &mut ExecutionInfo,


### PR DESCRIPTION


Fixed typos, grammar errors, and missing prepositions across documentation and code comments.

