### PR TITLE
fix(proposer): remove dispute game index race by resolving index from receipt-derived proxy

### DIFF
--- a/crates/proof/proposer/src/driver/mod.rs
+++ b/crates/proof/proposer/src/driver/mod.rs
@@ -19,7 +19,7 @@ use std::{
     time::Duration,
 };
 
-use alloy_primitives::{B256, U256};
+use alloy_primitives::{Address, B256, U256};
 use async_trait::async_trait;
 use base_proof_contracts::{AnchorStateRegistryClient, DisputeGameFactoryClient};
 use base_proof_rpc::{L1Provider, L2BlockRef, RollupProvider, RpcError};
@@ -532,27 +532,31 @@ where
             "Proposing output (creating dispute game)"
         );
 
+        let pre_create_count = match self.factory_client.game_count().await {
+            Ok(count) => Some(count),
+            Err(e) => {
+                warn!(error = %e, "Failed to read game_count before create, falling back to full scan");
+                None
+            }
+        };
+
         match tokio::time::timeout(
             PROPOSAL_TIMEOUT,
             self.output_proposer.propose_output(proposal, parent_index, intermediate_roots),
         )
         .await
         {
-            Ok(Ok(())) => {
-                info!(l2_block_number = proposal.to.number, "Dispute game created successfully");
+            Ok(Ok(dispute_proxy)) => {
+                info!(
+                    l2_block_number = proposal.to.number,
+                    dispute_proxy = %dispute_proxy,
+                    "Dispute game created successfully"
+                );
                 metrics::counter!(proposer_metrics::L2_OUTPUT_PROPOSALS_TOTAL).increment(1);
 
-                // TODO: This uses `game_count - 1` to infer the new game's index,
-                // which is racy if another proposer creates a game between our
-                // `create()` and this `game_count()` call. Consider parsing the
-                // game index from the transaction receipt's event logs instead.
-                // The current approach self-heals via `GameAlreadyExists` recovery.
-                match self.factory_client.game_count().await {
-                    Ok(count) if count > 0 => {
-                        let new_index = u32::try_from(count - 1).unwrap_or_else(|_| {
-                            warn!(count, "game_count exceeds u32::MAX, clamping to u32::MAX");
-                            u32::MAX
-                        });
+                let start_index = pre_create_count.unwrap_or(0);
+                match self.find_game_index_by_proxy(dispute_proxy, start_index).await {
+                    Ok(Some(new_index)) => {
                         self.parent_game_state = ParentGameState {
                             initialized: true,
                             game_index: new_index,
@@ -565,19 +569,33 @@ where
 
                         info!(
                             new_game_index = new_index,
+                            dispute_proxy = %dispute_proxy,
                             output_root = ?proposal.output.output_root,
                             l2_block_number = proposal.to.number,
                             "Updated parent game state"
                         );
                     }
-                    Ok(_) => {
-                        warn!("gameCount returned 0 after successful create");
+                    Ok(None) => {
+                        warn!(
+                            dispute_proxy = %dispute_proxy,
+                            start_index,
+                            "Created game not found by proxy lookup; recovering parent on next tick"
+                        );
+                        self.last_proposed_block = proposal.to.number;
+                        self.pending.clear();
+                        self.cached_intermediate_roots.clear();
+                        self.parent_game_state.initialized = false;
                     }
                     Err(e) => {
                         warn!(
                             error = %e,
-                            "Failed to get new game index, will recover on next tick"
+                            dispute_proxy = %dispute_proxy,
+                            "Failed to resolve game index by proxy, will recover on next tick"
                         );
+                        self.last_proposed_block = proposal.to.number;
+                        self.pending.clear();
+                        self.cached_intermediate_roots.clear();
+                        self.parent_game_state.initialized = false;
                     }
                 }
             }
@@ -605,6 +623,55 @@ where
                 );
             }
         }
+    }
+
+    async fn find_game_index_by_proxy(
+        &self,
+        dispute_proxy: Address,
+        preferred_start_index: u64,
+    ) -> Result<Option<u32>, ProposerError> {
+        let count = self
+            .factory_client
+            .game_count()
+            .await
+            .map_err(|e| ProposerError::Contract(format!("game_count failed: {e}")))?;
+        if count == 0 {
+            return Ok(None);
+        }
+
+        let start = preferred_start_index.min(count);
+
+        for index in (start..count).rev() {
+            let game = self
+                .factory_client
+                .game_at_index(index)
+                .await
+                .map_err(|e| ProposerError::Contract(format!("game_at_index({index}) failed: {e}")))?;
+            if game.proxy == dispute_proxy {
+                let resolved = u32::try_from(index).unwrap_or_else(|_| {
+                    warn!(index, "game index exceeds u32::MAX, clamping to u32::MAX");
+                    u32::MAX
+                });
+                return Ok(Some(resolved));
+            }
+        }
+
+        for index in (0..start).rev() {
+            let game = self
+                .factory_client
+                .game_at_index(index)
+                .await
+                .map_err(|e| ProposerError::Contract(format!("game_at_index({index}) failed: {e}")))?;
+            if game.proxy == dispute_proxy {
+                let resolved = u32::try_from(index).unwrap_or_else(|_| {
+                    warn!(index, "game index exceeds u32::MAX, clamping to u32::MAX");
+                    u32::MAX
+                });
+                return Ok(Some(resolved));
+            }
+        }
+
+        Ok(None)
     }
 }
 
@@ -897,9 +964,14 @@ mod tests {
             l1_block_number,
             sync_status,
             canonical_hash,
-            Arc::new(MockOutputProposer),
+            mock_output_proposer(),
             CancellationToken::new(),
         )
+    }
+
+    fn mock_output_proposer() -> Arc<dyn OutputProposer> {
+        let proposer: Arc<dyn OutputProposer> = Arc::new(MockOutputProposer);
+        proposer
     }
 
     // ---- Tests ----
