### PR TITLE
chore: optimize dev/ci profiles, add linker config, bump rust to 1.93

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,16 @@
+# Faster linkers: mold on Linux, lld on macOS.
+# Prerequisites:
+#   Linux:  apt install mold  (or already provided by CI setup-mold action)
+#   macOS:  brew install lld
+
+[target.x86_64-unknown-linux-gnu]
+rustflags = ["-C", "link-arg=-fuse-ld=mold"]
+
+[target.aarch64-unknown-linux-gnu]
+rustflags = ["-C", "link-arg=-fuse-ld=mold"]
+
+[target.aarch64-apple-darwin]
+rustflags = ["-C", "link-arg=-fuse-ld=/opt/homebrew/opt/lld/bin/ld64.lld", "-C", "split-debuginfo=unpacked"]
+
+[target.x86_64-apple-darwin]
+rustflags = ["-C", "link-arg=-fuse-ld=/usr/local/opt/lld/bin/ld64.lld", "-C", "split-debuginfo=unpacked"]

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -10,7 +10,7 @@ rustflags = ["-C", "link-arg=-fuse-ld=mold"]
 rustflags = ["-C", "link-arg=-fuse-ld=mold"]
 
 [target.aarch64-apple-darwin]
-rustflags = ["-C", "link-arg=-fuse-ld=/opt/homebrew/opt/lld/bin/ld64.lld", "-C", "split-debuginfo=unpacked"]
+rustflags = ["-C", "link-arg=-fuse-ld=/opt/homebrew/opt/lld/bin/ld64.lld"]
 
 [target.x86_64-apple-darwin]
-rustflags = ["-C", "link-arg=-fuse-ld=/usr/local/opt/lld/bin/ld64.lld", "-C", "split-debuginfo=unpacked"]
+rustflags = ["-C", "link-arg=-fuse-ld=/usr/local/opt/lld/bin/ld64.lld"]

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -1,0 +1,98 @@
+name: Setup
+description: Shared CI setup for Rust projects
+
+inputs:
+  toolchain:
+    description: Rust toolchain channel (stable or nightly)
+    default: "stable"
+  components:
+    description: Rust components to install (e.g. clippy, rustfmt)
+    default: ""
+  tools:
+    description: Cargo tools to install via taiki-e/install-action
+    default: ""
+  foundry:
+    description: Install Foundry
+    default: "false"
+  mold:
+    description: Install mold linker
+    default: "false"
+  native-deps:
+    description: Install native build dependencies (clang, llvm, etc.)
+    default: "false"
+  free-disk:
+    description: Free disk space before building
+    default: "false"
+  rust-cache-shared-key:
+    description: Shared key for Rust cache (empty to skip caching)
+    default: ""
+  rust-cache-save:
+    description: Whether to save the Rust cache
+    default: "false"
+
+runs:
+  using: composite
+  steps:
+    - name: Free Disk Space
+      if: inputs.free-disk == 'true'
+      uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
+      with:
+        tool-cache: false
+        android: true
+        dotnet: true
+        haskell: true
+        large-packages: false
+        swap-storage: true
+
+    - name: Install native dependencies
+      if: inputs.native-deps == 'true'
+      uses: awalsh128/cache-apt-pkgs-action@5902b33ae29014e6ca012c5d8025d4346556bd40 # v1.4.3
+      with:
+        packages: libsqlite3-dev clang libclang-dev llvm llvm-dev build-essential pkg-config
+        version: 1.2
+
+    - name: Install Rust (stable)
+      if: inputs.toolchain == 'stable'
+      uses: dtolnay/rust-toolchain@4305c38b25d97ef35a8ad1f985ccf2d2242004f2 # stable
+      with:
+        components: ${{ inputs.components }}
+
+    - name: Install Rust (nightly)
+      if: inputs.toolchain == 'nightly'
+      uses: dtolnay/rust-toolchain@0c3131df9e5407c0c36352032d04af846dbe0fb7 # nightly
+      with:
+        components: ${{ inputs.components }}
+
+    - name: Install mold
+      if: inputs.mold == 'true'
+      uses: rui314/setup-mold@725a8794d15fc7563f59595bd9556495c0564878 # v1
+
+    - name: Rust cache
+      if: inputs.rust-cache-shared-key != ''
+      uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2.8.2
+      with:
+        cache-on-failure: true
+        shared-key: ${{ inputs.rust-cache-shared-key }}
+        save-if: ${{ inputs.rust-cache-save }}
+
+    - name: Install just
+      uses: extractions/setup-just@e33e0265a09d6d736e2ee1e0eb685ef1de4669ff # v3
+
+    - name: Install cargo tools
+      if: inputs.tools != ''
+      uses: taiki-e/install-action@3575e532701a5fc614b0c842e4119af4cc5fd16d # v2.62.60
+      with:
+        tool: ${{ inputs.tools }}
+
+    - name: Install Foundry
+      if: inputs.foundry == 'true'
+      uses: foundry-rs/foundry-toolchain@50d5a8956f2e319df19e6b57539d7e2acb9f8c1e # v1.5.0
+      with:
+        version: stable
+
+    - name: Set LIBCLANG_PATH
+      if: inputs.native-deps == 'true'
+      shell: bash
+      run: |
+        LLVM_VERSION=$(llvm-config --version | cut -d. -f1)
+        echo "LIBCLANG_PATH=/usr/lib/llvm-${LLVM_VERSION}/lib" >> $GITHUB_ENV

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -54,10 +54,12 @@ runs:
     - name: Install Rust (stable via rust-toolchain.toml)
       if: inputs.toolchain == 'stable'
       shell: bash
