### PR TITLE
feat(etc): Add Witness Diff Utility

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4495,6 +4495,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "base-witness-diff"
+version = "0.0.0"
+dependencies = [
+ "alloy-primitives",
+ "alloy-provider",
+ "alloy-rlp",
+ "alloy-rpc-client",
+ "alloy-transport-http",
+ "alloy-trie",
+ "base-alloy-network",
+ "base-proof-mpt",
+ "clap",
+ "eyre",
+ "hex",
+ "serde",
+ "serde_json",
+ "tokio",
+]
+
+[[package]]
 name = "base-x"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ members = [
   "crates/alloy/*",
   "crates/execution/*",
   "crates/txpool",
+  "etc/tools/*",
   "devnet",
   "actions/harness",
 ]

--- a/etc/tools/witness-diff/Cargo.toml
+++ b/etc/tools/witness-diff/Cargo.toml
@@ -1,0 +1,32 @@
+[package]
+name = "base-witness-diff"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+
+[lints]
+workspace = true
+
+[dependencies]
+# alloy
+alloy-rlp.workspace = true
+alloy-trie.workspace = true
+alloy-primitives.workspace = true
+alloy-provider.workspace = true
+alloy-rpc-client.workspace = true
+alloy-transport-http.workspace = true
+
+# base
+base-alloy-network.workspace = true
+base-proof-mpt = { workspace = true, features = ["std"] }
+
+# misc
+hex.workspace = true
+eyre.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+clap = { workspace = true, features = ["derive"] }
+tokio = { workspace = true, features = ["full"] }

--- a/etc/tools/witness-diff/README.md
+++ b/etc/tools/witness-diff/README.md
@@ -1,0 +1,60 @@
+# witness-diff
+
+`witness-diff` compares two execution witnesses to identify exactly which trie nodes, bytecodes, or key preimages differ between them. The primary use case is investigating state root mismatches: when two nodes disagree on the post-block state root for the same block, this tool locates the specific accounts and storage slots that diverge rather than requiring you to diff multi-megabyte JSON blobs manually.
+
+An execution witness is the set of all Merkle trie node preimages, contract bytecodes, and key preimages that were read during the execution of a block. Two nodes that execute the same block identically will produce identical witnesses. If they disagree on the state root, their witnesses will differ in the leaf nodes corresponding to the accounts or storage slots that were computed differently.
+
+## Enabling execution witnesses in reth
+
+Execution witnesses are served via the `debug_executionWitness` JSON-RPC method, which is part of the debug namespace. To expose it, start reth with `--http.api debug` (or `--ws.api debug` for WebSocket). The method takes a block number in hex and returns the full witness for that block as re-executed by the node.
+
+To additionally record witnesses automatically when a bad block is encountered and compare them against a healthy reference node, use `--debug.invalid-block-hook witness` together with `--debug.healthy-node-rpc-url <URL>`. That flow is handled by reth internally, but `witness-diff` is useful for the same underlying problem when you want to drive the comparison yourself.
+
+## Obtaining a local witness
+
+The local witness is fetched from your node using the same `debug_executionWitness` RPC method and saved to a JSON file before running the diff. For example:
+
+```
+curl -s -X POST http://localhost:8545 \
+  -H 'Content-Type: application/json' \
+  -d '{"jsonrpc":"2.0","method":"debug_executionWitness","params":["0x292FA96"],"id":1}' \
+  | jq '.result' > witness_43127830.json
+```
+
+The block number in the `params` array must be hex. The `.result` field of the response is the witness object. Save it as-is — `witness-diff` will parse it directly.
+
+## Running the tool
+
+```
+cargo run -p base-witness-diff -- \
+  --local <PATH>    path to the local witness JSON file
+  --rpc-url <URL>   HTTP(S) URL of the reference L2 node to compare against
+  --block <NUMBER>  decimal block number to fetch from the reference node
+```
+
+`--block` is decimal here, not hex. The tool converts it internally when making the RPC call. The reference witness is fetched live at runtime; there is no need to save it separately.
+
+Example:
+
+```
+cargo run -p base-witness-diff -- \
+  --local ~/witnesses/43127830_witness.json \
+  --rpc-url https://reference-node:8545 \
+  --block 43127830
+```
+
+## Reading the output
+
+The tool prints four sections.
+
+`=== Overview ===` shows the raw counts of state trie node preimages, bytecodes, and key preimages in each witness, then for each category how many are common to both, only in the local witness, or only in the reference witness. Comparison is by keccak256 hash of the raw bytes, so a node present in both witnesses with the same content is counted as common regardless of where it appears in the trie. Any nonzero only-local or only-rpc count means the two witnesses touched a different set of trie nodes, which is the expected symptom of a divergence. It also reports how many address preimages are available, which affects whether account addresses can be resolved in later sections.
+
+`=== Differing Leaf Nodes ===` is the core analysis. The tool decodes every RLP-encoded trie node from both witnesses, filters down to leaf nodes (which hold actual account or storage values rather than internal trie structure), and finds pairs that share the same trie path but carry different values. These are the nodes where the two executions produced a different result for the same key. For each differing leaf it attempts to decode the value as a `TrieAccount` (the RLP-encoded struct containing nonce, balance, code hash, and storage root). If both sides decode successfully, it prints the account side-by-side with a `✓` on matching fields and `DIFFERS` on mismatches. If the address can be recovered from the key preimages in the witness, it is shown; otherwise the path suffix in nibble hex is the only identifier. Leaves that do not decode as accounts are counted as storage leaf diffs — these represent individual storage slot values that diverged.
+
+`=== Leaves Only in One Witness ===` appears only when there are trie leaves that exist in one witness but have no corresponding path entry in the other. This happens when an account is created or deleted during execution, or when a storage slot is written by one execution but not accessed at all by the other. Local-only leaves represent state that your node computed but the reference did not touch; RPC-only leaves are the inverse. Each is printed with its account data or raw storage value.
+
+`=== SUMMARY ===` collects all counts into a single block for quick comparison. If both witnesses are fully identical the final line reads `Witnesses are identical.`
+
+## Witness JSON format
+
+The tool accepts witnesses in either geth or reth output format. The `state` field contains hex-encoded RLP-encoded trie node preimages (branch, extension, and leaf nodes). The `codes` field contains hex-encoded raw contract bytecodes. The `keys` field contains hex-encoded RLP-encoded key preimages, which are 20-byte addresses encoded as RLP strings (the `0x94` prefix followed by the 20 address bytes) — these are what allow the tool to resolve a trie path back to a human-readable address. The `headers` field is accepted but ignored. All fields default to empty if absent.

