### PR TITLE
feat(tee): rework enclave build for monorepo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ target/
 .DS_Store
 .devnet/
 .sisyphus/
+eif.bin

--- a/crates/proof/tee/.cargo/config.toml
+++ b/crates/proof/tee/.cargo/config.toml
@@ -1,8 +1,0 @@
-# Cargo configuration for musl cross-compilation
-# Used for building static binaries for Nitro Enclave EIF
-
-[target.x86_64-unknown-linux-musl]
-rustflags = ["-C", "target-feature=+crt-static", "-C", "link-self-contained=yes"]
-
-[env]
-OPENSSL_STATIC = "1"

--- a/crates/proof/tee/Justfile
+++ b/crates/proof/tee/Justfile
@@ -1,28 +1,20 @@
 set positional-arguments
 
-eif_image_name := "op-enclave-rust-eif"
+eif_image_name := "base-enclave-rust-eif"
 eif_output := "eif.bin"
 
 # Default recipe to display help information
 default:
     @just --list
 
-# Build the Go enclave server
-build-go-server:
-    cd ../op-enclave/op-enclave && go build -o bin/enclave ./cmd/enclave
-
-# Run integration tests (requires Go server to be running)
-test-integration: build-go-server
-    cargo test --package op-enclave-server --test go_interop -- --ignored --test-threads=1
-
-# Run the enclave server locally (HTTP mode on port 1234)
-run-server:
+# Run the nitro enclave server locally (HTTP mode on port 1234)
+run-nitro:
     RUST_LOG=info OP_ENCLAVE_SIGNER_KEY=ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80 \
         cargo run --package base-prover --bin prover -- nitro
 
 # Build EIF using Docker
 build-eif:
-    docker build -f Dockerfile.enclave -t {{ eif_image_name }} .
+    cd ../../.. && docker build --platform linux/amd64 -f etc/docker/Dockerfile.enclave -t {{ eif_image_name }} .
     docker create --name eif-extract {{ eif_image_name }}
     docker cp eif-extract:/build/eif.bin {{ eif_output }}
     docker rm eif-extract
@@ -31,7 +23,8 @@ build-eif:
 
 # Local musl release build (requires musl toolchain)
 musl-release:
-    OPENSSL_STATIC=1 cargo build --release --target x86_64-unknown-linux-musl --package base-prover --bin prover
+    OPENSSL_STATIC=1 CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_RUSTFLAGS="-C target-feature=+crt-static -C link-self-contained=yes" \
+        cargo build --release --target x86_64-unknown-linux-musl --package base-prover --bin prover
     @echo "Binary built at: target/x86_64-unknown-linux-musl/release/prover"
     @ls -lh target/x86_64-unknown-linux-musl/release/prover
 

--- a/crates/proof/tee/eif/user-ramdisk-rust.yaml
+++ b/crates/proof/tee/eif/user-ramdisk-rust.yaml
@@ -35,11 +35,11 @@ files:
               ff02::2 ip6-allrouters
               "
     mode: "0755"
-  - path: rootfs/bin/enclave
-    source: target/x86_64-unknown-linux-musl/release/enclave
+  - path: rootfs/bin/prover
+    source: target/x86_64-unknown-linux-musl/release/prover
     mode: "0755"
   - path: cmd
-    contents: "/bin/enclave"
+    contents: "/bin/prover"
     mode: "0644"
   - path: env
     contents: ""

--- a/etc/docker/Dockerfile.enclave
+++ b/etc/docker/Dockerfile.enclave
@@ -1,15 +1,23 @@
-# Multi-stage Dockerfile for building Rust enclave EIF
-# Mirrors the Go setup in op-enclave/Dockerfile
+# Multi-stage Dockerfile for building Rust base-enclave EIF
 
 # Stage 1: Bootstrap - AWS Nitro SDK bootstrap image for kernel + NSM
 FROM ghcr.io/mdehoog/aws-nitro-enclaves-sdk-bootstrap@sha256:6e5e53bd47370dbc1920208e93d222533a36f9f5dc85615591cbfe56a03312b0 AS bootstrap
 
-
-# Stage 2: Builder - Alpine-based Rust image with musl toolchain
-FROM rust:1.88-alpine AS builder
+# Stage 2: Chef base image - Alpine provides musl libc, which produces fully static
+# binaries required for the Nitro Enclave ramdisk (no libc available at runtime).
+FROM lukemathwalker/cargo-chef:latest-rust-1.93-alpine3.21 AS chef
+WORKDIR /app
 
 # Set reproducible build timestamp
 ENV SOURCE_DATE_EPOCH=0
+
+# Set musl static linking flags
+ENV CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_RUSTFLAGS="-C target-feature=+crt-static -C link-self-contained=yes"
+
+# Set OpenSSL static linking environment variables
+ENV OPENSSL_STATIC=1
+ENV OPENSSL_LIB_DIR=/usr/lib
+ENV OPENSSL_INCLUDE_DIR=/usr/include
 
 # Install build dependencies for musl static builds
 RUN apk add --no-cache \
