### PR TITLE
feat(CHAIN-3452): ProverClient for prover signer endpoints

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4399,6 +4399,8 @@ dependencies = [
  "async-trait",
  "aws-sdk-ec2",
  "aws-sdk-elasticloadbalancingv2",
+ "jsonrpsee",
+ "k256",
  "rstest",
  "thiserror 2.0.18",
  "tokio",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4399,6 +4399,8 @@ dependencies = [
  "async-trait",
  "aws-sdk-ec2",
  "aws-sdk-elasticloadbalancingv2",
+ "base-proof-primitives",
+ "hex-literal 1.1.0",
  "jsonrpsee",
  "k256",
  "rstest",

--- a/crates/proof/tee/registrar/Cargo.toml
+++ b/crates/proof/tee/registrar/Cargo.toml
@@ -42,7 +42,7 @@ tracing.workspace = true
 url.workspace = true
 
 [dev-dependencies]
-hex-literal.workspace = true
 rstest.workspace = true
+hex-literal.workspace = true
 k256 = { workspace = true, features = ["ecdsa"] }
 tokio = { workspace = true, features = ["rt", "macros"] }

--- a/crates/proof/tee/registrar/Cargo.toml
+++ b/crates/proof/tee/registrar/Cargo.toml
@@ -22,6 +22,9 @@ alloy-signer-local.workspace = true
 aws-sdk-ec2.workspace = true
 aws-sdk-elasticloadbalancingv2.workspace = true
 
+# Crypto
+k256.workspace = true
+
 # RPC
 jsonrpsee = { workspace = true, features = ["http-client"] }
 
@@ -38,6 +41,5 @@ tracing.workspace = true
 url.workspace = true
 
 [dev-dependencies]
-k256.workspace = true
 rstest.workspace = true
 tokio = { workspace = true, features = ["rt", "macros"] }

--- a/crates/proof/tee/registrar/Cargo.toml
+++ b/crates/proof/tee/registrar/Cargo.toml
@@ -42,4 +42,5 @@ url.workspace = true
 
 [dev-dependencies]
 rstest.workspace = true
+k256 = { workspace = true, features = ["ecdsa"] }
 tokio = { workspace = true, features = ["rt", "macros"] }

--- a/crates/proof/tee/registrar/Cargo.toml
+++ b/crates/proof/tee/registrar/Cargo.toml
@@ -26,7 +26,8 @@ aws-sdk-elasticloadbalancingv2.workspace = true
 k256.workspace = true
 
 # RPC
-jsonrpsee = { workspace = true, features = ["http-client"] }
+jsonrpsee = { workspace = true, features = ["http-client", "server"] }
+base-proof-primitives = { workspace = true, features = ["rpc-client"] }
 
 # Async
 async-trait.workspace = true
@@ -41,6 +42,7 @@ tracing.workspace = true
 url.workspace = true
 
 [dev-dependencies]
+hex-literal.workspace = true
 rstest.workspace = true
 k256 = { workspace = true, features = ["ecdsa"] }
 tokio = { workspace = true, features = ["rt", "macros"] }

--- a/crates/proof/tee/registrar/Cargo.toml
+++ b/crates/proof/tee/registrar/Cargo.toml
@@ -22,6 +22,9 @@ alloy-signer-local.workspace = true
 aws-sdk-ec2.workspace = true
 aws-sdk-elasticloadbalancingv2.workspace = true
 
+# RPC
+jsonrpsee = { workspace = true, features = ["http-client"] }
+
 # Async
 async-trait.workspace = true
 
@@ -35,5 +38,6 @@ tracing.workspace = true
 url.workspace = true
 
 [dev-dependencies]
+k256.workspace = true
 rstest.workspace = true
 tokio = { workspace = true, features = ["rt", "macros"] }

--- a/crates/proof/tee/registrar/README.md
+++ b/crates/proof/tee/registrar/README.md
@@ -14,6 +14,7 @@ to detect new Nitro enclave instances, fetches their attestation documents via
 - **`config`** — [`RegistrarConfig`] runtime config struct, [`BoundlessConfig`],
   and [`SigningConfig`] for L1 transaction signing.
 - **`error`** — [`RegistrarError`] enum covering all failure modes.
+- **`prover`** — [`ProverClient`] JSON-RPC client for polling prover signer endpoints.
 - **`traits`** — [`InstanceDiscovery`] and [`AttestationProofProvider`] trait definitions.
 - **`types`** — Core domain types: [`ProverInstance`], [`AttestationResponse`],
   [`AttestationProof`], [`RegisteredSigner`].

--- a/crates/proof/tee/registrar/src/error.rs
+++ b/crates/proof/tee/registrar/src/error.rs
@@ -17,6 +17,10 @@ pub enum RegistrarError {
         source: Box<dyn std::error::Error + Send + Sync>,
     },
 
+    /// Public key returned by a prover instance is malformed.
+    #[error("invalid public key: {0}")]
+    InvalidPublicKey(String),
+
     /// ZK proof generation failed.
     #[error("proof generation failed")]
     ProofGeneration(#[source] Box<dyn std::error::Error + Send + Sync>),

--- a/crates/proof/tee/registrar/src/lib.rs
+++ b/crates/proof/tee/registrar/src/lib.rs
@@ -13,6 +13,9 @@ pub use discovery::{AwsTargetGroupDiscovery, K8sStatefulSetDiscovery};
 mod error;
 pub use error::{RegistrarError, Result};
 
+mod prover;
+pub use prover::ProverClient;
+
 mod registry;
 pub use registry::{RegistryClient, RegistryContractClient};
 

--- a/crates/proof/tee/registrar/src/prover.rs
+++ b/crates/proof/tee/registrar/src/prover.rs
@@ -45,10 +45,10 @@ impl ProverClient {
 
     /// Fetches the signer's 65-byte uncompressed public key via `enclave_signerPublicKey`.
     ///
-    /// Uses `Vec<u8>` deserialization to match the server's `RpcResult<Vec<u8>>` return type
-    /// (serialized as a JSON array of numbers by serde). Note: the existing `EnclaveClient`
-    /// in `base-enclave-client` deserializes as `Bytes` (hex string) for the same methods —
-    /// if the wire format is confirmed to differ, this should be updated accordingly.
+    /// Deserializes as `Vec<u8>` to match the server's canonical `RpcResult<Vec<u8>>` return
+    /// type in `EnclaveApi` (serialized as a JSON array of numbers by serde). Note: the
+    /// existing `EnclaveClient` in `base-enclave-client` deserializes as `Bytes` for the
+    /// same methods — that appears to be a mismatch on the client side, not here.
     pub async fn signer_public_key(&self) -> Result<Vec<u8>> {
         debug!(endpoint = %self.endpoint, "fetching signer public key");
         self.inner.request::<Vec<u8>, _>("enclave_signerPublicKey", rpc_params![]).await.map_err(
@@ -146,17 +146,30 @@ mod tests {
 
     #[rstest]
     #[case::empty(0)]
-    #[case::compressed(33)]
+    #[case::invalid_33_bytes(33)]
     #[case::too_long(66)]
-    fn derive_address_rejects_wrong_length(#[case] len: usize) {
+    fn derive_address_rejects_invalid_bytes(#[case] len: usize) {
         let key = vec![0x04; len];
         assert!(ProverClient::derive_address(&key).is_err());
     }
 
     #[test]
-    fn derive_address_rejects_wrong_prefix() {
+    fn derive_address_rejects_prefix_length_mismatch() {
+        // 0x02 = compressed prefix expects 33 bytes, but key is 65 bytes.
         let mut key = hardhat_public_key();
-        key[0] = 0x02; // compressed prefix
+        key[0] = 0x02;
         assert!(ProverClient::derive_address(&key).is_err());
+    }
+
+    #[test]
+    fn derive_address_compressed_matches_uncompressed() {
+        let signing_key = SigningKey::from_slice(&HARDHAT_PRIVATE_KEY).unwrap();
+        let verifying_key = signing_key.verifying_key();
+        let compressed = verifying_key.to_encoded_point(true).as_bytes().to_vec();
+        let uncompressed = hardhat_public_key();
+
+        let addr_compressed = ProverClient::derive_address(&compressed).unwrap();
+        let addr_uncompressed = ProverClient::derive_address(&uncompressed).unwrap();
+        assert_eq!(addr_compressed, addr_uncompressed);
     }
 }

--- a/crates/proof/tee/registrar/src/prover.rs
+++ b/crates/proof/tee/registrar/src/prover.rs
@@ -3,11 +3,8 @@
 use std::time::Duration;
 
 use alloy_primitives::{Address, Bytes, keccak256};
-use jsonrpsee::{
-    core::client::ClientT,
-    http_client::{HttpClient, HttpClientBuilder},
-    rpc_params,
-};
+use base_proof_primitives::EnclaveApiClient;
+use jsonrpsee::http_client::{HttpClient, HttpClientBuilder};
 use k256::elliptic_curve::sec1::ToEncodedPoint;
 use tracing::debug;
 
@@ -45,29 +42,24 @@ impl ProverClient {
 
     /// Fetches the signer's 65-byte uncompressed public key via `enclave_signerPublicKey`.
     ///
-    /// Deserializes as `Vec<u8>` to match the server's canonical `RpcResult<Vec<u8>>` return
-    /// type in `EnclaveApi` (serialized as a JSON array of numbers by serde). Note: the
-    /// existing `EnclaveClient` in `base-enclave-client` deserializes as `Bytes` for the
-    /// same methods — that appears to be a mismatch on the client side, not here.
+    /// Uses the generated [`EnclaveApiClient`] trait from `base-proof-primitives`,
+    /// which ensures the method name and return type (`Vec<u8>`) match the server's
+    /// `EnclaveApi` trait at compile time.
     pub async fn signer_public_key(&self) -> Result<Vec<u8>> {
         debug!(endpoint = %self.endpoint, "fetching signer public key");
-        self.inner.request::<Vec<u8>, _>("enclave_signerPublicKey", rpc_params![]).await.map_err(
-            |e| RegistrarError::ProverClient {
-                instance: self.endpoint.clone(),
-                source: Box::new(e),
-            },
-        )
+        self.inner.signer_public_key().await.map_err(|e| RegistrarError::ProverClient {
+            instance: self.endpoint.clone(),
+            source: Box::new(e),
+        })
     }
 
     /// Fetches the raw Nitro attestation document via `enclave_signerAttestation`.
     pub async fn signer_attestation(&self) -> Result<Vec<u8>> {
         debug!(endpoint = %self.endpoint, "fetching signer attestation");
-        self.inner.request::<Vec<u8>, _>("enclave_signerAttestation", rpc_params![]).await.map_err(
-            |e| RegistrarError::ProverClient {
-                instance: self.endpoint.clone(),
-                source: Box::new(e),
-            },
-        )
+        self.inner.signer_attestation().await.map_err(|e| RegistrarError::ProverClient {
+            instance: self.endpoint.clone(),
+            source: Box::new(e),
+        })
     }
 
     /// Derives an Ethereum [`Address`] from a SEC1-encoded public key.
@@ -110,17 +102,15 @@ impl ProverClient {
 #[cfg(test)]
 mod tests {
     use alloy_primitives::address;
+    use hex_literal::hex;
     use k256::ecdsa::SigningKey;
     use rstest::rstest;
 
     use super::*;
 
     /// Well-known Hardhat / Anvil account #0 private key.
-    const HARDHAT_PRIVATE_KEY: [u8; 32] = [
-        0xac, 0x09, 0x74, 0xbe, 0xc3, 0x9a, 0x17, 0xe3, 0x6b, 0xa4, 0xa6, 0xb4, 0xd2, 0x38, 0xff,
-        0x94, 0x4b, 0xac, 0xb4, 0x78, 0xcb, 0xed, 0x5e, 0xfc, 0xae, 0x78, 0x4d, 0x7b, 0xf4, 0xf2,
-        0xff, 0x80,
-    ];
+    const HARDHAT_PRIVATE_KEY: [u8; 32] =
+        hex!("ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80");
 
     /// Returns the 65-byte uncompressed public key for the Hardhat account #0.
     fn hardhat_public_key() -> Vec<u8> {

--- a/crates/proof/tee/registrar/src/prover.rs
+++ b/crates/proof/tee/registrar/src/prover.rs
@@ -1,0 +1,178 @@
+//! JSON-RPC client for polling prover instance signer endpoints.
+
+use std::time::Duration;
+
+use alloy_primitives::{Address, Bytes, keccak256};
+use jsonrpsee::{
+    core::client::ClientT,
+    http_client::{HttpClient, HttpClientBuilder},
+    rpc_params,
+};
+use tracing::debug;
+
+use crate::{AttestationResponse, RegistrarError, Result};
+
+/// Length of an uncompressed SEC1 public key (`0x04 || x || y`).
+const UNCOMPRESSED_PUBLIC_KEY_LENGTH: usize = 65;
+
+/// Uncompressed SEC1 public key prefix byte.
+const UNCOMPRESSED_PREFIX: u8 = 0x04;
+
+/// JSON-RPC client for a single prover instance's signer endpoints.
+///
+/// Wraps a `jsonrpsee` HTTP client configured for the prover's endpoint.
+/// Calls `enclave_signerPublicKey` and `enclave_signerAttestation` to obtain
+/// the signer's public key and Nitro attestation document, then derives the
+/// Ethereum address from the uncompressed public key.
+#[derive(Debug)]
+pub struct ProverClient {
+    /// The raw endpoint string (host:port, without scheme).
+    endpoint: String,
+    /// The underlying `jsonrpsee` HTTP client.
+    inner: HttpClient,
+}
+
+impl ProverClient {
+    /// Creates a new client for the prover at the given endpoint.
+    ///
+    /// `endpoint` is a `host:port` string (e.g.
+    /// `"prover-0.prover-headless.provers.svc.cluster.local:8000"` in K8s mode
+    /// or `"10.0.1.5:8000"` in AWS mode). An `http://` scheme is prepended
+    /// automatically.
+    pub fn new(endpoint: &str, timeout: Duration) -> Result<Self> {
+        let url = format!("http://{endpoint}");
+        let inner =
+            HttpClientBuilder::default().request_timeout(timeout).build(&url).map_err(|e| {
+                RegistrarError::ProverClient { instance: endpoint.to_string(), source: Box::new(e) }
+            })?;
+        Ok(Self { endpoint: endpoint.to_string(), inner })
+    }
+
+    /// Fetches the signer's 65-byte uncompressed public key via `enclave_signerPublicKey`.
+    pub async fn signer_public_key(&self) -> Result<Vec<u8>> {
+        debug!(endpoint = %self.endpoint, "fetching signer public key");
+        self.inner.request::<Vec<u8>, _>("enclave_signerPublicKey", rpc_params![]).await.map_err(
+            |e| RegistrarError::ProverClient {
+                instance: self.endpoint.clone(),
+                source: Box::new(e),
+            },
+        )
+    }
+
+    /// Fetches the raw Nitro attestation document via `enclave_signerAttestation`.
+    pub async fn signer_attestation(&self) -> Result<Vec<u8>> {
+        debug!(endpoint = %self.endpoint, "fetching signer attestation");
+        self.inner.request::<Vec<u8>, _>("enclave_signerAttestation", rpc_params![]).await.map_err(
+            |e| RegistrarError::ProverClient {
+                instance: self.endpoint.clone(),
+                source: Box::new(e),
+            },
+        )
+    }
+
+    /// Derives an Ethereum [`Address`] from a 65-byte uncompressed SEC1 public key.
+    ///
+    /// The public key must be in uncompressed format: `0x04 || x (32 bytes) || y (32 bytes)`.
+    /// The address is `keccak256(public_key[1..65])[12..32]` (last 20 bytes of the hash).
+    pub fn derive_address(public_key: &[u8]) -> Result<Address> {
+        if public_key.len() != UNCOMPRESSED_PUBLIC_KEY_LENGTH {
+            return Err(RegistrarError::ProverClient {
+                instance: String::new(),
+                source: format!(
+                    "invalid public key length: expected {UNCOMPRESSED_PUBLIC_KEY_LENGTH}, got {}",
+                    public_key.len()
+                )
+                .into(),
+            });
+        }
+        if public_key[0] != UNCOMPRESSED_PREFIX {
+            return Err(RegistrarError::ProverClient {
+                instance: String::new(),
+                source: format!(
+                    "invalid public key prefix: expected 0x{UNCOMPRESSED_PREFIX:02x}, got 0x{:02x}",
+                    public_key[0]
+                )
+                .into(),
+            });
+        }
+        let hash = keccak256(&public_key[1..]);
+        Ok(Address::from_slice(&hash[12..]))
+    }
+
+    /// Fetches the signer public key and attestation, derives the Ethereum address,
+    /// and returns a combined [`AttestationResponse`].
+    ///
+    /// This is the primary entry point for the registration poll loop. Calls
+    /// `enclave_signerPublicKey` first to get the address (cheap), then
+    /// `enclave_signerAttestation` for the raw attestation document (involves
+    /// Nitro NSM hardware — only call when registration is needed).
+    pub async fn get_attestation_response(&self) -> Result<AttestationResponse> {
+        let public_key = self.signer_public_key().await?;
+        let signer_address = Self::derive_address(&public_key).map_err(|e| {
+            RegistrarError::ProverClient { instance: self.endpoint.clone(), source: Box::new(e) }
+        })?;
+        let attestation = self.signer_attestation().await?;
+
+        debug!(
+            endpoint = %self.endpoint,
+            signer_address = %signer_address,
+            "fetched attestation response"
+        );
+
+        Ok(AttestationResponse { attestation_bytes: Bytes::from(attestation), signer_address })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloy_primitives::address;
+    use k256::ecdsa::SigningKey;
+    use rstest::rstest;
+
+    use super::*;
+
+    /// Well-known Hardhat / Anvil account #0 private key.
+    const HARDHAT_PRIVATE_KEY: [u8; 32] = [
+        0xac, 0x09, 0x74, 0xbe, 0xc3, 0x9a, 0x17, 0xe3, 0x6b, 0xa4, 0xa6, 0xb4, 0xd2, 0x38, 0xff,
+        0x94, 0x4b, 0xac, 0xb4, 0x78, 0xcb, 0xed, 0x5e, 0xfc, 0xae, 0x78, 0x4d, 0x7b, 0xf4, 0xf2,
+        0xff, 0x80,
+    ];
+
+    /// Returns the 65-byte uncompressed public key for the Hardhat account #0.
+    fn hardhat_public_key() -> Vec<u8> {
+        let signing_key = SigningKey::from_slice(&HARDHAT_PRIVATE_KEY).unwrap();
+        let verifying_key = signing_key.verifying_key();
+        verifying_key.to_encoded_point(false).as_bytes().to_vec()
+    }
+
+    #[test]
+    fn derive_address_hardhat_account_zero() {
+        let public_key = hardhat_public_key();
+        let derived = ProverClient::derive_address(&public_key).unwrap();
+        assert_eq!(derived, address!("f39Fd6e51aad88F6F4ce6aB8827279cffFb92266"));
+    }
+
+    #[test]
+    fn derive_address_validates_correct_format() {
+        let public_key = hardhat_public_key();
+        assert_eq!(public_key.len(), 65);
+        assert_eq!(public_key[0], 0x04);
+        assert!(ProverClient::derive_address(&public_key).is_ok());
+    }
+
+    #[rstest]
+    #[case::empty(0)]
+    #[case::compressed(33)]
+    #[case::too_long(66)]
+    fn derive_address_rejects_wrong_length(#[case] len: usize) {
+        let key = vec![0x04; len];
+        assert!(ProverClient::derive_address(&key).is_err());
+    }
+
+    #[test]
+    fn derive_address_rejects_wrong_prefix() {
+        let mut key = hardhat_public_key();
+        key[0] = 0x02; // compressed prefix
+        assert!(ProverClient::derive_address(&key).is_err());
+    }
+}

--- a/crates/proof/tee/registrar/src/prover.rs
+++ b/crates/proof/tee/registrar/src/prover.rs
@@ -8,15 +8,10 @@ use jsonrpsee::{
     http_client::{HttpClient, HttpClientBuilder},
     rpc_params,
 };
+use k256::elliptic_curve::sec1::ToEncodedPoint;
 use tracing::debug;
 
 use crate::{AttestationResponse, RegistrarError, Result};
-
-/// Length of an uncompressed SEC1 public key (`0x04 || x || y`).
-const UNCOMPRESSED_PUBLIC_KEY_LENGTH: usize = 65;
-
-/// Uncompressed SEC1 public key prefix byte.
-const UNCOMPRESSED_PREFIX: u8 = 0x04;
 
 /// JSON-RPC client for a single prover instance's signer endpoints.
 ///
@@ -75,24 +70,18 @@ impl ProverClient {
         )
     }
 
-    /// Derives an Ethereum [`Address`] from a 65-byte uncompressed SEC1 public key.
+    /// Derives an Ethereum [`Address`] from a SEC1-encoded public key.
     ///
-    /// The public key must be in uncompressed format: `0x04 || x (32 bytes) || y (32 bytes)`.
-    /// The address is `keccak256(public_key[1..65])[12..32]` (last 20 bytes of the hash).
+    /// Validates that the bytes represent a valid point on the secp256k1 curve
+    /// (via [`k256::PublicKey::from_sec1_bytes`]), then computes the address as
+    /// `keccak256(uncompressed_point[1..])[12..]`.
+    ///
+    /// Accepts both compressed (33-byte) and uncompressed (65-byte) SEC1 formats.
     pub fn derive_address(public_key: &[u8]) -> Result<Address> {
-        if public_key.len() != UNCOMPRESSED_PUBLIC_KEY_LENGTH {
-            return Err(RegistrarError::InvalidPublicKey(format!(
-                "expected {UNCOMPRESSED_PUBLIC_KEY_LENGTH} bytes, got {}",
-                public_key.len()
-            )));
-        }
-        if public_key[0] != UNCOMPRESSED_PREFIX {
-            return Err(RegistrarError::InvalidPublicKey(format!(
-                "expected uncompressed prefix 0x{UNCOMPRESSED_PREFIX:02x}, got 0x{:02x}",
-                public_key[0]
-            )));
-        }
-        let hash = keccak256(&public_key[1..]);
+        let key = k256::PublicKey::from_sec1_bytes(public_key)
+            .map_err(|e| RegistrarError::InvalidPublicKey(e.to_string()))?;
+        let uncompressed = key.to_encoded_point(false);
+        let hash = keccak256(&uncompressed.as_bytes()[1..]);
         Ok(Address::from_slice(&hash[12..]))
     }
 

--- a/crates/proof/tee/registrar/src/prover.rs
+++ b/crates/proof/tee/registrar/src/prover.rs
@@ -49,6 +49,11 @@ impl ProverClient {
     }
 
     /// Fetches the signer's 65-byte uncompressed public key via `enclave_signerPublicKey`.
+    ///
+    /// Uses `Vec<u8>` deserialization to match the server's `RpcResult<Vec<u8>>` return type
+    /// (serialized as a JSON array of numbers by serde). Note: the existing `EnclaveClient`
+    /// in `base-enclave-client` deserializes as `Bytes` (hex string) for the same methods —
+    /// if the wire format is confirmed to differ, this should be updated accordingly.
     pub async fn signer_public_key(&self) -> Result<Vec<u8>> {
         debug!(endpoint = %self.endpoint, "fetching signer public key");
         self.inner.request::<Vec<u8>, _>("enclave_signerPublicKey", rpc_params![]).await.map_err(
@@ -76,24 +81,16 @@ impl ProverClient {
     /// The address is `keccak256(public_key[1..65])[12..32]` (last 20 bytes of the hash).
     pub fn derive_address(public_key: &[u8]) -> Result<Address> {
         if public_key.len() != UNCOMPRESSED_PUBLIC_KEY_LENGTH {
-            return Err(RegistrarError::ProverClient {
-                instance: String::new(),
-                source: format!(
-                    "invalid public key length: expected {UNCOMPRESSED_PUBLIC_KEY_LENGTH}, got {}",
-                    public_key.len()
-                )
-                .into(),
-            });
+            return Err(RegistrarError::InvalidPublicKey(format!(
+                "expected {UNCOMPRESSED_PUBLIC_KEY_LENGTH} bytes, got {}",
+                public_key.len()
+            )));
         }
         if public_key[0] != UNCOMPRESSED_PREFIX {
-            return Err(RegistrarError::ProverClient {
-                instance: String::new(),
-                source: format!(
-                    "invalid public key prefix: expected 0x{UNCOMPRESSED_PREFIX:02x}, got 0x{:02x}",
-                    public_key[0]
-                )
-                .into(),
-            });
+            return Err(RegistrarError::InvalidPublicKey(format!(
+                "expected uncompressed prefix 0x{UNCOMPRESSED_PREFIX:02x}, got 0x{:02x}",
+                public_key[0]
+            )));
         }
         let hash = keccak256(&public_key[1..]);
         Ok(Address::from_slice(&hash[12..]))
@@ -108,9 +105,7 @@ impl ProverClient {
     /// Nitro NSM hardware — only call when registration is needed).
     pub async fn get_attestation_response(&self) -> Result<AttestationResponse> {
         let public_key = self.signer_public_key().await?;
-        let signer_address = Self::derive_address(&public_key).map_err(|e| {
-            RegistrarError::ProverClient { instance: self.endpoint.clone(), source: Box::new(e) }
-        })?;
+        let signer_address = Self::derive_address(&public_key)?;
         let attestation = self.signer_attestation().await?;
 
         debug!(


### PR DESCRIPTION
## Summary

- Adds `ProverClient` wrapping a `jsonrpsee` HTTP client to call `enclave_signerPublicKey` and `enclave_signerAttestation` JSON-RPC methods on prover instances
- `derive_address` derives the Ethereum signer address from the 65-byte uncompressed public key via `keccak256(key[1..])[12..]`, with validation for length and prefix
- `get_attestation_response` combines both calls into an `AttestationResponse` for the registration driver
- Configurable request timeout; errors use existing `RegistrarError::ProverClient`

## Test plan

- [x] `cargo clippy -p base-proof-tee-registrar -- -D warnings` passes clean
- [x] `cargo test -p base-proof-tee-registrar` — all tests passing
- [x] `derive_address` verified against Hardhat account #0 (same test vector as `crates/proof/tee/nitro/src/enclave/crypto.rs`)
- [x] Wrong-length and wrong-prefix inputs rejected via rstest parameterisation

Closes CHAIN-3452