### PR TITLE
feat(metering): add per-flashblock estimation with cache

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3849,6 +3849,7 @@ dependencies = [
  "jsonrpsee",
  "metrics",
  "metrics-derive",
+ "parking_lot",
  "rand 0.9.2",
  "reth-db",
  "reth-db-common",

--- a/crates/client/metering/Cargo.toml
+++ b/crates/client/metering/Cargo.toml
@@ -48,6 +48,7 @@ base-alloy-flz.workspace = true
 # metrics
 metrics.workspace = true
 metrics-derive.workspace = true
+parking_lot.workspace = true
 
 # misc
 eyre.workspace = true

--- a/crates/client/metering/Cargo.toml
+++ b/crates/client/metering/Cargo.toml
@@ -48,11 +48,11 @@ base-alloy-flz.workspace = true
 # metrics
 metrics.workspace = true
 metrics-derive.workspace = true
-parking_lot.workspace = true
 
 # misc
 eyre.workspace = true
 arc-swap.workspace = true
+parking_lot.workspace = true
 derive_more.workspace = true
 thiserror.workspace = true
 serde = { workspace = true, features = ["std"] }

--- a/crates/client/metering/README.md
+++ b/crates/client/metering/README.md
@@ -95,12 +95,18 @@ Meters a bundle and returns a recommended priority fee based on recent block con
 
 **Algorithm:**
 1. Meter the bundle to get resource consumption (gas, execution time, DA bytes)
-2. Meter the latest block to get historical transaction data
-3. For each resource type, run the estimation algorithm:
-   - Walk from highest-paying transactions, subtracting usage from remaining capacity
-   - Stop when adding another tx would leave less room than the bundle needs
-   - The last included tx's fee is the threshold
-4. Return the maximum fee across all resources as `priorityFee`
+2. Use cached metering data from the latest block (populated by ingestion pipeline)
+3. For each flashblock within the block:
+   - For each resource type, run the estimation algorithm:
+     - Walk from highest-paying transactions, subtracting usage from remaining capacity
+     - Stop when adding another tx would leave less room than the bundle needs
+     - The last included tx's fee is the threshold
+   - For "use-it-or-lose-it" resources (execution time), aggregate usage across all flashblocks
+4. Take the maximum fee across all flashblocks for each resource
+5. Return the maximum fee across all resources as `priorityFee`
+
+Note: The cache must be populated by the ingestion pipeline for estimates to be available.
+Currently returns `blocksSampled: 1` since estimation uses a single block.
 
 ## License
 

--- a/crates/client/metering/src/cache.rs
+++ b/crates/client/metering/src/cache.rs
@@ -1,0 +1,367 @@
+//! In-memory cache for metering data used by the priority fee estimator.
+//!
+//! Transactions are stored in sequencer order (highest priority fee first) as received
+//! from flashblock events.
+
+use std::collections::BTreeMap;
+
+use alloy_primitives::{B256, U256};
+
+/// A metered transaction with resource consumption data.
+#[derive(Debug, Clone)]
+pub struct MeteredTransaction {
+    /// Transaction hash.
+    pub tx_hash: B256,
+    /// Priority fee per gas for ordering.
+    pub priority_fee_per_gas: U256,
+    /// Gas consumed.
+    pub gas_used: u64,
+    /// Execution time in microseconds.
+    pub execution_time_us: u128,
+    /// State root computation time in microseconds.
+    pub state_root_time_us: u128,
+    /// Data availability bytes.
+    pub data_availability_bytes: u64,
+}
+
+impl MeteredTransaction {
+    /// Creates a zeroed transaction (placeholder with no resource usage).
+    pub const fn zeroed(tx_hash: B256) -> Self {
+        Self {
+            tx_hash,
+            priority_fee_per_gas: U256::ZERO,
+            gas_used: 0,
+            execution_time_us: 0,
+            state_root_time_us: 0,
+            data_availability_bytes: 0,
+        }
+    }
+}
+
+/// Aggregated resource totals.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct ResourceTotals {
+    /// Total gas used.
+    pub gas_used: u64,
+    /// Total execution time in microseconds.
+    pub execution_time_us: u128,
+    /// Total state root time in microseconds.
+    pub state_root_time_us: u128,
+    /// Total data availability bytes.
+    pub data_availability_bytes: u64,
+}
+
+impl ResourceTotals {
+    const fn accumulate(&mut self, tx: &MeteredTransaction) {
+        self.gas_used = self.gas_used.saturating_add(tx.gas_used);
+        self.execution_time_us = self.execution_time_us.saturating_add(tx.execution_time_us);
+        self.state_root_time_us = self.state_root_time_us.saturating_add(tx.state_root_time_us);
+        self.data_availability_bytes =
+            self.data_availability_bytes.saturating_add(tx.data_availability_bytes);
+    }
+}
+
+/// Metrics for a single flashblock within a block.
+///
+/// Transactions are stored in sequencer order (highest priority fee first).
+#[derive(Debug)]
+pub struct FlashblockMetrics {
+    /// Block number.
+    pub block_number: u64,
+    /// Flashblock index within the block.
+    pub flashblock_index: u64,
+    /// Transactions in sequencer order.
+    transactions: Vec<MeteredTransaction>,
+    totals: ResourceTotals,
+}
+
+impl FlashblockMetrics {
+    /// Creates a new flashblock metrics container.
+    pub fn new(block_number: u64, flashblock_index: u64) -> Self {
+        Self {
+            block_number,
+            flashblock_index,
+            transactions: Vec::new(),
+            totals: ResourceTotals::default(),
+        }
+    }
+
+    /// Appends a transaction, preserving sequencer order.
+    pub fn push_transaction(&mut self, tx: MeteredTransaction) {
+        self.totals.accumulate(&tx);
+        self.transactions.push(tx);
+    }
+
+    /// Returns the resource totals for this flashblock.
+    pub const fn totals(&self) -> ResourceTotals {
+        self.totals
+    }
+
+    /// Returns transactions in sequencer order.
+    pub fn transactions(&self) -> &[MeteredTransaction] {
+        &self.transactions
+    }
+
+    /// Returns the number of transactions.
+    pub const fn len(&self) -> usize {
+        self.transactions.len()
+    }
+
+    /// Returns true if empty.
+    pub const fn is_empty(&self) -> bool {
+        self.transactions.is_empty()
+    }
+}
+
+/// Aggregated metrics for a block, including per-flashblock breakdown.
+#[derive(Debug)]
+pub struct BlockMetrics {
+    /// Block number.
+    pub block_number: u64,
+    flashblocks: BTreeMap<u64, FlashblockMetrics>,
+    totals: ResourceTotals,
+}
+
+impl BlockMetrics {
+    /// Creates a new block metrics container.
+    pub fn new(block_number: u64) -> Self {
+        Self { block_number, flashblocks: BTreeMap::new(), totals: ResourceTotals::default() }
+    }
+
+    /// Returns the number of flashblocks.
+    pub fn flashblock_count(&self) -> usize {
+        self.flashblocks.len()
+    }
+
+    /// Iterates over all flashblocks.
+    pub fn flashblocks(&self) -> impl Iterator<Item = &FlashblockMetrics> {
+        self.flashblocks.values()
+    }
+
+    /// Returns a mutable reference to the flashblock, creating it if necessary.
+    /// Returns `(flashblock, is_new)`.
+    pub fn flashblock_mut(&mut self, flashblock_index: u64) -> (&mut FlashblockMetrics, bool) {
+        let is_new = !self.flashblocks.contains_key(&flashblock_index);
+        let entry = self
+            .flashblocks
+            .entry(flashblock_index)
+            .or_insert_with(|| FlashblockMetrics::new(self.block_number, flashblock_index));
+        (entry, is_new)
+    }
+
+    /// Returns the resource totals for this block.
+    pub const fn totals(&self) -> ResourceTotals {
+        self.totals
+    }
+
+    const fn accumulate(&mut self, tx: &MeteredTransaction) {
+        self.totals.accumulate(tx);
+    }
+}
+
+/// In-memory cache maintaining metering data for the most recent blocks.
+///
+/// Blocks are stored in a `BTreeMap` keyed by block number, which enforces
+/// ascending order and provides O(log n) lookup without a separate index.
+#[derive(Debug)]
+pub struct MeteringCache {
+    max_blocks: usize,
+    blocks: BTreeMap<u64, BlockMetrics>,
+}
+
+impl MeteringCache {
+    /// Creates a new cache retaining at most `max_blocks` recent blocks.
+    /// A value of zero is clamped to 1.
+    pub fn new(max_blocks: usize) -> Self {
+        Self { max_blocks: max_blocks.max(1), blocks: BTreeMap::new() }
+    }
+
+    /// Returns the maximum number of blocks retained.
+    pub const fn max_blocks(&self) -> usize {
+        self.max_blocks
+    }
+
+    /// Returns the block metrics for the given block number.
+    pub fn block(&self, block_number: u64) -> Option<&BlockMetrics> {
+        self.blocks.get(&block_number)
+    }
+
+    /// Returns a mutable reference to the block, creating it if necessary.
+    pub fn block_mut(&mut self, block_number: u64) -> &mut BlockMetrics {
+        if !self.blocks.contains_key(&block_number) {
+            self.evict_oldest();
+        }
+        self.blocks.entry(block_number).or_insert_with(|| BlockMetrics::new(block_number))
+    }
+
+    /// Appends a transaction to the cache, preserving sequencer order.
+    pub fn push_transaction(
+        &mut self,
+        block_number: u64,
+        flashblock_index: u64,
+        tx: MeteredTransaction,
+    ) {
+        let block = self.block_mut(block_number);
+        block.accumulate(&tx);
+        let (flashblock, _) = block.flashblock_mut(flashblock_index);
+        flashblock.push_transaction(tx);
+    }
+
+    /// Returns the number of cached blocks.
+    pub fn len(&self) -> usize {
+        self.blocks.len()
+    }
+
+    /// Returns true if the cache is empty.
+    pub fn is_empty(&self) -> bool {
+        self.blocks.is_empty()
+    }
+
+    /// Iterates over blocks in descending order (most recent first).
+    pub fn blocks_desc(&self) -> impl Iterator<Item = &BlockMetrics> {
+        self.blocks.values().rev()
+    }
+
+    /// Returns true if the specified `block_number` exists in the cache.
+    pub fn contains_block(&self, block_number: u64) -> bool {
+        self.blocks.contains_key(&block_number)
+    }
+
+    /// Clears all blocks with `block_number` >= the specified value.
+    /// Returns the number of blocks cleared.
+    pub fn clear_blocks_from(&mut self, block_number: u64) -> usize {
+        let to_remove: Vec<u64> = self.blocks.range(block_number..).map(|(&k, _)| k).collect();
+        let cleared = to_remove.len();
+        for key in to_remove {
+            self.blocks.remove(&key);
+        }
+        cleared
+    }
+
+    /// Evicts the oldest block if at capacity. Called before inserting a new block.
+    fn evict_oldest(&mut self) {
+        while self.blocks.len() >= self.max_blocks {
+            self.blocks.pop_first();
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_tx(hash: u64, priority: u64) -> MeteredTransaction {
+        let mut hash_bytes = [0u8; 32];
+        hash_bytes[24..].copy_from_slice(&hash.to_be_bytes());
+        MeteredTransaction {
+            tx_hash: B256::new(hash_bytes),
+            priority_fee_per_gas: U256::from(priority),
+            gas_used: 10,
+            execution_time_us: 5,
+            state_root_time_us: 7,
+            data_availability_bytes: 20,
+        }
+    }
+
+    #[test]
+    fn insert_and_retrieve_transactions() {
+        let mut cache = MeteringCache::new(12);
+        let tx1 = test_tx(1, 2);
+        cache.push_transaction(100, 0, tx1.clone());
+
+        let block = cache.block(100).unwrap();
+        let flashblock = block.flashblocks().next().unwrap();
+        assert_eq!(flashblock.len(), 1);
+        assert_eq!(flashblock.transactions()[0].tx_hash, tx1.tx_hash);
+    }
+
+    #[test]
+    fn transactions_preserve_sequencer_order() {
+        let mut cache = MeteringCache::new(12);
+        // Insert in sequencer order (highest priority first)
+        cache.push_transaction(100, 0, test_tx(1, 30));
+        cache.push_transaction(100, 0, test_tx(2, 20));
+        cache.push_transaction(100, 0, test_tx(3, 10));
+
+        let block = cache.block(100).unwrap();
+        let flashblock = block.flashblocks().next().unwrap();
+        let fees: Vec<_> =
+            flashblock.transactions().iter().map(|tx| tx.priority_fee_per_gas).collect();
+        // Order should be preserved as inserted
+        assert_eq!(fees, vec![U256::from(30u64), U256::from(20u64), U256::from(10u64)]);
+    }
+
+    #[test]
+    fn evicts_old_blocks() {
+        let mut cache = MeteringCache::new(2);
+        for block_number in 0..3u64 {
+            cache.push_transaction(block_number, 0, test_tx(block_number, block_number));
+        }
+        assert!(cache.block(0).is_none());
+        assert!(cache.block(1).is_some());
+        assert!(cache.block(2).is_some());
+    }
+
+    #[test]
+    fn contains_block_returns_correct_values() {
+        let mut cache = MeteringCache::new(10);
+        cache.push_transaction(100, 0, test_tx(1, 10));
+        cache.push_transaction(101, 0, test_tx(2, 20));
+
+        assert!(cache.contains_block(100));
+        assert!(cache.contains_block(101));
+        assert!(!cache.contains_block(99));
+        assert!(!cache.contains_block(102));
+    }
+
+    #[test]
+    fn clear_blocks_from_clears_subsequent_blocks() {
+        let mut cache = MeteringCache::new(10);
+        cache.push_transaction(100, 0, test_tx(1, 10));
+        cache.push_transaction(101, 0, test_tx(2, 20));
+        cache.push_transaction(102, 0, test_tx(3, 30));
+
+        let cleared = cache.clear_blocks_from(101);
+
+        assert_eq!(cleared, 2);
+        assert!(cache.contains_block(100));
+        assert!(!cache.contains_block(101));
+        assert!(!cache.contains_block(102));
+        assert_eq!(cache.len(), 1);
+    }
+
+    #[test]
+    fn clear_blocks_from_returns_zero_when_no_match() {
+        let mut cache = MeteringCache::new(10);
+        cache.push_transaction(100, 0, test_tx(1, 10));
+        cache.push_transaction(101, 0, test_tx(2, 20));
+
+        let cleared = cache.clear_blocks_from(200);
+
+        assert_eq!(cleared, 0);
+        assert_eq!(cache.len(), 2);
+    }
+
+    #[test]
+    fn clear_blocks_from_clears_all_blocks() {
+        let mut cache = MeteringCache::new(10);
+        cache.push_transaction(100, 0, test_tx(1, 10));
+        cache.push_transaction(101, 0, test_tx(2, 20));
+        cache.push_transaction(102, 0, test_tx(3, 30));
+
+        let cleared = cache.clear_blocks_from(100);
+
+        assert_eq!(cleared, 3);
+        assert!(cache.is_empty());
+    }
+
+    #[test]
+    fn clear_blocks_from_handles_empty_cache() {
+        let mut cache = MeteringCache::new(10);
+
+        let cleared = cache.clear_blocks_from(100);
+
+        assert_eq!(cleared, 0);
+        assert!(cache.is_empty());
+    }
+}

--- a/crates/client/metering/src/cache.rs
+++ b/crates/client/metering/src/cache.rs
@@ -3,7 +3,7 @@
 //! Transactions are stored in sequencer order (highest priority fee first) as received
 //! from flashblock events.
 
-use std::collections::BTreeMap;
+use std::{collections::BTreeMap, num::NonZeroUsize};
 
 use alloy_primitives::{B256, U256};
 
@@ -128,11 +128,6 @@ impl BlockMetrics {
         Self { block_number, flashblocks: BTreeMap::new(), totals: ResourceTotals::default() }
     }
 
-    /// Returns the number of flashblocks.
-    pub fn flashblock_count(&self) -> usize {
-        self.flashblocks.len()
-    }
-
     /// Iterates over all flashblocks.
     pub fn flashblocks(&self) -> impl Iterator<Item = &FlashblockMetrics> {
         self.flashblocks.values()
@@ -166,19 +161,40 @@ impl BlockMetrics {
 #[derive(Debug)]
 pub struct MeteringCache {
     max_blocks: usize,
+    max_flashblocks_per_block: usize,
     blocks: BTreeMap<u64, BlockMetrics>,
 }
 
 impl MeteringCache {
-    /// Creates a new cache retaining at most `max_blocks` recent blocks.
-    /// A value of zero is clamped to 1.
-    pub fn new(max_blocks: usize) -> Self {
-        Self { max_blocks: max_blocks.max(1), blocks: BTreeMap::new() }
+    /// Creates a new cache retaining at most `max_blocks` recent blocks and
+    /// at most `max_flashblocks_per_block` flashblocks per block.
+    ///
+    /// `max_flashblocks_per_block` counts all flashblocks for a block, including
+    /// the base flashblock at index `0`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `max_blocks` or `max_flashblocks_per_block` is zero.
+    pub const fn new(max_blocks: usize, max_flashblocks_per_block: usize) -> Self {
+        Self {
+            max_blocks: NonZeroUsize::new(max_blocks)
+                .expect("max_blocks must be greater than 0")
+                .get(),
+            max_flashblocks_per_block: NonZeroUsize::new(max_flashblocks_per_block)
+                .expect("max_flashblocks_per_block must be greater than 0")
+                .get(),
+            blocks: BTreeMap::new(),
+        }
     }
 
     /// Returns the maximum number of blocks retained.
     pub const fn max_blocks(&self) -> usize {
         self.max_blocks
+    }
+
+    /// Returns the maximum number of flashblocks retained per block.
+    pub const fn max_flashblocks_per_block(&self) -> usize {
+        self.max_flashblocks_per_block
     }
 
     /// Returns the block metrics for the given block number.
@@ -200,11 +216,16 @@ impl MeteringCache {
         block_number: u64,
         flashblock_index: u64,
         tx: MeteredTransaction,
-    ) {
+    ) -> bool {
+        if flashblock_index >= self.max_flashblocks_per_block as u64 {
+            return false;
+        }
+
         let block = self.block_mut(block_number);
         block.accumulate(&tx);
         let (flashblock, _) = block.flashblock_mut(flashblock_index);
         flashblock.push_transaction(tx);
+        true
     }
 
     /// Returns the number of cached blocks.
@@ -230,12 +251,7 @@ impl MeteringCache {
     /// Clears all blocks with `block_number` >= the specified value.
     /// Returns the number of blocks cleared.
     pub fn clear_blocks_from(&mut self, block_number: u64) -> usize {
-        let to_remove: Vec<u64> = self.blocks.range(block_number..).map(|(&k, _)| k).collect();
-        let cleared = to_remove.len();
-        for key in to_remove {
-            self.blocks.remove(&key);
-        }
-        cleared
+        self.blocks.split_off(&block_number).len()
     }
 
     /// Evicts the oldest block if at capacity. Called before inserting a new block.
@@ -265,7 +281,7 @@ mod tests {
 
     #[test]
     fn insert_and_retrieve_transactions() {
-        let mut cache = MeteringCache::new(12);
+        let mut cache = MeteringCache::new(12, 1);
         let tx1 = test_tx(1, 2);
         cache.push_transaction(100, 0, tx1.clone());
 
@@ -277,7 +293,7 @@ mod tests {
 
     #[test]
     fn transactions_preserve_sequencer_order() {
-        let mut cache = MeteringCache::new(12);
+        let mut cache = MeteringCache::new(12, 1);
         // Insert in sequencer order (highest priority first)
         cache.push_transaction(100, 0, test_tx(1, 30));
         cache.push_transaction(100, 0, test_tx(2, 20));
@@ -293,7 +309,7 @@ mod tests {
 
     #[test]
     fn evicts_old_blocks() {
-        let mut cache = MeteringCache::new(2);
+        let mut cache = MeteringCache::new(2, 1);
         for block_number in 0..3u64 {
             cache.push_transaction(block_number, 0, test_tx(block_number, block_number));
         }
@@ -303,8 +319,20 @@ mod tests {
     }
 
     #[test]
+    #[should_panic(expected = "max_blocks must be greater than 0")]
+    fn zero_capacity_panics() {
+        let _ = MeteringCache::new(0, 1);
+    }
+
+    #[test]
+    #[should_panic(expected = "max_flashblocks_per_block must be greater than 0")]
+    fn zero_flashblock_capacity_panics() {
+        let _ = MeteringCache::new(1, 0);
+    }
+
+    #[test]
     fn contains_block_returns_correct_values() {
-        let mut cache = MeteringCache::new(10);
+        let mut cache = MeteringCache::new(10, 1);
         cache.push_transaction(100, 0, test_tx(1, 10));
         cache.push_transaction(101, 0, test_tx(2, 20));
 
@@ -316,7 +344,7 @@ mod tests {
 
     #[test]
     fn clear_blocks_from_clears_subsequent_blocks() {
-        let mut cache = MeteringCache::new(10);
+        let mut cache = MeteringCache::new(10, 1);
         cache.push_transaction(100, 0, test_tx(1, 10));
         cache.push_transaction(101, 0, test_tx(2, 20));
         cache.push_transaction(102, 0, test_tx(3, 30));
@@ -332,7 +360,7 @@ mod tests {
 
     #[test]
     fn clear_blocks_from_returns_zero_when_no_match() {
-        let mut cache = MeteringCache::new(10);
+        let mut cache = MeteringCache::new(10, 1);
         cache.push_transaction(100, 0, test_tx(1, 10));
         cache.push_transaction(101, 0, test_tx(2, 20));
 
@@ -344,7 +372,7 @@ mod tests {
 
     #[test]
     fn clear_blocks_from_clears_all_blocks() {
-        let mut cache = MeteringCache::new(10);
+        let mut cache = MeteringCache::new(10, 1);
         cache.push_transaction(100, 0, test_tx(1, 10));
         cache.push_transaction(101, 0, test_tx(2, 20));
         cache.push_transaction(102, 0, test_tx(3, 30));
@@ -357,11 +385,26 @@ mod tests {
 
     #[test]
     fn clear_blocks_from_handles_empty_cache() {
-        let mut cache = MeteringCache::new(10);
+        let mut cache = MeteringCache::new(10, 1);
 
         let cleared = cache.clear_blocks_from(100);
 
         assert_eq!(cleared, 0);
         assert!(cache.is_empty());
+    }
+
+    #[test]
+    fn ignores_transactions_beyond_flashblock_capacity() {
+        let mut cache = MeteringCache::new(10, 2);
+
+        assert!(cache.push_transaction(100, 0, test_tx(1, 10)));
+        assert!(cache.push_transaction(100, 1, test_tx(2, 20)));
+        assert!(!cache.push_transaction(100, 2, test_tx(3, 30)));
+
+        let block = cache.block(100).unwrap();
+        let flashblock_indexes: Vec<_> =
+            block.flashblocks().map(|flashblock| flashblock.flashblock_index).collect();
+        assert_eq!(flashblock_indexes, vec![0, 1]);
+        assert_eq!(block.totals().gas_used, 20);
     }
 }

--- a/crates/client/metering/src/estimator.rs
+++ b/crates/client/metering/src/estimator.rs
@@ -1,11 +1,14 @@
-//! Priority fee estimation based on resource consumption.
+//! Priority fee estimation based on resource consumption in flashblocks.
 //!
 //! This module provides the core algorithm for estimating the priority fee needed
 //! to achieve inclusion in a block, based on historical transaction data.
 
-use std::cmp::Reverse;
+use std::{cmp::Reverse, sync::Arc};
 
 use alloy_primitives::U256;
+use parking_lot::RwLock;
+
+use crate::cache::{BlockMetrics, MeteredTransaction, MeteringCache};
 
 /// Errors that can occur during priority fee estimation.
 #[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
@@ -27,17 +30,18 @@ pub enum EstimateError {
 
 /// Configured capacity limits for each resource type.
 ///
-/// These values define the maximum capacity available per block. The estimator
-/// uses these limits to determine when resources are congested.
+/// These values define the maximum capacity available per flashblock (or per block
+/// for "use-it-or-lose-it" resources). The estimator uses these limits to determine
+/// when resources are congested.
 #[derive(Debug, Clone, Copy, Default)]
 pub struct ResourceLimits {
-    /// Gas limit per block.
+    /// Gas limit per flashblock.
     pub gas_used: Option<u64>,
     /// Execution time budget in microseconds.
     pub execution_time_us: Option<u128>,
     /// State root computation time budget in microseconds.
     pub state_root_time_us: Option<u128>,
-    /// Data availability bytes limit per block.
+    /// Data availability bytes limit per flashblock.
     pub data_availability_bytes: Option<u64>,
 }
 
@@ -53,7 +57,7 @@ impl ResourceLimits {
     }
 }
 
-/// Resources that influence block inclusion ordering.
+/// Resources that influence flashblock inclusion ordering.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum ResourceKind {
     /// Gas consumption.
@@ -70,6 +74,20 @@ impl ResourceKind {
     /// Returns all resource kinds in a fixed order.
     pub const fn all() -> [Self; 4] {
         [Self::GasUsed, Self::ExecutionTime, Self::StateRootTime, Self::DataAvailability]
+    }
+
+    /// Returns `true` if this resource is "use-it-or-lose-it", meaning capacity
+    /// that isn't consumed in one flashblock cannot be reclaimed in later ones.
+    ///
+    /// Execution time is the canonical example: the block builder has a fixed
+    /// time budget per block, and unused time in flashblock 0 doesn't roll over
+    /// to flashblock 1. For these resources, the estimator aggregates usage
+    /// across all flashblocks rather than evaluating each flashblock in isolation.
+    ///
+    /// Other resources like gas and DA bytes are bounded per-block but are
+    /// evaluated per-flashblock since their limits apply independently.
+    pub const fn use_it_or_lose_it(self) -> bool {
+        matches!(self, Self::ExecutionTime)
     }
 
     /// Returns a human-readable name for the resource kind.
@@ -193,19 +211,301 @@ impl ResourceEstimates {
     }
 }
 
-/// A transaction with its resource consumption metrics.
+/// Estimates for a specific flashblock index.
 #[derive(Debug, Clone)]
-pub struct MeteredTransaction {
-    /// Priority fee per gas paid by this transaction.
-    pub priority_fee_per_gas: U256,
-    /// Gas consumed.
-    pub gas_used: u64,
-    /// Execution time in microseconds.
-    pub execution_time_us: u128,
-    /// State root computation time in microseconds.
-    pub state_root_time_us: u128,
-    /// Data availability bytes.
-    pub data_availability_bytes: u64,
+pub struct FlashblockResourceEstimates {
+    /// Flashblock index.
+    pub flashblock_index: u64,
+    /// Per-resource estimates.
+    pub estimates: ResourceEstimates,
+}
+
+/// Aggregated estimates for a block.
+#[derive(Debug, Clone)]
+pub struct BlockPriorityEstimates {
+    /// Block number.
+    pub block_number: u64,
+    /// Per-flashblock estimates.
+    pub flashblocks: Vec<FlashblockResourceEstimates>,
+    /// Minimum recommended fee across all flashblocks (easiest inclusion).
+    pub min_across_flashblocks: ResourceEstimates,
+    /// Maximum recommended fee across all flashblocks (most competitive).
+    pub max_across_flashblocks: ResourceEstimates,
+}
+
+/// Priority fee estimate aggregated across multiple recent blocks.
+#[derive(Debug, Clone)]
+pub struct RollingPriorityEstimate {
+    /// Number of blocks that contributed to this estimate.
+    pub blocks_sampled: usize,
+    /// Per-resource estimates (median across sampled blocks).
+    pub estimates: ResourceEstimates,
+    /// Recommended priority fee: maximum across all resources.
+    pub priority_fee: U256,
+}
+
+/// Computes resource fee estimates based on cached flashblock metering data.
+#[derive(Debug)]
+pub struct PriorityFeeEstimator {
+    cache: Arc<RwLock<MeteringCache>>,
+    percentile: f64,
+    limits: ResourceLimits,
+    default_priority_fee: U256,
+}
+
+impl PriorityFeeEstimator {
+    /// Creates a new estimator referencing the shared metering cache.
+    ///
+    /// # Parameters
+    /// - `cache`: Shared cache containing recent flashblock metering data.
+    /// - `percentile`: Point in the fee distribution (among transactions above threshold)
+    ///   to use for the recommended fee.
+    /// - `limits`: Configured resource capacity limits.
+    /// - `default_priority_fee`: Fee to return when a resource is not congested.
+    pub const fn new(
+        cache: Arc<RwLock<MeteringCache>>,
+        percentile: f64,
+        limits: ResourceLimits,
+        default_priority_fee: U256,
+    ) -> Self {
+        Self { cache, percentile, limits, default_priority_fee }
+    }
+
+    /// Returns the bundle's demand and configured capacity for a resource,
+    /// or `None` if either is unconfigured.
+    fn resource_budget(
+        &self,
+        resource: ResourceKind,
+        demand: &ResourceDemand,
+    ) -> Option<(u128, u128)> {
+        Some((demand.demand_for(resource)?, self.limits.limit_for(resource)?))
+    }
+
+    /// Returns fee estimates for the provided block. If `block_number` is `None`
+    /// the most recent block in the cache is used.
+    ///
+    /// Returns `Ok(None)` if the cache is empty, the requested block is not cached,
+    /// or no transactions exist in the cached flashblocks.
+    ///
+    /// Returns `Err` if the bundle's demand exceeds any resource's capacity limit.
+    pub fn estimate_for_block(
+        &self,
+        block_number: Option<u64>,
+        demand: ResourceDemand,
+    ) -> Result<Option<BlockPriorityEstimates>, EstimateError> {
+        let cache_guard = self.cache.read();
+        let block_metrics = block_number
+            .map_or_else(|| cache_guard.blocks_desc().next(), |target| cache_guard.block(target));
+        let Some(block_metrics) = block_metrics else {
+            return Ok(None);
+        };
+
+        self.estimate_block(block_metrics, demand)
+    }
+
+    /// Estimates priority fees from a `BlockMetrics` reference without acquiring any lock.
+    fn estimate_block(
+        &self,
+        block_metrics: &BlockMetrics,
+        demand: ResourceDemand,
+    ) -> Result<Option<BlockPriorityEstimates>, EstimateError> {
+        let block_number = block_metrics.block_number;
+
+        // Collect transaction references per flashblock.
+        // Transactions are pre-sorted descending by priority fee in the cache.
+        let mut flashblock_transactions: Vec<(u64, Vec<&MeteredTransaction>)> = Vec::new();
+        let mut total_tx_count = 0usize;
+        for flashblock in block_metrics.flashblocks() {
+            let txs: Vec<_> = flashblock.transactions().iter().collect();
+            if txs.is_empty() {
+                continue;
+            }
+            total_tx_count += txs.len();
+            flashblock_transactions.push((flashblock.flashblock_index, txs));
+        }
+
+        if flashblock_transactions.is_empty() {
+            return Ok(None);
+        }
+
+        // Build the aggregate list for use-it-or-lose-it resources.
+        // Need to sort since we're combining multiple pre-sorted flashblocks.
+        let mut aggregate_refs: Vec<&MeteredTransaction> = Vec::with_capacity(total_tx_count);
+        for (_, txs) in &flashblock_transactions {
+            aggregate_refs.extend(txs.iter());
+        }
+        aggregate_refs.sort_by_key(|tx| Reverse(tx.priority_fee_per_gas));
+
+        // Pre-compute estimates for use-it-or-lose-it resources (e.g. execution time).
+        // These use the aggregate transaction list across all flashblocks and produce
+        // the same result regardless of flashblock, so we compute them once.
+        let mut aggregate_estimates = ResourceEstimates::default();
+        for resource in ResourceKind::all().into_iter().filter(|r| r.use_it_or_lose_it()) {
+            let Some((demand_value, limit_value)) = self.resource_budget(resource, &demand) else {
+                continue;
+            };
+            aggregate_estimates.set(
+                resource,
+                compute_estimate(
+                    resource,
+                    &aggregate_refs,
+                    demand_value,
+                    limit_value,
+                    usage_extractor(resource),
+                    self.percentile,
+                    self.default_priority_fee,
+                )?,
+            );
+        }
+
+        let mut flashblock_estimates = Vec::new();
+
+        for (flashblock_index, txs) in &flashblock_transactions {
+            let mut estimates = ResourceEstimates::default();
+            for resource in ResourceKind::all() {
+                let Some((demand_value, limit_value)) = self.resource_budget(resource, &demand)
+                else {
+                    continue;
+                };
+
+                let estimate = if let Some(precomputed) = aggregate_estimates.get(resource) {
+                    precomputed.clone()
+                } else {
+                    compute_estimate(
+                        resource,
+                        txs,
+                        demand_value,
+                        limit_value,
+                        usage_extractor(resource),
+                        self.percentile,
+                        self.default_priority_fee,
+                    )?
+                };
+
+                estimates.set(resource, estimate);
+            }
+
+            flashblock_estimates.push(FlashblockResourceEstimates {
+                flashblock_index: *flashblock_index,
+                estimates,
+            });
+        }
+
+        let (min_across_flashblocks, max_across_flashblocks) =
+            compute_min_max_estimates(&flashblock_estimates);
+
+        Ok(Some(BlockPriorityEstimates {
+            block_number,
+            flashblocks: flashblock_estimates,
+            min_across_flashblocks,
+            max_across_flashblocks,
+        }))
+    }
+
+    /// Returns rolling fee estimates aggregated across the most recent blocks in the cache.
+    ///
+    /// For each resource, computes estimates per-block and takes the median recommended fee.
+    /// The final `recommended_priority_fee` is the maximum across all resources.
+    ///
+    /// Returns `Ok(None)` if the cache is empty or no blocks contain transaction data.
+    ///
+    /// Returns `Err` if the bundle's demand exceeds any resource's capacity limit.
+    pub fn estimate_rolling(
+        &self,
+        demand: ResourceDemand,
+    ) -> Result<Option<RollingPriorityEstimate>, EstimateError> {
+        let cache_guard = self.cache.read();
+
+        if cache_guard.is_empty() {
+            return Ok(None);
+        }
+
+        // Collect per-block max estimates under a single read lock for a consistent snapshot.
+        let mut block_estimates = Vec::new();
+        for block_metrics in cache_guard.blocks_desc() {
+            if let Some(est) = self.estimate_block(block_metrics, demand)? {
+                block_estimates.push(est.max_across_flashblocks);
+            }
+        }
+
+        if block_estimates.is_empty() {
+            return Ok(None);
+        }
+
+        // Compute median fee for each resource across blocks.
+        let mut estimates = ResourceEstimates::default();
+        let mut max_fee = U256::ZERO;
+
+        for resource in ResourceKind::all() {
+            let mut fees: Vec<U256> = block_estimates
+                .iter()
+                .filter_map(|e| e.get(resource))
+                .map(|e| e.recommended_priority_fee)
+                .collect();
+
+            if fees.is_empty() {
+                continue;
+            }
+
+            fees.sort();
+            // Upper median: for even-length lists, picks the higher of the two middle values.
+            let median_fee = fees[fees.len() / 2];
+            max_fee = max_fee.max(median_fee);
+
+            estimates.set(
+                resource,
+                ResourceEstimate {
+                    threshold_priority_fee: median_fee,
+                    recommended_priority_fee: median_fee,
+                    cumulative_usage: 0,
+                    threshold_tx_count: 0,
+                    total_transactions: 0,
+                },
+            );
+        }
+
+        if estimates.is_empty() {
+            return Ok(None);
+        }
+
+        Ok(Some(RollingPriorityEstimate {
+            blocks_sampled: block_estimates.len(),
+            estimates,
+            priority_fee: max_fee,
+        }))
+    }
+}
+
+/// Computes the minimum and maximum recommended fees across all flashblocks.
+///
+/// Returns two `ResourceEstimates`:
+/// - First: For each resource, the estimate with the lowest recommended fee (easiest inclusion).
+/// - Second: For each resource, the estimate with the highest recommended fee (most competitive).
+fn compute_min_max_estimates(
+    flashblocks: &[FlashblockResourceEstimates],
+) -> (ResourceEstimates, ResourceEstimates) {
+    let mut min_estimates = ResourceEstimates::default();
+    let mut max_estimates = ResourceEstimates::default();
+
+    for flashblock in flashblocks {
+        for (resource, estimate) in flashblock.estimates.iter() {
+            if min_estimates
+                .get(resource)
+                .map_or(true, |cur| estimate.recommended_priority_fee < cur.recommended_priority_fee)
+            {
+                min_estimates.set(resource, estimate.clone());
+            }
+
+            if max_estimates
+                .get(resource)
+                .map_or(true, |cur| estimate.recommended_priority_fee > cur.recommended_priority_fee)
+            {
+                max_estimates.set(resource, estimate.clone());
+            }
+        }
+    }
+
+    (min_estimates, max_estimates)
 }
 
 /// Core estimation algorithm (top-down approach).
@@ -406,12 +706,17 @@ pub(crate) fn estimate_from_transactions(
 
 #[cfg(test)]
 mod tests {
+    use alloy_primitives::B256;
+
     use super::*;
 
     const DEFAULT_FEE: U256 = U256::from_limbs([1, 0, 0, 0]); // 1 wei
 
     fn tx(priority: u64, usage: u64) -> MeteredTransaction {
+        let mut hash_bytes = [0u8; 32];
+        hash_bytes[24..].copy_from_slice(&priority.to_be_bytes());
         MeteredTransaction {
+            tx_hash: B256::new(hash_bytes),
             priority_fee_per_gas: U256::from(priority),
             gas_used: usage,
             execution_time_us: usage as u128,
@@ -429,6 +734,7 @@ mod tests {
         da_bytes: u64,
     ) -> MeteredTransaction {
         MeteredTransaction {
+            tx_hash: B256::ZERO,
             priority_fee_per_gas: U256::from(priority),
             gas_used: gas,
             execution_time_us: exec_us,
@@ -654,5 +960,169 @@ mod tests {
 
         // Max fee is driven by the congested dimension (execution time)
         assert_eq!(max_fee, exec_est.recommended_priority_fee);
+    }
+
+    const DEFAULT_LIMITS: ResourceLimits = ResourceLimits {
+        gas_used: Some(25),
+        execution_time_us: Some(100),
+        state_root_time_us: None,
+        data_availability_bytes: Some(100),
+    };
+
+    fn setup_estimator(
+        limits: ResourceLimits,
+    ) -> (Arc<RwLock<MeteringCache>>, PriorityFeeEstimator) {
+        let cache = Arc::new(RwLock::new(MeteringCache::new(4)));
+        let estimator = PriorityFeeEstimator::new(Arc::clone(&cache), 0.5, limits, DEFAULT_FEE);
+        (cache, estimator)
+    }
+
+    #[test]
+    fn estimate_for_block_respects_limits() {
+        let (cache, estimator) = setup_estimator(DEFAULT_LIMITS);
+        {
+            let mut guard = cache.write();
+            guard.push_transaction(1, 0, tx(10, 10));
+            guard.push_transaction(1, 0, tx(5, 10));
+        }
+        let demand = ResourceDemand { gas_used: Some(15), ..Default::default() };
+
+        let estimates =
+            estimator.estimate_for_block(Some(1), demand).expect("no error").expect("cached block");
+
+        assert_eq!(estimates.block_number, 1);
+        let gas_estimate = estimates.max_across_flashblocks.gas_used.expect("gas estimate present");
+        assert_eq!(gas_estimate.threshold_priority_fee, U256::from(10));
+    }
+
+    #[test]
+    fn estimate_for_block_propagates_limit_errors() {
+        let mut limits = DEFAULT_LIMITS;
+        limits.gas_used = Some(10);
+        let (cache, estimator) = setup_estimator(limits);
+        {
+            let mut guard = cache.write();
+            guard.push_transaction(1, 0, tx(10, 10));
+            guard.push_transaction(1, 0, tx(5, 10));
+        }
+        let demand = ResourceDemand { gas_used: Some(15), ..Default::default() };
+
+        let err = estimator
+            .estimate_for_block(Some(1), demand)
+            .expect_err("demand should exceed capacity");
+        assert!(matches!(
+            err,
+            EstimateError::DemandExceedsCapacity {
+                resource: ResourceKind::GasUsed,
+                demand: 15,
+                limit: 10
+            }
+        ));
+    }
+
+    #[test]
+    fn estimate_rolling_aggregates_across_blocks() {
+        let (cache, estimator) = setup_estimator(DEFAULT_LIMITS);
+        {
+            let mut guard = cache.write();
+            // Block 1 → threshold 10
+            guard.push_transaction(1, 0, tx(10, 10));
+            guard.push_transaction(1, 0, tx(5, 10));
+            // Block 2 → threshold 30
+            guard.push_transaction(2, 0, tx(30, 10));
+            guard.push_transaction(2, 0, tx(25, 10));
+        }
+
+        let demand = ResourceDemand { gas_used: Some(15), ..Default::default() };
+
+        let rolling =
+            estimator.estimate_rolling(demand).expect("no error").expect("estimates available");
+
+        assert_eq!(rolling.blocks_sampled, 2);
+        let gas_estimate = rolling.estimates.gas_used.expect("gas estimate present");
+        // Median across [10, 30] = 30 (upper median for even count)
+        assert_eq!(gas_estimate.recommended_priority_fee, U256::from(30));
+        assert_eq!(rolling.priority_fee, U256::from(30));
+    }
+
+    // === Per-Flashblock Estimation Tests ===
+
+    #[test]
+    fn estimate_for_block_returns_none_for_empty_cache() {
+        let (_, estimator) = setup_estimator(DEFAULT_LIMITS);
+        let demand = ResourceDemand { gas_used: Some(10), ..Default::default() };
+
+        let result = estimator.estimate_for_block(Some(1), demand).expect("no error");
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn estimate_for_block_returns_none_for_missing_block() {
+        let (cache, estimator) = setup_estimator(DEFAULT_LIMITS);
+        {
+            let mut guard = cache.write();
+            guard.push_transaction(1, 0, tx(10, 10));
+        }
+        let demand = ResourceDemand { gas_used: Some(10), ..Default::default() };
+
+        // Block 2 doesn't exist
+        let result = estimator.estimate_for_block(Some(2), demand).expect("no error");
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn estimate_for_block_multiple_flashblocks_computes_min_max() {
+        let limits = ResourceLimits {
+            gas_used: Some(50),
+            execution_time_us: Some(200),
+            state_root_time_us: None,
+            data_availability_bytes: Some(200),
+        };
+        let (cache, estimator) = setup_estimator(limits);
+        {
+            let mut guard = cache.write();
+            // Flashblock 0: high-fee transactions (congested)
+            guard.push_transaction(1, 0, tx(100, 10));
+            guard.push_transaction(1, 0, tx(90, 10));
+            guard.push_transaction(1, 0, tx(80, 10));
+            // Flashblock 1: low-fee transactions (less congested)
+            guard.push_transaction(1, 1, tx(30, 10));
+            guard.push_transaction(1, 1, tx(20, 10));
+            // Flashblock 2: medium-fee transactions
+            guard.push_transaction(1, 2, tx(60, 10));
+            guard.push_transaction(1, 2, tx(50, 10));
+        }
+        let demand = ResourceDemand { gas_used: Some(25), ..Default::default() };
+
+        let result =
+            estimator.estimate_for_block(Some(1), demand).expect("no error").expect("block exists");
+
+        assert_eq!(result.block_number, 1);
+        assert_eq!(result.flashblocks.len(), 3);
+
+        // min_across_flashblocks should have the lowest recommended fee
+        let min_gas = result.min_across_flashblocks.gas_used.expect("gas estimate");
+        // max_across_flashblocks should have the highest recommended fee
+        let max_gas = result.max_across_flashblocks.gas_used.expect("gas estimate");
+
+        assert!(min_gas.recommended_priority_fee <= max_gas.recommended_priority_fee);
+    }
+
+    #[test]
+    fn estimate_for_block_uses_most_recent_when_block_none() {
+        let (cache, estimator) = setup_estimator(DEFAULT_LIMITS);
+        {
+            let mut guard = cache.write();
+            guard.push_transaction(1, 0, tx(10, 10));
+            guard.push_transaction(2, 0, tx(20, 10));
+            guard.push_transaction(3, 0, tx(30, 10));
+        }
+        let demand = ResourceDemand { gas_used: Some(10), ..Default::default() };
+
+        // Pass None for block_number - should use most recent (block 3)
+        let result =
+            estimator.estimate_for_block(None, demand).expect("no error").expect("block exists");
+
+        assert_eq!(result.block_number, 3);
     }
 }

--- a/crates/client/metering/src/estimator.rs
+++ b/crates/client/metering/src/estimator.rs
@@ -655,12 +655,33 @@ fn collect_sorted_transaction_prefixes<'a>(
     let mut running_transactions = Vec::with_capacity(total_tx_count);
 
     for flashblock in flashblocks {
-        running_transactions.extend(flashblock.transactions.iter().copied());
-        running_transactions.sort_by_key(|tx| Reverse(tx.priority_fee_per_gas));
+        running_transactions =
+            merge_transactions_desc(running_transactions, flashblock.transactions.as_slice());
         prefixes.push(running_transactions.clone());
     }
 
     prefixes
+}
+
+fn merge_transactions_desc<'a>(
+    existing: Vec<&'a MeteredTransaction>,
+    new_transactions: &[&'a MeteredTransaction],
+) -> Vec<&'a MeteredTransaction> {
+    let mut merged = Vec::with_capacity(existing.len() + new_transactions.len());
+    let mut existing_iter = existing.into_iter().peekable();
+    let mut new_iter = new_transactions.iter().copied().peekable();
+
+    while let (Some(existing_tx), Some(new_tx)) = (existing_iter.peek(), new_iter.peek()) {
+        if existing_tx.priority_fee_per_gas >= new_tx.priority_fee_per_gas {
+            merged.push(existing_iter.next().expect("peeked existing transaction"));
+        } else {
+            merged.push(new_iter.next().expect("peeked new transaction"));
+        }
+    }
+
+    merged.extend(existing_iter);
+    merged.extend(new_iter);
+    merged
 }
 
 /// Mirrors the builder's cumulative target math:
@@ -1401,6 +1422,45 @@ mod tests {
 
         let expected_max = gas_fee.max(exec_fee).max(da_fee);
         assert_eq!(result.priority_fee, expected_max);
+    }
+
+    #[test]
+    fn collect_sorted_transaction_prefixes_merges_each_flashblock_into_descending_prefixes() {
+        let tx_100 = tx(100, 1);
+        let tx_95 = tx(95, 1);
+        let tx_90 = tx(90, 1);
+        let tx_80 = tx(80, 1);
+        let tx_70 = tx(70, 1);
+        let tx_60 = tx(60, 1);
+
+        let flashblocks = vec![
+            FlashblockEstimateInput { flashblock_index: 1, transactions: vec![&tx_100, &tx_80] },
+            FlashblockEstimateInput { flashblock_index: 2, transactions: vec![&tx_90, &tx_70] },
+            FlashblockEstimateInput { flashblock_index: 3, transactions: vec![&tx_95, &tx_60] },
+        ];
+
+        let prefixes = collect_sorted_transaction_prefixes(&flashblocks);
+
+        let priorities: Vec<Vec<U256>> = prefixes
+            .iter()
+            .map(|prefix| prefix.iter().map(|tx| tx.priority_fee_per_gas).collect())
+            .collect();
+
+        assert_eq!(
+            priorities,
+            vec![
+                vec![U256::from(100), U256::from(80)],
+                vec![U256::from(100), U256::from(90), U256::from(80), U256::from(70)],
+                vec![
+                    U256::from(100),
+                    U256::from(95),
+                    U256::from(90),
+                    U256::from(80),
+                    U256::from(70),
+                    U256::from(60),
+                ],
+            ]
+        );
     }
 
     #[test]

--- a/crates/client/metering/src/estimator.rs
+++ b/crates/client/metering/src/estimator.rs
@@ -3,7 +3,7 @@
 //! This module provides the core algorithm for estimating the priority fee needed
 //! to achieve inclusion in a block, based on historical transaction data.
 
-use std::{cmp::Reverse, sync::Arc};
+use std::{cmp::Reverse, collections::BTreeMap, num::NonZeroUsize, sync::Arc};
 
 use alloy_primitives::U256;
 use parking_lot::RwLock;
@@ -30,18 +30,21 @@ pub enum EstimateError {
 
 /// Configured capacity limits for each resource type.
 ///
-/// These values define the maximum capacity available per flashblock (or per block
-/// for "use-it-or-lose-it" resources). The estimator uses these limits to determine
-/// when resources are congested.
+/// These limits mirror the builder's budget semantics.
+///
+/// Execution time resets for each flashblock, matching the builder's
+/// `flashblock_execution_time_limit_us` and `reset_flashblock_execution_time()`.
+/// Gas, DA bytes, and state root time accumulate across the block against
+/// cumulative per-flashblock targets derived from the whole-block budget.
 #[derive(Debug, Clone, Copy, Default)]
 pub struct ResourceLimits {
-    /// Gas limit per flashblock.
+    /// Gas budget for the whole block.
     pub gas_used: Option<u64>,
-    /// Execution time budget in microseconds.
+    /// Execution time budget per flashblock in microseconds.
     pub execution_time_us: Option<u128>,
-    /// State root computation time budget in microseconds.
+    /// State root computation budget for the whole block in microseconds.
     pub state_root_time_us: Option<u128>,
-    /// Data availability bytes limit per flashblock.
+    /// Data availability byte budget for the whole block.
     pub data_availability_bytes: Option<u64>,
 }
 
@@ -70,24 +73,30 @@ pub enum ResourceKind {
     DataAvailability,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ResourceBudgetBehavior {
+    ResetsEachFlashblock,
+    AccumulatesUntilBlockEnd,
+}
+
 impl ResourceKind {
     /// Returns all resource kinds in a fixed order.
     pub const fn all() -> [Self; 4] {
         [Self::GasUsed, Self::ExecutionTime, Self::StateRootTime, Self::DataAvailability]
     }
 
-    /// Returns `true` if this resource is "use-it-or-lose-it", meaning capacity
-    /// that isn't consumed in one flashblock cannot be reclaimed in later ones.
+    /// Returns how this resource budget behaves in the builder.
     ///
-    /// Execution time is the canonical example: the block builder has a fixed
-    /// time budget per block, and unused time in flashblock 0 doesn't roll over
-    /// to flashblock 1. For these resources, the estimator aggregates usage
-    /// across all flashblocks rather than evaluating each flashblock in isolation.
-    ///
-    /// Other resources like gas and DA bytes are bounded per-block but are
-    /// evaluated per-flashblock since their limits apply independently.
-    pub const fn use_it_or_lose_it(self) -> bool {
-        matches!(self, Self::ExecutionTime)
+    /// Execution time resets each flashblock, while gas, DA bytes, and state root time
+    /// accumulate across the block against growing cumulative targets in the tx-pool
+    /// flashblock loop.
+    const fn budget_behavior(self) -> ResourceBudgetBehavior {
+        match self {
+            Self::ExecutionTime => ResourceBudgetBehavior::ResetsEachFlashblock,
+            Self::GasUsed | Self::StateRootTime | Self::DataAvailability => {
+                ResourceBudgetBehavior::AccumulatesUntilBlockEnd
+            }
+        }
     }
 
     /// Returns a human-readable name for the resource kind.
@@ -214,7 +223,10 @@ impl ResourceEstimates {
 /// Estimates for a specific flashblock index.
 #[derive(Debug, Clone)]
 pub struct FlashblockResourceEstimates {
-    /// Flashblock index.
+    /// Flashblock index in the pending flashblock stream.
+    ///
+    /// The base flashblock at index `0` is excluded from estimation because the builder's
+    /// metered tx-pool budgeting loop starts at index `1`.
     pub flashblock_index: u64,
     /// Per-resource estimates.
     pub estimates: ResourceEstimates,
@@ -225,7 +237,7 @@ pub struct FlashblockResourceEstimates {
 pub struct BlockPriorityEstimates {
     /// Block number.
     pub block_number: u64,
-    /// Per-flashblock estimates.
+    /// Per-flashblock estimates for the scheduled tx-pool flashblocks (`1..=target`).
     pub flashblocks: Vec<FlashblockResourceEstimates>,
     /// Minimum recommended fee across all flashblocks (easiest inclusion).
     pub min_across_flashblocks: ResourceEstimates,
@@ -244,6 +256,90 @@ pub struct RollingPriorityEstimate {
     pub priority_fee: U256,
 }
 
+const TARGET_FLASHBLOCKS_PER_BLOCK_NON_ZERO_MSG: &str =
+    "target_flashblocks_per_block must be greater than 0";
+
+pub(crate) const fn assert_valid_percentile(percentile: f64) {
+    if !(percentile >= 0.0 && percentile <= 1.0) {
+        panic!("percentile must be between 0.0 and 1.0 inclusive");
+    }
+}
+
+#[derive(Debug)]
+struct FlashblockEstimateInput<'a> {
+    flashblock_index: u64,
+    transactions: Vec<&'a MeteredTransaction>,
+}
+
+#[derive(Debug)]
+struct EstimatedBlock {
+    estimates: BlockPriorityEstimates,
+    rolling_summary: ResourceEstimates,
+}
+
+#[derive(Debug)]
+struct BlockEstimateState<'a> {
+    flashblock_inputs: Vec<FlashblockEstimateInput<'a>>,
+    prefix_transactions: Vec<Vec<&'a MeteredTransaction>>,
+    flashblock_estimates: Vec<FlashblockResourceEstimates>,
+    min_across_flashblocks: ResourceEstimates,
+    max_across_flashblocks: ResourceEstimates,
+}
+
+impl<'a> BlockEstimateState<'a> {
+    fn new(block_metrics: &'a BlockMetrics, target_flashblocks_per_block: usize) -> Option<Self> {
+        let flashblock_inputs =
+            collect_scheduled_flashblock_inputs(block_metrics, target_flashblocks_per_block);
+        if flashblock_inputs.iter().all(|flashblock| flashblock.transactions.is_empty()) {
+            return None;
+        }
+
+        let prefix_transactions = collect_sorted_transaction_prefixes(&flashblock_inputs);
+        let flashblock_estimates = flashblock_inputs
+            .iter()
+            .map(|flashblock| FlashblockResourceEstimates {
+                flashblock_index: flashblock.flashblock_index,
+                estimates: ResourceEstimates::default(),
+            })
+            .collect();
+
+        Some(Self {
+            flashblock_inputs,
+            prefix_transactions,
+            flashblock_estimates,
+            min_across_flashblocks: ResourceEstimates::default(),
+            max_across_flashblocks: ResourceEstimates::default(),
+        })
+    }
+
+    fn record_estimate(
+        &mut self,
+        resource: ResourceKind,
+        flashblock_position: usize,
+        estimate: ResourceEstimate,
+    ) {
+        update_min_estimate(&mut self.min_across_flashblocks, resource, &estimate);
+        update_max_estimate(&mut self.max_across_flashblocks, resource, &estimate);
+        self.flashblock_estimates[flashblock_position].estimates.set(resource, estimate);
+    }
+
+    fn into_estimated_block(
+        self,
+        block_number: u64,
+        rolling_summary: ResourceEstimates,
+    ) -> EstimatedBlock {
+        EstimatedBlock {
+            estimates: BlockPriorityEstimates {
+                block_number,
+                flashblocks: self.flashblock_estimates,
+                min_across_flashblocks: self.min_across_flashblocks,
+                max_across_flashblocks: self.max_across_flashblocks,
+            },
+            rolling_summary,
+        }
+    }
+}
+
 /// Computes resource fee estimates based on cached flashblock metering data.
 #[derive(Debug)]
 pub struct PriorityFeeEstimator {
@@ -251,6 +347,7 @@ pub struct PriorityFeeEstimator {
     percentile: f64,
     limits: ResourceLimits,
     default_priority_fee: U256,
+    target_flashblocks_per_block: usize,
 }
 
 impl PriorityFeeEstimator {
@@ -262,13 +359,25 @@ impl PriorityFeeEstimator {
     ///   to use for the recommended fee.
     /// - `limits`: Configured resource capacity limits.
     /// - `default_priority_fee`: Fee to return when a resource is not congested.
+    /// - `target_flashblocks_per_block`: Number of tx-pool flashblocks the builder budgets
+    ///   per block. This excludes the initial base flashblock at index `0`.
     pub const fn new(
         cache: Arc<RwLock<MeteringCache>>,
         percentile: f64,
         limits: ResourceLimits,
         default_priority_fee: U256,
+        target_flashblocks_per_block: usize,
     ) -> Self {
-        Self { cache, percentile, limits, default_priority_fee }
+        assert_valid_percentile(percentile);
+        Self {
+            cache,
+            percentile,
+            limits,
+            default_priority_fee,
+            target_flashblocks_per_block: NonZeroUsize::new(target_flashblocks_per_block)
+                .expect(TARGET_FLASHBLOCKS_PER_BLOCK_NON_ZERO_MSG)
+                .get(),
+        }
     }
 
     /// Returns the bundle's demand and configured capacity for a resource,
@@ -281,11 +390,117 @@ impl PriorityFeeEstimator {
         Some((demand.demand_for(resource)?, self.limits.limit_for(resource)?))
     }
 
+    fn estimate_resource(
+        &self,
+        resource: ResourceKind,
+        transactions: &[&MeteredTransaction],
+        demand: u128,
+        limit: u128,
+    ) -> Result<ResourceEstimate, EstimateError> {
+        compute_estimate(
+            resource,
+            transactions,
+            demand,
+            limit,
+            usage_extractor(resource),
+            self.percentile,
+            self.default_priority_fee,
+        )
+    }
+
+    const fn ensure_capacity(
+        &self,
+        resource: ResourceKind,
+        demand: u128,
+        limit: u128,
+    ) -> Result<(), EstimateError> {
+        if demand > limit {
+            return Err(EstimateError::DemandExceedsCapacity { resource, demand, limit });
+        }
+
+        Ok(())
+    }
+
+    fn estimate_resetting_resource(
+        &self,
+        resource: ResourceKind,
+        state: &mut BlockEstimateState<'_>,
+        demand: u128,
+        limit: u128,
+    ) -> Result<ResourceEstimate, EstimateError> {
+        self.ensure_capacity(resource, demand, limit)?;
+
+        let mut rolling_summary = None;
+        for flashblock_position in 0..state.flashblock_inputs.len() {
+            let estimate = self.estimate_resource(
+                resource,
+                &state.flashblock_inputs[flashblock_position].transactions,
+                demand,
+                limit,
+            )?;
+
+            if rolling_summary.as_ref().is_none_or(|current: &ResourceEstimate| {
+                estimate.recommended_priority_fee > current.recommended_priority_fee
+            }) {
+                rolling_summary = Some(estimate.clone());
+            }
+
+            state.record_estimate(resource, flashblock_position, estimate);
+        }
+
+        Ok(rolling_summary.expect("flashblock_inputs are non-empty"))
+    }
+
+    fn estimate_accumulating_resource(
+        &self,
+        resource: ResourceKind,
+        state: &mut BlockEstimateState<'_>,
+        demand: u128,
+        total_limit: u128,
+    ) -> Result<ResourceEstimate, EstimateError> {
+        let block_end_limit = limit_at_block_end(total_limit, self.target_flashblocks_per_block);
+        self.ensure_capacity(resource, demand, block_end_limit)?;
+
+        for flashblock_position in 0..state.flashblock_inputs.len() {
+            let deadline_limit = cumulative_limit_for_flashblock(
+                total_limit,
+                state.flashblock_inputs[flashblock_position].flashblock_index,
+                self.target_flashblocks_per_block,
+            );
+            if demand > deadline_limit {
+                continue;
+            }
+
+            let estimate = self.estimate_resource(
+                resource,
+                state.prefix_transactions[flashblock_position].as_slice(),
+                demand,
+                deadline_limit,
+            )?;
+            state.record_estimate(resource, flashblock_position, estimate);
+        }
+
+        let block_end_transactions = state
+            .prefix_transactions
+            .last()
+            .map(Vec::as_slice)
+            .expect("prefix_transactions are non-empty");
+        let block_end_estimate =
+            self.estimate_resource(resource, block_end_transactions, demand, block_end_limit)?;
+
+        if state.min_across_flashblocks.get(resource).is_none() {
+            update_min_estimate(&mut state.min_across_flashblocks, resource, &block_end_estimate);
+            update_max_estimate(&mut state.max_across_flashblocks, resource, &block_end_estimate);
+        }
+
+        Ok(block_end_estimate)
+    }
+
     /// Returns fee estimates for the provided block. If `block_number` is `None`
     /// the most recent block in the cache is used.
     ///
     /// Returns `Ok(None)` if the cache is empty, the requested block is not cached,
-    /// or no transactions exist in the cached flashblocks.
+    /// or no transactions exist in the cached tx-pool flashblocks.
     ///
     /// Returns `Err` if the bundle's demand exceeds any resource's capacity limit.
     pub fn estimate_for_block(
@@ -301,6 +516,7 @@ impl PriorityFeeEstimator {
         };
 
         self.estimate_block(block_metrics, demand)
+            .map(|estimate| estimate.map(|estimated_block| estimated_block.estimates))
     }
 
     /// Estimates priority fees from a `BlockMetrics` reference without acquiring any lock.
@@ -308,98 +524,39 @@ impl PriorityFeeEstimator {
         &self,
         block_metrics: &BlockMetrics,
         demand: ResourceDemand,
-    ) -> Result<Option<BlockPriorityEstimates>, EstimateError> {
+    ) -> Result<Option<EstimatedBlock>, EstimateError> {
         let block_number = block_metrics.block_number;
-
-        // Collect transaction references per flashblock.
-        // Transactions are pre-sorted descending by priority fee in the cache.
-        let mut flashblock_transactions: Vec<(u64, Vec<&MeteredTransaction>)> = Vec::new();
-        let mut total_tx_count = 0usize;
-        for flashblock in block_metrics.flashblocks() {
-            let txs: Vec<_> = flashblock.transactions().iter().collect();
-            if txs.is_empty() {
-                continue;
-            }
-            total_tx_count += txs.len();
-            flashblock_transactions.push((flashblock.flashblock_index, txs));
-        }
-
-        if flashblock_transactions.is_empty() {
+        let Some(mut state) =
+            BlockEstimateState::new(block_metrics, self.target_flashblocks_per_block)
+        else {
             return Ok(None);
-        }
+        };
 
-        // Build the aggregate list for use-it-or-lose-it resources.
-        // Need to sort since we're combining multiple pre-sorted flashblocks.
-        let mut aggregate_refs: Vec<&MeteredTransaction> = Vec::with_capacity(total_tx_count);
-        for (_, txs) in &flashblock_transactions {
-            aggregate_refs.extend(txs.iter());
-        }
-        aggregate_refs.sort_by_key(|tx| Reverse(tx.priority_fee_per_gas));
-
-        // Pre-compute estimates for use-it-or-lose-it resources (e.g. execution time).
-        // These use the aggregate transaction list across all flashblocks and produce
-        // the same result regardless of flashblock, so we compute them once.
-        let mut aggregate_estimates = ResourceEstimates::default();
-        for resource in ResourceKind::all().into_iter().filter(|r| r.use_it_or_lose_it()) {
+        let mut rolling_summary = ResourceEstimates::default();
+        for resource in ResourceKind::all() {
             let Some((demand_value, limit_value)) = self.resource_budget(resource, &demand) else {
                 continue;
             };
-            aggregate_estimates.set(
-                resource,
-                compute_estimate(
+
+            let resource_summary = match resource.budget_behavior() {
+                ResourceBudgetBehavior::ResetsEachFlashblock => self.estimate_resetting_resource(
                     resource,
-                    &aggregate_refs,
+                    &mut state,
                     demand_value,
                     limit_value,
-                    usage_extractor(resource),
-                    self.percentile,
-                    self.default_priority_fee,
                 )?,
-            );
-        }
-
-        let mut flashblock_estimates = Vec::new();
-
-        for (flashblock_index, txs) in &flashblock_transactions {
-            let mut estimates = ResourceEstimates::default();
-            for resource in ResourceKind::all() {
-                let Some((demand_value, limit_value)) = self.resource_budget(resource, &demand)
-                else {
-                    continue;
-                };
-
-                let estimate = if let Some(precomputed) = aggregate_estimates.get(resource) {
-                    precomputed.clone()
-                } else {
-                    compute_estimate(
+                ResourceBudgetBehavior::AccumulatesUntilBlockEnd => self
+                    .estimate_accumulating_resource(
                         resource,
-                        txs,
+                        &mut state,
                         demand_value,
                         limit_value,
-                        usage_extractor(resource),
-                        self.percentile,
-                        self.default_priority_fee,
-                    )?
-                };
-
-                estimates.set(resource, estimate);
-            }
-
-            flashblock_estimates.push(FlashblockResourceEstimates {
-                flashblock_index: *flashblock_index,
-                estimates,
-            });
+                    )?,
+            };
+            rolling_summary.set(resource, resource_summary);
         }
 
-        let (min_across_flashblocks, max_across_flashblocks) =
-            compute_min_max_estimates(&flashblock_estimates);
-
-        Ok(Some(BlockPriorityEstimates {
-            block_number,
-            flashblocks: flashblock_estimates,
-            min_across_flashblocks,
-            max_across_flashblocks,
-        }))
+        Ok(Some(state.into_estimated_block(block_number, rolling_summary)))
     }
 
     /// Returns rolling fee estimates aggregated across the most recent blocks in the cache.
@@ -420,11 +577,11 @@ impl PriorityFeeEstimator {
             return Ok(None);
         }
 
-        // Collect per-block max estimates under a single read lock for a consistent snapshot.
+        // Collect per-block summaries under a single read lock for a consistent snapshot.
         let mut block_estimates = Vec::new();
         for block_metrics in cache_guard.blocks_desc() {
             if let Some(est) = self.estimate_block(block_metrics, demand)? {
-                block_estimates.push(est.max_across_flashblocks);
+                block_estimates.push(est.rolling_summary);
             }
         }
 
@@ -437,31 +594,18 @@ impl PriorityFeeEstimator {
         let mut max_fee = U256::ZERO;
 
         for resource in ResourceKind::all() {
-            let mut fees: Vec<U256> = block_estimates
-                .iter()
-                .filter_map(|e| e.get(resource))
-                .map(|e| e.recommended_priority_fee)
-                .collect();
+            let mut resource_estimates: Vec<ResourceEstimate> =
+                block_estimates.iter().filter_map(|e| e.get(resource)).cloned().collect();
 
-            if fees.is_empty() {
+            if resource_estimates.is_empty() {
                 continue;
             }
 
-            fees.sort();
+            resource_estimates.sort_by_key(|estimate| estimate.recommended_priority_fee);
             // Upper median: for even-length lists, picks the higher of the two middle values.
-            let median_fee = fees[fees.len() / 2];
-            max_fee = max_fee.max(median_fee);
-
-            estimates.set(
-                resource,
-                ResourceEstimate {
-                    threshold_priority_fee: median_fee,
-                    recommended_priority_fee: median_fee,
-                    cumulative_usage: 0,
-                    threshold_tx_count: 0,
-                    total_transactions: 0,
-                },
-            );
+            let median_estimate = resource_estimates[resource_estimates.len() / 2].clone();
+            max_fee = max_fee.max(median_estimate.recommended_priority_fee);
+            estimates.set(resource, median_estimate);
         }
 
         if estimates.is_empty() {
@@ -476,36 +620,100 @@ impl PriorityFeeEstimator {
     }
 }
 
-/// Computes the minimum and maximum recommended fees across all flashblocks.
-///
-/// Returns two `ResourceEstimates`:
-/// - First: For each resource, the estimate with the lowest recommended fee (easiest inclusion).
-/// - Second: For each resource, the estimate with the highest recommended fee (most competitive).
-fn compute_min_max_estimates(
-    flashblocks: &[FlashblockResourceEstimates],
-) -> (ResourceEstimates, ResourceEstimates) {
-    let mut min_estimates = ResourceEstimates::default();
-    let mut max_estimates = ResourceEstimates::default();
+fn collect_scheduled_flashblock_inputs<'a>(
+    block_metrics: &'a BlockMetrics,
+    target_flashblocks_per_block: usize,
+) -> Vec<FlashblockEstimateInput<'a>> {
+    let transactions_by_flashblock: BTreeMap<u64, Vec<&MeteredTransaction>> = block_metrics
+        .flashblocks()
+        .filter(|flashblock| flashblock.flashblock_index > 0)
+        .map(|flashblock| {
+            (flashblock.flashblock_index, flashblock.transactions().iter().collect::<Vec<_>>())
+        })
+        .collect();
+
+    // Late FCUs can cause the builder to emit fewer flashblocks for a given block, but this
+    // estimator still mirrors the configured tx-pool flashblock target rather than inferring the
+    // reduced count from cached data. Any scheduled flashblocks that were never emitted are
+    // therefore modeled as empty inputs.
+    (1..=target_flashblocks_per_block as u64)
+        .map(|flashblock_index| FlashblockEstimateInput {
+            flashblock_index,
+            transactions: transactions_by_flashblock
+                .get(&flashblock_index)
+                .cloned()
+                .unwrap_or_default(),
+        })
+        .collect()
+}
+
+fn collect_sorted_transaction_prefixes<'a>(
+    flashblocks: &[FlashblockEstimateInput<'a>],
+) -> Vec<Vec<&'a MeteredTransaction>> {
+    let total_tx_count = flashblocks.iter().map(|flashblock| flashblock.transactions.len()).sum();
+    let mut prefixes = Vec::with_capacity(flashblocks.len());
+    let mut running_transactions = Vec::with_capacity(total_tx_count);
 
     for flashblock in flashblocks {
-        for (resource, estimate) in flashblock.estimates.iter() {
-            if min_estimates
-                .get(resource)
-                .map_or(true, |cur| estimate.recommended_priority_fee < cur.recommended_priority_fee)
-            {
-                min_estimates.set(resource, estimate.clone());
-            }
-
-            if max_estimates
-                .get(resource)
-                .map_or(true, |cur| estimate.recommended_priority_fee > cur.recommended_priority_fee)
-            {
-                max_estimates.set(resource, estimate.clone());
-            }
-        }
+        running_transactions.extend(flashblock.transactions.iter().copied());
+        running_transactions.sort_by_key(|tx| Reverse(tx.priority_fee_per_gas));
+        prefixes.push(running_transactions.clone());
     }
 
-    (min_estimates, max_estimates)
+    prefixes
+}
+
+/// Mirrors the builder's cumulative target math:
+/// `per_batch = total_limit / flashblocks_per_block`, then the tx-pool flashblock deadline
+/// is `per_batch * flashblock_index`.
+///
+/// This intentionally preserves the builder's integer division. If `total_limit` is not evenly
+/// divisible by `total_flashblock_count`, the block-end deadline is slightly below `total_limit`.
+const fn cumulative_limit_for_flashblock(
+    total_limit: u128,
+    flashblock_index: u64,
+    total_flashblock_count: usize,
+) -> u128 {
+    if total_flashblock_count == 0 {
+        return 0;
+    }
+
+    let per_flashblock_limit = total_limit / total_flashblock_count as u128;
+    per_flashblock_limit.saturating_mul(flashblock_index as u128)
+}
+
+const fn limit_at_block_end(total_limit: u128, total_flashblock_count: usize) -> u128 {
+    cumulative_limit_for_flashblock(
+        total_limit,
+        total_flashblock_count as u64,
+        total_flashblock_count,
+    )
+}
+
+fn update_min_estimate(
+    estimates: &mut ResourceEstimates,
+    resource: ResourceKind,
+    candidate: &ResourceEstimate,
+) {
+    if estimates
+        .get(resource)
+        .is_none_or(|current| candidate.recommended_priority_fee < current.recommended_priority_fee)
+    {
+        estimates.set(resource, candidate.clone());
+    }
+}
+
+fn update_max_estimate(
+    estimates: &mut ResourceEstimates,
+    resource: ResourceKind,
+    candidate: &ResourceEstimate,
+) {
+    if estimates
+        .get(resource)
+        .is_none_or(|current| candidate.recommended_priority_fee > current.recommended_priority_fee)
+    {
+        estimates.set(resource, candidate.clone());
+    }
 }
 
 /// Core estimation algorithm (top-down approach).
@@ -609,7 +817,6 @@ fn compute_estimate(
             // For recommended fee, look at included transactions (those above threshold)
             // and pick one at the specified percentile for a safety margin.
             let included = &transactions[..=idx];
-            let percentile = percentile.clamp(0.0, 1.0);
             let recommended_fee = if included.len() <= 1 {
                 threshold_fee
             } else {
@@ -664,6 +871,8 @@ pub(crate) fn estimate_from_transactions(
     percentile: f64,
     default_fee: U256,
 ) -> Result<Option<(ResourceEstimates, U256)>, EstimateError> {
+    assert_valid_percentile(percentile);
+
     if transactions.is_empty() {
         return Ok(None);
     }
@@ -972,9 +1181,47 @@ mod tests {
     fn setup_estimator(
         limits: ResourceLimits,
     ) -> (Arc<RwLock<MeteringCache>>, PriorityFeeEstimator) {
-        let cache = Arc::new(RwLock::new(MeteringCache::new(4)));
-        let estimator = PriorityFeeEstimator::new(Arc::clone(&cache), 0.5, limits, DEFAULT_FEE);
+        setup_estimator_with_target(limits, 1)
+    }
+
+    fn setup_estimator_with_target(
+        limits: ResourceLimits,
+        target_flashblocks_per_block: usize,
+    ) -> (Arc<RwLock<MeteringCache>>, PriorityFeeEstimator) {
+        let cache = Arc::new(RwLock::new(MeteringCache::new(4, target_flashblocks_per_block + 1)));
+        let estimator = PriorityFeeEstimator::new(
+            Arc::clone(&cache),
+            0.5,
+            limits,
+            DEFAULT_FEE,
+            target_flashblocks_per_block,
+        );
         (cache, estimator)
+    }
+
+    #[test]
+    #[should_panic(expected = "target_flashblocks_per_block must be greater than 0")]
+    fn estimator_rejects_zero_target_flashblocks_per_block() {
+        let _ = setup_estimator_with_target(DEFAULT_LIMITS, 0);
+    }
+
+    #[test]
+    #[should_panic(expected = "percentile must be between 0.0 and 1.0 inclusive")]
+    fn estimator_rejects_nan_percentile() {
+        let cache = Arc::new(RwLock::new(MeteringCache::new(4, 2)));
+        let _ = PriorityFeeEstimator::new(cache, f64::NAN, DEFAULT_LIMITS, DEFAULT_FEE, 1);
+    }
+
+    #[test]
+    #[should_panic(expected = "percentile must be between 0.0 and 1.0 inclusive")]
+    fn estimate_from_transactions_rejects_out_of_range_percentile() {
+        let _ = estimate_from_transactions(
+            &[tx(10, 10)],
+            ResourceDemand { gas_used: Some(1), ..Default::default() },
+            &ResourceLimits { gas_used: Some(10), ..Default::default() },
+            1.5,
+            DEFAULT_FEE,
+        );
     }
 
     #[test]
@@ -982,8 +1229,8 @@ mod tests {
         let (cache, estimator) = setup_estimator(DEFAULT_LIMITS);
         {
             let mut guard = cache.write();
-            guard.push_transaction(1, 0, tx(10, 10));
-            guard.push_transaction(1, 0, tx(5, 10));
+            guard.push_transaction(1, 1, tx(10, 10));
+            guard.push_transaction(1, 1, tx(5, 10));
         }
         let demand = ResourceDemand { gas_used: Some(15), ..Default::default() };
 
@@ -1002,8 +1249,8 @@ mod tests {
         let (cache, estimator) = setup_estimator(limits);
         {
             let mut guard = cache.write();
-            guard.push_transaction(1, 0, tx(10, 10));
-            guard.push_transaction(1, 0, tx(5, 10));
+            guard.push_transaction(1, 1, tx(10, 10));
+            guard.push_transaction(1, 1, tx(5, 10));
         }
         let demand = ResourceDemand { gas_used: Some(15), ..Default::default() };
 
@@ -1026,11 +1273,11 @@ mod tests {
         {
             let mut guard = cache.write();
             // Block 1 → threshold 10
-            guard.push_transaction(1, 0, tx(10, 10));
-            guard.push_transaction(1, 0, tx(5, 10));
+            guard.push_transaction(1, 1, tx(10, 10));
+            guard.push_transaction(1, 1, tx(5, 10));
             // Block 2 → threshold 30
-            guard.push_transaction(2, 0, tx(30, 10));
-            guard.push_transaction(2, 0, tx(25, 10));
+            guard.push_transaction(2, 1, tx(30, 10));
+            guard.push_transaction(2, 1, tx(25, 10));
         }
 
         let demand = ResourceDemand { gas_used: Some(15), ..Default::default() };
@@ -1041,7 +1288,11 @@ mod tests {
         assert_eq!(rolling.blocks_sampled, 2);
         let gas_estimate = rolling.estimates.gas_used.expect("gas estimate present");
         // Median across [10, 30] = 30 (upper median for even count)
+        assert_eq!(gas_estimate.threshold_priority_fee, U256::from(30));
         assert_eq!(gas_estimate.recommended_priority_fee, U256::from(30));
+        assert_eq!(gas_estimate.cumulative_usage, 10);
+        assert_eq!(gas_estimate.threshold_tx_count, 1);
+        assert_eq!(gas_estimate.total_transactions, 2);
         assert_eq!(rolling.priority_fee, U256::from(30));
     }
 
@@ -1061,7 +1312,7 @@ mod tests {
         let (cache, estimator) = setup_estimator(DEFAULT_LIMITS);
         {
             let mut guard = cache.write();
-            guard.push_transaction(1, 0, tx(10, 10));
+            guard.push_transaction(1, 1, tx(10, 10));
         }
         let demand = ResourceDemand { gas_used: Some(10), ..Default::default() };
 
@@ -1071,7 +1322,49 @@ mod tests {
     }
 
     #[test]
-    fn estimate_for_block_multiple_flashblocks_computes_min_max() {
+    fn estimate_for_block_uses_most_recent_when_block_none() {
+        let (cache, estimator) = setup_estimator(DEFAULT_LIMITS);
+        {
+            let mut guard = cache.write();
+            guard.push_transaction(1, 1, tx(10, 10));
+            guard.push_transaction(2, 1, tx(20, 10));
+            guard.push_transaction(3, 1, tx(30, 10));
+        }
+        let demand = ResourceDemand { gas_used: Some(10), ..Default::default() };
+
+        // Pass None for block_number - should use most recent (block 3)
+        let result =
+            estimator.estimate_for_block(None, demand).expect("no error").expect("block exists");
+
+        assert_eq!(result.block_number, 3);
+    }
+
+    #[test]
+    fn estimate_rolling_computes_median_for_odd_blocks() {
+        let (cache, estimator) = setup_estimator(DEFAULT_LIMITS);
+        {
+            let mut guard = cache.write();
+            // Block 1: threshold 10
+            guard.push_transaction(1, 1, tx(10, 10));
+            guard.push_transaction(1, 1, tx(5, 10));
+            // Block 2: threshold 20
+            guard.push_transaction(2, 1, tx(20, 10));
+            guard.push_transaction(2, 1, tx(15, 10));
+            // Block 3: threshold 30
+            guard.push_transaction(3, 1, tx(30, 10));
+            guard.push_transaction(3, 1, tx(25, 10));
+        }
+        let demand = ResourceDemand { gas_used: Some(15), ..Default::default() };
+
+        let result = estimator.estimate_rolling(demand).expect("no error").expect("has data");
+
+        assert_eq!(result.blocks_sampled, 3);
+        let gas_estimate = result.estimates.gas_used.expect("gas estimate");
+        assert_eq!(gas_estimate.recommended_priority_fee, U256::from(20));
+    }
+
+    #[test]
+    fn estimate_rolling_priority_fee_is_max_across_resources() {
         let limits = ResourceLimits {
             gas_used: Some(50),
             execution_time_us: Some(200),
@@ -1081,48 +1374,156 @@ mod tests {
         let (cache, estimator) = setup_estimator(limits);
         {
             let mut guard = cache.write();
-            // Flashblock 0: high-fee transactions (congested)
-            guard.push_transaction(1, 0, tx(100, 10));
-            guard.push_transaction(1, 0, tx(90, 10));
-            guard.push_transaction(1, 0, tx(80, 10));
-            // Flashblock 1: low-fee transactions (less congested)
-            guard.push_transaction(1, 1, tx(30, 10));
-            guard.push_transaction(1, 1, tx(20, 10));
-            // Flashblock 2: medium-fee transactions
-            guard.push_transaction(1, 2, tx(60, 10));
-            guard.push_transaction(1, 2, tx(50, 10));
+            guard.push_transaction(1, 1, tx(100, 10));
+            guard.push_transaction(1, 1, tx(50, 10));
         }
-        let demand = ResourceDemand { gas_used: Some(25), ..Default::default() };
+        let demand = ResourceDemand {
+            gas_used: Some(25),
+            execution_time_us: Some(25),
+            data_availability_bytes: Some(25),
+            ..Default::default()
+        };
 
-        let result =
-            estimator.estimate_for_block(Some(1), demand).expect("no error").expect("block exists");
+        let result = estimator.estimate_rolling(demand).expect("no error").expect("has data");
 
-        assert_eq!(result.block_number, 1);
-        assert_eq!(result.flashblocks.len(), 3);
+        let gas_fee =
+            result.estimates.gas_used.map(|e| e.recommended_priority_fee).unwrap_or(U256::ZERO);
+        let exec_fee = result
+            .estimates
+            .execution_time
+            .map(|e| e.recommended_priority_fee)
+            .unwrap_or(U256::ZERO);
+        let da_fee = result
+            .estimates
+            .data_availability
+            .map(|e| e.recommended_priority_fee)
+            .unwrap_or(U256::ZERO);
 
-        // min_across_flashblocks should have the lowest recommended fee
-        let min_gas = result.min_across_flashblocks.gas_used.expect("gas estimate");
-        // max_across_flashblocks should have the highest recommended fee
-        let max_gas = result.max_across_flashblocks.gas_used.expect("gas estimate");
-
-        assert!(min_gas.recommended_priority_fee <= max_gas.recommended_priority_fee);
+        let expected_max = gas_fee.max(exec_fee).max(da_fee);
+        assert_eq!(result.priority_fee, expected_max);
     }
 
     #[test]
-    fn estimate_for_block_uses_most_recent_when_block_none() {
-        let (cache, estimator) = setup_estimator(DEFAULT_LIMITS);
+    fn estimate_for_block_resetting_resources_use_local_flashblock_competition() {
+        let limits = ResourceLimits {
+            gas_used: None,
+            execution_time_us: Some(30),
+            state_root_time_us: None,
+            data_availability_bytes: None,
+        };
+        let (cache, estimator) = setup_estimator_with_target(limits, 2);
         {
             let mut guard = cache.write();
-            guard.push_transaction(1, 0, tx(10, 10));
-            guard.push_transaction(2, 0, tx(20, 10));
-            guard.push_transaction(3, 0, tx(30, 10));
+            guard.push_transaction(1, 1, tx_multi(100, 0, 15, 0, 0));
+            guard.push_transaction(1, 1, tx_multi(90, 0, 15, 0, 0));
+            guard.push_transaction(1, 2, tx_multi(80, 0, 15, 0, 0));
+            guard.push_transaction(1, 2, tx_multi(70, 0, 15, 0, 0));
         }
-        let demand = ResourceDemand { gas_used: Some(10), ..Default::default() };
 
-        // Pass None for block_number - should use most recent (block 3)
+        let demand = ResourceDemand { execution_time_us: Some(15), ..Default::default() };
+        let result =
+            estimator.estimate_for_block(Some(1), demand).expect("no error").expect("block exists");
+
+        assert_eq!(result.flashblocks.len(), 2);
+        let first = result.flashblocks[0]
+            .estimates
+            .execution_time
+            .as_ref()
+            .expect("execution time estimate");
+        let second = result.flashblocks[1]
+            .estimates
+            .execution_time
+            .as_ref()
+            .expect("execution time estimate");
+
+        assert_eq!(first.threshold_priority_fee, U256::from(100));
+        assert_eq!(second.threshold_priority_fee, U256::from(80));
+    }
+
+    #[test]
+    fn estimate_for_block_accumulating_resources_follow_builder_cumulative_targets() {
+        let limits = ResourceLimits {
+            gas_used: Some(100),
+            execution_time_us: None,
+            state_root_time_us: None,
+            data_availability_bytes: None,
+        };
+        let (cache, estimator) = setup_estimator_with_target(limits, 4);
+        {
+            let mut guard = cache.write();
+            guard.push_transaction(1, 1, tx_multi(100, 20, 0, 0, 0));
+            guard.push_transaction(1, 3, tx_multi(90, 20, 0, 0, 0));
+        }
+
+        let demand = ResourceDemand { gas_used: Some(40), ..Default::default() };
         let result =
             estimator.estimate_for_block(None, demand).expect("no error").expect("block exists");
 
-        assert_eq!(result.block_number, 3);
+        assert_eq!(result.flashblocks.len(), 4);
+        assert!(result.flashblocks[0].estimates.gas_used.is_none());
+
+        let later_flashblock = result.flashblocks[1]
+            .estimates
+            .gas_used
+            .as_ref()
+            .expect("gas estimate for later flashblock");
+        assert_eq!(later_flashblock.threshold_priority_fee, U256::from(100));
+
+        let block_summary = result.max_across_flashblocks.gas_used.expect("gas summary");
+        assert_eq!(block_summary.threshold_priority_fee, U256::from(100));
+    }
+
+    #[test]
+    fn estimate_rolling_accumulating_resources_uses_block_end_budget() {
+        let limits = ResourceLimits {
+            gas_used: Some(100),
+            execution_time_us: None,
+            state_root_time_us: None,
+            data_availability_bytes: None,
+        };
+        let (cache, estimator) = setup_estimator_with_target(limits, 4);
+        {
+            let mut guard = cache.write();
+            guard.push_transaction(1, 1, tx_multi(100, 20, 0, 0, 0));
+            guard.push_transaction(1, 3, tx_multi(90, 20, 0, 0, 0));
+        }
+
+        let demand = ResourceDemand { gas_used: Some(40), ..Default::default() };
+        let rolling =
+            estimator.estimate_rolling(demand).expect("no error").expect("rolling estimate");
+
+        let gas_estimate = rolling.estimates.gas_used.expect("gas estimate");
+        assert_eq!(gas_estimate.threshold_priority_fee, DEFAULT_FEE);
+        assert_eq!(gas_estimate.recommended_priority_fee, DEFAULT_FEE);
+        assert_eq!(gas_estimate.cumulative_usage, 40);
+        assert_eq!(gas_estimate.threshold_tx_count, 2);
+    }
+
+    #[test]
+    fn estimate_for_block_ignores_base_flashblock_for_budgeted_resources() {
+        let limits = ResourceLimits {
+            gas_used: Some(20),
+            execution_time_us: None,
+            state_root_time_us: None,
+            data_availability_bytes: None,
+        };
+        let (cache, estimator) = setup_estimator(limits);
+        {
+            let mut guard = cache.write();
+            guard.push_transaction(1, 0, tx_multi(100, 10, 0, 0, 0));
+            guard.push_transaction(1, 1, tx_multi(10, 1, 0, 0, 0));
+        }
+
+        let demand = ResourceDemand { gas_used: Some(15), ..Default::default() };
+        let result =
+            estimator.estimate_for_block(Some(1), demand).expect("no error").expect("block exists");
+
+        let gas_estimate = result.flashblocks[0]
+            .estimates
+            .gas_used
+            .as_ref()
+            .expect("gas estimate for first tx-pool flashblock");
+        assert_eq!(gas_estimate.threshold_priority_fee, DEFAULT_FEE);
+        assert_eq!(gas_estimate.recommended_priority_fee, DEFAULT_FEE);
     }
 }

--- a/crates/client/metering/src/extension.rs
+++ b/crates/client/metering/src/extension.rs
@@ -25,11 +25,17 @@ pub struct MeteringResourceLimits {
 
 impl MeteringResourceLimits {
     /// Converts to the internal [`ResourceLimits`] type.
-    pub fn to_resource_limits(&self) -> ResourceLimits {
+    pub const fn to_resource_limits(&self) -> ResourceLimits {
         ResourceLimits {
             gas_used: self.gas_limit,
-            execution_time_us: self.execution_time_us.map(|v| v as u128),
-            state_root_time_us: self.state_root_time_us.map(|v| v as u128),
+            execution_time_us: match self.execution_time_us {
+                Some(v) => Some(v as u128),
+                None => None,
+            },
+            state_root_time_us: match self.state_root_time_us {
+                Some(v) => Some(v as u128),
+                None => None,
+            },
             data_availability_bytes: self.da_bytes,
         }
     }

--- a/crates/client/metering/src/extension.rs
+++ b/crates/client/metering/src/extension.rs
@@ -8,7 +8,9 @@ use base_flashblocks::{FlashblocksConfig, FlashblocksState};
 use base_node_runner::{BaseNodeExtension, FromExtensionConfig, NodeHooks};
 use tracing::info;
 
-use crate::{MeteringApiImpl, MeteringApiServer, ResourceLimits};
+use crate::{
+    MeteringApiImpl, MeteringApiServer, ResourceLimits, estimator::assert_valid_percentile,
+};
 
 /// Resource limits configuration for priority fee estimation.
 #[derive(Debug, Clone, Default)]
@@ -93,6 +95,7 @@ impl MeteringExtension {
 
     /// Sets the priority fee percentile.
     pub const fn with_percentile(mut self, percentile: f64) -> Self {
+        assert_valid_percentile(percentile);
         self.priority_fee_percentile = percentile;
         self
     }
@@ -215,6 +218,7 @@ impl MeteringConfig {
 
     /// Sets the priority fee percentile.
     pub const fn with_percentile(mut self, percentile: f64) -> Self {
+        assert_valid_percentile(percentile);
         self.priority_fee_percentile = percentile;
         self
     }
@@ -230,6 +234,7 @@ impl FromExtensionConfig for MeteringExtension {
     type Config = MeteringConfig;
 
     fn from_config(config: Self::Config) -> Self {
+        assert_valid_percentile(config.priority_fee_percentile);
         Self {
             enabled: config.enabled,
             flashblocks_config: config.flashblocks_config,

--- a/crates/client/metering/src/lib.rs
+++ b/crates/client/metering/src/lib.rs
@@ -10,10 +10,16 @@
 mod block;
 pub use block::meter_block;
 
+mod cache;
+pub use cache::{
+    BlockMetrics, FlashblockMetrics, MeteredTransaction, MeteringCache, ResourceTotals,
+};
+
 mod estimator;
 pub use estimator::{
-    EstimateError, MeteredTransaction, ResourceDemand, ResourceEstimate, ResourceEstimates,
-    ResourceKind, ResourceLimits,
+    BlockPriorityEstimates, EstimateError, FlashblockResourceEstimates, PriorityFeeEstimator,
+    ResourceDemand, ResourceEstimate, ResourceEstimates, ResourceKind, ResourceLimits,
+    RollingPriorityEstimate,
 };
 
 mod extension;

--- a/crates/client/metering/src/rpc.rs
+++ b/crates/client/metering/src/rpc.rs
@@ -398,6 +398,7 @@ where
             .transactions
             .iter()
             .map(|tx| MeteredTransaction {
+                tx_hash: tx.tx_hash,
                 priority_fee_per_gas: U256::ZERO,
                 gas_used: tx.gas_used,
                 execution_time_us: tx.execution_time_us,

--- a/crates/client/metering/src/rpc.rs
+++ b/crates/client/metering/src/rpc.rs
@@ -22,7 +22,9 @@ use tracing::{debug, error, info};
 use crate::{
     MeterBlockResponse, MeteredPriorityFeeResponse, MeteredTransaction, PendingState,
     PendingTrieCache, ResourceDemand, ResourceFeeEstimateResponse, ResourceLimits,
-    block::meter_block, estimator::estimate_from_transactions, meter::meter_bundle,
+    block::meter_block,
+    estimator::{assert_valid_percentile, estimate_from_transactions},
+    meter::meter_bundle,
     traits::MeteringApiServer,
 };
 
@@ -74,6 +76,7 @@ where
         percentile: f64,
         default_fee: U256,
     ) -> Self {
+        assert_valid_percentile(percentile);
         Self {
             provider,
             flashblocks_api,
@@ -243,6 +246,10 @@ where
         } else {
             U256::from(0)
         };
+        let total_execution_time_us = output
+            .results
+            .iter()
+            .fold(0u128, |acc, result| acc.saturating_add(result.execution_time_us));
 
         debug!(
             bundle_hash = %output.bundle_hash,
@@ -264,7 +271,7 @@ where
             state_block_number: header.number,
             state_flashblock_index: pending_blocks.as_ref().map(|pb| pb.latest_flashblock_index()),
             total_gas_used: output.total_gas_used,
-            total_execution_time_us: output.total_time_us,
+            total_execution_time_us,
             state_root_time_us: output.state_root_time_us,
         })
     }
@@ -479,7 +486,7 @@ fn compute_resource_demand(bundle: &Bundle, meter_result: &MeterBundleResponse) 
     ResourceDemand {
         gas_used: Some(meter_result.total_gas_used),
         execution_time_us: Some(meter_result.total_execution_time_us),
-        state_root_time_us: None, // Not available per-bundle
+        state_root_time_us: Some(meter_result.state_root_time_us),
         data_availability_bytes: Some(da_bytes),
     }
 }
@@ -673,6 +680,10 @@ mod tests {
         assert_eq!(response.results.len(), 1);
         assert_eq!(response.total_gas_used, 21_000);
         assert!(response.total_execution_time_us > 0);
+        assert_eq!(
+            response.total_execution_time_us,
+            response.results.iter().map(|result| result.execution_time_us).sum::<u128>()
+        );
 
         let result = &response.results[0];
         assert_eq!(result.from_address, sender_address);
@@ -739,6 +750,10 @@ mod tests {
         assert_eq!(response.results.len(), 2);
         assert_eq!(response.total_gas_used, 42_000);
         assert!(response.total_execution_time_us > 0);
+        assert_eq!(
+            response.total_execution_time_us,
+            response.results.iter().map(|result| result.execution_time_us).sum::<u128>()
+        );
 
         let result1 = &response.results[0];
         assert_eq!(result1.from_address, address1);
@@ -1018,5 +1033,24 @@ mod tests {
         assert_eq!(response.state_flashblock_index, Some(0));
 
         Ok(())
+    }
+
+    #[test]
+    fn compute_resource_demand_preserves_execution_and_state_root_dimensions() {
+        let tx = Bytes::from_static(&[0x02, 0x01, 0x02, 0x03]);
+        let bundle = create_bundle(vec![tx.clone()], 0, None);
+        let meter_result = MeterBundleResponse {
+            total_gas_used: 21_000,
+            total_execution_time_us: 123,
+            state_root_time_us: 45,
+            ..Default::default()
+        };
+
+        let demand = compute_resource_demand(&bundle, &meter_result);
+
+        assert_eq!(demand.gas_used, Some(21_000));
+        assert_eq!(demand.execution_time_us, Some(123));
+        assert_eq!(demand.state_root_time_us, Some(45));
+        assert_eq!(demand.data_availability_bytes, Some(flz_compress_len(&tx) as u64));
     }
 }

--- a/crates/client/metering/src/trie_cache.rs
+++ b/crates/client/metering/src/trie_cache.rs
@@ -121,6 +121,26 @@ mod tests {
         )
     }
 
+    #[test]
+    fn new_creates_empty_cache() {
+        let cache = PendingTrieCache::new();
+        // The cache should start empty (no cached entry)
+        let guard = cache.cache.load();
+        assert!(guard.is_none());
+    }
+
+    #[test]
+    fn default_equals_new() {
+        let cache1 = PendingTrieCache::new();
+        let cache2 = PendingTrieCache::default();
+
+        // Both should start with empty cache
+        let guard1 = cache1.cache.load();
+        let guard2 = cache2.cache.load();
+        assert!(guard1.is_none());
+        assert!(guard2.is_none());
+    }
+
     #[tokio::test]
     async fn ensure_cached_misses_on_different_payload_id() -> eyre::Result<()> {
         let harness = TestHarness::new().await?;


### PR DESCRIPTION
## PR Stack

This is **PR 2 of 5** in the metered priority fee stack:

1. #355 `base_meteredPriorityFeePerGas` RPC endpoint
2. **This PR** — Per-flashblock estimation with cache ⬅️
3. Rolling estimates from cache
4. Live data ingestion from flashblocks
5. Dynamic DA size config support

## Summary

- Add `MeteringCache` for storing per-flashblock metering data across recent blocks
- Add `PriorityFeeEstimator` that uses the cache to compute fee estimates per-block
- Add `FlashblockMetrics`, `BlockMetrics`, and `ResourceTotals` types for tracking resource consumption per flashblock
- Replace single-block estimation with cache-backed estimation that can look up any recent block
- Add `MeteredTransaction` with per-resource fields (gas, execution time, state root time, DA bytes)

## Test Plan

- [x] Unit tests for `MeteringCache` (push, eviction, block lookup)
- [x] Unit tests for `PriorityFeeEstimator` (single-block estimation, limit enforcement)