### PR TITLE
fix(derive): Preserve Error Classification in BlobSource::load_blobs

### DIFF
--- a/crates/consensus/derive/src/sources/blobs.rs
+++ b/crates/consensus/derive/src/sources/blobs.rs
@@ -393,6 +393,7 @@ pub(crate) mod tests {
             source.blob_fetcher.insert_blob(hash, Blob::with_last_byte(1u8));
         }
         let result = source.load_blobs(&BlockInfo::default(), batcher_address).await;
-        assert!(matches!(result, Err(BlobProviderError::Reset(ResetError::BlobsOverFill(5, 6)))));
+        assert!(matches!(result, Err(PipelineErrorKind::Reset(ResetError::BlobsOverFill(5, 6)))));
+
     }
 }

--- a/crates/consensus/derive/src/sources/blobs.rs
+++ b/crates/consensus/derive/src/sources/blobs.rs
@@ -394,6 +394,74 @@ pub(crate) mod tests {
         }
         let result = source.load_blobs(&BlockInfo::default(), batcher_address).await;
         assert!(matches!(result, Err(PipelineErrorKind::Reset(ResetError::BlobsOverFill(5, 6)))));
+    }
 
+    /// A minimal [`ChainProvider`] whose errors map to [`PipelineErrorKind::Reset`].
+    /// Used to verify that [`BlobSource::load_blobs`] preserves the `Reset` kind when the
+    /// underlying chain provider signals a reset condition (e.g. an L1 reorg).
+    #[derive(Debug, Clone, Default)]
+    struct ResetChainProvider;
+
+    #[derive(Debug)]
+    struct ResetProviderError;
+
+    impl core::fmt::Display for ResetProviderError {
+        fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+            write!(f, "reorg detected")
+        }
+    }
+
+    impl From<ResetProviderError> for PipelineErrorKind {
+        fn from(_: ResetProviderError) -> Self {
+            ResetError::ReorgDetected(Default::default(), Default::default()).reset()
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl ChainProvider for ResetChainProvider {
+        type Error = ResetProviderError;
+
+        async fn header_by_hash(
+            &mut self,
+            _: alloy_primitives::B256,
+        ) -> Result<alloy_consensus::Header, Self::Error> {
+            Err(ResetProviderError)
+        }
+
+        async fn block_info_by_number(&mut self, _: u64) -> Result<BlockInfo, Self::Error> {
+            Err(ResetProviderError)
+        }
+
+        async fn receipts_by_hash(
+            &mut self,
+            _: alloy_primitives::B256,
+        ) -> Result<alloc::vec::Vec<alloy_consensus::Receipt>, Self::Error> {
+            Err(ResetProviderError)
+        }
+
+        async fn block_info_and_transactions_by_hash(
+            &mut self,
+            _: alloy_primitives::B256,
+        ) -> Result<(BlockInfo, alloc::vec::Vec<TxEnvelope>), Self::Error> {
+            Err(ResetProviderError)
+        }
+    }
+
+    /// Regression test: when `block_info_and_transactions_by_hash` returns an error that maps to
+    /// `PipelineErrorKind::Reset`, `load_blobs` must propagate the `Reset` kind unchanged.
+    ///
+    /// Before the fix, `BlobSource` wrapped every chain-provider error as
+    /// `BlobProviderError::Backend(e.to_string()).into()`, which unconditionally produced
+    /// `PipelineErrorKind::Temporary`. The fix uses `map_err(Into::into)` so the `Reset` kind
+    /// is preserved, allowing the pipeline to recover via reset rather than spinning in a retry loop.
+    #[tokio::test]
+    async fn test_load_blobs_reset_error_preserved() {
+        let mut source =
+            BlobSource::new(ResetChainProvider, TestBlobProvider::default(), Address::ZERO);
+        let err = source.load_blobs(&BlockInfo::default(), Address::ZERO).await.unwrap_err();
+        assert!(
+            matches!(err, PipelineErrorKind::Reset(_)),
+            "expected Reset kind to be preserved, got {err:?}"
+        );
     }
 }

--- a/crates/consensus/derive/src/sources/blobs.rs
+++ b/crates/consensus/derive/src/sources/blobs.rs
@@ -11,8 +11,8 @@ use async_trait::async_trait;
 use base_protocol::BlockInfo;
 
 use crate::{
-    BlobData, BlobProvider, BlobProviderError, ChainProvider, DataAvailabilityProvider,
-    PipelineError, PipelineResult, ResetError,
+    BlobData, BlobProvider, ChainProvider, DataAvailabilityProvider, PipelineError, PipelineResult,
+    ResetError,
 };
 
 /// A data iterator that reads from a blob.

--- a/crates/consensus/derive/src/sources/blobs.rs
+++ b/crates/consensus/derive/src/sources/blobs.rs
@@ -1,6 +1,6 @@
 //! Blob Data Source
 
-use alloc::{boxed::Box, string::ToString, vec::Vec};
+use alloc::{boxed::Box, vec::Vec};
 
 use alloy_consensus::{
     Transaction, TxEip4844Variant, TxEnvelope, TxType, transaction::SignerRecoverable,
@@ -119,7 +119,7 @@ where
         &mut self,
         block_ref: &BlockInfo,
         batcher_address: Address,
-    ) -> Result<(), BlobProviderError> {
+    ) -> PipelineResult<()> {
         if self.open {
             return Ok(());
         }
@@ -128,7 +128,7 @@ where
             .chain_provider
             .block_info_and_transactions_by_hash(block_ref.hash)
             .await
-            .map_err(|e| BlobProviderError::Backend(e.to_string()))?;
+            .map_err(Into::into)?;
 
         let (mut data, blob_hashes) = self.extract_blob_data(info.1, batcher_address);
 
@@ -143,7 +143,7 @@ where
             self.blob_fetcher.get_and_validate_blobs(block_ref, &blob_hashes).await.map_err(
                 |e| {
                     warn!(target: "blob_source", error = %e, "Failed to fetch blobs");
-                    BlobProviderError::Backend(e.to_string())
+                    e.into()
                 },
             )?;
 
@@ -157,7 +157,7 @@ where
                     }
                 }
                 Err(e) => {
-                    return Err(e);
+                    return Err(e.into());
                 }
             }
         }
@@ -258,7 +258,7 @@ pub(crate) mod tests {
         let mut source = default_test_blob_source();
         assert!(matches!(
             source.load_blobs(&BlockInfo::default(), Address::ZERO).await,
-            Err(BlobProviderError::Backend(_))
+            Err(PipelineErrorKind::Temporary(_))
         ));
     }
 
@@ -286,7 +286,7 @@ pub(crate) mod tests {
         source.chain_provider.insert_block_with_transactions(1, block_info, txs);
         assert!(matches!(
             source.load_blobs(&BlockInfo::default(), batcher_address).await,
-            Err(BlobProviderError::Backend(_))
+            Err(PipelineErrorKind::Critical(_))
         ));
     }
 


### PR DESCRIPTION
## Summary

Fixes #999 

BlobSource::load_blobs was wrapping all chain provider errors in BlobProviderError::Backend(e.to_string()), discarding the original error classification so that every error became PipelineErrorKind::Temporary. This meant errors that should trigger a pipeline reset (e.g. block not found during a reorg) were silently retried instead. This port changes load_blobs to return PipelineResult<()> and replaces the wrapping closure with map_err(Into::into), letting chain provider errors propagate as their correct PipelineErrorKind variant. Blob fetcher errors continue to convert through the existing BlobProviderError → PipelineErrorKind impl, preserving Critical for SlotDerivation and Temporary for transient backend failures.