### PR TITLE
chore(proof): consolidate ECDSA_SIGNATURE_LENGTH into base-proof-primitives

### DIFF
--- a/crates/proof/primitives/src/lib.rs
+++ b/crates/proof/primitives/src/lib.rs
@@ -7,7 +7,7 @@ mod proof;
 pub use proof::{ProofBundle, ProofClaim, ProofEvidence, ProofRequest, ProofResult};
 
 mod proposal;
-pub use proposal::{Proposal, SIGNATURE_LENGTH};
+pub use proposal::{ECDSA_SIGNATURE_LENGTH, Proposal};
 
 mod prover;
 pub use prover::ProverBackend;

--- a/crates/proof/primitives/src/proposal.rs
+++ b/crates/proof/primitives/src/proposal.rs
@@ -1,7 +1,7 @@
 use alloy_primitives::{B256, Bytes, U256};
 
-/// ECDSA signature length (r + s + v).
-pub const SIGNATURE_LENGTH: usize = 65;
+/// ECDSA signature length in bytes (r: 32 + s: 32 + v: 1).
+pub const ECDSA_SIGNATURE_LENGTH: usize = 65;
 
 /// A proposal containing an output root and signature.
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/crates/proof/tee/core/src/lib.rs
+++ b/crates/proof/tee/core/src/lib.rs
@@ -19,7 +19,7 @@ mod error;
 pub use error::{ConfigError, CryptoError, EnclaveError, ExecutorError, ProviderError, Result};
 
 mod proof;
-pub use proof::{ECDSA_SIGNATURE_LENGTH, ECDSA_V_OFFSET, PROOF_TYPE_TEE, ProofEncoder};
+pub use proof::{ECDSA_V_OFFSET, PROOF_TYPE_TEE, ProofEncoder};
 
 mod executor;
 pub use executor::{

--- a/crates/proof/tee/core/src/proof.rs
+++ b/crates/proof/tee/core/src/proof.rs
@@ -1,9 +1,7 @@
 use alloy_primitives::{B256, Bytes, U256};
+use base_proof_primitives::ECDSA_SIGNATURE_LENGTH;
 
 use crate::CryptoError;
-
-/// Length of an ECDSA signature in bytes (r + s + v).
-pub const ECDSA_SIGNATURE_LENGTH: usize = 65;
 
 /// Offset to add to ECDSA v-value (0/1 -> 27/28).
 pub const ECDSA_V_OFFSET: u8 = 27;

--- a/crates/proof/tee/nitro/src/enclave/crypto.rs
+++ b/crates/proof/tee/nitro/src/enclave/crypto.rs
@@ -5,13 +5,11 @@
 use alloy_primitives::{Address, B256, Bytes, U256, keccak256};
 use alloy_signer::SignerSync;
 use alloy_signer_local::PrivateKeySigner;
+use base_proof_primitives::ECDSA_SIGNATURE_LENGTH;
 use k256::ecdsa::{Signature, SigningKey, VerifyingKey, signature::hazmat::PrehashVerifier};
 use rand_08::CryptoRng;
 
 use crate::error::{CryptoError, ProposalError, Result};
-
-/// Expected length of an ECDSA signature (r: 32 bytes, s: 32 bytes, v: 1 byte).
-pub const SIGNATURE_LENGTH: usize = 65;
 
 /// Base length of the signing data without intermediate roots:
 /// address(20) + 7 x bytes32(32) = 244 bytes.
@@ -136,7 +134,7 @@ impl Signing {
     ///
     /// Uses only the first 64 bytes (r, s), matching Go's `crypto.VerifySignature`.
     pub fn verify(public_key: &[u8], data: &[u8], signature: &[u8]) -> Result<bool> {
-        if signature.len() != SIGNATURE_LENGTH {
+        if signature.len() != ECDSA_SIGNATURE_LENGTH {
             return Err(ProposalError::InvalidSignatureLength(signature.len()).into());
         }
 
@@ -299,7 +297,7 @@ mod tests {
 
         let data = test_signing_data();
         let signature = Signing::sign(&signer, &data).expect("signing failed");
-        assert_eq!(signature.len(), SIGNATURE_LENGTH);
+        assert_eq!(signature.len(), ECDSA_SIGNATURE_LENGTH);
 
         let public_key = Ecdsa::public_key_bytes(&signer);
         let valid = Signing::verify(&public_key, &data, &signature).expect("verification failed");

--- a/crates/proof/tee/nitro/src/enclave/mod.rs
+++ b/crates/proof/tee/nitro/src/enclave/mod.rs
@@ -22,7 +22,7 @@ pub use attestation::{
 };
 
 mod crypto;
-pub use crypto::{Ecdsa, SIGNATURE_LENGTH, SIGNING_DATA_BASE_LENGTH, Signing};
+pub use crypto::{Ecdsa, SIGNING_DATA_BASE_LENGTH, Signing};
 
 mod nsm;
 pub use nsm::{NsmRng, NsmSession};

--- a/crates/proof/tee/nitro/src/lib.rs
+++ b/crates/proof/tee/nitro/src/lib.rs
@@ -11,7 +11,7 @@ mod enclave;
 pub use enclave::NitroEnclave;
 pub use enclave::{
     AttestationDocument, AwsCaRoot, DEFAULT_CA_ROOTS, DEFAULT_CA_ROOTS_SHA256, Ecdsa,
-    EnclaveConfig, NsmRng, NsmSession, SIGNATURE_LENGTH, SIGNING_DATA_BASE_LENGTH, Server, Signing,
+    EnclaveConfig, NsmRng, NsmSession, SIGNING_DATA_BASE_LENGTH, Server, Signing,
     VerificationResult, get_default_ca_root, verify_attestation,
 };
 


### PR DESCRIPTION
## Summary

- Removes duplicate `SIGNATURE_LENGTH` / `ECDSA_SIGNATURE_LENGTH` constant definitions from `base-proof-tee-nitro` and `base-enclave`
- Both crates now import `ECDSA_SIGNATURE_LENGTH` from `base-proof-primitives`, which is the single source of truth
- Addresses [review comment](https://github.com/base/base/pull/1141#discussion_r2908331737) from #1141

## Changes

| Crate | File | Change |
|---|---|---|
| `base-proof-primitives` | `proposal.rs` | Renamed `SIGNATURE_LENGTH` → `ECDSA_SIGNATURE_LENGTH` |
| `base-proof-primitives` | `lib.rs` | Updated re-export |
| `base-proof-tee-nitro` | `enclave/crypto.rs` | Removed local constant, imports from primitives |
| `base-proof-tee-nitro` | `enclave/mod.rs`, `lib.rs` | Removed stale re-exports |
| `base-enclave` | `proof.rs` | Removed local constant, imports from primitives |
| `base-enclave` | `lib.rs` | Removed stale re-export |