### PR TITLE
fix(trie): gate metrics-only imports behind feature flag

### DIFF
--- a/crates/execution/trie/src/db/store.rs
+++ b/crates/execution/trie/src/db/store.rs
@@ -2,6 +2,7 @@ use std::{ops::RangeBounds, path::Path};
 
 use alloy_eips::{BlockNumHash, NumHash, eip1898::BlockWithParent};
 use alloy_primitives::{B256, U256, map::HashMap};
+#[cfg(feature = "metrics")]
 use eyre::WrapErr;
 #[cfg(feature = "metrics")]
 use metrics::{Label, gauge};
@@ -18,6 +19,7 @@ use reth_trie_common::{
     BranchNodeCompact, HashedPostState, Nibbles, StoredNibbles,
     updates::{StorageTrieUpdates, TrieUpdates},
 };
+#[cfg(feature = "metrics")]
 use tracing::error;
 
 use super::{BlockNumberHash, ProofWindow, ProofWindowKey, Tables};

--- a/crates/execution/trie/src/prune/pruner.rs
+++ b/crates/execution/trie/src/prune/pruner.rs
@@ -31,6 +31,7 @@ pub struct OpProofStoragePruner<P, H> {
 
 impl<P, H> OpProofStoragePruner<P, H> {
     /// Create a new pruner.
+    #[allow(clippy::missing_const_for_fn)] // not const when `metrics` feature enables Metrics::default()
     pub fn new(
         provider: OpProofsStorage<P>,
         block_hash_reader: H,


### PR DESCRIPTION
## Summary

- Gate `eyre::WrapErr` and `tracing::error` imports in `store.rs` behind `#[cfg(feature = "metrics")]` since they are only used in metrics impl blocks
- Suppress `missing_const_for_fn` on `OpProofStoragePruner::new` — the lint fires without `metrics` but the function cannot be `const` when `metrics` is enabled (due to `Metrics::default()`)

## Context

`base-execution-trie` fails to compile when built individually (without the `metrics` feature):

```
error[E0432]: unresolved import `eyre`
error: unused import: `tracing::error`
```

Full workspace builds mask this because they enable `metrics` transitively.

The root cause is upstream: commit `be39a17` (op-rs/op-reth#407) added these imports unconditionally, then `3ebb5d7` (op-rs/op-reth#627) made `eyre` an optional dep gated behind `metrics` without updating the imports. Our `c8b2337` (#875) hoisted the imports to file-level, preserving the bug.

## Test plan

- [x] `cargo clippy -p base-execution-trie --profile ci -- -D warnings` (without metrics)
- [x] `cargo clippy -p base-execution-trie --profile ci --features metrics -- -D warnings` (with metrics)