### PR TITLE
Fix grammar in setup instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ You can build the project using the `justfile` for a release build:
 just build
 ```
 
-*For first-time setup (to ensure all dependencies are installed), you can optionally **setup** run as a precursor:*
+*For first-time setup (to ensure all dependencies are installed), you can optionally run **just setup** as a precursor:*
 
   ```bash
   just setup


### PR DESCRIPTION
The phrase “setup run” was a clear grammatical error and did not correctly describe the intended command. It was corrected to “run just setup” to properly indicate that the user should execute the setup command during the initial setup to install dependencies.