### PR TITLE
backport(v0.6.0): override nonce/basefee and remove nonce/7702 check in metering

### DIFF
--- a/crates/client/metering/src/meter.rs
+++ b/crates/client/metering/src/meter.rs
@@ -10,7 +10,7 @@ use base_execution_evm::{OpEvmConfig, OpNextBlockEnvAttributes};
 use base_revm::L1BlockInfo;
 use eyre::{Result as EyreResult, eyre};
 use reth_evm::{ConfigureEvm, execute::BlockBuilder};
-use reth_primitives_traits::{Account, Bytecode, SealedHeader};
+use reth_primitives_traits::{Account, SealedHeader};
 use reth_revm::{database::StateProviderDatabase, db::State};
 use reth_trie_common::TrieInput;
 use revm_database::states::{BundleState, bundle_state::BundleRetention};
@@ -152,12 +152,11 @@ where
     };
 
     // Pre-fetch account information for transaction validation
-    let mut account_infos: HashMap<Address, (Option<Account>, Option<Bytecode>)> = HashMap::new();
+    let mut account_infos: HashMap<Address, Option<Account>> = HashMap::new();
     for tx in bundle.transactions() {
         let from = tx.signer();
         let account = db.database.basic_account(&from)?;
-        let code = db.database.account_code(&from)?;
-        account_infos.insert(from, (account, code));
+        account_infos.insert(from, account);
     }
 
     // Execute transactions
@@ -179,13 +178,13 @@ where
             let to = tx.to();
             let value = tx.value();
             let gas_price = tx.max_fee_per_gas();
-            let (account, sender_code) = account_infos
+            let account = account_infos
                 .get(&from)
-                .ok_or_else(|| eyre!("Account not found in HashMap for address: {}", from))?;
-            let account = account.ok_or_else(|| eyre!("Account is none for tx: {}", tx_hash))?;
+                .ok_or_else(|| eyre!("Account not found in HashMap for address: {}", from))?
+                .ok_or_else(|| eyre!("Account is none for tx: {}", tx_hash))?;
 
             // Don't waste resources metering invalid transactions
-            validate_tx(account, sender_code.as_ref(), tx, &mut l1_block_info)
+            validate_tx(account, tx, &mut l1_block_info)
                 .map_err(|e| eyre!("Transaction {} validation failed: {}", tx_hash, e))?;
 
             let gas_used = builder

--- a/crates/client/metering/src/meter.rs
+++ b/crates/client/metering/src/meter.rs
@@ -11,7 +11,7 @@ use base_revm::L1BlockInfo;
 use eyre::{Result as EyreResult, eyre};
 use reth_evm::{ConfigureEvm, execute::BlockBuilder};
 use reth_primitives_traits::{Account, SealedHeader};
-use reth_revm::{database::StateProviderDatabase, db::State};
+use reth_revm::{database::StateProviderDatabase, db::State, primitives::KECCAK_EMPTY};
 use reth_trie_common::TrieInput;
 use revm_database::states::{BundleState, bundle_state::BundleRetention};
 
@@ -67,6 +67,11 @@ pub struct PendingState {
 }
 
 const BLOCK_TIME: u64 = 2; // 2 seconds per block
+// Static floor from the current minimum base fee for metering simulation.
+// The protocol has a dynamic min_base_fee via system config, but for metering
+// we use a static floor to reject transactions that will never make it onchain.
+const MIN_BASEFEE: u64 = 5_000_000;
+const MAX_NONCE_AHEAD: u64 = 10_000; // max nonce distance from on-chain state
 
 /// Output from metering a bundle of transactions
 #[derive(Debug)]
@@ -136,6 +141,44 @@ where
         State::builder().with_database(state_db).with_bundle_update().build()
     };
 
