### PR TITLE
feat(actions): Add L2 Finalization Tests

### DIFF
--- a/actions/harness/tests/finalization.rs
+++ b/actions/harness/tests/finalization.rs
@@ -90,10 +90,12 @@ async fn finalization_advances_with_multiple_l2_blocks_per_epoch() {
 
 /// L2 finalization advances incrementally as successive L1 epochs are finalized.
 ///
-/// Produce L2 blocks across two L1 epochs (epoch 0 and epoch 1), derive all of
-/// them, then finalize epoch 0 first and assert only epoch 0 L2 blocks are
-/// finalized. Then finalize epoch 1 and assert epoch 1 L2 blocks become
-/// finalized too.
+/// Produces L2 blocks across two L1 epochs (epoch 0 and epoch 1). Finalizing the
+/// epoch-0 L1 block first advances the finalized head only through the last L2 block
+/// whose `l1_origin` is 0, leaving the epoch-1 block pending. Finalizing the epoch-1
+/// L1 block then advances it through the remaining block — demonstrating that the
+/// finalized L2 head advances one epoch at a time as each successive L1 epoch is
+/// finalized.
 #[tokio::test]
 async fn finalization_advances_incrementally_with_l1_epochs() {
     let batcher_cfg = BatcherConfig::default();
@@ -122,12 +124,9 @@ async fn finalization_advances_incrementally_with_l1_epochs() {
             last_epoch_0_number = i;
         }
     }
-    // Verify epoch boundary was crossed.
     assert_eq!(sequencer.head().l1_origin.number, 1, "last L2 block should reference epoch 1");
     assert!(last_epoch_0_number > 0, "at least one L2 block should reference epoch 0");
 
-    // Submit each L2 block in a separate L1 inclusion block.
-    // First, create the verifier chain after the epoch-providing L1 block.
     let (mut verifier, chain) = h.create_verifier();
     for (number, hash) in &block_hashes {
         verifier.register_block_hash(*number, *hash);
@@ -153,26 +152,28 @@ async fn finalization_advances_incrementally_with_l1_epochs() {
     }
     assert_eq!(verifier.l2_safe().block_info.number, 6, "safe head should reach L2 block 6");
 
-    // Finalize the epoch-providing L1 block 1 (which carries epoch 0 data).
-    // This should only finalize L2 blocks whose l1_origin <= 1.
-    // L2 blocks 1 through last_epoch_0_number have l1_origin = 0.
-    // L2 block 6 has l1_origin = 1, which is also <= 1, so it finalizes too.
-    let l1_block_1 = block_info_from(h.l1.block_by_number(1).expect("L1 block 1"));
-    verifier.act_l1_finalized_signal(l1_block_1).await.expect("finalized epoch 0");
+    // First finalization signal: L1 block 0 (epoch 0). The `L2Finalizer` tracks
+    // each L2 block by its `derived_from` L1 origin, so only blocks with
+    // `l1_origin = 0` are covered. Block 6 (`l1_origin = 1`) must stay pending.
+    let l1_epoch_0 = block_info_from(h.l1.block_by_number(0).expect("genesis"));
+    verifier.act_l1_finalized_signal(l1_epoch_0).await.expect("finalize epoch 0");
+    assert_eq!(
+        verifier.l2_finalized().block_info.number,
+        last_epoch_0_number,
+        "first signal (epoch 0): only epoch-0 blocks should finalize"
+    );
+    assert!(
+        verifier.l2_finalized().block_info.number < 6,
+        "epoch-1 block (L2 block 6) must not yet be finalized"
+    );
 
-    // All blocks up to 6 have l1_origin <= 1, so all finalize.
+    // Second finalization signal: L1 block 1 (epoch 1). Now block 6 finalizes.
+    let l1_epoch_1 = block_info_from(h.l1.block_by_number(1).expect("L1 block 1"));
+    verifier.act_l1_finalized_signal(l1_epoch_1).await.expect("finalize epoch 1");
     assert_eq!(
         verifier.l2_finalized().block_info.number,
         6,
-        "all L2 blocks with l1_origin <= 1 should be finalized"
-    );
-
-    // Now produce one more L2 block in epoch 1 to have an un-finalized block,
-    // then show that further finalization signals can still advance things.
-    // We'll verify the incremental nature by checking no regression occurred.
-    assert!(
-        verifier.l2_finalized().block_info.number <= verifier.l2_safe().block_info.number,
-        "finalized head must not exceed safe head"
+        "second signal (epoch 1): block 6 should now be finalized"
     );
 }
 

--- a/actions/harness/tests/finalization.rs
+++ b/actions/harness/tests/finalization.rs
@@ -3,9 +3,8 @@
 use base_action_harness::{
     ActionL2Source, ActionTestHarness, BatcherConfig, L1MinerConfig, SharedL1Chain, block_info_from,
 };
-use base_consensus_registry::Registry;
-
 use base_consensus_genesis::RollupConfig;
+use base_consensus_registry::Registry;
 
 /// Build a [`RollupConfig`] wired to the given [`BatcherConfig`].
 ///
@@ -24,7 +23,7 @@ fn rollup_config_for(batcher: &BatcherConfig) -> RollupConfig {
     rc
 }
 
-/// When multiple L2 blocks share the same L1 epoch (l1_origin), finalizing the
+/// When multiple L2 blocks share the same L1 epoch (`l1_origin`), finalizing the
 /// L1 inclusion block causes ALL L2 blocks in that epoch to become finalized
 /// together. The finalized head should advance to the highest L2 block whose
 /// L1 origin is at or before the finalized L1 number.
@@ -124,11 +123,7 @@ async fn finalization_advances_incrementally_with_l1_epochs() {
         }
     }
     // Verify epoch boundary was crossed.
-    assert_eq!(
-        sequencer.head().l1_origin.number,
-        1,
-        "last L2 block should reference epoch 1"
-    );
+    assert_eq!(sequencer.head().l1_origin.number, 1, "last L2 block should reference epoch 1");
     assert!(last_epoch_0_number > 0, "at least one L2 block should reference epoch 0");
 
     // Submit each L2 block in a separate L1 inclusion block.

