### PR TITLE
chore: waterfall-sort Cargo.toml deps for proof/tee, proposer, and prover

### DIFF
--- a/bin/prover/Cargo.toml
+++ b/bin/prover/Cargo.toml
@@ -15,24 +15,24 @@ path = "src/main.rs"
 [lints]
 workspace = true
 
-[features]
-local = [ "base-proof-transport/test-utils" ]
-
 [dependencies]
-# workspace
-base-proof-tee-nitro = { workspace = true, features = ["host"] }
-base-proof-transport = { workspace = true, features = ["vsock"] }
-base-consensus-registry.workspace = true
+# Workspace
 base-proof-host.workspace = true
 alloy-primitives.workspace = true
+base-consensus-registry.workspace = true
+base-proof-transport = { workspace = true, features = ["vsock"] }
+base-proof-tee-nitro = { workspace = true, features = ["host"] }
 
-# cli
+# CLI
 eyre.workspace = true
 clap = { workspace = true, features = ["derive", "env"] }
 
-# async
+# Async
 tokio = { workspace = true, features = ["full"] }
 
-# tracing
+# Tracing
 tracing.workspace = true
 tracing-subscriber.workspace = true
+
+[features]
+local = ["base-proof-transport/test-utils"]

--- a/bin/prover/Cargo.toml
+++ b/bin/prover/Cargo.toml
@@ -20,8 +20,8 @@ workspace = true
 base-proof-host.workspace = true
 alloy-primitives.workspace = true
 base-consensus-registry.workspace = true
-base-proof-transport = { workspace = true, features = ["vsock"] }
 base-proof-tee-nitro = { workspace = true, features = ["host"] }
+base-proof-transport = { workspace = true, features = ["vsock"] }
 
 # CLI
 eyre.workspace = true

--- a/bin/prover/Cargo.toml
+++ b/bin/prover/Cargo.toml
@@ -35,4 +35,4 @@ tracing.workspace = true
 tracing-subscriber.workspace = true
 
 [features]
-local = ["base-proof-transport/test-utils"]
+local = [ "base-proof-transport/test-utils" ]

--- a/crates/proof/proposer/Cargo.toml
+++ b/crates/proof/proposer/Cargo.toml
@@ -14,16 +14,16 @@ workspace = true
 [dependencies]
 # Alloy
 alloy-eips.workspace = true
-alloy-rpc-types.workspace = true
+alloy-signer.workspace = true
+alloy-network.workspace = true
 alloy-contract.workspace = true
 alloy-provider.workspace = true
-alloy-network.workspace = true
-alloy-signer.workspace = true
 alloy-transport.workspace = true
-alloy-sol-types.workspace = true
-alloy-rpc-client.workspace = true
+alloy-rpc-types.workspace = true
 alloy-consensus.workspace = true
+alloy-sol-types.workspace = true
 alloy-primitives.workspace = true
+alloy-rpc-client.workspace = true
 alloy-signer-local.workspace = true
 alloy-rpc-types-eth.workspace = true
 alloy-transport-http.workspace = true
@@ -42,8 +42,8 @@ base-proof-primitives = { workspace = true, features = ["serde"] }
 base-protocol.workspace = true
 
 # Enclave
-base-enclave-client.workspace = true
 base-enclave.workspace = true
+base-enclave-client.workspace = true
 
 # Async
 tokio.workspace = true
@@ -79,8 +79,8 @@ hex.workspace = true
 url.workspace = true
 bytes.workspace = true
 backon.workspace = true
-jsonrpsee.workspace = true
 humantime.workspace = true
+jsonrpsee.workspace = true
 moka = { workspace = true, features = ["future"] }
 axum = { workspace = true, features = ["http1", "json", "tokio"] }
 

--- a/crates/proof/tee/client/Cargo.toml
+++ b/crates/proof/tee/client/Cargo.toml
@@ -4,11 +4,15 @@ version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
+# Core
 base-enclave.workspace = true
 base-proof-primitives = { workspace = true, features = ["serde", "std"] }
 
-# Alloy types
+# Alloy
 alloy-primitives.workspace = true
 
 # RPC
