### PR TITLE
backport(0.5.0): lower bundle metering failure log from error to info (#966)

### DIFF
--- a/crates/client/metering/src/rpc.rs
+++ b/crates/client/metering/src/rpc.rs
@@ -199,7 +199,7 @@ where
             if error_msg.contains("nonce") {
                 debug!(error = %e, "Bundle metering failed");
             } else {
-                error!(error = %e, "Bundle metering failed");
+                info!(error = %e, "Bundle metering failed");
             }
             jsonrpsee::types::ErrorObjectOwned::owned(
                 jsonrpsee::types::ErrorCode::InternalError.code(),


### PR DESCRIPTION
## Summary
- Cherry-pick of #966 onto `releases/v0.5.0`
- Transaction validation failures are expected rejections, not internal errors
- Lowers log level from `error!()` to `info!()` for non-nonce metering failures
- Nonce failures remain at `debug` level