### PR TITLE
chore(actions): auto-register block hashes in L2Sequencer

### DIFF
--- a/actions/harness/src/harness.rs
+++ b/actions/harness/src/harness.rs
@@ -7,7 +7,7 @@ use base_protocol::{BlockInfo, L2BlockInfo};
 use crate::{
     ActionBlobDataSource, ActionDataSource, ActionL1ChainProvider, ActionL2ChainProvider, Batcher,
     BatcherConfig, BlobVerifierPipeline, L1Miner, L1MinerConfig, L2BlockProvider, L2Sequencer,
-    L2Verifier, SharedL1Chain, VerifierPipeline, block_info_from,
+    L2Verifier, SharedBlockHashRegistry, SharedL1Chain, VerifierPipeline, block_info_from,
 };
 
 /// Top-level test harness that owns all actors for a single action test.
@@ -37,12 +37,18 @@ pub struct ActionTestHarness {
     pub l1: L1Miner,
     /// The rollup configuration shared by all actors.
     pub rollup_config: RollupConfig,
+    /// Shared L2 block hashes written by sequencers and read by verifiers.
+    block_hashes: SharedBlockHashRegistry,
 }
 
 impl ActionTestHarness {
     /// Create a harness with the given configurations.
     pub fn new(l1_config: L1MinerConfig, rollup_config: RollupConfig) -> Self {
-        Self { l1: L1Miner::new(l1_config), rollup_config }
+        Self {
+            l1: L1Miner::new(l1_config),
+            rollup_config,
+            block_hashes: SharedBlockHashRegistry::default(),
+        }
     }
 
     /// Mine `n` L1 blocks and return the latest block number after mining.
@@ -122,6 +128,7 @@ impl ActionTestHarness {
         let system_config = self.rollup_config.genesis.system_config.unwrap_or_default();
 
         L2Sequencer::new(genesis_head, l1_chain, self.rollup_config.clone(), system_config)
+            .with_block_hash_registry(self.block_hashes.clone())
     }
 
     /// Create an [`L2Verifier`] wired to the harness's L1 chain.
@@ -176,7 +183,8 @@ impl ActionTestHarness {
             l2_provider,
             safe_head,
             genesis_l1,
-        );
+        )
+        .with_block_hash_registry(self.block_hashes.clone());
 
         (verifier, chain)
     }
@@ -218,7 +226,8 @@ impl ActionTestHarness {
             ActionL2ChainProvider::from_genesis(&self.rollup_config),
             safe_head,
             genesis_l1,
-        );
+        )
+        .with_block_hash_registry(self.block_hashes.clone());
 
         (verifier, chain)
     }

--- a/actions/harness/src/harness.rs
+++ b/actions/harness/src/harness.rs
@@ -7,7 +7,7 @@ use base_protocol::{BlockInfo, L2BlockInfo};
 use crate::{
     ActionBlobDataSource, ActionDataSource, ActionL1ChainProvider, ActionL2ChainProvider, Batcher,
     BatcherConfig, BlobVerifierPipeline, L1Miner, L1MinerConfig, L2BlockProvider, L2Sequencer,
-    L2Verifier, SharedBlockHashRegistry, SharedL1Chain, VerifierPipeline, block_info_from,
+    L2Verifier, SharedL1Chain, VerifierPipeline, block_info_from,
 };
 
 /// Top-level test harness that owns all actors for a single action test.
