### PR TITLE
fix: revert flashblock metadata changes temporarily

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2992,6 +2992,7 @@ dependencies = [
  "bytes",
  "eyre",
  "kona-genesis",
+ "reth-optimism-primitives",
  "rstest",
  "serde",
  "serde_json",

--- a/crates/client/flashblocks-node/benches/pending_state.rs
+++ b/crates/client/flashblocks-node/benches/pending_state.rs
@@ -222,7 +222,7 @@ fn base_flashblock(
             transactions: vec![BLOCK_INFO_TXN],
             blob_gas_used: Default::default(),
         },
-        metadata: Metadata { block_number },
+        metadata: Metadata { block_number, ..Default::default() },
     }
 }
 
@@ -254,7 +254,7 @@ fn transaction_flashblock(
             transactions: tx_bytes,
             blob_gas_used: Default::default(),
         },
-        metadata: Metadata { block_number },
+        metadata: Metadata { block_number, ..Default::default() },
     }
 }
 

--- a/crates/client/flashblocks-node/src/test_harness.rs
+++ b/crates/client/flashblocks-node/src/test_harness.rs
@@ -612,7 +612,11 @@ impl<'a> FlashblockBuilder<'a> {
                 transactions: self.transactions.clone(),
                 blob_gas_used: Default::default(),
             },
-            metadata: Metadata { block_number: canonical_block_num },
+            metadata: Metadata {
+                receipts: self.receipts.clone().unwrap_or_default().into_iter().collect(),
+                block_number: canonical_block_num,
+                ..Default::default()
+            },
         }
     }
 }

--- a/crates/client/flashblocks-node/tests/eip7702_tests.rs
+++ b/crates/client/flashblocks-node/tests/eip7702_tests.rs
@@ -140,7 +140,7 @@ fn create_base_flashblock(setup: &TestSetup) -> Flashblock {
             transactions: vec![L1_BLOCK_INFO_DEPOSIT_TX, setup.account_deploy_tx.clone()],
             ..Default::default()
         },
-        metadata: Metadata { block_number: 1 },
+        metadata: Metadata { block_number: 1, ..Default::default() },
     }
 }
 
@@ -160,7 +160,7 @@ fn create_eip7702_flashblock(eip7702_tx: Bytes, cumulative_gas: u64) -> Flashblo
             logs_bloom: Default::default(),
             withdrawals_root: Default::default(),
         },
-        metadata: Metadata { block_number: 1 },
+        metadata: Metadata { block_number: 1, ..Default::default() },
     }
 }
 
@@ -265,7 +265,7 @@ async fn test_eip7702_multiple_delegations_same_flashblock() -> Result<()> {
             logs_bloom: Default::default(),
             withdrawals_root: Default::default(),
         },
-        metadata: Metadata { block_number: 1 },
+        metadata: Metadata { block_number: 1, ..Default::default() },
     };
 
     setup.send_flashblock(flashblock).await?;
@@ -383,7 +383,7 @@ async fn test_eip7702_delegation_then_execution() -> Result<()> {
             logs_bloom: Default::default(),
             withdrawals_root: Default::default(),
         },
-        metadata: Metadata { block_number: 1 },
+        metadata: Metadata { block_number: 1, ..Default::default() },
     };
 
     setup.send_flashblock(execution_flashblock).await?;

--- a/crates/client/flashblocks-node/tests/eth_call_erc20.rs
+++ b/crates/client/flashblocks-node/tests/eth_call_erc20.rs
@@ -91,7 +91,7 @@ impl Erc20TestSetup {
                 transactions: vec![L1_BLOCK_INFO_DEPOSIT_TX],
                 ..Default::default()
             },
-            metadata: Metadata { block_number: 1 },
+            metadata: Metadata { block_number: 1, ..Default::default() },
         }
     }
 
@@ -117,7 +117,7 @@ impl Erc20TestSetup {
                 logs_bloom: Default::default(),
                 withdrawals_root: Default::default(),
             },
-            metadata: Metadata { block_number: 1 },
+            metadata: Metadata { block_number: 1, ..Default::default() },
         }
     }
 
@@ -138,7 +138,7 @@ impl Erc20TestSetup {
                 logs_bloom: Default::default(),
                 withdrawals_root: Default::default(),
             },
-            metadata: Metadata { block_number: 1 },
+            metadata: Metadata { block_number: 1, ..Default::default() },
         }
     }
 

