### PR TITLE
fix: add fixed back as config for tests

### DIFF
--- a/bin/builder/src/cli.rs
+++ b/bin/builder/src/cli.rs
@@ -32,6 +32,10 @@ pub struct FlashblocksArgs {
     /// building time before calculating number of fbs.
     #[arg(long = "flashblocks.leeway-time", default_value = "75", env = "FLASHBLOCK_LEEWAY_TIME")]
     pub flashblocks_leeway_time: u64,
+
+    /// Use a fixed number of flashblocks per block instead of dynamically adjusting
+    #[arg(long = "flashblocks.fixed", default_value = "false", env = "FLASHBLOCKS_FIXED")]
+    pub flashblocks_fixed: bool,
 }
 
 impl Default for FlashblocksArgs {
@@ -41,6 +45,7 @@ impl Default for FlashblocksArgs {
             flashblocks_addr: "127.0.0.1".to_string(),
             flashblocks_block_time: 250,
             flashblocks_leeway_time: 75,
+            flashblocks_fixed: false,
         }
     }
 }
@@ -168,6 +173,7 @@ impl Args {
             block_state_root_time_budget_us: self.block_state_root_time_budget_us,
             execution_metering_mode: self.execution_metering_mode,
             max_uncompressed_block_size: self.max_uncompressed_block_size,
+            fixed: self.flashblocks.flashblocks_fixed,
             metering_provider,
         })
     }
@@ -270,6 +276,18 @@ mod tests {
         assert_eq!(result.unwrap().total_execution_time_us, 500);
     }
 