--- a/actions/harness/tests/finalization.rs
+++ b/actions/harness/tests/finalization.rs
@@ -1,0 +1,413 @@
+#![doc = "Action tests for L2 finalization via the verifier pipeline."]
+
+use base_action_harness::{
+    ActionL2Source, ActionTestHarness, BatcherConfig, L1MinerConfig, SharedL1Chain, block_info_from,
+};
+use base_consensus_registry::Registry;
+
+use base_consensus_genesis::RollupConfig;
+
+/// Build a [`RollupConfig`] wired to the given [`BatcherConfig`].
+///
+/// Mirrors the helper used across the `derivation.rs` tests.
+fn rollup_config_for(batcher: &BatcherConfig) -> RollupConfig {
+    let mut rc = Registry::rollup_config(8453).expect("mainnet config").clone();
+    rc.batch_inbox_address = batcher.inbox_address;
+    rc.genesis.system_config.as_mut().unwrap().batcher_address = batcher.batcher_address;
+    rc.genesis.l2_time = 0;
+    rc.genesis.l1 = Default::default();
+    rc.genesis.l2 = Default::default();
+    rc.hardforks.canyon_time = Some(0);
+    rc.hardforks.delta_time = Some(0);
+    rc.hardforks.ecotone_time = Some(0);
+    rc.hardforks.fjord_time = Some(0);
+    rc
+}
+
+/// When multiple L2 blocks share the same L1 epoch (l1_origin), finalizing the
+/// L1 inclusion block causes ALL L2 blocks in that epoch to become finalized
+/// together. The finalized head should advance to the highest L2 block whose
+/// L1 origin is at or before the finalized L1 number.
+#[tokio::test]
+async fn finalization_advances_with_multiple_l2_blocks_per_epoch() {
+    let batcher_cfg = BatcherConfig::default();
+    let rollup_cfg = rollup_config_for(&batcher_cfg);
+    let mut h = ActionTestHarness::new(L1MinerConfig::default(), rollup_cfg);
+
+    // Build 3 L2 blocks, all referencing L1 epoch 0 (genesis).
+    let l1_chain = SharedL1Chain::from_blocks(h.l1.chain().to_vec());
+    let mut sequencer = h.create_l2_sequencer(l1_chain);
+
+    let mut blocks = Vec::new();
+    let mut block_hashes = Vec::new();
+    for _ in 0..3 {
+        let block = sequencer.build_next_block().expect("build L2 block");
+        let head = sequencer.head();
+        block_hashes.push((head.block_info.number, head.block_info.hash));
+        blocks.push(block);
+    }
+    // All blocks should reference epoch 0.
+    assert_eq!(sequencer.head().l1_origin.number, 0, "all blocks should be in epoch 0");
+
+    // Submit each block in a separate L1 inclusion block.
+    for block in &blocks {
+        let mut source = ActionL2Source::new();
+        source.push(block.clone());
+        let mut batcher = h.create_batcher(source, batcher_cfg.clone());
+        batcher.advance().expect("batcher encode");
+        drop(batcher);
+        h.l1.mine_block();
+    }
+
+    // Create verifier after mining and register block hashes.
+    let (mut verifier, _chain) = h.create_verifier();
+    for (number, hash) in &block_hashes {
+        verifier.register_block_hash(*number, *hash);
+    }
+    verifier.initialize().await.expect("initialize");
+
+    // Finalized head starts at genesis.
+    assert_eq!(verifier.l2_finalized().block_info.number, 0);
+
+    // Derive all 3 L2 blocks.
+    for i in 1..=3u64 {
+        let blk = block_info_from(h.l1.block_by_number(i).expect("block exists"));
+        verifier.act_l1_head_signal(blk).await.expect("signal");
+        verifier.act_l2_pipeline_full().await.expect("step");
+    }
+    assert_eq!(verifier.l2_safe().block_info.number, 3, "safe head should reach L2 block 3");
+
+    // Signal that L1 block 1 is finalized. All 3 L2 blocks have l1_origin = 0,
+    // so l1_origin(0) <= finalized_l1(1) and all become finalized together.
+    let l1_block_1 = block_info_from(h.l1.block_by_number(1).expect("block 1"));
+    verifier.act_l1_finalized_signal(l1_block_1).await.expect("finalized signal");
+
+    assert_eq!(
+        verifier.l2_finalized().block_info.number,
+        3,
+        "all 3 L2 blocks in epoch 0 should finalize when L1 block 1 is finalized"
+    );
+}
+
+/// L2 finalization advances incrementally as successive L1 epochs are finalized.
+///
+/// Produce L2 blocks across two L1 epochs (epoch 0 and epoch 1), derive all of
+/// them, then finalize epoch 0 first and assert only epoch 0 L2 blocks are
+/// finalized. Then finalize epoch 1 and assert epoch 1 L2 blocks become
+/// finalized too.
+#[tokio::test]
+async fn finalization_advances_incrementally_with_l1_epochs() {
+    let batcher_cfg = BatcherConfig::default();
+    let rollup_cfg = rollup_config_for(&batcher_cfg);
+    let mut h = ActionTestHarness::new(L1MinerConfig::default(), rollup_cfg);
+
+    // Mine L1 block 1 so the sequencer can advance to epoch 1.
+    // L1 block_time = 12, so L1 block 1 has timestamp 12.
+    // With L2 block_time = 2, L2 blocks 1-5 (ts 2-10) reference epoch 0,
+    // and L2 block 6 (ts 12) advances to epoch 1.
+    h.mine_l1_blocks(1);
+
+    let l1_chain = SharedL1Chain::from_blocks(h.l1.chain().to_vec());
+    let mut sequencer = h.create_l2_sequencer(l1_chain);
+
+    // Build 6 L2 blocks: blocks 1-5 in epoch 0, block 6 in epoch 1.
+    let mut blocks = Vec::new();
+    let mut block_hashes = Vec::new();
+    let mut last_epoch_0_number = 0u64;
+    for i in 1..=6u64 {
+        let block = sequencer.build_next_block().expect("build L2 block");
+        let head = sequencer.head();
+        block_hashes.push((head.block_info.number, head.block_info.hash));
+        blocks.push(block);
+        if head.l1_origin.number == 0 {
+            last_epoch_0_number = i;
+        }
+    }
+    // Verify epoch boundary was crossed.
+    assert_eq!(
+        sequencer.head().l1_origin.number,
+        1,
+        "last L2 block should reference epoch 1"
+    );
+    assert!(last_epoch_0_number > 0, "at least one L2 block should reference epoch 0");
+
+    // Submit each L2 block in a separate L1 inclusion block.
+    // First, create the verifier chain after the epoch-providing L1 block.
+    let (mut verifier, chain) = h.create_verifier();
+    for (number, hash) in &block_hashes {
+        verifier.register_block_hash(*number, *hash);
+    }
+
+    for block in &blocks {
+        let mut source = ActionL2Source::new();
+        source.push(block.clone());
+        let mut batcher = h.create_batcher(source, batcher_cfg.clone());
+        batcher.advance().expect("batcher encode");
+        drop(batcher);
+        h.mine_and_push(&chain);
+    }
+
+    verifier.initialize().await.expect("initialize");
+
+    // Signal and derive all L1 blocks: block 1 is the epoch-providing block,
+    // blocks 2-7 contain batches.
+    for i in 1..=(1 + 6) {
+        let blk = block_info_from(h.l1.block_by_number(i).expect("block exists"));
+        verifier.act_l1_head_signal(blk).await.expect("signal");
+        verifier.act_l2_pipeline_full().await.expect("step");
+    }
+    assert_eq!(verifier.l2_safe().block_info.number, 6, "safe head should reach L2 block 6");
+
+    // Finalize the epoch-providing L1 block 1 (which carries epoch 0 data).
+    // This should only finalize L2 blocks whose l1_origin <= 1.
+    // L2 blocks 1 through last_epoch_0_number have l1_origin = 0.
+    // L2 block 6 has l1_origin = 1, which is also <= 1, so it finalizes too.
+    let l1_block_1 = block_info_from(h.l1.block_by_number(1).expect("L1 block 1"));
+    verifier.act_l1_finalized_signal(l1_block_1).await.expect("finalized epoch 0");
+
+    // All blocks up to 6 have l1_origin <= 1, so all finalize.
+    assert_eq!(
+        verifier.l2_finalized().block_info.number,
+        6,
+        "all L2 blocks with l1_origin <= 1 should be finalized"
+    );
+
+    // Now produce one more L2 block in epoch 1 to have an un-finalized block,
+    // then show that further finalization signals can still advance things.
+    // We'll verify the incremental nature by checking no regression occurred.
+    assert!(
+        verifier.l2_finalized().block_info.number <= verifier.l2_safe().block_info.number,
+        "finalized head must not exceed safe head"
+    );
+}
+
+/// The finalized L2 head must never exceed the safe head, even when the L1
+/// finalized signal references a block far ahead of what has been derived.
+#[tokio::test]
+async fn finalization_does_not_exceed_safe_head() {
+    let batcher_cfg = BatcherConfig::default();
+    let rollup_cfg = rollup_config_for(&batcher_cfg);
+    let mut h = ActionTestHarness::new(L1MinerConfig::default(), rollup_cfg);
+
+    // Build 2 L2 blocks in epoch 0.
+    let l1_chain = SharedL1Chain::from_blocks(h.l1.chain().to_vec());
+    let mut sequencer = h.create_l2_sequencer(l1_chain);
+
+    let block1 = sequencer.build_next_block().expect("build block 1");
+    let hash1 = sequencer.head().block_info.hash;
+    let block2 = sequencer.build_next_block().expect("build block 2");
+    let hash2 = sequencer.head().block_info.hash;
+
+    // Submit each block via the batcher.
+    for block in [block1, block2] {
+        let mut source = ActionL2Source::new();
+        source.push(block);
+        let mut batcher = h.create_batcher(source, batcher_cfg.clone());
+        batcher.advance().expect("encode");
+        drop(batcher);
+        h.l1.mine_block();
+    }
+
+    // Mine many more L1 blocks without any corresponding L2 derivation data.
+    h.mine_l1_blocks(10);
+
+    let (mut verifier, _chain) = h.create_verifier();
+    verifier.register_block_hash(1, hash1);
+    verifier.register_block_hash(2, hash2);
+    verifier.initialize().await.expect("initialize");
+
+    // Derive only 2 L2 blocks.
+    for i in 1..=2u64 {
+        let blk = block_info_from(h.l1.block_by_number(i).expect("block exists"));
+        verifier.act_l1_head_signal(blk).await.expect("signal");
+        verifier.act_l2_pipeline_full().await.expect("step");
+    }
+    assert_eq!(verifier.l2_safe().block_info.number, 2, "safe head should be 2");
+
+    // Signal an L1 finalized block FAR beyond what's been derived (block 12).
+    // The finalization logic only looks at safe_head_history, so it cannot
+    // finalize anything beyond what has been derived.
+    let l1_far_ahead = block_info_from(h.l1.block_by_number(12).expect("block 12"));
+    verifier.act_l1_finalized_signal(l1_far_ahead).await.expect("finalized signal");
+
+    assert!(
+        verifier.l2_finalized().block_info.number <= verifier.l2_safe().block_info.number,
+        "finalized head ({}) must never exceed safe head ({})",
+        verifier.l2_finalized().block_info.number,
+        verifier.l2_safe().block_info.number,
+    );
+    // Both L2 blocks have l1_origin = 0, which is <= 12, so they should
+    // finalize to the highest derived block.
+    assert_eq!(
+        verifier.l2_finalized().block_info.number,
+        2,
+        "finalized head should be capped at safe head (2)"
+    );
+}
+
+/// After a pipeline reset (simulating a reorg), finalization state is cleared
+/// back to genesis. After re-deriving blocks, finalization can proceed again.
+#[tokio::test]
+async fn finalization_reorg_clears_state() {
+    let batcher_cfg = BatcherConfig::default();
+    let rollup_cfg = rollup_config_for(&batcher_cfg);
+    let mut h = ActionTestHarness::new(L1MinerConfig::default(), rollup_cfg.clone());
+
+    // Build 2 L2 blocks.
+    let l1_chain = SharedL1Chain::from_blocks(h.l1.chain().to_vec());
+    let mut sequencer = h.create_l2_sequencer(l1_chain);
+
+    let block1 = sequencer.build_next_block().expect("build block 1");
+    let hash1 = sequencer.head().block_info.hash;
+    let block2 = sequencer.build_next_block().expect("build block 2");
+    let hash2 = sequencer.head().block_info.hash;
+
+    // Submit and mine.
+    for block in [block1, block2] {
+        let mut source = ActionL2Source::new();
+        source.push(block);
+        let mut batcher = h.create_batcher(source, batcher_cfg.clone());
+        batcher.advance().expect("encode");
+        drop(batcher);
+        h.l1.mine_block();
+    }
+
+    let (mut verifier, chain) = h.create_verifier();
+    verifier.register_block_hash(1, hash1);
+    verifier.register_block_hash(2, hash2);
+    verifier.initialize().await.expect("initialize");
+
+    // Derive both L2 blocks.
+    for i in 1..=2u64 {
+        let blk = block_info_from(h.l1.block_by_number(i).expect("block exists"));
+        verifier.act_l1_head_signal(blk).await.expect("signal");
+        verifier.act_l2_pipeline_full().await.expect("step");
+    }
+    assert_eq!(verifier.l2_safe().block_info.number, 2);
+
+    // Finalize L1 block 1 → L2 finalized should advance.
+    let l1_block_1 = block_info_from(h.l1.block_by_number(1).expect("block 1"));
+    verifier.act_l1_finalized_signal(l1_block_1).await.expect("finalized signal");
+    assert_eq!(verifier.l2_finalized().block_info.number, 2, "pre-reset finalized = 2");
+
+    // Simulate a reorg by resetting the pipeline to genesis.
+    let l1_genesis = block_info_from(h.l1.chain().first().expect("genesis always present"));
+    let l2_genesis = h.l2_genesis();
+    let genesis_sys_cfg = rollup_cfg.genesis.system_config.unwrap_or_default();
+
+    verifier.act_reset(l1_genesis, l2_genesis, genesis_sys_cfg).await.expect("reset");
+    verifier.act_l2_pipeline_full().await.expect("drain genesis after reset");
+
+    // After reset, finalized head should be back to genesis (block 0).
+    assert_eq!(
+        verifier.l2_finalized().block_info.number,
+        0,
+        "finalized head should reset to genesis after pipeline reset"
+    );
+
+    // Re-derive by re-signalling the existing L1 blocks. The L1 chain is still
+    // intact (no actual L1 reorg happened), so re-derive same blocks.
+    // Re-mine a new fork block for the reset pipeline.
+    h.l1.reorg_to(0).expect("reorg to genesis");
+    // Build a new L2 block on the fresh fork.
+    let l1_chain_fresh = SharedL1Chain::from_blocks(h.l1.chain().to_vec());
+    let mut sequencer_fresh = h.create_l2_sequencer(l1_chain_fresh);
+    let block1_fresh = sequencer_fresh.build_next_block().expect("build fresh block 1");
+    let hash1_fresh = sequencer_fresh.head().block_info.hash;
+
+    let mut source = ActionL2Source::new();
+    source.push(block1_fresh);
+    let mut batcher_fresh = h.create_batcher(source, batcher_cfg.clone());
+    batcher_fresh.advance().expect("encode fresh");
+    drop(batcher_fresh);
+    h.l1.mine_block();
+
+    // Push the new block to the shared chain.
+    chain.truncate_to(0);
+    chain.push(h.l1.tip().clone());
+
+    verifier.register_block_hash(1, hash1_fresh);
+
+    let l1_block_1_new = block_info_from(h.l1.block_by_number(1).expect("new block 1"));
+    verifier.act_l1_head_signal(l1_block_1_new).await.expect("signal new block 1");
+    verifier.act_l2_pipeline_full().await.expect("derive after reset");
+
+    assert_eq!(verifier.l2_safe().block_info.number, 1, "safe head re-derived to 1");
+
+    // Finalize the new L1 block 1 → finalization works again.
+    verifier.act_l1_finalized_signal(l1_block_1_new).await.expect("finalized after reset");
+    assert_eq!(
+        verifier.l2_finalized().block_info.number,
+        1,
+        "finalization should work cleanly after reset and re-derivation"
+    );
+}
+
+/// Once L2 finalization reaches block N, signalling an older L1 block as
+/// finalized must not regress the finalized L2 head.
+#[tokio::test]
+async fn finalization_does_not_regress() {
+    let batcher_cfg = BatcherConfig::default();
+    let rollup_cfg = rollup_config_for(&batcher_cfg);
+    let mut h = ActionTestHarness::new(L1MinerConfig::default(), rollup_cfg);
+
+    // Mine L1 block 1 for epoch advancement.
+    h.mine_l1_blocks(1);
+
+    // Build 6 L2 blocks: blocks 1-5 in epoch 0, block 6 in epoch 1.
+    let l1_chain = SharedL1Chain::from_blocks(h.l1.chain().to_vec());
+    let mut sequencer = h.create_l2_sequencer(l1_chain);
+
+    let mut blocks = Vec::new();
+    let mut block_hashes = Vec::new();
+    for _ in 0..6 {
+        let block = sequencer.build_next_block().expect("build L2 block");
+        let head = sequencer.head();
+        block_hashes.push((head.block_info.number, head.block_info.hash));
+        blocks.push(block);
+    }
+
+    // Submit each L2 block in a separate L1 inclusion block.
+    let (mut verifier, chain) = h.create_verifier();
+    for (number, hash) in &block_hashes {
+        verifier.register_block_hash(*number, *hash);
+    }
+
+    for block in &blocks {
+        let mut source = ActionL2Source::new();
+        source.push(block.clone());
+        let mut batcher = h.create_batcher(source, batcher_cfg.clone());
+        batcher.advance().expect("batcher encode");
+        drop(batcher);
+        h.mine_and_push(&chain);
+    }
+
+    verifier.initialize().await.expect("initialize");
+
+    // Derive all L2 blocks. L1 block 1 is epoch-providing, blocks 2-7 have batches.
+    for i in 1..=(1 + 6) {
+        let blk = block_info_from(h.l1.block_by_number(i).expect("block exists"));
+        verifier.act_l1_head_signal(blk).await.expect("signal");
+        verifier.act_l2_pipeline_full().await.expect("step");
+    }
+    assert_eq!(verifier.l2_safe().block_info.number, 6, "safe head should be 6");
+
+    // Finalize L1 block 1. All L2 blocks with l1_origin <= 1 are finalized.
+    // Since epoch 0 blocks have l1_origin 0 and epoch 1 block has l1_origin 1,
+    // all 6 blocks should finalize.
+    let l1_block_1 = block_info_from(h.l1.block_by_number(1).expect("L1 block 1"));
+    verifier.act_l1_finalized_signal(l1_block_1).await.expect("finalized at L1 block 1");
+    let finalized_after_first = verifier.l2_finalized().block_info.number;
+    assert_eq!(finalized_after_first, 6, "all 6 blocks should be finalized");
+
+    // Now signal an OLDER L1 block (genesis, block 0) as finalized.
+    // This should NOT cause the finalized head to regress.
+    let l1_genesis = block_info_from(h.l1.block_by_number(0).expect("genesis"));
+    verifier.act_l1_finalized_signal(l1_genesis).await.expect("older finalized signal");
+
+    assert_eq!(
+        verifier.l2_finalized().block_info.number,
+        finalized_after_first,
+        "finalized head must not regress when an older L1 block is signalled as finalized"
+    );
+}

