### PR TITLE
Fix docs wording

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,7 +19,7 @@ To ensure we're all rowing in the same direction and to prevent wasted effort, p
 ### What We Accept from External Contributors
 
 - **Small, focused changes**: One-liner fixes, typo corrections in code, small bug fixes, and similar minimal changes are welcome.
-- **Issues labeled `help wanted`**: Want to contribute code? Look for unassigned issues with this label — these are ones we've specifically identified for external contributions. You can find them [here][help-wanted].
+- **Issues labeled `help wanted`**: Want to contribute code? Look for unassigned issues with this label - these are ones we've specifically identified for external contributions. You can find them [here][help-wanted].
 - **Bug reports**: Well-documented bug reports with reproduction steps are always appreciated.
 
 ### Before Starting Work

--- a/docs/specs/pages/protocol/bridging/deposits.md
+++ b/docs/specs/pages/protocol/bridging/deposits.md
@@ -131,7 +131,7 @@ The deposit transaction is processed exactly like a type-2 (EIP-1559) transactio
 - No fee fields are verified: the deposit does not have any, as it pays for gas on L1.
 - No `nonce` field is verified: the deposit does not have any, it's uniquely identified by its `sourceHash`.
 - No access-list is processed: the deposit has no access-list, and it is thus processed as if the access-list is empty.
-- No check if `from` is an Externally Owner Account (EOA): the deposit is ensured not to be an EOA through L1 address
+- No check if `from` is an Externally Owned Account (EOA): the deposit is ensured not to be an EOA through L1 address
   masking, this may change in future L1 contract-deployments to e.g. enable an account-abstraction like mechanism.
 - No gas is refunded as ETH. (either by not refunding or utilizing the fact the gas-price of the deposit is `0`)
 - No transaction priority fee is charged. No payment is made to the block fee-recipient.

--- a/docs/specs/pages/upgrades/delta/span-batches.md
+++ b/docs/specs/pages/upgrades/delta/span-batches.md
@@ -83,7 +83,7 @@ Where:
   - `origin_bits`: standard bitlist of `block_count` bits:
     1 bit per L2 block, indicating if the L1 origin changed this L2 block.
   - `block_tx_counts`: for each block, a `uvarint` of `len(block.transactions)`.
-  - `txs`: L2 transactions which is reorganized and encoded as below.
+  - `txs`: L2 transactions that are reorganized and encoded as follows.
 - `txs = contract_creation_bits ++ y_parity_bits ++
 tx_sigs ++ tx_tos ++ tx_datas ++ tx_nonces ++ tx_gases ++ protected_bits`
   - `contract_creation_bits`: standard bitlist of `sum(block_tx_counts)` bits:
