### PR TITLE
feat(enclave-client): Add prove method to EnclaveClient

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3174,6 +3174,7 @@ dependencies = [
  "alloy-primitives",
  "async-trait",
  "base-enclave",
+ "base-proof-primitives",
  "jsonrpsee",
  "rustls 0.23.37",
  "rustls-pki-types",

--- a/crates/proof/tee/client/Cargo.toml
+++ b/crates/proof/tee/client/Cargo.toml
@@ -6,6 +6,7 @@ rust-version.workspace = true
 
 [dependencies]
 base-enclave.workspace = true
+base-proof-primitives = { workspace = true, features = ["serde", "std"] }
 
 # Alloy types
 alloy-primitives.workspace = true

--- a/crates/proof/tee/client/README.md
+++ b/crates/proof/tee/client/README.md
@@ -19,3 +19,30 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     Ok(())
 }
 ```
+
+### Proving
+
+The `prove` method sends a [`ProofRequest`] to the TEE server and receives a
+complete [`ProofResult`] back. The server handles all orchestration internally.
+
+```ignore
+use base_enclave_client::{EnclaveClient, ProofRequest};
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let client = EnclaveClient::new("http://127.0.0.1:1234")?;
+
+    let request = ProofRequest {
+        l1_head: Default::default(),
+        agreed_l2_head_hash: Default::default(),
+        agreed_l2_output_root: Default::default(),
+        claimed_l2_output_root: Default::default(),
+        claimed_l2_block_number: 42,
+    };
+
+    let result = client.prove(&request).await?;
+    println!("Proof claim: {:?}", result.claim);
+
+    Ok(())
+}
+```

--- a/crates/proof/tee/client/README.md
+++ b/crates/proof/tee/client/README.md
@@ -43,7 +43,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         claimed_l2_block_number: 42,
     };
 
-    let result = client.prove(&request).await?;
+    let result = client.prove(request).await?;
     println!("Proof claim: {:?}", result.claim);
 
     Ok(())

--- a/crates/proof/tee/client/README.md
+++ b/crates/proof/tee/client/README.md
@@ -22,8 +22,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
 ### Proving
 
-The `prove` method sends a [`ProofRequest`] to the TEE server and receives a
-complete [`ProofResult`] back. The server handles all orchestration internally.
+The `prove` method sends a `ProofRequest` to the TEE server and receives a
+complete `ProofResult` back. Unlike the lower-level `execute_stateless` and
+`aggregate` methods which require the caller to orchestrate individual block
+executions and aggregation, `prove` delegates all orchestration to the TEE
+server.
 
 ```ignore
 use base_enclave_client::{EnclaveClient, ProofRequest};

--- a/crates/proof/tee/client/src/client.rs
+++ b/crates/proof/tee/client/src/client.rs
@@ -4,6 +4,7 @@ use std::sync::Arc;
 
 use alloy_primitives::Bytes;
 use base_enclave::{AggregateRequest, ExecuteStatelessRequest, Proposal};
+use base_proof_primitives::{ProofRequest, ProofResult};
 use jsonrpsee::{
     core::client::ClientT,
     http_client::{HttpClient, HttpClientBuilder},
@@ -235,5 +236,21 @@ impl EnclaveClient {
     /// Returns an error if the RPC call fails or signature verification fails.
     pub async fn aggregate(&self, request: AggregateRequest) -> Result<Proposal, ClientError> {
         self.inner.request("enclave_aggregate", rpc_params![request]).await.map_err(Into::into)
+    }
+
+    /// Send a proof request to the TEE server and receive a complete proof result.
+    ///
+    /// Unlike [`execute_stateless`](Self::execute_stateless) and
+    /// [`aggregate`](Self::aggregate), which require the caller to orchestrate individual block
+    /// executions and aggregation, this method delegates all orchestration to the TEE server.
+    /// The server handles generating per-block proposals, aggregating them, and returning a
+    /// complete [`ProofResult`] containing the [`ProofClaim`](base_proof_primitives::ProofClaim)
+    /// and [`ProofEvidence`](base_proof_primitives::ProofEvidence).
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the RPC call fails.
+    pub async fn prove(&self, request: &ProofRequest) -> Result<ProofResult, ClientError> {
+        self.inner.request("enclave_prove", rpc_params![request]).await.map_err(Into::into)
     }
 }

--- a/crates/proof/tee/client/src/client.rs
+++ b/crates/proof/tee/client/src/client.rs
@@ -244,8 +244,7 @@ impl EnclaveClient {
     /// [`aggregate`](Self::aggregate), which require the caller to orchestrate individual block
     /// executions and aggregation, this method delegates all orchestration to the TEE server.
     /// The server handles generating per-block proposals, aggregating them, and returning a
-    /// complete [`ProofResult`] containing the [`ProofClaim`](base_proof_primitives::ProofClaim)
-    /// and [`ProofEvidence`](base_proof_primitives::ProofEvidence).
+    /// complete [`ProofResult`] containing the [`ProofClaim`] and [`ProofEvidence`].
     ///
     /// # Errors
     ///

--- a/crates/proof/tee/client/src/client.rs
+++ b/crates/proof/tee/client/src/client.rs
@@ -249,7 +249,7 @@ impl EnclaveClient {
     /// # Errors
     ///
     /// Returns an error if the RPC call fails.
-    pub async fn prove(&self, request: &ProofRequest) -> Result<ProofResult, ClientError> {
+    pub async fn prove(&self, request: ProofRequest) -> Result<ProofResult, ClientError> {
         self.inner.request("enclave_prove", rpc_params![request]).await.map_err(Into::into)
     }
 }

--- a/crates/proof/tee/client/src/lib.rs
+++ b/crates/proof/tee/client/src/lib.rs
@@ -7,8 +7,7 @@
 mod client;
 mod client_error;
 
-// Re-export core types
-pub use base_enclave::*;
+pub use base_enclave::{AggregateRequest, ExecuteStatelessRequest, Proposal};
 pub use base_proof_primitives::{
     ProofBundle, ProofClaim, ProofEvidence, ProofRequest, ProofResult,
 };

--- a/crates/proof/tee/client/src/lib.rs
+++ b/crates/proof/tee/client/src/lib.rs
@@ -9,5 +9,8 @@ mod client_error;
 
 // Re-export core types
 pub use base_enclave::*;
+pub use base_proof_primitives::{
+    ProofBundle, ProofClaim, ProofEvidence, ProofRequest, ProofResult,
+};
 pub use client::EnclaveClient;
 pub use client_error::ClientError;


### PR DESCRIPTION
### What changed? Why?
Adds a high-level `prove` method to `EnclaveClient` that delegates full proof orchestration (per-block execution + aggregation) to the TEE server, returning a complete `ProofResult`. This complements the existing low-level `execute_stateless` and `aggregate` methods which require callers to manage orchestration themselves.

### How has it been tested?
All CI checks (linting, clippy, type-checking, tests) pass cleanly. No new unit tests added, consistent with the existing crate pattern — all RPC methods are thin wrappers and are tested at the transport/integration layer.

### Notes to reviewers
Proof-primitive types (`ProofBundle`, `ProofClaim`, `ProofEvidence`, `ProofRequest`, `ProofResult`) are selectively re-exported from lib.rs to avoid a `Proposal` name conflict between `base-enclave` and `base-proof-primitives`.

### Change management
type=routine
risk=low
impact=sev4

### Backwards Compatibility
backwards_compatible=true

automerge=false