### PR TITLE
Handle pre-epoch system time when generating client auth IPC path

### DIFF
--- a/devnet/src/l2/in_process_client.rs
+++ b/devnet/src/l2/in_process_client.rs
@@ -104,12 +104,19 @@ impl InProcessClient {
         std::fs::write(&jwt_path, config.jwt_secret.as_bytes().encode_hex().as_bytes())
             .wrap_err("Failed to write JWT secret")?;
 
-        let unique_ipc_path = format!(
-            "/tmp/reth_client_api_{}_{}_{:?}.ipc",
-            std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH).unwrap().as_nanos(),
-            std::process::id(),
-            std::thread::current().id()
-        );
+        let unique_ipc_path = {
+            let now = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap_or_else(|_| std::time::Duration::from_secs(0))
+                .as_nanos();
+
+            format!(
+                "/tmp/reth_client_api_{}_{}_{:?}.ipc",
+                now,
+                std::process::id(),
+                std::thread::current().id()
+            )
+        };
 
         let mut rpc_args =
             if config.http_port.is_some() || config.ws_port.is_some() || config.auth_port.is_some()


### PR DESCRIPTION
## Problem

The in-process devnet client (`InProcessClient`) generates a unique IPC path for the auth RPC by calling:

```rust
SystemTime::now()
    .duration_since(UNIX_EPOCH)
    .unwrap()
    .as_nanos()
```

On systems where the clock is set before the Unix epoch (or otherwise misconfigured), `duration_since(UNIX_EPOCH)` returns an error, and the `unwrap()` causes a panic.

This means that starting the devnet client can crash the entire test process instead of returning a regular `Result` error, making devnet smoke tests and local runs fragile in such environments.

## Solution

Replace the `unwrap()` on `duration_since(UNIX_EPOCH)` with a fall-back that handles `SystemTimeError` gracefully. If the duration since the epoch cannot be computed, we fall back to a zero duration and still generate a deterministic IPC path using the process ID and thread ID:

```rust
let now = SystemTime::now()
    .duration_since(UNIX_EPOCH)
    .unwrap_or_else(|_| Duration::from_secs(0))
    .as_nanos();
```

The rest of the IPC path format is unchanged, so behavior on correctly configured systems remains the same.

## Impact

- Prevents panics when starting the in-process devnet client on machines or CI environments with misconfigured system time.
- Keeps the change minimal and localized to IPC path generation, without altering any network, RPC, or consensus behavior.
- Improves robustness of existing devnet smoke tests and developer workflows by ensuring `InProcessClient::start` reports errors through `Result` rather than aborting the process.
