### PR TITLE
feat(builder): add configurable flashblock publish delay

### DIFF
--- a/bin/builder/src/cli.rs
+++ b/bin/builder/src/cli.rs
@@ -58,6 +58,18 @@ pub struct FlashblocksArgs {
         env = "FLASHBLOCKS_COMPUTE_STATE_ROOT_ON_FINALIZE"
     )]
     pub flashblocks_compute_state_root_on_finalize: bool,
+
+    /// How long to buffer built flashblocks before publishing them in milliseconds.
+    ///
+    /// Gives downstream nodes time to canonicalize the parent block before
+    /// receiving flashblocks for the next block. Flashblocks are still built on
+    /// the normal schedule; only publication is deferred.
+    #[arg(
+        long = "flashblocks.publish-delay",
+        default_value = "0",
+        env = "FLASHBLOCKS_PUBLISH_DELAY"
+    )]
+    pub flashblocks_publish_delay: u64,
 }
 
 impl Default for FlashblocksArgs {
@@ -70,6 +82,7 @@ impl Default for FlashblocksArgs {
             flashblocks_leeway_time: 75,
             flashblocks_disable_state_root: false,
             flashblocks_compute_state_root_on_finalize: false,
+            flashblocks_publish_delay: 0,
         }
     }
 }
@@ -204,6 +217,8 @@ impl TryFrom<&Args> for FlashblocksConfig {
 
         let leeway_time = Duration::from_millis(args.flashblocks.flashblocks_leeway_time);
 
+        let publish_delay = Duration::from_millis(args.flashblocks.flashblocks_publish_delay);
+
         Ok(Self {
             ws_addr,
             interval,
@@ -213,6 +228,7 @@ impl TryFrom<&Args> for FlashblocksConfig {
             compute_state_root_on_finalize: args
                 .flashblocks
                 .flashblocks_compute_state_root_on_finalize,
+            publish_delay,
         })
     }
 }

--- a/crates/builder/core/src/flashblocks/config.rs
+++ b/crates/builder/core/src/flashblocks/config.rs
@@ -40,6 +40,13 @@ pub struct FlashblocksConfig {
     /// When enabled, flashblocks are built without state root, but the final payload
     /// returned by `get_payload` will have the state root computed.
     pub compute_state_root_on_finalize: bool,
+
+    /// How long to buffer built flashblocks before publishing them via WebSocket.
+    ///
+    /// This gives downstream nodes time to canonicalize the parent block before
+    /// receiving flashblocks for the next block. Flashblocks are still built on
+    /// the normal schedule; only publication is deferred.
+    pub publish_delay: Duration,
 }
 
 impl Default for FlashblocksConfig {
@@ -51,6 +58,7 @@ impl Default for FlashblocksConfig {
             fixed: false,
             disable_state_root: false,
             compute_state_root_on_finalize: false,
+            publish_delay: Duration::ZERO,
         }
     }
 }
@@ -66,6 +74,7 @@ impl FlashblocksConfig {
             fixed: false,
             disable_state_root: false,
             compute_state_root_on_finalize: false,
+            publish_delay: Duration::ZERO,
         }
     }
 
@@ -96,6 +105,12 @@ impl FlashblocksConfig {
     #[must_use]
     pub const fn with_compute_state_root_on_finalize(mut self, compute: bool) -> Self {
         self.compute_state_root_on_finalize = compute;
+        self
+    }
+
+    #[must_use]
+    pub const fn with_publish_delay_ms(mut self, ms: u64) -> Self {
+        self.publish_delay = Duration::from_millis(ms);
         self
     }
 

--- a/crates/builder/core/src/flashblocks/payload.rs
+++ b/crates/builder/core/src/flashblocks/payload.rs
@@ -290,11 +290,18 @@ where
             payload_id = fb_payload.payload_id.to_string(),
         );
 
+        let publish_after = tokio::time::Instant::now() + self.config.flashblocks.publish_delay;
+        let mut publish_buffer: Vec<FlashblocksPayloadV1> = Vec::new();
+
         // not emitting flashblock if no_tx_pool in FCU, it's just syncing
         if !ctx.attributes().no_tx_pool {
-            let flashblock_byte_size =
-                self.ws_pub.publish(&fb_payload).map_err(PayloadBuilderError::other)?;
-            ctx.metrics.flashblock_byte_size_histogram.record(flashblock_byte_size as f64);
+            if tokio::time::Instant::now() < publish_after {
+                publish_buffer.push(fb_payload);
+            } else {
+                let flashblock_byte_size =
+                    self.ws_pub.publish(&fb_payload).map_err(PayloadBuilderError::other)?;
+                ctx.metrics.flashblock_byte_size_histogram.record(flashblock_byte_size as f64);
+            }
         }
 
         if ctx.attributes().no_tx_pool {
@@ -440,6 +447,8 @@ where
                     &best_payload,
                     &publish_guard,
                     &fb_span,
+                    &mut publish_buffer,
+                    publish_after,
                 )
                 .await
             {
@@ -469,22 +478,36 @@ where
                 }
             };
 
