### PR TITLE
fix(metering): lower bundle metering failure log from error to info

### DIFF
--- a/crates/client/metering/src/rpc.rs
+++ b/crates/client/metering/src/rpc.rs
@@ -200,7 +200,7 @@ where
             if error_msg.contains("nonce") {
                 debug!(error = %e, "Bundle metering failed");
             } else {
-                error!(error = %e, "Bundle metering failed");
+                info!(error = %e, "Bundle metering failed");
             }
             jsonrpsee::types::ErrorObjectOwned::owned(
                 jsonrpsee::types::ErrorCode::InternalError.code(),


### PR DESCRIPTION
## Summary
- Transaction validation failures (insufficient funds, 7702 mismatches, etc.) are expected rejections of user-submitted bundles, not internal errors
- Lowers the log level from `error!()` to `info!()` for non-nonce metering failures
- Nonce failures remain at `debug` level