### PR TITLE
refactor(just): move devnet commands into a just module

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -264,6 +264,6 @@ jobs:
         with:
           key: docker-${{ runner.os }}-${{ hashFiles('devnet/src/images.rs', 'etc/docker/Dockerfile.devnet') }}
       - name: Pre-pull docker images
-        run: just devnet-pull-images
+        run: just devnet pull-images
       - name: Run devnet tests
-        run: just devnet-tests-ci
+        run: just devnet tests-ci

--- a/Justfile
+++ b/Justfile
@@ -1,7 +1,8 @@
 set positional-arguments := true
-set dotenv-filename := "etc/docker/devnet-env"
 
 mod tee 'crates/proof/tee'
+# Docker-based local devnet management
+mod devnet 'etc/docker'
 
 alias t := test
 alias f := fix
@@ -15,7 +16,7 @@ alias wc := watch-check
 
 # Default to display help menu
 default:
-    @just --list
+    @just --list --list-submodules
 
 # Runs the specs docs locally
 specs:
@@ -146,21 +147,6 @@ test-affected-ci base="main": install-nextest build-contracts
         exit $code
     }
 
-# Runs devnet tests (requires Docker)
-devnet-tests: install-nextest build-contracts
-    cargo nextest run -p devnet
-
-# Runs devnet tests with ci profile for minimal disk usage
-devnet-tests-ci: install-nextest build-contracts
-    cargo nextest run --locked -p devnet --cargo-profile ci
-
-# Pre-pulls Docker images needed for devnet tests
-devnet-pull-images:
-    docker build -t devnet-setup:local -f etc/docker/Dockerfile.devnet .
-    docker pull ghcr.io/paradigmxyz/reth:v1.10.2
-    docker pull sigp/lighthouse:v8.0.1
-    docker pull us-docker.pkg.dev/oplabs-tools-artifacts/images/op-batcher:v1.16.3
-
 # Checks that no_std crates compile without std
 check-no-std:
     ./etc/scripts/ci/check-no-std.sh
@@ -253,64 +239,6 @@ bench-flashblocks:
 # Runs MPT trie node benchmarks
 bench-proof-mpt:
     cargo bench -p base-proof-mpt --bench trie_node
-
-# Stops devnet, deletes data, and starts fresh
-devnet: devnet-down
-    docker compose --env-file etc/docker/devnet-env -f etc/docker/docker-compose.yml up -d --build --scale contender=0
-
-# Stops devnet, deletes data, and starts fresh with profiling (Pyroscope + optimized builds)
-devnet-profiling: devnet-down
-    CARGO_PROFILE=profiling docker compose --env-file etc/docker/devnet-env -f etc/docker/docker-compose.yml --profile profiling up -d --build --scale contender=0
-
-# Stops devnet and deletes all data
-devnet-down:
-    -docker compose --env-file etc/docker/devnet-env -f etc/docker/docker-compose.yml --profile profiling down
-    rm -rf .devnet
-
-# Shows devnet block numbers and sync status
-devnet-status:
-    ./etc/scripts/devnet/status.sh
-
-# Shows funded test accounts with live balances and nonces
-devnet-accounts:
-    ./etc/scripts/devnet/accounts.sh
-
-# Sends test transactions to L1 and L2
-devnet-smoke:
-    ./etc/scripts/devnet/smoke.sh
-
-# Runs full devnet checks (status + smoke tests)
-devnet-checks: devnet-status devnet-smoke
-
-# Starts the contender load generator
-devnet-load:
-    docker compose -f etc/docker/docker-compose.yml up -d --no-deps contender
-
-# Stops the contender load generator
-devnet-load-down:
-    docker compose -f etc/docker/docker-compose.yml down contender
-
-# Stream FB's from the builder via websocket
-devnet-flashblocks:
-    @command -v flashblocks-websocket-client >/dev/null 2>&1 || go install github.com/danyalprout/flashblocks-websocket-client@latest
-    flashblocks-websocket-client ws://localhost:${L2_BUILDER_FLASHBLOCKS_PORT}
-
-# Stream logs from devnet containers (optionally specify container names)
-devnet-logs *containers:
-    docker compose --env-file etc/docker/devnet-env -f etc/docker/docker-compose.yml logs -f {{ containers }}
-
-# Stops devnet+ingress, deletes data, and starts fresh with full ingress stack
-devnet-ingress: devnet-ingress-down
-    docker compose --env-file etc/docker/devnet-env -f etc/docker/docker-compose.yml -f etc/docker/docker-compose.ingress.yml up -d --build --scale contender=0
-
-# Stops devnet+ingress and deletes all data
-devnet-ingress-down:
-    -docker compose --env-file etc/docker/devnet-env -f etc/docker/docker-compose.yml -f etc/docker/docker-compose.ingress.yml down
-    rm -rf .devnet
-
-# Stream logs from devnet+ingress containers (optionally specify container names)
-devnet-ingress-logs *containers:
-    docker compose --env-file etc/docker/devnet-env -f etc/docker/docker-compose.yml -f etc/docker/docker-compose.ingress.yml logs -f {{ containers }}
 
 # Run basectl with specified config (mainnet, sepolia, devnet, or path)
 basectl config="mainnet":

