### PR TITLE
feat: introduce Base V1 upgrade

### DIFF
--- a/crates/alloy/evm/src/spec_id.rs
+++ b/crates/alloy/evm/src/spec_id.rs
@@ -14,7 +14,9 @@ pub fn spec(chain_spec: impl OpHardforks, header: impl BlockHeader) -> OpSpecId 
 /// This is only intended to be used after the Bedrock, when hardforks are activated by
 /// timestamp.
 pub fn spec_by_timestamp_after_bedrock(chain_spec: impl OpHardforks, timestamp: u64) -> OpSpecId {
-    if chain_spec.is_jovian_active_at_timestamp(timestamp) {
+    if chain_spec.is_base_v1_active_at_timestamp(timestamp) {
+        OpSpecId::BASE_V1
+    } else if chain_spec.is_jovian_active_at_timestamp(timestamp) {
         OpSpecId::JOVIAN
     } else if chain_spec.is_isthmus_active_at_timestamp(timestamp) {
         OpSpecId::ISTHMUS

--- a/crates/alloy/hardforks/src/chain.rs
+++ b/crates/alloy/hardforks/src/chain.rs
@@ -7,7 +7,9 @@ use EthereumHardfork::{
     Constantinople, Dao, Frontier, GrayGlacier, Homestead, Istanbul, London, MuirGlacier, Osaka,
     Paris, Petersburg, Prague, Shanghai, SpuriousDragon, Tangerine,
 };
-use OpHardfork::{Bedrock, Canyon, Ecotone, Fjord, Granite, Holocene, Isthmus, Jovian, Regolith};
+use OpHardfork::{
+    BaseV1, Bedrock, Canyon, Ecotone, Fjord, Granite, Holocene, Isthmus, Jovian, Regolith,
+};
 use alloy_hardforks::{EthereumHardfork, EthereumHardforks, ForkCondition};
 use alloy_primitives::U256;
 
@@ -101,6 +103,7 @@ impl Index<OpHardfork> for OpChainHardforks {
             Holocene => &self.forks[Holocene.idx()].1,
             Isthmus => &self.forks[Isthmus.idx()].1,
             Jovian => &self.forks[Jovian.idx()].1,
+            BaseV1 => &self.forks[BaseV1.idx()].1,
         }
     }
 }
@@ -131,7 +134,7 @@ impl Index<EthereumHardfork> for OpChainHardforks {
 #[cfg(test)]
 mod tests {
     use OpHardfork::{
-        Bedrock, Canyon, Ecotone, Fjord, Granite, Holocene, Isthmus, Jovian, Regolith,
+        BaseV1, Bedrock, Canyon, Ecotone, Fjord, Granite, Holocene, Isthmus, Jovian, Regolith,
     };
     use alloy_hardforks::EthereumHardfork;
 
@@ -242,6 +245,18 @@ mod tests {
         assert!(
             base_sepolia_forks.is_jovian_active_at_timestamp(BASE_SEPOLIA_JOVIAN_TIMESTAMP + 1000)
         );
+    }
+
+    #[test]
+    fn is_base_v1_active_at_timestamp() {
+        // BaseV1 is not scheduled on mainnet or sepolia yet
+        let base_mainnet_forks = OpChainHardforks::base_mainnet();
+        assert!(!base_mainnet_forks.is_base_v1_active_at_timestamp(0));
+        assert!(!base_mainnet_forks.is_base_v1_active_at_timestamp(u64::MAX));
+
+        let base_sepolia_forks = OpChainHardforks::base_sepolia();
+        assert!(!base_sepolia_forks.is_base_v1_active_at_timestamp(0));
+        assert!(!base_sepolia_forks.is_base_v1_active_at_timestamp(u64::MAX));
     }
 
     #[test]

--- a/crates/alloy/hardforks/src/chain.rs
+++ b/crates/alloy/hardforks/src/chain.rs
@@ -140,7 +140,8 @@ mod tests {
 
     use super::*;
     use crate::{
-        BASE_MAINNET_BEDROCK_BLOCK, BASE_MAINNET_CANYON_TIMESTAMP, BASE_MAINNET_ECOTONE_TIMESTAMP,
+        BASE_DEVNET_0_SEPOLIA_DEV_0_JOVIAN_TIMESTAMP, BASE_MAINNET_BEDROCK_BLOCK,
+        BASE_MAINNET_CANYON_TIMESTAMP, BASE_MAINNET_ECOTONE_TIMESTAMP,
         BASE_MAINNET_FJORD_TIMESTAMP, BASE_MAINNET_GRANITE_TIMESTAMP,
         BASE_MAINNET_HOLOCENE_TIMESTAMP, BASE_MAINNET_ISTHMUS_TIMESTAMP,
         BASE_MAINNET_JOVIAN_TIMESTAMP, BASE_MAINNET_REGOLITH_TIMESTAMP, BASE_SEPOLIA_BEDROCK_BLOCK,
@@ -148,7 +149,6 @@ mod tests {
         BASE_SEPOLIA_FJORD_TIMESTAMP, BASE_SEPOLIA_GRANITE_TIMESTAMP,
         BASE_SEPOLIA_HOLOCENE_TIMESTAMP, BASE_SEPOLIA_ISTHMUS_TIMESTAMP,
         BASE_SEPOLIA_JOVIAN_TIMESTAMP, BASE_SEPOLIA_REGOLITH_TIMESTAMP,
-        BASE_DEVNET_0_SEPOLIA_DEV_0_JOVIAN_TIMESTAMP,
     };
 
     #[test]
@@ -267,11 +267,14 @@ mod tests {
 
         // BaseV1 activates alongside Jovian on devnet-0-sepolia-dev-0
         let devnet0_forks = OpChainHardforks::base_devnet_0_sepolia_dev_0();
-        assert!(!devnet0_forks.is_base_v1_active_at_timestamp(
-            BASE_DEVNET_0_SEPOLIA_DEV_0_JOVIAN_TIMESTAMP - 1
-        ));
-        assert!(devnet0_forks
-            .is_base_v1_active_at_timestamp(BASE_DEVNET_0_SEPOLIA_DEV_0_JOVIAN_TIMESTAMP));
+        assert!(
+            !devnet0_forks
+                .is_base_v1_active_at_timestamp(BASE_DEVNET_0_SEPOLIA_DEV_0_JOVIAN_TIMESTAMP - 1)
+        );
+        assert!(
+            devnet0_forks
+                .is_base_v1_active_at_timestamp(BASE_DEVNET_0_SEPOLIA_DEV_0_JOVIAN_TIMESTAMP)
+        );
     }
 
     #[test]

--- a/crates/alloy/hardforks/src/chain.rs
+++ b/crates/alloy/hardforks/src/chain.rs
@@ -148,6 +148,7 @@ mod tests {
         BASE_SEPOLIA_FJORD_TIMESTAMP, BASE_SEPOLIA_GRANITE_TIMESTAMP,
         BASE_SEPOLIA_HOLOCENE_TIMESTAMP, BASE_SEPOLIA_ISTHMUS_TIMESTAMP,
         BASE_SEPOLIA_JOVIAN_TIMESTAMP, BASE_SEPOLIA_REGOLITH_TIMESTAMP,
+        BASE_DEVNET_0_SEPOLIA_DEV_0_JOVIAN_TIMESTAMP,
     };
 
     #[test]
@@ -186,6 +187,7 @@ mod tests {
             base_mainnet_forks[Jovian],
             ForkCondition::Timestamp(BASE_MAINNET_JOVIAN_TIMESTAMP)
         );
+        assert_eq!(base_mainnet_forks[BaseV1], ForkCondition::Never);
     }
 
     #[test]
@@ -224,6 +226,7 @@ mod tests {
             base_sepolia_forks.op_fork_activation(Jovian),
             ForkCondition::Timestamp(BASE_SEPOLIA_JOVIAN_TIMESTAMP)
         );
+        assert_eq!(base_sepolia_forks[BaseV1], ForkCondition::Never);
     }
 
     #[test]
@@ -249,7 +252,7 @@ mod tests {
 
     #[test]
     fn is_base_v1_active_at_timestamp() {
-        // BaseV1 is not scheduled on mainnet or sepolia yet
+        // BaseV1 is not scheduled on mainnet or sepolia yet (ForkCondition::Never)
         let base_mainnet_forks = OpChainHardforks::base_mainnet();
         assert!(!base_mainnet_forks.is_base_v1_active_at_timestamp(0));
         assert!(!base_mainnet_forks.is_base_v1_active_at_timestamp(u64::MAX));
@@ -257,6 +260,18 @@ mod tests {
         let base_sepolia_forks = OpChainHardforks::base_sepolia();
         assert!(!base_sepolia_forks.is_base_v1_active_at_timestamp(0));
         assert!(!base_sepolia_forks.is_base_v1_active_at_timestamp(u64::MAX));
+
+        // BaseV1 is active at genesis on devnet (ForkCondition::ZERO_TIMESTAMP)
+        let devnet_forks = OpChainHardforks::devnet();
+        assert!(devnet_forks.is_base_v1_active_at_timestamp(0));
+
+        // BaseV1 activates alongside Jovian on devnet-0-sepolia-dev-0
+        let devnet0_forks = OpChainHardforks::base_devnet_0_sepolia_dev_0();
+        assert!(!devnet0_forks.is_base_v1_active_at_timestamp(
+            BASE_DEVNET_0_SEPOLIA_DEV_0_JOVIAN_TIMESTAMP - 1
+        ));
+        assert!(devnet0_forks
+            .is_base_v1_active_at_timestamp(BASE_DEVNET_0_SEPOLIA_DEV_0_JOVIAN_TIMESTAMP));
     }
 
     #[test]

--- a/crates/alloy/hardforks/src/hardfork.rs
+++ b/crates/alloy/hardforks/src/hardfork.rs
@@ -42,6 +42,8 @@ hardfork!(
         Isthmus,
         /// Jovian: <https://github.com/ethereum-optimism/specs/tree/main/specs/protocol/jovian>
         Jovian,
+        /// Base V1: First Base-specific network upgrade.
+        BaseV1,
     }
 );
 
@@ -77,7 +79,7 @@ impl OpHardfork {
     }
 
     /// Base mainnet list of hardforks.
-    pub const fn base_mainnet() -> [(Self, ForkCondition); 9] {
+    pub const fn base_mainnet() -> [(Self, ForkCondition); 10] {
         [
             (Self::Bedrock, ForkCondition::Block(BASE_MAINNET_BEDROCK_BLOCK)),
             (Self::Regolith, ForkCondition::Timestamp(BASE_MAINNET_REGOLITH_TIMESTAMP)),
@@ -88,11 +90,12 @@ impl OpHardfork {
             (Self::Holocene, ForkCondition::Timestamp(BASE_MAINNET_HOLOCENE_TIMESTAMP)),
             (Self::Isthmus, ForkCondition::Timestamp(BASE_MAINNET_ISTHMUS_TIMESTAMP)),
             (Self::Jovian, ForkCondition::Timestamp(BASE_MAINNET_JOVIAN_TIMESTAMP)),
+            (Self::BaseV1, ForkCondition::Never),
         ]
     }
 
     /// Base Sepolia list of hardforks.
-    pub const fn base_sepolia() -> [(Self, ForkCondition); 9] {
+    pub const fn base_sepolia() -> [(Self, ForkCondition); 10] {
         [
             (Self::Bedrock, ForkCondition::Block(BASE_SEPOLIA_BEDROCK_BLOCK)),
             (Self::Regolith, ForkCondition::Timestamp(BASE_SEPOLIA_REGOLITH_TIMESTAMP)),
@@ -103,11 +106,12 @@ impl OpHardfork {
             (Self::Holocene, ForkCondition::Timestamp(BASE_SEPOLIA_HOLOCENE_TIMESTAMP)),
             (Self::Isthmus, ForkCondition::Timestamp(BASE_SEPOLIA_ISTHMUS_TIMESTAMP)),
             (Self::Jovian, ForkCondition::Timestamp(BASE_SEPOLIA_JOVIAN_TIMESTAMP)),
+            (Self::BaseV1, ForkCondition::Never),
         ]
     }
 
     /// Devnet list of hardforks.
-    pub const fn devnet() -> [(Self, ForkCondition); 9] {
+    pub const fn devnet() -> [(Self, ForkCondition); 10] {
         [
             (Self::Bedrock, ForkCondition::ZERO_BLOCK),
             (Self::Regolith, ForkCondition::ZERO_TIMESTAMP),
@@ -118,11 +122,12 @@ impl OpHardfork {
             (Self::Holocene, ForkCondition::ZERO_TIMESTAMP),
             (Self::Isthmus, ForkCondition::ZERO_TIMESTAMP),
             (Self::Jovian, ForkCondition::ZERO_TIMESTAMP),
+            (Self::BaseV1, ForkCondition::ZERO_TIMESTAMP),
         ]
     }
 
     /// Base devnet-0-sepolia-dev-0 list of hardforks.
-    pub const fn base_devnet_0_sepolia_dev_0() -> [(Self, ForkCondition); 9] {
+    pub const fn base_devnet_0_sepolia_dev_0() -> [(Self, ForkCondition); 10] {
         [
             (Self::Bedrock, ForkCondition::Block(BASE_DEVNET_0_SEPOLIA_DEV_0_BEDROCK_BLOCK)),
             (
@@ -148,6 +153,7 @@ impl OpHardfork {
                 ForkCondition::Timestamp(BASE_DEVNET_0_SEPOLIA_DEV_0_ISTHMUS_TIMESTAMP),
             ),
             (Self::Jovian, ForkCondition::Timestamp(BASE_DEVNET_0_SEPOLIA_DEV_0_JOVIAN_TIMESTAMP)),
+            (Self::BaseV1, ForkCondition::ZERO_TIMESTAMP),
         ]
     }
 
@@ -169,7 +175,7 @@ mod tests {
     fn check_op_hardfork_from_str() {
         let hardfork_str = [
             "beDrOck", "rEgOlITH", "cAnYoN", "eCoToNe", "FJorD", "GRaNiTe", "hOlOcEnE", "isthMUS",
-            "jOvIaN",
+            "jOvIaN", "bAsEv1",
         ];
         let expected_hardforks = [
             OpHardfork::Bedrock,
@@ -181,6 +187,7 @@ mod tests {
             OpHardfork::Holocene,
             OpHardfork::Isthmus,
             OpHardfork::Jovian,
+            OpHardfork::BaseV1,
         ];
 
         let hardforks: alloc::vec::Vec<OpHardfork> =

--- a/crates/alloy/hardforks/src/hardfork.rs
+++ b/crates/alloy/hardforks/src/hardfork.rs
@@ -153,7 +153,7 @@ impl OpHardfork {
                 ForkCondition::Timestamp(BASE_DEVNET_0_SEPOLIA_DEV_0_ISTHMUS_TIMESTAMP),
             ),
             (Self::Jovian, ForkCondition::Timestamp(BASE_DEVNET_0_SEPOLIA_DEV_0_JOVIAN_TIMESTAMP)),
-            (Self::BaseV1, ForkCondition::ZERO_TIMESTAMP),
+            (Self::BaseV1, ForkCondition::Timestamp(BASE_DEVNET_0_SEPOLIA_DEV_0_JOVIAN_TIMESTAMP)),
         ]
     }
 

--- a/crates/alloy/hardforks/src/hardfork.rs
+++ b/crates/alloy/hardforks/src/hardfork.rs
@@ -158,6 +158,9 @@ impl OpHardfork {
                 ForkCondition::Timestamp(BASE_DEVNET_0_SEPOLIA_DEV_0_ISTHMUS_TIMESTAMP),
             ),
             (Self::Jovian, ForkCondition::Timestamp(BASE_DEVNET_0_SEPOLIA_DEV_0_JOVIAN_TIMESTAMP)),
+            // BaseV1 co-activates with Jovian on this devnet. Both resolve to OpSpecId::BASE_V1
+            // since spec_by_timestamp_after_bedrock checks BaseV1 first (newest wins). This is
+            // intentional: BaseV1 is a strict superset of Jovian on this devnet configuration.
             (Self::BaseV1, ForkCondition::Timestamp(BASE_DEVNET_0_SEPOLIA_DEV_0_JOVIAN_TIMESTAMP)),
         ]
     }

--- a/crates/alloy/hardforks/src/hardfork.rs
+++ b/crates/alloy/hardforks/src/hardfork.rs
@@ -50,6 +50,11 @@ hardfork!(
 impl OpHardfork {
     /// Reverse lookup to find the hardfork given a chain ID and block timestamp.
     /// Returns the active hardfork at the given timestamp for the specified OP chain.
+    ///
+    /// Note: standalone upgrades like [`OpHardfork::BaseV1`] are not included here because
+    /// they do not participate in the sequential cascade and have no scheduled activation
+    /// timestamp on production chains. Use [`crate::OpHardforks::is_base_v1_active_at_timestamp`]
+    /// to check those independently.
     pub fn from_chain_and_timestamp(chain: Chain, timestamp: u64) -> Option<Self> {
         let named = chain.named()?;
 

--- a/crates/alloy/hardforks/src/hardforks.rs
+++ b/crates/alloy/hardforks/src/hardforks.rs
@@ -58,4 +58,9 @@ pub trait OpHardforks: EthereumHardforks {
     fn is_jovian_active_at_timestamp(&self, timestamp: u64) -> bool {
         self.op_fork_activation(OpHardfork::Jovian).active_at_timestamp(timestamp)
     }
+
+    /// Returns `true` if [`BaseV1`](OpHardfork::BaseV1) is active at given block timestamp.
+    fn is_base_v1_active_at_timestamp(&self, timestamp: u64) -> bool {
+        self.op_fork_activation(OpHardfork::BaseV1).active_at_timestamp(timestamp)
+    }
 }

--- a/crates/consensus/genesis/src/chain/hardfork.rs
+++ b/crates/consensus/genesis/src/chain/hardfork.rs
@@ -3,6 +3,18 @@
 use alloc::string::{String, ToString};
 use core::fmt::Display;
 
+/// Hardfork configuration for Base-specific upgrades.
+#[derive(Debug, Copy, Clone, Default, Hash, Eq, PartialEq)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(deny_unknown_fields))]
+pub struct BaseHardforkConfig {
+    /// `v1` sets the activation time for the Base V1 network upgrade.
+    /// Active if `v1` != None && L2 block timestamp >= `Some(v1)`, inactive otherwise.
+    #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
+    pub v1: Option<u64>,
+}
+
 /// Hardfork configuration.
 ///
 /// See: <https://github.com/ethereum-optimism/superchain-registry/blob/8ff62ada16e14dd59d0fb94ffb47761c7fa96e01/ops/internal/config/chain.go#L102-L110>
@@ -67,6 +79,9 @@ pub struct HardForkConfig {
     /// otherwise.
     #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
     pub jovian_time: Option<u64>,
+    /// `base` contains Base-specific hardfork activation times.
+    #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
+    pub base: Option<BaseHardforkConfig>,
 }
 
 impl Display for HardForkConfig {
@@ -98,6 +113,7 @@ impl HardForkConfig {
             ("Pectra Blob Schedule", self.pectra_blob_schedule_time),
             ("Isthmus", self.isthmus_time),
             ("Jovian", self.jovian_time),
+            ("Base V1", self.base.and_then(|b| b.v1)),
         ]
         .into_iter()
     }
@@ -132,6 +148,7 @@ mod tests {
             pectra_blob_schedule_time: None,
             isthmus_time: None,
             jovian_time: None,
+            base: None,
         };
 
         let deserialized: HardForkConfig = serde_json::from_str(raw).unwrap();
@@ -178,6 +195,7 @@ mod tests {
             pectra_blob_schedule_time: None,
             isthmus_time: None,
             jovian_time: None,
+            base: None,
         };
 
         let deserialized: HardForkConfig = toml::from_str(raw).unwrap();
@@ -211,6 +229,7 @@ mod tests {
             pectra_blob_schedule_time: Some(8),
             isthmus_time: Some(9),
             jovian_time: Some(10),
+            base: Some(BaseHardforkConfig { v1: Some(11) }),
         };
 
         let mut iter = hardforks.iter();
@@ -224,6 +243,7 @@ mod tests {
         assert_eq!(iter.next(), Some(("Pectra Blob Schedule", Some(8))));
         assert_eq!(iter.next(), Some(("Isthmus", Some(9))));
         assert_eq!(iter.next(), Some(("Jovian", Some(10))));
+        assert_eq!(iter.next(), Some(("Base V1", Some(11))));
         assert_eq!(iter.next(), None);
     }
 }

--- a/crates/consensus/genesis/src/chain/mod.rs
+++ b/crates/consensus/genesis/src/chain/mod.rs
@@ -13,7 +13,7 @@ mod config;
 pub use config::{ChainConfig, L1ChainConfig};
 
 mod hardfork;
-pub use hardfork::HardForkConfig;
+pub use hardfork::{BaseHardforkConfig, HardForkConfig};
 
 mod roles;
 pub use roles::Roles;

--- a/crates/consensus/genesis/src/lib.rs
+++ b/crates/consensus/genesis/src/lib.rs
@@ -39,8 +39,8 @@ pub use system::{
 
 mod chain;
 pub use chain::{
-    AddressList, BASE_MAINNET_CHAIN_ID, BASE_SEPOLIA_CHAIN_ID, ChainConfig, HardForkConfig,
-    L1ChainConfig, Roles,
+    AddressList, BASE_MAINNET_CHAIN_ID, BASE_SEPOLIA_CHAIN_ID, BaseHardforkConfig, ChainConfig,
+    HardForkConfig, L1ChainConfig, Roles,
 };
 
 mod genesis;

--- a/crates/consensus/genesis/src/rollup.rs
+++ b/crates/consensus/genesis/src/rollup.rs
@@ -467,6 +467,8 @@ mod tests {
         assert_eq!(config.spec_id(50), base_revm::OpSpecId::HOLOCENE);
         config.hardforks.isthmus_time = Some(60);
         assert_eq!(config.spec_id(60), base_revm::OpSpecId::ISTHMUS);
+        config.hardforks.jovian_time = Some(65);
+        assert_eq!(config.spec_id(65), base_revm::OpSpecId::JOVIAN);
         config.hardforks.base = Some(crate::BaseHardforkConfig { v1: Some(70) });
         assert_eq!(config.spec_id(70), base_revm::OpSpecId::BASE_V1);
     }

--- a/crates/consensus/genesis/src/rollup.rs
+++ b/crates/consensus/genesis/src/rollup.rs
@@ -137,7 +137,9 @@ impl RollupConfig {
     /// ## Returns
     /// The active [`base_revm::OpSpecId`] for the executor.
     pub fn spec_id(&self, timestamp: u64) -> base_revm::OpSpecId {
-        if self.is_jovian_active(timestamp) {
+        if self.is_base_v1_active(timestamp) {
+            base_revm::OpSpecId::BASE_V1
+        } else if self.is_jovian_active(timestamp) {
             base_revm::OpSpecId::JOVIAN
         } else if self.is_isthmus_active(timestamp) {
             base_revm::OpSpecId::ISTHMUS
@@ -276,6 +278,17 @@ impl RollupConfig {
             && !self.is_jovian_active(timestamp.saturating_sub(self.block_time))
     }
 
+    /// Returns true if Base V1 is active at the given timestamp.
+    pub fn is_base_v1_active(&self, timestamp: u64) -> bool {
+        self.hardforks.base.as_ref().and_then(|b| b.v1).is_some_and(|t| timestamp >= t)
+    }
+
+    /// Returns true if the timestamp marks the first Base V1 block.
+    pub fn is_first_base_v1_block(&self, timestamp: u64) -> bool {
+        self.is_base_v1_active(timestamp)
+            && !self.is_base_v1_active(timestamp.saturating_sub(self.block_time))
+    }
+
     /// Returns the max sequencer drift for the given timestamp.
     pub fn max_sequencer_drift(&self, timestamp: u64) -> u64 {
         if self.is_fjord_active(timestamp) {
@@ -401,6 +414,13 @@ impl OpHardforks for RollupConfig {
                 .hardforks
                 .jovian_time
                 .map(ForkCondition::Timestamp)
+                .unwrap_or_else(|| self.op_fork_activation(OpHardfork::BaseV1)),
+            OpHardfork::BaseV1 => self
+                .hardforks
+                .base
+                .as_ref()
+                .and_then(|b| b.v1)
+                .map(ForkCondition::Timestamp)
                 .unwrap_or(ForkCondition::Never),
             _ => ForkCondition::Never,
         }
@@ -447,6 +467,8 @@ mod tests {
         assert_eq!(config.spec_id(50), base_revm::OpSpecId::HOLOCENE);
         config.hardforks.isthmus_time = Some(60);
         assert_eq!(config.spec_id(60), base_revm::OpSpecId::ISTHMUS);
+        config.hardforks.base = Some(crate::BaseHardforkConfig { v1: Some(70) });
+        assert_eq!(config.spec_id(70), base_revm::OpSpecId::BASE_V1);
     }
 
     #[test]
@@ -583,10 +605,26 @@ mod tests {
         assert!(config.is_isthmus_active(10));
         assert!(config.is_jovian_active(10));
         assert!(!config.is_jovian_active(9));
+        assert!(!config.is_base_v1_active(10));
+    }
+
+    #[test]
+    fn test_base_v1_active() {
+        use crate::BaseHardforkConfig;
+        let mut config = RollupConfig::default();
+        assert!(!config.is_base_v1_active(0));
+        config.hardforks.base = Some(BaseHardforkConfig { v1: Some(10) });
+        // BaseV1 does not cascade upward to existing forks
+        assert!(!config.is_regolith_active(10));
+        assert!(!config.is_canyon_active(10));
+        assert!(!config.is_jovian_active(10));
+        assert!(config.is_base_v1_active(10));
+        assert!(!config.is_base_v1_active(9));
     }
 
     #[test]
     fn test_is_first_fork_block() {
+        use crate::BaseHardforkConfig;
         let cfg = RollupConfig {
             hardforks: HardForkConfig {
                 regolith_time: Some(10),
@@ -599,6 +637,7 @@ mod tests {
                 pectra_blob_schedule_time: Some(80),
                 isthmus_time: Some(90),
                 jovian_time: Some(100),
+                base: Some(BaseHardforkConfig { v1: Some(110) }),
             },
             block_time: 2,
             ..Default::default()
@@ -653,6 +692,11 @@ mod tests {
         assert!(!cfg.is_first_jovian_block(98));
         assert!(cfg.is_first_jovian_block(100));
         assert!(!cfg.is_first_jovian_block(102));
+
+        // Base V1
+        assert!(!cfg.is_first_base_v1_block(108));
+        assert!(cfg.is_first_base_v1_block(110));
+        assert!(!cfg.is_first_base_v1_block(112));
     }
 
     #[test]

--- a/crates/consensus/genesis/src/rollup.rs
+++ b/crates/consensus/genesis/src/rollup.rs
@@ -471,6 +471,9 @@ mod tests {
         assert_eq!(config.spec_id(65), base_revm::OpSpecId::JOVIAN);
         config.hardforks.base = Some(crate::BaseHardforkConfig { v1: Some(70) });
         assert_eq!(config.spec_id(70), base_revm::OpSpecId::BASE_V1);
+        // BaseV1 takes precedence over Jovian when both are active at the same timestamp
+        config.hardforks.base = Some(crate::BaseHardforkConfig { v1: Some(65) });
+        assert_eq!(config.spec_id(65), base_revm::OpSpecId::BASE_V1);
     }
 
     #[test]

--- a/crates/consensus/genesis/src/rollup.rs
+++ b/crates/consensus/genesis/src/rollup.rs
@@ -415,6 +415,8 @@ impl OpHardforks for RollupConfig {
                 .jovian_time
                 .map(ForkCondition::Timestamp)
                 .unwrap_or(ForkCondition::Never),
+            // BaseV1 is standalone: not part of the OP-stack cascade chain. It only activates
+            // when explicitly configured and never implies (or is implied by) Jovian being active.
             OpHardfork::BaseV1 => self
                 .hardforks
                 .base

--- a/crates/consensus/genesis/src/rollup.rs
+++ b/crates/consensus/genesis/src/rollup.rs
@@ -414,7 +414,7 @@ impl OpHardforks for RollupConfig {
                 .hardforks
                 .jovian_time
                 .map(ForkCondition::Timestamp)
-                .unwrap_or_else(|| self.op_fork_activation(OpHardfork::BaseV1)),
+                .unwrap_or(ForkCondition::Never),
             OpHardfork::BaseV1 => self
                 .hardforks
                 .base

--- a/crates/consensus/registry/src/test_utils/base_mainnet.rs
+++ b/crates/consensus/registry/src/test_utils/base_mainnet.rs
@@ -57,6 +57,7 @@ pub const BASE_MAINNET_CONFIG: RollupConfig = RollupConfig {
         pectra_blob_schedule_time: None,
         isthmus_time: Some(BASE_MAINNET_ISTHMUS_TIMESTAMP),
         jovian_time: Some(BASE_MAINNET_JOVIAN_TIMESTAMP),
+        base: None,
     },
     batch_inbox_address: address!("ff00000000000000000000000000000000008453"),
     deposit_contract_address: address!("49048044d57e1c92a77f79988d21fa8faf74e97e"),

--- a/crates/consensus/registry/src/test_utils/base_sepolia.rs
+++ b/crates/consensus/registry/src/test_utils/base_sepolia.rs
@@ -58,6 +58,7 @@ pub const BASE_SEPOLIA_CONFIG: RollupConfig = RollupConfig {
         pectra_blob_schedule_time: Some(1742486400),
         isthmus_time: Some(BASE_SEPOLIA_ISTHMUS_TIMESTAMP),
         jovian_time: Some(BASE_SEPOLIA_JOVIAN_TIMESTAMP),
+        base: None,
     },
     batch_inbox_address: address!("ff00000000000000000000000000000000084532"),
     deposit_contract_address: address!("49f53e41452c74589e85ca1677426ba426459e85"),

--- a/crates/execution/hardforks/src/chain.rs
+++ b/crates/execution/hardforks/src/chain.rs
@@ -60,6 +60,7 @@ impl OpChainHardforksExt for OpChainHardforks {
         forks.push((OpHardfork::Isthmus.boxed(), isthmus));
 
         forks.push((OpHardfork::Jovian.boxed(), self[OpHardfork::Jovian]));
+        forks.push((OpHardfork::BaseV1.boxed(), self[OpHardfork::BaseV1]));
 
         ChainHardforks::new(forks)
     }

--- a/crates/execution/hardforks/src/chain.rs
+++ b/crates/execution/hardforks/src/chain.rs
@@ -60,7 +60,11 @@ impl OpChainHardforksExt for OpChainHardforks {
         forks.push((OpHardfork::Isthmus.boxed(), isthmus));
 
         forks.push((OpHardfork::Jovian.boxed(), self[OpHardfork::Jovian]));
-        forks.push((OpHardfork::BaseV1.boxed(), self[OpHardfork::BaseV1]));
+
+        let base_v1 = self[OpHardfork::BaseV1];
+        if base_v1 != ForkCondition::Never {
+            forks.push((OpHardfork::BaseV1.boxed(), base_v1));
+        }
 
         ChainHardforks::new(forks)
     }

--- a/crates/execution/revm/src/precompiles.rs
+++ b/crates/execution/revm/src/precompiles.rs
@@ -36,7 +36,7 @@ impl OpPrecompiles {
             OpSpecId::FJORD => fjord(),
             OpSpecId::GRANITE | OpSpecId::HOLOCENE => granite(),
             OpSpecId::ISTHMUS => isthmus(),
-            OpSpecId::OSAKA | OpSpecId::JOVIAN => jovian(),
+            OpSpecId::OSAKA | OpSpecId::JOVIAN | OpSpecId::BASE_V1 => jovian(),
         };
 
         Self { inner: EthPrecompiles { precompiles, spec: SpecId::default() }, spec }

--- a/crates/execution/revm/src/spec.rs
+++ b/crates/execution/revm/src/spec.rs
@@ -28,6 +28,8 @@ pub enum OpSpecId {
     ISTHMUS,
     /// Jovian spec id.
     JOVIAN,
+    /// Base V1 spec id.
+    BASE_V1,
     /// Osaka spec id.
     OSAKA,
 }
@@ -39,7 +41,7 @@ impl OpSpecId {
             Self::BEDROCK | Self::REGOLITH => SpecId::MERGE,
             Self::CANYON => SpecId::SHANGHAI,
             Self::ECOTONE | Self::FJORD | Self::GRANITE | Self::HOLOCENE => SpecId::CANCUN,
-            Self::ISTHMUS | Self::JOVIAN => SpecId::PRAGUE,
+            Self::ISTHMUS | Self::JOVIAN | Self::BASE_V1 => SpecId::PRAGUE,
             Self::OSAKA => SpecId::OSAKA,
         }
     }
@@ -70,6 +72,7 @@ impl FromStr for OpSpecId {
             name::HOLOCENE => Ok(Self::HOLOCENE),
             name::ISTHMUS => Ok(Self::ISTHMUS),
             name::JOVIAN => Ok(Self::JOVIAN),
+            name::BASE_V1 => Ok(Self::BASE_V1),
             eth_name::OSAKA => Ok(Self::OSAKA),
             _ => Err(UnknownHardfork),
         }
@@ -88,6 +91,7 @@ impl From<OpSpecId> for &'static str {
             OpSpecId::HOLOCENE => name::HOLOCENE,
             OpSpecId::ISTHMUS => name::ISTHMUS,
             OpSpecId::JOVIAN => name::JOVIAN,
+            OpSpecId::BASE_V1 => name::BASE_V1,
             OpSpecId::OSAKA => eth_name::OSAKA,
         }
     }
@@ -113,6 +117,8 @@ pub mod name {
     pub const ISTHMUS: &str = "Isthmus";
     /// Jovian spec name.
     pub const JOVIAN: &str = "Jovian";
+    /// Base V1 spec name.
+    pub const BASE_V1: &str = "BaseV1";
 }
 
 #[cfg(test)]
@@ -206,6 +212,25 @@ mod tests {
                     (OpSpecId::FJORD, true),
                     (OpSpecId::HOLOCENE, true),
                     (OpSpecId::ISTHMUS, true),
+                ],
+            ),
+            (
+                OpSpecId::BASE_V1,
+                vec![
+                    (SpecId::PRAGUE, true),
+                    (SpecId::SHANGHAI, true),
+                    (SpecId::CANCUN, true),
+                    (SpecId::MERGE, true),
+                ],
+                vec![
+                    (OpSpecId::BEDROCK, true),
+                    (OpSpecId::REGOLITH, true),
+                    (OpSpecId::CANYON, true),
+                    (OpSpecId::ECOTONE, true),
+                    (OpSpecId::FJORD, true),
+                    (OpSpecId::HOLOCENE, true),
+                    (OpSpecId::ISTHMUS, true),
+                    (OpSpecId::JOVIAN, true),
                 ],
             ),
         ];

--- a/crates/proof/fpvm-precompiles/src/precompiles/provider.rs
+++ b/crates/proof/fpvm-precompiles/src/precompiles/provider.rs
@@ -46,7 +46,7 @@ where
             OpSpecId::FJORD => fjord(),
             OpSpecId::GRANITE | OpSpecId::HOLOCENE => granite(),
             OpSpecId::ISTHMUS => isthmus(),
-            OpSpecId::OSAKA | OpSpecId::JOVIAN => jovian(),
+            OpSpecId::OSAKA | OpSpecId::JOVIAN | OpSpecId::BASE_V1 => jovian(),
         };
 
         let accelerated_precompiles = match spec {
@@ -56,7 +56,7 @@ where
             OpSpecId::ECOTONE | OpSpecId::FJORD => accelerated_ecotone::<H, O>(),
             OpSpecId::GRANITE | OpSpecId::HOLOCENE => accelerated_granite::<H, O>(),
             OpSpecId::ISTHMUS => accelerated_isthmus::<H, O>(),
-            OpSpecId::OSAKA | OpSpecId::JOVIAN => accelerated_jovian::<H, O>(),
+            OpSpecId::OSAKA | OpSpecId::JOVIAN | OpSpecId::BASE_V1 => accelerated_jovian::<H, O>(),
         };
 
         Self {

--- a/crates/proof/tee/core/src/config/defaults.rs
+++ b/crates/proof/tee/core/src/config/defaults.rs
@@ -208,6 +208,8 @@ mod tests {
 
         // Regolith should also be active at genesis
         assert_eq!(config.hardforks.regolith_time, Some(0));
+        assert_eq!(config.hardforks.jovian_time, Some(0));
+        assert_eq!(config.hardforks.base.unwrap().v1, Some(0));
     }
 
     #[test]

--- a/crates/proof/tee/core/src/config/defaults.rs
+++ b/crates/proof/tee/core/src/config/defaults.rs
@@ -5,7 +5,8 @@ use std::collections::BTreeMap;
 use alloy_eips::{eip1898::BlockNumHash, eip7840::BlobParams};
 use alloy_primitives::Address;
 use base_consensus_genesis::{
-    BaseFeeConfig, ChainGenesis, HardForkConfig, L1ChainConfig, RollupConfig, SystemConfig,
+    BaseFeeConfig, BaseHardforkConfig, ChainGenesis, HardForkConfig, L1ChainConfig, RollupConfig,
+    SystemConfig,
 };
 
 /// Create a default rollup config matching Go's `DefaultDeployConfig()`.
@@ -53,7 +54,7 @@ pub fn default_rollup_config() -> RollupConfig {
             pectra_blob_schedule_time: None,
             isthmus_time: Some(0),
             jovian_time: Some(0),
-            base: None,
+            base: Some(BaseHardforkConfig { v1: Some(0) }),
         },
 
         // Base fee config

--- a/crates/proof/tee/core/src/config/defaults.rs
+++ b/crates/proof/tee/core/src/config/defaults.rs
@@ -53,6 +53,7 @@ pub fn default_rollup_config() -> RollupConfig {
             pectra_blob_schedule_time: None,
             isthmus_time: Some(0),
             jovian_time: Some(0),
+            base: None,
         },
 
         // Base fee config

--- a/docs/guides/UPGRADES.md
+++ b/docs/guides/UPGRADES.md
@@ -126,15 +126,13 @@ Also update `HardForkConfig::iter()` to include the new entry, and re-export any
 
 **File:** [`crates/consensus/genesis/src/rollup.rs`](https://github.com/base/base/blob/main/crates/consensus/genesis/src/rollup.rs)
 
-Add `is_X_active` and `is_first_X_block` after the previous upgrade's methods. Update the previous terminal upgrade to cascade into the new one:
+Add `is_X_active` and `is_first_X_block` after the previous upgrade's methods.
+
+There are two patterns depending on whether the new upgrade is **standalone** or **cascading**:
+
+**Standalone** (e.g. `pectra_blob_schedule`, `BaseV1`) — activated independently, never implied by a later upgrade being active. Use this pattern when the upgrade affects only protocol-level behavior and is not a prerequisite for the next upgrade:
 
 ```rust
-/// Returns true if Jovian is active at the given timestamp.
-pub fn is_jovian_active(&self, timestamp: u64) -> bool {
-    self.hardforks.jovian_time.is_some_and(|t| timestamp >= t)
-        || self.is_base_v1_active(timestamp)  // <-- cascade to next fork
-}
-
 /// Returns true if Base V1 is active at the given timestamp.
 pub fn is_base_v1_active(&self, timestamp: u64) -> bool {
     self.hardforks.base.as_ref().and_then(|b| b.v1).is_some_and(|t| timestamp >= t)
@@ -147,16 +145,31 @@ pub fn is_first_base_v1_block(&self, timestamp: u64) -> bool {
 }
 ```
 
-> **Note on standalone upgrades:** Some upgrades (e.g. `pectra_blob_schedule`, `BaseV1`) do not participate in the cascade — they are activated independently. For these, omit the `|| self.is_next_active(timestamp)` call and do not cascade the previous upgrade into them.
+The previous terminal upgrade's `is_X_active` method is left unchanged (no cascade added).
 
-Also update `op_fork_activation` in `impl OpHardforks for RollupConfig` to add the new arm and update the previous terminal arm's fallback:
+**Cascading** (e.g. `Canyon`, `Ecotone`, `Isthmus`) — the previous upgrade is considered active whenever the new one is. Update the previous terminal upgrade's method and add the new one:
+
+```rust
+/// Returns true if Jovian is active at the given timestamp.
+pub fn is_jovian_active(&self, timestamp: u64) -> bool {
+    self.hardforks.jovian_time.is_some_and(|t| timestamp >= t)
+        || self.is_next_active(timestamp)  // <-- cascade to next fork
+}
+
+/// Returns true if Next is active at the given timestamp.
+pub fn is_next_active(&self, timestamp: u64) -> bool {
+    self.hardforks.next_time.is_some_and(|t| timestamp >= t)
+}
+```
+
+Also update `op_fork_activation` in `impl OpHardforks for RollupConfig` to add the new arm. For **standalone** upgrades, the previous arm keeps `unwrap_or(ForkCondition::Never)`:
 
 ```rust
 OpHardfork::Jovian => self
     .hardforks
     .jovian_time
     .map(ForkCondition::Timestamp)
-    .unwrap_or_else(|| self.op_fork_activation(OpHardfork::BaseV1)),  // <-- cascade
+    .unwrap_or(ForkCondition::Never),  // standalone: no cascade
 OpHardfork::BaseV1 => self
     .hardforks
     .base
@@ -166,6 +179,8 @@ OpHardfork::BaseV1 => self
     .unwrap_or(ForkCondition::Never),
 _ => ForkCondition::Never,  // required: OpHardfork is #[non_exhaustive]
 ```
+
+For **cascading** upgrades, replace the previous arm's `unwrap_or(ForkCondition::Never)` with `.unwrap_or_else(|| self.op_fork_activation(OpHardfork::Next))`.
 
 ---
 

--- a/docs/guides/UPGRADES.md
+++ b/docs/guides/UPGRADES.md
@@ -40,7 +40,7 @@ hardfork!(
 );
 ```
 
-Then update all four chain config array methods from `[(Self, ForkCondition); N]` to `N+1` and append the new entry. Mainnet and sepolia use `ForkCondition::Never` until the upgrade is scheduled; devnets use `ForkCondition::ZERO_TIMESTAMP`:
+Then update all four chain config array methods from `[(Self, ForkCondition); N]` to `N+1` and append the new entry. Mainnet and sepolia use `ForkCondition::Never` until the upgrade is scheduled; the generic devnet uses `ForkCondition::ZERO_TIMESTAMP`:
 
 ```rust
 pub const fn base_mainnet() -> [(Self, ForkCondition); 10] {
@@ -54,6 +54,18 @@ pub const fn devnet() -> [(Self, ForkCondition); 10] {
     [
         // ... existing entries ...
         (Self::BaseV1, ForkCondition::ZERO_TIMESTAMP),
+    ]
+}
+```
+
+For named devnets like `base_devnet_0_sepolia_dev_0`, use the same timestamp as the previous upgrade rather than `ZERO_TIMESTAMP`, so the new upgrade does not activate before the one it follows:
+
+```rust
+pub const fn base_devnet_0_sepolia_dev_0() -> [(Self, ForkCondition); 10] {
+    [
+        // ... existing entries ...
+        (Self::Jovian, ForkCondition::Timestamp(BASE_DEVNET_0_SEPOLIA_DEV_0_JOVIAN_TIMESTAMP)),
+        (Self::BaseV1, ForkCondition::Timestamp(BASE_DEVNET_0_SEPOLIA_DEV_0_JOVIAN_TIMESTAMP)),
     ]
 }
 ```

--- a/docs/guides/UPGRADES.md
+++ b/docs/guides/UPGRADES.md
@@ -1,0 +1,377 @@
+# Adding a New Upgrade
+
+This guide covers every code change required to introduce a new network upgrade to this repository. Changes are split into two groups: those required for every upgrade, and those that depend on whether the upgrade changes EVM execution rules.
+
+The BaseV1 upgrade is used as the running example throughout. Replace `BaseV1` / `base_v1` / `BASE_V1` with the actual upgrade name.
+
+---
+
+## Architecture overview
+
+Upgrade activation flows through three layers:
+
+1. **Config layer** — `HardForkConfig` stores an optional activation timestamp per upgrade. `RollupConfig` embeds it and exposes `is_X_active(timestamp)` helpers.
+2. **Trait layer** — `OpHardfork` (enum) and `OpHardforks` (trait) provide typed, generic activation checks used by both the consensus and execution layers.
+3. **Execution layer** — `OpSpecId` maps the active upgrade to an EVM spec. `spec_by_timestamp_after_bedrock` and `RollupConfig::spec_id` resolve which spec to use. `OpPrecompiles` routes to the correct precompile set.
+
+---
+
+## Part 1 — Required for every upgrade
+
+### 1. Add the variant to the `OpHardfork` enum
+
+> The enum is named `OpHardfork` for historical reasons; new entries still represent upgrades.
+
+**File:** [`crates/alloy/hardforks/src/hardfork.rs`](https://github.com/base/base/blob/main/crates/alloy/hardforks/src/hardfork.rs)
+
+Inside the `hardfork!` macro, append the new variant after the current last entry:
+
+```rust
+hardfork!(
+    #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+    #[derive(Default)]
+    OpHardfork {
+        // ... existing variants ...
+        /// Jovian: <https://github.com/ethereum-optimism/specs/tree/main/specs/protocol/jovian>
+        Jovian,
+        /// Base V1: First Base-specific network upgrade.
+        BaseV1,   // <-- add here
+    }
+);
+```
+
+Then update all four chain config array methods from `[(Self, ForkCondition); N]` to `N+1` and append the new entry. Mainnet and sepolia use `ForkCondition::Never` until the upgrade is scheduled; devnets use `ForkCondition::ZERO_TIMESTAMP`:
+
+```rust
+pub const fn base_mainnet() -> [(Self, ForkCondition); 10] {
+    [
+        // ... existing entries ...
+        (Self::BaseV1, ForkCondition::Never),
+    ]
+}
+
+pub const fn devnet() -> [(Self, ForkCondition); 10] {
+    [
+        // ... existing entries ...
+        (Self::BaseV1, ForkCondition::ZERO_TIMESTAMP),
+    ]
+}
+```
+
+Update `check_op_hardfork_from_str` in the test module to include the new upgrade variant.
+
+---
+
+### 2. Add the `OpChainHardforks` index arm
+
+**File:** [`crates/alloy/hardforks/src/chain.rs`](https://github.com/base/base/blob/main/crates/alloy/hardforks/src/chain.rs)
+
+Add `BaseV1` to the `use OpHardfork::{...}` import and add a match arm to `Index<OpHardfork>`:
+
+```rust
+use OpHardfork::{
+    BaseV1, Bedrock, Canyon, Ecotone, Fjord, Granite, Holocene, Isthmus, Jovian, Regolith,
+};
+
+impl Index<OpHardfork> for OpChainHardforks {
+    fn index(&self, hf: OpHardfork) -> &Self::Output {
+        match hf {
+            // ... existing arms ...
+            Jovian  => &self.forks[Jovian.idx()].1,
+            BaseV1  => &self.forks[BaseV1.idx()].1,  // <-- add
+        }
+    }
+}
+```
+
+---
+
+### 3. Add the config field and nested struct
+
+**File:** [`crates/consensus/genesis/src/chain/hardfork.rs`](https://github.com/base/base/blob/main/crates/consensus/genesis/src/chain/hardfork.rs)
+
+For standard upgrades (flat timestamp field), add directly to `HardForkConfig`:
+
+```rust
+/// `base_v1_time` sets the activation time for the Base V1 network upgrade.
+#[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
+pub base_v1_time: Option<u64>,
+```
+
+For namespaced upgrades with the `{ "base": { "v1": <timestamp> } }` JSON shape, define a sub-struct and embed it:
+
+```rust
+/// Hardfork configuration for Base-specific upgrades.
+#[derive(Debug, Copy, Clone, Default, Hash, Eq, PartialEq)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(deny_unknown_fields))]
+pub struct BaseHardforkConfig {
+    #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
+    pub v1: Option<u64>,
+}
+
+pub struct HardForkConfig {
+    // ... existing fields ...
+    #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
+    pub base: Option<BaseHardforkConfig>,
+}
+```
+
+Also update `HardForkConfig::iter()` to include the new entry, and re-export any new public types from `crates/consensus/genesis/src/chain/mod.rs` and `crates/consensus/genesis/src/lib.rs`.
+
+---
+
+### 4. Add activation methods to `RollupConfig`
+
+**File:** [`crates/consensus/genesis/src/rollup.rs`](https://github.com/base/base/blob/main/crates/consensus/genesis/src/rollup.rs)
+
+Add `is_X_active` and `is_first_X_block` after the previous upgrade's methods. Update the previous terminal upgrade to cascade into the new one:
+
+```rust
+/// Returns true if Jovian is active at the given timestamp.
+pub fn is_jovian_active(&self, timestamp: u64) -> bool {
+    self.hardforks.jovian_time.is_some_and(|t| timestamp >= t)
+        || self.is_base_v1_active(timestamp)  // <-- cascade to next fork
+}
+
+/// Returns true if Base V1 is active at the given timestamp.
+pub fn is_base_v1_active(&self, timestamp: u64) -> bool {
+    self.hardforks.base.as_ref().and_then(|b| b.v1).is_some_and(|t| timestamp >= t)
+}
+
+/// Returns true if the timestamp marks the first Base V1 block.
+pub fn is_first_base_v1_block(&self, timestamp: u64) -> bool {
+    self.is_base_v1_active(timestamp)
+        && !self.is_base_v1_active(timestamp.saturating_sub(self.block_time))
+}
+```
+
+> **Note on standalone upgrades:** Some upgrades (e.g. `pectra_blob_schedule`, `BaseV1`) do not participate in the cascade — they are activated independently. For these, omit the `|| self.is_next_active(timestamp)` call and do not cascade the previous upgrade into them.
+
+Also update `op_fork_activation` in `impl OpHardforks for RollupConfig` to add the new arm and update the previous terminal arm's fallback:
+
+```rust
+OpHardfork::Jovian => self
+    .hardforks
+    .jovian_time
+    .map(ForkCondition::Timestamp)
+    .unwrap_or_else(|| self.op_fork_activation(OpHardfork::BaseV1)),  // <-- cascade
+OpHardfork::BaseV1 => self
+    .hardforks
+    .base
+    .as_ref()
+    .and_then(|b| b.v1)
+    .map(ForkCondition::Timestamp)
+    .unwrap_or(ForkCondition::Never),
+_ => ForkCondition::Never,  // required: OpHardfork is #[non_exhaustive]
+```
+
+---
+
+### 5. Add the trait method
+
+**File:** [`crates/alloy/hardforks/src/hardforks.rs`](https://github.com/base/base/blob/main/crates/alloy/hardforks/src/hardforks.rs)
+
+```rust
+/// Returns `true` if [`BaseV1`](OpHardfork::BaseV1) is active at given block timestamp.
+fn is_base_v1_active_at_timestamp(&self, timestamp: u64) -> bool {
+    self.op_fork_activation(OpHardfork::BaseV1).active_at_timestamp(timestamp)
+}
+```
+
+---
+
+### 6. Update timestamp constants and test fixtures
+
+**Files:**
+- [`crates/alloy/hardforks/src/mainnet.rs`](https://github.com/base/base/blob/main/crates/alloy/hardforks/src/mainnet.rs)
+- [`crates/alloy/hardforks/src/sepolia.rs`](https://github.com/base/base/blob/main/crates/alloy/hardforks/src/sepolia.rs)
+- [`crates/alloy/hardforks/src/devnet_0_sepolia_dev_0.rs`](https://github.com/base/base/blob/main/crates/alloy/hardforks/src/devnet_0_sepolia_dev_0.rs)
+- [`crates/alloy/hardforks/src/lib.rs`](https://github.com/base/base/blob/main/crates/alloy/hardforks/src/lib.rs)
+- [`crates/consensus/registry/src/test_utils/base_mainnet.rs`](https://github.com/base/base/blob/main/crates/consensus/registry/src/test_utils/base_mainnet.rs)
+- [`crates/consensus/registry/src/test_utils/base_sepolia.rs`](https://github.com/base/base/blob/main/crates/consensus/registry/src/test_utils/base_sepolia.rs)
+
+Add named constants once an activation timestamp is confirmed:
+
+```rust
+// mainnet.rs
+/// Base V1 mainnet activation timestamp.
+pub const BASE_MAINNET_BASE_V1_TIMESTAMP: u64 = <timestamp>;
+
+// sepolia.rs
+/// Base V1 sepolia activation timestamp.
+pub const BASE_SEPOLIA_BASE_V1_TIMESTAMP: u64 = <timestamp>;
+```
+
+Re-export from `lib.rs` alongside the other timestamp constants.
+
+Update the `HardForkConfig` literal in both registry fixture files:
+
+```rust
+hardforks: HardForkConfig {
+    // ... existing fields ...
+    jovian_time: Some(BASE_MAINNET_JOVIAN_TIMESTAMP),
+    base: Some(BaseHardforkConfig { v1: Some(BASE_MAINNET_BASE_V1_TIMESTAMP) }),
+},
+```
+
+Until an activation timestamp is confirmed, leave `base: None` and the chain arrays at `ForkCondition::Never`.
+
+---
+
+### 7. Update the default rollup config
+
+**File:** [`crates/proof/tee/core/src/config/defaults.rs`](https://github.com/base/base/blob/main/crates/proof/tee/core/src/config/defaults.rs)
+
+The `default_rollup_config()` function sets all upgrades active at genesis for dev use. Add the new upgrade:
+
+```rust
+hardforks: HardForkConfig {
+    // ... existing fields ...
+    jovian_time: Some(0),
+    base: Some(BaseHardforkConfig { v1: Some(0) }),
+},
+```
+
+---
+
+### 8. Verify the upgrade consistency tests
+
+**File:** [`crates/consensus/registry/tests/hardfork_consistency.rs`](https://github.com/base/base/blob/main/crates/consensus/registry/tests/hardfork_consistency.rs)
+
+These tests assert that `BASE_MAINNET_CONFIG.op_fork_activation(fork)` matches `OpChainHardforks::base_mainnet().op_fork_activation(fork)` for every `OpHardfork` variant. They should pass without changes as long as both sides consistently return `ForkCondition::Never` for an unscheduled upgrade or the same timestamp once scheduled.
+
+If there is a known discrepancy (e.g. the cascade causes a mismatch for an unset upgrade), add a skip with an explanatory comment as done for `Regolith`:
+
+```rust
+if *fork == OpHardfork::BaseV1 {
+    continue; // explanation of why the two sides differ
+}
+```
+
+---
+
+## Part 2 — Required when the upgrade changes EVM execution
+
+Skip this section if the upgrade only affects protocol-level behavior (batch decoding, derivation rules, system config) without introducing new EVM opcodes, precompile addresses, or gas rule changes.
+
+### 9. Add the `OpSpecId` variant
+
+**File:** [`crates/execution/revm/src/spec.rs`](https://github.com/base/base/blob/main/crates/execution/revm/src/spec.rs)
+
+```rust
+pub enum OpSpecId {
+    // ... existing variants ...
+    JOVIAN,
+    BASE_V1,  // <-- add
+    OSAKA,
+}
+```
+
+Extend `into_eth_spec()` — if no new Ethereum EL upgrade is paired, reuse the previous mapping:
+
+```rust
+Self::ISTHMUS | Self::JOVIAN | Self::BASE_V1 => SpecId::PRAGUE,
+```
+
+Add the string name and wire up `FromStr` and `From<OpSpecId> for &'static str`:
+
+```rust
+// name module
+pub const BASE_V1: &str = "BaseV1";
+
+// FromStr
+name::BASE_V1 => Ok(Self::BASE_V1),
+
+// From<OpSpecId> for &'static str
+OpSpecId::BASE_V1 => name::BASE_V1,
+```
+
+---
+
+### 10. Route precompiles
+
+**File:** [`crates/execution/revm/src/precompiles.rs`](https://github.com/base/base/blob/main/crates/execution/revm/src/precompiles.rs)
+
+If the upgrade introduces new precompiles, create a new `base_v1()` function. If it reuses the previous set, extend the existing arm:
+
+```rust
+// Reuse previous precompile set
+OpSpecId::OSAKA | OpSpecId::JOVIAN | OpSpecId::BASE_V1 => jovian(),
+
+// Or add a new set
+OpSpecId::BASE_V1 => base_v1(),
+```
+
+Export any new precompile module from `lib.rs`.
+
+---
+
+### 11. Update spec resolution
+
+**File:** [`crates/alloy/evm/src/spec_id.rs`](https://github.com/base/base/blob/main/crates/alloy/evm/src/spec_id.rs)
+
+Add the new upgrade as the first check (newest upgrade wins):
+
+```rust
+pub fn spec_by_timestamp_after_bedrock(chain_spec: impl OpHardforks, timestamp: u64) -> OpSpecId {
+    if chain_spec.is_base_v1_active_at_timestamp(timestamp) {
+        OpSpecId::BASE_V1
+    } else if chain_spec.is_jovian_active_at_timestamp(timestamp) {
+        OpSpecId::JOVIAN
+    } // ... remaining checks unchanged
+}
+```
+
+**File:** [`crates/consensus/genesis/src/rollup.rs`](https://github.com/base/base/blob/main/crates/consensus/genesis/src/rollup.rs)
+
+Same pattern in the `#[cfg(feature = "revm")] impl RollupConfig` block:
+
+```rust
+pub fn spec_id(&self, timestamp: u64) -> base_revm::OpSpecId {
+    if self.is_base_v1_active(timestamp) {
+        base_revm::OpSpecId::BASE_V1
+    } else if self.is_jovian_active(timestamp) {
+        base_revm::OpSpecId::JOVIAN
+    } // ... remaining checks unchanged
+}
+```
+
+---
+
+### 12. Update the reth `ChainHardforks` builder
+
+**File:** [`crates/execution/hardforks/src/chain.rs`](https://github.com/base/base/blob/main/crates/execution/hardforks/src/chain.rs)
+
+Append the new upgrade in `to_chain_hardforks()`. If it pairs with a new Ethereum upgrade (like Canyon→Shanghai), push both; if not, push only the OP upgrade entry:
+
+```rust
+// No paired Ethereum hardfork
+forks.push((OpHardfork::Jovian.boxed(), self[OpHardfork::Jovian]));
+forks.push((OpHardfork::BaseV1.boxed(), self[OpHardfork::BaseV1]));  // <-- add
+```
+
+---
+
+## Checklist
+
+### Always required
+
+- [ ] `OpHardfork` variant added in `hardfork.rs`; all four chain arrays updated
+- [ ] `Index<OpHardfork>` arm added in `chain.rs`
+- [ ] Config field (flat or nested struct) added to `HardForkConfig` in `hardfork.rs`; `iter()` updated; new types re-exported
+- [ ] `is_X_active` + `is_first_X_block` added to `RollupConfig`; `op_fork_activation` arm added; previous terminal upgrade cascades to new one (unless standalone)
+- [ ] `is_X_active_at_timestamp` added to `OpHardforks` trait
+- [ ] Timestamp constants added to `mainnet.rs`, `sepolia.rs`, `devnet_0_sepolia_dev_0.rs`; re-exported from `lib.rs`
+- [ ] Registry fixtures (`base_mainnet.rs`, `base_sepolia.rs`) updated
+- [ ] Default rollup config updated (`defaults.rs`)
+- [ ] Upgrade consistency tests pass
+
+### Required when EVM execution changes
+
+- [ ] `OpSpecId` variant added with `into_eth_spec`, `FromStr`, `From<&str>`, `name::X`
+- [ ] Precompile match arm updated (or new precompile set added)
+- [ ] `spec_by_timestamp_after_bedrock` updated (`alloy/evm/src/spec_id.rs`)
+- [ ] `RollupConfig::spec_id` updated (`consensus/genesis/src/rollup.rs`)
+- [ ] `to_chain_hardforks` updated (`execution/hardforks/src/chain.rs`)


### PR DESCRIPTION
## Summary

Wires up the Base V1 network upgrade across the repository. The upgrade uses a nested config format (`hardforks.base.v1`) to distinguish Base-specific upgrades from the OP stack hardfork chain. It is currently disabled on mainnet and sepolia (`ForkCondition::Never`) and active at genesis on devnets.

Changes span the full upgrade stack:

- `OpHardfork::BaseV1` variant added to the enum and all four chain config arrays
- `BaseHardforkConfig` struct introduced with nested serde shape `{ "base": { "v1": <timestamp> } }`
- `is_base_v1_active` / `is_first_base_v1_block` added to `RollupConfig`; `is_base_v1_active_at_timestamp` added to the `OpHardforks` trait
- `OpSpecId::BASE_V1` added, mapped to the Prague EL spec, routing to `jovian()` precompiles
- `spec_by_timestamp_after_bedrock` and `RollupConfig::spec_id` updated to resolve `BASE_V1` before `JOVIAN`
- `to_chain_hardforks` updated to include `BaseV1` in reth's `ChainHardforks`
- Registry fixtures and default rollup config updated
- `docs/guides/UPGRADES.md` added as a canonical checklist for wiring future upgrades

Makes progress on #1194