### PR TITLE
chore(ci): upgrade lychee-action to v2.8.0

### DIFF
--- a/.github/workflows/lychee.yml
+++ b/.github/workflows/lychee.yml
@@ -19,7 +19,7 @@ jobs:
         with:
           egress-policy: audit
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
-      - uses: lycheeverse/lychee-action@a8c4c7cb88f0c7386610c35eb25108e448569cb0 # v2.7.0
+      - uses: lycheeverse/lychee-action@8646ba30535128ac92d33dfc9133794bfdd9b411 # v2.8.0
         with:
           args: --config ./lychee.toml --cache-exclude-status 429 --root-dir ${{ github.workspace }}/docs/specs/public --exclude-path 'crates/shared/primitives/contracts/' '**/README.md' './docs/**/*.md' './docs/**/*.mdx' './docs/**/*.html' './docs/**/*.json'
           fail: true


### PR DESCRIPTION
Bumps `lycheeverse/lychee-action` from v2.7.0 to v2.8.0 to pick up the latest link-checking improvements.

Co-authored-by: Cursor <cursoragent@cursor.com>