### PR TITLE
fix(builder): merge instead of overwrite FBAL builder after best txs execution

### DIFF
--- a/crates/builder/core/src/flashblocks/context.rs
+++ b/crates/builder/core/src/flashblocks/context.rs
@@ -730,7 +730,7 @@ impl OpPayloadBuilderCtx {
 
         match fbal_db.finish() {
             Ok(fbal_builder) => {
-                info.extra.access_list_builder = fbal_builder;
+                info.extra.access_list_builder.merge(fbal_builder);
             }
             Err(err) => {
                 error!(error = %err, "Failed to finalize FBALBuilder");


### PR DESCRIPTION
`execute_best_transactions` was overwriting `access_list_builder` set by `execute_sequencer_transactions`, dropping all deposit transaction state changes from the FlashblockAccessList, changed to `merge` to preserve both.