### PR TITLE
feat(tx-manager): NonceManager with RAII NonceGuard

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -304,7 +304,7 @@ checksum = "b991c370ce44e70a3a9e474087e3d65e42e66f967644ad729dc4cec09a21fd09"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
- "alloy-hardforks",
+ "alloy-hardforks 0.4.7",
  "alloy-primitives",
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
@@ -330,6 +330,19 @@ dependencies = [
  "borsh",
  "serde",
  "serde_with",
+]
+
+[[package]]
+name = "alloy-hardforks"
+version = "0.2.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3165210652f71dfc094b051602bafd691f506c54050a174b1cba18fb5ef706a3"
+dependencies = [
+ "alloy-chains",
+ "alloy-eip2124",
+ "alloy-primitives",
+ "auto_impl",
+ "dyn-clone",
 ]
 
 [[package]]
@@ -410,6 +423,28 @@ dependencies = [
  "alloy-primitives",
  "alloy-serde",
  "serde",
+]
+
+[[package]]
+name = "alloy-node-bindings"
+version = "1.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "091dc8117d84de3a9ac7ec97f2c4d83987e24d485b478d26aa1ec455d7d52f7d"
+dependencies = [
+ "alloy-genesis",
+ "alloy-hardforks 0.2.13",
+ "alloy-network",
+ "alloy-primitives",
+ "alloy-signer",
+ "alloy-signer-local",
+ "k256",
+ "libc",
+ "rand 0.8.5",
+ "serde_json",
+ "tempfile",
+ "thiserror 2.0.18",
+ "tracing",
+ "url",
 ]
 
 [[package]]