+    // Override sender nonces to match their first transaction's nonce and collect
+    // account info for pre-flight validation. load_cache_account reads from bundle
+    // prestate (pending flashblocks) when available, so balances reflect pending state.
+    let mut first_nonces: HashMap<Address, u64> = HashMap::new();
+    for tx in bundle.transactions() {
+        first_nonces.entry(tx.signer()).or_insert_with(|| tx.nonce());
+    }
+
+    let mut account_infos: HashMap<Address, Option<Account>> = HashMap::new();
+    for (&addr, &nonce) in &first_nonces {
+        let cache_account = db.load_cache_account(addr)?;
+        if let Some(ref mut account) = cache_account.account {
+            let max_nonce = account.info.nonce.saturating_add(MAX_NONCE_AHEAD);
+            if nonce > max_nonce {
+                return Err(eyre!(
+                    "transaction nonce {} for {} exceeds max allowed (on-chain {} + {})",
+                    nonce,
+                    addr,
+                    account.info.nonce,
+                    MAX_NONCE_AHEAD,
+                ));
+            }
+            account.info.nonce = nonce;
+
+            account_infos.insert(
+                addr,
+                Some(Account {
+                    nonce: account.info.nonce,
+                    balance: account.info.balance,
+                    bytecode_hash: (account.info.code_hash != KECCAK_EMPTY)
+                        .then_some(account.info.code_hash),
+                }),
+            );
+        } else {
+            account_infos.insert(addr, None);
+        }
+    }
+
     // Set up next block attributes
     // Use bundle.min_timestamp if provided, otherwise use header timestamp + BLOCK_TIME
     let timestamp = bundle.min_timestamp.unwrap_or_else(|| header.timestamp() + BLOCK_TIME);
@@ -151,14 +194,6 @@ where
         extra_data: header.extra_data().clone(),
     };
 
-    // Pre-fetch account information for transaction validation
-    let mut account_infos: HashMap<Address, Option<Account>> = HashMap::new();
-    for tx in bundle.transactions() {
-        let from = tx.signer();
-        let account = db.database.basic_account(&from)?;
-        account_infos.insert(from, account);
-    }
-
     // Execute transactions
     let mut results = Vec::new();
     let mut total_gas_used = 0u64;
