### PR TITLE
fix(flashblocks): reset WebSocket backoff after successful connection

### DIFF
--- a/crates/execution/flashblocks/src/subscription.rs
+++ b/crates/execution/flashblocks/src/subscription.rs
@@ -57,6 +57,7 @@ where
             loop {
                 match connect_async(ws_url.as_str()).await {
                     Ok((ws_stream, _)) => {
+                        backoff = Duration::from_secs(1);
                         info!(message = "WebSocket connection established");
 
                         let mut ping_interval =


### PR DESCRIPTION
## Summary

- Fixes the exponential backoff delay for WebSocket reconnections never being reset after a successful connection, which caused permanently elevated reconnect delays after transient failures.
- Resets `backoff` to `Duration::from_secs(1)` immediately upon successful WebSocket connection in `FlashblocksSubscriber::start()`.

Closes #912