### PR TITLE
fix: build 0 flashblocks if no time

### DIFF
--- a/crates/builder/core/src/flashblocks/payload.rs
+++ b/crates/builder/core/src/flashblocks/payload.rs
@@ -286,22 +286,16 @@ where
             ctx.metrics.flashblock_byte_size_histogram.record(flashblock_byte_size as f64);
         }
 
+        let mut build_immediately = false;
         if ctx.attributes().no_tx_pool {
-            finalized_cell.set(payload);
-
             info!(
                 target: "payload_builder",
                 "No transaction pool, skipping transaction pool processing",
             );
 
-            let total_block_building_time = block_build_start_time.elapsed();
-            ctx.metrics.total_block_built_duration.record(total_block_building_time);
-            ctx.metrics.total_block_built_gauge.set(total_block_building_time);
-            ctx.metrics.payload_num_tx.record(info.executed_transactions.len() as f64);
-            ctx.metrics.payload_num_tx_gauge.set(info.executed_transactions.len() as f64);
-
-            return Ok(());
+            build_immediately = true;
         }
+
         // We adjust our flashblocks timings based on time_drift if dynamic adjustment enable
         let (flashblocks_per_block, first_flashblock_offset) =
             self.calculate_flashblocks(timestamp);
@@ -316,6 +310,21 @@ where
             self.config.flashblocks_per_block().saturating_sub(flashblocks_per_block) as f64,
         );
         ctx.metrics.first_flashblock_time_offset.record(first_flashblock_offset.as_millis() as f64);
+
+        // build immediately if flashblocks_per_block <= 0
+        build_immediately = build_immediately || flashblocks_per_block == 0;
+
+        if build_immediately {
+            finalized_cell.set(payload);
+            let total_block_building_time = block_build_start_time.elapsed();
+            ctx.metrics.total_block_built_duration.record(total_block_building_time);
+            ctx.metrics.total_block_built_gauge.set(total_block_building_time);
+            ctx.metrics.payload_num_tx.record(info.executed_transactions.len() as f64);
+            ctx.metrics.payload_num_tx_gauge.set(info.executed_transactions.len() as f64);
+
+            return Ok(());
+        }
+
         let gas_per_batch = ctx.block_gas_limit() / flashblocks_per_block;
         let da_per_batch = ctx
             .builder_config
@@ -796,12 +805,14 @@ where
         else {
             error!(
                 target: "payload_builder",
-                message = "FCU arrived too late or system clock are unsynced",
+                message = "FCU arrived too late or system clock are unsynced, building 0 flashblocks",
                 ?target_time,
                 ?now,
             );
-            return (self.config.flashblocks_per_block(), self.config.flashblocks_interval);
+            // in this case, we have no time to produce any flashblocks
+            return (0, Duration::ZERO);
         };
+
         self.metrics.flashblocks_time_drift.record(
             self.config.block_time.as_millis().saturating_sub(time_drift.as_millis()) as f64,
         );

--- a/crates/builder/core/src/flashblocks/payload.rs
+++ b/crates/builder/core/src/flashblocks/payload.rs
@@ -263,11 +263,17 @@ where
         ctx.metrics.sequencer_tx_duration.record(sequencer_tx_time);
         ctx.metrics.sequencer_tx_gauge.set(sequencer_tx_time);
 
+        // We adjust our flashblocks timings based on time_drift if dynamic adjustment enable
+        let (flashblocks_per_block, first_flashblock_offset) =
+            self.calculate_flashblocks(timestamp);
+
+        let skip_flashblocks_building = ctx.attributes().no_tx_pool || flashblocks_per_block == 0;
+
         let (payload, fb_payload) = build_block(
             &mut state,
             &ctx,
             &mut info,
-            ctx.attributes().no_tx_pool, // need to calculate state root for CL sync
+            skip_flashblocks_building, // need to calculate state root for CL sync or if not building flashblocks
         )?;
 
         self.payload_tx.send(payload.clone()).await.map_err(PayloadBuilderError::other)?;
@@ -284,37 +290,28 @@ where
             let flashblock_byte_size =
                 self.ws_pub.publish(&fb_payload).map_err(PayloadBuilderError::other)?;
             ctx.metrics.flashblock_byte_size_histogram.record(flashblock_byte_size as f64);
-        }
-
-        let mut build_immediately = false;
-        if ctx.attributes().no_tx_pool {
+        } else {
             info!(
                 target: "payload_builder",
                 "No transaction pool, skipping transaction pool processing",
             );
-
-            build_immediately = true;
         }
 
