### PR TITLE
chore(execution): Portability Removal

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -4,7 +4,7 @@
 #   macOS:  brew install lld
 
 [target.x86_64-unknown-linux-gnu]
-rustflags = ["-C", "link-arg=-fuse-ld=mold"]
+rustflags = ["-C", "link-arg=-fuse-ld=mold", "-C", "target-cpu=x86-64-v3"]
 
 [target.aarch64-unknown-linux-gnu]
 rustflags = ["-C", "link-arg=-fuse-ld=mold"]

--- a/crates/execution/revm/Cargo.toml
+++ b/crates/execution/revm/Cargo.toml
@@ -33,7 +33,7 @@ alloy-sol-types = { workspace = true, default-features = false }
 serde = { workspace = true, features = ["derive", "rc"] }
 
 [features]
-default = [ "blst", "c-kzg", "portable", "secp256k1", "std" ]
+default = [ "blst", "c-kzg", "secp256k1", "std" ]
 std = [
 	"alloy-evm?/std",
 	"alloy-primitives/std",


### PR DESCRIPTION
## Summary

`blst` defaults to a portable C fallback for broad CPU compatibility. `revm` inherits this, and `base-revm` inherited it from `revm`, meaning every BLS12-381 precompile operation and every KZG point evaluation has been running on the slow path. Removing portable and pinning `x86-64` Linux to `x86-64-v3` causes blst to compile its ADX-optimized assembly, which uses MULX/ADCX/ADOX to run two carry chains simultaneously during bignum multiplication. Expected improvement is 20-40% on BLS12-381 and KZG operations in the execution node and in the TEE enclave's stateless executor.

FPVM proof client builds are unaffected. `blst`'s build script omits x86 assembly entirely for non-x86 target triples regardless of the portable flag, so Cannon and Asterisc client binaries are unchanged. The `x86-64-v3` `rustflag` is scoped to `x86-64-unknown-linux-gnu` and does not apply to FPVM targets. The portable feature remains available in `base-revm`'s feature list for any consumer that needs it. `x86-64-v3` requires Intel Broadwell (2015) or AMD Zen (2017); all AWS instance families and GitHub Actions `x86-64` runners qualify.