@@ -95,7 +95,7 @@ tx_sigs ++ tx_tos ++ tx_datas ++ tx_nonces ++ tx_gases ++ protected_bits`
     - `s` is encoded as big-endian `uint256`
   - `tx_tos`: concatenated list of `to` field. `to` field in contract creation transaction will be `nil` and ignored.
   - `tx_datas`: concatenated list of variable length rlp encoded data,
-    matching the encoding of the fields as in the [EIP-2718] format of the `TransactionType`.
+    matching the encoding of the fields in the [EIP-2718] format of the `TransactionType`.
     - `legacy`: `rlp_encode(value, gasPrice, data)`
     - `1`: ([EIP-2930]): `0x01 ++ rlp_encode(value, gasPrice, data, accessList)`
     - `2`: ([EIP-1559]): `0x02 ++ rlp_encode(value, max_priority_fee_per_gas, max_fee_per_gas, data, access_list)`
@@ -167,8 +167,8 @@ The following fields stores truncated data:
 
 ### `tx_data_headers` removal from initial specs
 
-We do not need to store length per each `tx_datas` elements even if those are variable length,
-because the elements itself is RLP encoded, containing their length in RLP prefix.
+We do not need to store the length of each `tx_datas` element, even though they are variable length,
+because each element is RLP encoded and includes its length in the RLP prefix.
 
 ### `Chain ID` removal from initial specs
 

--- a/docs/specs/pages/upgrades/isthmus/derivation.md
+++ b/docs/specs/pages/upgrades/isthmus/derivation.md
@@ -326,13 +326,13 @@ This transaction MUST deploy a contract with the following code hash
 
 # Span Batch Updates
 
-[Span batches](../delta/span-batches.md) are a span of consecutive L2 blocks than are batched submitted.
+[Span batches](../delta/span-batches.md) are a span of consecutive L2 blocks that are submitted in batches.
 
 Span batches contain the L1 transactions and transaction types that are posted containing the span of L2 blocks.
 Since [EIP-7702] introduces a new transaction type, the Span Batch must be updated to support the [EIP-7702]
 transaction.
 
-This corresponds with a new RLP-encoding of the `tx_datas` list as specified in
+This corresponds to a new RLP encoding of the `tx_datas` list as specified in
 [the Delta span batch spec](../delta/span-batches.md), adding a new transaction type:
 
 Transaction type `4` ([EIP-7702] `SetCode`):

--- a/docs/specs/pages/upgrades/isthmus/exec-engine.md
+++ b/docs/specs/pages/upgrades/isthmus/exec-engine.md
@@ -240,7 +240,7 @@ of a transaction now includes the worst-case operator fee.
 
 `operatorFeeScalar` and `operatorFeeConstant` are loaded in a similar way to the `baseFeeScalar` and
 `blobBaseFeeScalar` used in the [`L1Fee`](../../protocol/execution/index.md#ecotone-l1-cost-fee-changes-eip-4844-da).
-calculation. In more detail, these parameters can be accessed in two interchangable ways.
+calculation. In more detail, these parameters can be accessed in two interchangeable ways.
 
 - read from the deposited L1 attributes (`operatorFeeScalar` and `operatorFeeConstant`) of the current L2 block
 - read from the L1 Block Info contract (`0x4200000000000000000000000000000000000015`)

--- a/docs/specs/pages/upgrades/jovian/exec-engine.md
+++ b/docs/specs/pages/upgrades/jovian/exec-engine.md
@@ -112,7 +112,7 @@ As a result, blocks with high DA usage may cause the base fee to increase in sub
 ### Scalar loading
 
 The `daFootprintGasScalar` is loaded in a similar way to the `operatorFeeScalar` and `operatorFeeConstant`
-[included](../isthmus/exec-engine.md#operator-fee) in the Isthmus fork. It can be read in two interchangable ways:
+[included](../isthmus/exec-engine.md#operator-fee) in the Isthmus fork. It can be read in two interchangeable ways:
 
 - read from the deposited L1 attributes (`daFootprintGasScalar`) of the current L2 block
 (decoded according to the [jovian schema](l1-attributes.md))

--- a/docs/specs/pages/upgrades/pectra-blob-schedule/derivation.md
+++ b/docs/specs/pages/upgrades/pectra-blob-schedule/derivation.md
@@ -2,7 +2,7 @@
 
 ## If enabled
 
-If this hardfork is enabled (i.e. if there is a non nil hardfork activation timestamp set), the following rules apply:
+If this hardfork is enabled (i.e. if there is a non-nil hardfork activation timestamp set), the following rules apply:
 
 When setting the [L1 Attributes Deposited Transaction](../../reference/glossary.md#l1-attributes-deposited-transaction),
 the adoption of the Pectra blob base fee update fraction


### PR DESCRIPTION
  This cleans up a small set of high-confidence documentation issues across the contribution guide and specs: an encoding glitch in `CONTRIBUTING.md`, obvious misspellings like `interchangable`, the incorrect term `Externally Owner Account`, and a few grammar-only sentences  that were unnecessarily hard to read.                                                                                                                                                                                                                                                          
  The changes are editorial only and do not change protocol behavior, field names, or identifiers.