### PR TITLE
chore(consensus): Reduce P2P Logging Verbosity [backport v0.6.0]

### DIFF
--- a/crates/consensus/gossip/src/driver.rs
+++ b/crates/consensus/gossip/src/driver.rs
@@ -397,7 +397,7 @@ where
             }
             SwarmEvent::ConnectionEstablished { peer_id, .. } => {
                 let peer_count = self.swarm.connected_peers().count();
-                info!(target: "gossip", peer_id = %peer_id, peer_count, "Connection established");
+                debug!(target: "gossip", peer_id = %peer_id, peer_count, "Connection established");
                 base_macros::inc!(
                     gauge,
                     crate::Metrics::GOSSIPSUB_CONNECTION,
@@ -434,7 +434,7 @@ where
             }
             SwarmEvent::ConnectionClosed { peer_id, cause, .. } => {
                 let peer_count = self.swarm.connected_peers().count();
-                warn!(target: "gossip", ?peer_id, ?cause, peer_count, "Connection closed");
+                debug!(target: "gossip", ?peer_id, ?cause, peer_count, "Connection closed");
                 base_macros::inc!(
                     gauge,
                     crate::Metrics::GOSSIPSUB_CONNECTION,


### PR DESCRIPTION
Backport of #1088 into `releases/v0.6.0`.

## Summary

Reduces P2P logging verbosity for logs that aren't actionable and just spam the logs.

## Backport

Cherry-picked from merge commit `7640d17be94b12723620b070f0b0e43087d3faa6`.