### PR TITLE
chore: add builder_tx channel size as metric to ingress-rpc

### DIFF
--- a/crates/infra/ingress-rpc/src/metrics.rs
+++ b/crates/infra/ingress-rpc/src/metrics.rs
@@ -1,4 +1,4 @@
-use metrics::{Counter, Histogram};
+use metrics::{Counter, Gauge, Histogram};
 use metrics_derive::Metrics;
 use tokio::time::Duration;
 
@@ -59,4 +59,8 @@ pub struct Metrics {
     /// Number of bundles that exceeded the metering time.
     #[metric(describe = "Number of bundles that exceeded the metering time")]
     pub bundles_exceeded_metering_time: Counter,
+
+    /// Size of the buffered `MeterBundleResponse` channel.
+    #[metric(describe = "Size of buffered meter bundle responses")]
+    pub buffered_meter_bundle_responses_size: Gauge,
 }

--- a/crates/infra/ingress-rpc/src/service.rs
+++ b/crates/infra/ingress-rpc/src/service.rs
@@ -186,6 +186,8 @@ impl<Q: MessageQueue + 'static> IngressApiServer for IngressService<Q> {
 
             if let Some(meter_info) = meter_bundle_response.as_ref() {
                 self.metrics.successful_simulations.increment(1);
+                // Update the current size of the `builder_tx` channel captured right before sending to the builder
+                self.metrics.buffered_meter_bundle_responses_size.set(self.builder_tx.len() as f64);
                 if self.send_to_builder {
                     _ = self.builder_tx.send(meter_info.clone());
                 }


### PR DESCRIPTION
- `TIPS_INGRESS_MAX_BUFFERED_METER_BUNDLE_RESPONSES` by default is 100 and this is what we're using in dry-run at the moment
- However, we suspect that we're hitting this limit causing us to potentially lag behind
- Add a metric to increase observability and fine-tune this channel size better