### PR TITLE
fix(batcher): Batcher Coverage And DA

### DIFF
--- a/actions/harness/src/batcher/actor.rs
+++ b/actions/harness/src/batcher/actor.rs
@@ -1,9 +1,10 @@
 use std::sync::Arc;
 
-use alloy_primitives::{Address, Bytes};
+use alloy_primitives::{Address, B256, Bytes};
 use base_batcher_encoder::{
     BatchEncoder, BatchPipeline, EncoderConfig, ReorgError, StepError, StepResult,
 };
+use base_blobs::BlobEncoder;
 use base_comp::{
     BatchComposeError, BatchComposer, BrotliCompressor, BrotliLevel, ChannelOut, ChannelOutError,
 };
@@ -39,6 +40,13 @@ pub enum GarbageKind {
     MalformedRlp,
     /// Valid frame header, brotli magic byte `0x00`, then random bytes.
     InvalidBrotli,
+    /// Frame data without the `DERIVATION_VERSION_0` prefix byte.
+    /// The derivation pipeline checks for the version byte first and ignores
+    /// transactions that don't start with it.
+    StripVersion,
+    /// Valid `DERIVATION_VERSION_0` prefix + complete frame, then appended garbage bytes.
+    /// The extra trailing bytes should be silently dropped by the frame parser.
+    DirtyAppend,
 }
 
 /// Configuration for the [`Batcher`] actor.
@@ -246,6 +254,37 @@ impl<'a, S: L2BlockProvider> Batcher<'a, S> {
         info!(frames = frames.len(), "batcher submitted frames to L1");
     }
 
+    /// Submit the given frames to the L1 miner as EIP-4844 blob sidecars.
+    ///
+    /// Each frame is encoded into one blob using [`BlobEncoder::encode_frames`].
+    /// Blobs are enqueued via [`L1Miner::enqueue_blob`] with a zero versioned
+    /// hash (sufficient for the in-memory [`ActionBlobDataSource`], which reads
+    /// all blob sidecars unconditionally).
+    ///
+    /// Mine an L1 block after calling this to include the blobs in a block.
+    ///
+    /// [`ActionBlobDataSource`]: crate::ActionBlobDataSource
+    pub fn submit_blob_frames(&mut self, frames: &[Arc<Frame>]) {
+        let blobs =
+            BlobEncoder::encode_frames(frames).expect("frame data fits within blob capacity");
+        for blob in blobs {
+            self.l1_miner.enqueue_blob(B256::ZERO, Box::new(blob));
+        }
+        info!(frames = frames.len(), "batcher submitted frames as blobs to L1");
+    }
+
+    /// Encode and submit all frames as blobs in one step.
+    ///
+    /// Equivalent to calling [`encode_frames`] followed by [`submit_blob_frames`].
+    ///
+    /// [`encode_frames`]: Batcher::encode_frames
+    /// [`submit_blob_frames`]: Batcher::submit_blob_frames
+    pub fn advance_blob(&mut self) -> Result<Vec<Arc<Frame>>, BatcherError> {
+        let frames = self.encode_frames()?;
+        self.submit_blob_frames(&frames);
+        Ok(frames)
+    }
+
     /// Submit intentionally malformed frame data to L1.
     ///
     /// These garbage frames should be silently dropped by the derivation
@@ -286,6 +325,28 @@ impl<'a, S: L2BlockProvider> Batcher<'a, S> {
                 v.push(1u8); // is_last = true
                 Bytes::from(v)
             }
+            GarbageKind::StripVersion => {
+                // Frame data without the DERIVATION_VERSION_0 prefix.
+                // Starts directly with a channel ID — no version byte, so the
+                // derivation pipeline discards the tx before parsing any frames.
+                let mut v = vec![];
+                v.extend_from_slice(&[0u8; 16]); // channel ID (no version prefix)
+                v.extend_from_slice(&[0u8, 0u8]); // frame number = 0
+                v.extend_from_slice(&[0u8, 0u8, 0u8, 0u8]); // frame data length = 0
+                v.push(1u8); // is_last = true
+                Bytes::from(v)
+            }
+            GarbageKind::DirtyAppend => {
+                // Valid DERIVATION_VERSION_0 + a minimal complete frame, then 50 garbage
+                // bytes appended. The extra trailing bytes follow the valid frame.
+                let mut v = vec![DERIVATION_VERSION_0];
+                v.extend_from_slice(&[0u8; 16]); // channel ID
+                v.extend_from_slice(&[0u8, 0u8]); // frame number = 0
+                v.extend_from_slice(&[0u8, 0u8, 0u8, 0u8]); // frame data length = 0
+                v.push(1u8); // is_last = true
+                v.extend_from_slice(&[0xBE_u8; 50]); // appended garbage
+                Bytes::from(v)
+            }
         };
 
         self.l1_miner.submit_tx(PendingTx {
@@ -294,6 +355,14 @@ impl<'a, S: L2BlockProvider> Batcher<'a, S> {
             input,
         });
         info!(kind = ?kind, "batcher submitted garbage frame");
+    }
+
+    /// Return the estimated number of unsubmitted data bytes in the encoding pipeline.
+    ///
+    /// Delegates to [`BatchEncoder::da_backlog_bytes`]. Useful for testing the
+    /// throttle controller's backlog detection.
+    pub fn da_backlog_bytes(&self) -> u64 {
+        self.pipeline.da_backlog_bytes()
     }
 
     /// Encode and submit all frames in one step (convenience wrapper).

--- a/actions/harness/src/test_rollup_config.rs
+++ b/actions/harness/src/test_rollup_config.rs
@@ -1,4 +1,5 @@
-use base_consensus_genesis::{BaseHardforkConfig, RollupConfig};
+use alloy_primitives::Address;
+use base_consensus_genesis::{BaseHardforkConfig, HardForkConfig, RollupConfig};
 use base_consensus_registry::Registry;
 
 use crate::BatcherConfig;
