### PR TITLE
feat: introduce `TxForwardingExtension` for new push-based RPC mempool

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4405,6 +4405,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "base-tx-forwarding"
+version = "0.0.0"
+dependencies = [
+ "base-node-runner",
+ "base-txpool",
+ "tracing",
+ "url",
+]
+
+[[package]]
 name = "base-tx-manager"
 version = "0.0.0"
 dependencies = [
@@ -4419,16 +4429,6 @@ dependencies = [
  "serde",
  "thiserror 2.0.18",
  "tokio",
-]
-
-[[package]]
-name = "base-tx-forwarding"
-version = "0.0.0"
-dependencies = [
- "base-node-runner",
- "base-txpool",
- "tracing",
- "url",
 ]
 
 [[package]]
@@ -5234,9 +5234,9 @@ dependencies = [
 
 [[package]]
 name = "c-kzg"
-version = "2.1.6"
+version = "2.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a0f582957c24870b7bfd12bf562c40b4734b533cafbaf8ded31d6d85f462c01"
+checksum = "6648ed1e4ea8e8a1a4a2c78e1cda29a3fd500bc622899c340d8525ea9a76b24a"
 dependencies = [
  "arbitrary",
  "blst",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4360,6 +4360,7 @@ dependencies = [
  "base-node-core",
  "base-node-runner",
  "base-proofs-extension",
+ "base-tx-forwarding",
  "base-txpool-rpc",
  "base-txpool-tracing",
  "clap",
@@ -4418,6 +4419,16 @@ dependencies = [
  "serde",
  "thiserror 2.0.18",
  "tokio",
+]
+
+[[package]]
+name = "base-tx-forwarding"
+version = "0.0.0"
+dependencies = [
+ "base-node-runner",
+ "base-txpool",
+ "tracing",
+ "url",
 ]
 
 [[package]]
@@ -6411,6 +6422,7 @@ dependencies = [
  "base-node-core",
  "base-node-runner",
  "base-protocol",
+ "base-tx-forwarding",
  "base-txpool",
  "base-txpool-rpc",
  "base-txpool-tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -165,6 +165,7 @@ base-builder-metering = { path = "crates/builder/metering" }
 # Client
 base-client-cli = { path = "crates/client/cli" }
 base-metering = { path = "crates/client/metering" }
+base-tx-forwarding = { path = "crates/client/tx-forwarding" }
 base-proofs-extension = { path = "crates/client/proofs" }
 base-txpool-tracing = { path = "crates/client/txpool-tracing" }
 base-flashblocks-node = { path = "crates/client/flashblocks-node" }

--- a/bin/node/Cargo.toml
+++ b/bin/node/Cargo.toml
@@ -17,12 +17,12 @@ workspace = true
 
 [dependencies]
 # workspace
-base-tx-forwarding.workspace = true
 base-metering.workspace = true
 base-cli-utils.workspace = true
 base-txpool-rpc.workspace = true
 base-flashblocks.workspace = true
 base-node-runner.workspace = true
+base-tx-forwarding.workspace = true
 base-txpool-tracing.workspace = true
 base-flashblocks-node.workspace = true
 base-proofs-extension.workspace = true

--- a/bin/node/Cargo.toml
+++ b/bin/node/Cargo.toml
@@ -17,6 +17,7 @@ workspace = true
 
 [dependencies]
 # workspace
+base-tx-forwarding.workspace = true
 base-metering.workspace = true
 base-cli-utils.workspace = true
 base-txpool-rpc.workspace = true

--- a/bin/node/src/cli.rs
+++ b/bin/node/src/cli.rs
@@ -2,6 +2,7 @@
 
 use base_flashblocks::FlashblocksConfig;
 use base_node_core::args::RollupArgs;
+use base_tx_forwarding::TxForwardingConfig;
 use url::Url;
 
 /// CLI Arguments
@@ -45,6 +46,45 @@ pub struct Args {
     /// Enable metering RPC for transaction bundle simulation
     #[arg(long = "enable-metering", value_name = "ENABLE_METERING")]
     pub enable_metering: bool,
+
+    /// Enable transaction forwarding for mempool nodes to builder RPC endpoints
+    #[arg(long = "enable-tx-forwarding", value_name = "ENABLE_TX_FORWARDING")]
+    pub enable_tx_forwarding: bool,
+
+    /// Builder RPC endpoints for transaction forwarding (one forwarder per URL), used by mempool nodes
+    #[arg(
+        long = "builder-rpc-urls",
+        value_name = "BUILDER_RPC_URLS",
+        requires = "enable-tx-forwarding"
+    )]
+    pub builder_rpc_urls: Vec<Url>,
+
+    /// Resend transactions that haven't been included after this duration in ms (default: 2 blocks)
+    #[arg(
+        long = "tx-forwarding-resend-after-ms",
+        value_name = "TX_FORWARDING_RESEND_AFTER_MS",
+        default_value = "4000",
+        requires = "enable-tx-forwarding"
+    )]
+    pub tx_forwarding_resend_after_ms: u64,
+
+    /// Maximum number of transactions per forwarding batch
+    #[arg(
+        long = "tx-forwarding-batch-size",
+        value_name = "TX_FORWARDING_BATCH_SIZE",
+        default_value = "100",
+        requires = "enable-tx-forwarding"
+    )]
+    pub tx_forwarding_batch_size: usize,
+
+    /// Maximum time to wait before sending an incomplete batch in ms
+    #[arg(
+        long = "tx-forwarding-batch-timeout-ms",
+        value_name = "TX_FORWARDING_BATCH_TIMEOUT_MS",
+        default_value = "50",
+        requires = "enable-tx-forwarding"
+    )]
+    pub tx_forwarding_batch_timeout_ms: u64,
 }
 
 impl From<&Args> for Option<FlashblocksConfig> {
@@ -54,5 +94,17 @@ impl From<&Args> for Option<FlashblocksConfig> {
             config.cached_execution = args.flashblocks_cached_execution;
             config
         })
+    }
+}
+
+impl From<&Args> for TxForwardingConfig {
+    fn from(args: &Args) -> Self {
+        if !args.enable_tx_forwarding || args.builder_rpc_urls.is_empty() {
+            return Self::default();
+        }
+
+        Self::new(args.builder_rpc_urls.clone())
+            .with_resend_after_ms(args.tx_forwarding_resend_after_ms)
+            .with_max_batch_size(args.tx_forwarding_batch_size)
     }
 }

--- a/bin/node/src/cli.rs
+++ b/bin/node/src/cli.rs
@@ -2,7 +2,9 @@
 
 use base_flashblocks::FlashblocksConfig;
 use base_node_core::args::RollupArgs;
-use base_tx_forwarding::TxForwardingConfig;
+use base_tx_forwarding::{
+    DEFAULT_MAX_BATCH_SIZE, DEFAULT_MAX_RPS, DEFAULT_RESEND_AFTER_MS, TxForwardingConfig,
+};
 use url::Url;
 
 /// CLI Arguments
@@ -48,7 +50,11 @@ pub struct Args {
     pub enable_metering: bool,
 
     /// Enable transaction forwarding for mempool nodes to builder RPC endpoints
-    #[arg(long = "enable-tx-forwarding", value_name = "ENABLE_TX_FORWARDING")]
+    #[arg(
+        long = "enable-tx-forwarding",
+        value_name = "ENABLE_TX_FORWARDING",
+        requires = "builder-rpc-urls"
+    )]
     pub enable_tx_forwarding: bool,
 
     /// Builder RPC endpoints for transaction forwarding (one forwarder per URL), used by mempool nodes
@@ -63,7 +69,7 @@ pub struct Args {
     #[arg(
         long = "tx-forwarding-resend-after-ms",
         value_name = "TX_FORWARDING_RESEND_AFTER_MS",
-        default_value = "4000",
+        default_value_t = DEFAULT_RESEND_AFTER_MS,
         requires = "enable-tx-forwarding"
     )]
     pub tx_forwarding_resend_after_ms: u64,
@@ -72,19 +78,19 @@ pub struct Args {
     #[arg(
         long = "tx-forwarding-batch-size",
         value_name = "TX_FORWARDING_BATCH_SIZE",
-        default_value = "100",
+        default_value_t = DEFAULT_MAX_BATCH_SIZE,
         requires = "enable-tx-forwarding"
     )]
     pub tx_forwarding_batch_size: usize,
 
-    /// Maximum time to wait before sending an incomplete batch in ms
+    /// Maximum RPC requests per second per forwarder (0 = unlimited).
     #[arg(
-        long = "tx-forwarding-batch-timeout-ms",
-        value_name = "TX_FORWARDING_BATCH_TIMEOUT_MS",
-        default_value = "50",
+        long = "tx-forwarding-max-rps",
+        value_name = "TX_FORWARDING_MAX_RPS",
+        default_value_t = DEFAULT_MAX_RPS,
         requires = "enable-tx-forwarding"
     )]
-    pub tx_forwarding_batch_timeout_ms: u64,
+    pub tx_forwarding_max_rps: u32,
 }
 
 impl From<&Args> for Option<FlashblocksConfig> {
@@ -106,5 +112,6 @@ impl From<&Args> for TxForwardingConfig {
         Self::new(args.builder_rpc_urls.clone())
             .with_resend_after_ms(args.tx_forwarding_resend_after_ms)
             .with_max_batch_size(args.tx_forwarding_batch_size)
+            .with_max_rps(args.tx_forwarding_max_rps)
     }
 }

