### PR TITLE
fix(tx-manager): Send Async Nonce Handling

### DIFF
--- a/bin/prover/src/cli.rs
+++ b/bin/prover/src/cli.rs
@@ -15,7 +15,6 @@ use base_proof_tee_nitro::{NitroEnclave, VSOCK_PORT};
 #[cfg(any(target_os = "linux", feature = "local"))]
 use base_proof_tee_nitro::{NitroProverServer, NitroTransport};
 use clap::{Parser, Subcommand};
-use eyre::eyre;
 #[cfg(any(target_os = "linux", feature = "local"))]
 use tracing::info;
 

--- a/bin/prover/src/cli.rs
+++ b/bin/prover/src/cli.rs
@@ -15,6 +15,8 @@ use base_proof_tee_nitro::{NitroEnclave, VSOCK_PORT};
 #[cfg(any(target_os = "linux", feature = "local"))]
 use base_proof_tee_nitro::{NitroProverServer, NitroTransport};
 use clap::{Parser, Subcommand};
+#[cfg(target_os = "linux")]
+use eyre::eyre;
 #[cfg(any(target_os = "linux", feature = "local"))]
 use tracing::info;
 

--- a/crates/utilities/tx-manager/src/manager.rs
+++ b/crates/utilities/tx-manager/src/manager.rs
@@ -246,7 +246,7 @@ impl SimpleTxManager {
         candidate: &TxCandidate,
         fee_overrides: Option<FeeOverride>,
     ) -> TxManagerResult<PreparedTx> {
-        self.prepare_with_initial_caps(candidate, fee_overrides, None).await
+        self.prepare_with_initial_caps(candidate, fee_overrides, None, None).await
     }
 
     /// Internal variant of [`prepare`](Self::prepare) that optionally reuses