+      env:
+        COMPONENTS: ${{ inputs.components }}
       run: |
         rustup show active-toolchain
-        if [ -n "${{ inputs.components }}" ]; then
-          rustup component add ${{ inputs.components }}
+        if [ -n "$COMPONENTS" ]; then
+          rustup component add $COMPONENTS
         fi
 
     - name: Install Rust (nightly)

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -51,11 +51,14 @@ runs:
         packages: libsqlite3-dev clang libclang-dev llvm llvm-dev build-essential pkg-config
         version: 1.2
 
-    - name: Install Rust (stable)
+    - name: Install Rust (stable via rust-toolchain.toml)
       if: inputs.toolchain == 'stable'
-      uses: dtolnay/rust-toolchain@4305c38b25d97ef35a8ad1f985ccf2d2242004f2 # stable
-      with:
-        components: ${{ inputs.components }}
+      shell: bash
+      run: |
+        rustup show active-toolchain
+        if [ -n "${{ inputs.components }}" ]; then
+          rustup component add ${{ inputs.components }}
+        fi
 
     - name: Install Rust (nightly)
       if: inputs.toolchain == 'nightly'

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -45,38 +45,15 @@ jobs:
           path: ~/bin
           key: ${{ runner.os }}-binaries-${{ hashFiles('Cargo.toml', 'Cargo.lock', 'crates/**', 'bin/**') }}
 
-      - name: Install native dependencies
+      - name: Setup Rust toolchain, cache, and dependencies
         if: steps.cache-binaries.outputs.cache-hit != 'true'
-        uses: awalsh128/cache-apt-pkgs-action@5902b33ae29014e6ca012c5d8025d4346556bd40 # v1.4.3
+        uses: ./.github/actions/setup
         with:
-          packages: libsqlite3-dev clang libclang-dev llvm llvm-dev build-essential pkg-config
-          version: 1.1
-
-      - name: Set up Rust
-        if: steps.cache-binaries.outputs.cache-hit != 'true'
-        uses: dtolnay/rust-toolchain@4305c38b25d97ef35a8ad1f985ccf2d2242004f2 # stable
-      - uses: rui314/setup-mold@725a8794d15fc7563f59595bd9556495c0564878 # v1
-        if: steps.cache-binaries.outputs.cache-hit != 'true'
-
-      - name: Rust cache
-        if: steps.cache-binaries.outputs.cache-hit != 'true'
-        uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2.8.2
-        with:
-          cache-on-failure: true
-          add-rust-environment-hash-key: "false"
-          key: benchmark-${{ hashFiles('Cargo.lock') }}
-
-      - name: Install Foundry
-        if: steps.cache-binaries.outputs.cache-hit != 'true'
-        uses: foundry-rs/foundry-toolchain@50d5a8956f2e319df19e6b57539d7e2acb9f8c1e # v1.5.0
-        with:
-          version: stable
-
-      - name: Set LIBCLANG_PATH
-        if: steps.cache-binaries.outputs.cache-hit != 'true'
-        run: |
-          LLVM_VERSION=$(llvm-config --version | cut -d. -f1)
-          echo "LIBCLANG_PATH=/usr/lib/llvm-${LLVM_VERSION}/lib" >> $GITHUB_ENV
+          native-deps: "true"
+          mold: "true"
+          foundry: "true"
+          rust-cache-shared-key: "benchmark"
+          rust-cache-save: "true"
 
       - name: Build base-reth-node
         if: steps.cache-binaries.outputs.cache-hit != 'true'

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -55,6 +55,8 @@ jobs:
       - name: Set up Rust
         if: steps.cache-binaries.outputs.cache-hit != 'true'
         uses: dtolnay/rust-toolchain@4305c38b25d97ef35a8ad1f985ccf2d2242004f2 # stable
