### PR TITLE
feat(tx-manager): Tx Queue

### DIFF
--- a/crates/utilities/tx-manager/src/lib.rs
+++ b/crates/utilities/tx-manager/src/lib.rs
@@ -34,10 +34,13 @@ mod manager;
 pub use manager::{PreparedTx, SimpleTxManager};
 
 mod queue;
-pub use queue::TxQueue;
+pub use queue::{TxQueue, TxReceipt};
 
 mod metrics;
 pub use metrics::TxMetrics;
 
 mod blob;
 pub use blob::BlobTxBuilder;
+
+#[cfg(test)]
+pub mod test_utils;

--- a/crates/utilities/tx-manager/src/lib.rs
+++ b/crates/utilities/tx-manager/src/lib.rs
@@ -34,7 +34,7 @@ mod manager;
 pub use manager::{PreparedTx, SimpleTxManager};
 
 mod queue;
-pub use queue::{TxQueue, TxReceipt};
+pub use queue::{SendResult, TxQueue};
 
 mod metrics;
 pub use metrics::TxMetrics;

--- a/crates/utilities/tx-manager/src/queue.rs
+++ b/crates/utilities/tx-manager/src/queue.rs
@@ -7,7 +7,7 @@
 
 use std::{num::NonZeroUsize, sync::Arc};
 
-use tokio::sync::{mpsc, OwnedSemaphorePermit, Semaphore};
+use tokio::sync::{OwnedSemaphorePermit, Semaphore, mpsc};
 use tracing::debug;
 
 use crate::{SendResponse, TxCandidate, TxManager};
@@ -65,14 +65,9 @@ impl<M: TxManager + 'static> TxQueue<M> {
         candidate: TxCandidate,
         result_tx: mpsc::Sender<SendResult<T>>,
     ) {
-        debug!(
-            available = self.semaphore.available_permits(),
-            "acquiring send permit",
-        );
-        let permit = Arc::clone(&self.semaphore)
-            .acquire_owned()
-            .await
-            .expect("semaphore is never closed");
+        debug!(available = self.semaphore.available_permits(), "acquiring send permit",);
+        let permit =
+            Arc::clone(&self.semaphore).acquire_owned().await.expect("semaphore is never closed");
         debug!("send permit acquired");
         self.dispatch(permit, id, candidate, result_tx).await;
     }