@@ -21,6 +25,3 @@ thiserror.workspace = true
 # TLS
 rustls-pki-types.workspace = true
 rustls = { workspace = true, features = ["std", "tls12"] }
-
-[lints]
-workspace = true

--- a/crates/proof/tee/core/Cargo.toml
+++ b/crates/proof/tee/core/Cargo.toml
@@ -39,8 +39,8 @@ base-protocol = { workspace = true, features = ["serde"] }
 # Misc
 tracing.workspace = true
 thiserror.workspace = true
-async-trait.workspace = true
 serde_json.workspace = true
+async-trait.workspace = true
 hex-literal.workspace = true
 parking_lot.workspace = true
 hex = { workspace = true, features = ["serde"] }

--- a/crates/proof/tee/core/Cargo.toml
+++ b/crates/proof/tee/core/Cargo.toml
@@ -4,6 +4,9 @@ version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 # EVM
 revm = { workspace = true, features = ["std"] }
@@ -26,8 +29,8 @@ base-alloy-rpc-types-engine = { workspace = true, features = ["serde"] }
 
 # Proof
 base-proof-mpt = { workspace = true, features = ["std"] }
-base-proof-primitives = { workspace = true, features = ["serde"] }
 base-proof-executor = { workspace = true, features = ["std"] }
+base-proof-primitives = { workspace = true, features = ["serde"] }
 base-consensus-genesis = { workspace = true, features = ["serde"] }
 
 # Consensus
@@ -37,15 +40,12 @@ base-protocol = { workspace = true, features = ["serde"] }
 tracing.workspace = true
 thiserror.workspace = true
 async-trait.workspace = true
+serde_json.workspace = true
 hex-literal.workspace = true
 parking_lot.workspace = true
-serde_json.workspace = true
 hex = { workspace = true, features = ["serde"] }
 serde = { workspace = true, features = ["derive"] }
 
 [dev-dependencies]
 hex.workspace = true
 rstest.workspace = true
-
-[lints]
-workspace = true

--- a/crates/proof/tee/nitro/Cargo.toml
+++ b/crates/proof/tee/nitro/Cargo.toml
@@ -4,14 +4,17 @@ version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 # Core
 base-alloy-evm.workspace = true
 base-proof-client.workspace = true
 base-proof-preimage.workspace = true
 base-proof-primitives.workspace = true
-base-proof-transport = { workspace = true, features = ["frame"] }
 base-proof-host = { workspace = true, optional = true }
+base-proof-transport = { workspace = true, features = ["frame"] }
 jsonrpsee = { workspace = true, optional = true, features = ["server", "macros"] }
 
 # Alloy
@@ -37,8 +40,8 @@ serde = { workspace = true, features = ["derive"] }
 zip = { workspace = true, features = ["deflate"] }
 
 # Async
-tokio = { workspace = true, features = ["rt", "time"] }
 async-trait.workspace = true
+tokio = { workspace = true, features = ["rt", "time"] }
 
 # Error
 eyre.workspace = true
@@ -57,9 +60,9 @@ rand_08.workspace = true
 tokio-vsock.workspace = true
 
 [dev-dependencies]
-base-proof-transport = { workspace = true, features = ["test-utils"] }
 rand_08.workspace = true
 tokio = { workspace = true, features = ["macros", "rt"] }
+base-proof-transport = { workspace = true, features = ["test-utils"] }
 
 [features]
 host = [
@@ -72,6 +75,3 @@ host = [
 
 [package.metadata.cargo-udeps.ignore]
 normal = ["aws-nitro-enclaves-nsm-api"]
-
-[lints]
-workspace = true


### PR DESCRIPTION
## Summary
- Sort dependencies by line length (waterfall style) within each logical group
- Move `[lints]` sections to after `[package]` (before `[dependencies]`)
- Move `[features]` sections to bottom of manifest
- Capitalize group comment headers for consistency

### Files changed
- `bin/prover/Cargo.toml`
- `crates/proof/proposer/Cargo.toml`
- `crates/proof/tee/client/Cargo.toml`
- `crates/proof/tee/core/Cargo.toml`
- `crates/proof/tee/nitro/Cargo.toml`