### PR TITLE
chore: rename proposer binary to base-proposer and add prover to default-members

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,7 @@ default-members = [
     "bin/audit-archiver",
     "bin/mempool-rebroadcaster",
     "bin/proposer",
+    "bin/prover",
 ]
 
 [workspace.metadata.cargo-udeps.ignore]

--- a/bin/proposer/Cargo.toml
+++ b/bin/proposer/Cargo.toml
@@ -9,7 +9,7 @@ homepage.workspace = true
 repository.workspace = true
 
 [[bin]]
-name = "proposer"
+name = "base-proposer"
 path = "src/main.rs"
 
 [lints]

--- a/crates/proof/proposer/justfile
+++ b/crates/proof/proposer/justfile
@@ -42,13 +42,13 @@ clean:
 
 # Run the proposer binary
 run *ARGS:
-    cargo run --bin proposer -- {{ARGS}}
+    cargo run --bin base-proposer -- {{ARGS}}
 
 # Run the proposer with development configuration (Base Sepolia)
 # Uses values from chart/configurations/development/values.yaml
 # Override ENCLAVE_RPC for local testing: just run-dev --enclave-rpc http://localhost:1234
 run-dev *ARGS:
-    cargo run --bin proposer -- \
+    cargo run --bin base-proposer -- \
         --l1-eth-rpc https://c3-chainproxy-eth-sepolia-full-dev.cbhq.net \
         --l2-eth-rpc https://base-sepolia-dev.cbhq.net:8545 \
         --rollup-rpc https://base-sepolia-archive-k8s-dev.cbhq.net:7545 \
@@ -67,7 +67,7 @@ run-dev *ARGS:
 # Run the proposer with local enclave server (for testing Generate() locally)
 # Start the enclave server first: cd op-enclave/rust && make run-server
 run-local *ARGS:
-    cargo run --bin proposer -- \
+    cargo run --bin base-proposer -- \
         --l1-eth-rpc https://c3-chainproxy-eth-sepolia-full-dev.cbhq.net \
         --l2-eth-rpc https://base-sepolia.cbhq.net \
         --rollup-rpc https://base-sepolia-archive-k8s-dev.cbhq.net:7545 \
@@ -82,7 +82,7 @@ run-local *ARGS:
 
 # Show help for the proposer binary
 help:
-    cargo run --bin proposer -- --help
+    cargo run --bin base-proposer -- --help
 
 # Build Docker image
 docker-build:

--- a/etc/docker/Dockerfile.proposer
+++ b/etc/docker/Dockerfile.proposer
@@ -31,7 +31,7 @@ RUN cargo chef cook --release --recipe-path recipe.json
 COPY . .
 
 # Build the application
-RUN cargo build --release --bin proposer
+RUN cargo build --release --bin base-proposer
 
 # Stage 4: Runtime - minimal runtime image
 FROM ubuntu:24.04 AS runtime
@@ -44,7 +44,7 @@ RUN apt-get update && apt-get install -y \
     && useradd -r -s /sbin/nologin proposer
 
 # Copy binary from builder
-COPY --from=builder /app/target/release/proposer /usr/local/bin/proposer
+COPY --from=builder /app/target/release/base-proposer /usr/local/bin/base-proposer
 
 # Set user and working directory
 USER proposer
@@ -54,4 +54,4 @@ WORKDIR /home/proposer
 EXPOSE 9090
 
 # Set entrypoint
-ENTRYPOINT ["/usr/local/bin/proposer"]
+ENTRYPOINT ["/usr/local/bin/base-proposer"]


### PR DESCRIPTION
## Summary
- Rename `proposer` binary target to `base-proposer` to match the workspace `base-` prefix convention
- Add `bin/prover` to `default-members` so it builds with bare `cargo build`
- Update Dockerfile and justfile references to use the new binary name

## Test plan
- [x] `cargo build --release --bin base-proposer` succeeds
- [x] Docker build still works with updated Dockerfile
- [x] `just` commands in `crates/proof/proposer/justfile` reference correct binary name

🤖 Generated with [Claude Code](https://claude.com/claude-code)