### PR TITLE
chore(docker): install specific mold version

### DIFF
--- a/etc/docker/Dockerfile.audit-archiver
+++ b/etc/docker/Dockerfile.audit-archiver
@@ -1,10 +1,22 @@
 # --- Builder ---
 FROM rust:1.93-trixie AS builder
 WORKDIR /app
+ARG MOLD_VERSION=2.40.4
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
-      git libclang-dev pkg-config curl build-essential cmake mold && \
+      git libclang-dev pkg-config curl build-essential cmake && \
     rm -rf /var/lib/apt/lists/*
+RUN set -eux; \
+    case "$(uname -m)" in \
+      x86_64) MOLD_ARCH=x86_64 ;; \
+      aarch64|arm64) MOLD_ARCH=aarch64 ;; \
+      armv7l|armv6l) MOLD_ARCH=arm ;; \
+      *) echo "unsupported architecture: $(uname -m)" >&2; exit 1 ;; \
+    esac; \
+    curl -fsSL "https://github.com/rui314/mold/releases/download/v${MOLD_VERSION}/mold-${MOLD_VERSION}-${MOLD_ARCH}-linux.tar.gz" -o /tmp/mold.tar.gz; \
+    tar -xzf /tmp/mold.tar.gz -C /tmp; \
+    cp /tmp/mold-${MOLD_VERSION}-${MOLD_ARCH}-linux/bin/* /usr/local/bin/; \
+    rm -rf /tmp/mold*
 
 ARG PROFILE=release
 

--- a/etc/docker/Dockerfile.audit-archiver
+++ b/etc/docker/Dockerfile.audit-archiver
@@ -2,18 +2,22 @@
 FROM rust:1.93-trixie AS builder
 WORKDIR /app
 ARG MOLD_VERSION=2.40.4
+ARG MOLD_SHA256_AARCH64=c799b9ccae8728793da2186718fbe53b76400a9da396184fac0c64aa3298ec37
+ARG MOLD_SHA256_ARM=d82792748a81202423ddd2496fc8719404fe694493abdef691cc080392ee44bf
+ARG MOLD_SHA256_X86_64=4c999e19ffa31afa5aa429c679b665d5e2ca5a6b6832ad4b79668e8dcf3d8ec1
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
       git libclang-dev pkg-config curl build-essential cmake && \
     rm -rf /var/lib/apt/lists/*
 RUN set -eux; \
     case "$(uname -m)" in \
-      x86_64) MOLD_ARCH=x86_64 ;; \
-      aarch64|arm64) MOLD_ARCH=aarch64 ;; \
-      armv7l|armv6l) MOLD_ARCH=arm ;; \
+      x86_64) MOLD_ARCH=x86_64; MOLD_SHA256="${MOLD_SHA256_X86_64}" ;; \
+      aarch64|arm64) MOLD_ARCH=aarch64; MOLD_SHA256="${MOLD_SHA256_AARCH64}" ;; \
+      armv7l|armv6l) MOLD_ARCH=arm; MOLD_SHA256="${MOLD_SHA256_ARM}" ;; \
       *) echo "unsupported architecture: $(uname -m)" >&2; exit 1 ;; \
     esac; \
     curl -fsSL "https://github.com/rui314/mold/releases/download/v${MOLD_VERSION}/mold-${MOLD_VERSION}-${MOLD_ARCH}-linux.tar.gz" -o /tmp/mold.tar.gz; \
+    echo "${MOLD_SHA256}  /tmp/mold.tar.gz" | sha256sum -c -; \
     tar -xzf /tmp/mold.tar.gz -C /tmp; \
     cp /tmp/mold-${MOLD_VERSION}-${MOLD_ARCH}-linux/bin/* /usr/local/bin/; \
     rm -rf /tmp/mold*

--- a/etc/docker/Dockerfile.builder
+++ b/etc/docker/Dockerfile.builder
@@ -1,10 +1,22 @@
 # --- Builder ---
 FROM rust:1.93-trixie AS builder
 WORKDIR /app
+ARG MOLD_VERSION=2.40.4
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
-      git libclang-dev pkg-config curl build-essential mold && \
+      git libclang-dev pkg-config curl build-essential && \
     rm -rf /var/lib/apt/lists/*
+RUN set -eux; \
+    case "$(uname -m)" in \
+      x86_64) MOLD_ARCH=x86_64 ;; \
+      aarch64|arm64) MOLD_ARCH=aarch64 ;; \
+      armv7l|armv6l) MOLD_ARCH=arm ;; \
+      *) echo "unsupported architecture: $(uname -m)" >&2; exit 1 ;; \
+    esac; \
+    curl -fsSL "https://github.com/rui314/mold/releases/download/v${MOLD_VERSION}/mold-${MOLD_VERSION}-${MOLD_ARCH}-linux.tar.gz" -o /tmp/mold.tar.gz; \
+    tar -xzf /tmp/mold.tar.gz -C /tmp; \
+    cp /tmp/mold-${MOLD_VERSION}-${MOLD_ARCH}-linux/bin/* /usr/local/bin/; \
+    rm -rf /tmp/mold*
 
 ARG PROFILE=release
 

--- a/etc/docker/Dockerfile.builder
+++ b/etc/docker/Dockerfile.builder
@@ -2,18 +2,22 @@
 FROM rust:1.93-trixie AS builder
 WORKDIR /app
 ARG MOLD_VERSION=2.40.4
+ARG MOLD_SHA256_AARCH64=c799b9ccae8728793da2186718fbe53b76400a9da396184fac0c64aa3298ec37
+ARG MOLD_SHA256_ARM=d82792748a81202423ddd2496fc8719404fe694493abdef691cc080392ee44bf
+ARG MOLD_SHA256_X86_64=4c999e19ffa31afa5aa429c679b665d5e2ca5a6b6832ad4b79668e8dcf3d8ec1
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
       git libclang-dev pkg-config curl build-essential && \
     rm -rf /var/lib/apt/lists/*
 RUN set -eux; \
     case "$(uname -m)" in \
-      x86_64) MOLD_ARCH=x86_64 ;; \
-      aarch64|arm64) MOLD_ARCH=aarch64 ;; \
-      armv7l|armv6l) MOLD_ARCH=arm ;; \
+      x86_64) MOLD_ARCH=x86_64; MOLD_SHA256="${MOLD_SHA256_X86_64}" ;; \
+      aarch64|arm64) MOLD_ARCH=aarch64; MOLD_SHA256="${MOLD_SHA256_AARCH64}" ;; \
+      armv7l|armv6l) MOLD_ARCH=arm; MOLD_SHA256="${MOLD_SHA256_ARM}" ;; \
       *) echo "unsupported architecture: $(uname -m)" >&2; exit 1 ;; \
     esac; \
     curl -fsSL "https://github.com/rui314/mold/releases/download/v${MOLD_VERSION}/mold-${MOLD_VERSION}-${MOLD_ARCH}-linux.tar.gz" -o /tmp/mold.tar.gz; \
+    echo "${MOLD_SHA256}  /tmp/mold.tar.gz" | sha256sum -c -; \
     tar -xzf /tmp/mold.tar.gz -C /tmp; \
     cp /tmp/mold-${MOLD_VERSION}-${MOLD_ARCH}-linux/bin/* /usr/local/bin/; \
     rm -rf /tmp/mold*

--- a/etc/docker/Dockerfile.client
+++ b/etc/docker/Dockerfile.client
@@ -1,10 +1,22 @@
 # --- Builder ---
 FROM rust:1.93-trixie AS builder
 WORKDIR /app
+ARG MOLD_VERSION=2.40.4
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
-      git libclang-dev pkg-config curl build-essential mold && \
+      git libclang-dev pkg-config curl build-essential && \
     rm -rf /var/lib/apt/lists/*
+RUN set -eux; \
+    case "$(uname -m)" in \
+      x86_64) MOLD_ARCH=x86_64 ;; \
+      aarch64|arm64) MOLD_ARCH=aarch64 ;; \
+      armv7l|armv6l) MOLD_ARCH=arm ;; \
+      *) echo "unsupported architecture: $(uname -m)" >&2; exit 1 ;; \
+    esac; \
+    curl -fsSL "https://github.com/rui314/mold/releases/download/v${MOLD_VERSION}/mold-${MOLD_VERSION}-${MOLD_ARCH}-linux.tar.gz" -o /tmp/mold.tar.gz; \
+    tar -xzf /tmp/mold.tar.gz -C /tmp; \
+    cp /tmp/mold-${MOLD_VERSION}-${MOLD_ARCH}-linux/bin/* /usr/local/bin/; \
+    rm -rf /tmp/mold*
 
 ARG PROFILE=release
 

--- a/etc/docker/Dockerfile.client
+++ b/etc/docker/Dockerfile.client
@@ -2,18 +2,22 @@
 FROM rust:1.93-trixie AS builder
 WORKDIR /app
 ARG MOLD_VERSION=2.40.4
+ARG MOLD_SHA256_AARCH64=c799b9ccae8728793da2186718fbe53b76400a9da396184fac0c64aa3298ec37
+ARG MOLD_SHA256_ARM=d82792748a81202423ddd2496fc8719404fe694493abdef691cc080392ee44bf
+ARG MOLD_SHA256_X86_64=4c999e19ffa31afa5aa429c679b665d5e2ca5a6b6832ad4b79668e8dcf3d8ec1
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
       git libclang-dev pkg-config curl build-essential && \
     rm -rf /var/lib/apt/lists/*
 RUN set -eux; \
     case "$(uname -m)" in \
-      x86_64) MOLD_ARCH=x86_64 ;; \
-      aarch64|arm64) MOLD_ARCH=aarch64 ;; \
-      armv7l|armv6l) MOLD_ARCH=arm ;; \
+      x86_64) MOLD_ARCH=x86_64; MOLD_SHA256="${MOLD_SHA256_X86_64}" ;; \
+      aarch64|arm64) MOLD_ARCH=aarch64; MOLD_SHA256="${MOLD_SHA256_AARCH64}" ;; \
+      armv7l|armv6l) MOLD_ARCH=arm; MOLD_SHA256="${MOLD_SHA256_ARM}" ;; \
       *) echo "unsupported architecture: $(uname -m)" >&2; exit 1 ;; \
     esac; \
     curl -fsSL "https://github.com/rui314/mold/releases/download/v${MOLD_VERSION}/mold-${MOLD_VERSION}-${MOLD_ARCH}-linux.tar.gz" -o /tmp/mold.tar.gz; \
+    echo "${MOLD_SHA256}  /tmp/mold.tar.gz" | sha256sum -c -; \
     tar -xzf /tmp/mold.tar.gz -C /tmp; \
     cp /tmp/mold-${MOLD_VERSION}-${MOLD_ARCH}-linux/bin/* /usr/local/bin/; \
     rm -rf /tmp/mold*

--- a/etc/docker/Dockerfile.consensus
+++ b/etc/docker/Dockerfile.consensus
@@ -1,10 +1,22 @@
 # --- Builder ---
 FROM rust:1.93-trixie AS builder
 WORKDIR /app
+ARG MOLD_VERSION=2.40.4
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
-      git libclang-dev pkg-config curl build-essential mold && \
+      git libclang-dev pkg-config curl build-essential && \
     rm -rf /var/lib/apt/lists/*
+RUN set -eux; \
+    case "$(uname -m)" in \
+      x86_64) MOLD_ARCH=x86_64 ;; \
+      aarch64|arm64) MOLD_ARCH=aarch64 ;; \
+      armv7l|armv6l) MOLD_ARCH=arm ;; \
+      *) echo "unsupported architecture: $(uname -m)" >&2; exit 1 ;; \
+    esac; \
+    curl -fsSL "https://github.com/rui314/mold/releases/download/v${MOLD_VERSION}/mold-${MOLD_VERSION}-${MOLD_ARCH}-linux.tar.gz" -o /tmp/mold.tar.gz; \
+    tar -xzf /tmp/mold.tar.gz -C /tmp; \
+    cp /tmp/mold-${MOLD_VERSION}-${MOLD_ARCH}-linux/bin/* /usr/local/bin/; \
+    rm -rf /tmp/mold*
 
 ARG PROFILE=release
 

--- a/etc/docker/Dockerfile.consensus
+++ b/etc/docker/Dockerfile.consensus
@@ -2,18 +2,22 @@
 FROM rust:1.93-trixie AS builder
 WORKDIR /app
 ARG MOLD_VERSION=2.40.4
+ARG MOLD_SHA256_AARCH64=c799b9ccae8728793da2186718fbe53b76400a9da396184fac0c64aa3298ec37
+ARG MOLD_SHA256_ARM=d82792748a81202423ddd2496fc8719404fe694493abdef691cc080392ee44bf
+ARG MOLD_SHA256_X86_64=4c999e19ffa31afa5aa429c679b665d5e2ca5a6b6832ad4b79668e8dcf3d8ec1
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
       git libclang-dev pkg-config curl build-essential && \
     rm -rf /var/lib/apt/lists/*
 RUN set -eux; \
     case "$(uname -m)" in \
-      x86_64) MOLD_ARCH=x86_64 ;; \
-      aarch64|arm64) MOLD_ARCH=aarch64 ;; \
-      armv7l|armv6l) MOLD_ARCH=arm ;; \
+      x86_64) MOLD_ARCH=x86_64; MOLD_SHA256="${MOLD_SHA256_X86_64}" ;; \
+      aarch64|arm64) MOLD_ARCH=aarch64; MOLD_SHA256="${MOLD_SHA256_AARCH64}" ;; \
+      armv7l|armv6l) MOLD_ARCH=arm; MOLD_SHA256="${MOLD_SHA256_ARM}" ;; \
       *) echo "unsupported architecture: $(uname -m)" >&2; exit 1 ;; \
     esac; \
     curl -fsSL "https://github.com/rui314/mold/releases/download/v${MOLD_VERSION}/mold-${MOLD_VERSION}-${MOLD_ARCH}-linux.tar.gz" -o /tmp/mold.tar.gz; \
+    echo "${MOLD_SHA256}  /tmp/mold.tar.gz" | sha256sum -c -; \
     tar -xzf /tmp/mold.tar.gz -C /tmp; \
     cp /tmp/mold-${MOLD_VERSION}-${MOLD_ARCH}-linux/bin/* /usr/local/bin/; \
     rm -rf /tmp/mold*

--- a/etc/docker/Dockerfile.ingress-rpc
+++ b/etc/docker/Dockerfile.ingress-rpc
@@ -1,10 +1,22 @@
 # --- Builder ---
 FROM rust:1.93-trixie AS builder
 WORKDIR /app
+ARG MOLD_VERSION=2.40.4
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
-      git libclang-dev pkg-config curl build-essential cmake mold && \
+      git libclang-dev pkg-config curl build-essential cmake && \
     rm -rf /var/lib/apt/lists/*
+RUN set -eux; \
+    case "$(uname -m)" in \
+      x86_64) MOLD_ARCH=x86_64 ;; \
+      aarch64|arm64) MOLD_ARCH=aarch64 ;; \
+      armv7l|armv6l) MOLD_ARCH=arm ;; \
+      *) echo "unsupported architecture: $(uname -m)" >&2; exit 1 ;; \
+    esac; \
+    curl -fsSL "https://github.com/rui314/mold/releases/download/v${MOLD_VERSION}/mold-${MOLD_VERSION}-${MOLD_ARCH}-linux.tar.gz" -o /tmp/mold.tar.gz; \
+    tar -xzf /tmp/mold.tar.gz -C /tmp; \
+    cp /tmp/mold-${MOLD_VERSION}-${MOLD_ARCH}-linux/bin/* /usr/local/bin/; \
+    rm -rf /tmp/mold*
 
 ARG PROFILE=release
 

--- a/etc/docker/Dockerfile.ingress-rpc
+++ b/etc/docker/Dockerfile.ingress-rpc
@@ -2,18 +2,22 @@
 FROM rust:1.93-trixie AS builder
 WORKDIR /app
 ARG MOLD_VERSION=2.40.4
+ARG MOLD_SHA256_AARCH64=c799b9ccae8728793da2186718fbe53b76400a9da396184fac0c64aa3298ec37
+ARG MOLD_SHA256_ARM=d82792748a81202423ddd2496fc8719404fe694493abdef691cc080392ee44bf
+ARG MOLD_SHA256_X86_64=4c999e19ffa31afa5aa429c679b665d5e2ca5a6b6832ad4b79668e8dcf3d8ec1
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
       git libclang-dev pkg-config curl build-essential cmake && \
     rm -rf /var/lib/apt/lists/*
 RUN set -eux; \
     case "$(uname -m)" in \
-      x86_64) MOLD_ARCH=x86_64 ;; \
-      aarch64|arm64) MOLD_ARCH=aarch64 ;; \
-      armv7l|armv6l) MOLD_ARCH=arm ;; \
+      x86_64) MOLD_ARCH=x86_64; MOLD_SHA256="${MOLD_SHA256_X86_64}" ;; \
+      aarch64|arm64) MOLD_ARCH=aarch64; MOLD_SHA256="${MOLD_SHA256_AARCH64}" ;; \
+      armv7l|armv6l) MOLD_ARCH=arm; MOLD_SHA256="${MOLD_SHA256_ARM}" ;; \
       *) echo "unsupported architecture: $(uname -m)" >&2; exit 1 ;; \
     esac; \
     curl -fsSL "https://github.com/rui314/mold/releases/download/v${MOLD_VERSION}/mold-${MOLD_VERSION}-${MOLD_ARCH}-linux.tar.gz" -o /tmp/mold.tar.gz; \
+    echo "${MOLD_SHA256}  /tmp/mold.tar.gz" | sha256sum -c -; \
     tar -xzf /tmp/mold.tar.gz -C /tmp; \
     cp /tmp/mold-${MOLD_VERSION}-${MOLD_ARCH}-linux/bin/* /usr/local/bin/; \
     rm -rf /tmp/mold*

--- a/etc/docker/Dockerfile.proposer
+++ b/etc/docker/Dockerfile.proposer
@@ -1,10 +1,22 @@
 # --- Builder ---
 FROM rust:1.93-trixie AS builder
 WORKDIR /app
+ARG MOLD_VERSION=2.40.4
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
-      git libclang-dev pkg-config curl build-essential mold && \
+      git libclang-dev pkg-config curl build-essential && \
     rm -rf /var/lib/apt/lists/*
+RUN set -eux; \
+    case "$(uname -m)" in \
+      x86_64) MOLD_ARCH=x86_64 ;; \
+      aarch64|arm64) MOLD_ARCH=aarch64 ;; \
+      armv7l|armv6l) MOLD_ARCH=arm ;; \
+      *) echo "unsupported architecture: $(uname -m)" >&2; exit 1 ;; \
+    esac; \
+    curl -fsSL "https://github.com/rui314/mold/releases/download/v${MOLD_VERSION}/mold-${MOLD_VERSION}-${MOLD_ARCH}-linux.tar.gz" -o /tmp/mold.tar.gz; \
+    tar -xzf /tmp/mold.tar.gz -C /tmp; \
+    cp /tmp/mold-${MOLD_VERSION}-${MOLD_ARCH}-linux/bin/* /usr/local/bin/; \
+    rm -rf /tmp/mold*
 
 ARG PROFILE=release
 

--- a/etc/docker/Dockerfile.proposer
+++ b/etc/docker/Dockerfile.proposer
@@ -2,18 +2,22 @@
 FROM rust:1.93-trixie AS builder
 WORKDIR /app
 ARG MOLD_VERSION=2.40.4
+ARG MOLD_SHA256_AARCH64=c799b9ccae8728793da2186718fbe53b76400a9da396184fac0c64aa3298ec37
+ARG MOLD_SHA256_ARM=d82792748a81202423ddd2496fc8719404fe694493abdef691cc080392ee44bf
+ARG MOLD_SHA256_X86_64=4c999e19ffa31afa5aa429c679b665d5e2ca5a6b6832ad4b79668e8dcf3d8ec1
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
       git libclang-dev pkg-config curl build-essential && \
     rm -rf /var/lib/apt/lists/*
 RUN set -eux; \
     case "$(uname -m)" in \
-      x86_64) MOLD_ARCH=x86_64 ;; \
-      aarch64|arm64) MOLD_ARCH=aarch64 ;; \
-      armv7l|armv6l) MOLD_ARCH=arm ;; \
+      x86_64) MOLD_ARCH=x86_64; MOLD_SHA256="${MOLD_SHA256_X86_64}" ;; \
+      aarch64|arm64) MOLD_ARCH=aarch64; MOLD_SHA256="${MOLD_SHA256_AARCH64}" ;; \
+      armv7l|armv6l) MOLD_ARCH=arm; MOLD_SHA256="${MOLD_SHA256_ARM}" ;; \
       *) echo "unsupported architecture: $(uname -m)" >&2; exit 1 ;; \
     esac; \
     curl -fsSL "https://github.com/rui314/mold/releases/download/v${MOLD_VERSION}/mold-${MOLD_VERSION}-${MOLD_ARCH}-linux.tar.gz" -o /tmp/mold.tar.gz; \
+    echo "${MOLD_SHA256}  /tmp/mold.tar.gz" | sha256sum -c -; \
     tar -xzf /tmp/mold.tar.gz -C /tmp; \
     cp /tmp/mold-${MOLD_VERSION}-${MOLD_ARCH}-linux/bin/* /usr/local/bin/; \
     rm -rf /tmp/mold*

--- a/etc/docker/Dockerfile.websocket-proxy
+++ b/etc/docker/Dockerfile.websocket-proxy
@@ -1,10 +1,22 @@
 # --- Builder ---
 FROM rust:1.93-trixie AS builder
 WORKDIR /app
+ARG MOLD_VERSION=2.40.4
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
-      git libclang-dev pkg-config curl build-essential mold && \
+      git libclang-dev pkg-config curl build-essential && \
     rm -rf /var/lib/apt/lists/*
+RUN set -eux; \
+    case "$(uname -m)" in \
+      x86_64) MOLD_ARCH=x86_64 ;; \
+      aarch64|arm64) MOLD_ARCH=aarch64 ;; \
+      armv7l|armv6l) MOLD_ARCH=arm ;; \
+      *) echo "unsupported architecture: $(uname -m)" >&2; exit 1 ;; \
+    esac; \
+    curl -fsSL "https://github.com/rui314/mold/releases/download/v${MOLD_VERSION}/mold-${MOLD_VERSION}-${MOLD_ARCH}-linux.tar.gz" -o /tmp/mold.tar.gz; \
+    tar -xzf /tmp/mold.tar.gz -C /tmp; \
+    cp /tmp/mold-${MOLD_VERSION}-${MOLD_ARCH}-linux/bin/* /usr/local/bin/; \
+    rm -rf /tmp/mold*
 
 ARG PROFILE=release
 

--- a/etc/docker/Dockerfile.websocket-proxy
+++ b/etc/docker/Dockerfile.websocket-proxy
@@ -2,18 +2,22 @@
 FROM rust:1.93-trixie AS builder
 WORKDIR /app
 ARG MOLD_VERSION=2.40.4
+ARG MOLD_SHA256_AARCH64=c799b9ccae8728793da2186718fbe53b76400a9da396184fac0c64aa3298ec37
+ARG MOLD_SHA256_ARM=d82792748a81202423ddd2496fc8719404fe694493abdef691cc080392ee44bf
+ARG MOLD_SHA256_X86_64=4c999e19ffa31afa5aa429c679b665d5e2ca5a6b6832ad4b79668e8dcf3d8ec1
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
       git libclang-dev pkg-config curl build-essential && \
     rm -rf /var/lib/apt/lists/*
 RUN set -eux; \
     case "$(uname -m)" in \
-      x86_64) MOLD_ARCH=x86_64 ;; \
-      aarch64|arm64) MOLD_ARCH=aarch64 ;; \
-      armv7l|armv6l) MOLD_ARCH=arm ;; \
+      x86_64) MOLD_ARCH=x86_64; MOLD_SHA256="${MOLD_SHA256_X86_64}" ;; \
+      aarch64|arm64) MOLD_ARCH=aarch64; MOLD_SHA256="${MOLD_SHA256_AARCH64}" ;; \
+      armv7l|armv6l) MOLD_ARCH=arm; MOLD_SHA256="${MOLD_SHA256_ARM}" ;; \
       *) echo "unsupported architecture: $(uname -m)" >&2; exit 1 ;; \
     esac; \
     curl -fsSL "https://github.com/rui314/mold/releases/download/v${MOLD_VERSION}/mold-${MOLD_VERSION}-${MOLD_ARCH}-linux.tar.gz" -o /tmp/mold.tar.gz; \
+    echo "${MOLD_SHA256}  /tmp/mold.tar.gz" | sha256sum -c -; \
     tar -xzf /tmp/mold.tar.gz -C /tmp; \
     cp /tmp/mold-${MOLD_VERSION}-${MOLD_ARCH}-linux/bin/* /usr/local/bin/; \
     rm -rf /tmp/mold*

--- a/lychee.toml
+++ b/lychee.toml
@@ -12,4 +12,5 @@ exclude = [
     'https://img.shields.io/github/issues-pr-raw/base/base',
     'https://rustup.rs/',
     'https://base.mirror.xyz/',
+    'https://www.man7.org/',
 ]


### PR DESCRIPTION
### Description
Older versions of mold (on Ubuntu 22) will cause the project to fail on startup with:

```
thread 'main' (14) panicked at bin/node/src/main.rs:52:6:
called `Result::unwrap()` on an `Err` value: failed to open the database: environment or database is not compatible with the requested operation or flags (-30784)
```

This PR ensures we use the specific version of mold that works