### PR TITLE
refactor(ingress-rpc): replace bind_health_server with HealthServer unit struct

### DIFF
--- a/bin/ingress-rpc/src/main.rs
+++ b/bin/ingress-rpc/src/main.rs
@@ -9,8 +9,8 @@ use base_bundles::MeterBundleResponse;
 use base_cli_utils::LogConfig;
 use clap::Parser;
 use ingress_rpc_lib::{
-    BuilderConnector, Config, IngressApiServer, IngressService, KafkaMessageQueue, Providers,
-    bind_health_server,
+    BuilderConnector, Config, HealthServer, IngressApiServer, IngressService, KafkaMessageQueue,
+    Providers,
 };
 use jsonrpsee::server::Server;
 use rdkafka::{ClientConfig, producer::FutureProducer};
@@ -100,7 +100,7 @@ async fn main() -> anyhow::Result<()> {
     });
 
     let health_check_addr = config.health_check_addr;
-    let (bound_health_addr, health_handle) = bind_health_server(health_check_addr).await?;
+    let (bound_health_addr, health_handle) = HealthServer::bind(health_check_addr).await?;
     info!(
         message = "Health check server started",
         address = %bound_health_addr

--- a/crates/infra/ingress-rpc/src/health.rs
+++ b/crates/infra/ingress-rpc/src/health.rs
@@ -9,6 +9,7 @@ async fn health() -> impl IntoResponse {
 }
 
 /// Health check server.
+#[derive(Debug)]
 pub struct HealthServer;
 
 impl HealthServer {

--- a/crates/infra/ingress-rpc/src/lib.rs
+++ b/crates/infra/ingress-rpc/src/lib.rs
@@ -2,7 +2,7 @@
 
 /// Health check HTTP server.
 mod health;
-pub use health::bind_health_server;
+pub use health::HealthServer;
 
 /// Prometheus metrics for the ingress RPC service.
 mod metrics;


### PR DESCRIPTION
Follows the same pattern as #882 (AuditConnector) and #921 (BuilderConnector).

CLAUDE.md requires functions to be methods on a type rather than bare module-level exported functions. 
`bind_health_server` spawns and manages the health check server task, so wrapping it in a `HealthServer` unit struct aligns it with the existing connector-style APIs.

Changes:
- Replace `bind_health_server` free function with `HealthServer::bind`
- Update crate re-export
- Update single call site in `bin/ingress-rpc`

No logic changes.
