### PR TITLE
feat(tx-manager): add PreparedTx, fee overrides, and publish_tx

### DIFF
--- a/crates/utilities/tx-manager/README.md
+++ b/crates/utilities/tx-manager/README.md
@@ -15,6 +15,10 @@ Transaction lifecycle management for Base onchain components.
 - **`TxCandidate`**: Input to the send pipeline. With empty `blobs` it produces a regular
   EIP-1559 (type-2) transaction; with non-empty `blobs` it produces an EIP-4844 (type-3)
   blob-carrying transaction. Carries calldata, optional recipient, gas limit, and value.
+- **`PreparedTx`**: A signed transaction together with the fee values (`gas_tip_cap`,
+  `gas_fee_cap`) that were applied during construction. Returned by `prepare()` and
+  `craft_tx()` so callers can track the actual on-wire fees without a redundant gas price
+  query.
 - **`GasPriceCaps`**: Intermediate fee estimates (tip cap, base fee cap, optional blob fee cap)
   passed between fee calculation and transaction construction.
 - **`FeeCalculator`**: Pure, deterministic fee arithmetic engine operating on `u128` values
@@ -63,9 +67,12 @@ Transaction lifecycle management for Base onchain components.
   `new()` validates the config and cross-checks the chain ID against the provider.
   `prepare()` wraps `craft_tx()` in a `backon` retry loop (up to 30 attempts, 2-second
   fixed delay) that retries only on transient errors and exits immediately when closed.
-  `craft_tx()` queries gas price caps, enforces fee limits, builds a `TransactionRequest`
-  with all fields set manually (no alloy fillers), estimates or validates gas, assigns a
-  nonce via `NonceManager`, signs via `NetworkWallet`, and returns RLP-encoded raw bytes.
+  Both methods accept optional fee overrides `(tip, fee_cap)` and return a `PreparedTx`
+  containing the RLP-encoded raw bytes and the actual fees applied. `craft_tx()` queries
+  gas price caps, applies fee overrides as a floor via `max(network_fee, override)`,
+  enforces fee limits, builds a `TransactionRequest` with all fields set manually (no
+  alloy fillers), estimates or validates gas, assigns a nonce via `NonceManager`, and
+  signs via `NetworkWallet`.
   `suggest_gas_price_caps()` queries the provider for tip cap and base fee, enforces
   configured minimums, and returns a `GasPriceCaps`. Blob transactions are not yet
   supported and are rejected with an error.
@@ -210,11 +217,13 @@ let candidate = TxCandidate {
 };
 
 // Construct and sign the transaction (with automatic retry on transient errors).
-// Returns RLP-encoded raw transaction bytes ready for submission.
-let raw_tx = manager.prepare(&candidate).await?;
+// Returns a PreparedTx containing the raw bytes and the fees that were applied.
+let prepared = manager.prepare(&candidate, None).await?;
+let raw_tx = prepared.raw_tx;
 
 // Or use craft_tx() directly for a single attempt without retry.
