### PR TITLE
feat(flashblocks): inject setIndex tx at the start of each flashblock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -298,9 +298,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-evm"
-version = "0.27.3"
+version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b991c370ce44e70a3a9e474087e3d65e42e66f967644ad729dc4cec09a21fd09"
+checksum = "d2ccfe6d724ceabd5518350cfb34f17dd3a6c3cc33579eee94d98101d3a511ff"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -2498,6 +2498,7 @@ dependencies = [
  "base-builder-core",
  "base-builder-publish",
  "base-bundles",
+ "base-contracts-bindings",
  "base-execution-chainspec",
  "base-execution-consensus",
  "base-execution-evm",
@@ -3100,6 +3101,15 @@ dependencies = [
  "base-protocol",
  "base-revm",
  "revm",
+]
+
+[[package]]
+name = "base-contracts-bindings"
+version = "0.1.0"
+source = "git+https://github.com/base/contracts?branch=bo%2Fchain-3336#1afe287d3c7e5b3226d0b771d8923ebb06d3a880"
+dependencies = [
+ "alloy-contract",
+ "alloy-sol-types",
 ]
 
 [[package]]
@@ -5104,9 +5114,9 @@ dependencies = [
 
 [[package]]
 name = "c-kzg"
-version = "2.1.6"
+version = "2.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a0f582957c24870b7bfd12bf562c40b4734b533cafbaf8ded31d6d85f462c01"
+checksum = "e00bf4b112b07b505472dbefd19e37e53307e2bfed5a79e0cc161d58ccd0e687"
 dependencies = [
  "arbitrary",
  "blst",
@@ -6060,7 +6070,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ab67060fc6b8ef687992d439ca0fa36e7ed17e9a0b16b25b601e8757df720de"
 dependencies = [
  "data-encoding",
- "syn 1.0.109",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -6432,9 +6442,9 @@ dependencies = [
 
 [[package]]
 name = "dispatch2"
-version = "0.3.1"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
+checksum = "89a09f22a6c6069a18470eb92d2298acf25463f14256d24778e1230d789a2aec"
 dependencies = [
  "bitflags 2.11.0",
  "objc2",
@@ -8573,7 +8583,7 @@ dependencies = [
  "p384",
  "p521",
  "rand_core 0.6.4",
- "rsa 0.10.0-rc.15",
+ "rsa 0.10.0-rc.16",
  "sec1",
  "sha1 0.10.6",
  "sha1 0.11.0-rc.5",
@@ -8731,9 +8741,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.91"
+version = "0.3.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b49715b7073f385ba4bc528e5747d02e66cb39c6146efb66b781f131f0fb399c"
+checksum = "14dc6f6450b3f6d4ed5b16327f38fed626d375a886159ca555bd7822c0c3a5a6"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -9486,7 +9496,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tracing",
  "yamux 0.12.1",
- "yamux 0.13.9",
+ "yamux 0.13.8",
 ]
 
 [[package]]
@@ -9502,14 +9512,13 @@ dependencies = [
 
 [[package]]
 name = "libredox"
-version = "0.1.14"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1744e39d1d6a9948f4f388969627434e31128196de472883b39f148769bfe30a"
+checksum = "3d0b95e02c851351f877147b7deea7b1afb1df71b63aa5f8270716e0c5720616"
 dependencies = [
  "bitflags 2.11.0",
  "libc",
- "plain",
- "redox_syscall 0.7.3",
+ "redox_syscall 0.7.2",
 ]
 
 [[package]]
@@ -10443,9 +10452,9 @@ dependencies = [
 
 [[package]]
 name = "objc2"
-version = "0.6.4"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a12a8ed07aefc768292f076dc3ac8c48f3781c8f2d5851dd3d98950e8c5a89f"
+checksum = "b7c2599ce0ec54857b29ce62166b0ed9b4f6f1a70ccc9a71165b6154caca8c05"
 dependencies = [
  "objc2-encode",
 ]
@@ -11230,18 +11239,18 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "1.1.11"
+version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1749c7ed4bcaf4c3d0a3efc28538844fb29bcdd7d2b67b2be7e20ba861ff517"
+checksum = "677f1add503faace112b9f1373e43e9e054bfdd22ff1a63c1bc485eaec6a6a8a"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.11"
+version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b20ed30f105399776b9c883e68e536ef602a16ae6f596d2c473591d6ad64c6"
+checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -11250,9 +11259,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.17"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
 
 [[package]]
 name = "pin-utils"
@@ -11323,12 +11332,6 @@ name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
-
-[[package]]
-name = "plain"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "plain_hasher"
@@ -12094,9 +12097,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.7.3"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ce70a74e890531977d37e532c34d45e9055d2409ed08ddba14529471ed0be16"
+checksum = "6d94dd2f7cd932d4dc02cc8b2b50dfd38bd079a4e5d79198b99743d7fcf9a4b4"
 dependencies = [
  "bitflags 2.11.0",
 ]
@@ -15285,9 +15288,9 @@ dependencies = [
 
 [[package]]
 name = "rsa"
-version = "0.10.0-rc.15"
+version = "0.10.0-rc.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b342b99544549f37509ed7fd42b0cea04bfd9ce07c16ca56094cf0fbeefbbcd"
+checksum = "6fb9fd8c1edd9e6a2693623baf0fe77ff05ce022a5d7746900ffc38a15c233de"
 dependencies = [
  "const-oid 0.10.2",
  "crypto-bigint 0.7.0-rc.28",
@@ -16745,7 +16748,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "82a72c767771b47409d2345987fda8628641887d5466101319899796367354a0"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.1",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
@@ -18039,9 +18042,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.114"
+version = "0.2.113"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6532f9a5c1ece3798cb1c2cfdba640b9b3ba884f5db45973a6f442510a87d38e"
+checksum = "60722a937f594b7fde9adb894d7c092fc1bb6612897c46368d18e7a20208eff2"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -18052,9 +18055,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.64"
+version = "0.4.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9c5522b3a28661442748e09d40924dfb9ca614b21c00d3fd135720e48b67db8"
+checksum = "8a89f4650b770e4521aa6573724e2aed4704372151bd0de9d16a3bbabb87441a"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -18066,9 +18069,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.114"
+version = "0.2.113"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18a2d50fcf105fb33bb15f00e7a77b772945a2ee45dcf454961fd843e74c18e6"
+checksum = "0fac8c6395094b6b91c4af293f4c79371c163f9a6f56184d2c9a85f5a95f3950"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -18076,9 +18079,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.114"
+version = "0.2.113"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03ce4caeaac547cdf713d280eda22a730824dd11e6b8c3ca9e42247b25c631e3"
+checksum = "ab3fabce6159dc20728033842636887e4877688ae94382766e00b180abac9d60"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -18089,9 +18092,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.114"
+version = "0.2.113"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75a326b8c223ee17883a4251907455a2431acc2791c98c26279376490c378c16"
+checksum = "de0e091bdb824da87dc01d967388880d017a0a9bc4f3bdc0d86ee9f9336e3bb5"
 dependencies = [
  "unicode-ident",
 ]
@@ -18159,9 +18162,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.91"
+version = "0.3.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "854ba17bb104abfb26ba36da9729addc7ce7f06f5c0f90f3c391f8461cca21f9"
+checksum = "705eceb4ce901230f8625bd1d665128056ccbe4b7408faa625eec1ba80f59a97"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -19097,9 +19100,9 @@ dependencies = [
 
 [[package]]
 name = "yamux"
-version = "0.13.9"
+version = "0.13.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c650efd29044140aa63caaf80129996a9e2659a2ab7045a7e061807d02fc8549"
+checksum = "deab71f2e20691b4728b349c6cee8fc7223880fa67b6b4f92225ec32225447e5"
 dependencies = [
  "futures",
  "log",
@@ -19151,18 +19154,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.40"
+version = "0.8.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a789c6e490b576db9f7e6b6d661bcc9799f7c0ac8352f56ea20193b2681532e5"
+checksum = "db6d35d663eadb6c932438e763b262fe1a70987f9ae936e60158176d710cae4a"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.40"
+version = "0.8.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f65c489a7071a749c849713807783f70672b28094011623e200cb86dcb835953"
+checksum = "4122cd3169e94605190e77839c9a40d40ed048d305bfdc146e7df40ab0f3e517"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -19246,9 +19249,9 @@ dependencies = [
 
 [[package]]
 name = "zip"
-version = "8.1.0"
+version = "8.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e499faf5c6b97a0d086f4a8733de6d47aee2252b8127962439d8d4311a73f72"
+checksum = "b680f2a0cd479b4cff6e1233c483fdead418106eae419dc60200ae9850f6d004"
 dependencies = [
  "crc32fast",
  "flate2",
@@ -19260,9 +19263,9 @@ dependencies = [
 
 [[package]]
 name = "zlib-rs"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c745c48e1007337ed136dc99df34128b9faa6ed542d80a1c673cf55a6d7236c8"
+checksum = "3be3d40e40a133f9c916ee3f9f4fa2d9d63435b5fbe1bfc6d9dae0aa0ada1513"
 
 [[package]]
 name = "zmij"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2459,8 +2459,6 @@ dependencies = [
  "base-txpool-rpc",
  "clap",
  "eyre",
- "hex",
- "k256",
  "reth-cli-util",
  "rstest",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2448,6 +2448,8 @@ dependencies = [
 name = "base-builder-bin"
 version = "0.0.0"
 dependencies = [
+ "alloy-primitives",
+ "alloy-signer-local",
  "base-builder-core",
  "base-builder-metering",
  "base-cli-utils",
@@ -2457,6 +2459,8 @@ dependencies = [
  "base-txpool-rpc",
  "clap",
  "eyre",
+ "hex",
+ "k256",
  "reth-cli-util",
  "rstest",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -234,6 +234,9 @@ base-proofs-extension = { path = "crates/client/proofs" }
 base-flashblocks-node = { path = "crates/client/flashblocks-node" }
 base-macros = { path = "crates/utilities/macros", default-features = false }
 
+# base/contracts bindings
+base-contracts-bindings = { git = "https://github.com/base/contracts", branch = "bo/chain-3336" }
+
 # revm
 revm = { version = "34.0.0", default-features = false }
 revm-bytecode = { version = "8.0.0", default-features = false }

--- a/bin/builder/Cargo.toml
+++ b/bin/builder/Cargo.toml
@@ -28,10 +28,16 @@ base-execution-cli = { workspace = true, features = ["otlp"] }
 base-node-core.workspace = true
 reth-cli-util.workspace = true
 
+# alloy
+alloy-primitives.workspace = true
+alloy-signer-local.workspace = true
+
 # cli
 clap.workspace = true
 
 # misc
+hex.workspace = true
+k256.workspace = true
 eyre.workspace = true
 
 [dev-dependencies]

--- a/bin/builder/Cargo.toml
+++ b/bin/builder/Cargo.toml
@@ -36,8 +36,6 @@ alloy-signer-local.workspace = true
 clap.workspace = true
 
 # misc
-hex.workspace = true
-k256.workspace = true
 eyre.workspace = true
 
 [dev-dependencies]

--- a/bin/builder/src/cli.rs
+++ b/bin/builder/src/cli.rs
@@ -408,7 +408,7 @@ mod tests {
         let config = config.unwrap();
         assert_eq!(
             config.contract_address,
-            "0xDeaDbeefdEAdbeefdEadbEEFdeadbeEFdEaDbeeF".parse().unwrap(),
+            "0xDeaDbeefdEAdbeefdEadbEEFdeadbeEFdEaDbeeF".parse::<Address>().unwrap(),
         );
     }
 

--- a/bin/builder/src/cli.rs
+++ b/bin/builder/src/cli.rs
@@ -81,7 +81,7 @@ impl Default for FlashblocksArgs {
 /// Parameters for the optional flashblock index transaction signer.
 ///
 /// When both `private_key` and `contract_address` are provided, the builder
-/// injects a signed `setIndex(uint256)` tx at the start of each flashblock.
+/// injects a flashblock index tx at the start of each flashblock.
 #[derive(Clone, Default, PartialEq, Eq, clap::Args)]
 pub struct FlashblockIndexArgs {
     /// Hex-encoded private key for signing flashblock index transactions.

--- a/bin/builder/src/cli.rs
+++ b/bin/builder/src/cli.rs
@@ -81,7 +81,7 @@ impl Default for FlashblocksArgs {
 /// Parameters for the optional flashblock index transaction signer.
 ///
 /// When both `private_key` and `contract_address` are provided, the builder
-/// injects a signed `setIndex(uint256)` TX at the start of each flashblock.
+/// injects a signed `setIndex(uint256)` tx at the start of each flashblock.
 #[derive(Clone, Default, PartialEq, Eq, clap::Args)]
 pub struct FlashblockIndexArgs {
     /// Hex-encoded private key for signing flashblock index transactions.
@@ -90,7 +90,7 @@ pub struct FlashblockIndexArgs {
 
     /// Address of the `FlashblockIndex` contract.
     #[arg(long = "flashblock-index.contract-address", env = "FLASHBLOCK_INDEX_CONTRACT_ADDRESS")]
-    pub contract_address: Option<String>,
+    pub contract_address: Option<Address>,
 }
 
 impl core::fmt::Debug for FlashblockIndexArgs {
@@ -162,7 +162,7 @@ pub struct Args {
     #[command(flatten)]
     pub flashblocks: FlashblocksArgs,
 
-    /// Flashblock index TX signer configuration
+    /// Flashblock index tx signer configuration
     #[command(flatten)]
     pub flashblock_index: FlashblockIndexArgs,
 }
@@ -203,14 +203,10 @@ impl FlashblockIndexArgs {
     /// Parses the CLI args into a [`FlashblockIndexConfig`], if both fields are provided.
     fn into_config(self) -> eyre::Result<Option<FlashblockIndexConfig>> {
         match (self.private_key, self.contract_address) {
-            (Some(key_hex), Some(addr_str)) => {
+            (Some(key_hex), Some(contract_address)) => {
                 let signer: PrivateKeySigner = key_hex
                     .parse()
                     .map_err(|e| eyre::eyre!("invalid flashblock-index private key: {e}"))?;
-
-                let contract_address: Address = addr_str
-                    .parse()
-                    .map_err(|e| eyre::eyre!("invalid flashblock-index contract address: {e}"))?;
 
                 Ok(Some(FlashblockIndexConfig { signer, contract_address }))
             }
@@ -397,19 +393,15 @@ mod tests {
 
     #[test]
     fn flashblock_index_both_provided() {
+        let addr: Address = "0xDeaDbeefdEAdbeefdEadbEEFdeadbeEFdEaDbeeF".parse().unwrap();
         let args = FlashblockIndexArgs {
             private_key: Some(
                 "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80".to_string(),
             ),
-            contract_address: Some("0xDeaDbeefdEAdbeefdEadbEEFdeadbeEFdEaDbeeF".to_string()),
+            contract_address: Some(addr),
         };
-        let config = args.into_config().unwrap();
-        assert!(config.is_some());
-        let config = config.unwrap();
-        assert_eq!(
-            config.contract_address,
-            "0xDeaDbeefdEAdbeefdEadbEEFdeadbeEFdEaDbeeF".parse::<Address>().unwrap(),
-        );
+        let config = args.into_config().unwrap().unwrap();
+        assert_eq!(config.contract_address, addr);
     }
 
     #[test]
@@ -432,29 +424,29 @@ mod tests {
 
     #[test]
     fn flashblock_index_only_address_provided() {
-        let args = FlashblockIndexArgs {
-            private_key: None,
-            contract_address: Some("0xDeaDbeefdEAdbeefdEadbEEFdeadbeEFdEaDbeeF".to_string()),
-        };
+        let addr: Address = "0xDeaDbeefdEAdbeefdEadbEEFdeadbeEFdEaDbeeF".parse().unwrap();
+        let args = FlashblockIndexArgs { private_key: None, contract_address: Some(addr) };
         assert!(args.into_config().is_err());
     }
 
     #[test]
     fn flashblock_index_invalid_key_hex() {
+        let addr: Address = "0xDeaDbeefdEAdbeefdEadbEEFdeadbeEFdEaDbeeF".parse().unwrap();
         let args = FlashblockIndexArgs {
             private_key: Some("not_hex".to_string()),
-            contract_address: Some("0xDeaDbeefdEAdbeefdEadbEEFdeadbeEFdEaDbeeF".to_string()),
+            contract_address: Some(addr),
         };
         assert!(args.into_config().is_err());
     }
 
     #[test]
     fn flashblock_index_key_without_0x_prefix() {
+        let addr: Address = "0xDeaDbeefdEAdbeefdEadbEEFdeadbeEFdEaDbeeF".parse().unwrap();
         let args = FlashblockIndexArgs {
             private_key: Some(
                 "ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80".to_string(),
             ),
-            contract_address: Some("0xDeaDbeefdEAdbeefdEadbEEFdeadbeEFdEaDbeeF".to_string()),
+            contract_address: Some(addr),
         };
         let config = args.into_config().unwrap();
         assert!(config.is_some());

--- a/bin/builder/src/cli.rs
+++ b/bin/builder/src/cli.rs
@@ -3,9 +3,14 @@
 use core::{convert::TryFrom, net::SocketAddr, time::Duration};
 use std::sync::Arc;
 
-use base_builder_core::{BuilderConfig, ExecutionMeteringMode, FlashblocksConfig};
+use alloy_primitives::Address;
+use alloy_signer_local::PrivateKeySigner;
+use base_builder_core::{
+    BuilderConfig, ExecutionMeteringMode, FlashblockIndexConfig, FlashblocksConfig,
+};
 use base_builder_metering::MeteringStore;
 use base_node_core::args::RollupArgs;
+use k256::ecdsa::SigningKey;
 
 /// Parameters for Flashblocks configuration.
 ///
@@ -74,6 +79,21 @@ impl Default for FlashblocksArgs {
     }
 }
 
+/// Parameters for the optional flashblock index transaction signer.
+///
+/// When both `private_key` and `contract_address` are provided, the builder
+/// injects a signed `setIndex(uint256)` TX at the start of each flashblock.
+#[derive(Debug, Clone, Default, PartialEq, Eq, clap::Args)]
+pub struct FlashblockIndexArgs {
+    /// Hex-encoded private key for signing flashblock index transactions.
+    #[arg(long = "flashblock-index.private-key", env = "FLASHBLOCK_INDEX_PRIVATE_KEY")]
+    pub private_key: Option<String>,
+
+    /// Address of the `FlashblockIndex` contract.
+    #[arg(long = "flashblock-index.contract-address", env = "FLASHBLOCK_INDEX_CONTRACT_ADDRESS")]
+    pub contract_address: Option<String>,
+}
+
 /// Parameters for rollup configuration
 #[derive(Debug, Clone, PartialEq, Eq, clap::Args)]
 #[command(next_help_heading = "Rollup")]
@@ -133,6 +153,10 @@ pub struct Args {
     /// Flashblocks configuration
     #[command(flatten)]
     pub flashblocks: FlashblocksArgs,
+
+    /// Flashblock index TX signer configuration
+    #[command(flatten)]
+    pub flashblock_index: FlashblockIndexArgs,
 }
 
 impl Args {
@@ -162,6 +186,33 @@ impl Default for Args {
             tx_data_store_buffer_size: 10000,
             sampling_ratio: 100,
             flashblocks: FlashblocksArgs::default(),
+            flashblock_index: FlashblockIndexArgs::default(),
+        }
+    }
+}
+
+impl FlashblockIndexArgs {
+    /// Parses the CLI args into a [`FlashblockIndexConfig`], if both fields are provided.
+    fn into_config(self) -> eyre::Result<Option<FlashblockIndexConfig>> {
+        match (self.private_key, self.contract_address) {
+            (Some(key_hex), Some(addr_str)) => {
+                let key_hex = key_hex.strip_prefix("0x").unwrap_or(&key_hex);
+                let key_bytes = hex::decode(key_hex)
+                    .map_err(|e| eyre::eyre!("invalid flashblock-index private key hex: {e}"))?;
+                let signing_key = SigningKey::from_slice(&key_bytes)
+                    .map_err(|e| eyre::eyre!("invalid flashblock-index signing key: {e}"))?;
+                let signer = PrivateKeySigner::from_signing_key(signing_key);
+
+                let contract_address: Address = addr_str
+                    .parse()
+                    .map_err(|e| eyre::eyre!("invalid flashblock-index contract address: {e}"))?;
+
+                Ok(Some(FlashblockIndexConfig { signer, contract_address }))
+            }
+            (None, None) => Ok(None),
+            _ => Err(eyre::eyre!(
+                "both --flashblock-index.private-key and --flashblock-index.contract-address must be provided together"
+            )),
         }
     }
 }
@@ -172,6 +223,7 @@ impl TryFrom<Args> for BuilderConfig {
     fn try_from(args: Args) -> Result<Self, Self::Error> {
         let flashblocks = FlashblocksConfig::try_from(&args)?;
         let metering_store = args.build_metering_store();
+        let flashblock_index = args.flashblock_index.into_config()?;
         Ok(Self {
             block_time: Duration::from_millis(args.chain_block_time),
             block_time_leeway: Duration::from_secs(args.extra_block_deadline_secs),
@@ -187,6 +239,7 @@ impl TryFrom<Args> for BuilderConfig {
             max_uncompressed_block_size: args.max_uncompressed_block_size,
             metering_provider: Arc::new(metering_store),
             flashblocks,
+            flashblock_index,
         })
     }
 }

--- a/bin/builder/src/cli.rs
+++ b/bin/builder/src/cli.rs
@@ -389,4 +389,69 @@ mod tests {
         assert_eq!(config.flashblocks.leeway_time, Duration::from_millis(50));
         assert!(config.flashblocks.fixed);
     }
+
+    #[test]
+    fn flashblock_index_both_provided() {
+        let args = FlashblockIndexArgs {
+            private_key: Some(
+                "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80".to_string(),
+            ),
+            contract_address: Some("0xDeaDbeefdEAdbeefdEadbEEFdeadbeEFdEaDbeeF".to_string()),
+        };
+        let config = args.into_config().unwrap();
+        assert!(config.is_some());
+        let config = config.unwrap();
+        assert_eq!(
+            config.contract_address,
+            "0xDeaDbeefdEAdbeefdEadbEEFdeadbeEFdEaDbeeF".parse().unwrap(),
+        );
+    }
+
+    #[test]
+    fn flashblock_index_none_provided() {
+        let args = FlashblockIndexArgs { private_key: None, contract_address: None };
+        let config = args.into_config().unwrap();
+        assert!(config.is_none());
+    }
+
+    #[test]
+    fn flashblock_index_only_key_provided() {
+        let args = FlashblockIndexArgs {
+            private_key: Some(
+                "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80".to_string(),
+            ),
+            contract_address: None,
+        };
+        assert!(args.into_config().is_err());
+    }
+
+    #[test]
+    fn flashblock_index_only_address_provided() {
+        let args = FlashblockIndexArgs {
+            private_key: None,
+            contract_address: Some("0xDeaDbeefdEAdbeefdEadbEEFdeadbeEFdEaDbeeF".to_string()),
+        };
+        assert!(args.into_config().is_err());
+    }
+
+    #[test]
+    fn flashblock_index_invalid_key_hex() {
+        let args = FlashblockIndexArgs {
+            private_key: Some("not_hex".to_string()),
+            contract_address: Some("0xDeaDbeefdEAdbeefdEadbEEFdeadbeEFdEaDbeeF".to_string()),
+        };
+        assert!(args.into_config().is_err());
+    }
+
+    #[test]
+    fn flashblock_index_key_without_0x_prefix() {
+        let args = FlashblockIndexArgs {
+            private_key: Some(
+                "ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80".to_string(),
+            ),
+            contract_address: Some("0xDeaDbeefdEAdbeefdEadbEEFdeadbeEFdEaDbeeF".to_string()),
+        };
+        let config = args.into_config().unwrap();
+        assert!(config.is_some());
+    }
 }

--- a/bin/builder/src/cli.rs
+++ b/bin/builder/src/cli.rs
@@ -83,7 +83,7 @@ impl Default for FlashblocksArgs {
 ///
 /// When both `private_key` and `contract_address` are provided, the builder
 /// injects a signed `setIndex(uint256)` TX at the start of each flashblock.
-#[derive(Debug, Clone, Default, PartialEq, Eq, clap::Args)]
+#[derive(Clone, Default, PartialEq, Eq, clap::Args)]
 pub struct FlashblockIndexArgs {
     /// Hex-encoded private key for signing flashblock index transactions.
     #[arg(long = "flashblock-index.private-key", env = "FLASHBLOCK_INDEX_PRIVATE_KEY")]
@@ -92,6 +92,15 @@ pub struct FlashblockIndexArgs {
     /// Address of the `FlashblockIndex` contract.
     #[arg(long = "flashblock-index.contract-address", env = "FLASHBLOCK_INDEX_CONTRACT_ADDRESS")]
     pub contract_address: Option<String>,
+}
+
+impl core::fmt::Debug for FlashblockIndexArgs {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("FlashblockIndexArgs")
+            .field("private_key", &self.private_key.as_ref().map(|_| "[redacted]"))
+            .field("contract_address", &self.contract_address)
+            .finish()
+    }
 }
 
 /// Parameters for rollup configuration

--- a/bin/builder/src/cli.rs
+++ b/bin/builder/src/cli.rs
@@ -10,7 +10,6 @@ use base_builder_core::{
 };
 use base_builder_metering::MeteringStore;
 use base_node_core::args::RollupArgs;
-use k256::ecdsa::SigningKey;
 
 /// Parameters for Flashblocks configuration.
 ///
@@ -205,12 +204,9 @@ impl FlashblockIndexArgs {
     fn into_config(self) -> eyre::Result<Option<FlashblockIndexConfig>> {
         match (self.private_key, self.contract_address) {
             (Some(key_hex), Some(addr_str)) => {
-                let key_hex = key_hex.strip_prefix("0x").unwrap_or(&key_hex);
-                let key_bytes = hex::decode(key_hex)
-                    .map_err(|e| eyre::eyre!("invalid flashblock-index private key hex: {e}"))?;
-                let signing_key = SigningKey::from_slice(&key_bytes)
-                    .map_err(|e| eyre::eyre!("invalid flashblock-index signing key: {e}"))?;
-                let signer = PrivateKeySigner::from_signing_key(signing_key);
+                let signer: PrivateKeySigner = key_hex
+                    .parse()
+                    .map_err(|e| eyre::eyre!("invalid flashblock-index private key: {e}"))?;
 
                 let contract_address: Address = addr_str
                     .parse()

--- a/crates/builder/core/Cargo.toml
+++ b/crates/builder/core/Cargo.toml
@@ -59,7 +59,6 @@ base-node-runner.workspace = true
 base-alloy-flashblocks.workspace = true
 base-access-lists.workspace = true
 base-builder-publish.workspace = true
-base-contracts-bindings.workspace = true
 
 # reth
 reth-cli.workspace = true
@@ -212,6 +211,9 @@ base-execution-rpc = { workspace = true, features = ["client"] }
 
 # alloy
 alloy-provider = { workspace = true, default-features = true, features = ["txpool-api"] }
+
+# contracts
+base-contracts-bindings.workspace = true
 
 # misc
 ctor.workspace = true

--- a/crates/builder/core/Cargo.toml
+++ b/crates/builder/core/Cargo.toml
@@ -59,6 +59,7 @@ base-node-runner.workspace = true
 base-alloy-flashblocks.workspace = true
 base-access-lists.workspace = true
 base-builder-publish.workspace = true
+base-contracts-bindings.workspace = true
 
 # reth
 reth-cli.workspace = true

--- a/crates/builder/core/src/config.rs
+++ b/crates/builder/core/src/config.rs
@@ -6,7 +6,8 @@ use std::sync::Arc;
 use base_execution_payload_builder::config::{OpDAConfig, OpGasLimitConfig};
 
 use crate::{
-    ExecutionMeteringMode, FlashblocksConfig, NoopMeteringProvider, SharedMeteringProvider,
+    ExecutionMeteringMode, FlashblockIndexConfig, FlashblocksConfig, NoopMeteringProvider,
+    SharedMeteringProvider,
 };
 
 /// Configuration values for the flashblocks builder.
@@ -32,6 +33,10 @@ pub struct BuilderConfig {
 
     /// Configuration values that are specific to the flashblocks block builder.
     pub flashblocks: FlashblocksConfig,
+
+    /// Optional configuration for the flashblock index transaction signer.
+    /// When set, the builder signs and injects a `setIndex` TX at the start of each flashblock.
+    pub flashblock_index: Option<FlashblockIndexConfig>,
 
     /// Maximum gas a transaction can use before being excluded.
     pub max_gas_per_txn: Option<u64>,
@@ -67,6 +72,7 @@ impl core::fmt::Debug for BuilderConfig {
             .field("gas_limit_config", &self.gas_limit_config)
             .field("sampling_ratio", &self.sampling_ratio)
             .field("flashblocks", &self.flashblocks)
+            .field("flashblock_index", &self.flashblock_index)
             .field("max_gas_per_txn", &self.max_gas_per_txn)
             .field("max_execution_time_per_tx_us", &self.max_execution_time_per_tx_us)
             .field("max_state_root_time_per_tx_us", &self.max_state_root_time_per_tx_us)
@@ -87,6 +93,7 @@ impl Default for BuilderConfig {
             da_config: OpDAConfig::default(),
             gas_limit_config: OpGasLimitConfig::default(),
             flashblocks: FlashblocksConfig::default(),
+            flashblock_index: None,
             sampling_ratio: 100,
             max_gas_per_txn: None,
             max_execution_time_per_tx_us: None,
@@ -131,6 +138,13 @@ impl BuilderConfig {
     #[must_use]
     pub const fn with_flashblocks(mut self, flashblocks: FlashblocksConfig) -> Self {
         self.flashblocks = flashblocks;
+        self
+    }
+
+    /// Sets the flashblock index configuration.
+    #[must_use]
+    pub fn with_flashblock_index(mut self, flashblock_index: FlashblockIndexConfig) -> Self {
+        self.flashblock_index = Some(flashblock_index);
         self
     }
 

--- a/crates/builder/core/src/config.rs
+++ b/crates/builder/core/src/config.rs
@@ -35,7 +35,7 @@ pub struct BuilderConfig {
     pub flashblocks: FlashblocksConfig,
 
     /// Optional configuration for the flashblock index transaction signer.
-    /// When set, the builder signs and injects a `setIndex` tx at the start of each flashblock.
+    /// When set, the builder injects a flashblock index tx at the start of each flashblock.
     pub flashblock_index: Option<FlashblockIndexConfig>,
 
     /// Maximum gas a transaction can use before being excluded.

--- a/crates/builder/core/src/config.rs
+++ b/crates/builder/core/src/config.rs
@@ -35,7 +35,7 @@ pub struct BuilderConfig {
     pub flashblocks: FlashblocksConfig,
 
     /// Optional configuration for the flashblock index transaction signer.
-    /// When set, the builder signs and injects a `setIndex` TX at the start of each flashblock.
+    /// When set, the builder signs and injects a `setIndex` tx at the start of each flashblock.
     pub flashblock_index: Option<FlashblockIndexConfig>,
 
     /// Maximum gas a transaction can use before being excluded.

--- a/crates/builder/core/src/flashblocks/config.rs
+++ b/crates/builder/core/src/flashblocks/config.rs
@@ -124,8 +124,9 @@ impl FlashBlocksConfigExt for BuilderConfig {
 
 /// Configuration for the flashblock index transaction signer.
 ///
-/// When present, the builder injects a signed EIP-1559 transaction calling
-/// `setIndex(uint256)` on the target contract at the start of each flashblock.
+/// When present, the builder injects a signed EIP-1559 transaction with 1-byte
+/// calldata (the flashblock index as `uint8`) to the target contract's `fallback()`
+/// at the start of each flashblock.
 #[derive(Debug, Clone)]
 pub struct FlashblockIndexConfig {
     /// The private key signer used to sign flashblock index transactions.

--- a/crates/builder/core/src/flashblocks/config.rs
+++ b/crates/builder/core/src/flashblocks/config.rs
@@ -3,6 +3,9 @@ use core::{
     time::Duration,
 };
 
+use alloy_primitives::Address;
+use alloy_signer_local::PrivateKeySigner;
+
 use crate::BuilderConfig;
 
 /// Configuration values specific to the flashblocks builder.
@@ -117,4 +120,16 @@ impl FlashBlocksConfigExt for BuilderConfig {
         }
         (self.block_time.as_millis() / self.flashblocks.interval.as_millis()) as u64
     }
+}
+
+/// Configuration for the flashblock index transaction signer.
+///
+/// When present, the builder injects a signed EIP-1559 transaction calling
+/// `setIndex(uint256)` on the target contract at the start of each flashblock.
+#[derive(Debug, Clone)]
+pub struct FlashblockIndexConfig {
+    /// The private key signer used to sign flashblock index transactions.
+    pub signer: PrivateKeySigner,
+    /// The address of the `FlashblockIndex` contract.
+    pub contract_address: Address,
 }

--- a/crates/builder/core/src/flashblocks/context.rs
+++ b/crates/builder/core/src/flashblocks/context.rs
@@ -510,7 +510,10 @@ impl OpPayloadBuilderCtx {
             flashblock_index,
         )?;
 
-        let mut evm = self.evm_config.evm_with_env(&mut *db, self.evm_env.clone());
+        let mut fbal_db = FBALBuilderDb::new(&mut *db);
+        let min_tx_index = info.executed_transactions.len() as u64;
+        fbal_db.set_index(min_tx_index);
+        let mut evm = self.evm_config.evm_with_env(&mut fbal_db, self.evm_env.clone());
 
         let ResultAndState { result, state } = evm
             .transact(&tx)
@@ -546,6 +549,13 @@ impl OpPayloadBuilderCtx {
 
         info.executed_senders.push(tx.signer());
         info.executed_transactions.push(tx.into_inner());
+
+        match fbal_db.finish() {
+            Ok(fbal_builder) => info.extra.access_list_builder = fbal_builder,
+            Err(err) => {
+                error!(error = %err, "Failed to finalize FBALBuilder");
+            }
+        }
 
         trace!(
             target: "payload_builder",

--- a/crates/builder/core/src/flashblocks/context.rs
+++ b/crates/builder/core/src/flashblocks/context.rs
@@ -549,11 +549,8 @@ impl OpPayloadBuilderCtx {
         info.executed_senders.push(tx.signer());
         info.executed_transactions.push(tx.into_inner());
 
-        // NOTE: execute_best_transactions overwrites access_list_builder with its own
-        // fresh FBALBuilderDb, so the index tx's accesses won't appear in the final list.
-        // This matches the existing pattern across all execute_* methods.
         match fbal_db.finish() {
-            Ok(fbal_builder) => info.extra.access_list_builder = fbal_builder,
+            Ok(fbal_builder) => info.extra.access_list_builder.merge(fbal_builder),
             Err(err) => {
                 error!(error = %err, "Failed to finalize FBALBuilder");
             }

--- a/crates/builder/core/src/flashblocks/context.rs
+++ b/crates/builder/core/src/flashblocks/context.rs
@@ -549,6 +549,9 @@ impl OpPayloadBuilderCtx {
         info.executed_senders.push(tx.signer());
         info.executed_transactions.push(tx.into_inner());
 
+        // NOTE: execute_best_transactions overwrites access_list_builder with its own
+        // fresh FBALBuilderDb, so the index TX's accesses won't appear in the final list.
+        // This matches the existing pattern across all execute_* methods.
         match fbal_db.finish() {
             Ok(fbal_builder) => info.extra.access_list_builder = fbal_builder,
             Err(err) => {

--- a/crates/builder/core/src/flashblocks/context.rs
+++ b/crates/builder/core/src/flashblocks/context.rs
@@ -36,13 +36,12 @@ use revm::{DatabaseCommit, context::result::ResultAndState, interpreter::as_u64_
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, error, trace, warn};
 
+use super::{FlashblockIndexConfig, index_tx::build_flashblock_index_tx};
 use crate::{
     BuilderMetrics, ExecutionInfo, ExecutionMeteringLimitExceeded, ExecutionMeteringMode,
     PayloadTxsBounds, ResourceLimits, SharedMeteringProvider, TxResources, TxnExecutionError,
     TxnOutcome,
 };
-
-use super::{FlashblockIndexConfig, index_tx::build_flashblock_index_tx};
 
 /// Records the priority fee of a rejected transaction with the given reason as a label.
 fn record_rejected_tx_priority_fee(reason: &TxnExecutionError, priority_fee: f64) {

--- a/crates/builder/core/src/flashblocks/context.rs
+++ b/crates/builder/core/src/flashblocks/context.rs
@@ -475,8 +475,8 @@ impl OpPayloadBuilderCtx {
 
     /// Executes the flashblock index transaction at the start of each flashblock.
     ///
-    /// Signs and injects an EIP-1559 transaction calling `setIndex(flashblock_index)`
-    /// on the configured `FlashblockIndex` contract.
+    /// Signs and injects an EIP-1559 transaction calling the `FlashblockIndex` contract's
+    /// `fallback()` with 1 byte of calldata encoding the flashblock index.
     pub(super) fn execute_flashblock_index_tx(
         &self,
         info: &mut ExecutionInfo,

--- a/crates/builder/core/src/flashblocks/context.rs
+++ b/crates/builder/core/src/flashblocks/context.rs
@@ -171,7 +171,7 @@ pub struct OpPayloadBuilderCtx {
     pub execution_metering_mode: ExecutionMeteringMode,
     /// Resource metering provider
     pub metering_provider: SharedMeteringProvider,
-    /// Optional flashblock index TX config (signer + contract address).
+    /// Optional flashblock index tx config (signer + contract address).
     pub flashblock_index_config: Option<FlashblockIndexConfig>,
 }
 
@@ -488,7 +488,7 @@ impl OpPayloadBuilderCtx {
             target: "payload_builder",
             flashblock_index,
             contract = %config.contract_address,
-            "executing flashblock index TX",
+            "executing flashblock index tx",
         );
 
         let signer_address = config.signer.address();
@@ -523,7 +523,7 @@ impl OpPayloadBuilderCtx {
                 target: "payload_builder",
                 flashblock_index,
                 contract = %config.contract_address,
-                "flashblock index TX reverted, skipping inclusion",
+                "flashblock index tx reverted, skipping inclusion",
             );
             return Ok(());
         }
@@ -550,7 +550,7 @@ impl OpPayloadBuilderCtx {
         info.executed_transactions.push(tx.into_inner());
 
         // NOTE: execute_best_transactions overwrites access_list_builder with its own
-        // fresh FBALBuilderDb, so the index TX's accesses won't appear in the final list.
+        // fresh FBALBuilderDb, so the index tx's accesses won't appear in the final list.
         // This matches the existing pattern across all execute_* methods.
         match fbal_db.finish() {
             Ok(fbal_builder) => info.extra.access_list_builder = fbal_builder,
@@ -563,7 +563,7 @@ impl OpPayloadBuilderCtx {
             target: "payload_builder",
             flashblock_index,
             gas_used,
-            "flashblock index TX executed",
+            "flashblock index tx executed",
         );
 
         Ok(())

--- a/crates/builder/core/src/flashblocks/context.rs
+++ b/crates/builder/core/src/flashblocks/context.rs
@@ -516,6 +516,16 @@ impl OpPayloadBuilderCtx {
             .transact(&tx)
             .map_err(|err| PayloadBuilderError::EvmExecutionError(Box::new(err)))?;
 
+        if !result.is_success() {
+            warn!(
+                target: "payload_builder",
+                flashblock_index,
+                contract = %config.contract_address,
+                "flashblock index TX reverted, skipping inclusion",
+            );
+            return Ok(());
+        }
+
         let gas_used = result.gas_used();
         info.cumulative_gas_used += gas_used;
 

--- a/crates/builder/core/src/flashblocks/context.rs
+++ b/crates/builder/core/src/flashblocks/context.rs
@@ -42,6 +42,8 @@ use crate::{
     TxnOutcome,
 };
 
+use super::{FlashblockIndexConfig, index_tx::build_flashblock_index_tx};
+
 /// Records the priority fee of a rejected transaction with the given reason as a label.
 fn record_rejected_tx_priority_fee(reason: &TxnExecutionError, priority_fee: f64) {
     let r = match reason {
@@ -170,6 +172,8 @@ pub struct OpPayloadBuilderCtx {
     pub execution_metering_mode: ExecutionMeteringMode,
     /// Resource metering provider
     pub metering_provider: SharedMeteringProvider,
+    /// Optional flashblock index TX config (signer + contract address).
+    pub flashblock_index_config: Option<FlashblockIndexConfig>,
 }
 
 impl OpPayloadBuilderCtx {
@@ -468,6 +472,79 @@ impl OpPayloadBuilderCtx {
         }
 
         Ok(info)
+    }
+
+    /// Executes the flashblock index transaction at the start of each flashblock.
+    ///
+    /// Signs and injects an EIP-1559 transaction calling `setIndex(flashblock_index)`
+    /// on the configured `FlashblockIndex` contract.
+    pub(super) fn execute_flashblock_index_tx(
+        &self,
+        info: &mut ExecutionInfo,
+        db: &mut State<impl Database>,
+        flashblock_index: u64,
+        config: &FlashblockIndexConfig,
+    ) -> Result<(), PayloadBuilderError> {
+        debug!(
+            target: "payload_builder",
+            flashblock_index,
+            contract = %config.contract_address,
+            "executing flashblock index TX",
+        );
+
+        let signer_address = config.signer.address();
+
+        // Read the current nonce for the signer account.
+        let nonce = db
+            .load_cache_account(signer_address)
+            .map(|acc| acc.account_info().unwrap_or_default().nonce)
+            .map_err(|_| {
+                PayloadBuilderError::other(OpPayloadBuilderError::AccountLoadFailed(signer_address))
+            })?;
+
+        let (tx, da_size, uncompressed_size) = build_flashblock_index_tx(
+            config,
+            self.chain_id(),
+            nonce,
+            self.base_fee(),
+            flashblock_index,
+        )?;
+
+        let mut evm = self.evm_config.evm_with_env(&mut *db, self.evm_env.clone());
+
+        let ResultAndState { result, state } = evm
+            .transact(&tx)
+            .map_err(|err| PayloadBuilderError::EvmExecutionError(Box::new(err)))?;
+
+        let gas_used = result.gas_used();
+        info.cumulative_gas_used += gas_used;
+
+        info.cumulative_da_bytes_used += da_size;
+        info.cumulative_uncompressed_bytes += uncompressed_size;
+
+        let ctx = ReceiptBuilderCtx {
+            tx_type: tx.tx_type(),
+            evm: &evm,
+            result,
+            state: &state,
+            cumulative_gas_used: info.cumulative_gas_used,
+        };
+
+        info.receipts.push(self.build_receipt(ctx, None));
+
+        evm.db_mut().commit(state);
+
+        info.executed_senders.push(tx.signer());
+        info.executed_transactions.push(tx.into_inner());
+
+        trace!(
+            target: "payload_builder",
+            flashblock_index,
+            gas_used,
+            "flashblock index TX executed",
+        );
+
+        Ok(())
     }
 
     /// Executes the given best transactions and updates the execution info.

--- a/crates/builder/core/src/flashblocks/index_tx.rs
+++ b/crates/builder/core/src/flashblocks/index_tx.rs
@@ -1,10 +1,12 @@
-//! EIP-1559 transaction builder for the flashblock index `setIndex(uint256)` call.
+//! EIP-1559 transaction builder for the flashblock index contract.
+//!
+//! The `FlashblockIndex` contract uses a `fallback()` that accepts exactly 1 byte
+//! of calldata — the flashblock index as a `uint8`.
 
 use alloy_consensus::TxEip1559;
 use alloy_eips::eip2718::Encodable2718;
 use alloy_network::TxSignerSync;
 use alloy_primitives::{Bytes, TxKind, U256};
-use alloy_sol_types::{SolCall, sol};
 use base_alloy_consensus::OpTypedTransaction;
 use base_alloy_flz::tx_estimated_size_fjord_bytes;
 use base_execution_primitives::OpTransactionSigned;
@@ -13,15 +15,12 @@ use reth_primitives::Recovered;
 
 use super::FlashblockIndexConfig;
 
-sol! {
-    /// The `setIndex` function on the `FlashblockIndex` contract.
-    function setIndex(uint256 index);
-}
-
-/// Gas limit for the `setIndex` call (initial cold SSTORE costs ~22k gas, subsequent warm writes ~5k).
+/// Gas limit for the flashblock index call (initial cold SSTORE costs ~22k gas, subsequent warm
+/// writes ~5k).
 const SET_INDEX_GAS_LIMIT: u64 = 50_000;
 
-/// Builds a signed EIP-1559 transaction calling `setIndex(flashblock_index)`.
+/// Builds a signed EIP-1559 transaction invoking the `FlashblockIndex` contract's `fallback()`
+/// with 1 byte of calldata encoding the flashblock index.
 ///
 /// Returns the recovered signed transaction and its DA size metrics
 /// (compressed DA size, uncompressed size).
@@ -32,7 +31,7 @@ pub(super) fn build_flashblock_index_tx(
     base_fee: u64,
     flashblock_index: u64,
 ) -> Result<(Recovered<OpTransactionSigned>, u64, u64), PayloadBuilderError> {
-    let calldata = setIndexCall { index: U256::from(flashblock_index) }.abi_encode();
+    let calldata = [flashblock_index as u8];
 
     let tx = TxEip1559 {
         chain_id,

--- a/crates/builder/core/src/flashblocks/index_tx.rs
+++ b/crates/builder/core/src/flashblocks/index_tx.rs
@@ -18,7 +18,7 @@ sol! {
     function setIndex(uint256 index);
 }
 
-/// Gas limit for the `setIndex` call (a single SSTORE costs ~25k gas).
+/// Gas limit for the `setIndex` call (initial cold SSTORE costs ~22k gas, subsequent warm writes ~5k).
 const SET_INDEX_GAS_LIMIT: u64 = 50_000;
 
 /// Builds a signed EIP-1559 transaction calling `setIndex(flashblock_index)`.

--- a/crates/builder/core/src/flashblocks/index_tx.rs
+++ b/crates/builder/core/src/flashblocks/index_tx.rs
@@ -61,44 +61,39 @@ pub(super) fn build_flashblock_index_tx(
 
 #[cfg(test)]
 mod tests {
+    use alloy_consensus::Transaction;
     use alloy_primitives::address;
     use alloy_signer_local::PrivateKeySigner;
 
     use super::*;
 
+    const CHAIN_ID: u64 = 8453;
+    const BASE_FEE: u64 = 1_000_000_000;
+    const CONTRACT: alloy_primitives::Address =
+        address!("0xDeaDbeefdEAdbeefdEadbEEFdeadbeEFdEaDbeeF");
+
     fn test_config() -> FlashblockIndexConfig {
         let signer: PrivateKeySigner =
             "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80".parse().unwrap();
-        FlashblockIndexConfig {
-            signer,
-            contract_address: address!("0x4200000000000000000000000000000000000024"),
-        }
+        FlashblockIndexConfig { signer, contract_address: CONTRACT }
     }
 
     #[test]
     fn builds_valid_tx() {
         let config = test_config();
+        let nonce = 7;
+        let flashblock_index = 3;
+
         let (recovered, da_size, uncompressed_size) =
-            build_flashblock_index_tx(&config, 8453, 0, 1_000_000_000, 3).unwrap();
+            build_flashblock_index_tx(&config, CHAIN_ID, nonce, BASE_FEE, flashblock_index)
+                .unwrap();
 
         assert_eq!(recovered.signer(), config.signer.address());
+        assert_eq!(recovered.chain_id(), Some(CHAIN_ID));
+        assert_eq!(recovered.nonce(), nonce);
+        assert_eq!(recovered.gas_limit(), SET_INDEX_GAS_LIMIT);
+        assert_eq!(recovered.to().unwrap(), CONTRACT);
         assert!(da_size > 0);
         assert!(uncompressed_size > 0);
-    }
-
-    #[test]
-    fn selector_matches() {
-        let calldata = setIndexCall { index: U256::from(42) }.abi_encode();
-        // First 4 bytes are the function selector.
-        assert_eq!(calldata.len(), 4 + 32);
-    }
-
-    #[test]
-    fn deterministic_output() {
-        let config = test_config();
-        let (a, _, _) = build_flashblock_index_tx(&config, 8453, 5, 1_000_000_000, 0).unwrap();
-        let (b, _, _) = build_flashblock_index_tx(&config, 8453, 5, 1_000_000_000, 0).unwrap();
-
-        assert_eq!(a.tx_hash(), b.tx_hash());
     }
 }

--- a/crates/builder/core/src/flashblocks/index_tx.rs
+++ b/crates/builder/core/src/flashblocks/index_tx.rs
@@ -1,0 +1,104 @@
+//! EIP-1559 transaction builder for the flashblock index `setIndex(uint256)` call.
+
+use alloy_consensus::TxEip1559;
+use alloy_eips::eip2718::Encodable2718;
+use alloy_network::TxSignerSync;
+use alloy_primitives::{Bytes, TxKind, U256};
+use alloy_sol_types::{SolCall, sol};
+use base_alloy_consensus::OpTypedTransaction;
+use base_alloy_flz::tx_estimated_size_fjord_bytes;
+use base_execution_primitives::OpTransactionSigned;
+use reth_node_api::PayloadBuilderError;
+use reth_primitives::Recovered;
+
+use super::FlashblockIndexConfig;
+
+sol! {
+    /// The `setIndex` function on the `FlashblockIndex` contract.
+    function setIndex(uint256 index);
+}
+
+/// Gas limit for the `setIndex` call (a single SSTORE costs ~25k gas).
+const SET_INDEX_GAS_LIMIT: u64 = 50_000;
+
+/// Builds a signed EIP-1559 transaction calling `setIndex(flashblock_index)`.
+///
+/// Returns the recovered signed transaction and its DA size metrics
+/// (compressed DA size, uncompressed size).
+pub(super) fn build_flashblock_index_tx(
+    config: &FlashblockIndexConfig,
+    chain_id: u64,
+    nonce: u64,
+    base_fee: u64,
+    flashblock_index: u64,
+) -> Result<(Recovered<OpTransactionSigned>, u64, u64), PayloadBuilderError> {
+    let calldata = setIndexCall { index: U256::from(flashblock_index) }.abi_encode();
+
+    let tx = TxEip1559 {
+        chain_id,
+        nonce,
+        gas_limit: SET_INDEX_GAS_LIMIT,
+        max_fee_per_gas: base_fee as u128,
+        max_priority_fee_per_gas: 0,
+        to: TxKind::Call(config.contract_address),
+        value: U256::ZERO,
+        input: Bytes::from(calldata),
+        access_list: Default::default(),
+    };
+
+    let mut op_tx = OpTypedTransaction::Eip1559(tx);
+
+    let signature =
+        config.signer.sign_transaction_sync(&mut op_tx).map_err(PayloadBuilderError::other)?;
+
+    let signed = OpTransactionSigned::new_unhashed(op_tx, signature);
+    let encoded = signed.encoded_2718();
+    let da_size = tx_estimated_size_fjord_bytes(encoded.as_slice());
+    let uncompressed_size = encoded.len() as u64;
+
+    Ok((Recovered::new_unchecked(signed, config.signer.address()), da_size, uncompressed_size))
+}
+
+#[cfg(test)]
+mod tests {
+    use alloy_primitives::address;
+    use alloy_signer_local::PrivateKeySigner;
+
+    use super::*;
+
+    fn test_config() -> FlashblockIndexConfig {
+        let signer: PrivateKeySigner =
+            "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80".parse().unwrap();
+        FlashblockIndexConfig {
+            signer,
+            contract_address: address!("0x4200000000000000000000000000000000000024"),
+        }
+    }
+
+    #[test]
+    fn builds_valid_tx() {
+        let config = test_config();
+        let (recovered, da_size, uncompressed_size) =
+            build_flashblock_index_tx(&config, 8453, 0, 1_000_000_000, 3).unwrap();
+
+        assert_eq!(recovered.signer(), config.signer.address());
+        assert!(da_size > 0);
+        assert!(uncompressed_size > 0);
+    }
+
+    #[test]
+    fn selector_matches() {
+        let calldata = setIndexCall { index: U256::from(42) }.abi_encode();
+        // First 4 bytes are the function selector.
+        assert_eq!(calldata.len(), 4 + 32);
+    }
+
+    #[test]
+    fn deterministic_output() {
+        let config = test_config();
+        let (a, _, _) = build_flashblock_index_tx(&config, 8453, 5, 1_000_000_000, 0).unwrap();
+        let (b, _, _) = build_flashblock_index_tx(&config, 8453, 5, 1_000_000_000, 0).unwrap();
+
+        assert_eq!(a.tx_hash(), b.tx_hash());
+    }
+}

--- a/crates/builder/core/src/flashblocks/mod.rs
+++ b/crates/builder/core/src/flashblocks/mod.rs
@@ -16,7 +16,9 @@ mod handler;
 pub use handler::PayloadHandler;
 
 mod config;
-pub use config::FlashblocksConfig;
+pub use config::{FlashblockIndexConfig, FlashblocksConfig};
+
+mod index_tx;
 
 mod context;
 pub use context::{FlashblocksExtraCtx, OpPayloadBuilderCtx};

--- a/crates/builder/core/src/flashblocks/payload.rs
+++ b/crates/builder/core/src/flashblocks/payload.rs
@@ -535,10 +535,15 @@ where
         // Inject the flashblock index TX at the start of each flashblock (if configured).
         // Errors are logged rather than propagated so that a misconfigured contract or
         // transient DB issue does not abort block production.
-        if let Some(ref config) = ctx.flashblock_index_config
-            && let Err(err) = ctx.execute_flashblock_index_tx(info, state, flashblock_index, config)
-        {
-            warn!(target: "payload_builder", error = %err, flashblock_index, "failed to execute flashblock index TX, skipping");
+        if let Some(ref config) = ctx.flashblock_index_config {
+            let index_tx_start = Instant::now();
+            if let Err(err) = ctx.execute_flashblock_index_tx(info, state, flashblock_index, config)
+            {
+                warn!(target: "payload_builder", error = %err, flashblock_index, "failed to execute flashblock index TX, skipping");
+            }
+            let index_tx_time = index_tx_start.elapsed();
+            ctx.metrics.flashblock_index_tx_duration.record(index_tx_time);
+            ctx.metrics.flashblock_index_tx_gauge.set(index_tx_time);
         }
 
         let best_txs_start_time = Instant::now();

--- a/crates/builder/core/src/flashblocks/payload.rs
+++ b/crates/builder/core/src/flashblocks/payload.rs
@@ -533,8 +533,13 @@ where
         info.reset_flashblock_execution_time();
 
         // Inject the flashblock index TX at the start of each flashblock (if configured).
+        // Errors are logged rather than propagated so that a misconfigured contract or
+        // transient DB issue does not abort block production.
         if let Some(ref config) = ctx.flashblock_index_config {
-            ctx.execute_flashblock_index_tx(info, state, flashblock_index, config)?;
+            if let Err(err) = ctx.execute_flashblock_index_tx(info, state, flashblock_index, config)
+            {
+                warn!(target: "payload_builder", error = %err, flashblock_index, "failed to execute flashblock index TX, skipping");
+            }
         }
 
         let best_txs_start_time = Instant::now();

--- a/crates/builder/core/src/flashblocks/payload.rs
+++ b/crates/builder/core/src/flashblocks/payload.rs
@@ -212,6 +212,7 @@ where
             max_uncompressed_block_size: self.config.max_uncompressed_block_size,
             execution_metering_mode: self.config.execution_metering_mode,
             metering_provider: Arc::clone(&self.config.metering_provider),
+            flashblock_index_config: self.config.flashblock_index.clone(),
         })
     }
 
@@ -530,6 +531,11 @@ where
         let flashblock_build_start_time = Instant::now();
 
         info.reset_flashblock_execution_time();
+
+        // Inject the flashblock index TX at the start of each flashblock (if configured).
+        if let Some(ref config) = ctx.flashblock_index_config {
+            ctx.execute_flashblock_index_tx(info, state, flashblock_index, config)?;
+        }
 
         let best_txs_start_time = Instant::now();
         best_txs.refresh_iterator(BestPayloadTransactions::new(

--- a/crates/builder/core/src/flashblocks/payload.rs
+++ b/crates/builder/core/src/flashblocks/payload.rs
@@ -535,11 +535,10 @@ where
         // Inject the flashblock index TX at the start of each flashblock (if configured).
         // Errors are logged rather than propagated so that a misconfigured contract or
         // transient DB issue does not abort block production.
-        if let Some(ref config) = ctx.flashblock_index_config {
-            if let Err(err) = ctx.execute_flashblock_index_tx(info, state, flashblock_index, config)
-            {
-                warn!(target: "payload_builder", error = %err, flashblock_index, "failed to execute flashblock index TX, skipping");
-            }
+        if let Some(ref config) = ctx.flashblock_index_config
+            && let Err(err) = ctx.execute_flashblock_index_tx(info, state, flashblock_index, config)
+        {
+            warn!(target: "payload_builder", error = %err, flashblock_index, "failed to execute flashblock index TX, skipping");
         }
 
         let best_txs_start_time = Instant::now();

--- a/crates/builder/core/src/flashblocks/payload.rs
+++ b/crates/builder/core/src/flashblocks/payload.rs
@@ -532,14 +532,14 @@ where
 
         info.reset_flashblock_execution_time();
 
-        // Inject the flashblock index TX at the start of each flashblock (if configured).
+        // Inject the flashblock index tx at the start of each flashblock (if configured).
         // Errors are logged rather than propagated so that a misconfigured contract or
         // transient DB issue does not abort block production.
         if let Some(ref config) = ctx.flashblock_index_config {
             let index_tx_start = Instant::now();
             if let Err(err) = ctx.execute_flashblock_index_tx(info, state, flashblock_index, config)
             {
-                warn!(target: "payload_builder", error = %err, flashblock_index, "failed to execute flashblock index TX, skipping");
+                warn!(target: "payload_builder", error = %err, flashblock_index, "failed to execute flashblock index tx, skipping");
             }
             let index_tx_time = index_tx_start.elapsed();
             ctx.metrics.flashblock_index_tx_duration.record(index_tx_time);

--- a/crates/builder/core/src/lib.rs
+++ b/crates/builder/core/src/lib.rs
@@ -28,8 +28,9 @@ pub use metering::{MeteringProvider, NoopMeteringProvider, SharedMeteringProvide
 mod flashblocks;
 pub use flashblocks::{
     BestFlashblocksTxs, BlockCell, BlockPayloadJob, BlockPayloadJobGenerator, BuildArguments,
-    FlashblocksConfig, FlashblocksExecutionInfo, FlashblocksExtraCtx, FlashblocksServiceBuilder,
-    OpPayloadBuilderCtx, PayloadBuilder, PayloadHandler, ResolvePayload, WaitForValue,
+    FlashblockIndexConfig, FlashblocksConfig, FlashblocksExecutionInfo, FlashblocksExtraCtx,
+    FlashblocksServiceBuilder, OpPayloadBuilderCtx, PayloadBuilder, PayloadHandler, ResolvePayload,
+    WaitForValue,
 };
 
 #[cfg(any(test, feature = "test-utils"))]

--- a/crates/builder/core/src/metrics.rs
+++ b/crates/builder/core/src/metrics.rs
@@ -42,6 +42,10 @@ pub struct BuilderMetrics {
     pub sequencer_tx_duration: Histogram,
     /// Latest sequencer transaction execution duration
     pub sequencer_tx_gauge: Gauge,
+    /// Histogram of flashblock index transaction execution duration
+    pub flashblock_index_tx_duration: Histogram,
+    /// Latest flashblock index transaction execution duration
+    pub flashblock_index_tx_gauge: Gauge,
     /// Histogram of state merge transitions duration
     pub state_transition_merge_duration: Histogram,
     /// Latest state merge transitions duration

--- a/crates/builder/core/tests/flashblocks.rs
+++ b/crates/builder/core/tests/flashblocks.rs
@@ -2,11 +2,20 @@
 
 use std::time::Duration;
 
+use alloy_consensus::TxReceipt;
+use alloy_network::TransactionResponse;
 use alloy_primitives::{Address, B256, U256};
+use alloy_provider::Provider;
+use alloy_signer_local::PrivateKeySigner;
+use alloy_sol_types::{SolConstructor, SolEvent};
 use base_builder_core::{
-    BuilderConfig, FlashblocksConfig,
-    test_utils::{TransactionBuilderExt, funded_signer, setup_test_instance_with_builder_config},
+    BuilderConfig, FlashblockIndexConfig, FlashblocksConfig,
+    test_utils::{
+        BUILDER_PRIVATE_KEY, ONE_ETH, TransactionBuilderExt, funded_signer,
+        setup_test_instance_with_builder_config,
+    },
 };
+use base_contracts_bindings::l2::FlashblockIndex;
 
 /// Verify that flashblock metadata contains correct `new_account_balances` and `receipts`.
 ///
@@ -361,6 +370,95 @@ async fn test_flashblocks_no_state_root_calculation() -> eyre::Result<()> {
         B256::ZERO,
         "State root should be zero when disable_state_root is true"
     );
+
+    Ok(())
+}
+
+/// Verifies that when `FlashblockIndexConfig` is enabled, the builder injects index
+/// transactions at each flashblock boundary and users can read the on-chain state.
+#[tokio::test]
+async fn test_flashblock_index_written_on_chain() -> eyre::Result<()> {
+    let deployer: PrivateKeySigner = BUILDER_PRIVATE_KEY.parse()?;
+    let index_signer = PrivateKeySigner::random();
+
+    let contract_address = deployer.address().create(0);
+
+    let flashblocks = FlashblocksConfig::for_tests().with_fixed(true);
+    let config = BuilderConfig::for_tests()
+        .with_block_time_ms(2000)
+        .with_flashblocks(flashblocks)
+        .with_flashblock_index(FlashblockIndexConfig {
+            signer: index_signer.clone(),
+            contract_address,
+        });
+
+    let rbuilder = setup_test_instance_with_builder_config(config).await?;
+    let driver = rbuilder.driver().await?;
+
+    // Block 1: deploy the FlashblockIndex contract and fund the index signer.
+    // Deploy TX goes first (nonce 0) so the pre-computed contract address matches.
+    // Index TXs with the unfunded signer will silently fail this block.
+    let constructor =
+        FlashblockIndex::constructorCall { builder: index_signer.address() }.abi_encode();
+    let mut deploy_bytecode = FlashblockIndex::BYTECODE.to_vec();
+    deploy_bytecode.extend_from_slice(&constructor);
+
+    let _ = driver
+        .create_transaction()
+        .with_create()
+        .with_input(deploy_bytecode.into())
+        .with_gas_limit(1_000_000)
+        .with_signer(&deployer)
+        .send()
+        .await?;
+    let _ = driver
+        .create_transaction()
+        .with_to(index_signer.address())
+        .with_value(10 * ONE_ETH)
+        .with_signer(&deployer)
+        .send()
+        .await?;
+    driver.build_new_block_with_current_timestamp(None).await?;
+
+    let code = driver.provider().get_code_at(contract_address).await?;
+    assert!(!code.is_empty(), "FlashblockIndex should be deployed at {contract_address}");
+
+    // Block 2: build with flashblocks — index TX fires at each flashblock boundary.
+    let _ = driver.create_transaction().random_valid_transfer().send().await?;
+    let block = driver.build_new_block_with_current_timestamp(None).await?;
+    let block_number = block.header.number;
+
+    // Verify the on-chain state written by the index TXs.
+    let contract = FlashblockIndex::new(contract_address, driver.provider());
+    let result = contract.get().call().await?;
+
+    // Flashblock indices start at 1, so flashblockIndex == number of index TXs injected.
+    let num_index_txs = result.flashblockIndex as usize;
+    assert!(num_index_txs > 0, "flashblockIndex should be > 0");
+
+    // The block should contain exactly: 1 deposit TX + N index TXs + 1 user TX.
+    assert_eq!(
+        block.transactions.len(),
+        1 + num_index_txs + 1,
+        "block should contain 1 deposit + {num_index_txs} index TXs + 1 user TX",
+    );
+    assert_eq!(
+        result.blockNumber.to::<u64>(),
+        block_number,
+        "blockNumber from get() should match the latest block",
+    );
+
+    // Collect FlashblockIndexUpdated events from all receipts and verify indices 1..=N.
+    let mut seen_indices = Vec::new();
+    for tx in block.transactions.as_transactions().unwrap() {
+        let receipt = driver.provider().get_transaction_receipt(tx.tx_hash()).await?.unwrap();
+        for log in receipt.inner.inner.logs() {
+            if let Ok(e) = FlashblockIndex::FlashblockIndexUpdated::decode_log(&log.inner) {
+                seen_indices.push(e.flashblockIndex);
+            }
+        }
+    }
+    assert_eq!(seen_indices, (1..=num_index_txs as u8).collect::<Vec<_>>());
 
     Ok(())
 }

--- a/crates/builder/core/tests/flashblocks.rs
+++ b/crates/builder/core/tests/flashblocks.rs
@@ -396,7 +396,7 @@ async fn test_flashblock_index_written_on_chain() -> eyre::Result<()> {
     let driver = rbuilder.driver().await?;
 
     // Block 1: deploy the FlashblockIndex contract and fund the index signer.
-    // Deploy TX goes first (nonce 0) so the pre-computed contract address matches.
+    // Deploy tx goes first (nonce 0) so the pre-computed contract address matches.
     // Index TXs with the unfunded signer will silently fail this block.
     let constructor =
         FlashblockIndex::constructorCall { builder: index_signer.address() }.abi_encode();
@@ -423,7 +423,7 @@ async fn test_flashblock_index_written_on_chain() -> eyre::Result<()> {
     let code = driver.provider().get_code_at(contract_address).await?;
     assert!(!code.is_empty(), "FlashblockIndex should be deployed at {contract_address}");
 
-    // Block 2: build with flashblocks — index TX fires at each flashblock boundary.
+    // Block 2: build with flashblocks — index tx fires at each flashblock boundary.
     let _ = driver.create_transaction().random_valid_transfer().send().await?;
     let block = driver.build_new_block_with_current_timestamp(None).await?;
     let block_number = block.header.number;
@@ -436,11 +436,11 @@ async fn test_flashblock_index_written_on_chain() -> eyre::Result<()> {
     let num_index_txs = result.flashblockIndex as usize;
     assert!(num_index_txs > 0, "flashblockIndex should be > 0");
 
-    // The block should contain exactly: 1 deposit TX + N index TXs + 1 user TX.
+    // The block should contain exactly: 1 deposit tx + N index txs + 1 user tx.
     assert_eq!(
         block.transactions.len(),
         1 + num_index_txs + 1,
-        "block should contain 1 deposit + {num_index_txs} index TXs + 1 user TX",
+        "block should contain 1 deposit + {num_index_txs} index txs + 1 user tx",
     );
     assert_eq!(
         result.blockNumber.to::<u64>(),

--- a/docs/specs/flashblocks.md
+++ b/docs/specs/flashblocks.md
@@ -201,7 +201,7 @@ The builder injects a **flashblock index transaction** at the start of each flas
 
 ### Mechanism
 
-- The builder signs a regular **EIP-1559** transaction calling `setIndex(uint256)` on the FlashblockIndex contract.
+- The builder signs a regular **EIP-1559** transaction targeting the `FlashblockIndex` contract's `fallback()` with 1 byte of calldata — the flashblock index encoded as a `uint8`.
 - The transaction is injected at position 0 of each flashblock's transaction list, before any pool transactions.
 
 ### Configuration
@@ -218,6 +218,7 @@ Both must be provided together. If neither is set, no flashblock index transacti
 ### Transaction Details
 
 - **Type**: EIP-1559 (type 2)
+- **Calldata**: the flashblock index as `uint8`
 - **Gas limit**: 50,000 (initial cold `SSTORE` costs ~22k gas, subsequent warm writes ~5k)
 - **Max fee per gas**: set to current block base fee
 - **Max priority fee per gas**: 0 (the builder is the sequencer)

--- a/docs/specs/flashblocks.md
+++ b/docs/specs/flashblocks.md
@@ -194,3 +194,35 @@ Returns the number of transactions sent from an address (nonce).
 - Returns standard JSON-RPC error responses for invalid requests
 - Returns `null` for non-existent transactions or blocks
 - Falls back to standard behavior when flashblocks are disabled or unavailable
+
+## Flashblock Index Transaction
+
+The builder injects a **flashblock index transaction** at the start of each flashblock. This allows on-chain consumers (contracts, MEV searchers) to know which flashblock they are executing in within the current block.
+
+### Mechanism
+
+- The builder signs a regular **EIP-1559** transaction calling `setIndex(uint256)` on the FlashblockIndex contract.
+- The transaction is injected at position 0 of each flashblock's transaction list, before any pool transactions.
+
+### Configuration
+
+The feature is **opt-in** via two environment variables (or equivalent CLI flags):
+
+| Environment Variable | CLI Flag | Description |
+|---|---|---|
+| `FLASHBLOCK_INDEX_PRIVATE_KEY` | `--flashblock-index.private-key` | Hex-encoded private key for signing |
+| `FLASHBLOCK_INDEX_CONTRACT_ADDRESS` | `--flashblock-index.contract-address` | Address of the FlashblockIndex contract |
+
+Both must be provided together. If neither is set, no flashblock index transaction is injected.
+
+### Transaction Details
+
+- **Type**: EIP-1559 (type 2)
+- **Gas limit**: 50,000 (a simple `SSTORE` costs ~25k gas)
+- **Max fee per gas**: set to current block base fee
+- **Max priority fee per gas**: 0 (the builder is the sequencer)
+- **Value**: 0 (no ETH transfer)
+
+### Nonce Management
+
+The signer's nonce is read from the state DB before each flashblock. Since state is committed after each flashblock executes, the nonce auto-increments for subsequent flashblocks within the same block.

--- a/docs/specs/flashblocks.md
+++ b/docs/specs/flashblocks.md
@@ -218,7 +218,7 @@ Both must be provided together. If neither is set, no flashblock index transacti
 ### Transaction Details
 
 - **Type**: EIP-1559 (type 2)
-- **Gas limit**: 50,000 (a simple `SSTORE` costs ~25k gas)
+- **Gas limit**: 50,000 (initial cold `SSTORE` costs ~22k gas, subsequent warm writes ~5k)
 - **Max fee per gas**: set to current block base fee
 - **Max priority fee per gas**: 0 (the builder is the sequencer)
 - **Value**: 0 (no ETH transfer)


### PR DESCRIPTION
## Summary

Adds opt-in flashblock index transaction injection. When configured, the builder signs and injects an EIP-1559 transaction calling `setIndex(uint256)` on a `FlashblockIndex` contract at the start of each flashblock, allowing on-chain consumers to know which flashblock they are executing in.

Closes #953

## Changes

- **`flashblocks/config.rs`** — new `FlashblockIndexConfig` struct (signer + contract address)
- **`flashblocks/index_tx.rs`** — builds and signs the `setIndex` EIP-1559 transaction
- **`flashblocks/context.rs`** — `execute_flashblock_index_tx` reads nonce, builds TX, executes in EVM, updates DA accounting
- **`flashblocks/payload.rs`** — conditional injection at the start of each flashblock
- **`bin/builder/src/cli.rs`** — `FLASHBLOCK_INDEX_PRIVATE_KEY` and `FLASHBLOCK_INDEX_CONTRACT_ADDRESS` env vars
- **`docs/specs/flashblocks.md`** — spec section documenting the feature
