### PR TITLE
test(flashblocks): add backwards compatibility tests for websocket wire format

### DIFF
--- a/crates/alloy/flashblocks/src/block.rs
+++ b/crates/alloy/flashblocks/src/block.rs
@@ -135,6 +135,148 @@ mod tests {
         Bytes::from(compressed)
     }
 
+    /// Hardcoded JSON representing the v0.4.1 wire format (metadata has only `block_number`).
+    /// If deserialization of this string ever breaks, we have introduced a backwards-incompatible
+    /// change to the flashblocks websocket schema.
+    const V0_4_1_PAYLOAD_JSON: &str = r#"{
+        "payload_id": "0x0000000000000000",
+        "index": 0,
+        "base": {
+            "parent_beacon_block_root": "0x0101010101010101010101010101010101010101010101010101010101010101",
+            "parent_hash": "0x0202020202020202020202020202020202020202020202020202020202020202",
+            "fee_recipient": "0x0000000000000000000000000000000000000000",
+            "prev_randao": "0x0303030303030303030303030303030303030303030303030303030303030303",
+            "block_number": "0x9",
+            "gas_limit": "0xf4240",
+            "timestamp": "0x6553f100",
+            "extra_data": "0xaabb",
+            "base_fee_per_gas": "0xa"
+        },
+        "diff": {
+            "state_root": "0x0404040404040404040404040404040404040404040404040404040404040404",
+            "receipts_root": "0x0505050505050505050505050505050505050505050505050505050505050505",
+            "logs_bloom": "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+            "gas_used": "0x7a120",
+            "block_hash": "0x0606060606060606060606060606060606060606060606060606060606060606",
+            "transactions": ["0x0102"],
+            "withdrawals": [],
+            "withdrawals_root": "0x0707070707070707070707070707070707070707070707070707070707070707",
+            "blob_gas_used": "0x2c"
+        },
+        "metadata": {
+            "block_number": 1234
+        }
+    }"#;
+
+    /// Hardcoded JSON representing the v0.5.0-rc.3 wire format (metadata includes receipts,
+    /// balances, and `access_list`). If deserialization of this string ever breaks, we have
+    /// introduced a backwards-incompatible change.
+    const V0_5_0_PAYLOAD_JSON: &str = r#"{
+        "payload_id": "0x0000000000000000",
+        "index": 0,
+        "base": {
+            "parent_beacon_block_root": "0x0101010101010101010101010101010101010101010101010101010101010101",
+            "parent_hash": "0x0202020202020202020202020202020202020202020202020202020202020202",
+            "fee_recipient": "0x0000000000000000000000000000000000000000",
+            "prev_randao": "0x0303030303030303030303030303030303030303030303030303030303030303",
+            "block_number": "0x9",
+            "gas_limit": "0xf4240",
+            "timestamp": "0x6553f100",
+            "extra_data": "0xaabb",
+            "base_fee_per_gas": "0xa"
+        },
+        "diff": {
+            "state_root": "0x0404040404040404040404040404040404040404040404040404040404040404",
+            "receipts_root": "0x0505050505050505050505050505050505050505050505050505050505050505",
+            "logs_bloom": "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+            "gas_used": "0x7a120",
+            "block_hash": "0x0606060606060606060606060606060606060606060606060606060606060606",
+            "transactions": ["0x0102"],
+            "withdrawals": [],
+            "withdrawals_root": "0x0707070707070707070707070707070707070707070707070707070707070707",
+            "blob_gas_used": "0x2c"
+        },
+        "metadata": {
+            "receipts": {
+                "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa": {
+                    "type": "0x2",
+                    "status": true,
+                    "cumulativeGasUsed": "0x5208",
+                    "logs": []
+                }
+            },
+            "new_account_balances": {
+                "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb": "0xde0b6b3a7640000"
+            },
+            "block_number": 1234,
+            "access_list": null
+        }
+    }"#;
+
+    /// The v0.4.1 wire format must deserialize successfully into current types.
+    #[test]
+    fn v0_4_1_wire_format_is_backwards_compatible() {
+        let payload: FlashblocksPayloadV1 =
+            serde_json::from_str(V0_4_1_PAYLOAD_JSON).expect("v0.4.1 JSON must deserialize");
+
+        assert_eq!(payload.index, 0);
+        assert!(payload.base.is_some());
+        assert_eq!(payload.base.as_ref().unwrap().block_number, 9);
+        assert_eq!(payload.diff.gas_used, 500_000);
+        assert_eq!(payload.metadata["block_number"], 1234);
+
+        // Client-side Metadata must also parse (ignoring unknown fields)
+        let metadata: Metadata =
+            serde_json::from_value(payload.metadata).expect("metadata must parse");
+        assert_eq!(metadata.block_number, 1234);
+    }
+
+    /// The v0.5.0-rc.3 wire format must deserialize successfully into current types.
+    #[test]
+    fn v0_5_0_wire_format_is_backwards_compatible() {
+        let payload: FlashblocksPayloadV1 =
+            serde_json::from_str(V0_5_0_PAYLOAD_JSON).expect("v0.5.0 JSON must deserialize");
+
+        assert_eq!(payload.index, 0);
+        assert!(payload.base.is_some());
+        assert_eq!(payload.diff.gas_used, 500_000);
+        assert_eq!(payload.metadata["block_number"], 1234);
+        assert!(payload.metadata.get("receipts").is_some());
+        assert!(payload.metadata.get("new_account_balances").is_some());
+        assert!(payload.metadata.get("access_list").is_some());
+
+        let metadata: Metadata =
+            serde_json::from_value(payload.metadata).expect("metadata must parse");
+        assert_eq!(metadata.block_number, 1234);
+    }
+
+    /// A subsequent flashblock (index > 0) omits `base`. This format must round-trip.
+    #[test]
+    fn subsequent_flashblock_without_base_deserializes() {
+        let json = r#"{
+            "payload_id": "0x0000000000000000",
+            "index": 3,
+            "diff": {
+                "state_root": "0x0404040404040404040404040404040404040404040404040404040404040404",
+                "receipts_root": "0x0505050505050505050505050505050505050505050505050505050505050505",
+                "logs_bloom": "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+                "gas_used": "0x5208",
+                "block_hash": "0x0606060606060606060606060606060606060606060606060606060606060606",
+                "transactions": [],
+                "withdrawals": [],
+                "withdrawals_root": "0x0707070707070707070707070707070707070707070707070707070707070707"
+            },
+            "metadata": {
+                "block_number": 99
+            }
+        }"#;
+
+        let payload: FlashblocksPayloadV1 =
+            serde_json::from_str(json).expect("payload without base must deserialize");
+        assert!(payload.base.is_none());
+        assert_eq!(payload.index, 3);
+    }
+
     fn sample_payload(metadata: serde_json::Value) -> FlashblocksPayloadV1 {
         FlashblocksPayloadV1 {
             payload_id: PayloadId::default(),

--- a/crates/alloy/flashblocks/src/payload.rs
+++ b/crates/alloy/flashblocks/src/payload.rs
@@ -79,3 +79,159 @@ pub struct FlashblocksPayloadV1 {
     /// Additional metadata associated with the flashblock
     pub metadata: Value,
 }
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeSet;
+
+    use alloy_primitives::{Address, B256, Bloom, Bytes, U256};
+    use alloy_rpc_types_engine::PayloadId;
+    use serde_json::json;
+
+    use super::*;
+
+    /// Pin the JSON field names and serde encoding of [`ExecutionPayloadBaseV1`].
+    ///
+    /// Any change to field names, serde attributes, or encoding (e.g. switching
+    /// `block_number` from hex-quantity to plain integer) will break downstream
+    /// consumers parsing the flashblocks websocket.
+    #[test]
+    fn base_v1_json_format_is_stable() {
+        let base = ExecutionPayloadBaseV1 {
+            parent_beacon_block_root: B256::from([0x01; 32]),
+            parent_hash: B256::from([0x02; 32]),
+            fee_recipient: Address::from([0xAA; 20]),
+            prev_randao: B256::from([0x03; 32]),
+            block_number: 100,
+            gas_limit: 30_000_000,
+            timestamp: 1_700_000_000,
+            extra_data: Bytes::from(vec![0xBE, 0xEF]),
+            base_fee_per_gas: U256::from(1_000_000_000u64),
+        };
+
+        let json = serde_json::to_value(&base).unwrap();
+        let obj = json.as_object().unwrap();
+
+        // Exact field set — adding or removing fields is a breaking change
+        let expected_fields: BTreeSet<&str> = [
+            "parent_beacon_block_root",
+            "parent_hash",
+            "fee_recipient",
+            "prev_randao",
+            "block_number",
+            "gas_limit",
+            "timestamp",
+            "extra_data",
+            "base_fee_per_gas",
+        ]
+        .into();
+        let actual_fields: BTreeSet<&str> = obj.keys().map(|s| s.as_str()).collect();
+        assert_eq!(actual_fields, expected_fields, "field names changed");
+
+        // Quantity-encoded fields must be hex strings
+        assert_eq!(obj["block_number"], json!("0x64"));
+        assert_eq!(obj["gas_limit"], json!("0x1c9c380"));
+        assert_eq!(obj["timestamp"], json!("0x6553f100"));
+
+        // Round-trip
+        let deserialized: ExecutionPayloadBaseV1 = serde_json::from_value(json.clone()).unwrap();
+        assert_eq!(deserialized, base);
+    }
+
+    /// Pin the JSON field names and serde encoding of [`ExecutionPayloadFlashblockDeltaV1`].
+    #[test]
+    fn delta_v1_json_format_is_stable() {
+        let delta = ExecutionPayloadFlashblockDeltaV1 {
+            state_root: B256::from([0x04; 32]),
+            receipts_root: B256::from([0x05; 32]),
+            logs_bloom: Bloom::default(),
+            gas_used: 21_000,
+            block_hash: B256::from([0x06; 32]),
+            transactions: vec![Bytes::from(vec![0x01, 0x02])],
+            withdrawals: Vec::new(),
+            withdrawals_root: B256::from([0x07; 32]),
+            blob_gas_used: Some(131_072),
+        };
+
+        let json = serde_json::to_value(&delta).unwrap();
+        let obj = json.as_object().unwrap();
+
+        let expected_fields: BTreeSet<&str> = [
+            "state_root",
+            "receipts_root",
+            "logs_bloom",
+            "gas_used",
+            "block_hash",
+            "transactions",
+            "withdrawals",
+            "withdrawals_root",
+            "blob_gas_used",
+        ]
+        .into();
+        let actual_fields: BTreeSet<&str> = obj.keys().map(|s| s.as_str()).collect();
+        assert_eq!(actual_fields, expected_fields, "field names changed");
+
+        assert_eq!(obj["gas_used"], json!("0x5208"));
+        assert_eq!(obj["blob_gas_used"], json!("0x20000"));
+
+        let deserialized: ExecutionPayloadFlashblockDeltaV1 =
+            serde_json::from_value(json.clone()).unwrap();
+        assert_eq!(deserialized, delta);
+    }
+
+    /// `blob_gas_used` must be omitted (not `null`) when `None`.
+    #[test]
+    fn delta_v1_omits_blob_gas_used_when_none() {
+        let delta = ExecutionPayloadFlashblockDeltaV1 { blob_gas_used: None, ..Default::default() };
+
+        let json = serde_json::to_value(&delta).unwrap();
+        assert!(
+            !json.as_object().unwrap().contains_key("blob_gas_used"),
+            "blob_gas_used should be omitted when None, not serialized as null"
+        );
+    }
+
+    /// `base` must be omitted (not `null`) when `None` in the top-level payload.
+    #[test]
+    fn payload_v1_omits_base_when_none() {
+        let payload = FlashblocksPayloadV1 {
+            payload_id: PayloadId::new([0x01; 8]),
+            index: 1,
+            base: None,
+            diff: ExecutionPayloadFlashblockDeltaV1::default(),
+            metadata: json!({"block_number": 1}),
+        };
+
+        let json = serde_json::to_value(&payload).unwrap();
+        assert!(
+            !json.as_object().unwrap().contains_key("base"),
+            "base should be omitted when None, not serialized as null"
+        );
+    }
+
+    /// Pin the top-level [`FlashblocksPayloadV1`] field set.
+    #[test]
+    fn payload_v1_json_format_is_stable() {
+        let payload = FlashblocksPayloadV1 {
+            payload_id: PayloadId::new([0x01; 8]),
+            index: 0,
+            base: Some(ExecutionPayloadBaseV1::default()),
+            diff: ExecutionPayloadFlashblockDeltaV1::default(),
+            metadata: json!({"block_number": 42}),
+        };
+
+        let json = serde_json::to_value(&payload).unwrap();
+        let obj = json.as_object().unwrap();
+
+        let expected_fields: BTreeSet<&str> =
+            ["payload_id", "index", "base", "diff", "metadata"].into();
+        let actual_fields: BTreeSet<&str> = obj.keys().map(|s| s.as_str()).collect();
+        assert_eq!(actual_fields, expected_fields, "top-level field names changed");
+
+        // index is a plain u64, not hex-encoded
+        assert_eq!(obj["index"], json!(0));
+
+        let deserialized: FlashblocksPayloadV1 = serde_json::from_value(json.clone()).unwrap();
+        assert_eq!(deserialized, payload);
+    }
+}

--- a/crates/builder/core/src/flashblocks/payload.rs
+++ b/crates/builder/core/src/flashblocks/payload.rs
@@ -1113,3 +1113,101 @@ where
         fb_payload,
     ))
 }
