### PR TITLE
feat(builder): skip transactions without metering data during wait period

### DIFF
--- a/bin/builder/src/cli.rs
+++ b/bin/builder/src/cli.rs
@@ -93,6 +93,11 @@ pub struct Args {
     #[arg(long = "builder.max-uncompressed-block-size")]
     pub max_uncompressed_block_size: Option<u64>,
 
+    /// Duration in milliseconds to wait for metering data before including a transaction.
+    /// Transactions younger than this without metering data will be skipped.
+    #[arg(long = "builder.metering-wait-duration-ms")]
+    pub metering_wait_duration_ms: Option<u64>,
+
     /// Buffer size for tx data store (LRU eviction when full)
     #[arg(long = "builder.tx-data-store-buffer-size", default_value = "10000")]
     pub tx_data_store_buffer_size: usize,
@@ -130,6 +135,7 @@ impl Default for Args {
             extra_block_deadline_secs: 20,
             enable_resource_metering: false,
             max_uncompressed_block_size: None,
+            metering_wait_duration_ms: None,
             tx_data_store_buffer_size: 10000,
             sampling_ratio: 100,
             flashblocks: FlashblocksArgs::default(),
@@ -168,6 +174,7 @@ impl Args {
             block_state_root_time_budget_us: self.block_state_root_time_budget_us,
             execution_metering_mode: self.execution_metering_mode,
             max_uncompressed_block_size: self.max_uncompressed_block_size,
+            metering_wait_duration: self.metering_wait_duration_ms.map(Duration::from_millis),
             metering_provider,
         })
     }
@@ -270,6 +277,19 @@ mod tests {
 
         let result = config.metering_provider.get(&tx_hash);
         assert_eq!(result.unwrap().total_execution_time_us, 500);
+    }
+
+    #[rstest]
+    #[case::some_duration(Some(500), Some(Duration::from_millis(500)))]
+    #[case::none(None, None)]
+    #[case::zero(Some(0), Some(Duration::from_millis(0)))]
+    fn metering_wait_duration_maps_correctly(
+        #[case] input: Option<u64>,
+        #[case] expected: Option<Duration>,
+    ) {
+        let args = Args { metering_wait_duration_ms: input, ..Default::default() };
+        let config = convert(args);
+        assert_eq!(config.metering_wait_duration, expected);
     }
 
     #[test]

--- a/crates/builder/core/src/config.rs
+++ b/crates/builder/core/src/config.rs
@@ -63,6 +63,10 @@ pub struct BuilderConfig {
     /// Maximum cumulative uncompressed (EIP-2718 encoded) block size in bytes.
     pub max_uncompressed_block_size: Option<u64>,
 
+    /// Duration to wait for metering data before including a transaction.
+    /// Transactions younger than this without metering data will be skipped.
+    pub metering_wait_duration: Option<Duration>,
+
     /// Resource metering provider
     pub metering_provider: SharedMeteringProvider,
 }
@@ -95,6 +99,7 @@ impl core::fmt::Debug for BuilderConfig {
             .field("block_state_root_time_budget_us", &self.block_state_root_time_budget_us)
             .field("execution_metering_mode", &self.execution_metering_mode)
             .field("max_uncompressed_block_size", &self.max_uncompressed_block_size)
+            .field("metering_wait_duration", &self.metering_wait_duration)
             .field("metering_provider", &self.metering_provider)
             .finish()
     }
@@ -118,6 +123,7 @@ impl Default for BuilderConfig {
             block_state_root_time_budget_us: None,
             execution_metering_mode: ExecutionMeteringMode::Off,
             max_uncompressed_block_size: None,
+            metering_wait_duration: None,
             metering_provider: Arc::new(NoopMeteringProvider),
         }
     }
@@ -171,6 +177,16 @@ impl BuilderConfig {
         max_uncompressed_block_size: Option<u64>,
     ) -> Self {
         self.max_uncompressed_block_size = max_uncompressed_block_size;
+        self
+    }
+
+    /// Sets the metering wait duration.
+    #[must_use]
+    pub const fn with_metering_wait_duration(
+        mut self,
+        metering_wait_duration: Option<Duration>,
+    ) -> Self {
+        self.metering_wait_duration = metering_wait_duration;
         self
     }
 }

