### PR TITLE
feat(tx-manager): Metrics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4638,6 +4638,7 @@ dependencies = [
  "backon",
  "clap",
  "humantime",
+ "metrics",
  "proptest",
  "rayon",
  "rstest",

--- a/crates/utilities/tx-manager/Cargo.toml
+++ b/crates/utilities/tx-manager/Cargo.toml
@@ -21,6 +21,7 @@ alloy-rpc-types-eth = { workspace = true, features = ["std"] }
 
 # misc
 backon.workspace = true
+metrics.workspace = true
 thiserror.workspace = true
 tracing = { workspace = true, features = ["std"] }
 tokio = { workspace = true, features = ["sync", "time"] }

--- a/crates/utilities/tx-manager/README.md
+++ b/crates/utilities/tx-manager/README.md
@@ -207,7 +207,7 @@ let provider = RootProvider::new_http("http://localhost:8545".parse()?);
 let wallet = EthereumWallet::from(signer);
 let config = TxManagerConfig::default();
 let chain_id = 1;
-let manager = SimpleTxManager::new(provider, wallet, config, chain_id, Arc::new(BaseTxMetrics)).await?;
+let manager = SimpleTxManager::new(provider, wallet, config, chain_id, Arc::new(BaseTxMetrics::new("my_service"))).await?;
 
 // Build a regular (type-2) transaction candidate.
 let candidate = TxCandidate {

--- a/crates/utilities/tx-manager/README.md
+++ b/crates/utilities/tx-manager/README.md
@@ -195,17 +195,19 @@ base-tx-manager = { git = "https://github.com/base/base" }
 ```
 
 ```rust,ignore
+use std::sync::Arc;
+
 use alloy_network::EthereumWallet;
 use alloy_primitives::{bytes, Address, U256};
 use alloy_provider::RootProvider;
-use base_tx_manager::{SimpleTxManager, TxCandidate, TxManager, TxManagerConfig};
+use base_tx_manager::{BaseTxMetrics, SimpleTxManager, TxCandidate, TxManager, TxManagerConfig};
 
 // Create a SimpleTxManager with a provider, wallet, and config.
 let provider = RootProvider::new_http("http://localhost:8545".parse()?);
 let wallet = EthereumWallet::from(signer);
 let config = TxManagerConfig::default();
 let chain_id = 1;
-let manager = SimpleTxManager::new(provider, wallet, config, chain_id).await?;
+let manager = SimpleTxManager::new(provider, wallet, config, chain_id, Arc::new(BaseTxMetrics)).await?;
 
 // Build a regular (type-2) transaction candidate.
 let candidate = TxCandidate {

--- a/crates/utilities/tx-manager/src/error.rs
+++ b/crates/utilities/tx-manager/src/error.rs
@@ -169,6 +169,16 @@ impl TxManagerError {
     pub const fn is_already_known(&self) -> bool {
         matches!(self, Self::AlreadyKnown)
     }
+
+    /// Returns `true` only for [`TxManagerError::Rpc`].
+    ///
+    /// Used to gate RPC error metric recording so that recognised state
+    /// errors (e.g. `NonceTooLow`, `ExecutionReverted`) do not inflate the
+    /// RPC error counter.
+    #[must_use]
+    pub const fn is_rpc_error(&self) -> bool {
+        matches!(self, Self::Rpc(_))
+    }
 }
 
 /// Result type alias for transaction manager operations.
@@ -336,6 +346,18 @@ mod tests {
     #[case::invalid_safe_abort(TxManagerError::InvalidSafeAbortNonceTooLowCount, false)]
     fn is_already_known(#[case] error: TxManagerError, #[case] expected: bool) {
         assert_eq!(error.is_already_known(), expected);
+    }
+
+    // ── is_rpc_error ─────────────────────────────────────────────────────
+
+    #[rstest]
+    #[case::rpc(TxManagerError::Rpc("any error".to_string()), true)]
+    #[case::nonce_too_low(TxManagerError::NonceTooLow, false)]
+    #[case::underpriced(TxManagerError::Underpriced, false)]
+    #[case::already_known(TxManagerError::AlreadyKnown, false)]
+    #[case::channel_closed(TxManagerError::ChannelClosed, false)]
+    fn is_rpc_error(#[case] error: TxManagerError, #[case] expected: bool) {
+        assert_eq!(error.is_rpc_error(), expected);
     }
 
     // ── Display output ──────────────────────────────────────────────────

--- a/crates/utilities/tx-manager/src/lib.rs
+++ b/crates/utilities/tx-manager/src/lib.rs
@@ -37,7 +37,7 @@ mod queue;
 pub use queue::{SendResult, TxQueue};
 
 mod metrics;
-pub use metrics::TxMetrics;
+pub use metrics::{BaseTxMetrics, NoopTxMetrics, TxMetrics};
 
 mod blob;
 pub use blob::BlobTxBuilder;

--- a/crates/utilities/tx-manager/src/manager.rs
+++ b/crates/utilities/tx-manager/src/manager.rs
@@ -56,8 +56,9 @@ use crate::{
     TxManagerResult, TxMetrics,
 };
 
-/// Number of wei in one gwei (10^9).
-const WEI_PER_GWEI: u128 = 1_000_000_000;
+/// Number of wei in one gwei (10^9), as `f64` for fractional-precision
+/// metric conversions that must not truncate sub-gwei values.
+const WEI_PER_GWEI: f64 = 1_000_000_000.0;
 
 /// A signed transaction together with the fee values that were applied
 /// during construction.
@@ -221,8 +222,8 @@ impl SimpleTxManager {
     }
 
     /// Returns a reference to the metrics collector.
-    pub fn metrics(&self) -> &Arc<dyn TxMetrics> {
-        &self.metrics
+    pub fn metrics(&self) -> &dyn TxMetrics {
+        self.metrics.as_ref()
     }
 
     /// Signals the manager to stop accepting new transactions.
@@ -243,7 +244,7 @@ impl SimpleTxManager {
 
     /// Records an RPC error metric and returns a [`TxManagerError::Rpc`] for a
     /// timed-out RPC call.
-    fn rpc_timeout(&self, msg: &str) -> TxManagerError {
+    fn rpc_timeout_error(&self, msg: &str) -> TxManagerError {
         self.metrics.record_rpc_error();
         TxManagerError::Rpc(msg.into())
     }
@@ -252,7 +253,7 @@ impl SimpleTxManager {
     /// error is an unrecognised transport failure ([`TxManagerError::Rpc`]).
     /// Recognised state errors (e.g. `NonceTooLow`, `ExecutionReverted`) are
     /// returned without inflating the RPC error counter.
-    fn classify_rpc(&self, error_msg: &str) -> TxManagerError {
+    fn classify_and_record_rpc(&self, error_msg: &str) -> TxManagerError {
         let err = RpcErrorClassifier::classify_rpc_error(error_msg);
         if err.is_rpc_error() {
             self.metrics.record_rpc_error();
@@ -367,12 +368,12 @@ impl SimpleTxManager {
         );
 
         let raw_tip_cap = tip_result
-            .map_err(|_| self.rpc_timeout("get_max_priority_fee_per_gas timed out"))?
-            .map_err(|e| self.classify_rpc(&e.to_string()))?;
+            .map_err(|_| self.rpc_timeout_error("get_max_priority_fee_per_gas timed out"))?
+            .map_err(|e| self.classify_and_record_rpc(&e.to_string()))?;
 
         let latest_block = block_result
-            .map_err(|_| self.rpc_timeout("get_block_by_number timed out"))?
-            .map_err(|e| self.classify_rpc(&e.to_string()))?
+            .map_err(|_| self.rpc_timeout_error("get_block_by_number timed out"))?
+            .map_err(|e| self.classify_and_record_rpc(&e.to_string()))?
             .ok_or_else(|| {
                 self.metrics.record_rpc_error();
                 TxManagerError::Rpc("latest block not found".to_string())
@@ -395,9 +396,9 @@ impl SimpleTxManager {
         // Compute gas fee cap with enforced minimums.
         let gas_fee_cap = FeeCalculator::calc_gas_fee_cap(base_fee, tip_cap);
 
-        // Record fee metrics (converted from wei to gwei via integer division).
-        self.metrics.record_basefee((base_fee / WEI_PER_GWEI) as u64);
-        self.metrics.record_tipcap((tip_cap / WEI_PER_GWEI) as u64);
+        // Record fee metrics (converted from wei to gwei with fractional precision).
+        self.metrics.record_basefee(base_fee as f64 / WEI_PER_GWEI);
+        self.metrics.record_tipcap(tip_cap as f64 / WEI_PER_GWEI);
 
         Ok(GasPriceCaps { gas_tip_cap: tip_cap, gas_fee_cap, raw_gas_fee_cap, blob_fee_cap: None })
     }
@@ -589,8 +590,8 @@ impl SimpleTxManager {
             self.provider.estimate_gas(tx_request.clone()),
         )
         .await
-        .map_err(|_| self.rpc_timeout("estimate_gas timed out"))?
-        .map_err(|e| self.classify_rpc(&e.to_string()))?;
+        .map_err(|_| self.rpc_timeout_error("estimate_gas timed out"))?
+        .map_err(|e| self.classify_and_record_rpc(&e.to_string()))?;
         let gas_limit = candidate.gas_limit.max(estimated);
         tx_request = tx_request.with_gas_limit(gas_limit);
 
@@ -629,7 +630,7 @@ impl SimpleTxManager {
                 drop(guard);
 
                 // Record tx fee metric: max possible fee in gwei.
-                let fee_gwei = (u128::from(gas_limit) * fee_cap / WEI_PER_GWEI) as u64;
+                let fee_gwei = u128::from(gas_limit) as f64 * fee_cap as f64 / WEI_PER_GWEI;
                 self.metrics.record_tx_fee(fee_gwei);
 
                 Ok(PreparedTx {
@@ -811,6 +812,7 @@ impl SimpleTxManager {
     ) -> SendResponse {
         let start = Instant::now();
 
+        let result: SendResponse = async {
         // Initial transaction preparation. prepare() is NOT cancellation-safe,
         // so it runs to completion before entering the select loop.
         // The returned PreparedTx carries the actual on-wire fees, eliminating
@@ -852,8 +854,6 @@ impl SimpleTxManager {
             // If a receipt is already waiting, return it immediately
             // instead of performing a wasted fee bump.
             if let Ok(receipt) = receipt_rx.try_recv() {
-                let latency_ms = u64::try_from(start.elapsed().as_millis()).unwrap_or(u64::MAX);
-                self.metrics.record_confirmed_latency(latency_ms);
                 info!(
                     tx_hash = %receipt.transaction_hash,
                     block = ?receipt.block_number,
@@ -896,8 +896,6 @@ impl SimpleTxManager {
                 result = receipt_rx.recv() => {
                     match result {
                         Some(receipt) => {
-                            let latency_ms = u64::try_from(start.elapsed().as_millis()).unwrap_or(u64::MAX);
-                            self.metrics.record_confirmed_latency(latency_ms);
                             info!(
                                 tx_hash = %receipt.transaction_hash,
                                 block = ?receipt.block_number,
@@ -922,6 +920,12 @@ impl SimpleTxManager {
             }
             bump_ticker.reset();
         }
+        }
+        .await;
+
+        let latency_ms = u64::try_from(start.elapsed().as_millis()).unwrap_or(u64::MAX);
+        self.metrics.record_confirmed_latency(latency_ms);
+        result
     }
 
     /// Performs a fee bump attempt and applies the result to the tracked state.
@@ -1079,7 +1083,7 @@ impl SimpleTxManager {
                 Ok(tx_hash)
             }
             Ok(Err(e)) => {
-                let classified = self.classify_rpc(&e.to_string());
+                let classified = self.classify_and_record_rpc(&e.to_string());
 
                 // AlreadyKnown on resubmission is a success — the tx is in
                 // the mempool from a prior publish. Return the previous hash.
@@ -1095,7 +1099,9 @@ impl SimpleTxManager {
                 }
 
                 send_state.process_send_error(&classified);
-                self.metrics.record_publish_error();
+                if !classified.is_already_known() {
+                    self.metrics.record_publish_error();
+                }
 
                 if classified.is_retryable() {
                     warn!(error = %classified, "publish failed, will retry");
@@ -1106,7 +1112,7 @@ impl SimpleTxManager {
                 Err(classified)
             }
             Err(_) => {
-                let err = self.rpc_timeout("send_raw_transaction timed out");
+                let err = self.rpc_timeout_error("send_raw_transaction timed out");
                 send_state.process_send_error(&err);
                 self.metrics.record_publish_error();
                 warn!("publish timed out");

--- a/crates/utilities/tx-manager/src/manager.rs
+++ b/crates/utilities/tx-manager/src/manager.rs
@@ -630,7 +630,7 @@ impl SimpleTxManager {
                 drop(guard);
 
                 // Record tx fee metric: max possible fee in gwei.
-                let fee_gwei = u128::from(gas_limit) as f64 * fee_cap as f64 / WEI_PER_GWEI;
+                let fee_gwei = u128::from(gas_limit) as f64 * (fee_cap as f64 / WEI_PER_GWEI);
                 self.metrics.record_tx_fee(fee_gwei);
 
                 Ok(PreparedTx {
@@ -813,118 +813,121 @@ impl SimpleTxManager {
         let start = Instant::now();
 
         let result: SendResponse = async {
-        // Initial transaction preparation. prepare() is NOT cancellation-safe,
-        // so it runs to completion before entering the select loop.
-        // The returned PreparedTx carries the actual on-wire fees, eliminating
-        // the need for a separate suggest_gas_price_caps() call.
-        let prepared =
-            self.prepare_with_initial_caps(candidate, None, None, nonce_override).await?;
-        let tx_hash = self.publish_tx(send_state, &prepared.raw_tx, None).await?;
-        let mut bump = BumpState::from_prepared(&prepared, tx_hash);
+            // Initial transaction preparation. prepare() is NOT cancellation-safe,
+            // so it runs to completion before entering the select loop.
+            // The returned PreparedTx carries the actual on-wire fees, eliminating
+            // the need for a separate suggest_gas_price_caps() call.
+            let prepared =
+                self.prepare_with_initial_caps(candidate, None, None, nonce_override).await?;
+            let tx_hash = self.publish_tx(send_state, &prepared.raw_tx, None).await?;
+            let mut bump = BumpState::from_prepared(&prepared, tx_hash);
 
-        // Receipt delivery channel — mpsc because fee bumps may spawn
-        // new wait tasks with different tx hashes.
-        let (receipt_tx, mut receipt_rx) = mpsc::channel::<TransactionReceipt>(1);
+            // Receipt delivery channel — mpsc because fee bumps may spawn
+            // new wait tasks with different tx hashes.
+            let (receipt_tx, mut receipt_rx) = mpsc::channel::<TransactionReceipt>(1);
 
-        // Spawn background receipt polling for the initial tx hash.
-        Self::wait_for_tx(
-            Arc::clone(send_state),
-            self.provider.clone(),
-            bump.tx_hash,
-            self.config.clone(),
-            receipt_tx.clone(),
-            Arc::clone(&self.closed),
-        );
+            // Spawn background receipt polling for the initial tx hash.
+            Self::wait_for_tx(
+                Arc::clone(send_state),
+                self.provider.clone(),
+                bump.tx_hash,
+                self.config.clone(),
+                receipt_tx.clone(),
+                Arc::clone(&self.closed),
+            );
 
-        // Resubmission timer for fee bumping.
-        let mut bump_ticker = tokio::time::interval(self.config.resubmission_timeout);
-        // Consume the first immediate tick.
-        bump_ticker.tick().await;
+            // Resubmission timer for fee bumping.
+            let mut bump_ticker = tokio::time::interval(self.config.resubmission_timeout);
+            // Consume the first immediate tick.
+            bump_ticker.tick().await;
 
-        loop {
-            // Check shutdown and critical errors before blocking.
-            if self.is_closed() {
-                return Err(TxManagerError::ChannelClosed);
-            }
-            if let Some(err) = send_state.critical_error() {
-                error!(error = %err, "critical error, aborting send");
-                return Err(err);
-            }
+            loop {
+                // Check shutdown and critical errors before blocking.
+                if self.is_closed() {
+                    return Err(TxManagerError::ChannelClosed);
+                }
+                if let Some(err) = send_state.critical_error() {
+                    error!(error = %err, "critical error, aborting send");
+                    return Err(err);
+                }
 
-            // If a receipt is already waiting, return it immediately
-            // instead of performing a wasted fee bump.
-            if let Ok(receipt) = receipt_rx.try_recv() {
-                info!(
-                    tx_hash = %receipt.transaction_hash,
-                    block = ?receipt.block_number,
-                    "transaction confirmed",
-                );
-                return Ok(receipt);
-            }
+                // If a receipt is already waiting, return it immediately
+                // instead of performing a wasted fee bump.
+                if let Ok(receipt) = receipt_rx.try_recv() {
+                    info!(
+                        tx_hash = %receipt.transaction_hash,
+                        block = ?receipt.block_number,
+                        "transaction confirmed",
+                    );
+                    return Ok(receipt);
+                }
 
-            // Respond immediately to the should_bump_fees flag set by
-            // process_send_error on retryable errors (e.g. Underpriced,
-            // ReplacementUnderpriced), rather than waiting for the next
-            // resubmission timer tick.
-            //
-            // Clear the flag before attempting the bump so that a failed
-            // attempt (e.g. RPC timeout) does not immediately re-trigger
-            // on the next loop iteration — instead, the loop falls through
-            // to tokio::select! which waits for the resubmission timer or
-            // a receipt, providing natural backoff. If a new retryable
-            // error occurs later, process_send_error will re-set the flag.
-            if send_state.should_bump_fees() {
-                send_state.clear_bump_fees();
+                // Respond immediately to the should_bump_fees flag set by
+                // process_send_error on retryable errors (e.g. Underpriced,
+                // ReplacementUnderpriced), rather than waiting for the next
+                // resubmission timer tick.
+                //
+                // Clear the flag before attempting the bump so that a failed
+                // attempt (e.g. RPC timeout) does not immediately re-trigger
+                // on the next loop iteration — instead, the loop falls through
+                // to tokio::select! which waits for the resubmission timer or
+                // a receipt, providing natural backoff. If a new retryable
+                // error occurs later, process_send_error will re-set the flag.
+                if send_state.should_bump_fees() {
+                    send_state.clear_bump_fees();
+                    if let Some(abort) =
+                        self.try_fee_bump(candidate, send_state, &receipt_tx, &mut bump).await
+                    {
+                        return Err(abort);
+                    }
+                    // Reset the bump ticker so we get a full interval
+                    // before the next timer-driven bump.
+                    bump_ticker.reset();
+                    continue;
+                }
+
+                // Determine which event fired. handle_fee_bump (and
+                // transitively prepare()) is NOT cancellation-safe, so it
+                // must not run inside tokio::select!. The select block only
+                // captures which arm won; fee bump work runs to completion
+                // outside the select block.
+                tokio::select! {
+                    biased;
+                    result = receipt_rx.recv() => {
+                        match result {
+                            Some(receipt) => {
+                                info!(
+                                    tx_hash = %receipt.transaction_hash,
+                                    block = ?receipt.block_number,
+                                    "transaction confirmed",
+                                );
+                                return Ok(receipt);
+                            }
+                            None => {
+                                // All senders dropped — should not happen in normal flow.
+                                return Err(TxManagerError::ChannelClosed);
+                            }
+                        }
+                    }
+                    _ = bump_ticker.tick() => {}
+                };
+
+                // Bump tick fired — run fee bump logic.
                 if let Some(abort) =
                     self.try_fee_bump(candidate, send_state, &receipt_tx, &mut bump).await
                 {
                     return Err(abort);
                 }
-                // Reset the bump ticker so we get a full interval
-                // before the next timer-driven bump.
                 bump_ticker.reset();
-                continue;
             }
-
-            // Determine which event fired. handle_fee_bump (and
-            // transitively prepare()) is NOT cancellation-safe, so it
-            // must not run inside tokio::select!. The select block only
-            // captures which arm won; fee bump work runs to completion
-            // outside the select block.
-            tokio::select! {
-                biased;
-                result = receipt_rx.recv() => {
-                    match result {
-                        Some(receipt) => {
-                            info!(
-                                tx_hash = %receipt.transaction_hash,
-                                block = ?receipt.block_number,
-                                "transaction confirmed",
-                            );
-                            return Ok(receipt);
-                        }
-                        None => {
-                            // All senders dropped — should not happen in normal flow.
-                            return Err(TxManagerError::ChannelClosed);
-                        }
-                    }
-                }
-                _ = bump_ticker.tick() => {}
-            };
-
-            // Bump tick fired — run fee bump logic.
-            if let Some(abort) =
-                self.try_fee_bump(candidate, send_state, &receipt_tx, &mut bump).await
-            {
-                return Err(abort);
-            }
-            bump_ticker.reset();
-        }
         }
         .await;
 
-        let latency_ms = u64::try_from(start.elapsed().as_millis()).unwrap_or(u64::MAX);
-        self.metrics.record_confirmed_latency(latency_ms);
+        if result.is_ok() {
+            let latency_ms = u64::try_from(start.elapsed().as_millis()).unwrap_or(u64::MAX);
+            self.metrics.record_confirmed_latency(latency_ms);
+            self.metrics.record_tx_confirmed();
+        }
         result
     }
 
@@ -1338,6 +1341,8 @@ impl TxManager for SimpleTxManager {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+
     use alloy_consensus::{TxEip1559, TxEnvelope};
     use alloy_eips::Decodable2718;
     use alloy_network::EthereumWallet;
@@ -1346,8 +1351,6 @@ mod tests {
     use alloy_provider::RootProvider;
     use alloy_signer_local::PrivateKeySigner;
     use rstest::rstest;
-
-    use std::sync::Arc;
 
     use super::{BumpState, SimpleTxManager};
     use crate::{GasPriceCaps, NoopTxMetrics, TxCandidate, TxManagerConfig, TxManagerError};

--- a/crates/utilities/tx-manager/src/manager.rs
+++ b/crates/utilities/tx-manager/src/manager.rs
@@ -53,7 +53,7 @@ use tracing::{debug, error, info, warn};
 use crate::{
     BumpedFees, FeeCalculator, FeeOverride, GasPriceCaps, NonceManager, RpcErrorClassifier,
     SendHandle, SendResponse, SendState, TxCandidate, TxManager, TxManagerConfig, TxManagerError,
-    TxManagerResult,
+    TxManagerResult, TxMetrics,
 };
 
 /// A signed transaction together with the fee values that were applied
@@ -132,6 +132,8 @@ pub struct SimpleTxManager {
     /// on the original manager is observed by tasks spawned via
     /// [`send_async`](Self::send_async) and [`wait_for_tx`](Self::wait_for_tx).
     closed: Arc<AtomicBool>,
+    /// Metrics collector for transaction lifecycle events.
+    metrics: Arc<dyn TxMetrics>,
 }
 
 impl SimpleTxManager {
@@ -159,6 +161,7 @@ impl SimpleTxManager {
         wallet: EthereumWallet,
         config: TxManagerConfig,
         chain_id: u64,
+        metrics: Arc<dyn TxMetrics>,
     ) -> TxManagerResult<Self> {
         config.validate().map_err(|e| TxManagerError::InvalidConfig(e.to_string()))?;
 
@@ -185,6 +188,7 @@ impl SimpleTxManager {
             nonce_manager,
             chain_id,
             closed: Arc::new(AtomicBool::new(false)),
+            metrics,
         })
     }
 
@@ -213,6 +217,11 @@ impl SimpleTxManager {
         self.chain_id
     }
 
+    /// Returns a reference to the metrics collector.
+    pub fn metrics(&self) -> &Arc<dyn TxMetrics> {
+        &self.metrics
+    }
+
     /// Signals the manager to stop accepting new transactions.
     ///
     /// After calling `close()`, any subsequent call to [`prepare`](Self::prepare)
@@ -227,6 +236,19 @@ impl SimpleTxManager {
     /// Returns `true` if the manager has been closed via [`close`](Self::close).
     pub fn is_closed(&self) -> bool {
         self.closed.load(Ordering::Acquire)
+    }
+
+    /// Records an RPC error metric and returns a [`TxManagerError::Rpc`] for a
+    /// timed-out RPC call.
+    fn rpc_timeout(&self, msg: &str) -> TxManagerError {
+        self.metrics.record_rpc_error();
+        TxManagerError::Rpc(msg.into())
+    }
+
+    /// Records an RPC error metric and classifies the RPC error string.
+    fn classify_rpc<E: std::fmt::Display>(&self, e: &E) -> TxManagerError {
+        self.metrics.record_rpc_error();
+        RpcErrorClassifier::classify_rpc_error(&e.to_string())
     }
 
     /// Constructs and signs a transaction, retrying on transient errors.
@@ -336,13 +358,16 @@ impl SimpleTxManager {
         );
 
         let raw_tip_cap = tip_result
-            .map_err(|_| TxManagerError::Rpc("get_max_priority_fee_per_gas timed out".into()))?
-            .map_err(|e| RpcErrorClassifier::classify_rpc_error(&e.to_string()))?;
+            .map_err(|_| self.rpc_timeout("get_max_priority_fee_per_gas timed out"))?
+            .map_err(|e| self.classify_rpc(&e))?;
 
         let latest_block = block_result
-            .map_err(|_| TxManagerError::Rpc("get_block_by_number timed out".into()))?
-            .map_err(|e| RpcErrorClassifier::classify_rpc_error(&e.to_string()))?
-            .ok_or_else(|| TxManagerError::Rpc("latest block not found".to_string()))?;
+            .map_err(|_| self.rpc_timeout("get_block_by_number timed out"))?
+            .map_err(|e| self.classify_rpc(&e))?
+            .ok_or_else(|| {
+                self.metrics.record_rpc_error();
+                TxManagerError::Rpc("latest block not found".to_string())
+            })?;
 
         let raw_base_fee = u128::from(
             latest_block
@@ -360,6 +385,13 @@ impl SimpleTxManager {
 
         // Compute gas fee cap with enforced minimums.
         let gas_fee_cap = FeeCalculator::calc_gas_fee_cap(base_fee, tip_cap);
+
+        // Record fee metrics.
+        #[allow(clippy::cast_precision_loss)]
+        {
+            self.metrics.record_basefee(base_fee as f64);
+            self.metrics.record_tipcap(tip_cap as f64);
+        }
 
         Ok(GasPriceCaps { gas_tip_cap: tip_cap, gas_fee_cap, raw_gas_fee_cap, blob_fee_cap: None })
     }
@@ -551,8 +583,8 @@ impl SimpleTxManager {
             self.provider.estimate_gas(tx_request.clone()),
         )
         .await
-        .map_err(|_| TxManagerError::Rpc("estimate_gas timed out".into()))?
-        .map_err(|e| RpcErrorClassifier::classify_rpc_error(&e.to_string()))?;
+        .map_err(|_| self.rpc_timeout("estimate_gas timed out"))?
+        .map_err(|e| self.classify_rpc(&e))?;
         let gas_limit = candidate.gas_limit.max(estimated);
         tx_request = tx_request.with_gas_limit(gas_limit);
 
@@ -570,6 +602,7 @@ impl SimpleTxManager {
             }
         };
         tx_request = tx_request.with_nonce(nonce);
+        self.metrics.record_current_nonce(nonce);
 
         info!(
             nonce,
@@ -588,6 +621,12 @@ impl SimpleTxManager {
             Ok(envelope) => {
                 // Consume the nonce (drop guard if present).
                 drop(guard);
+
+                // Record tx fee metric: max possible fee in gwei.
+                #[allow(clippy::cast_precision_loss)]
+                let fee_gwei = (gas_limit as f64 * fee_cap as f64) / 1e9;
+                self.metrics.record_tx_fee(fee_gwei);
+
                 Ok(PreparedTx {
                     raw_tx: Bytes::from(Encodable2718::encoded_2718(&envelope)),
                     gas_tip_cap: tip_cap,
@@ -765,6 +804,8 @@ impl SimpleTxManager {
         send_state: &Arc<SendState>,
         nonce_override: Option<u64>,
     ) -> SendResponse {
+        let start = Instant::now();
+
         // Initial transaction preparation. prepare() is NOT cancellation-safe,
         // so it runs to completion before entering the select loop.
         // The returned PreparedTx carries the actual on-wire fees, eliminating
@@ -806,6 +847,7 @@ impl SimpleTxManager {
             // If a receipt is already waiting, return it immediately
             // instead of performing a wasted fee bump.
             if let Ok(receipt) = receipt_rx.try_recv() {
+                self.metrics.record_confirmed_latency(start.elapsed().as_millis() as f64);
                 info!(
                     tx_hash = %receipt.transaction_hash,
                     block = ?receipt.block_number,
@@ -848,6 +890,7 @@ impl SimpleTxManager {
                 result = receipt_rx.recv() => {
                     match result {
                         Some(receipt) => {
+                            self.metrics.record_confirmed_latency(start.elapsed().as_millis() as f64);
                             info!(
                                 tx_hash = %receipt.transaction_hash,
                                 block = ?receipt.block_number,
@@ -942,6 +985,7 @@ impl SimpleTxManager {
         // Record the bump and log only after the transaction has been
         // successfully published to avoid inflating the count on failure.
         send_state.record_fee_bump();
+        self.metrics.record_gas_bump();
         info!(
             bump_count = %send_state.bump_count(),
             old_tip = %old.tip,
@@ -1044,6 +1088,8 @@ impl SimpleTxManager {
                 }
 
                 send_state.process_send_error(&classified);
+                self.metrics.record_publish_error();
+                self.metrics.record_rpc_error();
 
                 if classified.is_retryable() {
                     warn!(error = %classified, "publish failed, will retry");
@@ -1054,8 +1100,9 @@ impl SimpleTxManager {
                 Err(classified)
             }
             Err(_) => {
-                let err = TxManagerError::Rpc("send_raw_transaction timed out".into());
+                let err = self.rpc_timeout("send_raw_transaction timed out");
                 send_state.process_send_error(&err);
+                self.metrics.record_publish_error();
                 warn!("publish timed out");
                 Err(err)
             }
@@ -1288,8 +1335,10 @@ mod tests {
     use alloy_signer_local::PrivateKeySigner;
     use rstest::rstest;
 
+    use std::sync::Arc;
+
     use super::{BumpState, SimpleTxManager};
-    use crate::{GasPriceCaps, TxCandidate, TxManagerConfig, TxManagerError};
+    use crate::{GasPriceCaps, NoopTxMetrics, TxCandidate, TxManagerConfig, TxManagerError};
 
     async fn setup() -> (SimpleTxManager, alloy_node_bindings::AnvilInstance) {
         let anvil = Anvil::new().spawn();
@@ -1298,9 +1347,15 @@ mod tests {
         let signer: PrivateKeySigner = anvil.keys()[0].clone().into();
         let wallet = EthereumWallet::from(signer);
         let chain_id = anvil.chain_id();
-        let manager = SimpleTxManager::new(provider, wallet, TxManagerConfig::default(), chain_id)
-            .await
-            .expect("should create manager");
+        let manager = SimpleTxManager::new(
+            provider,
+            wallet,
+            TxManagerConfig::default(),
+            chain_id,
+            Arc::new(NoopTxMetrics),
+        )
+        .await
+        .expect("should create manager");
         (manager, anvil)
     }
 

--- a/crates/utilities/tx-manager/src/manager.rs
+++ b/crates/utilities/tx-manager/src/manager.rs
@@ -58,6 +58,10 @@ use crate::{
 
 /// Number of wei in one gwei (10^9), as `f64` for fractional-precision
 /// metric conversions that must not truncate sub-gwei values.
+///
+/// `u128 as f64` is lossless for values up to 2^53 (~9 × 10^15 wei, or
+/// ~9 million gwei). Realistic per-gas fee values (tip cap, base fee) are
+/// well under this threshold, so the conversion preserves full precision.
 const WEI_PER_GWEI: f64 = 1_000_000_000.0;
 
 /// A signed transaction together with the fee values that were applied
@@ -800,10 +804,9 @@ impl SimpleTxManager {
     /// Inner send loop extracted from [`send_tx`](Self::send_tx) to allow
     /// optional timeout wrapping.
     ///
-    /// `nonce_override` is forwarded to the **initial**
-    /// [`prepare_with_initial_caps`](Self::prepare_with_initial_caps) call.
-    /// Fee bump paths reuse the original nonce via their own `nonce_override`
-    /// to avoid corrupting concurrent `send_async` reservations.
+    /// Records latency, confirmation, and failure metrics on all exit paths.
+    /// The actual event loop lives in [`send_event_loop`](Self::send_event_loop);
+    /// this method is a thin metrics wrapper around it.
     async fn send_tx_inner(
         &self,
         candidate: &TxCandidate,
@@ -812,123 +815,140 @@ impl SimpleTxManager {
     ) -> SendResponse {
         let start = Instant::now();
 
-        let result: SendResponse = async {
-            // Initial transaction preparation. prepare() is NOT cancellation-safe,
-            // so it runs to completion before entering the select loop.
-            // The returned PreparedTx carries the actual on-wire fees, eliminating
-            // the need for a separate suggest_gas_price_caps() call.
-            let prepared =
-                self.prepare_with_initial_caps(candidate, None, None, nonce_override).await?;
-            let tx_hash = self.publish_tx(send_state, &prepared.raw_tx, None).await?;
-            let mut bump = BumpState::from_prepared(&prepared, tx_hash);
+        let result = self.send_event_loop(candidate, send_state, nonce_override).await;
 
-            // Receipt delivery channel — mpsc because fee bumps may spawn
-            // new wait tasks with different tx hashes.
-            let (receipt_tx, mut receipt_rx) = mpsc::channel::<TransactionReceipt>(1);
+        let latency_ms = u64::try_from(start.elapsed().as_millis()).unwrap_or(u64::MAX);
+        self.metrics.record_send_latency(latency_ms);
 
-            // Spawn background receipt polling for the initial tx hash.
-            Self::wait_for_tx(
-                Arc::clone(send_state),
-                self.provider.clone(),
-                bump.tx_hash,
-                self.config.clone(),
-                receipt_tx.clone(),
-                Arc::clone(&self.closed),
-            );
+        if result.is_ok() {
+            self.metrics.record_tx_confirmed();
+        } else {
+            self.metrics.record_tx_failed();
+        }
 
-            // Resubmission timer for fee bumping.
-            let mut bump_ticker = tokio::time::interval(self.config.resubmission_timeout);
-            // Consume the first immediate tick.
-            bump_ticker.tick().await;
+        result
+    }
 
-            loop {
-                // Check shutdown and critical errors before blocking.
-                if self.is_closed() {
-                    return Err(TxManagerError::ChannelClosed);
-                }
-                if let Some(err) = send_state.critical_error() {
-                    error!(error = %err, "critical error, aborting send");
-                    return Err(err);
-                }
+    /// Drives a signed transaction from publication through mempool to onchain
+    /// confirmation.
+    ///
+    /// `nonce_override` is forwarded to the **initial**
+    /// [`prepare_with_initial_caps`](Self::prepare_with_initial_caps) call.
+    /// Fee bump paths reuse the original nonce via their own `nonce_override`
+    /// to avoid corrupting concurrent `send_async` reservations.
+    async fn send_event_loop(
+        &self,
+        candidate: &TxCandidate,
+        send_state: &Arc<SendState>,
+        nonce_override: Option<u64>,
+    ) -> SendResponse {
+        // Initial transaction preparation. prepare() is NOT cancellation-safe,
+        // so it runs to completion before entering the select loop.
+        // The returned PreparedTx carries the actual on-wire fees, eliminating
+        // the need for a separate suggest_gas_price_caps() call.
+        let prepared =
+            self.prepare_with_initial_caps(candidate, None, None, nonce_override).await?;
+        let tx_hash = self.publish_tx(send_state, &prepared.raw_tx, None).await?;
+        let mut bump = BumpState::from_prepared(&prepared, tx_hash);
 
-                // If a receipt is already waiting, return it immediately
-                // instead of performing a wasted fee bump.
-                if let Ok(receipt) = receipt_rx.try_recv() {
-                    info!(
-                        tx_hash = %receipt.transaction_hash,
-                        block = ?receipt.block_number,
-                        "transaction confirmed",
-                    );
-                    return Ok(receipt);
-                }
+        // Receipt delivery channel — mpsc because fee bumps may spawn
+        // new wait tasks with different tx hashes.
+        let (receipt_tx, mut receipt_rx) = mpsc::channel::<TransactionReceipt>(1);
 
-                // Respond immediately to the should_bump_fees flag set by
-                // process_send_error on retryable errors (e.g. Underpriced,
-                // ReplacementUnderpriced), rather than waiting for the next
-                // resubmission timer tick.
-                //
-                // Clear the flag before attempting the bump so that a failed
-                // attempt (e.g. RPC timeout) does not immediately re-trigger
-                // on the next loop iteration — instead, the loop falls through
-                // to tokio::select! which waits for the resubmission timer or
-                // a receipt, providing natural backoff. If a new retryable
-                // error occurs later, process_send_error will re-set the flag.
-                if send_state.should_bump_fees() {
-                    send_state.clear_bump_fees();
-                    if let Some(abort) =
-                        self.try_fee_bump(candidate, send_state, &receipt_tx, &mut bump).await
-                    {
-                        return Err(abort);
-                    }
-                    // Reset the bump ticker so we get a full interval
-                    // before the next timer-driven bump.
-                    bump_ticker.reset();
-                    continue;
-                }
+        // Spawn background receipt polling for the initial tx hash.
+        Self::wait_for_tx(
+            Arc::clone(send_state),
+            self.provider.clone(),
+            bump.tx_hash,
+            self.config.clone(),
+            receipt_tx.clone(),
+            Arc::clone(&self.closed),
+        );
 
-                // Determine which event fired. handle_fee_bump (and
-                // transitively prepare()) is NOT cancellation-safe, so it
-                // must not run inside tokio::select!. The select block only
-                // captures which arm won; fee bump work runs to completion
-                // outside the select block.
-                tokio::select! {
-                    biased;
-                    result = receipt_rx.recv() => {
-                        match result {
-                            Some(receipt) => {
-                                info!(
-                                    tx_hash = %receipt.transaction_hash,
-                                    block = ?receipt.block_number,
-                                    "transaction confirmed",
-                                );
-                                return Ok(receipt);
-                            }
-                            None => {
-                                // All senders dropped — should not happen in normal flow.
-                                return Err(TxManagerError::ChannelClosed);
-                            }
-                        }
-                    }
-                    _ = bump_ticker.tick() => {}
-                };
+        // Resubmission timer for fee bumping.
+        let mut bump_ticker = tokio::time::interval(self.config.resubmission_timeout);
+        // Consume the first immediate tick.
+        bump_ticker.tick().await;
 
-                // Bump tick fired — run fee bump logic.
+        loop {
+            // Check shutdown and critical errors before blocking.
+            if self.is_closed() {
+                return Err(TxManagerError::ChannelClosed);
+            }
+            if let Some(err) = send_state.critical_error() {
+                error!(error = %err, "critical error, aborting send");
+                return Err(err);
+            }
+
+            // If a receipt is already waiting, return it immediately
+            // instead of performing a wasted fee bump.
+            if let Ok(receipt) = receipt_rx.try_recv() {
+                info!(
+                    tx_hash = %receipt.transaction_hash,
+                    block = ?receipt.block_number,
+                    "transaction confirmed",
+                );
+                return Ok(receipt);
+            }
+
+            // Respond immediately to the should_bump_fees flag set by
+            // process_send_error on retryable errors (e.g. Underpriced,
+            // ReplacementUnderpriced), rather than waiting for the next
+            // resubmission timer tick.
+            //
+            // Clear the flag before attempting the bump so that a failed
+            // attempt (e.g. RPC timeout) does not immediately re-trigger
+            // on the next loop iteration — instead, the loop falls through
+            // to tokio::select! which waits for the resubmission timer or
+            // a receipt, providing natural backoff. If a new retryable
+            // error occurs later, process_send_error will re-set the flag.
+            if send_state.should_bump_fees() {
+                send_state.clear_bump_fees();
                 if let Some(abort) =
                     self.try_fee_bump(candidate, send_state, &receipt_tx, &mut bump).await
                 {
                     return Err(abort);
                 }
+                // Reset the bump ticker so we get a full interval
+                // before the next timer-driven bump.
                 bump_ticker.reset();
+                continue;
             }
-        }
-        .await;
 
-        if result.is_ok() {
-            let latency_ms = u64::try_from(start.elapsed().as_millis()).unwrap_or(u64::MAX);
-            self.metrics.record_confirmed_latency(latency_ms);
-            self.metrics.record_tx_confirmed();
+            // Determine which event fired. handle_fee_bump (and
+            // transitively prepare()) is NOT cancellation-safe, so it
+            // must not run inside tokio::select!. The select block only
+            // captures which arm won; fee bump work runs to completion
+            // outside the select block.
+            tokio::select! {
+                biased;
+                result = receipt_rx.recv() => {
+                    match result {
+                        Some(receipt) => {
+                            info!(
+                                tx_hash = %receipt.transaction_hash,
+                                block = ?receipt.block_number,
+                                "transaction confirmed",
+                            );
+                            return Ok(receipt);
+                        }
+                        None => {
+                            // All senders dropped — should not happen in normal flow.
+                            return Err(TxManagerError::ChannelClosed);
+                        }
+                    }
+                }
+                _ = bump_ticker.tick() => {}
+            };
+
+            // Bump tick fired — run fee bump logic.
+            if let Some(abort) =
+                self.try_fee_bump(candidate, send_state, &receipt_tx, &mut bump).await
+            {
+                return Err(abort);
+            }
+            bump_ticker.reset();
         }
-        result
     }
 
     /// Performs a fee bump attempt and applies the result to the tracked state.

--- a/crates/utilities/tx-manager/src/manager.rs
+++ b/crates/utilities/tx-manager/src/manager.rs
@@ -56,6 +56,9 @@ use crate::{
     TxManagerResult, TxMetrics,
 };
 
+/// Number of wei in one gwei (10^9).
+const WEI_PER_GWEI: u128 = 1_000_000_000;
+
 /// A signed transaction together with the fee values that were applied
 /// during construction.
 ///
@@ -245,10 +248,16 @@ impl SimpleTxManager {
         TxManagerError::Rpc(msg.into())
     }
 
-    /// Records an RPC error metric and classifies the RPC error string.
-    fn classify_rpc<E: std::fmt::Display>(&self, e: &E) -> TxManagerError {
-        self.metrics.record_rpc_error();
-        RpcErrorClassifier::classify_rpc_error(&e.to_string())
+    /// Classifies an RPC error string and records an RPC error metric when the
+    /// error is an unrecognised transport failure ([`TxManagerError::Rpc`]).
+    /// Recognised state errors (e.g. `NonceTooLow`, `ExecutionReverted`) are
+    /// returned without inflating the RPC error counter.
+    fn classify_rpc(&self, error_msg: &str) -> TxManagerError {
+        let err = RpcErrorClassifier::classify_rpc_error(error_msg);
+        if err.is_rpc_error() {
+            self.metrics.record_rpc_error();
+        }
+        err
     }
 
     /// Constructs and signs a transaction, retrying on transient errors.
@@ -359,11 +368,11 @@ impl SimpleTxManager {
 
         let raw_tip_cap = tip_result
             .map_err(|_| self.rpc_timeout("get_max_priority_fee_per_gas timed out"))?
-            .map_err(|e| self.classify_rpc(&e))?;
+            .map_err(|e| self.classify_rpc(&e.to_string()))?;
 
         let latest_block = block_result
             .map_err(|_| self.rpc_timeout("get_block_by_number timed out"))?
-            .map_err(|e| self.classify_rpc(&e))?
+            .map_err(|e| self.classify_rpc(&e.to_string()))?
             .ok_or_else(|| {
                 self.metrics.record_rpc_error();
                 TxManagerError::Rpc("latest block not found".to_string())
@@ -386,12 +395,9 @@ impl SimpleTxManager {
         // Compute gas fee cap with enforced minimums.
         let gas_fee_cap = FeeCalculator::calc_gas_fee_cap(base_fee, tip_cap);
 
-        // Record fee metrics.
-        #[allow(clippy::cast_precision_loss)]
-        {
-            self.metrics.record_basefee(base_fee as f64);
-            self.metrics.record_tipcap(tip_cap as f64);
-        }
+        // Record fee metrics (converted from wei to gwei via integer division).
+        self.metrics.record_basefee((base_fee / WEI_PER_GWEI) as u64);
+        self.metrics.record_tipcap((tip_cap / WEI_PER_GWEI) as u64);
 
         Ok(GasPriceCaps { gas_tip_cap: tip_cap, gas_fee_cap, raw_gas_fee_cap, blob_fee_cap: None })
     }
@@ -584,7 +590,7 @@ impl SimpleTxManager {
         )
         .await
         .map_err(|_| self.rpc_timeout("estimate_gas timed out"))?
-        .map_err(|e| self.classify_rpc(&e))?;
+        .map_err(|e| self.classify_rpc(&e.to_string()))?;
         let gas_limit = candidate.gas_limit.max(estimated);
         tx_request = tx_request.with_gas_limit(gas_limit);
 
@@ -623,8 +629,7 @@ impl SimpleTxManager {
                 drop(guard);
 
                 // Record tx fee metric: max possible fee in gwei.
-                #[allow(clippy::cast_precision_loss)]
-                let fee_gwei = (gas_limit as f64 * fee_cap as f64) / 1e9;
+                let fee_gwei = (u128::from(gas_limit) * fee_cap / WEI_PER_GWEI) as u64;
                 self.metrics.record_tx_fee(fee_gwei);
 
                 Ok(PreparedTx {
@@ -847,7 +852,8 @@ impl SimpleTxManager {
             // If a receipt is already waiting, return it immediately
             // instead of performing a wasted fee bump.
             if let Ok(receipt) = receipt_rx.try_recv() {
-                self.metrics.record_confirmed_latency(start.elapsed().as_millis() as f64);
+                let latency_ms = u64::try_from(start.elapsed().as_millis()).unwrap_or(u64::MAX);
+                self.metrics.record_confirmed_latency(latency_ms);
                 info!(
                     tx_hash = %receipt.transaction_hash,
                     block = ?receipt.block_number,
@@ -890,7 +896,8 @@ impl SimpleTxManager {
                 result = receipt_rx.recv() => {
                     match result {
                         Some(receipt) => {
-                            self.metrics.record_confirmed_latency(start.elapsed().as_millis() as f64);
+                            let latency_ms = u64::try_from(start.elapsed().as_millis()).unwrap_or(u64::MAX);
+                            self.metrics.record_confirmed_latency(latency_ms);
                             info!(
                                 tx_hash = %receipt.transaction_hash,
                                 block = ?receipt.block_number,
@@ -1072,7 +1079,7 @@ impl SimpleTxManager {
                 Ok(tx_hash)
             }
             Ok(Err(e)) => {
-                let classified = RpcErrorClassifier::classify_rpc_error(&e.to_string());
+                let classified = self.classify_rpc(&e.to_string());
 
                 // AlreadyKnown on resubmission is a success — the tx is in
                 // the mempool from a prior publish. Return the previous hash.
@@ -1089,7 +1096,6 @@ impl SimpleTxManager {
 
                 send_state.process_send_error(&classified);
                 self.metrics.record_publish_error();
-                self.metrics.record_rpc_error();
 
                 if classified.is_retryable() {
                     warn!(error = %classified, "publish failed, will retry");

--- a/crates/utilities/tx-manager/src/manager.rs
+++ b/crates/utilities/tx-manager/src/manager.rs
@@ -633,9 +633,9 @@ impl SimpleTxManager {
                 // Consume the nonce (drop guard if present).
                 drop(guard);
 
-                // Record tx fee metric: max possible fee in gwei.
-                let fee_gwei = u128::from(gas_limit) as f64 * (fee_cap as f64 / WEI_PER_GWEI);
-                self.metrics.record_tx_fee(fee_gwei);
+                // Record max possible fee metric in gwei.
+                let fee_gwei = gas_limit as f64 * (fee_cap as f64 / WEI_PER_GWEI);
+                self.metrics.record_tx_max_fee(fee_gwei);
 
                 Ok(PreparedTx {
                     raw_tx: Bytes::from(Encodable2718::encoded_2718(&envelope)),
@@ -705,13 +705,15 @@ impl SimpleTxManager {
             send_state.set_mempool_deadline(Instant::now() + self.config.tx_not_in_mempool_timeout);
         }
 
-        // Wrap the inner loop in a send timeout if configured.
+        let start = Instant::now();
+
+        // Wrap the event loop in a send timeout if configured.
         let result = if self.config.tx_send_timeout.is_zero() {
-            self.send_tx_inner(&candidate, &send_state, nonce_override).await
+            self.send_event_loop(&candidate, &send_state, nonce_override).await
         } else {
             tokio::time::timeout(
                 self.config.tx_send_timeout,
-                self.send_tx_inner(&candidate, &send_state, nonce_override),
+                self.send_event_loop(&candidate, &send_state, nonce_override),
             )
             .await
             .unwrap_or_else(|_| {
@@ -722,6 +724,15 @@ impl SimpleTxManager {
                 Err(TxManagerError::SendTimeout)
             })
         };
+
+        let latency_ms = u64::try_from(start.elapsed().as_millis()).unwrap_or(u64::MAX);
+        self.metrics.record_send_latency(latency_ms);
+
+        if result.is_ok() {
+            self.metrics.record_tx_confirmed();
+        } else {
+            self.metrics.record_tx_failed();
+        }
 
         if Self::should_reset_nonce_on_send_error(&result, &send_state, nonce_override) {
             // Three policies (see should_reset_nonce_on_send_error):
@@ -799,34 +810,6 @@ impl SimpleTxManager {
             Ok(_) | Err(TxManagerError::NonceTooHigh | TxManagerError::NonceTooLow) => false,
             Err(_) => send_state.successful_publish_count() == 0,
         }
-    }
-
-    /// Inner send loop extracted from [`send_tx`](Self::send_tx) to allow
-    /// optional timeout wrapping.
-    ///
-    /// Records latency, confirmation, and failure metrics on all exit paths.
-    /// The actual event loop lives in [`send_event_loop`](Self::send_event_loop);
-    /// this method is a thin metrics wrapper around it.
-    async fn send_tx_inner(
-        &self,
-        candidate: &TxCandidate,
-        send_state: &Arc<SendState>,
-        nonce_override: Option<u64>,
-    ) -> SendResponse {
-        let start = Instant::now();
-
-        let result = self.send_event_loop(candidate, send_state, nonce_override).await;
-
-        let latency_ms = u64::try_from(start.elapsed().as_millis()).unwrap_or(u64::MAX);
-        self.metrics.record_send_latency(latency_ms);
-
-        if result.is_ok() {
-            self.metrics.record_tx_confirmed();
-        } else {
-            self.metrics.record_tx_failed();
-        }
-
-        result
     }
 
     /// Drives a signed transaction from publication through mempool to onchain
@@ -1122,7 +1105,7 @@ impl SimpleTxManager {
                 }
 
                 send_state.process_send_error(&classified);
-                if !classified.is_already_known() {
+                if classified.is_rpc_error() {
                     self.metrics.record_publish_error();
                 }
 

--- a/crates/utilities/tx-manager/src/manager.rs
+++ b/crates/utilities/tx-manager/src/manager.rs
@@ -246,9 +246,8 @@ impl SimpleTxManager {
         self.closed.load(Ordering::Acquire)
     }
 
-    /// Records an RPC error metric and returns a [`TxManagerError::Rpc`] for a
-    /// timed-out RPC call.
-    fn rpc_timeout_error(&self, msg: &str) -> TxManagerError {
+    /// Records an RPC error metric and returns a [`TxManagerError::Rpc`].
+    fn rpc_error(&self, msg: &str) -> TxManagerError {
         self.metrics.record_rpc_error();
         TxManagerError::Rpc(msg.into())
     }
@@ -372,22 +371,19 @@ impl SimpleTxManager {
         );
 
         let raw_tip_cap = tip_result
-            .map_err(|_| self.rpc_timeout_error("get_max_priority_fee_per_gas timed out"))?
+            .map_err(|_| self.rpc_error("get_max_priority_fee_per_gas timed out"))?
             .map_err(|e| self.classify_and_record_rpc(&e.to_string()))?;
 
         let latest_block = block_result
-            .map_err(|_| self.rpc_timeout_error("get_block_by_number timed out"))?
+            .map_err(|_| self.rpc_error("get_block_by_number timed out"))?
             .map_err(|e| self.classify_and_record_rpc(&e.to_string()))?
-            .ok_or_else(|| {
-                self.metrics.record_rpc_error();
-                TxManagerError::Rpc("latest block not found".to_string())
-            })?;
+            .ok_or_else(|| self.rpc_error("latest block not found"))?;
 
         let raw_base_fee = u128::from(
             latest_block
                 .header
                 .base_fee_per_gas
-                .ok_or_else(|| TxManagerError::Rpc("base fee not available".to_string()))?,
+                .ok_or_else(|| self.rpc_error("base fee not available"))?,
         );
 
         // Compute raw gas fee cap from provider values before enforcing minimums.
@@ -594,7 +590,7 @@ impl SimpleTxManager {
             self.provider.estimate_gas(tx_request.clone()),
         )
         .await
-        .map_err(|_| self.rpc_timeout_error("estimate_gas timed out"))?
+        .map_err(|_| self.rpc_error("estimate_gas timed out"))?
         .map_err(|e| self.classify_and_record_rpc(&e.to_string()))?;
         let gas_limit = candidate.gas_limit.max(estimated);
         tx_request = tx_request.with_gas_limit(gas_limit);
@@ -1118,7 +1114,7 @@ impl SimpleTxManager {
                 Err(classified)
             }
             Err(_) => {
-                let err = self.rpc_timeout_error("send_raw_transaction timed out");
+                let err = self.rpc_error("send_raw_transaction timed out");
                 send_state.process_send_error(&err);
                 self.metrics.record_publish_error();
                 warn!("publish timed out");

--- a/crates/utilities/tx-manager/src/manager.rs
+++ b/crates/utilities/tx-manager/src/manager.rs
@@ -629,7 +629,8 @@ impl SimpleTxManager {
                 // Consume the nonce (drop guard if present).
                 drop(guard);
 
-                // Record max possible fee metric in gwei.
+                // Record max possible fee metric in gwei. Intentionally recorded on every
+                // attempt (initial + fee bumps) to track fee escalation across retries.
                 let fee_gwei = gas_limit as f64 * (fee_cap as f64 / WEI_PER_GWEI);
                 self.metrics.record_tx_max_fee(fee_gwei);
 

--- a/crates/utilities/tx-manager/src/metrics.rs
+++ b/crates/utilities/tx-manager/src/metrics.rs
@@ -123,7 +123,10 @@ impl BaseTxMetrics {
     /// Called automatically by [`new`](Self::new). Descriptions are idempotent
     /// — calling this multiple times is safe.
     pub fn describe() {
-        describe_histogram!(TX_MAX_FEE_GWEI, "Maximum possible transaction fee in gwei (gas_limit * fee_cap)");
+        describe_histogram!(
+            TX_MAX_FEE_GWEI,
+            "Maximum possible transaction fee in gwei (gas_limit * fee_cap)"
+        );
         describe_counter!(TX_GAS_BUMP_COUNT, "Number of gas bump events");
         describe_histogram!(TX_SEND_LATENCY_MS, "Send-loop latency in milliseconds");
         describe_gauge!(CURRENT_NONCE, "Current nonce value");

--- a/crates/utilities/tx-manager/src/metrics.rs
+++ b/crates/utilities/tx-manager/src/metrics.rs
@@ -33,8 +33,8 @@ const RPC_ERROR_COUNT: &str = "base_tx_manager_rpc_error_count";
 /// Implement this trait to plug in your own metrics backend. A [`BaseTxMetrics`]
 /// implementation backed by the [`metrics`] crate is provided for production use.
 pub trait TxMetrics: Send + Sync + Debug + 'static {
-    /// Record the transaction fee in gwei.
-    fn record_tx_fee(&self, fee_gwei: u64);
+    /// Record the transaction fee in gwei (fractional precision preserved).
+    fn record_tx_fee(&self, fee_gwei: f64);
 
     /// Record a gas bump event.
     fn record_gas_bump(&self);
@@ -48,11 +48,11 @@ pub trait TxMetrics: Send + Sync + Debug + 'static {
     /// Record a transaction publish error.
     fn record_publish_error(&self);
 
-    /// Record the base fee in gwei.
-    fn record_basefee(&self, basefee_gwei: u64);
+    /// Record the base fee in gwei (fractional precision preserved).
+    fn record_basefee(&self, basefee_gwei: f64);
 
-    /// Record the tip cap in gwei.
-    fn record_tipcap(&self, tipcap_gwei: u64);
+    /// Record the tip cap in gwei (fractional precision preserved).
+    fn record_tipcap(&self, tipcap_gwei: f64);
 
     /// Record an RPC error.
     fn record_rpc_error(&self);
@@ -66,13 +66,13 @@ pub trait TxMetrics: Send + Sync + Debug + 'static {
 pub struct NoopTxMetrics;
 
 impl TxMetrics for NoopTxMetrics {
-    fn record_tx_fee(&self, _fee_gwei: u64) {}
+    fn record_tx_fee(&self, _fee_gwei: f64) {}
     fn record_gas_bump(&self) {}
     fn record_confirmed_latency(&self, _latency_ms: u64) {}
     fn record_current_nonce(&self, _nonce: u64) {}
     fn record_publish_error(&self) {}
-    fn record_basefee(&self, _basefee_gwei: u64) {}
-    fn record_tipcap(&self, _tipcap_gwei: u64) {}
+    fn record_basefee(&self, _basefee_gwei: f64) {}
+    fn record_tipcap(&self, _tipcap_gwei: f64) {}
     fn record_rpc_error(&self) {}
 }
 
@@ -84,8 +84,8 @@ impl TxMetrics for NoopTxMetrics {
 pub struct BaseTxMetrics;
 
 impl TxMetrics for BaseTxMetrics {
-    fn record_tx_fee(&self, fee_gwei: u64) {
-        histogram!(TX_FEE_GWEI).record(fee_gwei as f64);
+    fn record_tx_fee(&self, fee_gwei: f64) {
+        histogram!(TX_FEE_GWEI).record(fee_gwei);
     }
 
     fn record_gas_bump(&self) {
@@ -104,12 +104,12 @@ impl TxMetrics for BaseTxMetrics {
         counter!(TX_PUBLISH_ERROR_COUNT).increment(1);
     }
 
-    fn record_basefee(&self, basefee_gwei: u64) {
-        gauge!(BASEFEE_GWEI).set(basefee_gwei as f64);
+    fn record_basefee(&self, basefee_gwei: f64) {
+        gauge!(BASEFEE_GWEI).set(basefee_gwei);
     }
 
-    fn record_tipcap(&self, tipcap_gwei: u64) {
-        gauge!(TIPCAP_GWEI).set(tipcap_gwei as f64);
+    fn record_tipcap(&self, tipcap_gwei: f64) {
+        gauge!(TIPCAP_GWEI).set(tipcap_gwei);
     }
 
     fn record_rpc_error(&self) {
@@ -124,26 +124,26 @@ mod tests {
     #[test]
     fn noop_tx_metrics_can_be_constructed_and_called() {
         let m = NoopTxMetrics;
-        m.record_tx_fee(1);
+        m.record_tx_fee(1.5);
         m.record_gas_bump();
         m.record_confirmed_latency(120);
         m.record_current_nonce(42);
         m.record_publish_error();
-        m.record_basefee(30);
-        m.record_tipcap(2);
+        m.record_basefee(30.123);
+        m.record_tipcap(2.456);
         m.record_rpc_error();
     }
 
     #[test]
     fn base_tx_metrics_can_be_constructed_and_called() {
         let m = BaseTxMetrics;
-        m.record_tx_fee(1);
+        m.record_tx_fee(1.5);
         m.record_gas_bump();
         m.record_confirmed_latency(120);
         m.record_current_nonce(42);
         m.record_publish_error();
-        m.record_basefee(30);
-        m.record_tipcap(2);
+        m.record_basefee(30.123);
+        m.record_tipcap(2.456);
         m.record_rpc_error();
     }
 }

--- a/crates/utilities/tx-manager/src/metrics.rs
+++ b/crates/utilities/tx-manager/src/metrics.rs
@@ -1,5 +1,150 @@
 //! Transaction operation metrics.
 
-/// Metrics collection for transaction operations.
-#[derive(Debug)]
-pub struct TxMetrics;
+use std::fmt::Debug;
+
+use metrics::{counter, gauge, histogram};
+
+/// Metric name for the transaction fee in gwei.
+const TX_FEE_GWEI: &str = "base_tx_manager_tx_fee_gwei";
+
+/// Metric name for gas bump count.
+const TX_GAS_BUMP: &str = "base_tx_manager_tx_gas_bump";
+
+/// Metric name for confirmed transaction latency in milliseconds.
+const TX_CONFIRMED_LATENCY_MS: &str = "base_tx_manager_tx_confirmed_latency_ms";
+
+/// Metric name for the current nonce.
+const CURRENT_NONCE: &str = "base_tx_manager_current_nonce";
+
+/// Metric name for transaction publish error count.
+const TX_PUBLISH_ERROR_COUNT: &str = "base_tx_manager_tx_publish_error_count";
+
+/// Metric name for the base fee in wei.
+const BASEFEE_WEI: &str = "base_tx_manager_basefee_wei";
+
+/// Metric name for the tip cap in wei.
+const TIPCAP_WEI: &str = "base_tx_manager_tipcap_wei";
+
+/// Metric name for RPC error count.
+const RPC_ERROR_COUNT: &str = "base_tx_manager_rpc_error_count";
+
+/// Trait abstracting metrics collection for the transaction manager.
+///
+/// Implement this trait to plug in your own metrics backend. A [`BaseTxMetrics`]
+/// implementation backed by the [`metrics`] crate is provided for production use.
+pub trait TxMetrics: Send + Sync + Debug + 'static {
+    /// Record the transaction fee in gwei.
+    fn record_tx_fee(&self, fee_gwei: f64);
+
+    /// Record a gas bump event.
+    fn record_gas_bump(&self);
+
+    /// Record the confirmed transaction latency in milliseconds.
+    fn record_confirmed_latency(&self, latency_ms: f64);
+
+    /// Record the current nonce.
+    fn record_current_nonce(&self, nonce: u64);
+
+    /// Record a transaction publish error.
+    fn record_publish_error(&self);
+
+    /// Record the base fee in wei.
+    fn record_basefee(&self, basefee_wei: f64);
+
+    /// Record the tip cap in wei.
+    fn record_tipcap(&self, tipcap_wei: f64);
+
+    /// Record an RPC error.
+    fn record_rpc_error(&self);
+}
+
+/// No-op [`TxMetrics`] implementation.
+///
+/// All methods are no-ops — useful for unit tests and environments where
+/// metrics collection is not required.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct NoopTxMetrics;
+
+impl TxMetrics for NoopTxMetrics {
+    fn record_tx_fee(&self, _fee_gwei: f64) {}
+    fn record_gas_bump(&self) {}
+    fn record_confirmed_latency(&self, _latency_ms: f64) {}
+    fn record_current_nonce(&self, _nonce: u64) {}
+    fn record_publish_error(&self) {}
+    fn record_basefee(&self, _basefee_wei: f64) {}
+    fn record_tipcap(&self, _tipcap_wei: f64) {}
+    fn record_rpc_error(&self) {}
+}
+
+/// Production [`TxMetrics`] implementation backed by the [`metrics`] crate.
+///
+/// Each method emits directly via the global metrics recorder using gauge/counter
+/// macros. No handles are stored; the recorder is resolved on each call.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct BaseTxMetrics;
+
+impl TxMetrics for BaseTxMetrics {
+    fn record_tx_fee(&self, fee_gwei: f64) {
+        gauge!(TX_FEE_GWEI).set(fee_gwei);
+    }
+
+    fn record_gas_bump(&self) {
+        counter!(TX_GAS_BUMP).increment(1);
+    }
+
+    fn record_confirmed_latency(&self, latency_ms: f64) {
+        histogram!(TX_CONFIRMED_LATENCY_MS).record(latency_ms);
+    }
+
+    #[allow(clippy::cast_precision_loss)]
+    fn record_current_nonce(&self, nonce: u64) {
+        gauge!(CURRENT_NONCE).set(nonce as f64);
+    }
+
+    fn record_publish_error(&self) {
+        counter!(TX_PUBLISH_ERROR_COUNT).increment(1);
+    }
+
+    fn record_basefee(&self, basefee_wei: f64) {
+        gauge!(BASEFEE_WEI).set(basefee_wei);
+    }
+
+    fn record_tipcap(&self, tipcap_wei: f64) {
+        gauge!(TIPCAP_WEI).set(tipcap_wei);
+    }
+
+    fn record_rpc_error(&self) {
+        counter!(RPC_ERROR_COUNT).increment(1);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn noop_tx_metrics_can_be_constructed_and_called() {
+        let m = NoopTxMetrics;
+        m.record_tx_fee(1.5);
+        m.record_gas_bump();
+        m.record_confirmed_latency(120.0);
+        m.record_current_nonce(42);
+        m.record_publish_error();
+        m.record_basefee(1_000_000.0);
+        m.record_tipcap(500_000.0);
+        m.record_rpc_error();
+    }
+
+    #[test]
+    fn base_tx_metrics_can_be_constructed_and_called() {
+        let m = BaseTxMetrics;
+        m.record_tx_fee(1.5);
+        m.record_gas_bump();
+        m.record_confirmed_latency(120.0);
+        m.record_current_nonce(42);
+        m.record_publish_error();
+        m.record_basefee(1_000_000.0);
+        m.record_tipcap(500_000.0);
+        m.record_rpc_error();
+    }
+}

--- a/crates/utilities/tx-manager/src/metrics.rs
+++ b/crates/utilities/tx-manager/src/metrics.rs
@@ -19,11 +19,11 @@ const CURRENT_NONCE: &str = "base_tx_manager_current_nonce";
 /// Metric name for transaction publish error count.
 const TX_PUBLISH_ERROR_COUNT: &str = "base_tx_manager_tx_publish_error_count";
 
-/// Metric name for the base fee in wei.
-const BASEFEE_WEI: &str = "base_tx_manager_basefee_wei";
+/// Metric name for the base fee in gwei.
+const BASEFEE_GWEI: &str = "base_tx_manager_basefee_gwei";
 
-/// Metric name for the tip cap in wei.
-const TIPCAP_WEI: &str = "base_tx_manager_tipcap_wei";
+/// Metric name for the tip cap in gwei.
+const TIPCAP_GWEI: &str = "base_tx_manager_tipcap_gwei";
 
 /// Metric name for RPC error count.
 const RPC_ERROR_COUNT: &str = "base_tx_manager_rpc_error_count";
@@ -34,13 +34,13 @@ const RPC_ERROR_COUNT: &str = "base_tx_manager_rpc_error_count";
 /// implementation backed by the [`metrics`] crate is provided for production use.
 pub trait TxMetrics: Send + Sync + Debug + 'static {
     /// Record the transaction fee in gwei.
-    fn record_tx_fee(&self, fee_gwei: f64);
+    fn record_tx_fee(&self, fee_gwei: u64);
 
     /// Record a gas bump event.
     fn record_gas_bump(&self);
 
     /// Record the confirmed transaction latency in milliseconds.
-    fn record_confirmed_latency(&self, latency_ms: f64);
+    fn record_confirmed_latency(&self, latency_ms: u64);
 
     /// Record the current nonce.
     fn record_current_nonce(&self, nonce: u64);
@@ -48,11 +48,11 @@ pub trait TxMetrics: Send + Sync + Debug + 'static {
     /// Record a transaction publish error.
     fn record_publish_error(&self);
 
-    /// Record the base fee in wei.
-    fn record_basefee(&self, basefee_wei: f64);
+    /// Record the base fee in gwei.
+    fn record_basefee(&self, basefee_gwei: u64);
 
-    /// Record the tip cap in wei.
-    fn record_tipcap(&self, tipcap_wei: f64);
+    /// Record the tip cap in gwei.
+    fn record_tipcap(&self, tipcap_gwei: u64);
 
     /// Record an RPC error.
     fn record_rpc_error(&self);
@@ -66,13 +66,13 @@ pub trait TxMetrics: Send + Sync + Debug + 'static {
 pub struct NoopTxMetrics;
 
 impl TxMetrics for NoopTxMetrics {
-    fn record_tx_fee(&self, _fee_gwei: f64) {}
+    fn record_tx_fee(&self, _fee_gwei: u64) {}
     fn record_gas_bump(&self) {}
-    fn record_confirmed_latency(&self, _latency_ms: f64) {}
+    fn record_confirmed_latency(&self, _latency_ms: u64) {}
     fn record_current_nonce(&self, _nonce: u64) {}
     fn record_publish_error(&self) {}
-    fn record_basefee(&self, _basefee_wei: f64) {}
-    fn record_tipcap(&self, _tipcap_wei: f64) {}
+    fn record_basefee(&self, _basefee_gwei: u64) {}
+    fn record_tipcap(&self, _tipcap_gwei: u64) {}
     fn record_rpc_error(&self) {}
 }
 
@@ -84,19 +84,18 @@ impl TxMetrics for NoopTxMetrics {
 pub struct BaseTxMetrics;
 
 impl TxMetrics for BaseTxMetrics {
-    fn record_tx_fee(&self, fee_gwei: f64) {
-        gauge!(TX_FEE_GWEI).set(fee_gwei);
+    fn record_tx_fee(&self, fee_gwei: u64) {
+        histogram!(TX_FEE_GWEI).record(fee_gwei as f64);
     }
 
     fn record_gas_bump(&self) {
         counter!(TX_GAS_BUMP).increment(1);
     }
 
-    fn record_confirmed_latency(&self, latency_ms: f64) {
-        histogram!(TX_CONFIRMED_LATENCY_MS).record(latency_ms);
+    fn record_confirmed_latency(&self, latency_ms: u64) {
+        histogram!(TX_CONFIRMED_LATENCY_MS).record(latency_ms as f64);
     }
 
-    #[allow(clippy::cast_precision_loss)]
     fn record_current_nonce(&self, nonce: u64) {
         gauge!(CURRENT_NONCE).set(nonce as f64);
     }
@@ -105,12 +104,12 @@ impl TxMetrics for BaseTxMetrics {
         counter!(TX_PUBLISH_ERROR_COUNT).increment(1);
     }
 
-    fn record_basefee(&self, basefee_wei: f64) {
-        gauge!(BASEFEE_WEI).set(basefee_wei);
+    fn record_basefee(&self, basefee_gwei: u64) {
+        gauge!(BASEFEE_GWEI).set(basefee_gwei as f64);
     }
 
-    fn record_tipcap(&self, tipcap_wei: f64) {
-        gauge!(TIPCAP_WEI).set(tipcap_wei);
+    fn record_tipcap(&self, tipcap_gwei: u64) {
+        gauge!(TIPCAP_GWEI).set(tipcap_gwei as f64);
     }
 
     fn record_rpc_error(&self) {
@@ -125,26 +124,26 @@ mod tests {
     #[test]
     fn noop_tx_metrics_can_be_constructed_and_called() {
         let m = NoopTxMetrics;
-        m.record_tx_fee(1.5);
+        m.record_tx_fee(1);
         m.record_gas_bump();
-        m.record_confirmed_latency(120.0);
+        m.record_confirmed_latency(120);
         m.record_current_nonce(42);
         m.record_publish_error();
-        m.record_basefee(1_000_000.0);
-        m.record_tipcap(500_000.0);
+        m.record_basefee(30);
+        m.record_tipcap(2);
         m.record_rpc_error();
     }
 
     #[test]
     fn base_tx_metrics_can_be_constructed_and_called() {
         let m = BaseTxMetrics;
-        m.record_tx_fee(1.5);
+        m.record_tx_fee(1);
         m.record_gas_bump();
-        m.record_confirmed_latency(120.0);
+        m.record_confirmed_latency(120);
         m.record_current_nonce(42);
         m.record_publish_error();
-        m.record_basefee(1_000_000.0);
-        m.record_tipcap(500_000.0);
+        m.record_basefee(30);
+        m.record_tipcap(2);
         m.record_rpc_error();
     }
 }

--- a/crates/utilities/tx-manager/src/metrics.rs
+++ b/crates/utilities/tx-manager/src/metrics.rs
@@ -2,16 +2,17 @@
 
 use std::fmt::Debug;
 
-use metrics::{counter, gauge, histogram};
+use metrics::{counter, describe_counter, describe_gauge, describe_histogram, gauge, histogram};
 
 /// Metric name for the transaction fee in gwei.
 const TX_FEE_GWEI: &str = "base_tx_manager_tx_fee_gwei";
 
 /// Metric name for gas bump count.
-const TX_GAS_BUMP: &str = "base_tx_manager_tx_gas_bump";
+const TX_GAS_BUMP_COUNT: &str = "base_tx_manager_tx_gas_bump_count";
 
-/// Metric name for confirmed transaction latency in milliseconds.
-const TX_CONFIRMED_LATENCY_MS: &str = "base_tx_manager_tx_confirmed_latency_ms";
+/// Metric name for send-loop latency in milliseconds (recorded on all exit
+/// paths — both confirmed and failed transactions).
+const TX_SEND_LATENCY_MS: &str = "base_tx_manager_tx_send_latency_ms";
 
 /// Metric name for the current nonce.
 const CURRENT_NONCE: &str = "base_tx_manager_current_nonce";
@@ -31,6 +32,12 @@ const RPC_ERROR_COUNT: &str = "base_tx_manager_rpc_error_count";
 /// Metric name for confirmed transaction count.
 const TX_CONFIRMED_COUNT: &str = "base_tx_manager_tx_confirmed_count";
 
+/// Metric name for failed transaction count.
+const TX_FAILED_COUNT: &str = "base_tx_manager_tx_failed_count";
+
+/// Label key for the tx-manager instance name.
+const NAME_LABEL: &str = "name";
+
 /// Trait abstracting metrics collection for the transaction manager.
 ///
 /// Implement this trait to plug in your own metrics backend. A [`BaseTxMetrics`]
@@ -42,8 +49,8 @@ pub trait TxMetrics: Send + Sync + Debug + 'static {
     /// Record a gas bump event.
     fn record_gas_bump(&self);
 
-    /// Record the confirmed transaction latency in milliseconds.
-    fn record_confirmed_latency(&self, latency_ms: u64);
+    /// Record the send-loop latency in milliseconds (all exit paths).
+    fn record_send_latency(&self, latency_ms: u64);
 
     /// Record the current nonce.
     fn record_current_nonce(&self, nonce: u64);
@@ -62,6 +69,9 @@ pub trait TxMetrics: Send + Sync + Debug + 'static {
 
     /// Record a confirmed (successfully mined) transaction.
     fn record_tx_confirmed(&self);
+
+    /// Record a failed (aborted) transaction.
+    fn record_tx_failed(&self);
 }
 
 /// No-op [`TxMetrics`] implementation.
@@ -74,57 +84,96 @@ pub struct NoopTxMetrics;
 impl TxMetrics for NoopTxMetrics {
     fn record_tx_fee(&self, _fee_gwei: f64) {}
     fn record_gas_bump(&self) {}
-    fn record_confirmed_latency(&self, _latency_ms: u64) {}
+    fn record_send_latency(&self, _latency_ms: u64) {}
     fn record_current_nonce(&self, _nonce: u64) {}
     fn record_publish_error(&self) {}
     fn record_basefee(&self, _basefee_gwei: f64) {}
     fn record_tipcap(&self, _tipcap_gwei: f64) {}
     fn record_rpc_error(&self) {}
     fn record_tx_confirmed(&self) {}
+    fn record_tx_failed(&self) {}
 }
 
 /// Production [`TxMetrics`] implementation backed by the [`metrics`] crate.
 ///
 /// Each method emits directly via the global metrics recorder using gauge/counter
 /// macros. No handles are stored; the recorder is resolved on each call.
-#[derive(Debug, Clone, Copy, Default)]
-pub struct BaseTxMetrics;
+///
+/// The `name` field is attached as a `"name"` label on every metric emission,
+/// allowing multiple tx-manager instances (e.g. challenger vs. proposer) to be
+/// disambiguated within a shared metrics backend.
+#[derive(Debug, Clone)]
+pub struct BaseTxMetrics {
+    /// Instance name label attached to all metric emissions.
+    pub name: &'static str,
+}
+
+impl BaseTxMetrics {
+    /// Create a new [`BaseTxMetrics`] with the given instance name.
+    ///
+    /// The `name` is emitted as a `"name"` label on every metric, allowing
+    /// multiple tx-manager instances to be distinguished in dashboards.
+    pub const fn new(name: &'static str) -> Self {
+        Self { name }
+    }
+
+    /// Register human-readable descriptions for all tx-manager metrics.
+    ///
+    /// Call once during application startup, before any metrics are emitted.
+    /// Descriptions are idempotent — calling this multiple times is safe.
+    pub fn describe() {
+        describe_histogram!(TX_FEE_GWEI, "Transaction fee in gwei");
+        describe_counter!(TX_GAS_BUMP_COUNT, "Number of gas bump events");
+        describe_histogram!(TX_SEND_LATENCY_MS, "Send-loop latency in milliseconds");
+        describe_gauge!(CURRENT_NONCE, "Current nonce value");
+        describe_counter!(TX_PUBLISH_ERROR_COUNT, "Number of transaction publish errors");
+        describe_gauge!(BASEFEE_GWEI, "Base fee in gwei");
+        describe_gauge!(TIPCAP_GWEI, "Tip cap in gwei");
+        describe_counter!(RPC_ERROR_COUNT, "Number of RPC errors");
+        describe_counter!(TX_CONFIRMED_COUNT, "Number of confirmed transactions");
+        describe_counter!(TX_FAILED_COUNT, "Number of failed transactions");
+    }
+}
 
 impl TxMetrics for BaseTxMetrics {
     fn record_tx_fee(&self, fee_gwei: f64) {
-        histogram!(TX_FEE_GWEI).record(fee_gwei);
+        histogram!(TX_FEE_GWEI, NAME_LABEL => self.name).record(fee_gwei);
     }
 
     fn record_gas_bump(&self) {
-        counter!(TX_GAS_BUMP).increment(1);
+        counter!(TX_GAS_BUMP_COUNT, NAME_LABEL => self.name).increment(1);
     }
 
-    fn record_confirmed_latency(&self, latency_ms: u64) {
-        histogram!(TX_CONFIRMED_LATENCY_MS).record(latency_ms as f64);
+    fn record_send_latency(&self, latency_ms: u64) {
+        histogram!(TX_SEND_LATENCY_MS, NAME_LABEL => self.name).record(latency_ms as f64);
     }
 
     fn record_current_nonce(&self, nonce: u64) {
-        gauge!(CURRENT_NONCE).set(nonce as f64);
+        gauge!(CURRENT_NONCE, NAME_LABEL => self.name).set(nonce as f64);
     }
 
     fn record_publish_error(&self) {
-        counter!(TX_PUBLISH_ERROR_COUNT).increment(1);
+        counter!(TX_PUBLISH_ERROR_COUNT, NAME_LABEL => self.name).increment(1);
     }
 
     fn record_basefee(&self, basefee_gwei: f64) {
-        gauge!(BASEFEE_GWEI).set(basefee_gwei);
+        gauge!(BASEFEE_GWEI, NAME_LABEL => self.name).set(basefee_gwei);
     }
 
     fn record_tipcap(&self, tipcap_gwei: f64) {
-        gauge!(TIPCAP_GWEI).set(tipcap_gwei);
+        gauge!(TIPCAP_GWEI, NAME_LABEL => self.name).set(tipcap_gwei);
     }
 
     fn record_rpc_error(&self) {
-        counter!(RPC_ERROR_COUNT).increment(1);
+        counter!(RPC_ERROR_COUNT, NAME_LABEL => self.name).increment(1);
     }
 
     fn record_tx_confirmed(&self) {
-        counter!(TX_CONFIRMED_COUNT).increment(1);
+        counter!(TX_CONFIRMED_COUNT, NAME_LABEL => self.name).increment(1);
+    }
+
+    fn record_tx_failed(&self) {
+        counter!(TX_FAILED_COUNT, NAME_LABEL => self.name).increment(1);
     }
 }
 
@@ -137,26 +186,28 @@ mod tests {
         let m = NoopTxMetrics;
         m.record_tx_fee(1.5);
         m.record_gas_bump();
-        m.record_confirmed_latency(120);
+        m.record_send_latency(120);
         m.record_current_nonce(42);
         m.record_publish_error();
         m.record_basefee(30.123);
         m.record_tipcap(2.456);
         m.record_rpc_error();
         m.record_tx_confirmed();
+        m.record_tx_failed();
     }
 
     #[test]
     fn base_tx_metrics_can_be_constructed_and_called() {
-        let m = BaseTxMetrics;
+        let m = BaseTxMetrics::new("test");
         m.record_tx_fee(1.5);
         m.record_gas_bump();
-        m.record_confirmed_latency(120);
+        m.record_send_latency(120);
         m.record_current_nonce(42);
         m.record_publish_error();
         m.record_basefee(30.123);
         m.record_tipcap(2.456);
         m.record_rpc_error();
         m.record_tx_confirmed();
+        m.record_tx_failed();
     }
 }

--- a/crates/utilities/tx-manager/src/metrics.rs
+++ b/crates/utilities/tx-manager/src/metrics.rs
@@ -4,8 +4,8 @@ use std::fmt::Debug;
 
 use metrics::{counter, describe_counter, describe_gauge, describe_histogram, gauge, histogram};
 
-/// Metric name for the transaction fee in gwei.
-const TX_FEE_GWEI: &str = "base_tx_manager_tx_fee_gwei";
+/// Metric name for the maximum possible transaction fee in gwei.
+const TX_MAX_FEE_GWEI: &str = "base_tx_manager_tx_max_fee_gwei";
 
 /// Metric name for gas bump count.
 const TX_GAS_BUMP_COUNT: &str = "base_tx_manager_tx_gas_bump_count";
@@ -43,8 +43,8 @@ const NAME_LABEL: &str = "name";
 /// Implement this trait to plug in your own metrics backend. A [`BaseTxMetrics`]
 /// implementation backed by the [`metrics`] crate is provided for production use.
 pub trait TxMetrics: Send + Sync + Debug + 'static {
-    /// Record the transaction fee in gwei (fractional precision preserved).
-    fn record_tx_fee(&self, fee_gwei: f64);
+    /// Record the maximum possible transaction fee in gwei (`gas_limit` * `fee_cap`).
+    fn record_tx_max_fee(&self, fee_gwei: f64);
 
     /// Record a gas bump event.
     fn record_gas_bump(&self);
@@ -55,7 +55,7 @@ pub trait TxMetrics: Send + Sync + Debug + 'static {
     /// Record the current nonce.
     fn record_current_nonce(&self, nonce: u64);
 
-    /// Record a transaction publish error.
+    /// Record a transaction publish error (transport/RPC failures only, not state errors).
     fn record_publish_error(&self);
 
     /// Record the base fee in gwei (fractional precision preserved).
@@ -82,7 +82,7 @@ pub trait TxMetrics: Send + Sync + Debug + 'static {
 pub struct NoopTxMetrics;
 
 impl TxMetrics for NoopTxMetrics {
-    fn record_tx_fee(&self, _fee_gwei: f64) {}
+    fn record_tx_max_fee(&self, _fee_gwei: f64) {}
     fn record_gas_bump(&self) {}
     fn record_send_latency(&self, _latency_ms: u64) {}
     fn record_current_nonce(&self, _nonce: u64) {}
@@ -113,16 +113,17 @@ impl BaseTxMetrics {
     ///
     /// The `name` is emitted as a `"name"` label on every metric, allowing
     /// multiple tx-manager instances to be distinguished in dashboards.
-    pub const fn new(name: &'static str) -> Self {
+    pub fn new(name: &'static str) -> Self {
+        Self::describe();
         Self { name }
     }
 
     /// Register human-readable descriptions for all tx-manager metrics.
     ///
-    /// Call once during application startup, before any metrics are emitted.
-    /// Descriptions are idempotent — calling this multiple times is safe.
+    /// Called automatically by [`new`](Self::new). Descriptions are idempotent
+    /// — calling this multiple times is safe.
     pub fn describe() {
-        describe_histogram!(TX_FEE_GWEI, "Transaction fee in gwei");
+        describe_histogram!(TX_MAX_FEE_GWEI, "Maximum possible transaction fee in gwei (gas_limit * fee_cap)");
         describe_counter!(TX_GAS_BUMP_COUNT, "Number of gas bump events");
         describe_histogram!(TX_SEND_LATENCY_MS, "Send-loop latency in milliseconds");
         describe_gauge!(CURRENT_NONCE, "Current nonce value");
@@ -136,8 +137,8 @@ impl BaseTxMetrics {
 }
 
 impl TxMetrics for BaseTxMetrics {
-    fn record_tx_fee(&self, fee_gwei: f64) {
-        histogram!(TX_FEE_GWEI, NAME_LABEL => self.name).record(fee_gwei);
+    fn record_tx_max_fee(&self, fee_gwei: f64) {
+        histogram!(TX_MAX_FEE_GWEI, NAME_LABEL => self.name).record(fee_gwei);
     }
 
     fn record_gas_bump(&self) {
@@ -184,7 +185,7 @@ mod tests {
     #[test]
     fn noop_tx_metrics_can_be_constructed_and_called() {
         let m = NoopTxMetrics;
-        m.record_tx_fee(1.5);
+        m.record_tx_max_fee(1.5);
         m.record_gas_bump();
         m.record_send_latency(120);
         m.record_current_nonce(42);
@@ -197,9 +198,15 @@ mod tests {
     }
 
     #[test]
+    fn describe_is_idempotent() {
+        BaseTxMetrics::describe();
+        BaseTxMetrics::describe();
+    }
+
+    #[test]
     fn base_tx_metrics_can_be_constructed_and_called() {
         let m = BaseTxMetrics::new("test");
-        m.record_tx_fee(1.5);
+        m.record_tx_max_fee(1.5);
         m.record_gas_bump();
         m.record_send_latency(120);
         m.record_current_nonce(42);

--- a/crates/utilities/tx-manager/src/metrics.rs
+++ b/crates/utilities/tx-manager/src/metrics.rs
@@ -142,7 +142,10 @@ impl BaseTxMetrics {
         describe_gauge!(TIPCAP_GWEI, "Tip cap in gwei");
         describe_counter!(RPC_ERROR_COUNT, "Number of RPC errors");
         describe_counter!(TX_CONFIRMED_COUNT, "Number of confirmed transactions");
-        describe_counter!(TX_FAILED_COUNT, "Number of failed send attempts (includes timeouts where the tx may still confirm)");
+        describe_counter!(
+            TX_FAILED_COUNT,
+            "Number of failed send attempts (includes timeouts where the tx may still confirm)"
+        );
     }
 }
 

--- a/crates/utilities/tx-manager/src/metrics.rs
+++ b/crates/utilities/tx-manager/src/metrics.rs
@@ -70,7 +70,14 @@ pub trait TxMetrics: Send + Sync + Debug + 'static {
     /// Record a confirmed (successfully mined) transaction.
     fn record_tx_confirmed(&self);
 
-    /// Record a failed (aborted) transaction.
+    /// Record a failed send attempt.
+    ///
+    /// This fires on **any** `send_tx` error path, including `SendTimeout`.
+    /// A timeout does not guarantee the transaction will never confirm — the
+    /// background `wait_for_tx` task may still be running and the transaction
+    /// may already be in the mempool. This counter therefore tracks "send
+    /// attempts that did not return a confirmed receipt," not definitive
+    /// on-chain failures.
     fn record_tx_failed(&self);
 }
 
@@ -135,7 +142,7 @@ impl BaseTxMetrics {
         describe_gauge!(TIPCAP_GWEI, "Tip cap in gwei");
         describe_counter!(RPC_ERROR_COUNT, "Number of RPC errors");
         describe_counter!(TX_CONFIRMED_COUNT, "Number of confirmed transactions");
-        describe_counter!(TX_FAILED_COUNT, "Number of failed transactions");
+        describe_counter!(TX_FAILED_COUNT, "Number of failed send attempts (includes timeouts where the tx may still confirm)");
     }
 }
 

--- a/crates/utilities/tx-manager/src/metrics.rs
+++ b/crates/utilities/tx-manager/src/metrics.rs
@@ -28,6 +28,9 @@ const TIPCAP_GWEI: &str = "base_tx_manager_tipcap_gwei";
 /// Metric name for RPC error count.
 const RPC_ERROR_COUNT: &str = "base_tx_manager_rpc_error_count";
 
+/// Metric name for confirmed transaction count.
+const TX_CONFIRMED_COUNT: &str = "base_tx_manager_tx_confirmed_count";
+
 /// Trait abstracting metrics collection for the transaction manager.
 ///
 /// Implement this trait to plug in your own metrics backend. A [`BaseTxMetrics`]
@@ -56,6 +59,9 @@ pub trait TxMetrics: Send + Sync + Debug + 'static {
 
     /// Record an RPC error.
     fn record_rpc_error(&self);
+
+    /// Record a confirmed (successfully mined) transaction.
+    fn record_tx_confirmed(&self);
 }
 
 /// No-op [`TxMetrics`] implementation.
@@ -74,6 +80,7 @@ impl TxMetrics for NoopTxMetrics {
     fn record_basefee(&self, _basefee_gwei: f64) {}
     fn record_tipcap(&self, _tipcap_gwei: f64) {}
     fn record_rpc_error(&self) {}
+    fn record_tx_confirmed(&self) {}
 }
 
 /// Production [`TxMetrics`] implementation backed by the [`metrics`] crate.
@@ -115,6 +122,10 @@ impl TxMetrics for BaseTxMetrics {
     fn record_rpc_error(&self) {
         counter!(RPC_ERROR_COUNT).increment(1);
     }
+
+    fn record_tx_confirmed(&self) {
+        counter!(TX_CONFIRMED_COUNT).increment(1);
+    }
 }
 
 #[cfg(test)]
@@ -132,6 +143,7 @@ mod tests {
         m.record_basefee(30.123);
         m.record_tipcap(2.456);
         m.record_rpc_error();
+        m.record_tx_confirmed();
     }
 
     #[test]
@@ -145,5 +157,6 @@ mod tests {
         m.record_basefee(30.123);
         m.record_tipcap(2.456);
         m.record_rpc_error();
+        m.record_tx_confirmed();
     }
 }

--- a/crates/utilities/tx-manager/tests/craft_tx.rs
+++ b/crates/utilities/tx-manager/tests/craft_tx.rs
@@ -1,5 +1,7 @@
 //! Integration tests for [`SimpleTxManager`] transaction construction with Anvil.
 
+use std::sync::Arc;
+
 use alloy_consensus::{SignableTransaction, TxEip1559, TxEnvelope};
 use alloy_eips::{Decodable2718, eip4844::Blob};
 use alloy_network::{EthereumWallet, TxSigner};
@@ -9,8 +11,8 @@ use alloy_provider::RootProvider;
 use alloy_signer_local::PrivateKeySigner;
 use async_trait::async_trait;
 use base_tx_manager::{
-    FeeCalculator, FeeOverride, GasPriceCaps, SimpleTxManager, TxCandidate, TxManager,
-    TxManagerConfig, TxManagerError,
+    FeeCalculator, FeeOverride, GasPriceCaps, NoopTxMetrics, SimpleTxManager, TxCandidate,
+    TxManager, TxManagerConfig, TxManagerError,
 };
 
 /// Helper: spawns an Anvil instance and returns a [`SimpleTxManager`]
@@ -24,9 +26,10 @@ async fn setup_with_config(
     let signer: PrivateKeySigner = anvil.keys()[0].clone().into();
     let wallet = EthereumWallet::from(signer);
     let chain_id = anvil.chain_id();
-    let manager = SimpleTxManager::new(provider, wallet, config, chain_id)
-        .await
-        .expect("should create manager");
+    let manager =
+        SimpleTxManager::new(provider, wallet, config, chain_id, Arc::new(NoopTxMetrics))
+            .await
+            .expect("should create manager");
     (manager, anvil)
 }
 
@@ -258,9 +261,10 @@ async fn new_rejects_chain_id_mismatch() {
 
     // Anvil uses chain_id 31337 by default; supply a wrong one.
     let wrong_chain_id = 999;
-    let err = SimpleTxManager::new(provider, wallet, config, wrong_chain_id)
-        .await
-        .expect_err("should reject mismatched chain_id");
+    let err =
+        SimpleTxManager::new(provider, wallet, config, wrong_chain_id, Arc::new(NoopTxMetrics))
+            .await
+            .expect_err("should reject mismatched chain_id");
 
     match &err {
         TxManagerError::InvalidConfig(msg) => {
@@ -342,9 +346,15 @@ async fn new_rejects_invalid_config() {
 
     let invalid_config = TxManagerConfig { num_confirmations: 0, ..TxManagerConfig::default() };
 
-    let err = SimpleTxManager::new(provider, wallet, invalid_config, anvil.chain_id())
-        .await
-        .expect_err("should reject invalid config");
+    let err = SimpleTxManager::new(
+        provider,
+        wallet,
+        invalid_config,
+        anvil.chain_id(),
+        Arc::new(NoopTxMetrics),
+    )
+    .await
+    .expect_err("should reject invalid config");
 
     match &err {
         TxManagerError::InvalidConfig(msg) => {
@@ -440,9 +450,15 @@ async fn setup_with_failing_signer() -> (SimpleTxManager, alloy_node_bindings::A
     let address = anvil.addresses()[0];
     let wallet = EthereumWallet::from(FailingSigner { address });
     let chain_id = anvil.chain_id();
-    let manager = SimpleTxManager::new(provider, wallet, TxManagerConfig::default(), chain_id)
-        .await
-        .expect("should create manager with failing signer");
+    let manager = SimpleTxManager::new(
+        provider,
+        wallet,
+        TxManagerConfig::default(),
+        chain_id,
+        Arc::new(NoopTxMetrics),
+    )
+    .await
+    .expect("should create manager with failing signer");
     (manager, anvil)
 }
 

--- a/crates/utilities/tx-manager/tests/craft_tx.rs
+++ b/crates/utilities/tx-manager/tests/craft_tx.rs
@@ -26,10 +26,9 @@ async fn setup_with_config(
     let signer: PrivateKeySigner = anvil.keys()[0].clone().into();
     let wallet = EthereumWallet::from(signer);
     let chain_id = anvil.chain_id();
-    let manager =
-        SimpleTxManager::new(provider, wallet, config, chain_id, Arc::new(NoopTxMetrics))
-            .await
-            .expect("should create manager");
+    let manager = SimpleTxManager::new(provider, wallet, config, chain_id, Arc::new(NoopTxMetrics))
+        .await
+        .expect("should create manager");
     (manager, anvil)
 }
 

--- a/crates/utilities/tx-manager/tests/send_lifecycle.rs
+++ b/crates/utilities/tx-manager/tests/send_lifecycle.rs
@@ -17,7 +17,8 @@ use alloy_provider::{Provider, RootProvider};
 use alloy_signer_local::PrivateKeySigner;
 use async_trait::async_trait;
 use base_tx_manager::{
-    SendState, SimpleTxManager, TxCandidate, TxManager, TxManagerConfig, TxManagerError,
+    NoopTxMetrics, SendState, SimpleTxManager, TxCandidate, TxManager, TxManagerConfig,
+    TxManagerError,
 };
 use rstest::rstest;
 use tokio::sync::mpsc;
@@ -54,9 +55,10 @@ async fn setup_with_config(
     let signer: PrivateKeySigner = anvil.keys()[0].clone().into();
     let wallet = EthereumWallet::from(signer);
     let chain_id = anvil.chain_id();
-    let manager = SimpleTxManager::new(provider, wallet, config, chain_id)
-        .await
-        .expect("should create manager");
+    let manager =
+        SimpleTxManager::new(provider, wallet, config, chain_id, Arc::new(NoopTxMetrics))
+            .await
+            .expect("should create manager");
     (manager, anvil)
 }
 
@@ -100,9 +102,10 @@ async fn setup_with_failing_signer_config(
     let address = anvil.addresses()[0];
     let wallet = EthereumWallet::from(FailingSigner { address });
     let chain_id = anvil.chain_id();
-    let manager = SimpleTxManager::new(provider, wallet, config, chain_id)
-        .await
-        .expect("should create manager with failing signer");
+    let manager =
+        SimpleTxManager::new(provider, wallet, config, chain_id, Arc::new(NoopTxMetrics))
+            .await
+            .expect("should create manager with failing signer");
     (manager, anvil)
 }
 

--- a/crates/utilities/tx-manager/tests/send_lifecycle.rs
+++ b/crates/utilities/tx-manager/tests/send_lifecycle.rs
@@ -55,10 +55,9 @@ async fn setup_with_config(
     let signer: PrivateKeySigner = anvil.keys()[0].clone().into();
     let wallet = EthereumWallet::from(signer);
     let chain_id = anvil.chain_id();
-    let manager =
-        SimpleTxManager::new(provider, wallet, config, chain_id, Arc::new(NoopTxMetrics))
-            .await
-            .expect("should create manager");
+    let manager = SimpleTxManager::new(provider, wallet, config, chain_id, Arc::new(NoopTxMetrics))
+        .await
+        .expect("should create manager");
     (manager, anvil)
 }
 
@@ -102,10 +101,9 @@ async fn setup_with_failing_signer_config(
     let address = anvil.addresses()[0];
     let wallet = EthereumWallet::from(FailingSigner { address });
     let chain_id = anvil.chain_id();
-    let manager =
-        SimpleTxManager::new(provider, wallet, config, chain_id, Arc::new(NoopTxMetrics))
-            .await
-            .expect("should create manager with failing signer");
+    let manager = SimpleTxManager::new(provider, wallet, config, chain_id, Arc::new(NoopTxMetrics))
+        .await
+        .expect("should create manager with failing signer");
     (manager, anvil)
 }
 


### PR DESCRIPTION
### What changed? Why?

Add metrics instrumentation to `base-tx-manager` to provide observability into transaction lifecycle events.

- Introduce a `TxMetrics` trait abstracting metrics collection, with a production `BaseTxMetrics` implementation (backed by the `metrics` crate) and a `NoopTxMetrics` for tests.
- `SimpleTxManager` now accepts an `Arc<dyn TxMetrics>` and records: base fee, tip cap, gas bumps, send latency, confirmed/failed tx counts, RPC errors, publish errors, current nonce, and max possible fee (in gwei).
- Add `TxManagerError::is_rpc_error()` to distinguish raw RPC transport failures from recognised state errors (e.g. `NonceTooLow`), so only true RPC errors inflate the error counter.
- Helper methods `rpc_timeout_error` and `classify_and_record_rpc` centralise error classification + metric recording.
- Rename `send_tx_inner` to `send_event_loop` for clarity.
- All metrics carry a `name` label so multiple tx-manager instances (e.g. challenger vs proposer) are distinguishable in dashboards.

### Notes to reviewers

The `TxMetrics` trait makes the metrics backend swappable. `NoopTxMetrics` keeps all existing tests free of a metrics recorder dependency.

### How has it been tested?

- Existing unit and integration tests updated to pass `Arc::new(NoopTxMetrics)`.
- New unit tests for `is_rpc_error`, `NoopTxMetrics`, and `BaseTxMetrics` construction/idempotent describe.

### Change management ([definitions](http://go/change-management))

type=routine<!--routine,nonroutine,emergency-->
risk=low<!--low,medium,high-->
impact=sev5<!--sev5,sev4,sev3,sev2,sev1-->

### Backwards Compatibility ([learn more](http://go/backwards-compatibility))

backwards_compatible=false<!-- true false -->

<!-- Automatically merge your PR once the necessary approvals have been received (you probably want this) -->

automerge=false