### PR TITLE
feat(CHAIN-3482): Dual-mode discovery — K8s StatefulSet + AWS ALB

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4314,11 +4314,11 @@ dependencies = [
  "alloy-signer-local",
  "alloy-sol-types",
  "async-trait",
- "aws-config",
  "aws-sdk-ec2",
  "aws-sdk-elasticloadbalancingv2",
  "rstest",
  "thiserror 2.0.18",
+ "tokio",
  "tracing",
  "url",
 ]

--- a/bin/prover-registrar/src/cli.rs
+++ b/bin/prover-registrar/src/cli.rs
@@ -195,6 +195,11 @@ impl Cli {
                         "--prover-replicas is required for k8s discovery mode".into(),
                     )
                 })?;
+                if replicas == 0 {
+                    return Err(RegistrarError::Config(
+                        "--prover-replicas must be greater than 0".into(),
+                    ));
+                }
                 DiscoveryConfig::K8s {
                     statefulset_name,
                     service_name,
@@ -523,6 +528,17 @@ mod tests {
             "ipfs://bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi",
         ];
         assert!(Cli::try_parse_from(args).is_err());
+    }
+
+    #[test]
+    fn zero_replicas_fails_into_config() {
+        let mut args = base_args();
+        // Replace the existing --prover-replicas value with 0.
+        let idx = args.iter().position(|a| *a == "--prover-replicas").unwrap();
+        args[idx + 1] = "0";
+        assert!(
+            Cli::try_parse_from(args).expect("clap should parse these args").into_config().is_err()
+        );
     }
 
     #[test]

--- a/bin/prover-registrar/src/cli.rs
+++ b/bin/prover-registrar/src/cli.rs
@@ -5,7 +5,7 @@ use std::time::Duration;
 use alloy_primitives::Address;
 use alloy_signer_local::PrivateKeySigner;
 use base_proof_tee_registrar::{
-    AwsDiscoveryConfig, BoundlessConfig, DiscoveryConfig, K8sStatefulSetDiscovery, RegistrarConfig,
+    AwsDiscoveryConfig, BoundlessConfig, DiscoveryConfig, K8sDiscoveryConfig, RegistrarConfig,
     RegistrarError, RemoteSignerConfig, SigningConfig,
 };
 use clap::{ArgGroup, Args, Parser, ValueEnum};
@@ -200,13 +200,13 @@ impl Cli {
                         "--prover-replicas must be greater than 0".into(),
                     ));
                 }
