### PR TITLE
fix(alloy): handle Legacy variant in From<OpTxEnvelope> for OpTransactionRequest

### DIFF
--- a/crates/alloy/rpc-types/src/transaction/request.rs
+++ b/crates/alloy/rpc-types/src/transaction/request.rs
@@ -190,11 +190,11 @@ impl From<OpTypedTransaction> for OpTransactionRequest {
 impl From<OpTxEnvelope> for OpTransactionRequest {
     fn from(value: OpTxEnvelope) -> Self {
         match value {
+            OpTxEnvelope::Legacy(tx) => tx.into(),
             OpTxEnvelope::Eip2930(tx) => tx.into(),
             OpTxEnvelope::Eip1559(tx) => tx.into(),
             OpTxEnvelope::Eip7702(tx) => tx.into(),
             OpTxEnvelope::Deposit(tx) => tx.into(),
-            _ => Default::default(),
         }
     }
 }


### PR DESCRIPTION
Legacy transactions were hitting the _ => Default::default() fallback, silently returning an empty request with all fields dropped. Added the missing Legacy arm and removed the wildcard so the compiler catches any future new variants.