--- a/crates/builder/core/src/execution.rs
+++ b/crates/builder/core/src/execution.rs
@@ -175,6 +175,10 @@ pub enum TxnExecutionError {
     /// Transaction gas usage exceeds configured maximum.
     #[error("max gas usage exceeded")]
     MaxGasUsageExceeded,
+
+    /// Metering data has not yet arrived for this transaction.
+    #[error("metering data pending")]
+    MeteringDataPending,
 }
 
 impl From<ExecutionMeteringLimitExceeded> for TxnExecutionError {

--- a/crates/builder/core/src/flashblocks/context.rs
+++ b/crates/builder/core/src/flashblocks/context.rs
@@ -705,7 +705,7 @@ impl OpPayloadBuilderCtx {
                 let tx_age_ms = now_ms.saturating_sub(tx_received_at_ms);
                 if tx_age_ms < wait_duration.as_millis() {
                     log_txn(Err(TxnExecutionError::MeteringDataPending));
-                    self.metrics.metering_data_pending_skip.increment(1);
+                    BuilderMetrics::metering_data_pending_skip().increment(1);
                     best_txs.mark_invalid(tx.signer(), tx.nonce());
                     continue;
                 }

--- a/crates/builder/core/src/flashblocks/context.rs
+++ b/crates/builder/core/src/flashblocks/context.rs
@@ -1,5 +1,8 @@
 use core::fmt::Debug;
-use std::{sync::Arc, time::Instant};
+use std::{
+    sync::Arc,
+    time::{Instant, SystemTime},
+};
 
 use alloy_consensus::{Eip658Value, Transaction};
 use alloy_eips::{Encodable2718, Typed2718};
@@ -15,7 +18,7 @@ use base_execution_evm::{OpEvmConfig, OpNextBlockEnvAttributes};
 use base_execution_payload_builder::{OpPayloadBuilderAttributes, error::OpPayloadBuilderError};
 use base_execution_primitives::OpTransactionSigned;
 use base_revm::{L1BlockInfo, OpSpecId};
-use base_txpool::{BundleTransaction, estimated_da_size::DataAvailabilitySized};
+use base_txpool::{BundleTransaction, TimestampedTransaction, estimated_da_size::DataAvailabilitySized};
 use reth_basic_payload_builder::PayloadConfig;
 use reth_chainspec::{EthChainSpec, EthereumHardforks};
 use reth_evm::{
@@ -47,6 +50,7 @@ fn record_rejected_tx_priority_fee(reason: &TxnExecutionError, priority_fee: f64
         TxnExecutionError::BlockUncompressedSizeExceeded { .. } => {
             "block_uncompressed_size_exceeded"
         }
+        TxnExecutionError::MeteringDataPending => "metering_data_pending",
         TxnExecutionError::ExecutionMeteringLimitExceeded(inner) => match inner {
             ExecutionMeteringLimitExceeded::TransactionExecutionTime(_, _) => {
                 "tx_execution_time_exceeded"
@@ -657,6 +661,7 @@ impl OpPayloadBuilderCtx {
             }
 
             let tx_da_size = tx.estimated_da_size();
+            let tx_received_at_ms = tx.received_at();
             let tx = tx.into_consensus();
             let tx_hash = tx.tx_hash();
             let tx_uncompressed_size = tx.encode_2718_len() as u64;
@@ -678,6 +683,23 @@ impl OpPayloadBuilderCtx {
             num_txs_considered += 1;
 
             let resource_usage = self.builder_config.metering_provider.get(&tx_hash);
+
+            // Skip transactions that are too young and don't have metering data yet
+            if resource_usage.is_none()
+                && let Some(wait_duration) = self.builder_config.metering_wait_duration
+            {
+                    let now_ms = SystemTime::now()
+                        .duration_since(SystemTime::UNIX_EPOCH)
+                        .map(|d| d.as_millis())
+                        .unwrap_or(0);
+                    let tx_age_ms = now_ms.saturating_sub(tx_received_at_ms);
+                    if tx_age_ms < wait_duration.as_millis() {
+                        log_txn(Err(TxnExecutionError::MeteringDataPending));
+                        self.metrics.metering_data_pending_skip.increment(1);
+                        best_txs.mark_invalid(tx.signer(), tx.nonce());
+                        continue;
+                    }
+                }
 
             // Extract predicted execution and state root times from metering data
             let predicted_execution_time_us =

--- a/crates/builder/core/src/flashblocks/context.rs
+++ b/crates/builder/core/src/flashblocks/context.rs
@@ -685,21 +685,22 @@ impl OpPayloadBuilderCtx {
             let resource_usage = self.builder_config.metering_provider.get(&tx_hash);
 
             // Skip transactions that are too young and don't have metering data yet
-            if resource_usage.is_none()
+            if self.builder_config.metering_provider.is_enabled()
+                && resource_usage.is_none()
                 && let Some(wait_duration) = self.builder_config.metering_wait_duration
             {
-                    let now_ms = SystemTime::now()
-                        .duration_since(SystemTime::UNIX_EPOCH)
-                        .map(|d| d.as_millis())
-                        .unwrap_or(0);
-                    let tx_age_ms = now_ms.saturating_sub(tx_received_at_ms);
-                    if tx_age_ms < wait_duration.as_millis() {
-                        log_txn(Err(TxnExecutionError::MeteringDataPending));
-                        self.metrics.metering_data_pending_skip.increment(1);
-                        best_txs.mark_invalid(tx.signer(), tx.nonce());
-                        continue;
-                    }
+                let now_ms = SystemTime::now()
+                    .duration_since(SystemTime::UNIX_EPOCH)
+                    .map(|d| d.as_millis())
+                    .unwrap_or(0);
+                let tx_age_ms = now_ms.saturating_sub(tx_received_at_ms);
+                if tx_age_ms < wait_duration.as_millis() {
+                    log_txn(Err(TxnExecutionError::MeteringDataPending));
+                    self.metrics.metering_data_pending_skip.increment(1);
+                    best_txs.mark_invalid(tx.signer(), tx.nonce());
+                    continue;
                 }
+            }
 
             // Extract predicted execution and state root times from metering data
             let predicted_execution_time_us =

--- a/crates/builder/core/src/flashblocks/context.rs
+++ b/crates/builder/core/src/flashblocks/context.rs
@@ -18,7 +18,9 @@ use base_execution_evm::{OpEvmConfig, OpNextBlockEnvAttributes};
 use base_execution_payload_builder::{OpPayloadBuilderAttributes, error::OpPayloadBuilderError};
 use base_execution_primitives::OpTransactionSigned;
 use base_revm::{L1BlockInfo, OpSpecId};
-use base_txpool::{BundleTransaction, TimestampedTransaction, estimated_da_size::DataAvailabilitySized};
+use base_txpool::{
+    BundleTransaction, TimestampedTransaction, estimated_da_size::DataAvailabilitySized,
+};
 use reth_basic_payload_builder::PayloadConfig;
 use reth_chainspec::{EthChainSpec, EthereumHardforks};
 use reth_evm::{
@@ -200,7 +202,8 @@ impl FlashblockDiagnostics {
             | TxnExecutionError::NonceTooLow
             | TxnExecutionError::InternalError(_)
             | TxnExecutionError::EvmError
-            | TxnExecutionError::MaxGasUsageExceeded => {
+            | TxnExecutionError::MaxGasUsageExceeded
+            | TxnExecutionError::MeteringDataPending => {
                 self.txs_rejected_other += 1;
             }
         }
@@ -1052,9 +1055,10 @@ mod tests {
         diag.record_rejection(&TxnExecutionError::SequencerTransaction);
         diag.record_rejection(&TxnExecutionError::NonceTooLow);
         diag.record_rejection(&TxnExecutionError::MaxGasUsageExceeded);
+        diag.record_rejection(&TxnExecutionError::MeteringDataPending);
 
-        assert_eq!(diag.txs_rejected_other, 3);
-        assert_eq!(diag.txs_rejected_total(), 3);
+        assert_eq!(diag.txs_rejected_other, 4);
+        assert_eq!(diag.txs_rejected_total(), 4);
     }
 
     #[test]

--- a/crates/builder/core/src/flashblocks/context.rs
+++ b/crates/builder/core/src/flashblocks/context.rs
@@ -122,6 +122,8 @@ pub struct FlashblockDiagnostics {
     pub txs_rejected_state_root_time: u64,
     /// Number rejected by uncompressed size limit.
     pub txs_rejected_uncompressed_size: u64,
+    /// Number skipped because metering data has not yet arrived.
+    pub txs_rejected_metering_data_pending: u64,
     /// Number rejected or skipped for other reasons.
     pub txs_rejected_other: u64,
     /// Minimum effective priority fee (tip per gas) among included transactions.
@@ -141,7 +143,7 @@ impl FlashblockDiagnostics {
     }
 
     /// Returns the rejection counts keyed by their metric/log reason labels.
-    pub const fn rejection_counts(&self) -> [(&'static str, u64); 7] {
+    pub const fn rejection_counts(&self) -> [(&'static str, u64); 8] {
         [
             ("gas_limit", self.txs_rejected_gas),
             ("da_size", self.txs_rejected_da),
@@ -149,6 +151,7 @@ impl FlashblockDiagnostics {
             ("execution_time", self.txs_rejected_execution_time),
             ("state_root_time", self.txs_rejected_state_root_time),
             ("uncompressed_size", self.txs_rejected_uncompressed_size),
+            ("metering_data_pending", self.txs_rejected_metering_data_pending),
             ("other", self.txs_rejected_other),
         ]
     }
@@ -161,7 +164,7 @@ impl FlashblockDiagnostics {
             .collect()
     }
 
-    /// Total number of rejected transactions across all limit types.
+    /// Total number of rejected or skipped transactions across all tracked categories.
     pub const fn txs_rejected_total(&self) -> u64 {
         self.txs_rejected_gas
             + self.txs_rejected_da
@@ -169,6 +172,7 @@ impl FlashblockDiagnostics {
             + self.txs_rejected_execution_time
             + self.txs_rejected_state_root_time
             + self.txs_rejected_uncompressed_size
+            + self.txs_rejected_metering_data_pending
             + self.txs_rejected_other
     }
 
@@ -198,12 +202,14 @@ impl FlashblockDiagnostics {
                     self.txs_rejected_state_root_time += 1;
                 }
             },
+            TxnExecutionError::MeteringDataPending => {
+                self.txs_rejected_metering_data_pending += 1;
+            }
             TxnExecutionError::SequencerTransaction
             | TxnExecutionError::NonceTooLow
             | TxnExecutionError::InternalError(_)
             | TxnExecutionError::EvmError
-            | TxnExecutionError::MaxGasUsageExceeded
-            | TxnExecutionError::MeteringDataPending => {
+            | TxnExecutionError::MaxGasUsageExceeded => {
                 self.txs_rejected_other += 1;
             }
         }
@@ -1044,6 +1050,7 @@ mod tests {
                 ("execution_time", 0),
                 ("state_root_time", 1),
                 ("uncompressed_size", 0),
+                ("metering_data_pending", 0),
                 ("other", 0),
             ]
         );
@@ -1057,7 +1064,8 @@ mod tests {
         diag.record_rejection(&TxnExecutionError::MaxGasUsageExceeded);
         diag.record_rejection(&TxnExecutionError::MeteringDataPending);
 
-        assert_eq!(diag.txs_rejected_other, 4);
+        assert_eq!(diag.txs_rejected_metering_data_pending, 1);
+        assert_eq!(diag.txs_rejected_other, 3);
         assert_eq!(diag.txs_rejected_total(), 4);
     }
 

--- a/crates/builder/core/src/metering.rs
+++ b/crates/builder/core/src/metering.rs
@@ -11,6 +11,11 @@ pub trait MeteringProvider: Debug + Send + Sync + 'static {
     /// Retrieves the metering data for a given transaction hash.
     fn get(&self, tx_hash: &TxHash) -> Option<MeterBundleResponse>;
 
+    /// Returns whether resource metering is currently enabled.
+    fn is_enabled(&self) -> bool {
+        false
+    }
+
     /// Inserts metering information for a transaction.
     fn insert(&self, _tx_hash: TxHash, _metering: MeterBundleResponse) {}
 

--- a/crates/builder/core/src/metrics.rs
+++ b/crates/builder/core/src/metrics.rs
@@ -301,6 +301,7 @@ mod tests {
             txs_included: 3,
             txs_rejected_gas: 2,
             txs_rejected_da: 1,
+            txs_rejected_metering_data_pending: 1,
             min_priority_fee: Some(200_000),
             ..Default::default()
         };
@@ -332,6 +333,9 @@ mod tests {
         ));
         assert!(rendered.contains(
             "base_builder_flashblock_rejections_total{flashblock_index=\"7\",reason=\"da_size\"} 1"
+        ));
+        assert!(rendered.contains(
+            "base_builder_flashblock_rejections_total{flashblock_index=\"7\",reason=\"metering_data_pending\"} 1"
         ));
         assert!(
             rendered.contains("base_builder_flashblock_txs_included_sum{flashblock_index=\"7\"} 3")

--- a/crates/builder/core/src/metrics.rs
+++ b/crates/builder/core/src/metrics.rs
@@ -98,6 +98,8 @@ base_metrics::define_metrics! {
     metering_unknown_transaction: counter,
     #[describe("Number of LRU evictions from MeteringStore")]
     metering_store_lru_evictions: counter,
+    #[describe("Transactions skipped because metering data has not yet arrived")]
+    metering_data_pending_skip: counter,
     #[describe("Transactions rejected by per-tx DA size limit")]
     tx_da_size_exceeded_total: counter,
     #[describe("Transactions rejected by block DA size limit")]

--- a/crates/builder/core/src/traits.rs
+++ b/crates/builder/core/src/traits.rs
@@ -32,14 +32,14 @@ impl<T> NodeBounds for T where
 /// Composite trait bound for a transaction pool compatible with the Base builder.
 pub trait PoolBounds:
     TransactionPool<
-        Transaction:
-            OpPooledTx<Consensus = OpTransactionSigned> + BundleTransaction + TimestampedTransaction,
+        Transaction: OpPooledTx<Consensus = OpTransactionSigned>
+                         + BundleTransaction
+                         + TimestampedTransaction,
     > + TransactionPoolExt
     + Unpin
     + 'static
 where
-    <Self as TransactionPool>::Transaction:
-        OpPooledTx + BundleTransaction + TimestampedTransaction,
+    <Self as TransactionPool>::Transaction: OpPooledTx + BundleTransaction + TimestampedTransaction,
 {
 }
 
@@ -47,13 +47,12 @@ impl<T> PoolBounds for T
 where
     T: TransactionPool<
             Transaction: OpPooledTx<Consensus = OpTransactionSigned>
-                + BundleTransaction
-                + TimestampedTransaction,
+                             + BundleTransaction
+                             + TimestampedTransaction,
         > + TransactionPoolExt
         + Unpin
         + 'static,
-    <Self as TransactionPool>::Transaction:
-        OpPooledTx + BundleTransaction + TimestampedTransaction,
+    <Self as TransactionPool>::Transaction: OpPooledTx + BundleTransaction + TimestampedTransaction,
 {
 }
 
@@ -77,16 +76,18 @@ impl<T> ClientBounds for T where
 /// Composite trait bound for payload transaction iterators used by the Base builder.
 pub trait PayloadTxsBounds:
     PayloadTransactions<
-    Transaction:
-        OpPooledTx<Consensus = OpTransactionSigned> + BundleTransaction + TimestampedTransaction,
+    Transaction: OpPooledTx<Consensus = OpTransactionSigned>
+                     + BundleTransaction
+                     + TimestampedTransaction,
 >
 {
 }
 
 impl<T> PayloadTxsBounds for T where
     T: PayloadTransactions<
-        Transaction:
-            OpPooledTx<Consensus = OpTransactionSigned> + BundleTransaction + TimestampedTransaction,
+        Transaction: OpPooledTx<Consensus = OpTransactionSigned>
+                         + BundleTransaction
+                         + TimestampedTransaction,
     >
 {
 }

--- a/crates/builder/core/src/traits.rs
+++ b/crates/builder/core/src/traits.rs
@@ -4,7 +4,7 @@ use alloy_consensus::Header;
 use base_execution_chainspec::OpChainSpec;
 use base_execution_primitives::{OpPrimitives, OpTransactionSigned};
 use base_node_core::OpEngineTypes;
-use base_txpool::{BundleTransaction, OpPooledTx};
+use base_txpool::{BundleTransaction, OpPooledTx, TimestampedTransaction};
 use reth_node_api::{FullNodeTypes, NodeTypes};
 use reth_payload_util::PayloadTransactions;
 use reth_provider::{BlockReaderIdExt, ChainSpecProvider, StateProviderFactory};
@@ -31,23 +31,29 @@ impl<T> NodeBounds for T where
 
 /// Composite trait bound for a transaction pool compatible with the Base builder.
 pub trait PoolBounds:
-    TransactionPool<Transaction: OpPooledTx<Consensus = OpTransactionSigned> + BundleTransaction>
-    + TransactionPoolExt
+    TransactionPool<
+        Transaction:
+            OpPooledTx<Consensus = OpTransactionSigned> + BundleTransaction + TimestampedTransaction,
+    > + TransactionPoolExt
     + Unpin
     + 'static
 where
-    <Self as TransactionPool>::Transaction: OpPooledTx + BundleTransaction,
+    <Self as TransactionPool>::Transaction:
+        OpPooledTx + BundleTransaction + TimestampedTransaction,
 {
 }
 
 impl<T> PoolBounds for T
 where
     T: TransactionPool<
-            Transaction: OpPooledTx<Consensus = OpTransactionSigned> + BundleTransaction,
+            Transaction: OpPooledTx<Consensus = OpTransactionSigned>
+                + BundleTransaction
+                + TimestampedTransaction,
         > + TransactionPoolExt
         + Unpin
         + 'static,
-    <Self as TransactionPool>::Transaction: OpPooledTx + BundleTransaction,
+    <Self as TransactionPool>::Transaction:
+        OpPooledTx + BundleTransaction + TimestampedTransaction,
 {
 }
 
@@ -70,13 +76,17 @@ impl<T> ClientBounds for T where
 
 /// Composite trait bound for payload transaction iterators used by the Base builder.
 pub trait PayloadTxsBounds:
-    PayloadTransactions<Transaction: OpPooledTx<Consensus = OpTransactionSigned> + BundleTransaction>
+    PayloadTransactions<
+    Transaction:
+        OpPooledTx<Consensus = OpTransactionSigned> + BundleTransaction + TimestampedTransaction,
+>
 {
 }
 
 impl<T> PayloadTxsBounds for T where
     T: PayloadTransactions<
-        Transaction: OpPooledTx<Consensus = OpTransactionSigned> + BundleTransaction,
+        Transaction:
+            OpPooledTx<Consensus = OpTransactionSigned> + BundleTransaction + TimestampedTransaction,
     >
 {
 }

--- a/crates/builder/core/tests/smoke.rs
+++ b/crates/builder/core/tests/smoke.rs
@@ -233,3 +233,28 @@ async fn chain_produces_big_tx_without_gas_limit() -> eyre::Result<()> {
 
     Ok(())
 }
+
+#[tokio::test]
+async fn metering_wait_duration_does_not_delay_txs_when_metering_is_disabled() -> eyre::Result<()> {
+    let config =
+        BuilderConfig::for_tests().with_metering_wait_duration(Some(Duration::from_secs(60)));
+    let rbuilder = setup_test_instance_with_builder_config(config).await?;
+    let driver = rbuilder.driver().await?;
+
+    let tx = driver
+        .create_transaction()
+        .random_valid_transfer()
+        .send()
+        .await
+        .expect("Failed to send transaction");
+
+    let block = driver.build_new_block_with_current_timestamp(None).await?;
+    let txs = block.transactions;
+
+    assert!(
+        txs.hashes().any(|hash| hash == *tx.tx_hash()),
+        "fresh tx should not be delayed when metering is disabled"
+    );
+
+    Ok(())
+}

--- a/crates/builder/metering/src/store.rs
+++ b/crates/builder/metering/src/store.rs
@@ -69,6 +69,10 @@ impl MeteringProvider for MeteringStore {
         Some(entry)
     }
 
+    fn is_enabled(&self) -> bool {
+        self.metering_enabled.load(Ordering::Relaxed)
+    }
+
     fn insert(&self, tx_hash: TxHash, metering: MeterBundleResponse) {
         self.cache.insert(tx_hash, metering);
     }
@@ -169,6 +173,19 @@ mod tests {
         store.cache.run_pending_tasks();
 
         assert_eq!(store.len(), 2);
+    }
+
+    #[test]
+    fn test_metering_enabled_state_tracks_runtime_toggle() {
+        let store = MeteringStore::new(false, 100);
+
+        assert!(!store.is_enabled());
+
+        store.set_enabled(true);
+        assert!(store.is_enabled());
+
+        store.set_enabled(false);
+        assert!(!store.is_enabled());
     }
 
     #[test]

--- a/crates/txpool/src/ordering.rs
+++ b/crates/txpool/src/ordering.rs
@@ -79,7 +79,7 @@ where
         // Reth sorts descending (higher value = picked first).
         // We want older transactions (lower timestamp) first,
         // so invert: MAX - timestamp.
-        Priority::Value(u128::MAX - transaction.timestamp())
+        Priority::Value(u128::MAX - transaction.received_at())
     }
 }
 
@@ -209,7 +209,7 @@ mod tests {
         let priority = ordering.priority(&tx, 0);
         match priority {
             Priority::Value(val) => {
-                assert_eq!(val, u128::MAX - tx.timestamp());
+                assert_eq!(val, u128::MAX - tx.received_at());
             }
             Priority::None => panic!("Expected Priority::Value"),
         }

--- a/crates/txpool/src/transaction.rs
+++ b/crates/txpool/src/transaction.rs
@@ -139,7 +139,7 @@ impl<Cons: SignedTransaction, Pooled> BasePooledTransaction<Cons, Pooled> {
     }
 
     /// Returns the timestamp (millis since Unix epoch) when this transaction was received.
-    pub const fn received_at(&self) -> u128 {
+    const fn inner_received_at(&self) -> u128 {
         self.received_at
     }
 }
@@ -337,10 +337,10 @@ where
     }
 }
 
-/// Trait for transactions that expose their timestamp.
+/// Trait for transactions that expose their received-at timestamp.
 pub trait TimestampedTransaction {
-    /// Returns the timestamp (millis since Unix epoch) when this transaction was received.
-    fn timestamp(&self) -> u128;
+    /// Returns the time (millis since Unix epoch) when this transaction was received.
+    fn received_at(&self) -> u128;
 }
 
 impl<Cons, Pooled> TimestampedTransaction for BasePooledTransaction<Cons, Pooled>
@@ -348,8 +348,8 @@ where
     Cons: SignedTransaction,
     Pooled: Send + Sync + 'static,
 {
-    fn timestamp(&self) -> u128 {
-        self.received_at()
+    fn received_at(&self) -> u128 {
+        self.inner_received_at()
     }
 }
 


### PR DESCRIPTION
## Summary
- Add configurable `metering_wait_duration` parameter to the builder. If a transaction has been in the pool for less than this duration and has no metering data, it is skipped (deferred to a later flashblock or block).
- Add `--builder.metering-wait-duration-ms` CLI argument, `MeteringDataPending` error variant, and `metering_data_pending_skip` counter metric.
- Rename `TimestampedTransaction::timestamp()` to `received_at()` to match the underlying method it delegates to.

## Test plan
- [x] New rstest for CLI arg mapping (`metering_wait_duration_maps_correctly`)
- [x] All existing `base-builder-core` and `base-builder-bin` tests pass
- [x] All `base-txpool` tests pass
- [ ] Manual verification with metering service enabled