### PR TITLE
feat(flashblocks): Incremental trie cache optimization for state root calculation

### DIFF
--- a/crates/builder/core/benches/state_root.rs
+++ b/crates/builder/core/benches/state_root.rs
@@ -194,20 +194,23 @@ fn per_flashblock_benches(c: &mut Criterion) {
             b.iter(|| {
                 let mut prev_trie_updates: Option<TrieUpdates> = None;
                 for snapshot in &snapshots {
-                    let (root, new_updates) = if let Some(prev) = prev_trie_updates.take() {
-                        let trie_input = TrieInput::new(
-                            prev,
-                            snapshot.clone(),
-                            snapshot.construct_prefix_sets(),
-                        );
-                        provider
-                            .state_root_from_nodes_with_updates(trie_input)
-                            .expect("state root should succeed")
-                    } else {
-                        provider
-                            .state_root_with_updates(snapshot.clone())
-                            .expect("state root should succeed")
-                    };
+                    let (root, new_updates) = prev_trie_updates.take().map_or_else(
+                        || {
+                            provider
+                                .state_root_with_updates(snapshot.clone())
+                                .expect("state root should succeed")
+                        },
+                        |prev| {
+                            let trie_input = TrieInput::new(
+                                prev,
+                                snapshot.clone(),
+                                snapshot.construct_prefix_sets(),
+                            );
+                            provider
+                                .state_root_from_nodes_with_updates(trie_input)
+                                .expect("state root should succeed")
+                        },
+                    );
                     prev_trie_updates = Some(new_updates);
                     black_box(root);
                 }

--- a/crates/builder/core/benches/state_root.rs
+++ b/crates/builder/core/benches/state_root.rs
@@ -7,8 +7,12 @@
 //!   once over the full accumulated state at finalization. This is the
 //!   **current production behavior**.
 //!
-//! - `per_flashblock` (`calculate_state_root = true`) — state root
-//!   recomputed from scratch after every flashblock.
+//! - `per_flashblock` (`calculate_state_root = true`) — state root computed
+//!   after every flashblock using the **incremental** path: the first call uses
+//!   [`StateRootProvider::state_root_with_updates`], then each subsequent call
+//!   uses [`StateRootProvider::state_root_from_nodes_with_updates`] with
+//!   [`TrieInput`] built from the previous flashblock’s [`TrieUpdates`], matching
+//!   the incremental path in flashblocks `build_block`.
 //!
 //! The benchmarks use an MDBX-backed [`MdbxProofsStorage`] pre-populated with
 //! 50k base-state accounts so that state root computation exercises real disk
@@ -32,6 +36,7 @@ use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
 use rand::{Rng, SeedableRng, rngs::StdRng};
 use reth_primitives_traits::Account;
 use reth_provider::{StateRootProvider, noop::NoopProvider};
+use reth_trie::{TrieInput, updates::TrieUpdates};
 use reth_trie_common::{HashedPostState, HashedStorage};
 use tempfile::TempDir;
 
@@ -159,8 +164,9 @@ fn finalize_only_benches(c: &mut Criterion) {
     g.finish();
 }
 
-/// Benchmarks `calculate_state_root = true`: state root recomputed from
-/// scratch after every flashblock.
+/// Benchmarks `calculate_state_root = true`: chained incremental state root
+/// after every flashblock (first call full overlay, rest
+/// `state_root_from_nodes_with_updates`).
 fn per_flashblock_benches(c: &mut Criterion) {
     let mut g = c.benchmark_group("state_root/per_flashblock");
     g.sample_size(10);
@@ -186,12 +192,24 @@ fn per_flashblock_benches(c: &mut Criterion) {
 
         g.bench_function(BenchmarkId::new("accounts_per_fb", accounts_per_fb), |b| {
             b.iter(|| {
+                let mut prev_trie_updates: Option<TrieUpdates> = None;
                 for snapshot in &snapshots {
-                    black_box(
+                    let (root, new_updates) = if let Some(prev) = prev_trie_updates.take() {
+                        let trie_input = TrieInput::new(
+                            prev,
+                            snapshot.clone(),
+                            snapshot.construct_prefix_sets(),
+                        );
+                        provider
+                            .state_root_from_nodes_with_updates(trie_input)
+                            .expect("state root should succeed")
+                    } else {
                         provider
                             .state_root_with_updates(snapshot.clone())
-                            .expect("state root should succeed"),
-                    );
+                            .expect("state root should succeed")
+                    };
+                    prev_trie_updates = Some(new_updates);
+                    black_box(root);
                 }
             });
         });

--- a/crates/builder/core/src/flashblocks/payload.rs
+++ b/crates/builder/core/src/flashblocks/payload.rs
@@ -39,7 +39,7 @@ use reth_revm::{
     State, database::StateProviderDatabase, db::states::bundle_state::BundleRetention,
 };
 use reth_transaction_pool::TransactionPool;
-use reth_trie::{HashedPostState, updates::TrieUpdates};
+use reth_trie::{HashedPostState, TrieInput, updates::TrieUpdates};
 use revm::Database as _;
 use serde::{Deserialize, Serialize};
 use serde_with::skip_serializing_none;
@@ -82,6 +82,11 @@ pub struct FlashblocksExecutionInfo {
 
     /// Flashblock-level access list builder
     pub(crate) access_list_builder: FlashblockAccessListBuilder,
+
+    /// Trie updates from the previous flashblock state root calculation, used so the
+    /// next `state_root_from_nodes_with_updates` call can reuse cached trie nodes.
+    /// `None` for the first flashblock in a block or until a state root has been computed.
+    pub(crate) prev_trie_updates: Option<Arc<TrieUpdates>>,
 }
 
 /// Base payload builder
@@ -982,23 +987,65 @@ where
     // calculate the state root
     let state_root_start_time = Instant::now();
     let mut state_root = B256::ZERO;
-    let mut trie_output = TrieUpdates::default();
     let mut hashed_state = HashedPostState::default();
+    let mut trie_updates_to_cache: Option<Arc<TrieUpdates>> = None;
 
     if calculate_state_root {
         let state_provider = state.database.as_ref();
+        let prev_trie = info.extra.prev_trie_updates.clone();
+        let flashblock_index = ctx.flashblock_index();
+
         hashed_state = state_provider.hashed_post_state(&state.bundle_state);
-        (state_root, trie_output) =
+
+        let trie_output;
+        (state_root, trie_output) = if let Some(prev_trie) = prev_trie {
+            debug!(
+                target: "payload_builder",
+                flashblock_index,
+                "Using incremental state root calculation with cached trie",
+            );
+
+            let trie_input = TrieInput::new(
+                (*prev_trie).clone(),
+                hashed_state.clone(),
+                hashed_state.construct_prefix_sets(),
+            );
+
+            state_provider
+                .state_root_from_nodes_with_updates(trie_input)
+                .map_err(PayloadBuilderError::other)?
+        } else {
+            debug!(
+                target: "payload_builder",
+                flashblock_index,
+                "Using full state root calculation",
+            );
+
             state_provider.state_root_with_updates(hashed_state.clone()).inspect_err(|err| {
-                warn!(target: "payload_builder",
+                warn!(
+                    target: "payload_builder",
                     parent_header=%ctx.parent().hash(),
                     %err,
                     "failed to calculate state root for payload"
                 );
-            })?;
+            })?
+        };
+
+        trie_updates_to_cache = Some(Arc::new(trie_output));
+
         let state_root_calculation_time = state_root_start_time.elapsed();
         BuilderMetrics::state_root_calculation_duration().record(state_root_calculation_time);
         BuilderMetrics::state_root_calculation_gauge().set(state_root_calculation_time);
+
+        debug!(
+            target: "payload_builder",
+            flashblock_index,
+            state_root = %state_root,
+            duration_ms = state_root_calculation_time.as_millis(),
+            "State root calculation completed",
+        );
+
+        info.extra.prev_trie_updates = trie_updates_to_cache.clone();
     }
 
     let mut requests_hash = None;
@@ -1083,7 +1130,11 @@ where
             state: state.take_bundle(),
         }),
         hashed_state: Either::Left(Arc::new(hashed_state)),
-        trie_updates: Either::Left(Arc::new(trie_output)),
+        trie_updates: Either::Left(
+            trie_updates_to_cache
+                .clone()
+                .unwrap_or_else(|| Arc::new(TrieUpdates::default())),
+        ),
     };
     debug!(target: "payload_builder", message = "Executed block created");
 

--- a/crates/builder/core/src/flashblocks/payload.rs
+++ b/crates/builder/core/src/flashblocks/payload.rs
@@ -1131,9 +1131,7 @@ where
         }),
         hashed_state: Either::Left(Arc::new(hashed_state)),
         trie_updates: Either::Left(
-            trie_updates_to_cache
-                .clone()
-                .unwrap_or_else(|| Arc::new(TrieUpdates::default())),
+            trie_updates_to_cache.unwrap_or_else(|| Arc::new(TrieUpdates::default())),
         ),
     };
     debug!(target: "payload_builder", message = "Executed block created");


### PR DESCRIPTION
This is a port of [#385](https://github.com/flashbots/op-rbuilder/pull/385) from [flashbots/op-rbuilder](https://github.com/flashbots/op-rbuilder), that optimizes our state root calculation when we calculate state root per flashblock.