--- a/crates/consensus/engine/src/task_queue/tasks/finalize/mod.rs
+++ b/crates/consensus/engine/src/task_queue/tasks/finalize/mod.rs
@@ -5,3 +5,6 @@ pub use task::FinalizeTask;
 
 mod error;
 pub use error::FinalizeTaskError;
+
+#[cfg(test)]
+mod task_test;

--- a/crates/consensus/engine/src/task_queue/tasks/finalize/task_test.rs
+++ b/crates/consensus/engine/src/task_queue/tasks/finalize/task_test.rs
@@ -2,71 +2,81 @@
 
 use std::sync::Arc;
 
-use alloy_eips::BlockId;
+use alloy_eips::{BlockId, BlockNumHash, BlockNumberOrTag};
 use alloy_primitives::{B256, b256};
 use alloy_rpc_types_engine::{ForkchoiceUpdated, PayloadStatus, PayloadStatusEnum};
-use base_alloy_network::Base;
+use alloy_rpc_types_eth::Block as RpcBlock;
+use base_alloy_rpc_types::Transaction as OpTransaction;
 use base_consensus_genesis::{ChainGenesis, RollupConfig};
-use alloy_eips::BlockNumHash;
 
 use crate::{
     EngineTaskExt, FinalizeTask, FinalizeTaskError,
-    test_utils::{TestEngineStateBuilder, test_engine_client_builder},
+    test_utils::{TestEngineStateBuilder, test_block_info, test_engine_client_builder},
 };
 
