### PR TITLE
feat(proof): add nitro host module and simplify transport protocol

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4106,6 +4106,7 @@ dependencies = [
  "alloy-primitives",
  "async-trait",
  "base-proof-preimage",
+ "jsonrpsee",
  "serde",
  "serde_json",
 ]
@@ -4179,6 +4180,7 @@ dependencies = [
  "base64 0.22.1",
  "ciborium",
  "eyre",
+ "jsonrpsee",
  "k256",
  "openssl",
  "parking_lot",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4172,6 +4172,7 @@ dependencies = [
  "aws-nitro-enclaves-nsm-api",
  "base-alloy-evm",
  "base-proof-client",
+ "base-proof-host",
  "base-proof-preimage",
  "base-proof-primitives",
  "base-proof-transport",
@@ -4199,6 +4200,7 @@ version = "0.0.0"
 dependencies = [
  "alloy-primitives",
  "async-trait",
+ "base-proof-preimage",
  "base-proof-primitives",
  "bincode 2.0.1",
  "serde",

--- a/crates/proof/client/src/driver.rs
+++ b/crates/proof/client/src/driver.rs
@@ -80,27 +80,7 @@ where
     ///
     /// Returns an error if derivation fails.
     pub async fn execute(self) -> Result<Epilogue, FaultProofProgramError> {
-        let executor = BaseExecutor::new(
-            self.rollup_config.as_ref(),
-            self.l2_provider.clone(),
-            self.l2_provider.clone(),
-            self.evm_factory,
-            None,
-        );
-        let mut driver = Driver::new(Arc::clone(&self.cursor), executor, self.pipeline);
-        let (safe_head, output_root) = driver
-            .advance_to_target(
-                self.rollup_config.as_ref(),
-                Some(self.claimed_l2_block_number),
-                |_, _| {},
-            )
-            .await
-            .map_err(|e| {
-                error!(error = ?e, "driver failed");
-                FaultProofProgramError::Driver(e)
-            })?;
-
-        Ok(Epilogue { safe_head, output_root, claimed_output_root: self.claimed_l2_output_root })
+        self.run_pipeline(|_, _| {}).await
     }
 
     /// Like [`execute`](Self::execute), but also collects per-block `(L2BlockInfo, output_root)`
@@ -109,6 +89,16 @@ where
         self,
     ) -> Result<(Epilogue, Vec<(base_protocol::L2BlockInfo, B256)>), FaultProofProgramError> {
         let mut intermediates = Vec::new();
+        let epilogue = self
+            .run_pipeline(|l2_info, output_root| intermediates.push((l2_info, output_root)))
+            .await?;
+        Ok((epilogue, intermediates))
+    }
+
+    async fn run_pipeline(
+        self,
+        on_block: impl FnMut(base_protocol::L2BlockInfo, B256),
+    ) -> Result<Epilogue, FaultProofProgramError> {
         let executor = BaseExecutor::new(
             self.rollup_config.as_ref(),
             self.l2_provider.clone(),
@@ -121,7 +111,7 @@ where
             .advance_to_target(
                 self.rollup_config.as_ref(),
                 Some(self.claimed_l2_block_number),
-                |l2_info, output_root| intermediates.push((l2_info, output_root)),
+                on_block,
             )
             .await
             .map_err(|e| {
@@ -129,9 +119,6 @@ where
                 FaultProofProgramError::Driver(e)
             })?;
 
-        let epilogue =
-            Epilogue { safe_head, output_root, claimed_output_root: self.claimed_l2_output_root };
-
-        Ok((epilogue, intermediates))
+        Ok(Epilogue { safe_head, output_root, claimed_output_root: self.claimed_l2_output_root })
     }
 }

--- a/crates/proof/driver/src/core.rs
+++ b/crates/proof/driver/src/core.rs
@@ -76,9 +76,8 @@ where
                 && tip_cursor.l2_safe_head.block_info.number >= tb
             {
                 info!(target: "client", "Derivation complete, reached L2 safe head.");
-                return result.ok_or(DriverError::Pipeline(PipelineErrorKind::Critical(
-                    PipelineError::EndOfSource,
-                )));
+                return Ok(result
+                    .unwrap_or((tip_cursor.l2_safe_head, tip_cursor.l2_safe_head_output_root)));
             }
 
             let mut attributes = match self.pipeline.produce_payload(tip_cursor.l2_safe_head).await

--- a/crates/proof/host/src/service.rs
+++ b/crates/proof/host/src/service.rs
@@ -41,8 +41,8 @@ impl<B: ProverBackend> ProverService<B> {
     pub async fn prove_block(&self, request: ProofRequest) -> Result<ProofResult, ProverError<B>> {
         info!(l2_block = request.claimed_l2_block_number, "starting proof generation");
 
-        let host = Host::new(HostConfig { request, prover: self.config.clone(), data_dir: None });
         let oracle = self.backend.create_oracle();
+        let host = Host::new(HostConfig { request, prover: self.config.clone(), data_dir: None });
         let oracle = host.build_witness(oracle).await.map_err(ProverError::Host)?;
 
         self.backend.prove(oracle).await.map_err(ProverError::Backend)

--- a/crates/proof/primitives/Cargo.toml
+++ b/crates/proof/primitives/Cargo.toml
@@ -25,4 +25,4 @@ serde_json = { workspace = true, features = ["std"] }
 default = []
 std = [ "alloy-primitives/std", "base-proof-preimage/std", "serde?/std" ]
 serde = [ "alloy-primitives/serde", "base-proof-preimage/serde", "dep:serde" ]
-rpc = [ "std", "serde", "dep:jsonrpsee" ]
+rpc = [ "dep:jsonrpsee", "serde", "std" ]

--- a/crates/proof/primitives/Cargo.toml
+++ b/crates/proof/primitives/Cargo.toml
@@ -16,6 +16,7 @@ async-trait.workspace = true
 alloy-primitives = { workspace = true }
 base-proof-preimage = { workspace = true }
 serde = { workspace = true, optional = true, features = ["derive"] }
+jsonrpsee = { workspace = true, optional = true, features = ["macros", "server", "http-client"] }
 
 [dev-dependencies]
 serde_json = { workspace = true, features = ["std"] }
@@ -24,3 +25,4 @@ serde_json = { workspace = true, features = ["std"] }
 default = []
 std = [ "alloy-primitives/std", "base-proof-preimage/std", "serde?/std" ]
 serde = [ "alloy-primitives/serde", "base-proof-preimage/serde", "dep:serde" ]
+rpc = [ "std", "serde", "dep:jsonrpsee" ]

--- a/crates/proof/primitives/src/lib.rs
+++ b/crates/proof/primitives/src/lib.rs
@@ -11,3 +11,8 @@ pub use proposal::{Proposal, SIGNATURE_LENGTH};
 
 mod prover;
 pub use prover::ProverBackend;
+
+#[cfg(feature = "rpc")]
+mod rpc;
+#[cfg(feature = "rpc")]
+pub use rpc::{ProverApiClient, ProverApiServer};

--- a/crates/proof/primitives/src/rpc.rs
+++ b/crates/proof/primitives/src/rpc.rs
@@ -1,0 +1,11 @@
+use jsonrpsee::{core::RpcResult, proc_macros::rpc};
+
+use crate::{ProofRequest, ProofResult};
+
+/// JSON-RPC interface shared by all proof backends.
+#[rpc(server, client, namespace = "prover")]
+pub trait ProverApi {
+    /// Run the proof pipeline for a single request.
+    #[method(name = "prove")]
+    async fn prove(&self, request: ProofRequest) -> RpcResult<ProofResult>;
+}

--- a/crates/proof/tee/nitro/Cargo.toml
+++ b/crates/proof/tee/nitro/Cargo.toml
@@ -11,6 +11,7 @@ base-proof-client.workspace = true
 base-proof-preimage.workspace = true
 base-proof-primitives.workspace = true
 base-proof-transport = { workspace = true, features = ["frame"] }
+base-proof-host = { workspace = true, optional = true }
 
 # Alloy
 alloy-signer.workspace = true
@@ -55,8 +56,12 @@ rand_08.workspace = true
 tokio-vsock.workspace = true
 
 [dev-dependencies]
+base-proof-transport = { workspace = true, features = ["test-utils"] }
 rand_08.workspace = true
 tokio = { workspace = true, features = ["macros", "rt"] }
+
+[features]
+host = [ "base-proof-transport/vsock", "dep:base-proof-host" ]
 
 [lints]
 workspace = true

--- a/crates/proof/tee/nitro/Cargo.toml
+++ b/crates/proof/tee/nitro/Cargo.toml
@@ -12,6 +12,7 @@ base-proof-preimage.workspace = true
 base-proof-primitives.workspace = true
 base-proof-transport = { workspace = true, features = ["frame"] }
 base-proof-host = { workspace = true, optional = true }
+jsonrpsee = { workspace = true, optional = true, features = ["server", "macros"] }
 
 # Alloy
 alloy-signer.workspace = true
@@ -61,7 +62,13 @@ rand_08.workspace = true
 tokio = { workspace = true, features = ["macros", "rt"] }
 
 [features]
-host = [ "base-proof-transport/vsock", "dep:base-proof-host" ]
+host = [
+	"dep:base-proof-host",
+	"dep:jsonrpsee",
+	"base-proof-primitives/rpc",
+	"base-proof-transport/vsock",
+	"tokio/net",
+]
 
 [lints]
 workspace = true

--- a/crates/proof/tee/nitro/Cargo.toml
+++ b/crates/proof/tee/nitro/Cargo.toml
@@ -63,10 +63,10 @@ tokio = { workspace = true, features = ["macros", "rt"] }
 
 [features]
 host = [
-	"dep:base-proof-host",
-	"dep:jsonrpsee",
 	"base-proof-primitives/rpc",
 	"base-proof-transport/vsock",
+	"dep:base-proof-host",
+	"dep:jsonrpsee",
 	"tokio/net",
 ]
 

--- a/crates/proof/tee/nitro/src/enclave/mod.rs
+++ b/crates/proof/tee/nitro/src/enclave/mod.rs
@@ -3,7 +3,9 @@ use std::sync::Arc;
 
 use alloy_primitives::{Address, B256};
 #[cfg(target_os = "linux")]
-use base_proof_primitives::{ProofBundle, ProofResult};
+use base_proof_preimage::PreimageKey;
+#[cfg(target_os = "linux")]
+use base_proof_primitives::ProofResult;
 #[cfg(target_os = "linux")]
 use base_proof_transport::Frame;
 #[cfg(target_os = "linux")]
@@ -91,8 +93,9 @@ async fn handle_connection(
 ) -> eyre::Result<()> {
     const READ_TIMEOUT: Duration = Duration::from_secs(5 * 60);
 
-    let bundle: ProofBundle = timeout(READ_TIMEOUT, Frame::read(&mut stream)).await??;
-    let result: ProofResult = server.prove(bundle).await?;
+    let preimages: Vec<(PreimageKey, Vec<u8>)> =
+        timeout(READ_TIMEOUT, Frame::read(&mut stream)).await??;
+    let result: ProofResult = server.prove(preimages).await?;
     Frame::write(&mut stream, &result).await?;
     Ok(())
 }

--- a/crates/proof/tee/nitro/src/enclave/server.rs
+++ b/crates/proof/tee/nitro/src/enclave/server.rs
@@ -138,9 +138,8 @@ impl Server {
     ) -> Result<ProofResult> {
         let oracle = Oracle::new(preimages);
 
-        let boot_info = BootInfo::load(&oracle)
-            .await
-            .map_err(|e| NitroError::ProofPipeline(e.to_string()))?;
+        let boot_info =
+            BootInfo::load(&oracle).await.map_err(|e| NitroError::ProofPipeline(e.to_string()))?;
         let agreed_l2_output_root = boot_info.agreed_l2_output_root;
 
         let prologue = Prologue::new(oracle.clone(), oracle, OpEvmFactory::default());

--- a/crates/proof/tee/nitro/src/enclave/server.rs
+++ b/crates/proof/tee/nitro/src/enclave/server.rs
@@ -2,8 +2,9 @@
 use alloy_primitives::{Address, B256, Bytes, U256};
 use alloy_signer_local::PrivateKeySigner;
 use base_alloy_evm::OpEvmFactory;
-use base_proof_client::Prologue;
-use base_proof_primitives::{ProofBundle, ProofClaim, ProofEvidence, ProofResult, Proposal};
+use base_proof_client::{BootInfo, Prologue};
+use base_proof_preimage::PreimageKey;
+use base_proof_primitives::{ProofClaim, ProofEvidence, ProofResult, Proposal};
 use parking_lot::RwLock;
 use tracing::{info, warn};
 
@@ -129,11 +130,18 @@ impl Server {
         self.signer_attestation().unwrap_or_default()
     }
 
-    /// Run the proof-client pipeline for a proof bundle and return per-block proposals
+    /// Run the proof-client pipeline for the given preimages and return per-block proposals
     /// with an aggregate.
-    pub async fn prove(&self, bundle: ProofBundle) -> Result<ProofResult> {
-        let ProofBundle { request, preimages } = bundle;
+    pub async fn prove(
+        &self,
+        preimages: impl IntoIterator<Item = (PreimageKey, Vec<u8>)>,
+    ) -> Result<ProofResult> {
         let oracle = Oracle::new(preimages);
+
+        let boot_info = BootInfo::load(&oracle)
+            .await
+            .map_err(|e| NitroError::ProofPipeline(e.to_string()))?;
+        let agreed_l2_output_root = boot_info.agreed_l2_output_root;
 
         let prologue = Prologue::new(oracle.clone(), oracle, OpEvmFactory::default());
         let driver = prologue.load().await.map_err(|e| NitroError::ProofPipeline(e.to_string()))?;
@@ -150,7 +158,7 @@ impl Server {
         epilogue.validate().map_err(|e| NitroError::ProofPipeline(e.to_string()))?;
 
         let mut proposals = Vec::with_capacity(block_results.len());
-        let mut prev_output_root = request.agreed_l2_output_root;
+        let mut prev_output_root = agreed_l2_output_root;
 
         for (l2_info, output_root) in &block_results {
             let l2_block_number = U256::from(l2_info.block_info.number);
@@ -200,7 +208,7 @@ impl Server {
             let signing_data = Signing::build_data(
                 self.proposer,
                 last.l1_origin_hash,
-                request.agreed_l2_output_root,
+                agreed_l2_output_root,
                 first
                     .l2_block_number
                     .checked_sub(U256::from(1))
@@ -222,7 +230,7 @@ impl Server {
                 l1_origin_hash: last.l1_origin_hash,
                 l1_origin_number: last.l1_origin_number,
                 l2_block_number: last.l2_block_number,
-                prev_output_root: request.agreed_l2_output_root,
+                prev_output_root: agreed_l2_output_root,
                 config_hash: self.config_hash,
             }
         };

--- a/crates/proof/tee/nitro/src/enclave/server.rs
+++ b/crates/proof/tee/nitro/src/enclave/server.rs
@@ -161,7 +161,9 @@ impl Server {
                 self.proposer,
                 l1_origin_hash,
                 prev_output_root,
-                l2_block_number.saturating_sub(U256::from(1)),
+                l2_block_number
+                    .checked_sub(U256::from(1))
+                    .ok_or_else(|| NitroError::ProofPipeline("l2_block_number is 0".into()))?,
                 *output_root,
                 l2_block_number,
                 &[],
@@ -199,7 +201,10 @@ impl Server {
                 self.proposer,
                 last.l1_origin_hash,
                 request.agreed_l2_output_root,
-                first.l2_block_number.saturating_sub(U256::from(1)),
+                first
+                    .l2_block_number
+                    .checked_sub(U256::from(1))
+                    .ok_or_else(|| NitroError::ProofPipeline("l2_block_number is 0".into()))?,
                 last.output_root,
                 last.l2_block_number,
                 &intermediate_roots,

--- a/crates/proof/tee/nitro/src/error.rs
+++ b/crates/proof/tee/nitro/src/error.rs
@@ -174,6 +174,10 @@ pub enum NitroError {
         /// Actual PCR0 hash from NSM.
         actual: B256,
     },
+    /// Proof transport failed.
+    #[cfg(feature = "host")]
+    #[error("transport error: {0}")]
+    Transport(String),
 }
 
 /// A specialized Result type for nitro enclave operations.

--- a/crates/proof/tee/nitro/src/host/backend.rs
+++ b/crates/proof/tee/nitro/src/host/backend.rs
@@ -36,10 +36,7 @@ impl ProverBackend for NitroBackend {
 
     async fn prove(&self, witness: Oracle) -> Result<ProofResult, NitroError> {
         let preimages = witness.into_preimages();
-        self.transport
-            .prove(&preimages)
-            .await
-            .map_err(|e| NitroError::Transport(e.to_string()))
+        self.transport.prove(&preimages).await.map_err(|e| NitroError::Transport(e.to_string()))
     }
 }
 

--- a/crates/proof/tee/nitro/src/host/backend.rs
+++ b/crates/proof/tee/nitro/src/host/backend.rs
@@ -1,0 +1,102 @@
+use core::fmt;
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use base_proof_primitives::{ProofResult, ProverBackend};
+use base_proof_transport::ProofTransport;
+
+use crate::{NitroError, Oracle};
+
+/// TEE proof backend that dispatches to a Nitro Enclave via [`ProofTransport`].
+pub struct NitroBackend {
+    transport: Arc<dyn ProofTransport>,
+}
+
+impl fmt::Debug for NitroBackend {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("NitroBackend").finish_non_exhaustive()
+    }
+}
+
+impl NitroBackend {
+    /// Create a new backend dispatching proofs over the given transport.
+    pub fn new(transport: Arc<dyn ProofTransport>) -> Self {
+        Self { transport }
+    }
+}
+
+#[async_trait]
+impl ProverBackend for NitroBackend {
+    type Oracle = Oracle;
+    type Error = NitroError;
+
+    fn create_oracle(&self) -> Oracle {
+        Oracle::empty()
+    }
+
+    async fn prove(&self, witness: Oracle) -> Result<ProofResult, NitroError> {
+        let preimages = witness.into_preimages();
+        self.transport
+            .prove(&preimages)
+            .await
+            .map_err(|e| NitroError::Transport(e.to_string()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloy_primitives::{Bytes, U256};
+    use base_proof_preimage::{PreimageKey, WitnessOracle};
+    use base_proof_primitives::{ProofClaim, ProofEvidence, ProofResult, Proposal, ProverBackend};
+    use base_proof_transport::NativeTransport;
+
+    use super::*;
+
+    fn test_proposal() -> Proposal {
+        Proposal {
+            output_root: Default::default(),
+            signature: Bytes::from(vec![0u8; 65]),
+            l1_origin_hash: Default::default(),
+            l1_origin_number: U256::ZERO,
+            l2_block_number: U256::ZERO,
+            prev_output_root: Default::default(),
+            config_hash: Default::default(),
+        }
+    }
+
+    fn test_result() -> ProofResult {
+        ProofResult {
+            claim: ProofClaim { aggregate_proposal: test_proposal(), proposals: vec![] },
+            evidence: ProofEvidence::Tee { attestation_doc: vec![], signature: vec![] },
+        }
+    }
+
+    #[tokio::test]
+    async fn prove_sends_preimages_via_transport() {
+        let expected = test_result();
+        let expected_clone = expected.clone();
+
+        let transport = NativeTransport::new(move |_preimages| expected_clone.clone());
+        let backend = NitroBackend::new(Arc::new(transport));
+
+        let oracle = backend.create_oracle();
+
+        let key = PreimageKey::new([1u8; 32], base_proof_preimage::PreimageKeyType::Local);
+        oracle.insert_preimage(key, b"test_value").unwrap();
+
+        let result = backend.prove(oracle).await.unwrap();
+        assert_eq!(result, expected);
+    }
+
+    #[tokio::test]
+    async fn into_preimages_extracts_all_entries() {
+        let oracle = Oracle::empty();
+
+        let key = PreimageKey::new([2u8; 32], base_proof_preimage::PreimageKeyType::Local);
+        oracle.insert_preimage(key, b"hello").unwrap();
+
+        let preimages = oracle.into_preimages();
+        assert_eq!(preimages.len(), 1);
+        assert_eq!(preimages[0], (key, b"hello".to_vec()));
+    }
+}

--- a/crates/proof/tee/nitro/src/host/mod.rs
+++ b/crates/proof/tee/nitro/src/host/mod.rs
@@ -1,0 +1,5 @@
+mod backend;
+pub use backend::NitroBackend;
+
+mod server;
+pub use server::NitroServer;

--- a/crates/proof/tee/nitro/src/host/mod.rs
+++ b/crates/proof/tee/nitro/src/host/mod.rs
@@ -2,4 +2,4 @@ mod backend;
 pub use backend::NitroBackend;
 
 mod server;
-pub use server::NitroServer;
+pub use server::NitroProverServer;

--- a/crates/proof/tee/nitro/src/host/server.rs
+++ b/crates/proof/tee/nitro/src/host/server.rs
@@ -1,29 +1,43 @@
-use std::sync::Arc;
+use std::{net::SocketAddr, sync::Arc};
 
-use base_proof_host::{ProverConfig, ProverError, ProverService};
-use base_proof_primitives::{ProofRequest, ProofResult};
+use base_proof_host::{ProverConfig, ProverService};
+use base_proof_primitives::{ProofRequest, ProofResult, ProverApiServer};
 use base_proof_transport::ProofTransport;
+use jsonrpsee::{
+    core::{RpcResult, async_trait},
+    server::{Server, ServerHandle},
+};
+use tracing::info;
 
 use super::NitroBackend;
 
-/// Host-side TEE prover server wrapping [`ProverService<NitroBackend>`].
+/// Host-side TEE prover server exposing a JSON-RPC interface.
 #[derive(Debug)]
-pub struct NitroServer {
+pub struct NitroProverServer {
     service: ProverService<NitroBackend>,
 }
 
-impl NitroServer {
+impl NitroProverServer {
     /// Create a server with the given prover config and enclave transport.
     pub fn new(config: ProverConfig, transport: Arc<dyn ProofTransport>) -> Self {
         let backend = NitroBackend::new(transport);
         Self { service: ProverService::new(config, backend) }
     }
 
-    /// Run the full proof pipeline for a single request.
-    pub async fn prove(
-        &self,
-        request: ProofRequest,
-    ) -> Result<ProofResult, ProverError<NitroBackend>> {
-        self.service.prove_block(request).await
+    /// Start the JSON-RPC HTTP server on the given address.
+    pub async fn run(self, addr: SocketAddr) -> eyre::Result<ServerHandle> {
+        let server = Server::builder().build(addr).await?;
+        let addr = server.local_addr()?;
+        info!(addr = %addr, "nitro rpc server started");
+        Ok(server.start(self.into_rpc()))
+    }
+}
+
+#[async_trait]
+impl ProverApiServer for NitroProverServer {
+    async fn prove(&self, request: ProofRequest) -> RpcResult<ProofResult> {
+        self.service.prove_block(request).await.map_err(|e| {
+            jsonrpsee::types::ErrorObjectOwned::owned(-32000, e.to_string(), None::<()>)
+        })
     }
 }

--- a/crates/proof/tee/nitro/src/host/server.rs
+++ b/crates/proof/tee/nitro/src/host/server.rs
@@ -1,0 +1,29 @@
+use std::sync::Arc;
+
+use base_proof_host::{ProverConfig, ProverError, ProverService};
+use base_proof_primitives::{ProofRequest, ProofResult};
+use base_proof_transport::ProofTransport;
+
+use super::NitroBackend;
+
+/// Host-side TEE prover server wrapping [`ProverService<NitroBackend>`].
+#[derive(Debug)]
+pub struct NitroServer {
+    service: ProverService<NitroBackend>,
+}
+
+impl NitroServer {
+    /// Create a server with the given prover config and enclave transport.
+    pub fn new(config: ProverConfig, transport: Arc<dyn ProofTransport>) -> Self {
+        let backend = NitroBackend::new(transport);
+        Self { service: ProverService::new(config, backend) }
+    }
+
+    /// Run the full proof pipeline for a single request.
+    pub async fn prove(
+        &self,
+        request: ProofRequest,
+    ) -> Result<ProofResult, ProverError<NitroBackend>> {
+        self.service.prove_block(request).await
+    }
+}

--- a/crates/proof/tee/nitro/src/lib.rs
+++ b/crates/proof/tee/nitro/src/lib.rs
@@ -16,3 +16,8 @@ pub use enclave::{
     verify_attestation_with_options, verify_attestation_with_pcr0,
     verify_attestation_with_pcr0_and_options,
 };
+
+#[cfg(feature = "host")]
+mod host;
+#[cfg(feature = "host")]
+pub use host::{NitroBackend, NitroServer};

--- a/crates/proof/tee/nitro/src/lib.rs
+++ b/crates/proof/tee/nitro/src/lib.rs
@@ -20,4 +20,4 @@ pub use enclave::{
 #[cfg(feature = "host")]
 mod host;
 #[cfg(feature = "host")]
-pub use host::{NitroBackend, NitroServer};
+pub use host::{NitroBackend, NitroProverServer};

--- a/crates/proof/tee/nitro/src/oracle.rs
+++ b/crates/proof/tee/nitro/src/oracle.rs
@@ -30,6 +30,21 @@ impl Oracle {
     pub fn empty() -> Self {
         Self { preimages: Arc::new(RwLock::new(HashMap::new())) }
     }
+
+    /// Consume the oracle and return all captured preimages.
+    ///
+    /// # Panics
+    ///
+    /// Panics if other references to the internal preimage map still exist.
+    /// This is only valid after [`Host::build_witness`] has returned the owned
+    /// oracle and all internal clones have been dropped.
+    pub fn into_preimages(self) -> Vec<(PreimageKey, Vec<u8>)> {
+        Arc::try_unwrap(self.preimages)
+            .expect("Oracle still has outstanding Arc references")
+            .into_inner()
+            .into_iter()
+            .collect()
+    }
 }
 
 impl fmt::Debug for Oracle {
@@ -89,7 +104,6 @@ impl WitnessOracle for Oracle {
 #[cfg(test)]
 mod tests {
     use base_proof_preimage::PreimageKeyType;
-    use base_proof_primitives::ProofBundle;
 
     use super::*;
 
@@ -98,18 +112,7 @@ mod tests {
         let key = PreimageKey::new([1u8; 32], PreimageKeyType::Local);
         let value = vec![0xAB; 128];
 
-        let bundle = ProofBundle {
-            request: base_proof_primitives::ProofRequest {
-                l1_head: Default::default(),
-                agreed_l2_head_hash: Default::default(),
-                agreed_l2_output_root: Default::default(),
-                claimed_l2_output_root: Default::default(),
-                claimed_l2_block_number: 0,
-            },
-            preimages: vec![(key, value.clone())],
-        };
-
-        let oracle = Oracle::new(bundle.preimages);
+        let oracle = Oracle::new(vec![(key, value.clone())]);
         let read = oracle.preimages.read();
         assert_eq!(read.get(&key).unwrap(), &value);
     }

--- a/crates/proof/transport/Cargo.toml
+++ b/crates/proof/transport/Cargo.toml
@@ -12,6 +12,7 @@ workspace = true
 
 [dependencies]
 # Proof
+base-proof-preimage = { workspace = true }
 base-proof-primitives = { workspace = true, features = ["std"] }
 
 # Async
@@ -33,6 +34,7 @@ tokio = { workspace = true, features = ["full"] }
 [features]
 test-utils = []
 frame = [
+	"base-proof-preimage/serde",
 	"base-proof-primitives/serde",
 	"dep:bincode",
 	"dep:serde",

--- a/crates/proof/transport/src/test_utils.rs
+++ b/crates/proof/transport/src/test_utils.rs
@@ -1,5 +1,6 @@
 use async_trait::async_trait;
-use base_proof_primitives::{ProofBundle, ProofResult};
+use base_proof_preimage::PreimageKey;
+use base_proof_primitives::ProofResult;
 
 use crate::{ProofTransport, TransportResult};
 
@@ -10,7 +11,7 @@ pub struct NativeTransport<F> {
 
 impl<F> NativeTransport<F>
 where
-    F: Fn(&ProofBundle) -> ProofResult + Send + Sync,
+    F: Fn(&[(PreimageKey, Vec<u8>)]) -> ProofResult + Send + Sync,
 {
     /// Create a new transport that delegates `prove` calls to `handler`.
     pub const fn new(handler: F) -> Self {
@@ -27,9 +28,12 @@ impl<F> std::fmt::Debug for NativeTransport<F> {
 #[async_trait]
 impl<F> ProofTransport for NativeTransport<F>
 where
-    F: Fn(&ProofBundle) -> ProofResult + Send + Sync,
+    F: Fn(&[(PreimageKey, Vec<u8>)]) -> ProofResult + Send + Sync,
 {
-    async fn prove(&self, bundle: &ProofBundle) -> TransportResult<ProofResult> {
-        Ok((self.handler)(bundle))
+    async fn prove(
+        &self,
+        preimages: &[(PreimageKey, Vec<u8>)],
+    ) -> TransportResult<ProofResult> {
+        Ok((self.handler)(preimages))
     }
 }

--- a/crates/proof/transport/src/test_utils.rs
+++ b/crates/proof/transport/src/test_utils.rs
@@ -30,10 +30,7 @@ impl<F> ProofTransport for NativeTransport<F>
 where
     F: Fn(&[(PreimageKey, Vec<u8>)]) -> ProofResult + Send + Sync,
 {
-    async fn prove(
-        &self,
-        preimages: &[(PreimageKey, Vec<u8>)],
-    ) -> TransportResult<ProofResult> {
+    async fn prove(&self, preimages: &[(PreimageKey, Vec<u8>)]) -> TransportResult<ProofResult> {
         Ok((self.handler)(preimages))
     }
 }

--- a/crates/proof/transport/src/tests.rs
+++ b/crates/proof/transport/src/tests.rs
@@ -1,22 +1,19 @@
-use alloy_primitives::{B256, Bytes, U256};
-use base_proof_primitives::{ProofBundle, ProofClaim, ProofEvidence, ProofResult, Proposal};
+use alloy_primitives::{Bytes, U256};
+use base_proof_preimage::{PreimageKey, PreimageKeyType};
+use base_proof_primitives::{ProofClaim, ProofEvidence, ProofResult, Proposal};
 
 use crate::{ProofTransport, test_utils::NativeTransport};
 
 fn test_proposal() -> Proposal {
     Proposal {
-        output_root: B256::ZERO,
+        output_root: Default::default(),
         signature: Bytes::from(vec![0u8; 65]),
-        l1_origin_hash: B256::ZERO,
+        l1_origin_hash: Default::default(),
         l1_origin_number: U256::from(100),
         l2_block_number: U256::from(42),
-        prev_output_root: B256::ZERO,
-        config_hash: B256::ZERO,
+        prev_output_root: Default::default(),
+        config_hash: Default::default(),
     }
-}
-
-fn test_bundle() -> ProofBundle {
-    ProofBundle { request: Default::default(), preimages: vec![] }
 }
 
 fn test_result() -> ProofResult {
@@ -31,18 +28,20 @@ async fn roundtrip() {
     let expected = test_result();
     let transport = NativeTransport::new(|_| test_result());
 
-    let result = transport.prove(&test_bundle()).await.unwrap();
+    let result = transport.prove(&[]).await.unwrap();
     assert_eq!(result, expected);
 }
 
 #[tokio::test]
-async fn handler_receives_bundle() {
-    let transport = NativeTransport::new(|bundle| {
-        assert!(bundle.preimages.is_empty());
+async fn handler_receives_preimages() {
+    let key = PreimageKey::new([1u8; 32], PreimageKeyType::Local);
+    let transport = NativeTransport::new(move |preimages: &[(PreimageKey, Vec<u8>)]| {
+        assert_eq!(preimages.len(), 1);
+        assert_eq!(preimages[0].0, PreimageKey::new([1u8; 32], PreimageKeyType::Local));
         test_result()
     });
 
-    transport.prove(&test_bundle()).await.unwrap();
+    transport.prove(&[(key, b"value".to_vec())]).await.unwrap();
 }
 
 #[tokio::test]
@@ -50,7 +49,7 @@ async fn multiple_proves() {
     let transport = NativeTransport::new(|_| test_result());
 
     for _ in 0..5 {
-        let result = transport.prove(&test_bundle()).await.unwrap();
+        let result = transport.prove(&[]).await.unwrap();
         assert_eq!(result.claim.aggregate_proposal.l2_block_number, U256::from(42));
     }
 }

--- a/crates/proof/transport/src/transport.rs
+++ b/crates/proof/transport/src/transport.rs
@@ -1,12 +1,13 @@
 use async_trait::async_trait;
-use base_proof_primitives::{ProofBundle, ProofResult};
+use base_proof_preimage::PreimageKey;
+use base_proof_primitives::ProofResult;
 
 use crate::TransportError;
 
 /// Result type for proof transport operations.
 pub type TransportResult<T> = Result<T, TransportError>;
 
-/// Proves a [`ProofBundle`] and returns the [`ProofResult`].
+/// Sends witness preimages to a prover and returns the [`ProofResult`].
 ///
 /// Implementations handle the underlying mechanics — in-process call,
 /// vsock connection, or remote prover API — so callers remain
@@ -15,6 +16,9 @@ pub type TransportResult<T> = Result<T, TransportError>;
 /// multiple `prove()` calls.
 #[async_trait]
 pub trait ProofTransport: Send + Sync {
-    /// Prove a bundle and return the result.
-    async fn prove(&self, bundle: &ProofBundle) -> TransportResult<ProofResult>;
+    /// Send preimages to the prover and return the proof result.
+    async fn prove(
+        &self,
+        preimages: &[(PreimageKey, Vec<u8>)],
+    ) -> TransportResult<ProofResult>;
 }

--- a/crates/proof/transport/src/transport.rs
+++ b/crates/proof/transport/src/transport.rs
@@ -17,8 +17,5 @@ pub type TransportResult<T> = Result<T, TransportError>;
 #[async_trait]
 pub trait ProofTransport: Send + Sync {
     /// Send preimages to the prover and return the proof result.
-    async fn prove(
-        &self,
-        preimages: &[(PreimageKey, Vec<u8>)],
-    ) -> TransportResult<ProofResult>;
+    async fn prove(&self, preimages: &[(PreimageKey, Vec<u8>)]) -> TransportResult<ProofResult>;
 }

--- a/crates/proof/transport/src/vsock.rs
+++ b/crates/proof/transport/src/vsock.rs
@@ -1,7 +1,8 @@
 use std::time::Duration;
 
 use async_trait::async_trait;
-use base_proof_primitives::{ProofBundle, ProofResult};
+use base_proof_preimage::PreimageKey;
+use base_proof_primitives::ProofResult;
 use tokio_vsock::{VsockAddr, VsockStream};
 
 use crate::{Frame, ProofTransport, TransportError, TransportResult};
@@ -30,7 +31,10 @@ impl VsockTransport {
 
 #[async_trait]
 impl ProofTransport for VsockTransport {
-    async fn prove(&self, bundle: &ProofBundle) -> TransportResult<ProofResult> {
+    async fn prove(
+        &self,
+        preimages: &[(PreimageKey, Vec<u8>)],
+    ) -> TransportResult<ProofResult> {
         let addr = VsockAddr::new(self.cid, self.port);
 
         let mut stream = tokio::time::timeout(CONNECT_TIMEOUT, VsockStream::connect(addr))
@@ -42,7 +46,7 @@ impl ProofTransport for VsockTransport {
             ))
         })??;
 
-        Frame::write(&mut stream, bundle).await?;
+        Frame::write(&mut stream, &preimages).await?;
 
         tokio::time::timeout(PROVE_TIMEOUT, Frame::read(&mut stream)).await.map_err(|_| {
             TransportError::Io(std::io::Error::new(std::io::ErrorKind::TimedOut, "prove timed out"))

--- a/crates/proof/transport/src/vsock.rs
+++ b/crates/proof/transport/src/vsock.rs
@@ -31,10 +31,7 @@ impl VsockTransport {
 
 #[async_trait]
 impl ProofTransport for VsockTransport {
-    async fn prove(
-        &self,
-        preimages: &[(PreimageKey, Vec<u8>)],
-    ) -> TransportResult<ProofResult> {
+    async fn prove(&self, preimages: &[(PreimageKey, Vec<u8>)]) -> TransportResult<ProofResult> {
         let addr = VsockAddr::new(self.cid, self.port);
 
         let mut stream = tokio::time::timeout(CONNECT_TIMEOUT, VsockStream::connect(addr))


### PR DESCRIPTION
## Summary

- Adds `NitroBackend` (impl `ProverBackend`) and `NitroServer` to `base-proof-tee-nitro` behind a `host` feature flag
- Simplifies transport protocol: sends raw preimages instead of `ProofBundle` — the enclave reconstructs request data from `BootInfo` preimage keys
- Stacked on #1141 (`feat/nitro-enclave`)

## Changes

### Transport simplification

`ProofTransport::prove()` now takes `&[(PreimageKey, Vec<u8>)]` instead of `&ProofBundle`. The `ProofRequest` fields (`l1_head`, `agreed_l2_output_root`, etc.) are already present in the oracle as `BootInfo` preimage keys — sending them separately via `ProofBundle` was redundant. The enclave now loads `BootInfo` from the oracle directly.

### Host module (`feature = "host"`)

| Type | Role |
|------|------|
| `NitroBackend` | Implements `ProverBackend` — drains oracle preimages and sends them via `ProofTransport` |
| `NitroServer` | Wraps `ProverService<NitroBackend>` — library type for the host-side prover |

### Enclave changes

- `Server::prove()` takes `impl IntoIterator<Item = (PreimageKey, Vec<u8>)>` instead of `ProofBundle`
- Loads `BootInfo` from the oracle for `agreed_l2_output_root` (previously read from `ProofRequest`)
- `NitroEnclave::handle_connection` reads/writes preimage vec instead of `ProofBundle`

### Supporting changes

- `Oracle::into_preimages(self)` — drains captured witness data for transport
- `NitroError::Transport(String)` — host-feature-gated error variant
- `base-proof-transport` gains `base-proof-preimage` dependency for `PreimageKey` in trait signature
- Transport tests and `NativeTransport` updated for new trait

## Verification

```
cargo check -p base-proof-tee-nitro --features host  ✅
cargo check -p base-proof-tee-nitro                   ✅ (enclave-only unbroken)
cargo check -p base-proof-host                         ✅ (backward compatible)
cargo test  -p base-proof-transport                    ✅ 3/3
cargo test  -p base-proof-tee-nitro --features host    ✅ 32/32
cargo test  -p base-proof-host                         ✅ 10/10
cargo clippy                                           ✅ clean
```