### PR TITLE
feat(proof): add witness transport abstraction

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4133,6 +4133,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "base-proof-transport"
+version = "0.0.0"
+dependencies = [
+ "alloy-primitives",
+ "async-trait",
+ "base-proof-primitives",
+ "thiserror 2.0.18",
+ "tokio",
+]
+
+[[package]]
 name = "base-proofs-extension"
 version = "0.0.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ members = [
   "crates/proof/tee/core",
   "crates/proof/tee/client",
   "crates/proof/tee/server",
+  "crates/proof/transport",
   "crates/proof/contracts",
   "crates/proof/rpc",
   "crates/proof/proposer",
@@ -225,6 +226,7 @@ base-proof-contracts = { path = "crates/proof/contracts" }
 base-proof-rpc = { path = "crates/proof/rpc" }
 base-proposer = { path = "crates/proof/proposer" }
 base-challenger = { path = "crates/proof/challenge" }
+base-proof-transport = { path = "crates/proof/transport" }
 
 # Utilities
 base-jwt = { path = "crates/utilities/jwt" }

--- a/crates/proof/primitives/Cargo.toml
+++ b/crates/proof/primitives/Cargo.toml
@@ -18,5 +18,9 @@ serde = { workspace = true, optional = true, features = ["derive"] }
 
 [features]
 default = []
-std = [ "alloy-primitives/std", "base-proof-preimage/std" ]
+std = [
+	"alloy-primitives/std",
+	"base-proof-preimage/std",
+	"serde?/std"
+]
 serde = [ "alloy-primitives/serde", "base-proof-preimage/serde", "dep:serde" ]

--- a/crates/proof/primitives/Cargo.toml
+++ b/crates/proof/primitives/Cargo.toml
@@ -18,9 +18,5 @@ serde = { workspace = true, optional = true, features = ["derive"] }
 
 [features]
 default = []
-std = [
-	"alloy-primitives/std",
-	"base-proof-preimage/std",
-	"serde?/std"
-]
+std = [ "alloy-primitives/std", "base-proof-preimage/std", "serde?/std" ]
 serde = [ "alloy-primitives/serde", "base-proof-preimage/serde", "dep:serde" ]

--- a/crates/proof/transport/Cargo.toml
+++ b/crates/proof/transport/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "base-proof-transport"
+description = "Witness transport abstraction for proof backends"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+
+[lints]
+workspace = true
+
+[dependencies]
+# Proof
+base-proof-primitives = { workspace = true, features = ["std"] }
+
+# Async
+tokio = { workspace = true, features = ["sync"] }
+async-trait = { workspace = true }
+
+# Error handling
+thiserror = { workspace = true }
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["full"] }
+alloy-primitives = { workspace = true }

--- a/crates/proof/transport/README.md
+++ b/crates/proof/transport/README.md
@@ -1,0 +1,14 @@
+# base-proof-transport
+
+Witness transport abstraction for proof backends.
+
+Defines `WitnessTransport`, a trait that abstracts how witness bundles reach
+proof backends and how results come back. Implementations handle the
+underlying channel — in-process, `AF_VSOCK`, or guest stdin — so callers remain
+transport-agnostic.
+
+## Transports
+
+| Transport | Purpose |
+|-----------|---------|
+| `NativeTransport` | In-process channel for testing and single-process provers |

--- a/crates/proof/transport/src/errors.rs
+++ b/crates/proof/transport/src/errors.rs
@@ -1,0 +1,13 @@
+use thiserror::Error;
+
+/// Errors that can occur during witness transport operations.
+#[derive(Error, Debug)]
+pub enum TransportError {
+    /// The underlying channel was closed by the remote end.
+    #[error("channel closed")]
+    ChannelClosed,
+
+    /// Sending a message through the channel failed.
+    #[error("send failed: {0}")]
+    Send(String),
+}

--- a/crates/proof/transport/src/lib.rs
+++ b/crates/proof/transport/src/lib.rs
@@ -1,0 +1,13 @@
+#![doc = include_str!("../README.md")]
+
+mod errors;
+pub use errors::TransportError;
+
+mod transport;
+pub use transport::{TransportResult, WitnessTransport};
+
+mod native;
+pub use native::{NativeBackend, NativeTransport};
+
+#[cfg(test)]
+mod tests;