-        // We adjust our flashblocks timings based on time_drift if dynamic adjustment enable
-        let (flashblocks_per_block, first_flashblock_offset) =
-            self.calculate_flashblocks(timestamp);
-        info!(
-            target: "payload_builder",
-            message = "Performed flashblocks timing derivation",
-            flashblocks_per_block,
-            first_flashblock_offset = first_flashblock_offset.as_millis(),
-            flashblocks_interval = self.config.flashblocks_interval.as_millis(),
-        );
-        ctx.metrics.reduced_flashblocks_number.record(
-            self.config.flashblocks_per_block().saturating_sub(flashblocks_per_block) as f64,
-        );
-        ctx.metrics.first_flashblock_time_offset.record(first_flashblock_offset.as_millis() as f64);
+        if flashblocks_per_block == 0 {
+            error!(
+                target: "payload_builder",
+                message = "FCU arrived too late or system clock are unsynced, building 0 flashblocks"
+            );
+            ctx.metrics
+                .reduced_flashblocks_number
+                .record(self.config.flashblocks_per_block().saturating_sub(flashblocks_per_block)
+                    as f64);
+            ctx.metrics
+                .first_flashblock_time_offset
+                .record(first_flashblock_offset.as_millis() as f64);
+        }
 
-        // build immediately if flashblocks_per_block <= 0
-        build_immediately = build_immediately || flashblocks_per_block == 0;
-
-        if build_immediately {
+        if skip_flashblocks_building {
             finalized_cell.set(payload);
             let total_block_building_time = block_build_start_time.elapsed();
             ctx.metrics.total_block_built_duration.record(total_block_building_time);
@@ -324,6 +321,14 @@ where
 
             return Ok(());
         }
+
+        info!(
+            target: "payload_builder",
+            message = "Performed flashblocks timing derivation",
+            flashblocks_per_block,
+            first_flashblock_offset = first_flashblock_offset.as_millis(),
+            flashblocks_interval = self.config.flashblocks_interval.as_millis(),
+        );
 
         let gas_per_batch = ctx.block_gas_limit() / flashblocks_per_block;
         let da_per_batch = ctx
@@ -803,12 +808,6 @@ where
         let Some(time_drift) =
             target_time.duration_since(now).ok().filter(|duration| duration.as_millis() > 0)
         else {
-            error!(
-                target: "payload_builder",
-                message = "FCU arrived too late or system clock are unsynced, building 0 flashblocks",
-                ?target_time,
-                ?now,
-            );
             // in this case, we have no time to produce any flashblocks
             return (0, Duration::ZERO);
         };

--- a/crates/builder/core/src/flashblocks/payload.rs
+++ b/crates/builder/core/src/flashblocks/payload.rs
@@ -303,13 +303,21 @@ where
                 message = "FCU arrived too late or system clock are unsynced, building 0 flashblocks"
             );
             ctx.metrics
-                .reduced_flashblocks_number
-                .record(self.config.flashblocks_per_block().saturating_sub(flashblocks_per_block)
-                    as f64);
-            ctx.metrics
                 .first_flashblock_time_offset
                 .record(first_flashblock_offset.as_millis() as f64);
+
+            self.record_flashblocks_metrics(
+                &ctx,
+                &info,
+                flashblocks_per_block,
+                &span,
+                "FCU arrived too late or system clock are unsynced, building 0 flashblocks",
+            );
         }
+
+        ctx.metrics.reduced_flashblocks_number.record(
+            self.config.flashblocks_per_block().saturating_sub(flashblocks_per_block) as f64,
+        );
 
         if skip_flashblocks_building {
             finalized_cell.set(payload);

--- a/crates/builder/core/src/flashblocks/payload.rs
+++ b/crates/builder/core/src/flashblocks/payload.rs
@@ -290,6 +290,13 @@ where
             let flashblock_byte_size =
                 self.ws_pub.publish(&fb_payload).map_err(PayloadBuilderError::other)?;
             ctx.metrics.flashblock_byte_size_histogram.record(flashblock_byte_size as f64);
+            ctx.metrics
+                .first_flashblock_time_offset
+                .record(first_flashblock_offset.as_millis() as f64);
+            ctx.metrics
+                .reduced_flashblocks_number
+                .record(self.config.flashblocks_per_block().saturating_sub(flashblocks_per_block)
+                    as f64);
         } else {
             info!(
                 target: "payload_builder",
@@ -315,11 +322,6 @@ where
                 "FCU arrived too late or system clock are unsynced, building 0 flashblocks",
             );
         }
