### PR TITLE
feat(tx-manager): Transaction Confirmation Polling

### DIFF
--- a/crates/utilities/tx-manager/src/config.rs
+++ b/crates/utilities/tx-manager/src/config.rs
@@ -111,6 +111,8 @@ pub struct TxManagerConfig {
     pub tx_send_timeout: Duration,
     /// Mempool appearance timeout (zero = disabled).
     pub tx_not_in_mempool_timeout: Duration,
+    /// Maximum time to poll for confirmation before giving up.
+    pub confirmation_timeout: Duration,
 }
 
 impl Default for TxManagerConfig {
@@ -127,6 +129,7 @@ impl Default for TxManagerConfig {
             receipt_query_interval: Duration::from_secs(12),
             tx_send_timeout: Duration::ZERO,
             tx_not_in_mempool_timeout: Duration::from_secs(120),
+            confirmation_timeout: Duration::from_secs(300),
         }
     }
 }
@@ -143,6 +146,7 @@ impl TxManagerConfig {
     /// - `network_timeout` must be > 0
     /// - `resubmission_timeout` must be > 0
     /// - `receipt_query_interval` must be > 0
+    /// - `confirmation_timeout` must be > 0
     pub fn validate(&self) -> Result<(), ConfigError> {
         if self.num_confirmations == 0 {
             return Err(ConfigError::OutOfRange {
@@ -182,6 +186,13 @@ impl TxManagerConfig {
         if self.receipt_query_interval.is_zero() {
             return Err(ConfigError::OutOfRange {
                 field: "receipt_query_interval",
+                constraint: "> 0",
+                value: "0s".to_string(),
+            });
+        }
+        if self.confirmation_timeout.is_zero() {
+            return Err(ConfigError::OutOfRange {
+                field: "confirmation_timeout",
                 constraint: "> 0",
                 value: "0s".to_string(),
             });
@@ -272,5 +283,16 @@ mod tests {
     #[test]
     fn default_passes_validation() {
         TxManagerConfig::default().validate().expect("default config should be valid");
+    }
+
+    #[test]
+    fn validation_rejects_zero_confirmation_timeout() {
+        let config =
+            TxManagerConfig { confirmation_timeout: Duration::ZERO, ..TxManagerConfig::default() };
+        let err = config.validate().unwrap_err();
+        assert!(
+            matches!(err, ConfigError::OutOfRange { field: "confirmation_timeout", .. }),
+            "expected OutOfRange for confirmation_timeout, got: {err}"
+        );
     }
 }

--- a/crates/utilities/tx-manager/src/macros.rs
+++ b/crates/utilities/tx-manager/src/macros.rs
@@ -8,7 +8,7 @@
 /// base_tx_manager::define_tx_manager_cli!("BASE_CHALLENGER_TX_MANAGER");
 /// ```
 ///
-/// The generated struct has eleven fields covering confirmations, fee limits,
+/// The generated struct has twelve fields covering confirmations, fee limits,
 /// timeouts, and polling intervals. Each env-backed field uses
 /// `concat!($prefix, "_", "FIELD_NAME")` — e.g., with prefix
 /// `"BASE_CHALLENGER_TX_MANAGER"` the num-confirmations field reads from
@@ -142,6 +142,16 @@ macro_rules! define_tx_manager_cli {
                 value_parser = ::humantime::parse_duration
             )]
             pub tx_not_in_mempool_timeout: ::std::time::Duration,
+
+            /// Maximum time to poll for transaction confirmation before giving
+            /// up (e.g., "5m", "300s").
+            #[arg(
+                long = "tx-manager.confirmation-timeout",
+                env = concat!($prefix, "_", "CONFIRMATION_TIMEOUT"),
+                default_value = "5m",
+                value_parser = ::humantime::parse_duration
+            )]
+            pub confirmation_timeout: ::std::time::Duration,
         }
 
         impl Default for TxManagerCli {
@@ -173,6 +183,7 @@ macro_rules! define_tx_manager_cli {
                     receipt_query_interval: cli.receipt_query_interval,
                     tx_send_timeout: cli.tx_send_timeout,
                     tx_not_in_mempool_timeout: cli.tx_not_in_mempool_timeout,
+                    confirmation_timeout: cli.confirmation_timeout,
                 };
                 config.validate()?;
                 Ok(config)

--- a/crates/utilities/tx-manager/src/manager.rs
+++ b/crates/utilities/tx-manager/src/manager.rs
@@ -30,7 +30,7 @@ use std::{
         Arc,
         atomic::{AtomicBool, Ordering},
     },
-    time::Duration,
+    time::{Duration, Instant},
 };
 
 use alloy_eips::{BlockNumberOrTag, Encodable2718};
@@ -526,7 +526,7 @@ impl SimpleTxManager {
     ///   already delivered).
     /// - Polling frequency is governed by `receipt_query_interval`, so
     ///   RPC load is proportional to `bump_count × 1/interval`.
-    fn wait_for_tx(
+    pub fn wait_for_tx(
         send_state: Arc<SendState>,
         provider: RootProvider,
         tx_hash: B256,
@@ -552,18 +552,29 @@ impl SimpleTxManager {
     /// the transaction is mined and confirmed to the required depth.
     ///
     /// Returns `Some(receipt)` when the transaction reaches
-    /// `num_confirmations` depth, or `None` if the manager is closed.
-    async fn wait_mined(
+    /// `num_confirmations` depth, or `None` if the manager is closed or
+    /// the `confirmation_timeout` deadline is exceeded.
+    pub async fn wait_mined(
         send_state: &SendState,
         provider: &RootProvider,
         tx_hash: B256,
         config: &TxManagerConfig,
         closed: &AtomicBool,
     ) -> Option<TransactionReceipt> {
+        let deadline = Instant::now() + config.confirmation_timeout;
         let mut poll_interval = tokio::time::interval(config.receipt_query_interval);
 
         loop {
             poll_interval.tick().await;
+
+            if Instant::now() >= deadline {
+                warn!(
+                    tx_hash = %tx_hash,
+                    timeout = ?config.confirmation_timeout,
+                    "confirmation timeout exceeded",
+                );
+                return None;
+            }
 
             // Check shutdown state each iteration to support cancellation.
             if closed.load(Ordering::Acquire) {
@@ -611,6 +622,13 @@ impl SimpleTxManager {
         num_confirmations: u64,
         network_timeout: Duration,
     ) -> TxManagerResult<Option<TransactionReceipt>> {
+        // Fetch tip *before* the receipt so that a reorg between the two
+        // calls can only undercount confirmations (safe), never overcount.
+        let tip_height = tokio::time::timeout(network_timeout, provider.get_block_number())
+            .await
+            .map_err(|_| TxManagerError::Rpc("get_block_number timed out".into()))?
+            .map_err(|e| RpcErrorClassifier::classify_rpc_error(&e.to_string()))?;
+
         let receipt_opt =
             tokio::time::timeout(network_timeout, provider.get_transaction_receipt(tx_hash))
                 .await
@@ -638,11 +656,6 @@ impl SimpleTxManager {
         };
 
         // Check confirmation depth: tx_block + num_confirmations <= tip + 1
-        let tip_height = tokio::time::timeout(network_timeout, provider.get_block_number())
-            .await
-            .map_err(|_| TxManagerError::Rpc("get_block_number timed out".into()))?
-            .map_err(|e| RpcErrorClassifier::classify_rpc_error(&e.to_string()))?;
-
         if tx_block.saturating_add(num_confirmations) <= tip_height.saturating_add(1) {
             info!(
                 tx_hash = %tx_hash,

--- a/crates/utilities/tx-manager/src/manager.rs
+++ b/crates/utilities/tx-manager/src/manager.rs
@@ -37,9 +37,10 @@ use alloy_eips::{BlockNumberOrTag, Encodable2718};
 use alloy_network::{Ethereum, EthereumWallet, NetworkWallet, TransactionBuilder};
 use alloy_primitives::{Address, B256, Bytes};
 use alloy_provider::{Provider, RootProvider};
-use alloy_rpc_types_eth::TransactionRequest;
+use alloy_rpc_types_eth::{TransactionReceipt, TransactionRequest};
 use backon::{ConstantBuilder, Retryable};
-use tracing::{error, info, warn};
+use tokio::sync::mpsc;
+use tracing::{debug, error, info, warn};
 
 use crate::{
     FeeCalculator, FeeOverride, GasPriceCaps, NonceManager, RpcErrorClassifier, SendHandle,
@@ -502,6 +503,164 @@ impl SimpleTxManager {
                 warn!("publish timed out");
                 Err(err)
             }
+        }
+    }
+
+    /// Spawns a background task that polls for a transaction receipt and
+    /// sends it through the provided channel once confirmed.
+    ///
+    /// The task calls [`wait_mined`](Self::wait_mined) in a loop, checking
+    /// both confirmation status and manager shutdown via the shared `closed`
+    /// flag.
+    ///
+    /// # Task accumulation
+    ///
+    /// Each fee bump spawns a new polling task for the replacement tx hash
+    /// without cancelling the previous one. This is intentional: any
+    /// previously-published variant may still confirm (the original or an
+    /// earlier bump), and we want to detect whichever is mined first.
+    /// Accumulated tasks are bounded by three mechanisms:
+    /// - The `closed` flag causes all pollers to exit on shutdown.
+    /// - Each poller exits once it delivers a receipt through the mpsc
+    ///   channel (or finds the channel closed because a different poller
+    ///   already delivered).
+    /// - Polling frequency is governed by `receipt_query_interval`, so
+    ///   RPC load is proportional to `bump_count × 1/interval`.
+    fn wait_for_tx(
+        send_state: Arc<SendState>,
+        provider: RootProvider,
+        tx_hash: B256,
+        config: TxManagerConfig,
+        receipt_tx: mpsc::Sender<TransactionReceipt>,
+        closed: Arc<AtomicBool>,
+    ) {
+        tokio::spawn(async move {
+            debug!(tx_hash = %tx_hash, "starting receipt polling");
+
+            let receipt = Self::wait_mined(&send_state, &provider, tx_hash, &config, &closed).await;
+            if let Some(receipt) = receipt {
+                // Best-effort send — if the receiver is dropped, the
+                // send loop has already exited (e.g., another tx confirmed).
+                let _ = receipt_tx.send(receipt).await;
+            }
+
+            debug!(tx_hash = %tx_hash, "receipt polling ended");
+        });
+    }
+
+    /// Polls for a transaction receipt at `receipt_query_interval` until
+    /// the transaction is mined and confirmed to the required depth.
+    ///
+    /// Returns `Some(receipt)` when the transaction reaches
+    /// `num_confirmations` depth, or `None` if the manager is closed.
+    async fn wait_mined(
+        send_state: &SendState,
+        provider: &RootProvider,
+        tx_hash: B256,
+        config: &TxManagerConfig,
+        closed: &AtomicBool,
+    ) -> Option<TransactionReceipt> {
+        let mut poll_interval = tokio::time::interval(config.receipt_query_interval);
+
+        loop {
+            poll_interval.tick().await;
+
+            // Check shutdown state each iteration to support cancellation.
+            if closed.load(Ordering::Acquire) {
+                debug!(tx_hash = %tx_hash, "manager closed, stopping receipt polling");
+                return None;
+            }
+
+            match Self::query_receipt(
+                send_state,
+                provider,
+                tx_hash,
+                config.num_confirmations,
+                config.network_timeout,
+            )
+            .await
+            {
+                Ok(Some(receipt)) => return Some(receipt),
+                Ok(None) => {
+                    // Not yet confirmed — continue polling.
+                }
+                Err(e) => {
+                    warn!(tx_hash = %tx_hash, error = %e, "receipt query failed");
+                }
+            }
+        }
+    }
+
+    /// Performs a single receipt check for the given transaction hash.
+    ///
+    /// - If no receipt is found, calls [`SendState::tx_not_mined`] (reorg
+    ///   detection) and returns `Ok(None)`.
+    /// - If a receipt is found, calls [`SendState::tx_mined`] and checks
+    ///   confirmation depth via the formula:
+    ///   `tx_block + num_confirmations <= tip_height + 1`.
+    /// - Returns `Ok(Some(receipt))` when sufficiently confirmed, or
+    ///   `Ok(None)` when the receipt exists but needs more confirmations.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`TxManagerError::Rpc`] if provider calls fail.
+    pub async fn query_receipt(
+        send_state: &SendState,
+        provider: &RootProvider,
+        tx_hash: B256,
+        num_confirmations: u64,
+        network_timeout: Duration,
+    ) -> TxManagerResult<Option<TransactionReceipt>> {
+        let receipt_opt =
+            tokio::time::timeout(network_timeout, provider.get_transaction_receipt(tx_hash))
+                .await
+                .map_err(|_| TxManagerError::Rpc("get_transaction_receipt timed out".into()))?
+                .map_err(|e| RpcErrorClassifier::classify_rpc_error(&e.to_string()))?;
+
+        let receipt = match receipt_opt {
+            Some(r) => r,
+            None => {
+                send_state.tx_not_mined(tx_hash);
+                debug!(tx_hash = %tx_hash, "receipt not found, possible reorg");
+                return Ok(None);
+            }
+        };
+
+        // Receipt exists — record as mined regardless of confirmation depth.
+        send_state.tx_mined(tx_hash);
+
+        let tx_block = match receipt.block_number {
+            Some(block) => block,
+            None => {
+                // Receipt without a block number (e.g., pending) — treat as not yet confirmed.
+                return Ok(None);
+            }
+        };
+
+        // Check confirmation depth: tx_block + num_confirmations <= tip + 1
+        let tip_height = tokio::time::timeout(network_timeout, provider.get_block_number())
+            .await
+            .map_err(|_| TxManagerError::Rpc("get_block_number timed out".into()))?
+            .map_err(|e| RpcErrorClassifier::classify_rpc_error(&e.to_string()))?;
+
+        if tx_block.saturating_add(num_confirmations) <= tip_height.saturating_add(1) {
+            info!(
+                tx_hash = %tx_hash,
+                tx_block = %tx_block,
+                tip_height = %tip_height,
+                num_confirmations = %num_confirmations,
+                "transaction confirmed to required depth",
+            );
+            Ok(Some(receipt))
+        } else {
+            debug!(
+                tx_hash = %tx_hash,
+                tx_block = %tx_block,
+                tip_height = %tip_height,
+                needed = %num_confirmations,
+                "waiting for more confirmations",
+            );
+            Ok(None)
         }
     }
 }

--- a/crates/utilities/tx-manager/src/manager.rs
+++ b/crates/utilities/tx-manager/src/manager.rs
@@ -651,6 +651,7 @@ impl SimpleTxManager {
             Some(block) => block,
             None => {
                 // Receipt without a block number (e.g., pending) — treat as not yet confirmed.
+                send_state.tx_not_mined(tx_hash);
                 return Ok(None);
             }
         };

--- a/crates/utilities/tx-manager/src/manager.rs
+++ b/crates/utilities/tx-manager/src/manager.rs
@@ -30,7 +30,7 @@ use std::{
         Arc,
         atomic::{AtomicBool, Ordering},
     },
-    time::{Duration, Instant},
+    time::Duration,
 };
 
 use alloy_eips::{BlockNumberOrTag, Encodable2718};
@@ -39,7 +39,7 @@ use alloy_primitives::{Address, B256, Bytes};
 use alloy_provider::{Provider, RootProvider};
 use alloy_rpc_types_eth::{TransactionReceipt, TransactionRequest};
 use backon::{ConstantBuilder, Retryable};
-use tokio::sync::mpsc;
+use tokio::{sync::mpsc, time::Instant};
 use tracing::{debug, error, info, warn};
 
 use crate::{
@@ -509,9 +509,12 @@ impl SimpleTxManager {
     /// Spawns a background task that polls for a transaction receipt and
     /// sends it through the provided channel once confirmed.
     ///
-    /// The task calls [`wait_mined`](Self::wait_mined) in a loop, checking
-    /// both confirmation status and manager shutdown via the shared `closed`
-    /// flag.
+    /// The task delegates to [`wait_mined`](Self::wait_mined), which polls
+    /// internally until the transaction is confirmed or the manager shuts
+    /// down.
+    ///
+    /// Returns the [`JoinHandle`](tokio::task::JoinHandle) of the spawned
+    /// task so callers can await its completion if needed.
     ///
     /// # Task accumulation
     ///
@@ -533,7 +536,7 @@ impl SimpleTxManager {
         config: TxManagerConfig,
         receipt_tx: mpsc::Sender<TransactionReceipt>,
         closed: Arc<AtomicBool>,
-    ) {
+    ) -> tokio::task::JoinHandle<()> {
         tokio::spawn(async move {
             debug!(tx_hash = %tx_hash, "starting receipt polling");
 
@@ -545,7 +548,7 @@ impl SimpleTxManager {
             }
 
             debug!(tx_hash = %tx_hash, "receipt polling ended");
-        });
+        })
     }
 
     /// Polls for a transaction receipt at `receipt_query_interval` until
@@ -567,21 +570,6 @@ impl SimpleTxManager {
         loop {
             poll_interval.tick().await;
 
-            if Instant::now() >= deadline {
-                warn!(
-                    tx_hash = %tx_hash,
-                    timeout = ?config.confirmation_timeout,
-                    "confirmation timeout exceeded",
-                );
-                return None;
-            }
-
-            // Check shutdown state each iteration to support cancellation.
-            if closed.load(Ordering::Acquire) {
-                debug!(tx_hash = %tx_hash, "manager closed, stopping receipt polling");
-                return None;
-            }
-
             match Self::query_receipt(
                 send_state,
                 provider,
@@ -598,6 +586,21 @@ impl SimpleTxManager {
                 Err(e) => {
                     warn!(tx_hash = %tx_hash, error = %e, "receipt query failed");
                 }
+            }
+
+            if Instant::now() >= deadline {
+                warn!(
+                    tx_hash = %tx_hash,
+                    timeout = ?config.confirmation_timeout,
+                    "confirmation timeout exceeded",
+                );
+                return None;
+            }
+
+            // Check shutdown state each iteration to support cancellation.
+            if closed.load(Ordering::Acquire) {
+                debug!(tx_hash = %tx_hash, "manager closed, stopping receipt polling");
+                return None;
             }
         }
     }
@@ -644,9 +647,6 @@ impl SimpleTxManager {
             }
         };
 
-        // Receipt exists — record as mined regardless of confirmation depth.
-        send_state.tx_mined(tx_hash);
-
         let tx_block = match receipt.block_number {
             Some(block) => block,
             None => {
@@ -654,6 +654,9 @@ impl SimpleTxManager {
                 return Ok(None);
             }
         };
+
+        // Receipt exists with a block number — record as mined.
+        send_state.tx_mined(tx_hash);
 
         // Check confirmation depth: tx_block + num_confirmations <= tip + 1
         if tx_block.saturating_add(num_confirmations) <= tip_height.saturating_add(1) {
@@ -670,7 +673,7 @@ impl SimpleTxManager {
                 tx_hash = %tx_hash,
                 tx_block = %tx_block,
                 tip_height = %tip_height,
-                needed = %num_confirmations,
+                num_confirmations = %num_confirmations,
                 "waiting for more confirmations",
             );
             Ok(None)

--- a/crates/utilities/tx-manager/src/manager.rs
+++ b/crates/utilities/tx-manager/src/manager.rs
@@ -566,6 +566,7 @@ impl SimpleTxManager {
     ) -> Option<TransactionReceipt> {
         let deadline = Instant::now() + config.confirmation_timeout;
         let mut poll_interval = tokio::time::interval(config.receipt_query_interval);
+        poll_interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
 
         loop {
             poll_interval.tick().await;

--- a/crates/utilities/tx-manager/tests/custom_prefix.rs
+++ b/crates/utilities/tx-manager/tests/custom_prefix.rs
@@ -30,6 +30,7 @@ fn env_vars_use_custom_prefix() {
         ("tx-manager.receipt-query-interval", "CUSTOM_PREFIX_RECEIPT_QUERY_INTERVAL"),
         ("tx-manager.tx-send-timeout", "CUSTOM_PREFIX_TX_SEND_TIMEOUT"),
         ("tx-manager.tx-not-in-mempool-timeout", "CUSTOM_PREFIX_TX_NOT_IN_MEMPOOL_TIMEOUT"),
+        ("tx-manager.confirmation-timeout", "CUSTOM_PREFIX_CONFIRMATION_TIMEOUT"),
     ];
 
     for (long_name, expected_env) in cases {

--- a/crates/utilities/tx-manager/tests/send_lifecycle.rs
+++ b/crates/utilities/tx-manager/tests/send_lifecycle.rs
@@ -3,7 +3,7 @@
 use std::{
     sync::{
         Arc,
-        atomic::{AtomicBool, Ordering},
+        atomic::AtomicBool,
     },
     time::Duration,
 };

--- a/crates/utilities/tx-manager/tests/send_lifecycle.rs
+++ b/crates/utilities/tx-manager/tests/send_lifecycle.rs
@@ -208,7 +208,11 @@ async fn wait_mined_returns_confirmed_receipt() {
 /// `wait_mined` returns `None` when the manager is shut down.
 #[tokio::test]
 async fn wait_mined_returns_none_on_shutdown() {
-    let config = fast_polling_config();
+    let config = TxManagerConfig {
+        num_confirmations: 100,
+        receipt_query_interval: Duration::from_millis(50),
+        ..TxManagerConfig::default()
+    };
     let (manager, _anvil) = setup_with_config(config.clone()).await;
     let (tx_hash, send_state) = publish_simple_tx(&manager).await;
     let closed = AtomicBool::new(true);
@@ -251,7 +255,7 @@ async fn wait_for_tx_delivers_receipt() {
     let closed = Arc::new(AtomicBool::new(false));
     let (receipt_tx, mut receipt_rx) = mpsc::channel(1);
 
-    SimpleTxManager::wait_for_tx(
+    let _handle = SimpleTxManager::wait_for_tx(
         Arc::new(send_state),
         manager.provider().clone(),
         tx_hash,
@@ -277,23 +281,75 @@ async fn wait_for_tx_closes_channel_on_shutdown() {
     };
     let (manager, _anvil) = setup_with_config(config.clone()).await;
     let (tx_hash, send_state) = publish_simple_tx(&manager).await;
-    let closed = Arc::new(AtomicBool::new(false));
+    let closed = Arc::new(AtomicBool::new(true));
     let (receipt_tx, mut receipt_rx) = mpsc::channel(1);
 
-    SimpleTxManager::wait_for_tx(
+    let _handle = SimpleTxManager::wait_for_tx(
         Arc::new(send_state),
         manager.provider().clone(),
         tx_hash,
         config,
         receipt_tx,
-        Arc::clone(&closed),
+        closed,
     );
-
-    tokio::time::sleep(Duration::from_millis(100)).await;
-    closed.store(true, Ordering::Release);
 
     let result = tokio::time::timeout(Duration::from_secs(5), receipt_rx.recv())
         .await
         .expect("should not time out");
     assert!(result.is_none(), "channel should close without delivering a receipt");
+}
+
+/// `wait_for_tx` exits cleanly without panicking when the receiver is
+/// dropped before the task delivers a receipt.
+#[tokio::test]
+async fn wait_for_tx_does_not_panic_on_dropped_receiver() {
+    let config = fast_polling_config();
+    let (manager, _anvil) = setup_with_config(config.clone()).await;
+    let (tx_hash, send_state) = publish_simple_tx(&manager).await;
+    let closed = Arc::new(AtomicBool::new(false));
+    let (receipt_tx, receipt_rx) = mpsc::channel(1);
+
+    let handle = SimpleTxManager::wait_for_tx(
+        Arc::new(send_state),
+        manager.provider().clone(),
+        tx_hash,
+        config,
+        receipt_tx,
+        closed,
+    );
+
+    // Drop receiver immediately — task should exit cleanly.
+    drop(receipt_rx);
+
+    // Await the handle to confirm the task exits without panic.
+    tokio::time::timeout(Duration::from_secs(5), handle)
+        .await
+        .expect("task should not time out")
+        .expect("task should not panic");
+}
+
+// ── query_receipt() error paths ───────────────────────────────────────
+
+/// `query_receipt` returns `Err` when the provider is unreachable.
+#[tokio::test]
+async fn query_receipt_returns_error_on_unreachable_provider() {
+    // Spawn Anvil to get a valid endpoint, then drop it to close the port.
+    let anvil = Anvil::new().spawn();
+    let url = anvil.endpoint_url();
+    let provider = RootProvider::new_http(url);
+    drop(anvil);
+
+    let send_state = SendState::new(3).expect("should create send state");
+    let fake_hash = B256::with_last_byte(0xFF);
+
+    let result = SimpleTxManager::query_receipt(
+        &send_state,
+        &provider,
+        fake_hash,
+        1,
+        Duration::from_secs(2),
+    )
+    .await;
+
+    assert!(result.is_err(), "query_receipt should fail when provider is unreachable");
 }

--- a/crates/utilities/tx-manager/tests/send_lifecycle.rs
+++ b/crates/utilities/tx-manager/tests/send_lifecycle.rs
@@ -8,7 +8,7 @@ use std::{
 use alloy_network::EthereumWallet;
 use alloy_node_bindings::Anvil;
 use alloy_primitives::{Address, B256, U256};
-use alloy_provider::RootProvider;
+use alloy_provider::{Provider, RootProvider};
 use alloy_signer_local::PrivateKeySigner;
 use base_tx_manager::{SendState, SimpleTxManager, TxCandidate, TxManagerConfig};
 use tokio::sync::mpsc;
@@ -111,8 +111,17 @@ async fn query_receipt_returns_confirmed_receipt() {
     let tx_hash =
         manager.publish_tx(&send_state, &prepared.raw_tx, None).await.expect("should publish tx");
 
-    // With num_confirmations = 1 and Anvil auto-mining at the same block,
-    // the formula tx_block + 1 <= tip + 1 is satisfied immediately.
+    // Mine an extra block so tip_height is strictly ahead of the tx block.
+    // query_receipt fetches tip_height before the receipt (for reorg safety),
+    // so under CI load the tip may be stale on a single-call test.
+    manager
+        .provider()
+        .raw_request::<(), String>("evm_mine".into(), ())
+        .await
+        .expect("evm_mine should succeed");
+
+    // With num_confirmations = 1 and the extra block mined above,
+    // the formula tx_block + 1 <= tip + 1 is satisfied.
     let result = SimpleTxManager::query_receipt(
         &send_state,
         manager.provider(),

--- a/crates/utilities/tx-manager/tests/send_lifecycle.rs
+++ b/crates/utilities/tx-manager/tests/send_lifecycle.rs
@@ -1,5 +1,7 @@
 //! Integration tests for [`SimpleTxManager::publish_tx`] with Anvil.
 
+use std::time::Duration;
+
 use alloy_network::EthereumWallet;
 use alloy_node_bindings::Anvil;
 use alloy_primitives::{Address, B256, U256};
@@ -47,4 +49,109 @@ async fn publish_tx_success_returns_hash_and_records_publish() {
 
     assert_ne!(tx_hash, B256::ZERO, "published tx hash should be non-zero");
     assert_eq!(send_state.successful_publish_count(), 1, "should record one successful publish");
+}
+
+// ── query_receipt() ───────────────────────────────────────────────────
+
+/// `query_receipt` returns `None` for a transaction hash that does not
+/// exist on chain, and records `tx_not_mined` on the `SendState`.
+#[tokio::test]
+async fn query_receipt_returns_none_for_unknown_tx() {
+    let (manager, _anvil) = setup_with_config(TxManagerConfig::default()).await;
+
+    let send_state = SendState::new(3).expect("should create send state");
+    let fake_hash = B256::with_last_byte(0xFF);
+
+    let result = SimpleTxManager::query_receipt(
+        &send_state,
+        manager.provider(),
+        fake_hash,
+        1,
+        Duration::from_secs(10),
+    )
+    .await
+    .expect("query should not error");
+
+    assert!(result.is_none(), "should return None for unknown tx hash");
+    // The unknown hash was never mined, so is_waiting_for_confirmation
+    // should remain false (tx_not_mined only resets the counter for
+    // hashes that were previously tracked).
+    assert!(!send_state.is_waiting_for_confirmation(), "no tx should be tracked as mined",);
+}
+
+/// `query_receipt` returns `Some(receipt)` when the transaction is mined
+/// and has reached the required confirmation depth.
+#[tokio::test]
+async fn query_receipt_returns_confirmed_receipt() {
+    let (manager, _anvil) = setup_with_config(TxManagerConfig::default()).await;
+
+    let candidate = TxCandidate {
+        to: Some(Address::with_last_byte(0x42)),
+        value: U256::from(1_000u64),
+        gas_limit: 0,
+        ..Default::default()
+    };
+
+    // Craft, publish, and let Anvil auto-mine.
+    let prepared = manager.craft_tx(&candidate, None).await.expect("should craft tx");
+    let send_state = SendState::new(3).expect("should create send state");
+    let tx_hash =
+        manager.publish_tx(&send_state, &prepared.raw_tx, None).await.expect("should publish tx");
+
+    // With num_confirmations = 1 and Anvil auto-mining at the same block,
+    // the formula tx_block + 1 <= tip + 1 is satisfied immediately.
+    let result = SimpleTxManager::query_receipt(
+        &send_state,
+        manager.provider(),
+        tx_hash,
+        1,
+        Duration::from_secs(10),
+    )
+    .await
+    .expect("query should not error");
+
+    let receipt = result.expect("should return a receipt for a mined tx");
+    assert_eq!(receipt.transaction_hash, tx_hash, "receipt hash should match");
+    assert!(receipt.block_number.is_some(), "receipt should have a block number");
+    // tx_mined should have been called.
+    assert!(send_state.is_waiting_for_confirmation(), "tx should be tracked as mined",);
+}
+
+/// `query_receipt` returns `None` when the receipt exists but the
+/// transaction has not reached the required confirmation depth. The
+/// `SendState` should still record the transaction as mined.
+#[tokio::test]
+async fn query_receipt_returns_none_when_not_enough_confirmations() {
+    let (manager, _anvil) = setup_with_config(TxManagerConfig::default()).await;
+
+    let candidate = TxCandidate {
+        to: Some(Address::with_last_byte(0x42)),
+        value: U256::from(1_000u64),
+        gas_limit: 0,
+        ..Default::default()
+    };
+
+    let prepared = manager.craft_tx(&candidate, None).await.expect("should craft tx");
+    let send_state = SendState::new(3).expect("should create send state");
+    let tx_hash =
+        manager.publish_tx(&send_state, &prepared.raw_tx, None).await.expect("should publish tx");
+
+    // Require 100 confirmations — far more than the single block Anvil
+    // has mined. The receipt exists but is not sufficiently confirmed.
+    let result = SimpleTxManager::query_receipt(
+        &send_state,
+        manager.provider(),
+        tx_hash,
+        100,
+        Duration::from_secs(10),
+    )
+    .await
+    .expect("query should not error");
+
+    assert!(result.is_none(), "should return None when not enough confirmations");
+    // The tx should still be tracked as mined even though not yet confirmed.
+    assert!(
+        send_state.is_waiting_for_confirmation(),
+        "tx should be tracked as mined despite insufficient confirmations",
+    );
 }

--- a/crates/utilities/tx-manager/tests/send_lifecycle.rs
+++ b/crates/utilities/tx-manager/tests/send_lifecycle.rs
@@ -1,10 +1,7 @@
 //! Integration tests for [`SimpleTxManager`] send lifecycle with Anvil.
 
 use std::{
-    sync::{
-        Arc,
-        atomic::AtomicBool,
-    },
+    sync::{Arc, atomic::AtomicBool},
     time::Duration,
 };
 

--- a/crates/utilities/tx-manager/tests/send_lifecycle.rs
+++ b/crates/utilities/tx-manager/tests/send_lifecycle.rs
@@ -1,6 +1,12 @@
-//! Integration tests for [`SimpleTxManager::publish_tx`] with Anvil.
+//! Integration tests for [`SimpleTxManager`] send lifecycle with Anvil.
 
-use std::time::Duration;
+use std::{
+    sync::{
+        Arc,
+        atomic::{AtomicBool, Ordering},
+    },
+    time::Duration,
+};
 
 use alloy_network::EthereumWallet;
 use alloy_node_bindings::Anvil;
@@ -8,6 +14,16 @@ use alloy_primitives::{Address, B256, U256};
 use alloy_provider::RootProvider;
 use alloy_signer_local::PrivateKeySigner;
 use base_tx_manager::{SendState, SimpleTxManager, TxCandidate, TxManagerConfig};
+use tokio::sync::mpsc;
+
+/// Returns a config with fast polling suitable for tests.
+fn fast_polling_config() -> TxManagerConfig {
+    TxManagerConfig {
+        num_confirmations: 1,
+        receipt_query_interval: Duration::from_millis(50),
+        ..TxManagerConfig::default()
+    }
+}
 
 /// Helper: spawns an Anvil instance and returns a [`SimpleTxManager`]
 /// configured with the given [`TxManagerConfig`].
@@ -154,4 +170,130 @@ async fn query_receipt_returns_none_when_not_enough_confirmations() {
         send_state.is_waiting_for_confirmation(),
         "tx should be tracked as mined despite insufficient confirmations",
     );
+}
+
+// ── wait_mined() ──────────────────────────────────────────────────────
+
+/// Helper: publishes a simple value-transfer tx and returns the hash.
+async fn publish_simple_tx(manager: &SimpleTxManager) -> (B256, SendState) {
+    let candidate = TxCandidate {
+        to: Some(Address::with_last_byte(0x42)),
+        value: U256::from(1_000u64),
+        gas_limit: 0,
+        ..Default::default()
+    };
+    let prepared = manager.craft_tx(&candidate, None).await.expect("should craft tx");
+    let send_state = SendState::new(3).expect("should create send state");
+    let tx_hash =
+        manager.publish_tx(&send_state, &prepared.raw_tx, None).await.expect("should publish tx");
+    (tx_hash, send_state)
+}
+
+/// `wait_mined` returns a confirmed receipt for a mined transaction.
+#[tokio::test]
+async fn wait_mined_returns_confirmed_receipt() {
+    let config = fast_polling_config();
+    let (manager, _anvil) = setup_with_config(config.clone()).await;
+    let (tx_hash, send_state) = publish_simple_tx(&manager).await;
+    let closed = AtomicBool::new(false);
+
+    let receipt =
+        SimpleTxManager::wait_mined(&send_state, manager.provider(), tx_hash, &config, &closed)
+            .await;
+
+    let receipt = receipt.expect("should return a receipt");
+    assert_eq!(receipt.transaction_hash, tx_hash, "receipt hash should match");
+}
+
+/// `wait_mined` returns `None` when the manager is shut down.
+#[tokio::test]
+async fn wait_mined_returns_none_on_shutdown() {
+    let config = fast_polling_config();
+    let (manager, _anvil) = setup_with_config(config.clone()).await;
+    let (tx_hash, send_state) = publish_simple_tx(&manager).await;
+    let closed = AtomicBool::new(true);
+
+    let receipt =
+        SimpleTxManager::wait_mined(&send_state, manager.provider(), tx_hash, &config, &closed)
+            .await;
+
+    assert!(receipt.is_none(), "should return None when closed");
+}
+
+/// `wait_mined` returns `None` when the confirmation timeout expires.
+#[tokio::test]
+async fn wait_mined_returns_none_on_timeout() {
+    let config = TxManagerConfig {
+        num_confirmations: 100,
+        receipt_query_interval: Duration::from_millis(50),
+        confirmation_timeout: Duration::from_millis(200),
+        ..TxManagerConfig::default()
+    };
+    let (manager, _anvil) = setup_with_config(config.clone()).await;
+    let (tx_hash, send_state) = publish_simple_tx(&manager).await;
+    let closed = AtomicBool::new(false);
+
+    let receipt =
+        SimpleTxManager::wait_mined(&send_state, manager.provider(), tx_hash, &config, &closed)
+            .await;
+
+    assert!(receipt.is_none(), "should return None when timeout exceeded");
+}
+
+// ── wait_for_tx() ─────────────────────────────────────────────────────
+
+/// `wait_for_tx` delivers a receipt through the mpsc channel.
+#[tokio::test]
+async fn wait_for_tx_delivers_receipt() {
+    let config = fast_polling_config();
+    let (manager, _anvil) = setup_with_config(config.clone()).await;
+    let (tx_hash, send_state) = publish_simple_tx(&manager).await;
+    let closed = Arc::new(AtomicBool::new(false));
+    let (receipt_tx, mut receipt_rx) = mpsc::channel(1);
+
+    SimpleTxManager::wait_for_tx(
+        Arc::new(send_state),
+        manager.provider().clone(),
+        tx_hash,
+        config,
+        receipt_tx,
+        closed,
+    );
+
+    let receipt = tokio::time::timeout(Duration::from_secs(5), receipt_rx.recv())
+        .await
+        .expect("should not time out")
+        .expect("channel should deliver a receipt");
+    assert_eq!(receipt.transaction_hash, tx_hash, "receipt hash should match");
+}
+
+/// `wait_for_tx` closes the channel when the manager shuts down.
+#[tokio::test]
+async fn wait_for_tx_closes_channel_on_shutdown() {
+    let config = TxManagerConfig {
+        num_confirmations: 100,
+        receipt_query_interval: Duration::from_millis(50),
+        ..TxManagerConfig::default()
+    };
+    let (manager, _anvil) = setup_with_config(config.clone()).await;
+    let (tx_hash, send_state) = publish_simple_tx(&manager).await;
+    let closed = Arc::new(AtomicBool::new(false));
+    let (receipt_tx, mut receipt_rx) = mpsc::channel(1);
+
+    SimpleTxManager::wait_for_tx(
+        Arc::new(send_state),
+        manager.provider().clone(),
+        tx_hash,
+        config,
+        receipt_tx,
+        Arc::clone(&closed),
+    );
+
+    tokio::time::sleep(Duration::from_millis(100)).await;
+    closed.store(true, Ordering::Release);
+
+    let result = tokio::time::timeout(Duration::from_secs(5), receipt_rx.recv())
+        .await
+        .expect("should not time out");
+    assert!(result.is_none(), "channel should close without delivering a receipt");
 }


### PR DESCRIPTION
### What changed? Why?

Adds transaction confirmation polling to `SimpleTxManager` with three new methods:

- **`wait_for_tx`** — Spawns a background task that polls for a transaction receipt and sends it through an `mpsc` channel once confirmed. Multiple pollers can run concurrently (one per fee bump) since any previously-published variant may still confirm; they self-terminate via the `closed` flag or when the channel is consumed.
- **`wait_mined`** — Polls at `receipt_query_interval` in a loop, checking both confirmation status and manager shutdown via the shared `closed` flag. Returns `Some(receipt)` when confirmed or `None` on shutdown or when the `confirmation_timeout` deadline is exceeded.
- **`query_receipt`** — Single-shot receipt check that integrates with `SendState` for reorg detection (`tx_not_mined`/`tx_mined`) and verifies confirmation depth using `tx_block + num_confirmations <= tip_height + 1`.

Also adds a new `confirmation_timeout` config field (default 5m) to `TxManagerConfig`, the CLI macro, and validation — so operators can cap how long the manager waits for a transaction to reach the required depth.

### Notes to reviewers

Working on a larger transaction lifecycle PR but the diff was getting too big so splitting into smaller PRs including this one. `wait_for_tx` and `wait_mined` are not yet called — they will be wired into the send loop in the next PR.

### How has it been tested?

Integration tests in `crates/utilities/tx-manager/tests/send_lifecycle.rs` against a local Anvil node covering all three methods:

**`query_receipt`**
- Unknown tx hash returns `None`
- Mined + confirmed tx returns `Some(receipt)`
- Mined but insufficiently confirmed tx returns `None` while still tracking as mined in `SendState`
- Unreachable provider returns `Err`

**`wait_mined`**
- Returns confirmed receipt for a mined transaction
- Returns `None` when the manager is shut down (`closed` flag)
- Returns `None` when `confirmation_timeout` expires

**`wait_for_tx`**
- Delivers a receipt through the mpsc channel
- Closes the channel on shutdown
- Exits cleanly without panicking when the receiver is dropped early

Plus a unit test for `validation_rejects_zero_confirmation_timeout` and an update to the `custom_prefix` test for the new CLI flag.

### Change management

type=routine
risk=low
impact=sev5

### Backwards Compatibility

backwards_compatible=true