### PR TITLE
feat(ci): add label-maintainer-issues job to stale workflow

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -8,7 +8,37 @@ permissions:
   contents: read
 
 jobs:
+  label-maintainer-issues:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@95d9a5deda9de15063e7595e9719c11c38c90ae2 # v2.13.2
+        with:
+          egress-policy: audit
+
+      - name: Exempt core maintainer issues from stale
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+        run: |
+          MAINTAINERS="refcell danyalprout cody-wang-cb haardikk21 meyer9 wlawt niran mw2000"
+          for maintainer in $MAINTAINERS; do
+            gh issue list \
+              --repo "$REPO" \
+              --author "$maintainer" \
+              --state open \
+              --json number \
+              --jq '.[].number' | while read -r issue_num; do
+                gh issue edit "$issue_num" \
+                  --repo "$REPO" \
+                  --add-label "M-prevent-stale" 2>/dev/null || true
+            done
+          done
+
   stale:
+    needs: label-maintainer-issues
     runs-on: ubuntu-latest
     permissions:
       actions: write
@@ -28,7 +58,5 @@ jobs:
           stale-pr-message: 'This pull request has been automatically marked as stale because it has not had recent activity. It will be closed if no further activity occurs. Thank you for your contributions.'
           close-issue-message: 'This issue was closed because it has been inactive for 5 days since being marked as stale.'
           close-pr-message: 'This pull request was closed because it has been inactive for 5 days since being marked as stale.'
-          exempt-issue-labels: keep-open
+          exempt-issue-labels: 'keep-open,M-prevent-stale'
           exempt-pr-labels: keep-open
-          exempt-issue-authors: refcell,danyalprout,cody-wang-cb,haardikk21,meyer9,wlawt,niran,mw2000
-          exempt-authors: refcell,danyalprout,cody-wang-cb,haardikk21,meyer9,wlawt,niran,mw2000


### PR DESCRIPTION
Adds a job that automatically labels open issues from core maintainers with M-prevent-stale, exempting them from the stale bot.