+      - uses: rui314/setup-mold@725a8794d15fc7563f59595bd9556495c0564878 # v1
+        if: steps.cache-binaries.outputs.cache-hit != 'true'
 
       - name: Rust cache
         if: steps.cache-binaries.outputs.cache-hit != 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
           egress-policy: audit
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
-          fetch-depth: ${{ github.event_name == 'push' && 1 || 0 }}
+          fetch-depth: ${{ github.event_name == 'pull_request' && 0 || 1 }}
       - uses: ./.github/actions/setup
         with:
           free-disk: "true"
@@ -59,10 +59,10 @@ jobs:
         env:
           BASE_REF: ${{ github.base_ref || 'main' }}
         run: |
-          if [[ "${{ github.event_name }}" == "push" ]]; then
-            just test-ci
-          else
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
             just test-affected-ci "origin/$BASE_REF"
+          else
+            just test-ci
           fi
 
   fmt:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,11 +56,13 @@ jobs:
           tools: cargo-nextest
           rust-cache-shared-key: "stable"
       - name: Run tests
+        env:
+          BASE_REF: ${{ github.base_ref || 'main' }}
         run: |
           if [[ "${{ github.event_name }}" == "push" ]]; then
             just test-ci
           else
-            just test-affected-ci origin/${{ github.base_ref || 'main' }}
+            just test-affected-ci "origin/$BASE_REF"
           fi
 
   fmt:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,8 @@ jobs:
   test:
     name: Test
     runs-on: ubuntu-latest
+    env:
+      BASE_REF: ${{ github.base_ref || 'main' }}
     steps:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@95d9a5deda9de15063e7595e9719c11c38c90ae2 # v2.13.2
@@ -49,7 +51,7 @@ jobs:
           fetch-depth: ${{ github.event_name == 'pull_request' && 0 || 1 }}
       - name: Fetch base branch
         if: github.event_name == 'pull_request'
-        run: git fetch origin ${{ github.base_ref }}:refs/remotes/origin/${{ github.base_ref }}
+        run: git fetch origin "$BASE_REF":refs/remotes/origin/"$BASE_REF"
       - uses: ./.github/actions/setup
         with:
           free-disk: "true"
@@ -59,8 +61,6 @@ jobs:
           tools: cargo-nextest
           rust-cache-shared-key: "stable"
       - name: Run tests
-        env:
-          BASE_REF: ${{ github.base_ref || 'main' }}
         run: |
           if [[ "${{ github.event_name }}" == "pull_request" ]]; then
             just test-affected-ci "origin/$BASE_REF"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,9 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: ${{ github.event_name == 'pull_request' && 0 || 1 }}
+      - name: Fetch base branch
+        if: github.event_name == 'pull_request'
+        run: git fetch origin ${{ github.base_ref }}:refs/remotes/origin/${{ github.base_ref }}
       - uses: ./.github/actions/setup
         with:
           free-disk: "true"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
           egress-policy: audit
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
-          fetch-depth: 0
+          fetch-depth: ${{ github.event_name == 'push' && 1 || 0 }}
       - uses: ./.github/actions/setup
         with:
           free-disk: "true"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,7 @@ jobs:
           version: 1.2
 
       - uses: dtolnay/rust-toolchain@4305c38b25d97ef35a8ad1f985ccf2d2242004f2 # stable
+      - uses: rui314/setup-mold@725a8794d15fc7563f59595bd9556495c0564878 # v1
       - uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2.8.2
         with:
           cache-on-failure: true
@@ -165,6 +166,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@4305c38b25d97ef35a8ad1f985ccf2d2242004f2 # stable
         with:
           components: clippy
+      - uses: rui314/setup-mold@725a8794d15fc7563f59595bd9556495c0564878 # v1
       - uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2.8.2
         with:
           cache-on-failure: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,7 @@ jobs:
           rust-cache-shared-key: "stable"
       - name: Run tests
         run: |
