### PR TITLE
fix(proof/tee): remove EnclaveConfig and hardcode enclave parameters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ eif.bin
 docs/specs/node_modules/
 docs/specs/dist/
 docs/specs/.vocs/
+*.log

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4288,6 +4288,8 @@ dependencies = [
  "aws-nitro-enclaves-cose",
  "aws-nitro-enclaves-nsm-api",
  "base-alloy-evm",
+ "base-consensus-registry",
+ "base-enclave",
  "base-health",
  "base-proof-client",
  "base-proof-host",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3286,6 +3286,7 @@ dependencies = [
  "alloy-trie",
  "base-alloy-consensus",
  "base-consensus-genesis",
+ "base-consensus-registry",
  "base-proof-primitives",
  "base-protocol",
  "hex",
@@ -4465,7 +4466,6 @@ dependencies = [
 name = "base-prover"
 version = "0.0.0"
 dependencies = [
- "alloy-primitives",
  "base-consensus-registry",
  "base-proof-host",
  "base-proof-tee-nitro",

--- a/bin/prover/Cargo.toml
+++ b/bin/prover/Cargo.toml
@@ -21,7 +21,6 @@ local = []
 [dependencies]
 # Workspace – TEE
 base-proof-host.workspace = true
-alloy-primitives.workspace = true
 base-consensus-registry.workspace = true
 base-proof-tee-nitro = { workspace = true, features = ["host"] }
 

--- a/bin/prover/src/cli.rs
+++ b/bin/prover/src/cli.rs
@@ -4,12 +4,10 @@ use std::net::SocketAddr;
 #[cfg(any(target_os = "linux", feature = "local"))]
 use std::sync::Arc;
 
-use alloy_primitives::B256;
 #[cfg(any(target_os = "linux", feature = "local"))]
 use base_consensus_registry::Registry;
 #[cfg(any(target_os = "linux", feature = "local"))]
 use base_proof_host::ProverConfig;
-use base_proof_tee_nitro::EnclaveConfig;
 #[cfg(target_os = "linux")]
 use base_proof_tee_nitro::NitroEnclave;
 #[cfg(feature = "local")]
@@ -61,7 +59,8 @@ enum NitroCommand {
     /// Run the proving process inside the Nitro Enclave.
     ///
     /// Listens on vsock for proving requests from the host server.
-    Enclave(NitroEnclaveArgs),
+    #[cfg(target_os = "linux")]
+    Enclave,
 
     /// Run server and enclave in a single process for local development.
     #[cfg(feature = "local")]
@@ -112,22 +111,6 @@ struct NitroServerArgs {
     vsock_port: u32,
 }
 
-/// Arguments for the `nitro enclave` subcommand.
-#[derive(Parser)]
-struct NitroEnclaveArgs {
-    /// Vsock CID to bind.
-    #[arg(long, env = "VSOCK_CID")]
-    vsock_cid: u32,
-
-    /// Vsock port to listen on.
-    #[arg(long, env = "VSOCK_PORT")]
-    vsock_port: u32,
-
-    /// Per-chain configuration hash.
-    #[arg(long, env = "CONFIG_HASH")]
-    config_hash: B256,
-}
-
 impl Cli {
     /// Run the selected subcommand.
     pub(crate) async fn run(self) -> eyre::Result<()> {
@@ -144,7 +127,8 @@ impl NitroArgs {
         match self.command {
             #[cfg(target_os = "linux")]
             NitroCommand::Server(args) => args.run().await,
-            NitroCommand::Enclave(args) => args.run().await,
+            #[cfg(target_os = "linux")]
+            NitroCommand::Enclave => NitroEnclave::new()?.run().await,
             #[cfg(feature = "local")]
             NitroCommand::Local(args) => args.run().await,
         }
@@ -182,38 +166,12 @@ impl NitroServerArgs {
     }
 }
 
-impl NitroEnclaveArgs {
-    async fn run(self) -> eyre::Result<()> {
-        let config = EnclaveConfig {
-            vsock_cid: self.vsock_cid,
-            vsock_port: self.vsock_port,
-            config_hash: self.config_hash,
-        };
-
-        #[cfg(not(target_os = "linux"))]
-        {
-            let _ = config;
-            Err(eyre!("enclave subcommand is only supported on Linux"))
-        }
-
-        #[cfg(target_os = "linux")]
-        {
-            let enclave = NitroEnclave::new(&config)?;
-            enclave.run().await
-        }
-    }
-}
-
 /// Arguments for the `nitro local` subcommand.
 #[cfg(feature = "local")]
 #[derive(Parser)]
 struct NitroLocalArgs {
     #[command(flatten)]
     server: ProverServerArgs,
-
-    /// Per-chain configuration hash.
-    #[arg(long, env = "CONFIG_HASH")]
-    config_hash: B256,
 }
 
 #[cfg(feature = "local")]
@@ -227,9 +185,6 @@ impl NitroLocalArgs {
             .ok_or_else(|| eyre!("unknown L1 chain ID: {}", rollup_config.l1_chain_id))?
             .clone();
 
-        let enclave_config =
-            EnclaveConfig { vsock_cid: 0, vsock_port: 0, config_hash: self.config_hash };
-
         let prover_config = ProverConfig {
             l1_eth_url: self.server.l1_eth_url,
             l2_eth_url: self.server.l2_eth_url,
@@ -240,7 +195,7 @@ impl NitroLocalArgs {
             enable_experimental_witness_endpoint: self.server.enable_experimental_witness_endpoint,
         };
 
-        let enclave_server = Arc::new(Server::new(&enclave_config)?);
+        let enclave_server = Arc::new(Server::new()?);
         let transport = Arc::new(NitroTransport::local(enclave_server));
         let server = NitroProverServer::new(prover_config, transport);
 

--- a/bin/prover/src/cli.rs
+++ b/bin/prover/src/cli.rs
@@ -8,10 +8,10 @@ use std::sync::Arc;
 use base_consensus_registry::Registry;
 #[cfg(any(target_os = "linux", feature = "local"))]
 use base_proof_host::ProverConfig;
-#[cfg(target_os = "linux")]
-use base_proof_tee_nitro::NitroEnclave;
 #[cfg(feature = "local")]
 use base_proof_tee_nitro::Server;
+#[cfg(target_os = "linux")]
+use base_proof_tee_nitro::{NitroEnclave, VSOCK_PORT};
 #[cfg(any(target_os = "linux", feature = "local"))]
 use base_proof_tee_nitro::{NitroProverServer, NitroTransport};
 use clap::{Parser, Subcommand};
@@ -105,10 +105,6 @@ struct NitroServerArgs {
     /// Vsock CID of the enclave.
     #[arg(long, env = "VSOCK_CID")]
     vsock_cid: u32,
-
-    /// Vsock port to connect to the enclave.
-    #[arg(long, env = "VSOCK_PORT")]
-    vsock_port: u32,
 }
 
 impl Cli {
@@ -156,7 +152,7 @@ impl NitroServerArgs {
             enable_experimental_witness_endpoint: self.server.enable_experimental_witness_endpoint,
         };
 
-        let transport = Arc::new(NitroTransport::vsock(self.vsock_cid, self.vsock_port));
+        let transport = Arc::new(NitroTransport::vsock(self.vsock_cid, VSOCK_PORT));
         let server = NitroProverServer::new(config, transport);
 
         info!(addr = %self.server.listen_addr, "starting nitro prover server");

--- a/crates/proof/tee/Justfile
+++ b/crates/proof/tee/Justfile
@@ -26,9 +26,12 @@ nitro-local *args:
         --l1-beacon-url "${L1_BEACON_URL:-http://localhost:5052}" \
         --l2-chain-id "${L2_CHAIN_ID:-8453}" \
         --listen-addr "${LISTEN_ADDR:-0.0.0.0:7300}" \
-        --config-hash "${CONFIG_HASH:-0x0000000000000000000000000000000000000000000000000000000000000000}" \
         --enable-experimental-witness-endpoint \
         {{ args }}
+
+# Print config hashes for all supported chains
+config-hashes:
+    cargo test -p base-enclave print_real_config_hashes -- --nocapture --ignored
 
 # Build EIF using Docker
 build-eif:

--- a/crates/proof/tee/core/Cargo.toml
+++ b/crates/proof/tee/core/Cargo.toml
@@ -34,3 +34,4 @@ serde = { workspace = true, features = ["derive"] }
 hex.workspace = true
 rstest.workspace = true
 serde_json.workspace = true
+base-consensus-registry.workspace = true

--- a/crates/proof/tee/core/src/types/config.rs
+++ b/crates/proof/tee/core/src/types/config.rs
@@ -259,6 +259,7 @@ impl PerChainConfig {
 #[cfg(test)]
 mod tests {
     use alloy_primitives::{address, b256};
+    use base_consensus_registry::Registry;
 
     use super::*;
 
@@ -456,5 +457,41 @@ mod tests {
         assert_eq!(rollup_config.hardforks.holocene_time, Some(0));
         assert_eq!(rollup_config.hardforks.isthmus_time, Some(0));
         assert_eq!(rollup_config.hardforks.regolith_time, Some(0));
+    }
+
+    /// Print config hashes for supported chains so they can be hardcoded in the
+    /// enclave server. Run with:
+    /// `cargo test -p base-enclave print_real_config_hashes -- --nocapture --ignored`
+    #[test]
+    #[ignore]
+    fn print_real_config_hashes() {
+        let chains: &[(u64, &str)] =
+            &[(8453, "Base Mainnet"), (84532, "Base Sepolia"), (11763072, "Sepolia Alpha")];
+
+        for &(chain_id, name) in chains {
+            let rollup = Registry::rollup_config(chain_id)
+                .unwrap_or_else(|| panic!("missing rollup config for {name} ({chain_id})"));
+
+            let sc = rollup.genesis.system_config.as_ref().expect("missing system_config");
+            let mut per_chain = PerChainConfig {
+                chain_id: U256::from(rollup.l2_chain_id.id()),
+                genesis: Genesis {
+                    l1: BlockId { hash: rollup.genesis.l1.hash, number: rollup.genesis.l1.number },
+                    l2: BlockId { hash: rollup.genesis.l2.hash, number: rollup.genesis.l2.number },
+                    l2_time: rollup.genesis.l2_time,
+                    system_config: GenesisSystemConfig {
+                        batcher_addr: sc.batcher_address,
+                        overhead: B256::ZERO,
+                        scalar: B256::from(sc.scalar.to_be_bytes::<32>()),
+                        gas_limit: sc.gas_limit,
+                    },
+                },
+                block_time: rollup.block_time,
+                deposit_contract_address: rollup.deposit_contract_address,
+                l1_system_config_address: rollup.l1_system_config_address,
+            };
+            per_chain.force_defaults();
+            println!("{name} ({chain_id}): {:?}", per_chain.hash());
+        }
     }
 }

--- a/crates/proof/tee/core/src/types/config.rs
+++ b/crates/proof/tee/core/src/types/config.rs
@@ -116,6 +116,31 @@ impl Default for PerChainConfig {
 }
 
 impl PerChainConfig {
+    /// Create a `PerChainConfig` from a [`RollupConfig`].
+    ///
+    /// Returns `None` if the rollup config is missing `genesis.system_config`.
+    #[must_use]
+    pub fn from_rollup_config(cfg: &RollupConfig) -> Option<Self> {
+        let sc = cfg.genesis.system_config.as_ref()?;
+        Some(Self {
+            chain_id: U256::from(cfg.l2_chain_id.id()),
+            genesis: Genesis {
+                l1: BlockId { hash: cfg.genesis.l1.hash, number: cfg.genesis.l1.number },
+                l2: BlockId { hash: cfg.genesis.l2.hash, number: cfg.genesis.l2.number },
+                l2_time: cfg.genesis.l2_time,
+                system_config: GenesisSystemConfig {
+                    batcher_addr: sc.batcher_address,
+                    overhead: B256::ZERO,
+                    scalar: B256::from(sc.scalar.to_be_bytes::<32>()),
+                    gas_limit: sc.gas_limit,
+                },
+            },
+            block_time: cfg.block_time,
+            deposit_contract_address: cfg.deposit_contract_address,
+            l1_system_config_address: cfg.l1_system_config_address,
+        })
+    }
+
     /// Serialize the config to binary format matching Go's `MarshalBinary()`.
     ///
     /// Binary layout (all big-endian, 212 bytes total):
@@ -471,25 +496,8 @@ mod tests {
         for &(chain_id, name) in chains {
             let rollup = Registry::rollup_config(chain_id)
                 .unwrap_or_else(|| panic!("missing rollup config for {name} ({chain_id})"));
-
-            let sc = rollup.genesis.system_config.as_ref().expect("missing system_config");
-            let mut per_chain = PerChainConfig {
-                chain_id: U256::from(rollup.l2_chain_id.id()),
-                genesis: Genesis {
-                    l1: BlockId { hash: rollup.genesis.l1.hash, number: rollup.genesis.l1.number },
-                    l2: BlockId { hash: rollup.genesis.l2.hash, number: rollup.genesis.l2.number },
-                    l2_time: rollup.genesis.l2_time,
-                    system_config: GenesisSystemConfig {
-                        batcher_addr: sc.batcher_address,
-                        overhead: B256::ZERO,
-                        scalar: B256::from(sc.scalar.to_be_bytes::<32>()),
-                        gas_limit: sc.gas_limit,
-                    },
-                },
-                block_time: rollup.block_time,
-                deposit_contract_address: rollup.deposit_contract_address,
-                l1_system_config_address: rollup.l1_system_config_address,
-            };
+            let mut per_chain = PerChainConfig::from_rollup_config(rollup)
+                .unwrap_or_else(|| panic!("missing system_config for {name} ({chain_id})"));
             per_chain.force_defaults();
             println!("{name} ({chain_id}): {:?}", per_chain.hash());
         }

--- a/crates/proof/tee/nitro/Cargo.toml
+++ b/crates/proof/tee/nitro/Cargo.toml
@@ -64,6 +64,8 @@ tokio = { workspace = true, features = ["rt-multi-thread"] }
 
 [dev-dependencies]
 rand_08.workspace = true
+base-enclave.workspace = true
+base-consensus-registry.workspace = true
 tokio = { workspace = true, features = ["macros", "rt"] }
 
 [features]

--- a/crates/proof/tee/nitro/src/enclave/mod.rs
+++ b/crates/proof/tee/nitro/src/enclave/mod.rs
@@ -29,10 +29,6 @@ pub use protocol::{EnclaveRequest, EnclaveResponse};
 mod server;
 pub use server::Server;
 
-/// Accept connections from any CID (only the host can reach the enclave over vsock).
-#[cfg(target_os = "linux")]
-const VSOCK_CID: u32 = VMADDR_CID_ANY;
-
 /// Fixed vsock port the enclave listens on.
 pub const VSOCK_PORT: u32 = 8000;
 
@@ -54,8 +50,8 @@ impl NitroEnclave {
 
     /// Listen on vsock, prove blocks, return results.
     pub async fn run(self) -> eyre::Result<()> {
-        let listener = VsockListener::bind(VsockAddr::new(VSOCK_CID, VSOCK_PORT))?;
-        info!(cid = VSOCK_CID, port = VSOCK_PORT, "listening on vsock");
+        let listener = VsockListener::bind(VsockAddr::new(VMADDR_CID_ANY, VSOCK_PORT))?;
+        info!(cid = VMADDR_CID_ANY, port = VSOCK_PORT, "listening on vsock");
 
         loop {
             let (stream, peer) = listener.accept().await?;

--- a/crates/proof/tee/nitro/src/enclave/mod.rs
+++ b/crates/proof/tee/nitro/src/enclave/mod.rs
@@ -34,8 +34,7 @@ pub use server::Server;
 const VSOCK_CID: u32 = VMADDR_CID_ANY;
 
 /// Fixed vsock port the enclave listens on.
-#[cfg(target_os = "linux")]
-const VSOCK_PORT: u32 = 8000;
+pub const VSOCK_PORT: u32 = 8000;
 
 /// Nitro Enclave runtime.
 #[cfg(target_os = "linux")]

--- a/crates/proof/tee/nitro/src/enclave/mod.rs
+++ b/crates/proof/tee/nitro/src/enclave/mod.rs
@@ -1,11 +1,10 @@
 #[cfg(target_os = "linux")]
 use std::sync::Arc;
 
-use alloy_primitives::B256;
 #[cfg(target_os = "linux")]
 use tokio::time::{Duration, timeout};
 #[cfg(target_os = "linux")]
-use tokio_vsock::{VsockAddr, VsockListener};
+use tokio_vsock::{VMADDR_CID_ANY, VsockAddr, VsockListener};
 #[cfg(target_os = "linux")]
 use tracing::{debug, info, warn};
 
@@ -30,39 +29,34 @@ pub use protocol::{EnclaveRequest, EnclaveResponse};
 mod server;
 pub use server::Server;
 
-/// Enclave runtime configuration.
-#[derive(Debug)]
-pub struct EnclaveConfig {
-    /// Vsock CID to bind.
-    pub vsock_cid: u32,
-    /// Vsock port to listen on.
-    pub vsock_port: u32,
-    /// Per-chain configuration hash.
-    pub config_hash: B256,
-}
+/// Accept connections from any CID (only the host can reach the enclave over vsock).
+#[cfg(target_os = "linux")]
+const VSOCK_CID: u32 = VMADDR_CID_ANY;
+
+/// Fixed vsock port the enclave listens on.
+#[cfg(target_os = "linux")]
+const VSOCK_PORT: u32 = 8000;
 
 /// Nitro Enclave runtime.
 #[cfg(target_os = "linux")]
 #[derive(Debug)]
 pub struct NitroEnclave {
     server: Arc<Server>,
-    vsock_cid: u32,
-    vsock_port: u32,
 }
 
 #[cfg(target_os = "linux")]
 impl NitroEnclave {
-    /// Create a new enclave runtime from the given configuration.
-    pub fn new(config: &EnclaveConfig) -> eyre::Result<Self> {
-        let server = Arc::new(Server::new(config)?);
+    /// Create a new enclave runtime.
+    pub fn new() -> eyre::Result<Self> {
+        let server = Arc::new(Server::new()?);
         info!(address = %server.signer_address(), "enclave initialized");
-        Ok(Self { server, vsock_cid: config.vsock_cid, vsock_port: config.vsock_port })
+        Ok(Self { server })
     }
 
     /// Listen on vsock, prove blocks, return results.
     pub async fn run(self) -> eyre::Result<()> {
-        let listener = VsockListener::bind(VsockAddr::new(self.vsock_cid, self.vsock_port))?;
-        info!(cid = self.vsock_cid, port = self.vsock_port, "listening on vsock");
+        let listener = VsockListener::bind(VsockAddr::new(VSOCK_CID, VSOCK_PORT))?;
+        info!(cid = VSOCK_CID, port = VSOCK_PORT, "listening on vsock");
 
         loop {
             let (stream, peer) = listener.accept().await?;

--- a/crates/proof/tee/nitro/src/enclave/server.rs
+++ b/crates/proof/tee/nitro/src/enclave/server.rs
@@ -1,5 +1,5 @@
 /// Enclave server — manages keys, attestation, signing, and proof execution.
-use alloy_primitives::{Address, B256, Bytes, U256, keccak256};
+use alloy_primitives::{Address, B256, Bytes, U256, b256, keccak256};
 use alloy_signer_local::PrivateKeySigner;
 use base_alloy_evm::OpEvmFactory;
 use base_proof_client::{BootInfo, Prologue};
@@ -10,7 +10,6 @@ use tracing::{info, warn};
 use crate::{
     Oracle,
     enclave::{
-        EnclaveConfig,
         crypto::{Ecdsa, Signing},
         nsm::{NsmRng, NsmSession},
     },
@@ -23,6 +22,34 @@ const SIGNER_KEY_ENV_VAR: &str = "OP_ENCLAVE_SIGNER_KEY";
 /// PCR0 is a SHA-384 hash (48 bytes) per the AWS Nitro Enclaves specification.
 const PCR0_LENGTH: usize = 48;
 
+/// `keccak256(PerChainConfig::marshal_binary())` for Base Mainnet (chain 8453).
+///
+/// Produced by `print_real_config_hashes` in `base-enclave/src/types/config.rs`.
+const CONFIG_HASH_BASE_MAINNET: B256 =
+    b256!("1607709d90d40904f790574404e2ad614eac858f6162faa0ec34c6bf5e5f3c57");
+
+/// `keccak256(PerChainConfig::marshal_binary())` for Base Sepolia (chain 84532).
+///
+/// Produced by `print_real_config_hashes` in `base-enclave/src/types/config.rs`.
+const CONFIG_HASH_BASE_SEPOLIA: B256 =
+    b256!("12e9c45f19f9817c6d4385fad29e7a70c355502cf0883e76a9a7e478a85d1360");
+
+/// `keccak256(PerChainConfig::marshal_binary())` for Sepolia Alpha (chain 11763072).
+///
+/// Produced by `print_real_config_hashes` in `base-enclave/src/types/config.rs`.
+const CONFIG_HASH_SEPOLIA_ALPHA: B256 =
+    b256!("4600cdaa81262bf5f124bd9276f605264e2ded951e34923bc838e81c442f0fa4");
+
+/// Look up the hardcoded config hash for a supported chain.
+fn config_hash_for_chain(chain_id: u64) -> Result<B256> {
+    match chain_id {
+        8453 => Ok(CONFIG_HASH_BASE_MAINNET),
+        84532 => Ok(CONFIG_HASH_BASE_SEPOLIA),
+        11763072 => Ok(CONFIG_HASH_SEPOLIA_ALPHA),
+        _ => Err(NitroError::UnsupportedChain(chain_id)),
+    }
+}
+
 /// The enclave server.
 ///
 /// Manages cryptographic keys and attestation for the enclave.
@@ -33,8 +60,6 @@ pub struct Server {
     pcr0: Vec<u8>,
     /// ECDSA signing key.
     signer_key: PrivateKeySigner,
-    /// Per-chain config hash.
-    config_hash: B256,
     /// TEE image hash (keccak256 of PCR0 in enclave mode, zero in local mode).
     tee_image_hash: B256,
 }
@@ -46,17 +71,17 @@ impl Server {
     /// `tee_image_hash`, and uses the hardware RNG for key generation.
     ///
     /// In local mode (no NSM): uses the OS RNG and sets `tee_image_hash` to zero.
-    pub fn new(config: &EnclaveConfig) -> Result<Self> {
+    pub fn new() -> Result<Self> {
         NsmSession::open()?.map_or_else(
             || {
                 warn!("running in local mode without NSM");
-                Self::new_local(config)
+                Self::new_local()
             },
-            |session| Self::new_enclave(config, &session),
+            |session| Self::new_enclave(&session),
         )
     }
 
-    fn new_enclave(config: &EnclaveConfig, session: &NsmSession) -> Result<Self> {
+    fn new_enclave(session: &NsmSession) -> Result<Self> {
         let pcr0 = session.describe_pcr0()?;
         if pcr0.len() != PCR0_LENGTH {
             return Err(NsmError::DescribePcr(format!(
@@ -72,10 +97,10 @@ impl Server {
             .ok_or_else(|| NsmError::SessionOpen("failed to initialize NSM RNG".into()))?;
         let signer_key = Ecdsa::generate(&mut rng)?;
 
-        Ok(Self { pcr0, signer_key, config_hash: config.config_hash, tee_image_hash })
+        Ok(Self { pcr0, signer_key, tee_image_hash })
     }
 
-    fn new_local(config: &EnclaveConfig) -> Result<Self> {
+    fn new_local() -> Result<Self> {
         let signer_key = match std::env::var(SIGNER_KEY_ENV_VAR) {
             Ok(hex_key) => {
                 info!("using signer key from environment variable");
@@ -84,12 +109,7 @@ impl Server {
             Err(_) => Ecdsa::generate(&mut NsmRng::default())?,
         };
 
-        Ok(Self {
-            pcr0: Vec::new(),
-            signer_key,
-            config_hash: config.config_hash,
-            tee_image_hash: B256::ZERO,
-        })
+        Ok(Self { pcr0: Vec::new(), signer_key, tee_image_hash: B256::ZERO })
     }
 
     /// Check if the server is running in local mode.
@@ -128,6 +148,7 @@ impl Server {
 
         let boot_info =
             BootInfo::load(&oracle).await.map_err(|e| NitroError::ProofPipeline(e.to_string()))?;
+        let config_hash = config_hash_for_chain(boot_info.chain_id)?;
         let agreed_l2_output_root = boot_info.agreed_l2_output_root;
 
         let prologue = Prologue::new(oracle.clone(), oracle, OpEvmFactory::default());
@@ -162,7 +183,7 @@ impl Server {
                 output_root: *output_root,
                 ending_l2_block: l2_block_number,
                 intermediate_roots: vec![],
-                config_hash: self.config_hash,
+                config_hash,
                 tee_image_hash: self.tee_image_hash,
             };
             let signing_data = journal.encode();
@@ -176,7 +197,7 @@ impl Server {
                 l1_origin_number,
                 l2_block_number,
                 prev_output_root,
-                config_hash: self.config_hash,
+                config_hash,
             });
 
             prev_output_root = *output_root;
@@ -202,7 +223,7 @@ impl Server {
                 output_root: last.output_root,
                 ending_l2_block: last.l2_block_number,
                 intermediate_roots,
-                config_hash: self.config_hash,
+                config_hash,
                 tee_image_hash: self.tee_image_hash,
             };
             let signing_data = journal.encode();
@@ -216,7 +237,7 @@ impl Server {
                 l1_origin_number: last.l1_origin_number,
                 l2_block_number: last.l2_block_number,
                 prev_output_root: agreed_l2_output_root,
-                config_hash: self.config_hash,
+                config_hash,
             }
         };
 
@@ -225,14 +246,9 @@ impl Server {
 
     /// Create a server for testing (no NSM, no PCR0 verification).
     #[cfg(test)]
-    pub fn new_for_testing(config: &EnclaveConfig) -> Result<Self> {
+    pub fn new_for_testing() -> Result<Self> {
         let signer_key = Ecdsa::generate(&mut rand_08::rngs::OsRng)?;
-        Ok(Self {
-            pcr0: Vec::new(),
-            signer_key,
-            config_hash: config.config_hash,
-            tee_image_hash: B256::ZERO,
-        })
+        Ok(Self { pcr0: Vec::new(), signer_key, tee_image_hash: B256::ZERO })
     }
 }
 
@@ -240,14 +256,9 @@ impl Server {
 mod tests {
     use super::*;
 
-    fn test_config() -> EnclaveConfig {
-        EnclaveConfig { vsock_cid: 0, vsock_port: 1234, config_hash: B256::ZERO }
-    }
-
     #[test]
     fn test_server_new_local_mode() {
-        let config = test_config();
-        let server = Server::new(&config).expect("failed to create server");
+        let server = Server::new().expect("failed to create server");
 
         #[cfg(not(target_os = "linux"))]
         assert!(server.is_local_mode());
@@ -259,8 +270,7 @@ mod tests {
 
     #[test]
     fn test_signer_address_consistency() {
-        let config = test_config();
-        let server = Server::new(&config).expect("failed to create server");
+        let server = Server::new().expect("failed to create server");
 
         let addr1 = server.signer_address();
         let addr2 = server.signer_address();
@@ -269,5 +279,13 @@ mod tests {
         let pk1 = server.signer_public_key();
         let pk2 = server.signer_public_key();
         assert_eq!(pk1, pk2);
+    }
+
+    #[test]
+    fn config_hash_known_chains() {
+        assert!(config_hash_for_chain(8453).is_ok());
+        assert!(config_hash_for_chain(84532).is_ok());
+        assert!(config_hash_for_chain(11763072).is_ok());
+        assert!(config_hash_for_chain(999999).is_err());
     }
 }

--- a/crates/proof/tee/nitro/src/enclave/server.rs
+++ b/crates/proof/tee/nitro/src/enclave/server.rs
@@ -248,7 +248,7 @@ impl Server {
 #[cfg(test)]
 mod tests {
     use base_consensus_registry::Registry;
-    use base_enclave::{BlockId, Genesis, GenesisSystemConfig, PerChainConfig};
+    use base_enclave::PerChainConfig;
 
     use super::*;
 
@@ -293,25 +293,8 @@ mod tests {
         for &(chain_id, expected) in chains {
             let rollup = Registry::rollup_config(chain_id)
                 .unwrap_or_else(|| panic!("missing rollup config for chain {chain_id}"));
-            let sc = rollup.genesis.system_config.as_ref().expect("missing system_config");
-
-            let mut per_chain = PerChainConfig {
-                chain_id: U256::from(rollup.l2_chain_id.id()),
-                genesis: Genesis {
-                    l1: BlockId { hash: rollup.genesis.l1.hash, number: rollup.genesis.l1.number },
-                    l2: BlockId { hash: rollup.genesis.l2.hash, number: rollup.genesis.l2.number },
-                    l2_time: rollup.genesis.l2_time,
-                    system_config: GenesisSystemConfig {
-                        batcher_addr: sc.batcher_address,
-                        overhead: B256::ZERO,
-                        scalar: B256::from(sc.scalar.to_be_bytes::<32>()),
-                        gas_limit: sc.gas_limit,
-                    },
-                },
-                block_time: rollup.block_time,
-                deposit_contract_address: rollup.deposit_contract_address,
-                l1_system_config_address: rollup.l1_system_config_address,
-            };
+            let mut per_chain = PerChainConfig::from_rollup_config(rollup)
+                .unwrap_or_else(|| panic!("missing system_config for chain {chain_id}"));
             per_chain.force_defaults();
 
             assert_eq!(per_chain.hash(), expected, "config hash mismatch for chain {chain_id}");

--- a/crates/proof/tee/nitro/src/enclave/server.rs
+++ b/crates/proof/tee/nitro/src/enclave/server.rs
@@ -41,7 +41,7 @@ const CONFIG_HASH_SEPOLIA_ALPHA: B256 =
     b256!("4600cdaa81262bf5f124bd9276f605264e2ded951e34923bc838e81c442f0fa4");
 
 /// Look up the hardcoded config hash for a supported chain.
-fn config_hash_for_chain(chain_id: u64) -> Result<B256> {
+const fn config_hash_for_chain(chain_id: u64) -> Result<B256> {
     match chain_id {
         8453 => Ok(CONFIG_HASH_BASE_MAINNET),
         84532 => Ok(CONFIG_HASH_BASE_SEPOLIA),

--- a/crates/proof/tee/nitro/src/enclave/server.rs
+++ b/crates/proof/tee/nitro/src/enclave/server.rs
@@ -243,17 +243,13 @@ impl Server {
 
         Ok(ProofResult::Tee { aggregate_proposal, proposals })
     }
-
-    /// Create a server for testing (no NSM, no PCR0 verification).
-    #[cfg(test)]
-    pub fn new_for_testing() -> Result<Self> {
-        let signer_key = Ecdsa::generate(&mut rand_08::rngs::OsRng)?;
-        Ok(Self { pcr0: Vec::new(), signer_key, tee_image_hash: B256::ZERO })
-    }
 }
 
 #[cfg(test)]
 mod tests {
+    use base_consensus_registry::Registry;
+    use base_enclave::{BlockId, Genesis, GenesisSystemConfig, PerChainConfig};
+
     use super::*;
 
     #[test]
@@ -282,10 +278,43 @@ mod tests {
     }
 
     #[test]
-    fn config_hash_known_chains() {
-        assert!(config_hash_for_chain(8453).is_ok());
-        assert!(config_hash_for_chain(84532).is_ok());
-        assert!(config_hash_for_chain(11763072).is_ok());
+    fn config_hash_unknown_chain() {
         assert!(config_hash_for_chain(999999).is_err());
+    }
+
+    #[test]
+    fn config_hashes_match_registry() {
+        let chains: &[(u64, B256)] = &[
+            (8453, CONFIG_HASH_BASE_MAINNET),
+            (84532, CONFIG_HASH_BASE_SEPOLIA),
+            (11763072, CONFIG_HASH_SEPOLIA_ALPHA),
+        ];
+
+        for &(chain_id, expected) in chains {
+            let rollup = Registry::rollup_config(chain_id)
+                .unwrap_or_else(|| panic!("missing rollup config for chain {chain_id}"));
+            let sc = rollup.genesis.system_config.as_ref().expect("missing system_config");
+
+            let mut per_chain = PerChainConfig {
+                chain_id: U256::from(rollup.l2_chain_id.id()),
+                genesis: Genesis {
+                    l1: BlockId { hash: rollup.genesis.l1.hash, number: rollup.genesis.l1.number },
+                    l2: BlockId { hash: rollup.genesis.l2.hash, number: rollup.genesis.l2.number },
+                    l2_time: rollup.genesis.l2_time,
+                    system_config: GenesisSystemConfig {
+                        batcher_addr: sc.batcher_address,
+                        overhead: B256::ZERO,
+                        scalar: B256::from(sc.scalar.to_be_bytes::<32>()),
+                        gas_limit: sc.gas_limit,
+                    },
+                },
+                block_time: rollup.block_time,
+                deposit_contract_address: rollup.deposit_contract_address,
+                l1_system_config_address: rollup.l1_system_config_address,
+            };
+            per_chain.force_defaults();
+
+            assert_eq!(per_chain.hash(), expected, "config hash mismatch for chain {chain_id}");
+        }
     }
 }

--- a/crates/proof/tee/nitro/src/error.rs
+++ b/crates/proof/tee/nitro/src/error.rs
@@ -159,6 +159,9 @@ pub enum NitroError {
     /// Internal error.
     #[error("internal error: {0}")]
     Internal(String),
+    /// Unsupported chain ID.
+    #[error("unsupported chain ID: {0}")]
+    UnsupportedChain(u64),
     /// Proof transport failed.
     #[cfg(feature = "host")]
     #[error("transport error: {0}")]

--- a/crates/proof/tee/nitro/src/host/backend.rs
+++ b/crates/proof/tee/nitro/src/host/backend.rs
@@ -42,16 +42,11 @@ impl ProverBackend for NitroBackend {
 
 #[cfg(test)]
 mod tests {
-    use alloy_primitives::B256;
     use base_proof_preimage::{PreimageKey, WitnessOracle};
     use base_proof_primitives::ProverBackend;
 
     use super::*;
-    use crate::enclave::{EnclaveConfig, Server};
-
-    fn test_config() -> EnclaveConfig {
-        EnclaveConfig { vsock_cid: 0, vsock_port: 0, config_hash: B256::ZERO }
-    }
+    use crate::enclave::Server;
 
     #[tokio::test]
     async fn into_preimages_extracts_all_entries() {
@@ -67,8 +62,7 @@ mod tests {
 
     #[tokio::test]
     async fn backend_create_oracle_returns_empty() {
-        let config = test_config();
-        let server = Arc::new(Server::new(&config).unwrap());
+        let server = Arc::new(Server::new().unwrap());
         let transport = Arc::new(NitroTransport::local(server));
         let backend = NitroBackend::new(transport);
 

--- a/crates/proof/tee/nitro/src/host/server.rs
+++ b/crates/proof/tee/nitro/src/host/server.rs
@@ -88,20 +88,14 @@ impl EnclaveApiServer for NitroSignerRpc {
 
 #[cfg(test)]
 mod tests {
-    use alloy_primitives::B256;
     use base_proof_primitives::EnclaveApiServer;
 
     use super::*;
-    use crate::enclave::{EnclaveConfig, Server as EnclaveServer};
-
-    fn test_config() -> EnclaveConfig {
-        EnclaveConfig { vsock_cid: 0, vsock_port: 0, config_hash: B256::ZERO }
-    }
+    use crate::enclave::Server as EnclaveServer;
 
     #[tokio::test]
     async fn signer_public_key_routed_to_transport() {
-        let config = test_config();
-        let server = Arc::new(EnclaveServer::new(&config).unwrap());
+        let server = Arc::new(EnclaveServer::new().unwrap());
         let transport = Arc::new(NitroTransport::local(Arc::clone(&server)));
         let expected = server.signer_public_key();
 
@@ -121,8 +115,7 @@ mod tests {
 
     #[tokio::test]
     async fn signer_attestation_routed_to_transport() {
-        let config = test_config();
-        let server = Arc::new(EnclaveServer::new(&config).unwrap());
+        let server = Arc::new(EnclaveServer::new().unwrap());
         let transport = Arc::new(NitroTransport::local(Arc::clone(&server)));
 
         let rpc = NitroSignerRpc { transport };

--- a/crates/proof/tee/nitro/src/lib.rs
+++ b/crates/proof/tee/nitro/src/lib.rs
@@ -14,8 +14,8 @@ mod enclave;
 pub use enclave::NitroEnclave;
 pub use enclave::{
     AttestationDocument, AwsCaRoot, DEFAULT_CA_ROOTS, DEFAULT_CA_ROOTS_SHA256, Ecdsa,
-    EnclaveConfig, EnclaveRequest, EnclaveResponse, NsmRng, NsmSession, Server, Signing,
-    VerificationResult, get_default_ca_root, verify_attestation,
+    EnclaveRequest, EnclaveResponse, NsmRng, NsmSession, Server, Signing, VerificationResult,
+    get_default_ca_root, verify_attestation,
 };
 
 #[cfg(feature = "host")]

--- a/crates/proof/tee/nitro/src/lib.rs
+++ b/crates/proof/tee/nitro/src/lib.rs
@@ -14,8 +14,8 @@ mod enclave;
 pub use enclave::NitroEnclave;
 pub use enclave::{
     AttestationDocument, AwsCaRoot, DEFAULT_CA_ROOTS, DEFAULT_CA_ROOTS_SHA256, Ecdsa,
-    EnclaveRequest, EnclaveResponse, NsmRng, NsmSession, Server, Signing, VerificationResult,
-    get_default_ca_root, verify_attestation,
+    EnclaveRequest, EnclaveResponse, NsmRng, NsmSession, Server, Signing, VSOCK_PORT,
+    VerificationResult, get_default_ca_root, verify_attestation,
 };
 
 #[cfg(feature = "host")]


### PR DESCRIPTION
## Summary

- Remove `EnclaveConfig` struct entirely — the enclave now derives all configuration at runtime
- `tee_image_hash`: derived as `keccak256(PCR0)` from NSM hardware (no CLI arg needed)
- `config_hash`: looked up by `chain_id` from hardcoded constants (Base Mainnet, Base Sepolia, Sepolia Alpha)
- vsock: binds `VMADDR_CID_ANY:8000` as constants instead of CLI args
- Remove `Pcr0Mismatch` error variant, add `UnsupportedChain`
- Remove `NitroEnclaveArgs` (now an empty struct → unit variant)

## Motivation

Baking `tee_image_hash` or `config_hash` into the enclave ramdisk changes the EIF, which changes PCR0, which invalidates the hash — a chicken-and-egg problem. The enclave is the source of truth for PCR0 (via NSM hardware) and can look up `config_hash` by chain ID, so these CLI args were unnecessary.

## Changes

| File | Change |
|------|--------|
| `bin/prover/src/cli.rs` | Remove `NitroEnclaveArgs` struct, `Enclave` is now a unit variant. Remove `config_hash`/`tee_image_hash`/`vsock_*` CLI args from both enclave and local subcommands. |
| `crates/proof/tee/nitro/src/enclave/mod.rs` | Remove `EnclaveConfig` struct. Add `VSOCK_CID`/`VSOCK_PORT` constants. `NitroEnclave::new()` takes no params. |
| `crates/proof/tee/nitro/src/enclave/server.rs` | Remove `config_hash` from `Server` struct. Add hardcoded `CONFIG_HASH_*` constants for 3 chains. `prove()` looks up config hash by `boot_info.chain_id`. Remove PCR0 verification check. |
| `crates/proof/tee/nitro/src/error.rs` | Replace `Pcr0Mismatch` with `UnsupportedChain(u64)`. |
| `crates/proof/tee/nitro/src/lib.rs` | Remove `EnclaveConfig` from re-exports. |
| `crates/proof/tee/Justfile` | Remove `--config-hash` and `--tee-image-hash` from `nitro-local` recipe. |
| `crates/proof/tee/core/src/types/config.rs` | Add `print_real_config_hashes` test covering all 3 chains. |
| Host tests | Remove `test_config()` helpers, use `Server::new()` directly. |

## Config Hash Values

Computed via `keccak256(PerChainConfig::marshal_binary())`:

| Chain | ID | Config Hash |
|-------|-----|-------------|
| Base Mainnet | 8453 | `0x1607709d...5f3c57` |
| Base Sepolia | 84532 | `0x12e9c45f...d1360` |
| Sepolia Alpha | 11763072 | `0x4600cdaa...2f0fa4` |