### PR TITLE
refactor(tee): update encode proof bytes input type for l1 origin number

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3162,6 +3162,7 @@ dependencies = [
  "hex-literal 1.1.0",
  "parking_lot",
  "revm",
+ "rstest",
  "serde",
  "serde_json",
  "thiserror 2.0.18",

--- a/crates/proof/proposer/src/output_proposer.rs
+++ b/crates/proof/proposer/src/output_proposer.rs
@@ -61,7 +61,7 @@ pub fn build_proof_data(proposal: &ProverProposal) -> Result<Bytes, ProposerErro
     ProofEncoder::encode_proof_bytes(
         &proposal.output.signature,
         proposal.to.l1origin.hash,
-        proposal.to.l1origin.number,
+        U256::from(proposal.to.l1origin.number),
     )
     .map_err(|e| ProposerError::Internal(e.to_string()))
 }

--- a/crates/proof/tee/core/Cargo.toml
+++ b/crates/proof/tee/core/Cargo.toml
@@ -45,6 +45,7 @@ serde = { workspace = true, features = ["derive"] }
 
 [dev-dependencies]
 hex.workspace = true
+rstest.workspace = true
 
 [lints]
 workspace = true

--- a/crates/proof/tee/core/src/proof.rs
+++ b/crates/proof/tee/core/src/proof.rs
@@ -1,4 +1,4 @@
-use alloy_primitives::{B256, Bytes};
+use alloy_primitives::{B256, Bytes, U256};
 
 use crate::CryptoError;
 
