### PR TITLE
refactor(enclave): extract ProofEncoder and EnclaveProvider trait

### DIFF
--- a/crates/proof/proposer/Cargo.toml
+++ b/crates/proof/proposer/Cargo.toml
@@ -34,8 +34,8 @@ base-alloy-rpc-types.workspace = true
 base-alloy-consensus = { workspace = true, features = ["std", "serde"] }
 
 # Proof
-base-proof-contracts.workspace = true
 base-proof-rpc.workspace = true
+base-proof-contracts.workspace = true
 
 # Consensus
 base-protocol.workspace = true

--- a/crates/proof/proposer/src/constants.rs
+++ b/crates/proof/proposer/src/constants.rs
@@ -20,12 +20,6 @@ pub const BLOCKHASH_SAFETY_MARGIN: u64 = 100;
 /// Maximum time to wait for a proposal to be included on-chain.
 pub const PROPOSAL_TIMEOUT: Duration = Duration::from_secs(600);
 
-/// Length of an ECDSA signature in bytes.
-pub const ECDSA_SIGNATURE_LENGTH: usize = 65;
-
-/// Offset to add to ECDSA v-value (0/1 -> 27/28).
-pub const ECDSA_V_OFFSET: u8 = 27;
-
 /// Default poll interval for checking new blocks.
 pub const DEFAULT_POLL_INTERVAL: Duration = Duration::from_secs(12);
 
@@ -33,9 +27,6 @@ pub const DEFAULT_POLL_INTERVAL: Duration = Duration::from_secs(12);
 /// the anchor state registry (i.e., no parent game exists).
 /// This is `uint32.max` per the `DisputeGameFactory` contract.
 pub const NO_PARENT_INDEX: u32 = 0xFFFF_FFFF;
-
-/// Proof type byte for TEE proofs (matches `AggregateVerifier.ProofType.TEE`).
-pub const PROOF_TYPE_TEE: u8 = 0;
 
 /// Maximum number of games to scan backwards when recovering parent game state
 /// on startup.

