### PR TITLE
chore(ci): fix affected tests

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -133,7 +133,14 @@ test-affected-ci base="main": install-nextest build-contracts
         pkg_args="$pkg_args -p $crate"
     done <<< "$affected"
     echo "Testing affected crates:$pkg_args"
-    cargo nextest run --all-features --cargo-profile ci $pkg_args
+    cargo nextest run --all-features --cargo-profile ci $pkg_args || {
+        code=$?
+        if [ $code -eq 4 ]; then
+            echo "No tests to run."
+            exit 0
+        fi
+        exit $code
+    }
 
 # Runs devnet tests (requires Docker)
 devnet-tests: install-nextest build-contracts


### PR DESCRIPTION
## Summary

In #957, ci failed because there were no affected tests, which results in a ci error instead of a success. This PR fixes the affected tests justfile target to succeed if there are no affected tests.