### PR TITLE
feat: support most RPCs in follow command

### DIFF
--- a/bin/consensus/src/cli.rs
+++ b/bin/consensus/src/cli.rs
@@ -4,13 +4,16 @@ use std::sync::Arc;
 
 use alloy_chains::Chain;
 use alloy_primitives::Address;
+use alloy_provider::RootProvider;
 use base_cli_utils::{CliStyles, LogConfig, RuntimeManager};
 use base_client_cli::{
     L1ClientArgs, L1ConfigFile, L2ClientArgs, L2ConfigFile, P2PArgs, RpcArgs, SequencerArgs,
 };
 use base_consensus_node::{
-    DelegateL2Client, EngineConfig, FollowNode, L1ConfigBuilder, NodeMode, RollupNodeBuilder,
+    DelegateL2Client, EngineConfig, FollowNode, L1Config, L1ConfigBuilder, NodeMode,
+    RollupNodeBuilder,
 };
+use base_consensus_providers::OnlineBeaconClient;
 use base_consensus_registry::Registry;
 use clap::{Args, Parser, Subcommand};
 use strum::IntoEnumIterator;
@@ -75,10 +78,6 @@ pub struct Follow {
     )]
     pub l2_rpc_url: Url,
 
-    /// L1 execution layer RPC URL.
-    #[arg(long = "l1-eth-rpc", env = "BASE_NODE_L1_ETH_RPC")]
-    pub l1_eth_rpc: Url,
-
     /// L2 engine CLI arguments.
     #[clap(flatten)]
     pub l2_client_args: L2ClientArgs,