--- a/bin/node/src/main.rs
+++ b/bin/node/src/main.rs
@@ -11,6 +11,7 @@ use base_flashblocks_node::FlashblocksExtension;
 use base_metering::{MeteringConfig, MeteringExtension};
 use base_node_runner::BaseNodeRunner;
 use base_proofs_extension::ProofsHistoryExtension;
+use base_tx_forwarding::TxForwardingExtension;
 use base_txpool_rpc::{TxPoolRpcConfig, TxPoolRpcExtension};
 use base_txpool_tracing::{TxPoolExtension, TxpoolConfig};
 
@@ -48,6 +49,7 @@ fn main() {
             MeteringConfig::disabled()
         };
         runner.install_ext::<MeteringExtension>(metering_config);
+        runner.install_ext::<TxForwardingExtension>((&args).into());
         runner.install_ext::<FlashblocksExtension>(flashblocks_config);
         runner.install_ext::<ProofsHistoryExtension>(args.rollup_args);
 

--- a/crates/batcher/comp/Cargo.toml
+++ b/crates/batcher/comp/Cargo.toml
@@ -40,6 +40,7 @@ tracing-subscriber = { workspace = true, features = ["fmt"] }
 default = []
 std = [
 	"alloy-eips/std",
+	"alloy-primitives?/std",
 	"base-alloy-consensus/std",
 	"base-consensus-genesis/std",
 	"base-protocol/std",
@@ -51,9 +52,14 @@ std = [
 ]
 test-utils = [ "base-protocol/test-utils", "dep:alloy-primitives" ]
 serde = [
+	"alloy-primitives?/serde",
 	"base-consensus-genesis/serde",
 	"base-protocol/serde",
 	"miniz_oxide/serde",
 	"rand/serde",
 ]
-arbitrary = [ "base-consensus-genesis/arbitrary", "base-protocol/arbitrary" ]
+arbitrary = [
+	"alloy-primitives?/arbitrary",
+	"base-consensus-genesis/arbitrary",
+	"base-protocol/arbitrary",
+]

--- a/crates/client/tx-forwarding/Cargo.toml
+++ b/crates/client/tx-forwarding/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "base-tx-forwarding"
+description = "Transaction forwarding extension for Base node"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+
+[lints]
+workspace = true
+
+[dependencies]
+# workspace
+base-txpool.workspace = true
+base-node-runner.workspace = true
+
+# misc
+url.workspace = true
+tracing = { workspace = true, features = ["std"] }
+
+[dev-dependencies]
+# workspace
+base-node-runner = { workspace = true, features = ["test-utils"] }

--- a/crates/client/tx-forwarding/README.md
+++ b/crates/client/tx-forwarding/README.md
@@ -1,0 +1,31 @@
+# base-tx-forwarding
+
+Transaction forwarding extension for Base node. Forwards transactions from the mempool to builder RPC endpoints.
+
+## Overview
+
+This crate provides:
+
+- **Transaction Consumer**: Subscribes to pool events and broadcasts transactions to forwarders
+- **Transaction Forwarder**: Batches and forwards transactions to builder RPC endpoints
+- **Resend Logic**: Automatically resends transactions that haven't been included after a configurable window
+
+## CLI Flags
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--enable-tx-forwarding` | bool | false | Enable the forwarding pipeline |
+| `--builder-rpc-urls` | Vec<Url> | Required | Builder RPC endpoints (one forwarder per URL) |
+| `--tx-forwarding-resend-after-ms` | u64 | 4000 | Resend-after window in ms (default: 2 blocks) |
+| `--tx-forwarding-batch-size` | usize | 100 | Forwarder batch size |
+| `--tx-forwarding-batch-timeout-ms` | u64 | 50 | Batch timeout in ms |
+
+## Usage
+
+Enable transaction forwarding on the Base node CLI:
+
+```bash
+cargo run -p node --release -- \
+  --enable-tx-forwarding \
+  --builder-rpc-urls http://builder1:8545,http://builder2:8545 \
+```

--- a/crates/client/tx-forwarding/README.md
+++ b/crates/client/tx-forwarding/README.md
@@ -18,7 +18,7 @@ This crate provides:
 | `--builder-rpc-urls` | Vec<Url> | Required | Builder RPC endpoints (one forwarder per URL) |
 | `--tx-forwarding-resend-after-ms` | u64 | 4000 | Resend-after window in ms (default: 2 blocks) |
 | `--tx-forwarding-batch-size` | usize | 100 | Forwarder batch size |
-| `--tx-forwarding-batch-timeout-ms` | u64 | 50 | Batch timeout in ms |
+| `--tx-forwarding-max-rps` | u32 | 200 | Maximum RPC requests per second per forwarder |
 
 ## Usage
 

--- a/crates/client/tx-forwarding/src/config.rs
+++ b/crates/client/tx-forwarding/src/config.rs
@@ -1,0 +1,80 @@
+//! Transaction forwarding configuration types.
+
+use std::time::Duration;
+
+use base_txpool::{
+    ConsumerConfig as TxpoolConsumerConfig, ForwarderConfig as TxpoolForwarderConfig,
+};
+use url::Url;
+
+/// Full configuration for the transaction forwarding extension.
+#[derive(Debug, Clone)]
+pub struct TxForwardingConfig {
+    /// Whether transaction forwarding is enabled.
+    pub enabled: bool,
+    /// Builder RPC endpoints to forward transactions to.
+    pub builder_urls: Vec<Url>,
+    /// Resend transactions that haven't been included after this duration in milliseconds.
+    pub resend_after_ms: u64,
+    /// Maximum number of transactions per batch (0 = unlimited).
+    pub max_batch_size: usize,
+    /// Maximum RPC requests per second per forwarder (0 = unlimited).
+    pub max_rps: u32,
+}
+
+impl Default for TxForwardingConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            builder_urls: Vec::new(),
+            // Default: 2 blocks (~4 seconds on Base)
+            resend_after_ms: 4000,
+            max_batch_size: 500,
+            max_rps: 200,
+        }
+    }
+}
+
+impl TxForwardingConfig {
+    /// Creates a disabled configuration.
+    pub fn disabled() -> Self {
+        Self::default()
+    }
+
+    /// Creates a new configuration with forwarding enabled.
+    pub fn new(builder_urls: Vec<Url>) -> Self {
+        Self { enabled: true, builder_urls, ..Default::default() }
+    }
+
+    /// Sets the resend-after window in milliseconds.
+    pub const fn with_resend_after_ms(mut self, ms: u64) -> Self {
+        self.resend_after_ms = ms;
+        self
+    }
+
+    /// Sets the maximum batch size per RPC request.
+    pub const fn with_max_batch_size(mut self, size: usize) -> Self {
+        self.max_batch_size = size;
+        self
+    }
+
+    /// Sets the maximum RPC requests per second.
+    pub const fn with_max_rps(mut self, rps: u32) -> Self {
+        self.max_rps = rps;
+        self
+    }
+
+    /// Converts to the consumer config used by `base-txpool`.
+    pub fn to_consumer_config(&self) -> TxpoolConsumerConfig {
+        TxpoolConsumerConfig::default()
+            .with_resend_after(Duration::from_millis(self.resend_after_ms))
+    }
+
+    /// Converts to the forwarder config used by `base-txpool`.
+    pub fn to_forwarder_config(&self) -> TxpoolForwarderConfig {
+        TxpoolForwarderConfig::default()
+            .with_builder_urls(self.builder_urls.clone())
+            .with_max_batch_size(self.max_batch_size)
+            .with_max_rps(self.max_rps)
+    }
+}

--- a/crates/client/tx-forwarding/src/config.rs
+++ b/crates/client/tx-forwarding/src/config.rs
@@ -1,4 +1,4 @@
-//! Transaction forwarding configuration types.
+//! Configuration for the transaction forwarding extension.
 
 use std::time::Duration;
 
@@ -6,6 +6,13 @@ use base_txpool::{
     ConsumerConfig as TxpoolConsumerConfig, ForwarderConfig as TxpoolForwarderConfig,
 };
 use url::Url;
+
+/// Default resend-after window in milliseconds (~2 blocks on Base).
+pub const DEFAULT_RESEND_AFTER_MS: u64 = 4000;
+/// Default maximum number of transactions per RPC batch.
+pub const DEFAULT_MAX_BATCH_SIZE: usize = 100;
+/// Default maximum RPC requests per second per forwarder.
+pub const DEFAULT_MAX_RPS: u32 = 200;
 
 /// Full configuration for the transaction forwarding extension.
 #[derive(Debug, Clone)]
@@ -28,9 +35,9 @@ impl Default for TxForwardingConfig {
             enabled: false,
             builder_urls: Vec::new(),
             // Default: 2 blocks (~4 seconds on Base)
-            resend_after_ms: 4000,
-            max_batch_size: 500,
-            max_rps: 200,
+            resend_after_ms: DEFAULT_RESEND_AFTER_MS,
+            max_batch_size: DEFAULT_MAX_BATCH_SIZE,
+            max_rps: DEFAULT_MAX_RPS,
         }
     }
 }

--- a/crates/client/tx-forwarding/src/extension.rs
+++ b/crates/client/tx-forwarding/src/extension.rs
@@ -2,7 +2,7 @@
 //! forwarding pipeline on the Base node builder.
 
 use base_node_runner::{BaseNodeExtension, FromExtensionConfig, NodeHooks};
-use base_txpool::{ConsumerHandle, ForwarderHandle};
+use base_txpool::{SpawnedConsumer, SpawnedForwarder};
 use tracing::info;
 
 use crate::TxForwardingConfig;
@@ -30,7 +30,7 @@ impl BaseNodeExtension for TxForwardingExtension {
 
         let config = self.config;
 
-        hooks.add_rpc_module(move |ctx| {
+        hooks.add_node_started_hook(move |ctx| {
             info!(
                 builder_urls = ?config.builder_urls,
                 resend_after_ms = config.resend_after_ms,
@@ -40,16 +40,20 @@ impl BaseNodeExtension for TxForwardingExtension {
             );
 
             let pool = ctx.pool().clone();
-
-            // Spawn the consumer on a dedicated OS thread. It continuously reads
-            // from best_transactions(), deduplicates, and broadcasts to subscribers.
             let consumer_config = config.to_consumer_config();
-            let consumer_handle = ConsumerHandle::spawn(pool, consumer_config);
-
-            // This forwarder handle will spawn one forwarder async task per builder URL. Each subscribes to
-            // the consumer's broadcast channel and forwards transactions via RPC.
             let forwarder_config = config.to_forwarder_config();
-            let _ = ForwarderHandle::spawn(&consumer_handle.sender, forwarder_config);
+
+            let executor = ctx.task_executor;
+            let consumer = SpawnedConsumer::spawn(pool, consumer_config, &executor);
+            let forwarder = SpawnedForwarder::spawn(&consumer.sender, forwarder_config, &executor);
+
+            executor.spawn_with_graceful_shutdown_signal(|signal| {
+                Box::pin(async move {
+                    let _guard = signal.await;
+                    forwarder.shutdown().await;
+                    consumer.shutdown();
+                })
+            });
 
             Ok(())
         })

--- a/crates/client/tx-forwarding/src/extension.rs
+++ b/crates/client/tx-forwarding/src/extension.rs
@@ -49,15 +49,7 @@ impl BaseNodeExtension for TxForwardingExtension {
             // This forwarder handle will spawn one forwarder async task per builder URL. Each subscribes to
             // the consumer's broadcast channel and forwards transactions via RPC.
             let forwarder_config = config.to_forwarder_config();
-            let forwarder_handle =
-                ForwarderHandle::spawn(&consumer_handle.sender, forwarder_config);
-
-            // Detach handles so the consumer and forwarder tasks run for the
-            // process lifetime. Both handles cancel their tasks on Drop, but this
-            // closure's scope is too short — detach() prevents Drop from firing
-            // while keeping the Drop impl available for callers who want clean shutdown.
-            consumer_handle.detach();
-            forwarder_handle.detach();
+            let _ = ForwarderHandle::spawn(&consumer_handle.sender, forwarder_config);
 
             Ok(())
         })

--- a/crates/client/tx-forwarding/src/extension.rs
+++ b/crates/client/tx-forwarding/src/extension.rs
@@ -11,7 +11,7 @@ use crate::TxForwardingConfig;
 #[derive(Debug)]
 pub struct TxForwardingExtension {
     /// Transaction forwarding configuration.
-    config: TxForwardingConfig,
+    pub config: TxForwardingConfig,
 }
 
 impl TxForwardingExtension {
@@ -52,14 +52,12 @@ impl BaseNodeExtension for TxForwardingExtension {
             let forwarder_handle =
                 ForwarderHandle::spawn(&consumer_handle.sender, forwarder_config);
 
-            // Store handles in the RPC context to keep them alive for the node's
-            // lifetime. The handles will gracefully shut down when dropped.
-            //
-            // We use Box::leak here because the handles need to live for the
-            // entire duration of the node. This is intentional — the node process
-            // will clean up on exit.
-            Box::leak(Box::new(consumer_handle));
-            Box::leak(Box::new(forwarder_handle));
+            // Detach handles so the consumer and forwarder tasks run for the
+            // process lifetime. Both handles cancel their tasks on Drop, but this
+            // closure's scope is too short — detach() prevents Drop from firing
+            // while keeping the Drop impl available for callers who want clean shutdown.
+            consumer_handle.detach();
+            forwarder_handle.detach();
 
             Ok(())
         })

--- a/crates/client/tx-forwarding/src/extension.rs
+++ b/crates/client/tx-forwarding/src/extension.rs
@@ -1,0 +1,75 @@
+//! Contains the [`TxForwardingExtension`] which wires up the transaction
+//! forwarding pipeline on the Base node builder.
+
+use base_node_runner::{BaseNodeExtension, FromExtensionConfig, NodeHooks};
+use base_txpool::{ConsumerHandle, ForwarderHandle};
+use tracing::info;
+
+use crate::TxForwardingConfig;
+
+/// Helper struct that wires the transaction forwarding pipeline into the node builder.
+#[derive(Debug)]
+pub struct TxForwardingExtension {
+    /// Transaction forwarding configuration.
+    config: TxForwardingConfig,
+}
+
+impl TxForwardingExtension {
+    /// Creates a new transaction forwarding extension.
+    pub const fn new(config: TxForwardingConfig) -> Self {
+        Self { config }
+    }
+}
+
+impl BaseNodeExtension for TxForwardingExtension {
+    /// Applies the extension to the supplied hooks.
+    fn apply(self: Box<Self>, hooks: NodeHooks) -> NodeHooks {
+        if !self.config.enabled || self.config.builder_urls.is_empty() {
+            return hooks;
+        }
+
+        let config = self.config;
+
+        hooks.add_rpc_module(move |ctx| {
+            info!(
+                builder_urls = ?config.builder_urls,
+                resend_after_ms = config.resend_after_ms,
+                max_batch_size = config.max_batch_size,
+                max_rps = config.max_rps,
+                "starting transaction forwarding pipeline"
+            );
+
+            let pool = ctx.pool().clone();
+
+            // Spawn the consumer on a dedicated OS thread. It continuously reads
+            // from best_transactions(), deduplicates, and broadcasts to subscribers.
+            let consumer_config = config.to_consumer_config();
+            let consumer_handle = ConsumerHandle::spawn(pool, consumer_config);
+
+            // This forwarder handle will spawn one forwarder async task per builder URL. Each subscribes to
+            // the consumer's broadcast channel and forwards transactions via RPC.
+            let forwarder_config = config.to_forwarder_config();
+            let forwarder_handle =
+                ForwarderHandle::spawn(&consumer_handle.sender, forwarder_config);
+
+            // Store handles in the RPC context to keep them alive for the node's
+            // lifetime. The handles will gracefully shut down when dropped.
+            //
+            // We use Box::leak here because the handles need to live for the
+            // entire duration of the node. This is intentional — the node process
+            // will clean up on exit.
+            Box::leak(Box::new(consumer_handle));
+            Box::leak(Box::new(forwarder_handle));
+
+            Ok(())
+        })
+    }
+}
+
+impl FromExtensionConfig for TxForwardingExtension {
+    type Config = TxForwardingConfig;
+
+    fn from_config(config: Self::Config) -> Self {
+        Self::new(config)
+    }
+}

--- a/crates/client/tx-forwarding/src/extension.rs
+++ b/crates/client/tx-forwarding/src/extension.rs
@@ -50,8 +50,8 @@ impl BaseNodeExtension for TxForwardingExtension {
             executor.spawn_with_graceful_shutdown_signal(|signal| {
                 Box::pin(async move {
                     let _guard = signal.await;
-                    forwarder.shutdown().await;
                     consumer.shutdown();
+                    forwarder.shutdown().await;
                 })
             });
 

--- a/crates/client/tx-forwarding/src/lib.rs
+++ b/crates/client/tx-forwarding/src/lib.rs
@@ -4,7 +4,9 @@
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
 
 mod config;
-pub use config::TxForwardingConfig;
+pub use config::{
+    DEFAULT_MAX_BATCH_SIZE, DEFAULT_MAX_RPS, DEFAULT_RESEND_AFTER_MS, TxForwardingConfig,
+};
 
 mod extension;
 pub use extension::TxForwardingExtension;

--- a/crates/client/tx-forwarding/src/lib.rs
+++ b/crates/client/tx-forwarding/src/lib.rs
@@ -1,0 +1,10 @@
+#![doc = include_str!("../README.md")]
+#![doc(issue_tracker_base_url = "https://github.com/base/base/issues/")]
+#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
+#![cfg_attr(not(test), warn(unused_crate_dependencies))]
+
+mod config;
+pub use config::TxForwardingConfig;
+
+mod extension;
+pub use extension::TxForwardingExtension;

--- a/crates/txpool/Cargo.toml
+++ b/crates/txpool/Cargo.toml
@@ -36,10 +36,10 @@ base-alloy-consensus.workspace = true
 base-execution-primitives.workspace = true
 
 # misc
+futures.workspace = true
 url.workspace = true
 serde.workspace = true
 c-kzg.workspace = true
-futures.workspace = true
 metrics.workspace = true
 tracing.workspace = true
 tokio-util.workspace = true

--- a/crates/txpool/PROPAGATION_PIPELINE.md
+++ b/crates/txpool/PROPAGATION_PIPELINE.md
@@ -150,10 +150,10 @@ Wires consumer + forwarder into the node using the `BaseNodeExtension` pattern.
 | Flag | Type | Default | Description |
 |------|------|---------|-------------|
 | `--enable-tx-forwarding` | bool | false | Enable the forwarding pipeline |
-| `--builder-rpc-urls` | Vec\<String\> | Required | Builder RPC endpoints (one forwarder per URL) |
+| `--builder-rpc-urls` | Vec<Url> | Required | Builder RPC endpoints (one forwarder per URL) |
 | `--tx-forwarding-resend-after-ms` | u64 | 4000 | Resend-after window in ms (default: 2 blocks) |
 | `--tx-forwarding-batch-size` | usize | 100 | Forwarder batch size |
-| `--tx-forwarding-batch-timeout-ms` | u64 | 50 | Batch timeout in ms |
+| `--tx-forwarding-max-rps` | u32 | 200 | Maximum RPC requests per second per forwarder |
 
 ### Extension Pattern
 

--- a/crates/txpool/src/consumer/mod.rs
+++ b/crates/txpool/src/consumer/mod.rs
@@ -49,15 +49,6 @@ impl<T: PoolTransaction> ConsumerHandle<T> {
 
         Self { sender, cancel, handle: Some(handle) }
     }
-
-    /// Detaches the consumer, allowing it to run for the process lifetime.
-    ///
-    /// The background thread will continue running without a way to cancel it.
-    /// This is useful when the consumer should live as long as the process.
-    pub const fn detach(self) {
-        // Prevent Drop from cancelling the background thread.
-        std::mem::forget(self);
-    }
 }
 
 impl<T: PoolTransaction> Drop for ConsumerHandle<T> {

--- a/crates/txpool/src/consumer/mod.rs
+++ b/crates/txpool/src/consumer/mod.rs
@@ -1,7 +1,7 @@
-use std::{sync::Arc, thread};
+use std::sync::Arc;
 
-use reth_tasks::spawn_os_thread;
-use reth_transaction_pool::{PoolTransaction, TransactionPool, ValidPoolTransaction};
+use reth_tasks::TaskExecutor;
+use reth_transaction_pool::{TransactionPool, ValidPoolTransaction};
 use tokio::sync::broadcast;
 use tokio_util::sync::CancellationToken;
 
@@ -17,52 +17,47 @@ pub use validator::RecentlySent;
 mod task;
 pub use task::Consumer;
 
-/// Handle returned by [`ConsumerHandle::spawn`].
+/// Result of spawning a [`Consumer`] via the reth task executor.
 ///
 /// Holds the broadcast sender so that downstream forwarders (one per builder)
 /// can each call [`.subscribe()`](broadcast::Sender::subscribe) to receive
-/// every deduplicated transaction independently. Cancels the background
-/// consumer on drop.
-pub struct ConsumerHandle<T: PoolTransaction> {
+/// every deduplicated transaction independently.
+pub struct SpawnedConsumer<P: TransactionPool> {
     /// Broadcast sender — call `.subscribe()` to create a new receiver.
-    pub sender: broadcast::Sender<Arc<ValidPoolTransaction<T>>>,
-    cancel: CancellationToken,
-    handle: Option<thread::JoinHandle<()>>,
+    pub sender: broadcast::Sender<Arc<ValidPoolTransaction<P::Transaction>>>,
+    /// Cancellation token — cancel this to stop the consumer loop.
+    pub cancel: CancellationToken,
 }
 
-impl<T: PoolTransaction> ConsumerHandle<T> {
-    /// Spawns the consumer on a dedicated OS thread and returns a handle for
-    /// subscribing forwarders.
-    pub fn spawn<P>(pool: P, config: ConsumerConfig) -> Self
-    where
-        P: TransactionPool<Transaction = T> + Send + 'static,
-    {
+impl<P> SpawnedConsumer<P>
+where
+    P: TransactionPool + Send + 'static,
+{
+    /// Creates and spawns a [`Consumer`] as a blocking task on the executor.
+    pub fn spawn(pool: P, config: ConsumerConfig, executor: &TaskExecutor) -> Self {
         let (sender, _) = broadcast::channel(config.channel_capacity);
         let broadcast_sender = sender.clone();
         let metrics = ConsumerMetrics::default();
         let cancel = CancellationToken::new();
-        let consumer = Consumer::new(pool, config, broadcast_sender, metrics, cancel.child_token());
+        let mut consumer =
+            Consumer::new(pool, config, broadcast_sender, metrics, cancel.child_token());
 
-        let handle = spawn_os_thread("txpool-consumer", move || {
+        executor.spawn_blocking_task(Box::pin(async move {
             consumer.run();
-        });
+        }));
 
-        Self { sender, cancel, handle: Some(handle) }
+        Self { sender, cancel }
     }
-}
 
-impl<T: PoolTransaction> Drop for ConsumerHandle<T> {
-    fn drop(&mut self) {
+    /// Cancels the consumer loop.
+    pub fn shutdown(&self) {
         self.cancel.cancel();
-        if let Some(handle) = self.handle.take() {
-            let _ = handle.join();
-        }
     }
 }
 
-impl<T: PoolTransaction> std::fmt::Debug for ConsumerHandle<T> {
+impl<P: TransactionPool> std::fmt::Debug for SpawnedConsumer<P> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("ConsumerHandle")
+        f.debug_struct("SpawnedConsumer")
             .field("cancelled", &self.cancel.is_cancelled())
             .finish_non_exhaustive()
     }

--- a/crates/txpool/src/consumer/mod.rs
+++ b/crates/txpool/src/consumer/mod.rs
@@ -50,6 +50,8 @@ where
     }
 
     /// Cancels the consumer loop.
+    /// The consumer is checking for cancellation extremely often, so we don't need to have
+    /// a "long" timeout for it as it will shutdown within a few milliseconds anyway
     pub fn shutdown(&self) {
         self.cancel.cancel();
     }

--- a/crates/txpool/src/consumer/mod.rs
+++ b/crates/txpool/src/consumer/mod.rs
@@ -49,6 +49,15 @@ impl<T: PoolTransaction> ConsumerHandle<T> {
 
         Self { sender, cancel, handle: Some(handle) }
     }
+
+    /// Detaches the consumer, allowing it to run for the process lifetime.
+    ///
+    /// The background thread will continue running without a way to cancel it.
+    /// This is useful when the consumer should live as long as the process.
+    pub const fn detach(self) {
+        // Prevent Drop from cancelling the background thread.
+        std::mem::forget(self);
+    }
 }
 
 impl<T: PoolTransaction> Drop for ConsumerHandle<T> {

--- a/crates/txpool/src/consumer/task.rs
+++ b/crates/txpool/src/consumer/task.rs
@@ -9,7 +9,6 @@ use super::{config::ConsumerConfig, metrics::ConsumerMetrics, validator::Recentl
 
 /// Background consumer that drains the pool and broadcasts transactions.
 ///
-/// Runs on a dedicated OS thread via [`std::thread::Builder`].
 /// Each iteration creates a fresh `best_transactions()` snapshot, skips
 /// recently-sent hashes, and broadcasts new transactions. Downstream
 /// forwarders (one per builder) each subscribe to receive every transaction.
@@ -40,7 +39,7 @@ where
     }
 
     /// Blocking loop — runs until the [`CancellationToken`] is cancelled.
-    pub fn run(mut self) {
+    pub fn run(&mut self) {
         info!(
             resend_after_ms = self.config.resend_after.as_millis() as u64,
             channel_capacity = self.config.channel_capacity,

--- a/crates/txpool/src/forwarder/mod.rs
+++ b/crates/txpool/src/forwarder/mod.rs
@@ -99,6 +99,15 @@ impl ForwarderHandle {
             warn!("forwarder tasks did not finish within shutdown timeout");
         }
     }
+
+    /// Detaches the forwarder tasks, allowing them to run for the process lifetime.
+    ///
+    /// The spawned tasks will continue running without a way to cancel them.
+    /// This is useful when the forwarders should live as long as the process.
+    pub const fn detach(self) {
+        // Prevent Drop from cancelling the forwarder tasks.
+        std::mem::forget(self);
+    }
 }
 
 impl Drop for ForwarderHandle {

--- a/crates/txpool/src/forwarder/mod.rs
+++ b/crates/txpool/src/forwarder/mod.rs
@@ -99,15 +99,6 @@ impl ForwarderHandle {
             warn!("forwarder tasks did not finish within shutdown timeout");
         }
     }
-
-    /// Detaches the forwarder tasks, allowing them to run for the process lifetime.
-    ///
-    /// The spawned tasks will continue running without a way to cancel them.
-    /// This is useful when the forwarders should live as long as the process.
-    pub const fn detach(self) {
-        // Prevent Drop from cancelling the forwarder tasks.
-        std::mem::forget(self);
-    }
 }
 
 impl Drop for ForwarderHandle {

--- a/crates/txpool/src/forwarder/mod.rs
+++ b/crates/txpool/src/forwarder/mod.rs
@@ -1,6 +1,7 @@
 use std::{sync::Arc, time::Duration};
 
 use jsonrpsee::http_client::HttpClientBuilder;
+use reth_tasks::TaskExecutor;
 use reth_transaction_pool::{PoolTransaction, ValidPoolTransaction};
 use tokio::sync::broadcast;
 use tokio_util::sync::CancellationToken;
@@ -15,22 +16,24 @@ pub use metrics::ForwarderMetrics;
 mod task;
 pub use task::Forwarder;
 
-/// Handle for the set of forwarder tasks (one per builder URL).
+/// Set of spawned forwarder tasks (one per builder URL).
 ///
-/// Cancels all forwarder tasks on drop. For a clean shutdown that waits for
-/// in-flight RPC requests to complete, use [`ForwarderHandle::shutdown`].
-#[must_use = "dropping the handle cancels all forwarder tasks without draining buffers — call shutdown() for graceful termination"]
-pub struct ForwarderHandle {
-    cancel: CancellationToken,
+/// Exposes the [`CancellationToken`] and task join handles so callers can
+/// wire up graceful shutdown (e.g. via reth's
+/// `spawn_with_graceful_shutdown_signal`).
+pub struct SpawnedForwarder {
+    /// Cancellation token — cancel this to stop all forwarder loops.
+    pub cancel: CancellationToken,
     tasks: Vec<tokio::task::JoinHandle<()>>,
 }
 
-impl ForwarderHandle {
+impl SpawnedForwarder {
     /// Spawns one forwarder async task per builder URL, each subscribing to
     /// the given broadcast sender.
     pub fn spawn<T>(
         sender: &broadcast::Sender<Arc<ValidPoolTransaction<T>>>,
         config: ForwarderConfig,
+        executor: &TaskExecutor,
     ) -> Self
     where
         T: PoolTransaction + 'static,
@@ -67,32 +70,23 @@ impl ForwarderHandle {
                 cancel.child_token(),
             );
 
-            let handle = tokio::spawn(async move {
+            let handle = executor.spawn_task(Box::pin(async move {
                 forwarder.run().await;
-            });
+            }));
 
             info!(builder_url = %url, "spawned transaction forwarder");
             tasks.push(handle);
         }
 
-        if tasks.is_empty() {
-            warn!("no forwarder tasks spawned — check builder_urls config");
-        }
-
         Self { cancel, tasks }
     }
-}
 
-impl ForwarderHandle {
-    /// Gracefully shuts down all forwarder tasks.
-    ///
-    /// Signals cancellation and waits up to 30 seconds for each forwarder to
+    /// Cancels all forwarder tasks and waits up to 30 seconds for each to
     /// drain its buffer and complete in-flight RPC requests.
-    pub async fn shutdown(mut self) {
+    pub async fn shutdown(self) {
         self.cancel.cancel();
 
-        let tasks = std::mem::take(&mut self.tasks);
-        if tokio::time::timeout(Duration::from_secs(30), futures::future::join_all(tasks))
+        if tokio::time::timeout(Duration::from_secs(30), futures::future::join_all(self.tasks))
             .await
             .is_err()
         {
@@ -101,15 +95,9 @@ impl ForwarderHandle {
     }
 }
 
-impl Drop for ForwarderHandle {
-    fn drop(&mut self) {
-        self.cancel.cancel();
-    }
-}
-
-impl std::fmt::Debug for ForwarderHandle {
+impl std::fmt::Debug for SpawnedForwarder {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("ForwarderHandle")
+        f.debug_struct("SpawnedForwarder")
             .field("tasks", &self.tasks.len())
             .field("cancelled", &self.cancel.is_cancelled())
             .finish()

--- a/crates/txpool/src/lib.rs
+++ b/crates/txpool/src/lib.rs
@@ -17,10 +17,10 @@ mod ordering;
 pub use ordering::{BaseOrdering, TimestampOrdering};
 
 mod consumer;
-pub use consumer::{Consumer, ConsumerConfig, ConsumerHandle, ConsumerMetrics, RecentlySent};
+pub use consumer::{Consumer, ConsumerConfig, ConsumerMetrics, RecentlySent, SpawnedConsumer};
 
 mod forwarder;
-pub use forwarder::{Forwarder, ForwarderConfig, ForwarderHandle, ForwarderMetrics};
+pub use forwarder::{Forwarder, ForwarderConfig, ForwarderMetrics, SpawnedForwarder};
 
 mod builder;
 pub use builder::{BuilderApiImpl, BuilderApiMetrics, BuilderApiServer};

--- a/devnet/Cargo.toml
+++ b/devnet/Cargo.toml
@@ -21,6 +21,7 @@ base-consensus-rpc = { workspace = true, features = ["client"] }
 base-protocol = { workspace = true, features = ["serde", "std"] }
 base-node-runner = { workspace = true, features = ["test-utils"] }
 base-builder-core = { workspace = true, features = ["test-utils"] }
+base-tx-forwarding.workspace = true
 
 # consensus
 base-consensus-disc.workspace = true

--- a/devnet/Cargo.toml
+++ b/devnet/Cargo.toml
@@ -15,13 +15,13 @@ workspace = true
 # workspace
 base-txpool-rpc.workspace = true
 base-flashblocks.workspace = true
+base-tx-forwarding.workspace = true
 base-txpool-tracing.workspace = true
 base-flashblocks-node.workspace = true
 base-consensus-rpc = { workspace = true, features = ["client"] }
 base-protocol = { workspace = true, features = ["serde", "std"] }
 base-node-runner = { workspace = true, features = ["test-utils"] }
 base-builder-core = { workspace = true, features = ["test-utils"] }
-base-tx-forwarding.workspace = true
 
 # consensus
 base-consensus-disc.workspace = true

--- a/devnet/src/l2/in_process_builder.rs
+++ b/devnet/src/l2/in_process_builder.rs
@@ -13,13 +13,12 @@ use base_builder_core::{BuilderConfig, FlashblocksServiceBuilder, test_utils::ge
 use base_execution_chainspec::OpChainSpec;
 use base_node_core::{args::RollupArgs, node::OpPoolBuilder};
 use base_node_runner::BaseNode;
-use base_txpool::BasePooledTransaction;
+use base_txpool::{BasePooledTransaction, BuilderApiImpl, BuilderApiServer};
 use eyre::{Result, WrapErr, eyre};
 use nanoid::nanoid;
 use reth_db::{
     ClientVersion, DatabaseEnv, init_db,
     mdbx::{DatabaseArguments, KILOBYTE, MEGABYTE, MaxReadTransactionDuration},
-    test_utils::TempDatabase,
 };
 use reth_node_builder::{NodeBuilder, NodeConfig, NodeHandle};
 use reth_node_core::{
@@ -134,7 +133,7 @@ impl InProcessBuilder {
             .with_gas_limit_config(gas_limit_config)
             .build();
 
-        let (db, db_path) = create_test_db(&data_path)?;
+        let (db, _db_path) = create_test_db(&data_path)?;
 
         let node_config = create_node_config(chain_spec, &data_path, &jwt_path, &config)?;
         let p2p_port = node_config.network.port;
@@ -150,7 +149,13 @@ impl InProcessBuilder {
                     .payload(FlashblocksServiceBuilder(builder_config)),
             )
             .with_add_ons(addons)
-            .on_component_initialized(move |_ctx| Ok(()));
+            .on_component_initialized(move |_ctx| Ok(()))
+            // Register the builder API RPC module (base_insertValidatedTransaction)
+            .extend_rpc_modules(|ctx| {
+                let api = BuilderApiImpl::new(ctx.pool().clone());
+                ctx.modules.merge_configured(api.into_rpc())?;
+                Ok(())
+            });
 
         let NodeHandle { node: node_handle, node_exit_future } =
             node_builder.launch().await.wrap_err("Failed to launch builder node")?;
@@ -166,9 +171,6 @@ impl InProcessBuilder {
             .ok_or_else(|| eyre!("WebSocket RPC server failed to bind to address"))?;
 
         let engine_addr = node_handle.auth_server_handle().local_addr();
-
-        // Delete db_path since we use data_path as the main cleanup path
-        drop(db_path);
 
         Ok(Self {
             http_api_addr,
@@ -337,9 +339,7 @@ fn create_node_config(
     Ok(node_config)
 }
 
-fn create_test_db(
-    data_path: &std::path::Path,
-) -> Result<(Arc<TempDatabase<DatabaseEnv>>, PathBuf)> {
+fn create_test_db(data_path: &std::path::Path) -> Result<(DatabaseEnv, PathBuf)> {
     let db_path = data_path.join("db");
     std::fs::create_dir_all(&db_path).wrap_err("Failed to create db directory")?;
 
@@ -352,7 +352,7 @@ fn create_test_db(
     )
     .wrap_err("Failed to initialize database")?;
 
-    Ok((Arc::new(TempDatabase::new(db, db_path.clone())), db_path))
+    Ok((db, db_path))
 }
 
 fn pool_component(_rollup_args: &RollupArgs) -> OpPoolBuilder<BasePooledTransaction> {

--- a/devnet/src/l2/in_process_client.rs
+++ b/devnet/src/l2/in_process_client.rs
@@ -11,6 +11,7 @@ use base_flashblocks::FlashblocksConfig;
 use base_flashblocks_node::FlashblocksExtension;
 use base_node_core::args::RollupArgs;
 use base_node_runner::{BaseNode, BaseNodeExtension, FromExtensionConfig, NodeHooks};
+use base_tx_forwarding::{TxForwardingConfig, TxForwardingExtension};
 use base_txpool_rpc::{TxPoolRpcConfig, TxPoolRpcExtension};
 use base_txpool_tracing::{TxPoolExtension, TxpoolConfig};
 use eyre::{Context, Result, eyre};
@@ -48,6 +49,9 @@ pub struct InProcessClientConfig {
     pub auth_port: Option<u16>,
     /// Optional fixed P2P port (uses random if None).
     pub p2p_port: Option<u16>,
+    /// Optional transaction forwarding configuration.
+    /// When set, the client will forward transactions to builder RPC endpoints.
+    pub tx_forwarding_config: Option<TxForwardingConfig>,
 }
 
 /// In-process Base client node that syncs from a builder.
@@ -259,6 +263,11 @@ impl InProcessClient {
             flashblocks_config: Some(flashblocks_config.clone()),
         };
         extensions.push(Box::new(TxPoolExtension::new(txpool_config)));
+
+        // TxForwarding extension (optional - forwards txs to builder RPC)
+        if let Some(ref tx_fwd_config) = config.tx_forwarding_config {
+            extensions.push(Box::new(TxForwardingExtension::from_config(tx_fwd_config.clone())));
+        }
 
         // Flashblocks extension (must be last - uses replace_configured)
         extensions.push(Box::new(FlashblocksExtension::new(Some(flashblocks_config))));

--- a/devnet/src/l2/stack.rs
+++ b/devnet/src/l2/stack.rs
@@ -10,6 +10,7 @@ use alloy_primitives::B256;
 use alloy_rpc_types_engine::JwtSecret;
 use base_consensus_genesis::{L1ChainConfig, RollupConfig};
 use base_consensus_node::NodeMode;
+use base_tx_forwarding::TxForwardingConfig;
 use eyre::{Result, WrapErr};
 use url::Url;
 
@@ -42,6 +43,9 @@ pub struct L2StackConfig {
     pub l1_beacon_url: String,
     /// Optional container configuration for stable naming and port binding.
     pub container_config: Option<L2ContainerConfig>,
+    /// Optional transaction forwarding configuration for the client node.
+    /// When set, the client will forward transactions to builder RPC endpoints.
+    pub tx_forwarding_config: Option<TxForwardingConfig>,
 }
 
 /// A complete L2 network stack composed of Builder + Consensus + Batcher.
@@ -154,6 +158,17 @@ impl L2Stack {
             .wrap_err("Failed to start batcher")?;
 
         // 4. Start the client (in-process EL).
+        // If tx forwarding is enabled, configure it with the builder's RPC URL
+        let tx_forwarding_config = config.tx_forwarding_config.map(|mut cfg| {
+            // Add the builder's RPC URL to the forwarding config
+            // The config may have empty builder_urls which we need to populate
+            if cfg.builder_urls.is_empty() {
+                cfg.builder_urls =
+                    vec![builder.rpc_url().expect("builder RPC URL should be available")];
+            }
+            cfg
+        });
+
         let client_config = InProcessClientConfig {
             genesis_json: config.l2_genesis.clone(),
             jwt_secret: config.jwt_secret,
@@ -164,6 +179,7 @@ impl L2Stack {
             ws_port: container_config.and_then(|c| c.client_ws_port),
             auth_port: container_config.and_then(|c| c.client_auth_port),
             p2p_port: container_config.and_then(|c| c.client_p2p_port),
+            tx_forwarding_config,
         };
         let client = InProcessClient::start(client_config)
             .await

--- a/devnet/src/l2/stack.rs
+++ b/devnet/src/l2/stack.rs
@@ -159,15 +159,16 @@ impl L2Stack {
 
         // 4. Start the client (in-process EL).
         // If tx forwarding is enabled, configure it with the builder's RPC URL
-        let tx_forwarding_config = config.tx_forwarding_config.map(|mut cfg| {
+        let tx_forwarding_config = if let Some(mut cfg) = config.tx_forwarding_config {
             // Add the builder's RPC URL to the forwarding config
             // The config may have empty builder_urls which we need to populate
             if cfg.builder_urls.is_empty() {
-                cfg.builder_urls =
-                    vec![builder.rpc_url().expect("builder RPC URL should be available")];
+                cfg.builder_urls = vec![builder.rpc_url()?];
             }
-            cfg
-        });
+            Some(cfg)
+        } else {
+            None
+        };
 
         let client_config = InProcessClientConfig {
             genesis_json: config.l2_genesis.clone(),

--- a/devnet/src/smoke.rs
+++ b/devnet/src/smoke.rs
@@ -7,6 +7,7 @@ use alloy_provider::RootProvider;
 use alloy_rpc_client::RpcClient;
 use alloy_rpc_types_engine::JwtSecret;
 use base_alloy_network::Base;
+use base_tx_forwarding::TxForwardingConfig;
 use eyre::{Result, WrapErr};
 use tempfile::TempDir;
 use url::Url;
@@ -128,6 +129,7 @@ pub struct DevnetBuilder {
     slot_duration: Option<u64>,
     output_dir: Option<PathBuf>,
     stable_config: Option<StableDevnetConfig>,
+    tx_forwarding_config: Option<TxForwardingConfig>,
 }
 
 impl DevnetBuilder {
@@ -163,6 +165,14 @@ impl DevnetBuilder {
     /// Enables stable container names and ports matching docker-compose.yml.
     pub fn with_stable_config(mut self) -> Self {
         self.stable_config = Some(StableDevnetConfig::devnet());
+        self
+    }
+
+    /// Enables transaction forwarding on the client node.
+    /// When enabled, the client will forward transactions to the builder via
+    /// the `base_insertValidatedTransaction` RPC endpoint.
+    pub fn with_tx_forwarding(mut self, config: TxForwardingConfig) -> Self {
+        self.tx_forwarding_config = Some(config);
         self
     }
 
@@ -264,6 +274,7 @@ impl DevnetBuilder {
             l1_rpc_url: l1_stack.reth().rpc_url().await?.to_string(),
             l1_beacon_url: l1_stack.beacon().beacon_url().await?,
             container_config: l2_container_config,
+            tx_forwarding_config: self.tx_forwarding_config,
         };
 
         let l2_stack = L2Stack::start(l2_config).await.wrap_err("Failed to start L2 stack")?;

--- a/devnet/tests/tx_forwarding.rs
+++ b/devnet/tests/tx_forwarding.rs
@@ -1,0 +1,288 @@
+//! End-to-end tests for the transaction forwarding pipeline.
+//!
+//! These tests verify that transactions can be forwarded from mempool nodes
+//! to builder nodes via the `base_insertValidatedTransaction` RPC endpoint.
+
+use std::time::Duration;
+
+use alloy_consensus::SignableTransaction;
+use alloy_eips::eip2718::Encodable2718;
+use alloy_primitives::{Address, Bytes, U256};
+use alloy_provider::Provider;
+use alloy_rpc_client::RpcClient;
+use alloy_signer::SignerSync;
+use alloy_signer_local::PrivateKeySigner;
+use base_tx_forwarding::TxForwardingConfig;
+use base_txpool::ValidatedTransaction;
+use devnet::{DevnetBuilder, config::ANVIL_ACCOUNT_1};
+use eyre::{Result, WrapErr};
+use tokio::time::{sleep, timeout};
+
+const L1_CHAIN_ID: u64 = 1337;
+const L2_CHAIN_ID: u64 = 84538453;
+const TX_RECEIPT_TIMEOUT: Duration = Duration::from_secs(60);
+
+/// Creates a signed EIP-1559 transaction and returns the sender, raw bytes, and tx hash.
+fn create_signed_eip1559_tx(
+    signer: &PrivateKeySigner,
+    chain_id: u64,
+    nonce: u64,
+    recipient: Address,
+) -> Result<(Address, Bytes, alloy_primitives::B256)> {
+    use base_alloy_network::TransactionBuilder;
+    use base_alloy_rpc_types::OpTransactionRequest;
+
+    let sender = signer.address();
+
+    let tx_request = OpTransactionRequest::default()
+        .from(sender)
+        .to(recipient)
+        .value(U256::from(1_000_000_000u64))
+        .transaction_type(2)
+        .with_gas_limit(21000)
+        .with_max_fee_per_gas(1_000_000_000)
+        .with_max_priority_fee_per_gas(1_000_000)
+        .with_chain_id(chain_id)
+        .with_nonce(nonce);
+
+    let tx = tx_request.build_typed_tx().map_err(|_| eyre::eyre!("invalid transaction request"))?;
+    let signature = signer.sign_hash_sync(&tx.signature_hash())?;
+    let signed_tx = tx.into_signed(signature);
+    let tx_hash = *signed_tx.hash();
+    let raw_tx: Bytes = signed_tx.encoded_2718().into();
+
+    Ok((sender, raw_tx, tx_hash))
+}
+
+/// Tests that a single transaction can be inserted via `base_insertValidatedTransaction`.
+///
+/// This is the foundational test for the forwarding pipeline. It verifies:
+/// 1. The builder node has the `base_insertValidatedTransaction` RPC endpoint
+/// 2. The endpoint accepts a valid pre-validated transaction
+/// 3. The transaction is included in a block on the builder
+#[tokio::test]
+async fn test_insert_validated_transaction_single() -> Result<()> {
+    let devnet = DevnetBuilder::new()
+        .with_l1_chain_id(L1_CHAIN_ID)
+        .with_l2_chain_id(L2_CHAIN_ID)
+        .build()
+        .await?;
+
+    let builder_provider = devnet.l2_builder_provider()?;
+
+    // Wait for some blocks to be produced so the chain is ready
+    timeout(Duration::from_secs(15), async {
+        loop {
+            let block = builder_provider.get_block_number().await?;
+            if block >= 2 {
+                return Ok::<_, eyre::Error>(block);
+            }
+            sleep(Duration::from_millis(500)).await;
+        }
+    })
+    .await
+    .wrap_err("Builder block production timed out")??;
+
+    // Set up the signer with a funded account
+    let private_key_hex = format!("0x{}", hex::encode(ANVIL_ACCOUNT_1.private_key.as_slice()));
+    let signer: PrivateKeySigner = private_key_hex.parse()?;
+    let sender = signer.address();
+
+    // Verify sender has balance
+    let balance = builder_provider.get_balance(sender).await?;
+    assert!(balance > U256::ZERO, "Sender should have balance");
+
+    // Get current nonce
+    let nonce = builder_provider.get_transaction_count(sender).await?;
+
+    // Create a signed transaction
+    let recipient: Address = "0x000000000000000000000000000000000000dEaD".parse()?;
+    let (sender, raw_tx, expected_tx_hash) =
+        create_signed_eip1559_tx(&signer, L2_CHAIN_ID, nonce, recipient)?;
+
+    // Create the ValidatedTransaction payload
+    let validated_tx = ValidatedTransaction { sender, raw: raw_tx };
+
+    // Create RPC client for the builder
+    let builder_rpc_url = devnet.l2_rpc_url()?;
+    let rpc_client = RpcClient::builder().http(builder_rpc_url);
+
+    // Call base_insertValidatedTransaction
+    let result: Result<(), _> =
+        rpc_client.request("base_insertValidatedTransaction", (validated_tx,)).await;
+
+    assert!(result.is_ok(), "base_insertValidatedTransaction should succeed, got: {result:?}");
+
+    // Wait for the transaction to be included in a block
+    let receipt = timeout(TX_RECEIPT_TIMEOUT, async {
+        loop {
+            if let Some(receipt) =
+                builder_provider.get_transaction_receipt(expected_tx_hash).await?
+            {
+                return Ok::<_, eyre::Error>(receipt);
+            }
+            sleep(Duration::from_secs(1)).await;
+        }
+    })
+    .await
+    .wrap_err("Transaction receipt timed out")?
+    .wrap_err("Failed to get transaction receipt")?;
+
+    // Verify the transaction was included
+    assert_eq!(receipt.inner.transaction_hash, expected_tx_hash);
+    assert!(receipt.inner.block_number.is_some(), "Receipt should have block number");
+    assert_eq!(receipt.inner.from, sender);
+    assert_eq!(receipt.inner.to, Some(recipient));
+
+    Ok(())
+}
+
+/// Tests that invalid transaction bytes are rejected with appropriate error.
+#[tokio::test]
+async fn test_insert_validated_transaction_invalid_bytes() -> Result<()> {
+    let devnet = DevnetBuilder::new()
+        .with_l1_chain_id(L1_CHAIN_ID)
+        .with_l2_chain_id(L2_CHAIN_ID)
+        .build()
+        .await?;
+
+    // Wait for builder to be ready
+    let builder_provider = devnet.l2_builder_provider()?;
+    timeout(Duration::from_secs(15), async {
+        loop {
+            let block = builder_provider.get_block_number().await?;
+            if block >= 2 {
+                return Ok::<_, eyre::Error>(block);
+            }
+            sleep(Duration::from_millis(500)).await;
+        }
+    })
+    .await
+    .wrap_err("Builder block production timed out")??;
+
+    // Create RPC client for the builder
+    let builder_rpc_url = devnet.l2_rpc_url()?;
+    let rpc_client = RpcClient::builder().http(builder_rpc_url);
+
+    // Create an invalid ValidatedTransaction with garbage bytes
+    let validated_tx = ValidatedTransaction {
+        sender: Address::repeat_byte(0x42),
+        raw: Bytes::from(vec![0xDE, 0xAD, 0xBE, 0xEF]),
+    };
+
+    // Call base_insertValidatedTransaction - should fail
+    let result: Result<(), _> =
+        rpc_client.request("base_insertValidatedTransaction", (validated_tx,)).await;
+
+    let err = result.expect_err("expected decode error for invalid bytes");
+    let err_str = err.to_string();
+
+    // Should get InvalidParams error (-32602) for decode failure
+    assert!(
+        err_str.contains("-32602") || err_str.contains("failed to decode"),
+        "expected InvalidParams for decode failure, got: {err_str}"
+    );
+
+    Ok(())
+}
+
+/// Full end-to-end test for the transaction forwarding pipeline.
+///
+/// This test verifies the complete flow:
+/// 1. Client node receives a transaction
+/// 2. `TxForwardingExtension` picks it up from the mempool
+/// 3. Forwarder calls `base_insertValidatedTransaction` on the builder
+/// 4. Transaction is included in a block on the builder
+///
+/// This is different from `test_insert_validated_transaction_single` which
+/// directly calls the RPC endpoint. Here we test the full pipeline.
+#[tokio::test]
+async fn test_tx_forwarding_pipeline_e2e() -> Result<()> {
+    // Build devnet with tx forwarding enabled on the client
+    // The client will forward transactions to the builder's RPC endpoint
+    let devnet = DevnetBuilder::new()
+        .with_l1_chain_id(L1_CHAIN_ID)
+        .with_l2_chain_id(L2_CHAIN_ID)
+        .with_tx_forwarding(
+            // Empty vector here because the stack will populate it with the builder RPC URL on start
+            TxForwardingConfig::new(vec![]).with_resend_after_ms(2000).with_max_batch_size(100),
+        )
+        .build()
+        .await?;
+
+    let builder_provider = devnet.l2_builder_provider()?;
+    let client_provider = devnet.l2_client_provider()?;
+
+    // Wait for some blocks to be produced so both nodes are synced
+    timeout(Duration::from_secs(15), async {
+        loop {
+            let builder_block = builder_provider.get_block_number().await?;
+            let client_block = client_provider.get_block_number().await?;
+            if builder_block >= 3 && client_block >= 3 {
+                return Ok::<_, eyre::Error>((builder_block, client_block));
+            }
+            sleep(Duration::from_millis(500)).await;
+        }
+    })
+    .await
+    .wrap_err("Block production/sync timed out")??;
+
+    // Set up the signer with a funded account
+    let private_key_hex = format!("0x{}", hex::encode(ANVIL_ACCOUNT_1.private_key.as_slice()));
+    let signer: PrivateKeySigner = private_key_hex.parse()?;
+    let sender = signer.address();
+
+    // Wait for client to sync balance
+    timeout(Duration::from_secs(15), async {
+        loop {
+            let client_balance = client_provider.get_balance(sender).await?;
+            if client_balance > U256::ZERO {
+                return Ok::<_, eyre::Error>(());
+            }
+            sleep(Duration::from_millis(500)).await;
+        }
+    })
+    .await
+    .wrap_err("Timed out waiting for client to sync balance")??;
+
+    // Get nonce from client (the node we'll send to)
+    let nonce = client_provider.get_transaction_count(sender).await?;
+
+    // Create a signed transaction
+    let recipient: Address = "0x000000000000000000000000000000000000dEaD".parse()?;
+    let (_, raw_tx, expected_tx_hash) =
+        create_signed_eip1559_tx(&signer, L2_CHAIN_ID, nonce, recipient)?;
+
+    // Send the transaction to the CLIENT node (not builder)
+    // The forwarding pipeline should forward it to the builder
+    let pending_tx = client_provider
+        .send_raw_transaction(&raw_tx)
+        .await
+        .wrap_err("Failed to send transaction to client")?;
+    let tx_hash = *pending_tx.tx_hash();
+    assert_eq!(tx_hash, expected_tx_hash, "Transaction hash mismatch");
+
+    // Wait for the transaction to be included in a block on the BUILDER
+    // This proves the forwarding pipeline worked
+    let receipt = timeout(TX_RECEIPT_TIMEOUT, async {
+        loop {
+            if let Some(receipt) =
+                builder_provider.get_transaction_receipt(expected_tx_hash).await?
+            {
+                return Ok::<_, eyre::Error>(receipt);
+            }
+            sleep(Duration::from_secs(2)).await;
+        }
+    })
+    .await
+    .wrap_err("Transaction receipt timed out on builder - forwarding may have failed")?
+    .wrap_err("Failed to get transaction receipt")?;
+
+    // Verify the transaction was included
+    assert_eq!(receipt.inner.transaction_hash, expected_tx_hash);
+    assert!(receipt.inner.block_number.is_some(), "Receipt should have block number");
+    assert_eq!(receipt.inner.from, sender);
+    assert_eq!(receipt.inner.to, Some(recipient));
+
+    Ok(())
+}

--- a/devnet/tests/tx_forwarding.rs
+++ b/devnet/tests/tx_forwarding.rs
@@ -12,6 +12,8 @@ use alloy_provider::Provider;
 use alloy_rpc_client::RpcClient;
 use alloy_signer::SignerSync;
 use alloy_signer_local::PrivateKeySigner;
+use base_alloy_network::TransactionBuilder;
+use base_alloy_rpc_types::OpTransactionRequest;
 use base_tx_forwarding::TxForwardingConfig;
 use base_txpool::ValidatedTransaction;
 use devnet::{
@@ -32,9 +34,6 @@ fn create_signed_eip1559_tx(
     nonce: u64,
     recipient: Address,
 ) -> Result<(Address, Bytes, alloy_primitives::B256)> {
-    use base_alloy_network::TransactionBuilder;
-    use base_alloy_rpc_types::OpTransactionRequest;
-
     let sender = signer.address();
 
     let tx_request = OpTransactionRequest::default()
@@ -48,7 +47,9 @@ fn create_signed_eip1559_tx(
         .with_chain_id(chain_id)
         .with_nonce(nonce);
 
-    let tx = tx_request.build_typed_tx().map_err(|_| eyre::eyre!("invalid transaction request"))?;
+    let tx = tx_request
+        .build_typed_tx()
+        .map_err(|e| eyre::eyre!("invalid transaction request: {e:?}"))?;
     let signature = signer.sign_hash_sync(&tx.signature_hash())?;
     let signed_tx = tx.into_signed(signature);
     let tx_hash = *signed_tx.hash();
@@ -333,9 +334,9 @@ async fn test_tx_forwarding_pipeline_e2e_high_load() -> Result<()> {
         .iter()
         .map(|acct| {
             let hex = format!("0x{}", hex::encode(acct.private_key.as_slice()));
-            hex.parse().expect("valid private key")
+            hex.parse::<PrivateKeySigner>().map_err(|e| eyre::eyre!("invalid private key: {e:?}"))
         })
-        .collect();
+        .collect::<Result<Vec<PrivateKeySigner>>>()?;
 
     // Wait for all accounts to have balance on the client
     timeout(Duration::from_secs(15), async {

--- a/devnet/tests/tx_forwarding.rs
+++ b/devnet/tests/tx_forwarding.rs
@@ -14,7 +14,10 @@ use alloy_signer::SignerSync;
 use alloy_signer_local::PrivateKeySigner;
 use base_tx_forwarding::TxForwardingConfig;
 use base_txpool::ValidatedTransaction;
-use devnet::{DevnetBuilder, config::ANVIL_ACCOUNT_1};
+use devnet::{
+    DevnetBuilder,
+    config::{ANVIL_ACCOUNT_1, ANVIL_ACCOUNT_2, ANVIL_ACCOUNT_3, ANVIL_ACCOUNT_4},
+};
 use eyre::{Result, WrapErr};
 use tokio::time::{sleep, timeout};
 
@@ -283,6 +286,144 @@ async fn test_tx_forwarding_pipeline_e2e() -> Result<()> {
     assert!(receipt.inner.block_number.is_some(), "Receipt should have block number");
     assert_eq!(receipt.inner.from, sender);
     assert_eq!(receipt.inner.to, Some(recipient));
+
+    Ok(())
+}
+
+/// Tests that the forwarding pipeline handles high transaction load under rate limiting.
+///
+/// Uses all 4 available test accounts (`ANVIL_ACCOUNT_1` through `ANVIL_ACCOUNT_4`) to send
+/// transactions concurrently, with `max_rps = 1` forcing the forwarder to buffer heavily.
+/// Each account sends 10 transactions for a total of 40, verifying that all are eventually
+/// forwarded to the builder and included in blocks despite the constrained send rate.
+#[tokio::test]
+async fn test_tx_forwarding_pipeline_e2e_high_load() -> Result<()> {
+    const TXS_PER_ACCOUNT: usize = 10;
+
+    let accounts = [&*ANVIL_ACCOUNT_1, &*ANVIL_ACCOUNT_2, &*ANVIL_ACCOUNT_3, &*ANVIL_ACCOUNT_4];
+
+    let devnet = DevnetBuilder::new()
+        .with_l1_chain_id(L1_CHAIN_ID)
+        .with_l2_chain_id(L2_CHAIN_ID)
+        .with_tx_forwarding(
+            TxForwardingConfig::new(vec![]).with_max_rps(1).with_resend_after_ms(30_000), // high resend window so we don't double-send
+        )
+        .build()
+        .await?;
+
+    let builder_provider = devnet.l2_builder_provider()?;
+    let client_provider = devnet.l2_client_provider()?;
+
+    // Wait for some blocks to be produced so both nodes are synced
+    timeout(Duration::from_secs(15), async {
+        loop {
+            let builder_block = builder_provider.get_block_number().await?;
+            let client_block = client_provider.get_block_number().await?;
+            if builder_block >= 3 && client_block >= 3 {
+                return Ok::<_, eyre::Error>((builder_block, client_block));
+            }
+            sleep(Duration::from_millis(500)).await;
+        }
+    })
+    .await
+    .wrap_err("Block production/sync timed out")??;
+
+    // Set up signers for all accounts
+    let signers: Vec<PrivateKeySigner> = accounts
+        .iter()
+        .map(|acct| {
+            let hex = format!("0x{}", hex::encode(acct.private_key.as_slice()));
+            hex.parse().expect("valid private key")
+        })
+        .collect();
+
+    // Wait for all accounts to have balance on the client
+    timeout(Duration::from_secs(15), async {
+        loop {
+            let mut all_funded = true;
+            for signer in &signers {
+                let balance = client_provider.get_balance(signer.address()).await?;
+                if balance == U256::ZERO {
+                    all_funded = false;
+                    break;
+                }
+            }
+            if all_funded {
+                return Ok::<_, eyre::Error>(());
+            }
+            sleep(Duration::from_millis(500)).await;
+        }
+    })
+    .await
+    .wrap_err("Timed out waiting for all accounts to sync balance")??;
+
+    let recipient: Address = "0x000000000000000000000000000000000000dEaD".parse()?;
+
+    // Send TXS_PER_ACCOUNT transactions from each signer, interleaving accounts
+    // to maximize concurrency pressure on the forwarder
+    let mut expected: Vec<(Address, alloy_primitives::B256)> = Vec::new();
+    let mut nonces: Vec<u64> = Vec::with_capacity(signers.len());
+    for signer in &signers {
+        let nonce = client_provider.get_transaction_count(signer.address()).await?;
+        nonces.push(nonce);
+    }
+
+    for tx_idx in 0..TXS_PER_ACCOUNT {
+        for (acct_idx, signer) in signers.iter().enumerate() {
+            let nonce = nonces[acct_idx] + tx_idx as u64;
+            let (_, raw_tx, expected_tx_hash) =
+                create_signed_eip1559_tx(signer, L2_CHAIN_ID, nonce, recipient)?;
+
+            let pending_tx = client_provider
+                .send_raw_transaction(&raw_tx)
+                .await
+                .wrap_err_with(|| format!("Failed to send tx {tx_idx} from account {acct_idx}"))?;
+
+            assert_eq!(
+                *pending_tx.tx_hash(),
+                expected_tx_hash,
+                "Transaction hash mismatch for tx {tx_idx} from account {acct_idx}"
+            );
+            expected.push((signer.address(), expected_tx_hash));
+        }
+    }
+
+    let total_txs = expected.len();
+
+    // Wait for ALL transactions to be included on the builder.
+    // With max_rps=1 and 40 txs, the forwarder needs significant time to drain.
+    let mut received = vec![false; total_txs];
+
+    timeout(Duration::from_secs(180), async {
+        loop {
+            let mut all_received = true;
+            for (i, (sender, hash)) in expected.iter().enumerate() {
+                if received[i] {
+                    continue;
+                }
+                if let Some(receipt) = builder_provider.get_transaction_receipt(*hash).await? {
+                    assert_eq!(receipt.inner.transaction_hash, *hash);
+                    assert_eq!(receipt.inner.from, *sender);
+                    assert_eq!(receipt.inner.to, Some(recipient));
+                    received[i] = true;
+                } else {
+                    all_received = false;
+                }
+            }
+            if all_received {
+                return Ok::<_, eyre::Error>(());
+            }
+            sleep(Duration::from_secs(2)).await;
+        }
+    })
+    .await
+    .wrap_err("Timed out waiting for all transactions - forwarding under load may have failed")??;
+
+    let included_count = received.iter().filter(|&&r| r).count();
+    assert_eq!(
+        included_count, total_txs,
+        "Expected all {total_txs} transactions to be included, got {included_count}"
+    );
 
     Ok(())
 }


### PR DESCRIPTION
- Created a new crate, `crate/tx-forwarding`. This sets up the Consumer and Forwarder
- Added config flags to easily turn on/off the push-based RPC logic
- Added config flags to easily tune the Consumer/Forwarder logic (i.e., RPS, batch size, retry time etc.)
- Added devnet e2e test for the following:
   - `test_tx_forwarding_pipeline_e2e`: The full e2e logic for a single tx. Tests that a valid tx is able to be received at the mempool and sent to the builder RPC and then included in the block
   - `test_tx_forwarding_pipeline_e2e_high_load`: Tests the batching/rate-limiting by setting the `max_rps=1` low, and sending high amount of txs (10 txs every account, so 40 txs total)
   - Added two other devnet tests for just sanity checking

Next up:
- [x] Add CLI flag to easily toggle between Ordering algo 
- [ ] Bundle support