### PR TITLE
Fix proposer binary Cli struct name collision with base_proposer::Cli

### DIFF
--- a/bin/proposer/src/cli.rs
+++ b/bin/proposer/src/cli.rs
@@ -5,12 +5,12 @@ use clap::Parser;
 /// Base Proposer.
 #[derive(Parser)]
 #[command(author, version)]
-pub(crate) struct Cli {
+pub(crate) struct ProposerBin {
     #[command(flatten)]
     args: base_proposer::Cli,
 }
 
-impl Cli {
+impl ProposerBin {
     /// Run the proposer service.
     pub(crate) async fn run(self) -> eyre::Result<()> {
         base_proposer::run(base_proposer::ProposerConfig::from_cli(self.args)?).await

--- a/bin/proposer/src/cli.rs
+++ b/bin/proposer/src/cli.rs
@@ -5,12 +5,13 @@ use clap::Parser;
 /// Base Proposer.
 #[derive(Parser)]
 #[command(author, version)]
-pub(crate) struct ProposerBin {
+#[group(skip)]
+pub(crate) struct Cli {
     #[command(flatten)]
     args: base_proposer::Cli,
 }
 
-impl ProposerBin {
+impl Cli {
     /// Run the proposer service.
     pub(crate) async fn run(self) -> eyre::Result<()> {
         base_proposer::run(base_proposer::ProposerConfig::from_cli(self.args)?).await

--- a/bin/proposer/src/main.rs
+++ b/bin/proposer/src/main.rs
@@ -9,7 +9,7 @@ mod cli;
 
 #[tokio::main]
 async fn main() {
-    if let Err(err) = cli::Cli::parse().run().await {
+    if let Err(err) = cli::ProposerBin::parse().run().await {
         eprintln!("Error: {err:?}");
         std::process::exit(1);
     }

--- a/bin/proposer/src/main.rs
+++ b/bin/proposer/src/main.rs
@@ -9,7 +9,7 @@ mod cli;
 
 #[tokio::main]
 async fn main() {
-    if let Err(err) = cli::ProposerBin::parse().run().await {
+    if let Err(err) = cli::Cli::parse().run().await {
         eprintln!("Error: {err:?}");
         std::process::exit(1);
     }


### PR DESCRIPTION
Prevent clap from creating a duplicate argument group named `Cli` on the binary wrapper `Cli` struct  — one from bin/proposer::Cli and one from the flattened base_proposer::Cli. This avoids a clap argument group name collision that caused a panic on startup.