@@ -97,9 +96,21 @@ pub struct Follow {
     #[command(flatten)]
     pub logging: LogArgs,
 
+    /// RPC CLI arguments.
+    #[command(flatten)]
+    pub rpc_flags: RpcArgs,
+
     /// L2 configuration file.
     #[clap(flatten)]
     pub l2_config: L2ConfigFile,
+
+    /// L1 configuration file.
+    #[clap(flatten)]
+    pub l1_config: L1ConfigFile,
+
+    /// L1 RPC CLI arguments.
+    #[clap(flatten)]
+    pub l1_rpc_args: L1ClientArgs,
 }
 
 impl Follow {
@@ -124,25 +135,43 @@ impl Follow {
         );
 
         let jwt_secret = self.l2_client_args.validate_jwt().await?;
-        let rollup_config = Arc::new(cfg);
+        let rollup_config = Arc::new(cfg.clone());
 
         let engine_config = EngineConfig {
             config: Arc::clone(&rollup_config),
             l2_url: self.l2_client_args.l2_engine_rpc.clone(),
             l2_jwt_secret: jwt_secret,
-            l1_url: self.l1_eth_rpc.clone(),
+            l1_url: self.l1_rpc_args.l1_eth_rpc.clone(),
             mode: NodeMode::Validator,
         };
 
-        let local_l2_provider = alloy_provider::RootProvider::<base_alloy_network::Base>::new_http(
-            self.l2_rpc_url.clone(),
-        );
-        let l2_source = DelegateL2Client::new(self.source_l2_rpc.clone());
+        let l1_chain_config =
+            self.l1_config.load(cfg.l1_chain_id).map_err(|e| eyre::eyre!("{e}"))?;
 
-        FollowNode::new(rollup_config, engine_config, local_l2_provider, l2_source)
-            .start()
-            .await
-            .map_err(|e| {
+        let local_l2_provider =
+            RootProvider::<base_alloy_network::Base>::new_http(self.l2_rpc_url.clone());
+        let l2_source = DelegateL2Client::new(self.source_l2_rpc.clone());
+        let rpc_builder = self.rpc_flags.clone().into();
+        let l1_beacon = OnlineBeaconClient::new_http(self.l1_rpc_args.l1_beacon.to_string());
+
+        let l1_config = L1Config {
+            chain_config: Arc::new(l1_chain_config),
+            trust_rpc: self.l1_rpc_args.l1_trust_rpc,
+            beacon_client: l1_beacon,
+            engine_provider: RootProvider::new_http(self.l1_rpc_args.l1_eth_rpc.clone()),
+        };
+
+        FollowNode::new(
+            rollup_config,
+            engine_config,
+            local_l2_provider,
+            l2_source,
+            rpc_builder,
+            l1_config,
+        )
+        .start()
+        .await
+        .map_err(|e| {
             error!(target: "rollup_node", error = %e, "Failed to start follow node");
             eyre::eyre!("{e}")
         })?;

--- a/crates/consensus/service/src/actors/l1_watcher/actor.rs
+++ b/crates/consensus/service/src/actors/l1_watcher/actor.rs
@@ -48,7 +48,7 @@ where
     /// Client used to interact with the [`crate::DerivationActor`].
     derivation_client: L1WatcherDerivationClient_,
     /// The block signer sender.
-    block_signer_sender: mpsc::Sender<Address>,
+    block_signer_sender: Option<mpsc::Sender<Address>>,
     /// The cancellation token, shared between all tasks.
     cancellation: CancellationToken,
     /// A stream over the latest head.
@@ -71,7 +71,7 @@ where
         l1_query_rx: mpsc::Receiver<L1WatcherQueries>,
         l1_head_updates_tx: watch::Sender<Option<BlockInfo>>,
         derivation_client: L1WatcherDerivationClient_,
-        signer: mpsc::Sender<Address>,
+        signer: Option<mpsc::Sender<Address>>,
         cancellation: CancellationToken,
         head_stream: BlockStream,
         finalized_stream: BlockStream,
@@ -143,7 +143,7 @@ where
                                     target: "l1_watcher",
                                     "Unsafe block signer update: {unsafe_block_signer}"
                                 );
-                                if let Err(e) = self.block_signer_sender.send(unsafe_block_signer).await {
+                                if let Some(ref block_signer_sender) = self.block_signer_sender && let Err(e) = block_signer_sender.send(unsafe_block_signer).await {
                                     error!(
                                         target: "l1_watcher",
                                         "Error sending unsafe block signer update: {e}"

--- a/crates/consensus/service/src/actors/rpc/actor.rs
+++ b/crates/consensus/service/src/actors/rpc/actor.rs
@@ -37,9 +37,9 @@ where
 #[derive(Debug)]
 pub struct RpcContext {
     /// The network p2p rpc sender.
-    pub p2p_network: mpsc::Sender<P2pRpcRequest>,
+    pub p2p_network: Option<mpsc::Sender<P2pRpcRequest>>,
     /// The network admin rpc sender.
-    pub network_admin: mpsc::Sender<NetworkAdminQuery>,
+    pub network_admin: Option<mpsc::Sender<NetworkAdminQuery>>,
     /// The l1 watcher queries sender.
     pub l1_watcher_queries: mpsc::Sender<L1WatcherQueries>,
     /// The cancellation token, shared between all tasks.
@@ -104,10 +104,15 @@ where
         modules.merge(HealthzApiServer::into_rpc(HealthzRpc {}))?;
 
         // Build the p2p rpc module.
-        modules.merge(P2pRpc::new(p2p_network).into_rpc())?;
+        if let Some(p2p_network) = p2p_network {
+            modules.merge(P2pRpc::new(p2p_network).into_rpc())?;
+        }
 
         // Build the admin rpc module.
-        modules.merge(AdminRpc::new(self.sequencer_admin_rpc_client, network_admin).into_rpc())?;
+        if let Some(network_admin) = network_admin {
+            modules
+                .merge(AdminRpc::new(self.sequencer_admin_rpc_client, network_admin).into_rpc())?;
+        }
 
         // Create context for communication between actors.
         let rollup_rpc = RollupRpc::new(self.engine_rpc_client.clone(), l1_watcher_queries);

--- a/crates/consensus/service/src/service/follow.rs
+++ b/crates/consensus/service/src/service/follow.rs
@@ -1,30 +1,36 @@
-use std::sync::Arc;
+use std::{sync::Arc, time::Duration};
 
+use alloy_eips::BlockNumberOrTag;
 use alloy_provider::RootProvider;
 use base_alloy_network::Base;
 use base_consensus_engine::{Engine, EngineState};
 use base_consensus_genesis::RollupConfig;
+use base_consensus_rpc::RpcBuilder;
 use tokio::sync::{mpsc, watch};
 use tokio_util::sync::CancellationToken;
 
 use super::LocalEngineActor;
 use crate::{
-    DelegateL2Client, DelegateL2DerivationActor, EngineActor, EngineActorRequest, EngineConfig,
-    EngineProcessor, EngineRpcProcessor, NodeActor, QueuedDerivationEngineClient,
-    QueuedEngineDerivationClient,
+    BlockStream, DelegateL2Client, DelegateL2DerivationActor, EngineActor, EngineActorRequest,
+    EngineConfig, EngineProcessor, EngineRpcProcessor, L1Config, L1WatcherActor, NodeActor,
+    QueuedDerivationEngineClient, QueuedEngineDerivationClient, QueuedEngineRpcClient,
+    QueuedL1WatcherDerivationClient, RpcActor, RpcContext,
+    service::node::{FINALIZED_STREAM_POLL_INTERVAL, HEAD_STREAM_POLL_INTERVAL},
 };
 
 /// A lightweight node that follows another L2 node by polling its execution
 /// layer RPC and driving the local engine via `NewPayload` + FCU.
 ///
-/// Runs only the [`EngineActor`] and [`DelegateL2DerivationActor`] — no L1
-/// watcher, derivation pipeline, P2P, or sequencer.
+/// Runs only the [`EngineActor`] and [`DelegateL2DerivationActor`] — no derivation
+/// pipeline, P2P, or sequencer.
 #[derive(Debug)]
 pub struct FollowNode {
     config: Arc<RollupConfig>,
     engine_config: EngineConfig,
     local_l2_provider: RootProvider<Base>,
     l2_source: DelegateL2Client,
+    l1_config: L1Config,
+    rpc_builder: Option<RpcBuilder>,
 }
 
 impl FollowNode {
@@ -34,8 +40,10 @@ impl FollowNode {
         engine_config: EngineConfig,
         local_l2_provider: RootProvider<Base>,
         l2_source: DelegateL2Client,
+        rpc_builder: Option<RpcBuilder>,
+        l1_config: L1Config,
     ) -> Self {
-        Self { config, engine_config, local_l2_provider, l2_source }
+        Self { config, engine_config, local_l2_provider, l2_source, rpc_builder, l1_config }
     }
 
     fn create_engine_actor(
@@ -84,23 +92,72 @@ impl FollowNode {
         let engine_actor = self.create_engine_actor(
             cancellation.clone(),
             engine_actor_request_rx,
-            QueuedEngineDerivationClient::new(derivation_actor_request_tx),
+            QueuedEngineDerivationClient::new(derivation_actor_request_tx.clone()),
         );
 
         let derivation = DelegateL2DerivationActor::<_>::new(
             QueuedDerivationEngineClient {
                 engine_actor_request_tx: engine_actor_request_tx.clone(),
             },
-            engine_actor_request_tx,
+            engine_actor_request_tx.clone(),
             cancellation.clone(),
             derivation_actor_request_rx,
             self.local_l2_provider.clone(),
             self.l2_source.clone(),
         );
 
+        // Create the RPC server actor if configured.
+        let rpc = self.rpc_builder.clone().map(|b| {
+            RpcActor::new(
+                b,
+                QueuedEngineRpcClient::new(engine_actor_request_tx.clone()),
+                None::<crate::QueuedSequencerAdminAPIClient>,
+            )
+        });
+
+        let (l1_query_tx, l1_query_rx) = mpsc::channel(1024);
+
+        let head_stream = BlockStream::new_as_stream(
+            self.l1_config.engine_provider.clone(),
+            BlockNumberOrTag::Latest,
+            Duration::from_secs(HEAD_STREAM_POLL_INTERVAL),
+        )?;
+        let finalized_stream = BlockStream::new_as_stream(
+            self.l1_config.engine_provider.clone(),
+            BlockNumberOrTag::Finalized,
+            Duration::from_secs(FINALIZED_STREAM_POLL_INTERVAL),
+        )?;
+
+        let (l1_head_updates_tx, _l1_head_updates_rx) = watch::channel(None);
+        // Create the [`L1WatcherActor`]. Previously known as the DA watcher actor.
+        let l1_watcher = L1WatcherActor::new(
+            Arc::clone(&self.config),
+            self.l1_config.engine_provider.clone(),
+            l1_query_rx,
+            l1_head_updates_tx,
+            QueuedL1WatcherDerivationClient { derivation_actor_request_tx },
+            None,
+            cancellation.clone(),
+            head_stream,
+            finalized_stream,
+        );
+
         crate::service::spawn_and_wait!(
             cancellation,
-            actors = [Some((derivation, ())), Some((engine_actor, ())),]
+            actors = [
+                rpc.map(|r| (
+                    r,
+                    RpcContext {
+                        cancellation: cancellation.clone(),
+                        p2p_network: None,
+                        network_admin: None,
+                        l1_watcher_queries: l1_query_tx,
+                    }
+                )),
+                Some((derivation, ())),
+                Some((engine_actor, ())),
+                Some((l1_watcher, ())),
+            ]
         );
         Ok(())
     }

--- a/crates/consensus/service/src/service/node.rs
+++ b/crates/consensus/service/src/service/node.rs
@@ -29,8 +29,8 @@ use crate::{
 };
 
 const DERIVATION_PROVIDER_CACHE_SIZE: usize = 1024;
-const HEAD_STREAM_POLL_INTERVAL: u64 = 4;
-const FINALIZED_STREAM_POLL_INTERVAL: u64 = 60;
+pub(crate) const HEAD_STREAM_POLL_INTERVAL: u64 = 4;
+pub(crate) const FINALIZED_STREAM_POLL_INTERVAL: u64 = 60;
 
 /// The configuration for the L1 chain.
 #[derive(Debug, Clone)]
@@ -326,7 +326,7 @@ impl RollupNode {
             l1_query_rx,
             l1_head_updates_tx.clone(),
             QueuedL1WatcherDerivationClient { derivation_actor_request_tx },
-            signer,
+            Some(signer),
             cancellation.clone(),
             head_stream,
             finalized_stream,
@@ -379,8 +379,8 @@ impl RollupNode {
                     r,
                     RpcContext {
                         cancellation: cancellation.clone(),
-                        p2p_network: network_rpc,
-                        network_admin: net_admin_rpc,
+                        p2p_network: Some(network_rpc),
+                        network_admin: Some(net_admin_rpc),
                         l1_watcher_queries: l1_query_tx,
                     }
                 )),


### PR DESCRIPTION
Sets up RPC server for follow command.

- Make admin and p2p RPCs optional.
- Start RPC server in follow command service.
- Pass L1 watcher to RPC server.
- Add L1 args to follow command.