--- a/crates/proof/transport/src/native.rs
+++ b/crates/proof/transport/src/native.rs
@@ -1,0 +1,64 @@
+use async_trait::async_trait;
+use base_proof_primitives::{ProofResult, WitnessBundle};
+use tokio::sync::{Mutex, mpsc};
+
+use crate::{TransportError, TransportResult, WitnessTransport};
+
+/// In-process witness transport backed by tokio mpsc channels.
+///
+/// Created via [`NativeTransport::channel`], which returns a sender/receiver
+/// pair. The sender submits witness bundles, and the receiver retrieves proof
+/// results produced by the backend.
+#[derive(Debug)]
+pub struct NativeTransport {
+    witness_tx: mpsc::Sender<WitnessBundle>,
+    result_rx: Mutex<mpsc::Receiver<ProofResult>>,
+}
+
+/// The backend half of a [`NativeTransport`] channel.
+///
+/// The proof backend receives witness bundles from this handle and sends back
+/// proof results.
+#[derive(Debug)]
+pub struct NativeBackend {
+    witness_rx: Mutex<mpsc::Receiver<WitnessBundle>>,
+    result_tx: mpsc::Sender<ProofResult>,
+}
+
+impl NativeTransport {
+    /// Create a connected transport/backend pair with the given channel
+    /// capacity.
+    pub fn channel(capacity: usize) -> (Self, NativeBackend) {
+        let (witness_tx, witness_rx) = mpsc::channel(capacity);
+        let (result_tx, result_rx) = mpsc::channel(capacity);
+
+        let transport = Self { witness_tx, result_rx: Mutex::new(result_rx) };
+
+        let backend = NativeBackend { witness_rx: Mutex::new(witness_rx), result_tx };
+
+        (transport, backend)
+    }
+}
+
+impl NativeBackend {
+    /// Receive the next witness bundle from the transport.
+    pub async fn recv_witness(&self) -> TransportResult<WitnessBundle> {
+        self.witness_rx.lock().await.recv().await.ok_or(TransportError::ChannelClosed)
+    }
+
+    /// Send a proof result back to the transport.
+    pub async fn send_result(&self, result: ProofResult) -> TransportResult<()> {
+        self.result_tx.send(result).await.map_err(|e| TransportError::Send(e.to_string()))
+    }
+}
+
+#[async_trait]
+impl WitnessTransport for NativeTransport {
+    async fn send_witness(&self, bundle: WitnessBundle) -> TransportResult<()> {
+        self.witness_tx.send(bundle).await.map_err(|e| TransportError::Send(e.to_string()))
+    }
+
+    async fn recv_result(&self) -> TransportResult<ProofResult> {
+        self.result_rx.lock().await.recv().await.ok_or(TransportError::ChannelClosed)
+    }
+}