@@ -1063,7 +1135,7 @@ mod tests {
             400,
             sync_status,
             Some(canonical_hash),
-            Arc::new(MockOutputProposer),
+            mock_output_proposer(),
             cancel,
         );
 
@@ -1088,7 +1160,7 @@ mod tests {
     #[tokio::test]
     async fn test_step_calls_output_proposer() {
         struct TrackingOutputProposer {
-            called: AtomicBool,
+            called: Arc<AtomicBool>,
         }
 
         #[async_trait]
@@ -1098,15 +1170,17 @@ mod tests {
                 _proposal: &ProverProposal,
                 _parent_index: u32,
                 _intermediate_roots: &[B256],
-            ) -> Result<(), ProposerError> {
+            ) -> Result<Address, ProposerError> {
                 self.called.store(true, Ordering::SeqCst);
-                Ok(())
+                Ok(Address::ZERO)
             }
         }
 
         let canonical_hash = B256::repeat_byte(0x30);
         let sync_status = test_sync_status(200, canonical_hash);
-        let tracking = Arc::new(TrackingOutputProposer { called: AtomicBool::new(false) });
+        let called = Arc::new(AtomicBool::new(false));
+        let tracking_concrete = Arc::new(TrackingOutputProposer { called: called.clone() });
+        let tracking_proposer: Arc<dyn OutputProposer> = tracking_concrete;
 
         let mut driver = test_driver_custom(
             MockEnclave,
@@ -1114,7 +1188,7 @@ mod tests {
             1000,
             sync_status,
             Some(canonical_hash),
-            Arc::clone(&tracking) as Arc<dyn OutputProposer>,
+            tracking_proposer,
             CancellationToken::new(),
         );
 
@@ -1125,7 +1199,7 @@ mod tests {
         let result = driver.step().await;
         assert!(result.is_ok(), "step() should succeed, got: {result:?}");
         assert!(
-            tracking.called.load(Ordering::SeqCst),
+            called.load(Ordering::SeqCst),
             "OutputProposer::propose_output should have been called"
         );
     }
@@ -1145,7 +1219,7 @@ mod tests {
             1000,
             sync_status,
             None,
-            Arc::new(MockOutputProposer),
+            mock_output_proposer(),
             cancel.clone(),
         );
 
@@ -1182,7 +1256,7 @@ mod tests {
             1000,
             sync_status,
             None,
-            Arc::new(MockOutputProposer),
+            mock_output_proposer(),
             global_cancel.child_token(),
         );
         DriverHandle::new(driver, global_cancel)
@@ -1294,7 +1368,7 @@ mod tests {
             1000,
             sync_status,
             None,
-            Arc::new(MockOutputProposer),
+            mock_output_proposer(),
             CancellationToken::new(),
         );
 
@@ -1334,7 +1408,7 @@ mod tests {
             1000,
             sync_status,
             None,
-            Arc::new(MockOutputProposer),
+            mock_output_proposer(),
             CancellationToken::new(),
         );
 
@@ -1367,7 +1441,7 @@ mod tests {
             1000,
             sync_status,
             None,
-            Arc::new(MockOutputProposer),
+            mock_output_proposer(),
             CancellationToken::new(),
         );
 

--- a/crates/proof/proposer/src/output_proposer.rs
+++ b/crates/proof/proposer/src/output_proposer.rs
@@ -10,7 +10,8 @@ use std::{future::Future, sync::Arc};
 
 use alloy_eips::Encodable2718;
 use alloy_network::{EthereumWallet, TransactionBuilder};
-use alloy_primitives::{Address, B256, Bytes, U256};
+use alloy_primitives::{Address, B256, Bytes, U256, keccak256};
+use alloy_rpc_types_eth::TransactionReceipt;
 use alloy_provider::{Provider, RootProvider};
 use alloy_rpc_types_eth::{TransactionInput, TransactionRequest};
 use alloy_signer_local::PrivateKeySigner;
@@ -79,8 +80,10 @@ async fn submit_proposal<F, Fut>(
     init_bond: U256,
     l2_block_number: u64,
     chain_id_cell: &OnceCell<u64>,
+    game_type: u32,
+    root_claim: B256,
     sign_tx: F,
-) -> Result<(), ProposerError>
+) -> Result<Address, ProposerError>
 where
     F: FnOnce(TransactionRequest) -> Fut,
     Fut: Future<Output = Result<Bytes, ProposerError>>,
@@ -145,7 +148,56 @@ where
         block_number = receipt.block_number,
         "Proposal transaction confirmed"
     );
