### PR TITLE
ci: broaden affected-crates fallback for infra and workflow changes

### DIFF
--- a/etc/scripts/local/affected-crates.py
+++ b/etc/scripts/local/affected-crates.py
@@ -90,12 +90,17 @@ def main():
 
     crate_dirs = build_crate_map(meta)
 
-    # Files at the workspace root that affect all crates when changed
+    # Paths that should trigger workspace-wide testing when changed.
+    # These include toolchain/build files and CI/scripting infrastructure.
     workspace_root_patterns = (
         "Cargo.toml",
         "Cargo.lock",
         ".cargo/",
         "rust-toolchain.toml",
+        ".github/",
+        "etc/scripts/",
+        "justfile",
+        "deny.toml",
     )
 
     # Map changed files to their crate (longest prefix match)


### PR DESCRIPTION
## Summary
This PR hardens `affected-crates` fallback detection to avoid false “no affected crates” outcomes when CI/scripting infrastructure changes.

## What changed
In `etc/scripts/local/affected-crates.py`, expanded the workspace-wide trigger patterns to include:

- `.github/`
- `etc/scripts/`
- `justfile`
- `deny.toml`

These are now treated similarly to existing root/toolchain triggers (`Cargo.toml`, `Cargo.lock`, `.cargo/`, `rust-toolchain.toml`).

## Why
Previously, changes to workflows or local CI scripts could produce an empty affected set, allowing PR checks to skip tests unintentionally.   This update ensures infra-level changes trigger broad test coverage by default.

## Risk
Low.  
The change may increase CI workload for infra-only PRs, but intentionally trades a bit of runtime for improved reliability and reduced false-green results.

## Validation
- Script updated and diff verified.
- Lint diagnostics on the changed file show no new issues.