### PR TITLE
docs: fix invalid `docker compose down` command

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -284,7 +284,7 @@ devnet-load:
 
 # Stops the contender load generator
 devnet-load-down:
-    docker compose -f etc/docker/docker-compose.yml down contender
+    docker compose -f etc/docker/docker-compose.yml stop contender
 
 # Stream FB's from the builder via websocket
 devnet-flashblocks:


### PR DESCRIPTION
docker compose `down` does not support stopping a single service and the command with contender will fail. Replaced with docker compose `stop` contender which correctly stops the service started by docker compose up -d --no-deps contender.