### PR TITLE
backport: override nonce and cap base fee in bundle simulation (#1049)

### DIFF
--- a/crates/client/metering/src/meter.rs
+++ b/crates/client/metering/src/meter.rs
@@ -11,7 +11,7 @@ use reth_evm::{ConfigureEvm, execute::BlockBuilder};
 use reth_optimism_chainspec::OpChainSpec;
 use reth_optimism_evm::{OpEvmConfig, OpNextBlockEnvAttributes};
 use reth_primitives_traits::{Account, SealedHeader};
-use reth_revm::{database::StateProviderDatabase, db::State};
+use reth_revm::{database::StateProviderDatabase, db::State, primitives::KECCAK_EMPTY};
 use reth_trie_common::TrieInput;
 use revm_database::states::{BundleState, bundle_state::BundleRetention};
 
@@ -67,6 +67,11 @@ pub struct PendingState {
 }
 
 const BLOCK_TIME: u64 = 2; // 2 seconds per block
+// Static floor from the current minimum base fee for metering simulation.
+// The protocol has a dynamic min_base_fee via system config, but for metering
+// we use a static floor to reject transactions that will never make it onchain.
+const MIN_BASEFEE: u64 = 5_000_000;
+const MAX_NONCE_AHEAD: u64 = 10_000; // max nonce distance from on-chain state
 
 /// Output from metering a bundle of transactions
 #[derive(Debug)]
@@ -136,6 +141,44 @@ where
         State::builder().with_database(state_db).with_bundle_update().build()
     };
 
+    // Override sender nonces to match their first transaction's nonce and collect
+    // account info for pre-flight validation. load_cache_account reads from bundle
+    // prestate (pending flashblocks) when available, so balances reflect pending state.
+    let mut first_nonces: HashMap<Address, u64> = HashMap::new();
+    for tx in bundle.transactions() {
+        first_nonces.entry(tx.signer()).or_insert_with(|| tx.nonce());
+    }
+
+    let mut account_infos: HashMap<Address, Option<Account>> = HashMap::new();
+    for (&addr, &nonce) in &first_nonces {
+        let cache_account = db.load_cache_account(addr)?;
+        if let Some(ref mut account) = cache_account.account {
+            let max_nonce = account.info.nonce.saturating_add(MAX_NONCE_AHEAD);
+            if nonce > max_nonce {
+                return Err(eyre!(
+                    "transaction nonce {} for {} exceeds max allowed (on-chain {} + {})",
+                    nonce,
+                    addr,
+                    account.info.nonce,
+                    MAX_NONCE_AHEAD,
+                ));
+            }
+            account.info.nonce = nonce;
+
+            account_infos.insert(
+                addr,
+                Some(Account {
+                    nonce: account.info.nonce,
+                    balance: account.info.balance,
+                    bytecode_hash: (account.info.code_hash != KECCAK_EMPTY)
+                        .then_some(account.info.code_hash),
+                }),
+            );
+        } else {
+            account_infos.insert(addr, None);
+        }
+    }
+
     // Set up next block attributes
     // Use bundle.min_timestamp if provided, otherwise use header timestamp + BLOCK_TIME
     let timestamp = bundle.min_timestamp.unwrap_or_else(|| header.timestamp() + BLOCK_TIME);
@@ -151,15 +194,6 @@ where
         extra_data: header.extra_data().clone(),
     };
 
-    // Pre-fetch account information for all transactions before creating builder. The
-    // account information is used to validate the transaction.
-    let mut accounts: HashMap<Address, Option<Account>> = HashMap::new();
-    for tx in bundle.transactions() {
-        let from = tx.recover_signer()?;
-        let account = db.database.basic_account(&from)?;
-        accounts.insert(from, account);
-    }
-
     // Execute transactions
     let mut results = Vec::new();
     let mut total_gas_used = 0u64;
@@ -170,6 +204,13 @@ where
         let evm_config = OpEvmConfig::optimism(chain_spec);
         let mut builder = evm_config.builder_for_next_block(&mut db, header, attributes)?;
 
