### PR TITLE
test(consensus): IndexedBlobHash Test Coverage

### DIFF
--- a/crates/consensus/derive/src/sources/blobs.rs
+++ b/crates/consensus/derive/src/sources/blobs.rs
@@ -520,4 +520,36 @@ pub(crate) mod tests {
             "expected Reset kind to be preserved, got {err:?}"
         );
     }
+
+    /// Verifies that EIP-4844 blobs from non-batcher transactions are excluded from the pipeline.
+    ///
+    /// When `source.batcher_address` does not match the transaction's `to` field, the entire
+    /// transaction is skipped — no blob hashes are collected and `data` remains empty. This tests
+    /// the exclusion path that previously incremented an index counter regardless of the sender.
+    ///
+    /// Two cases are exercised back-to-back to make the contrast explicit:
+    /// 1. Wrong batcher address → no blobs captured.
+    /// 2. Correct batcher address → all 5 blobs from the batcher transaction are captured.
+    #[test]
+    fn test_extract_blob_data_non_batcher_blobs_excluded() {
+        // Case 1: source.batcher_address = Address::ZERO does not match the tx's `to` field
+        // (0x11E9CA82...), so the transaction is skipped and no blobs are captured.
+        let source = default_test_blob_source(); // batcher_address = Address::ZERO
+        let (data, hashes) = source.extract_blob_data(
+            valid_blob_txs(),
+            alloy_primitives::address!("A83C816D4f9b2783761a22BA6FADB0eB0606D7B2"),
+        );
+        assert!(data.is_empty(), "non-batcher blobs must not be captured (data)");
+        assert!(hashes.is_empty(), "non-batcher blob hashes must not be captured");
+
+        // Case 2: correct batcher address → all 5 blobs from the batcher transaction captured.
+        let mut source2 = default_test_blob_source();
+        source2.batcher_address =
+            alloy_primitives::address!("11E9CA82A3a762b4B5bd264d4173a242e7a77064");
+        let batcher_address =
+            alloy_primitives::address!("A83C816D4f9b2783761a22BA6FADB0eB0606D7B2");
+        let (data, hashes) = source2.extract_blob_data(valid_blob_txs(), batcher_address);
+        assert_eq!(data.len(), 5, "all 5 batcher blobs must be captured");
+        assert_eq!(hashes.len(), 5, "all 5 batcher blob hashes must be captured");
+    }
 }

