### PR TITLE
fix(builder): correct reduced_flashblocks_number metric calculation

### DIFF
--- a/crates/builder/core/src/flashblocks/payload.rs
+++ b/crates/builder/core/src/flashblocks/payload.rs
@@ -322,8 +322,7 @@ where
             flashblocks_interval = self.config.flashblocks.interval.as_millis(),
         );
         ctx.metrics.reduced_flashblocks_number.record(
-            self.config.flashblocks_per_block().saturating_sub(ctx.target_flashblock_count())
-                as f64,
+            self.config.flashblocks_per_block().saturating_sub(flashblocks_per_block) as f64,
         );
         ctx.metrics.first_flashblock_time_offset.record(first_flashblock_offset.as_millis() as f64);
         let gas_per_batch = ctx.block_gas_limit() / flashblocks_per_block;


### PR DESCRIPTION
The reduced_flashblocks_number metric was always recording 0 because it compared config value against itself. Now it correctly compares the configured flashblocks count with the dynamically calculated one, showing how many flashblocks were skipped due to time drift.