@@ -48,6 +49,39 @@ impl TestRollupConfigBuilder {
     /// Overrides the pre-Fjord `max_sequencer_drift` field on the config.
     pub const fn with_max_sequencer_drift(mut self, n: u64) -> Self {
         self.config.max_sequencer_drift = n;
+        self
+    }
+
+    /// Overrides the L2 block time in seconds.
+    pub const fn with_block_time(mut self, n: u64) -> Self {
+        self.config.block_time = n;
+        self
+    }
+
+    /// Overrides the sequencer window size (in L1 blocks).
+    pub const fn with_seq_window_size(mut self, n: u64) -> Self {
+        self.config.seq_window_size = n;
+        self
+    }
+
+    /// Overrides the L1 system config contract address.
+    pub const fn with_l1_system_config_address(mut self, addr: Address) -> Self {
+        self.config.l1_system_config_address = addr;
+        self
+    }
+
+    /// Overrides the L1 deposit contract address.
+    pub const fn with_deposit_contract(mut self, addr: Address) -> Self {
+        self.config.deposit_contract_address = addr;
+        self
+    }
+
+    /// Replaces the entire hardfork schedule with the supplied [`HardForkConfig`].
+    ///
+    /// Use this when a test needs fine-grained control over which forks are active
+    /// at which timestamps (e.g. hardfork boundary tests, span-batch gating tests).
+    pub const fn with_hardforks(mut self, hardforks: HardForkConfig) -> Self {
+        self.config.hardforks = hardforks;
         self
     }
 

--- a/actions/harness/src/verifier.rs
+++ b/actions/harness/src/verifier.rs
@@ -387,6 +387,19 @@ impl<P: Pipeline + SignalReceiver + Debug + Send> L2Verifier<P> {
                             // No more data for now — pipeline is idle.
                             break;
                         }
+                        PipelineErrorKind::Temporary(PipelineError::ChannelReaderEmpty) => {
+                            // The channel bank pruned a timed-out channel and has nothing
+                            // ready to provide to the channel reader. Step once more; the
+                            // next call will either find a ready channel or return Eof.
+                            no_progress += 1;
+                            if no_progress > 1_000 {
+                                return Err(VerifierError::Pipeline(Box::new(
+                                    PipelineError::Provider(
+                                        "pipeline stuck: 1000 consecutive ChannelReaderEmpty without progress".into()
+                                    ).temp()
+                                )));
+                            }
+                        }
                         PipelineErrorKind::Temporary(PipelineError::NotEnoughData) => {
                             // The channel bank just ingested a frame but the channel isn't
                             // assembled yet, or the batch reader needs another read attempt.

--- a/actions/harness/tests/batch_submission.rs
+++ b/actions/harness/tests/batch_submission.rs
@@ -274,3 +274,23 @@ fn garbage_invalid_brotli_submitted_to_l1() {
     drop(batcher);
     assert_eq!(h.l1.pending_txs().len(), 1, "garbage tx should be queued");
 }
+
+#[test]
+fn garbage_strip_version_submitted_to_l1() {
+    let mut h = ActionTestHarness::default();
+    let source = ActionL2Source::new();
+    let mut batcher = h.create_batcher(source, BatcherConfig::default());
+    batcher.submit_garbage_frames(GarbageKind::StripVersion);
+    drop(batcher);
+    assert_eq!(h.l1.pending_txs().len(), 1, "garbage tx should be queued");
+}
+
+#[test]
+fn garbage_dirty_append_submitted_to_l1() {
+    let mut h = ActionTestHarness::default();
+    let source = ActionL2Source::new();
+    let mut batcher = h.create_batcher(source, BatcherConfig::default());
+    batcher.submit_garbage_frames(GarbageKind::DirtyAppend);
+    drop(batcher);
+    assert_eq!(h.l1.pending_txs().len(), 1, "garbage tx should be queued");
+}

--- a/actions/harness/tests/batcher_blobs.rs
+++ b/actions/harness/tests/batcher_blobs.rs
@@ -1,0 +1,253 @@
+#![doc = "Action tests for blob DA submission and mixed calldata/blob derivation."]
+
+use alloy_primitives::B256;
+use base_action_harness::{
+    ActionL2Source, ActionTestHarness, BatcherConfig, L1MinerConfig, SharedL1Chain,
+    TestRollupConfigBuilder, block_info_from,
+};
+use base_batcher_encoder::EncoderConfig;
+
+// ---------------------------------------------------------------------------
+// Blob DA end-to-end
+// ---------------------------------------------------------------------------
+
+/// Encode 3 L2 blocks as EIP-4844 blobs (one blob per L2 block, each in its
+/// own L1 block) and verify that the blob verifier pipeline derives all three.
+///
+/// Follows the same one-block-per-L1-block pattern as the calldata derivation
+/// tests.  Block hashes from the sequencer are registered with the verifier so
+/// that parent-hash validation succeeds for blocks 2 and 3.
+#[tokio::test]
+async fn batcher_blob_da_end_to_end() {
+    let batcher_cfg = BatcherConfig::default();
+    let rollup_cfg = TestRollupConfigBuilder::base_mainnet(&batcher_cfg).build();
+    let mut h = ActionTestHarness::new(L1MinerConfig::default(), rollup_cfg);
+
+    let l1_chain = SharedL1Chain::from_blocks(h.l1.chain().to_vec());
+    let mut sequencer = h.create_l2_sequencer(l1_chain);
+
+    let mut block_hashes: Vec<(u64, B256)> = Vec::new();
+
+    // Build and submit each L2 block in its own L1 blob block.
+    for i in 1..=3u64 {
+        let block = sequencer.build_next_block().expect("build L2 block");
+        let hash = sequencer.head().block_info.hash;
+        block_hashes.push((i, hash));
+
+        let mut source = ActionL2Source::new();
+        source.push(block);
+        let mut batcher = h.create_batcher(source, batcher_cfg.clone());
+        let frames = batcher.encode_frames().expect("encode frames");
+        batcher.submit_blob_frames(&frames);
+        drop(batcher);
+
+        h.l1.mine_block();
+    }
+
+    // Create the blob verifier AFTER mining so the SharedL1Chain snapshot
+    // includes all L1 blocks with their blob sidecars.
+    let (mut verifier, _chain) = h.create_blob_verifier();
+    for (number, hash) in &block_hashes {
+        verifier.register_block_hash(*number, *hash);
+    }
+    verifier.initialize().await.expect("initialize");
+
+    // Drive derivation one L1 block at a time.
+    for i in 1..=3u64 {
+        let l1_block = block_info_from(h.l1.block_by_number(i).expect("block exists"));
+        verifier.act_l1_head_signal(l1_block).await.expect("signal L1 block");
+        let derived = verifier.act_l2_pipeline_full().await.expect("derive pipeline");
+        assert_eq!(derived, 1, "L1 block {i} should derive exactly one L2 block via blob DA");
+    }
+
+    assert_eq!(verifier.l2_safe().block_info.number, 3, "safe head should reach L2 block 3");
+}
+
+// ---------------------------------------------------------------------------
+// Multi-blob packing (many frames → many blob sidecars in one L1 block)
+// ---------------------------------------------------------------------------
+
+/// Force channel fragmentation via a tiny `max_frame_size`, then submit all
+/// resulting frames as separate blob sidecars in a single L1 block.
+///
+/// The blob verifier must read every blob sidecar from that L1 block, reassemble
+/// the channel fragments, and derive the encoded L2 block.  This exercises the
+/// path where a single L1 block carries multiple blob sidecars from the same
+/// channel.
+///
+/// An empty L1 block 2 is mined after the blob block so the `BatchQueue` has
+/// a next epoch boundary available when it emits the derived L2 block.
+#[tokio::test]
+async fn batcher_multi_blob_packing() {
+    let batcher_cfg = BatcherConfig {
+        encoder: EncoderConfig { max_frame_size: 80, ..EncoderConfig::default() },
+        ..BatcherConfig::default()
+    };
+    let rollup_cfg = TestRollupConfigBuilder::base_mainnet(&batcher_cfg).build();
+    let mut h = ActionTestHarness::new(L1MinerConfig::default(), rollup_cfg);
+
+    let l1_chain = SharedL1Chain::from_blocks(h.l1.chain().to_vec());
+    let mut sequencer = h.create_l2_sequencer(l1_chain);
+
+    // Build 1 L2 block and encode it into multiple frames (tiny max_frame_size).
+    let block = sequencer.build_next_block().expect("build L2 block");
+    let hash1 = sequencer.head().block_info.hash;
+
+    let mut source = ActionL2Source::new();
+    source.push(block);
+    let mut batcher = h.create_batcher(source, batcher_cfg.clone());
+    let frames = batcher.encode_frames().expect("encode frames");
+    assert!(
+        frames.len() >= 2,
+        "expected multiple frames with max_frame_size=80, got {}",
+        frames.len()
+    );
+    // All frames go into the same L1 block as separate blob sidecars.
+    batcher.submit_blob_frames(&frames);
+    drop(batcher);
+
+    h.l1.mine_block(); // L1 block 1: all blob sidecars for the fragmented channel
+
+    // Create verifier AFTER mining so the snapshot includes the blob block.
+    let (mut verifier, _chain) = h.create_blob_verifier();
+    verifier.register_block_hash(1, hash1);
+    verifier.initialize().await.expect("initialize");
+
+    // Signal L1 block 1: the pipeline reads all blob sidecars, reassembles the
+    // fragmented channel, and emits the batch.  L1 block 1 is the "next epoch"
+    // after epoch 0, so BatchQueue can emit as soon as it has all frames.
+    let l1_block_1 = block_info_from(h.l1.block_by_number(1).expect("L1 block 1"));
+    verifier.act_l1_head_signal(l1_block_1).await.expect("signal L1 block 1");
+    let derived = verifier.act_l2_pipeline_full().await.expect("step after L1 block 1");
+
+    assert_eq!(derived, 1, "expected 1 L2 block derived from multi-blob channel");
+    assert_eq!(verifier.l2_safe().block_info.number, 1, "safe head should reach L2 block 1");
+}
+
+// ---------------------------------------------------------------------------
+// Calldata DA (explicit)
+// ---------------------------------------------------------------------------
+
+/// Encode 3 L2 blocks as calldata frames (one calldata tx per L2 block, each
+/// in its own L1 block) and verify that the calldata verifier pipeline derives
+/// all three.
+///
+/// This mirrors `batcher_blob_da_end_to_end` but uses the calldata DA path,
+/// making both paths explicit and comparable in the test suite.
+#[tokio::test]
+async fn batcher_calldata_da() {
+    let batcher_cfg = BatcherConfig::default();
+    let rollup_cfg = TestRollupConfigBuilder::base_mainnet(&batcher_cfg).build();
+    let mut h = ActionTestHarness::new(L1MinerConfig::default(), rollup_cfg);
+
+    let l1_chain = SharedL1Chain::from_blocks(h.l1.chain().to_vec());
+    let mut sequencer = h.create_l2_sequencer(l1_chain);
+
+    let mut block_hashes: Vec<(u64, B256)> = Vec::new();
+
+    for i in 1..=3u64 {
+        let block = sequencer.build_next_block().expect("build L2 block");
+        let hash = sequencer.head().block_info.hash;
+        block_hashes.push((i, hash));
+
+        let mut source = ActionL2Source::new();
+        source.push(block);
+        let mut batcher = h.create_batcher(source, batcher_cfg.clone());
+        let frames = batcher.encode_frames().expect("encode frames");
+        batcher.submit_frames(&frames);
+        drop(batcher);
+
+        h.l1.mine_block();
+    }
+
+    let (mut verifier, _chain) = h.create_verifier();
+    for (number, hash) in &block_hashes {
+        verifier.register_block_hash(*number, *hash);
+    }
+    verifier.initialize().await.expect("initialize");
+
+    for i in 1..=3u64 {
+        let l1_block = block_info_from(h.l1.block_by_number(i).expect("block exists"));
+        verifier.act_l1_head_signal(l1_block).await.expect("signal L1 block");
+        let derived = verifier.act_l2_pipeline_full().await.expect("derive pipeline");
+        assert_eq!(derived, 1, "L1 block {i} should derive exactly one L2 block via calldata DA");
+    }
+
+    assert_eq!(verifier.l2_safe().block_info.number, 3, "safe head should reach L2 block 3");
+}
+
+// ---------------------------------------------------------------------------
+// Mixed calldata + blob derivation
+// ---------------------------------------------------------------------------
+
+/// Submit 3 L2 blocks as calldata and 3 more as blobs, each in separate L1
+/// blocks, then derive all 6 using the blob verifier pipeline.
+///
+/// The blob verifier pipeline reads both calldata (`batcher_txs`) and blob
+/// sidecars from each L1 block, making it suitable for mixed-DA sequences
+/// without any pipeline configuration changes.
+///
+/// This exercises the DA-switching scenario: the pipeline must process calldata
+/// from L1 blocks 1-3 and blob data from L1 blocks 4-6 to produce all 6 L2
+/// blocks in order.
+#[tokio::test]
+async fn batcher_da_switching() {
+    let batcher_cfg = BatcherConfig::default();
+    let rollup_cfg = TestRollupConfigBuilder::base_mainnet(&batcher_cfg).build();
+    let mut h = ActionTestHarness::new(L1MinerConfig::default(), rollup_cfg);
+
+    // One sequencer for all 6 blocks ensures a contiguous parent-hash chain.
+    let l1_chain = SharedL1Chain::from_blocks(h.l1.chain().to_vec());
+    let mut sequencer = h.create_l2_sequencer(l1_chain);
+
+    let mut block_hashes: Vec<(u64, B256)> = Vec::new();
+
+    // Blocks 1-3: submit as calldata (one block per L1 block).
+    for i in 1..=3u64 {
+        let block = sequencer.build_next_block().expect("build calldata block");
+        let hash = sequencer.head().block_info.hash;
+        block_hashes.push((i, hash));
+
+        let mut source = ActionL2Source::new();
+        source.push(block);
+        let mut batcher = h.create_batcher(source, batcher_cfg.clone());
+        let frames = batcher.encode_frames().expect("encode calldata frames");
+        batcher.submit_frames(&frames);
+        drop(batcher);
+        h.l1.mine_block();
+    }
+
+    // Blocks 4-6: submit as blobs (one block per L1 block).
+    for i in 4..=6u64 {
+        let block = sequencer.build_next_block().expect("build blob block");
+        let hash = sequencer.head().block_info.hash;
+        block_hashes.push((i, hash));
+
+        let mut source = ActionL2Source::new();
+        source.push(block);
+        let mut batcher = h.create_batcher(source, batcher_cfg.clone());
+        let frames = batcher.encode_frames().expect("encode blob frames");
+        batcher.submit_blob_frames(&frames);
+        drop(batcher);
+        h.l1.mine_block();
+    }
+
+    // The blob verifier handles both calldata (batcher_txs) and blobs
+    // (blob_sidecars) from each block, making it capable of deriving the
+    // full mixed sequence without any pipeline changes.
+    let (mut verifier, _chain) = h.create_blob_verifier();
+    for (number, hash) in &block_hashes {
+        verifier.register_block_hash(*number, *hash);
+    }
+    verifier.initialize().await.expect("initialize");
+
+    let mut total_derived = 0;
+    for i in 1..=6u64 {
+        let l1_block = block_info_from(h.l1.block_by_number(i).expect("block exists"));
+        verifier.act_l1_head_signal(l1_block).await.expect("signal L1 block");
+        total_derived += verifier.act_l2_pipeline_full().await.expect("derive pipeline");
+    }
+
+    assert_eq!(total_derived, 6, "expected 6 L2 blocks derived (3 calldata + 3 blob)");
+    assert_eq!(verifier.l2_safe().block_info.number, 6, "safe head should reach L2 block 6");
+}

--- a/actions/harness/tests/batcher_channels.rs
+++ b/actions/harness/tests/batcher_channels.rs
@@ -52,10 +52,6 @@ use base_action_harness::{
 /// issues, `ChannelDriver` needs a `with_channel_id(id)` builder or random
 /// ID generation.
 #[tokio::test]
-#[ignore = "channel timeout semantics in the IndexedTraversal mode need verification; \
-            the indexed traversal clears the ChannelBank per L1 block, which may mean \
-            multi-block channel timeout is not exercisable in the current harness — \
-            the test skeleton documents the expected flow for when the harness supports it"]
 async fn channel_timeout_triggers_channel_invalidation() {
     use base_batcher_encoder::EncoderConfig;
 
@@ -167,9 +163,10 @@ async fn channel_timeout_triggers_channel_invalidation() {
 /// No new methods needed — uses existing `Batcher::advance()` with a fresh
 /// `ChannelDriver` instance for the recovery submission.
 #[tokio::test]
-#[ignore = "blocked on channel timeout test infrastructure; once the channel bank \
-            correctly prunes timed-out channels in the IndexedTraversal path, \
-            this recovery test can be enabled"]
+#[ignore = "test design issue: batcher.advance() submits all frames in a single L1 \
+            block, so the channel completes immediately and the safe head advances \
+            before the timeout window elapses — needs restructuring to use selective \
+            per-frame submission to make the channel actually expire before recovery"]
 async fn channel_timeout_recovery_resubmits_successfully() {
     let batcher_cfg = BatcherConfig::default();
     let rollup_cfg =
@@ -271,20 +268,12 @@ async fn channel_timeout_recovery_resubmits_successfully() {
 /// 2. **Randomize by default** — have `ChannelDriver::flush()` generate a
 ///    random `ChannelId` per flush call (matches op-batcher behaviour).
 ///
-/// Additionally, the `IndexedTraversal` mode clears the `ChannelBank` on
-/// each `ProvideBlock` signal. For interleaving to work, all interleaved
-/// frames must be in the SAME L1 block (as separate transactions). This
-/// is already supported by the harness: call `submit_frames` for each
-/// frame individually, then mine one block.
+/// ## Note on same-block placement
 ///
-/// ## NOTE on `IndexedTraversal` limitation
-///
-/// The current `IndexedTraversal` mode processes one L1 block at a time
-/// and clears the channel bank between blocks. This means multi-block
-/// interleaving (frames from different channels in different L1 blocks)
-/// is NOT supported. All interleaved frames must land in the same L1
-/// block. This is a known limitation of the test harness, not the
-/// derivation pipeline itself.
+/// For interleaving to work across two channels both channels' frames must
+/// land in the same L1 block (as separate transactions).  All interleaved
+/// frames are submitted to the harness before a single `mine_and_push` call,
+/// so they all appear in L1 block 1.
 #[tokio::test]
 async fn interleaved_channels_correctly_reassembled() {
     use base_batcher_encoder::EncoderConfig;
@@ -360,4 +349,91 @@ async fn interleaved_channels_correctly_reassembled() {
     // Both channels should be reassembled and both L2 blocks derived.
     assert_eq!(derived, 2, "expected 2 L2 blocks derived from interleaved channels");
     assert_eq!(verifier.l2_safe().block_info.number, 2);
+}
+
+// ---------------------------------------------------------------------------
+// D. Multi-block channel — frames split across consecutive L1 blocks
+// ---------------------------------------------------------------------------
+
+/// A single channel whose frames are spread across two consecutive L1 blocks
+/// is correctly reassembled by the derivation pipeline.
+///
+/// This is the primary regression test for the `ProvideBlock` signal fix in
+/// [`ChannelBank`]: when a new L1 block arrives via `ProvideBlock`, the channel
+/// bank must **not** discard in-progress channels.  Without the fix, frame 0
+/// (submitted in L1 block 1) would be lost when L1 block 2 is signalled, and
+/// the channel could never complete.
+///
+/// ## Setup
+///
+/// - `max_frame_size = 80` forces a multi-frame channel so we can split frame 0
+///   and the remainder across two distinct L1 blocks.
+/// - Frame 0 is submitted in L1 block 1; remaining frames in L1 block 2.
+/// - Both blocks are within the default `channel_timeout` window.
+///
+/// ## Expected behaviour
+///
+/// After processing L1 block 2 the pipeline assembles the complete channel and
+/// derives L2 block 1.  The safe head advances to 1.
+#[tokio::test]
+async fn multi_block_channel_assembles_across_l1_blocks() {
+    use base_batcher_encoder::EncoderConfig;
+    let batcher_cfg = BatcherConfig {
+        encoder: EncoderConfig { max_frame_size: 80, ..EncoderConfig::default() },
+        ..BatcherConfig::default()
+    };
+    let rollup_cfg = TestRollupConfigBuilder::base_mainnet(&batcher_cfg).build();
+    let mut h = ActionTestHarness::new(L1MinerConfig::default(), rollup_cfg);
+
+    let l1_chain = SharedL1Chain::from_blocks(h.l1.chain().to_vec());
+    let mut sequencer = h.create_l2_sequencer(l1_chain);
+    let block = sequencer.build_next_block().expect("build L2 block 1");
+    let hash1 = sequencer.head().block_info.hash;
+
+    let mut source = ActionL2Source::new();
+    source.push(block);
+    let mut batcher = h.create_batcher(source, batcher_cfg.clone());
+    let frames = batcher.encode_frames().expect("encode");
+    assert!(
+        frames.len() >= 2,
+        "need at least 2 frames for this test; got {} (increase payload or decrease max_frame_size)",
+        frames.len()
+    );
+
+    // Submit frame 0 only → L1 block 1.
+    batcher.submit_frames(&frames[..1]);
+    drop(batcher);
+
+    let (mut verifier, chain) = h.create_verifier();
+    verifier.register_block_hash(1, hash1);
+
+    h.mine_and_push(&chain); // L1 block 1: frame 0
+
+    verifier.initialize().await.expect("initialize");
+    let l1_block_1 = block_info_from(h.l1.block_by_number(1).expect("block 1"));
+    verifier.act_l1_head_signal(l1_block_1).await.expect("signal block 1");
+    verifier.act_l2_pipeline_full().await.expect("step block 1");
+
+    // Channel is open but incomplete — safe head stays at genesis.
+    assert_eq!(
+        verifier.l2_safe().block_info.number,
+        0,
+        "channel incomplete after block 1; safe head must stay at genesis"
+    );
+
+    // Submit remaining frames → L1 block 2 (well within channel_timeout).
+    {
+        let empty_source = ActionL2Source::new();
+        let mut batcher2 = h.create_batcher(empty_source, batcher_cfg);
+        batcher2.submit_frames(&frames[1..]);
+        drop(batcher2);
+    }
+    h.mine_and_push(&chain); // L1 block 2: remaining frames
+
+    let l1_block_2 = block_info_from(h.l1.block_by_number(2).expect("block 2"));
+    verifier.act_l1_head_signal(l1_block_2).await.expect("signal block 2");
+    let derived = verifier.act_l2_pipeline_full().await.expect("step block 2");
+
+    assert_eq!(derived, 1, "multi-block channel must yield 1 L2 block");
+    assert_eq!(verifier.l2_safe().block_info.number, 1, "safe head must advance to 1");
 }

--- a/actions/harness/tests/batcher_sequencer_drift.rs
+++ b/actions/harness/tests/batcher_sequencer_drift.rs
@@ -39,8 +39,8 @@ use base_action_harness::{
 async fn sequencer_drift_produces_deposit_only_blocks() {
     let l1_cfg = L1MinerConfig { block_time: 4 };
     let batcher_cfg = BatcherConfig::default();
-    let mut rollup_cfg = TestRollupConfigBuilder::base_mainnet(&batcher_cfg).build();
-    rollup_cfg.block_time = 300;
+    let rollup_cfg =
+        TestRollupConfigBuilder::base_mainnet(&batcher_cfg).with_block_time(300).build();
     let mut h = ActionTestHarness::new(l1_cfg, rollup_cfg.clone());
 
     // Mine L1 block 1 (ts=4) so the sequencer has an epoch to reference,
@@ -136,8 +136,8 @@ async fn sequencer_drift_produces_deposit_only_blocks() {
 async fn sequencer_drift_forced_empty_blocks_accepted() {
     let l1_cfg = L1MinerConfig { block_time: 4 };
     let batcher_cfg = BatcherConfig::default();
-    let mut rollup_cfg = TestRollupConfigBuilder::base_mainnet(&batcher_cfg).build();
-    rollup_cfg.block_time = 300;
+    let rollup_cfg =
+        TestRollupConfigBuilder::base_mainnet(&batcher_cfg).with_block_time(300).build();
     let mut h = ActionTestHarness::new(l1_cfg, rollup_cfg);
 
     // Mine 1 L1 block so epoch 1 exists, but pin sequencer to epoch 0.

--- a/actions/harness/tests/batcher_stress.rs
+++ b/actions/harness/tests/batcher_stress.rs
@@ -1,0 +1,50 @@
+#![doc = "Stress tests for batcher channel fragmentation."]
+
+use base_action_harness::{ActionL2Source, ActionTestHarness, BatcherConfig, SharedL1Chain};
+use base_batcher_encoder::EncoderConfig;
+
+/// Stress test: tiny `max_frame_size` forces channel fragmentation into many frames.
+///
+/// With `max_frame_size = 80`, each L2 block's compressed batch data is split
+/// across multiple frames, producing far more L1 transactions than blocks. This
+/// exercises the multi-frame submission path and verifies the encoder correctly
+/// fragments large channels.
+#[test]
+fn batcher_stress_large_txs() {
+    let mut h = ActionTestHarness::default();
+    let l1_chain = SharedL1Chain::from_blocks(h.l1.chain().to_vec());
+    let mut sequencer = h.create_l2_sequencer(l1_chain);
+
+    // Build 5 L2 blocks.
+    let mut source = ActionL2Source::new();
+    for _ in 0..5 {
+        source.push(sequencer.build_next_block().expect("build L2 block"));
+    }
+
+    // Tiny max_frame_size forces fragmentation: at 80 bytes per frame,
+    // 5 L2 blocks (each with a deposit tx) produce many frames.
+    let cfg = BatcherConfig {
+        encoder: EncoderConfig { max_frame_size: 80, ..EncoderConfig::default() },
+        ..BatcherConfig::default()
+    };
+    let mut batcher = h.create_batcher(source, cfg);
+    let frames = batcher.encode_frames().expect("encode frames");
+
+    // With max_frame_size=80 and 5 blocks, expect multiple frames.
+    assert!(
+        frames.len() >= 3,
+        "expected at least 3 frames with max_frame_size=80, got {}",
+        frames.len()
+    );
+
+    // Submit all frames to L1.
+    batcher.submit_frames(&frames);
+    drop(batcher);
+
+    // Mine the block containing all frame txs.
+    h.l1.mine_block();
+    let tip = h.l1.tip();
+
+    // Each frame becomes one batcher tx.
+    assert_eq!(tip.batcher_txs.len(), frames.len(), "mined block should contain one tx per frame");
+}

--- a/actions/harness/tests/batcher_throttling.rs
+++ b/actions/harness/tests/batcher_throttling.rs
@@ -120,3 +120,53 @@ fn test_throttle_step_strategy_full_intensity() {
     assert_eq!(params.max_block_size, 2_000, "step at full intensity: block lower limit");
     assert_eq!(params.max_tx_size, 150, "step at full intensity: tx lower limit");
 }
+
+/// Verify that `da_backlog_bytes()` returns 0 after encoding (all blocks
+/// consumed by the pipeline) and that [`ThrottleController`] correctly
+/// signals throttling for a simulated high backlog then clears when the
+/// backlog reaches zero.
+#[test]
+fn test_throttle_batcher_integration() {
+    let l1_cfg = L1MinerConfig { block_time: 2 };
+    let batcher_cfg = BatcherConfig::default();
+    let rollup_cfg = {
+        let mut rc = Registry::rollup_config(8453).unwrap().clone();
+        rc.batch_inbox_address = batcher_cfg.inbox_address;
+        rc.genesis.system_config.as_mut().unwrap().batcher_address = batcher_cfg.batcher_address;
+        rc.genesis.l2_time = 0;
+        rc.genesis.l1 = Default::default();
+        rc.genesis.l2 = Default::default();
+        rc.hardforks.canyon_time = Some(0);
+        rc.hardforks.delta_time = Some(0);
+        rc.hardforks.ecotone_time = Some(0);
+        rc.hardforks.fjord_time = Some(0);
+        rc
+    };
+    let mut h = ActionTestHarness::new(l1_cfg, rollup_cfg);
+    let l1_chain = SharedL1Chain::from_blocks(h.l1.chain().to_vec());
+    let mut sequencer = h.create_l2_sequencer(l1_chain);
+
+    let mut source = ActionL2Source::new();
+    for _ in 0..3 {
+        source.push(sequencer.build_next_block().unwrap());
+    }
+
+    let mut batcher = h.create_batcher(source, batcher_cfg);
+
+    // After encoding all blocks the encoder has consumed them: backlog is 0.
+    batcher.encode_frames().unwrap();
+    let backlog_after = batcher.da_backlog_bytes();
+    assert_eq!(backlog_after, 0, "backlog should be 0 after all blocks are encoded");
+
+    // Simulate a high-backlog scenario with ThrottleController directly.
+    let threshold = 1_000u64;
+    let config = ThrottleConfig { threshold_bytes: threshold, ..ThrottleConfig::default() };
+    let ctrl = ThrottleController::new(config, ThrottleStrategy::Linear);
+
+    let simulated_backlog = threshold * 2;
+    let params = ctrl.update(simulated_backlog);
+    assert!(params.is_some(), "throttle should activate for high simulated backlog");
+
+    // Zero backlog: throttle deactivated.
+    assert!(ctrl.update(0).is_none(), "throttle clears when backlog is zero");
+}

--- a/actions/harness/tests/derivation.rs
+++ b/actions/harness/tests/derivation.rs
@@ -10,9 +10,7 @@ use base_action_harness::{
     L2Verifier, PendingTx, SharedL1Chain, StepResult, TestRollupConfigBuilder, block_info_from,
 };
 use base_blobs::BlobEncoder;
-use base_consensus_genesis::{
-    CONFIG_UPDATE_EVENT_VERSION_0, CONFIG_UPDATE_TOPIC, L1ChainConfig, RollupConfig,
-};
+use base_consensus_genesis::{CONFIG_UPDATE_EVENT_VERSION_0, CONFIG_UPDATE_TOPIC, L1ChainConfig};
 use base_protocol::{
     BlockInfo, DEPOSIT_EVENT_ABI_HASH, DEPOSIT_EVENT_VERSION_0, DERIVATION_VERSION_0, L2BlockInfo,
 };
@@ -498,8 +496,9 @@ async fn batch_accepted_at_last_seq_window_block() {
     const SEQ_WINDOW: u64 = 4;
 
     let batcher_cfg = BatcherConfig::default();
-    let mut rollup_cfg = TestRollupConfigBuilder::base_mainnet(&batcher_cfg).build();
-    rollup_cfg.seq_window_size = SEQ_WINDOW;
+    let rollup_cfg = TestRollupConfigBuilder::base_mainnet(&batcher_cfg)
+        .with_seq_window_size(SEQ_WINDOW)
+        .build();
     let mut h = ActionTestHarness::new(L1MinerConfig::default(), rollup_cfg);
 
     // Build L2 block 1 referencing L1 genesis (epoch 0).
@@ -647,10 +646,9 @@ fn user_deposit_log(
 async fn l1_deposit_included_in_derived_l2_block() {
     let deposit_contract = Address::repeat_byte(0xDD);
     let batcher_cfg = BatcherConfig::default();
-    let rollup_cfg = RollupConfig {
-        deposit_contract_address: deposit_contract,
-        ..TestRollupConfigBuilder::base_mainnet(&batcher_cfg).build()
-    };
+    let rollup_cfg = TestRollupConfigBuilder::base_mainnet(&batcher_cfg)
+        .with_deposit_contract(deposit_contract)
+        .build();
     let mut h = ActionTestHarness::new(L1MinerConfig::default(), rollup_cfg);
 
     // Build L2 block 1 from the sequencer.
@@ -725,8 +723,9 @@ async fn batcher_key_rotation_accepts_new_batcher() {
     let batcher_b =
         BatcherConfig { batcher_address: Address::repeat_byte(0xBB), ..batcher_a.clone() };
 
-    let mut rollup_cfg = TestRollupConfigBuilder::base_mainnet(&batcher_a).build();
-    rollup_cfg.l1_system_config_address = l1_sys_cfg_addr;
+    let rollup_cfg = TestRollupConfigBuilder::base_mainnet(&batcher_a)
+        .with_l1_system_config_address(l1_sys_cfg_addr)
+        .build();
     let mut h = ActionTestHarness::new(L1MinerConfig::default(), rollup_cfg.clone());
 
     // Build all L2 blocks (1, 2, and 3) upfront from the L1 genesis state.
@@ -873,8 +872,9 @@ async fn multi_l2_per_l1_epoch() {
 async fn batch_past_sequence_window_rejected() {
     const SEQ_WINDOW: u64 = 3;
     let batcher_cfg = BatcherConfig::default();
-    let mut rollup_cfg = TestRollupConfigBuilder::base_mainnet(&batcher_cfg).build();
-    rollup_cfg.seq_window_size = SEQ_WINDOW;
+    let rollup_cfg = TestRollupConfigBuilder::base_mainnet(&batcher_cfg)
+        .with_seq_window_size(SEQ_WINDOW)
+        .build();
     let mut h = ActionTestHarness::new(L1MinerConfig::default(), rollup_cfg);
 
     // Build L2 block 1 (epoch 0).
@@ -1396,10 +1396,9 @@ fn gas_limit_update_log(l1_sys_cfg_addr: Address, gas_limit: u64) -> alloy_primi
 async fn gpo_params_change_does_not_disrupt_derivation() {
     let l1_sys_cfg_addr = Address::repeat_byte(0xCC);
     let batcher_cfg = BatcherConfig::default();
-    let rollup_cfg = RollupConfig {
-        l1_system_config_address: l1_sys_cfg_addr,
-        ..TestRollupConfigBuilder::base_mainnet(&batcher_cfg).build()
-    };
+    let rollup_cfg = TestRollupConfigBuilder::base_mainnet(&batcher_cfg)
+        .with_l1_system_config_address(l1_sys_cfg_addr)
+        .build();
     let mut h = ActionTestHarness::new(L1MinerConfig::default(), rollup_cfg);
 
     let l1_chain = SharedL1Chain::from_blocks(h.l1.chain().to_vec());
@@ -1458,10 +1457,9 @@ async fn gpo_params_change_does_not_disrupt_derivation() {
 async fn gas_limit_change_does_not_disrupt_derivation() {
     let l1_sys_cfg_addr = Address::repeat_byte(0xCC);
     let batcher_cfg = BatcherConfig::default();
-    let rollup_cfg = RollupConfig {
-        l1_system_config_address: l1_sys_cfg_addr,
-        ..TestRollupConfigBuilder::base_mainnet(&batcher_cfg).build()
-    };
+    let rollup_cfg = TestRollupConfigBuilder::base_mainnet(&batcher_cfg)
+        .with_l1_system_config_address(l1_sys_cfg_addr)
+        .build();
     let mut h = ActionTestHarness::new(L1MinerConfig::default(), rollup_cfg);
 
     let l1_chain = SharedL1Chain::from_blocks(h.l1.chain().to_vec());
@@ -1939,8 +1937,9 @@ async fn batcher_config_update_rolled_back_on_reorg() {
     let batcher_b =
         BatcherConfig { batcher_address: Address::repeat_byte(0xBB), ..batcher_a.clone() };
 
-    let mut rollup_cfg = TestRollupConfigBuilder::base_mainnet(&batcher_a).build();
-    rollup_cfg.l1_system_config_address = l1_sys_cfg_addr;
+    let rollup_cfg = TestRollupConfigBuilder::base_mainnet(&batcher_a)
+        .with_l1_system_config_address(l1_sys_cfg_addr)
+        .build();
     let genesis_sys_cfg = rollup_cfg.genesis.system_config.unwrap_or_default();
     let mut h = ActionTestHarness::new(L1MinerConfig::default(), rollup_cfg.clone());
 

--- a/actions/harness/tests/hardfork_activation.rs
+++ b/actions/harness/tests/hardfork_activation.rs
@@ -246,17 +246,6 @@ fn base_v1_is_standalone_from_jovian() {
 // activates at T, keeping the upgrade-transaction injection isolated.
 // ---------------------------------------------------------------------------
 
-/// Build a [`RollupConfig`] wired to the given [`BatcherConfig`] and [`HardForkConfig`].
-///
-/// Starts from the real Base mainnet config and replaces the hardfork schedule
-/// with the caller-supplied `hardforks`. This lets derivation tests set exact
-/// hardfork timestamps without spurious cascade activations from unlisted forks.
-fn rollup_config_for(batcher: &BatcherConfig, hardforks: HardForkConfig) -> RollupConfig {
-    let mut rc = TestRollupConfigBuilder::base_mainnet(batcher).build();
-    rc.hardforks = hardforks;
-    rc
-}
-
 /// With only Canyon active (Delta NOT active, Fjord NOT active), a span batch
 /// submitted by the batcher must NOT be derived.
 ///
@@ -270,7 +259,8 @@ fn rollup_config_for(batcher: &BatcherConfig, hardforks: HardForkConfig) -> Roll
 async fn span_batch_rejected_before_delta() {
     let batcher_cfg = BatcherConfig::default();
     let hardforks = HardForkConfig { canyon_time: Some(0), ..Default::default() };
-    let rollup_cfg = rollup_config_for(&batcher_cfg, hardforks);
+    let rollup_cfg =
+        TestRollupConfigBuilder::base_mainnet(&batcher_cfg).with_hardforks(hardforks).build();
     let mut h = ActionTestHarness::new(L1MinerConfig::default(), rollup_cfg);
 
     let l1_chain = SharedL1Chain::from_blocks(h.l1.chain().to_vec());
@@ -307,7 +297,8 @@ async fn span_batch_rejected_before_delta() {
 async fn span_batch_derives_after_delta() {
     let batcher_cfg = BatcherConfig::default();
     let hardforks = HardForkConfig { fjord_time: Some(0), ..Default::default() };
-    let rollup_cfg = rollup_config_for(&batcher_cfg, hardforks);
+    let rollup_cfg =
+        TestRollupConfigBuilder::base_mainnet(&batcher_cfg).with_hardforks(hardforks).build();
     let mut h = ActionTestHarness::new(L1MinerConfig::default(), rollup_cfg);
 
     let l1_chain = SharedL1Chain::from_blocks(h.l1.chain().to_vec());
@@ -345,7 +336,8 @@ async fn span_batch_derives_after_delta() {
 async fn single_batch_derives_with_fjord() {
     let batcher_cfg = BatcherConfig::default();
     let hardforks = HardForkConfig { fjord_time: Some(0), ..Default::default() };
-    let rollup_cfg = rollup_config_for(&batcher_cfg, hardforks);
+    let rollup_cfg =
+        TestRollupConfigBuilder::base_mainnet(&batcher_cfg).with_hardforks(hardforks).build();
     let mut h = ActionTestHarness::new(L1MinerConfig::default(), rollup_cfg);
 
     let l1_chain = SharedL1Chain::from_blocks(h.l1.chain().to_vec());
@@ -416,7 +408,8 @@ async fn jovian_derivation_crosses_activation_boundary() {
         jovian_time: Some(jovian_time),
         ..Default::default()
     };
-    let rollup_cfg = rollup_config_for(&batcher_cfg, hardforks);
+    let rollup_cfg =
+        TestRollupConfigBuilder::base_mainnet(&batcher_cfg).with_hardforks(hardforks).build();
     let mut h = ActionTestHarness::new(L1MinerConfig::default(), rollup_cfg);
 
     let l1_chain = SharedL1Chain::from_blocks(h.l1.chain().to_vec());

--- a/actions/harness/tests/operator_fees.rs
+++ b/actions/harness/tests/operator_fees.rs
@@ -2,34 +2,12 @@
 
 use alloy_primitives::{Address, B256, LogData};
 use base_action_harness::{
-    ActionL2Source, ActionTestHarness, BatcherConfig, L1MinerConfig, SharedL1Chain, block_info_from,
+    ActionL2Source, ActionTestHarness, BatcherConfig, L1MinerConfig, SharedL1Chain,
+    TestRollupConfigBuilder, block_info_from,
 };
 use base_alloy_consensus::{OpBlock, OpTxEnvelope};
-use base_consensus_genesis::{
-    CONFIG_UPDATE_EVENT_VERSION_0, CONFIG_UPDATE_TOPIC, HardForkConfig, RollupConfig,
-};
-use base_consensus_registry::Registry;
+use base_consensus_genesis::{CONFIG_UPDATE_EVENT_VERSION_0, CONFIG_UPDATE_TOPIC, HardForkConfig};
 use base_protocol::L1BlockInfoTx;
-
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-
-/// Build a [`RollupConfig`] for operator fee tests with the given hardfork schedule.
-///
-/// Starts from the real Base mainnet config and zeroes the genesis fields for
-/// in-memory testing (L1 miner starts at ts=0). The caller supplies the
-/// complete [`HardForkConfig`].
-fn rollup_config_for(batcher: &BatcherConfig, hardforks: HardForkConfig) -> RollupConfig {
-    let mut rc = Registry::rollup_config(8453).expect("mainnet config").clone();
-    rc.batch_inbox_address = batcher.inbox_address;
-    rc.genesis.system_config.as_mut().unwrap().batcher_address = batcher.batcher_address;
-    rc.genesis.l2_time = 0;
-    rc.genesis.l1 = Default::default();
-    rc.genesis.l2 = Default::default();
-    rc.hardforks = hardforks;
-    rc
-}
 
 /// Decode the [`L1BlockInfoTx`] from the first (L1 info deposit) transaction of
 /// an [`OpBlock`].
@@ -81,7 +59,8 @@ fn operator_fee_not_encoded_before_isthmus() {
         // their mainnet timestamps are unreachable (L1 miner starts at ts=0).
         ..Default::default()
     };
-    let rollup_cfg = rollup_config_for(&batcher_cfg, hardforks);
+    let rollup_cfg =
+        TestRollupConfigBuilder::base_mainnet(&batcher_cfg).with_hardforks(hardforks).build();
     let h = ActionTestHarness::new(L1MinerConfig::default(), rollup_cfg);
     let l1_chain = SharedL1Chain::from_blocks(h.l1.chain().to_vec());
     let mut builder = h.create_l2_sequencer(l1_chain);
@@ -128,7 +107,8 @@ fn operator_fee_encoded_in_l1_info_post_isthmus() {
         isthmus_time: Some(0),
         ..Default::default()
     };
-    let mut rollup_cfg = rollup_config_for(&batcher_cfg, hardforks);
+    let mut rollup_cfg =
+        TestRollupConfigBuilder::base_mainnet(&batcher_cfg).with_hardforks(hardforks).build();
     let sys_cfg = rollup_cfg.genesis.system_config.as_mut().unwrap();
     sys_cfg.operator_fee_scalar = Some(OPERATOR_FEE_SCALAR);
     sys_cfg.operator_fee_constant = Some(OPERATOR_FEE_CONSTANT);
@@ -191,7 +171,8 @@ fn l1_info_format_transitions_at_isthmus_boundary() {
         isthmus_time: Some(isthmus_time),
         ..Default::default()
     };
-    let mut rollup_cfg = rollup_config_for(&batcher_cfg, hardforks);
+    let mut rollup_cfg =
+        TestRollupConfigBuilder::base_mainnet(&batcher_cfg).with_hardforks(hardforks).build();
     let sys_cfg = rollup_cfg.genesis.system_config.as_mut().unwrap();
     sys_cfg.operator_fee_scalar = Some(OPERATOR_FEE_SCALAR);
     sys_cfg.operator_fee_constant = Some(OPERATOR_FEE_CONSTANT);
@@ -300,7 +281,8 @@ fn l1_info_format_transitions_at_jovian_boundary() {
         jovian_time: Some(jovian_time),
         ..Default::default()
     };
-    let mut rollup_cfg = rollup_config_for(&batcher_cfg, hardforks);
+    let mut rollup_cfg =
+        TestRollupConfigBuilder::base_mainnet(&batcher_cfg).with_hardforks(hardforks).build();
     let sys_cfg = rollup_cfg.genesis.system_config.as_mut().unwrap();
     sys_cfg.operator_fee_scalar = Some(OPERATOR_FEE_SCALAR);
     sys_cfg.operator_fee_constant = Some(OPERATOR_FEE_CONSTANT);
@@ -409,7 +391,8 @@ async fn isthmus_derivation_crosses_operator_fee_boundary() {
         isthmus_time: Some(isthmus_time),
         ..Default::default()
     };
-    let mut rollup_cfg = rollup_config_for(&batcher_cfg, hardforks);
+    let mut rollup_cfg =
+        TestRollupConfigBuilder::base_mainnet(&batcher_cfg).with_hardforks(hardforks).build();
     let sys_cfg = rollup_cfg.genesis.system_config.as_mut().unwrap();
     sys_cfg.operator_fee_scalar = Some(OPERATOR_FEE_SCALAR);
     sys_cfg.operator_fee_constant = Some(OPERATOR_FEE_CONSTANT);
@@ -495,7 +478,8 @@ async fn jovian_non_empty_transition_batch_generates_deposit_only_block() {
         jovian_time: Some(jovian_time),
         ..Default::default()
     };
-    let mut rollup_cfg = rollup_config_for(&batcher_cfg, hardforks);
+    let mut rollup_cfg =
+        TestRollupConfigBuilder::base_mainnet(&batcher_cfg).with_hardforks(hardforks).build();
     // Narrow the sequencing window: epoch-0 batches must land in L1 blocks 0–3.
     // When the pipeline reaches L1 block 4 (epoch 0 + 4 = 4), force-inclusion
     // fires and a deposit-only block is generated for any pending L2 slot.
@@ -675,7 +659,8 @@ async fn operator_fee_config_update_propagates_to_l1_info() {
         isthmus_time: Some(0),
         ..Default::default()
     };
-    let mut rollup_cfg = rollup_config_for(&batcher_cfg, hardforks);
+    let mut rollup_cfg =
+        TestRollupConfigBuilder::base_mainnet(&batcher_cfg).with_hardforks(hardforks).build();
     rollup_cfg.l1_system_config_address = l1_sys_cfg_addr;
     let sys_cfg = rollup_cfg.genesis.system_config.as_mut().unwrap();
     sys_cfg.operator_fee_scalar = Some(OLD_SCALAR);

--- a/bin/batcher/src/cli.rs
+++ b/bin/batcher/src/cli.rs
@@ -142,6 +142,7 @@ impl BatcherArgs {
             max_channel_duration: self.max_channel_duration,
             sub_safety_margin: self.sub_safety_margin,
             target_num_frames: self.target_num_frames,
+            ..base_batcher_encoder::EncoderConfig::default()
         };
         encoder_config.validate()?;
         Ok(BatcherConfig {

--- a/crates/batcher/core/Cargo.toml
+++ b/crates/batcher/core/Cargo.toml
@@ -20,12 +20,12 @@ base-batcher-source.workspace = true
 base-batcher-encoder.workspace = true
 tracing = { workspace = true, features = ["std"] }
 thiserror = { workspace = true, features = ["std"] }
+base-protocol = { workspace = true, features = ["std"] }
 alloy-primitives = { workspace = true, features = ["std"] }
 tokio = { workspace = true, features = ["sync", "macros", "rt"] }
 
 [dev-dependencies]
 async-trait.workspace = true
-base-protocol = { workspace = true, features = ["std"] }
 alloy-consensus = { workspace = true, features = ["std"] }
 alloy-rpc-types-eth = { workspace = true, features = ["std"] }
 base-alloy-consensus = { workspace = true, features = ["std"] }

--- a/crates/batcher/core/src/driver.rs
+++ b/crates/batcher/core/src/driver.rs
@@ -3,9 +3,10 @@
 use std::{future::Future, pin::Pin, sync::Arc};
 
 use alloy_primitives::{Address, Bytes, U256};
-use base_batcher_encoder::{BatchPipeline, StepResult, SubmissionId};
+use base_batcher_encoder::{BatchPipeline, DaType, StepResult, SubmissionId};
 use base_batcher_source::{L2BlockEvent, UnsafeBlockSource};
 use base_blobs::BlobEncoder;
+use base_protocol::DERIVATION_VERSION_0;
 use base_tx_manager::{TxCandidate, TxManager};
 use futures::stream::{FuturesUnordered, StreamExt};
 use tokio::sync::Semaphore;
@@ -167,41 +168,61 @@ where
                     break; // Nothing to submit; wait for more encoding work.
                 };
                 let id = sub.id;
-                match BlobEncoder::encode_frames(&sub.frames) {
-                    Ok(blobs) => {
-                        let candidate = TxCandidate {
+                let candidate = match sub.da_type {
+                    DaType::Blob => match BlobEncoder::encode_frames(&sub.frames) {
+                        Ok(blobs) => TxCandidate {
                             to: Some(self.inbox),
                             tx_data: Bytes::new(),
                             value: U256::ZERO,
                             gas_limit: 0,
                             blobs,
-                        };
-                        let handle = self.tx_manager.send_async(candidate).await;
-                        let fut: Pin<Box<dyn Future<Output = (SubmissionId, TxOutcome)> + Send>> =
-                            Box::pin(async move {
-                                let outcome = match handle.await {
-                                    Ok(receipt) => {
-                                        let l1_block = receipt.block_number.unwrap_or_else(|| {
-                                            warn!(id = %id.0, "confirmed receipt missing block number; l1_head will not advance");
-                                            0
-                                        });
-                                        TxOutcome::Confirmed { l1_block }
-                                    }
-                                    Err(e) => {
-                                        warn!(id = %id.0, error = %e, "submission failed");
-                                        TxOutcome::Failed
-                                    }
-                                };
-                                drop(permit);
-                                (id, outcome)
-                            });
-                        self.in_flight.push(fut);
+                        },
+                        Err(e) => {
+                            warn!(id = %id.0, error = %e, "failed to encode frames to blobs, requeueing");
+                            self.pipeline.requeue(id);
+                            drop(permit);
+                            continue;
+                        }
+                    },
+                    DaType::Calldata => {
+                        // Calldata mode: one frame per submission (enforced by
+                        // EncoderConfig::validate). Encode as
+                        // [DERIVATION_VERSION_0] ++ frame.encode().
+                        let frame = &sub.frames[0];
+                        let encoded = frame.encode();
+                        let mut data = Vec::with_capacity(1 + encoded.len());
+                        data.push(DERIVATION_VERSION_0);
+                        data.extend_from_slice(&encoded);
+                        TxCandidate {
+                            to: Some(self.inbox),
+                            tx_data: Bytes::from(data),
+                            value: U256::ZERO,
+                            gas_limit: 0,
+                            blobs: vec![],
+                        }
                     }
-                    Err(e) => {
-                        warn!(id = %id.0, error = %e, "failed to encode frames to blobs, requeueing");
-                        self.pipeline.requeue(id);
-                        drop(permit);
-                    }
+                };
+                {
+                    let handle = self.tx_manager.send_async(candidate).await;
+                    let fut: Pin<Box<dyn Future<Output = (SubmissionId, TxOutcome)> + Send>> =
+                        Box::pin(async move {
+                            let outcome = match handle.await {
+                                Ok(receipt) => {
+                                    let l1_block = receipt.block_number.unwrap_or_else(|| {
+                                        warn!(id = %id.0, "confirmed receipt missing block number; l1_head will not advance");
+                                        0
+                                    });
+                                    TxOutcome::Confirmed { l1_block }
+                                }
+                                Err(e) => {
+                                    warn!(id = %id.0, error = %e, "submission failed");
+                                    TxOutcome::Failed
+                                }
+                            };
+                            drop(permit);
+                            (id, outcome)
+                        });
+                    self.in_flight.push(fut);
                 }
             }
 
@@ -557,6 +578,7 @@ mod tests {
         BatchSubmission {
             id: SubmissionId(id),
             channel_id: ChannelId::default(),
+            da_type: base_batcher_encoder::DaType::Blob,
             frames: vec![Arc::new(Frame::default())],
         }
     }
@@ -662,6 +684,7 @@ mod tests {
         pipeline.submissions.push_back(BatchSubmission {
             id: SubmissionId(0),
             channel_id: ChannelId::default(),
+            da_type: base_batcher_encoder::DaType::Blob,
             frames: vec![Arc::new(Frame { data: vec![0u8; OVERSIZED], ..Frame::default() })],
         });
 

--- a/crates/batcher/encoder/src/encoder.rs
+++ b/crates/batcher/encoder/src/encoder.rs
@@ -6,6 +6,15 @@ use std::{
     sync::Arc,
 };
 
+/// Approximate compression ratio used by the `ShadowCompressor` (Brotli-10).
+/// Must stay in sync with the `approx_compr_ratio` value in `BatchEncoder::open_new_channel`.
+const APPROX_COMPR_RATIO: f64 = 0.6;
+
+/// Approximate bytes of per-block overhead when encoding as part of a [`SpanBatch`].
+/// Accounts for the fixed fields carried per singular batch (parent hash, epoch number,
+/// epoch hash, timestamp) plus RLP framing. Used for span accumulator size estimation.
+const SPAN_BATCH_PER_BLOCK_OVERHEAD: usize = 50;
+
 use alloy_eips::eip2718::Encodable2718;
 use alloy_primitives::B256;
 use base_alloy_consensus::{OpBlock, OpTxEnvelope};
@@ -13,12 +22,13 @@ use base_comp::{
     BatchComposer, ChannelOut, CompressionAlgo, CompressorType, Config, ShadowCompressor,
 };
 use base_consensus_genesis::RollupConfig;
-use base_protocol::{Batch, ChannelId};
+use base_protocol::{Batch, ChannelId, SingleBatch, SpanBatch};
 use rand::{RngCore, SeedableRng, rngs::SmallRng};
 use tracing::{debug, warn};
 
 use crate::{
-    BatchPipeline, BatchSubmission, EncoderConfig, ReorgError, StepError, StepResult, SubmissionId,
+    BatchPipeline, BatchSubmission, BatchType, EncoderConfig, ReorgError, StepError, StepResult,
+    SubmissionId,
     channel::{OpenChannel, PendingRef, ReadyChannel},
 };
 
@@ -49,6 +59,20 @@ pub struct BatchEncoder {
     next_id: u64,
     /// Per-instance RNG for generating unique channel IDs.
     rng: SmallRng,
+    /// Accumulated (`SingleBatch`, `sequence_number`) pairs when operating in
+    /// [`BatchType::Span`] mode. Blocks are collected here during `step()` and
+    /// flushed as a single [`SpanBatch`] when `close_current_channel()` is called.
+    span_accumulator: Vec<(SingleBatch, u64)>,
+    /// Running sum of the estimated raw (uncompressed) byte size of all blocks currently
+    /// in `span_accumulator`. Incremented by `SPAN_BATCH_PER_BLOCK_OVERHEAD` plus raw
+    /// transaction bytes for each block pushed in `step()`, and reset to zero when the
+    /// accumulator is drained. Avoids an O(N·M) re-scan of the accumulator on every step.
+    span_raw_bytes: usize,
+    /// L1 head block number when the first block was accumulated into the current span
+    /// (Span mode only). Used by `check_channel_timeout()` to detect when the span has
+    /// been open too long and must be flushed, since `current_channel` is `None` between
+    /// span flushes. Cleared when `close_current_channel()` drains the accumulator.
+    span_opened_at_l1: Option<u64>,
 }
 
 impl fmt::Debug for BatchEncoder {
@@ -62,6 +86,9 @@ impl fmt::Debug for BatchEncoder {
             .field("ready_channels", &self.ready_channels.len())
             .field("pending", &self.pending.len())
             .field("next_id", &self.next_id)
+            .field("span_accumulator_len", &self.span_accumulator.len())
+            .field("span_raw_bytes", &self.span_raw_bytes)
+            .field("span_opened_at_l1", &self.span_opened_at_l1)
             .finish_non_exhaustive()
     }
 }
@@ -81,11 +108,74 @@ impl BatchEncoder {
             pending: HashMap::new(),
             next_id: 0,
             rng: SmallRng::from_os_rng(),
+            span_accumulator: Vec::new(),
+            span_raw_bytes: 0,
+            span_opened_at_l1: None,
         }
     }
 
     /// Close the current channel, drain its frames, and push it to `ready_channels`.
+    ///
+    /// In [`BatchType::Span`] mode the span accumulator is flushed as a single
+    /// [`SpanBatch`] into a freshly-opened channel before draining frames.
+    /// If both the channel and the accumulator are empty the call is a no-op.
     fn close_current_channel(&mut self) {
+        // In Span mode: build a SpanBatch from the accumulator, then open a channel
+        // and write it. The accumulator is only consumed if all appends succeed, so
+        // blocks are never silently lost on error — they remain in the accumulator for
+        // the next close attempt.
+        //
+        // Importantly, both the channel open and the accumulator drain happen only
+        // after successful batch construction: this prevents writing a zero-block (or
+        // partial) SpanBatch to the channel, which would be silently ignored by the
+        // derivation pipeline and waste L1 DA space.
+        if self.config.batch_type == BatchType::Span && !self.span_accumulator.is_empty() {
+            let chain_id = self.rollup_config.l2_chain_id.id();
+            let mut span_batch = SpanBatch { chain_id, ..Default::default() };
+            let total = self.span_accumulator.len();
+            let mut append_failed = false;
+
+            for (single, seq_num) in &self.span_accumulator {
+                if let Err(e) = span_batch.append_singular_batch(single.clone(), *seq_num) {
+                    warn!(
+                        error = %e,
+                        total,
+                        "span batch append failed; blocks preserved in accumulator"
+                    );
+                    append_failed = true;
+                    break;
+                }
+            }
+
+            if !append_failed {
+                // All blocks encoded into the SpanBatch. Now open a channel and write it.
+                // The accumulator is only cleared *after* a successful add_batch so that
+                // blocks are never silently lost if the channel rejects the batch (e.g.
+                // if the span batch exceeds MAX_RLP_BYTES_PER_CHANNEL).
+                if self.current_channel.is_none() {
+                    self.open_new_channel();
+                }
+
+                let add_ok = self
+                    .current_channel
+                    .as_mut()
+                    .map(|open| {
+                        open.out.add_batch(Batch::Span(span_batch)).map_err(|e| {
+                            warn!(error = %e, total, "failed to add span batch to channel; blocks preserved in accumulator");
+                        }).is_ok()
+                    })
+                    .unwrap_or(false);
+
+                if add_ok {
+                    self.span_accumulator.clear();
+                    self.span_raw_bytes = 0;
+                    self.span_opened_at_l1 = None;
+                }
+            }
+            // On failure (append or add_batch): accumulator is untouched so blocks
+            // are retried on the next close attempt. No partial SpanBatch is submitted.
+        }
+
         let Some(mut open) = self.current_channel.take() else {
             return;
         };
@@ -144,7 +234,7 @@ impl BatchEncoder {
             target_output_size: self.config.target_frame_size as u64,
             kind: CompressorType::Shadow,
             compression_algo: CompressionAlgo::Brotli10,
-            approx_compr_ratio: 0.6,
+            approx_compr_ratio: APPROX_COMPR_RATIO,
         };
         let compressor = ShadowCompressor::from(compressor_config);
 
@@ -153,15 +243,26 @@ impl BatchEncoder {
         self.current_channel = Some(OpenChannel { out: channel_out, opened_at_l1: self.l1_head });
     }
 
-    /// Check if the current channel has timed out and close it if so.
+    /// Check if the current channel (or span accumulator) has timed out and close it if so.
     fn check_channel_timeout(&mut self) -> bool {
+        // Apply the safety margin so channels are closed `sub_safety_margin` L1 blocks
+        // before the configured `max_channel_duration`, ensuring frames land well within
+        // the protocol's `channel_timeout` inclusion window.
+        let effective_duration =
+            self.config.max_channel_duration.saturating_sub(self.config.sub_safety_margin);
+
         let should_close = if let Some(ref open) = self.current_channel {
-            // Apply the safety margin so channels are closed `sub_safety_margin` L1 blocks
-            // before the configured `max_channel_duration`, ensuring frames land well within
-            // the protocol's `channel_timeout` inclusion window.
-            let effective_duration =
-                self.config.max_channel_duration.saturating_sub(self.config.sub_safety_margin);
             self.l1_head.saturating_sub(open.opened_at_l1) >= effective_duration
+        } else if self.config.batch_type == BatchType::Span {
+            // In Span mode there is no open channel between size-based flushes; instead
+            // we track the L1 head at which the first block was accumulated. If the
+            // accumulator is non-empty and the effective duration has elapsed, flush it.
+            self.span_opened_at_l1
+                .map(|opened_at| {
+                    !self.span_accumulator.is_empty()
+                        && self.l1_head.saturating_sub(opened_at) >= effective_duration
+                })
+                .unwrap_or(false)
         } else {
             false
         };
@@ -202,42 +303,99 @@ impl BatchPipeline for BatchEncoder {
             return Ok(StepResult::Idle);
         }
 
-        // Ensure a channel is open.
-        if self.current_channel.is_none() {
-            self.open_new_channel();
-        }
-
         // Get the block at the cursor.
         let block = &self.blocks[self.block_cursor];
 
         // Convert block to a SingleBatch. Failure here is fatal: skipping the block
         // would produce a gap in the L2 block sequence submitted to L1.
-        let (single_batch, _l1_info) = BatchComposer::block_to_single_batch(block)
+        let (single_batch, l1_info) = BatchComposer::block_to_single_batch(block)
             .map_err(|source| StepError::CompositionFailed { cursor: self.block_cursor, source })?;
 
-        // Try to add the batch to the current channel.
-        let batch = Batch::Single(single_batch);
-        let open = self.current_channel.as_mut().unwrap();
-        Ok(match open.out.add_batch(batch) {
-            Ok(()) => {
+        match self.config.batch_type {
+            BatchType::Span => {
+                // In Span mode blocks are accumulated in memory; the span batch is
+                // written to the channel only when close_current_channel() is called.
+                let seq_num = l1_info.sequence_number();
+                // Maintain a running byte counter so the size check below is O(1) per
+                // step rather than O(N·M) over the entire accumulator.
+                let block_raw_bytes = SPAN_BATCH_PER_BLOCK_OVERHEAD
+                    + single_batch.transactions.iter().map(|tx| tx.len()).sum::<usize>();
+                self.span_raw_bytes += block_raw_bytes;
+                self.span_accumulator.push((single_batch, seq_num));
                 self.block_cursor += 1;
 
+                // Track the L1 head at which the first block of this span was accumulated.
+                // `check_channel_timeout()` uses this to detect when the span has been open
+                // too long even though `current_channel` is None between flushes.
+                if self.span_opened_at_l1.is_none() {
+                    self.span_opened_at_l1 = Some(self.l1_head);
+                }
+
+                // Estimate the compressed size of the accumulated span batch and close
+                // the channel when it would exceed the configured size budget. This mirrors
+                // op-batcher's `SpanChannelOut`, which triggers closure based on estimated
+                // compressed size rather than waiting for a timeout.
+                //
+                // Each block contributes fixed-field overhead plus its raw transaction bytes.
+                // The compressed estimate uses the same ratio as the ShadowCompressor so that
+                // the size trigger fires at roughly the same threshold as Single mode.
+                let compressed_estimate =
+                    (self.span_raw_bytes as f64 * APPROX_COMPR_RATIO) as usize;
+                let size_target =
+                    self.config.target_frame_size.saturating_mul(self.config.target_num_frames);
+
                 debug!(
-                    block_cursor = %self.block_cursor,
-                    blocks_len = %self.blocks.len(),
-                    "encoded block into channel"
+                    block_cursor = self.block_cursor,
+                    blocks_len = self.blocks.len(),
+                    span_accumulator_len = self.span_accumulator.len(),
+                    span_raw_bytes = self.span_raw_bytes,
+                    compressed_estimate,
+                    size_target,
+                    "accumulated block for span batch"
                 );
 
-                StepResult::BlockEncoded
+                if compressed_estimate >= size_target {
+                    debug!(
+                        span_len = self.span_accumulator.len(),
+                        compressed_estimate, size_target, "span accumulator full, closing channel"
+                    );
+                    self.close_current_channel();
+                    return Ok(StepResult::ChannelClosed);
+                }
+
+                Ok(StepResult::BlockEncoded)
             }
-            Err(e) => {
-                // Channel is full (ExceedsMaxRlpBytesPerChannel or compression full).
-                // Close the current channel and the caller will retry on the next step.
-                debug!(error = %e, "channel rejected batch, closing");
-                self.close_current_channel();
-                StepResult::ChannelClosed
+            BatchType::Single => {
+                // Ensure a channel is open.
+                if self.current_channel.is_none() {
+                    self.open_new_channel();
+                }
+
+                // Try to add the batch to the current channel.
+                let batch = Batch::Single(single_batch);
+                let open = self.current_channel.as_mut().unwrap();
+                Ok(match open.out.add_batch(batch) {
+                    Ok(()) => {
+                        self.block_cursor += 1;
+
+                        debug!(
+                            block_cursor = self.block_cursor,
+                            blocks_len = self.blocks.len(),
+                            "encoded block into channel"
+                        );
+
+                        StepResult::BlockEncoded
+                    }
+                    Err(e) => {
+                        // Channel is full (ExceedsMaxRlpBytesPerChannel or compression full).
+                        // Close the current channel and the caller will retry on the next step.
+                        debug!(error = %e, "channel rejected batch, closing");
+                        self.close_current_channel();
+                        StepResult::ChannelClosed
+                    }
+                })
             }
-        })
+        }
     }
 
     fn next_submission(&mut self) -> Option<BatchSubmission> {
@@ -261,7 +419,12 @@ impl BatchPipeline for BatchEncoder {
                 self.pending
                     .insert(id, PendingRef { channel_idx: chan_idx, frame_start, frame_count });
 
-                return Some(BatchSubmission { id, channel_id: channel.id, frames });
+                return Some(BatchSubmission {
+                    id,
+                    channel_id: channel.id,
+                    da_type: self.config.da_type,
+                    frames,
+                });
             }
         }
 
@@ -363,6 +526,9 @@ impl BatchPipeline for BatchEncoder {
         self.current_channel = None;
         self.ready_channels.clear();
         self.pending.clear();
+        self.span_accumulator.clear();
+        self.span_raw_bytes = 0;
+        self.span_opened_at_l1 = None;
         // Intentionally not resetting `next_id`: keeping it monotonically
         // increasing across resets means post-reset submissions can never
         // share an ID with any pre-reset in-flight submission, eliminating
@@ -761,6 +927,7 @@ mod tests {
             target_num_frames: 2,
             max_channel_duration: 2,
             sub_safety_margin: 0,
+            ..EncoderConfig::default()
         };
         let mut encoder = BatchEncoder::new(Arc::new(RollupConfig::default()), config);
 
@@ -799,6 +966,7 @@ mod tests {
             target_num_frames: 3,
             max_channel_duration: 2,
             sub_safety_margin: 0,
+            ..EncoderConfig::default()
         };
         let mut encoder = BatchEncoder::new(Arc::new(RollupConfig::default()), config);
 
@@ -924,5 +1092,252 @@ mod tests {
         // Cursor must still be 0 — the block was not consumed.
         assert_eq!(encoder.block_cursor, 0);
         assert_eq!(encoder.blocks.len(), 1);
+    }
+
+    // --- Span batch tests ---
+
+    /// A [`BatchEncoder`] in Span mode with a tiny `target_frame_size` so the very first
+    /// accumulated block exceeds the compressed-size threshold and triggers `ChannelClosed`.
+    fn span_encoder_tiny_target() -> BatchEncoder {
+        let config = EncoderConfig {
+            batch_type: BatchType::Span,
+            target_frame_size: 1,
+            max_frame_size: 130_044,
+            ..EncoderConfig::default()
+        };
+        BatchEncoder::new(Arc::new(RollupConfig::default()), config)
+    }
+
+    /// In Span mode, `step()` returns `BlockEncoded` for multiple blocks without
+    /// opening a channel — blocks accumulate in the span accumulator until the size
+    /// threshold or timeout fires.
+    #[test]
+    fn test_span_batch_accumulates_blocks_without_channel() {
+        let config = EncoderConfig {
+            batch_type: BatchType::Span,
+            target_frame_size: 130_044, // large: size won't trigger
+            max_channel_duration: 1000,
+            ..EncoderConfig::default()
+        };
+        let mut encoder = BatchEncoder::new(Arc::new(RollupConfig::default()), config);
+
+        let b1 = make_block(B256::ZERO);
+        let b1_hash = b1.header.hash_slow();
+        encoder.add_block(b1).unwrap();
+        assert_eq!(encoder.step().unwrap(), StepResult::BlockEncoded);
+
+        // No channel opened — blocks are in the span accumulator.
+        assert!(encoder.current_channel.is_none());
+        assert_eq!(encoder.span_accumulator.len(), 1);
+        assert!(encoder.span_opened_at_l1.is_some(), "span_opened_at_l1 must be set");
+
+        let b2 = make_block(b1_hash);
+        let b2_hash = b2.header.hash_slow();
+        encoder.add_block(b2).unwrap();
+        assert_eq!(encoder.step().unwrap(), StepResult::BlockEncoded);
+        assert!(encoder.current_channel.is_none());
+        assert_eq!(encoder.span_accumulator.len(), 2);
+
+        let b3 = make_block(b2_hash);
+        encoder.add_block(b3).unwrap();
+        assert_eq!(encoder.step().unwrap(), StepResult::BlockEncoded);
+        assert!(encoder.current_channel.is_none());
+        assert_eq!(encoder.span_accumulator.len(), 3);
+
+        // No submissions available until channel is closed.
+        assert!(encoder.next_submission().is_none());
+    }
+
+    /// When the estimated compressed size of the span accumulator exceeds
+    /// `target_frame_size * target_num_frames`, `step()` returns `ChannelClosed`
+    /// and a submission is immediately available.
+    #[test]
+    fn test_span_batch_size_threshold_triggers_close() {
+        let mut encoder = span_encoder_tiny_target();
+
+        let block = make_block(B256::ZERO);
+        encoder.add_block(block).unwrap();
+
+        // The first block's overhead alone exceeds target_frame_size=1.
+        assert_eq!(encoder.step().unwrap(), StepResult::ChannelClosed);
+
+        // Accumulator must be flushed.
+        assert!(encoder.span_accumulator.is_empty());
+        assert!(encoder.span_opened_at_l1.is_none());
+
+        // A submission must be immediately available.
+        let sub = encoder.next_submission();
+        assert!(sub.is_some(), "span batch should produce a submission after size-based close");
+    }
+
+    /// In Span mode, `advance_l1_head` triggers `check_channel_timeout()` which closes
+    /// and flushes the span accumulator when the effective duration has elapsed, even
+    /// though `current_channel` is `None`.
+    #[test]
+    fn test_span_batch_timeout_triggers_close() {
+        let config = EncoderConfig {
+            batch_type: BatchType::Span,
+            target_frame_size: 130_044, // large: size won't trigger
+            max_frame_size: 130_044,
+            max_channel_duration: 5,
+            sub_safety_margin: 0,
+            ..EncoderConfig::default()
+        };
+        let mut encoder = BatchEncoder::new(Arc::new(RollupConfig::default()), config);
+
+        let block = make_block(B256::ZERO);
+        encoder.add_block(block).unwrap();
+        assert_eq!(encoder.step().unwrap(), StepResult::BlockEncoded);
+
+        // One block accumulated; no channel open.
+        assert!(encoder.current_channel.is_none());
+        assert_eq!(encoder.span_accumulator.len(), 1);
+        assert_eq!(encoder.span_opened_at_l1, Some(0));
+
+        // Advance L1 head just below the timeout — accumulator must be preserved.
+        encoder.advance_l1_head(4);
+        assert_eq!(encoder.span_accumulator.len(), 1, "accumulator must survive before timeout");
+        assert!(encoder.ready_channels.is_empty());
+
+        // At exactly the timeout threshold — accumulator must be flushed.
+        encoder.advance_l1_head(5);
+        assert!(encoder.span_accumulator.is_empty(), "accumulator must be flushed at timeout");
+        assert!(encoder.span_opened_at_l1.is_none());
+        assert!(!encoder.ready_channels.is_empty(), "a ready channel must exist after flush");
+
+        let sub = encoder.next_submission();
+        assert!(sub.is_some(), "should have a submission after timeout flush");
+    }
+
+    /// `sub_safety_margin` shortens the effective timeout in Span mode just as it does
+    /// in Single mode: a span opened at L1 block 0 with `max_channel_duration=10,
+    /// sub_safety_margin=4` must flush when `l1_head` reaches 6.
+    #[test]
+    fn test_span_batch_sub_safety_margin_shortens_timeout() {
+        let config = EncoderConfig {
+            batch_type: BatchType::Span,
+            target_frame_size: 130_044,
+            max_frame_size: 130_044,
+            max_channel_duration: 10,
+            sub_safety_margin: 4,
+            ..EncoderConfig::default()
+        };
+        let mut encoder = BatchEncoder::new(Arc::new(RollupConfig::default()), config);
+
+        let block = make_block(B256::ZERO);
+        encoder.add_block(block).unwrap();
+        assert_eq!(encoder.step().unwrap(), StepResult::BlockEncoded);
+
+        // One block before effective threshold (10 - 4 = 6) — must survive.
+        encoder.advance_l1_head(5);
+        assert_eq!(
+            encoder.span_accumulator.len(),
+            1,
+            "accumulator must survive before effective timeout"
+        );
+
+        // At exactly the effective threshold — must flush.
+        encoder.advance_l1_head(6);
+        assert!(encoder.span_accumulator.is_empty(), "must flush at effective timeout");
+        assert!(!encoder.ready_channels.is_empty());
+    }
+
+    /// End-to-end span batch path: add a block, trigger size-based close,
+    /// get submission, confirm, and verify blocks are pruned.
+    #[test]
+    fn test_span_batch_end_to_end() {
+        let mut encoder = span_encoder_tiny_target();
+
+        let b1 = make_block(B256::ZERO);
+        encoder.add_block(b1).unwrap();
+        assert_eq!(encoder.step().unwrap(), StepResult::ChannelClosed);
+
+        let sub = encoder.next_submission().expect("submission must be available");
+        let sub_id = sub.id;
+
+        // Blocks must NOT be pruned until the submission is confirmed.
+        assert!(!encoder.blocks.is_empty());
+
+        encoder.confirm(sub_id, 10);
+
+        // After confirmation blocks must be pruned.
+        assert!(encoder.blocks.is_empty());
+        assert_eq!(encoder.block_cursor, 0);
+    }
+
+    /// `reset()` in Span mode must clear both the accumulator and `span_opened_at_l1`.
+    #[test]
+    fn test_span_batch_reset_clears_span_state() {
+        let config = EncoderConfig {
+            batch_type: BatchType::Span,
+            target_frame_size: 130_044, // large: size won't trigger
+            max_channel_duration: 1000,
+            ..EncoderConfig::default()
+        };
+        let mut encoder = BatchEncoder::new(Arc::new(RollupConfig::default()), config);
+
+        let block = make_block(B256::ZERO);
+        encoder.add_block(block).unwrap();
+        encoder.step().unwrap();
+
+        assert_eq!(encoder.span_accumulator.len(), 1);
+        assert!(encoder.span_opened_at_l1.is_some());
+
+        encoder.reset();
+
+        assert!(encoder.span_accumulator.is_empty());
+        assert!(encoder.span_opened_at_l1.is_none());
+    }
+
+    /// Multiple successive Span channels work correctly: each block immediately triggers
+    /// a size-based close (with tiny target), and each channel is confirmed and pruned
+    /// independently.
+    #[test]
+    fn test_span_batch_multiple_channels() {
+        let mut encoder = span_encoder_tiny_target();
+
+        // First block → size threshold → first channel closed.
+        let b1 = make_block(B256::ZERO);
+        let b1_hash = b1.header.hash_slow();
+        encoder.add_block(b1).unwrap();
+        assert_eq!(encoder.step().unwrap(), StepResult::ChannelClosed);
+        assert_eq!(encoder.ready_channels.len(), 1);
+
+        // Second block → size threshold → second channel closed.
+        let b2 = make_block(b1_hash);
+        encoder.add_block(b2).unwrap();
+        assert_eq!(encoder.step().unwrap(), StepResult::ChannelClosed);
+        assert_eq!(encoder.ready_channels.len(), 2);
+
+        // Confirm first channel — its block is pruned.
+        let sub1 = encoder.next_submission().expect("ch1 must have a submission");
+        let id1 = sub1.id;
+        encoder.confirm(id1, 10);
+        assert_eq!(encoder.ready_channels.len(), 1);
+
+        // Confirm second channel — its block is pruned.
+        let sub2 = encoder.next_submission().expect("ch2 must have a submission");
+        let id2 = sub2.id;
+        encoder.confirm(id2, 11);
+        assert_eq!(encoder.ready_channels.len(), 0);
+        assert!(encoder.blocks.is_empty());
+    }
+
+    /// A span-mode requeue rewinds the cursor on the ready channel just as in Single mode.
+    #[test]
+    fn test_span_batch_requeue_rewinds_cursor() {
+        let mut encoder = span_encoder_tiny_target();
+
+        let block = make_block(B256::ZERO);
+        encoder.add_block(block).unwrap();
+        assert_eq!(encoder.step().unwrap(), StepResult::ChannelClosed);
+
+        let sub = encoder.next_submission().unwrap();
+        let sub_id = sub.id;
+
+        encoder.requeue(sub_id);
+
+        let resub = encoder.next_submission();
+        assert!(resub.is_some(), "requeued span frames must be available again");
     }
 }

--- a/crates/batcher/encoder/src/lib.rs
+++ b/crates/batcher/encoder/src/lib.rs
@@ -9,8 +9,8 @@
 
 mod types;
 pub use types::{
-    BatchSubmission, EncoderConfig, EncoderConfigError, ReorgError, StepError, StepResult,
-    SubmissionId,
+    BatchSubmission, BatchType, DaType, EncoderConfig, EncoderConfigError, ReorgError, StepError,
+    StepResult, SubmissionId,
 };
 
 mod pipeline;

--- a/crates/batcher/encoder/src/types.rs
+++ b/crates/batcher/encoder/src/types.rs
@@ -3,6 +3,7 @@
 use std::sync::Arc;
 
 use alloy_primitives::B256;
+pub use base_protocol::BatchType;
 use base_protocol::{ChannelId, Frame};
 
 /// Identifies a batch submission for receipt tracking.
@@ -15,6 +16,24 @@ use base_protocol::{ChannelId, Frame};
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct SubmissionId(pub u64);
 
+/// Selects how batch frames are encoded for L1 submission.
+///
+/// The driver uses this field on each [`BatchSubmission`] to determine whether
+/// frames should be packed into EIP-4844 blobs or sent as transaction calldata.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum DaType {
+    /// Frames are packed into EIP-4844 blobs, one blob per frame (default).
+    #[default]
+    Blob,
+    /// Each frame is sent as a single calldata transaction
+    /// (`[DERIVATION_VERSION_0] ++ frame.encode()`).
+    ///
+    /// When using calldata mode, set
+    /// [`EncoderConfig::target_num_frames`] to `1` so that each
+    /// [`BatchSubmission`] contains exactly one frame.
+    Calldata,
+}
+
 /// A single L1 transaction's worth of batch data: one or more frames encoded as blobs.
 ///
 /// Contains up to [`EncoderConfig::target_num_frames`] frames, each mapping to one
@@ -26,6 +45,8 @@ pub struct BatchSubmission {
     pub id: SubmissionId,
     /// The channel this submission belongs to.
     pub channel_id: ChannelId,
+    /// How frames in this submission should be encoded for L1.
+    pub da_type: DaType,
     /// Frames to include in this L1 transaction.
     /// Each frame maps to one EIP-4844 blob. Shared via [`Arc`] to avoid
     /// deep copies of the frame payload when handing off to the driver.
@@ -118,6 +139,23 @@ pub struct EncoderConfig {
     ///
     /// Default: 1 (one blob per transaction).
     pub target_num_frames: usize,
+
+    /// Whether to encode blocks as individual [`SingleBatch`](base_consensus_genesis::batch::SingleBatch)es
+    /// or accumulate them into a single [`SpanBatch`](base_protocol::SpanBatch).
+    ///
+    /// Default: [`BatchType::Single`].
+    pub batch_type: BatchType,
+
+    /// How frames should be encoded for L1 submission.
+    ///
+    /// When set to [`DaType::Calldata`], set [`target_num_frames`] to `1` so
+    /// that each [`BatchSubmission`] contains exactly one frame (one calldata
+    /// tx per frame matches the derivation protocol).
+    ///
+    /// Default: [`DaType::Blob`].
+    ///
+    /// [`target_num_frames`]: EncoderConfig::target_num_frames
+    pub da_type: DaType,
 }
 
 impl Default for EncoderConfig {
@@ -128,6 +166,8 @@ impl Default for EncoderConfig {
             max_channel_duration: 2,
             sub_safety_margin: 0,
             target_num_frames: 1,
+            batch_type: BatchType::Single,
+            da_type: DaType::Blob,
         }
     }
 }
@@ -144,6 +184,11 @@ impl EncoderConfig {
             return Err(EncoderConfigError::SafetyMarginTooLarge {
                 sub_safety_margin: self.sub_safety_margin,
                 max_channel_duration: self.max_channel_duration,
+            });
+        }
+        if matches!(self.da_type, DaType::Calldata) && self.target_num_frames != 1 {
+            return Err(EncoderConfigError::CalldataRequiresSingleFrame {
+                target_num_frames: self.target_num_frames,
             });
         }
         Ok(())
@@ -167,6 +212,15 @@ pub enum EncoderConfigError {
         sub_safety_margin: u64,
         /// The configured maximum channel duration.
         max_channel_duration: u64,
+    },
+    /// `da_type == DaType::Calldata` but `target_num_frames != 1`.
+    ///
+    /// Calldata mode submits one frame per L1 transaction. Set
+    /// `target_num_frames = 1` when using [`DaType::Calldata`].
+    #[error("calldata DA requires target_num_frames == 1, got {target_num_frames}")]
+    CalldataRequiresSingleFrame {
+        /// The configured target number of frames.
+        target_num_frames: usize,
     },
 }
 

--- a/crates/batcher/service/src/service.rs
+++ b/crates/batcher/service/src/service.rs
@@ -186,6 +186,8 @@ impl BatcherService {
     /// if any of those steps fail — the caller sees the failure immediately,
     /// before any background work is spawned.
     pub async fn setup(self) -> eyre::Result<ReadyBatcher> {
+        self.config.encoder_config.validate()?;
+
         info!(
             l1_rpc = %self.config.l1_rpc_url,
             l2_rpc = %self.config.l2_rpc_url,

--- a/crates/consensus/derive/src/stages/channel/channel_bank.rs
+++ b/crates/consensus/derive/src/stages/channel/channel_bank.rs
@@ -231,10 +231,28 @@ impl<P> SignalReceiver for ChannelBank<P>
 where
     P: NextFrameProvider + OriginAdvancer + OriginProvider + SignalReceiver + Send + Debug,
 {
+    /// Handle a pipeline signal.
+    ///
+    /// `Reset`, `Activation`, and `FlushChannel` clear the channel bank because they represent
+    /// a discontinuity in the L1 data stream (reorg, hardfork boundary, or explicit flush).
+    ///
+    /// `ProvideBlock` is intentionally **not** cleared here, diverging from kona's upstream
+    /// `ChannelBank` which clears unconditionally on all signals. Channels can span multiple
+    /// L1 blocks; clearing on every block advancement would destroy in-progress multi-block
+    /// channels before their frames have all arrived, breaking channel timeout detection.
+    /// This matches op-node's `channel_bank.go`, where only `Reset()` discards channel state
+    /// and normal L1 block advancement leaves channels intact.
     async fn signal(&mut self, signal: Signal) -> PipelineResult<()> {
-        self.prev.signal(signal).await?;
-        self.channels.clear();
-        self.channel_queue = VecDeque::with_capacity(10);
+        match signal {
+            Signal::Reset(_) | Signal::Activation(_) | Signal::FlushChannel => {
+                self.prev.signal(signal).await?;
+                self.channels.clear();
+                self.channel_queue = VecDeque::with_capacity(10);
+            }
+            Signal::ProvideBlock(_) => {
+                self.prev.signal(signal).await?;
+            }
+        }
         Ok(())
     }
 }
@@ -250,7 +268,7 @@ mod tests {
     use super::*;
     use crate::{
         test_utils::{CollectingLayer, TestNextFrameProvider, TraceStorage},
-        types::ResetSignal,
+        types::{ActivationSignal, ResetSignal},
     };
 
     #[test]
@@ -418,6 +436,111 @@ mod tests {
         assert_eq!(channel_bank.channels.len(), 0);
         assert_eq!(channel_bank.channel_queue.len(), 0);
         assert!(channel_bank.prev.reset);
+    }
+
+    /// `Activation` is a hardfork-boundary signal and must discard buffered
+    /// channel data, just like `Reset`.
+    #[tokio::test]
+    async fn test_activation_clears_channels() {
+        let mock = TestNextFrameProvider::new(vec![]);
+        let cfg = Arc::new(RollupConfig::default());
+        let mut channel_bank = ChannelBank::new(cfg, mock);
+        channel_bank.channels.insert([0xFF; 16], Channel::default());
+        channel_bank.channel_queue.push_back([0xFF; 16]);
+        assert!(!channel_bank.prev.reset);
+        channel_bank.signal(ActivationSignal::default().signal()).await.unwrap();
+        assert_eq!(channel_bank.channels.len(), 0, "Activation must clear channels");
+        assert_eq!(channel_bank.channel_queue.len(), 0, "Activation must clear channel queue");
+        assert!(channel_bank.prev.reset, "Activation must propagate to prev stage");
+    }
+
+    /// `FlushChannel` is an explicit flush directive and must discard buffered
+    /// channel data, just like `Reset`.
+    #[tokio::test]
+    async fn test_flush_channel_clears_channels() {
+        let mock = TestNextFrameProvider::new(vec![]);
+        let cfg = Arc::new(RollupConfig::default());
+        let mut channel_bank = ChannelBank::new(cfg, mock);
+        channel_bank.channels.insert([0xFF; 16], Channel::default());
+        channel_bank.channel_queue.push_back([0xFF; 16]);
+        assert!(!channel_bank.prev.reset);
+        channel_bank.signal(Signal::FlushChannel).await.unwrap();
+        assert_eq!(channel_bank.channels.len(), 0, "FlushChannel must clear channels");
+        assert_eq!(channel_bank.channel_queue.len(), 0, "FlushChannel must clear channel queue");
+        assert!(channel_bank.prev.reset, "FlushChannel must propagate to prev stage");
+    }
+
+    /// `ProvideBlock` advances the L1 origin and must NOT discard in-progress
+    /// channels — this is the intentional divergence from kona's upstream
+    /// `ChannelBank`, which clears unconditionally on all signals.  Channels
+    /// that span multiple L1 blocks must survive each `ProvideBlock` so that
+    /// the channel-timeout window can be measured correctly.
+    #[tokio::test]
+    async fn test_provide_block_preserves_channels() {
+        let mock = TestNextFrameProvider::new(vec![]);
+        let cfg = Arc::new(RollupConfig::default());
+        let mut channel_bank = ChannelBank::new(cfg, mock);
+        channel_bank.channels.insert([0xFF; 16], Channel::default());
+        channel_bank.channel_queue.push_back([0xFF; 16]);
+        assert!(!channel_bank.prev.reset);
+        channel_bank.signal(Signal::ProvideBlock(BlockInfo::default())).await.unwrap();
+        assert_eq!(channel_bank.channels.len(), 1, "ProvideBlock must not clear channels");
+        assert_eq!(
+            channel_bank.channel_queue.len(),
+            1,
+            "ProvideBlock must not clear channel queue"
+        );
+        assert!(channel_bank.prev.reset, "ProvideBlock must still propagate to prev stage");
+    }
+
+    /// Multiple successive `ProvideBlock` signals — one per simulated L1 block
+    /// — must all leave in-progress channels intact.
+    #[tokio::test]
+    async fn test_provide_block_preserves_channels_across_multiple_signals() {
+        let mock = TestNextFrameProvider::new(vec![]);
+        let cfg = Arc::new(RollupConfig::default());
+        let mut channel_bank = ChannelBank::new(cfg, mock);
+        channel_bank.channels.insert([0xAA; 16], Channel::default());
+        channel_bank.channel_queue.push_back([0xAA; 16]);
+        for i in 0u64..5 {
+            channel_bank
+                .signal(Signal::ProvideBlock(BlockInfo { number: i, ..Default::default() }))
+                .await
+                .unwrap();
+            assert_eq!(channel_bank.channels.len(), 1, "channels must survive ProvideBlock #{i}");
+            assert_eq!(
+                channel_bank.channel_queue.len(),
+                1,
+                "channel queue must survive ProvideBlock #{i}"
+            );
+        }
+    }
+
+    /// After some `ProvideBlock` signals (which must preserve channel state), a
+    /// subsequent `Reset` must still clear everything.
+    #[tokio::test]
+    async fn test_reset_after_provide_block_clears_channels() {
+        let mock = TestNextFrameProvider::new(vec![]);
+        let cfg = Arc::new(RollupConfig::default());
+        let mut channel_bank = ChannelBank::new(cfg, mock);
+        channel_bank.channels.insert([0xBB; 16], Channel::default());
+        channel_bank.channel_queue.push_back([0xBB; 16]);
+        // Advance a few L1 blocks — channels must survive.
+        for i in 0u64..3 {
+            channel_bank
+                .signal(Signal::ProvideBlock(BlockInfo { number: i, ..Default::default() }))
+                .await
+                .unwrap();
+        }
+        assert_eq!(channel_bank.channels.len(), 1, "channels must survive ProvideBlock signals");
+        // A Reset (e.g. reorg) must now clear everything.
+        channel_bank.signal(ResetSignal::default().signal()).await.unwrap();
+        assert_eq!(channel_bank.channels.len(), 0, "Reset must clear channels after ProvideBlock");
+        assert_eq!(
+            channel_bank.channel_queue.len(),
+            0,
+            "Reset must clear channel queue after ProvideBlock"
+        );
     }
 
     #[test]

--- a/crates/consensus/protocol/src/batch/type.rs
+++ b/crates/consensus/protocol/src/batch/type.rs
@@ -19,10 +19,11 @@ pub const SINGLE_BATCH_TYPE: u8 = 0x00;
 pub const SPAN_BATCH_TYPE: u8 = 0x01;
 
 /// The Batch Type.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 #[repr(u8)]
 pub enum BatchType {
     /// Single Batch.
+    #[default]
     Single = SINGLE_BATCH_TYPE,
     /// Span Batch.
     Span = SPAN_BATCH_TYPE,


### PR DESCRIPTION
## Summary

This PR addresses several gaps in batcher test coverage and makes a number of correctness improvements to the encoder and derivation pipeline.

On the encoder side, the `BatchType::Span` path was wired up but never actually produced submissions. The fix adds a size-based flush trigger that estimates the compressed size of the accumulated span batch after each block and closes the channel when it reaches the configured size budget, mirroring the approach taken in op-batcher's `SpanChannelOut`. A timeout-based flush path was also added for spans that grow slowly. Two correctness bugs in `close_current_channel` were fixed: previously, a failed `append_singular_batch` would still write a zero-block span batch to the channel, and the blocks were permanently lost because the accumulator was consumed via `std::mem::take` before the loop. Now the accumulator is only cleared after both batch construction and channel write succeed, so blocks are always preserved on any failure path. The size estimation was also made O(1) per step by maintaining a running byte counter instead of re-scanning the entire accumulator on every call.

A bug in the `ChannelBank` derivation stage was fixed where `signal()` was unconditionally clearing the channel map on every signal, including `ProvideBlock`. This caused multi-block channels to be discarded at L1 block boundaries, breaking channel timeout tests. Now only `Reset`, `Activation`, and `FlushChannel` signals clear state.

On the test infrastructure side, the `TestRollupConfigBuilder` was extended with new builder methods and all action tests that were manually constructing or mutating `RollupConfig` values have been updated to use it, removing several duplicated local helper functions. New action tests were added covering span batch end-to-end encoding, blob DA submission, multi-blob packing, calldata DA, DA type switching, DA throttling, large-transaction stress, and sequencer drift scenarios.