### PR TITLE
revert: priority fee ordering between flashblocks (#650)

### DIFF
--- a/crates/builder/core/src/flashblocks/best_txs.rs
+++ b/crates/builder/core/src/flashblocks/best_txs.rs
@@ -83,7 +83,6 @@ mod tests {
     use std::sync::Arc;
 
     use alloy_consensus::Transaction;
-    use alloy_eips::eip1559::MIN_PROTOCOL_BASE_FEE;
     use reth_payload_util::{BestPayloadTransactions, PayloadTransactions};
     use reth_transaction_pool::{
         CoinbaseTipOrdering, PoolTransaction,
@@ -135,95 +134,5 @@ mod tests {
         iterator.refresh_iterator(BestPayloadTransactions::new(pool.best()));
         // Check that it's empty
         assert!(iterator.next(()).is_none(), "Iterator should be empty");
-    }
-
-    /// This test simulates the nonce-chain gating fix across flashblock boundaries.
-    ///
-    /// Scenario (based on real Base Mainnet block 41628995):
-    /// - Sender A has `TX_A` (nonce 0, LOW tip) and `TX_B` (nonce 1, HIGH tip) in the pool
-    /// - Sender B has `TX_C` (MEDIUM tip)
-    ///
-    /// `TX_A` is in the mempool, `TX_B` and `TX_C` arrive later after the first flashblock has
-    /// started building already.
-    ///
-    /// - In flashblock 1, `TX_A` gets consumed (`TX_B` unlocks after `TX_A`)
-    /// - Only `TX_A` is marked as committed (simulating flashblock timer expiring)
-    /// - In flashblock 2, `TX_B` (HIGH tip) should come before `TX_C` (MEDIUM tip)
-    ///
-    /// Expected: `TX_B` (100 gwei) before `TX_C` (10 gwei) in flashblock 2.
-    ///
-    /// The upstream reth PR (<https://github.com/paradigmxyz/reth/pull/21765>) that added
-    /// `prune_transactions` to the pool trait has been merged. The production fix calls
-    /// `pool.prune_transactions` after `mark_committed` between flashblocks, which removes
-    /// the already-executed `TX_A` from the pool so the iterator sees the correct priority
-    /// ordering. This test simulates that behavior by recreating the pool without `TX_A`
-    /// and verifies that `TX_B` (100 gwei) is correctly ordered before `TX_C` (10 gwei).
-    #[test]
-    fn test_nonce_chain_gating_bug_across_flashblocks() {
-        use alloy_primitives::Address;
-
-        let mut pool = PendingPool::new(CoinbaseTipOrdering::<MockTransaction>::default());
-        let mut f = MockTransactionFactory::default();
-
-        let sender_a = Address::random();
-        let sender_b = Address::random();
-
-        let tx_a = MockTransaction::eip1559()
-            .with_sender(sender_a)
-            .with_nonce(0)
-            .with_priority_fee(1_000_000_000) // 1 gwei - LOW
-            .with_max_fee(100_000_000_000);
-
-        let tx_b = MockTransaction::eip1559()
-            .with_sender(sender_a)
-            .with_nonce(1)
-            .with_priority_fee(100_000_000_000) // 100 gwei - HIGH (depends on TX_A)
-            .with_max_fee(200_000_000_000);
-
-        let tx_c = MockTransaction::eip1559()
-            .with_sender(sender_b)
-            .with_nonce(0)
-            .with_priority_fee(10_000_000_000) // 10 gwei - MEDIUM
-            .with_max_fee(100_000_000_000);
-
-        pool.add_transaction(Arc::new(f.validated(tx_a.clone())), 0);
-
-        // === FLASHBLOCK 1 ===
-        let mut iterator = BestFlashblocksTxs::new(BestPayloadTransactions::new(pool.best()));
-
-        // Simulate: Flashblock 1 starts building
-        // Start consuming txns from the txpool
-        let first = iterator.next(()).unwrap();
-        assert_eq!(first.sender(), sender_a, "First should be TX_A (1 gwei)");
-
-        // TX_B and TX_C arrive late, but we have already yielded lower-priority transactions
-        // from the iterator, so these do not immediately get added to the best txns
-        pool.add_transaction(Arc::new(f.validated(tx_b.clone())), 0);
-        pool.add_transaction(Arc::new(f.validated(tx_c.clone())), 0);
-        assert_eq!(iterator.next(()), None);
-
-        // Simulate: flashblock 1 is complete after TX_A was executed
-        iterator.mark_committed(&[*tx_a.hash()]);
-        // Simulate pool.prune_transactions by recreating the pool without TX_A
-        let mut pool = PendingPool::new(CoinbaseTipOrdering::<MockTransaction>::default());
-        pool.add_transaction(Arc::new(f.validated(tx_b)), 0);
-        pool.add_transaction(Arc::new(f.validated(tx_c)), 0);
-
-        // === FLASHBLOCK 2 ===
-        // We refresh the iterator with the latest best transactions
-        iterator.refresh_iterator(BestPayloadTransactions::new(pool.best()));
-
-        // Now, theoretically, TX_A has already been executed, so
-        // TX_B should be the best txn and TX_C the second best
-        // Expected: TX_B (100 gwei) first, TX_C (10 gwei) second
-        let fb2_first = iterator.next(()).unwrap();
-        let fb2_second = iterator.next(()).unwrap();
-
-        assert_eq!(fb2_first.sender(), sender_a);
-        assert_eq!(fb2_second.sender(), sender_b);
-        assert!(
-            fb2_second.effective_tip_per_gas(MIN_PROTOCOL_BASE_FEE)
-                < fb2_first.effective_tip_per_gas(MIN_PROTOCOL_BASE_FEE)
-        );
     }
 }

--- a/crates/builder/core/src/flashblocks/payload.rs
+++ b/crates/builder/core/src/flashblocks/payload.rs
@@ -557,7 +557,6 @@ where
             .map(|tx| tx.tx_hash())
             .collect::<Vec<_>>();
         best_txs.mark_committed(&new_transactions);
-        self.pool.prune_transactions(new_transactions);
 
         // We got block cancelled, we won't need anything from the block at this point
         // Caution: this assume that block cancel token only cancelled when new FCU is received


### PR DESCRIPTION
## Summary
- Reverts commit b134f1d9 from PR #650 ("fix(builder): Transactions not being priority fee ordered within Flashblocks")
- The `pool.prune_transactions()` call between flashblocks has degraded transaction inclusion in the 0.6.0 release
- Removes the pruning call from `FlashblocksPayloadBuilder` and the associated test