@@ -28,7 +28,7 @@ impl ProofEncoder {
     pub fn encode_proof_bytes(
         signature: &[u8],
         l1_origin_hash: B256,
-        l1_origin_number: u64,
+        l1_origin_number: U256,
     ) -> Result<Bytes, CryptoError> {
         if signature.len() != ECDSA_SIGNATURE_LENGTH {
             return Err(CryptoError::InvalidSignatureLength(signature.len()));
@@ -43,8 +43,7 @@ impl ProofEncoder {
         proof_data[1..33].copy_from_slice(l1_origin_hash.as_slice());
 
         // Bytes 33-64: L1 origin number as 32-byte big-endian uint256
-        // The u64 is placed in the last 8 bytes of the 32-byte field (bytes 57-64)
-        proof_data[57..65].copy_from_slice(&l1_origin_number.to_be_bytes());
+        proof_data[33..65].copy_from_slice(&l1_origin_number.to_be_bytes::<32>());
 
         // Bytes 65-129: ECDSA signature with v-value adjusted from 0/1 to 27/28
         proof_data[65..130].copy_from_slice(&signature[..ECDSA_SIGNATURE_LENGTH]);
@@ -71,14 +70,18 @@ mod tests {
     #[test]
     fn test_encode_proof_bytes_length() {
         let sig = test_signature(0);
-        let proof = ProofEncoder::encode_proof_bytes(&sig, B256::repeat_byte(0xCC), 500).unwrap();
+        let proof =
+            ProofEncoder::encode_proof_bytes(&sig, B256::repeat_byte(0xCC), U256::from(500))
+                .unwrap();
         assert_eq!(proof.len(), 130);
     }
 
     #[test]
     fn test_encode_proof_bytes_type() {
         let sig = test_signature(0);
-        let proof = ProofEncoder::encode_proof_bytes(&sig, B256::repeat_byte(0xCC), 500).unwrap();
+        let proof =
+            ProofEncoder::encode_proof_bytes(&sig, B256::repeat_byte(0xCC), U256::from(500))
+                .unwrap();
         assert_eq!(proof[0], PROOF_TYPE_TEE);
     }
 
@@ -86,54 +89,51 @@ mod tests {
     fn test_encode_proof_bytes_l1_origin_hash() {
         let l1_hash = B256::repeat_byte(0xDD);
         let sig = test_signature(0);
-        let proof = ProofEncoder::encode_proof_bytes(&sig, l1_hash, 500).unwrap();
+        let proof = ProofEncoder::encode_proof_bytes(&sig, l1_hash, U256::from(500)).unwrap();
         assert_eq!(&proof[1..33], l1_hash.as_slice());
     }
 
     #[test]
     fn test_encode_proof_bytes_l1_origin_number() {
         let sig = test_signature(0);
-        let proof = ProofEncoder::encode_proof_bytes(&sig, B256::ZERO, 12345).unwrap();
-        // Leading 24 bytes of the uint256 field (bytes 33-56) must be zero padding
-        assert_eq!(&proof[33..57], &[0u8; 24]);
-        // u64 is placed in bytes 57-64 (last 8 bytes of the 32-byte field)
-        let mut expected = [0u8; 8];
-        expected.copy_from_slice(&proof[57..65]);
-        assert_eq!(u64::from_be_bytes(expected), 12345);
+        let l1_origin_number = U256::from(12345);
+        let proof = ProofEncoder::encode_proof_bytes(&sig, B256::ZERO, l1_origin_number).unwrap();
+        // Full 32-byte field should match the U256 big-endian encoding
+        assert_eq!(&proof[33..65], &l1_origin_number.to_be_bytes::<32>());
     }
 
     #[test]
     fn test_encode_proof_bytes_v_zero_adjusted_to_27() {
         let sig = test_signature(0);
-        let proof = ProofEncoder::encode_proof_bytes(&sig, B256::ZERO, 0).unwrap();
+        let proof = ProofEncoder::encode_proof_bytes(&sig, B256::ZERO, U256::ZERO).unwrap();
         assert_eq!(proof[129], 27);
     }
 
     #[test]
     fn test_encode_proof_bytes_v_one_adjusted_to_28() {
         let sig = test_signature(1);
-        let proof = ProofEncoder::encode_proof_bytes(&sig, B256::ZERO, 0).unwrap();
+        let proof = ProofEncoder::encode_proof_bytes(&sig, B256::ZERO, U256::ZERO).unwrap();
         assert_eq!(proof[129], 28);
     }
 
     #[test]
     fn test_encode_proof_bytes_v_27_unchanged() {
         let sig = test_signature(27);
-        let proof = ProofEncoder::encode_proof_bytes(&sig, B256::ZERO, 0).unwrap();
+        let proof = ProofEncoder::encode_proof_bytes(&sig, B256::ZERO, U256::ZERO).unwrap();
         assert_eq!(proof[129], 27);
     }
 
     #[test]
     fn test_encode_proof_bytes_v_28_unchanged() {
         let sig = test_signature(28);
-        let proof = ProofEncoder::encode_proof_bytes(&sig, B256::ZERO, 0).unwrap();
+        let proof = ProofEncoder::encode_proof_bytes(&sig, B256::ZERO, U256::ZERO).unwrap();
         assert_eq!(proof[129], 28);
     }
 
     #[test]
     fn test_encode_proof_bytes_invalid_v() {
         let sig = test_signature(5);
-        let result = ProofEncoder::encode_proof_bytes(&sig, B256::ZERO, 0);
+        let result = ProofEncoder::encode_proof_bytes(&sig, B256::ZERO, U256::ZERO);
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("invalid ECDSA v-value"));
     }
@@ -141,7 +141,7 @@ mod tests {
     #[test]
     fn test_encode_proof_bytes_short_signature() {
         let sig = Bytes::from(vec![0u8; 32]);
-        let result = ProofEncoder::encode_proof_bytes(&sig, B256::ZERO, 0);
+        let result = ProofEncoder::encode_proof_bytes(&sig, B256::ZERO, U256::ZERO);
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("invalid signature length"));
     }
@@ -149,7 +149,7 @@ mod tests {
     #[test]
     fn test_encode_proof_bytes_oversized_signature() {
         let sig = Bytes::from(vec![0u8; 70]);
-        let result = ProofEncoder::encode_proof_bytes(&sig, B256::ZERO, 0);
+        let result = ProofEncoder::encode_proof_bytes(&sig, B256::ZERO, U256::ZERO);
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("invalid signature length"));
     }

--- a/crates/proof/tee/core/src/proof.rs
+++ b/crates/proof/tee/core/src/proof.rs
@@ -59,6 +59,8 @@ impl ProofEncoder {
 
 #[cfg(test)]
 mod tests {
+    use rstest::rstest;
+
     use super::*;
 
     fn test_signature(v: u8) -> Bytes {
@@ -68,20 +70,12 @@ mod tests {
     }
 
     #[test]
-    fn test_encode_proof_bytes_length() {
+    fn test_encode_proof_bytes_format() {
         let sig = test_signature(0);
         let proof =
             ProofEncoder::encode_proof_bytes(&sig, B256::repeat_byte(0xCC), U256::from(500))
                 .unwrap();
         assert_eq!(proof.len(), 130);
-    }
-
-    #[test]
-    fn test_encode_proof_bytes_type() {
-        let sig = test_signature(0);
-        let proof =
-            ProofEncoder::encode_proof_bytes(&sig, B256::repeat_byte(0xCC), U256::from(500))
-                .unwrap();
         assert_eq!(proof[0], PROOF_TYPE_TEE);
     }
 
@@ -98,59 +92,27 @@ mod tests {
         let sig = test_signature(0);
         let l1_origin_number = U256::from(12345);
         let proof = ProofEncoder::encode_proof_bytes(&sig, B256::ZERO, l1_origin_number).unwrap();
-        // Full 32-byte field should match the U256 big-endian encoding
         assert_eq!(&proof[33..65], &l1_origin_number.to_be_bytes::<32>());
     }
 
-    #[test]
-    fn test_encode_proof_bytes_v_zero_adjusted_to_27() {
-        let sig = test_signature(0);
+    #[rstest]
+    #[case::v_zero_adjusted_to_27(0, 27)]
+    #[case::v_one_adjusted_to_28(1, 28)]
+    #[case::v_27_unchanged(27, 27)]
+    #[case::v_28_unchanged(28, 28)]
+    fn test_encode_proof_bytes_v_value(#[case] input_v: u8, #[case] expected_v: u8) {
+        let sig = test_signature(input_v);
         let proof = ProofEncoder::encode_proof_bytes(&sig, B256::ZERO, U256::ZERO).unwrap();
-        assert_eq!(proof[129], 27);
+        assert_eq!(proof[129], expected_v);
     }
 
-    #[test]
-    fn test_encode_proof_bytes_v_one_adjusted_to_28() {
-        let sig = test_signature(1);
-        let proof = ProofEncoder::encode_proof_bytes(&sig, B256::ZERO, U256::ZERO).unwrap();
-        assert_eq!(proof[129], 28);
-    }
-
-    #[test]
-    fn test_encode_proof_bytes_v_27_unchanged() {
-        let sig = test_signature(27);
-        let proof = ProofEncoder::encode_proof_bytes(&sig, B256::ZERO, U256::ZERO).unwrap();
-        assert_eq!(proof[129], 27);
-    }
-
-    #[test]
-    fn test_encode_proof_bytes_v_28_unchanged() {
-        let sig = test_signature(28);
-        let proof = ProofEncoder::encode_proof_bytes(&sig, B256::ZERO, U256::ZERO).unwrap();
-        assert_eq!(proof[129], 28);
-    }
-
-    #[test]
-    fn test_encode_proof_bytes_invalid_v() {
-        let sig = test_signature(5);
-        let result = ProofEncoder::encode_proof_bytes(&sig, B256::ZERO, U256::ZERO);
+    #[rstest]
+    #[case::invalid_v(vec![0xAB; 64].into_iter().chain(std::iter::once(5)).collect::<Vec<_>>(), "invalid ECDSA v-value")]
+    #[case::short_signature(vec![0u8; 32], "invalid signature length")]
+    #[case::oversized_signature(vec![0u8; 70], "invalid signature length")]
+    fn test_encode_proof_bytes_errors(#[case] sig: Vec<u8>, #[case] expected_err: &str) {
+        let result = ProofEncoder::encode_proof_bytes(&Bytes::from(sig), B256::ZERO, U256::ZERO);
         assert!(result.is_err());
-        assert!(result.unwrap_err().to_string().contains("invalid ECDSA v-value"));
-    }
-
-    #[test]
-    fn test_encode_proof_bytes_short_signature() {
-        let sig = Bytes::from(vec![0u8; 32]);
-        let result = ProofEncoder::encode_proof_bytes(&sig, B256::ZERO, U256::ZERO);
-        assert!(result.is_err());
-        assert!(result.unwrap_err().to_string().contains("invalid signature length"));
-    }
-
-    #[test]
-    fn test_encode_proof_bytes_oversized_signature() {
-        let sig = Bytes::from(vec![0u8; 70]);
-        let result = ProofEncoder::encode_proof_bytes(&sig, B256::ZERO, U256::ZERO);
-        assert!(result.is_err());
-        assert!(result.unwrap_err().to_string().contains("invalid signature length"));
+        assert!(result.unwrap_err().to_string().contains(expected_err));
     }
 }


### PR DESCRIPTION
Updates input type for `l1_origin_number` in `encode_proof_bytes` to be `U256` from alloy primitive types to match the types returned by the enclave server