### PR TITLE
feat(health): add shared base-health crate and wire healthz into nitro prover

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3740,6 +3740,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "base-health"
+version = "0.0.0"
+dependencies = [
+ "async-trait",
+ "jsonrpsee",
+ "serde",
+]
+
+[[package]]
 name = "base-jwt"
 version = "0.0.0"
 dependencies = [
@@ -4218,6 +4227,7 @@ dependencies = [
  "aws-nitro-enclaves-cose",
  "aws-nitro-enclaves-nsm-api",
  "base-alloy-evm",
+ "base-health",
  "base-proof-client",
  "base-proof-host",
  "base-proof-preimage",
@@ -4237,6 +4247,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tokio-vsock",
+ "tower",
  "tracing",
  "x509-cert",
  "zip",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -245,6 +245,7 @@ base-comp = { path = "crates/batcher/comp", default-features = false }
 
 # Utilities
 base-jwt = { path = "crates/utilities/jwt" }
+base-health = { path = "crates/utilities/health" }
 base-cli-utils = { path = "crates/utilities/cli" }
 base-test-utils = { path = "crates/utilities/test-utils" }
 base-tx-manager = { path = "crates/utilities/tx-manager" }

--- a/crates/proof/tee/nitro/Cargo.toml
+++ b/crates/proof/tee/nitro/Cargo.toml
@@ -15,7 +15,6 @@ workspace = true
 # Core
 base-alloy-evm.workspace = true
 base-proof-client.workspace = true
-tower = { workspace = true, optional = true }
 base-health = { workspace = true, optional = true }
 base-proof-host = { workspace = true, optional = true }
 base-proof-preimage = { workspace = true, features = ["serde"] }
@@ -57,6 +56,7 @@ thiserror.workspace = true
 tracing.workspace = true
 rand_08.workspace = true
 parking_lot.workspace = true
+tower = { workspace = true, optional = true }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 tokio-vsock.workspace = true

--- a/crates/proof/tee/nitro/Cargo.toml
+++ b/crates/proof/tee/nitro/Cargo.toml
@@ -15,11 +15,11 @@ workspace = true
 # Core
 base-alloy-evm.workspace = true
 base-proof-client.workspace = true
+tower = { workspace = true, optional = true }
 base-health = { workspace = true, optional = true }
 base-proof-host = { workspace = true, optional = true }
 base-proof-preimage = { workspace = true, features = ["serde"] }
 base-proof-primitives = { workspace = true, features = ["std", "serde"] }
-tower = { workspace = true, optional = true }
 jsonrpsee = { workspace = true, optional = true, features = ["server", "macros"] }
 
 # Alloy

--- a/crates/proof/tee/nitro/Cargo.toml
+++ b/crates/proof/tee/nitro/Cargo.toml
@@ -15,9 +15,11 @@ workspace = true
 # Core
 base-alloy-evm.workspace = true
 base-proof-client.workspace = true
+base-health = { workspace = true, optional = true }
 base-proof-host = { workspace = true, optional = true }
 base-proof-preimage = { workspace = true, features = ["serde"] }
 base-proof-primitives = { workspace = true, features = ["std", "serde"] }
+tower = { workspace = true, optional = true }
 jsonrpsee = { workspace = true, optional = true, features = ["server", "macros"] }
 
 # Alloy
@@ -67,8 +69,10 @@ tokio = { workspace = true, features = ["macros", "rt"] }
 [features]
 host = [
 	"base-proof-primitives/rpc-server",
+	"dep:base-health",
 	"dep:base-proof-host",
 	"dep:jsonrpsee",
+	"dep:tower",
 	"tokio/net",
 ]
 

--- a/crates/proof/tee/nitro/src/host/server.rs
+++ b/crates/proof/tee/nitro/src/host/server.rs
@@ -1,11 +1,12 @@
-use std::{fmt, net::SocketAddr, sync::Arc};
+use std::{fmt, net::SocketAddr, sync::Arc, time::Duration};
 
+use base_health::{HealthzApiServer, HealthzRpc};
 use base_proof_host::{ProverConfig, ProverService};
 use base_proof_primitives::{EnclaveApiServer, ProofRequest, ProofResult, ProverApiServer};
 use jsonrpsee::{
     RpcModule,
     core::{RpcResult, async_trait},
-    server::{Server, ServerHandle},
+    server::{Server, ServerHandle, middleware::http::ProxyGetRequestLayer},
 };
 use tracing::info;
 
@@ -36,13 +37,20 @@ impl NitroProverServer {
 
     /// Start the JSON-RPC HTTP server on the given address.
     pub async fn run(self, addr: SocketAddr) -> eyre::Result<ServerHandle> {
-        let server = Server::builder().build(addr).await?;
+        let middleware = tower::ServiceBuilder::new()
+            .layer(
+                ProxyGetRequestLayer::new([("/healthz", "healthz")])
+                    .expect("valid healthz proxy layer"),
+            )
+            .timeout(Duration::from_secs(2));
+        let server = Server::builder().set_http_middleware(middleware).build(addr).await?;
         let addr = server.local_addr()?;
         info!(addr = %addr, "nitro rpc server started");
 
         let mut module = RpcModule::new(());
         module.merge(NitroProverRpc { service: self.service }.into_rpc())?;
         module.merge(NitroSignerRpc { transport: self.transport }.into_rpc())?;
+        module.merge(HealthzRpc::new(env!("CARGO_PKG_VERSION")).into_rpc())?;
 
         Ok(server.start(module))
     }
@@ -111,6 +119,13 @@ mod tests {
         assert_eq!(result, expected);
         assert_eq!(result.len(), 65);
         assert_eq!(result[0], 0x04);
+    }
+
+    #[tokio::test]
+    async fn healthz_returns_version() {
+        let rpc = HealthzRpc::new(env!("CARGO_PKG_VERSION"));
+        let result = HealthzApiServer::healthz(&rpc).await.unwrap();
+        assert_eq!(result.version, env!("CARGO_PKG_VERSION"));
     }
 
     #[tokio::test]

--- a/crates/proof/tee/nitro/src/host/server.rs
+++ b/crates/proof/tee/nitro/src/host/server.rs
@@ -1,4 +1,4 @@
-use std::{fmt, net::SocketAddr, sync::Arc, time::Duration};
+use std::{fmt, net::SocketAddr, sync::Arc};
 
 use base_health::{HealthzApiServer, HealthzRpc};
 use base_proof_host::{ProverConfig, ProverService};

--- a/crates/proof/tee/nitro/src/host/server.rs
+++ b/crates/proof/tee/nitro/src/host/server.rs
@@ -38,8 +38,7 @@ impl NitroProverServer {
     /// Start the JSON-RPC HTTP server on the given address.
     pub async fn run(self, addr: SocketAddr) -> eyre::Result<ServerHandle> {
         let middleware = tower::ServiceBuilder::new()
-            .layer(ProxyGetRequestLayer::new([("/healthz", "healthz")])?)
-            .timeout(Duration::from_secs(2));
+            .layer(ProxyGetRequestLayer::new([("/healthz", "healthz")])?);
         let server = Server::builder().set_http_middleware(middleware).build(addr).await?;
         let addr = server.local_addr()?;
         info!(addr = %addr, "nitro rpc server started");

--- a/crates/proof/tee/nitro/src/host/server.rs
+++ b/crates/proof/tee/nitro/src/host/server.rs
@@ -38,10 +38,7 @@ impl NitroProverServer {
     /// Start the JSON-RPC HTTP server on the given address.
     pub async fn run(self, addr: SocketAddr) -> eyre::Result<ServerHandle> {
         let middleware = tower::ServiceBuilder::new()
-            .layer(
-                ProxyGetRequestLayer::new([("/healthz", "healthz")])
-                    .expect("valid healthz proxy layer"),
-            )
+            .layer(ProxyGetRequestLayer::new([("/healthz", "healthz")])?)
             .timeout(Duration::from_secs(2));
         let server = Server::builder().set_http_middleware(middleware).build(addr).await?;
         let addr = server.local_addr()?;

--- a/crates/utilities/health/Cargo.toml
+++ b/crates/utilities/health/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "base-health"
+description = "Shared health check RPC endpoint for JSON-RPC servers"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+
+[lints]
+workspace = true
+
+[dependencies]
+async-trait.workspace = true
+serde = { workspace = true, features = ["derive"] }
+jsonrpsee = { workspace = true, features = ["server", "macros"] }

--- a/crates/utilities/health/README.md
+++ b/crates/utilities/health/README.md
@@ -1,0 +1,23 @@
+# `base-health`
+
+Shared health check RPC endpoint for JSON-RPC servers.
+
+Provides a `HealthzApi` trait and `HealthzRpc` implementation that returns
+the crate version via a `healthz` JSON-RPC method. Designed to work with
+`jsonrpsee`'s `ProxyGetRequestLayer` to expose `GET /healthz` on the same
+port as the RPC server.
+
+## Usage
+
+```toml
+[dependencies]
+base-health = { git = "https://github.com/base/base" }
+```
+
+```rust,ignore
+use base_health::{HealthzApiServer, HealthzRpc};
+use jsonrpsee::RpcModule;
+
+let mut module = RpcModule::new(());
+module.merge(HealthzRpc.into_rpc())?;
+```

--- a/crates/utilities/health/README.md
+++ b/crates/utilities/health/README.md
@@ -19,5 +19,5 @@ use base_health::{HealthzApiServer, HealthzRpc};
 use jsonrpsee::RpcModule;
 
 let mut module = RpcModule::new(());
-module.merge(HealthzRpc.into_rpc())?;
+module.merge(HealthzRpc::new(env!("CARGO_PKG_VERSION")).into_rpc())?;
 ```

--- a/crates/utilities/health/src/lib.rs
+++ b/crates/utilities/health/src/lib.rs
@@ -1,0 +1,43 @@
+#![doc = include_str!("../README.md")]
+
+use async_trait::async_trait;
+use jsonrpsee::core::RpcResult;
+
+/// A healthcheck response for the RPC server.
+#[derive(Debug, Clone, serde::Deserialize, serde::Serialize)]
+pub struct HealthzResponse {
+    /// The application version.
+    pub version: String,
+}
+
+/// The healthz RPC API.
+#[jsonrpsee::proc_macros::rpc(server)]
+pub trait HealthzApi {
+    /// Returns the health status of the server.
+    #[method(name = "healthz")]
+    async fn healthz(&self) -> RpcResult<HealthzResponse>;
+}
+
+/// The healthz RPC server implementation.
+///
+/// Returns a [`HealthzResponse`] containing the version from the calling
+/// crate's `CARGO_PKG_VERSION` at compile time.
+#[derive(Debug, Clone)]
+pub struct HealthzRpc {
+    /// The version string to report.
+    pub version: &'static str,
+}
+
+impl HealthzRpc {
+    /// Create a new [`HealthzRpc`] with the given version.
+    pub const fn new(version: &'static str) -> Self {
+        Self { version }
+    }
+}
+
+#[async_trait]
+impl HealthzApiServer for HealthzRpc {
+    async fn healthz(&self) -> RpcResult<HealthzResponse> {
+        Ok(HealthzResponse { version: self.version.to_string() })
+    }
+}

--- a/crates/utilities/health/src/lib.rs
+++ b/crates/utilities/health/src/lib.rs
@@ -1,4 +1,11 @@
 #![doc = include_str!("../README.md")]
+#![doc(
+    html_logo_url = "https://avatars.githubusercontent.com/u/16627100?s=200&v=4",
+    html_favicon_url = "https://avatars.githubusercontent.com/u/16627100?s=200&v=4",
+    issue_tracker_base_url = "https://github.com/base/base/issues/"
+)]
+#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
+#![cfg_attr(not(test), warn(unused_crate_dependencies))]
 
 use async_trait::async_trait;
 use jsonrpsee::core::RpcResult;

--- a/crates/utilities/health/src/lib.rs
+++ b/crates/utilities/health/src/lib.rs
@@ -7,44 +7,5 @@
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
 
-use async_trait::async_trait;
-use jsonrpsee::core::RpcResult;
-
-/// A healthcheck response for the RPC server.
-#[derive(Debug, Clone, serde::Deserialize, serde::Serialize)]
-pub struct HealthzResponse {
-    /// The application version.
-    pub version: String,
-}
-
-/// The healthz RPC API.
-#[jsonrpsee::proc_macros::rpc(server)]
-pub trait HealthzApi {
-    /// Returns the health status of the server.
-    #[method(name = "healthz")]
-    async fn healthz(&self) -> RpcResult<HealthzResponse>;
-}
-
-/// The healthz RPC server implementation.
-///
-/// Returns a [`HealthzResponse`] containing the version from the calling
-/// crate's `CARGO_PKG_VERSION` at compile time.
-#[derive(Debug, Clone)]
-pub struct HealthzRpc {
-    /// The version string to report.
-    pub version: &'static str,
-}
-
-impl HealthzRpc {
-    /// Create a new [`HealthzRpc`] with the given version.
-    pub const fn new(version: &'static str) -> Self {
-        Self { version }
-    }
-}
-
-#[async_trait]
-impl HealthzApiServer for HealthzRpc {
-    async fn healthz(&self) -> RpcResult<HealthzResponse> {
-        Ok(HealthzResponse { version: self.version.to_string() })
-    }
-}
+mod rpc;
+pub use rpc::{HealthzApiServer, HealthzResponse, HealthzRpc};

--- a/crates/utilities/health/src/rpc.rs
+++ b/crates/utilities/health/src/rpc.rs
@@ -1,0 +1,40 @@
+//! Health check RPC trait, types, and default implementation.
+
+use async_trait::async_trait;
+use jsonrpsee::core::RpcResult;
+
+/// A healthcheck response for the RPC server.
+#[derive(Debug, Clone, serde::Deserialize, serde::Serialize)]
+pub struct HealthzResponse {
+    /// The application version.
+    pub version: String,
+}
+
+/// The healthz RPC API.
+#[jsonrpsee::proc_macros::rpc(server)]
+pub trait HealthzApi {
+    /// Returns the health status of the server.
+    #[method(name = "healthz")]
+    async fn healthz(&self) -> RpcResult<HealthzResponse>;
+}
+
+/// The healthz RPC server implementation.
+#[derive(Debug, Clone)]
+pub struct HealthzRpc {
+    /// The version string to report.
+    pub version: &'static str,
+}
+
+impl HealthzRpc {
+    /// Create a new [`HealthzRpc`] with the given version.
+    pub const fn new(version: &'static str) -> Self {
+        Self { version }
+    }
+}
+
+#[async_trait]
+impl HealthzApiServer for HealthzRpc {
+    async fn healthz(&self) -> RpcResult<HealthzResponse> {
+        Ok(HealthzResponse { version: self.version.to_string() })
+    }
+}


### PR DESCRIPTION
## Summary

- Introduces `base-health` (`crates/utilities/health`), a shared crate providing `HealthzApi` JSON-RPC trait, `HealthzResponse` type, and `HealthzRpc` implementation for reusable health check endpoints across jsonrpsee servers.
- Wires the nitro prover's jsonrpsee server to serve `GET /healthz` on the same RPC port via `ProxyGetRequestLayer`, using the shared `base-health` crate.
- `HealthzRpc` accepts a `version: &'static str` so each consumer reports its own `CARGO_PKG_VERSION` rather than the shared crate's version.

## Details

The health check returns HTTP 200 with the crate version, compatible with AWS ALB target group health checks and Kubernetes liveness probes (both only check HTTP status code).

This follows the existing pattern used by `base-consensus-rpc` (consensus node's `ProxyGetRequestLayer` + healthz RPC method), extracted into a shared crate to avoid duplication as more jsonrpsee servers need health endpoints.

## Test Plan

- `cargo check -p base-health` ✅
- `cargo check -p base-proof-tee-nitro --features host` ✅
- `cargo test -p base-proof-tee-nitro --features host -- healthz` ✅ (unit test verifies correct version is returned)