--- a/etc/docker/Justfile
+++ b/etc/docker/Justfile
@@ -1,0 +1,87 @@
+set dotenv-path := "devnet-env"
+set working-directory := '../..'
+
+# Show devnet commands
+default:
+    @just devnet --list
+
+# Stops devnet, deletes data, and starts fresh
+up: down
+    docker compose --env-file etc/docker/devnet-env -f etc/docker/docker-compose.yml up -d --build --scale contender=0
+
+# Stops devnet, deletes data, and starts fresh with profiling (Pyroscope + optimized builds)
+profiling: down
+    CARGO_PROFILE=profiling docker compose --env-file etc/docker/devnet-env -f etc/docker/docker-compose.yml --profile profiling up -d --build --scale contender=0
+
+# Stops devnet and deletes all data
+down:
+    -docker compose --env-file etc/docker/devnet-env -f etc/docker/docker-compose.yml --profile profiling down
+    rm -rf .devnet
+
+# Shows devnet block numbers and sync status
+status:
+    ./etc/scripts/devnet/status.sh
+
+# Shows funded test accounts with live balances and nonces
+accounts:
+    ./etc/scripts/devnet/accounts.sh
+
+# Sends test transactions to L1 and L2
+smoke:
+    ./etc/scripts/devnet/smoke.sh
+
+# Runs full devnet checks (status + smoke tests)
+checks: status smoke
+
+# Starts the contender load generator
+load:
+    docker compose -f etc/docker/docker-compose.yml up -d --no-deps contender
+
+# Stops the contender load generator
+load-down:
+    docker compose -f etc/docker/docker-compose.yml down contender
+
+# Stream FB's from the builder via websocket
+flashblocks:
+    @command -v flashblocks-websocket-client >/dev/null 2>&1 || go install github.com/danyalprout/flashblocks-websocket-client@latest
+    flashblocks-websocket-client ws://localhost:${L2_BUILDER_FLASHBLOCKS_PORT}
+
+# Stream logs from devnet containers (optionally specify container names)
+logs *containers:
+    docker compose --env-file etc/docker/devnet-env -f etc/docker/docker-compose.yml logs -f {{ containers }}
+
+# Stops devnet+ingress, deletes data, and starts fresh with full ingress stack
+ingress: ingress-down
+    docker compose --env-file etc/docker/devnet-env -f etc/docker/docker-compose.yml -f etc/docker/docker-compose.ingress.yml up -d --build --scale contender=0
+
+# Stops devnet+ingress and deletes all data
+ingress-down:
+    -docker compose --env-file etc/docker/devnet-env -f etc/docker/docker-compose.yml -f etc/docker/docker-compose.ingress.yml down
+    rm -rf .devnet
+
+# Stream logs from devnet+ingress containers (optionally specify container names)
+ingress-logs *containers:
+    docker compose --env-file etc/docker/devnet-env -f etc/docker/docker-compose.yml -f etc/docker/docker-compose.ingress.yml logs -f {{ containers }}
+
+# Pre-pulls Docker images needed for devnet tests
+pull-images:
+    docker build -t devnet-setup:local -f etc/docker/Dockerfile.devnet .
+    docker pull ghcr.io/paradigmxyz/reth:v1.10.2
+    docker pull sigp/lighthouse:v8.0.1
+    docker pull us-docker.pkg.dev/oplabs-tools-artifacts/images/op-batcher:v1.16.3
+
+# Runs devnet tests (requires Docker)
+tests: _install-nextest _build-contracts
+    cargo nextest run -p devnet
+
+# Runs devnet tests with ci profile for minimal disk usage
+tests-ci: _install-nextest _build-contracts
+    cargo nextest run --locked -p devnet --cargo-profile ci
+
+[private]
+_install-nextest:
+    @command -v cargo-nextest >/dev/null 2>&1 || cargo install cargo-nextest
+
+[private]
+_build-contracts:
+    cd crates/utilities/test-utils/contracts && forge soldeer install && forge build

