### PR TITLE
fix(builder): drain lru queue on metering store clear

### DIFF
--- a/crates/builder/metering/src/store.rs
+++ b/crates/builder/metering/src/store.rs
@@ -90,6 +90,8 @@ impl MeteringProvider for MeteringStore {
 
     fn clear(&self) {
         self.by_tx_hash.clear();
+        // Drain the LRU queue to prevent stale entries from accumulating
+        while self.lru.pop().is_ok() {}
     }
 
     fn set_enabled(&self, enabled: bool) {


### PR DESCRIPTION
Fixes an issue where stale transaction hashes accumulated in the LRU queue, by properly draining the queue when the metering store is cleared.
