### PR TITLE
Fix invalid return type

### DIFF
--- a/crates/builder/core/src/test_utils/apis.rs
+++ b/crates/builder/core/src/test_utils/apis.rs
@@ -77,7 +77,7 @@ pub struct EngineApi<P: Protocol = Ipc> {
 }
 
 impl<P: Protocol> EngineApi<P> {
-    async fn client(&self) -> impl SubscriptionClientT + Send + Sync + Unpin + 'static + use<P> {
+    async fn client(&self) -> impl SubscriptionClientT + Send + Sync + Unpin + 'static {
         P::client(self.jwt_secret, self.address.clone()).await
     }
 }


### PR DESCRIPTION
Remove invalid + `use<P>` bound from the return type of `EngineApi::client`.

The previous signature contained a non-existent trait bound (`use<P>`), which is not valid Rust syntax. The method now correctly returns: `impl SubscriptionClientT + Send + Sync + Unpin + 'static`

((No behavioral changes - syntax-level fix only.**