--- a/etc/docker/README.md
+++ b/etc/docker/README.md
@@ -26,10 +26,10 @@ All services read configuration from `devnet-env` in this directory. The devnet 
 The easiest way to interact with Docker is through the Justfile recipes:
 
 ```bash
-just devnet        # Start fresh devnet (stops existing, clears data, rebuilds)
-just devnet-down   # Stop devnet and remove data
-just devnet-logs   # Stream logs from all containers
-just devnet-status # Check block numbers and sync status
+just devnet up     # Start fresh devnet (stops existing, clears data, rebuilds)
+just devnet down   # Stop devnet and remove data
+just devnet logs   # Stream logs from all containers
+just devnet status # Check block numbers and sync status
 ```
 
 To build the client image directly:

--- a/etc/scripts/devnet/setup-l1.sh
+++ b/etc/scripts/devnet/setup-l1.sh
@@ -8,9 +8,9 @@ SLOT_DURATION="${SLOT_DURATION:-2}"
 L1_DATA_DIR="${L1_DATA_DIR:-/data}"
 TEMPLATE_DIR="${TEMPLATE_DIR:-/templates}"
 
-# Error if genesis already exists (run devnet-down first)
+# Error if genesis already exists (run devnet down first)
 if [ -f "$OUTPUT_DIR/el/genesis.json" ] || [ -f "$OUTPUT_DIR/cl/genesis.ssz" ]; then
-  echo "ERROR: L1 genesis already exists. Run 'just devnet-down' first." >&2
+  echo "ERROR: L1 genesis already exists. Run 'just devnet down' first." >&2
   exit 1
 fi
 

--- a/etc/scripts/devnet/smoke.sh
+++ b/etc/scripts/devnet/smoke.sh
@@ -37,5 +37,5 @@ if curl -sf "$INGRESS_HEALTH_URL" >/dev/null 2>&1; then
     sleep 3  # wait for the previous tx's nonce to be reflected on-chain
     cast send --private-key $PK --rpc-url $L2_INGRESS_RPC_URL $TO --value 0.001ether --json | jq -r '"TX: \(.transactionHash) block=\(.blockNumber)"'
 else
-    echo "Ingress not running (start with: just devnet-ingress)"
+    echo "Ingress not running (start with: just devnet ingress)"
 fi


### PR DESCRIPTION
## Summary

The devnet-* recipes were cluttering the top-level help menu output from `just`. This moves them into a dedicated `devnet` module backed by `etc/docker/Justfile`, which is the natural home for docker-related tooling.

`just devnet <command>` replaces `just devnet-<command>` (e.g. `just devnet up`, `just devnet down`, `just devnet logs`). The root `default` recipe now uses `--list-submodules` so the full devnet command list is still visible when running `just`, just grouped under a `devnet:` section rather than mixed into the top-level list.

CI workflow, the docker README, and devnet scripts updated to use the new names.