### PR TITLE
backport: metric add lru eviction count to MeterStore (#1125)

### DIFF
--- a/crates/builder/core/src/metrics.rs
+++ b/crates/builder/core/src/metrics.rs
@@ -96,6 +96,8 @@ pub struct BuilderMetrics {
     pub metering_known_transaction: Counter,
     /// Count of the number of times transactions did not have any metering information
     pub metering_unknown_transaction: Counter,
+    /// Number of LRU evictions from `MeteringStore`
+    pub metering_store_lru_evictions: Counter,
 
     // === DA Size Limit Metrics (always enforced, operator-configured) ===
     /// Transactions rejected by per-tx DA size limit

--- a/crates/builder/metering/src/store.rs
+++ b/crates/builder/metering/src/store.rs
@@ -48,6 +48,7 @@ impl MeteringStore {
             && let Ok(evicted_hash) = self.lru.pop()
         {
             self.by_tx_hash.remove(&evicted_hash);
+            self.metrics.metering_store_lru_evictions.increment(1);
             debug!(
                 target: "metering_store",
                 evicted_tx = ?evicted_hash,


### PR DESCRIPTION
Since the Resource Metering dry-run is going out in 0.6.0, I also want this metric to go out with it so I can gather more data and go from there