### PR TITLE
fix(release): use shasum fallback on macOS

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -119,7 +119,11 @@ jobs:
           for bin in base-reth-node basectl; do
             ARCHIVE="${bin}-${TAG}-${TARGET}.tar.gz"
             tar -czf "$ARCHIVE" -C target/maxperf "$bin"
-            sha256sum "$ARCHIVE" > "${ARCHIVE}.sha256"
+            if command -v sha256sum &>/dev/null; then
+              sha256sum "$ARCHIVE" > "${ARCHIVE}.sha256"
+            else
+              shasum -a 256 "$ARCHIVE" > "${ARCHIVE}.sha256"
+            fi
           done
 
       - name: Upload artifacts


### PR DESCRIPTION
Fix sha256sum not found on macos runners. Fixes https://github.com/base/base/actions/runs/22579734730/job/65408251809