### PR TITLE
chore(txpool-tracing): update README with correct directory name

### DIFF
--- a/crates/client/txpool-tracing/README.md
+++ b/crates/client/txpool-tracing/README.md
@@ -1,4 +1,4 @@
-# `base-txpool`
+# `base-txpool-tracing`
 
 <a href="https://github.com/base/base/actions/workflows/ci.yml"><img src="https://github.com/base/base/actions/workflows/ci.yml/badge.svg?label=ci" alt="CI"></a>
 <a href="https://github.com/base/base/blob/main/LICENSE"><img src="https://img.shields.io/badge/License-MIT-d1d1f6.svg?label=license&labelColor=2a2f35" alt="MIT License"></a>


### PR DESCRIPTION
In PR #683, the directory name was changed from `txpool` to `txpool-tracing`:
<img width="489" height="97" alt="image" src="https://github.com/user-attachments/assets/c5708be8-5bf7-4d2b-87e5-accb6b37a898" />
Also, in the `Cargo.toml` file, the name is set to `name = "base-txpool-tracing"`.
**Updated** the title in the README from `base-txpool` to `base-txpool-tracing`.