### PR TITLE
chore(batcher): Cleanup Batcher Crates

### DIFF
--- a/crates/batcher/comp/src/brotli.rs
+++ b/crates/batcher/comp/src/brotli.rs
@@ -2,6 +2,8 @@
 
 use alloc::vec::Vec;
 
+use brotli::enc::{BrotliCompress, BrotliEncoderParams};
+
 use crate::{ChannelCompressor, CompressorError, CompressorResult, CompressorWriter};
 
 /// The brotli encoding level used in Base.
@@ -53,33 +55,30 @@ impl BrotliCompressor {
         let level = level.into();
         Self { compressed: Vec::new(), raw: Vec::new(), closed: false, level }
     }
+
+    /// Compresses the given bytes data using the Brotli compressor implemented
+    /// in the [`brotli`](https://crates.io/crates/brotli) crate.
+    ///
+    /// Note: The level must be between 0 and 11. In Base, the levels 9, 10, and 11 are used.
+    ///       By default, [`BrotliLevel::Brotli10`] is used.
+    pub fn compress(
+        mut input: &[u8],
+        level: BrotliLevel,
+    ) -> Result<Vec<u8>, BrotliCompressionError> {
+        let mut output = alloc::vec![];
+        BrotliCompress(
+            &mut input,
+            &mut output,
+            &BrotliEncoderParams { quality: level as i32, ..Default::default() },
+        )?;
+        Ok(output)
+    }
 }
 
 impl From<BrotliLevel> for BrotliCompressor {
     fn from(level: BrotliLevel) -> Self {
         Self::new(level)
     }
-}
-
-/// Compresses the given bytes data using the Brotli compressor implemented
-/// in the [`brotli`](https://crates.io/crates/brotli) crate.
-///
-/// Note: The level must be between 0 and 11. In Base, the levels 9, 10, and 11 are used.
-///       By default, [`BrotliLevel::Brotli10`] is used.
-#[allow(unused_variables)]
-#[allow(unused_mut)]
-pub fn compress_brotli(
-    mut input: &[u8],
-    level: BrotliLevel,
-) -> Result<Vec<u8>, BrotliCompressionError> {
-    use brotli::enc::{BrotliCompress, BrotliEncoderParams};
-    let mut output = alloc::vec![];
-    BrotliCompress(
-        &mut input,
-        &mut output,
-        &BrotliEncoderParams { quality: level as i32, ..Default::default() },
-    )?;
-    Ok(output)
 }
 
 impl CompressorWriter for BrotliCompressor {
@@ -93,7 +92,7 @@ impl CompressorWriter for BrotliCompressor {
 
         // Compress the raw buffer.
         self.compressed =
-            compress_brotli(&self.raw, self.level).map_err(|_| CompressorError::Brotli)?;
+            Self::compress(&self.raw, self.level).map_err(|_| CompressorError::Brotli)?;
 
         Ok(data.len())
     }

--- a/crates/batcher/comp/src/channel_out.rs
+++ b/crates/batcher/comp/src/channel_out.rs
@@ -1,6 +1,6 @@
 //! Contains the `ChannelOut` primitive for Base.
 
-use alloc::{sync::Arc, vec, vec::Vec};
+use alloc::{fmt, sync::Arc, vec, vec::Vec};
 
 use alloy_rlp::Encodable;
 use base_consensus_genesis::RollupConfig;
@@ -36,7 +36,6 @@ pub enum ChannelOutError {
 }
 
 /// [`ChannelOut`] constructs a channel from compressed, encoded batch data.
-#[allow(missing_debug_implementations)]
 pub struct ChannelOut<C>
 where
     C: ChannelCompressor,
@@ -54,6 +53,17 @@ where
     pub frame_number: u16,
     /// The compressor.
     pub compressor: C,
+}
+
+impl<C: ChannelCompressor> fmt::Debug for ChannelOut<C> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ChannelOut")
+            .field("id", &self.id)
+            .field("rlp_length", &self.rlp_length)
+            .field("frame_number", &self.frame_number)
+            .field("closed", &self.closed)
+            .finish_non_exhaustive()
+    }
 }
 
 impl<C> ChannelOut<C>
@@ -147,10 +157,7 @@ where
             if self.frame_number == 0 { self.compressor.channel_version_byte() } else { None };
         let prefix_len = usize::from(version_byte.is_some());
 
