### PR TITLE
fix(README): correct package name

### DIFF
--- a/crates/client/txpool-tracing/README.md
+++ b/crates/client/txpool-tracing/README.md
@@ -19,7 +19,7 @@ This crate provides:
 Enable transaction tracing on the Base node CLI:
 
 ```bash
-cargo run -p node --release -- \
+cargo run -p base-reth-node --release -- \
   --enable-transaction-tracing \
   --enable-transaction-tracing-logs  # optional: emit per-tx lifecycle logs
 ```


### PR DESCRIPTION
The README in `crates/client/txpool-tracing/README.md` (Usage section) shows the command:

`cargo run -p node --release --`

However, there is no `node` package in the workspace. The actual node binary package is `base-reth-node` (see [`bin/node/Cargo.toml`](https://github.com/LisaMoore01/base/blob/main/bin/node/Cargo.toml#L2)).

This change updates the command to:

`cargo run -p base-reth-node --release --`

so the example works correctly when running the Base node.