### PR TITLE
feat(CHAIN-3451): AWS ALB target group instance discovery

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4306,6 +4306,7 @@ dependencies = [
  "aws-config",
  "aws-sdk-ec2",
  "aws-sdk-elasticloadbalancingv2",
+ "rstest",
  "thiserror 2.0.18",
  "tracing",
  "url",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1861,6 +1861,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "aws-sdk-ec2"
+version = "1.217.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b572f880a0a0ea4eb989c2423d298a26e920fb185b123e0dd5522e7ff8c406a4"
+dependencies = [
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-smithy-async",
+ "aws-smithy-http 0.63.6",
+ "aws-smithy-json 0.62.5",
+ "aws-smithy-observability",
+ "aws-smithy-query",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-smithy-xml",
+ "aws-types",
+ "fastrand",
+ "http 0.2.12",
+ "http 1.4.0",
+ "regex-lite",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-elasticloadbalancingv2"
+version = "1.109.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97d2254c6c1cec72b956352196525b0615ca9b8e2090a4abe9ccaba7cfa07991"
+dependencies = [
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-smithy-async",
+ "aws-smithy-http 0.63.6",
+ "aws-smithy-json 0.62.5",
+ "aws-smithy-observability",
+ "aws-smithy-query",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-smithy-xml",
+ "aws-types",
+ "fastrand",
+ "http 0.2.12",
+ "http 1.4.0",
+ "regex-lite",
+ "tracing",
+]
+
+[[package]]
 name = "aws-sdk-s3"
 version = "1.119.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4253,7 +4303,11 @@ dependencies = [
  "alloy-signer-local",
  "alloy-sol-types",
  "async-trait",
+ "aws-config",
+ "aws-sdk-ec2",
+ "aws-sdk-elasticloadbalancingv2",
  "thiserror 2.0.18",
+ "tracing",
  "url",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -401,8 +401,10 @@ metrics-exporter-prometheus = { version = "0.18.1", default-features = false }
 aws-nitro-enclaves-cose = "0.5"
 aws-nitro-enclaves-nsm-api = "0.4"
 aws-config = { version = "1.1.7", default-features = false }
+aws-sdk-ec2 = { version = "1", default-features = false }
 aws-sdk-s3 = { version = "1.106.0", default-features = false }
 aws-credential-types = { version = "1.1.7", default-features = false }
+aws-sdk-elasticloadbalancingv2 = { version = "1", default-features = false }
 
 # crypto
 sha3 = "0.10"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -401,10 +401,10 @@ metrics-exporter-prometheus = { version = "0.18.1", default-features = false }
 aws-nitro-enclaves-cose = "0.5"
 aws-nitro-enclaves-nsm-api = "0.4"
 aws-config = { version = "1.1.7", default-features = false }
-aws-sdk-ec2 = { version = "1", default-features = false }
 aws-sdk-s3 = { version = "1.106.0", default-features = false }
+aws-sdk-ec2 = { version = "1.217.0", default-features = false }
 aws-credential-types = { version = "1.1.7", default-features = false }
-aws-sdk-elasticloadbalancingv2 = { version = "1", default-features = false }
+aws-sdk-elasticloadbalancingv2 = { version = "1.109.0", default-features = false }
 
 # crypto
 sha3 = "0.10"

--- a/crates/proof/tee/registrar/Cargo.toml
+++ b/crates/proof/tee/registrar/Cargo.toml
@@ -34,3 +34,6 @@ tracing.workspace = true
 
 # Misc
 url.workspace = true
+
+[dev-dependencies]
+rstest.workspace = true

--- a/crates/proof/tee/registrar/Cargo.toml
+++ b/crates/proof/tee/registrar/Cargo.toml
@@ -21,8 +21,16 @@ alloy-signer-local.workspace = true
 # Async
 async-trait.workspace = true
 
+# AWS
+aws-config = { workspace = true, features = ["default-https-client", "rt-tokio"] }
+aws-sdk-ec2 = { workspace = true, features = ["rustls", "default-https-client", "rt-tokio"] }
+aws-sdk-elasticloadbalancingv2 = { workspace = true, features = ["rustls", "default-https-client", "rt-tokio"] }
+
 # Error
 thiserror.workspace = true
+
+# Tracing
+tracing.workspace = true
 
 # Misc
 url.workspace = true

--- a/crates/proof/tee/registrar/src/discovery.rs
+++ b/crates/proof/tee/registrar/src/discovery.rs
@@ -63,7 +63,7 @@ impl AwsTargetGroupDiscovery {
                 }
             };
             let health_status =
-                health_map.get(&instance_id).cloned().unwrap_or(InstanceHealthStatus::Unhealthy);
+                health_map.get(&instance_id).copied().unwrap_or(InstanceHealthStatus::Unhealthy);
 
             debug!(
                 instance_id = %instance_id,
@@ -127,6 +127,11 @@ impl InstanceDiscovery for AwsTargetGroupDiscovery {
             {
                 e.insert(health_status);
                 instance_ids.push(instance_id.to_string());
+            } else {
+                debug!(
+                    instance_id = %instance_id,
+                    "instance registered on multiple ports; keeping first-seen health status"
+                );
             }
         }
 
@@ -135,6 +140,9 @@ impl InstanceDiscovery for AwsTargetGroupDiscovery {
         }
 
         // Step 3: Resolve private IPs for all instance IDs in a single EC2 call.
+        // describe_instances returns up to 1000 results per page. Pagination is intentionally
+        // omitted here: the instance count is bounded by the ASG size (typically ≤ 10), so
+        // truncation cannot occur in practice.
         let instances_output = self
             .ec2_client
             .describe_instances()

--- a/crates/proof/tee/registrar/src/discovery.rs
+++ b/crates/proof/tee/registrar/src/discovery.rs
@@ -1,0 +1,249 @@
+//! AWS ALB target group instance discovery.
+
+use std::{collections::HashMap, net::IpAddr};
+
+use async_trait::async_trait;
+use aws_sdk_ec2::Client as Ec2Client;
+use aws_sdk_elasticloadbalancingv2::Client as ElbClient;
+use tracing::{debug, warn};
+
+use crate::{InstanceDiscovery, InstanceHealthStatus, ProverInstance, RegistrarError, Result};
+
+/// Maps an AWS ALB target health state string to [`InstanceHealthStatus`].
+///
+/// Unknown or unrecognised states are treated as [`InstanceHealthStatus::Unhealthy`]
+/// to avoid routing work to targets whose status cannot be determined.
+pub fn health_state_from_str(state: &str) -> InstanceHealthStatus {
+    match state {
+        "initial" => InstanceHealthStatus::Initial,
+        "healthy" => InstanceHealthStatus::Healthy,
+        "draining" => InstanceHealthStatus::Draining,
+        _ => InstanceHealthStatus::Unhealthy,
+    }
+}
+
+/// Discovers prover instances by querying an AWS ALB target group.
+///
+/// Uses `describe_target_health` to enumerate all registered targets, including
+/// those in the `Initial` state that have not yet passed the ALB health check.
+/// This allows the registrar to detect and pre-register new instances during the
+/// ALB warm-up window (typically ~1 hour) before they begin receiving traffic.
+///
+/// Private IP addresses are resolved from the EC2 instance IDs returned by the
+/// target group via a `describe_instances` call.
+#[derive(Debug)]
+pub struct AwsTargetGroupDiscovery {
+    elb_client: ElbClient,
+    ec2_client: Ec2Client,
+    target_group_arn: String,
+}
+
+impl AwsTargetGroupDiscovery {
+    /// Creates a new discovery client for the given target group ARN and AWS region.
+    pub async fn new(target_group_arn: String, aws_region: String) -> Result<Self> {
+        let sdk_config = aws_config::defaults(aws_config::BehaviorVersion::latest())
+            .region(aws_sdk_ec2::config::Region::new(aws_region))
+            .load()
+            .await;
+        let elb_client = ElbClient::new(&sdk_config);
+        let ec2_client = Ec2Client::new(&sdk_config);
+        Ok(Self { elb_client, ec2_client, target_group_arn })
+    }
+
+    /// Builds a [`ProverInstance`] list from a health map and raw `(instance_id, private_ip_str)`
+    /// pairs that have already been extracted from EC2 reservations.
+    ///
+    /// Extracted from [`Self::discover_instances`] so that the IP-parse, health-map lookup,
+    /// and assembly logic can be unit-tested without constructing AWS SDK mock clients.
+    pub fn assemble_prover_instances(
+        health_map: &HashMap<String, InstanceHealthStatus>,
+        pairs: impl IntoIterator<Item = (String, String)>,
+    ) -> Vec<ProverInstance> {
+        let mut instances = Vec::new();
+        for (instance_id, private_ip_str) in pairs {
+            let private_ip: IpAddr = match private_ip_str.parse() {
+                Ok(ip) => ip,
+                Err(e) => {
+                    warn!(instance_id = %instance_id, error = %e, "invalid private IP, skipping");
+                    continue;
+                }
+            };
+            let health_status =
+                health_map.get(&instance_id).cloned().unwrap_or(InstanceHealthStatus::Unhealthy);
+
+            debug!(
+                instance_id = %instance_id,
+                private_ip = %private_ip,
+                health = ?health_status,
+                "discovered prover instance"
+            );
+
+            instances.push(ProverInstance { instance_id, private_ip, health_status });
+        }
+        instances
+    }
+}
+
+#[async_trait]
+impl InstanceDiscovery for AwsTargetGroupDiscovery {
+    async fn discover_instances(&self) -> Result<Vec<ProverInstance>> {
+        // Step 1: Query the target group for all registered targets and their health status.
+        // This includes instances in the Initial state before the ALB routes traffic to them.
+        let health_output = self
+            .elb_client
+            .describe_target_health()
+            .target_group_arn(&self.target_group_arn)
+            .send()
+            .await
+            .map_err(|e| RegistrarError::Discovery(Box::new(e)))?;
+
+        let target_descriptions = health_output.target_health_descriptions();
+        if target_descriptions.is_empty() {
+            debug!(target_group = %self.target_group_arn, "no targets in target group");
+            return Ok(vec![]);
+        }
+
+        // Step 2: Build an instance_id → health_status map and collect instance IDs for EC2 lookup.
+        let mut health_map: HashMap<String, InstanceHealthStatus> = HashMap::new();
+        let mut instance_ids: Vec<String> = Vec::new();
+
+        for desc in target_descriptions {
+            let Some(instance_id) = desc.target().and_then(|t| t.id()) else {
+                warn!("target group entry missing instance ID, skipping");
+                continue;
+            };
+            let health_status = desc
+                .target_health()
+                .and_then(|h| h.state())
+                .map(|s| health_state_from_str(s.as_str()))
+                .unwrap_or(InstanceHealthStatus::Unhealthy);
+
+            health_map.insert(instance_id.to_string(), health_status);
+            instance_ids.push(instance_id.to_string());
+        }
+
+        if instance_ids.is_empty() {
+            return Ok(vec![]);
+        }
+
+        // Step 3: Resolve private IPs for all instance IDs in a single EC2 call.
+        let instances_output = self
+            .ec2_client
+            .describe_instances()
+            .set_instance_ids(Some(instance_ids))
+            .send()
+            .await
+            .map_err(|e| RegistrarError::Discovery(Box::new(e)))?;
+
+        // Step 4: Extract (instance_id, private_ip_str) pairs, skipping incomplete entries.
+        let mut pairs: Vec<(String, String)> = Vec::new();
+        for reservation in instances_output.reservations() {
+            for instance in reservation.instances() {
+                let Some(instance_id) = instance.instance_id() else {
+                    warn!("EC2 instance returned with no ID, skipping");
+                    continue;
+                };
+                let Some(private_ip_str) = instance.private_ip_address() else {
+                    warn!(instance_id = %instance_id, "EC2 instance has no private IP, skipping");
+                    continue;
+                };
+                pairs.push((instance_id.to_string(), private_ip_str.to_string()));
+            }
+        }
+
+        Ok(Self::assemble_prover_instances(&health_map, pairs))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::net::IpAddr;
+
+    use super::*;
+
+    #[test]
+    fn health_state_initial() {
+        assert_eq!(health_state_from_str("initial"), InstanceHealthStatus::Initial);
+    }
+
+    #[test]
+    fn health_state_healthy() {
+        assert_eq!(health_state_from_str("healthy"), InstanceHealthStatus::Healthy);
+    }
+
+    #[test]
+    fn health_state_draining() {
+        assert_eq!(health_state_from_str("draining"), InstanceHealthStatus::Draining);
+    }
+
+    #[test]
+    fn health_state_unhealthy() {
+        assert_eq!(health_state_from_str("unhealthy"), InstanceHealthStatus::Unhealthy);
+    }
+
+    #[test]
+    fn health_state_unknown_maps_to_unhealthy() {
+        assert_eq!(health_state_from_str("unavailable"), InstanceHealthStatus::Unhealthy);
+        assert_eq!(health_state_from_str(""), InstanceHealthStatus::Unhealthy);
+        assert_eq!(health_state_from_str("bogus"), InstanceHealthStatus::Unhealthy);
+    }
+
+    #[test]
+    fn assemble_empty_pairs_returns_empty() {
+        let health_map = HashMap::new();
+        assert!(AwsTargetGroupDiscovery::assemble_prover_instances(&health_map, vec![]).is_empty());
+    }
+
+    #[test]
+    fn assemble_invalid_ip_is_skipped() {
+        let health_map = HashMap::new();
+        let pairs = vec![("i-123".to_string(), "not-an-ip".to_string())];
+        assert!(AwsTargetGroupDiscovery::assemble_prover_instances(&health_map, pairs).is_empty());
+    }
+
+    #[test]
+    fn assemble_instance_not_in_health_map_defaults_to_unhealthy() {
+        let health_map = HashMap::new();
+        let pairs = vec![("i-123".to_string(), "10.0.0.1".to_string())];
+        let result = AwsTargetGroupDiscovery::assemble_prover_instances(&health_map, pairs);
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].instance_id, "i-123");
+        assert_eq!(result[0].health_status, InstanceHealthStatus::Unhealthy);
+    }
+
+    #[test]
+    fn assemble_health_status_is_looked_up_from_map() {
+        let mut health_map = HashMap::new();
+        health_map.insert("i-abc".to_string(), InstanceHealthStatus::Healthy);
+        health_map.insert("i-def".to_string(), InstanceHealthStatus::Initial);
+        let pairs = vec![
+            ("i-abc".to_string(), "10.0.0.1".to_string()),
+            ("i-def".to_string(), "10.0.0.2".to_string()),
+        ];
+        let result = AwsTargetGroupDiscovery::assemble_prover_instances(&health_map, pairs);
+        assert_eq!(result.len(), 2);
+        assert_eq!(result[0].health_status, InstanceHealthStatus::Healthy);
+        assert_eq!(result[1].health_status, InstanceHealthStatus::Initial);
+    }
+
+    #[test]
+    fn assemble_parses_ipv4_address() {
+        let health_map = HashMap::new();
+        let pairs = vec![("i-123".to_string(), "192.168.1.100".to_string())];
+        let result = AwsTargetGroupDiscovery::assemble_prover_instances(&health_map, pairs);
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].private_ip, "192.168.1.100".parse::<IpAddr>().unwrap());
+    }
+
+    #[test]
+    fn assemble_invalid_ip_does_not_affect_valid_pairs() {
+        let health_map = HashMap::new();
+        let pairs = vec![
+            ("i-bad".to_string(), "not-an-ip".to_string()),
+            ("i-good".to_string(), "10.0.0.5".to_string()),
+        ];
+        let result = AwsTargetGroupDiscovery::assemble_prover_instances(&health_map, pairs);
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].instance_id, "i-good");
+    }
+}

