### PR TITLE
[backport v0.6.0] Map BlockNotFound errors to ResetError for reorg recovery

### DIFF
--- a/crates/consensus/derive/src/errors/pipeline.rs
+++ b/crates/consensus/derive/src/errors/pipeline.rs
@@ -2,6 +2,7 @@
 
 use alloc::string::String;
 
+use alloy_eips::BlockId;
 use alloy_primitives::B256;
 use base_consensus_genesis::SystemConfigUpdateError;
 use base_protocol::{DepositError, SpanBatchError};
@@ -358,6 +359,10 @@ pub enum ResetError {
     /// The first argument is the expected blob index, and the second argument is the actual blob count.
     #[error("Blobs over-fill: expected {0} blobs, got {1}")]
     BlobsOverFill(usize, usize),
+    /// An L1 or L2 block referenced during derivation is no longer present on the chain,
+    /// typically because a reorg removed it. The pipeline must reset to recover.
+    #[error("Block not found: {0}")]
+    BlockNotFound(BlockId),
 }
 
 impl ResetError {
@@ -447,6 +452,7 @@ mod tests {
             )),
             ResetError::HoloceneActivation,
             ResetError::BlobsUnavailable(0),
+            ResetError::BlockNotFound(B256::default().into()),
         ];
         for error in reset_errors {
             let expected = PipelineErrorKind::Reset(error.clone());

--- a/crates/consensus/providers-alloy/src/chain_provider.rs
+++ b/crates/consensus/providers-alloy/src/chain_provider.rs
@@ -8,7 +8,7 @@ use alloy_primitives::B256;
 use alloy_provider::{Provider, RootProvider};
 use alloy_transport::{RpcError, TransportErrorKind};
 use async_trait::async_trait;
-use base_consensus_derive::{ChainProvider, PipelineError, PipelineErrorKind};
+use base_consensus_derive::{ChainProvider, PipelineError, PipelineErrorKind, ResetError};
 use base_protocol::BlockInfo;
 use lru::LruCache;
 
@@ -129,7 +129,16 @@ impl From<AlloyChainProviderError> for PipelineErrorKind {
                 Self::Temporary(PipelineError::Provider(format!("Transport error: {e}")))
             }
             AlloyChainProviderError::BlockNotFound(id) => {
-                Self::Temporary(PipelineError::Provider(format!("L1 Block not found: {id}")))
+                // A hash-based lookup returning not-found means the block was reorged out —
+                // retrying will never succeed, so reset.
+                // A number-based lookup returning not-found means the next L1 block hasn't
+                // been produced yet — this is transient, so Temporary.
+                match id {
+                    BlockId::Hash(_) => ResetError::BlockNotFound(id).reset(),
+                    BlockId::Number(_) => Self::Temporary(PipelineError::Provider(format!(
+                        "L1 Block not found: {id}"
+                    ))),
+                }
             }
             AlloyChainProviderError::ReceiptsConversion(_) => {
                 Self::Temporary(PipelineError::Provider(
@@ -269,5 +278,46 @@ impl ChainProvider for AlloyChainProvider {
         base_macros::inc!(gauge, Metrics::CACHE_ENTRIES, "cache" => "block_info_and_tx");
 
         Ok((block_info, block.body.transactions))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloy_primitives::B256;
+
+    use super::*;
+
+    #[test]
+    fn test_from_alloy_chain_provider_error() {
+        // Transport errors are transient — retry makes sense.
+        let kind: PipelineErrorKind =
+            AlloyChainProviderError::Transport(alloy_transport::RpcError::Transport(
+                alloy_transport::TransportErrorKind::Custom("timeout".into()),
+            ))
+            .into();
+        assert!(matches!(kind, PipelineErrorKind::Temporary(_)));
+
+        // ReceiptsConversion is a transient decode failure.
+        let kind: PipelineErrorKind =
+            AlloyChainProviderError::ReceiptsConversion(Default::default()).into();
+        assert!(matches!(kind, PipelineErrorKind::Temporary(_)));
+
+        // Hash-based BlockNotFound: the block was reorged out. Retrying will never succeed
+        // — the pipeline must reset. Without this, the safe head stalls on L1 reorgs.
+        let kind: PipelineErrorKind =
+            AlloyChainProviderError::BlockNotFound(B256::default().into()).into();
+        assert!(
+            matches!(kind, PipelineErrorKind::Reset(_)),
+            "hash-based BlockNotFound must map to Reset (block reorged out)"
+        );
+
+        // Number-based BlockNotFound: the next L1 block hasn't been mined yet. This is
+        // transient — the pipeline must wait, not reset.
+        let kind: PipelineErrorKind =
+            AlloyChainProviderError::BlockNotFound(0u64.into()).into();
+        assert!(
+            matches!(kind, PipelineErrorKind::Temporary(_)),
+            "number-based BlockNotFound must stay Temporary (block not yet produced)"
+        );
     }
 }

--- a/crates/consensus/providers-alloy/src/chain_provider.rs
+++ b/crates/consensus/providers-alloy/src/chain_provider.rs
@@ -313,8 +313,7 @@ mod tests {
 
         // Number-based BlockNotFound: the next L1 block hasn't been mined yet. This is
         // transient — the pipeline must wait, not reset.
-        let kind: PipelineErrorKind =
-            AlloyChainProviderError::BlockNotFound(0u64.into()).into();
+        let kind: PipelineErrorKind = AlloyChainProviderError::BlockNotFound(0u64.into()).into();
         assert!(
             matches!(kind, PipelineErrorKind::Temporary(_)),
             "number-based BlockNotFound must stay Temporary (block not yet produced)"

--- a/crates/consensus/providers-alloy/src/l2_chain_provider.rs
+++ b/crates/consensus/providers-alloy/src/l2_chain_provider.rs
@@ -15,7 +15,7 @@ use alloy_transport_http::{
 use async_trait::async_trait;
 use base_alloy_consensus::OpBlock;
 use base_alloy_network::Base;
-use base_consensus_derive::{L2ChainProvider, PipelineError, PipelineErrorKind};
+use base_consensus_derive::{L2ChainProvider, PipelineError, PipelineErrorKind, ResetError};
 use base_consensus_genesis::{RollupConfig, SystemConfig};
 use base_protocol::{BatchValidationProvider, L2BlockInfo, to_system_config};
 use http_body_util::Full;
@@ -202,8 +202,8 @@ impl From<AlloyL2ChainProviderError> for PipelineErrorKind {
             AlloyL2ChainProviderError::Transport(e) => {
                 Self::Temporary(PipelineError::Provider(format!("Transport error: {e}")))
             }
-            AlloyL2ChainProviderError::BlockNotFound(_) => {
-                Self::Temporary(PipelineError::Provider("Block not found".to_string()))
+            AlloyL2ChainProviderError::BlockNotFound(number) => {
+                ResetError::BlockNotFound(alloy_eips::BlockId::Number(number.into())).reset()
             }
             AlloyL2ChainProviderError::L2BlockInfoConstruction(_) => Self::Temporary(
                 PipelineError::Provider("L2 block info construction failed".to_string()),
@@ -212,6 +212,40 @@ impl From<AlloyL2ChainProviderError> for PipelineErrorKind {
                 PipelineError::Provider("system config conversion failed".to_string()),
             ),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_from_alloy_l2_chain_provider_error() {
+        // Transport errors are transient — retry makes sense.
+        let kind: PipelineErrorKind =
+            AlloyL2ChainProviderError::Transport(alloy_transport::RpcError::Transport(
+                alloy_transport::TransportErrorKind::Custom("timeout".into()),
+            ))
+            .into();
+        assert!(matches!(kind, PipelineErrorKind::Temporary(_)));
+
+        // L2BlockInfoConstruction is a decode failure — transient.
+        let kind: PipelineErrorKind =
+            AlloyL2ChainProviderError::L2BlockInfoConstruction(0).into();
+        assert!(matches!(kind, PipelineErrorKind::Temporary(_)));
+
+        // SystemConfigConversion is a decode failure — transient.
+        let kind: PipelineErrorKind =
+            AlloyL2ChainProviderError::SystemConfigConversion(0).into();
+        assert!(matches!(kind, PipelineErrorKind::Temporary(_)));
+
+        // L2 BlockNotFound: the pipeline only requests blocks that should exist on the
+        // canonical chain. A missing L2 block means a reorg occurred — must Reset.
+        let kind: PipelineErrorKind = AlloyL2ChainProviderError::BlockNotFound(42).into();
+        assert!(
+            matches!(kind, PipelineErrorKind::Reset(_)),
+            "L2 BlockNotFound must map to Reset (block disappeared due to reorg)"
+        );
     }
 }
 

--- a/crates/consensus/providers-alloy/src/l2_chain_provider.rs
+++ b/crates/consensus/providers-alloy/src/l2_chain_provider.rs
@@ -215,38 +215,6 @@ impl From<AlloyL2ChainProviderError> for PipelineErrorKind {
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_from_alloy_l2_chain_provider_error() {
-        // Transport errors are transient — retry makes sense.
-        let kind: PipelineErrorKind =
-            AlloyL2ChainProviderError::Transport(alloy_transport::RpcError::Transport(
-                alloy_transport::TransportErrorKind::Custom("timeout".into()),
-            ))
-            .into();
-        assert!(matches!(kind, PipelineErrorKind::Temporary(_)));
-
-        // L2BlockInfoConstruction is a decode failure — transient.
-        let kind: PipelineErrorKind = AlloyL2ChainProviderError::L2BlockInfoConstruction(0).into();
-        assert!(matches!(kind, PipelineErrorKind::Temporary(_)));
-
-        // SystemConfigConversion is a decode failure — transient.
-        let kind: PipelineErrorKind = AlloyL2ChainProviderError::SystemConfigConversion(0).into();
-        assert!(matches!(kind, PipelineErrorKind::Temporary(_)));
-
-        // L2 BlockNotFound: the pipeline only requests blocks that should exist on the
-        // canonical chain. A missing L2 block means a reorg occurred — must Reset.
-        let kind: PipelineErrorKind = AlloyL2ChainProviderError::BlockNotFound(42).into();
-        assert!(
-            matches!(kind, PipelineErrorKind::Reset(_)),
-            "L2 BlockNotFound must map to Reset (block disappeared due to reorg)"
-        );
-    }
-}
-
 #[async_trait]
 impl BatchValidationProvider for AlloyL2ChainProvider {
     type Error = AlloyL2ChainProviderError;
@@ -300,5 +268,37 @@ impl L2ChainProvider for AlloyL2ChainProvider {
             .map_err(|_| AlloyL2ChainProviderError::BlockNotFound(number))?;
         to_system_config(&block, &rollup_config)
             .map_err(|_| AlloyL2ChainProviderError::SystemConfigConversion(number))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_from_alloy_l2_chain_provider_error() {
+        // Transport errors are transient — retry makes sense.
+        let kind: PipelineErrorKind =
+            AlloyL2ChainProviderError::Transport(alloy_transport::RpcError::Transport(
+                alloy_transport::TransportErrorKind::Custom("timeout".into()),
+            ))
+            .into();
+        assert!(matches!(kind, PipelineErrorKind::Temporary(_)));
+
+        // L2BlockInfoConstruction is a decode failure — transient.
+        let kind: PipelineErrorKind = AlloyL2ChainProviderError::L2BlockInfoConstruction(0).into();
+        assert!(matches!(kind, PipelineErrorKind::Temporary(_)));
+
+        // SystemConfigConversion is a decode failure — transient.
+        let kind: PipelineErrorKind = AlloyL2ChainProviderError::SystemConfigConversion(0).into();
+        assert!(matches!(kind, PipelineErrorKind::Temporary(_)));
+
+        // L2 BlockNotFound: the pipeline only requests blocks that should exist on the
+        // canonical chain. A missing L2 block means a reorg occurred — must Reset.
+        let kind: PipelineErrorKind = AlloyL2ChainProviderError::BlockNotFound(42).into();
+        assert!(
+            matches!(kind, PipelineErrorKind::Reset(_)),
+            "L2 BlockNotFound must map to Reset (block disappeared due to reorg)"
+        );
     }
 }

--- a/crates/consensus/providers-alloy/src/l2_chain_provider.rs
+++ b/crates/consensus/providers-alloy/src/l2_chain_provider.rs
@@ -230,13 +230,11 @@ mod tests {
         assert!(matches!(kind, PipelineErrorKind::Temporary(_)));
 
         // L2BlockInfoConstruction is a decode failure — transient.
-        let kind: PipelineErrorKind =
-            AlloyL2ChainProviderError::L2BlockInfoConstruction(0).into();
+        let kind: PipelineErrorKind = AlloyL2ChainProviderError::L2BlockInfoConstruction(0).into();
         assert!(matches!(kind, PipelineErrorKind::Temporary(_)));
 
         // SystemConfigConversion is a decode failure — transient.
-        let kind: PipelineErrorKind =
-            AlloyL2ChainProviderError::SystemConfigConversion(0).into();
+        let kind: PipelineErrorKind = AlloyL2ChainProviderError::SystemConfigConversion(0).into();
         assert!(matches!(kind, PipelineErrorKind::Temporary(_)));
 
         // L2 BlockNotFound: the pipeline only requests blocks that should exist on the


### PR DESCRIPTION
Backport of #1127 to releases/v0.6.0.

When an L1 block lookup by hash returns not-found, the block was reorged out and retrying will never succeed. When an L2 block lookup returns not-found, the pipeline only queries blocks that should exist, so the block disappeared due to a reorg. In both cases the previous behavior was PipelineErrorKind::Temporary, which stalls the pipeline forever instead of resetting to recover.

This adds ResetError::BlockNotFound(BlockId) and updates the error mappings: hash-based L1 BlockNotFound maps to Reset, number-based L1 BlockNotFound stays Temporary since the block simply hasn't been produced yet, and L2 BlockNotFound maps to Reset.

Mirrors ethereum-optimism/optimism#19344.