### PR TITLE
feat(enclave): add output_root_v0_with_hash to avoid redundant hashing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4193,6 +4193,7 @@ dependencies = [
  "metrics-exporter-prometheus",
  "moka",
  "reqwest 0.13.2",
+ "rstest",
  "rustls 0.23.37",
  "serde",
  "serde_json",

--- a/crates/proof/proposer/Cargo.toml
+++ b/crates/proof/proposer/Cargo.toml
@@ -84,5 +84,6 @@ hex.workspace = true
 url.workspace = true
 
 [dev-dependencies]
+rstest.workspace = true
 tokio = { workspace = true, features = ["test-util"] }
 reqwest = { workspace = true, features = ["json"] }

--- a/crates/proof/proposer/src/prover/mod.rs
+++ b/crates/proof/proposer/src/prover/mod.rs
@@ -13,7 +13,8 @@ use alloy_rpc_types_eth::TransactionReceipt;
 use base_alloy_consensus::OpTxEnvelope;
 use base_alloy_rpc_types::Transaction as OpTransaction;
 use base_enclave::{
-    AggregateRequest, ChainConfig, Proposal, RollupConfig, l2_block_to_block_info, output_root_v0,
+    AggregateRequest, ChainConfig, Proposal, RollupConfig, l2_block_to_block_info,
+    output_root_v0_with_hash,
 };
 use base_enclave_client::ExecuteStatelessRequest;
 use base_proof_rpc::{L1BlockId, L1Provider, L2BlockRef, OpBlock};
@@ -250,7 +251,8 @@ where
         };
 
         // Verify output root matches local computation
