### PR TITLE
refactor(ingress-rpc): replace bare function with BuilderConnector un…

### DIFF
--- a/bin/ingress-rpc/src/main.rs
+++ b/bin/ingress-rpc/src/main.rs
@@ -9,8 +9,8 @@ use base_bundles::MeterBundleResponse;
 use base_cli_utils::LogConfig;
 use clap::Parser;
 use ingress_rpc_lib::{
-    Config, IngressApiServer, IngressService, KafkaMessageQueue, Providers, bind_health_server,
-    connect_ingress_to_builder,
+    BuilderConnector, Config, IngressApiServer, IngressService, KafkaMessageQueue, Providers,
+    bind_health_server,
 };
 use jsonrpsee::server::Server;
 use rdkafka::{ClientConfig, producer::FutureProducer};
@@ -96,7 +96,7 @@ async fn main() -> anyhow::Result<()> {
         broadcast::channel::<MeterBundleResponse>(config.max_buffered_meter_bundle_responses);
     config.builder_rpcs.iter().for_each(|builder_rpc| {
         let metering_rx = builder_tx.subscribe();
-        connect_ingress_to_builder(metering_rx, builder_rpc.clone());
+        BuilderConnector::connect(metering_rx, builder_rpc.clone());
     });
 
     let health_check_addr = config.health_check_addr;


### PR DESCRIPTION
  Follows the same pattern as #882 (AuditConnector). CLAUDE.md requires functions to be methods on types rather than bare functions. `connect_ingress_to_builder` spawns a background task to forward metering data—wrapping it in a unit struct makes the API consistent with the rest of the codebase.

  Only 2 files changed, no logic modified, compiles cleanly.