--- a/crates/consensus/providers-alloy/src/beacon_client.rs
+++ b/crates/consensus/providers-alloy/src/beacon_client.rs
@@ -278,7 +278,7 @@ impl BeaconClient for OnlineBeaconClient {
 #[cfg(test)]
 mod tests {
     use alloy_consensus::Blob;
-    use alloy_primitives::{FixedBytes, hex::FromHex};
+    use alloy_primitives::{B256, FixedBytes, hex::FromHex};
     use httpmock::prelude::*;
     use serde_json::json;
 
@@ -288,6 +288,11 @@ mod tests {
     const TEST_BLOB_HASH_HEX: &str =
         "0x016c357b8b3a6b3fd82386e7bebf77143d537cdb1c856509661c412602306a04";
 
+    /// Computes the versioned hash for a blob using the same path as production code.
+    fn versioned_hash_for(blob: &Blob) -> B256 {
+        super::blob_versioned_hash(blob).unwrap()
+    }
+
     #[test]
     fn test_blob_versioned_hash() {
         let input: Blob = FixedBytes::repeat_byte(1);
@@ -295,68 +300,74 @@ mod tests {
         assert_eq!(test_blob_hash, blob_versioned_hash(&input).unwrap());
     }
 
+    /// Verifies that `filtered_beacon_blobs` returns blobs in request order, not server order.
+    ///
+    /// The server returns `[blob_a, blob_b]` but the client requests `[hash_b, hash_a]`.
+    /// The result must follow the request order: `[blob_b, blob_a]`.
     #[tokio::test]
-    async fn test_filtered_beacon_blobs() {
-        let slot = 987654321;
-        let slot_string = slot.to_string();
-        let repeated_blob_data: Vec<Blob> = vec![TEST_BLOB_DATA, TEST_BLOB_DATA];
-        let garbage_blob_data: Vec<Blob> = vec![FixedBytes::repeat_byte(2)];
-        let required_query_param = format!("{TEST_BLOB_HASH_HEX},{TEST_BLOB_HASH_HEX}");
-        let test_blob_hash: FixedBytes<32> = FixedBytes::from_hex(TEST_BLOB_HASH_HEX).unwrap();
-        let requested_blob_hashes: Vec<B256> = vec![test_blob_hash, test_blob_hash];
+    async fn test_filtered_beacon_blobs_distinct_blobs() {
+        let blob_a: Blob = FixedBytes::repeat_byte(1);
+        let blob_b: Blob = FixedBytes::repeat_byte(2);
+        let hash_a = versioned_hash_for(&blob_a);
+        let hash_b = versioned_hash_for(&blob_b);
 
-        struct TestCase {
-            name: &'static str,
-            mock_response_data: Vec<Blob>,
-            want: Option<Vec<BoxedBlob>>, // if none, expect an error
-        }
-
-        let test_cases = vec![
-            TestCase {
-                name: "Repeated Blob Data, expect success",
-                mock_response_data: repeated_blob_data,
-                want: Some(vec![
-                    BoxedBlob { blob: Box::new(TEST_BLOB_DATA) },
-                    BoxedBlob { blob: Box::new(TEST_BLOB_DATA) },
-                ]),
-            },
-            TestCase {
-                name: "Garbage Blob Data, expect error",
-                mock_response_data: garbage_blob_data,
-                want: None, // indicates an error is expected
-            },
-        ];
+        let slot = 987654321u64;
+        // Request in reverse order relative to what the server will return.
+        let requested_hashes: Vec<B256> = vec![hash_b, hash_a];
+        let required_query_param = format!("{hash_b},{hash_a}");
 
         let server = MockServer::start();
-        for test_case in test_cases {
-            // This server mocks a single, specific query on a beacon node,
-            let mock_response = json!({
+        let blobs_mock = server.mock(|when, then| {
+            when.method(GET)
+                .path(format!("/eth/v1/beacon/blobs/{slot}"))
+                .query_param("versioned_hashes", required_query_param);
+            then.status(200).json_body(json!({
                 "execution_optimistic": false,
                 "finalized": false,
-                "data": test_case.mock_response_data
-            });
-            let mut blobs_mock = server.mock(|when, then| {
-                when.method(GET)
-                    .path(format!("/eth/v1/beacon/blobs/{slot_string}"))
-                    .query_param("versioned_hashes", required_query_param.clone());
-                then.status(200).json_body(mock_response);
-            });
+                "data": [blob_a, blob_b]  // server returns natural order
+            }));
+        });
 
-            let client = OnlineBeaconClient::new_http(server.base_url());
-            let response = client.filtered_beacon_blobs(slot, &requested_blob_hashes).await;
-            blobs_mock.assert();
-            match test_case.want {
-                Some(s) => {
-                    let r = response.unwrap();
-                    assert_eq!(r.len(), s.len(), "length mismatch{}", test_case.name);
-                    assert_eq!(r, s, "{}", test_case.name)
-                }
-                None => {
-                    assert!(response.is_err(), "{}", test_case.name)
-                }
-            }
-            blobs_mock.delete();
-        }
+        let client = OnlineBeaconClient::new_http(server.base_url());
+        let result = client.filtered_beacon_blobs(slot, &requested_hashes).await.unwrap();
+        blobs_mock.assert();
+
+        // Output must follow request order (hash_b first, then hash_a).
+        assert_eq!(result.len(), 2);
+        assert_eq!(result[0], BoxedBlob { blob: Box::new(blob_b) }, "first result must be blob_b");
+        assert_eq!(result[1], BoxedBlob { blob: Box::new(blob_a) }, "second result must be blob_a");
+    }
+
+    /// Verifies that requesting a hash that does not match any returned blob yields
+    /// `BeaconClientError::BlobNotFound`.
+    ///
+    /// The server returns `blob_b` (which hashes to `hash_b`), but the client requests
+    /// `hash_a`. Since no returned blob hashes to `hash_a`, the lookup must fail.
+    #[tokio::test]
+    async fn test_filtered_beacon_blobs_hash_mismatch_returns_not_found() {
+        let blob_a: Blob = FixedBytes::repeat_byte(1);
+        let blob_b: Blob = FixedBytes::repeat_byte(2);
+        let hash_a = versioned_hash_for(&blob_a);
+
+        let slot = 5678u64;
+        let server = MockServer::start();
+        let blobs_mock = server.mock(|when, then| {
+            when.method(GET).path(format!("/eth/v1/beacon/blobs/{slot}"));
+            then.status(200).json_body(json!({
+                "execution_optimistic": false,
+                "finalized": false,
+                "data": [blob_b]  // server returns blob_b, but client wants hash_a
+            }));
+        });
+
+        let client = OnlineBeaconClient::new_http(server.base_url());
+        let result = client.filtered_beacon_blobs(slot, &[hash_a]).await;
+        blobs_mock.assert();
+
+        assert!(
+            matches!(result, Err(BeaconClientError::BlobNotFound(_))),
+            "expected BlobNotFound when returned blob does not match requested hash, got {result:?}"
+        );
     }
 
     /// Regression test: a beacon node HTTP 404 for a given slot must return

--- a/crates/consensus/providers-alloy/src/beacon_client.rs
+++ b/crates/consensus/providers-alloy/src/beacon_client.rs
@@ -284,7 +284,6 @@ mod tests {
 
     use super::*;
 
-    const TEST_BLOB_DATA: Blob = FixedBytes::repeat_byte(1);
     const TEST_BLOB_HASH_HEX: &str =
         "0x016c357b8b3a6b3fd82386e7bebf77143d537cdb1c856509661c412602306a04";
 

--- a/crates/consensus/providers-alloy/src/blobs.rs
+++ b/crates/consensus/providers-alloy/src/blobs.rs
@@ -179,6 +179,188 @@ impl<B: BeaconClient> OnlineBlobProvider<B> {
     }
 }
 
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use alloy_eips::eip4844::{Blob, env_settings::EnvKzgSettings, kzg_to_versioned_hash};
+    use alloy_primitives::{B256, FixedBytes};
+    use async_trait::async_trait;
+    use base_consensus_derive::{BlobProvider, BlobProviderError};
+    use base_protocol::BlockInfo;
+
+    use super::{BlobWithCommitmentAndProof, BoxedBlob, OnlineBlobProvider};
+    use crate::{APIConfigResponse, APIGenesisResponse, BeaconClient};
+
+    /// Local error type for [`MockBeaconClient`].
+    #[derive(Debug)]
+    enum MockBeaconError {
+        SlotNotFound,
+        BlobNotFound(B256),
+    }
+
+    impl std::fmt::Display for MockBeaconError {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::SlotNotFound => write!(f, "slot not found"),
+                Self::BlobNotFound(h) => write!(f, "blob not found: {h}"),
+            }
+        }
+    }
+
+    /// A minimal [`BeaconClient`] for unit-testing [`OnlineBlobProvider`].
+    ///
+    /// `filtered_beacon_blobs` iterates the requested hashes in order and looks each up in the
+    /// internal map, returning `BlobNotFound` for any miss — matching the ordering contract of
+    /// [`crate::OnlineBeaconClient`].
+    #[derive(Debug, Default)]
+    struct MockBeaconClient {
+        blobs: HashMap<B256, Blob>,
+        fail_with_slot_not_found: bool,
+    }
+
+    #[async_trait]
+    impl BeaconClient for MockBeaconClient {
+        type Error = MockBeaconError;
+
+        fn slot_not_found(err: &Self::Error) -> Option<u64> {
+            if matches!(err, MockBeaconError::SlotNotFound) { Some(0) } else { None }
+        }
+
+        async fn slot_interval(&self) -> Result<APIConfigResponse, Self::Error> {
+            Ok(APIConfigResponse::new(12))
+        }
+
+        async fn genesis_time(&self) -> Result<APIGenesisResponse, Self::Error> {
+            Ok(APIGenesisResponse::new(0))
+        }
+
+        async fn filtered_beacon_blobs(
+            &self,
+            _slot: u64,
+            blob_hashes: &[B256],
+        ) -> Result<Vec<BoxedBlob>, Self::Error> {
+            if self.fail_with_slot_not_found {
+                return Err(MockBeaconError::SlotNotFound);
+            }
+            blob_hashes
+                .iter()
+                .map(|hash| {
+                    self.blobs
+                        .get(hash)
+                        .map(|blob| BoxedBlob { blob: Box::new(*blob) })
+                        .ok_or(MockBeaconError::BlobNotFound(*hash))
+                })
+                .collect()
+        }
+    }
+
+    /// Computes the versioned hash for a blob using the KZG settings.
+    fn versioned_hash_for(blob: &Blob) -> B256 {
+        let kzg_settings = EnvKzgSettings::Default;
+        let kzg_blob = c_kzg::Blob::new(blob.0);
+        let commitment = kzg_settings.get().blob_to_kzg_commitment(&kzg_blob).unwrap();
+        kzg_to_versioned_hash(commitment.as_slice())
+    }
+
+    /// An empty `blob_hashes` slice must return `Ok(vec![])` without touching the beacon client.
+    #[tokio::test]
+    async fn test_get_and_validate_blobs_empty() {
+        let mut provider = OnlineBlobProvider {
+            beacon_client: MockBeaconClient::default(),
+            genesis_time: 0,
+            slot_interval: 12,
+        };
+        let block_ref = BlockInfo::default();
+        let result = provider.get_and_validate_blobs(&block_ref, &[]).await.unwrap();
+        assert!(result.is_empty(), "empty hashes must return empty blob vec");
+    }
+
+    /// Verifies that `get_and_validate_blobs` preserves the ordering of the input hashes.
+    ///
+    /// The mock stores `{hash_a: blob_a, hash_b: blob_b}` but the request is `[hash_b, hash_a]`.
+    /// The result must be `[blob_b, blob_a]`, following the request order end-to-end through
+    /// [`OnlineBlobProvider`].
+    #[tokio::test]
+    async fn test_get_and_validate_blobs_ordering() {
+        let blob_a: Blob = FixedBytes::repeat_byte(1);
+        let blob_b: Blob = FixedBytes::repeat_byte(2);
+        let hash_a = versioned_hash_for(&blob_a);
+        let hash_b = versioned_hash_for(&blob_b);
+
+        let mut mock = MockBeaconClient::default();
+        mock.blobs.insert(hash_a, blob_a);
+        mock.blobs.insert(hash_b, blob_b);
+
+        let mut provider =
+            OnlineBlobProvider { beacon_client: mock, genesis_time: 0, slot_interval: 12 };
+        let block_ref = BlockInfo { timestamp: 12, ..Default::default() };
+
+        let result = provider.get_and_validate_blobs(&block_ref, &[hash_b, hash_a]).await.unwrap();
+
+        assert_eq!(result.len(), 2);
+        assert_eq!(*result[0], blob_b, "first result must be blob_b (requested first)");
+        assert_eq!(*result[1], blob_a, "second result must be blob_a (requested second)");
+    }
+
+    /// Verifies that a slot-not-found signal from the beacon client propagates through
+    /// [`OnlineBlobProvider`] as `BlobProviderError::BlobNotFound`.
+    ///
+    /// This is the path taken when a beacon node returns HTTP 404 for a missed/orphaned slot.
+    /// The provider must surface `BlobNotFound` so the pipeline triggers a reset instead of
+    /// retrying indefinitely.
+    #[tokio::test]
+    async fn test_get_and_validate_blobs_slot_not_found() {
+        let hash = versioned_hash_for(&FixedBytes::repeat_byte(1));
+
+        let mut mock = MockBeaconClient::default();
+        mock.fail_with_slot_not_found = true;
+
+        let mut provider =
+            OnlineBlobProvider { beacon_client: mock, genesis_time: 0, slot_interval: 12 };
+        let block_ref = BlockInfo { timestamp: 12, ..Default::default() };
+
+        let result = provider.get_and_validate_blobs(&block_ref, &[hash]).await;
+
+        assert!(
+            matches!(result, Err(BlobProviderError::BlobNotFound { .. })),
+            "slot-not-found must propagate as BlobProviderError::BlobNotFound, got {result:?}"
+        );
+    }
+
+    /// Verifies that `fetch_blobs_with_proofs` produces cryptographically correct KZG commitments.
+    ///
+    /// Stores a real blob in the mock, calls `fetch_blobs_with_proofs`, then recomputes the
+    /// versioned hash from the returned commitment and asserts it matches the requested hash.
+    #[tokio::test]
+    async fn test_fetch_blobs_with_proofs_kzg_valid() {
+        let blob: Blob = FixedBytes::repeat_byte(1);
+        let hash = versioned_hash_for(&blob);
+
+        let mut mock = MockBeaconClient::default();
+        mock.blobs.insert(hash, blob);
+
+        let provider =
+            OnlineBlobProvider { beacon_client: mock, genesis_time: 0, slot_interval: 12 };
+        let block_ref = BlockInfo { timestamp: 12, ..Default::default() };
+
+        let result: Vec<BlobWithCommitmentAndProof> =
+            provider.fetch_blobs_with_proofs(&block_ref, &[hash]).await.unwrap();
+
+        assert_eq!(result.len(), 1);
+        let commitment = result[0].kzg_commitment;
+        assert_ne!(commitment, FixedBytes::ZERO, "KZG commitment must be non-zero");
+
+        // Recompute the versioned hash from the returned commitment and verify it
+        // matches the hash we originally requested.
+        let recomputed_hash = kzg_to_versioned_hash(commitment.as_slice());
+        assert_eq!(
+            recomputed_hash, hash,
+            "versioned hash derived from returned commitment must equal the requested hash"
+        );
+    }
+}
+
 #[async_trait]
 impl<B> BlobProvider for OnlineBlobProvider<B>
 where

--- a/crates/consensus/providers-alloy/src/blobs.rs
+++ b/crates/consensus/providers-alloy/src/blobs.rs
@@ -179,6 +179,37 @@ impl<B: BeaconClient> OnlineBlobProvider<B> {
     }
 }
 
+#[async_trait]
+impl<B> BlobProvider for OnlineBlobProvider<B>
+where
+    B: BeaconClient + Send + Sync,
+{
+    type Error = BlobProviderError;
+
+    /// Fetches blobs that were confirmed in the specified L1 block with the given versioned
+    /// hashes. The blobs are already validated by the beacon client by recomputing their
+    /// commitments and checking against the expected hashes.
+    async fn get_and_validate_blobs(
+        &mut self,
+        block_ref: &BlockInfo,
+        blob_hashes: &[B256],
+    ) -> Result<Vec<Box<Blob>>, Self::Error> {
+        if blob_hashes.is_empty() {
+            return Ok(Default::default());
+        }
+
+        // Calculate the slot for the given timestamp.
+        let slot = Self::slot(self.genesis_time, self.slot_interval, block_ref.timestamp)?;
+
+        // Fetch and validate blobs from the beacon client.
+        // The beacon client already validates each blob by recomputing its commitment
+        // and checking it against the expected hash.
+        let blobs = self.fetch_filtered_blobs(slot, blob_hashes).await?;
+
+        Ok(blobs.into_iter().map(|boxed_blob| boxed_blob.blob).collect())
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::collections::HashMap;
@@ -313,8 +344,7 @@ mod tests {
     async fn test_get_and_validate_blobs_slot_not_found() {
         let hash = versioned_hash_for(&FixedBytes::repeat_byte(1));
 
-        let mut mock = MockBeaconClient::default();
-        mock.fail_with_slot_not_found = true;
+        let mock = MockBeaconClient { fail_with_slot_not_found: true, ..Default::default() };
 
         let mut provider =
             OnlineBlobProvider { beacon_client: mock, genesis_time: 0, slot_interval: 12 };
@@ -358,36 +388,5 @@ mod tests {
             recomputed_hash, hash,
             "versioned hash derived from returned commitment must equal the requested hash"
         );
-    }
-}
-
-#[async_trait]
-impl<B> BlobProvider for OnlineBlobProvider<B>
-where
-    B: BeaconClient + Send + Sync,
-{
-    type Error = BlobProviderError;
-
-    /// Fetches blobs that were confirmed in the specified L1 block with the given versioned
-    /// hashes. The blobs are already validated by the beacon client by recomputing their
-    /// commitments and checking against the expected hashes.
-    async fn get_and_validate_blobs(
-        &mut self,
-        block_ref: &BlockInfo,
-        blob_hashes: &[B256],
-    ) -> Result<Vec<Box<Blob>>, Self::Error> {
-        if blob_hashes.is_empty() {
-            return Ok(Default::default());
-        }
-
-        // Calculate the slot for the given timestamp.
-        let slot = Self::slot(self.genesis_time, self.slot_interval, block_ref.timestamp)?;
-
-        // Fetch and validate blobs from the beacon client.
-        // The beacon client already validates each blob by recomputing its commitment
-        // and checking it against the expected hash.
-        let blobs = self.fetch_filtered_blobs(slot, blob_hashes).await?;
-
-        Ok(blobs.into_iter().map(|boxed_blob| boxed_blob.blob).collect())
     }
 }


### PR DESCRIPTION
## Summary

Adds tests for three coverage gaps in #1203.

The existing test_filtered_beacon_blobs used identical blobs, so the HashMap lookup proved nothing about ordering or hash correctness. It is replaced by a distinct-blob ordering test and a hash-mismatch test that asserts BlobNotFound when the server returns a blob whose hash does not match what was requested.

OnlineBlobProvider had no unit tests. A MockBeaconClient is added along with four tests covering empty input, request-order preservation, slot-not-found propagation, and a KZG round-trip that recomputes the versioned hash from the returned commitment.

BlobSource::extract_blob_data gets a test that confirms non-batcher EIP-4844 transactions contribute no blob hashes while batcher transactions are captured in full.