-          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+          if [[ "$GITHUB_EVENT_NAME" == "pull_request" ]]; then
             just test-affected-ci "origin/$BASE_REF"
           else
             just test-ci

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,42 +25,15 @@ jobs:
         uses: step-security/harden-runner@95d9a5deda9de15063e7595e9719c11c38c90ae2 # v2.13.2
         with:
           egress-policy: audit
-
-      - name: Free Disk Space
-        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
-        with:
-          tool-cache: false
-          android: true
-          dotnet: true
-          haskell: true
-          large-packages: false
-          swap-storage: true
-
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-
-      - name: Install native dependencies
-        uses: awalsh128/cache-apt-pkgs-action@5902b33ae29014e6ca012c5d8025d4346556bd40 # v1.4.3
+      - uses: ./.github/actions/setup
         with:
-          packages: libsqlite3-dev clang libclang-dev llvm llvm-dev build-essential pkg-config
-          version: 1.2
-
-      - uses: dtolnay/rust-toolchain@4305c38b25d97ef35a8ad1f985ccf2d2242004f2 # stable
-      - uses: rui314/setup-mold@725a8794d15fc7563f59595bd9556495c0564878 # v1
-      - uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2.8.2
-        with:
-          cache-on-failure: true
-          shared-key: "stable"
-          save-if: ${{ github.ref == 'refs/heads/main' }}
-      - name: Install just
-        uses: extractions/setup-just@e33e0265a09d6d736e2ee1e0eb685ef1de4669ff # v3
-      - name: Install Foundry
-        uses: foundry-rs/foundry-toolchain@50d5a8956f2e319df19e6b57539d7e2acb9f8c1e # v1.5.0
-        with:
-          version: stable
-      - name: Set LIBCLANG_PATH
-        run: |
-          LLVM_VERSION=$(llvm-config --version | cut -d. -f1)
-          echo "LIBCLANG_PATH=/usr/lib/llvm-${LLVM_VERSION}/lib" >> $GITHUB_ENV
+          free-disk: "true"
+          native-deps: "true"
+          mold: "true"
+          foundry: "true"
+          rust-cache-shared-key: "stable"
+          rust-cache-save: ${{ github.ref == 'refs/heads/main' }}
       - run: just build-ci
 
   test:
@@ -71,48 +44,24 @@ jobs:
         uses: step-security/harden-runner@95d9a5deda9de15063e7595e9719c11c38c90ae2 # v2.13.2
         with:
           egress-policy: audit
-
-      - name: Free Disk Space
-        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
-        with:
-          tool-cache: false
-          android: true
-          dotnet: true
-          haskell: true
-          large-packages: false
-          swap-storage: true
-
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-
-      - name: Install native dependencies
-        uses: awalsh128/cache-apt-pkgs-action@5902b33ae29014e6ca012c5d8025d4346556bd40 # v1.4.3
         with:
-          packages: libsqlite3-dev clang libclang-dev llvm llvm-dev build-essential pkg-config
-          version: 1.2
-
-      - uses: dtolnay/rust-toolchain@4305c38b25d97ef35a8ad1f985ccf2d2242004f2 # stable
-      - uses: rui314/setup-mold@725a8794d15fc7563f59595bd9556495c0564878 # v1
-      - uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2.8.2
+          fetch-depth: 0
+      - uses: ./.github/actions/setup
         with:
-          cache-on-failure: true
-          shared-key: "stable"
-          save-if: false
-      - name: Install just
-        uses: extractions/setup-just@e33e0265a09d6d736e2ee1e0eb685ef1de4669ff # v3
-      - name: Install cargo-nextest
-        uses: taiki-e/install-action@3575e532701a5fc614b0c842e4119af4cc5fd16d # v2.62.60
-        with:
-          tool: cargo-nextest
-      - name: Install Foundry
-        uses: foundry-rs/foundry-toolchain@50d5a8956f2e319df19e6b57539d7e2acb9f8c1e # v1.5.0
-        with:
-          version: stable
-      - name: Set LIBCLANG_PATH
-        run: |
-          LLVM_VERSION=$(llvm-config --version | cut -d. -f1)
-          echo "LIBCLANG_PATH=/usr/lib/llvm-${LLVM_VERSION}/lib" >> $GITHUB_ENV
+          free-disk: "true"
+          native-deps: "true"
+          mold: "true"
+          foundry: "true"
+          tools: cargo-nextest
+          rust-cache-shared-key: "stable"
       - name: Run tests
