### PR TITLE
chore(consensus): Reduce Logging Verbosity [backport v0.6.0]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4280,7 +4280,6 @@ dependencies = [
  "alloy-consensus",
  "alloy-eips",
  "alloy-primitives",
- "async-trait",
  "base-alloy-consensus",
  "base-alloy-flz",
  "base-execution-chainspec",
@@ -4301,11 +4300,9 @@ dependencies = [
  "reth-storage-api",
  "reth-tasks",
  "reth-transaction-pool",
- "serde",
  "tokio",
  "tokio-util",
  "tracing",
- "url",
 ]
 
 [[package]]

--- a/crates/consensus/service/src/actors/derivation/actor.rs
+++ b/crates/consensus/service/src/actors/derivation/actor.rs
@@ -241,7 +241,8 @@ where
             return Ok(());
         }
 
-        info!(target: "derivation", derivation_state=?self.derivation_state_machine, "Attempting derivation.");
+        info!(target: "derivation", derivation_state=self.derivation_state_machine.confirmed_safe_head.block_info.number, "Attempting derivation.");
+        debug!(target: "derivation", derivation_state=?self.derivation_state_machine, "Attempting derivation.");
 
         // Advance the pipeline as much as possible, new data may be available or there still may be
         // payloads in the attributes queue.

--- a/crates/consensus/service/src/actors/derivation/state_machine.rs
+++ b/crates/consensus/service/src/actors/derivation/state_machine.rs
@@ -161,8 +161,10 @@ fn transition(
 /// processed.
 #[derive(Debug)]
 pub struct DerivationStateMachine {
-    confirmed_safe_head: L2BlockInfo,
-    state: DerivationState,
+    /// The last safe head confirmed by the engine, which is the base of the current derivation
+    pub confirmed_safe_head: L2BlockInfo,
+    /// The derivation state.
+    pub state: DerivationState,
 }
 
 impl Default for DerivationStateMachine {

--- a/crates/consensus/service/src/actors/engine/engine_request_processor.rs
+++ b/crates/consensus/service/src/actors/engine/engine_request_processor.rs
@@ -196,7 +196,8 @@ where
     async fn send_derivation_actor_safe_head_if_updated(&mut self) -> Result<(), EngineError> {
         let engine_safe_head = self.engine.state().sync_state.safe_head();
         if engine_safe_head == self.last_safe_head_sent {
-            info!(target: "engine", safe_head = ?engine_safe_head, "Safe head unchanged");
+            info!(target: "engine", safe_head = engine_safe_head.block_info.number, "Safe head unchanged");
+            debug!(target: "engine", safe_head = ?engine_safe_head, "unchanged safe head");
             // This was already sent, so do not send it.
             return Ok(());
         }

--- a/crates/consensus/service/src/actors/engine/engine_request_processor.rs
+++ b/crates/consensus/service/src/actors/engine/engine_request_processor.rs
@@ -207,7 +207,8 @@ where
             EngineError::ChannelClosed
         })?;
 
-        info!(target: "engine", safe_head = ?engine_safe_head, "Attempted L2 Safe Head Update");
+        info!(target: "engine", safe_head = engine_safe_head.block_info.number, "Attempted L2 Safe Head Update");
+        debug!(target: "engine", safe_head = ?engine_safe_head, "Attempted L2 Safe Head Update");
         self.last_safe_head_sent = engine_safe_head;
 
         Ok(())


### PR DESCRIPTION
Backport of #1121 into `releases/v0.6.0`.

## Summary

- Reduces derivation and engine actor logging verbosity by demoting full struct debug prints from `info!` to `debug!`, and logging only the relevant block number at `info!` level.
- Makes `DerivationStateMachine::confirmed_safe_head` and `state` fields `pub` to allow field access in the `info!` log.

## Backport

Cherry-picked commits from #1121:
- `abbd847` chore(consensus): reduce logging verbosity
- `aa60664` fix logging verbosity