-
-        ctx.metrics.first_flashblock_time_offset.record(first_flashblock_offset.as_millis() as f64);
-        ctx.metrics.reduced_flashblocks_number.record(
-            self.config.flashblocks_per_block().saturating_sub(flashblocks_per_block) as f64,
-        );
 
         if skip_flashblocks_building {
             finalized_cell.set(payload);

--- a/crates/builder/core/src/flashblocks/payload.rs
+++ b/crates/builder/core/src/flashblocks/payload.rs
@@ -299,15 +299,13 @@ where
             ctx.metrics.payload_num_tx_gauge.set(info.executed_transactions.len() as f64);
         }
 
-        if flashblocks_per_block == 0 {
+        // fcu just arrived late, not syncing
+        if flashblocks_per_block == 0 && !ctx.attributes().no_tx_pool {
             error!(
                 target: "payload_builder",
                 message = "FCU arrived too late or system clock are unsynced, building 0 flashblocks",
                 timestamp,
             );
-            ctx.metrics
-                .first_flashblock_time_offset
-                .record(first_flashblock_offset.as_millis() as f64);
 
             self.record_flashblocks_metrics(
                 &ctx,
@@ -318,6 +316,7 @@ where
             );
         }
 
+        ctx.metrics.first_flashblock_time_offset.record(first_flashblock_offset.as_millis() as f64);
         ctx.metrics.reduced_flashblocks_number.record(
             self.config.flashblocks_per_block().saturating_sub(flashblocks_per_block) as f64,
         );

--- a/crates/builder/core/src/flashblocks/payload.rs
+++ b/crates/builder/core/src/flashblocks/payload.rs
@@ -295,12 +295,15 @@ where
                 target: "payload_builder",
                 "No transaction pool, skipping transaction pool processing",
             );
+            ctx.metrics.payload_num_tx.record(info.executed_transactions.len() as f64);
+            ctx.metrics.payload_num_tx_gauge.set(info.executed_transactions.len() as f64);
         }
 
         if flashblocks_per_block == 0 {
             error!(
                 target: "payload_builder",
-                message = "FCU arrived too late or system clock are unsynced, building 0 flashblocks"
+                message = "FCU arrived too late or system clock are unsynced, building 0 flashblocks",
+                timestamp,
             );
             ctx.metrics
                 .first_flashblock_time_offset
@@ -324,8 +327,6 @@ where
             let total_block_building_time = block_build_start_time.elapsed();
             ctx.metrics.total_block_built_duration.record(total_block_building_time);
             ctx.metrics.total_block_built_gauge.set(total_block_building_time);
-            ctx.metrics.payload_num_tx.record(info.executed_transactions.len() as f64);
-            ctx.metrics.payload_num_tx_gauge.set(info.executed_transactions.len() as f64);
 
             return Ok(());
         }

--- a/crates/builder/core/src/test_utils/driver.rs
+++ b/crates/builder/core/src/test_utils/driver.rs
@@ -9,6 +9,7 @@ use base_alloy_consensus::{OpTypedTransaction, TxDeposit};
 use base_alloy_network::Base;
 use base_alloy_rpc_types::Transaction;
 use base_node_core::OpPayloadAttributes;
