### PR TITLE
feat(proof): add base-proof-primitives crate and move FlushableCache to preimage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3078,8 +3078,6 @@ dependencies = [
  "base-alloy-evm",
  "base-alloy-rpc-types-engine",
  "base-consensus-genesis",
- "base-proof",
- "base-proof-driver",
  "base-proof-executor",
  "base-proof-mpt",
  "base-proof-preimage",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4043,6 +4043,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "base-proof-primitives"
+version = "0.0.0"
+dependencies = [
+ "alloy-primitives",
+ "base-proof-preimage",
+ "serde",
+]
+
+[[package]]
 name = "base-proof-rpc"
 version = "0.0.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ members = [
   "crates/proof/client",
   "crates/proof/executor",
   "crates/proof/preimage",
+  "crates/proof/primitives",
   "crates/proof/fpvm-precompiles",
   "crates/proof/host",
   "crates/proof/std-fpvm",
@@ -210,6 +211,7 @@ base-proof-client = { path = "crates/proof/client", default-features = false }
 base-proof-driver = { path = "crates/proof/driver", default-features = false }
 base-proof-executor = { path = "crates/proof/executor", default-features = false }
 base-proof-preimage = { path = "crates/proof/preimage", default-features = false }
+base-proof-primitives = { path = "crates/proof/primitives", default-features = false }
 base-proof-fpvm-precompiles = { path = "crates/proof/fpvm-precompiles", default-features = false }
 base-proof-host = { path = "crates/proof/host", default-features = false }
 base-proof-std-fpvm = { path = "crates/proof/std-fpvm", default-features = false }

--- a/crates/proof/preimage/src/lib.rs
+++ b/crates/proof/preimage/src/lib.rs
@@ -24,8 +24,9 @@ pub use hint::{HintReader, HintWriter};
 
 mod traits;
 pub use traits::{
-    Channel, CommsClient, HintReaderServer, HintRouter, HintWriterClient, PreimageFetcher,
-    PreimageOracleClient, PreimageOracleServer, PreimageServerBackend,
+    Channel, CommsClient, FlushableCache, HintReaderServer, HintRouter, HintWriterClient,
+    PreimageFetcher, PreimageOracleClient, PreimageOracleServer, PreimageServerBackend,
+    WitnessOracle,
 };
 
 #[cfg(feature = "std")]

--- a/crates/proof/preimage/src/traits.rs
+++ b/crates/proof/preimage/src/traits.rs
@@ -111,6 +111,27 @@ pub trait PreimageServerBackend: PreimageFetcher + HintRouter {}
 // Implement the super trait for any type that satisfies the bounds
 impl<T: PreimageFetcher + HintRouter> PreimageServerBackend for T {}
 
+/// A cache that can be flushed to discard cached data.
+pub trait FlushableCache {
+    /// Flush the cache, discarding all cached entries.
+    fn flush(&self);
+}
+
+/// A witness oracle that supports preimage insertion and finalization.
+///
+/// Extends [`CommsClient`] and [`FlushableCache`] to provide a unified
+/// interface for oracle implementations across TEE, ZK, and FPVM backends.
+pub trait WitnessOracle: CommsClient + FlushableCache + Send + Sync {
+    /// Insert a preimage into the oracle under the given key.
+    fn insert_preimage(&mut self, key: PreimageKey, value: Vec<u8>);
+
+    /// Finalize the oracle, signaling that no more preimages will be inserted.
+    fn finalize(&mut self);
+
+    /// Return the number of preimages currently held by the oracle.
+    fn preimage_count(&self) -> usize;
+}
+
 /// A [`Channel`] is a high-level interface to read and write data to a counterparty.
 #[async_trait]
 pub trait Channel {

--- a/crates/proof/preimage/src/traits.rs
+++ b/crates/proof/preimage/src/traits.rs
@@ -123,10 +123,10 @@ pub trait FlushableCache {
 /// interface for oracle implementations across TEE, ZK, and FPVM backends.
 pub trait WitnessOracle: CommsClient + FlushableCache + Send + Sync {
     /// Insert a preimage into the oracle under the given key.
-    fn insert_preimage(&mut self, key: PreimageKey, value: Vec<u8>);
+    fn insert_preimage(&self, key: PreimageKey, value: Vec<u8>);
 
     /// Finalize the oracle, signaling that no more preimages will be inserted.
-    fn finalize(&mut self);
+    fn finalize(&self);
 
     /// Return the number of preimages currently held by the oracle.
     fn preimage_count(&self) -> usize;

--- a/crates/proof/preimage/src/traits.rs
+++ b/crates/proof/preimage/src/traits.rs
@@ -123,7 +123,7 @@ pub trait FlushableCache {
 /// interface for oracle implementations across TEE, ZK, and FPVM backends.
 pub trait WitnessOracle: CommsClient + FlushableCache + Send + Sync {
     /// Insert a preimage into the oracle under the given key.
-    fn insert_preimage(&self, key: PreimageKey, value: Vec<u8>);
+    fn insert_preimage(&self, key: PreimageKey, value: &[u8]);
 
     /// Finalize the oracle, signaling that no more preimages will be inserted.
     fn finalize(&self);

--- a/crates/proof/primitives/Cargo.toml
+++ b/crates/proof/primitives/Cargo.toml
@@ -14,11 +14,7 @@ workspace = true
 # General
 alloy-primitives = { workspace = true }
 base-proof-preimage = { workspace = true }
-
-[dependencies.serde]
-workspace = true
-optional = true
-features = ["derive"]
+serde = { workspace = true, optional = true, features = ["derive"] }
 
 [features]
 default = []

--- a/crates/proof/primitives/Cargo.toml
+++ b/crates/proof/primitives/Cargo.toml
@@ -22,12 +22,5 @@ features = ["derive"]
 
 [features]
 default = []
-std = [
-    "alloy-primitives/std",
-    "base-proof-preimage/std",
-]
-serde = [
-    "dep:serde",
-    "alloy-primitives/serde",
-    "base-proof-preimage/serde",
-]
+std = [ "alloy-primitives/std", "base-proof-preimage/std" ]
+serde = [ "alloy-primitives/serde", "base-proof-preimage/serde", "dep:serde" ]

--- a/crates/proof/primitives/Cargo.toml
+++ b/crates/proof/primitives/Cargo.toml
@@ -1,0 +1,33 @@
+[package]
+name = "base-proof-primitives"
+description = "Shared primitive types and traits for the Base proof system"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+
+[lints]
+workspace = true
+
+[dependencies]
+# General
+alloy-primitives = { workspace = true }
+base-proof-preimage = { workspace = true }
+
+[dependencies.serde]
+workspace = true
+optional = true
+features = ["derive"]
+
+[features]
+default = []
+std = [
+    "alloy-primitives/std",
+    "base-proof-preimage/std",
+]
+serde = [
+    "dep:serde",
+    "alloy-primitives/serde",
+    "base-proof-preimage/serde",
+]

--- a/crates/proof/primitives/README.md
+++ b/crates/proof/primitives/README.md
@@ -1,0 +1,12 @@
+# base-proof-primitives
+
+Shared primitive types and traits for the Base proof system.
+
+This crate provides the core protocol types used across TEE, ZK, and FPVM proof
+backends:
+
+- **`WitnessBundle`** — Wire format carrying a set of preimage key-value pairs.
+- **`ProofClaim`** — The claim being proven: L2 block number, output root, and
+  L1 head.
+- **`ProofEvidence`** — Backend-specific evidence (TEE attestation or ZK proof).
+- **`ProofResult`** — A claim paired with its evidence.

--- a/crates/proof/primitives/src/lib.rs
+++ b/crates/proof/primitives/src/lib.rs
@@ -1,0 +1,10 @@
+#![doc = include_str!("../README.md")]
+#![cfg_attr(not(feature = "std"), no_std)]
+
+extern crate alloc;
+
+mod witness;
+pub use witness::WitnessBundle;
+
+mod proof;
+pub use proof::{ProofClaim, ProofEvidence, ProofResult};

--- a/crates/proof/primitives/src/proof.rs
+++ b/crates/proof/primitives/src/proof.rs
@@ -1,0 +1,45 @@
+use alloc::vec::Vec;
+
+use alloy_primitives::B256;
+
+/// The claim being proven: an L2 output root at a given block, anchored to an L1 head.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct ProofClaim {
+    /// The L2 block number this claim covers.
+    pub l2_block_number: u64,
+    /// The L2 output root at `l2_block_number`.
+    pub output_root: B256,
+    /// The L1 head hash used to derive the L2 state.
+    pub l1_head: B256,
+}
+
+/// Backend-specific evidence that accompanies a [`ProofClaim`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub enum ProofEvidence {
+    /// Evidence produced by a TEE backend.
+    Tee {
+        /// The attestation document from the enclave.
+        attestation_doc: Vec<u8>,
+        /// The signature over the claim.
+        signature: Vec<u8>,
+    },
+    /// Evidence produced by a ZK backend.
+    Zk {
+        /// The ZK proof bytes.
+        proof_bytes: Vec<u8>,
+        /// The image ID (program hash) that produced this proof.
+        image_id: B256,
+    },
+}
+
+/// A proven claim: a [`ProofClaim`] paired with its [`ProofEvidence`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct ProofResult {
+    /// The claim being proven.
+    pub claim: ProofClaim,
+    /// The backend-specific evidence for this claim.
+    pub evidence: ProofEvidence,
+}

--- a/crates/proof/primitives/src/witness.rs
+++ b/crates/proof/primitives/src/witness.rs
@@ -1,0 +1,11 @@
+use alloc::vec::Vec;
+
+use base_proof_preimage::PreimageKey;
+
+/// Wire format for a set of preimage key-value pairs.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct WitnessBundle {
+    /// The preimage key-value pairs.
+    pub preimages: Vec<(PreimageKey, Vec<u8>)>,
+}

--- a/crates/proof/proof/src/caching_oracle.rs
+++ b/crates/proof/proof/src/caching_oracle.rs
@@ -7,7 +7,8 @@ use core::num::NonZeroUsize;
 
 use async_trait::async_trait;
 use base_proof_preimage::{
-    HintWriterClient, PreimageKey, PreimageOracleClient, errors::PreimageOracleResult,
+    FlushableCache, HintWriterClient, PreimageKey, PreimageOracleClient,
+    errors::PreimageOracleResult,
 };
 use lru::LruCache;
 use spin::Mutex;
@@ -45,12 +46,6 @@ where
             hint_writer,
         }
     }
