### PR TITLE
fix(docker): serialize access to shared cargo cache mounts

### DIFF
--- a/etc/docker/Dockerfile.audit-archiver
+++ b/etc/docker/Dockerfile.audit-archiver
@@ -19,15 +19,15 @@ ARG PROFILE=release
 COPY --from=planner /app/recipe.json recipe.json
 
 # Build dependencies - THIS LAYER IS CACHED until Cargo.toml/Cargo.lock change
-RUN --mount=type=cache,target=/usr/local/cargo/registry \
-    --mount=type=cache,target=/usr/local/cargo/git \
+RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
+    --mount=type=cache,target=/usr/local/cargo/git,sharing=locked \
     --mount=type=cache,target=/app/target,id=audit-archiver-target \
     cargo chef cook --profile $PROFILE --recipe-path recipe.json
 
 # Now copy source and build (only your code compiles here)
 COPY . .
-RUN --mount=type=cache,target=/usr/local/cargo/registry \
-    --mount=type=cache,target=/usr/local/cargo/git \
+RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
+    --mount=type=cache,target=/usr/local/cargo/git,sharing=locked \
     --mount=type=cache,target=/app/target,id=audit-archiver-target \
     cargo build --profile $PROFILE --bin audit-archiver && \
     cp /app/target/$([ "$PROFILE" = "dev" ] && echo debug || echo $PROFILE)/audit-archiver /app/audit-archiver

--- a/etc/docker/Dockerfile.builder
+++ b/etc/docker/Dockerfile.builder
@@ -19,15 +19,15 @@ ARG PROFILE=release
 COPY --from=planner /app/recipe.json recipe.json
 
 # Build dependencies - THIS LAYER IS CACHED until Cargo.toml/Cargo.lock change
-RUN --mount=type=cache,target=/usr/local/cargo/registry \
-    --mount=type=cache,target=/usr/local/cargo/git \
+RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
+    --mount=type=cache,target=/usr/local/cargo/git,sharing=locked \
     --mount=type=cache,target=/app/target,id=builder-target \
     cargo chef cook --profile $PROFILE --recipe-path recipe.json
 
 # Now copy source and build (only your code compiles here)
 COPY . .
-RUN --mount=type=cache,target=/usr/local/cargo/registry \
-    --mount=type=cache,target=/usr/local/cargo/git \
+RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
+    --mount=type=cache,target=/usr/local/cargo/git,sharing=locked \
     --mount=type=cache,target=/app/target,id=builder-target \
     cargo build --profile $PROFILE --bin base-builder && \
     cp /app/target/$([ "$PROFILE" = "dev" ] && echo debug || echo $PROFILE)/base-builder /app/base-builder

--- a/etc/docker/Dockerfile.client
+++ b/etc/docker/Dockerfile.client
@@ -19,15 +19,15 @@ ARG PROFILE=release
 COPY --from=planner /app/recipe.json recipe.json
 
 # Build dependencies - THIS LAYER IS CACHED until Cargo.toml/Cargo.lock change
-RUN --mount=type=cache,target=/usr/local/cargo/registry \
-    --mount=type=cache,target=/usr/local/cargo/git \
+RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
+    --mount=type=cache,target=/usr/local/cargo/git,sharing=locked \
     --mount=type=cache,target=/app/target,id=client-target \
     cargo chef cook --profile $PROFILE --recipe-path recipe.json
 
 # Now copy source and build (only your code compiles here)
 COPY . .
-RUN --mount=type=cache,target=/usr/local/cargo/registry \
-    --mount=type=cache,target=/usr/local/cargo/git \
+RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
+    --mount=type=cache,target=/usr/local/cargo/git,sharing=locked \
     --mount=type=cache,target=/app/target,id=client-target \
     cargo build --profile $PROFILE --bin base-reth-node && \
     cp /app/target/$([ "$PROFILE" = "dev" ] && echo debug || echo $PROFILE)/base-reth-node /app/base-client

--- a/etc/docker/Dockerfile.ingress-rpc
+++ b/etc/docker/Dockerfile.ingress-rpc
@@ -19,15 +19,15 @@ ARG PROFILE=release
 COPY --from=planner /app/recipe.json recipe.json
 
 # Build dependencies - THIS LAYER IS CACHED until Cargo.toml/Cargo.lock change
-RUN --mount=type=cache,target=/usr/local/cargo/registry \
-    --mount=type=cache,target=/usr/local/cargo/git \
+RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
+    --mount=type=cache,target=/usr/local/cargo/git,sharing=locked \
     --mount=type=cache,target=/app/target,id=ingress-rpc-target \
     cargo chef cook --profile $PROFILE --recipe-path recipe.json
 
 # Now copy source and build (only your code compiles here)
 COPY . .
-RUN --mount=type=cache,target=/usr/local/cargo/registry \
-    --mount=type=cache,target=/usr/local/cargo/git \
+RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
+    --mount=type=cache,target=/usr/local/cargo/git,sharing=locked \
     --mount=type=cache,target=/app/target,id=ingress-rpc-target \
     cargo build --profile $PROFILE --bin ingress-rpc && \
     cp /app/target/$([ "$PROFILE" = "dev" ] && echo debug || echo $PROFILE)/ingress-rpc /app/ingress-rpc


### PR DESCRIPTION
## Summary
- Adds `sharing=locked` to the cargo git and registry `--mount=type=cache` directives in all 4 Rust Dockerfiles (builder, client, ingress-rpc, audit-archiver)
- When `docker compose up --build` builds these images concurrently, the default `sharing=shared` allows multiple cargo processes to write to the same git cache simultaneously, corrupting the clone of large repos (like reth) and causing `revision not found` errors
- `sharing=locked` serializes access so one build completes its git fetch before the next begins

## Test plan
- [x] Verified `docker build` succeeds for individual images
- [x] Verified `just devnet-ingress` succeeds with all services starting (full concurrent compose build)