+use chrono::Utc;
 
 use super::{
     DEFAULT_DENOMINATOR, DEFAULT_ELASTICITY, DEFAULT_GAS_LIMIT, EngineApi, ExternalNode, Ipc,
@@ -249,7 +250,10 @@ impl<RpcProtocol: Protocol> ChainDriver<RpcProtocol> {
         txs: Vec<Bytes>,
     ) -> eyre::Result<Block<Transaction>> {
         let latest = self.latest().await?;
-        let latest_timestamp = Duration::from_secs(latest.header.timestamp);
+        let mut latest_timestamp = Duration::from_secs(latest.header.timestamp);
+        // latest_timestamp must be in the future
+        latest_timestamp =
+            latest_timestamp.max(Duration::from_secs(Utc::now().timestamp() as u64 + 1));
         // Use block_time for timestamp calculation to ensure the payload doesn't expire
         // before we can retrieve it. The sleep in build_new_block_with_txs_timestamp uses
         // block_time, so the timestamp must also be block_time ahead.

--- a/crates/builder/core/src/test_utils/instance.rs
+++ b/crates/builder/core/src/test_utils/instance.rs
@@ -15,7 +15,7 @@ use base_alloy_network::Base;
 use base_execution_chainspec::OpChainSpec;
 use base_execution_rpc::OpEthApiBuilder;
 use base_node_core::{OpEngineValidatorBuilder, args::RollupArgs, node::OpPoolBuilder};
-use base_node_runner::BaseNode;
+use base_node_runner::{BaseNode, test_utils::init_silenced_tracing};
 use base_txpool::BasePooledTransaction;
 use futures::{FutureExt, StreamExt};
 use nanoid::nanoid;
@@ -89,6 +89,7 @@ impl LocalInstance {
         node_config: NodeConfig<OpChainSpec>,
     ) -> eyre::Result<Self> {
         clear_otel_env_vars();
+        init_silenced_tracing();
         let runtime = RuntimeBuilder::new(RuntimeConfig::default()).build()?;
         let base_node = BaseNode::new(RollupArgs::default());
 

--- a/crates/builder/core/tests/flashblocks.rs
+++ b/crates/builder/core/tests/flashblocks.rs
@@ -262,7 +262,6 @@ async fn unichain_dynamic_with_lag() -> eyre::Result<()> {
 }
 
 #[tokio::test]
-#[ignore = "flaky in CI"]
 async fn dynamic_with_full_block_lag() -> eyre::Result<()> {
     let config =
         BuilderConfig::for_tests().with_block_time_ms(1000).with_flashblocks_leeway_time_ms(0);

--- a/crates/builder/core/tests/forks.rs
+++ b/crates/builder/core/tests/forks.rs
@@ -6,7 +6,6 @@ use alloy_eips::{BlockNumberOrTag::Latest, Encodable2718, eip1559::MIN_PROTOCOL_
 use alloy_primitives::bytes;
 use base_builder_core::test_utils::{BlockTransactionsExt, setup_test_instance};
 use chrono::Utc;
-use tracing::info;
 
 #[tokio::test]
 async fn jovian_block_parameters_set() -> eyre::Result<()> {
@@ -111,7 +110,6 @@ async fn jovian_minimum_base_fee() -> eyre::Result<()> {
 async fn jovian_minimum_fee_must_be_set() -> eyre::Result<()> {
     let rbuilder = setup_test_instance().await?;
     let driver = rbuilder.driver().await?;
-    let genesis = driver.get_block(Latest).await?.expect("must have genesis block");
     let block_timestamp = Duration::from_secs(Utc::now().timestamp() as u64 + 2);
     let response = driver
         .build_new_block_with_txs_timestamp(vec![], None, Some(block_timestamp), None, None)

--- a/crates/builder/core/tests/forks.rs
+++ b/crates/builder/core/tests/forks.rs
@@ -5,6 +5,8 @@ use std::time::Duration;
 use alloy_eips::{BlockNumberOrTag::Latest, Encodable2718, eip1559::MIN_PROTOCOL_BASE_FEE};
 use alloy_primitives::bytes;
 use base_builder_core::test_utils::{BlockTransactionsExt, setup_test_instance};
+use chrono::Utc;
+use tracing::info;
 
 #[tokio::test]
 async fn jovian_block_parameters_set() -> eyre::Result<()> {
@@ -73,7 +75,8 @@ async fn jovian_minimum_base_fee() -> eyre::Result<()> {
 
     let min_base_fee = Some(MIN_PROTOCOL_BASE_FEE * 2);
 
-    let block_timestamp = Duration::from_secs(genesis.header.timestamp) + Duration::from_secs(1);
+    // give at least 2 seconds to build the block
+    let block_timestamp = Duration::from_secs(Utc::now().timestamp() as u64 + 2);
     let block_one = driver
         .build_new_block_with_txs_timestamp(vec![], None, Some(block_timestamp), None, min_base_fee)
         .await?;
@@ -109,7 +112,7 @@ async fn jovian_minimum_fee_must_be_set() -> eyre::Result<()> {
     let rbuilder = setup_test_instance().await?;
     let driver = rbuilder.driver().await?;
     let genesis = driver.get_block(Latest).await?.expect("must have genesis block");
-    let block_timestamp = Duration::from_secs(genesis.header.timestamp) + Duration::from_secs(1);
+    let block_timestamp = Duration::from_secs(Utc::now().timestamp() as u64 + 2);
     let response = driver
         .build_new_block_with_txs_timestamp(vec![], None, Some(block_timestamp), None, None)
         .await;


### PR DESCRIPTION
When we have no time to build flashblocks, we should not build any flashblocks. Otherwise, our builder is just doing wasted work when the getPayload call will come immediately after anyway.

This fixes a test flake in CI where if the flashblock derivation started in <1 ms, the test would succeed, but >1 ms and the test would fail.

This is because (for a 1 sec block time):
- if timing is derived at 999 ms, it will give 1 ms left and build 1 tiny flashblock
- if timing is derived at 1001 ms, it will give 1s left and build the full number of flashblocks

This fixes the behavior so that 1001 ms produces 0 flashblocks.