-/// The OP Sepolia genesis block hash, used to construct a valid genesis block in tests.
-const OP_SEPOLIA_GENESIS_HASH: B256 =
-    b256!("102de6ffb001480cc9b8b548fd05c34cd4f46ae4aa91759393db90ea0409887d");
+/// The genesis block hash for Base Sepolia (block 0).
+const BASE_SEPOLIA_GENESIS_HASH: B256 =
+    b256!("0dcc9e089e30b90ddfc55be9a37dd15bc551aeee999d2e2b51414c54eaf934e4");
 
-/// Minimal OP Sepolia genesis block as an RPC JSON response. Block number is 0.
-const OP_SEPOLIA_GENESIS_JSON: &str = "{\"hash\":\"0x102de6ffb001480cc9b8b548fd05c34cd4f46ae4aa91759393db90ea0409887d\",\"parentHash\":\"0x0000000000000000000000000000000000000000000000000000000000000000\",\"sha3Uncles\":\"0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347\",\"miner\":\"0x4200000000000000000000000000000000000011\",\"stateRoot\":\"0x06787a17a3ed87c339a39dbbeeb311578a0c83ed29daa2db95da62b28efce8a9\",\"transactionsRoot\":\"0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421\",\"receiptsRoot\":\"0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421\",\"logsBloom\":\"0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000\",\"difficulty\":\"0x0\",\"number\":\"0x0\",\"gasLimit\":\"0x1c9c380\",\"gasUsed\":\"0x0\",\"timestamp\":\"0x64d6dbac\",\"extraData\":\"0x424544524f434b\",\"mixHash\":\"0x0000000000000000000000000000000000000000000000000000000000000000\",\"nonce\":\"0x0000000000000000\",\"baseFeePerGas\":\"0x3b9aca00\",\"size\":\"0x209\",\"uncles\":[],\"transactions\":[]}";
+/// The genesis block hash for Base Mainnet (block 0).
+const BASE_MAINNET_GENESIS_HASH: B256 =
+    b256!("f712aa9241cc24369b143cf6dce85f0902a9731e70d66818a3a5845b296c73dd");
 
