### PR TITLE
feat(tx-manager): TxManagerError Types & RPC Error Classification

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4392,6 +4392,9 @@ dependencies = [
 [[package]]
 name = "base-tx-manager"
 version = "0.0.0"
+dependencies = [
+ "thiserror 2.0.18",
+]
 
 [[package]]
 name = "base-txpool"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4393,6 +4393,7 @@ dependencies = [
 name = "base-tx-manager"
 version = "0.0.0"
 dependencies = [
+ "rstest",
  "thiserror 2.0.18",
 ]
 

--- a/crates/utilities/tx-manager/Cargo.toml
+++ b/crates/utilities/tx-manager/Cargo.toml
@@ -13,3 +13,6 @@ workspace = true
 
 [dependencies]
 thiserror.workspace = true
+
+[dev-dependencies]
+rstest.workspace = true

--- a/crates/utilities/tx-manager/Cargo.toml
+++ b/crates/utilities/tx-manager/Cargo.toml
@@ -12,3 +12,4 @@ repository.workspace = true
 workspace = true
 
 [dependencies]
+thiserror.workspace = true

--- a/crates/utilities/tx-manager/README.md
+++ b/crates/utilities/tx-manager/README.md
@@ -7,7 +7,11 @@ Transaction lifecycle management for Base onchain components.
 
 ## Overview
 
-- **`TxManagerError`**: Error types for transaction management operations.
+- **`TxManagerError`**: Error types for transaction management, categorized as critical
+  (non-retryable), fee/replacement (retryable via fee bumps), and infrastructure (transient/retryable).
+- **`RpcErrorClassifier`**: Maps raw RPC/geth error strings into structured `TxManagerError` variants
+  using ordered substring matching.
+- **`TxManagerResult<T>`**: Result type alias for transaction manager operations.
 - **`TxCandidate`**: Represents a candidate transaction to be submitted.
 - **`FeeCalculator`**: Calculates and bumps transaction fees.
 - **`SendState`**: Tracks the state of a transaction through its lifecycle.
@@ -18,6 +22,36 @@ Transaction lifecycle management for Base onchain components.
 - **`TxQueue`**: Queue for ordering and batching transactions.
 - **`TxMetrics`**: Metrics collection for transaction operations.
 - **`BlobTxBuilder`**: Builder for EIP-4844 blob-carrying transactions.
+
+## Error Handling
+
+`TxManagerError` variants are classified to let the send loop decide whether to retry,
+bump fees, or abort. Use `is_retryable()` and `is_already_known()` to branch on error
+type:
+
+```rust,ignore
+use base_tx_manager::{RpcErrorClassifier, TxManagerError};
+
+fn handle_rpc_error(raw_msg: &str) {
+    let err = RpcErrorClassifier::classify_rpc_error(raw_msg);
+    if err.is_already_known() {
+        // Transaction is already in the mempool — treat as success on resubmission.
+    } else if err.is_retryable() {
+        // Fee/replacement errors and transient infrastructure errors — retry with backoff.
+    } else {
+        // Critical errors (nonce conflicts, insufficient funds, reverts) — abort.
+    }
+}
+```
+
+`RpcErrorClassifier::classify_rpc_error` lowercases the input and matches against known
+geth error substrings in a fixed order (e.g., `"replacement transaction underpriced"`
+before `"transaction underpriced"`). Unrecognized strings fall through to the
+`TxManagerError::Rpc` fallback, which is conservatively treated as retryable — callers
+must enforce bounded retry counts.
+
+For custom error matching beyond the built-in classification, use
+`RpcErrorClassifier::err_string_contains_any`.
 
 ## Usage
 

--- a/crates/utilities/tx-manager/src/error.rs
+++ b/crates/utilities/tx-manager/src/error.rs
@@ -192,245 +192,115 @@ impl RpcErrorClassifier {
 
 #[cfg(test)]
 mod tests {
+    use rstest::rstest;
+
     use super::*;
 
-    // ── classify_rpc_error: known geth error strings ─────────────────────
+    // ── classify_rpc_error ───────────────────────────────────────────────
 
-    #[test]
-    fn classify_replacement_underpriced() {
-        let err = RpcErrorClassifier::classify_rpc_error("replacement transaction underpriced");
-        assert!(
-            matches!(err, TxManagerError::ReplacementUnderpriced),
-            "must return ReplacementUnderpriced, not Underpriced — ordering matters"
-        );
+    #[rstest]
+    #[case::replacement_underpriced(
+        "replacement transaction underpriced",
+        TxManagerError::ReplacementUnderpriced
+    )]
+    #[case::underpriced("transaction underpriced", TxManagerError::Underpriced)]
+    #[case::nonce_too_low("nonce too low", TxManagerError::NonceTooLow)]
+    #[case::nonce_too_high("nonce too high", TxManagerError::NonceTooHigh)]
+    #[case::insufficient_funds("insufficient funds", TxManagerError::InsufficientFunds)]
+    #[case::intrinsic_gas_too_low("intrinsic gas too low", TxManagerError::IntrinsicGasTooLow)]
+    #[case::execution_reverted("execution reverted", TxManagerError::ExecutionReverted)]
+    #[case::fee_too_low("fee too low", TxManagerError::FeeTooLow)]
+    #[case::max_fee_too_low(
+        "max fee per gas less than block base fee",
+        TxManagerError::MaxFeePerGasTooLow
+    )]
+    #[case::already_known("already known", TxManagerError::AlreadyKnown)]
+    #[case::already_in_pool("transaction already in pool", TxManagerError::AlreadyKnown)]
+    #[case::case_insensitive_upper("NONCE TOO LOW", TxManagerError::NonceTooLow)]
+    #[case::case_insensitive_mixed("Nonce Too Low", TxManagerError::NonceTooLow)]
+    #[case::substring_in_context(
+        "some context: nonce too low for account",
+        TxManagerError::NonceTooLow
+    )]
+    #[case::unknown_fallback("something unexpected", TxManagerError::Rpc("something unexpected".to_string()))]
+    #[case::preserves_casing("Some Unknown ERROR", TxManagerError::Rpc("Some Unknown ERROR".to_string()))]
+    #[case::empty_string("", TxManagerError::Rpc(String::new()))]
+    #[case::mempool_deadline_not_classified("mempool deadline expired", TxManagerError::Rpc("mempool deadline expired".to_string()))]
+    #[case::already_reserved_not_classified("nonce already reserved", TxManagerError::Rpc("nonce already reserved".to_string()))]
+    fn classify_rpc_error(#[case] input: &str, #[case] expected: TxManagerError) {
+        assert_eq!(RpcErrorClassifier::classify_rpc_error(input), expected);
     }
 
