### PR TITLE
docs: add hardfork activation timestamp tables

### DIFF
--- a/docs/specs/pages/protocol/canyon/overview.md
+++ b/docs/specs/pages/protocol/canyon/overview.md
@@ -1,5 +1,12 @@
 # Canyon
 
+## Activation Timestamps
+
+| Network | Activation timestamp |
+| --- | --- |
+| `mainnet` | `1704992401` (2024-01-11 17:00:01 UTC) |
+| `sepolia` | `1699981200` (2023-11-14 17:00:00 UTC) |
+
 [eip3651]: https://eips.ethereum.org/EIPS/eip-3651
 [eip3855]: https://eips.ethereum.org/EIPS/eip-3855
 [eip3860]: https://eips.ethereum.org/EIPS/eip-3860

--- a/docs/specs/pages/protocol/delta/overview.md
+++ b/docs/specs/pages/protocol/delta/overview.md
@@ -1,5 +1,12 @@
 # Delta
 
+## Activation Timestamps
+
+| Network | Activation timestamp |
+| --- | --- |
+| `mainnet` | `1708560000` (2024-02-22 00:00:00 UTC) |
+| `sepolia` | `1703203200` (2023-12-22 00:00:00 UTC) |
+
 The Delta upgrade uses a _L2 block-timestamp_ activation-rule, and is specified only in the rollup-node (`delta_time`).
 
 ## Consensus Layer

--- a/docs/specs/pages/protocol/ecotone/overview.md
+++ b/docs/specs/pages/protocol/ecotone/overview.md
@@ -1,5 +1,12 @@
 # Ecotone Network Upgrade
 
+## Activation Timestamps
+
+| Network | Activation timestamp |
+| --- | --- |
+| `mainnet` | `1710374401` (2024-03-14 00:00:01 UTC) |
+| `sepolia` | `1708534800` (2024-02-21 17:00:00 UTC) |
+
 The Ecotone upgrade contains the Dencun upgrade from L1, and adopts EIP-4844 blobs for data-availability.
 
 ## Execution Layer

--- a/docs/specs/pages/protocol/fjord/overview.md
+++ b/docs/specs/pages/protocol/fjord/overview.md
@@ -1,5 +1,12 @@
 # Fjord Network Upgrade
 
+## Activation Timestamps
+
+| Network | Activation timestamp |
+| --- | --- |
+| `mainnet` | `1720627201` (2024-07-10 16:00:01 UTC) |
+| `sepolia` | `1716998400` (2024-05-29 16:00:00 UTC) |
+
 ## Execution Layer
 
 - [RIP-7212: Precompile for secp256r1 Curve Support](../precompiles.md#P256VERIFY)

--- a/docs/specs/pages/protocol/granite/overview.md
+++ b/docs/specs/pages/protocol/granite/overview.md
@@ -1,5 +1,12 @@
 # Granite Network Upgrade
 
+## Activation Timestamps
+
+| Network | Activation timestamp |
+| --- | --- |
+| `mainnet` | `1726070401` (2024-09-11 16:00:01 UTC) |
+| `sepolia` | `1723478400` (2024-08-12 16:00:00 UTC) |
+
 ## Execution Layer
 
 - [Limit `bn256Pairing` precompile input size](./exec-engine.md#bn256pairing-precompile-input-restriction)

--- a/docs/specs/pages/protocol/holocene/overview.md
+++ b/docs/specs/pages/protocol/holocene/overview.md
@@ -1,5 +1,12 @@
 # Holocene Network Upgrade
 
+## Activation Timestamps
+
+| Network | Activation timestamp |
+| --- | --- |
+| `mainnet` | `1736445601` (2025-01-09 18:00:01 UTC) |
+| `sepolia` | `1732633200` (2024-11-26 15:00:00 UTC) |
+
 ## Execution Layer
 
 - [Dynamic EIP-1559 Parameters](./exec-engine.md#dynamic-eip-1559-parameters)

--- a/docs/specs/pages/protocol/isthmus/overview.md
+++ b/docs/specs/pages/protocol/isthmus/overview.md
@@ -1,5 +1,12 @@
 # Isthmus Network Upgrade
 
+## Activation Timestamps
+
+| Network | Activation timestamp |
+| --- | --- |
+| `mainnet` | `1746806401` (2025-05-09 16:00:01 UTC) |
+| `sepolia` | `1744905600` (2025-04-17 16:00:00 UTC) |
+
 ## Execution Layer
 
 - [Pectra](https://eips.ethereum.org/EIPS/eip-7600) (Execution Layer):

--- a/docs/specs/pages/protocol/jovian/overview.md
+++ b/docs/specs/pages/protocol/jovian/overview.md
@@ -1,5 +1,12 @@
 # Jovian Network Upgrade
 
+## Activation Timestamps
+
+| Network | Activation timestamp |
+| --- | --- |
+| `mainnet` | `1764691201` (2025-12-02 16:00:01 UTC) |
+| `sepolia` | `1763568001` (2025-11-19 16:00:01 UTC) |
+
 ## Execution Layer
 
 - [Minimum Base Fee](./exec-engine.md#minimum-base-fee)

--- a/docs/specs/pages/protocol/pectra-blob-schedule/overview.md
+++ b/docs/specs/pages/protocol/pectra-blob-schedule/overview.md
@@ -1,5 +1,12 @@
 # Pectra Blob Schedule (Optional) Network Upgrade
 
+## Activation Timestamps
+
+| Network | Activation timestamp |
+| --- | --- |
+| `mainnet` | Not activated |
+| `sepolia` | `1742486400` (2025-03-20 16:00:00 UTC) |
+
 The Pectra Blob Schedule hardfork is an optional hardfork which delays the adoption of the
 Prague blob base fee update fraction until the specified time. Until that time, the Cancun
 update fraction from the previous fork is retained.


### PR DESCRIPTION
## Summary
- add an Activation Timestamps table at the top of each hardfork overview page
- include `mainnet` and `sepolia` activation timestamps sourced from Superchain Registry-backed configs
- mark Pectra Blob Schedule as not activated on mainnet because no mainnet activation timestamp is set

## Testing
- docs-only change