-        run: just test-ci
+        run: |
+          if [[ "${{ github.event_name }}" == "push" ]]; then
+            just test-ci
+          else
+            just test-affected-ci origin/${{ github.base_ref || 'main' }}
+          fi
 
   fmt:
     name: Format
@@ -122,18 +71,13 @@ jobs:
         uses: step-security/harden-runner@95d9a5deda9de15063e7595e9719c11c38c90ae2 # v2.13.2
         with:
           egress-policy: audit
-
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - uses: dtolnay/rust-toolchain@0c3131df9e5407c0c36352032d04af846dbe0fb7 # nightly
+      - uses: ./.github/actions/setup
         with:
+          toolchain: nightly
           components: rustfmt
-      - uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2.8.2
-        with:
-          cache-on-failure: true
-          shared-key: "nightly"
-          save-if: ${{ github.ref == 'refs/heads/main' }}
-      - name: Install just
-        uses: extractions/setup-just@e33e0265a09d6d736e2ee1e0eb685ef1de4669ff # v3
+          rust-cache-shared-key: "nightly"
+          rust-cache-save: ${{ github.ref == 'refs/heads/main' }}
       - run: just check-format
 
   clippy:
@@ -144,44 +88,15 @@ jobs:
         uses: step-security/harden-runner@95d9a5deda9de15063e7595e9719c11c38c90ae2 # v2.13.2
         with:
           egress-policy: audit
-
-      - name: Free Disk Space
-        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
-        with:
-          tool-cache: false
-          android: true
-          dotnet: true
-          haskell: true
-          large-packages: false
-          swap-storage: true
-
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-
-      - name: Install native dependencies
-        uses: awalsh128/cache-apt-pkgs-action@5902b33ae29014e6ca012c5d8025d4346556bd40 # v1.4.3
+      - uses: ./.github/actions/setup
         with:
-          packages: libsqlite3-dev clang libclang-dev llvm llvm-dev build-essential pkg-config
-          version: 1.2
-
-      - uses: dtolnay/rust-toolchain@4305c38b25d97ef35a8ad1f985ccf2d2242004f2 # stable
-        with:
+          free-disk: "true"
+          native-deps: "true"
+          mold: "true"
+          foundry: "true"
           components: clippy
-      - uses: rui314/setup-mold@725a8794d15fc7563f59595bd9556495c0564878 # v1
-      - uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2.8.2
-        with:
-          cache-on-failure: true
-          shared-key: "stable"
-          save-if: false
-      - name: Install just
-        uses: extractions/setup-just@e33e0265a09d6d736e2ee1e0eb685ef1de4669ff # v3
-      - name: Install Foundry
-        uses: foundry-rs/foundry-toolchain@50d5a8956f2e319df19e6b57539d7e2acb9f8c1e # v1.5.0
-        with:
-          version: stable
-      - name: Set LIBCLANG_PATH
-        run: |
-          LLVM_VERSION=$(llvm-config --version | cut -d. -f1)
-          echo "LIBCLANG_PATH=/usr/lib/llvm-${LLVM_VERSION}/lib" >> $GITHUB_ENV
+          rust-cache-shared-key: "stable"
       - run: just check-clippy-ci
 
   changes:
@@ -246,35 +161,15 @@ jobs:
         uses: step-security/harden-runner@95d9a5deda9de15063e7595e9719c11c38c90ae2 # v2.13.2
         with:
           egress-policy: audit
-
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-
-      - name: Install native dependencies
-        uses: awalsh128/cache-apt-pkgs-action@5902b33ae29014e6ca012c5d8025d4346556bd40 # v1.4.3
+      - uses: ./.github/actions/setup
         with:
-          packages: libsqlite3-dev clang libclang-dev llvm llvm-dev build-essential pkg-config
-          version: 1.2
-
-      - uses: rui314/setup-mold@725a8794d15fc7563f59595bd9556495c0564878 # v1
-      - uses: dtolnay/rust-toolchain@0c3131df9e5407c0c36352032d04af846dbe0fb7 # nightly
-      - uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2.8.2
-        with:
-          cache-on-failure: true
-          shared-key: "nightly"
-          save-if: false
-      - uses: taiki-e/install-action@3575e532701a5fc614b0c842e4119af4cc5fd16d # v2.62.60
-        with:
-          tool: cargo-udeps
-      - name: Install just
-        uses: extractions/setup-just@e33e0265a09d6d736e2ee1e0eb685ef1de4669ff # v3
-      - name: Install Foundry
-        uses: foundry-rs/foundry-toolchain@50d5a8956f2e319df19e6b57539d7e2acb9f8c1e # v1.5.0
-        with:
-          version: stable
-      - name: Set LIBCLANG_PATH
-        run: |
-          LLVM_VERSION=$(llvm-config --version | cut -d. -f1)
-          echo "LIBCLANG_PATH=/usr/lib/llvm-${LLVM_VERSION}/lib" >> $GITHUB_ENV
+          toolchain: nightly
+          native-deps: "true"
+          mold: "true"
+          foundry: "true"
+          tools: cargo-udeps
+          rust-cache-shared-key: "nightly"
       - run: just check-udeps
 
   crate-deps:
@@ -285,11 +180,8 @@ jobs:
         uses: step-security/harden-runner@95d9a5deda9de15063e7595e9719c11c38c90ae2 # v2.13.2
         with:
           egress-policy: audit
-
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - uses: dtolnay/rust-toolchain@4305c38b25d97ef35a8ad1f985ccf2d2242004f2 # stable
-      - name: Install just
-        uses: extractions/setup-just@e33e0265a09d6d736e2ee1e0eb685ef1de4669ff # v3
+      - uses: ./.github/actions/setup
       - run: just check-crate-deps
 
   deny:
@@ -300,26 +192,10 @@ jobs:
         uses: step-security/harden-runner@95d9a5deda9de15063e7595e9719c11c38c90ae2 # v2.13.2
         with:
           egress-policy: audit
-
-      - name: Free Disk Space
-        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
-        with:
-          tool-cache: false
-          android: true
-          dotnet: true
-          haskell: true
-          large-packages: false
-          swap-storage: true
-
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - uses: dtolnay/rust-toolchain@4305c38b25d97ef35a8ad1f985ccf2d2242004f2 # stable
-      - uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2.8.2
+      - uses: ./.github/actions/setup
         with:
-          cache-on-failure: true
-          shared-key: "stable"
-          save-if: false
-      - name: Install just
-        uses: extractions/setup-just@e33e0265a09d6d736e2ee1e0eb685ef1de4669ff # v3
+          rust-cache-shared-key: "stable"
       - run: just check-deny
 
   devnet-tests:
@@ -331,51 +207,21 @@ jobs:
         uses: step-security/harden-runner@95d9a5deda9de15063e7595e9719c11c38c90ae2 # v2.13.2
         with:
           egress-policy: audit
-
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-
-      - name: Install native dependencies
-        uses: awalsh128/cache-apt-pkgs-action@5902b33ae29014e6ca012c5d8025d4346556bd40 # v1.4.3
+      - uses: ./.github/actions/setup
         with:
-          packages: libsqlite3-dev clang libclang-dev llvm llvm-dev build-essential pkg-config
-          version: 1.2
-
-      - uses: dtolnay/rust-toolchain@4305c38b25d97ef35a8ad1f985ccf2d2242004f2 # stable
-      - uses: rui314/setup-mold@725a8794d15fc7563f59595bd9556495c0564878 # v1
-      - uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2.8.2
-        with:
-          cache-on-failure: true
-          shared-key: "stable"
-          save-if: false
-
+          native-deps: "true"
+          mold: "true"
+          foundry: "true"
+          tools: cargo-nextest
+          rust-cache-shared-key: "stable"
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
-
-      - name: Install just
-        uses: extractions/setup-just@e33e0265a09d6d736e2ee1e0eb685ef1de4669ff # v3
-
-      - name: Install cargo-nextest
-        uses: taiki-e/install-action@3575e532701a5fc614b0c842e4119af4cc5fd16d # v2.62.60
-        with:
-          tool: cargo-nextest
-
-      - name: Install Foundry
-        uses: foundry-rs/foundry-toolchain@50d5a8956f2e319df19e6b57539d7e2acb9f8c1e # v1.5.0
-        with:
-          version: stable
-
-      - name: Set LIBCLANG_PATH
-        run: |
-          LLVM_VERSION=$(llvm-config --version | cut -d. -f1)
-          echo "LIBCLANG_PATH=/usr/lib/llvm-${LLVM_VERSION}/lib" >> $GITHUB_ENV
-
       - name: Cache docker images
         uses: ScribeMD/docker-cache@fb28c93772363301b8d0a6072ce850224b73f74e # 0.5.0
         with:
           key: docker-${{ runner.os }}-${{ hashFiles('devnet/src/images.rs', 'etc/docker/Dockerfile.devnet') }}
-
       - name: Pre-pull docker images
         run: just devnet-pull-images
