### PR TITLE
minor changes to span and mock engine client

### DIFF
--- a/crates/consensus/engine/src/test_utils/engine_client.rs
+++ b/crates/consensus/engine/src/test_utils/engine_client.rs
@@ -98,14 +98,16 @@ pub struct MockEngineStorage {
 ///
 /// # Example
 ///
-/// ```rust,ignore
+/// ```rust
 /// use base_consensus_engine::test_utils::{MockEngineClient};
+/// use base_consensus_genesis::RollupConfig;
 /// use alloy_rpc_types_engine::{PayloadStatus, PayloadStatusEnum};
+/// use alloy_primitives::B256;
 /// use std::sync::Arc;
 ///
 /// let mock = MockEngineClient::builder()
 ///     .with_config(Arc::new(RollupConfig::default()))
-///     .with_payload_status(PayloadStatus {
+///     .with_new_payload_v1_response(PayloadStatus {
 ///         status: PayloadStatusEnum::Valid,
 ///         latest_valid_hash: Some(B256::ZERO),
 ///     })

--- a/crates/consensus/protocol/src/batch/span.rs
+++ b/crates/consensus/protocol/src/batch/span.rs
@@ -782,15 +782,6 @@ mod tests {
     }
 
     #[test]
-    fn test_timestamp() {
-        let timestamp = 10;
-        let first_element = SpanBatchElement { timestamp, ..Default::default() };
-        let batch =
-            SpanBatch { batches: vec![first_element, Default::default()], ..Default::default() };
-        assert_eq!(batch.starting_timestamp(), timestamp);
-    }
-
-    #[test]
     fn test_starting_timestamp() {
         let timestamp = 10;
         let first_element = SpanBatchElement { timestamp, ..Default::default() };


### PR DESCRIPTION
PR makes three minor changes
- update method on `MockEngineClient` so it compiles when test-utils feature is enabled
- prevent `origin_index` resets during search, as both l1_origins and batches are expected to be ordered
- remove duplicate tests in span