### PR TITLE
chore(workspace): Enforce Mod.rs Doc Comments

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,6 +10,8 @@ Do not add features to dependencies in the workspace root Cargo.toml. Features m
 
 All crates in the workspace should have a `base-` prefix in their crate name (e.g. `base-enclave`, `base-builder-core`).
 
+Every `mod.rs` file must begin with a `//!` module doc comment describing what the module contains.
+
 All `use` imports must be at the top of the file or the top of a `mod` block. Never place `use` statements inside function bodies or closures. Exception: conditional imports behind `#[cfg(...)]` may be scoped to the `cfg`-gated block (e.g., inside a `#[cfg(test)] mod tests`, `#[cfg(feature = "...")]` function, or similar) rather than hoisted to the top of the file. Another exception: `use` inside `macro_rules!` bodies is acceptable when the macro needs to import items in its expansion context.
 
 Use structured tracing instead of interpolated strings. Always use key=value fields for any dynamic data: `info!(block = %block_number, "processed block")` rather than `info!("processed block {block_number}")`. Use `%` for Display, `?` for Debug. The message string should be a static description; all variable data goes in fields. Correct: `error!(error = %e, peer = %peer_id, "connection failed")`. Incorrect: `error!("connection to {peer_id} failed: {e}")`.


### PR DESCRIPTION
## Summary

Broadens the existing CLAUDE.md convention to require a `//!` module doc comment at the top of all `mod.rs` files, not just new ones. This ensures agents and contributors add documentation to any `mod.rs` they create or modify.