-
       - name: Run devnet tests
         run: just devnet-tests-ci

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [workspace.package]
 version = "0.0.0"
 edition = "2024"
-rust-version = "1.88"
+rust-version = "1.93"
 license = "MIT"
 homepage = "https://github.com/base/base"
 repository = "https://github.com/base/base"
@@ -10,38 +10,38 @@ exclude = [".github/"]
 [workspace]
 resolver = "2"
 members = [
-    "bin/*",
-    "crates/client/*",
-    "crates/consensus/*",
-    "crates/proof/mpt",
-    "crates/proof/proof",
-    "crates/proof/driver",
-    "crates/proof/executor",
-    "crates/proof/preimage",
-    "crates/proof/std-fpvm",
-    "crates/proof/std-fpvm-proc",
-    "crates/proof/tee/core",
-    "crates/proof/tee/client",
-    "crates/proof/tee/server",
-    "crates/proof/proposer",
-    "crates/utilities/*",
-    "crates/builder/*",
-    "crates/infra/*",
-    "crates/alloy/*",
-    "crates/execution/*",
-    "devnet",
+  "bin/*",
+  "crates/client/*",
+  "crates/consensus/*",
+  "crates/proof/mpt",
+  "crates/proof/proof",
+  "crates/proof/driver",
+  "crates/proof/executor",
+  "crates/proof/preimage",
+  "crates/proof/std-fpvm",
+  "crates/proof/std-fpvm-proc",
+  "crates/proof/tee/core",
+  "crates/proof/tee/client",
+  "crates/proof/tee/server",
+  "crates/proof/proposer",
+  "crates/utilities/*",
+  "crates/builder/*",
+  "crates/infra/*",
+  "crates/alloy/*",
+  "crates/execution/*",
+  "devnet",
 ]
 default-members = [
-    "bin/based",
-    "bin/node",
-    "bin/basectl",
-    "bin/builder",
-    "bin/consensus",
-    "bin/ingress-rpc",
-    "bin/audit-archiver",
-    "bin/mempool-rebroadcaster",
-    "bin/proposer",
-    "bin/prover",
+  "bin/based",
+  "bin/node",
+  "bin/basectl",
+  "bin/builder",
+  "bin/consensus",
+  "bin/ingress-rpc",
+  "bin/audit-archiver",
+  "bin/mempool-rebroadcaster",
+  "bin/proposer",
+  "bin/prover",
 ]
 
 [workspace.metadata.cargo-udeps.ignore]
@@ -100,8 +100,7 @@ string-lit-as-bytes = "warn"
 
 [profile.dev]
 debug = "line-tables-only"
-split-debuginfo = "packed"
-incremental = false
+incremental = true
 
 [profile.release]
 opt-level = 3
@@ -109,6 +108,7 @@ lto = "thin"
 debug = "none"
 strip = "symbols"
 panic = "unwind"
+overflow-checks = true
 codegen-units = 16
 
 [profile.maxperf]
@@ -124,11 +124,7 @@ lto = false
 debug = "line-tables-only"
 strip = "none"
 
-# CI profile: optimized for minimal disk usage in CI environments
-# - Inherits from dev for fast compilation
-# - No debug info to minimize artifact size
-# - No split-debuginfo to avoid extra files
-# - Incremental disabled to reduce cache size
+# CI profile: optimized for fast GHA builds and minimal disk usage
 [profile.ci]
 inherits = "dev"
 debug = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -128,7 +128,6 @@ strip = "none"
 [profile.ci]
 inherits = "dev"
 debug = false
