### PR TITLE
fix: retry on MissingCanonicalHeader to prevent flashblocks processor stall

### DIFF
--- a/crates/client/flashblocks/src/metrics.rs
+++ b/crates/client/flashblocks/src/metrics.rs
@@ -104,6 +104,10 @@ pub struct Metrics {
     )]
     pub rpc_get_block_transaction_count_by_number: Counter,
 
+    /// Count of retries waiting for a canonical header to become available.
+    #[metric(describe = "Count of retries waiting for a canonical header to become available")]
+    pub canonical_header_retries: Counter,
+
     /// Time taken to clone bundle state.
     #[metric(describe = "Time taken to clone bundle state")]
     pub bundle_state_clone_duration: Histogram,


### PR DESCRIPTION
Summary
- Adds retry logic with exponential backoff when MissingCanonicalHeader is encountered during flashblock processing
- After a node restart, snapshot restore, or initial sync, canonical headers may not be immediately available — previously this caused the update to be discarded and the processor to stall
- Retries up to 10 times (200ms → 1s backoff) to allow the header to become available before giving up
- Adds a canonical_header_retries counter metric for observability

Test plan
 - Verify the node recovers gracefully after a restart when flashblocks arrive before canonical headers are synced
 - Monitor canonical_header_retries metric to confirm retries are happening as expected
 - Confirm no regression in steady-state flashblock processing (no retries when headers are available)

Fixes #826