### PR TITLE
chore(builder): remove unused metering lock metric

### DIFF
--- a/crates/builder/core/src/metrics.rs
+++ b/crates/builder/core/src/metrics.rs
@@ -96,8 +96,6 @@ pub struct BuilderMetrics {
     pub metering_known_transaction: Counter,
     /// Count of the number of times transactions did not have any metering information
     pub metering_unknown_transaction: Counter,
-    /// Count of the number of times we were unable to resolve metering information due to locking
-    pub metering_locked_transaction: Counter,
 
     // === DA Size Limit Metrics (always enforced, operator-configured) ===
     /// Transactions rejected by per-tx DA size limit


### PR DESCRIPTION
Remove `metering_locked_transaction` from `BuilderMetrics` because no path increments it and metering lookups are backed by `DashMap` with no lock- ailure branch, this metric appears to have been carried over during the op- rbuilder merge/refactor chain (#354, later refactors like #658 & #705) and never wired up.