### PR TITLE
Avoid panic during TxPool RPC initialization on invalid `sequencer_rpc`

### DIFF
--- a/crates/execution/txpool-rpc/src/extension.rs
+++ b/crates/execution/txpool-rpc/src/extension.rs
@@ -26,8 +26,7 @@ impl BaseNodeExtension for TxPoolRpcExtension {
 
         builder.add_rpc_module(move |ctx: &mut BaseRpcContext<'_>| {
             // Register TransactionStatusApi
-            let status_api = TransactionStatusApiImpl::new(sequencer_rpc, ctx.pool().clone())
-                .expect("Failed to create transaction status API");
+            let status_api = TransactionStatusApiImpl::new(sequencer_rpc.clone(), ctx.pool().clone())?;
             ctx.modules.merge_configured(status_api.into_rpc())?;
 
             // Register AdminTxPoolApi


### PR DESCRIPTION
Replace `expect` with error propagation when initializing `TransactionStatusApiImpl`.

Previously, an invalid `sequencer_rpc` URL could cause a panic during node startup:

    expect("Failed to create transaction status API")

This change propagates the error using `?`, allowing the node to fail gracefully with a proper configuration error instead of panicking.