### PR TITLE
chore(ci): publish final releases as drafts

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -293,7 +293,7 @@ jobs:
           if gh release view "$TAG" > /dev/null 2>&1; then
             echo "GitHub Release $TAG already exists, skipping creation"
           else
-            gh release create "$TAG" --title "$TAG" --generate-notes
+            gh release create "$TAG" --title "$TAG" --generate-notes --draft
           fi
 
       - name: Download binary artifacts


### PR DESCRIPTION
Adds `--draft` to `gh release create` so final releases are created as drafts rather than published immediately.