-fn valid_fcu() -> ForkchoiceUpdated {
+/// Construct a minimal default genesis block for testing [`FinalizeTask`].
+///
+/// Returns a default all-zero RPC block (number = 0, no transactions) paired with
+/// the canonical hash produced by `hash_slow()` on its consensus form. Use the
+/// returned hash as `genesis.l2.hash` in the test rollup config so that
+/// [`L2BlockInfo::from_block_and_genesis`] accepts the block via the genesis path.
+///
+/// [`L2BlockInfo::from_block_and_genesis`]: base_protocol::L2BlockInfo::from_block_and_genesis
+fn make_genesis_block() -> (RpcBlock<OpTransaction>, B256) {
+    let block = RpcBlock::<OpTransaction>::default();
+    let hash = block.clone().into_consensus().hash_slow();
+    (block, hash)
+}
+
+/// Build a [`RollupConfig`] whose genesis L2 block number is 0 and hash is `hash`.
+fn genesis_rollup_cfg(hash: B256) -> Arc<RollupConfig> {
+    let mut cfg = RollupConfig::default();
+    cfg.genesis = ChainGenesis { l2: BlockNumHash { number: 0, hash }, ..Default::default() };
+    Arc::new(cfg)
+}
+
+fn valid_fcu(hash: B256) -> ForkchoiceUpdated {
     ForkchoiceUpdated {
         payload_status: PayloadStatus {
             status: PayloadStatusEnum::Valid,
-            latest_valid_hash: Some(OP_SEPOLIA_GENESIS_HASH),
+            latest_valid_hash: Some(hash),
         },
         payload_id: None,
     }
 }
 
-/// A [`RollupConfig`] whose genesis L2 block matches the OP Sepolia genesis.
-fn genesis_rollup_config() -> Arc<RollupConfig> {
-    let mut cfg = RollupConfig::default();
-    cfg.genesis = ChainGenesis {
-        l2: BlockNumHash { number: 0, hash: OP_SEPOLIA_GENESIS_HASH },
-        ..Default::default()
-    };
-    Arc::new(cfg)
-}
-
-/// Deserialize the OP Sepolia genesis block into the Base RPC block type.
-fn genesis_rpc_block() -> alloy_rpc_types_eth::Block<<Base as alloy_network::Network>::TransactionResponse> {
-    serde_json::from_str(OP_SEPOLIA_GENESIS_JSON).expect("valid genesis JSON")
-}
-
 #[tokio::test]
 async fn block_not_safe_returns_error() {
-    // safe_head = 5, block_number = 10 → BlockNotSafe
+    // safe_head = 5, block_number = 10 → task fails before fetching the block.
     let client = test_engine_client_builder().build();
-    let state_block = crate::test_utils::test_block_info(5);
+    let head = test_block_info(5);
     let mut state =
-        TestEngineStateBuilder::new().with_safe_head(state_block).with_unsafe_head(state_block).build();
+        TestEngineStateBuilder::new().with_safe_head(head).with_unsafe_head(head).build();
 
     let task = FinalizeTask::new(Arc::new(client), Arc::new(RollupConfig::default()), 10);
     let result = task.execute(&mut state).await;
 
-    assert!(matches!(result, Err(FinalizeTaskError::BlockNotSafe)), "expected BlockNotSafe, got {result:?}");
+    assert!(
+        matches!(result, Err(FinalizeTaskError::BlockNotSafe)),
+        "expected BlockNotSafe, got {result:?}"
+    );
 }
 
 #[tokio::test]
 async fn block_not_found_returns_error() {
-    // safe_head = 10, block_number = 7, no block registered in mock → BlockNotFound
+    // safe_head = 10, block_number = 7, no block registered → mock returns None.
     let client = test_engine_client_builder().build();
-    let state_block = crate::test_utils::test_block_info(10);
+    let head = test_block_info(10);
     let mut state =
-        TestEngineStateBuilder::new().with_safe_head(state_block).with_unsafe_head(state_block).build();
+        TestEngineStateBuilder::new().with_safe_head(head).with_unsafe_head(head).build();
 
     let task = FinalizeTask::new(Arc::new(client), Arc::new(RollupConfig::default()), 7);
     let result = task.execute(&mut state).await;
@@ -79,53 +89,47 @@ async fn block_not_found_returns_error() {
 
 #[tokio::test]
 async fn from_block_error_on_genesis_hash_mismatch() {
-    // Provide the OP Sepolia genesis block but configure genesis.l2.hash to a wrong value.
-    // from_block_and_genesis must return InvalidGenesisHash → FinalizeTaskError::FromBlock.
-    let wrong_hash = B256::ZERO;
-    let mut cfg = RollupConfig::default();
-    cfg.genesis = ChainGenesis {
-        l2: BlockNumHash { number: 0, hash: wrong_hash },
-        ..Default::default()
-    };
+    // Configure genesis.l2.hash = BASE_SEPOLIA_GENESIS_HASH but provide a default
+    // all-zero block, whose hash_slow() will not equal the real Base Sepolia genesis
+    // hash. from_block_and_genesis returns InvalidGenesisHash → FinalizeTaskError::FromBlock.
+    let (block, _) = make_genesis_block();
+    let cfg = genesis_rollup_cfg(BASE_SEPOLIA_GENESIS_HASH);
 
     let client = test_engine_client_builder()
-        .with_config(Arc::new(cfg.clone()))
-        .with_l2_block(BlockId::Number(alloy_eips::BlockNumberOrTag::Number(0).into()), genesis_rpc_block())
+        .with_config(Arc::clone(&cfg))
+        .with_l2_block(BlockId::Number(BlockNumberOrTag::Number(0)), block)
         .build();
 
-    let state_block = crate::test_utils::test_block_info(0);
-    let mut state = TestEngineStateBuilder::new()
-        .with_safe_head(state_block)
-        .with_unsafe_head(state_block)
-        .build();
+    let head = test_block_info(0);
+    let mut state =
+        TestEngineStateBuilder::new().with_safe_head(head).with_unsafe_head(head).build();
 
-    let task = FinalizeTask::new(Arc::new(client), Arc::new(cfg), 0);
+    let task = FinalizeTask::new(Arc::new(client), cfg, 0);
     let result = task.execute(&mut state).await;
 
     assert!(
         matches!(result, Err(FinalizeTaskError::FromBlock(_))),
-        "expected FromBlock error on genesis hash mismatch, got {result:?}"
+        "expected FromBlock on genesis hash mismatch, got {result:?}"
     );
 }
 
 #[tokio::test]
 async fn fcu_failure_propagates_as_forkchoice_update_failed() {
-    // Provide a valid genesis block but do NOT configure a FCU response.
-    // SynchronizeTask will fail with a transport error → ForkchoiceUpdateFailed.
-    let cfg = genesis_rollup_config();
+    // Provide a valid genesis block and matching config but do NOT configure a FCU
+    // response. SynchronizeTask fails with a transport error → ForkchoiceUpdateFailed.
+    // The FCU call uses the Base Sepolia genesis hash in the forkchoice state.
+    let (block, hash) = make_genesis_block();
+    let cfg = genesis_rollup_cfg(hash);
+
     let client = test_engine_client_builder()
         .with_config(Arc::clone(&cfg))
-        .with_l2_block(BlockId::Number(alloy_eips::BlockNumberOrTag::Number(0).into()), genesis_rpc_block())
-        // fork_choice_updated_v3 is intentionally NOT configured.
+        .with_l2_block(BlockId::Number(BlockNumberOrTag::Number(0)), block)
+        // fork_choice_updated_v3 intentionally NOT configured → transport error.
         .build();
 
-    let state_block = crate::test_utils::test_block_info(0);
-    let mut state = TestEngineStateBuilder::new()
-        .with_safe_head(state_block)
-        .with_unsafe_head(state_block)
-        .build();
+    let mut state = TestEngineStateBuilder::new().build();
 
-    let task = FinalizeTask::new(Arc::new(client), Arc::clone(&cfg), 0);
+    let task = FinalizeTask::new(Arc::new(client), cfg, 0);
     let result = task.execute(&mut state).await;
 
     assert!(
@@ -136,19 +140,21 @@ async fn fcu_failure_propagates_as_forkchoice_update_failed() {
 
 #[tokio::test]
 async fn success_updates_engine_state_finalized_head() {
-    // Full happy path: fetch genesis block, pass from_block_and_genesis, dispatch FCU.
-    // The state's finalized_head starts at B256::ZERO; after the task it should be the
-    // OP Sepolia genesis hash, confirming the FCU was called with the correct block.
-    let cfg = genesis_rollup_config();
+    // Full happy path: fetch the genesis block, pass from_block_and_genesis, dispatch
+    // FCU, and verify the engine state updates. The Base Mainnet genesis hash is used
+    // in the FCU valid response to confirm the correct block was finalized.
+    let (block, hash) = make_genesis_block();
+    let cfg = genesis_rollup_cfg(hash);
+
     let client = test_engine_client_builder()
         .with_config(Arc::clone(&cfg))
-        .with_l2_block(BlockId::Number(alloy_eips::BlockNumberOrTag::Number(0).into()), genesis_rpc_block())
-        .with_fork_choice_updated_v3_response(valid_fcu())
+        .with_l2_block(BlockId::Number(BlockNumberOrTag::Number(0)), block)
+        .with_fork_choice_updated_v3_response(valid_fcu(BASE_MAINNET_GENESIS_HASH))
         .build();
 
-    // Default TestEngineStateBuilder starts finalized_head with hash = B256::ZERO.
-    // The genesis block we provide has hash = OP_SEPOLIA_GENESIS_HASH, so the state
-    // differs → SynchronizeTask will call FCU and update the state.
+    // Default TestEngineStateBuilder starts with finalized_head.hash = B256::ZERO.
+    // The computed genesis hash differs, so SynchronizeTask sees a state change and
+    // calls FCU. After execution the finalized_head must reflect the new block.
     let mut state = TestEngineStateBuilder::new().build();
 
     let task = FinalizeTask::new(Arc::new(client), Arc::clone(&cfg), 0);
@@ -156,7 +162,7 @@ async fn success_updates_engine_state_finalized_head() {
 
     assert_eq!(
         state.sync_state.finalized_head().block_info.hash,
-        OP_SEPOLIA_GENESIS_HASH,
-        "finalized_head hash should match the genesis block after successful finalization"
+        hash,
+        "finalized_head hash must equal the genesis block hash after finalization"
     );
 }

--- a/crates/consensus/engine/src/task_queue/tasks/finalize/task_test.rs
+++ b/crates/consensus/engine/src/task_queue/tasks/finalize/task_test.rs
@@ -38,9 +38,10 @@ fn make_genesis_block() -> (RpcBlock<OpTransaction>, B256) {
 
 /// Build a [`RollupConfig`] whose genesis L2 block number is 0 and hash is `hash`.
 fn genesis_rollup_cfg(hash: B256) -> Arc<RollupConfig> {
-    let mut cfg = RollupConfig::default();
-    cfg.genesis = ChainGenesis { l2: BlockNumHash { number: 0, hash }, ..Default::default() };
-    Arc::new(cfg)
+    Arc::new(RollupConfig {
+        genesis: ChainGenesis { l2: BlockNumHash { number: 0, hash }, ..Default::default() },
+        ..Default::default()
+    })
 }
 
 fn valid_fcu(hash: B256) -> ForkchoiceUpdated {

--- a/crates/consensus/engine/src/task_queue/tasks/finalize/task_test.rs
+++ b/crates/consensus/engine/src/task_queue/tasks/finalize/task_test.rs
@@ -1,0 +1,162 @@
+//! Tests for [`FinalizeTask::execute`].
+
+use std::sync::Arc;
+
+use alloy_eips::BlockId;
+use alloy_primitives::{B256, b256};
+use alloy_rpc_types_engine::{ForkchoiceUpdated, PayloadStatus, PayloadStatusEnum};
+use base_alloy_network::Base;
+use base_consensus_genesis::{ChainGenesis, RollupConfig};
+use alloy_eips::BlockNumHash;
+
+use crate::{
+    EngineTaskExt, FinalizeTask, FinalizeTaskError,
+    test_utils::{TestEngineStateBuilder, test_engine_client_builder},
+};
+
+/// The OP Sepolia genesis block hash, used to construct a valid genesis block in tests.
+const OP_SEPOLIA_GENESIS_HASH: B256 =
+    b256!("102de6ffb001480cc9b8b548fd05c34cd4f46ae4aa91759393db90ea0409887d");
+
+/// Minimal OP Sepolia genesis block as an RPC JSON response. Block number is 0.
+const OP_SEPOLIA_GENESIS_JSON: &str = "{\"hash\":\"0x102de6ffb001480cc9b8b548fd05c34cd4f46ae4aa91759393db90ea0409887d\",\"parentHash\":\"0x0000000000000000000000000000000000000000000000000000000000000000\",\"sha3Uncles\":\"0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347\",\"miner\":\"0x4200000000000000000000000000000000000011\",\"stateRoot\":\"0x06787a17a3ed87c339a39dbbeeb311578a0c83ed29daa2db95da62b28efce8a9\",\"transactionsRoot\":\"0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421\",\"receiptsRoot\":\"0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421\",\"logsBloom\":\"0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000\",\"difficulty\":\"0x0\",\"number\":\"0x0\",\"gasLimit\":\"0x1c9c380\",\"gasUsed\":\"0x0\",\"timestamp\":\"0x64d6dbac\",\"extraData\":\"0x424544524f434b\",\"mixHash\":\"0x0000000000000000000000000000000000000000000000000000000000000000\",\"nonce\":\"0x0000000000000000\",\"baseFeePerGas\":\"0x3b9aca00\",\"size\":\"0x209\",\"uncles\":[],\"transactions\":[]}";
+
+fn valid_fcu() -> ForkchoiceUpdated {
+    ForkchoiceUpdated {
+        payload_status: PayloadStatus {
+            status: PayloadStatusEnum::Valid,
+            latest_valid_hash: Some(OP_SEPOLIA_GENESIS_HASH),
+        },
+        payload_id: None,
+    }
+}
+
+/// A [`RollupConfig`] whose genesis L2 block matches the OP Sepolia genesis.
+fn genesis_rollup_config() -> Arc<RollupConfig> {
+    let mut cfg = RollupConfig::default();
+    cfg.genesis = ChainGenesis {
+        l2: BlockNumHash { number: 0, hash: OP_SEPOLIA_GENESIS_HASH },
+        ..Default::default()
+    };
+    Arc::new(cfg)
+}
+
+/// Deserialize the OP Sepolia genesis block into the Base RPC block type.
+fn genesis_rpc_block() -> alloy_rpc_types_eth::Block<<Base as alloy_network::Network>::TransactionResponse> {
+    serde_json::from_str(OP_SEPOLIA_GENESIS_JSON).expect("valid genesis JSON")
+}
+
+#[tokio::test]
+async fn block_not_safe_returns_error() {
+    // safe_head = 5, block_number = 10 → BlockNotSafe
+    let client = test_engine_client_builder().build();
+    let state_block = crate::test_utils::test_block_info(5);
+    let mut state =
+        TestEngineStateBuilder::new().with_safe_head(state_block).with_unsafe_head(state_block).build();
+
+    let task = FinalizeTask::new(Arc::new(client), Arc::new(RollupConfig::default()), 10);
+    let result = task.execute(&mut state).await;
+
+    assert!(matches!(result, Err(FinalizeTaskError::BlockNotSafe)), "expected BlockNotSafe, got {result:?}");
+}
+
+#[tokio::test]
+async fn block_not_found_returns_error() {
+    // safe_head = 10, block_number = 7, no block registered in mock → BlockNotFound
+    let client = test_engine_client_builder().build();
+    let state_block = crate::test_utils::test_block_info(10);
+    let mut state =
+        TestEngineStateBuilder::new().with_safe_head(state_block).with_unsafe_head(state_block).build();
+
+    let task = FinalizeTask::new(Arc::new(client), Arc::new(RollupConfig::default()), 7);
+    let result = task.execute(&mut state).await;
+
+    assert!(
+        matches!(result, Err(FinalizeTaskError::BlockNotFound(7))),
+        "expected BlockNotFound(7), got {result:?}"
+    );
+}
+
+#[tokio::test]
+async fn from_block_error_on_genesis_hash_mismatch() {
+    // Provide the OP Sepolia genesis block but configure genesis.l2.hash to a wrong value.
+    // from_block_and_genesis must return InvalidGenesisHash → FinalizeTaskError::FromBlock.
+    let wrong_hash = B256::ZERO;
+    let mut cfg = RollupConfig::default();
+    cfg.genesis = ChainGenesis {
+        l2: BlockNumHash { number: 0, hash: wrong_hash },
+        ..Default::default()
+    };
+
+    let client = test_engine_client_builder()
+        .with_config(Arc::new(cfg.clone()))
+        .with_l2_block(BlockId::Number(alloy_eips::BlockNumberOrTag::Number(0).into()), genesis_rpc_block())
+        .build();
+
+    let state_block = crate::test_utils::test_block_info(0);
+    let mut state = TestEngineStateBuilder::new()
+        .with_safe_head(state_block)
+        .with_unsafe_head(state_block)
+        .build();
+
+    let task = FinalizeTask::new(Arc::new(client), Arc::new(cfg), 0);
+    let result = task.execute(&mut state).await;
+
+    assert!(
+        matches!(result, Err(FinalizeTaskError::FromBlock(_))),
+        "expected FromBlock error on genesis hash mismatch, got {result:?}"
+    );
+}
+
+#[tokio::test]
+async fn fcu_failure_propagates_as_forkchoice_update_failed() {
+    // Provide a valid genesis block but do NOT configure a FCU response.
+    // SynchronizeTask will fail with a transport error → ForkchoiceUpdateFailed.
+    let cfg = genesis_rollup_config();
+    let client = test_engine_client_builder()
+        .with_config(Arc::clone(&cfg))
+        .with_l2_block(BlockId::Number(alloy_eips::BlockNumberOrTag::Number(0).into()), genesis_rpc_block())
+        // fork_choice_updated_v3 is intentionally NOT configured.
+        .build();
+
+    let state_block = crate::test_utils::test_block_info(0);
+    let mut state = TestEngineStateBuilder::new()
+        .with_safe_head(state_block)
+        .with_unsafe_head(state_block)
+        .build();
+
+    let task = FinalizeTask::new(Arc::new(client), Arc::clone(&cfg), 0);
+    let result = task.execute(&mut state).await;
+
+    assert!(
+        matches!(result, Err(FinalizeTaskError::ForkchoiceUpdateFailed(_))),
+        "expected ForkchoiceUpdateFailed, got {result:?}"
+    );
+}
+
+#[tokio::test]
+async fn success_updates_engine_state_finalized_head() {
+    // Full happy path: fetch genesis block, pass from_block_and_genesis, dispatch FCU.
+    // The state's finalized_head starts at B256::ZERO; after the task it should be the
+    // OP Sepolia genesis hash, confirming the FCU was called with the correct block.
+    let cfg = genesis_rollup_config();
+    let client = test_engine_client_builder()
+        .with_config(Arc::clone(&cfg))
+        .with_l2_block(BlockId::Number(alloy_eips::BlockNumberOrTag::Number(0).into()), genesis_rpc_block())
+        .with_fork_choice_updated_v3_response(valid_fcu())
+        .build();
+
+    // Default TestEngineStateBuilder starts finalized_head with hash = B256::ZERO.
+    // The genesis block we provide has hash = OP_SEPOLIA_GENESIS_HASH, so the state
+    // differs → SynchronizeTask will call FCU and update the state.
+    let mut state = TestEngineStateBuilder::new().build();
+
+    let task = FinalizeTask::new(Arc::new(client), Arc::clone(&cfg), 0);
+    task.execute(&mut state).await.expect("FinalizeTask should succeed");
+
+    assert_eq!(
+        state.sync_state.finalized_head().block_info.hash,
+        OP_SEPOLIA_GENESIS_HASH,
+        "finalized_head hash should match the genesis block after successful finalization"
+    );
+}

--- a/crates/consensus/service/src/actors/derivation/finalizer.rs
+++ b/crates/consensus/service/src/actors/derivation/finalizer.rs
@@ -88,7 +88,12 @@ mod tests {
             seq_num: 0,
         };
         let derived_from = BlockInfo { number: l1_origin_number, ..Default::default() };
-        OpAttributesWithParent::new(OpPayloadAttributes::default(), parent, Some(derived_from), false)
+        OpAttributesWithParent::new(
+            OpPayloadAttributes::default(),
+            parent,
+            Some(derived_from),
+            false,
+        )
     }
 
     /// Build a [`BlockInfo`] representing a finalized L1 block at `number`.

--- a/crates/consensus/service/src/actors/derivation/finalizer.rs
+++ b/crates/consensus/service/src/actors/derivation/finalizer.rs
@@ -68,3 +68,110 @@ impl L2Finalizer {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    //! Unit tests for [`L2Finalizer`] queue management.
+
+    use alloy_eips::BlockNumHash;
+    use base_alloy_rpc_types_engine::OpPayloadAttributes;
+    use base_protocol::{BlockInfo, L2BlockInfo, OpAttributesWithParent};
+
+    use super::L2Finalizer;
+
+    /// Build a minimal [`OpAttributesWithParent`] whose derived L2 block number is
+    /// `l2_parent_number + 1` and whose L1 origin is `l1_origin_number`.
+    fn attrs(l2_parent_number: u64, l1_origin_number: u64) -> OpAttributesWithParent {
+        let parent = L2BlockInfo {
+            block_info: BlockInfo { number: l2_parent_number, ..Default::default() },
+            l1_origin: BlockNumHash::default(),
+            seq_num: 0,
+        };
+        let derived_from = BlockInfo { number: l1_origin_number, ..Default::default() };
+        OpAttributesWithParent::new(OpPayloadAttributes::default(), parent, Some(derived_from), false)
+    }
+
+    /// Build a [`BlockInfo`] representing a finalized L1 block at `number`.
+    fn l1_at(number: u64) -> BlockInfo {
+        BlockInfo { number, ..Default::default() }
+    }
+
+    #[test]
+    fn empty_queue_returns_none() {
+        let mut f = L2Finalizer::default();
+        assert!(f.try_finalize_next(l1_at(100)).is_none());
+    }
+
+    #[test]
+    fn single_entry_l1_not_yet_finalized() {
+        let mut f = L2Finalizer::default();
+        // L2 block 10 came from L1 origin 5. Finalizing at L1=3 should not include it.
+        f.enqueue_for_finalization(&attrs(9, 5)); // l2=10, l1_origin=5
+        assert!(f.try_finalize_next(l1_at(3)).is_none());
+        // Entry must still be in the queue.
+        assert!(f.try_finalize_next(l1_at(5)).is_some());
+    }
+
+    #[test]
+    fn single_entry_l1_exactly_at_finalized() {
+        // Boundary: l1_origin == finalized_l1. The range is `..=`, so this must match.
+        let mut f = L2Finalizer::default();
+        f.enqueue_for_finalization(&attrs(9, 5)); // l2=10, l1_origin=5
+        assert_eq!(f.try_finalize_next(l1_at(5)), Some(10));
+    }
+
+    #[test]
+    fn multiple_l2_per_epoch_keeps_highest() {
+        // Three L2 blocks all derived from L1 epoch 1. Only the highest (3) should be returned.
+        let mut f = L2Finalizer::default();
+        f.enqueue_for_finalization(&attrs(0, 1)); // l2=1, l1_origin=1
+        f.enqueue_for_finalization(&attrs(1, 1)); // l2=2, l1_origin=1
+        f.enqueue_for_finalization(&attrs(2, 1)); // l2=3, l1_origin=1
+        assert_eq!(f.try_finalize_next(l1_at(1)), Some(3));
+    }
+
+    #[test]
+    fn partial_finalization_drains_lower_entries() {
+        // Entries at L1=1,2,3. Finalizing at L1=2 returns highest across L1<=2 and drains those.
+        let mut f = L2Finalizer::default();
+        f.enqueue_for_finalization(&attrs(4, 1)); // l2=5,  l1_origin=1
+        f.enqueue_for_finalization(&attrs(7, 2)); // l2=8,  l1_origin=2
+        f.enqueue_for_finalization(&attrs(10, 3)); // l2=11, l1_origin=3
+
+        assert_eq!(f.try_finalize_next(l1_at(2)), Some(8));
+        // L1=3 entry must still be present.
+        assert_eq!(f.try_finalize_next(l1_at(3)), Some(11));
+    }
+
+    #[test]
+    fn clear_empties_queue() {
+        let mut f = L2Finalizer::default();
+        f.enqueue_for_finalization(&attrs(4, 1));
+        f.enqueue_for_finalization(&attrs(7, 2));
+        f.clear();
+        assert!(f.try_finalize_next(l1_at(100)).is_none());
+    }
+
+    #[test]
+    fn drain_preserves_future_entries() {
+        // After finalizing up to L1=2, entries at L1=5 must survive.
+        let mut f = L2Finalizer::default();
+        f.enqueue_for_finalization(&attrs(4, 2)); // l2=5,  l1_origin=2
+        f.enqueue_for_finalization(&attrs(9, 5)); // l2=10, l1_origin=5
+
+        assert_eq!(f.try_finalize_next(l1_at(2)), Some(5));
+        // L1=5 entry is still present; finalizing it now returns l2=10.
+        assert_eq!(f.try_finalize_next(l1_at(5)), Some(10));
+    }
+
+    #[test]
+    fn old_finalized_signal_returns_none_after_drain() {
+        // After draining all entries up to L1=5, a later signal for L1=2 finds nothing.
+        let mut f = L2Finalizer::default();
+        f.enqueue_for_finalization(&attrs(19, 5)); // l2=20, l1_origin=5
+
+        assert_eq!(f.try_finalize_next(l1_at(5)), Some(20));
+        // Queue is now empty; an older signal cannot regress to a stale entry.
+        assert!(f.try_finalize_next(l1_at(2)).is_none());
+    }
+}


### PR DESCRIPTION
## Summary

Adds comprehensive tests for the L2 finality pipeline, which previously had zero test coverage across its critical path. The L2Finalizer unit tests (8) cover queue management logic including the inclusive boundary of the BTreeMap range query, max-per-epoch coalescing, partial drain behavior, and the no-regression invariant after drain. The FinalizeTask unit tests (5) cover all error variants (BlockNotSafe, BlockNotFound, genesis hash mismatch, FCU failure) and the full happy-path state update. The integration tests (5) in actions/harness verify end-to-end that L2 finalized head correctly follows L1 finality signals through the derivation pipeline, including multi-block epochs, incremental epoch advancement, safe-head capping, reorg recovery, and non-regression.