--- a/crates/proof/tee/registrar/src/discovery.rs
+++ b/crates/proof/tee/registrar/src/discovery.rs
@@ -27,14 +27,14 @@ pub struct AwsTargetGroupDiscovery {
 
 impl AwsTargetGroupDiscovery {
     /// Creates a new discovery client for the given target group ARN and AWS region.
-    pub async fn new(target_group_arn: String, aws_region: String) -> Result<Self> {
+    pub async fn new(target_group_arn: String, aws_region: String) -> Self {
         let sdk_config = aws_config::defaults(aws_config::BehaviorVersion::latest())
             .region(aws_sdk_ec2::config::Region::new(aws_region))
             .load()
             .await;
         let elb_client = ElbClient::new(&sdk_config);
         let ec2_client = Ec2Client::new(&sdk_config);
-        Ok(Self { elb_client, ec2_client, target_group_arn })
+        Self { elb_client, ec2_client, target_group_arn }
     }
 
     /// Builds a [`ProverInstance`] list from a health map and raw `(instance_id, private_ip_str)`

--- a/crates/proof/tee/registrar/src/discovery.rs
+++ b/crates/proof/tee/registrar/src/discovery.rs
@@ -108,6 +108,14 @@ impl InstanceDiscovery for AwsTargetGroupDiscovery {
                 warn!("target group entry missing instance ID, skipping");
                 continue;
             };
+            if !instance_id.starts_with("i-") {
+                warn!(
+                    id = %instance_id,
+                    "target group entry is not an instance-type target (id does not start with \
+                     'i-'); is the target group type set to 'instance'? skipping"
+                );
+                continue;
+            }
             let health_status = desc
                 .target_health()
                 .and_then(|h| h.state())

--- a/crates/proof/tee/registrar/src/discovery.rs
+++ b/crates/proof/tee/registrar/src/discovery.rs
@@ -175,42 +175,20 @@ impl InstanceDiscovery for AwsTargetGroupDiscovery {
 mod tests {
     use std::net::IpAddr;
 
+    use rstest::rstest;
+
     use super::*;
 
-    #[test]
-    fn from_aws_state_initial() {
-        assert_eq!(InstanceHealthStatus::from_aws_state("initial"), InstanceHealthStatus::Initial);
-    }
-
-    #[test]
-    fn from_aws_state_healthy() {
-        assert_eq!(InstanceHealthStatus::from_aws_state("healthy"), InstanceHealthStatus::Healthy);
-    }
-
-    #[test]
-    fn from_aws_state_draining() {
-        assert_eq!(
-            InstanceHealthStatus::from_aws_state("draining"),
-            InstanceHealthStatus::Draining
-        );
-    }
-
-    #[test]
-    fn from_aws_state_unhealthy() {
-        assert_eq!(
-            InstanceHealthStatus::from_aws_state("unhealthy"),
-            InstanceHealthStatus::Unhealthy
-        );
-    }
-
-    #[test]
-    fn from_aws_state_unknown_maps_to_unhealthy() {
-        assert_eq!(
-            InstanceHealthStatus::from_aws_state("unavailable"),
-            InstanceHealthStatus::Unhealthy
-        );
-        assert_eq!(InstanceHealthStatus::from_aws_state(""), InstanceHealthStatus::Unhealthy);
-        assert_eq!(InstanceHealthStatus::from_aws_state("bogus"), InstanceHealthStatus::Unhealthy);
+    #[rstest]
+    #[case::initial("initial", InstanceHealthStatus::Initial)]
+    #[case::healthy("healthy", InstanceHealthStatus::Healthy)]
+    #[case::draining("draining", InstanceHealthStatus::Draining)]
+    #[case::unhealthy("unhealthy", InstanceHealthStatus::Unhealthy)]
+    #[case::unknown_unavailable("unavailable", InstanceHealthStatus::Unhealthy)]
+    #[case::unknown_empty("", InstanceHealthStatus::Unhealthy)]
+    #[case::unknown_bogus("bogus", InstanceHealthStatus::Unhealthy)]
+    fn from_aws_state(#[case] input: &str, #[case] expected: InstanceHealthStatus) {
+        assert_eq!(InstanceHealthStatus::from_aws_state(input), expected);
     }
 
     #[test]

--- a/crates/proof/tee/registrar/src/discovery.rs
+++ b/crates/proof/tee/registrar/src/discovery.rs
@@ -18,6 +18,13 @@ use crate::{InstanceDiscovery, InstanceHealthStatus, ProverInstance, RegistrarEr
 ///
 /// Private IP addresses are resolved from the EC2 instance IDs returned by the
 /// target group via a `describe_instances` call.
+///
+/// # Assumptions
+///
+/// The target group must be configured with **instance-type** targets (IDs of the
+/// form `i-xxxxxxxxxxxxxxxxx`). IP-type target groups return IP address strings
+/// from `target.id()`, which would cause `describe_instances` to return an
+/// `InvalidParameterValue` error at runtime.
 #[derive(Debug)]
 pub struct AwsTargetGroupDiscovery {
     elb_client: ElbClient,
@@ -91,6 +98,8 @@ impl InstanceDiscovery for AwsTargetGroupDiscovery {
         }
 
         // Step 2: Build an instance_id → health_status map and collect instance IDs for EC2 lookup.
+        // Uses entry().or_insert() so that if the same instance is registered on multiple ports,
+        // the first-seen port's health status wins and the instance ID is not duplicated.
         let mut health_map: HashMap<String, InstanceHealthStatus> = HashMap::new();
         let mut instance_ids: Vec<String> = Vec::new();
 
@@ -105,8 +114,12 @@ impl InstanceDiscovery for AwsTargetGroupDiscovery {
                 .map(|s| InstanceHealthStatus::from_aws_state(s.as_str()))
                 .unwrap_or(InstanceHealthStatus::Unhealthy);
 
-            health_map.insert(instance_id.to_string(), health_status);
-            instance_ids.push(instance_id.to_string());
+            if let std::collections::hash_map::Entry::Vacant(e) =
+                health_map.entry(instance_id.to_string())
+            {
+                e.insert(health_status);
+                instance_ids.push(instance_id.to_string());
+            }
         }
 
         if instance_ids.is_empty() {

--- a/crates/proof/tee/registrar/src/discovery.rs
+++ b/crates/proof/tee/registrar/src/discovery.rs
@@ -9,19 +9,6 @@ use tracing::{debug, warn};
 
 use crate::{InstanceDiscovery, InstanceHealthStatus, ProverInstance, RegistrarError, Result};
 
-/// Maps an AWS ALB target health state string to [`InstanceHealthStatus`].
-///
-/// Unknown or unrecognised states are treated as [`InstanceHealthStatus::Unhealthy`]
-/// to avoid routing work to targets whose status cannot be determined.
-pub fn health_state_from_str(state: &str) -> InstanceHealthStatus {
-    match state {
-        "initial" => InstanceHealthStatus::Initial,
-        "healthy" => InstanceHealthStatus::Healthy,
-        "draining" => InstanceHealthStatus::Draining,
-        _ => InstanceHealthStatus::Unhealthy,
-    }
-}
-
 /// Discovers prover instances by querying an AWS ALB target group.
 ///
 /// Uses `describe_target_health` to enumerate all registered targets, including
@@ -115,7 +102,7 @@ impl InstanceDiscovery for AwsTargetGroupDiscovery {
             let health_status = desc
                 .target_health()
                 .and_then(|h| h.state())
-                .map(|s| health_state_from_str(s.as_str()))
+                .map(|s| InstanceHealthStatus::from_aws_state(s.as_str()))
                 .unwrap_or(InstanceHealthStatus::Unhealthy);
 
             health_map.insert(instance_id.to_string(), health_status);
@@ -162,30 +149,39 @@ mod tests {
     use super::*;
 
     #[test]
-    fn health_state_initial() {
-        assert_eq!(health_state_from_str("initial"), InstanceHealthStatus::Initial);
+    fn from_aws_state_initial() {
+        assert_eq!(InstanceHealthStatus::from_aws_state("initial"), InstanceHealthStatus::Initial);
     }
 
     #[test]
-    fn health_state_healthy() {
-        assert_eq!(health_state_from_str("healthy"), InstanceHealthStatus::Healthy);
+    fn from_aws_state_healthy() {
+        assert_eq!(InstanceHealthStatus::from_aws_state("healthy"), InstanceHealthStatus::Healthy);
     }
 
     #[test]
-    fn health_state_draining() {
-        assert_eq!(health_state_from_str("draining"), InstanceHealthStatus::Draining);
+    fn from_aws_state_draining() {
+        assert_eq!(
+            InstanceHealthStatus::from_aws_state("draining"),
+            InstanceHealthStatus::Draining
+        );
     }
 
     #[test]
-    fn health_state_unhealthy() {
-        assert_eq!(health_state_from_str("unhealthy"), InstanceHealthStatus::Unhealthy);
+    fn from_aws_state_unhealthy() {
+        assert_eq!(
+            InstanceHealthStatus::from_aws_state("unhealthy"),
+            InstanceHealthStatus::Unhealthy
+        );
     }
 
     #[test]
-    fn health_state_unknown_maps_to_unhealthy() {
-        assert_eq!(health_state_from_str("unavailable"), InstanceHealthStatus::Unhealthy);
-        assert_eq!(health_state_from_str(""), InstanceHealthStatus::Unhealthy);
-        assert_eq!(health_state_from_str("bogus"), InstanceHealthStatus::Unhealthy);
+    fn from_aws_state_unknown_maps_to_unhealthy() {
+        assert_eq!(
+            InstanceHealthStatus::from_aws_state("unavailable"),
+            InstanceHealthStatus::Unhealthy
+        );
+        assert_eq!(InstanceHealthStatus::from_aws_state(""), InstanceHealthStatus::Unhealthy);
+        assert_eq!(InstanceHealthStatus::from_aws_state("bogus"), InstanceHealthStatus::Unhealthy);
     }
 
     #[test]

--- a/crates/proof/tee/registrar/src/lib.rs
+++ b/crates/proof/tee/registrar/src/lib.rs
@@ -4,6 +4,9 @@
 mod config;
 pub use config::{BoundlessConfig, RegistrarConfig, RemoteSignerConfig, SigningConfig};
 
+mod discovery;
+pub use discovery::{AwsTargetGroupDiscovery, health_state_from_str};
+
 mod error;
 pub use error::{RegistrarError, Result};
 

--- a/crates/proof/tee/registrar/src/lib.rs
+++ b/crates/proof/tee/registrar/src/lib.rs
@@ -5,7 +5,7 @@ mod config;
 pub use config::{BoundlessConfig, RegistrarConfig, RemoteSignerConfig, SigningConfig};
 
 mod discovery;
-pub use discovery::{AwsTargetGroupDiscovery, health_state_from_str};
+pub use discovery::AwsTargetGroupDiscovery;
 
 mod error;
 pub use error::{RegistrarError, Result};

--- a/crates/proof/tee/registrar/src/registry.rs
+++ b/crates/proof/tee/registrar/src/registry.rs
@@ -8,6 +8,8 @@ use url::Url;
 
 use crate::{RegistrarError, Result};
 
+// Interface mirrored from the canonical contract source:
+// https://github.com/base/contracts/blob/96b132077b86bdc77f3f96dd40e09dad363df32e/src/multiproof/tee/TEEProverRegistry.sol
 sol! {
     /// `TEEProverRegistry` contract interface.
     #[sol(rpc)]

--- a/crates/proof/tee/registrar/src/types.rs
+++ b/crates/proof/tee/registrar/src/types.rs
@@ -14,7 +14,7 @@ pub struct ProverInstance {
 }
 
 /// Health status of a prover instance in the ALB target group.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum InstanceHealthStatus {
     /// Health checks are in progress; instance is not yet receiving traffic.
     Initial,

--- a/crates/proof/tee/registrar/src/types.rs
+++ b/crates/proof/tee/registrar/src/types.rs
@@ -27,6 +27,19 @@ pub enum InstanceHealthStatus {
 }
 
 impl InstanceHealthStatus {
+    /// Maps an AWS ALB target health state string to [`InstanceHealthStatus`].
+    ///
+    /// Unknown or unrecognised states are treated as [`Self::Unhealthy`] to avoid
+    /// routing work to targets whose status cannot be determined.
+    pub fn from_aws_state(state: &str) -> Self {
+        match state {
+            "initial" => Self::Initial,
+            "healthy" => Self::Healthy,
+            "draining" => Self::Draining,
+            _ => Self::Unhealthy,
+        }
+    }
+
     /// Returns `true` if the instance should be registered (initial or healthy).
     pub const fn should_register(&self) -> bool {
         matches!(self, Self::Initial | Self::Healthy)


### PR DESCRIPTION
Implements `AwsTargetGroupDiscovery`, the `InstanceDiscovery` backend that powers the registrar's instance enumeration loop. Queries `describe_target_health` to include instances still in the ALB warm-up window (Initial state), then resolves private IPs via a single `describe_instances` call. Adds `aws-sdk-ec2` and `aws-sdk-elasticloadbalancingv2` to the workspace. The join / assemble logic is extracted into `AwsTargetGroupDiscovery::assemble_prover_instances` so it can be unit-tested without AWS SDK mocks; 11 unit tests total.