-}
-
-/// A trait that provides a method to flush a cache.
-pub trait FlushableCache {
-    /// Flushes the cache, removing all entries.
-    fn flush(&self);
 }
 
 impl<OR, HW> FlushableCache for CachingOracle<OR, HW>

--- a/crates/proof/proof/src/l1/pipeline.rs
+++ b/crates/proof/proof/src/l1/pipeline.rs
@@ -14,12 +14,12 @@ use base_consensus_derive::{
 use base_consensus_genesis::{L1ChainConfig, RollupConfig, SystemConfig};
 use base_proof_driver::{DriverPipeline, PipelineCursor};
 use base_proof_executor::TrieDBProvider;
-use base_proof_preimage::CommsClient;
+use base_proof_preimage::{CommsClient, FlushableCache};
 use base_protocol::{BlockInfo, L2BlockInfo, OpAttributesWithParent};
 use spin::RwLock;
 
 use crate::{
-    FlushableCache, OracleBlobProvider, OracleL1ChainProvider, OracleL2ChainProvider,
+    OracleBlobProvider, OracleL1ChainProvider, OracleL2ChainProvider,
     boot::BootInfo,
     sync::{SafeHeadFetcher, new_oracle_pipeline_cursor},
 };

--- a/crates/proof/proof/src/lib.rs
+++ b/crates/proof/proof/src/lib.rs
@@ -29,7 +29,8 @@ mod boot;
 pub use boot::*;
 
 mod caching_oracle;
-pub use caching_oracle::{CachingOracle, FlushableCache};
+pub use base_proof_preimage::FlushableCache;
+pub use caching_oracle::CachingOracle;
 
 mod blocking_runtime;
 pub use blocking_runtime::block_on;

--- a/crates/proof/proof/src/lib.rs
+++ b/crates/proof/proof/src/lib.rs
@@ -29,8 +29,8 @@ mod boot;
 pub use boot::*;
 
 mod caching_oracle;
-pub use caching_oracle::CachingOracle;
 pub use base_proof_preimage::FlushableCache;
+pub use caching_oracle::CachingOracle;
 
 mod blocking_runtime;
 pub use blocking_runtime::block_on;

--- a/crates/proof/proof/src/lib.rs
+++ b/crates/proof/proof/src/lib.rs
@@ -29,7 +29,6 @@ mod boot;
 pub use boot::*;
 
 mod caching_oracle;
-pub use base_proof_preimage::FlushableCache;
 pub use caching_oracle::CachingOracle;
 
 mod blocking_runtime;

--- a/crates/proof/proof/src/lib.rs
+++ b/crates/proof/proof/src/lib.rs
@@ -29,8 +29,8 @@ mod boot;
 pub use boot::*;
 
 mod caching_oracle;
-pub use base_proof_preimage::FlushableCache;
 pub use caching_oracle::CachingOracle;
+pub use base_proof_preimage::FlushableCache;
 
 mod blocking_runtime;
 pub use blocking_runtime::block_on;

--- a/crates/proof/tee/core/Cargo.toml
+++ b/crates/proof/tee/core/Cargo.toml
@@ -25,9 +25,7 @@ base-alloy-consensus = { workspace = true, features = ["serde"] }
 base-alloy-rpc-types-engine = { workspace = true, features = ["serde"] }
 
 # Proof
-base-proof = { workspace = true, features = ["std"] }
 base-proof-mpt = { workspace = true, features = ["std"] }
-base-proof-driver = { workspace = true, features = ["std"] }
 base-proof-executor = { workspace = true, features = ["std"] }
 base-proof-preimage = { workspace = true, features = ["std"] }
 base-consensus-genesis = { workspace = true, features = ["serde"] }

--- a/crates/proof/tee/core/src/executor/oracle.rs
+++ b/crates/proof/tee/core/src/executor/oracle.rs
@@ -1,9 +1,8 @@
 use std::{collections::HashMap, fmt, sync::Arc};
 
 use async_trait::async_trait;
-use base_proof::FlushableCache;
 use base_proof_preimage::{
-    HintWriterClient, PreimageKey, PreimageOracleClient,
+    FlushableCache, HintWriterClient, PreimageKey, PreimageOracleClient,
     errors::{PreimageOracleError, PreimageOracleResult},
 };
 

--- a/etc/scripts/ci/check-no-std-proof.sh
+++ b/etc/scripts/ci/check-no-std-proof.sh
@@ -20,13 +20,14 @@ RUSTFLAGS="${RUSTFLAGS} --cfg getrandom_backend=\"custom\""
 export RUSTFLAGS
 
 proof_packages=(
-  base-proof-preimage
-  base-proof-mpt
-  base-proof-executor
-  base-proof-driver
   base-proof
   base-proof-client
+  base-proof-driver
+  base-proof-executor
   base-proof-fpvm-precompiles
+  base-proof-mpt
+  base-proof-preimage
+  base-proof-primitives
 )
 
 for package in "${proof_packages[@]}"; do


### PR DESCRIPTION
## Summary

- Introduces `base-proof-primitives`, a new `no_std` crate with shared wire types for the unified proof architecture: `ProofClaim`, `ProofEvidence`, `ProofResult`, `WitnessBundle`.
- Moves `FlushableCache` trait from `base-proof` down to `base-proof-preimage` so all oracle supertraits (`CommsClient`, `FlushableCache`) live at the bottom of the dependency graph. `base-proof` re-exports for backwards compatibility.
- Adds `WitnessOracle` trait to `base-proof-preimage`, extending `CommsClient + FlushableCache + Send + Sync` with preimage insertion, finalization, and counting.
- Adds `base-proof-primitives` to the `no_std` CI check script.

## Motivation

The proof system currently has TEE, ZK, and FPVM backends that each define their own claim/evidence types and oracle patterns. This PR lays the foundation for unifying them behind shared protocol types and a common oracle trait.

**Why `base-proof-primitives`?** We need a lightweight `no_std` crate for wire types (`ProofClaim`, `ProofEvidence`, `ProofResult`, `WitnessBundle`) that any backend can depend on without pulling in the full `base-proof` SDK.

**Why move `FlushableCache` to `base-proof-preimage`?** `FlushableCache` was defined in `base-proof` (the SDK), but `WitnessOracle` needs it as a supertrait alongside `CommsClient` (which lives in `base-proof-preimage`). Moving it down avoids a circular dependency — primitives should sit *below* the SDK, not depend on it.

## New types

### `base-proof-primitives`

| Type | Description |
|------|-------------|
| `ProofClaim` | The claim being proven: L2 block number, output root, L1 head |
| `ProofEvidence` | Backend-specific evidence — `Tee { attestation_doc, signature }` or `Zk { proof_bytes, image_id }` |
| `ProofResult` | A `ProofClaim` paired with its `ProofEvidence` |
| `WitnessBundle` | Wire format: `Vec<(PreimageKey, Vec<u8>)>` for preimage transport |

### `base-proof-preimage` (new additions)

| Type | Description |
|------|-------------|
| `FlushableCache` | Trait with `fn flush(&self)` — moved from `base-proof` |
| `WitnessOracle` | Trait extending `CommsClient + FlushableCache + Send + Sync` with `insert_preimage`, `finalize`, `preimage_count` |

## Dependency graph (proof crates)

```
base-proof-preimage  (leaf — defines CommsClient, FlushableCache, WitnessOracle)
base-proof-primitives (leaf — depends on preimage for PreimageKey only)
        │
base-proof (SDK — depends on preimage, re-exports FlushableCache)
        │
base-proof-client, base-enclave, etc.
```

## What this unblocks

- **RecordingOracle**: a generic `WitnessOracle` impl that records preimages during execution
- **Witness-aware host**: host that accepts `WitnessBundle` for offline replay
- **Proposer integration**: proposer submits `ProofResult` regardless of backend