+
+#[cfg(test)]
+mod tests {
+    use alloy_consensus::Receipt;
+    use alloy_primitives::{Address, B256, Log, U256, map::foldhash::HashMap};
+    use base_alloy_flashblocks::Metadata;
+    use base_execution_primitives::OpReceipt;
+
+    use super::FlashblocksMetadata;
+
+    /// Pin the JSON field names and structure of [`FlashblocksMetadata`].
+    ///
+    /// This struct is serialized into the `metadata` field of the flashblocks
+    /// websocket payload. Changing field names, types, or serde attributes
+    /// without updating downstream consumers is a breaking change.
+    #[test]
+    fn flashblocks_metadata_json_format_is_stable() {
+        let tx_hash = B256::from([0xAA; 32]);
+        let address = Address::from([0xBB; 20]);
+
+        let receipt = OpReceipt::Eip1559(Receipt {
+            status: true.into(),
+            cumulative_gas_used: 21_000,
+            logs: Vec::<Log>::new(),
+        });
+
+        let mut receipts = HashMap::default();
+        receipts.insert(tx_hash, receipt);
+
+        let mut balances = HashMap::default();
+        balances.insert(address, U256::from(1_000_000_000_000_000_000u128));
+
+        let metadata = FlashblocksMetadata {
+            receipts,
+            new_account_balances: balances,
+            block_number: 42,
+            access_list: None,
+        };
+
+        let json = serde_json::to_value(&metadata).unwrap();
+        let obj = json.as_object().unwrap();
+
+        // Verify exact field set
+        let mut keys: Vec<&String> = obj.keys().collect();
+        keys.sort();
+        assert_eq!(
+            keys,
+            vec!["access_list", "block_number", "new_account_balances", "receipts"],
+            "metadata field names changed"
+        );
+
+        // block_number is a plain integer, not hex-encoded
+        assert_eq!(obj["block_number"], serde_json::json!(42));
+
+        // receipts is a map keyed by tx hash
+        let receipts_obj = obj["receipts"].as_object().unwrap();
+        let tx_key = format!("{tx_hash:#x}");
+        assert!(receipts_obj.contains_key(&tx_key), "receipt should be keyed by tx hash");
+
+        // receipt has internally-tagged type field
+        let receipt_json = &receipts_obj[&tx_key];
+        assert_eq!(receipt_json["type"], "0x2", "EIP-1559 receipt type tag must be 0x2");
+
+        // new_account_balances is a map keyed by address
+        let balances_obj = obj["new_account_balances"].as_object().unwrap();
+        let addr_key = format!("{address:#x}");
+        assert!(balances_obj.contains_key(&addr_key), "balance should be keyed by address");
+
+        // access_list is null when None
+        assert!(obj["access_list"].is_null());
+    }
+
+    /// The client-side [`Metadata`] type must be able to deserialize from
+    /// `FlashblocksMetadata` JSON, ignoring the extra fields.
+    #[test]
+    fn client_metadata_deserializes_from_builder_metadata() {
+        let metadata = FlashblocksMetadata {
+            receipts: HashMap::default(),
+            new_account_balances: HashMap::default(),
+            block_number: 99,
+            access_list: None,
+        };
+
+        let json = serde_json::to_value(&metadata).unwrap();
+        let client_metadata: Metadata =
+            serde_json::from_value(json).expect("client Metadata must parse builder metadata");
+        assert_eq!(client_metadata.block_number, 99);
+    }
+
+    /// The v0.4.1 metadata format (only `block_number`) must still deserialize
+    /// into the client-side [`Metadata`] type.
+    #[test]
+    fn client_metadata_deserializes_from_v0_4_1_format() {
+        let json = serde_json::json!({"block_number": 123});
+        let metadata: Metadata = serde_json::from_value(json).expect("v0.4.1 metadata must parse");
+        assert_eq!(metadata.block_number, 123);
+    }
+}