-            tokio::select! {
-                Some(fb_cancel) = rx.recv() => {
-                    ctx = ctx.with_cancel(fb_cancel).with_extra_ctx(next_flashblocks_ctx);
-                },
-                _ = block_cancel.cancelled() => {
-                    self.record_flashblocks_metrics(
-                        &ctx,
-                        &info,
-                        flashblocks_per_block,
-                        &span,
-                        "Payload building complete, channel closed or job cancelled",
-                    );
-                    if compute_state_root_on_finalize {
-                        self.finalize_payload(&mut state, &ctx, &mut info, &finalized_cell)?;
+            loop {
+                tokio::select! {
+                    Some(fb_cancel) = rx.recv() => {
+                        ctx = ctx.with_cancel(fb_cancel).with_extra_ctx(next_flashblocks_ctx);
+                        break;
+                    },
+                    _ = block_cancel.cancelled() => {
+                        self.record_flashblocks_metrics(
+                            &ctx,
+                            &info,
+                            flashblocks_per_block,
+                            &span,
+                            "Payload building complete, channel closed or job cancelled",
+                        );
+                        if compute_state_root_on_finalize {
+                            self.finalize_payload(&mut state, &ctx, &mut info, &finalized_cell)?;
+                        }
+                        return Ok(());
                     }
-                    return Ok(());
+                    _ = tokio::time::sleep_until(publish_after), if !publish_buffer.is_empty() => {
+                        let _guard = publish_guard.lock();
+                        if !block_cancel.is_cancelled() {
+                            for buffered in publish_buffer.drain(..) {
+                                let size = self.ws_pub
+                                    .publish(&buffered)
+                                    .map_err(PayloadBuilderError::other)?;
+                                ctx.metrics.flashblock_byte_size_histogram.record(size as f64);
+                            }
+                        }
+                    }
                 }
             }
         }
@@ -504,6 +527,8 @@ where
         best_payload: &BlockCell<OpBuiltPayload>,
         publish_guard: &parking_lot::Mutex<()>,
         span: &tracing::Span,
+        publish_buffer: &mut Vec<FlashblocksPayloadV1>,
+        publish_after: tokio::time::Instant,
     ) -> eyre::Result<Option<FlashblocksExtraCtx>> {
         let flashblock_index = ctx.flashblock_index();
         let target_gas_for_batch = ctx.extra.target_gas_for_batch;
@@ -598,7 +623,7 @@ where
                 fb_payload.index = flashblock_index;
                 fb_payload.base = None;
 
-                // Synchronized check + publish.
+                // Synchronized check + publish (or buffer).
                 // The publish_guard mutex ensures that if get_payload (resolve_kind) is called,
                 // it will either:
                 // 1. Cancel before we acquire the lock → we see cancelled and return early
@@ -607,7 +632,16 @@ where
                     let _guard = publish_guard.lock();
                     if block_cancel.is_cancelled() {
                         (true, 0)
+                    } else if tokio::time::Instant::now() < publish_after {
+                        publish_buffer.push(fb_payload);
+                        (false, 0)
                     } else {
+                        for buffered in publish_buffer.drain(..) {
+                            let size = self.ws_pub
+                                .publish(&buffered)
+                                .wrap_err("failed to publish buffered flashblock via websocket")?;
+                            ctx.metrics.flashblock_byte_size_histogram.record(size as f64);
+                        }
                         let size = self
                             .ws_pub
                             .publish(&fb_payload)


### PR DESCRIPTION
## Summary

- Adds `--flashblocks.publish-delay` (default 0ms) to buffer built flashblocks before WebSocket publication
- Gives downstream nodes time to canonicalize the parent block before receiving flashblocks for the next block, avoiding `MissingCanonicalHeader` errors after node restarts
- Building proceeds on the normal schedule with no wasted compute — only publication is deferred
- Buffer drains exactly when the delay expires via a dedicated `sleep_until` branch in the `select!` loop, or when the next flashblock is built after the deadline
- Buffered flashblocks are dropped if the block is cancelled by `get_payload`, preserving existing `publish_guard` synchronization
- Zero overhead when delay is 0 (default): `publish_after` is in the past so the buffer path is never taken

## Context

Mainnet reth nodes receive flashblocks for block N 31–276ms (median 136ms) before block N-1 is canonicalized via the engine API, affecting 99.6% of blocks. In steady state this is handled gracefully, but after a restart or snapshot restore the first flashblocks fail with `MissingCanonicalHeader`. Setting `--flashblocks.publish-delay 150` covers the median gap.