### PR TITLE
feat: basectl print out raw FB data

### DIFF
--- a/bin/basectl/src/cli.rs
+++ b/bin/basectl/src/cli.rs
@@ -23,7 +23,11 @@ pub(crate) enum Commands {
     Config,
     /// Flashblocks operations
     #[command(visible_alias = "f")]
-    Flashblocks,
+    Flashblocks {
+        /// Output flashblocks as JSON lines instead of the TUI
+        #[arg(long)]
+        json: bool,
+    },
     /// DA (Data Availability) backlog monitor
     #[command(visible_alias = "d")]
     Da,

--- a/bin/basectl/src/main.rs
+++ b/bin/basectl/src/main.rs
@@ -2,7 +2,7 @@
 
 mod cli;
 
-use basectl_cli::{ChainConfig, ViewId, run_app, run_app_with_view};
+use basectl_cli::{ChainConfig, ViewId, run_app, run_app_with_view, run_flashblocks_json};
 use clap::Parser;
 
 #[tokio::main]
@@ -16,7 +16,8 @@ async fn main() -> anyhow::Result<()> {
 
     match cli.command {
         Some(cli::Commands::Config) => run_app_with_view(chain_config, ViewId::Config).await,
-        Some(cli::Commands::Flashblocks) => {
+        Some(cli::Commands::Flashblocks { json: true }) => run_flashblocks_json(chain_config).await,
+        Some(cli::Commands::Flashblocks { json: false }) => {
             run_app_with_view(chain_config, ViewId::Flashblocks).await
         }
         Some(cli::Commands::Da) => run_app_with_view(chain_config, ViewId::DaMonitor).await,

--- a/crates/infra/basectl/src/app/mod.rs
+++ b/crates/infra/basectl/src/app/mod.rs
@@ -12,7 +12,7 @@ pub(crate) use router::Router;
 pub use router::ViewId;
 
 mod runner;
-pub use runner::{run_app, run_app_with_view};
+pub use runner::{run_app, run_app_with_view, run_flashblocks_json};
 
 mod view;
 pub(crate) use view::View;

--- a/crates/infra/basectl/src/app/runner.rs
+++ b/crates/infra/basectl/src/app/runner.rs
@@ -110,7 +110,7 @@ pub async fn run_flashblocks_json(config: ChainConfig) -> Result<()> {
 
     tokio::spawn(async move {
         while let Some(toast) = toast_rx.recv().await {
-            warn!(msg = %toast.message, "connection status");
+            eprintln!("connection status: {}", toast.message);
         }
     });
 

--- a/crates/infra/basectl/src/app/runner.rs
+++ b/crates/infra/basectl/src/app/runner.rs
@@ -3,7 +3,6 @@ use std::io::Write;
 use anyhow::Result;
 use base_alloy_flashblocks::Flashblock;
 use tokio::sync::mpsc;
-use tracing::warn;
 
 use super::{App, Resources, ViewId, views::create_view};
 use crate::{

--- a/crates/infra/basectl/src/lib.rs
+++ b/crates/infra/basectl/src/lib.rs
@@ -1,7 +1,7 @@
 #![doc = include_str!("../README.md")]
 
 mod app;
-pub use app::{ViewId, run_app, run_app_with_view};
+pub use app::{ViewId, run_app, run_app_with_view, run_flashblocks_json};
 
 mod commands;
 mod config;


### PR DESCRIPTION
# Description
Enable `basectl` to be a replacement for https://github.com/danyalprout/flashblocks-websocket-client, it used to do this but may have got list in the port to this repo
```
basectl -c mainnet flashblocks --json | jq
```