### PR TITLE
feat(actions): Use Mainnet Rollup Config

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2314,6 +2314,7 @@ dependencies = [
  "base-comp",
  "base-consensus-derive",
  "base-consensus-genesis",
+ "base-consensus-registry",
  "base-execution-chainspec",
  "base-execution-evm",
  "base-protocol",

--- a/actions/harness/Cargo.toml
+++ b/actions/harness/Cargo.toml
@@ -37,3 +37,4 @@ base-batcher-driver.workspace = true
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["rt", "macros"] }
+base-consensus-registry.workspace = true

--- a/actions/harness/tests/batcher_channels.rs
+++ b/actions/harness/tests/batcher_channels.rs
@@ -4,7 +4,8 @@ use base_action_harness::{
     ActionL2Source, ActionTestHarness, BatcherConfig, ChannelDriverConfig, L1MinerConfig,
     SharedL1Chain, block_info_from,
 };
-use base_consensus_genesis::{ChainGenesis, HardForkConfig, RollupConfig, SystemConfig};
+use base_consensus_genesis::RollupConfig;
+use base_consensus_registry::Registry;
 
 // ---------------------------------------------------------------------------
 // Shared helpers
@@ -12,51 +13,39 @@ use base_consensus_genesis::{ChainGenesis, HardForkConfig, RollupConfig, SystemC
 
 /// Build a [`RollupConfig`] with tight `channel_timeout` for timeout tests.
 ///
+/// Starts from the real Base mainnet config. Overrides:
 /// - `channel_timeout = 2` so a channel whose first frame lands in L1 block N
 ///   expires if no more frames arrive by block N+2.
-/// - All other windows are generous so only the timeout matters.
+/// - Batcher actor fields, genesis, and hardfork times as in all test configs.
 fn timeout_rollup_config(batcher: &BatcherConfig) -> RollupConfig {
-    RollupConfig {
-        batch_inbox_address: batcher.inbox_address,
-        block_time: 2,
-        max_sequencer_drift: 600,
-        seq_window_size: 3600,
-        channel_timeout: 2,
-        genesis: ChainGenesis {
-            system_config: Some(SystemConfig {
-                batcher_address: batcher.batcher_address,
-                gas_limit: 30_000_000,
-                ..Default::default()
-            }),
-            ..Default::default()
-        },
-        hardforks: HardForkConfig { fjord_time: Some(0), ..Default::default() },
-        ..Default::default()
-    }
+    let mut rc = base_rollup_config_for(batcher);
+    rc.channel_timeout = 2;
+    rc
 }
 
 /// Build a standard [`RollupConfig`] for interleaving tests.
 ///
-/// Uses generous windows; the test exercises the channel bank's ability to
-/// track multiple open channels rather than any timeout logic.
+/// Starts from the real Base mainnet config. Uses generous windows; the test
+/// exercises the channel bank's ability to track multiple open channels rather
+/// than any timeout logic.
 fn interleave_rollup_config(batcher: &BatcherConfig) -> RollupConfig {
-    RollupConfig {
-        batch_inbox_address: batcher.inbox_address,
-        block_time: 2,
-        max_sequencer_drift: 600,
-        seq_window_size: 3600,
-        channel_timeout: 300,
-        genesis: ChainGenesis {
-            system_config: Some(SystemConfig {
-                batcher_address: batcher.batcher_address,
-                gas_limit: 30_000_000,
-                ..Default::default()
-            }),
-            ..Default::default()
-        },
-        hardforks: HardForkConfig { fjord_time: Some(0), ..Default::default() },
-        ..Default::default()
-    }
+    base_rollup_config_for(batcher)
+}
+
+/// Base config for all channel tests: real Base mainnet config with test actor
+/// fields and hardfork times overridden for the in-memory L1 miner.
+fn base_rollup_config_for(batcher: &BatcherConfig) -> RollupConfig {
+    let mut rc = Registry::rollup_config(8453).expect("mainnet config").clone();
+    rc.batch_inbox_address = batcher.inbox_address;
+    rc.genesis.system_config.as_mut().unwrap().batcher_address = batcher.batcher_address;
+    rc.genesis.l2_time = 0;
+    rc.genesis.l1 = Default::default();
+    rc.genesis.l2 = Default::default();
+    rc.hardforks.canyon_time = Some(0);
+    rc.hardforks.delta_time = Some(0);
+    rc.hardforks.ecotone_time = Some(0);
+    rc.hardforks.fjord_time = Some(0);
+    rc
 }
 
 // ---------------------------------------------------------------------------

--- a/actions/harness/tests/batcher_sequencer_drift.rs
+++ b/actions/harness/tests/batcher_sequencer_drift.rs
@@ -4,7 +4,8 @@ use alloy_primitives::B256;
 use base_action_harness::{
     ActionL2Source, ActionTestHarness, BatcherConfig, L1MinerConfig, SharedL1Chain, block_info_from,
 };
-use base_consensus_genesis::{ChainGenesis, HardForkConfig, RollupConfig, SystemConfig};
+use base_consensus_genesis::RollupConfig;
+use base_consensus_registry::Registry;
 
 // ---------------------------------------------------------------------------
 // Shared helpers
@@ -12,28 +13,26 @@ use base_consensus_genesis::{ChainGenesis, HardForkConfig, RollupConfig, SystemC
 
 /// Build a [`RollupConfig`] with tight `max_sequencer_drift` for drift tests.
 ///
-/// - `block_time = 2` (L2 block interval)
-/// - `max_sequencer_drift = 8` (4 L2 blocks before drift is exceeded)
-/// - L1 `block_time = 4` (via [`L1MinerConfig`])
-/// - All other windows are generous so only drift matters.
+/// Starts from the real Base mainnet config. Overrides:
+/// - `max_sequencer_drift = 8` so drift is exceeded after 4 L2 blocks
+///   when pinned to a stale L1 origin with `block_time = 2`.
+/// - Batcher actor fields, genesis, and hardfork times as in all test configs.
+///
+/// L1 `block_time = 4` is controlled via [`L1MinerConfig`] at the call site.
 fn drift_rollup_config(batcher: &BatcherConfig) -> RollupConfig {
-    RollupConfig {
-        batch_inbox_address: batcher.inbox_address,
-        block_time: 2,
-        max_sequencer_drift: 8,
-        seq_window_size: 3600,
-        channel_timeout: 300,
-        genesis: ChainGenesis {
-            system_config: Some(SystemConfig {
-                batcher_address: batcher.batcher_address,
-                gas_limit: 30_000_000,
-                ..Default::default()
-            }),
-            ..Default::default()
-        },
-        hardforks: HardForkConfig { fjord_time: Some(0), ..Default::default() },
-        ..Default::default()
-    }
+    let mut rc = Registry::rollup_config(8453).expect("mainnet config").clone();
+    rc.batch_inbox_address = batcher.inbox_address;
+    rc.genesis.system_config.as_mut().unwrap().batcher_address = batcher.batcher_address;
+    rc.genesis.l2_time = 0;
+    rc.genesis.l1 = Default::default();
+    rc.genesis.l2 = Default::default();
+    rc.hardforks.canyon_time = Some(0);
+    rc.hardforks.delta_time = Some(0);
+    rc.hardforks.ecotone_time = Some(0);
+    rc.hardforks.fjord_time = Some(0);
+    // Tight drift: 4 L2 blocks (at block_time=2) before the boundary is crossed.
+    rc.max_sequencer_drift = 8;
+    rc
 }
 
 // ---------------------------------------------------------------------------

--- a/actions/harness/tests/derivation.rs
+++ b/actions/harness/tests/derivation.rs
@@ -11,43 +11,37 @@ use base_action_harness::{
 };
 use base_blobs::BlobEncoder;
 use base_consensus_genesis::{
-    CONFIG_UPDATE_EVENT_VERSION_0, CONFIG_UPDATE_TOPIC, ChainGenesis, HardForkConfig,
-    L1ChainConfig, RollupConfig, SystemConfig,
+    CONFIG_UPDATE_EVENT_VERSION_0, CONFIG_UPDATE_TOPIC, L1ChainConfig, RollupConfig,
 };
+use base_consensus_registry::Registry;
 use base_protocol::{
     BlockInfo, DEPOSIT_EVENT_ABI_HASH, DEPOSIT_EVENT_VERSION_0, DERIVATION_VERSION_0, L2BlockInfo,
 };
 
 /// Build a [`RollupConfig`] wired to the given [`BatcherConfig`].
 ///
-/// The config is minimal but sufficient for derivation tests:
-/// - `batch_inbox_address` matches the batcher's inbox so frames are picked up.
-/// - `genesis.system_config.batcher_address` matches the batcher's address so
-///   the pipeline's batcher-address filter accepts the L1 transactions.
-/// - `block_time = 2` so L2 timestamps advance.
-/// - `seq_window_size` and `channel_timeout` are generous so no windows expire.
+/// Starts from the real Base mainnet config and overrides only the fields that
+/// must differ for in-memory action tests:
+/// - `batch_inbox_address` and `batcher_address` wire the test actors.
+/// - `genesis` is zeroed so the in-memory L1 miner (which starts at ts=0) is
+///   the chain origin.
+/// - Canyon through Fjord are set to `Some(0)` so the batcher's brotli
+///   compression and span-batch encoding are accepted from genesis.
+/// - Hardforks after Fjord retain their mainnet timestamps, which are
+///   unreachable during tests (L1 miner starts at ts=0), making them
+///   effectively inactive without losing their real config values.
 fn rollup_config_for(batcher: &BatcherConfig) -> RollupConfig {
-    RollupConfig {
-        batch_inbox_address: batcher.inbox_address,
-        block_time: 2,
-        max_sequencer_drift: 600,
-        seq_window_size: 3600,
-        channel_timeout: 300,
-        genesis: ChainGenesis {
-            system_config: Some(SystemConfig {
-                batcher_address: batcher.batcher_address,
-                gas_limit: 30_000_000,
-                ..Default::default()
-            }),
-            ..Default::default()
-        },
-        // The batcher uses brotli compression which BatchReader only accepts
-        // when Fjord is active.  Setting fjord_time=0 also implicitly activates
-        // all earlier hardforks (canyon/delta/ecotone) via the cascading
-        // is_X_active checks, so no transition blocks are triggered.
-        hardforks: HardForkConfig { fjord_time: Some(0), ..Default::default() },
-        ..Default::default()
-    }
+    let mut rc = Registry::rollup_config(8453).expect("mainnet config").clone();
+    rc.batch_inbox_address = batcher.inbox_address;
+    rc.genesis.system_config.as_mut().unwrap().batcher_address = batcher.batcher_address;
+    rc.genesis.l2_time = 0;
+    rc.genesis.l1 = Default::default();
+    rc.genesis.l2 = Default::default();
+    rc.hardforks.canyon_time = Some(0);
+    rc.hardforks.delta_time = Some(0);
+    rc.hardforks.ecotone_time = Some(0);
+    rc.hardforks.fjord_time = Some(0);
+    rc
 }
 
 /// The derivation pipeline reads a single batcher frame from L1 and derives
@@ -400,23 +394,8 @@ async fn batch_accepted_at_last_seq_window_block() {
     const SEQ_WINDOW: u64 = 4;
 
     let batcher_cfg = BatcherConfig::default();
-    let rollup_cfg = RollupConfig {
-        batch_inbox_address: batcher_cfg.inbox_address,
-        block_time: 2,
-        max_sequencer_drift: 600,
-        seq_window_size: SEQ_WINDOW,
-        channel_timeout: 300,
-        genesis: ChainGenesis {
-            system_config: Some(SystemConfig {
-                batcher_address: batcher_cfg.batcher_address,
-                gas_limit: 30_000_000,
-                ..Default::default()
-            }),
-            ..Default::default()
-        },
-        hardforks: HardForkConfig { fjord_time: Some(0), ..Default::default() },
-        ..Default::default()
-    };
+    let mut rollup_cfg = rollup_config_for(&batcher_cfg);
+    rollup_cfg.seq_window_size = SEQ_WINDOW;
     let mut h = ActionTestHarness::new(L1MinerConfig::default(), rollup_cfg);
 
     // Build L2 block 1 referencing L1 genesis (epoch 0).
@@ -642,24 +621,8 @@ async fn batcher_key_rotation_accepts_new_batcher() {
     let batcher_b =
         BatcherConfig { batcher_address: Address::repeat_byte(0xBB), ..batcher_a.clone() };
 
-    let rollup_cfg = RollupConfig {
-        batch_inbox_address: batcher_a.inbox_address,
-        block_time: 2,
-        max_sequencer_drift: 600,
-        seq_window_size: 3600,
-        channel_timeout: 300,
-        l1_system_config_address: l1_sys_cfg_addr,
-        genesis: ChainGenesis {
-            system_config: Some(SystemConfig {
-                batcher_address: batcher_a.batcher_address,
-                gas_limit: 30_000_000,
-                ..Default::default()
-            }),
-            ..Default::default()
-        },
-        hardforks: HardForkConfig { fjord_time: Some(0), ..Default::default() },
-        ..Default::default()
-    };
+    let mut rollup_cfg = rollup_config_for(&batcher_a);
+    rollup_cfg.l1_system_config_address = l1_sys_cfg_addr;
     let mut h = ActionTestHarness::new(L1MinerConfig::default(), rollup_cfg.clone());
 
     // Build all L2 blocks (1, 2, and 3) upfront from the L1 genesis state.
@@ -806,23 +769,8 @@ async fn multi_l2_per_l1_epoch() {
 async fn batch_past_sequence_window_rejected() {
     const SEQ_WINDOW: u64 = 3;
     let batcher_cfg = BatcherConfig::default();
-    let rollup_cfg = RollupConfig {
-        batch_inbox_address: batcher_cfg.inbox_address,
-        block_time: 2,
-        max_sequencer_drift: 600,
-        seq_window_size: SEQ_WINDOW,
-        channel_timeout: 300,
-        genesis: ChainGenesis {
-            system_config: Some(SystemConfig {
-                batcher_address: batcher_cfg.batcher_address,
-                gas_limit: 30_000_000,
-                ..Default::default()
-            }),
-            ..Default::default()
-        },
-        hardforks: HardForkConfig { fjord_time: Some(0), ..Default::default() },
-        ..Default::default()
-    };
+    let mut rollup_cfg = rollup_config_for(&batcher_cfg);
+    rollup_cfg.seq_window_size = SEQ_WINDOW;
     let mut h = ActionTestHarness::new(L1MinerConfig::default(), rollup_cfg);
 
     // Build L2 block 1 (epoch 0).
@@ -1887,24 +1835,8 @@ async fn batcher_config_update_rolled_back_on_reorg() {
     let batcher_b =
         BatcherConfig { batcher_address: Address::repeat_byte(0xBB), ..batcher_a.clone() };
 
-    let rollup_cfg = RollupConfig {
-        batch_inbox_address: batcher_a.inbox_address,
-        block_time: 2,
-        max_sequencer_drift: 600,
-        seq_window_size: 3600,
-        channel_timeout: 300,
-        l1_system_config_address: l1_sys_cfg_addr,
-        genesis: ChainGenesis {
-            system_config: Some(SystemConfig {
-                batcher_address: batcher_a.batcher_address,
-                gas_limit: 30_000_000,
-                ..Default::default()
-            }),
-            ..Default::default()
-        },
-        hardforks: HardForkConfig { fjord_time: Some(0), ..Default::default() },
-        ..Default::default()
-    };
+    let mut rollup_cfg = rollup_config_for(&batcher_a);
+    rollup_cfg.l1_system_config_address = l1_sys_cfg_addr;
     let genesis_sys_cfg = rollup_cfg.genesis.system_config.unwrap_or_default();
     let mut h = ActionTestHarness::new(L1MinerConfig::default(), rollup_cfg.clone());
 

--- a/actions/harness/tests/hardfork_activation.rs
+++ b/actions/harness/tests/hardfork_activation.rs
@@ -1,0 +1,462 @@
+#![doc = "Action tests for hardfork activation gating and cascade semantics."]
+
+use base_action_harness::{
+    ActionL2Source, ActionTestHarness, BatchType, BatcherConfig, L1MinerConfig, SharedL1Chain,
+    block_info_from,
+};
+use base_consensus_genesis::{HardForkConfig, RollupConfig};
+use base_consensus_registry::Registry;
+
+// ---------------------------------------------------------------------------
+// Section 1: Base mainnet config — hardfork boundary tests
+//
+// These tests use the real Base mainnet rollup config from the chain registry
+// and fast-forward through timestamps to verify that each fork activates at
+// exactly the right moment and that protocol parameters change as specified.
+//
+// No L2 blocks are built here. The hardfork activation functions act as a
+// virtual clock: querying is_X_active(timestamp ± 1) and the dynamic
+// parameter methods at the exact fork boundary is sufficient to verify
+// correct activation semantics.
+// ---------------------------------------------------------------------------
+
+/// Returns the Base mainnet [`RollupConfig`] from the chain registry.
+fn mainnet() -> &'static RollupConfig {
+    Registry::rollup_config(8453).expect("Base mainnet config must exist in the registry")
+}
+
+/// Every hardfork activates at its recorded mainnet timestamp and is inactive
+/// one second before that timestamp.
+///
+/// Timestamps are read from the config itself — no hardcoded magic numbers —
+/// so this test catches any future drift between the registry and the
+/// activation logic.
+#[test]
+fn each_hardfork_activates_at_its_mainnet_timestamp() {
+    let rc = mainnet();
+
+    let canyon_time = rc.hardforks.canyon_time.expect("canyon_time must be set on mainnet");
+    let delta_time = rc.hardforks.delta_time.expect("delta_time must be set on mainnet");
+    let ecotone_time = rc.hardforks.ecotone_time.expect("ecotone_time must be set on mainnet");
+    let fjord_time = rc.hardforks.fjord_time.expect("fjord_time must be set on mainnet");
+    let granite_time = rc.hardforks.granite_time.expect("granite_time must be set on mainnet");
+    let holocene_time = rc.hardforks.holocene_time.expect("holocene_time must be set on mainnet");
+    let isthmus_time = rc.hardforks.isthmus_time.expect("isthmus_time must be set on mainnet");
+    let jovian_time = rc.hardforks.jovian_time.expect("jovian_time must be set on mainnet");
+
+    // Canyon
+    assert!(!rc.is_canyon_active(canyon_time - 1), "Canyon must be inactive before its timestamp");
+    assert!(rc.is_canyon_active(canyon_time), "Canyon must be active at its timestamp");
+
+    // Delta: only Canyon is active at delta_time - 1 (Delta cascade doesn't reach backward).
+    assert!(rc.is_canyon_active(delta_time - 1), "Canyon must remain active before Delta");
+    assert!(!rc.is_delta_active(delta_time - 1), "Delta must be inactive before its timestamp");
+    assert!(rc.is_delta_active(delta_time), "Delta must be active at its timestamp");
+
+    // Ecotone
+    assert!(!rc.is_ecotone_active(ecotone_time - 1), "Ecotone must be inactive before its timestamp");
+    assert!(rc.is_ecotone_active(ecotone_time), "Ecotone must be active at its timestamp");
+
+    // Fjord
+    assert!(!rc.is_fjord_active(fjord_time - 1), "Fjord must be inactive before its timestamp");
+    assert!(rc.is_fjord_active(fjord_time), "Fjord must be active at its timestamp");
+
+    // Granite
+    assert!(!rc.is_granite_active(granite_time - 1), "Granite must be inactive before its timestamp");
+    assert!(rc.is_granite_active(granite_time), "Granite must be active at its timestamp");
+
+    // Holocene
+    assert!(!rc.is_holocene_active(holocene_time - 1), "Holocene must be inactive before its timestamp");
+    assert!(rc.is_holocene_active(holocene_time), "Holocene must be active at its timestamp");
+
+    // Isthmus
+    assert!(!rc.is_isthmus_active(isthmus_time - 1), "Isthmus must be inactive before its timestamp");
+    assert!(rc.is_isthmus_active(isthmus_time), "Isthmus must be active at its timestamp");
+
+    // Jovian
+    assert!(!rc.is_jovian_active(jovian_time - 1), "Jovian must be inactive before its timestamp");
+    assert!(rc.is_jovian_active(jovian_time), "Jovian must be active at its timestamp");
+}
+
+/// Hardfork timestamps on Base mainnet are strictly increasing. This guarantees
+/// that no two forks activate simultaneously — each fork's `is_X_active` check
+/// trips at a different second, so there is never a spurious simultaneous cascade.
+#[test]
+fn mainnet_hardfork_timestamps_are_strictly_ordered() {
+    let h = &mainnet().hardforks;
+
+    let ordered: &[(&str, u64)] = &[
+        ("canyon", h.canyon_time.expect("canyon_time")),
+        ("delta", h.delta_time.expect("delta_time")),
+        ("ecotone", h.ecotone_time.expect("ecotone_time")),
+        ("fjord", h.fjord_time.expect("fjord_time")),
+        ("granite", h.granite_time.expect("granite_time")),
+        ("holocene", h.holocene_time.expect("holocene_time")),
+        ("isthmus", h.isthmus_time.expect("isthmus_time")),
+        ("jovian", h.jovian_time.expect("jovian_time")),
+    ];
+
+    for pair in ordered.windows(2) {
+        let (name_a, ts_a) = pair[0];
+        let (name_b, ts_b) = pair[1];
+        assert!(
+            ts_a < ts_b,
+            "{name_a} ({ts_a}) must activate strictly before {name_b} ({ts_b})"
+        );
+    }
+}
+
+/// Activating a later fork implies all earlier forks via the cascade chain.
+/// At each fork's exact timestamp, all preceding forks are already active,
+/// and all later forks are not yet active.
+#[test]
+fn cascade_implies_all_preceding_forks_and_no_later_forks() {
+    let rc = mainnet();
+
+    let delta_time = rc.hardforks.delta_time.expect("delta_time");
+    let fjord_time = rc.hardforks.fjord_time.expect("fjord_time");
+    let granite_time = rc.hardforks.granite_time.expect("granite_time");
+    let jovian_time = rc.hardforks.jovian_time.expect("jovian_time");
+
+    // At delta_time: Canyon is implied; Ecotone and later are not yet active.
+    assert!(rc.is_canyon_active(delta_time), "Canyon must be implied at Delta");
+    assert!(rc.is_delta_active(delta_time));
+    assert!(!rc.is_ecotone_active(delta_time), "Ecotone must not be implied by Delta");
+
+    // At fjord_time: Canyon through Fjord are implied; Granite and later are not.
+    assert!(rc.is_canyon_active(fjord_time));
+    assert!(rc.is_delta_active(fjord_time));
+    assert!(rc.is_ecotone_active(fjord_time));
+    assert!(rc.is_fjord_active(fjord_time));
+    assert!(!rc.is_granite_active(fjord_time), "Granite must not be implied by Fjord");
+
+    // At granite_time: Canyon through Granite are implied; Holocene and later are not.
+    assert!(rc.is_fjord_active(granite_time));
+    assert!(rc.is_granite_active(granite_time));
+    assert!(!rc.is_holocene_active(granite_time), "Holocene must not be implied by Granite");
+
+    // At jovian_time: all OP hardforks are implied.
+    assert!(rc.is_canyon_active(jovian_time));
+    assert!(rc.is_delta_active(jovian_time));
+    assert!(rc.is_ecotone_active(jovian_time));
+    assert!(rc.is_fjord_active(jovian_time));
+    assert!(rc.is_granite_active(jovian_time));
+    assert!(rc.is_holocene_active(jovian_time));
+    assert!(rc.is_isthmus_active(jovian_time));
+    assert!(rc.is_jovian_active(jovian_time));
+
+    // BaseV1 is a standalone Base-specific fork; Jovian does NOT imply it.
+    assert!(!rc.is_base_v1_active(jovian_time), "BaseV1 must not be implied by Jovian");
+    // And setting only BaseV1 does not imply Jovian (tested in base_v1_is_standalone).
+}
+
+/// Fjord changes `max_sequencer_drift` from the per-chain configured value
+/// to the protocol-defined constant 1800. The transition is sharp: one second
+/// before Fjord the configured value applies; at Fjord the constant applies.
+#[test]
+fn fjord_changes_max_sequencer_drift_at_mainnet_timestamp() {
+    let rc = mainnet();
+    let fjord_time = rc.hardforks.fjord_time.expect("fjord_time");
+
+    // One second before Fjord: the rollup config field is used.
+    assert_eq!(
+        rc.max_sequencer_drift(fjord_time - 1),
+        rc.max_sequencer_drift,
+        "max_sequencer_drift must use the config field before Fjord"
+    );
+
+    // At Fjord activation: protocol constant 1800 (FJORD_MAX_SEQUENCER_DRIFT) overrides.
+    assert_eq!(
+        rc.max_sequencer_drift(fjord_time),
+        1800,
+        "max_sequencer_drift must be 1800 at Fjord activation"
+    );
+    assert_eq!(
+        rc.max_sequencer_drift(fjord_time + 1),
+        1800,
+        "max_sequencer_drift must remain 1800 after Fjord"
+    );
+}
+
+/// Granite changes `channel_timeout` from the per-chain configured value to
+/// `granite_channel_timeout`. The transition is sharp at the exact fork second.
+#[test]
+fn granite_changes_channel_timeout_at_mainnet_timestamp() {
+    let rc = mainnet();
+    let granite_time = rc.hardforks.granite_time.expect("granite_time");
+
+    // One second before Granite: the base channel_timeout field is used.
+    assert_eq!(
+        rc.channel_timeout(granite_time - 1),
+        rc.channel_timeout,
+        "channel_timeout must use the config field before Granite"
+    );
+
+    // At Granite activation: granite_channel_timeout overrides.
+    assert_eq!(
+        rc.channel_timeout(granite_time),
+        rc.granite_channel_timeout,
+        "channel_timeout must use granite_channel_timeout at Granite activation"
+    );
+    assert_eq!(
+        rc.channel_timeout(granite_time + 1),
+        rc.granite_channel_timeout,
+        "channel_timeout must remain at granite_channel_timeout after Granite"
+    );
+}
+
+/// `BaseV1` is a standalone Base-specific hardfork. It is not part of the OP
+/// cascade chain: Jovian does not imply it, and it does not imply Jovian.
+#[test]
+fn base_v1_is_standalone_from_jovian() {
+    let rc = mainnet();
+    let jovian_time = rc.hardforks.jovian_time.expect("jovian_time");
+
+    // On mainnet BaseV1 is not yet scheduled, so it's inactive at all times.
+    assert!(!rc.is_base_v1_active(jovian_time), "BaseV1 must not be implied by Jovian");
+    assert!(!rc.is_base_v1_active(u64::MAX), "BaseV1 must remain inactive when unscheduled");
+}
+
+// ---------------------------------------------------------------------------
+// Section 2: Derivation tests — pipeline behaviour at hardfork boundaries
+//
+// These tests exercise the full derivation pipeline with synthetic rollup
+// configs. A synthetic config is necessary because the L1 miner starts at
+// timestamp 0: using real mainnet timestamps (e.g. delta_time ≈ 1.7 × 10⁹)
+// would require an unreachable number of L1 blocks. The synthetic configs use
+// the same code paths and enforce the same protocol rules.
+//
+// All derivation tests require Fjord active (fjord_time = Some(0)) because
+// the batcher always uses brotli compression, which the verifier's BatchReader
+// rejects when Fjord is not active. Setting fjord_time = Some(0) activates
+// the full cascade from Canyon through Fjord, so Delta is also active.
+//
+// When testing a hardfork boundary at a specific timestamp T, all forks
+// *earlier* than that fork are set to Some(0) so they are active from
+// genesis and do not activate again at T. Only the fork under test
+// activates at T, keeping the upgrade-transaction injection isolated.
+// ---------------------------------------------------------------------------
+
+/// Build a [`RollupConfig`] wired to the given [`BatcherConfig`] and [`HardForkConfig`].
+///
+/// Starts from the real Base mainnet config and replaces the hardfork schedule
+/// with the caller-supplied `hardforks`. This lets derivation tests set exact
+/// hardfork timestamps without spurious cascade activations from unlisted forks.
+fn rollup_config_for(batcher: &BatcherConfig, hardforks: HardForkConfig) -> RollupConfig {
+    let mut rc = Registry::rollup_config(8453).expect("mainnet config").clone();
+    rc.batch_inbox_address = batcher.inbox_address;
+    rc.genesis.system_config.as_mut().unwrap().batcher_address = batcher.batcher_address;
+    rc.genesis.l2_time = 0;
+    rc.genesis.l1 = Default::default();
+    rc.genesis.l2 = Default::default();
+    rc.hardforks = hardforks;
+    rc
+}
+
+/// With only Canyon active (Delta NOT active, Fjord NOT active), a span batch
+/// submitted by the batcher must NOT be derived.
+///
+/// Two protocol gates combine to prevent derivation:
+/// 1. The batcher uses brotli compression; `BatchReader` rejects brotli before Fjord.
+/// 2. Even without the compression gate, `SpanBatch` validation drops the batch
+///    when Delta is not active at the batch L1 origin (`SpanBatchPreDelta`).
+///
+/// The net result: zero L2 blocks derived, pipeline returns `Ok(0)`.
+#[tokio::test]
+async fn span_batch_rejected_before_delta() {
+    let batcher_cfg = BatcherConfig::default();
+    let hardforks = HardForkConfig { canyon_time: Some(0), ..Default::default() };
+    let rollup_cfg = rollup_config_for(&batcher_cfg, hardforks);
+    let mut h = ActionTestHarness::new(L1MinerConfig::default(), rollup_cfg);
+
+    let l1_chain = SharedL1Chain::from_blocks(h.l1.chain().to_vec());
+    let mut builder = h.create_l2_sequencer(l1_chain);
+    let mut source = ActionL2Source::new();
+    source.push(builder.build_next_block().expect("build L2 block 1"));
+    source.push(builder.build_next_block().expect("build L2 block 2"));
+
+    let span_cfg = BatcherConfig { batch_type: BatchType::Span, ..batcher_cfg.clone() };
+    let mut batcher = h.create_batcher(source, span_cfg);
+    batcher.advance().expect("batcher should encode span batch");
+    drop(batcher);
+
+    h.l1.mine_block();
+
+    let (mut verifier, _chain) = h.create_verifier();
+    verifier.initialize().await.expect("initialize");
+    verifier.act_l1_head_signal(block_info_from(h.l1.tip())).await.expect("signal");
+    verifier.act_l2_pipeline_full().await.expect("pipeline");
+
+    assert_eq!(
+        verifier.l2_safe().block_info.number,
+        0,
+        "no blocks should be derived: span batch rejected pre-Delta/Fjord"
+    );
+}
+
+/// With Fjord active from genesis (which cascades to activate Ecotone, Delta,
+/// Canyon, and Regolith), a span batch derives successfully.
+///
+/// Fjord is required for two reasons: it activates Delta (via cascade), and
+/// the batcher's brotli compression is only accepted by the verifier at Fjord.
+#[tokio::test]
+async fn span_batch_derives_after_delta() {
+    let batcher_cfg = BatcherConfig::default();
+    let hardforks = HardForkConfig { fjord_time: Some(0), ..Default::default() };
+    let rollup_cfg = rollup_config_for(&batcher_cfg, hardforks);
+    let mut h = ActionTestHarness::new(L1MinerConfig::default(), rollup_cfg);
+
+    let l1_chain = SharedL1Chain::from_blocks(h.l1.chain().to_vec());
+    let mut builder = h.create_l2_sequencer(l1_chain);
+
+    let mut block_hashes = Vec::new();
+    let mut source = ActionL2Source::new();
+    source.push(builder.build_next_block().expect("build L2 block 1"));
+    block_hashes.push((builder.head().block_info.number, builder.head().block_info.hash));
+    source.push(builder.build_next_block().expect("build L2 block 2"));
+    block_hashes.push((builder.head().block_info.number, builder.head().block_info.hash));
+
+    let span_cfg = BatcherConfig { batch_type: BatchType::Span, ..batcher_cfg.clone() };
+    let mut batcher = h.create_batcher(source, span_cfg);
+    batcher.advance().expect("batcher encode span batch");
+    drop(batcher);
+
+    h.l1.mine_block();
+
+    let (mut verifier, _chain) = h.create_verifier();
+    for (number, hash) in &block_hashes {
+        verifier.register_block_hash(*number, *hash);
+    }
+    verifier.initialize().await.expect("initialize");
+    verifier.act_l1_head_signal(block_info_from(h.l1.tip())).await.expect("signal");
+    let derived = verifier.act_l2_pipeline_full().await.expect("pipeline");
+
+    assert_eq!(derived, 2, "expected 2 L2 blocks derived from span batch");
+    assert_eq!(verifier.l2_safe().block_info.number, 2, "safe head should advance to block 2");
+}
+
+/// Control test: with Fjord active, `SingleBatch` (the default encoding) derives
+/// one L2 block per L1 block, regardless of span batch gating.
+#[tokio::test]
+async fn single_batch_derives_with_fjord() {
+    let batcher_cfg = BatcherConfig::default();
+    let hardforks = HardForkConfig { fjord_time: Some(0), ..Default::default() };
+    let rollup_cfg = rollup_config_for(&batcher_cfg, hardforks);
+    let mut h = ActionTestHarness::new(L1MinerConfig::default(), rollup_cfg);
+
+    let l1_chain = SharedL1Chain::from_blocks(h.l1.chain().to_vec());
+    let mut builder = h.create_l2_sequencer(l1_chain);
+
+    let mut block_hashes = Vec::new();
+    for _ in 0..2 {
+        let mut source = ActionL2Source::new();
+        source.push(builder.build_next_block().expect("build L2 block"));
+        let head = builder.head();
+        block_hashes.push((head.block_info.number, head.block_info.hash));
+
+        let mut batcher = h.create_batcher(source, batcher_cfg.clone());
+        batcher.advance().expect("batcher advance");
+        drop(batcher);
+        h.l1.mine_block();
+    }
+
+    let (mut verifier, _chain) = h.create_verifier();
+    for (number, hash) in &block_hashes {
+        verifier.register_block_hash(*number, *hash);
+    }
+    verifier.initialize().await.expect("initialize");
+
+    for i in 1..=2u64 {
+        let l1_block = block_info_from(h.l1.block_by_number(i).expect("block exists"));
+        verifier.act_l1_head_signal(l1_block).await.expect("signal");
+        let derived = verifier.act_l2_pipeline_full().await.expect("pipeline");
+        assert_eq!(derived, 1, "L1 block {i} should derive exactly one L2 block");
+    }
+
+    assert_eq!(
+        verifier.l2_safe().block_info.number,
+        2,
+        "safe head should advance to block 2"
+    );
+}
+
+/// Derivation must succeed across the Jovian activation boundary.
+///
+/// Configuration: all forks from Canyon through Isthmus are active from
+/// genesis (`Some(0)`). Jovian activates at ts=6 (L2 block 3 with `block_time=2`).
+/// Because each preceding fork is already active at genesis, the
+/// `is_first_X_block` check returns false for all of them at ts=6 — only
+/// `is_first_jovian_block` returns true. This isolates the upgrade-transaction
+/// injection to Jovian alone, with no simultaneous cascade activations.
+///
+/// The first Jovian block (block 3) must be empty (no user transactions).
+/// The batch validator enforces `NonEmptyTransitionBlock`: any batch containing
+/// user transactions in the upgrade block is dropped, because the derivation
+/// pipeline prepends the Jovian upgrade deposit transactions to that block's
+/// attribute set.
+#[tokio::test]
+async fn jovian_derivation_crosses_activation_boundary() {
+    let batcher_cfg = BatcherConfig::default();
+
+    // All forks through Isthmus active from genesis so that at ts=6 only
+    // Jovian is "new". With block_time=2 and L2 genesis at ts=0:
+    //   block 1 → ts=2  (pre-Jovian, user txs ok)
+    //   block 2 → ts=4  (pre-Jovian, user txs ok)
+    //   block 3 → ts=6  (first Jovian block — must be empty)
+    //   block 4 → ts=8  (post-Jovian, user txs ok)
+    let jovian_time = 6u64;
+    let hardforks = HardForkConfig {
+        canyon_time: Some(0),
+        delta_time: Some(0),
+        ecotone_time: Some(0),
+        fjord_time: Some(0),
+        granite_time: Some(0),
+        holocene_time: Some(0),
+        isthmus_time: Some(0),
+        jovian_time: Some(jovian_time),
+        ..Default::default()
+    };
+    let rollup_cfg = rollup_config_for(&batcher_cfg, hardforks);
+    let mut h = ActionTestHarness::new(L1MinerConfig::default(), rollup_cfg);
+
+    let l1_chain = SharedL1Chain::from_blocks(h.l1.chain().to_vec());
+    let mut builder = h.create_l2_sequencer(l1_chain);
+
+    let mut block_hashes = Vec::new();
+    for i in 1..=4u64 {
+        let mut source = ActionL2Source::new();
+        let block = if i == 3 {
+            // First Jovian block: must contain no user transactions.
+            builder.build_empty_block().expect("build empty Jovian transition block")
+        } else {
+            builder.build_next_block().expect("build L2 block")
+        };
+        source.push(block);
+        let head = builder.head();
+        block_hashes.push((head.block_info.number, head.block_info.hash));
+
+        let mut batcher = h.create_batcher(source, batcher_cfg.clone());
+        batcher.advance().expect("batcher encode");
+        drop(batcher);
+        h.l1.mine_block();
+    }
+
+    let (mut verifier, _chain) = h.create_verifier();
+    for (number, hash) in &block_hashes {
+        verifier.register_block_hash(*number, *hash);
+    }
+    verifier.initialize().await.expect("initialize");
+
+    for i in 1..=4u64 {
+        let l1_block = block_info_from(h.l1.block_by_number(i).expect("block exists"));
+        verifier.act_l1_head_signal(l1_block).await.expect("signal");
+        let derived = verifier.act_l2_pipeline_full().await.expect("pipeline");
+        assert_eq!(derived, 1, "L1 block {i} should derive exactly one L2 block");
+    }
+
+    assert_eq!(
+        verifier.l2_safe().block_info.number,
+        4,
+        "safe head should advance past the Jovian activation boundary"
+    );
+}

--- a/actions/harness/tests/hardfork_activation.rs
+++ b/actions/harness/tests/hardfork_activation.rs
@@ -54,7 +54,10 @@ fn each_hardfork_activates_at_its_mainnet_timestamp() {
     assert!(rc.is_delta_active(delta_time), "Delta must be active at its timestamp");
 
     // Ecotone
-    assert!(!rc.is_ecotone_active(ecotone_time - 1), "Ecotone must be inactive before its timestamp");
+    assert!(
+        !rc.is_ecotone_active(ecotone_time - 1),
+        "Ecotone must be inactive before its timestamp"
+    );
     assert!(rc.is_ecotone_active(ecotone_time), "Ecotone must be active at its timestamp");
 
     // Fjord
@@ -62,15 +65,24 @@ fn each_hardfork_activates_at_its_mainnet_timestamp() {
     assert!(rc.is_fjord_active(fjord_time), "Fjord must be active at its timestamp");
 
     // Granite
-    assert!(!rc.is_granite_active(granite_time - 1), "Granite must be inactive before its timestamp");
+    assert!(
+        !rc.is_granite_active(granite_time - 1),
+        "Granite must be inactive before its timestamp"
+    );
     assert!(rc.is_granite_active(granite_time), "Granite must be active at its timestamp");
 
     // Holocene
-    assert!(!rc.is_holocene_active(holocene_time - 1), "Holocene must be inactive before its timestamp");
+    assert!(
+        !rc.is_holocene_active(holocene_time - 1),
+        "Holocene must be inactive before its timestamp"
+    );
     assert!(rc.is_holocene_active(holocene_time), "Holocene must be active at its timestamp");
 
     // Isthmus
-    assert!(!rc.is_isthmus_active(isthmus_time - 1), "Isthmus must be inactive before its timestamp");
+    assert!(
+        !rc.is_isthmus_active(isthmus_time - 1),
+        "Isthmus must be inactive before its timestamp"
+    );
     assert!(rc.is_isthmus_active(isthmus_time), "Isthmus must be active at its timestamp");
 
     // Jovian
@@ -99,10 +111,7 @@ fn mainnet_hardfork_timestamps_are_strictly_ordered() {
     for pair in ordered.windows(2) {
         let (name_a, ts_a) = pair[0];
         let (name_b, ts_b) = pair[1];
-        assert!(
-            ts_a < ts_b,
-            "{name_a} ({ts_a}) must activate strictly before {name_b} ({ts_b})"
-        );
+        assert!(ts_a < ts_b, "{name_a} ({ts_a}) must activate strictly before {name_b} ({ts_b})");
     }
 }
 
@@ -373,11 +382,7 @@ async fn single_batch_derives_with_fjord() {
         assert_eq!(derived, 1, "L1 block {i} should derive exactly one L2 block");
     }
 
-    assert_eq!(
-        verifier.l2_safe().block_info.number,
-        2,
-        "safe head should advance to block 2"
-    );
+    assert_eq!(verifier.l2_safe().block_info.number, 2, "safe head should advance to block 2");
 }
 
 /// Derivation must succeed across the Jovian activation boundary.


### PR DESCRIPTION
## Summary

Refactors all action test helpers in the harness to start from the real Base mainnet rollup config (`Registry::rollup_config(8453)`) rather than building synthetic `RollupConfig` structs from scratch. Each helper clones the registry config and overrides only the fields that must differ for in-memory tests: the batcher actor addresses, the genesis block references (zeroed so the in-memory L1 miner at ts=0 is the chain origin), and hardfork timestamps (Canyon through Fjord set to `Some(0)` so brotli compression and span-batch encoding are accepted from genesis; later forks retain their real mainnet timestamps, which are unreachable during tests). Test-specific overrides such as tight `channel_timeout`, tight `max_sequencer_drift`, custom `seq_window_size`, and custom `l1_system_config_address` are applied as field mutations on top of the base config. This eliminates synthetic config drift and ensures all tests exercise the real protocol parameters.