### PR TITLE
feat(tee): remove proposer from enclave config and fix PCR0 handling

### DIFF
--- a/bin/prover/src/cli.rs
+++ b/bin/prover/src/cli.rs
@@ -4,7 +4,7 @@ use std::net::SocketAddr;
 #[cfg(any(target_os = "linux", feature = "local"))]
 use std::sync::Arc;
 
-use alloy_primitives::{Address, B256};
+use alloy_primitives::B256;
 #[cfg(any(target_os = "linux", feature = "local"))]
 use base_consensus_registry::Registry;
 #[cfg(any(target_os = "linux", feature = "local"))]
@@ -114,10 +114,6 @@ struct NitroEnclaveArgs {
     #[arg(long, env = "VSOCK_PORT", default_value_t = 1234)]
     vsock_port: u32,
 
-    /// Proposer address.
-    #[arg(long, env = "PROPOSER")]
-    proposer: Address,
-
     /// Per-chain configuration hash.
     #[arg(long, env = "CONFIG_HASH")]
     config_hash: B256,
@@ -184,7 +180,6 @@ impl NitroEnclaveArgs {
     async fn run(self) -> eyre::Result<()> {
         let config = EnclaveConfig {
             vsock_port: self.vsock_port,
-            proposer: self.proposer,
             config_hash: self.config_hash,
             tee_image_hash: self.tee_image_hash,
         };
@@ -210,10 +205,6 @@ struct NitroLocalArgs {
     #[command(flatten)]
     server: ProverServerArgs,
 
-    /// Proposer address.
-    #[arg(long, env = "PROPOSER")]
-    proposer: Address,
-
     /// Per-chain configuration hash.
     #[arg(long, env = "CONFIG_HASH")]
     config_hash: B256,
@@ -236,7 +227,6 @@ impl NitroLocalArgs {
 
         let enclave_config = EnclaveConfig {
             vsock_port: 0,
-            proposer: self.proposer,
             config_hash: self.config_hash,
             tee_image_hash: self.tee_image_hash,
         };

--- a/crates/proof/tee/Justfile
+++ b/crates/proof/tee/Justfile
@@ -25,7 +25,6 @@ nitro-local *args:
         --l2-eth-url "${L2_ETH_URL:-http://localhost:9545}" \
         --l1-beacon-url "${L1_BEACON_URL:-http://localhost:5052}" \
         --l2-chain-id "${L2_CHAIN_ID:-8453}" \
-        --proposer "${PROPOSER:-0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266}" \
         --config-hash "${CONFIG_HASH:-0x0000000000000000000000000000000000000000000000000000000000000000}" \
         --tee-image-hash "${TEE_IMAGE_HASH:-0x0000000000000000000000000000000000000000000000000000000000000000}" \
         --enable-experimental-witness-endpoint \

--- a/crates/proof/tee/nitro/src/enclave/mod.rs
+++ b/crates/proof/tee/nitro/src/enclave/mod.rs
@@ -1,7 +1,7 @@
 #[cfg(target_os = "linux")]
 use std::sync::Arc;
 
-use alloy_primitives::{Address, B256};
+use alloy_primitives::B256;
 #[cfg(target_os = "linux")]
 use base_proof_transport::Frame;
 #[cfg(target_os = "linux")]
@@ -34,11 +34,9 @@ pub use server::Server;
 pub struct EnclaveConfig {
     /// Vsock port to listen on.
     pub vsock_port: u32,
-    /// The proposer address (set at deploy time).
-    pub proposer: Address,
     /// Per-chain configuration hash.
     pub config_hash: B256,
-    /// Expected PCR0 measurement. Verified against NSM at startup.
+    /// Expected TEE image hash. In enclave mode, verified as keccak256(PCR0) against NSM at startup.
     pub tee_image_hash: B256,
 }
 

--- a/crates/proof/tee/nitro/src/enclave/server.rs
+++ b/crates/proof/tee/nitro/src/enclave/server.rs
@@ -1,5 +1,5 @@
 /// Enclave server — manages keys, attestation, signing, and proof execution.
-use alloy_primitives::{Address, B256, Bytes, U256};
+use alloy_primitives::{Address, B256, Bytes, U256, keccak256};
 use alloy_signer_local::PrivateKeySigner;
 use base_alloy_evm::OpEvmFactory;
 use base_proof_client::{BootInfo, Prologue};
@@ -20,8 +20,8 @@ use crate::{
 /// Environment variable for setting the signer key in local mode.
 const SIGNER_KEY_ENV_VAR: &str = "OP_ENCLAVE_SIGNER_KEY";
 
-/// PCR0 length
-const PCR0_LENGTH: usize = 32;
+/// PCR0 is a SHA-384 hash (48 bytes) per the AWS Nitro Enclaves specification.
+const PCR0_LENGTH: usize = 48;
 
 /// The enclave server.
 ///
@@ -33,66 +33,69 @@ pub struct Server {
     pcr0: Vec<u8>,
     /// ECDSA signing key.
     signer_key: PrivateKeySigner,
-    /// The proposer address.
-    proposer: Address,
     /// Per-chain config hash.
     config_hash: B256,
-    /// TEE image hash (from PCR0 or config in local mode).
+    /// TEE image hash (keccak256 of PCR0 in enclave mode, from config in local mode).
     tee_image_hash: B256,
 }
 
 impl Server {
     /// Create a new server instance.
     ///
-    /// Attempts to open an NSM session and verify PCR0 against `config.tee_image_hash`.
-    /// Falls back to local mode if NSM is unavailable.
+    /// In enclave mode (NSM available): reads PCR0, keccak256-hashes it to derive
+    /// `tee_image_hash`, verifies against the configured expected hash, and uses the
+    /// hardware RNG for key generation.
+    ///
+    /// In local mode (no NSM): uses the OS RNG and accepts `config.tee_image_hash` as-is.
     pub fn new(config: &EnclaveConfig) -> Result<Self> {
-        let (mut rng, pcr0) = match NsmSession::open()? {
-            Some(session) => {
-                let pcr0 = session.describe_pcr0()?;
-
-                if pcr0.len() != PCR0_LENGTH {
-                    return Err(NsmError::DescribePcr(format!(
-                        "unexpected PCR0 length {}, expected 32.",
-                        pcr0.len()
-                    ))
-                    .into());
-                }
-                let actual_hash = B256::from_slice(&pcr0);
-                if actual_hash != config.tee_image_hash {
-                    return Err(NitroError::Pcr0Mismatch {
-                        expected: config.tee_image_hash,
-                        actual: actual_hash,
-                    });
-                }
-
-                let rng = NsmRng::new()
-                    .ok_or_else(|| NsmError::SessionOpen("failed to initialize NSM RNG".into()))?;
-                (rng, pcr0)
-            }
-            None => {
+        NsmSession::open()?.map_or_else(
+            || {
                 warn!("running in local mode without NSM");
-                (NsmRng::default(), Vec::new())
-            }
-        };
+                Self::new_local(config)
+            },
+            |session| Self::new_enclave(config, &session),
+        )
+    }
 
+    fn new_enclave(config: &EnclaveConfig, session: &NsmSession) -> Result<Self> {
+        let pcr0 = session.describe_pcr0()?;
+        if pcr0.len() != PCR0_LENGTH {
+            return Err(NsmError::DescribePcr(format!(
+                "unexpected PCR0 length {}, expected {PCR0_LENGTH}",
+                pcr0.len()
+            ))
+            .into());
+        }
+
+        let tee_image_hash = keccak256(&pcr0);
+        if tee_image_hash != config.tee_image_hash {
+            return Err(NitroError::Pcr0Mismatch {
+                expected: config.tee_image_hash,
+                actual: tee_image_hash,
+            });
+        }
+
+        let mut rng = NsmRng::new()
+            .ok_or_else(|| NsmError::SessionOpen("failed to initialize NSM RNG".into()))?;
+        let signer_key = Ecdsa::generate(&mut rng)?;
+
+        Ok(Self { pcr0, signer_key, config_hash: config.config_hash, tee_image_hash })
+    }
+
+    fn new_local(config: &EnclaveConfig) -> Result<Self> {
         let signer_key = match std::env::var(SIGNER_KEY_ENV_VAR) {
             Ok(hex_key) => {
                 info!("using signer key from environment variable");
                 Ecdsa::from_hex(&hex_key)?
             }
-            Err(_) => Ecdsa::generate(&mut rng)?,
+            Err(_) => Ecdsa::generate(&mut NsmRng::default())?,
         };
 
-        let tee_image_hash =
-            if pcr0.is_empty() { config.tee_image_hash } else { B256::from_slice(&pcr0) };
-
         Ok(Self {
-            pcr0,
+            pcr0: Vec::new(),
             signer_key,
-            proposer: config.proposer,
             config_hash: config.config_hash,
-            tee_image_hash,
+            tee_image_hash: config.tee_image_hash,
         })
     }
 
@@ -162,7 +165,7 @@ impl Server {
             let l1_origin_number = U256::from(l2_info.l1_origin.number);
 
             let signing_data = Signing::build_data(
-                self.proposer,
+                self.signer_key.address(),
                 l1_origin_hash,
                 prev_output_root,
                 l2_block_number
@@ -200,7 +203,7 @@ impl Server {
                 proposals[..proposals.len() - 1].iter().map(|p| p.output_root).collect();
 
             let signing_data = Signing::build_data(
-                self.proposer,
+                self.signer_key.address(),
                 last.l1_origin_hash,
                 agreed_l2_output_root,
                 first
@@ -246,7 +249,6 @@ impl Server {
         Ok(Self {
             pcr0: Vec::new(),
             signer_key,
-            proposer: config.proposer,
             config_hash: config.config_hash,
             tee_image_hash: config.tee_image_hash,
         })
@@ -258,12 +260,7 @@ mod tests {
     use super::*;
 
     fn test_config() -> EnclaveConfig {
-        EnclaveConfig {
-            vsock_port: 1234,
-            proposer: Address::ZERO,
-            config_hash: B256::ZERO,
-            tee_image_hash: B256::ZERO,
-        }
+        EnclaveConfig { vsock_port: 1234, config_hash: B256::ZERO, tee_image_hash: B256::ZERO }
     }
 
     #[test]

--- a/crates/proof/tee/nitro/src/host/backend.rs
+++ b/crates/proof/tee/nitro/src/host/backend.rs
@@ -42,7 +42,7 @@ impl ProverBackend for NitroBackend {
 
 #[cfg(test)]
 mod tests {
-    use alloy_primitives::{Address, B256};
+    use alloy_primitives::B256;
     use base_proof_preimage::{PreimageKey, WitnessOracle};
     use base_proof_primitives::ProverBackend;
 
@@ -50,12 +50,7 @@ mod tests {
     use crate::enclave::{EnclaveConfig, Server};
 
     fn test_config() -> EnclaveConfig {
-        EnclaveConfig {
-            vsock_port: 0,
-            proposer: Address::ZERO,
-            config_hash: B256::ZERO,
-            tee_image_hash: B256::ZERO,
-        }
+        EnclaveConfig { vsock_port: 0, config_hash: B256::ZERO, tee_image_hash: B256::ZERO }
     }
 
     #[tokio::test]

--- a/crates/proof/tee/nitro/src/host/server.rs
+++ b/crates/proof/tee/nitro/src/host/server.rs
@@ -78,19 +78,14 @@ impl EnclaveApiServer for NitroSignerRpc {
 
 #[cfg(test)]
 mod tests {
-    use alloy_primitives::{Address, B256};
+    use alloy_primitives::B256;
     use base_proof_primitives::EnclaveApiServer;
 
     use super::*;
     use crate::enclave::{EnclaveConfig, Server as EnclaveServer};
 
     fn test_config() -> EnclaveConfig {
-        EnclaveConfig {
-            vsock_port: 0,
-            proposer: Address::ZERO,
-            config_hash: B256::ZERO,
-            tee_image_hash: B256::ZERO,
-        }
+        EnclaveConfig { vsock_port: 0, config_hash: B256::ZERO, tee_image_hash: B256::ZERO }
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- Remove the `proposer` field from `EnclaveConfig`, `Server`, and CLI args — the enclave
  now signs with its own ephemeral key (`signer_key.address()`) instead of a deploy-time
  proposer address.
- Fix `PCR0_LENGTH` from 32 to 48 bytes (SHA-384 per AWS Nitro spec) and derive
  `tee_image_hash` via `keccak256(pcr0)` so the 48-byte digest fits in a B256.
- Restructure `Server::new()` into `new_enclave()` / `new_local()` helpers for clearer
  separation of enclave vs local initialization logic.

## Changes

### Commit 1: `feat(tee): remove proposer field on enclave config`
- **`bin/prover/src/cli.rs`**: Remove `--proposer` CLI arg from `NitroEnclaveArgs` and `NitroLocalArgs`
- **`crates/proof/tee/nitro/src/enclave/mod.rs`**: Remove `proposer: Address` from `EnclaveConfig`
- **`crates/proof/tee/nitro/src/enclave/server.rs`**: Remove `proposer` from `Server`, pass `signer_key.address()` to `build_data()` instead

### Commit 2: `fix(tee): correct PCR0 length and derive tee_image_hash via keccak256`
- **`crates/proof/tee/nitro/src/enclave/server.rs`**: Fix `PCR0_LENGTH` 32→48, derive `tee_image_hash = keccak256(pcr0)`, split constructor into `new_enclave()`/`new_local()`
- **`crates/proof/tee/Justfile`**: Remove `--proposer` from `nitro-local` command

## Testing

All 26 tests in `base-proof-tee-nitro` pass. Both `base-proof-tee-nitro` and `base-prover` compile cleanly.