### PR TITLE
chore(workspace): Fix Dep Grouping And Ordering

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -144,15 +144,15 @@ incremental = false
 
 [workspace.dependencies]
 # Base Primitives
-base-alloy-evm = { path = "crates/alloy/evm", default-features = false }
 base-bundles = { path = "crates/alloy/bundles" }
 base-alloy-network = { path = "crates/alloy/network" }
 base-alloy-provider = { path = "crates/alloy/provider" }
-base-alloy-rpc-types = { path = "crates/alloy/rpc-types" }
 base-alloy-upgrades = { path = "crates/alloy/upgrades" }
+base-alloy-rpc-types = { path = "crates/alloy/rpc-types" }
 base-access-lists = { path = "crates/alloy/access-lists" }
 base-alloy-flashblocks = { path = "crates/alloy/flashblocks" }
 base-alloy-rpc-jsonrpsee = { path = "crates/alloy/rpc-jsonrpsee" }
+base-alloy-evm = { path = "crates/alloy/evm", default-features = false }
 base-alloy-flz = { path = "crates/alloy/flz", default-features = false }
 base-alloy-consensus = { path = "crates/alloy/consensus", default-features = false }
 base-alloy-rpc-types-engine = { path = "crates/alloy/rpc-types-engine", default-features = false }
@@ -165,14 +165,16 @@ base-builder-metering = { path = "crates/builder/metering" }
 # Client
 base-client-cli = { path = "crates/client/cli" }
 base-metering = { path = "crates/client/metering" }
+base-proofs-extension = { path = "crates/client/proofs" }
 base-txpool-tracing = { path = "crates/client/txpool-tracing" }
+base-flashblocks-node = { path = "crates/client/flashblocks-node" }
 
 # Consensus
-base-comp = { path = "crates/batcher/comp", default-features = false }
 base-consensus-rpc = { path = "crates/consensus/rpc" }
 base-protocol = { path = "crates/consensus/protocol", default-features = false }
 base-consensus-disc = { path = "crates/consensus/disc", default-features = false }
 base-consensus-peers = { path = "crates/consensus/peers", default-features = false }
+base-consensus-node = { path = "crates/consensus/service", default-features = false }
 base-consensus-derive = { path = "crates/consensus/derive", default-features = false }
 base-consensus-engine = { path = "crates/consensus/engine", default-features = false }
 base-consensus-gossip = { path = "crates/consensus/gossip", default-features = false }
