### PR TITLE
chore(actions): deduplicate RollupConfig builder into TestRollupConfigBuilder

### DIFF
--- a/actions/harness/Cargo.toml
+++ b/actions/harness/Cargo.toml
@@ -31,11 +31,11 @@ base-alloy-consensus = { workspace = true, features = ["std", "evm"] }
 base-execution-chainspec.workspace = true
 base-consensus-genesis = { workspace = true, features = ["std"] }
 base-consensus-derive = { workspace = true, features = ["test-utils"] }
+base-consensus-registry.workspace = true
 base-blobs.workspace = true
 base-comp = { workspace = true, features = ["std"] }
 base-batcher-encoder.workspace = true
 
 [dev-dependencies]
 base-batcher-core.workspace = true
-base-consensus-registry.workspace = true
 tokio = { workspace = true, features = ["rt", "macros"] }

--- a/actions/harness/src/lib.rs
+++ b/actions/harness/src/lib.rs
@@ -20,6 +20,9 @@ pub use harness::ActionTestHarness;
 mod batcher;
 pub use batcher::{BatchType, Batcher, BatcherConfig, BatcherError, GarbageKind};
 
+mod test_rollup_config;
+pub use test_rollup_config::TestRollupConfigBuilder;
+
 mod providers;
 pub use providers::{
     ActionBlobDataSource, ActionBlobProvider, ActionDataSource, ActionL1ChainProvider,

--- a/actions/harness/src/test_rollup_config.rs
+++ b/actions/harness/src/test_rollup_config.rs
@@ -1,0 +1,77 @@
+use base_consensus_genesis::{BaseHardforkConfig, RollupConfig};
+use base_consensus_registry::Registry;
+
+use crate::BatcherConfig;
+
+/// Builder for the mainnet-derived [`RollupConfig`] values used by harness tests.
+#[derive(Debug, Clone)]
+pub struct TestRollupConfigBuilder {
+    config: RollupConfig,
+}
+
+impl TestRollupConfigBuilder {
+    /// Starts from the Base mainnet config and applies the common harness overrides.
+    ///
+    /// This preserves the existing harness-test behavior by wiring the test batcher
+    /// addresses, zeroing genesis for the in-memory L1 miner, and activating the
+    /// Canyon-through-Fjord path from genesis.
+    pub fn base_mainnet(batcher: &BatcherConfig) -> Self {
+        let mut config = Registry::rollup_config(8453)
+            .expect("Base mainnet config must exist in the registry")
+            .clone();
+
+        config.batch_inbox_address = batcher.inbox_address;
+        config
+            .genesis
+            .system_config
+            .as_mut()
+            .expect("Base mainnet config must define a system config")
+            .batcher_address = batcher.batcher_address;
+        config.genesis.l2_time = 0;
+        config.genesis.l1 = Default::default();
+        config.genesis.l2 = Default::default();
+        config.hardforks.canyon_time = Some(0);
+        config.hardforks.delta_time = Some(0);
+        config.hardforks.ecotone_time = Some(0);
+        config.hardforks.fjord_time = Some(0);
+
+        Self { config }
+    }
+
+    /// Overrides the channel timeout used before and after Granite activation.
+    pub fn with_channel_timeout(mut self, n: u64) -> Self {
+        self.config.channel_timeout = n;
+        self.config.granite_channel_timeout = n;
+        self
+    }
+
+    /// Overrides the pre-Fjord `max_sequencer_drift` field on the config.
+    pub fn with_max_sequencer_drift(mut self, n: u64) -> Self {
+        self.config.max_sequencer_drift = n;
+        self
+    }
+
+    /// Activates every scheduled fork from genesis for tests that need it.
+    ///
+    /// `base_mainnet` intentionally keeps the harness's existing "Canyon through
+    /// Fjord active" behavior; this opt-in extends that to the later upgrades.
+    pub fn all_forks_active(mut self) -> Self {
+        self.config.hardforks.regolith_time = Some(0);
+        self.config.hardforks.canyon_time = Some(0);
+        self.config.hardforks.delta_time = Some(0);
+        self.config.hardforks.ecotone_time = Some(0);
+        self.config.hardforks.fjord_time = Some(0);
+        self.config.hardforks.granite_time = Some(0);
+        self.config.hardforks.holocene_time = Some(0);
+        self.config.hardforks.pectra_blob_schedule_time = Some(0);
+        self.config.hardforks.isthmus_time = Some(0);
+        self.config.hardforks.jovian_time = Some(0);
+        self.config.hardforks.base.get_or_insert(BaseHardforkConfig::default()).v1 = Some(0);
+        self
+    }
+
+    /// Finalizes the builder and returns the configured rollup config.
+    pub fn build(self) -> RollupConfig {
+        self.config
+    }
+}

--- a/actions/harness/src/test_rollup_config.rs
+++ b/actions/harness/src/test_rollup_config.rs
@@ -39,14 +39,14 @@ impl TestRollupConfigBuilder {
     }
 
     /// Overrides the channel timeout used before and after Granite activation.
-    pub fn with_channel_timeout(mut self, n: u64) -> Self {
+    pub const fn with_channel_timeout(mut self, n: u64) -> Self {
         self.config.channel_timeout = n;
         self.config.granite_channel_timeout = n;
         self
     }
 
     /// Overrides the pre-Fjord `max_sequencer_drift` field on the config.
-    pub fn with_max_sequencer_drift(mut self, n: u64) -> Self {
+    pub const fn with_max_sequencer_drift(mut self, n: u64) -> Self {
         self.config.max_sequencer_drift = n;
         self
     }
@@ -66,12 +66,12 @@ impl TestRollupConfigBuilder {
         self.config.hardforks.pectra_blob_schedule_time = Some(0);
         self.config.hardforks.isthmus_time = Some(0);
         self.config.hardforks.jovian_time = Some(0);
-        self.config.hardforks.base.get_or_insert(BaseHardforkConfig::default()).v1 = Some(0);
+        self.config.hardforks.base.get_or_insert_with(BaseHardforkConfig::default).v1 = Some(0);
         self
     }
 
     /// Finalizes the builder and returns the configured rollup config.
-    pub fn build(self) -> RollupConfig {
+    pub const fn build(self) -> RollupConfig {
         self.config
     }
 }

--- a/actions/harness/tests/batcher_channels.rs
+++ b/actions/harness/tests/batcher_channels.rs
@@ -1,51 +1,9 @@
 #![doc = "TDD action test skeletons for channel timeout and interleaving scenarios."]
 
 use base_action_harness::{
-    ActionL2Source, ActionTestHarness, BatcherConfig, L1MinerConfig, SharedL1Chain, block_info_from,
+    ActionL2Source, ActionTestHarness, BatcherConfig, L1MinerConfig, SharedL1Chain,
+    TestRollupConfigBuilder, block_info_from,
 };
-use base_consensus_genesis::RollupConfig;
-use base_consensus_registry::Registry;
-
-// ---------------------------------------------------------------------------
-// Shared helpers
-// ---------------------------------------------------------------------------
-
-/// Build a [`RollupConfig`] with tight `channel_timeout` for timeout tests.
-///
-/// Starts from the real Base mainnet config. Overrides:
-/// - `channel_timeout = 2` so a channel whose first frame lands in L1 block N
-///   expires if no more frames arrive by block N+2.
-/// - Batcher actor fields, genesis, and hardfork times as in all test configs.
-fn timeout_rollup_config(batcher: &BatcherConfig) -> RollupConfig {
-    let mut rc = base_rollup_config_for(batcher);
-    rc.channel_timeout = 2;
-    rc
-}
-
-/// Build a standard [`RollupConfig`] for interleaving tests.
-///
-/// Starts from the real Base mainnet config. Uses generous windows; the test
-/// exercises the channel bank's ability to track multiple open channels rather
-/// than any timeout logic.
-fn interleave_rollup_config(batcher: &BatcherConfig) -> RollupConfig {
-    base_rollup_config_for(batcher)
-}
-
-/// Base config for all channel tests: real Base mainnet config with test actor
-/// fields and hardfork times overridden for the in-memory L1 miner.
-fn base_rollup_config_for(batcher: &BatcherConfig) -> RollupConfig {
-    let mut rc = Registry::rollup_config(8453).expect("mainnet config").clone();
-    rc.batch_inbox_address = batcher.inbox_address;
-    rc.genesis.system_config.as_mut().unwrap().batcher_address = batcher.batcher_address;
-    rc.genesis.l2_time = 0;
-    rc.genesis.l1 = Default::default();
-    rc.genesis.l2 = Default::default();
-    rc.hardforks.canyon_time = Some(0);
-    rc.hardforks.delta_time = Some(0);
-    rc.hardforks.ecotone_time = Some(0);
-    rc.hardforks.fjord_time = Some(0);
-    rc
-}
 
 // ---------------------------------------------------------------------------
 // A. Channel timeout — first frame's inclusion span exceeds channel_timeout
@@ -99,9 +57,14 @@ fn base_rollup_config_for(batcher: &BatcherConfig) -> RollupConfig {
             multi-block channel timeout is not exercisable in the current harness — \
             the test skeleton documents the expected flow for when the harness supports it"]
 async fn channel_timeout_triggers_channel_invalidation() {
-    // TODO: configure small target_frame_size via EncoderConfig to force multi-frame output.
-    let batcher_cfg = BatcherConfig::default();
-    let rollup_cfg = timeout_rollup_config(&batcher_cfg);
+    use base_batcher_encoder::EncoderConfig;
+
+    let batcher_cfg = BatcherConfig {
+        encoder: EncoderConfig { max_frame_size: 80, ..EncoderConfig::default() },
+        ..BatcherConfig::default()
+    };
+    let rollup_cfg =
+        TestRollupConfigBuilder::base_mainnet(&batcher_cfg).with_channel_timeout(2).build();
     let mut h = ActionTestHarness::new(L1MinerConfig::default(), rollup_cfg);
 
     // Build 1 L2 block and encode it into multiple frames.
@@ -209,7 +172,8 @@ async fn channel_timeout_triggers_channel_invalidation() {
             this recovery test can be enabled"]
 async fn channel_timeout_recovery_resubmits_successfully() {
     let batcher_cfg = BatcherConfig::default();
-    let rollup_cfg = timeout_rollup_config(&batcher_cfg);
+    let rollup_cfg =
+        TestRollupConfigBuilder::base_mainnet(&batcher_cfg).with_channel_timeout(2).build();
     let mut h = ActionTestHarness::new(L1MinerConfig::default(), rollup_cfg);
 
     // Build L2 block 1.
@@ -330,7 +294,7 @@ async fn interleaved_channels_correctly_reassembled() {
         encoder: EncoderConfig { max_frame_size: 80, ..EncoderConfig::default() },
         ..BatcherConfig::default()
     };
-    let rollup_cfg = interleave_rollup_config(&batcher_cfg);
+    let rollup_cfg = TestRollupConfigBuilder::base_mainnet(&batcher_cfg).build();
     let mut h = ActionTestHarness::new(L1MinerConfig::default(), rollup_cfg);
 
     let l1_chain = SharedL1Chain::from_blocks(h.l1.chain().to_vec());

--- a/actions/harness/tests/batcher_sequencer_drift.rs
+++ b/actions/harness/tests/batcher_sequencer_drift.rs
@@ -2,44 +2,9 @@
 
 use alloy_primitives::B256;
 use base_action_harness::{
-    ActionL2Source, ActionTestHarness, BatcherConfig, L1MinerConfig, SharedL1Chain, block_info_from,
+    ActionL2Source, ActionTestHarness, BatcherConfig, L1MinerConfig, SharedL1Chain,
+    TestRollupConfigBuilder, block_info_from,
 };
-use base_consensus_genesis::RollupConfig;
-use base_consensus_registry::Registry;
-
-// ---------------------------------------------------------------------------
-// Shared helpers
-// ---------------------------------------------------------------------------
-
-/// Build a [`RollupConfig`] configured for sequencer-drift tests.
-///
-/// Starts from the real Base mainnet config. Overrides:
-/// - Fjord active from genesis — the batcher uses brotli compression (channel
-///   version byte `0x01`), which the derivation pipeline only accepts after
-///   the Fjord hardfork. Fjord also hard-codes `max_sequencer_drift = 1800 s`.
-/// - `block_time = 300 s` so that exactly 6 L2 blocks fit within the 1800 s
-///   Fjord drift window when the sequencer is pinned to a stale L1 origin.
-///   L2 timestamps: 300, 600, …, 1800 (blocks 1-6 ≤ drift), 2100, 2400 (blocks
-///   7-8 > drift → deposit-only).
-/// - Batcher actor fields and genesis reset as in all test configs.
-///
-/// L1 `block_time = 4` is controlled via [`L1MinerConfig`] at the call site.
-fn drift_rollup_config(batcher: &BatcherConfig) -> RollupConfig {
-    let mut rc = Registry::rollup_config(8453).expect("mainnet config").clone();
-    rc.batch_inbox_address = batcher.inbox_address;
-    rc.genesis.system_config.as_mut().unwrap().batcher_address = batcher.batcher_address;
-    rc.genesis.l2_time = 0;
-    rc.genesis.l1 = Default::default();
-    rc.genesis.l2 = Default::default();
-    rc.hardforks.canyon_time = Some(0);
-    rc.hardforks.delta_time = Some(0);
-    rc.hardforks.ecotone_time = Some(0);
-    rc.hardforks.fjord_time = Some(0);
-    // 300 s blocks: 6 blocks × 300 s = 1800 s == Fjord max_sequencer_drift.
-    // Block 7 (ts=2100) is the first over the boundary.
-    rc.block_time = 300;
-    rc
-}
 
 // ---------------------------------------------------------------------------
 // A. Sequencer drift — L2 timestamp exceeds L1 origin time + max_sequencer_drift
@@ -74,7 +39,8 @@ fn drift_rollup_config(batcher: &BatcherConfig) -> RollupConfig {
 async fn sequencer_drift_produces_deposit_only_blocks() {
     let l1_cfg = L1MinerConfig { block_time: 4 };
     let batcher_cfg = BatcherConfig::default();
-    let rollup_cfg = drift_rollup_config(&batcher_cfg);
+    let mut rollup_cfg = TestRollupConfigBuilder::base_mainnet(&batcher_cfg).build();
+    rollup_cfg.block_time = 300;
     let mut h = ActionTestHarness::new(l1_cfg, rollup_cfg.clone());
 
     // Mine L1 block 1 (ts=4) so the sequencer has an epoch to reference,
@@ -170,7 +136,8 @@ async fn sequencer_drift_produces_deposit_only_blocks() {
 async fn sequencer_drift_forced_empty_blocks_accepted() {
     let l1_cfg = L1MinerConfig { block_time: 4 };
     let batcher_cfg = BatcherConfig::default();
-    let rollup_cfg = drift_rollup_config(&batcher_cfg);
+    let mut rollup_cfg = TestRollupConfigBuilder::base_mainnet(&batcher_cfg).build();
+    rollup_cfg.block_time = 300;
     let mut h = ActionTestHarness::new(l1_cfg, rollup_cfg);
 
     // Mine 1 L1 block so epoch 1 exists, but pin sequencer to epoch 0.

--- a/actions/harness/tests/derivation.rs
+++ b/actions/harness/tests/derivation.rs
@@ -7,49 +7,22 @@ use alloy_primitives::{Address, B256, Bytes, LogData, U256};
 use base_action_harness::{
     ActionDataSource, ActionL1ChainProvider, ActionL2ChainProvider, ActionL2Source,
     ActionTestHarness, BatchType, BatcherConfig, GarbageKind, L1MinerConfig, L2Sequencer,
-    L2Verifier, PendingTx, SharedL1Chain, StepResult, block_info_from,
+    L2Verifier, PendingTx, SharedL1Chain, StepResult, TestRollupConfigBuilder, block_info_from,
 };
 use base_blobs::BlobEncoder;
 use base_consensus_genesis::{
     CONFIG_UPDATE_EVENT_VERSION_0, CONFIG_UPDATE_TOPIC, L1ChainConfig, RollupConfig,
 };
-use base_consensus_registry::Registry;
 use base_protocol::{
     BlockInfo, DEPOSIT_EVENT_ABI_HASH, DEPOSIT_EVENT_VERSION_0, DERIVATION_VERSION_0, L2BlockInfo,
 };
-
-/// Build a [`RollupConfig`] wired to the given [`BatcherConfig`].
-///
-/// Starts from the real Base mainnet config and overrides only the fields that
-/// must differ for in-memory action tests:
-/// - `batch_inbox_address` and `batcher_address` wire the test actors.
-/// - `genesis` is zeroed so the in-memory L1 miner (which starts at ts=0) is
-///   the chain origin.
-/// - Canyon through Fjord are set to `Some(0)` so the batcher's brotli
-///   compression and span-batch encoding are accepted from genesis.
-/// - Hardforks after Fjord retain their mainnet timestamps, which are
-///   unreachable during tests (L1 miner starts at ts=0), making them
-///   effectively inactive without losing their real config values.
-fn rollup_config_for(batcher: &BatcherConfig) -> RollupConfig {
-    let mut rc = Registry::rollup_config(8453).expect("mainnet config").clone();
-    rc.batch_inbox_address = batcher.inbox_address;
-    rc.genesis.system_config.as_mut().unwrap().batcher_address = batcher.batcher_address;
-    rc.genesis.l2_time = 0;
-    rc.genesis.l1 = Default::default();
-    rc.genesis.l2 = Default::default();
-    rc.hardforks.canyon_time = Some(0);
-    rc.hardforks.delta_time = Some(0);
-    rc.hardforks.ecotone_time = Some(0);
-    rc.hardforks.fjord_time = Some(0);
-    rc
-}
 
 /// The derivation pipeline reads a single batcher frame from L1 and derives
 /// the corresponding L2 block, advancing the safe head from genesis (0) to 1.
 #[tokio::test]
 async fn single_l2_block_derived_from_batcher_frame() {
     let batcher_cfg = BatcherConfig::default();
-    let rollup_cfg = rollup_config_for(&batcher_cfg);
+    let rollup_cfg = TestRollupConfigBuilder::base_mainnet(&batcher_cfg).build();
     let mut h = ActionTestHarness::new(L1MinerConfig::default(), rollup_cfg);
 
     // Build L2 block 1 using the L2Sequencer, which automatically computes
@@ -99,7 +72,7 @@ async fn multiple_l1_blocks_each_derive_one_l2_block() {
     const L2_BLOCK_COUNT: u64 = 3;
 
     let batcher_cfg = BatcherConfig::default();
-    let rollup_cfg = rollup_config_for(&batcher_cfg);
+    let rollup_cfg = TestRollupConfigBuilder::base_mainnet(&batcher_cfg).build();
     let mut h = ActionTestHarness::new(L1MinerConfig::default(), rollup_cfg);
 
     // Build L2 blocks 1-3 from genesis. With block_time=2 and L1 block_time=12,
@@ -146,7 +119,7 @@ async fn multiple_l1_blocks_each_derive_one_l2_block() {
 #[tokio::test]
 async fn batch_in_orphaned_l1_block_is_not_derived() {
     let batcher_cfg = BatcherConfig::default();
-    let rollup_cfg = rollup_config_for(&batcher_cfg);
+    let rollup_cfg = TestRollupConfigBuilder::base_mainnet(&batcher_cfg).build();
     let mut h = ActionTestHarness::new(L1MinerConfig::default(), rollup_cfg);
 
     // Encode L2 block 1 and mine L1 block 1 containing the batcher frame.
@@ -184,7 +157,7 @@ async fn batch_in_orphaned_l1_block_is_not_derived() {
 #[tokio::test]
 async fn reorg_reverts_derived_safe_head() {
     let batcher_cfg = BatcherConfig::default();
-    let rollup_cfg = rollup_config_for(&batcher_cfg);
+    let rollup_cfg = TestRollupConfigBuilder::base_mainnet(&batcher_cfg).build();
     let mut h = ActionTestHarness::new(L1MinerConfig::default(), rollup_cfg.clone());
 
     // Batch and mine L1 block 1.
@@ -240,7 +213,7 @@ async fn reorg_reverts_derived_safe_head() {
 #[tokio::test]
 async fn reorg_and_resubmit_rederives_l2_block() {
     let batcher_cfg = BatcherConfig::default();
-    let rollup_cfg = rollup_config_for(&batcher_cfg);
+    let rollup_cfg = TestRollupConfigBuilder::base_mainnet(&batcher_cfg).build();
     let mut h = ActionTestHarness::new(L1MinerConfig::default(), rollup_cfg.clone());
 
     // --- Pre-reorg: derive L2 block 1 from L1 block 1. ---
@@ -311,7 +284,7 @@ async fn reorg_and_resubmit_rederives_l2_block() {
 #[tokio::test]
 async fn reorg_flip_flop() {
     let batcher_cfg = BatcherConfig::default();
-    let rollup_cfg = rollup_config_for(&batcher_cfg);
+    let rollup_cfg = TestRollupConfigBuilder::base_mainnet(&batcher_cfg).build();
     let mut h = ActionTestHarness::new(L1MinerConfig::default(), rollup_cfg.clone());
 
     // Build L2 block 1 once; we re-use (clone) it across all forks since the
@@ -399,7 +372,7 @@ async fn reorg_flip_flop() {
 #[tokio::test]
 async fn reorg_flip_flop_empty_middle_fork() {
     let batcher_cfg = BatcherConfig::default();
-    let rollup_cfg = rollup_config_for(&batcher_cfg);
+    let rollup_cfg = TestRollupConfigBuilder::base_mainnet(&batcher_cfg).build();
     let mut h = ActionTestHarness::new(L1MinerConfig::default(), rollup_cfg.clone());
 
     // Build L2 blocks 1-2 against a genesis-only chain so both reference epoch 0
@@ -525,7 +498,7 @@ async fn batch_accepted_at_last_seq_window_block() {
     const SEQ_WINDOW: u64 = 4;
 
     let batcher_cfg = BatcherConfig::default();
-    let mut rollup_cfg = rollup_config_for(&batcher_cfg);
+    let mut rollup_cfg = TestRollupConfigBuilder::base_mainnet(&batcher_cfg).build();
     rollup_cfg.seq_window_size = SEQ_WINDOW;
     let mut h = ActionTestHarness::new(L1MinerConfig::default(), rollup_cfg);
 
@@ -676,7 +649,7 @@ async fn l1_deposit_included_in_derived_l2_block() {
     let batcher_cfg = BatcherConfig::default();
     let rollup_cfg = RollupConfig {
         deposit_contract_address: deposit_contract,
-        ..rollup_config_for(&batcher_cfg)
+        ..TestRollupConfigBuilder::base_mainnet(&batcher_cfg).build()
     };
     let mut h = ActionTestHarness::new(L1MinerConfig::default(), rollup_cfg);
 
@@ -752,7 +725,7 @@ async fn batcher_key_rotation_accepts_new_batcher() {
     let batcher_b =
         BatcherConfig { batcher_address: Address::repeat_byte(0xBB), ..batcher_a.clone() };
 
-    let mut rollup_cfg = rollup_config_for(&batcher_a);
+    let mut rollup_cfg = TestRollupConfigBuilder::base_mainnet(&batcher_a).build();
     rollup_cfg.l1_system_config_address = l1_sys_cfg_addr;
     let mut h = ActionTestHarness::new(L1MinerConfig::default(), rollup_cfg.clone());
 
@@ -843,7 +816,7 @@ async fn batcher_key_rotation_accepts_new_batcher() {
 async fn multi_l2_per_l1_epoch() {
     const L2_COUNT: u64 = 6;
     let batcher_cfg = BatcherConfig::default();
-    let rollup_cfg = rollup_config_for(&batcher_cfg);
+    let rollup_cfg = TestRollupConfigBuilder::base_mainnet(&batcher_cfg).build();
     let mut h = ActionTestHarness::new(L1MinerConfig::default(), rollup_cfg);
 
     let l1_chain = SharedL1Chain::from_blocks(h.l1.chain().to_vec());
@@ -900,7 +873,7 @@ async fn multi_l2_per_l1_epoch() {
 async fn batch_past_sequence_window_rejected() {
     const SEQ_WINDOW: u64 = 3;
     let batcher_cfg = BatcherConfig::default();
-    let mut rollup_cfg = rollup_config_for(&batcher_cfg);
+    let mut rollup_cfg = TestRollupConfigBuilder::base_mainnet(&batcher_cfg).build();
     rollup_cfg.seq_window_size = SEQ_WINDOW;
     let mut h = ActionTestHarness::new(L1MinerConfig::default(), rollup_cfg);
 
@@ -962,7 +935,7 @@ async fn batch_past_sequence_window_rejected() {
 #[tokio::test]
 async fn multi_epoch_sequence() {
     let batcher_cfg = BatcherConfig::default();
-    let rollup_cfg = rollup_config_for(&batcher_cfg);
+    let rollup_cfg = TestRollupConfigBuilder::base_mainnet(&batcher_cfg).build();
     let mut h = ActionTestHarness::new(L1MinerConfig::default(), rollup_cfg);
 
     // Mine L1 blocks 1 and 2 so the builder can advance epochs.
@@ -1026,7 +999,7 @@ async fn multi_epoch_sequence() {
 #[tokio::test]
 async fn same_epoch_multi_batch_one_l1_block() {
     let batcher_cfg = BatcherConfig::default();
-    let rollup_cfg = rollup_config_for(&batcher_cfg);
+    let rollup_cfg = TestRollupConfigBuilder::base_mainnet(&batcher_cfg).build();
     let mut h = ActionTestHarness::new(L1MinerConfig::default(), rollup_cfg);
 
     let l1_chain = SharedL1Chain::from_blocks(h.l1.chain().to_vec());
@@ -1074,7 +1047,7 @@ async fn same_epoch_multi_batch_one_l1_block() {
 #[tokio::test]
 async fn deep_reorg_multi_block() {
     let batcher_cfg = BatcherConfig::default();
-    let rollup_cfg = rollup_config_for(&batcher_cfg);
+    let rollup_cfg = TestRollupConfigBuilder::base_mainnet(&batcher_cfg).build();
     let mut h = ActionTestHarness::new(L1MinerConfig::default(), rollup_cfg.clone());
 
     let l1_chain = SharedL1Chain::from_blocks(h.l1.chain().to_vec());
@@ -1155,7 +1128,7 @@ async fn deep_reorg_multi_block() {
 #[tokio::test]
 async fn garbage_frame_data_ignored() {
     let batcher_cfg = BatcherConfig::default();
-    let rollup_cfg = rollup_config_for(&batcher_cfg);
+    let rollup_cfg = TestRollupConfigBuilder::base_mainnet(&batcher_cfg).build();
     let mut h = ActionTestHarness::new(L1MinerConfig::default(), rollup_cfg);
 
     let l1_chain = SharedL1Chain::from_blocks(h.l1.chain().to_vec());
@@ -1222,7 +1195,7 @@ async fn multi_frame_channel_reassembled() {
         encoder: EncoderConfig { max_frame_size: 80, ..EncoderConfig::default() },
         ..BatcherConfig::default()
     };
-    let rollup_cfg = rollup_config_for(&batcher_cfg);
+    let rollup_cfg = TestRollupConfigBuilder::base_mainnet(&batcher_cfg).build();
     let mut h = ActionTestHarness::new(L1MinerConfig::default(), rollup_cfg);
 
     let l1_chain = SharedL1Chain::from_blocks(h.l1.chain().to_vec());
@@ -1280,7 +1253,7 @@ async fn multi_frame_channel_reassembled() {
 #[tokio::test]
 async fn single_l2_block_derived_from_span_batch() {
     let batcher_cfg = BatcherConfig { batch_type: BatchType::Span, ..BatcherConfig::default() };
-    let rollup_cfg = rollup_config_for(&batcher_cfg);
+    let rollup_cfg = TestRollupConfigBuilder::base_mainnet(&batcher_cfg).build();
     let mut h = ActionTestHarness::new(L1MinerConfig::default(), rollup_cfg);
 
     let l1_chain = SharedL1Chain::from_blocks(h.l1.chain().to_vec());
@@ -1316,7 +1289,7 @@ async fn single_l2_block_derived_from_span_batch() {
 #[tokio::test]
 async fn three_l2_blocks_derived_from_span_batch() {
     let batcher_cfg = BatcherConfig { batch_type: BatchType::Span, ..BatcherConfig::default() };
-    let rollup_cfg = rollup_config_for(&batcher_cfg);
+    let rollup_cfg = TestRollupConfigBuilder::base_mainnet(&batcher_cfg).build();
     let mut h = ActionTestHarness::new(L1MinerConfig::default(), rollup_cfg);
 
     let l1_chain = SharedL1Chain::from_blocks(h.l1.chain().to_vec());
@@ -1425,7 +1398,7 @@ async fn gpo_params_change_does_not_disrupt_derivation() {
     let batcher_cfg = BatcherConfig::default();
     let rollup_cfg = RollupConfig {
         l1_system_config_address: l1_sys_cfg_addr,
-        ..rollup_config_for(&batcher_cfg)
+        ..TestRollupConfigBuilder::base_mainnet(&batcher_cfg).build()
     };
     let mut h = ActionTestHarness::new(L1MinerConfig::default(), rollup_cfg);
 
@@ -1487,7 +1460,7 @@ async fn gas_limit_change_does_not_disrupt_derivation() {
     let batcher_cfg = BatcherConfig::default();
     let rollup_cfg = RollupConfig {
         l1_system_config_address: l1_sys_cfg_addr,
-        ..rollup_config_for(&batcher_cfg)
+        ..TestRollupConfigBuilder::base_mainnet(&batcher_cfg).build()
     };
     let mut h = ActionTestHarness::new(L1MinerConfig::default(), rollup_cfg);
 
@@ -1546,7 +1519,7 @@ async fn gas_limit_change_does_not_disrupt_derivation() {
 /// variant without crashing or poisoning subsequent channel state.
 async fn garbage_kind_silently_ignored_then_valid_batch_derived(kind: GarbageKind) {
     let batcher_cfg = BatcherConfig::default();
-    let rollup_cfg = rollup_config_for(&batcher_cfg);
+    let rollup_cfg = TestRollupConfigBuilder::base_mainnet(&batcher_cfg).build();
     let mut h = ActionTestHarness::new(L1MinerConfig::default(), rollup_cfg);
 
     let l1_chain = SharedL1Chain::from_blocks(h.l1.chain().to_vec());
@@ -1626,7 +1599,7 @@ async fn garbage_invalid_brotli_silently_ignored() {
 #[tokio::test]
 async fn l2_finalized_advances_via_l1_finalized_signal() {
     let batcher_cfg = BatcherConfig::default();
-    let rollup_cfg = rollup_config_for(&batcher_cfg);
+    let rollup_cfg = TestRollupConfigBuilder::base_mainnet(&batcher_cfg).build();
     let mut h = ActionTestHarness::new(L1MinerConfig::default(), rollup_cfg);
 
     let l1_chain = SharedL1Chain::from_blocks(h.l1.chain().to_vec());
@@ -1684,7 +1657,7 @@ async fn l2_finalized_advances_via_l1_finalized_signal() {
 #[tokio::test]
 async fn sequencer_pin_l1_origin_keeps_epoch_and_empty_block() {
     let batcher_cfg = BatcherConfig::default();
-    let rollup_cfg = rollup_config_for(&batcher_cfg);
+    let rollup_cfg = TestRollupConfigBuilder::base_mainnet(&batcher_cfg).build();
     let mut h = ActionTestHarness::new(L1MinerConfig::default(), rollup_cfg);
 
     // Mine 2 L1 blocks so multiple epochs are available for auto-selection.
@@ -1748,7 +1721,7 @@ async fn sequencer_pin_l1_origin_keeps_epoch_and_empty_block() {
 #[tokio::test]
 async fn derive_chain_from_near_l1_genesis() {
     let batcher_cfg = BatcherConfig::default();
-    let mut rollup_cfg = rollup_config_for(&batcher_cfg);
+    let mut rollup_cfg = TestRollupConfigBuilder::base_mainnet(&batcher_cfg).build();
     let mut h = ActionTestHarness::new(L1MinerConfig::default(), rollup_cfg.clone());
 
     // Mine 5 "pre-history" L1 blocks before L2 genesis.
@@ -1845,7 +1818,7 @@ async fn derive_chain_from_near_l1_genesis() {
 #[tokio::test]
 async fn single_l2_block_derived_from_blob() {
     let batcher_cfg = BatcherConfig::default();
-    let rollup_cfg = rollup_config_for(&batcher_cfg);
+    let rollup_cfg = TestRollupConfigBuilder::base_mainnet(&batcher_cfg).build();
     let mut h = ActionTestHarness::new(L1MinerConfig::default(), rollup_cfg);
 
     // Build L2 block 1.
@@ -1888,7 +1861,7 @@ async fn multiple_l2_blocks_derived_from_blob() {
     const L2_BLOCK_COUNT: u64 = 3;
 
     let batcher_cfg = BatcherConfig::default();
-    let rollup_cfg = rollup_config_for(&batcher_cfg);
+    let rollup_cfg = TestRollupConfigBuilder::base_mainnet(&batcher_cfg).build();
     let mut h = ActionTestHarness::new(L1MinerConfig::default(), rollup_cfg);
 
     // Build L2 blocks 1-3 from genesis.
@@ -1966,7 +1939,7 @@ async fn batcher_config_update_rolled_back_on_reorg() {
     let batcher_b =
         BatcherConfig { batcher_address: Address::repeat_byte(0xBB), ..batcher_a.clone() };
 
-    let mut rollup_cfg = rollup_config_for(&batcher_a);
+    let mut rollup_cfg = TestRollupConfigBuilder::base_mainnet(&batcher_a).build();
     rollup_cfg.l1_system_config_address = l1_sys_cfg_addr;
     let genesis_sys_cfg = rollup_cfg.genesis.system_config.unwrap_or_default();
     let mut h = ActionTestHarness::new(L1MinerConfig::default(), rollup_cfg.clone());
@@ -2095,7 +2068,7 @@ async fn batcher_config_update_rolled_back_on_reorg() {
 #[tokio::test]
 async fn out_of_order_singular_batches_reordered_by_batch_queue() {
     let batcher_cfg = BatcherConfig::default();
-    let rollup_cfg = rollup_config_for(&batcher_cfg);
+    let rollup_cfg = TestRollupConfigBuilder::base_mainnet(&batcher_cfg).build();
     let mut h = ActionTestHarness::new(L1MinerConfig::default(), rollup_cfg);
 
     let l1_chain = SharedL1Chain::from_blocks(h.l1.chain().to_vec());
@@ -2189,7 +2162,7 @@ async fn out_of_order_singular_batches_reordered_by_batch_queue() {
 #[tokio::test]
 async fn pipeline_idle_before_l1_signal_derives_after() {
     let batcher_cfg = BatcherConfig::default();
-    let rollup_cfg = rollup_config_for(&batcher_cfg);
+    let rollup_cfg = TestRollupConfigBuilder::base_mainnet(&batcher_cfg).build();
     let mut h = ActionTestHarness::new(L1MinerConfig::default(), rollup_cfg);
 
     let l1_chain = SharedL1Chain::from_blocks(h.l1.chain().to_vec());
@@ -2249,7 +2222,7 @@ async fn pipeline_idle_before_l1_signal_derives_after() {
 #[tokio::test]
 async fn pipeline_l1_origin_advance_observable_after_epoch_exhausted() {
     let batcher_cfg = BatcherConfig::default();
-    let rollup_cfg = rollup_config_for(&batcher_cfg);
+    let rollup_cfg = TestRollupConfigBuilder::base_mainnet(&batcher_cfg).build();
     let mut h = ActionTestHarness::new(L1MinerConfig::default(), rollup_cfg);
 
     let l1_chain = SharedL1Chain::from_blocks(h.l1.chain().to_vec());

--- a/actions/harness/tests/finalization.rs
+++ b/actions/harness/tests/finalization.rs
@@ -1,27 +1,9 @@
 #![doc = "Action tests for L2 finalization via the verifier pipeline."]
 
 use base_action_harness::{
-    ActionL2Source, ActionTestHarness, BatcherConfig, L1MinerConfig, SharedL1Chain, block_info_from,
+    ActionL2Source, ActionTestHarness, BatcherConfig, L1MinerConfig, SharedL1Chain,
+    TestRollupConfigBuilder, block_info_from,
 };
-use base_consensus_genesis::RollupConfig;
-use base_consensus_registry::Registry;
-
-/// Build a [`RollupConfig`] wired to the given [`BatcherConfig`].
-///
-/// Mirrors the helper used across the `derivation.rs` tests.
-fn rollup_config_for(batcher: &BatcherConfig) -> RollupConfig {
-    let mut rc = Registry::rollup_config(8453).expect("mainnet config").clone();
-    rc.batch_inbox_address = batcher.inbox_address;
-    rc.genesis.system_config.as_mut().unwrap().batcher_address = batcher.batcher_address;
-    rc.genesis.l2_time = 0;
-    rc.genesis.l1 = Default::default();
-    rc.genesis.l2 = Default::default();
-    rc.hardforks.canyon_time = Some(0);
-    rc.hardforks.delta_time = Some(0);
-    rc.hardforks.ecotone_time = Some(0);
-    rc.hardforks.fjord_time = Some(0);
-    rc
-}
 
 /// When multiple L2 blocks share the same L1 epoch (`l1_origin`), finalizing the
 /// L1 inclusion block causes ALL L2 blocks in that epoch to become finalized
@@ -30,7 +12,7 @@ fn rollup_config_for(batcher: &BatcherConfig) -> RollupConfig {
 #[tokio::test]
 async fn finalization_advances_with_multiple_l2_blocks_per_epoch() {
     let batcher_cfg = BatcherConfig::default();
-    let rollup_cfg = rollup_config_for(&batcher_cfg);
+    let rollup_cfg = TestRollupConfigBuilder::base_mainnet(&batcher_cfg).build();
     let mut h = ActionTestHarness::new(L1MinerConfig::default(), rollup_cfg);
 
     // Build 3 L2 blocks, all referencing L1 epoch 0 (genesis).
@@ -99,7 +81,7 @@ async fn finalization_advances_with_multiple_l2_blocks_per_epoch() {
 #[tokio::test]
 async fn finalization_advances_incrementally_with_l1_epochs() {
     let batcher_cfg = BatcherConfig::default();
-    let rollup_cfg = rollup_config_for(&batcher_cfg);
+    let rollup_cfg = TestRollupConfigBuilder::base_mainnet(&batcher_cfg).build();
     let mut h = ActionTestHarness::new(L1MinerConfig::default(), rollup_cfg);
 
     // Mine L1 block 1 so the sequencer can advance to epoch 1.
@@ -182,7 +164,7 @@ async fn finalization_advances_incrementally_with_l1_epochs() {
 #[tokio::test]
 async fn finalization_does_not_exceed_safe_head() {
     let batcher_cfg = BatcherConfig::default();
-    let rollup_cfg = rollup_config_for(&batcher_cfg);
+    let rollup_cfg = TestRollupConfigBuilder::base_mainnet(&batcher_cfg).build();
     let mut h = ActionTestHarness::new(L1MinerConfig::default(), rollup_cfg);
 
     // Build 2 L2 blocks in epoch 0.
@@ -246,7 +228,7 @@ async fn finalization_does_not_exceed_safe_head() {
 #[tokio::test]
 async fn finalization_reorg_clears_state() {
     let batcher_cfg = BatcherConfig::default();
-    let rollup_cfg = rollup_config_for(&batcher_cfg);
+    let rollup_cfg = TestRollupConfigBuilder::base_mainnet(&batcher_cfg).build();
     let mut h = ActionTestHarness::new(L1MinerConfig::default(), rollup_cfg.clone());
 
     // Build 2 L2 blocks.
@@ -344,7 +326,7 @@ async fn finalization_reorg_clears_state() {
 #[tokio::test]
 async fn finalization_does_not_regress() {
     let batcher_cfg = BatcherConfig::default();
-    let rollup_cfg = rollup_config_for(&batcher_cfg);
+    let rollup_cfg = TestRollupConfigBuilder::base_mainnet(&batcher_cfg).build();
     let mut h = ActionTestHarness::new(L1MinerConfig::default(), rollup_cfg);
 
     // Mine L1 block 1 for epoch advancement.

--- a/actions/harness/tests/hardfork_activation.rs
+++ b/actions/harness/tests/hardfork_activation.rs
@@ -2,7 +2,7 @@
 
 use base_action_harness::{
     ActionL2Source, ActionTestHarness, BatchType, BatcherConfig, L1MinerConfig, SharedL1Chain,
-    block_info_from,
+    TestRollupConfigBuilder, block_info_from,
 };
 use base_consensus_genesis::{HardForkConfig, RollupConfig};
 use base_consensus_registry::Registry;
@@ -252,12 +252,7 @@ fn base_v1_is_standalone_from_jovian() {
 /// with the caller-supplied `hardforks`. This lets derivation tests set exact
 /// hardfork timestamps without spurious cascade activations from unlisted forks.
 fn rollup_config_for(batcher: &BatcherConfig, hardforks: HardForkConfig) -> RollupConfig {
-    let mut rc = Registry::rollup_config(8453).expect("mainnet config").clone();
-    rc.batch_inbox_address = batcher.inbox_address;
-    rc.genesis.system_config.as_mut().unwrap().batcher_address = batcher.batcher_address;
-    rc.genesis.l2_time = 0;
-    rc.genesis.l1 = Default::default();
-    rc.genesis.l2 = Default::default();
+    let mut rc = TestRollupConfigBuilder::base_mainnet(batcher).build();
     rc.hardforks = hardforks;
     rc
 }

--- a/actions/harness/tests/unsafe_gossip.rs
+++ b/actions/harness/tests/unsafe_gossip.rs
@@ -4,30 +4,11 @@ use std::sync::Arc;
 
 use base_action_harness::{
     ActionDataSource, ActionL1ChainProvider, ActionL2ChainProvider, ActionL2Source,
-    ActionTestHarness, BatcherConfig, L1MinerConfig, L2Verifier, SharedL1Chain, VerifierPipeline,
-    block_info_from,
+    ActionTestHarness, BatcherConfig, L1MinerConfig, L2Verifier, SharedL1Chain,
+    TestRollupConfigBuilder, VerifierPipeline, block_info_from,
 };
 use base_consensus_genesis::{L1ChainConfig, RollupConfig};
-use base_consensus_registry::Registry;
 use base_protocol::{BlockInfo, L2BlockInfo};
-
-/// Build a [`RollupConfig`] wired to the given [`BatcherConfig`].
-///
-/// Mirrors the helper in `derivation.rs`: starts from the Base mainnet config
-/// and overrides only the fields that must differ for in-memory action tests.
-fn rollup_config_for(batcher: &BatcherConfig) -> RollupConfig {
-    let mut rc = Registry::rollup_config(8453).expect("mainnet config").clone();
-    rc.batch_inbox_address = batcher.inbox_address;
-    rc.genesis.system_config.as_mut().unwrap().batcher_address = batcher.batcher_address;
-    rc.genesis.l2_time = 0;
-    rc.genesis.l1 = Default::default();
-    rc.genesis.l2 = Default::default();
-    rc.hardforks.canyon_time = Some(0);
-    rc.hardforks.delta_time = Some(0);
-    rc.hardforks.ecotone_time = Some(0);
-    rc.hardforks.fjord_time = Some(0);
-    rc
-}
 
 /// Create a verifier wired to `h`'s current L1 chain, returning both the
 /// verifier and the shared chain.
@@ -79,7 +60,7 @@ async fn test_unsafe_chain_advances_safe_catches_up() {
     const L2_BLOCK_COUNT: u64 = 5;
 
     let batcher_cfg = BatcherConfig::default();
-    let rollup_cfg = rollup_config_for(&batcher_cfg);
+    let rollup_cfg = TestRollupConfigBuilder::base_mainnet(&batcher_cfg).build();
     let mut h = ActionTestHarness::new(L1MinerConfig::default(), rollup_cfg.clone());
 
     // --- Phase 1: Build L2 blocks with the sequencer. ---
@@ -153,7 +134,7 @@ async fn test_unsafe_chain_advances_safe_catches_up() {
 #[tokio::test]
 async fn test_out_of_order_gossip_is_dropped() {
     let batcher_cfg = BatcherConfig::default();
-    let rollup_cfg = rollup_config_for(&batcher_cfg);
+    let rollup_cfg = TestRollupConfigBuilder::base_mainnet(&batcher_cfg).build();
     let h = ActionTestHarness::new(L1MinerConfig::default(), rollup_cfg.clone());
 
     // Build 3 sequential L2 blocks (we will inject block 3 first, skipping 1 & 2).


### PR DESCRIPTION
Closes #1312

## Summary

Introduces `TestRollupConfigBuilder` in `base-action-harness` to eliminate
the duplicated rollup config construction that was scattered across four test
files. All test files previously defined their own private helper that
followed the identical pattern: start from `Registry::rollup_config(8453)`,
override batcher addresses, zero genesis fields, and activate Canyon–Fjord
from genesis.

## Changes

- **`actions/harness/src/test_rollup_config.rs`** — new `TestRollupConfigBuilder`
  with `base_mainnet()`, `with_channel_timeout()`, `with_max_sequencer_drift()`,
  `all_forks_active()`, and `build()`
- **`actions/harness/src/lib.rs`** — re-exports `TestRollupConfigBuilder`
- **`actions/harness/Cargo.toml`** — moves `base-consensus-registry` from
  `dev-dependencies` to `dependencies` since the builder lives in `src/`
- **`batcher_channels.rs`** — removes `base_rollup_config_for`, `timeout_rollup_config`, `interleave_rollup_config`
- **`batcher_sequencer_drift.rs`** — removes `drift_rollup_config`
- **`derivation.rs`** — removes inline config construction boilerplate
- **`finalization.rs`** — removes `rollup_config_for`
- **`unsafe_gossip.rs`** — removes `rollup_config_for`
- **`hardfork_activation.rs`** — reuses builder before applying custom `HardForkConfig`

## Testing

All 101 tests pass (`cargo test -p base-action-harness`).