### PR TITLE
fix(consensus): Span Batch Decode Bounds Checks

### DIFF
--- a/crates/builder/core/tests/flashblocks.rs
+++ b/crates/builder/core/tests/flashblocks.rs
@@ -263,8 +263,7 @@ async fn unichain_dynamic_with_lag() -> eyre::Result<()> {
 
 #[tokio::test]
 async fn dynamic_with_full_block_lag() -> eyre::Result<()> {
-    let config =
-        BuilderConfig::for_tests().with_block_time_ms(1000).with_flashblocks_leeway_time_ms(0);
+    let config = BuilderConfig::for_tests().with_block_time_ms(1000);
     let rbuilder = setup_test_instance_with_builder_config(config).await?;
     let driver = rbuilder.driver().await?;
     let flashblocks_listener = rbuilder.spawn_flashblocks_listener();

--- a/crates/builder/core/tests/flashblocks.rs
+++ b/crates/builder/core/tests/flashblocks.rs
@@ -263,7 +263,8 @@ async fn unichain_dynamic_with_lag() -> eyre::Result<()> {
 
 #[tokio::test]
 async fn dynamic_with_full_block_lag() -> eyre::Result<()> {
-    let config = BuilderConfig::for_tests().with_block_time_ms(1000);
+    let config =
+        BuilderConfig::for_tests().with_block_time_ms(1000).with_flashblocks_leeway_time_ms(0);
     let rbuilder = setup_test_instance_with_builder_config(config).await?;
     let driver = rbuilder.driver().await?;
     let flashblocks_listener = rbuilder.spawn_flashblocks_listener();

--- a/crates/consensus/protocol/src/batch/prefix.rs
+++ b/crates/consensus/protocol/src/batch/prefix.rs
@@ -48,6 +48,9 @@ impl SpanBatchPrefix {
 
     /// Decodes the parent check from a reader.
     pub fn decode_parent_check(&mut self, r: &mut &[u8]) -> Result<(), SpanBatchError> {
+        if r.len() < 20 {
+            return Err(SpanBatchError::Decoding(SpanDecodingError::ParentCheck));
+        }
         let (parent_check, remaining) = r.split_at(20);
         let parent_check = FixedBytes::<20>::from_slice(parent_check);
         *r = remaining;
@@ -57,6 +60,9 @@ impl SpanBatchPrefix {
 
     /// Decodes the L1 origin check from a reader.
     pub fn decode_l1_origin_check(&mut self, r: &mut &[u8]) -> Result<(), SpanBatchError> {
+        if r.len() < 20 {
+            return Err(SpanBatchError::Decoding(SpanDecodingError::L1OriginCheck));
+        }
         let (l1_origin_check, remaining) = r.split_at(20);
         let l1_origin_check = FixedBytes::<20>::from_slice(l1_origin_check);
         *r = remaining;
@@ -81,6 +87,28 @@ mod test {
     use alloy_primitives::address;
 
     use super::*;
+
+    /// Regression: truncated input to decode_parent_check must return an error, not panic.
+    #[test]
+    fn test_decode_parent_check_truncated_input() {
+        let mut prefix = SpanBatchPrefix::default();
+        let short = [0u8; 19];
+        assert_eq!(
+            prefix.decode_parent_check(&mut short.as_ref()),
+            Err(SpanBatchError::Decoding(SpanDecodingError::ParentCheck))
+        );
+    }
+
+    /// Regression: truncated input to decode_l1_origin_check must return an error, not panic.
+    #[test]
+    fn test_decode_l1_origin_check_truncated_input() {
+        let mut prefix = SpanBatchPrefix::default();
+        let short = [0u8; 19];
+        assert_eq!(
+            prefix.decode_l1_origin_check(&mut short.as_ref()),
+            Err(SpanBatchError::Decoding(SpanDecodingError::L1OriginCheck))
+        );
+    }
 
     #[test]
     fn test_span_batch_prefix_encoding_roundtrip() {

--- a/crates/consensus/protocol/src/batch/prefix.rs
+++ b/crates/consensus/protocol/src/batch/prefix.rs
@@ -88,7 +88,7 @@ mod test {
 
     use super::*;
 
-    /// Regression: truncated input to decode_parent_check must return an error, not panic.
+    /// Regression: truncated input to `decode_parent_check` must return an error, not panic.
     #[test]
     fn test_decode_parent_check_truncated_input() {
         let mut prefix = SpanBatchPrefix::default();
@@ -99,7 +99,7 @@ mod test {
         );
     }
 
-    /// Regression: truncated input to decode_l1_origin_check must return an error, not panic.
+    /// Regression: truncated input to `decode_l1_origin_check` must return an error, not panic.
     #[test]
     fn test_decode_l1_origin_check_truncated_input() {
         let mut prefix = SpanBatchPrefix::default();

--- a/crates/consensus/protocol/src/batch/transactions.rs
+++ b/crates/consensus/protocol/src/batch/transactions.rs
@@ -155,6 +155,9 @@ impl SpanBatchTransactions {
         let mut sigs = Vec::with_capacity(self.total_block_tx_count as usize);
         for i in 0..self.total_block_tx_count {
             let y_parity = y_parity_bits.get_bit(i as usize).expect("same length");
+            if r.len() < 64 {
+                return Err(SpanBatchError::Decoding(SpanDecodingError::InvalidTransactionData));
+            }
             let r_val = U256::from_be_slice(&r[..32]);
             let s_val = U256::from_be_slice(&r[32..64]);
             sigs.push(Signature::new(r_val, s_val, y_parity == 1));
@@ -195,6 +198,9 @@ impl SpanBatchTransactions {
         let mut tos = Vec::with_capacity(self.total_block_tx_count as usize);
         let contract_creation_count = self.contract_creation_count();
         for _ in 0..(self.total_block_tx_count - contract_creation_count) {
+            if r.len() < 20 {
+                return Err(SpanBatchError::Decoding(SpanDecodingError::InvalidTransactionData));
+            }
             let to = Address::from_slice(&r[..20]);
             tos.push(to);
             r.advance(20);
@@ -359,6 +365,36 @@ mod tests {
     use alloy_primitives::{Signature, TxKind, address};
 
     use super::*;
+
+    /// Regression: truncated input to decode_tx_sigs must return an error, not panic.
+    /// A dishonest batcher can craft a span batch with fewer bytes than the declared tx count
+    /// requires, which previously caused an out-of-bounds slice panic.
+    #[test]
+    fn test_decode_tx_sigs_truncated_input() {
+        let mut txs = SpanBatchTransactions { total_block_tx_count: 1, ..Default::default() };
+        // y_parity bitfield for 1 tx = 1 byte (all zeros = false parity), then we need 64 bytes
+        // for r+s. Provide only 32 bytes to trigger the bounds check.
+        let truncated = [0u8; 33]; // 1 byte bitfield + 32 bytes (not enough for 64-byte sig)
+        assert_eq!(
+            txs.decode_tx_sigs(&mut truncated.as_ref()),
+            Err(SpanBatchError::Decoding(SpanDecodingError::InvalidTransactionData))
+        );
+    }
+
+    /// Regression: truncated input to decode_tx_tos must return an error, not panic.
+    /// A dishonest batcher can craft a span batch with fewer bytes than the declared non-contract
+    /// tx count requires, which previously caused an out-of-bounds slice panic.
+    #[test]
+    fn test_decode_tx_tos_truncated_input() {
+        let mut txs = SpanBatchTransactions { total_block_tx_count: 1, ..Default::default() };
+        // contract_creation_bits is all zeros (default), so contract_creation_count = 0,
+        // meaning we expect 1 `to` address (20 bytes). Provide only 19 bytes.
+        let truncated = [0u8; 19];
+        assert_eq!(
+            txs.decode_tx_tos(&mut truncated.as_ref()),
+            Err(SpanBatchError::Decoding(SpanDecodingError::InvalidTransactionData))
+        );
+    }
 
     #[test]
     fn test_span_batch_transactions_add_empty_txs() {

--- a/crates/consensus/protocol/src/batch/transactions.rs
+++ b/crates/consensus/protocol/src/batch/transactions.rs
@@ -366,7 +366,7 @@ mod tests {
 
     use super::*;
 
-    /// Regression: truncated input to decode_tx_sigs must return an error, not panic.
+    /// Regression: truncated input to `decode_tx_sigs` must return an error, not panic.
     /// A dishonest batcher can craft a span batch with fewer bytes than the declared tx count
     /// requires, which previously caused an out-of-bounds slice panic.
     #[test]
@@ -381,7 +381,7 @@ mod tests {
         );
     }
 
-    /// Regression: truncated input to decode_tx_tos must return an error, not panic.
+    /// Regression: truncated input to `decode_tx_tos` must return an error, not panic.
     /// A dishonest batcher can craft a span batch with fewer bytes than the declared non-contract
     /// tx count requires, which previously caused an out-of-bounds slice panic.
     #[test]


### PR DESCRIPTION
## Summary

Adds explicit length guards before unchecked slice operations in span batch decoding. Four paths were vulnerable: \`decode_parent_check\` and \`decode_l1_origin_check\` in \`SpanBatchPrefix\`, and \`decode_tx_sigs\` and \`decode_tx_tos\` in \`SpanBatchTransactions\`. A dishonest batcher could craft a truncated span batch to panic the derivation pipeline rather than receiving a clean \`SpanBatchError::Decoding\`. Each guard returns the appropriate typed error. Four regression tests are included. Ported from ethereum-optimism/optimism#19361.