### PR TITLE
wip - feat: override `eth_sendRawTransaction`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2864,6 +2864,7 @@ dependencies = [
  "reth-rpc-convert",
  "reth-rpc-eth-api",
  "reth-rpc-eth-types",
+ "reth-transaction-pool",
  "revm",
  "revm-database",
  "rstest",

--- a/bin/node/src/cli.rs
+++ b/bin/node/src/cli.rs
@@ -47,6 +47,6 @@ impl From<&Args> for Option<FlashblocksConfig> {
     fn from(args: &Args) -> Self {
         args.flashblocks_url
             .clone()
-            .map(|url| FlashblocksConfig::new(url, args.max_pending_blocks_depth))
+            .and_then(|url| FlashblocksConfig::new(url, args.max_pending_blocks_depth, None).ok())
     }
 }

--- a/bin/node/src/cli.rs
+++ b/bin/node/src/cli.rs
@@ -27,6 +27,18 @@ pub struct Args {
     )]
     pub max_pending_blocks_depth: u64,
 
+    /// URLs of builder RPC endpoints to forward transactions to.
+    #[arg(long = "builder-rpc-urls", value_name = "BUILDER_RPC_URL", num_args = 1..)]
+    pub builder_rpc_urls: Option<Vec<Url>>,
+
+    /// Maximum concurrent in-flight transactions to builder RPCs.
+    #[arg(
+        long = "max-builder-in-flight-req",
+        value_name = "MAX_BUILDER_IN_FLIGHT_REQ",
+        default_value = "10"
+    )]
+    pub max_builder_in_flight_req: usize,
+
     /// Enable transaction tracing for mempool-to-block timing analysis
     #[arg(long = "enable-transaction-tracing", value_name = "ENABLE_TRANSACTION_TRACING")]
     pub enable_transaction_tracing: bool,
@@ -45,8 +57,14 @@ pub struct Args {
 
 impl From<&Args> for Option<FlashblocksConfig> {
     fn from(args: &Args) -> Self {
-        args.flashblocks_url
-            .clone()
-            .and_then(|url| FlashblocksConfig::new(url, args.max_pending_blocks_depth, None).ok())
+        args.flashblocks_url.clone().and_then(|url| {
+            FlashblocksConfig::new(
+                url,
+                args.max_pending_blocks_depth,
+                args.builder_rpc_urls.clone(),
+                Some(args.max_builder_in_flight_req),
+            )
+            .ok()
+        })
     }
 }

--- a/bin/node/src/cli.rs
+++ b/bin/node/src/cli.rs
@@ -27,7 +27,16 @@ pub struct Args {
     )]
     pub max_pending_blocks_depth: u64,
 
+    /// Enable transaction forwarding to builder RPCs (mempool node only).
+    ///
+    /// When enabled, transactions submitted via `eth_sendRawTransaction` will be
+    /// forwarded to builder RPC endpoints specified by `--builder-rpc-urls`.
+    #[arg(long = "enable-mempool-tx-forwarding")]
+    pub enable_mempool_tx_forwarding: bool,
+
     /// URLs of builder RPC endpoints to forward transactions to.
+    ///
+    /// Requires `--enable-mempool-tx-forwarding` to be set for forwarding to occur.
     #[arg(long = "builder-rpc-urls", value_name = "BUILDER_RPC_URL", num_args = 1..)]
     pub builder_rpc_urls: Option<Vec<Url>>,
 
