### PR TITLE
Fix grammar in fault-proof protocol documentation

### DIFF
--- a/docs/specs/pages/protocol/fault-proof/index.md
+++ b/docs/specs/pages/protocol/fault-proof/index.md
@@ -484,7 +484,7 @@ This approach ensures that the fault proof program can complete a state transiti
 amount of time.
 
 During program execution, the precompiles are substituted with interactions with pre-image oracle.
-The program hints the host for a precompile input. Which it the subsequently retrieves the result of the precompile
+The program hints the host for a precompile input. Which then subsequently retrieves the result of the precompile
 operation using the [type 6 global precompile key](#type-6-global-precompile-key).
 All accelerated precompiles must be functionally equivalent to their EVM equivalent.
 


### PR DESCRIPTION
Fix a grammatical error in the fault-proof protocol documentation.

The sentence describing precompile accelerators contained an incorrect word order and an extra "the", which made it read as invalid English. This change corrects the sentence for clarity.