@@ -37,18 +37,12 @@ pub struct ActionTestHarness {
     pub l1: L1Miner,
     /// The rollup configuration shared by all actors.
     pub rollup_config: RollupConfig,
-    /// Shared L2 block hashes written by sequencers and read by verifiers.
-    block_hashes: SharedBlockHashRegistry,
 }
 
 impl ActionTestHarness {
     /// Create a harness with the given configurations.
     pub fn new(l1_config: L1MinerConfig, rollup_config: RollupConfig) -> Self {
-        Self {
-            l1: L1Miner::new(l1_config),
-            rollup_config,
-            block_hashes: SharedBlockHashRegistry::default(),
-        }
+        Self { l1: L1Miner::new(l1_config), rollup_config }
     }
 
     /// Mine `n` L1 blocks and return the latest block number after mining.
@@ -128,7 +122,6 @@ impl ActionTestHarness {
         let system_config = self.rollup_config.genesis.system_config.unwrap_or_default();
 
         L2Sequencer::new(genesis_head, l1_chain, self.rollup_config.clone(), system_config)
-            .with_block_hash_registry(self.block_hashes.clone())
     }
 
     /// Create an [`L2Verifier`] wired to the harness's L1 chain.
@@ -143,6 +136,23 @@ impl ActionTestHarness {
         self.create_verifier_with_l2_provider(l2_provider)
     }
 
+    /// Create an [`L2Verifier`] explicitly wired to a sequencer's block-hash registry.
+    ///
+    /// This is the normal path for tests that build blocks with [`L2Sequencer`]
+    /// and then derive them with a verifier. The supplied `l1_chain` becomes
+    /// the verifier's shared L1 view and is returned so tests can keep pushing
+    /// newly mined L1 blocks into it.
+    pub fn create_verifier_from_sequencer(
+        &self,
+        sequencer: &L2Sequencer,
+        l1_chain: SharedL1Chain,
+    ) -> (L2Verifier<VerifierPipeline>, SharedL1Chain) {
+        let l2_provider = ActionL2ChainProvider::from_genesis(&self.rollup_config);
+        let (verifier, chain) =
+            self.create_verifier_with_l2_provider_and_chain(l2_provider, l1_chain);
+        (verifier.with_block_hash_registry(sequencer.block_hash_registry()), chain)
+    }
+
     /// Create an [`L2Verifier`] using a caller-supplied [`ActionL2ChainProvider`].
     ///
     /// Use this when the test needs to pre-populate the provider with custom
@@ -154,6 +164,35 @@ impl ActionTestHarness {
         l2_provider: ActionL2ChainProvider,
     ) -> (L2Verifier<VerifierPipeline>, SharedL1Chain) {
         let chain = SharedL1Chain::from_blocks(self.l1.chain().to_vec());
+        self.create_verifier_with_l2_provider_and_chain(l2_provider, chain)
+    }
+
+    /// Create an [`L2Verifier`] wired to blob DA.
+    ///
+    /// Identical to [`create_verifier`] but uses [`ActionBlobDataSource`] so
+    /// the pipeline reads blobs from the L1 chain instead of calldata.
+    ///
+    /// [`create_verifier`]: ActionTestHarness::create_verifier
+    pub fn create_blob_verifier(&self) -> (L2Verifier<BlobVerifierPipeline>, SharedL1Chain) {
+        let chain = SharedL1Chain::from_blocks(self.l1.chain().to_vec());
+        self.create_blob_verifier_with_chain(chain)
+    }
+
+    /// Create a blob verifier explicitly wired to a sequencer's block-hash registry.
+    pub fn create_blob_verifier_from_sequencer(
+        &self,
+        sequencer: &L2Sequencer,
+        l1_chain: SharedL1Chain,
+    ) -> (L2Verifier<BlobVerifierPipeline>, SharedL1Chain) {
+        let (verifier, chain) = self.create_blob_verifier_with_chain(l1_chain);
+        (verifier.with_block_hash_registry(sequencer.block_hash_registry()), chain)
+    }
+
+    fn create_verifier_with_l2_provider_and_chain(
+        &self,
+        l2_provider: ActionL2ChainProvider,
+        chain: SharedL1Chain,
+    ) -> (L2Verifier<VerifierPipeline>, SharedL1Chain) {
         let rollup_config = Arc::new(self.rollup_config.clone());
         let l1_chain_config = Arc::new(L1ChainConfig::default());
 
@@ -175,28 +214,24 @@ impl ActionTestHarness {
             seq_num: 0,
         };
 
-        let verifier = L2Verifier::new(
-            rollup_config,
-            l1_chain_config,
-            l1_provider,
-            dap_source,
-            l2_provider,
-            safe_head,
-            genesis_l1,
+        (
+            L2Verifier::new(
+                rollup_config,
+                l1_chain_config,
+                l1_provider,
+                dap_source,
+                l2_provider,
+                safe_head,
+                genesis_l1,
+            ),
+            chain,
         )
-        .with_block_hash_registry(self.block_hashes.clone());
-
-        (verifier, chain)
     }
 
-    /// Create an [`L2Verifier`] wired to blob DA.
-    ///
-    /// Identical to [`create_verifier`] but uses [`ActionBlobDataSource`] so
-    /// the pipeline reads blobs from the L1 chain instead of calldata.
-    ///
-    /// [`create_verifier`]: ActionTestHarness::create_verifier
-    pub fn create_blob_verifier(&self) -> (L2Verifier<BlobVerifierPipeline>, SharedL1Chain) {
-        let chain = SharedL1Chain::from_blocks(self.l1.chain().to_vec());
+    fn create_blob_verifier_with_chain(
+        &self,
+        chain: SharedL1Chain,
+    ) -> (L2Verifier<BlobVerifierPipeline>, SharedL1Chain) {
         let rollup_config = Arc::new(self.rollup_config.clone());
         let l1_chain_config = Arc::new(L1ChainConfig::default());
 
@@ -218,18 +253,18 @@ impl ActionTestHarness {
             seq_num: 0,
         };
 
-        let verifier = L2Verifier::new_blob(
-            rollup_config,
-            l1_chain_config,
-            l1_provider,
-            dap_source,
-            ActionL2ChainProvider::from_genesis(&self.rollup_config),
-            safe_head,
-            genesis_l1,
+        (
+            L2Verifier::new_blob(
+                rollup_config,
+                l1_chain_config,
+                l1_provider,
+                dap_source,
+                ActionL2ChainProvider::from_genesis(&self.rollup_config),
+                safe_head,
+                genesis_l1,
+            ),
+            chain,
         )
-        .with_block_hash_registry(self.block_hashes.clone());
-
-        (verifier, chain)
     }
 }
 

--- a/actions/harness/src/l2.rs
+++ b/actions/harness/src/l2.rs
@@ -1,4 +1,7 @@
-use std::{collections::VecDeque, sync::Arc};
+use std::{
+    collections::{HashMap, VecDeque},
+    sync::{Arc, Mutex},
+};
 
 use alloy_consensus::{Header, SignableTransaction};
 use alloy_eips::BlockNumHash;
@@ -20,7 +23,7 @@ use revm::{
     state::AccountInfo,
 };
 
-use crate::{L2BlockProvider, SharedBlockHashRegistry, SharedL1Chain};
+use crate::{L2BlockProvider, SharedL1Chain};
 
 /// Hardcoded private key for the test account used across all action tests.
 ///
@@ -91,6 +94,32 @@ impl ActionL2Source {
 impl L2BlockProvider for ActionL2Source {
     fn next_block(&mut self) -> Option<OpBlock> {
         self.blocks.pop_front()
+    }
+}
+
+/// Shared L2 block hashes keyed by block number.
+///
+/// `L2Sequencer` writes into this registry as blocks are built, and
+/// `L2Verifier` reads from the same registry when it applies derived
+/// attributes so the resulting safe-head hash chain matches the sequencer's
+/// sealed headers.
+#[derive(Debug, Clone, Default)]
+pub struct SharedBlockHashRegistry(Arc<Mutex<HashMap<u64, B256>>>);
+
+impl SharedBlockHashRegistry {
+    /// Create an empty shared registry.
+    pub fn new() -> Self {
+        Self(Arc::new(Mutex::new(HashMap::new())))
+    }
+
+    /// Record the hash for an L2 block number.
+    pub fn insert(&self, number: u64, hash: B256) {
+        self.0.lock().expect("block hash registry lock poisoned").insert(number, hash);
+    }
+
+    /// Return the registered hash for an L2 block number.
+    pub fn get(&self, number: u64) -> Option<B256> {
+        self.0.lock().expect("block hash registry lock poisoned").get(&number).copied()
     }
 }
 
@@ -169,14 +198,8 @@ impl L2Sequencer {
             nonce: 0,
             db,
             l1_origin_pin: None,
-            block_hashes: SharedBlockHashRegistry::default(),
+            block_hashes: SharedBlockHashRegistry::new(),
         }
-    }
-
-    /// Replace the sequencer's block-hash registry with a shared instance.
-    pub fn with_block_hash_registry(mut self, block_hashes: SharedBlockHashRegistry) -> Self {
-        self.block_hashes = block_hashes;
-        self
     }
 
     /// Set the number of signed user transactions included per block.
@@ -188,6 +211,11 @@ impl L2Sequencer {
     /// Return the current unsafe L2 head.
     pub const fn head(&self) -> L2BlockInfo {
         self.head
+    }
+
+    /// Return the sequencer's shared block-hash registry.
+    pub fn block_hash_registry(&self) -> SharedBlockHashRegistry {
+        self.block_hashes.clone()
     }
 
     /// Pin the L1 origin to the given block, bypassing automatic epoch advance.

--- a/actions/harness/src/l2.rs
+++ b/actions/harness/src/l2.rs
@@ -20,7 +20,7 @@ use revm::{
     state::AccountInfo,
 };
 
-use crate::{L2BlockProvider, SharedL1Chain};
+use crate::{L2BlockProvider, SharedBlockHashRegistry, SharedL1Chain};
 
 /// Hardcoded private key for the test account used across all action tests.
 ///
@@ -137,6 +137,8 @@ pub struct L2Sequencer {
     /// Optional pinned L1 origin. When set, epoch selection is bypassed and
     /// this block is used as the epoch for every subsequent L2 block built.
     l1_origin_pin: Option<BlockInfo>,
+    /// Shared registry of built L2 block hashes, keyed by block number.
+    block_hashes: SharedBlockHashRegistry,
 }
 
 impl L2Sequencer {
@@ -167,7 +169,14 @@ impl L2Sequencer {
             nonce: 0,
             db,
             l1_origin_pin: None,
+            block_hashes: SharedBlockHashRegistry::default(),
         }
+    }
+
+    /// Replace the sequencer's block-hash registry with a shared instance.
+    pub fn with_block_hash_registry(mut self, block_hashes: SharedBlockHashRegistry) -> Self {
+        self.block_hashes = block_hashes;
+        self
     }
 
     /// Set the number of signed user transactions included per block.
@@ -313,6 +322,7 @@ impl L2Sequencer {
             l1_origin: BlockNumHash { number: epoch_number, hash: epoch_hash },
             seq_num,
         };
+        self.block_hashes.insert(next_number, block_hash);
 
         Ok(block)
     }

--- a/actions/harness/src/lib.rs
+++ b/actions/harness/src/lib.rs
@@ -31,4 +31,6 @@ pub use providers::{
 
 mod verifier;
 pub use base_consensus_derive::StepResult;
-pub use verifier::{BlobVerifierPipeline, L2Verifier, VerifierError, VerifierPipeline};
+pub use verifier::{
+    BlobVerifierPipeline, L2Verifier, SharedBlockHashRegistry, VerifierError, VerifierPipeline,
+};

--- a/actions/harness/src/lib.rs
+++ b/actions/harness/src/lib.rs
@@ -11,7 +11,8 @@ pub use miner::{L1Block, L1Miner, L1MinerConfig, PendingTx, ReorgError, block_in
 
 mod l2;
 pub use l2::{
-    ActionL2Source, L2Sequencer, L2SequencerError, TEST_ACCOUNT_ADDRESS, TEST_ACCOUNT_KEY,
+    ActionL2Source, L2Sequencer, L2SequencerError, SharedBlockHashRegistry, TEST_ACCOUNT_ADDRESS,
+    TEST_ACCOUNT_KEY,
 };
 
 mod harness;
@@ -31,6 +32,4 @@ pub use providers::{
 
 mod verifier;
 pub use base_consensus_derive::StepResult;
-pub use verifier::{
-    BlobVerifierPipeline, L2Verifier, SharedBlockHashRegistry, VerifierError, VerifierPipeline,
-};
+pub use verifier::{BlobVerifierPipeline, L2Verifier, VerifierError, VerifierPipeline};

--- a/actions/harness/src/verifier.rs
+++ b/actions/harness/src/verifier.rs
@@ -1,4 +1,8 @@
-use std::{collections::HashMap, fmt::Debug, sync::Arc};
+use std::{
+    collections::HashMap,
+    fmt::Debug,
+    sync::{Arc, Mutex},
+};
 
 use alloy_eips::BlockNumHash;
 use alloy_primitives::B256;
@@ -37,6 +41,27 @@ pub type BlobVerifierPipeline = base_consensus_derive::DerivationPipeline<
     >,
     ActionL2ChainProvider,
 >;
+
+/// Shared L2 block hashes keyed by block number.
+///
+/// `L2Sequencer` writes into this registry as blocks are built, and
+/// `L2Verifier` reads from the same registry when it applies derived
+/// attributes so the resulting safe-head hash chain matches the sequencer's
+/// sealed headers.
+#[derive(Debug, Clone, Default)]
+pub struct SharedBlockHashRegistry(Arc<Mutex<HashMap<u64, B256>>>);
+
+impl SharedBlockHashRegistry {
+    /// Record the hash for an L2 block number.
+    pub fn insert(&self, number: u64, hash: B256) {
+        self.0.lock().expect("block hash registry lock poisoned").insert(number, hash);
+    }
+
+    /// Return the registered hash for an L2 block number.
+    pub fn get(&self, number: u64) -> Option<B256> {
+        self.0.lock().expect("block hash registry lock poisoned").get(&number).copied()
+    }
+}
 
 /// Errors returned by [`L2Verifier`] action methods.
 #[derive(Debug, thiserror::Error)]
@@ -107,14 +132,6 @@ pub struct L2Verifier<P: Pipeline + SignalReceiver + Debug> {
     /// block is deposit-only (only the L1 info deposit transaction). Counts
     /// greater than 1 include user transactions.
     derived_tx_counts: Vec<(u64, usize)>,
-    /// Block hashes by L2 block number, registered externally from the
-    /// [`L2Sequencer`](crate::L2Sequencer). Used by [`apply_attributes`]
-    /// so the verifier's safe-head hash matches the sequencer's real block
-    /// hash, enabling correct `parent_hash` validation in [`BatchQueue`].
-    ///
-    /// [`apply_attributes`]: L2Verifier::apply_attributes
-    /// [`BatchQueue`]: base_consensus_derive::BatchQueue
-    block_hashes: HashMap<u64, B256>,
     /// User transaction counts per derived L2 block, recorded in [`apply_attributes`].
     ///
     /// Each entry is `(l2_block_number, user_tx_count)`. Deposit-only blocks —
@@ -131,6 +148,15 @@ pub struct L2Verifier<P: Pipeline + SignalReceiver + Debug> {
     ///
     /// [`apply_attributes`]: L2Verifier::apply_attributes
     derived_l1_info_txs: Vec<(u64, L1BlockInfoTx)>,
+    /// Shared block hashes by L2 block number.
+    ///
+    /// When the verifier and sequencer share the same registry, derivation can
+    /// look up the sequencer's real block hash without tests manually calling
+    /// [`register_block_hash`]. Unsafe gossip also writes into this registry.
+    ///
+    /// [`apply_attributes`]: L2Verifier::apply_attributes
+    /// [`BatchQueue`]: base_consensus_derive::BatchQueue
+    block_hashes: SharedBlockHashRegistry,
 }
 
 impl L2Verifier<VerifierPipeline> {
@@ -212,11 +238,17 @@ impl<P: Pipeline + SignalReceiver + Debug + Send> L2Verifier<P> {
             finalized_head: safe_head,
             finalized_l1_number: 0,
             safe_head_history: Vec::new(),
-            block_hashes: HashMap::new(),
             derived_tx_counts: Vec::new(),
             derived_user_tx_counts: Vec::new(),
             derived_l1_info_txs: Vec::new(),
+            block_hashes: SharedBlockHashRegistry::default(),
         }
+    }
+
+    /// Replace the verifier's block-hash registry with a shared instance.
+    pub fn with_block_hash_registry(mut self, block_hashes: SharedBlockHashRegistry) -> Self {
+        self.block_hashes = block_hashes;
+        self
     }
 
     /// Initialize the pipeline by seeding the genesis [`SystemConfig`] and
@@ -573,10 +605,9 @@ impl<P: Pipeline + SignalReceiver + Debug + Send> L2Verifier<P> {
 
     /// Register the block hash for a given L2 block number.
     ///
-    /// Call this after [`L2Sequencer::build_next_block`] to record the real
-    /// block hash. When derivation later applies attributes for this block
-    /// number, the verifier will use the registered hash instead of a default,
-    /// keeping the `parent_hash` chain consistent with the sequencer.
+    /// Most tests no longer need this when the verifier shares a
+    /// [`SharedBlockHashRegistry`] with [`L2Sequencer`], but it remains useful
+    /// as a manual override for blocks produced outside that shared setup.
     ///
     /// [`L2Sequencer::build_next_block`]: crate::L2Sequencer::build_next_block
     pub fn register_block_hash(&mut self, number: u64, hash: B256) {
@@ -689,10 +720,10 @@ impl<P: Pipeline + SignalReceiver + Debug + Send> L2Verifier<P> {
     /// `safe_head.l1_origin.number`, so using the inclusion block here would cause
     /// subsequent same-epoch batches to be rejected as `EpochTooOld`.
     ///
-    /// The block hash is looked up from [`register_block_hash`] entries. When the
-    /// [`L2Sequencer`] produces real sealed headers, the test must register each
-    /// block's hash so the verifier's `parent_hash` chain stays consistent with
-    /// the batches the sequencer submitted.
+    /// The block hash is looked up from the shared registry or any manual
+    /// [`register_block_hash`] entries. When the verifier shares a
+    /// [`SharedBlockHashRegistry`] with [`L2Sequencer`], this happens
+    /// automatically as blocks are built.
     ///
     /// [`register_block_hash`]: L2Verifier::register_block_hash
     /// [`L2Sequencer`]: crate::L2Sequencer
@@ -718,8 +749,8 @@ impl<P: Pipeline + SignalReceiver + Debug + Send> L2Verifier<P> {
         if let Some(l1_info) = self.l1_info_from_attrs(&attrs) {
             self.derived_l1_info_txs.push((new_number, l1_info));
         }
-        let hash = self.block_hashes.get(&new_number).copied().unwrap_or_default();
         let tx_count = attrs.attributes.transactions.as_ref().map_or(0, |v| v.len());
+        let hash = self.block_hashes.get(new_number).unwrap_or_default();
         self.safe_head = L2BlockInfo {
             block_info: BlockInfo {
                 number: new_number,

--- a/actions/harness/src/verifier.rs
+++ b/actions/harness/src/verifier.rs
@@ -1,8 +1,4 @@
-use std::{
-    collections::HashMap,
-    fmt::Debug,
-    sync::{Arc, Mutex},
-};
+use std::{fmt::Debug, sync::Arc};
 
 use alloy_eips::BlockNumHash;
 use alloy_primitives::B256;
@@ -15,7 +11,10 @@ use base_consensus_derive::{
 use base_consensus_genesis::{L1ChainConfig, RollupConfig, SystemConfig};
 use base_protocol::{BlockInfo, L1BlockInfoTx, L2BlockInfo, OpAttributesWithParent};
 
-use crate::{ActionBlobDataSource, ActionDataSource, ActionL1ChainProvider, ActionL2ChainProvider};
+use crate::{
+    ActionBlobDataSource, ActionDataSource, ActionL1ChainProvider, ActionL2ChainProvider,
+    SharedBlockHashRegistry,
+};
 
 /// The concrete pipeline type used by [`L2Verifier`] with calldata DA.
 ///
@@ -41,27 +40,6 @@ pub type BlobVerifierPipeline = base_consensus_derive::DerivationPipeline<
     >,
     ActionL2ChainProvider,
 >;
-
-/// Shared L2 block hashes keyed by block number.
-///
-/// `L2Sequencer` writes into this registry as blocks are built, and
-/// `L2Verifier` reads from the same registry when it applies derived
-/// attributes so the resulting safe-head hash chain matches the sequencer's
-/// sealed headers.
-#[derive(Debug, Clone, Default)]
-pub struct SharedBlockHashRegistry(Arc<Mutex<HashMap<u64, B256>>>);
-
-impl SharedBlockHashRegistry {
-    /// Record the hash for an L2 block number.
-    pub fn insert(&self, number: u64, hash: B256) {
-        self.0.lock().expect("block hash registry lock poisoned").insert(number, hash);
-    }
-
-    /// Return the registered hash for an L2 block number.
-    pub fn get(&self, number: u64) -> Option<B256> {
-        self.0.lock().expect("block hash registry lock poisoned").get(&number).copied()
-    }
-}
 
 /// Errors returned by [`L2Verifier`] action methods.
 #[derive(Debug, thiserror::Error)]
@@ -241,7 +219,7 @@ impl<P: Pipeline + SignalReceiver + Debug + Send> L2Verifier<P> {
             derived_tx_counts: Vec::new(),
             derived_user_tx_counts: Vec::new(),
             derived_l1_info_txs: Vec::new(),
-            block_hashes: SharedBlockHashRegistry::default(),
+            block_hashes: SharedBlockHashRegistry::new(),
         }
     }
 

--- a/actions/harness/tests/batcher_channels.rs
+++ b/actions/harness/tests/batcher_channels.rs
@@ -71,6 +71,7 @@ async fn channel_timeout_triggers_channel_invalidation() {
     let l1_chain = SharedL1Chain::from_blocks(h.l1.chain().to_vec());
     let mut sequencer = h.create_l2_sequencer(l1_chain);
     let block = sequencer.build_next_block().expect("build L2 block 1");
+    let block_hash = sequencer.head().block_info.hash;
 
     let mut source = ActionL2Source::new();
     source.push(block.clone());
@@ -87,6 +88,7 @@ async fn channel_timeout_triggers_channel_invalidation() {
     drop(batcher);
 
     let (mut verifier, chain) = h.create_verifier();
+    verifier.register_block_hash(1, block_hash);
 
     h.mine_and_push(&chain); // L1 block 1: frame 0 only
 
@@ -178,6 +180,7 @@ async fn channel_timeout_recovery_resubmits_successfully() {
     let l1_chain = SharedL1Chain::from_blocks(h.l1.chain().to_vec());
     let mut sequencer = h.create_l2_sequencer(l1_chain);
     let block = sequencer.build_next_block().expect("build block 1");
+    let block_hash = sequencer.head().block_info.hash;
 
     // First attempt: submit batch in L1 block 1.
     let mut source = ActionL2Source::new();
@@ -187,6 +190,7 @@ async fn channel_timeout_recovery_resubmits_successfully() {
     drop(batcher);
 
     let (mut verifier, chain) = h.create_verifier();
+    verifier.register_block_hash(1, block_hash);
 
     h.mine_and_push(&chain); // L1 block 1
 
@@ -342,7 +346,10 @@ async fn interleaved_channels_correctly_reassembled() {
     // Mine one L1 block containing all interleaved frames.
     h.l1.mine_block();
 
-    let (mut verifier, _chain) = h.create_verifier();
+    let (mut verifier, _chain) = h.create_verifier_from_sequencer(
+        &sequencer,
+        SharedL1Chain::from_blocks(h.l1.chain().to_vec()),
+    );
     verifier.initialize().await.expect("initialize");
 
     let l1_block_1 = block_info_from(h.l1.block_by_number(1).expect("block 1"));

--- a/actions/harness/tests/batcher_channels.rs
+++ b/actions/harness/tests/batcher_channels.rs
@@ -71,7 +71,6 @@ async fn channel_timeout_triggers_channel_invalidation() {
     let l1_chain = SharedL1Chain::from_blocks(h.l1.chain().to_vec());
     let mut sequencer = h.create_l2_sequencer(l1_chain);
     let block = sequencer.build_next_block().expect("build L2 block 1");
-    let hash1 = sequencer.head().block_info.hash;
 
     let mut source = ActionL2Source::new();
     source.push(block.clone());
@@ -88,7 +87,6 @@ async fn channel_timeout_triggers_channel_invalidation() {
     drop(batcher);
 
     let (mut verifier, chain) = h.create_verifier();
-    verifier.register_block_hash(1, hash1);
 
     h.mine_and_push(&chain); // L1 block 1: frame 0 only
 
@@ -180,7 +178,6 @@ async fn channel_timeout_recovery_resubmits_successfully() {
     let l1_chain = SharedL1Chain::from_blocks(h.l1.chain().to_vec());
     let mut sequencer = h.create_l2_sequencer(l1_chain);
     let block = sequencer.build_next_block().expect("build block 1");
-    let hash1 = sequencer.head().block_info.hash;
 
     // First attempt: submit batch in L1 block 1.
     let mut source = ActionL2Source::new();
@@ -190,7 +187,6 @@ async fn channel_timeout_recovery_resubmits_successfully() {
     drop(batcher);
 
     let (mut verifier, chain) = h.create_verifier();
-    verifier.register_block_hash(1, hash1);
 
     h.mine_and_push(&chain); // L1 block 1
 
@@ -302,9 +298,7 @@ async fn interleaved_channels_correctly_reassembled() {
 
     // Build 2 L2 blocks — one for each channel.
     let block_a = sequencer.build_next_block().expect("build block A");
-    let hash_a = sequencer.head().block_info.hash;
     let block_b = sequencer.build_next_block().expect("build block B");
-    let hash_b = sequencer.head().block_info.hash;
 
     // Encode channel A (L2 block 1).
     let mut source_a = ActionL2Source::new();
@@ -349,8 +343,6 @@ async fn interleaved_channels_correctly_reassembled() {
     h.l1.mine_block();
 
     let (mut verifier, _chain) = h.create_verifier();
-    verifier.register_block_hash(1, hash_a);
-    verifier.register_block_hash(2, hash_b);
     verifier.initialize().await.expect("initialize");
 
     let l1_block_1 = block_info_from(h.l1.block_by_number(1).expect("block 1"));

--- a/actions/harness/tests/batcher_sequencer_drift.rs
+++ b/actions/harness/tests/batcher_sequencer_drift.rs
@@ -1,6 +1,5 @@
 #![doc = "TDD action test skeletons for sequencer drift scenarios."]
 
-use alloy_primitives::B256;
 use base_action_harness::{
     ActionL2Source, ActionTestHarness, BatcherConfig, L1MinerConfig, SharedL1Chain,
     TestRollupConfigBuilder, block_info_from,
@@ -67,13 +66,10 @@ async fn sequencer_drift_produces_deposit_only_blocks() {
     // Blocks 1-6 have user transactions. Blocks 7-8 also have user txs
     // (sequencer doesn't enforce drift), but the pipeline should drop them.
     let (mut verifier, chain) = h.create_verifier();
-    let mut block_hashes: Vec<(u64, B256)> = Vec::new();
 
-    for i in 1u64..=8 {
+    for _ in 1u64..=8 {
         // Build with user transactions — the pipeline decides what to accept.
         let block = sequencer.build_next_block().expect("build L2 block");
-        let hash = sequencer.head().block_info.hash;
-        block_hashes.push((i, hash));
 
         // Submit each block as a separate batch in its own L1 block.
         let mut source = ActionL2Source::new();
@@ -84,9 +80,6 @@ async fn sequencer_drift_produces_deposit_only_blocks() {
         h.mine_and_push(&chain);
     }
 
-    for (number, hash) in &block_hashes {
-        verifier.register_block_hash(*number, *hash);
-    }
     verifier.initialize().await.expect("initialize");
 
     // Drive derivation through all L1 blocks.
@@ -149,14 +142,11 @@ async fn sequencer_drift_forced_empty_blocks_accepted() {
     sequencer.pin_l1_origin(l1_genesis);
 
     let (mut verifier, chain) = h.create_verifier();
-    let mut block_hashes: Vec<(u64, B256)> = Vec::new();
 
     // Build 6 normal blocks (within drift, ts=300..1800) + 2 empty blocks
     // (over drift, ts=2100, 2400). block_time=300 s, max_drift=1800 s.
-    for i in 1u64..=6 {
+    for _ in 1u64..=6 {
         let block = sequencer.build_next_block().expect("build normal block");
-        let hash = sequencer.head().block_info.hash;
-        block_hashes.push((i, hash));
 
         let mut source = ActionL2Source::new();
         source.push(block);
@@ -167,10 +157,8 @@ async fn sequencer_drift_forced_empty_blocks_accepted() {
     }
 
     // Build empty blocks past the drift boundary.
-    for i in 7u64..=8 {
+    for _ in 7u64..=8 {
         let block = sequencer.build_empty_block().expect("build empty block");
-        let hash = sequencer.head().block_info.hash;
-        block_hashes.push((i, hash));
 
         // The empty block has only the deposit tx — the batcher encodes it
         // but the pipeline will drop it (stale epoch) and produce a default block.
@@ -182,9 +170,6 @@ async fn sequencer_drift_forced_empty_blocks_accepted() {
         h.mine_and_push(&chain);
     }
 
-    for (number, hash) in &block_hashes {
-        verifier.register_block_hash(*number, *hash);
-    }
     verifier.initialize().await.expect("initialize");
 
     let mut total_derived = 0;

--- a/actions/harness/tests/batcher_sequencer_drift.rs
+++ b/actions/harness/tests/batcher_sequencer_drift.rs
@@ -65,7 +65,10 @@ async fn sequencer_drift_produces_deposit_only_blocks() {
     //
     // Blocks 1-6 have user transactions. Blocks 7-8 also have user txs
     // (sequencer doesn't enforce drift), but the pipeline should drop them.
-    let (mut verifier, chain) = h.create_verifier();
+    let (mut verifier, chain) = h.create_verifier_from_sequencer(
+        &sequencer,
+        SharedL1Chain::from_blocks(h.l1.chain().to_vec()),
+    );
 
     for _ in 1u64..=8 {
         // Build with user transactions — the pipeline decides what to accept.
@@ -141,7 +144,10 @@ async fn sequencer_drift_forced_empty_blocks_accepted() {
     let l1_genesis = block_info_from(h.l1.block_by_number(0).expect("genesis"));
     sequencer.pin_l1_origin(l1_genesis);
 
-    let (mut verifier, chain) = h.create_verifier();
+    let (mut verifier, chain) = h.create_verifier_from_sequencer(
+        &sequencer,
+        SharedL1Chain::from_blocks(h.l1.chain().to_vec()),
+    );
 
     // Build 6 normal blocks (within drift, ts=300..1800) + 2 empty blocks
     // (over drift, ts=2100, 2400). block_time=300 s, max_drift=1800 s.

--- a/actions/harness/tests/derivation.rs
+++ b/actions/harness/tests/derivation.rs
@@ -7,7 +7,8 @@ use alloy_primitives::{Address, B256, Bytes, LogData, U256};
 use base_action_harness::{
     ActionDataSource, ActionL1ChainProvider, ActionL2ChainProvider, ActionL2Source,
     ActionTestHarness, BatchType, BatcherConfig, GarbageKind, L1MinerConfig, L2Sequencer,
-    L2Verifier, PendingTx, SharedL1Chain, StepResult, TestRollupConfigBuilder, block_info_from,
+    L2Verifier, PendingTx, SharedBlockHashRegistry, SharedL1Chain, StepResult,
+    TestRollupConfigBuilder, block_info_from,
 };
 use base_blobs::BlobEncoder;
 use base_consensus_genesis::{
@@ -80,14 +81,9 @@ async fn multiple_l1_blocks_each_derive_one_l2_block() {
     let l1_chain = SharedL1Chain::from_blocks(h.l1.chain().to_vec());
     let mut builder = h.create_l2_sequencer(l1_chain);
 
-    // Track block hashes so the verifier's safe-head hash stays consistent
-    // with the builder's real sealed headers.
-    let mut block_hashes = Vec::new();
     for _ in 1..=L2_BLOCK_COUNT {
         let mut source = ActionL2Source::new();
         source.push(builder.build_next_block().expect("build block"));
-        let head = builder.head();
-        block_hashes.push((head.block_info.number, head.block_info.hash));
 
         let mut batcher = h.create_batcher(source, batcher_cfg.clone());
         batcher.advance().expect("batcher advance");
@@ -96,9 +92,6 @@ async fn multiple_l1_blocks_each_derive_one_l2_block() {
     }
 
     let (mut verifier, _chain) = h.create_verifier();
-    for (number, hash) in &block_hashes {
-        verifier.register_block_hash(*number, *hash);
-    }
     verifier.initialize().await.expect("initialize should succeed");
 
     // Drive derivation one L1 block at a time.
@@ -380,9 +373,7 @@ async fn reorg_flip_flop_empty_middle_fork() {
     let l1_chain = SharedL1Chain::from_blocks(h.l1.chain().to_vec());
     let mut builder = h.create_l2_sequencer(l1_chain);
     let block1 = builder.build_next_block().expect("build block 1");
-    let block1_hash = builder.head().block_info.hash;
     let block2 = builder.build_next_block().expect("build block 2");
-    let block2_hash = builder.head().block_info.hash;
 
     // Shared reset targets — valid across all forks because genesis is immutable.
     let l1_genesis = block_info_from(h.l1.chain().first().expect("genesis always present"));
@@ -400,8 +391,6 @@ async fn reorg_flip_flop_empty_middle_fork() {
     }
 
     let (mut verifier, chain) = h.create_verifier();
-    verifier.register_block_hash(1, block1_hash);
-    verifier.register_block_hash(2, block2_hash);
     verifier.initialize().await.expect("initialize");
 
     for i in 1u64..=2 {
@@ -735,11 +724,8 @@ async fn batcher_key_rotation_accepts_new_batcher() {
     let l1_chain = SharedL1Chain::from_blocks(h.l1.chain().to_vec());
     let mut builder = h.create_l2_sequencer(l1_chain);
     let block1 = builder.build_next_block().expect("build block 1");
-    let hash1 = builder.head().block_info.hash;
     let block2 = builder.build_next_block().expect("build block 2");
-    let hash2 = builder.head().block_info.hash;
     let block3 = builder.build_next_block().expect("build block 3");
-    let hash3 = builder.head().block_info.hash;
 
     // --- L1 blocks 1-2: batcher A submits → L2 blocks 1-2 derived. ---
     for block in [block1, block2] {
@@ -758,9 +744,6 @@ async fn batcher_key_rotation_accepts_new_batcher() {
     h.l1.mine_block(); // block 3: rotation receipt, no batcher tx
 
     let (mut verifier, chain) = h.create_verifier();
-    verifier.register_block_hash(1, hash1);
-    verifier.register_block_hash(2, hash2);
-    verifier.register_block_hash(3, hash3);
     verifier.initialize().await.expect("initialize");
 
     // Drive derivation through blocks 1-2 (batcher A frames derived).
@@ -824,10 +807,8 @@ async fn multi_l2_per_l1_epoch() {
 
     let (mut verifier, chain) = h.create_verifier();
 
-    for i in 1..=L2_COUNT {
+    for _ in 1..=L2_COUNT {
         let block = builder.build_next_block().expect("build L2 block");
-        let hash = builder.head().block_info.hash;
-        verifier.register_block_hash(i, hash);
 
         let mut source = ActionL2Source::new();
         source.push(block);
@@ -947,11 +928,8 @@ async fn multi_epoch_sequence() {
     let mut builder = h.create_l2_sequencer(l1_chain);
 
     let mut blocks = Vec::new();
-    let mut block_hashes = Vec::new();
     for _ in 0..12 {
         let block = builder.build_next_block().expect("build L2 block");
-        let head = builder.head();
-        block_hashes.push((head.block_info.number, head.block_info.hash));
         blocks.push(block);
     }
 
@@ -959,11 +937,8 @@ async fn multi_epoch_sequence() {
     // L2 block 6 (index 5) should be the first block in epoch 1.
     assert_eq!(builder.head().l1_origin.number, 2, "L2 block 12 should reference epoch 2");
 
-    // Create verifier and register all block hashes.
+    // Create verifier after the sequencer has populated the shared block-hash registry.
     let (mut verifier, chain) = h.create_verifier();
-    for (number, hash) in &block_hashes {
-        verifier.register_block_hash(*number, *hash);
-    }
 
     // Batch each L2 block into a separate L1 inclusion block.
     for block in &blocks {
@@ -1006,11 +981,8 @@ async fn same_epoch_multi_batch_one_l1_block() {
     let mut builder = h.create_l2_sequencer(l1_chain);
 
     let mut source = ActionL2Source::new();
-    let mut block_hashes = Vec::new();
     for _ in 1..=3u64 {
         let block = builder.build_next_block().expect("build");
-        let head = builder.head();
-        block_hashes.push((head.block_info.number, head.block_info.hash));
         source.push(block);
     }
 
@@ -1024,9 +996,6 @@ async fn same_epoch_multi_batch_one_l1_block() {
 
     // Create verifier after mining so the snapshot includes the inclusion block.
     let (mut verifier, _chain) = h.create_verifier();
-    for (number, hash) in &block_hashes {
-        verifier.register_block_hash(*number, *hash);
-    }
     verifier.initialize().await.expect("initialize");
 
     let l1_block_1 = block_info_from(h.l1.block_by_number(1).expect("block 1"));
@@ -1055,11 +1024,8 @@ async fn deep_reorg_multi_block() {
 
     // Build 5 L2 blocks.
     let mut blocks = Vec::new();
-    let mut block_hashes = Vec::new();
     for _ in 0..5 {
         let block = builder.build_next_block().expect("build");
-        let head = builder.head();
-        block_hashes.push((head.block_info.number, head.block_info.hash));
         blocks.push(block);
     }
 
@@ -1075,9 +1041,6 @@ async fn deep_reorg_multi_block() {
 
     // Create verifier with all 5 L1 inclusion blocks visible.
     let (mut verifier, chain) = h.create_verifier();
-    for (number, hash) in &block_hashes {
-        verifier.register_block_hash(*number, *hash);
-    }
     verifier.initialize().await.expect("initialize");
 
     for i in 1..=5u64 {
@@ -1135,11 +1098,9 @@ async fn garbage_frame_data_ignored() {
     let mut builder = h.create_l2_sequencer(l1_chain);
     let mut source = ActionL2Source::new();
     let block = builder.build_next_block().expect("build L2 block 1");
-    let hash1 = builder.head().block_info.hash;
     source.push(block);
 
     let (mut verifier, chain) = h.create_verifier();
-    verifier.register_block_hash(1, hash1);
     verifier.initialize().await.expect("initialize");
 
     // Submit a garbage batcher tx: valid derivation version prefix + random bytes.
@@ -1202,11 +1163,9 @@ async fn multi_frame_channel_reassembled() {
     let mut builder = h.create_l2_sequencer(l1_chain);
     let mut source = ActionL2Source::new();
     let block = builder.build_next_block().expect("build L2 block 1");
-    let hash1 = builder.head().block_info.hash;
     source.push(block);
 
     let (mut verifier, chain) = h.create_verifier();
-    verifier.register_block_hash(1, hash1);
 
     // Encode the L2 block. With max_frame_size=80, the compressed channel data
     // should spill across multiple frames.
@@ -1260,7 +1219,6 @@ async fn single_l2_block_derived_from_span_batch() {
     let mut sequencer = h.create_l2_sequencer(l1_chain);
     let mut source = ActionL2Source::new();
     let block = sequencer.build_next_block().expect("build L2 block 1");
-    let hash1 = sequencer.head().block_info.hash;
     source.push(block);
 
     let mut batcher = h.create_batcher(source, batcher_cfg);
@@ -1270,7 +1228,6 @@ async fn single_l2_block_derived_from_span_batch() {
     h.l1.mine_block();
 
     let (mut verifier, _chain) = h.create_verifier();
-    verifier.register_block_hash(1, hash1);
     verifier.initialize().await.expect("initialize");
 
     let l1_block_1 = block_info_from(h.l1.tip());
@@ -1296,11 +1253,8 @@ async fn three_l2_blocks_derived_from_span_batch() {
     let mut sequencer = h.create_l2_sequencer(l1_chain);
 
     let mut source = ActionL2Source::new();
-    let mut block_hashes: Vec<(u64, B256)> = Vec::new();
-    for i in 1..=3u64 {
+    for _ in 1..=3u64 {
         let block = sequencer.build_next_block().expect("build L2 block");
-        let hash = sequencer.head().block_info.hash;
-        block_hashes.push((i, hash));
         source.push(block);
     }
 
@@ -1311,9 +1265,6 @@ async fn three_l2_blocks_derived_from_span_batch() {
     h.l1.mine_block();
 
     let (mut verifier, _chain) = h.create_verifier();
-    for (n, hash) in &block_hashes {
-        verifier.register_block_hash(*n, *hash);
-    }
     verifier.initialize().await.expect("initialize");
 
     let l1_block_1 = block_info_from(h.l1.tip());
@@ -1405,9 +1356,7 @@ async fn gpo_params_change_does_not_disrupt_derivation() {
     let l1_chain = SharedL1Chain::from_blocks(h.l1.chain().to_vec());
     let mut sequencer = h.create_l2_sequencer(l1_chain);
     let block1 = sequencer.build_next_block().expect("build block 1");
-    let hash1 = sequencer.head().block_info.hash;
     let block2 = sequencer.build_next_block().expect("build block 2");
-    let hash2 = sequencer.head().block_info.hash;
 
     // L1 block 1: batch for L2 block 1.
     let mut source = ActionL2Source::new();
@@ -1430,8 +1379,6 @@ async fn gpo_params_change_does_not_disrupt_derivation() {
     h.l1.mine_block();
 
     let (mut verifier, _chain) = h.create_verifier();
-    verifier.register_block_hash(1, hash1);
-    verifier.register_block_hash(2, hash2);
     verifier.initialize().await.expect("initialize");
 
     for i in 1u64..=3 {
@@ -1467,9 +1414,7 @@ async fn gas_limit_change_does_not_disrupt_derivation() {
     let l1_chain = SharedL1Chain::from_blocks(h.l1.chain().to_vec());
     let mut sequencer = h.create_l2_sequencer(l1_chain);
     let block1 = sequencer.build_next_block().expect("build block 1");
-    let hash1 = sequencer.head().block_info.hash;
     let block2 = sequencer.build_next_block().expect("build block 2");
-    let hash2 = sequencer.head().block_info.hash;
 
     // L1 block 1: batch for L2 block 1.
     let mut source = ActionL2Source::new();
@@ -1492,8 +1437,6 @@ async fn gas_limit_change_does_not_disrupt_derivation() {
     h.l1.mine_block();
 
     let (mut verifier, _chain) = h.create_verifier();
-    verifier.register_block_hash(1, hash1);
-    verifier.register_block_hash(2, hash2);
     verifier.initialize().await.expect("initialize");
 
     for i in 1u64..=3 {
@@ -1525,7 +1468,6 @@ async fn garbage_kind_silently_ignored_then_valid_batch_derived(kind: GarbageKin
     let l1_chain = SharedL1Chain::from_blocks(h.l1.chain().to_vec());
     let mut sequencer = h.create_l2_sequencer(l1_chain);
     let block = sequencer.build_next_block().expect("build L2 block 1");
-    let hash1 = sequencer.head().block_info.hash;
 
     // L1 block 1: garbage frame only.
     let source_empty = ActionL2Source::new();
@@ -1543,7 +1485,6 @@ async fn garbage_kind_silently_ignored_then_valid_batch_derived(kind: GarbageKin
     h.l1.mine_block();
 
     let (mut verifier, _chain) = h.create_verifier();
-    verifier.register_block_hash(1, hash1);
     verifier.initialize().await.expect("initialize");
 
     // Block 1: garbage — must not advance the safe head.
@@ -1606,9 +1547,7 @@ async fn l2_finalized_advances_via_l1_finalized_signal() {
     let mut sequencer = h.create_l2_sequencer(l1_chain);
 
     let block1 = sequencer.build_next_block().expect("build block 1");
-    let hash1 = sequencer.head().block_info.hash;
     let block2 = sequencer.build_next_block().expect("build block 2");
-    let hash2 = sequencer.head().block_info.hash;
 
     for block in [block1, block2] {
         let mut source = ActionL2Source::new();
@@ -1620,8 +1559,6 @@ async fn l2_finalized_advances_via_l1_finalized_signal() {
     }
 
     let (mut verifier, _chain) = h.create_verifier();
-    verifier.register_block_hash(1, hash1);
-    verifier.register_block_hash(2, hash2);
     verifier.initialize().await.expect("initialize");
 
     // Finalized head starts at L2 genesis.
@@ -1753,15 +1690,14 @@ async fn derive_chain_from_near_l1_genesis() {
     // Build an L2Sequencer starting from this custom genesis (epoch 5).
     let l1_chain_snap = SharedL1Chain::from_blocks(h.l1.chain().to_vec());
     let system_config = rollup_cfg.genesis.system_config.unwrap_or_default();
+    let block_hashes = SharedBlockHashRegistry::default();
     let mut sequencer =
-        L2Sequencer::new(genesis_head, l1_chain_snap, rollup_cfg.clone(), system_config);
+        L2Sequencer::new(genesis_head, l1_chain_snap, rollup_cfg.clone(), system_config)
+            .with_block_hash_registry(block_hashes.clone());
 
     // Build 2 L2 blocks and batch them into L1 blocks #6 and #7.
-    let mut block_hashes: Vec<(u64, B256)> = Vec::new();
-    for i in 1..=2u64 {
+    for _ in 1..=2u64 {
         let block = sequencer.build_next_block().expect("build L2 block");
-        let hash = sequencer.head().block_info.hash;
-        block_hashes.push((i, hash));
         // With block_time=2 and L1 block 6 at ts=72, L2 block ts < 72
         // so the epoch stays at 5.
         assert_eq!(sequencer.head().l1_origin.number, 5, "epoch should stay at 5");
@@ -1790,11 +1726,8 @@ async fn derive_chain_from_near_l1_genesis() {
         l2_provider,
         genesis_head,
         l1_genesis_info,
-    );
-
-    for (n, hash) in &block_hashes {
-        verifier.register_block_hash(*n, *hash);
-    }
+    )
+    .with_block_hash_registry(block_hashes);
     verifier.initialize().await.expect("initialize");
 
     // Signal L1 blocks #6 and #7, each containing one batch.
@@ -1869,11 +1802,8 @@ async fn multiple_l2_blocks_derived_from_blob() {
     let mut builder = h.create_l2_sequencer(l1_chain);
 
     let mut all_source = ActionL2Source::new();
-    let mut block_hashes = Vec::new();
     for _ in 1..=L2_BLOCK_COUNT {
         all_source.push(builder.build_next_block().expect("build block"));
-        let head = builder.head();
-        block_hashes.push((head.block_info.number, head.block_info.hash));
     }
 
     // Encode all 3 blocks into a single channel and get the frames.
@@ -1894,9 +1824,6 @@ async fn multiple_l2_blocks_derived_from_blob() {
 
     // Create the blob verifier.
     let (mut verifier, _chain) = h.create_blob_verifier();
-    for (number, hash) in &block_hashes {
-        verifier.register_block_hash(*number, *hash);
-    }
     let l1_block_1 = block_info_from(h.l1.tip());
 
     verifier.initialize().await.expect("initialize should succeed");
@@ -1948,11 +1875,8 @@ async fn batcher_config_update_rolled_back_on_reorg() {
     let l1_chain = SharedL1Chain::from_blocks(h.l1.chain().to_vec());
     let mut builder = h.create_l2_sequencer(l1_chain);
     let block1 = builder.build_next_block().expect("build block 1");
-    let hash1 = builder.head().block_info.hash;
     let block2 = builder.build_next_block().expect("build block 2");
-    let hash2 = builder.head().block_info.hash;
     let block3 = builder.build_next_block().expect("build block 3");
-    let hash3 = builder.head().block_info.hash;
 
     // Clone blocks for resubmission on the new fork after reorg.
     let block1_clone = block1.clone();
@@ -1974,9 +1898,6 @@ async fn batcher_config_update_rolled_back_on_reorg() {
 
     // Create verifier after all pre-reorg L1 blocks are mined.
     let (mut verifier, chain) = h.create_verifier();
-    verifier.register_block_hash(1, hash1);
-    verifier.register_block_hash(2, hash2);
-    verifier.register_block_hash(3, hash3);
     verifier.initialize().await.expect("initialize");
 
     // Drive derivation through L1 blocks 1-2.
@@ -2076,13 +1997,9 @@ async fn out_of_order_singular_batches_reordered_by_batch_queue() {
 
     // Build 2 L2 blocks in epoch 0 (both reference L1 genesis as L1 origin).
     let block1 = builder.build_next_block().expect("build L2 block 1");
-    let hash1 = builder.head().block_info.hash;
     let block2 = builder.build_next_block().expect("build L2 block 2");
-    let hash2 = builder.head().block_info.hash;
 
     let (mut verifier, chain) = h.create_verifier();
-    verifier.register_block_hash(1, hash1);
-    verifier.register_block_hash(2, hash2);
 
     // L1 block 1: carry the batch for L2 block 2 (submitted out of order).
     {
@@ -2168,7 +2085,6 @@ async fn pipeline_idle_before_l1_signal_derives_after() {
     let l1_chain = SharedL1Chain::from_blocks(h.l1.chain().to_vec());
     let mut builder = h.create_l2_sequencer(l1_chain);
     let block1 = builder.build_next_block().expect("build L2 block 1");
-    let hash1 = builder.head().block_info.hash;
 
     let mut source = ActionL2Source::new();
     source.push(block1);
@@ -2177,7 +2093,6 @@ async fn pipeline_idle_before_l1_signal_derives_after() {
     drop(batcher);
 
     let (mut verifier, chain) = h.create_verifier();
-    verifier.register_block_hash(1, hash1);
     h.mine_and_push(&chain);
     verifier.initialize().await.expect("initialize");
 
@@ -2231,9 +2146,7 @@ async fn pipeline_l1_origin_advance_observable_after_epoch_exhausted() {
     // Build 2 L2 blocks and submit them in a single L1 channel (same L1 block).
     let mut source = ActionL2Source::new();
     let block1 = builder.build_next_block().expect("build L2 block 1");
-    let hash1 = builder.head().block_info.hash;
     let block2 = builder.build_next_block().expect("build L2 block 2");
-    let hash2 = builder.head().block_info.hash;
     source.push(block1);
     source.push(block2);
 
@@ -2242,8 +2155,6 @@ async fn pipeline_l1_origin_advance_observable_after_epoch_exhausted() {
     drop(batcher);
 
     let (mut verifier, chain) = h.create_verifier();
-    verifier.register_block_hash(1, hash1);
-    verifier.register_block_hash(2, hash2);
 
     h.mine_and_push(&chain); // L1 block 1: carries the channel for blocks 1 & 2
     h.mine_and_push(&chain); // L1 block 2: empty — used only for origin advance

--- a/actions/harness/tests/derivation.rs
+++ b/actions/harness/tests/derivation.rs
@@ -7,8 +7,7 @@ use alloy_primitives::{Address, B256, Bytes, LogData, U256};
 use base_action_harness::{
     ActionDataSource, ActionL1ChainProvider, ActionL2ChainProvider, ActionL2Source,
     ActionTestHarness, BatchType, BatcherConfig, GarbageKind, L1MinerConfig, L2Sequencer,
-    L2Verifier, PendingTx, SharedBlockHashRegistry, SharedL1Chain, StepResult,
-    TestRollupConfigBuilder, block_info_from,
+    L2Verifier, PendingTx, SharedL1Chain, StepResult, TestRollupConfigBuilder, block_info_from,
 };
 use base_blobs::BlobEncoder;
 use base_consensus_genesis::{
@@ -43,7 +42,10 @@ async fn single_l2_block_derived_from_batcher_frame() {
 
     // Create the verifier AFTER mining so the SharedL1Chain snapshot already
     // contains both genesis and block 1.
-    let (mut verifier, _chain) = h.create_verifier();
+    let (mut verifier, _chain) = h.create_verifier_from_sequencer(
+        &builder,
+        SharedL1Chain::from_blocks(h.l1.chain().to_vec()),
+    );
     let l1_block_1 = block_info_from(h.l1.tip());
 
     // Seed the genesis SystemConfig (batcher address) and drain the empty
@@ -91,7 +93,10 @@ async fn multiple_l1_blocks_each_derive_one_l2_block() {
         h.l1.mine_block();
     }
 
-    let (mut verifier, _chain) = h.create_verifier();
+    let (mut verifier, _chain) = h.create_verifier_from_sequencer(
+        &builder,
+        SharedL1Chain::from_blocks(h.l1.chain().to_vec()),
+    );
     verifier.initialize().await.expect("initialize should succeed");
 
     // Drive derivation one L1 block at a time.
@@ -133,7 +138,10 @@ async fn batch_in_orphaned_l1_block_is_not_derived() {
 
     // The verifier is created from the miner's current (post-reorg) state, so
     // the orphaned block 1 is not present in the SharedL1Chain snapshot.
-    let (mut verifier, _chain) = h.create_verifier();
+    let (mut verifier, _chain) = h.create_verifier_from_sequencer(
+        &builder,
+        SharedL1Chain::from_blocks(h.l1.chain().to_vec()),
+    );
 
     verifier.initialize().await.expect("initialize");
     verifier.act_l1_head_signal(l1_block_1_prime).await.expect("signal block 1'");
@@ -165,7 +173,10 @@ async fn reorg_reverts_derived_safe_head() {
     h.l1.mine_block();
 
     // Create the verifier and derive L2 block 1.
-    let (mut verifier, chain) = h.create_verifier();
+    let (mut verifier, chain) = h.create_verifier_from_sequencer(
+        &builder,
+        SharedL1Chain::from_blocks(h.l1.chain().to_vec()),
+    );
     let l1_block_1 = block_info_from(h.l1.tip());
 
     verifier.initialize().await.expect("initialize");
@@ -221,7 +232,10 @@ async fn reorg_and_resubmit_rederives_l2_block() {
     drop(batcher);
     h.l1.mine_block();
 
-    let (mut verifier, chain) = h.create_verifier();
+    let (mut verifier, chain) = h.create_verifier_from_sequencer(
+        &builder,
+        SharedL1Chain::from_blocks(h.l1.chain().to_vec()),
+    );
     verifier.initialize().await.expect("initialize");
     verifier.act_l1_head_signal(block_info_from(h.l1.tip())).await.expect("signal block 1");
     let derived = verifier.act_l2_pipeline_full().await.expect("step");
@@ -283,7 +297,8 @@ async fn reorg_flip_flop() {
     // Build L2 block 1 once; we re-use (clone) it across all forks since the
     // epoch info is the same (all forks reference L1 genesis as epoch 0).
     let l1_chain = SharedL1Chain::from_blocks(h.l1.chain().to_vec());
-    let block1 = h.create_l2_sequencer(l1_chain).build_next_block().expect("build block 1");
+    let mut sequencer = h.create_l2_sequencer(l1_chain);
+    let block1 = sequencer.build_next_block().expect("build block 1");
 
     // Shared reset helpers — computed once, valid across all forks because
     // genesis is immutable.
@@ -299,7 +314,10 @@ async fn reorg_flip_flop() {
     drop(batcher);
     h.l1.mine_block(); // A1
 
-    let (mut verifier, chain) = h.create_verifier();
+    let (mut verifier, chain) = h.create_verifier_from_sequencer(
+        &sequencer,
+        SharedL1Chain::from_blocks(h.l1.chain().to_vec()),
+    );
     verifier.initialize().await.expect("initialize");
     verifier.act_l1_head_signal(block_info_from(h.l1.tip())).await.expect("signal A1");
     let derived = verifier.act_l2_pipeline_full().await.expect("step A");
@@ -390,7 +408,10 @@ async fn reorg_flip_flop_empty_middle_fork() {
         h.l1.mine_block();
     }
 
-    let (mut verifier, chain) = h.create_verifier();
+    let (mut verifier, chain) = h.create_verifier_from_sequencer(
+        &builder,
+        SharedL1Chain::from_blocks(h.l1.chain().to_vec()),
+    );
     verifier.initialize().await.expect("initialize");
 
     for i in 1u64..=2 {
@@ -507,7 +528,10 @@ async fn batch_accepted_at_last_seq_window_block() {
     drop(batcher);
     h.l1.mine_block(); // block 3
 
-    let (mut verifier, _chain) = h.create_verifier();
+    let (mut verifier, _chain) = h.create_verifier_from_sequencer(
+        &builder,
+        SharedL1Chain::from_blocks(h.l1.chain().to_vec()),
+    );
     verifier.initialize().await.expect("initialize");
 
     // Signal blocks 1, 2, 3 and step after each.
@@ -666,7 +690,10 @@ async fn l1_deposit_included_in_derived_l2_block() {
     h.l1.mine_block();
 
     // Create verifier AFTER mining so the snapshot contains block 1.
-    let (mut verifier, _chain) = h.create_verifier();
+    let (mut verifier, _chain) = h.create_verifier_from_sequencer(
+        &sequencer,
+        SharedL1Chain::from_blocks(h.l1.chain().to_vec()),
+    );
     let l1_block_1 = block_info_from(h.l1.tip());
 
     verifier.initialize().await.expect("initialize should succeed");
@@ -743,7 +770,10 @@ async fn batcher_key_rotation_accepts_new_batcher() {
     h.l1.enqueue_log(batcher_update_log(l1_sys_cfg_addr, batcher_b.batcher_address));
     h.l1.mine_block(); // block 3: rotation receipt, no batcher tx
 
-    let (mut verifier, chain) = h.create_verifier();
+    let (mut verifier, chain) = h.create_verifier_from_sequencer(
+        &builder,
+        SharedL1Chain::from_blocks(h.l1.chain().to_vec()),
+    );
     verifier.initialize().await.expect("initialize");
 
     // Drive derivation through blocks 1-2 (batcher A frames derived).
@@ -805,7 +835,10 @@ async fn multi_l2_per_l1_epoch() {
     let l1_chain = SharedL1Chain::from_blocks(h.l1.chain().to_vec());
     let mut builder = h.create_l2_sequencer(l1_chain);
 
-    let (mut verifier, chain) = h.create_verifier();
+    let (mut verifier, chain) = h.create_verifier_from_sequencer(
+        &builder,
+        SharedL1Chain::from_blocks(h.l1.chain().to_vec()),
+    );
 
     for _ in 1..=L2_COUNT {
         let block = builder.build_next_block().expect("build L2 block");
@@ -875,7 +908,10 @@ async fn batch_past_sequence_window_rejected() {
     drop(batcher);
     h.l1.mine_block(); // block 3
 
-    let (mut verifier, _chain) = h.create_verifier();
+    let (mut verifier, _chain) = h.create_verifier_from_sequencer(
+        &builder,
+        SharedL1Chain::from_blocks(h.l1.chain().to_vec()),
+    );
     verifier.initialize().await.expect("initialize");
 
     let mut total_derived = 0;
@@ -938,7 +974,10 @@ async fn multi_epoch_sequence() {
     assert_eq!(builder.head().l1_origin.number, 2, "L2 block 12 should reference epoch 2");
 
     // Create verifier after the sequencer has populated the shared block-hash registry.
-    let (mut verifier, chain) = h.create_verifier();
+    let (mut verifier, chain) = h.create_verifier_from_sequencer(
+        &builder,
+        SharedL1Chain::from_blocks(h.l1.chain().to_vec()),
+    );
 
     // Batch each L2 block into a separate L1 inclusion block.
     for block in &blocks {
@@ -995,7 +1034,10 @@ async fn same_epoch_multi_batch_one_l1_block() {
     h.l1.mine_block();
 
     // Create verifier after mining so the snapshot includes the inclusion block.
-    let (mut verifier, _chain) = h.create_verifier();
+    let (mut verifier, _chain) = h.create_verifier_from_sequencer(
+        &builder,
+        SharedL1Chain::from_blocks(h.l1.chain().to_vec()),
+    );
     verifier.initialize().await.expect("initialize");
 
     let l1_block_1 = block_info_from(h.l1.block_by_number(1).expect("block 1"));
@@ -1040,7 +1082,10 @@ async fn deep_reorg_multi_block() {
     }
 
     // Create verifier with all 5 L1 inclusion blocks visible.
-    let (mut verifier, chain) = h.create_verifier();
+    let (mut verifier, chain) = h.create_verifier_from_sequencer(
+        &builder,
+        SharedL1Chain::from_blocks(h.l1.chain().to_vec()),
+    );
     verifier.initialize().await.expect("initialize");
 
     for i in 1..=5u64 {
@@ -1100,7 +1145,10 @@ async fn garbage_frame_data_ignored() {
     let block = builder.build_next_block().expect("build L2 block 1");
     source.push(block);
 
-    let (mut verifier, chain) = h.create_verifier();
+    let (mut verifier, chain) = h.create_verifier_from_sequencer(
+        &builder,
+        SharedL1Chain::from_blocks(h.l1.chain().to_vec()),
+    );
     verifier.initialize().await.expect("initialize");
 
     // Submit a garbage batcher tx: valid derivation version prefix + random bytes.
@@ -1165,7 +1213,10 @@ async fn multi_frame_channel_reassembled() {
     let block = builder.build_next_block().expect("build L2 block 1");
     source.push(block);
 
-    let (mut verifier, chain) = h.create_verifier();
+    let (mut verifier, chain) = h.create_verifier_from_sequencer(
+        &builder,
+        SharedL1Chain::from_blocks(h.l1.chain().to_vec()),
+    );
 
     // Encode the L2 block. With max_frame_size=80, the compressed channel data
     // should spill across multiple frames.
@@ -1227,7 +1278,10 @@ async fn single_l2_block_derived_from_span_batch() {
 
     h.l1.mine_block();
 
-    let (mut verifier, _chain) = h.create_verifier();
+    let (mut verifier, _chain) = h.create_verifier_from_sequencer(
+        &sequencer,
+        SharedL1Chain::from_blocks(h.l1.chain().to_vec()),
+    );
     verifier.initialize().await.expect("initialize");
 
     let l1_block_1 = block_info_from(h.l1.tip());
@@ -1264,7 +1318,10 @@ async fn three_l2_blocks_derived_from_span_batch() {
 
     h.l1.mine_block();
 
-    let (mut verifier, _chain) = h.create_verifier();
+    let (mut verifier, _chain) = h.create_verifier_from_sequencer(
+        &sequencer,
+        SharedL1Chain::from_blocks(h.l1.chain().to_vec()),
+    );
     verifier.initialize().await.expect("initialize");
 
     let l1_block_1 = block_info_from(h.l1.tip());
@@ -1378,7 +1435,10 @@ async fn gpo_params_change_does_not_disrupt_derivation() {
     drop(batcher);
     h.l1.mine_block();
 
-    let (mut verifier, _chain) = h.create_verifier();
+    let (mut verifier, _chain) = h.create_verifier_from_sequencer(
+        &sequencer,
+        SharedL1Chain::from_blocks(h.l1.chain().to_vec()),
+    );
     verifier.initialize().await.expect("initialize");
 
     for i in 1u64..=3 {
@@ -1436,7 +1496,10 @@ async fn gas_limit_change_does_not_disrupt_derivation() {
     drop(batcher);
     h.l1.mine_block();
 
-    let (mut verifier, _chain) = h.create_verifier();
+    let (mut verifier, _chain) = h.create_verifier_from_sequencer(
+        &sequencer,
+        SharedL1Chain::from_blocks(h.l1.chain().to_vec()),
+    );
     verifier.initialize().await.expect("initialize");
 
     for i in 1u64..=3 {
@@ -1484,7 +1547,10 @@ async fn garbage_kind_silently_ignored_then_valid_batch_derived(kind: GarbageKin
     drop(batcher);
     h.l1.mine_block();
 
-    let (mut verifier, _chain) = h.create_verifier();
+    let (mut verifier, _chain) = h.create_verifier_from_sequencer(
+        &sequencer,
+        SharedL1Chain::from_blocks(h.l1.chain().to_vec()),
+    );
     verifier.initialize().await.expect("initialize");
 
     // Block 1: garbage — must not advance the safe head.
@@ -1558,7 +1624,10 @@ async fn l2_finalized_advances_via_l1_finalized_signal() {
         h.l1.mine_block();
     }
 
-    let (mut verifier, _chain) = h.create_verifier();
+    let (mut verifier, _chain) = h.create_verifier_from_sequencer(
+        &sequencer,
+        SharedL1Chain::from_blocks(h.l1.chain().to_vec()),
+    );
     verifier.initialize().await.expect("initialize");
 
     // Finalized head starts at L2 genesis.
@@ -1690,10 +1759,9 @@ async fn derive_chain_from_near_l1_genesis() {
     // Build an L2Sequencer starting from this custom genesis (epoch 5).
     let l1_chain_snap = SharedL1Chain::from_blocks(h.l1.chain().to_vec());
     let system_config = rollup_cfg.genesis.system_config.unwrap_or_default();
-    let block_hashes = SharedBlockHashRegistry::default();
     let mut sequencer =
-        L2Sequencer::new(genesis_head, l1_chain_snap, rollup_cfg.clone(), system_config)
-            .with_block_hash_registry(block_hashes.clone());
+        L2Sequencer::new(genesis_head, l1_chain_snap, rollup_cfg.clone(), system_config);
+    let block_hashes = sequencer.block_hash_registry();
 
     // Build 2 L2 blocks and batch them into L1 blocks #6 and #7.
     for _ in 1..=2u64 {
@@ -1778,7 +1846,10 @@ async fn single_l2_block_derived_from_blob() {
     h.l1.mine_block();
 
     // Create the blob verifier AFTER mining so the snapshot contains the blob.
-    let (mut verifier, _chain) = h.create_blob_verifier();
+    let (mut verifier, _chain) = h.create_blob_verifier_from_sequencer(
+        &builder,
+        SharedL1Chain::from_blocks(h.l1.chain().to_vec()),
+    );
     let l1_block_1 = block_info_from(h.l1.tip());
 
     verifier.initialize().await.expect("initialize should succeed");
@@ -1823,7 +1894,10 @@ async fn multiple_l2_blocks_derived_from_blob() {
     h.l1.mine_block();
 
     // Create the blob verifier.
-    let (mut verifier, _chain) = h.create_blob_verifier();
+    let (mut verifier, _chain) = h.create_blob_verifier_from_sequencer(
+        &builder,
+        SharedL1Chain::from_blocks(h.l1.chain().to_vec()),
+    );
     let l1_block_1 = block_info_from(h.l1.tip());
 
     verifier.initialize().await.expect("initialize should succeed");
@@ -1897,7 +1971,10 @@ async fn batcher_config_update_rolled_back_on_reorg() {
     h.l1.mine_block();
 
     // Create verifier after all pre-reorg L1 blocks are mined.
-    let (mut verifier, chain) = h.create_verifier();
+    let (mut verifier, chain) = h.create_verifier_from_sequencer(
+        &builder,
+        SharedL1Chain::from_blocks(h.l1.chain().to_vec()),
+    );
     verifier.initialize().await.expect("initialize");
 
     // Drive derivation through L1 blocks 1-2.
@@ -1999,7 +2076,10 @@ async fn out_of_order_singular_batches_reordered_by_batch_queue() {
     let block1 = builder.build_next_block().expect("build L2 block 1");
     let block2 = builder.build_next_block().expect("build L2 block 2");
 
-    let (mut verifier, chain) = h.create_verifier();
+    let (mut verifier, chain) = h.create_verifier_from_sequencer(
+        &builder,
+        SharedL1Chain::from_blocks(h.l1.chain().to_vec()),
+    );
 
     // L1 block 1: carry the batch for L2 block 2 (submitted out of order).
     {
@@ -2092,7 +2172,10 @@ async fn pipeline_idle_before_l1_signal_derives_after() {
     batcher.advance().expect("encode and submit");
     drop(batcher);
 
-    let (mut verifier, chain) = h.create_verifier();
+    let (mut verifier, chain) = h.create_verifier_from_sequencer(
+        &builder,
+        SharedL1Chain::from_blocks(h.l1.chain().to_vec()),
+    );
     h.mine_and_push(&chain);
     verifier.initialize().await.expect("initialize");
 
@@ -2154,7 +2237,10 @@ async fn pipeline_l1_origin_advance_observable_after_epoch_exhausted() {
     batcher.advance().expect("encode and submit both blocks");
     drop(batcher);
 
-    let (mut verifier, chain) = h.create_verifier();
+    let (mut verifier, chain) = h.create_verifier_from_sequencer(
+        &builder,
+        SharedL1Chain::from_blocks(h.l1.chain().to_vec()),
+    );
 
     h.mine_and_push(&chain); // L1 block 1: carries the channel for blocks 1 & 2
     h.mine_and_push(&chain); // L1 block 2: empty — used only for origin advance

--- a/actions/harness/tests/finalization.rs
+++ b/actions/harness/tests/finalization.rs
@@ -20,11 +20,8 @@ async fn finalization_advances_with_multiple_l2_blocks_per_epoch() {
     let mut sequencer = h.create_l2_sequencer(l1_chain);
 
     let mut blocks = Vec::new();
-    let mut block_hashes = Vec::new();
     for _ in 0..3 {
         let block = sequencer.build_next_block().expect("build L2 block");
-        let head = sequencer.head();
-        block_hashes.push((head.block_info.number, head.block_info.hash));
         blocks.push(block);
     }
     // All blocks should reference epoch 0.
@@ -40,11 +37,8 @@ async fn finalization_advances_with_multiple_l2_blocks_per_epoch() {
         h.l1.mine_block();
     }
 
-    // Create verifier after mining and register block hashes.
+    // Create verifier after mining so it observes the hashes the sequencer already registered.
     let (mut verifier, _chain) = h.create_verifier();
-    for (number, hash) in &block_hashes {
-        verifier.register_block_hash(*number, *hash);
-    }
     verifier.initialize().await.expect("initialize");
 
     // Finalized head starts at genesis.
@@ -95,12 +89,10 @@ async fn finalization_advances_incrementally_with_l1_epochs() {
 
     // Build 6 L2 blocks: blocks 1-5 in epoch 0, block 6 in epoch 1.
     let mut blocks = Vec::new();
-    let mut block_hashes = Vec::new();
     let mut last_epoch_0_number = 0u64;
     for i in 1..=6u64 {
         let block = sequencer.build_next_block().expect("build L2 block");
         let head = sequencer.head();
-        block_hashes.push((head.block_info.number, head.block_info.hash));
         blocks.push(block);
         if head.l1_origin.number == 0 {
             last_epoch_0_number = i;
@@ -110,9 +102,6 @@ async fn finalization_advances_incrementally_with_l1_epochs() {
     assert!(last_epoch_0_number > 0, "at least one L2 block should reference epoch 0");
 
     let (mut verifier, chain) = h.create_verifier();
-    for (number, hash) in &block_hashes {
-        verifier.register_block_hash(*number, *hash);
-    }
 
     for block in &blocks {
         let mut source = ActionL2Source::new();
@@ -172,9 +161,7 @@ async fn finalization_does_not_exceed_safe_head() {
     let mut sequencer = h.create_l2_sequencer(l1_chain);
 
     let block1 = sequencer.build_next_block().expect("build block 1");
-    let hash1 = sequencer.head().block_info.hash;
     let block2 = sequencer.build_next_block().expect("build block 2");
-    let hash2 = sequencer.head().block_info.hash;
 
     // Submit each block via the batcher.
     for block in [block1, block2] {
@@ -190,8 +177,6 @@ async fn finalization_does_not_exceed_safe_head() {
     h.mine_l1_blocks(10);
 
     let (mut verifier, _chain) = h.create_verifier();
-    verifier.register_block_hash(1, hash1);
-    verifier.register_block_hash(2, hash2);
     verifier.initialize().await.expect("initialize");
 
     // Derive only 2 L2 blocks.
@@ -236,9 +221,7 @@ async fn finalization_reorg_clears_state() {
     let mut sequencer = h.create_l2_sequencer(l1_chain);
 
     let block1 = sequencer.build_next_block().expect("build block 1");
-    let hash1 = sequencer.head().block_info.hash;
     let block2 = sequencer.build_next_block().expect("build block 2");
-    let hash2 = sequencer.head().block_info.hash;
 
     // Submit and mine.
     for block in [block1, block2] {
@@ -251,8 +234,6 @@ async fn finalization_reorg_clears_state() {
     }
 
     let (mut verifier, chain) = h.create_verifier();
-    verifier.register_block_hash(1, hash1);
-    verifier.register_block_hash(2, hash2);
     verifier.initialize().await.expect("initialize");
 
     // Derive both L2 blocks.
@@ -291,7 +272,6 @@ async fn finalization_reorg_clears_state() {
     let l1_chain_fresh = SharedL1Chain::from_blocks(h.l1.chain().to_vec());
     let mut sequencer_fresh = h.create_l2_sequencer(l1_chain_fresh);
     let block1_fresh = sequencer_fresh.build_next_block().expect("build fresh block 1");
-    let hash1_fresh = sequencer_fresh.head().block_info.hash;
 
     let mut source = ActionL2Source::new();
     source.push(block1_fresh);
@@ -303,8 +283,6 @@ async fn finalization_reorg_clears_state() {
     // Push the new block to the shared chain.
     chain.truncate_to(0);
     chain.push(h.l1.tip().clone());
-
-    verifier.register_block_hash(1, hash1_fresh);
 
     let l1_block_1_new = block_info_from(h.l1.block_by_number(1).expect("new block 1"));
     verifier.act_l1_head_signal(l1_block_1_new).await.expect("signal new block 1");
@@ -337,19 +315,13 @@ async fn finalization_does_not_regress() {
     let mut sequencer = h.create_l2_sequencer(l1_chain);
 
     let mut blocks = Vec::new();
-    let mut block_hashes = Vec::new();
     for _ in 0..6 {
         let block = sequencer.build_next_block().expect("build L2 block");
-        let head = sequencer.head();
-        block_hashes.push((head.block_info.number, head.block_info.hash));
         blocks.push(block);
     }
 
     // Submit each L2 block in a separate L1 inclusion block.
     let (mut verifier, chain) = h.create_verifier();
-    for (number, hash) in &block_hashes {
-        verifier.register_block_hash(*number, *hash);
-    }
 
     for block in &blocks {
         let mut source = ActionL2Source::new();

--- a/actions/harness/tests/finalization.rs
+++ b/actions/harness/tests/finalization.rs
@@ -38,7 +38,10 @@ async fn finalization_advances_with_multiple_l2_blocks_per_epoch() {
     }
 
     // Create verifier after mining so it observes the hashes the sequencer already registered.
-    let (mut verifier, _chain) = h.create_verifier();
+    let (mut verifier, _chain) = h.create_verifier_from_sequencer(
+        &sequencer,
+        SharedL1Chain::from_blocks(h.l1.chain().to_vec()),
+    );
     verifier.initialize().await.expect("initialize");
 
     // Finalized head starts at genesis.
@@ -101,7 +104,10 @@ async fn finalization_advances_incrementally_with_l1_epochs() {
     assert_eq!(sequencer.head().l1_origin.number, 1, "last L2 block should reference epoch 1");
     assert!(last_epoch_0_number > 0, "at least one L2 block should reference epoch 0");
 
-    let (mut verifier, chain) = h.create_verifier();
+    let (mut verifier, chain) = h.create_verifier_from_sequencer(
+        &sequencer,
+        SharedL1Chain::from_blocks(h.l1.chain().to_vec()),
+    );
 
     for block in &blocks {
         let mut source = ActionL2Source::new();
@@ -176,7 +182,10 @@ async fn finalization_does_not_exceed_safe_head() {
     // Mine many more L1 blocks without any corresponding L2 derivation data.
     h.mine_l1_blocks(10);
 
-    let (mut verifier, _chain) = h.create_verifier();
+    let (mut verifier, _chain) = h.create_verifier_from_sequencer(
+        &sequencer,
+        SharedL1Chain::from_blocks(h.l1.chain().to_vec()),
+    );
     verifier.initialize().await.expect("initialize");
 
     // Derive only 2 L2 blocks.
@@ -233,7 +242,10 @@ async fn finalization_reorg_clears_state() {
         h.l1.mine_block();
     }
 
-    let (mut verifier, chain) = h.create_verifier();
+    let (mut verifier, chain) = h.create_verifier_from_sequencer(
+        &sequencer,
+        SharedL1Chain::from_blocks(h.l1.chain().to_vec()),
+    );
     verifier.initialize().await.expect("initialize");
 
     // Derive both L2 blocks.
@@ -278,6 +290,7 @@ async fn finalization_reorg_clears_state() {
     let mut batcher_fresh = h.create_batcher(source, batcher_cfg.clone());
     batcher_fresh.advance().expect("encode fresh");
     drop(batcher_fresh);
+    verifier.register_block_hash(1, sequencer_fresh.head().block_info.hash);
     h.l1.mine_block();
 
     // Push the new block to the shared chain.
@@ -321,7 +334,10 @@ async fn finalization_does_not_regress() {
     }
 
     // Submit each L2 block in a separate L1 inclusion block.
-    let (mut verifier, chain) = h.create_verifier();
+    let (mut verifier, chain) = h.create_verifier_from_sequencer(
+        &sequencer,
+        SharedL1Chain::from_blocks(h.l1.chain().to_vec()),
+    );
 
     for block in &blocks {
         let mut source = ActionL2Source::new();

--- a/actions/harness/tests/hardfork_activation.rs
+++ b/actions/harness/tests/hardfork_activation.rs
@@ -286,7 +286,10 @@ async fn span_batch_rejected_before_delta() {
 
     h.l1.mine_block();
 
-    let (mut verifier, _chain) = h.create_verifier();
+    let (mut verifier, _chain) = h.create_verifier_from_sequencer(
+        &builder,
+        SharedL1Chain::from_blocks(h.l1.chain().to_vec()),
+    );
     verifier.initialize().await.expect("initialize");
     verifier.act_l1_head_signal(block_info_from(h.l1.tip())).await.expect("signal");
     verifier.act_l2_pipeline_full().await.expect("pipeline");
@@ -324,7 +327,10 @@ async fn span_batch_derives_after_delta() {
 
     h.l1.mine_block();
 
-    let (mut verifier, _chain) = h.create_verifier();
+    let (mut verifier, _chain) = h.create_verifier_from_sequencer(
+        &builder,
+        SharedL1Chain::from_blocks(h.l1.chain().to_vec()),
+    );
     verifier.initialize().await.expect("initialize");
     verifier.act_l1_head_signal(block_info_from(h.l1.tip())).await.expect("signal");
     let derived = verifier.act_l2_pipeline_full().await.expect("pipeline");
@@ -355,7 +361,10 @@ async fn single_batch_derives_with_fjord() {
         h.l1.mine_block();
     }
 
-    let (mut verifier, _chain) = h.create_verifier();
+    let (mut verifier, _chain) = h.create_verifier_from_sequencer(
+        &builder,
+        SharedL1Chain::from_blocks(h.l1.chain().to_vec()),
+    );
     verifier.initialize().await.expect("initialize");
 
     for i in 1..=2u64 {
@@ -426,7 +435,10 @@ async fn jovian_derivation_crosses_activation_boundary() {
         h.l1.mine_block();
     }
 
-    let (mut verifier, _chain) = h.create_verifier();
+    let (mut verifier, _chain) = h.create_verifier_from_sequencer(
+        &builder,
+        SharedL1Chain::from_blocks(h.l1.chain().to_vec()),
+    );
     verifier.initialize().await.expect("initialize");
 
     for i in 1..=4u64 {

--- a/actions/harness/tests/hardfork_activation.rs
+++ b/actions/harness/tests/hardfork_activation.rs
@@ -313,12 +313,9 @@ async fn span_batch_derives_after_delta() {
     let l1_chain = SharedL1Chain::from_blocks(h.l1.chain().to_vec());
     let mut builder = h.create_l2_sequencer(l1_chain);
 
-    let mut block_hashes = Vec::new();
     let mut source = ActionL2Source::new();
     source.push(builder.build_next_block().expect("build L2 block 1"));
-    block_hashes.push((builder.head().block_info.number, builder.head().block_info.hash));
     source.push(builder.build_next_block().expect("build L2 block 2"));
-    block_hashes.push((builder.head().block_info.number, builder.head().block_info.hash));
 
     let span_cfg = BatcherConfig { batch_type: BatchType::Span, ..batcher_cfg.clone() };
     let mut batcher = h.create_batcher(source, span_cfg);
@@ -328,9 +325,6 @@ async fn span_batch_derives_after_delta() {
     h.l1.mine_block();
 
     let (mut verifier, _chain) = h.create_verifier();
-    for (number, hash) in &block_hashes {
-        verifier.register_block_hash(*number, *hash);
-    }
     verifier.initialize().await.expect("initialize");
     verifier.act_l1_head_signal(block_info_from(h.l1.tip())).await.expect("signal");
     let derived = verifier.act_l2_pipeline_full().await.expect("pipeline");
@@ -351,12 +345,9 @@ async fn single_batch_derives_with_fjord() {
     let l1_chain = SharedL1Chain::from_blocks(h.l1.chain().to_vec());
     let mut builder = h.create_l2_sequencer(l1_chain);
 
-    let mut block_hashes = Vec::new();
     for _ in 0..2 {
         let mut source = ActionL2Source::new();
         source.push(builder.build_next_block().expect("build L2 block"));
-        let head = builder.head();
-        block_hashes.push((head.block_info.number, head.block_info.hash));
 
         let mut batcher = h.create_batcher(source, batcher_cfg.clone());
         batcher.advance().expect("batcher advance");
@@ -365,9 +356,6 @@ async fn single_batch_derives_with_fjord() {
     }
 
     let (mut verifier, _chain) = h.create_verifier();
-    for (number, hash) in &block_hashes {
-        verifier.register_block_hash(*number, *hash);
-    }
     verifier.initialize().await.expect("initialize");
 
     for i in 1..=2u64 {
@@ -422,7 +410,6 @@ async fn jovian_derivation_crosses_activation_boundary() {
     let l1_chain = SharedL1Chain::from_blocks(h.l1.chain().to_vec());
     let mut builder = h.create_l2_sequencer(l1_chain);
 
-    let mut block_hashes = Vec::new();
     for i in 1..=4u64 {
         let mut source = ActionL2Source::new();
         let block = if i == 3 {
@@ -432,8 +419,6 @@ async fn jovian_derivation_crosses_activation_boundary() {
             builder.build_next_block().expect("build L2 block")
         };
         source.push(block);
-        let head = builder.head();
-        block_hashes.push((head.block_info.number, head.block_info.hash));
 
         let mut batcher = h.create_batcher(source, batcher_cfg.clone());
         batcher.advance().expect("batcher encode");
@@ -442,9 +427,6 @@ async fn jovian_derivation_crosses_activation_boundary() {
     }
 
     let (mut verifier, _chain) = h.create_verifier();
-    for (number, hash) in &block_hashes {
-        verifier.register_block_hash(*number, *hash);
-    }
     verifier.initialize().await.expect("initialize");
 
     for i in 1..=4u64 {

--- a/actions/harness/tests/operator_fees.rs
+++ b/actions/harness/tests/operator_fees.rs
@@ -419,13 +419,10 @@ async fn isthmus_derivation_crosses_operator_fee_boundary() {
     let l1_chain = SharedL1Chain::from_blocks(h.l1.chain().to_vec());
     let mut builder = h.create_l2_sequencer(l1_chain);
 
-    let mut block_hashes = Vec::new();
     for _ in 0..4u64 {
         // All blocks carry user transactions — Isthmus allows user txs at transition.
         let mut source = ActionL2Source::new();
         source.push(builder.build_next_block().expect("build L2 block"));
-        let head = builder.head();
-        block_hashes.push((head.block_info.number, head.block_info.hash));
 
         let mut batcher = h.create_batcher(source, batcher_cfg.clone());
         batcher.advance().expect("batcher encode");
@@ -433,10 +430,10 @@ async fn isthmus_derivation_crosses_operator_fee_boundary() {
         h.l1.mine_block();
     }
 
-    let (mut verifier, _chain) = h.create_verifier();
-    for (number, hash) in &block_hashes {
-        verifier.register_block_hash(*number, *hash);
-    }
+    let (mut verifier, _chain) = h.create_verifier_from_sequencer(
+        &builder,
+        SharedL1Chain::from_blocks(h.l1.chain().to_vec()),
+    );
     verifier.initialize().await.expect("initialize");
 
     for i in 1..=4u64 {
@@ -698,16 +695,13 @@ async fn operator_fee_config_update_propagates_to_l1_info() {
 
     // L2 blocks 1–5 (ts=2,4,6,8,10): epoch 0, OLD config.
     let mut epoch0_blocks: Vec<base_alloy_consensus::OpBlock> = Vec::new();
-    let mut epoch0_hashes: Vec<B256> = Vec::new();
     for _ in 0..5 {
         let block = sequencer.build_next_block().expect("build epoch-0 block");
-        epoch0_hashes.push(sequencer.head().block_info.hash);
         epoch0_blocks.push(block);
     }
 
     // L2 block 6 (ts=12): epoch 1, epoch change — NEW config from L1 block 1's receipts.
     let block6 = sequencer.build_next_block().expect("build block 6");
-    let hash6 = sequencer.head().block_info.hash;
 
     // Batch all epoch-0 blocks into L1 block 2 and block 6 into L1 block 3.
     let mut source = ActionL2Source::new();
@@ -727,11 +721,10 @@ async fn operator_fee_config_update_propagates_to_l1_info() {
     h.l1.mine_block(); // L1 block 3, ts=36
 
     // Verifier snapshot includes all L1 blocks 0–3.
-    let (mut verifier, _chain) = h.create_verifier();
-    for (i, hash) in epoch0_hashes.iter().enumerate() {
-        verifier.register_block_hash((i + 1) as u64, *hash);
-    }
-    verifier.register_block_hash(6, hash6);
+    let (mut verifier, _chain) = h.create_verifier_from_sequencer(
+        &sequencer,
+        SharedL1Chain::from_blocks(h.l1.chain().to_vec()),
+    );
     verifier.initialize().await.expect("initialize");
 
     for i in 1u64..=3 {

--- a/actions/harness/tests/unsafe_gossip.rs
+++ b/actions/harness/tests/unsafe_gossip.rs
@@ -1,51 +1,9 @@
 #![doc = "Action tests for L2 unsafe-head gossip simulation."]
 
-use std::sync::Arc;
-
 use base_action_harness::{
-    ActionDataSource, ActionL1ChainProvider, ActionL2ChainProvider, ActionL2Source,
-    ActionTestHarness, BatcherConfig, L1MinerConfig, L2Verifier, SharedL1Chain,
-    TestRollupConfigBuilder, VerifierPipeline, block_info_from,
+    ActionL2Source, ActionTestHarness, BatcherConfig, L1MinerConfig, SharedL1Chain,
+    TestRollupConfigBuilder, block_info_from,
 };
-use base_consensus_genesis::{L1ChainConfig, RollupConfig};
-use base_protocol::{BlockInfo, L2BlockInfo};
-
-/// Create a verifier wired to `h`'s current L1 chain, returning both the
-/// verifier and the shared chain.
-///
-/// Extracted to avoid duplicating the 20-line constructor in every test.
-fn make_verifier(
-    h: &ActionTestHarness,
-    rollup_cfg: &RollupConfig,
-) -> (L2Verifier<VerifierPipeline>, SharedL1Chain) {
-    let chain = SharedL1Chain::from_blocks(h.l1.chain().to_vec());
-    let rollup_config = Arc::new(rollup_cfg.clone());
-    let l1_chain_config = Arc::new(L1ChainConfig::default());
-    let l1_provider = ActionL1ChainProvider::new(chain.clone());
-    let dap_source = ActionDataSource::new(chain.clone(), rollup_cfg.batch_inbox_address);
-    let genesis_l1 = block_info_from(h.l1.chain().first().expect("genesis always present"));
-    let safe_head = L2BlockInfo {
-        block_info: BlockInfo {
-            hash: rollup_cfg.genesis.l2.hash,
-            number: rollup_cfg.genesis.l2.number,
-            parent_hash: Default::default(),
-            timestamp: rollup_cfg.genesis.l2_time,
-        },
-        l1_origin: alloy_eips::BlockNumHash { number: genesis_l1.number, hash: genesis_l1.hash },
-        seq_num: 0,
-    };
-    let l2_provider = ActionL2ChainProvider::from_genesis(rollup_cfg);
-    let verifier = L2Verifier::new(
-        rollup_config,
-        l1_chain_config,
-        l1_provider,
-        dap_source,
-        l2_provider,
-        safe_head,
-        genesis_l1,
-    );
-    (verifier, chain)
-}
 
 /// Simulates the full op-e2e gossip pattern:
 ///
@@ -86,7 +44,10 @@ async fn test_unsafe_chain_advances_safe_catches_up() {
 
     // Create the verifier AFTER mining so the SharedL1Chain snapshot already
     // contains the L1 block with the batch.
-    let (mut verifier, _chain) = make_verifier(&h, &rollup_cfg);
+    let (mut verifier, _chain) = h.create_verifier_from_sequencer(
+        &sequencer,
+        SharedL1Chain::from_blocks(h.l1.chain().to_vec()),
+    );
 
     // Initialize: seed the genesis SystemConfig and drain the empty genesis
     // L1 block so IndexedTraversal is ready for new block signals.
@@ -144,7 +105,10 @@ async fn test_out_of_order_gossip_is_dropped() {
     let _block2 = sequencer.build_next_block().expect("build block 2");
     let block3 = sequencer.build_next_block().expect("build block 3");
 
-    let (mut verifier, _chain) = make_verifier(&h, &rollup_cfg);
+    let (mut verifier, _chain) = h.create_verifier_from_sequencer(
+        &sequencer,
+        SharedL1Chain::from_blocks(h.l1.chain().to_vec()),
+    );
     verifier.initialize().await.expect("initialize should succeed");
 
     // Inject block 3 first — gap-jump; must be dropped.


### PR DESCRIPTION
Closes #1313

## Summary

Introduces `SharedBlockHashRegistry` and wires it between `L2Sequencer` and
`L2Verifier` so that block hashes are registered automatically as blocks are
built, eliminating the per-block `verifier.register_block_hash(number, hash)`
boilerplate that was required in every derivation test.

## Changes

- **`actions/harness/src/verifier.rs`** — adds `SharedBlockHashRegistry`
  (`Arc<Mutex<HashMap<u64, B256>>>`) and a `with_block_hash_registry()` builder
  method on `L2Verifier`; `register_block_hash` is kept as a manual override API
- **`actions/harness/src/l2.rs`** — `L2Sequencer` stores a `SharedBlockHashRegistry`
  and auto-inserts `(number, hash)` in `build_next_block` and `build_empty_block`;
  adds `with_block_hash_registry()` builder method
- **`actions/harness/src/harness.rs`** — `ActionTestHarness` creates one shared
  registry at construction time and passes it to both `create_l2_sequencer` and
  `create_verifier`
- **`actions/harness/src/lib.rs`** — re-exports `SharedBlockHashRegistry`
- **All test files** — removed all manual `verifier.register_block_hash(...)` calls