-    #[test]
-    fn classify_underpriced() {
-        let err = RpcErrorClassifier::classify_rpc_error("transaction underpriced");
-        assert!(matches!(err, TxManagerError::Underpriced));
+    // ── is_retryable ────────────────────────────────────────────────────
+
+    #[rstest]
+    #[case::nonce_too_low(TxManagerError::NonceTooLow, false)]
+    #[case::nonce_too_high(TxManagerError::NonceTooHigh, false)]
+    #[case::insufficient_funds(TxManagerError::InsufficientFunds, false)]
+    #[case::intrinsic_gas_too_low(TxManagerError::IntrinsicGasTooLow, false)]
+    #[case::execution_reverted(TxManagerError::ExecutionReverted, false)]
+    #[case::mempool_deadline(TxManagerError::MempoolDeadlineExpired, false)]
+    #[case::already_reserved(TxManagerError::AlreadyReserved, false)]
+    #[case::underpriced(TxManagerError::Underpriced, true)]
+    #[case::replacement_underpriced(TxManagerError::ReplacementUnderpriced, true)]
+    #[case::fee_too_low(TxManagerError::FeeTooLow, true)]
+    #[case::max_fee_too_low(TxManagerError::MaxFeePerGasTooLow, true)]
+    #[case::already_known(TxManagerError::AlreadyKnown, true)]
+    #[case::rpc(TxManagerError::Rpc("any error".to_string()), true)]
+    fn is_retryable(#[case] error: TxManagerError, #[case] expected: bool) {
+        assert_eq!(error.is_retryable(), expected);
     }
 
-    #[test]
-    fn classify_nonce_too_low() {
-        let err = RpcErrorClassifier::classify_rpc_error("nonce too low");
-        assert!(matches!(err, TxManagerError::NonceTooLow));
+    // ── is_already_known ────────────────────────────────────────────────
+
+    #[rstest]
+    #[case::already_known(TxManagerError::AlreadyKnown, true)]
+    #[case::nonce_too_low(TxManagerError::NonceTooLow, false)]
+    #[case::underpriced(TxManagerError::Underpriced, false)]
+    #[case::rpc_with_already_known_text(TxManagerError::Rpc("already known".to_string()), false)]
+    fn is_already_known(#[case] error: TxManagerError, #[case] expected: bool) {
+        assert_eq!(error.is_already_known(), expected);
     }
 
-    #[test]
-    fn classify_nonce_too_high() {
-        let err = RpcErrorClassifier::classify_rpc_error("nonce too high");
-        assert!(matches!(err, TxManagerError::NonceTooHigh));
+    // ── Display output ──────────────────────────────────────────────────
+
+    #[rstest]
+    #[case::nonce_too_low(TxManagerError::NonceTooLow, "nonce too low")]
+    #[case::nonce_too_high(TxManagerError::NonceTooHigh, "nonce too high")]
+    #[case::insufficient_funds(TxManagerError::InsufficientFunds, "insufficient funds")]
+    #[case::intrinsic_gas_too_low(TxManagerError::IntrinsicGasTooLow, "intrinsic gas too low")]
+    #[case::execution_reverted(TxManagerError::ExecutionReverted, "execution reverted")]
+    #[case::mempool_deadline(TxManagerError::MempoolDeadlineExpired, "mempool deadline expired")]
+    #[case::already_reserved(TxManagerError::AlreadyReserved, "nonce already reserved")]
+    #[case::underpriced(TxManagerError::Underpriced, "transaction underpriced")]
+    #[case::replacement_underpriced(
+        TxManagerError::ReplacementUnderpriced,
+        "replacement transaction underpriced"
+    )]
+    #[case::fee_too_low(TxManagerError::FeeTooLow, "fee too low")]
+    #[case::max_fee_too_low(
+        TxManagerError::MaxFeePerGasTooLow,
+        "max fee per gas less than block base fee"
+    )]
+    #[case::already_known(TxManagerError::AlreadyKnown, "transaction already known")]
+    #[case::rpc(TxManagerError::Rpc("test".to_string()), "rpc error: test")]
+    fn display_output(#[case] error: TxManagerError, #[case] expected: &str) {
+        assert_eq!(error.to_string(), expected);
     }
 
-    #[test]
-    fn classify_insufficient_funds() {
-        let err = RpcErrorClassifier::classify_rpc_error("insufficient funds");
-        assert!(matches!(err, TxManagerError::InsufficientFunds));
-    }
+    // ── err_string_contains_any ─────────────────────────────────────────
 