+    #[rstest]
+    #[case::fixed_true(true, true)]
+    #[case::fixed_false(false, false)]
+    fn flashblocks_fixed_mode_maps_correctly(#[case] input: bool, #[case] expected: bool) {
+        let args = Args {
+            flashblocks: FlashblocksArgs { flashblocks_fixed: input, ..Default::default() },
+            ..Default::default()
+        };
+        let config = convert(args);
+        assert_eq!(config.fixed, expected);
+    }
+
     #[test]
     fn combined_overrides_work_together() {
         let args = Args {
@@ -279,6 +297,7 @@ mod tests {
             flashblocks: FlashblocksArgs {
                 flashblocks_block_time: 200,
                 flashblocks_leeway_time: 50,
+                flashblocks_fixed: true,
                 ..Default::default()
             },
             ..Default::default()
@@ -290,5 +309,6 @@ mod tests {
         assert_eq!(config.block_time_leeway, Duration::from_secs(10));
         assert_eq!(config.flashblocks_interval, Duration::from_millis(200));
         assert_eq!(config.flashblocks_leeway_time, Duration::from_millis(50));
+        assert!(config.fixed);
     }
 }

--- a/crates/builder/core/src/config.rs
+++ b/crates/builder/core/src/config.rs
@@ -63,6 +63,10 @@ pub struct BuilderConfig {
     /// Maximum cumulative uncompressed (EIP-2718 encoded) block size in bytes.
     pub max_uncompressed_block_size: Option<u64>,
 
+    /// When true, use a fixed number of flashblocks per block (block_time / interval)
+    /// instead of dynamically adjusting based on time drift.
+    pub fixed: bool,
+
     /// Resource metering provider
     pub metering_provider: SharedMeteringProvider,
 }
@@ -95,6 +99,7 @@ impl core::fmt::Debug for BuilderConfig {
             .field("block_state_root_time_budget_us", &self.block_state_root_time_budget_us)
             .field("execution_metering_mode", &self.execution_metering_mode)
             .field("max_uncompressed_block_size", &self.max_uncompressed_block_size)
+            .field("fixed", &self.fixed)
             .field("metering_provider", &self.metering_provider)
             .finish()
     }
@@ -118,6 +123,7 @@ impl Default for BuilderConfig {
             block_state_root_time_budget_us: None,
             execution_metering_mode: ExecutionMeteringMode::Off,
             max_uncompressed_block_size: None,
+            fixed: false,
             metering_provider: Arc::new(NoopMeteringProvider),
         }
     }
@@ -161,6 +167,13 @@ impl BuilderConfig {
     #[must_use]
     pub const fn with_flashblocks_interval_ms(mut self, ms: u64) -> Self {
         self.flashblocks_interval = Duration::from_millis(ms);
+        self
+    }
+
+    /// Sets the fixed flashblocks mode.
+    #[must_use]
+    pub const fn with_fixed(mut self, fixed: bool) -> Self {
+        self.fixed = fixed;
         self
     }
 

--- a/crates/builder/core/src/flashblocks/payload.rs
+++ b/crates/builder/core/src/flashblocks/payload.rs
@@ -782,6 +782,12 @@ where
 
     /// Calculate number of flashblocks, taking time drift into account.
     pub(super) fn calculate_flashblocks(&self, timestamp: u64) -> (u64, Duration) {
+        if self.config.fixed {
+            return (
+                self.config.flashblocks_per_block(),
+                self.config.flashblocks_interval - self.config.flashblocks_leeway_time,
+            );
+        }
         // We use this system time to determine remaining time to build a block
         // Things to consider:
         // FCU(a) - FCU with attributes

--- a/crates/builder/core/tests/flashblocks.rs
+++ b/crates/builder/core/tests/flashblocks.rs
@@ -14,8 +14,10 @@ use base_builder_core::{
 /// `take_bundle()` emptied the bundle state, producing an always-empty map.
 #[tokio::test]
 async fn test_flashblock_metadata_balances_and_receipts() -> eyre::Result<()> {
-    let config =
-        BuilderConfig::for_tests().with_block_time_ms(1000).with_flashblocks_leeway_time_ms(50);
+    let config = BuilderConfig::for_tests()
+        .with_block_time_ms(1000)
+        .with_flashblocks_leeway_time_ms(50)
+        .with_fixed(true);
     let rbuilder = setup_test_instance_with_builder_config(config).await?;
     let driver = rbuilder.driver().await?;
     let flashblocks_listener = rbuilder.spawn_flashblocks_listener();
@@ -99,7 +101,7 @@ async fn test_flashblock_metadata_balances_and_receipts() -> eyre::Result<()> {
 /// 2. The final payload returned by `get_payload` has a valid state root (non-zero)
 #[tokio::test]
 async fn test_state_root_computed_on_finalize() -> eyre::Result<()> {
-    let config = BuilderConfig::for_tests().with_block_time_ms(2000);
+    let config = BuilderConfig::for_tests().with_block_time_ms(2000).with_fixed(true);
     let rbuilder = setup_test_instance_with_builder_config(config).await?;
     let driver = rbuilder.driver().await?;
     let flashblocks_listener = rbuilder.spawn_flashblocks_listener();
@@ -188,8 +190,10 @@ async fn smoke_dynamic_unichain() -> eyre::Result<()> {
 
 #[tokio::test]
 async fn smoke_classic_unichain() -> eyre::Result<()> {
-    let config =
-        BuilderConfig::for_tests().with_block_time_ms(1000).with_flashblocks_leeway_time_ms(50);
+    let config = BuilderConfig::for_tests()
+        .with_block_time_ms(1000)
+        .with_flashblocks_leeway_time_ms(50)
+        .with_fixed(true);
     let rbuilder = setup_test_instance_with_builder_config(config).await?;
     let driver = rbuilder.driver().await?;
     let flashblocks_listener = rbuilder.spawn_flashblocks_listener();
@@ -213,8 +217,10 @@ async fn smoke_classic_unichain() -> eyre::Result<()> {
 
 #[tokio::test]
 async fn smoke_classic_base() -> eyre::Result<()> {
-    let config =
-        BuilderConfig::for_tests().with_block_time_ms(2000).with_flashblocks_leeway_time_ms(50);
+    let config = BuilderConfig::for_tests()
+        .with_block_time_ms(2000)
+        .with_flashblocks_leeway_time_ms(50)
+        .with_fixed(true);
     let rbuilder = setup_test_instance_with_builder_config(config).await?;
     let driver = rbuilder.driver().await?;
     let flashblocks_listener = rbuilder.spawn_flashblocks_listener();
@@ -288,7 +294,7 @@ async fn dynamic_with_full_block_lag() -> eyre::Result<()> {
 /// (historical sync), `resolve_kind` must still return a payload.
 #[tokio::test]
 async fn test_no_tx_pool_with_finalize() -> eyre::Result<()> {
-    let config = BuilderConfig::for_tests().with_block_time_ms(2000);
+    let config = BuilderConfig::for_tests().with_block_time_ms(2000).with_fixed(true);
     let rbuilder = setup_test_instance_with_builder_config(config).await?;
     let driver = rbuilder.driver().await?;
 
@@ -321,7 +327,7 @@ async fn test_no_tx_pool_with_finalize() -> eyre::Result<()> {
 
 #[tokio::test]
 async fn test_flashblocks_state_root_computed_on_finalize() -> eyre::Result<()> {
-    let config = BuilderConfig::for_tests().with_block_time_ms(1000);
+    let config = BuilderConfig::for_tests().with_block_time_ms(1000).with_fixed(true);
     let rbuilder = setup_test_instance_with_builder_config(config).await?;
     let driver = rbuilder.driver().await?;
 


### PR DESCRIPTION
Reverts b016658561f1263ebe0d8b5d5ef5645f86714e0c partially.

The fixed config for tests was needed to ensure block_time did not affect flashblock timing. Without this config, flaky tests occur This also adds back the CLI arg which is useful for benchmarking.