### PR TITLE
chore(ci): align harden-runner version in docs job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,7 +128,7 @@ jobs:
       docker: ${{ steps.filter.outputs.docker }}
     steps:
       - name: Harden the runner (Audit all outbound calls)
-        uses: step-security/harden-runner@a90bcbc6539c36a85cdfeb73f7e2f433735f215b # v2.15.0
+        uses: step-security/harden-runner@95d9a5deda9de15063e7595e9719c11c38c90ae2 # v2.13.2
         with:
           egress-policy: audit
 


### PR DESCRIPTION
The docs job was on harden-runner v2.15.0 while every other job uses v2.13.2. Align to v2.13.2 for consistency.