### PR TITLE
refactor(proof): simplify ProofResult from struct to enum

### DIFF
--- a/crates/proof/primitives/README.md
+++ b/crates/proof/primitives/README.md
@@ -10,10 +10,9 @@ on-chain verifiers:
 
 - **`Proposal`** — An output root proposal with its ECDSA signature and L1/L2 context.
 - **`ProofBundle`** — Request plus preimage key-value pairs sent to a prover.
-- **`ProofClaim`** — The claim being proven: an aggregated `Proposal` covering the
-  entire block range and the individual per-block `Proposal`s that were aggregated.
-- **`ProofEvidence`** — Backend-specific evidence (TEE attestation or ZK proof).
-- **`ProofResult`** — A claim paired with its evidence.
+- **`ProofResult`** — The output of a proof computation, with one variant per backend:
+  - `Tee` — aggregated and per-block `Proposal`s.
+  - `Zk` — opaque proof bytes.
 
 ## Usage
 

--- a/crates/proof/primitives/src/lib.rs
+++ b/crates/proof/primitives/src/lib.rs
@@ -4,7 +4,7 @@
 extern crate alloc;
 
 mod proof;
-pub use proof::{ProofBundle, ProofClaim, ProofEvidence, ProofRequest, ProofResult};
+pub use proof::{ProofBundle, ProofRequest, ProofResult};
 
 mod proposal;
 pub use proposal::{ECDSA_SIGNATURE_LENGTH, Proposal};

--- a/crates/proof/primitives/src/proof.rs
+++ b/crates/proof/primitives/src/proof.rs
@@ -5,49 +5,32 @@ use base_proof_preimage::PreimageKey;
 
 use crate::Proposal;
 
-/// The claim being proven, containing an aggregated proposal over a block range
-/// and the individual per-block proposals that were aggregated.
+/// The result of a proof computation, parameterized by backend.
 ///
-/// The TEE server generates a [`Proposal`] for each block in the range, then
-/// aggregates them into a single [`Proposal`]. Verifiers can check both
-/// per-block correctness and aggregation integrity.
+/// Each variant carries exactly the data its backend needs:
+///
+/// - **`Tee`**: The TEE server generates a [`Proposal`] for each block in the
+///   range, then aggregates them into a single [`Proposal`]. On-chain
+///   verification uses the per-proposal ECDSA signatures directly; the
+///   attestation document is handled separately at signer registration time.
+///
+/// - **`Zk`**: The ZK prover produces an opaque proof blob that the on-chain
+///   verifier checks against a committed image ID.
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-pub struct ProofClaim {
-    /// The aggregated proposal covering the entire proven block range.
-    pub aggregate_proposal: Proposal,
-    /// The individual per-block proposals that were aggregated.
-    pub proposals: Vec<Proposal>,
-}
-
-/// Backend-specific evidence that accompanies a [`ProofClaim`].
-#[derive(Debug, Clone, PartialEq, Eq)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-pub enum ProofEvidence {
-    /// Evidence produced by a TEE backend.
+pub enum ProofResult {
+    /// Result from a TEE backend.
     Tee {
-        /// The attestation document from the enclave.
-        attestation_doc: Vec<u8>,
-        /// The signature over the claim.
-        signature: Vec<u8>,
+        /// The aggregated proposal covering the entire proven block range.
+        aggregate_proposal: Proposal,
+        /// The individual per-block proposals that were aggregated.
+        proposals: Vec<Proposal>,
     },
-    /// Evidence produced by a ZK backend.
+    /// Result from a ZK backend.
     Zk {
         /// The ZK proof bytes.
         proof_bytes: Vec<u8>,
-        /// The image ID (program hash) that produced this proof.
-        image_id: B256,
     },
-}
-
-/// A proven claim: a [`ProofClaim`] paired with its [`ProofEvidence`].
-#[derive(Debug, Clone, PartialEq, Eq)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-pub struct ProofResult {
-    /// The claim being proven.
-    pub claim: ProofClaim,
-    /// The backend-specific evidence for this claim.
-    pub evidence: ProofEvidence,
 }
 
 /// Per-proof parameters — which block to prove.

