### PR TITLE
chore: remove unnecessary logs in metering

### DIFF
--- a/crates/client/metering/src/transaction.rs
+++ b/crates/client/metering/src/transaction.rs
@@ -4,7 +4,6 @@ use alloy_primitives::U256;
 use base_revm::{L1BlockInfo, OpSpecId};
 use derive_more::Display;
 use reth_primitives_traits::Account;
-use tracing::warn;
 
 /// Errors that can occur when validating a transaction.
 #[derive(Debug, PartialEq, Eq, Display)]
@@ -36,7 +35,6 @@ pub fn validate_tx<T: Transaction + Encodable2718>(
 
     // Return error if execution cost exceeds balance
     if txn_cost > account.balance {
-        warn!(message = "Insufficient funds for transfer");
         return Err(TxValidationError::InsufficientFundsForTransfer(txn_cost, account.balance));
     }
 
@@ -45,7 +43,6 @@ pub fn validate_tx<T: Transaction + Encodable2718>(
     let l1_cost_addition = l1_block_info.calculate_tx_l1_cost(&data, OpSpecId::ISTHMUS);
     let l1_cost = txn_cost.saturating_add(l1_cost_addition);
     if l1_cost > account.balance {
-        warn!(message = "Insufficient funds for L1 gas");
         return Err(TxValidationError::InsufficientFundsForL1Gas(l1_cost, account.balance));
     }
 


### PR DESCRIPTION
- These warn logs are unnecessary because we return the error msg here https://github.com/base/base/blob/5d2213e6bd911b7d2a3e20cc9717ecd0e1459abb/crates/client/metering/src/meter.rs#L232 , which also contains more useful information like the tx_hash
- It is then logged as info here https://github.com/base/base/blob/5d2213e6bd911b7d2a3e20cc9717ecd0e1459abb/crates/client/metering/src/rpc.rs#L203 which is better than warn as its more sampled in DD