### PR TITLE
feat(alloy): Fix Upgrade Method And Type Naming

### DIFF
--- a/crates/alloy/evm/src/executor.rs
+++ b/crates/alloy/evm/src/executor.rs
@@ -380,7 +380,7 @@ mod tests {
     fn test_with_encoded() {
         let executor_factory = OpBlockExecutorFactory::new(
             OpAlloyReceiptBuilder::default(),
-            BaseChainUpgrades::base_mainnet(),
+            BaseChainUpgrades::mainnet(),
             OpEvmFactory::default(),
         );
         let mut db =
@@ -487,7 +487,7 @@ mod tests {
 
         let mut db = prepare_jovian_db(DA_FOOTPRINT_GAS_SCALAR);
         let op_chain_hardforks = BaseChainUpgrades::new(
-            BaseUpgrade::base_mainnet()
+            BaseUpgrade::mainnet()
                 .into_iter()
                 .chain(vec![(BaseUpgrade::Jovian, ForkCondition::Timestamp(JOVIAN_TIMESTAMP))]),
         );
@@ -532,7 +532,7 @@ mod tests {
 
         let mut db = prepare_jovian_db(DA_FOOTPRINT_GAS_SCALAR);
         let op_chain_hardforks = BaseChainUpgrades::new(
-            BaseUpgrade::base_mainnet()
+            BaseUpgrade::mainnet()
                 .into_iter()
                 .chain(vec![(BaseUpgrade::Jovian, ForkCondition::Timestamp(JOVIAN_TIMESTAMP))]),
         );
@@ -589,7 +589,7 @@ mod tests {
 
         let mut db = prepare_jovian_db(DA_FOOTPRINT_GAS_SCALAR);
         let op_chain_hardforks = BaseChainUpgrades::new(
-            BaseUpgrade::base_mainnet()
+            BaseUpgrade::mainnet()
                 .into_iter()
                 .chain(vec![(BaseUpgrade::Jovian, ForkCondition::Timestamp(JOVIAN_TIMESTAMP))]),
         );

--- a/crates/alloy/upgrades/README.md
+++ b/crates/alloy/upgrades/README.md
@@ -5,7 +5,7 @@ Named bindings for network upgrades.
 ## Overview
 
 Defines the `BaseUpgrade` enum and `BaseUpgrades` trait for the Base upgrade sequence
-(Bedrock, Canyon, Ecotone, Fjord, Granite, Holocene, Isthmus, Jovian, `BaseV1`). Provides concrete
+(Bedrock, Canyon, Ecotone, Fjord, Granite, Holocene, Isthmus, Jovian, `V1`). Provides concrete
 activation timestamps for Base Mainnet, Base Sepolia, and devnet chains as typed constants, and
 `BaseChainUpgrades` for per-chain configuration.
 

--- a/crates/alloy/upgrades/src/chain.rs
+++ b/crates/alloy/upgrades/src/chain.rs
@@ -2,7 +2,7 @@ use alloc::vec::Vec;
 use core::ops::Index;
 
 use BaseUpgrade::{
-    BaseV1, Bedrock, Canyon, Ecotone, Fjord, Granite, Holocene, Isthmus, Jovian, Regolith,
+    Bedrock, Canyon, Ecotone, Fjord, Granite, Holocene, Isthmus, Jovian, Regolith, V1,
 };
 // Production imports for hardfork implementations
 use EthereumHardfork::{
@@ -42,13 +42,13 @@ impl BaseChainUpgrades {
     }
 
     /// Creates a new [`BaseChainUpgrades`] with Base mainnet configuration.
-    pub fn base_mainnet() -> Self {
-        Self::new(BaseUpgrade::base_mainnet())
+    pub fn mainnet() -> Self {
+        Self::new(BaseUpgrade::mainnet())
     }
 
     /// Creates a new [`BaseChainUpgrades`] with Base Sepolia configuration.
-    pub fn base_sepolia() -> Self {
-        Self::new(BaseUpgrade::base_sepolia())
+    pub fn sepolia() -> Self {
+        Self::new(BaseUpgrade::sepolia())
     }
 
     /// Creates a new [`BaseChainUpgrades`] with devnet configuration.
@@ -103,7 +103,7 @@ impl Index<BaseUpgrade> for BaseChainUpgrades {
             Holocene => &self.forks[Holocene.idx()].1,
             Isthmus => &self.forks[Isthmus.idx()].1,
             Jovian => &self.forks[Jovian.idx()].1,
-            BaseV1 => &self.forks[BaseV1.idx()].1,
+            V1 => &self.forks[V1.idx()].1,
         }
     }
 }
@@ -134,7 +134,7 @@ impl Index<EthereumHardfork> for BaseChainUpgrades {
 #[cfg(test)]
 mod tests {
     use BaseUpgrade::{
-        BaseV1, Bedrock, Canyon, Ecotone, Fjord, Granite, Holocene, Isthmus, Jovian, Regolith,
+        Bedrock, Canyon, Ecotone, Fjord, Granite, Holocene, Isthmus, Jovian, Regolith, V1,
     };
     use alloy_hardforks::EthereumHardfork;
 
@@ -153,7 +153,7 @@ mod tests {
 
     #[test]
     fn base_mainnet_fork_conditions() {
-        let base_mainnet_forks = BaseChainUpgrades::base_mainnet();
+        let base_mainnet_forks = BaseChainUpgrades::mainnet();
         assert_eq!(base_mainnet_forks[Bedrock], ForkCondition::Block(BASE_MAINNET_BEDROCK_BLOCK));
         assert_eq!(
             base_mainnet_forks[Regolith],
@@ -187,12 +187,12 @@ mod tests {
             base_mainnet_forks[Jovian],
             ForkCondition::Timestamp(BASE_MAINNET_JOVIAN_TIMESTAMP)
         );
-        assert_eq!(base_mainnet_forks[BaseV1], ForkCondition::Never);
+        assert_eq!(base_mainnet_forks[V1], ForkCondition::Never);
     }
 
     #[test]
     fn base_sepolia_fork_conditions() {
-        let base_sepolia_forks = BaseChainUpgrades::base_sepolia();
+        let base_sepolia_forks = BaseChainUpgrades::sepolia();
         assert_eq!(base_sepolia_forks[Bedrock], ForkCondition::Block(BASE_SEPOLIA_BEDROCK_BLOCK));
         assert_eq!(
             base_sepolia_forks[Regolith],
@@ -226,12 +226,12 @@ mod tests {
             base_sepolia_forks.upgrade_activation(Jovian),
             ForkCondition::Timestamp(BASE_SEPOLIA_JOVIAN_TIMESTAMP)
         );
-        assert_eq!(base_sepolia_forks[BaseV1], ForkCondition::Never);
+        assert_eq!(base_sepolia_forks[V1], ForkCondition::Never);
     }
 
     #[test]
     fn is_jovian_active_at_timestamp() {
-        let base_mainnet_forks = BaseChainUpgrades::base_mainnet();
+        let base_mainnet_forks = BaseChainUpgrades::mainnet();
         assert!(base_mainnet_forks.is_jovian_active_at_timestamp(BASE_MAINNET_JOVIAN_TIMESTAMP));
         assert!(
             !base_mainnet_forks.is_jovian_active_at_timestamp(BASE_MAINNET_JOVIAN_TIMESTAMP - 1)
@@ -240,7 +240,7 @@ mod tests {
             base_mainnet_forks.is_jovian_active_at_timestamp(BASE_MAINNET_JOVIAN_TIMESTAMP + 1000)
         );
 
-        let base_sepolia_forks = BaseChainUpgrades::base_sepolia();
+        let base_sepolia_forks = BaseChainUpgrades::sepolia();
         assert!(base_sepolia_forks.is_jovian_active_at_timestamp(BASE_SEPOLIA_JOVIAN_TIMESTAMP));
         assert!(
             !base_sepolia_forks.is_jovian_active_at_timestamp(BASE_SEPOLIA_JOVIAN_TIMESTAMP - 1)
@@ -252,20 +252,20 @@ mod tests {
 
     #[test]
     fn is_base_v1_active_at_timestamp() {
-        // BaseV1 is not scheduled on mainnet or sepolia yet (ForkCondition::Never)
-        let base_mainnet_forks = BaseChainUpgrades::base_mainnet();
+        // V1 is not scheduled on mainnet or sepolia yet (ForkCondition::Never)
+        let base_mainnet_forks = BaseChainUpgrades::mainnet();
         assert!(!base_mainnet_forks.is_base_v1_active_at_timestamp(0));
         assert!(!base_mainnet_forks.is_base_v1_active_at_timestamp(u64::MAX));
 
-        let base_sepolia_forks = BaseChainUpgrades::base_sepolia();
+        let base_sepolia_forks = BaseChainUpgrades::sepolia();
         assert!(!base_sepolia_forks.is_base_v1_active_at_timestamp(0));
         assert!(!base_sepolia_forks.is_base_v1_active_at_timestamp(u64::MAX));
 
-        // BaseV1 is active at genesis on devnet (ForkCondition::ZERO_TIMESTAMP)
+        // V1 is active at genesis on devnet (ForkCondition::ZERO_TIMESTAMP)
         let devnet_forks = BaseChainUpgrades::devnet();
         assert!(devnet_forks.is_base_v1_active_at_timestamp(0));
 
-        // BaseV1 activates alongside Jovian on devnet-0-sepolia-dev-0
+        // V1 activates alongside Jovian on devnet-0-sepolia-dev-0
         let devnet0_forks = BaseChainUpgrades::base_devnet_0_sepolia_dev_0();
         assert!(
             !devnet0_forks
@@ -279,7 +279,7 @@ mod tests {
 
     #[test]
     fn test_ethereum_fork_activation_consistency() {
-        let base_mainnet_forks = BaseChainUpgrades::base_mainnet();
+        let base_mainnet_forks = BaseChainUpgrades::mainnet();
         for ethereum_hardfork in EthereumHardfork::VARIANTS {
             let _ = base_mainnet_forks.ethereum_fork_activation(*ethereum_hardfork);
         }

--- a/crates/alloy/upgrades/src/hardfork.rs
+++ b/crates/alloy/upgrades/src/hardfork.rs
@@ -42,8 +42,8 @@ hardfork!(
         Isthmus,
         /// Jovian: <https://github.com/ethereum-optimism/specs/tree/main/specs/protocol/jovian>
         Jovian,
-        /// Base V1: First Base-specific network upgrade.
-        BaseV1,
+        /// V1: First Base-specific network upgrade.
+        V1,
     }
 );
 
@@ -51,7 +51,7 @@ impl BaseUpgrade {
     /// Reverse lookup to find the hardfork given a chain ID and block timestamp.
     /// Returns the active hardfork at the given timestamp for the specified Base chain.
     ///
-    /// Note: standalone upgrades like [`BaseUpgrade::BaseV1`] are not included here because
+    /// Note: standalone upgrades like [`BaseUpgrade::V1`] are not included here because
     /// they do not participate in the sequential cascade and have no scheduled activation
     /// timestamp on production chains. Use [`crate::BaseUpgrades::is_base_v1_active_at_timestamp`]
     /// to check those independently.
@@ -84,7 +84,7 @@ impl BaseUpgrade {
     }
 
     /// Base mainnet list of hardforks.
-    pub const fn base_mainnet() -> [(Self, ForkCondition); 10] {
+    pub const fn mainnet() -> [(Self, ForkCondition); 10] {
         [
             (Self::Bedrock, ForkCondition::Block(BASE_MAINNET_BEDROCK_BLOCK)),
             (Self::Regolith, ForkCondition::Timestamp(BASE_MAINNET_REGOLITH_TIMESTAMP)),
@@ -95,12 +95,12 @@ impl BaseUpgrade {
             (Self::Holocene, ForkCondition::Timestamp(BASE_MAINNET_HOLOCENE_TIMESTAMP)),
             (Self::Isthmus, ForkCondition::Timestamp(BASE_MAINNET_ISTHMUS_TIMESTAMP)),
             (Self::Jovian, ForkCondition::Timestamp(BASE_MAINNET_JOVIAN_TIMESTAMP)),
-            (Self::BaseV1, ForkCondition::Never),
+            (Self::V1, ForkCondition::Never),
         ]
     }
 
     /// Base Sepolia list of hardforks.
-    pub const fn base_sepolia() -> [(Self, ForkCondition); 10] {
+    pub const fn sepolia() -> [(Self, ForkCondition); 10] {
         [
             (Self::Bedrock, ForkCondition::Block(BASE_SEPOLIA_BEDROCK_BLOCK)),
             (Self::Regolith, ForkCondition::Timestamp(BASE_SEPOLIA_REGOLITH_TIMESTAMP)),
@@ -111,7 +111,7 @@ impl BaseUpgrade {
             (Self::Holocene, ForkCondition::Timestamp(BASE_SEPOLIA_HOLOCENE_TIMESTAMP)),
             (Self::Isthmus, ForkCondition::Timestamp(BASE_SEPOLIA_ISTHMUS_TIMESTAMP)),
             (Self::Jovian, ForkCondition::Timestamp(BASE_SEPOLIA_JOVIAN_TIMESTAMP)),
-            (Self::BaseV1, ForkCondition::Never),
+            (Self::V1, ForkCondition::Never),
         ]
     }
 
@@ -127,7 +127,7 @@ impl BaseUpgrade {
             (Self::Holocene, ForkCondition::ZERO_TIMESTAMP),
             (Self::Isthmus, ForkCondition::ZERO_TIMESTAMP),
             (Self::Jovian, ForkCondition::ZERO_TIMESTAMP),
-            (Self::BaseV1, ForkCondition::ZERO_TIMESTAMP),
+            (Self::V1, ForkCondition::ZERO_TIMESTAMP),
         ]
     }
 
@@ -158,10 +158,10 @@ impl BaseUpgrade {
                 ForkCondition::Timestamp(BASE_DEVNET_0_SEPOLIA_DEV_0_ISTHMUS_TIMESTAMP),
             ),
             (Self::Jovian, ForkCondition::Timestamp(BASE_DEVNET_0_SEPOLIA_DEV_0_JOVIAN_TIMESTAMP)),
-            // BaseV1 co-activates with Jovian on this devnet. Both resolve to OpSpecId::BASE_V1
-            // since spec_by_timestamp_after_bedrock checks BaseV1 first (newest wins). This is
-            // intentional: BaseV1 is a strict superset of Jovian on this devnet configuration.
-            (Self::BaseV1, ForkCondition::Timestamp(BASE_DEVNET_0_SEPOLIA_DEV_0_JOVIAN_TIMESTAMP)),
+            // V1 co-activates with Jovian on this devnet. Both resolve to OpSpecId::BASE_V1
+            // since spec_by_timestamp_after_bedrock checks V1 first (newest wins). This is
+            // intentional: V1 is a strict superset of Jovian on this devnet configuration.
+            (Self::V1, ForkCondition::Timestamp(BASE_DEVNET_0_SEPOLIA_DEV_0_JOVIAN_TIMESTAMP)),
         ]
     }
 
@@ -183,7 +183,7 @@ mod tests {
     fn check_base_hardfork_from_str() {
         let hardfork_str = [
             "beDrOck", "rEgOlITH", "cAnYoN", "eCoToNe", "FJorD", "GRaNiTe", "hOlOcEnE", "isthMUS",
-            "jOvIaN", "bAsEv1",
+            "jOvIaN", "v1",
         ];
         let expected_hardforks = [
             BaseUpgrade::Bedrock,
@@ -195,7 +195,7 @@ mod tests {
             BaseUpgrade::Holocene,
             BaseUpgrade::Isthmus,
             BaseUpgrade::Jovian,
-            BaseUpgrade::BaseV1,
+            BaseUpgrade::V1,
         ];
 
         let hardforks: alloc::vec::Vec<BaseUpgrade> =

--- a/crates/alloy/upgrades/src/hardforks.rs
+++ b/crates/alloy/upgrades/src/hardforks.rs
@@ -59,8 +59,8 @@ pub trait BaseUpgrades: EthereumHardforks {
         self.upgrade_activation(BaseUpgrade::Jovian).active_at_timestamp(timestamp)
     }
 
-    /// Returns `true` if [`BaseV1`](BaseUpgrade::BaseV1) is active at given block timestamp.
+    /// Returns `true` if [`V1`](BaseUpgrade::V1) is active at given block timestamp.
     fn is_base_v1_active_at_timestamp(&self, timestamp: u64) -> bool {
-        self.upgrade_activation(BaseUpgrade::BaseV1).active_at_timestamp(timestamp)
+        self.upgrade_activation(BaseUpgrade::V1).active_at_timestamp(timestamp)
     }
 }

--- a/crates/consensus/genesis/src/rollup.rs
+++ b/crates/consensus/genesis/src/rollup.rs
@@ -415,9 +415,9 @@ impl BaseUpgrades for RollupConfig {
                 .jovian_time
                 .map(ForkCondition::Timestamp)
                 .unwrap_or(ForkCondition::Never),
-            // BaseV1 is standalone: not part of the Base upgrade cascade chain. It only activates
+            // V1 is standalone: not part of the Base upgrade cascade chain. It only activates
             // when explicitly configured and never implies (or is implied by) Jovian being active.
-            BaseUpgrade::BaseV1 => self
+            BaseUpgrade::V1 => self
                 .hardforks
                 .base
                 .as_ref()
@@ -473,7 +473,7 @@ mod tests {
         assert_eq!(config.spec_id(65), base_revm::OpSpecId::JOVIAN);
         config.hardforks.base = Some(crate::BaseHardforkConfig { v1: Some(70) });
         assert_eq!(config.spec_id(70), base_revm::OpSpecId::BASE_V1);
-        // BaseV1 takes precedence over Jovian when both are active at the same timestamp
+        // V1 takes precedence over Jovian when both are active at the same timestamp
         config.hardforks.base = Some(crate::BaseHardforkConfig { v1: Some(65) });
         assert_eq!(config.spec_id(65), base_revm::OpSpecId::BASE_V1);
     }
@@ -621,7 +621,7 @@ mod tests {
         let mut config = RollupConfig::default();
         assert!(!config.is_base_v1_active(0));
         config.hardforks.base = Some(BaseHardforkConfig { v1: Some(10) });
-        // BaseV1 does not cascade upward to existing forks
+        // V1 does not cascade upward to existing forks
         assert!(!config.is_regolith_active(10));
         assert!(!config.is_canyon_active(10));
         assert!(!config.is_jovian_active(10));

--- a/crates/consensus/registry/tests/hardfork_consistency.rs
+++ b/crates/consensus/registry/tests/hardfork_consistency.rs
@@ -6,7 +6,7 @@ use base_consensus_registry::test_utils::{BASE_MAINNET_CONFIG, BASE_SEPOLIA_CONF
 
 #[test]
 fn mainnet_rollup_config_matches_chain_hardforks() {
-    let chain = BaseChainUpgrades::base_mainnet();
+    let chain = BaseChainUpgrades::mainnet();
     for fork in BaseUpgrade::VARIANTS {
         // Regolith activated at genesis on Base and is stored as `regolith_time: None`
         // in the rollup config. The `upgrade_activation` cascade returns Canyon's
@@ -26,7 +26,7 @@ fn mainnet_rollup_config_matches_chain_hardforks() {
 
 #[test]
 fn sepolia_rollup_config_matches_chain_hardforks() {
-    let chain = BaseChainUpgrades::base_sepolia();
+    let chain = BaseChainUpgrades::sepolia();
     for fork in BaseUpgrade::VARIANTS {
         // See comment in mainnet test above.
         if *fork == BaseUpgrade::Regolith {

--- a/crates/execution/hardforks/src/chain.rs
+++ b/crates/execution/hardforks/src/chain.rs
@@ -61,9 +61,9 @@ impl BaseChainUpgradesExt for BaseChainUpgrades {
 
         forks.push((BaseUpgrade::Jovian.boxed(), self[BaseUpgrade::Jovian]));
 
-        let base_v1 = self[BaseUpgrade::BaseV1];
+        let base_v1 = self[BaseUpgrade::V1];
         if base_v1 != ForkCondition::Never {
-            forks.push((BaseUpgrade::BaseV1.boxed(), base_v1));
+            forks.push((BaseUpgrade::V1.boxed(), base_v1));
         }
 
         ChainHardforks::new(forks)
@@ -76,11 +76,11 @@ pub static DEV_HARDFORKS: Lazy<ChainHardforks> =
 
 /// Base Sepolia list of hardforks.
 pub static BASE_SEPOLIA_HARDFORKS: Lazy<ChainHardforks> =
-    Lazy::new(|| BaseChainUpgrades::base_sepolia().to_chain_hardforks());
+    Lazy::new(|| BaseChainUpgrades::sepolia().to_chain_hardforks());
 
 /// Base mainnet list of hardforks.
 pub static BASE_MAINNET_HARDFORKS: Lazy<ChainHardforks> =
-    Lazy::new(|| BaseChainUpgrades::base_mainnet().to_chain_hardforks());
+    Lazy::new(|| BaseChainUpgrades::mainnet().to_chain_hardforks());
 
 /// Base devnet-0-sepolia-dev-0 list of hardforks.
 pub static BASE_DEVNET_0_SEPOLIA_DEV_0_HARDFORKS: Lazy<ChainHardforks> =

--- a/crates/execution/revm/src/spec.rs
+++ b/crates/execution/revm/src/spec.rs
@@ -118,7 +118,7 @@ pub mod name {
     /// Jovian spec name.
     pub const JOVIAN: &str = "Jovian";
     /// Base V1 spec name.
-    pub const BASE_V1: &str = "BaseV1";
+    pub const BASE_V1: &str = "V1";
 }
 
 #[cfg(test)]

--- a/docs/guides/UPGRADES.md
+++ b/docs/guides/UPGRADES.md
@@ -2,7 +2,7 @@
 
 This guide covers every code change required to introduce a new network upgrade to this repository. Changes are split into two groups: those required for every upgrade, and those that depend on whether the upgrade changes EVM execution rules.
 
-The BaseV1 upgrade is used as the running example throughout. Replace `BaseV1` / `base_v1` / `BASE_V1` with the actual upgrade name.
+The V1 upgrade is used as the running example throughout. Replace `V1` / `base_v1` / `BASE_V1` with the actual upgrade name.
 
 ---
 
@@ -32,8 +32,8 @@ hardfork!(
         // ... existing variants ...
         /// Jovian: <https://github.com/ethereum-optimism/specs/tree/main/specs/protocol/jovian>
         Jovian,
-        /// Base V1: First Base-specific network upgrade.
-        BaseV1,   // <-- add here
+        /// V1: First Base-specific network upgrade.
+        V1,   // <-- add here
     }
 );
 ```
@@ -41,17 +41,17 @@ hardfork!(
 Then update all four chain config array methods from `[(Self, ForkCondition); N]` to `N+1` and append the new entry. Mainnet and sepolia use `ForkCondition::Never` until the upgrade is scheduled; the generic devnet uses `ForkCondition::ZERO_TIMESTAMP`:
 
 ```rust
-pub const fn base_mainnet() -> [(Self, ForkCondition); 10] {
+pub const fn mainnet() -> [(Self, ForkCondition); 10] {
     [
         // ... existing entries ...
-        (Self::BaseV1, ForkCondition::Never),
+        (Self::V1, ForkCondition::Never),
     ]
 }
 
 pub const fn devnet() -> [(Self, ForkCondition); 10] {
     [
         // ... existing entries ...
-        (Self::BaseV1, ForkCondition::ZERO_TIMESTAMP),
+        (Self::V1, ForkCondition::ZERO_TIMESTAMP),
     ]
 }
 ```
@@ -63,7 +63,7 @@ pub const fn base_devnet_0_sepolia_dev_0() -> [(Self, ForkCondition); 10] {
     [
         // ... existing entries ...
         (Self::Jovian, ForkCondition::Timestamp(BASE_DEVNET_0_SEPOLIA_DEV_0_JOVIAN_TIMESTAMP)),
-        (Self::BaseV1, ForkCondition::Timestamp(BASE_DEVNET_0_SEPOLIA_DEV_0_JOVIAN_TIMESTAMP)),
+        (Self::V1, ForkCondition::Timestamp(BASE_DEVNET_0_SEPOLIA_DEV_0_JOVIAN_TIMESTAMP)),
     ]
 }
 ```
@@ -76,11 +76,11 @@ Update `check_base_upgrade_from_str` in the test module to include the new upgra
 
 **File:** [`crates/alloy/upgrades/src/chain.rs`](../../crates/alloy/upgrades/src/chain.rs)
 
-Add `BaseV1` to the `use BaseUpgrade::{...}` import and add a match arm to `Index<BaseUpgrade>`:
+Add `V1` to the `use BaseUpgrade::{...}` import and add a match arm to `Index<BaseUpgrade>`:
 
 ```rust
 use BaseUpgrade::{
-    BaseV1, Bedrock, Canyon, Ecotone, Fjord, Granite, Holocene, Isthmus, Jovian, Regolith,
+    Bedrock, Canyon, Ecotone, Fjord, Granite, Holocene, Isthmus, Jovian, Regolith, V1,
 };
 
 impl Index<BaseUpgrade> for BaseChainUpgrades {
@@ -88,7 +88,7 @@ impl Index<BaseUpgrade> for BaseChainUpgrades {
         match hf {
             // ... existing arms ...
             Jovian  => &self.forks[Jovian.idx()].1,
-            BaseV1  => &self.forks[BaseV1.idx()].1,  // <-- add
+            V1      => &self.forks[V1.idx()].1,  // <-- add
         }
     }
 }
@@ -140,7 +140,7 @@ Add `is_X_active` and `is_first_X_block` after the previous upgrade's methods.
 
 There are two patterns depending on whether the new upgrade is **standalone** or **cascading**:
 
-**Standalone** (e.g. `pectra_blob_schedule`, `BaseV1`) — activated independently, never implied by a later upgrade being active. Use this pattern when the upgrade affects only protocol-level behavior and is not a prerequisite for the next upgrade:
+**Standalone** (e.g. `pectra_blob_schedule`, `V1`) — activated independently, never implied by a later upgrade being active. Use this pattern when the upgrade affects only protocol-level behavior and is not a prerequisite for the next upgrade:
 
 ```rust
 /// Returns true if Base V1 is active at the given timestamp.
@@ -180,7 +180,7 @@ BaseUpgrade::Jovian => self
     .jovian_time
     .map(ForkCondition::Timestamp)
     .unwrap_or(ForkCondition::Never),  // standalone: no cascade
-BaseUpgrade::BaseV1 => self
+BaseUpgrade::V1 => self
     .hardforks
     .base
     .as_ref()
@@ -199,9 +199,9 @@ For **cascading** upgrades, replace the previous arm's `unwrap_or(ForkCondition:
 **File:** [`crates/alloy/upgrades/src/hardforks.rs`](../../crates/alloy/upgrades/src/hardforks.rs)
 
 ```rust
-/// Returns `true` if [`BaseV1`](BaseUpgrade::BaseV1) is active at given block timestamp.
+/// Returns `true` if [`V1`](BaseUpgrade::V1) is active at given block timestamp.
 fn is_base_v1_active_at_timestamp(&self, timestamp: u64) -> bool {
-    self.upgrade_activation(BaseUpgrade::BaseV1).active_at_timestamp(timestamp)
+    self.upgrade_activation(BaseUpgrade::V1).active_at_timestamp(timestamp)
 }
 ```
 
@@ -265,12 +265,12 @@ hardforks: HardForkConfig {
 
 **File:** [`crates/consensus/registry/tests/hardfork_consistency.rs`](https://github.com/base/base/blob/main/crates/consensus/registry/tests/hardfork_consistency.rs)
 
-These tests assert that `BASE_MAINNET_CONFIG.upgrade_activation(fork)` matches `BaseChainUpgrades::base_mainnet().upgrade_activation(fork)` for every `BaseUpgrade` variant. They should pass without changes as long as both sides consistently return `ForkCondition::Never` for an unscheduled upgrade or the same timestamp once scheduled.
+These tests assert that `BASE_MAINNET_CONFIG.upgrade_activation(fork)` matches `BaseChainUpgrades::mainnet().upgrade_activation(fork)` for every `BaseUpgrade` variant. They should pass without changes as long as both sides consistently return `ForkCondition::Never` for an unscheduled upgrade or the same timestamp once scheduled.
 
 If there is a known discrepancy (e.g. the cascade causes a mismatch for an unset upgrade), add a skip with an explanatory comment as done for `Regolith`:
 
 ```rust
-if *fork == BaseUpgrade::BaseV1 {
+if *fork == BaseUpgrade::V1 {
     continue; // explanation of why the two sides differ
 }
 ```
@@ -304,7 +304,7 @@ Add the string name and wire up `FromStr` and `From<OpSpecId> for &'static str`:
 
 ```rust
 // name module
-pub const BASE_V1: &str = "BaseV1";
+pub const BASE_V1: &str = "V1";
 
 // FromStr
 name::BASE_V1 => Ok(Self::BASE_V1),
@@ -374,7 +374,7 @@ Append the new upgrade in `to_chain_hardforks()`. If it pairs with a new Ethereu
 ```rust
 // No paired Ethereum hardfork
 forks.push((BaseUpgrade::Jovian.boxed(), self[BaseUpgrade::Jovian]));
-forks.push((BaseUpgrade::BaseV1.boxed(), self[BaseUpgrade::BaseV1]));  // <-- add
+forks.push((BaseUpgrade::V1.boxed(), self[BaseUpgrade::V1]));  // <-- add
 ```
 
 ---


### PR DESCRIPTION
## Summary

Fixes two naming inconsistencies introduced in #1214. Renames `BaseUpgrade::BaseV1` to `BaseUpgrade::V1` to remove the redundant type prefix, and renames `BaseUpgrade::base_mainnet()` / `BaseChainUpgrades::base_mainnet()` to `mainnet()` to remove the redundant `base_` prefix already implied by the type names. All call sites, tests, and docs updated accordingly.

Closes #1230.