### PR TITLE
refactor(audit): replace bare function with AuditConnector unit struct

### DIFF
--- a/bin/ingress-rpc/src/main.rs
+++ b/bin/ingress-rpc/src/main.rs
@@ -2,7 +2,7 @@
 
 use alloy_provider::ProviderBuilder;
 use audit_archiver_lib::{
-    BundleEvent, KafkaBundleEventPublisher, connect_audit_to_publisher, load_kafka_config_from_file,
+    AuditConnector, BundleEvent, KafkaBundleEventPublisher, load_kafka_config_from_file,
 };
 use base_alloy_network::Base;
 use base_bundles::MeterBundleResponse;
@@ -73,7 +73,7 @@ async fn main() -> anyhow::Result<()> {
 
     let audit_publisher = KafkaBundleEventPublisher::new(audit_producer, config.audit_topic);
     let (audit_tx, audit_rx) = mpsc::unbounded_channel::<BundleEvent>();
-    connect_audit_to_publisher(audit_rx, audit_publisher);
+    AuditConnector::connect(audit_rx, audit_publisher);
 
     let (builder_tx, _) =
         broadcast::channel::<MeterBundleResponse>(config.max_buffered_meter_bundle_responses);

--- a/crates/infra/audit/README.md
+++ b/crates/infra/audit/README.md
@@ -1,0 +1,5 @@
+# audit-archiver
+
+Audit library for tracking and archiving bundle events.
+
+This crate provides functionality for publishing events to Kafka, archiving them to S3, and reading event history.

--- a/crates/infra/audit/src/lib.rs
+++ b/crates/infra/audit/src/lib.rs
@@ -1,8 +1,4 @@
-//! Audit library for tracking and archiving bundle events.
-//!
-//! This crate provides functionality for publishing events to Kafka,
-//! archiving them to S3, and reading event history.
-
+#![doc = include_str!("../README.md")]
 #![doc(issue_tracker_base_url = "https://github.com/base/tips/issues/")]
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
@@ -35,17 +31,23 @@ use tokio::sync::mpsc;
 use tracing::error;
 pub use types::{BundleEvent, BundleId, DropReason, Transaction, TransactionId};
 
-/// Connects a bundle event receiver to a publisher, spawning a task to forward events.
-pub fn connect_audit_to_publisher<P>(event_rx: mpsc::UnboundedReceiver<BundleEvent>, publisher: P)
-where
-    P: BundleEventPublisher + 'static,
-{
-    tokio::spawn(async move {
-        let mut event_rx = event_rx;
-        while let Some(event) = event_rx.recv().await {
-            if let Err(e) = publisher.publish(event).await {
-                error!(error = %e, "failed to publish bundle event");
+/// Connects bundle event receivers to publishers.
+#[derive(Debug)]
+pub struct AuditConnector;
+
+impl AuditConnector {
+    /// Connects a bundle event receiver to a publisher, spawning a task to forward events.
+    pub fn connect<P>(event_rx: mpsc::UnboundedReceiver<BundleEvent>, publisher: P)
+    where
+        P: BundleEventPublisher + 'static,
+    {
+        tokio::spawn(async move {
+            let mut event_rx = event_rx;
+            while let Some(event) = event_rx.recv().await {
+                if let Err(e) = publisher.publish(event).await {
+                    error!(error = %e, "failed to publish bundle event");
+                }
             }
-        }
-    });
+        });
+    }
 }

--- a/crates/infra/ingress-rpc/src/service.rs
+++ b/crates/infra/ingress-rpc/src/service.rs
@@ -9,9 +9,7 @@ use alloy_provider::{Provider, RootProvider, network::eip2718::Decodable2718};
 use audit_archiver_lib::BundleEvent;
 use base_alloy_consensus::OpTxEnvelope;
 use base_alloy_network::Base;
-use base_bundles::{
-    AcceptedBundle, Bundle, BundleExtensions, MeterBundleResponse, ParsedBundle,
-};
+use base_bundles::{AcceptedBundle, Bundle, BundleExtensions, MeterBundleResponse, ParsedBundle};
 use jsonrpsee::{
     core::{RpcResult, async_trait},
     proc_macros::rpc,


### PR DESCRIPTION
`connect_audit_to_publisher` is a bare exported function, violating the project convention of placing functions as methods on a type. Replace it with an `AuditConnector` unit struct and a `connect` associated method.
No logic changes — the tokio spawn, event loop, and error handling are identical. The single call site in `ingress-rpc` is updated accordingly.