### PR TITLE
fix(ci): throttle lychee link checks to avoid GitHub rate limits

### DIFF
--- a/.github/workflows/lychee.yml
+++ b/.github/workflows/lychee.yml
@@ -6,6 +6,12 @@ on:
   merge_group:
   workflow_dispatch:
 
+# Prevent concurrent link-check runs from hitting GitHub rate limits.
+# New runs cancel any in-progress run for the same ref.
+concurrency:
+  group: lychee-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/lychee.toml
+++ b/lychee.toml
@@ -1,6 +1,9 @@
 verbose = "debug"
 no_progress = false
 exclude_all_private = false
+max_concurrency = 48
+max_retries = 3
+retry_wait_time = 5
 accept = [200, 403, 429] # 403 is often returned by private repos instead of 404; 429 is rate limiting
 exclude_path = [
     "crates/utilities/test-utils/contracts/",


### PR DESCRIPTION
## Summary

- Reduces lychee `max_concurrency` from the default 128 to 48 to prevent concurrent CI runs across multiple PRs from collectively overwhelming GitHub's API rate limits
- Adds `max_retries = 3` and `retry_wait_time = 5` so transient 429s are retried with backoff instead of immediately failing
- Adds a `concurrency` group to the workflow so re-pushes to the same branch cancel in-progress lychee runs