### PR TITLE
docs(consensus): fix typo in EIP-1559 params comment

### DIFF
--- a/crates/alloy/consensus/src/eip1559.rs
+++ b/crates/alloy/consensus/src/eip1559.rs
@@ -34,7 +34,7 @@ fn encode_eip_1559_params(
     Ok(())
 }
 
-/// Extracts the Holocene 1599 parameters from the encoded form:
+/// Extracts the Holocene 1559 parameters from the encoded form:
 /// <https://github.com/ethereum-optimism/specs/blob/main/specs/protocol/holocene/exec-engine.md#eip1559params-encoding>
 ///
 /// Returns (`elasticity`, `denominator`)

--- a/crates/alloy/consensus/src/eip1559.rs
+++ b/crates/alloy/consensus/src/eip1559.rs
@@ -34,8 +34,9 @@ fn encode_eip_1559_params(
     Ok(())
 }
 
-/// Extracts the Holocene 1559 parameters from the encoded form:
-/// <https://github.com/ethereum-optimism/specs/blob/main/specs/protocol/holocene/exec-engine.md#eip1559params-encoding>
+/// Extracts the EIP-1559 parameters from the encoded form.
+///
+/// Used by both Holocene and Jovian hardforks to decode the 8-byte EIP-1559 parameter encoding.
 ///
 /// Returns (`elasticity`, `denominator`)
 pub fn decode_eip_1559_params(eip_1559_params: B64) -> (u32, u32) {


### PR DESCRIPTION
Correct a typo in the documentation, changing `1599` to `1559`.