### PR TITLE
Use per-test temp subdirectory for disk key-value store tests

### DIFF
--- a/crates/proof/host/src/kv/disk.rs
+++ b/crates/proof/host/src/kv/disk.rs
@@ -89,7 +89,15 @@ mod test {
         /// Test that converting from a [`DiskKeyValueStore`] to a [`MemoryKeyValueStore`] is lossless.
         #[test]
         fn convert_disk_kv_to_mem_kv(k_v in hash_map(any::<[u8; 32]>(), vec(any::<u8>(), 0..128), 1..128)) {
-            let tempdir = temp_dir();
+            // Use a unique subdirectory under the system temp directory so that dropping
+            // the store (which calls `DB::destroy`) never targets the temp root itself.
+            let mut tempdir = temp_dir();
+            tempdir.push(format!(
+                "disk_kv_test_{}_{}",
+                std::process::id(),
+                std::thread::current().id().as_u64().get()
+            ));
+
             let mut disk_kv = DiskKeyValueStore::new(tempdir);
             for (k, v) in &k_v {
                 disk_kv.set(k.into(), v.clone()).unwrap();


### PR DESCRIPTION
## Problem

The `DiskKeyValueStore` tests currently construct the store using `std::env::temp_dir()` directly as the database path.  
`DiskKeyValueStore`'s `Drop` implementation calls `rocksdb::DB::destroy` on the `data_directory` path, which in this case is the **root** system temp directory (e.g. `/tmp` or `C:\Users\...\AppData\Local\Temp`).  
This means running the property-based test `convert_disk_kv_to_mem_kv` can cause RocksDB to destroy the entire temp directory, potentially deleting unrelated temporary files and interfering with other tests or processes.

## Solution

Create a unique subdirectory under `temp_dir()` and use that as the RocksDB data directory in the test:

- Build a per-test path like `temp_dir()/disk_kv_test_<pid>_<thread_id>`.
- Pass this subdirectory path into `DiskKeyValueStore::new`.

This keeps the production API unchanged while ensuring that `DB::destroy` only targets the dedicated test directory and never the temp root.

## Impact

- Prevents accidental deletion or corruption of the global temporary directory when running the `DiskKeyValueStore` tests.
- Makes the proof host key-value store tests safer and more reliable in both local and CI environments.
- The change is limited to the test module of `crates/proof/host/src/kv/disk.rs` and does not affect runtime behavior or public APIs.