### PR TITLE
backport(0.5.1): cache flashblocks arriving before their canonical block

### DIFF
--- a/crates/client/flashblocks-node/tests/state.rs
+++ b/crates/client/flashblocks-node/tests/state.rs
@@ -641,6 +641,100 @@ async fn test_sequential_nonces_across_flashblocks() {
 }
 
 #[tokio::test]
+async fn test_flashblock_cached_and_applied_after_canonical_block() {
+    let mut test = FlashblocksBuilderTestHarness::new().await;
+
+    // Send a flashblock targeting block 2 (canonical_block_number=1) before
+    // canonical block 1 exists. This triggers MissingCanonicalHeader and should
+    // be cached by the processor.
+    test.send_flashblock(FlashblockBuilder::new_base(&test).with_canonical_block_number(1).build())
+        .await;
+
+    assert!(
+        test.flashblocks.get_pending_blocks().is_none(),
+        "pending state should be empty because canonical block 1 does not exist yet"
+    );
+
+    // Build canonical block 1 so the processor can replay the cached flashblock.
+    test.new_canonical_block(vec![]).await;
+    assert_eq!(test.node.latest_block().number, 1);
+
+    let pending =
+        test.flashblocks.get_pending_blocks().get_block(true).expect("cached flashblock replayed");
+    assert_eq!(pending.header.number, 2, "replayed flashblock should produce pending block 2");
+}
+
+#[tokio::test]
+async fn test_cached_flashblock_with_transactions_applied_after_canonical() {
+    let mut test = FlashblocksBuilderTestHarness::new().await;
+
+    let transfer_amount = 100_000u128;
+
+    // Cache a base flashblock for block 2 (needs canonical block 1).
+    test.send_flashblock(FlashblockBuilder::new_base(&test).with_canonical_block_number(1).build())
+        .await;
+    assert!(test.flashblocks.get_pending_blocks().is_none());
+
+    // Also cache a second flashblock (index 1) with a transaction.
+    test.send_flashblock(
+        FlashblockBuilder::new(&test, 1)
+            .with_canonical_block_number(1)
+            .with_transactions(vec![test.build_transaction_to_send_eth(
+                Account::Alice,
+                Account::Bob,
+                transfer_amount,
+            )])
+            .build(),
+    )
+    .await;
+    assert!(test.flashblocks.get_pending_blocks().is_none());
+
+    // Provide canonical block 1 to unlock the cache.
+    test.new_canonical_block(vec![]).await;
+
+    let pending =
+        test.flashblocks.get_pending_blocks().get_block(true).expect("cached flashblocks replayed");
+    assert_eq!(pending.header.number, 2);
+    assert_eq!(pending.transactions.len(), 2, "deposit tx from base + Alice->Bob transfer");
+
+    let overrides = test
+        .flashblocks
+        .get_pending_blocks()
+        .get_state_overrides()
+        .expect("state overrides should exist after replayed flashblock execution");
+    assert!(
+        overrides.contains_key(&Account::Alice.address()),
+        "Alice should appear in overrides after sending ETH"
+    );
+    assert_eq!(
+        overrides
+            .get(&Account::Bob.address())
+            .expect("Bob should have state override")
+            .balance
+            .expect("balance should be overridden"),
+        test.expected_pending_balance(Account::Bob, transfer_amount)
+    );
+}
+
+#[tokio::test]
+async fn test_flashblock_far_ahead_of_canonical_not_cached() {
+    let test = FlashblocksBuilderTestHarness::new().await;
+
+    // Send a flashblock targeting a block far in the future (canonical_block_number=100).
+    // This is more than MAX_CACHE_AHEAD_BLOCKS (5) ahead of genesis, so it should NOT
+    // be cached and pending state should remain empty.
+    test.send_flashblock(
+        FlashblockBuilder::new_base(&test).with_canonical_block_number(100).build(),
+    )
+    .await;
+
+    assert!(
+        test.flashblocks.get_pending_blocks().is_none(),
+        "flashblock too far ahead should not be cached or produce pending state"
+    );
+}
+
+#[tokio::test]
 async fn test_progress_canonical_blocks_without_flashblocks() {
     let mut test = FlashblocksBuilderTestHarness::new().await;
 

--- a/crates/client/flashblocks/src/cache.rs
+++ b/crates/client/flashblocks/src/cache.rs
@@ -1,0 +1,207 @@
+//! Cache for flashblocks that arrive before their canonical block.
+
+use std::collections::HashMap;
+
+use alloy_primitives::BlockNumber;
+use base_primitives::Flashblock;
+
+/// Maximum number of blocks ahead of the latest canonical block for which
+/// flashblocks may be cached. Flashblocks further ahead than this are rejected
+/// to avoid unbounded memory growth during syncing.
+const MAX_CACHE_AHEAD_BLOCKS: u64 = 5;
+
+/// Buffers flashblocks that arrive before their parent canonical block has been
+/// processed. Once the canonical block lands, the caller drains the
+/// corresponding entries and feeds them through normal execution.
+#[derive(Debug)]
+pub struct FlashblockCache {
+    /// Flashblocks keyed by block number, then by flashblock index. Using a
+    /// nested map deduplicates by index — a later flashblock with the same
+    /// index silently replaces the earlier one.
+    entries: HashMap<BlockNumber, HashMap<u64, Flashblock>>,
+
+    /// The latest canonical block number we have observed, used to decide
+    /// whether a flashblock is close enough to cache.
+    latest_canonical: Option<BlockNumber>,
+}
+
+impl FlashblockCache {
+    /// Creates a new cache initialized with the given canonical block number.
+    pub fn new(latest_canonical: BlockNumber) -> Self {
+        Self { entries: HashMap::new(), latest_canonical: Some(latest_canonical) }
+    }
+
+    /// Returns `true` when the flashblock is cached.
+    pub fn has_flashblock(&self, block_number: BlockNumber, index: u64) -> bool {
+        self.entries.get(&block_number).and_then(|by_index| by_index.get(&index)).is_some()
+    }
+
+    /// Returns `true` when the flashblock's block number is within
+    /// [`MAX_CACHE_AHEAD_BLOCKS`] of the latest known canonical block and is
+    /// therefore eligible for caching.
+    pub const fn is_cacheable(&self, block_number: BlockNumber) -> bool {
+        match self.latest_canonical {
+            Some(canonical) => block_number <= canonical + MAX_CACHE_AHEAD_BLOCKS + 1,
+            None => false,
+        }
+    }
+
+    /// Inserts a flashblock into the cache.
+    ///
+    /// Returns `true` if the flashblock was cached, `false` if it was rejected
+    /// because its block number exceeds the cache-ahead limit.
+    pub fn insert(&mut self, flashblock: Flashblock) -> bool {
+        let block_number = flashblock.metadata.block_number;
+        if !self.is_cacheable(block_number) {
+            return false;
+        }
+        self.entries.entry(block_number).or_default().insert(flashblock.index, flashblock);
+        true
+    }
+
+    /// Drains all cached flashblocks for the given block number, returning them
+    /// sorted by index. Returns an empty `Vec` when nothing is cached.
+    pub fn drain(&mut self, block_number: BlockNumber) -> Vec<Flashblock> {
+        let Some(by_index) = self.entries.remove(&block_number) else {
+            return Vec::new();
+        };
+        let mut flashblocks: Vec<Flashblock> = by_index.into_values().collect();
+        flashblocks.sort_by_key(|fb| fb.index);
+        flashblocks
+    }
+
+    /// Updates the latest canonical block number and evicts any cached entries
+    /// at or below it (they can no longer be useful).
+    pub fn update_canonical(&mut self, block_number: BlockNumber) {
+        self.latest_canonical = Some(block_number);
+        self.entries.retain(|&bn, _| bn > block_number);
+    }
+
+    /// Returns the number of distinct block numbers currently cached.
+    pub fn len(&self) -> usize {
+        self.entries.len()
+    }
+
+    /// Returns `true` when the cache holds no entries.
+    pub fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+
+    /// Returns the total number of individual flashblocks cached across all
+    /// block numbers.
+    pub fn total_flashblocks(&self) -> usize {
+        self.entries.values().map(|by_index| by_index.len()).sum()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloy_rpc_types_engine::PayloadId;
+    use base_primitives::{ExecutionPayloadFlashblockDeltaV1, Metadata};
+
+    use super::*;
+
+    fn make_flashblock(block_number: u64, index: u64) -> Flashblock {
+        Flashblock {
+            payload_id: PayloadId::default(),
+            index,
+            base: None,
+            diff: ExecutionPayloadFlashblockDeltaV1::default(),
+            metadata: Metadata { block_number },
+        }
+    }
+
+    #[test]
+    fn insert_and_drain() {
+        let mut cache = FlashblockCache::new(10);
+
+        assert!(cache.insert(make_flashblock(11, 1)));
+        assert!(cache.insert(make_flashblock(11, 0)));
+        assert_eq!(cache.len(), 1);
+        assert_eq!(cache.total_flashblocks(), 2);
+
+        let drained = cache.drain(11);
+        assert_eq!(drained.len(), 2);
+        // Should be sorted by index
+        assert_eq!(drained[0].index, 0);
+        assert_eq!(drained[1].index, 1);
+        assert!(cache.is_empty());
+    }
+
+    #[test]
+    fn drain_empty() {
+        let mut cache = FlashblockCache::new(0);
+        let drained = cache.drain(42);
+        assert!(drained.is_empty());
+    }
+
+    #[test]
+    fn rejects_beyond_cache_limit() {
+        let mut cache = FlashblockCache::new(10);
+
+        // Block 16 is the last cacheable block (10 + 5 + 1)
+        assert!(cache.insert(make_flashblock(16, 0)));
+        // Block 17 exceeds the limit
+        assert!(!cache.insert(make_flashblock(17, 0)));
+        assert_eq!(cache.len(), 1);
+    }
+
+    #[test]
+    fn update_canonical_evicts_old_entries() {
+        let mut cache = FlashblockCache::new(10);
+
+        assert!(cache.insert(make_flashblock(11, 0)));
+        assert!(cache.insert(make_flashblock(12, 0)));
+        assert!(cache.insert(make_flashblock(13, 0)));
+        assert_eq!(cache.len(), 3);
+
+        // Advancing canonical to 12 should evict blocks 11 and 12
+        cache.update_canonical(12);
+        assert_eq!(cache.len(), 1);
+        assert!(cache.drain(11).is_empty());
+        assert!(cache.drain(12).is_empty());
+        assert_eq!(cache.drain(13).len(), 1);
+    }
+
+    #[test]
+    fn not_cacheable_without_canonical() {
+        let mut cache = FlashblockCache { entries: HashMap::new(), latest_canonical: None };
+        assert!(!cache.is_cacheable(1));
+        assert!(!cache.insert(make_flashblock(1, 0)));
+    }
+
+    #[test]
+    fn duplicate_index_keeps_latest() {
+        let mut cache = FlashblockCache::new(10);
+
+        let mut fb_old = make_flashblock(11, 0);
+        fb_old.diff.state_root = alloy_primitives::B256::ZERO;
+        let mut fb_new = make_flashblock(11, 0);
+        fb_new.diff.state_root = alloy_primitives::B256::with_last_byte(1);
+
+        assert!(cache.insert(fb_old));
+        assert!(cache.insert(fb_new.clone()));
+        assert_eq!(cache.total_flashblocks(), 1);
+
+        let drained = cache.drain(11);
+        assert_eq!(drained.len(), 1);
+        assert_eq!(drained[0].diff.state_root, fb_new.diff.state_root);
+    }
+
+    #[test]
+    fn multiple_flashblocks_same_block() {
+        let mut cache = FlashblockCache::new(10);
+
+        assert!(cache.insert(make_flashblock(11, 0)));
+        assert!(cache.insert(make_flashblock(11, 1)));
+        assert!(cache.insert(make_flashblock(11, 2)));
+        assert_eq!(cache.total_flashblocks(), 3);
+        assert_eq!(cache.len(), 1);
+
+        let drained = cache.drain(11);
+        assert_eq!(drained.len(), 3);
+        assert_eq!(drained[0].index, 0);
+        assert_eq!(drained[1].index, 1);
+        assert_eq!(drained[2].index, 2);
+    }
+}

--- a/crates/client/flashblocks/src/cache.rs
+++ b/crates/client/flashblocks/src/cache.rs
@@ -55,6 +55,8 @@ impl FlashblockCache {
         if !self.is_cacheable(block_number) {
             return false;
         }
+        let min_block_number_to_retain = block_number.saturating_sub(MAX_CACHE_AHEAD_BLOCKS);
+        self.entries.retain(|&bn, _| bn > min_block_number_to_retain);
         self.entries.entry(block_number).or_default().insert(flashblock.index, flashblock);
         true
     }

--- a/crates/client/flashblocks/src/error.rs
+++ b/crates/client/flashblocks/src/error.rs
@@ -126,6 +126,10 @@ pub enum StateProcessorError {
     /// Pending blocks build errors.
     #[error(transparent)]
     Build(#[from] BuildError),
+
+    /// Missing first flashblock, so this one can't be processed.
+    #[error("missing first flashblock: cannot build pending blocks without first flashblock")]
+    MissingFirstFlashblock,
 }
 
 impl From<RecoveryError> for StateProcessorError {

--- a/crates/client/flashblocks/src/lib.rs
+++ b/crates/client/flashblocks/src/lib.rs
@@ -9,6 +9,9 @@ extern crate tracing;
 mod block_assembler;
 pub use block_assembler::{AssembledBlock, BlockAssembler};
 
+mod cache;
+pub use cache::FlashblockCache;
+
 mod error;
 pub use error::{
     BuildError, ExecutionError, ProtocolError, ProviderError, Result, StateProcessorError,

--- a/crates/client/flashblocks/src/processor.rs
+++ b/crates/client/flashblocks/src/processor.rs
@@ -26,8 +26,8 @@ use revm_database::states::bundle_state::BundleRetention;
 use tokio::sync::{Mutex, broadcast::Sender, mpsc::UnboundedReceiver};
 
 use crate::{
-    BlockAssembler, ExecutionError, Metrics, PendingBlocks, PendingBlocksBuilder,
-    PendingStateBuilder, ProviderError, Result,
+    BlockAssembler, ExecutionError, FlashblockCache, Metrics, PendingBlocks, PendingBlocksBuilder,
+    PendingStateBuilder, ProviderError, Result, StateProcessorError,
     validation::{
         CanonicalBlockReconciler, FlashblockSequenceValidator, ReconciliationStrategy,
         ReorgDetector, SequenceValidationResult,
@@ -52,6 +52,7 @@ pub struct StateProcessor<Client> {
     metrics: Metrics,
     client: Client,
     sender: Sender<Arc<PendingBlocks>>,
+    cache: Arc<Mutex<FlashblockCache>>,
 }
 
 impl<Client> StateProcessor<Client>
@@ -70,7 +71,19 @@ where
         rx: Arc<Mutex<UnboundedReceiver<StateUpdate>>>,
         sender: Sender<Arc<PendingBlocks>>,
     ) -> Self {
-        Self { metrics: Metrics::default(), pending_blocks, client, max_depth, rx, sender }
+        let cache = client
+            .best_block_number()
+            .map_or_else(|_| FlashblockCache::new(0), FlashblockCache::new);
+
+        Self {
+            metrics: Metrics::default(),
+            pending_blocks,
+            client,
+            max_depth,
+            rx,
+            sender,
+            cache: Arc::new(Mutex::new(cache)),
+        }
     }
 
     /// Processes updates from the queue until the channel closes.
@@ -83,6 +96,23 @@ where
                     match self.process_canonical_block(prev_pending_blocks, &block) {
                         Ok(new_pending_blocks) => {
                             self.pending_blocks.swap(new_pending_blocks);
+
+                            let mut cache = self.cache.lock().await;
+                            cache.update_canonical(block.number);
+                            let cached = cache.drain(block.number + 1);
+                            drop(cache);
+
+                            if !cached.is_empty() {
+                                debug!(
+                                    message = "replaying cached flashblocks after canonical block",
+                                    canonical_block = block.number,
+                                    cached_count = cached.len(),
+                                );
+                                for flashblock in cached {
+                                    let fb_prev = self.pending_blocks.load_full();
+                                    self.apply_flashblock(fb_prev, flashblock).await;
+                                }
+                            }
                         }
                         Err(e) => {
                             error!(message = "could not process canonical block", error = %e);
@@ -90,27 +120,62 @@ where
                     }
                 }
                 StateUpdate::Flashblock(flashblock) => {
-                    let start_time = Instant::now();
                     debug!(
                         message = "processing flashblock",
                         block_number = flashblock.metadata.block_number,
                         flashblock_index = flashblock.index
                     );
-                    match self.process_flashblock(prev_pending_blocks, flashblock) {
-                        Ok(new_pending_blocks) => {
-                            if new_pending_blocks.is_some() {
-                                _ = self.sender.send(new_pending_blocks.clone().unwrap())
-                            }
+                    self.apply_flashblock(prev_pending_blocks, flashblock).await;
+                }
+            }
+        }
+    }
 
-                            self.pending_blocks.swap(new_pending_blocks);
-                            self.metrics.block_processing_duration.record(start_time.elapsed());
-                        }
-                        Err(e) => {
-                            error!(message = "could not process Flashblock", error = %e);
-                            self.metrics.block_processing_error.increment(1);
+    async fn apply_flashblock(
+        &self,
+        prev_pending_blocks: Option<Arc<PendingBlocks>>,
+        flashblock: Flashblock,
+    ) {
+        let start_time = Instant::now();
+        match self.process_flashblock(prev_pending_blocks, &flashblock) {
+            Ok(new_pending_blocks) => {
+                if let Some(ref pb) = new_pending_blocks {
+                    _ = self.sender.send(Arc::clone(pb));
+                }
+                self.pending_blocks.swap(new_pending_blocks);
+                self.metrics.block_processing_duration.record(start_time.elapsed());
+            }
+            Err(e) => {
+                match e {
+                    StateProcessorError::Provider(ProviderError::MissingCanonicalHeader {
+                        ..
+                    }) => {
+                        if self.cache.lock().await.insert(flashblock) {
+                            debug!(message = "cached flashblock pending canonical block", error = %e);
+                            return;
                         }
                     }
+                    StateProcessorError::MissingFirstFlashblock => {
+                        let mut cache = self.cache.lock().await;
+                        // this error should only occur for non-zero index flashblocks, but check here for index safety
+                        if flashblock.index > 0
+                            && cache.has_flashblock(
+                                flashblock.metadata.block_number,
+                                flashblock.index - 1,
+                            )
+                            && cache.insert(flashblock)
+                        {
+                            return;
+                        }
+                        info!("waiting for first Flashblock");
+                        // we should ignore this error since it doesn't necessarily indicate a problem
+                        return;
+                    }
+                    _ => {}
                 }
+
+                error!(message = "could not process Flashblock", error = %e);
+                self.metrics.block_processing_error.increment(1);
             }
         }
     }
@@ -210,16 +275,16 @@ where
     fn process_flashblock(
         &self,
         prev_pending_blocks: Option<Arc<PendingBlocks>>,
-        flashblock: Flashblock,
+        flashblock: &Flashblock,
     ) -> Result<Option<Arc<PendingBlocks>>> {
         let pending_blocks = match &prev_pending_blocks {
             Some(pb) => pb,
             None => {
                 if flashblock.index == 0 {
-                    return self.build_pending_state(None, &[flashblock]);
+                    return self.build_pending_state(None, std::slice::from_ref(flashblock));
                 }
-                info!(message = "waiting for first Flashblock");
-                return Ok(None);
+
+                return Err(StateProcessorError::MissingFirstFlashblock);
             }
         };
 
@@ -236,7 +301,7 @@ where
                 // We have received the next flashblock for the current block
                 // or the first flashblock for the next block
                 let mut flashblocks = pending_blocks.get_flashblocks();
-                flashblocks.push(flashblock);
+                flashblocks.push(flashblock.clone());
                 self.build_pending_state(prev_pending_blocks, &flashblocks)
             }
             SequenceValidationResult::Duplicate => {


### PR DESCRIPTION
When the first flashblock for a new block arrives before its parent canonical block exists, the processor now caches it in a FlashblockCache instead of returning MissingCanonicalHeader. When the canonical block is later received and processed, any cached flashblocks for the next block are drained and replayed automatically.

The cache limits how far ahead flashblocks can be (MAX_CACHE_AHEAD_BLOCKS = 5) so that nodes syncing far behind tip still reject flashblocks they cannot process.