--- a/crates/proof/transport/src/native.rs
+++ b/crates/proof/transport/src/native.rs
@@ -54,8 +54,8 @@ impl NativeBackend {
 
 #[async_trait]
 impl WitnessTransport for NativeTransport {
-    async fn send_witness(&self, bundle: WitnessBundle) -> TransportResult<()> {
-        self.witness_tx.send(bundle).await.map_err(|e| TransportError::Send(e.to_string()))
+    async fn send_witness(&self, bundle: &WitnessBundle) -> TransportResult<()> {
+        self.witness_tx.send(bundle.clone()).await.map_err(|e| TransportError::Send(e.to_string()))
     }
 
     async fn recv_result(&self) -> TransportResult<ProofResult> {

--- a/crates/proof/transport/src/tests.rs
+++ b/crates/proof/transport/src/tests.rs
@@ -20,7 +20,7 @@ async fn roundtrip() {
     let bundle = test_bundle();
     let result = test_result();
 
-    transport.send_witness(bundle.clone()).await.unwrap();
+    transport.send_witness(&bundle).await.unwrap();
 
     let received_bundle = backend.recv_witness().await.unwrap();
     assert_eq!(received_bundle, bundle);
@@ -48,7 +48,7 @@ async fn send_after_receiver_dropped() {
 
     drop(backend);
 
-    let err = transport.send_witness(bundle).await.unwrap_err();
+    let err = transport.send_witness(&bundle).await.unwrap_err();
     assert!(matches!(err, TransportError::Send(_)));
 }
 
@@ -79,7 +79,7 @@ async fn multiple_bundles() {
 
     for i in 0..5u64 {
         let bundle = WitnessBundle { preimages: vec![] };
-        transport.send_witness(bundle).await.unwrap();
+        transport.send_witness(&bundle).await.unwrap();
 
         let _ = backend.recv_witness().await.unwrap();
 

--- a/crates/proof/transport/src/tests.rs
+++ b/crates/proof/transport/src/tests.rs
@@ -1,0 +1,95 @@
+use alloy_primitives::B256;
+use base_proof_primitives::{ProofClaim, ProofEvidence, ProofResult, WitnessBundle};
+
+use crate::{NativeTransport, TransportError, WitnessTransport};
+
+fn test_bundle() -> WitnessBundle {
+    WitnessBundle { preimages: vec![] }
+}
+
+fn test_result() -> ProofResult {
+    ProofResult {
+        claim: ProofClaim { l2_block_number: 42, output_root: B256::ZERO, l1_head: B256::ZERO },
+        evidence: ProofEvidence::Tee { attestation_doc: vec![1, 2, 3], signature: vec![4, 5, 6] },
+    }
+}
+
+#[tokio::test]
+async fn roundtrip() {
+    let (transport, backend) = NativeTransport::channel(1);
+    let bundle = test_bundle();
+    let result = test_result();
+
+    transport.send_witness(bundle.clone()).await.unwrap();
+
+    let received_bundle = backend.recv_witness().await.unwrap();
+    assert_eq!(received_bundle, bundle);
+
+    backend.send_result(result.clone()).await.unwrap();
+
+    let received_result = transport.recv_result().await.unwrap();
+    assert_eq!(received_result, result);
+}
+
+#[tokio::test]
+async fn recv_after_sender_dropped() {
+    let (transport, backend) = NativeTransport::channel(1);
+
+    drop(backend);
+
+    let err = transport.recv_result().await.unwrap_err();
+    assert!(matches!(err, TransportError::ChannelClosed));
+}
+
+#[tokio::test]
+async fn send_after_receiver_dropped() {
+    let (transport, backend) = NativeTransport::channel(1);
+    let bundle = test_bundle();
+
+    drop(backend);
+
+    let err = transport.send_witness(bundle).await.unwrap_err();
+    assert!(matches!(err, TransportError::Send(_)));
+}
+
+#[tokio::test]
+async fn backend_recv_after_transport_dropped() {
+    let (transport, backend) = NativeTransport::channel(1);
+
+    drop(transport);
+
+    let err = backend.recv_witness().await.unwrap_err();
+    assert!(matches!(err, TransportError::ChannelClosed));
+}
+
+#[tokio::test]
+async fn backend_send_after_transport_dropped() {
+    let (transport, backend) = NativeTransport::channel(1);
+    let result = test_result();
+
+    drop(transport);
+
+    let err = backend.send_result(result).await.unwrap_err();
+    assert!(matches!(err, TransportError::Send(_)));
+}
+
+#[tokio::test]
+async fn multiple_bundles() {
+    let (transport, backend) = NativeTransport::channel(8);
+
+    for i in 0..5u64 {
+        let bundle = WitnessBundle { preimages: vec![] };
+        transport.send_witness(bundle).await.unwrap();
+
+        let _ = backend.recv_witness().await.unwrap();
+
+        let result = ProofResult {
+            claim: ProofClaim { l2_block_number: i, output_root: B256::ZERO, l1_head: B256::ZERO },
+            evidence: ProofEvidence::Tee { attestation_doc: vec![], signature: vec![] },
+        };
+        backend.send_result(result).await.unwrap();
+
+        let received = transport.recv_result().await.unwrap();
+        assert_eq!(received.claim.l2_block_number, i);
+    }
+}

--- a/crates/proof/transport/src/transport.rs
+++ b/crates/proof/transport/src/transport.rs
@@ -11,10 +11,16 @@ pub type TransportResult<T> = Result<T, TransportError>;
 ///
 /// Implementations handle the underlying channel — in-process, `AF_VSOCK`, or
 /// ZK guest stdin — so callers remain transport-agnostic.
+///
+/// Both ends are single-consumer: a transport should be owned by one sender
+/// task and one receiver task. Concurrent calls to [`recv_result`] may
+/// serialize depending on the implementation.
+///
+/// [`recv_result`]: WitnessTransport::recv_result
 #[async_trait]
 pub trait WitnessTransport: Send + Sync {
     /// Send a witness bundle to the proof backend.
-    async fn send_witness(&self, bundle: WitnessBundle) -> TransportResult<()>;
+    async fn send_witness(&self, bundle: &WitnessBundle) -> TransportResult<()>;
 
     /// Receive a proof result from the backend.
     async fn recv_result(&self) -> TransportResult<ProofResult>;

--- a/crates/proof/transport/src/transport.rs
+++ b/crates/proof/transport/src/transport.rs
@@ -1,0 +1,21 @@
+use async_trait::async_trait;
+use base_proof_primitives::{ProofResult, WitnessBundle};
+
+use crate::TransportError;
+
+/// Result type for witness transport operations.
+pub type TransportResult<T> = Result<T, TransportError>;
+
+/// Abstracts how witness bundles reach proof backends and how results come
+/// back.
+///
+/// Implementations handle the underlying channel — in-process, `AF_VSOCK`, or
+/// ZK guest stdin — so callers remain transport-agnostic.
+#[async_trait]
+pub trait WitnessTransport: Send + Sync {
+    /// Send a witness bundle to the proof backend.
+    async fn send_witness(&self, bundle: WitnessBundle) -> TransportResult<()>;
+
+    /// Receive a proof result from the backend.
+    async fn recv_result(&self) -> TransportResult<ProofResult>;
+}


### PR DESCRIPTION
## Summary

- Introduce `WitnessTransport` trait abstracting how witness bundles reach proof backends and how results come back — decoupling callers from the underlying channel (in-process, AF_VSOCK, ZK guest stdin).
- Ship `NativeTransport`, an in-process implementation backed by tokio mpsc channels, with a paired `NativeBackend` handle for the proof backend side.

## Test plan

6 tests covering roundtrip, channel-closed errors (both transport and backend sides), send-after-drop, and sequential multi-bundle flow.

```
cargo test -p base-proof-transport
cargo clippy -p base-proof-transport -- -D warnings
```