### PR TITLE
Avoid block range underflow in enclave proposal aggregation

### DIFF
--- a/crates/proof/tee/server/src/server.rs
+++ b/crates/proof/tee/server/src/server.rs
@@ -435,8 +435,14 @@ impl Server {
         // corresponding block boundary, preventing a compromised proposer from
         // submitting fake intermediate checkpoints.
         if !intermediate_roots.is_empty() && proposals.len() > 1 {
-            let total_blocks =
-                proposals.last().unwrap().l2_block_number.to::<u64>() - prev_block_number;
+            let last_block = proposals.last().unwrap().l2_block_number.to::<u64>();
+            if last_block < prev_block_number {
+                return Err(ProposalError::ExecutionFailed(
+                    "last proposal block number is less than prev_block_number".to_string(),
+                )
+                .into());
+            }
+            let total_blocks = last_block - prev_block_number;
             if !total_blocks.is_multiple_of(intermediate_roots.len() as u64) {
                 return Err(ProposalError::ExecutionFailed(format!(
                     "block range ({total_blocks}) not divisible by intermediate root count ({})",
@@ -1019,6 +1025,51 @@ mod tests {
         assert!(
             matches!(&result, Err(ServerError::Proposal(ProposalError::ExecutionFailed(_)))),
             "Expected ExecutionFailed error for single proposal with intermediate roots, got: {result:?}"
+        );
+    }
+
+    #[test]
+    fn test_aggregate_rejects_inconsistent_prev_block_number() {
+        let server = Server::new_for_testing().expect("failed to create server");
+
+        let proposer = Address::ZERO;
+        let tee_image_hash = B256::ZERO;
+        let config_hash = B256::repeat_byte(0x11);
+        let l1_origin_hash = B256::repeat_byte(0x22);
+        let l1_origin_number = U256::from(100);
+        let prev_output_root = B256::repeat_byte(0x33);
+        let output_root = B256::repeat_byte(0x44);
+
+        // Create a single proposal at block 100.
+        let proposal = make_proposal(
+            &server,
+            proposer,
+            tee_image_hash,
+            config_hash,
+            l1_origin_hash,
+            l1_origin_number,
+            prev_output_root,
+            99,
+            output_root,
+            100,
+        );
+
+        // Use a prev_block_number that is *after* the proposal's block number, which
+        // should now be rejected with a typed error instead of panicking on underflow.
+        let bad_prev_block_number = 101u64;
+        let result = server.aggregate(
+            config_hash,
+            prev_output_root,
+            bad_prev_block_number,
+            &[proposal],
+            proposer,
+            tee_image_hash,
+            &[output_root],
+        );
+
+        assert!(
+            matches!(&result, Err(ServerError::Proposal(ProposalError::ExecutionFailed(msg))) if msg.contains("last proposal block number is less than prev_block_number")),
+            "Expected ExecutionFailed error for inconsistent prev_block_number, got: {result:?}"
         );
     }
 }


### PR DESCRIPTION
## Problem

`Server::aggregate` validates intermediate roots by computing the total number of blocks covered by the proposals:

```rust
let total_blocks =
    proposals.last().unwrap().l2_block_number.to::<u64>() - prev_block_number;
```

If `prev_block_number` is greater than the last proposal's `l2_block_number`, this subtraction underflows on `u64`.

In debug builds this triggers a panic, and in release builds it silently wraps, producing an invalid `total_blocks` value.

Since `aggregate` is a public API and the arguments can be inconsistent due to caller bugs or malformed inputs, this represents a real edge-case runtime bug that can either crash the process or cause misleading validation behavior.

## Solution

Add explicit validation before performing the subtraction.

1. Compute:

```rust
let last_block = proposals.last().unwrap().l2_block_number.to::<u64>();
```

2. If `last_block < prev_block_number`, return a `ProposalError::ExecutionFailed` with a clear message instead of subtracting.

3. Only compute the total after this check passes:

```rust
let total_blocks = last_block - prev_block_number;
```

Additionally, extend the tests in `server.rs` to cover this edge case, asserting that an inconsistent `prev_block_number` now yields a typed error instead of panicking.

## Impact

- Prevents arithmetic underflow and potential panics in `Server::aggregate` when called with inconsistent block numbers.
- Ensures callers always receive a structured `ServerError::Proposal(ProposalError::ExecutionFailed(...))` that can be handled gracefully.
- Keeps behavior for valid inputs unchanged; only the invalid-argument path is affected and is now safer and easier to diagnose.
