### PR TITLE
fix(alloy-consensus): override is_system_tx() for OpTxEnvelope

### DIFF
--- a/crates/alloy/consensus/src/reth_compat.rs
+++ b/crates/alloy/consensus/src/reth_compat.rs
@@ -106,7 +106,11 @@ impl reth_primitives_traits::InMemorySize for OpTxEnvelope {
 
 impl reth_primitives_traits::SignedTransaction for OpPooledTransaction {}
 
-impl reth_primitives_traits::SignedTransaction for OpTxEnvelope {}
+impl reth_primitives_traits::SignedTransaction for OpTxEnvelope {
+    fn is_system_tx(&self) -> bool {
+        self.is_system_transaction()
+    }
+}
 
 // ---------------------------------------------------------------------------
 // SerdeBincodeCompat (reth-primitives-traits)


### PR DESCRIPTION
The reth v1.11.2 upgrade (PR #22882) added is_system_tx() to the SignedTransaction trait, delegating to the underlying transaction type's system transaction flag. Our OpTxEnvelope impl was left as a blank default, causing deposit system transactions to always return false from is_system_tx(). This incorrectly included them in prewarming instead of filtering them out.

This fix overrides is_system_tx() on OpTxEnvelope to delegate to OpTxEnvelope::is_system_transaction(), which checks the is_system_transaction field on deposit variants and returns false for all non-deposit types. OpPooledTransaction keeps its blank impl since pooled transactions are never deposits.

Relevant upstream: https://github.com/paradigmxyz/reth/pull/22882