### PR TITLE
ci: add free disk space step to clippy and cargo deny jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,6 +144,16 @@ jobs:
         with:
           egress-policy: audit
 
+      - name: Free Disk Space
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
+        with:
+          tool-cache: false
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: false
+          swap-storage: true
+
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Install native dependencies
@@ -259,6 +269,16 @@ jobs:
         uses: step-security/harden-runner@95d9a5deda9de15063e7595e9719c11c38c90ae2 # v2.13.2
         with:
           egress-policy: audit
+
+      - name: Free Disk Space
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
+        with:
+          tool-cache: false
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: false
+          swap-storage: true
 
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: dtolnay/rust-toolchain@4305c38b25d97ef35a8ad1f985ccf2d2242004f2 # stable


### PR DESCRIPTION
## Summary
- The Clippy and Cargo Deny CI jobs were failing with `No space left on device` errors during the rust-cache restore step
- The Build and Test jobs already had the `jlumbroso/free-disk-space` step but Clippy and Cargo Deny were missing it
- Adds the same free disk space step to both jobs, freeing ~30GB by removing preinstalled Android SDK, .NET, Haskell, and swap storage