### PR TITLE
fix(devnet): use release profile in devnet to avoid reth `debug_assert` panic

### DIFF
--- a/etc/docker/docker-compose.yml
+++ b/etc/docker/docker-compose.yml
@@ -159,7 +159,8 @@ services:
       context: ../..
       dockerfile: etc/docker/Dockerfile.builder
       args:
-        - PROFILE=${CARGO_PROFILE:-dev}
+        # TODO: change this to dev once reth includes paradigmxyz/reth#22505 as part of an official release
+        - PROFILE=${CARGO_PROFILE:-release}
     container_name: base-builder
     depends_on:
       setup-l2:
@@ -322,7 +323,8 @@ services:
       context: ../..
       dockerfile: etc/docker/Dockerfile.client
       args:
-        - PROFILE=${CARGO_PROFILE:-dev}
+        # TODO: change this to dev once reth includes paradigmxyz/reth#22505 as part of an official release
+        - PROFILE=${CARGO_PROFILE:-release}
     container_name: base-client
     depends_on:
       setup-l2:


### PR DESCRIPTION
We use the release profile for base-client and base-builder in our devnet for now to avoid the `debug_assert` panic in reth v1.11.1 that causes our `op-node` in devnet to crash, stalling the devnet. `op-node` engine's proof workers happen to run on rayon threads, so they trip this assert in dev builds.

Upstream reth has already [fixed this](https://github.com/paradigmxyz/reth/pull/22505) but this is yet to be released.