--- a/crates/proof/primitives/src/proof.rs
+++ b/crates/proof/primitives/src/proof.rs
@@ -16,6 +16,7 @@ use crate::Proposal;
 ///
 /// - **`Zk`**: The ZK prover produces an opaque proof blob that the on-chain
 ///   verifier checks against a committed image ID.
+#[allow(clippy::large_enum_variant)]
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum ProofResult {

--- a/crates/proof/tee/client/README.md
+++ b/crates/proof/tee/client/README.md
@@ -58,7 +58,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     };
 
     let result = client.prove(request).await?;
-    println!("Proof claim: {:?}", result.claim);
+    println!("Proof result: {:?}", result);
 
     Ok(())
 }

--- a/crates/proof/tee/client/src/client.rs
+++ b/crates/proof/tee/client/src/client.rs
@@ -198,7 +198,7 @@ impl EnclaveClient {
     /// [`aggregate`](Self::aggregate), which require the caller to orchestrate individual block
     /// executions and aggregation, this method delegates all orchestration to the TEE server.
     /// The server handles generating per-block proposals, aggregating them, and returning a
-    /// complete [`ProofResult`] containing the [`ProofClaim`] and [`ProofEvidence`].
+    /// complete [`ProofResult`].
     ///
     /// # Errors
     ///

--- a/crates/proof/tee/nitro/src/enclave/server.rs
+++ b/crates/proof/tee/nitro/src/enclave/server.rs
@@ -4,7 +4,7 @@ use alloy_signer_local::PrivateKeySigner;
 use base_alloy_evm::OpEvmFactory;
 use base_proof_client::{BootInfo, Prologue};
 use base_proof_preimage::PreimageKey;
-use base_proof_primitives::{ProofClaim, ProofEvidence, ProofResult, Proposal};
+use base_proof_primitives::{ProofResult, Proposal};
 use tracing::{info, warn};
 
 use crate::{
@@ -230,16 +230,7 @@ impl Server {
             }
         };
 
-        let attestation_doc = self.try_get_attestation_bytes();
-        let evidence_signature = Signing::sign(&self.signer_key, &aggregate_proposal.signature)?;
-
-        Ok(ProofResult {
-            claim: ProofClaim { aggregate_proposal, proposals },
-            evidence: ProofEvidence::Tee {
-                attestation_doc,
-                signature: evidence_signature.to_vec(),
-            },
-        })
+        Ok(ProofResult::Tee { aggregate_proposal, proposals })
     }
 
     /// Create a server for testing (no NSM, no PCR0 verification).

--- a/crates/proof/tee/nitro/src/enclave/server.rs
+++ b/crates/proof/tee/nitro/src/enclave/server.rs
@@ -125,11 +125,6 @@ impl Server {
         session.get_attestation(public_key)
     }
 
-    /// Try to get attestation bytes, returning empty vec on failure.
-    fn try_get_attestation_bytes(&self) -> Vec<u8> {
-        self.signer_attestation().unwrap_or_default()
-    }
-
     /// Run the proof-client pipeline for the given preimages and return per-block proposals
     /// with an aggregate.
     pub async fn prove(


### PR DESCRIPTION
## Summary

- Collapse `ProofClaim`, `ProofEvidence`, and `ProofResult` struct into a single `ProofResult` enum with `Tee` and `Zk` variants
- Remove dead data from the TEE path: `attestation_doc` (handled separately at signer registration) and `evidence_signature` (sig-over-sig never consumed downstream — on-chain verification uses per-proposal signatures from the claim)

## Changes

| File | What changed |
|------|-------------|
| `crates/proof/primitives/src/proof.rs` | `ProofResult` is now an enum; `ProofClaim` and `ProofEvidence` removed |
| `crates/proof/primitives/src/lib.rs` | Removed `ProofClaim`, `ProofEvidence` re-exports |
| `crates/proof/tee/nitro/src/enclave/server.rs` | Removed dead `attestation_doc` fetch and `evidence_signature` computation; returns `ProofResult::Tee` directly |
| `crates/proof/tee/client/src/client.rs` | Updated doc comment referencing removed types |

All downstream consumers (protocol, host/backend, host/server, host/transport, host/vsock, service, proposer) handle `ProofResult` opaquely and required no changes.