### PR TITLE
feat(txpool): add consumer task for mempool→builder tx propagation

### DIFF
--- a/crates/txpool/Cargo.toml
+++ b/crates/txpool/Cargo.toml
@@ -38,10 +38,10 @@ base-execution-primitives.workspace = true
 # misc
 c-kzg.workspace = true
 metrics.workspace = true
-dashmap.workspace = true
 tracing.workspace = true
 derive_more.workspace = true
 parking_lot.workspace = true
+tokio-util.workspace = true
 tokio = { workspace = true, features = ["sync", "rt"] }
 
 [dev-dependencies]

--- a/crates/txpool/Cargo.toml
+++ b/crates/txpool/Cargo.toml
@@ -18,10 +18,11 @@ alloy-eips.workspace = true
 alloy-primitives.workspace = true
 
 # reth
-reth-chainspec.workspace = true
 reth-evm.workspace = true
-reth-primitives-traits.workspace = true
+reth-metrics.workspace = true
+reth-chainspec.workspace = true
 reth-storage-api.workspace = true
+reth-primitives-traits.workspace = true
 reth-transaction-pool.workspace = true
 
 # revm
@@ -36,12 +37,15 @@ base-execution-primitives.workspace = true
 
 # misc
 c-kzg.workspace = true
+metrics.workspace = true
+dashmap.workspace = true
 tracing.workspace = true
 derive_more.workspace = true
 parking_lot.workspace = true
+tokio = { workspace = true, features = ["sync", "rt"] }
 
 [dev-dependencies]
-tokio = { workspace = true, features = ["time"] }
+tokio = { workspace = true, features = ["time", "rt-multi-thread", "macros"] }
 alloy-eips.workspace = true
 base-test-utils.workspace = true
 base-execution-chainspec.workspace = true

--- a/crates/txpool/Cargo.toml
+++ b/crates/txpool/Cargo.toml
@@ -19,6 +19,7 @@ alloy-primitives.workspace = true
 
 # reth
 reth-evm.workspace = true
+reth-tasks.workspace = true
 reth-metrics.workspace = true
 reth-chainspec.workspace = true
 reth-storage-api.workspace = true

--- a/crates/txpool/PROPAGATION_PIPELINE.md
+++ b/crates/txpool/PROPAGATION_PIPELINE.md
@@ -49,7 +49,7 @@ Background task on a dedicated blocking thread that continuously drains
 |---------|---------|-------------|
 | `resend_after` | 4s (2 blocks) | Skip txs sent within this window |
 | `channel_capacity` | 10,000 | Bounded channel size |
-| `poll_interval` | 1ms | Sleep when iterator empty |
+| `poll_interval` | 10ms | Sleep when no new transactions sent |
 
 ### Metrics
 

