### PR TITLE
fix(ci): use AWS ECR public mirror for devnet base images

### DIFF
--- a/etc/docker/Dockerfile.devnet
+++ b/etc/docker/Dockerfile.devnet
@@ -1,4 +1,4 @@
-FROM golang:1.25-alpine AS builder
+FROM public.ecr.aws/docker/library/golang:1.25-alpine AS builder
 
 # Install build dependencies for CGO (required for BLS library)
 RUN apk add --no-cache git make gcc g++ musl-dev linux-headers curl ca-certificates
@@ -26,7 +26,7 @@ WORKDIR /build2
 RUN git clone --depth 1 https://github.com/protolambda/eth2-val-tools.git .
 RUN go build -o /go/bin/eth2-val-tools .
 
-FROM alpine:3.21
+FROM public.ecr.aws/docker/library/alpine:3.21
 
 RUN apk add --no-cache bash jq openssl curl gettext
 


### PR DESCRIPTION
## Summary

Docker Hub was returning 500 errors on anonymous pulls for `golang:1.25-alpine` and `alpine:3.21` in the devnet CI job due to rate limiting on shared GitHub Actions runner IPs. Switches both `FROM` lines in `Dockerfile.devnet` to use the AWS ECR Public Gallery mirror (`public.ecr.aws/docker/library/`), which mirrors all Docker Hub official images with no authentication and no rate limits.