-                DiscoveryConfig::K8s(K8sStatefulSetDiscovery::new(
+                DiscoveryConfig::K8s(K8sDiscoveryConfig {
                     statefulset_name,
                     service_name,
                     namespace,
                     replicas,
-                    self.prover_port,
-                ))
+                    port: self.prover_port,
+                })
             }
             DiscoveryMode::Aws => {
                 let target_group_arn = self.target_group_arn.ok_or_else(|| {
@@ -268,7 +268,10 @@ impl Cli {
     /// Run the registrar service.
     pub(crate) async fn run(self) -> eyre::Result<()> {
         let _config = self.into_config()?;
-        // TODO(CHAIN-3455): start RegistrationDriver
+        // TODO(CHAIN-3455): start RegistrationDriver. When wiring up the driver,
+        // this binary crate will need `aws-config` with features
+        // `["default-https-client", "rt-tokio"]` to construct real AWS SDK clients
+        // for AwsTargetGroupDiscovery in `aws` discovery mode.
         Ok(())
     }
 }

--- a/bin/prover-registrar/src/cli.rs
+++ b/bin/prover-registrar/src/cli.rs
@@ -5,10 +5,22 @@ use std::time::Duration;
 use alloy_primitives::Address;
 use alloy_signer_local::PrivateKeySigner;
 use base_proof_tee_registrar::{
-    BoundlessConfig, RegistrarConfig, RegistrarError, RemoteSignerConfig, SigningConfig,
+    BoundlessConfig, DiscoveryConfig, RegistrarConfig, RegistrarError, RemoteSignerConfig,
+    SigningConfig,
 };
-use clap::{ArgGroup, Args, Parser};
+use clap::{ArgGroup, Args, Parser, ValueEnum};
 use url::Url;
+
+/// Discovery backend selection.
+#[derive(ValueEnum, Clone, Debug, PartialEq, Eq)]
+pub(crate) enum DiscoveryMode {
+    /// K8s `StatefulSet` DNS enumeration (preferred — no AWS SDK calls required).
+    #[value(name = "k8s")]
+    K8s,
+    /// AWS ALB target group polling (fallback — supports `Initial` warm-up window).
+    #[value(name = "aws")]
+    Aws,
+}
 
 /// Prover Registrar — automated TEE signer registration service.
 #[derive(Parser)]
@@ -32,14 +44,38 @@ pub(crate) struct Cli {
     #[arg(long, env = "REGISTRAR_TEE_PROVER_REGISTRY_ADDRESS")]
     tee_prover_registry_address: Address,
 
-    // ── AWS ───────────────────────────────────────────────────────────────────
-    /// AWS ALB target group ARN for prover instance discovery.
-    #[arg(long, env = "REGISTRAR_TARGET_GROUP_ARN")]
-    target_group_arn: String,
+    // ── Discovery ─────────────────────────────────────────────────────────────
+    /// Discovery backend: `k8s` (K8s `StatefulSet` DNS) or `aws` (ALB target group).
+    #[arg(long, env = "REGISTRAR_DISCOVERY_MODE")]
+    discovery_mode: DiscoveryMode,
 
-    /// AWS region.
-    #[arg(long, env = "REGISTRAR_AWS_REGION")]
-    aws_region: String,
+    /// K8s `StatefulSet` name for prover pods (e.g. `prover`). Required for `k8s` mode.
+    #[arg(
+        long,
+        env = "REGISTRAR_PROVER_STATEFULSET_NAME",
+        required_if_eq("discovery_mode", "k8s")
+    )]
+    prover_statefulset_name: Option<String>,
+
+    /// Headless K8s Service name used for pod DNS (e.g. `prover-headless`). Required for `k8s` mode.
+    #[arg(long, env = "REGISTRAR_PROVER_SERVICE_NAME", required_if_eq("discovery_mode", "k8s"))]
+    prover_service_name: Option<String>,
+
+    /// K8s namespace of the prover `StatefulSet` (e.g. `provers`). Required for `k8s` mode.
+    #[arg(long, env = "REGISTRAR_PROVER_NAMESPACE", required_if_eq("discovery_mode", "k8s"))]
+    prover_namespace: Option<String>,
+
+    /// Number of `StatefulSet` replicas to enumerate. Required for `k8s` mode.
+    #[arg(long, env = "REGISTRAR_PROVER_REPLICAS", required_if_eq("discovery_mode", "k8s"))]
+    prover_replicas: Option<usize>,
+
+    /// AWS ALB target group ARN for prover instance discovery. Required for `aws` mode.
+    #[arg(long, env = "REGISTRAR_TARGET_GROUP_ARN", required_if_eq("discovery_mode", "aws"))]
+    target_group_arn: Option<String>,
+
+    /// AWS region (e.g. `us-east-1`). Required for `aws` mode.
+    #[arg(long, env = "REGISTRAR_AWS_REGION", required_if_eq("discovery_mode", "aws"))]
+    aws_region: Option<String>,
 
     /// JSON-RPC port to poll on each prover instance.
     #[arg(long, env = "REGISTRAR_PROVER_PORT", default_value_t = 8000)]
@@ -136,6 +172,50 @@ impl Cli {
             }
         };
 
+        // Build discovery config from mode and corresponding arguments.
+        let discovery = match self.discovery_mode {
+            DiscoveryMode::K8s => {
+                let statefulset_name = self.prover_statefulset_name.ok_or_else(|| {
+                    RegistrarError::Config(
+                        "--prover-statefulset-name is required for k8s discovery mode".into(),
+                    )
+                })?;
+                let service_name = self.prover_service_name.ok_or_else(|| {
+                    RegistrarError::Config(
+                        "--prover-service-name is required for k8s discovery mode".into(),
+                    )
+                })?;
+                let namespace = self.prover_namespace.ok_or_else(|| {
+                    RegistrarError::Config(
+                        "--prover-namespace is required for k8s discovery mode".into(),
+                    )
+                })?;
+                let replicas = self.prover_replicas.ok_or_else(|| {
+                    RegistrarError::Config(
+                        "--prover-replicas is required for k8s discovery mode".into(),
+                    )
+                })?;
+                DiscoveryConfig::K8s {
+                    statefulset_name,
+                    service_name,
+                    namespace,
+                    replicas,
+                    port: self.prover_port,
+                }
+            }
+            DiscoveryMode::Aws => {
+                let target_group_arn = self.target_group_arn.ok_or_else(|| {
+                    RegistrarError::Config(
+                        "--target-group-arn is required for aws discovery mode".into(),
+                    )
+                })?;
+                let aws_region = self.aws_region.ok_or_else(|| {
+                    RegistrarError::Config("--aws-region is required for aws discovery mode".into())
+                })?;
+                DiscoveryConfig::Aws { target_group_arn, aws_region, port: self.prover_port }
+            }
+        };
+
         if self.boundless.boundless_min_price > self.boundless.boundless_max_price {
             return Err(RegistrarError::Config(
                 "--boundless-min-price must not exceed --boundless-max-price".into(),
@@ -157,9 +237,7 @@ impl Cli {
         Ok(RegistrarConfig {
             l1_rpc_url: self.l1_rpc_url,
             tee_prover_registry_address: self.tee_prover_registry_address,
-            target_group_arn: self.target_group_arn,
-            aws_region: self.aws_region,
-            prover_port: self.prover_port,
+            discovery,
             signing,
             boundless: BoundlessConfig {
                 rpc_url: self.boundless.boundless_rpc_url,
@@ -199,10 +277,16 @@ mod tests {
             "http://localhost:8545",
             "--tee-prover-registry-address",
             "0x0000000000000000000000000000000000000001",
-            "--target-group-arn",
-            "arn:aws:elasticloadbalancing:us-east-1:123456789012:targetgroup/test/abc",
-            "--aws-region",
-            "us-east-1",
+            "--discovery-mode",
+            "k8s",
+            "--prover-statefulset-name",
+            "prover",
+            "--prover-service-name",
+            "prover-headless",
+            "--prover-namespace",
+            "provers",
+            "--prover-replicas",
+            "4",
             "--private-key",
             "0x0101010101010101010101010101010101010101010101010101010101010101",
             "--boundless-rpc-url",
@@ -221,10 +305,16 @@ mod tests {
             "http://localhost:8545",
             "--tee-prover-registry-address",
             "0x0000000000000000000000000000000000000001",
-            "--target-group-arn",
-            "arn:aws:elasticloadbalancing:us-east-1:123456789012:targetgroup/test/abc",
-            "--aws-region",
-            "us-east-1",
+            "--discovery-mode",
+            "k8s",
+            "--prover-statefulset-name",
+            "prover",
+            "--prover-service-name",
+            "prover-headless",
+            "--prover-namespace",
+            "provers",
+            "--prover-replicas",
+            "4",
             "--signer-endpoint",
             "http://localhost:8546",
             "--signer-address",
@@ -238,14 +328,43 @@ mod tests {
         ]
     }
 
+    fn aws_args() -> Vec<&'static str> {
+        vec![
+            "prover-registrar",
+            "--l1-rpc-url",
+            "http://localhost:8545",
+            "--tee-prover-registry-address",
+            "0x0000000000000000000000000000000000000001",
+            "--discovery-mode",
+            "aws",
+            "--target-group-arn",
+            "arn:aws:elasticloadbalancing:us-east-1:123456789012:targetgroup/prover/abc123",
+            "--aws-region",
+            "us-east-1",
+            "--private-key",
+            "0x0101010101010101010101010101010101010101010101010101010101010101",
+            "--boundless-rpc-url",
+            "http://localhost:9545",
+            "--boundless-private-key",
+            "0202020202020202020202020202020202020202020202020202020202020202",
+            "--boundless-verifier-program-url",
+            "ipfs://bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi",
+        ]
+    }
+
     #[test]
-    fn valid_local_key_config_into_config() {
+    fn valid_local_key_k8s_config_into_config() {
         assert!(Cli::parse_from(base_args()).into_config().is_ok());
     }
 
     #[test]
-    fn valid_remote_signer_config_into_config() {
+    fn valid_remote_signer_k8s_config_into_config() {
         assert!(Cli::parse_from(remote_args()).into_config().is_ok());
+    }
+
+    #[test]
+    fn valid_aws_discovery_config_into_config() {
+        assert!(Cli::parse_from(aws_args()).into_config().is_ok());
     }
 
     #[test]
@@ -261,6 +380,18 @@ mod tests {
     }
 
     #[test]
+    fn into_config_k8s_returns_k8s_discovery() {
+        let config = Cli::parse_from(base_args()).into_config().unwrap();
+        assert!(matches!(config.discovery, DiscoveryConfig::K8s { .. }));
+    }
+
+    #[test]
+    fn into_config_aws_returns_aws_discovery() {
+        let config = Cli::parse_from(aws_args()).into_config().unwrap();
+        assert!(matches!(config.discovery, DiscoveryConfig::Aws { .. }));
+    }
+
+    #[test]
     fn no_signing_method_fails_clap_parse() {
         let args = vec![
             "prover-registrar",
@@ -268,10 +399,16 @@ mod tests {
             "http://localhost:8545",
             "--tee-prover-registry-address",
             "0x0000000000000000000000000000000000000001",
-            "--target-group-arn",
-            "arn:aws:elasticloadbalancing:us-east-1:123456789012:targetgroup/test/abc",
-            "--aws-region",
-            "us-east-1",
+            "--discovery-mode",
+            "k8s",
+            "--prover-statefulset-name",
+            "prover",
+            "--prover-service-name",
+            "prover-headless",
+            "--prover-namespace",
+            "provers",
+            "--prover-replicas",
+            "4",
             "--boundless-rpc-url",
             "http://localhost:9545",
             "--boundless-private-key",
@@ -290,12 +427,94 @@ mod tests {
             "http://localhost:8545",
             "--tee-prover-registry-address",
             "0x0000000000000000000000000000000000000001",
-            "--target-group-arn",
-            "arn:aws:elasticloadbalancing:us-east-1:123456789012:targetgroup/test/abc",
-            "--aws-region",
-            "us-east-1",
+            "--discovery-mode",
+            "k8s",
+            "--prover-statefulset-name",
+            "prover",
+            "--prover-service-name",
+            "prover-headless",
+            "--prover-namespace",
+            "provers",
+            "--prover-replicas",
+            "4",
             "--signer-endpoint",
             "http://localhost:8546",
+            "--boundless-rpc-url",
+            "http://localhost:9545",
+            "--boundless-private-key",
+            "0202020202020202020202020202020202020202020202020202020202020202",
+            "--boundless-verifier-program-url",
+            "ipfs://bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi",
+        ];
+        assert!(Cli::try_parse_from(args).is_err());
+    }
+
+    #[test]
+    fn k8s_mode_without_statefulset_name_fails_clap_parse() {
+        let args = vec![
+            "prover-registrar",
+            "--l1-rpc-url",
+            "http://localhost:8545",
+            "--tee-prover-registry-address",
+            "0x0000000000000000000000000000000000000001",
+            "--discovery-mode",
+            "k8s",
+            "--prover-service-name",
+            "prover-headless",
+            "--prover-namespace",
+            "provers",
+            "--prover-replicas",
+            "4",
+            "--private-key",
+            "0x0101010101010101010101010101010101010101010101010101010101010101",
+            "--boundless-rpc-url",
+            "http://localhost:9545",
+            "--boundless-private-key",
+            "0202020202020202020202020202020202020202020202020202020202020202",
+            "--boundless-verifier-program-url",
+            "ipfs://bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi",
+        ];
+        assert!(Cli::try_parse_from(args).is_err());
+    }
+
+    #[test]
+    fn aws_mode_without_target_group_arn_fails_clap_parse() {
+        let args = vec![
+            "prover-registrar",
+            "--l1-rpc-url",
+            "http://localhost:8545",
+            "--tee-prover-registry-address",
+            "0x0000000000000000000000000000000000000001",
+            "--discovery-mode",
+            "aws",
+            "--aws-region",
+            "us-east-1",
+            "--private-key",
+            "0x0101010101010101010101010101010101010101010101010101010101010101",
+            "--boundless-rpc-url",
+            "http://localhost:9545",
+            "--boundless-private-key",
+            "0202020202020202020202020202020202020202020202020202020202020202",
+            "--boundless-verifier-program-url",
+            "ipfs://bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi",
+        ];
+        assert!(Cli::try_parse_from(args).is_err());
+    }
+
+    #[test]
+    fn aws_mode_without_region_fails_clap_parse() {
+        let args = vec![
+            "prover-registrar",
+            "--l1-rpc-url",
+            "http://localhost:8545",
+            "--tee-prover-registry-address",
+            "0x0000000000000000000000000000000000000001",
+            "--discovery-mode",
+            "aws",
+            "--target-group-arn",
+            "arn:aws:elasticloadbalancing:us-east-1:123456789012:targetgroup/prover/abc123",
+            "--private-key",
+            "0x0101010101010101010101010101010101010101010101010101010101010101",
             "--boundless-rpc-url",
             "http://localhost:9545",
             "--boundless-private-key",
@@ -337,5 +556,34 @@ mod tests {
     fn poll_interval_returns_duration() {
         let config = Cli::parse_from(base_args()).into_config().unwrap();
         assert_eq!(config.poll_interval, Duration::from_secs(30));
+    }
+
+    #[test]
+    fn k8s_discovery_config_fields() {
+        let config = Cli::parse_from(base_args()).into_config().unwrap();
+        let DiscoveryConfig::K8s { statefulset_name, service_name, namespace, replicas, port } =
+            config.discovery
+        else {
+            panic!("expected K8s discovery config");
+        };
+        assert_eq!(statefulset_name, "prover");
+        assert_eq!(service_name, "prover-headless");
+        assert_eq!(namespace, "provers");
+        assert_eq!(replicas, 4);
+        assert_eq!(port, 8000);
+    }
+
+    #[test]
+    fn aws_discovery_config_fields() {
+        let config = Cli::parse_from(aws_args()).into_config().unwrap();
+        let DiscoveryConfig::Aws { target_group_arn, aws_region, port } = config.discovery else {
+            panic!("expected Aws discovery config");
+        };
+        assert_eq!(
+            target_group_arn,
+            "arn:aws:elasticloadbalancing:us-east-1:123456789012:targetgroup/prover/abc123"
+        );
+        assert_eq!(aws_region, "us-east-1");
+        assert_eq!(port, 8000);
     }
 }

--- a/bin/prover-registrar/src/cli.rs
+++ b/bin/prover-registrar/src/cli.rs
@@ -5,8 +5,8 @@ use std::time::Duration;
 use alloy_primitives::Address;
 use alloy_signer_local::PrivateKeySigner;
 use base_proof_tee_registrar::{
-    BoundlessConfig, DiscoveryConfig, RegistrarConfig, RegistrarError, RemoteSignerConfig,
-    SigningConfig,
+    AwsDiscoveryConfig, BoundlessConfig, DiscoveryConfig, K8sStatefulSetDiscovery, RegistrarConfig,
+    RegistrarError, RemoteSignerConfig, SigningConfig,
 };
 use clap::{ArgGroup, Args, Parser, ValueEnum};
 use url::Url;
@@ -200,13 +200,13 @@ impl Cli {
                         "--prover-replicas must be greater than 0".into(),
                     ));
                 }
-                DiscoveryConfig::K8s {
+                DiscoveryConfig::K8s(K8sStatefulSetDiscovery::new(
                     statefulset_name,
                     service_name,
                     namespace,
                     replicas,
-                    port: self.prover_port,
-                }
+                    self.prover_port,
+                ))
             }
             DiscoveryMode::Aws => {
                 let target_group_arn = self.target_group_arn.ok_or_else(|| {
@@ -217,7 +217,11 @@ impl Cli {
                 let aws_region = self.aws_region.ok_or_else(|| {
                     RegistrarError::Config("--aws-region is required for aws discovery mode".into())
                 })?;
-                DiscoveryConfig::Aws { target_group_arn, aws_region, port: self.prover_port }
+                DiscoveryConfig::Aws(AwsDiscoveryConfig {
+                    target_group_arn,
+                    aws_region,
+                    port: self.prover_port,
+                })
             }
         };
 
@@ -387,13 +391,13 @@ mod tests {
     #[test]
     fn into_config_k8s_returns_k8s_discovery() {
         let config = Cli::parse_from(base_args()).into_config().unwrap();
-        assert!(matches!(config.discovery, DiscoveryConfig::K8s { .. }));
+        assert!(matches!(config.discovery, DiscoveryConfig::K8s(_)));
     }
 
     #[test]
     fn into_config_aws_returns_aws_discovery() {
         let config = Cli::parse_from(aws_args()).into_config().unwrap();
-        assert!(matches!(config.discovery, DiscoveryConfig::Aws { .. }));
+        assert!(matches!(config.discovery, DiscoveryConfig::Aws(_)));
     }
 
     #[test]
@@ -575,31 +579,16 @@ mod tests {
     }
 
     #[test]
-    fn k8s_discovery_config_fields() {
-        let config = Cli::parse_from(base_args()).into_config().unwrap();
-        let DiscoveryConfig::K8s { statefulset_name, service_name, namespace, replicas, port } =
-            config.discovery
-        else {
-            panic!("expected K8s discovery config");
-        };
-        assert_eq!(statefulset_name, "prover");
-        assert_eq!(service_name, "prover-headless");
-        assert_eq!(namespace, "provers");
-        assert_eq!(replicas, 4);
-        assert_eq!(port, 8000);
-    }
-
-    #[test]
     fn aws_discovery_config_fields() {
         let config = Cli::parse_from(aws_args()).into_config().unwrap();
-        let DiscoveryConfig::Aws { target_group_arn, aws_region, port } = config.discovery else {
+        let DiscoveryConfig::Aws(aws) = config.discovery else {
             panic!("expected Aws discovery config");
         };
         assert_eq!(
-            target_group_arn,
+            aws.target_group_arn,
             "arn:aws:elasticloadbalancing:us-east-1:123456789012:targetgroup/prover/abc123"
         );
-        assert_eq!(aws_region, "us-east-1");
-        assert_eq!(port, 8000);
+        assert_eq!(aws.aws_region, "us-east-1");
+        assert_eq!(aws.port, 8000);
     }
 }

--- a/crates/proof/tee/registrar/Cargo.toml
+++ b/crates/proof/tee/registrar/Cargo.toml
@@ -12,8 +12,8 @@ workspace = true
 
 [dependencies]
 # Alloy
-alloy-provider.workspace = true
 alloy-contract.workspace = true
+alloy-provider.workspace = true
 alloy-sol-types.workspace = true
 alloy-primitives.workspace = true
 alloy-signer-local.workspace = true

--- a/crates/proof/tee/registrar/Cargo.toml
+++ b/crates/proof/tee/registrar/Cargo.toml
@@ -12,9 +12,9 @@ workspace = true
 
 [dependencies]
 # Alloy
-alloy-sol-types.workspace = true
 alloy-provider.workspace = true
 alloy-contract.workspace = true
+alloy-sol-types.workspace = true
 alloy-primitives.workspace = true
 alloy-signer-local.workspace = true
 

--- a/crates/proof/tee/registrar/Cargo.toml
+++ b/crates/proof/tee/registrar/Cargo.toml
@@ -12,19 +12,18 @@ workspace = true
 
 [dependencies]
 # Alloy
-alloy-contract.workspace = true
-alloy-provider.workspace = true
 alloy-sol-types.workspace = true
+alloy-provider.workspace = true
+alloy-contract.workspace = true
 alloy-primitives.workspace = true
 alloy-signer-local.workspace = true
 
+# AWS
+aws-sdk-ec2.workspace = true
+aws-sdk-elasticloadbalancingv2.workspace = true
+
 # Async
 async-trait.workspace = true
-
-# AWS
-aws-config = { workspace = true, features = ["default-https-client", "rt-tokio"] }
-aws-sdk-ec2 = { workspace = true, features = ["rustls", "default-https-client", "rt-tokio"] }
-aws-sdk-elasticloadbalancingv2 = { workspace = true, features = ["rustls", "default-https-client", "rt-tokio"] }
 
 # Error
 thiserror.workspace = true
@@ -37,3 +36,4 @@ url.workspace = true
 
 [dev-dependencies]
 rstest.workspace = true
+tokio = { workspace = true, features = ["rt", "macros"] }

--- a/crates/proof/tee/registrar/src/config.rs
+++ b/crates/proof/tee/registrar/src/config.rs
@@ -46,6 +46,26 @@ impl std::fmt::Debug for SigningConfig {
     }
 }
 
+/// K8s `StatefulSet` discovery configuration.
+///
+/// Contains the parameters needed to construct a [`K8sStatefulSetDiscovery`]
+/// at runtime. The driver builds the discovery implementation from this config.
+///
+/// [`K8sStatefulSetDiscovery`]: crate::K8sStatefulSetDiscovery
+#[derive(Clone, Debug)]
+pub struct K8sDiscoveryConfig {
+    /// K8s `StatefulSet` name (e.g. `"prover"`).
+    pub statefulset_name: String,
+    /// Headless Service name used for pod DNS (e.g. `"prover-headless"`).
+    pub service_name: String,
+    /// Namespace of the prover `StatefulSet` (e.g. `"provers"`).
+    pub namespace: String,
+    /// Number of `StatefulSet` replicas to enumerate.
+    pub replicas: usize,
+    /// JSON-RPC port to poll on each prover pod.
+    pub port: u16,
+}
+
 /// AWS ALB target group discovery configuration.
 ///
 /// Contains the parameters needed to construct an [`AwsTargetGroupDiscovery`]
@@ -66,20 +86,18 @@ pub struct AwsDiscoveryConfig {
 ///
 /// Selected at startup via `--discovery-mode`. Only the active variant's
 /// parameters are required; unused variant fields are never read.
+///
+/// Both variants wrap plain config structs — the runtime discovery
+/// implementations ([`K8sStatefulSetDiscovery`], [`AwsTargetGroupDiscovery`])
+/// are constructed from these by the driver.
+///
+/// [`K8sStatefulSetDiscovery`]: crate::K8sStatefulSetDiscovery
+/// [`AwsTargetGroupDiscovery`]: crate::AwsTargetGroupDiscovery
 #[derive(Clone, Debug)]
 pub enum DiscoveryConfig {
     /// K8s `StatefulSet` DNS enumeration (preferred).
-    ///
-    /// Wraps [`K8sStatefulSetDiscovery`] directly — no duplicate fields.
-    ///
-    /// [`K8sStatefulSetDiscovery`]: crate::K8sStatefulSetDiscovery
-    K8s(crate::K8sStatefulSetDiscovery),
+    K8s(K8sDiscoveryConfig),
     /// AWS ALB target group polling (fallback).
-    ///
-    /// Wraps [`AwsDiscoveryConfig`] with the connection parameters needed to
-    /// construct an [`AwsTargetGroupDiscovery`] at runtime.
-    ///
-    /// [`AwsTargetGroupDiscovery`]: crate::AwsTargetGroupDiscovery
     Aws(AwsDiscoveryConfig),
 }
 

--- a/crates/proof/tee/registrar/src/config.rs
+++ b/crates/proof/tee/registrar/src/config.rs
@@ -46,6 +46,44 @@ impl std::fmt::Debug for SigningConfig {
     }
 }
 
+/// Discovery backend configuration.
+///
+/// Selected at startup via `--discovery-mode`. Only the fields of the active
+/// variant are required; unused variant fields are never read.
+#[derive(Clone, Debug)]
+pub enum DiscoveryConfig {
+    /// K8s `StatefulSet` DNS enumeration (preferred).
+    ///
+    /// Discovers pods by iterating `0..replicas` and constructing deterministic
+    /// DNS names (`{name}-{i}.{svc}.{ns}.svc.cluster.local:{port}`).
+    /// No AWS API calls required.
+    K8s {
+        /// K8s `StatefulSet` name (e.g. `"prover"`).
+        statefulset_name: String,
+        /// Headless Service name used for pod DNS (e.g. `"prover-headless"`).
+        service_name: String,
+        /// Namespace of the prover `StatefulSet` (e.g. `"provers"`).
+        namespace: String,
+        /// Number of `StatefulSet` replicas to enumerate.
+        replicas: usize,
+        /// JSON-RPC port to poll on each prover pod.
+        port: u16,
+    },
+    /// AWS ALB target group polling (fallback).
+    ///
+    /// Discovers instances via `describe_target_health` + `describe_instances`.
+    /// Supports the `Initial` warm-up window so new instances are registered
+    /// before the ALB health check completes.
+    Aws {
+        /// AWS ALB target group ARN for prover instance discovery.
+        target_group_arn: String,
+        /// AWS region (e.g. `"us-east-1"`).
+        aws_region: String,
+        /// JSON-RPC port to poll on each prover instance.
+        port: u16,
+    },
+}
+
 /// Boundless Network configuration for ZK proof generation.
 #[derive(Clone)]
 pub struct BoundlessConfig {
@@ -90,13 +128,9 @@ pub struct RegistrarConfig {
     pub l1_rpc_url: Url,
     /// `TEEProverRegistry` contract address on L1.
     pub tee_prover_registry_address: Address,
-    // ── AWS ───────────────────────────────────────────────────────────────────
-    /// AWS ALB target group ARN for prover instance discovery.
-    pub target_group_arn: String,
-    /// AWS region.
-    pub aws_region: String,
-    /// JSON-RPC port to poll on each prover instance.
-    pub prover_port: u16,
+    // ── Discovery ─────────────────────────────────────────────────────────────
+    /// Discovery backend configuration.
+    pub discovery: DiscoveryConfig,
     // ── Signing ───────────────────────────────────────────────────────────────
     /// Resolved signing configuration.
     pub signing: SigningConfig,
@@ -125,9 +159,7 @@ impl std::fmt::Debug for RegistrarConfig {
         f.debug_struct("RegistrarConfig")
             .field("l1_rpc_url", &url_origin(&self.l1_rpc_url))
             .field("tee_prover_registry_address", &self.tee_prover_registry_address)
-            .field("target_group_arn", &self.target_group_arn)
-            .field("aws_region", &self.aws_region)
-            .field("prover_port", &self.prover_port)
+            .field("discovery", &self.discovery)
             .field("signing", &self.signing)
             .field("boundless", &self.boundless)
             .field("poll_interval", &self.poll_interval)

--- a/crates/proof/tee/registrar/src/config.rs
+++ b/crates/proof/tee/registrar/src/config.rs
@@ -46,42 +46,41 @@ impl std::fmt::Debug for SigningConfig {
     }
 }
 
+/// AWS ALB target group discovery configuration.
+///
+/// Contains the parameters needed to construct an [`AwsTargetGroupDiscovery`]
+/// at runtime. The SDK clients are built separately from these values.
+///
+/// [`AwsTargetGroupDiscovery`]: crate::AwsTargetGroupDiscovery
+#[derive(Clone, Debug)]
+pub struct AwsDiscoveryConfig {
+    /// AWS ALB target group ARN for prover instance discovery.
+    pub target_group_arn: String,
+    /// AWS region (e.g. `"us-east-1"`).
+    pub aws_region: String,
+    /// JSON-RPC port to poll on each prover instance.
+    pub port: u16,
+}
+
 /// Discovery backend configuration.
 ///
-/// Selected at startup via `--discovery-mode`. Only the fields of the active
-/// variant are required; unused variant fields are never read.
+/// Selected at startup via `--discovery-mode`. Only the active variant's
+/// parameters are required; unused variant fields are never read.
 #[derive(Clone, Debug)]
 pub enum DiscoveryConfig {
     /// K8s `StatefulSet` DNS enumeration (preferred).
     ///
-    /// Discovers pods by iterating `0..replicas` and constructing deterministic
-    /// DNS names (`{name}-{i}.{svc}.{ns}.svc.cluster.local:{port}`).
-    /// No AWS API calls required.
-    K8s {
-        /// K8s `StatefulSet` name (e.g. `"prover"`).
-        statefulset_name: String,
-        /// Headless Service name used for pod DNS (e.g. `"prover-headless"`).
-        service_name: String,
-        /// Namespace of the prover `StatefulSet` (e.g. `"provers"`).
-        namespace: String,
-        /// Number of `StatefulSet` replicas to enumerate.
-        replicas: usize,
-        /// JSON-RPC port to poll on each prover pod.
-        port: u16,
-    },
+    /// Wraps [`K8sStatefulSetDiscovery`] directly — no duplicate fields.
+    ///
+    /// [`K8sStatefulSetDiscovery`]: crate::K8sStatefulSetDiscovery
+    K8s(crate::K8sStatefulSetDiscovery),
     /// AWS ALB target group polling (fallback).
     ///
-    /// Discovers instances via `describe_target_health` + `describe_instances`.
-    /// Supports the `Initial` warm-up window so new instances are registered
-    /// before the ALB health check completes.
-    Aws {
-        /// AWS ALB target group ARN for prover instance discovery.
-        target_group_arn: String,
-        /// AWS region (e.g. `"us-east-1"`).
-        aws_region: String,
-        /// JSON-RPC port to poll on each prover instance.
-        port: u16,
-    },
+    /// Wraps [`AwsDiscoveryConfig`] with the connection parameters needed to
+    /// construct an [`AwsTargetGroupDiscovery`] at runtime.
+    ///
+    /// [`AwsTargetGroupDiscovery`]: crate::AwsTargetGroupDiscovery
+    Aws(AwsDiscoveryConfig),
 }
 
 /// Boundless Network configuration for ZK proof generation.

--- a/crates/proof/tee/registrar/src/discovery.rs
+++ b/crates/proof/tee/registrar/src/discovery.rs
@@ -182,7 +182,8 @@ impl InstanceDiscovery for AwsTargetGroupDiscovery {
             }
         }
 
-        let targets: Vec<(String, InstanceHealthStatus)> = health_map.into_iter().collect();
+        let mut targets: Vec<(String, InstanceHealthStatus)> = health_map.into_iter().collect();
+        targets.sort_by(|(a, _), (b, _)| a.cmp(b));
 
         // Collect IDs for instances that should be registered.
         let registerable_ids: Vec<String> = targets

--- a/crates/proof/tee/registrar/src/discovery.rs
+++ b/crates/proof/tee/registrar/src/discovery.rs
@@ -1,89 +1,138 @@
-//! AWS ALB target group instance discovery.
+//! K8s `StatefulSet` and AWS ALB target group instance discovery.
 
-use std::{collections::HashMap, net::IpAddr};
+use std::collections::HashMap;
 
 use async_trait::async_trait;
 use aws_sdk_ec2::Client as Ec2Client;
 use aws_sdk_elasticloadbalancingv2::Client as ElbClient;
-use tracing::{debug, warn};
+use tracing::debug;
 
 use crate::{InstanceDiscovery, InstanceHealthStatus, ProverInstance, RegistrarError, Result};
 
-/// Discovers prover instances by querying an AWS ALB target group.
+/// Discovers prover pods by enumerating a K8s `StatefulSet`'s deterministic DNS names.
 ///
-/// Uses `describe_target_health` to enumerate all registered targets, including
-/// those in the `Initial` state that have not yet passed the ALB health check.
-/// This allows the registrar to detect and pre-register new instances during the
-/// ALB warm-up window (typically ~1 hour) before they begin receiving traffic.
+/// `StatefulSet` pods receive stable DNS names of the form:
+/// `{name}-{i}.{svc}.{ns}.svc.cluster.local`
 ///
-/// Private IP addresses are resolved from the EC2 instance IDs returned by the
-/// target group via a `describe_instances` call.
+/// Discovery requires no API calls — pod endpoints are fully deterministic
+/// from the `StatefulSet` name, headless service name, namespace, replica count,
+/// and port alone. K8s pod readiness gates proposal traffic independently;
+/// the registrar polls every enumerated pod each cycle regardless.
+#[derive(Debug)]
+pub struct K8sStatefulSetDiscovery {
+    statefulset_name: String,
+    service_name: String,
+    namespace: String,
+    replicas: usize,
+    port: u16,
+}
+
+impl K8sStatefulSetDiscovery {
+    /// Creates a new discovery instance for the given `StatefulSet`.
+    pub const fn new(
+        statefulset_name: String,
+        service_name: String,
+        namespace: String,
+        replicas: usize,
+        port: u16,
+    ) -> Self {
+        Self { statefulset_name, service_name, namespace, replicas, port }
+    }
+
+    /// Returns the pod DNS endpoint for replica index `i`.
+    ///
+    /// Format: `{name}-{i}.{svc}.{ns}.svc.cluster.local:{port}`
+    pub fn pod_endpoint(&self, i: usize) -> String {
+        format!(
+            "{}-{}.{}.{}.svc.cluster.local:{}",
+            self.statefulset_name, i, self.service_name, self.namespace, self.port
+        )
+    }
+}
+
+#[async_trait]
+impl InstanceDiscovery for K8sStatefulSetDiscovery {
+    async fn discover_instances(&self) -> Result<Vec<ProverInstance>> {
+        let instances = (0..self.replicas)
+            .map(|i| {
+                let endpoint = self.pod_endpoint(i);
+                debug!(pod = %endpoint, "discovered prover pod");
+                ProverInstance {
+                    instance_id: endpoint.clone(),
+                    endpoint,
+                    health_status: InstanceHealthStatus::Healthy,
+                }
+            })
+            .collect();
+        Ok(instances)
+    }
+}
+
+/// Discovers prover instances via AWS Elastic Load Balancing target groups.
 ///
-/// # Assumptions
-///
-/// The target group must be configured with **instance-type** targets (IDs of the
-/// form `i-xxxxxxxxxxxxxxxxx`). IP-type target groups return IP address strings
-/// from `target.id()`, which would cause `describe_instances` to return an
-/// `InvalidParameterValue` error at runtime.
+/// Queries `describe_target_health` to enumerate registered targets, then
+/// resolves each EC2 instance's private IP address via `describe_instances`.
+/// Health state is mapped from the ALB target health state, supporting the
+/// `Initial` warm-up window during which new instances should be registered.
 #[derive(Debug)]
 pub struct AwsTargetGroupDiscovery {
     elb_client: ElbClient,
     ec2_client: Ec2Client,
     target_group_arn: String,
+    port: u16,
 }
 
 impl AwsTargetGroupDiscovery {
-    /// Creates a new discovery client for the given target group ARN and AWS region.
-    pub async fn new(target_group_arn: String, aws_region: String) -> Self {
-        let sdk_config = aws_config::defaults(aws_config::BehaviorVersion::latest())
-            .region(aws_sdk_ec2::config::Region::new(aws_region))
-            .load()
-            .await;
-        let elb_client = ElbClient::new(&sdk_config);
-        let ec2_client = Ec2Client::new(&sdk_config);
-        Self { elb_client, ec2_client, target_group_arn }
+    /// Creates a new `AwsTargetGroupDiscovery` with the given AWS clients.
+    pub const fn new(
+        elb_client: ElbClient,
+        ec2_client: Ec2Client,
+        target_group_arn: String,
+        port: u16,
+    ) -> Self {
+        Self { elb_client, ec2_client, target_group_arn, port }
     }
 
-    /// Builds a [`ProverInstance`] list from a health map and raw `(instance_id, private_ip_str)`
-    /// pairs that have already been extracted from EC2 reservations.
+    /// Assembles [`ProverInstance`] objects from ELB target data and EC2 IP data.
     ///
-    /// Extracted from [`Self::discover_instances`] so that the IP-parse, health-map lookup,
-    /// and assembly logic can be unit-tested without constructing AWS SDK mock clients.
+    /// Filters `targets` to those whose [`InstanceHealthStatus::should_register`]
+    /// returns `true`, then looks up the private IP in `instance_ips` to form the
+    /// `endpoint` field. Targets with no matching IP entry are silently dropped
+    /// (this can happen if an EC2 lookup fails for a specific instance).
+    ///
+    /// This function is a pure transformation — no AWS SDK calls are made — which
+    /// makes it straightforwardly unit-testable without SDK mocks.
     pub fn assemble_prover_instances(
-        health_map: &HashMap<String, InstanceHealthStatus>,
-        pairs: impl IntoIterator<Item = (String, String)>,
+        targets: &[(String, InstanceHealthStatus)],
+        instance_ips: &HashMap<String, String>,
+        port: u16,
     ) -> Vec<ProverInstance> {
-        let mut instances = Vec::new();
-        for (instance_id, private_ip_str) in pairs {
-            let private_ip: IpAddr = match private_ip_str.parse() {
-                Ok(ip) => ip,
-                Err(e) => {
-                    warn!(instance_id = %instance_id, error = %e, "invalid private IP, skipping");
-                    continue;
-                }
-            };
-            let health_status =
-                health_map.get(&instance_id).copied().unwrap_or(InstanceHealthStatus::Unhealthy);
-
-            debug!(
-                instance_id = %instance_id,
-                private_ip = %private_ip,
-                health = ?health_status,
-                "discovered prover instance"
-            );
-
-            instances.push(ProverInstance { instance_id, private_ip, health_status });
-        }
-        instances
+        targets
+            .iter()
+            .filter(|(_, status)| status.should_register())
+            .filter_map(|(instance_id, health_status)| {
+                let private_ip = instance_ips.get(instance_id)?;
+                let endpoint = format!("{private_ip}:{port}");
+                debug!(
+                    instance_id = %instance_id,
+                    endpoint = %endpoint,
+                    "discovered AWS prover instance"
+                );
+                Some(ProverInstance {
+                    instance_id: instance_id.clone(),
+                    endpoint,
+                    health_status: *health_status,
+                })
+            })
+            .collect()
     }
 }
 
 #[async_trait]
 impl InstanceDiscovery for AwsTargetGroupDiscovery {
     async fn discover_instances(&self) -> Result<Vec<ProverInstance>> {
-        // Step 1: Query the target group for all registered targets and their health status.
-        // This includes instances in the Initial state before the ALB routes traffic to them.
-        let health_output = self
+        // Query ELB for current target health.
+        let elb_resp = self
             .elb_client
             .describe_target_health()
             .target_group_arn(&self.target_group_arn)
@@ -91,162 +140,223 @@ impl InstanceDiscovery for AwsTargetGroupDiscovery {
             .await
             .map_err(|e| RegistrarError::Discovery(Box::new(e)))?;
 
-        let target_descriptions = health_output.target_health_descriptions();
-        if target_descriptions.is_empty() {
-            debug!(target_group = %self.target_group_arn, "no targets in target group");
+        // Extract (instance_id, health_status) pairs from the ELB response.
+        let targets: Vec<(String, InstanceHealthStatus)> = elb_resp
+            .target_health_descriptions()
+            .iter()
+            .filter_map(|t| {
+                let instance_id = t.target()?.id()?.to_string();
+                let state = t.target_health()?.state()?;
+                let health_status = InstanceHealthStatus::from_aws_state(state.as_str());
+                Some((instance_id, health_status))
+            })
+            .collect();
+
+        // Collect IDs for instances that should be registered.
+        let registerable_ids: Vec<String> = targets
+            .iter()
+            .filter(|(_, status)| status.should_register())
+            .map(|(id, _)| id.clone())
+            .collect();
+
+        if registerable_ids.is_empty() {
             return Ok(vec![]);
         }
 
-        // Step 2: Build an instance_id → health_status map and collect instance IDs for EC2 lookup.
-        // Uses entry().or_insert() so that if the same instance is registered on multiple ports,
-        // the first-seen port's health status wins and the instance ID is not duplicated.
-        let mut health_map: HashMap<String, InstanceHealthStatus> = HashMap::new();
-        let mut instance_ids: Vec<String> = Vec::new();
-
-        for desc in target_descriptions {
-            let Some(instance_id) = desc.target().and_then(|t| t.id()) else {
-                warn!("target group entry missing instance ID, skipping");
-                continue;
-            };
-            if !instance_id.starts_with("i-") {
-                warn!(
-                    id = %instance_id,
-                    "target group entry is not an instance-type target (id does not start with \
-                     'i-'); is the target group type set to 'instance'? skipping"
-                );
-                continue;
-            }
-            let health_status = desc
-                .target_health()
-                .and_then(|h| h.state())
-                .map(|s| InstanceHealthStatus::from_aws_state(s.as_str()))
-                .unwrap_or(InstanceHealthStatus::Unhealthy);
-
-            if let std::collections::hash_map::Entry::Vacant(e) =
-                health_map.entry(instance_id.to_string())
-            {
-                e.insert(health_status);
-                instance_ids.push(instance_id.to_string());
-            } else {
-                debug!(
-                    instance_id = %instance_id,
-                    "instance registered on multiple ports; keeping first-seen health status"
-                );
-            }
-        }
-
-        if instance_ids.is_empty() {
-            return Ok(vec![]);
-        }
-
-        // Step 3: Resolve private IPs for all instance IDs in a single EC2 call.
-        // describe_instances returns up to 1000 results per page. Pagination is intentionally
-        // omitted here: the instance count is bounded by the ASG size (typically ≤ 10), so
-        // truncation cannot occur in practice.
-        let instances_output = self
+        // Resolve private IPs for registerable instances via EC2.
+        let ec2_resp = self
             .ec2_client
             .describe_instances()
-            .set_instance_ids(Some(instance_ids))
+            .set_instance_ids(Some(registerable_ids))
             .send()
             .await
             .map_err(|e| RegistrarError::Discovery(Box::new(e)))?;
 
-        // Step 4: Extract (instance_id, private_ip_str) pairs, skipping incomplete entries.
-        let mut pairs: Vec<(String, String)> = Vec::new();
-        for reservation in instances_output.reservations() {
-            for instance in reservation.instances() {
-                let Some(instance_id) = instance.instance_id() else {
-                    warn!("EC2 instance returned with no ID, skipping");
-                    continue;
-                };
-                let Some(private_ip_str) = instance.private_ip_address() else {
-                    warn!(instance_id = %instance_id, "EC2 instance has no private IP, skipping");
-                    continue;
-                };
-                pairs.push((instance_id.to_string(), private_ip_str.to_string()));
-            }
-        }
+        let instance_ips: HashMap<String, String> = ec2_resp
+            .reservations()
+            .iter()
+            .flat_map(|r| r.instances())
+            .filter_map(|i| {
+                let id = i.instance_id()?.to_string();
+                let ip = i.private_ip_address()?.to_string();
+                Some((id, ip))
+            })
+            .collect();
 
-        Ok(Self::assemble_prover_instances(&health_map, pairs))
+        Ok(Self::assemble_prover_instances(&targets, &instance_ips, self.port))
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use std::net::IpAddr;
-
     use rstest::rstest;
 
     use super::*;
 
+    fn four_replica_discovery() -> K8sStatefulSetDiscovery {
+        K8sStatefulSetDiscovery::new(
+            "prover".into(),
+            "prover-headless".into(),
+            "provers".into(),
+            4,
+            8000,
+        )
+    }
+
+    #[test]
+    fn pod_endpoint_ordinal_zero() {
+        assert_eq!(
+            four_replica_discovery().pod_endpoint(0),
+            "prover-0.prover-headless.provers.svc.cluster.local:8000"
+        );
+    }
+
+    #[test]
+    fn pod_endpoint_last_ordinal() {
+        assert_eq!(
+            four_replica_discovery().pod_endpoint(3),
+            "prover-3.prover-headless.provers.svc.cluster.local:8000"
+        );
+    }
+
     #[rstest]
-    #[case::initial("initial", InstanceHealthStatus::Initial)]
-    #[case::healthy("healthy", InstanceHealthStatus::Healthy)]
-    #[case::draining("draining", InstanceHealthStatus::Draining)]
-    #[case::unhealthy("unhealthy", InstanceHealthStatus::Unhealthy)]
-    #[case::unknown_unavailable("unavailable", InstanceHealthStatus::Unhealthy)]
-    #[case::unknown_empty("", InstanceHealthStatus::Unhealthy)]
-    #[case::unknown_bogus("bogus", InstanceHealthStatus::Unhealthy)]
-    fn from_aws_state(#[case] input: &str, #[case] expected: InstanceHealthStatus) {
-        assert_eq!(InstanceHealthStatus::from_aws_state(input), expected);
+    #[case::zero(0)]
+    #[case::one(1)]
+    #[case::four(4)]
+    #[tokio::test]
+    async fn discover_instances_returns_one_per_replica(#[case] replicas: usize) {
+        let d = K8sStatefulSetDiscovery::new(
+            "prover".into(),
+            "prover-headless".into(),
+            "provers".into(),
+            replicas,
+            8000,
+        );
+        let instances = d.discover_instances().await.unwrap();
+        assert_eq!(instances.len(), replicas);
     }
 
-    #[test]
-    fn assemble_empty_pairs_returns_empty() {
-        let health_map = HashMap::new();
-        assert!(AwsTargetGroupDiscovery::assemble_prover_instances(&health_map, vec![]).is_empty());
+    #[tokio::test]
+    async fn all_discovered_instances_are_healthy() {
+        let instances = four_replica_discovery().discover_instances().await.unwrap();
+        assert!(instances.iter().all(|i| i.health_status == InstanceHealthStatus::Healthy));
     }
 
-    #[test]
-    fn assemble_invalid_ip_is_skipped() {
-        let health_map = HashMap::new();
-        let pairs = vec![("i-123".to_string(), "not-an-ip".to_string())];
-        assert!(AwsTargetGroupDiscovery::assemble_prover_instances(&health_map, pairs).is_empty());
+    #[tokio::test]
+    async fn instance_ids_match_pod_endpoints() {
+        let d = four_replica_discovery();
+        let instances = d.discover_instances().await.unwrap();
+        for (i, inst) in instances.iter().enumerate() {
+            assert_eq!(inst.instance_id, d.pod_endpoint(i));
+        }
     }
 
-    #[test]
-    fn assemble_instance_not_in_health_map_defaults_to_unhealthy() {
-        let health_map = HashMap::new();
-        let pairs = vec![("i-123".to_string(), "10.0.0.1".to_string())];
-        let result = AwsTargetGroupDiscovery::assemble_prover_instances(&health_map, pairs);
-        assert_eq!(result.len(), 1);
-        assert_eq!(result[0].instance_id, "i-123");
-        assert_eq!(result[0].health_status, InstanceHealthStatus::Unhealthy);
+    #[tokio::test]
+    async fn endpoints_match_pod_endpoints() {
+        let d = four_replica_discovery();
+        let instances = d.discover_instances().await.unwrap();
+        for (i, inst) in instances.iter().enumerate() {
+            assert_eq!(inst.endpoint, d.pod_endpoint(i));
+        }
     }
 
-    #[test]
-    fn assemble_health_status_is_looked_up_from_map() {
-        let mut health_map = HashMap::new();
-        health_map.insert("i-abc".to_string(), InstanceHealthStatus::Healthy);
-        health_map.insert("i-def".to_string(), InstanceHealthStatus::Initial);
-        let pairs = vec![
-            ("i-abc".to_string(), "10.0.0.1".to_string()),
-            ("i-def".to_string(), "10.0.0.2".to_string()),
-        ];
-        let result = AwsTargetGroupDiscovery::assemble_prover_instances(&health_map, pairs);
-        assert_eq!(result.len(), 2);
-        assert_eq!(result[0].health_status, InstanceHealthStatus::Healthy);
-        assert_eq!(result[1].health_status, InstanceHealthStatus::Initial);
-    }
+    mod aws {
+        use super::*;
 
-    #[test]
-    fn assemble_parses_ipv4_address() {
-        let health_map = HashMap::new();
-        let pairs = vec![("i-123".to_string(), "192.168.1.100".to_string())];
-        let result = AwsTargetGroupDiscovery::assemble_prover_instances(&health_map, pairs);
-        assert_eq!(result.len(), 1);
-        assert_eq!(result[0].private_ip, "192.168.1.100".parse::<IpAddr>().unwrap());
-    }
+        fn make_ips(pairs: &[(&str, &str)]) -> HashMap<String, String> {
+            pairs.iter().map(|(id, ip)| (id.to_string(), ip.to_string())).collect()
+        }
 
-    #[test]
-    fn assemble_invalid_ip_does_not_affect_valid_pairs() {
-        let health_map = HashMap::new();
-        let pairs = vec![
-            ("i-bad".to_string(), "not-an-ip".to_string()),
-            ("i-good".to_string(), "10.0.0.5".to_string()),
-        ];
-        let result = AwsTargetGroupDiscovery::assemble_prover_instances(&health_map, pairs);
-        assert_eq!(result.len(), 1);
-        assert_eq!(result[0].instance_id, "i-good");
+        fn make_targets(
+            pairs: &[(&str, InstanceHealthStatus)],
+        ) -> Vec<(String, InstanceHealthStatus)> {
+            pairs.iter().map(|(id, s)| (id.to_string(), *s)).collect()
+        }
+
+        #[test]
+        fn assemble_healthy_instance_produces_correct_endpoint() {
+            let targets = make_targets(&[("i-001", InstanceHealthStatus::Healthy)]);
+            let ips = make_ips(&[("i-001", "10.0.0.1")]);
+            let instances =
+                AwsTargetGroupDiscovery::assemble_prover_instances(&targets, &ips, 8000);
+            assert_eq!(instances.len(), 1);
+            assert_eq!(instances[0].instance_id, "i-001");
+            assert_eq!(instances[0].endpoint, "10.0.0.1:8000");
+        }
+
+        #[test]
+        fn assemble_initial_instance_is_included() {
+            let targets = make_targets(&[("i-002", InstanceHealthStatus::Initial)]);
+            let ips = make_ips(&[("i-002", "10.0.0.2")]);
+            let instances =
+                AwsTargetGroupDiscovery::assemble_prover_instances(&targets, &ips, 8000);
+            assert_eq!(instances.len(), 1);
+            assert_eq!(instances[0].instance_id, "i-002");
+        }
+
+        #[test]
+        fn assemble_excludes_unhealthy() {
+            let targets = make_targets(&[("i-003", InstanceHealthStatus::Unhealthy)]);
+            let ips = make_ips(&[("i-003", "10.0.0.3")]);
+            let instances =
+                AwsTargetGroupDiscovery::assemble_prover_instances(&targets, &ips, 8000);
+            assert!(instances.is_empty());
+        }
+
+        #[test]
+        fn assemble_excludes_draining() {
+            let targets = make_targets(&[("i-004", InstanceHealthStatus::Draining)]);
+            let ips = make_ips(&[("i-004", "10.0.0.4")]);
+            let instances =
+                AwsTargetGroupDiscovery::assemble_prover_instances(&targets, &ips, 8000);
+            assert!(instances.is_empty());
+        }
+
+        #[test]
+        fn assemble_drops_instance_missing_from_ip_map() {
+            let targets = make_targets(&[("i-005", InstanceHealthStatus::Healthy)]);
+            let ips = HashMap::new();
+            let instances =
+                AwsTargetGroupDiscovery::assemble_prover_instances(&targets, &ips, 8000);
+            assert!(instances.is_empty());
+        }
+
+        #[test]
+        fn assemble_empty_targets_returns_empty() {
+            let instances =
+                AwsTargetGroupDiscovery::assemble_prover_instances(&[], &HashMap::new(), 8000);
+            assert!(instances.is_empty());
+        }
+
+        #[test]
+        fn assemble_port_appears_in_endpoint() {
+            let targets = make_targets(&[("i-006", InstanceHealthStatus::Healthy)]);
+            let ips = make_ips(&[("i-006", "10.0.0.6")]);
+            let instances =
+                AwsTargetGroupDiscovery::assemble_prover_instances(&targets, &ips, 9999);
+            assert_eq!(instances[0].endpoint, "10.0.0.6:9999");
+        }
+
+        #[test]
+        fn assemble_mixed_statuses_only_includes_registerable() {
+            let targets = make_targets(&[
+                ("i-010", InstanceHealthStatus::Healthy),
+                ("i-011", InstanceHealthStatus::Initial),
+                ("i-012", InstanceHealthStatus::Unhealthy),
+                ("i-013", InstanceHealthStatus::Draining),
+            ]);
+            let ips = make_ips(&[
+                ("i-010", "10.0.1.0"),
+                ("i-011", "10.0.1.1"),
+                ("i-012", "10.0.1.2"),
+                ("i-013", "10.0.1.3"),
+            ]);
+            let instances =
+                AwsTargetGroupDiscovery::assemble_prover_instances(&targets, &ips, 8000);
+            assert_eq!(instances.len(), 2);
+            let ids: Vec<&str> = instances.iter().map(|i| i.instance_id.as_str()).collect();
+            assert!(ids.contains(&"i-010"));
+            assert!(ids.contains(&"i-011"));
+        }
     }
 }

--- a/crates/proof/tee/registrar/src/discovery.rs
+++ b/crates/proof/tee/registrar/src/discovery.rs
@@ -18,7 +18,7 @@ use crate::{InstanceDiscovery, InstanceHealthStatus, ProverInstance, RegistrarEr
 /// from the `StatefulSet` name, headless service name, namespace, replica count,
 /// and port alone. K8s pod readiness gates proposal traffic independently;
 /// the registrar polls every enumerated pod each cycle regardless.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct K8sStatefulSetDiscovery {
     statefulset_name: String,
     service_name: String,
@@ -102,10 +102,13 @@ impl AwsTargetGroupDiscovery {
 
     /// Assembles [`ProverInstance`] objects from ELB target data and EC2 IP data.
     ///
-    /// Filters `targets` to those whose [`InstanceHealthStatus::should_register`]
-    /// returns `true`, then looks up the private IP in `instance_ips` to form the
-    /// `endpoint` field. Targets with no matching IP entry are silently dropped
-    /// (this can happen if an EC2 lookup fails for a specific instance).
+    /// Returns **all** discovered instances regardless of health status, matching
+    /// the behavior of `K8sStatefulSetDiscovery` which also returns every replica.
+    /// The caller (registration driver) decides which instances to act on based on
+    /// [`InstanceHealthStatus::should_register`].
+    ///
+    /// Targets with no matching IP entry are silently dropped (this can happen if
+    /// an instance was terminated between the ELB and EC2 calls).
     ///
     /// This function is a pure transformation — no AWS SDK calls are made — which
     /// makes it straightforwardly unit-testable without SDK mocks.
@@ -116,13 +119,13 @@ impl AwsTargetGroupDiscovery {
     ) -> Vec<ProverInstance> {
         targets
             .iter()
-            .filter(|(_, status)| status.should_register())
             .filter_map(|(instance_id, health_status)| {
                 let private_ip = instance_ips.get(instance_id)?;
                 let endpoint = format!("{private_ip}:{port}");
                 debug!(
                     instance_id = %instance_id,
                     endpoint = %endpoint,
+                    health = ?health_status,
                     "discovered AWS prover instance"
                 );
                 Some(ProverInstance {
@@ -185,22 +188,20 @@ impl InstanceDiscovery for AwsTargetGroupDiscovery {
         let mut targets: Vec<(String, InstanceHealthStatus)> = health_map.into_iter().collect();
         targets.sort_by(|(a, _), (b, _)| a.cmp(b));
 
-        // Collect IDs for instances that should be registered.
-        let registerable_ids: Vec<String> = targets
-            .iter()
-            .filter(|(_, status)| status.should_register())
-            .map(|(id, _)| id.clone())
-            .collect();
-
-        if registerable_ids.is_empty() {
+        if targets.is_empty() {
             return Ok(vec![]);
         }
 
-        // Resolve private IPs for registerable instances via EC2.
+        // Collect all instance IDs for EC2 lookup (not just registerable ones),
+        // so that discover_instances returns the full set — consistent with
+        // K8sStatefulSetDiscovery which returns all replicas.
+        let all_ids: Vec<String> = targets.iter().map(|(id, _)| id.clone()).collect();
+
+        // Resolve private IPs for all instances in a single EC2 call.
         let ec2_resp = self
             .ec2_client
             .describe_instances()
-            .set_instance_ids(Some(registerable_ids))
+            .set_instance_ids(Some(all_ids))
             .send()
             .await
             .map_err(|e| RegistrarError::Discovery(Box::new(e)))?;
@@ -216,11 +217,11 @@ impl InstanceDiscovery for AwsTargetGroupDiscovery {
             })
             .collect();
 
-        // Warn about registerable instances that the EC2 call didn't return
+        // Warn about instances that the EC2 call didn't return
         // (e.g. terminated between the ELB and EC2 calls, or missing a private IP).
-        for (id, _) in targets.iter().filter(|(_, s)| s.should_register()) {
+        for (id, _) in &targets {
             if !instance_ips.contains_key(id) {
-                warn!(instance_id = %id, "registerable instance missing from EC2 response, skipping");
+                warn!(instance_id = %id, "instance missing from EC2 response, skipping");
             }
         }
 
@@ -244,20 +245,11 @@ mod tests {
         )
     }
 
-    #[test]
-    fn pod_endpoint_ordinal_zero() {
-        assert_eq!(
-            four_replica_discovery().pod_endpoint(0),
-            "prover-0.prover-headless.provers.svc.cluster.local:8000"
-        );
-    }
-
-    #[test]
-    fn pod_endpoint_last_ordinal() {
-        assert_eq!(
-            four_replica_discovery().pod_endpoint(3),
-            "prover-3.prover-headless.provers.svc.cluster.local:8000"
-        );
+    #[rstest]
+    #[case::ordinal_zero(0, "prover-0.prover-headless.provers.svc.cluster.local:8000")]
+    #[case::last_ordinal(3, "prover-3.prover-headless.provers.svc.cluster.local:8000")]
+    fn pod_endpoint_format(#[case] ordinal: usize, #[case] expected: &str) {
+        assert_eq!(four_replica_discovery().pod_endpoint(ordinal), expected);
     }
 
     #[rstest]
@@ -314,43 +306,24 @@ mod tests {
             pairs.iter().map(|(id, s)| (id.to_string(), *s)).collect()
         }
 
-        #[test]
-        fn assemble_healthy_instance_produces_correct_endpoint() {
-            let targets = make_targets(&[("i-001", InstanceHealthStatus::Healthy)]);
-            let ips = make_ips(&[("i-001", "10.0.0.1")]);
+        #[rstest]
+        #[case::healthy("i-001", "10.0.0.1", InstanceHealthStatus::Healthy)]
+        #[case::initial("i-002", "10.0.0.2", InstanceHealthStatus::Initial)]
+        #[case::unhealthy("i-003", "10.0.0.3", InstanceHealthStatus::Unhealthy)]
+        #[case::draining("i-004", "10.0.0.4", InstanceHealthStatus::Draining)]
+        fn assemble_single_instance_preserves_status(
+            #[case] id: &str,
+            #[case] ip: &str,
+            #[case] status: InstanceHealthStatus,
+        ) {
+            let targets = make_targets(&[(id, status)]);
+            let ips = make_ips(&[(id, ip)]);
             let instances =
                 AwsTargetGroupDiscovery::assemble_prover_instances(&targets, &ips, 8000);
             assert_eq!(instances.len(), 1);
-            assert_eq!(instances[0].instance_id, "i-001");
-            assert_eq!(instances[0].endpoint, "10.0.0.1:8000");
-        }
-
-        #[test]
-        fn assemble_initial_instance_is_included() {
-            let targets = make_targets(&[("i-002", InstanceHealthStatus::Initial)]);
-            let ips = make_ips(&[("i-002", "10.0.0.2")]);
-            let instances =
-                AwsTargetGroupDiscovery::assemble_prover_instances(&targets, &ips, 8000);
-            assert_eq!(instances.len(), 1);
-            assert_eq!(instances[0].instance_id, "i-002");
-        }
-
-        #[test]
-        fn assemble_excludes_unhealthy() {
-            let targets = make_targets(&[("i-003", InstanceHealthStatus::Unhealthy)]);
-            let ips = make_ips(&[("i-003", "10.0.0.3")]);
-            let instances =
-                AwsTargetGroupDiscovery::assemble_prover_instances(&targets, &ips, 8000);
-            assert!(instances.is_empty());
-        }
-
-        #[test]
-        fn assemble_excludes_draining() {
-            let targets = make_targets(&[("i-004", InstanceHealthStatus::Draining)]);
-            let ips = make_ips(&[("i-004", "10.0.0.4")]);
-            let instances =
-                AwsTargetGroupDiscovery::assemble_prover_instances(&targets, &ips, 8000);
-            assert!(instances.is_empty());
+            assert_eq!(instances[0].instance_id, id);
+            assert_eq!(instances[0].endpoint, format!("{ip}:8000"));
+            assert_eq!(instances[0].health_status, status);
         }
 
         #[test]
@@ -379,7 +352,7 @@ mod tests {
         }
 
         #[test]
-        fn assemble_mixed_statuses_only_includes_registerable() {
+        fn assemble_returns_all_statuses() {
             let targets = make_targets(&[
                 ("i-010", InstanceHealthStatus::Healthy),
                 ("i-011", InstanceHealthStatus::Initial),
@@ -394,10 +367,7 @@ mod tests {
             ]);
             let instances =
                 AwsTargetGroupDiscovery::assemble_prover_instances(&targets, &ips, 8000);
-            assert_eq!(instances.len(), 2);
-            let ids: Vec<&str> = instances.iter().map(|i| i.instance_id.as_str()).collect();
-            assert!(ids.contains(&"i-010"));
-            assert!(ids.contains(&"i-011"));
+            assert_eq!(instances.len(), 4);
         }
     }
 }

--- a/crates/proof/tee/registrar/src/discovery.rs
+++ b/crates/proof/tee/registrar/src/discovery.rs
@@ -5,7 +5,7 @@ use std::collections::HashMap;
 use async_trait::async_trait;
 use aws_sdk_ec2::Client as Ec2Client;
 use aws_sdk_elasticloadbalancingv2::Client as ElbClient;
-use tracing::debug;
+use tracing::{debug, warn};
 
 use crate::{InstanceDiscovery, InstanceHealthStatus, ProverInstance, RegistrarError, Result};
 
@@ -52,6 +52,13 @@ impl K8sStatefulSetDiscovery {
 
 #[async_trait]
 impl InstanceDiscovery for K8sStatefulSetDiscovery {
+    /// Returns one [`ProverInstance`] per replica, all marked [`InstanceHealthStatus::Healthy`].
+    ///
+    /// Unlike the AWS path where the ALB provides real health status, K8s discovery
+    /// has no liveness signal — pod DNS names are deterministic regardless of
+    /// whether a pod is actually running. The registrar's downstream poll loop
+    /// (`ProverClient`) handles unreachable pods by returning connection errors,
+    /// which the driver treats as per-instance failures without stopping the cycle.
     async fn discover_instances(&self) -> Result<Vec<ProverInstance>> {
         let instances = (0..self.replicas)
             .map(|i| {
@@ -141,16 +148,41 @@ impl InstanceDiscovery for AwsTargetGroupDiscovery {
             .map_err(|e| RegistrarError::Discovery(Box::new(e)))?;
 
         // Extract (instance_id, health_status) pairs from the ELB response.
-        let targets: Vec<(String, InstanceHealthStatus)> = elb_resp
-            .target_health_descriptions()
-            .iter()
-            .filter_map(|t| {
-                let instance_id = t.target()?.id()?.to_string();
-                let state = t.target_health()?.state()?;
-                let health_status = InstanceHealthStatus::from_aws_state(state.as_str());
-                Some((instance_id, health_status))
-            })
-            .collect();
+        // Validates that targets are instance-type (id starts with "i-") and
+        // deduplicates instances registered on multiple ports (first-seen wins).
+        let mut health_map: HashMap<String, InstanceHealthStatus> = HashMap::new();
+        for desc in elb_resp.target_health_descriptions() {
+            let Some(instance_id) = desc.target().and_then(|t| t.id()) else {
+                warn!("target group entry missing instance ID, skipping");
+                continue;
+            };
+            if !instance_id.starts_with("i-") {
+                warn!(
+                    id = %instance_id,
+                    "target is not an instance-type target (id does not start with \
+                     'i-'); is the target group type set to 'instance'? skipping"
+                );
+                continue;
+            }
+            let health_status = desc
+                .target_health()
+                .and_then(|h| h.state())
+                .map(|s| InstanceHealthStatus::from_aws_state(s.as_str()))
+                .unwrap_or(InstanceHealthStatus::Unhealthy);
+
+            if let std::collections::hash_map::Entry::Vacant(e) =
+                health_map.entry(instance_id.to_string())
+            {
+                e.insert(health_status);
+            } else {
+                debug!(
+                    instance_id = %instance_id,
+                    "instance registered on multiple ports; keeping first-seen health status"
+                );
+            }
+        }
+
+        let targets: Vec<(String, InstanceHealthStatus)> = health_map.into_iter().collect();
 
         // Collect IDs for instances that should be registered.
         let registerable_ids: Vec<String> = targets

--- a/crates/proof/tee/registrar/src/discovery.rs
+++ b/crates/proof/tee/registrar/src/discovery.rs
@@ -7,7 +7,10 @@ use aws_sdk_ec2::Client as Ec2Client;
 use aws_sdk_elasticloadbalancingv2::Client as ElbClient;
 use tracing::{debug, warn};
 
-use crate::{InstanceDiscovery, InstanceHealthStatus, ProverInstance, RegistrarError, Result};
+use crate::{
+    InstanceDiscovery, InstanceHealthStatus, K8sDiscoveryConfig, ProverInstance, RegistrarError,
+    Result,
+};
 
 /// Discovers prover pods by enumerating a K8s `StatefulSet`'s deterministic DNS names.
 ///
@@ -18,25 +21,17 @@ use crate::{InstanceDiscovery, InstanceHealthStatus, ProverInstance, RegistrarEr
 /// from the `StatefulSet` name, headless service name, namespace, replica count,
 /// and port alone. K8s pod readiness gates proposal traffic independently;
 /// the registrar polls every enumerated pod each cycle regardless.
-#[derive(Debug, Clone)]
+///
+/// Constructed from a [`K8sDiscoveryConfig`] via [`Self::from_config`].
+#[derive(Debug)]
 pub struct K8sStatefulSetDiscovery {
-    statefulset_name: String,
-    service_name: String,
-    namespace: String,
-    replicas: usize,
-    port: u16,
+    config: K8sDiscoveryConfig,
 }
 
 impl K8sStatefulSetDiscovery {
-    /// Creates a new discovery instance for the given `StatefulSet`.
-    pub const fn new(
-        statefulset_name: String,
-        service_name: String,
-        namespace: String,
-        replicas: usize,
-        port: u16,
-    ) -> Self {
-        Self { statefulset_name, service_name, namespace, replicas, port }
+    /// Creates a new discovery instance from the given config.
+    pub const fn from_config(config: K8sDiscoveryConfig) -> Self {
+        Self { config }
     }
 
     /// Returns the pod DNS endpoint for replica index `i`.
@@ -45,7 +40,11 @@ impl K8sStatefulSetDiscovery {
     pub fn pod_endpoint(&self, i: usize) -> String {
         format!(
             "{}-{}.{}.{}.svc.cluster.local:{}",
-            self.statefulset_name, i, self.service_name, self.namespace, self.port
+            self.config.statefulset_name,
+            i,
+            self.config.service_name,
+            self.config.namespace,
+            self.config.port
         )
     }
 }
@@ -60,7 +59,7 @@ impl InstanceDiscovery for K8sStatefulSetDiscovery {
     /// (`ProverClient`) handles unreachable pods by returning connection errors,
     /// which the driver treats as per-instance failures without stopping the cycle.
     async fn discover_instances(&self) -> Result<Vec<ProverInstance>> {
-        let instances = (0..self.replicas)
+        let instances = (0..self.config.replicas)
             .map(|i| {
                 let endpoint = self.pod_endpoint(i);
                 debug!(pod = %endpoint, "discovered prover pod");
@@ -236,13 +235,13 @@ mod tests {
     use super::*;
 
     fn four_replica_discovery() -> K8sStatefulSetDiscovery {
-        K8sStatefulSetDiscovery::new(
-            "prover".into(),
-            "prover-headless".into(),
-            "provers".into(),
-            4,
-            8000,
-        )
+        K8sStatefulSetDiscovery::from_config(K8sDiscoveryConfig {
+            statefulset_name: "prover".into(),
+            service_name: "prover-headless".into(),
+            namespace: "provers".into(),
+            replicas: 4,
+            port: 8000,
+        })
     }
 
     #[rstest]
@@ -258,13 +257,13 @@ mod tests {
     #[case::four(4)]
     #[tokio::test]
     async fn discover_instances_returns_one_per_replica(#[case] replicas: usize) {
-        let d = K8sStatefulSetDiscovery::new(
-            "prover".into(),
-            "prover-headless".into(),
-            "provers".into(),
+        let d = K8sStatefulSetDiscovery::from_config(K8sDiscoveryConfig {
+            statefulset_name: "prover".into(),
+            service_name: "prover-headless".into(),
+            namespace: "provers".into(),
             replicas,
-            8000,
-        );
+            port: 8000,
+        });
         let instances = d.discover_instances().await.unwrap();
         assert_eq!(instances.len(), replicas);
     }

--- a/crates/proof/tee/registrar/src/discovery.rs
+++ b/crates/proof/tee/registrar/src/discovery.rs
@@ -216,6 +216,14 @@ impl InstanceDiscovery for AwsTargetGroupDiscovery {
             })
             .collect();
 
+        // Warn about registerable instances that the EC2 call didn't return
+        // (e.g. terminated between the ELB and EC2 calls, or missing a private IP).
+        for (id, _) in targets.iter().filter(|(_, s)| s.should_register()) {
+            if !instance_ips.contains_key(id) {
+                warn!(instance_id = %id, "registerable instance missing from EC2 response, skipping");
+            }
+        }
+
         Ok(Self::assemble_prover_instances(&targets, &instance_ips, self.port))
     }
 }

--- a/crates/proof/tee/registrar/src/discovery.rs
+++ b/crates/proof/tee/registrar/src/discovery.rs
@@ -25,7 +25,8 @@ use crate::{
 /// Constructed from a [`K8sDiscoveryConfig`] via [`Self::from_config`].
 #[derive(Debug)]
 pub struct K8sStatefulSetDiscovery {
-    config: K8sDiscoveryConfig,
+    /// The K8s `StatefulSet` discovery configuration.
+    pub config: K8sDiscoveryConfig,
 }
 
 impl K8sStatefulSetDiscovery {

--- a/crates/proof/tee/registrar/src/lib.rs
+++ b/crates/proof/tee/registrar/src/lib.rs
@@ -2,10 +2,12 @@
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
 
 mod config;
-pub use config::{BoundlessConfig, RegistrarConfig, RemoteSignerConfig, SigningConfig};
+pub use config::{
+    BoundlessConfig, DiscoveryConfig, RegistrarConfig, RemoteSignerConfig, SigningConfig,
+};
 
 mod discovery;
-pub use discovery::AwsTargetGroupDiscovery;
+pub use discovery::{AwsTargetGroupDiscovery, K8sStatefulSetDiscovery};
 
 mod error;
 pub use error::{RegistrarError, Result};

--- a/crates/proof/tee/registrar/src/lib.rs
+++ b/crates/proof/tee/registrar/src/lib.rs
@@ -3,7 +3,8 @@
 
 mod config;
 pub use config::{
-    BoundlessConfig, DiscoveryConfig, RegistrarConfig, RemoteSignerConfig, SigningConfig,
+    AwsDiscoveryConfig, BoundlessConfig, DiscoveryConfig, RegistrarConfig, RemoteSignerConfig,
+    SigningConfig,
 };
 
 mod discovery;

--- a/crates/proof/tee/registrar/src/lib.rs
+++ b/crates/proof/tee/registrar/src/lib.rs
@@ -3,8 +3,8 @@
 
 mod config;
 pub use config::{
-    AwsDiscoveryConfig, BoundlessConfig, DiscoveryConfig, RegistrarConfig, RemoteSignerConfig,
-    SigningConfig,
+    AwsDiscoveryConfig, BoundlessConfig, DiscoveryConfig, K8sDiscoveryConfig, RegistrarConfig,
+    RemoteSignerConfig, SigningConfig,
 };
 
 mod discovery;

--- a/crates/proof/tee/registrar/src/traits.rs
+++ b/crates/proof/tee/registrar/src/traits.rs
@@ -4,9 +4,10 @@ use crate::{AttestationProof, ProverInstance, Result};
 
 /// Discovers active prover instances from the infrastructure layer.
 ///
-/// The primary implementation is `AwsTargetGroupDiscovery`, which queries
-/// an ALB target group via the AWS SDK. Other implementations (e.g., a static
-/// list for local testing) can be substituted.
+/// Implementations: [`K8sStatefulSetDiscovery`] (K8s `StatefulSet` DNS enumeration)
+/// and [`AwsTargetGroupDiscovery`] (AWS ALB target group polling). Selected at
+/// runtime via `--discovery-mode`. A static list implementation may be substituted
+/// for local testing.
 #[async_trait]
 pub trait InstanceDiscovery: Send + Sync {
     /// Return the current set of prover instances with their health status.

--- a/crates/proof/tee/registrar/src/types.rs
+++ b/crates/proof/tee/registrar/src/types.rs
@@ -54,60 +54,29 @@ impl InstanceHealthStatus {
 
 #[cfg(test)]
 mod tests {
+    use rstest::rstest;
+
     use super::*;
 
-    #[test]
-    fn healthy_should_register() {
-        assert!(InstanceHealthStatus::Healthy.should_register());
+    #[rstest]
+    #[case::initial(InstanceHealthStatus::Initial, true)]
+    #[case::healthy(InstanceHealthStatus::Healthy, true)]
+    #[case::unhealthy(InstanceHealthStatus::Unhealthy, false)]
+    #[case::draining(InstanceHealthStatus::Draining, false)]
+    fn should_register(#[case] status: InstanceHealthStatus, #[case] expected: bool) {
+        assert_eq!(status.should_register(), expected);
     }
 
-    #[test]
-    fn initial_should_register() {
-        assert!(InstanceHealthStatus::Initial.should_register());
-    }
-
-    #[test]
-    fn unhealthy_should_not_register() {
-        assert!(!InstanceHealthStatus::Unhealthy.should_register());
-    }
-
-    #[test]
-    fn draining_should_not_register() {
-        assert!(!InstanceHealthStatus::Draining.should_register());
-    }
-
-    #[test]
-    fn from_aws_state_initial() {
-        assert_eq!(InstanceHealthStatus::from_aws_state("initial"), InstanceHealthStatus::Initial);
-    }
-
-    #[test]
-    fn from_aws_state_healthy() {
-        assert_eq!(InstanceHealthStatus::from_aws_state("healthy"), InstanceHealthStatus::Healthy);
-    }
-
-    #[test]
-    fn from_aws_state_draining() {
-        assert_eq!(
-            InstanceHealthStatus::from_aws_state("draining"),
-            InstanceHealthStatus::Draining
-        );
-    }
-
-    #[test]
-    fn from_aws_state_unhealthy() {
-        assert_eq!(
-            InstanceHealthStatus::from_aws_state("unhealthy"),
-            InstanceHealthStatus::Unhealthy
-        );
-    }
-
-    #[test]
-    fn from_aws_state_unknown_maps_to_unhealthy() {
-        assert_eq!(
-            InstanceHealthStatus::from_aws_state("unavailable"),
-            InstanceHealthStatus::Unhealthy
-        );
+    #[rstest]
+    #[case::initial("initial", InstanceHealthStatus::Initial)]
+    #[case::healthy("healthy", InstanceHealthStatus::Healthy)]
+    #[case::draining("draining", InstanceHealthStatus::Draining)]
+    #[case::unhealthy("unhealthy", InstanceHealthStatus::Unhealthy)]
+    #[case::unavailable("unavailable", InstanceHealthStatus::Unhealthy)]
+    #[case::empty("", InstanceHealthStatus::Unhealthy)]
+    #[case::bogus("bogus", InstanceHealthStatus::Unhealthy)]
+    fn from_aws_state(#[case] input: &str, #[case] expected: InstanceHealthStatus) {
+        assert_eq!(InstanceHealthStatus::from_aws_state(input), expected);
     }
 }
 

--- a/crates/proof/tee/registrar/src/types.rs
+++ b/crates/proof/tee/registrar/src/types.rs
@@ -1,36 +1,47 @@
-use std::net::IpAddr;
-
 use alloy_primitives::{Address, B256, Bytes};
 
 /// A prover instance discovered from the infrastructure layer.
 #[derive(Debug, Clone)]
 pub struct ProverInstance {
-    /// AWS EC2 instance ID.
+    /// Unique identifier for the instance.
+    ///
+    /// K8s mode: pod DNS name (`{name}-{i}.{svc}.{ns}.svc.cluster.local:{port}`).
+    /// AWS mode: EC2 instance ID (e.g. `i-0abc123def456`).
     pub instance_id: String,
-    /// Private IP address of the instance within the VPC.
-    pub private_ip: IpAddr,
-    /// Current health status reported by the ALB target group.
+    /// HTTP connection endpoint used to contact the instance.
+    ///
+    /// K8s mode: same as `instance_id` (pod DNS:port).
+    /// AWS mode: private IP and port (e.g. `10.0.1.5:8000`).
+    pub endpoint: String,
+    /// Current health status of the instance.
     pub health_status: InstanceHealthStatus,
 }
 
-/// Health status of a prover instance in the ALB target group.
+/// Health status of a discovered prover instance.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum InstanceHealthStatus {
-    /// Health checks are in progress; instance is not yet receiving traffic.
+    /// ALB health checks are in progress (AWS mode only — instance just started).
     Initial,
-    /// Instance is passing health checks and receiving proposal traffic.
+    /// Instance is reachable and passing health checks.
     Healthy,
-    /// Instance is failing health checks.
+    /// Instance did not respond to the poll or is failing health checks.
     Unhealthy,
-    /// Instance is being decommissioned.
+    /// ALB is draining connections from this instance (AWS mode only).
     Draining,
 }
 
 impl InstanceHealthStatus {
-    /// Maps an AWS ALB target health state string to [`InstanceHealthStatus`].
+    /// Returns `true` if the instance should be registered on-chain.
     ///
-    /// Unknown or unrecognised states are treated as [`Self::Unhealthy`] to avoid
-    /// routing work to targets whose status cannot be determined.
+    /// Both `Initial` (AWS warm-up) and `Healthy` instances are candidates for
+    /// registration. `Unhealthy` and `Draining` instances are not.
+    pub const fn should_register(&self) -> bool {
+        matches!(self, Self::Initial | Self::Healthy)
+    }
+
+    /// Maps an AWS ELB target health state string to [`InstanceHealthStatus`].
+    ///
+    /// Used by `AwsTargetGroupDiscovery` to convert `describe_target_health` responses.
     pub fn from_aws_state(state: &str) -> Self {
         match state {
             "initial" => Self::Initial,
@@ -39,10 +50,64 @@ impl InstanceHealthStatus {
             _ => Self::Unhealthy,
         }
     }
+}
 
-    /// Returns `true` if the instance should be registered (initial or healthy).
-    pub const fn should_register(&self) -> bool {
-        matches!(self, Self::Initial | Self::Healthy)
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn healthy_should_register() {
+        assert!(InstanceHealthStatus::Healthy.should_register());
+    }
+
+    #[test]
+    fn initial_should_register() {
+        assert!(InstanceHealthStatus::Initial.should_register());
+    }
+
+    #[test]
+    fn unhealthy_should_not_register() {
+        assert!(!InstanceHealthStatus::Unhealthy.should_register());
+    }
+
+    #[test]
+    fn draining_should_not_register() {
+        assert!(!InstanceHealthStatus::Draining.should_register());
+    }
+
+    #[test]
+    fn from_aws_state_initial() {
+        assert_eq!(InstanceHealthStatus::from_aws_state("initial"), InstanceHealthStatus::Initial);
+    }
+
+    #[test]
+    fn from_aws_state_healthy() {
+        assert_eq!(InstanceHealthStatus::from_aws_state("healthy"), InstanceHealthStatus::Healthy);
+    }
+
+    #[test]
+    fn from_aws_state_draining() {
+        assert_eq!(
+            InstanceHealthStatus::from_aws_state("draining"),
+            InstanceHealthStatus::Draining
+        );
+    }
+
+    #[test]
+    fn from_aws_state_unhealthy() {
+        assert_eq!(
+            InstanceHealthStatus::from_aws_state("unhealthy"),
+            InstanceHealthStatus::Unhealthy
+        );
+    }
+
+    #[test]
+    fn from_aws_state_unknown_maps_to_unhealthy() {
+        assert_eq!(
+            InstanceHealthStatus::from_aws_state("unavailable"),
+            InstanceHealthStatus::Unhealthy
+        );
     }
 }
 


### PR DESCRIPTION
## Summary

Adds `K8sStatefulSetDiscovery` alongside the existing `AwsTargetGroupDiscovery`, with both backends selectable at runtime via `--discovery-mode k8s|aws`.

- **`types.rs`**: Add `endpoint: String` to `ProverInstance` so downstream code is backend-agnostic; restore `Initial`/`Draining` variants and `from_aws_state` to `InstanceHealthStatus`; `should_register()` now matches `Initial | Healthy`
- **`discovery.rs`**: `K8sStatefulSetDiscovery` enumerates pods by deterministic DNS (`{name}-{i}.{svc}.{ns}.svc.cluster.local:{port}`), no AWS SDK calls; `AwsTargetGroupDiscovery` restored with `assemble_prover_instances` as a pure static function (testable without SDK mocks)
- **`config.rs`**: `DiscoveryConfig` enum (`K8s { ... }` / `Aws { ... }`) replaces the flat K8s fields on `RegistrarConfig`
- **`cli.rs`**: `--discovery-mode k8s|aws` flag added; K8s and AWS args are `Option<T>` with `required_if_eq` so only the active mode's args are required
- AWS SDK deps (`aws-sdk-ec2`, `aws-sdk-elasticloadbalancingv2`) restored to workspace and crate `Cargo.toml`

## Test plan

- [x] `cargo clippy -p base-proof-tee-registrar -p base-proof-tee-registrar-bin -- -D warnings` passes clean
- [x] `cargo test -p base-proof-tee-registrar -p base-proof-tee-registrar-bin` — 46 tests, all passing
- [x] K8s args required when `--discovery-mode k8s`, rejected when `--discovery-mode aws`
- [x] AWS args required when `--discovery-mode aws`, rejected when `--discovery-mode k8s`

Closes CHAIN-3482