### PR TITLE
feat(proof): implement WitnessOracle for TEE Oracle

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3127,6 +3127,7 @@ dependencies = [
  "base-revm",
  "hex",
  "hex-literal 1.1.0",
+ "parking_lot",
  "revm",
  "serde",
  "serde_json",

--- a/crates/proof/host/src/error.rs
+++ b/crates/proof/host/src/error.rs
@@ -3,7 +3,7 @@ use std::array::TryFromSliceError;
 use alloy_rlp::Error as RlpError;
 use alloy_transport::TransportError;
 use base_proof_client::FaultProofProgramError;
-use base_proof_preimage::errors::PreimageOracleError;
+use base_proof_preimage::errors::{PreimageOracleError, WitnessOracleError};
 use thiserror::Error;
 
 /// Result type for host operations.
@@ -109,6 +109,9 @@ pub enum HostError {
     /// Preimage server panicked during witness capture.
     #[error("preimage server panicked: {0}")]
     ServerPanicked(tokio::task::JoinError),
+    /// Witness oracle error.
+    #[error("Witness oracle error: {0}")]
+    WitnessOracle(#[from] WitnessOracleError),
     /// IO error.
     #[error("IO error: {0}")]
     Io(#[from] std::io::Error),

--- a/crates/proof/host/src/host.rs
+++ b/crates/proof/host/src/host.rs
@@ -123,8 +123,8 @@ impl Host {
 
         server_task.abort();
 
-        witness.finalize();
-        let preimage_count = witness.preimage_count();
+        witness.finalize()?;
+        let preimage_count = witness.preimage_count()?;
         info!(preimage_count, "witness capture complete");
 
         Ok(())

--- a/crates/proof/host/src/recording.rs
+++ b/crates/proof/host/src/recording.rs
@@ -269,7 +269,11 @@ mod tests {
         let recording = RecordingOracle::new(oracle, hint, Arc::clone(&witness));
 
         assert!(recording.get(key).await.is_err());
-        assert_eq!(witness.preimage_count().unwrap(), 0, "get error should not record into witness");
+        assert_eq!(
+            witness.preimage_count().unwrap(),
+            0,
+            "get error should not record into witness"
+        );
 
         let mut buf = vec![0u8; 4];
         assert!(recording.get_exact(key, &mut buf).await.is_err());

--- a/crates/proof/host/src/recording.rs
+++ b/crates/proof/host/src/recording.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use base_proof_preimage::{
     FlushableCache, HintWriterClient, PreimageKey, PreimageOracleClient, WitnessOracle,
-    errors::PreimageOracleResult,
+    errors::{PreimageOracleError, PreimageOracleResult},
 };
 
 /// A transparent oracle wrapper that records every preimage fetched into a [`WitnessOracle`].
@@ -51,13 +51,17 @@ where
 {
     async fn get(&self, key: PreimageKey) -> PreimageOracleResult<Vec<u8>> {
         let value = self.oracle.get(key).await?;
-        self.witness.insert_preimage(key, &value);
+        self.witness
+            .insert_preimage(key, &value)
+            .map_err(|e| PreimageOracleError::Other(e.to_string()))?;
         Ok(value)
     }
 
     async fn get_exact(&self, key: PreimageKey, buf: &mut [u8]) -> PreimageOracleResult<()> {
         self.oracle.get_exact(key, buf).await?;
-        self.witness.insert_preimage(key, buf);
+        self.witness
+            .insert_preimage(key, buf)
+            .map_err(|e| PreimageOracleError::Other(e.to_string()))?;
         Ok(())
     }
 }
@@ -87,7 +91,7 @@ where
 mod tests {
     use std::{collections::HashMap, sync::Mutex};
 
-    use base_proof_preimage::{PreimageKeyType, errors::PreimageOracleError};
+    use base_proof_preimage::{PreimageKeyType, WitnessOracleResult, errors::PreimageOracleError};
 
     use super::*;
 
@@ -131,14 +135,17 @@ mod tests {
     }
 
     impl WitnessOracle for MockWitness {
-        fn insert_preimage(&self, key: PreimageKey, value: &[u8]) {
+        fn insert_preimage(&self, key: PreimageKey, value: &[u8]) -> WitnessOracleResult<()> {
             self.preimages.lock().unwrap().push((key, value.to_vec()));
+            Ok(())
         }
 
-        fn finalize(&self) {}
+        fn finalize(&self) -> WitnessOracleResult<()> {
+            Ok(())
+        }
 
-        fn preimage_count(&self) -> usize {
-            self.preimages.lock().unwrap().len()
+        fn preimage_count(&self) -> WitnessOracleResult<usize> {
+            Ok(self.preimages.lock().unwrap().len())
         }
     }
 
@@ -195,7 +202,7 @@ mod tests {
         assert_eq!(hints.len(), 1);
         assert_eq!(hints[0], "test-hint");
 
-        assert_eq!(witness.preimage_count(), 0);
+        assert_eq!(witness.preimage_count().unwrap(), 0);
     }
 
     #[tokio::test]
@@ -266,11 +273,15 @@ mod tests {
         let recording = RecordingOracle::new(oracle, hint, Arc::clone(&witness));
 
         assert!(recording.get(key).await.is_err());
-        assert_eq!(witness.preimage_count(), 0, "get error should not record into witness");
+        assert_eq!(witness.preimage_count().unwrap(), 0, "get error should not record into witness");
 
         let mut buf = vec![0u8; 4];
         assert!(recording.get_exact(key, &mut buf).await.is_err());
-        assert_eq!(witness.preimage_count(), 0, "get_exact error should not record into witness");
+        assert_eq!(
+            witness.preimage_count().unwrap(),
+            0,
+            "get_exact error should not record into witness"
+        );
     }
 
     #[tokio::test]
@@ -288,6 +299,6 @@ mod tests {
         recording.get(key).await.unwrap();
         cloned.get(key).await.unwrap();
 
-        assert_eq!(witness.preimage_count(), 2);
+        assert_eq!(witness.preimage_count().unwrap(), 2);
     }
 }

--- a/crates/proof/host/src/recording.rs
+++ b/crates/proof/host/src/recording.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use base_proof_preimage::{
     FlushableCache, HintWriterClient, PreimageKey, PreimageOracleClient, WitnessOracle,
-    errors::{PreimageOracleError, PreimageOracleResult},
+    errors::PreimageOracleResult,
 };
 
 /// A transparent oracle wrapper that records every preimage fetched into a [`WitnessOracle`].
@@ -51,17 +51,13 @@ where
 {
     async fn get(&self, key: PreimageKey) -> PreimageOracleResult<Vec<u8>> {
         let value = self.oracle.get(key).await?;
-        self.witness
-            .insert_preimage(key, &value)
-            .map_err(|e| PreimageOracleError::Other(e.to_string()))?;
+        self.witness.insert_preimage(key, &value)?;
         Ok(value)
     }
 
     async fn get_exact(&self, key: PreimageKey, buf: &mut [u8]) -> PreimageOracleResult<()> {
         self.oracle.get_exact(key, buf).await?;
-        self.witness
-            .insert_preimage(key, buf)
-            .map_err(|e| PreimageOracleError::Other(e.to_string()))?;
+        self.witness.insert_preimage(key, buf)?;
         Ok(())
     }
 }

--- a/crates/proof/preimage/src/errors.rs
+++ b/crates/proof/preimage/src/errors.rs
@@ -27,6 +27,9 @@ pub enum PreimageOracleError {
     /// Failed to parse hint.
     #[error("Failed to parse hint: {0}")]
     HintParseFailed(String),
+    /// Witness oracle error.
+    #[error(transparent)]
+    WitnessOracle(#[from] WitnessOracleError),
     /// Other errors.
     #[error("Error in preimage server: {0}")]
     Other(String),
@@ -55,9 +58,6 @@ pub type ChannelResult<T> = Result<T, ChannelError>;
 /// An error that can occur during witness oracle operations.
 #[derive(Error, Debug)]
 pub enum WitnessOracleError {
-    /// The oracle's internal lock is poisoned.
-    #[error("Oracle lock poisoned: {0}")]
-    LockPoisoned(String),
     /// Other witness oracle errors.
     #[error("Witness oracle error: {0}")]
     Other(String),

--- a/crates/proof/preimage/src/errors.rs
+++ b/crates/proof/preimage/src/errors.rs
@@ -51,3 +51,17 @@ pub enum ChannelError {
 
 /// A [Result] type for the [`ChannelError`] enum.
 pub type ChannelResult<T> = Result<T, ChannelError>;
+
+/// An error that can occur during witness oracle operations.
+#[derive(Error, Debug)]
+pub enum WitnessOracleError {
+    /// The oracle's internal lock is poisoned.
+    #[error("Oracle lock poisoned: {0}")]
+    LockPoisoned(String),
+    /// Other witness oracle errors.
+    #[error("Witness oracle error: {0}")]
+    Other(String),
+}
+
+/// A [Result] type for the [`WitnessOracleError`] enum.
+pub type WitnessOracleResult<T> = Result<T, WitnessOracleError>;

--- a/crates/proof/preimage/src/lib.rs
+++ b/crates/proof/preimage/src/lib.rs
@@ -23,12 +23,12 @@ mod hint;
 pub use hint::{HintReader, HintWriter};
 
 mod traits;
+pub use errors::{WitnessOracleError, WitnessOracleResult};
 pub use traits::{
     Channel, CommsClient, FlushableCache, HintReaderServer, HintRouter, HintWriterClient,
     PreimageFetcher, PreimageOracleClient, PreimageOracleServer, PreimageServerBackend,
     WitnessOracle,
 };
-pub use errors::{WitnessOracleError, WitnessOracleResult};
 
 #[cfg(feature = "std")]
 mod native_channel;

--- a/crates/proof/preimage/src/lib.rs
+++ b/crates/proof/preimage/src/lib.rs
@@ -12,6 +12,7 @@ extern crate alloc;
 extern crate tracing;
 
 pub mod errors;
+pub use errors::{WitnessOracleError, WitnessOracleResult};
 
 mod key;
 pub use key::{PreimageKey, PreimageKeyType};
@@ -23,7 +24,6 @@ mod hint;
 pub use hint::{HintReader, HintWriter};
 
 mod traits;
-pub use errors::{WitnessOracleError, WitnessOracleResult};
 pub use traits::{
     Channel, CommsClient, FlushableCache, HintReaderServer, HintRouter, HintWriterClient,
     PreimageFetcher, PreimageOracleClient, PreimageOracleServer, PreimageServerBackend,

--- a/crates/proof/preimage/src/lib.rs
+++ b/crates/proof/preimage/src/lib.rs
@@ -28,6 +28,7 @@ pub use traits::{
     PreimageFetcher, PreimageOracleClient, PreimageOracleServer, PreimageServerBackend,
     WitnessOracle,
 };
+pub use errors::{WitnessOracleError, WitnessOracleResult};
 
 #[cfg(feature = "std")]
 mod native_channel;

--- a/crates/proof/preimage/src/traits.rs
+++ b/crates/proof/preimage/src/traits.rs
@@ -4,7 +4,7 @@ use async_trait::async_trait;
 
 use crate::{
     PreimageKey,
-    errors::{ChannelResult, PreimageOracleResult},
+    errors::{ChannelResult, PreimageOracleResult, WitnessOracleResult},
 };
 
 /// A [`PreimageOracleClient`] is a high-level interface to read data from the host, keyed by a
@@ -126,13 +126,13 @@ pub trait FlushableCache {
 /// not on this trait.
 pub trait WitnessOracle: Send + Sync {
     /// Insert a preimage into the oracle under the given key.
-    fn insert_preimage(&self, key: PreimageKey, value: &[u8]);
+    fn insert_preimage(&self, key: PreimageKey, value: &[u8]) -> WitnessOracleResult<()>;
 
     /// Finalize the oracle, signaling that no more preimages will be inserted.
-    fn finalize(&self);
+    fn finalize(&self) -> WitnessOracleResult<()>;
 
     /// Return the number of preimages currently held by the oracle.
-    fn preimage_count(&self) -> usize;
+    fn preimage_count(&self) -> WitnessOracleResult<usize>;
 }
 
 /// A [`Channel`] is a high-level interface to read and write data to a counterparty.

--- a/crates/proof/tee/core/Cargo.toml
+++ b/crates/proof/tee/core/Cargo.toml
@@ -37,6 +37,7 @@ base-protocol = { workspace = true, features = ["serde"] }
 hex = { workspace = true, features = ["serde"] }
 serde = { workspace = true, features = ["derive"] }
 hex-literal.workspace = true
+parking_lot.workspace = true
 serde_json.workspace = true
 async-trait.workspace = true
 thiserror.workspace = true

--- a/crates/proof/tee/core/src/executor/oracle.rs
+++ b/crates/proof/tee/core/src/executor/oracle.rs
@@ -1,33 +1,46 @@
-use std::{collections::HashMap, fmt, sync::Arc};
+use std::{
+    collections::HashMap,
+    fmt,
+    sync::{Arc, RwLock},
+};
 
 use async_trait::async_trait;
 use base_proof_preimage::{
-    FlushableCache, HintWriterClient, PreimageKey, PreimageOracleClient,
+    FlushableCache, HintWriterClient, PreimageKey, PreimageOracleClient, WitnessOracle,
     errors::{PreimageOracleError, PreimageOracleResult},
 };
 
 /// HashMap-backed preimage oracle for in-enclave stateless execution.
 ///
-/// Loaded once from the proposer's preimage bundle; all I/O is local
-/// `HashMap` lookups. [`HintWriterClient`] and [`FlushableCache`] are no-ops
-/// because data is pre-loaded and immutable.
+/// Stores preimages in a shared, mutable map so the same oracle can serve
+/// both roles: **writing** (during witness capture via [`WitnessOracle`]) and
+/// **reading** (during block re-execution via [`PreimageOracleClient`]).
+///
+/// [`HintWriterClient`] and [`FlushableCache`] are no-ops because TEE
+/// execution doesn't route hints or manage an external cache.
 #[derive(Clone)]
 pub struct Oracle {
-    preimages: Arc<HashMap<PreimageKey, Vec<u8>>>,
+    preimages: Arc<RwLock<HashMap<PreimageKey, Vec<u8>>>>,
 }
 
 impl Oracle {
     /// Construct an [`Oracle`] from an iterator of `(key, value)` pairs.
     pub fn new(preimages: impl IntoIterator<Item = (PreimageKey, Vec<u8>)>) -> Self {
-        Self { preimages: Arc::new(preimages.into_iter().collect()) }
+        Self { preimages: Arc::new(RwLock::new(preimages.into_iter().collect())) }
+    }
+
+    /// Construct an empty [`Oracle`] for witness capture.
+    pub fn empty() -> Self {
+        Self { preimages: Arc::new(RwLock::new(HashMap::new())) }
     }
 }
 
 impl fmt::Debug for Oracle {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let total_bytes: usize = self.preimages.values().map(Vec::len).sum();
+        let preimages = self.preimages.read().expect("oracle lock poisoned");
+        let total_bytes: usize = preimages.values().map(Vec::len).sum();
         f.debug_struct("Oracle")
-            .field("keys", &self.preimages.len())
+            .field("keys", &preimages.len())
             .field("total_bytes", &total_bytes)
             .finish()
     }
@@ -36,11 +49,17 @@ impl fmt::Debug for Oracle {
 #[async_trait]
 impl PreimageOracleClient for Oracle {
     async fn get(&self, key: PreimageKey) -> PreimageOracleResult<Vec<u8>> {
-        self.preimages.get(&key).cloned().ok_or(PreimageOracleError::KeyNotFound)
+        self.preimages
+            .read()
+            .expect("oracle lock poisoned")
+            .get(&key)
+            .cloned()
+            .ok_or(PreimageOracleError::KeyNotFound)
     }
 
     async fn get_exact(&self, key: PreimageKey, buf: &mut [u8]) -> PreimageOracleResult<()> {
-        let value = self.preimages.get(&key).ok_or(PreimageOracleError::KeyNotFound)?;
+        let preimages = self.preimages.read().expect("oracle lock poisoned");
+        let value = preimages.get(&key).ok_or(PreimageOracleError::KeyNotFound)?;
         if value.len() != buf.len() {
             return Err(PreimageOracleError::BufferLengthMismatch(buf.len(), value.len()));
         }
@@ -58,4 +77,16 @@ impl HintWriterClient for Oracle {
 
 impl FlushableCache for Oracle {
     fn flush(&self) {}
+}
+
+impl WitnessOracle for Oracle {
+    fn insert_preimage(&self, key: PreimageKey, value: &[u8]) {
+        self.preimages.write().expect("oracle lock poisoned").insert(key, value.to_vec());
+    }
+
+    fn finalize(&self) {}
+
+    fn preimage_count(&self) -> usize {
+        self.preimages.read().expect("oracle lock poisoned").len()
+    }
 }

--- a/crates/proof/tee/core/src/executor/oracle.rs
+++ b/crates/proof/tee/core/src/executor/oracle.rs
@@ -7,7 +7,7 @@ use std::{
 use async_trait::async_trait;
 use base_proof_preimage::{
     FlushableCache, HintWriterClient, PreimageKey, PreimageOracleClient, WitnessOracle,
-    errors::{PreimageOracleError, PreimageOracleResult},
+    errors::{PreimageOracleError, PreimageOracleResult, WitnessOracleError, WitnessOracleResult},
 };
 
 /// HashMap-backed preimage oracle for in-enclave stateless execution.
@@ -37,12 +37,16 @@ impl Oracle {
 
 impl fmt::Debug for Oracle {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let preimages = self.preimages.read().expect("oracle lock poisoned");
-        let total_bytes: usize = preimages.values().map(Vec::len).sum();
-        f.debug_struct("Oracle")
-            .field("keys", &preimages.len())
-            .field("total_bytes", &total_bytes)
-            .finish()
+        match self.preimages.read() {
+            Ok(preimages) => {
+                let total_bytes: usize = preimages.values().map(Vec::len).sum();
+                f.debug_struct("Oracle")
+                    .field("keys", &preimages.len())
+                    .field("total_bytes", &total_bytes)
+                    .finish()
+            }
+            Err(_) => f.debug_struct("Oracle").field("status", &"poisoned").finish(),
+        }
     }
 }
 
@@ -51,14 +55,15 @@ impl PreimageOracleClient for Oracle {
     async fn get(&self, key: PreimageKey) -> PreimageOracleResult<Vec<u8>> {
         self.preimages
             .read()
-            .expect("oracle lock poisoned")
+            .map_err(|e| PreimageOracleError::Other(e.to_string()))?
             .get(&key)
             .cloned()
             .ok_or(PreimageOracleError::KeyNotFound)
     }
 
     async fn get_exact(&self, key: PreimageKey, buf: &mut [u8]) -> PreimageOracleResult<()> {
-        let preimages = self.preimages.read().expect("oracle lock poisoned");
+        let preimages =
+            self.preimages.read().map_err(|e| PreimageOracleError::Other(e.to_string()))?;
         let value = preimages.get(&key).ok_or(PreimageOracleError::KeyNotFound)?;
         if value.len() != buf.len() {
             return Err(PreimageOracleError::BufferLengthMismatch(buf.len(), value.len()));
@@ -80,13 +85,23 @@ impl FlushableCache for Oracle {
 }
 
 impl WitnessOracle for Oracle {
-    fn insert_preimage(&self, key: PreimageKey, value: &[u8]) {
-        self.preimages.write().expect("oracle lock poisoned").insert(key, value.to_vec());
+    fn insert_preimage(&self, key: PreimageKey, value: &[u8]) -> WitnessOracleResult<()> {
+        self.preimages
+            .write()
+            .map_err(|e| WitnessOracleError::LockPoisoned(e.to_string()))?
+            .insert(key, value.to_vec());
+        Ok(())
     }
 
-    fn finalize(&self) {}
+    fn finalize(&self) -> WitnessOracleResult<()> {
+        Ok(())
+    }
 
-    fn preimage_count(&self) -> usize {
-        self.preimages.read().expect("oracle lock poisoned").len()
+    fn preimage_count(&self) -> WitnessOracleResult<usize> {
+        Ok(self
+            .preimages
+            .read()
+            .map_err(|e| WitnessOracleError::LockPoisoned(e.to_string()))?
+            .len())
     }
 }

--- a/crates/proof/tee/core/src/executor/oracle.rs
+++ b/crates/proof/tee/core/src/executor/oracle.rs
@@ -1,14 +1,11 @@
-use std::{
-    collections::HashMap,
-    fmt,
-    sync::{Arc, RwLock},
-};
+use std::{collections::HashMap, fmt, sync::Arc};
 
 use async_trait::async_trait;
 use base_proof_preimage::{
     FlushableCache, HintWriterClient, PreimageKey, PreimageOracleClient, WitnessOracle,
-    errors::{PreimageOracleError, PreimageOracleResult, WitnessOracleError, WitnessOracleResult},
+    errors::{PreimageOracleError, PreimageOracleResult, WitnessOracleResult},
 };
+use parking_lot::RwLock;
 
 /// HashMap-backed preimage oracle for in-enclave stateless execution.
 ///
@@ -37,33 +34,23 @@ impl Oracle {
 
 impl fmt::Debug for Oracle {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self.preimages.read() {
-            Ok(preimages) => {
-                let total_bytes: usize = preimages.values().map(Vec::len).sum();
-                f.debug_struct("Oracle")
-                    .field("keys", &preimages.len())
-                    .field("total_bytes", &total_bytes)
-                    .finish()
-            }
-            Err(_) => f.debug_struct("Oracle").field("status", &"poisoned").finish(),
-        }
+        let preimages = self.preimages.read();
+        let total_bytes: usize = preimages.values().map(Vec::len).sum();
+        f.debug_struct("Oracle")
+            .field("keys", &preimages.len())
+            .field("total_bytes", &total_bytes)
+            .finish()
     }
 }
 
 #[async_trait]
 impl PreimageOracleClient for Oracle {
     async fn get(&self, key: PreimageKey) -> PreimageOracleResult<Vec<u8>> {
-        self.preimages
-            .read()
-            .map_err(|e| PreimageOracleError::Other(e.to_string()))?
-            .get(&key)
-            .cloned()
-            .ok_or(PreimageOracleError::KeyNotFound)
+        self.preimages.read().get(&key).cloned().ok_or(PreimageOracleError::KeyNotFound)
     }
 
     async fn get_exact(&self, key: PreimageKey, buf: &mut [u8]) -> PreimageOracleResult<()> {
-        let preimages =
-            self.preimages.read().map_err(|e| PreimageOracleError::Other(e.to_string()))?;
+        let preimages = self.preimages.read();
         let value = preimages.get(&key).ok_or(PreimageOracleError::KeyNotFound)?;
         if value.len() != buf.len() {
             return Err(PreimageOracleError::BufferLengthMismatch(buf.len(), value.len()));
@@ -86,10 +73,7 @@ impl FlushableCache for Oracle {
 
 impl WitnessOracle for Oracle {
     fn insert_preimage(&self, key: PreimageKey, value: &[u8]) -> WitnessOracleResult<()> {
-        self.preimages
-            .write()
-            .map_err(|e| WitnessOracleError::LockPoisoned(e.to_string()))?
-            .insert(key, value.to_vec());
+        self.preimages.write().insert(key, value.to_vec());
         Ok(())
     }
 
@@ -98,10 +82,6 @@ impl WitnessOracle for Oracle {
     }
 
     fn preimage_count(&self) -> WitnessOracleResult<usize> {
-        Ok(self
-            .preimages
-            .read()
-            .map_err(|e| WitnessOracleError::LockPoisoned(e.to_string()))?
-            .len())
+        Ok(self.preimages.read().len())
     }
 }


### PR DESCRIPTION
## Summary

- Implements `WitnessOracle` trait on the existing TEE `Oracle` in `base-enclave`, enabling it to serve as the witness capture target during host-side derivation
- Switches internal storage from `Arc<HashMap>` to `Arc<RwLock<HashMap>>` for interior mutability (`WitnessOracle` trait methods take `&self`)
- Adds `Oracle::empty()` constructor for the witness capture phase

## Context

Part of the unified proof architecture ([W3](https://github.com/base/base/pull/1082)). The TEE Oracle now supports two phases:
1. **Capture** — `RecordingOracle` calls `insert_preimage()` to populate the map during host-side derivation
2. **Replay** — enclave re-executes using `PreimageOracleClient::get()` against the populated map

Depends on #1082 (witness capture / `WitnessOracle` trait).