--- a/crates/txpool/PROPAGATION_PIPELINE.md
+++ b/crates/txpool/PROPAGATION_PIPELINE.md
@@ -1,0 +1,218 @@
+# Mempool Propagation Pipeline
+
+Multi-PR implementation plan for forwarding transactions from mempool nodes
+to builder nodes via a custom RPC, replacing P2P propagation.
+
+## Architecture
+
+```
+┌──────────────────┐   broadcast   ┌──────────────────┐     RPC      ┌──────────────────┐
+│   Consumer       │──────────────▶│   Forwarder (×N) │─────────────▶│   Builder        │
+│   (PR 1)         │   channel     │   (PR 2)         │   batched    │   (PR 3)         │
+└──────────────────┘               └──────────────────┘              └──────────────────┘
+        │                                   │                                │
+        │ reads from                        │ batches txs                    │ receives via
+        │ best_transactions()               │ sends via RPC                  │ base_insertValidatedTransactions
+        ▼                                   ▼                                ▼
+┌──────────────────┐               ┌──────────────────┐              ┌──────────────────┐
+│ Transaction Pool │               │ Builder RPC URL  │              │ Builder Mempool  │
+│ (timestamp order)│               │                  │              │                  │
+└──────────────────┘               └──────────────────┘              └──────────────────┘
+```
+
+Mempool nodes use `TimestampOrdering` (FIFO) for the consumer iterator.
+Builder nodes use `CoinbaseTipOrdering` (priority fee) for block building.
+
+---
+
+## PR 1: Consumer Task ✅
+
+**Crate:** `crates/txpool/`
+**Directory:** `src/consumer/`
+
+Background task on a dedicated blocking thread that continuously drains
+`best_transactions()`, validates/deduplicates, and broadcasts to subscribers.
+
+### Files
+
+| File | Purpose |
+|------|---------|
+| `consumer/mod.rs` | Module root, `run_consumer()` entry point, `ConsumerHandle` (broadcast sender) |
+| `consumer/config.rs` | `ConsumerConfig` with `resend_after`, `channel_capacity`, `poll_interval` |
+| `consumer/metrics.rs` | `ConsumerMetrics` — Prometheus counters/gauge |
+| `consumer/validator.rs` | `RecentlySent` hash-based dedup with periodic pruning |
+| `consumer/task.rs` | `Consumer<P>` struct and blocking `run()` loop |
+
+### Configuration Defaults
+
+| Setting | Default | Description |
+|---------|---------|-------------|
+| `resend_after` | 4s (2 blocks) | Skip txs sent within this window |
+| `channel_capacity` | 10,000 | Bounded channel size |
+| `poll_interval` | 1ms | Sleep when iterator empty |
+
+### Metrics
+
+| Metric | Type | Description |
+|--------|------|-------------|
+| `txpool.consumer.txs_read` | Counter | Total txs read from iterator |
+| `txpool.consumer.txs_sent` | Counter | Total txs broadcast |
+| `txpool.consumer.txs_ignored` | Counter | Total txs skipped (validator) |
+| `txpool.consumer.dedup_cache_size` | Gauge | Current dedup cache entries |
+
+---
+
+## PR 2: Forwarder Task
+
+**Crate:** `crates/txpool/`
+**Directory:** `src/forwarder/`
+
+Subscribes to the consumer's broadcast channel, batches transactions, and
+sends to a builder node via a custom RPC endpoint. One forwarder is spawned
+per builder node.
+
+### Planned Types
+
+| Type | Description |
+|------|-------------|
+| `ForwarderConfig` | `builder_urls: Vec<String>`, `batch_size`, `batch_timeout`, `max_retries`, `retry_backoff` |
+| `ForwarderMetrics` | `batches_sent`, `txs_forwarded`, `rpc_errors`, `rpc_latency` |
+| `ForwarderHandle` | Shutdown handle + stats |
+| `Forwarder` | Main struct — async task consuming from `broadcast::Receiver` |
+| `run_forwarder()` | Entry point, calls `consumer_handle.sender.subscribe()` |
+
+### Algorithm
+
+```
+let mut receiver = consumer_handle.sender.subscribe();
+loop {
+    batch = collect_batch(&mut receiver, batch_size, batch_timeout).await;
+    if batch.is_empty() { continue; }
+    send_batch_rpc(&client, builder_url, &batch).await;  // with retries
+}
+```
+
+### Configuration Defaults
+
+| Setting | Default | Description |
+|---------|---------|-------------|
+| `builder_urls` | Required | Builder RPC endpoint URLs (one forwarder per URL) |
+| `batch_size` | 100 | Max transactions per batch |
+| `batch_timeout` | 50ms | Max wait time for batch fill |
+| `max_retries` | 3 | Retry attempts per batch |
+| `retry_backoff` | 100ms | Initial retry delay |
+
+### Dependencies
+
+- PR 1 (consumer broadcast sender)
+- HTTP/RPC client (reqwest or jsonrpsee)
+
+---
+
+## PR 3: Builder RPC Endpoint
+
+**Crate:** `crates/builder/core/` or new `crates/builder/rpc/`
+
+RPC endpoint on builder nodes to receive forwarded transactions.
+
+### RPC Method
+
+```rust
+#[rpc(server, namespace = "base")]
+pub trait BaseTxApi {
+    #[method(name = "insertValidatedTransactions")]
+    async fn insert_validated_transactions(
+        &self,
+        txs: Vec<Bytes>,
+    ) -> RpcResult<ReceiveTxsResponse>;
+}
+```
+
+### Response
+
+```rust
+pub struct ReceiveTxsResponse {
+    pub accepted: u64,
+    pub rejected: u64,
+    pub errors: Vec<TxRejection>,
+}
+```
+
+### Dependencies
+
+- None (can be implemented in parallel with PRs 1-2)
+
+---
+
+## PR 4: Node Integration
+
+**Crate:** New `crates/client/tx-forwarding/` extension crate
+
+Wires consumer + forwarder into the node using the `BaseNodeExtension` pattern.
+
+### CLI Flags
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--enable-tx-forwarding` | bool | false | Enable the forwarding pipeline |
+| `--builder-rpc-urls` | Vec\<String\> | Required | Builder RPC endpoints (one forwarder per URL) |
+| `--tx-forwarding-resend-after-ms` | u64 | 4000 | Resend-after window in ms (default: 2 blocks) |
+| `--tx-forwarding-batch-size` | usize | 100 | Forwarder batch size |
+| `--tx-forwarding-batch-timeout-ms` | u64 | 50 | Batch timeout in ms |
+
+### Extension Pattern
+
+```rust
+impl BaseNodeExtension for TxForwardingExtension {
+    fn apply(self: Box<Self>, hooks: NodeHooks) -> NodeHooks {
+        hooks.add_rpc_module(move |ctx| {
+            let pool = ctx.pool().clone();
+            let handle = run_consumer(pool, self.consumer_config);
+            // One forwarder per builder URL, each subscribing to the broadcast
+            for url in &self.forwarder_config.builder_urls {
+                let rx = handle.sender.subscribe();
+                run_forwarder(rx, url.clone(), &self.forwarder_config);
+            }
+            Ok(())
+        })
+    }
+}
+```
+
+### Registration
+
+```rust
+// bin/node/src/main.rs
+if args.enable_tx_forwarding {
+    runner.install_ext::<TxForwardingExtension>(config);
+}
+```
+
+### Dependencies
+
+- PR 1 (consumer)
+- PR 2 (forwarder)
+- PR 3 (builder RPC)
+
+---
+
+## Implementation Order
+
+```
+PR 1: Consumer ──────┐
+                      ├──▶ PR 2: Forwarder ──┐
+PR 3: Builder RPC ───┘                       ├──▶ PR 4: Node Integration
+                      ────────────────────────┘
+```
+
+PRs 1 and 3 can be developed in parallel. PR 2 depends on PR 1.
+PR 4 depends on all three.
+
+## Testing Strategy
+
+| PR | Tests |
+|----|-------|
+| PR 1 | Unit tests for `RecentlySent`, `ConsumerConfig`. Integration with mock pool. |
+| PR 2 | Unit tests for batching. Integration with mock HTTP server. |
+| PR 3 | Unit tests for tx decoding. Integration for RPC endpoint. |
+| PR 4 | End-to-end: submit tx → consumer → forwarder → builder. |

--- a/crates/txpool/README.md
+++ b/crates/txpool/README.md
@@ -1,3 +1,3 @@
-# `base-execution-txpool`
+# `base-txpool`
 
-Transaction pool for Base/OP Stack.
+Transaction pool for Base

--- a/crates/txpool/src/consumer/config.rs
+++ b/crates/txpool/src/consumer/config.rs
@@ -1,0 +1,77 @@
+use std::time::Duration;
+
+/// Configuration for the transaction pool consumer task.
+///
+/// The consumer continuously reads from the pool's `best_transactions()` iterator,
+/// deduplicates transactions, and broadcasts them for downstream forwarding to
+/// builder nodes.
+#[derive(Debug, Clone)]
+pub struct ConsumerConfig {
+    /// Duration after which a previously sent transaction may be re-sent.
+    ///
+    /// Transactions seen within this window are skipped to avoid sending
+    /// duplicates to the forwarder.
+    pub resend_after: Duration,
+
+    /// Bounded channel capacity for outgoing transactions.
+    pub channel_capacity: usize,
+
+    /// Sleep duration when the pool iterator yields no transactions,
+    /// preventing busy-spinning.
+    pub poll_interval: Duration,
+}
+
+impl Default for ConsumerConfig {
+    fn default() -> Self {
+        Self {
+            resend_after: Duration::from_secs(4),
+            channel_capacity: 10_000,
+            poll_interval: Duration::from_millis(1),
+        }
+    }
+}
+
+impl ConsumerConfig {
+    /// Sets the resend-after duration.
+    pub const fn with_resend_after(mut self, duration: Duration) -> Self {
+        self.resend_after = duration;
+        self
+    }
+
+    /// Sets the channel capacity.
+    pub const fn with_channel_capacity(mut self, capacity: usize) -> Self {
+        self.channel_capacity = capacity;
+        self
+    }
+
+    /// Sets the poll interval.
+    pub const fn with_poll_interval(mut self, interval: Duration) -> Self {
+        self.poll_interval = interval;
+        self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn defaults() {
+        let config = ConsumerConfig::default();
+        assert_eq!(config.resend_after, Duration::from_secs(4));
+        assert_eq!(config.channel_capacity, 10_000);
+        assert_eq!(config.poll_interval, Duration::from_millis(1));
+    }
+
+    #[test]
+    fn builder_methods() {
+        let config = ConsumerConfig::default()
+            .with_resend_after(Duration::from_secs(10))
+            .with_channel_capacity(5_000)
+            .with_poll_interval(Duration::from_millis(5));
+
+        assert_eq!(config.resend_after, Duration::from_secs(10));
+        assert_eq!(config.channel_capacity, 5_000);
+        assert_eq!(config.poll_interval, Duration::from_millis(5));
+    }
+}

--- a/crates/txpool/src/consumer/config.rs
+++ b/crates/txpool/src/consumer/config.rs
@@ -26,7 +26,7 @@ impl Default for ConsumerConfig {
         Self {
             resend_after: Duration::from_secs(4),
             channel_capacity: 10_000,
-            poll_interval: Duration::from_millis(1),
+            poll_interval: Duration::from_millis(10),
         }
     }
 }
@@ -60,7 +60,7 @@ mod tests {
         let config = ConsumerConfig::default();
         assert_eq!(config.resend_after, Duration::from_secs(4));
         assert_eq!(config.channel_capacity, 10_000);
-        assert_eq!(config.poll_interval, Duration::from_millis(1));
+        assert_eq!(config.poll_interval, Duration::from_millis(10));
     }
 
     #[test]

--- a/crates/txpool/src/consumer/metrics.rs
+++ b/crates/txpool/src/consumer/metrics.rs
@@ -7,9 +7,11 @@ use reth_metrics::{
 #[derive(Metrics, Clone)]
 #[metrics(scope = "txpool.consumer")]
 pub struct ConsumerMetrics {
+    /// Total consumer loop iterations.
+    pub iterations: Counter,
     /// Total transactions read from the pool iterator.
     pub txs_read: Counter,
-    /// Total transactions sent to the channel after deduplication.
+    /// Total transactions broadcast after deduplication.
     pub txs_sent: Counter,
     /// Total transactions skipped by the validator.
     pub txs_ignored: Counter,

--- a/crates/txpool/src/consumer/metrics.rs
+++ b/crates/txpool/src/consumer/metrics.rs
@@ -1,0 +1,18 @@
+use reth_metrics::{
+    Metrics,
+    metrics::{Counter, Gauge},
+};
+
+/// Prometheus metrics for the transaction consumer.
+#[derive(Metrics, Clone)]
+#[metrics(scope = "txpool.consumer")]
+pub struct ConsumerMetrics {
+    /// Total transactions read from the pool iterator.
+    pub txs_read: Counter,
+    /// Total transactions sent to the channel after deduplication.
+    pub txs_sent: Counter,
+    /// Total transactions skipped by the validator.
+    pub txs_ignored: Counter,
+    /// Current number of entries in the dedup cache.
+    pub dedup_cache_size: Gauge,
+}

--- a/crates/txpool/src/consumer/mod.rs
+++ b/crates/txpool/src/consumer/mod.rs
@@ -1,3 +1,10 @@
+use std::sync::Arc;
+
+use reth_transaction_pool::{PoolTransaction, TransactionPool, ValidPoolTransaction};
+use tokio::{sync::broadcast, task::JoinHandle};
+use tokio_util::sync::CancellationToken;
+use tracing::info;
+
 mod config;
 pub use config::ConsumerConfig;
 
@@ -8,32 +15,24 @@ mod validator;
 pub use validator::RecentlySent;
 
 mod task;
-use std::sync::Arc;
-
-use reth_transaction_pool::{PoolTransaction, TransactionPool, ValidPoolTransaction};
 pub use task::Consumer;
-use tokio::sync::broadcast;
 
 /// Handle returned by [`ConsumerHandle::spawn`].
 ///
 /// Holds the broadcast sender so that downstream forwarders (one per builder)
 /// can each call [`.subscribe()`](broadcast::Sender::subscribe) to receive
-/// every deduplicated transaction independently. Slow receivers that fall
-/// behind will receive [`broadcast::error::RecvError::Lagged`], naturally
-/// shedding stale transactions.
-#[derive(Debug)]
+/// every deduplicated transaction independently. Cancels the background
+/// consumer on drop.
 pub struct ConsumerHandle<T: PoolTransaction> {
     /// Broadcast sender — call `.subscribe()` to create a new receiver.
     pub sender: broadcast::Sender<Arc<ValidPoolTransaction<T>>>,
+    cancel: CancellationToken,
+    _handle: JoinHandle<()>,
 }
 
 impl<T: PoolTransaction> ConsumerHandle<T> {
     /// Spawns the consumer on a dedicated blocking thread and returns a
     /// handle for subscribing forwarders.
-    ///
-    /// The consumer continuously refreshes the pool's `best_transactions()`
-    /// iterator, deduplicates by hash, and broadcasts transactions. It shuts
-    /// down when all receivers are dropped.
     pub fn spawn<P>(pool: P, config: ConsumerConfig) -> Self
     where
         P: TransactionPool<Transaction = T> + Send + 'static,
@@ -41,12 +40,28 @@ impl<T: PoolTransaction> ConsumerHandle<T> {
         let (sender, _) = broadcast::channel(config.channel_capacity);
         let broadcast_sender = sender.clone();
         let metrics = ConsumerMetrics::default();
-        let consumer = Consumer::new(pool, config, broadcast_sender, metrics);
+        let cancel = CancellationToken::new();
+        let consumer = Consumer::new(pool, config, broadcast_sender, metrics, cancel.child_token());
 
-        tokio::task::spawn_blocking(move || {
+        let handle = tokio::task::spawn_blocking(move || {
             consumer.run();
         });
 
-        Self { sender }
+        Self { sender, cancel, _handle: handle }
+    }
+}
+
+impl<T: PoolTransaction> Drop for ConsumerHandle<T> {
+    fn drop(&mut self) {
+        self.cancel.cancel();
+        info!("consumer handle dropped, cancelling background task");
+    }
+}
+
+impl<T: PoolTransaction> std::fmt::Debug for ConsumerHandle<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ConsumerHandle")
+            .field("cancelled", &self.cancel.is_cancelled())
+            .finish_non_exhaustive()
     }
 }

--- a/crates/txpool/src/consumer/mod.rs
+++ b/crates/txpool/src/consumer/mod.rs
@@ -3,7 +3,6 @@ use std::{sync::Arc, thread};
 use reth_transaction_pool::{PoolTransaction, TransactionPool, ValidPoolTransaction};
 use tokio::sync::broadcast;
 use tokio_util::sync::CancellationToken;
-use tracing::info;
 
 mod config;
 pub use config::ConsumerConfig;

--- a/crates/txpool/src/consumer/mod.rs
+++ b/crates/txpool/src/consumer/mod.rs
@@ -1,7 +1,7 @@
-use std::sync::Arc;
+use std::{sync::Arc, thread};
 
 use reth_transaction_pool::{PoolTransaction, TransactionPool, ValidPoolTransaction};
-use tokio::{sync::broadcast, task::JoinHandle};
+use tokio::sync::broadcast;
 use tokio_util::sync::CancellationToken;
 use tracing::info;
 
@@ -27,12 +27,12 @@ pub struct ConsumerHandle<T: PoolTransaction> {
     /// Broadcast sender — call `.subscribe()` to create a new receiver.
     pub sender: broadcast::Sender<Arc<ValidPoolTransaction<T>>>,
     cancel: CancellationToken,
-    _handle: JoinHandle<()>,
+    _handle: thread::JoinHandle<()>,
 }
 
 impl<T: PoolTransaction> ConsumerHandle<T> {
-    /// Spawns the consumer on a dedicated blocking thread and returns a
-    /// handle for subscribing forwarders.
+    /// Spawns the consumer on a dedicated OS thread and returns a handle for
+    /// subscribing forwarders.
     pub fn spawn<P>(pool: P, config: ConsumerConfig) -> Self
     where
         P: TransactionPool<Transaction = T> + Send + 'static,
@@ -43,9 +43,12 @@ impl<T: PoolTransaction> ConsumerHandle<T> {
         let cancel = CancellationToken::new();
         let consumer = Consumer::new(pool, config, broadcast_sender, metrics, cancel.child_token());
 
-        let handle = tokio::task::spawn_blocking(move || {
-            consumer.run();
-        });
+        let handle = thread::Builder::new()
+            .name("txpool-consumer".into())
+            .spawn(move || {
+                consumer.run();
+            })
+            .expect("failed to spawn txpool-consumer thread");
 
         Self { sender, cancel, _handle: handle }
     }

--- a/crates/txpool/src/consumer/mod.rs
+++ b/crates/txpool/src/consumer/mod.rs
@@ -1,5 +1,6 @@
 use std::{sync::Arc, thread};
 
+use reth_tasks::spawn_os_thread;
 use reth_transaction_pool::{PoolTransaction, TransactionPool, ValidPoolTransaction};
 use tokio::sync::broadcast;
 use tokio_util::sync::CancellationToken;
@@ -42,12 +43,9 @@ impl<T: PoolTransaction> ConsumerHandle<T> {
         let cancel = CancellationToken::new();
         let consumer = Consumer::new(pool, config, broadcast_sender, metrics, cancel.child_token());
 
-        let handle = thread::Builder::new()
-            .name("txpool-consumer".into())
-            .spawn(move || {
-                consumer.run();
-            })
-            .expect("failed to spawn txpool-consumer thread");
+        let handle = spawn_os_thread("txpool-consumer", move || {
+            consumer.run();
+        });
 
         Self { sender, cancel, handle: Some(handle) }
     }

--- a/crates/txpool/src/consumer/mod.rs
+++ b/crates/txpool/src/consumer/mod.rs
@@ -27,7 +27,7 @@ pub struct ConsumerHandle<T: PoolTransaction> {
     /// Broadcast sender — call `.subscribe()` to create a new receiver.
     pub sender: broadcast::Sender<Arc<ValidPoolTransaction<T>>>,
     cancel: CancellationToken,
-    _handle: thread::JoinHandle<()>,
+    handle: Option<thread::JoinHandle<()>>,
 }
 
 impl<T: PoolTransaction> ConsumerHandle<T> {
@@ -50,14 +50,16 @@ impl<T: PoolTransaction> ConsumerHandle<T> {
             })
             .expect("failed to spawn txpool-consumer thread");
 
-        Self { sender, cancel, _handle: handle }
+        Self { sender, cancel, handle: Some(handle) }
     }
 }
 
 impl<T: PoolTransaction> Drop for ConsumerHandle<T> {
     fn drop(&mut self) {
         self.cancel.cancel();
-        info!("consumer handle dropped, cancelling background task");
+        if let Some(handle) = self.handle.take() {
+            let _ = handle.join();
+        }
     }
 }
 

--- a/crates/txpool/src/consumer/mod.rs
+++ b/crates/txpool/src/consumer/mod.rs
@@ -1,0 +1,52 @@
+mod config;
+pub use config::ConsumerConfig;
+
+mod metrics;
+pub use metrics::ConsumerMetrics;
+
+mod validator;
+pub use validator::RecentlySent;
+
+mod task;
+use std::sync::Arc;
+
+use reth_transaction_pool::{PoolTransaction, TransactionPool, ValidPoolTransaction};
+pub use task::Consumer;
+use tokio::sync::broadcast;
+
+/// Handle returned by [`ConsumerHandle::spawn`].
+///
+/// Holds the broadcast sender so that downstream forwarders (one per builder)
+/// can each call [`.subscribe()`](broadcast::Sender::subscribe) to receive
+/// every deduplicated transaction independently. Slow receivers that fall
+/// behind will receive [`broadcast::error::RecvError::Lagged`], naturally
+/// shedding stale transactions.
+#[derive(Debug)]
+pub struct ConsumerHandle<T: PoolTransaction> {
+    /// Broadcast sender — call `.subscribe()` to create a new receiver.
+    pub sender: broadcast::Sender<Arc<ValidPoolTransaction<T>>>,
+}
+
+impl<T: PoolTransaction> ConsumerHandle<T> {
+    /// Spawns the consumer on a dedicated blocking thread and returns a
+    /// handle for subscribing forwarders.
+    ///
+    /// The consumer continuously refreshes the pool's `best_transactions()`
+    /// iterator, deduplicates by hash, and broadcasts transactions. It shuts
+    /// down when all receivers are dropped.
+    pub fn spawn<P>(pool: P, config: ConsumerConfig) -> Self
+    where
+        P: TransactionPool<Transaction = T> + Send + 'static,
+    {
+        let (sender, _) = broadcast::channel(config.channel_capacity);
+        let broadcast_sender = sender.clone();
+        let metrics = ConsumerMetrics::default();
+        let consumer = Consumer::new(pool, config, broadcast_sender, metrics);
+
+        tokio::task::spawn_blocking(move || {
+            consumer.run();
+        });
+
+        Self { sender }
+    }
+}

--- a/crates/txpool/src/consumer/task.rs
+++ b/crates/txpool/src/consumer/task.rs
@@ -9,7 +9,7 @@ use super::{config::ConsumerConfig, metrics::ConsumerMetrics, validator::Recentl
 
 /// Background consumer that drains the pool and broadcasts transactions.
 ///
-/// Runs on a dedicated blocking thread via [`tokio::task::spawn_blocking`].
+/// Runs on a dedicated OS thread via [`std::thread::Builder`].
 /// Each iteration creates a fresh `best_transactions()` snapshot, skips
 /// recently-sent hashes, and broadcasts new transactions. Downstream
 /// forwarders (one per builder) each subscribe to receive every transaction.
@@ -39,9 +39,7 @@ where
         Self { pool, config, recently_sent, sender, metrics, cancel }
     }
 
-    /// Blocking loop — intended to be called from [`tokio::task::spawn_blocking`].
-    ///
-    /// Returns when cancelled or all receivers have been dropped.
+    /// Blocking loop — runs until the [`CancellationToken`] is cancelled.
     pub fn run(mut self) {
         info!(
             resend_after_ms = self.config.resend_after.as_millis() as u64,
@@ -71,15 +69,9 @@ where
                     continue;
                 }
 
-                match self.sender.send(tx) {
-                    Ok(_receivers) => {
-                        self.recently_sent.mark_sent(hash);
-                        txs_sent += 1;
-                    }
-                    Err(_) => {
-                        info!("all broadcast receivers dropped, shutting down");
-                        return;
-                    }
+                if self.sender.send(tx).is_ok() {
+                    self.recently_sent.mark_sent(hash);
+                    txs_sent += 1;
                 }
             }
 

--- a/crates/txpool/src/consumer/task.rs
+++ b/crates/txpool/src/consumer/task.rs
@@ -1,0 +1,107 @@
+use std::{fmt, sync::Arc};
+
+use reth_transaction_pool::{PoolTransaction, TransactionPool, ValidPoolTransaction};
+use tokio::sync::broadcast;
+use tracing::{info, trace};
+
+use super::{config::ConsumerConfig, metrics::ConsumerMetrics, validator::RecentlySent};
+
+/// Background consumer that drains the pool and broadcasts transactions.
+///
+/// Runs on a dedicated blocking thread via [`tokio::task::spawn_blocking`].
+/// Each iteration creates a fresh `best_transactions()` snapshot, skips
+/// recently-sent hashes, and broadcasts new transactions. Downstream
+/// forwarders (one per builder) each subscribe to receive every transaction.
+pub struct Consumer<P: TransactionPool> {
+    pool: P,
+    config: ConsumerConfig,
+    recently_sent: RecentlySent,
+    sender: broadcast::Sender<Arc<ValidPoolTransaction<P::Transaction>>>,
+    metrics: ConsumerMetrics,
+}
+
+impl<P> Consumer<P>
+where
+    P: TransactionPool + 'static,
+    P::Transaction: PoolTransaction,
+{
+    /// Creates a new consumer.
+    pub fn new(
+        pool: P,
+        config: ConsumerConfig,
+        sender: broadcast::Sender<Arc<ValidPoolTransaction<P::Transaction>>>,
+        metrics: ConsumerMetrics,
+    ) -> Self {
+        let recently_sent = RecentlySent::new(config.resend_after);
+        Self { pool, config, recently_sent, sender, metrics }
+    }
+
+    /// Blocking loop — intended to be called from [`tokio::task::spawn_blocking`].
+    ///
+    /// Returns when all receivers have been dropped.
+    pub fn run(self) {
+        info!(
+            resend_after_ms = self.config.resend_after.as_millis() as u64,
+            channel_capacity = self.config.channel_capacity,
+            poll_interval_ms = self.config.poll_interval.as_millis() as u64,
+            "starting transaction consumer",
+        );
+
+        loop {
+            let mut txs_read: u64 = 0;
+            let mut txs_sent: u64 = 0;
+            let mut txs_ignored: u64 = 0;
+
+            let best_txs = self.pool.best_transactions();
+
+            for tx in best_txs {
+                txs_read += 1;
+                let hash = *tx.hash();
+
+                if self.recently_sent.was_recently_sent(&hash) {
+                    txs_ignored += 1;
+                    continue;
+                }
+
+                match self.sender.send(tx) {
+                    Ok(_receivers) => {
+                        self.recently_sent.mark_sent(hash);
+                        txs_sent += 1;
+                    }
+                    Err(_) => {
+                        info!("all broadcast receivers dropped, shutting down");
+                        return;
+                    }
+                }
+            }
+
+            if txs_read > 0 {
+                self.metrics.txs_read.increment(txs_read);
+                self.metrics.txs_sent.increment(txs_sent);
+                self.metrics.txs_ignored.increment(txs_ignored);
+                self.metrics.dedup_cache_size.set(self.recently_sent.len() as f64);
+
+                trace!(
+                    txs_read = txs_read,
+                    txs_sent = txs_sent,
+                    txs_ignored = txs_ignored,
+                    dedup_cache = self.recently_sent.len(),
+                    "consumer iteration complete",
+                );
+            }
+
+            if txs_read == 0 {
+                std::thread::sleep(self.config.poll_interval);
+            }
+        }
+    }
+}
+
+impl<P: TransactionPool> fmt::Debug for Consumer<P> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Consumer")
+            .field("config", &self.config)
+            .field("recently_sent", &self.recently_sent)
+            .finish_non_exhaustive()
+    }
+}

--- a/crates/txpool/src/consumer/task.rs
+++ b/crates/txpool/src/consumer/task.rs
@@ -75,6 +75,8 @@ where
                 }
             }
 
+            self.metrics.iterations.increment(1);
+
             if txs_read > 0 {
                 self.metrics.txs_read.increment(txs_read);
                 self.metrics.txs_sent.increment(txs_sent);

--- a/crates/txpool/src/consumer/task.rs
+++ b/crates/txpool/src/consumer/task.rs
@@ -90,7 +90,7 @@ where
                 );
             }
 
-            if txs_read == 0 {
+            if txs_sent == 0 {
                 std::thread::sleep(self.config.poll_interval);
             }
         }

--- a/crates/txpool/src/consumer/task.rs
+++ b/crates/txpool/src/consumer/task.rs
@@ -2,6 +2,7 @@ use std::{fmt, sync::Arc};
 
 use reth_transaction_pool::{PoolTransaction, TransactionPool, ValidPoolTransaction};
 use tokio::sync::broadcast;
+use tokio_util::sync::CancellationToken;
 use tracing::{info, trace};
 
 use super::{config::ConsumerConfig, metrics::ConsumerMetrics, validator::RecentlySent};
@@ -18,6 +19,7 @@ pub struct Consumer<P: TransactionPool> {
     recently_sent: RecentlySent,
     sender: broadcast::Sender<Arc<ValidPoolTransaction<P::Transaction>>>,
     metrics: ConsumerMetrics,
+    cancel: CancellationToken,
 }
 
 impl<P> Consumer<P>
@@ -31,15 +33,16 @@ where
         config: ConsumerConfig,
         sender: broadcast::Sender<Arc<ValidPoolTransaction<P::Transaction>>>,
         metrics: ConsumerMetrics,
+        cancel: CancellationToken,
     ) -> Self {
         let recently_sent = RecentlySent::new(config.resend_after);
-        Self { pool, config, recently_sent, sender, metrics }
+        Self { pool, config, recently_sent, sender, metrics, cancel }
     }
 
     /// Blocking loop — intended to be called from [`tokio::task::spawn_blocking`].
     ///
-    /// Returns when all receivers have been dropped.
-    pub fn run(self) {
+    /// Returns when cancelled or all receivers have been dropped.
+    pub fn run(mut self) {
         info!(
             resend_after_ms = self.config.resend_after.as_millis() as u64,
             channel_capacity = self.config.channel_capacity,
@@ -47,7 +50,7 @@ where
             "starting transaction consumer",
         );
 
-        loop {
+        while !self.cancel.is_cancelled() {
             let mut txs_read: u64 = 0;
             let mut txs_sent: u64 = 0;
             let mut txs_ignored: u64 = 0;
@@ -55,6 +58,11 @@ where
             let best_txs = self.pool.best_transactions();
 
             for tx in best_txs {
+                if self.cancel.is_cancelled() {
+                    info!("consumer cancelled during iteration");
+                    return;
+                }
+
                 txs_read += 1;
                 let hash = *tx.hash();
 
@@ -94,6 +102,8 @@ where
                 std::thread::sleep(self.config.poll_interval);
             }
         }
+
+        info!("consumer cancelled, shutting down");
     }
 }
 

--- a/crates/txpool/src/consumer/validator.rs
+++ b/crates/txpool/src/consumer/validator.rs
@@ -1,10 +1,9 @@
 use std::{
-    sync::atomic::{AtomicU64, Ordering},
+    collections::HashMap,
     time::{Duration, Instant},
 };
 
 use alloy_primitives::B256;
-use dashmap::DashMap;
 
 /// Number of [`RecentlySent::was_recently_sent`] calls between pruning sweeps.
 const PRUNE_INTERVAL: u64 = 1000;
@@ -12,35 +11,39 @@ const PRUNE_INTERVAL: u64 = 1000;
 /// Hash-based deduplication tracker with a configurable time-to-live.
 ///
 /// Tracks transaction hashes that have already been forwarded through the
-/// consumer channel. A transaction whose hash appears in the map and whose
-/// entry is younger than `resend_after` will be skipped. Expired entries are
-/// pruned periodically (every [`PRUNE_INTERVAL`] lookups) to bound memory.
+/// consumer broadcast channel. A transaction whose hash appears in the map
+/// and whose entry is younger than `resend_after` will be skipped. Expired
+/// entries are pruned periodically (every [`PRUNE_INTERVAL`] lookups) to
+/// bound memory.
+///
+/// This type is **not** thread-safe — it is designed to be used exclusively
+/// from the single consumer blocking thread.
 pub struct RecentlySent {
-    seen: DashMap<B256, Instant>,
+    seen: HashMap<B256, Instant>,
     resend_after: Duration,
-    check_count: AtomicU64,
+    check_count: u64,
 }
 
 impl RecentlySent {
     /// Creates a new tracker.
     pub fn new(resend_after: Duration) -> Self {
-        Self { seen: DashMap::new(), resend_after, check_count: AtomicU64::new(0) }
+        Self { seen: HashMap::new(), resend_after, check_count: 0 }
     }
 
     /// Returns `true` if the hash was sent within the `resend_after` window.
     ///
     /// Triggers a pruning sweep every [`PRUNE_INTERVAL`] calls.
-    pub fn was_recently_sent(&self, hash: &B256) -> bool {
-        let count = self.check_count.fetch_add(1, Ordering::Relaxed);
-        if count.is_multiple_of(PRUNE_INTERVAL) {
+    pub fn was_recently_sent(&mut self, hash: &B256) -> bool {
+        self.check_count += 1;
+        if self.check_count.is_multiple_of(PRUNE_INTERVAL) {
             self.prune_expired();
         }
 
-        self.seen.get(hash).is_some_and(|entry| entry.elapsed() < self.resend_after)
+        self.seen.get(hash).is_some_and(|instant| instant.elapsed() < self.resend_after)
     }
 
     /// Records a hash as sent at the current instant.
-    pub fn mark_sent(&self, hash: B256) {
+    pub fn mark_sent(&mut self, hash: B256) {
         self.seen.insert(hash, Instant::now());
     }
 
@@ -54,7 +57,7 @@ impl RecentlySent {
         self.seen.is_empty()
     }
 
-    fn prune_expired(&self) {
+    fn prune_expired(&mut self) {
         let now = Instant::now();
         self.seen.retain(|_, instant| now.duration_since(*instant) < self.resend_after);
     }
@@ -75,13 +78,13 @@ mod tests {
 
     #[test]
     fn unseen_hash_is_not_recent() {
-        let tracker = RecentlySent::new(Duration::from_secs(5));
+        let mut tracker = RecentlySent::new(Duration::from_secs(5));
         assert!(!tracker.was_recently_sent(&B256::random()));
     }
 
     #[test]
     fn sent_hash_is_recent() {
-        let tracker = RecentlySent::new(Duration::from_secs(5));
+        let mut tracker = RecentlySent::new(Duration::from_secs(5));
         let hash = B256::random();
 
         tracker.mark_sent(hash);
@@ -90,7 +93,7 @@ mod tests {
 
     #[test]
     fn expired_hash_is_not_recent() {
-        let tracker = RecentlySent::new(Duration::from_millis(10));
+        let mut tracker = RecentlySent::new(Duration::from_millis(10));
         let hash = B256::random();
 
         tracker.mark_sent(hash);
@@ -100,7 +103,7 @@ mod tests {
 
     #[test]
     fn len_tracks_entries() {
-        let tracker = RecentlySent::new(Duration::from_secs(5));
+        let mut tracker = RecentlySent::new(Duration::from_secs(5));
         assert!(tracker.is_empty());
 
         tracker.mark_sent(B256::random());
@@ -112,7 +115,7 @@ mod tests {
 
     #[test]
     fn prune_removes_expired() {
-        let tracker = RecentlySent::new(Duration::from_millis(10));
+        let mut tracker = RecentlySent::new(Duration::from_millis(10));
 
         for _ in 0..5 {
             tracker.mark_sent(B256::random());

--- a/crates/txpool/src/consumer/validator.rs
+++ b/crates/txpool/src/consumer/validator.rs
@@ -15,9 +15,6 @@ const PRUNE_INTERVAL: u64 = 1000;
 /// and whose entry is younger than `resend_after` will be skipped. Expired
 /// entries are pruned periodically (every [`PRUNE_INTERVAL`] lookups) to
 /// bound memory.
-///
-/// This type is **not** thread-safe — it is designed to be used exclusively
-/// from the single consumer blocking thread.
 pub struct RecentlySent {
     seen: HashMap<B256, Instant>,
     resend_after: Duration,

--- a/crates/txpool/src/consumer/validator.rs
+++ b/crates/txpool/src/consumer/validator.rs
@@ -1,0 +1,127 @@
+use std::{
+    sync::atomic::{AtomicU64, Ordering},
+    time::{Duration, Instant},
+};
+
+use alloy_primitives::B256;
+use dashmap::DashMap;
+
+/// Number of [`RecentlySent::was_recently_sent`] calls between pruning sweeps.
+const PRUNE_INTERVAL: u64 = 1000;
+
+/// Hash-based deduplication tracker with a configurable time-to-live.
+///
+/// Tracks transaction hashes that have already been forwarded through the
+/// consumer channel. A transaction whose hash appears in the map and whose
+/// entry is younger than `resend_after` will be skipped. Expired entries are
+/// pruned periodically (every [`PRUNE_INTERVAL`] lookups) to bound memory.
+pub struct RecentlySent {
+    seen: DashMap<B256, Instant>,
+    resend_after: Duration,
+    check_count: AtomicU64,
+}
+
+impl RecentlySent {
+    /// Creates a new tracker.
+    pub fn new(resend_after: Duration) -> Self {
+        Self { seen: DashMap::new(), resend_after, check_count: AtomicU64::new(0) }
+    }
+
+    /// Returns `true` if the hash was sent within the `resend_after` window.
+    ///
+    /// Triggers a pruning sweep every [`PRUNE_INTERVAL`] calls.
+    pub fn was_recently_sent(&self, hash: &B256) -> bool {
+        let count = self.check_count.fetch_add(1, Ordering::Relaxed);
+        if count.is_multiple_of(PRUNE_INTERVAL) {
+            self.prune_expired();
+        }
+
+        self.seen.get(hash).is_some_and(|entry| entry.elapsed() < self.resend_after)
+    }
+
+    /// Records a hash as sent at the current instant.
+    pub fn mark_sent(&self, hash: B256) {
+        self.seen.insert(hash, Instant::now());
+    }
+
+    /// Returns the current cache size.
+    pub fn len(&self) -> usize {
+        self.seen.len()
+    }
+
+    /// Returns `true` when the cache is empty.
+    pub fn is_empty(&self) -> bool {
+        self.seen.is_empty()
+    }
+
+    fn prune_expired(&self) {
+        let now = Instant::now();
+        self.seen.retain(|_, instant| now.duration_since(*instant) < self.resend_after);
+    }
+}
+
+impl std::fmt::Debug for RecentlySent {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("RecentlySent")
+            .field("resend_after", &self.resend_after)
+            .field("entries", &self.seen.len())
+            .finish()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn unseen_hash_is_not_recent() {
+        let tracker = RecentlySent::new(Duration::from_secs(5));
+        assert!(!tracker.was_recently_sent(&B256::random()));
+    }
+
+    #[test]
+    fn sent_hash_is_recent() {
+        let tracker = RecentlySent::new(Duration::from_secs(5));
+        let hash = B256::random();
+
+        tracker.mark_sent(hash);
+        assert!(tracker.was_recently_sent(&hash));
+    }
+
+    #[test]
+    fn expired_hash_is_not_recent() {
+        let tracker = RecentlySent::new(Duration::from_millis(10));
+        let hash = B256::random();
+
+        tracker.mark_sent(hash);
+        std::thread::sleep(Duration::from_millis(15));
+        assert!(!tracker.was_recently_sent(&hash));
+    }
+
+    #[test]
+    fn len_tracks_entries() {
+        let tracker = RecentlySent::new(Duration::from_secs(5));
+        assert!(tracker.is_empty());
+
+        tracker.mark_sent(B256::random());
+        tracker.mark_sent(B256::random());
+        tracker.mark_sent(B256::random());
+
+        assert_eq!(tracker.len(), 3);
+    }
+
+    #[test]
+    fn prune_removes_expired() {
+        let tracker = RecentlySent::new(Duration::from_millis(10));
+
+        for _ in 0..5 {
+            tracker.mark_sent(B256::random());
+        }
+        assert_eq!(tracker.len(), 5);
+
+        std::thread::sleep(Duration::from_millis(15));
+        tracker.prune_expired();
+
+        assert_eq!(tracker.len(), 0);
+    }
+}

--- a/crates/txpool/src/lib.rs
+++ b/crates/txpool/src/lib.rs
@@ -16,6 +16,9 @@ pub use transaction::{BasePooledTransaction, OpPooledTx, TimestampedTransaction}
 mod ordering;
 pub use ordering::{BaseOrdering, TimestampOrdering};
 
+mod consumer;
+pub use consumer::{Consumer, ConsumerConfig, ConsumerHandle, ConsumerMetrics, RecentlySent};
+
 pub mod estimated_da_size;
 
 use reth_transaction_pool::{Pool, TransactionValidationTaskExecutor};


### PR DESCRIPTION
## Summary

Introduces the **consumer** background task for the new mempool→builder transaction propagation pipeline (PR 1 of 4). This replaces P2P propagation with a direct broadcast-based approach.

- Dedicated OS thread (`txpool-consumer` via `std::thread::Builder`) continuously drains `best_transactions()` (timestamp-ordered), deduplicates via a hash-based validator with configurable TTL (`resend_after`, default 4s / 2 blocks), and broadcasts transactions over a `tokio::sync::broadcast` channel
- Each builder node's forwarder (PR 2) subscribes independently — slow receivers naturally shed stale txns via `Lagged` errors
- Graceful shutdown via `CancellationToken` — `ConsumerHandle` cancels and joins the thread on drop
- Prometheus metrics: `txs_read`, `txs_sent`, `txs_ignored`, `dedup_cache_size`

## New Types

| Type | File | Description |
|------|------|-------------|
| `ConsumerConfig` | `consumer/config.rs` | `resend_after` (4s), `channel_capacity` (10k), `poll_interval` (10ms) |
| `ConsumerMetrics` | `consumer/metrics.rs` | Prometheus counters/gauge via `reth_metrics::Metrics` derive |
| `RecentlySent` | `consumer/validator.rs` | `HashMap<B256, Instant>` dedup tracker with periodic pruning |
| `Consumer<P>` | `consumer/task.rs` | Generic over `TransactionPool`, blocking loop on dedicated thread |
| `ConsumerHandle<T>` | `consumer/mod.rs` | Broadcast sender + `CancellationToken` + thread join on drop |

## Design Decisions

- **`broadcast` channel** (not `mpsc`): Single producer, multiple receivers — one forwarder per builder subscribes independently
- **`std::thread::Builder`** (not `spawn_blocking`): Consumer is long-lived, shouldn't occupy the tokio blocking thread pool
- **`HashMap`** (not `DashMap`): Single-threaded access from consumer thread, no concurrency overhead needed
- **Sleep on zero sends**: Sleeps `poll_interval` when `txs_sent == 0` (even if pool non-empty but all deduped) to avoid busy-spinning
- **Zero-receiver sends silently dropped**: Prevents startup race where consumer starts before forwarders subscribe

## Pipeline Roadmap

Full roadmap in `crates/txpool/PROPAGATION_PIPELINE.md`:

| PR | Component | Status |
|----|-----------|--------|
| **PR 1** | Consumer (this PR) | ✅ |
| PR 2 | Forwarder (per-builder, batched RPC) | Planned |
| PR 3 | Builder RPC (`base_insertValidatedTransactions`) | Planned |
| PR 4 | Node integration (extension pattern) | Planned |

## Testing

- 7 unit tests for config defaults/builder methods and validator dedup/expiry/pruning
- All 14 crate tests pass
- `just ci` passes (cargo fix, fmt, clippy clean)