### PR TITLE
fix(consensus-peers): Dedicated PeerId Module

### DIFF
--- a/crates/consensus/peers/src/id.rs
+++ b/crates/consensus/peers/src/id.rs
@@ -1,0 +1,4 @@
+/// Alias for a peer identifier.
+///
+/// This is the most primitive secp256k1 public key identifier for a given peer.
+pub type PeerId = alloy_primitives::B512;

--- a/crates/consensus/peers/src/lib.rs
+++ b/crates/consensus/peers/src/lib.rs
@@ -9,10 +9,8 @@
 #[macro_use]
 extern crate tracing;
 
-/// Alias for a peer identifier.
-///
-/// This is the most primitive secp256k1 public key identifier for a given peer.
-pub type PeerId = alloy_primitives::B512;
+mod id;
+pub use id::PeerId;
 
 mod nodes;
 pub use nodes::{BootNodes, OP_RAW_BOOTNODES, OP_RAW_TESTNET_BOOTNODES};


### PR DESCRIPTION
## Summary

Tiny PR to move `PeerId` to a dedicated module