### PR TITLE
fix(builder): populate finalized_cell during historical sync

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -656,7 +656,6 @@ dependencies = [
  "alloy-primitives",
  "alloy-rlp",
  "alloy-serde",
- "arbitrary",
  "derive_more",
  "ethereum_ssz 0.9.1",
  "ethereum_ssz_derive 0.9.1",

--- a/crates/builder/core/src/flashblocks/payload.rs
+++ b/crates/builder/core/src/flashblocks/payload.rs
@@ -282,6 +282,9 @@ where
         )?;
 
         self.payload_tx.send(payload.clone()).await.map_err(PayloadBuilderError::other)?;
+        if compute_state_root_on_finalize {
+            finalized_cell.set(payload.clone());
+        }
         best_payload.set(payload);
 
         info!(
@@ -309,7 +312,6 @@ where
             ctx.metrics.payload_num_tx.record(info.executed_transactions.len() as f64);
             ctx.metrics.payload_num_tx_gauge.set(info.executed_transactions.len() as f64);
 
-            // return early since we don't need to build a block with transactions from the pool
             return Ok(());
         }
         // We adjust our flashblocks timings based on time_drift if dynamic adjustment enable

--- a/crates/builder/core/src/flashblocks/payload.rs
+++ b/crates/builder/core/src/flashblocks/payload.rs
@@ -282,10 +282,7 @@ where
         )?;
 
         self.payload_tx.send(payload.clone()).await.map_err(PayloadBuilderError::other)?;
-        if compute_state_root_on_finalize {
-            finalized_cell.set(payload.clone());
-        }
-        best_payload.set(payload);
+        best_payload.set(payload.clone());
 
         info!(
             target: "payload_builder",
@@ -301,6 +298,10 @@ where
         }
 
         if ctx.attributes().no_tx_pool {
+            if compute_state_root_on_finalize {
+                finalized_cell.set(payload);
+            }
+
             info!(
                 target: "payload_builder",
                 "No transaction pool, skipping transaction pool processing",

--- a/crates/builder/core/tests/flashblocks.rs
+++ b/crates/builder/core/tests/flashblocks.rs
@@ -213,7 +213,7 @@ async fn dynamic_with_full_block_lag() -> eyre::Result<()> {
 
 /// Regression test: when `compute_state_root_on_finalize` is enabled and the builder
 /// receives an FCU with `no_tx_pool = true` (historical sync), `resolve_kind` must still
-/// return a payload. 
+/// return a payload.
 #[tokio::test]
 async fn test_no_tx_pool_with_compute_state_root_on_finalize() -> eyre::Result<()> {
     let flashblocks = FlashblocksConfig::for_tests()
@@ -229,12 +229,10 @@ async fn test_no_tx_pool_with_compute_state_root_on_finalize() -> eyre::Result<(
 
     // Build a block with no_tx_pool=true (historical sync).
     // Before the fix this would hang forever because finalized_cell was never set.
-    let block = tokio::time::timeout(
-        Duration::from_secs(30),
-        driver.build_new_block_with_no_tx_pool(),
-    )
-    .await
-    .expect("get_payload timed out — finalized_cell was likely never populated")?;
+    let block =
+        tokio::time::timeout(Duration::from_secs(30), driver.build_new_block_with_no_tx_pool())
+            .await
+            .expect("get_payload timed out — finalized_cell was likely never populated")?;
 
     // The block must contain the deposit transaction
     assert_eq!(


### PR DESCRIPTION
When `compute_state_root_on_finalize` is enabled and the builder receives an FCU with `no_tx_pool = true` (historical sync), `resolve_kind` waits on `finalized_cell` which was never populated in the early-return path. This caused `get_payload` to hang until the op-node's context deadline expired, breaking historical sync.