### PR TITLE
fix(proof/tee): remove tee_image_hash from enclave CLI and config

### DIFF
--- a/bin/prover/src/cli.rs
+++ b/bin/prover/src/cli.rs
@@ -221,11 +221,8 @@ impl NitroLocalArgs {
             .ok_or_else(|| eyre!("unknown L1 chain ID: {}", rollup_config.l1_chain_id))?
             .clone();
 
-        let enclave_config = EnclaveConfig {
-            vsock_cid: 0,
-            vsock_port: 0,
-            config_hash: self.config_hash,
-        };
+        let enclave_config =
+            EnclaveConfig { vsock_cid: 0, vsock_port: 0, config_hash: self.config_hash };
 
         let prover_config = ProverConfig {
             l1_eth_url: self.server.l1_eth_url,

--- a/bin/prover/src/cli.rs
+++ b/bin/prover/src/cli.rs
@@ -121,10 +121,6 @@ struct NitroEnclaveArgs {
     /// Per-chain configuration hash.
     #[arg(long, env = "CONFIG_HASH")]
     config_hash: B256,
-
-    /// Expected PCR0 measurement of the enclave image.
-    #[arg(long, env = "TEE_IMAGE_HASH")]
-    tee_image_hash: B256,
 }
 
 impl Cli {
@@ -186,7 +182,6 @@ impl NitroEnclaveArgs {
             vsock_cid: self.vsock_cid,
             vsock_port: self.vsock_port,
             config_hash: self.config_hash,
-            tee_image_hash: self.tee_image_hash,
         };
 
         #[cfg(not(target_os = "linux"))]
@@ -213,10 +208,6 @@ struct NitroLocalArgs {
     /// Per-chain configuration hash.
     #[arg(long, env = "CONFIG_HASH")]
     config_hash: B256,
-
-    /// Expected PCR0 measurement of the enclave image.
-    #[arg(long, env = "TEE_IMAGE_HASH")]
-    tee_image_hash: B256,
 }
 
 #[cfg(feature = "local")]
@@ -234,7 +225,6 @@ impl NitroLocalArgs {
             vsock_cid: 0,
             vsock_port: 0,
             config_hash: self.config_hash,
-            tee_image_hash: self.tee_image_hash,
         };
 
         let prover_config = ProverConfig {

--- a/crates/proof/tee/Justfile
+++ b/crates/proof/tee/Justfile
@@ -27,7 +27,6 @@ nitro-local *args:
         --l2-chain-id "${L2_CHAIN_ID:-8453}" \
         --listen-addr "${LISTEN_ADDR:-0.0.0.0:7300}" \
         --config-hash "${CONFIG_HASH:-0x0000000000000000000000000000000000000000000000000000000000000000}" \
-        --tee-image-hash "${TEE_IMAGE_HASH:-0x0000000000000000000000000000000000000000000000000000000000000000}" \
         --enable-experimental-witness-endpoint \
         {{ args }}
 

--- a/crates/proof/tee/nitro/src/enclave/mod.rs
+++ b/crates/proof/tee/nitro/src/enclave/mod.rs
@@ -39,8 +39,6 @@ pub struct EnclaveConfig {
     pub vsock_port: u32,
     /// Per-chain configuration hash.
     pub config_hash: B256,
-    /// Expected TEE image hash. In enclave mode, verified as keccak256(PCR0) against NSM at startup.
-    pub tee_image_hash: B256,
 }
 
 /// Nitro Enclave runtime.

--- a/crates/proof/tee/nitro/src/enclave/server.rs
+++ b/crates/proof/tee/nitro/src/enclave/server.rs
@@ -35,7 +35,7 @@ pub struct Server {
     signer_key: PrivateKeySigner,
     /// Per-chain config hash.
     config_hash: B256,
-    /// TEE image hash (keccak256 of PCR0 in enclave mode, from config in local mode).
+    /// TEE image hash (keccak256 of PCR0 in enclave mode, zero in local mode).
     tee_image_hash: B256,
 }
 
@@ -43,10 +43,9 @@ impl Server {
     /// Create a new server instance.
     ///
     /// In enclave mode (NSM available): reads PCR0, keccak256-hashes it to derive
-    /// `tee_image_hash`, verifies against the configured expected hash, and uses the
-    /// hardware RNG for key generation.
+    /// `tee_image_hash`, and uses the hardware RNG for key generation.
     ///
-    /// In local mode (no NSM): uses the OS RNG and accepts `config.tee_image_hash` as-is.
+    /// In local mode (no NSM): uses the OS RNG and sets `tee_image_hash` to zero.
     pub fn new(config: &EnclaveConfig) -> Result<Self> {
         NsmSession::open()?.map_or_else(
             || {
@@ -68,12 +67,6 @@ impl Server {
         }
 
         let tee_image_hash = keccak256(&pcr0);
-        if tee_image_hash != config.tee_image_hash {
-            return Err(NitroError::Pcr0Mismatch {
-                expected: config.tee_image_hash,
-                actual: tee_image_hash,
-            });
-        }
 
         let mut rng = NsmRng::new()
             .ok_or_else(|| NsmError::SessionOpen("failed to initialize NSM RNG".into()))?;
@@ -95,7 +88,7 @@ impl Server {
             pcr0: Vec::new(),
             signer_key,
             config_hash: config.config_hash,
-            tee_image_hash: config.tee_image_hash,
+            tee_image_hash: B256::ZERO,
         })
     }
 
@@ -238,7 +231,7 @@ impl Server {
             pcr0: Vec::new(),
             signer_key,
             config_hash: config.config_hash,
-            tee_image_hash: config.tee_image_hash,
+            tee_image_hash: B256::ZERO,
         })
     }
 }
@@ -248,12 +241,7 @@ mod tests {
     use super::*;
 
     fn test_config() -> EnclaveConfig {
-        EnclaveConfig {
-            vsock_cid: 0,
-            vsock_port: 1234,
-            config_hash: B256::ZERO,
-            tee_image_hash: B256::ZERO,
-        }
+        EnclaveConfig { vsock_cid: 0, vsock_port: 1234, config_hash: B256::ZERO }
     }
 
     #[test]

--- a/crates/proof/tee/nitro/src/error.rs
+++ b/crates/proof/tee/nitro/src/error.rs
@@ -1,6 +1,5 @@
 //! Error types for enclave server operations.
 
-use alloy_primitives::B256;
 use thiserror::Error;
 
 /// Errors that can occur during NSM operations.
@@ -160,14 +159,6 @@ pub enum NitroError {
     /// Internal error.
     #[error("internal error: {0}")]
     Internal(String),
-    /// PCR0 mismatch between config and NSM.
-    #[error("PCR0 mismatch: expected {expected}, actual {actual}")]
-    Pcr0Mismatch {
-        /// Expected PCR0 hash from config.
-        expected: B256,
-        /// Actual PCR0 hash from NSM.
-        actual: B256,
-    },
     /// Proof transport failed.
     #[cfg(feature = "host")]
     #[error("transport error: {0}")]

--- a/crates/proof/tee/nitro/src/host/backend.rs
+++ b/crates/proof/tee/nitro/src/host/backend.rs
@@ -50,12 +50,7 @@ mod tests {
     use crate::enclave::{EnclaveConfig, Server};
 
     fn test_config() -> EnclaveConfig {
-        EnclaveConfig {
-            vsock_cid: 0,
-            vsock_port: 0,
-            config_hash: B256::ZERO,
-            tee_image_hash: B256::ZERO,
-        }
+        EnclaveConfig { vsock_cid: 0, vsock_port: 0, config_hash: B256::ZERO }
     }
 
     #[tokio::test]

--- a/crates/proof/tee/nitro/src/host/server.rs
+++ b/crates/proof/tee/nitro/src/host/server.rs
@@ -95,12 +95,7 @@ mod tests {
     use crate::enclave::{EnclaveConfig, Server as EnclaveServer};
 
     fn test_config() -> EnclaveConfig {
-        EnclaveConfig {
-            vsock_cid: 0,
-            vsock_port: 0,
-            config_hash: B256::ZERO,
-            tee_image_hash: B256::ZERO,
-        }
+        EnclaveConfig { vsock_cid: 0, vsock_port: 0, config_hash: B256::ZERO }
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- Remove `tee_image_hash` from `EnclaveConfig`, `NitroEnclaveArgs`, and `NitroLocalArgs` to fix a chicken-and-egg problem where baking the hash into the EIF ramdisk changes PCR0, invalidating the hash
- The enclave now self-derives `tee_image_hash` as `keccak256(PCR0)` from NSM hardware (the source of truth) instead of accepting it via CLI
- Local mode uses `B256::ZERO` (matching existing host test conventions)
- Remove the now-unused `Pcr0Mismatch` error variant and `--tee-image-hash` Justfile arg

## Not touched

- Proposer CLI (`BASE_PROPOSER_TEE_IMAGE_HASH`) — separate concern, receives the hash externally
- `ProofJournal.tee_image_hash` — still populated by the enclave server from the derived value
- Core/RPC types, crypto tests, lib.rs re-exports