### PR TITLE
fix(node): require --proofs-history.storage-path when --proofs-history is set

### DIFF
--- a/crates/execution/node/src/args.rs
+++ b/crates/execution/node/src/args.rs
@@ -46,6 +46,7 @@ pub struct RollupArgs {
     #[arg(
         long = "proofs-history",
         value_name = "PROOFS_HISTORY",
+        requires = "proofs_history_storage_path",
         default_value_ifs([
             ("proofs-history.storage-path", ArgPredicate::IsPresent, "true")
         ])

--- a/crates/execution/node/src/proof_history.rs
+++ b/crates/execution/node/src/proof_history.rs
@@ -20,9 +20,7 @@ use tracing::info;
 
 use crate::{OpNode, args::RollupArgs};
 
-/// - no proofs history (plain node),
-/// - in-mem proofs storage,
-/// - MDBX proofs storage.
+/// Launches a node optionally configured with on-disk MDBX proofs history.
 pub async fn launch_node_with_proof_history(
     builder: WithLaunchContext<NodeBuilder<Arc<DatabaseEnv>, OpChainSpec>>,
     args: RollupArgs,
@@ -42,7 +40,7 @@ pub async fn launch_node_with_proof_history(
         let path = args
             .proofs_history_storage_path
             .clone()
-            .expect("Path must be provided if not using in-memory storage");
+            .expect("--proofs-history.storage-path is required when --proofs-history is enabled");
         info!(target: "reth::cli", "Using on-disk storage for proofs history");
 
         let mdbx = Arc::new(


### PR DESCRIPTION
Without this, passing --proofs-history alone silently starts the node and panics at runtime on an .expect(). Added the missing requires constraint (same pattern as sequencer_headers → sequencer) so clap catches it at parse time. Also cleaned up stale references to the removed in-memory storage mode.