### PR TITLE
backport: update pool sender nonces before FB2+ to fix tx queuing (#1107)

### DIFF
--- a/crates/builder/core/src/flashblocks/best_txs.rs
+++ b/crates/builder/core/src/flashblocks/best_txs.rs
@@ -226,4 +226,81 @@ mod tests {
                 < fb2_first.effective_tip_per_gas(MIN_PROTOCOL_BASE_FEE)
         );
     }
+
+    /// Reproduces the nonce-chain queuing bug caused by `prune_transactions`.
+    ///
+    /// After FB1 prunes executed nonce-0 txs, the pool's on-chain nonce view is stale
+    /// (block not sealed), so nonce-1 txs from the same senders land in `queued`
+    /// instead of `pending`, making them invisible to FB2+.
+    #[tokio::test]
+    async fn test_prune_transactions_causes_nonce_chain_queuing() {
+        use alloy_primitives::{Address, U256};
+        use reth_execution_types::ChangedAccount;
+        use reth_transaction_pool::{
+            BestTransactionsAttributes, TransactionOrigin, TransactionPool, TransactionPoolExt,
+            test_utils::testing_pool,
+        };
+
+        let pool = testing_pool();
+
+        let senders: Vec<Address> = (0..3).map(|_| Address::random()).collect();
+
+        // All senders submit nonce-0 txs
+        for sender in &senders {
+            let tx = MockTransaction::eip1559()
+                .with_sender(*sender)
+                .with_nonce(0)
+                .with_gas_limit(21_000)
+                .with_priority_fee(5_000_000_000)
+                .with_max_fee(100_000_000_000);
+            pool.add_transaction(TransactionOrigin::External, tx).await.unwrap();
+        }
+        assert_eq!(pool.pool_size().pending, 3);
+
+        // Simulate FB1: consume all nonce-0 txs, then prune them
+        let best_attrs = BestTransactionsAttributes::new(0, None);
+        let mut best_iter = pool.best_transactions_with_attributes(best_attrs);
+        let mut executed_hashes = Vec::new();
+        for tx in best_iter.by_ref() {
+            executed_hashes.push(*tx.hash());
+        }
+        drop(best_iter);
+        assert_eq!(executed_hashes.len(), 3);
+        pool.prune_transactions(executed_hashes);
+        assert_eq!(pool.pool_size().pending, 0);
+
+        // Senders submit nonce-1 txs (arrive between FB1 and FB2)
+        for sender in &senders {
+            let tx = MockTransaction::eip1559()
+                .with_sender(*sender)
+                .with_nonce(1)
+                .with_gas_limit(21_000)
+                .with_priority_fee(5_000_000_000)
+                .with_max_fee(100_000_000_000);
+            pool.add_transaction(TransactionOrigin::External, tx).await.unwrap();
+        }
+
+        // Bug: nonce-1 txs are queued (nonce gap) because pool still thinks on-chain nonce is 0
+        assert_eq!(pool.pool_size().pending, 0, "nonce-1 txs should be queued without fix");
+        assert_eq!(pool.pool_size().queued, 3, "nonce-1 txs land in queued due to stale nonce");
+
+        // Fix: update_accounts corrects the pool's nonce view, promoting queued -> pending.
+        // U256::MAX balance is fine here — testing_pool has no revm state to read from.
+        // Production code uses state.basic(address) for real balances.
+        let changed_accounts: Vec<ChangedAccount> = senders
+            .iter()
+            .map(|&address| ChangedAccount { address, nonce: 1, balance: U256::MAX })
+            .collect();
+        pool.update_accounts(changed_accounts);
+        assert_eq!(pool.pool_size().pending, 3, "nonce-1 txs should be pending after fix");
+        assert_eq!(pool.pool_size().queued, 0, "no txs should be queued after fix");
+
+        // FB2's iterator must see all 3 nonce-1 txs
+        let mut fb2_iter = pool.best_transactions_with_attributes(best_attrs);
+        let mut count = 0;
+        while fb2_iter.next().is_some() {
+            count += 1;
+        }
+        assert_eq!(count, 3);
+    }
 }

--- a/crates/builder/core/src/flashblocks/payload.rs
+++ b/crates/builder/core/src/flashblocks/payload.rs
@@ -6,7 +6,7 @@ use std::{
 };
 
 use alloy_consensus::{
-    BlockBody, EMPTY_OMMER_ROOT_HASH, Header, constants::EMPTY_WITHDRAWALS, proofs,
+    BlockBody, EMPTY_OMMER_ROOT_HASH, Header, Transaction, constants::EMPTY_WITHDRAWALS, proofs,
 };
 use alloy_eips::{Encodable2718, eip7685::EMPTY_REQUESTS_HASH, merge::BEACON_NONCE};
 use alloy_evm::Database;
@@ -25,6 +25,7 @@ use either::Either;
 use eyre::WrapErr as _;
 use reth_basic_payload_builder::BuildOutcome;
 use reth_evm::{ConfigureEvm, execute::BlockBuilder};
+use reth_execution_types::ChangedAccount;
 use reth_node_api::{Block, BuiltPayloadExecutedBlock, PayloadBuilderError};
 use reth_payload_primitives::PayloadBuilderAttributes;
 use reth_payload_util::BestPayloadTransactions;
