### PR TITLE
chore(peers): gracefully handle bootnode parsing errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2940,6 +2940,7 @@ dependencies = [
  "libp2p",
  "libp2p-identity",
  "multihash",
+ "rstest",
  "secp256k1 0.30.0",
  "serde",
  "serde_json",

--- a/crates/client/cli/src/p2p.rs
+++ b/crates/client/cli/src/p2p.rs
@@ -529,7 +529,8 @@ impl P2PArgs {
 
 #[cfg(test)]
 mod tests {
-    use alloy_primitives::b256;
+    use alloy_primitives::{Address, b256};
+    use base_consensus_genesis::RollupConfig;
     use base_consensus_peers::NodeRecord;
     use clap::Parser;
 
@@ -706,6 +707,20 @@ mod tests {
                 "enr:-J64QBbwPjPLZ6IOOToOLsSjtFUjjzN66qmBZdUexpO32Klrc458Q24kbty2PdRaLacHM5z-cZQr8mjeQu3pik6jPSOGAYYFIqBfgmlkgnY0gmlwhDaRWFWHb3BzdGFja4SzlAUAiXNlY3AyNTZrMaECmeSnJh7zjKrDSPoNMGXoopeDF4hhpj5I0OsQUUt4u8uDdGNwgiQGg3VkcIIkBg",
             ]
         );
+    }
+
+    #[tokio::test]
+    async fn test_p2p_config_errors_on_invalid_bootnode() {
+        let args = MockCommand::parse_from(["test", "--p2p.bootnodes", "enr:invalid"]);
+
+        let err = args
+            .p2p
+            .config(&RollupConfig::default(), 8453, None, Some(Address::ZERO))
+            .await
+            .expect_err("invalid bootnode should fail config")
+            .to_string();
+
+        assert!(err.contains("Failed to parse bootnode 'enr:invalid'"));
     }
 
     #[test]

--- a/crates/client/cli/src/p2p.rs
+++ b/crates/client/cli/src/p2p.rs
@@ -468,8 +468,11 @@ impl P2PArgs {
         let bootnodes = self
             .bootnodes
             .iter()
-            .map(|bootnode| BootNode::parse_bootnode(bootnode))
-            .collect::<Vec<BootNode>>()
+            .map(|bootnode| {
+                BootNode::parse_bootnode(bootnode)
+                    .map_err(|e| eyre::eyre!("Failed to parse bootnode '{bootnode}': {e}"))
+            })
+            .collect::<Result<Vec<BootNode>>>()?
             .into();
 
         Ok(NetworkConfig {
@@ -663,7 +666,8 @@ mod tests {
             .bootnodes
             .iter()
             .map(|bootnode| BootNode::parse_bootnode(bootnode))
-            .collect::<Vec<BootNode>>();
+            .collect::<std::result::Result<Vec<BootNode>, _>>()
+            .expect("test bootnode should parse");
 
         // Otherwise, attempt to use the Node Record format.
         let record = NodeRecord::from_str(

--- a/crates/consensus/peers/Cargo.toml
+++ b/crates/consensus/peers/Cargo.toml
@@ -46,6 +46,7 @@ arbtest.workspace = true
 tempfile.workspace = true
 multihash.workspace = true
 serde_json = { workspace = true, features = ["std"] }
+rstest.workspace = true
 
 base-consensus-genesis.workspace = true
 

--- a/crates/consensus/peers/src/boot.rs
+++ b/crates/consensus/peers/src/boot.rs
@@ -68,7 +68,7 @@ impl BootNode {
     pub fn parse_bootnode(raw: &str) -> Result<Self, BootNodeParseError> {
         // If the string starts with "enr:" it is an ENR record.
         if raw.starts_with("enr:") {
-            let enr = Enr::from_str(raw).map_err(|e| BootNodeParseError::Enr(e.to_string()))?;
+            let enr = Enr::from_str(raw).map_err(BootNodeParseError::Enr)?;
             return Ok(Self::from(enr));
         }
         // Otherwise, attempt to use the Node Record format.

--- a/crates/consensus/peers/src/boot.rs
+++ b/crates/consensus/peers/src/boot.rs
@@ -86,6 +86,7 @@ mod tests {
         enr::{CombinedPublicKey, k256},
         handler::NodeContact,
     };
+    use rstest::rstest;
 
     use super::*;
     use crate::utils::peer_id_to_secp256k1_pubkey;
@@ -145,5 +146,31 @@ mod tests {
 
         // These two keys should be equal.
         assert_eq!(contact_pkey, expected_pkey);
+    }
+
+    #[derive(Debug, Clone, Copy)]
+    enum ParseErrorKind {
+        Enr,
+        NodeRecord,
+        PeerIdConversion,
+    }
+
+    #[rstest]
+    #[case("enr:invalid", ParseErrorKind::Enr)]
+    #[case("enode://invalid@127.0.0.1:30303", ParseErrorKind::NodeRecord)]
+    #[case(
+        "enode://00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000@127.0.0.1:30303",
+        ParseErrorKind::PeerIdConversion
+    )]
+    fn test_parse_bootnode_error_variants(#[case] raw: &str, #[case] expected: ParseErrorKind) {
+        let err = BootNode::parse_bootnode(raw).expect_err("input should fail to parse");
+        match (expected, err) {
+            (ParseErrorKind::Enr, BootNodeParseError::Enr(_)) => {}
+            (ParseErrorKind::NodeRecord, BootNodeParseError::NodeRecord(_)) => {}
+            (ParseErrorKind::PeerIdConversion, BootNodeParseError::PeerIdConversion(_)) => {}
+            (expected, actual) => {
+                panic!("expected {expected:?}, got {actual:?}");
+            }
+        }
     }
 }

--- a/crates/consensus/peers/src/boot.rs
+++ b/crates/consensus/peers/src/boot.rs
@@ -12,6 +12,20 @@ use serde::{Deserialize, Serialize};
 use super::utils::{PeerIdConversionError, local_id_to_p2p_id};
 use crate::{NodeRecord, enr_to_multiaddr};
 
+/// Errors that can occur when parsing a bootnode.
+#[derive(Debug, thiserror::Error)]
+pub enum BootNodeParseError {
+    /// Failed to parse ENR.
+    #[error("Failed to parse ENR: {0}")]
+    Enr(String),
+    /// Failed to parse node record.
+    #[error("Failed to parse node record: {0}")]
+    NodeRecord(String),
+    /// Failed to convert peer ID.
+    #[error(transparent)]
+    PeerIdConversion(#[from] PeerIdConversionError),
+}
+
 /// A boot node can be added either as a string in either 'enode' URL scheme or serialized from
 /// [`Enr`] type.
 #[derive(Clone, Debug, PartialEq, Eq, Hash, From, Display, Serialize, Deserialize)]
@@ -51,15 +65,16 @@ impl BootNode {
     }
 
     /// Helper method to parse a bootnode from a string.
-    pub fn parse_bootnode(raw: &str) -> Self {
+    pub fn parse_bootnode(raw: &str) -> Result<Self, BootNodeParseError> {
         // If the string starts with "enr:" it is an ENR record.
         if raw.starts_with("enr:") {
-            let enr = Enr::from_str(raw).unwrap();
-            return Self::from(enr);
+            let enr = Enr::from_str(raw).map_err(|e| BootNodeParseError::Enr(e.to_string()))?;
+            return Ok(Self::from(enr));
         }
         // Otherwise, attempt to use the Node Record format.
-        let record = NodeRecord::from_str(raw).unwrap();
-        Self::from_unsigned(record).unwrap()
+        let record =
+            NodeRecord::from_str(raw).map_err(|e| BootNodeParseError::NodeRecord(e.to_string()))?;
+        Ok(Self::from_unsigned(record)?)
     }
 }
 

--- a/crates/consensus/peers/src/lib.rs
+++ b/crates/consensus/peers/src/lib.rs
@@ -30,7 +30,7 @@ mod any;
 pub use any::{AnyNode, DialOptsError};
 
 mod boot;
-pub use boot::BootNode;
+pub use boot::{BootNode, BootNodeParseError};
 
 mod record;
 pub use record::{NodeRecord, NodeRecordParseError};

--- a/crates/consensus/peers/src/nodes.rs
+++ b/crates/consensus/peers/src/nodes.rs
@@ -48,12 +48,19 @@ impl BootNodes {
 }
 
 /// Default op bootnodes to use.
-static OP_BOOTNODES: LazyLock<Vec<BootNode>> =
-    LazyLock::new(|| OP_RAW_BOOTNODES.iter().map(|raw| BootNode::parse_bootnode(raw)).collect());
+static OP_BOOTNODES: LazyLock<Vec<BootNode>> = LazyLock::new(|| {
+    OP_RAW_BOOTNODES
+        .iter()
+        .map(|raw| BootNode::parse_bootnode(raw).expect("hardcoded bootnode should parse"))
+        .collect()
+});
 
 /// Default op testnet bootnodes to use.
 static OP_TESTNET_BOOTNODES: LazyLock<Vec<BootNode>> = LazyLock::new(|| {
-    OP_RAW_TESTNET_BOOTNODES.iter().map(|raw| BootNode::parse_bootnode(raw)).collect()
+    OP_RAW_TESTNET_BOOTNODES
+        .iter()
+        .map(|raw| BootNode::parse_bootnode(raw).expect("hardcoded bootnode should parse"))
+        .collect()
 });
 
 /// OP stack mainnet boot nodes.
@@ -124,11 +131,11 @@ mod tests {
     #[test]
     fn test_parse_raw_bootnodes() {
         for raw in OP_RAW_BOOTNODES {
-            BootNode::parse_bootnode(raw);
+            BootNode::parse_bootnode(raw).expect("hardcoded bootnode should parse");
         }
 
         for raw in OP_RAW_TESTNET_BOOTNODES {
-            BootNode::parse_bootnode(raw);
+            BootNode::parse_bootnode(raw).expect("hardcoded bootnode should parse");
         }
     }
 


### PR DESCRIPTION
Replaces unwraps with a dedicated BootNodeParseError, preventing panics during invalid boot node configuration parsing.