@@ -138,15 +133,15 @@ impl<M: TxManager + 'static> TxQueue<M> {
 #[cfg(test)]
 mod tests {
     use std::sync::{
-        atomic::{AtomicU64, Ordering},
         Arc,
+        atomic::{AtomicU64, Ordering},
     };
 
     use alloy_primitives::Address;
-    use tokio::sync::{mpsc, Notify};
+    use tokio::sync::{Notify, mpsc};
 
     use super::*;
-    use crate::{test_utils::stub_receipt, SendHandle, TxManagerError};
+    use crate::{SendHandle, TxManagerError, test_utils::stub_receipt};
 
     fn stub_candidate() -> TxCandidate {
         TxCandidate::default()
@@ -281,11 +276,8 @@ mod tests {
 
         // On current_thread, yield_now deterministically advances the spawned
         // task to its semaphore await. Use a short timeout as a safety net.
-        let timeout_result = tokio::time::timeout(
-            std::time::Duration::from_millis(50),
-            &mut blocked,
-        )
-        .await;
+        let timeout_result =
+            tokio::time::timeout(std::time::Duration::from_millis(50), &mut blocked).await;
         assert!(timeout_result.is_err(), "third send should be blocked");
 
         // Complete the first transaction — frees a permit.
@@ -397,5 +389,4 @@ mod tests {
         assert_eq!(second.id, 2);
         assert_eq!(second.result.unwrap_err(), TxManagerError::NonceTooLow);
     }
-
 }

--- a/crates/utilities/tx-manager/src/queue.rs
+++ b/crates/utilities/tx-manager/src/queue.rs
@@ -5,7 +5,7 @@
 //! queue order because [`TxManager::send_async`] is called on the caller's
 //! task before spawning a background completion task.
 
-use std::sync::Arc;
+use std::{num::NonZeroUsize, sync::Arc};
 
 use tokio::sync::{mpsc, OwnedSemaphorePermit, Semaphore};
 use tracing::debug;
@@ -37,11 +37,8 @@ impl<M: TxManager + 'static> TxQueue<M> {
     ///
     /// `max_pending` controls how many transactions may be in-flight at once.
     /// `None` means unlimited (no backpressure).
-    pub fn new(tx_mgr: Arc<M>, max_pending: Option<usize>) -> Self {
-        if max_pending == Some(0) {
-            panic!("max_pending must be > 0 or None for unlimited");
-        }
-        let permits = max_pending.unwrap_or(Semaphore::MAX_PERMITS);
+    pub fn new(tx_mgr: Arc<M>, max_pending: Option<NonZeroUsize>) -> Self {
+        let permits = max_pending.map(|n| n.get()).unwrap_or(Semaphore::MAX_PERMITS);
         debug!(max_pending = permits, "tx queue created");
         Self { tx_mgr, semaphore: Arc::new(Semaphore::new(permits)) }
     }
@@ -56,11 +53,12 @@ impl<M: TxManager + 'static> TxQueue<M> {
     ///
     /// # Warning: not cancellation-safe
     ///
-    /// This future **must not** be used inside `tokio::select!`. If dropped
-    /// after [`TxManager::send_async`] has been called but before the
-    /// background task delivers a result, the nonce is managed by the
-    /// underlying `TxManager` (returned to the pool on error), but the
-    /// result will never be delivered to `result_tx`.
+    /// This future **must not** be dropped after polling begins — do not use
+    /// it inside `tokio::select!`, `tokio::time::timeout`,
+    /// `FuturesUnordered`, or any combinator that may drop in-progress
+    /// futures. If dropped after [`TxManager::send_async`] has been called
+    /// but before the background task is spawned, a nonce is consumed and
+    /// the result will never be delivered to `result_tx`.
     pub async fn send<T: Send + 'static>(
         &self,
         id: T,
@@ -87,8 +85,12 @@ impl<M: TxManager + 'static> TxQueue<M> {
     ///
     /// # Warning: not cancellation-safe
     ///
-    /// Same as [`send`](Self::send) — not cancellation-safe once dispatch
-    /// begins.
+    /// This future **must not** be dropped after polling begins — do not use
+    /// it inside `tokio::select!`, `tokio::time::timeout`,
+    /// `FuturesUnordered`, or any combinator that may drop in-progress
+    /// futures. If dropped after [`TxManager::send_async`] has been called
+    /// but before the background task is spawned, a nonce is consumed and
+    /// the result will never be delivered to `result_tx`.
     pub async fn try_send<T: Send + 'static>(
         &self,
         id: T,
@@ -263,7 +265,7 @@ mod tests {
         let mgr = Arc::new(GatedMockTxManager::new(3));
         let (result_tx, mut result_rx) = mpsc::channel::<SendResult<u64>>(16);
 
-        let queue = Arc::new(TxQueue::new(Arc::clone(&mgr), Some(2)));
+        let queue = Arc::new(TxQueue::new(Arc::clone(&mgr), Some(NonZeroUsize::new(2).unwrap())));
 
         // First two sends should proceed immediately.
         queue.send(1, stub_candidate(), result_tx.clone()).await;
@@ -272,14 +274,19 @@ mod tests {
         // Third send should block because both permits are held.
         let queue_clone = Arc::clone(&queue);
         let result_tx_clone = result_tx.clone();
-        let blocked = tokio::spawn(async move {
+        let mut blocked = tokio::spawn(async move {
             // This will not return until a permit is freed.
             queue_clone.send(3, stub_candidate(), result_tx_clone).await;
         });
 
-        // Yield to let the spawned task reach the semaphore.
-        tokio::task::yield_now().await;
-        assert!(!blocked.is_finished(), "third send should be blocked");
+        // On current_thread, yield_now deterministically advances the spawned
+        // task to its semaphore await. Use a short timeout as a safety net.
+        let timeout_result = tokio::time::timeout(
+            std::time::Duration::from_millis(50),
+            &mut blocked,
+        )
+        .await;
+        assert!(timeout_result.is_err(), "third send should be blocked");
 
         // Complete the first transaction — frees a permit.
         mgr.complete(0);
@@ -298,10 +305,10 @@ mod tests {
 
     #[tokio::test(flavor = "current_thread")]
     async fn try_send_returns_err_when_full() {
-        let mgr = Arc::new(GatedMockTxManager::new(4));
+        let mgr = Arc::new(GatedMockTxManager::new(3));
         let (result_tx, mut result_rx) = mpsc::channel::<SendResult<u64>>(16);
 
-        let queue = TxQueue::new(Arc::clone(&mgr), Some(2));
+        let queue = TxQueue::new(Arc::clone(&mgr), Some(NonZeroUsize::new(2).unwrap()));
 
         assert!(queue.try_send(1, stub_candidate(), result_tx.clone()).await.is_ok());
         assert!(queue.try_send(2, stub_candidate(), result_tx.clone()).await.is_ok());
@@ -315,18 +322,9 @@ mod tests {
         mgr.complete(0);
         let _ = result_rx.recv().await;
 
-        // Wait for the permit to be released by the spawned task.
-        let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(1);
-        loop {
-            tokio::task::yield_now().await;
-            if queue.try_send(4, stub_candidate(), result_tx.clone()).await.is_ok() {
-                break;
-            }
-            assert!(
-                tokio::time::Instant::now() < deadline,
-                "permit was not released within 1s",
-            );
-        }
+        // The permit was released before the result was sent (see `dispatch`),
+        // so a slot is guaranteed to be free by the time we receive the result.
+        assert!(queue.try_send(4, stub_candidate(), result_tx.clone()).await.is_ok());
 
         // Cleanup.
         mgr.complete(1);
@@ -338,7 +336,7 @@ mod tests {
         let mgr = Arc::new(MockTxManager::new());
         let (result_tx, mut result_rx) = mpsc::channel::<SendResult<String>>(16);
 
-        let queue = TxQueue::new(mgr, Some(10));
+        let queue = TxQueue::new(mgr, Some(NonZeroUsize::new(10).unwrap()));
 
         let ids = ["alpha", "beta", "gamma"];
         for id in &ids {
@@ -383,7 +381,7 @@ mod tests {
         let (result_tx, mut result_rx) = mpsc::channel::<SendResult<u64>>(16);
 
         // Only one permit — if the error doesn't release it, the second send hangs.
-        let queue = TxQueue::new(Arc::clone(&mgr), Some(1));
+        let queue = TxQueue::new(Arc::clone(&mgr), Some(NonZeroUsize::new(1).unwrap()));
 
         // First send: should resolve to an error.
         queue.send(1, stub_candidate(), result_tx.clone()).await;
@@ -400,10 +398,4 @@ mod tests {
         assert_eq!(second.result.unwrap_err(), TxManagerError::NonceTooLow);
     }
 
-    #[test]
-    #[should_panic(expected = "max_pending must be > 0")]
-    fn max_pending_zero_panics() {
-        let mgr = Arc::new(MockTxManager::new());
-        let _ = TxQueue::new(mgr, Some(0));
-    }
 }

--- a/crates/utilities/tx-manager/src/queue.rs
+++ b/crates/utilities/tx-manager/src/queue.rs
@@ -1,5 +1,317 @@
-//! Transaction queue for ordering and batching.
+//! Bounded async transaction send queue with backpressure.
+//!
+//! [`TxQueue`] wraps a [`TxManager`] and limits the number of in-flight
+//! transactions using a [`tokio::sync::Semaphore`]. Nonces are assigned in
+//! queue order because [`TxManager::send_async`] is called on the caller's
+//! task before spawning a background completion task.
 
-/// Queue for ordering and batching transactions.
+use std::sync::Arc;
+
+use tokio::sync::{mpsc, OwnedSemaphorePermit, Semaphore};
+use tracing::debug;
+
+use crate::{SendResponse, TxCandidate, TxManager};
+
+/// Pairs a caller-supplied identifier with the outcome of a transaction send.
 #[derive(Debug)]
-pub struct TxQueue;
+pub struct TxReceipt<T> {
+    /// Caller-supplied identifier for the transaction.
+    pub id: T,
+    /// The result of the transaction send.
+    pub result: SendResponse,
+}
+
+/// Bounded async transaction send queue with backpressure.
+///
+/// Limits the number of concurrently in-flight transactions via a semaphore.
+/// Nonces are assigned in call order because [`TxManager::send_async`] runs on
+/// the caller's task before the background completion task is spawned.
+#[derive(Debug)]
+pub struct TxQueue<M> {
+    tx_mgr: Arc<M>,
+    semaphore: Arc<Semaphore>,
+}
+
+impl<M: TxManager + 'static> TxQueue<M> {
+    /// Creates a new `TxQueue`.
+    ///
+    /// `max_pending` controls how many transactions may be in-flight at once.
+    /// A value of `0` means unlimited (no backpressure).
+    pub fn new(tx_mgr: Arc<M>, max_pending: usize) -> Self {
+        let permits = if max_pending == 0 { Semaphore::MAX_PERMITS } else { max_pending };
+        debug!(max_pending = permits, "tx queue created");
+        Self { tx_mgr, semaphore: Arc::new(Semaphore::new(permits)) }
+    }
+
+    /// Queues a transaction for sending, blocking if the queue is full.
+    ///
+    /// 1. Acquires a semaphore permit (blocks when at capacity).
+    /// 2. Calls [`TxManager::send_async`] **on the caller's task** so that
+    ///    nonces are reserved in call order.
+    /// 3. Spawns a background task that awaits the [`SendHandle`], delivers the
+    ///    result on `result_tx`, and releases the permit.
+    pub async fn send<T: Send + 'static>(
+        &self,
+        id: T,
+        candidate: TxCandidate,
+        result_tx: mpsc::Sender<TxReceipt<T>>,
+    ) {
+        let permit = Arc::clone(&self.semaphore)
+            .acquire_owned()
+            .await
+            .expect("semaphore is never closed");
+        self.dispatch(permit, id, candidate, result_tx).await;
+    }
+
+    /// Attempts to queue a transaction without blocking.
+    ///
+    /// Returns `true` if a permit was available and the transaction was
+    /// enqueued, `false` if the queue is full.
+    pub async fn try_send<T: Send + 'static>(
+        &self,
+        id: T,
+        candidate: TxCandidate,
+        result_tx: mpsc::Sender<TxReceipt<T>>,
+    ) -> bool {
+        let permit = match Arc::clone(&self.semaphore).try_acquire_owned() {
+            Ok(p) => p,
+            Err(_) => return false,
+        };
+        self.dispatch(permit, id, candidate, result_tx).await;
+        true
+    }
+
+    /// Reserves a nonce on the caller's task, then spawns a background task to
+    /// await the send and deliver the receipt.
+    async fn dispatch<T: Send + 'static>(
+        &self,
+        permit: OwnedSemaphorePermit,
+        id: T,
+        candidate: TxCandidate,
+        result_tx: mpsc::Sender<TxReceipt<T>>,
+    ) {
+        let handle = self.tx_mgr.send_async(candidate).await;
+        tokio::spawn(async move {
+            let result = handle.await;
+            if result_tx.send(TxReceipt { id, result }).await.is_err() {
+                debug!("result receiver dropped, tx receipt lost");
+            }
+            drop(permit);
+        });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::{
+        atomic::{AtomicU64, Ordering},
+        Arc,
+    };
+
+    use alloy_primitives::Address;
+    use tokio::sync::{mpsc, Notify};
+
+    use super::*;
+    use crate::{test_utils::stub_receipt, SendHandle};
+
+    fn stub_candidate() -> TxCandidate {
+        TxCandidate::default()
+    }
+
+    // ── MockTxManager ───────────────────────────────────────────────────
+
+    /// A mock that immediately resolves the `SendHandle` with a stub receipt.
+    #[derive(Debug)]
+    struct MockTxManager {
+        call_count: AtomicU64,
+    }
+
+    impl MockTxManager {
+        fn new() -> Self {
+            Self { call_count: AtomicU64::new(0) }
+        }
+    }
+
+    impl TxManager for MockTxManager {
+        async fn send(&self, _candidate: TxCandidate) -> SendResponse {
+            Ok(stub_receipt())
+        }
+
+        async fn send_async(&self, _candidate: TxCandidate) -> SendHandle {
+            self.call_count.fetch_add(1, Ordering::SeqCst);
+            let (tx, rx) = tokio::sync::oneshot::channel();
+            tx.send(Ok(stub_receipt())).expect("receiver not dropped");
+            SendHandle::new(rx)
+        }
+
+        fn sender_address(&self) -> Address {
+            Address::ZERO
+        }
+    }
+
+    // ── GatedMockTxManager ──────────────────────────────────────────────
+
+    /// A mock whose `SendHandle` blocks until the test calls `complete(index)`.
+    #[derive(Debug)]
+    struct GatedMockTxManager {
+        call_count: AtomicU64,
+        /// One `Notify` per expected send — test calls `complete(i)` to
+        /// unblock the i-th send.
+        gates: Vec<Arc<Notify>>,
+    }
+
+    impl GatedMockTxManager {
+        fn new(num_gates: usize) -> Self {
+            let gates = (0..num_gates).map(|_| Arc::new(Notify::new())).collect();
+            Self { call_count: AtomicU64::new(0), gates }
+        }
+
+        /// Unblocks the `index`-th `send_async` call.
+        fn complete(&self, index: usize) {
+            self.gates[index].notify_one();
+        }
+    }
+
+    impl TxManager for GatedMockTxManager {
+        async fn send(&self, _candidate: TxCandidate) -> SendResponse {
+            Ok(stub_receipt())
+        }
+
+        async fn send_async(&self, _candidate: TxCandidate) -> SendHandle {
+            let idx = self.call_count.fetch_add(1, Ordering::SeqCst) as usize;
+            let gate = Arc::clone(&self.gates[idx]);
+            let (tx, rx) = tokio::sync::oneshot::channel();
+            tokio::spawn(async move {
+                gate.notified().await;
+                let _ = tx.send(Ok(stub_receipt()));
+            });
+            SendHandle::new(rx)
+        }
+
+        fn sender_address(&self) -> Address {
+            Address::ZERO
+        }
+    }
+
+    // ── Tests ───────────────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn send_blocks_when_full() {
+        let mgr = Arc::new(GatedMockTxManager::new(3));
+        let (result_tx, mut result_rx) = mpsc::channel::<TxReceipt<u64>>(16);
+
+        let queue = Arc::new(TxQueue::new(Arc::clone(&mgr), 2));
+
+        // First two sends should proceed immediately.
+        queue.send(1, stub_candidate(), result_tx.clone()).await;
+        queue.send(2, stub_candidate(), result_tx.clone()).await;
+
+        // Third send should block because both permits are held.
+        let queue_clone = Arc::clone(&queue);
+        let result_tx_clone = result_tx.clone();
+        let blocked = tokio::spawn(async move {
+            // This will not return until a permit is freed.
+            queue_clone.send(3, stub_candidate(), result_tx_clone).await;
+        });
+
+        // Give the spawned task time to reach the semaphore.
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        assert!(!blocked.is_finished(), "third send should be blocked");
+
+        // Complete the first transaction — frees a permit.
+        mgr.complete(0);
+        let _ = result_rx.recv().await;
+
+        // Now the third send should unblock.
+        tokio::time::timeout(std::time::Duration::from_secs(1), blocked)
+            .await
+            .expect("third send should unblock after permit freed")
+            .expect("task should not panic");
+
+        // Cleanup: complete remaining.
+        mgr.complete(1);
+        mgr.complete(2);
+    }
+
+    #[tokio::test]
+    async fn try_send_returns_false_when_full() {
+        let mgr = Arc::new(GatedMockTxManager::new(4));
+        let (result_tx, mut result_rx) = mpsc::channel::<TxReceipt<u64>>(16);
+
+        let queue = TxQueue::new(Arc::clone(&mgr), 2);
+
+        assert!(queue.try_send(1, stub_candidate(), result_tx.clone()).await);
+        assert!(queue.try_send(2, stub_candidate(), result_tx.clone()).await);
+        assert!(!queue.try_send(3, stub_candidate(), result_tx.clone()).await);
+
+        // Free a slot.
+        mgr.complete(0);
+        let _ = result_rx.recv().await;
+
+        // Allow the permit to be released by the spawned task.
+        tokio::task::yield_now().await;
+
+        assert!(queue.try_send(4, stub_candidate(), result_tx.clone()).await);
+
+        // Cleanup.
+        mgr.complete(1);
+        mgr.complete(2);
+    }
+
+    #[tokio::test]
+    async fn results_delivered_with_matching_ids() {
+        let mgr = Arc::new(MockTxManager::new());
+        let (result_tx, mut result_rx) = mpsc::channel::<TxReceipt<String>>(16);
+
+        let queue = TxQueue::new(mgr, 10);
+
+        let ids = ["alpha", "beta", "gamma"];
+        for id in &ids {
+            queue.send(id.to_string(), stub_candidate(), result_tx.clone()).await;
+        }
+
+        let mut received = Vec::new();
+        for _ in 0..3 {
+            let receipt = tokio::time::timeout(
+                std::time::Duration::from_secs(2),
+                result_rx.recv(),
+            )
+            .await
+            .expect("should receive within timeout")
+            .expect("channel should not be closed");
+
+            assert!(receipt.result.is_ok());
+            received.push(receipt.id);
+        }
+
+        received.sort();
+        let mut expected: Vec<String> = ids.iter().map(|s| s.to_string()).collect();
+        expected.sort();
+        assert_eq!(received, expected);
+    }
+
+    #[tokio::test]
+    async fn max_pending_zero_means_unlimited() {
+        let mgr = Arc::new(MockTxManager::new());
+        let (result_tx, mut result_rx) = mpsc::channel::<TxReceipt<u64>>(256);
+
+        let queue = TxQueue::new(Arc::clone(&mgr), 0);
+
+        for i in 0..100 {
+            queue.send(i, stub_candidate(), result_tx.clone()).await;
+        }
+
+        for _ in 0..100 {
+            let receipt = tokio::time::timeout(
+                std::time::Duration::from_secs(5),
+                result_rx.recv(),
+            )
+            .await
+            .expect("should receive within timeout")
+            .expect("channel should not be closed");
+            assert!(receipt.result.is_ok());
+        }
+
+        assert_eq!(mgr.call_count.load(Ordering::SeqCst), 100);
+    }
+}

--- a/crates/utilities/tx-manager/src/queue.rs
+++ b/crates/utilities/tx-manager/src/queue.rs
@@ -38,6 +38,9 @@ impl<M: TxManager + 'static> TxQueue<M> {
     /// `max_pending` controls how many transactions may be in-flight at once.
     /// `None` means unlimited (no backpressure).
     pub fn new(tx_mgr: Arc<M>, max_pending: Option<usize>) -> Self {
+        if max_pending == Some(0) {
+            panic!("max_pending must be > 0 or None for unlimited");
+        }
         let permits = max_pending.unwrap_or(Semaphore::MAX_PERMITS);
         debug!(max_pending = permits, "tx queue created");
         Self { tx_mgr, semaphore: Arc::new(Semaphore::new(permits)) }
@@ -141,7 +144,7 @@ mod tests {
     use tokio::sync::{mpsc, Notify};
 
     use super::*;
-    use crate::{test_utils::stub_receipt, SendHandle};
+    use crate::{test_utils::stub_receipt, SendHandle, TxManagerError};
 
     fn stub_candidate() -> TxCandidate {
         TxCandidate::default()
@@ -220,6 +223,37 @@ mod tests {
         fn sender_address(&self) -> Address {
             Address::ZERO
         }
+    }
+
+    // ── ErrorMockTxManager ───────────────────────────────────────────────
+
+    /// A mock whose `send_async` always resolves to an error.
+    #[derive(Debug)]
+    struct ErrorMockTxManager;
+
+    impl TxManager for ErrorMockTxManager {
+        async fn send(&self, _candidate: TxCandidate) -> SendResponse {
+            Err(TxManagerError::NonceTooLow)
+        }
+
+        async fn send_async(&self, _candidate: TxCandidate) -> SendHandle {
+            let (tx, rx) = tokio::sync::oneshot::channel();
+            tx.send(Err(TxManagerError::NonceTooLow)).expect("receiver not dropped");
+            SendHandle::new(rx)
+        }
+
+        fn sender_address(&self) -> Address {
+            Address::ZERO
+        }
+    }
+
+    // ── Helpers ──────────────────────────────────────────────────────────
+
+    async fn recv_timeout<T>(rx: &mut mpsc::Receiver<T>, secs: u64) -> T {
+        tokio::time::timeout(std::time::Duration::from_secs(secs), rx.recv())
+            .await
+            .expect("should receive within timeout")
+            .expect("channel should not be closed")
     }
 
     // ── Tests ───────────────────────────────────────────────────────────
@@ -313,14 +347,7 @@ mod tests {
 
         let mut received = Vec::new();
         for _ in 0..3 {
-            let receipt = tokio::time::timeout(
-                std::time::Duration::from_secs(2),
-                result_rx.recv(),
-            )
-            .await
-            .expect("should receive within timeout")
-            .expect("channel should not be closed");
-
+            let receipt = recv_timeout(&mut result_rx, 2).await;
             assert!(receipt.result.is_ok());
             received.push(receipt.id);
         }
@@ -343,16 +370,40 @@ mod tests {
         }
 
         for _ in 0..100 {
-            let receipt = tokio::time::timeout(
-                std::time::Duration::from_secs(5),
-                result_rx.recv(),
-            )
-            .await
-            .expect("should receive within timeout")
-            .expect("channel should not be closed");
+            let receipt = recv_timeout(&mut result_rx, 5).await;
             assert!(receipt.result.is_ok());
         }
 
         assert_eq!(mgr.call_count.load(Ordering::SeqCst), 100);
+    }
+
+    #[tokio::test]
+    async fn error_result_propagates_and_releases_permit() {
+        let mgr = Arc::new(ErrorMockTxManager);
+        let (result_tx, mut result_rx) = mpsc::channel::<SendResult<u64>>(16);
+
+        // Only one permit — if the error doesn't release it, the second send hangs.
+        let queue = TxQueue::new(Arc::clone(&mgr), Some(1));
+
+        // First send: should resolve to an error.
+        queue.send(1, stub_candidate(), result_tx.clone()).await;
+        let first = recv_timeout(&mut result_rx, 2).await;
+        assert_eq!(first.id, 1);
+        assert_eq!(first.result.unwrap_err(), TxManagerError::NonceTooLow);
+
+        // Second send on the SAME queue: proves the permit was released despite
+        // the error. With only one permit, this would hang if the first send
+        // leaked it.
+        queue.send(2, stub_candidate(), result_tx.clone()).await;
+        let second = recv_timeout(&mut result_rx, 2).await;
+        assert_eq!(second.id, 2);
+        assert_eq!(second.result.unwrap_err(), TxManagerError::NonceTooLow);
+    }
+
+    #[test]
+    #[should_panic(expected = "max_pending must be > 0")]
+    fn max_pending_zero_panics() {
+        let mgr = Arc::new(MockTxManager::new());
+        let _ = TxQueue::new(mgr, Some(0));
     }
 }

--- a/crates/utilities/tx-manager/src/queue.rs
+++ b/crates/utilities/tx-manager/src/queue.rs
@@ -51,33 +51,38 @@ impl<M: TxManager + 'static> TxQueue<M> {
     /// 3. Spawns a background task that awaits the [`SendHandle`], delivers the
     ///    result on `result_tx`, and releases the permit.
     ///
-    /// # Cancellation safety
+    /// # Warning: not cancellation-safe
     ///
-    /// This future is **not** cancellation-safe. If dropped after
-    /// [`TxManager::send_async`] has been called but before the background
-    /// task delivers a result, the nonce is managed by the underlying
-    /// `TxManager` (returned to the pool on error), but the result will
-    /// never be delivered to `result_tx`. The semaphore permit is released
-    /// when the spawned task completes or on drop.
+    /// This future **must not** be used inside `tokio::select!`. If dropped
+    /// after [`TxManager::send_async`] has been called but before the
+    /// background task delivers a result, the nonce is managed by the
+    /// underlying `TxManager` (returned to the pool on error), but the
+    /// result will never be delivered to `result_tx`.
     pub async fn send<T: Send + 'static>(
         &self,
         id: T,
         candidate: TxCandidate,
         result_tx: mpsc::Sender<SendResult<T>>,
     ) {
+        debug!(
+            available = self.semaphore.available_permits(),
+            "acquiring send permit",
+        );
         let permit = Arc::clone(&self.semaphore)
             .acquire_owned()
             .await
             .expect("semaphore is never closed");
+        debug!("send permit acquired");
         self.dispatch(permit, id, candidate, result_tx).await;
     }
 
     /// Attempts to queue a transaction without blocking.
     ///
-    /// Returns `true` if a permit was available and the transaction was
-    /// enqueued, `false` if the queue is full.
+    /// Returns `Ok(())` if a permit was available and the transaction was
+    /// enqueued. Returns `Err((id, candidate))` if the queue is full, giving
+    /// ownership of the consumed values back to the caller.
     ///
-    /// # Cancellation safety
+    /// # Warning: not cancellation-safe
     ///
     /// Same as [`send`](Self::send) — not cancellation-safe once dispatch
     /// begins.
@@ -86,13 +91,19 @@ impl<M: TxManager + 'static> TxQueue<M> {
         id: T,
         candidate: TxCandidate,
         result_tx: mpsc::Sender<SendResult<T>>,
-    ) -> bool {
+    ) -> Result<(), (T, TxCandidate)> {
         let permit = match Arc::clone(&self.semaphore).try_acquire_owned() {
             Ok(p) => p,
-            Err(_) => return false,
+            Err(_) => {
+                debug!(
+                    available = self.semaphore.available_permits(),
+                    "try_send rejected, queue full",
+                );
+                return Err((id, candidate));
+            }
         };
         self.dispatch(permit, id, candidate, result_tx).await;
-        true
+        Ok(())
     }
 
     /// Reserves a nonce on the caller's task, then spawns a background task to
@@ -104,13 +115,17 @@ impl<M: TxManager + 'static> TxQueue<M> {
         candidate: TxCandidate,
         result_tx: mpsc::Sender<SendResult<T>>,
     ) {
+        debug!("dispatching send_async");
         let handle = self.tx_mgr.send_async(candidate).await;
         tokio::spawn(async move {
             let result = handle.await;
+            // Release the permit before sending the result to avoid deadlock:
+            // the result channel may be full, blocking this task while holding
+            // a permit that the receiver needs freed before it can drain.
+            drop(permit);
             if result_tx.send(SendResult { id, result }).await.is_err() {
                 debug!("result receiver dropped, tx receipt lost");
             }
-            drop(permit);
         });
     }
 }
@@ -248,24 +263,36 @@ mod tests {
     }
 
     #[tokio::test(flavor = "current_thread")]
-    async fn try_send_returns_false_when_full() {
+    async fn try_send_returns_err_when_full() {
         let mgr = Arc::new(GatedMockTxManager::new(4));
         let (result_tx, mut result_rx) = mpsc::channel::<SendResult<u64>>(16);
 
         let queue = TxQueue::new(Arc::clone(&mgr), Some(2));
 
-        assert!(queue.try_send(1, stub_candidate(), result_tx.clone()).await);
-        assert!(queue.try_send(2, stub_candidate(), result_tx.clone()).await);
-        assert!(!queue.try_send(3, stub_candidate(), result_tx.clone()).await);
+        assert!(queue.try_send(1, stub_candidate(), result_tx.clone()).await.is_ok());
+        assert!(queue.try_send(2, stub_candidate(), result_tx.clone()).await.is_ok());
+
+        // Queue is full — should return the id and candidate back.
+        let err = queue.try_send(3, stub_candidate(), result_tx.clone()).await;
+        assert!(err.is_err());
+        assert_eq!(err.unwrap_err().0, 3);
 
         // Free a slot.
         mgr.complete(0);
         let _ = result_rx.recv().await;
 
-        // Allow the permit to be released by the spawned task.
-        tokio::task::yield_now().await;
-
-        assert!(queue.try_send(4, stub_candidate(), result_tx.clone()).await);
+        // Wait for the permit to be released by the spawned task.
+        let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(1);
+        loop {
+            tokio::task::yield_now().await;
+            if queue.try_send(4, stub_candidate(), result_tx.clone()).await.is_ok() {
+                break;
+            }
+            assert!(
+                tokio::time::Instant::now() < deadline,
+                "permit was not released within 1s",
+            );
+        }
 
         // Cleanup.
         mgr.complete(1);

--- a/crates/utilities/tx-manager/src/queue.rs
+++ b/crates/utilities/tx-manager/src/queue.rs
@@ -26,6 +26,9 @@ pub struct SendResult<T> {
 /// Limits the number of concurrently in-flight transactions via a semaphore.
 /// Nonces are assigned in call order because [`TxManager::send_async`] runs on
 /// the caller's task before the background completion task is spawned.
+///
+/// `Clone` produces a handle to the same queue — clones share the semaphore and
+/// underlying [`TxManager`], so backpressure limits apply across all handles.
 #[derive(Debug, Clone)]
 pub struct TxQueue<M> {
     tx_mgr: Arc<M>,
@@ -58,7 +61,9 @@ impl<M: TxManager + 'static> TxQueue<M> {
     /// `FuturesUnordered`, or any combinator that may drop in-progress
     /// futures. If dropped after [`TxManager::send_async`] has been called
     /// but before the background task is spawned, a nonce is consumed and
-    /// the result will never be delivered to `result_tx`.
+    /// the result will never be delivered to `result_tx`. The underlying
+    /// transaction task will still run to completion (sign, publish, and
+    /// poll), wasting gas on a transaction no caller is awaiting.
     pub async fn send<T: Send + 'static>(
         &self,
         id: T,
@@ -85,7 +90,9 @@ impl<M: TxManager + 'static> TxQueue<M> {
     /// `FuturesUnordered`, or any combinator that may drop in-progress
     /// futures. If dropped after [`TxManager::send_async`] has been called
     /// but before the background task is spawned, a nonce is consumed and
-    /// the result will never be delivered to `result_tx`.
+    /// the result will never be delivered to `result_tx`. The underlying
+    /// transaction task will still run to completion (sign, publish, and
+    /// poll), wasting gas on a transaction no caller is awaiting.
     pub async fn try_send<T: Send + 'static>(
         &self,
         id: T,

--- a/crates/utilities/tx-manager/src/queue.rs
+++ b/crates/utilities/tx-manager/src/queue.rs
@@ -8,7 +8,7 @@
 use std::{num::NonZeroUsize, sync::Arc};
 
 use tokio::sync::{OwnedSemaphorePermit, Semaphore, mpsc};
-use tracing::debug;
+use tracing::{debug, warn};
 
 use crate::{SendResponse, TxCandidate, TxManager};
 
@@ -119,12 +119,13 @@ impl<M: TxManager + 'static> TxQueue<M> {
         let handle = self.tx_mgr.send_async(candidate).await;
         tokio::spawn(async move {
             let result = handle.await;
+            let success = result.is_ok();
             // Release the permit before sending the result to avoid deadlock:
             // the result channel may be full, blocking this task while holding
             // a permit that the receiver needs freed before it can drain.
             drop(permit);
             if result_tx.send(SendResult { id, result }).await.is_err() {
-                debug!("result receiver dropped, tx receipt lost");
+                warn!(success, "result receiver dropped, tx receipt lost");
             }
         });
     }

--- a/crates/utilities/tx-manager/src/queue.rs
+++ b/crates/utilities/tx-manager/src/queue.rs
@@ -14,7 +14,7 @@ use crate::{SendResponse, TxCandidate, TxManager};
 
 /// Pairs a caller-supplied identifier with the outcome of a transaction send.
 #[derive(Debug)]
-pub struct TxReceipt<T> {
+pub struct SendResult<T> {
     /// Caller-supplied identifier for the transaction.
     pub id: T,
     /// The result of the transaction send.
@@ -26,7 +26,7 @@ pub struct TxReceipt<T> {
 /// Limits the number of concurrently in-flight transactions via a semaphore.
 /// Nonces are assigned in call order because [`TxManager::send_async`] runs on
 /// the caller's task before the background completion task is spawned.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct TxQueue<M> {
     tx_mgr: Arc<M>,
     semaphore: Arc<Semaphore>,
@@ -36,9 +36,9 @@ impl<M: TxManager + 'static> TxQueue<M> {
     /// Creates a new `TxQueue`.
     ///
     /// `max_pending` controls how many transactions may be in-flight at once.
-    /// A value of `0` means unlimited (no backpressure).
-    pub fn new(tx_mgr: Arc<M>, max_pending: usize) -> Self {
-        let permits = if max_pending == 0 { Semaphore::MAX_PERMITS } else { max_pending };
+    /// `None` means unlimited (no backpressure).
+    pub fn new(tx_mgr: Arc<M>, max_pending: Option<usize>) -> Self {
+        let permits = max_pending.unwrap_or(Semaphore::MAX_PERMITS);
         debug!(max_pending = permits, "tx queue created");
         Self { tx_mgr, semaphore: Arc::new(Semaphore::new(permits)) }
     }
@@ -50,11 +50,20 @@ impl<M: TxManager + 'static> TxQueue<M> {
     ///    nonces are reserved in call order.
     /// 3. Spawns a background task that awaits the [`SendHandle`], delivers the
     ///    result on `result_tx`, and releases the permit.
+    ///
+    /// # Cancellation safety
+    ///
+    /// This future is **not** cancellation-safe. If dropped after
+    /// [`TxManager::send_async`] has been called but before the background
+    /// task delivers a result, the nonce is managed by the underlying
+    /// `TxManager` (returned to the pool on error), but the result will
+    /// never be delivered to `result_tx`. The semaphore permit is released
+    /// when the spawned task completes or on drop.
     pub async fn send<T: Send + 'static>(
         &self,
         id: T,
         candidate: TxCandidate,
-        result_tx: mpsc::Sender<TxReceipt<T>>,
+        result_tx: mpsc::Sender<SendResult<T>>,
     ) {
         let permit = Arc::clone(&self.semaphore)
             .acquire_owned()
@@ -67,11 +76,16 @@ impl<M: TxManager + 'static> TxQueue<M> {
     ///
     /// Returns `true` if a permit was available and the transaction was
     /// enqueued, `false` if the queue is full.
+    ///
+    /// # Cancellation safety
+    ///
+    /// Same as [`send`](Self::send) — not cancellation-safe once dispatch
+    /// begins.
     pub async fn try_send<T: Send + 'static>(
         &self,
         id: T,
         candidate: TxCandidate,
-        result_tx: mpsc::Sender<TxReceipt<T>>,
+        result_tx: mpsc::Sender<SendResult<T>>,
     ) -> bool {
         let permit = match Arc::clone(&self.semaphore).try_acquire_owned() {
             Ok(p) => p,
@@ -88,12 +102,12 @@ impl<M: TxManager + 'static> TxQueue<M> {
         permit: OwnedSemaphorePermit,
         id: T,
         candidate: TxCandidate,
-        result_tx: mpsc::Sender<TxReceipt<T>>,
+        result_tx: mpsc::Sender<SendResult<T>>,
     ) {
         let handle = self.tx_mgr.send_async(candidate).await;
         tokio::spawn(async move {
             let result = handle.await;
-            if result_tx.send(TxReceipt { id, result }).await.is_err() {
+            if result_tx.send(SendResult { id, result }).await.is_err() {
                 debug!("result receiver dropped, tx receipt lost");
             }
             drop(permit);
@@ -195,12 +209,12 @@ mod tests {
 
     // ── Tests ───────────────────────────────────────────────────────────
 
-    #[tokio::test]
+    #[tokio::test(flavor = "current_thread")]
     async fn send_blocks_when_full() {
         let mgr = Arc::new(GatedMockTxManager::new(3));
-        let (result_tx, mut result_rx) = mpsc::channel::<TxReceipt<u64>>(16);
+        let (result_tx, mut result_rx) = mpsc::channel::<SendResult<u64>>(16);
 
-        let queue = Arc::new(TxQueue::new(Arc::clone(&mgr), 2));
+        let queue = Arc::new(TxQueue::new(Arc::clone(&mgr), Some(2)));
 
         // First two sends should proceed immediately.
         queue.send(1, stub_candidate(), result_tx.clone()).await;
@@ -214,8 +228,8 @@ mod tests {
             queue_clone.send(3, stub_candidate(), result_tx_clone).await;
         });
 
-        // Give the spawned task time to reach the semaphore.
-        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        // Yield to let the spawned task reach the semaphore.
+        tokio::task::yield_now().await;
         assert!(!blocked.is_finished(), "third send should be blocked");
 
         // Complete the first transaction — frees a permit.
@@ -233,12 +247,12 @@ mod tests {
         mgr.complete(2);
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "current_thread")]
     async fn try_send_returns_false_when_full() {
         let mgr = Arc::new(GatedMockTxManager::new(4));
-        let (result_tx, mut result_rx) = mpsc::channel::<TxReceipt<u64>>(16);
+        let (result_tx, mut result_rx) = mpsc::channel::<SendResult<u64>>(16);
 
-        let queue = TxQueue::new(Arc::clone(&mgr), 2);
+        let queue = TxQueue::new(Arc::clone(&mgr), Some(2));
 
         assert!(queue.try_send(1, stub_candidate(), result_tx.clone()).await);
         assert!(queue.try_send(2, stub_candidate(), result_tx.clone()).await);
@@ -261,9 +275,9 @@ mod tests {
     #[tokio::test]
     async fn results_delivered_with_matching_ids() {
         let mgr = Arc::new(MockTxManager::new());
-        let (result_tx, mut result_rx) = mpsc::channel::<TxReceipt<String>>(16);
+        let (result_tx, mut result_rx) = mpsc::channel::<SendResult<String>>(16);
 
-        let queue = TxQueue::new(mgr, 10);
+        let queue = TxQueue::new(mgr, Some(10));
 
         let ids = ["alpha", "beta", "gamma"];
         for id in &ids {
@@ -291,11 +305,11 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn max_pending_zero_means_unlimited() {
+    async fn max_pending_none_means_unlimited() {
         let mgr = Arc::new(MockTxManager::new());
-        let (result_tx, mut result_rx) = mpsc::channel::<TxReceipt<u64>>(256);
+        let (result_tx, mut result_rx) = mpsc::channel::<SendResult<u64>>(256);
 
-        let queue = TxQueue::new(Arc::clone(&mgr), 0);
+        let queue = TxQueue::new(Arc::clone(&mgr), None);
 
         for i in 0..100 {
             queue.send(i, stub_candidate(), result_tx.clone()).await;

--- a/crates/utilities/tx-manager/src/queue.rs
+++ b/crates/utilities/tx-manager/src/queue.rs
@@ -72,7 +72,7 @@ impl<M: TxManager + 'static> TxQueue<M> {
         self.dispatch(permit, id, candidate, result_tx).await;
     }
 
-    /// Attempts to queue a transaction without blocking.
+    /// Attempts to queue a transaction if a permit is available.
     ///
     /// Returns `Ok(())` if a permit was available and the transaction was
     /// enqueued. Returns `Err((id, candidate))` if the queue is full, giving

--- a/crates/utilities/tx-manager/src/test_utils.rs
+++ b/crates/utilities/tx-manager/src/test_utils.rs
@@ -1,0 +1,31 @@
+//! Shared test utilities for the tx-manager crate.
+
+use alloy_consensus::{Eip658Value, Receipt, ReceiptEnvelope, ReceiptWithBloom};
+use alloy_primitives::{Address, B256, Bloom};
+use alloy_rpc_types_eth::TransactionReceipt;
+
+/// Helper to build a minimal `TransactionReceipt` for tests.
+pub fn stub_receipt() -> TransactionReceipt {
+    let inner = ReceiptEnvelope::Legacy(ReceiptWithBloom {
+        receipt: Receipt {
+            status: Eip658Value::Eip658(true),
+            cumulative_gas_used: 21_000,
+            logs: vec![],
+        },
+        logs_bloom: Bloom::ZERO,
+    });
+    TransactionReceipt {
+        inner,
+        transaction_hash: B256::ZERO,
+        transaction_index: Some(0),
+        block_hash: Some(B256::ZERO),
+        block_number: Some(1),
+        gas_used: 21_000,
+        effective_gas_price: 1_000_000_000,
+        blob_gas_used: None,
+        blob_gas_price: None,
+        from: Address::ZERO,
+        to: Some(Address::ZERO),
+        contract_address: None,
+    }
+}

--- a/crates/utilities/tx-manager/src/traits.rs
+++ b/crates/utilities/tx-manager/src/traits.rs
@@ -70,7 +70,7 @@ mod tests {
     use tokio::sync::oneshot;
 
     use super::*;
-    use crate::{test_utils::stub_receipt, TxManagerError};
+    use crate::{TxManagerError, test_utils::stub_receipt};
 
     #[tokio::test]
     async fn send_handle_yields_ok_on_success() {

--- a/crates/utilities/tx-manager/src/traits.rs
+++ b/crates/utilities/tx-manager/src/traits.rs
@@ -67,39 +67,10 @@ pub trait TxManager: Send + Sync + Debug {
 
 #[cfg(test)]
 mod tests {
-    use alloy_consensus::{Eip658Value, Receipt, ReceiptEnvelope, ReceiptWithBloom};
-    use alloy_primitives::{Address, B256, Bloom};
-    use alloy_rpc_types_eth::TransactionReceipt;
     use tokio::sync::oneshot;
 
     use super::*;
-    use crate::TxManagerError;
-
-    /// Helper to build a minimal `TransactionReceipt` for tests.
-    fn stub_receipt() -> TransactionReceipt {
-        let inner = ReceiptEnvelope::Legacy(ReceiptWithBloom {
-            receipt: Receipt {
-                status: Eip658Value::Eip658(true),
-                cumulative_gas_used: 21_000,
-                logs: vec![],
-            },
-            logs_bloom: Bloom::ZERO,
-        });
-        TransactionReceipt {
-            inner,
-            transaction_hash: B256::ZERO,
-            transaction_index: Some(0),
-            block_hash: Some(B256::ZERO),
-            block_number: Some(1),
-            gas_used: 21_000,
-            effective_gas_price: 1_000_000_000,
-            blob_gas_used: None,
-            blob_gas_price: None,
-            from: Address::ZERO,
-            to: Some(Address::ZERO),
-            contract_address: None,
-        }
-    }
+    use crate::{test_utils::stub_receipt, TxManagerError};
 
     #[tokio::test]
     async fn send_handle_yields_ok_on_success() {


### PR DESCRIPTION
### What changed? Why?

Implements `TxQueue`, a bounded async transaction send queue with backpressure for the tx-manager crate.

- `TxQueue<M>` wraps a `TxManager` and limits in-flight transactions via a `tokio::sync::Semaphore`. Nonces are assigned in queue order because `send_async` runs on the caller's task before spawning a background completion task.
- `send()` blocks when the queue is full (backpressure); `try_send()` returns `Err((id, candidate))` immediately if no permits are available.
- `SendResult<T>` pairs a caller-supplied identifier with the transaction outcome, delivered through an `mpsc` channel.
- The semaphore permit is released **before** sending the result to the mpsc channel to avoid deadlock when the result channel is full.
- Extracts the duplicated `stub_receipt` helper from `traits.rs` tests into a shared `test_utils` module.

### Notes to reviewers

Both `send` and `try_send` are documented as **not cancellation-safe** — dropping the future after `send_async` has been called but before the background task is spawned will consume a nonce and lose the result.

### How has it been tested?

Unit tests covering:
- Backpressure: third send blocks when `max_pending=2`, unblocks after a permit is freed
- `try_send` returns `Err` when full and succeeds after a slot opens
- Results delivered with correct caller-supplied IDs
- `max_pending=None` allows unlimited concurrent sends (100 sends)
- Error results propagate correctly and still release permits

### Change management ([definitions](http://go/change-management))

type=routine<!--routine,nonroutine,emergency-->
risk=low<!--low,medium,high-->
impact=sev5<!--sev5,sev4,sev3,sev2,sev1-->

### Backwards Compatibility ([learn more](http://go/backwards-compatibility))

backwards_compatible=true<!-- true false -->

<!-- Automatically merge your PR once the necessary approvals have been received (you probably want this) -->

automerge=false