### PR TITLE
ci: enforce Cargo.lock consistency with --locked

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -58,14 +58,14 @@ jobs:
       - name: Build base-reth-node
         if: steps.cache-binaries.outputs.cache-hit != 'true'
         run: |
-          cargo build --bin base-reth-node --profile maxperf
+          cargo build --locked --bin base-reth-node --profile maxperf
           mkdir -p ~/bin
           cp target/maxperf/base-reth-node ~/bin/
 
       - name: Build base-builder
         if: steps.cache-binaries.outputs.cache-hit != 'true'
         run: |
-          cargo build --bin base-builder --profile maxperf
+          cargo build --locked --bin base-builder --profile maxperf
           cp target/maxperf/base-builder ~/bin/base-builder
 
       - name: Verify binaries exist

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -60,7 +60,7 @@ jobs:
         uses: dtolnay/rust-toolchain@4305c38b25d97ef35a8ad1f985ccf2d2242004f2 # stable
 
       - name: Build binaries
-        run: cargo build --profile maxperf --bin base-reth-node --bin basectl
+        run: cargo build --locked --profile maxperf --bin base-reth-node --bin basectl
 
       - name: Package binaries
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,21 @@ permissions:
   contents: read
 
 jobs:
+  lockfile:
+    name: Lockfile
+    runs-on: ubuntu-latest
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@95d9a5deda9de15063e7595e9719c11c38c90ae2 # v2.13.2
+        with:
+          egress-policy: audit
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: ./.github/actions/setup
+        with:
+          rust-cache-shared-key: "stable"
+      - name: Validate Cargo.lock is up to date
+        run: cargo metadata --format-version 1 --no-deps --locked >/dev/null
+
   build:
     name: Build
     runs-on: ubuntu-latest
@@ -177,7 +192,7 @@ jobs:
           native-deps: "true"
           mold: "true"
           rust-cache-shared-key: "stable"
-      - run: cargo bench -p base-proof-mpt --bench trie_node -- --test
+      - run: cargo bench --locked -p base-proof-mpt --bench trie_node -- --test
 
   udeps:
     name: udeps

--- a/Justfile
+++ b/Justfile
@@ -117,7 +117,7 @@ test-affected base="main": install-nextest build-contracts
 
 # Runs tests with ci profile for minimal disk usage
 test-ci: install-nextest build-contracts
-    cargo nextest run --workspace --all-features --exclude devnet --cargo-profile ci
+    cargo nextest run --locked --workspace --all-features --exclude devnet --cargo-profile ci
 
 # Runs tests only for affected crates with ci profile (for PRs)
 test-affected-ci base="main": install-nextest build-contracts
@@ -133,7 +133,7 @@ test-affected-ci base="main": install-nextest build-contracts
         pkg_args="$pkg_args -p $crate"
     done <<< "$affected"
     echo "Testing affected crates:$pkg_args"
-    cargo nextest run --all-features --cargo-profile ci $pkg_args || {
+    cargo nextest run --locked --all-features --cargo-profile ci $pkg_args || {
         code=$?
         if [ $code -eq 4 ]; then
             echo "No tests to run."
@@ -148,7 +148,7 @@ devnet-tests: install-nextest build-contracts
 
 # Runs devnet tests with ci profile for minimal disk usage
 devnet-tests-ci: install-nextest build-contracts
-    cargo nextest run -p devnet --cargo-profile ci
+    cargo nextest run --locked -p devnet --cargo-profile ci
 
 # Pre-pulls Docker images needed for devnet tests
 devnet-pull-images:
@@ -186,7 +186,7 @@ check-clippy: build-contracts
 
 # Checks clippy with ci profile for minimal disk usage
 check-clippy-ci: build-contracts
-    cargo clippy --workspace --all-targets --profile ci -- -D warnings
+    cargo clippy --locked --workspace --all-targets --profile ci -- -D warnings
 
 # Fixes any clippy issues
 clippy-fix:
@@ -202,7 +202,7 @@ build-all-targets: build-contracts
 
 # Builds all targets with ci profile (minimal disk usage for CI)
 build-ci: build-contracts
-    cargo build --workspace --all-targets --profile ci
+    cargo build --locked --workspace --all-targets --profile ci
 
 # Builds the workspace with maxperf
 build-maxperf:
@@ -223,7 +223,7 @@ clean:
 # Checks if there are any unused dependencies
 check-udeps: build-contracts
     @command -v cargo-udeps >/dev/null 2>&1 || cargo install cargo-udeps
-    cargo +nightly udeps --workspace --all-features --all-targets
+    cargo +nightly udeps --locked --workspace --all-features --all-targets
 
 # Checks crate dependency boundary rules
 check-crate-deps:

--- a/etc/scripts/ci/check-crate-deps.sh
+++ b/etc/scripts/ci/check-crate-deps.sh
@@ -25,8 +25,8 @@ ALLOWED_DEPS=(
 ALLOWED_FILTER=$(printf '"%s",' "${ALLOWED_DEPS[@]}")
 ALLOWED_FILTER="[${ALLOWED_FILTER%,}]"
 
-# Fetch cargo metadata once
-METADATA=$(cargo metadata --format-version 1 --no-deps)
+# Fetch cargo metadata once, ensuring Cargo.lock is in sync
+METADATA=$(cargo metadata --format-version 1 --no-deps --locked)
 
 FOUND_VIOLATIONS=false
 

--- a/etc/scripts/ci/check-no-std-proof.sh
+++ b/etc/scripts/ci/check-no-std-proof.sh
@@ -31,7 +31,7 @@ proof_packages=(
 )
 
 for package in "${proof_packages[@]}"; do
-  cmd="cargo +nightly build -p $package -Zbuild-std=core,alloc --target riscv32imac-unknown-none-elf --no-default-features"
+  cmd="cargo +nightly build --locked -p $package -Zbuild-std=core,alloc --target riscv32imac-unknown-none-elf --no-default-features"
   if [ -n "$CI" ]; then
     echo "::group::$cmd"
   else

--- a/etc/scripts/ci/check-no-std.sh
+++ b/etc/scripts/ci/check-no-std.sh
@@ -25,7 +25,7 @@ no_std_packages=(
 )
 
 for package in "${no_std_packages[@]}"; do
-  cmd="cargo build -p $package --target riscv32imac-unknown-none-elf --no-default-features"
+  cmd="cargo build --locked -p $package --target riscv32imac-unknown-none-elf --no-default-features"
   if [ -n "$CI" ]; then
     echo "::group::$cmd"
   else


### PR DESCRIPTION
## Summary
- add a dedicated CI lockfile job that runs `cargo metadata --locked`
- enforce `--locked` in CI-focused cargo invocations (build, test, clippy, no-std checks, crate metadata checks, benchmark/release builds)
- enforce `--locked` on the benchmark command in the main CI workflow

## Why
This prevents CI from silently resolving dependencies different from the committed `Cargo.lock`, and fails fast when manifests and lockfile drift.

## Validation
- `cargo metadata --format-version 1 --no-deps --locked`
- `bash -n etc/scripts/ci/check-no-std.sh etc/scripts/ci/check-no-std-proof.sh etc/scripts/ci/check-crate-deps.sh`
- `just --list`
