### PR TITLE
feat(actions): Unsafe Head Gossip Simulation

### DIFF
--- a/actions/harness/src/verifier.rs
+++ b/actions/harness/src/verifier.rs
@@ -425,7 +425,7 @@ impl<P: Pipeline + SignalReceiver + Debug + Send> L2Verifier<P> {
                 Ok(StepResult::OriginAdvanceErr(PipelineErrorKind::Temporary(e)))
             }
             StepResult::StepFailed(err) | StepResult::OriginAdvanceErr(err) => {
-                Err(VerifierError::Pipeline(err))
+                Err(VerifierError::Pipeline(Box::new(err)))
             }
         }
     }
@@ -509,22 +509,22 @@ impl<P: Pipeline + SignalReceiver + Debug + Send> L2Verifier<P> {
                     PipelineErrorKind::Temporary(PipelineError::NotEnoughData) => {
                         no_progress += 1;
                         if no_progress > 1_000 {
-                            return Err(VerifierError::Pipeline(
+                            return Err(VerifierError::Pipeline(Box::new(
                                 PipelineError::Provider(
                                     "pipeline stuck: 1000 consecutive NotEnoughData without progress"
                                         .into(),
                                 )
                                 .temp(),
-                            ));
+                            )));
                         }
                     }
-                    err => return Err(VerifierError::Pipeline(err)),
+                    err => return Err(VerifierError::Pipeline(Box::new(err))),
                 },
                 StepResult::OriginAdvanceErr(err) => match err {
                     PipelineErrorKind::Temporary(PipelineError::Eof) => {
                         return Ok((steps, false));
                     }
-                    err => return Err(VerifierError::Pipeline(err)),
+                    err => return Err(VerifierError::Pipeline(Box::new(err))),
                 },
             }
         }

--- a/actions/harness/src/verifier.rs
+++ b/actions/harness/src/verifier.rs
@@ -3,7 +3,7 @@ use std::{collections::HashMap, fmt::Debug, sync::Arc};
 use alloy_eips::BlockNumHash;
 use alloy_primitives::B256;
 use alloy_rlp::Decodable;