@@ -38,6 +39,7 @@ use reth_revm::{
 };
 use reth_transaction_pool::TransactionPool;
 use reth_trie::{HashedPostState, updates::TrieUpdates};
+use revm::Database as _;
 use serde::{Deserialize, Serialize};
 use tokio::sync::mpsc;
 use tokio_util::sync::CancellationToken;
@@ -402,6 +404,9 @@ where
             }
         });
 
+        // Highest executed nonce per sender, updated incrementally per flashblock.
+        let mut executed_sender_nonces: HashMap<Address, u64> = HashMap::default();
+
         // Process flashblocks in a blocking loop
         loop {
             let fb_span = if span.is_none() {
@@ -440,6 +445,7 @@ where
                     &best_payload,
                     &publish_guard,
                     &fb_span,
+                    &mut executed_sender_nonces,
                 )
                 .await
             {
@@ -504,6 +510,7 @@ where
         best_payload: &BlockCell<OpBuiltPayload>,
         publish_guard: &parking_lot::Mutex<()>,
         span: &tracing::Span,
+        executed_sender_nonces: &mut HashMap<Address, u64>,
     ) -> eyre::Result<Option<FlashblocksExtraCtx>> {
         let flashblock_index = ctx.flashblock_index();
         let target_gas_for_batch = ctx.extra.target_gas_for_batch;
@@ -530,6 +537,28 @@ where
         let flashblock_build_start_time = Instant::now();
 
         info.reset_flashblock_execution_time();
+
+        // Correct the pool's sender nonce tracking before reading the next iterator.
+        // `prune_transactions` clears sender_info, causing nonce-continuation txs to
+        // land in `queued` instead of `pending` since the block isn't sealed yet.
+        if !executed_sender_nonces.is_empty() {
+            let changed_accounts: Vec<ChangedAccount> = executed_sender_nonces
+                .iter()
+                .map(|(&address, &nonce)| {
+                    // Fall back to zero balance on error — conservatively parks the tx until the next block resolves it.
+                    let balance = match state.basic(address) {
+                        Ok(Some(info)) => info.balance,
+                        Ok(None) => U256::ZERO,
+                        Err(e) => {
+                            warn!(address = %address, error = %e, "failed to read sender balance from state, defaulting to zero");
+                            U256::ZERO
+                        }
+                    };
+                    ChangedAccount { address, nonce: nonce + 1, balance }
+                })
+                .collect();
+            self.pool.update_accounts(changed_accounts);
+        }
 
         let best_txs_start_time = Instant::now();
         best_txs.refresh_iterator(BestPayloadTransactions::new(
@@ -558,6 +587,22 @@ where
             .collect::<Vec<_>>();
         best_txs.mark_committed(&new_transactions);
         self.pool.prune_transactions(new_transactions);
+
+        // Track executed nonces incrementally for the next flashblock's update_accounts call.
+        debug_assert_eq!(
+            info.executed_transactions.len(),
+            info.executed_senders.len(),
+            "executed_transactions and executed_senders must be in lockstep"
+        );
+        for (tx, sender) in info.executed_transactions[info.extra.last_flashblock_index..]
+            .iter()
+            .zip(info.executed_senders[info.extra.last_flashblock_index..].iter())
+        {
+            executed_sender_nonces
+                .entry(*sender)
+                .and_modify(|n| *n = (*n).max(tx.nonce()))
+                .or_insert_with(|| tx.nonce());
+        }
 
         // We got block cancelled, we won't need anything from the block at this point
         // Caution: this assume that block cancel token only cancelled when new FCU is received

--- a/crates/builder/core/src/traits.rs
+++ b/crates/builder/core/src/traits.rs
@@ -8,7 +8,7 @@ use base_txpool::OpPooledTx;
 use reth_node_api::{FullNodeTypes, NodeTypes};
 use reth_payload_util::PayloadTransactions;
 use reth_provider::{BlockReaderIdExt, ChainSpecProvider, StateProviderFactory};
-use reth_transaction_pool::TransactionPool;
+use reth_transaction_pool::{TransactionPool, TransactionPoolExt};
 
 pub trait NodeBounds:
     FullNodeTypes<
@@ -29,7 +29,10 @@ impl<T> NodeBounds for T where
 }
 
 pub trait PoolBounds:
-    TransactionPool<Transaction: OpPooledTx<Consensus = OpTransactionSigned>> + Unpin + 'static
+    TransactionPool<Transaction: OpPooledTx<Consensus = OpTransactionSigned>>
+    + TransactionPoolExt
+    + Unpin
+    + 'static
 where
     <Self as TransactionPool>::Transaction: OpPooledTx,
 {
@@ -37,7 +40,10 @@ where
 
 impl<T> PoolBounds for T
 where
-    T: TransactionPool<Transaction: OpPooledTx<Consensus = OpTransactionSigned>> + Unpin + 'static,
+    T: TransactionPool<Transaction: OpPooledTx<Consensus = OpTransactionSigned>>
+        + TransactionPoolExt
+        + Unpin
+        + 'static,
     <Self as TransactionPool>::Transaction: OpPooledTx,
 {
 }


### PR DESCRIPTION
## Summary
- Backports #1107 to the v0.6.0 release branch
- Updates pool sender nonces before building flashblocks 2+ so that subsequent transactions from the same sender are not stuck in the queued state