### PR TITLE
fix(gossip): correct misleading log message in peer dump send path

### DIFF
--- a/crates/consensus/gossip/src/rpc/request.rs
+++ b/crates/consensus/gossip/src/rpc/request.rs
@@ -465,7 +465,7 @@ impl P2pRpcRequest {
                 banned_ips,
                 banned_subnets,
             }) {
-                warn!(target: "p2p::rpc", error = ?e, "Failed to send peer info through response channel");
+                warn!(target: "p2p::rpc", error = ?e, "Failed to send peer dump through response channel");
             }
         });
     }


### PR DESCRIPTION
Copy-paste(maybe) leftover — the PeerDump send failure was logging "peer info" instead of "peer dump", making it look like the peer info handler failed.