-    #[test]
-    fn classify_intrinsic_gas_too_low() {
-        let err = RpcErrorClassifier::classify_rpc_error("intrinsic gas too low");
-        assert!(matches!(err, TxManagerError::IntrinsicGasTooLow));
-    }
-
-    #[test]
-    fn classify_execution_reverted() {
-        let err = RpcErrorClassifier::classify_rpc_error("execution reverted");
-        assert!(matches!(err, TxManagerError::ExecutionReverted));
-    }
-
-    #[test]
-    fn classify_fee_too_low() {
-        let err = RpcErrorClassifier::classify_rpc_error("fee too low");
-        assert!(matches!(err, TxManagerError::FeeTooLow));
-    }
-
-    #[test]
-    fn classify_max_fee_per_gas_too_low() {
-        let err =
-            RpcErrorClassifier::classify_rpc_error("max fee per gas less than block base fee");
-        assert!(matches!(err, TxManagerError::MaxFeePerGasTooLow));
-    }
-
-    #[test]
-    fn classify_already_known() {
-        let err = RpcErrorClassifier::classify_rpc_error("already known");
-        assert!(matches!(err, TxManagerError::AlreadyKnown));
-    }
-
-    #[test]
-    fn classify_transaction_already_in_pool() {
-        let err = RpcErrorClassifier::classify_rpc_error("transaction already in pool");
-        assert!(matches!(err, TxManagerError::AlreadyKnown));
-    }
-
-    // ── Fallback to Rpc variant ──────────────────────────────────────────
-
-    #[test]
-    fn classify_unknown_returns_rpc_fallback() {
-        let msg = "something unexpected";
-        let err = RpcErrorClassifier::classify_rpc_error(msg);
-        assert!(matches!(err, TxManagerError::Rpc(ref s) if s == msg));
-    }
-
-    #[test]
-    fn classify_rpc_preserves_original_casing() {
-        let msg = "Some Unknown ERROR Message";
-        let err = RpcErrorClassifier::classify_rpc_error(msg);
-        assert!(matches!(err, TxManagerError::Rpc(ref s) if s == msg));
-    }
-
-    // ── Case-insensitivity ───────────────────────────────────────────────
-
-    #[test]
-    fn classify_case_insensitive_upper() {
-        let err = RpcErrorClassifier::classify_rpc_error("NONCE TOO LOW");
-        assert!(matches!(err, TxManagerError::NonceTooLow));
-    }
-
-    #[test]
-    fn classify_case_insensitive_mixed() {
-        let err = RpcErrorClassifier::classify_rpc_error("Nonce Too Low");
-        assert!(matches!(err, TxManagerError::NonceTooLow));
-    }
-
-    // ── Substring containment in context ─────────────────────────────────
-
-    #[test]
-    fn classify_substring_in_longer_message() {
-        let err = RpcErrorClassifier::classify_rpc_error("some context: nonce too low for account");
-        assert!(matches!(err, TxManagerError::NonceTooLow));
-    }
-
-    // ── err_string_contains_any ──────────────────────────────────────────
-
-    #[test]
-    fn err_string_contains_any_positive_match() {
-        assert!(RpcErrorClassifier::err_string_contains_any(
-            "nonce too low",
-            &["nonce too low", "insufficient funds"]
-        ));
-    }
-
-    #[test]
-    fn err_string_contains_any_no_match() {
-        assert!(!RpcErrorClassifier::err_string_contains_any(
-            "something else",
-            &["nonce too low", "insufficient funds"]
-        ));
-    }
-
-    #[test]
-    fn err_string_contains_any_empty_slice() {
-        assert!(!RpcErrorClassifier::err_string_contains_any("nonce too low", &[]));
-    }
-
-    #[test]
-    fn err_string_contains_any_partial_substring() {
-        assert!(RpcErrorClassifier::err_string_contains_any(
-            "error: nonce too low for account 0x123",
-            &["nonce too low"]
-        ));
-    }
-
-    #[test]
-    fn err_string_contains_any_case_insensitive() {
-        assert!(RpcErrorClassifier::err_string_contains_any("NONCE TOO LOW", &["nonce too low"]));
-    }
-
-    // ── is_retryable ─────────────────────────────────────────────────────
-
-    #[test]
-    fn is_retryable_critical_errors() {
-        assert!(!TxManagerError::NonceTooLow.is_retryable());
-        assert!(!TxManagerError::NonceTooHigh.is_retryable());
-        assert!(!TxManagerError::InsufficientFunds.is_retryable());
-        assert!(!TxManagerError::IntrinsicGasTooLow.is_retryable());
-        assert!(!TxManagerError::ExecutionReverted.is_retryable());
-        assert!(!TxManagerError::MempoolDeadlineExpired.is_retryable());
-        assert!(!TxManagerError::AlreadyReserved.is_retryable());
-    }
-
-    #[test]
-    fn is_retryable_fee_errors() {
-        assert!(TxManagerError::Underpriced.is_retryable());
-        assert!(TxManagerError::ReplacementUnderpriced.is_retryable());
-        assert!(TxManagerError::FeeTooLow.is_retryable());
-        assert!(TxManagerError::MaxFeePerGasTooLow.is_retryable());
-    }
-
-    #[test]
-    fn is_retryable_infra_errors() {
-        assert!(TxManagerError::AlreadyKnown.is_retryable());
-        assert!(TxManagerError::Rpc("any error".to_string()).is_retryable());
-    }
-
-    // ── is_already_known ─────────────────────────────────────────────────
-
-    #[test]
-    fn is_already_known_true() {
-        assert!(TxManagerError::AlreadyKnown.is_already_known());
-    }
-
-    #[test]
-    fn is_already_known_false_for_other_variants() {
-        assert!(!TxManagerError::NonceTooLow.is_already_known());
-        assert!(!TxManagerError::Underpriced.is_already_known());
-        assert!(!TxManagerError::Rpc("already known".to_string()).is_already_known());
-    }
-
-    // ── Display output ────────────────────────────────────────────────────
-
-    #[test]
-    fn display_output_all_variants() {
-        assert_eq!(TxManagerError::NonceTooLow.to_string(), "nonce too low");
-        assert_eq!(TxManagerError::NonceTooHigh.to_string(), "nonce too high");
-        assert_eq!(TxManagerError::InsufficientFunds.to_string(), "insufficient funds");
-        assert_eq!(TxManagerError::IntrinsicGasTooLow.to_string(), "intrinsic gas too low");
-        assert_eq!(TxManagerError::ExecutionReverted.to_string(), "execution reverted");
-        assert_eq!(TxManagerError::MempoolDeadlineExpired.to_string(), "mempool deadline expired");
-        assert_eq!(TxManagerError::AlreadyReserved.to_string(), "nonce already reserved");
-        assert_eq!(TxManagerError::Underpriced.to_string(), "transaction underpriced");
-        assert_eq!(
-            TxManagerError::ReplacementUnderpriced.to_string(),
-            "replacement transaction underpriced"
-        );
-        assert_eq!(TxManagerError::FeeTooLow.to_string(), "fee too low");
-        assert_eq!(
-            TxManagerError::MaxFeePerGasTooLow.to_string(),
-            "max fee per gas less than block base fee"
-        );
-        assert_eq!(TxManagerError::AlreadyKnown.to_string(), "transaction already known");
-        assert_eq!(TxManagerError::Rpc("test".to_string()).to_string(), "rpc error: test");
-    }
-
-    // ── Edge cases ──────────────────────────────────────────────────────
-
-    #[test]
-    fn classify_empty_string_returns_rpc_fallback() {
-        let err = RpcErrorClassifier::classify_rpc_error("");
-        assert!(matches!(err, TxManagerError::Rpc(ref s) if s.is_empty()));
-    }
-
-    // ── Negative classifier tests: internal-only variants ───────────────
-
-    #[test]
-    fn classify_mempool_deadline_not_recognized() {
-        let err = RpcErrorClassifier::classify_rpc_error("mempool deadline expired");
-        assert!(
-            matches!(err, TxManagerError::Rpc(_)),
-            "MempoolDeadlineExpired is internal-only, classifier must not produce it"
-        );
-    }
-
-    #[test]
-    fn classify_already_reserved_not_recognized() {
-        let err = RpcErrorClassifier::classify_rpc_error("nonce already reserved");
-        assert!(
-            matches!(err, TxManagerError::Rpc(_)),
-            "AlreadyReserved is internal-only, classifier must not produce it"
-        );
+    #[rstest]
+    #[case::positive_match("nonce too low", &["nonce too low", "insufficient funds"], true)]
+    #[case::no_match("something else", &["nonce too low", "insufficient funds"], false)]
+    #[case::empty_slice("nonce too low", &[], false)]
+    #[case::partial_substring("error: nonce too low for account 0x123", &["nonce too low"], true)]
+    #[case::case_insensitive("NONCE TOO LOW", &["nonce too low"], true)]
+    fn err_string_contains_any(
+        #[case] input: &str,
+        #[case] substrings: &[&str],
+        #[case] expected: bool,
+    ) {
+        assert_eq!(RpcErrorClassifier::err_string_contains_any(input, substrings), expected);
     }
 }

