### PR TITLE
feat(actions): Conditional Pipeline Stepping

### DIFF
--- a/actions/harness/src/lib.rs
+++ b/actions/harness/src/lib.rs
@@ -29,5 +29,5 @@ pub use providers::{
 };
 
 mod verifier;
-pub use verifier::{BlobVerifierPipeline, L2Verifier, VerifierError, VerifierPipeline};
 pub use base_consensus_derive::StepResult;
+pub use verifier::{BlobVerifierPipeline, L2Verifier, VerifierError, VerifierPipeline};

--- a/actions/harness/src/lib.rs
+++ b/actions/harness/src/lib.rs
@@ -30,3 +30,4 @@ pub use providers::{
 
 mod verifier;
 pub use verifier::{BlobVerifierPipeline, L2Verifier, VerifierError, VerifierPipeline};
+pub use base_consensus_derive::StepResult;

--- a/actions/harness/src/verifier.rs
+++ b/actions/harness/src/verifier.rs
@@ -374,6 +374,135 @@ impl<P: Pipeline + SignalReceiver + Debug + Send> L2Verifier<P> {
         Ok(derived)
     }
 
+    /// Execute exactly one derivation step and return the raw [`StepResult`].
+    ///
+    /// Unlike [`act_l2_pipeline_full`], this does **not** loop. The caller
+    /// decides whether and when to step again, making it possible to assert on
+    /// intermediate pipeline state between steps or to stop as soon as a
+    /// specific outcome is observed.
+    ///
+    /// When the step returns [`StepResult::PreparedAttributes`] the attributes
+    /// are consumed and applied to the safe head automatically, identical to
+    /// the behaviour inside [`act_l2_pipeline_full`].
+    ///
+    /// # Errors
+    ///
+    /// Returns [`VerifierError::Pipeline`] if the pipeline returns a critical
+    /// error. Transient results (`Eof`, `NotEnoughData`) are returned as-is so
+    /// the caller can decide how to handle them.
+    ///
+    /// [`act_l2_pipeline_full`]: L2Verifier::act_l2_pipeline_full
+    pub async fn act_l2_pipeline_step(&mut self) -> Result<StepResult, VerifierError> {
+        let result = self.pipeline.step(self.safe_head).await;
+        if matches!(result, StepResult::PreparedAttributes) {
+            if let Some(attrs) = self.pipeline.next() {
+                self.apply_attributes(attrs);
+            }
+        }
+        Ok(result)
+    }
+
+    /// Step the pipeline until `condition` returns `true` for a [`StepResult`],
+    /// or until the pipeline reaches EOF (goes idle), or until `max_steps` is
+    /// exhausted.
+    ///
+    /// This is the Rust equivalent of op-e2e's `ActL2EventsUntil`. It drives
+    /// the pipeline forward step-by-step and hands each raw [`StepResult`] to
+    /// the caller's predicate. Use it when a test needs to stop at a specific
+    /// derivation outcome without knowing in advance how many steps it takes to
+    /// get there.
+    ///
+    /// Attributes are consumed and applied automatically on each
+    /// [`StepResult::PreparedAttributes`] step, just as in
+    /// [`act_l2_pipeline_full`].
+    ///
+    /// Returns `(steps_taken, condition_met)`. `condition_met` is `false` when
+    /// the pipeline reached EOF or `max_steps` before the predicate fired.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`VerifierError::Pipeline`] on any non-transient pipeline error,
+    /// or when `NotEnoughData` is returned more than 1 000 consecutive times
+    /// without progress (indicating a stuck pipeline).
+    ///
+    /// # Example
+    ///
+    /// ```rust,ignore
+    /// // Drive the pipeline until the L1 origin advances past genesis.
+    /// let (steps, hit) = verifier
+    ///     .act_l2_pipeline_until(
+    ///         |r| matches!(r, StepResult::AdvancedOrigin),
+    ///         500,
+    ///     )
+    ///     .await?;
+    /// assert!(hit, "pipeline idled before advancing the L1 origin");
+    ///
+    /// // Drive until exactly one L2 block is derived, then inspect state.
+    /// let (_, hit) = verifier
+    ///     .act_l2_pipeline_until(
+    ///         |r| matches!(r, StepResult::PreparedAttributes),
+    ///         500,
+    ///     )
+    ///     .await?;
+    /// assert!(hit);
+    /// assert_eq!(verifier.l2_safe().block_info.number, 1);
+    /// ```
+    ///
+    /// [`act_l2_pipeline_full`]: L2Verifier::act_l2_pipeline_full
+    pub async fn act_l2_pipeline_until(
+        &mut self,
+        condition: impl Fn(&StepResult) -> bool,
+        max_steps: usize,
+    ) -> Result<(usize, bool), VerifierError> {
+        let mut steps = 0;
+        let mut no_progress = 0usize;
+        loop {
+            if steps >= max_steps {
+                return Ok((steps, false));
+            }
+            let result = self.pipeline.step(self.safe_head).await;
+            steps += 1;
+            if matches!(result, StepResult::PreparedAttributes) {
+                no_progress = 0;
+                if let Some(attrs) = self.pipeline.next() {
+                    self.apply_attributes(attrs);
+                }
+            }
+            if condition(&result) {
+                return Ok((steps, true));
+            }
+            match result {
+                StepResult::PreparedAttributes | StepResult::AdvancedOrigin => {
+                    no_progress = 0;
+                }
+                StepResult::StepFailed(err) => match err {
+                    PipelineErrorKind::Temporary(PipelineError::Eof) => {
+                        return Ok((steps, false));
+                    }
+                    PipelineErrorKind::Temporary(PipelineError::NotEnoughData) => {
+                        no_progress += 1;
+                        if no_progress > 1_000 {
+                            return Err(VerifierError::Pipeline(
+                                PipelineError::Provider(
+                                    "pipeline stuck: 1000 consecutive NotEnoughData without progress"
+                                        .into(),
+                                )
+                                .temp(),
+                            ));
+                        }
+                    }
+                    err => return Err(VerifierError::Pipeline(err)),
+                },
+                StepResult::OriginAdvanceErr(err) => match err {
+                    PipelineErrorKind::Temporary(PipelineError::Eof) => {
+                        return Ok((steps, false));
+                    }
+                    err => return Err(VerifierError::Pipeline(err)),
+                },
+            }
+        }
+    }
+
     /// Return the current L1 origin the pipeline is positioned at.
     pub fn l1_origin(&self) -> Option<BlockInfo> {
         self.pipeline.origin()

--- a/actions/harness/src/verifier.rs
+++ b/actions/harness/src/verifier.rs
@@ -394,12 +394,23 @@ impl<P: Pipeline + SignalReceiver + Debug + Send> L2Verifier<P> {
     /// [`act_l2_pipeline_full`]: L2Verifier::act_l2_pipeline_full
     pub async fn act_l2_pipeline_step(&mut self) -> Result<StepResult, VerifierError> {
         let result = self.pipeline.step(self.safe_head).await;
-        if matches!(result, StepResult::PreparedAttributes) {
-            if let Some(attrs) = self.pipeline.next() {
-                self.apply_attributes(attrs);
+        match result {
+            StepResult::PreparedAttributes => {
+                if let Some(attrs) = self.pipeline.next() {
+                    self.apply_attributes(attrs);
+                }
+                Ok(StepResult::PreparedAttributes)
             }
+            StepResult::AdvancedOrigin => Ok(StepResult::AdvancedOrigin),
+            StepResult::StepFailed(PipelineErrorKind::Temporary(e)) => {
+                Ok(StepResult::StepFailed(PipelineErrorKind::Temporary(e)))
+            }
+            StepResult::OriginAdvanceErr(PipelineErrorKind::Temporary(e)) => {
+                Ok(StepResult::OriginAdvanceErr(PipelineErrorKind::Temporary(e)))
+            }
+            StepResult::StepFailed(err) => Err(VerifierError::Pipeline(err)),
+            StepResult::OriginAdvanceErr(err) => Err(VerifierError::Pipeline(err)),
         }
-        Ok(result)
     }
 
     /// Step the pipeline until `condition` returns `true` for a [`StepResult`],
@@ -463,7 +474,6 @@ impl<P: Pipeline + SignalReceiver + Debug + Send> L2Verifier<P> {
             let result = self.pipeline.step(self.safe_head).await;
             steps += 1;
             if matches!(result, StepResult::PreparedAttributes) {
-                no_progress = 0;
                 if let Some(attrs) = self.pipeline.next() {
                     self.apply_attributes(attrs);
                 }

--- a/actions/harness/src/verifier.rs
+++ b/actions/harness/src/verifier.rs
@@ -408,8 +408,9 @@ impl<P: Pipeline + SignalReceiver + Debug + Send> L2Verifier<P> {
             StepResult::OriginAdvanceErr(PipelineErrorKind::Temporary(e)) => {
                 Ok(StepResult::OriginAdvanceErr(PipelineErrorKind::Temporary(e)))
             }
-            StepResult::StepFailed(err) => Err(VerifierError::Pipeline(err)),
-            StepResult::OriginAdvanceErr(err) => Err(VerifierError::Pipeline(err)),
+            StepResult::StepFailed(err) | StepResult::OriginAdvanceErr(err) => {
+                Err(VerifierError::Pipeline(err))
+            }
         }
     }
 
@@ -473,10 +474,10 @@ impl<P: Pipeline + SignalReceiver + Debug + Send> L2Verifier<P> {
             }
             let result = self.pipeline.step(self.safe_head).await;
             steps += 1;
-            if matches!(result, StepResult::PreparedAttributes) {
-                if let Some(attrs) = self.pipeline.next() {
-                    self.apply_attributes(attrs);
-                }
+            if matches!(result, StepResult::PreparedAttributes)
+                && let Some(attrs) = self.pipeline.next()
+            {
+                self.apply_attributes(attrs);
             }
             if condition(&result) {
                 return Ok((steps, true));

--- a/actions/harness/tests/derivation.rs
+++ b/actions/harness/tests/derivation.rs
@@ -7,7 +7,7 @@ use alloy_primitives::{Address, B256, Bytes, LogData, U256};
 use base_action_harness::{
     ActionDataSource, ActionL1ChainProvider, ActionL2ChainProvider, ActionL2Source,
     ActionTestHarness, BatchType, BatcherConfig, ChannelDriverConfig, GarbageKind, L1MinerConfig,
-    L2Sequencer, L2Verifier, PendingTx, SharedL1Chain, block_info_from,
+    L2Sequencer, L2Verifier, PendingTx, SharedL1Chain, StepResult, block_info_from,
 };
 use base_blobs::BlobEncoder;
 use base_consensus_genesis::{
@@ -2010,5 +2010,244 @@ async fn batcher_config_update_rolled_back_on_reorg() {
         verifier.l2_safe().block_info.number,
         3,
         "safe head advances to 3 — config rollback restored batcher A"
+    );
+}
+
+// ── act_l2_pipeline_until edge-case tests ─────────────────────────────────────
+
+/// Submit the batch for L2 block 2 to L1 before the batch for L2 block 1.
+///
+/// The [`BatchQueue`] (pre-Holocene) buffers future batches rather than
+/// dropping them. When the missing predecessor batch (block 1) arrives on the
+/// next L1 block, the queue derives block 1 first, then pops the buffered
+/// block 2 — restoring correct L2 ordering even though the L1 submission order
+/// was reversed.
+///
+/// [`act_l2_pipeline_until`] is used to stop after each
+/// [`StepResult::PreparedAttributes`] so the test can assert the exact block
+/// number at each derivation step rather than racing to the final safe head.
+///
+/// [`BatchQueue`]: base_consensus_derive::BatchQueue
+/// [`act_l2_pipeline_until`]: L2Verifier::act_l2_pipeline_until
+#[tokio::test]
+async fn out_of_order_singular_batches_reordered_by_batch_queue() {
+    let batcher_cfg = BatcherConfig::default();
+    let rollup_cfg = rollup_config_for(&batcher_cfg);
+    let mut h = ActionTestHarness::new(L1MinerConfig::default(), rollup_cfg);
+
+    let l1_chain = SharedL1Chain::from_blocks(h.l1.chain().to_vec());
+    let mut builder = h.create_l2_sequencer(l1_chain);
+
+    // Build 2 L2 blocks in epoch 0 (both reference L1 genesis as L1 origin).
+    let block1 = builder.build_next_block().expect("build L2 block 1");
+    let hash1 = builder.head().block_info.hash;
+    let block2 = builder.build_next_block().expect("build L2 block 2");
+    let hash2 = builder.head().block_info.hash;
+
+    let (mut verifier, chain) = h.create_verifier();
+    verifier.register_block_hash(1, hash1);
+    verifier.register_block_hash(2, hash2);
+
+    // L1 block 1: carry the batch for L2 block 2 (submitted out of order).
+    {
+        let mut source = ActionL2Source::new();
+        source.push(block2);
+        let mut batcher = h.create_batcher(source, batcher_cfg.clone());
+        batcher.advance().expect("submit future batch (block 2)");
+        drop(batcher);
+    }
+    h.mine_and_push(&chain); // L1 block 1: future batch
+
+    // L1 block 2: carry the batch for L2 block 1 (the expected-next batch).
+    {
+        let mut source = ActionL2Source::new();
+        source.push(block1);
+        let mut batcher = h.create_batcher(source, batcher_cfg);
+        batcher.advance().expect("submit present batch (block 1)");
+        drop(batcher);
+    }
+    h.mine_and_push(&chain); // L1 block 2: present batch
+
+    verifier.initialize().await.expect("initialize");
+
+    // Signal L1 block 1 and step until idle.  The BatchQueue sees a future
+    // batch (block 2, timestamp 4 > expected 2) and buffers it.  No attributes
+    // are produced; the pipeline returns Eof.
+    let l1_block_1 = block_info_from(h.l1.block_by_number(1).expect("block 1"));
+    verifier.act_l1_head_signal(l1_block_1).await.expect("signal block 1");
+    let (_, hit) = verifier
+        .act_l2_pipeline_until(|r| matches!(r, StepResult::PreparedAttributes), 500)
+        .await
+        .expect("step after block 1 signal");
+    assert!(
+        !hit,
+        "pipeline must not derive anything from L1 block 1 alone: \
+         the batch for block 2 is a future batch — block 1 has not arrived yet"
+    );
+    assert_eq!(verifier.l2_safe().block_info.number, 0, "safe head must remain at genesis");
+
+    // Signal L1 block 2.  The BatchQueue now receives the expected-next batch
+    // (block 1) and derives it before popping the buffered block 2.
+    let l1_block_2 = block_info_from(h.l1.block_by_number(2).expect("block 2"));
+    verifier.act_l1_head_signal(l1_block_2).await.expect("signal block 2");
+
+    // First PreparedAttributes: must be L2 block 1 (earliest timestamp).
+    let (_, hit1) = verifier
+        .act_l2_pipeline_until(|r| matches!(r, StepResult::PreparedAttributes), 500)
+        .await
+        .expect("step for block 1 attributes");
+    assert!(hit1, "pipeline must derive block 1 when its batch arrives");
+    assert_eq!(
+        verifier.l2_safe().block_info.number,
+        1,
+        "BatchQueue must reorder: block 1 derived before the buffered block 2"
+    );
+
+    // Second PreparedAttributes: the buffered block 2 batch is now the
+    // expected-next (timestamp 4 == safe head timestamp 2 + block_time 2).
+    let (_, hit2) = verifier
+        .act_l2_pipeline_until(|r| matches!(r, StepResult::PreparedAttributes), 500)
+        .await
+        .expect("step for block 2 attributes");
+    assert!(hit2, "pipeline must derive buffered block 2 after block 1 is safe");
+    assert_eq!(verifier.l2_safe().block_info.number, 2, "safe head must reach block 2");
+}
+
+/// [`act_l2_pipeline_until`] returns `(steps, false)` when the pipeline is
+/// idle (no L1 data signalled yet), and `(steps, true)` once a block with
+/// batch data is signalled.
+///
+/// This documents the Eof → data → attributes lifecycle and verifies that
+/// calling [`act_l2_pipeline_until`] before and after an
+/// [`act_l1_head_signal`] produces the expected pair of outcomes.
+///
+/// [`act_l2_pipeline_until`]: L2Verifier::act_l2_pipeline_until
+/// [`act_l1_head_signal`]: L2Verifier::act_l1_head_signal
+#[tokio::test]
+async fn pipeline_idle_before_l1_signal_derives_after() {
+    let batcher_cfg = BatcherConfig::default();
+    let rollup_cfg = rollup_config_for(&batcher_cfg);
+    let mut h = ActionTestHarness::new(L1MinerConfig::default(), rollup_cfg);
+
+    let l1_chain = SharedL1Chain::from_blocks(h.l1.chain().to_vec());
+    let mut builder = h.create_l2_sequencer(l1_chain);
+    let block1 = builder.build_next_block().expect("build L2 block 1");
+    let hash1 = builder.head().block_info.hash;
+
+    let mut source = ActionL2Source::new();
+    source.push(block1);
+    let mut batcher = h.create_batcher(source, batcher_cfg);
+    batcher.advance().expect("encode and submit");
+    drop(batcher);
+
+    let (mut verifier, chain) = h.create_verifier();
+    verifier.register_block_hash(1, hash1);
+    h.mine_and_push(&chain);
+    verifier.initialize().await.expect("initialize");
+
+    // Before any signal: the pipeline exhausted genesis during initialize() and
+    // is now at Eof.  The condition should never fire; the call returns quickly.
+    let (_, before_signal) = verifier
+        .act_l2_pipeline_until(|r| matches!(r, StepResult::PreparedAttributes), 50)
+        .await
+        .expect("step before signal");
+    assert!(!before_signal, "pipeline must be idle before receiving an L1 head signal");
+    assert_eq!(verifier.l2_safe().block_info.number, 0);
+
+    // After signalling L1 block 1: the pipeline can now derive L2 block 1.
+    let l1_block_1 = block_info_from(h.l1.block_by_number(1).expect("block 1"));
+    verifier.act_l1_head_signal(l1_block_1).await.expect("signal block 1");
+    let (_, after_signal) = verifier
+        .act_l2_pipeline_until(|r| matches!(r, StepResult::PreparedAttributes), 500)
+        .await
+        .expect("step after signal");
+    assert!(after_signal, "pipeline must derive L2 block 1 after receiving L1 head signal");
+    assert_eq!(verifier.l2_safe().block_info.number, 1);
+}
+
+/// After all L2 blocks from an L1 block are derived, the pipeline emits
+/// [`StepResult::AdvancedOrigin`] when it transitions to the next L1 block.
+///
+/// Two L2 blocks are encoded into a single L1 channel.  After both are derived,
+/// the pipeline has exhausted L1 block 1's data.  Signalling an empty L1
+/// block 2 and calling [`act_l2_pipeline_until`] with
+/// [`StepResult::AdvancedOrigin`] catches the L1 origin advance without any
+/// new L2 attributes being produced — demonstrating that the safe head stays
+/// at 2 while the pipeline moves forward on L1.
+///
+/// `AdvancedOrigin` is returned by `DerivationPipeline::step` only when
+/// `next_attributes` returns `Eof` for the current epoch **and** the
+/// traversal can advance to the next L1 block.  A single-batch block bypasses
+/// this: `next_attributes` succeeds inline and returns `PreparedAttributes`
+/// without emitting `AdvancedOrigin` first.  The two-block setup here
+/// exhausts all attributes from block 1 before block 2 is processed.
+///
+/// [`act_l2_pipeline_until`]: L2Verifier::act_l2_pipeline_until
+#[tokio::test]
+async fn pipeline_l1_origin_advance_observable_after_epoch_exhausted() {
+    let batcher_cfg = BatcherConfig::default();
+    let rollup_cfg = rollup_config_for(&batcher_cfg);
+    let mut h = ActionTestHarness::new(L1MinerConfig::default(), rollup_cfg);
+
+    let l1_chain = SharedL1Chain::from_blocks(h.l1.chain().to_vec());
+    let mut builder = h.create_l2_sequencer(l1_chain);
+
+    // Build 2 L2 blocks and submit them in a single L1 channel (same L1 block).
+    let mut source = ActionL2Source::new();
+    let block1 = builder.build_next_block().expect("build L2 block 1");
+    let hash1 = builder.head().block_info.hash;
+    let block2 = builder.build_next_block().expect("build L2 block 2");
+    let hash2 = builder.head().block_info.hash;
+    source.push(block1);
+    source.push(block2);
+
+    let mut batcher = h.create_batcher(source, batcher_cfg);
+    batcher.advance().expect("encode and submit both blocks");
+    drop(batcher);
+
+    let (mut verifier, chain) = h.create_verifier();
+    verifier.register_block_hash(1, hash1);
+    verifier.register_block_hash(2, hash2);
+
+    h.mine_and_push(&chain); // L1 block 1: carries the channel for blocks 1 & 2
+    h.mine_and_push(&chain); // L1 block 2: empty — used only for origin advance
+
+    verifier.initialize().await.expect("initialize");
+
+    // Signal and derive both L2 blocks from L1 block 1.
+    let l1_block_1 = block_info_from(h.l1.block_by_number(1).expect("block 1"));
+    verifier.act_l1_head_signal(l1_block_1).await.expect("signal block 1");
+    let (_, hit1) = verifier
+        .act_l2_pipeline_until(|r| matches!(r, StepResult::PreparedAttributes), 500)
+        .await
+        .expect("step for L2 block 1");
+    assert!(hit1);
+    assert_eq!(verifier.l2_safe().block_info.number, 1);
+
+    let (_, hit2) = verifier
+        .act_l2_pipeline_until(|r| matches!(r, StepResult::PreparedAttributes), 500)
+        .await
+        .expect("step for L2 block 2");
+    assert!(hit2);
+    assert_eq!(verifier.l2_safe().block_info.number, 2);
+
+    // L1 block 1 is now fully exhausted.  Signal the empty L1 block 2 and
+    // step until AdvancedOrigin: the pipeline advances the L1 origin from
+    // block 1 to block 2 without producing any new L2 attributes.
+    let l1_block_2 = block_info_from(h.l1.block_by_number(2).expect("block 2"));
+    verifier.act_l1_head_signal(l1_block_2).await.expect("signal block 2");
+    let (_, advanced) = verifier
+        .act_l2_pipeline_until(|r| matches!(r, StepResult::AdvancedOrigin), 50)
+        .await
+        .expect("step until origin advance");
+    assert!(
+        advanced,
+        "pipeline must emit AdvancedOrigin when transitioning from an \
+         exhausted L1 block to the next"
+    );
+    assert_eq!(
+        verifier.l2_safe().block_info.number,
+        2,
+        "safe head must not change: origin advanced but empty block 2 has no batch"
     );
 }


### PR DESCRIPTION
## Summary

Adds act_l2_pipeline_step() for single-step pipeline control and act_l2_pipeline_until(condition, max_steps) for conditional stepping, modeled after op-e2e's ActL2EventsUntil pattern. StepResult is re-exported from the harness crate so tests do not need a separate base_consensus_derive import.

Adds three edge case derivation tests: out-of-order batch reordering by BatchQueue (pre-Holocene), pipeline idle behavior before an L1 head signal is received, and observable AdvancedOrigin emission after an L1 epoch is fully exhausted.