+        // Cap the base fee at MIN_BASEFEE so transactions aren't rejected for
+        // max_fee_per_gas < basefee. We're simulating for gas measurement, not fee
+        // accounting. Balance checks in validate_tx still catch underfunded senders
+        // intentionally.
+        let block = &mut builder.evm_mut().block;
+        block.basefee = block.basefee.min(MIN_BASEFEE);
+
         builder.apply_pre_execution_changes()?;
 
         for tx in bundle.transactions() {
@@ -179,12 +220,14 @@ where
             let to = tx.to();
             let value = tx.value();
             let gas_price = tx.max_fee_per_gas();
-            let account = accounts
+            let account = account_infos
                 .get(&from)
                 .ok_or_else(|| eyre!("Account not found in HashMap for address: {}", from))?
                 .ok_or_else(|| eyre!("Account is none for tx: {}", tx_hash))?;
 
-            // Don't waste resources metering invalid transactions
+            // Don't waste resources metering invalid transactions.
+            // Note: balance checks (InsufficientFunds*) are intentionally kept — an underfunded
+            // sender is a meaningful validation failure. Nonce and base fee are overridden above.
             validate_tx(account, tx, &mut l1_block_info)
                 .map_err(|e| eyre!("Transaction {} validation failed: {}", tx_hash, e))?;
 
@@ -255,7 +298,7 @@ mod tests {
     use eyre::Context;
     use reth_optimism_primitives::OpTransactionSigned;
     use reth_provider::StateProviderFactory;
-    use reth_revm::{bytecode::Bytecode, primitives::KECCAK_EMPTY, state::AccountInfo};
+    use reth_revm::{bytecode::Bytecode, state::AccountInfo};
     use reth_transaction_pool::test_utils::TransactionBuilder;
     use revm_context_interface::transaction::{AccessList, AccessListItem};
 
@@ -586,27 +629,26 @@ mod tests {
         Ok(())
     }
 
-    /// Integration test: verifies `meter_bundle` uses flashblocks state correctly.
+    /// Verifies that a nonce ahead of on-chain state succeeds via override.
     ///
-    /// A transaction using nonce=1 should fail without flashblocks state (since
-    /// canonical nonce is 0), but succeed when flashblocks state indicates nonce=1.
+    /// Canonical nonce is 0, but the transaction uses nonce=1. The nonce override
+    /// sets the account nonce to match, so simulation succeeds.
     #[tokio::test]
-    async fn meter_bundle_requires_correct_layering_for_pending_nonce() -> eyre::Result<()> {
+    async fn meter_bundle_overrides_nonce_too_high() -> eyre::Result<()> {
         let harness = TestHarness::new().await?;
         let latest = harness.latest_block();
         let header = latest.sealed_header().clone();
 
-        // Create a transaction that requires nonce=1 (assuming canonical nonce is 0)
         let to = Address::random();
         let signed_tx = TransactionBuilder::default()
             .signer(Account::Alice.signer_b256())
             .chain_id(harness.chain_id())
-            .nonce(1) // Requires pending state to have nonce=1
+            .nonce(1) // Ahead of canonical nonce (0)
             .to(to)
             .value(100)
             .gas_limit(21_000)
-            .max_fee_per_gas(10)
-            .max_priority_fee_per_gas(1)
+            .max_fee_per_gas(MIN_BASEFEE as u128)
+            .max_priority_fee_per_gas(0)
             .into_eip1559();
 
         let tx = OpTransactionSigned::Eip1559(
@@ -614,62 +656,95 @@ mod tests {
         );
         let parsed_bundle = create_parsed_bundle(vec![tx])?;
 
-        // Without flashblocks state, transaction should fail (nonce mismatch)
         let state_provider = harness
             .blockchain_provider()
             .state_by_block_hash(latest.hash())
             .context("getting state provider")?;
 
-        let result_without_flashblocks = meter_bundle(
+        let result = meter_bundle(
             state_provider,
             harness.chain_spec(),
-            parsed_bundle.clone(),
+            parsed_bundle,
             &header,
             header.parent_beacon_block_root(),
-            None, // No pending state
+            None,
             L1BlockInfo::default(),
         );
 
         assert!(
-            result_without_flashblocks.is_err(),
-            "Transaction with nonce=1 should fail without pending state (canonical nonce is 0)"
+            result.is_ok(),
+            "Nonce ahead of on-chain state should succeed via override: {:?}",
+            result.err()
         );
 
-        // Now create pending state with nonce=1 for Alice
-        // Use BundleState::new() to properly calculate state_size
+        let output = result.unwrap();
+        assert_eq!(output.results.len(), 1);
+        assert_eq!(output.total_gas_used, 21_000);
+
+        Ok(())
+    }
+
+    /// Verifies that a nonce behind on-chain state succeeds via override.
+    ///
+    /// Uses pending state to advance Alice's nonce to 5, then submits a transaction
+    /// with nonce=0. The nonce override sets the account nonce to match the
+    /// transaction, so simulation succeeds despite the nonce being "too low".
+    #[tokio::test]
+    async fn meter_bundle_overrides_nonce_too_low() -> eyre::Result<()> {
+        let harness = TestHarness::new().await?;
+        let latest = harness.latest_block();
+        let header = latest.sealed_header().clone();
+
+        // Build pending state where Alice's nonce has advanced to 5
         let bundle_state = BundleState::new(
             [(
                 Account::Alice.address(),
                 Some(AccountInfo {
-                    balance: U256::from(1_000_000_000u64),
+                    balance: U256::from(1_000_000_000_000_000_000u128),
                     nonce: 0, // original
                     code_hash: KECCAK_EMPTY,
                     code: None,
                     account_id: None,
                 }),
                 Some(AccountInfo {
-                    balance: U256::from(1_000_000_000u64),
-                    nonce: 1, // pending (after first flashblock tx)
+                    balance: U256::from(1_000_000_000_000_000_000u128),
+                    nonce: 5, // pending
                     code_hash: KECCAK_EMPTY,
                     code: None,
                     account_id: None,
                 }),
-                Default::default(), // no storage changes
+                Default::default(),
             )],
             Vec::<Vec<(Address, Option<Option<AccountInfo>>, Vec<(U256, U256)>)>>::new(),
             Vec::<(B256, Bytecode)>::new(),
         );
-
         let pending_state = PendingState { bundle_state, trie_input: None };
 
-        // With correct pending state, transaction should succeed
-        let state_provider2 = harness
+        // Transaction with nonce=0 — "too low" relative to pending nonce of 5
+        let to = Address::random();
+        let signed_tx = TransactionBuilder::default()
+            .signer(Account::Alice.signer_b256())
+            .chain_id(harness.chain_id())
+            .nonce(0)
+            .to(to)
+            .value(100)
+            .gas_limit(21_000)
+            .max_fee_per_gas(MIN_BASEFEE as u128)
+            .max_priority_fee_per_gas(0)
+            .into_eip1559();
+
+        let tx = OpTransactionSigned::Eip1559(
+            signed_tx.as_eip1559().expect("eip1559 transaction").clone(),
+        );
+        let parsed_bundle = create_parsed_bundle(vec![tx])?;
+
+        let state_provider = harness
             .blockchain_provider()
             .state_by_block_hash(latest.hash())
             .context("getting state provider")?;
 
-        let result_with_pending = meter_bundle(
-            state_provider2,
+        let result = meter_bundle(
+            state_provider,
             harness.chain_spec(),
             parsed_bundle,
             &header,
@@ -679,10 +754,121 @@ mod tests {
         );
 
         assert!(
-            result_with_pending.is_ok(),
-            "Transaction with nonce=1 should succeed with pending state showing nonce=1: {:?}",
-            result_with_pending.err()
+            result.is_ok(),
+            "Nonce behind on-chain state should succeed via override: {:?}",
+            result.err()
         );
+
+        let output = result.unwrap();
+        assert_eq!(output.results.len(), 1);
+        assert_eq!(output.total_gas_used, 21_000);
+
+        Ok(())
+    }
+
+    /// Verifies that nonce overrides are rejected when too far ahead of on-chain state.
+    #[tokio::test]
+    async fn meter_bundle_err_nonce_too_far_ahead() -> eyre::Result<()> {
+        let harness = TestHarness::new().await?;
+        let latest = harness.latest_block();
+        let header = latest.sealed_header().clone();
+
+        let to = Address::random();
+        let nonce = MAX_NONCE_AHEAD + 1; // Just over the limit (on-chain nonce is 0)
+        let signed_tx = TransactionBuilder::default()
+            .signer(Account::Alice.signer_b256())
+            .chain_id(harness.chain_id())
+            .nonce(nonce)
+            .to(to)
+            .value(100)
+            .gas_limit(21_000)
+            .max_fee_per_gas(MIN_BASEFEE as u128)
+            .max_priority_fee_per_gas(0)
+            .into_eip1559();
+
+        let tx = OpTransactionSigned::Eip1559(
+            signed_tx.as_eip1559().expect("eip1559 transaction").clone(),
+        );
+
+        let state_provider = harness
+            .blockchain_provider()
+            .state_by_block_hash(latest.hash())
+            .context("getting state provider")?;
+
+        let parsed_bundle = create_parsed_bundle(vec![tx])?;
+
+        let result = meter_bundle(
+            state_provider,
+            harness.chain_spec(),
+            parsed_bundle,
+            &header,
+            header.parent_beacon_block_root(),
+            None,
+            L1BlockInfo::default(),
+        );
+
+        assert!(result.is_err(), "Nonce exceeding MAX_NONCE_AHEAD should fail");
+        assert!(
+            result.unwrap_err().to_string().contains("exceeds max allowed"),
+            "Expected max nonce error"
+        );
+
+        Ok(())
+    }
+
+    /// Verifies that the base fee is capped at `MIN_BASEFEE` for simulation.
+    ///
+    /// The test genesis produces a next-block base fee of ~980M wei. A transaction with
+    /// `max_fee_per_gas` at the `MIN_BASEFEE` floor (5M wei) would normally be rejected,
+    /// but `meter_bundle` caps the base fee so simulation succeeds.
+    #[tokio::test]
+    async fn meter_bundle_caps_basefee_at_minimum() -> eyre::Result<()> {
+        let harness = TestHarness::new().await?;
+        let latest = harness.latest_block();
+        let header = latest.sealed_header().clone();
+
+        let to = Address::random();
+        let signed_tx = TransactionBuilder::default()
+            .signer(Account::Alice.signer_b256())
+            .chain_id(harness.chain_id())
+            .nonce(0)
+            .to(to)
+            .value(1_000)
+            .gas_limit(21_000)
+            .max_fee_per_gas(MIN_BASEFEE as u128) // At the floor, below the ~980M on-chain base fee
+            .max_priority_fee_per_gas(0)
+            .into_eip1559();
+
+        let tx = OpTransactionSigned::Eip1559(
+            signed_tx.as_eip1559().expect("eip1559 transaction").clone(),
+        );
+
+        let state_provider = harness
+            .blockchain_provider()
+            .state_by_block_hash(latest.hash())
+            .context("getting state provider")?;
+
+        let parsed_bundle = create_parsed_bundle(vec![tx])?;
+
+        let result = meter_bundle(
+            state_provider,
+            harness.chain_spec(),
+            parsed_bundle,
+            &header,
+            header.parent_beacon_block_root(),
+            None,
+            L1BlockInfo::default(),
+        );
+
+        assert!(
+            result.is_ok(),
+            "Transaction with max_fee_per_gas below base fee but at least MIN_BASEFEE should succeed: {:?}",
+            result.err()
+        );
+
+        let output = result.unwrap();
+        assert_eq!(output.results.len(), 1);
+        assert_eq!(output.total_gas_used, 21_000);
 
         Ok(())
     }


### PR DESCRIPTION
## Summary

Backport of #1049 (merged to main as 5d2213e6) onto `releases/v0.5.2`.

- Override sender nonces in metering simulation state to match bundle transaction nonces, with a `MAX_NONCE_AHEAD` (10,000) safety cap
- Cap the EVM block base fee at `MIN_BASEFEE` (5M wei) so transactions aren't rejected for `max_fee_per_gas < basefee`
- Read account info from `State` cache (not `db.database`) so pending flashblocks balances are reflected
- Balance checks intentionally preserved as meaningful validation failures

## Dependencies

Conflicts with #1053 (backport of nonce/7702 check removal). Whichever merges second will need a rebase. Our nonce override works correctly with or without #1053's `validate_tx` simplifications.

## Test plan

- [x] `cargo test -p base-metering` — all 35 tests pass
- [x] `cargo clippy -p base-metering --all-targets --profile ci -- -D warnings` — clean