### PR TITLE
refactor(ingress-rpc): wrap health server in HealthServer unit struct

### DIFF
--- a/bin/ingress-rpc/src/main.rs
+++ b/bin/ingress-rpc/src/main.rs
@@ -9,8 +9,8 @@ use base_bundles::MeterBundleResponse;
 use base_cli_utils::LogConfig;
 use clap::Parser;
 use ingress_rpc_lib::{
-    BuilderConnector, Config, IngressApiServer, IngressService, KafkaMessageQueue, Providers,
-    bind_health_server,
+    BuilderConnector, Config, HealthServer, IngressApiServer, IngressService, KafkaMessageQueue,
+    Providers,
 };
 use jsonrpsee::server::Server;
 use rdkafka::{ClientConfig, producer::FutureProducer};
@@ -100,7 +100,7 @@ async fn main() -> anyhow::Result<()> {
     });
 
     let health_check_addr = config.health_check_addr;
-    let (bound_health_addr, health_handle) = bind_health_server(health_check_addr).await?;
+    let (bound_health_addr, health_handle) = HealthServer::serve(health_check_addr).await?;
     info!(
         message = "Health check server started",
         address = %bound_health_addr

--- a/crates/infra/ingress-rpc/src/health.rs
+++ b/crates/infra/ingress-rpc/src/health.rs
@@ -3,30 +3,35 @@ use std::net::SocketAddr;
 use axum::{Router, http::StatusCode, response::IntoResponse, routing::get};
 use tracing::info;
 
-/// Health check handler that always returns 200 OK
-async fn health() -> impl IntoResponse {
-    StatusCode::OK
+/// Health check HTTP server.
+pub struct HealthServer;
+
+impl HealthServer {
+    /// Binds and starts the health check server on the specified address.
+    /// Returns the bound address and a handle that can be awaited to run the server.
+    pub async fn serve(
+        addr: SocketAddr,
+    ) -> anyhow::Result<(SocketAddr, tokio::task::JoinHandle<anyhow::Result<()>>)> {
+        let app = Router::new().route("/health", get(health));
+
+        let listener = tokio::net::TcpListener::bind(addr).await?;
+        let bound_addr = listener.local_addr()?;
+
+        info!(
+            message = "Health check server bound successfully",
+            address = %bound_addr
+        );
+
+        let handle = tokio::spawn(async move {
+            axum::serve(listener, app).await?;
+            Ok(())
+        });
+
+        Ok((bound_addr, handle))
+    }
 }
 
-/// Bind and start the health check server on the specified address.
-/// Returns a handle that can be awaited to run the server.
-pub async fn bind_health_server(
-    addr: SocketAddr,
-) -> anyhow::Result<(SocketAddr, tokio::task::JoinHandle<anyhow::Result<()>>)> {
-    let app = Router::new().route("/health", get(health));
-
-    let listener = tokio::net::TcpListener::bind(addr).await?;
-    let bound_addr = listener.local_addr()?;
-
-    info!(
-        message = "Health check server bound successfully",
-        address = %bound_addr
-    );
-
-    let handle = tokio::spawn(async move {
-        axum::serve(listener, app).await?;
-        Ok(())
-    });
-
-    Ok((bound_addr, handle))
+/// Health check handler that always returns 200 OK.
+async fn health() -> impl IntoResponse {
+    StatusCode::OK
 }

--- a/crates/infra/ingress-rpc/src/lib.rs
+++ b/crates/infra/ingress-rpc/src/lib.rs
@@ -2,7 +2,7 @@
 
 /// Health check HTTP server.
 mod health;
-pub use health::bind_health_server;
+pub use health::HealthServer;
 
 /// Prometheus metrics for the ingress RPC service.
 mod metrics;


### PR DESCRIPTION
`bind_health_server` was a bare `pub fn` exported directly from the crate root, which violates the project convention of exporting types rather than loose functions (CLAUDE.md). This follows the same pattern established by `BuilderConnector` (#921) and `AuditConnector` (#882).

  The function is now `HealthServer::serve`, with `serve` chosen over `bind` to avoid confusion with `TcpListener::bind` — our method both binds the port and spawns the server task.