### PR TITLE
feat(proof,consensus): remove IndexedBlobHash, simplify blob handling

### DIFF
--- a/crates/consensus/derive/src/sources/blobs.rs
+++ b/crates/consensus/derive/src/sources/blobs.rs
@@ -5,8 +5,7 @@ use alloc::{boxed::Box, vec::Vec};
 use alloy_consensus::{
     Transaction, TxEip4844Variant, TxEnvelope, TxType, transaction::SignerRecoverable,
 };
-use alloy_eips::eip4844::IndexedBlobHash;
-use alloy_primitives::{Address, Bytes};
+use alloy_primitives::{Address, B256, Bytes};
 use async_trait::async_trait;
 use base_protocol::BlockInfo;
 
@@ -48,8 +47,7 @@ where
         &self,
         txs: Vec<TxEnvelope>,
         batcher_address: Address,
-    ) -> (Vec<BlobData>, Vec<IndexedBlobHash>) {
-        let mut index: u64 = 0;
+    ) -> (Vec<BlobData>, Vec<B256>) {
         let mut data = Vec::new();
         let mut hashes = Vec::new();
         for tx in txs {
@@ -71,11 +69,9 @@ where
             let Some(to) = tx_kind else { continue };
 
             if to != self.batcher_address {
-                index += blob_hashes.map_or(0, |h| h.len() as u64);
                 continue;
             }
             if tx.recover_signer().unwrap_or_default() != batcher_address {
-                index += blob_hashes.map_or(0, |h| h.len() as u64);
                 continue;
             }
             if tx.tx_type() != TxType::Eip4844 {
@@ -99,10 +95,8 @@ where
                 continue;
             };
             for hash in blob_hashes {
-                let indexed = IndexedBlobHash { hash, index };
-                hashes.push(indexed);
+                hashes.push(hash);
                 data.push(BlobData::default());
-                index += 1;
             }
         }
         #[cfg(feature = "metrics")]

--- a/crates/consensus/derive/src/test_utils/blob_provider.rs
+++ b/crates/consensus/derive/src/test_utils/blob_provider.rs
@@ -2,7 +2,7 @@
 
 use alloc::{boxed::Box, vec::Vec};
 
-use alloy_eips::eip4844::{Blob, IndexedBlobHash};
+use alloy_eips::eip4844::Blob;
 use alloy_primitives::{B256, map::HashMap};
 use async_trait::async_trait;
 use base_protocol::BlockInfo;
@@ -42,7 +42,7 @@ impl BlobProvider for TestBlobProvider {
     async fn get_and_validate_blobs(
         &mut self,
         _block_ref: &BlockInfo,
-        blob_hashes: &[IndexedBlobHash],
+        blob_hashes: &[B256],
     ) -> Result<Vec<Box<Blob>>, Self::Error> {
         if self.should_error {
             return Err(BlobProviderError::SlotDerivation);
@@ -55,7 +55,7 @@ impl BlobProvider for TestBlobProvider {
         }
         let mut blobs = Vec::new();
         for blob_hash in blob_hashes {
-            if let Some(data) = self.blobs.get(&blob_hash.hash) {
+            if let Some(data) = self.blobs.get(blob_hash) {
                 blobs.push(Box::new(*data));
             }
         }

--- a/crates/consensus/derive/src/traits/data_sources.rs
+++ b/crates/consensus/derive/src/traits/data_sources.rs
@@ -4,8 +4,8 @@
 use alloc::{boxed::Box, fmt::Debug, string::ToString, vec::Vec};
 use core::fmt::Display;
 
-use alloy_eips::eip4844::{Blob, IndexedBlobHash};
-use alloy_primitives::{Address, Bytes};
+use alloy_eips::eip4844::Blob;
+use alloy_primitives::{Address, B256, Bytes};
 use async_trait::async_trait;
 use base_protocol::BlockInfo;
 
@@ -21,7 +21,7 @@ pub trait BlobProvider {
     async fn get_and_validate_blobs(
         &mut self,
         block_ref: &BlockInfo,
-        blob_hashes: &[IndexedBlobHash],
+        blob_hashes: &[B256],
     ) -> Result<Vec<Box<Blob>>, Self::Error>;
 }
 

--- a/crates/consensus/providers-alloy/src/beacon_client.rs
+++ b/crates/consensus/providers-alloy/src/beacon_client.rs
@@ -2,7 +2,7 @@
 
 use std::{boxed::Box, collections::HashMap, format, string::String, vec::Vec};
 
-use alloy_eips::eip4844::{IndexedBlobHash, env_settings::EnvKzgSettings, kzg_to_versioned_hash};
+use alloy_eips::eip4844::{env_settings::EnvKzgSettings, kzg_to_versioned_hash};
 use alloy_primitives::{B256, FixedBytes};
 use alloy_rpc_types_beacon::sidecar::GetBlobsResponse;
 use alloy_transport_http::reqwest::{self, Client};
@@ -12,7 +12,7 @@ use thiserror::Error;
 
 #[cfg(feature = "metrics")]
 use crate::Metrics;
-use crate::blobs::BoxedBlobWithIndex;
+use crate::blobs::BoxedBlob;
 
 /// The config spec engine api method.
 const SPEC_METHOD: &str = "eth/v1/config/spec";
@@ -89,12 +89,12 @@ pub trait BeaconClient {
     async fn genesis_time(&self) -> Result<APIGenesisResponse, Self::Error>;
 
     /// Fetches blobs that were confirmed in the specified L1 block with the given slot.
-    /// Blob data is not checked for validity.
+    /// Blob data is checked for validity.
     async fn filtered_beacon_blobs(
         &self,
         slot: u64,
-        blob_hashes: &[IndexedBlobHash],
-    ) -> Result<Vec<BoxedBlobWithIndex>, Self::Error>;
+        blob_hashes: &[B256],
+    ) -> Result<Vec<BoxedBlob>, Self::Error>;
 }
 
 const BLOB_SIZE: usize = 131072;
@@ -168,9 +168,9 @@ impl OnlineBeaconClient {
     async fn filtered_beacon_blobs(
         &self,
         slot: u64,
-        blob_hashes: &[IndexedBlobHash],
-    ) -> Result<Vec<BoxedBlobWithIndex>, BeaconClientError> {
-        let params = blob_hashes.iter().map(|blob| blob.hash.to_string()).collect::<Vec<_>>();
+        blob_hashes: &[B256],
+    ) -> Result<Vec<BoxedBlob>, BeaconClientError> {
+        let params = blob_hashes.iter().map(|hash| hash.to_string()).collect::<Vec<_>>();
         let response = self
             .inner
             .get(format!("{}/{}/{}", self.base, BLOBS_METHOD_PREFIX, slot))
@@ -202,11 +202,11 @@ impl OnlineBeaconClient {
         // whose hash matches the input:
         blob_hashes
             .iter()
-            .map(|blob_hash| -> Result<BoxedBlobWithIndex, BeaconClientError> {
+            .map(|blob_hash| -> Result<BoxedBlob, BeaconClientError> {
                 let matching_data = returned_blobs_mapped_by_hash
-                    .get(&blob_hash.hash)
-                    .ok_or(BeaconClientError::BlobNotFound(blob_hash.hash.to_string()))?;
-                Ok(BoxedBlobWithIndex { blob: Box::new(**matching_data), index: blob_hash.index })
+                    .get(blob_hash)
+                    .ok_or(BeaconClientError::BlobNotFound(blob_hash.to_string()))?;
+                Ok(BoxedBlob { blob: Box::new(**matching_data) })
             })
             .collect::<Result<Vec<_>, BeaconClientError>>()
     }
@@ -260,8 +260,8 @@ impl BeaconClient for OnlineBeaconClient {
     async fn filtered_beacon_blobs(
         &self,
         slot: u64,
-        blob_hashes: &[IndexedBlobHash],
-    ) -> Result<Vec<BoxedBlobWithIndex>, BeaconClientError> {
+        blob_hashes: &[B256],
+    ) -> Result<Vec<BoxedBlob>, BeaconClientError> {
         base_macros::inc!(gauge, Metrics::BEACON_CLIENT_REQUESTS, "method" => "blobs");
 
         // Try to get the blobs from the blobs endpoint.
@@ -303,15 +303,12 @@ mod tests {
         let garbage_blob_data: Vec<Blob> = vec![FixedBytes::repeat_byte(2)];
         let required_query_param = format!("{TEST_BLOB_HASH_HEX},{TEST_BLOB_HASH_HEX}");
         let test_blob_hash: FixedBytes<32> = FixedBytes::from_hex(TEST_BLOB_HASH_HEX).unwrap();
-        let requested_blob_hashes: Vec<IndexedBlobHash> = vec![
-            IndexedBlobHash { index: 0, hash: test_blob_hash },
-            IndexedBlobHash { index: 2, hash: test_blob_hash },
-        ];
+        let requested_blob_hashes: Vec<B256> = vec![test_blob_hash, test_blob_hash];
 
         struct TestCase {
             name: &'static str,
             mock_response_data: Vec<Blob>,
-            want: Option<Vec<BoxedBlobWithIndex>>, // if none, expect an error
+            want: Option<Vec<BoxedBlob>>, // if none, expect an error
         }
 
         let test_cases = vec![
@@ -319,8 +316,8 @@ mod tests {
                 name: "Repeated Blob Data, expect success",
                 mock_response_data: repeated_blob_data,
                 want: Some(vec![
-                    BoxedBlobWithIndex { index: 0, blob: Box::new(TEST_BLOB_DATA) },
-                    BoxedBlobWithIndex { index: 2, blob: Box::new(TEST_BLOB_DATA) },
+                    BoxedBlob { blob: Box::new(TEST_BLOB_DATA) },
+                    BoxedBlob { blob: Box::new(TEST_BLOB_DATA) },
                 ]),
             },
             TestCase {
@@ -370,8 +367,7 @@ mod tests {
     async fn test_filtered_beacon_blobs_404_returns_slot_not_found() {
         let slot = 13779552u64;
         let test_blob_hash: FixedBytes<32> = FixedBytes::from_hex(TEST_BLOB_HASH_HEX).unwrap();
-        let requested_blob_hashes: Vec<IndexedBlobHash> =
-            vec![IndexedBlobHash { index: 0, hash: test_blob_hash }];
+        let requested_blob_hashes: Vec<B256> = vec![test_blob_hash];
 
         let server = MockServer::start();
         let blobs_mock = server.mock(|when, then| {

--- a/crates/consensus/providers-alloy/src/blobs.rs
+++ b/crates/consensus/providers-alloy/src/blobs.rs
@@ -2,10 +2,8 @@
 
 use std::{boxed::Box, string::ToString, vec::Vec};
 
-use alloy_eips::eip4844::{
-    Blob, BlobTransactionSidecarItem, IndexedBlobHash, env_settings::EnvKzgSettings,
-};
-use alloy_primitives::FixedBytes;
+use alloy_eips::eip4844::{Blob, Bytes48, env_settings::EnvKzgSettings};
+use alloy_primitives::{B256, FixedBytes};
 use async_trait::async_trait;
 use base_consensus_derive::{BlobProvider, BlobProviderError};
 use base_protocol::BlockInfo;
@@ -15,13 +13,25 @@ use crate::BeaconClient;
 #[cfg(feature = "metrics")]
 use crate::Metrics;
 
-/// A boxed blob with index.
+/// A boxed blob.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct BoxedBlobWithIndex {
-    /// The index of the blob.
-    pub index: u64,
+pub struct BoxedBlob {
     /// The blob data.
     pub blob: Box<Blob>,
+}
+
+/// A blob with its KZG commitment and proof.
+///
+/// This is used by the host to store blob preimages. Unlike `BlobTransactionSidecarItem`,
+/// this does not include an index field since blobs are fetched by hash, not by index.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BlobWithCommitmentAndProof {
+    /// The blob data.
+    pub blob: Box<Blob>,
+    /// The KZG commitment for the blob.
+    pub kzg_commitment: Bytes48,
+    /// The KZG proof for the blob.
+    pub kzg_proof: Bytes48,
 }
 
 /// An online implementation of the [`BlobProvider`] trait.
@@ -76,8 +86,8 @@ impl<B: BeaconClient> OnlineBlobProvider<B> {
     async fn fetch_filtered_blobs(
         &self,
         slot: u64,
-        blob_hashes: &[IndexedBlobHash],
-    ) -> Result<Vec<BoxedBlobWithIndex>, BlobProviderError> {
+        blob_hashes: &[B256],
+    ) -> Result<Vec<BoxedBlob>, BlobProviderError> {
         base_macros::inc!(gauge, Metrics::BLOB_FETCHES);
 
         let result =
@@ -105,13 +115,13 @@ impl<B: BeaconClient> OnlineBlobProvider<B> {
         result
     }
 
-    /// Converts a vector of boxed blobs with index to a vector of blob transaction sidecar items.
+    /// Converts a vector of boxed blobs to a vector of blobs with their KZG commitments and proofs.
     ///
     /// Note: for performance reasons, we need to transmute the blobs to the `c_kzg::Blob` type to
     /// avoid the overhead of moving the blobs around or reallocating the memory.
-    fn sidecar_from_blobs(
-        blobs: Vec<BoxedBlobWithIndex>,
-    ) -> Result<Vec<BlobTransactionSidecarItem>, c_kzg::Error> {
+    fn blobs_with_proofs(
+        blobs: Vec<BoxedBlob>,
+    ) -> Result<Vec<BlobWithCommitmentAndProof>, c_kzg::Error> {
         blobs
             .into_iter()
             .map(|blob| {
@@ -134,8 +144,7 @@ impl<B: BeaconClient> OnlineBlobProvider<B> {
                 let alloy_blob =
                     unsafe { Box::from_raw(Box::<c_kzg::Blob>::into_raw(kzg_blob) as *mut Blob) };
 
-                Ok(BlobTransactionSidecarItem {
-                    index: blob.index,
+                Ok(BlobWithCommitmentAndProof {
                     blob: alloy_blob,
                     kzg_commitment: FixedBytes::from(*commitment),
                     kzg_proof: FixedBytes::from(*proof),
@@ -144,16 +153,17 @@ impl<B: BeaconClient> OnlineBlobProvider<B> {
             .collect()
     }
 
-    /// Fetches blob sidecars for the given block reference and blob hashes.
-    /// Does not validate the blobs. Recomputes the kzg proofs associated with the blobs.
+    /// Fetches and validates blobs for the given block reference and blob hashes.
+    /// Recomputes the kzg proofs associated with the blobs and returns as a vector of
+    /// [`BlobWithCommitmentAndProof`]s.
     ///
     /// Use [`Self::beacon_client`] to fetch the blobs without recomputing the kzg
     /// proofs/commitments.
-    pub async fn fetch_filtered_blob_sidecars(
+    pub async fn fetch_blobs_with_proofs(
         &self,
         block_ref: &BlockInfo,
-        blob_hashes: &[IndexedBlobHash],
-    ) -> Result<Vec<BlobTransactionSidecarItem>, BlobProviderError> {
+        blob_hashes: &[B256],
+    ) -> Result<Vec<BlobWithCommitmentAndProof>, BlobProviderError> {
         if blob_hashes.is_empty() {
             return Ok(Default::default());
         }
@@ -161,10 +171,10 @@ impl<B: BeaconClient> OnlineBlobProvider<B> {
         // Calculate the slot for the given timestamp.
         let slot = Self::slot(self.genesis_time, self.slot_interval, block_ref.timestamp)?;
 
-        // Fetch blobs for the slot using.
+        // Fetch blobs for the slot.
         let blobs = self.fetch_filtered_blobs(slot, blob_hashes).await?;
 
-        Self::sidecar_from_blobs(blobs)
+        Self::blobs_with_proofs(blobs)
             .map_err(|e| BlobProviderError::Backend(format!("KZG commitment error: {e}")))
     }
 }
@@ -176,36 +186,26 @@ where
 {
     type Error = BlobProviderError;
 
-    /// Fetches blobs that were confirmed in the specified L1 block with the given indexed
-    /// hashes. The blobs are validated for their index and hashes using the specified
-    /// [`IndexedBlobHash`].
+    /// Fetches blobs that were confirmed in the specified L1 block with the given versioned
+    /// hashes. The blobs are already validated by the beacon client by recomputing their
+    /// commitments and checking against the expected hashes.
     async fn get_and_validate_blobs(
         &mut self,
         block_ref: &BlockInfo,
-        blob_hashes: &[IndexedBlobHash],
+        blob_hashes: &[B256],
     ) -> Result<Vec<Box<Blob>>, Self::Error> {
-        // Fetch the blob sidecars for the given block reference and blob hashes.
-        let blobs = self.fetch_filtered_blob_sidecars(block_ref, blob_hashes).await?;
+        if blob_hashes.is_empty() {
+            return Ok(Default::default());
+        }
 
-        // Validate the blob sidecars straight away with the num hashes.
-        let blobs = blobs
-            .into_iter()
-            .enumerate()
-            .map(|(i, sidecar)| {
-                let hash = blob_hashes
-                    .get(i)
-                    .ok_or_else(|| BlobProviderError::Backend("Missing blob hash".to_string()))?
-                    .hash
-                    .as_slice();
+        // Calculate the slot for the given timestamp.
+        let slot = Self::slot(self.genesis_time, self.slot_interval, block_ref.timestamp)?;
 
-                if sidecar.to_kzg_versioned_hash() != hash {
-                    return Err(BlobProviderError::Backend("KZG commitment mismatch".to_string()));
-                }
+        // Fetch and validate blobs from the beacon client.
+        // The beacon client already validates each blob by recomputing its commitment
+        // and checking it against the expected hash.
+        let blobs = self.fetch_filtered_blobs(slot, blob_hashes).await?;
 
-                Ok(sidecar.blob)
-            })
-            .collect::<Result<Vec<Box<Blob>>, BlobProviderError>>()
-            .map_err(|e| BlobProviderError::Backend(e.to_string()))?;
-        Ok(blobs)
+        Ok(blobs.into_iter().map(|boxed_blob| boxed_blob.blob).collect())
     }
 }

--- a/crates/consensus/providers-alloy/src/lib.rs
+++ b/crates/consensus/providers-alloy/src/lib.rs
@@ -15,7 +15,7 @@ pub use beacon_client::{
 };
 
 mod blobs;
-pub use blobs::{BoxedBlobWithIndex, OnlineBlobProvider};
+pub use blobs::{BlobWithCommitmentAndProof, BoxedBlob, OnlineBlobProvider};
 
 mod chain_provider;
 pub use chain_provider::{AlloyChainProvider, AlloyChainProviderError};

--- a/crates/proof/host/src/handler.rs
+++ b/crates/proof/host/src/handler.rs
@@ -1,14 +1,12 @@
 use alloy_consensus::Header;
-use alloy_eips::{
-    eip2718::Encodable2718,
-    eip4844::{FIELD_ELEMENTS_PER_BLOB, IndexedBlobHash},
-};
+use alloy_eips::{eip2718::Encodable2718, eip4844::FIELD_ELEMENTS_PER_BLOB};
 use alloy_primitives::{Address, B256, Bytes, keccak256};
 use alloy_provider::Provider;
 use alloy_rlp::Decodable;
 use alloy_rpc_types::{Block, debug::ExecutionWitness};
 use ark_ff::{BigInteger, PrimeField};
 use base_alloy_rpc_types_engine::OpPayloadAttributes;
+use base_consensus_providers::BlobWithCommitmentAndProof;
 use base_proof::{Hint, HintType, ROOTS_OF_UNITY};
 use base_proof_preimage::{PreimageKey, PreimageKeyType};
 use base_protocol::{BlockInfo, OutputRoot, Predeploys};
@@ -108,19 +106,16 @@ pub async fn handle_hint(
 
             let partial_block_ref = BlockInfo { timestamp, ..Default::default() };
 
-            let blob_hash = IndexedBlobHash { hash, index: 0 };
             let mut blobs = providers
                 .blobs
-                .fetch_filtered_blob_sidecars(&partial_block_ref, &[blob_hash])
+                .fetch_blobs_with_proofs(&partial_block_ref, &[hash])
                 .await
                 .map_err(|e| HostError::BlobSidecarFetchFailed(e.to_string()))?;
             if blobs.len() != 1 {
                 return Err(HostError::BlobCountMismatch { expected: 1, actual: blobs.len() });
             }
-            let sidecar = blobs.pop().expect("Expected 1 blob");
-            let blob = &sidecar.blob;
-            let proof = sidecar.kzg_proof;
-            let commitment = sidecar.kzg_commitment;
+            let BlobWithCommitmentAndProof { blob, kzg_proof: proof, kzg_commitment: commitment } =
+                blobs.pop().expect("Expected 1 blob");
 
             let mut kv_lock = kv.write().await;
 

--- a/crates/proof/proof/src/l1/blob_provider.rs
+++ b/crates/proof/proof/src/l1/blob_provider.rs
@@ -4,7 +4,7 @@ use alloc::{boxed::Box, sync::Arc, vec::Vec};
 use core::str::FromStr;
 
 use alloy_consensus::Blob;
-use alloy_eips::eip4844::{FIELD_ELEMENTS_PER_BLOB, IndexedBlobHash};
+use alloy_eips::eip4844::FIELD_ELEMENTS_PER_BLOB;
 use alloy_primitives::{B256, keccak256};
 use ark_bls12_381::Fr;
 use ark_ff::{AdditiveGroup, BigInteger, BigInteger256, Field, PrimeField};
@@ -95,11 +95,11 @@ impl<T: CommsClient + Sync + Send> BlobProvider for OracleBlobProvider<T> {
     async fn get_and_validate_blobs(
         &mut self,
         block_ref: &BlockInfo,
-        blob_hashes: &[IndexedBlobHash],
+        blob_hashes: &[B256],
     ) -> Result<Vec<Box<Blob>>, Self::Error> {
         let mut blobs = Vec::with_capacity(blob_hashes.len());
-        for indexed in blob_hashes {
-            blobs.push(Box::new(self.get_blob(block_ref, &indexed.hash).await?));
+        for hash in blob_hashes {
+            blobs.push(Box::new(self.get_blob(block_ref, hash).await?));
         }
         Ok(blobs)
     }


### PR DESCRIPTION
## Summary

Port of [ethereum-optimism/optimism#19081](https://github.com/ethereum-optimism/optimism/pull/19081) from the upstream kona subtree.

`IndexedBlobHash` paired a blob hash with its transaction index, but the beacon API's `?versioned_hashes=` query doesn't use the index. Carrying it through the derive pipeline and proof client was unnecessary and a latent correctness risk. Upstream consolidated blob validation into the beacon client fetch itself, removing the need for re-validation in `get_and_validate_blobs`.

This port replaces `&[IndexedBlobHash]` with `&[B256]` throughout the `BlobProvider` trait and all implementations, renames `BoxedBlobWithIndex` to `BoxedBlob`, introduces `BlobWithCommitmentAndProof` for host preimage storage, and renames `fetch_filtered_blob_sidecars` to `fetch_blobs_with_proofs`. The 40-byte hint wire format was already present in `base-proof-host` prior to this port.