@@ -180,28 +182,29 @@ base-consensus-sources = { path = "crates/consensus/sources", default-features =
 base-consensus-genesis = { path = "crates/consensus/genesis", default-features = false }
 base-consensus-registry = { path = "crates/consensus/registry", default-features = false }
 base-consensus-upgrades = { path = "crates/consensus/upgrades", default-features = false }
-base-consensus-node = { path = "crates/consensus/service", default-features = false }
 base-consensus-providers = { path = "crates/consensus/providers-alloy", default-features = false }
 
 # Execution
-base-revm = { path = "crates/execution/revm", default-features = false }
-base-execution-chainspec = { path = "crates/execution/chainspec" }
+base-node-core = { path = "crates/execution/node" }
 base-execution-cli = { path = "crates/execution/cli" }
-base-execution-consensus = { path = "crates/execution/consensus" }
-base-engine-tree = { path = "crates/execution/engine-tree" }
 base-execution-evm = { path = "crates/execution/evm" }
+base-execution-rpc = { path = "crates/execution/rpc" }
+base-node-runner = { path = "crates/execution/runner" }
 base-execution-exex = { path = "crates/execution/exex" }
+base-execution-trie = { path = "crates/execution/trie" }
+base-txpool-rpc = { path = "crates/execution/txpool-rpc" }
+base-engine-tree = { path = "crates/execution/engine-tree" }
 base-flashblocks = { path = "crates/execution/flashblocks" }
 base-execution-forks = { path = "crates/execution/hardforks" }
-base-execution-payload-builder = { path = "crates/execution/payload" }
-base-execution-primitives = { path = "crates/execution/primitives" }
-base-execution-rpc = { path = "crates/execution/rpc" }
 base-execution-storage = { path = "crates/execution/storage" }
-base-execution-trie = { path = "crates/execution/trie" }
+base-execution-chainspec = { path = "crates/execution/chainspec" }
+base-execution-consensus = { path = "crates/execution/consensus" }
+base-execution-primitives = { path = "crates/execution/primitives" }
+base-execution-payload-builder = { path = "crates/execution/payload" }
+base-revm = { path = "crates/execution/revm", default-features = false }
+
+# Txpool
 base-txpool = { path = "crates/txpool" }
-base-node-core = { path = "crates/execution/node" }
-base-node-runner = { path = "crates/execution/runner" }
-base-txpool-rpc = { path = "crates/execution/txpool-rpc" }
 
 # Infra
 based = { path = "crates/infra/based" }
@@ -212,40 +215,39 @@ websocket-proxy = { path = "crates/infra/websocket-proxy" }
 mempool-rebroadcaster = { path = "crates/infra/mempool-rebroadcaster" }
 
 # Proof
-base-proof-mpt = { path = "crates/proof/mpt", default-features = false }
+base-proof-rpc = { path = "crates/proof/rpc" }
+base-enclave = { path = "crates/proof/tee/core" }
+base-proposer = { path = "crates/proof/proposer" }
+base-zk-client = { path = "crates/proof/zk/client" }
+base-challenger = { path = "crates/proof/challenge" }
+base-enclave-client = { path = "crates/proof/tee/client" }
+base-proof-tee-nitro = { path = "crates/proof/tee/nitro" }
+base-proof-contracts = { path = "crates/proof/contracts" }
+base-proof-transport = { path = "crates/proof/transport" }
 base-proof = { path = "crates/proof/proof", default-features = false }
+base-proof-mpt = { path = "crates/proof/mpt", default-features = false }
+base-proof-host = { path = "crates/proof/host", default-features = false }
 base-proof-client = { path = "crates/proof/client", default-features = false }
 base-proof-driver = { path = "crates/proof/driver", default-features = false }
 base-proof-executor = { path = "crates/proof/executor", default-features = false }
 base-proof-preimage = { path = "crates/proof/preimage", default-features = false }
-base-proof-primitives = { path = "crates/proof/primitives", default-features = false }
-base-proof-fpvm-precompiles = { path = "crates/proof/fpvm-precompiles", default-features = false }
-base-proof-host = { path = "crates/proof/host", default-features = false }
 base-proof-std-fpvm = { path = "crates/proof/std-fpvm", default-features = false }
+base-proof-primitives = { path = "crates/proof/primitives", default-features = false }
 base-proof-std-fpvm-proc = { path = "crates/proof/std-fpvm-proc", default-features = false }
-base-enclave = { path = "crates/proof/tee/core" }
-base-enclave-client = { path = "crates/proof/tee/client" }
-base-proof-tee-nitro = { path = "crates/proof/tee/nitro" }
-base-proof-contracts = { path = "crates/proof/contracts" }
-base-proof-rpc = { path = "crates/proof/rpc" }
-base-proposer = { path = "crates/proof/proposer" }
-base-zk-client = { path = "crates/proof/zk/client" }
-base-challenger = { path = "crates/proof/challenge" }
-base-proof-transport = { path = "crates/proof/transport" }
+base-proof-fpvm-precompiles = { path = "crates/proof/fpvm-precompiles", default-features = false }
 
 # Actions
 base-action-harness = { path = "actions/harness" }
 
 # Batcher
 base-batcher-driver = { path = "crates/batcher/driver" }
+base-comp = { path = "crates/batcher/comp", default-features = false }
 
 # Utilities
 base-jwt = { path = "crates/utilities/jwt" }
 base-cli-utils = { path = "crates/utilities/cli" }
 base-test-utils = { path = "crates/utilities/test-utils" }
-base-proofs-extension = { path = "crates/client/proofs" }
 base-tx-manager = { path = "crates/utilities/tx-manager" }
-base-flashblocks-node = { path = "crates/client/flashblocks-node" }
 base-macros = { path = "crates/utilities/macros", default-features = false }
 
 # revm


### PR DESCRIPTION
## Summary

Moves misplaced workspace dependencies into their correct sections: base-comp into Batcher, base-proofs-extension and base-flashblocks-node into Client, and base-txpool into a new dedicated Txpool section. All sections are sorted by line length in waterfall style.