-        let mut max_size = max_size - FRAME_V0_OVERHEAD - prefix_len;
-        if max_size > self.ready_bytes() {
-            max_size = self.ready_bytes();
-        }
+        let max_size = (max_size - FRAME_V0_OVERHEAD - prefix_len).min(self.ready_bytes());
 
         let mut data = Vec::with_capacity(prefix_len + max_size);
         if let Some(v) = version_byte {

--- a/crates/batcher/comp/src/lib.rs
+++ b/crates/batcher/comp/src/lib.rs
@@ -26,12 +26,12 @@ mod types;
 pub use types::{CompressionAlgo, CompressorError, CompressorResult, CompressorType};
 
 mod zlib;
-pub use zlib::{ZlibCompressor, compress_zlib, decompress_zlib};
+pub use zlib::ZlibCompressor;
 
 #[cfg(feature = "std")]
 mod brotli;
 #[cfg(feature = "std")]
-pub use brotli::{BrotliCompressionError, BrotliCompressor, BrotliLevel, compress_brotli};
+pub use brotli::{BrotliCompressionError, BrotliCompressor, BrotliLevel};
 
 #[cfg(feature = "std")]
 mod variant;

--- a/crates/batcher/comp/src/ratio.rs
+++ b/crates/batcher/comp/src/ratio.rs
@@ -55,13 +55,9 @@ impl From<Config> for RatioCompressor {
 
 impl CompressorWriter for RatioCompressor {
     fn write(&mut self, data: &[u8]) -> CompressorResult<usize> {
-        match self.compressor.write(data) {
-            Ok(n) => {
-                self.lake += n as u64;
-                Ok(n)
-            }
-            Err(e) => Err(e),
-        }
+        let n = self.compressor.write(data)?;
+        self.lake += n as u64;
+        Ok(n)
     }
 
     fn flush(&mut self) -> CompressorResult<()> {

--- a/crates/batcher/comp/src/traits.rs
+++ b/crates/batcher/comp/src/traits.rs
@@ -9,7 +9,6 @@ use crate::CompressorResult;
 /// A trait that expands the standard library `Write` trait to include
 /// compression-specific methods and return [`CompressorResult`] instead of
 /// standard library `Result`.
-#[allow(clippy::len_without_is_empty)]
 pub trait CompressorWriter {
     /// Writes the given data to the compressor.
     fn write(&mut self, data: &[u8]) -> CompressorResult<usize>;
@@ -25,6 +24,11 @@ pub trait CompressorWriter {
 
     /// Returns the length of the compressed data.
     fn len(&self) -> usize;
+
+    /// Returns `true` if the compressed output is empty.
+    fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
 
     /// Reads the compressed data into the given buffer.
     /// Returns the number of bytes read.

--- a/crates/batcher/comp/src/zlib.rs
+++ b/crates/batcher/comp/src/zlib.rs
@@ -6,18 +6,8 @@ use miniz_oxide::inflate::DecompressError;
 
 use crate::{ChannelCompressor, CompressorResult, CompressorWriter};
 
-/// The best compression.
+/// The best compression level for ZLIB.
 const BEST_ZLIB_COMPRESSION: u8 = 9;
-
-/// Method to compress data using ZLIB.
-pub fn compress_zlib(data: &[u8]) -> Vec<u8> {
-    miniz_oxide::deflate::compress_to_vec(data, BEST_ZLIB_COMPRESSION)
-}
-
-/// Method to decompress data using ZLIB.
-pub fn decompress_zlib(data: &[u8]) -> Result<Vec<u8>, DecompressError> {
-    miniz_oxide::inflate::decompress_to_vec(data)
-}
 
 /// The ZLIB compressor.
 #[derive(Debug, Clone, Default)]
@@ -34,13 +24,23 @@ impl ZlibCompressor {
     pub const fn new() -> Self {
         Self { buffer: Vec::new(), compressed: Vec::new() }
     }
+
+    /// Compress `data` using ZLIB deflate.
+    pub fn compress(data: &[u8]) -> Vec<u8> {
+        miniz_oxide::deflate::compress_to_vec(data, BEST_ZLIB_COMPRESSION)
+    }
+
+    /// Decompress ZLIB-deflated `data`.
+    pub fn decompress(data: &[u8]) -> Result<Vec<u8>, DecompressError> {
+        miniz_oxide::inflate::decompress_to_vec(data)
+    }
 }
 
 impl CompressorWriter for ZlibCompressor {
     fn write(&mut self, data: &[u8]) -> CompressorResult<usize> {
         self.buffer.extend_from_slice(data);
         self.compressed.clear();
-        self.compressed.extend_from_slice(&compress_zlib(&self.buffer));
+        self.compressed.extend_from_slice(&Self::compress(&self.buffer));
         Ok(data.len())
     }
 

--- a/crates/batcher/core/src/driver.rs
+++ b/crates/batcher/core/src/driver.rs
@@ -260,7 +260,7 @@ where
                         TxOutcome::Confirmed { l1_block } => {
                             self.pipeline.confirm(id, l1_block);
                             self.pipeline.advance_l1_head(l1_block);
-                            debug!(id = %id.0, l1_block, "submission confirmed");
+                            debug!(id = %id.0, l1_block = %l1_block, "submission confirmed");
                         }
                         TxOutcome::Failed => {
                             self.pipeline.requeue(id);

--- a/crates/batcher/encoder/src/encoder.rs
+++ b/crates/batcher/encoder/src/encoder.rs
@@ -119,9 +119,9 @@ impl BatchEncoder {
 
         debug!(
             channel_id = ?channel_id,
-            frame_count = frames.len(),
-            block_range_start = block_range.start,
-            block_range_end = block_range.end,
+            frame_count = %frames.len(),
+            block_range_start = %block_range.start,
+            block_range_end = %block_range.end,
             "closed channel"
         );
 
@@ -167,7 +167,7 @@ impl BatchEncoder {
         };
 
         if should_close {
-            debug!(l1_head = self.l1_head, "channel timed out, closing");
+            debug!(l1_head = %self.l1_head, "channel timed out, closing");
             self.close_current_channel();
         }
 
@@ -223,8 +223,8 @@ impl BatchPipeline for BatchEncoder {
                 self.block_cursor += 1;
 
                 debug!(
-                    block_cursor = self.block_cursor,
-                    blocks_len = self.blocks.len(),
+                    block_cursor = %self.block_cursor,
+                    blocks_len = %self.blocks.len(),
                     "encoded block into channel"
                 );
 
@@ -276,7 +276,7 @@ impl BatchPipeline for BatchEncoder {
 
         let chan_idx = pending_ref.channel_idx;
         if chan_idx >= self.ready_channels.len() {
-            warn!(id = ?id, chan_idx, "confirm: channel index out of bounds; submission lost");
+            warn!(id = ?id, chan_idx = %chan_idx, "confirm: channel index out of bounds; submission lost");
             return;
         }
 
@@ -290,8 +290,8 @@ impl BatchPipeline for BatchEncoder {
 
             debug!(
                 channel_id = ?channel.id,
-                block_range_start = block_range.start,
-                block_range_end = block_range.end,
+                block_range_start = %block_range.start,
+                block_range_end = %block_range.end,
                 "channel fully confirmed, pruning blocks"
             );
 
@@ -308,9 +308,7 @@ impl BatchPipeline for BatchEncoder {
             // Prune confirmed blocks from the deque.
             let prune_count = block_range.end;
             if prune_count > 0 {
-                for _ in 0..prune_count {
-                    self.blocks.pop_front();
-                }
+                self.blocks.drain(..prune_count);
                 self.block_cursor = self.block_cursor.saturating_sub(prune_count);
 
                 // Adjust the high-water mark for all remaining channels.
@@ -330,7 +328,7 @@ impl BatchPipeline for BatchEncoder {
 
         let chan_idx = pending_ref.channel_idx;
         if chan_idx >= self.ready_channels.len() {
-            warn!(id = ?id, chan_idx, "requeue: channel index out of bounds; submission lost");
+            warn!(id = ?id, chan_idx = %chan_idx, "requeue: channel index out of bounds; submission lost");
             return;
         }
 
@@ -344,8 +342,8 @@ impl BatchPipeline for BatchEncoder {
 
         debug!(
             id = ?id,
-            frame_start = pending_ref.frame_start,
-            frame_count = pending_ref.frame_count,
+            frame_start = %pending_ref.frame_start,
+            frame_count = %pending_ref.frame_count,
             "requeued submission"
         );
     }
@@ -373,17 +371,13 @@ impl BatchPipeline for BatchEncoder {
     }
 
     fn da_backlog_bytes(&self) -> u64 {
-        let mut total: u64 = 0;
-        for block in self.blocks.iter().skip(self.block_cursor) {
-            for tx in &block.body.transactions {
-                // Exclude deposit transactions (type 0x7E).
-                if matches!(tx, OpTxEnvelope::Deposit(_)) {
-                    continue;
-                }
-                total += tx.encode_2718_len() as u64;
-            }
-        }
-        total
+        self.blocks
+            .iter()
+            .skip(self.block_cursor)
+            .flat_map(|b| &b.body.transactions)
+            .filter(|tx| !matches!(tx, OpTxEnvelope::Deposit(_)))
+            .map(|tx| tx.encode_2718_len() as u64)
+            .sum()
     }
 }
 

--- a/crates/batcher/encoder/src/types.rs
+++ b/crates/batcher/encoder/src/types.rs
@@ -150,6 +150,26 @@ impl EncoderConfig {
     }
 }
 
+/// Errors returned by [`EncoderConfig::validate`].
+#[derive(Debug, thiserror::Error)]
+pub enum EncoderConfigError {
+    /// `sub_safety_margin >= max_channel_duration`.
+    ///
+    /// The effective channel timeout (`max_channel_duration - sub_safety_margin`) would
+    /// saturate to 0, causing every channel to close immediately on the first
+    /// `advance_l1_head` call. Ensure `sub_safety_margin < max_channel_duration`.
+    #[error(
+        "sub_safety_margin ({sub_safety_margin}) must be less than \
+         max_channel_duration ({max_channel_duration})"
+    )]
+    SafetyMarginTooLarge {
+        /// The configured safety margin.
+        sub_safety_margin: u64,
+        /// The configured maximum channel duration.
+        max_channel_duration: u64,
+    },
+}
+
 #[cfg(test)]
 mod tests {
     use rstest::rstest;
@@ -186,24 +206,4 @@ mod tests {
         assert!(msg.contains(&sub_safety_margin.to_string()));
         assert!(msg.contains(&max_channel_duration.to_string()));
     }
-}
-
-/// Errors returned by [`EncoderConfig::validate`].
-#[derive(Debug, thiserror::Error)]
-pub enum EncoderConfigError {
-    /// `sub_safety_margin >= max_channel_duration`.
-    ///
-    /// The effective channel timeout (`max_channel_duration - sub_safety_margin`) would
-    /// saturate to 0, causing every channel to close immediately on the first
-    /// `advance_l1_head` call. Ensure `sub_safety_margin < max_channel_duration`.
-    #[error(
-        "sub_safety_margin ({sub_safety_margin}) must be less than \
-         max_channel_duration ({max_channel_duration})"
-    )]
-    SafetyMarginTooLarge {
-        /// The configured safety margin.
-        sub_safety_margin: u64,
-        /// The configured maximum channel duration.
-        max_channel_duration: u64,
-    },
 }

--- a/crates/batcher/source/src/hybrid.rs
+++ b/crates/batcher/source/src/hybrid.rs
@@ -79,13 +79,13 @@ where
             }
             Some(existing_hash) if *existing_hash == hash => {
                 // Duplicate — already seen this exact block.
-                tracing::debug!(block = number, "duplicate block, skipping");
+                tracing::debug!(block = %number, "duplicate block, skipping");
                 None
             }
             Some(_) => {
                 // Same number, different hash — reorg detected.
                 tracing::warn!(
-                    block = number,
+                    block = %number,
                     "reorg detected: different hash for same block number"
                 );
                 self.seen.insert(number, hash);


### PR DESCRIPTION
## Summary

Cleans up the batcher crates to conform with CLAUDE.md conventions. Bare functions like `compress_brotli`, `compress_zlib`, and `decompress_zlib` are moved to associated methods on their respective types. Suppressed lints are removed by fixing the underlying issues — adding `is_empty` to `CompressorWriter` and implementing `Debug` for `ChannelOut`. Tracing calls are updated to use `%` for Display values. Several minor code patterns are simplified using `?`, `.min()`, `drain()`, and iterator chains.