### PR TITLE
fix: read new_account_balances before take_bundle empties state

### DIFF
--- a/crates/builder/core/src/flashblocks/payload.rs
+++ b/crates/builder/core/src/flashblocks/payload.rs
@@ -1004,8 +1004,16 @@ where
 
     let recovered_block =
         RecoveredBlock::new_unhashed(block.clone(), info.executed_senders.clone());
-    // create the executed block data
 
+    // Read account balances BEFORE take_bundle() empties the bundle state.
+    let new_account_balances = state
+        .bundle_state
+        .state
+        .iter()
+        .filter_map(|(address, account)| account.info.as_ref().map(|info| (*address, info.balance)))
+        .collect::<HashMap<Address, U256>>();
+
+    // create the executed block data
     let executed = BuiltPayloadExecutedBlock {
         recovered_block: Arc::new(recovered_block),
         execution_output: Arc::new(BlockExecutionOutput {
@@ -1044,13 +1052,6 @@ where
         .zip(new_receipts.iter())
         .map(|(tx, receipt)| (tx.tx_hash(), receipt.clone()))
         .collect::<HashMap<B256, OpReceipt>>();
-
-    let new_account_balances = state
-        .bundle_state
-        .state
-        .iter()
-        .filter_map(|(address, account)| account.info.as_ref().map(|info| (*address, info.balance)))
-        .collect::<HashMap<Address, U256>>();
 
     // finalize and build the FAL
     let fal_builder = std::mem::take(&mut info.extra.access_list_builder);


### PR DESCRIPTION
## Summary

`new_account_balances` in `FlashblocksMetadata` is always empty because it's read after `state.take_bundle()` empties the bundle state. This moves the read above `take_bundle()` so it captures actual balances.

Introduced by #861 which placed the read after `take_bundle()`. The earlier closed PR #859 had the correct ordering.

Closes #894

## Changes

- Moved `new_account_balances` computation before `take_bundle()` call in `build_block()`
- Removed the now-redundant read that was below `take_bundle()`