### PR TITLE
feat(actions): Extend Test Framework & Bug Fixes

### DIFF
--- a/actions/harness/src/batcher/actor.rs
+++ b/actions/harness/src/batcher/actor.rs
@@ -86,18 +86,21 @@ impl<'a, S: L2BlockProvider> Batcher<'a, S> {
         Self { l1_miner, l2_source, driver, config }
     }
 
-    /// Drain all available L2 blocks, encode them, and submit the resulting
-    /// frames to the L1 miner as pending transactions.
+    /// Drain all available L2 blocks and encode them into frames without
+    /// submitting to L1.
     ///
-    /// Returns the [`Frame`]s produced so callers can inspect the encoded
-    /// output without mining a block first.
+    /// Returns the encoded frames so callers can inspect or submit them
+    /// selectively. Use [`submit_frames`] to submit a subset of frames to
+    /// the L1 miner.
+    ///
+    /// [`submit_frames`]: Batcher::submit_frames
     ///
     /// # Errors
     ///
     /// Returns [`BatcherError::NoBlocks`] if the L2 source is empty.
     /// Returns [`BatcherError::MissingL1Info`] if the first tx is not a valid deposit.
     /// Returns [`BatcherError::Driver`] if channel encoding fails.
-    pub fn advance(&mut self) -> Result<Vec<Frame>, BatcherError> {
+    pub fn encode_frames(&mut self) -> Result<Vec<Frame>, BatcherError> {
         let mut batch_count = 0u64;
 
         while let Some(block) = self.l2_source.next_block() {
@@ -133,9 +136,15 @@ impl<'a, S: L2BlockProvider> Batcher<'a, S> {
         }
 
         let frames = self.driver.flush()?;
+        info!(batches = batch_count, frames = frames.len(), "batcher encoded frames");
+        Ok(frames)
+    }
 
-        for frame in &frames {
-            // L1 tx payload: DERIVATION_VERSION_0 ++ encoded frame
+    /// Submit the given frames to the L1 miner as pending transactions.
+    ///
+    /// Each frame is submitted as a separate [`PendingTx`].
+    pub fn submit_frames(&mut self, frames: &[Frame]) {
+        for frame in frames {
             let encoded = frame.encode();
             let mut input = Vec::with_capacity(1 + encoded.len());
             input.push(DERIVATION_VERSION_0);
@@ -147,9 +156,19 @@ impl<'a, S: L2BlockProvider> Batcher<'a, S> {
                 input: Bytes::from(input),
             });
         }
+        info!(frames = frames.len(), "batcher submitted frames to L1");
+    }
 
-        info!(batches = batch_count, frames = frames.len(), "batcher submitted frames to L1");
-
+    /// Encode and submit all frames in one step (convenience wrapper).
+    ///
+    /// Equivalent to calling [`encode_frames`] followed by [`submit_frames`]
+    /// with all produced frames.
+    ///
+    /// [`encode_frames`]: Batcher::encode_frames
+    /// [`submit_frames`]: Batcher::submit_frames
+    pub fn advance(&mut self) -> Result<Vec<Frame>, BatcherError> {
+        let frames = self.encode_frames()?;
+        self.submit_frames(&frames);
         Ok(frames)
     }
 }

--- a/actions/harness/src/batcher/mod.rs
+++ b/actions/harness/src/batcher/mod.rs
@@ -1,2 +1,3 @@
 mod actor;
 pub use actor::{Batcher, BatcherConfig, BatcherError};
+pub use base_batcher_driver::ChannelDriverConfig;

--- a/actions/harness/src/harness.rs
+++ b/actions/harness/src/harness.rs
@@ -53,6 +53,35 @@ impl ActionTestHarness {
         self.l1.latest_number()
     }
 
+    /// Mine one L1 block and immediately push it to the given shared chain.
+    ///
+    /// Equivalent to calling `self.l1.mine_block()` followed by
+    /// `chain.push(self.l1.tip().clone())`. Returns the [`BlockInfo`] of the
+    /// newly mined block for use in pipeline signals.
+    pub fn mine_and_push(&mut self, chain: &SharedL1Chain) -> BlockInfo {
+        self.l1.mine_block();
+        chain.push(self.l1.tip().clone());
+        block_info_from(self.l1.tip())
+    }
+
+    /// Return the L2 genesis [`L2BlockInfo`] anchored to the L1 genesis block.
+    ///
+    /// Convenience method eliminating the repeated 10-line construction used in
+    /// reorg reset tests.
+    pub fn l2_genesis(&self) -> L2BlockInfo {
+        let genesis_l1 = block_info_from(self.l1.chain().first().expect("genesis always present"));
+        L2BlockInfo {
+            block_info: BlockInfo {
+                hash: self.rollup_config.genesis.l2.hash,
+                number: self.rollup_config.genesis.l2.number,
+                parent_hash: Default::default(),
+                timestamp: self.rollup_config.genesis.l2_time,
+            },
+            l1_origin: BlockNumHash { number: genesis_l1.number, hash: genesis_l1.hash },
+            seq_num: 0,
+        }
+    }
+
     /// Create a [`Batcher`] backed by the supplied L2 block source.
     ///
     /// Unlike the previous `create_batcher` that consumed an internal

--- a/actions/harness/src/l2.rs
+++ b/actions/harness/src/l2.rs
@@ -376,6 +376,9 @@ fn compute_state_root(db: &InMemoryDB) -> B256 {
 
 impl L2BlockProvider for L2BlockBuilder {
     fn next_block(&mut self) -> Option<OpBlock> {
-        self.build_next_block().ok()
+        Some(
+            self.build_next_block()
+                .unwrap_or_else(|e| panic!("L2BlockBuilder::next_block failed: {e}")),
+        )
     }
 }

--- a/actions/harness/src/lib.rs
+++ b/actions/harness/src/lib.rs
@@ -18,7 +18,7 @@ mod harness;
 pub use harness::ActionTestHarness;
 
 mod batcher;
-pub use batcher::{Batcher, BatcherConfig, BatcherError};
+pub use batcher::{Batcher, BatcherConfig, BatcherError, ChannelDriverConfig};
 
 mod providers;
 pub use providers::{

--- a/actions/harness/src/providers/l1.rs
+++ b/actions/harness/src/providers/l1.rs
@@ -122,6 +122,9 @@ impl ChainProvider for ActionL1ChainProvider {
         &mut self,
         hash: B256,
     ) -> Result<(BlockInfo, Vec<alloy_consensus::TxEnvelope>), Self::Error> {
+        // The derivation pipeline reads batcher data via `DataAvailabilityProvider::next`,
+        // not via this method. Returning an empty transaction list is correct for the
+        // current action-test use case; returning real batcher txs here is not needed.
         self.chain.with(|blocks| {
             blocks
                 .iter()

--- a/actions/harness/tests/derivation.rs
+++ b/actions/harness/tests/derivation.rs
@@ -1,33 +1,15 @@
 #![doc = "Action tests for L2 derivation via the verifier pipeline."]
 
-use alloy_eips::BlockNumHash;
-use alloy_primitives::{Address, B256, LogData};
+use alloy_primitives::{Address, B256, Bytes, LogData};
 use base_action_harness::{
-    ActionL2Source, ActionTestHarness, BatcherConfig, L1MinerConfig, SharedL1Chain, block_info_from,
+    ActionL2Source, ActionTestHarness, BatcherConfig, ChannelDriverConfig, L1MinerConfig,
+    PendingTx, SharedL1Chain, block_info_from,
 };
 use base_consensus_genesis::{
     CONFIG_UPDATE_EVENT_VERSION_0, CONFIG_UPDATE_TOPIC, ChainGenesis, HardForkConfig, RollupConfig,
     SystemConfig,
 };
-use base_protocol::{BlockInfo, L2BlockInfo};
-
-/// Build an [`L2BlockInfo`] representing the L2 genesis state for a rollup.
-///
-/// The L2 genesis anchors to the given `l1_genesis` block as its L1 origin.
-/// Used to populate [`L2Verifier::act_reset`] when reverting to genesis after
-/// an L1 reorg.
-fn l2_genesis_for(rollup_cfg: &RollupConfig, l1_genesis: BlockInfo) -> L2BlockInfo {
-    L2BlockInfo {
-        block_info: BlockInfo {
-            hash: rollup_cfg.genesis.l2.hash,
-            number: rollup_cfg.genesis.l2.number,
-            parent_hash: Default::default(),
-            timestamp: rollup_cfg.genesis.l2_time,
-        },
-        l1_origin: BlockNumHash { hash: l1_genesis.hash, number: l1_genesis.number },
-        seq_num: 0,
-    }
-}
+use base_protocol::DERIVATION_VERSION_0;
 
 /// Build a [`RollupConfig`] wired to the given [`BatcherConfig`].
 ///
@@ -236,7 +218,7 @@ async fn reorg_reverts_derived_safe_head() {
 
     // Reset the pipeline: revert safe head and L1 origin to genesis.
     let l1_genesis = block_info_from(h.l1.chain().first().expect("genesis always present"));
-    let l2_genesis = l2_genesis_for(&rollup_cfg, l1_genesis);
+    let l2_genesis = h.l2_genesis();
     let genesis_sys_cfg = rollup_cfg.genesis.system_config.unwrap_or_default();
 
     verifier.act_reset(l1_genesis, l2_genesis, genesis_sys_cfg).await.expect("reset");
@@ -288,7 +270,7 @@ async fn reorg_and_resubmit_rederives_l2_block() {
 
     // Reset pipeline to genesis.
     let l1_genesis = block_info_from(h.l1.chain().first().expect("genesis always present"));
-    let l2_genesis = l2_genesis_for(&rollup_cfg, l1_genesis);
+    let l2_genesis = h.l2_genesis();
     let genesis_sys_cfg = rollup_cfg.genesis.system_config.unwrap_or_default();
 
     verifier.act_reset(l1_genesis, l2_genesis, genesis_sys_cfg).await.expect("reset");
@@ -339,7 +321,7 @@ async fn reorg_flip_flop() {
     // Shared reset helpers — computed once, valid across all forks because
     // genesis is immutable.
     let l1_genesis = block_info_from(h.l1.chain().first().expect("genesis always present"));
-    let l2_genesis = l2_genesis_for(&rollup_cfg, l1_genesis);
+    let l2_genesis = h.l2_genesis();
     let genesis_sys_cfg = rollup_cfg.genesis.system_config.unwrap_or_default();
 
     // --- Phase 1: Fork A canonical (genesis → A1 with batch). ---
@@ -620,4 +602,455 @@ async fn batcher_key_rotation_accepts_new_batcher() {
     let derived_b = verifier.act_l2_pipeline_full().await.expect("step block 5");
     assert_eq!(derived_b, 1, "batcher B frame must be derived after key rotation");
     assert_eq!(verifier.l2_safe().block_info.number, 3, "safe head advances to 3");
+}
+
+/// Derive 6 L2 blocks all belonging to the same L1 epoch (genesis).
+///
+/// With `block_time=2` and L1 `block_time=12`, L2 blocks 1-6 (timestamps
+/// 2,4,6,8,10,12) all reference epoch 0 because the first L1 block after
+/// genesis has not been mined yet when the blocks are built. Each L2 block
+/// is batched into a separate L1 inclusion block.
+#[tokio::test]
+async fn multi_l2_per_l1_epoch() {
+    const L2_COUNT: u64 = 6;
+    let batcher_cfg = BatcherConfig::default();
+    let rollup_cfg = rollup_config_for(&batcher_cfg);
+    let mut h = ActionTestHarness::new(L1MinerConfig::default(), rollup_cfg);
+
+    let l1_chain = SharedL1Chain::from_blocks(h.l1.chain().to_vec());
+    let mut builder = h.create_l2_builder(l1_chain);
+
+    let (mut verifier, chain) = h.create_verifier();
+
+    for i in 1..=L2_COUNT {
+        let block = builder.build_next_block().expect("build L2 block");
+        let hash = builder.head().block_info.hash;
+        verifier.register_block_hash(i, hash);
+
+        let mut source = ActionL2Source::new();
+        source.push(block);
+        let mut batcher = h.create_batcher(source, batcher_cfg.clone());
+        batcher.advance().expect("batcher advance");
+        drop(batcher);
+
+        h.mine_and_push(&chain);
+    }
+
+    verifier.initialize().await.expect("initialize");
+
+    for i in 1..=L2_COUNT {
+        let l1_block = block_info_from(h.l1.block_by_number(i).expect("block exists"));
+        verifier.act_l1_head_signal(l1_block).await.expect("signal");
+        let derived = verifier.act_l2_pipeline_full().await.expect("step");
+        assert_eq!(derived, 1, "L1 block {i} should derive exactly one L2 block");
+    }
+
+    assert_eq!(
+        verifier.l2_safe().block_info.number,
+        L2_COUNT,
+        "safe head should be at L2 block {L2_COUNT}"
+    );
+    assert_eq!(verifier.l2_safe().l1_origin.number, 0, "all blocks in epoch 0");
+}
+
+/// A batch submitted past the sequence window is rejected and the pipeline
+/// generates deposit-only (default) blocks to fill the epoch instead.
+///
+/// With `seq_window_size = 3` and epoch 0, valid inclusion blocks are those
+/// with `inclusion_block < epoch + seq_window = 0 + 3 = 3`, i.e. blocks 1
+/// and 2. A batch included in block 3 is past the window and is dropped.
+///
+/// When the sequence window closes without a valid batch for an epoch, the
+/// pipeline generates default (deposit-only) blocks for all L2 slots in
+/// that epoch. This means the safe head still advances — but only with
+/// deposit-only blocks, not with the user-submitted batch content.
+///
+/// Contrast with [`batch_accepted_at_last_seq_window_block`] where the
+/// batch is submitted inside the window and is accepted.
+#[tokio::test]
+async fn batch_past_sequence_window_rejected() {
+    const SEQ_WINDOW: u64 = 3;
+    let batcher_cfg = BatcherConfig::default();
+    let rollup_cfg = RollupConfig {
+        batch_inbox_address: batcher_cfg.inbox_address,
+        block_time: 2,
+        max_sequencer_drift: 600,
+        seq_window_size: SEQ_WINDOW,
+        channel_timeout: 300,
+        genesis: ChainGenesis {
+            system_config: Some(SystemConfig {
+                batcher_address: batcher_cfg.batcher_address,
+                gas_limit: 30_000_000,
+                ..Default::default()
+            }),
+            ..Default::default()
+        },
+        hardforks: HardForkConfig { fjord_time: Some(0), ..Default::default() },
+        ..Default::default()
+    };
+    let mut h = ActionTestHarness::new(L1MinerConfig::default(), rollup_cfg);
+
+    // Build L2 block 1 (epoch 0).
+    let l1_chain = SharedL1Chain::from_blocks(h.l1.chain().to_vec());
+    let mut builder = h.create_l2_builder(l1_chain);
+    let mut source = ActionL2Source::new();
+    source.push(builder.build_next_block().expect("build block 1"));
+
+    // Mine 2 empty L1 blocks (seq_window=3, so valid inclusion is blocks 1 and 2 only).
+    // Batch is valid if inclusion_block < epoch + seq_window = 0 + 3 = 3.
+    // So blocks 1 and 2 are valid, block 3 is NOT.
+    h.mine_l1_blocks(2); // mine blocks 1 and 2 (no batch yet)
+
+    // Submit batch in block 3 — past the window.
+    let mut batcher = h.create_batcher(source, batcher_cfg);
+    batcher.advance().expect("encode");
+    drop(batcher);
+    h.l1.mine_block(); // block 3
+
+    let (mut verifier, _chain) = h.create_verifier();
+    verifier.initialize().await.expect("initialize");
+
+    let mut total_derived = 0;
+    for i in 1..=SEQ_WINDOW {
+        let block = block_info_from(h.l1.block_by_number(i).expect("block exists"));
+        verifier.act_l1_head_signal(block).await.expect("signal");
+        total_derived += verifier.act_l2_pipeline_full().await.expect("step");
+    }
+
+    // The pipeline generates deposit-only blocks to fill the epoch when the
+    // sequence window expires without a valid batch. The safe head advances
+    // past genesis because default blocks are still derived.
+    assert!(
+        verifier.l2_safe().block_info.number > 0,
+        "pipeline should generate deposit-only blocks when sequence window expires"
+    );
+    assert!(
+        total_derived > 0,
+        "pipeline should derive deposit-only (default) blocks for the expired epoch"
+    );
+    // All derived blocks are in epoch 0 since no L1 epoch boundary was crossed.
+    assert_eq!(
+        verifier.l2_safe().l1_origin.number,
+        0,
+        "all deposit-only blocks should reference epoch 0"
+    );
+}
+
+/// Build 12 L2 blocks spanning two epoch boundaries (epoch 0 → 1 → 2).
+///
+/// With `block_time=2` and L1 `block_time=12`:
+/// - L2 blocks 1-5 (timestamps 2-10) reference epoch 0 (L1 genesis at ts=0)
+/// - L2 blocks 6-11 (timestamps 12-22) reference epoch 1 (L1 block 1 at ts=12)
+/// - L2 block 12 (timestamp 24) references epoch 2 (L1 block 2 at ts=24)
+///
+/// Each L2 block is batched into its own L1 inclusion block. The test verifies
+/// that all 12 blocks are derived and the final safe head reaches block 12.
+#[tokio::test]
+async fn multi_epoch_sequence() {
+    let batcher_cfg = BatcherConfig::default();
+    let rollup_cfg = rollup_config_for(&batcher_cfg);
+    let mut h = ActionTestHarness::new(L1MinerConfig::default(), rollup_cfg);
+
+    // Mine L1 blocks 1 and 2 so the builder can advance epochs.
+    h.mine_l1_blocks(2);
+
+    // Build 12 L2 blocks from genesis using a shared L1 chain that includes
+    // the two mined L1 blocks for epoch advancement.
+    let l1_chain = SharedL1Chain::from_blocks(h.l1.chain().to_vec());
+    let mut builder = h.create_l2_builder(l1_chain);
+
+    let mut blocks = Vec::new();
+    let mut block_hashes = Vec::new();
+    for _ in 0..12 {
+        let block = builder.build_next_block().expect("build L2 block");
+        let head = builder.head();
+        block_hashes.push((head.block_info.number, head.block_info.hash));
+        blocks.push(block);
+    }
+
+    // Verify the builder's epoch assignment at the boundary.
+    // L2 block 6 (index 5) should be the first block in epoch 1.
+    assert_eq!(builder.head().l1_origin.number, 2, "L2 block 12 should reference epoch 2");
+
+    // Create verifier and register all block hashes.
+    let (mut verifier, chain) = h.create_verifier();
+    for (number, hash) in &block_hashes {
+        verifier.register_block_hash(*number, *hash);
+    }
+
+    // Batch each L2 block into a separate L1 inclusion block.
+    for block in &blocks {
+        let mut source = ActionL2Source::new();
+        source.push(block.clone());
+        let mut batcher = h.create_batcher(source, batcher_cfg.clone());
+        batcher.advance().expect("batcher advance");
+        drop(batcher);
+        h.mine_and_push(&chain);
+    }
+
+    verifier.initialize().await.expect("initialize");
+
+    // Drive derivation through all L1 blocks: blocks 1-2 are epoch-providing
+    // (no batches), blocks 3-14 each contain one batch.
+    let mut total_derived = 0;
+    for i in 1..=(2 + 12) {
+        let l1_block = block_info_from(h.l1.block_by_number(i).expect("block exists"));
+        verifier.act_l1_head_signal(l1_block).await.expect("signal");
+        total_derived += verifier.act_l2_pipeline_full().await.expect("step");
+    }
+
+    assert_eq!(total_derived, 12, "all 12 L2 blocks should be derived");
+    assert_eq!(verifier.l2_safe().block_info.number, 12, "safe head should reach L2 block 12");
+}
+
+/// Build 3 L2 blocks, encode all 3 into a single batcher submission (one
+/// channel), mine one L1 block, and verify that all 3 are derived from that
+/// single L1 block.
+///
+/// This tests that the pipeline correctly handles multiple batches within a
+/// single channel frame delivered in one L1 block.
+#[tokio::test]
+async fn same_epoch_multi_batch_one_l1_block() {
+    let batcher_cfg = BatcherConfig::default();
+    let rollup_cfg = rollup_config_for(&batcher_cfg);
+    let mut h = ActionTestHarness::new(L1MinerConfig::default(), rollup_cfg);
+
+    let l1_chain = SharedL1Chain::from_blocks(h.l1.chain().to_vec());
+    let mut builder = h.create_l2_builder(l1_chain);
+
+    let mut source = ActionL2Source::new();
+    let mut block_hashes = Vec::new();
+    for _ in 1..=3u64 {
+        let block = builder.build_next_block().expect("build");
+        let head = builder.head();
+        block_hashes.push((head.block_info.number, head.block_info.hash));
+        source.push(block);
+    }
+
+    // Encode all 3 blocks into one batcher submission (single channel).
+    let mut batcher = h.create_batcher(source, batcher_cfg);
+    batcher.advance().expect("batcher encode 3 blocks");
+    drop(batcher);
+
+    // Mine ONE L1 block containing all 3 batches.
+    h.l1.mine_block();
+
+    // Create verifier after mining so the snapshot includes the inclusion block.
+    let (mut verifier, _chain) = h.create_verifier();
+    for (number, hash) in &block_hashes {
+        verifier.register_block_hash(*number, *hash);
+    }
+    verifier.initialize().await.expect("initialize");
+
+    let l1_block_1 = block_info_from(h.l1.block_by_number(1).expect("block 1"));
+    verifier.act_l1_head_signal(l1_block_1).await.expect("signal");
+    let derived = verifier.act_l2_pipeline_full().await.expect("step");
+
+    assert_eq!(derived, 3, "all 3 L2 blocks should be derived from one L1 block");
+    assert_eq!(verifier.l2_safe().block_info.number, 3);
+}
+
+/// Derive 5 L2 blocks, reorg L1 all the way back to genesis, resubmit all 5
+/// batches on the new fork, and verify the safe head recovers to 5.
+///
+/// This is a deeper reorg than [`reorg_reverts_derived_safe_head`] which only
+/// tests a single-block reorg. Here the verifier must correctly reset its
+/// internal state (channels, batch queue, safe head) after a deep reorg that
+/// removes 5 L1 inclusion blocks.
+#[tokio::test]
+async fn deep_reorg_multi_block() {
+    let batcher_cfg = BatcherConfig::default();
+    let rollup_cfg = rollup_config_for(&batcher_cfg);
+    let mut h = ActionTestHarness::new(L1MinerConfig::default(), rollup_cfg.clone());
+
+    let l1_chain = SharedL1Chain::from_blocks(h.l1.chain().to_vec());
+    let mut builder = h.create_l2_builder(l1_chain);
+
+    // Build 5 L2 blocks.
+    let mut blocks = Vec::new();
+    let mut block_hashes = Vec::new();
+    for _ in 0..5 {
+        let block = builder.build_next_block().expect("build");
+        let head = builder.head();
+        block_hashes.push((head.block_info.number, head.block_info.hash));
+        blocks.push(block);
+    }
+
+    // Submit each block's batch individually and mine an L1 block for each.
+    for block in &blocks {
+        let mut source = ActionL2Source::new();
+        source.push(block.clone());
+        let mut batcher = h.create_batcher(source, batcher_cfg.clone());
+        batcher.advance().expect("encode");
+        drop(batcher);
+        h.l1.mine_block();
+    }
+
+    // Create verifier with all 5 L1 inclusion blocks visible.
+    let (mut verifier, chain) = h.create_verifier();
+    for (number, hash) in &block_hashes {
+        verifier.register_block_hash(*number, *hash);
+    }
+    verifier.initialize().await.expect("initialize");
+
+    for i in 1..=5u64 {
+        let l1_block = block_info_from(h.l1.block_by_number(i).expect("block exists"));
+        verifier.act_l1_head_signal(l1_block).await.expect("signal");
+        verifier.act_l2_pipeline_full().await.expect("step");
+    }
+    assert_eq!(verifier.l2_safe().block_info.number, 5, "pre-reorg: 5 L2 blocks derived");
+
+    // Reorg all the way back to genesis.
+    h.l1.reorg_to(0).expect("reorg to genesis");
+    chain.truncate_to(0);
+
+    let l1_genesis = block_info_from(h.l1.chain().first().expect("genesis"));
+    let l2_genesis = h.l2_genesis();
+    let genesis_sys_cfg = rollup_cfg.genesis.system_config.unwrap_or_default();
+    verifier.act_reset(l1_genesis, l2_genesis, genesis_sys_cfg).await.expect("reset");
+    verifier.act_l2_pipeline_full().await.expect("drain after reset");
+
+    assert_eq!(verifier.l2_safe().block_info.number, 0, "safe head reverted to genesis");
+
+    // Re-submit all 5 batches on the new fork.
+    for block in &blocks {
+        let mut source = ActionL2Source::new();
+        source.push(block.clone());
+        let mut batcher = h.create_batcher(source, batcher_cfg.clone());
+        batcher.advance().expect("re-encode");
+        drop(batcher);
+        h.mine_and_push(&chain);
+    }
+
+    // Drive derivation on the new fork.
+    for i in 1..=5u64 {
+        let new_l1_block = block_info_from(h.l1.block_by_number(i).expect("block"));
+        verifier.act_l1_head_signal(new_l1_block).await.expect("signal");
+        verifier.act_l2_pipeline_full().await.expect("step");
+    }
+
+    assert_eq!(verifier.l2_safe().block_info.number, 5, "post-reorg: 5 L2 blocks recovered");
+}
+
+/// Garbage frame data (valid derivation version prefix but corrupt frame
+/// bytes) must be silently ignored by the pipeline. A valid batch submitted
+/// in a subsequent L1 block must still derive correctly.
+///
+/// This verifies the `ChannelBank`'s robustness: malformed frames are
+/// dropped without crashing the pipeline or poisoning subsequent channels.
+#[tokio::test]
+async fn garbage_frame_data_ignored() {
+    let batcher_cfg = BatcherConfig::default();
+    let rollup_cfg = rollup_config_for(&batcher_cfg);
+    let mut h = ActionTestHarness::new(L1MinerConfig::default(), rollup_cfg);
+
+    let l1_chain = SharedL1Chain::from_blocks(h.l1.chain().to_vec());
+    let mut builder = h.create_l2_builder(l1_chain);
+    let mut source = ActionL2Source::new();
+    let block = builder.build_next_block().expect("build L2 block 1");
+    let hash1 = builder.head().block_info.hash;
+    source.push(block);
+
+    let (mut verifier, chain) = h.create_verifier();
+    verifier.register_block_hash(1, hash1);
+    verifier.initialize().await.expect("initialize");
+
+    // Submit a garbage batcher tx: valid derivation version prefix + random bytes.
+    // The ChannelBank should reject the malformed frame and not crash.
+    let garbage = {
+        let mut v = vec![DERIVATION_VERSION_0];
+        v.extend_from_slice(&[0xFF, 0xAB, 0x12, 0x34, 0x56, 0x78]);
+        Bytes::from(v)
+    };
+    h.l1.submit_tx(PendingTx {
+        from: batcher_cfg.batcher_address,
+        to: batcher_cfg.inbox_address,
+        input: garbage,
+    });
+    h.mine_and_push(&chain);
+
+    let l1_block_1 = block_info_from(h.l1.block_by_number(1).expect("block 1"));
+    verifier.act_l1_head_signal(l1_block_1).await.expect("signal garbage block");
+    let derived = verifier.act_l2_pipeline_full().await.expect("step over garbage");
+    assert_eq!(derived, 0, "garbage frame must be silently ignored");
+    assert_eq!(verifier.l2_safe().block_info.number, 0);
+
+    // Now submit the real batch.
+    let mut batcher = h.create_batcher(source, batcher_cfg);
+    batcher.advance().expect("encode");
+    drop(batcher);
+    h.mine_and_push(&chain);
+
+    let l1_block_2 = block_info_from(h.l1.block_by_number(2).expect("block 2"));
+    verifier.act_l1_head_signal(l1_block_2).await.expect("signal real block");
+    let derived = verifier.act_l2_pipeline_full().await.expect("step real block");
+    assert_eq!(derived, 1, "real frame after garbage must still be derived");
+    assert_eq!(verifier.l2_safe().block_info.number, 1);
+}
+
+/// A channel whose compressed data exceeds `max_frame_size` is split across
+/// multiple frames. All frames are submitted in the same L1 block (as separate
+/// transactions) and the `ChannelBank` reassembles them into the original
+/// channel data, deriving the L2 block.
+///
+/// This exercises the `ChannelDriver` multi-frame output path and verifies
+/// that [`Batcher::encode_frames`] / [`Batcher::submit_frames`] correctly
+/// produce multiple frame transactions that the derivation pipeline reassembles.
+///
+/// NOTE: The `IndexedTraversal` mode clears the `ChannelBank` on each
+/// `ProvideBlock` signal, so multi-L1-block channels are not supported in this
+/// test harness. All frames must land in the same L1 block.
+#[tokio::test]
+async fn multi_frame_channel_reassembled() {
+    let batcher_cfg = BatcherConfig {
+        // A very small frame size forces the channel to spill across
+        // multiple frames even for a single L2 block's batch data.
+        driver: ChannelDriverConfig { max_frame_size: 80 },
+        ..BatcherConfig::default()
+    };
+    let rollup_cfg = rollup_config_for(&batcher_cfg);
+    let mut h = ActionTestHarness::new(L1MinerConfig::default(), rollup_cfg);
+
+    let l1_chain = SharedL1Chain::from_blocks(h.l1.chain().to_vec());
+    let mut builder = h.create_l2_builder(l1_chain);
+    let mut source = ActionL2Source::new();
+    let block = builder.build_next_block().expect("build L2 block 1");
+    let hash1 = builder.head().block_info.hash;
+    source.push(block);
+
+    let (mut verifier, chain) = h.create_verifier();
+    verifier.register_block_hash(1, hash1);
+
+    // Encode the L2 block. With max_frame_size=80, the compressed channel data
+    // should spill across multiple frames.
+    let mut batcher = h.create_batcher(source, batcher_cfg);
+    let frames = batcher.encode_frames().expect("encode");
+    assert!(
+        frames.len() >= 2,
+        "expected channel to split into 2+ frames with max_frame_size=80, got {}",
+        frames.len()
+    );
+
+    // Verify frame structure: sequential numbers, same channel ID, only last frame has is_last.
+    for (i, frame) in frames.iter().enumerate() {
+        assert_eq!(frame.number, i as u16, "frame {i} should have number {i}");
+        assert_eq!(frame.id, frames[0].id, "all frames should share the same channel ID");
+        if i < frames.len() - 1 {
+            assert!(!frame.is_last, "intermediate frame {i} must not be marked as last");
+        } else {
+            assert!(frame.is_last, "final frame must be marked as last");
+        }
+    }
+
+    // Submit ALL frames to the same L1 block (each as a separate tx).
+    batcher.submit_frames(&frames);
+    drop(batcher);
+    h.mine_and_push(&chain);
+
+    verifier.initialize().await.expect("initialize");
+    let l1_block_1 = block_info_from(h.l1.block_by_number(1).expect("block 1"));
+    verifier.act_l1_head_signal(l1_block_1).await.expect("signal block 1");
+    let derived = verifier.act_l2_pipeline_full().await.expect("step block 1");
+    assert_eq!(derived, 1, "multi-frame channel should be reassembled and derived");
+    assert_eq!(verifier.l2_safe().block_info.number, 1);
 }

--- a/crates/batcher/comp/src/brotli.rs
+++ b/crates/batcher/comp/src/brotli.rs
@@ -117,6 +117,7 @@ impl CompressorWriter for BrotliCompressor {
     fn read(&mut self, buf: &mut [u8]) -> CompressorResult<usize> {
         let len = self.compressed.len().min(buf.len());
         buf[..len].copy_from_slice(&self.compressed[..len]);
+        self.compressed.drain(..len);
         Ok(len)
     }
 

--- a/crates/batcher/comp/src/channel_out.rs
+++ b/crates/batcher/comp/src/channel_out.rs
@@ -1,6 +1,6 @@
 //! Contains the `ChannelOut` primitive for Optimism.
 
-use alloc::vec;
+use alloc::{vec, vec::Vec};
 
 use alloy_rlp::Encodable;
 use base_consensus_genesis::RollupConfig;
@@ -130,14 +130,16 @@ where
     }
 
     /// Outputs a [Frame] from the [`ChannelOut`].
+    ///
+    /// Call this repeatedly until [`ready_bytes`] returns 0 to drain all
+    /// compressed data into frames. Only the final frame (when no data
+    /// remains and the channel is closed) will have `is_last = true`.
+    ///
+    /// [`ready_bytes`]: ChannelOut::ready_bytes
     pub fn output_frame(&mut self, max_size: usize) -> Result<Frame, ChannelOutError> {
         if max_size < FRAME_V0_OVERHEAD {
             return Err(ChannelOutError::MaxFrameSizeTooSmall);
         }
-
-        // Construct an empty frame.
-        let mut frame =
-            Frame { id: self.id, number: self.frame_number, is_last: self.closed, data: vec![] };
 
         // The first frame carries the channel version prefix (if any) so that
         // the reader can identify the compression format.  For brotli this is
@@ -151,16 +153,22 @@ where
             max_size = self.ready_bytes();
         }
 
+        let mut data = Vec::with_capacity(prefix_len + max_size);
         if let Some(v) = version_byte {
-            frame.data.push(v);
+            data.push(v);
         }
 
         // Read `max_size` bytes from the compressed data.
-        let mut data = vec![0u8; max_size];
-        self.compressor.read(&mut data).map_err(ChannelOutError::Compression)?;
-        frame.data.extend_from_slice(data.as_slice());
+        let mut buf = vec![0u8; max_size];
+        self.compressor.read(&mut buf).map_err(ChannelOutError::Compression)?;
+        data.extend_from_slice(&buf);
 
-        // Update the compressed data.
+        // `is_last` is only true when the channel is closed AND all
+        // compressed data has been consumed (ready_bytes == 0 after read).
+        let is_last = self.closed && self.ready_bytes() == 0;
+
+        let frame = Frame { id: self.id, number: self.frame_number, is_last, data };
+
         self.frame_number += 1;
         Ok(frame)
     }

--- a/crates/batcher/driver/src/driver.rs
+++ b/crates/batcher/driver/src/driver.rs
@@ -66,8 +66,10 @@ impl ChannelDriver {
     ///
     /// A fresh [`ChannelOut`] is created for each flush so channels do not
     /// span across calls. All pending batches are drained, compressed together
-    /// into a single channel, and returned as a `Vec<Frame>`. After a
-    /// successful flush the driver is empty and ready for the next round.
+    /// into a single channel, and returned as a `Vec<Frame>`. When
+    /// `max_frame_size` is smaller than the compressed output, the channel is
+    /// split across multiple frames. After a successful flush the driver is
+    /// empty and ready for the next round.
     ///
     /// # Errors
     ///
@@ -92,21 +94,24 @@ impl ChannelDriver {
         channel_out.flush()?;
         channel_out.close();
 
-        let frame = channel_out.output_frame(self.config.max_frame_size)?;
+        let mut frames = Vec::new();
+        while channel_out.ready_bytes() > 0 {
+            let frame = channel_out.output_frame(self.config.max_frame_size)?;
+            debug!(
+                channel_id = ?frame.id,
+                frame_number = frame.number,
+                is_last = frame.is_last,
+                data_len = frame.data.len(),
+                "flushed channel frame"
+            );
+            frames.push(frame);
+        }
 
         // Clear pending only after all operations succeed so a failed flush
         // leaves the queue intact for retry or inspection.
         self.pending.clear();
 
-        debug!(
-            channel_id = ?frame.id,
-            frame_number = frame.number,
-            is_last = frame.is_last,
-            data_len = frame.data.len(),
-            "flushed channel to frame"
-        );
-
-        Ok(vec![frame])
+        Ok(frames)
     }
 }
 


### PR DESCRIPTION
> [!WARNING]
> Stacked on #1200. Review and merge that first.

Extends the action test framework with correctness fixes, new derivation tests, and three bug fixes in the batcher stack uncovered during testing.

Correctness fixes: `L2BlockBuilder::next_block` now panics on error instead of silently returning `None`. `ActionTestHarness` gains `mine_and_push` (mine + push to `SharedL1Chain` in one call) and `l2_genesis` (eliminates the repeated 10-line genesis construction across reorg tests). The empty-tx stub in `block_info_and_transactions_by_hash` is documented.

Batcher bug fixes: `BrotliCompressor::read` was copying without draining so multi-frame output was impossible. `ChannelOut::output_frame` set `is_last` on every frame when the channel was closed rather than only the final one. `ChannelDriver::flush` only ever produced one frame instead of looping until all data was consumed. `Batcher::advance` is split into `encode_frames` and `submit_frames` for per-frame submission control.

New tests (8): `multi_l2_per_l1_epoch`, `batch_past_sequence_window_rejected`, `multi_epoch_sequence` (12 L2 blocks across 3 epochs), `same_epoch_multi_batch_one_l1_block`, `deep_reorg_multi_block` (5-block reorg recovery), `multi_frame_channel_reassembled` (max_frame_size=80 forces 4-frame split), `garbage_frame_data_ignored`. All 15 derivation tests, 9 batch_submission tests, 12 comp tests, and 6 batcher-driver tests pass.