### PR TITLE
feat(CHAIN-3450): TEEProverRegistry contract bindings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4246,8 +4246,11 @@ dependencies = [
 name = "base-proof-tee-registrar"
 version = "0.0.0"
 dependencies = [
+ "alloy-contract",
  "alloy-primitives",
+ "alloy-provider",
  "alloy-signer-local",
+ "alloy-sol-types",
  "async-trait",
  "thiserror 2.0.18",
  "url",

--- a/crates/proof/tee/registrar/Cargo.toml
+++ b/crates/proof/tee/registrar/Cargo.toml
@@ -12,6 +12,9 @@ workspace = true
 
 [dependencies]
 # Alloy
+alloy-contract.workspace = true
+alloy-provider.workspace = true
+alloy-sol-types.workspace = true
 alloy-primitives.workspace = true
 alloy-signer-local.workspace = true
 

--- a/crates/proof/tee/registrar/src/error.rs
+++ b/crates/proof/tee/registrar/src/error.rs
@@ -25,6 +25,16 @@ pub enum RegistrarError {
     #[error("registry error")]
     Registry(#[source] Box<dyn std::error::Error + Send + Sync>),
 
+    /// An on-chain registry contract call failed.
+    #[error("registry call failed: {context}")]
+    RegistryCall {
+        /// Description of the call that failed (e.g. `"isValidSigner(0x1234…)"`).
+        context: String,
+        /// The underlying contract call error.
+        #[source]
+        source: Box<dyn std::error::Error + Send + Sync>,
+    },
+
     /// Transaction signing or submission failed.
     #[error("signing error")]
     Signing(#[source] Box<dyn std::error::Error + Send + Sync>),

--- a/crates/proof/tee/registrar/src/lib.rs
+++ b/crates/proof/tee/registrar/src/lib.rs
@@ -7,6 +7,9 @@ pub use config::{BoundlessConfig, RegistrarConfig, RemoteSignerConfig, SigningCo
 mod error;
 pub use error::{RegistrarError, Result};
 
+mod registry;
+pub use registry::RegistryChecker;
+
 mod traits;
 pub use traits::{AttestationProofProvider, InstanceDiscovery};
 

--- a/crates/proof/tee/registrar/src/lib.rs
+++ b/crates/proof/tee/registrar/src/lib.rs
@@ -8,7 +8,7 @@ mod error;
 pub use error::{RegistrarError, Result};
 
 mod registry;
-pub use registry::RegistryChecker;
+pub use registry::{RegistryClient, RegistryContractClient};
 
 mod traits;
 pub use traits::{AttestationProofProvider, InstanceDiscovery};

--- a/crates/proof/tee/registrar/src/registry.rs
+++ b/crates/proof/tee/registrar/src/registry.rs
@@ -1,8 +1,9 @@
-//! `TEEProverRegistry` contract bindings and registry checker.
+//! `TEEProverRegistry` contract bindings and registry client.
 
 use alloy_primitives::Address;
 use alloy_provider::RootProvider;
 use alloy_sol_types::sol;
+use async_trait::async_trait;
 use url::Url;
 
 use crate::{RegistrarError, Result};
@@ -29,32 +30,43 @@ sol! {
 }
 
 /// Reads registration state from the on-chain `TEEProverRegistry`.
-#[derive(Debug)]
-pub struct RegistryChecker {
-    contract: ITEEProverRegistry::ITEEProverRegistryInstance<RootProvider>,
-}
-
-impl RegistryChecker {
-    /// Creates a new checker for the given registry address and L1 RPC URL.
-    pub fn new(address: Address, l1_rpc_url: Url) -> Self {
-        let provider = RootProvider::new_http(l1_rpc_url);
-        let contract = ITEEProverRegistry::ITEEProverRegistryInstance::new(address, provider);
-        Self { contract }
-    }
-
+#[async_trait]
+pub trait RegistryClient: Send + Sync {
     /// Returns `true` if `signer` is currently registered on-chain.
-    pub async fn is_registered(&self, signer: Address) -> Result<bool> {
-        self.contract.isValidSigner(signer).call().await.map_err(|e| {
-            RegistrarError::Registry(format!("isValidSigner({signer}) failed: {e}").into())
-        })
-    }
+    async fn is_registered(&self, signer: Address) -> Result<bool>;
 
     /// Fetches the complete set of registered signer addresses in a single view call.
     ///
     /// The signer set is expected to be small (bounded by the prover ASG size, typically 4),
     /// so returning the full array in one call is appropriate. This assumption holds as long
     /// as the ASG is configured with a fixed, small instance count.
-    pub async fn get_registered_signers(&self) -> Result<Vec<Address>> {
+    async fn get_registered_signers(&self) -> Result<Vec<Address>>;
+}
+
+/// Concrete implementation of [`RegistryClient`] backed by Alloy's sol-generated contract bindings.
+#[derive(Debug)]
+pub struct RegistryContractClient {
+    contract: ITEEProverRegistry::ITEEProverRegistryInstance<RootProvider>,
+}
+
+impl RegistryContractClient {
+    /// Creates a new client for the given registry address and L1 RPC URL.
+    pub fn new(address: Address, l1_rpc_url: Url) -> Self {
+        let provider = RootProvider::new_http(l1_rpc_url);
+        let contract = ITEEProverRegistry::ITEEProverRegistryInstance::new(address, provider);
+        Self { contract }
+    }
+}
+
+#[async_trait]
+impl RegistryClient for RegistryContractClient {
+    async fn is_registered(&self, signer: Address) -> Result<bool> {
+        self.contract.isValidSigner(signer).call().await.map_err(|e| {
+            RegistrarError::Registry(format!("isValidSigner({signer}) failed: {e}").into())
+        })
+    }
+
+    async fn get_registered_signers(&self) -> Result<Vec<Address>> {
         self.contract.getRegisteredSigners().call().await.map_err(|e| {
             RegistrarError::Registry(format!("getRegisteredSigners() failed: {e}").into())
         })

--- a/crates/proof/tee/registrar/src/registry.rs
+++ b/crates/proof/tee/registrar/src/registry.rs
@@ -44,20 +44,20 @@ impl RegistryChecker {
 
     /// Returns `true` if `signer` is currently registered on-chain.
     pub async fn is_registered(&self, signer: Address) -> Result<bool> {
-        self.contract
-            .isValidSigner(signer)
-            .call()
-            .await
-            .map_err(|e| RegistrarError::Registry(Box::new(e)))
+        self.contract.isValidSigner(signer).call().await.map_err(|e| {
+            RegistrarError::Registry(format!("isValidSigner({signer}) failed: {e}").into())
+        })
     }
 
     /// Fetches the complete set of registered signer addresses in a single view call.
+    ///
+    /// The signer set is expected to be small (bounded by the prover ASG size, typically 4),
+    /// so returning the full array in one call is appropriate. This assumption holds as long
+    /// as the ASG is configured with a fixed, small instance count.
     pub async fn get_registered_signers(&self) -> Result<Vec<Address>> {
-        self.contract
-            .getRegisteredSigners()
-            .call()
-            .await
-            .map_err(|e| RegistrarError::Registry(Box::new(e)))
+        self.contract.getRegisteredSigners().call().await.map_err(|e| {
+            RegistrarError::Registry(format!("getRegisteredSigners() failed: {e}").into())
+        })
     }
 }
 

--- a/crates/proof/tee/registrar/src/registry.rs
+++ b/crates/proof/tee/registrar/src/registry.rs
@@ -1,0 +1,100 @@
+//! `TEEProverRegistry` contract bindings and registry checker.
+
+use alloy_primitives::Address;
+use alloy_provider::RootProvider;
+use alloy_sol_types::sol;
+use url::Url;
+
+use crate::{RegistrarError, Result};
+
+sol! {
+    /// `TEEProverRegistry` contract interface.
+    #[sol(rpc)]
+    interface ITEEProverRegistry {
+        /// Registers a signer using a ZK-proven AWS Nitro attestation.
+        function registerSigner(bytes calldata output, bytes calldata proofBytes) external;
+
+        /// Deregisters a signer.
+        function deregisterSigner(address signer) external;
+
+        /// Returns the PCR0 hash a signer was registered with, or `bytes32(0)` if not registered.
+        function signerPCR0(address signer) external view returns (bytes32);
+
+        /// Returns `true` if the signer is currently registered.
+        function isValidSigner(address signer) external view returns (bool);
+
+        /// Returns all currently registered signer addresses.
+        function getRegisteredSigners() external view returns (address[]);
+    }
+}
+
+/// Reads registration state from the on-chain `TEEProverRegistry`.
+#[derive(Debug)]
+pub struct RegistryChecker {
+    contract: ITEEProverRegistry::ITEEProverRegistryInstance<RootProvider>,
+}
+
+impl RegistryChecker {
+    /// Creates a new checker for the given registry address and L1 RPC URL.
+    pub fn new(address: Address, l1_rpc_url: Url) -> Self {
+        let provider = RootProvider::new_http(l1_rpc_url);
+        let contract = ITEEProverRegistry::ITEEProverRegistryInstance::new(address, provider);
+        Self { contract }
+    }
+
+    /// Returns `true` if `signer` is currently registered on-chain.
+    pub async fn is_registered(&self, signer: Address) -> Result<bool> {
+        self.contract
+            .isValidSigner(signer)
+            .call()
+            .await
+            .map_err(|e| RegistrarError::Registry(Box::new(e)))
+    }
+
+    /// Fetches the complete set of registered signer addresses in a single view call.
+    pub async fn get_registered_signers(&self) -> Result<Vec<Address>> {
+        self.contract
+            .getRegisteredSigners()
+            .call()
+            .await
+            .map_err(|e| RegistrarError::Registry(Box::new(e)))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloy_primitives::{Address, Bytes};
+    use alloy_sol_types::SolCall;
+
+    use super::*;
+
+    #[test]
+    fn register_signer_abi_encodes_correctly() {
+        let call = ITEEProverRegistry::registerSignerCall {
+            output: Bytes::new(),
+            proofBytes: Bytes::new(),
+        };
+        let encoded = call.abi_encode();
+        // 4 (selector) + 2×32 (offsets) + 2×32 (lengths) + 0 (data) = 132
+        assert_eq!(encoded.len(), 132);
+        assert_eq!(&encoded[..4], &ITEEProverRegistry::registerSignerCall::SELECTOR);
+    }
+
+    #[test]
+    fn deregister_signer_abi_encodes_correctly() {
+        let call = ITEEProverRegistry::deregisterSignerCall { signer: Address::ZERO };
+        let encoded = call.abi_encode();
+        // 4 (selector) + 32 (padded address) = 36
+        assert_eq!(encoded.len(), 36);
+        assert_eq!(&encoded[..4], &ITEEProverRegistry::deregisterSignerCall::SELECTOR);
+    }
+
+    #[test]
+    fn all_selectors_are_nonzero() {
+        assert_ne!(ITEEProverRegistry::registerSignerCall::SELECTOR, [0u8; 4]);
+        assert_ne!(ITEEProverRegistry::deregisterSignerCall::SELECTOR, [0u8; 4]);
+        assert_ne!(ITEEProverRegistry::signerPCR0Call::SELECTOR, [0u8; 4]);
+        assert_ne!(ITEEProverRegistry::isValidSignerCall::SELECTOR, [0u8; 4]);
+        assert_ne!(ITEEProverRegistry::getRegisteredSignersCall::SELECTOR, [0u8; 4]);
+    }
+}

--- a/crates/proof/tee/registrar/src/registry.rs
+++ b/crates/proof/tee/registrar/src/registry.rs
@@ -61,14 +61,18 @@ impl RegistryContractClient {
 #[async_trait]
 impl RegistryClient for RegistryContractClient {
     async fn is_registered(&self, signer: Address) -> Result<bool> {
-        self.contract.isValidSigner(signer).call().await.map_err(|e| {
-            RegistrarError::Registry(format!("isValidSigner({signer}) failed: {e}").into())
+        self.contract.isValidSigner(signer).call().await.map_err(|e| RegistrarError::RegistryCall {
+            context: format!("isValidSigner({signer})"),
+            source: Box::new(e),
         })
     }
 
     async fn get_registered_signers(&self) -> Result<Vec<Address>> {
         self.contract.getRegisteredSigners().call().await.map_err(|e| {
-            RegistrarError::Registry(format!("getRegisteredSigners() failed: {e}").into())
+            RegistrarError::RegistryCall {
+                context: "getRegisteredSigners()".into(),
+                source: Box::new(e),
+            }
         })
     }
 }


### PR DESCRIPTION
Adds `registry.rs` to `base-proof-tee-registrar` with `alloy::sol!` bindings for the `TEEProverRegistry` contract (`registerSigner`, `deregisterSigner`, `signerPCR0`, `isValidSigner`, `getRegisteredSigners`) and a `RegistryChecker` struct with `is_registered` and `get_registered_signers` methods for reading on-chain registration state. Unit tests cover ABI encoding and selector correctness for all five bindings.

Closes CHAIN-3450.
