### PR TITLE
fix(execution): Missing Apply Pre Execution Changes in Executor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3574,6 +3574,7 @@ version = "0.0.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
+ "alloy-evm",
  "alloy-primitives",
  "alloy-provider",
  "alloy-rpc-types",

--- a/crates/alloy/evm/src/canyon.rs
+++ b/crates/alloy/evm/src/canyon.rs
@@ -18,7 +18,7 @@ const CREATE_2_DEPLOYER_BYTECODE: [u8; 1584] = hex!(
 /// The Canyon hardfork issues an irregular state transition that force-deploys the create2
 /// deployer contract. This is done by directly setting the code of the create2 deployer account
 /// prior to executing any transactions on the timestamp activation of the fork.
-pub(crate) fn ensure_create2_deployer<DB>(
+pub fn ensure_create2_deployer<DB>(
     chain_spec: impl OpHardforks,
     timestamp: u64,
     db: &mut DB,

--- a/crates/alloy/evm/src/lib.rs
+++ b/crates/alloy/evm/src/lib.rs
@@ -27,6 +27,7 @@ mod receipt_builder;
 pub use receipt_builder::{OpAlloyReceiptBuilder, OpReceiptBuilder};
 
 mod canyon;
+pub use canyon::ensure_create2_deployer;
 
 mod executor;
 pub use executor::{OpBlockExecutor, OpTxResult};

--- a/crates/execution/flashblocks/Cargo.toml
+++ b/crates/execution/flashblocks/Cargo.toml
@@ -14,6 +14,7 @@ workspace = true
 [dependencies]
 # workspace
 base-alloy-flashblocks.workspace = true
+alloy-evm = { workspace = true, features = ["std"] }
 base-alloy-evm = { workspace = true, features = ["std"] }
 
 # reth

--- a/crates/execution/flashblocks/src/processor.rs
+++ b/crates/execution/flashblocks/src/processor.rs
@@ -442,6 +442,9 @@ where
             // Clone header before moving block to avoid cloning the entire block
             let block_header = assembled.block.header.clone();
 
+            let parent_hash = last_block_header.hash_slow();
+            let parent_beacon_block_root = Some(assembled.base.parent_beacon_block_root);
+
             let mut pending_state_builder = PendingStateBuilder::new(
                 self.client.chain_spec(),
                 evm,
@@ -450,6 +453,9 @@ where
                 l1_block_info,
                 state_overrides,
             );
+
+            pending_state_builder
+                .apply_pre_execution_changes(parent_hash, parent_beacon_block_root)?;
 
             for (idx, (transaction, sender)) in txs_with_senders.into_iter().enumerate() {
                 let tx_hash = transaction.tx_hash();

--- a/crates/execution/flashblocks/src/state_builder.rs
+++ b/crates/execution/flashblocks/src/state_builder.rs
@@ -4,7 +4,10 @@ use alloy_consensus::{
     Block, Header, TxReceipt,
     transaction::{Recovered, TransactionMeta},
 };
-use alloy_evm::{Database as AlloyDatabase, block::{StateDB, SystemCaller}};
+use alloy_evm::{
+    Database as AlloyDatabase,
+    block::{StateDB, SystemCaller},
+};
 use alloy_primitives::B256;
 use alloy_rpc_types::TransactionTrait;
 use alloy_rpc_types_eth::state::StateOverride;
@@ -147,8 +150,7 @@ where
         ChainSpec: Clone,
     {
         let spec = self.receipt_builder.chain_spec();
-        let state_clear_flag =
-            spec.is_spurious_dragon_active_at_block(self.pending_block.number);
+        let state_clear_flag = spec.is_spurious_dragon_active_at_block(self.pending_block.number);
         self.evm.db_mut().set_state_clear_flag(state_clear_flag);
 
         let mut system_caller = SystemCaller::new(spec.clone());

--- a/crates/execution/flashblocks/src/state_builder.rs
+++ b/crates/execution/flashblocks/src/state_builder.rs
@@ -4,10 +4,12 @@ use alloy_consensus::{
     Block, Header, TxReceipt,
     transaction::{Recovered, TransactionMeta},
 };
+use alloy_evm::{Database as AlloyDatabase, block::{StateDB, SystemCaller}};
 use alloy_primitives::B256;
 use alloy_rpc_types::TransactionTrait;
 use alloy_rpc_types_eth::state::StateOverride;
 use base_alloy_consensus::{OpReceipt, OpTxEnvelope};
+use base_alloy_evm::ensure_create2_deployer;
 use base_alloy_rpc_types::{OpTransactionReceipt, Transaction};
 use base_execution_forks::OpHardforks;
 use base_execution_primitives::OpPrimitives;
@@ -128,6 +130,39 @@ where
         } else {
             self.execute_with_evm(transaction, idx, effective_gas_price)
         }
+    }
+
+    /// Applies EIP-4788, EIP-2935, and Canyon create2 deployer pre-execution changes to the EVM.
+    ///
+    /// Must be called once per block, before executing any transactions. This mirrors the
+    /// `apply_pre_execution_changes` behavior of [`base_alloy_evm::OpBlockExecutor`] to ensure
+    /// that the cached execution results match what the validator computes.
+    pub fn apply_pre_execution_changes(
+        &mut self,
+        parent_hash: B256,
+        parent_beacon_block_root: Option<B256>,
+    ) -> Result<(), StateProcessorError>
+    where
+        DB: AlloyDatabase + StateDB,
+        ChainSpec: Clone,
+    {
+        let spec = self.receipt_builder.chain_spec();
+        let state_clear_flag =
+            spec.is_spurious_dragon_active_at_block(self.pending_block.number);
+        self.evm.db_mut().set_state_clear_flag(state_clear_flag);
+
+        let mut system_caller = SystemCaller::new(spec.clone());
+        system_caller
+            .apply_blockhashes_contract_call(parent_hash, &mut self.evm)
+            .map_err(|e| ExecutionError::EvmEnv(e.to_string()))?;
+        system_caller
+            .apply_beacon_root_contract_call(parent_beacon_block_root, &mut self.evm)
+            .map_err(|e| ExecutionError::EvmEnv(e.to_string()))?;
+
+        ensure_create2_deployer(spec, self.pending_block.timestamp, self.evm.db_mut())
+            .map_err(|e| ExecutionError::EvmEnv(e.to_string()))?;
+
+        Ok(())
     }
 
     /// Builds transaction result from cached receipt and state data.


### PR DESCRIPTION
## Summary

StateProcessor::build_pending_state in crates/execution/flashblocks/src/processor.rs never called apply_pre_execution_changes before executing flashblock
  transactions. The validator (via CachedExecutor) calls it, but the flashblock state processor didn't.

  The bug chain:
  1. StateProcessor executes flashblock transactions WITHOUT applying EIP-4788 (beacon root) and EIP-2935 (blockhashes) system calls
  2. The EIP-4788 beacon root contract retains the value from the previous block in the StateProcessor's EVM
  3. If a flashblock transaction reads from the EIP-4788 contract (e.g., a contract verifying beacon roots), its cached ExecutionResult.logs contains the stale
   beacon root value
  4. This wrong ExecutionResult is stored in PendingBlocks.transaction_results
  5. When block 42969982 arrives for validation, FlashblocksCachedExecutionProvider returns the cached OpTxResult with incorrect logs
  6. The validator builds a receipt from the wrong logs → wrong receipt_root (0xae38...) ≠ the builder's correct receipt_root (0x0381...)