### PR TITLE
docs(tx): fix copy-paste error in op tx deposit comment

### DIFF
--- a/crates/alloy/consensus/src/transaction/envelope.rs
+++ b/crates/alloy/consensus/src/transaction/envelope.rs
@@ -384,7 +384,7 @@ impl OpTxEnvelope {
         }
     }
 
-    /// Returns the [`TxEip1559`] variant if the transaction is an EIP-1559 transaction.
+    /// Returns the [`TxDeposit`] variant if the transaction is a deposit transaction.
     pub const fn as_deposit(&self) -> Option<&Sealed<TxDeposit>> {
         match self {
             Self::Deposit(tx) => Some(tx),


### PR DESCRIPTION
Hello Team, I fix a copy-paste error in the documentation, updating the description for the TxDeposit variant.