### PR TITLE
chore(flashblocks): feature flag cached execution

### DIFF
--- a/bin/node/src/cli.rs
+++ b/bin/node/src/cli.rs
@@ -41,12 +41,60 @@ pub struct Args {
     /// Enable metering RPC for transaction bundle simulation
     #[arg(long = "enable-metering", value_name = "ENABLE_METERING")]
     pub enable_metering: bool,
+
+    /// Enable flashblocks cached execution in the engine validator.
+    ///
+    /// This is disabled by default until cached execution has been further validated in
+    /// production conditions.
+    #[arg(
+        long = "enable-flashblocks-cached-execution",
+        env = "BASE_NODE_ENABLE_FLASHBLOCKS_CACHED_EXECUTION",
+        default_value = "false",
+        value_name = "ENABLE_FLASHBLOCKS_CACHED_EXECUTION"
+    )]
+    pub enable_flashblocks_cached_execution: bool,
 }
 
 impl From<&Args> for Option<FlashblocksConfig> {
     fn from(args: &Args) -> Self {
-        args.flashblocks_url
-            .clone()
-            .map(|url| FlashblocksConfig::new(url, args.max_pending_blocks_depth))
+        args.flashblocks_url.clone().map(|url| {
+            FlashblocksConfig::new(url, args.max_pending_blocks_depth)
+                .with_cached_execution_enabled(args.enable_flashblocks_cached_execution)
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn args_with_flashblocks_url() -> Args {
+        Args {
+            rollup_args: RollupArgs::default(),
+            flashblocks_url: Some(Url::parse("ws://localhost:12345").unwrap()),
+            max_pending_blocks_depth: 3,
+            enable_transaction_tracing: false,
+            enable_transaction_tracing_logs: false,
+            enable_metering: false,
+            enable_flashblocks_cached_execution: false,
+        }
+    }
+
+    #[test]
+    fn cached_execution_flag_defaults_to_disabled() {
+        let args = args_with_flashblocks_url();
+        let config: Option<FlashblocksConfig> = (&args).into();
+        let config = config.expect("flashblocks config should be created");
+        assert!(!config.cached_execution_enabled);
+    }
+
+    #[test]
+    fn cached_execution_flag_maps_to_flashblocks_config() {
+        let mut args = args_with_flashblocks_url();
+        args.enable_flashblocks_cached_execution = true;
+
+        let config: Option<FlashblocksConfig> = (&args).into();
+        let config = config.expect("flashblocks config should be created");
+        assert!(config.cached_execution_enabled);
     }
 }

--- a/crates/client/flashblocks-node/src/extension.rs
+++ b/crates/client/flashblocks-node/src/extension.rs
@@ -36,20 +36,26 @@ impl BaseNodeExtension for FlashblocksExtension {
             return hooks;
         };
 
+        let enable_cached_execution = cfg.cached_execution_enabled;
         let state = cfg.state;
         let mut subscriber = FlashblocksSubscriber::new(Arc::clone(&state), cfg.websocket_url);
 
         let state_for_canonical = Arc::clone(&state);
         let state_for_rpc = Arc::clone(&state);
-        let state_for_engine = Arc::clone(&state);
         let state_for_start = state;
 
-        let hooks = hooks.add_add_ons_hook(move |add_ons| {
-            add_ons.with_engine_validator(
-                BaseEngineValidatorBuilder::new(OpEngineValidatorBuilder::default())
-                    .with_flashblocks_state(state_for_engine),
-            )
-        });
+        let hooks = if enable_cached_execution {
+            let state_for_engine = Arc::clone(&state_for_start);
+            hooks.add_add_ons_hook(move |add_ons| {
+                add_ons.with_engine_validator(
+                    BaseEngineValidatorBuilder::new(OpEngineValidatorBuilder::default())
+                        .with_flashblocks_state(state_for_engine),
+                )
+            })
+        } else {
+            info!(message = "flashblocks cached execution is disabled");
+            hooks
+        };
 
         // Start state processor, subscriber, and canonical subscription after node is started
         let hooks = hooks.add_node_started_hook(move |ctx| {

--- a/crates/execution/flashblocks/src/config.rs
+++ b/crates/execution/flashblocks/src/config.rs
@@ -11,6 +11,8 @@ pub struct FlashblocksConfig {
     pub websocket_url: Url,
     /// Maximum number of pending flashblocks to retain in memory.
     pub max_pending_blocks_depth: u64,
+    /// Whether to enable cached execution when validating blocks against flashblocks.
+    pub cached_execution_enabled: bool,
     /// Shared Flashblocks state.
     pub state: Arc<FlashblocksState>,
 }
@@ -19,6 +21,12 @@ impl FlashblocksConfig {
     /// Create a new Flashblocks configuration.
     pub fn new(websocket_url: Url, max_pending_blocks_depth: u64) -> Self {
         let state = Arc::new(FlashblocksState::new(max_pending_blocks_depth));
-        Self { websocket_url, max_pending_blocks_depth, state }
+        Self { websocket_url, max_pending_blocks_depth, cached_execution_enabled: false, state }
+    }
+
+    /// Set whether cached execution should be enabled in the engine validator.
+    pub fn with_cached_execution_enabled(mut self, enabled: bool) -> Self {
+        self.cached_execution_enabled = enabled;
+        self
     }
 }


### PR DESCRIPTION
## Summary
- add a `cached_execution_enabled` toggle to `FlashblocksConfig` defaulting to `false`
- add Base node CLI/env feature flag `--enable-flashblocks-cached-execution` / `BASE_NODE_ENABLE_FLASHBLOCKS_CACHED_EXECUTION`
- wire the flag into flashblocks config creation for the Base node
- gate engine-validator cached execution wiring in `FlashblocksExtension` behind the new flag
- add CLI unit tests to verify default-off behavior and flag mapping

## Testing
- cargo test -p base-reth-node
- cargo check -p base-flashblocks-node

Closes #1076
