### PR TITLE
fix(rpc): enforce strict sequencer header validation and fail on malformed entries

### DIFF
--- a/crates/execution/rpc/src/sequencer.rs
+++ b/crates/execution/rpc/src/sequencer.rs
@@ -63,7 +63,8 @@ impl SequencerClient {
 
     /// Creates a new `SequencerClient` for the given URL with the given headers
     ///
-    /// This expects headers in the form: `header=value`
+    /// This expects headers in the form: `header=value`.
+    /// Invalid entries return [`Error::InvalidHeader`] instead of being ignored.
     pub async fn new_with_headers(
         sequencer_endpoint: impl Into<String>,
         headers: Vec<String>,
@@ -77,18 +78,31 @@ impl SequencerClient {
 
             if !headers.is_empty() {
                 let mut header_map = alloy_reqwest::header::HeaderMap::new();
-                for header in headers {
-                    if let Some((key, value)) = header.split_once('=') {
-                        header_map.insert(
-                            key.trim()
-                                .parse::<alloy_reqwest::header::HeaderName>()
-                                .map_err(|err| Error::InvalidHeader(err.to_string()))?,
-                            value
-                                .trim()
-                                .parse::<alloy_reqwest::header::HeaderValue>()
-                                .map_err(|err| Error::InvalidHeader(err.to_string()))?,
-                        );
+                for (idx, header) in headers.into_iter().enumerate() {
+                    let (key, value) = header.split_once('=').ok_or_else(|| {
+                        Error::InvalidHeader(format!(
+                            "header at index {idx} must be in `key=value` format"
+                        ))
+                    })?;
+                    let key = key.trim();
+                    let value = value.trim();
+                    if key.is_empty() {
+                        return Err(Error::InvalidHeader(format!(
+                            "header at index {idx} has an empty key"
+                        )));
                     }
+                    if value.is_empty() {
+                        return Err(Error::InvalidHeader(format!(
+                            "header at index {idx} has an empty value"
+                        )));
+                    }
+                    header_map.insert(
+                        key.parse::<alloy_reqwest::header::HeaderName>()
+                            .map_err(|err| Error::InvalidHeader(err.to_string()))?,
+                        value
+                            .parse::<alloy_reqwest::header::HeaderValue>()
+                            .map_err(|err| Error::InvalidHeader(err.to_string()))?,
+                    );
                 }
                 builder = builder.default_headers(header_map);
             }
@@ -222,5 +236,34 @@ mod tests {
             body,
             r#"{"method":"eth_getBlockByNumber","params":["0xa"],"id":0,"jsonrpc":"2.0"}"#
         );
+    }
+
+    #[tokio::test]
+    async fn test_new_with_headers_rejects_missing_separator() {
+        let result = SequencerClient::new_with_headers(
+            "http://localhost:8545",
+            vec!["x-auth-token".to_string()],
+        )
+        .await;
+
+        assert!(matches!(result, Err(Error::InvalidHeader(_))));
+    }
+
+    #[tokio::test]
+    async fn test_new_with_headers_rejects_empty_key() {
+        let result =
+            SequencerClient::new_with_headers("http://localhost:8545", vec![" = value".to_string()])
+                .await;
+
+        assert!(matches!(result, Err(Error::InvalidHeader(_))));
+    }
+
+    #[tokio::test]
+    async fn test_new_with_headers_rejects_empty_value() {
+        let result =
+            SequencerClient::new_with_headers("http://localhost:8545", vec!["x-auth-token=".to_string()])
+                .await;
+
+        assert!(matches!(result, Err(Error::InvalidHeader(_))));
     }
 }


### PR DESCRIPTION
## Summary
- Enforce strict validation for sequencer headers passed to `new_with_headers`.
- Reject malformed entries early instead of silently ignoring them.
- Add focused tests for common invalid-header cases.

## Changes
- Updated header parsing in `crates/execution/rpc/src/sequencer.rs`:
  - return `Error::InvalidHeader` when header is not in `key=value` format
  - return `Error::InvalidHeader` when key is empty
  - return `Error::InvalidHeader` when value is empty
  - keep returning `Error::InvalidHeader` for invalid header name/value parsing
- Updated method docs to state invalid headers are rejected.

## Tests
- Added:
  - `test_new_with_headers_rejects_missing_separator`
  - `test_new_with_headers_rejects_empty_key`
  - `test_new_with_headers_rejects_empty_value`

## Why this matters
- Prevents silent misconfiguration.
- Makes invalid runtime config fail fast and observable.
- Improves operator/developer debugging experience.