### PR TITLE
fix(builder): populate finalized_cell during historical sync

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -652,7 +652,6 @@ dependencies = [
  "alloy-primitives",
  "alloy-rlp",
  "alloy-serde",
- "arbitrary",
  "derive_more",
  "ethereum_ssz",
  "ethereum_ssz_derive",

--- a/crates/builder/core/src/flashblocks/payload.rs
+++ b/crates/builder/core/src/flashblocks/payload.rs
@@ -282,6 +282,9 @@ where
         )?;
 
         self.payload_tx.send(payload.clone()).await.map_err(PayloadBuilderError::other)?;
+        if compute_state_root_on_finalize {
+            finalized_cell.set(payload.clone());
+        }
         best_payload.set(payload);
 
         info!(
@@ -309,7 +312,6 @@ where
             ctx.metrics.payload_num_tx.record(info.executed_transactions.len() as f64);
             ctx.metrics.payload_num_tx_gauge.set(info.executed_transactions.len() as f64);
 
-            // return early since we don't need to build a block with transactions from the pool
             return Ok(());
         }
         // We adjust our flashblocks timings based on time_drift if dynamic adjustment enable

--- a/crates/builder/core/src/flashblocks/payload.rs
+++ b/crates/builder/core/src/flashblocks/payload.rs
@@ -282,10 +282,7 @@ where
         )?;
 
         self.payload_tx.send(payload.clone()).await.map_err(PayloadBuilderError::other)?;
-        if compute_state_root_on_finalize {
-            finalized_cell.set(payload.clone());
-        }
-        best_payload.set(payload);
+        best_payload.set(payload.clone());
 
         info!(
             target: "payload_builder",
@@ -301,6 +298,10 @@ where
         }
 
         if ctx.attributes().no_tx_pool {
+            if compute_state_root_on_finalize {
+                finalized_cell.set(payload);
+            }
+
             info!(
                 target: "payload_builder",
                 "No transaction pool, skipping transaction pool processing",

--- a/crates/builder/core/tests/flashblocks.rs
+++ b/crates/builder/core/tests/flashblocks.rs
@@ -298,7 +298,7 @@ async fn dynamic_with_full_block_lag() -> eyre::Result<()> {
 
 /// Regression test: when `compute_state_root_on_finalize` is enabled and the builder
 /// receives an FCU with `no_tx_pool = true` (historical sync), `resolve_kind` must still
-/// return a payload. 
+/// return a payload.
 #[tokio::test]
 async fn test_no_tx_pool_with_compute_state_root_on_finalize() -> eyre::Result<()> {
     let flashblocks = FlashblocksConfig::for_tests()
@@ -314,12 +314,10 @@ async fn test_no_tx_pool_with_compute_state_root_on_finalize() -> eyre::Result<(
 
     // Build a block with no_tx_pool=true (historical sync).
     // Before the fix this would hang forever because finalized_cell was never set.
-    let block = tokio::time::timeout(
-        Duration::from_secs(30),
-        driver.build_new_block_with_no_tx_pool(),
-    )
-    .await
-    .expect("get_payload timed out — finalized_cell was likely never populated")?;
+    let block =
+        tokio::time::timeout(Duration::from_secs(30), driver.build_new_block_with_no_tx_pool())
+            .await
+            .expect("get_payload timed out — finalized_cell was likely never populated")?;
 
     // The block must contain the deposit transaction
     assert_eq!(

--- a/crates/builder/core/tests/flashblocks.rs
+++ b/crates/builder/core/tests/flashblocks.rs
@@ -296,6 +296,48 @@ async fn dynamic_with_full_block_lag() -> eyre::Result<()> {
     flashblocks_listener.stop().await
 }
 
+/// Regression test: when `compute_state_root_on_finalize` is enabled and the builder
+/// receives an FCU with `no_tx_pool = true` (historical sync), `resolve_kind` must still
+/// return a payload. 
+#[tokio::test]
+async fn test_no_tx_pool_with_compute_state_root_on_finalize() -> eyre::Result<()> {
+    let flashblocks = FlashblocksConfig::for_tests()
+        .with_fixed(true)
+        .with_disable_state_root(true)
+        .with_compute_state_root_on_finalize(true);
+    let config = BuilderConfig::for_tests().with_block_time_ms(2000).with_flashblocks(flashblocks);
+    let rbuilder = setup_test_instance_with_builder_config(config).await?;
+    let driver = rbuilder.driver().await?;
+
+    // Seed the chain with a normal block first so we have a valid parent
+    let _ = driver.build_new_block_with_current_timestamp(None).await?;
+
+    // Build a block with no_tx_pool=true (historical sync).
+    // Before the fix this would hang forever because finalized_cell was never set.
+    let block = tokio::time::timeout(
+        Duration::from_secs(30),
+        driver.build_new_block_with_no_tx_pool(),
+    )
+    .await
+    .expect("get_payload timed out — finalized_cell was likely never populated")?;
+
+    // The block must contain the deposit transaction
+    assert_eq!(
+        block.transactions.len(),
+        1,
+        "no_tx_pool block should contain exactly one deposit transaction"
+    );
+
+    // State root should be valid (non-zero) because no_tx_pool forces state root calculation
+    assert_ne!(
+        block.header.state_root,
+        B256::ZERO,
+        "State root must be computed for CL sync (no_tx_pool path)"
+    );
+
+    Ok(())
+}
+
 #[tokio::test]
 async fn test_flashblocks_no_state_root_calculation() -> eyre::Result<()> {
     let flashblocks = FlashblocksConfig::for_tests()


### PR DESCRIPTION
When `compute_state_root_on_finalize` is enabled and the builder receives an FCU with `no_tx_pool = true` (historical sync), `resolve_kind` waits on `finalized_cell` which was never populated in the early-return path. This caused `get_payload` to hang until the op-node's context deadline expired, breaking historical sync.