### PR TITLE
[backport v0.6.0] Map blob-not-found errors to ResetError for missed beacon slots

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2982,6 +2982,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tower",
+ "tracing",
  "url",
 ]
 

--- a/crates/consensus/derive/src/errors/pipeline.rs
+++ b/crates/consensus/derive/src/errors/pipeline.rs
@@ -345,6 +345,10 @@ pub enum ResetError {
     /// The next l1 block provided to the managed traversal stage is not the expected one.
     #[error("Next L1 block hash mismatch: expected {0}, got {1}")]
     NextL1BlockHashMismatch(B256, B256),
+    /// Blobs referenced by an L1 block are permanently unavailable (e.g. missed beacon slot).
+    /// The pipeline must reset to move past the offending L1 block.
+    #[error("Blobs unavailable: beacon node returned 404 for slot {0}")]
+    BlobsUnavailable(u64),
     /// Blobs under-fill: expected more blobs than were provided.
     /// The first argument is the expected number of blobs, and the second argument is the actual
     /// number of blobs.
@@ -442,6 +446,7 @@ mod tests {
                 Default::default(),
             )),
             ResetError::HoloceneActivation,
+            ResetError::BlobsUnavailable(0),
         ];
         for error in reset_errors {
             let expected = PipelineErrorKind::Reset(error.clone());

--- a/crates/consensus/derive/src/errors/sources.rs
+++ b/crates/consensus/derive/src/errors/sources.rs
@@ -35,6 +35,16 @@ pub enum BlobProviderError {
     /// Blob decoding error.
     #[error("Blob decoding error: {0}")]
     BlobDecoding(#[from] BlobDecodingError),
+    /// The beacon node returned a 404 for the requested slot, indicating the slot was missed or
+    /// orphaned. Blobs for missed/orphaned slots will never become available, so the pipeline
+    /// must reset to move past the L1 block that referenced them.
+    #[error("Blob not found at slot {slot}: {reason}")]
+    BlobNotFound {
+        /// The beacon slot that returned 404.
+        slot: u64,
+        /// The underlying error message from the beacon client.
+        reason: String,
+    },
     /// Error pertaining to the backend transport.
     #[error("{0}")]
     Backend(String),
@@ -54,6 +64,9 @@ impl From<BlobProviderError> for PipelineErrorKind {
             BlobProviderError::SidecarLengthMismatch(_, _)
             | BlobProviderError::SlotDerivation
             | BlobProviderError::BlobDecoding(_) => PipelineError::Provider(val.to_string()).crit(),
+            BlobProviderError::BlobNotFound { slot, .. } => {
+                ResetError::BlobsUnavailable(slot).reset()
+            }
             BlobProviderError::Backend(_) => PipelineError::Provider(val.to_string()).temp(),
             BlobProviderError::NotEnoughBlobs(expected, got) => {
                 Self::Reset(ResetError::BlobsUnderFill(expected, got))
@@ -89,5 +102,18 @@ mod tests {
 
         let err: PipelineErrorKind = BlobProviderError::NotEnoughBlobs(2, 1).into();
         assert!(matches!(err, PipelineErrorKind::Reset(_)));
+
+        let err: PipelineErrorKind = BlobProviderError::Backend("transport error".into()).into();
+        assert!(matches!(err, PipelineErrorKind::Temporary(_)));
+
+        // A 404 from the beacon node (missed/orphaned slot) must trigger a pipeline reset,
+        // not a temporary retry. Without this, the safe head stalls indefinitely.
+        let err: PipelineErrorKind =
+            BlobProviderError::BlobNotFound { slot: 13779552, reason: "slot not found".into() }
+                .into();
+        assert!(
+            matches!(err, PipelineErrorKind::Reset(_)),
+            "BlobNotFound must map to Reset so the pipeline moves past the missed slot"
+        );
     }
 }

--- a/crates/consensus/derive/src/sources/blobs.rs
+++ b/crates/consensus/derive/src/sources/blobs.rs
@@ -11,8 +11,8 @@ use async_trait::async_trait;
 use base_protocol::BlockInfo;
 
 use crate::{
-    BlobData, BlobProvider, ChainProvider, DataAvailabilityProvider, PipelineError, PipelineResult,
-    ResetError,
+    BlobData, BlobProvider, ChainProvider, DataAvailabilityProvider, PipelineError,
+    PipelineErrorKind, PipelineResult, ResetError,
 };
 
 /// A data iterator that reads from a blob.
@@ -139,13 +139,36 @@ where
             return Ok(());
         }
 
-        let blobs =
-            self.blob_fetcher.get_and_validate_blobs(block_ref, &blob_hashes).await.map_err(
-                |e| {
-                    warn!(target: "blob_source", error = %e, "Failed to fetch blobs");
-                    e.into()
-                },
-            )?;
+        // Convert via Into<PipelineErrorKind> which routes:
+        //   BlobNotFound  -> PipelineErrorKind::Reset   (missed/orphaned slot)
+        //   Backend       -> PipelineErrorKind::Temporary (transient, retry)
+        //   others        -> PipelineErrorKind::Critical
+        let blobs = self
+            .blob_fetcher
+            .get_and_validate_blobs(block_ref, &blob_hashes)
+            .await
+            .map_err(Into::<PipelineErrorKind>::into)
+            .inspect_err(|kind| match kind {
+                PipelineErrorKind::Reset(_) => {
+                    warn!(
+                        target: "blob_source",
+                        block_hash = %block_ref.hash,
+                        block_number = block_ref.number,
+                        timestamp = block_ref.timestamp,
+                        "Blobs permanently unavailable (missed/orphaned beacon slot); \
+                         triggering pipeline reset"
+                    );
+                }
+                _ => {
+                    warn!(
+                        target: "blob_source",
+                        block_hash = %block_ref.hash,
+                        block_number = block_ref.number,
+                        timestamp = block_ref.timestamp,
+                        "Failed to fetch blobs: {kind}"
+                    );
+                }
+            })?;
 
         // Fill the blob pointers.
         let mut blob_index = 0;
@@ -445,6 +468,45 @@ pub(crate) mod tests {
         ) -> Result<(BlockInfo, alloc::vec::Vec<TxEnvelope>), Self::Error> {
             Err(ResetProviderError)
         }
+    }
+
+    /// Regression test: a beacon node 404 (missed/orphaned slot) must propagate through
+    /// `load_blobs` as `PipelineErrorKind::Reset`, not as a temporary retryable error.
+    #[tokio::test]
+    async fn test_load_blobs_not_found_triggers_reset() {
+        let mut source = default_test_blob_source();
+        let block_info = BlockInfo::default();
+        let batcher_address =
+            alloy_primitives::address!("A83C816D4f9b2783761a22BA6FADB0eB0606D7B2");
+        source.batcher_address =
+            alloy_primitives::address!("11E9CA82A3a762b4B5bd264d4173a242e7a77064");
+        source.chain_provider.insert_block_with_transactions(1, block_info, valid_blob_txs());
+        source.blob_fetcher.should_return_not_found = true;
+        let err = source.load_blobs(&BlockInfo::default(), batcher_address).await.unwrap_err();
+        assert!(
+            matches!(err, PipelineErrorKind::Reset(_)),
+            "expected Reset for missed beacon slot, got {err:?}"
+        );
+    }
+
+    /// Regression test: `BlobProviderError::BlobNotFound` from the blob fetcher must surface
+    /// through `next()` as `PipelineErrorKind::Reset`, triggering a pipeline reset.
+    /// Without this, a missed beacon slot causes an infinite retry loop and safe head stall.
+    #[tokio::test]
+    async fn test_missed_beacon_slot_triggers_pipeline_reset() {
+        let mut source = default_test_blob_source();
+        let block_info = BlockInfo::default();
+        let batcher_address =
+            alloy_primitives::address!("A83C816D4f9b2783761a22BA6FADB0eB0606D7B2");
+        source.batcher_address =
+            alloy_primitives::address!("11E9CA82A3a762b4B5bd264d4173a242e7a77064");
+        source.chain_provider.insert_block_with_transactions(1, block_info, valid_blob_txs());
+        source.blob_fetcher.should_return_not_found = true;
+        let err = source.next(&BlockInfo::default(), batcher_address).await.unwrap_err();
+        assert!(
+            matches!(err, PipelineErrorKind::Reset(_)),
+            "expected Reset for missed beacon slot, got {err:?}"
+        );
     }
 
     /// Regression test: when `block_info_and_transactions_by_hash` returns an error that maps to

--- a/crates/consensus/derive/src/test_utils/blob_provider.rs
+++ b/crates/consensus/derive/src/test_utils/blob_provider.rs
@@ -14,10 +14,13 @@ use crate::{BlobProvider, errors::BlobProviderError};
 pub struct TestBlobProvider {
     /// Maps block hashes to blob data.
     pub blobs: HashMap<B256, Blob>,
-    /// whether the blob provider should return an error.
+    /// Whether the blob provider should return a generic backend error.
     pub should_error: bool,
-    /// whether the blob provider should return an extra blob beyond what was requested.
+    /// Whether the blob provider should return an extra blob beyond what was requested.
     pub should_return_extra_blob: bool,
+    /// When `true`, `get_and_validate_blobs` returns `BlobProviderError::BlobNotFound`,
+    /// simulating a missed/orphaned beacon slot (HTTP 404 from the beacon node).
+    pub should_return_not_found: bool,
 }
 
 impl TestBlobProvider {
@@ -43,6 +46,12 @@ impl BlobProvider for TestBlobProvider {
     ) -> Result<Vec<Box<Blob>>, Self::Error> {
         if self.should_error {
             return Err(BlobProviderError::SlotDerivation);
+        }
+        if self.should_return_not_found {
+            return Err(BlobProviderError::BlobNotFound {
+                slot: 0,
+                reason: "mock: slot not found".into(),
+            });
         }
         let mut blobs = Vec::new();
         for blob_hash in blob_hashes {

--- a/crates/consensus/providers-alloy/Cargo.toml
+++ b/crates/consensus/providers-alloy/Cargo.toml
@@ -45,6 +45,7 @@ url.workspace = true
 http-body-util.workspace = true
 
 c-kzg.workspace = true
+tracing.workspace = true
 
 # `metrics` feature
 metrics = { workspace = true, optional = true }

--- a/crates/consensus/providers-alloy/src/beacon_client.rs
+++ b/crates/consensus/providers-alloy/src/beacon_client.rs
@@ -75,6 +75,13 @@ pub trait BeaconClient {
     /// The error type for [`BeaconClient`] implementations.
     type Error: core::fmt::Display;
 
+    /// Returns the slot number if this error represents a beacon slot not found (HTTP 404).
+    ///
+    /// Returns `None` for all other error kinds. This allows the blob provider to distinguish
+    /// permanently-unavailable slots (missed/orphaned beacon blocks) from transient errors,
+    /// and trigger a pipeline reset instead of retrying indefinitely.
+    fn slot_not_found(err: &Self::Error) -> Option<u64>;
+
     /// Returns the slot interval in seconds.
     async fn slot_interval(&self) -> Result<APIConfigResponse, Self::Error>;
 
@@ -106,6 +113,11 @@ pub enum BeaconClientError {
     /// HTTP request failed.
     #[error("HTTP request failed: {0}")]
     Http(#[from] reqwest::Error),
+
+    /// The beacon node returned HTTP 404 for the requested slot. This means the slot was missed
+    /// or orphaned and the blobs will never be available.
+    #[error("Beacon slot not found (HTTP 404) for slot {0}")]
+    SlotNotFound(u64),
 
     /// Blob hash not found in beacon response.
     #[error("Blob hash not found in beacon response: {0}")]
@@ -164,8 +176,16 @@ impl OnlineBeaconClient {
             .get(format!("{}/{}/{}", self.base, BLOBS_METHOD_PREFIX, slot))
             .query(&[("versioned_hashes", &params.join(","))])
             .send()
-            .await?
-            .error_for_status()?;
+            .await?;
+
+        // A 404 means the beacon slot was missed or orphaned. Blobs for such slots will never
+        // become available, so surface this as a distinct error rather than a generic HTTP error
+        // so that callers can trigger a pipeline reset instead of retrying indefinitely.
+        if response.status() == reqwest::StatusCode::NOT_FOUND {
+            return Err(BeaconClientError::SlotNotFound(slot));
+        }
+
+        let response = response.error_for_status()?;
         let bundle = response.json::<GetBlobsResponse>().await?;
 
         let returned_blobs_mapped_by_hash = bundle
@@ -195,6 +215,10 @@ impl OnlineBeaconClient {
 #[async_trait]
 impl BeaconClient for OnlineBeaconClient {
     type Error = BeaconClientError;
+
+    fn slot_not_found(err: &Self::Error) -> Option<u64> {
+        if let BeaconClientError::SlotNotFound(slot) = err { Some(*slot) } else { None }
+    }
 
     async fn slot_interval(&self) -> Result<APIConfigResponse, Self::Error> {
         base_macros::inc!(gauge, Metrics::BEACON_CLIENT_REQUESTS, "method" => "spec");
@@ -336,5 +360,32 @@ mod tests {
             }
             blobs_mock.delete();
         }
+    }
+
+    /// Regression test: a beacon node HTTP 404 for a given slot must return
+    /// `BeaconClientError::SlotNotFound` rather than a generic `Http` error.
+    /// This allows the blob provider layer to map it to `BlobProviderError::BlobNotFound`
+    /// and the pipeline to issue a reset rather than retrying indefinitely.
+    #[tokio::test]
+    async fn test_filtered_beacon_blobs_404_returns_slot_not_found() {
+        let slot = 13779552u64;
+        let test_blob_hash: FixedBytes<32> = FixedBytes::from_hex(TEST_BLOB_HASH_HEX).unwrap();
+        let requested_blob_hashes: Vec<IndexedBlobHash> =
+            vec![IndexedBlobHash { index: 0, hash: test_blob_hash }];
+
+        let server = MockServer::start();
+        let blobs_mock = server.mock(|when, then| {
+            when.method(GET).path(format!("/eth/v1/beacon/blobs/{slot}"));
+            then.status(404).body(r#"{"code":404,"message":"Block not found"}"#);
+        });
+
+        let client = OnlineBeaconClient::new_http(server.base_url());
+        let response = client.filtered_beacon_blobs(slot, &requested_blob_hashes).await;
+        blobs_mock.assert();
+
+        assert!(
+            matches!(response, Err(BeaconClientError::SlotNotFound(s)) if s == slot),
+            "expected SlotNotFound({slot}), got {response:?}"
+        );
     }
 }

--- a/crates/consensus/providers-alloy/src/blobs.rs
+++ b/crates/consensus/providers-alloy/src/blobs.rs
@@ -2,6 +2,8 @@
 
 use std::{boxed::Box, string::ToString, vec::Vec};
 
+use tracing::warn;
+
 use alloy_eips::eip4844::{
     Blob, BlobTransactionSidecarItem, IndexedBlobHash, env_settings::EnvKzgSettings,
 };
@@ -79,11 +81,22 @@ impl<B: BeaconClient> OnlineBlobProvider<B> {
     ) -> Result<Vec<BoxedBlobWithIndex>, BlobProviderError> {
         base_macros::inc!(gauge, Metrics::BLOB_FETCHES);
 
-        let result = self
-            .beacon_client
-            .filtered_beacon_blobs(slot, blob_hashes)
-            .await
-            .map_err(|e| BlobProviderError::Backend(e.to_string()));
+        let result =
+            self.beacon_client.filtered_beacon_blobs(slot, blob_hashes).await.map_err(|e| {
+                // The beacon node returned 404 for this slot. The slot was missed or
+                // orphaned; its blobs will never be available. Map to BlobNotFound so
+                // the pipeline issues a reset rather than retrying indefinitely.
+                let Some(missing_slot) = B::slot_not_found(&e) else {
+                    return BlobProviderError::Backend(e.to_string());
+                };
+                warn!(
+                    target: "blob_provider",
+                    slot = missing_slot,
+                    "Beacon slot not found (404); slot may be missed or orphaned, \
+                     triggering pipeline reset"
+                );
+                BlobProviderError::BlobNotFound { slot: missing_slot, reason: e.to_string() }
+            });
 
         #[cfg(feature = "metrics")]
         if result.is_err() {

--- a/crates/consensus/providers-alloy/src/blobs.rs
+++ b/crates/consensus/providers-alloy/src/blobs.rs
@@ -2,8 +2,6 @@
 
 use std::{boxed::Box, string::ToString, vec::Vec};
 
-use tracing::warn;
-
 use alloy_eips::eip4844::{
     Blob, BlobTransactionSidecarItem, IndexedBlobHash, env_settings::EnvKzgSettings,
 };
@@ -11,6 +9,7 @@ use alloy_primitives::FixedBytes;
 use async_trait::async_trait;
 use base_consensus_derive::{BlobProvider, BlobProviderError};
 use base_protocol::BlockInfo;
+use tracing::warn;
 
 use crate::BeaconClient;
 #[cfg(feature = "metrics")]


### PR DESCRIPTION
Backport of #1126 to releases/v0.6.0.

When a beacon node returns HTTP 404 for a slot, the blobs for that slot are permanently gone and retrying will never succeed. Previously all beacon errors collapsed into BlobProviderError::Backend which mapped to PipelineErrorKind::Temporary, causing the pipeline to stall forever on missed or orphaned beacon slots.

This adds BeaconClientError::SlotNotFound(u64) to distinguish 404 responses from transient failures, BlobProviderError::BlobNotFound { slot, reason } which maps to ResetError::BlobsUnavailable(slot), and ResetError::BlobsUnavailable(u64) so the pipeline resets and recovers rather than retrying indefinitely.

Mirrors ethereum-optimism/optimism#19328.