@@ -23,65 +31,43 @@ RUN apk add --no-cache \
     git \
     go
 
-# Set OpenSSL static linking environment variables
-ENV OPENSSL_STATIC=1
-ENV OPENSSL_LIB_DIR=/usr/lib
-ENV OPENSSL_INCLUDE_DIR=/usr/include
-
 # Install linuxkit at the specific commit
 RUN go install github.com/linuxkit/linuxkit/src/cmd/linuxkit@270fd1c5aa1986977b31af6c743c6a2681f67a29
 ENV PATH="${PATH}:/root/go/bin"
 
-WORKDIR /build
+# Stage 3: Planner - analyze dependencies
+FROM chef AS planner
+COPY . .
+RUN cargo chef prepare --recipe-path recipe.json
 
-# Add musl target
-RUN rustup target add x86_64-unknown-linux-musl
+# Stage 4: Builder - cook dependencies, then build
+FROM chef AS builder
 
-# Copy Cargo files first for dependency caching
-COPY Cargo.toml Cargo.lock ./
-COPY .cargo .cargo/
-COPY core/Cargo.toml core/
-COPY server/Cargo.toml server/
-COPY client/Cargo.toml client/
+# Copy ONLY the recipe (dependency metadata)
+COPY --from=planner /app/recipe.json recipe.json
 
-# Create dummy source files for dependency compilation
-RUN mkdir -p core/src server/src client/src && \
-    echo "pub fn dummy() {}" > core/src/lib.rs && \
-    mkdir -p server/src/bin && \
-    echo "fn main() {}" > server/src/lib.rs && \
-    echo "fn main() {}" > server/src/bin/enclave.rs && \
-    echo "fn main() {}" > client/src/lib.rs
+# Build dependencies - THIS LAYER IS CACHED until Cargo.toml/Cargo.lock change
+RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
+    --mount=type=cache,target=/usr/local/cargo/git,sharing=locked \
+    cargo chef cook --release --target x86_64-unknown-linux-musl --package base-prover --recipe-path recipe.json
 
-# Build dependencies (cached layer)
-RUN cargo build --release --target x86_64-unknown-linux-musl --package base-enclave-server --bin enclave || true
-
-# Copy actual source code
-COPY core core/
-COPY server server/
-COPY client client/
-
-# Touch source files to invalidate cache
-RUN touch core/src/lib.rs server/src/lib.rs
-
-# Build the enclave binary with musl target
-RUN cargo build --release --target x86_64-unknown-linux-musl --package base-enclave-server --bin enclave
+# Now copy source and build (only your code compiles here)
+COPY . .
+RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
+    --mount=type=cache,target=/usr/local/cargo/git,sharing=locked \
+    cargo build --release --target x86_64-unknown-linux-musl --package base-prover --bin prover
 
 # Strip debug symbols for smaller binary
-RUN strip target/x86_64-unknown-linux-musl/release/enclave
+RUN strip target/x86_64-unknown-linux-musl/release/prover
 
 # Copy EIF configuration and build ramdisks
-COPY eif eif/
 COPY --from=bootstrap /build/out bootstrap
-
-# Build init ramdisk (init-ramdisk.yaml copied from Go setup)
-RUN linuxkit build --format kernel+initrd --no-sbom --name init-ramdisk ./eif/init-ramdisk.yaml
-
-# Build user ramdisk with Rust binary
-RUN linuxkit build --format kernel+initrd --no-sbom --name user-ramdisk ./eif/user-ramdisk-rust.yaml
+RUN linuxkit build --format kernel+initrd --no-sbom --name init-ramdisk ./crates/proof/tee/eif/init-ramdisk.yaml
+RUN linuxkit build --format kernel+initrd --no-sbom --name user-ramdisk ./crates/proof/tee/eif/user-ramdisk-rust.yaml
 
 
-# Stage 3: EIF - Build EIF using aws-nitro-enclaves-image-format
-FROM rust:1.88 AS eif
+# Stage 5: EIF - Build EIF using aws-nitro-enclaves-image-format
+FROM rust:1.93 AS eif
 
 # Set reproducible build timestamp
 ENV SOURCE_DATE_EPOCH=0
@@ -98,11 +84,11 @@ RUN git init && \
 
 RUN cargo build --all --release
 
-# Copy cmdline (copied from Go setup)
-COPY eif/cmdline-x86_64 cmdline
+# Copy cmdline and build artifacts
+COPY crates/proof/tee/eif/cmdline-x86_64 cmdline
 COPY --from=bootstrap /build/out bootstrap
