### PR TITLE
feat(challenger): Add tee_prover() and nullify() to proof contract bindings

### DIFF
--- a/crates/proof/challenge/src/test_utils.rs
+++ b/crates/proof/challenge/src/test_utils.rs
@@ -21,6 +21,8 @@ pub struct MockGameState {
     pub status: u8,
     /// Address of the ZK prover (`Address::ZERO` if unchallenged).
     pub zk_prover: Address,
+    /// Address of the TEE prover (`Address::ZERO` if no TEE proof submitted).
+    pub tee_prover: Address,
     /// Game info (root claim, L2 block number, parent index).
     pub game_info: GameInfo,
     /// Starting block number for this game.
@@ -86,6 +88,13 @@ impl AggregateVerifierClient for MockAggregateVerifier {
             .ok_or_else(|| ContractError::Validation(format!("unknown game {game_address}")))
     }
 
+    async fn tee_prover(&self, game_address: Address) -> Result<Address, ContractError> {
+        self.games
+            .get(&game_address)
+            .map(|s| s.tee_prover)
+            .ok_or_else(|| ContractError::Validation(format!("unknown game {game_address}")))
+    }
+
     async fn starting_block_number(&self, game_address: Address) -> Result<u64, ContractError> {
         self.games
             .get(&game_address)
@@ -122,6 +131,7 @@ fn mock_state(status: u8, zk_prover: Address, block_number: u64) -> MockGameStat
     MockGameState {
         status,
         zk_prover,
+        tee_prover: Address::ZERO,
         game_info: GameInfo {
             root_claim: B256::repeat_byte(block_number as u8),
             l2_block_number: block_number,

--- a/crates/proof/challenge/src/test_utils.rs
+++ b/crates/proof/challenge/src/test_utils.rs
@@ -128,10 +128,20 @@ fn factory_game(index: u64, game_type: u32) -> GameAtIndex {
 
 /// Helper to build mock game state for the verifier.
 fn mock_state(status: u8, zk_prover: Address, block_number: u64) -> MockGameState {
+    mock_state_with_tee(status, zk_prover, Address::ZERO, block_number)
+}
+
+/// Helper to build mock game state with an explicit TEE prover address.
+fn mock_state_with_tee(
+    status: u8,
+    zk_prover: Address,
+    tee_prover: Address,
+    block_number: u64,
+) -> MockGameState {
     MockGameState {
         status,
         zk_prover,
-        tee_prover: Address::ZERO,
+        tee_prover,
         game_info: GameInfo {
             root_claim: B256::repeat_byte(block_number as u8),
             l2_block_number: block_number,
@@ -467,6 +477,37 @@ mod tests {
         assert_eq!(candidates[0].index, 1);
         assert_eq!(candidates[1].index, 2);
         assert_eq!(new_last_scanned, Some(2));
+    }
+
+    /// Games with a non-zero TEE prover but zero ZK prover are still candidates.
+    ///
+    /// The scanner currently filters only on `zk_prover`; a TEE proof alone does
+    /// not mark a game as challenged. This test guards that behaviour so a future
+    /// change to the filtering logic will surface as a test failure.
+    #[tokio::test]
+    async fn test_scan_tee_prover_nonzero_still_candidate() {
+        let tee_addr = Address::repeat_byte(0xEE);
+
+        let factory = Arc::new(MockDisputeGameFactory {
+            games: vec![factory_game(0, 1), factory_game(1, 1)],
+        });
+
+        let mut verifier_games = HashMap::new();
+        // Game 0: IN_PROGRESS, no ZK prover, but has a TEE prover -> still a candidate
+        verifier_games.insert(addr(0), mock_state_with_tee(0, Address::ZERO, tee_addr, 100));
+        // Game 1: IN_PROGRESS, no ZK prover, no TEE prover -> candidate
+        verifier_games.insert(addr(1), mock_state(0, Address::ZERO, 200));
+
+        let verifier = Arc::new(MockAggregateVerifier { games: verifier_games });
+
+        let scanner = GameScanner::new(factory, verifier, ScannerConfig { lookback_games: 1000 });
+
+        let (candidates, new_last_scanned) = scanner.scan(None).await.unwrap();
+
+        assert_eq!(candidates.len(), 2);
+        assert_eq!(candidates[0].index, 0);
+        assert_eq!(candidates[1].index, 1);
+        assert_eq!(new_last_scanned, Some(1));
     }
 
     /// Error at the first index (0) with `last_scanned = None` preserves fresh-start semantics.

--- a/crates/proof/contracts/README.md
+++ b/crates/proof/contracts/README.md
@@ -11,7 +11,7 @@ Provides async client traits and concrete Alloy-backed implementations for:
 
 - **`DisputeGameFactoryClient`**: Creating new dispute games and querying existing ones.
 - **`AnchorStateRegistryClient`**: Reading the anchor state (latest finalized output root).
-- **`AggregateVerifierClient`**: Querying individual dispute game instances and reading onchain configuration (`BLOCK_INTERVAL`, `INTERMEDIATE_BLOCK_INTERVAL`).
+- **`AggregateVerifierClient`**: Querying individual dispute game instances (status, ZK/TEE prover addresses, output roots), reading onchain configuration (`BLOCK_INTERVAL`, `INTERMEDIATE_BLOCK_INTERVAL`), and constructing state-changing calls such as `nullify` via the sol!-generated `IAggregateVerifier::nullifyCall` type.
 
 Also provides shared data types (`GameAtIndex`, `AnchorRoot`, `GameInfo`), pure encoding helpers
 (`encode_extra_data`, `encode_create_calldata`), and a `ContractError` type for error handling.

--- a/crates/proof/contracts/README.md
+++ b/crates/proof/contracts/README.md
@@ -11,10 +11,10 @@ Provides async client traits and concrete Alloy-backed implementations for:
 
 - **`DisputeGameFactoryClient`**: Creating new dispute games and querying existing ones.
 - **`AnchorStateRegistryClient`**: Reading the anchor state (latest finalized output root).
-- **`AggregateVerifierClient`**: Querying individual dispute game instances (status, ZK/TEE prover addresses, output roots), reading onchain configuration (`BLOCK_INTERVAL`, `INTERMEDIATE_BLOCK_INTERVAL`), and constructing state-changing calls such as `nullify` via the sol!-generated `IAggregateVerifier::nullifyCall` type.
+- **`AggregateVerifierClient`**: Querying individual dispute game instances (status, ZK/TEE prover addresses, output roots), reading onchain configuration (`BLOCK_INTERVAL`, `INTERMEDIATE_BLOCK_INTERVAL`), and constructing state-changing calls such as `nullify` via [`encode_nullify_calldata`].
 
 Also provides shared data types (`GameAtIndex`, `AnchorRoot`, `GameInfo`), pure encoding helpers
-(`encode_extra_data`, `encode_create_calldata`), and a `ContractError` type for error handling.
+(`encode_extra_data`, `encode_create_calldata`, `encode_nullify_calldata`), and a `ContractError` type for error handling.
 
 These bindings are used by both [`base-proposer`](../proposer/) and the challenger.
 

--- a/crates/proof/contracts/src/aggregate_verifier.rs
+++ b/crates/proof/contracts/src/aggregate_verifier.rs
@@ -45,6 +45,18 @@ sol! {
 
         /// Returns the starting block number.
         function startingBlockNumber() external view returns (uint256);
+
+        /// Nullifies an intermediate root checkpoint for the given game.
+        ///
+        /// The first byte of `proofBytes` is the proof type discriminator:
+        /// `0` for TEE, `1` for ZK. This is a state-changing function—no
+        /// Rust trait method is provided. Use `IAggregateVerifier::nullifyCall`
+        /// directly via alloy.
+        function nullify(
+            bytes calldata proofBytes,
+            uint256 intermediateRootIndex,
+            bytes32 intermediateRootToProve
+        ) external;
     }
 }
 
@@ -70,6 +82,9 @@ pub trait AggregateVerifierClient: Send + Sync {
 
     /// Returns the address that provided a ZK proof for the given game.
     async fn zk_prover(&self, game_address: Address) -> Result<Address, ContractError>;
+
+    /// Returns the address that provided a TEE proof for the given game.
+    async fn tee_prover(&self, game_address: Address) -> Result<Address, ContractError>;
 
     /// Returns the starting block number for the given game.
     async fn starting_block_number(&self, game_address: Address) -> Result<u64, ContractError>;
@@ -147,6 +162,17 @@ impl AggregateVerifierClient for AggregateVerifierContractClient {
             .call()
             .await
             .map_err(|e| ContractError::Call { context: "zkProver failed".into(), source: e })
+    }
+
+    async fn tee_prover(&self, game_address: Address) -> Result<Address, ContractError> {
+        let contract =
+            IAggregateVerifier::IAggregateVerifierInstance::new(game_address, &self.provider);
+
+        contract
+            .teeProver()
+            .call()
+            .await
+            .map_err(|e| ContractError::Call { context: "teeProver failed".into(), source: e })
     }
 
     async fn starting_block_number(&self, game_address: Address) -> Result<u64, ContractError> {

--- a/crates/proof/contracts/src/aggregate_verifier.rs
+++ b/crates/proof/contracts/src/aggregate_verifier.rs
@@ -256,3 +256,50 @@ pub fn encode_nullify_calldata(
     };
     Bytes::from(call.abi_encode())
 }
+
+#[cfg(test)]
+mod tests {
+    use alloy_sol_types::SolCall as _;
+
+    use super::*;
+
+    #[test]
+    fn test_encode_nullify_calldata_has_selector() {
+        let calldata = encode_nullify_calldata(
+            Bytes::from(vec![0x00, 0xAA, 0xBB]),
+            42,
+            B256::repeat_byte(0xFF),
+        );
+        assert_eq!(&calldata[..4], &IAggregateVerifier::nullifyCall::SELECTOR);
+    }
+
+    #[test]
+    fn test_encode_nullify_calldata_roundtrip() {
+        let proof_bytes = Bytes::from(vec![0x01, 0xDE, 0xAD]);
+        let index = 7u64;
+        let root = B256::repeat_byte(0xAB);
+
+        let calldata = encode_nullify_calldata(proof_bytes.clone(), index, root);
+
+        let decoded = IAggregateVerifier::nullifyCall::abi_decode(&calldata)
+            .expect("round-trip decode should succeed");
+
+        assert_eq!(decoded.proofBytes, proof_bytes);
+        assert_eq!(decoded.intermediateRootIndex, U256::from(index));
+        assert_eq!(decoded.intermediateRootToProve, root);
+    }
+
+    #[test]
+    fn test_encode_nullify_calldata_empty_proof_bytes() {
+        let calldata = encode_nullify_calldata(Bytes::new(), 0, B256::ZERO);
+
+        assert_eq!(&calldata[..4], &IAggregateVerifier::nullifyCall::SELECTOR);
+
+        let decoded = IAggregateVerifier::nullifyCall::abi_decode(&calldata)
+            .expect("decode with empty proof bytes should succeed");
+
+        assert!(decoded.proofBytes.is_empty());
+        assert_eq!(decoded.intermediateRootIndex, U256::ZERO);
+        assert_eq!(decoded.intermediateRootToProve, B256::ZERO);
+    }
+}

--- a/crates/proof/contracts/src/aggregate_verifier.rs
+++ b/crates/proof/contracts/src/aggregate_verifier.rs
@@ -3,12 +3,12 @@
 //! Used to query individual dispute game instances (status, ZK/TEE prover
 //! addresses, output roots), read configuration such as `BLOCK_INTERVAL`
 //! and `INTERMEDIATE_BLOCK_INTERVAL` from the implementation contract, and
-//! construct state-changing calls like `nullify` via the sol!-generated
-//! `IAggregateVerifier::nullifyCall` type.
+//! construct state-changing calls like `nullify` via
+//! [`encode_nullify_calldata`].
 
-use alloy_primitives::{Address, B256, U256};
+use alloy_primitives::{Address, B256, Bytes, U256};
 use alloy_provider::RootProvider;
-use alloy_sol_types::sol;
+use alloy_sol_types::{SolCall, sol};
 use async_trait::async_trait;
 
 use crate::ContractError;
@@ -52,9 +52,8 @@ sol! {
         /// Nullifies an intermediate root checkpoint for the given game.
         ///
         /// The first byte of `proofBytes` is the proof type discriminator:
-        /// `0` for TEE, `1` for ZK. This is a state-changing function—no
-        /// Rust trait method is provided. Use `IAggregateVerifier::nullifyCall`
-        /// directly via alloy.
+        /// `0` for TEE, `1` for ZK. Use [`encode_nullify_calldata`] to
+        /// construct ABI-encoded calldata for this function.
         function nullify(
             bytes calldata proofBytes,
             uint256 intermediateRootIndex,
@@ -239,4 +238,21 @@ impl AggregateVerifierClient for AggregateVerifierContractClient {
 
         Ok(interval)
     }
+}
+
+/// Encodes the calldata for `IAggregateVerifier.nullify()`.
+///
+/// The first byte of `proof_bytes` is the proof type discriminator:
+/// `0` for TEE, `1` for ZK.
+pub fn encode_nullify_calldata(
+    proof_bytes: Bytes,
+    intermediate_root_index: u64,
+    intermediate_root_to_prove: B256,
+) -> Bytes {
+    let call = IAggregateVerifier::nullifyCall {
+        proofBytes: proof_bytes,
+        intermediateRootIndex: U256::from(intermediate_root_index),
+        intermediateRootToProve: intermediate_root_to_prove,
+    };
+    Bytes::from(call.abi_encode())
 }

--- a/crates/proof/contracts/src/aggregate_verifier.rs
+++ b/crates/proof/contracts/src/aggregate_verifier.rs
@@ -1,7 +1,10 @@
 //! `AggregateVerifier` contract bindings.
 //!
-//! Used to query individual dispute game instances and read the
-//! `BLOCK_INTERVAL` from the implementation contract at startup.
+//! Used to query individual dispute game instances (status, ZK/TEE prover
+//! addresses, output roots), read configuration such as `BLOCK_INTERVAL`
+//! and `INTERMEDIATE_BLOCK_INTERVAL` from the implementation contract, and
+//! construct state-changing calls like `nullify` via the sol!-generated
+//! `IAggregateVerifier::nullifyCall` type.
 
 use alloy_primitives::{Address, B256, U256};
 use alloy_provider::RootProvider;

--- a/crates/proof/contracts/src/lib.rs
+++ b/crates/proof/contracts/src/lib.rs
@@ -3,7 +3,9 @@
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 
 mod aggregate_verifier;
-pub use aggregate_verifier::{AggregateVerifierClient, AggregateVerifierContractClient, GameInfo};
+pub use aggregate_verifier::{
+    AggregateVerifierClient, AggregateVerifierContractClient, GameInfo, encode_nullify_calldata,
+};
 
 mod anchor_state_registry;
 pub use anchor_state_registry::{


### PR DESCRIPTION
### What changed? Why?
Adds `tee_prover()` and `nullify()` to the AggregateVerifier contract bindings, enabling the scanner to read TEE prover addresses and the challenge submitter to construct nullification calls. This is a breaking change because the `AggregateVerifierClient` trait gains a new required method.

### How has it been tested?
All 53 existing tests pass. Clippy and `just fix` run cleanly. The mock verifier in test_utils is updated with `tee_prover` defaulting to `Address::ZERO`, so no existing call sites required changes.

### Notes to reviewers
Breaking change: external implementors of `AggregateVerifierClient` must add a `tee_prover()` method. The `nullify()` binding is intentionally sol!-only with no trait method—callers use `IAggregateVerifier::nullifyCall` directly via alloy.

In a future PR will remove the contracts crate in favor of importing directly from `base/contracts` (once Baptiste is done setting that up).

### Change management
type=routine
risk=low
impact=sev5

### Backwards Compatibility
backwards_compatible=false

automerge=false