-split-debuginfo = "off"
 incremental = false
 
 [workspace.dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -108,7 +108,6 @@ lto = "thin"
 debug = "none"
 strip = "symbols"
 panic = "unwind"
-overflow-checks = true
 codegen-units = 16
 
 [profile.maxperf]

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ This repository (`base/base`, previously `base/node-reth`) contains **Base Reth 
 
 ## Prerequisites
 
-- **Rust:** Version 1.88 or later (matches the `rust-version` in `Cargo.toml`). You can install Rust using [rustup](https://rustup.rs/).
+- **Rust:** Version 1.93 or later (matches the `rust-version` in `Cargo.toml`). You can install Rust using [rustup](https://rustup.rs/).
 - **Just:** A command runner. Installation instructions can be found [here](https://github.com/casey/just#installation).
 - **Foundry:** Required for compiling Solidity test contracts (`just build-contracts`). Install via [foundry.sh](https://getfoundry.sh/).
 - **Docker:** (Optional) For building and running the node in a container. See [Docker installation guide](https://docs.docker.com/get-docker/).

--- a/etc/docker/Dockerfile.audit-archiver
+++ b/etc/docker/Dockerfile.audit-archiver
@@ -3,7 +3,7 @@ FROM rust:1.93-trixie AS builder
 WORKDIR /app
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
-      git libclang-dev pkg-config curl build-essential cmake && \
+      git libclang-dev pkg-config curl build-essential cmake mold && \
     rm -rf /var/lib/apt/lists/*
 
 ARG PROFILE=release

--- a/etc/docker/Dockerfile.builder
+++ b/etc/docker/Dockerfile.builder
@@ -3,7 +3,7 @@ FROM rust:1.93-trixie AS builder
 WORKDIR /app
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
-      git libclang-dev pkg-config curl build-essential && \
+      git libclang-dev pkg-config curl build-essential mold && \
     rm -rf /var/lib/apt/lists/*
 
 ARG PROFILE=release

--- a/etc/docker/Dockerfile.client
+++ b/etc/docker/Dockerfile.client
@@ -3,7 +3,7 @@ FROM rust:1.93-trixie AS builder
 WORKDIR /app
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
-      git libclang-dev pkg-config curl build-essential && \
+      git libclang-dev pkg-config curl build-essential mold && \
     rm -rf /var/lib/apt/lists/*
 
 ARG PROFILE=release

--- a/etc/docker/Dockerfile.ingress-rpc
+++ b/etc/docker/Dockerfile.ingress-rpc
@@ -3,7 +3,7 @@ FROM rust:1.93-trixie AS builder
 WORKDIR /app
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
-      git libclang-dev pkg-config curl build-essential cmake && \
+      git libclang-dev pkg-config curl build-essential cmake mold && \
     rm -rf /var/lib/apt/lists/*
 
 ARG PROFILE=release

--- a/etc/docker/Dockerfile.proposer
+++ b/etc/docker/Dockerfile.proposer
@@ -3,7 +3,7 @@ FROM rust:1.93-trixie AS builder
 WORKDIR /app
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
-      git libclang-dev pkg-config curl build-essential && \
+      git libclang-dev pkg-config curl build-essential mold && \
     rm -rf /var/lib/apt/lists/*
 
 ARG PROFILE=release

--- a/etc/docker/Dockerfile.websocket-proxy
+++ b/etc/docker/Dockerfile.websocket-proxy
@@ -3,7 +3,7 @@ FROM rust:1.93-trixie AS builder
 WORKDIR /app
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
-      git libclang-dev pkg-config curl build-essential && \
+      git libclang-dev pkg-config curl build-essential mold && \
     rm -rf /var/lib/apt/lists/*
 
 ARG PROFILE=release

--- a/etc/scripts/local/affected-crates.py
+++ b/etc/scripts/local/affected-crates.py
@@ -90,10 +90,22 @@ def main():
 
     crate_dirs = build_crate_map(meta)
 
+    # Files at the workspace root that affect all crates when changed
+    workspace_root_patterns = (
+        "Cargo.toml",
+        "Cargo.lock",
+        ".cargo/",
+        "rust-toolchain.toml",
+    )
+
     # Map changed files to their crate (longest prefix match)
     sorted_dirs = sorted(crate_dirs.keys(), key=len, reverse=True)
     changed_crates = set()
     for f in changed_files:
+        # If a workspace-root build file changed, all crates are affected
+        if any(f == p or f.startswith(p) for p in workspace_root_patterns):
+            changed_crates = set(all_names)
+            break
         for d in sorted_dirs:
             if f.startswith(d + "/") or f == d:
                 changed_crates.add(crate_dirs[d])

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "1.93.1"
+components = ["clippy", "rustfmt"]


### PR DESCRIPTION
## Description
- **Shared CI setup action**: Extracted composite `.github/actions/setup` action deduplicating Rust toolchain, cache, mold, foundry, and native deps across all CI jobs
- **Affected-crate testing**: PRs only test crates changed (+ transitive dependents) via `affected-crates.py`, with fallback to full suite for workspace-root file changes
- **Faster builds**: `mold` linker on Linux, `lld` on macOS via `.cargo/config.toml`, optimized dev/CI profiles
- **Rust 1.93.1**: Pinned via `rust-toolchain.toml`, bumped Dockerfile references
- **`just setup`**: One-step developer setup recipe for tooling + contract builds