### PR TITLE
feat(consensus): Hardfork Consistency Tests

### DIFF
--- a/crates/consensus/registry/Cargo.toml
+++ b/crates/consensus/registry/Cargo.toml
@@ -34,6 +34,10 @@ lazy_static = { workspace = true, features = ["spin_no_std"] }
 [dev-dependencies]
 alloy-eips.workspace = true
 
+[[test]]
+name = "hardfork_consistency"
+required-features = ["test-utils"]
+
 [features]
 default = []
 std = [
@@ -44,3 +48,4 @@ std = [
 	"kona-genesis/std",
 	"toml/std",
 ]
+test-utils = []

--- a/crates/consensus/registry/src/lib.rs
+++ b/crates/consensus/registry/src/lib.rs
@@ -15,5 +15,5 @@ pub use registry::Registry;
 mod l1;
 pub use l1::{L1Config, L1GenesisGetterErrors};
 
-#[cfg(test)]
+#[cfg(any(test, feature = "test-utils"))]
 pub mod test_utils;

--- a/crates/consensus/registry/tests/hardfork_consistency.rs
+++ b/crates/consensus/registry/tests/hardfork_consistency.rs
@@ -1,0 +1,41 @@
+//! Integration tests verifying that [`kona_registry`] rollup configs agree with
+//! [`base_alloy_hardforks`] chain hardfork schedules for every [`OpHardfork`] variant.
+
+use base_alloy_hardforks::{OpChainHardforks, OpHardfork, OpHardforks};
+use kona_registry::test_utils::{BASE_MAINNET_CONFIG, BASE_SEPOLIA_CONFIG};
+
+#[test]
+fn mainnet_rollup_config_matches_chain_hardforks() {
+    let chain = OpChainHardforks::base_mainnet();
+    for fork in OpHardfork::VARIANTS {
+        // Regolith activated at genesis on Base and is stored as `regolith_time: None`
+        // in the rollup config. The `op_fork_activation` cascade returns Canyon's
+        // ForkCondition when Regolith is unset, which differs from OpChainHardforks'
+        // explicit Timestamp(0). This is harmless: Canyon is already in the past, so
+        // Regolith is always active at any real L2 timestamp.
+        if *fork == OpHardfork::Regolith {
+            continue;
+        }
+        assert_eq!(
+            BASE_MAINNET_CONFIG.op_fork_activation(*fork),
+            chain.op_fork_activation(*fork),
+            "mainnet fork activation mismatch for {fork:?}",
+        );
+    }
+}
+
+#[test]
+fn sepolia_rollup_config_matches_chain_hardforks() {
+    let chain = OpChainHardforks::base_sepolia();
+    for fork in OpHardfork::VARIANTS {
+        // See comment in mainnet test above.
+        if *fork == OpHardfork::Regolith {
+            continue;
+        }
+        assert_eq!(
+            BASE_SEPOLIA_CONFIG.op_fork_activation(*fork),
+            chain.op_fork_activation(*fork),
+            "sepolia fork activation mismatch for {fork:?}",
+        );
+    }
+}


### PR DESCRIPTION
## Add hardfork schedule consistency integration tests

Adds integration tests to `kona-registry` that verify `RollupConfig`
hardfork activation conditions match the canonical `OpChainHardforks`
schedules in `base-alloy-hardforks` for every `OpHardfork` variant, on
both Base mainnet and Base Sepolia.

These tests guard against a class of silent divergence: when a new
hardfork is added to `OpHardfork` but its activation timestamp is
omitted or misset in the registry rollup configs (or vice versa), the
tests fail immediately.

Regolith is explicitly skipped with a comment — Base launched with
Regolith active at genesis so `regolith_time` is `None` in the rollup
config, causing `op_fork_activation` to fall back to Canyon's condition.
The representations differ but the behavior is equivalent since Canyon is
already in the past.

Run with:
```
cargo test -p kona-registry --features kona-registry/test-utils
```