### PR TITLE
Use structured logging for genesis generation

### DIFF
--- a/crates/builder/core/src/test_utils/apis.rs
+++ b/crates/builder/core/src/test_utils/apis.rs
@@ -217,7 +217,7 @@ pub fn generate_genesis(output: Option<String>) -> eyre::Result<()> {
     // Write the result to the output file
     if let Some(output) = output {
         std::fs::write(&output, serde_json::to_string_pretty(&genesis)?)?;
-        info!("Generated genesis file at: {output}");
+        info!(%output, "Generated genesis file");
     } else {
         println!("{}", serde_json::to_string_pretty(&genesis)?);
     }


### PR DESCRIPTION
**Change:**
Replace string interpolation in the log message with structured logging using `tracing`.

**Impact:**
This makes the `output` value a structured field, improving log parsing and compatibility with observability tools.