@@ -61,7 +70,11 @@ impl From<&Args> for Option<FlashblocksConfig> {
             FlashblocksConfig::new(
                 url,
                 args.max_pending_blocks_depth,
-                args.builder_rpc_urls.clone(),
+                if args.enable_mempool_tx_forwarding {
+                    args.builder_rpc_urls.clone()
+                } else {
+                    None
+                },
                 Some(args.max_builder_in_flight_req),
             )
             .ok()

--- a/crates/client/flashblocks-node/src/extension.rs
+++ b/crates/client/flashblocks-node/src/extension.rs
@@ -41,7 +41,8 @@ impl BaseNodeExtension for FlashblocksExtension {
         let state_for_rpc = Arc::clone(&state);
         let state_for_start = state;
 
-        let builder_rpc = cfg.builder_rpc;
+        let builder_clients = cfg.builder_clients;
+        let builder_rpc_semaphore = cfg.builder_rpc_semaphore;
 
         // Start state processor, subscriber, and canonical subscription after node is started
         let hooks = hooks.add_node_started_hook(move |ctx| {
@@ -72,8 +73,8 @@ impl BaseNodeExtension for FlashblocksExtension {
                 ctx.registry.eth_handlers().filter.clone(),
                 Arc::clone(&state_for_rpc),
                 ctx.pool().clone(),
-                // TODO: no unwrap
-                builder_rpc.unwrap(),
+                builder_clients.clone(),
+                Arc::clone(&builder_rpc_semaphore),
             );
             ctx.modules.replace_configured(api_ext.into_rpc())?;
 

--- a/crates/client/flashblocks-node/src/extension.rs
+++ b/crates/client/flashblocks-node/src/extension.rs
@@ -41,6 +41,8 @@ impl BaseNodeExtension for FlashblocksExtension {
         let state_for_rpc = Arc::clone(&state);
         let state_for_start = state;
 
+        let builder_rpc = cfg.builder_rpc;
+
         // Start state processor, subscriber, and canonical subscription after node is started
         let hooks = hooks.add_node_started_hook(move |ctx| {
             info!(message = "Starting Flashblocks state processor");
@@ -69,6 +71,9 @@ impl BaseNodeExtension for FlashblocksExtension {
                 ctx.registry.eth_api().clone(),
                 ctx.registry.eth_handlers().filter.clone(),
                 Arc::clone(&state_for_rpc),
+                ctx.pool().clone(),
+                // TODO: no unwrap
+                builder_rpc.unwrap(),
             );
             ctx.modules.replace_configured(api_ext.into_rpc())?;
 

--- a/crates/client/flashblocks-node/src/extension.rs
+++ b/crates/client/flashblocks-node/src/extension.rs
@@ -41,9 +41,6 @@ impl BaseNodeExtension for FlashblocksExtension {
         let state_for_rpc = Arc::clone(&state);
         let state_for_start = state;
 
-        let builder_clients = cfg.builder_clients;
-        let builder_rpc_semaphore = cfg.builder_rpc_semaphore;
-
         // Start state processor, subscriber, and canonical subscription after node is started
         let hooks = hooks.add_node_started_hook(move |ctx| {
             info!(message = "Starting Flashblocks state processor");
@@ -73,8 +70,8 @@ impl BaseNodeExtension for FlashblocksExtension {
                 ctx.registry.eth_handlers().filter.clone(),
                 Arc::clone(&state_for_rpc),
                 ctx.pool().clone(),
-                builder_clients.clone(),
-                Arc::clone(&builder_rpc_semaphore),
+                cfg.builder_clients.clone(),
+                Arc::clone(&cfg.concurrency_limiter),
             );
             ctx.modules.replace_configured(api_ext.into_rpc())?;
 

--- a/crates/client/flashblocks-node/src/test_harness.rs
+++ b/crates/client/flashblocks-node/src/test_harness.rs
@@ -31,8 +31,8 @@ use base_client_node::{
     },
 };
 use base_flashblocks::{
-    EthApiExt, EthApiOverrideServer, EthPubSub, EthPubSubApiServer, FlashblocksAPI,
-    FlashblocksReceiver, FlashblocksState, PendingBlocksAPI,
+    AdaptiveConcurrencyLimiter, EthApiExt, EthApiOverrideServer, EthPubSub, EthPubSubApiServer,
+    FlashblocksAPI, FlashblocksReceiver, FlashblocksState, PendingBlocksAPI,
 };
 use derive_more::Deref;
 use eyre::Result;
@@ -186,7 +186,7 @@ impl BaseNodeExtension for FlashblocksTestExtension {
                 Arc::clone(&fb),
                 ctx.pool().clone(),
                 Vec::new(),
-                Arc::new(tokio::sync::Semaphore::new(10)),
+                Arc::new(AdaptiveConcurrencyLimiter::new(10)),
             );
             ctx.modules.replace_configured(api_ext.into_rpc())?;
 

--- a/crates/client/flashblocks-node/src/test_harness.rs
+++ b/crates/client/flashblocks-node/src/test_harness.rs
@@ -184,6 +184,9 @@ impl BaseNodeExtension for FlashblocksTestExtension {
                 ctx.registry.eth_api().clone(),
                 ctx.registry.eth_handlers().filter.clone(),
                 Arc::clone(&fb),
+                ctx.pool().clone(),
+                Vec::new(),
+                Arc::new(tokio::sync::Semaphore::new(10)),
             );
             ctx.modules.replace_configured(api_ext.into_rpc())?;
 

--- a/crates/client/flashblocks/Cargo.toml
+++ b/crates/client/flashblocks/Cargo.toml
@@ -28,6 +28,7 @@ reth-rpc-eth-types.workspace = true
 reth-optimism-evm.workspace = true
 reth-optimism-rpc.workspace = true
 reth-optimism-forks.workspace = true
+reth-transaction-pool.workspace = true
 reth-optimism-primitives.workspace = true
 
 # revm

--- a/crates/client/flashblocks/Cargo.toml
+++ b/crates/client/flashblocks/Cargo.toml
@@ -63,7 +63,7 @@ futures-util.workspace = true
 
 # rpc
 serde = { workspace = true, features = ["std"] }
-jsonrpsee.workspace = true
+jsonrpsee = { workspace = true, features = ["http-client"] }
 jsonrpsee-types.workspace = true
 
 # metrics

--- a/crates/client/flashblocks/src/config.rs
+++ b/crates/client/flashblocks/src/config.rs
@@ -1,8 +1,13 @@
 use std::sync::Arc;
 
+use jsonrpsee::http_client::{HttpClient, HttpClientBuilder};
+use tokio::sync::Semaphore;
 use url::Url;
 
 use crate::FlashblocksState;
+
+/// Default max concurrent builder RPC requests.
+const DEFAULT_MAX_CONCURRENT_BUILDER_REQUESTS: usize = 10;
 
 /// Flashblocks-specific configuration knobs.
 #[derive(Debug, Clone)]
@@ -13,14 +18,36 @@ pub struct FlashblocksConfig {
     pub max_pending_blocks_depth: u64,
     /// Shared Flashblocks state.
     pub state: Arc<FlashblocksState>,
-    /// Builder RPC endpoints.
-    pub builder_rpc: Option<Vec<Url>>,
+    /// Pre-built HTTP clients for builder RPC endpoints.
+    pub builder_clients: Vec<HttpClient>,
+    /// Semaphore for rate limiting builder RPC calls.
+    pub builder_rpc_semaphore: Arc<Semaphore>,
 }
 
 impl FlashblocksConfig {
     /// Create a new Flashblocks configuration.
-    pub fn new(websocket_url: Url, max_pending_blocks_depth: u64, builder_rpc: Option<Vec<Url>>) -> Self {
+    pub fn new(
+        websocket_url: Url,
+        max_pending_blocks_depth: u64,
+        builder_rpc: Option<Vec<Url>>,
+    ) -> Result<Self, jsonrpsee::core::ClientError> {
         let state = Arc::new(FlashblocksState::new(max_pending_blocks_depth));
-        Self { websocket_url, max_pending_blocks_depth, state, builder_rpc }
+
+        let builder_clients = builder_rpc
+            .unwrap_or_default()
+            .into_iter()
+            .map(|url| HttpClientBuilder::default().build(url.as_str()))
+            .collect::<Result<Vec<_>, _>>()?;
+
+        let builder_rpc_semaphore =
+            Arc::new(Semaphore::new(DEFAULT_MAX_CONCURRENT_BUILDER_REQUESTS));
+
+        Ok(Self {
+            websocket_url,
+            max_pending_blocks_depth,
+            state,
+            builder_clients,
+            builder_rpc_semaphore,
+        })
     }
 }

--- a/crates/client/flashblocks/src/config.rs
+++ b/crates/client/flashblocks/src/config.rs
@@ -1,16 +1,14 @@
-use std::sync::Arc;
+use std::{fmt, sync::Arc};
 
 use jsonrpsee::http_client::{HttpClient, HttpClientBuilder};
-use tokio::sync::Semaphore;
 use url::Url;
 
-use crate::FlashblocksState;
+use crate::{AdaptiveConcurrencyLimiter, BuilderRpcStats, FlashblocksState};
 
 /// Default max concurrent builder RPC requests.
 const DEFAULT_MAX_CONCURRENT_BUILDER_REQUESTS: usize = 10;
 
 /// Flashblocks-specific configuration knobs.
-#[derive(Debug, Clone)]
 pub struct FlashblocksConfig {
     /// The websocket endpoint that streams flashblock updates.
     pub websocket_url: Url,
@@ -18,36 +16,64 @@ pub struct FlashblocksConfig {
     pub max_pending_blocks_depth: u64,
     /// Shared Flashblocks state.
     pub state: Arc<FlashblocksState>,
-    /// Pre-built HTTP clients for builder RPC endpoints.
-    pub builder_clients: Vec<HttpClient>,
-    /// Semaphore for rate limiting builder RPC calls.
-    pub builder_rpc_semaphore: Arc<Semaphore>,
+    /// Builder RPC clients.
+    pub builder_clients: Vec<(HttpClient, Arc<BuilderRpcStats>)>,
+    /// Adaptive concurrency limiter.
+    pub concurrency_limiter: Arc<AdaptiveConcurrencyLimiter>,
 }
 
+impl Clone for FlashblocksConfig {
+    fn clone(&self) -> Self {
+        Self {
+            websocket_url: self.websocket_url.clone(),
+            max_pending_blocks_depth: self.max_pending_blocks_depth,
+            state: Arc::clone(&self.state),
+            builder_clients: self.builder_clients.clone(),
+            concurrency_limiter: Arc::clone(&self.concurrency_limiter),
+        }
+    }
+}
+
+impl fmt::Debug for FlashblocksConfig {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("FlashblocksConfig")
+            .field("websocket_url", &self.websocket_url)
+            .field("max_pending_blocks_depth", &self.max_pending_blocks_depth)
+            .field("builder_clients_count", &self.builder_clients.len())
+            .field("concurrency_limiter", &self.concurrency_limiter)
+            .finish()
+    }
+}
 impl FlashblocksConfig {
-    /// Create a new Flashblocks configuration.
+    /// Creates a new Flashblocks configuration.
     pub fn new(
         websocket_url: Url,
         max_pending_blocks_depth: u64,
         builder_rpc: Option<Vec<Url>>,
+        max_concurrent_builder_requests: Option<usize>,
     ) -> Result<Self, jsonrpsee::core::ClientError> {
         let state = Arc::new(FlashblocksState::new(max_pending_blocks_depth));
 
         let builder_clients = builder_rpc
             .unwrap_or_default()
             .into_iter()
-            .map(|url| HttpClientBuilder::default().build(url.as_str()))
+            .map(|url| -> Result<_, jsonrpsee::core::ClientError> {
+                let client = HttpClientBuilder::default().build(url.as_str())?;
+                let stats = Arc::new(BuilderRpcStats::new(url.as_str()));
+                Ok((client, stats))
+            })
             .collect::<Result<Vec<_>, _>>()?;
 
-        let builder_rpc_semaphore =
-            Arc::new(Semaphore::new(DEFAULT_MAX_CONCURRENT_BUILDER_REQUESTS));
+        let max_concurrent =
+            max_concurrent_builder_requests.unwrap_or(DEFAULT_MAX_CONCURRENT_BUILDER_REQUESTS);
+        let concurrency_limiter = Arc::new(AdaptiveConcurrencyLimiter::new(max_concurrent));
 
         Ok(Self {
             websocket_url,
             max_pending_blocks_depth,
             state,
             builder_clients,
-            builder_rpc_semaphore,
+            concurrency_limiter,
         })
     }
 }

--- a/crates/client/flashblocks/src/config.rs
+++ b/crates/client/flashblocks/src/config.rs
@@ -13,12 +13,14 @@ pub struct FlashblocksConfig {
     pub max_pending_blocks_depth: u64,
     /// Shared Flashblocks state.
     pub state: Arc<FlashblocksState>,
+    /// Builder RPC endpoints.
+    pub builder_rpc: Option<Vec<Url>>,
 }
 
 impl FlashblocksConfig {
     /// Create a new Flashblocks configuration.
-    pub fn new(websocket_url: Url, max_pending_blocks_depth: u64) -> Self {
+    pub fn new(websocket_url: Url, max_pending_blocks_depth: u64, builder_rpc: Option<Vec<Url>>) -> Self {
         let state = Arc::new(FlashblocksState::new(max_pending_blocks_depth));
-        Self { websocket_url, max_pending_blocks_depth, state }
+        Self { websocket_url, max_pending_blocks_depth, state, builder_rpc }
     }
 }

--- a/crates/client/flashblocks/src/lib.rs
+++ b/crates/client/flashblocks/src/lib.rs
@@ -49,6 +49,7 @@ pub use config::FlashblocksConfig;
 
 mod rpc;
 pub use rpc::{
-    BaseSubscriptionKind, EthApiExt, EthApiOverrideServer, EthPubSub, EthPubSubApiServer,
-    ExtendedSubscriptionKind, TransactionWithLogs,
+    AdaptiveConcurrencyLimiter, AdaptivePermit, BaseSubscriptionKind, BuilderRpcStats, EthApiExt,
+    EthApiOverrideServer, EthPubSub, EthPubSubApiServer, ExtendedSubscriptionKind,
+    TransactionWithLogs,
 };

--- a/crates/client/flashblocks/src/metrics.rs
+++ b/crates/client/flashblocks/src/metrics.rs
@@ -111,4 +111,25 @@ pub struct Metrics {
     /// Size of bundle state being cloned (number of accounts).
     #[metric(describe = "Size of bundle state being cloned (number of accounts)")]
     pub bundle_state_clone_size: Histogram,
+
+    // Builder RPC metrics
+    /// Count of successful builder RPC forwards.
+    #[metric(describe = "Count of successful builder RPC forwards")]
+    pub builder_rpc_success: Counter,
+
+    /// Count of failed builder RPC forwards.
+    #[metric(describe = "Count of failed builder RPC forwards")]
+    pub builder_rpc_error: Counter,
+
+    /// Count of builder RPC forwards skipped due to rate limiting.
+    #[metric(describe = "Count of builder RPC forwards skipped due to rate limiting")]
+    pub builder_rpc_rate_limited: Counter,
+
+    /// Current adaptive concurrency soft limit for builder RPCs.
+    #[metric(describe = "Current adaptive concurrency soft limit for builder RPCs")]
+    pub builder_rpc_concurrency_limit: Gauge,
+
+    /// Current number of in-flight builder RPC requests.
+    #[metric(describe = "Current number of in-flight builder RPC requests")]
+    pub builder_rpc_in_flight: Gauge,
 }

--- a/crates/client/flashblocks/src/rpc/backpressure.rs
+++ b/crates/client/flashblocks/src/rpc/backpressure.rs
@@ -1,0 +1,352 @@
+//! Adaptive concurrency control for builder RPC calls.
+//!
+//! Implements AIMD (Additive Increase Multiplicative Decrease) backpressure
+//! to dynamically adjust concurrency based on success/failure rates.
+
+use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
+
+use tokio::sync::{Semaphore, SemaphorePermit};
+
+/// Minimum concurrency limit (never stop completely).
+const MIN_CONCURRENCY_LIMIT: usize = 1;
+
+/// Per-builder RPC statistics for observability.
+///
+/// Tracks success and error counts for a single builder endpoint,
+/// enabling per-builder health monitoring via metrics.
+#[derive(Debug)]
+pub struct BuilderRpcStats {
+    builder_url: String,
+    success_count: AtomicU64,
+    error_count: AtomicU64,
+}
+
+impl BuilderRpcStats {
+    /// Creates new stats tracker for a builder endpoint.
+    pub fn new(url: impl Into<String>) -> Self {
+        Self {
+            builder_url: url.into(),
+            success_count: AtomicU64::new(0),
+            error_count: AtomicU64::new(0),
+        }
+    }
+
+    /// Records a successful RPC call.
+    pub fn on_success(&self) {
+        self.success_count.fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// Records a failed RPC call.
+    pub fn on_error(&self) {
+        self.error_count.fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// Returns the total success count.
+    pub fn success_count(&self) -> u64 {
+        self.success_count.load(Ordering::Relaxed)
+    }
+
+    /// Returns the total error count.
+    pub fn error_count(&self) -> u64 {
+        self.error_count.load(Ordering::Relaxed)
+    }
+
+    /// Returns the builder URL.
+    pub fn url(&self) -> &str {
+        &self.builder_url
+    }
+}
+
+/// AIMD-style adaptive concurrency limiter.
+///
+/// Uses a static semaphore as a hard ceiling and an atomic soft limit
+/// that adjusts dynamically based on success/failure feedback:
+/// - On success: `soft_limit = min(soft_limit + 1, max_limit)` (additive increase)
+/// - On error: `soft_limit = max(soft_limit / 2, 1)` (multiplicative decrease)
+#[derive(Debug)]
+pub struct AdaptiveConcurrencyLimiter {
+    /// Hard ceiling - static semaphore that never changes size.
+    hard_limit: Semaphore,
+    /// Current soft limit (AIMD-adjusted). Requests check this before acquiring.
+    soft_limit: AtomicUsize,
+    /// Current number of in-flight requests.
+    in_flight: AtomicUsize,
+    /// Maximum allowed limit (for additive increase cap).
+    max_limit: usize,
+}
+
+impl AdaptiveConcurrencyLimiter {
+    /// Creates a new adaptive limiter with the given maximum concurrency.
+    ///
+    /// The soft limit starts at `max_limit` and adjusts based on feedback.
+    pub fn new(max_limit: usize) -> Self {
+        let max_limit = max_limit.max(MIN_CONCURRENCY_LIMIT);
+        Self {
+            hard_limit: Semaphore::new(max_limit),
+            soft_limit: AtomicUsize::new(max_limit),
+            in_flight: AtomicUsize::new(0),
+            max_limit,
+        }
+    }
+
+    /// Attempts to acquire a permit for an in-flight request.
+    ///
+    /// Returns `None` if the soft limit has been reached or the hard limit
+    /// semaphore has no available permits.
+    pub fn try_acquire(&self) -> Option<AdaptivePermit<'_>> {
+        // Check soft limit first (fast path)
+        let current_in_flight = self.in_flight.load(Ordering::Relaxed);
+        let current_soft_limit = self.soft_limit.load(Ordering::Relaxed);
+
+        if current_in_flight >= current_soft_limit {
+            return None;
+        }
+
+        // Try to acquire from hard limit semaphore
+        let semaphore_permit = self.hard_limit.try_acquire().ok()?;
+
+        // Increment in-flight counter
+        self.in_flight.fetch_add(1, Ordering::Relaxed);
+
+        Some(AdaptivePermit { limiter: self, _semaphore_permit: semaphore_permit })
+    }
+
+    /// Records a successful request - additive increase.
+    ///
+    /// Increases the soft limit by 1, up to the maximum.
+    pub fn on_success(&self) {
+        let current = self.soft_limit.load(Ordering::Relaxed);
+        let new_limit = (current + 1).min(self.max_limit);
+        self.soft_limit.store(new_limit, Ordering::Relaxed);
+    }
+
+    /// Records a failed request - multiplicative decrease.
+    ///
+    /// Halves the soft limit, with a minimum of 1.
+    pub fn on_error(&self) {
+        let current = self.soft_limit.load(Ordering::Relaxed);
+        let new_limit = (current / 2).max(MIN_CONCURRENCY_LIMIT);
+        self.soft_limit.store(new_limit, Ordering::Relaxed);
+    }
+
+    /// Returns the current soft limit.
+    pub fn current_limit(&self) -> usize {
+        self.soft_limit.load(Ordering::Relaxed)
+    }
+
+    /// Returns the current number of in-flight requests.
+    pub fn in_flight(&self) -> usize {
+        self.in_flight.load(Ordering::Relaxed)
+    }
+
+    /// Returns the maximum limit.
+    pub const fn max_limit(&self) -> usize {
+        self.max_limit
+    }
+}
+
+/// RAII guard that decrements the in-flight counter on drop.
+#[derive(Debug)]
+pub struct AdaptivePermit<'a> {
+    limiter: &'a AdaptiveConcurrencyLimiter,
+    _semaphore_permit: SemaphorePermit<'a>,
+}
+
+impl Drop for AdaptivePermit<'_> {
+    fn drop(&mut self) {
+        self.limiter.in_flight.fetch_sub(1, Ordering::Relaxed);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_builder_rpc_stats_counting() {
+        let stats = BuilderRpcStats::new("http://builder:8545");
+        assert_eq!(stats.success_count(), 0);
+        assert_eq!(stats.error_count(), 0);
+
+        stats.on_success();
+        stats.on_success();
+        stats.on_error();
+
+        assert_eq!(stats.success_count(), 2);
+        assert_eq!(stats.error_count(), 1);
+        assert_eq!(stats.url(), "http://builder:8545");
+    }
+
+    #[test]
+    fn test_adaptive_limiter_respects_soft_limit() {
+        let limiter = AdaptiveConcurrencyLimiter::new(10);
+        assert_eq!(limiter.current_limit(), 10);
+        assert_eq!(limiter.in_flight(), 0);
+
+        // Acquire up to soft limit
+        let permits: Vec<_> = (0..10).filter_map(|_| limiter.try_acquire()).collect();
+        assert_eq!(permits.len(), 10);
+        assert_eq!(limiter.in_flight(), 10);
+
+        // Should fail - at soft limit
+        assert!(limiter.try_acquire().is_none());
+    }
+
+    #[test]
+    fn test_aimd_additive_increase() {
+        let limiter = AdaptiveConcurrencyLimiter::new(10);
+
+        // Simulate errors reducing limit
+        limiter.on_error(); // 10 -> 5
+        limiter.on_error(); // 5 -> 2
+        assert_eq!(limiter.current_limit(), 2);
+
+        // Additive increase
+        limiter.on_success();
+        assert_eq!(limiter.current_limit(), 3);
+
+        limiter.on_success();
+        assert_eq!(limiter.current_limit(), 4);
+    }
+
+    #[test]
+    fn test_aimd_additive_increase_capped_at_max() {
+        let limiter = AdaptiveConcurrencyLimiter::new(5);
+        assert_eq!(limiter.current_limit(), 5);
+
+        // Should not exceed max
+        limiter.on_success();
+        assert_eq!(limiter.current_limit(), 5);
+    }
+
+    #[test]
+    fn test_aimd_multiplicative_decrease() {
+        let limiter = AdaptiveConcurrencyLimiter::new(10);
+
+        limiter.on_error();
+        assert_eq!(limiter.current_limit(), 5); // 10 / 2
+
+        limiter.on_error();
+        assert_eq!(limiter.current_limit(), 2); // 5 / 2 = 2 (floor)
+
+        limiter.on_error();
+        assert_eq!(limiter.current_limit(), 1); // 2 / 2 = 1
+
+        limiter.on_error();
+        assert_eq!(limiter.current_limit(), 1); // stays at min
+    }
+
+    #[test]
+    fn test_permit_releases_on_drop() {
+        let limiter = AdaptiveConcurrencyLimiter::new(2);
+
+        {
+            let _p1 = limiter.try_acquire().unwrap();
+            let _p2 = limiter.try_acquire().unwrap();
+            assert_eq!(limiter.in_flight(), 2);
+            assert!(limiter.try_acquire().is_none());
+        }
+
+        // Permits dropped
+        assert_eq!(limiter.in_flight(), 0);
+        assert!(limiter.try_acquire().is_some());
+    }
+
+    #[test]
+    fn test_min_limit_enforced() {
+        // Even with 0, should enforce minimum of 1
+        let limiter = AdaptiveConcurrencyLimiter::new(0);
+        assert_eq!(limiter.current_limit(), 1);
+        assert_eq!(limiter.max_limit(), 1);
+    }
+
+    #[test]
+    fn test_concurrent_acquire_and_release() {
+        let limiter = AdaptiveConcurrencyLimiter::new(3);
+
+        // Acquire all permits
+        let p1 = limiter.try_acquire().unwrap();
+        let p2 = limiter.try_acquire().unwrap();
+        let p3 = limiter.try_acquire().unwrap();
+        assert_eq!(limiter.in_flight(), 3);
+        assert!(limiter.try_acquire().is_none());
+
+        // Drop one, should be able to acquire again
+        drop(p1);
+        assert_eq!(limiter.in_flight(), 2);
+        let p4 = limiter.try_acquire().unwrap();
+        assert_eq!(limiter.in_flight(), 3);
+
+        // Cleanup
+        drop(p2);
+        drop(p3);
+        drop(p4);
+        assert_eq!(limiter.in_flight(), 0);
+    }
+
+    #[test]
+    fn test_soft_limit_reduces_available_permits() {
+        let limiter = AdaptiveConcurrencyLimiter::new(10);
+
+        // Reduce soft limit via errors
+        limiter.on_error(); // 10 -> 5
+        assert_eq!(limiter.current_limit(), 5);
+
+        // Can only acquire up to soft limit
+        let permits: Vec<_> = (0..10).filter_map(|_| limiter.try_acquire()).collect();
+        assert_eq!(permits.len(), 5);
+        assert_eq!(limiter.in_flight(), 5);
+    }
+
+    #[test]
+    fn test_recovery_after_errors() {
+        let limiter = AdaptiveConcurrencyLimiter::new(10);
+
+        // Hammer with errors to reduce limit
+        for _ in 0..5 {
+            limiter.on_error();
+        }
+        assert_eq!(limiter.current_limit(), 1); // Should be at minimum
+
+        // Recover with successes
+        for _ in 0..9 {
+            limiter.on_success();
+        }
+        assert_eq!(limiter.current_limit(), 10); // Back to max
+
+        // One more success shouldn't exceed max
+        limiter.on_success();
+        assert_eq!(limiter.current_limit(), 10);
+    }
+
+    #[test]
+    fn test_stats_are_independent_per_builder() {
+        let stats1 = BuilderRpcStats::new("http://builder1:8545");
+        let stats2 = BuilderRpcStats::new("http://builder2:8545");
+
+        stats1.on_success();
+        stats1.on_success();
+        stats2.on_error();
+
+        assert_eq!(stats1.success_count(), 2);
+        assert_eq!(stats1.error_count(), 0);
+        assert_eq!(stats2.success_count(), 0);
+        assert_eq!(stats2.error_count(), 1);
+    }
+
+    #[test]
+    fn test_limiter_stress_many_errors() {
+        let limiter = AdaptiveConcurrencyLimiter::new(1000);
+
+        // Even 100 errors shouldn't go below 1
+        for _ in 0..100 {
+            limiter.on_error();
+        }
+        assert_eq!(limiter.current_limit(), 1);
+
+        // Still able to acquire 1
+        let permit = limiter.try_acquire();
+        assert!(permit.is_some());
+        assert_eq!(limiter.in_flight(), 1);
+    }
+}

--- a/crates/client/flashblocks/src/rpc/eth.rs
+++ b/crates/client/flashblocks/src/rpc/eth.rs
@@ -13,13 +13,17 @@ use alloy_rpc_types::{
     state::{EvmOverrides, StateOverride, StateOverridesBuilder},
 };
 use alloy_rpc_types_eth::{Filter, Log};
+use base_alloy_consensus::OpTxEnvelope;
 use base_alloy_network::Base;
 use base_alloy_rpc_types::OpTransactionRequest;
 use jsonrpsee::{
-    core::{RpcResult, async_trait},
+    core::{RpcResult, async_trait, client::ClientT},
+    http_client::HttpClient,
     proc_macros::rpc,
+    rpc_params,
 };
 use jsonrpsee_types::{ErrorObjectOwned, error::INVALID_PARAMS_CODE};
+use reth_primitives::transaction::SignedTransaction;
 use reth_provider::CanonStateSubscriptions;
 use reth_rpc::eth::EthFilter;
 use reth_rpc_eth_api::{
@@ -27,12 +31,12 @@ use reth_rpc_eth_api::{
     helpers::{EthBlocks, EthCall, EthState, EthTransactions, FullEthApi},
 };
 use reth_rpc_eth_types::EthApiError;
-use tokio::{sync::broadcast::error::RecvError, time};
+use reth_transaction_pool::{PoolTransaction, TransactionOrigin, TransactionPool};
+use tokio::{
+    sync::{Semaphore, broadcast::error::RecvError},
+    time,
+};
 use tokio_stream::{StreamExt, wrappers::BroadcastStream};
-use reth_transaction_pool::{TransactionPool, TransactionOrigin, PoolTransaction};
-use reth_primitives::transaction::SignedTransaction;
-use base_alloy_consensus::OpTxEnvelope;
-use url::Url;
 use tracing::{debug, trace, warn};
 
 use crate::{FlashblocksAPI, Metrics, PendingBlocksAPI};
@@ -123,7 +127,8 @@ pub trait EthApiOverride {
 
     /// Sends a raw transaction
     #[method(name = "sendRawTransaction")]
-    async fn send_raw_transaction(&self, transaction: alloy_primitives::Bytes) -> RpcResult<TxHash>;
+    async fn send_raw_transaction(&self, transaction: alloy_primitives::Bytes)
+    -> RpcResult<TxHash>;
 }
 
 /// Extended Eth API with flashblocks support.
@@ -133,14 +138,30 @@ pub struct EthApiExt<Eth: EthApiTypes, FB, Pool> {
     eth_filter: EthFilter<Eth>,
     flashblocks_state: Arc<FB>,
     pool: Pool,
-    builder_rpc: Vec<Url>,
+    builder_clients: Vec<HttpClient>,
+    builder_rpc_semaphore: Arc<Semaphore>,
     metrics: Metrics,
 }
 
 impl<Eth: EthApiTypes, FB, Pool> EthApiExt<Eth, FB, Pool> {
     /// Creates a new extended Eth API instance with flashblocks support.
-    pub fn new(eth_api: Eth, eth_filter: EthFilter<Eth>, flashblocks_state: Arc<FB>, pool: Pool, builder_rpc: Vec<Url>) -> Self {
-        Self { eth_api, eth_filter, flashblocks_state, pool, builder_rpc, metrics: Metrics::default() }
+    pub fn new(
+        eth_api: Eth,
+        eth_filter: EthFilter<Eth>,
+        flashblocks_state: Arc<FB>,
+        pool: Pool,
+        builder_clients: Vec<HttpClient>,
+        builder_rpc_semaphore: Arc<Semaphore>,
+    ) -> Self {
+        Self {
+            eth_api,
+            eth_filter,
+            flashblocks_state,
+            pool,
+            builder_clients,
+            builder_rpc_semaphore,
+            metrics: Metrics::default(),
+        }
     }
 }
 
@@ -150,7 +171,8 @@ where
     Eth: FullEthApi<NetworkTypes = Base> + Send + Sync + 'static,
     FB: FlashblocksAPI + Send + Sync + 'static,
     Pool: TransactionPool + 'static,
-    <Pool as TransactionPool>::Transaction: PoolTransaction<Pooled = base_alloy_consensus::OpPooledTransaction>,
+    <Pool as TransactionPool>::Transaction:
+        PoolTransaction<Pooled = base_alloy_consensus::OpPooledTransaction>,
     jsonrpsee_types::error::ErrorObject<'static>: From<Eth::Error>,
 {
     async fn block_by_number(
@@ -546,38 +568,59 @@ where
             .map_err(Into::into)
     }
 
-    async fn send_raw_transaction(&self, transaction: alloy_primitives::Bytes) -> RpcResult<TxHash> {
+    async fn send_raw_transaction(
+        &self,
+        transaction: alloy_primitives::Bytes,
+    ) -> RpcResult<TxHash> {
         debug!(
             message = "rpc::send_raw_transaction",
             transaction = ?transaction
         );
 
-        // Decode the transaction
+        // Decode the transaction with proper error handling
         let mut b = transaction.as_ref();
-        // TODO: no unwraps
-        let envelope = OpTxEnvelope::decode_2718(&mut b).unwrap();
-        let pooled = envelope.try_into_pooled().unwrap();
-        let recovered = pooled.try_into_recovered().unwrap();
+        let envelope = OpTxEnvelope::decode_2718(&mut b)
+            .map_err(|_| EthApiError::FailedToDecodeSignedTransaction)?;
+        let pooled =
+            envelope.try_into_pooled().map_err(|_| EthApiError::FailedToDecodeSignedTransaction)?;
+        let recovered =
+            pooled.try_into_recovered().map_err(|_| EthApiError::InvalidTransactionSignature)?;
 
         // Validate the transaction by adding it to the pool
         let pool_tx = <Pool as TransactionPool>::Transaction::from_pooled(recovered);
-        let tx_hash = pool_tx.hash().0.to_owned();
-        self.pool.add_transaction(TransactionOrigin::External, pool_tx).await
-            .map_err(|e| EthApiError::PoolError(e.into()).into())?;
+        let tx_hash = *pool_tx.hash();
+        self.pool
+            .add_transaction(TransactionOrigin::External, pool_tx)
+            .await
+            .map_err(|e| EthApiError::PoolError(e.into()))?;
 
-        // No errors, so the tx is valid
-        // Rollout 1: We call the builder's RPC endpoint to `eth_sendRawTransaction`
-        for builder_rpc in self.builder_rpc.iter() {
-            let client = JsonRpcClient::new(builder_rpc.clone());
-            let response = client.send_raw_transaction(transaction).await;
-            if response.is_ok() {
-                return Ok(TxHash::from(tx_hash));
-            }
+        // Fire-and-forget to all builder RPCs concurrently with rate limiting
+        for client in &self.builder_clients {
+            let client = client.clone();
+            let semaphore = Arc::clone(&self.builder_rpc_semaphore);
+            let tx_bytes = transaction.clone();
+
+            tokio::spawn(async move {
+                // Try to acquire permit, skip if rate limited
+                let _permit = match semaphore.try_acquire() {
+                    Ok(p) => p,
+                    Err(_) => {
+                        warn!(message = "rate limited: skipping builder RPC forward");
+                        return;
+                    }
+                };
+
+                // Fire-and-forget RPC call to builder
+                if let Err(e) = client
+                    .request::<TxHash, _>("eth_sendRawTransaction", rpc_params![tx_bytes])
+                    .await
+                {
+                    warn!(message = "builder RPC forward failed", error = %e);
+                }
+            });
         }
 
-        
-
-        Ok(TxHash::from(tx_hash))
+        Ok(tx_hash)
     }
 }
 

--- a/crates/client/flashblocks/src/rpc/mod.rs
+++ b/crates/client/flashblocks/src/rpc/mod.rs
@@ -1,9 +1,11 @@
 //! RPC trait definitions and implementations for flashblocks.
 
+mod backpressure;
 mod eth;
 mod pubsub;
 mod types;
 
+pub use backpressure::{AdaptiveConcurrencyLimiter, AdaptivePermit, BuilderRpcStats};
 pub use eth::{EthApiExt, EthApiOverrideServer};
 pub use pubsub::{EthPubSub, EthPubSubApiServer};
 pub use types::{BaseSubscriptionKind, ExtendedSubscriptionKind, TransactionWithLogs};

--- a/crates/client/metering/src/rpc.rs
+++ b/crates/client/metering/src/rpc.rs
@@ -773,7 +773,7 @@ mod tests {
 
         // Create a shared flashblocks state that we can inject pending blocks into
         let flashblocks_config =
-            FlashblocksConfig::new(Url::parse("ws://localhost:12345").unwrap(), 10, None)
+            FlashblocksConfig::new(Url::parse("ws://localhost:12345").unwrap(), 10, None, None)
                 .expect("Failed to create flashblocks config");
         let flashblocks_state = Arc::clone(&flashblocks_config.state);
 

--- a/crates/client/metering/src/rpc.rs
+++ b/crates/client/metering/src/rpc.rs
@@ -773,7 +773,8 @@ mod tests {
 
         // Create a shared flashblocks state that we can inject pending blocks into
         let flashblocks_config =
-            FlashblocksConfig::new(Url::parse("ws://localhost:12345").unwrap(), 10);
+            FlashblocksConfig::new(Url::parse("ws://localhost:12345").unwrap(), 10, None)
+                .expect("Failed to create flashblocks config");
         let flashblocks_state = Arc::clone(&flashblocks_config.state);
 
         // Setup harness with flashblocks-enabled metering

--- a/crates/infra/ingress-rpc/src/service.rs
+++ b/crates/infra/ingress-rpc/src/service.rs
@@ -9,9 +9,7 @@ use alloy_provider::{Provider, RootProvider, network::eip2718::Decodable2718};
 use audit_archiver_lib::BundleEvent;
 use base_alloy_consensus::OpTxEnvelope;
 use base_alloy_network::Base;
-use base_bundles::{
-    AcceptedBundle, Bundle, BundleExtensions, MeterBundleResponse, ParsedBundle,
-};
+use base_bundles::{AcceptedBundle, Bundle, BundleExtensions, MeterBundleResponse, ParsedBundle};
 use jsonrpsee::{
     core::{RpcResult, async_trait},
     proc_macros::rpc,

--- a/devnet/src/l2/in_process_client.rs
+++ b/devnet/src/l2/in_process_client.rs
@@ -234,7 +234,7 @@ impl InProcessClient {
             .parse()
             .map_err(|e| eyre!("Failed to parse flashblocks URL: {}", e))?;
 
-        let flashblocks_config = FlashblocksConfig::new(flashblocks_url, 3);
+        let flashblocks_config = FlashblocksConfig::new(flashblocks_url, 3, None)?;
 
         // TxPool RPC extension (management + status APIs)
         let txpool_rpc_config =

--- a/devnet/src/l2/in_process_client.rs
+++ b/devnet/src/l2/in_process_client.rs
@@ -234,7 +234,7 @@ impl InProcessClient {
             .parse()
             .map_err(|e| eyre!("Failed to parse flashblocks URL: {}", e))?;
 
-        let flashblocks_config = FlashblocksConfig::new(flashblocks_url, 3, None)?;
+        let flashblocks_config = FlashblocksConfig::new(flashblocks_url, 3, None, None)?;
 
         // TxPool RPC extension (management + status APIs)
         let txpool_rpc_config =


### PR DESCRIPTION
Spec'd out implementation PR to override `eth_sendRawTransaction`

Why?
- First pass lets us make changes to only the mpool nodes, which this override will only be available on without needing to touch the builder
- Lets us align on the skeleton / architecture of the following rollouts on where this rpc method lives

Changes
- Overrides `eth_sendRawTransaction` to validate by adding the transaction to its local pool
- Forwards to a configured set of builder RPC URLs
- Implements dynamic throttling by measuring the # of sucess/failures return by the builder
- Has a configurable number of max in-flight requests that we can adjust to cap the ceiling 
