### PR TITLE
fix(consensus): correct misleading log in reset_engine_forkchoice

### DIFF
--- a/crates/consensus/service/src/actors/derivation/engine_client.rs
+++ b/crates/consensus/service/src/actors/derivation/engine_client.rs
@@ -51,7 +51,7 @@ impl DerivationEngineClient for QueuedDerivationEngineClient {
             .await
             .inspect(|_| info!(target: "derivation", "Engine reset successfully."))
             .ok_or_else(|| {
-                error!(target: "derivation_engine_client", "Failed to receive built payload");
+                error!(target: "derivation_engine_client", "Failed to receive forkchoice reset result");
                 EngineClientError::ResponseError("response channel closed.".to_string())
             })?
     }

--- a/crates/consensus/service/src/actors/sequencer/engine_client.rs
+++ b/crates/consensus/service/src/actors/sequencer/engine_client.rs
@@ -73,7 +73,7 @@ impl SequencerEngineClient for QueuedSequencerEngineClient {
             .await
             .inspect(|_| info!(target: "sequencer", "Engine reset successfully."))
             .ok_or_else(|| {
-                error!(target: "block_engine", "Failed to receive built payload");
+                error!(target: "block_engine", "Failed to receive forkchoice reset result");
                 EngineClientError::ResponseError("response channel closed.".to_string())
             })?
     }


### PR DESCRIPTION
Both sequencer and derivation engine clients were logging "Failed to receive built payload" inside the forkchoice reset path.

weird and confused when see these logs in the node.