### PR TITLE
feat(metering): use rolling estimates from cache

### DIFF
--- a/crates/client/metering/README.md
+++ b/crates/client/metering/README.md
@@ -71,7 +71,7 @@ Meters a bundle and returns a recommended priority fee based on recent block con
   "totalGasUsed": 21000,
   "totalExecutionTimeUs": 1234,
   "priorityFee": "0x5f5e100",
-  "blocksSampled": 1,
+  "blocksSampled": 12,
   "resourceEstimates": [
     {
       "resource": "gasUsed",
@@ -95,18 +95,20 @@ Meters a bundle and returns a recommended priority fee based on recent block con
 
 **Algorithm:**
 1. Meter the bundle to get resource consumption (gas, execution time, DA bytes)
-2. Use cached metering data from the latest block (populated by ingestion pipeline)
-3. For each flashblock within the block:
-   - For each resource type, run the estimation algorithm:
-     - Walk from highest-paying transactions, subtracting usage from remaining capacity
-     - Stop when adding another tx would leave less room than the bundle needs
-     - The last included tx's fee is the threshold
-   - For "use-it-or-lose-it" resources (execution time), aggregate usage across all flashblocks
-4. Take the maximum fee across all flashblocks for each resource
+2. Use cached metering data from recent blocks (populated by ingestion pipeline)
+3. For each block in the cache:
+   - For execution time, estimate each tx-pool flashblock independently because that budget
+     resets each flashblock in the builder
+   - For gas, state root time, and DA bytes, estimate against cumulative transaction prefixes
+     for scheduled tx-pool flashblocks `1..=target_flashblocks_per_block`, mirroring the
+     builder's per-flashblock cumulative targets and excluding the base flashblock at index `0`
+4. Take the median fee across all blocks for each resource (upper median for even counts)
 5. Return the maximum fee across all resources as `priorityFee`
 
 Note: The cache must be populated by the ingestion pipeline for estimates to be available.
-Currently returns `blocksSampled: 1` since estimation uses a single block.
+The `blocksSampled` field indicates how many blocks were used in the rolling estimate.
+For gas, state root time, or DA estimation, `target_flashblocks_per_block` must be configured so
+the estimator can mirror the builder's flashblock budgeting.
 
 ## License
 

--- a/crates/client/metering/src/estimator.rs
+++ b/crates/client/metering/src/estimator.rs
@@ -3,7 +3,7 @@
 //! This module provides the core algorithm for estimating the priority fee needed
 //! to achieve inclusion in a block, based on historical transaction data.
 
-use std::{cmp::Reverse, collections::BTreeMap, num::NonZeroUsize, sync::Arc};
+use std::{collections::BTreeMap, num::NonZeroUsize, sync::Arc};
 
 use alloy_primitives::U256;
 use parking_lot::RwLock;
@@ -440,7 +440,7 @@ impl PriorityFeeEstimator {
             )?;
 
             if rolling_summary.as_ref().is_none_or(|current: &ResourceEstimate| {
-                estimate.recommended_priority_fee > current.recommended_priority_fee
+                is_more_competitive_estimate(&estimate, current)
             }) {
                 rolling_summary = Some(estimate.clone());
             }
@@ -711,6 +711,24 @@ const fn limit_at_block_end(total_limit: u128, total_flashblock_count: usize) ->
     )
 }
 