-use base_alloy_consensus::TxDeposit;
+use base_alloy_consensus::{OpBlock, OpTxEnvelope, TxDeposit};
 use base_consensus_derive::{
     ActivationSignal, IndexedAttributesQueueStage, Pipeline, PipelineBuilder, PipelineError,
     PipelineErrorKind, ResetSignal, Signal, SignalReceiver, StatefulAttributesBuilder, StepResult,
@@ -47,6 +47,9 @@ pub enum VerifierError {
     /// A pipeline signal failed.
     #[error("signal error: {0}")]
     Signal(PipelineErrorKind),
+    /// The gossiped block has no L1 info deposit as its first transaction.
+    #[error("gossip receive: missing or invalid L1 info deposit in block")]
+    GossipDecodeFailed,
 }
 
 /// In-process rollup node for action tests.
@@ -71,6 +74,14 @@ pub struct L2Verifier<P: Pipeline + SignalReceiver + Debug> {
     pipeline: P,
     /// The current L2 safe head (advances as attributes are consumed).
     safe_head: L2BlockInfo,
+    /// The current L2 unsafe head.
+    ///
+    /// In a verifier-only setup this equals `safe_head`. When unsafe blocks are
+    /// injected via [`act_l2_unsafe_gossip_receive`], it advances independently
+    /// and ahead of `safe_head` until derivation catches up.
+    ///
+    /// [`act_l2_unsafe_gossip_receive`]: L2Verifier::act_l2_unsafe_gossip_receive
+    unsafe_head: L2BlockInfo,
     /// The current L2 finalized head.
     ///
     /// Updated via [`act_l1_finalized_signal`] by scanning [`safe_head_history`]
@@ -175,6 +186,7 @@ impl<P: Pipeline + SignalReceiver + Debug + Send> L2Verifier<P> {
         Self {
             pipeline,
             safe_head,
+            unsafe_head: safe_head,
             finalized_head: safe_head,
             finalized_l1_number: 0,
             safe_head_history: Vec::new(),
@@ -224,12 +236,13 @@ impl<P: Pipeline + SignalReceiver + Debug + Send> L2Verifier<P> {
     /// Return the current L2 unsafe head.
     ///
     /// In a verifier-only setup the unsafe head is the same as the safe head
-    /// since no sequencer is operating. When paired with an [`L2Sequencer`]
-    /// actor this will diverge.
+    /// since no sequencer is operating. When unsafe blocks are injected via
+    /// [`act_l2_unsafe_gossip_receive`], this advances ahead of `safe_head`
+    /// until derivation catches up.
     ///
-    /// [`L2Sequencer`]: crate::L2Sequencer
+    /// [`act_l2_unsafe_gossip_receive`]: L2Verifier::act_l2_unsafe_gossip_receive
     pub const fn l2_unsafe(&self) -> L2BlockInfo {
-        self.safe_head
+        self.unsafe_head
     }
 
     /// Return the current L2 finalized head.
@@ -529,6 +542,68 @@ impl<P: Pipeline + SignalReceiver + Debug + Send> L2Verifier<P> {
     /// [`L2Sequencer::build_next_block`]: crate::L2Sequencer::build_next_block
     pub fn register_block_hash(&mut self, number: u64, hash: B256) {
         self.block_hashes.insert(number, hash);
+    }
+
+    /// Inject an unsafe L2 block as if received via P2P gossip.
+    ///
+    /// Equivalent to op-e2e's `ActL2UnsafeGossipReceive`. The block's header is
+    /// used to advance `unsafe_head`; the block hash is also registered in
+    /// `block_hashes` so that subsequent derivation can build a consistent
+    /// `parent_hash` chain without a separate [`register_block_hash`] call.
+    ///
+    /// Only advances `unsafe_head` if `block.header.number` is exactly
+    /// `unsafe_head.number + 1` — gaps and out-of-order gossip are silently dropped.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`VerifierError::GossipDecodeFailed`] if the first transaction is
+    /// not a valid L1 info deposit (i.e. the block was not produced by a
+    /// well-formed sequencer).
+    ///
+    /// [`register_block_hash`]: L2Verifier::register_block_hash
+    pub fn act_l2_unsafe_gossip_receive(&mut self, block: &OpBlock) -> Result<(), VerifierError> {
+        // Only accept the strictly next block; gaps and duplicates are dropped silently.
+        if block.header.number != self.unsafe_head.block_info.number + 1 {
+            return Ok(());
+        }
+        let hash = block.header.hash_slow();
+        // Auto-register so parent_hash chaining works in later derivation.
+        self.block_hashes.insert(block.header.number, hash);
+
+        let l1_origin =
+            self.l1_origin_from_block(block).ok_or(VerifierError::GossipDecodeFailed)?;
+        let seq_num = if l1_origin == self.unsafe_head.l1_origin {
+            self.unsafe_head.seq_num + 1
+        } else {
+            0
+        };
+        self.unsafe_head = L2BlockInfo {
+            block_info: BlockInfo {
+                number: block.header.number,
+                hash,
+                parent_hash: block.header.parent_hash,
+                timestamp: block.header.timestamp,
+            },
+            l1_origin,
+            seq_num,
+        };
+        Ok(())
+    }
+
+    /// Decode the L1 epoch from the first deposit transaction in an [`OpBlock`].
+    ///
+    /// Mirrors [`l1_origin_from_attrs`] but operates on a fully-formed block
+    /// (received via gossip) rather than on derived [`OpAttributesWithParent`].
+    ///
+    /// [`l1_origin_from_attrs`]: L2Verifier::l1_origin_from_attrs
+    fn l1_origin_from_block(&self, block: &OpBlock) -> Option<BlockNumHash> {
+        let first = block.body.transactions.first()?;
+        let deposit = match first {
+            OpTxEnvelope::Deposit(d) => d,
+            _ => return None,
+        };
+        let l1_info = L1BlockInfoTx::decode_calldata(deposit.inner().input.as_ref()).ok()?;
+        Some(l1_info.id())
     }
 
     /// Apply derived attributes to the in-memory L2 chain, advancing the safe head.

--- a/actions/harness/src/verifier.rs
+++ b/actions/harness/src/verifier.rs
@@ -43,10 +43,10 @@ pub type BlobVerifierPipeline = base_consensus_derive::DerivationPipeline<
 pub enum VerifierError {
     /// The pipeline returned a critical error.
     #[error("pipeline error: {0}")]
-    Pipeline(PipelineErrorKind),
+    Pipeline(Box<PipelineErrorKind>),
     /// A pipeline signal failed.
     #[error("signal error: {0}")]
-    Signal(PipelineErrorKind),
+    Signal(Box<PipelineErrorKind>),
     /// The gossiped block has no L1 info deposit as its first transaction.
     #[error("gossip receive: missing or invalid L1 info deposit in block")]
     GossipDecodeFailed,
@@ -221,7 +221,7 @@ impl<P: Pipeline + SignalReceiver + Debug + Send> L2Verifier<P> {
                     .signal(),
             )
             .await
-            .map_err(VerifierError::Signal)?;
+            .map_err(|e| VerifierError::Signal(Box::new(e)))?;
 
         // Drain the genesis L1 block (no batcher data; sets IndexedTraversal::done = true).
         self.act_l2_pipeline_full().await?;
@@ -258,7 +258,7 @@ impl<P: Pipeline + SignalReceiver + Debug + Send> L2Verifier<P> {
     ///
     /// [`IndexedTraversal`]: base_consensus_derive::IndexedTraversal
     pub async fn act_l1_head_signal(&mut self, head: BlockInfo) -> Result<(), VerifierError> {
-        self.pipeline.signal(Signal::ProvideBlock(head)).await.map_err(VerifierError::Signal)
+        self.pipeline.signal(Signal::ProvideBlock(head)).await.map_err(|e| VerifierError::Signal(Box::new(e)))
     }
 
     /// Signal the pipeline that a new L1 safe head is available.
@@ -310,7 +310,7 @@ impl<P: Pipeline + SignalReceiver + Debug + Send> L2Verifier<P> {
                     .signal(),
             )
             .await
-            .map_err(VerifierError::Signal)?;
+            .map_err(|e| VerifierError::Signal(Box::new(e)))?;
         self.safe_head = l2_safe_head;
         // Clear stale finalization state so a subsequent act_l1_finalized_signal
         // cannot promote an L2 block that no longer exists on the canonical chain.
@@ -363,14 +363,14 @@ impl<P: Pipeline + SignalReceiver + Debug + Send> L2Verifier<P> {
                             // This is a transient state — step again immediately.
                             no_progress += 1;
                             if no_progress > 1_000 {
-                                return Err(VerifierError::Pipeline(
+                                return Err(VerifierError::Pipeline(Box::new(
                                     PipelineError::Provider(
                                         "pipeline stuck: 1000 consecutive NotEnoughData without progress".into()
                                     ).temp()
-                                ));
+                                )));
                             }
                         }
-                        _ => return Err(VerifierError::Pipeline(err)),
+                        _ => return Err(VerifierError::Pipeline(Box::new(err))),
                     }
                 }
                 StepResult::OriginAdvanceErr(err) => {
@@ -379,7 +379,7 @@ impl<P: Pipeline + SignalReceiver + Debug + Send> L2Verifier<P> {
                             // Traversal exhausted — no more L1 blocks to advance to.
                             break;
                         }
-                        _ => return Err(VerifierError::Pipeline(err)),
+                        _ => return Err(VerifierError::Pipeline(Box::new(err))),
                     }
                 }
             }

--- a/actions/harness/src/verifier.rs
+++ b/actions/harness/src/verifier.rs
@@ -572,11 +572,8 @@ impl<P: Pipeline + SignalReceiver + Debug + Send> L2Verifier<P> {
 
         let l1_origin =
             self.l1_origin_from_block(block).ok_or(VerifierError::GossipDecodeFailed)?;
-        let seq_num = if l1_origin == self.unsafe_head.l1_origin {
-            self.unsafe_head.seq_num + 1
-        } else {
-            0
-        };
+        let seq_num =
+            if l1_origin == self.unsafe_head.l1_origin { self.unsafe_head.seq_num + 1 } else { 0 };
         self.unsafe_head = L2BlockInfo {
             block_info: BlockInfo {
                 number: block.header.number,

--- a/actions/harness/src/verifier.rs
+++ b/actions/harness/src/verifier.rs
@@ -258,7 +258,10 @@ impl<P: Pipeline + SignalReceiver + Debug + Send> L2Verifier<P> {
     ///
     /// [`IndexedTraversal`]: base_consensus_derive::IndexedTraversal
     pub async fn act_l1_head_signal(&mut self, head: BlockInfo) -> Result<(), VerifierError> {
-        self.pipeline.signal(Signal::ProvideBlock(head)).await.map_err(|e| VerifierError::Signal(Box::new(e)))
+        self.pipeline
+            .signal(Signal::ProvideBlock(head))
+            .await
+            .map_err(|e| VerifierError::Signal(Box::new(e)))
     }
 
     /// Signal the pipeline that a new L1 safe head is available.

--- a/actions/harness/tests/unsafe_gossip.rs
+++ b/actions/harness/tests/unsafe_gossip.rs
@@ -113,9 +113,7 @@ async fn test_unsafe_chain_advances_safe_catches_up() {
 
     // --- Phase 2: Gossip each block into the verifier. ---
     for block in &blocks {
-        verifier
-            .act_l2_unsafe_gossip_receive(block)
-            .expect("gossip receive should succeed");
+        verifier.act_l2_unsafe_gossip_receive(block).expect("gossip receive should succeed");
     }
 
     assert_eq!(
@@ -131,8 +129,7 @@ async fn test_unsafe_chain_advances_safe_catches_up() {
 
     // --- Phase 3+4: Signal L1 head and run derivation. ---
     verifier.act_l1_head_signal(l1_block_1).await.expect("L1 head signal should succeed");
-    let derived =
-        verifier.act_l2_pipeline_full().await.expect("pipeline full should succeed");
+    let derived = verifier.act_l2_pipeline_full().await.expect("pipeline full should succeed");
 
     assert_eq!(derived, L2_BLOCK_COUNT as usize, "expected {L2_BLOCK_COUNT} L2 blocks derived");
     assert_eq!(
@@ -170,9 +167,7 @@ async fn test_out_of_order_gossip_is_dropped() {
     verifier.initialize().await.expect("initialize should succeed");
 
     // Inject block 3 first — gap-jump; must be dropped.
-    verifier
-        .act_l2_unsafe_gossip_receive(&block3)
-        .expect("out-of-order gossip must not error");
+    verifier.act_l2_unsafe_gossip_receive(&block3).expect("out-of-order gossip must not error");
     assert_eq!(
         verifier.l2_unsafe().block_info.number,
         0,
@@ -180,9 +175,7 @@ async fn test_out_of_order_gossip_is_dropped() {
     );
 
     // Inject block 1 — sequential; must advance.
-    verifier
-        .act_l2_unsafe_gossip_receive(&block1)
-        .expect("in-order gossip must succeed");
+    verifier.act_l2_unsafe_gossip_receive(&block1).expect("in-order gossip must succeed");
     assert_eq!(
         verifier.l2_unsafe().block_info.number,
         1,
@@ -190,9 +183,7 @@ async fn test_out_of_order_gossip_is_dropped() {
     );
 
     // Inject block 3 again — still a gap (unsafe_head=1, next expected=2); must be dropped.
-    verifier
-        .act_l2_unsafe_gossip_receive(&block3)
-        .expect("gap gossip must not error");
+    verifier.act_l2_unsafe_gossip_receive(&block3).expect("gap gossip must not error");
     assert_eq!(
         verifier.l2_unsafe().block_info.number,
         1,

--- a/actions/harness/tests/unsafe_gossip.rs
+++ b/actions/harness/tests/unsafe_gossip.rs
@@ -1,0 +1,201 @@
+#![doc = "Action tests for L2 unsafe-head gossip simulation."]
+
+use std::sync::Arc;
+
+use base_action_harness::{
+    ActionDataSource, ActionL1ChainProvider, ActionL2ChainProvider, ActionL2Source,
+    ActionTestHarness, BatcherConfig, L1MinerConfig, L2Verifier, SharedL1Chain, VerifierPipeline,
+    block_info_from,
+};
+use base_consensus_genesis::{L1ChainConfig, RollupConfig};
+use base_consensus_registry::Registry;
+use base_protocol::{BlockInfo, L2BlockInfo};
+
+/// Build a [`RollupConfig`] wired to the given [`BatcherConfig`].
+///
+/// Mirrors the helper in `derivation.rs`: starts from the Base mainnet config
+/// and overrides only the fields that must differ for in-memory action tests.
+fn rollup_config_for(batcher: &BatcherConfig) -> RollupConfig {
+    let mut rc = Registry::rollup_config(8453).expect("mainnet config").clone();
+    rc.batch_inbox_address = batcher.inbox_address;
+    rc.genesis.system_config.as_mut().unwrap().batcher_address = batcher.batcher_address;
+    rc.genesis.l2_time = 0;
+    rc.genesis.l1 = Default::default();
+    rc.genesis.l2 = Default::default();
+    rc.hardforks.canyon_time = Some(0);
+    rc.hardforks.delta_time = Some(0);
+    rc.hardforks.ecotone_time = Some(0);
+    rc.hardforks.fjord_time = Some(0);
+    rc
+}
+
+/// Create a verifier wired to `h`'s current L1 chain, returning both the
+/// verifier and the shared chain.
+///
+/// Extracted to avoid duplicating the 20-line constructor in every test.
+fn make_verifier(
+    h: &ActionTestHarness,
+    rollup_cfg: &RollupConfig,
+) -> (L2Verifier<VerifierPipeline>, SharedL1Chain) {
+    let chain = SharedL1Chain::from_blocks(h.l1.chain().to_vec());
+    let rollup_config = Arc::new(rollup_cfg.clone());
+    let l1_chain_config = Arc::new(L1ChainConfig::default());
+    let l1_provider = ActionL1ChainProvider::new(chain.clone());
+    let dap_source = ActionDataSource::new(chain.clone(), rollup_cfg.batch_inbox_address);
+    let genesis_l1 = block_info_from(h.l1.chain().first().expect("genesis always present"));
+    let safe_head = L2BlockInfo {
+        block_info: BlockInfo {
+            hash: rollup_cfg.genesis.l2.hash,
+            number: rollup_cfg.genesis.l2.number,
+            parent_hash: Default::default(),
+            timestamp: rollup_cfg.genesis.l2_time,
+        },
+        l1_origin: alloy_eips::BlockNumHash { number: genesis_l1.number, hash: genesis_l1.hash },
+        seq_num: 0,
+    };
+    let l2_provider = ActionL2ChainProvider::from_genesis(rollup_cfg);
+    let verifier = L2Verifier::new(
+        rollup_config,
+        l1_chain_config,
+        l1_provider,
+        dap_source,
+        l2_provider,
+        safe_head,
+        genesis_l1,
+    );
+    (verifier, chain)
+}
+
+/// Simulates the full op-e2e gossip pattern:
+///
+/// 1. A sequencer builds 5 L2 blocks.
+/// 2. Each block is gossiped to the verifier, advancing `unsafe_head` to 5.
+///    Throughout this phase `safe_head` stays at genesis (0).
+/// 3. All blocks are batched and submitted to L1; one L1 block is mined.
+/// 4. The verifier is signalled about the new L1 head and runs full derivation.
+///    `safe_head` catches up to `unsafe_head` (both at 5).
+#[tokio::test]
+async fn test_unsafe_chain_advances_safe_catches_up() {
+    const L2_BLOCK_COUNT: u64 = 5;
+
+    let batcher_cfg = BatcherConfig::default();
+    let rollup_cfg = rollup_config_for(&batcher_cfg);
+    let mut h = ActionTestHarness::new(L1MinerConfig::default(), rollup_cfg.clone());
+
+    // --- Phase 1: Build L2 blocks with the sequencer. ---
+    let l1_chain = SharedL1Chain::from_blocks(h.l1.chain().to_vec());
+    let mut sequencer = h.create_l2_sequencer(l1_chain);
+    let mut blocks = Vec::with_capacity(L2_BLOCK_COUNT as usize);
+    for _ in 0..L2_BLOCK_COUNT {
+        blocks.push(sequencer.build_next_block().expect("build L2 block"));
+    }
+
+    // --- Phase 2 (setup): Batch + mine so the verifier can later derive. ---
+    // All 5 blocks are encoded into one batcher transaction and mined into
+    // a single L1 block before the verifier is created.
+    let mut source = ActionL2Source::new();
+    for block in &blocks {
+        source.push(block.clone());
+    }
+    let mut batcher = h.create_batcher(source, batcher_cfg);
+    batcher.advance().expect("batcher should encode all blocks");
+    drop(batcher);
+    h.l1.mine_block();
+    let l1_block_1 = block_info_from(h.l1.tip());
+
+    // Create the verifier AFTER mining so the SharedL1Chain snapshot already
+    // contains the L1 block with the batch.
+    let (mut verifier, _chain) = make_verifier(&h, &rollup_cfg);
+
+    // Initialize: seed the genesis SystemConfig and drain the empty genesis
+    // L1 block so IndexedTraversal is ready for new block signals.
+    verifier.initialize().await.expect("initialize should succeed");
+
+    // --- Phase 2: Gossip each block into the verifier. ---
+    for block in &blocks {
+        verifier
+            .act_l2_unsafe_gossip_receive(block)
+            .expect("gossip receive should succeed");
+    }
+
+    assert_eq!(
+        verifier.l2_unsafe().block_info.number,
+        L2_BLOCK_COUNT,
+        "unsafe_head should have advanced to block {L2_BLOCK_COUNT} after gossip"
+    );
+    assert_eq!(
+        verifier.l2_safe().block_info.number,
+        0,
+        "safe_head should still be at genesis before derivation"
+    );
+
+    // --- Phase 3+4: Signal L1 head and run derivation. ---
+    verifier.act_l1_head_signal(l1_block_1).await.expect("L1 head signal should succeed");
+    let derived =
+        verifier.act_l2_pipeline_full().await.expect("pipeline full should succeed");
+
+    assert_eq!(derived, L2_BLOCK_COUNT as usize, "expected {L2_BLOCK_COUNT} L2 blocks derived");
+    assert_eq!(
+        verifier.l2_safe().block_info.number,
+        L2_BLOCK_COUNT,
+        "safe_head should have caught up to block {L2_BLOCK_COUNT}"
+    );
+    assert_eq!(
+        verifier.l2_unsafe().block_info.number,
+        verifier.l2_safe().block_info.number,
+        "unsafe_head and safe_head should be equal after safe chain caught up"
+    );
+}
+
+/// Verify that gossiped blocks arriving out of sequential order are silently
+/// dropped and do not advance `unsafe_head`.
+///
+/// The guard accepts only `block.number == unsafe_head.number + 1`.  Injecting
+/// block 3 when `unsafe_head` is at genesis (0) is a gap-jump: 3 ≠ 0 + 1,
+/// so the block is dropped and `unsafe_head` stays at 0.
+#[tokio::test]
+async fn test_out_of_order_gossip_is_dropped() {
+    let batcher_cfg = BatcherConfig::default();
+    let rollup_cfg = rollup_config_for(&batcher_cfg);
+    let h = ActionTestHarness::new(L1MinerConfig::default(), rollup_cfg.clone());
+
+    // Build 3 sequential L2 blocks (we will inject block 3 first, skipping 1 & 2).
+    let l1_chain = SharedL1Chain::from_blocks(h.l1.chain().to_vec());
+    let mut sequencer = h.create_l2_sequencer(l1_chain);
+    let block1 = sequencer.build_next_block().expect("build block 1");
+    let _block2 = sequencer.build_next_block().expect("build block 2");
+    let block3 = sequencer.build_next_block().expect("build block 3");
+
+    let (mut verifier, _chain) = make_verifier(&h, &rollup_cfg);
+    verifier.initialize().await.expect("initialize should succeed");
+
+    // Inject block 3 first — gap-jump; must be dropped.
+    verifier
+        .act_l2_unsafe_gossip_receive(&block3)
+        .expect("out-of-order gossip must not error");
+    assert_eq!(
+        verifier.l2_unsafe().block_info.number,
+        0,
+        "unsafe_head must not advance when block 3 arrives before blocks 1 and 2"
+    );
+
+    // Inject block 1 — sequential; must advance.
+    verifier
+        .act_l2_unsafe_gossip_receive(&block1)
+        .expect("in-order gossip must succeed");
+    assert_eq!(
+        verifier.l2_unsafe().block_info.number,
+        1,
+        "unsafe_head should advance to 1 after sequential gossip of block 1"
+    );
+
+    // Inject block 3 again — still a gap (unsafe_head=1, next expected=2); must be dropped.
+    verifier
+        .act_l2_unsafe_gossip_receive(&block3)
+        .expect("gap gossip must not error");
+    assert_eq!(
+        verifier.l2_unsafe().block_info.number,
+        1,
+        "unsafe_head must stay at 1 when block 3 arrives before block 2"
+    );
+}


### PR DESCRIPTION
## Summary

Implements P2P gossip simulation in the actions/harness framework by adding an unsafe_head field to L2Verifier and a new act_l2_unsafe_gossip_receive method. The method advances unsafe_head when gossiped blocks arrive in sequential order and silently drops gaps or duplicates. A new l1_origin_from_block helper decodes the L1 epoch from the first deposit transaction in a gossiped OpBlock, mirroring the existing l1_origin_from_attrs path. The VerifierError enum gains a GossipDecodeFailed variant and l2_unsafe() now returns the real unsafe_head instead of the prior safe_head stub. Two integration tests in unsafe_gossip.rs verify the full pattern: unsafe_head advances independently while safe_head stays at genesis, then derivation runs and safe_head catches up, and separately that out-of-order gossip is silently dropped.