### PR TITLE
fix(ci): reduce lychee flakiness from rate limiting

### DIFF
--- a/.github/workflows/lychee.yml
+++ b/.github/workflows/lychee.yml
@@ -29,3 +29,5 @@ jobs:
         with:
           args: --config ./lychee.toml --cache-exclude-status 429 --root-dir ${{ github.workspace }}/docs/specs/public --exclude-path 'crates/shared/primitives/contracts/' '**/README.md' './docs/**/*.md' './docs/**/*.mdx' './docs/**/*.html' './docs/**/*.json'
           fail: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/docs/guides/UPGRADES.md
+++ b/docs/guides/UPGRADES.md
@@ -247,7 +247,7 @@ Until an activation timestamp is confirmed, leave `base: None` and the chain arr
 
 ### 7. Update the default rollup config
 
-**File:** [`crates/proof/tee/core/src/config/defaults.rs`](https://github.com/base/base/blob/main/crates/proof/tee/core/src/config/defaults.rs)
+**File:** [`crates/consensus/registry/src/test_utils/base_sepolia.rs`](https://github.com/base/base/blob/main/crates/consensus/registry/src/test_utils/base_sepolia.rs)
 
 The `default_rollup_config()` function sets all upgrades active at genesis for dev use. Add the new upgrade:
 

--- a/lychee.toml
+++ b/lychee.toml
@@ -1,25 +1,41 @@
 verbose = "debug"
 no_progress = false
 exclude_all_private = false
-max_concurrency = 48
+max_concurrency = 16
 max_retries = 3
 retry_wait_time = 5
 accept = [200, 403, 429, 503] # 403 is often returned by private repos instead of 404; 429 is rate limiting; 503 is transient GitHub unavailability
 exclude_path = [
     "crates/utilities/test-utils/contracts/",
-    "package-lock\\.json",
+    "**/package-lock.json",
 ]
 exclude = [
+    # Internal / placeholder
     'foo.bar',
     'localhost',
+
+    # Shields.io badges that query live GitHub stats (flaky, not real links)
     'https://img.shields.io/github/commit-activity/w/base/base',
     'https://img.shields.io/github/issues-pr-raw/base/base',
-    'https://rustup.rs/',
-    'https://base.mirror.xyz/',
-    'https://www.man7.org/',
-    'https://tidelift.com/',
-    'https://specs.base.org',
-    'https://patreon.com',
-    'https://www.patreon.com',
-    'https://www.linux-mips.org',
+
+    # Sites that block automated HTTP clients / scrapers
+    'https://.*etherscan\.io',         # Block explorer; returns 403/429 for bots
+    'https://medium\.com',             # Medium blocks crawlers
+    'https://.*\.medium\.com',
+    'https://twitter\.com',            # Returns 4xx without a browser UA
+    'https://www\.man7\.org',          # Linux man pages, blocks crawlers
+    'https://www\.linux-mips\.org',
+    'https://patreon\.com',
+    'https://www\.patreon\.com',
+    'https://tidelift\.com',
+
+    # Internal / staging sites not meant for link checking
+    'https://rustup\.rs/',
+    'https://base\.mirror\.xyz/',
+    'https://specs\.base\.org',
+
+    # High-volume npm registry URLs from lockfiles (belt-and-suspenders alongside
+    # the package-lock.json exclude_path; registry URLs are not meaningful doc links)
+    'https://registry\.npmjs\.org',
+    'https://opencollective\.com',     # Funding pages; rate-limits and redirects heavily
 ]


### PR DESCRIPTION
## Summary

Fixes intermittent lychee failures caused by rate limiting and an invalid package-lock.json exclusion pattern.

The package-lock.json exclusion used regex-style escaping (`package-lock\\.json`) which is invalid as a glob, so lychee was scanning the file and generating ~800 npm registry URL checks per run. Fixed to `**/package-lock.json`. Added `registry.npmjs.org` to the exclude list as belt-and-suspenders.

Lowered `max_concurrency` from 48 to 16 to reduce concurrent request pressure on GitHub and other hosts. Added `GITHUB_TOKEN` to the lychee action so GitHub URL checks are authenticated (5,000 req/hr instead of 60). Expanded the exclude list with proper regex patterns to cover etherscan, medium, opencollective, and twitter, which are all known to block automated clients.

Also fixes the one real 404: the upgrade guide referenced `crates/proof/tee/core/src/config/defaults.rs` which was removed in the enclave refactor. Updated to point at the correct file.