### PR TITLE
fix(node): fix mempool v2 args

### DIFF
--- a/bin/node/src/cli.rs
+++ b/bin/node/src/cli.rs
@@ -53,7 +53,7 @@ pub struct Args {
     #[arg(
         long = "enable-tx-forwarding",
         value_name = "ENABLE_TX_FORWARDING",
-        requires = "builder-rpc-urls"
+        requires = "builder_rpc_urls"
     )]
     pub enable_tx_forwarding: bool,
 
@@ -61,7 +61,7 @@ pub struct Args {
     #[arg(
         long = "builder-rpc-urls",
         value_name = "BUILDER_RPC_URLS",
-        requires = "enable-tx-forwarding"
+        requires = "enable_tx_forwarding"
     )]
     pub builder_rpc_urls: Vec<Url>,
 
@@ -70,7 +70,7 @@ pub struct Args {
         long = "tx-forwarding-resend-after-ms",
         value_name = "TX_FORWARDING_RESEND_AFTER_MS",
         default_value_t = DEFAULT_RESEND_AFTER_MS,
-        requires = "enable-tx-forwarding"
+        requires = "enable_tx_forwarding"
     )]
     pub tx_forwarding_resend_after_ms: u64,
 
@@ -79,7 +79,7 @@ pub struct Args {
         long = "tx-forwarding-batch-size",
         value_name = "TX_FORWARDING_BATCH_SIZE",
         default_value_t = DEFAULT_MAX_BATCH_SIZE,
-        requires = "enable-tx-forwarding"
+        requires = "enable_tx_forwarding"
     )]
     pub tx_forwarding_batch_size: usize,
 
@@ -88,7 +88,7 @@ pub struct Args {
         long = "tx-forwarding-max-rps",
         value_name = "TX_FORWARDING_MAX_RPS",
         default_value_t = DEFAULT_MAX_RPS,
-        requires = "enable-tx-forwarding"
+        requires = "enable_tx_forwarding"
     )]
     pub tx_forwarding_max_rps: u32,
 }


### PR DESCRIPTION
## Summary
Fix mempool v2 args, the current setup will cause the node to crash with

```
base-client  | Command node: Argument or group 'builder-rpc-urls' specified in 'requires*' for 'enable_tx_forwarding' does not exist
base-client  | stack backtrace:
base-client  |    0: __rustc::rust_begin_unwind
base-client  |              at /rustc/01f6ddf7588f42ae2d7eb0a2f21d44e8e96674cf/library/std/src/panicking.rs:689:5
```