+fn estimate_competitiveness_key(estimate: &ResourceEstimate) -> (U256, U256, usize, usize, u128) {
+    (
+        estimate.recommended_priority_fee,
+        estimate.threshold_priority_fee,
+        estimate.total_transactions,
+        estimate.threshold_tx_count,
+        estimate.cumulative_usage,
+    )
+}
+
+fn is_more_competitive_estimate(candidate: &ResourceEstimate, current: &ResourceEstimate) -> bool {
+    estimate_competitiveness_key(candidate) > estimate_competitiveness_key(current)
+}
+
+fn is_less_competitive_estimate(candidate: &ResourceEstimate, current: &ResourceEstimate) -> bool {
+    estimate_competitiveness_key(candidate) < estimate_competitiveness_key(current)
+}
+
 fn update_min_estimate(
     estimates: &mut ResourceEstimates,
     resource: ResourceKind,
@@ -718,7 +736,7 @@ fn update_min_estimate(
 ) {
     if estimates
         .get(resource)
-        .is_none_or(|current| candidate.recommended_priority_fee < current.recommended_priority_fee)
+        .is_none_or(|current| is_less_competitive_estimate(candidate, current))
     {
         estimates.set(resource, candidate.clone());
     }
@@ -731,7 +749,7 @@ fn update_max_estimate(
 ) {
     if estimates
         .get(resource)
-        .is_none_or(|current| candidate.recommended_priority_fee > current.recommended_priority_fee)
+        .is_none_or(|current| is_more_competitive_estimate(candidate, current))
     {
         estimates.set(resource, candidate.clone());
     }
@@ -871,69 +889,6 @@ fn usage_extractor(resource: ResourceKind) -> fn(&MeteredTransaction) -> u128 {
     }
 }
 
-/// Estimates priority fees for all configured resources given a list of transactions.
-///
-/// This is a simple single-block estimation that treats all transactions as a single pool.
-///
-/// # Arguments
-///
-/// * `transactions` - Transactions from a block, will be sorted by priority fee descending
-/// * `demand` - Resource demand for the bundle being priced
-/// * `limits` - Configured resource limits
-/// * `percentile` - Percentile for recommended fee calculation
-/// * `default_fee` - Fee to return when resources are uncongested
-///
-/// Returns `Ok(None)` if no transactions are provided.
-/// Returns `Err` if bundle demand exceeds any resource limit.
-pub(crate) fn estimate_from_transactions(
-    transactions: &[MeteredTransaction],
-    demand: ResourceDemand,
-    limits: &ResourceLimits,
-    percentile: f64,
-    default_fee: U256,
-) -> Result<Option<(ResourceEstimates, U256)>, EstimateError> {
-    assert_valid_percentile(percentile);
-
-    if transactions.is_empty() {
-        return Ok(None);
-    }
-
-    // Sort transactions by priority fee descending
-    let mut sorted: Vec<&MeteredTransaction> = transactions.iter().collect();
-    sorted.sort_by_key(|tx| Reverse(tx.priority_fee_per_gas));
-
-    let mut estimates = ResourceEstimates::default();
-    let mut max_fee = U256::ZERO;
-
-    for resource in ResourceKind::all() {
-        let Some(demand_value) = demand.demand_for(resource) else {
-            continue;
-        };
-        let Some(limit_value) = limits.limit_for(resource) else {
-            continue;
-        };
-
-        let estimate = compute_estimate(
-            resource,
-            &sorted,
-            demand_value,
-            limit_value,
-            usage_extractor(resource),
-            percentile,
-            default_fee,
-        )?;
-
-        max_fee = max_fee.max(estimate.recommended_priority_fee);
-        estimates.set(resource, estimate);
-    }
-
-    if estimates.is_empty() {
-        return Ok(None);
-    }
-
-    Ok(Some((estimates, max_fee)))
-}
-
 #[cfg(test)]
 mod tests {
     use alloy_primitives::B256;
@@ -963,8 +918,10 @@ mod tests {
         state_root_us: u128,
         da_bytes: u64,
     ) -> MeteredTransaction {
+        let mut hash_bytes = [0u8; 32];
+        hash_bytes[24..].copy_from_slice(&priority.to_be_bytes());
         MeteredTransaction {
-            tx_hash: B256::ZERO,
+            tx_hash: B256::new(hash_bytes),
             priority_fee_per_gas: U256::from(priority),
             gas_used: gas,
             execution_time_us: exec_us,
@@ -1129,69 +1086,6 @@ mod tests {
         assert_eq!(quote.recommended_priority_fee, DEFAULT_FEE);
     }
 
-    #[test]
-    fn estimate_from_transactions_basic() {
-        let txs = vec![tx(10, 10), tx(5, 10), tx(2, 10)];
-        let demand = ResourceDemand { gas_used: Some(15), ..Default::default() };
-        let limits = ResourceLimits { gas_used: Some(30), ..Default::default() };
-
-        let result = estimate_from_transactions(&txs, demand, &limits, 0.5, DEFAULT_FEE)
-            .expect("no error")
-            .expect("has estimates");
-
-        let (estimates, max_fee) = result;
-        let gas_estimate = estimates.gas_used.expect("gas estimate present");
-        assert_eq!(gas_estimate.threshold_priority_fee, U256::from(10));
-        assert_eq!(max_fee, U256::from(10));
-    }
-
-    #[test]
-    fn estimate_independent_dimensions() {
-        // Demonstrate that each resource dimension is evaluated independently.
-        //
-        // Transactions have low gas but high execution time:
-        //   priority=10: gas=5,  exec_time=15
-        //   priority=5:  gas=5,  exec_time=15
-        //   priority=2:  gas=5,  exec_time=15
-        //
-        // Gas (limit 100, demand 10):
-        //   Total usage = 15, remaining = 85 >= 10 → uncongested → default fee
-        //
-        // Execution time (limit 30, demand 15):
-        //   Include priority=10: remaining = 30-15 = 15 >= 15 → ok
-        //   Include priority=5:  remaining = 15-15 = 0 < 15 → stop
-        //   Congested → threshold = 10
-        let txs =
-            vec![tx_multi(10, 5, 15, 0, 0), tx_multi(5, 5, 15, 0, 0), tx_multi(2, 5, 15, 0, 0)];
-        let demand = ResourceDemand {
-            gas_used: Some(10),
-            execution_time_us: Some(15),
-            ..Default::default()
-        };
-        let limits = ResourceLimits {
-            gas_used: Some(100),
-            execution_time_us: Some(30),
-            ..Default::default()
-        };
-
-        let (estimates, max_fee) =
-            estimate_from_transactions(&txs, demand, &limits, 0.5, DEFAULT_FEE)
-                .expect("no error")
-                .expect("has estimates");
-
-        // Gas is uncongested → default fee
-        let gas_est = estimates.gas_used.expect("gas estimate");
-        assert_eq!(gas_est.recommended_priority_fee, DEFAULT_FEE);
-
-        // Execution time is congested → fee driven by competition
-        let exec_est = estimates.execution_time.expect("exec estimate");
-        assert_eq!(exec_est.threshold_priority_fee, U256::from(10));
-        assert!(exec_est.recommended_priority_fee > DEFAULT_FEE);
-
-        // Max fee is driven by the congested dimension (execution time)
-        assert_eq!(max_fee, exec_est.recommended_priority_fee);
-    }
-
     const DEFAULT_LIMITS: ResourceLimits = ResourceLimits {
         gas_used: Some(25),
         execution_time_us: Some(100),
@@ -1231,18 +1125,6 @@ mod tests {
     fn estimator_rejects_nan_percentile() {
         let cache = Arc::new(RwLock::new(MeteringCache::new(4, 2)));
         let _ = PriorityFeeEstimator::new(cache, f64::NAN, DEFAULT_LIMITS, DEFAULT_FEE, 1);
-    }
-
-    #[test]
-    #[should_panic(expected = "percentile must be between 0.0 and 1.0 inclusive")]
-    fn estimate_from_transactions_rejects_out_of_range_percentile() {
-        let _ = estimate_from_transactions(
-            &[tx(10, 10)],
-            ResourceDemand { gas_used: Some(1), ..Default::default() },
-            &ResourceLimits { gas_used: Some(10), ..Default::default() },
-            1.5,
-            DEFAULT_FEE,
-        );
     }
 
     #[test]
@@ -1317,7 +1199,16 @@ mod tests {
         assert_eq!(rolling.priority_fee, U256::from(30));
     }
 
-    // === Per-Flashblock Estimation Tests ===
+    // === Rolling Estimate Tests ===
+
+    #[test]
+    fn estimate_rolling_returns_none_for_empty_cache() {
+        let (_, estimator) = setup_estimator(DEFAULT_LIMITS);
+        let demand = ResourceDemand { gas_used: Some(10), ..Default::default() };
+
+        let result = estimator.estimate_rolling(demand).expect("no error");
+        assert!(result.is_none());
+    }
 
     #[test]
     fn estimate_for_block_returns_none_for_empty_cache() {
@@ -1337,7 +1228,6 @@ mod tests {
         }
         let demand = ResourceDemand { gas_used: Some(10), ..Default::default() };
 
-        // Block 2 doesn't exist
         let result = estimator.estimate_for_block(Some(2), demand).expect("no error");
         assert!(result.is_none());
     }
@@ -1353,7 +1243,6 @@ mod tests {
         }
         let demand = ResourceDemand { gas_used: Some(10), ..Default::default() };
 
-        // Pass None for block_number - should use most recent (block 3)
         let result =
             estimator.estimate_for_block(None, demand).expect("no error").expect("block exists");
 
@@ -1498,6 +1387,57 @@ mod tests {
 
         assert_eq!(first.threshold_priority_fee, U256::from(100));
         assert_eq!(second.threshold_priority_fee, U256::from(80));
+    }
+
+    #[test]
+    fn estimate_for_block_resetting_resource_prefers_non_empty_summary_on_fee_tie() {
+        let limits = ResourceLimits {
+            gas_used: None,
+            execution_time_us: Some(100),
+            state_root_time_us: None,
+            data_availability_bytes: None,
+        };
+        let (cache, estimator) = setup_estimator_with_target(limits, 4);
+        {
+            let mut guard = cache.write();
+            guard.push_transaction(1, 3, tx_multi(100, 0, 0, 0, 0));
+            guard.push_transaction(1, 3, tx_multi(90, 0, 0, 0, 0));
+        }
+
+        let demand = ResourceDemand { execution_time_us: Some(10), ..Default::default() };
+        let result =
+            estimator.estimate_for_block(Some(1), demand).expect("no error").expect("block exists");
+
+        let execution_summary =
+            result.max_across_flashblocks.execution_time.as_ref().expect("execution time summary");
+        assert_eq!(execution_summary.recommended_priority_fee, DEFAULT_FEE);
+        assert_eq!(execution_summary.total_transactions, 2);
+        assert_eq!(execution_summary.threshold_tx_count, 2);
+    }
+
+    #[test]
+    fn estimate_rolling_resetting_resource_prefers_non_empty_summary_on_fee_tie() {
+        let limits = ResourceLimits {
+            gas_used: None,
+            execution_time_us: Some(100),
+            state_root_time_us: None,
+            data_availability_bytes: None,
+        };
+        let (cache, estimator) = setup_estimator_with_target(limits, 4);
+        {
+            let mut guard = cache.write();
+            guard.push_transaction(1, 3, tx_multi(100, 0, 0, 0, 0));
+            guard.push_transaction(1, 3, tx_multi(90, 0, 0, 0, 0));
+        }
+
+        let demand = ResourceDemand { execution_time_us: Some(10), ..Default::default() };
+        let result = estimator.estimate_rolling(demand).expect("no error").expect("has data");
+
+        let execution_summary =
+            result.estimates.execution_time.as_ref().expect("execution time summary");
+        assert_eq!(execution_summary.recommended_priority_fee, DEFAULT_FEE);
+        assert_eq!(execution_summary.total_transactions, 2);
+        assert_eq!(execution_summary.threshold_tx_count, 2);
     }
 
     #[test]

--- a/crates/client/metering/src/estimator.rs
+++ b/crates/client/metering/src/estimator.rs
@@ -711,7 +711,9 @@ const fn limit_at_block_end(total_limit: u128, total_flashblock_count: usize) ->
     )
 }
 
-fn estimate_competitiveness_key(estimate: &ResourceEstimate) -> (U256, U256, usize, usize, u128) {
+const fn estimate_competitiveness_key(
+    estimate: &ResourceEstimate,
+) -> (U256, U256, usize, usize, u128) {
     (
         estimate.recommended_priority_fee,
         estimate.threshold_priority_fee,

--- a/crates/client/metering/src/extension.rs
+++ b/crates/client/metering/src/extension.rs
@@ -1,45 +1,59 @@
 //! Contains the [`MeteringExtension`] which wires up the metering RPC surface
 //! on the Base node builder.
 
-use std::sync::Arc;
+use std::{num::NonZeroUsize, sync::Arc};
 
 use alloy_primitives::U256;
 use base_flashblocks::{FlashblocksConfig, FlashblocksState};
 use base_node_runner::{BaseNodeExtension, FromExtensionConfig, NodeHooks};
+use parking_lot::RwLock;
 use tracing::info;
 
 use crate::{
-    MeteringApiImpl, MeteringApiServer, ResourceLimits, estimator::assert_valid_percentile,
+    MeteringApiImpl, MeteringApiServer, MeteringCache, PriorityFeeEstimator, ResourceLimits,
+    estimator::assert_valid_percentile,
 };
+
+const TARGET_FLASHBLOCKS_PER_BLOCK_NON_ZERO_MSG: &str =
+    "target_flashblocks_per_block must be greater than 0";
+const CACHE_SIZE_NON_ZERO_MSG: &str = "cache_size must be greater than 0";
 
 /// Resource limits configuration for priority fee estimation.
 #[derive(Debug, Clone, Default)]
 pub struct MeteringResourceLimits {
-    /// Maximum gas per block.
+    /// Total gas budget for the block.
+    ///
+    /// The estimator mirrors the builder's flashblock loop and converts this into
+    /// cumulative per-flashblock gas targets.
     pub gas_limit: Option<u64>,
-    /// Maximum execution time per block in microseconds.
+    /// Execution time budget per flashblock in microseconds.
+    ///
+    /// This matches the builder's flashblock execution budget, which resets each
+    /// flashblock instead of accumulating across the block.
     pub execution_time_us: Option<u64>,
-    /// Maximum state root computation time per block in microseconds.
+    /// Total state root computation budget for the block in microseconds.
+    ///
+    /// Like the builder, the estimator treats this as a cumulative budget that
+    /// later flashblocks can consume if earlier ones underuse it.
     pub state_root_time_us: Option<u64>,
-    /// Maximum data availability bytes per block.
+    /// Total data-availability byte budget for the block.
     pub da_bytes: Option<u64>,
 }
 
 impl MeteringResourceLimits {
     /// Converts to the internal [`ResourceLimits`] type.
-    pub const fn to_resource_limits(&self) -> ResourceLimits {
+    pub fn to_resource_limits(&self) -> ResourceLimits {
         ResourceLimits {
             gas_used: self.gas_limit,
-            execution_time_us: match self.execution_time_us {
-                Some(v) => Some(v as u128),
-                None => None,
-            },
-            state_root_time_us: match self.state_root_time_us {
-                Some(v) => Some(v as u128),
-                None => None,
-            },
+            execution_time_us: self.execution_time_us.map(|v| v as u128),
+            state_root_time_us: self.state_root_time_us.map(|v| v as u128),
             data_availability_bytes: self.da_bytes,
         }
+    }
+
+    /// Returns true if any resource uses the builder's cumulative multi-flashblock budget.
+    const fn uses_accumulating_resource_limits(&self) -> bool {
+        self.gas_limit.is_some() || self.state_root_time_us.is_some() || self.da_bytes.is_some()
     }
 }
 
@@ -56,6 +70,16 @@ pub struct MeteringExtension {
     pub priority_fee_percentile: f64,
     /// Default priority fee when resources are uncongested (in wei).
     pub uncongested_priority_fee: u64,
+    /// Number of blocks to retain in the metering cache.
+    ///
+    /// Must be greater than zero when set on an estimator-enabled configuration.
+    pub cache_size: usize,
+    /// Target number of tx-pool flashblocks the builder budgets each block against.
+    ///
+    /// This excludes the initial base flashblock at index `0`.
+    /// Must be greater than zero when set. Required when gas, state root time,
+    /// or DA priority fee estimation is enabled.
+    pub target_flashblocks_per_block: Option<usize>,
 }
 
 impl Default for MeteringExtension {
@@ -65,7 +89,9 @@ impl Default for MeteringExtension {
             flashblocks_config: None,
             resource_limits: MeteringResourceLimits::default(),
             priority_fee_percentile: 0.5,
-            uncongested_priority_fee: 1_000_000, // 1 Mwei (0.001 gwei) default
+            uncongested_priority_fee: 1_000_000,
+            cache_size: 12,
+            target_flashblocks_per_block: None,
         }
     }
 }
@@ -84,6 +110,8 @@ impl MeteringExtension {
             },
             priority_fee_percentile: 0.5,
             uncongested_priority_fee: 1_000_000,
+            cache_size: 12,
+            target_flashblocks_per_block: None,
         }
     }
 
@@ -106,12 +134,45 @@ impl MeteringExtension {
         self
     }
 
+    /// Sets the cache size.
+    pub const fn with_cache_size(mut self, size: usize) -> Self {
+        self.cache_size = size;
+        self
+    }
+
+    /// Sets the target number of tx-pool flashblocks the builder budgets per block.
+    pub const fn with_target_flashblocks_per_block(mut self, count: usize) -> Self {
+        self.target_flashblocks_per_block = Some(count);
+        self
+    }
+
     /// Returns true if priority fee estimation is configured (has resource limits).
     const fn has_estimator_config(&self) -> bool {
         self.resource_limits.gas_limit.is_some()
             || self.resource_limits.execution_time_us.is_some()
             || self.resource_limits.state_root_time_us.is_some()
             || self.resource_limits.da_bytes.is_some()
+    }
+
+    const fn resolved_cache_size(&self) -> usize {
+        NonZeroUsize::new(self.cache_size).expect(CACHE_SIZE_NON_ZERO_MSG).get()
+    }
+
+    const fn resolved_target_flashblocks_per_block(
+        &self,
+        requires_target_flashblocks: bool,
+    ) -> usize {
+        match self.target_flashblocks_per_block {
+            Some(count) => {
+                NonZeroUsize::new(count).expect(TARGET_FLASHBLOCKS_PER_BLOCK_NON_ZERO_MSG).get()
+            }
+            None if requires_target_flashblocks => {
+                panic!(
+                    "target_flashblocks_per_block must be configured when gas, state root time, or data availability priority fee estimation is enabled"
+                )
+            }
+            None => 1,
+        }
     }
 }
 
@@ -123,28 +184,44 @@ impl BaseNodeExtension for MeteringExtension {
         }
 
         let has_estimator = self.has_estimator_config();
-        let flashblocks_config = self.flashblocks_config;
+        let requires_target_flashblocks = self.resource_limits.uses_accumulating_resource_limits();
         let resource_limits = self.resource_limits.to_resource_limits();
         let percentile = self.priority_fee_percentile;
         let default_fee = U256::from(self.uncongested_priority_fee);
+        let cache_size = has_estimator.then(|| self.resolved_cache_size());
+        let target_flashblocks_per_block = has_estimator
+            .then(|| self.resolved_target_flashblocks_per_block(requires_target_flashblocks));
+        let flashblocks_config = self.flashblocks_config;
 
         hooks.add_rpc_module(move |ctx| {
-            // Get flashblocks state from config, or create a default one if not configured
             let fb_state: Arc<FlashblocksState> =
                 flashblocks_config.as_ref().map(|cfg| Arc::clone(&cfg.state)).unwrap_or_default();
 
             let metering_api = if has_estimator {
+                let cache_size = cache_size.expect("estimator configuration validated");
+                let target_flashblocks_per_block =
+                    target_flashblocks_per_block.expect("estimator configuration validated");
+
                 info!(
                     message = "Starting Metering RPC with priority fee estimation",
+                    cache_size = cache_size,
                     percentile = percentile,
+                    target_flashblocks_per_block = target_flashblocks_per_block,
                 );
-                MeteringApiImpl::with_estimator_config(
-                    ctx.provider().clone(),
-                    fb_state,
-                    resource_limits,
+
+                let cache = Arc::new(RwLock::new(MeteringCache::new(
+                    cache_size,
+                    target_flashblocks_per_block + 1,
+                )));
+                let estimator = Arc::new(PriorityFeeEstimator::new(
+                    Arc::clone(&cache),
                     percentile,
+                    resource_limits,
                     default_fee,
-                )
+                    target_flashblocks_per_block,
+                ));
+
+                MeteringApiImpl::with_estimator(ctx.provider().clone(), fb_state, estimator)
             } else {
                 info!(message = "Starting Metering RPC (priority fee estimation disabled)");
                 MeteringApiImpl::new(ctx.provider().clone(), fb_state)
@@ -170,6 +247,15 @@ pub struct MeteringConfig {
     pub priority_fee_percentile: f64,
     /// Default priority fee when uncongested.
     pub uncongested_priority_fee: u64,
+    /// Number of blocks to retain in the metering cache.
+    ///
+    /// Must be greater than zero when used for priority fee estimation.
+    pub cache_size: usize,
+    /// Target number of tx-pool flashblocks the builder budgets per block.
+    ///
+    /// Must be greater than zero when set. Required when gas, state root time,
+    /// or DA priority fee estimation is enabled.
+    pub target_flashblocks_per_block: Option<usize>,
 }
 
 impl MeteringConfig {
@@ -191,6 +277,8 @@ impl MeteringConfig {
             },
             priority_fee_percentile: 0.5,
             uncongested_priority_fee: 1_000_000,
+            cache_size: 12,
+            target_flashblocks_per_block: None,
         }
     }
 
@@ -207,6 +295,8 @@ impl MeteringConfig {
             },
             priority_fee_percentile: 0.5,
             uncongested_priority_fee: 1_000_000,
+            cache_size: 12,
+            target_flashblocks_per_block: None,
         }
     }
 
@@ -228,6 +318,18 @@ impl MeteringConfig {
         self.uncongested_priority_fee = fee;
         self
     }
+
+    /// Sets the cache size.
+    pub const fn with_cache_size(mut self, size: usize) -> Self {
+        self.cache_size = size;
+        self
+    }
+
+    /// Sets the target number of tx-pool flashblocks the builder budgets per block.
+    pub const fn with_target_flashblocks_per_block(mut self, count: usize) -> Self {
+        self.target_flashblocks_per_block = Some(count);
+        self
+    }
 }
 
 impl FromExtensionConfig for MeteringExtension {
@@ -241,6 +343,53 @@ impl FromExtensionConfig for MeteringExtension {
             resource_limits: config.resource_limits,
             priority_fee_percentile: config.priority_fee_percentile,
             uncongested_priority_fee: config.uncongested_priority_fee,
+            cache_size: config.cache_size,
+            target_flashblocks_per_block: config.target_flashblocks_per_block,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn resolves_default_target_flashblocks_when_optional() {
+        let extension = MeteringExtension::default();
+
+        assert_eq!(extension.resolved_target_flashblocks_per_block(false), 1);
+    }
+
+    #[test]
+    fn resolves_configured_target_flashblocks() {
+        let extension = MeteringExtension::default().with_target_flashblocks_per_block(4);
+
+        assert_eq!(extension.resolved_target_flashblocks_per_block(true), 4);
+    }
+
+    #[test]
+    #[should_panic(
+        expected = "target_flashblocks_per_block must be configured when gas, state root time, or data availability priority fee estimation is enabled"
+    )]
+    fn missing_required_target_flashblocks_panics() {
+        let extension = MeteringExtension::default();
+
+        let _ = extension.resolved_target_flashblocks_per_block(true);
+    }
+
+    #[test]
+    #[should_panic(expected = "target_flashblocks_per_block must be greater than 0")]
+    fn zero_target_flashblocks_panics() {
+        let extension = MeteringExtension::default().with_target_flashblocks_per_block(0);
+
+        let _ = extension.resolved_target_flashblocks_per_block(false);
+    }
+
+    #[test]
+    #[should_panic(expected = "cache_size must be greater than 0")]
+    fn zero_cache_size_panics() {
+        let extension = MeteringExtension::default().with_cache_size(0);
+
+        let _ = extension.resolved_cache_size();
     }
 }

--- a/crates/client/metering/src/rpc.rs
+++ b/crates/client/metering/src/rpc.rs
@@ -17,24 +17,13 @@ use reth_primitives_traits::SealedHeader;
 use reth_provider::{
     BlockReader, BlockReaderIdExt, ChainSpecProvider, HeaderProvider, StateProviderFactory,
 };
-use tracing::{debug, error, info};
+use tracing::{debug, error, info, warn};
 
 use crate::{
-    MeterBlockResponse, MeteredPriorityFeeResponse, MeteredTransaction, PendingState,
-    PendingTrieCache, ResourceDemand, ResourceFeeEstimateResponse, ResourceLimits,
-    block::meter_block,
-    estimator::{assert_valid_percentile, estimate_from_transactions},
-    meter::meter_bundle,
-    traits::MeteringApiServer,
+    MeterBlockResponse, MeteredPriorityFeeResponse, PendingState, PendingTrieCache,
+    PriorityFeeEstimator, ResourceDemand, ResourceFeeEstimateResponse, block::meter_block,
+    meter::meter_bundle, traits::MeteringApiServer,
 };
-
-/// Estimator configuration for priority fee estimation.
-#[derive(Debug, Clone)]
-struct EstimatorConfig {
-    limits: ResourceLimits,
-    percentile: f64,
-    default_fee: U256,
-}
 
 /// Implementation of the metering RPC API.
 #[derive(Debug)]
@@ -44,8 +33,8 @@ pub struct MeteringApiImpl<Provider, FB> {
     /// Cache for pending trie input, ensuring each bundle's state root
     /// calculation only measures the bundle's incremental I/O.
     pending_trie_cache: PendingTrieCache,
-    /// Configuration for priority fee estimation, if enabled.
-    estimator_config: Option<EstimatorConfig>,
+    /// Optional priority fee estimator for `meteredPriorityFeePerGas`.
+    priority_fee_estimator: Option<Arc<PriorityFeeEstimator>>,
 }
 
 impl<Provider, FB> MeteringApiImpl<Provider, FB>
@@ -64,24 +53,21 @@ where
             provider,
             flashblocks_api,
             pending_trie_cache: PendingTrieCache::new(),
-            estimator_config: None,
+            priority_fee_estimator: None,
         }
     }
 
     /// Creates a new instance with priority fee estimation enabled.
-    pub fn with_estimator_config(
+    pub fn with_estimator(
         provider: Provider,
         flashblocks_api: Arc<FB>,
-        limits: ResourceLimits,
-        percentile: f64,
-        default_fee: U256,
+        estimator: Arc<PriorityFeeEstimator>,
     ) -> Self {
-        assert_valid_percentile(percentile);
         Self {
             provider,
             flashblocks_api,
             pending_trie_cache: PendingTrieCache::new(),
-            estimator_config: Some(EstimatorConfig { limits, percentile, default_fee }),
+            priority_fee_estimator: Some(estimator),
         }
     }
 }
@@ -356,7 +342,7 @@ where
         &self,
         bundle: Bundle,
     ) -> RpcResult<MeteredPriorityFeeResponse> {
-        let Some(config) = &self.estimator_config else {
+        let Some(estimator) = &self.priority_fee_estimator else {
             debug!("Priority fee estimation requested but no estimator configured");
             return Err(jsonrpsee::types::ErrorObjectOwned::owned(
                 jsonrpsee::types::ErrorCode::InternalError.code(),
@@ -374,58 +360,11 @@ where
         // Meter the bundle to get resource consumption
         let meter_bundle_response = self.meter_bundle(bundle.clone()).await?;
 
-        // Get the latest block and meter it for historical data
-        let block = self
-            .provider
-            .block_by_number_or_tag(BlockNumberOrTag::Latest)
-            .map_err(|e| {
-                error!(error = %e, "Failed to get latest block");
-                jsonrpsee::types::ErrorObjectOwned::owned(
-                    jsonrpsee::types::ErrorCode::InternalError.code(),
-                    format!("Failed to get latest block: {e}"),
-                    None::<()>,
-                )
-            })?
-            .ok_or_else(|| {
-                jsonrpsee::types::ErrorObjectOwned::owned(
-                    jsonrpsee::types::ErrorCode::InternalError.code(),
-                    "Latest block not found".to_string(),
-                    None::<()>,
-                )
-            })?;
-
-        let block_metering = self.meter_block_internal(&block)?;
-
-        // TODO(niran): replace with cache-based rolling estimates (see
-        // niran/priority-fee-1c-rolling-estimates). Real per-transaction
-        // priority_fee_per_gas and data_availability_bytes are computed in
-        // niran/priority-fee-2-ingestion via base_setMeteringInfo +
-        // flashblock annotation.
-        let transactions: Vec<MeteredTransaction> = block_metering
-            .transactions
-            .iter()
-            .map(|tx| MeteredTransaction {
-                tx_hash: tx.tx_hash,
-                priority_fee_per_gas: U256::ZERO,
-                gas_used: tx.gas_used,
-                execution_time_us: tx.execution_time_us,
-                state_root_time_us: 0,
-                data_availability_bytes: 0,
-            })
-            .collect();
-
         // Compute resource demand from metering results
         let demand = compute_resource_demand(&bundle, &meter_bundle_response);
 
-        // Estimate fees
-        let estimate_result = estimate_from_transactions(
-            &transactions,
-            demand,
-            &config.limits,
-            config.percentile,
-            config.default_fee,
-        )
-        .map_err(|e| {
+        // Get rolling estimate from the estimator
+        let rolling_estimate = estimator.estimate_rolling(demand).map_err(|e| {
             debug!(error = %e, "Priority fee estimation failed");
             jsonrpsee::types::ErrorObjectOwned::owned(
                 jsonrpsee::types::ErrorCode::InternalError.code(),
@@ -434,23 +373,18 @@ where
             )
         })?;
 
-        let Some((estimates, priority_fee)) = estimate_result else {
-            // No transactions in block - return default fee
-            debug!(
-                priority_fee = %config.default_fee,
-                blocks_sampled = 1,
-                "No transactions in block, returning default fee"
-            );
-            return Ok(MeteredPriorityFeeResponse {
-                meter_bundle: meter_bundle_response,
-                priority_fee: config.default_fee,
-                blocks_sampled: 1,
-                resource_estimates: vec![],
-            });
+        let Some(rolling_estimate) = rolling_estimate else {
+            warn!("No metering data available for priority fee estimation");
+            return Err(jsonrpsee::types::ErrorObjectOwned::owned(
+                jsonrpsee::types::ErrorCode::InternalError.code(),
+                "No metering data available: cache is empty or not yet populated".to_string(),
+                None::<()>,
+            ));
         };
 
         // Build response
-        let resource_estimates: Vec<ResourceFeeEstimateResponse> = estimates
+        let resource_estimates: Vec<ResourceFeeEstimateResponse> = rolling_estimate
+            .estimates
             .iter()
             .map(|(kind, est)| ResourceFeeEstimateResponse {
                 resource: kind.as_camel_case().to_string(),
@@ -463,15 +397,15 @@ where
             .collect();
 
         debug!(
-            priority_fee = %priority_fee,
-            blocks_sampled = 1,
+            priority_fee = %rolling_estimate.priority_fee,
+            blocks_sampled = rolling_estimate.blocks_sampled,
             "Metered priority fee estimation completed"
         );
 
         Ok(MeteredPriorityFeeResponse {
             meter_bundle: meter_bundle_response,
-            priority_fee,
-            blocks_sampled: 1,
+            priority_fee: rolling_estimate.priority_fee,
+            blocks_sampled: rolling_estimate.blocks_sampled as u64,
             resource_estimates,
         })
     }


### PR DESCRIPTION
## PR Stack

This is **PR 3 of 5** in the metered priority fee stack:

1. #355 `base_meteredPriorityFeePerGas` RPC endpoint
2. #1111 Per-flashblock estimation with cache
3. **This PR** — Rolling estimates from cache ⬅️
4. Live data ingestion from flashblocks
5. Dynamic DA size config support

## Summary

- Add `estimate_rolling` to `PriorityFeeEstimator` — computes a rolling median of per-block threshold fees across all cached blocks
- Wire `base_meteredPriorityFeePerGas` to use rolling estimates instead of single-block estimation
- Add `RollingPriorityEstimate` response type with `blocks_sampled` count
- Return the maximum recommended fee across all resource types as the final priority fee

## Test Plan

- [x] Unit tests for rolling estimate (odd/even block counts, empty cache, max-across-resources)
- [x] Integration test for `base_meteredPriorityFeePerGas` RPC with empty cache