### PR TITLE
fix: resolve clippy warnings in enr.rs and hint.rs

### DIFF
--- a/crates/consensus/peers/src/enr.rs
+++ b/crates/consensus/peers/src/enr.rs
@@ -132,7 +132,7 @@ mod tests {
     fn roundtrip_op_stack_enr() {
         arbtest::arbtest(|u| {
             let op_stack_enr = OpStackEnr::from_chain_id(u.arbitrary()?);
-            let bytes = alloy_rlp::encode(op_stack_enr).to_vec();
+            let bytes = alloy_rlp::encode(op_stack_enr);
             let decoded = OpStackEnr::decode(&mut &bytes[..]).unwrap();
             assert_eq!(decoded, op_stack_enr);
             Ok(())

--- a/crates/proof/preimage/src/hint.rs
+++ b/crates/proof/preimage/src/hint.rs
@@ -154,6 +154,8 @@ mod test {
         let client = tokio::task::spawn(async move {
             let hint_writer = HintWriter::new(hint_channel.client);
 
+            // SAFETY: This is intentionally invalid UTF-8 to test error handling.
+            // The test verifies that invalid UTF-8 causes an error on the host side.
             #[allow(invalid_from_utf8_unchecked)]
             hint_writer.write(unsafe { alloc::str::from_utf8_unchecked(&mock_data) }).await
         });


### PR DESCRIPTION
- Remove redundant `.to_vec()` call in `enr.rs` - `alloy_rlp::encode()` already returns `Vec<u8>`
- Add SAFETY comment for unsafe block in `hint.rs` to satisfy `clippy::undocumented_unsafe_blocks`