### PR TITLE
fix(ingress-rpc): record meter bundle metrics

### DIFF
--- a/crates/infra/ingress-rpc/src/metrics.rs
+++ b/crates/infra/ingress-rpc/src/metrics.rs
@@ -48,6 +48,10 @@ pub struct Metrics {
     #[metric(describe = "Duration of meter_bundle")]
     pub meter_bundle_duration: Histogram,
 
+    /// State root calculation time reported by metering.
+    #[metric(describe = "State root calculation time from meter_bundle (microseconds)")]
+    pub meter_bundle_state_root_time_us: Histogram,
+
     /// Duration of send raw transaction.
     #[metric(describe = "Duration of send_raw_transaction")]
     pub send_raw_transaction_duration: Histogram,

--- a/crates/infra/ingress-rpc/src/service.rs
+++ b/crates/infra/ingress-rpc/src/service.rs
@@ -278,7 +278,10 @@ impl<Q: MessageQueue> IngressService<Q> {
         })?
         .map_err(|e| EthApiError::InvalidParams(e.to_string()).into_rpc_err())?;
 
-        record_histogram(start.elapsed(), "base_meterBundle".to_string());
+        let elapsed = start.elapsed();
+        self.metrics.meter_bundle_duration.record(elapsed.as_secs_f64());
+        self.metrics.meter_bundle_state_root_time_us.record(res.state_root_time_us as f64);
+        record_histogram(elapsed, "base_meterBundle".to_string());
 
         // we can save some builder payload building computation by not including bundles
         // that we know will take longer than the block time to execute


### PR DESCRIPTION
Record `meter_bundle_duration` and `meter_bundle_state_root_time_us` in `IngressService::meter_bundle`, keeping the existing `base_meterBundle` latency histogram while exposing state-root timing telemetry.