--- a/etc/tools/witness-diff/src/diff.rs
+++ b/etc/tools/witness-diff/src/diff.rs
@@ -1,4 +1,8 @@
-use std::{collections::HashMap, fs, path::PathBuf};
+use std::{
+    collections::{HashMap, HashSet},
+    fs,
+    path::PathBuf,
+};
 
 use alloy_primitives::{Address, B256, Bytes, keccak256};
 use alloy_provider::{Provider, RootProvider};
@@ -78,11 +82,17 @@ pub fn build_nibble_address_lookup(
 }
 
 /// Look up an address by matching `prefix_hex` as a suffix of the hashed key.
+///
+/// Tries an O(1) direct lookup first (works when `prefix_hex` is the full
+/// 64-nibble path). Falls back to an O(n) suffix scan for partial paths.
 pub fn resolve_address(
     nibble_lookup: &HashMap<String, Address>,
     prefix_hex: &str,
 ) -> Option<Address> {
-    nibble_lookup.iter().find(|(nibbles, _)| nibbles.ends_with(prefix_hex)).map(|(_, a)| *a)
+    if let Some(&addr) = nibble_lookup.get(prefix_hex) {
+        return Some(addr);
+    }
+    nibble_lookup.iter().find(|(k, _)| k.ends_with(prefix_hex)).map(|(_, a)| *a)
 }
 
 /// Extract leaf nodes from a set of trie node preimages.
@@ -267,15 +277,13 @@ pub async fn run(local: PathBuf, rpc_url: String, block: u64) -> Result<()> {
     }
 
     // 6. Count leaves only in one side (created/deleted accounts or storage slots).
-    let rpc_prefixes: HashMap<&Nibbles, &Bytes> =
-        rpc_leaves.iter().map(|l| (&l.prefix, &l.value)).collect();
-    let local_prefixes: HashMap<&Nibbles, &Bytes> =
-        local_leaves.iter().map(|l| (&l.prefix, &l.value)).collect();
+    let rpc_prefixes: HashSet<&Nibbles> = rpc_leaves.iter().map(|l| &l.prefix).collect();
+    let local_prefixes: HashSet<&Nibbles> = local_leaves.iter().map(|l| &l.prefix).collect();
 
     let leaves_only_local: Vec<_> =