-        let expected_output_root = output_root_v0(&block.header.inner, msg_storage_hash);
+        let expected_output_root =
+            output_root_v0_with_hash(&block.header.inner, msg_storage_hash, block_hash);
         if proposal.output_root != expected_output_root {
             return Err(ProposerError::OutputRootMismatch {
                 expected: expected_output_root,

--- a/crates/proof/proposer/src/prover/mod.rs
+++ b/crates/proof/proposer/src/prover/mod.rs
@@ -527,10 +527,23 @@ mod tests {
     use alloy_primitives::{B256, Bloom, BloomInput, Bytes, U256};
     use async_trait::async_trait;
     use base_enclave_client::{ClientError, ExecuteStatelessRequest};
+    use rstest::rstest;
     use types::test_helpers::test_proposal;
 
     use super::*;
     use crate::{enclave::EnclaveClientTrait, test_utils::test_prover};
+
+    fn zero_proposal() -> Proposal {
+        Proposal {
+            output_root: B256::ZERO,
+            signature: Bytes::new(),
+            l1_origin_hash: B256::ZERO,
+            l1_origin_number: U256::ZERO,
+            l2_block_number: U256::ZERO,
+            prev_output_root: B256::ZERO,
+            config_hash: B256::ZERO,
+        }
+    }
 
     #[test]
     fn test_check_withdrawals_empty_bloom() {
@@ -547,38 +560,24 @@ mod tests {
 
     // --- extract_missing_trie_hash tests ---
 
-    #[test]
-    fn test_extract_missing_trie_hash_valid() {
-        let hash_hex = "0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890";
-        let err = format!("execution failed: trie node not found for hash: {hash_hex}");
-        let result = extract_missing_trie_hash(&err);
-        assert_eq!(result, Some(hash_hex.parse::<B256>().unwrap()));
-    }
-
-    #[test]
-    fn test_extract_missing_trie_hash_no_match() {
-        let err = "execution failed: something completely different";
-        assert_eq!(extract_missing_trie_hash(err), None);
-    }
-
-    #[test]
-    fn test_extract_missing_trie_hash_truncated() {
-        let err = "trie node not found for hash: 0xabcd";
-        assert_eq!(extract_missing_trie_hash(err), None);
-    }
-
-    #[test]
-    fn test_extract_missing_trie_hash_trailing_chars() {
-        let hash_hex = "0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890";
-        let err = format!("trie node not found for hash: {hash_hex}\",");
-        let result = extract_missing_trie_hash(&err);
-        assert_eq!(result, Some(hash_hex.parse::<B256>().unwrap()));
-    }
-
-    #[test]
-    fn test_extract_missing_trie_hash_no_0x_prefix() {
-        let err = "trie node not found for hash: abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890";
-        assert_eq!(extract_missing_trie_hash(err), None);
+    #[rstest]
+    #[case::valid(
+        "execution failed: trie node not found for hash: 0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
+        Some("0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890")
+    )]
+    #[case::no_match("execution failed: something completely different", None)]
+    #[case::truncated("trie node not found for hash: 0xabcd", None)]
+    #[case::trailing_chars(
+        "trie node not found for hash: 0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890\",",
+        Some("0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890")
+    )]
+    #[case::no_0x_prefix(
+        "trie node not found for hash: abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
+        None
+    )]
+    fn test_extract_missing_trie_hash(#[case] err: &str, #[case] expected: Option<&str>) {
+        let expected = expected.map(|h| h.parse::<B256>().unwrap());
+        assert_eq!(extract_missing_trie_hash(err), expected);
     }
 
     // --- check_withdrawals tests ---
@@ -655,17 +654,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_aggregate_empty_proposals() {
-        let prover = test_prover(MockEnclaveClient {
-            aggregate_result: Proposal {
-                output_root: B256::ZERO,
-                signature: Bytes::new(),
-                l1_origin_hash: B256::ZERO,
-                l1_origin_number: U256::ZERO,
-                l2_block_number: U256::ZERO,
-                prev_output_root: B256::ZERO,
-                config_hash: B256::ZERO,
-            },
-        });
+        let prover = test_prover(MockEnclaveClient { aggregate_result: zero_proposal() });
 
         let result = prover.aggregate(B256::ZERO, 0, vec![], vec![]).await;
         assert!(result.is_err());
@@ -674,17 +663,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_aggregate_single_proposal() {
-        let prover = test_prover(MockEnclaveClient {
-            aggregate_result: Proposal {
-                output_root: B256::ZERO,
-                signature: Bytes::new(),
-                l1_origin_hash: B256::ZERO,
-                l1_origin_number: U256::ZERO,
-                l2_block_number: U256::ZERO,
-                prev_output_root: B256::ZERO,
-                config_hash: B256::ZERO,
-            },
-        });
+        let prover = test_prover(MockEnclaveClient { aggregate_result: zero_proposal() });
 
         let single = test_proposal(5, 5, true);
         let result = prover.aggregate(B256::ZERO, 0, vec![single.clone()], vec![]).await;
@@ -723,8 +702,19 @@ mod tests {
         assert_eq!(result.output.output_root, agg_output.output_root);
     }
 
+    #[rstest]
+    #[case::none_have_withdrawals(false, false, false, false)]
+    #[case::first_has_withdrawal(true, false, false, true)]
+    #[case::middle_has_withdrawal(false, true, false, true)]
+    #[case::last_has_withdrawal(false, false, true, true)]
+    #[case::all_have_withdrawals(true, true, true, true)]
     #[tokio::test]
-    async fn test_aggregate_withdrawal_combinations() {
+    async fn test_aggregate_withdrawal_combinations(
+        #[case] w1: bool,
+        #[case] w2: bool,
+        #[case] w3: bool,
+        #[case] expected: bool,
+    ) {
         let agg_output = Proposal {
             output_root: B256::repeat_byte(0xAA),
             signature: Bytes::from(vec![0xBB; 65]),
@@ -735,90 +725,17 @@ mod tests {
             config_hash: B256::ZERO,
         };
 
-        // [F, F, F] → F
-        let prover = test_prover(MockEnclaveClient { aggregate_result: agg_output.clone() });
-        let result = prover
-            .aggregate(
-                B256::ZERO,
-                0,
-                vec![
-                    test_proposal(1, 1, false),
-                    test_proposal(2, 2, false),
-                    test_proposal(3, 3, false),
-                ],
-                vec![],
-            )
-            .await
-            .unwrap();
-        assert!(!result.has_withdrawals);
-
-        // [T, F, F] → T
-        let prover = test_prover(MockEnclaveClient { aggregate_result: agg_output.clone() });
-        let result = prover
-            .aggregate(
-                B256::ZERO,
-                0,
-                vec![
-                    test_proposal(1, 1, true),
-                    test_proposal(2, 2, false),
-                    test_proposal(3, 3, false),
-                ],
-                vec![],
-            )
-            .await
-            .unwrap();
-        assert!(result.has_withdrawals);
-
-        // [F, T, F] → T
-        let prover = test_prover(MockEnclaveClient { aggregate_result: agg_output.clone() });
-        let result = prover
-            .aggregate(
-                B256::ZERO,
-                0,
-                vec![
-                    test_proposal(1, 1, false),
-                    test_proposal(2, 2, true),
-                    test_proposal(3, 3, false),
-                ],
-                vec![],
-            )
-            .await
-            .unwrap();
-        assert!(result.has_withdrawals);
-
-        // [F, F, T] → T
-        let prover = test_prover(MockEnclaveClient { aggregate_result: agg_output.clone() });
-        let result = prover
-            .aggregate(
-                B256::ZERO,
-                0,
-                vec![
-                    test_proposal(1, 1, false),
-                    test_proposal(2, 2, false),
-                    test_proposal(3, 3, true),
-                ],
-                vec![],
-            )
-            .await
-            .unwrap();
-        assert!(result.has_withdrawals);
-
-        // [T, T, T] → T
         let prover = test_prover(MockEnclaveClient { aggregate_result: agg_output });
         let result = prover
             .aggregate(
                 B256::ZERO,
                 0,
-                vec![
-                    test_proposal(1, 1, true),
-                    test_proposal(2, 2, true),
-                    test_proposal(3, 3, true),
-                ],
+                vec![test_proposal(1, 1, w1), test_proposal(2, 2, w2), test_proposal(3, 3, w3)],
                 vec![],
             )
             .await
             .unwrap();
-        assert!(result.has_withdrawals);
+        assert_eq!(result.has_withdrawals, expected);
     }
 
     // --- enclave error / timeout tests ---
@@ -873,15 +790,7 @@ mod tests {
         }
         async fn aggregate(&self, _: AggregateRequest) -> Result<Proposal, ClientError> {
             tokio::time::sleep(Duration::from_secs(601)).await;
-            Ok(Proposal {
-                output_root: B256::ZERO,
-                signature: Bytes::new(),
-                l1_origin_hash: B256::ZERO,
-                l1_origin_number: U256::ZERO,
-                l2_block_number: U256::ZERO,
-                prev_output_root: B256::ZERO,
-                config_hash: B256::ZERO,
-            })
+            Ok(zero_proposal())
         }
     }
 

--- a/crates/proof/tee/core/src/lib.rs
+++ b/crates/proof/tee/core/src/lib.rs
@@ -39,5 +39,5 @@ mod types;
 pub use types::{
     AccountResult, AggregateRequest, BlockId, ExecuteStatelessRequest, Genesis,
     GenesisSystemConfig, MARSHAL_BINARY_SIZE, PerChainConfig, Proposal, ProposalParams,
-    RollupConfig, SIGNATURE_LENGTH, StorageProof, output_root_v0,
+    RollupConfig, SIGNATURE_LENGTH, StorageProof, output_root_v0, output_root_v0_with_hash,
 };

--- a/crates/proof/tee/core/src/types/mod.rs
+++ b/crates/proof/tee/core/src/types/mod.rs
@@ -7,7 +7,7 @@ pub use config::{
 };
 
 mod output;
-pub use output::output_root_v0;
+pub use output::{output_root_v0, output_root_v0_with_hash};
 
 mod proposal;
 pub use proposal::{Proposal, ProposalParams, SIGNATURE_LENGTH};

--- a/crates/proof/tee/core/src/types/output.rs
+++ b/crates/proof/tee/core/src/types/output.rs
@@ -49,6 +49,7 @@ pub fn output_root_v0(header: &Header, storage_root: B256) -> B256 {
 /// The 32-byte output root hash.
 #[must_use]
 pub fn output_root_v0_with_hash(header: &Header, storage_root: B256, block_hash: B256) -> B256 {
+    debug_assert_eq!(block_hash, header.hash_slow(), "block_hash does not match header");
     let state_root = header.state_root;
 
     // 128 bytes: version (32, all zeros) || state_root (32) || storage_root (32) || block_hash (32)

--- a/crates/proof/tee/core/src/types/output.rs
+++ b/crates/proof/tee/core/src/types/output.rs
@@ -29,7 +29,26 @@ use alloy_primitives::{B256, keccak256};
 /// The 32-byte output root hash.
 #[must_use]
 pub fn output_root_v0(header: &Header, storage_root: B256) -> B256 {
-    let block_hash = header.hash_slow();
+    output_root_v0_with_hash(header, storage_root, header.hash_slow())
+}
+
+/// Compute output root v0 using a precomputed block hash.
+///
+/// This is identical to [`output_root_v0`] but accepts an already-computed
+/// `block_hash`, avoiding a redundant `header.hash_slow()` call when the
+/// caller has already hashed the header (e.g. for RPC verification).
+///
+/// # Arguments
+///
+/// * `header` - The L2 block header (used for `state_root`)
+/// * `storage_root` - The storage root of the `L2ToL1MessagePasser` contract
+/// * `block_hash` - The precomputed hash of the block header
+///
+/// # Returns
+///
+/// The 32-byte output root hash.
+#[must_use]
+pub fn output_root_v0_with_hash(header: &Header, storage_root: B256, block_hash: B256) -> B256 {
     let state_root = header.state_root;
 
     // 128 bytes: version (32, all zeros) || state_root (32) || storage_root (32) || block_hash (32)

--- a/crates/proof/tee/core/src/types/output.rs
+++ b/crates/proof/tee/core/src/types/output.rs
@@ -131,6 +131,38 @@ mod tests {
     }
 
     #[test]
+    fn test_output_root_v0_with_hash_correct_hash() {
+        let header = test_header_for_output();
+        let storage_root =
+            b256!("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb");
+        let block_hash = header.hash_slow();
+
+        let root_via_with_hash = output_root_v0_with_hash(&header, storage_root, block_hash);
+        let root_via_convenience = output_root_v0(&header, storage_root);
+
+        assert_eq!(root_via_with_hash, root_via_convenience);
+    }
+
+    /// Passing an incorrect hash produces a different (wrong) output root.
+    /// Only `debug_assert` guards this, so callers bear responsibility for
+    /// hash correctness. This test only runs without debug assertions since
+    /// the `debug_assert_eq!` in the function would panic otherwise.
+    #[test]
+    #[cfg(not(debug_assertions))]
+    fn test_output_root_v0_with_hash_incorrect_hash() {
+        let header = test_header_for_output();
+        let storage_root =
+            b256!("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb");
+        let bogus_hash = b256!("ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
+
+        let root_bogus = output_root_v0_with_hash(&header, storage_root, bogus_hash);
+        let root_correct = output_root_v0(&header, storage_root);
+
+        // A wrong block_hash feeds into the keccak input, so the result diverges.
+        assert_ne!(root_bogus, root_correct);
+    }
+
+    #[test]
     fn test_output_root_v0_different_state_roots() {
         let header_1 = test_header_for_output();
         let mut header_2 = test_header_for_output();


### PR DESCRIPTION
## Summary

- Introduces `output_root_v0_with_hash()` in `base-enclave` that accepts a precomputed block hash, avoiding a redundant `header.hash_slow()` call when the caller already has the hash
- Refactors `output_root_v0()` to delegate to the new function
- Updates the proposer to use `output_root_v0_with_hash` with its already-computed `block_hash`

## Test plan

- [x] `cargo check -p base-enclave` compiles
- [x] `cargo check -p base-proposer` compiles
- [x] `cargo test -p base-enclave` — all 98 tests pass
- [x] Diff contains only the 4 expected files