### PR TITLE
fix(reth): P2P Test Flakiness

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,6 +1,13 @@
 [test-groups.system-tests]
 max-threads = 1
 
+[test-groups.e2e-tests]
+max-threads = 1
+
 [[profile.default.overrides]]
 filter = 'test(system_test_)'
 test-group = 'system-tests'
+
+[[profile.default.overrides]]
+filter = 'binary(e2e-testsuite)'
+test-group = 'e2e-tests'

--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -9,5 +9,5 @@ filter = 'test(system_test_)'
 test-group = 'system-tests'
 
 [[profile.default.overrides]]
-filter = 'binary(e2e-testsuite)'
+filter = 'binary(e2e_testsuite)'
 test-group = 'e2e-tests'

--- a/crates/execution/node/tests/e2e-testsuite/p2p.rs
+++ b/crates/execution/node/tests/e2e-testsuite/p2p.rs
@@ -15,7 +15,7 @@ async fn can_sync() -> eyre::Result<()> {
     let mut second_node = nodes.pop().unwrap();
     let mut first_node = nodes.pop().unwrap();
 
-    let tip: usize = 90;
+    let tip: usize = 20;
     let tip_index: usize = tip - 1;
     let reorg_depth = 2;
 


### PR DESCRIPTION
## Summary

Small PR to fix p2p test flakiness in reth crates by relaxing some of the constraints. Since we don't have our own custom github action runners, these tests are often timing out now, including in the merge queue which ends up indefinitely blocking the merge queue.