### PR TITLE
feat(proof): add ProverBackend trait and ProverService orchestrator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4067,6 +4067,7 @@ dependencies = [
  "base-proof-client",
  "base-proof-mpt",
  "base-proof-preimage",
+ "base-proof-primitives",
  "base-protocol",
  "proptest",
  "revm",
@@ -4117,6 +4118,7 @@ name = "base-proof-primitives"
 version = "0.0.0"
 dependencies = [
  "alloy-primitives",
+ "async-trait",
  "base-proof-preimage",
  "serde",
 ]

--- a/crates/proof/host/Cargo.toml
+++ b/crates/proof/host/Cargo.toml
@@ -12,14 +12,15 @@ workspace = true
 
 [dependencies]
 # base
-base-proof-mpt.workspace = true
 base-protocol.workspace = true
+base-proof-mpt.workspace = true
 base-alloy-evm.workspace = true
 base-alloy-network.workspace = true
 base-consensus-providers.workspace = true
 base-proof = { workspace = true, features = ["std"] }
 base-proof-client = { workspace = true, features = ["std"] }
 base-proof-preimage = { workspace = true, features = ["std"] }
+base-proof-primitives = { workspace = true, features = ["serde", "std"] }
 base-consensus-genesis = { workspace = true, features = ["serde", "std"] }
 base-alloy-rpc-types-engine = { workspace = true, features = ["serde", "std"] }
 

--- a/crates/proof/host/src/config.rs
+++ b/crates/proof/host/src/config.rs
@@ -1,13 +1,11 @@
 use std::path::PathBuf;
 
-use alloy_primitives::B256;
 use alloy_provider::RootProvider;
 use base_alloy_network::Base;
 use base_consensus_genesis::{L1ChainConfig, RollupConfig};
 use base_consensus_providers::{OnlineBeaconClient, OnlineBlobProvider};
+use base_proof_primitives::ProofRequest;
 use serde::Serialize;
-
-use crate::{HostError, Result};
 
 /// The providers required for the host.
 #[derive(Debug, Clone)]
@@ -20,57 +18,41 @@ pub struct HostProviders {
     pub l2: RootProvider<Base>,
 }
 
-/// Configuration for the proof host.
-#[derive(Default, Serialize, Clone, Debug)]
-pub struct HostConfig {
-    /// Hash of the L1 head block.
-    pub l1_head: B256,
-    /// Hash of the agreed upon safe L2 block.
-    pub agreed_l2_head_hash: B256,
-    /// Agreed safe L2 Output Root to start derivation from.
-    pub agreed_l2_output_root: B256,
-    /// Claimed L2 output root to validate.
-    pub claimed_l2_output_root: B256,
-    /// Number of the L2 block that the claimed output root commits to.
-    pub claimed_l2_block_number: u64,
-    /// Address of L2 JSON-RPC endpoint to use.
-    pub l2_node_address: Option<String>,
-    /// Address of L1 JSON-RPC endpoint to use.
-    pub l1_node_address: Option<String>,
-    /// Address of the L1 Beacon API endpoint to use.
-    pub l1_beacon_address: Option<String>,
-    /// Data directory for preimage data storage.
-    pub data_dir: Option<PathBuf>,
-    /// The L2 chain ID of a supported chain.
-    pub l2_chain_id: Option<u64>,
-    /// Path to rollup config.
-    pub rollup_config_path: Option<PathBuf>,
-    /// Path to L1 config.
-    pub l1_config_path: Option<PathBuf>,
-    /// Enables the use of `debug_executePayload` to collect the execution witness.
+/// Static infrastructure config — set once at startup, reused across proofs.
+///
+/// Constructed by the binary from CLI args or environment.
+#[derive(Debug, Clone, Serialize)]
+pub struct ProverConfig {
+    /// L1 execution layer RPC URL.
+    pub l1_eth_url: String,
+    /// L2 execution layer RPC URL.
+    pub l2_eth_url: String,
+    /// L1 beacon API URL.
+    pub l1_beacon_url: String,
+    /// L2 chain ID.
+    pub l2_chain_id: u64,
+    /// Rollup configuration.
+    pub rollup_config: RollupConfig,
+    /// L1 chain configuration.
+    pub l1_config: L1ChainConfig,
+    /// Enables `debug_executePayload` for execution witness collection.
     pub enable_experimental_witness_endpoint: bool,
+}
+
+/// Configuration for the proof host.
+#[derive(Debug, Clone)]
+pub struct HostConfig {
+    /// Per-proof parameters.
+    pub request: ProofRequest,
+    /// Static infrastructure config.
+    pub prover: ProverConfig,
+    /// Data directory for preimage data storage. When set, enables offline mode.
+    pub data_dir: Option<PathBuf>,
 }
 
 impl HostConfig {
     /// Returns `true` if the host is running in offline mode.
     pub const fn is_offline(&self) -> bool {
-        self.l1_node_address.is_none()
-            && self.l2_node_address.is_none()
-            && self.l1_beacon_address.is_none()
-            && self.data_dir.is_some()
-    }
-
-    /// Reads the [`RollupConfig`] from the file system.
-    pub fn read_rollup_config(&self) -> Result<RollupConfig> {
-        let path = self.rollup_config_path.as_ref().ok_or(HostError::NoRollupConfig)?;
-        let ser_config = std::fs::read_to_string(path)?;
-        serde_json::from_str(&ser_config).map_err(HostError::from)
-    }
-
-    /// Reads the [`L1ChainConfig`] from the file system.
-    pub fn read_l1_config(&self) -> Result<L1ChainConfig> {
-        let path = self.l1_config_path.as_ref().ok_or(HostError::NoL1Config)?;
-        let ser_config = std::fs::read_to_string(path)?;
-        serde_json::from_str(&ser_config).map_err(HostError::from)
+        self.data_dir.is_some()
     }
 }

--- a/crates/proof/host/src/error.rs
+++ b/crates/proof/host/src/error.rs
@@ -27,12 +27,6 @@ pub enum HostError {
     /// Failed precompile execution.
     #[error("Failed precompile execution: {0}")]
     PrecompileExecutionFailed(String),
-    /// No rollup config found.
-    #[error("No rollup config found")]
-    NoRollupConfig,
-    /// No L1 config found.
-    #[error("No L1 config found")]
-    NoL1Config,
     /// Output root mismatch.
     #[error("Output root does not match L2 head")]
     OutputRootMismatch,

--- a/crates/proof/host/src/handler.rs
+++ b/crates/proof/host/src/handler.rs
@@ -222,24 +222,24 @@ pub async fn handle_hint(
             let raw_header: Bytes = providers
                 .l2
                 .client()
-                .request("debug_getRawHeader", &[cfg.agreed_l2_head_hash])
+                .request("debug_getRawHeader", &[cfg.request.agreed_l2_head_hash])
                 .await?;
             let header = Header::decode(&mut raw_header.as_ref())?;
 
             let l2_to_l1_message_passer = providers
                 .l2
                 .get_proof(Predeploys::L2_TO_L1_MESSAGE_PASSER, Default::default())
-                .block_id(cfg.agreed_l2_head_hash.into())
+                .block_id(cfg.request.agreed_l2_head_hash.into())
                 .await?;
 
             let output_root = OutputRoot::from_parts(
                 header.state_root,
                 l2_to_l1_message_passer.storage_hash,
-                cfg.agreed_l2_head_hash,
+                cfg.request.agreed_l2_head_hash,
             );
             let output_root_hash = output_root.hash();
 
-            if output_root_hash != cfg.agreed_l2_output_root {
+            if output_root_hash != cfg.request.agreed_l2_output_root {
                 return Err(HostError::OutputRootMismatch);
             }
 
@@ -349,7 +349,7 @@ pub async fn handle_hint(
             })?;
         }
         HintType::L2PayloadWitness => {
-            if !cfg.enable_experimental_witness_endpoint {
+            if !cfg.prover.enable_experimental_witness_endpoint {
                 warn!("L2PayloadWitness hint sent but payload witness is disabled, skipping");
                 return Ok(());
             }

--- a/crates/proof/host/src/host.rs
+++ b/crates/proof/host/src/host.rs
@@ -180,27 +180,12 @@ impl Host {
 
     /// Creates the providers required for the host backend.
     pub async fn create_providers(&self) -> Result<HostProviders> {
-        let l1_provider = rpc_provider(
-            self.config
-                .l1_node_address
-                .as_ref()
-                .ok_or_else(|| HostError::Custom("Provider must be set".into()))?,
-        )
-        .await?;
+        let l1_provider = rpc_provider(&self.config.prover.l1_eth_url).await?;
         let blob_provider = OnlineBlobProvider::init(OnlineBeaconClient::new_http(
-            self.config
-                .l1_beacon_address
-                .clone()
-                .ok_or_else(|| HostError::Custom("Beacon API URL must be set".into()))?,
+            self.config.prover.l1_beacon_url.clone(),
         ))
         .await;
-        let l2_provider = rpc_provider::<Base>(
-            self.config
-                .l2_node_address
-                .as_ref()
-                .ok_or_else(|| HostError::Custom("L2 node address must be set".into()))?,
-        )
-        .await?;
+        let l2_provider = rpc_provider::<Base>(&self.config.prover.l2_eth_url).await?;
 
         Ok(HostProviders { l1: l1_provider, blobs: blob_provider, l2: l2_provider })
     }

--- a/crates/proof/host/src/host.rs
+++ b/crates/proof/host/src/host.rs
@@ -76,10 +76,15 @@ impl Host {
 
     /// Runs the fault-proof program in-process, capturing all fetched preimages into the
     /// provided [`WitnessOracle`].
-    pub async fn build_witness<W>(&self, witness: Arc<W>) -> Result<()>
+    ///
+    /// Takes ownership of the oracle and returns it after witness generation completes.
+    /// [`Arc`] sharing with internal tasks is managed entirely within this method.
+    pub async fn build_witness<W>(&self, witness: W) -> Result<W>
     where
         W: WitnessOracle + std::fmt::Debug + 'static,
     {
+        let witness = Arc::new(witness);
+
         let kv_store = self.create_key_value_store()?;
         let providers = self.create_providers().await?;
         let backend = Arc::new(
@@ -122,12 +127,18 @@ impl Host {
         }
 
         server_task.abort();
+        let _ = (&mut server_task).await;
 
         witness.finalize()?;
         let preimage_count = witness.preimage_count()?;
         info!(preimage_count, "witness capture complete");
 
-        Ok(())
+        Arc::try_unwrap(witness).map_err(|arc| {
+            HostError::Custom(format!(
+                "failed to recover witness oracle: {} references still held",
+                Arc::strong_count(&arc),
+            ))
+        })
     }
 
     /// Runs the fault-proof program client: prologue → driver → epilogue.

--- a/crates/proof/host/src/kv/boot.rs
+++ b/crates/proof/host/src/kv/boot.rs
@@ -24,23 +24,19 @@ impl KeyValueStore for BootKeyValueStore {
     fn get(&self, key: B256) -> Option<Vec<u8>> {
         let preimage_key = PreimageKey::try_from(*key).ok()?;
         match preimage_key.key_value() {
-            L1_HEAD_KEY => Some(self.cfg.l1_head.to_vec()),
-            L2_OUTPUT_ROOT_KEY => Some(self.cfg.agreed_l2_output_root.to_vec()),
-            L2_CLAIM_KEY => Some(self.cfg.claimed_l2_output_root.to_vec()),
+            L1_HEAD_KEY => Some(self.cfg.request.l1_head.to_vec()),
+            L2_OUTPUT_ROOT_KEY => Some(self.cfg.request.agreed_l2_output_root.to_vec()),
+            L2_CLAIM_KEY => Some(self.cfg.request.claimed_l2_output_root.to_vec()),
             L2_CLAIM_BLOCK_NUMBER_KEY => {
-                Some(self.cfg.claimed_l2_block_number.to_be_bytes().to_vec())
+                Some(self.cfg.request.claimed_l2_block_number.to_be_bytes().to_vec())
             }
-            L2_CHAIN_ID_KEY => {
-                Some(self.cfg.l2_chain_id.unwrap_or_default().to_be_bytes().to_vec())
-            }
+            L2_CHAIN_ID_KEY => Some(self.cfg.prover.l2_chain_id.to_be_bytes().to_vec()),
             L2_ROLLUP_CONFIG_KEY => {
-                let rollup_config = self.cfg.read_rollup_config().ok()?;
-                let serialized = serde_json::to_vec(&rollup_config).ok()?;
+                let serialized = serde_json::to_vec(&self.cfg.prover.rollup_config).ok()?;
                 Some(serialized)
             }
             L1_CONFIG_KEY => {
-                let l1_config = self.cfg.read_l1_config().ok()?;
-                let serialized = serde_json::to_vec(&l1_config).ok()?;
+                let serialized = serde_json::to_vec(&self.cfg.prover.l1_config).ok()?;
                 Some(serialized)
             }
             _ => None,

--- a/crates/proof/host/src/lib.rs
+++ b/crates/proof/host/src/lib.rs
@@ -4,7 +4,7 @@ mod error;
 pub use error::{HostError, Result};
 
 mod config;
-pub use config::{HostConfig, HostProviders};
+pub use config::{HostConfig, HostProviders, ProverConfig};
 
 mod host;
 pub use host::Host;
@@ -28,6 +28,9 @@ pub use recording::RecordingOracle;
 
 mod backend;
 pub use backend::{OfflineHostBackend, OnlineHostBackend};
+
+mod service;
+pub use service::{ProverError, ProverService};
 
 #[cfg(feature = "precompiles")]
 mod precompiles;

--- a/crates/proof/host/src/service.rs
+++ b/crates/proof/host/src/service.rs
@@ -1,6 +1,5 @@
-use std::{fmt, sync::Arc};
+use std::fmt;
 
-use base_proof_preimage::WitnessOracle;
 use base_proof_primitives::{ProofRequest, ProofResult, ProverBackend};
 use tracing::info;
 
@@ -44,18 +43,7 @@ impl<B: ProverBackend> ProverService<B> {
 
         let host = Host::new(HostConfig { request, prover: self.config.clone(), data_dir: None });
         let oracle = self.backend.create_oracle();
-        let oracle = Arc::new(oracle);
-
-        host.build_witness(Arc::clone(&oracle)).await.map_err(ProverError::Host)?;
-
-        // Extract oracle from Arc. Safe because Host drops its clone after
-        // build_witness returns — no background tasks retain a reference.
-        let oracle = Arc::try_unwrap(oracle).map_err(|_| ProverError::WitnessNotRecovered)?;
-
-        info!(
-            preimage_count = oracle.preimage_count(),
-            "witness generation complete, starting proving"
-        );
+        let oracle = host.build_witness(oracle).await.map_err(ProverError::Host)?;
 
         self.backend.prove(oracle).await.map_err(ProverError::Backend)
     }
@@ -73,11 +61,6 @@ pub enum ProverError<B: ProverBackend> {
     /// Backend proving failed.
     #[error("proving failed: {0}")]
     Backend(B::Error),
-
-    /// Witness oracle could not be recovered after witness generation.
-    /// This indicates a bug — Host should drop all references before returning.
-    #[error("failed to recover witness oracle after witness generation")]
-    WitnessNotRecovered,
 }
 
 #[cfg(test)]
@@ -97,12 +80,21 @@ mod tests {
     }
 
     impl WitnessOracle for NoopOracle {
-        fn insert_preimage(&self, key: PreimageKey, value: &[u8]) {
+        fn insert_preimage(
+            &self,
+            key: PreimageKey,
+            value: &[u8],
+        ) -> base_proof_preimage::WitnessOracleResult<()> {
             self.preimages.write().unwrap().insert(key, value.to_vec());
+            Ok(())
         }
-        fn finalize(&self) {}
-        fn preimage_count(&self) -> usize {
-            self.preimages.read().unwrap().len()
+
+        fn finalize(&self) -> base_proof_preimage::WitnessOracleResult<()> {
+            Ok(())
+        }
+
+        fn preimage_count(&self) -> base_proof_preimage::WitnessOracleResult<usize> {
+            Ok(self.preimages.read().unwrap().len())
         }
     }
 
@@ -137,11 +129,5 @@ mod tests {
         let err: ProverError<NoopBackend> = ProverError::Backend(NoopError);
         assert!(err.to_string().contains("proving failed"));
         assert!(err.to_string().contains("noop"));
-    }
-
-    #[test]
-    fn prover_error_witness_not_recovered_display() {
-        let err: ProverError<NoopBackend> = ProverError::WitnessNotRecovered;
-        assert!(err.to_string().contains("failed to recover witness oracle"));
     }
 }

--- a/crates/proof/host/src/service.rs
+++ b/crates/proof/host/src/service.rs
@@ -1,0 +1,147 @@
+use std::{fmt, sync::Arc};
+
+use base_proof_preimage::WitnessOracle;
+use base_proof_primitives::{ProofRequest, ProofResult, ProverBackend};
+use tracing::info;
+
+use crate::{Host, HostConfig, HostError, ProverConfig};
+
+/// Orchestrates witness generation ([`Host`]) and proving ([`ProverBackend`]).
+///
+/// Long-lived — holds static config and a backend instance.
+/// Receives per-proof [`ProofRequest`]s via [`prove_block`](Self::prove_block).
+pub struct ProverService<B: ProverBackend> {
+    config: ProverConfig,
+    backend: B,
+}
+
+impl<B: ProverBackend> fmt::Debug for ProverService<B> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ProverService").field("config", &self.config).finish_non_exhaustive()
+    }
+}
+
+impl<B: ProverBackend> ProverService<B> {
+    /// Creates a new prover service.
+    pub const fn new(config: ProverConfig, backend: B) -> Self {
+        Self { config, backend }
+    }
+
+    /// Returns a reference to the prover configuration.
+    pub const fn config(&self) -> &ProverConfig {
+        &self.config
+    }
+
+    /// Prove a single block.
+    ///
+    /// 1. Assembles [`HostConfig`] from static config + per-proof request
+    /// 2. Creates a fresh [`Host`] (connects RPCs internally)
+    /// 3. Creates a backend-specific oracle via [`ProverBackend::create_oracle`]
+    /// 4. Runs witness generation via [`Host::build_witness`]
+    /// 5. Hands the populated oracle to [`ProverBackend::prove`]
+    pub async fn prove_block(&self, request: ProofRequest) -> Result<ProofResult, ProverError<B>> {
+        info!(l2_block = request.claimed_l2_block_number, "starting proof generation");
+
+        let host = Host::new(HostConfig { request, prover: self.config.clone(), data_dir: None });
+        let oracle = self.backend.create_oracle();
+        let oracle = Arc::new(oracle);
+
+        host.build_witness(Arc::clone(&oracle)).await.map_err(ProverError::Host)?;
+
+        // Extract oracle from Arc. Safe because Host drops its clone after
+        // build_witness returns — no background tasks retain a reference.
+        let oracle = Arc::try_unwrap(oracle).map_err(|_| ProverError::WitnessNotRecovered)?;
+
+        info!(
+            preimage_count = oracle.preimage_count(),
+            "witness generation complete, starting proving"
+        );
+
+        self.backend.prove(oracle).await.map_err(ProverError::Backend)
+    }
+}
+
+/// Error type for [`ProverService`] operations.
+///
+/// Generic over the backend to carry its specific error type without boxing.
+#[derive(Debug, thiserror::Error)]
+pub enum ProverError<B: ProverBackend> {
+    /// Witness generation failed.
+    #[error("witness generation failed: {0}")]
+    Host(HostError),
+
+    /// Backend proving failed.
+    #[error("proving failed: {0}")]
+    Backend(B::Error),
+
+    /// Witness oracle could not be recovered after witness generation.
+    /// This indicates a bug — Host should drop all references before returning.
+    #[error("failed to recover witness oracle after witness generation")]
+    WitnessNotRecovered,
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{collections::HashMap, sync::RwLock};
+
+    use base_proof_preimage::{PreimageKey, WitnessOracle};
+
+    use super::*;
+
+    /// Minimal backend for testing trait bounds and `ProverService` compilation.
+    struct NoopBackend;
+
+    #[derive(Debug, Default)]
+    struct NoopOracle {
+        preimages: RwLock<HashMap<PreimageKey, Vec<u8>>>,
+    }
+
+    impl WitnessOracle for NoopOracle {
+        fn insert_preimage(&self, key: PreimageKey, value: &[u8]) {
+            self.preimages.write().unwrap().insert(key, value.to_vec());
+        }
+        fn finalize(&self) {}
+        fn preimage_count(&self) -> usize {
+            self.preimages.read().unwrap().len()
+        }
+    }
+
+    #[derive(Debug, thiserror::Error)]
+    #[error("noop")]
+    struct NoopError;
+
+    #[async_trait::async_trait]
+    impl ProverBackend for NoopBackend {
+        type Oracle = NoopOracle;
+        type Error = NoopError;
+
+        fn create_oracle(&self) -> Self::Oracle {
+            NoopOracle::default()
+        }
+
+        async fn prove(&self, _witness: Self::Oracle) -> Result<ProofResult, Self::Error> {
+            Err(NoopError)
+        }
+    }
+
+    #[test]
+    fn prover_error_host_display() {
+        let err: ProverError<NoopBackend> =
+            ProverError::Host(HostError::Custom("rpc timeout".into()));
+        assert!(err.to_string().contains("witness generation failed"));
+        assert!(err.to_string().contains("rpc timeout"));
+    }
+
+    #[test]
+    fn prover_error_backend_display() {
+        let err: ProverError<NoopBackend> = ProverError::Backend(NoopError);
+        assert!(err.to_string().contains("proving failed"));
+        assert!(err.to_string().contains("noop"));
+    }
+
+    #[test]
+    fn prover_error_witness_not_recovered_display() {
+        let err: ProverError<NoopBackend> = ProverError::WitnessNotRecovered;
+        assert!(err.to_string().contains("failed to recover witness oracle"));
+    }
+}

--- a/crates/proof/host/src/service.rs
+++ b/crates/proof/host/src/service.rs
@@ -9,7 +9,7 @@ use crate::{Host, HostConfig, HostError, ProverConfig};
 ///
 /// Long-lived — holds static config and a backend instance.
 /// Receives per-proof [`ProofRequest`]s via [`prove_block`](Self::prove_block).
-pub struct ProverService<B: ProverBackend> {
+pub struct ProverService<B> {
     config: ProverConfig,
     backend: B,
 }

--- a/crates/proof/primitives/Cargo.toml
+++ b/crates/proof/primitives/Cargo.toml
@@ -12,6 +12,7 @@ workspace = true
 
 [dependencies]
 # General
+async-trait.workspace = true
 alloy-primitives = { workspace = true }
 base-proof-preimage = { workspace = true }
 serde = { workspace = true, optional = true, features = ["derive"] }

--- a/crates/proof/primitives/src/lib.rs
+++ b/crates/proof/primitives/src/lib.rs
@@ -7,4 +7,7 @@ mod witness;
 pub use witness::WitnessBundle;
 
 mod proof;
-pub use proof::{ProofClaim, ProofEvidence, ProofResult};
+pub use proof::{ProofClaim, ProofEvidence, ProofRequest, ProofResult};
+
+mod prover;
+pub use prover::ProverBackend;

--- a/crates/proof/primitives/src/proof.rs
+++ b/crates/proof/primitives/src/proof.rs
@@ -43,3 +43,22 @@ pub struct ProofResult {
     /// The backend-specific evidence for this claim.
     pub evidence: ProofEvidence,
 }
+
+/// Per-proof parameters — which block to prove.
+///
+/// Maps 1:1 to `BootInfo` local preimage keys on the guest side.
+/// Changes every proof; the caller passes one per `prove_block()` call.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct ProofRequest {
+    /// Hash of the L1 head block.
+    pub l1_head: B256,
+    /// Hash of the agreed-upon safe L2 block.
+    pub agreed_l2_head_hash: B256,
+    /// Agreed safe L2 output root to start derivation from.
+    pub agreed_l2_output_root: B256,
+    /// Claimed L2 output root to validate.
+    pub claimed_l2_output_root: B256,
+    /// L2 block number that the claimed output root commits to.
+    pub claimed_l2_block_number: u64,
+}

--- a/crates/proof/primitives/src/prover.rs
+++ b/crates/proof/primitives/src/prover.rs
@@ -1,0 +1,32 @@
+use alloc::boxed::Box;
+use core::fmt::Debug;
+
+use base_proof_preimage::WitnessOracle;
+
+use crate::ProofResult;
+
+/// A proof backend that owns its witness oracle type and proving logic.
+///
+/// Each backend (TEE, SP1, RISC Zero) implements this with its own
+/// oracle storage layout and proving strategy.
+///
+/// The oracle type must implement [`WitnessOracle`] for the capture path
+/// (receiving preimages during witness generation) and must be `Send + Sync`
+/// so it can be shared with the host's preimage server.
+#[async_trait::async_trait]
+pub trait ProverBackend: Send + Sync {
+    /// The backend-specific oracle that receives preimages during witness generation.
+    type Oracle: WitnessOracle + Debug + Send + Sync + 'static;
+
+    /// The error type returned by this backend's proving operations.
+    type Error: core::error::Error + Send + Sync + 'static;
+
+    /// Create a fresh oracle instance for a single proof's witness generation.
+    fn create_oracle(&self) -> Self::Oracle;
+
+    /// Execute the proof using the populated witness oracle.
+    ///
+    /// Called after [`Host::build_witness`] has filled the oracle with preimages
+    /// and called `finalize()`.
+    async fn prove(&self, witness: Self::Oracle) -> Result<ProofResult, Self::Error>;
+}


### PR DESCRIPTION
## Summary
- Add `ProverBackend` async trait in `base-proof-primitives` defining the interface for proving backends (create oracle, produce proof)
- Add `ProverService<B>` orchestrator in `base-proof-host` that wires together `Host` witness generation and `ProverBackend::prove`
- Add `ProofRequest` struct to `base-proof-primitives` for per-proof parameters (block number, L2 claim, output root, etc.)
- Refactor `HostConfig`: embed `ProverConfig` (URLs, rollup/L1 configs) and `ProofRequest`, removing raw optional fields and runtime unwraps
- Remove `NoRollupConfig`/`NoL1Config` error variants — configs are now always present

## Motivation
The proof system currently couples static prover configuration (RPC URLs, chain configs) with per-proof request data (block number, claims) inside a single flat `HostConfig`. This makes it hard for different proving backends to share the host infrastructure.

This PR introduces:
1. **`ProofRequest`** — a standalone struct for per-proof parameters, separating them from long-lived config
2. **`ProverConfig`** — static configuration (URLs, chain configs) embedded in `HostConfig`, replacing optional fields with always-present values
3. **`ProverBackend` trait** — the async interface that proving backends implement: `create_oracle()` for a fresh witness oracle and `prove(oracle)` to produce a proof from the populated oracle
4. **`ProverService<B>`** — the orchestrator that owns a `ProverConfig` + backend, receives `ProofRequest`s, spins up a `Host` for witness generation, and hands the populated oracle to the backend for proving

Future backends (e.g. SP1/Succinct, Nitro) will implement `ProverBackend` and plug into `ProverService` without touching host/witness logic.

## Changes
| File | Change |
|------|--------|
| `proof/primitives/src/proof.rs` | Add `ProofRequest` struct |
| `proof/primitives/src/prover.rs` | Add `ProverBackend` async trait |
| `proof/host/src/config.rs` | Refactor `HostConfig` to embed `ProverConfig` + `ProofRequest`; remove optional URL fields |
| `proof/host/src/service.rs` | Add `ProverService<B>` and `ProverError<B>` with tests |
| `proof/host/src/error.rs` | Remove `NoRollupConfig`/`NoL1Config` variants |
| `proof/host/src/host.rs` | Simplify `create_providers()` — no more `.ok_or_else()` unwrapping |
| `proof/host/src/handler.rs` | Update field access (`cfg.prover.*`, `cfg.request.*`) |
| `proof/host/src/kv/boot.rs` | Update field access |