### PR TITLE
Mirror client base images

### DIFF
--- a/etc/docker/Dockerfile.client
+++ b/etc/docker/Dockerfile.client
@@ -1,5 +1,5 @@
 # --- Builder ---
-FROM rust:1.93-trixie AS builder
+FROM public.ecr.aws/docker/library/rust:1.93-trixie AS builder
 WORKDIR /app
 ARG MOLD_VERSION=2.40.4
 ARG MOLD_SHA256_AARCH64=c799b9ccae8728793da2186718fbe53b76400a9da396184fac0c64aa3298ec37
@@ -32,7 +32,7 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
     cp /app/target/$([ "$PROFILE" = "dev" ] && echo debug || echo $PROFILE)/base-reth-node /app/base-client
 
 # --- Runtime ---
-FROM debian:trixie-slim
+FROM public.ecr.aws/docker/library/debian:trixie-slim
 RUN apt-get update && \
     apt-get install -y --no-install-recommends ca-certificates curl && \
     rm -rf /var/lib/apt/lists/* && \


### PR DESCRIPTION
  This switches `etc/docker/Dockerfile.client` from Docker Hub official images to the public ECR mirror, following the same reliability fix already applied to the devnet Dockerfile.                                                                                                                                                            
                                                                                                                                                                         
  This Dockerfile is built in both PR CI and release workflows, so reducing Docker Hub pull-limit risk here has direct impact on the most important image path in the repo. The change is low risk because it only swaps the registry host while keeping the exact same `rust:1.93-trixie` and `debian:trixie-slim` tags, and both mirrored tags are available in public ECR.                                                                                                                                      
 