### PR TITLE
fix: load system call caller during execution

### DIFF
--- a/crates/execution/revm/src/api/exec.rs
+++ b/crates/execution/revm/src/api/exec.rs
@@ -142,6 +142,11 @@ where
             data,
         ));
         let mut h = OpHandler::<_, _, EthFrame<EthInterpreter>>::new();
+
+        // load caller account into the journal (necessary for Geth proofs compatibility)
+        // remove once https://github.com/bluealloy/revm/issues/3484 is fixed
+        self.0.ctx.journal_mut().load_account_with_code_mut(caller)?;
+
         h.run_system_call(self)
     }
 }
@@ -165,6 +170,61 @@ where
             data,
         ));
         let mut h = OpHandler::<_, _, EthFrame<EthInterpreter>>::new();
+
+        // load caller account into the journal (necessary for Geth proofs compatibility)
+        // remove once https://github.com/bluealloy/revm/issues/3484 is fixed
+        self.0.ctx.journal_mut().load_account_with_code_mut(caller)?;
+
         h.inspect_run_system_call(self)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloy_primitives::Address;
+    use revm::{
+        ExecuteEvm, SystemCallEvm,
+        database::{InMemoryDB, State},
+    };
+
+    use crate::{DefaultOp, OpBuilder, OpContext};
+
+    /// Verifies that the system call caller is loaded into the EVM state cache so it appears in the
+    /// execution witness.
+    ///
+    /// The state cache (`State.cache.accounts`) is exactly what `ExecutionWitnessRecord` reads to
+    /// build the `hashed_state` fed to `state_provider.witness(...)`. Without the
+    /// `load_account_with_code_mut` call in `system_call_one_with_caller`, the caller account
+    /// would not be cached and would be absent from the generated witness, breaking Geth proof
+    /// compatibility.
+    ///
+    /// See: <https://github.com/bluealloy/revm/issues/3484>
+    #[test]
+    fn system_call_caller_appears_in_witness() {
+        let caller = Address::repeat_byte(0xCA);
+        let contract = Address::repeat_byte(0xAB);
+
+        // Use State with bundle tracking, mirroring the witness generation path in
+        // OpBuilder::witness and debug_executionWitness.
+        let state =
+            State::builder().with_database(InMemoryDB::default()).with_bundle_update().build();
+
+        let ctx = OpContext::op().with_db(state);
+        let mut evm = ctx.build_op();
+
+        // Execute a system call. This internally calls `load_account_with_code_mut(caller)`,
+        // causing the State DB to load and cache the caller's account in `State.cache.accounts`.
+        let _ = evm.system_call_one_with_caller(caller, contract, Default::default());
+
+        // Finalize to flush the journal, then inspect the underlying State cache.
+        // `ExecutionWitnessRecord::from_executed_state` iterates `State.cache.accounts` to build
+        // the hashed state, so the caller must appear here to be included in the witness.
+        let _ = evm.finalize();
+        let state = evm.into_context().journaled_state.database;
+
+        assert!(
+            state.cache.accounts.contains_key(&caller),
+            "system call caller must be in state cache for Geth proof compatibility"
+        );
     }
 }


### PR DESCRIPTION
Reth witnesses are currently not compatible with Geth because Geth loads the system caller during execution. This fixes this issue. Opened a revm issue here: https://github.com/bluealloy/revm/issues/3484

This should not affect execution at all since it's just loading an account into cache. Geth also marks this account as warm, so this PR does too. It shouldn't matter since warm/cold addresses are tx-level not block-level.

Geth reference: https://github.com/ethereum-optimism/op-geth/blob/e4826126d22171e97a31a05c7405b46143384ab7/core/state_processor.go#L259 and https://github.com/ethereum-optimism/op-geth/blob/e4826126d22171e97a31a05c7405b46143384ab7/core/vm/evm.go#L300 and https://github.com/ethereum-optimism/op-geth/blob/e4826126d22171e97a31a05c7405b46143384ab7/core/evm.go#L150-L154