### PR TITLE
Refactor ShutdownSignal Handling

### DIFF
--- a/crates/consensus/service/src/service/mod.rs
+++ b/crates/consensus/service/src/service/mod.rs
@@ -13,4 +13,4 @@ mod node;
 pub use node::{L1Config, RollupNode};
 
 pub(crate) mod util;
-pub(crate) use util::{shutdown_signal, spawn_and_wait};
+pub(crate) use util::spawn_and_wait;

--- a/crates/consensus/service/src/service/util.rs
+++ b/crates/consensus/service/src/service/util.rs
@@ -40,7 +40,7 @@ macro_rules! spawn_and_wait {
         )*
 
         // Create the shutdown signal future
-        let shutdown = $crate::service::shutdown_signal();
+        let shutdown = $crate::service::util::ShutdownSignal::wait();
         tokio::pin!(shutdown);
 
         loop {
@@ -79,28 +79,34 @@ macro_rules! spawn_and_wait {
 pub(crate) use spawn_and_wait;
 
 /// Listens for OS shutdown signals (SIGTERM, SIGINT)
-pub(crate) async fn shutdown_signal() {
-    let ctrl_c = async {
-        tokio::signal::ctrl_c().await.expect("failed to install Ctrl+C handler");
-    };
+#[derive(Debug)]
+pub(crate) struct ShutdownSignal;
 
-    #[cfg(unix)]
-    let terminate = async {
-        tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate())
-            .expect("failed to install SIGTERM handler")
-            .recv()
-            .await;
-    };
+impl ShutdownSignal {
+    /// Waits for OS shutdown signals (SIGTERM, SIGINT).
+    pub(crate) async fn wait() {
+        let ctrl_c = async {
+            tokio::signal::ctrl_c().await.expect("failed to install Ctrl+C handler");
+        };
 
-    #[cfg(not(unix))]
-    let terminate = std::future::pending::<()>();
+        #[cfg(unix)]
+        let terminate = async {
+            tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate())
+                .expect("failed to install SIGTERM handler")
+                .recv()
+                .await;
+        };
 
-    tokio::select! {
-        _ = ctrl_c => {
-            info!(target: "rollup_node", "Received SIGINT (Ctrl+C)");
-        },
-        _ = terminate => {
-            info!(target: "rollup_node", "Received SIGTERM");
-        },
+        #[cfg(not(unix))]
+        let terminate = std::future::pending::<()>();
+
+        tokio::select! {
+            _ = ctrl_c => {
+                info!(target: "rollup_node", "Received SIGINT (Ctrl+C)");
+            },
+            _ = terminate => {
+                info!(target: "rollup_node", "Received SIGTERM");
+            },
+        }
     }
 }


### PR DESCRIPTION
  This PR replaces `shutdown_signal()` with `ShutdownSignal::wait()` in `consensus/service`.

  Why: it makes shutdown handling follow the same type-based pattern used in proposer signal handling, and removes an unnecessary top-level utility export from `service::mod`, keeping signal logic scoped to `service::util`.

  Correctness: behavior is unchanged. The new method keeps the exact same `tokio::select!` branches for `Ctrl+C` and Unix `SIGTERM`, with the same logs and cancellation path used by `spawn_and_wait!`. This is a pure API-shape refactor, not a runtime behavior change.