### PR TITLE
chore(genesis): handle deprecated `hardfork_config()` method

### DIFF
--- a/crates/consensus/genesis/src/rollup.rs
+++ b/crates/consensus/genesis/src/rollup.rs
@@ -313,13 +313,6 @@ impl RollupConfig {
             self.channel_timeout
         }
     }
-
-    /// Returns the [`HardForkConfig`] using [`RollupConfig`] timestamps.
-    #[deprecated(since = "0.1.0", note = "Use the `hardforks` field instead.")]
-    pub const fn hardfork_config(&self) -> HardForkConfig {
-        self.hardforks
-    }
-
     /// Computes a block number from a timestamp, relative to the L2 genesis time and the block
     /// time.
     ///


### PR DESCRIPTION
This has been deprecated since 0.1.0 and has zero callers — everyone already uses the `hardforks` field directly. Just dead code at this point.