--- a/crates/client/flashblocks-node/tests/flashblocks_rpc.rs
+++ b/crates/client/flashblocks-node/tests/flashblocks_rpc.rs
@@ -284,7 +284,7 @@ impl TestSetup {
                 withdrawals_root: EMPTY_WITHDRAWALS,
                 ..Default::default()
             },
-            metadata: Metadata { block_number: 1 },
+            metadata: Metadata { block_number: 1, ..Default::default() },
         }
     }
 
@@ -316,7 +316,7 @@ impl TestSetup {
                 logs_bloom: Default::default(),
                 withdrawals_root: EMPTY_WITHDRAWALS,
             },
-            metadata: Metadata { block_number: 1 },
+            metadata: Metadata { block_number: 1, ..Default::default() },
         }
     }
 

--- a/crates/client/flashblocks/src/block_assembler.rs
+++ b/crates/client/flashblocks/src/block_assembler.rs
@@ -170,7 +170,7 @@ mod tests {
                 withdrawals_root: B256::ZERO,
                 blob_gas_used: None,
             },
-            metadata: Metadata { block_number: 100 },
+            metadata: Metadata { block_number: 100, ..Default::default() },
         }
     }
 

--- a/crates/client/metering/src/rpc.rs
+++ b/crates/client/metering/src/rpc.rs
@@ -827,7 +827,7 @@ mod tests {
                 withdrawals_root: B256::ZERO,
                 blob_gas_used: Some(0),
             },
-            metadata: Metadata { block_number: 2 },
+            metadata: Metadata { block_number: 2, ..Default::default() },
         };
 
         // Build PendingBlocks with zero-hash header

--- a/crates/shared/primitives/Cargo.toml
+++ b/crates/shared/primitives/Cargo.toml
@@ -47,6 +47,7 @@ thiserror = { workspace = true, features = ["std"] }
 serde_json = { workspace = true, features = ["std"] }
 eyre = { workspace = true, optional = true }
 uuid = { workspace = true, features = ["v5", "serde"] }
+reth-optimism-primitives.workspace = true
 
 [dev-dependencies]
 rstest.workspace = true

--- a/crates/shared/primitives/src/flashblocks/block.rs
+++ b/crates/shared/primitives/src/flashblocks/block.rs
@@ -93,27 +93,6 @@ mod tests {
     }
 
     #[rstest]
-    #[case::plain(encode_plain)]
-    #[case::brotli(encode_brotli)]
-    fn try_decode_old_format_still_decodes(#[case] encoder: fn(&FlashblocksPayloadV1) -> Bytes) {
-        // old format should still decode
-        let payload = sample_payload(json!({
-            "block_number": 1234u64,
-            "receipts": {},
-            "new_account_balances": {},
-        }));
-
-        let decoded =
-            Flashblock::try_decode_message(encoder(&payload)).expect("payload should decode");
-
-        assert_eq!(decoded.payload_id, payload.payload_id);
-        assert_eq!(decoded.index, payload.index);
-        assert_eq!(decoded.base, payload.base);
-        assert_eq!(decoded.diff, payload.diff);
-        assert_eq!(decoded.metadata.block_number, 1234);
-    }
-
-    #[rstest]
     #[case::invalid_brotli(Bytes::from_static(b"not brotli data"))]
     #[case::missing_metadata(encode_plain(&sample_payload(json!({
     }))))] // missing block_number in metadata

--- a/crates/shared/primitives/src/flashblocks/metadata.rs
+++ b/crates/shared/primitives/src/flashblocks/metadata.rs
@@ -1,10 +1,18 @@
 //! Contains the [`Metadata`] type used in Flashblocks.
 
+use alloy_primitives::{Address, B256, U256, map::foldhash::HashMap};
+use reth_optimism_primitives::OpReceipt;
 use serde::{Deserialize, Serialize};
 
 /// Metadata associated with a flashblock.
 #[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Eq, Default)]
 pub struct Metadata {
+    /// Transaction receipts indexed by hash.
+    #[serde(default)]
+    pub receipts: HashMap<B256, OpReceipt>,
+    /// Updated account balances.
+    #[serde(default)]
+    pub new_account_balances: HashMap<Address, U256>,
     /// Block number this flashblock belongs to.
     pub block_number: u64,
 }


### PR DESCRIPTION
We will reapply these soon once we give users a bit more time to eliminate their reliance on this.