### PR TITLE
fix(consensus): graceful startup when L1 node is still syncing

### DIFF
--- a/crates/client/cli/src/p2p.rs
+++ b/crates/client/cli/src/p2p.rs
@@ -360,9 +360,16 @@ impl P2PArgs {
                 .await?;
 
             // Convert the unsafe block signer address to the correct type.
-            return Ok(alloy_primitives::Address::from_slice(
+            let signer = alloy_primitives::Address::from_slice(
                 &unsafe_block_signer_address.to_be_bytes_vec()[12..],
-            ));
+            );
+
+            // If storage returns zero (e.g. L1 is still early in sync and the SystemConfig
+            // contract hadn't been deployed at the queried block), fall through to the
+            // genesis/registry signer rather than using the zero address.
+            if !signer.is_zero() {
+                return Ok(signer);
+            }
         }
 
         // Otherwise use the genesis signer or the configured unsafe block signer.

--- a/crates/client/cli/src/p2p.rs
+++ b/crates/client/cli/src/p2p.rs
@@ -717,6 +717,60 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_unsafe_block_signer_uses_genesis_when_no_l1() {
+        let args = MockCommand::parse_from(["test"]).p2p;
+        let genesis: Address = "0xAf6E19BE0F9cE7f8afd49a1824851023A8249e8a".parse().unwrap();
+        let signer = args
+            .unsafe_block_signer(8453, &RollupConfig::default(), None, Some(genesis))
+            .await
+            .unwrap();
+        assert_eq!(signer, genesis);
+    }
+
+    #[tokio::test]
+    async fn test_unsafe_block_signer_uses_cli_flag_when_no_genesis() {
+        let expected: Address = "0xAf6E19BE0F9cE7f8afd49a1824851023A8249e8a".parse().unwrap();
+        let args = MockCommand::parse_from([
+            "test",
+            "--p2p.unsafe.block.signer",
+            "0xAf6E19BE0F9cE7f8afd49a1824851023A8249e8a",
+        ])
+        .p2p;
+        let signer = args
+            .unsafe_block_signer(8453, &RollupConfig::default(), None, None)
+            .await
+            .unwrap();
+        assert_eq!(signer, expected);
+    }
+
+    #[tokio::test]
+    async fn test_unsafe_block_signer_genesis_takes_priority_over_cli() {
+        let genesis: Address = "0xAf6E19BE0F9cE7f8afd49a1824851023A8249e8a".parse().unwrap();
+        let args = MockCommand::parse_from([
+            "test",
+            "--p2p.unsafe.block.signer",
+            "0x0000000000000000000000000000000000000001",
+        ])
+        .p2p;
+        let signer = args
+            .unsafe_block_signer(8453, &RollupConfig::default(), None, Some(genesis))
+            .await
+            .unwrap();
+        assert_eq!(signer, genesis);
+    }
+
+    #[tokio::test]
+    async fn test_unsafe_block_signer_errors_with_no_fallbacks() {
+        let args = MockCommand::parse_from(["test"]).p2p;
+        let err = args
+            .unsafe_block_signer(99999, &RollupConfig::default(), None, None)
+            .await
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("99999"));
+    }
+
+    #[tokio::test]
     async fn test_p2p_config_errors_on_invalid_bootnode() {
         let args = MockCommand::parse_from(["test", "--p2p.bootnodes", "enr:invalid"]);
 

--- a/crates/client/cli/src/p2p.rs
+++ b/crates/client/cli/src/p2p.rs
@@ -370,6 +370,13 @@ impl P2PArgs {
             if !signer.is_zero() {
                 return Ok(signer);
             }
+
+            warn!(
+                target: "p2p::flags",
+                block_number = block_info.number,
+                "L1 SystemConfig returned zero unsafe block signer (L1 may still be syncing), \
+                 falling back to registry/genesis signer"
+            );
         }
 
         // Otherwise use the genesis signer or the configured unsafe block signer.
@@ -736,10 +743,8 @@ mod tests {
             "0xAf6E19BE0F9cE7f8afd49a1824851023A8249e8a",
         ])
         .p2p;
-        let signer = args
-            .unsafe_block_signer(8453, &RollupConfig::default(), None, None)
-            .await
-            .unwrap();
+        let signer =
+            args.unsafe_block_signer(8453, &RollupConfig::default(), None, None).await.unwrap();
         assert_eq!(signer, expected);
     }
 

--- a/crates/consensus/registry/configs/base-mainnet.toml
+++ b/crates/consensus/registry/configs/base-mainnet.toml
@@ -42,6 +42,7 @@ max_sequencer_drift = 600
 
 [roles]
   ProxyAdminOwner = "0x7bB41C3008B3f03FE483B28b8DB90e19Cf07595c"
