### PR TITLE
feat(flashblocks): gate cached execution behind --flashblocks.cached-execution CLI flag

### DIFF
--- a/bin/node/src/cli.rs
+++ b/bin/node/src/cli.rs
@@ -27,6 +27,10 @@ pub struct Args {
     )]
     pub max_pending_blocks_depth: u64,
 
+    /// Enable cached execution via the flashblocks-aware engine validator.
+    #[arg(long = "flashblocks.cached-execution", requires = "flashblocks_url")]
+    pub flashblocks_cached_execution: bool,
+
     /// Enable transaction tracing for mempool-to-block timing analysis
     #[arg(long = "enable-transaction-tracing", value_name = "ENABLE_TRANSACTION_TRACING")]
     pub enable_transaction_tracing: bool,
@@ -45,8 +49,10 @@ pub struct Args {
 
 impl From<&Args> for Option<FlashblocksConfig> {
     fn from(args: &Args) -> Self {
-        args.flashblocks_url
-            .clone()
-            .map(|url| FlashblocksConfig::new(url, args.max_pending_blocks_depth))
+        args.flashblocks_url.clone().map(|url| {
+            let mut config = FlashblocksConfig::new(url, args.max_pending_blocks_depth);
+            config.cached_execution = args.flashblocks_cached_execution;
+            config
+        })
     }
 }

--- a/crates/client/flashblocks-node/src/extension.rs
+++ b/crates/client/flashblocks-node/src/extension.rs
@@ -41,15 +41,21 @@ impl BaseNodeExtension for FlashblocksExtension {
 
         let state_for_canonical = Arc::clone(&state);
         let state_for_rpc = Arc::clone(&state);
-        let state_for_engine = Arc::clone(&state);
         let state_for_start = state;
 
-        let hooks = hooks.add_add_ons_hook(move |add_ons| {
-            add_ons.with_engine_validator(
-                BaseEngineValidatorBuilder::new(OpEngineValidatorBuilder::default())
-                    .with_flashblocks_state(state_for_engine),
-            )
-        });
+        let hooks = if cfg.cached_execution {
+            info!(message = "Cached execution is enabled");
+            let state_for_engine = Arc::clone(&state_for_start);
+            hooks.add_add_ons_hook(move |add_ons| {
+                add_ons.with_engine_validator(
+                    BaseEngineValidatorBuilder::new(OpEngineValidatorBuilder::default())
+                        .with_flashblocks_state(state_for_engine),
+                )
+            })
+        } else {
+            info!(message = "Cached execution is disabled");
+            hooks
+        };
 
         // Start state processor, subscriber, and canonical subscription after node is started
         let hooks = hooks.add_node_started_hook(move |ctx| {

--- a/crates/execution/flashblocks/src/config.rs
+++ b/crates/execution/flashblocks/src/config.rs
@@ -11,6 +11,8 @@ pub struct FlashblocksConfig {
     pub websocket_url: Url,
     /// Maximum number of pending flashblocks to retain in memory.
     pub max_pending_blocks_depth: u64,
+    /// Whether to enable cached execution via the flashblocks-aware engine validator.
+    pub cached_execution: bool,
     /// Shared Flashblocks state.
     pub state: Arc<FlashblocksState>,
 }
@@ -19,6 +21,6 @@ impl FlashblocksConfig {
     /// Create a new Flashblocks configuration.
     pub fn new(websocket_url: Url, max_pending_blocks_depth: u64) -> Self {
         let state = Arc::new(FlashblocksState::new(max_pending_blocks_depth));
-        Self { websocket_url, max_pending_blocks_depth, state }
+        Self { websocket_url, max_pending_blocks_depth, cached_execution: false, state }
     }
 }


### PR DESCRIPTION
## Summary

- Adds a `--flashblocks.cached-execution` CLI flag to the node binary to opt-in to the flashblocks-aware engine validator.
- The `add_add_ons_hook` that installs `BaseEngineValidatorBuilder` with flashblocks state is now only applied when this flag is set.
- Adds a `cached_execution` field to `FlashblocksConfig`, defaulting to `false`.