### PR TITLE
chore(ingress-rpc): retain audit connector handle

### DIFF
--- a/bin/ingress-rpc/src/main.rs
+++ b/bin/ingress-rpc/src/main.rs
@@ -90,7 +90,7 @@ async fn main() -> anyhow::Result<()> {
     let audit_publisher =
         KafkaBundleEventPublisher::new(audit_producer, config.audit_topic.clone());
     let (audit_tx, audit_rx) = mpsc::unbounded_channel::<BundleEvent>();
-    AuditConnector::connect(audit_rx, audit_publisher);
+    let _audit_handle = AuditConnector::connect(audit_rx, audit_publisher);
 
     let (builder_tx, _) =
         broadcast::channel::<MeterBundleResponse>(config.max_buffered_meter_bundle_responses);


### PR DESCRIPTION
Retain the AuditConnector JoinHandle in ingress-rpc main, making background task ownership explicit without changing forwarding behavior.