+  UnsafeBlockSigner = "0xAf6E19BE0F9cE7f8afd49a1824851023A8249e8a"
 
 [addresses]
   L1StandardBridgeProxy = "0x3154Cf16ccdb4C6d922629664174b904d80F2C35"

--- a/crates/consensus/registry/configs/base-sepolia.toml
+++ b/crates/consensus/registry/configs/base-sepolia.toml
@@ -43,6 +43,7 @@ max_sequencer_drift = 600
 
 [roles]
   ProxyAdminOwner = "0x0fe884546476dDd290eC46318785046ef68a0BA9"
+  UnsafeBlockSigner = "0xb830b99c95Ea32300039624Cb567d324D4b1D83C"
 
 [addresses]
   L1StandardBridgeProxy = "0xfd0Bf71F60660E2f608ed56e1659C450eB113120"

--- a/crates/consensus/registry/src/registry.rs
+++ b/crates/consensus/registry/src/registry.rs
@@ -90,6 +90,29 @@ mod tests {
     use crate::test_utils;
 
     #[test]
+    fn test_unsafe_block_signer_mainnet() {
+        let signer = Registry::unsafe_block_signer(8453).unwrap();
+        assert_eq!(
+            signer,
+            "0xAf6E19BE0F9cE7f8afd49a1824851023A8249e8a".parse::<Address>().unwrap()
+        );
+    }
+
+    #[test]
+    fn test_unsafe_block_signer_sepolia() {
+        let signer = Registry::unsafe_block_signer(84532).unwrap();
+        assert_eq!(
+            signer,
+            "0xb830b99c95Ea32300039624Cb567d324D4b1D83C".parse::<Address>().unwrap()
+        );
+    }
+
+    #[test]
+    fn test_unsafe_block_signer_unknown_chain() {
+        assert!(Registry::unsafe_block_signer(99999).is_none());
+    }
+
+    #[test]
     fn test_hardcoded_rollup_configs() {
         let test_cases =
             [(8453, test_utils::BASE_MAINNET_CONFIG), (84532, test_utils::BASE_SEPOLIA_CONFIG)]

--- a/crates/consensus/service/src/actors/l1_watcher/blockstream.rs
+++ b/crates/consensus/service/src/actors/l1_watcher/blockstream.rs
@@ -44,8 +44,12 @@ impl<L1P: Provider> BlockStream<L1P> {
     }
 
     /// Creates a [`Stream`] of [`BlockInfo`].
+    ///
+    /// Null responses (e.g. `eth_getBlockByNumber("finalized")` before the CL has communicated
+    /// a finalized checkpoint, or `"latest"` before the L1 node has synced any blocks) are
+    /// silently skipped rather than causing a deserialization error.
     pub fn into_stream(self) -> impl Stream<Item = BlockInfo> + Unpin + Send {
-        let mut poll_stream = PollerBuilder::<(BlockNumberOrTag, bool), Block>::new(
+        let mut poll_stream = PollerBuilder::<(BlockNumberOrTag, bool), Option<Block>>::new(
             self.l1_provider.weak_client(),
             "eth_getBlockByNumber",
             (self.tag, false),
@@ -56,7 +60,8 @@ impl<L1P: Provider> BlockStream<L1P> {
         Box::pin(stream! {
             let mut last_block = None;
             while let Some(next) = poll_stream.next().await {
-                let info: BlockInfo = next.into_consensus().into();
+                let Some(block) = next else { continue };
+                let info: BlockInfo = block.into_consensus().into();
 
                 if last_block.map(|b| b != info).unwrap_or(true) {
                     last_block = Some(info);

--- a/crates/consensus/service/src/service/node.rs
+++ b/crates/consensus/service/src/service/node.rs
@@ -1,8 +1,8 @@
 //! Contains the [`RollupNode`] implementation.
 use std::{ops::Not as _, sync::Arc, time::Duration};
 
-use alloy_eips::BlockNumberOrTag;
-use alloy_provider::RootProvider;
+use alloy_eips::{BlockId, BlockNumberOrTag};
+use alloy_provider::{Provider, RootProvider};
 use base_alloy_network::Base;
 use base_consensus_derive::StatefulAttributesBuilder;
 use base_consensus_engine::{Engine, EngineState};
@@ -31,6 +31,8 @@ use crate::{
 const DERIVATION_PROVIDER_CACHE_SIZE: usize = 1024;
 const HEAD_STREAM_POLL_INTERVAL: u64 = 4;
 const FINALIZED_STREAM_POLL_INTERVAL: u64 = 60;
+const L1_READY_POLL_INTERVAL: u64 = 10;
+const L1_READY_TIMEOUT: u64 = 300;
 
 /// The configuration for the L1 chain.
 #[derive(Debug, Clone)]
@@ -168,6 +170,73 @@ impl RollupNode {
         )
     }
 
+    /// Waits for the L1 node to become ready by polling for the latest block.
+    ///
+    /// The L1 node is considered ready when it can return a block for the latest tag.
+    /// This prevents crashes during node startup when the L1 node is still syncing and
+    /// returns null for eth_getBlockByNumber(latest).
+    ///
+    /// If L1 is not ready after the timeout, a warning is logged but the node proceeds anyway
+    /// (to handle cases where syncing information is unavailable).
+    async fn wait_for_l1_ready(&self) -> Result<(), String> {
+        info!(target: "l1_watcher", "Checking L1 node readiness");
+
+        let start = std::time::Instant::now();
+        let timeout = Duration::from_secs(L1_READY_TIMEOUT);
+        let poll_interval = Duration::from_secs(L1_READY_POLL_INTERVAL);
+
+        loop {
+            match self.l1_config.engine_provider.get_block(BlockId::latest()).await {
+                Ok(Some(block)) => {
+                    let elapsed = start.elapsed();
+                    info!(
+                        target: "l1_watcher",
+                        block_number = block.header.number,
+                        elapsed_seconds = elapsed.as_secs(),
+                        "L1 is ready, starting consensus service"
+                    );
+                    return Ok(());
+                }
+                Ok(None) => {
+                    if start.elapsed() > timeout {
+                        warn!(
+                            target: "l1_watcher",
+                            elapsed_seconds = timeout.as_secs(),
+                            "L1 node not ready after timeout, proceeding anyway"
+                        );
+                        return Ok(());
+                    }
+
+                    info!(
+                        target: "l1_watcher",
+                        elapsed_seconds = start.elapsed().as_secs(),
+                        "Waiting for L1 to sync"
+                    );
+                    tokio::time::sleep(poll_interval).await;
+                }
+                Err(e) => {
+                    if start.elapsed() > timeout {
+                        warn!(
+                            target: "l1_watcher",
+                            elapsed_seconds = timeout.as_secs(),
+                            error = %e,
+                            "L1 node not ready after timeout, proceeding anyway"
+                        );
+                        return Ok(());
+                    }
+
+                    warn!(
+                        target: "l1_watcher",
+                        error = %e,
+                        elapsed_seconds = start.elapsed().as_secs(),
+                        "Error checking L1 readiness, retrying"
+                    );
+                    tokio::time::sleep(poll_interval).await;
+                }
+            }
+        }
+    }
+
     /// Helper function to assemble the [`EngineActor`] since there are many structs created that
     /// are not relevant to other actors or logic.
     /// Note: ignoring complex type warning. This type only pertains to this function, so it is
@@ -229,6 +298,10 @@ impl RollupNode {
     /// finalizes `safe` blocks that it has derived when L1 finalized block updates are
     /// received.
     pub async fn start(&self) -> Result<(), String> {
+        // Wait for L1 node to be ready before proceeding with startup.
+        // This prevents crashes when L1 is still syncing and returns null for block queries.
+        self.wait_for_l1_ready().await?;
+
         // Create a global cancellation token for graceful shutdown of tasks.
         let cancellation = CancellationToken::new();
 

--- a/crates/consensus/service/src/service/node.rs
+++ b/crates/consensus/service/src/service/node.rs
@@ -178,7 +178,7 @@ impl RollupNode {
     ///
     /// If L1 is not ready after the timeout, a warning is logged but the node proceeds anyway
     /// (to handle cases where syncing information is unavailable).
-    async fn wait_for_l1_ready(&self) {
+    async fn wait_for_l1_ready(&self, cancellation: &CancellationToken) {
         info!(target: "l1_watcher", "Checking L1 node readiness");
 
         let start = std::time::Instant::now();
@@ -212,7 +212,6 @@ impl RollupNode {
                         elapsed_seconds = start.elapsed().as_secs(),
                         "Waiting for L1 to sync"
                     );
-                    tokio::time::sleep(poll_interval).await;
                 }
                 Err(e) => {
                     if start.elapsed() > timeout {
@@ -231,8 +230,15 @@ impl RollupNode {
                         elapsed_seconds = start.elapsed().as_secs(),
                         "Error checking L1 readiness, retrying"
                     );
-                    tokio::time::sleep(poll_interval).await;
                 }
+            }
+
+            tokio::select! {
+                _ = cancellation.cancelled() => {
+                    info!(target: "l1_watcher", "Shutdown requested during L1 readiness check");
+                    return;
+                }
+                _ = tokio::time::sleep(poll_interval) => {}
             }
         }
     }
@@ -298,12 +304,13 @@ impl RollupNode {
     /// finalizes `safe` blocks that it has derived when L1 finalized block updates are
     /// received.
     pub async fn start(&self) -> Result<(), String> {
-        // Wait for L1 node to be ready before proceeding with startup.
-        // This prevents crashes when L1 is still syncing and returns null for block queries.
-        self.wait_for_l1_ready().await;
-
         // Create a global cancellation token for graceful shutdown of tasks.
         let cancellation = CancellationToken::new();
+
+        // Wait for L1 node to be ready before spawning any actors.
+        // This prevents crashes when L1 is still syncing and returns null for block queries.
+        // The cancellation token allows a clean shutdown if SIGTERM arrives during this wait.
+        self.wait_for_l1_ready(&cancellation).await;
 
         let (derivation_actor_request_tx, derivation_actor_request_rx) = mpsc::channel(1024);
 

--- a/crates/consensus/service/src/service/node.rs
+++ b/crates/consensus/service/src/service/node.rs
@@ -1,8 +1,8 @@
 //! Contains the [`RollupNode`] implementation.
 use std::{ops::Not as _, sync::Arc, time::Duration};
 
-use alloy_eips::{BlockId, BlockNumberOrTag};
-use alloy_provider::{Provider, RootProvider};
+use alloy_eips::BlockNumberOrTag;
+use alloy_provider::RootProvider;
 use base_alloy_network::Base;
 use base_consensus_derive::StatefulAttributesBuilder;
 use base_consensus_engine::{Engine, EngineState};
@@ -31,8 +31,6 @@ use crate::{
 const DERIVATION_PROVIDER_CACHE_SIZE: usize = 1024;
 const HEAD_STREAM_POLL_INTERVAL: u64 = 4;
 const FINALIZED_STREAM_POLL_INTERVAL: u64 = 60;
-const L1_READY_POLL_INTERVAL: u64 = 10;
-const L1_READY_TIMEOUT: u64 = 300;
 
 /// The configuration for the L1 chain.
 #[derive(Debug, Clone)]
@@ -170,79 +168,6 @@ impl RollupNode {
         )
     }
 
-    /// Waits for the L1 node to become ready by polling for the latest block.
-    ///
-    /// The L1 node is considered ready when it can return a block for the latest tag.
-    /// This prevents crashes during node startup when the L1 node is still syncing and
-    /// returns null for eth_getBlockByNumber(latest).
-    ///
-    /// If L1 is not ready after the timeout, a warning is logged but the node proceeds anyway
-    /// (to handle cases where syncing information is unavailable).
-    async fn wait_for_l1_ready(&self, cancellation: &CancellationToken) {
-        info!(target: "l1_watcher", "Checking L1 node readiness");
-
-        let start = std::time::Instant::now();
-        let timeout = Duration::from_secs(L1_READY_TIMEOUT);
-        let poll_interval = Duration::from_secs(L1_READY_POLL_INTERVAL);
-
-        loop {
-            match self.l1_config.engine_provider.get_block(BlockId::latest()).await {
-                Ok(Some(block)) => {
-                    let elapsed = start.elapsed();
-                    info!(
-                        target: "l1_watcher",
-                        block_number = block.header.number,
-                        elapsed_seconds = elapsed.as_secs(),
-                        "L1 is ready, starting consensus service"
-                    );
-                    return;
-                }
-                Ok(None) => {
-                    if start.elapsed() > timeout {
-                        warn!(
-                            target: "l1_watcher",
-                            elapsed_seconds = timeout.as_secs(),
-                            "L1 node not ready after timeout, proceeding anyway"
-                        );
-                        return;
-                    }
-
-                    info!(
-                        target: "l1_watcher",
-                        elapsed_seconds = start.elapsed().as_secs(),
-                        "Waiting for L1 to sync"
-                    );
-                }
-                Err(e) => {
-                    if start.elapsed() > timeout {
-                        warn!(
-                            target: "l1_watcher",
-                            elapsed_seconds = timeout.as_secs(),
-                            error = %e,
-                            "L1 node not ready after timeout, proceeding anyway"
-                        );
-                        return;
-                    }
-
-                    warn!(
-                        target: "l1_watcher",
-                        error = %e,
-                        elapsed_seconds = start.elapsed().as_secs(),
-                        "Error checking L1 readiness, retrying"
-                    );
-                }
-            }
-
-            tokio::select! {
-                _ = cancellation.cancelled() => {
-                    info!(target: "l1_watcher", "Shutdown requested during L1 readiness check");
-                    return;
-                }
-                _ = tokio::time::sleep(poll_interval) => {}
-            }
-        }
-    }
-
     /// Helper function to assemble the [`EngineActor`] since there are many structs created that
     /// are not relevant to other actors or logic.
     /// Note: ignoring complex type warning. This type only pertains to this function, so it is
@@ -306,11 +231,6 @@ impl RollupNode {
     pub async fn start(&self) -> Result<(), String> {
         // Create a global cancellation token for graceful shutdown of tasks.
         let cancellation = CancellationToken::new();
-
-        // Wait for L1 node to be ready before spawning any actors.
-        // This prevents crashes when L1 is still syncing and returns null for block queries.
-        // The cancellation token allows a clean shutdown if SIGTERM arrives during this wait.
-        self.wait_for_l1_ready(&cancellation).await;
 
         let (derivation_actor_request_tx, derivation_actor_request_rx) = mpsc::channel(1024);
 

--- a/crates/consensus/service/src/service/node.rs
+++ b/crates/consensus/service/src/service/node.rs
@@ -178,7 +178,7 @@ impl RollupNode {
     ///
     /// If L1 is not ready after the timeout, a warning is logged but the node proceeds anyway
     /// (to handle cases where syncing information is unavailable).
-    async fn wait_for_l1_ready(&self) -> Result<(), String> {
+    async fn wait_for_l1_ready(&self) {
         info!(target: "l1_watcher", "Checking L1 node readiness");
 
         let start = std::time::Instant::now();
@@ -195,7 +195,7 @@ impl RollupNode {
                         elapsed_seconds = elapsed.as_secs(),
                         "L1 is ready, starting consensus service"
                     );
-                    return Ok(());
+                    return;
                 }
                 Ok(None) => {
                     if start.elapsed() > timeout {
@@ -204,7 +204,7 @@ impl RollupNode {
                             elapsed_seconds = timeout.as_secs(),
                             "L1 node not ready after timeout, proceeding anyway"
                         );
-                        return Ok(());
+                        return;
                     }
 
                     info!(
@@ -222,7 +222,7 @@ impl RollupNode {
                             error = %e,
                             "L1 node not ready after timeout, proceeding anyway"
                         );
-                        return Ok(());
+                        return;
                     }
 
                     warn!(
@@ -300,7 +300,7 @@ impl RollupNode {
     pub async fn start(&self) -> Result<(), String> {
         // Wait for L1 node to be ready before proceeding with startup.
         // This prevents crashes when L1 is still syncing and returns null for block queries.
-        self.wait_for_l1_ready().await?;
+        self.wait_for_l1_ready().await;
 
         // Create a global cancellation token for graceful shutdown of tasks.
         let cancellation = CancellationToken::new();

--- a/lychee.toml
+++ b/lychee.toml
@@ -18,4 +18,5 @@ exclude = [
     'https://specs.base.org',
     'https://patreon.com',
     'https://www.patreon.com',
+    'https://www.linux-mips.org',
 ]


### PR DESCRIPTION
When running base-consensus against a freshly started Ethereum L1 node (reth + lighthouse), the node crashed immediately because it assumed L1 was fully synced.

The first problem was in BlockStream, which used PollerBuilder typed as Block rather than Option<Block>. When eth_getBlockByNumber("latest") or eth_getBlockByNumber("finalized") returns null during early sync, alloy's deserializer panics instead of handling the absence gracefully. Changing the type to Option<Block> and skipping null responses in the stream fixes both the head and finalized pollers. With this fix in place, a not-yet-synced L1 causes the derivation and finalization paths to idle naturally rather than crash — there is no startup gate needed.

The second problem was the gossip layer rejecting every incoming block with a signer mismatch. The node fetches the unsafe block signer at startup by reading a storage slot from the L1 SystemConfig contract. When L1 is early in its sync, that contract hasn't been deployed yet at the queried block height, so get_storage_at returns zero bytes. The code was accepting zero as a valid signer address, causing gossip to expect 0x000...000 and reject every legitimately signed block from the Base sequencer. The fix skips the zero result, logs a warning so operators know the L1-fetched signer was discarded, and falls through to the registry signer. That exposed a second gap: UnsafeBlockSigner was never populated in the base-mainnet and base-sepolia registry TOMLs, despite the field existing in the Roles struct. Both addresses were verified directly from the SystemConfigProxy storage on L1 and added to the configs.