@@ -2327,7 +2362,7 @@ dependencies = [
  "alloy-consensus",
  "alloy-eips",
  "alloy-evm",
- "alloy-hardforks",
+ "alloy-hardforks 0.4.7",
  "alloy-primitives",
  "auto_impl",
  "base-alloy-consensus",
@@ -2452,7 +2487,7 @@ name = "base-alloy-upgrades"
 version = "0.0.0"
 dependencies = [
  "alloy-chains",
- "alloy-hardforks",
+ "alloy-hardforks 0.4.7",
  "alloy-primitives",
  "auto_impl",
  "serde",
@@ -2914,7 +2949,7 @@ dependencies = [
  "alloy-consensus",
  "alloy-eips",
  "alloy-genesis",
- "alloy-hardforks",
+ "alloy-hardforks 0.4.7",
  "alloy-primitives",
  "alloy-sol-types",
  "arbitrary",
@@ -3095,7 +3130,7 @@ dependencies = [
  "alloy-chains",
  "alloy-eips",
  "alloy-genesis",
- "alloy-hardforks",
+ "alloy-hardforks 0.4.7",
  "alloy-primitives",
  "base-alloy-upgrades",
  "base-consensus-genesis",
@@ -3248,7 +3283,7 @@ dependencies = [
  "alloy-consensus",
  "alloy-eips",
  "alloy-genesis",
- "alloy-hardforks",
+ "alloy-hardforks 0.4.7",
  "alloy-primitives",
  "base-alloy-consensus",
  "base-alloy-rpc-types",
@@ -4395,7 +4430,9 @@ version = "0.0.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
+ "alloy-node-bindings",
  "alloy-primitives",
+ "alloy-provider",
  "alloy-rpc-types-eth",
  "clap",
  "humantime",
@@ -4404,6 +4441,7 @@ dependencies = [
  "serde",
  "thiserror 2.0.18",
  "tokio",
+ "tracing",
 ]
 
 [[package]]
@@ -13270,7 +13308,7 @@ dependencies = [
  "alloy-chains",
  "alloy-consensus",
  "alloy-eips",
- "alloy-hardforks",
+ "alloy-hardforks 0.4.7",
  "alloy-primitives",
  "alloy-rlp",
  "arbitrary",
@@ -13326,7 +13364,7 @@ version = "1.11.2"
 source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.2#793a3d5fb3e3413e9ecc9b024a5e26672e61e7c3"
 dependencies = [
  "alloy-eip2124",
- "alloy-hardforks",
+ "alloy-hardforks 0.4.7",
  "alloy-primitives",
  "arbitrary",
  "auto_impl",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4451,6 +4451,7 @@ dependencies = [
  "clap",
  "humantime",
  "proptest",
+ "rayon",
  "rstest",
  "serde",
  "thiserror 2.0.18",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -427,9 +427,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-node-bindings"
-version = "1.7.3"
+version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "091dc8117d84de3a9ac7ec97f2c4d83987e24d485b478d26aa1ec455d7d52f7d"
+checksum = "35c4f71997ada33b6aa3114d663a93b33a9af9d57bc5e21d79861f7491915e42"
 dependencies = [
  "alloy-genesis",
  "alloy-hardforks 0.2.13",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -276,6 +276,7 @@ alloy-sol-types = { version = "1.5.0", default-features = false }
 alloy-sol-macro = "1.5.0"
 alloy-rpc-client = "1.5.2"
 alloy-signer-local = "1.5.2"
+alloy-node-bindings = "1.5.2"
 alloy-rpc-types-eth = { version = "1.5.2", default-features = false }
 alloy-transport-http = "1.5.2"
 alloy-rpc-types-debug = { version = "1.6.3", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -276,8 +276,7 @@ alloy-sol-types = { version = "1.5.0", default-features = false }
 alloy-sol-macro = "1.5.0"
 alloy-rpc-client = "1.5.2"
 alloy-signer-local = "1.5.2"
-# pinned: alloy-node-bindings 1.5.3+ pulls in incompatible alloy-hardforks
-alloy-node-bindings = "=1.5.2"
+alloy-node-bindings = "1.5.2"
 alloy-rpc-types-eth = { version = "1.5.2", default-features = false }
 alloy-transport-http = "1.5.2"
 alloy-rpc-types-debug = { version = "1.6.3", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -276,6 +276,7 @@ alloy-sol-types = { version = "1.5.0", default-features = false }
 alloy-sol-macro = "1.5.0"
 alloy-rpc-client = "1.5.2"
 alloy-signer-local = "1.5.2"
+# pinned: alloy-node-bindings 1.5.3+ pulls in incompatible alloy-hardforks
 alloy-node-bindings = "=1.5.2"
 alloy-rpc-types-eth = { version = "1.5.2", default-features = false }
 alloy-transport-http = "1.5.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -276,7 +276,7 @@ alloy-sol-types = { version = "1.5.0", default-features = false }
 alloy-sol-macro = "1.5.0"
 alloy-rpc-client = "1.5.2"
 alloy-signer-local = "1.5.2"
-alloy-node-bindings = "1.5.2"
+alloy-node-bindings = "=1.5.2"
 alloy-rpc-types-eth = { version = "1.5.2", default-features = false }
 alloy-transport-http = "1.5.2"
 alloy-rpc-types-debug = { version = "1.6.3", default-features = false }

--- a/crates/utilities/tx-manager/Cargo.toml
+++ b/crates/utilities/tx-manager/Cargo.toml
@@ -31,4 +31,4 @@ alloy-consensus.workspace = true
 alloy-node-bindings.workspace = true
 clap = { workspace = true, features = ["derive", "env"] }
 serde = { workspace = true, features = ["derive", "std"] }
-tokio = { workspace = true, features = ["macros", "rt", "rt-multi-thread"] }
+tokio = { workspace = true, features = ["macros", "net", "rt", "rt-multi-thread"] }

--- a/crates/utilities/tx-manager/Cargo.toml
+++ b/crates/utilities/tx-manager/Cargo.toml
@@ -13,7 +13,9 @@ workspace = true
 
 [dependencies]
 thiserror.workspace = true
+alloy-provider.workspace = true
 tokio = { workspace = true, features = ["sync"] }
+tracing = { workspace = true, features = ["std"] }
 alloy-eips = { workspace = true, features = ["std"] }
 alloy-primitives = { workspace = true, features = ["std"] }
 alloy-rpc-types-eth = { workspace = true, features = ["std"] }
@@ -23,6 +25,7 @@ rstest.workspace = true
 proptest.workspace = true
 humantime.workspace = true
 alloy-consensus.workspace = true
+alloy-node-bindings.workspace = true
 clap = { workspace = true, features = ["derive", "env"] }
-tokio = { workspace = true, features = ["macros", "rt"] }
 serde = { workspace = true, features = ["derive", "std"] }
+tokio = { workspace = true, features = ["macros", "rt", "rt-multi-thread"] }

--- a/crates/utilities/tx-manager/Cargo.toml
+++ b/crates/utilities/tx-manager/Cargo.toml
@@ -20,8 +20,8 @@ alloy-rpc-types-eth = { workspace = true, features = ["std"] }
 
 # misc
 thiserror.workspace = true
-tokio = { workspace = true, features = ["sync", "time"] }
 tracing = { workspace = true, features = ["std"] }
+tokio = { workspace = true, features = ["sync", "time"] }
 
 [dev-dependencies]
 rstest.workspace = true

--- a/crates/utilities/tx-manager/Cargo.toml
+++ b/crates/utilities/tx-manager/Cargo.toml
@@ -12,13 +12,16 @@ repository.workspace = true
 workspace = true
 
 [dependencies]
-thiserror.workspace = true
+# alloy
 alloy-provider.workspace = true
-tokio = { workspace = true, features = ["sync"] }
-tracing = { workspace = true, features = ["std"] }
 alloy-eips = { workspace = true, features = ["std"] }
 alloy-primitives = { workspace = true, features = ["std"] }
 alloy-rpc-types-eth = { workspace = true, features = ["std"] }
+
+# misc
+thiserror.workspace = true
+tokio = { workspace = true, features = ["sync"] }
+tracing = { workspace = true, features = ["std"] }
 
 [dev-dependencies]
 rstest.workspace = true

--- a/crates/utilities/tx-manager/Cargo.toml
+++ b/crates/utilities/tx-manager/Cargo.toml
@@ -24,6 +24,7 @@ tracing = { workspace = true, features = ["std"] }
 tokio = { workspace = true, features = ["sync", "time"] }
 
 [dev-dependencies]
+rayon.workspace = true
 rstest.workspace = true
 proptest.workspace = true
 humantime.workspace = true

--- a/crates/utilities/tx-manager/Cargo.toml
+++ b/crates/utilities/tx-manager/Cargo.toml
@@ -20,7 +20,7 @@ alloy-rpc-types-eth = { workspace = true, features = ["std"] }
 
 # misc
 thiserror.workspace = true
-tokio = { workspace = true, features = ["sync"] }
+tokio = { workspace = true, features = ["sync", "time"] }
 tracing = { workspace = true, features = ["std"] }
 
 [dev-dependencies]

--- a/crates/utilities/tx-manager/README.md
+++ b/crates/utilities/tx-manager/README.md
@@ -49,7 +49,15 @@ Transaction lifecycle management for Base onchain components.
   to `u128` wei via `alloy_primitives::utils::parse_units`.
 - **`TxManager`**: Trait defining the public API — `send` (blocking), `send_async` (returns
   a `SendHandle`), and `sender_address`. Requires `Send + Sync`.
-- **`NonceManager`**: Manages nonce allocation and tracking.
+- **`NonceManager`**: Manages nonce allocation and tracking with lazy initialization from
+  chain state. Wraps a `tokio::sync::Mutex` around a cached nonce, fetching the initial
+  value via `get_transaction_count()` on first use and incrementing locally on subsequent
+  calls. Returns a [`NonceGuard`] from `next_nonce()` that holds the lock for the duration
+  of signing. `reset()` clears the cache, forcing a fresh chain fetch on the next call.
+- **`NonceGuard`**: RAII guard holding a reserved nonce and the nonce mutex lock. Drop the
+  guard after successful signing to advance the nonce, or call `rollback()` on failure to
+  restore it for reuse. Uses `OwnedMutexGuard` so the guard is `Send` and can cross task
+  spawn boundaries.
 - **`SimpleTxManager`**: Default `TxManager` implementation.
 - **`TxQueue`**: Queue for ordering and batching transactions.
 - **`TxMetrics`**: Metrics collection for transaction operations.

--- a/crates/utilities/tx-manager/README.md
+++ b/crates/utilities/tx-manager/README.md
@@ -55,9 +55,9 @@ Transaction lifecycle management for Base onchain components.
   calls. Returns a [`NonceGuard`] from `next_nonce()` that holds the lock for the duration
   of signing. `reset()` clears the cache, forcing a fresh chain fetch on the next call.
 - **`NonceGuard`**: RAII guard holding a reserved nonce and the nonce mutex lock. Drop the
-  guard after successful signing to advance the nonce, or call `rollback()` on failure to
-  restore it for reuse. Uses `OwnedMutexGuard` so the guard is `Send` and can cross task
-  spawn boundaries.
+  guard after successful signing to release the lock, or call `rollback()` on failure to
+  restore the nonce for reuse. Uses `OwnedMutexGuard` so the guard is `Send` and can cross
+  task spawn boundaries.
 - **`SimpleTxManager`**: Default `TxManager` implementation.
 - **`TxQueue`**: Queue for ordering and batching transactions.
 - **`TxMetrics`**: Metrics collection for transaction operations.

--- a/crates/utilities/tx-manager/src/error.rs
+++ b/crates/utilities/tx-manager/src/error.rs
@@ -333,7 +333,10 @@ mod tests {
         "invalid safe_abort_nonce_too_low_count: must be greater than 0"
     )]
     #[case::nonce_overflow(TxManagerError::NonceOverflow, "nonce overflow")]
-    #[case::nonce_acquisition_failed(TxManagerError::NonceAcquisitionFailed, "nonce acquisition failed")]
+    #[case::nonce_acquisition_failed(
+        TxManagerError::NonceAcquisitionFailed,
+        "nonce acquisition failed"
+    )]
     #[case::rpc(TxManagerError::Rpc("test".to_string()), "rpc error: test")]
     fn display_output(#[case] error: TxManagerError, #[case] expected: &str) {
         assert_eq!(error.to_string(), expected);

--- a/crates/utilities/tx-manager/src/error.rs
+++ b/crates/utilities/tx-manager/src/error.rs
@@ -41,6 +41,10 @@ pub enum TxManagerError {
     #[error("nonce overflow")]
     NonceOverflow,
 
+    /// Nonce reservation failed due to repeated cache contention.
+    #[error("nonce acquisition failed")]
+    NonceAcquisitionFailed,
+
     /// Send response channel closed before a result was delivered.
     ///
     /// The background send task exited (panicked or was cancelled)
@@ -277,6 +281,7 @@ mod tests {
     #[case::fee_limit_exceeded(TxManagerError::FeeLimitExceeded { fee: 0, ceiling: 0 }, false)]
     #[case::invalid_safe_abort(TxManagerError::InvalidSafeAbortNonceTooLowCount, false)]
     #[case::nonce_overflow(TxManagerError::NonceOverflow, false)]
+    #[case::nonce_acquisition_failed(TxManagerError::NonceAcquisitionFailed, false)]
     #[case::underpriced(TxManagerError::Underpriced, true)]
     #[case::replacement_underpriced(TxManagerError::ReplacementUnderpriced, true)]
     #[case::fee_too_low(TxManagerError::FeeTooLow, true)]
@@ -328,6 +333,7 @@ mod tests {
         "invalid safe_abort_nonce_too_low_count: must be greater than 0"
     )]
     #[case::nonce_overflow(TxManagerError::NonceOverflow, "nonce overflow")]
+    #[case::nonce_acquisition_failed(TxManagerError::NonceAcquisitionFailed, "nonce acquisition failed")]
     #[case::rpc(TxManagerError::Rpc("test".to_string()), "rpc error: test")]
     fn display_output(#[case] error: TxManagerError, #[case] expected: &str) {
         assert_eq!(error.to_string(), expected);

--- a/crates/utilities/tx-manager/src/error.rs
+++ b/crates/utilities/tx-manager/src/error.rs
@@ -37,6 +37,10 @@ pub enum TxManagerError {
     #[error("nonce already reserved")]
     AlreadyReserved,
 
+    /// Nonce arithmetic overflowed `u64::MAX`.
+    #[error("nonce overflow")]
+    NonceOverflow,
+
     /// Send response channel closed before a result was delivered.
     ///
     /// The background send task exited (panicked or was cancelled)
@@ -272,6 +276,7 @@ mod tests {
     #[case::channel_closed(TxManagerError::ChannelClosed, false)]
     #[case::fee_limit_exceeded(TxManagerError::FeeLimitExceeded { fee: 0, ceiling: 0 }, false)]
     #[case::invalid_safe_abort(TxManagerError::InvalidSafeAbortNonceTooLowCount, false)]
+    #[case::nonce_overflow(TxManagerError::NonceOverflow, false)]
     #[case::underpriced(TxManagerError::Underpriced, true)]
     #[case::replacement_underpriced(TxManagerError::ReplacementUnderpriced, true)]
     #[case::fee_too_low(TxManagerError::FeeTooLow, true)]
@@ -322,6 +327,7 @@ mod tests {
         TxManagerError::InvalidSafeAbortNonceTooLowCount,
         "invalid safe_abort_nonce_too_low_count: must be greater than 0"
     )]
+    #[case::nonce_overflow(TxManagerError::NonceOverflow, "nonce overflow")]
     #[case::rpc(TxManagerError::Rpc("test".to_string()), "rpc error: test")]
     fn display_output(#[case] error: TxManagerError, #[case] expected: &str) {
         assert_eq!(error.to_string(), expected);

--- a/crates/utilities/tx-manager/src/lib.rs
+++ b/crates/utilities/tx-manager/src/lib.rs
@@ -28,7 +28,7 @@ mod traits;
 pub use traits::{SendHandle, SendResponse, TxManager};
 
 mod nonce;
-pub use nonce::{NonceGuard, NonceManager};
+pub use nonce::{NonceGuard, NonceManager, NonceState};
 
 mod manager;
 pub use manager::SimpleTxManager;

--- a/crates/utilities/tx-manager/src/lib.rs
+++ b/crates/utilities/tx-manager/src/lib.rs
@@ -28,7 +28,7 @@ mod traits;
 pub use traits::{SendHandle, SendResponse, TxManager};
 
 mod nonce;
-pub use nonce::NonceManager;
+pub use nonce::{NonceGuard, NonceManager};
 
 mod manager;
 pub use manager::SimpleTxManager;

--- a/crates/utilities/tx-manager/src/nonce.rs
+++ b/crates/utilities/tx-manager/src/nonce.rs
@@ -146,15 +146,12 @@ impl NonceManager {
     pub async fn next_nonce(&self) -> Result<NonceGuard, TxManagerError> {
         for attempt in 0..Self::MAX_RETRY_ATTEMPTS {
             // Acquire the owned lock once upfront.
-            let mut guard = Arc::clone(&self.inner).lock_owned().await;
+            let guard = Arc::clone(&self.inner).lock_owned().await;
 
             // Fast path: cache is populated — read-and-increment in a
             // single lock round-trip.
             if let Some(n) = guard.nonce {
-                let next = n.checked_add(1).ok_or(TxManagerError::NonceOverflow)?;
-                guard.nonce = Some(next);
-                debug!(nonce = n, "nonce reserved");
-                return Ok(NonceGuard { guard: Some(guard), nonce: n });
+                return Self::reserve_nonce(guard, n);
             }
 
             // Cache miss: snapshot the generation, then drop the lock so
@@ -199,14 +196,27 @@ impl NonceManager {
                 debug!(nonce = fetched, "nonce fetched from chain");
                 fetched
             });
-            let next = nonce.checked_add(1).ok_or(TxManagerError::NonceOverflow)?;
-            guard.nonce = Some(next);
-            debug!(nonce, "nonce reserved");
-            return Ok(NonceGuard { guard: Some(guard), nonce });
+            return Self::reserve_nonce(guard, nonce);
         }
 
         warn!(attempts = Self::MAX_RETRY_ATTEMPTS, "nonce acquisition failed after max retries",);
         Err(TxManagerError::NonceAcquisitionFailed)
+    }
+
+    /// Advances the cached nonce by one and returns a [`NonceGuard`]
+    /// holding the lock and the reserved value.
+    ///
+    /// Both the fast path (cache hit) and Phase 3 (after RPC fetch) use
+    /// this single call-site for the `checked_add` overflow check,
+    /// ensuring consistent behavior.
+    fn reserve_nonce(
+        mut guard: OwnedMutexGuard<NonceState>,
+        nonce: u64,
+    ) -> Result<NonceGuard, TxManagerError> {
+        let next = nonce.checked_add(1).ok_or(TxManagerError::NonceOverflow)?;
+        guard.nonce = Some(next);
+        debug!(nonce, "nonce reserved");
+        Ok(NonceGuard { guard: Some(guard), nonce })
     }
 
     /// Clears the cached nonce, forcing a fresh chain fetch on the next
@@ -304,6 +314,20 @@ mod tests {
                 test_barrier: Some(barrier),
             }
         }
+    }
+
+    #[test]
+    fn nonce_state_new_is_none_and_generation_zero() {
+        let state = NonceState::new();
+        assert_eq!(state.nonce(), None);
+        assert_eq!(state.generation(), 0);
+    }
+
+    #[test]
+    fn nonce_state_default_matches_new() {
+        let state = NonceState::default();
+        assert_eq!(state.nonce(), None);
+        assert_eq!(state.generation(), 0);
     }
 
     #[tokio::test]

--- a/crates/utilities/tx-manager/src/nonce.rs
+++ b/crates/utilities/tx-manager/src/nonce.rs
@@ -9,10 +9,38 @@ use tracing::{debug, info, warn};
 
 use crate::TxManagerError;
 
+/// Internal state tracked by [`NonceManager`].
+///
+/// Pairs the optional cached nonce with a generation counter that
+/// distinguishes "never initialized" (`generation == 0`) from
+/// "cleared by [`NonceManager::reset`]" (`generation > 0`).
+#[derive(Debug)]
+pub struct NonceState {
+    /// The cached nonce value, or `None` if uninitialized / reset.
+    pub nonce: Option<u64>,
+    /// Monotonically increasing counter bumped on every
+    /// [`NonceManager::reset`].
+    pub generation: u64,
+}
+
+impl NonceState {
+    /// Creates a new [`NonceState`] with no cached nonce and generation
+    /// zero.
+    pub const fn new() -> Self {
+        Self { nonce: None, generation: 0 }
+    }
+}
+
+impl Default for NonceState {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 /// Manages nonce allocation and tracking.
 ///
-/// Wraps a [`tokio::sync::Mutex`] around an optional cached nonce value,
-/// lazily fetching the initial nonce from chain state via
+/// Wraps a [`tokio::sync::Mutex`] around a [`NonceState`], lazily
+/// fetching the initial nonce from chain state via
 /// [`Provider::get_transaction_count`] on first use. Subsequent calls
 /// increment locally without making RPC calls.
 ///
@@ -21,7 +49,7 @@ use crate::TxManagerError;
 /// under concurrent access.
 #[derive(Debug, Clone)]
 pub struct NonceManager {
-    inner: Arc<Mutex<Option<u64>>>,
+    inner: Arc<Mutex<NonceState>>,
     provider: RootProvider,
     address: Address,
 }
@@ -32,7 +60,7 @@ impl NonceManager {
     /// The first call to [`next_nonce`](Self::next_nonce) will fetch the
     /// current transaction count from the provider.
     pub fn new(provider: RootProvider, address: Address) -> Self {
-        Self { inner: Arc::new(Mutex::new(None)), provider, address }
+        Self { inner: Arc::new(Mutex::new(NonceState::new())), provider, address }
     }
 
     /// Maximum number of retry attempts when `reset()` races with
@@ -66,8 +94,12 @@ impl NonceManager {
     /// exceeds `u64::MAX`.
     pub async fn next_nonce(&self) -> Result<NonceGuard, TxManagerError> {
         for attempt in 0..Self::MAX_RETRY_ATTEMPTS {
-            // Phase 1: peek under the lock to check whether init is needed.
-            let needs_init = self.inner.lock().await.is_none();
+            // Phase 1: peek under the lock to check whether init is needed
+            // and snapshot the current generation.
+            let (needs_init, generation) = {
+                let state = self.inner.lock().await;
+                (state.nonce.is_none(), state.generation)
+            };
 
             // Phase 2: if uninitialized, fetch from chain *without* holding
             // the lock so concurrent callers are not blocked by the RPC
@@ -84,15 +116,23 @@ impl NonceManager {
                     })?;
 
                 // Phase 3: re-acquire the lock and populate only if still
-                // unset. Another caller may have won the race; its value
-                // is used.
+                // unset AND the generation has not changed. If reset()
+                // was called mid-flight the generation will have been
+                // bumped — discard the stale fetch and retry.
                 let mut guard = Arc::clone(&self.inner).lock_owned().await;
-                let nonce = *guard.get_or_insert_with(|| {
+
+                if guard.generation != generation {
+                    drop(guard);
+                    debug!(attempt, "nonce cache reset during RPC fetch, retrying");
+                    continue;
+                }
+
+                let nonce = *guard.nonce.get_or_insert_with(|| {
                     debug!(nonce = fetched, "nonce fetched from chain");
                     fetched
                 });
                 let next = nonce.checked_add(1).ok_or(TxManagerError::NonceOverflow)?;
-                *guard = Some(next);
+                guard.nonce = Some(next);
                 debug!(nonce, "nonce reserved");
                 return Ok(NonceGuard { guard: Some(guard), nonce });
             }
@@ -100,9 +140,9 @@ impl NonceManager {
             // Steady-state fast path: cache is populated. Acquire the
             // owned lock for the read-and-increment.
             let mut guard = Arc::clone(&self.inner).lock_owned().await;
-            if let Some(n) = *guard {
+            if let Some(n) = guard.nonce {
                 let next = n.checked_add(1).ok_or(TxManagerError::NonceOverflow)?;
-                *guard = Some(next);
+                guard.nonce = Some(next);
                 debug!(nonce = n, "nonce reserved");
                 return Ok(NonceGuard { guard: Some(guard), nonce: n });
             }
@@ -128,7 +168,8 @@ impl NonceManager {
     /// may conflict with pending transactions in the mempool.
     pub async fn reset(&self) {
         let mut guard = self.inner.lock().await;
-        *guard = None;
+        guard.nonce = None;
+        guard.generation = guard.generation.wrapping_add(1);
         info!(address = %self.address, "nonce cache reset");
     }
 }
@@ -141,7 +182,7 @@ impl NonceManager {
 /// to restore the nonce for reuse.
 #[derive(Debug)]
 pub struct NonceGuard {
-    guard: Option<OwnedMutexGuard<Option<u64>>>,
+    guard: Option<OwnedMutexGuard<NonceState>>,
     nonce: u64,
 }
 
@@ -158,7 +199,7 @@ impl NonceGuard {
     /// the same nonce value. Consumes the guard, releasing the lock.
     pub fn rollback(mut self) {
         if let Some(mut guard) = self.guard.take() {
-            *guard = Some(self.nonce);
+            guard.nonce = Some(self.nonce);
             debug!(nonce = self.nonce, "nonce rolled back");
         }
     }
@@ -184,7 +225,11 @@ mod tests {
         /// Test-only: allows exercising edge-case nonce values (e.g.
         /// `u64::MAX`) without a real chain fetch.
         fn new_with_nonce(provider: RootProvider, address: Address, nonce: u64) -> Self {
-            Self { inner: Arc::new(Mutex::new(Some(nonce))), provider, address }
+            Self {
+                inner: Arc::new(Mutex::new(NonceState { nonce: Some(nonce), generation: 0 })),
+                provider,
+                address,
+            }
         }
     }
 

--- a/crates/utilities/tx-manager/src/nonce.rs
+++ b/crates/utilities/tx-manager/src/nonce.rs
@@ -99,8 +99,8 @@ impl NonceManager {
     }
 
     /// Maximum number of retry attempts when `reset()` races with
-    /// `next_nonce()`, clearing the cache between the peek and lock
-    /// acquisition.
+    /// `next_nonce()`, clearing the cache between the RPC fetch and
+    /// lock re-acquisition.
     const MAX_RETRY_ATTEMPTS: u8 = 5;
 
     /// Reserves the next nonce for transaction signing.
@@ -129,60 +129,11 @@ impl NonceManager {
     /// exceeds `u64::MAX`.
     pub async fn next_nonce(&self) -> Result<NonceGuard, TxManagerError> {
         for attempt in 0..Self::MAX_RETRY_ATTEMPTS {
-            // Phase 1: peek under the lock to check whether init is needed
-            // and snapshot the current generation.
-            let (needs_init, generation) = {
-                let state = self.inner.lock().await;
-                (state.nonce.is_none(), state.generation)
-            };
-
-            // Phase 2: if uninitialized, fetch from chain *without* holding
-            // the lock so concurrent callers are not blocked by the RPC
-            // round-trip. Multiple concurrent callers may fetch redundantly;
-            // only the first writer's value is used.
-            if needs_init {
-                let fetched =
-                    self.provider.get_transaction_count(self.address).await.map_err(|e| {
-                        warn!(
-                            error = %e, address = %self.address,
-                            "failed to fetch nonce from chain",
-                        );
-                        TxManagerError::Rpc(e.to_string())
-                    })?;
-
-                // Test hook: pause between Phase 2 and Phase 3 so tests
-                // can deterministically call reset() during this window.
-                #[cfg(test)]
-                if let Some(barrier) = &self.test_barrier {
-                    barrier.fetch_completed.notify_one();
-                    barrier.may_proceed.notified().await;
-                }
-
-                // Phase 3: re-acquire the lock and populate only if still
-                // unset AND the generation has not changed. If reset()
-                // was called mid-flight the generation will have been
-                // bumped — discard the stale fetch and retry.
-                let mut guard = Arc::clone(&self.inner).lock_owned().await;
-
-                if guard.generation != generation {
-                    drop(guard);
-                    debug!(attempt, "nonce cache reset during RPC fetch, retrying");
-                    continue;
-                }
-
-                let nonce = *guard.nonce.get_or_insert_with(|| {
-                    debug!(nonce = fetched, "nonce fetched from chain");
-                    fetched
-                });
-                let next = nonce.checked_add(1).ok_or(TxManagerError::NonceOverflow)?;
-                guard.nonce = Some(next);
-                debug!(nonce, "nonce reserved");
-                return Ok(NonceGuard { guard: Some(guard), nonce });
-            }
-
-            // Steady-state fast path: cache is populated. Acquire the
-            // owned lock for the read-and-increment.
+            // Acquire the owned lock once upfront.
             let mut guard = Arc::clone(&self.inner).lock_owned().await;
+
+            // Fast path: cache is populated — read-and-increment in a
+            // single lock round-trip.
             if let Some(n) = guard.nonce {
                 let next = n.checked_add(1).ok_or(TxManagerError::NonceOverflow)?;
                 guard.nonce = Some(next);
@@ -190,10 +141,52 @@ impl NonceManager {
                 return Ok(NonceGuard { guard: Some(guard), nonce: n });
             }
 
-            // Rare: reset() cleared the cache between our peek and lock
-            // acquisition. Drop the lock and retry.
+            // Cache miss: snapshot the generation, then drop the lock so
+            // the RPC fetch doesn't block concurrent callers.
+            let generation = guard.generation;
             drop(guard);
-            debug!(attempt, "nonce cache cleared during acquisition, retrying");
+
+            // Phase 2: fetch from chain *without* holding the lock so
+            // concurrent callers are not blocked by the RPC round-trip.
+            // Multiple concurrent callers may fetch redundantly; only
+            // the first writer's value is used.
+            let fetched =
+                self.provider.get_transaction_count(self.address).await.map_err(|e| {
+                    warn!(
+                        error = %e, address = %self.address,
+                        "failed to fetch nonce from chain",
+                    );
+                    TxManagerError::Rpc(e.to_string())
+                })?;
+
+            // Test hook: pause between Phase 2 and Phase 3 so tests
+            // can deterministically call reset() during this window.
+            #[cfg(test)]
+            if let Some(barrier) = &self.test_barrier {
+                barrier.fetch_completed.notify_one();
+                barrier.may_proceed.notified().await;
+            }
+
+            // Phase 3: re-acquire the lock and populate only if still
+            // unset AND the generation has not changed. If reset()
+            // was called mid-flight the generation will have been
+            // bumped — discard the stale fetch and retry.
+            let mut guard = Arc::clone(&self.inner).lock_owned().await;
+
+            if guard.generation != generation {
+                drop(guard);
+                debug!(attempt, "nonce cache reset during RPC fetch, retrying");
+                continue;
+            }
+
+            let nonce = *guard.nonce.get_or_insert_with(|| {
+                debug!(nonce = fetched, "nonce fetched from chain");
+                fetched
+            });
+            let next = nonce.checked_add(1).ok_or(TxManagerError::NonceOverflow)?;
+            guard.nonce = Some(next);
+            debug!(nonce, "nonce reserved");
+            return Ok(NonceGuard { guard: Some(guard), nonce });
         }
 
         warn!(attempts = Self::MAX_RETRY_ATTEMPTS, "nonce acquisition failed after max retries",);

--- a/crates/utilities/tx-manager/src/nonce.rs
+++ b/crates/utilities/tx-manager/src/nonce.rs
@@ -4,6 +4,8 @@ use std::sync::Arc;
 
 use alloy_primitives::Address;
 use alloy_provider::{Provider, RootProvider};
+#[cfg(test)]
+use tokio::sync::Notify;
 use tokio::sync::{Mutex, OwnedMutexGuard};
 use tracing::{debug, info, warn};
 
@@ -37,6 +39,31 @@ impl Default for NonceState {
     }
 }
 
+/// Synchronization barrier for deterministic race-condition testing.
+///
+/// Inserted between Phase 2 (RPC fetch) and Phase 3 (lock
+/// re-acquisition) in [`NonceManager::next_nonce`] to give tests a
+/// window to call [`NonceManager::reset`] and verify the
+/// generation-mismatch retry logic.
+#[cfg(test)]
+#[derive(Debug)]
+pub(crate) struct TestBarrier {
+    /// Signalled by `next_nonce` after the RPC fetch completes, before
+    /// re-acquiring the lock.
+    pub(crate) fetch_completed: Notify,
+    /// Awaited by `next_nonce` after signalling `fetch_completed`.
+    /// The test signals this once it has finished mutating state.
+    pub(crate) may_proceed: Notify,
+}
+
+#[cfg(test)]
+impl TestBarrier {
+    /// Creates a new [`TestBarrier`].
+    pub(crate) fn new() -> Self {
+        Self { fetch_completed: Notify::new(), may_proceed: Notify::new() }
+    }
+}
+
 /// Manages nonce allocation and tracking.
 ///
 /// Wraps a [`tokio::sync::Mutex`] around a [`NonceState`], lazily
@@ -52,6 +79,8 @@ pub struct NonceManager {
     inner: Arc<Mutex<NonceState>>,
     provider: RootProvider,
     address: Address,
+    #[cfg(test)]
+    test_barrier: Option<Arc<TestBarrier>>,
 }
 
 impl NonceManager {
@@ -60,7 +89,13 @@ impl NonceManager {
     /// The first call to [`next_nonce`](Self::next_nonce) will fetch the
     /// current transaction count from the provider.
     pub fn new(provider: RootProvider, address: Address) -> Self {
-        Self { inner: Arc::new(Mutex::new(NonceState::new())), provider, address }
+        Self {
+            inner: Arc::new(Mutex::new(NonceState::new())),
+            provider,
+            address,
+            #[cfg(test)]
+            test_barrier: None,
+        }
     }
 
     /// Maximum number of retry attempts when `reset()` races with
@@ -114,6 +149,14 @@ impl NonceManager {
                         );
                         TxManagerError::Rpc(e.to_string())
                     })?;
+
+                // Test hook: pause between Phase 2 and Phase 3 so tests
+                // can deterministically call reset() during this window.
+                #[cfg(test)]
+                if let Some(barrier) = &self.test_barrier {
+                    barrier.fetch_completed.notify_one();
+                    barrier.may_proceed.notified().await;
+                }
 
                 // Phase 3: re-acquire the lock and populate only if still
                 // unset AND the generation has not changed. If reset()
@@ -229,6 +272,25 @@ mod tests {
                 inner: Arc::new(Mutex::new(NonceState { nonce: Some(nonce), generation: 0 })),
                 provider,
                 address,
+                test_barrier: None,
+            }
+        }
+
+        /// Creates a [`NonceManager`] with a [`TestBarrier`] installed.
+        ///
+        /// The barrier pauses `next_nonce` between the RPC fetch and
+        /// lock re-acquisition, giving the test precise control over
+        /// when `reset()` is called.
+        fn new_with_barrier(
+            provider: RootProvider,
+            address: Address,
+            barrier: Arc<TestBarrier>,
+        ) -> Self {
+            Self {
+                inner: Arc::new(Mutex::new(NonceState::new())),
+                provider,
+                address,
+                test_barrier: Some(barrier),
             }
         }
     }
@@ -244,5 +306,58 @@ mod tests {
 
         let err = manager.next_nonce().await.expect_err("should overflow");
         assert_eq!(err, TxManagerError::NonceOverflow);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn generation_mismatch_retries_after_reset_during_fetch() {
+        let anvil = Anvil::new().spawn();
+        let url = anvil.endpoint_url();
+        let provider = RootProvider::new_http(url);
+        let address = anvil.addresses()[0];
+
+        let barrier = Arc::new(TestBarrier::new());
+        let manager = NonceManager::new_with_barrier(provider, address, Arc::clone(&barrier));
+        let mgr = manager.clone();
+
+        let handle = tokio::spawn(async move { mgr.next_nonce().await });
+
+        // Attempt 0: intercept between fetch and re-lock, then reset to
+        // bump the generation so the fetched value is discarded.
+        barrier.fetch_completed.notified().await;
+        manager.reset().await;
+        barrier.may_proceed.notify_one();
+
+        // Attempt 1: the retry re-fetches. Let it proceed normally.
+        barrier.fetch_completed.notified().await;
+        barrier.may_proceed.notify_one();
+
+        let guard = handle.await.unwrap().expect("should succeed on retry");
+        // Fresh Anvil account — nonce should be 0.
+        assert_eq!(guard.nonce(), 0);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn retry_exhaustion_returns_nonce_acquisition_failed() {
+        let anvil = Anvil::new().spawn();
+        let url = anvil.endpoint_url();
+        let provider = RootProvider::new_http(url);
+        let address = anvil.addresses()[0];
+
+        let barrier = Arc::new(TestBarrier::new());
+        let manager = NonceManager::new_with_barrier(provider, address, Arc::clone(&barrier));
+        let mgr = manager.clone();
+
+        let handle = tokio::spawn(async move { mgr.next_nonce().await });
+
+        // Reset during every attempt so the generation always mismatches,
+        // exhausting MAX_RETRY_ATTEMPTS.
+        for _ in 0..NonceManager::MAX_RETRY_ATTEMPTS {
+            barrier.fetch_completed.notified().await;
+            manager.reset().await;
+            barrier.may_proceed.notify_one();
+        }
+
+        let err = handle.await.unwrap().expect_err("should exhaust retries");
+        assert_eq!(err, TxManagerError::NonceAcquisitionFailed);
     }
 }

--- a/crates/utilities/tx-manager/src/nonce.rs
+++ b/crates/utilities/tx-manager/src/nonce.rs
@@ -1,7 +1,6 @@
 //! Nonce allocation and tracking.
 
-use std::sync::Arc;
-use std::time::Duration;
+use std::{sync::Arc, time::Duration};
 
 use alloy_primitives::Address;
 use alloy_provider::{Provider, RootProvider};

--- a/crates/utilities/tx-manager/src/nonce.rs
+++ b/crates/utilities/tx-manager/src/nonce.rs
@@ -116,9 +116,8 @@ impl NonceManager {
 ///
 /// The lock is held for the duration of transaction signing to prevent
 /// concurrent nonce conflicts. Drop the guard after successful signing
-/// to release the lock and advance the nonce. Call
-/// [`rollback`](Self::rollback) on signing failure to restore the nonce
-/// for reuse.
+/// to release the lock, or call [`rollback`](Self::rollback) on failure
+/// to restore the nonce for reuse.
 #[derive(Debug)]
 pub struct NonceGuard {
     guard: Option<OwnedMutexGuard<Option<u64>>>,

--- a/crates/utilities/tx-manager/src/nonce.rs
+++ b/crates/utilities/tx-manager/src/nonce.rs
@@ -1,6 +1,7 @@
 //! Nonce allocation and tracking.
 
 use std::sync::Arc;
+use std::time::Duration;
 
 use alloy_primitives::Address;
 use alloy_provider::{Provider, RootProvider};
@@ -95,20 +96,40 @@ pub struct NonceManager {
     inner: Arc<Mutex<NonceState>>,
     provider: RootProvider,
     address: Address,
+    rpc_timeout: Duration,
     #[cfg(test)]
     test_barrier: Option<Arc<TestBarrier>>,
 }
 
 impl NonceManager {
-    /// Creates a new [`NonceManager`] with no cached nonce.
+    /// Default timeout for the `get_transaction_count` RPC call.
+    const DEFAULT_RPC_TIMEOUT: Duration = Duration::from_secs(10);
+
+    /// Creates a new [`NonceManager`] with no cached nonce and the
+    /// [`default RPC timeout`](Self::DEFAULT_RPC_TIMEOUT).
     ///
     /// The first call to [`next_nonce`](Self::next_nonce) will fetch the
     /// current transaction count from the provider.
     pub fn new(provider: RootProvider, address: Address) -> Self {
+        Self::with_rpc_timeout(provider, address, Self::DEFAULT_RPC_TIMEOUT)
+    }
+
+    /// Creates a new [`NonceManager`] with no cached nonce and a custom
+    /// RPC timeout.
+    ///
+    /// The timeout bounds the `get_transaction_count` RPC call performed
+    /// during lazy nonce initialization. See [`new`](Self::new) for the
+    /// default.
+    pub fn with_rpc_timeout(
+        provider: RootProvider,
+        address: Address,
+        rpc_timeout: Duration,
+    ) -> Self {
         Self {
             inner: Arc::new(Mutex::new(NonceState::new())),
             provider,
             address,
+            rpc_timeout,
             #[cfg(test)]
             test_barrier: None,
         }
@@ -163,7 +184,20 @@ impl NonceManager {
             // concurrent callers are not blocked by the RPC round-trip.
             // Multiple concurrent callers may fetch redundantly; only
             // the first writer's value is used.
-            let fetched = self.provider.get_transaction_count(self.address).await.map_err(|e| {
+            let fetched = tokio::time::timeout(
+                self.rpc_timeout,
+                self.provider.get_transaction_count(self.address),
+            )
+            .await
+            .map_err(|_| {
+                warn!(
+                    address = %self.address,
+                    timeout = ?self.rpc_timeout,
+                    "nonce fetch timed out",
+                );
+                TxManagerError::Rpc("nonce fetch timed out".into())
+            })?
+            .map_err(|e| {
                 warn!(
                     error = %e, address = %self.address,
                     "failed to fetch nonce from chain",
@@ -191,10 +225,14 @@ impl NonceManager {
                 continue;
             }
 
-            let nonce = *guard.nonce.get_or_insert_with(|| {
+            // If `nonce` is still `None`, we are the first writer —
+            // populate the cache with the fetched value. If `Some`,
+            // a concurrent caller that won the race already set it.
+            if guard.nonce.is_none() {
                 debug!(nonce = fetched, "nonce fetched from chain");
-                fetched
-            });
+                guard.nonce = Some(fetched);
+            }
+            let nonce = guard.nonce.expect("always Some: set above or by concurrent caller");
             return Self::reserve_nonce(guard, nonce);
         }
 
@@ -292,6 +330,7 @@ mod tests {
                 inner: Arc::new(Mutex::new(NonceState { nonce: Some(nonce), generation: 0 })),
                 provider,
                 address,
+                rpc_timeout: Self::DEFAULT_RPC_TIMEOUT,
                 test_barrier: None,
             }
         }
@@ -310,6 +349,7 @@ mod tests {
                 inner: Arc::new(Mutex::new(NonceState::new())),
                 provider,
                 address,
+                rpc_timeout: Self::DEFAULT_RPC_TIMEOUT,
                 test_barrier: Some(barrier),
             }
         }

--- a/crates/utilities/tx-manager/src/nonce.rs
+++ b/crates/utilities/tx-manager/src/nonce.rs
@@ -14,7 +14,7 @@ use crate::TxManagerError;
 /// Pairs the optional cached nonce with a generation counter that
 /// distinguishes "never initialized" (`generation == 0`) from
 /// "cleared by [`NonceManager::reset`]" (`generation > 0`).
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct NonceState {
     /// The cached nonce value, or `None` if uninitialized / reset.
     nonce: Option<u64>,
@@ -44,12 +44,6 @@ impl NonceState {
     /// Returns the current generation counter.
     pub const fn generation(&self) -> u64 {
         self.generation
-    }
-}
-
-impl Default for NonceState {
-    fn default() -> Self {
-        Self::new()
     }
 }
 

--- a/crates/utilities/tx-manager/src/nonce.rs
+++ b/crates/utilities/tx-manager/src/nonce.rs
@@ -42,9 +42,11 @@ impl NonceManager {
     /// increment the cached value locally without making RPC calls.
     ///
     /// The RPC fetch (when needed) is performed without holding the
-    /// assignment lock, so concurrent callers are not blocked by the
-    /// network round-trip. The lock is only held for the fast
-    /// read-and-increment path.
+    /// lock, so concurrent callers are not blocked by the network
+    /// round-trip. Once a nonce is reserved, the returned
+    /// [`NonceGuard`] holds the lock for its entire lifetime,
+    /// serializing all nonce assignment until the guard is dropped or
+    /// rolled back.
     ///
     /// Returns a [`NonceGuard`] that holds the mutex lock for the duration
     /// of transaction signing. Drop the guard on success, or call
@@ -76,12 +78,10 @@ impl NonceManager {
                 // unset. Another caller may have won the race; its value
                 // is used.
                 let mut guard = Arc::clone(&self.inner).lock_owned().await;
-                if guard.is_none() {
-                    *guard = Some(fetched);
+                let nonce = *guard.get_or_insert_with(|| {
                     debug!(nonce = fetched, "nonce fetched from chain");
-                }
-
-                let nonce = guard.expect("cache is initialized");
+                    fetched
+                });
                 *guard = Some(nonce + 1);
                 debug!(nonce, "nonce reserved");
                 return Ok(NonceGuard { guard: Some(guard), nonce });
@@ -139,6 +139,14 @@ impl NonceGuard {
         if let Some(mut guard) = self.guard.take() {
             *guard = Some(self.nonce);
             debug!(nonce = self.nonce, "nonce rolled back");
+        }
+    }
+}
+
+impl Drop for NonceGuard {
+    fn drop(&mut self) {
+        if self.guard.is_some() {
+            debug!(nonce = self.nonce, "nonce consumed");
         }
     }
 }

--- a/crates/utilities/tx-manager/src/nonce.rs
+++ b/crates/utilities/tx-manager/src/nonce.rs
@@ -66,29 +66,14 @@ pub struct NonceManager {
 }
 
 impl NonceManager {
-    /// Default timeout for the `get_transaction_count` RPC call.
-    const DEFAULT_RPC_TIMEOUT: Duration = Duration::from_secs(10);
-
-    /// Creates a new [`NonceManager`] with no cached nonce and the
-    /// default RPC timeout (10 seconds).
+    /// Creates a new [`NonceManager`] with no cached nonce.
+    ///
+    /// The `rpc_timeout` bounds the `get_transaction_count` RPC call
+    /// performed during lazy nonce initialization.
     ///
     /// The first call to [`next_nonce`](Self::next_nonce) will fetch the
     /// current transaction count from the provider.
-    pub fn new(provider: RootProvider, address: Address) -> Self {
-        Self::with_rpc_timeout(provider, address, Self::DEFAULT_RPC_TIMEOUT)
-    }
-
-    /// Creates a new [`NonceManager`] with no cached nonce and a custom
-    /// RPC timeout.
-    ///
-    /// The timeout bounds the `get_transaction_count` RPC call performed
-    /// during lazy nonce initialization. See [`new`](Self::new) for the
-    /// default.
-    pub fn with_rpc_timeout(
-        provider: RootProvider,
-        address: Address,
-        rpc_timeout: Duration,
-    ) -> Self {
+    pub fn new(provider: RootProvider, address: Address, rpc_timeout: Duration) -> Self {
         Self { inner: Arc::new(Mutex::new(NonceState::new())), provider, address, rpc_timeout }
     }
 
@@ -279,7 +264,7 @@ mod tests {
                 inner: Arc::new(Mutex::new(NonceState { nonce: Some(nonce), generation: 0 })),
                 provider,
                 address,
-                rpc_timeout: Self::DEFAULT_RPC_TIMEOUT,
+                rpc_timeout: Duration::from_secs(10),
             }
         }
     }

--- a/crates/utilities/tx-manager/src/nonce.rs
+++ b/crates/utilities/tx-manager/src/nonce.rs
@@ -163,14 +163,13 @@ impl NonceManager {
             // concurrent callers are not blocked by the RPC round-trip.
             // Multiple concurrent callers may fetch redundantly; only
             // the first writer's value is used.
-            let fetched =
-                self.provider.get_transaction_count(self.address).await.map_err(|e| {
-                    warn!(
-                        error = %e, address = %self.address,
-                        "failed to fetch nonce from chain",
-                    );
-                    TxManagerError::Rpc(e.to_string())
-                })?;
+            let fetched = self.provider.get_transaction_count(self.address).await.map_err(|e| {
+                warn!(
+                    error = %e, address = %self.address,
+                    "failed to fetch nonce from chain",
+                );
+                TxManagerError::Rpc(e.to_string())
+            })?;
 
             // Test hook: pause between Phase 2 and Phase 3 so tests
             // can deterministically call reset() during this window.

--- a/crates/utilities/tx-manager/src/nonce.rs
+++ b/crates/utilities/tx-manager/src/nonce.rs
@@ -19,10 +19,15 @@ use crate::TxManagerError;
 #[derive(Debug)]
 pub struct NonceState {
     /// The cached nonce value, or `None` if uninitialized / reset.
-    pub nonce: Option<u64>,
+    nonce: Option<u64>,
     /// Monotonically increasing counter bumped on every
     /// [`NonceManager::reset`].
-    pub generation: u64,
+    ///
+    /// Uses [`u64::wrapping_add`] so the counter cannot panic. A
+    /// generation collision (wrapping all the way around to the same
+    /// snapshot value) would require 2^64 calls to `reset()`, which
+    /// is infeasible in practice.
+    generation: u64,
 }
 
 impl NonceState {
@@ -30,6 +35,17 @@ impl NonceState {
     /// zero.
     pub const fn new() -> Self {
         Self { nonce: None, generation: 0 }
+    }
+
+    /// Returns the cached nonce value, or `None` if uninitialized /
+    /// reset.
+    pub const fn nonce(&self) -> Option<u64> {
+        self.nonce
+    }
+
+    /// Returns the current generation counter.
+    pub const fn generation(&self) -> u64 {
+        self.generation
     }
 }
 
@@ -205,6 +221,8 @@ impl NonceManager {
     pub async fn reset(&self) {
         let mut guard = self.inner.lock().await;
         guard.nonce = None;
+        // Wrapping add is intentional: a full u64 wrap-around (2^64 resets)
+        // is infeasible, and wrapping avoids a panic on overflow.
         guard.generation = guard.generation.wrapping_add(1);
         info!(address = %self.address, "nonce cache reset");
     }

--- a/crates/utilities/tx-manager/src/nonce.rs
+++ b/crates/utilities/tx-manager/src/nonce.rs
@@ -140,14 +140,10 @@ impl NonceManager {
                 continue;
             }
 
-            // If `nonce` is still `None`, we are the first writer —
-            // populate the cache with the fetched value. If `Some`,
-            // a concurrent caller that won the race already set it.
-            if guard.nonce.is_none() {
+            let nonce = *guard.nonce.get_or_insert_with(|| {
                 debug!(nonce = fetched, "nonce fetched from chain");
-                guard.nonce = Some(fetched);
-            }
-            let nonce = guard.nonce.expect("always Some: set above or by concurrent caller");
+                fetched
+            });
             return Self::reserve_nonce(guard, nonce);
         }
 

--- a/crates/utilities/tx-manager/src/nonce.rs
+++ b/crates/utilities/tx-manager/src/nonce.rs
@@ -106,7 +106,7 @@ impl NonceManager {
     const DEFAULT_RPC_TIMEOUT: Duration = Duration::from_secs(10);
 
     /// Creates a new [`NonceManager`] with no cached nonce and the
-    /// [`default RPC timeout`](Self::DEFAULT_RPC_TIMEOUT).
+    /// default RPC timeout (10 seconds).
     ///
     /// The first call to [`next_nonce`](Self::next_nonce) will fetch the
     /// current transaction count from the provider.

--- a/crates/utilities/tx-manager/src/nonce.rs
+++ b/crates/utilities/tx-manager/src/nonce.rs
@@ -41,6 +41,11 @@ impl NonceManager {
     /// current transaction count from the provider. Subsequent calls
     /// increment the cached value locally without making RPC calls.
     ///
+    /// The RPC fetch (when needed) is performed without holding the
+    /// assignment lock, so concurrent callers are not blocked by the
+    /// network round-trip. The lock is only held for the fast
+    /// read-and-increment path.
+    ///
     /// Returns a [`NonceGuard`] that holds the mutex lock for the duration
     /// of transaction signing. Drop the guard on success, or call
     /// [`NonceGuard::rollback`] on failure to restore the nonce.
@@ -49,26 +54,53 @@ impl NonceManager {
     ///
     /// Returns [`TxManagerError::Rpc`] if the provider call fails.
     pub async fn next_nonce(&self) -> Result<NonceGuard, TxManagerError> {
-        let mut guard = Arc::clone(&self.inner).lock_owned().await;
+        loop {
+            // Phase 1: peek under the lock to check whether init is needed.
+            let needs_init = self.inner.lock().await.is_none();
 
-        let nonce = match *guard {
-            Some(n) => {
+            // Phase 2: if uninitialized, fetch from chain *without* holding
+            // the lock so concurrent callers are not blocked by the RPC
+            // round-trip. Multiple concurrent callers may fetch redundantly;
+            // only the first writer's value is used.
+            if needs_init {
+                let fetched =
+                    self.provider.get_transaction_count(self.address).await.map_err(|e| {
+                        warn!(
+                            error = %e, address = %self.address,
+                            "failed to fetch nonce from chain",
+                        );
+                        TxManagerError::Rpc(e.to_string())
+                    })?;
+
+                // Phase 3: re-acquire the lock and populate only if still
+                // unset. Another caller may have won the race; its value
+                // is used.
+                let mut guard = Arc::clone(&self.inner).lock_owned().await;
+                if guard.is_none() {
+                    *guard = Some(fetched);
+                    debug!(nonce = fetched, "nonce fetched from chain");
+                }
+
+                let nonce = guard.expect("cache is initialized");
+                *guard = Some(nonce + 1);
+                debug!(nonce, "nonce reserved");
+                return Ok(NonceGuard { guard: Some(guard), nonce });
+            }
+
+            // Steady-state fast path: cache is populated. Acquire the
+            // owned lock for the read-and-increment.
+            let mut guard = Arc::clone(&self.inner).lock_owned().await;
+            if let Some(n) = *guard {
+                *guard = Some(n + 1);
                 debug!(nonce = n, "nonce reserved");
-                n
+                return Ok(NonceGuard { guard: Some(guard), nonce: n });
             }
-            None => {
-                let n = self.provider.get_transaction_count(self.address).await.map_err(|e| {
-                    warn!(error = %e, address = %self.address, "failed to fetch nonce from chain");
-                    TxManagerError::Rpc(e.to_string())
-                })?;
-                debug!(nonce = n, "nonce fetched from chain");
-                n
-            }
-        };
 
-        *guard = Some(nonce + 1);
-
-        Ok(NonceGuard { guard: Some(guard), nonce })
+            // Rare: reset() cleared the cache between our peek and lock
+            // acquisition. Drop the lock and retry.
+            drop(guard);
+            debug!("nonce cache cleared during acquisition, retrying");
+        }
     }
 
     /// Clears the cached nonce, forcing a fresh chain fetch on the next

--- a/crates/utilities/tx-manager/src/nonce.rs
+++ b/crates/utilities/tx-manager/src/nonce.rs
@@ -35,6 +35,11 @@ impl NonceManager {
         Self { inner: Arc::new(Mutex::new(None)), provider, address }
     }
 
+    /// Maximum number of retry attempts when `reset()` races with
+    /// `next_nonce()`, clearing the cache between the peek and lock
+    /// acquisition.
+    const MAX_RETRY_ATTEMPTS: u8 = 5;
+
     /// Reserves the next nonce for transaction signing.
     ///
     /// On the first call (or after [`reset`](Self::reset)), fetches the
@@ -54,9 +59,11 @@ impl NonceManager {
     ///
     /// # Errors
     ///
-    /// Returns [`TxManagerError::Rpc`] if the provider call fails.
+    /// Returns [`TxManagerError::Rpc`] if the provider call fails,
+    /// or [`TxManagerError::NonceOverflow`] if the nonce exceeds
+    /// `u64::MAX`.
     pub async fn next_nonce(&self) -> Result<NonceGuard, TxManagerError> {
-        loop {
+        for attempt in 0..Self::MAX_RETRY_ATTEMPTS {
             // Phase 1: peek under the lock to check whether init is needed.
             let needs_init = self.inner.lock().await.is_none();
 
@@ -82,7 +89,8 @@ impl NonceManager {
                     debug!(nonce = fetched, "nonce fetched from chain");
                     fetched
                 });
-                *guard = Some(nonce + 1);
+                let next = nonce.checked_add(1).ok_or(TxManagerError::NonceOverflow)?;
+                *guard = Some(next);
                 debug!(nonce, "nonce reserved");
                 return Ok(NonceGuard { guard: Some(guard), nonce });
             }
@@ -91,7 +99,8 @@ impl NonceManager {
             // owned lock for the read-and-increment.
             let mut guard = Arc::clone(&self.inner).lock_owned().await;
             if let Some(n) = *guard {
-                *guard = Some(n + 1);
+                let next = n.checked_add(1).ok_or(TxManagerError::NonceOverflow)?;
+                *guard = Some(next);
                 debug!(nonce = n, "nonce reserved");
                 return Ok(NonceGuard { guard: Some(guard), nonce: n });
             }
@@ -99,12 +108,22 @@ impl NonceManager {
             // Rare: reset() cleared the cache between our peek and lock
             // acquisition. Drop the lock and retry.
             drop(guard);
-            debug!("nonce cache cleared during acquisition, retrying");
+            debug!(attempt, "nonce cache cleared during acquisition, retrying");
         }
+
+        warn!(attempts = Self::MAX_RETRY_ATTEMPTS, "nonce acquisition failed after max retries",);
+        Err(TxManagerError::Rpc("nonce cache repeatedly cleared during acquisition".to_string()))
     }
 
     /// Clears the cached nonce, forcing a fresh chain fetch on the next
     /// call to [`next_nonce`](Self::next_nonce).
+    ///
+    /// # Caution
+    ///
+    /// The fresh fetch uses the `latest` block tag, so pending-but-unconfirmed
+    /// transactions are not counted. Callers should avoid calling `reset()`
+    /// while transactions are still in-flight, as the freshly fetched nonce
+    /// may conflict with pending transactions in the mempool.
     pub async fn reset(&self) {
         let mut guard = self.inner.lock().await;
         *guard = None;

--- a/crates/utilities/tx-manager/src/nonce.rs
+++ b/crates/utilities/tx-manager/src/nonce.rs
@@ -60,8 +60,10 @@ impl NonceManager {
     /// # Errors
     ///
     /// Returns [`TxManagerError::Rpc`] if the provider call fails,
-    /// or [`TxManagerError::NonceOverflow`] if the nonce exceeds
-    /// `u64::MAX`.
+    /// [`TxManagerError::NonceAcquisitionFailed`] if the nonce cache is
+    /// repeatedly cleared by concurrent [`reset`](Self::reset) calls during
+    /// acquisition, or [`TxManagerError::NonceOverflow`] if the nonce
+    /// exceeds `u64::MAX`.
     pub async fn next_nonce(&self) -> Result<NonceGuard, TxManagerError> {
         for attempt in 0..Self::MAX_RETRY_ATTEMPTS {
             // Phase 1: peek under the lock to check whether init is needed.
@@ -112,7 +114,7 @@ impl NonceManager {
         }
 
         warn!(attempts = Self::MAX_RETRY_ATTEMPTS, "nonce acquisition failed after max retries",);
-        Err(TxManagerError::Rpc("nonce cache repeatedly cleared during acquisition".to_string()))
+        Err(TxManagerError::NonceAcquisitionFailed)
     }
 
     /// Clears the cached nonce, forcing a fresh chain fetch on the next

--- a/crates/utilities/tx-manager/src/nonce.rs
+++ b/crates/utilities/tx-manager/src/nonce.rs
@@ -4,8 +4,6 @@ use std::{sync::Arc, time::Duration};
 
 use alloy_primitives::Address;
 use alloy_provider::{Provider, RootProvider};
-#[cfg(test)]
-use tokio::sync::Notify;
 use tokio::sync::{Mutex, OwnedMutexGuard};
 use tracing::{debug, info, warn};
 
@@ -55,31 +53,6 @@ impl Default for NonceState {
     }
 }
 
-/// Synchronization barrier for deterministic race-condition testing.
-///
-/// Inserted between Phase 2 (RPC fetch) and Phase 3 (lock
-/// re-acquisition) in [`NonceManager::next_nonce`] to give tests a
-/// window to call [`NonceManager::reset`] and verify the
-/// generation-mismatch retry logic.
-#[cfg(test)]
-#[derive(Debug)]
-pub(crate) struct TestBarrier {
-    /// Signalled by `next_nonce` after the RPC fetch completes, before
-    /// re-acquiring the lock.
-    pub(crate) fetch_completed: Notify,
-    /// Awaited by `next_nonce` after signalling `fetch_completed`.
-    /// The test signals this once it has finished mutating state.
-    pub(crate) may_proceed: Notify,
-}
-
-#[cfg(test)]
-impl TestBarrier {
-    /// Creates a new [`TestBarrier`].
-    pub(crate) fn new() -> Self {
-        Self { fetch_completed: Notify::new(), may_proceed: Notify::new() }
-    }
-}
-
 /// Manages nonce allocation and tracking.
 ///
 /// Wraps a [`tokio::sync::Mutex`] around a [`NonceState`], lazily
@@ -96,8 +69,6 @@ pub struct NonceManager {
     provider: RootProvider,
     address: Address,
     rpc_timeout: Duration,
-    #[cfg(test)]
-    test_barrier: Option<Arc<TestBarrier>>,
 }
 
 impl NonceManager {
@@ -124,14 +95,7 @@ impl NonceManager {
         address: Address,
         rpc_timeout: Duration,
     ) -> Self {
-        Self {
-            inner: Arc::new(Mutex::new(NonceState::new())),
-            provider,
-            address,
-            rpc_timeout,
-            #[cfg(test)]
-            test_barrier: None,
-        }
+        Self { inner: Arc::new(Mutex::new(NonceState::new())), provider, address, rpc_timeout }
     }
 
     /// Maximum number of retry attempts when `reset()` races with
@@ -203,14 +167,6 @@ impl NonceManager {
                 );
                 TxManagerError::Rpc(e.to_string())
             })?;
-
-            // Test hook: pause between Phase 2 and Phase 3 so tests
-            // can deterministically call reset() during this window.
-            #[cfg(test)]
-            if let Some(barrier) = &self.test_barrier {
-                barrier.fetch_completed.notify_one();
-                barrier.may_proceed.notified().await;
-            }
 
             // Phase 3: re-acquire the lock and populate only if still
             // unset AND the generation has not changed. If reset()
@@ -330,26 +286,6 @@ mod tests {
                 provider,
                 address,
                 rpc_timeout: Self::DEFAULT_RPC_TIMEOUT,
-                test_barrier: None,
-            }
-        }
-
-        /// Creates a [`NonceManager`] with a [`TestBarrier`] installed.
-        ///
-        /// The barrier pauses `next_nonce` between the RPC fetch and
-        /// lock re-acquisition, giving the test precise control over
-        /// when `reset()` is called.
-        fn new_with_barrier(
-            provider: RootProvider,
-            address: Address,
-            barrier: Arc<TestBarrier>,
-        ) -> Self {
-            Self {
-                inner: Arc::new(Mutex::new(NonceState::new())),
-                provider,
-                address,
-                rpc_timeout: Self::DEFAULT_RPC_TIMEOUT,
-                test_barrier: Some(barrier),
             }
         }
     }
@@ -379,58 +315,5 @@ mod tests {
 
         let err = manager.next_nonce().await.expect_err("should overflow");
         assert_eq!(err, TxManagerError::NonceOverflow);
-    }
-
-    #[tokio::test(flavor = "multi_thread")]
-    async fn generation_mismatch_retries_after_reset_during_fetch() {
-        let anvil = Anvil::new().spawn();
-        let url = anvil.endpoint_url();
-        let provider = RootProvider::new_http(url);
-        let address = anvil.addresses()[0];
-
-        let barrier = Arc::new(TestBarrier::new());
-        let manager = NonceManager::new_with_barrier(provider, address, Arc::clone(&barrier));
-        let mgr = manager.clone();
-
-        let handle = tokio::spawn(async move { mgr.next_nonce().await });
-
-        // Attempt 0: intercept between fetch and re-lock, then reset to
-        // bump the generation so the fetched value is discarded.
-        barrier.fetch_completed.notified().await;
-        manager.reset().await;
-        barrier.may_proceed.notify_one();
-
-        // Attempt 1: the retry re-fetches. Let it proceed normally.
-        barrier.fetch_completed.notified().await;
-        barrier.may_proceed.notify_one();
-
-        let guard = handle.await.unwrap().expect("should succeed on retry");
-        // Fresh Anvil account — nonce should be 0.
-        assert_eq!(guard.nonce(), 0);
-    }
-
-    #[tokio::test(flavor = "multi_thread")]
-    async fn retry_exhaustion_returns_nonce_acquisition_failed() {
-        let anvil = Anvil::new().spawn();
-        let url = anvil.endpoint_url();
-        let provider = RootProvider::new_http(url);
-        let address = anvil.addresses()[0];
-
-        let barrier = Arc::new(TestBarrier::new());
-        let manager = NonceManager::new_with_barrier(provider, address, Arc::clone(&barrier));
-        let mgr = manager.clone();
-
-        let handle = tokio::spawn(async move { mgr.next_nonce().await });
-
-        // Reset during every attempt so the generation always mismatches,
-        // exhausting MAX_RETRY_ATTEMPTS.
-        for _ in 0..NonceManager::MAX_RETRY_ATTEMPTS {
-            barrier.fetch_completed.notified().await;
-            manager.reset().await;
-            barrier.may_proceed.notify_one();
-        }
-
-        let err = handle.await.unwrap().expect_err("should exhaust retries");
-        assert_eq!(err, TxManagerError::NonceAcquisitionFailed);
     }
 }

--- a/crates/utilities/tx-manager/src/nonce.rs
+++ b/crates/utilities/tx-manager/src/nonce.rs
@@ -171,3 +171,33 @@ impl Drop for NonceGuard {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use alloy_node_bindings::Anvil;
+
+    use super::*;
+
+    impl NonceManager {
+        /// Creates a [`NonceManager`] with the cache pre-seeded to `nonce`.
+        ///
+        /// Test-only: allows exercising edge-case nonce values (e.g.
+        /// `u64::MAX`) without a real chain fetch.
+        fn new_with_nonce(provider: RootProvider, address: Address, nonce: u64) -> Self {
+            Self { inner: Arc::new(Mutex::new(Some(nonce))), provider, address }
+        }
+    }
+
+    #[tokio::test]
+    async fn next_nonce_returns_overflow_at_u64_max() {
+        let anvil = Anvil::new().spawn();
+        let url = anvil.endpoint_url();
+        let provider = RootProvider::new_http(url);
+        let address = anvil.addresses()[0];
+
+        let manager = NonceManager::new_with_nonce(provider, address, u64::MAX);
+
+        let err = manager.next_nonce().await.expect_err("should overflow");
+        assert_eq!(err, TxManagerError::NonceOverflow);
+    }
+}

--- a/crates/utilities/tx-manager/src/nonce.rs
+++ b/crates/utilities/tx-manager/src/nonce.rs
@@ -17,7 +17,7 @@ use crate::TxManagerError;
 #[derive(Debug, Default)]
 pub struct NonceState {
     /// The cached nonce value, or `None` if uninitialized / reset.
-    nonce: Option<u64>,
+    pub nonce: Option<u64>,
     /// Monotonically increasing counter bumped on every
     /// [`NonceManager::reset`].
     ///
@@ -25,26 +25,7 @@ pub struct NonceState {
     /// generation collision (wrapping all the way around to the same
     /// snapshot value) would require 2^64 calls to `reset()`, which
     /// is infeasible in practice.
-    generation: u64,
-}
-
-impl NonceState {
-    /// Creates a new [`NonceState`] with no cached nonce and generation
-    /// zero.
-    pub const fn new() -> Self {
-        Self { nonce: None, generation: 0 }
-    }
-
-    /// Returns the cached nonce value, or `None` if uninitialized /
-    /// reset.
-    pub const fn nonce(&self) -> Option<u64> {
-        self.nonce
-    }
-
-    /// Returns the current generation counter.
-    pub const fn generation(&self) -> u64 {
-        self.generation
-    }
+    pub generation: u64,
 }
 
 /// Manages nonce allocation and tracking.
@@ -74,7 +55,7 @@ impl NonceManager {
     /// The first call to [`next_nonce`](Self::next_nonce) will fetch the
     /// current transaction count from the provider.
     pub fn new(provider: RootProvider, address: Address, rpc_timeout: Duration) -> Self {
-        Self { inner: Arc::new(Mutex::new(NonceState::new())), provider, address, rpc_timeout }
+        Self { inner: Arc::new(Mutex::new(NonceState::default())), provider, address, rpc_timeout }
     }
 
     /// Maximum number of retry attempts when `reset()` races with
@@ -270,17 +251,10 @@ mod tests {
     }
 
     #[test]
-    fn nonce_state_new_is_none_and_generation_zero() {
-        let state = NonceState::new();
-        assert_eq!(state.nonce(), None);
-        assert_eq!(state.generation(), 0);
-    }
-
-    #[test]
-    fn nonce_state_default_matches_new() {
+    fn nonce_state_default_is_none_and_generation_zero() {
         let state = NonceState::default();
-        assert_eq!(state.nonce(), None);
-        assert_eq!(state.generation(), 0);
+        assert_eq!(state.nonce, None);
+        assert_eq!(state.generation, 0);
     }
 
     #[tokio::test]

--- a/crates/utilities/tx-manager/src/nonce.rs
+++ b/crates/utilities/tx-manager/src/nonce.rs
@@ -1,5 +1,113 @@
 //! Nonce allocation and tracking.
 
+use std::sync::Arc;
+
+use alloy_primitives::Address;
+use alloy_provider::{Provider, RootProvider};
+use tokio::sync::{Mutex, OwnedMutexGuard};
+use tracing::{debug, info, warn};
+
+use crate::TxManagerError;
+
 /// Manages nonce allocation and tracking.
+///
+/// Wraps a [`tokio::sync::Mutex`] around an optional cached nonce value,
+/// lazily fetching the initial nonce from chain state via
+/// [`Provider::get_transaction_count`] on first use. Subsequent calls
+/// increment locally without making RPC calls.
+///
+/// The mutex is held for the duration of transaction signing via the
+/// returned [`NonceGuard`], ensuring sequential nonce assignment even
+/// under concurrent access.
+#[derive(Debug, Clone)]
+pub struct NonceManager {
+    inner: Arc<Mutex<Option<u64>>>,
+    provider: RootProvider,
+    address: Address,
+}
+
+impl NonceManager {
+    /// Creates a new [`NonceManager`] with no cached nonce.
+    ///
+    /// The first call to [`next_nonce`](Self::next_nonce) will fetch the
+    /// current transaction count from the provider.
+    pub fn new(provider: RootProvider, address: Address) -> Self {
+        Self { inner: Arc::new(Mutex::new(None)), provider, address }
+    }
+
+    /// Reserves the next nonce for transaction signing.
+    ///
+    /// On the first call (or after [`reset`](Self::reset)), fetches the
+    /// current transaction count from the provider. Subsequent calls
+    /// increment the cached value locally without making RPC calls.
+    ///
+    /// Returns a [`NonceGuard`] that holds the mutex lock for the duration
+    /// of transaction signing. Drop the guard on success, or call
+    /// [`NonceGuard::rollback`] on failure to restore the nonce.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`TxManagerError::Rpc`] if the provider call fails.
+    pub async fn next_nonce(&self) -> Result<NonceGuard, TxManagerError> {
+        let mut guard = Arc::clone(&self.inner).lock_owned().await;
+
+        let nonce = match *guard {
+            Some(n) => {
+                debug!(nonce = n, "nonce reserved");
+                n
+            }
+            None => {
+                let n = self.provider.get_transaction_count(self.address).await.map_err(|e| {
+                    warn!(error = %e, address = %self.address, "failed to fetch nonce from chain");
+                    TxManagerError::Rpc(e.to_string())
+                })?;
+                debug!(nonce = n, "nonce fetched from chain");
+                n
+            }
+        };
+
+        *guard = Some(nonce + 1);
+
+        Ok(NonceGuard { guard: Some(guard), nonce })
+    }
+
+    /// Clears the cached nonce, forcing a fresh chain fetch on the next
+    /// call to [`next_nonce`](Self::next_nonce).
+    pub async fn reset(&self) {
+        let mut guard = self.inner.lock().await;
+        *guard = None;
+        info!(address = %self.address, "nonce cache reset");
+    }
+}
+
+/// RAII guard holding a reserved nonce and the nonce mutex lock.
+///
+/// The lock is held for the duration of transaction signing to prevent
+/// concurrent nonce conflicts. Drop the guard after successful signing
+/// to release the lock and advance the nonce. Call
+/// [`rollback`](Self::rollback) on signing failure to restore the nonce
+/// for reuse.
 #[derive(Debug)]
-pub struct NonceManager;
+pub struct NonceGuard {
+    guard: Option<OwnedMutexGuard<Option<u64>>>,
+    nonce: u64,
+}
+
+impl NonceGuard {
+    /// Returns the reserved nonce value.
+    pub const fn nonce(&self) -> u64 {
+        self.nonce
+    }
+
+    /// Rolls back the nonce reservation, restoring the cached nonce to
+    /// the value that was reserved.
+    ///
+    /// This allows the next call to [`NonceManager::next_nonce`] to reuse
+    /// the same nonce value. Consumes the guard, releasing the lock.
+    pub fn rollback(mut self) {
+        if let Some(mut guard) = self.guard.take() {
+            *guard = Some(self.nonce);
+            debug!(nonce = self.nonce, "nonce rolled back");
+        }
+    }
+}

--- a/crates/utilities/tx-manager/tests/nonce.rs
+++ b/crates/utilities/tx-manager/tests/nonce.rs
@@ -21,7 +21,7 @@ fn setup() -> (NonceManager, alloy_node_bindings::AnvilInstance) {
     let url = anvil.endpoint_url();
     let provider = RootProvider::new_http(url);
     let address = anvil.addresses()[0];
-    let manager = NonceManager::new(provider, address);
+    let manager = NonceManager::new(provider, address, Duration::from_secs(10));
     (manager, anvil)
 }
 
@@ -122,7 +122,7 @@ async fn provider_failure_returns_rpc_error() {
     let url = "http://127.0.0.1:1".parse().expect("valid url");
     let provider = RootProvider::new_http(url);
     let address = Address::ZERO;
-    let manager = NonceManager::new(provider, address);
+    let manager = NonceManager::new(provider, address, Duration::from_secs(10));
 
     let err = manager.next_nonce().await.expect_err("should fail on unreachable provider");
     assert!(matches!(err, TxManagerError::Rpc(_)), "expected TxManagerError::Rpc, got {err:?}");
@@ -144,7 +144,7 @@ async fn rpc_timeout_returns_rpc_error() {
     let url = format!("http://{addr}").parse().expect("valid url");
     let provider = RootProvider::new_http(url);
     let address = Address::ZERO;
-    let manager = NonceManager::with_rpc_timeout(provider, address, Duration::from_millis(1));
+    let manager = NonceManager::new(provider, address, Duration::from_millis(1));
 
     let err = manager.next_nonce().await.expect_err("should time out");
     match &err {

--- a/crates/utilities/tx-manager/tests/nonce.rs
+++ b/crates/utilities/tx-manager/tests/nonce.rs
@@ -1,10 +1,12 @@
 //! Integration tests for [`NonceManager`] with an Anvil backend.
 
-use std::sync::{
-    Arc,
-    atomic::{AtomicBool, Ordering},
+use std::{
+    sync::{
+        Arc,
+        atomic::{AtomicBool, Ordering},
+    },
+    time::Duration,
 };
-use std::time::Duration;
 
 use alloy_node_bindings::Anvil;
 use alloy_primitives::Address;
@@ -142,16 +144,12 @@ async fn rpc_timeout_returns_rpc_error() {
     let url = format!("http://{addr}").parse().expect("valid url");
     let provider = RootProvider::new_http(url);
     let address = Address::ZERO;
-    let manager =
-        NonceManager::with_rpc_timeout(provider, address, Duration::from_millis(1));
+    let manager = NonceManager::with_rpc_timeout(provider, address, Duration::from_millis(1));
 
     let err = manager.next_nonce().await.expect_err("should time out");
     match &err {
         TxManagerError::Rpc(msg) => {
-            assert!(
-                msg.contains("timed out"),
-                "expected 'timed out' in message, got: {msg}",
-            );
+            assert!(msg.contains("timed out"), "expected 'timed out' in message, got: {msg}",);
         }
         other => panic!("expected TxManagerError::Rpc, got {other:?}"),
     }

--- a/crates/utilities/tx-manager/tests/nonce.rs
+++ b/crates/utilities/tx-manager/tests/nonce.rs
@@ -1,0 +1,114 @@
+//! Integration tests for [`NonceManager`] with an Anvil backend.
+
+use alloy_node_bindings::Anvil;
+use alloy_provider::RootProvider;
+use base_tx_manager::{NonceGuard, NonceManager};
+
+/// Helper: spawns an Anvil instance and returns a [`NonceManager`] wired to
+/// the first default account.
+fn setup() -> (NonceManager, alloy_node_bindings::AnvilInstance) {
+    let anvil = Anvil::new().spawn();
+    let url = anvil.endpoint_url();
+    let provider = RootProvider::new_http(url);
+    let address = anvil.addresses()[0];
+    let manager = NonceManager::new(provider, address);
+    (manager, anvil)
+}
+
+#[tokio::test]
+async fn first_call_fetches_nonce_from_provider() {
+    let (manager, _anvil) = setup();
+
+    let guard = manager.next_nonce().await.expect("should fetch nonce");
+    // Fresh Anvil account has zero transactions.
+    assert_eq!(guard.nonce(), 0);
+}
+
+#[tokio::test]
+async fn subsequent_calls_increment_locally() {
+    let (manager, _anvil) = setup();
+
+    let g0 = manager.next_nonce().await.expect("first nonce");
+    assert_eq!(g0.nonce(), 0);
+    drop(g0);
+
+    let g1 = manager.next_nonce().await.expect("second nonce");
+    assert_eq!(g1.nonce(), 1);
+    drop(g1);
+
+    let g2 = manager.next_nonce().await.expect("third nonce");
+    assert_eq!(g2.nonce(), 2);
+}
+
+#[tokio::test]
+async fn rollback_restores_nonce() {
+    let (manager, _anvil) = setup();
+
+    // Reserve nonces 0 and 1, drop them to advance the cache.
+    let g0 = manager.next_nonce().await.unwrap();
+    assert_eq!(g0.nonce(), 0);
+    drop(g0);
+
+    let g1 = manager.next_nonce().await.unwrap();
+    assert_eq!(g1.nonce(), 1);
+    drop(g1);
+
+    // Reserve nonce 2, then roll it back.
+    let g2 = manager.next_nonce().await.unwrap();
+    assert_eq!(g2.nonce(), 2);
+    g2.rollback();
+
+    // Next call should reuse nonce 2.
+    let g2_again = manager.next_nonce().await.unwrap();
+    assert_eq!(g2_again.nonce(), 2);
+}
+
+#[tokio::test]
+async fn reset_forces_fresh_chain_fetch() {
+    let (manager, _anvil) = setup();
+
+    // Advance the local cache to nonce 2.
+    let g0 = manager.next_nonce().await.unwrap();
+    drop(g0);
+    let g1 = manager.next_nonce().await.unwrap();
+    drop(g1);
+
+    // Reset clears the cache.
+    manager.reset().await;
+
+    // Next call fetches from chain — still 0 since no tx was sent.
+    let guard = manager.next_nonce().await.unwrap();
+    assert_eq!(guard.nonce(), 0);
+}
+
+#[tokio::test]
+async fn concurrent_calls_get_unique_sequential_nonces() {
+    let (manager, _anvil) = setup();
+
+    let mut handles = Vec::new();
+    for _ in 0..10 {
+        let mgr = manager.clone();
+        handles.push(tokio::spawn(async move {
+            let guard = mgr.next_nonce().await.unwrap();
+            let n = guard.nonce();
+            drop(guard);
+            n
+        }));
+    }
+
+    let mut nonces = Vec::new();
+    for h in handles {
+        nonces.push(h.await.unwrap());
+    }
+
+    nonces.sort();
+    let expected: Vec<u64> = (0..10).collect();
+    assert_eq!(nonces, expected, "all nonces should be unique and sequential");
+}
+
+#[tokio::test]
+async fn nonce_guard_is_send() {
+    /// Asserts that `T` implements [`Send`].
+    fn assert_send<T: Send>() {}
+    assert_send::<NonceGuard>();
+}

--- a/crates/utilities/tx-manager/tests/nonce.rs
+++ b/crates/utilities/tx-manager/tests/nonce.rs
@@ -2,12 +2,12 @@
 
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::time::Duration;
 
 use alloy_node_bindings::Anvil;
 use alloy_primitives::Address;
 use alloy_provider::RootProvider;
 use base_tx_manager::{NonceGuard, NonceManager, TxManagerError};
+use tokio::sync::Notify;
 
 /// Helper: spawns an Anvil instance and returns a [`NonceManager`] wired to
 /// the first default account.
@@ -183,17 +183,22 @@ async fn reset_blocks_while_guard_held() {
 
     let reset_completed = Arc::new(AtomicBool::new(false));
     let flag = Arc::clone(&reset_completed);
+    let about_to_reset = Arc::new(Notify::new());
+    let notify = Arc::clone(&about_to_reset);
     let mgr = manager.clone();
 
     // Spawn a task that calls reset(). It should block because the
     // guard holds the same mutex.
     let handle = tokio::spawn(async move {
+        notify.notify_one();
         mgr.reset().await;
         flag.store(true, Ordering::SeqCst);
     });
 
-    // Give the spawned task time to contend on the lock.
-    tokio::time::sleep(Duration::from_millis(50)).await;
+    // Wait until the spawned task is about to call reset(), then yield
+    // to let it enter the lock wait.
+    about_to_reset.notified().await;
+    tokio::task::yield_now().await;
     assert!(
         !reset_completed.load(Ordering::SeqCst),
         "reset() must not complete while a NonceGuard is held",
@@ -216,27 +221,38 @@ async fn reset_blocks_while_guard_held() {
 async fn concurrent_next_nonce_and_reset_stress() {
     let (manager, _anvil) = setup();
 
-    // Interleave next_nonce() and reset() calls concurrently to
-    // exercise the retry-loop path where reset() clears the cache
-    // between the peek and lock acquisition in next_nonce().
-    let mut handles = Vec::new();
-    for i in 0u32..100 {
-        let mgr = manager.clone();
-        if i % 10 == 0 {
-            // Sprinkle resets to trigger the retry path.
-            handles.push(tokio::spawn(async move {
-                mgr.reset().await;
-            }));
-        } else {
+    // Run several rounds of concurrent next_nonce() calls separated by
+    // resets. Within each round all assigned nonces must be unique —
+    // concurrent callers must never receive the same slot.
+    for round in 0u32..5 {
+        let batch_size = 20usize;
+        let mut handles = Vec::with_capacity(batch_size);
+        for _ in 0..batch_size {
+            let mgr = manager.clone();
             handles.push(tokio::spawn(async move {
                 let guard = mgr.next_nonce().await.unwrap();
+                let n = guard.nonce();
                 drop(guard);
+                n
             }));
         }
-    }
 
-    // All operations must complete without deadlock or panic.
-    for h in handles {
-        h.await.unwrap();
+        let mut nonces = Vec::with_capacity(batch_size);
+        for h in handles {
+            nonces.push(h.await.unwrap());
+        }
+
+        // All nonces within a round must be unique.
+        nonces.sort();
+        for pair in nonces.windows(2) {
+            assert_ne!(
+                pair[0], pair[1],
+                "round {round}: duplicate nonce {}, full set: {nonces:?}",
+                pair[0],
+            );
+        }
+
+        // Reset clears the cache, forcing a fresh chain fetch next round.
+        manager.reset().await;
     }
 }

--- a/crates/utilities/tx-manager/tests/nonce.rs
+++ b/crates/utilities/tx-manager/tests/nonce.rs
@@ -250,6 +250,32 @@ async fn reset_blocks_while_guard_held() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn rayon_parallel_nonce_acquisition_produces_unique_nonces() {
+    use rayon::prelude::*;
+
+    let (manager, _anvil) = setup();
+    let handle = tokio::runtime::Handle::current();
+
+    let nonces: Vec<u64> = (0..100)
+        .into_par_iter()
+        .map(|_| {
+            let mgr = manager.clone();
+            handle.block_on(async move {
+                let guard = mgr.next_nonce().await.unwrap();
+                let n = guard.nonce();
+                drop(guard);
+                n
+            })
+        })
+        .collect();
+
+    let mut sorted = nonces;
+    sorted.sort();
+    let expected: Vec<u64> = (0..100).collect();
+    assert_eq!(sorted, expected, "all nonces must be unique and contiguous");
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn concurrent_next_nonce_and_reset_stress() {
     let (manager, _anvil) = setup();
 

--- a/crates/utilities/tx-manager/tests/nonce.rs
+++ b/crates/utilities/tx-manager/tests/nonce.rs
@@ -161,6 +161,8 @@ async fn reset_then_rollback_interaction() {
 
 #[tokio::test]
 async fn nonce_guard_is_send() {
+    // `NonceGuard` must be `Send` so it can be moved into a `tokio::spawn`
+    // task after nonce reservation in `send_async()`.
     /// Asserts that `T` implements [`Send`].
     fn assert_send<T: Send>() {}
     assert_send::<NonceGuard>();

--- a/crates/utilities/tx-manager/tests/nonce.rs
+++ b/crates/utilities/tx-manager/tests/nonce.rs
@@ -1,6 +1,11 @@
 //! Integration tests for [`NonceManager`] with an Anvil backend.
 
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::Duration;
+
 use alloy_node_bindings::Anvil;
+use alloy_primitives::Address;
 use alloy_provider::RootProvider;
 use base_tx_manager::{NonceGuard, NonceManager, TxManagerError};
 
@@ -111,7 +116,7 @@ async fn provider_failure_returns_rpc_error() {
     // Point the provider at a non-listening port so the RPC call fails.
     let url = "http://127.0.0.1:1".parse().expect("valid url");
     let provider = RootProvider::new_http(url);
-    let address = alloy_primitives::Address::ZERO;
+    let address = Address::ZERO;
     let manager = NonceManager::new(provider, address);
 
     let err = manager.next_nonce().await.expect_err("should fail on unreachable provider");
@@ -166,4 +171,72 @@ async fn nonce_guard_is_send() {
     /// Asserts that `T` implements [`Send`].
     fn assert_send<T: Send>() {}
     assert_send::<NonceGuard>();
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn reset_blocks_while_guard_held() {
+    let (manager, _anvil) = setup();
+
+    // Reserve nonce 0 — the guard holds the lock.
+    let guard = manager.next_nonce().await.unwrap();
+    assert_eq!(guard.nonce(), 0);
+
+    let reset_completed = Arc::new(AtomicBool::new(false));
+    let flag = Arc::clone(&reset_completed);
+    let mgr = manager.clone();
+
+    // Spawn a task that calls reset(). It should block because the
+    // guard holds the same mutex.
+    let handle = tokio::spawn(async move {
+        mgr.reset().await;
+        flag.store(true, Ordering::SeqCst);
+    });
+
+    // Give the spawned task time to contend on the lock.
+    tokio::time::sleep(Duration::from_millis(50)).await;
+    assert!(
+        !reset_completed.load(Ordering::SeqCst),
+        "reset() must not complete while a NonceGuard is held",
+    );
+
+    // Drop the guard — reset() should now complete.
+    drop(guard);
+    handle.await.unwrap();
+    assert!(
+        reset_completed.load(Ordering::SeqCst),
+        "reset() should have completed after guard was dropped",
+    );
+
+    // After the reset, next nonce should re-fetch from chain (0).
+    let g = manager.next_nonce().await.unwrap();
+    assert_eq!(g.nonce(), 0);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn concurrent_next_nonce_and_reset_stress() {
+    let (manager, _anvil) = setup();
+
+    // Interleave next_nonce() and reset() calls concurrently to
+    // exercise the retry-loop path where reset() clears the cache
+    // between the peek and lock acquisition in next_nonce().
+    let mut handles = Vec::new();
+    for i in 0u32..100 {
+        let mgr = manager.clone();
+        if i % 10 == 0 {
+            // Sprinkle resets to trigger the retry path.
+            handles.push(tokio::spawn(async move {
+                mgr.reset().await;
+            }));
+        } else {
+            handles.push(tokio::spawn(async move {
+                let guard = mgr.next_nonce().await.unwrap();
+                drop(guard);
+            }));
+        }
+    }
+
+    // All operations must complete without deadlock or panic.
+    for h in handles {
+        h.await.unwrap();
+    }
 }

--- a/crates/utilities/tx-manager/tests/nonce.rs
+++ b/crates/utilities/tx-manager/tests/nonce.rs
@@ -242,15 +242,14 @@ async fn concurrent_next_nonce_and_reset_stress() {
             nonces.push(h.await.unwrap());
         }
 
-        // All nonces within a round must be unique.
+        // Each round re-fetches from chain (0 — no txs sent) so the
+        // sorted nonces must form the contiguous range 0..batch_size.
         nonces.sort();
-        for pair in nonces.windows(2) {
-            assert_ne!(
-                pair[0], pair[1],
-                "round {round}: duplicate nonce {}, full set: {nonces:?}",
-                pair[0],
-            );
-        }
+        let expected: Vec<u64> = (0..batch_size as u64).collect();
+        assert_eq!(
+            nonces, expected,
+            "round {round}: nonces should be contiguous 0..{batch_size}",
+        );
 
         // Reset clears the cache, forcing a fresh chain fetch next round.
         manager.reset().await;

--- a/crates/utilities/tx-manager/tests/nonce.rs
+++ b/crates/utilities/tx-manager/tests/nonce.rs
@@ -4,6 +4,7 @@ use std::sync::{
     Arc,
     atomic::{AtomicBool, Ordering},
 };
+use std::time::Duration;
 
 use alloy_node_bindings::Anvil;
 use alloy_primitives::Address;
@@ -123,6 +124,37 @@ async fn provider_failure_returns_rpc_error() {
 
     let err = manager.next_nonce().await.expect_err("should fail on unreachable provider");
     assert!(matches!(err, TxManagerError::Rpc(_)), "expected TxManagerError::Rpc, got {err:?}");
+}
+
+#[tokio::test]
+async fn rpc_timeout_returns_rpc_error() {
+    // Start a TCP listener that accepts connections but never responds,
+    // simulating a hung RPC endpoint.
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+
+    tokio::spawn(async move {
+        // Accept one connection and hold it open indefinitely.
+        let (_socket, _) = listener.accept().await.unwrap();
+        std::future::pending::<()>().await;
+    });
+
+    let url = format!("http://{addr}").parse().expect("valid url");
+    let provider = RootProvider::new_http(url);
+    let address = Address::ZERO;
+    let manager =
+        NonceManager::with_rpc_timeout(provider, address, Duration::from_millis(1));
+
+    let err = manager.next_nonce().await.expect_err("should time out");
+    match &err {
+        TxManagerError::Rpc(msg) => {
+            assert!(
+                msg.contains("timed out"),
+                "expected 'timed out' in message, got: {msg}",
+            );
+        }
+        other => panic!("expected TxManagerError::Rpc, got {other:?}"),
+    }
 }
 
 #[tokio::test]

--- a/crates/utilities/tx-manager/tests/nonce.rs
+++ b/crates/utilities/tx-manager/tests/nonce.rs
@@ -2,7 +2,7 @@
 
 use alloy_node_bindings::Anvil;
 use alloy_provider::RootProvider;
-use base_tx_manager::{NonceGuard, NonceManager};
+use base_tx_manager::{NonceGuard, NonceManager, TxManagerError};
 
 /// Helper: spawns an Anvil instance and returns a [`NonceManager`] wired to
 /// the first default account.
@@ -81,7 +81,7 @@ async fn reset_forces_fresh_chain_fetch() {
     assert_eq!(guard.nonce(), 0);
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn concurrent_calls_get_unique_sequential_nonces() {
     let (manager, _anvil) = setup();
 
@@ -104,6 +104,59 @@ async fn concurrent_calls_get_unique_sequential_nonces() {
     nonces.sort();
     let expected: Vec<u64> = (0..10).collect();
     assert_eq!(nonces, expected, "all nonces should be unique and sequential");
+}
+
+#[tokio::test]
+async fn provider_failure_returns_rpc_error() {
+    // Point the provider at a non-listening port so the RPC call fails.
+    let url = "http://127.0.0.1:1".parse().expect("valid url");
+    let provider = RootProvider::new_http(url);
+    let address = alloy_primitives::Address::ZERO;
+    let manager = NonceManager::new(provider, address);
+
+    let err = manager.next_nonce().await.expect_err("should fail on unreachable provider");
+    assert!(matches!(err, TxManagerError::Rpc(_)), "expected TxManagerError::Rpc, got {err:?}");
+}
+
+#[tokio::test]
+async fn drop_without_rollback_advances_nonce() {
+    let (manager, _anvil) = setup();
+
+    // Reserve nonce 0 and drop without rollback — cache should stay at 1.
+    let g0 = manager.next_nonce().await.unwrap();
+    assert_eq!(g0.nonce(), 0);
+    drop(g0);
+
+    // The nonce advanced to 1, confirming drop (not rollback) is the
+    // success path.
+    let g1 = manager.next_nonce().await.unwrap();
+    assert_eq!(g1.nonce(), 1);
+}
+
+#[tokio::test]
+async fn reset_then_rollback_interaction() {
+    let (manager, _anvil) = setup();
+
+    // Advance to nonce 2.
+    let g0 = manager.next_nonce().await.unwrap();
+    drop(g0);
+    let g1 = manager.next_nonce().await.unwrap();
+    drop(g1);
+
+    // Reset forces a fresh fetch from chain (returns 0 since no txs sent).
+    manager.reset().await;
+    let g_fresh = manager.next_nonce().await.unwrap();
+    assert_eq!(g_fresh.nonce(), 0);
+
+    // Roll back the freshly-fetched nonce — next call should reuse 0.
+    g_fresh.rollback();
+    let g_reused = manager.next_nonce().await.unwrap();
+    assert_eq!(g_reused.nonce(), 0);
+    drop(g_reused);
+
+    // After consuming the reused nonce, the next one should be 1.
+    let g_next = manager.next_nonce().await.unwrap();
+    assert_eq!(g_next.nonce(), 1);
 }
 
 #[tokio::test]

--- a/crates/utilities/tx-manager/tests/nonce.rs
+++ b/crates/utilities/tx-manager/tests/nonce.rs
@@ -1,7 +1,9 @@
 //! Integration tests for [`NonceManager`] with an Anvil backend.
 
-use std::sync::Arc;
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{
+    Arc,
+    atomic::{AtomicBool, Ordering},
+};
 
 use alloy_node_bindings::Anvil;
 use alloy_primitives::Address;
@@ -246,10 +248,7 @@ async fn concurrent_next_nonce_and_reset_stress() {
         // sorted nonces must form the contiguous range 0..batch_size.
         nonces.sort();
         let expected: Vec<u64> = (0..batch_size as u64).collect();
-        assert_eq!(
-            nonces, expected,
-            "round {round}: nonces should be contiguous 0..{batch_size}",
-        );
+        assert_eq!(nonces, expected, "round {round}: nonces should be contiguous 0..{batch_size}");
 
         // Reset clears the cache, forcing a fresh chain fetch next round.
         manager.reset().await;

--- a/crates/utilities/tx-manager/tests/nonce.rs
+++ b/crates/utilities/tx-manager/tests/nonce.rs
@@ -166,8 +166,8 @@ async fn reset_then_rollback_interaction() {
     assert_eq!(g_next.nonce(), 1);
 }
 
-#[tokio::test]
-async fn nonce_guard_is_send() {
+#[test]
+fn nonce_guard_is_send() {
     // `NonceGuard` must be `Send` so it can be moved into a `tokio::spawn`
     // task after nonce reservation in `send_async()`.
     /// Asserts that `T` implements [`Send`].


### PR DESCRIPTION
### What changed? Why?
Implements a production-ready `NonceManager` for concurrent nonce reservation in `base-tx-manager`. Key design:

- **Lazy initialization** — nonce is fetched from chain via `get_transaction_count()` only on first use; subsequent calls increment locally from cache.
- **Lock-free RPC fetch** — on cache miss the mutex is dropped before the RPC call so concurrent callers aren't blocked by the network round-trip. A generation counter detects `reset()` races mid-flight and retries (up to 5 attempts).
- **RAII `NonceGuard`** — returned by `next_nonce()`, holds an `OwnedMutexGuard` for the caller's entire signing duration, serializing nonce assignment. Supports `rollback()` to restore the nonce on failure; implicit drop finalizes consumption.
- **`Send`-safe** — `OwnedMutexGuard` (via `Arc<Mutex>`) makes the guard `'static` so it can cross `tokio::spawn` boundaries, required for the `send_async()` pattern.
- **RPC timeout** — configurable timeout on chain fetches to prevent indefinite hangs.
- **Error variants** — adds `NonceOverflow` (checked at `u64::MAX`) and `NonceAcquisitionFailed` to `TxManagerError`.

Also adds `RpcErrorClassifier` with `classify_rpc_error()` and `err_string_contains_any()` for mapping raw geth RPC error strings into structured `TxManagerError` variants with retry semantics (`is_retryable()`, `is_already_known()`).

### How has it been tested?
14 integration tests using Anvil cover:
- Initial chain fetch and local increment
- Rollback and drop semantics
- Reset with fresh chain fetch and reset-then-rollback interaction
- Concurrent unique sequential nonces (10 tasks)
- Concurrent next_nonce + reset stress test (5 rounds x 20 tasks, asserting contiguous nonces)
- Reset blocking while guard held (lock contention)
- Provider failure and RPC timeout error paths
- Nonce overflow at `u64::MAX`
- Compile-time `Send` bound assertion

### Notes to reviewers
- The `OwnedMutexGuard` (via `Arc<Mutex>`) design is intentional — it makes `NonceGuard` `'static` so it can cross `tokio::spawn` boundaries, which is required for the `send_async()` pattern where nonce reservation happens before task spawn.
- `NonceState` fields are private with read-only accessors; a test-only constructor (`new_with_nonce`) pre-seeds cache for edge-case testing without chain interaction.
- RPC error classification relies on case-insensitive substring matching against known geth error strings. Other clients (Erigon, Besu) may have different wording and could fall through to the `Rpc(String)` fallback (treated as retryable).

### Change management
type=routine
risk=low
impact=sev4

### Backwards Compatibility
backwards_compatible=true

automerge=false