@@ -168,6 +203,13 @@ where
     {
         let evm_config = OpEvmConfig::optimism(chain_spec);
         let mut builder = evm_config.builder_for_next_block(&mut db, header, attributes)?;
+
+        // Cap the base fee at MIN_BASEFEE so transactions aren't rejected for
+        // max_fee_per_gas < basefee. We're simulating for gas measurement, not fee
+        // accounting. Balance checks in validate_tx still catch underfunded senders
+        // intentionally.
+        let block = &mut builder.evm_mut().block;
+        block.basefee = block.basefee.min(MIN_BASEFEE);
 
         builder.apply_pre_execution_changes()?;
 
@@ -183,7 +225,9 @@ where
                 .ok_or_else(|| eyre!("Account not found in HashMap for address: {}", from))?
                 .ok_or_else(|| eyre!("Account is none for tx: {}", tx_hash))?;
 
-            // Don't waste resources metering invalid transactions
+            // Don't waste resources metering invalid transactions.
+            // Note: balance checks (InsufficientFunds*) are intentionally kept — an underfunded
+            // sender is a meaningful validation failure. Nonce and base fee are overridden above.
             validate_tx(account, tx, &mut l1_block_info)
                 .map_err(|e| eyre!("Transaction {} validation failed: {}", tx_hash, e))?;
 
@@ -264,7 +308,7 @@ mod tests {
     use base_node_runner::test_utils::{Account, TestHarness};
     use eyre::Context;
     use reth_provider::StateProviderFactory;
-    use reth_revm::{bytecode::Bytecode, primitives::KECCAK_EMPTY, state::AccountInfo};
+    use reth_revm::{bytecode::Bytecode, state::AccountInfo};
     use reth_transaction_pool::test_utils::TransactionBuilder;
 
     use super::*;
@@ -594,27 +638,26 @@ mod tests {
         Ok(())
     }
 
-    /// Integration test: verifies `meter_bundle` uses flashblocks state correctly.
+    /// Verifies that a nonce ahead of on-chain state succeeds via override.
     ///
-    /// A transaction using nonce=1 should fail without flashblocks state (since
-    /// canonical nonce is 0), but succeed when flashblocks state indicates nonce=1.
+    /// Canonical nonce is 0, but the transaction uses nonce=1. The nonce override
+    /// sets the account nonce to match, so simulation succeeds.
     #[tokio::test]
-    async fn meter_bundle_requires_correct_layering_for_pending_nonce() -> eyre::Result<()> {
+    async fn meter_bundle_overrides_nonce_too_high() -> eyre::Result<()> {
         let harness = TestHarness::new().await?;
         let latest = harness.latest_block();
         let header = latest.sealed_header().clone();
 
-        // Create a transaction that requires nonce=1 (assuming canonical nonce is 0)
         let to = Address::random();
         let signed_tx = TransactionBuilder::default()
             .signer(Account::Alice.signer_b256())
             .chain_id(harness.chain_id())
-            .nonce(1) // Requires pending state to have nonce=1
+            .nonce(1) // Ahead of canonical nonce (0)
             .to(to)
             .value(100)
             .gas_limit(21_000)
-            .max_fee_per_gas(10)
-            .max_priority_fee_per_gas(1)
+            .max_fee_per_gas(MIN_BASEFEE as u128)
+            .max_priority_fee_per_gas(0)
             .into_eip1559();
 
         let tx = OpTransactionSigned::Eip1559(
@@ -622,62 +665,95 @@ mod tests {
         );
         let parsed_bundle = create_parsed_bundle(vec![tx])?;
 
-        // Without flashblocks state, transaction should fail (nonce mismatch)
         let state_provider = harness
             .blockchain_provider()
             .state_by_block_hash(latest.hash())
             .context("getting state provider")?;
 
-        let result_without_flashblocks = meter_bundle(
+        let result = meter_bundle(
             state_provider,
             harness.chain_spec(),
-            parsed_bundle.clone(),
+            parsed_bundle,
             &header,
             header.parent_beacon_block_root(),
-            None, // No pending state
+            None,
             L1BlockInfo::default(),
         );
 
         assert!(
-            result_without_flashblocks.is_err(),
-            "Transaction with nonce=1 should fail without pending state (canonical nonce is 0)"
+            result.is_ok(),
+            "Nonce ahead of on-chain state should succeed via override: {:?}",
+            result.err()
         );
 
-        // Now create pending state with nonce=1 for Alice
-        // Use BundleState::new() to properly calculate state_size
+        let output = result.unwrap();
+        assert_eq!(output.results.len(), 1);
+        assert_eq!(output.total_gas_used, 21_000);
+
+        Ok(())
+    }
+
+    /// Verifies that a nonce behind on-chain state succeeds via override.
+    ///
+    /// Uses pending state to advance Alice's nonce to 5, then submits a transaction
+    /// with nonce=0. The nonce override sets the account nonce to match the
+    /// transaction, so simulation succeeds despite the nonce being "too low".
+    #[tokio::test]
+    async fn meter_bundle_overrides_nonce_too_low() -> eyre::Result<()> {
+        let harness = TestHarness::new().await?;
+        let latest = harness.latest_block();
+        let header = latest.sealed_header().clone();
+
+        // Build pending state where Alice's nonce has advanced to 5
         let bundle_state = BundleState::new(
             [(
                 Account::Alice.address(),
                 Some(AccountInfo {
-                    balance: U256::from(1_000_000_000u64),
+                    balance: U256::from(1_000_000_000_000_000_000u128),
                     nonce: 0, // original
                     code_hash: KECCAK_EMPTY,
                     code: None,
                     account_id: None,
                 }),
                 Some(AccountInfo {
-                    balance: U256::from(1_000_000_000u64),
-                    nonce: 1, // pending (after first flashblock tx)
+                    balance: U256::from(1_000_000_000_000_000_000u128),
+                    nonce: 5, // pending
                     code_hash: KECCAK_EMPTY,
                     code: None,
                     account_id: None,
                 }),
-                Default::default(), // no storage changes
+                Default::default(),
             )],
             Vec::<Vec<(Address, Option<Option<AccountInfo>>, Vec<(U256, U256)>)>>::new(),
             Vec::<(B256, Bytecode)>::new(),
         );
-
         let pending_state = PendingState { bundle_state, trie_input: None };
 
-        // With correct pending state, transaction should succeed
-        let state_provider2 = harness
+        // Transaction with nonce=0 — "too low" relative to pending nonce of 5
+        let to = Address::random();
+        let signed_tx = TransactionBuilder::default()
+            .signer(Account::Alice.signer_b256())
+            .chain_id(harness.chain_id())
+            .nonce(0)
+            .to(to)
+            .value(100)
+            .gas_limit(21_000)
+            .max_fee_per_gas(MIN_BASEFEE as u128)
+            .max_priority_fee_per_gas(0)
+            .into_eip1559();
+
+        let tx = OpTransactionSigned::Eip1559(
+            signed_tx.as_eip1559().expect("eip1559 transaction").clone(),
+        );
+        let parsed_bundle = create_parsed_bundle(vec![tx])?;
+
+        let state_provider = harness
             .blockchain_provider()
             .state_by_block_hash(latest.hash())
             .context("getting state provider")?;
 
-        let result_with_pending = meter_bundle(
-            state_provider2,
+        let result = meter_bundle(
+            state_provider,
             harness.chain_spec(),
             parsed_bundle,
             &header,
@@ -687,10 +763,121 @@ mod tests {
         );
 
         assert!(
-            result_with_pending.is_ok(),
-            "Transaction with nonce=1 should succeed with pending state showing nonce=1: {:?}",
-            result_with_pending.err()
+            result.is_ok(),
+            "Nonce behind on-chain state should succeed via override: {:?}",
+            result.err()
         );
+
+        let output = result.unwrap();
+        assert_eq!(output.results.len(), 1);
+        assert_eq!(output.total_gas_used, 21_000);
+
+        Ok(())
+    }
+
+    /// Verifies that nonce overrides are rejected when too far ahead of on-chain state.
+    #[tokio::test]
+    async fn meter_bundle_err_nonce_too_far_ahead() -> eyre::Result<()> {
+        let harness = TestHarness::new().await?;
+        let latest = harness.latest_block();
+        let header = latest.sealed_header().clone();
+
+        let to = Address::random();
+        let nonce = MAX_NONCE_AHEAD + 1; // Just over the limit (on-chain nonce is 0)
+        let signed_tx = TransactionBuilder::default()
+            .signer(Account::Alice.signer_b256())
+            .chain_id(harness.chain_id())
+            .nonce(nonce)
+            .to(to)
+            .value(100)
+            .gas_limit(21_000)
+            .max_fee_per_gas(MIN_BASEFEE as u128)
+            .max_priority_fee_per_gas(0)
+            .into_eip1559();
+
+        let tx = OpTransactionSigned::Eip1559(
+            signed_tx.as_eip1559().expect("eip1559 transaction").clone(),
+        );
+
+        let state_provider = harness
+            .blockchain_provider()
+            .state_by_block_hash(latest.hash())
+            .context("getting state provider")?;
+
+        let parsed_bundle = create_parsed_bundle(vec![tx])?;
+
+        let result = meter_bundle(
+            state_provider,
+            harness.chain_spec(),
+            parsed_bundle,
+            &header,
+            header.parent_beacon_block_root(),
+            None,
+            L1BlockInfo::default(),
+        );
+
+        assert!(result.is_err(), "Nonce exceeding MAX_NONCE_AHEAD should fail");
+        assert!(
+            result.unwrap_err().to_string().contains("exceeds max allowed"),
+            "Expected max nonce error"
+        );
+
+        Ok(())
+    }
+
+    /// Verifies that the base fee is capped at `MIN_BASEFEE` for simulation.
+    ///
+    /// The test genesis produces a next-block base fee of ~980M wei. A transaction with
+    /// `max_fee_per_gas` at the `MIN_BASEFEE` floor (5M wei) would normally be rejected,
+    /// but `meter_bundle` caps the base fee so simulation succeeds.
+    #[tokio::test]
+    async fn meter_bundle_caps_basefee_at_minimum() -> eyre::Result<()> {
+        let harness = TestHarness::new().await?;
+        let latest = harness.latest_block();
+        let header = latest.sealed_header().clone();
+
+        let to = Address::random();
+        let signed_tx = TransactionBuilder::default()
+            .signer(Account::Alice.signer_b256())
+            .chain_id(harness.chain_id())
+            .nonce(0)
+            .to(to)
+            .value(1_000)
+            .gas_limit(21_000)
+            .max_fee_per_gas(MIN_BASEFEE as u128) // At the floor, below the ~980M on-chain base fee
+            .max_priority_fee_per_gas(0)
+            .into_eip1559();
+
+        let tx = OpTransactionSigned::Eip1559(
+            signed_tx.as_eip1559().expect("eip1559 transaction").clone(),
+        );
+
+        let state_provider = harness
+            .blockchain_provider()
+            .state_by_block_hash(latest.hash())
+            .context("getting state provider")?;
+
+        let parsed_bundle = create_parsed_bundle(vec![tx])?;
+
+        let result = meter_bundle(
+            state_provider,
+            harness.chain_spec(),
+            parsed_bundle,
+            &header,
+            header.parent_beacon_block_root(),
+            None,
+            L1BlockInfo::default(),
+        );
+
+        assert!(
+            result.is_ok(),
+            "Transaction with max_fee_per_gas below base fee but at least MIN_BASEFEE should succeed: {:?}",
+            result.err()
+        );
+
+        let output = result.unwrap();
+        assert_eq!(output.results.len(), 1);
+        assert_eq!(output.total_gas_used, 21_000);
 
         Ok(())
     }

--- a/crates/client/metering/src/transaction.rs
+++ b/crates/client/metering/src/transaction.rs
@@ -3,21 +3,12 @@ use alloy_eips::Encodable2718;
 use alloy_primitives::U256;
 use base_revm::{L1BlockInfo, OpSpecId};
 use derive_more::Display;
-use reth_primitives_traits::{Account, Bytecode};
+use reth_primitives_traits::Account;
 use tracing::warn;
 
 /// Errors that can occur when validating a transaction.
 #[derive(Debug, PartialEq, Eq, Display)]
 pub enum TxValidationError {
-    /// Signer account has non-EIP-7702 bytecode (i.e., it's a contract, not an EOA)
-    #[display("Signer account has bytecode that is not EIP-7702 delegation")]
-    SignerAccountHasBytecode,
-    /// EIP-7702 transaction has empty authorization list
-    #[display("EIP-7702 transaction has empty authorization list")]
-    AuthorizationListIsEmpty,
-    /// Transaction nonce is too low
-    #[display("Transaction nonce: {_0} is too low, account nonce: {_1}")]
-    TransactionNonceTooLow(u64, u64),
     /// Insufficient funds for transfer
     #[display("Insufficient funds for transfer: {_0}, account balance: {_1}")]
     InsufficientFundsForTransfer(U256, U256),
@@ -27,9 +18,6 @@ pub enum TxValidationError {
 }
 
 /// Helper function to validate a transaction. A valid transaction must satisfy the following criteria:
-/// - The transaction is not EIP-4844
-/// - If the account has bytecode, it MUST be EIP-7702 bytecode
-/// - The transaction's nonce is the latest
 /// - The transaction's execution cost is less than the account's balance
 /// - The transaction's L1 gas cost is less than the account's balance
 ///   
@@ -37,30 +25,10 @@ pub enum TxValidationError {
 /// which only includes Legacy, Eip2930, Eip1559, Eip7702, and Deposit.
 pub fn validate_tx<T: Transaction + Encodable2718>(
     account: Account,
-    sender_code: Option<&Bytecode>,
     txn: &Recovered<T>,
     l1_block_info: &mut L1BlockInfo,
 ) -> Result<(), TxValidationError> {
     let data = txn.encoded_2718();
-
-    // If an account has bytecode, it MUST be EIP-7702 bytecode
-    if let Some(bytecode) = sender_code
-        && !bytecode.is_eip7702()
-    {
-        return Err(TxValidationError::SignerAccountHasBytecode);
-    }
-
-    // If tx is 7702 type, it needs a valid authorization list
-    // https://github.com/paradigmxyz/reth/blob/68e4ff1f7d9f5b40bc02ba7433077dcba0456783/crates/transaction-pool/src/validate/eth.rs#L476
-    if txn.is_eip7702() && txn.authorization_list().is_none_or(|l| l.is_empty()) {
-        return Err(TxValidationError::AuthorizationListIsEmpty);
-    }
-
-    // Return error if tx nonce is not equal to or greater than the latest on chain
-    // https://github.com/paradigmxyz/reth/blob/a047a055ab996f85a399f5cfb2fe15e350356546/crates/transaction-pool/src/validate/eth.rs#L611
-    if txn.nonce() < account.nonce {
-        return Err(TxValidationError::TransactionNonceTooLow(txn.nonce(), account.nonce));
-    }
 
     // For EIP-1559 transactions: `max_fee_per_gas * gas_limit + tx_value`.
     let max_fee = txn.max_fee_per_gas().saturating_mul(txn.gas_limit() as u128);
@@ -86,17 +54,13 @@ pub fn validate_tx<T: Transaction + Encodable2718>(
 
 #[cfg(test)]
 mod tests {
-    use std::sync::Arc;
-
     use alloy_consensus::{
-        SignableTransaction, Transaction, TxEip1559, TxEip7702, transaction::SignerRecoverable,
+        SignableTransaction, Transaction, TxEip1559, transaction::SignerRecoverable,
     };
-    use alloy_eips::eip7702::Authorization;
-    use alloy_primitives::{Address, Bytes, U256, bytes};
+    use alloy_primitives::{Address, U256, bytes};
     use base_alloy_consensus::OpTxEnvelope;
     use base_alloy_network::TxSignerSync;
-    use base_node_runner::test_utils::{Account as BaseAccount, SignerSync};
-    use revm_bytecode::eip7702::Eip7702Bytecode;
+    use base_node_runner::test_utils::Account as BaseAccount;
 
     use super::*;
 
@@ -104,173 +68,8 @@ mod tests {
         Account { balance, nonce, bytecode_hash: None }
     }
 
-    fn create_eip7702_bytecode() -> Bytecode {
-        Bytecode(revm_bytecode::Bytecode::Eip7702(Arc::new(
-            Eip7702Bytecode::new(Address::random()),
-        )))
-    }
-
-    fn create_contract_bytecode() -> Bytecode {
-        Bytecode::new_raw(Bytes::from_static(&[0x60, 0x80, 0x60, 0x40, 0x52]))
-    }
-
     fn create_l1_block_info() -> L1BlockInfo {
         L1BlockInfo::default()
-    }
-
-    fn create_signed_authorization(
-        chain_id: u64,
-        contract_address: Address,
-        nonce: u64,
-        account: &BaseAccount,
-    ) -> alloy_eips::eip7702::SignedAuthorization {
-        let auth =
-            Authorization { chain_id: U256::from(chain_id), address: contract_address, nonce };
-        let signature = account.signer().sign_hash_sync(&auth.signature_hash()).unwrap();
-        auth.into_signed(signature)
-    }
-
-    #[test]
-    fn test_valid_tx_no_bytecode() {
-        // Create a sample EIP-1559 transaction
-        let signer = BaseAccount::Alice.signer();
-        let mut tx = TxEip1559 {
-            chain_id: 1,
-            nonce: 0,
-            gas_limit: 21000,
-            max_fee_per_gas: 20000000000u128,
-            max_priority_fee_per_gas: 1000000000u128,
-            to: Address::random().into(),
-            value: U256::from(10000000000000u128),
-            access_list: Default::default(),
-            input: bytes!(""),
-        };
-
-        let account = create_account(0, U256::from(1000000000000000000u128));
-        let mut l1_block_info = create_l1_block_info();
-
-        let signature = signer.sign_transaction_sync(&mut tx).unwrap();
-        let envelope = OpTxEnvelope::Eip1559(tx.into_signed(signature));
-        let recovered_tx = envelope.try_into_recovered().unwrap();
-        assert!(validate_tx(account, None, &recovered_tx, &mut l1_block_info).is_ok());
-    }
-
-    #[test]
-    fn test_valid_eip1559_tx_from_delegated_account() {
-        let signer = BaseAccount::Alice.signer();
-        let mut tx = TxEip1559 {
-            chain_id: 1,
-            nonce: 0,
-            gas_limit: 21000,
-            max_fee_per_gas: 20000000000u128,
-            max_priority_fee_per_gas: 1000000000u128,
-            to: Address::random().into(),
-            value: U256::from(10000000000000u128),
-            access_list: Default::default(),
-            input: bytes!(""),
-        };
-
-        let account = create_account(0, U256::from(1000000000000000000u128));
-        let eip7702_code = create_eip7702_bytecode();
-        let mut l1_block_info = create_l1_block_info();
-
-        let signature = signer.sign_transaction_sync(&mut tx).unwrap();
-        let envelope = OpTxEnvelope::Eip1559(tx.into_signed(signature));
-        let recovered_tx = envelope.try_into_recovered().unwrap();
-        assert!(
-            validate_tx(account, Some(&eip7702_code), &recovered_tx, &mut l1_block_info).is_ok()
-        );
-    }
-
-    #[test]
-    fn test_valid_7702_tx_from_delegated_account() {
-        let signer = BaseAccount::Alice.signer();
-        let delegate_to = Address::random();
-        let authorization = create_signed_authorization(1, delegate_to, 0, &BaseAccount::Alice);
-
-        let mut tx = TxEip7702 {
-            chain_id: 1,
-            nonce: 0,
-            gas_limit: 21000,
-            max_fee_per_gas: 20000000000u128,
-            max_priority_fee_per_gas: 1000000000u128,
-            to: Address::random(),
-            value: U256::from(10000000000000u128),
-            authorization_list: vec![authorization],
-            access_list: Default::default(),
-            input: bytes!(""),
-        };
-
-        let account = create_account(0, U256::from(1000000000000000000u128));
-        let eip7702_code = create_eip7702_bytecode();
-        let mut l1_block_info = create_l1_block_info();
-
-        let signature = signer.sign_transaction_sync(&mut tx).unwrap();
-        let envelope = OpTxEnvelope::Eip7702(tx.into_signed(signature));
-        let recovered_tx = envelope.try_into_recovered().unwrap();
-        assert!(
-            validate_tx(account, Some(&eip7702_code), &recovered_tx, &mut l1_block_info).is_ok()
-        );
-    }
-
-    #[test]
-    fn test_err_signer_has_contract_bytecode() {
-        let signer = BaseAccount::Alice.signer();
-
-        let mut tx = TxEip1559 {
-            chain_id: 1,
-            nonce: 0,
-            gas_limit: 21000,
-            max_fee_per_gas: 20000000000u128,
-            max_priority_fee_per_gas: 1000000000u128,
-            to: Address::random().into(),
-            value: U256::from(10000000000000u128),
-            access_list: Default::default(),
-            input: bytes!(""),
-        };
-
-        let account = create_account(0, U256::from(1000000000000000000u128));
-        let contract_code = create_contract_bytecode();
-        let mut l1_block_info = create_l1_block_info();
-
-        let signature = signer.sign_transaction_sync(&mut tx).unwrap();
-        let envelope = OpTxEnvelope::Eip1559(tx.into_signed(signature));
-        let recovered_tx = envelope.try_into_recovered().unwrap();
-
-        assert_eq!(
-            validate_tx(account, Some(&contract_code), &recovered_tx, &mut l1_block_info),
-            Err(TxValidationError::SignerAccountHasBytecode)
-        );
-    }
-
-    #[test]
-    fn test_err_tx_nonce_too_low() {
-        let signer = BaseAccount::Alice.signer();
-        let mut tx = TxEip1559 {
-            chain_id: 1,
-            nonce: 0,
-            gas_limit: 21000,
-            max_fee_per_gas: 20000000000u128,
-            max_priority_fee_per_gas: 1000000000u128,
-            to: Address::random().into(),
-            value: U256::from(10000000000000u128),
-            access_list: Default::default(),
-            input: bytes!(""),
-        };
-
-        let account = create_account(1, U256::from(1000000000000000000u128));
-        let mut l1_block_info = create_l1_block_info();
-
-        let tx_nonce = tx.nonce();
-        let nonce = account.nonce;
-
-        let signature = signer.sign_transaction_sync(&mut tx).unwrap();
-        let envelope = OpTxEnvelope::Eip1559(tx.into_signed(signature));
-        let recovered_tx = envelope.try_into_recovered().unwrap();
-        assert_eq!(
-            validate_tx(account, None, &recovered_tx, &mut l1_block_info),
-            Err(TxValidationError::TransactionNonceTooLow(tx_nonce, nonce))
-        );
     }
 
     #[test]
@@ -299,7 +98,7 @@ mod tests {
         let envelope = OpTxEnvelope::Eip1559(tx.into_signed(signature));
         let recovered_tx = envelope.try_into_recovered().unwrap();
         assert_eq!(
-            validate_tx(account, None, &recovered_tx, &mut l1_block_info),
+            validate_tx(account, &recovered_tx, &mut l1_block_info),
             Err(TxValidationError::InsufficientFundsForTransfer(txn_cost, account_balance))
         );
     }
@@ -335,68 +134,34 @@ mod tests {
         let recovered_tx = envelope.try_into_recovered().unwrap();
 
         assert_eq!(
-            validate_tx(account, None, &recovered_tx, &mut l1_block_info),
+            validate_tx(account, &recovered_tx, &mut l1_block_info),
             Err(TxValidationError::InsufficientFundsForL1Gas(l1_cost, account_balance))
         );
     }
 
     #[test]
-    fn test_valid_7702_tx_from_eoa() {
+    fn test_valid_tx() {
         let signer = BaseAccount::Alice.signer();
-        let delegate_to = Address::random();
-        let authorization = create_signed_authorization(1, delegate_to, 0, &BaseAccount::Alice);
-
-        let mut tx = TxEip7702 {
+        let mut tx = TxEip1559 {
             chain_id: 1,
             nonce: 0,
             gas_limit: 21000,
             max_fee_per_gas: 20000000000u128,
-            max_priority_fee_per_gas: 1000000000u128,
-            to: Address::random(),
+            max_priority_fee_per_gas: 10000000000000u128,
+            to: Address::random().into(),
             value: U256::from(10000000000000u128),
-            authorization_list: vec![authorization],
             access_list: Default::default(),
             input: bytes!(""),
         };
 
-        let account = create_account(0, U256::from(1000000000000000000u128));
+        let account_balance = U256::from(1000000000000000000u128);
+        let account = create_account(0, account_balance);
         let mut l1_block_info = create_l1_block_info();
 
         let signature = signer.sign_transaction_sync(&mut tx).unwrap();
-        let envelope = OpTxEnvelope::Eip7702(tx.into_signed(signature));
-        let recovered_tx = envelope.try_into_recovered().unwrap();
-        assert!(
-            validate_tx(account, None, &recovered_tx, &mut l1_block_info).is_ok(),
-            "EOA setting up delegation for the first time should be valid"
-        );
-    }
-
-    #[test]
-    fn test_err_7702_tx_with_empty_authorization_list() {
-        let signer = BaseAccount::Alice.signer();
-        let mut tx = TxEip7702 {
-            chain_id: 1,
-            nonce: 0,
-            gas_limit: 21000,
-            max_fee_per_gas: 20000000000u128,
-            max_priority_fee_per_gas: 1000000000u128,
-            to: Address::random(),
-            value: U256::from(10000000000000u128),
-            authorization_list: vec![],
-            access_list: Default::default(),
-            input: bytes!(""),
-        };
-
-        let account = create_account(0, U256::from(1000000000000000000u128));
-        let mut l1_block_info = create_l1_block_info();
-
-        let signature = signer.sign_transaction_sync(&mut tx).unwrap();
-        let envelope = OpTxEnvelope::Eip7702(tx.into_signed(signature));
+        let envelope = OpTxEnvelope::Eip1559(tx.into_signed(signature));
         let recovered_tx = envelope.try_into_recovered().unwrap();
 
-        assert_eq!(
-            validate_tx(account, None, &recovered_tx, &mut l1_block_info),
-            Err(TxValidationError::AuthorizationListIsEmpty)
-        );
+        assert_eq!(validate_tx(account, &recovered_tx, &mut l1_block_info), Ok(()));
     }
 }


### PR DESCRIPTION
## Summary

Backport of two metering fixes from main onto `releases/v0.6.0`:

- **#1045** (`259b9c6c`) — Remove nonce and 7702 checks from `validate_tx`, keeping only balance validation
- **#1049** (`5d2213e6`) — Override sender nonces in simulation state, cap base fee at `MIN_BASEFEE` (5M wei), read account info from State cache for pending flashblocks balances, add `MAX_NONCE_AHEAD` (10,000) safety cap

Both cherry-picks applied cleanly. All 31 tests pass, clippy clean.

## Test plan

- [x] `cargo test -p base-metering` — 31 passed
- [x] `cargo clippy -p base-metering --all-targets --profile ci -- -D warnings` — clean