### PR TITLE
fix: remove duplicate blob_fields call in build_block

### DIFF
--- a/crates/builder/core/src/flashblocks/payload.rs
+++ b/crates/builder/core/src/flashblocks/payload.rs
@@ -1066,8 +1066,6 @@ where
         access_list: None,
     };
 
-    let (_, blob_gas_used) = ctx.blob_fields(info);
-
     // Prepare the flashblocks message
     let fb_payload = FlashblocksPayloadV1 {
         payload_id: ctx.payload_id(),


### PR DESCRIPTION
Remove redundant second call to ctx.blob_fields(info) in build_block function. The blob_gas_used value was already computed on line 970 and reused correctly on line 1101, making the second call an unnecessary operation.