### PR TITLE
fix(cli): add missing argument ID to metrics macro and fix compose env vars

### DIFF
--- a/crates/utilities/cli/src/macros.rs
+++ b/crates/utilities/cli/src/macros.rs
@@ -39,6 +39,7 @@ macro_rules! define_metrics_args {
 
             /// The port to serve Prometheus metrics on.
             #[arg(
+                id = "metrics_port",
                 long = "metrics.port",
                 global = true,
                 default_value = stringify!($default_port),

--- a/etc/docker/docker-compose.ingress.yml
+++ b/etc/docker/docker-compose.ingress.yml
@@ -92,7 +92,8 @@ services:
     environment:
       - TIPS_INGRESS_PORT=${L2_INGRESS_HTTP_PORT}
       - TIPS_INGRESS_HEALTH_CHECK_ADDR=0.0.0.0:${L2_INGRESS_HEALTH_PORT}
-      - TIPS_INGRESS_METRICS_ADDR=0.0.0.0:${L2_INGRESS_METRICS_PORT}
+      - TIPS_INGRESS_METRICS_ADDR=0.0.0.0
+      - TIPS_INGRESS_METRICS_PORT=${L2_INGRESS_METRICS_PORT}
       - TIPS_INGRESS_RPC_MEMPOOL=http://base-builder:${L2_BUILDER_HTTP_PORT}
       - TIPS_INGRESS_RPC_SIMULATION=http://base-client:${L2_CLIENT_HTTP_PORT}
       - TIPS_INGRESS_BUILDER_RPCS=http://base-builder:${L2_BUILDER_HTTP_PORT}
@@ -157,7 +158,8 @@ services:
     volumes:
       - ./kafka:/kafka-config:ro
     environment:
-      - TIPS_AUDIT_METRICS_ADDR=0.0.0.0:${AUDIT_METRICS_PORT}
+      - TIPS_AUDIT_METRICS_ADDR=0.0.0.0
+      - TIPS_AUDIT_METRICS_PORT=${AUDIT_METRICS_PORT}
       - TIPS_AUDIT_KAFKA_PROPERTIES_FILE=/kafka-config/audit.properties
       - TIPS_AUDIT_KAFKA_TOPIC=tips-audit
       - TIPS_AUDIT_S3_BUCKET=tips


### PR DESCRIPTION
## Summary
- Add `id = "metrics_port"` to the `define_metrics_args!` macro's port field, restoring the explicit ID that the original hand-written `MetricsArgs` struct had. Without this, any binary flattening `MetricsArgs` alongside another struct with a `port` field (e.g. `ingress-rpc`) crashes at startup due to a clap argument name collision.
- Split `METRICS_ADDR` env vars in `docker-compose.ingress.yml` into separate `METRICS_ADDR` (IpAddr) and `METRICS_PORT` (u16) for both `ingress-rpc` and `audit-archiver`, matching what the macro's clap args actually expect.