-COPY --from=builder /build/init-ramdisk-initrd.img .
-COPY --from=builder /build/user-ramdisk-initrd.img .
+COPY --from=builder /app/init-ramdisk-initrd.img .
+COPY --from=builder /app/user-ramdisk-initrd.img .
 
 # Build the EIF
 RUN ./target/release/eif_build \
@@ -114,10 +100,11 @@ RUN ./target/release/eif_build \
     --output eif.bin
 
 
-# Stage 4: Final - Extract EIF to minimal container
+# Stage 6: Final - Minimal container for artifact extraction via `docker cp`.
+# Nothing here runs directly; the enclave binary executes inside the Nitro Enclave ramdisk.
 FROM busybox
 
 WORKDIR /build
 
 COPY --from=eif /build/eif.bin .
-COPY --from=builder /build/target/x86_64-unknown-linux-musl/release/enclave .
+COPY --from=builder /app/target/x86_64-unknown-linux-musl/release/prover .

--- a/etc/docker/Dockerfile.enclave
+++ b/etc/docker/Dockerfile.enclave
@@ -5,7 +5,7 @@ FROM ghcr.io/mdehoog/aws-nitro-enclaves-sdk-bootstrap@sha256:6e5e53bd47370dbc192
 
 # Stage 2: Chef base image - Alpine provides musl libc, which produces fully static
 # binaries required for the Nitro Enclave ramdisk (no libc available at runtime).
-FROM lukemathwalker/cargo-chef:latest-rust-1.93-alpine3.21 AS chef
+FROM lukemathwalker/cargo-chef:latest-rust-1.93-alpine3.21@sha256:7d9f8f8e78087879b8988fd4e55d477a2b7f949d45a1e52903d466df99ae8c66 AS chef
 WORKDIR /app
 
 # Set reproducible build timestamp
@@ -28,12 +28,7 @@ RUN apk add --no-cache \
     perl \
     make \
     clang \
-    git \
-    go
-
-# Install linuxkit at the specific commit
-RUN go install github.com/linuxkit/linuxkit/src/cmd/linuxkit@270fd1c5aa1986977b31af6c743c6a2681f67a29
-ENV PATH="${PATH}:/root/go/bin"
+    git
 
 # Stage 3: Planner - analyze dependencies
 FROM chef AS planner
@@ -42,6 +37,11 @@ RUN cargo chef prepare --recipe-path recipe.json
 
 # Stage 4: Builder - cook dependencies, then build
 FROM chef AS builder
+
+# Install go + linuxkit (only needed here for ramdisk assembly)
+RUN apk add --no-cache go
+RUN go install github.com/linuxkit/linuxkit/src/cmd/linuxkit@270fd1c5aa1986977b31af6c743c6a2681f67a29
+ENV PATH="${PATH}:/root/go/bin"
 
 # Copy ONLY the recipe (dependency metadata)
 COPY --from=planner /app/recipe.json recipe.json

--- a/etc/docker/Dockerfile.enclave
+++ b/etc/docker/Dockerfile.enclave
@@ -67,7 +67,7 @@ RUN linuxkit build --format kernel+initrd --no-sbom --name user-ramdisk ./crates
 
 
 # Stage 5: EIF - Build EIF using aws-nitro-enclaves-image-format
-FROM rust:1.93 AS eif
+FROM rust:1.93@sha256:f7c649bf7cc388826273a4977e8304778b7f8ad2e20838c1d52283cf23e49f7a AS eif
 
 # Set reproducible build timestamp
 ENV SOURCE_DATE_EPOCH=0
@@ -102,7 +102,7 @@ RUN ./target/release/eif_build \
 
 # Stage 6: Final - Minimal container for artifact extraction via `docker cp`.
 # Nothing here runs directly; the enclave binary executes inside the Nitro Enclave ramdisk.
-FROM busybox
+FROM busybox@sha256:70ce0a747f09cd7c09c2d6eaeab69d60adb0398f569296e8c0e844599388ebd6
 
 WORKDIR /build
 


### PR DESCRIPTION
## Summary

- **Rework `Dockerfile.enclave` for monorepo**: build from repo root, replace manual dummy-crate dependency caching with `cargo-chef`, upgrade Rust 1.88 → 1.93, and move musl static linking flags from `.cargo/config.toml` into env vars
- **Update `Justfile`**: rename image to `base-enclave-rust-eif`, point `build-eif` at repo root, reference `base-prover` package, remove stale Go interop targets
- **Update `user-ramdisk-rust.yaml`**: rename binary from `enclave` to `prover`
- **Remove `.cargo/config.toml`**: musl rustflags and `OPENSSL_STATIC` now live in the Dockerfile and Justfile
- **Gitignore `eif.bin`**

## Test plan

- [x] `just tee build-eif` produces `eif.bin` via Docker from the repo root
- [x] `just tee musl-release` builds the static musl binary
- [x] `just tee run-nitro` starts the enclave server locally in HTTP mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)