### PR TITLE
feat(txpool): add transaction forwarder with sliding window rate limiter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -258,9 +258,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-eip7928"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3231de68d5d6e75332b7489cfcc7f4dfabeba94d990a10e4b923af0e6623540"
+checksum = "f8222b1d88f9a6d03be84b0f5e76bb60cd83991b43ad8ab6477f0e4a7809b98d"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -439,7 +439,7 @@ dependencies = [
  "derive_more",
  "fixed-cache",
  "foldhash 0.2.0",
- "getrandom 0.4.1",
+ "getrandom 0.4.2",
  "hashbrown 0.16.1",
  "indexmap 2.13.0",
  "itoa",
@@ -1734,8 +1734,8 @@ dependencies = [
  "aws-runtime",
  "aws-sdk-sts",
  "aws-smithy-async",
- "aws-smithy-http 0.63.5",
- "aws-smithy-json 0.62.4",
+ "aws-smithy-http 0.63.6",
+ "aws-smithy-json 0.62.5",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -1763,9 +1763,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.16.0"
+version = "1.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9a7b350e3bb1767102698302bc37256cbd48422809984b98d292c40e2579aa9"
+checksum = "94bffc006df10ac2a68c83692d734a465f8ee6c5b384d8545a636f81d858f4bf"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -1773,9 +1773,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.37.1"
+version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b092fe214090261288111db7a2b2c2118e5a7f30dc2569f1732c4069a6840549"
+checksum = "4321e568ed89bb5a7d291a7f37997c2c0df89809d7b6d12062c81ddb54aa782e"
 dependencies = [
  "cc",
  "cmake",
@@ -1821,7 +1821,7 @@ dependencies = [
  "aws-sigv4",
  "aws-smithy-async",
  "aws-smithy-eventstream",
- "aws-smithy-http 0.63.5",
+ "aws-smithy-http 0.63.6",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -1882,8 +1882,8 @@ dependencies = [
  "aws-credential-types",
  "aws-runtime",
  "aws-smithy-async",
- "aws-smithy-http 0.63.5",
- "aws-smithy-json 0.62.4",
+ "aws-smithy-http 0.63.6",
+ "aws-smithy-json 0.62.5",
  "aws-smithy-observability",
  "aws-smithy-query",
  "aws-smithy-runtime",
@@ -1906,7 +1906,7 @@ checksum = "37411f8e0f4bea0c3ca0958ce7f18f6439db24d555dbd809787262cd00926aa9"
 dependencies = [
  "aws-credential-types",
  "aws-smithy-eventstream",
- "aws-smithy-http 0.63.5",
+ "aws-smithy-http 0.63.6",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
  "bytes",
@@ -1923,9 +1923,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-async"
-version = "1.2.13"
+version = "1.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cc50d0f63e714784b84223abd7abbc8577de8c35d699e0edd19f0a88a08ae13"
+checksum = "2ffcaf626bdda484571968400c326a244598634dc75fd451325a54ad1a59acfc"
 dependencies = [
  "futures-util",
  "pin-project-lite",
@@ -1954,9 +1954,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-eventstream"
-version = "0.60.19"
+version = "0.60.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c0b3e587fbaa5d7f7e870544508af8ce82ea47cd30376e69e1e37c4ac746f79"
+checksum = "faf09d74e5e32f76b8762da505a3cd59303e367a664ca67295387baa8c1d7548"
 dependencies = [
  "aws-smithy-types",
  "bytes",
@@ -1987,9 +1987,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-http"
-version = "0.63.5"
+version = "0.63.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d619373d490ad70966994801bc126846afaa0d1ee920697a031f0cf63f2568e7"
+checksum = "ba1ab2dc1c2c3749ead27180d333c42f11be8b0e934058fb4b2258ee8dbe5231"
 dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -2008,9 +2008,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-http-client"
-version = "1.1.11"
+version = "1.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00ccbb08c10f6bcf912f398188e42ee2eab5f1767ce215a02a73bc5df1bbdd95"
+checksum = "6a2f165a7feee6f263028b899d0a181987f4fa7179a6411a32a439fba7c5f769"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-runtime-api",
@@ -2047,27 +2047,27 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-json"
-version = "0.62.4"
+version = "0.62.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27b3a779093e18cad88bbae08dc4261e1d95018c4c5b9356a52bcae7c0b6e9bb"
+checksum = "9648b0bb82a2eedd844052c6ad2a1a822d1f8e3adee5fbf668366717e428856a"
 dependencies = [
  "aws-smithy-types",
 ]
 
 [[package]]
 name = "aws-smithy-observability"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d3f39d5bb871aaf461d59144557f16d5927a5248a983a40654d9cf3b9ba183b"
+checksum = "a06c2315d173edbf1920da8ba3a7189695827002e4c0fc961973ab1c54abca9c"
 dependencies = [
  "aws-smithy-runtime-api",
 ]
 
 [[package]]
 name = "aws-smithy-query"
-version = "0.60.14"
+version = "0.60.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05f76a580e3d8f8961e5d48763214025a2af65c2fa4cd1fb7f270a0e107a71b0"
+checksum = "1a56d79744fb3edb5d722ef79d86081e121d3b9422cb209eb03aea6aa4f21ebd"
 dependencies = [
  "aws-smithy-types",
  "urlencoding",
@@ -2075,12 +2075,12 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime"
-version = "1.10.2"
+version = "1.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22ccf7f6eba8b2dcf8ce9b74806c6c185659c311665c4bf8d6e71ebd454db6bf"
+checksum = "028999056d2d2fd58a697232f9eec4a643cf73a71cf327690a7edad1d2af2110"
 dependencies = [
  "aws-smithy-async",
- "aws-smithy-http 0.63.5",
+ "aws-smithy-http 0.63.6",
  "aws-smithy-http-client",
  "aws-smithy-observability",
  "aws-smithy-runtime-api",
@@ -2100,9 +2100,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime-api"
-version = "1.11.5"
+version = "1.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4af6e5def28be846479bbeac55aa4603d6f7986fc5da4601ba324dd5d377516"
+checksum = "876ab3c9c29791ba4ba02b780a3049e21ec63dabda09268b175272c3733a79e6"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-types",
@@ -2117,9 +2117,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-types"
-version = "1.4.5"
+version = "1.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ca2734c16913a45343b37313605d84e7d8b34a4611598ce1d25b35860a2bed3"
+checksum = "d2b1117b3b2bbe166d11199b540ceed0d0f7676e36e7b962b5a437a9971eac75"
 dependencies = [
  "base64-simd",
  "bytes",
@@ -2143,9 +2143,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-xml"
-version = "0.60.14"
+version = "0.60.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b53543b4b86ed43f051644f704a98c7291b3618b67adf057ee77a366fa52fcaa"
+checksum = "0ce02add1aa3677d022f8adf81dcbe3046a95f17a1b1e8979c145cd21d3d22b3"
 dependencies = [
  "xmlparser",
 ]
@@ -3015,7 +3015,7 @@ dependencies = [
  "base-consensus-gossip",
  "base-macros",
  "base-protocol",
- "getrandom 0.4.1",
+ "getrandom 0.4.2",
  "ipnet",
  "jsonrpsee",
  "libp2p",
@@ -3696,7 +3696,7 @@ dependencies = [
  "reth-revm",
  "reth-transaction-pool",
  "reth-trie-common",
- "revm-bytecode",
+ "revm-bytecode 8.0.0",
  "revm-context-interface",
  "revm-database",
  "serde",
@@ -4226,6 +4226,7 @@ dependencies = [
  "base-test-utils",
  "c-kzg",
  "derive_more",
+ "jsonrpsee",
  "metrics",
  "parking_lot",
  "reth-chainspec",
@@ -4236,6 +4237,8 @@ dependencies = [
  "reth-storage-api",
  "reth-tasks",
  "reth-transaction-pool",
+ "serde",
+ "serde_json",
  "tokio",
  "tokio-util",
  "tracing",
@@ -5404,9 +5407,9 @@ dependencies = [
 
 [[package]]
 name = "const-hex"
-version = "1.18.0"
+version = "1.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af9a108e542ddf1de36743a6126e94d6659dccda38fc8a77e80b915102ac784a"
+checksum = "531185e432bb31db1ecda541e9e7ab21468d4d844ad7505e0546a49b4945d49b"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -5946,7 +5949,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ab67060fc6b8ef687992d439ca0fa36e7ed17e9a0b16b25b601e8757df720de"
 dependencies = [
  "data-encoding",
- "syn 1.0.109",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -7219,7 +7222,7 @@ dependencies = [
  "log",
  "rustversion",
  "windows-link",
- "windows-result 0.4.1",
+ "windows-result",
 ]
 
 [[package]]
@@ -7276,21 +7279,21 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "r-efi",
+ "r-efi 5.3.0",
  "wasip2",
  "wasm-bindgen",
 ]
 
 [[package]]
 name = "getrandom"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "139ef39800118c7683f2fd3c98c1b23c09ae076556b435f8e9064ae108aaeeec"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "r-efi",
+ "r-efi 6.0.0",
  "wasip2",
  "wasip3",
  "wasm-bindgen",
@@ -8011,7 +8014,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "socket2 0.6.2",
- "system-configuration 0.7.0",
+ "system-configuration",
  "tokio",
  "tower-layer",
  "tower-service",
@@ -8046,7 +8049,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.62.2",
+ "windows-core",
 ]
 
 [[package]]
@@ -8182,16 +8185,6 @@ dependencies = [
 
 [[package]]
 name = "if-addrs"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cabb0019d51a643781ff15c9c8a3e5dedc365c47211270f4e8f82812fedd8f0a"
-dependencies = [
- "libc",
- "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "if-addrs"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf39cc0423ee66021dc5eccface85580e4a001e0c5288bae8bea7ecb69225e90"
@@ -8201,16 +8194,26 @@ dependencies = [
 ]
 
 [[package]]
-name = "if-watch"
-version = "3.2.1"
+name = "if-addrs"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdf9d64cfcf380606e64f9a0bcf493616b65331199f984151a6fa11a7b3cde38"
+checksum = "c0a05c691e1fae256cf7013d99dad472dc52d5543322761f83ec8d47eab40d2b"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "if-watch"
+version = "3.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71c02a5161c313f0cbdbadc511611893584a10a7b6153cb554bdf83ddce99ec2"
 dependencies = [
  "async-io",
  "core-foundation 0.9.4",
  "fnv",
  "futures",
- "if-addrs 0.10.2",
+ "if-addrs 0.15.0",
  "ipnet",
  "log",
  "netlink-packet-core",
@@ -8218,9 +8221,9 @@ dependencies = [
  "netlink-proto",
  "netlink-sys",
  "rtnetlink",
- "system-configuration 0.6.1",
+ "system-configuration",
  "tokio",
- "windows 0.53.0",
+ "windows",
 ]
 
 [[package]]
@@ -8459,7 +8462,7 @@ dependencies = [
  "p384",
  "p521",
  "rand_core 0.6.4",
- "rsa 0.10.0-rc.15",
+ "rsa 0.10.0-rc.16",
  "sec1",
  "sha1 0.10.6",
  "sha1 0.11.0-rc.5",
@@ -8510,9 +8513,9 @@ dependencies = [
 
 [[package]]
 name = "ipnet"
-version = "2.11.0"
+version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
+checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 dependencies = [
  "serde",
 ]
@@ -9761,7 +9764,7 @@ dependencies = [
  "once_cell",
  "procfs",
  "rlimit",
- "windows 0.62.2",
+ "windows",
 ]
 
 [[package]]
@@ -9883,9 +9886,9 @@ dependencies = [
 
 [[package]]
 name = "moka"
-version = "0.12.13"
+version = "0.12.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4ac832c50ced444ef6be0767a008b02c106a909ba79d1d830501e94b96f6b7e"
+checksum = "85f8024e1c8e71c778968af91d43700ce1d11b219d127d79fb2934153b82b42b"
 dependencies = [
  "async-lock",
  "crossbeam-channel",
@@ -10000,46 +10003,30 @@ dependencies = [
 
 [[package]]
 name = "netlink-packet-core"
-version = "0.7.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72724faf704479d67b388da142b186f916188505e7e0b26719019c525882eda4"
+checksum = "3463cbb78394cb0141e2c926b93fc2197e473394b761986eca3b9da2c63ae0f4"
 dependencies = [
- "anyhow",
- "byteorder",
- "netlink-packet-utils",
+ "paste",
 ]
 
 [[package]]
 name = "netlink-packet-route"
-version = "0.17.1"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "053998cea5a306971f88580d0829e90f270f940befd7cf928da179d4187a5a66"
+checksum = "4ce3636fa715e988114552619582b530481fd5ef176a1e5c1bf024077c2c9445"
 dependencies = [
- "anyhow",
- "bitflags 1.3.2",
- "byteorder",
+ "bitflags 2.11.0",
  "libc",
+ "log",
  "netlink-packet-core",
- "netlink-packet-utils",
-]
-
-[[package]]
-name = "netlink-packet-utils"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ede8a08c71ad5a95cdd0e4e52facd37190977039a4704eb82a283f713747d34"
-dependencies = [
- "anyhow",
- "byteorder",
- "paste",
- "thiserror 1.0.69",
 ]
 
 [[package]]
 name = "netlink-proto"
-version = "0.11.5"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72452e012c2f8d612410d89eea01e2d9b56205274abb35d53f60200b2ec41d60"
+checksum = "b65d130ee111430e47eed7896ea43ca693c387f097dd97376bffafbf25812128"
 dependencies = [
  "bytes",
  "futures",
@@ -10093,6 +10080,18 @@ name = "nix"
 version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
+dependencies = [
+ "bitflags 2.11.0",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
+
+[[package]]
+name = "nix"
+version = "0.31.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d6d0705320c1e6ba1d912b5e37cf18071b6c2e9b7fa8215a1e8a7651966f5d3"
 dependencies = [
  "bitflags 2.11.0",
  "cfg-if",
@@ -10802,7 +10801,7 @@ dependencies = [
  "sha2 0.10.9",
  "thiserror 1.0.69",
  "tokio",
- "windows 0.62.2",
+ "windows",
  "windows-strings",
 ]
 
@@ -11574,12 +11573,9 @@ dependencies = [
 
 [[package]]
 name = "pxfm"
-version = "0.1.27"
+version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7186d3822593aa4393561d186d1393b3923e9d6163d3fbfd6e825e3e6cf3e6a8"
-dependencies = [
- "num-traits",
-]
+checksum = "b5a041e753da8b807c9255f28de81879c78c876392ff2469cde94799b2896b9d"
 
 [[package]]
 name = "quanta"
@@ -11689,9 +11685,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.44"
+version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21b2ebcf727b7760c461f091f9f0f539b77b8e87f2fd88131e7f1b433b3cece4"
+checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
@@ -11701,6 +11697,12 @@ name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "radium"
@@ -12223,7 +12225,7 @@ dependencies = [
  "reth-storage-api",
  "reth-trie",
  "revm-database",
- "revm-state",
+ "revm-state 9.0.0",
  "serde",
  "tokio",
  "tokio-stream",
@@ -13342,7 +13344,7 @@ dependencies = [
  "reth-tracing",
  "reth-trie",
  "revm",
- "revm-bytecode",
+ "revm-bytecode 8.0.0",
  "revm-database",
  "serde",
  "serde_json",
@@ -13974,9 +13976,9 @@ dependencies = [
  "proptest-arbitrary-interop",
  "rayon",
  "reth-codecs",
- "revm-bytecode",
+ "revm-bytecode 8.0.0",
  "revm-primitives",
- "revm-state",
+ "revm-state 9.0.0",
  "secp256k1 0.30.0",
  "serde",
  "serde_with",
@@ -14021,7 +14023,7 @@ dependencies = [
  "reth-trie",
  "reth-trie-db",
  "revm-database",
- "revm-state",
+ "revm-state 9.0.0",
  "rocksdb",
  "strum 0.27.2",
  "tokio",
@@ -14570,7 +14572,7 @@ dependencies = [
  "reth-prune-types",
  "reth-static-file-types",
  "revm-database-interface",
- "revm-state",
+ "revm-state 9.0.0",
  "thiserror 2.0.18",
 ]
 
@@ -14830,7 +14832,7 @@ version = "34.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2aabdebaa535b3575231a88d72b642897ae8106cf6b0d12eafc6bfdf50abfc7"
 dependencies = [
- "revm-bytecode",
+ "revm-bytecode 8.0.0",
  "revm-context",
  "revm-context-interface",
  "revm-database",
@@ -14840,7 +14842,7 @@ dependencies = [
  "revm-interpreter",
  "revm-precompile",
  "revm-primitives",
- "revm-state",
+ "revm-state 9.0.0",
 ]
 
 [[package]]
@@ -14848,6 +14850,18 @@ name = "revm-bytecode"
 version = "8.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74d1e5c1eaa44d39d537f668bc5c3409dc01e5c8be954da6c83370bbdf006457"
+dependencies = [
+ "bitvec",
+ "phf 0.13.1",
+ "revm-primitives",
+ "serde",
+]
+
+[[package]]
+name = "revm-bytecode"
+version = "9.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e86e468df3cf5cf59fa7ef71a3e9ccabb76bb336401ea2c0674f563104cf3c5e"
 dependencies = [
  "bitvec",
  "phf 0.13.1",
@@ -14864,11 +14878,11 @@ dependencies = [
  "bitvec",
  "cfg-if",
  "derive-where",
- "revm-bytecode",
+ "revm-bytecode 8.0.0",
  "revm-context-interface",
  "revm-database-interface",
  "revm-primitives",
- "revm-state",
+ "revm-state 9.0.0",
  "serde",
 ]
 
@@ -14884,7 +14898,7 @@ dependencies = [
  "either",
  "revm-database-interface",
  "revm-primitives",
- "revm-state",
+ "revm-state 9.0.0",
  "serde",
 ]
 
@@ -14895,23 +14909,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "529528d0b05fe646be86223032c3e77aa8b05caa2a35447d538c55965956a511"
 dependencies = [
  "alloy-eips",
- "revm-bytecode",
+ "revm-bytecode 8.0.0",
  "revm-database-interface",
  "revm-primitives",
- "revm-state",
+ "revm-state 9.0.0",
  "serde",
 ]
 
 [[package]]
 name = "revm-database-interface"
-version = "9.0.0"
+version = "9.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7bf93ac5b91347c057610c0d96e923db8c62807e03f036762d03e981feddc1d"
+checksum = "8bc1da862c71ba380b0e2ee0b19b186e282f931ba4f479dfbc83903294a5e596"
 dependencies = [
  "auto_impl",
  "either",
  "revm-primitives",
- "revm-state",
+ "revm-state 10.0.0",
  "serde",
  "thiserror 2.0.18",
 ]
@@ -14924,14 +14938,14 @@ checksum = "0cd0e43e815a85eded249df886c4badec869195e70cdd808a13cfca2794622d2"
 dependencies = [
  "auto_impl",
  "derive-where",
- "revm-bytecode",
+ "revm-bytecode 8.0.0",
  "revm-context",
  "revm-context-interface",
  "revm-database-interface",
  "revm-interpreter",
  "revm-precompile",
  "revm-primitives",
- "revm-state",
+ "revm-state 9.0.0",
  "serde",
 ]
 
@@ -14948,7 +14962,7 @@ dependencies = [
  "revm-handler",
  "revm-interpreter",
  "revm-primitives",
- "revm-state",
+ "revm-state 9.0.0",
  "serde",
  "serde_json",
 ]
@@ -14979,18 +14993,18 @@ version = "32.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11406408597bc249392d39295831c4b641b3a6f5c471a7c41104a7a1e3564c07"
 dependencies = [
- "revm-bytecode",
+ "revm-bytecode 8.0.0",
  "revm-context-interface",
  "revm-primitives",
- "revm-state",
+ "revm-state 9.0.0",
  "serde",
 ]
 
 [[package]]
 name = "revm-precompile"
-version = "32.0.0"
+version = "32.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50c1285c848d240678bf69cb0f6179ff5a4aee6fc8e921d89708087197a0aff3"
+checksum = "e2ec11f45deec71e4945e1809736bb20d454285f9167ab53c5159dae1deb603f"
 dependencies = [
  "ark-bls12-381",
  "ark-bn254",
@@ -15013,9 +15027,9 @@ dependencies = [
 
 [[package]]
 name = "revm-primitives"
-version = "22.0.0"
+version = "22.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba580c56a8ec824a64f8a1683577876c2e1dbe5247044199e9b881421ad5dcf9"
+checksum = "4bcfb5ce6cf18b118932bcdb7da05cd9c250f2cb9f64131396b55f3fe3537c35"
 dependencies = [
  "alloy-primitives",
  "num_enum",
@@ -15031,7 +15045,20 @@ checksum = "311720d4f0f239b041375e7ddafdbd20032a33b7bae718562ea188e188ed9fd3"
 dependencies = [
  "alloy-eip7928",
  "bitflags 2.11.0",
- "revm-bytecode",
+ "revm-bytecode 8.0.0",
+ "revm-primitives",
+ "serde",
+]
+
+[[package]]
+name = "revm-state"
+version = "10.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d29404707763da607e5d6e4771cb203998c28159279c2f64cc32de08d2814651"
+dependencies = [
+ "alloy-eip7928",
+ "bitflags 2.11.0",
+ "revm-bytecode 9.0.0",
  "revm-primitives",
  "serde",
 ]
@@ -15171,9 +15198,9 @@ dependencies = [
 
 [[package]]
 name = "rsa"
-version = "0.10.0-rc.15"
+version = "0.10.0-rc.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b342b99544549f37509ed7fd42b0cea04bfd9ce07c16ca56094cf0fbeefbbcd"
+checksum = "6fb9fd8c1edd9e6a2693623baf0fe77ff05ce022a5d7746900ffc38a15c233de"
 dependencies = [
  "const-oid 0.10.2",
  "crypto-bigint 0.7.0-rc.28",
@@ -15218,18 +15245,18 @@ dependencies = [
 
 [[package]]
 name = "rtnetlink"
-version = "0.13.1"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a552eb82d19f38c3beed3f786bd23aa434ceb9ac43ab44419ca6d67a7e186c0"
+checksum = "4b960d5d873a75b5be9761b1e73b146f52dddcd27bac75263f40fba686d4d7b5"
 dependencies = [
- "futures",
+ "futures-channel",
+ "futures-util",
  "log",
  "netlink-packet-core",
  "netlink-packet-route",
- "netlink-packet-utils",
  "netlink-proto",
  "netlink-sys",
- "nix 0.26.4",
+ "nix 0.30.1",
  "thiserror 1.0.69",
  "tokio",
 ]
@@ -16226,9 +16253,9 @@ checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
 
 [[package]]
 name = "sketches-ddsketch"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1e9a774a6c28142ac54bb25d25562e6bcf957493a184f15ad4eebccb23e410a"
+checksum = "0c6f73aeb92d671e0cc4dca167e59b2deb6387c375391bc99ee743f326994a2b"
 
 [[package]]
 name = "slab"
@@ -16551,18 +16578,7 @@ dependencies = [
  "ntapi",
  "objc2-core-foundation",
  "objc2-io-kit",
- "windows 0.62.2",
-]
-
-[[package]]
-name = "system-configuration"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
-dependencies = [
- "bitflags 2.11.0",
- "core-foundation 0.9.4",
- "system-configuration-sys",
+ "windows",
 ]
 
 [[package]]
@@ -16631,7 +16647,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "82a72c767771b47409d2345987fda8628641887d5466101319899796367354a0"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
@@ -16982,9 +16998,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.49.0"
+version = "1.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72a2903cd7736441aac9df9d7688bd0ce48edccaadf181c3b90be801e81d3d86"
+checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
 dependencies = [
  "bytes",
  "libc",
@@ -16999,9 +17015,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.6.0"
+version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
+checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -17763,7 +17779,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b672338555252d43fd2240c714dc444b8c6fb0a5c5335e65a07bba7742735ddb"
 dependencies = [
  "atomic",
- "getrandom 0.4.1",
+ "getrandom 0.4.2",
  "js-sys",
  "serde_core",
  "sha1_smol",
@@ -17854,12 +17870,12 @@ checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
 
 [[package]]
 name = "vsock"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2da6e4ac76cd19635dce0f98985378bb62f8044ee2ff80abd2a7334b920ed63"
+checksum = "b82aeb12ad864eb8cd26a6c21175d0bdc66d398584ee6c93c76964c3bcfc78ff"
 dependencies = [
  "libc",
- "nix 0.30.1",
+ "nix 0.31.2",
 ]
 
 [[package]]
@@ -18256,22 +18272,12 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efc5cf48f83140dcaab716eeaea345f9e93d0018fb81162753a3f76c3397b538"
-dependencies = [
- "windows-core 0.53.0",
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows"
 version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
 dependencies = [
  "windows-collections",
- "windows-core 0.62.2",
+ "windows-core",
  "windows-future",
  "windows-numerics",
 ]
@@ -18282,17 +18288,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
 dependencies = [
- "windows-core 0.62.2",
-]
-
-[[package]]
-name = "windows-core"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dcc5b895a6377f1ab9fa55acedab1fd5ac0db66ad1e6c7f47e28a22e446a5dd"
-dependencies = [
- "windows-result 0.1.2",
- "windows-targets 0.52.6",
+ "windows-core",
 ]
 
 [[package]]
@@ -18304,7 +18300,7 @@ dependencies = [
  "windows-implement",
  "windows-interface",
  "windows-link",
- "windows-result 0.4.1",
+ "windows-result",
  "windows-strings",
 ]
 
@@ -18314,7 +18310,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
 dependencies = [
- "windows-core 0.62.2",
+ "windows-core",
  "windows-link",
  "windows-threading",
 ]
@@ -18353,7 +18349,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
 dependencies = [
- "windows-core 0.62.2",
+ "windows-core",
  "windows-link",
 ]
 
@@ -18364,17 +18360,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
 dependencies = [
  "windows-link",
- "windows-result 0.4.1",
+ "windows-result",
  "windows-strings",
-]
-
-[[package]]
-name = "windows-result"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e383302e8ec8515204254685643de10811af0ed97ea37210dc26fb0032647f8"
-dependencies = [
- "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -19132,9 +19119,9 @@ dependencies = [
 
 [[package]]
 name = "zip"
-version = "8.1.0"
+version = "8.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e499faf5c6b97a0d086f4a8733de6d47aee2252b8127962439d8d4311a73f72"
+checksum = "b680f2a0cd479b4cff6e1233c483fdead418106eae419dc60200ae9850f6d004"
 dependencies = [
  "crc32fast",
  "flate2",
@@ -19146,9 +19133,9 @@ dependencies = [
 
 [[package]]
 name = "zlib-rs"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c745c48e1007337ed136dc99df34128b9faa6ed542d80a1c673cf55a6d7236c8"
+checksum = "3be3d40e40a133f9c916ee3f9f4fa2d9d63435b5fbe1bfc6d9dae0aa0ada1513"
 
 [[package]]
 name = "zmij"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -258,9 +258,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-eip7928"
-version = "0.3.3"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8222b1d88f9a6d03be84b0f5e76bb60cd83991b43ad8ab6477f0e4a7809b98d"
+checksum = "d3231de68d5d6e75332b7489cfcc7f4dfabeba94d990a10e4b923af0e6623540"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -439,7 +439,7 @@ dependencies = [
  "derive_more",
  "fixed-cache",
  "foldhash 0.2.0",
- "getrandom 0.4.2",
+ "getrandom 0.4.1",
  "hashbrown 0.16.1",
  "indexmap 2.13.0",
  "itoa",
@@ -1734,8 +1734,8 @@ dependencies = [
  "aws-runtime",
  "aws-sdk-sts",
  "aws-smithy-async",
- "aws-smithy-http 0.63.6",
- "aws-smithy-json 0.62.5",
+ "aws-smithy-http 0.63.5",
+ "aws-smithy-json 0.62.4",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -1763,9 +1763,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.16.1"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94bffc006df10ac2a68c83692d734a465f8ee6c5b384d8545a636f81d858f4bf"
+checksum = "d9a7b350e3bb1767102698302bc37256cbd48422809984b98d292c40e2579aa9"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -1773,9 +1773,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.38.0"
+version = "0.37.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4321e568ed89bb5a7d291a7f37997c2c0df89809d7b6d12062c81ddb54aa782e"
+checksum = "b092fe214090261288111db7a2b2c2118e5a7f30dc2569f1732c4069a6840549"
 dependencies = [
  "cc",
  "cmake",
@@ -1821,7 +1821,7 @@ dependencies = [
  "aws-sigv4",
  "aws-smithy-async",
  "aws-smithy-eventstream",
- "aws-smithy-http 0.63.6",
+ "aws-smithy-http 0.63.5",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -1882,8 +1882,8 @@ dependencies = [
  "aws-credential-types",
  "aws-runtime",
  "aws-smithy-async",
- "aws-smithy-http 0.63.6",
- "aws-smithy-json 0.62.5",
+ "aws-smithy-http 0.63.5",
+ "aws-smithy-json 0.62.4",
  "aws-smithy-observability",
  "aws-smithy-query",
  "aws-smithy-runtime",
@@ -1906,7 +1906,7 @@ checksum = "37411f8e0f4bea0c3ca0958ce7f18f6439db24d555dbd809787262cd00926aa9"
 dependencies = [
  "aws-credential-types",
  "aws-smithy-eventstream",
- "aws-smithy-http 0.63.6",
+ "aws-smithy-http 0.63.5",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
  "bytes",
@@ -1923,9 +1923,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-async"
-version = "1.2.14"
+version = "1.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ffcaf626bdda484571968400c326a244598634dc75fd451325a54ad1a59acfc"
+checksum = "5cc50d0f63e714784b84223abd7abbc8577de8c35d699e0edd19f0a88a08ae13"
 dependencies = [
  "futures-util",
  "pin-project-lite",
@@ -1954,9 +1954,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-eventstream"
-version = "0.60.20"
+version = "0.60.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "faf09d74e5e32f76b8762da505a3cd59303e367a664ca67295387baa8c1d7548"
+checksum = "1c0b3e587fbaa5d7f7e870544508af8ce82ea47cd30376e69e1e37c4ac746f79"
 dependencies = [
  "aws-smithy-types",
  "bytes",
@@ -1987,9 +1987,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-http"
-version = "0.63.6"
+version = "0.63.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba1ab2dc1c2c3749ead27180d333c42f11be8b0e934058fb4b2258ee8dbe5231"
+checksum = "d619373d490ad70966994801bc126846afaa0d1ee920697a031f0cf63f2568e7"
 dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -2008,9 +2008,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-http-client"
-version = "1.1.12"
+version = "1.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a2f165a7feee6f263028b899d0a181987f4fa7179a6411a32a439fba7c5f769"
+checksum = "00ccbb08c10f6bcf912f398188e42ee2eab5f1767ce215a02a73bc5df1bbdd95"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-runtime-api",
@@ -2047,27 +2047,27 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-json"
-version = "0.62.5"
+version = "0.62.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9648b0bb82a2eedd844052c6ad2a1a822d1f8e3adee5fbf668366717e428856a"
+checksum = "27b3a779093e18cad88bbae08dc4261e1d95018c4c5b9356a52bcae7c0b6e9bb"
 dependencies = [
  "aws-smithy-types",
 ]
 
 [[package]]
 name = "aws-smithy-observability"
-version = "0.2.6"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a06c2315d173edbf1920da8ba3a7189695827002e4c0fc961973ab1c54abca9c"
+checksum = "4d3f39d5bb871aaf461d59144557f16d5927a5248a983a40654d9cf3b9ba183b"
 dependencies = [
  "aws-smithy-runtime-api",
 ]
 
 [[package]]
 name = "aws-smithy-query"
-version = "0.60.15"
+version = "0.60.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a56d79744fb3edb5d722ef79d86081e121d3b9422cb209eb03aea6aa4f21ebd"
+checksum = "05f76a580e3d8f8961e5d48763214025a2af65c2fa4cd1fb7f270a0e107a71b0"
 dependencies = [
  "aws-smithy-types",
  "urlencoding",
@@ -2075,12 +2075,12 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime"
-version = "1.10.3"
+version = "1.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "028999056d2d2fd58a697232f9eec4a643cf73a71cf327690a7edad1d2af2110"
+checksum = "22ccf7f6eba8b2dcf8ce9b74806c6c185659c311665c4bf8d6e71ebd454db6bf"
 dependencies = [
  "aws-smithy-async",
- "aws-smithy-http 0.63.6",
+ "aws-smithy-http 0.63.5",
  "aws-smithy-http-client",
  "aws-smithy-observability",
  "aws-smithy-runtime-api",
@@ -2100,9 +2100,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime-api"
-version = "1.11.6"
+version = "1.11.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "876ab3c9c29791ba4ba02b780a3049e21ec63dabda09268b175272c3733a79e6"
+checksum = "b4af6e5def28be846479bbeac55aa4603d6f7986fc5da4601ba324dd5d377516"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-types",
@@ -2117,9 +2117,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-types"
-version = "1.4.6"
+version = "1.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2b1117b3b2bbe166d11199b540ceed0d0f7676e36e7b962b5a437a9971eac75"
+checksum = "8ca2734c16913a45343b37313605d84e7d8b34a4611598ce1d25b35860a2bed3"
 dependencies = [
  "base64-simd",
  "bytes",
@@ -2143,9 +2143,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-xml"
-version = "0.60.15"
+version = "0.60.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ce02add1aa3677d022f8adf81dcbe3046a95f17a1b1e8979c145cd21d3d22b3"
+checksum = "b53543b4b86ed43f051644f704a98c7291b3618b67adf057ee77a366fa52fcaa"
 dependencies = [
  "xmlparser",
 ]
@@ -3015,7 +3015,7 @@ dependencies = [
  "base-consensus-gossip",
  "base-macros",
  "base-protocol",
- "getrandom 0.4.2",
+ "getrandom 0.4.1",
  "ipnet",
  "jsonrpsee",
  "libp2p",
@@ -3696,7 +3696,7 @@ dependencies = [
  "reth-revm",
  "reth-transaction-pool",
  "reth-trie-common",
- "revm-bytecode 8.0.0",
+ "revm-bytecode",
  "revm-context-interface",
  "revm-database",
  "serde",
@@ -4226,6 +4226,7 @@ dependencies = [
  "base-test-utils",
  "c-kzg",
  "derive_more",
+ "futures",
  "jsonrpsee",
  "metrics",
  "parking_lot",
@@ -5407,9 +5408,9 @@ dependencies = [
 
 [[package]]
 name = "const-hex"
-version = "1.18.1"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "531185e432bb31db1ecda541e9e7ab21468d4d844ad7505e0546a49b4945d49b"
+checksum = "af9a108e542ddf1de36743a6126e94d6659dccda38fc8a77e80b915102ac784a"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -5949,7 +5950,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ab67060fc6b8ef687992d439ca0fa36e7ed17e9a0b16b25b601e8757df720de"
 dependencies = [
  "data-encoding",
- "syn 2.0.117",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -7222,7 +7223,7 @@ dependencies = [
  "log",
  "rustversion",
  "windows-link",
- "windows-result",
+ "windows-result 0.4.1",
 ]
 
 [[package]]
@@ -7279,21 +7280,21 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "r-efi 5.3.0",
+ "r-efi",
  "wasip2",
  "wasm-bindgen",
 ]
 
 [[package]]
 name = "getrandom"
-version = "0.4.2"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+checksum = "139ef39800118c7683f2fd3c98c1b23c09ae076556b435f8e9064ae108aaeeec"
 dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "r-efi 6.0.0",
+ "r-efi",
  "wasip2",
  "wasip3",
  "wasm-bindgen",
@@ -8014,7 +8015,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "socket2 0.6.2",
- "system-configuration",
+ "system-configuration 0.7.0",
  "tokio",
  "tower-layer",
  "tower-service",
@@ -8049,7 +8050,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -8185,6 +8186,16 @@ dependencies = [
 
 [[package]]
 name = "if-addrs"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cabb0019d51a643781ff15c9c8a3e5dedc365c47211270f4e8f82812fedd8f0a"
+dependencies = [
+ "libc",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "if-addrs"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf39cc0423ee66021dc5eccface85580e4a001e0c5288bae8bea7ecb69225e90"
@@ -8194,26 +8205,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "if-addrs"
-version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0a05c691e1fae256cf7013d99dad472dc52d5543322761f83ec8d47eab40d2b"
-dependencies = [
- "libc",
- "windows-sys 0.61.2",
-]
-
-[[package]]
 name = "if-watch"
-version = "3.2.2"
+version = "3.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71c02a5161c313f0cbdbadc511611893584a10a7b6153cb554bdf83ddce99ec2"
+checksum = "cdf9d64cfcf380606e64f9a0bcf493616b65331199f984151a6fa11a7b3cde38"
 dependencies = [
  "async-io",
  "core-foundation 0.9.4",
  "fnv",
  "futures",
- "if-addrs 0.15.0",
+ "if-addrs 0.10.2",
  "ipnet",
  "log",
  "netlink-packet-core",
@@ -8221,9 +8222,9 @@ dependencies = [
  "netlink-proto",
  "netlink-sys",
  "rtnetlink",
- "system-configuration",
+ "system-configuration 0.6.1",
  "tokio",
- "windows",
+ "windows 0.53.0",
 ]
 
 [[package]]
@@ -8462,7 +8463,7 @@ dependencies = [
  "p384",
  "p521",
  "rand_core 0.6.4",
- "rsa 0.10.0-rc.16",
+ "rsa 0.10.0-rc.15",
  "sec1",
  "sha1 0.10.6",
  "sha1 0.11.0-rc.5",
@@ -8513,9 +8514,9 @@ dependencies = [
 
 [[package]]
 name = "ipnet"
-version = "2.12.0"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
 dependencies = [
  "serde",
 ]
@@ -9764,7 +9765,7 @@ dependencies = [
  "once_cell",
  "procfs",
  "rlimit",
- "windows",
+ "windows 0.62.2",
 ]
 
 [[package]]
@@ -9886,9 +9887,9 @@ dependencies = [
 
 [[package]]
 name = "moka"
-version = "0.12.14"
+version = "0.12.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85f8024e1c8e71c778968af91d43700ce1d11b219d127d79fb2934153b82b42b"
+checksum = "b4ac832c50ced444ef6be0767a008b02c106a909ba79d1d830501e94b96f6b7e"
 dependencies = [
  "async-lock",
  "crossbeam-channel",
@@ -10003,30 +10004,46 @@ dependencies = [
 
 [[package]]
 name = "netlink-packet-core"
-version = "0.8.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3463cbb78394cb0141e2c926b93fc2197e473394b761986eca3b9da2c63ae0f4"
+checksum = "72724faf704479d67b388da142b186f916188505e7e0b26719019c525882eda4"
 dependencies = [
- "paste",
+ "anyhow",
+ "byteorder",
+ "netlink-packet-utils",
 ]
 
 [[package]]
 name = "netlink-packet-route"
-version = "0.28.0"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ce3636fa715e988114552619582b530481fd5ef176a1e5c1bf024077c2c9445"
+checksum = "053998cea5a306971f88580d0829e90f270f940befd7cf928da179d4187a5a66"
 dependencies = [
- "bitflags 2.11.0",
+ "anyhow",
+ "bitflags 1.3.2",
+ "byteorder",
  "libc",
- "log",
  "netlink-packet-core",
+ "netlink-packet-utils",
+]
+
+[[package]]
+name = "netlink-packet-utils"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ede8a08c71ad5a95cdd0e4e52facd37190977039a4704eb82a283f713747d34"
+dependencies = [
+ "anyhow",
+ "byteorder",
+ "paste",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
 name = "netlink-proto"
-version = "0.12.0"
+version = "0.11.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b65d130ee111430e47eed7896ea43ca693c387f097dd97376bffafbf25812128"
+checksum = "72452e012c2f8d612410d89eea01e2d9b56205274abb35d53f60200b2ec41d60"
 dependencies = [
  "bytes",
  "futures",
@@ -10080,18 +10097,6 @@ name = "nix"
 version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
-dependencies = [
- "bitflags 2.11.0",
- "cfg-if",
- "cfg_aliases",
- "libc",
-]
-
-[[package]]
-name = "nix"
-version = "0.31.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d6d0705320c1e6ba1d912b5e37cf18071b6c2e9b7fa8215a1e8a7651966f5d3"
 dependencies = [
  "bitflags 2.11.0",
  "cfg-if",
@@ -10801,7 +10806,7 @@ dependencies = [
  "sha2 0.10.9",
  "thiserror 1.0.69",
  "tokio",
- "windows",
+ "windows 0.62.2",
  "windows-strings",
 ]
 
@@ -11573,9 +11578,12 @@ dependencies = [
 
 [[package]]
 name = "pxfm"
-version = "0.1.28"
+version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5a041e753da8b807c9255f28de81879c78c876392ff2469cde94799b2896b9d"
+checksum = "7186d3822593aa4393561d186d1393b3923e9d6163d3fbfd6e825e3e6cf3e6a8"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "quanta"
@@ -11685,9 +11693,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.45"
+version = "1.0.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
+checksum = "21b2ebcf727b7760c461f091f9f0f539b77b8e87f2fd88131e7f1b433b3cece4"
 dependencies = [
  "proc-macro2",
 ]
@@ -11697,12 +11705,6 @@ name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
-
-[[package]]
-name = "r-efi"
-version = "6.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "radium"
@@ -12225,7 +12227,7 @@ dependencies = [
  "reth-storage-api",
  "reth-trie",
  "revm-database",
- "revm-state 9.0.0",
+ "revm-state",
  "serde",
  "tokio",
  "tokio-stream",
@@ -13344,7 +13346,7 @@ dependencies = [
  "reth-tracing",
  "reth-trie",
  "revm",
- "revm-bytecode 8.0.0",
+ "revm-bytecode",
  "revm-database",
  "serde",
  "serde_json",
@@ -13976,9 +13978,9 @@ dependencies = [
  "proptest-arbitrary-interop",
  "rayon",
  "reth-codecs",
- "revm-bytecode 8.0.0",
+ "revm-bytecode",
  "revm-primitives",
- "revm-state 9.0.0",
+ "revm-state",
  "secp256k1 0.30.0",
  "serde",
  "serde_with",
@@ -14023,7 +14025,7 @@ dependencies = [
  "reth-trie",
  "reth-trie-db",
  "revm-database",
- "revm-state 9.0.0",
+ "revm-state",
  "rocksdb",
  "strum 0.27.2",
  "tokio",
@@ -14572,7 +14574,7 @@ dependencies = [
  "reth-prune-types",
  "reth-static-file-types",
  "revm-database-interface",
- "revm-state 9.0.0",
+ "revm-state",
  "thiserror 2.0.18",
 ]
 
@@ -14832,7 +14834,7 @@ version = "34.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2aabdebaa535b3575231a88d72b642897ae8106cf6b0d12eafc6bfdf50abfc7"
 dependencies = [
- "revm-bytecode 8.0.0",
+ "revm-bytecode",
  "revm-context",
  "revm-context-interface",
  "revm-database",
@@ -14842,7 +14844,7 @@ dependencies = [
  "revm-interpreter",
  "revm-precompile",
  "revm-primitives",
- "revm-state 9.0.0",
+ "revm-state",
 ]
 
 [[package]]
@@ -14850,18 +14852,6 @@ name = "revm-bytecode"
 version = "8.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74d1e5c1eaa44d39d537f668bc5c3409dc01e5c8be954da6c83370bbdf006457"
-dependencies = [
- "bitvec",
- "phf 0.13.1",
- "revm-primitives",
- "serde",
-]
-
-[[package]]
-name = "revm-bytecode"
-version = "9.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e86e468df3cf5cf59fa7ef71a3e9ccabb76bb336401ea2c0674f563104cf3c5e"
 dependencies = [
  "bitvec",
  "phf 0.13.1",
@@ -14878,11 +14868,11 @@ dependencies = [
  "bitvec",
  "cfg-if",
  "derive-where",
- "revm-bytecode 8.0.0",
+ "revm-bytecode",
  "revm-context-interface",
  "revm-database-interface",
  "revm-primitives",
- "revm-state 9.0.0",
+ "revm-state",
  "serde",
 ]
 
@@ -14898,7 +14888,7 @@ dependencies = [
  "either",
  "revm-database-interface",
  "revm-primitives",
- "revm-state 9.0.0",
+ "revm-state",
  "serde",
 ]
 
@@ -14909,23 +14899,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "529528d0b05fe646be86223032c3e77aa8b05caa2a35447d538c55965956a511"
 dependencies = [
  "alloy-eips",
- "revm-bytecode 8.0.0",
+ "revm-bytecode",
  "revm-database-interface",
  "revm-primitives",
- "revm-state 9.0.0",
+ "revm-state",
  "serde",
 ]
 
 [[package]]
 name = "revm-database-interface"
-version = "9.0.1"
+version = "9.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bc1da862c71ba380b0e2ee0b19b186e282f931ba4f479dfbc83903294a5e596"
+checksum = "b7bf93ac5b91347c057610c0d96e923db8c62807e03f036762d03e981feddc1d"
 dependencies = [
  "auto_impl",
  "either",
  "revm-primitives",
- "revm-state 10.0.0",
+ "revm-state",
  "serde",
  "thiserror 2.0.18",
 ]
@@ -14938,14 +14928,14 @@ checksum = "0cd0e43e815a85eded249df886c4badec869195e70cdd808a13cfca2794622d2"
 dependencies = [
  "auto_impl",
  "derive-where",
- "revm-bytecode 8.0.0",
+ "revm-bytecode",
  "revm-context",
  "revm-context-interface",
  "revm-database-interface",
  "revm-interpreter",
  "revm-precompile",
  "revm-primitives",
- "revm-state 9.0.0",
+ "revm-state",
  "serde",
 ]
 
@@ -14962,7 +14952,7 @@ dependencies = [
  "revm-handler",
  "revm-interpreter",
  "revm-primitives",
- "revm-state 9.0.0",
+ "revm-state",
  "serde",
  "serde_json",
 ]
@@ -14993,18 +14983,18 @@ version = "32.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11406408597bc249392d39295831c4b641b3a6f5c471a7c41104a7a1e3564c07"
 dependencies = [
- "revm-bytecode 8.0.0",
+ "revm-bytecode",
  "revm-context-interface",
  "revm-primitives",
- "revm-state 9.0.0",
+ "revm-state",
  "serde",
 ]
 
 [[package]]
 name = "revm-precompile"
-version = "32.1.0"
+version = "32.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2ec11f45deec71e4945e1809736bb20d454285f9167ab53c5159dae1deb603f"
+checksum = "50c1285c848d240678bf69cb0f6179ff5a4aee6fc8e921d89708087197a0aff3"
 dependencies = [
  "ark-bls12-381",
  "ark-bn254",
@@ -15027,9 +15017,9 @@ dependencies = [
 
 [[package]]
 name = "revm-primitives"
-version = "22.1.0"
+version = "22.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bcfb5ce6cf18b118932bcdb7da05cd9c250f2cb9f64131396b55f3fe3537c35"
+checksum = "ba580c56a8ec824a64f8a1683577876c2e1dbe5247044199e9b881421ad5dcf9"
 dependencies = [
  "alloy-primitives",
  "num_enum",
@@ -15045,20 +15035,7 @@ checksum = "311720d4f0f239b041375e7ddafdbd20032a33b7bae718562ea188e188ed9fd3"
 dependencies = [
  "alloy-eip7928",
  "bitflags 2.11.0",
- "revm-bytecode 8.0.0",
- "revm-primitives",
- "serde",
-]
-
-[[package]]
-name = "revm-state"
-version = "10.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d29404707763da607e5d6e4771cb203998c28159279c2f64cc32de08d2814651"
-dependencies = [
- "alloy-eip7928",
- "bitflags 2.11.0",
- "revm-bytecode 9.0.0",
+ "revm-bytecode",
  "revm-primitives",
  "serde",
 ]
@@ -15198,9 +15175,9 @@ dependencies = [
 
 [[package]]
 name = "rsa"
-version = "0.10.0-rc.16"
+version = "0.10.0-rc.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fb9fd8c1edd9e6a2693623baf0fe77ff05ce022a5d7746900ffc38a15c233de"
+checksum = "1b342b99544549f37509ed7fd42b0cea04bfd9ce07c16ca56094cf0fbeefbbcd"
 dependencies = [
  "const-oid 0.10.2",
  "crypto-bigint 0.7.0-rc.28",
@@ -15245,18 +15222,18 @@ dependencies = [
 
 [[package]]
 name = "rtnetlink"
-version = "0.20.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b960d5d873a75b5be9761b1e73b146f52dddcd27bac75263f40fba686d4d7b5"
+checksum = "7a552eb82d19f38c3beed3f786bd23aa434ceb9ac43ab44419ca6d67a7e186c0"
 dependencies = [
- "futures-channel",
- "futures-util",
+ "futures",
  "log",
  "netlink-packet-core",
  "netlink-packet-route",
+ "netlink-packet-utils",
  "netlink-proto",
  "netlink-sys",
- "nix 0.30.1",
+ "nix 0.26.4",
  "thiserror 1.0.69",
  "tokio",
 ]
@@ -16253,9 +16230,9 @@ checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
 
 [[package]]
 name = "sketches-ddsketch"
-version = "0.3.1"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c6f73aeb92d671e0cc4dca167e59b2deb6387c375391bc99ee743f326994a2b"
+checksum = "c1e9a774a6c28142ac54bb25d25562e6bcf957493a184f15ad4eebccb23e410a"
 
 [[package]]
 name = "slab"
@@ -16578,7 +16555,18 @@ dependencies = [
  "ntapi",
  "objc2-core-foundation",
  "objc2-io-kit",
- "windows",
+ "windows 0.62.2",
+]
+
+[[package]]
+name = "system-configuration"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
+dependencies = [
+ "bitflags 2.11.0",
+ "core-foundation 0.9.4",
+ "system-configuration-sys",
 ]
 
 [[package]]
@@ -16647,7 +16635,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "82a72c767771b47409d2345987fda8628641887d5466101319899796367354a0"
 dependencies = [
  "fastrand",
- "getrandom 0.4.2",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
@@ -16998,9 +16986,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.50.0"
+version = "1.49.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
+checksum = "72a2903cd7736441aac9df9d7688bd0ce48edccaadf181c3b90be801e81d3d86"
 dependencies = [
  "bytes",
  "libc",
@@ -17015,9 +17003,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.6.1"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
+checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -17779,7 +17767,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b672338555252d43fd2240c714dc444b8c6fb0a5c5335e65a07bba7742735ddb"
 dependencies = [
  "atomic",
- "getrandom 0.4.2",
+ "getrandom 0.4.1",
  "js-sys",
  "serde_core",
  "sha1_smol",
@@ -17870,12 +17858,12 @@ checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
 
 [[package]]
 name = "vsock"
-version = "0.5.3"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b82aeb12ad864eb8cd26a6c21175d0bdc66d398584ee6c93c76964c3bcfc78ff"
+checksum = "e2da6e4ac76cd19635dce0f98985378bb62f8044ee2ff80abd2a7334b920ed63"
 dependencies = [
  "libc",
- "nix 0.31.2",
+ "nix 0.30.1",
 ]
 
 [[package]]
@@ -18272,12 +18260,22 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "efc5cf48f83140dcaab716eeaea345f9e93d0018fb81162753a3f76c3397b538"
+dependencies = [
+ "windows-core 0.53.0",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows"
 version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
 dependencies = [
  "windows-collections",
- "windows-core",
+ "windows-core 0.62.2",
  "windows-future",
  "windows-numerics",
 ]
@@ -18288,7 +18286,17 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
 dependencies = [
- "windows-core",
+ "windows-core 0.62.2",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dcc5b895a6377f1ab9fa55acedab1fd5ac0db66ad1e6c7f47e28a22e446a5dd"
+dependencies = [
+ "windows-result 0.1.2",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -18300,7 +18308,7 @@ dependencies = [
  "windows-implement",
  "windows-interface",
  "windows-link",
- "windows-result",
+ "windows-result 0.4.1",
  "windows-strings",
 ]
 
@@ -18310,7 +18318,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
 dependencies = [
- "windows-core",
+ "windows-core 0.62.2",
  "windows-link",
  "windows-threading",
 ]
@@ -18349,7 +18357,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
 dependencies = [
- "windows-core",
+ "windows-core 0.62.2",
  "windows-link",
 ]
 
@@ -18360,8 +18368,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
 dependencies = [
  "windows-link",
- "windows-result",
+ "windows-result 0.4.1",
  "windows-strings",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e383302e8ec8515204254685643de10811af0ed97ea37210dc26fb0032647f8"
+dependencies = [
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -19119,9 +19136,9 @@ dependencies = [
 
 [[package]]
 name = "zip"
-version = "8.2.0"
+version = "8.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b680f2a0cd479b4cff6e1233c483fdead418106eae419dc60200ae9850f6d004"
+checksum = "6e499faf5c6b97a0d086f4a8733de6d47aee2252b8127962439d8d4311a73f72"
 dependencies = [
  "crc32fast",
  "flate2",
@@ -19133,9 +19150,9 @@ dependencies = [
 
 [[package]]
 name = "zlib-rs"
-version = "0.6.3"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3be3d40e40a133f9c916ee3f9f4fa2d9d63435b5fbe1bfc6d9dae0aa0ada1513"
+checksum = "c745c48e1007337ed136dc99df34128b9faa6ed542d80a1c673cf55a6d7236c8"
 
 [[package]]
 name = "zmij"

--- a/crates/txpool/Cargo.toml
+++ b/crates/txpool/Cargo.toml
@@ -37,13 +37,16 @@ base-execution-forks.workspace = true
 base-execution-primitives.workspace = true
 
 # misc
+serde.workspace = true
 c-kzg.workspace = true
+serde_json.workspace = true
 metrics.workspace = true
 tracing.workspace = true
 derive_more.workspace = true
 parking_lot.workspace = true
 tokio-util.workspace = true
-tokio = { workspace = true, features = ["sync", "rt"] }
+tokio = { workspace = true, features = ["sync", "rt", "time"] }
+jsonrpsee = { workspace = true, features = ["http-client"] }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["time", "rt-multi-thread", "macros"] }

--- a/crates/txpool/Cargo.toml
+++ b/crates/txpool/Cargo.toml
@@ -40,6 +40,7 @@ base-execution-primitives.workspace = true
 serde.workspace = true
 c-kzg.workspace = true
 metrics.workspace = true
+futures.workspace = true
 tracing.workspace = true
 tokio-util.workspace = true
 serde_json.workspace = true

--- a/crates/txpool/Cargo.toml
+++ b/crates/txpool/Cargo.toml
@@ -39,12 +39,12 @@ base-execution-primitives.workspace = true
 # misc
 serde.workspace = true
 c-kzg.workspace = true
-serde_json.workspace = true
 metrics.workspace = true
 tracing.workspace = true
+tokio-util.workspace = true
+serde_json.workspace = true
 derive_more.workspace = true
 parking_lot.workspace = true
-tokio-util.workspace = true
 tokio = { workspace = true, features = ["sync", "rt", "time"] }
 jsonrpsee = { workspace = true, features = ["http-client"] }
 

--- a/crates/txpool/Cargo.toml
+++ b/crates/txpool/Cargo.toml
@@ -43,11 +43,12 @@ c-kzg.workspace = true
 metrics.workspace = true
 futures.workspace = true
 tracing.workspace = true
+async-trait.workspace = true
 tokio-util.workspace = true
 derive_more.workspace = true
 parking_lot.workspace = true
 tokio = { workspace = true, features = ["sync", "rt", "time"] }
-jsonrpsee = { workspace = true, features = ["http-client", "macros"] }
+jsonrpsee = { workspace = true, features = ["http-client", "server", "macros"] }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["time", "rt-multi-thread", "macros"] }

--- a/crates/txpool/Cargo.toml
+++ b/crates/txpool/Cargo.toml
@@ -37,17 +37,17 @@ base-execution-forks.workspace = true
 base-execution-primitives.workspace = true
 
 # misc
+url.workspace = true
 serde.workspace = true
 c-kzg.workspace = true
 metrics.workspace = true
 futures.workspace = true
 tracing.workspace = true
 tokio-util.workspace = true
-serde_json.workspace = true
 derive_more.workspace = true
 parking_lot.workspace = true
 tokio = { workspace = true, features = ["sync", "rt", "time"] }
-jsonrpsee = { workspace = true, features = ["http-client"] }
+jsonrpsee = { workspace = true, features = ["http-client", "macros"] }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["time", "rt-multi-thread", "macros"] }

--- a/crates/txpool/src/forwarder/config.rs
+++ b/crates/txpool/src/forwarder/config.rs
@@ -21,6 +21,8 @@ pub struct ForwarderConfig {
     pub max_retries: u32,
     /// Base delay between retries (doubles each attempt).
     pub retry_backoff: Duration,
+    /// Per-request timeout for the HTTP client.
+    pub request_timeout: Duration,
 }
 
 impl Default for ForwarderConfig {
@@ -31,6 +33,7 @@ impl Default for ForwarderConfig {
             max_batch_size: 500,
             max_retries: 3,
             retry_backoff: Duration::from_millis(100),
+            request_timeout: Duration::from_secs(1),
         }
     }
 }
@@ -65,6 +68,12 @@ impl ForwarderConfig {
         self.retry_backoff = backoff;
         self
     }
+
+    /// Sets the per-request HTTP timeout.
+    pub const fn with_request_timeout(mut self, timeout: Duration) -> Self {
+        self.request_timeout = timeout;
+        self
+    }
 }
 
 #[cfg(test)]
@@ -79,6 +88,7 @@ mod tests {
         assert_eq!(config.max_batch_size, 500);
         assert_eq!(config.max_retries, 3);
         assert_eq!(config.retry_backoff, Duration::from_millis(100));
+        assert_eq!(config.request_timeout, Duration::from_secs(1));
     }
 
     #[test]
@@ -89,13 +99,15 @@ mod tests {
             .with_max_rps(500)
             .with_max_batch_size(200)
             .with_max_retries(5)
-            .with_retry_backoff(Duration::from_millis(250));
+            .with_retry_backoff(Duration::from_millis(250))
+            .with_request_timeout(Duration::from_millis(500));
 
         assert_eq!(config.builder_urls, vec![url]);
         assert_eq!(config.max_rps, 500);
         assert_eq!(config.max_batch_size, 200);
         assert_eq!(config.max_retries, 5);
         assert_eq!(config.retry_backoff, Duration::from_millis(250));
+        assert_eq!(config.request_timeout, Duration::from_millis(500));
     }
 
     #[test]

--- a/crates/txpool/src/forwarder/config.rs
+++ b/crates/txpool/src/forwarder/config.rs
@@ -1,5 +1,7 @@
 use std::time::Duration;
 
+use url::Url;
+
 /// Configuration for the transaction forwarder.
 ///
 /// One forwarder is spawned per builder URL. Each subscribes to the consumer's
@@ -10,7 +12,7 @@ use std::time::Duration;
 #[derive(Debug, Clone)]
 pub struct ForwarderConfig {
     /// Builder RPC endpoint URLs — one forwarder task per URL.
-    pub builder_urls: Vec<String>,
+    pub builder_urls: Vec<Url>,
     /// Maximum RPC requests per second per forwarder (sliding window). 0 = unlimited.
     pub max_rps: u32,
     /// Maximum transactions per RPC request. 0 = unlimited.
@@ -35,7 +37,7 @@ impl Default for ForwarderConfig {
 
 impl ForwarderConfig {
     /// Sets the builder URLs.
-    pub fn with_builder_urls(mut self, urls: Vec<String>) -> Self {
+    pub fn with_builder_urls(mut self, urls: Vec<Url>) -> Self {
         self.builder_urls = urls;
         self
     }
@@ -81,14 +83,15 @@ mod tests {
 
     #[test]
     fn builder_methods() {
+        let url: Url = "http://builder1:8545".parse().unwrap();
         let config = ForwarderConfig::default()
-            .with_builder_urls(vec!["http://builder1:8545".into()])
+            .with_builder_urls(vec![url.clone()])
             .with_max_rps(500)
             .with_max_batch_size(200)
             .with_max_retries(5)
             .with_retry_backoff(Duration::from_millis(250));
 
-        assert_eq!(config.builder_urls, vec!["http://builder1:8545"]);
+        assert_eq!(config.builder_urls, vec![url]);
         assert_eq!(config.max_rps, 500);
         assert_eq!(config.max_batch_size, 200);
         assert_eq!(config.max_retries, 5);

--- a/crates/txpool/src/forwarder/config.rs
+++ b/crates/txpool/src/forwarder/config.rs
@@ -11,9 +11,9 @@ use std::time::Duration;
 pub struct ForwarderConfig {
     /// Builder RPC endpoint URLs — one forwarder task per URL.
     pub builder_urls: Vec<String>,
-    /// Maximum RPC requests per second per forwarder (sliding window).
+    /// Maximum RPC requests per second per forwarder (sliding window). 0 = unlimited.
     pub max_rps: u32,
-    /// Maximum transactions per RPC request (safety cap).
+    /// Maximum transactions per RPC request. 0 = unlimited.
     pub max_batch_size: usize,
     /// Maximum RPC send retries before dropping a batch.
     pub max_retries: u32,
@@ -93,5 +93,12 @@ mod tests {
         assert_eq!(config.max_batch_size, 200);
         assert_eq!(config.max_retries, 5);
         assert_eq!(config.retry_backoff, Duration::from_millis(250));
+    }
+
+    #[test]
+    fn zero_means_unlimited() {
+        let config = ForwarderConfig::default().with_max_rps(0).with_max_batch_size(0);
+        assert_eq!(config.max_rps, 0);
+        assert_eq!(config.max_batch_size, 0);
     }
 }

--- a/crates/txpool/src/forwarder/config.rs
+++ b/crates/txpool/src/forwarder/config.rs
@@ -1,0 +1,97 @@
+use std::time::Duration;
+
+/// Configuration for the transaction forwarder.
+///
+/// One forwarder is spawned per builder URL. Each subscribes to the consumer's
+/// broadcast channel and forwards transactions via `base_insertValidatedTransactions`.
+/// Under normal load, transactions are sent immediately (batch of 1). When the
+/// sliding window rate limit is hit, incoming transactions buffer and flush as
+/// a single batch once the window opens.
+#[derive(Debug, Clone)]
+pub struct ForwarderConfig {
+    /// Builder RPC endpoint URLs — one forwarder task per URL.
+    pub builder_urls: Vec<String>,
+    /// Maximum RPC requests per second per forwarder (sliding window).
+    pub max_rps: u32,
+    /// Maximum transactions per RPC request (safety cap).
+    pub max_batch_size: usize,
+    /// Maximum RPC send retries before dropping a batch.
+    pub max_retries: u32,
+    /// Base delay between retries (doubles each attempt).
+    pub retry_backoff: Duration,
+}
+
+impl Default for ForwarderConfig {
+    fn default() -> Self {
+        Self {
+            builder_urls: Vec::new(),
+            max_rps: 200,
+            max_batch_size: 500,
+            max_retries: 3,
+            retry_backoff: Duration::from_millis(100),
+        }
+    }
+}
+
+impl ForwarderConfig {
+    /// Sets the builder URLs.
+    pub fn with_builder_urls(mut self, urls: Vec<String>) -> Self {
+        self.builder_urls = urls;
+        self
+    }
+
+    /// Sets the maximum RPC requests per second.
+    pub const fn with_max_rps(mut self, rps: u32) -> Self {
+        self.max_rps = rps;
+        self
+    }
+
+    /// Sets the maximum batch size per request.
+    pub const fn with_max_batch_size(mut self, size: usize) -> Self {
+        self.max_batch_size = size;
+        self
+    }
+
+    /// Sets the max retries.
+    pub const fn with_max_retries(mut self, retries: u32) -> Self {
+        self.max_retries = retries;
+        self
+    }
+
+    /// Sets the retry backoff.
+    pub const fn with_retry_backoff(mut self, backoff: Duration) -> Self {
+        self.retry_backoff = backoff;
+        self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn defaults() {
+        let config = ForwarderConfig::default();
+        assert!(config.builder_urls.is_empty());
+        assert_eq!(config.max_rps, 200);
+        assert_eq!(config.max_batch_size, 500);
+        assert_eq!(config.max_retries, 3);
+        assert_eq!(config.retry_backoff, Duration::from_millis(100));
+    }
+
+    #[test]
+    fn builder_methods() {
+        let config = ForwarderConfig::default()
+            .with_builder_urls(vec!["http://builder1:8545".into()])
+            .with_max_rps(500)
+            .with_max_batch_size(200)
+            .with_max_retries(5)
+            .with_retry_backoff(Duration::from_millis(250));
+
+        assert_eq!(config.builder_urls, vec!["http://builder1:8545"]);
+        assert_eq!(config.max_rps, 500);
+        assert_eq!(config.max_batch_size, 200);
+        assert_eq!(config.max_retries, 5);
+        assert_eq!(config.retry_backoff, Duration::from_millis(250));
+    }
+}

--- a/crates/txpool/src/forwarder/metrics.rs
+++ b/crates/txpool/src/forwarder/metrics.rs
@@ -9,9 +9,11 @@ pub struct ForwarderMetrics {
     pub txs_forwarded: Counter,
     /// Total RPC send errors (after all retries exhausted).
     pub rpc_errors: Counter,
-    /// Total batches dropped due to lagged broadcast receiver.
+    /// Total lag events from the broadcast receiver.
     pub batches_lagged: Counter,
-    /// RPC round-trip latency in seconds.
+    /// Total individual transactions skipped due to lag.
+    pub txs_lagged: Counter,
+    /// RPC round-trip latency in seconds (including retries).
     pub rpc_latency: Histogram,
 }
 
@@ -24,6 +26,7 @@ impl ForwarderMetrics {
             txs_forwarded: counter!("txpool.forwarder.txs_forwarded", labels.clone()),
             rpc_errors: counter!("txpool.forwarder.rpc_errors", labels.clone()),
             batches_lagged: counter!("txpool.forwarder.batches_lagged", labels.clone()),
+            txs_lagged: counter!("txpool.forwarder.txs_lagged", labels.clone()),
             rpc_latency: histogram!("txpool.forwarder.rpc_latency", labels),
         }
     }

--- a/crates/txpool/src/forwarder/metrics.rs
+++ b/crates/txpool/src/forwarder/metrics.rs
@@ -1,11 +1,7 @@
-use reth_metrics::{
-    Metrics,
-    metrics::{Counter, Histogram},
-};
+use metrics::{Counter, Histogram, Label, counter, histogram};
 
-/// Prometheus metrics for a single forwarder instance.
-#[derive(Metrics, Clone)]
-#[metrics(scope = "txpool.forwarder")]
+/// Prometheus metrics for a single forwarder instance, labeled by builder URL.
+#[derive(Clone)]
 pub struct ForwarderMetrics {
     /// Total RPC batches sent successfully.
     pub batches_sent: Counter,
@@ -17,4 +13,24 @@ pub struct ForwarderMetrics {
     pub batches_lagged: Counter,
     /// RPC round-trip latency in seconds.
     pub rpc_latency: Histogram,
+}
+
+impl ForwarderMetrics {
+    /// Creates metrics labeled with the given builder URL.
+    pub fn new(builder_url: &str) -> Self {
+        let labels = vec![Label::new("builder_url", builder_url.to_string())];
+        Self {
+            batches_sent: counter!("txpool.forwarder.batches_sent", labels.clone()),
+            txs_forwarded: counter!("txpool.forwarder.txs_forwarded", labels.clone()),
+            rpc_errors: counter!("txpool.forwarder.rpc_errors", labels.clone()),
+            batches_lagged: counter!("txpool.forwarder.batches_lagged", labels.clone()),
+            rpc_latency: histogram!("txpool.forwarder.rpc_latency", labels),
+        }
+    }
+}
+
+impl std::fmt::Debug for ForwarderMetrics {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ForwarderMetrics").finish_non_exhaustive()
+    }
 }

--- a/crates/txpool/src/forwarder/metrics.rs
+++ b/crates/txpool/src/forwarder/metrics.rs
@@ -1,0 +1,20 @@
+use reth_metrics::{
+    Metrics,
+    metrics::{Counter, Histogram},
+};
+
+/// Prometheus metrics for a single forwarder instance.
+#[derive(Metrics, Clone)]
+#[metrics(scope = "txpool.forwarder")]
+pub struct ForwarderMetrics {
+    /// Total RPC batches sent successfully.
+    pub batches_sent: Counter,
+    /// Total individual transactions forwarded.
+    pub txs_forwarded: Counter,
+    /// Total RPC send errors (after all retries exhausted).
+    pub rpc_errors: Counter,
+    /// Total batches dropped due to lagged broadcast receiver.
+    pub batches_lagged: Counter,
+    /// RPC round-trip latency in seconds.
+    pub rpc_latency: Histogram,
+}

--- a/crates/txpool/src/forwarder/metrics.rs
+++ b/crates/txpool/src/forwarder/metrics.rs
@@ -1,4 +1,4 @@
-use metrics::{Counter, Histogram, Label, counter, histogram};
+use metrics::{Counter, Gauge, Histogram, Label, counter, gauge, histogram};
 
 /// Prometheus metrics for a single forwarder instance, labeled by builder URL.
 #[derive(Clone)]
@@ -15,6 +15,8 @@ pub struct ForwarderMetrics {
     pub txs_lagged: Counter,
     /// RPC round-trip latency in seconds (including retries).
     pub rpc_latency: Histogram,
+    /// Current number of transactions buffered and awaiting send.
+    pub buffer_size: Gauge,
 }
 
 impl ForwarderMetrics {
@@ -27,7 +29,8 @@ impl ForwarderMetrics {
             rpc_errors: counter!("txpool.forwarder.rpc_errors", labels.clone()),
             batches_lagged: counter!("txpool.forwarder.batches_lagged", labels.clone()),
             txs_lagged: counter!("txpool.forwarder.txs_lagged", labels.clone()),
-            rpc_latency: histogram!("txpool.forwarder.rpc_latency", labels),
+            rpc_latency: histogram!("txpool.forwarder.rpc_latency", labels.clone()),
+            buffer_size: gauge!("txpool.forwarder.buffer_size", labels),
         }
     }
 }

--- a/crates/txpool/src/forwarder/mod.rs
+++ b/crates/txpool/src/forwarder/mod.rs
@@ -39,7 +39,10 @@ impl ForwarderHandle {
         let mut tasks = Vec::with_capacity(config.builder_urls.len());
 
         for url in &config.builder_urls {
-            let client = match HttpClientBuilder::default().build(url) {
+            let client = match HttpClientBuilder::default()
+                .request_timeout(Duration::from_secs(5))
+                .build(url)
+            {
                 Ok(client) => client,
                 Err(err) => {
                     error!(

--- a/crates/txpool/src/forwarder/mod.rs
+++ b/crates/txpool/src/forwarder/mod.rs
@@ -12,6 +12,9 @@ pub use config::ForwarderConfig;
 mod metrics;
 pub use metrics::ForwarderMetrics;
 
+mod rpc;
+pub use rpc::{BuilderApiClient, BuilderApiServer};
+
 mod task;
 pub use task::{Forwarder, ValidTransaction};
 
@@ -37,11 +40,12 @@ impl ForwarderHandle {
     {
         let cancel = CancellationToken::new();
         let mut tasks = Vec::with_capacity(config.builder_urls.len());
+        let config = Arc::new(config);
 
         for url in &config.builder_urls {
             let client = match HttpClientBuilder::default()
                 .request_timeout(Duration::from_secs(5))
-                .build(url)
+                .build(url.as_str())
             {
                 Ok(client) => client,
                 Err(err) => {
@@ -55,12 +59,12 @@ impl ForwarderHandle {
             };
 
             let receiver = sender.subscribe();
-            let metrics = ForwarderMetrics::new(url);
+            let metrics = ForwarderMetrics::new(url.as_str());
             let forwarder = Forwarder::new(
                 url.clone(),
                 client,
                 receiver,
-                config.clone(),
+                Arc::clone(&config),
                 metrics,
                 cancel.child_token(),
             );
@@ -84,17 +88,17 @@ impl ForwarderHandle {
 impl ForwarderHandle {
     /// Gracefully shuts down all forwarder tasks.
     ///
-    /// Signals cancellation and waits up to 5 seconds for in-flight RPC
-    /// requests to complete before abandoning them.
+    /// Signals cancellation and waits up to 30 seconds for each forwarder to
+    /// drain its buffer and complete in-flight RPC requests.
     pub async fn shutdown(mut self) {
         self.cancel.cancel();
 
         let tasks = std::mem::take(&mut self.tasks);
-        let results =
-            tokio::time::timeout(Duration::from_secs(30), futures::future::join_all(tasks)).await;
-
-        if let Err(err) = results {
-            warn!(error = %err, "forwarder tasks did not finish within shutdown timeout");
+        if tokio::time::timeout(Duration::from_secs(30), futures::future::join_all(tasks))
+            .await
+            .is_err()
+        {
+            warn!("forwarder tasks did not finish within shutdown timeout");
         }
     }
 }

--- a/crates/txpool/src/forwarder/mod.rs
+++ b/crates/txpool/src/forwarder/mod.rs
@@ -22,6 +22,7 @@ pub use task::{Forwarder, ValidTransaction};
 ///
 /// Cancels all forwarder tasks on drop. For a clean shutdown that waits for
 /// in-flight RPC requests to complete, use [`ForwarderHandle::shutdown`].
+#[must_use = "dropping the handle cancels all forwarder tasks without draining buffers — call shutdown() for graceful termination"]
 pub struct ForwarderHandle {
     cancel: CancellationToken,
     tasks: Vec<tokio::task::JoinHandle<()>>,

--- a/crates/txpool/src/forwarder/mod.rs
+++ b/crates/txpool/src/forwarder/mod.rs
@@ -4,7 +4,7 @@ use jsonrpsee::http_client::HttpClientBuilder;
 use reth_transaction_pool::{PoolTransaction, ValidPoolTransaction};
 use tokio::sync::broadcast;
 use tokio_util::sync::CancellationToken;
-use tracing::{error, info};
+use tracing::{error, info, warn};
 
 mod config;
 pub use config::ForwarderConfig;
@@ -67,6 +67,10 @@ impl ForwarderHandle {
 
             info!(builder_url = %url, "spawned transaction forwarder");
             tasks.push(handle);
+        }
+
+        if tasks.is_empty() {
+            warn!("no forwarder tasks spawned — check builder_urls config");
         }
 
         Self { cancel, _tasks: tasks }

--- a/crates/txpool/src/forwarder/mod.rs
+++ b/crates/txpool/src/forwarder/mod.rs
@@ -51,7 +51,7 @@ impl ForwarderHandle {
             };
 
             let receiver = sender.subscribe();
-            let metrics = ForwarderMetrics::default();
+            let metrics = ForwarderMetrics::new(url);
             let forwarder = Forwarder::new(
                 url.clone(),
                 client,

--- a/crates/txpool/src/forwarder/mod.rs
+++ b/crates/txpool/src/forwarder/mod.rs
@@ -89,10 +89,12 @@ impl ForwarderHandle {
     pub async fn shutdown(mut self) {
         self.cancel.cancel();
 
-        for task in std::mem::take(&mut self.tasks) {
-            if let Err(err) = tokio::time::timeout(Duration::from_secs(5), task).await {
-                warn!(error = %err, "forwarder task did not finish within shutdown timeout");
-            }
+        let tasks = std::mem::take(&mut self.tasks);
+        let results =
+            tokio::time::timeout(Duration::from_secs(5), futures::future::join_all(tasks)).await;
+
+        if let Err(err) = results {
+            warn!(error = %err, "forwarder tasks did not finish within shutdown timeout");
         }
     }
 }

--- a/crates/txpool/src/forwarder/mod.rs
+++ b/crates/txpool/src/forwarder/mod.rs
@@ -44,7 +44,7 @@ impl ForwarderHandle {
 
         for url in &config.builder_urls {
             let client = match HttpClientBuilder::default()
-                .request_timeout(Duration::from_secs(5))
+                .request_timeout(config.request_timeout)
                 .build(url.as_str())
             {
                 Ok(client) => client,

--- a/crates/txpool/src/forwarder/mod.rs
+++ b/crates/txpool/src/forwarder/mod.rs
@@ -13,7 +13,7 @@ mod metrics;
 pub use metrics::ForwarderMetrics;
 
 mod rpc;
-pub use rpc::{BuilderApiClient, BuilderApiServer};
+pub use rpc::{BuilderApiClient, BuilderApiHandler, BuilderApiServer};
 
 mod task;
 pub use task::{Forwarder, ValidTransaction};

--- a/crates/txpool/src/forwarder/mod.rs
+++ b/crates/txpool/src/forwarder/mod.rs
@@ -1,0 +1,89 @@
+use std::sync::Arc;
+
+use jsonrpsee::http_client::HttpClientBuilder;
+use reth_transaction_pool::{PoolTransaction, ValidPoolTransaction};
+use tokio::sync::broadcast;
+use tokio_util::sync::CancellationToken;
+use tracing::{error, info};
+
+mod config;
+pub use config::ForwarderConfig;
+
+mod metrics;
+pub use metrics::ForwarderMetrics;
+
+mod task;
+pub use task::{Forwarder, ValidTransaction};
+
+/// Handle for the set of forwarder tasks (one per builder URL).
+///
+/// Cancels all forwarder tasks on drop.
+pub struct ForwarderHandle {
+    cancel: CancellationToken,
+    _tasks: Vec<tokio::task::JoinHandle<()>>,
+}
+
+impl ForwarderHandle {
+    /// Spawns one forwarder async task per builder URL, each subscribing to
+    /// the given broadcast sender.
+    pub fn spawn<T>(
+        sender: &broadcast::Sender<Arc<ValidPoolTransaction<T>>>,
+        config: ForwarderConfig,
+    ) -> Self
+    where
+        T: PoolTransaction + 'static,
+        <T as PoolTransaction>::Consensus: alloy_eips::Encodable2718,
+    {
+        let cancel = CancellationToken::new();
+        let mut tasks = Vec::with_capacity(config.builder_urls.len());
+
+        for url in &config.builder_urls {
+            let client = match HttpClientBuilder::default().build(url) {
+                Ok(client) => client,
+                Err(err) => {
+                    error!(
+                        builder_url = %url,
+                        error = %err,
+                        "failed to build HTTP client for forwarder, skipping",
+                    );
+                    continue;
+                }
+            };
+
+            let receiver = sender.subscribe();
+            let metrics = ForwarderMetrics::default();
+            let forwarder = Forwarder::new(
+                url.clone(),
+                client,
+                receiver,
+                config.clone(),
+                metrics,
+                cancel.child_token(),
+            );
+
+            let handle = tokio::spawn(async move {
+                forwarder.run().await;
+            });
+
+            info!(builder_url = %url, "spawned transaction forwarder");
+            tasks.push(handle);
+        }
+
+        Self { cancel, _tasks: tasks }
+    }
+}
+
+impl Drop for ForwarderHandle {
+    fn drop(&mut self) {
+        self.cancel.cancel();
+    }
+}
+
+impl std::fmt::Debug for ForwarderHandle {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ForwarderHandle")
+            .field("tasks", &self._tasks.len())
+            .field("cancelled", &self.cancel.is_cancelled())
+            .finish()
+    }
+}

--- a/crates/txpool/src/forwarder/mod.rs
+++ b/crates/txpool/src/forwarder/mod.rs
@@ -91,7 +91,7 @@ impl ForwarderHandle {
 
         let tasks = std::mem::take(&mut self.tasks);
         let results =
-            tokio::time::timeout(Duration::from_secs(5), futures::future::join_all(tasks)).await;
+            tokio::time::timeout(Duration::from_secs(30), futures::future::join_all(tasks)).await;
 
         if let Err(err) = results {
             warn!(error = %err, "forwarder tasks did not finish within shutdown timeout");

--- a/crates/txpool/src/forwarder/mod.rs
+++ b/crates/txpool/src/forwarder/mod.rs
@@ -1,4 +1,4 @@
-use std::sync::Arc;
+use std::{sync::Arc, time::Duration};
 
 use jsonrpsee::http_client::HttpClientBuilder;
 use reth_transaction_pool::{PoolTransaction, ValidPoolTransaction};
@@ -17,10 +17,11 @@ pub use task::{Forwarder, ValidTransaction};
 
 /// Handle for the set of forwarder tasks (one per builder URL).
 ///
-/// Cancels all forwarder tasks on drop.
+/// Cancels all forwarder tasks on drop. For a clean shutdown that waits for
+/// in-flight RPC requests to complete, use [`ForwarderHandle::shutdown`].
 pub struct ForwarderHandle {
     cancel: CancellationToken,
-    _tasks: Vec<tokio::task::JoinHandle<()>>,
+    tasks: Vec<tokio::task::JoinHandle<()>>,
 }
 
 impl ForwarderHandle {
@@ -73,7 +74,23 @@ impl ForwarderHandle {
             warn!("no forwarder tasks spawned — check builder_urls config");
         }
 
-        Self { cancel, _tasks: tasks }
+        Self { cancel, tasks }
+    }
+}
+
+impl ForwarderHandle {
+    /// Gracefully shuts down all forwarder tasks.
+    ///
+    /// Signals cancellation and waits up to 5 seconds for in-flight RPC
+    /// requests to complete before abandoning them.
+    pub async fn shutdown(mut self) {
+        self.cancel.cancel();
+
+        for task in std::mem::take(&mut self.tasks) {
+            if let Err(err) = tokio::time::timeout(Duration::from_secs(5), task).await {
+                warn!(error = %err, "forwarder task did not finish within shutdown timeout");
+            }
+        }
     }
 }
 
@@ -86,7 +103,7 @@ impl Drop for ForwarderHandle {
 impl std::fmt::Debug for ForwarderHandle {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("ForwarderHandle")
-            .field("tasks", &self._tasks.len())
+            .field("tasks", &self.tasks.len())
             .field("cancelled", &self.cancel.is_cancelled())
             .finish()
     }

--- a/crates/txpool/src/forwarder/rpc.rs
+++ b/crates/txpool/src/forwarder/rpc.rs
@@ -9,3 +9,14 @@ pub trait BuilderApi {
     #[method(name = "insertValidatedTransactions")]
     async fn insert_validated_transactions(&self, txs: Vec<ValidTransaction>) -> RpcResult<()>;
 }
+
+/// Stub server implementation. Will be filled in by the builder crate.
+#[derive(Debug)]
+pub struct BuilderApiHandler;
+
+#[async_trait::async_trait]
+impl BuilderApiServer for BuilderApiHandler {
+    async fn insert_validated_transactions(&self, _txs: Vec<ValidTransaction>) -> RpcResult<()> {
+        todo!("implement on builder side")
+    }
+}

--- a/crates/txpool/src/forwarder/rpc.rs
+++ b/crates/txpool/src/forwarder/rpc.rs
@@ -1,0 +1,11 @@
+use jsonrpsee::{core::RpcResult, proc_macros::rpc};
+
+use super::task::ValidTransaction;
+
+/// RPC interface for submitting pre-validated transactions to a block builder.
+#[rpc(server, client, namespace = "base")]
+pub trait BuilderApi {
+    /// Inserts a batch of transactions with pre-recovered senders.
+    #[method(name = "insertValidatedTransactions")]
+    async fn insert_validated_transactions(&self, txs: Vec<ValidTransaction>) -> RpcResult<()>;
+}

--- a/crates/txpool/src/forwarder/task.rs
+++ b/crates/txpool/src/forwarder/task.rs
@@ -38,6 +38,7 @@ struct RateLimiter {
 
 impl RateLimiter {
     fn new(max_rps: u32) -> Self {
+        assert!(max_rps > 0, "max_rps must be at least 1");
         Self { timestamps: VecDeque::with_capacity(max_rps as usize), max_rps }
     }
 
@@ -52,23 +53,20 @@ impl RateLimiter {
         }
     }
 
-    fn can_send(&mut self) -> bool {
-        self.prune(Instant::now());
-        (self.timestamps.len() as u32) < self.max_rps
-    }
-
-    fn time_until_available(&mut self) -> std::time::Duration {
+    /// Returns `None` if a send is allowed now, or `Some(wait)` with the
+    /// precise duration until the next slot opens.
+    fn check_rate_limit(&mut self) -> Option<std::time::Duration> {
         let now = Instant::now();
         self.prune(now);
 
         if (self.timestamps.len() as u32) < self.max_rps {
-            return std::time::Duration::ZERO;
+            return None;
         }
 
         let oldest = self.timestamps.front().expect("non-empty after prune");
         let window = std::time::Duration::from_secs(1);
         let elapsed = now.duration_since(*oldest);
-        window.saturating_sub(elapsed)
+        Some(window.saturating_sub(elapsed))
     }
 
     fn record_send(&mut self) {
@@ -127,28 +125,29 @@ where
                 return;
             }
 
-            if self.limiter.can_send() && !self.buffer.is_empty() {
-                self.flush_buffer().await;
-                continue;
-            }
-
-            if !self.limiter.can_send() {
-                let wait = self.limiter.time_until_available();
-                tokio::select! {
-                    _ = self.cancel.cancelled() => return,
-                    _ = time::sleep(wait) => continue,
-                    result = self.receiver.recv() => {
-                        self.handle_recv(result);
-                    }
+            match self.limiter.check_rate_limit() {
+                None if !self.buffer.is_empty() => {
+                    self.flush_buffer().await;
+                    continue;
                 }
-                continue;
+                Some(wait) => {
+                    tokio::select! {
+                        _ = self.cancel.cancelled() => return,
+                        _ = time::sleep(wait) => continue,
+                        result = self.receiver.recv() => {
+                            self.handle_recv(result);
+                        }
+                    }
+                    continue;
+                }
+                _ => {}
             }
 
             tokio::select! {
                 _ = self.cancel.cancelled() => return,
                 result = self.receiver.recv() => {
                     self.handle_recv(result);
-                    if !self.buffer.is_empty() && self.limiter.can_send() {
+                    if !self.buffer.is_empty() && self.limiter.check_rate_limit().is_none() {
                         self.flush_buffer().await;
                     }
                 }
@@ -221,33 +220,41 @@ where
                     self.metrics.txs_forwarded.increment(tx_count);
                     return;
                 }
-                Err(err) => {
-                    if attempt < self.config.max_retries {
-                        let backoff = self.config.retry_backoff * 2u32.pow(attempt);
-                        debug!(
-                            builder_url = %self.builder_url,
-                            attempt = attempt + 1,
-                            max_retries = self.config.max_retries,
-                            backoff_ms = backoff.as_millis() as u64,
-                            error = %err,
-                            "RPC send failed, retrying",
-                        );
-                        tokio::select! {
-                            _ = self.cancel.cancelled() => return,
-                            _ = time::sleep(backoff) => {}
-                        }
-                    } else {
-                        error!(
-                            builder_url = %self.builder_url,
-                            error = %err,
-                            txs = tx_count,
-                            "RPC send failed after all retries, dropping batch",
-                        );
-                        self.metrics.rpc_errors.increment(1);
+                Err(err) if Self::is_retryable(&err) && attempt < self.config.max_retries => {
+                    let backoff = self.config.retry_backoff * 2u32.pow(attempt);
+                    debug!(
+                        builder_url = %self.builder_url,
+                        attempt = attempt + 1,
+                        max_retries = self.config.max_retries,
+                        backoff_ms = backoff.as_millis() as u64,
+                        error = %err,
+                        "RPC send failed, retrying",
+                    );
+                    tokio::select! {
+                        _ = self.cancel.cancelled() => return,
+                        _ = time::sleep(backoff) => {}
                     }
+                }
+                Err(err) => {
+                    error!(
+                        builder_url = %self.builder_url,
+                        error = %err,
+                        txs = tx_count,
+                        retryable = Self::is_retryable(&err),
+                        "RPC send failed, dropping batch",
+                    );
+                    self.metrics.rpc_errors.increment(1);
+                    return;
                 }
             }
         }
+    }
+
+    fn is_retryable(err: &ClientError) -> bool {
+        matches!(
+            err,
+            ClientError::Transport(_) | ClientError::RequestTimeout | ClientError::RestartNeeded(_)
+        )
     }
 }
 

--- a/crates/txpool/src/forwarder/task.rs
+++ b/crates/txpool/src/forwarder/task.rs
@@ -2,17 +2,14 @@ use std::{collections::VecDeque, sync::Arc, time::Instant};
 
 use alloy_eips::Encodable2718;
 use alloy_primitives::{Address, Bytes};
-use jsonrpsee::{
-    core::{ClientError, client::ClientT},
-    http_client::HttpClient,
-};
+use jsonrpsee::{core::ClientError, http_client::HttpClient};
 use reth_transaction_pool::{PoolTransaction, ValidPoolTransaction};
 use serde::{Deserialize, Serialize};
 use tokio::{sync::broadcast, time};
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, error, info, trace, warn};
 
-use super::{config::ForwarderConfig, metrics::ForwarderMetrics};
+use super::{config::ForwarderConfig, metrics::ForwarderMetrics, rpc::BuilderApiClient};
 
 /// Pre-validated transaction for the builder RPC wire format.
 ///
@@ -89,10 +86,10 @@ impl RateLimiter {
 /// transactions buffer and flush as a single batch (capped at
 /// `max_batch_size`) once the window opens.
 pub struct Forwarder<T: PoolTransaction> {
-    builder_url: String,
+    builder_url: url::Url,
     client: HttpClient,
     receiver: broadcast::Receiver<Arc<ValidPoolTransaction<T>>>,
-    config: ForwarderConfig,
+    config: Arc<ForwarderConfig>,
     metrics: ForwarderMetrics,
     cancel: CancellationToken,
     limiter: RateLimiter,
@@ -106,10 +103,10 @@ where
 {
     /// Creates a new forwarder for a single builder endpoint.
     pub fn new(
-        builder_url: String,
+        builder_url: url::Url,
         client: HttpClient,
         receiver: broadcast::Receiver<Arc<ValidPoolTransaction<T>>>,
-        config: ForwarderConfig,
+        config: Arc<ForwarderConfig>,
         metrics: ForwarderMetrics,
         cancel: CancellationToken,
     ) -> Self {
@@ -238,8 +235,7 @@ where
         let tx_count = batch.len() as u64;
         let overall_start = Instant::now();
         for attempt in 0..=self.config.max_retries {
-            let result: Result<serde_json::Value, ClientError> =
-                self.client.request("base_insertValidatedTransactions", vec![&batch]).await;
+            let result = self.client.insert_validated_transactions(batch.clone()).await;
 
             match result {
                 Ok(_) => {

--- a/crates/txpool/src/forwarder/task.rs
+++ b/crates/txpool/src/forwarder/task.rs
@@ -232,7 +232,10 @@ where
                             error = %err,
                             "RPC send failed, retrying",
                         );
-                        time::sleep(backoff).await;
+                        tokio::select! {
+                            _ = self.cancel.cancelled() => return,
+                            _ = time::sleep(backoff) => {}
+                        }
                     } else {
                         error!(
                             builder_url = %self.builder_url,

--- a/crates/txpool/src/forwarder/task.rs
+++ b/crates/txpool/src/forwarder/task.rs
@@ -38,8 +38,8 @@ struct RateLimiter {
 
 impl RateLimiter {
     fn new(max_rps: u32) -> Self {
-        assert!(max_rps > 0, "max_rps must be at least 1");
-        Self { timestamps: VecDeque::with_capacity(max_rps as usize), max_rps }
+        let capacity = if max_rps == 0 { 0 } else { max_rps as usize };
+        Self { timestamps: VecDeque::with_capacity(capacity), max_rps }
     }
 
     fn prune(&mut self, now: Instant) {
@@ -54,8 +54,13 @@ impl RateLimiter {
     }
 
     /// Returns `None` if a send is allowed now, or `Some(wait)` with the
-    /// precise duration until the next slot opens.
+    /// precise duration until the next slot opens. A `max_rps` of 0 disables
+    /// rate limiting entirely.
     fn check_rate_limit(&mut self) -> Option<std::time::Duration> {
+        if self.max_rps == 0 {
+            return None;
+        }
+
         let now = Instant::now();
         self.prune(now);
 
@@ -70,7 +75,9 @@ impl RateLimiter {
     }
 
     fn record_send(&mut self) {
-        self.timestamps.push_back(Instant::now());
+        if self.max_rps > 0 {
+            self.timestamps.push_back(Instant::now());
+        }
     }
 }
 
@@ -107,7 +114,8 @@ where
         cancel: CancellationToken,
     ) -> Self {
         let limiter = RateLimiter::new(config.max_rps);
-        let buffer = Vec::with_capacity(config.max_batch_size);
+        let initial_capacity = if config.max_batch_size == 0 { 256 } else { config.max_batch_size };
+        let buffer = Vec::with_capacity(initial_capacity);
         Self { builder_url, client, receiver, config, metrics, cancel, limiter, buffer }
     }
 
@@ -186,7 +194,11 @@ where
     }
 
     async fn flush_buffer(&mut self) {
-        let batch_size = self.buffer.len().min(self.config.max_batch_size);
+        let batch_size = if self.config.max_batch_size == 0 {
+            self.buffer.len()
+        } else {
+            self.buffer.len().min(self.config.max_batch_size)
+        };
         let batch: Vec<ValidTransaction> = self.buffer.drain(..batch_size).collect();
 
         if batch.is_empty() {
@@ -250,7 +262,7 @@ where
         }
     }
 
-    fn is_retryable(err: &ClientError) -> bool {
+    const fn is_retryable(err: &ClientError) -> bool {
         matches!(
             err,
             ClientError::Transport(_) | ClientError::RequestTimeout | ClientError::RestartNeeded(_)

--- a/crates/txpool/src/forwarder/task.rs
+++ b/crates/txpool/src/forwarder/task.rs
@@ -172,7 +172,8 @@ where
                     skipped = skipped,
                     "forwarder lagged, dropped transactions",
                 );
-                self.metrics.batches_lagged.increment(1);
+                        self.metrics.batches_lagged.increment(1);
+                        self.metrics.txs_lagged.increment(skipped);
             }
             Err(broadcast::error::RecvError::Closed) => {
                 info!(
@@ -205,17 +206,15 @@ where
 
     async fn send_with_retries(&self, batch: Vec<ValidTransaction>) {
         let tx_count = batch.len() as u64;
+        let overall_start = Instant::now();
 
         for attempt in 0..=self.config.max_retries {
-            let start = Instant::now();
             let result: Result<serde_json::Value, ClientError> =
                 self.client.request("base_insertValidatedTransactions", vec![&batch]).await;
-            let elapsed = start.elapsed();
-
-            self.metrics.rpc_latency.record(elapsed.as_secs_f64());
 
             match result {
                 Ok(_) => {
+                    self.metrics.rpc_latency.record(overall_start.elapsed().as_secs_f64());
                     self.metrics.batches_sent.increment(1);
                     self.metrics.txs_forwarded.increment(tx_count);
                     return;
@@ -236,6 +235,7 @@ where
                     }
                 }
                 Err(err) => {
+                    self.metrics.rpc_latency.record(overall_start.elapsed().as_secs_f64());
                     error!(
                         builder_url = %self.builder_url,
                         error = %err,

--- a/crates/txpool/src/forwarder/task.rs
+++ b/crates/txpool/src/forwarder/task.rs
@@ -172,8 +172,8 @@ where
                     skipped = skipped,
                     "forwarder lagged, dropped transactions",
                 );
-                        self.metrics.batches_lagged.increment(1);
-                        self.metrics.txs_lagged.increment(skipped);
+                self.metrics.batches_lagged.increment(1);
+                self.metrics.txs_lagged.increment(skipped);
             }
             Err(broadcast::error::RecvError::Closed) => {
                 info!(
@@ -220,7 +220,7 @@ where
                     return;
                 }
                 Err(err) if Self::is_retryable(&err) && attempt < self.config.max_retries => {
-                    let backoff = self.config.retry_backoff * 2u32.pow(attempt);
+                    let backoff = self.config.retry_backoff * 2u32.saturating_pow(attempt);
                     debug!(
                         builder_url = %self.builder_url,
                         attempt = attempt + 1,

--- a/crates/txpool/src/forwarder/task.rs
+++ b/crates/txpool/src/forwarder/task.rs
@@ -1,0 +1,258 @@
+use std::{collections::VecDeque, sync::Arc, time::Instant};
+
+use alloy_eips::Encodable2718;
+use alloy_primitives::{Address, Bytes};
+use jsonrpsee::{
+    core::{ClientError, client::ClientT},
+    http_client::HttpClient,
+};
+use reth_transaction_pool::{PoolTransaction, ValidPoolTransaction};
+use serde::{Deserialize, Serialize};
+use tokio::{sync::broadcast, time};
+use tokio_util::sync::CancellationToken;
+use tracing::{debug, error, info, trace, warn};
+
+use super::{config::ForwarderConfig, metrics::ForwarderMetrics};
+
+/// Pre-validated transaction for the builder RPC wire format.
+///
+/// Carries the recovered sender address so the builder can skip signer
+/// recovery, and the EIP-2718 encoded transaction envelope.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ValidTransaction {
+    /// Recovered signer address.
+    pub sender: Address,
+    /// EIP-2718 encoded transaction bytes.
+    pub raw: Bytes,
+}
+
+/// Sliding window rate limiter that tracks request timestamps.
+///
+/// Maintains a bounded deque of send timestamps within a 1-second window.
+/// When the window is full (at `max_rps`), reports how long until the
+/// oldest entry expires so the caller can sleep precisely.
+struct RateLimiter {
+    timestamps: VecDeque<Instant>,
+    max_rps: u32,
+}
+
+impl RateLimiter {
+    fn new(max_rps: u32) -> Self {
+        Self { timestamps: VecDeque::with_capacity(max_rps as usize), max_rps }
+    }
+
+    fn prune(&mut self, now: Instant) {
+        let window = std::time::Duration::from_secs(1);
+        while let Some(&front) = self.timestamps.front() {
+            if now.duration_since(front) >= window {
+                self.timestamps.pop_front();
+            } else {
+                break;
+            }
+        }
+    }
+
+    fn can_send(&mut self) -> bool {
+        self.prune(Instant::now());
+        (self.timestamps.len() as u32) < self.max_rps
+    }
+
+    fn time_until_available(&mut self) -> std::time::Duration {
+        let now = Instant::now();
+        self.prune(now);
+
+        if (self.timestamps.len() as u32) < self.max_rps {
+            return std::time::Duration::ZERO;
+        }
+
+        let oldest = self.timestamps.front().expect("non-empty after prune");
+        let window = std::time::Duration::from_secs(1);
+        let elapsed = now.duration_since(*oldest);
+        window.saturating_sub(elapsed)
+    }
+
+    fn record_send(&mut self) {
+        self.timestamps.push_back(Instant::now());
+    }
+}
+
+/// Async forwarder task that receives transactions from a broadcast channel
+/// and sends them to a single builder via RPC.
+///
+/// Under normal load, each transaction is sent immediately as a batch of 1.
+/// When the sliding window rate limit (`max_rps`) is hit, incoming
+/// transactions buffer and flush as a single batch (capped at
+/// `max_batch_size`) once the window opens.
+pub struct Forwarder<T: PoolTransaction> {
+    builder_url: String,
+    client: HttpClient,
+    receiver: broadcast::Receiver<Arc<ValidPoolTransaction<T>>>,
+    config: ForwarderConfig,
+    metrics: ForwarderMetrics,
+    cancel: CancellationToken,
+    limiter: RateLimiter,
+    buffer: Vec<ValidTransaction>,
+}
+
+impl<T> Forwarder<T>
+where
+    T: PoolTransaction,
+    <T as PoolTransaction>::Consensus: Encodable2718,
+{
+    /// Creates a new forwarder for a single builder endpoint.
+    pub fn new(
+        builder_url: String,
+        client: HttpClient,
+        receiver: broadcast::Receiver<Arc<ValidPoolTransaction<T>>>,
+        config: ForwarderConfig,
+        metrics: ForwarderMetrics,
+        cancel: CancellationToken,
+    ) -> Self {
+        let limiter = RateLimiter::new(config.max_rps);
+        let buffer = Vec::with_capacity(config.max_batch_size);
+        Self { builder_url, client, receiver, config, metrics, cancel, limiter, buffer }
+    }
+
+    /// Runs the forwarder loop until cancelled.
+    pub async fn run(mut self) {
+        info!(
+            builder_url = %self.builder_url,
+            max_rps = self.config.max_rps,
+            max_batch_size = self.config.max_batch_size,
+            "starting transaction forwarder",
+        );
+
+        loop {
+            if self.cancel.is_cancelled() {
+                return;
+            }
+
+            if self.limiter.can_send() && !self.buffer.is_empty() {
+                self.flush_buffer().await;
+                continue;
+            }
+
+            if !self.limiter.can_send() {
+                let wait = self.limiter.time_until_available();
+                tokio::select! {
+                    _ = self.cancel.cancelled() => return,
+                    _ = time::sleep(wait) => continue,
+                    result = self.receiver.recv() => {
+                        self.handle_recv(result);
+                    }
+                }
+                continue;
+            }
+
+            tokio::select! {
+                _ = self.cancel.cancelled() => return,
+                result = self.receiver.recv() => {
+                    self.handle_recv(result);
+                    if !self.buffer.is_empty() && self.limiter.can_send() {
+                        self.flush_buffer().await;
+                    }
+                }
+            }
+        }
+    }
+
+    fn handle_recv(
+        &mut self,
+        result: Result<Arc<ValidPoolTransaction<T>>, broadcast::error::RecvError>,
+    ) {
+        match result {
+            Ok(tx) => {
+                let sender = *tx.sender_ref();
+                let consensus = tx.transaction.clone_into_consensus();
+                let raw = Bytes::from(consensus.inner().encoded_2718());
+                self.buffer.push(ValidTransaction { sender, raw });
+            }
+            Err(broadcast::error::RecvError::Lagged(skipped)) => {
+                warn!(
+                    builder_url = %self.builder_url,
+                    skipped = skipped,
+                    "forwarder lagged, dropped transactions",
+                );
+                self.metrics.batches_lagged.increment(1);
+            }
+            Err(broadcast::error::RecvError::Closed) => {
+                info!(
+                    builder_url = %self.builder_url,
+                    "broadcast channel closed, shutting down forwarder",
+                );
+                self.cancel.cancel();
+            }
+        }
+    }
+
+    async fn flush_buffer(&mut self) {
+        let batch_size = self.buffer.len().min(self.config.max_batch_size);
+        let batch: Vec<ValidTransaction> = self.buffer.drain(..batch_size).collect();
+
+        if batch.is_empty() {
+            return;
+        }
+
+        trace!(
+            builder_url = %self.builder_url,
+            txs = batch.len(),
+            remaining = self.buffer.len(),
+            "flushing batch",
+        );
+
+        self.send_with_retries(batch).await;
+        self.limiter.record_send();
+    }
+
+    async fn send_with_retries(&self, batch: Vec<ValidTransaction>) {
+        let tx_count = batch.len() as u64;
+
+        for attempt in 0..=self.config.max_retries {
+            let start = Instant::now();
+            let result: Result<serde_json::Value, ClientError> =
+                self.client.request("base_insertValidatedTransactions", vec![&batch]).await;
+            let elapsed = start.elapsed();
+
+            self.metrics.rpc_latency.record(elapsed.as_secs_f64());
+
+            match result {
+                Ok(_) => {
+                    self.metrics.batches_sent.increment(1);
+                    self.metrics.txs_forwarded.increment(tx_count);
+                    return;
+                }
+                Err(err) => {
+                    if attempt < self.config.max_retries {
+                        let backoff = self.config.retry_backoff * 2u32.pow(attempt);
+                        debug!(
+                            builder_url = %self.builder_url,
+                            attempt = attempt + 1,
+                            max_retries = self.config.max_retries,
+                            backoff_ms = backoff.as_millis() as u64,
+                            error = %err,
+                            "RPC send failed, retrying",
+                        );
+                        time::sleep(backoff).await;
+                    } else {
+                        error!(
+                            builder_url = %self.builder_url,
+                            error = %err,
+                            txs = tx_count,
+                            "RPC send failed after all retries, dropping batch",
+                        );
+                        self.metrics.rpc_errors.increment(1);
+                    }
+                }
+            }
+        }
+    }
+}
+
+impl<T: PoolTransaction> std::fmt::Debug for Forwarder<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Forwarder")
+            .field("builder_url", &self.builder_url)
+            .field("config", &self.config)
+            .finish_non_exhaustive()
+    }
+}

--- a/crates/txpool/src/forwarder/task.rs
+++ b/crates/txpool/src/forwarder/task.rs
@@ -130,7 +130,7 @@ where
 
         loop {
             if self.cancel.is_cancelled() {
-                return;
+                break;
             }
 
             match self.limiter.check_rate_limit() {
@@ -139,40 +139,50 @@ where
                     continue;
                 }
                 Some(wait) => {
-                    tokio::select! {
-                        _ = self.cancel.cancelled() => return,
-                        _ = time::sleep(wait) => continue,
+                    let closed = tokio::select! {
+                        _ = self.cancel.cancelled() => break,
+                        _ = time::sleep(wait) => { continue; }
                         result = self.receiver.recv() => {
-                            self.handle_recv(result);
+                            self.handle_recv(result)
                         }
+                    };
+                    if closed {
+                        break;
                     }
                     continue;
                 }
                 _ => {}
             }
 
-            tokio::select! {
-                _ = self.cancel.cancelled() => return,
+            let closed = tokio::select! {
+                _ = self.cancel.cancelled() => break,
                 result = self.receiver.recv() => {
-                    self.handle_recv(result);
-                    if !self.buffer.is_empty() && self.limiter.check_rate_limit().is_none() {
-                        self.flush_buffer().await;
-                    }
+                    self.handle_recv(result)
                 }
+            };
+            if closed {
+                break;
+            }
+            if !self.buffer.is_empty() && self.limiter.check_rate_limit().is_none() {
+                self.flush_buffer().await;
             }
         }
+
+        self.flush_remaining().await;
     }
 
+    /// Returns `true` if the channel is closed and the forwarder should shut down.
     fn handle_recv(
         &mut self,
         result: Result<Arc<ValidPoolTransaction<T>>, broadcast::error::RecvError>,
-    ) {
+    ) -> bool {
         match result {
             Ok(tx) => {
                 let sender = *tx.sender_ref();
                 let consensus = tx.transaction.clone_into_consensus();
                 let raw = Bytes::from(consensus.inner().encoded_2718());
                 self.buffer.push(ValidTransaction { sender, raw });
+                false
             }
             Err(broadcast::error::RecvError::Lagged(skipped)) => {
                 warn!(
@@ -182,14 +192,22 @@ where
                 );
                 self.metrics.batches_lagged.increment(1);
                 self.metrics.txs_lagged.increment(skipped);
+                false
             }
             Err(broadcast::error::RecvError::Closed) => {
                 info!(
                     builder_url = %self.builder_url,
-                    "broadcast channel closed, shutting down forwarder",
+                    buffered = self.buffer.len(),
+                    "broadcast channel closed",
                 );
-                self.cancel.cancel();
+                true
             }
+        }
+    }
+
+    async fn flush_remaining(&mut self) {
+        while !self.buffer.is_empty() {
+            self.flush_buffer().await;
         }
     }
 

--- a/crates/txpool/src/forwarder/task.rs
+++ b/crates/txpool/src/forwarder/task.rs
@@ -237,7 +237,6 @@ where
     async fn send_with_retries(&self, batch: Vec<ValidTransaction>) {
         let tx_count = batch.len() as u64;
         let overall_start = Instant::now();
-
         for attempt in 0..=self.config.max_retries {
             let result: Result<serde_json::Value, ClientError> =
                 self.client.request("base_insertValidatedTransactions", vec![&batch]).await;
@@ -294,5 +293,34 @@ impl<T: PoolTransaction> std::fmt::Debug for Forwarder<T> {
             .field("builder_url", &self.builder_url)
             .field("config", &self.config)
             .finish_non_exhaustive()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rate_limiter_unlimited_when_zero() {
+        let mut limiter = RateLimiter::new(0);
+
+        for _ in 0..10_000 {
+            assert!(limiter.check_rate_limit().is_none());
+            limiter.record_send();
+        }
+
+        assert!(limiter.timestamps.is_empty());
+    }
+
+    #[test]
+    fn rate_limiter_enforces_limit() {
+        let mut limiter = RateLimiter::new(3);
+
+        for _ in 0..3 {
+            assert!(limiter.check_rate_limit().is_none());
+            limiter.record_send();
+        }
+
+        assert!(limiter.check_rate_limit().is_some());
     }
 }

--- a/crates/txpool/src/forwarder/task.rs
+++ b/crates/txpool/src/forwarder/task.rs
@@ -179,6 +179,7 @@ where
                 let consensus = tx.transaction.clone_into_consensus();
                 let raw = Bytes::from(consensus.inner().encoded_2718());
                 self.buffer.push(ValidTransaction { sender, raw });
+                self.metrics.buffer_size.set(self.buffer.len() as f64);
                 false
             }
             Err(broadcast::error::RecvError::Lagged(skipped)) => {
@@ -215,6 +216,7 @@ where
             self.buffer.len().min(self.config.max_batch_size)
         };
         let batch: Vec<ValidTransaction> = self.buffer.drain(..batch_size).collect();
+        self.metrics.buffer_size.set(self.buffer.len() as f64);
 
         if batch.is_empty() {
             return;

--- a/crates/txpool/src/lib.rs
+++ b/crates/txpool/src/lib.rs
@@ -21,8 +21,8 @@ pub use consumer::{Consumer, ConsumerConfig, ConsumerHandle, ConsumerMetrics, Re
 
 mod forwarder;
 pub use forwarder::{
-    BuilderApiClient, BuilderApiServer, Forwarder, ForwarderConfig, ForwarderHandle,
-    ForwarderMetrics, ValidTransaction,
+    BuilderApiClient, BuilderApiHandler, BuilderApiServer, Forwarder, ForwarderConfig,
+    ForwarderHandle, ForwarderMetrics, ValidTransaction,
 };
 
 pub mod estimated_da_size;

--- a/crates/txpool/src/lib.rs
+++ b/crates/txpool/src/lib.rs
@@ -21,7 +21,8 @@ pub use consumer::{Consumer, ConsumerConfig, ConsumerHandle, ConsumerMetrics, Re
 
 mod forwarder;
 pub use forwarder::{
-    Forwarder, ForwarderConfig, ForwarderHandle, ForwarderMetrics, ValidTransaction,
+    BuilderApiClient, BuilderApiServer, Forwarder, ForwarderConfig, ForwarderHandle,
+    ForwarderMetrics, ValidTransaction,
 };
 
 pub mod estimated_da_size;

--- a/crates/txpool/src/lib.rs
+++ b/crates/txpool/src/lib.rs
@@ -19,6 +19,11 @@ pub use ordering::{BaseOrdering, TimestampOrdering};
 mod consumer;
 pub use consumer::{Consumer, ConsumerConfig, ConsumerHandle, ConsumerMetrics, RecentlySent};
 
+mod forwarder;
+pub use forwarder::{
+    Forwarder, ForwarderConfig, ForwarderHandle, ForwarderMetrics, ValidTransaction,
+};
+
 pub mod estimated_da_size;
 
 use reth_transaction_pool::{Pool, TransactionValidationTaskExecutor};


### PR DESCRIPTION
## Summary

Transaction forwarder for the mempool→builder propagation pipeline (PR 2 of 4). Spawns one async task per builder URL, subscribing to the consumer's broadcast channel.

Uses a sliding window rate limiter (default 200 RPS) so transactions are forwarded immediately under normal load. Under spike pressure, incoming txs buffer and flush as a single batch when the window opens (capped at 500 txs per request).

Wire format: `ValidTransaction { sender, raw }` — sender included so the builder skips signer recovery.

## Open Questions

**Buffer bounding**: The forwarder's internal buffer is currently unbounded. Under a sustained spike that exceeds the rate limit for an extended period, the buffer will grow. In practice, the consumer's dedup window (4s) and broadcast channel capacity (10k) limit the inflow rate. Should we add a buffer cap with drop-oldest, or is unbounded acceptable given the natural upstream limits?

## Pipeline Status

| PR | Component | Status |
|----|-----------|--------|
| PR 1 | Consumer | ✅ Merged |
| **PR 2** | **Forwarder** | 🔄 |
| PR 3 | Builder RPC | Planned |
| PR 4 | Node integration | Planned |