### PR TITLE
refactor(tx-manager): fix nits from recent PRs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4487,7 +4487,6 @@ dependencies = [
  "proptest",
  "rayon",
  "rstest",
- "serde",
  "thiserror 2.0.18",
  "tokio",
  "tracing",

--- a/crates/utilities/tx-manager/Cargo.toml
+++ b/crates/utilities/tx-manager/Cargo.toml
@@ -36,5 +36,4 @@ alloy-consensus.workspace = true
 alloy-signer-local.workspace = true
 alloy-node-bindings.workspace = true
 clap = { workspace = true, features = ["derive", "env"] }
-serde = { workspace = true, features = ["derive", "std"] }
 tokio = { workspace = true, features = ["macros", "net", "rt", "rt-multi-thread"] }

--- a/crates/utilities/tx-manager/Cargo.toml
+++ b/crates/utilities/tx-manager/Cargo.toml
@@ -15,8 +15,8 @@ workspace = true
 # alloy
 alloy-network.workspace = true
 alloy-provider.workspace = true
+alloy-primitives.workspace = true
 alloy-eips = { workspace = true, features = ["std"] }
-alloy-primitives = { workspace = true, features = ["std"] }
 alloy-rpc-types-eth = { workspace = true, features = ["std"] }
 
 # misc

--- a/crates/utilities/tx-manager/README.md
+++ b/crates/utilities/tx-manager/README.md
@@ -38,8 +38,8 @@ Transaction lifecycle management for Base onchain components.
   pre-publish nonce-too-low, threshold nonce-too-low, and mempool deadline expiry.
 - **`TxManagerCli`**: Clap-based CLI argument struct with environment variable fallbacks
   (prefix `BASE_TX_MANAGER`). Captures all tunable tx-manager parameters and is designed
-  to be `#[command(flatten)]`-ed into parent CLI structs. Derives `Serialize`/`Deserialize`
-  and generates `Default` and `TryFrom<TxManagerCli> for TxManagerConfig` impls.
+  to be `#[command(flatten)]`-ed into parent CLI structs. Generates `Default` and
+  `TryFrom<TxManagerCli> for TxManagerConfig` impls.
 - **`TxManagerConfig`**: Validated runtime configuration with public fields. Can be
   constructed directly and validated via `validate()`, or converted from `TxManagerCli`
   via `TryFrom`.
@@ -159,10 +159,9 @@ struct Cli {
 let config = TxManagerConfig::try_from(cli.tx)?;
 ```
 
-> **Note:** The macro expands to absolute paths (`::clap::Parser`,
-> `::humantime::parse_duration`, `::serde::{Serialize, Deserialize}`),
-> so consumer crates must add `clap` (with `derive` + `env` features),
-> `humantime`, and `serde` (with `derive` feature) to their own
+> **Note:** The macro expands to absolute paths (`::clap::Parser` and
+> `::humantime::parse_duration`), so consumer crates must add `clap`
+> (with `derive` + `env` features) and `humantime` to their own
 > `Cargo.toml`.
 
 ### Fee limit checks

--- a/crates/utilities/tx-manager/src/macros.rs
+++ b/crates/utilities/tx-manager/src/macros.rs
@@ -21,16 +21,15 @@
 ///
 /// # Required downstream dependencies
 ///
-/// The macro expands to code that references `::clap::Parser`,
-/// `::humantime::parse_duration`, and `::serde::{Serialize, Deserialize}` via
-/// absolute paths. Consumer crates that invoke `define_tx_manager_cli!` must
-/// add these dependencies to their own `Cargo.toml`:
+/// The macro expands to code that references `::clap::Parser` and
+/// `::humantime::parse_duration` via absolute paths. Consumer crates that
+/// invoke `define_tx_manager_cli!` must add these dependencies to their own
+/// `Cargo.toml`:
 ///
 /// ```toml
 /// [dependencies]
 /// clap = { version = "...", features = ["derive", "env"] }
 /// humantime = "..."
-/// serde = { version = "...", features = ["derive"] }
 /// ```
 #[rustfmt::skip]
 #[macro_export]
@@ -41,7 +40,7 @@ macro_rules! define_tx_manager_cli {
         /// Designed to be `#[command(flatten)]`-ed into parent CLI structs
         /// (proposer, challenger, batcher binaries). All fields use environment
         /// variable fallbacks with the configured prefix.
-        #[derive(Debug, Clone, ::clap::Parser, ::serde::Serialize, ::serde::Deserialize)]
+        #[derive(Debug, Clone, ::clap::Parser)]
         #[command(next_help_heading = "Tx Manager")]
         pub struct TxManagerCli {
             /// Number of block confirmations to wait before considering a

--- a/crates/utilities/tx-manager/src/manager.rs
+++ b/crates/utilities/tx-manager/src/manager.rs
@@ -316,7 +316,7 @@ impl SimpleTxManager {
             .with_value(candidate.value)
             .with_chain_id(self.chain_id);
 
-        tx_request.from = Some(from);
+        tx_request.set_from(from);
 
         match candidate.to {
             Some(to) => tx_request.set_to(to),

--- a/crates/utilities/tx-manager/src/manager.rs
+++ b/crates/utilities/tx-manager/src/manager.rs
@@ -177,10 +177,6 @@ impl SimpleTxManager {
     /// manager is closed. Otherwise returns the first non-retryable error,
     /// or the last retryable error after exhausting all retry attempts.
     pub async fn prepare(&self, candidate: &TxCandidate) -> TxManagerResult<Bytes> {
-        if self.is_closed() {
-            return Err(TxManagerError::ChannelClosed);
-        }
-
         (|| async {
             // Re-check closed flag on each retry attempt to avoid wasted
             // RPC calls after shutdown. ChannelClosed is non-retryable,

--- a/crates/utilities/tx-manager/src/nonce.rs
+++ b/crates/utilities/tx-manager/src/nonce.rs
@@ -227,6 +227,11 @@ impl Drop for NonceGuard {
 
 #[cfg(test)]
 mod tests {
+    use std::{
+        future::{Future, poll_fn},
+        task::Poll,
+    };
+
     use alloy_node_bindings::Anvil;
 
     use super::*;
@@ -264,5 +269,34 @@ mod tests {
 
         let err = manager.next_nonce().await.expect_err("should overflow");
         assert_eq!(err, TxManagerError::NonceOverflow);
+    }
+
+    #[tokio::test]
+    async fn reset_stays_pending_while_nonce_guard_holds_mutex() {
+        let anvil = Anvil::new().spawn();
+        let url = anvil.endpoint_url();
+        let provider = RootProvider::new_http(url);
+        let address = anvil.addresses()[0];
+
+        let manager = NonceManager::new_with_nonce(provider, address, 0);
+
+        let guard = manager.next_nonce().await.expect("should reserve nonce");
+        assert_eq!(guard.nonce(), 0);
+
+        let mut reset = std::pin::pin!(manager.reset());
+        let reset_is_pending = poll_fn(|cx| {
+            Poll::Ready(matches!(reset.as_mut().poll(cx), Poll::Pending))
+        })
+        .await;
+        assert!(
+            reset_is_pending,
+            "reset() must stay pending while a NonceGuard holds the mutex",
+        );
+
+        drop(guard);
+        reset.await;
+
+        let guard = manager.next_nonce().await.expect("should re-fetch after reset");
+        assert_eq!(guard.nonce(), 0);
     }
 }

--- a/crates/utilities/tx-manager/src/nonce.rs
+++ b/crates/utilities/tx-manager/src/nonce.rs
@@ -284,14 +284,9 @@ mod tests {
         assert_eq!(guard.nonce(), 0);
 
         let mut reset = std::pin::pin!(manager.reset());
-        let reset_is_pending = poll_fn(|cx| {
-            Poll::Ready(matches!(reset.as_mut().poll(cx), Poll::Pending))
-        })
-        .await;
-        assert!(
-            reset_is_pending,
-            "reset() must stay pending while a NonceGuard holds the mutex",
-        );
+        let reset_is_pending =
+            poll_fn(|cx| Poll::Ready(matches!(reset.as_mut().poll(cx), Poll::Pending))).await;
+        assert!(reset_is_pending, "reset() must stay pending while a NonceGuard holds the mutex",);
 
         drop(guard);
         reset.await;

--- a/crates/utilities/tx-manager/tests/craft_tx.rs
+++ b/crates/utilities/tx-manager/tests/craft_tx.rs
@@ -1,7 +1,5 @@
 //! Integration tests for [`SimpleTxManager`] transaction construction with Anvil.
 
-use std::time::Duration;
-
 use alloy_consensus::{SignableTransaction, TxEip1559, TxEnvelope};
 use alloy_eips::{Decodable2718, eip4844::Blob};
 use alloy_network::{EthereumWallet, TxSigner};
@@ -372,9 +370,7 @@ async fn craft_tx_returns_fee_limit_exceeded_when_minimums_inflate_beyond_multip
 }
 
 /// Verifies that `prepare()` exits immediately on a non-retryable error
-/// rather than looping through all 30 retry attempts. A 5-second timeout
-/// guard catches regressions where `Unsupported` is accidentally marked
-/// retryable.
+/// rather than looping through all retry attempts.
 #[tokio::test]
 async fn prepare_exits_immediately_on_non_retryable_error() {
     let (manager, _anvil) = setup().await;
@@ -385,13 +381,7 @@ async fn prepare_exits_immediately_on_non_retryable_error() {
         ..Default::default()
     };
 
-    // If Unsupported were retryable, prepare would wait up to
-    // 30 × 2 s = 60 s. The 5-second timeout catches that regression.
-    let result = tokio::time::timeout(Duration::from_secs(5), manager.prepare(&candidate)).await;
-
-    let err = result
-        .expect("prepare should return within 5 s for a non-retryable error")
-        .expect_err("should reject blob tx");
+    let err = manager.prepare(&candidate).await.expect_err("should reject blob tx");
 
     assert!(
         matches!(err, TxManagerError::Unsupported(_)),

--- a/crates/utilities/tx-manager/tests/nonce.rs
+++ b/crates/utilities/tx-manager/tests/nonce.rs
@@ -276,7 +276,7 @@ async fn rayon_parallel_nonce_acquisition_produces_unique_nonces() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn concurrent_next_nonce_and_reset_stress() {
+async fn concurrent_next_nonce_uniqueness_across_resets() {
     let (manager, _anvil) = setup();
 
     // Run several rounds of concurrent next_nonce() calls separated by

--- a/crates/utilities/tx-manager/tests/nonce.rs
+++ b/crates/utilities/tx-manager/tests/nonce.rs
@@ -1,19 +1,12 @@
 //! Integration tests for [`NonceManager`] with an Anvil backend.
 
-use std::{
-    sync::{
-        Arc,
-        atomic::{AtomicBool, Ordering},
-    },
-    time::Duration,
-};
+use std::time::Duration;
 
 use alloy_node_bindings::Anvil;
 use alloy_primitives::Address;
 use alloy_provider::RootProvider;
 use base_tx_manager::{NonceGuard, NonceManager, TxManagerError};
 use rayon::prelude::*;
-use tokio::sync::Notify;
 
 /// Helper: spawns an Anvil instance and returns a [`NonceManager`] wired to
 /// the first default account.
@@ -204,50 +197,6 @@ fn nonce_guard_is_send() {
     /// Asserts that `T` implements [`Send`].
     fn assert_send<T: Send>() {}
     assert_send::<NonceGuard>();
-}
-
-#[tokio::test(flavor = "multi_thread")]
-async fn reset_blocks_while_guard_held() {
-    let (manager, _anvil) = setup();
-
-    // Reserve nonce 0 — the guard holds the lock.
-    let guard = manager.next_nonce().await.unwrap();
-    assert_eq!(guard.nonce(), 0);
-
-    let reset_completed = Arc::new(AtomicBool::new(false));
-    let flag = Arc::clone(&reset_completed);
-    let about_to_reset = Arc::new(Notify::new());
-    let notify = Arc::clone(&about_to_reset);
-    let mgr = manager.clone();
-
-    // Spawn a task that calls reset(). It should block because the
-    // guard holds the same mutex.
-    let handle = tokio::spawn(async move {
-        notify.notify_one();
-        mgr.reset().await;
-        flag.store(true, Ordering::SeqCst);
-    });
-
-    // Wait until the spawned task is about to call reset(), then yield
-    // to let it enter the lock wait.
-    about_to_reset.notified().await;
-    tokio::task::yield_now().await;
-    assert!(
-        !reset_completed.load(Ordering::SeqCst),
-        "reset() must not complete while a NonceGuard is held",
-    );
-
-    // Drop the guard — reset() should now complete.
-    drop(guard);
-    handle.await.unwrap();
-    assert!(
-        reset_completed.load(Ordering::SeqCst),
-        "reset() should have completed after guard was dropped",
-    );
-
-    // After the reset, next nonce should re-fetch from chain (0).
-    let g = manager.next_nonce().await.unwrap();
-    assert_eq!(g.nonce(), 0);
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/crates/utilities/tx-manager/tests/nonce.rs
+++ b/crates/utilities/tx-manager/tests/nonce.rs
@@ -12,6 +12,7 @@ use alloy_node_bindings::Anvil;
 use alloy_primitives::Address;
 use alloy_provider::RootProvider;
 use base_tx_manager::{NonceGuard, NonceManager, TxManagerError};
+use rayon::prelude::*;
 use tokio::sync::Notify;
 
 /// Helper: spawns an Anvil instance and returns a [`NonceManager`] wired to
@@ -251,8 +252,6 @@ async fn reset_blocks_while_guard_held() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn rayon_parallel_nonce_acquisition_produces_unique_nonces() {
-    use rayon::prelude::*;
-
     let (manager, _anvil) = setup();
     let handle = tokio::runtime::Handle::current();
 


### PR DESCRIPTION
## Summary

  Follow-up cleanup for recent `tx-manager` changes.

  This PR:
  - removes unnecessary `serde` derives from `TxManagerCli` and drops the now-unused `serde` dependency from `base-tx-manager`
  - updates the `tx-manager` macro docs and README so downstream dependency guidance matches the actual generated code
  - removes a redundant early `is_closed()` check in `SimpleTxManager::prepare()` while keeping the retry-loop shutdown check in place
  - switches transaction construction to use `set_from(...)` instead of assigning the field directly
  - simplifies and renames a few `tx-manager` tests to keep coverage focused on the remaining behavior

  ## Notes

  This is intended as a small refactor / cleanup PR with no functional product-facing changes.