### PR TITLE
fix(derive): Carry Over Origin on Upgrade

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4226,14 +4226,18 @@ dependencies = [
  "base-test-utils",
  "c-kzg",
  "derive_more",
+ "metrics",
  "parking_lot",
  "reth-chainspec",
  "reth-evm",
+ "reth-metrics",
  "reth-primitives-traits",
  "reth-provider",
  "reth-storage-api",
+ "reth-tasks",
  "reth-transaction-pool",
  "tokio",
+ "tokio-util",
  "tracing",
 ]
 

--- a/crates/consensus/derive/src/stages/batch/batch_provider.rs
+++ b/crates/consensus/derive/src/stages/batch/batch_provider.rs
@@ -76,6 +76,7 @@ where
             let batch_queue = self.batch_queue.take().expect("Must have batch queue");
             let mut bv = BatchValidator::new(Arc::clone(&self.cfg), batch_queue.prev);
             bv.l1_blocks = batch_queue.l1_blocks;
+            bv.origin = batch_queue.origin;
             self.batch_validator = Some(bv);
         } else if self.batch_validator.is_some() && !self.cfg.is_holocene_active(origin.timestamp) {
             // If the batch validator is active, and Holocene is not active, it indicates an L1
@@ -240,6 +241,39 @@ mod test {
         assert!(batch_provider.batch_validator.is_some());
 
         assert_eq!(batch_provider.origin().unwrap().number, 1);
+    }
+
+    #[test]
+    fn test_spec_batch_provider_holocene_transition_origin_not_transferred() {
+        let provider = TestNextBatchProvider::new(vec![]);
+        let l2_provider = TestL2ChainProvider::default();
+        let cfg = Arc::new(RollupConfig {
+            hardforks: HardForkConfig { holocene_time: Some(10), ..Default::default() },
+            ..Default::default()
+        });
+        let mut batch_provider = BatchProvider::new(cfg, provider, l2_provider);
+
+        batch_provider.attempt_update().unwrap();
+
+        // Set origin and l1_blocks on the BatchQueue before the transition.
+        let Some(ref mut stage) = batch_provider.batch_queue else {
+            panic!("Expected BatchQueue");
+        };
+        stage.origin = Some(BlockInfo { number: 5, timestamp: 3, ..Default::default() });
+        stage.l1_blocks = vec![BlockInfo { number: 5, timestamp: 3, ..Default::default() }];
+
+        // Update the L1 origin to Holocene activation.
+        stage.prev.origin = Some(BlockInfo { number: 1, timestamp: 10, ..Default::default() });
+
+        // Transition to the BatchValidator stage.
+        batch_provider.attempt_update().unwrap();
+        assert!(batch_provider.batch_queue.is_none());
+        assert!(batch_provider.batch_validator.is_some());
+
+        // Assert that origin was transferred.
+        let bv = batch_provider.batch_validator.as_ref().unwrap();
+        assert_eq!(bv.origin, Some(BlockInfo { number: 5, timestamp: 3, ..Default::default() }));
+        assert_eq!(bv.l1_blocks, vec![BlockInfo { number: 5, timestamp: 3, ..Default::default() }]);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fixes the Holocene `BatchQueue`→`BatchValidator` transition in `attempt_update()` to copy the `origin` field alongside `l1_blocks`. Without this, `BatchValidator` starts with `origin: None` after the transition, causing `update_origins()` to either duplicate-insert the current L1 block into `l1_blocks` (corrupting the two-slot epoch window) or clear `l1_blocks` entirely and permanently halt derivation. The Go op-node copies both fields in `batch_mux.go:L67-68`; the Rust implementation was only copying one.

A regression test `test_spec_batch_provider_holocene_transition_origin_not_transferred` is included that verifies both `origin` and `l1_blocks` survive the transition intact.

Closes #997. Upstream: ethereum-optimism/optimism#19360.