### PR TITLE
Use RAII Terminal Session

### DIFF
--- a/crates/infra/basectl/src/app/core.rs
+++ b/crates/infra/basectl/src/app/core.rs
@@ -7,7 +7,7 @@ use ratatui::prelude::*;
 use super::{Action, Resources, Router, View, ViewId};
 use crate::{
     commands::common::EVENT_POLL_TIMEOUT,
-    tui::{AppFrame, restore_terminal, setup_terminal},
+    tui::{AppFrame, TerminalSession},
 };
 
 /// Main TUI application that manages views, routing, and the event loop.
@@ -29,9 +29,9 @@ impl App {
     where
         F: FnMut(ViewId) -> Box<dyn View>,
     {
-        let mut terminal = setup_terminal()?;
-        let result = self.run_loop(&mut terminal, &mut view_factory).await;
-        restore_terminal(&mut terminal)?;
+        let mut session = TerminalSession::new()?;
+        let result = self.run_loop(session.terminal_mut(), &mut view_factory).await;
+        session.close()?;
         result
     }
 

--- a/crates/infra/basectl/src/tui/mod.rs
+++ b/crates/infra/basectl/src/tui/mod.rs
@@ -6,9 +6,9 @@ pub(crate) use app_frame::AppFrame;
 mod keybinding;
 pub(crate) use keybinding::Keybinding;
 
-/// Terminal setup and teardown utilities.
+/// Terminal lifecycle utilities.
 mod terminal;
-pub(crate) use terminal::{restore_terminal, setup_terminal};
+pub(crate) use terminal::TerminalSession;
 
 /// Toast notification system.
 mod toast;

--- a/crates/infra/basectl/src/tui/terminal.rs
+++ b/crates/infra/basectl/src/tui/terminal.rs
@@ -8,8 +8,43 @@ use crossterm::{
 };
 use ratatui::prelude::*;
 
+/// Owns terminal lifecycle and restores terminal state on drop.
+#[derive(Debug)]
+pub(crate) struct TerminalSession {
+    terminal: Option<Terminal<CrosstermBackend<Stdout>>>,
+}
+
+impl TerminalSession {
+    /// Initializes the terminal session.
+    pub(crate) fn new() -> Result<Self> {
+        let terminal = setup_terminal()?;
+        Ok(Self { terminal: Some(terminal) })
+    }
+
+    /// Returns a mutable reference to the inner terminal.
+    pub(crate) fn terminal_mut(&mut self) -> &mut Terminal<CrosstermBackend<Stdout>> {
+        self.terminal.as_mut().expect("terminal session already closed")
+    }
+
+    /// Restores terminal state and closes the session.
+    pub(crate) fn close(mut self) -> Result<()> {
+        if let Some(mut terminal) = self.terminal.take() {
+            restore_terminal(&mut terminal)?;
+        }
+        Ok(())
+    }
+}
+
+impl Drop for TerminalSession {
+    fn drop(&mut self) {
+        if let Some(mut terminal) = self.terminal.take() {
+            let _ = restore_terminal(&mut terminal);
+        }
+    }
+}
+
 /// Initializes the terminal in raw mode with an alternate screen.
-pub(crate) fn setup_terminal() -> Result<Terminal<CrosstermBackend<Stdout>>> {
+fn setup_terminal() -> Result<Terminal<CrosstermBackend<Stdout>>> {
     enable_raw_mode()?;
     let mut stdout = io::stdout();
     execute!(stdout, EnterAlternateScreen, DisableMouseCapture)?;
@@ -19,7 +54,7 @@ pub(crate) fn setup_terminal() -> Result<Terminal<CrosstermBackend<Stdout>>> {
 }
 
 /// Restores the terminal to its original state.
-pub(crate) fn restore_terminal(terminal: &mut Terminal<CrosstermBackend<Stdout>>) -> Result<()> {
+fn restore_terminal(terminal: &mut Terminal<CrosstermBackend<Stdout>>) -> Result<()> {
     disable_raw_mode()?;
     execute!(terminal.backend_mut(), LeaveAlternateScreen, DisableMouseCapture)?;
     Ok(())


### PR DESCRIPTION
  `basectl` used manual terminal setup/restore in `App::run`, so cleanup depended on reaching the explicit restore call. This PR introduces `TerminalSession` to own terminal lifecycle and restore on `Drop`, which makes cleanup reliable on early- return and panic-unwind paths.

  Correctness is preserved: `App::run` still calls `session.close()?` on the normal path, so restore errors are still surfaced (same behavior as before), while `Drop` is a safety net for exceptional paths. Scope is intentionally small (TUI internals  only), and `cargo check -p basectl-cli` passes.