### PR TITLE
fix(engine): prevent receipt-root false invalids from cached execution misalignment

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3205,6 +3205,7 @@ dependencies = [
  "crossbeam-channel",
  "derive_more",
  "eyre",
+ "metrics",
  "reth-chain-state",
  "reth-consensus",
  "reth-engine-primitives",

--- a/crates/execution/consensus/src/validation/mod.rs
+++ b/crates/execution/consensus/src/validation/mod.rs
@@ -118,12 +118,32 @@ pub fn validate_block_post_execution<R: DepositReceipt>(
     // See more about EIP here: https://eips.ethereum.org/EIPS/eip-658
     if chain_spec.is_byzantium_active_at_block(header.number()) {
         let result = if let Some((receipts_root, logs_bloom)) = receipt_root_bloom {
-            compare_receipts_root_and_logs_bloom(
+            // Fast path: trust precomputed root/bloom from the background receipt task.
+            //
+            // If this mismatches, fall back to recomputing from the full receipts slice before
+            // rejecting the block. This preserves safety for true execution divergences while
+            // avoiding false invalid payloads from precompute-path anomalies.
+            match compare_receipts_root_and_logs_bloom(
                 receipts_root,
                 logs_bloom,
                 header.receipts_root(),
                 header.logs_bloom(),
-            )
+            ) {
+                Ok(()) => Ok(()),
+                Err(precomputed_error) => {
+                    debug!(
+                        %precomputed_error,
+                        "precomputed receipt root/logs bloom mismatch, recomputing from receipts"
+                    );
+                    verify_receipts_optimism(
+                        header.receipts_root(),
+                        header.logs_bloom(),
+                        receipts,
+                        chain_spec,
+                        header.timestamp(),
+                    )
+                }
+            }
         } else {
             verify_receipts_optimism(
                 header.receipts_root(),
@@ -210,7 +230,7 @@ fn compare_receipts_root_and_logs_bloom(
 mod tests {
     use std::sync::Arc;
 
-    use alloy_consensus::Header;
+    use alloy_consensus::{Header, Receipt, TxReceipt};
     use alloy_eips::eip7685::Requests;
     use alloy_primitives::{Bytes, U256, b256, hex};
     use base_alloy_consensus::OpTxEnvelope;
@@ -563,6 +583,50 @@ mod tests {
             gas_used: GAS_USED,
         };
         validate_block_post_execution(&header, &chainspec, &result, None).unwrap();
+    }
+
+    #[test]
+    fn test_receipt_root_bloom_mismatch_falls_back_to_recompute() {
+        let chainspec = BASE_SEPOLIA.clone();
+        let timestamp = HOLOCENE_TIMESTAMP + 1;
+        let receipts = vec![OpReceipt::Legacy(Receipt {
+            status: true.into(),
+            cumulative_gas_used: 21_000,
+            logs: vec![],
+        })];
+
+        let receipts_with_bloom =
+            receipts.iter().map(TxReceipt::with_bloom_ref).collect::<Vec<_>>();
+        let expected_receipts_root =
+            calculate_receipt_root_optimism(&receipts_with_bloom, &*chainspec, timestamp);
+        let expected_logs_bloom =
+            receipts_with_bloom.iter().fold(Bloom::ZERO, |bloom, r| bloom | r.bloom_ref());
+
+        let header = Header {
+            number: 1,
+            timestamp,
+            receipts_root: expected_receipts_root,
+            logs_bloom: expected_logs_bloom,
+            gas_used: 21_000,
+            ..Default::default()
+        };
+
+        let result = BlockExecutionResult::<OpReceipt> {
+            receipts,
+            requests: Requests::default(),
+            gas_used: 21_000,
+            blob_gas_used: 0,
+        };
+
+        let wrong_precomputed_root =
+            b256!("0x1111111111111111111111111111111111111111111111111111111111111111");
+        validate_block_post_execution(
+            &header,
+            &*chainspec,
+            &result,
+            Some((wrong_precomputed_root, expected_logs_bloom)),
+        )
+        .unwrap();
     }
 
     #[test]

--- a/crates/execution/engine-tree/Cargo.toml
+++ b/crates/execution/engine-tree/Cargo.toml
@@ -52,3 +52,4 @@ tracing.workspace = true
 derive_more.workspace = true
 crossbeam-channel.workspace = true
 eyre.workspace = true
+metrics.workspace = true

--- a/crates/execution/engine-tree/src/cached_execution.rs
+++ b/crates/execution/engine-tree/src/cached_execution.rs
@@ -8,6 +8,7 @@ use base_execution_chainspec::OpChainSpec;
 use base_execution_evm::OpRethReceiptBuilder;
 use base_flashblocks::{FlashblocksAPI, FlashblocksState};
 use base_revm::{OpHaltReason, OpTransaction};
+use metrics::counter;
 use reth_errors::BlockExecutionError;
 use reth_evm::{
     Evm, RecoveredTx,
@@ -35,6 +36,39 @@ impl<P> FlashblocksCachedExecutionProvider<P> {
     }
 }
 
+const CACHE_MISALIGNMENT_TOTAL: &str = "reth_base_engine_tree_cache_misalignment_total";
+
+#[inline]
+fn cache_alignment_miss_reason(
+    this_block_number: u64,
+    tx_block_number: u64,
+    tx_index: u64,
+    prev_position: Option<(u64, u64)>,
+) -> Option<&'static str> {
+    if tx_block_number != this_block_number {
+        return Some("tx_block_number_mismatch");
+    }
+
+    match prev_position {
+        Some((prev_block_number, prev_index)) => {
+            if prev_block_number != this_block_number {
+                Some("prev_block_number_mismatch")
+            } else if prev_index.checked_add(1) != Some(tx_index) {
+                Some("non_adjacent_prev_tx")
+            } else {
+                None
+            }
+        }
+        None => {
+            if tx_index != 0 {
+                Some("non_zero_first_tx_index")
+            } else {
+                None
+            }
+        }
+    }
+}
+
 impl<P> CachedExecutionProvider<OpTxResult<OpHaltReason, OpTxType>>
     for FlashblocksCachedExecutionProvider<P>
 where
@@ -56,26 +90,65 @@ where
 
         let pending_blocks = flashblocks_state.get_pending_blocks().clone()?;
 
-        if let Some(prev_cached_hash) = prev_cached_hash {
-            // all previous transactions from start of block to prev_cached_hash are cached, so only check if the previous transaction is cached
-            if !pending_blocks.has_transaction_hash(prev_cached_hash) {
+        let Some(tx) = pending_blocks.get_transaction_by_hash(*tx_hash) else {
+            warn!(tx_hash = ?tx_hash, "Not using cached results - transaction not cached");
+            return None;
+        };
+
+        let Some(tx_block_number) = tx.inner.block_number else {
+            warn!(tx_hash = ?tx_hash, "Not using cached results - cached tx missing block number");
+            return None;
+        };
+
+        let Some(tx_index) = tx.inner.transaction_index else {
+            warn!(tx_hash = ?tx_hash, "Not using cached results - cached tx missing transaction index");
+            return None;
+        };
+
+        let prev_position = if let Some(prev_cached_hash) = prev_cached_hash {
+            // Enforce strict adjacency in the same block to avoid cross-block / out-of-order cache hits.
+            let Some(prev_tx) = pending_blocks.get_transaction_by_hash(*prev_cached_hash) else {
                 warn!(
                     prev_cached_hash = ?prev_cached_hash,
                     "Not using cached results - previous transaction not cached",
                 );
                 return None;
-            }
-        } else {
-            // must be the first tx in the block
-            if pending_blocks
-                .get_transactions_for_block(this_block_number)
-                .next()
-                .map(|tx| tx.inner.inner.tx_hash())
-                != Some(*tx_hash)
-            {
-                warn!(tx_hash = ?tx_hash, "Not using cached results - first transaction not cached");
+            };
+
+            let Some(prev_block_number) = prev_tx.inner.block_number else {
+                warn!(
+                    prev_cached_hash = ?prev_cached_hash,
+                    "Not using cached results - previous cached tx missing block number",
+                );
                 return None;
-            }
+            };
+
+            let Some(prev_index) = prev_tx.inner.transaction_index else {
+                warn!(
+                    prev_cached_hash = ?prev_cached_hash,
+                    "Not using cached results - previous cached tx missing transaction index",
+                );
+                return None;
+            };
+            Some((prev_block_number, prev_index))
+        } else {
+            None
+        };
+
+        if let Some(reason) =
+            cache_alignment_miss_reason(this_block_number, tx_block_number, tx_index, prev_position)
+        {
+            counter!(CACHE_MISALIGNMENT_TOTAL, "reason" => reason).increment(1);
+            warn!(
+                tx_hash = ?tx_hash,
+                tx_block_number,
+                tx_index,
+                ?prev_position,
+                this_block_number,
+                reason,
+                "Not using cached results - tx not aligned with expected block/position",
+            );
+            return None;
         }
 
         trace!(tx_hash = ?tx_hash, "cache hit for transaction");
@@ -230,5 +303,42 @@ where
 
     fn evm(&self) -> &Self::Evm {
         self.executor.evm()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cache_alignment_requires_same_block() {
+        assert_eq!(
+            cache_alignment_miss_reason(100, 101, 0, None),
+            Some("tx_block_number_mismatch")
+        );
+        assert_eq!(cache_alignment_miss_reason(100, 99, 0, None), Some("tx_block_number_mismatch"));
+    }
+
+    #[test]
+    fn cache_alignment_requires_zero_index_for_first_tx() {
+        assert_eq!(cache_alignment_miss_reason(100, 100, 0, None), None);
+        assert_eq!(cache_alignment_miss_reason(100, 100, 1, None), Some("non_zero_first_tx_index"));
+    }
+
+    #[test]
+    fn cache_alignment_requires_adjacent_previous_tx() {
+        assert_eq!(cache_alignment_miss_reason(100, 100, 1, Some((100, 0))), None);
+        assert_eq!(
+            cache_alignment_miss_reason(100, 100, 2, Some((100, 0))),
+            Some("non_adjacent_prev_tx")
+        );
+        assert_eq!(
+            cache_alignment_miss_reason(100, 100, 1, Some((101, 0))),
+            Some("prev_block_number_mismatch")
+        );
+        assert_eq!(
+            cache_alignment_miss_reason(100, 100, 0, Some((100, 0))),
+            Some("non_adjacent_prev_tx")
+        );
     }
 }


### PR DESCRIPTION
## Summary
- add a defensive fallback in post-execution consensus validation: if precomputed `(receipts_root, logs_bloom)` mismatches the header, recompute from full receipts before rejecting
- harden flashblocks cached-execution gating to require strict block/index alignment before cache hit:
  - cached tx must belong to `parent + 1` block
  - first tx must have `transaction_index == 0`
  - non-first tx must be adjacent to previous tx (`prev_index + 1 == tx_index`) in the same block
- add `reth_base_engine_tree_cache_misalignment_total{reason=...}` counter to quantify cache misses caused by misalignment
- keep warning logs on misalignment with explicit `reason`
- add unit tests for cache-alignment rules and receipts-root fallback regression

## Why
We observed canonical payload invalidations with `receipt root mismatch` where the header root was correct. This change prevents false invalidations caused by precomputed/cached-path anomalies while preserving strict validation for true execution divergences.

## Testing
- `cargo test -p base-engine-tree --lib`
- `cargo test -p base-execution-consensus --lib`