-        local_leaves.iter().filter(|l| !rpc_prefixes.contains_key(&l.prefix)).collect();
+        local_leaves.iter().filter(|l| !rpc_prefixes.contains(&l.prefix)).collect();
     let leaves_only_rpc: Vec<_> =
-        rpc_leaves.iter().filter(|l| !local_prefixes.contains_key(&l.prefix)).collect();
+        rpc_leaves.iter().filter(|l| !local_prefixes.contains(&l.prefix)).collect();
 
     if !leaves_only_local.is_empty() || !leaves_only_rpc.is_empty() {
         println!("=== Leaves Only in One Witness ===");

--- a/etc/tools/witness-diff/src/diff.rs
+++ b/etc/tools/witness-diff/src/diff.rs
@@ -1,0 +1,346 @@
+use std::{collections::HashMap, fs, path::PathBuf};
+
+use alloy_primitives::{Address, B256, Bytes, keccak256};
+use alloy_provider::{Provider, RootProvider};
+use alloy_rlp::Decodable;
+use alloy_rpc_client::RpcClient;
+use alloy_transport_http::{Client, Http};
+use alloy_trie::TrieAccount;
+use base_alloy_network::Base;
+use base_proof_mpt::{Nibbles, TrieNode};
+use eyre::Result;
+use serde::{Deserialize, Deserializer};
+
+/// Deserializes a vector while treating a JSON `null` as an empty vector.
+pub fn deserialize_null_vec<'de, D, T>(deserializer: D) -> Result<Vec<T>, D::Error>
+where
+    D: Deserializer<'de>,
+    T: Deserialize<'de>,
+{
+    Option::<Vec<T>>::deserialize(deserializer).map(Option::unwrap_or_default)
+}
+
+/// Execution witness format returned by reth/geth `debug_executionWitness`.
+///
+/// Both reth and geth return arrays (not maps) for `state`, `codes`, and `keys`.
+/// Unknown fields (e.g. `headers`) are silently ignored by serde.
+#[derive(Debug, Deserialize)]
+pub struct Witness {
+    /// State trie node preimages.
+    #[serde(default, deserialize_with = "deserialize_null_vec")]
+    pub state: Vec<Bytes>,
+    /// Contract bytecodes.
+    #[serde(default, deserialize_with = "deserialize_null_vec")]
+    pub codes: Vec<Bytes>,
+    /// MPT key preimages.
+    #[serde(default, deserialize_with = "deserialize_null_vec")]
+    pub keys: Vec<Bytes>,
+}
+
+/// A decoded trie leaf node with its path.
+#[derive(Debug)]
+pub struct DecodedLeaf {
+    /// Nibble-encoded path prefix of the leaf.
+    pub prefix: Nibbles,
+    /// RLP-encoded value stored at this leaf.
+    pub value: Bytes,
+}
+
+/// Index a slice of raw preimage bytes into a map keyed by their keccak256 hash.
+pub fn index_by_hash(items: &[Bytes]) -> HashMap<B256, &Bytes> {
+    items.iter().map(|b| (keccak256(b.as_ref()), b)).collect()
+}
+
+/// Build an address lookup map from key preimages.
+///
+/// Key preimages use RLP encoding: `0x94` prefix (`0x80 + 20`) indicates a
+/// 20-byte address follows. The map is keyed by `keccak256(address)`.
+pub fn build_address_lookup<'a>(keys: impl Iterator<Item = &'a Bytes>) -> HashMap<B256, Address> {
+    let mut lookup = HashMap::new();
+    for k in keys {
+        if k.len() == 21 && k[0] == 0x94 {
+            let addr = Address::from_slice(&k[1..]);
+            lookup.insert(keccak256(addr), addr);
+        }
+    }
+    lookup
+}
+
+/// Pre-encode the address lookup keys as nibble-hex strings for suffix matching.
+///
+/// Trie leaf paths are suffixes of the 64-nibble keccak256 hash of the key. We
+/// store the full nibble-hex string so address resolution can call `ends_with`
+/// without re-encoding the hash on every lookup.
+pub fn build_nibble_address_lookup(
+    address_lookup: &HashMap<B256, Address>,
+) -> HashMap<String, Address> {
+    address_lookup.iter().map(|(h, a)| (hex::encode(h), *a)).collect()
+}
+
+/// Look up an address by matching `prefix_hex` as a suffix of the hashed key.
+pub fn resolve_address(
+    nibble_lookup: &HashMap<String, Address>,
+    prefix_hex: &str,
+) -> Option<Address> {
+    nibble_lookup.iter().find(|(nibbles, _)| nibbles.ends_with(prefix_hex)).map(|(_, a)| *a)
+}
+
+/// Extract leaf nodes from a set of trie node preimages.
+pub fn extract_leaves(items: &[Bytes]) -> Vec<DecodedLeaf> {
+    let mut leaves = Vec::new();
+    for data in items {
+        if let Ok(TrieNode::Leaf { prefix, value }) = TrieNode::decode(&mut data.as_ref()) {
+            leaves.push(DecodedLeaf { prefix, value });
+        }
+    }
+    leaves
+}
+
+/// Try to decode a leaf value as a `TrieAccount` (RLP-encoded account data).
+pub fn try_decode_account(value: &Bytes) -> Option<TrieAccount> {
+    TrieAccount::decode(&mut value.as_ref()).ok()
+}
+
+/// Find leaf nodes that share the same trie path but carry different values.
+///
+/// A well-formed trie has at most one leaf per path, so duplicate prefixes
+/// within a single witness are not expected. If the input is malformed the
+/// `HashMap::collect()` below will silently retain only the last entry for any
+/// duplicate path; this is acceptable for a diagnostic tool where correctness
+/// of the trie structure is a precondition.
+pub fn find_differing_leaf_pairs(
+    local_leaves: &[DecodedLeaf],
+    rpc_leaves: &[DecodedLeaf],
+) -> Vec<(Nibbles, Bytes, Bytes)> {
+    let rpc_by_prefix: HashMap<&Nibbles, &Bytes> =
+        rpc_leaves.iter().map(|l| (&l.prefix, &l.value)).collect();
+
+    let mut pairs = Vec::new();
+    for local_leaf in local_leaves {
+        if let Some(rpc_value) = rpc_by_prefix.get(&local_leaf.prefix)
+            && local_leaf.value != **rpc_value
+        {
+            pairs.push((local_leaf.prefix, local_leaf.value.clone(), (*rpc_value).clone()));
+        }
+    }
+    pairs
+}
+
+/// Compare two sets of bytes and print a compact diff summary.
+///
+/// Returns the total number of entries that differ (only-local + only-rpc).
+pub fn compare_sets(label: &str, local_items: &[Bytes], rpc_items: &[Bytes]) -> usize {
+    let local_map = index_by_hash(local_items);
+    let rpc_map = index_by_hash(rpc_items);
+
+    let only_local = local_map.keys().filter(|h| !rpc_map.contains_key(*h)).count();
+    let only_rpc = rpc_map.keys().filter(|h| !local_map.contains_key(*h)).count();
+    let common = local_map.keys().filter(|h| rpc_map.contains_key(*h)).count();
+
+    println!("  {label}: {common} common, {only_local} only-local, {only_rpc} only-rpc");
+
+    only_local + only_rpc
+}
+
+/// Run the witness diff tool.
+///
+/// Fetches the reference witness from the given RPC URL and compares it against
+/// the local witness file, printing a human-readable diff of diverging trie nodes,
+/// bytecodes, and account state.
+pub async fn run(local: PathBuf, rpc_url: String, block: u64) -> Result<()> {
+    // 1. Read local witness.
+    println!("Reading local witness from: {}", local.display());
+    let local_json = fs::read_to_string(&local)?;
+    let local_witness: Witness = serde_json::from_str(&local_json)?;
+
+    println!(
+        "  Local: {} state nodes, {} codes, {} keys",
+        local_witness.state.len(),
+        local_witness.codes.len(),
+        local_witness.keys.len()
+    );
+
+    // 2. Fetch RPC witness.
+    println!("Fetching RPC witness for block #{block} from {rpc_url}");
+    let url = rpc_url.parse()?;
+    let http = Http::<Client>::new(url);
+    let provider = RootProvider::<Base>::new(RpcClient::new(http, false));
+
+    let block_hex = format!("0x{block:x}");
+    let rpc_witness: Witness =
+        provider.client().request("debug_executionWitness", &[&block_hex]).await?;
+
+    println!(
+        "  RPC:   {} state nodes, {} codes, {} keys",
+        rpc_witness.state.len(),
+        rpc_witness.codes.len(),
+        rpc_witness.keys.len()
+    );
+
+    // 3. High-level comparison.
+    println!("\n=== Overview ===");
+    let state_diffs = compare_sets("state", &local_witness.state, &rpc_witness.state);
+    let code_diffs = compare_sets("codes", &local_witness.codes, &rpc_witness.codes);
+    let key_diffs = compare_sets("keys", &local_witness.keys, &rpc_witness.keys);
+
+    // Merge both key sets for address lookups by chaining iterators — no clone needed.
+    let address_lookup =
+        build_address_lookup(local_witness.keys.iter().chain(rpc_witness.keys.iter()));
+    let nibble_lookup = build_nibble_address_lookup(&address_lookup);
+
+    println!("  address preimages available: {}", address_lookup.len());
+
+    // 4. Extract leaves once — reused for both diff analysis and one-sided leaf counts.
+    let local_leaves = extract_leaves(&local_witness.state);
+    let rpc_leaves = extract_leaves(&rpc_witness.state);
+
+    // 5. Find differing leaf nodes — this is the core analysis.
+    println!("\n=== Differing Leaf Nodes ===");
+    let leaf_pairs = find_differing_leaf_pairs(&local_leaves, &rpc_leaves);
+
+    if leaf_pairs.is_empty() {
+        println!("  No leaf nodes share the same path with different values.");
+    } else {
+        let mut account_diffs = Vec::new();
+        let mut storage_diff_count = 0usize;
+
+        for (prefix, local_value, rpc_value) in &leaf_pairs {
+            let local_account = try_decode_account(local_value);
+            let rpc_account = try_decode_account(rpc_value);
+
+            if let (Some(local_acct), Some(rpc_acct)) = (local_account, rpc_account) {
+                account_diffs.push((*prefix, local_acct, rpc_acct));
+            } else {
+                storage_diff_count += 1;
+            }
+        }
+
+        if account_diffs.is_empty() {
+            println!("  No account leaves differ (all diffs are storage leaves).");
+        } else {
+            println!("  {} account(s) with different state:\n", account_diffs.len());
+            for (prefix, local_acct, rpc_acct) in &account_diffs {
+                let prefix_hex = prefix.iter().map(|n| format!("{n:x}")).collect::<String>();
+                let found_address = resolve_address(&nibble_lookup, &prefix_hex);
+
+                println!("  ACCOUNT (path suffix: 0x{prefix_hex})");
+                if let Some(addr) = found_address {
+                    println!("    Address:          {addr}");
+                } else {
+                    println!("    Address:          (unknown)");
+                }
+                println!(
+                    "    Nonce:            {} (local) vs {} (rpc){}",
+                    local_acct.nonce,
+                    rpc_acct.nonce,
+                    if local_acct.nonce == rpc_acct.nonce { " ✓" } else { " DIFFERS" }
+                );
+                println!(
+                    "    Balance:          {} (local) vs {} (rpc){}",
+                    local_acct.balance,
+                    rpc_acct.balance,
+                    if local_acct.balance == rpc_acct.balance { " ✓" } else { " DIFFERS" }
+                );
+                println!("    Code hash:        {} (local)", local_acct.code_hash);
+                println!(
+                    "                      {} (rpc){}",
+                    rpc_acct.code_hash,
+                    if local_acct.code_hash == rpc_acct.code_hash { " ✓" } else { " DIFFERS" }
+                );
+                println!("    Storage root:     {} (local)", local_acct.storage_root);
+                println!(
+                    "                      {} (rpc){}",
+                    rpc_acct.storage_root,
+                    if local_acct.storage_root == rpc_acct.storage_root {
+                        " ✓"
+                    } else {
+                        " DIFFERS"
+                    }
+                );
+                println!();
+            }
+        }
+
+        println!(
+            "  {storage_diff_count} storage leaf(s) also differ (values computed differently)."
+        );
+    }
+
+    // 6. Count leaves only in one side (created/deleted accounts or storage slots).
+    let rpc_prefixes: HashMap<&Nibbles, &Bytes> =
+        rpc_leaves.iter().map(|l| (&l.prefix, &l.value)).collect();
+    let local_prefixes: HashMap<&Nibbles, &Bytes> =
+        local_leaves.iter().map(|l| (&l.prefix, &l.value)).collect();
+
+    let leaves_only_local: Vec<_> =
+        local_leaves.iter().filter(|l| !rpc_prefixes.contains_key(&l.prefix)).collect();
+    let leaves_only_rpc: Vec<_> =
+        rpc_leaves.iter().filter(|l| !local_prefixes.contains_key(&l.prefix)).collect();
+
+    if !leaves_only_local.is_empty() || !leaves_only_rpc.is_empty() {
+        println!("=== Leaves Only in One Witness ===");
+        println!(
+            "  {} leaves only in local, {} leaves only in RPC",
+            leaves_only_local.len(),
+            leaves_only_rpc.len()
+        );
+
+        for leaf in &leaves_only_local {
+            let prefix_hex = leaf.prefix.iter().map(|n| format!("{n:x}")).collect::<String>();
+            if let Some(acct) = try_decode_account(&leaf.value) {
+                let addr_str = resolve_address(&nibble_lookup, &prefix_hex)
+                    .map(|a| a.to_string())
+                    .unwrap_or_else(|| String::from("(unknown)"));
+                println!(
+                    "    LOCAL-ONLY account {addr_str}: nonce={}, balance={}, storage_root={}",
+                    acct.nonce, acct.balance, acct.storage_root
+                );
+            } else {
+                println!(
+                    "    LOCAL-ONLY storage leaf path=0x{prefix_hex}: 0x{}",
+                    hex::encode(&leaf.value)
+                );
+            }
+        }
+
+        for leaf in &leaves_only_rpc {
+            let prefix_hex = leaf.prefix.iter().map(|n| format!("{n:x}")).collect::<String>();
+            if let Some(acct) = try_decode_account(&leaf.value) {
+                let addr_str = resolve_address(&nibble_lookup, &prefix_hex)
+                    .map(|a| a.to_string())
+                    .unwrap_or_else(|| String::from("(unknown)"));
+                println!(
+                    "    RPC-ONLY  account {addr_str}: nonce={}, balance={}, storage_root={}",
+                    acct.nonce, acct.balance, acct.storage_root
+                );
+            } else {
+                println!(
+                    "    RPC-ONLY  storage leaf path=0x{prefix_hex}: 0x{}",
+                    hex::encode(&leaf.value)
+                );
+            }
+        }
+        println!();
+    }
+
+    // 7. Summary.
+    println!("=== SUMMARY ===");
+    println!("State node diffs:     {state_diffs}");
+    println!("Code diffs:           {code_diffs}");
+    println!("Key diffs:            {key_diffs}");
+    println!("Differing leaf pairs: {}", leaf_pairs.len());
+    println!("Leaves only-local:    {}", leaves_only_local.len());
+    println!("Leaves only-rpc:      {}", leaves_only_rpc.len());
+
+    let total_diffs = state_diffs
+        + code_diffs
+        + key_diffs
+        + leaf_pairs.len()
+        + leaves_only_local.len()
+        + leaves_only_rpc.len();
+    if total_diffs == 0 {
+        println!("\nWitnesses are identical.");
+    }
+
+    Ok(())
+}

