### PR TITLE
chore(docker): optimize Dockerfiles and CI caching

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -182,9 +182,34 @@ jobs:
           echo "LIBCLANG_PATH=/usr/lib/llvm-${LLVM_VERSION}/lib" >> $GITHUB_ENV
       - run: just check-clippy-ci
 
+  changes:
+    name: Detect Changes
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    outputs:
+      docker: ${{ steps.filter.outputs.docker }}
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
+        id: filter
+        with:
+          filters: |
+            docker:
+              - 'Cargo.toml'
+              - 'Cargo.lock'
+              - 'crates/**'
+              - 'bin/**'
+              - 'etc/docker/Dockerfile.client'
+
   docker:
     name: Docker
     runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.docker == 'true'
+    permissions:
+      contents: read
+      packages: read
     steps:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@95d9a5deda9de15063e7595e9719c11c38c90ae2 # v2.13.2
@@ -197,14 +222,21 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
 
+      - name: Login to GHCR
+        if: github.event.pull_request.head.repo.fork != true
+        uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3.6.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Build Docker image
         uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
         with:
           context: .
           file: etc/docker/Dockerfile.client
           push: false
-          cache-from: type=gha,scope=ci-docker
-          cache-to: type=gha,mode=max,scope=ci-docker
+          cache-from: type=registry,ref=ghcr.io/${{ github.repository_owner }}/node-reth-dev:cache-linux-amd64
 
   udeps:
     name: udeps
@@ -314,8 +346,8 @@ jobs:
       - uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2.8.2
         with:
           cache-on-failure: true
-          add-rust-environment-hash-key: "false"
-          key: stable-${{ hashFiles('Cargo.lock') }}
+          shared-key: "stable"
+          save-if: false
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -196,11 +196,8 @@ jobs:
         with:
           filters: |
             docker:
-              - 'Cargo.toml'
-              - 'Cargo.lock'
-              - 'crates/**'
-              - 'bin/**'
-              - 'etc/docker/Dockerfile.client'
+              - 'etc/docker/Dockerfile.*'
+              - '.dockerignore'
 
   docker:
     name: Docker

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -203,7 +203,7 @@ jobs:
     name: Docker
     runs-on: ubuntu-latest
     needs: changes
-    if: needs.changes.outputs.docker == 'true'
+    if: github.event_name == 'push' || needs.changes.outputs.docker == 'true'
     permissions:
       contents: read
       packages: read

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -187,8 +187,8 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           platforms: ${{ matrix.settings.arch }}
           outputs: type=image,push-by-digest=true,name-canonical=true,push=true
-          cache-from: type=gha,scope=release-docker
-          cache-to: type=gha,mode=max,scope=release-docker
+          cache-from: type=registry,ref=ghcr.io/${{ github.repository_owner }}/node-reth-dev:cache-${{ env.PLATFORM_PAIR }}
+          cache-to: type=registry,ref=ghcr.io/${{ github.repository_owner }}/node-reth-dev:cache-${{ env.PLATFORM_PAIR }},mode=max
 
       - name: Export digest
         run: |

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -67,8 +67,8 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           platforms: ${{ matrix.settings.arch }}
           outputs: type=image,push-by-digest=true,name-canonical=true,push=true
-          cache-from: type=gha,scope=docker-dev
-          cache-to: type=gha,mode=max,scope=docker-dev
+          cache-from: type=registry,ref=ghcr.io/${{ github.repository_owner }}/node-reth-dev:cache-${{ env.PLATFORM_PAIR }}
+          cache-to: type=registry,ref=ghcr.io/${{ github.repository_owner }}/node-reth-dev:cache-${{ env.PLATFORM_PAIR }},mode=max
 
       - name: Export digest
         run: |

