### PR TITLE
fix(flashblocks): emit canonical pending updates

### DIFF
--- a/crates/execution/flashblocks/src/processor.rs
+++ b/crates/execution/flashblocks/src/processor.rs
@@ -95,6 +95,9 @@ where
                     debug!(message = "processing canonical block", block_number = block.number);
                     match self.process_canonical_block(prev_pending_blocks, &block) {
                         Ok(new_pending_blocks) => {
+                            if let Some(ref pb) = new_pending_blocks {
+                                _ = self.sender.send(Arc::clone(pb));
+                            }
                             self.pending_blocks.swap(new_pending_blocks);
 
                             let mut cache = self.cache.lock().await;


### PR DESCRIPTION
Emit pending-block updates when canonical reconciliation produces a new snapshot, keeping flashblocks subscribers in sync when state changes are not triggered by direct flashblock processing.