--- a/crates/proof/proposer/src/driver/mod.rs
+++ b/crates/proof/proposer/src/driver/mod.rs
@@ -771,8 +771,8 @@ mod tests {
 
     use alloy_primitives::{B256, Bytes};
     use async_trait::async_trait;
-    use base_enclave::{Proposal, RollupConfig};
-    use base_enclave_client::{ClientError, ExecuteStatelessRequest};
+    use base_enclave::{ExecuteStatelessRequest, Proposal, RollupConfig};
+    use base_enclave_client::ClientError;
     use base_proof_rpc::SyncStatus;
     use tokio_util::sync::CancellationToken;
 

--- a/crates/proof/proposer/src/enclave/mod.rs
+++ b/crates/proof/proposer/src/enclave/mod.rs
@@ -2,10 +2,12 @@
 
 use alloy_primitives::{B256, U256};
 use async_trait::async_trait;
-use base_enclave::{AggregateRequest, BlockId, Genesis, GenesisSystemConfig, RollupConfig};
+use base_enclave::{
+    AggregateRequest, BlockId, ExecuteStatelessRequest, Genesis, GenesisSystemConfig, RollupConfig,
+};
 pub use base_enclave::{PerChainConfig, Proposal};
+use base_enclave_client::ClientError;
 pub use base_enclave_client::EnclaveClient;
-use base_enclave_client::{ClientError, ExecuteStatelessRequest};
 
 use crate::ProposerError;
 

--- a/crates/proof/proposer/src/output_proposer.rs
+++ b/crates/proof/proposer/src/output_proposer.rs
@@ -16,6 +16,7 @@ use alloy_rpc_types_eth::{TransactionInput, TransactionRequest};
 use alloy_signer_local::PrivateKeySigner;
 use async_trait::async_trait;
 use backon::Retryable;
+use base_enclave::ProofEncoder;
 use base_proof_contracts::{
     encode_create_calldata, encode_extra_data, game_already_exists_selector,
 };
@@ -28,10 +29,7 @@ use url::Url;
 use crate::{
     ProposerError,
     config::SigningConfig,
-    constants::{
-        ECDSA_SIGNATURE_LENGTH, ECDSA_V_OFFSET, GAS_LIMIT_MULTIPLIER_DENOMINATOR,
-        GAS_LIMIT_MULTIPLIER_NUMERATOR, PROOF_TYPE_TEE,
-    },
+    constants::{GAS_LIMIT_MULTIPLIER_DENOMINATOR, GAS_LIMIT_MULTIPLIER_NUMERATOR},
     prover::ProverProposal,
 };
 
@@ -60,39 +58,12 @@ fn classify_contract_error(context: &str, err: impl std::fmt::Display) -> Propos
 ///
 /// Matches Go's `buildProofData()` in `driver.go`.
 pub fn build_proof_data(proposal: &ProverProposal) -> Result<Bytes, ProposerError> {
-    let sig = &proposal.output.signature;
-    if sig.len() < ECDSA_SIGNATURE_LENGTH {
-        return Err(ProposerError::Internal(format!(
-            "signature too short: expected at least {ECDSA_SIGNATURE_LENGTH} bytes, got {}",
-            sig.len()
-        )));
-    }
-
-    let mut proof_data = vec![0u8; 1 + 32 + 32 + ECDSA_SIGNATURE_LENGTH];
-
-    // Byte 0: proof type (TEE = 0)
-    proof_data[0] = PROOF_TYPE_TEE;
-
-    // Bytes 1-32: L1 origin hash
-    proof_data[1..33].copy_from_slice(proposal.to.l1origin.hash.as_slice());
-
-    // Bytes 33-64: L1 origin number as 32-byte big-endian uint256
-    // The uint64 is placed in the last 8 bytes of the 32-byte field (bytes 57-64)
-    proof_data[57..65].copy_from_slice(&proposal.to.l1origin.number.to_be_bytes());
-
-    // Bytes 65-129: ECDSA signature with v-value adjusted from 0/1 to 27/28
-    proof_data[65..130].copy_from_slice(&sig[..ECDSA_SIGNATURE_LENGTH]);
-    proof_data[129] = match proof_data[129] {
-        0 | 1 => proof_data[129] + ECDSA_V_OFFSET,
-        27 | 28 => proof_data[129],
-        v => {
-            return Err(ProposerError::Internal(format!(
-                "unexpected ECDSA v-value: {v}, expected 0, 1, 27, or 28"
-            )));
-        }
-    };
-
-    Ok(Bytes::from(proof_data))
+    ProofEncoder::encode_proof_bytes(
+        &proposal.output.signature,
+        proposal.to.l1origin.hash,
+        proposal.to.l1origin.number,
+    )
+    .map_err(|e| ProposerError::Internal(e.to_string()))
 }
 
 /// Shared logic for building, signing, broadcasting, and confirming a proposal transaction.
@@ -457,6 +428,8 @@ pub fn create_output_proposer(
 
 #[cfg(test)]
 mod tests {
+    use base_enclave::PROOF_TYPE_TEE;
+
     use super::*;
     use crate::prover::test_helpers::test_proposal;
 
@@ -534,7 +507,7 @@ mod tests {
 
         let result = build_proof_data(&proposal);
         assert!(result.is_err());
-        assert!(result.unwrap_err().to_string().contains("unexpected ECDSA v-value"));
+        assert!(result.unwrap_err().to_string().contains("invalid ECDSA v-value"));
     }
 
     // ========================================================================

--- a/crates/proof/proposer/src/prover/mod.rs
+++ b/crates/proof/proposer/src/prover/mod.rs
@@ -13,10 +13,9 @@ use alloy_rpc_types_eth::TransactionReceipt;
 use base_alloy_consensus::OpTxEnvelope;
 use base_alloy_rpc_types::Transaction as OpTransaction;
 use base_enclave::{
-    AggregateRequest, ChainConfig, Proposal, RollupConfig, l2_block_to_block_info,
-    output_root_v0_with_hash,
+    AggregateRequest, ChainConfig, ExecuteStatelessRequest, Proposal, RollupConfig,
+    l2_block_to_block_info, output_root_v0_with_hash,
 };
-use base_enclave_client::ExecuteStatelessRequest;
 use base_proof_rpc::{L1BlockId, L1Provider, L2BlockRef, OpBlock};
 use base_protocol::Predeploys;
 pub use types::ProverProposal;
@@ -526,7 +525,7 @@ mod tests {
 
     use alloy_primitives::{B256, Bloom, BloomInput, Bytes, U256};
     use async_trait::async_trait;
-    use base_enclave_client::{ClientError, ExecuteStatelessRequest};
+    use base_enclave_client::ClientError;
     use rstest::rstest;
     use types::test_helpers::test_proposal;
 

--- a/crates/proof/tee/client/src/client.rs
+++ b/crates/proof/tee/client/src/client.rs
@@ -3,6 +3,7 @@
 use std::sync::Arc;
 
 use alloy_primitives::Bytes;
+use async_trait::async_trait;
 use base_enclave::{AggregateRequest, ExecuteStatelessRequest, Proposal};
 use base_proof_primitives::{ProofRequest, ProofResult};
 use jsonrpsee::{
@@ -251,5 +252,24 @@ impl EnclaveClient {
     /// Returns an error if the RPC call fails.
     pub async fn prove(&self, request: ProofRequest) -> Result<ProofResult, ClientError> {
         self.inner.request("enclave_prove", rpc_params![request]).await.map_err(Into::into)
+    }
+}
+
+/// Abstraction over a TEE prover that accepts a [`ProofRequest`] and returns a
+/// [`ProofResult`].
+///
+/// The canonical implementation delegates to
+/// [`EnclaveClient::prove`], but the trait allows callers (e.g. the challenger)
+/// to swap in a mock for testing without needing real RPC servers.
+#[async_trait]
+pub trait EnclaveProvider: Send + Sync {
+    /// Generate a complete TEE proof for the given request.
+    async fn prove(&self, request: ProofRequest) -> Result<ProofResult, ClientError>;
+}
+
+#[async_trait]
+impl EnclaveProvider for EnclaveClient {
+    async fn prove(&self, request: ProofRequest) -> Result<ProofResult, ClientError> {
+        self.prove(request).await
     }
 }

--- a/crates/proof/tee/client/src/client_error.rs
+++ b/crates/proof/tee/client/src/client_error.rs
@@ -17,3 +17,22 @@ pub enum ClientError {
     #[error("invalid URL: {0}")]
     InvalidUrl(String),
 }
+
+impl ClientError {
+    /// Returns `true` if this error is transient and the operation can be retried.
+    ///
+    /// Only transport-level failures from the underlying jsonrpsee client are
+    /// considered retryable. Configuration errors (`ClientCreation`, `InvalidUrl`)
+    /// are never retryable.
+    pub const fn is_retryable(&self) -> bool {
+        matches!(
+            self,
+            Self::Rpc(
+                jsonrpsee::core::client::Error::Transport(_)
+                    | jsonrpsee::core::client::Error::RestartNeeded(_)
+                    | jsonrpsee::core::client::Error::RequestTimeout
+                    | jsonrpsee::core::client::Error::ServiceDisconnect,
+            )
+        )
+    }
+}

--- a/crates/proof/tee/client/src/lib.rs
+++ b/crates/proof/tee/client/src/lib.rs
@@ -8,8 +8,4 @@ mod client;
 pub use client::{EnclaveClient, EnclaveProvider};
 
 mod client_error;
-pub use base_enclave::{AggregateRequest, ExecuteStatelessRequest, Proposal};
-pub use base_proof_primitives::{
-    ProofBundle, ProofClaim, ProofEvidence, ProofRequest, ProofResult,
-};
 pub use client_error::ClientError;

--- a/crates/proof/tee/client/src/lib.rs
+++ b/crates/proof/tee/client/src/lib.rs
@@ -5,11 +5,11 @@
 #![deny(rust_2018_idioms)]
 
 mod client;
-mod client_error;
+pub use client::{EnclaveClient, EnclaveProvider};
 
+mod client_error;
 pub use base_enclave::{AggregateRequest, ExecuteStatelessRequest, Proposal};
 pub use base_proof_primitives::{
     ProofBundle, ProofClaim, ProofEvidence, ProofRequest, ProofResult,
 };
-pub use client::EnclaveClient;
 pub use client_error::ClientError;

--- a/crates/proof/tee/core/src/error.rs
+++ b/crates/proof/tee/core/src/error.rs
@@ -22,6 +22,10 @@ pub enum CryptoError {
     /// Signature has invalid length.
     #[error("invalid signature length: expected 65 bytes, got {0}")]
     InvalidSignatureLength(usize),
+
+    /// Invalid ECDSA v-value.
+    #[error("invalid ECDSA v-value: expected 0, 1, 27, or 28, got {0}")]
+    InvalidVValue(u8),
 }
 
 /// Errors that can occur during stateless block execution.

--- a/crates/proof/tee/core/src/lib.rs
+++ b/crates/proof/tee/core/src/lib.rs
@@ -18,6 +18,9 @@ pub use config::{
 mod error;
 pub use error::{ConfigError, CryptoError, EnclaveError, ExecutorError, ProviderError, Result};
 
+mod proof;
+pub use proof::{ECDSA_SIGNATURE_LENGTH, ECDSA_V_OFFSET, PROOF_TYPE_TEE, ProofEncoder};
+
 mod executor;
 pub use executor::{
     BlockExecutionResult, DEPOSIT_EVENT_TOPIC, EnclaveEvmFactory, EnclaveTrieDB, EnclaveTrieHinter,

--- a/crates/proof/tee/core/src/proof.rs
+++ b/crates/proof/tee/core/src/proof.rs
@@ -26,7 +26,7 @@ impl ProofEncoder {
     ///
     /// Returns an error if the signature is not exactly 65 bytes or has an invalid v-value.
     pub fn encode_proof_bytes(
-        signature: &Bytes,
+        signature: &[u8],
         l1_origin_hash: B256,
         l1_origin_number: u64,
     ) -> Result<Bytes, CryptoError> {

--- a/crates/proof/tee/core/src/proof.rs
+++ b/crates/proof/tee/core/src/proof.rs
@@ -24,13 +24,13 @@ impl ProofEncoder {
     ///
     /// # Errors
     ///
-    /// Returns an error if the signature is too short or has an invalid v-value.
+    /// Returns an error if the signature is not exactly 65 bytes or has an invalid v-value.
     pub fn encode_proof_bytes(
         signature: &Bytes,
         l1_origin_hash: B256,
         l1_origin_number: u64,
     ) -> Result<Bytes, CryptoError> {
-        if signature.len() < ECDSA_SIGNATURE_LENGTH {
+        if signature.len() != ECDSA_SIGNATURE_LENGTH {
             return Err(CryptoError::InvalidSignatureLength(signature.len()));
         }
 
@@ -141,6 +141,14 @@ mod tests {
     #[test]
     fn test_encode_proof_bytes_short_signature() {
         let sig = Bytes::from(vec![0u8; 32]);
+        let result = ProofEncoder::encode_proof_bytes(&sig, B256::ZERO, 0);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("invalid signature length"));
+    }
+
+    #[test]
+    fn test_encode_proof_bytes_oversized_signature() {
+        let sig = Bytes::from(vec![0u8; 70]);
         let result = ProofEncoder::encode_proof_bytes(&sig, B256::ZERO, 0);
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("invalid signature length"));

--- a/crates/proof/tee/core/src/proof.rs
+++ b/crates/proof/tee/core/src/proof.rs
@@ -1,0 +1,148 @@
+use alloy_primitives::{B256, Bytes};
+
+use crate::CryptoError;
+
+/// Length of an ECDSA signature in bytes (r + s + v).
+pub const ECDSA_SIGNATURE_LENGTH: usize = 65;
+
+/// Offset to add to ECDSA v-value (0/1 -> 27/28).
+pub const ECDSA_V_OFFSET: u8 = 27;
+
+/// Proof type byte for TEE proofs (matches `AggregateVerifier.ProofType.TEE`).
+pub const PROOF_TYPE_TEE: u8 = 0;
+
+/// Proof encoding utilities for TEE proofs.
+#[derive(Debug)]
+pub struct ProofEncoder;
+
+impl ProofEncoder {
+    /// Encodes a TEE proof into the 130-byte format expected by `AggregateVerifier`.
+    ///
+    /// Format: `proofType(1) + l1OriginHash(32) + l1OriginNumber(32) + signature(65)`
+    ///
+    /// The v-value in the ECDSA signature is adjusted from 0/1 to 27/28 if needed.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the signature is too short or has an invalid v-value.
+    pub fn encode_proof_bytes(
+        signature: &Bytes,
+        l1_origin_hash: B256,
+        l1_origin_number: u64,
+    ) -> Result<Bytes, CryptoError> {
+        if signature.len() < ECDSA_SIGNATURE_LENGTH {
+            return Err(CryptoError::InvalidSignatureLength(signature.len()));
+        }
+
+        let mut proof_data = vec![0u8; 1 + 32 + 32 + ECDSA_SIGNATURE_LENGTH];
+
+        // Byte 0: proof type (TEE = 0)
+        proof_data[0] = PROOF_TYPE_TEE;
+
+        // Bytes 1-32: L1 origin hash
+        proof_data[1..33].copy_from_slice(l1_origin_hash.as_slice());
+
+        // Bytes 33-64: L1 origin number as 32-byte big-endian uint256
+        // The u64 is placed in the last 8 bytes of the 32-byte field (bytes 57-64)
+        proof_data[57..65].copy_from_slice(&l1_origin_number.to_be_bytes());
+
+        // Bytes 65-129: ECDSA signature with v-value adjusted from 0/1 to 27/28
+        proof_data[65..130].copy_from_slice(&signature[..ECDSA_SIGNATURE_LENGTH]);
+        proof_data[129] = match proof_data[129] {
+            0 | 1 => proof_data[129] + ECDSA_V_OFFSET,
+            27 | 28 => proof_data[129],
+            v => return Err(CryptoError::InvalidVValue(v)),
+        };
+
+        Ok(Bytes::from(proof_data))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_signature(v: u8) -> Bytes {
+        let mut sig = vec![0xAB; 65];
+        sig[64] = v;
+        Bytes::from(sig)
+    }
+
+    #[test]
+    fn test_encode_proof_bytes_length() {
+        let sig = test_signature(0);
+        let proof = ProofEncoder::encode_proof_bytes(&sig, B256::repeat_byte(0xCC), 500).unwrap();
+        assert_eq!(proof.len(), 130);
+    }
+
+    #[test]
+    fn test_encode_proof_bytes_type() {
+        let sig = test_signature(0);
+        let proof = ProofEncoder::encode_proof_bytes(&sig, B256::repeat_byte(0xCC), 500).unwrap();
+        assert_eq!(proof[0], PROOF_TYPE_TEE);
+    }
+
+    #[test]
+    fn test_encode_proof_bytes_l1_origin_hash() {
+        let l1_hash = B256::repeat_byte(0xDD);
+        let sig = test_signature(0);
+        let proof = ProofEncoder::encode_proof_bytes(&sig, l1_hash, 500).unwrap();
+        assert_eq!(&proof[1..33], l1_hash.as_slice());
+    }
+
+    #[test]
+    fn test_encode_proof_bytes_l1_origin_number() {
+        let sig = test_signature(0);
+        let proof = ProofEncoder::encode_proof_bytes(&sig, B256::ZERO, 12345).unwrap();
+        // Leading 24 bytes of the uint256 field (bytes 33-56) must be zero padding
+        assert_eq!(&proof[33..57], &[0u8; 24]);
+        // u64 is placed in bytes 57-64 (last 8 bytes of the 32-byte field)
+        let mut expected = [0u8; 8];
+        expected.copy_from_slice(&proof[57..65]);
+        assert_eq!(u64::from_be_bytes(expected), 12345);
+    }
+
+    #[test]
+    fn test_encode_proof_bytes_v_zero_adjusted_to_27() {
+        let sig = test_signature(0);
+        let proof = ProofEncoder::encode_proof_bytes(&sig, B256::ZERO, 0).unwrap();
+        assert_eq!(proof[129], 27);
+    }
+
+    #[test]
+    fn test_encode_proof_bytes_v_one_adjusted_to_28() {
+        let sig = test_signature(1);
+        let proof = ProofEncoder::encode_proof_bytes(&sig, B256::ZERO, 0).unwrap();
+        assert_eq!(proof[129], 28);
+    }
+
+    #[test]
+    fn test_encode_proof_bytes_v_27_unchanged() {
+        let sig = test_signature(27);
+        let proof = ProofEncoder::encode_proof_bytes(&sig, B256::ZERO, 0).unwrap();
+        assert_eq!(proof[129], 27);
+    }
+
+    #[test]
+    fn test_encode_proof_bytes_v_28_unchanged() {
+        let sig = test_signature(28);
+        let proof = ProofEncoder::encode_proof_bytes(&sig, B256::ZERO, 0).unwrap();
+        assert_eq!(proof[129], 28);
+    }
+
+    #[test]
+    fn test_encode_proof_bytes_invalid_v() {
+        let sig = test_signature(5);
+        let result = ProofEncoder::encode_proof_bytes(&sig, B256::ZERO, 0);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("invalid ECDSA v-value"));
+    }
+
+    #[test]
+    fn test_encode_proof_bytes_short_signature() {
+        let sig = Bytes::from(vec![0u8; 32]);
+        let result = ProofEncoder::encode_proof_bytes(&sig, B256::ZERO, 0);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("invalid signature length"));
+    }
+}


### PR DESCRIPTION
## Summary
- Extract proof encoding logic from `base-proposer` into a shared `ProofEncoder` type in `base-enclave`, enabling reuse by both the proposer and challenger
- Add `EnclaveProvider` trait to `base-enclave-client` for abstracting TEE client interactions
- Add `is_retryable()` helper to `EnclaveClientError` for retry logic
- Add `InvalidVValue` error variant to `base-enclave` core errors

## Test plan
- [x] `cargo check -p base-enclave -p base-enclave-client -p base-proposer` passes
- [x] `cargo test -p base-enclave -- proof` passes (11 tests)
- [x] `cargo test -p base-proposer -- build_proof_data` passes (5 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)