-    Ok(())
+
+    extract_created_dispute_proxy(&receipt, factory_address, game_type, root_claim).ok_or_else(|| {
+        ProposerError::Contract(format!(
+            "transaction {tx_hash} succeeded but no matching DisputeGameCreated event was found"
+        ))
+    })
+}
+
+const DISPUTE_GAME_CREATED_EVENT: &str = "DisputeGameCreated(address,uint32,bytes32)";
+
+fn topic_for_u32(value: u32) -> B256 {
+    let mut bytes = [0u8; 32];
+    bytes[28..].copy_from_slice(&value.to_be_bytes());
+    B256::from(bytes)
+}
+
+fn topic_to_address(topic: B256) -> Option<Address> {
+    if topic.as_slice()[..12].iter().any(|byte| *byte != 0) {
+        return None;
+    }
+    let mut address = [0u8; 20];
+    address.copy_from_slice(&topic.as_slice()[12..]);
+    Some(Address::from(address))
+}
+
+fn extract_created_dispute_proxy(
+    receipt: &TransactionReceipt,
+    factory_address: Address,
+    game_type: u32,
+    root_claim: B256,
+) -> Option<Address> {
+    let expected_topic = keccak256(DISPUTE_GAME_CREATED_EVENT);
+    let expected_game_type_topic = topic_for_u32(game_type);
+
+    for log in receipt.inner.logs() {
+        if log.inner.address != factory_address {
+            continue;
+        }
+        let topics = log.inner.data.topics();
+        if topics.len() != 4 || topics[0] != expected_topic {
+            continue;
+        }
+        if topics[2] != expected_game_type_topic || topics[3] != root_claim {
+            continue;
+        }
+        if let Some(proxy) = topic_to_address(topics[1]) {
+            return Some(proxy);
+        }
+    }
+    None
 }
 
 const fn is_retryable(e: &ProposerError) -> bool {
@@ -162,14 +214,14 @@ pub const fn is_game_already_exists(e: &ProposerError) -> bool {
 pub trait OutputProposer: Send + Sync {
     /// Creates a new dispute game for the given proposal.
     ///
-    /// Returns the result of the transaction. The caller should query
-    /// factory `gameCount()` afterwards to get the new game's factory index.
+    /// Returns the created dispute game's proxy address from the transaction
+    /// receipt logs.
     async fn propose_output(
         &self,
         proposal: &ProverProposal,
         parent_index: u32,
         intermediate_roots: &[B256],
-    ) -> Result<(), ProposerError>;
+    ) -> Result<Address, ProposerError>;
 }
 
 /// Output proposer that signs transactions locally with a private key.
@@ -224,7 +276,7 @@ impl OutputProposer for LocalOutputProposer {
         proposal: &ProverProposal,
         parent_index: u32,
         intermediate_roots: &[B256],
-    ) -> Result<(), ProposerError> {
+    ) -> Result<Address, ProposerError> {
         let proof_data = build_proof_data(proposal)?;
         let extra_data = encode_extra_data(proposal.to.number, parent_index, intermediate_roots);
         let calldata = encode_create_calldata(
@@ -256,6 +308,8 @@ impl OutputProposer for LocalOutputProposer {
                 self.init_bond,
                 l2_block_number,
                 &self.chain_id,
+                self.game_type,
+                proposal.output.output_root,
                 |tx| async {
                     let envelope = <TransactionRequest as TransactionBuilder<
                         alloy_network::Ethereum,
@@ -336,7 +390,7 @@ impl OutputProposer for RemoteOutputProposer {
         proposal: &ProverProposal,
         parent_index: u32,
         intermediate_roots: &[B256],
-    ) -> Result<(), ProposerError> {
+    ) -> Result<Address, ProposerError> {
         let proof_data = build_proof_data(proposal)?;
         let extra_data = encode_extra_data(proposal.to.number, parent_index, intermediate_roots);
         let calldata = encode_create_calldata(
@@ -366,6 +420,8 @@ impl OutputProposer for RemoteOutputProposer {
                 self.init_bond,
                 l2_block_number,
                 &self.chain_id,
+                self.game_type,
+                proposal.output.output_root,
                 |tx| async move {
                     let mut params = ArrayParams::new();
                     params.insert(&tx).map_err(|e| {

--- a/crates/proof/proposer/src/test_utils.rs
+++ b/crates/proof/proposer/src/test_utils.rs
@@ -136,7 +136,7 @@ impl DisputeGameFactoryClient for MockDisputeGameFactory {
         Ok(self.game_count)
     }
     async fn game_at_index(&self, _: u64) -> Result<GameAtIndex, ContractError> {
-        unimplemented!()
+        Ok(GameAtIndex { game_type: 0, timestamp: 0, proxy: Address::ZERO })
     }
     async fn init_bonds(&self, _: u32) -> Result<U256, ContractError> {
         Ok(U256::ZERO)
@@ -225,7 +225,7 @@ impl OutputProposer for MockOutputProposer {
         _proposal: &ProverProposal,
         _parent_index: u32,
         _intermediate_roots: &[B256],
-    ) -> Result<(), ProposerError> {
-        Ok(())
+    ) -> Result<Address, ProposerError> {
+        Ok(Address::ZERO)
     }
 }


### PR DESCRIPTION
### PR Title
fix(proposer): remove dispute game index race by resolving index from receipt-derived proxy

### Background
After creating a dispute game, the previous logic inferred the new index via `game_count - 1`.  
Under concurrent proposers, this is race-prone and can resolve the wrong index, risking incorrect parent linkage.

### Scope
- `crates/proof/proposer/src/output_proposer.rs`
- `crates/proof/proposer/src/driver/mod.rs`
- `crates/proof/proposer/src/test_utils.rs` (test mock adjustments)

### Key changes
1. **OutputProposer return type update**
   - `propose_output` changed from `Result<(), ProposerError>` to `Result<Address, ProposerError>`
   - Returns the created dispute game proxy address
2. **Receipt event parsing for created game**
   - After tx confirmation, parse `DisputeGameCreated(address,uint32,bytes32)`
   - Event matching validates:
     - emitting address equals factory address
     - `gameType` topic matches
     - `rootClaim` topic matches
   - Extracts `dispute_proxy`; returns error if no matching event is found

3. **Driver resolves index by proxy lookup**
   - Removed `game_count - 1` inference path
   - Added `find_game_index_by_proxy`:
     - uses `pre_create_count` as preferred search window
     - scans via `game_at_index` to find the proxy match
   - If unresolved, falls back to safe recovery (`initialized = false`) instead of writing a potentially wrong parent index

4. **Tests/mocks updated**
   - Updated `OutputProposer` mock signatures
   - Implemented minimal `MockDisputeGameFactory::game_at_index` to avoid `unimplemented!()` panic

### Outcome
- Eliminates the race source in index resolution
- Prevents incorrect index selection under concurrent proposer activity
- Prefers safe recovery over corrupt parent-state advancement

### Validation
- `cargo check -p base-proposer` ✅
- `cargo test -p base-proposer --no-run` ✅
- `cargo test -p base-proposer` ✅ (97 passed, 0 failed)