### PR TITLE
refactor(flashblocks): avoid lock-across-await in state update receive path

### DIFF
--- a/crates/execution/flashblocks/src/processor.rs
+++ b/crates/execution/flashblocks/src/processor.rs
@@ -44,9 +44,9 @@ pub enum StateUpdate {
 }
 
 /// Processes flashblocks and canonical blocks to keep pending state updated.
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct StateProcessor<Client> {
-    rx: Arc<Mutex<UnboundedReceiver<StateUpdate>>>,
+    rx: UnboundedReceiver<StateUpdate>,
     pending_blocks: Arc<ArcSwapOption<PendingBlocks>>,
     max_depth: u64,
     metrics: Metrics,
@@ -68,7 +68,7 @@ where
         client: Client,
         pending_blocks: Arc<ArcSwapOption<PendingBlocks>>,
         max_depth: u64,
-        rx: Arc<Mutex<UnboundedReceiver<StateUpdate>>>,
+        rx: UnboundedReceiver<StateUpdate>,
         sender: Sender<Arc<PendingBlocks>>,
     ) -> Self {
         let cache = client
@@ -87,8 +87,8 @@ where
     }
 
     /// Processes updates from the queue until the channel closes.
-    pub async fn start(&self) {
-        while let Some(update) = self.rx.lock().await.recv().await {
+    pub async fn start(mut self) {
+        while let Some(update) = self.rx.recv().await {
             let prev_pending_blocks = self.pending_blocks.load_full();
             match update {
                 StateUpdate::Canonical(block) => {

--- a/crates/execution/flashblocks/src/state.rs
+++ b/crates/execution/flashblocks/src/state.rs
@@ -1,6 +1,6 @@
 //! Flashblocks state management.
 
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 
 use alloy_consensus::Header;
 use arc_swap::{ArcSwapOption, Guard};
@@ -11,7 +11,6 @@ use reth_chainspec::{ChainSpecProvider, EthChainSpec};
 use reth_primitives::RecoveredBlock;
 use reth_provider::{BlockReaderIdExt, StateProviderFactory};
 use tokio::sync::{
-    Mutex,
     broadcast::{self, Sender},
     mpsc,
 };
@@ -29,7 +28,7 @@ const BUFFER_SIZE: usize = 20;
 pub struct FlashblocksState {
     pending_blocks: Arc<ArcSwapOption<PendingBlocks>>,
     queue: mpsc::UnboundedSender<StateUpdate>,
-    rx: Arc<Mutex<mpsc::UnboundedReceiver<StateUpdate>>>,
+    rx: Mutex<Option<mpsc::UnboundedReceiver<StateUpdate>>>,
     flashblock_sender: Sender<Arc<PendingBlocks>>,
     max_pending_blocks_depth: u64,
 }
@@ -47,7 +46,7 @@ impl FlashblocksState {
         Self {
             pending_blocks,
             queue: tx,
-            rx: Arc::new(Mutex::new(rx)),
+            rx: Mutex::new(Some(rx)),
             flashblock_sender,
             max_pending_blocks_depth,
         }
@@ -65,11 +64,25 @@ impl FlashblocksState {
             + Clone
             + 'static,
     {
+        let mut rx_guard = match self.rx.lock() {
+            Ok(guard) => guard,
+            Err(poisoned) => {
+                error!(message = "state receiver mutex poisoned, recovering ownership");
+                poisoned.into_inner()
+            }
+        };
+
+        let Some(rx) = rx_guard.take() else {
+            warn!(message = "state processor already started, ignoring duplicate start");
+            return;
+        };
+        drop(rx_guard);
+
         let state_processor = StateProcessor::new(
             client,
             Arc::clone(&self.pending_blocks),
             self.max_pending_blocks_depth,
-            Arc::clone(&self.rx),
+            rx,
             self.flashblock_sender.clone(),
         );
 


### PR DESCRIPTION
## Motivation

The update loop previously used `self.rx.lock().await.recv().await`, which keeps a mutex guard alive while awaiting.  
That pattern is safe but suboptimal for a hot async receive path: it introduces avoidable serialization and makes ownership/concurrency less explicit.

## What is included

This PR is intentionally narrow and only touches receiver ownership/startup wiring:

- `crates/execution/flashblocks/src/processor.rs`
- `crates/execution/flashblocks/src/state.rs`

## Design changes

- `StateProcessor` now owns `UnboundedReceiver<StateUpdate>` directly.
- `StateProcessor::start` consumes `self` and awaits on `self.rx.recv().await`.
- `FlashblocksState` stores the receiver as `Mutex<Option<UnboundedReceiver<_>>>`.
- On startup, receiver ownership is transferred exactly once via `take()`.

## Defensive handling added

- If `start()` is invoked more than once, we log and return (no double-consumer race).
- If the receiver mutex is poisoned, we recover ownership and continue with an explicit log.

## Expected result

No API behavior change, but cleaner async semantics:
- no lock held across await on the receive path
- less contention risk
- clearer one-owner model for channel consumption

## Verification status

No new lints were introduced in touched files.  
Full crate check needs to be rerun in a normal local toolchain environment; current environment is blocked by linker configuration.