--- a/etc/docker/Dockerfile.audit-archiver
+++ b/etc/docker/Dockerfile.audit-archiver
@@ -20,9 +20,9 @@ FROM debian:trixie-slim
 RUN apt-get update && \
     apt-get install -y --no-install-recommends ca-certificates curl && \
     rm -rf /var/lib/apt/lists/* && \
-    useradd -r -s /sbin/nologin app
+    useradd -r -s /sbin/nologin base
 
 WORKDIR /app
 COPY --from=builder /app/audit-archiver ./
-USER app
+USER base
 ENTRYPOINT ["./audit-archiver"]

--- a/etc/docker/Dockerfile.audit-archiver
+++ b/etc/docker/Dockerfile.audit-archiver
@@ -1,43 +1,28 @@
-# --- Chef base image ---
-FROM lukemathwalker/cargo-chef:latest-rust-1.93-trixie AS chef
+# --- Builder ---
+FROM rust:1.93-trixie AS builder
 WORKDIR /app
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
       git libclang-dev pkg-config curl build-essential cmake && \
     rm -rf /var/lib/apt/lists/*
 
-# --- Planner: analyze dependencies ---
-FROM chef AS planner
-COPY . .
-RUN cargo chef prepare --recipe-path recipe.json
-
-# --- Builder: cook dependencies, then build ---
-FROM chef AS builder
 ARG PROFILE=release
 
-# Copy ONLY the recipe (dependency metadata)
-COPY --from=planner /app/recipe.json recipe.json
-
-# Build dependencies - THIS LAYER IS CACHED until Cargo.toml/Cargo.lock change
-RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
-    --mount=type=cache,target=/usr/local/cargo/git,sharing=locked \
-    --mount=type=cache,target=/app/target,id=audit-archiver-target \
-    cargo chef cook --profile $PROFILE --recipe-path recipe.json
-
-# Now copy source and build (only your code compiles here)
 COPY . .
 RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
     --mount=type=cache,target=/usr/local/cargo/git,sharing=locked \
-    --mount=type=cache,target=/app/target,id=audit-archiver-target \
-    cargo build --profile $PROFILE --bin audit-archiver && \
+    --mount=type=cache,target=/app/target,id=audit-archiver-target,sharing=locked \
+    cargo build --profile $PROFILE --package audit-archiver --bin audit-archiver && \
     cp /app/target/$([ "$PROFILE" = "dev" ] && echo debug || echo $PROFILE)/audit-archiver /app/audit-archiver
 
-# --- Runtime image ---
-FROM ubuntu:24.04
+# --- Runtime ---
+FROM debian:trixie-slim
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends jq curl ca-certificates && \
-    rm -rf /var/lib/apt/lists/*
+    apt-get install -y --no-install-recommends ca-certificates curl && \
+    rm -rf /var/lib/apt/lists/* && \
+    useradd -r -s /sbin/nologin app
 
 WORKDIR /app
 COPY --from=builder /app/audit-archiver ./
+USER app
 ENTRYPOINT ["./audit-archiver"]

--- a/etc/docker/Dockerfile.builder
+++ b/etc/docker/Dockerfile.builder
@@ -1,43 +1,28 @@
-# --- Chef base image ---
-FROM lukemathwalker/cargo-chef:latest-rust-1.93-trixie AS chef
+# --- Builder ---
+FROM rust:1.93-trixie AS builder
 WORKDIR /app
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
       git libclang-dev pkg-config curl build-essential && \
     rm -rf /var/lib/apt/lists/*
 
-# --- Planner: analyze dependencies ---
-FROM chef AS planner
-COPY . .
-RUN cargo chef prepare --recipe-path recipe.json
-
-# --- Builder: cook dependencies, then build ---
-FROM chef AS builder
 ARG PROFILE=release
 
-# Copy ONLY the recipe (dependency metadata)
-COPY --from=planner /app/recipe.json recipe.json
-
-# Build dependencies - THIS LAYER IS CACHED until Cargo.toml/Cargo.lock change
-RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
-    --mount=type=cache,target=/usr/local/cargo/git,sharing=locked \
-    --mount=type=cache,target=/app/target,id=builder-target \
-    cargo chef cook --profile $PROFILE --recipe-path recipe.json
-
-# Now copy source and build (only your code compiles here)
 COPY . .
 RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
     --mount=type=cache,target=/usr/local/cargo/git,sharing=locked \
-    --mount=type=cache,target=/app/target,id=builder-target \
-    cargo build --profile $PROFILE --bin base-builder && \
+    --mount=type=cache,target=/app/target,id=builder-target,sharing=locked \
+    cargo build --profile $PROFILE --package base-builder-bin --bin base-builder && \
     cp /app/target/$([ "$PROFILE" = "dev" ] && echo debug || echo $PROFILE)/base-builder /app/base-builder
 
-# --- Runtime image ---
-FROM ubuntu:24.04
+# --- Runtime ---
+FROM debian:trixie-slim
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends jq curl && \
-    rm -rf /var/lib/apt/lists/*
+    apt-get install -y --no-install-recommends ca-certificates curl && \
+    rm -rf /var/lib/apt/lists/* && \
+    useradd -r -s /sbin/nologin app
 
 WORKDIR /app
 COPY --from=builder /app/base-builder ./
+USER app
 ENTRYPOINT ["./base-builder"]

--- a/etc/docker/Dockerfile.builder
+++ b/etc/docker/Dockerfile.builder
@@ -20,9 +20,9 @@ FROM debian:trixie-slim
 RUN apt-get update && \
     apt-get install -y --no-install-recommends ca-certificates curl && \
     rm -rf /var/lib/apt/lists/* && \
-    useradd -r -s /sbin/nologin app
+    useradd -r -s /sbin/nologin base
 
 WORKDIR /app
 COPY --from=builder /app/base-builder ./
-USER app
+USER base
 ENTRYPOINT ["./base-builder"]

--- a/etc/docker/Dockerfile.client
+++ b/etc/docker/Dockerfile.client
@@ -1,43 +1,28 @@
-# --- Chef base image ---
-FROM lukemathwalker/cargo-chef:latest-rust-1.93-trixie AS chef
+# --- Builder ---
+FROM rust:1.93-trixie AS builder
 WORKDIR /app
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
       git libclang-dev pkg-config curl build-essential && \
     rm -rf /var/lib/apt/lists/*
 
-# --- Planner: analyze dependencies ---
-FROM chef AS planner
-COPY . .
-RUN cargo chef prepare --recipe-path recipe.json
-
-# --- Builder: cook dependencies, then build ---
-FROM chef AS builder
 ARG PROFILE=release
 
-# Copy ONLY the recipe (dependency metadata)
-COPY --from=planner /app/recipe.json recipe.json
-
-# Build dependencies - THIS LAYER IS CACHED until Cargo.toml/Cargo.lock change
-RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
-    --mount=type=cache,target=/usr/local/cargo/git,sharing=locked \
-    --mount=type=cache,target=/app/target,id=client-target \
-    cargo chef cook --profile $PROFILE --recipe-path recipe.json
-
-# Now copy source and build (only your code compiles here)
 COPY . .
 RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
     --mount=type=cache,target=/usr/local/cargo/git,sharing=locked \
-    --mount=type=cache,target=/app/target,id=client-target \
-    cargo build --profile $PROFILE --bin base-reth-node && \
+    --mount=type=cache,target=/app/target,id=client-target,sharing=locked \
+    cargo build --profile $PROFILE --package base-reth-node --bin base-reth-node && \
     cp /app/target/$([ "$PROFILE" = "dev" ] && echo debug || echo $PROFILE)/base-reth-node /app/base-client
 
-# --- Runtime image ---
-FROM ubuntu:24.04
+# --- Runtime ---
+FROM debian:trixie-slim
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends jq curl && \
-    rm -rf /var/lib/apt/lists/*
+    apt-get install -y --no-install-recommends ca-certificates curl && \
+    rm -rf /var/lib/apt/lists/* && \
+    useradd -r -s /sbin/nologin app
 
 WORKDIR /app
 COPY --from=builder /app/base-client ./
+USER app
 ENTRYPOINT ["./base-client"]

--- a/etc/docker/Dockerfile.client
+++ b/etc/docker/Dockerfile.client
@@ -20,9 +20,9 @@ FROM debian:trixie-slim
 RUN apt-get update && \
     apt-get install -y --no-install-recommends ca-certificates curl && \
     rm -rf /var/lib/apt/lists/* && \
-    useradd -r -s /sbin/nologin app
+    useradd -r -s /sbin/nologin base
 
 WORKDIR /app
 COPY --from=builder /app/base-client ./
-USER app
+USER base
 ENTRYPOINT ["./base-client"]

--- a/etc/docker/Dockerfile.devnet
+++ b/etc/docker/Dockerfile.devnet
@@ -17,16 +17,16 @@ RUN ARCH=$(uname -m | sed 's/x86_64/amd64/g' | sed 's/aarch64/arm64/g') && \
 
 # Build eth-beacon-genesis from source (has replace directives, can't use go install)
 WORKDIR /build
-RUN git clone https://github.com/ethpandaops/eth-beacon-genesis.git .
+RUN git clone --depth 1 https://github.com/ethpandaops/eth-beacon-genesis.git .
 ENV CGO_ENABLED=1
 RUN go build -o /go/bin/eth-genesis-state-generator ./cmd/eth-genesis-state-generator
 
 # Build eth2-val-tools for validator keystore generation
 WORKDIR /build2
-RUN git clone https://github.com/protolambda/eth2-val-tools.git .
+RUN git clone --depth 1 https://github.com/protolambda/eth2-val-tools.git .
 RUN go build -o /go/bin/eth2-val-tools .
 
-FROM alpine:latest
+FROM alpine:3.21
 
 RUN apk add --no-cache bash jq openssl curl gettext
 

--- a/etc/docker/Dockerfile.enclave
+++ b/etc/docker/Dockerfile.enclave
@@ -57,9 +57,6 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
     --mount=type=cache,target=/usr/local/cargo/git,sharing=locked \
     cargo build --release --target x86_64-unknown-linux-musl --package base-prover --bin base-prover
 
-# Strip debug symbols for smaller binary
-RUN strip target/x86_64-unknown-linux-musl/release/base-prover
-
 # Copy EIF configuration and build ramdisks
 COPY --from=bootstrap /build/out bootstrap
 RUN linuxkit build --format kernel+initrd --no-sbom --name init-ramdisk ./crates/proof/tee/eif/init-ramdisk.yaml

--- a/etc/docker/Dockerfile.ingress-rpc
+++ b/etc/docker/Dockerfile.ingress-rpc
@@ -20,9 +20,9 @@ FROM debian:trixie-slim
 RUN apt-get update && \
     apt-get install -y --no-install-recommends ca-certificates curl && \
     rm -rf /var/lib/apt/lists/* && \
-    useradd -r -s /sbin/nologin app
+    useradd -r -s /sbin/nologin base
 
 WORKDIR /app
 COPY --from=builder /app/ingress-rpc ./
-USER app
+USER base
 ENTRYPOINT ["./ingress-rpc"]

--- a/etc/docker/Dockerfile.ingress-rpc
+++ b/etc/docker/Dockerfile.ingress-rpc
@@ -1,43 +1,28 @@
-# --- Chef base image ---
-FROM lukemathwalker/cargo-chef:latest-rust-1.93-trixie AS chef
+# --- Builder ---
+FROM rust:1.93-trixie AS builder
 WORKDIR /app
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
       git libclang-dev pkg-config curl build-essential cmake && \
     rm -rf /var/lib/apt/lists/*
 
-# --- Planner: analyze dependencies ---
-FROM chef AS planner
-COPY . .
-RUN cargo chef prepare --recipe-path recipe.json
-
-# --- Builder: cook dependencies, then build ---
-FROM chef AS builder
 ARG PROFILE=release
 
-# Copy ONLY the recipe (dependency metadata)
-COPY --from=planner /app/recipe.json recipe.json
-
-# Build dependencies - THIS LAYER IS CACHED until Cargo.toml/Cargo.lock change
-RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
-    --mount=type=cache,target=/usr/local/cargo/git,sharing=locked \
-    --mount=type=cache,target=/app/target,id=ingress-rpc-target \
-    cargo chef cook --profile $PROFILE --recipe-path recipe.json
-
-# Now copy source and build (only your code compiles here)
 COPY . .
 RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
     --mount=type=cache,target=/usr/local/cargo/git,sharing=locked \
-    --mount=type=cache,target=/app/target,id=ingress-rpc-target \
-    cargo build --profile $PROFILE --bin ingress-rpc && \
+    --mount=type=cache,target=/app/target,id=ingress-rpc-target,sharing=locked \
+    cargo build --profile $PROFILE --package ingress-rpc --bin ingress-rpc && \
     cp /app/target/$([ "$PROFILE" = "dev" ] && echo debug || echo $PROFILE)/ingress-rpc /app/ingress-rpc
 
-# --- Runtime image ---
-FROM ubuntu:24.04
+# --- Runtime ---
+FROM debian:trixie-slim
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends jq curl ca-certificates && \
-    rm -rf /var/lib/apt/lists/*
+    apt-get install -y --no-install-recommends ca-certificates curl && \
+    rm -rf /var/lib/apt/lists/* && \
+    useradd -r -s /sbin/nologin app
 
 WORKDIR /app
 COPY --from=builder /app/ingress-rpc ./
+USER app
 ENTRYPOINT ["./ingress-rpc"]

--- a/etc/docker/Dockerfile.proposer
+++ b/etc/docker/Dockerfile.proposer
@@ -12,8 +12,8 @@ COPY . .
 RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
     --mount=type=cache,target=/usr/local/cargo/git,sharing=locked \
     --mount=type=cache,target=/app/target,id=proposer-target,sharing=locked \
-    cargo build --profile $PROFILE --package base-proposer-bin --bin proposer && \
-    cp /app/target/$([ "$PROFILE" = "dev" ] && echo debug || echo $PROFILE)/proposer /app/proposer
+    cargo build --profile $PROFILE --package base-proposer-bin --bin base-proposer && \
+    cp /app/target/$([ "$PROFILE" = "dev" ] && echo debug || echo $PROFILE)/base-proposer /app/base-proposer
 
 # --- Runtime ---
 FROM debian:trixie-slim
@@ -23,7 +23,7 @@ RUN apt-get update && \
     useradd -r -s /sbin/nologin base
 
 WORKDIR /app
-COPY --from=builder /app/proposer ./
+COPY --from=builder /app/base-proposer ./
 USER base
 EXPOSE 9090
-ENTRYPOINT ["./proposer"]
+ENTRYPOINT ["./base-proposer"]

--- a/etc/docker/Dockerfile.proposer
+++ b/etc/docker/Dockerfile.proposer
@@ -1,57 +1,29 @@
-# syntax=docker/dockerfile:1
-
-# Multi-stage Dockerfile for proposer
-# Uses cargo-chef for efficient layer caching
-
-# Stage 1: Chef - prepare recipe
-FROM rust:1.88-bookworm AS chef
-RUN cargo install cargo-chef
+# --- Builder ---
+FROM rust:1.93-trixie AS builder
 WORKDIR /app
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+      git libclang-dev pkg-config curl build-essential && \
+    rm -rf /var/lib/apt/lists/*
 
-# Stage 2: Planner - create build recipe
-FROM chef AS planner
+ARG PROFILE=release
+
 COPY . .
-RUN cargo chef prepare --recipe-path recipe.json
+RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
+    --mount=type=cache,target=/usr/local/cargo/git,sharing=locked \
+    --mount=type=cache,target=/app/target,id=proposer-target,sharing=locked \
+    cargo build --profile $PROFILE --package base-proposer-bin --bin proposer && \
+    cp /app/target/$([ "$PROFILE" = "dev" ] && echo debug || echo $PROFILE)/proposer /app/proposer
 
-# Stage 3: Builder - build the application
-FROM chef AS builder
+# --- Runtime ---
+FROM debian:trixie-slim
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends ca-certificates && \
+    rm -rf /var/lib/apt/lists/* && \
+    useradd -r -s /sbin/nologin proposer
 
-# Install build dependencies
-RUN apt-get update && apt-get install -y \
-    pkg-config \
-    libssl-dev \
-    libclang-dev \
-    && rm -rf /var/lib/apt/lists/*
-
-# Copy recipe and build dependencies first (cached layer)
-COPY --from=planner /app/recipe.json recipe.json
-RUN cargo chef cook --release --recipe-path recipe.json
-
-# Copy source code
-COPY . .
-
-# Build the application
-RUN cargo build --release --bin base-proposer
-
-# Stage 4: Runtime - minimal runtime image
-FROM ubuntu:24.04 AS runtime
-
-# Install runtime dependencies and create non-root user
-RUN apt-get update && apt-get install -y \
-    ca-certificates \
-    libssl3 \
-    && rm -rf /var/lib/apt/lists/* \
-    && useradd -r -s /sbin/nologin proposer
-
-# Copy binary from builder
-COPY --from=builder /app/target/release/base-proposer /usr/local/bin/base-proposer
-
-# Set user and working directory
+WORKDIR /app
+COPY --from=builder /app/proposer ./
 USER proposer
-WORKDIR /home/proposer
-
-# Expose metrics port
 EXPOSE 9090
-
-# Set entrypoint
-ENTRYPOINT ["/usr/local/bin/base-proposer"]
+ENTRYPOINT ["./proposer"]

--- a/etc/docker/Dockerfile.proposer
+++ b/etc/docker/Dockerfile.proposer
@@ -20,10 +20,10 @@ FROM debian:trixie-slim
 RUN apt-get update && \
     apt-get install -y --no-install-recommends ca-certificates && \
     rm -rf /var/lib/apt/lists/* && \
-    useradd -r -s /sbin/nologin proposer
+    useradd -r -s /sbin/nologin base
 
 WORKDIR /app
 COPY --from=builder /app/proposer ./
-USER proposer
+USER base
 EXPOSE 9090
 ENTRYPOINT ["./proposer"]

--- a/etc/docker/Dockerfile.websocket-proxy
+++ b/etc/docker/Dockerfile.websocket-proxy
@@ -1,41 +1,28 @@
-# --- Chef base image ---
-FROM lukemathwalker/cargo-chef:latest-rust-1.93-trixie AS chef
+# --- Builder ---
+FROM rust:1.93-trixie AS builder
 WORKDIR /app
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
       git libclang-dev pkg-config curl build-essential && \
     rm -rf /var/lib/apt/lists/*
 
-# --- Planner: analyze dependencies ---
-FROM chef AS planner
-COPY . .
-RUN cargo chef prepare --recipe-path recipe.json
-
-# --- Builder: cook dependencies, then build ---
-FROM chef AS builder
 ARG PROFILE=release
 
-# Copy ONLY the recipe (dependency metadata)
-COPY --from=planner /app/recipe.json recipe.json
-
-# Build dependencies - THIS LAYER IS CACHED until Cargo.toml/Cargo.lock change
-RUN --mount=type=cache,target=/usr/local/cargo/registry \
-    --mount=type=cache,target=/usr/local/cargo/git \
-    cargo chef cook --profile $PROFILE --recipe-path recipe.json
-
-# Now copy source and build (only your code compiles here)
 COPY . .
-RUN --mount=type=cache,target=/usr/local/cargo/registry \
-    --mount=type=cache,target=/usr/local/cargo/git \
-    cargo build --profile $PROFILE --bin websocket-proxy && \
+RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
+    --mount=type=cache,target=/usr/local/cargo/git,sharing=locked \
+    --mount=type=cache,target=/app/target,id=websocket-proxy-target,sharing=locked \
+    cargo build --profile $PROFILE --package websocket-proxy-bin --bin websocket-proxy && \
     cp /app/target/$([ "$PROFILE" = "dev" ] && echo debug || echo $PROFILE)/websocket-proxy /app/websocket-proxy
 
-# --- Runtime image ---
-FROM ubuntu:24.04
+# --- Runtime ---
+FROM debian:trixie-slim
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends jq curl && \
-    rm -rf /var/lib/apt/lists/*
+    apt-get install -y --no-install-recommends ca-certificates curl && \
+    rm -rf /var/lib/apt/lists/* && \
+    useradd -r -s /sbin/nologin app
 
 WORKDIR /app
 COPY --from=builder /app/websocket-proxy ./
+USER app
 ENTRYPOINT ["./websocket-proxy"]

--- a/etc/docker/Dockerfile.websocket-proxy
+++ b/etc/docker/Dockerfile.websocket-proxy
@@ -20,9 +20,9 @@ FROM debian:trixie-slim
 RUN apt-get update && \
     apt-get install -y --no-install-recommends ca-certificates curl && \
     rm -rf /var/lib/apt/lists/* && \
-    useradd -r -s /sbin/nologin app
+    useradd -r -s /sbin/nologin base
 
 WORKDIR /app
 COPY --from=builder /app/websocket-proxy ./
-USER app
+USER base
 ENTRYPOINT ["./websocket-proxy"]


### PR DESCRIPTION
## Description                                                                                   
- **Faster Docker builds**: Replaced `cargo-chef` with BuildKit `target/` cache mounts for simpler, incremental compilation
- **Better CI caching**: Switched from GHA cache (10GB shared limit) to registry-based       caching in GHCR — no more evictions
- **Smaller, more secure images**: `debian:trixie-slim` runtime base, non-root `base` user,   trimmed unnecessary runtime deps
- **Skip Docker**: Docker job skipped on PRs that don't touch Dockerfiles, this is already checked via cargo jobs

Even with this being the first PR and having no caching, the docker job took 13m 36s vs. 16 minutes it took [here](https://github.com/base/base/actions/runs/22509586593/job/65215798535). Hopefully this should be much quicker with the caching
