### PR TITLE
refactor(proof): extract ProofJournal struct into base-proof-primitives

### DIFF
--- a/crates/proof/primitives/src/lib.rs
+++ b/crates/proof/primitives/src/lib.rs
@@ -7,7 +7,7 @@ mod proof;
 pub use proof::{ProofBundle, ProofRequest, ProofResult};
 
 mod proposal;
-pub use proposal::{ECDSA_SIGNATURE_LENGTH, Proposal};
+pub use proposal::{ECDSA_SIGNATURE_LENGTH, PROOF_JOURNAL_BASE_LENGTH, ProofJournal, Proposal};
 
 mod prover;
 pub use prover::ProverBackend;

--- a/crates/proof/primitives/src/proposal.rs
+++ b/crates/proof/primitives/src/proposal.rs
@@ -18,7 +18,7 @@ pub const PROOF_JOURNAL_BASE_LENGTH: usize = 244;
 ///   || startingL2Block(32) || outputRoot(32) || endingL2Block(32)
 ///   || intermediateRoots(32*N) || configHash(32) || imageHash(32)
 /// ```
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ProofJournal {
     /// The proposer address.
     pub proposer: Address,

--- a/crates/proof/primitives/src/proposal.rs
+++ b/crates/proof/primitives/src/proposal.rs
@@ -1,7 +1,67 @@
-use alloy_primitives::{B256, Bytes, U256};
+use alloc::vec::Vec;
+
+use alloy_primitives::{Address, B256, Bytes, U256};
 
 /// ECDSA signature length in bytes (r: 32 + s: 32 + v: 1).
 pub const ECDSA_SIGNATURE_LENGTH: usize = 65;
+
+/// Base length of the proof journal without intermediate roots:
+/// address(20) + 7 × bytes32(32) = 244 bytes.
+pub const PROOF_JOURNAL_BASE_LENGTH: usize = 244;
+
+/// The `AggregateVerifier` contract journal encoding.
+///
+/// Serializes proposal fields into the byte format expected by on-chain verification:
+///
+/// ```text
+/// prover(20) || l1OriginHash(32) || prevOutputRoot(32)
+///   || startingL2Block(32) || outputRoot(32) || endingL2Block(32)
+///   || intermediateRoots(32*N) || configHash(32) || imageHash(32)
+/// ```
+#[derive(Debug, Clone)]
+pub struct ProofJournal {
+    /// The proposer address.
+    pub proposer: Address,
+    /// The L1 origin block hash.
+    pub l1_origin_hash: B256,
+    /// The previous output root hash.
+    pub prev_output_root: B256,
+    /// The starting L2 block number.
+    pub starting_l2_block: U256,
+    /// The output root hash.
+    pub output_root: B256,
+    /// The ending L2 block number.
+    pub ending_l2_block: U256,
+    /// Intermediate output roots for aggregate proposals.
+    pub intermediate_roots: Vec<B256>,
+    /// The config hash.
+    pub config_hash: B256,
+    /// The TEE image hash.
+    pub tee_image_hash: B256,
+}
+
+impl ProofJournal {
+    /// Encode the journal into the ABI-packed byte format.
+    #[must_use]
+    pub fn encode(&self) -> Vec<u8> {
+        let mut data =
+            Vec::with_capacity(PROOF_JOURNAL_BASE_LENGTH + 32 * self.intermediate_roots.len());
+
+        data.extend_from_slice(self.proposer.as_slice());
+        data.extend_from_slice(self.l1_origin_hash.as_slice());
+        data.extend_from_slice(self.prev_output_root.as_slice());
+        data.extend_from_slice(&self.starting_l2_block.to_be_bytes::<32>());
+        data.extend_from_slice(self.output_root.as_slice());
+        data.extend_from_slice(&self.ending_l2_block.to_be_bytes::<32>());
+        for root in &self.intermediate_roots {
+            data.extend_from_slice(root.as_slice());
+        }
+        data.extend_from_slice(self.config_hash.as_slice());
+        data.extend_from_slice(self.tee_image_hash.as_slice());
+
+        data
+    }
+}
 
 /// A proposal containing an output root and signature.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -25,11 +85,9 @@ pub struct Proposal {
 
 #[cfg(test)]
 mod tests {
-    extern crate alloc;
-
     use alloc::vec;
 
-    use alloy_primitives::b256;
+    use alloy_primitives::{address, b256};
 
     use super::*;
 
@@ -92,5 +150,83 @@ mod tests {
 
         let json = serde_json::to_string(&proposal).unwrap();
         assert!(json.contains("\"l2_block_number\":\"0x0\""));
+    }
+
+    fn test_journal() -> ProofJournal {
+        ProofJournal {
+            proposer: address!("f39Fd6e51aad88F6F4ce6aB8827279cffFb92266"),
+            l1_origin_hash: b256!(
+                "2222222222222222222222222222222222222222222222222222222222222222"
+            ),
+            prev_output_root: b256!(
+                "3333333333333333333333333333333333333333333333333333333333333333"
+            ),
+            starting_l2_block: U256::from(999),
+            output_root: b256!("4444444444444444444444444444444444444444444444444444444444444444"),
+            ending_l2_block: U256::from(1000),
+            intermediate_roots: vec![],
+            config_hash: b256!("1111111111111111111111111111111111111111111111111111111111111111"),
+            tee_image_hash: b256!(
+                "5555555555555555555555555555555555555555555555555555555555555555"
+            ),
+        }
+    }
+
+    #[test]
+    fn test_journal_encode_length() {
+        let data = test_journal().encode();
+        assert_eq!(data.len(), PROOF_JOURNAL_BASE_LENGTH);
+        assert_eq!(data.len(), 244);
+    }
+
+    #[test]
+    fn test_journal_encode_components() {
+        let journal = test_journal();
+        let data = journal.encode();
+
+        let mut off = 0;
+        assert_eq!(
+            &data[off..off + 20],
+            address!("f39Fd6e51aad88F6F4ce6aB8827279cffFb92266").as_slice()
+        );
+        off += 20;
+        assert_eq!(&data[off..off + 32], journal.l1_origin_hash.as_slice());
+        off += 32;
+        assert_eq!(&data[off..off + 32], journal.prev_output_root.as_slice());
+        off += 32;
+        assert_eq!(&data[off..off + 32], &journal.starting_l2_block.to_be_bytes::<32>());
+        off += 32;
+        assert_eq!(&data[off..off + 32], journal.output_root.as_slice());
+        off += 32;
+        assert_eq!(&data[off..off + 32], &journal.ending_l2_block.to_be_bytes::<32>());
+        off += 32;
+        assert_eq!(&data[off..off + 32], journal.config_hash.as_slice());
+        off += 32;
+        assert_eq!(&data[off..off + 32], journal.tee_image_hash.as_slice());
+    }
+
+    #[test]
+    fn test_journal_encode_with_intermediate_roots() {
+        let journal = ProofJournal {
+            proposer: address!("f39Fd6e51aad88F6F4ce6aB8827279cffFb92266"),
+            l1_origin_hash: B256::ZERO,
+            prev_output_root: B256::ZERO,
+            starting_l2_block: U256::ZERO,
+            output_root: B256::ZERO,
+            ending_l2_block: U256::ZERO,
+            intermediate_roots: vec![
+                b256!("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"),
+                b256!("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"),
+            ],
+            config_hash: B256::ZERO,
+            tee_image_hash: B256::ZERO,
+        };
+
+        let data = journal.encode();
+        assert_eq!(data.len(), PROOF_JOURNAL_BASE_LENGTH + 64);
+
+        let ir_offset = 20 + 5 * 32;
+        assert_eq!(&data[ir_offset..ir_offset + 32], journal.intermediate_roots[0].as_slice());
+        assert_eq!(&data[ir_offset + 32..ir_offset + 64], journal.intermediate_roots[1].as_slice());
     }
 }

--- a/crates/proof/tee/nitro/src/enclave/crypto.rs
+++ b/crates/proof/tee/nitro/src/enclave/crypto.rs
@@ -2,7 +2,7 @@
 ///
 /// Provides key generation, parsing, and address derivation using
 /// `alloy-signer-local::PrivateKeySigner`.
-use alloy_primitives::{Address, B256, Bytes, U256, keccak256};
+use alloy_primitives::{Address, Bytes, keccak256};
 use alloy_signer::SignerSync;
 use alloy_signer_local::PrivateKeySigner;
 use base_proof_primitives::ECDSA_SIGNATURE_LENGTH;
@@ -10,10 +10,6 @@ use k256::ecdsa::{Signature, SigningKey, VerifyingKey, signature::hazmat::Prehas
 use rand_08::CryptoRng;
 
 use crate::error::{CryptoError, ProposalError, Result};
-
-/// Base length of the signing data without intermediate roots:
-/// address(20) + 7 x bytes32(32) = 244 bytes.
-pub const SIGNING_DATA_BASE_LENGTH: usize = 244;
 
 /// ECDSA secp256k1 operations.
 #[derive(Debug)]
@@ -58,67 +54,11 @@ impl Ecdsa {
     }
 }
 
-/// Proposal signing and verification (`AggregateVerifier` journal format).
+/// Proposal signing and verification.
 #[derive(Debug)]
 pub struct Signing;
 
 impl Signing {
-    /// Build the signing data for a proposal.
-    ///
-    /// The format matches the `AggregateVerifier` contract's journal:
-    /// ```text
-    /// prover(20) || l1OriginHash(32) || prevOutputRoot(32)
-    ///   || startingL2Block(32) || outputRoot(32) || endingL2Block(32)
-    ///   || intermediateRoots(32*N) || configHash(32) || imageHash(32)
-    /// ```
-    #[must_use]
-    #[allow(clippy::too_many_arguments)]
-    pub fn build_data(
-        proposer: Address,
-        l1_origin_hash: B256,
-        prev_output_root: B256,
-        starting_l2_block: U256,
-        output_root: B256,
-        ending_l2_block: U256,
-        intermediate_roots: &[B256],
-        config_hash: B256,
-        tee_image_hash: B256,
-    ) -> Vec<u8> {
-        let len = SIGNING_DATA_BASE_LENGTH + 32 * intermediate_roots.len();
-        let mut data = vec![0u8; len];
-        let mut offset = 0;
-
-        data[offset..offset + 20].copy_from_slice(proposer.as_slice());
-        offset += 20;
-
-        data[offset..offset + 32].copy_from_slice(l1_origin_hash.as_slice());
-        offset += 32;
-
-        data[offset..offset + 32].copy_from_slice(prev_output_root.as_slice());
-        offset += 32;
-
-        data[offset..offset + 32].copy_from_slice(&starting_l2_block.to_be_bytes::<32>());
-        offset += 32;
-
-        data[offset..offset + 32].copy_from_slice(output_root.as_slice());
-        offset += 32;
-
-        data[offset..offset + 32].copy_from_slice(&ending_l2_block.to_be_bytes::<32>());
-        offset += 32;
-
-        for root in intermediate_roots {
-            data[offset..offset + 32].copy_from_slice(root.as_slice());
-            offset += 32;
-        }
-
-        data[offset..offset + 32].copy_from_slice(config_hash.as_slice());
-        offset += 32;
-
-        data[offset..offset + 32].copy_from_slice(tee_image_hash.as_slice());
-
-        data
-    }
-
     /// Sign data with keccak256 hash, returns 65-byte signature (r || s || v).
     pub fn sign(signer: &PrivateKeySigner, data: &[u8]) -> Result<Bytes> {
         let hash = keccak256(data);
@@ -151,24 +91,31 @@ impl Signing {
 
 #[cfg(test)]
 mod tests {
-    use alloy_primitives::{address, b256};
+    use alloy_primitives::{U256, address, b256};
+    use base_proof_primitives::{PROOF_JOURNAL_BASE_LENGTH, ProofJournal};
     use rand_08::rngs::OsRng;
 
     use super::*;
     use crate::NitroError;
 
-    fn test_signing_data() -> Vec<u8> {
-        Signing::build_data(
-            address!("f39Fd6e51aad88F6F4ce6aB8827279cffFb92266"),
-            b256!("2222222222222222222222222222222222222222222222222222222222222222"),
-            b256!("3333333333333333333333333333333333333333333333333333333333333333"),
-            U256::from(999),
-            b256!("4444444444444444444444444444444444444444444444444444444444444444"),
-            U256::from(1000),
-            &[],
-            b256!("1111111111111111111111111111111111111111111111111111111111111111"),
-            b256!("5555555555555555555555555555555555555555555555555555555555555555"),
-        )
+    fn test_journal() -> ProofJournal {
+        ProofJournal {
+            proposer: address!("f39Fd6e51aad88F6F4ce6aB8827279cffFb92266"),
+            l1_origin_hash: b256!(
+                "2222222222222222222222222222222222222222222222222222222222222222"
+            ),
+            prev_output_root: b256!(
+                "3333333333333333333333333333333333333333333333333333333333333333"
+            ),
+            starting_l2_block: U256::from(999),
+            output_root: b256!("4444444444444444444444444444444444444444444444444444444444444444"),
+            ending_l2_block: U256::from(1000),
+            intermediate_roots: vec![],
+            config_hash: b256!("1111111111111111111111111111111111111111111111111111111111111111"),
+            tee_image_hash: b256!(
+                "5555555555555555555555555555555555555555555555555555555555555555"
+            ),
+        }
     }
 
     #[test]
@@ -213,89 +160,11 @@ mod tests {
     }
 
     #[test]
-    fn test_build_signing_data_length() {
-        let data = test_signing_data();
-        assert_eq!(data.len(), SIGNING_DATA_BASE_LENGTH);
-        assert_eq!(data.len(), 244);
-    }
-
-    #[test]
-    fn test_build_signing_data_components() {
-        let proposer = address!("f39Fd6e51aad88F6F4ce6aB8827279cffFb92266");
-        let l1_origin_hash =
-            b256!("2222222222222222222222222222222222222222222222222222222222222222");
-        let prev_output_root =
-            b256!("3333333333333333333333333333333333333333333333333333333333333333");
-        let starting_l2_block = U256::from(999);
-        let output_root = b256!("4444444444444444444444444444444444444444444444444444444444444444");
-        let ending_l2_block = U256::from(1000);
-        let config_hash = b256!("1111111111111111111111111111111111111111111111111111111111111111");
-        let tee_image_hash =
-            b256!("5555555555555555555555555555555555555555555555555555555555555555");
-
-        let data = Signing::build_data(
-            proposer,
-            l1_origin_hash,
-            prev_output_root,
-            starting_l2_block,
-            output_root,
-            ending_l2_block,
-            &[],
-            config_hash,
-            tee_image_hash,
-        );
-
-        let mut off = 0;
-        assert_eq!(&data[off..off + 20], proposer.as_slice());
-        off += 20;
-        assert_eq!(&data[off..off + 32], l1_origin_hash.as_slice());
-        off += 32;
-        assert_eq!(&data[off..off + 32], prev_output_root.as_slice());
-        off += 32;
-        assert_eq!(&data[off..off + 32], &starting_l2_block.to_be_bytes::<32>());
-        off += 32;
-        assert_eq!(&data[off..off + 32], output_root.as_slice());
-        off += 32;
-        assert_eq!(&data[off..off + 32], &ending_l2_block.to_be_bytes::<32>());
-        off += 32;
-        assert_eq!(&data[off..off + 32], config_hash.as_slice());
-        off += 32;
-        assert_eq!(&data[off..off + 32], tee_image_hash.as_slice());
-    }
-
-    #[test]
-    fn test_build_signing_data_with_intermediate_roots() {
-        let proposer = address!("f39Fd6e51aad88F6F4ce6aB8827279cffFb92266");
-        let intermediate_roots = vec![
-            b256!("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"),
-            b256!("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"),
-        ];
-
-        let data = Signing::build_data(
-            proposer,
-            B256::ZERO,
-            B256::ZERO,
-            U256::ZERO,
-            B256::ZERO,
-            U256::ZERO,
-            &intermediate_roots,
-            B256::ZERO,
-            B256::ZERO,
-        );
-
-        assert_eq!(data.len(), SIGNING_DATA_BASE_LENGTH + 64);
-
-        let ir_offset = 20 + 5 * 32;
-        assert_eq!(&data[ir_offset..ir_offset + 32], intermediate_roots[0].as_slice());
-        assert_eq!(&data[ir_offset + 32..ir_offset + 64], intermediate_roots[1].as_slice());
-    }
-
-    #[test]
     fn test_sign_and_verify_roundtrip() {
         let mut rng = OsRng;
         let signer = Ecdsa::generate(&mut rng).expect("failed to generate signer");
 
-        let data = test_signing_data();
+        let data = test_journal().encode();
         let signature = Signing::sign(&signer, &data).expect("signing failed");
         assert_eq!(signature.len(), ECDSA_SIGNATURE_LENGTH);
 
@@ -310,7 +179,7 @@ mod tests {
         let signer1 = Ecdsa::generate(&mut rng).expect("failed to generate signer");
         let signer2 = Ecdsa::generate(&mut rng).expect("failed to generate signer");
 
-        let data = test_signing_data();
+        let data = test_journal().encode();
         let signature = Signing::sign(&signer1, &data).expect("signing failed");
 
         let wrong_public_key = Ecdsa::public_key_bytes(&signer2);
@@ -324,19 +193,13 @@ mod tests {
         let mut rng = OsRng;
         let signer = Ecdsa::generate(&mut rng).expect("failed to generate signer");
 
-        let data1 = test_signing_data();
+        let data1 = test_journal().encode();
 
-        let data2 = Signing::build_data(
-            address!("0000000000000000000000000000000000000001"),
-            b256!("2222222222222222222222222222222222222222222222222222222222222222"),
-            b256!("3333333333333333333333333333333333333333333333333333333333333333"),
-            U256::from(999),
-            b256!("4444444444444444444444444444444444444444444444444444444444444444"),
-            U256::from(1000),
-            &[],
-            b256!("1111111111111111111111111111111111111111111111111111111111111111"),
-            b256!("5555555555555555555555555555555555555555555555555555555555555555"),
-        );
+        let journal2 = ProofJournal {
+            proposer: address!("0000000000000000000000000000000000000001"),
+            ..test_journal()
+        };
+        let data2 = journal2.encode();
 
         let signature = Signing::sign(&signer, &data1).expect("signing failed");
 
@@ -348,7 +211,7 @@ mod tests {
     #[test]
     fn test_invalid_signature_length() {
         let public_key = vec![0x04; 65];
-        let data = [0u8; SIGNING_DATA_BASE_LENGTH];
+        let data = [0u8; PROOF_JOURNAL_BASE_LENGTH];
         let short_sig = vec![0u8; 64];
 
         let result = Signing::verify(&public_key, &data, &short_sig);

--- a/crates/proof/tee/nitro/src/enclave/mod.rs
+++ b/crates/proof/tee/nitro/src/enclave/mod.rs
@@ -18,7 +18,7 @@ pub use attestation::{
 };
 
 mod crypto;
-pub use crypto::{Ecdsa, SIGNING_DATA_BASE_LENGTH, Signing};
+pub use crypto::{Ecdsa, Signing};
 
 mod nsm;
 pub use nsm::{NsmRng, NsmSession};

--- a/crates/proof/tee/nitro/src/enclave/server.rs
+++ b/crates/proof/tee/nitro/src/enclave/server.rs
@@ -4,7 +4,7 @@ use alloy_signer_local::PrivateKeySigner;
 use base_alloy_evm::OpEvmFactory;
 use base_proof_client::{BootInfo, Prologue};
 use base_proof_preimage::PreimageKey;
-use base_proof_primitives::{ProofResult, Proposal};
+use base_proof_primitives::{ProofResult, ProofJournal, Proposal};
 use tracing::{info, warn};
 
 use crate::{
@@ -159,19 +159,20 @@ impl Server {
             let l1_origin_hash = l2_info.l1_origin.hash;
             let l1_origin_number = U256::from(l2_info.l1_origin.number);
 
-            let signing_data = Signing::build_data(
-                self.signer_key.address(),
+            let journal = ProofJournal {
+                proposer: self.signer_key.address(),
                 l1_origin_hash,
                 prev_output_root,
-                l2_block_number
+                starting_l2_block: l2_block_number
                     .checked_sub(U256::from(1))
                     .ok_or_else(|| NitroError::ProofPipeline("l2_block_number is 0".into()))?,
-                *output_root,
-                l2_block_number,
-                &[],
-                self.config_hash,
-                self.tee_image_hash,
-            );
+                output_root: *output_root,
+                ending_l2_block: l2_block_number,
+                intermediate_roots: vec![],
+                config_hash: self.config_hash,
+                tee_image_hash: self.tee_image_hash,
+            };
+            let signing_data = journal.encode();
 
             let signature = Signing::sign(&self.signer_key, &signing_data)?;
 
@@ -197,20 +198,21 @@ impl Server {
             let intermediate_roots: Vec<B256> =
                 proposals[..proposals.len() - 1].iter().map(|p| p.output_root).collect();
 
-            let signing_data = Signing::build_data(
-                self.signer_key.address(),
-                last.l1_origin_hash,
-                agreed_l2_output_root,
-                first
+            let journal = ProofJournal {
+                proposer: self.signer_key.address(),
+                l1_origin_hash: last.l1_origin_hash,
+                prev_output_root: agreed_l2_output_root,
+                starting_l2_block: first
                     .l2_block_number
                     .checked_sub(U256::from(1))
                     .ok_or_else(|| NitroError::ProofPipeline("l2_block_number is 0".into()))?,
-                last.output_root,
-                last.l2_block_number,
-                &intermediate_roots,
-                self.config_hash,
-                self.tee_image_hash,
-            );
+                output_root: last.output_root,
+                ending_l2_block: last.l2_block_number,
+                intermediate_roots,
+                config_hash: self.config_hash,
+                tee_image_hash: self.tee_image_hash,
+            };
+            let signing_data = journal.encode();
 
             let signature = Signing::sign(&self.signer_key, &signing_data)?;
 

--- a/crates/proof/tee/nitro/src/enclave/server.rs
+++ b/crates/proof/tee/nitro/src/enclave/server.rs
@@ -4,7 +4,7 @@ use alloy_signer_local::PrivateKeySigner;
 use base_alloy_evm::OpEvmFactory;
 use base_proof_client::{BootInfo, Prologue};
 use base_proof_preimage::PreimageKey;
-use base_proof_primitives::{ProofResult, ProofJournal, Proposal};
+use base_proof_primitives::{ProofJournal, ProofResult, Proposal};
 use tracing::{info, warn};
 
 use crate::{

--- a/crates/proof/tee/nitro/src/lib.rs
+++ b/crates/proof/tee/nitro/src/lib.rs
@@ -11,8 +11,8 @@ mod enclave;
 pub use enclave::NitroEnclave;
 pub use enclave::{
     AttestationDocument, AwsCaRoot, DEFAULT_CA_ROOTS, DEFAULT_CA_ROOTS_SHA256, Ecdsa,
-    EnclaveConfig, EnclaveRequest, EnclaveResponse, NsmRng, NsmSession, SIGNING_DATA_BASE_LENGTH,
-    Server, Signing, VerificationResult, get_default_ca_root, verify_attestation,
+    EnclaveConfig, EnclaveRequest, EnclaveResponse, NsmRng, NsmSession, Server, Signing,
+    VerificationResult, get_default_ca_root, verify_attestation,
 };
 
 #[cfg(feature = "host")]


### PR DESCRIPTION
## Summary

- Adds `ProofJournal` struct to `base-proof-primitives` that encodes the `AggregateVerifier` contract journal format, replacing the 9-argument `Signing::build_data()` function
- Refactors `base-proof-tee-nitro` to construct `ProofJournal` and call `.encode()` instead of positional args — removes `#[allow(clippy::too_many_arguments)]` and manual offset arithmetic
- Moves encoding tests to the primitives crate alongside the struct

## Motivation

Addresses [review feedback](https://github.com/base/base/pull/1141#discussion_r2908344252) on #1141: the `build_data` function had too many positional arguments (suppressed via clippy allow) and used error-prone manual byte offset tracking with magic numbers.

## Changes

### `base-proof-primitives`
- **`proposal.rs`**: New `ProofJournal` struct with `encode()` method using `extend_from_slice` (no magic numbers, no offset tracking). New `PROOF_JOURNAL_BASE_LENGTH` constant.
- **`lib.rs`**: Re-exports `ProofJournal` and `PROOF_JOURNAL_BASE_LENGTH`.

### `base-proof-tee-nitro`
- **`crypto.rs`**: Removed `Signing::build_data()`, `SIGNING_DATA_BASE_LENGTH`, and the clippy suppression. `Signing` retains only `sign()` and `verify()`. Tests updated.
- **`server.rs`**: Both call sites construct `ProofJournal` and call `.encode()`.
- **`mod.rs`** / **`lib.rs`**: Removed `SIGNING_DATA_BASE_LENGTH` from re-exports.