### PR TITLE
fix: correct upstream connection metric decrement

### DIFF
--- a/crates/infra/websocket-proxy/src/subscriber.rs
+++ b/crates/infra/websocket-proxy/src/subscriber.rs
@@ -146,7 +146,6 @@ where
                                 error = e.to_string()
                             );
                             self.metrics.upstream_errors.increment(1);
-                            self.metrics.upstream_connections.decrement(1);
 
                             if let Some(duration) = self.backoff.next_backoff() {
                                 warn!(
@@ -243,6 +242,7 @@ where
         };
 
         ping_task.abort();
+        self.metrics.upstream_connections.decrement(1);
         result
     }
 


### PR DESCRIPTION
Moves `upstream_connections.decrement()` to function exit, ensuring it's called exactly once per connection instead of multiple times during reconnection attempts.