### PR TITLE
feat(challenger): Challenger game scanner

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2643,8 +2643,10 @@ dependencies = [
  "alloy-primitives",
  "alloy-signer",
  "alloy-signer-local",
+ "async-trait",
  "axum",
  "base-cli-utils",
+ "base-proof-contracts",
  "clap",
  "eyre",
  "hex",
@@ -4320,6 +4322,7 @@ dependencies = [
  "alloy-consensus",
  "alloy-eips",
  "alloy-primitives",
+ "async-trait",
  "base-alloy-consensus",
  "base-alloy-flz",
  "base-execution-chainspec",
@@ -4343,10 +4346,10 @@ dependencies = [
  "reth-tasks",
  "reth-transaction-pool",
  "serde",
- "serde_json",
  "tokio",
  "tokio-util",
  "tracing",
+ "url",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2649,6 +2649,7 @@ dependencies = [
  "base-proof-contracts",
  "clap",
  "eyre",
+ "futures",
  "hex",
  "humantime",
  "metrics",

--- a/crates/proof/challenge/Cargo.toml
+++ b/crates/proof/challenge/Cargo.toml
@@ -16,7 +16,6 @@ workspace = true
 alloy-primitives.workspace = true
 
 # Async
-async-trait.workspace = true
 tokio.workspace = true
 
 # Tracing
@@ -55,5 +54,6 @@ url.workspace = true
 
 [dev-dependencies]
 rstest.workspace = true
+async-trait.workspace = true
 tokio = { workspace = true, features = ["test-util"] }
 reqwest = { workspace = true, features = ["json"] }

--- a/crates/proof/challenge/Cargo.toml
+++ b/crates/proof/challenge/Cargo.toml
@@ -16,6 +16,7 @@ workspace = true
 alloy-primitives.workspace = true
 
 # Async
+futures.workspace = true
 tokio.workspace = true
 
 # Tracing

--- a/crates/proof/challenge/Cargo.toml
+++ b/crates/proof/challenge/Cargo.toml
@@ -16,6 +16,7 @@ workspace = true
 alloy-primitives.workspace = true
 
 # Async
+async-trait.workspace = true
 tokio.workspace = true
 
 # Tracing
@@ -37,6 +38,9 @@ zeroize.workspace = true
 # CLI
 base-cli-utils.workspace = true
 clap.workspace = true
+
+# Contracts
+base-proof-contracts.workspace = true
 
 # Metrics
 metrics.workspace = true

--- a/crates/proof/challenge/README.md
+++ b/crates/proof/challenge/README.md
@@ -7,7 +7,7 @@ ZK-proof dispute game challenger.
 
 ## Overview
 
-- **Scanner**: Reads the `DisputeGameFactory` for new dispute games, filtering by game type, `IN_PROGRESS` status, and unchallenged state (`zkProver == zero`) to produce `CandidateGame`s for downstream processing.
+- **Scanner**: Reads the `DisputeGameFactory` for new dispute games, filtering by `IN_PROGRESS` status and unchallenged state (`zkProver == zero`) to produce `CandidateGame`s for downstream processing.
 - **Service**: Lifecycle orchestration for the challenger (init, health, metrics, shutdown).
 - **Config**: Validated runtime configuration with CLI argument parsing.
 - **Health**: HTTP liveness (`/healthz`) and readiness (`/readyz`) probes.

--- a/crates/proof/challenge/README.md
+++ b/crates/proof/challenge/README.md
@@ -7,6 +7,7 @@ ZK-proof dispute game challenger.
 
 ## Overview
 
+- **Scanner**: Reads the `DisputeGameFactory` for new dispute games, filtering by game type, `IN_PROGRESS` status, and unchallenged state (`zkProver == zero`) to produce `CandidateGame`s for downstream processing.
 - **Service**: Lifecycle orchestration for the challenger (init, health, metrics, shutdown).
 - **Config**: Validated runtime configuration with CLI argument parsing.
 - **Health**: HTTP liveness (`/healthz`) and readiness (`/readyz`) probes.

--- a/crates/proof/challenge/src/cli.rs
+++ b/crates/proof/challenge/src/cli.rs
@@ -68,10 +68,6 @@ pub struct ChallengerArgs {
     #[arg(long = "anchor-state-registry-addr", env = "CHALLENGER_ANCHOR_STATE_REGISTRY_ADDR")]
     pub anchor_state_registry_addr: Address,
 
-    /// Game type ID for dispute games to monitor.
-    #[arg(long = "game-type", env = "CHALLENGER_GAME_TYPE")]
-    pub game_type: u32,
-
     /// Polling interval for new dispute games (e.g., "12s", "1m").
     #[arg(
         long = "poll-interval",
@@ -116,7 +112,6 @@ impl std::fmt::Debug for ChallengerArgs {
             .field("rollup_rpc", &self.rollup_rpc)
             .field("dispute_game_factory_addr", &self.dispute_game_factory_addr)
             .field("anchor_state_registry_addr", &self.anchor_state_registry_addr)
-            .field("game_type", &self.game_type)
             .field("poll_interval", &self.poll_interval)
             .field("zk_proof_service_endpoint", &self.zk_proof_service_endpoint)
             .field("signer_endpoint", &self.signer_endpoint)

--- a/crates/proof/challenge/src/config.rs
+++ b/crates/proof/challenge/src/config.rs
@@ -125,8 +125,6 @@ pub struct ChallengerConfig {
     pub dispute_game_factory_addr: Address,
     /// Address of the `AnchorStateRegistry` contract on L1.
     pub anchor_state_registry_addr: Address,
-    /// Game type ID for dispute games to monitor.
-    pub game_type: u32,
     /// Polling interval for new dispute games.
     pub poll_interval: Duration,
     /// URL of the ZK proof service endpoint.
@@ -216,7 +214,6 @@ impl ChallengerConfig {
             rollup_rpc,
             dispute_game_factory_addr: cli.challenger.dispute_game_factory_addr,
             anchor_state_registry_addr: cli.challenger.anchor_state_registry_addr,
-            game_type: cli.challenger.game_type,
             poll_interval: cli.challenger.poll_interval,
             zk_proof_service_endpoint,
             signing,
@@ -293,7 +290,6 @@ mod tests {
             ("--rollup-rpc", "http://localhost:7545"),
             ("--dispute-game-factory-addr", "0x1234567890123456789012345678901234567890"),
             ("--anchor-state-registry-addr", "0x2234567890123456789012345678901234567890"),
-            ("--game-type", "1"),
             ("--zk-proof-service-endpoint", "http://localhost:5000"),
             ("--signer-endpoint", "http://localhost:8546"),
             ("--signer-address", "0x1234567890123456789012345678901234567890"),
@@ -314,7 +310,6 @@ mod tests {
     fn test_valid_config() {
         let cli = cli_from_args(&[]);
         let config = ChallengerConfig::from_cli(cli, None).unwrap();
-        assert_eq!(config.game_type, 1);
         assert_eq!(config.poll_interval, Duration::from_secs(12));
         assert_eq!(config.lookback_games, 1000);
         assert_eq!(config.health_addr, "0.0.0.0:8080".parse::<SocketAddr>().unwrap());

--- a/crates/proof/challenge/src/config.rs
+++ b/crates/proof/challenge/src/config.rs
@@ -185,6 +185,15 @@ impl ChallengerConfig {
             });
         }
 
+        // Validate lookback_games > 0
+        if cli.challenger.lookback_games == 0 {
+            return Err(ConfigError::OutOfRange {
+                field: "lookback-games",
+                constraint: "greater than 0",
+                value: "0".to_string(),
+            });
+        }
+
         // Validate metrics port when enabled
         if cli.metrics.enabled && cli.metrics.port == 0 {
             return Err(ConfigError::Metrics(
@@ -433,6 +442,13 @@ mod tests {
         } else {
             assert!(matches!(result, Err(ConfigError::Signing(_))));
         }
+    }
+
+    #[test]
+    fn test_zero_lookback_games() {
+        let cli = cli_from_args(&["--lookback-games", "0"]);
+        let result = ChallengerConfig::from_cli(cli, None);
+        assert!(matches!(result, Err(ConfigError::OutOfRange { field: "lookback-games", .. })));
     }
 
     #[test]

--- a/crates/proof/challenge/src/lib.rs
+++ b/crates/proof/challenge/src/lib.rs
@@ -15,10 +15,10 @@ mod metrics;
 pub use metrics::ChallengerMetrics;
 
 mod scanner;
-pub use scanner::{CandidateGame, GameScanner, ScannerConfig};
+pub use scanner::{CandidateGame, GameScanner, STATUS_IN_PROGRESS, ScannerConfig};
 
 mod service;
 pub use service::ChallengerService;
 
 #[cfg(test)]
-mod test_utils;
+pub mod test_utils;

--- a/crates/proof/challenge/src/lib.rs
+++ b/crates/proof/challenge/src/lib.rs
@@ -15,7 +15,7 @@ mod metrics;
 pub use metrics::ChallengerMetrics;
 
 mod scanner;
-pub use scanner::{CandidateGame, GameScanner, SCAN_CONCURRENCY, STATUS_IN_PROGRESS, ScannerConfig};
+pub use scanner::{CandidateGame, GameScanner, ScannerConfig};
 
 mod service;
 pub use service::ChallengerService;

--- a/crates/proof/challenge/src/lib.rs
+++ b/crates/proof/challenge/src/lib.rs
@@ -15,7 +15,7 @@ mod metrics;
 pub use metrics::ChallengerMetrics;
 
 mod scanner;
-pub use scanner::{CandidateGame, GameScanner, STATUS_IN_PROGRESS, ScannerConfig};
+pub use scanner::{CandidateGame, GameScanner, SCAN_CONCURRENCY, STATUS_IN_PROGRESS, ScannerConfig};
 
 mod service;
 pub use service::ChallengerService;

--- a/crates/proof/challenge/src/lib.rs
+++ b/crates/proof/challenge/src/lib.rs
@@ -14,5 +14,11 @@ pub use health::HealthServer;
 mod metrics;
 pub use metrics::ChallengerMetrics;
 
+mod scanner;
+pub use scanner::{CandidateGame, GameScanner, ScannerConfig};
+
 mod service;
 pub use service::ChallengerService;
+
+#[cfg(test)]
+mod test_utils;

--- a/crates/proof/challenge/src/metrics.rs
+++ b/crates/proof/challenge/src/metrics.rs
@@ -9,6 +9,12 @@ impl ChallengerMetrics {
     /// Gauge: challenger is running (set to 1 at startup).
     pub const UP: &str = "base_challenger_up";
 
+    /// Counter: total number of games evaluated during scanning.
+    pub const GAMES_SCANNED_TOTAL: &str = "base_challenger_games_scanned_total";
+
+    /// Gauge: latest factory index scanned by the game scanner.
+    pub const SCAN_HEAD: &str = "base_challenger_scan_head";
+
     /// Label key for version.
     pub const LABEL_VERSION: &str = "version";
 

--- a/crates/proof/challenge/src/scanner.rs
+++ b/crates/proof/challenge/src/scanner.rs
@@ -130,20 +130,24 @@ impl GameScanner {
         }
 
         metrics::counter!(ChallengerMetrics::GAMES_SCANNED_TOTAL).increment(games_to_scan);
-        metrics::gauge!(ChallengerMetrics::SCAN_HEAD).set(end as f64);
-
-        info!(
-            games_found = candidates.len(),
-            scan_head = end,
-            games_scanned = games_to_scan,
-            "scan complete"
-        );
 
         let new_last_scanned = match lowest_error {
             Some(0) => last_scanned,
             Some(e) => Some(e - 1),
             None => Some(end),
         };
+
+        if let Some(head) = new_last_scanned {
+            metrics::gauge!(ChallengerMetrics::SCAN_HEAD).set(head as f64);
+        }
+
+        info!(
+            games_found = candidates.len(),
+            scan_head = ?new_last_scanned,
+            games_scanned = games_to_scan,
+            "scan complete"
+        );
+
         Ok((candidates, new_last_scanned))
     }
 

--- a/crates/proof/challenge/src/scanner.rs
+++ b/crates/proof/challenge/src/scanner.rs
@@ -174,10 +174,11 @@ impl GameScanner {
             return Ok(None);
         }
 
-        let GameInfo { root_claim, l2_block_number, parent_index } =
-            self.verifier_client.game_info(proxy).await?;
-
-        let starting_block_number = self.verifier_client.starting_block_number(proxy).await?;
+        let (GameInfo { root_claim, l2_block_number, parent_index }, starting_block_number) =
+            tokio::try_join!(
+                self.verifier_client.game_info(proxy),
+                self.verifier_client.starting_block_number(proxy),
+            )?;
 
         Ok(Some(CandidateGame {
             index,

--- a/crates/proof/challenge/src/scanner.rs
+++ b/crates/proof/challenge/src/scanner.rs
@@ -14,6 +14,9 @@ use tracing::{debug, info, warn};
 
 use crate::ChallengerMetrics;
 
+/// Game status indicating the dispute is still in progress.
+pub const STATUS_IN_PROGRESS: u8 = 0;
+
 /// Configuration for the game scanner.
 #[derive(Debug, Clone)]
 pub struct ScannerConfig {
@@ -123,7 +126,7 @@ impl GameScanner {
     /// Evaluates a single game at the given factory index.
     ///
     /// Returns `Some(CandidateGame)` if the game matches the configured game type,
-    /// is `IN_PROGRESS`, and has not been challenged (zkProver == zero).
+    /// is `IN_PROGRESS`, and has not been challenged (`zkProver` == zero).
     /// Returns `None` if the game should be skipped.
     async fn evaluate_game(&self, index: u64) -> Result<Option<CandidateGame>> {
         let GameAtIndex { game_type, proxy, .. } = self.factory_client.game_at_index(index).await?;
@@ -139,7 +142,7 @@ impl GameScanner {
         }
 
         let status = self.verifier_client.status(proxy).await?;
-        if status != 0 {
+        if status != STATUS_IN_PROGRESS {
             debug!(index = index, status = status, "skipping game not in progress");
             return Ok(None);
         }

--- a/crates/proof/challenge/src/scanner.rs
+++ b/crates/proof/challenge/src/scanner.rs
@@ -16,12 +16,16 @@ use base_proof_contracts::{
     AggregateVerifierClient, DisputeGameFactoryClient, GameAtIndex, GameInfo,
 };
 use eyre::Result;
+use futures::stream::{self, StreamExt};
 use tracing::{debug, info, warn};
 
 use crate::ChallengerMetrics;
 
 /// Game status indicating the dispute is still in progress.
 pub const STATUS_IN_PROGRESS: u8 = 0;
+
+/// Maximum number of games to evaluate concurrently during a scan.
+pub const SCAN_CONCURRENCY: usize = 32;
 
 /// Configuration for the game scanner.
 #[derive(Debug, Clone)]
@@ -108,11 +112,18 @@ impl GameScanner {
         }
 
         let games_to_scan = end - start + 1;
+
+        let results: Vec<(u64, Result<Option<CandidateGame>>)> = stream::iter(start..=end)
+            .map(|i| async move { (i, self.evaluate_game(i).await) })
+            .buffer_unordered(SCAN_CONCURRENCY)
+            .collect()
+            .await;
+
         let mut candidates = Vec::new();
         let mut lowest_error: Option<u64> = None;
 
-        for i in start..=end {
-            match self.evaluate_game(i).await {
+        for (i, result) in results {
+            match result {
                 Ok(Some(candidate)) => candidates.push(candidate),
                 Ok(None) => {}
                 Err(e) => {
@@ -121,6 +132,8 @@ impl GameScanner {
                 }
             }
         }
+
+        candidates.sort_by_key(|c| c.index);
 
         metrics::counter!(ChallengerMetrics::GAMES_SCANNED_TOTAL).increment(games_to_scan);
 
@@ -149,7 +162,7 @@ impl GameScanner {
     /// Returns `Some(CandidateGame)` if the game is `IN_PROGRESS` and has not
     /// been challenged (`zkProver` == zero). Returns `None` if the game should
     /// be skipped.
-    async fn evaluate_game(&self, index: u64) -> Result<Option<CandidateGame>> {
+    pub async fn evaluate_game(&self, index: u64) -> Result<Option<CandidateGame>> {
         let factory = self.factory_client.game_at_index(index).await?;
 
         let status = self.verifier_client.status(factory.proxy).await?;

--- a/crates/proof/challenge/src/scanner.rs
+++ b/crates/proof/challenge/src/scanner.rs
@@ -4,7 +4,7 @@
 //! for dispute games requiring validation. Each game is evaluated through a
 //! two-stage filter:
 //!
-//! 1. **Status** — must be `IN_PROGRESS` ([`STATUS_IN_PROGRESS`]).
+//! 1. **Status** — must be `IN_PROGRESS` ([`GameScanner::STATUS_IN_PROGRESS`]).
 //! 2. **Challenge state** — `zkProver` must be `Address::ZERO` (unchallenged).
 //!
 //! Games passing both filters are returned as [`CandidateGame`] structs.
@@ -20,12 +20,6 @@ use futures::stream::{self, StreamExt};
 use tracing::{debug, info, warn};
 
 use crate::ChallengerMetrics;
-
-/// Game status indicating the dispute is still in progress.
-pub const STATUS_IN_PROGRESS: u8 = 0;
-
-/// Maximum number of games to evaluate concurrently during a scan.
-pub const SCAN_CONCURRENCY: usize = 32;
 
 /// Configuration for the game scanner.
 #[derive(Debug, Clone)]
@@ -64,6 +58,12 @@ impl std::fmt::Debug for GameScanner {
 }
 
 impl GameScanner {
+    /// Game status indicating the dispute is still in progress.
+    pub const STATUS_IN_PROGRESS: u8 = 0;
+
+    /// Maximum number of games to evaluate concurrently during a scan.
+    pub const SCAN_CONCURRENCY: usize = 32;
+
     /// Creates a new game scanner.
     pub fn new(
         factory_client: Arc<dyn DisputeGameFactoryClient>,
@@ -115,7 +115,7 @@ impl GameScanner {
 
         let results: Vec<(u64, Result<Option<CandidateGame>>)> = stream::iter(start..=end)
             .map(|i| async move { (i, self.evaluate_game(i).await) })
-            .buffer_unordered(SCAN_CONCURRENCY)
+            .buffer_unordered(Self::SCAN_CONCURRENCY)
             .collect()
             .await;
 
@@ -166,7 +166,7 @@ impl GameScanner {
         let factory = self.factory_client.game_at_index(index).await?;
 
         let status = self.verifier_client.status(factory.proxy).await?;
-        if status != STATUS_IN_PROGRESS {
+        if status != Self::STATUS_IN_PROGRESS {
             debug!(index = index, status = status, "skipping game not in progress");
             return Ok(None);
         }

--- a/crates/proof/challenge/src/scanner.rs
+++ b/crates/proof/challenge/src/scanner.rs
@@ -1,7 +1,14 @@
 //! Game scanner for the challenger service.
 //!
-//! Scans the `DisputeGameFactory` for dispute games requiring validation,
-//! filtering by game type, status, and challenge state.
+//! Scans the [`DisputeGameFactory`](base_proof_contracts::DisputeGameFactoryClient)
+//! for dispute games requiring validation. Each game is evaluated through a
+//! three-stage filter:
+//!
+//! 1. **Game type** — must match [`ScannerConfig::game_type`].
+//! 2. **Status** — must be `IN_PROGRESS` ([`STATUS_IN_PROGRESS`]).
+//! 3. **Challenge state** — `zkProver` must be `Address::ZERO` (unchallenged).
+//!
+//! Games passing all three filters are returned as [`CandidateGame`] structs.
 
 use std::sync::Arc;
 
@@ -77,6 +84,11 @@ impl GameScanner {
     ///
     /// On a fresh start, pass `0` as `last_scanned` and the lookback window will
     /// determine the scan range.
+    ///
+    /// Individual game query failures are logged and skipped so that a transient
+    /// RPC error on one game does not abort the entire scan. After evaluation,
+    /// the `base_challenger_games_scanned_total` counter and
+    /// `base_challenger_scan_head` gauge are updated.
     pub async fn scan(&self, last_scanned: u64) -> Result<(Vec<CandidateGame>, u64)> {
         let game_count = self.factory_client.game_count().await?;
 

--- a/crates/proof/challenge/src/scanner.rs
+++ b/crates/proof/challenge/src/scanner.rs
@@ -174,11 +174,10 @@ impl GameScanner {
             return Ok(None);
         }
 
-        let (GameInfo { root_claim, l2_block_number, parent_index }, starting_block_number) =
-            tokio::try_join!(
-                self.verifier_client.game_info(proxy),
-                self.verifier_client.starting_block_number(proxy),
-            )?;
+        let (GameInfo { root_claim, l2_block_number, parent_index }, starting_block_number) = tokio::try_join!(
+            self.verifier_client.game_info(proxy),
+            self.verifier_client.starting_block_number(proxy),
+        )?;
 
         Ok(Some(CandidateGame {
             index,

--- a/crates/proof/challenge/src/scanner.rs
+++ b/crates/proof/challenge/src/scanner.rs
@@ -116,6 +116,7 @@ impl GameScanner {
 
         let games_to_scan = end - start + 1;
         let mut candidates = Vec::new();
+        let mut lowest_error: Option<u64> = None;
 
         for i in start..=end {
             match self.evaluate_game(i).await {
@@ -123,6 +124,7 @@ impl GameScanner {
                 Ok(None) => {}
                 Err(e) => {
                     warn!(error = %e, index = i, "failed to query game, skipping");
+                    lowest_error = lowest_error.map_or(Some(i), |prev| Some(prev.min(i)));
                 }
             }
         }
@@ -137,7 +139,12 @@ impl GameScanner {
             "scan complete"
         );
 
-        Ok((candidates, Some(end)))
+        let new_last_scanned = match lowest_error {
+            Some(0) => last_scanned,
+            Some(e) => Some(e - 1),
+            None => Some(end),
+        };
+        Ok((candidates, new_last_scanned))
     }
 
     /// Evaluates a single game at the given factory index.

--- a/crates/proof/challenge/src/scanner.rs
+++ b/crates/proof/challenge/src/scanner.rs
@@ -82,14 +82,17 @@ impl GameScanner {
     /// is the latest factory index that was evaluated. The caller is responsible
     /// for tracking `last_scanned` between calls.
     ///
-    /// On a fresh start, pass `0` as `last_scanned` and the lookback window will
+    /// On a fresh start, pass `None` as `last_scanned` and the lookback window will
     /// determine the scan range.
     ///
     /// Individual game query failures are logged and skipped so that a transient
     /// RPC error on one game does not abort the entire scan. After evaluation,
     /// the `base_challenger_games_scanned_total` counter and
     /// `base_challenger_scan_head` gauge are updated.
-    pub async fn scan(&self, last_scanned: u64) -> Result<(Vec<CandidateGame>, u64)> {
+    pub async fn scan(
+        &self,
+        last_scanned: Option<u64>,
+    ) -> Result<(Vec<CandidateGame>, Option<u64>)> {
         let game_count = self.factory_client.game_count().await?;
 
         if game_count == 0 {
@@ -98,11 +101,12 @@ impl GameScanner {
         }
 
         let end = game_count - 1;
-        let start = (last_scanned + 1).max(game_count.saturating_sub(self.config.lookback_games));
+        let lookback_start = game_count.saturating_sub(self.config.lookback_games);
+        let start = last_scanned.map_or(lookback_start, |idx| (idx + 1).max(lookback_start));
 
         if start > end {
             debug!(
-                last_scanned = last_scanned,
+                last_scanned = ?last_scanned,
                 game_count = game_count,
                 "no new games since last scan"
             );
@@ -132,7 +136,7 @@ impl GameScanner {
             "scan complete"
         );
 
-        Ok((candidates, end))
+        Ok((candidates, Some(end)))
     }
 
     /// Evaluates a single game at the given factory index.

--- a/crates/proof/challenge/src/scanner.rs
+++ b/crates/proof/challenge/src/scanner.rs
@@ -102,7 +102,7 @@ impl GameScanner {
 
         let end = game_count - 1;
         let lookback_start = game_count.saturating_sub(self.config.lookback_games);
-        let start = last_scanned.map_or(lookback_start, |idx| (idx + 1).max(lookback_start));
+        let start = last_scanned.map_or(lookback_start, |idx| idx.saturating_add(1).max(lookback_start));
 
         if start > end {
             debug!(

--- a/crates/proof/challenge/src/scanner.rs
+++ b/crates/proof/challenge/src/scanner.rs
@@ -11,7 +11,7 @@
 
 use std::sync::Arc;
 
-use alloy_primitives::{Address, B256};
+use alloy_primitives::Address;
 use base_proof_contracts::{
     AggregateVerifierClient, DisputeGameFactoryClient, GameAtIndex, GameInfo,
 };
@@ -35,16 +35,10 @@ pub struct ScannerConfig {
 pub struct CandidateGame {
     /// The factory index of this game.
     pub index: u64,
-    /// The game type ID from the factory.
-    pub game_type: u32,
-    /// The proxy address of the game contract.
-    pub proxy: Address,
-    /// The output root claimed by this game.
-    pub root_claim: B256,
-    /// The L2 block number of this game.
-    pub l2_block_number: u64,
-    /// The parent game's factory index.
-    pub parent_index: u32,
+    /// Game data from the factory contract.
+    pub factory: GameAtIndex,
+    /// Game info from the verifier contract.
+    pub info: GameInfo,
     /// The starting block number for this game.
     pub starting_block_number: u64,
 }
@@ -156,15 +150,15 @@ impl GameScanner {
     /// been challenged (`zkProver` == zero). Returns `None` if the game should
     /// be skipped.
     async fn evaluate_game(&self, index: u64) -> Result<Option<CandidateGame>> {
-        let GameAtIndex { game_type, proxy, .. } = self.factory_client.game_at_index(index).await?;
+        let factory = self.factory_client.game_at_index(index).await?;
 
-        let status = self.verifier_client.status(proxy).await?;
+        let status = self.verifier_client.status(factory.proxy).await?;
         if status != STATUS_IN_PROGRESS {
             debug!(index = index, status = status, "skipping game not in progress");
             return Ok(None);
         }
 
-        let zk_prover = self.verifier_client.zk_prover(proxy).await?;
+        let zk_prover = self.verifier_client.zk_prover(factory.proxy).await?;
         if zk_prover != Address::ZERO {
             debug!(
                 index = index,
@@ -174,19 +168,11 @@ impl GameScanner {
             return Ok(None);
         }
 
-        let (GameInfo { root_claim, l2_block_number, parent_index }, starting_block_number) = tokio::try_join!(
-            self.verifier_client.game_info(proxy),
-            self.verifier_client.starting_block_number(proxy),
+        let (info, starting_block_number) = tokio::try_join!(
+            self.verifier_client.game_info(factory.proxy),
+            self.verifier_client.starting_block_number(factory.proxy),
         )?;
 
-        Ok(Some(CandidateGame {
-            index,
-            game_type,
-            proxy,
-            root_claim,
-            l2_block_number,
-            parent_index,
-            starting_block_number,
-        }))
+        Ok(Some(CandidateGame { index, factory, info, starting_block_number }))
     }
 }

--- a/crates/proof/challenge/src/scanner.rs
+++ b/crates/proof/challenge/src/scanner.rs
@@ -102,7 +102,8 @@ impl GameScanner {
 
         let end = game_count - 1;
         let lookback_start = game_count.saturating_sub(self.config.lookback_games);
-        let start = last_scanned.map_or(lookback_start, |idx| idx.saturating_add(1).max(lookback_start));
+        let start =
+            last_scanned.map_or(lookback_start, |idx| idx.saturating_add(1).max(lookback_start));
 
         if start > end {
             debug!(

--- a/crates/proof/challenge/src/scanner.rs
+++ b/crates/proof/challenge/src/scanner.rs
@@ -2,13 +2,12 @@
 //!
 //! Scans the [`DisputeGameFactory`](base_proof_contracts::DisputeGameFactoryClient)
 //! for dispute games requiring validation. Each game is evaluated through a
-//! three-stage filter:
+//! two-stage filter:
 //!
-//! 1. **Game type** — must match [`ScannerConfig::game_type`].
-//! 2. **Status** — must be `IN_PROGRESS` ([`STATUS_IN_PROGRESS`]).
-//! 3. **Challenge state** — `zkProver` must be `Address::ZERO` (unchallenged).
+//! 1. **Status** — must be `IN_PROGRESS` ([`STATUS_IN_PROGRESS`]).
+//! 2. **Challenge state** — `zkProver` must be `Address::ZERO` (unchallenged).
 //!
-//! Games passing all three filters are returned as [`CandidateGame`] structs.
+//! Games passing both filters are returned as [`CandidateGame`] structs.
 
 use std::sync::Arc;
 
@@ -27,8 +26,6 @@ pub const STATUS_IN_PROGRESS: u8 = 0;
 /// Configuration for the game scanner.
 #[derive(Debug, Clone)]
 pub struct ScannerConfig {
-    /// Game type ID to filter for.
-    pub game_type: u32,
     /// Number of past games to scan on startup (lookback window).
     pub lookback_games: u64,
 }
@@ -38,6 +35,8 @@ pub struct ScannerConfig {
 pub struct CandidateGame {
     /// The factory index of this game.
     pub index: u64,
+    /// The game type ID from the factory.
+    pub game_type: u32,
     /// The proxy address of the game contract.
     pub proxy: Address,
     /// The output root claimed by this game.
@@ -153,21 +152,11 @@ impl GameScanner {
 
     /// Evaluates a single game at the given factory index.
     ///
-    /// Returns `Some(CandidateGame)` if the game matches the configured game type,
-    /// is `IN_PROGRESS`, and has not been challenged (`zkProver` == zero).
-    /// Returns `None` if the game should be skipped.
+    /// Returns `Some(CandidateGame)` if the game is `IN_PROGRESS` and has not
+    /// been challenged (`zkProver` == zero). Returns `None` if the game should
+    /// be skipped.
     async fn evaluate_game(&self, index: u64) -> Result<Option<CandidateGame>> {
         let GameAtIndex { game_type, proxy, .. } = self.factory_client.game_at_index(index).await?;
-
-        if game_type != self.config.game_type {
-            debug!(
-                index = index,
-                game_type = game_type,
-                expected = self.config.game_type,
-                "skipping non-matching game type"
-            );
-            return Ok(None);
-        }
 
         let status = self.verifier_client.status(proxy).await?;
         if status != STATUS_IN_PROGRESS {
@@ -192,6 +181,7 @@ impl GameScanner {
 
         Ok(Some(CandidateGame {
             index,
+            game_type,
             proxy,
             root_claim,
             l2_block_number,

--- a/crates/proof/challenge/src/scanner.rs
+++ b/crates/proof/challenge/src/scanner.rs
@@ -1,0 +1,171 @@
+//! Game scanner for the challenger service.
+//!
+//! Scans the `DisputeGameFactory` for dispute games requiring validation,
+//! filtering by game type, status, and challenge state.
+
+use std::sync::Arc;
+
+use alloy_primitives::{Address, B256};
+use base_proof_contracts::{
+    AggregateVerifierClient, DisputeGameFactoryClient, GameAtIndex, GameInfo,
+};
+use eyre::Result;
+use tracing::{debug, info, warn};
+
+use crate::ChallengerMetrics;
+
+/// Configuration for the game scanner.
+#[derive(Debug, Clone)]
+pub struct ScannerConfig {
+    /// Game type ID to filter for.
+    pub game_type: u32,
+    /// Number of past games to scan on startup (lookback window).
+    pub lookback_games: u64,
+}
+
+/// A dispute game that has been identified as a candidate for challenge.
+#[derive(Debug, Clone)]
+pub struct CandidateGame {
+    /// The factory index of this game.
+    pub index: u64,
+    /// The proxy address of the game contract.
+    pub proxy: Address,
+    /// The output root claimed by this game.
+    pub root_claim: B256,
+    /// The L2 block number of this game.
+    pub l2_block_number: u64,
+    /// The parent game's factory index.
+    pub parent_index: u32,
+    /// The starting block number for this game.
+    pub starting_block_number: u64,
+}
+
+/// Scans the `DisputeGameFactory` for new dispute games that need validation.
+///
+/// The scanner is stateless across restarts — `last_scanned_index` is ephemeral
+/// and recomputed from the lookback window on startup.
+pub struct GameScanner {
+    factory_client: Arc<dyn DisputeGameFactoryClient>,
+    verifier_client: Arc<dyn AggregateVerifierClient>,
+    config: ScannerConfig,
+}
+
+impl std::fmt::Debug for GameScanner {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("GameScanner").field("config", &self.config).finish_non_exhaustive()
+    }
+}
+
+impl GameScanner {
+    /// Creates a new game scanner.
+    pub fn new(
+        factory_client: Arc<dyn DisputeGameFactoryClient>,
+        verifier_client: Arc<dyn AggregateVerifierClient>,
+        config: ScannerConfig,
+    ) -> Self {
+        Self { factory_client, verifier_client, config }
+    }
+
+    /// Scans for new candidate games since `last_scanned`.
+    ///
+    /// Returns a tuple of `(candidates, new_last_scanned)` where `new_last_scanned`
+    /// is the latest factory index that was evaluated. The caller is responsible
+    /// for tracking `last_scanned` between calls.
+    ///
+    /// On a fresh start, pass `0` as `last_scanned` and the lookback window will
+    /// determine the scan range.
+    pub async fn scan(&self, last_scanned: u64) -> Result<(Vec<CandidateGame>, u64)> {
+        let game_count = self.factory_client.game_count().await?;
+
+        if game_count == 0 {
+            debug!("factory has no games");
+            return Ok((vec![], last_scanned));
+        }
+
+        let end = game_count - 1;
+        let start = (last_scanned + 1).max(game_count.saturating_sub(self.config.lookback_games));
+
+        if start > end {
+            debug!(
+                last_scanned = last_scanned,
+                game_count = game_count,
+                "no new games since last scan"
+            );
+            return Ok((vec![], last_scanned));
+        }
+
+        let games_to_scan = end - start + 1;
+        let mut candidates = Vec::new();
+
+        for i in start..=end {
+            match self.evaluate_game(i).await {
+                Ok(Some(candidate)) => candidates.push(candidate),
+                Ok(None) => {}
+                Err(e) => {
+                    warn!(error = %e, index = i, "failed to query game, skipping");
+                }
+            }
+        }
+
+        metrics::counter!(ChallengerMetrics::GAMES_SCANNED_TOTAL).increment(games_to_scan);
+        metrics::gauge!(ChallengerMetrics::SCAN_HEAD).set(end as f64);
+
+        info!(
+            games_found = candidates.len(),
+            scan_head = end,
+            games_scanned = games_to_scan,
+            "scan complete"
+        );
+
+        Ok((candidates, end))
+    }
+
+    /// Evaluates a single game at the given factory index.
+    ///
+    /// Returns `Some(CandidateGame)` if the game matches the configured game type,
+    /// is `IN_PROGRESS`, and has not been challenged (zkProver == zero).
+    /// Returns `None` if the game should be skipped.
+    async fn evaluate_game(&self, index: u64) -> Result<Option<CandidateGame>> {
+        let GameAtIndex { game_type, proxy, .. } = self.factory_client.game_at_index(index).await?;
+
+        if game_type != self.config.game_type {
+            debug!(
+                index = index,
+                game_type = game_type,
+                expected = self.config.game_type,
+                "skipping non-matching game type"
+            );
+            return Ok(None);
+        }
+
+        let status = self.verifier_client.status(proxy).await?;
+        if status != 0 {
+            debug!(index = index, status = status, "skipping game not in progress");
+            return Ok(None);
+        }
+
+        let zk_prover = self.verifier_client.zk_prover(proxy).await?;
+        if zk_prover != Address::ZERO {
+            debug!(
+                index = index,
+                zk_prover = %zk_prover,
+                "skipping already-challenged game"
+            );
+            return Ok(None);
+        }
+
+        let GameInfo { root_claim, l2_block_number, parent_index } =
+            self.verifier_client.game_info(proxy).await?;
+
+        let starting_block_number = self.verifier_client.starting_block_number(proxy).await?;
+
+        Ok(Some(CandidateGame {
+            index,
+            proxy,
+            root_claim,
+            l2_block_number,
+            parent_index,
+            starting_block_number,
+        }))
+    }
+}

--- a/crates/proof/challenge/src/test_utils.rs
+++ b/crates/proof/challenge/src/test_utils.rs
@@ -348,6 +348,7 @@ mod tests {
     }
 
     /// Error resilience: a per-game error is logged and skipped, other games still returned.
+    /// `new_last_scanned` is set to one before the errored index so it will be retried.
     #[tokio::test]
     async fn test_scan_skips_errored_games() {
         // 3 games: index 1 will error, indices 0 and 2 are valid candidates
@@ -377,11 +378,98 @@ mod tests {
 
         // start = max(0, 3-1000) = 0, end = 2
         // Index 0 -> candidate. Index 1 errors -> skipped. Index 2 -> candidate.
+        // new_last_scanned = lowest_error(1) - 1 = 0, so next scan retries from index 1.
         let (candidates, new_last_scanned) = scanner.scan(None).await.unwrap();
 
         assert_eq!(candidates.len(), 2);
         assert_eq!(candidates[0].index, 0);
         assert_eq!(candidates[1].index, 2);
+        assert_eq!(new_last_scanned, Some(0));
+    }
+
+    /// Retry: errored games are retried on the next scan when the error clears.
+    #[tokio::test]
+    async fn test_scan_retries_errored_games() {
+        // Phase 1: index 1 errors, so new_last_scanned = Some(0)
+        let factory = Arc::new(ErrorOnIndexFactory {
+            inner: MockDisputeGameFactory {
+                games: vec![
+                    factory_game(0, TARGET_TYPE),
+                    factory_game(1, TARGET_TYPE),
+                    factory_game(2, TARGET_TYPE),
+                ],
+            },
+            error_indices: vec![1],
+        });
+
+        let mut verifier_games = HashMap::new();
+        verifier_games.insert(addr(0), mock_state(0, Address::ZERO, 100));
+        verifier_games.insert(addr(1), mock_state(0, Address::ZERO, 200));
+        verifier_games.insert(addr(2), mock_state(0, Address::ZERO, 300));
+
+        let verifier = Arc::new(MockAggregateVerifier { games: verifier_games.clone() });
+
+        let scanner = GameScanner::new(
+            factory,
+            verifier,
+            ScannerConfig { game_type: TARGET_TYPE, lookback_games: 1000 },
+        );
+
+        let (_, new_last_scanned) = scanner.scan(None).await.unwrap();
+        assert_eq!(new_last_scanned, Some(0));
+
+        // Phase 2: no errors, pass last_scanned = Some(0) to retry from index 1
+        let factory2 = Arc::new(MockDisputeGameFactory {
+            games: vec![
+                factory_game(0, TARGET_TYPE),
+                factory_game(1, TARGET_TYPE),
+                factory_game(2, TARGET_TYPE),
+            ],
+        });
+
+        let verifier2 = Arc::new(MockAggregateVerifier { games: verifier_games });
+
+        let scanner2 = GameScanner::new(
+            factory2,
+            verifier2,
+            ScannerConfig { game_type: TARGET_TYPE, lookback_games: 1000 },
+        );
+
+        let (candidates, new_last_scanned) = scanner2.scan(Some(0)).await.unwrap();
+
+        // Indices 1 and 2 are now scanned successfully
+        assert_eq!(candidates.len(), 2);
+        assert_eq!(candidates[0].index, 1);
+        assert_eq!(candidates[1].index, 2);
         assert_eq!(new_last_scanned, Some(2));
+    }
+
+    /// Error at the first index (0) with `last_scanned = None` preserves fresh-start semantics.
+    #[tokio::test]
+    async fn test_scan_error_at_first_index() {
+        let factory = Arc::new(ErrorOnIndexFactory {
+            inner: MockDisputeGameFactory {
+                games: vec![factory_game(0, TARGET_TYPE), factory_game(1, TARGET_TYPE)],
+            },
+            error_indices: vec![0],
+        });
+
+        let mut verifier_games = HashMap::new();
+        verifier_games.insert(addr(1), mock_state(0, Address::ZERO, 200));
+
+        let verifier = Arc::new(MockAggregateVerifier { games: verifier_games });
+
+        let scanner = GameScanner::new(
+            factory,
+            verifier,
+            ScannerConfig { game_type: TARGET_TYPE, lookback_games: 1000 },
+        );
+
+        // last_scanned = None, lowest_error = 0 -> preserves None (fresh-start semantics)
+        let (candidates, new_last_scanned) = scanner.scan(None).await.unwrap();
+
+        assert_eq!(candidates.len(), 1);
+        assert_eq!(candidates[0].index, 1);
+        assert_eq!(new_last_scanned, None);
     }
 }

--- a/crates/proof/challenge/src/test_utils.rs
+++ b/crates/proof/challenge/src/test_utils.rs
@@ -1,0 +1,318 @@
+//! Test utilities: mock stubs for contract clients and scanner tests.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use alloy_primitives::{Address, B256, U256};
+use async_trait::async_trait;
+use base_proof_contracts::{
+    AggregateVerifierClient, ContractError, DisputeGameFactoryClient, GameAtIndex, GameInfo,
+};
+
+use crate::scanner::{GameScanner, ScannerConfig};
+
+/// Per-game state for the mock verifier.
+#[derive(Debug, Clone)]
+pub(crate) struct MockGameState {
+    /// Game status (`0=IN_PROGRESS`, `1=CHALLENGER_WINS`, `2=DEFENDER_WINS`).
+    pub status: u8,
+    /// Address of the ZK prover (`Address::ZERO` if unchallenged).
+    pub zk_prover: Address,
+    /// Game info (root claim, L2 block number, parent index).
+    pub game_info: GameInfo,
+    /// Starting block number for this game.
+    pub starting_block_number: u64,
+}
+
+/// Mock dispute game factory with configurable per-index game data.
+pub(crate) struct MockDisputeGameFactory {
+    /// Ordered list of games in the factory.
+    pub games: Vec<GameAtIndex>,
+}
+
+#[async_trait]
+impl DisputeGameFactoryClient for MockDisputeGameFactory {
+    async fn game_count(&self) -> Result<u64, ContractError> {
+        Ok(self.games.len() as u64)
+    }
+
+    async fn game_at_index(&self, index: u64) -> Result<GameAtIndex, ContractError> {
+        self.games
+            .get(index as usize)
+            .cloned()
+            .ok_or_else(|| ContractError::Validation(format!("index {index} out of bounds")))
+    }
+
+    async fn init_bonds(&self, _game_type: u32) -> Result<U256, ContractError> {
+        Ok(U256::ZERO)
+    }
+
+    async fn game_impls(&self, _game_type: u32) -> Result<Address, ContractError> {
+        Ok(Address::ZERO)
+    }
+}
+
+/// Mock aggregate verifier with configurable per-address game state.
+pub(crate) struct MockAggregateVerifier {
+    /// Per-address game state lookup.
+    pub games: HashMap<Address, MockGameState>,
+}
+
+#[async_trait]
+impl AggregateVerifierClient for MockAggregateVerifier {
+    async fn game_info(&self, game_address: Address) -> Result<GameInfo, ContractError> {
+        self.games
+            .get(&game_address)
+            .map(|s| s.game_info.clone())
+            .ok_or_else(|| ContractError::Validation(format!("unknown game {game_address}")))
+    }
+
+    async fn status(&self, game_address: Address) -> Result<u8, ContractError> {
+        self.games
+            .get(&game_address)
+            .map(|s| s.status)
+            .ok_or_else(|| ContractError::Validation(format!("unknown game {game_address}")))
+    }
+
+    async fn zk_prover(&self, game_address: Address) -> Result<Address, ContractError> {
+        self.games
+            .get(&game_address)
+            .map(|s| s.zk_prover)
+            .ok_or_else(|| ContractError::Validation(format!("unknown game {game_address}")))
+    }
+
+    async fn starting_block_number(&self, game_address: Address) -> Result<u64, ContractError> {
+        self.games
+            .get(&game_address)
+            .map(|s| s.starting_block_number)
+            .ok_or_else(|| ContractError::Validation(format!("unknown game {game_address}")))
+    }
+
+    async fn read_block_interval(&self, _impl_address: Address) -> Result<u64, ContractError> {
+        Ok(10)
+    }
+
+    async fn read_intermediate_block_interval(
+        &self,
+        _impl_address: Address,
+    ) -> Result<u64, ContractError> {
+        Ok(5)
+    }
+}
+
+/// Helper to create an address from a `u64` index.
+fn addr(index: u64) -> Address {
+    let mut bytes = [0u8; 20];
+    bytes[12..20].copy_from_slice(&index.to_be_bytes());
+    Address::from(bytes)
+}
+
+/// Helper to build a factory game entry.
+fn factory_game(index: u64, game_type: u32) -> GameAtIndex {
+    GameAtIndex { game_type, timestamp: 1_000_000 + index, proxy: addr(index) }
+}
+
+/// Helper to build mock game state for the verifier.
+fn mock_state(status: u8, zk_prover: Address, block_number: u64) -> MockGameState {
+    MockGameState {
+        status,
+        zk_prover,
+        game_info: GameInfo {
+            root_claim: B256::repeat_byte(block_number as u8),
+            l2_block_number: block_number,
+            parent_index: 0,
+        },
+        starting_block_number: block_number.saturating_sub(10),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const TARGET_TYPE: u32 = 1;
+
+    /// Happy path: mixed games, only matching / IN_PROGRESS / unchallenged returned.
+    #[tokio::test]
+    async fn test_scan_happy_path() {
+        // Game 0: matching type, IN_PROGRESS, unchallenged -> candidate
+        // Game 1: wrong type -> skipped
+        // Game 2: matching type, status=1 (not in progress) -> skipped
+        // Game 3: matching type, IN_PROGRESS, already challenged -> skipped
+        // Game 4: matching type, IN_PROGRESS, unchallenged -> candidate
+        let factory = Arc::new(MockDisputeGameFactory {
+            games: vec![
+                factory_game(0, TARGET_TYPE),
+                factory_game(1, 99),
+                factory_game(2, TARGET_TYPE),
+                factory_game(3, TARGET_TYPE),
+                factory_game(4, TARGET_TYPE),
+            ],
+        });
+
+        let challenger_addr = Address::repeat_byte(0xCC);
+        let mut verifier_games = HashMap::new();
+        verifier_games.insert(addr(0), mock_state(0, Address::ZERO, 100));
+        verifier_games.insert(addr(2), mock_state(1, Address::ZERO, 200));
+        verifier_games.insert(addr(3), mock_state(0, challenger_addr, 300));
+        verifier_games.insert(addr(4), mock_state(0, Address::ZERO, 400));
+
+        let verifier = Arc::new(MockAggregateVerifier { games: verifier_games });
+
+        let scanner = GameScanner::new(
+            factory,
+            verifier,
+            ScannerConfig { game_type: TARGET_TYPE, lookback_games: 1000 },
+        );
+
+        let (candidates, new_last_scanned) = scanner.scan(0).await.unwrap();
+
+        // last_scanned=0, start = max(0+1, 5-1000) = 1, so games 1..=4 scanned
+        // But game 0 is at index 0 which is < start=1, so only games 1-4.
+        // Game 1: wrong type. Game 2: status != 0. Game 3: challenged. Game 4: candidate.
+        assert_eq!(candidates.len(), 1);
+        assert_eq!(candidates[0].index, 4);
+        assert_eq!(candidates[0].l2_block_number, 400);
+        assert_eq!(new_last_scanned, 4);
+    }
+
+    /// Already-challenged games (zkProver != zero) are filtered out.
+    #[tokio::test]
+    async fn test_scan_filters_challenged_games() {
+        let challenger_addr = Address::repeat_byte(0xAA);
+
+        let factory = Arc::new(MockDisputeGameFactory {
+            games: vec![
+                factory_game(0, TARGET_TYPE),
+                factory_game(1, TARGET_TYPE),
+                factory_game(2, TARGET_TYPE),
+            ],
+        });
+
+        let mut verifier_games = HashMap::new();
+        // All IN_PROGRESS but index 0 and 2 are already challenged
+        verifier_games.insert(addr(0), mock_state(0, challenger_addr, 100));
+        verifier_games.insert(addr(1), mock_state(0, Address::ZERO, 200));
+        verifier_games.insert(addr(2), mock_state(0, challenger_addr, 300));
+
+        let verifier = Arc::new(MockAggregateVerifier { games: verifier_games });
+
+        let scanner = GameScanner::new(
+            factory,
+            verifier,
+            ScannerConfig { game_type: TARGET_TYPE, lookback_games: 1000 },
+        );
+
+        // Scan from the beginning (last_scanned=0, lookback covers all)
+        // start = max(0+1, 3-1000) = 1, end = 2
+        // Game 1: unchallenged -> candidate. Game 2: challenged -> skip.
+        let (candidates, new_last_scanned) = scanner.scan(0).await.unwrap();
+
+        assert_eq!(candidates.len(), 1);
+        assert_eq!(candidates[0].index, 1);
+        assert_eq!(new_last_scanned, 2);
+    }
+
+    /// Games with non-matching game_type are skipped.
+    #[tokio::test]
+    async fn test_scan_filters_wrong_game_type() {
+        let factory = Arc::new(MockDisputeGameFactory {
+            games: vec![factory_game(0, 99), factory_game(1, 50), factory_game(2, TARGET_TYPE)],
+        });
+
+        let mut verifier_games = HashMap::new();
+        verifier_games.insert(addr(2), mock_state(0, Address::ZERO, 100));
+
+        let verifier = Arc::new(MockAggregateVerifier { games: verifier_games });
+
+        let scanner = GameScanner::new(
+            factory,
+            verifier,
+            ScannerConfig { game_type: TARGET_TYPE, lookback_games: 1000 },
+        );
+
+        // start = max(0+1, 3-1000) = 1, end = 2
+        // Game 1: wrong type. Game 2: matching -> candidate.
+        let (candidates, new_last_scanned) = scanner.scan(0).await.unwrap();
+
+        assert_eq!(candidates.len(), 1);
+        assert_eq!(candidates[0].index, 2);
+        assert_eq!(new_last_scanned, 2);
+    }
+
+    /// Empty factory returns empty vec without error.
+    #[tokio::test]
+    async fn test_scan_empty_factory() {
+        let factory = Arc::new(MockDisputeGameFactory { games: vec![] });
+        let verifier = Arc::new(MockAggregateVerifier { games: HashMap::new() });
+
+        let scanner = GameScanner::new(
+            factory,
+            verifier,
+            ScannerConfig { game_type: TARGET_TYPE, lookback_games: 1000 },
+        );
+
+        let (candidates, new_last_scanned) = scanner.scan(0).await.unwrap();
+
+        assert!(candidates.is_empty());
+        assert_eq!(new_last_scanned, 0);
+    }
+
+    /// No new games since last scan returns empty vec.
+    #[tokio::test]
+    async fn test_scan_no_new_games() {
+        let factory = Arc::new(MockDisputeGameFactory {
+            games: vec![factory_game(0, TARGET_TYPE), factory_game(1, TARGET_TYPE)],
+        });
+
+        let mut verifier_games = HashMap::new();
+        verifier_games.insert(addr(0), mock_state(0, Address::ZERO, 100));
+        verifier_games.insert(addr(1), mock_state(0, Address::ZERO, 200));
+
+        let verifier = Arc::new(MockAggregateVerifier { games: verifier_games });
+
+        let scanner = GameScanner::new(
+            factory,
+            verifier,
+            ScannerConfig { game_type: TARGET_TYPE, lookback_games: 1000 },
+        );
+
+        // last_scanned = 1 (gameCount - 1), so start = 2 > end = 1
+        let (candidates, new_last_scanned) = scanner.scan(1).await.unwrap();
+
+        assert!(candidates.is_empty());
+        assert_eq!(new_last_scanned, 1);
+    }
+
+    /// Lookback window: on fresh start with large factory, only lookback_games are scanned.
+    #[tokio::test]
+    async fn test_scan_lookback_window() {
+        // Factory with 100 games, but lookback is 3 -> only scan indices 97, 98, 99
+        let mut games = Vec::new();
+        let mut verifier_games = HashMap::new();
+
+        for i in 0..100u64 {
+            games.push(factory_game(i, TARGET_TYPE));
+            verifier_games.insert(addr(i), mock_state(0, Address::ZERO, i * 10));
+        }
+
+        let factory = Arc::new(MockDisputeGameFactory { games });
+        let verifier = Arc::new(MockAggregateVerifier { games: verifier_games });
+
+        let scanner = GameScanner::new(
+            factory,
+            verifier,
+            ScannerConfig { game_type: TARGET_TYPE, lookback_games: 3 },
+        );
+
+        // Fresh start: last_scanned = 0
+        // start = max(0+1, 100-3) = 97, end = 99
+        let (candidates, new_last_scanned) = scanner.scan(0).await.unwrap();
+
+        assert_eq!(candidates.len(), 3);
+        assert_eq!(candidates[0].index, 97);
+        assert_eq!(candidates[1].index, 98);
+        assert_eq!(candidates[2].index, 99);
+        assert_eq!(new_last_scanned, 99);
+    }
+}

--- a/crates/proof/challenge/src/test_utils.rs
+++ b/crates/proof/challenge/src/test_utils.rs
@@ -159,29 +159,28 @@ impl DisputeGameFactoryClient for ErrorOnIndexFactory {
 mod tests {
     use super::*;
 
-    const TARGET_TYPE: u32 = 1;
-
-    /// Happy path: mixed games, only matching / `IN_PROGRESS` / unchallenged returned.
+    /// Happy path: mixed games, only `IN_PROGRESS` / unchallenged returned.
     #[tokio::test]
     async fn test_scan_happy_path() {
-        // Game 0: matching type, IN_PROGRESS, unchallenged -> candidate
-        // Game 1: wrong type -> skipped
-        // Game 2: matching type, status=1 (not in progress) -> skipped
-        // Game 3: matching type, IN_PROGRESS, already challenged -> skipped
-        // Game 4: matching type, IN_PROGRESS, unchallenged -> candidate
+        // Game 0: type 1, IN_PROGRESS, unchallenged -> candidate
+        // Game 1: type 99, IN_PROGRESS, unchallenged -> candidate (all types scanned)
+        // Game 2: type 1, status=1 (not in progress) -> skipped
+        // Game 3: type 1, IN_PROGRESS, already challenged -> skipped
+        // Game 4: type 1, IN_PROGRESS, unchallenged -> candidate
         let factory = Arc::new(MockDisputeGameFactory {
             games: vec![
-                factory_game(0, TARGET_TYPE),
+                factory_game(0, 1),
                 factory_game(1, 99),
-                factory_game(2, TARGET_TYPE),
-                factory_game(3, TARGET_TYPE),
-                factory_game(4, TARGET_TYPE),
+                factory_game(2, 1),
+                factory_game(3, 1),
+                factory_game(4, 1),
             ],
         });
 
         let challenger_addr = Address::repeat_byte(0xCC);
         let mut verifier_games = HashMap::new();
         verifier_games.insert(addr(0), mock_state(0, Address::ZERO, 100));
+        verifier_games.insert(addr(1), mock_state(0, Address::ZERO, 150));
         verifier_games.insert(addr(2), mock_state(1, Address::ZERO, 200));
         verifier_games.insert(addr(3), mock_state(0, challenger_addr, 300));
         verifier_games.insert(addr(4), mock_state(0, Address::ZERO, 400));
@@ -191,19 +190,24 @@ mod tests {
         let scanner = GameScanner::new(
             factory,
             verifier,
-            ScannerConfig { game_type: TARGET_TYPE, lookback_games: 1000 },
+            ScannerConfig { lookback_games: 1000 },
         );
 
         let (candidates, new_last_scanned) = scanner.scan(None).await.unwrap();
 
         // last_scanned=None, start = max(0, 5-1000) = 0, so games 0..=4 scanned
-        // Game 0: candidate. Game 1: wrong type. Game 2: status != 0.
+        // Game 0: candidate. Game 1: candidate. Game 2: status != 0.
         // Game 3: challenged. Game 4: candidate.
-        assert_eq!(candidates.len(), 2);
+        assert_eq!(candidates.len(), 3);
         assert_eq!(candidates[0].index, 0);
+        assert_eq!(candidates[0].game_type, 1);
         assert_eq!(candidates[0].l2_block_number, 100);
-        assert_eq!(candidates[1].index, 4);
-        assert_eq!(candidates[1].l2_block_number, 400);
+        assert_eq!(candidates[1].index, 1);
+        assert_eq!(candidates[1].game_type, 99);
+        assert_eq!(candidates[1].l2_block_number, 150);
+        assert_eq!(candidates[2].index, 4);
+        assert_eq!(candidates[2].game_type, 1);
+        assert_eq!(candidates[2].l2_block_number, 400);
         assert_eq!(new_last_scanned, Some(4));
     }
 
@@ -214,9 +218,9 @@ mod tests {
 
         let factory = Arc::new(MockDisputeGameFactory {
             games: vec![
-                factory_game(0, TARGET_TYPE),
-                factory_game(1, TARGET_TYPE),
-                factory_game(2, TARGET_TYPE),
+                factory_game(0, 1),
+                factory_game(1, 1),
+                factory_game(2, 1),
             ],
         });
 
@@ -231,7 +235,7 @@ mod tests {
         let scanner = GameScanner::new(
             factory,
             verifier,
-            ScannerConfig { game_type: TARGET_TYPE, lookback_games: 1000 },
+            ScannerConfig { lookback_games: 1000 },
         );
 
         // Scan from the beginning (last_scanned=None, lookback covers all)
@@ -244,33 +248,6 @@ mod tests {
         assert_eq!(new_last_scanned, Some(2));
     }
 
-    /// Games with non-matching `game_type` are skipped.
-    #[tokio::test]
-    async fn test_scan_filters_wrong_game_type() {
-        let factory = Arc::new(MockDisputeGameFactory {
-            games: vec![factory_game(0, 99), factory_game(1, 50), factory_game(2, TARGET_TYPE)],
-        });
-
-        let mut verifier_games = HashMap::new();
-        verifier_games.insert(addr(2), mock_state(0, Address::ZERO, 100));
-
-        let verifier = Arc::new(MockAggregateVerifier { games: verifier_games });
-
-        let scanner = GameScanner::new(
-            factory,
-            verifier,
-            ScannerConfig { game_type: TARGET_TYPE, lookback_games: 1000 },
-        );
-
-        // start = max(0, 3-1000) = 0, end = 2
-        // Game 0: wrong type. Game 1: wrong type. Game 2: matching -> candidate.
-        let (candidates, new_last_scanned) = scanner.scan(None).await.unwrap();
-
-        assert_eq!(candidates.len(), 1);
-        assert_eq!(candidates[0].index, 2);
-        assert_eq!(new_last_scanned, Some(2));
-    }
-
     /// Empty factory returns empty vec without error.
     #[tokio::test]
     async fn test_scan_empty_factory() {
@@ -280,7 +257,7 @@ mod tests {
         let scanner = GameScanner::new(
             factory,
             verifier,
-            ScannerConfig { game_type: TARGET_TYPE, lookback_games: 1000 },
+            ScannerConfig { lookback_games: 1000 },
         );
 
         let (candidates, new_last_scanned) = scanner.scan(None).await.unwrap();
@@ -293,7 +270,7 @@ mod tests {
     #[tokio::test]
     async fn test_scan_no_new_games() {
         let factory = Arc::new(MockDisputeGameFactory {
-            games: vec![factory_game(0, TARGET_TYPE), factory_game(1, TARGET_TYPE)],
+            games: vec![factory_game(0, 1), factory_game(1, 1)],
         });
 
         let mut verifier_games = HashMap::new();
@@ -305,7 +282,7 @@ mod tests {
         let scanner = GameScanner::new(
             factory,
             verifier,
-            ScannerConfig { game_type: TARGET_TYPE, lookback_games: 1000 },
+            ScannerConfig { lookback_games: 1000 },
         );
 
         // last_scanned = Some(1) (gameCount - 1), so start = 2 > end = 1
@@ -323,7 +300,7 @@ mod tests {
         let mut verifier_games = HashMap::new();
 
         for i in 0..100u64 {
-            games.push(factory_game(i, TARGET_TYPE));
+            games.push(factory_game(i, 1));
             verifier_games.insert(addr(i), mock_state(0, Address::ZERO, i * 10));
         }
 
@@ -333,7 +310,7 @@ mod tests {
         let scanner = GameScanner::new(
             factory,
             verifier,
-            ScannerConfig { game_type: TARGET_TYPE, lookback_games: 3 },
+            ScannerConfig { lookback_games: 3 },
         );
 
         // Fresh start: last_scanned = None
@@ -355,9 +332,9 @@ mod tests {
         let factory = Arc::new(ErrorOnIndexFactory {
             inner: MockDisputeGameFactory {
                 games: vec![
-                    factory_game(0, TARGET_TYPE),
-                    factory_game(1, TARGET_TYPE),
-                    factory_game(2, TARGET_TYPE),
+                    factory_game(0, 1),
+                    factory_game(1, 1),
+                    factory_game(2, 1),
                 ],
             },
             error_indices: vec![1],
@@ -373,7 +350,7 @@ mod tests {
         let scanner = GameScanner::new(
             factory,
             verifier,
-            ScannerConfig { game_type: TARGET_TYPE, lookback_games: 1000 },
+            ScannerConfig { lookback_games: 1000 },
         );
 
         // start = max(0, 3-1000) = 0, end = 2
@@ -394,9 +371,9 @@ mod tests {
         let factory = Arc::new(ErrorOnIndexFactory {
             inner: MockDisputeGameFactory {
                 games: vec![
-                    factory_game(0, TARGET_TYPE),
-                    factory_game(1, TARGET_TYPE),
-                    factory_game(2, TARGET_TYPE),
+                    factory_game(0, 1),
+                    factory_game(1, 1),
+                    factory_game(2, 1),
                 ],
             },
             error_indices: vec![1],
@@ -412,7 +389,7 @@ mod tests {
         let scanner = GameScanner::new(
             factory,
             verifier,
-            ScannerConfig { game_type: TARGET_TYPE, lookback_games: 1000 },
+            ScannerConfig { lookback_games: 1000 },
         );
 
         let (_, new_last_scanned) = scanner.scan(None).await.unwrap();
@@ -421,9 +398,9 @@ mod tests {
         // Phase 2: no errors, pass last_scanned = Some(0) to retry from index 1
         let factory2 = Arc::new(MockDisputeGameFactory {
             games: vec![
-                factory_game(0, TARGET_TYPE),
-                factory_game(1, TARGET_TYPE),
-                factory_game(2, TARGET_TYPE),
+                factory_game(0, 1),
+                factory_game(1, 1),
+                factory_game(2, 1),
             ],
         });
 
@@ -432,7 +409,7 @@ mod tests {
         let scanner2 = GameScanner::new(
             factory2,
             verifier2,
-            ScannerConfig { game_type: TARGET_TYPE, lookback_games: 1000 },
+            ScannerConfig { lookback_games: 1000 },
         );
 
         let (candidates, new_last_scanned) = scanner2.scan(Some(0)).await.unwrap();
@@ -449,7 +426,7 @@ mod tests {
     async fn test_scan_error_at_first_index() {
         let factory = Arc::new(ErrorOnIndexFactory {
             inner: MockDisputeGameFactory {
-                games: vec![factory_game(0, TARGET_TYPE), factory_game(1, TARGET_TYPE)],
+                games: vec![factory_game(0, 1), factory_game(1, 1)],
             },
             error_indices: vec![0],
         });
@@ -462,7 +439,7 @@ mod tests {
         let scanner = GameScanner::new(
             factory,
             verifier,
-            ScannerConfig { game_type: TARGET_TYPE, lookback_games: 1000 },
+            ScannerConfig { lookback_games: 1000 },
         );
 
         // last_scanned = None, lowest_error = 0 -> preserves None (fresh-start semantics)

--- a/crates/proof/challenge/src/test_utils.rs
+++ b/crates/proof/challenge/src/test_utils.rs
@@ -12,7 +12,7 @@ use crate::scanner::{GameScanner, ScannerConfig};
 
 /// Per-game state for the mock verifier.
 #[derive(Debug, Clone)]
-pub(crate) struct MockGameState {
+pub struct MockGameState {
     /// Game status (`0=IN_PROGRESS`, `1=CHALLENGER_WINS`, `2=DEFENDER_WINS`).
     pub status: u8,
     /// Address of the ZK prover (`Address::ZERO` if unchallenged).
@@ -24,7 +24,8 @@ pub(crate) struct MockGameState {
 }
 
 /// Mock dispute game factory with configurable per-index game data.
-pub(crate) struct MockDisputeGameFactory {
+#[derive(Debug)]
+pub struct MockDisputeGameFactory {
     /// Ordered list of games in the factory.
     pub games: Vec<GameAtIndex>,
 }
@@ -52,7 +53,8 @@ impl DisputeGameFactoryClient for MockDisputeGameFactory {
 }
 
 /// Mock aggregate verifier with configurable per-address game state.
-pub(crate) struct MockAggregateVerifier {
+#[derive(Debug)]
+pub struct MockAggregateVerifier {
     /// Per-address game state lookup.
     pub games: HashMap<Address, MockGameState>,
 }
@@ -126,7 +128,8 @@ fn mock_state(status: u8, zk_prover: Address, block_number: u64) -> MockGameStat
 }
 
 /// Mock factory that returns an error for specific indices.
-pub(crate) struct ErrorOnIndexFactory {
+#[derive(Debug)]
+pub struct ErrorOnIndexFactory {
     /// The inner factory providing normal game data.
     pub inner: MockDisputeGameFactory,
     /// Indices that should return an error when queried.

--- a/crates/proof/challenge/src/test_utils.rs
+++ b/crates/proof/challenge/src/test_utils.rs
@@ -1,7 +1,6 @@
 //! Test utilities: mock stubs for contract clients and scanner tests.
 
-use std::collections::HashMap;
-use std::sync::Arc;
+use std::{collections::HashMap, sync::Arc};
 
 use alloy_primitives::{Address, B256, U256};
 use async_trait::async_trait;
@@ -195,15 +194,17 @@ mod tests {
             ScannerConfig { game_type: TARGET_TYPE, lookback_games: 1000 },
         );
 
-        let (candidates, new_last_scanned) = scanner.scan(0).await.unwrap();
+        let (candidates, new_last_scanned) = scanner.scan(None).await.unwrap();
 
-        // last_scanned=0, start = max(0+1, 5-1000) = 1, so games 1..=4 scanned
-        // But game 0 is at index 0 which is < start=1, so only games 1-4.
-        // Game 1: wrong type. Game 2: status != 0. Game 3: challenged. Game 4: candidate.
-        assert_eq!(candidates.len(), 1);
-        assert_eq!(candidates[0].index, 4);
-        assert_eq!(candidates[0].l2_block_number, 400);
-        assert_eq!(new_last_scanned, 4);
+        // last_scanned=None, start = max(0, 5-1000) = 0, so games 0..=4 scanned
+        // Game 0: candidate. Game 1: wrong type. Game 2: status != 0.
+        // Game 3: challenged. Game 4: candidate.
+        assert_eq!(candidates.len(), 2);
+        assert_eq!(candidates[0].index, 0);
+        assert_eq!(candidates[0].l2_block_number, 100);
+        assert_eq!(candidates[1].index, 4);
+        assert_eq!(candidates[1].l2_block_number, 400);
+        assert_eq!(new_last_scanned, Some(4));
     }
 
     /// Already-challenged games (zkProver != zero) are filtered out.
@@ -233,14 +234,14 @@ mod tests {
             ScannerConfig { game_type: TARGET_TYPE, lookback_games: 1000 },
         );
 
-        // Scan from the beginning (last_scanned=0, lookback covers all)
-        // start = max(0+1, 3-1000) = 1, end = 2
-        // Game 1: unchallenged -> candidate. Game 2: challenged -> skip.
-        let (candidates, new_last_scanned) = scanner.scan(0).await.unwrap();
+        // Scan from the beginning (last_scanned=None, lookback covers all)
+        // start = max(0, 3-1000) = 0, end = 2
+        // Game 0: challenged -> skip. Game 1: unchallenged -> candidate. Game 2: challenged -> skip.
+        let (candidates, new_last_scanned) = scanner.scan(None).await.unwrap();
 
         assert_eq!(candidates.len(), 1);
         assert_eq!(candidates[0].index, 1);
-        assert_eq!(new_last_scanned, 2);
+        assert_eq!(new_last_scanned, Some(2));
     }
 
     /// Games with non-matching `game_type` are skipped.
@@ -261,13 +262,13 @@ mod tests {
             ScannerConfig { game_type: TARGET_TYPE, lookback_games: 1000 },
         );
 
-        // start = max(0+1, 3-1000) = 1, end = 2
-        // Game 1: wrong type. Game 2: matching -> candidate.
-        let (candidates, new_last_scanned) = scanner.scan(0).await.unwrap();
+        // start = max(0, 3-1000) = 0, end = 2
+        // Game 0: wrong type. Game 1: wrong type. Game 2: matching -> candidate.
+        let (candidates, new_last_scanned) = scanner.scan(None).await.unwrap();
 
         assert_eq!(candidates.len(), 1);
         assert_eq!(candidates[0].index, 2);
-        assert_eq!(new_last_scanned, 2);
+        assert_eq!(new_last_scanned, Some(2));
     }
 
     /// Empty factory returns empty vec without error.
@@ -282,10 +283,10 @@ mod tests {
             ScannerConfig { game_type: TARGET_TYPE, lookback_games: 1000 },
         );
 
-        let (candidates, new_last_scanned) = scanner.scan(0).await.unwrap();
+        let (candidates, new_last_scanned) = scanner.scan(None).await.unwrap();
 
         assert!(candidates.is_empty());
-        assert_eq!(new_last_scanned, 0);
+        assert_eq!(new_last_scanned, None);
     }
 
     /// No new games since last scan returns empty vec.
@@ -307,11 +308,11 @@ mod tests {
             ScannerConfig { game_type: TARGET_TYPE, lookback_games: 1000 },
         );
 
-        // last_scanned = 1 (gameCount - 1), so start = 2 > end = 1
-        let (candidates, new_last_scanned) = scanner.scan(1).await.unwrap();
+        // last_scanned = Some(1) (gameCount - 1), so start = 2 > end = 1
+        let (candidates, new_last_scanned) = scanner.scan(Some(1)).await.unwrap();
 
         assert!(candidates.is_empty());
-        assert_eq!(new_last_scanned, 1);
+        assert_eq!(new_last_scanned, Some(1));
     }
 
     /// Lookback window: on fresh start with large factory, only `lookback_games` are scanned.
@@ -335,15 +336,15 @@ mod tests {
             ScannerConfig { game_type: TARGET_TYPE, lookback_games: 3 },
         );
 
-        // Fresh start: last_scanned = 0
-        // start = max(0+1, 100-3) = 97, end = 99
-        let (candidates, new_last_scanned) = scanner.scan(0).await.unwrap();
+        // Fresh start: last_scanned = None
+        // start = max(0, 100-3) = 97, end = 99
+        let (candidates, new_last_scanned) = scanner.scan(None).await.unwrap();
 
         assert_eq!(candidates.len(), 3);
         assert_eq!(candidates[0].index, 97);
         assert_eq!(candidates[1].index, 98);
         assert_eq!(candidates[2].index, 99);
-        assert_eq!(new_last_scanned, 99);
+        assert_eq!(new_last_scanned, Some(99));
     }
 
     /// Error resilience: a per-game error is logged and skipped, other games still returned.
@@ -374,12 +375,13 @@ mod tests {
             ScannerConfig { game_type: TARGET_TYPE, lookback_games: 1000 },
         );
 
-        // start = max(0+1, 3-1000) = 1, end = 2
-        // Index 1 errors -> skipped. Index 2 -> candidate.
-        let (candidates, new_last_scanned) = scanner.scan(0).await.unwrap();
+        // start = max(0, 3-1000) = 0, end = 2
+        // Index 0 -> candidate. Index 1 errors -> skipped. Index 2 -> candidate.
+        let (candidates, new_last_scanned) = scanner.scan(None).await.unwrap();
 
-        assert_eq!(candidates.len(), 1);
-        assert_eq!(candidates[0].index, 2);
-        assert_eq!(new_last_scanned, 2);
+        assert_eq!(candidates.len(), 2);
+        assert_eq!(candidates[0].index, 0);
+        assert_eq!(candidates[1].index, 2);
+        assert_eq!(new_last_scanned, Some(2));
     }
 }

--- a/crates/proof/challenge/src/test_utils.rs
+++ b/crates/proof/challenge/src/test_utils.rs
@@ -200,14 +200,14 @@ mod tests {
         // Game 3: challenged. Game 4: candidate.
         assert_eq!(candidates.len(), 3);
         assert_eq!(candidates[0].index, 0);
-        assert_eq!(candidates[0].game_type, 1);
-        assert_eq!(candidates[0].l2_block_number, 100);
+        assert_eq!(candidates[0].factory.game_type, 1);
+        assert_eq!(candidates[0].info.l2_block_number, 100);
         assert_eq!(candidates[1].index, 1);
-        assert_eq!(candidates[1].game_type, 99);
-        assert_eq!(candidates[1].l2_block_number, 150);
+        assert_eq!(candidates[1].factory.game_type, 99);
+        assert_eq!(candidates[1].info.l2_block_number, 150);
         assert_eq!(candidates[2].index, 4);
-        assert_eq!(candidates[2].game_type, 1);
-        assert_eq!(candidates[2].l2_block_number, 400);
+        assert_eq!(candidates[2].factory.game_type, 1);
+        assert_eq!(candidates[2].info.l2_block_number, 400);
         assert_eq!(new_last_scanned, Some(4));
     }
 

--- a/crates/proof/challenge/src/test_utils.rs
+++ b/crates/proof/challenge/src/test_utils.rs
@@ -126,13 +126,43 @@ fn mock_state(status: u8, zk_prover: Address, block_number: u64) -> MockGameStat
     }
 }
 
+/// Mock factory that returns an error for specific indices.
+pub(crate) struct ErrorOnIndexFactory {
+    /// The inner factory providing normal game data.
+    pub inner: MockDisputeGameFactory,
+    /// Indices that should return an error when queried.
+    pub error_indices: Vec<u64>,
+}
+
+#[async_trait]
+impl DisputeGameFactoryClient for ErrorOnIndexFactory {
+    async fn game_count(&self) -> Result<u64, ContractError> {
+        self.inner.game_count().await
+    }
+
+    async fn game_at_index(&self, index: u64) -> Result<GameAtIndex, ContractError> {
+        if self.error_indices.contains(&index) {
+            return Err(ContractError::Validation(format!("simulated error at index {index}")));
+        }
+        self.inner.game_at_index(index).await
+    }
+
+    async fn init_bonds(&self, game_type: u32) -> Result<U256, ContractError> {
+        self.inner.init_bonds(game_type).await
+    }
+
+    async fn game_impls(&self, game_type: u32) -> Result<Address, ContractError> {
+        self.inner.game_impls(game_type).await
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
 
     const TARGET_TYPE: u32 = 1;
 
-    /// Happy path: mixed games, only matching / IN_PROGRESS / unchallenged returned.
+    /// Happy path: mixed games, only matching / `IN_PROGRESS` / unchallenged returned.
     #[tokio::test]
     async fn test_scan_happy_path() {
         // Game 0: matching type, IN_PROGRESS, unchallenged -> candidate
@@ -213,7 +243,7 @@ mod tests {
         assert_eq!(new_last_scanned, 2);
     }
 
-    /// Games with non-matching game_type are skipped.
+    /// Games with non-matching `game_type` are skipped.
     #[tokio::test]
     async fn test_scan_filters_wrong_game_type() {
         let factory = Arc::new(MockDisputeGameFactory {
@@ -284,7 +314,7 @@ mod tests {
         assert_eq!(new_last_scanned, 1);
     }
 
-    /// Lookback window: on fresh start with large factory, only lookback_games are scanned.
+    /// Lookback window: on fresh start with large factory, only `lookback_games` are scanned.
     #[tokio::test]
     async fn test_scan_lookback_window() {
         // Factory with 100 games, but lookback is 3 -> only scan indices 97, 98, 99
@@ -314,5 +344,42 @@ mod tests {
         assert_eq!(candidates[1].index, 98);
         assert_eq!(candidates[2].index, 99);
         assert_eq!(new_last_scanned, 99);
+    }
+
+    /// Error resilience: a per-game error is logged and skipped, other games still returned.
+    #[tokio::test]
+    async fn test_scan_skips_errored_games() {
+        // 3 games: index 1 will error, indices 0 and 2 are valid candidates
+        let factory = Arc::new(ErrorOnIndexFactory {
+            inner: MockDisputeGameFactory {
+                games: vec![
+                    factory_game(0, TARGET_TYPE),
+                    factory_game(1, TARGET_TYPE),
+                    factory_game(2, TARGET_TYPE),
+                ],
+            },
+            error_indices: vec![1],
+        });
+
+        let mut verifier_games = HashMap::new();
+        verifier_games.insert(addr(0), mock_state(0, Address::ZERO, 100));
+        // index 1 won't be queried on the verifier because the factory errors first
+        verifier_games.insert(addr(2), mock_state(0, Address::ZERO, 300));
+
+        let verifier = Arc::new(MockAggregateVerifier { games: verifier_games });
+
+        let scanner = GameScanner::new(
+            factory,
+            verifier,
+            ScannerConfig { game_type: TARGET_TYPE, lookback_games: 1000 },
+        );
+
+        // start = max(0+1, 3-1000) = 1, end = 2
+        // Index 1 errors -> skipped. Index 2 -> candidate.
+        let (candidates, new_last_scanned) = scanner.scan(0).await.unwrap();
+
+        assert_eq!(candidates.len(), 1);
+        assert_eq!(candidates[0].index, 2);
+        assert_eq!(new_last_scanned, 2);
     }
 }

--- a/crates/proof/challenge/src/test_utils.rs
+++ b/crates/proof/challenge/src/test_utils.rs
@@ -190,11 +190,7 @@ mod tests {
 
         let verifier = Arc::new(MockAggregateVerifier { games: verifier_games });
 
-        let scanner = GameScanner::new(
-            factory,
-            verifier,
-            ScannerConfig { lookback_games: 1000 },
-        );
+        let scanner = GameScanner::new(factory, verifier, ScannerConfig { lookback_games: 1000 });
 
         let (candidates, new_last_scanned) = scanner.scan(None).await.unwrap();
 
@@ -220,11 +216,7 @@ mod tests {
         let challenger_addr = Address::repeat_byte(0xAA);
 
         let factory = Arc::new(MockDisputeGameFactory {
-            games: vec![
-                factory_game(0, 1),
-                factory_game(1, 1),
-                factory_game(2, 1),
-            ],
+            games: vec![factory_game(0, 1), factory_game(1, 1), factory_game(2, 1)],
         });
 
         let mut verifier_games = HashMap::new();
@@ -235,11 +227,7 @@ mod tests {
 
         let verifier = Arc::new(MockAggregateVerifier { games: verifier_games });
 
-        let scanner = GameScanner::new(
-            factory,
-            verifier,
-            ScannerConfig { lookback_games: 1000 },
-        );
+        let scanner = GameScanner::new(factory, verifier, ScannerConfig { lookback_games: 1000 });
 
         // Scan from the beginning (last_scanned=None, lookback covers all)
         // start = max(0, 3-1000) = 0, end = 2
@@ -257,11 +245,7 @@ mod tests {
         let factory = Arc::new(MockDisputeGameFactory { games: vec![] });
         let verifier = Arc::new(MockAggregateVerifier { games: HashMap::new() });
 
-        let scanner = GameScanner::new(
-            factory,
-            verifier,
-            ScannerConfig { lookback_games: 1000 },
-        );
+        let scanner = GameScanner::new(factory, verifier, ScannerConfig { lookback_games: 1000 });
 
         let (candidates, new_last_scanned) = scanner.scan(None).await.unwrap();
 
@@ -282,11 +266,7 @@ mod tests {
 
         let verifier = Arc::new(MockAggregateVerifier { games: verifier_games });
 
-        let scanner = GameScanner::new(
-            factory,
-            verifier,
-            ScannerConfig { lookback_games: 1000 },
-        );
+        let scanner = GameScanner::new(factory, verifier, ScannerConfig { lookback_games: 1000 });
 
         // last_scanned = Some(1) (gameCount - 1), so start = 2 > end = 1
         let (candidates, new_last_scanned) = scanner.scan(Some(1)).await.unwrap();
@@ -310,11 +290,7 @@ mod tests {
         let factory = Arc::new(MockDisputeGameFactory { games });
         let verifier = Arc::new(MockAggregateVerifier { games: verifier_games });
 
-        let scanner = GameScanner::new(
-            factory,
-            verifier,
-            ScannerConfig { lookback_games: 3 },
-        );
+        let scanner = GameScanner::new(factory, verifier, ScannerConfig { lookback_games: 3 });
 
         // Fresh start: last_scanned = None
         // start = max(0, 100-3) = 97, end = 99
@@ -334,11 +310,7 @@ mod tests {
         // 3 games: index 1 will error, indices 0 and 2 are valid candidates
         let factory = Arc::new(ErrorOnIndexFactory {
             inner: MockDisputeGameFactory {
-                games: vec![
-                    factory_game(0, 1),
-                    factory_game(1, 1),
-                    factory_game(2, 1),
-                ],
+                games: vec![factory_game(0, 1), factory_game(1, 1), factory_game(2, 1)],
             },
             error_indices: vec![1],
         });
@@ -350,11 +322,7 @@ mod tests {
 
         let verifier = Arc::new(MockAggregateVerifier { games: verifier_games });
 
-        let scanner = GameScanner::new(
-            factory,
-            verifier,
-            ScannerConfig { lookback_games: 1000 },
-        );
+        let scanner = GameScanner::new(factory, verifier, ScannerConfig { lookback_games: 1000 });
 
         // start = max(0, 3-1000) = 0, end = 2
         // Index 0 -> candidate. Index 1 errors -> skipped. Index 2 -> candidate.
@@ -373,11 +341,7 @@ mod tests {
         // Phase 1: index 1 errors, so new_last_scanned = Some(0)
         let factory = Arc::new(ErrorOnIndexFactory {
             inner: MockDisputeGameFactory {
-                games: vec![
-                    factory_game(0, 1),
-                    factory_game(1, 1),
-                    factory_game(2, 1),
-                ],
+                games: vec![factory_game(0, 1), factory_game(1, 1), factory_game(2, 1)],
             },
             error_indices: vec![1],
         });
@@ -389,31 +353,20 @@ mod tests {
 
         let verifier = Arc::new(MockAggregateVerifier { games: verifier_games.clone() });
 
-        let scanner = GameScanner::new(
-            factory,
-            verifier,
-            ScannerConfig { lookback_games: 1000 },
-        );
+        let scanner = GameScanner::new(factory, verifier, ScannerConfig { lookback_games: 1000 });
 
         let (_, new_last_scanned) = scanner.scan(None).await.unwrap();
         assert_eq!(new_last_scanned, Some(0));
 
         // Phase 2: no errors, pass last_scanned = Some(0) to retry from index 1
         let factory2 = Arc::new(MockDisputeGameFactory {
-            games: vec![
-                factory_game(0, 1),
-                factory_game(1, 1),
-                factory_game(2, 1),
-            ],
+            games: vec![factory_game(0, 1), factory_game(1, 1), factory_game(2, 1)],
         });
 
         let verifier2 = Arc::new(MockAggregateVerifier { games: verifier_games });
 
-        let scanner2 = GameScanner::new(
-            factory2,
-            verifier2,
-            ScannerConfig { lookback_games: 1000 },
-        );
+        let scanner2 =
+            GameScanner::new(factory2, verifier2, ScannerConfig { lookback_games: 1000 });
 
         let (candidates, new_last_scanned) = scanner2.scan(Some(0)).await.unwrap();
 
@@ -428,9 +381,7 @@ mod tests {
     #[tokio::test]
     async fn test_scan_error_at_first_index() {
         let factory = Arc::new(ErrorOnIndexFactory {
-            inner: MockDisputeGameFactory {
-                games: vec![factory_game(0, 1), factory_game(1, 1)],
-            },
+            inner: MockDisputeGameFactory { games: vec![factory_game(0, 1), factory_game(1, 1)] },
             error_indices: vec![0],
         });
 
@@ -439,11 +390,7 @@ mod tests {
 
         let verifier = Arc::new(MockAggregateVerifier { games: verifier_games });
 
-        let scanner = GameScanner::new(
-            factory,
-            verifier,
-            ScannerConfig { lookback_games: 1000 },
-        );
+        let scanner = GameScanner::new(factory, verifier, ScannerConfig { lookback_games: 1000 });
 
         // last_scanned = None, lowest_error = 0 -> preserves None (fresh-start semantics)
         let (candidates, new_last_scanned) = scanner.scan(None).await.unwrap();

--- a/crates/proof/contracts/src/aggregate_verifier.rs
+++ b/crates/proof/contracts/src/aggregate_verifier.rs
@@ -65,6 +65,15 @@ pub trait AggregateVerifierClient: Send + Sync {
     /// Queries game details from a game proxy address.
     async fn game_info(&self, game_address: Address) -> Result<GameInfo, ContractError>;
 
+    /// Returns the current game status (`0=IN_PROGRESS`, `1=CHALLENGER_WINS`, `2=DEFENDER_WINS`).
+    async fn status(&self, game_address: Address) -> Result<u8, ContractError>;
+
+    /// Returns the address that provided a ZK proof for the given game.
+    async fn zk_prover(&self, game_address: Address) -> Result<Address, ContractError>;
+
+    /// Returns the starting block number for the given game.
+    async fn starting_block_number(&self, game_address: Address) -> Result<u64, ContractError>;
+
     /// Reads `BLOCK_INTERVAL` from the `AggregateVerifier` implementation contract.
     async fn read_block_interval(&self, impl_address: Address) -> Result<u64, ContractError>;
 
@@ -116,6 +125,41 @@ impl AggregateVerifierClient for AggregateVerifierContractClient {
             .map_err(|e| ContractError::Call { context: "parentIndex failed".into(), source: e })?;
 
         Ok(GameInfo { root_claim, l2_block_number, parent_index })
+    }
+
+    async fn status(&self, game_address: Address) -> Result<u8, ContractError> {
+        let contract =
+            IAggregateVerifier::IAggregateVerifierInstance::new(game_address, &self.provider);
+
+        contract
+            .status()
+            .call()
+            .await
+            .map_err(|e| ContractError::Call { context: "status failed".into(), source: e })
+    }
+
+    async fn zk_prover(&self, game_address: Address) -> Result<Address, ContractError> {
+        let contract =
+            IAggregateVerifier::IAggregateVerifierInstance::new(game_address, &self.provider);
+
+        contract
+            .zkProver()
+            .call()
+            .await
+            .map_err(|e| ContractError::Call { context: "zkProver failed".into(), source: e })
+    }
+
+    async fn starting_block_number(&self, game_address: Address) -> Result<u64, ContractError> {
+        let contract =
+            IAggregateVerifier::IAggregateVerifierInstance::new(game_address, &self.provider);
+
+        let block_u256: U256 = contract.startingBlockNumber().call().await.map_err(|e| {
+            ContractError::Call { context: "startingBlockNumber failed".into(), source: e }
+        })?;
+
+        block_u256
+            .try_into()
+            .map_err(|_| ContractError::Validation("startingBlockNumber overflows u64".into()))
     }
 
     async fn read_block_interval(&self, impl_address: Address) -> Result<u64, ContractError> {


### PR DESCRIPTION
### What changed? Why?
Adds the GameScanner component to the challenger service, which monitors the DisputeGameFactory contract for dispute games that need validation. The scanner filters games by type, in-progress status, and unchallenged state (zero zkProver), returning candidate games for downstream processing. Also extends the AggregateVerifierClient trait with three new methods (status, zk_prover, starting_block_number) needed for per-game queries.

### How has it been tested?
All 30 tests pass (7 new scanner tests covering happy path, all filter conditions, edge cases, and error resilience), clippy clean.

### Notes to reviewers
Purely additive — no existing behavior is modified. The scanner is stateless across restarts (lookback window recomputed on startup). Uses trait objects (Arc<dyn AggregateVerifierClient>) for testability. Individual game query failures are logged and skipped to stay resilient against transient RPC errors.

### Change management
type=routine
risk=low
impact=sev5

### Backwards Compatibility
backwards_compatible=true

automerge=false