### PR TITLE
fix(derive): reset frame queue metrics on signal

### DIFF
--- a/crates/consensus/derive/src/stages/frame_queue.rs
+++ b/crates/consensus/derive/src/stages/frame_queue.rs
@@ -198,6 +198,11 @@ where
     async fn signal(&mut self, signal: Signal) -> PipelineResult<()> {
         self.prev.signal(signal).await?;
         self.queue = VecDeque::default();
+        base_macros::set!(gauge, crate::metrics::Metrics::PIPELINE_FRAME_QUEUE_BUFFER, 0.0);
+        #[cfg(feature = "metrics")]
+        {
+            base_macros::set!(gauge, crate::metrics::Metrics::PIPELINE_FRAME_QUEUE_MEM, 0.0);
+        }
         Ok(())
     }
 }


### PR DESCRIPTION
Set FrameQueue metrics to zero when signal handling clears the in-memory queue, preventing stale queue telemetry after reset-like control flow.