-let raw_tx = manager.craft_tx(&candidate).await?;
+let prepared = manager.craft_tx(&candidate, None).await?;
+let raw_tx = prepared.raw_tx;
 ```
 
 ## License

--- a/crates/utilities/tx-manager/src/fees.rs
+++ b/crates/utilities/tx-manager/src/fees.rs
@@ -334,6 +334,33 @@ mod tests {
         }
     }
 
+    // ── calc_gas_fee_cap roundtrip ───────────────────────────────────────
+
+    /// Verifies that the reverse calculation `(fee_cap - tip) / 2`
+    /// recovers the original `base_fee` from a fee cap produced by
+    /// `calc_gas_fee_cap`. This roundtrip is relied upon by
+    /// `handle_fee_bump` in the manager to derive the effective base
+    /// fee from a `GasPriceCaps` result.
+    #[rstest]
+    #[case::one_gwei(1_000_000_000, 500_000_000)]
+    #[case::zeroes(0, 0)]
+    #[case::tip_only(0, 100)]
+    #[case::base_only(100, 0)]
+    #[case::large(5_000_000_000_000, 1_000_000_000_000)]
+    fn calc_gas_fee_cap_roundtrip_recovers_base_fee(#[case] base_fee: u128, #[case] tip: u128) {
+        let fee_cap = FeeCalculator::calc_gas_fee_cap(base_fee, tip);
+        // fee_cap = tip + 2 * base_fee, so (fee_cap - tip) / 2 == base_fee
+        // (only exact when no saturation occurs).
+        if fee_cap < u128::MAX {
+            let recovered = (fee_cap - tip) / 2;
+            assert_eq!(
+                recovered, base_fee,
+                "roundtrip should recover the base fee: \
+                 fee_cap={fee_cap}, tip={tip}, recovered={recovered}",
+            );
+        }
+    }
+
     // ── Property tests ──────────────────────────────────────────────────
 
     proptest! {
@@ -412,6 +439,20 @@ mod tests {
                 final_fee_cap >= final_tip,
                 "EIP-1559 invariant violated: fee_cap {final_fee_cap} < tip {final_tip}",
             );
+        }
+
+        #[test]
+        fn calc_gas_fee_cap_roundtrip(
+            base_fee in 0..u64::MAX as u128,
+            tip in 0..u64::MAX as u128,
+        ) {
+            let fee_cap = FeeCalculator::calc_gas_fee_cap(base_fee, tip);
+            // fee_cap = tip + 2 * base_fee ⇒ (fee_cap - tip) / 2 == base_fee.
+            // Only exact when no saturation occurred.
+            if fee_cap < u128::MAX {
+                let recovered = fee_cap.saturating_sub(tip) / 2;
+                prop_assert_eq!(recovered, base_fee);
+            }
         }
 
         #[test]

--- a/crates/utilities/tx-manager/src/fees.rs
+++ b/crates/utilities/tx-manager/src/fees.rs
@@ -169,6 +169,32 @@ impl FeeCalculator {
     }
 }
 
+/// Caller-supplied fee floor for transaction construction.
+///
+/// Used by [`crate::SimpleTxManager::prepare`] and
+/// [`crate::SimpleTxManager::craft_tx`] to enforce minimum fees during
+/// fee-bump iterations. The manager takes `max(network_fee, override)`
+/// for each component so the resulting transaction is guaranteed to meet
+/// the override thresholds even if network fees have dropped.
+///
+/// Field names mirror [`GasPriceCaps`] for consistency.
+#[non_exhaustive]
+#[derive(Debug, Clone, Copy, Default)]
+pub struct FeeOverride {
+    /// Minimum acceptable maximum priority fee per gas (tip).
+    pub gas_tip_cap: u128,
+    /// Minimum acceptable maximum total fee per gas (base fee + tip).
+    pub gas_fee_cap: u128,
+}
+
+impl FeeOverride {
+    /// Creates a new [`FeeOverride`] with the given tip and fee cap floors.
+    #[must_use]
+    pub const fn new(gas_tip_cap: u128, gas_fee_cap: u128) -> Self {
+        Self { gas_tip_cap, gas_fee_cap }
+    }
+}
+
 /// Intermediate fee estimates computed during gas price suggestion.
 ///
 /// Used between fee calculation and transaction construction to carry

--- a/crates/utilities/tx-manager/src/lib.rs
+++ b/crates/utilities/tx-manager/src/lib.rs
@@ -14,7 +14,7 @@ mod candidate;
 pub use candidate::TxCandidate;
 
 mod fees;
-pub use fees::{FeeCalculator, GasPriceCaps};
+pub use fees::{FeeCalculator, FeeOverride, GasPriceCaps};
 
 mod send_state;
 pub use send_state::SendState;

--- a/crates/utilities/tx-manager/src/lib.rs
+++ b/crates/utilities/tx-manager/src/lib.rs
@@ -31,7 +31,7 @@ mod nonce;
 pub use nonce::{NonceGuard, NonceManager, NonceState};
 
 mod manager;
-pub use manager::SimpleTxManager;
+pub use manager::{PreparedTx, SimpleTxManager};
 
 mod queue;
 pub use queue::TxQueue;

--- a/crates/utilities/tx-manager/src/manager.rs
+++ b/crates/utilities/tx-manager/src/manager.rs
@@ -13,13 +13,6 @@
 //! and the actual fees that were applied, eliminating the need for callers to
 //! re-query gas prices after transaction construction.
 //!
-//! The `send_tx` method drives a signed transaction from publication through
-//! mempool to onchain confirmation via a `tokio::select!` event loop that
-//! coordinates fee bumping, receipt polling, and critical error detection.
-//! The `select!` block only determines which event fired; fee bump logic
-//! (including [`prepare`]) always runs to completion outside the `select!`
-//! block to preserve cancellation safety.
-//!
 //! All transaction fields are set manually on [`TransactionRequest`] — no
 //! alloy fillers or `PendingTransactionBuilder` are used.
 //!

--- a/crates/utilities/tx-manager/src/manager.rs
+++ b/crates/utilities/tx-manager/src/manager.rs
@@ -1,14 +1,24 @@
 //! Core transaction manager implementation.
 //!
 //! [`SimpleTxManager`] takes a [`TxCandidate`] through the full construction
-//! pipeline: gas price estimation via [`suggest_gas_price_caps`], fee limit
-//! enforcement via [`FeeCalculator::check_limits`], gas estimation or
-//! validation against the provider, nonce assignment via [`NonceManager`],
-//! and signing via alloy's [`NetworkWallet`] trait.
+//! pipeline: gas price estimation via [`suggest_gas_price_caps`], optional fee
+//! override enforcement, fee limit checks via [`FeeCalculator::check_limits`],
+//! gas estimation or validation against the provider, nonce assignment via
+//! [`NonceManager`], and signing via alloy's [`NetworkWallet`] trait.
 //!
 //! The outer [`prepare`] method wraps [`craft_tx`] in a `backon` retry loop
 //! (up to 30 attempts, 2-second fixed delay) that retries only on transient
-//! errors and exits immediately on shutdown.
+//! errors and exits immediately on shutdown. Both methods accept optional fee
+//! overrides and return a [`PreparedTx`] containing the raw transaction bytes
+//! and the actual fees that were applied, eliminating the need for callers to
+//! re-query gas prices after transaction construction.
+//!
+//! The `send_tx` method drives a signed transaction from publication through
+//! mempool to onchain confirmation via a `tokio::select!` event loop that
+//! coordinates fee bumping, receipt polling, and critical error detection.
+//! The `select!` block only determines which event fired; fee bump logic
+//! (including [`prepare`]) always runs to completion outside the `select!`
+//! block to preserve cancellation safety.
 //!
 //! All transaction fields are set manually on [`TransactionRequest`] — no
 //! alloy fillers or `PendingTransactionBuilder` are used.
@@ -23,22 +33,42 @@
 //! [`TransactionRequest`]: alloy_rpc_types_eth::TransactionRequest
 
 use std::{
-    sync::atomic::{AtomicBool, Ordering},
+    sync::{
+        Arc,
+        atomic::{AtomicBool, Ordering},
+    },
     time::Duration,
 };
 
 use alloy_eips::{BlockNumberOrTag, Encodable2718};
 use alloy_network::{Ethereum, EthereumWallet, NetworkWallet, TransactionBuilder};
-use alloy_primitives::{Address, Bytes};
+use alloy_primitives::{Address, B256, Bytes};
 use alloy_provider::{Provider, RootProvider};
 use alloy_rpc_types_eth::TransactionRequest;
 use backon::{ConstantBuilder, Retryable};
-use tracing::{info, warn};
+use tracing::{error, info, warn};
 
 use crate::{
     FeeCalculator, GasPriceCaps, NonceManager, RpcErrorClassifier, SendHandle, SendResponse,
-    TxCandidate, TxManager, TxManagerConfig, TxManagerError, TxManagerResult,
+    SendState, TxCandidate, TxManager, TxManagerConfig, TxManagerError, TxManagerResult,
 };
+
+/// A signed transaction together with the fee values that were applied
+/// during construction.
+///
+/// Returned by [`SimpleTxManager::prepare`] and
+/// [`SimpleTxManager::craft_tx`] so that callers can track the actual
+/// on-wire fees without a redundant gas price query.
+#[non_exhaustive]
+#[derive(Debug, Clone)]
+pub struct PreparedTx {
+    /// RLP-encoded signed transaction bytes.
+    pub raw_tx: Bytes,
+    /// Maximum priority fee per gas (tip) used in the signed transaction.
+    pub gas_tip_cap: u128,
+    /// Maximum total fee per gas used in the signed transaction.
+    pub gas_fee_cap: u128,
+}
 
 /// Default transaction manager implementation.
 ///
@@ -57,8 +87,11 @@ pub struct SimpleTxManager {
     nonce_manager: NonceManager,
     /// Chain ID for transaction construction.
     chain_id: u64,
-    /// Shutdown flag. Set to `true` to close the manager.
-    closed: AtomicBool,
+    /// Shutdown flag shared across the manager and any spawned background
+    /// tasks. Wrapped in [`Arc`] so that calling [`close`](Self::close)
+    /// on the original manager is observed by tasks spawned via
+    /// [`send_async`](Self::send_async) and `wait_for_tx`.
+    closed: Arc<AtomicBool>,
 }
 
 impl SimpleTxManager {
@@ -111,7 +144,7 @@ impl SimpleTxManager {
             config,
             nonce_manager,
             chain_id,
-            closed: AtomicBool::new(false),
+            closed: Arc::new(AtomicBool::new(false)),
         })
     }
 
@@ -144,6 +177,9 @@ impl SimpleTxManager {
     ///
     /// After calling `close()`, any subsequent call to [`prepare`](Self::prepare)
     /// will immediately return `Err(TxManagerError::ChannelClosed)`.
+    /// Background tasks spawned by [`send_async`](Self::send_async) and
+    /// receipt polling tasks will also observe the shutdown and exit
+    /// gracefully, since `closed` is shared via [`Arc`].
     pub fn close(&self) {
         self.closed.store(true, Ordering::Release);
     }
@@ -159,6 +195,13 @@ impl SimpleTxManager {
     /// [`Self::PREPARE_MAX_RETRIES`] attempts and a [`Self::PREPARE_RETRY_DELAY`]
     /// fixed delay between retries. Only errors where
     /// [`TxManagerError::is_retryable`] returns `true` trigger a retry.
+    ///
+    /// When `fee_overrides` is `Some((tip, fee_cap))`, the provided values
+    /// are used as a floor — `craft_tx` takes `max(network_fee, override)`
+    /// so the resulting transaction is guaranteed to meet the override
+    /// thresholds. Pass `None` for the initial send; pass the bumped fees
+    /// during fee-bump iterations to ensure replacement transactions
+    /// satisfy geth's replacement rules.
     ///
     /// # Cancellation safety
     ///
@@ -176,7 +219,11 @@ impl SimpleTxManager {
     /// Returns immediately with [`TxManagerError::ChannelClosed`] if the
     /// manager is closed. Otherwise returns the first non-retryable error,
     /// or the last retryable error after exhausting all retry attempts.
-    pub async fn prepare(&self, candidate: &TxCandidate) -> TxManagerResult<Bytes> {
+    pub async fn prepare(
+        &self,
+        candidate: &TxCandidate,
+        fee_overrides: Option<(u128, u128)>,
+    ) -> TxManagerResult<PreparedTx> {
         (|| async {
             // Re-check closed flag on each retry attempt to avoid wasted
             // RPC calls after shutdown. ChannelClosed is non-retryable,
@@ -184,7 +231,7 @@ impl SimpleTxManager {
             if self.is_closed() {
                 return Err(TxManagerError::ChannelClosed);
             }
-            self.craft_tx(candidate).await
+            self.craft_tx(candidate, fee_overrides).await
         })
         .retry(
             ConstantBuilder::default()
@@ -257,16 +304,24 @@ impl SimpleTxManager {
     ///
     /// Steps:
     /// 1. Query gas price caps via [`suggest_gas_price_caps`](Self::suggest_gas_price_caps)
-    /// 2. Check fee limits via [`FeeCalculator::check_limits`]
-    /// 3. Build a [`TransactionRequest`] with all fields set manually
-    /// 4. Estimate gas via the provider; use `max(estimate, candidate.gas_limit)` as floor
-    /// 5. Assign nonce via [`NonceManager::next_nonce`]
-    /// 6. Sign and RLP-encode to raw transaction bytes
+    /// 2. Apply fee overrides as a floor (`max(network_fee, override)`)
+    /// 3. Check fee limits via [`FeeCalculator::check_limits`]
+    /// 4. Build a [`TransactionRequest`] with all fields set manually
+    /// 5. Estimate gas via the provider; use `max(estimate, candidate.gas_limit)` as floor
+    /// 6. Assign nonce via [`NonceManager::next_nonce`]
+    /// 7. Sign and RLP-encode to raw transaction bytes
+    ///
+    /// When `fee_overrides` is `Some((tip, fee_cap))`, the provided values
+    /// are used as a floor — the transaction will use
+    /// `max(network_fee, override)` for each component. This ensures that
+    /// replacement transactions always meet the bumped fee thresholds
+    /// required by geth's tx-replacement rules, even if network fees have
+    /// dropped since the bump was calculated.
     ///
     /// # Cancellation safety
     ///
     /// This future is **not** cancellation-safe. If dropped after nonce
-    /// acquisition (step 5) but before signing completes (step 6), the
+    /// acquisition (step 6) but before signing completes (step 7), the
     /// nonce is consumed without producing a transaction, creating a
     /// permanent nonce gap. Callers must not wrap this future in
     /// `tokio::select!`, `tokio::time::timeout`, or similar combinators
@@ -276,7 +331,11 @@ impl SimpleTxManager {
     ///
     /// Returns classified RPC errors, [`TxManagerError::FeeLimitExceeded`],
     /// nonce errors, or signing errors.
-    pub async fn craft_tx(&self, candidate: &TxCandidate) -> TxManagerResult<Bytes> {
+    pub async fn craft_tx(
+        &self,
+        candidate: &TxCandidate,
+        fee_overrides: Option<(u128, u128)>,
+    ) -> TxManagerResult<PreparedTx> {
         // Blob transactions are not yet supported.
         if !candidate.blobs.is_empty() {
             return Err(TxManagerError::Unsupported(
@@ -287,28 +346,40 @@ impl SimpleTxManager {
         // Step 1: Get fee estimates.
         let caps = self.suggest_gas_price_caps().await?;
 
-        // Step 2: Check fee limits.
+        // Step 2: Apply fee overrides as a floor.
+        //
+        // During fee bumps the caller passes the bumped (tip, fee_cap)
+        // as overrides. We take the max of the fresh network estimate
+        // and the override so the replacement transaction is guaranteed
+        // to satisfy geth's replacement rules even if network fees have
+        // dropped since the bump was calculated.
+        let (tip_cap, fee_cap) = match fee_overrides {
+            Some((override_tip, override_fee_cap)) => {
+                (caps.gas_tip_cap.max(override_tip), caps.gas_fee_cap.max(override_fee_cap))
+            }
+            None => (caps.gas_tip_cap, caps.gas_fee_cap),
+        };
+
+        // Step 3: Check fee limits.
         //
         // The `suggested` parameter is the raw gas_fee_cap computed from
         // the provider's values before enforcing our configured minimums
         // (`min_tip_cap`, `min_basefee`). This detects when enforced
-        // minimums inflate the fee cap beyond
-        // `fee_limit_multiplier × raw_provider_fee_cap`. During fee bumps
-        // (future ticket) the caller passes the previous fee as
-        // `suggested` instead.
+        // minimums or fee overrides inflate the fee cap beyond
+        // `fee_limit_multiplier × raw_provider_fee_cap`.
         FeeCalculator::check_limits(
-            caps.gas_fee_cap,
+            fee_cap,
             caps.raw_gas_fee_cap,
             self.config.fee_limit_multiplier,
             self.config.fee_limit_threshold,
         )?;
 
-        // Step 3: Build TransactionRequest.
+        // Step 4: Build TransactionRequest.
         let from = self.sender_address();
         let mut tx_request = TransactionRequest::default()
             .with_input(candidate.tx_data.clone())
-            .with_max_fee_per_gas(caps.gas_fee_cap)
-            .with_max_priority_fee_per_gas(caps.gas_tip_cap)
+            .with_max_fee_per_gas(fee_cap)
+            .with_max_priority_fee_per_gas(tip_cap)
             .with_value(candidate.value)
             .with_chain_id(self.chain_id);
 
@@ -319,7 +390,7 @@ impl SimpleTxManager {
             None => tx_request = tx_request.into_create(),
         }
 
-        // Step 4: Gas estimation.
+        // Step 5: Gas estimation.
         //
         // Always call estimate_gas to enforce intrinsic gas checks (e.g.
         // the 21,000 minimum for plain value transfers). When the caller
@@ -335,19 +406,19 @@ impl SimpleTxManager {
         let gas_limit = candidate.gas_limit.max(estimated);
         tx_request = tx_request.with_gas_limit(gas_limit);
 
-        // Step 5: Assign nonce.
+        // Step 6: Assign nonce.
         let guard = self.nonce_manager.next_nonce().await?;
         tx_request = tx_request.with_nonce(guard.nonce());
 
         info!(
             nonce = guard.nonce(),
             gas_limit = %gas_limit,
-            tip_cap = %caps.gas_tip_cap,
-            fee_cap = %caps.gas_fee_cap,
+            tip_cap = %tip_cap,
+            fee_cap = %fee_cap,
             "transaction crafted",
         );
 
-        // Step 6: Sign and encode.
+        // Step 7: Sign and encode.
         let sign_result =
             <TransactionRequest as TransactionBuilder<Ethereum>>::build(tx_request, &self.wallet)
                 .await;
@@ -356,12 +427,84 @@ impl SimpleTxManager {
             Ok(envelope) => {
                 // Consume the nonce (drop guard).
                 drop(guard);
-                Ok(Bytes::from(Encodable2718::encoded_2718(&envelope)))
+                Ok(PreparedTx {
+                    raw_tx: Bytes::from(Encodable2718::encoded_2718(&envelope)),
+                    gas_tip_cap: tip_cap,
+                    gas_fee_cap: fee_cap,
+                })
             }
             Err(e) => {
                 // Roll back nonce on sign failure.
                 guard.rollback();
                 Err(TxManagerError::Sign(e.to_string()))
+            }
+        }
+    }
+
+    /// Broadcasts a raw transaction to the network.
+    ///
+    /// On success, records a successful publish on the [`SendState`] and
+    /// returns the transaction hash. On [`TxManagerError::AlreadyKnown`]
+    /// after a prior successful publish, treats it as success — records
+    /// another successful publish and returns `Ok(last_tx_hash)` so
+    /// callers do not need to special-case this variant. All other errors
+    /// are forwarded to [`SendState::process_send_error`] for state tracking.
+    ///
+    /// The `last_tx_hash` parameter is the hash from the most recent
+    /// successful publish. When the network returns `AlreadyKnown` on
+    /// resubmission, this hash is returned as the successful result.
+    ///
+    /// # Errors
+    ///
+    /// Returns the classified error on publication failure.
+    pub async fn publish_tx(
+        &self,
+        send_state: &SendState,
+        raw_tx: &Bytes,
+        last_tx_hash: Option<B256>,
+    ) -> TxManagerResult<B256> {
+        let result = tokio::time::timeout(
+            self.config.network_timeout,
+            self.provider.send_raw_transaction(raw_tx),
+        )
+        .await;
+
+        match result {
+            Ok(Ok(pending)) => {
+                let tx_hash = *pending.tx_hash();
+                send_state.record_successful_publish();
+                info!(tx_hash = %tx_hash, "transaction published");
+                Ok(tx_hash)
+            }
+            Ok(Err(e)) => {
+                let classified = RpcErrorClassifier::classify_rpc_error(&e.to_string());
+
+                // AlreadyKnown on resubmission is a success — the tx is in
+                // the mempool from a prior publish. Return the previous hash.
+                if classified.is_already_known() && send_state.successful_publish_count() > 0 {
+                    let hash = last_tx_hash.ok_or_else(|| {
+                        TxManagerError::Rpc("AlreadyKnown but no prior tx hash available".into())
+                    })?;
+                    send_state.record_successful_publish();
+                    info!(tx_hash = %hash, "transaction already known in mempool, treating as success");
+                    return Ok(hash);
+                }
+
+                send_state.process_send_error(&classified);
+
+                if classified.is_retryable() {
+                    warn!(error = %classified, "publish failed, will retry");
+                } else {
+                    error!(error = %classified, "publish failed with non-retryable error");
+                }
+
+                Err(classified)
+            }
+            Err(_) => {
+                let err = TxManagerError::Rpc("send_raw_transaction timed out".into());
+                send_state.process_send_error(&err);
+                warn!("publish timed out");
+                Err(err)
             }
         }
     }

--- a/crates/utilities/tx-manager/src/manager.rs
+++ b/crates/utilities/tx-manager/src/manager.rs
@@ -49,8 +49,9 @@ use backon::{ConstantBuilder, Retryable};
 use tracing::{error, info, warn};
 
 use crate::{
-    FeeCalculator, GasPriceCaps, NonceManager, RpcErrorClassifier, SendHandle, SendResponse,
-    SendState, TxCandidate, TxManager, TxManagerConfig, TxManagerError, TxManagerResult,
+    FeeCalculator, FeeOverride, GasPriceCaps, NonceManager, RpcErrorClassifier, SendHandle,
+    SendResponse, SendState, TxCandidate, TxManager, TxManagerConfig, TxManagerError,
+    TxManagerResult,
 };
 
 /// A signed transaction together with the fee values that were applied
@@ -196,7 +197,7 @@ impl SimpleTxManager {
     /// fixed delay between retries. Only errors where
     /// [`TxManagerError::is_retryable`] returns `true` trigger a retry.
     ///
-    /// When `fee_overrides` is `Some((tip, fee_cap))`, the provided values
+    /// When `fee_overrides` is `Some`, the provided [`FeeOverride`] values
     /// are used as a floor — `craft_tx` takes `max(network_fee, override)`
     /// so the resulting transaction is guaranteed to meet the override
     /// thresholds. Pass `None` for the initial send; pass the bumped fees
@@ -222,7 +223,7 @@ impl SimpleTxManager {
     pub async fn prepare(
         &self,
         candidate: &TxCandidate,
-        fee_overrides: Option<(u128, u128)>,
+        fee_overrides: Option<FeeOverride>,
     ) -> TxManagerResult<PreparedTx> {
         (|| async {
             // Re-check closed flag on each retry attempt to avoid wasted
@@ -311,7 +312,7 @@ impl SimpleTxManager {
     /// 6. Assign nonce via [`NonceManager::next_nonce`]
     /// 7. Sign and RLP-encode to raw transaction bytes
     ///
-    /// When `fee_overrides` is `Some((tip, fee_cap))`, the provided values
+    /// When `fee_overrides` is `Some`, the provided [`FeeOverride`] values
     /// are used as a floor — the transaction will use
     /// `max(network_fee, override)` for each component. This ensures that
     /// replacement transactions always meet the bumped fee thresholds
@@ -334,7 +335,7 @@ impl SimpleTxManager {
     pub async fn craft_tx(
         &self,
         candidate: &TxCandidate,
-        fee_overrides: Option<(u128, u128)>,
+        fee_overrides: Option<FeeOverride>,
     ) -> TxManagerResult<PreparedTx> {
         // Blob transactions are not yet supported.
         if !candidate.blobs.is_empty() {
@@ -354,8 +355,8 @@ impl SimpleTxManager {
         // to satisfy geth's replacement rules even if network fees have
         // dropped since the bump was calculated.
         let (tip_cap, fee_cap) = match fee_overrides {
-            Some((override_tip, override_fee_cap)) => {
-                (caps.gas_tip_cap.max(override_tip), caps.gas_fee_cap.max(override_fee_cap))
+            Some(FeeOverride { gas_tip_cap, gas_fee_cap }) => {
+                (caps.gas_tip_cap.max(gas_tip_cap), caps.gas_fee_cap.max(gas_fee_cap))
             }
             None => (caps.gas_tip_cap, caps.gas_fee_cap),
         };
@@ -483,7 +484,9 @@ impl SimpleTxManager {
                 // the mempool from a prior publish. Return the previous hash.
                 if classified.is_already_known() && send_state.successful_publish_count() > 0 {
                     let hash = last_tx_hash.ok_or_else(|| {
-                        TxManagerError::Rpc("AlreadyKnown but no prior tx hash available".into())
+                        TxManagerError::InvalidConfig(
+                            "AlreadyKnown but no prior tx hash available — caller must track the hash from publish_tx".into(),
+                        )
                     })?;
                     send_state.record_successful_publish();
                     info!(tx_hash = %hash, "transaction already known in mempool, treating as success");

--- a/crates/utilities/tx-manager/src/send_state.rs
+++ b/crates/utilities/tx-manager/src/send_state.rs
@@ -205,6 +205,23 @@ impl SendState {
         inner.bump_fees
     }
 
+    /// Clears the bump-fees flag without incrementing the bump counter.
+    ///
+    /// Called before attempting a fee bump so that a failed attempt
+    /// (e.g., RPC timeout in [`suggest_gas_price_caps`]) does not
+    /// immediately re-trigger the bump on the next loop iteration. If
+    /// the bump succeeds, [`record_fee_bump`] will also clear the flag
+    /// (a harmless no-op) and increment the counter. If a new retryable
+    /// error occurs later, [`process_send_error`] will re-set the flag.
+    ///
+    /// [`suggest_gas_price_caps`]: crate::SimpleTxManager::suggest_gas_price_caps
+    /// [`record_fee_bump`]: Self::record_fee_bump
+    /// [`process_send_error`]: Self::process_send_error
+    pub fn clear_bump_fees(&self) {
+        let mut inner = self.inner.lock().expect("SendState mutex poisoned");
+        inner.bump_fees = false;
+    }
+
     /// Sets the mempool inclusion deadline.
     pub fn set_mempool_deadline(&self, deadline: Instant) {
         let mut inner = self.inner.lock().expect("SendState mutex poisoned");
@@ -216,6 +233,13 @@ impl SendState {
     pub fn bump_count(&self) -> u64 {
         let inner = self.inner.lock().expect("SendState mutex poisoned");
         inner.bump_count
+    }
+
+    /// Returns the number of successful transaction publications.
+    #[must_use]
+    pub fn successful_publish_count(&self) -> u64 {
+        let inner = self.inner.lock().expect("SendState mutex poisoned");
+        inner.successful_publish_count
     }
 }
 
@@ -569,6 +593,48 @@ mod tests {
         let state = SendState::new(3).unwrap();
         state.process_send_error(&TxManagerError::InsufficientFunds);
         assert!(!state.should_bump_fees());
+    }
+
+    #[test]
+    fn clear_bump_fees_clears_flag_without_incrementing_count() {
+        let state = SendState::new(3).unwrap();
+        state.process_send_error(&TxManagerError::Underpriced);
+        assert!(state.should_bump_fees());
+        assert_eq!(state.bump_count(), 0);
+
+        // clear_bump_fees clears the flag but does not touch the counter.
+        state.clear_bump_fees();
+        assert!(!state.should_bump_fees());
+        assert_eq!(state.bump_count(), 0, "bump_count should not increment on clear");
+    }
+
+    #[test]
+    fn clear_bump_fees_allows_flag_to_be_re_set() {
+        let state = SendState::new(3).unwrap();
+        state.process_send_error(&TxManagerError::Underpriced);
+        assert!(state.should_bump_fees());
+
+        state.clear_bump_fees();
+        assert!(!state.should_bump_fees());
+
+        // A new retryable error re-sets the flag.
+        state.process_send_error(&TxManagerError::ReplacementUnderpriced);
+        assert!(state.should_bump_fees());
+    }
+
+    // ── successful_publish_count ─────────────────────────────────────────
+
+    #[test]
+    fn successful_publish_count_tracks_publications() {
+        let state = SendState::new(3).unwrap();
+        assert_eq!(state.successful_publish_count(), 0);
+
+        state.record_successful_publish();
+        assert_eq!(state.successful_publish_count(), 1);
+
+        state.record_successful_publish();
+        state.record_successful_publish();
+        assert_eq!(state.successful_publish_count(), 3);
     }
 
     // ── is_waiting_for_confirmation ─────────────────────────────────────

--- a/crates/utilities/tx-manager/tests/craft_tx.rs
+++ b/crates/utilities/tx-manager/tests/craft_tx.rs
@@ -9,7 +9,8 @@ use alloy_provider::RootProvider;
 use alloy_signer_local::PrivateKeySigner;
 use async_trait::async_trait;
 use base_tx_manager::{
-    GasPriceCaps, SimpleTxManager, TxCandidate, TxManager, TxManagerConfig, TxManagerError,
+    FeeOverride, GasPriceCaps, SimpleTxManager, TxCandidate, TxManager, TxManagerConfig,
+    TxManagerError,
 };
 
 /// Helper: spawns an Anvil instance and returns a [`SimpleTxManager`]
@@ -512,8 +513,9 @@ async fn craft_tx_with_fee_overrides_uses_overrides_when_above_network() {
         ..Default::default()
     };
 
+    let overrides = FeeOverride::new(override_tip, override_fee_cap);
     let prepared = manager
-        .craft_tx(&candidate, Some((override_tip, override_fee_cap)))
+        .craft_tx(&candidate, Some(overrides))
         .await
         .expect("should craft tx with fee overrides");
 
@@ -553,8 +555,9 @@ async fn craft_tx_with_fee_overrides_uses_network_when_overrides_below() {
         ..Default::default()
     };
 
+    let overrides = FeeOverride::new(override_tip, override_fee_cap);
     let prepared = manager
-        .craft_tx(&candidate, Some((override_tip, override_fee_cap)))
+        .craft_tx(&candidate, Some(overrides))
         .await
         .expect("should craft tx with low fee overrides");
 
@@ -587,10 +590,8 @@ async fn prepared_tx_fees_match_decoded_transaction_with_overrides() {
         ..Default::default()
     };
 
-    let prepared = manager
-        .craft_tx(&candidate, Some((override_tip, override_fee_cap)))
-        .await
-        .expect("should craft tx");
+    let overrides = FeeOverride::new(override_tip, override_fee_cap);
+    let prepared = manager.craft_tx(&candidate, Some(overrides)).await.expect("should craft tx");
     let tx = decode_eip1559(&prepared.raw_tx);
 
     assert_eq!(

--- a/crates/utilities/tx-manager/tests/craft_tx.rs
+++ b/crates/utilities/tx-manager/tests/craft_tx.rs
@@ -61,8 +61,8 @@ async fn craft_tx_produces_valid_signed_eip1559_transaction() {
         ..Default::default()
     };
 
-    let raw_tx = manager.craft_tx(&candidate).await.expect("should craft tx");
-    let tx = decode_eip1559(&raw_tx);
+    let prepared = manager.craft_tx(&candidate, None).await.expect("should craft tx");
+    let tx = decode_eip1559(&prepared.raw_tx);
 
     assert_eq!(tx.to, TxKind::Call(to));
     assert_eq!(tx.value, value);
@@ -71,6 +71,20 @@ async fn craft_tx_produces_valid_signed_eip1559_transaction() {
     assert_eq!(tx.gas_limit, 21_000, "plain value transfer intrinsic gas should be 21,000");
     assert!(tx.max_fee_per_gas > 0, "max_fee_per_gas should be non-zero");
     assert!(tx.max_priority_fee_per_gas > 0, "max_priority_fee_per_gas should be non-zero");
+    assert!(prepared.gas_tip_cap > 0, "PreparedTx gas_tip_cap should be non-zero");
+    assert!(
+        prepared.gas_fee_cap > prepared.gas_tip_cap,
+        "PreparedTx gas_fee_cap should exceed gas_tip_cap",
+    );
+    // PreparedTx fees must match the fees encoded in the signed transaction.
+    assert_eq!(
+        prepared.gas_tip_cap, tx.max_priority_fee_per_gas,
+        "PreparedTx gas_tip_cap should match decoded max_priority_fee_per_gas",
+    );
+    assert_eq!(
+        prepared.gas_fee_cap, tx.max_fee_per_gas,
+        "PreparedTx gas_fee_cap should match decoded max_fee_per_gas",
+    );
 }
 
 #[tokio::test]
@@ -88,8 +102,9 @@ async fn craft_tx_with_explicit_gas_limit_above_estimate() {
         ..Default::default()
     };
 
-    let raw_tx = manager.craft_tx(&candidate).await.expect("should craft tx with explicit gas");
-    let tx = decode_eip1559(&raw_tx);
+    let prepared =
+        manager.craft_tx(&candidate, None).await.expect("should craft tx with explicit gas");
+    let tx = decode_eip1559(&prepared.raw_tx);
 
     // The decoded gas_limit must equal the caller's explicit value,
     // proving it was used as a floor above the provider estimate.
@@ -106,7 +121,7 @@ async fn craft_tx_rejects_blob_transactions() {
         ..Default::default()
     };
 
-    let err = manager.craft_tx(&candidate).await.expect_err("should reject blob tx");
+    let err = manager.craft_tx(&candidate, None).await.expect_err("should reject blob tx");
     match &err {
         TxManagerError::Unsupported(msg) => {
             assert!(
@@ -130,8 +145,9 @@ async fn craft_tx_contract_creation() {
         ..Default::default()
     };
 
-    let raw_tx = manager.craft_tx(&candidate).await.expect("should craft contract creation tx");
-    let tx = decode_eip1559(&raw_tx);
+    let prepared =
+        manager.craft_tx(&candidate, None).await.expect("should craft contract creation tx");
+    let tx = decode_eip1559(&prepared.raw_tx);
 
     assert_eq!(tx.to, TxKind::Create);
 }
@@ -170,8 +186,8 @@ async fn prepare_produces_valid_signed_transaction() {
         ..Default::default()
     };
 
-    let raw_tx = manager.prepare(&candidate).await.expect("should prepare tx");
-    let tx = decode_eip1559(&raw_tx);
+    let prepared = manager.prepare(&candidate, None).await.expect("should prepare tx");
+    let tx = decode_eip1559(&prepared.raw_tx);
 
     // Confirm the candidate's fields survive the retry wrapper.
     assert_eq!(tx.to, TxKind::Call(to));
@@ -190,7 +206,7 @@ async fn prepare_returns_channel_closed_when_manager_is_closed() {
         ..Default::default()
     };
 
-    let err = manager.prepare(&candidate).await.expect_err("should fail");
+    let err = manager.prepare(&candidate, None).await.expect_err("should fail");
     assert_eq!(err, TxManagerError::ChannelClosed);
 }
 
@@ -223,11 +239,11 @@ async fn sequential_craft_tx_increments_nonce() {
     };
 
     // Craft two transactions — nonces should be sequential.
-    let raw_tx1 = manager.craft_tx(&candidate).await.expect("first tx");
-    let raw_tx2 = manager.craft_tx(&candidate).await.expect("second tx");
+    let prepared1 = manager.craft_tx(&candidate, None).await.expect("first tx");
+    let prepared2 = manager.craft_tx(&candidate, None).await.expect("second tx");
 
-    assert_eq!(decode_eip1559(&raw_tx1).nonce, 0);
-    assert_eq!(decode_eip1559(&raw_tx2).nonce, 1);
+    assert_eq!(decode_eip1559(&prepared1.raw_tx).nonce, 0);
+    assert_eq!(decode_eip1559(&prepared2.raw_tx).nonce, 1);
 }
 
 #[tokio::test]
@@ -269,8 +285,8 @@ async fn craft_tx_preserves_calldata() {
         ..Default::default()
     };
 
-    let raw_tx = manager.craft_tx(&candidate).await.expect("should craft tx with calldata");
-    let tx = decode_eip1559(&raw_tx);
+    let prepared = manager.craft_tx(&candidate, None).await.expect("should craft tx with calldata");
+    let tx = decode_eip1559(&prepared.raw_tx);
 
     assert_eq!(tx.input, calldata, "calldata should be preserved in the decoded transaction");
 }
@@ -362,7 +378,7 @@ async fn craft_tx_returns_fee_limit_exceeded_when_minimums_inflate_beyond_multip
         ..Default::default()
     };
 
-    let err = manager.craft_tx(&candidate).await.expect_err("should exceed fee limit");
+    let err = manager.craft_tx(&candidate, None).await.expect_err("should exceed fee limit");
     assert!(
         matches!(err, TxManagerError::FeeLimitExceeded { .. }),
         "expected TxManagerError::FeeLimitExceeded, got {err:?}",
@@ -381,7 +397,7 @@ async fn prepare_exits_immediately_on_non_retryable_error() {
         ..Default::default()
     };
 
-    let err = manager.prepare(&candidate).await.expect_err("should reject blob tx");
+    let err = manager.prepare(&candidate, None).await.expect_err("should reject blob tx");
 
     assert!(
         matches!(err, TxManagerError::Unsupported(_)),
@@ -466,7 +482,7 @@ async fn craft_tx_rolls_back_nonce_on_sign_failure() {
     };
 
     // First call: signing fails, nonce should be rolled back.
-    let err = failing_manager.craft_tx(&candidate).await.expect_err("should fail to sign");
+    let err = failing_manager.craft_tx(&candidate, None).await.expect_err("should fail to sign");
     assert!(matches!(err, TxManagerError::Sign(_)), "expected TxManagerError::Sign, got {err:?}",);
 
     // Query the same NonceManager directly. If rollback worked the
@@ -476,6 +492,115 @@ async fn craft_tx_rolls_back_nonce_on_sign_failure() {
     assert_eq!(guard.nonce(), 0, "nonce should be 0 — rollback must have restored it");
     // Drop the guard so the nonce is consumed (prevents test pollution).
     drop(guard);
+}
+
+/// When fee overrides are above network fees, the [`PreparedTx`] must use the
+/// overrides (since `craft_tx` takes `max(network_fee, override)`).
+#[tokio::test]
+async fn craft_tx_with_fee_overrides_uses_overrides_when_above_network() {
+    let (manager, _anvil) = setup().await;
+
+    // Learn current network fees so we can set overrides above them.
+    let caps = manager.suggest_gas_price_caps().await.expect("should get caps");
+    let override_tip = caps.gas_tip_cap + 50_000_000_000; // +50 gwei
+    let override_fee_cap = caps.gas_fee_cap + 100_000_000_000; // +100 gwei
+
+    let candidate = TxCandidate {
+        to: Some(Address::with_last_byte(0x42)),
+        value: U256::from(1_000u64),
+        gas_limit: 0,
+        ..Default::default()
+    };
+
+    let prepared = manager
+        .craft_tx(&candidate, Some((override_tip, override_fee_cap)))
+        .await
+        .expect("should craft tx with fee overrides");
+
+    // PreparedTx must reflect the overrides since they exceed network fees.
+    assert_eq!(
+        prepared.gas_tip_cap, override_tip,
+        "gas_tip_cap should equal the override when it exceeds the network fee",
+    );
+    assert_eq!(
+        prepared.gas_fee_cap, override_fee_cap,
+        "gas_fee_cap should equal the override when it exceeds the network fee",
+    );
+
+    // The signed transaction must also carry the override fees.
+    let tx = decode_eip1559(&prepared.raw_tx);
+    assert_eq!(tx.max_priority_fee_per_gas, override_tip);
+    assert_eq!(tx.max_fee_per_gas, override_fee_cap);
+}
+
+/// When fee overrides are below network fees, the [`PreparedTx`] must use the
+/// network fees (since `craft_tx` takes `max(network_fee, override)`).
+#[tokio::test]
+async fn craft_tx_with_fee_overrides_uses_network_when_overrides_below() {
+    let (manager, _anvil) = setup().await;
+
+    // Learn current network fees.
+    let caps = manager.suggest_gas_price_caps().await.expect("should get caps");
+
+    // Set overrides well below network fees (1 wei each).
+    let override_tip = 1u128;
+    let override_fee_cap = 1u128;
+
+    let candidate = TxCandidate {
+        to: Some(Address::with_last_byte(0x42)),
+        value: U256::from(1_000u64),
+        gas_limit: 0,
+        ..Default::default()
+    };
+
+    let prepared = manager
+        .craft_tx(&candidate, Some((override_tip, override_fee_cap)))
+        .await
+        .expect("should craft tx with low fee overrides");
+
+    // PreparedTx must use network fees since they exceed the overrides.
+    assert_eq!(
+        prepared.gas_tip_cap, caps.gas_tip_cap,
+        "gas_tip_cap should use network fee, not the low override",
+    );
+    assert_eq!(
+        prepared.gas_fee_cap, caps.gas_fee_cap,
+        "gas_fee_cap should use network fee, not the low override",
+    );
+}
+
+/// Verifies that the [`PreparedTx`] fee fields are always consistent with the
+/// fees encoded in the signed transaction — the core invariant that
+/// [`PreparedTx`] is designed to guarantee.
+#[tokio::test]
+async fn prepared_tx_fees_match_decoded_transaction_with_overrides() {
+    let (manager, _anvil) = setup().await;
+
+    let caps = manager.suggest_gas_price_caps().await.expect("should get caps");
+    let override_tip = caps.gas_tip_cap + 10_000_000_000;
+    let override_fee_cap = caps.gas_fee_cap + 20_000_000_000;
+
+    let candidate = TxCandidate {
+        to: Some(Address::with_last_byte(0x42)),
+        value: U256::from(1_000u64),
+        gas_limit: 0,
+        ..Default::default()
+    };
+
+    let prepared = manager
+        .craft_tx(&candidate, Some((override_tip, override_fee_cap)))
+        .await
+        .expect("should craft tx");
+    let tx = decode_eip1559(&prepared.raw_tx);
+
+    assert_eq!(
+        prepared.gas_tip_cap, tx.max_priority_fee_per_gas,
+        "PreparedTx gas_tip_cap must match decoded max_priority_fee_per_gas",
+    );
+    assert_eq!(
+        prepared.gas_fee_cap, tx.max_fee_per_gas,
+        "PreparedTx gas_fee_cap must match decoded max_fee_per_gas",
+    );
 }
 
 #[test]

--- a/crates/utilities/tx-manager/tests/send_lifecycle.rs
+++ b/crates/utilities/tx-manager/tests/send_lifecycle.rs
@@ -1,0 +1,50 @@
+//! Integration tests for [`SimpleTxManager::publish_tx`] with Anvil.
+
+use alloy_network::EthereumWallet;
+use alloy_node_bindings::Anvil;
+use alloy_primitives::{Address, B256, U256};
+use alloy_provider::RootProvider;
+use alloy_signer_local::PrivateKeySigner;
+use base_tx_manager::{SendState, SimpleTxManager, TxCandidate, TxManagerConfig};
+
+/// Helper: spawns an Anvil instance and returns a [`SimpleTxManager`]
+/// configured with the given [`TxManagerConfig`].
+async fn setup_with_config(
+    config: TxManagerConfig,
+) -> (SimpleTxManager, alloy_node_bindings::AnvilInstance) {
+    let anvil = Anvil::new().spawn();
+    let url = anvil.endpoint_url();
+    let provider = RootProvider::new_http(url);
+    let signer: PrivateKeySigner = anvil.keys()[0].clone().into();
+    let wallet = EthereumWallet::from(signer);
+    let chain_id = anvil.chain_id();
+    let manager = SimpleTxManager::new(provider, wallet, config, chain_id)
+        .await
+        .expect("should create manager");
+    (manager, anvil)
+}
+
+// ── publish_tx() ──────────────────────────────────────────────────────
+
+/// `publish_tx` broadcasts a valid raw transaction, returns a non-zero
+/// hash, and records a successful publish on the `SendState`.
+#[tokio::test]
+async fn publish_tx_success_returns_hash_and_records_publish() {
+    let (manager, _anvil) = setup_with_config(TxManagerConfig::default()).await;
+
+    let candidate = TxCandidate {
+        to: Some(Address::with_last_byte(0x42)),
+        value: U256::from(1_000u64),
+        gas_limit: 0,
+        ..Default::default()
+    };
+
+    let prepared = manager.craft_tx(&candidate, None).await.expect("should craft tx");
+    let send_state = SendState::new(3).expect("should create send state");
+
+    let tx_hash =
+        manager.publish_tx(&send_state, &prepared.raw_tx, None).await.expect("should publish tx");
+
+    assert_ne!(tx_hash, B256::ZERO, "published tx hash should be non-zero");
+    assert_eq!(send_state.successful_publish_count(), 1, "should record one successful publish");
+}


### PR DESCRIPTION
## Summary

Extracts publishing infrastructure from the full send/confirm lifecycle (`feat/tx-publish-confirm-loop`) into a focused PR:

- **`PreparedTx` struct** — returned by `prepare()` and `craft_tx()` to carry the actual on-wire fees (`gas_tip_cap`, `gas_fee_cap`) alongside the raw signed bytes, eliminating redundant gas price queries
- **Fee overrides** — `prepare()` and `craft_tx()` accept `Option<(u128, u128)>` to support fee bump iterations via `max(network_fee, override)` floor logic
- **`publish_tx()`** — broadcasts raw transactions with `SendState` tracking, `AlreadyKnown` deduplication, and structured error classification
- **`Arc<AtomicBool>` closed flag** — enables sharing the shutdown signal with spawned background tasks (needed by `send_async` in the follow-up PR)
- **`SendState` additions** — `clear_bump_fees()` and `successful_publish_count()` methods with unit tests
- **Test coverage** — fee override integration tests, `calc_gas_fee_cap` roundtrip tests (rstest + proptest), and `publish_tx` lifecycle test

`send()` and `send_async()` remain `todo!()` — the confirmation loop (send_tx, wait_mined, query_receipt, trait impls) follows in a separate PR.

## Test plan

- [x] `cargo build -p base-tx-manager` — clean
- [x] `cargo clippy -p base-tx-manager -- -D warnings` — clean
- [x] `cargo test -p base-tx-manager` — 241 tests pass (204 unit + 22 craft_tx integration + 2 macros + 12 nonce + 1 send_lifecycle)
- [x] `cargo doc -p base-tx-manager` — no new doc warnings
- [x] `send()` / `send_async()` verified still `todo!()`