### PR TITLE
fix(docker): add missing `node` subcommand to base-consensus services

### DIFF
--- a/etc/docker/docker-compose.yml
+++ b/etc/docker/docker-compose.yml
@@ -243,6 +243,7 @@ services:
       - ../../.devnet/l2/configs:/genesis/l2:ro
     entrypoint: /app/base-consensus
     command:
+      - node
       - --chain
       - ${L2_CHAIN_ID}
       - --l1-eth-rpc
@@ -413,6 +414,7 @@ services:
       - ../../.devnet/l2/configs:/genesis/l2:ro
     entrypoint: /app/base-consensus
     command:
+      - node
       - --chain
       - ${L2_CHAIN_ID}
       - --l1-eth-rpc


### PR DESCRIPTION
Adds the missing `node` subcommand to the `base-consensus` command in both consensus service definitions in the docker-compose file.


Co-authored-by: cursor[bot] <cursor@cursor.com>