### PR DESCRIPTION
## Summary

- Adds snapshot tests pinning the JSON wire format of flashblocks websocket payloads (`FlashblocksPayloadV1`, `ExecutionPayloadBaseV1`, `ExecutionPayloadFlashblockDeltaV1`)
- Adds hardcoded JSON backwards compatibility tests for v0.4.1 and v0.5.0-rc.3 wire formats
- Pins the builder-side `FlashblocksMetadata` serialization (field names, receipt type tags, balance keys)
- Verifies the client-side `Metadata` type can deserialize from both old and new builder metadata formats

These tests catch breaking changes to the flashblocks websocket schema at CI time — any change to field names, serde attributes, or encoding will fail these tests.

## Context

The reth v1.9.3 → v1.10.2 upgrade (op-alloy-consensus v0.22 → v0.23) changed `OpReceipt` serialization from externally-tagged (`{"Eip1559": {...}}`) to internally-tagged (`{"type": "0x2", ...}`), breaking downstream consumers. These tests prevent similar regressions.

## Test plan

- [x] `cargo test -p base-alloy-flashblocks` (18 tests pass)
- [x] `cargo test -p base-builder-core --lib -- flashblocks::payload` (3 tests pass)
- [x] `cargo clippy -p base-alloy-flashblocks --profile ci -- -D warnings` (clean)