--- a/etc/tools/witness-diff/src/lib.rs
+++ b/etc/tools/witness-diff/src/lib.rs
@@ -1,0 +1,4 @@
+#![doc = include_str!("../README.md")]
+
+mod diff;
+pub use diff::*;

--- a/etc/tools/witness-diff/src/main.rs
+++ b/etc/tools/witness-diff/src/main.rs
@@ -1,0 +1,33 @@
+#![doc = include_str!("../README.md")]
+
+use std::path::PathBuf;
+
+use clap::Parser;
+use eyre::Result;
+
+/// Compare two execution witnesses to find trie node differences.
+///
+/// Fetches one witness from an L2 RPC via `debug_executionWitness` and reads
+/// the other from a local JSON file, then reports exactly which trie nodes,
+/// codes, and keys differ — including a detailed breakdown of affected accounts.
+#[derive(Parser, Debug)]
+#[command(name = "witness-diff")]
+struct Args {
+    /// Path to the local witness JSON file (from re-execution).
+    #[arg(long)]
+    local: PathBuf,
+
+    /// L2 RPC URL to fetch the reference witness from.
+    #[arg(long)]
+    rpc_url: String,
+
+    /// Block number to fetch the witness for.
+    #[arg(long)]
+    block: u64,
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let args = Args::parse();
+    base_witness_diff::run(args.local, args.rpc_url, args.block).await
+}


### PR DESCRIPTION
## Summary

Ports the `witness-diff` utility from the regression testing branch into `etc/`. The tool compares two execution witnesses — one fetched live from a reference L2 node via `debug_executionWitness` and one read from a local JSON file — to identify exactly which trie nodes, bytecodes, and key preimages diverge. The core analysis decodes RLP-encoded trie leaf nodes from both witnesses and finds pairs that share the same path but carry different values, then further decodes those as `TrieAccount` structs to produce a human-readable account-level diff with nonce, balance, code hash, and storage root side-by-side. This is the primary tool for diagnosing state root mismatches without manually comparing multi-megabyte witness blobs.