--- a/crates/utilities/tx-manager/src/error.rs
+++ b/crates/utilities/tx-manager/src/error.rs
@@ -6,7 +6,7 @@ use thiserror::Error;
 ///
 /// Variants are grouped into critical (non-retryable), fee/replacement
 /// (retryable via fee bumps), and infrastructure (retryable/transient) errors.
-#[derive(Debug, Error)]
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
 pub enum TxManagerError {
     // ── Critical errors (non-retryable) ──────────────────────────────────
     /// Nonce already consumed onchain.

--- a/crates/utilities/tx-manager/src/error.rs
+++ b/crates/utilities/tx-manager/src/error.rs
@@ -60,6 +60,11 @@ pub enum TxManagerError {
     AlreadyKnown,
 
     /// Unclassified RPC error preserving the original error string.
+    ///
+    /// This variant is treated as retryable by [`TxManagerError::is_retryable`]
+    /// because unknown errors may be transient. Callers **must** enforce bounded
+    /// retry counts and exponential backoff to prevent retry storms from
+    /// persistent, non-transient errors that happen to be unclassified.
     #[error("rpc error: {0}")]
     Rpc(String),
 }
@@ -71,6 +76,13 @@ impl TxManagerError {
     /// Fee/replacement errors and infrastructure errors are retryable.
     /// Critical errors (nonce conflicts, insufficient funds, reverts,
     /// deadline expiry, reservation conflicts) are not.
+    ///
+    /// # Caller requirements
+    ///
+    /// The [`Rpc`](Self::Rpc) fallback is conservatively treated as retryable.
+    /// Callers **must** enforce a maximum retry count with exponential backoff
+    /// to avoid unbounded retries on persistent, non-transient errors that are
+    /// unrecognized by [`RpcErrorClassifier::classify_rpc_error`].
     #[must_use]
     pub const fn is_retryable(&self) -> bool {
         matches!(
@@ -101,6 +113,15 @@ pub type TxManagerResult<T> = Result<T, TxManagerError>;
 ///
 /// This mirrors the Go `op-service/txmgr` `errStringMatch` approach, enabling
 /// the send loop to make retry/abort decisions based on error type.
+///
+/// # Limitations
+///
+/// Classification relies on substring matching against known geth error
+/// messages. Other Ethereum clients (Erigon, Besu, Nethermind) may use
+/// different wording for equivalent errors, causing them to fall through to
+/// the [`TxManagerError::Rpc`] fallback. Future improvements could augment
+/// string matching with JSON-RPC error codes (e.g., `-32000`) for more
+/// robust cross-client classification.
 #[derive(Debug)]
 pub struct RpcErrorClassifier;
 

--- a/crates/utilities/tx-manager/src/error.rs
+++ b/crates/utilities/tx-manager/src/error.rs
@@ -199,7 +199,10 @@ mod tests {
     #[test]
     fn classify_replacement_underpriced() {
         let err = RpcErrorClassifier::classify_rpc_error("replacement transaction underpriced");
-        assert!(matches!(err, TxManagerError::ReplacementUnderpriced));
+        assert!(
+            matches!(err, TxManagerError::ReplacementUnderpriced),
+            "must return ReplacementUnderpriced, not Underpriced — ordering matters"
+        );
     }
 
     #[test]
@@ -261,17 +264,6 @@ mod tests {
     fn classify_transaction_already_in_pool() {
         let err = RpcErrorClassifier::classify_rpc_error("transaction already in pool");
         assert!(matches!(err, TxManagerError::AlreadyKnown));
-    }
-
-    // ── Ordering: replacement before underpriced ─────────────────────────
-
-    #[test]
-    fn classify_replacement_before_underpriced() {
-        let err = RpcErrorClassifier::classify_rpc_error("replacement transaction underpriced");
-        assert!(
-            matches!(err, TxManagerError::ReplacementUnderpriced),
-            "must return ReplacementUnderpriced, not Underpriced"
-        );
     }
 
     // ── Fallback to Rpc variant ──────────────────────────────────────────
@@ -389,22 +381,56 @@ mod tests {
         assert!(!TxManagerError::Rpc("already known".to_string()).is_already_known());
     }
 
-    // ── Variant construction ─────────────────────────────────────────────
+    // ── Display output ────────────────────────────────────────────────────
 
     #[test]
-    fn all_variants_constructable() {
-        let _ = TxManagerError::NonceTooLow;
-        let _ = TxManagerError::NonceTooHigh;
-        let _ = TxManagerError::InsufficientFunds;
-        let _ = TxManagerError::IntrinsicGasTooLow;
-        let _ = TxManagerError::ExecutionReverted;
-        let _ = TxManagerError::MempoolDeadlineExpired;
-        let _ = TxManagerError::AlreadyReserved;
-        let _ = TxManagerError::Underpriced;
-        let _ = TxManagerError::ReplacementUnderpriced;
-        let _ = TxManagerError::FeeTooLow;
-        let _ = TxManagerError::MaxFeePerGasTooLow;
-        let _ = TxManagerError::AlreadyKnown;
-        let _ = TxManagerError::Rpc("test".to_string());
+    fn display_output_all_variants() {
+        assert_eq!(TxManagerError::NonceTooLow.to_string(), "nonce too low");
+        assert_eq!(TxManagerError::NonceTooHigh.to_string(), "nonce too high");
+        assert_eq!(TxManagerError::InsufficientFunds.to_string(), "insufficient funds");
+        assert_eq!(TxManagerError::IntrinsicGasTooLow.to_string(), "intrinsic gas too low");
+        assert_eq!(TxManagerError::ExecutionReverted.to_string(), "execution reverted");
+        assert_eq!(TxManagerError::MempoolDeadlineExpired.to_string(), "mempool deadline expired");
+        assert_eq!(TxManagerError::AlreadyReserved.to_string(), "nonce already reserved");
+        assert_eq!(TxManagerError::Underpriced.to_string(), "transaction underpriced");
+        assert_eq!(
+            TxManagerError::ReplacementUnderpriced.to_string(),
+            "replacement transaction underpriced"
+        );
+        assert_eq!(TxManagerError::FeeTooLow.to_string(), "fee too low");
+        assert_eq!(
+            TxManagerError::MaxFeePerGasTooLow.to_string(),
+            "max fee per gas less than block base fee"
+        );
+        assert_eq!(TxManagerError::AlreadyKnown.to_string(), "transaction already known");
+        assert_eq!(TxManagerError::Rpc("test".to_string()).to_string(), "rpc error: test");
+    }
+
+    // ── Edge cases ──────────────────────────────────────────────────────
+
+    #[test]
+    fn classify_empty_string_returns_rpc_fallback() {
+        let err = RpcErrorClassifier::classify_rpc_error("");
+        assert!(matches!(err, TxManagerError::Rpc(ref s) if s.is_empty()));
+    }
+
+    // ── Negative classifier tests: internal-only variants ───────────────
+
+    #[test]
+    fn classify_mempool_deadline_not_recognized() {
+        let err = RpcErrorClassifier::classify_rpc_error("mempool deadline expired");
+        assert!(
+            matches!(err, TxManagerError::Rpc(_)),
+            "MempoolDeadlineExpired is internal-only, classifier must not produce it"
+        );
+    }
+
+    #[test]
+    fn classify_already_reserved_not_recognized() {
+        let err = RpcErrorClassifier::classify_rpc_error("nonce already reserved");
+        assert!(
+            matches!(err, TxManagerError::Rpc(_)),
+            "AlreadyReserved is internal-only, classifier must not produce it"
+        );
     }
 }

--- a/crates/utilities/tx-manager/src/error.rs
+++ b/crates/utilities/tx-manager/src/error.rs
@@ -1,7 +1,389 @@
 //! Transaction manager error types.
 
+use thiserror::Error;
+
 /// Transaction manager error types.
-#[derive(Debug)]
+///
+/// Variants are grouped into critical (non-retryable), fee/replacement
+/// (retryable via fee bumps), and infrastructure (retryable/transient) errors.
+#[derive(Debug, Error)]
 pub enum TxManagerError {
-    // TODO: add variants as error cases are identified in follow-up PRs
+    // ── Critical errors (non-retryable) ──────────────────────────────────
+    /// Nonce already consumed onchain.
+    #[error("nonce too low")]
+    NonceTooLow,
+
+    /// Nonce too far ahead of chain state.
+    #[error("nonce too high")]
+    NonceTooHigh,
+
+    /// Account balance cannot cover gas + value.
+    #[error("insufficient funds")]
+    InsufficientFunds,
+
+    /// Gas limit below intrinsic gas cost.
+    #[error("intrinsic gas too low")]
+    IntrinsicGasTooLow,
+
+    /// EVM execution reverted.
+    #[error("execution reverted")]
+    ExecutionReverted,
+
+    /// Mempool inclusion deadline expired.
+    #[error("mempool deadline expired")]
+    MempoolDeadlineExpired,
+
+    /// Nonce slot was already reserved.
+    #[error("nonce already reserved")]
+    AlreadyReserved,
+
+    // ── Fee / replacement errors (retryable) ─────────────────────────────
+    /// Fee too low to enter the mempool.
+    #[error("transaction underpriced")]
+    Underpriced,
+
+    /// Replacement transaction fee bump insufficient.
+    #[error("replacement transaction underpriced")]
+    ReplacementUnderpriced,
+
+    /// Generic fee rejection.
+    #[error("fee too low")]
+    FeeTooLow,
+
+    /// `maxFeePerGas` below block base fee.
+    #[error("max fee per gas less than block base fee")]
+    MaxFeePerGasTooLow,
+
+    // ── Infrastructure / transient errors (retryable) ────────────────────
+    /// Transaction already present in the mempool (benign on resubmission).
+    #[error("transaction already known")]
+    AlreadyKnown,
+
+    /// Unclassified RPC error preserving the original error string.
+    #[error("rpc error: {0}")]
+    Rpc(String),
+}
+
+impl TxManagerError {
+    /// Returns `true` if this error is transient or can be resolved by
+    /// bumping fees, meaning the send loop should retry.
+    ///
+    /// Fee/replacement errors and infrastructure errors are retryable.
+    /// Critical errors (nonce conflicts, insufficient funds, reverts,
+    /// deadline expiry, reservation conflicts) are not.
+    #[must_use]
+    pub const fn is_retryable(&self) -> bool {
+        matches!(
+            self,
+            Self::Underpriced
+                | Self::ReplacementUnderpriced
+                | Self::FeeTooLow
+                | Self::MaxFeePerGasTooLow
+                | Self::AlreadyKnown
+                | Self::Rpc(_)
+        )
+    }
+
+    /// Returns `true` only for [`TxManagerError::AlreadyKnown`].
+    ///
+    /// The send loop uses this to distinguish "already in mempool" (a
+    /// success on resubmission) from actual errors.
+    #[must_use]
+    pub const fn is_already_known(&self) -> bool {
+        matches!(self, Self::AlreadyKnown)
+    }
+}
+
+/// Result type alias for transaction manager operations.
+pub type TxManagerResult<T> = Result<T, TxManagerError>;
+
+/// Classifies raw RPC error strings into structured [`TxManagerError`] variants.
+///
+/// This mirrors the Go `op-service/txmgr` `errStringMatch` approach, enabling
+/// the send loop to make retry/abort decisions based on error type.
+#[derive(Debug)]
+pub struct RpcErrorClassifier;
+
+impl RpcErrorClassifier {
+    /// Classifies a raw RPC error message into a [`TxManagerError`] variant.
+    ///
+    /// The input is lowercased once, then checked against known geth error
+    /// substrings in a fixed order. The first match wins.
+    ///
+    /// **Ordering is critical**: `"replacement transaction underpriced"` is
+    /// matched before `"transaction underpriced"` because the latter is a
+    /// substring of the former.
+    ///
+    /// Unknown error strings fall through to [`TxManagerError::Rpc`],
+    /// preserving the original casing.
+    #[must_use]
+    pub fn classify_rpc_error(error_msg: &str) -> TxManagerError {
+        let lowered = error_msg.to_lowercase();
+
+        if lowered.contains("replacement transaction underpriced") {
+            return TxManagerError::ReplacementUnderpriced;
+        }
+        if lowered.contains("transaction underpriced") {
+            return TxManagerError::Underpriced;
+        }
+        if lowered.contains("nonce too low") {
+            return TxManagerError::NonceTooLow;
+        }
+        if lowered.contains("nonce too high") {
+            return TxManagerError::NonceTooHigh;
+        }
+        if lowered.contains("insufficient funds") {
+            return TxManagerError::InsufficientFunds;
+        }
+        if lowered.contains("intrinsic gas too low") {
+            return TxManagerError::IntrinsicGasTooLow;
+        }
+        if lowered.contains("execution reverted") {
+            return TxManagerError::ExecutionReverted;
+        }
+        if lowered.contains("fee too low") {
+            return TxManagerError::FeeTooLow;
+        }
+        if lowered.contains("max fee per gas less than block base fee") {
+            return TxManagerError::MaxFeePerGasTooLow;
+        }
+        if lowered.contains("already known") {
+            return TxManagerError::AlreadyKnown;
+        }
+        if lowered.contains("transaction already in pool") {
+            return TxManagerError::AlreadyKnown;
+        }
+
+        TxManagerError::Rpc(error_msg.to_string())
+    }
+
+    /// Returns `true` if `error_msg` contains any of the given substrings
+    /// (compared case-insensitively).
+    ///
+    /// This enables callers to define custom error matching sets beyond the
+    /// built-in [`RpcErrorClassifier::classify_rpc_error`] classification.
+    #[must_use]
+    pub fn err_string_contains_any(error_msg: &str, substrings: &[&str]) -> bool {
+        let lowered = error_msg.to_lowercase();
+        substrings.iter().any(|s| lowered.contains(&s.to_lowercase()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ── classify_rpc_error: known geth error strings ─────────────────────
+
+    #[test]
+    fn classify_replacement_underpriced() {
+        let err = RpcErrorClassifier::classify_rpc_error("replacement transaction underpriced");
+        assert!(matches!(err, TxManagerError::ReplacementUnderpriced));
+    }
+
+    #[test]
+    fn classify_underpriced() {
+        let err = RpcErrorClassifier::classify_rpc_error("transaction underpriced");
+        assert!(matches!(err, TxManagerError::Underpriced));
+    }
+
+    #[test]
+    fn classify_nonce_too_low() {
+        let err = RpcErrorClassifier::classify_rpc_error("nonce too low");
+        assert!(matches!(err, TxManagerError::NonceTooLow));
+    }
+
+    #[test]
+    fn classify_nonce_too_high() {
+        let err = RpcErrorClassifier::classify_rpc_error("nonce too high");
+        assert!(matches!(err, TxManagerError::NonceTooHigh));
+    }
+
+    #[test]
+    fn classify_insufficient_funds() {
+        let err = RpcErrorClassifier::classify_rpc_error("insufficient funds");
+        assert!(matches!(err, TxManagerError::InsufficientFunds));
+    }
+
+    #[test]
+    fn classify_intrinsic_gas_too_low() {
+        let err = RpcErrorClassifier::classify_rpc_error("intrinsic gas too low");
+        assert!(matches!(err, TxManagerError::IntrinsicGasTooLow));
+    }
+
+    #[test]
+    fn classify_execution_reverted() {
+        let err = RpcErrorClassifier::classify_rpc_error("execution reverted");
+        assert!(matches!(err, TxManagerError::ExecutionReverted));
+    }
+
+    #[test]
+    fn classify_fee_too_low() {
+        let err = RpcErrorClassifier::classify_rpc_error("fee too low");
+        assert!(matches!(err, TxManagerError::FeeTooLow));
+    }
+
+    #[test]
+    fn classify_max_fee_per_gas_too_low() {
+        let err =
+            RpcErrorClassifier::classify_rpc_error("max fee per gas less than block base fee");
+        assert!(matches!(err, TxManagerError::MaxFeePerGasTooLow));
+    }
+
+    #[test]
+    fn classify_already_known() {
+        let err = RpcErrorClassifier::classify_rpc_error("already known");
+        assert!(matches!(err, TxManagerError::AlreadyKnown));
+    }
+
+    #[test]
+    fn classify_transaction_already_in_pool() {
+        let err = RpcErrorClassifier::classify_rpc_error("transaction already in pool");
+        assert!(matches!(err, TxManagerError::AlreadyKnown));
+    }
+
+    // ── Ordering: replacement before underpriced ─────────────────────────
+
+    #[test]
+    fn classify_replacement_before_underpriced() {
+        let err = RpcErrorClassifier::classify_rpc_error("replacement transaction underpriced");
+        assert!(
+            matches!(err, TxManagerError::ReplacementUnderpriced),
+            "must return ReplacementUnderpriced, not Underpriced"
+        );
+    }
+
+    // ── Fallback to Rpc variant ──────────────────────────────────────────
+
+    #[test]
+    fn classify_unknown_returns_rpc_fallback() {
+        let msg = "something unexpected";
+        let err = RpcErrorClassifier::classify_rpc_error(msg);
+        assert!(matches!(err, TxManagerError::Rpc(ref s) if s == msg));
+    }
+
+    #[test]
+    fn classify_rpc_preserves_original_casing() {
+        let msg = "Some Unknown ERROR Message";
+        let err = RpcErrorClassifier::classify_rpc_error(msg);
+        assert!(matches!(err, TxManagerError::Rpc(ref s) if s == msg));
+    }
+
+    // ── Case-insensitivity ───────────────────────────────────────────────
+
+    #[test]
+    fn classify_case_insensitive_upper() {
+        let err = RpcErrorClassifier::classify_rpc_error("NONCE TOO LOW");
+        assert!(matches!(err, TxManagerError::NonceTooLow));
+    }
+
+    #[test]
+    fn classify_case_insensitive_mixed() {
+        let err = RpcErrorClassifier::classify_rpc_error("Nonce Too Low");
+        assert!(matches!(err, TxManagerError::NonceTooLow));
+    }
+
+    // ── Substring containment in context ─────────────────────────────────
+
+    #[test]
+    fn classify_substring_in_longer_message() {
+        let err = RpcErrorClassifier::classify_rpc_error("some context: nonce too low for account");
+        assert!(matches!(err, TxManagerError::NonceTooLow));
+    }
+
+    // ── err_string_contains_any ──────────────────────────────────────────
+
+    #[test]
+    fn err_string_contains_any_positive_match() {
+        assert!(RpcErrorClassifier::err_string_contains_any(
+            "nonce too low",
+            &["nonce too low", "insufficient funds"]
+        ));
+    }
+
+    #[test]
+    fn err_string_contains_any_no_match() {
+        assert!(!RpcErrorClassifier::err_string_contains_any(
+            "something else",
+            &["nonce too low", "insufficient funds"]
+        ));
+    }
+
+    #[test]
+    fn err_string_contains_any_empty_slice() {
+        assert!(!RpcErrorClassifier::err_string_contains_any("nonce too low", &[]));
+    }
+
+    #[test]
+    fn err_string_contains_any_partial_substring() {
+        assert!(RpcErrorClassifier::err_string_contains_any(
+            "error: nonce too low for account 0x123",
+            &["nonce too low"]
+        ));
+    }
+
+    #[test]
+    fn err_string_contains_any_case_insensitive() {
+        assert!(RpcErrorClassifier::err_string_contains_any("NONCE TOO LOW", &["nonce too low"]));
+    }
+
+    // ── is_retryable ─────────────────────────────────────────────────────
+
+    #[test]
+    fn is_retryable_critical_errors() {
+        assert!(!TxManagerError::NonceTooLow.is_retryable());
+        assert!(!TxManagerError::NonceTooHigh.is_retryable());
+        assert!(!TxManagerError::InsufficientFunds.is_retryable());
+        assert!(!TxManagerError::IntrinsicGasTooLow.is_retryable());
+        assert!(!TxManagerError::ExecutionReverted.is_retryable());
+        assert!(!TxManagerError::MempoolDeadlineExpired.is_retryable());
+        assert!(!TxManagerError::AlreadyReserved.is_retryable());
+    }
+
+    #[test]
+    fn is_retryable_fee_errors() {
+        assert!(TxManagerError::Underpriced.is_retryable());
+        assert!(TxManagerError::ReplacementUnderpriced.is_retryable());
+        assert!(TxManagerError::FeeTooLow.is_retryable());
+        assert!(TxManagerError::MaxFeePerGasTooLow.is_retryable());
+    }
+
+    #[test]
+    fn is_retryable_infra_errors() {
+        assert!(TxManagerError::AlreadyKnown.is_retryable());
+        assert!(TxManagerError::Rpc("any error".to_string()).is_retryable());
+    }
+
+    // ── is_already_known ─────────────────────────────────────────────────
+
+    #[test]
+    fn is_already_known_true() {
+        assert!(TxManagerError::AlreadyKnown.is_already_known());
+    }
+
+    #[test]
+    fn is_already_known_false_for_other_variants() {
+        assert!(!TxManagerError::NonceTooLow.is_already_known());
+        assert!(!TxManagerError::Underpriced.is_already_known());
+        assert!(!TxManagerError::Rpc("already known".to_string()).is_already_known());
+    }
+
+    // ── Variant construction ─────────────────────────────────────────────
+
+    #[test]
+    fn all_variants_constructable() {
+        let _ = TxManagerError::NonceTooLow;
+        let _ = TxManagerError::NonceTooHigh;
+        let _ = TxManagerError::InsufficientFunds;
+        let _ = TxManagerError::IntrinsicGasTooLow;
+        let _ = TxManagerError::ExecutionReverted;
+        let _ = TxManagerError::MempoolDeadlineExpired;
+        let _ = TxManagerError::AlreadyReserved;
+        let _ = TxManagerError::Underpriced;
+        let _ = TxManagerError::ReplacementUnderpriced;
+        let _ = TxManagerError::FeeTooLow;
+        let _ = TxManagerError::MaxFeePerGasTooLow;
+        let _ = TxManagerError::AlreadyKnown;
+        let _ = TxManagerError::Rpc("test".to_string());
+    }
 }

--- a/crates/utilities/tx-manager/src/lib.rs
+++ b/crates/utilities/tx-manager/src/lib.rs
@@ -4,7 +4,7 @@
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
 
 mod error;
-pub use error::TxManagerError;
+pub use error::{RpcErrorClassifier, TxManagerError, TxManagerResult};
 
 mod candidate;
 pub use candidate::TxCandidate;


### PR DESCRIPTION
### What changed? Why?
Populates the stub `TxManagerError` enum in `base-tx-manager` with structured error variants (critical, retryable, infrastructure) and adds `RpcErrorClassifier` to map raw geth RPC error strings into typed variants. This enables the future send loop to make retry/abort/fee-bump decisions based on classified error type, mirroring the Go `op-service/txmgr` `errStringMatch` approach.

### How has it been tested?
All CI checks (clippy, rustfmt, zepter, build) pass cleanly. 30+ unit tests cover every classifier branch (all 11 known geth error strings plus fallback), case-insensitivity, substring-in-context matching, `err_string_contains_any` utility, `is_retryable`/`is_already_known` across all 13 variants, Display output verification for every variant, empty-string edge case, and negative tests confirming internal-only variants are never produced by the classifier.

### Notes to reviewers
Matching order is critical: `"replacement transaction underpriced"` must be checked before `"transaction underpriced"` since the latter is a substring. The `Rpc(String)` fallback is treated as retryable — doc comments mandate callers enforce bounded retries with exponential backoff.

### Change management
type=routine
risk=low
impact=sev5

### Backwards Compatibility
backwards_compatible=true

automerge=false