### PR TITLE
chore: remove frame pointers / fix warning

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -117,7 +117,6 @@ inherits = "release"
 lto = false
 debug = "line-tables-only"
 strip = "none"
-force-frame-pointers = true
 
 # CI profile: optimized for minimal disk usage in CI environments
 # - Inherits from dev for fast compilation

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -112,6 +112,8 @@ inherits = "release"
 lto = "fat"
 codegen-units = 1
 
+# TODO: add `rustflags = ["-Cforce-frame-pointers=yes"]` here once
+# `profile-rustflags` is stabilized (tracking: rust-lang/cargo#10271)
 [profile.profiling]
 inherits = "release"
 lto = false


### PR DESCRIPTION
### Description
I don't think this flag works, and prints warnings on my machine

```
~/c/e/base > just format-fix
cargo fix --allow-dirty --allow-staged --workspace
warning: /Users/danyal/code/ext/base/Cargo.toml: unused manifest key: profile.profiling.force-frame-pointers
    Checking base-revm v0.0.0 (/Users/danyal/code/ext/base/crates/execution/revm)
```