### PR TITLE
backport(0.5.0): fix validate_tx logic for 7702 (#733)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2801,6 +2801,7 @@ dependencies = [
  "reth-revm",
  "reth-transaction-pool",
  "reth-trie-common",
+ "revm-bytecode 8.0.0",
  "revm-context-interface 14.0.0",
  "revm-database 10.0.0",
  "serde",

--- a/crates/client/metering/Cargo.toml
+++ b/crates/client/metering/Cargo.toml
@@ -68,6 +68,7 @@ reth-db = { workspace = true, features = ["op", "test-utils"] }
 reth-transaction-pool = { workspace = true, features = ["test-utils"] }
 
 # revm
+revm-bytecode.workspace = true
 revm-context-interface.workspace = true
 
 # alloy


### PR DESCRIPTION
## Summary
- Cherry-pick of #733 onto `releases/v0.5.0`
- Fixes incorrect rejection of non-7702 transactions from EIP-7702 delegated accounts
- Replaces `AccountIs7702ButTxIsNot7702` error with proper bytecode-aware validation
- Adds `AuthorizationListIsEmpty` check for 7702 transactions