### PR TITLE
fix(basectl): remove table state clone

### DIFF
--- a/crates/infra/basectl/src/app/views/flashblocks.rs
+++ b/crates/infra/basectl/src/app/views/flashblocks.rs
@@ -294,6 +294,6 @@ impl View for FlashblocksView {
 
         let table = Table::new(rows, widths).header(header);
 
-        frame.render_stateful_widget(table, inner, &mut self.table_state.clone());
+        frame.render_stateful_widget(table, inner, &mut self.table_state);
     }
 }


### PR DESCRIPTION
Remove the redundant table state clone, allowing the widget to correctly persist its scrolling offset.