@@ -256,11 +256,16 @@ impl SimpleTxManager {
     /// `suggest_gas_price_caps()` round-trip after it has already fetched caps
     /// to compute bump thresholds. Retries intentionally fall back to fresh fee
     /// estimation so transient failures do not pin stale network conditions.
+    ///
+    /// When `nonce_override` is `Some(n)`, the same pre-assigned nonce is
+    /// forwarded to every retry attempt (the nonce was already consumed from
+    /// the nonce manager, so it must be reused on retries).
     async fn prepare_with_initial_caps(
         &self,
         candidate: &TxCandidate,
         fee_overrides: Option<FeeOverride>,
         mut initial_caps: Option<GasPriceCaps>,
+        nonce_override: Option<u64>,
     ) -> TxManagerResult<PreparedTx> {
         (|| {
             let caps = initial_caps.take();
@@ -271,7 +276,7 @@ impl SimpleTxManager {
                 if self.is_closed() {
                     return Err(TxManagerError::ChannelClosed);
                 }
-                self.craft_tx_with_caps(candidate, fee_overrides, caps).await
+                self.craft_tx_with_caps(candidate, fee_overrides, caps, nonce_override).await
             }
         })
         .retry(
@@ -444,16 +449,21 @@ impl SimpleTxManager {
         candidate: &TxCandidate,
         fee_overrides: Option<FeeOverride>,
     ) -> TxManagerResult<PreparedTx> {
-        self.craft_tx_with_caps(candidate, fee_overrides, None).await
+        self.craft_tx_with_caps(candidate, fee_overrides, None, None).await
     }
 
     /// Internal variant of [`craft_tx`](Self::craft_tx) that optionally uses
     /// pre-fetched fee caps instead of querying the provider again.
+    ///
+    /// When `nonce_override` is `Some(n)`, the provided nonce is used directly
+    /// without acquiring one from the [`NonceManager`]. This is used by
+    /// [`send_async`] to honour pre-assigned nonces for call-order guarantees.
     async fn craft_tx_with_caps(
         &self,
         candidate: &TxCandidate,
         fee_overrides: Option<FeeOverride>,
         caps: Option<GasPriceCaps>,
+        nonce_override: Option<u64>,
     ) -> TxManagerResult<PreparedTx> {
         // Blob transactions are not yet supported.
         if !candidate.blobs.is_empty() {
@@ -529,11 +539,22 @@ impl SimpleTxManager {
         tx_request = tx_request.with_gas_limit(gas_limit);
 
         // Step 6: Assign nonce.
-        let guard = self.nonce_manager.next_nonce().await?;
-        tx_request = tx_request.with_nonce(guard.nonce());
+        //
+        // When a nonce was pre-assigned (via `send_async`), use it directly
+        // without acquiring the nonce manager lock. Otherwise, acquire a
+        // `NonceGuard` so the nonce can be rolled back on sign failure.
+        let (nonce, guard) = match nonce_override {
+            Some(n) => (n, None),
+            None => {
+                let g = self.nonce_manager.next_nonce().await?;
+                let n = g.nonce();
+                (n, Some(g))
+            }
+        };
+        tx_request = tx_request.with_nonce(nonce);
 
         info!(
-            nonce = guard.nonce(),
+            nonce,
             gas_limit = %gas_limit,
             tip_cap = %tip_cap,
             fee_cap = %fee_cap,
@@ -547,7 +568,7 @@ impl SimpleTxManager {
 
         match sign_result {
             Ok(envelope) => {
-                // Consume the nonce (drop guard).
+                // Consume the nonce (drop guard if present).
                 drop(guard);
                 Ok(PreparedTx {
                     raw_tx: Bytes::from(Encodable2718::encoded_2718(&envelope)),
@@ -557,8 +578,10 @@ impl SimpleTxManager {
                 })
             }
             Err(e) => {
-                // Roll back nonce on sign failure.
-                guard.rollback();
+                // Roll back nonce on sign failure (only when guard-managed).
+                if let Some(g) = guard {
+                    g.rollback();
+                }
                 Err(TxManagerError::Sign(e.to_string()))
             }
         }
@@ -602,7 +625,7 @@ impl SimpleTxManager {
     ///
     /// Returns the confirmed [`TransactionReceipt`] on success, or a
     /// [`TxManagerError`] on critical errors, timeout, or manager shutdown.
-    async fn send_tx(&self, candidate: TxCandidate) -> SendResponse {
+    async fn send_tx(&self, candidate: TxCandidate, nonce_override: Option<u64>) -> SendResponse {
         if self.is_closed() {
             return Err(TxManagerError::ChannelClosed);
         }
@@ -616,11 +639,11 @@ impl SimpleTxManager {
 
         // Wrap the inner loop in a send timeout if configured.
         let result = if self.config.tx_send_timeout.is_zero() {
-            self.send_tx_inner(&candidate, &send_state).await
+            self.send_tx_inner(&candidate, &send_state, nonce_override).await
         } else {
             tokio::time::timeout(
                 self.config.tx_send_timeout,
-                self.send_tx_inner(&candidate, &send_state),
+                self.send_tx_inner(&candidate, &send_state, nonce_override),
             )
             .await
             .unwrap_or_else(|_| {
@@ -665,16 +688,23 @@ impl SimpleTxManager {
 
     /// Inner send loop extracted from [`send_tx`](Self::send_tx) to allow
     /// optional timeout wrapping.
+    ///
+    /// `nonce_override` is forwarded to the **initial**
+    /// [`prepare_with_initial_caps`](Self::prepare_with_initial_caps) call
+    /// only. Fee bump paths always pass `None` (they reset the nonce manager
+    /// and re-acquire).
     async fn send_tx_inner(
         &self,
         candidate: &TxCandidate,
         send_state: &Arc<SendState>,
+        nonce_override: Option<u64>,
     ) -> SendResponse {
         // Initial transaction preparation. prepare() is NOT cancellation-safe,
         // so it runs to completion before entering the select loop.
         // The returned PreparedTx carries the actual on-wire fees, eliminating
         // the need for a separate suggest_gas_price_caps() call.
-        let prepared = self.prepare(candidate, None).await?;
+        let prepared =
+            self.prepare_with_initial_caps(candidate, None, None, nonce_override).await?;
         let tx_hash = self.publish_tx(send_state, &prepared.raw_tx, None).await?;
         let mut bump = BumpState {
             tip: prepared.gas_tip_cap,
@@ -836,11 +866,14 @@ impl SimpleTxManager {
 
         // Rebuild transaction with bumped fees as overrides and the fresh
         // caps to avoid a redundant provider round-trip.
+        // Fee bump path always passes `None` for nonce_override — the nonce
+        // manager was just reset, so craft_tx_with_caps re-acquires normally.
         let prepared = self
             .prepare_with_initial_caps(
                 &bump_candidate,
                 Some(FeeOverride::new(bumped.gas_tip_cap, bumped.gas_fee_cap)),
                 Some(bumped.caps),
+                None,
             )
             .await?;
 
@@ -1153,11 +1186,22 @@ impl SimpleTxManager {
 
 impl TxManager for SimpleTxManager {
     async fn send(&self, candidate: TxCandidate) -> SendResponse {
-        self.send_tx(candidate).await
+        self.send_tx(candidate, None).await
     }
 
     async fn send_async(&self, candidate: TxCandidate) -> SendHandle {
         let (tx, rx) = oneshot::channel();
+
+        // Reserve nonce BEFORE spawning to guarantee call-order assignment.
+        // Two sequential `send_async()` calls will receive monotonically
+        // increasing nonces regardless of tokio task scheduling order.
+        let nonce = match self.nonce_manager.reserve_nonce().await {
+            Ok(n) => Some(n),
+            Err(e) => {
+                let _ = tx.send(Err(e));
+                return SendHandle::new(rx);
+            }
+        };
 
         // Clone the manager for the spawned task. The `closed` flag is
         // Arc-wrapped, so the spawned task shares the same shutdown signal
@@ -1166,7 +1210,7 @@ impl TxManager for SimpleTxManager {
         let manager = self.clone();
 
         tokio::spawn(async move {
-            let result = manager.send_tx(candidate).await;
+            let result = manager.send_tx(candidate, nonce).await;
             let _ = tx.send(result);
         });
 
@@ -1286,7 +1330,7 @@ mod tests {
         };
 
         let prepared = manager
-            .prepare_with_initial_caps(&candidate, None, Some(caps.clone()))
+            .prepare_with_initial_caps(&candidate, None, Some(caps.clone()), None)
             .await
             .expect("should prepare tx using supplied caps");
         let tx = decode_eip1559(&prepared.raw_tx);

--- a/crates/utilities/tx-manager/src/manager.rs
+++ b/crates/utilities/tx-manager/src/manager.rs
@@ -741,7 +741,16 @@ impl SimpleTxManager {
         result: &TxManagerResult<T>,
         send_state: &SendState,
     ) -> bool {
-        result.is_err() && send_state.successful_publish_count() == 0
+        match result {
+            Ok(_) => false,
+            // Nonce errors indicate the nonce is genuinely invalid, not a
+            // transient failure.  Returning it to the reuse pool would
+            // cause an infinite retry loop: after a reset() the chain
+            // nonce is re-fetched, but advance_nonce() pops
+            // returned_nonces first, reissuing the same invalid value.
+            Err(TxManagerError::NonceTooHigh | TxManagerError::NonceTooLow) => false,
+            Err(_) => send_state.successful_publish_count() == 0,
+        }
     }
 
     /// Inner send loop extracted from [`send_tx`](Self::send_tx) to allow
@@ -1376,6 +1385,8 @@ mod tests {
     #[case::success(false, Ok(()), false)]
     #[case::timeout_no_publish(false, Err(TxManagerError::SendTimeout), true)]
     #[case::timeout_after_publish(true, Err(TxManagerError::SendTimeout), false)]
+    #[case::nonce_too_high(false, Err(TxManagerError::NonceTooHigh), false)]
+    #[case::nonce_too_low(false, Err(TxManagerError::NonceTooLow), false)]
     fn should_return_reserved_nonce(
         #[case] has_publish: bool,
         #[case] result: crate::TxManagerResult<()>,

--- a/crates/utilities/tx-manager/src/manager.rs
+++ b/crates/utilities/tx-manager/src/manager.rs
@@ -99,7 +99,7 @@ struct BumpState {
 impl BumpState {
     /// Constructs a [`BumpState`] from a [`PreparedTx`] and the hash of the
     /// published transaction.
-    fn from_prepared(prepared: &PreparedTx, tx_hash: B256) -> Self {
+    const fn from_prepared(prepared: &PreparedTx, tx_hash: B256) -> Self {
         Self {
             tip: prepared.gas_tip_cap,
             fee_cap: prepared.gas_fee_cap,
@@ -691,11 +691,10 @@ impl SimpleTxManager {
         // Return pre-reserved nonces that were never published so they can
         // be reissued by subsequent send/send_async calls, preventing
         // irrecoverable nonce gaps.
-        if let Some(n) = nonce_override {
-            if Self::should_return_reserved_nonce(&result, &send_state) {
+        if let Some(n) = nonce_override
+            && Self::should_return_reserved_nonce(&result, &send_state) {
                 self.nonce_manager.return_reserved_nonce(n).await;
             }
-        }
 
         result
     }
@@ -1348,7 +1347,12 @@ mod tests {
     #[case::nonce_too_high_no_override(false, Err(TxManagerError::NonceTooHigh), None, true)]
     #[case::nonce_too_high_with_override(false, Err(TxManagerError::NonceTooHigh), Some(42), true)]
     #[case::nonce_override_timeout(false, Err(TxManagerError::SendTimeout), Some(42), false)]
-    #[case::nonce_override_pre_publish_error(false, Err(TxManagerError::ChannelClosed), Some(42), false)]
+    #[case::nonce_override_pre_publish_error(
+        false,
+        Err(TxManagerError::ChannelClosed),
+        Some(42),
+        false
+    )]
     fn should_reset_nonce_on_send_error(
         #[case] has_publish: bool,
         #[case] result: crate::TxManagerResult<()>,
@@ -1360,11 +1364,7 @@ mod tests {
             send_state.record_successful_publish();
         }
         assert_eq!(
-            SimpleTxManager::should_reset_nonce_on_send_error(
-                &result,
-                &send_state,
-                nonce_override,
-            ),
+            SimpleTxManager::should_reset_nonce_on_send_error(&result, &send_state, nonce_override,),
             expected,
         );
     }
@@ -1384,13 +1384,7 @@ mod tests {
         if has_publish {
             send_state.record_successful_publish();
         }
-        assert_eq!(
-            SimpleTxManager::should_return_reserved_nonce(
-                &result,
-                &send_state,
-            ),
-            expected,
-        );
+        assert_eq!(SimpleTxManager::should_return_reserved_nonce(&result, &send_state,), expected,);
     }
 
     #[tokio::test]

--- a/crates/utilities/tx-manager/src/manager.rs
+++ b/crates/utilities/tx-manager/src/manager.rs
@@ -692,9 +692,10 @@ impl SimpleTxManager {
         // be reissued by subsequent send/send_async calls, preventing
         // irrecoverable nonce gaps.
         if let Some(n) = nonce_override
-            && Self::should_return_reserved_nonce(&result, &send_state) {
-                self.nonce_manager.return_reserved_nonce(n).await;
-            }
+            && Self::should_return_reserved_nonce(&result, &send_state)
+        {
+            self.nonce_manager.return_reserved_nonce(n).await;
+        }
 
         result
     }

--- a/crates/utilities/tx-manager/src/manager.rs
+++ b/crates/utilities/tx-manager/src/manager.rs
@@ -675,7 +675,10 @@ impl SimpleTxManager {
         };
 
         if Self::should_reset_nonce_on_send_error(&result, &send_state, nonce_override) {
-            // Two policies (see should_reset_nonce_on_send_error):
+            // Three policies (see should_reset_nonce_on_send_error):
+            // • NonceTooHigh — always reset, even with nonce_override.
+            //   No tx entered the mempool; reserved_high_water protects
+            //   concurrent reservations from collision after reset.
             // • SendTimeout — always reset. The timeout may have cancelled
             //   prepare() after it reserved a nonce but before the tx reached
             //   the mempool, leaking the nonce manager's internal counter.
@@ -702,14 +705,16 @@ impl SimpleTxManager {
         send_state: &SendState,
         nonce_override: Option<u64>,
     ) -> bool {
-        // When a nonce_override was used, the nonce was irrevocably
-        // consumed at reserve_nonce() time. Resetting the nonce manager
-        // would corrupt concurrent send_async reservations.
-        if nonce_override.is_some() {
-            return false;
-        }
         match result {
             Ok(_) => false,
+            // Always reset on NonceTooHigh — the publish failed, no tx
+            // entered the mempool, and reserved_high_water protects
+            // concurrent reservations from collision after reset.
+            Err(TxManagerError::NonceTooHigh) => true,
+            // When a nonce_override was used, the nonce was irrevocably
+            // consumed at reserve_nonce() time. Resetting the nonce manager
+            // would corrupt concurrent send_async reservations.
+            _ if nonce_override.is_some() => false,
             // Always reset on timeout — the timeout may have cancelled
             // prepare() mid-flight during a fee bump, leaking a nonce
             // from the nonce manager's internal counter.
@@ -1340,6 +1345,8 @@ mod tests {
     #[case::non_timeout_error_after_publish(true, Err(TxManagerError::ChannelClosed), None, false)]
     #[case::timeout_after_publish(true, Err(TxManagerError::SendTimeout), None, true)]
     #[case::success(false, Ok(()), None, false)]
+    #[case::nonce_too_high_no_override(false, Err(TxManagerError::NonceTooHigh), None, true)]
+    #[case::nonce_too_high_with_override(false, Err(TxManagerError::NonceTooHigh), Some(42), true)]
     #[case::nonce_override_timeout(false, Err(TxManagerError::SendTimeout), Some(42), false)]
     #[case::nonce_override_pre_publish_error(false, Err(TxManagerError::ChannelClosed), Some(42), false)]
     fn should_reset_nonce_on_send_error(

--- a/crates/utilities/tx-manager/src/manager.rs
+++ b/crates/utilities/tx-manager/src/manager.rs
@@ -685,6 +685,15 @@ impl SimpleTxManager {
             self.nonce_manager.reset().await;
         }
 
+        // Return pre-reserved nonces that were never published so they can
+        // be reissued by subsequent send/send_async calls, preventing
+        // irrecoverable nonce gaps.
+        if let Some(n) = nonce_override {
+            if Self::should_return_reserved_nonce(&result, &send_state) {
+                self.nonce_manager.return_reserved_nonce(n).await;
+            }
+        }
+
         result
     }
 
@@ -710,6 +719,24 @@ impl SimpleTxManager {
             // via the chain's pending nonce anyway.
             Err(_) => send_state.successful_publish_count() == 0,
         }
+    }
+
+    /// Returns `true` when a pre-reserved nonce should be returned to the
+    /// nonce manager's reuse pool.
+    ///
+    /// A nonce is eligible for return when BOTH of these hold:
+    /// 1. The send failed (`result.is_err()`).
+    /// 2. No transaction was ever successfully published — if a tx was
+    ///    published, the nonce may be in the mempool and must not be
+    ///    reused.
+    ///
+    /// The caller is responsible for checking that a nonce override exists
+    /// (i.e. the send came from `send_async`, not `send`).
+    fn should_return_reserved_nonce<T>(
+        result: &TxManagerResult<T>,
+        send_state: &SendState,
+    ) -> bool {
+        result.is_err() && send_state.successful_publish_count() == 0
     }
 
     /// Inner send loop extracted from [`send_tx`](Self::send_tx) to allow
@@ -1330,6 +1357,30 @@ mod tests {
                 &result,
                 &send_state,
                 nonce_override,
+            ),
+            expected,
+        );
+    }
+
+    #[rstest]
+    #[case::pre_publish_error(false, Err(TxManagerError::Sign("fail".into())), true)]
+    #[case::after_publish(true, Err(TxManagerError::Sign("fail".into())), false)]
+    #[case::success(false, Ok(()), false)]
+    #[case::timeout_no_publish(false, Err(TxManagerError::SendTimeout), true)]
+    #[case::timeout_after_publish(true, Err(TxManagerError::SendTimeout), false)]
+    fn should_return_reserved_nonce(
+        #[case] has_publish: bool,
+        #[case] result: crate::TxManagerResult<()>,
+        #[case] expected: bool,
+    ) {
+        let send_state = crate::SendState::new(3).expect("should create send state");
+        if has_publish {
+            send_state.record_successful_publish();
+        }
+        assert_eq!(
+            SimpleTxManager::should_return_reserved_nonce(
+                &result,
+                &send_state,
             ),
             expected,
         );

--- a/crates/utilities/tx-manager/src/manager.rs
+++ b/crates/utilities/tx-manager/src/manager.rs
@@ -73,6 +73,8 @@ pub struct PreparedTx {
     pub gas_fee_cap: u128,
     /// Gas limit used in the signed transaction.
     pub gas_limit: u64,
+    /// Nonce assigned to the signed transaction.
+    pub nonce: u64,
 }
 
 /// Mutable fee-bump state tracked across iterations in the send loop.
@@ -90,6 +92,22 @@ struct BumpState {
     gas_limit: u64,
     /// Hash of the most recently published transaction.
     tx_hash: B256,
+    /// Nonce used in the most recently published transaction.
+    nonce: u64,
+}
+
+impl BumpState {
+    /// Constructs a [`BumpState`] from a [`PreparedTx`] and the hash of the
+    /// published transaction.
+    fn from_prepared(prepared: &PreparedTx, tx_hash: B256) -> Self {
+        Self {
+            tip: prepared.gas_tip_cap,
+            fee_cap: prepared.gas_fee_cap,
+            gas_limit: prepared.gas_limit,
+            tx_hash,
+            nonce: prepared.nonce,
+        }
+    }
 }
 
 /// Default transaction manager implementation.
@@ -575,6 +593,7 @@ impl SimpleTxManager {
                     gas_tip_cap: tip_cap,
                     gas_fee_cap: fee_cap,
                     gas_limit,
+                    nonce,
                 })
             }
             Err(e) => {
@@ -655,7 +674,7 @@ impl SimpleTxManager {
             })
         };
 
-        if Self::should_reset_nonce_on_send_error(&result, &send_state) {
+        if Self::should_reset_nonce_on_send_error(&result, &send_state, nonce_override) {
             // Two policies (see should_reset_nonce_on_send_error):
             // • SendTimeout — always reset. The timeout may have cancelled
             //   prepare() after it reserved a nonce but before the tx reached
@@ -672,7 +691,14 @@ impl SimpleTxManager {
     fn should_reset_nonce_on_send_error<T>(
         result: &TxManagerResult<T>,
         send_state: &SendState,
+        nonce_override: Option<u64>,
     ) -> bool {
+        // When a nonce_override was used, the nonce was irrevocably
+        // consumed at reserve_nonce() time. Resetting the nonce manager
+        // would corrupt concurrent send_async reservations.
+        if nonce_override.is_some() {
+            return false;
+        }
         match result {
             Ok(_) => false,
             // Always reset on timeout — the timeout may have cancelled
@@ -690,9 +716,9 @@ impl SimpleTxManager {
     /// optional timeout wrapping.
     ///
     /// `nonce_override` is forwarded to the **initial**
-    /// [`prepare_with_initial_caps`](Self::prepare_with_initial_caps) call
-    /// only. Fee bump paths always pass `None` (they reset the nonce manager
-    /// and re-acquire).
+    /// [`prepare_with_initial_caps`](Self::prepare_with_initial_caps) call.
+    /// Fee bump paths reuse the original nonce via their own `nonce_override`
+    /// to avoid corrupting concurrent `send_async` reservations.
     async fn send_tx_inner(
         &self,
         candidate: &TxCandidate,
@@ -706,12 +732,7 @@ impl SimpleTxManager {
         let prepared =
             self.prepare_with_initial_caps(candidate, None, None, nonce_override).await?;
         let tx_hash = self.publish_tx(send_state, &prepared.raw_tx, None).await?;
-        let mut bump = BumpState {
-            tip: prepared.gas_tip_cap,
-            fee_cap: prepared.gas_fee_cap,
-            gas_limit: prepared.gas_limit,
-            tx_hash,
-        };
+        let mut bump = BumpState::from_prepared(&prepared, tx_hash);
 
         // Receipt delivery channel — mpsc because fee bumps may spawn
         // new wait tasks with different tx hashes.
@@ -830,8 +851,8 @@ impl SimpleTxManager {
     /// Handles a single fee bump iteration.
     ///
     /// Delegates fee computation to [`increase_gas_price`](Self::increase_gas_price),
-    /// resets the nonce manager, rebuilds and re-publishes the transaction,
-    /// and spawns a new receipt polling task.
+    /// rebuilds the transaction reusing the same nonce via `nonce_override`,
+    /// re-publishes it, and spawns a new receipt polling task.
     ///
     /// The bumped fee values are passed as fee overrides to
     /// [`prepare_with_initial_caps`](Self::prepare_with_initial_caps),
@@ -855,9 +876,6 @@ impl SimpleTxManager {
     ) -> TxManagerResult<BumpState> {
         let bumped = self.increase_gas_price(candidate, old.tip, old.fee_cap, None).await?;
 
-        // Reset nonce manager so prepare() gets the same latest nonce.
-        self.nonce_manager.reset().await;
-
         // Clone candidate with the previous gas limit as a floor so that
         // craft_tx_with_caps's `candidate.gas_limit.max(estimated)` logic
         // ensures the gas limit never decreases across bumps.
@@ -866,14 +884,16 @@ impl SimpleTxManager {
 
         // Rebuild transaction with bumped fees as overrides and the fresh
         // caps to avoid a redundant provider round-trip.
-        // Fee bump path always passes `None` for nonce_override — the nonce
-        // manager was just reset, so craft_tx_with_caps re-acquires normally.
+        // Reuse the exact nonce from the transaction being replaced via
+        // nonce_override, rather than resetting the nonce manager.
+        // Resetting would corrupt nonces pre-reserved by concurrent
+        // send_async() tasks.
         let prepared = self
             .prepare_with_initial_caps(
                 &bump_candidate,
                 Some(FeeOverride::new(bumped.gas_tip_cap, bumped.gas_fee_cap)),
                 Some(bumped.caps),
-                None,
+                Some(old.nonce),
             )
             .await?;
 
@@ -903,12 +923,7 @@ impl SimpleTxManager {
             Arc::clone(&self.closed),
         );
 
-        Ok(BumpState {
-            tip: prepared.gas_tip_cap,
-            fee_cap: prepared.gas_fee_cap,
-            gas_limit: prepared.gas_limit,
-            tx_hash: new_hash,
-        })
+        Ok(BumpState::from_prepared(&prepared, new_hash))
     }
 
     /// Applies the result of a fee bump attempt, updating the tracked fee
@@ -1262,7 +1277,7 @@ mod tests {
 
     #[rstest]
     #[case::success_updates_state(
-        Ok(BumpState { tip: 200, fee_cap: 2000, gas_limit: 50_000, tx_hash: B256::with_last_byte(0x42) }),
+        Ok(BumpState { tip: 200, fee_cap: 2000, gas_limit: 50_000, tx_hash: B256::with_last_byte(0x42), nonce: 0 }),
         false, 200, 2000, 50_000, B256::with_last_byte(0x42),
     )]
     #[case::non_retryable_returns_abort(
@@ -1282,7 +1297,7 @@ mod tests {
         #[case] expected_hash: B256,
     ) {
         let mut state =
-            BumpState { tip: 100, fee_cap: 1000, gas_limit: 21_000, tx_hash: B256::ZERO };
+            BumpState { tip: 100, fee_cap: 1000, gas_limit: 21_000, tx_hash: B256::ZERO, nonce: 0 };
 
         let abort = SimpleTxManager::apply_bump_result(input, &mut state);
 
@@ -1294,13 +1309,16 @@ mod tests {
     }
 
     #[rstest]
-    #[case::error_before_first_publish(false, Err(TxManagerError::SendTimeout), true)]
-    #[case::non_timeout_error_after_publish(true, Err(TxManagerError::ChannelClosed), false)]
-    #[case::timeout_after_publish(true, Err(TxManagerError::SendTimeout), true)]
-    #[case::success(false, Ok(()), false)]
+    #[case::error_before_first_publish(false, Err(TxManagerError::SendTimeout), None, true)]
+    #[case::non_timeout_error_after_publish(true, Err(TxManagerError::ChannelClosed), None, false)]
+    #[case::timeout_after_publish(true, Err(TxManagerError::SendTimeout), None, true)]
+    #[case::success(false, Ok(()), None, false)]
+    #[case::nonce_override_timeout(false, Err(TxManagerError::SendTimeout), Some(42), false)]
+    #[case::nonce_override_pre_publish_error(false, Err(TxManagerError::ChannelClosed), Some(42), false)]
     fn should_reset_nonce_on_send_error(
         #[case] has_publish: bool,
         #[case] result: crate::TxManagerResult<()>,
+        #[case] nonce_override: Option<u64>,
         #[case] expected: bool,
     ) {
         let send_state = crate::SendState::new(3).expect("should create send state");
@@ -1308,7 +1326,11 @@ mod tests {
             send_state.record_successful_publish();
         }
         assert_eq!(
-            SimpleTxManager::should_reset_nonce_on_send_error(&result, &send_state),
+            SimpleTxManager::should_reset_nonce_on_send_error(
+                &result,
+                &send_state,
+                nonce_override,
+            ),
             expected,
         );
     }

--- a/crates/utilities/tx-manager/src/manager.rs
+++ b/crates/utilities/tx-manager/src/manager.rs
@@ -742,13 +742,12 @@ impl SimpleTxManager {
         send_state: &SendState,
     ) -> bool {
         match result {
-            Ok(_) => false,
             // Nonce errors indicate the nonce is genuinely invalid, not a
             // transient failure.  Returning it to the reuse pool would
             // cause an infinite retry loop: after a reset() the chain
             // nonce is re-fetched, but advance_nonce() pops
             // returned_nonces first, reissuing the same invalid value.
-            Err(TxManagerError::NonceTooHigh | TxManagerError::NonceTooLow) => false,
+            Ok(_) | Err(TxManagerError::NonceTooHigh | TxManagerError::NonceTooLow) => false,
             Err(_) => send_state.successful_publish_count() == 0,
         }
     }

--- a/crates/utilities/tx-manager/src/nonce.rs
+++ b/crates/utilities/tx-manager/src/nonce.rs
@@ -321,12 +321,10 @@ impl NonceGuard {
     /// computation would overflow `u64`.
     pub fn consume_reserved(mut self) -> Result<u64, TxManagerError> {
         let nonce = self.nonce;
-        if let Some(ref mut guard) = self.guard {
+        if let Some(mut guard) = self.guard.take() {
             let next = nonce.checked_add(1).ok_or(TxManagerError::NonceOverflow)?;
             guard.reserved_high_water = guard.reserved_high_water.max(next);
         }
-        // Clear the guard so Drop sees `guard.is_none()` and takes no action.
-        let _ = self.guard.take();
         Ok(nonce)
     }
 

--- a/crates/utilities/tx-manager/src/nonce.rs
+++ b/crates/utilities/tx-manager/src/nonce.rs
@@ -166,7 +166,11 @@ impl NonceManager {
             // the original set retains elements < fetched (stale).
             let kept = guard.returned_nonces.split_off(&fetched);
             if !guard.returned_nonces.is_empty() {
-                debug!(pruned = guard.returned_nonces.len(), chain_nonce = fetched, "pruned stale returned nonces");
+                debug!(
+                    pruned = guard.returned_nonces.len(),
+                    chain_nonce = fetched,
+                    "pruned stale returned nonces"
+                );
             }
             guard.returned_nonces = kept;
 

--- a/crates/utilities/tx-manager/src/nonce.rs
+++ b/crates/utilities/tx-manager/src/nonce.rs
@@ -160,6 +160,16 @@ impl NonceManager {
                 debug!(nonce = fetched, "nonce fetched from chain");
                 fetched
             });
+
+            // Prune returned nonces that the chain has already confirmed.
+            // `split_off(fetched)` moves elements >= fetched into `kept`;
+            // the original set retains elements < fetched (stale).
+            let kept = guard.returned_nonces.split_off(&fetched);
+            if !guard.returned_nonces.is_empty() {
+                debug!(pruned = guard.returned_nonces.len(), chain_nonce = fetched, "pruned stale returned nonces");
+            }
+            guard.returned_nonces = kept;
+
             return Self::advance_nonce(guard, nonce);
         }
 
@@ -180,6 +190,15 @@ impl NonceManager {
         // Priority: reissue a returned nonce before allocating a fresh one.
         // BTreeSet::pop_first gives the smallest gap, filling holes
         // left-to-right so the chain can make forward progress.
+        //
+        // `reserved_high_water` is NOT updated here because the two call
+        // paths handle it differently:
+        // • `reserve_nonce` path (`send_async`): the caller's
+        //   `consume_reserved()` updates `reserved_high_water`, covering
+        //   recycled nonces.
+        // • `next_nonce` guard path (`send`): the mutex is held for the
+        //   entire signing duration, so concurrent collision is impossible
+        //   and `reserved_high_water` is irrelevant.
         if let Some(returned) = guard.returned_nonces.pop_first() {
             debug!(nonce = returned, "reissuing returned nonce");
             return Ok(NonceGuard { guard: Some(guard), nonce: returned, recycled: true });
@@ -302,6 +321,8 @@ impl NonceGuard {
             let next = nonce.checked_add(1).ok_or(TxManagerError::NonceOverflow)?;
             guard.reserved_high_water = guard.reserved_high_water.max(next);
         }
+        // Clear the guard so Drop sees `guard.is_none()` and takes no action.
+        let _ = self.guard.take();
         Ok(nonce)
     }
 

--- a/crates/utilities/tx-manager/src/nonce.rs
+++ b/crates/utilities/tx-manager/src/nonce.rs
@@ -26,6 +26,14 @@ pub struct NonceState {
     /// snapshot value) would require 2^64 calls to `reset()`, which
     /// is infeasible in practice.
     pub generation: u64,
+    /// Tracks the highest nonce consumed by [`NonceManager::reserve_nonce`].
+    ///
+    /// After a [`NonceManager::reset`], the nonce cache is cleared and
+    /// re-fetched from the chain. The high-water mark ensures that
+    /// [`NonceManager::advance_nonce`] never re-issues a nonce that was
+    /// previously reserved by a concurrent `send_async()` task. The
+    /// effective starting nonce after reset is `max(chain_nonce, reserved_high_water)`.
+    pub reserved_high_water: u64,
 }
 
 /// Manages nonce allocation and tracking.
@@ -161,10 +169,23 @@ impl NonceManager {
         mut guard: OwnedMutexGuard<NonceState>,
         nonce: u64,
     ) -> Result<NonceGuard, TxManagerError> {
-        let next = nonce.checked_add(1).ok_or(TxManagerError::NonceOverflow)?;
+        // Ensure the nonce is at least as high as the high-water mark set
+        // by previous reserve_nonce() calls. After a reset(), the chain
+        // may return a nonce below reserved values; skipping past them
+        // prevents duplicate nonce assignment.
+        let effective = nonce.max(guard.reserved_high_water);
+        if effective != nonce {
+            debug!(
+                chain_nonce = nonce,
+                high_water = guard.reserved_high_water,
+                effective,
+                "high-water mark advanced nonce past chain value",
+            );
+        }
+        let next = effective.checked_add(1).ok_or(TxManagerError::NonceOverflow)?;
         guard.nonce = Some(next);
-        debug!(nonce, "nonce reserved");
-        Ok(NonceGuard { guard: Some(guard), nonce })
+        debug!(nonce = effective, "nonce reserved");
+        Ok(NonceGuard { guard: Some(guard), nonce: effective })
     }
 
     /// Reserves the next nonce and immediately releases the lock, returning
@@ -185,9 +206,7 @@ impl NonceManager {
     /// Returns the same errors as [`next_nonce`](Self::next_nonce).
     pub async fn reserve_nonce(&self) -> Result<u64, TxManagerError> {
         let guard = self.next_nonce().await?;
-        let nonce = guard.nonce();
-        drop(guard); // consume nonce, release lock
-        Ok(nonce)
+        Ok(guard.consume_reserved())
     }
 
     /// Clears the cached nonce, forcing a fresh chain fetch on the next
@@ -225,6 +244,21 @@ impl NonceGuard {
     /// Returns the reserved nonce value.
     pub const fn nonce(&self) -> u64 {
         self.nonce
+    }
+
+    /// Consumes the reserved nonce and updates the high-water mark.
+    ///
+    /// Records `self.nonce + 1` as the high-water mark so that
+    /// [`NonceManager::advance_nonce`] will never re-issue this nonce
+    /// after a [`NonceManager::reset`]. The guard is consumed (dropped),
+    /// releasing the mutex lock.
+    pub fn consume_reserved(mut self) -> u64 {
+        let nonce = self.nonce;
+        if let Some(ref mut guard) = self.guard {
+            guard.reserved_high_water =
+                guard.reserved_high_water.max(nonce.saturating_add(1));
+        }
+        nonce
     }
 
     /// Rolls back the nonce reservation, restoring the cached nonce to
@@ -266,7 +300,10 @@ mod tests {
         /// `u64::MAX`) without a real chain fetch.
         fn new_with_nonce(provider: RootProvider, address: Address, nonce: u64) -> Self {
             Self {
-                inner: Arc::new(Mutex::new(NonceState { nonce: Some(nonce), generation: 0 })),
+                inner: Arc::new(Mutex::new(NonceState {
+                    nonce: Some(nonce),
+                    ..Default::default()
+                })),
                 provider,
                 address,
                 rpc_timeout: Duration::from_secs(10),

--- a/crates/utilities/tx-manager/src/nonce.rs
+++ b/crates/utilities/tx-manager/src/nonce.rs
@@ -1,6 +1,6 @@
 //! Nonce allocation and tracking.
 
-use std::{sync::Arc, time::Duration};
+use std::{collections::BTreeSet, sync::Arc, time::Duration};
 
 use alloy_primitives::Address;
 use alloy_provider::{Provider, RootProvider};
@@ -34,6 +34,14 @@ pub struct NonceState {
     /// previously reserved by a concurrent `send_async()` task. The
     /// effective starting nonce after reset is `max(chain_nonce, reserved_high_water)`.
     pub reserved_high_water: u64,
+    /// Nonces that were reserved via [`NonceManager::reserve_nonce`] but
+    /// never published. These are recycled by [`NonceManager::advance_nonce`]
+    /// on subsequent nonce requests, filling gaps left by failed
+    /// `send_async` tasks.
+    ///
+    /// Not cleared by [`NonceManager::reset`] — the nonces were never
+    /// published and must persist for reuse.
+    pub returned_nonces: BTreeSet<u64>,
 }
 
 /// Manages nonce allocation and tracking.
@@ -169,6 +177,14 @@ impl NonceManager {
         mut guard: OwnedMutexGuard<NonceState>,
         nonce: u64,
     ) -> Result<NonceGuard, TxManagerError> {
+        // Priority: reissue a returned nonce before allocating a fresh one.
+        // BTreeSet::pop_first gives the smallest gap, filling holes
+        // left-to-right so the chain can make forward progress.
+        if let Some(returned) = guard.returned_nonces.pop_first() {
+            debug!(nonce = returned, "reissuing returned nonce");
+            return Ok(NonceGuard { guard: Some(guard), nonce: returned, recycled: true });
+        }
+
         // Ensure the nonce is at least as high as the high-water mark set
         // by previous reserve_nonce() calls. After a reset(), the chain
         // may return a nonce below reserved values; skipping past them
@@ -185,7 +201,7 @@ impl NonceManager {
         let next = effective.checked_add(1).ok_or(TxManagerError::NonceOverflow)?;
         guard.nonce = Some(next);
         debug!(nonce = effective, "nonce reserved");
-        Ok(NonceGuard { guard: Some(guard), nonce: effective })
+        Ok(NonceGuard { guard: Some(guard), nonce: effective, recycled: false })
     }
 
     /// Reserves the next nonce and immediately releases the lock, returning
@@ -206,7 +222,7 @@ impl NonceManager {
     /// Returns the same errors as [`next_nonce`](Self::next_nonce).
     pub async fn reserve_nonce(&self) -> Result<u64, TxManagerError> {
         let guard = self.next_nonce().await?;
-        Ok(guard.consume_reserved())
+        guard.consume_reserved()
     }
 
     /// Clears the cached nonce, forcing a fresh chain fetch on the next
@@ -224,7 +240,25 @@ impl NonceManager {
         // Wrapping add is intentional: a full u64 wrap-around (2^64 resets)
         // is infeasible, and wrapping avoids a panic on overflow.
         guard.generation = guard.generation.wrapping_add(1);
+        // `returned_nonces` is intentionally NOT cleared — these nonces
+        // were never published and must persist for reuse.
         info!(address = %self.address, "nonce cache reset");
+    }
+
+    /// Returns a previously reserved nonce for reuse.
+    ///
+    /// Called when a `send_async` task fails before publishing, making the
+    /// pre-reserved nonce available for reissue by the next
+    /// [`next_nonce`](Self::next_nonce) or [`reserve_nonce`](Self::reserve_nonce)
+    /// call.
+    ///
+    /// The returned nonce is stored in [`NonceState::returned_nonces`] and
+    /// is not cleared by [`reset`](Self::reset), since it was never
+    /// published to the network.
+    pub async fn return_reserved_nonce(&self, nonce: u64) {
+        let mut guard = self.inner.lock().await;
+        guard.returned_nonces.insert(nonce);
+        debug!(nonce, "reserved nonce returned for reuse");
     }
 }
 
@@ -238,6 +272,11 @@ impl NonceManager {
 pub struct NonceGuard {
     guard: Option<OwnedMutexGuard<NonceState>>,
     nonce: u64,
+    /// Whether this guard's nonce was recycled from
+    /// [`NonceState::returned_nonces`]. Affects rollback behavior:
+    /// recycled nonces are returned to the set rather than restoring the
+    /// cache.
+    recycled: bool,
 }
 
 impl NonceGuard {
@@ -252,24 +291,38 @@ impl NonceGuard {
     /// [`NonceManager::advance_nonce`] will never re-issue this nonce
     /// after a [`NonceManager::reset`]. The guard is consumed (dropped),
     /// releasing the mutex lock.
-    pub fn consume_reserved(mut self) -> u64 {
+    ///
+    /// # Errors
+    ///
+    /// Returns [`TxManagerError::NonceOverflow`] if the high-water mark
+    /// computation would overflow `u64`.
+    pub fn consume_reserved(mut self) -> Result<u64, TxManagerError> {
         let nonce = self.nonce;
         if let Some(ref mut guard) = self.guard {
-            guard.reserved_high_water =
-                guard.reserved_high_water.max(nonce.saturating_add(1));
+            let next = nonce.checked_add(1).ok_or(TxManagerError::NonceOverflow)?;
+            guard.reserved_high_water = guard.reserved_high_water.max(next);
         }
-        nonce
+        Ok(nonce)
     }
 
     /// Rolls back the nonce reservation, restoring the cached nonce to
     /// the value that was reserved.
     ///
+    /// For recycled nonces (from [`NonceState::returned_nonces`]), the
+    /// nonce is re-inserted into the returned set rather than restoring
+    /// the cache, since the cache was never advanced for these nonces.
+    ///
     /// This allows the next call to [`NonceManager::next_nonce`] to reuse
     /// the same nonce value. Consumes the guard, releasing the lock.
     pub fn rollback(mut self) {
         if let Some(mut guard) = self.guard.take() {
-            guard.nonce = Some(self.nonce);
-            debug!(nonce = self.nonce, "nonce rolled back");
+            if self.recycled {
+                guard.returned_nonces.insert(self.nonce);
+                debug!(nonce = self.nonce, "recycled nonce returned to reuse set");
+            } else {
+                guard.nonce = Some(self.nonce);
+                debug!(nonce = self.nonce, "nonce rolled back");
+            }
         }
     }
 }
@@ -316,6 +369,8 @@ mod tests {
         let state = NonceState::default();
         assert_eq!(state.nonce, None);
         assert_eq!(state.generation, 0);
+        assert_eq!(state.reserved_high_water, 0);
+        assert!(state.returned_nonces.is_empty());
     }
 
     #[tokio::test]

--- a/crates/utilities/tx-manager/src/nonce.rs
+++ b/crates/utilities/tx-manager/src/nonce.rs
@@ -95,7 +95,7 @@ impl NonceManager {
             // Fast path: cache is populated — read-and-increment in a
             // single lock round-trip.
             if let Some(n) = guard.nonce {
-                return Self::reserve_nonce(guard, n);
+                return Self::advance_nonce(guard, n);
             }
 
             // Cache miss: snapshot the generation, then drop the lock so
@@ -144,7 +144,7 @@ impl NonceManager {
                 debug!(nonce = fetched, "nonce fetched from chain");
                 fetched
             });
-            return Self::reserve_nonce(guard, nonce);
+            return Self::advance_nonce(guard, nonce);
         }
 
         warn!(attempts = Self::MAX_RETRY_ATTEMPTS, "nonce acquisition failed after max retries",);
@@ -157,7 +157,7 @@ impl NonceManager {
     /// Both the fast path (cache hit) and Phase 3 (after RPC fetch) use
     /// this single call-site for the `checked_add` overflow check,
     /// ensuring consistent behavior.
-    fn reserve_nonce(
+    fn advance_nonce(
         mut guard: OwnedMutexGuard<NonceState>,
         nonce: u64,
     ) -> Result<NonceGuard, TxManagerError> {
@@ -165,6 +165,29 @@ impl NonceManager {
         guard.nonce = Some(next);
         debug!(nonce, "nonce reserved");
         Ok(NonceGuard { guard: Some(guard), nonce })
+    }
+
+    /// Reserves the next nonce and immediately releases the lock, returning
+    /// the raw `u64` value.
+    ///
+    /// Unlike [`next_nonce`](Self::next_nonce), this method does **not** hold
+    /// the mutex for the lifetime of a guard — it acquires, increments, and
+    /// releases in a single call. This makes the reserved nonce irrevocable:
+    /// there is no [`NonceGuard`] to roll back on failure.
+    ///
+    /// This is used by [`send_async`](crate::SimpleTxManager::send_async) to
+    /// pre-assign nonces **before** `tokio::spawn`, guaranteeing that
+    /// sequential `send_async()` calls receive monotonically increasing nonces
+    /// regardless of task scheduling order.
+    ///
+    /// # Errors
+    ///
+    /// Returns the same errors as [`next_nonce`](Self::next_nonce).
+    pub async fn reserve_nonce(&self) -> Result<u64, TxManagerError> {
+        let guard = self.next_nonce().await?;
+        let nonce = guard.nonce();
+        drop(guard); // consume nonce, release lock
+        Ok(nonce)
     }
 
     /// Clears the cached nonce, forcing a fresh chain fetch on the next

--- a/crates/utilities/tx-manager/src/send_state.rs
+++ b/crates/utilities/tx-manager/src/send_state.rs
@@ -42,6 +42,8 @@ struct SendStateInner {
     successful_publish_count: u64,
     /// Number of nonce-too-low errors encountered.
     nonce_too_low_count: u64,
+    /// Whether a nonce-too-high error was encountered.
+    nonce_too_high: bool,
     /// Whether the nonce slot was already reserved by another sender.
     already_reserved: bool,
     /// Whether the next send attempt should bump fees.
@@ -70,6 +72,7 @@ impl SendState {
                 mined_txs: HashSet::new(),
                 successful_publish_count: 0,
                 nonce_too_low_count: 0,
+                nonce_too_high: false,
                 already_reserved: false,
                 bump_fees: false,
                 bump_count: 0,
@@ -94,6 +97,9 @@ impl SendState {
         match err {
             TxManagerError::NonceTooLow => {
                 inner.nonce_too_low_count += 1;
+            }
+            TxManagerError::NonceTooHigh => {
+                inner.nonce_too_high = true;
             }
             TxManagerError::AlreadyReserved => {
                 inner.already_reserved = true;
@@ -134,13 +140,16 @@ impl SendState {
     /// 1. If any transaction is mined, returns `None` (wait for confirmation).
     /// 2. If the nonce slot was already reserved, returns
     ///    [`TxManagerError::AlreadyReserved`].
-    /// 3. If no successful publish has occurred and a nonce-too-low error was
+    /// 3. If a nonce-too-high error was seen, returns
+    ///    [`TxManagerError::NonceTooHigh`] (immediate abort — the nonce is
+    ///    ahead of chain state and no tx entered the mempool).
+    /// 4. If no successful publish has occurred and a nonce-too-low error was
     ///    seen, returns [`TxManagerError::NonceTooLow`] (immediate abort).
-    /// 4. If nonce-too-low errors have reached the threshold, returns
+    /// 5. If nonce-too-low errors have reached the threshold, returns
     ///    [`TxManagerError::NonceTooLow`].
-    /// 5. If the mempool deadline has expired, returns
+    /// 6. If the mempool deadline has expired, returns
     ///    [`TxManagerError::MempoolDeadlineExpired`].
-    /// 6. Otherwise, returns `None`.
+    /// 7. Otherwise, returns `None`.
     #[must_use]
     pub fn critical_error(&self) -> Option<TxManagerError> {
         let inner = self.inner.lock().expect("SendState mutex poisoned");
@@ -155,25 +164,31 @@ impl SendState {
             return Some(TxManagerError::AlreadyReserved);
         }
 
-        // 3. Pre-publish immediate abort: nonce consumed before any successful
+        // 3. Nonce too high: the nonce is ahead of chain state. No tx
+        //    entered the mempool, so retry is pointless without a reset.
+        if inner.nonce_too_high {
+            return Some(TxManagerError::NonceTooHigh);
+        }
+
+        // 4. Pre-publish immediate abort: nonce consumed before any successful
         //    publish.
         if inner.successful_publish_count == 0 && inner.nonce_too_low_count > 0 {
             return Some(TxManagerError::NonceTooLow);
         }
 
-        // 4. Nonce-too-low threshold reached after successful publishes.
+        // 5. Nonce-too-low threshold reached after successful publishes.
         if inner.nonce_too_low_count >= self.safe_abort_nonce_too_low_count {
             return Some(TxManagerError::NonceTooLow);
         }
 
-        // 5. Mempool deadline expired.
+        // 6. Mempool deadline expired.
         if let Some(deadline) = inner.mempool_deadline
             && Instant::now() >= deadline
         {
             return Some(TxManagerError::MempoolDeadlineExpired);
         }
 
-        // 6. No critical error — continue sending.
+        // 7. No critical error — continue sending.
         None
     }
 
@@ -502,6 +517,43 @@ mod tests {
         assert_eq!(state.critical_error(), Some(TxManagerError::NonceTooLow));
     }
 
+    // ── NonceTooHigh ───────────────────────────────────────────────────
+
+    #[test]
+    fn nonce_too_high_triggers_immediate_abort() {
+        let state = SendState::new(3).unwrap();
+        state.process_send_error(&TxManagerError::NonceTooHigh);
+        assert_eq!(state.critical_error(), Some(TxManagerError::NonceTooHigh));
+    }
+
+    #[test]
+    fn mined_tx_suppresses_nonce_too_high_abort() {
+        let state = SendState::new(3).unwrap();
+        state.process_send_error(&TxManagerError::NonceTooHigh);
+        assert_eq!(state.critical_error(), Some(TxManagerError::NonceTooHigh));
+
+        state.tx_mined(B256::with_last_byte(1));
+        assert!(state.critical_error().is_none());
+    }
+
+    #[test]
+    fn nonce_too_high_takes_priority_over_nonce_too_low() {
+        let state = SendState::new(3).unwrap();
+        state.process_send_error(&TxManagerError::NonceTooHigh);
+        state.process_send_error(&TxManagerError::NonceTooLow);
+
+        // NonceTooHigh (priority 3) wins over pre-publish NonceTooLow
+        // (priority 4).
+        assert_eq!(state.critical_error(), Some(TxManagerError::NonceTooHigh));
+    }
+
+    #[test]
+    fn nonce_too_high_does_not_set_bump_fees() {
+        let state = SendState::new(3).unwrap();
+        state.process_send_error(&TxManagerError::NonceTooHigh);
+        assert!(!state.should_bump_fees());
+    }
+
     // ── AlreadyReserved ─────────────────────────────────────────────────
 
     #[test]
@@ -520,7 +572,7 @@ mod tests {
         state.set_mempool_deadline(Instant::now() - Duration::from_secs(1));
 
         // AlreadyReserved (priority 2) wins over MempoolDeadlineExpired
-        // (priority 5).
+        // (priority 6).
         assert_eq!(state.critical_error(), Some(TxManagerError::AlreadyReserved));
     }
 
@@ -531,8 +583,8 @@ mod tests {
         state.process_send_error(&TxManagerError::NonceTooLow);
         state.set_mempool_deadline(Instant::now() - Duration::from_secs(1));
 
-        // Pre-publish NonceTooLow (priority 3) wins over
-        // MempoolDeadlineExpired (priority 5).
+        // Pre-publish NonceTooLow (priority 4) wins over
+        // MempoolDeadlineExpired (priority 6).
         assert_eq!(state.critical_error(), Some(TxManagerError::NonceTooLow));
     }
 

--- a/crates/utilities/tx-manager/tests/nonce.rs
+++ b/crates/utilities/tx-manager/tests/nonce.rs
@@ -278,3 +278,80 @@ async fn reserve_nonce_consumes_and_increments() {
     let guard = manager.next_nonce().await.expect("next_nonce after reserves");
     assert_eq!(guard.nonce(), 3);
 }
+
+// ── high-water mark tests ─────────────────────────────────────────
+
+#[tokio::test]
+async fn consume_reserved_sets_high_water_mark() {
+    let (manager, _anvil) = setup();
+
+    // Reserve nonce 0 — sets high-water mark to 1.
+    let n = manager.reserve_nonce().await.expect("should reserve nonce 0");
+    assert_eq!(n, 0);
+
+    // Reset clears the cache; chain returns 0 since no tx was sent.
+    // But the high-water mark ensures we skip past nonce 0.
+    manager.reset().await;
+    let guard = manager.next_nonce().await.expect("should get nonce after reset");
+    assert_eq!(guard.nonce(), 1, "high-water mark should prevent reuse of reserved nonce 0");
+}
+
+#[tokio::test]
+async fn high_water_mark_tracks_highest_reservation() {
+    let (manager, _anvil) = setup();
+
+    // Reserve nonces 0, 1, 2 — high-water mark advances to 3.
+    for expected in 0..3u64 {
+        let n = manager.reserve_nonce().await.expect("should reserve nonce");
+        assert_eq!(n, expected);
+    }
+
+    // Reset and verify next nonce skips past all reserved nonces.
+    manager.reset().await;
+    let guard = manager.next_nonce().await.expect("should get nonce after reset");
+    assert_eq!(guard.nonce(), 3, "next nonce after reset should skip past all reserved nonces");
+}
+
+#[tokio::test]
+async fn high_water_mark_no_op_when_cache_ahead() {
+    let (manager, _anvil) = setup();
+
+    // Reserve nonce 0 — high-water mark is 1.
+    let n = manager.reserve_nonce().await.expect("should reserve nonce 0");
+    assert_eq!(n, 0);
+
+    // Advance the cache past the high-water mark via next_nonce.
+    let g1 = manager.next_nonce().await.expect("nonce 1");
+    assert_eq!(g1.nonce(), 1);
+    drop(g1);
+    let g2 = manager.next_nonce().await.expect("nonce 2");
+    assert_eq!(g2.nonce(), 2);
+    drop(g2);
+
+    // Cache is at 3, high-water mark is 1. Next nonce should be 3 (no interference).
+    let g3 = manager.next_nonce().await.expect("nonce 3");
+    assert_eq!(g3.nonce(), 3, "high-water mark should not interfere when cache is ahead");
+}
+
+#[tokio::test]
+async fn reserve_nonce_protects_against_reset_collision() {
+    let (manager, _anvil) = setup();
+
+    // Reserve nonces 0 and 1 (simulating two concurrent send_async calls).
+    let n0 = manager.reserve_nonce().await.expect("should reserve nonce 0");
+    let n1 = manager.reserve_nonce().await.expect("should reserve nonce 1");
+    assert_eq!(n0, 0);
+    assert_eq!(n1, 1);
+
+    // Simulate a concurrent send() failure triggering reset().
+    manager.reset().await;
+
+    // After reset, chain returns 0. But high-water mark (2) ensures
+    // next_nonce() returns >= 2, avoiding collision with reserved 0 and 1.
+    let guard = manager.next_nonce().await.expect("should get nonce after reset");
+    assert!(
+        guard.nonce() >= 2,
+        "nonce after reset must be >= 2 to avoid collision with reserved nonces, got {}",
+        guard.nonce(),
+    );
+}

--- a/crates/utilities/tx-manager/tests/nonce.rs
+++ b/crates/utilities/tx-manager/tests/nonce.rs
@@ -258,3 +258,23 @@ async fn concurrent_next_nonce_uniqueness_across_resets() {
         manager.reset().await;
     }
 }
+
+#[tokio::test]
+async fn reserve_nonce_consumes_and_increments() {
+    let (manager, _anvil) = setup();
+
+    // reserve_nonce returns sequential values starting from 0.
+    let n0 = manager.reserve_nonce().await.expect("first reserve");
+    assert_eq!(n0, 0);
+
+    let n1 = manager.reserve_nonce().await.expect("second reserve");
+    assert_eq!(n1, 1);
+
+    let n2 = manager.reserve_nonce().await.expect("third reserve");
+    assert_eq!(n2, 2);
+
+    // The lock is released immediately — next_nonce can acquire it
+    // without blocking and picks up from where reserve_nonce left off.
+    let guard = manager.next_nonce().await.expect("next_nonce after reserves");
+    assert_eq!(guard.nonce(), 3);
+}

--- a/crates/utilities/tx-manager/tests/nonce.rs
+++ b/crates/utilities/tx-manager/tests/nonce.rs
@@ -349,9 +349,117 @@ async fn reserve_nonce_protects_against_reset_collision() {
     // After reset, chain returns 0. But high-water mark (2) ensures
     // next_nonce() returns >= 2, avoiding collision with reserved 0 and 1.
     let guard = manager.next_nonce().await.expect("should get nonce after reset");
-    assert!(
-        guard.nonce() >= 2,
-        "nonce after reset must be >= 2 to avoid collision with reserved nonces, got {}",
+    assert_eq!(
         guard.nonce(),
+        2,
+        "nonce after reset must be exactly 2 to avoid collision with reserved nonces 0 and 1",
     );
+}
+
+// ── returned nonce (gap recovery) tests ───────────────────────────
+
+#[tokio::test]
+async fn return_reserved_nonce_enables_reuse() {
+    let (manager, _anvil) = setup();
+
+    // Reserve nonces 0, 1, 2.
+    let n0 = manager.reserve_nonce().await.unwrap();
+    let n1 = manager.reserve_nonce().await.unwrap();
+    let n2 = manager.reserve_nonce().await.unwrap();
+    assert_eq!((n0, n1, n2), (0, 1, 2));
+
+    // Simulate failure of task with nonce 1.
+    manager.return_reserved_nonce(1).await;
+
+    // next_nonce should reissue 1 before allocating 3.
+    let guard = manager.next_nonce().await.unwrap();
+    assert_eq!(guard.nonce(), 1, "returned nonce should be reissued");
+    drop(guard);
+
+    // After reissue, next nonce should be 3 (fresh).
+    let guard = manager.next_nonce().await.unwrap();
+    assert_eq!(guard.nonce(), 3, "next nonce should be fresh after returned nonce consumed");
+}
+
+#[tokio::test]
+async fn returned_nonces_survive_reset() {
+    let (manager, _anvil) = setup();
+
+    let n = manager.reserve_nonce().await.unwrap();
+    assert_eq!(n, 0);
+
+    // Return it then reset — returned nonce must persist.
+    manager.return_reserved_nonce(0).await;
+    manager.reset().await;
+
+    let guard = manager.next_nonce().await.unwrap();
+    assert_eq!(guard.nonce(), 0, "returned nonce should survive reset");
+}
+
+#[tokio::test]
+async fn rollback_recycled_nonce_re_inserts() {
+    let (manager, _anvil) = setup();
+
+    // Reserve 0 and 1, return 0.
+    let _ = manager.reserve_nonce().await.unwrap();
+    let _ = manager.reserve_nonce().await.unwrap();
+    manager.return_reserved_nonce(0).await;
+
+    // Get recycled nonce 0.
+    let guard = manager.next_nonce().await.unwrap();
+    assert_eq!(guard.nonce(), 0);
+
+    // Roll it back — should re-insert into returned_nonces.
+    guard.rollback();
+
+    // Next nonce should be 0 again.
+    let guard = manager.next_nonce().await.unwrap();
+    assert_eq!(guard.nonce(), 0, "rolled-back recycled nonce should be reissued");
+}
+
+#[tokio::test]
+async fn multiple_returned_nonces_reissued_in_order() {
+    let (manager, _anvil) = setup();
+
+    // Reserve 0, 1, 2, 3.
+    for _ in 0..4 {
+        manager.reserve_nonce().await.unwrap();
+    }
+
+    // Return 3 and 1 (out of order).
+    manager.return_reserved_nonce(3).await;
+    manager.return_reserved_nonce(1).await;
+
+    // Should reissue smallest first: 1, then 3.
+    let g1 = manager.next_nonce().await.unwrap();
+    assert_eq!(g1.nonce(), 1);
+    drop(g1);
+
+    let g3 = manager.next_nonce().await.unwrap();
+    assert_eq!(g3.nonce(), 3);
+    drop(g3);
+
+    // Next fresh nonce should be 4.
+    let g4 = manager.next_nonce().await.unwrap();
+    assert_eq!(g4.nonce(), 4, "next fresh nonce after returned nonces should be 4");
+}
+
+#[tokio::test]
+async fn reserve_nonce_reuses_returned_nonce() {
+    let (manager, _anvil) = setup();
+
+    // Reserve 0 and 1.
+    let _ = manager.reserve_nonce().await.unwrap();
+    let _ = manager.reserve_nonce().await.unwrap();
+
+    // Return 0.
+    manager.return_reserved_nonce(0).await;
+
+    // reserve_nonce should reissue 0 (via next_nonce → advance_nonce).
+    let n = manager.reserve_nonce().await.unwrap();
+    assert_eq!(n, 0, "reserve_nonce should reuse returned nonce");
+
+    // Next fresh should be 2.
+    let n = manager.reserve_nonce().await.unwrap();
+    assert_eq!(n, 2, "next reserve after reuse should be fresh nonce 2");
 }

--- a/crates/utilities/tx-manager/tests/nonce.rs
+++ b/crates/utilities/tx-manager/tests/nonce.rs
@@ -2,9 +2,12 @@
 
 use std::time::Duration;
 
+use alloy_network::EthereumWallet;
 use alloy_node_bindings::Anvil;
-use alloy_primitives::Address;
-use alloy_provider::RootProvider;
+use alloy_primitives::{Address, U256};
+use alloy_provider::{Provider, ProviderBuilder, RootProvider};
+use alloy_rpc_types_eth::TransactionRequest;
+use alloy_signer_local::PrivateKeySigner;
 use base_tx_manager::{NonceGuard, NonceManager, TxManagerError};
 use rayon::prelude::*;
 
@@ -462,4 +465,66 @@ async fn reserve_nonce_reuses_returned_nonce() {
     // Next fresh should be 2.
     let n = manager.reserve_nonce().await.unwrap();
     assert_eq!(n, 2, "next reserve after reuse should be fresh nonce 2");
+}
+
+// ── returned nonce pruning tests ──────────────────────────────────
+
+#[tokio::test]
+async fn returned_nonces_below_chain_count_are_pruned_after_reset() {
+    let anvil = Anvil::new().spawn();
+    let url = anvil.endpoint_url();
+    let address = anvil.addresses()[0];
+
+    // Create a wallet-backed provider to send real transactions.
+    let signer: PrivateKeySigner = anvil.keys()[0].clone().into();
+    let wallet = EthereumWallet::from(signer);
+    let sender = ProviderBuilder::new().wallet(wallet).connect_http(url.clone());
+
+    // Send two real transactions to advance the chain nonce to 2.
+    for _ in 0..2 {
+        let tx = TransactionRequest::default().to(address).value(U256::from(1));
+        let _ = sender.send_transaction(tx).await.unwrap().get_receipt().await.unwrap();
+    }
+
+    // Verify chain nonce is now 2.
+    let root = RootProvider::new_http(url);
+    let chain_nonce = root.get_transaction_count(address).await.unwrap();
+    assert_eq!(chain_nonce, 2);
+
+    // Create a NonceManager and populate its cache.
+    let manager = NonceManager::new(root, address, Duration::from_secs(10));
+    let guard = manager.next_nonce().await.unwrap();
+    assert_eq!(guard.nonce(), 2);
+    drop(guard);
+
+    // Reserve nonces 3, 4 and return them (simulating failed send_async).
+    let _ = manager.reserve_nonce().await.unwrap(); // 3
+    let _ = manager.reserve_nonce().await.unwrap(); // 4
+    manager.return_reserved_nonce(3).await;
+    manager.return_reserved_nonce(4).await;
+
+    // Also return nonces 0 and 1 — these are below the chain nonce and
+    // should be pruned after a reset + re-fetch.
+    manager.return_reserved_nonce(0).await;
+    manager.return_reserved_nonce(1).await;
+
+    // Reset forces a chain fetch; the pruning logic should remove 0 and 1
+    // (which are < chain_nonce 2) and keep 3 and 4 (which are >= 2).
+    manager.reset().await;
+
+    // The next nonce should be a returned nonce >= chain_nonce.
+    // Since returned_nonces has {3, 4} after pruning, the smallest (3)
+    // should be reissued first.
+    let guard = manager.next_nonce().await.unwrap();
+    assert_eq!(guard.nonce(), 3, "stale nonces 0 and 1 should have been pruned");
+    drop(guard);
+
+    let guard = manager.next_nonce().await.unwrap();
+    assert_eq!(guard.nonce(), 4, "returned nonce 4 should still be available");
+    drop(guard);
+
+    // After both returned nonces are consumed, next should be fresh (5).
+    // high-water mark from reserve_nonce(4) is 5, chain nonce is 2 → effective is 5.
+    let guard = manager.next_nonce().await.unwrap();
+    assert_eq!(guard.nonce(), 5, "next fresh nonce should be 5");
 }

--- a/crates/utilities/tx-manager/tests/send_lifecycle.rs
+++ b/crates/utilities/tx-manager/tests/send_lifecycle.rs
@@ -9,7 +9,7 @@ use std::{
     time::Duration,
 };
 
-use alloy_consensus::SignableTransaction;
+use alloy_consensus::{SignableTransaction, Transaction};
 use alloy_network::{EthereumWallet, TxSigner};
 use alloy_node_bindings::Anvil;
 use alloy_primitives::{Address, B256, Signature, U256};
@@ -485,4 +485,50 @@ async fn query_receipt_returns_error_on_unreachable_provider() {
     .await;
 
     assert!(result.is_err(), "query_receipt should fail when provider is unreachable");
+}
+
+// ── send_async() nonce ordering ───────────────────────────────────────
+
+/// Sequential `send_async()` calls receive monotonically increasing nonces,
+/// regardless of tokio task scheduling order.
+#[tokio::test]
+async fn send_async_preserves_call_order_nonces() {
+    let (manager, _anvil) = setup_with_config(fast_send_config()).await;
+
+    let count = 5;
+    let mut handles = Vec::with_capacity(count);
+
+    // Call send_async sequentially — each call pre-reserves a nonce before
+    // spawning, so the nonce assignment matches call order.
+    for _ in 0..count {
+        let candidate = TxCandidate {
+            to: Some(Address::with_last_byte(0x42)),
+            value: U256::from(1u64),
+            gas_limit: 0,
+            ..Default::default()
+        };
+        handles.push(manager.send_async(candidate).await);
+    }
+
+    // Collect receipts (order may differ from send order).
+    let mut nonces: Vec<u64> = Vec::with_capacity(count);
+    for handle in handles {
+        let receipt = tokio::time::timeout(Duration::from_secs(30), handle)
+            .await
+            .expect("send_async should complete within 30 s")
+            .expect("send_async should succeed");
+
+        let tx = manager
+            .provider()
+            .get_transaction_by_hash(receipt.transaction_hash)
+            .await
+            .expect("should fetch tx")
+            .expect("tx should exist");
+        nonces.push(tx.inner.nonce());
+    }
+
+    // Nonces should form a contiguous, monotonically increasing sequence
+    // starting from 0.
+    let expected: Vec<u64> = (0..count as u64).collect();
+    assert_eq!(nonces, expected, "send_async nonces should match call order");
 }

--- a/crates/utilities/tx-manager/tests/send_lifecycle.rs
+++ b/crates/utilities/tx-manager/tests/send_lifecycle.rs
@@ -22,6 +22,18 @@ use base_tx_manager::{
 use rstest::rstest;
 use tokio::sync::mpsc;
 
+/// Force-mine a block on Anvil so receipts are committed before queries.
+///
+/// Under CI load Anvil's auto-mine may not have flushed yet, causing
+/// `query_receipt` to see stale tip heights or missing receipts.
+async fn mine_block(manager: &SimpleTxManager) {
+    manager
+        .provider()
+        .raw_request::<(), String>("evm_mine".into(), ())
+        .await
+        .expect("evm_mine should succeed");
+}
+
 /// Returns a config with fast polling suitable for tests.
 fn fast_polling_config() -> TxManagerConfig {
     TxManagerConfig {
@@ -241,11 +253,7 @@ async fn query_receipt_returns_confirmed_receipt() {
     // Mine an extra block so tip_height is strictly ahead of the tx block.
     // query_receipt fetches tip_height before the receipt (for reorg safety),
     // so under CI load the tip may be stale on a single-call test.
-    manager
-        .provider()
-        .raw_request::<(), String>("evm_mine".into(), ())
-        .await
-        .expect("evm_mine should succeed");
+    mine_block(&manager).await;
 
     // With num_confirmations = 1 and the extra block mined above,
     // the formula tx_block + 1 <= tip + 1 is satisfied.
@@ -284,6 +292,10 @@ async fn query_receipt_returns_none_when_not_enough_confirmations() {
     let send_state = SendState::new(3).expect("should create send state");
     let tx_hash =
         manager.publish_tx(&send_state, &prepared.raw_tx, None).await.expect("should publish tx");
+
+    // Mine an extra block so the receipt is available before we query.
+    // Under CI load Anvil's auto-mine may not have committed yet.
+    mine_block(&manager).await;
 
     // Require 100 confirmations — far more than the single block Anvil
     // has mined. The receipt exists but is not sufficiently confirmed.

--- a/crates/utilities/tx-manager/tests/send_lifecycle.rs
+++ b/crates/utilities/tx-manager/tests/send_lifecycle.rs
@@ -532,3 +532,29 @@ async fn send_async_preserves_call_order_nonces() {
     let expected: Vec<u64> = (0..count as u64).collect();
     assert_eq!(nonces, expected, "send_async nonces should match call order");
 }
+
+/// When `send_async` fails before publishing (e.g., signing failure), the
+/// pre-reserved nonce is returned for reuse by subsequent calls.
+#[tokio::test]
+async fn send_async_failure_returns_nonce_for_reuse() {
+    let (manager, _anvil) = setup_with_failing_signer_config(fast_send_config()).await;
+    let candidate = TxCandidate {
+        to: Some(Address::with_last_byte(0x42)),
+        value: U256::from(1u64),
+        gas_limit: 0,
+        ..Default::default()
+    };
+
+    // send_async reserves nonce 0, spawned task fails at signing.
+    let handle = manager.send_async(candidate).await;
+    let err = tokio::time::timeout(Duration::from_secs(30), handle)
+        .await
+        .expect("send_async should complete")
+        .expect_err("send_async should fail with signing error");
+
+    assert!(matches!(err, TxManagerError::Sign(_)), "expected sign error, got {err:?}");
+
+    // The nonce should have been returned. Next nonce should be 0, not 1.
+    let guard = manager.nonce_manager().next_nonce().await.expect("should get nonce");
+    assert_eq!(guard.nonce(), 0, "returned nonce should be reused after send_async failure");
+}

--- a/crates/utilities/tx-manager/tests/send_lifecycle.rs
+++ b/crates/utilities/tx-manager/tests/send_lifecycle.rs
@@ -491,7 +491,7 @@ async fn query_receipt_returns_error_on_unreachable_provider() {
 
 /// Sequential `send_async()` calls receive monotonically increasing nonces,
 /// regardless of tokio task scheduling order.
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn send_async_preserves_call_order_nonces() {
     let (manager, _anvil) = setup_with_config(fast_send_config()).await;
 


### PR DESCRIPTION
### What changed? Why?

Fixes nonce handling for `send_async()` to guarantee call-order nonce assignment and prevent nonce gaps on failure.

**Problem:** `send_async()` previously spawned a tokio task and acquired the nonce inside the task. This meant two sequential `send_async()` calls could receive out-of-order nonces depending on task scheduling, violating the caller's expected ordering guarantees.

**Solution:** Pre-reserve nonces *before* `tokio::spawn` so that sequential `send_async()` calls receive monotonically increasing nonces regardless of task scheduling. This required several coordinated changes:

- **`NonceManager::reserve_nonce()`** — new method that acquires a nonce and immediately releases the lock, returning a raw `u64`. The nonce is irrevocable (no guard-based rollback).
- **`reserved_high_water` tracking** — prevents `reset()` from re-issuing nonces that were already reserved by concurrent `send_async()` tasks. After reset, `advance_nonce()` skips past the high-water mark.
- **`returned_nonces` pool** — when a `send_async` task fails before publishing, the pre-reserved nonce is returned via `return_reserved_nonce()` for reuse by subsequent calls, preventing irrecoverable nonce gaps. Returned nonces survive `reset()` (they were never published) and are pruned when the chain nonce advances past them.
- **`nonce_override` plumbing** — `send_tx()`, `send_tx_inner()`, `craft_tx_with_caps()`, and `prepare_with_initial_caps()` accept an optional nonce override, bypassing the nonce manager lock when a nonce was pre-assigned.
- **Fee bump nonce reuse** — bump iterations now reuse the original nonce via `nonce_override` instead of resetting the nonce manager, which would corrupt concurrent `send_async` reservations.
- **`NonceTooHigh` handling** — new error variant in `SendState` triggers immediate abort and nonce manager reset (safe because `reserved_high_water` protects concurrent reservations).
- **`NonceGuard` recycled flag** — rollback of recycled (returned) nonces re-inserts them into the reuse pool rather than restoring the cache.

### Notes to reviewers

The `nonce_override` parameter threads through several layers — this is intentional to keep the nonce manager lock semantics clean (either guard-managed or caller-managed, never mixed).

### How has it been tested?

- Unit tests for `should_reset_nonce_on_send_error` with nonce override cases
- Unit tests for `should_return_reserved_nonce` (pre-publish failure vs post-publish)
- Unit tests for `NonceTooHigh` in `SendState` (immediate abort, priority, suppression by mined tx)
- Integration tests for `reserve_nonce` (sequential values, high-water mark, reset protection)
- Integration tests for returned nonce reuse (gap recovery, ordering, reset survival, pruning of stale nonces)
- Integration test for `send_async` call-order nonce preservation (multi-threaded tokio)
- Integration test for `send_async` failure returning nonce for reuse

### Change management ([definitions](http://go/change-management))

type=routine<!--routine,nonroutine,emergency-->
risk=medium<!--low,medium,high-->
impact=sev5<!--sev5,sev4,sev3,sev2,sev1-->

### Backwards Compatibility ([learn more](http://go/backwards-compatibility))

backwards_compatible=true<!-- true false -->

<!-- Automatically merge your PR once the necessary approvals have been received (you probably want this) -->

automerge=false