### PR TITLE
feat(proof/tee): add vsock_cid config, make all CLI args required, fix stack overflow

### DIFF
--- a/bin/prover/src/cli.rs
+++ b/bin/prover/src/cli.rs
@@ -83,8 +83,8 @@ struct ProverServerArgs {
     l2_chain_id: u64,
 
     /// Socket address to listen on for JSON-RPC.
-    #[arg(long, env = "RPC_ADDR", default_value = "0.0.0.0:7300")]
-    rpc_addr: SocketAddr,
+    #[arg(long, env = "LISTEN_ADDR")]
+    listen_addr: SocketAddr,
 
     /// Enable experimental `debug_executePayload` witness endpoint.
     #[arg(long, env = "ENABLE_EXPERIMENTAL_WITNESS_ENDPOINT")]
@@ -99,19 +99,23 @@ struct NitroServerArgs {
     server: ProverServerArgs,
 
     /// Vsock CID of the enclave.
-    #[arg(long, env = "VSOCK_CID", default_value_t = 16)]
+    #[arg(long, env = "VSOCK_CID")]
     vsock_cid: u32,
 
     /// Vsock port to connect to the enclave.
-    #[arg(long, env = "VSOCK_PORT", default_value_t = 1234)]
+    #[arg(long, env = "VSOCK_PORT")]
     vsock_port: u32,
 }
 
 /// Arguments for the `nitro enclave` subcommand.
 #[derive(Parser)]
 struct NitroEnclaveArgs {
+    /// Vsock CID to bind.
+    #[arg(long, env = "VSOCK_CID")]
+    vsock_cid: u32,
+
     /// Vsock port to listen on.
-    #[arg(long, env = "VSOCK_PORT", default_value_t = 1234)]
+    #[arg(long, env = "VSOCK_PORT")]
     vsock_port: u32,
 
     /// Per-chain configuration hash.
@@ -169,8 +173,8 @@ impl NitroServerArgs {
         let transport = Arc::new(NitroTransport::vsock(self.vsock_cid, self.vsock_port));
         let server = NitroProverServer::new(config, transport);
 
-        info!(addr = %self.server.rpc_addr, "starting nitro prover server");
-        let handle = server.run(self.server.rpc_addr).await?;
+        info!(addr = %self.server.listen_addr, "starting nitro prover server");
+        let handle = server.run(self.server.listen_addr).await?;
         handle.stopped().await;
         Ok(())
     }
@@ -179,6 +183,7 @@ impl NitroServerArgs {
 impl NitroEnclaveArgs {
     async fn run(self) -> eyre::Result<()> {
         let config = EnclaveConfig {
+            vsock_cid: self.vsock_cid,
             vsock_port: self.vsock_port,
             config_hash: self.config_hash,
             tee_image_hash: self.tee_image_hash,
@@ -226,6 +231,7 @@ impl NitroLocalArgs {
             .clone();
 
         let enclave_config = EnclaveConfig {
+            vsock_cid: 0,
             vsock_port: 0,
             config_hash: self.config_hash,
             tee_image_hash: self.tee_image_hash,
@@ -245,8 +251,8 @@ impl NitroLocalArgs {
         let transport = Arc::new(NitroTransport::local(enclave_server));
         let server = NitroProverServer::new(prover_config, transport);
 
-        info!(addr = %self.server.rpc_addr, "starting nitro prover server (local mode)");
-        let handle = server.run(self.server.rpc_addr).await?;
+        info!(addr = %self.server.listen_addr, "starting nitro prover server (local mode)");
+        let handle = server.run(self.server.listen_addr).await?;
         handle.stopped().await;
         Ok(())
     }

--- a/crates/proof/tee/Justfile
+++ b/crates/proof/tee/Justfile
@@ -25,6 +25,7 @@ nitro-local *args:
         --l2-eth-url "${L2_ETH_URL:-http://localhost:9545}" \
         --l1-beacon-url "${L1_BEACON_URL:-http://localhost:5052}" \
         --l2-chain-id "${L2_CHAIN_ID:-8453}" \
+        --listen-addr "${LISTEN_ADDR:-0.0.0.0:7300}" \
         --config-hash "${CONFIG_HASH:-0x0000000000000000000000000000000000000000000000000000000000000000}" \
         --tee-image-hash "${TEE_IMAGE_HASH:-0x0000000000000000000000000000000000000000000000000000000000000000}" \
         --enable-experimental-witness-endpoint \

--- a/crates/proof/tee/nitro/src/enclave/mod.rs
+++ b/crates/proof/tee/nitro/src/enclave/mod.rs
@@ -7,7 +7,7 @@ use base_proof_transport::Frame;
 #[cfg(target_os = "linux")]
 use tokio::time::{Duration, timeout};
 #[cfg(target_os = "linux")]
-use tokio_vsock::{VMADDR_CID_ANY, VsockAddr, VsockListener};
+use tokio_vsock::{VsockAddr, VsockListener};
 #[cfg(target_os = "linux")]
 use tracing::{debug, info, warn};
 
@@ -32,6 +32,8 @@ pub use server::Server;
 /// Enclave runtime configuration.
 #[derive(Debug)]
 pub struct EnclaveConfig {
+    /// Vsock CID to bind.
+    pub vsock_cid: u32,
     /// Vsock port to listen on.
     pub vsock_port: u32,
     /// Per-chain configuration hash.
@@ -45,6 +47,7 @@ pub struct EnclaveConfig {
 #[derive(Debug)]
 pub struct NitroEnclave {
     server: Arc<Server>,
+    vsock_cid: u32,
     vsock_port: u32,
 }
 
@@ -54,13 +57,13 @@ impl NitroEnclave {
     pub fn new(config: &EnclaveConfig) -> eyre::Result<Self> {
         let server = Arc::new(Server::new(config)?);
         info!(address = %server.signer_address(), "enclave initialized");
-        Ok(Self { server, vsock_port: config.vsock_port })
+        Ok(Self { server, vsock_cid: config.vsock_cid, vsock_port: config.vsock_port })
     }
 
     /// Listen on vsock, prove blocks, return results.
     pub async fn run(self) -> eyre::Result<()> {
-        let listener = VsockListener::bind(VsockAddr::new(VMADDR_CID_ANY, self.vsock_port))?;
-        info!(port = self.vsock_port, "listening on vsock");
+        let listener = VsockListener::bind(VsockAddr::new(self.vsock_cid, self.vsock_port))?;
+        info!(cid = self.vsock_cid, port = self.vsock_port, "listening on vsock");
 
         loop {
             let (stream, peer) = listener.accept().await?;

--- a/crates/proof/tee/nitro/src/enclave/server.rs
+++ b/crates/proof/tee/nitro/src/enclave/server.rs
@@ -248,7 +248,12 @@ mod tests {
     use super::*;
 
     fn test_config() -> EnclaveConfig {
-        EnclaveConfig { vsock_port: 1234, config_hash: B256::ZERO, tee_image_hash: B256::ZERO }
+        EnclaveConfig {
+            vsock_cid: 0,
+            vsock_port: 1234,
+            config_hash: B256::ZERO,
+            tee_image_hash: B256::ZERO,
+        }
     }
 
     #[test]

--- a/crates/proof/tee/nitro/src/host/backend.rs
+++ b/crates/proof/tee/nitro/src/host/backend.rs
@@ -50,7 +50,12 @@ mod tests {
     use crate::enclave::{EnclaveConfig, Server};
 
     fn test_config() -> EnclaveConfig {
-        EnclaveConfig { vsock_port: 0, config_hash: B256::ZERO, tee_image_hash: B256::ZERO }
+        EnclaveConfig {
+            vsock_cid: 0,
+            vsock_port: 0,
+            config_hash: B256::ZERO,
+            tee_image_hash: B256::ZERO,
+        }
     }
 
     #[tokio::test]

--- a/crates/proof/tee/nitro/src/host/server.rs
+++ b/crates/proof/tee/nitro/src/host/server.rs
@@ -91,7 +91,12 @@ mod tests {
     use crate::enclave::{EnclaveConfig, Server as EnclaveServer};
 
     fn test_config() -> EnclaveConfig {
-        EnclaveConfig { vsock_port: 0, config_hash: B256::ZERO, tee_image_hash: B256::ZERO }
+        EnclaveConfig {
+            vsock_cid: 0,
+            vsock_port: 0,
+            config_hash: B256::ZERO,
+            tee_image_hash: B256::ZERO,
+        }
     }
 
     #[tokio::test]

--- a/crates/proof/tee/nitro/src/host/transport.rs
+++ b/crates/proof/tee/nitro/src/host/transport.rs
@@ -39,7 +39,7 @@ impl NitroTransport {
         match self {
             #[cfg(target_os = "linux")]
             Self::Vsock(t) => t.prove(preimages).await,
-            Self::Local(s) => s.prove(preimages).await,
+            Self::Local(s) => Box::pin(s.prove(preimages)).await,
         }
     }
 


### PR DESCRIPTION
## Summary

- Add `vsock_cid` to `EnclaveConfig` and `NitroEnclave`, replacing hardcoded `VMADDR_CID_ANY` with configurable CID in `VsockListener::bind`
- Remove default values from all vsock and listen-addr CLI args (`--vsock-cid`, `--vsock-port`, `--listen-addr`) so deployments must be explicit
- Rename `rpc_addr` → `listen_addr` on `ProverServerArgs` for clarity; add `--listen-addr` to the `nitro-local` Justfile recipe
- `Box::pin` the local-mode prove future in `NitroTransport` to prevent tokio worker stack overflow from the deep async proof pipeline

## Changes

| File | Change |
|------|--------|
| `crates/proof/tee/nitro/src/enclave/mod.rs` | Add `vsock_cid` field to `EnclaveConfig` and `NitroEnclave`, use it in `VsockListener::bind` |
| `bin/prover/src/cli.rs` | Add `--vsock-cid` to `NitroEnclaveArgs`, remove all defaults, rename `rpc_addr` → `listen_addr` |
| `crates/proof/tee/Justfile` | Add `--listen-addr` to `nitro-local` recipe |
| `crates/proof/tee/nitro/src/host/transport.rs` | `Box::pin` the `Server::prove` future in `NitroTransport::Local` arm |
| `crates/proof/tee/nitro/src/enclave/server.rs` | Update test helper with `vsock_cid: 0` |
| `crates/proof/tee/nitro/src/host/server.rs` | Update test helper with `vsock_cid: 0` |
| `crates/proof/tee/nitro/src/host/backend.rs` | Update test helper with `vsock_cid: 0` |