### PR TITLE
feat(tee): add BlockDeriver for L1-derived block attributes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3084,7 +3084,6 @@ dependencies = [
  "revm",
  "serde",
  "serde_json",
- "spin 0.9.8",
  "thiserror 2.0.18",
  "tracing",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3070,6 +3070,7 @@ dependencies = [
  "base-alloy-consensus",
  "base-alloy-evm",
  "base-alloy-rpc-types-engine",
+ "base-consensus-derive",
  "base-consensus-genesis",
  "base-proof",
  "base-proof-driver",
@@ -3083,6 +3084,7 @@ dependencies = [
  "revm",
  "serde",
  "serde_json",
+ "spin 0.9.8",
  "thiserror 2.0.18",
  "tracing",
 ]

--- a/crates/proof/tee/core/Cargo.toml
+++ b/crates/proof/tee/core/Cargo.toml
@@ -33,6 +33,7 @@ base-proof-preimage.workspace = true
 base-consensus-genesis = { workspace = true, features = ["serde"] }
 
 # Consensus
+base-consensus-derive.workspace = true
 base-protocol = { workspace = true, features = ["serde"] }
 
 # Misc
@@ -43,6 +44,7 @@ serde_json.workspace = true
 async-trait.workspace = true
 thiserror.workspace = true
 tracing.workspace = true
+spin.workspace = true
 
 [dev-dependencies]
 hex.workspace = true

--- a/crates/proof/tee/core/Cargo.toml
+++ b/crates/proof/tee/core/Cargo.toml
@@ -44,7 +44,6 @@ serde_json.workspace = true
 async-trait.workspace = true
 thiserror.workspace = true
 tracing.workspace = true
-spin.workspace = true
 
 [dev-dependencies]
 hex.workspace = true

--- a/crates/proof/tee/core/src/executor/derive.rs
+++ b/crates/proof/tee/core/src/executor/derive.rs
@@ -52,7 +52,7 @@ impl BlockDeriver {
             .map_err(|e| {
                 ExecutorError::DerivationFailed(format!("failed to get output root preimage: {e}"))
             })?;
-        if output_preimage.len() < 128 {
+        if output_preimage.len() != 128 {
             return Err(ExecutorError::DerivationFailed(format!(
                 "output root preimage too short: expected 128 bytes, got {}",
                 output_preimage.len()
@@ -61,7 +61,7 @@ impl BlockDeriver {
         let l2_head_hash = B256::from_slice(&output_preimage[96..128]);
 
         // Create providers backed by the oracle.
-        let l1_provider = OracleL1ChainProvider::new(boot_info.l1_head, Arc::clone(&self.oracle));
+        let mut l1_provider = OracleL1ChainProvider::new(boot_info.l1_head, Arc::clone(&self.oracle));
         let mut l2_provider =
             OracleL2ChainProvider::new(l2_head_hash, Arc::clone(&cfg), Arc::clone(&self.oracle));
         let blob_provider = OracleBlobProvider::new(Arc::clone(&self.oracle));
@@ -80,7 +80,7 @@ impl BlockDeriver {
         let cursor = new_oracle_pipeline_cursor(
             &cfg,
             safe_header,
-            &mut l1_provider.clone(),
+            &mut l1_provider,
             &mut l2_provider,
         )
         .await

--- a/crates/proof/tee/core/src/executor/derive.rs
+++ b/crates/proof/tee/core/src/executor/derive.rs
@@ -61,7 +61,8 @@ impl BlockDeriver {
         let l2_head_hash = B256::from_slice(&output_preimage[96..128]);
 
         // Create providers backed by the oracle.
-        let mut l1_provider = OracleL1ChainProvider::new(boot_info.l1_head, Arc::clone(&self.oracle));
+        let mut l1_provider =
+            OracleL1ChainProvider::new(boot_info.l1_head, Arc::clone(&self.oracle));
         let mut l2_provider =
             OracleL2ChainProvider::new(l2_head_hash, Arc::clone(&cfg), Arc::clone(&self.oracle));
         let blob_provider = OracleBlobProvider::new(Arc::clone(&self.oracle));
@@ -77,16 +78,14 @@ impl BlockDeriver {
             .seal_slow();
 
         // Create the pipeline cursor at the safe head.
-        let cursor = new_oracle_pipeline_cursor(
-            &cfg,
-            safe_header,
-            &mut l1_provider,
-            &mut l2_provider,
-        )
-        .await
-        .map_err(|e| {
-            ExecutorError::DerivationFailed(format!("failed to create pipeline cursor: {e}"))
-        })?;
+        let cursor =
+            new_oracle_pipeline_cursor(&cfg, safe_header, &mut l1_provider, &mut l2_provider)
+                .await
+                .map_err(|e| {
+                    ExecutorError::DerivationFailed(format!(
+                        "failed to create pipeline cursor: {e}"
+                    ))
+                })?;
 
         // Set cursor on L2 provider so it tracks derivation progress.
         l2_provider.set_cursor(Arc::clone(&cursor));

--- a/crates/proof/tee/core/src/executor/derive.rs
+++ b/crates/proof/tee/core/src/executor/derive.rs
@@ -1,0 +1,118 @@
+use std::sync::Arc;
+
+use alloy_primitives::{B256, Sealable};
+use base_consensus_derive::EthereumDataSource;
+use base_proof::{
+    OracleBlobProvider, OracleL1ChainProvider, OracleL2ChainProvider, OraclePipeline,
+    new_oracle_pipeline_cursor,
+};
+use base_proof_driver::DriverPipeline;
+use base_proof_executor::TrieDBProvider;
+use base_proof_preimage::{PreimageKey, PreimageOracleClient};
+use base_protocol::OpAttributesWithParent;
+
+use crate::{error::ExecutorError, executor::Oracle};
+
+/// Derives L2 block attributes from L1 data using the kona derivation pipeline.
+///
+/// Wraps a pre-populated [`Oracle`] and runs the derivation pipeline to produce
+/// [`OpAttributesWithParent`] for a target block, replacing trust in the proposer
+/// with cryptographic verification of L1-derived data.
+#[derive(Debug)]
+pub struct BlockDeriver {
+    oracle: Arc<Oracle>,
+}
+
+impl BlockDeriver {
+    /// Creates a new [`BlockDeriver`] backed by the given oracle.
+    pub const fn new(oracle: Arc<Oracle>) -> Self {
+        Self { oracle }
+    }
+
+    /// Derives the payload attributes for the target block by running the kona
+    /// derivation pipeline from the agreed L2 safe head.
+    ///
+    /// The safe head is resolved from `boot_info.agreed_l2_output_root` by
+    /// fetching the output root preimage and extracting the block hash.
+    pub async fn derive_block_attributes(
+        &self,
+        boot_info: &base_proof::BootInfo,
+        target_block_number: u64,
+    ) -> Result<OpAttributesWithParent, ExecutorError> {
+        let cfg = Arc::new(boot_info.rollup_config.clone());
+        let l1_cfg = Arc::new(boot_info.l1_config.clone());
+
+        // Resolve the L2 safe head block hash from the agreed output root.
+        // Output root v0 preimage layout:
+        //   version(32) ++ state_root(32) ++ msg_passer_root(32) ++ block_hash(32)
+        let output_preimage = self
+            .oracle
+            .get(PreimageKey::new_keccak256(*boot_info.agreed_l2_output_root))
+            .await
+            .map_err(|e| {
+                ExecutorError::DerivationFailed(format!("failed to get output root preimage: {e}"))
+            })?;
+        let l2_head_hash = B256::from_slice(&output_preimage[96..128]);
+
+        // Create providers backed by the oracle.
+        let l1_provider = OracleL1ChainProvider::new(boot_info.l1_head, Arc::clone(&self.oracle));
+        let mut l2_provider =
+            OracleL2ChainProvider::new(l2_head_hash, Arc::clone(&cfg), Arc::clone(&self.oracle));
+        let blob_provider = OracleBlobProvider::new(Arc::clone(&self.oracle));
+        let da_provider =
+            EthereumDataSource::new_from_parts(l1_provider.clone(), blob_provider, &cfg);
+
+        // Get the safe head header and seal it.
+        let safe_header = l2_provider
+            .header_by_hash(l2_head_hash)
+            .map_err(|e| {
+                ExecutorError::DerivationFailed(format!("failed to get safe head header: {e}"))
+            })?
+            .seal_slow();
+
+        // Create the pipeline cursor at the safe head.
+        let cursor = new_oracle_pipeline_cursor(
+            &cfg,
+            safe_header,
+            &mut l1_provider.clone(),
+            &mut l2_provider,
+        )
+        .await
+        .map_err(|e| {
+            ExecutorError::DerivationFailed(format!("failed to create pipeline cursor: {e}"))
+        })?;
+
+        // Set cursor on L2 provider so it tracks derivation progress.
+        l2_provider.set_cursor(Arc::clone(&cursor));
+
+        // Build the derivation pipeline.
+        let mut pipeline = OraclePipeline::new(
+            cfg,
+            l1_cfg,
+            Arc::clone(&cursor),
+            Arc::clone(&self.oracle),
+            da_provider,
+            l1_provider,
+            l2_provider,
+        )
+        .await
+        .map_err(|e| ExecutorError::DerivationFailed(format!("failed to build pipeline: {e}")))?;
+
+        // Derive the next block's payload attributes.
+        let l2_safe_head = *cursor.read().l2_safe_head();
+        let attributes = pipeline
+            .produce_payload(l2_safe_head)
+            .await
+            .map_err(|e| ExecutorError::DerivationFailed(format!("derivation failed: {e}")))?;
+
+        // Verify the derived block number matches the target.
+        let derived_number = attributes.block_number();
+        if derived_number != target_block_number {
+            return Err(ExecutorError::DerivationFailed(format!(
+                "derived block {derived_number} but target is {target_block_number}"
+            )));
+        }
+
+        Ok(attributes)
+    }
+}

--- a/crates/proof/tee/core/src/executor/derive.rs
+++ b/crates/proof/tee/core/src/executor/derive.rs
@@ -54,7 +54,7 @@ impl BlockDeriver {
             })?;
         if output_preimage.len() != 128 {
             return Err(ExecutorError::DerivationFailed(format!(
-                "output root preimage too short: expected 128 bytes, got {}",
+                "invalid output root preimage length: expected 128 bytes, got {}",
                 output_preimage.len()
             )));
         }

--- a/crates/proof/tee/core/src/executor/derive.rs
+++ b/crates/proof/tee/core/src/executor/derive.rs
@@ -52,6 +52,12 @@ impl BlockDeriver {
             .map_err(|e| {
                 ExecutorError::DerivationFailed(format!("failed to get output root preimage: {e}"))
             })?;
+        if output_preimage.len() < 128 {
+            return Err(ExecutorError::DerivationFailed(format!(
+                "output root preimage too short: expected 128 bytes, got {}",
+                output_preimage.len()
+            )));
+        }
         let l2_head_hash = B256::from_slice(&output_preimage[96..128]);
 
         // Create providers backed by the oracle.

--- a/crates/proof/tee/core/src/executor/mod.rs
+++ b/crates/proof/tee/core/src/executor/mod.rs
@@ -36,6 +36,8 @@
 //! ```
 
 mod attributes;
+mod derive;
+pub use derive::BlockDeriver;
 mod evm;
 mod l2_block_ref;
 mod oracle;

--- a/crates/proof/tee/core/src/lib.rs
+++ b/crates/proof/tee/core/src/lib.rs
@@ -23,10 +23,11 @@ pub use base_consensus_genesis::{
 pub use error::{ConfigError, CryptoError, EnclaveError, ExecutorError, ProviderError, Result};
 // Re-export executor types
 pub use executor::{
-    DEPOSIT_EVENT_TOPIC, EnclaveTrieDB, ExecutionResult, ExecutionWitness, L1_ATTRIBUTES_DEPOSITOR,
-    L1_ATTRIBUTES_PREDEPLOYED, L2_TO_L1_MESSAGE_PASSER, MAX_SEQUENCER_DRIFT_FJORD, Oracle,
-    TransformedWitness, execute_stateless, extract_deposits_from_receipts, l2_block_to_block_info,
-    transform_witness, validate_not_deposit, validate_sequencer_drift,
+    BlockDeriver, DEPOSIT_EVENT_TOPIC, EnclaveTrieDB, ExecutionResult, ExecutionWitness,
+    L1_ATTRIBUTES_DEPOSITOR, L1_ATTRIBUTES_PREDEPLOYED, L2_TO_L1_MESSAGE_PASSER,
+    MAX_SEQUENCER_DRIFT_FJORD, Oracle, TransformedWitness, execute_stateless,
+    extract_deposits_from_receipts, l2_block_to_block_info, transform_witness,
+    validate_not_deposit, validate_sequencer_drift,
 };
 // Re-export provider types
 pub use providers::{


### PR DESCRIPTION
## Summary
- Add `BlockDeriver` struct that runs the kona derivation pipeline to produce `OpAttributesWithParent` from a pre-populated `Oracle`, replacing trust in the proposer with L1-derived transactions
- Resolves the L2 safe head from `agreed_l2_output_root` by fetching the output root preimage and extracting the block hash
- Wires up `OracleL1ChainProvider`, `OracleL2ChainProvider`, `OracleBlobProvider`, and `EthereumDataSource` into an `OraclePipeline` that derives the next block's payload attributes

## Test plan
- [x] `just pr` passes (build, clippy, riscv32 cross-compile)
- [ ] Integration test fixture with devnet preimage data (tracked as TODO in implementation plan — depends on proposer-side preimage collection in later steps)

🤖 Generated with [Claude Code](https://claude.com/claude-code)