### PR TITLE
chore(actions): Enables all Action Tests

### DIFF
--- a/actions/harness/src/batcher/actor.rs
+++ b/actions/harness/src/batcher/actor.rs
@@ -1,32 +1,17 @@
 use std::sync::Arc;
 
+use alloy_eips::eip4844::Blob;
 use alloy_primitives::{Address, B256, Bytes};
 use base_batcher_encoder::{
-    BatchEncoder, BatchPipeline, EncoderConfig, ReorgError, StepError, StepResult,
+    BatchEncoder, BatchPipeline, BatchType, EncoderConfig, ReorgError, StepError, StepResult,
 };
 use base_blobs::BlobEncoder;
-use base_comp::{
-    BatchComposeError, BatchComposer, BrotliCompressor, BrotliLevel, ChannelOut, ChannelOutError,
-};
+use base_comp::BatchComposeError;
 use base_consensus_genesis::RollupConfig;
-use base_protocol::{
-    Batch, ChannelId, DERIVATION_VERSION_0, Frame, MAX_FRAME_LEN, SingleBatch, SpanBatch,
-    SpanBatchError,
-};
+use base_protocol::{DERIVATION_VERSION_0, Frame};
 use tracing::info;
 
 use crate::{Action, L1Miner, L2BlockProvider, PendingTx};
-
-/// Selects whether the batcher encodes blocks as individual [`SingleBatch`]es
-/// or groups them into a single [`SpanBatch`].
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
-pub enum BatchType {
-    /// Each L2 block is encoded as a separate [`SingleBatch`] (default).
-    #[default]
-    Single,
-    /// All L2 blocks in one cycle are grouped into a single [`SpanBatch`].
-    Span,
-}
 
 /// Selects the kind of invalid frame data submitted by
 /// [`Batcher::submit_garbage_frames`].
@@ -57,7 +42,8 @@ pub struct BatcherConfig {
     pub batcher_address: Address,
     /// Batch inbox address on L1. Used as the `to` field on L1 transactions.
     pub inbox_address: Address,
-    /// Whether to encode blocks as [`SingleBatch`]es or a [`SpanBatch`].
+    /// Whether to encode blocks as [`SingleBatch`](base_protocol::SingleBatch)es
+    /// or a [`SpanBatch`](base_protocol::SpanBatch).
     pub batch_type: BatchType,
     /// Encoder configuration forwarded to [`BatchEncoder`].
     pub encoder: EncoderConfig,
@@ -86,12 +72,6 @@ pub enum BatcherError {
     /// An L2 reorg was detected during block ingestion.
     #[error("reorg: {0}")]
     Reorg(#[from] ReorgError),
-    /// Channel encoding or compression failed.
-    #[error("channel error: {0}")]
-    Channel(#[from] ChannelOutError),
-    /// Span batch construction failed.
-    #[error("span batch error: {0}")]
-    SpanBatch(#[from] SpanBatchError),
 }
 
 impl From<StepError> for BatcherError {
@@ -105,52 +85,56 @@ impl From<StepError> for BatcherError {
 /// Batcher actor for action tests.
 ///
 /// `Batcher` drains [`OpBlock`]s from an [`L2BlockProvider`], encodes each
-/// one as a [`SingleBatch`] via [`BatchEncoder`] or groups them into a
-/// [`SpanBatch`] depending on [`BatcherConfig::batch_type`], compresses
-/// batches into a channel, and submits the resulting frame data to the
-/// [`L1Miner`] as a [`PendingTx`].
+/// one as a [`SingleBatch`] via [`BatchEncoder`] (or accumulates them into a
+/// [`SpanBatch`] when configured for span mode), compresses batches into a
+/// channel, and buffers the resulting frame data internally.
+///
+/// Call [`flush`] to drain the pending transactions and blobs into an
+/// [`L1Miner`].
 ///
 /// A single call to [`advance`] (or [`Action::act`]) runs one full encode
-/// cycle: drain all available L2 blocks → encode → flush → submit to L1.
-/// Callers then mine an L1 block to include the submitted transactions.
+/// cycle: drain all available L2 blocks → encode → buffer submissions.
+/// Callers then call [`flush`] and mine an L1 block to include the submitted
+/// transactions.
 ///
 /// [`advance`]: Batcher::advance
+/// [`flush`]: Batcher::flush
 /// [`OpBlock`]: base_alloy_consensus::OpBlock
 #[derive(Debug)]
-pub struct Batcher<'a, S: L2BlockProvider> {
-    l1_miner: &'a mut L1Miner,
+pub struct Batcher<S: L2BlockProvider> {
     l2_source: S,
     pipeline: BatchEncoder,
-    rollup_config: Arc<RollupConfig>,
     config: BatcherConfig,
+    pending_txs: Vec<PendingTx>,
+    pending_blobs: Vec<(B256, Box<Blob>)>,
 }
 
-impl<'a, S: L2BlockProvider> Batcher<'a, S> {
+impl<S: L2BlockProvider> Batcher<S> {
     /// Create a new [`Batcher`].
     ///
-    /// The batcher borrows `l1_miner` mutably so it can submit transactions
-    /// directly. `l2_source` is moved in so the batcher owns the block queue.
-    pub fn new(
-        l1_miner: &'a mut L1Miner,
-        l2_source: S,
-        rollup_config: &RollupConfig,
-        config: BatcherConfig,
-    ) -> Self {
+    /// Pending transactions and blobs are buffered internally. Call [`flush`]
+    /// to drain them into an [`L1Miner`].
+    ///
+    /// [`flush`]: Batcher::flush
+    pub fn new(l2_source: S, rollup_config: &RollupConfig, config: BatcherConfig) -> Self {
         let rollup_config = Arc::new(rollup_config.clone());
-        let pipeline = BatchEncoder::new(Arc::clone(&rollup_config), config.encoder.clone());
-        Self { l1_miner, l2_source, pipeline, rollup_config, config }
+        let mut encoder_config = config.encoder.clone();
+        encoder_config.batch_type = config.batch_type;
+        let pipeline = BatchEncoder::new(rollup_config, encoder_config);
+        Self { l2_source, pipeline, config, pending_txs: Vec::new(), pending_blobs: Vec::new() }
     }
 
     /// Drain all available L2 blocks and encode them into frames without
     /// submitting to L1.
     ///
-    /// For [`BatchType::Single`], blocks are fed through [`BatchEncoder`].
-    /// For [`BatchType::Span`], all blocks are collected into one [`SpanBatch`]
-    /// and encoded via a fresh [`ChannelOut`].
+    /// Blocks are fed through [`BatchEncoder`], which handles both
+    /// [`SingleBatch`](base_protocol::SingleBatch) and
+    /// [`SpanBatch`](base_protocol::SpanBatch) modes via its internal
+    /// [`EncoderConfig`].
     ///
     /// Returns the encoded frames so callers can inspect or submit them
     /// selectively. Use [`submit_frames`] to submit a subset of frames to
-    /// the L1 miner.
+    /// the pending buffer.
     ///
     /// [`submit_frames`]: Batcher::submit_frames
     ///
@@ -159,16 +143,7 @@ impl<'a, S: L2BlockProvider> Batcher<'a, S> {
     /// Returns [`BatcherError::NoBlocks`] if the L2 source is empty.
     /// Returns [`BatcherError::Compose`] if the first tx is not a valid deposit.
     /// Returns [`BatcherError::Reorg`] if a block parent hash mismatch is detected.
-    /// Returns [`BatcherError::Channel`] if channel encoding fails.
-    /// Returns [`BatcherError::SpanBatch`] if span batch construction fails.
     pub fn encode_frames(&mut self) -> Result<Vec<Arc<Frame>>, BatcherError> {
-        match self.config.batch_type {
-            BatchType::Single => self.encode_single_frames(),
-            BatchType::Span => self.encode_span_frames(),
-        }
-    }
-
-    fn encode_single_frames(&mut self) -> Result<Vec<Arc<Frame>>, BatcherError> {
         let mut block_count = 0u64;
 
         while let Some(block) = self.l2_source.next_block() {
@@ -188,7 +163,8 @@ impl<'a, S: L2BlockProvider> Batcher<'a, S> {
             }
         }
 
-        // Force-close the current channel by advancing the L1 head past the timeout.
+        // Intentional test-only force-flush: advance the L1 head past the
+        // channel timeout so the encoder closes the channel immediately.
         self.pipeline.advance_l1_head(u64::MAX);
 
         let mut frames = Vec::new();
@@ -196,48 +172,16 @@ impl<'a, S: L2BlockProvider> Batcher<'a, S> {
             frames.extend(sub.frames);
         }
 
-        info!(blocks = block_count, frames = frames.len(), "batcher encoded single frames");
+        info!(blocks = block_count, frames = frames.len(), "batcher encoded frames");
         Ok(frames)
     }
 
-    fn encode_span_frames(&mut self) -> Result<Vec<Arc<Frame>>, BatcherError> {
-        let mut singles: Vec<(SingleBatch, u64)> = Vec::new();
-
-        while let Some(block) = self.l2_source.next_block() {
-            let (single, l1_info) = BatchComposer::block_to_single_batch(&block)?;
-            singles.push((single, l1_info.sequence_number()));
-        }
-
-        if singles.is_empty() {
-            return Err(BatcherError::NoBlocks);
-        }
-
-        let mut span_batch =
-            SpanBatch { chain_id: self.rollup_config.l2_chain_id.id(), ..Default::default() };
-        for (single, seq_num) in singles {
-            span_batch.append_singular_batch(single, seq_num)?;
-        }
-
-        // Encode the span batch directly via ChannelOut.
-        let compressor = BrotliCompressor::new(BrotliLevel::Brotli10);
-        let mut channel_out =
-            ChannelOut::new(ChannelId::default(), Arc::clone(&self.rollup_config), compressor);
-        channel_out.add_batch(Batch::Span(span_batch))?;
-        channel_out.flush()?;
-        channel_out.close();
-
-        let mut frames = Vec::new();
-        while channel_out.ready_bytes() > 0 {
-            frames.push(Arc::new(channel_out.output_frame(MAX_FRAME_LEN)?));
-        }
-
-        info!(frames = frames.len(), "batcher encoded span frames");
-        Ok(frames)
-    }
-
-    /// Submit the given frames to the L1 miner as pending transactions.
+    /// Buffer the given frames as pending L1 transactions.
     ///
-    /// Each frame is submitted as a separate [`PendingTx`].
+    /// Each frame is buffered as a separate [`PendingTx`]. Call [`flush`] to
+    /// drain them into an [`L1Miner`].
+    ///
+    /// [`flush`]: Batcher::flush
     pub fn submit_frames(&mut self, frames: &[Arc<Frame>]) {
         for frame in frames {
             let encoded = frame.encode();
@@ -245,32 +189,38 @@ impl<'a, S: L2BlockProvider> Batcher<'a, S> {
             input.push(DERIVATION_VERSION_0);
             input.extend_from_slice(&encoded);
 
-            self.l1_miner.submit_tx(PendingTx {
+            self.pending_txs.push(PendingTx {
                 from: self.config.batcher_address,
                 to: self.config.inbox_address,
                 input: Bytes::from(input),
             });
         }
-        info!(frames = frames.len(), "batcher submitted frames to L1");
+        info!(frames = frames.len(), "batcher buffered frames");
     }
 
-    /// Submit the given frames to the L1 miner as EIP-4844 blob sidecars.
+    /// Buffer the given frames as EIP-4844 blob sidecars.
     ///
     /// Each frame is encoded into one blob using [`BlobEncoder::encode_frames`].
-    /// Blobs are enqueued via [`L1Miner::enqueue_blob`] with a zero versioned
-    /// hash (sufficient for the in-memory [`ActionBlobDataSource`], which reads
-    /// all blob sidecars unconditionally).
+    /// Call [`flush`] to drain them into an [`L1Miner`].
     ///
-    /// Mine an L1 block after calling this to include the blobs in a block.
-    ///
-    /// [`ActionBlobDataSource`]: crate::ActionBlobDataSource
+    /// [`flush`]: Batcher::flush
     pub fn submit_blob_frames(&mut self, frames: &[Arc<Frame>]) {
         let blobs =
             BlobEncoder::encode_frames(frames).expect("frame data fits within blob capacity");
         for blob in blobs {
-            self.l1_miner.enqueue_blob(B256::ZERO, Box::new(blob));
+            self.pending_blobs.push((B256::ZERO, Box::new(blob)));
         }
-        info!(frames = frames.len(), "batcher submitted frames as blobs to L1");
+        info!(frames = frames.len(), "batcher buffered frames as blobs");
+    }
+
+    /// Drain all pending transactions and blobs into the given [`L1Miner`].
+    pub fn flush(&mut self, l1: &mut L1Miner) {
+        for tx in self.pending_txs.drain(..) {
+            l1.submit_tx(tx);
+        }
+        for (hash, blob) in self.pending_blobs.drain(..) {
+            l1.enqueue_blob(hash, blob);
+        }
     }
 
     /// Encode and submit all frames as blobs in one step.
@@ -285,11 +235,15 @@ impl<'a, S: L2BlockProvider> Batcher<'a, S> {
         Ok(frames)
     }
 
-    /// Submit intentionally malformed frame data to L1.
+    /// Buffer intentionally malformed frame data as a pending L1 transaction.
     ///
     /// These garbage frames should be silently dropped by the derivation
     /// pipeline. Use them to test that invalid data does not corrupt channel
     /// state or advance the safe head.
+    ///
+    /// Call [`flush`] to drain pending transactions into an [`L1Miner`].
+    ///
+    /// [`flush`]: Batcher::flush
     pub fn submit_garbage_frames(&mut self, kind: GarbageKind) {
         let input = match kind {
             GarbageKind::Random => {
@@ -349,12 +303,12 @@ impl<'a, S: L2BlockProvider> Batcher<'a, S> {
             }
         };
 
-        self.l1_miner.submit_tx(PendingTx {
+        self.pending_txs.push(PendingTx {
             from: self.config.batcher_address,
             to: self.config.inbox_address,
             input,
         });
-        info!(kind = ?kind, "batcher submitted garbage frame");
+        info!(kind = ?kind, "batcher buffered garbage frame");
     }
 
     /// Return the estimated number of unsubmitted data bytes in the encoding pipeline.
@@ -365,7 +319,7 @@ impl<'a, S: L2BlockProvider> Batcher<'a, S> {
         self.pipeline.da_backlog_bytes()
     }
 
-    /// Encode and submit all frames in one step (convenience wrapper).
+    /// Encode and buffer all frames in one step (convenience wrapper).
     ///
     /// Equivalent to calling [`encode_frames`] followed by [`submit_frames`]
     /// with all produced frames.
@@ -379,7 +333,7 @@ impl<'a, S: L2BlockProvider> Batcher<'a, S> {
     }
 }
 
-impl<S: L2BlockProvider> Action for Batcher<'_, S> {
+impl<S: L2BlockProvider> Action for Batcher<S> {
     type Output = Vec<Arc<Frame>>;
     type Error = BatcherError;
 

--- a/actions/harness/src/batcher/mod.rs
+++ b/actions/harness/src/batcher/mod.rs
@@ -1,4 +1,4 @@
 //! Batcher actor and supporting types for action tests.
 
 mod actor;
-pub use actor::{BatchType, Batcher, BatcherConfig, BatcherError, GarbageKind};
+pub use actor::{Batcher, BatcherConfig, BatcherError, GarbageKind};

--- a/actions/harness/src/harness.rs
+++ b/actions/harness/src/harness.rs
@@ -87,12 +87,15 @@ impl ActionTestHarness {
     /// Unlike the previous `create_batcher` that consumed an internal
     /// `MockL2Source`, this accepts any [`L2BlockProvider`] so tests can wire
     /// an [`L2BlockBuilder`] or a hand-rolled source directly.
+    ///
+    /// The returned batcher buffers pending transactions and blobs internally.
+    /// Call [`Batcher::flush`] to drain them into `self.l1`.
     pub fn create_batcher<S: L2BlockProvider>(
-        &mut self,
+        &self,
         source: S,
         config: BatcherConfig,
-    ) -> Batcher<'_, S> {
-        Batcher::new(&mut self.l1, source, &self.rollup_config, config)
+    ) -> Batcher<S> {
+        Batcher::new(source, &self.rollup_config, config)
     }
 
     /// Create an [`L2Sequencer`] starting from L2 genesis, wired to a

--- a/actions/harness/src/lib.rs
+++ b/actions/harness/src/lib.rs
@@ -19,7 +19,8 @@ mod harness;
 pub use harness::ActionTestHarness;
 
 mod batcher;
-pub use batcher::{BatchType, Batcher, BatcherConfig, BatcherError, GarbageKind};
+pub use base_batcher_encoder::BatchType;
+pub use batcher::{Batcher, BatcherConfig, BatcherError, GarbageKind};
 
 mod test_rollup_config;
 pub use test_rollup_config::TestRollupConfigBuilder;

--- a/actions/harness/tests/batch_submission.rs
+++ b/actions/harness/tests/batch_submission.rs
@@ -26,7 +26,7 @@ fn make_source(h: &ActionTestHarness, n: u64) -> ActionL2Source {
 
 #[test]
 fn batcher_produces_frames_for_single_block() {
-    let mut h = ActionTestHarness::default();
+    let h = ActionTestHarness::default();
     let source = make_source(&h, 1);
     let mut batcher = h.create_batcher(source, BatcherConfig::default());
     let frames = batcher.advance().expect("advance should succeed");
@@ -35,7 +35,7 @@ fn batcher_produces_frames_for_single_block() {
 
 #[test]
 fn batcher_produces_frames_for_multiple_blocks() {
-    let mut h = ActionTestHarness::default();
+    let h = ActionTestHarness::default();
     let source = make_source(&h, 5);
     let mut batcher = h.create_batcher(source, BatcherConfig::default());
     let frames = batcher.advance().expect("advance should succeed");
@@ -44,7 +44,7 @@ fn batcher_produces_frames_for_multiple_blocks() {
 
 #[test]
 fn batcher_errors_when_no_l2_blocks() {
-    let mut h = ActionTestHarness::default();
+    let h = ActionTestHarness::default();
     let source = ActionL2Source::new(); // empty
     let mut batcher = h.create_batcher(source, BatcherConfig::default());
     let err = batcher.advance().expect_err("should fail with no blocks");
@@ -57,7 +57,7 @@ fn batcher_errors_when_no_l2_blocks() {
 
 #[test]
 fn batcher_produces_frames_for_single_block_span() {
-    let mut h = ActionTestHarness::default();
+    let h = ActionTestHarness::default();
     let source = make_source(&h, 1);
     let cfg = BatcherConfig { batch_type: BatchType::Span, ..Default::default() };
     let mut batcher = h.create_batcher(source, cfg);
@@ -67,7 +67,7 @@ fn batcher_produces_frames_for_single_block_span() {
 
 #[test]
 fn batcher_produces_span_frames_for_multiple_blocks() {
-    let mut h = ActionTestHarness::default();
+    let h = ActionTestHarness::default();
     let source = make_source(&h, 5);
     let cfg = BatcherConfig { batch_type: BatchType::Span, ..Default::default() };
     let mut batcher = h.create_batcher(source, cfg);
@@ -89,7 +89,7 @@ fn batcher_submits_tx_to_l1_pending_pool() {
     let source = make_source(&h, 3);
     let mut batcher = h.create_batcher(source, cfg);
     batcher.advance().expect("advance should succeed");
-    drop(batcher);
+    batcher.flush(&mut h.l1);
 
     // Before mining: pending pool should have at least one tx.
     let pending = h.l1.pending_txs();
@@ -106,7 +106,7 @@ fn batcher_tx_payload_starts_with_derivation_version_0() {
     let source = make_source(&h, 2);
     let mut batcher = h.create_batcher(source, BatcherConfig::default());
     batcher.advance().expect("advance should succeed");
-    drop(batcher);
+    batcher.flush(&mut h.l1);
 
     for tx in h.l1.pending_txs() {
         assert_eq!(
@@ -123,7 +123,7 @@ fn mined_block_contains_batcher_txs() {
     let source = make_source(&h, 2);
     let mut batcher = h.create_batcher(source, BatcherConfig::default());
     batcher.advance().expect("advance should succeed");
-    drop(batcher);
+    batcher.flush(&mut h.l1);
 
     h.l1.mine_block();
 
@@ -137,7 +137,7 @@ fn mined_block_contains_batcher_txs() {
 
 #[test]
 fn action_act_delegates_to_advance() {
-    let mut h = ActionTestHarness::default();
+    let h = ActionTestHarness::default();
     let source = make_source(&h, 1);
     let mut batcher = h.create_batcher(source, BatcherConfig::default());
     let frames = batcher.act().expect("act should succeed");
@@ -162,6 +162,7 @@ fn two_batcher_cycles_each_submit_distinct_txs() {
         }
         let mut batcher = h.create_batcher(source, BatcherConfig::default());
         batcher.advance().expect("first advance");
+        batcher.flush(&mut h.l1);
     }
     h.l1.mine_block();
     let after_first = h.l1.tip().batcher_txs.len();
@@ -175,6 +176,7 @@ fn two_batcher_cycles_each_submit_distinct_txs() {
         }
         let mut batcher = h.create_batcher(source, BatcherConfig::default());
         batcher.advance().expect("second advance");
+        batcher.flush(&mut h.l1);
     }
     h.l1.mine_block();
     let after_second = h.l1.tip().batcher_txs.len();
@@ -205,6 +207,7 @@ fn batcher_txs_survive_reorg_and_resubmit() {
         }
         let mut batcher = h.create_batcher(source, BatcherConfig::default());
         batcher.advance().expect("advance");
+        batcher.flush(&mut h.l1);
     }
     h.l1.mine_block();
     assert_eq!(h.l1.latest_number(), 2);
@@ -223,6 +226,7 @@ fn batcher_txs_survive_reorg_and_resubmit() {
         }
         let mut batcher = h.create_batcher(source, BatcherConfig::default());
         batcher.advance().expect("re-advance after reorg");
+        batcher.flush(&mut h.l1);
     }
     h.l1.mine_block();
 
@@ -241,7 +245,7 @@ fn garbage_random_submitted_to_l1() {
     let source = ActionL2Source::new();
     let mut batcher = h.create_batcher(source, BatcherConfig::default());
     batcher.submit_garbage_frames(GarbageKind::Random);
-    drop(batcher);
+    batcher.flush(&mut h.l1);
     assert_eq!(h.l1.pending_txs().len(), 1, "garbage tx should be queued");
 }
 
@@ -251,7 +255,7 @@ fn garbage_truncated_submitted_to_l1() {
     let source = ActionL2Source::new();
     let mut batcher = h.create_batcher(source, BatcherConfig::default());
     batcher.submit_garbage_frames(GarbageKind::Truncated);
-    drop(batcher);
+    batcher.flush(&mut h.l1);
     assert_eq!(h.l1.pending_txs().len(), 1, "garbage tx should be queued");
 }
 
@@ -261,7 +265,7 @@ fn garbage_malformed_rlp_submitted_to_l1() {
     let source = ActionL2Source::new();
     let mut batcher = h.create_batcher(source, BatcherConfig::default());
     batcher.submit_garbage_frames(GarbageKind::MalformedRlp);
-    drop(batcher);
+    batcher.flush(&mut h.l1);
     assert_eq!(h.l1.pending_txs().len(), 1, "garbage tx should be queued");
 }
 
@@ -271,7 +275,7 @@ fn garbage_invalid_brotli_submitted_to_l1() {
     let source = ActionL2Source::new();
     let mut batcher = h.create_batcher(source, BatcherConfig::default());
     batcher.submit_garbage_frames(GarbageKind::InvalidBrotli);
-    drop(batcher);
+    batcher.flush(&mut h.l1);
     assert_eq!(h.l1.pending_txs().len(), 1, "garbage tx should be queued");
 }
 
@@ -281,7 +285,7 @@ fn garbage_strip_version_submitted_to_l1() {
     let source = ActionL2Source::new();
     let mut batcher = h.create_batcher(source, BatcherConfig::default());
     batcher.submit_garbage_frames(GarbageKind::StripVersion);
-    drop(batcher);
+    batcher.flush(&mut h.l1);
     assert_eq!(h.l1.pending_txs().len(), 1, "garbage tx should be queued");
 }
 
@@ -291,6 +295,6 @@ fn garbage_dirty_append_submitted_to_l1() {
     let source = ActionL2Source::new();
     let mut batcher = h.create_batcher(source, BatcherConfig::default());
     batcher.submit_garbage_frames(GarbageKind::DirtyAppend);
-    drop(batcher);
+    batcher.flush(&mut h.l1);
     assert_eq!(h.l1.pending_txs().len(), 1, "garbage tx should be queued");
 }

--- a/actions/harness/tests/batcher_blobs.rs
+++ b/actions/harness/tests/batcher_blobs.rs
@@ -1,6 +1,5 @@
 #![doc = "Action tests for blob DA submission and mixed calldata/blob derivation."]
 
-use alloy_primitives::B256;
 use base_action_harness::{
     ActionL2Source, ActionTestHarness, BatcherConfig, L1MinerConfig, SharedL1Chain,
     TestRollupConfigBuilder, block_info_from,
@@ -26,30 +25,26 @@ async fn batcher_blob_da_end_to_end() {
     let l1_chain = SharedL1Chain::from_blocks(h.l1.chain().to_vec());
     let mut sequencer = h.create_l2_sequencer(l1_chain);
 
-    let mut block_hashes: Vec<(u64, B256)> = Vec::new();
-
     // Build and submit each L2 block in its own L1 blob block.
-    for i in 1..=3u64 {
+    for _ in 1..=3u64 {
         let block = sequencer.build_next_block().expect("build L2 block");
-        let hash = sequencer.head().block_info.hash;
-        block_hashes.push((i, hash));
 
         let mut source = ActionL2Source::new();
         source.push(block);
         let mut batcher = h.create_batcher(source, batcher_cfg.clone());
         let frames = batcher.encode_frames().expect("encode frames");
         batcher.submit_blob_frames(&frames);
-        drop(batcher);
+        batcher.flush(&mut h.l1);
 
         h.l1.mine_block();
     }
 
     // Create the blob verifier AFTER mining so the SharedL1Chain snapshot
     // includes all L1 blocks with their blob sidecars.
-    let (mut verifier, _chain) = h.create_blob_verifier();
-    for (number, hash) in &block_hashes {
-        verifier.register_block_hash(*number, *hash);
-    }
+    let (mut verifier, _chain) = h.create_blob_verifier_from_sequencer(
+        &sequencer,
+        SharedL1Chain::from_blocks(h.l1.chain().to_vec()),
+    );
     verifier.initialize().await.expect("initialize");
 
     // Drive derivation one L1 block at a time.
@@ -91,7 +86,6 @@ async fn batcher_multi_blob_packing() {
 
     // Build 1 L2 block and encode it into multiple frames (tiny max_frame_size).
     let block = sequencer.build_next_block().expect("build L2 block");
-    let hash1 = sequencer.head().block_info.hash;
 
     let mut source = ActionL2Source::new();
     source.push(block);
@@ -104,13 +98,15 @@ async fn batcher_multi_blob_packing() {
     );
     // All frames go into the same L1 block as separate blob sidecars.
     batcher.submit_blob_frames(&frames);
-    drop(batcher);
+    batcher.flush(&mut h.l1);
 
     h.l1.mine_block(); // L1 block 1: all blob sidecars for the fragmented channel
 
     // Create verifier AFTER mining so the snapshot includes the blob block.
-    let (mut verifier, _chain) = h.create_blob_verifier();
-    verifier.register_block_hash(1, hash1);
+    let (mut verifier, _chain) = h.create_blob_verifier_from_sequencer(
+        &sequencer,
+        SharedL1Chain::from_blocks(h.l1.chain().to_vec()),
+    );
     verifier.initialize().await.expect("initialize");
 
     // Signal L1 block 1: the pipeline reads all blob sidecars, reassembles the
@@ -143,27 +139,23 @@ async fn batcher_calldata_da() {
     let l1_chain = SharedL1Chain::from_blocks(h.l1.chain().to_vec());
     let mut sequencer = h.create_l2_sequencer(l1_chain);
 
-    let mut block_hashes: Vec<(u64, B256)> = Vec::new();
-
-    for i in 1..=3u64 {
+    for _ in 1..=3u64 {
         let block = sequencer.build_next_block().expect("build L2 block");
-        let hash = sequencer.head().block_info.hash;
-        block_hashes.push((i, hash));
 
         let mut source = ActionL2Source::new();
         source.push(block);
         let mut batcher = h.create_batcher(source, batcher_cfg.clone());
         let frames = batcher.encode_frames().expect("encode frames");
         batcher.submit_frames(&frames);
-        drop(batcher);
+        batcher.flush(&mut h.l1);
 
         h.l1.mine_block();
     }
 
-    let (mut verifier, _chain) = h.create_verifier();
-    for (number, hash) in &block_hashes {
-        verifier.register_block_hash(*number, *hash);
-    }
+    let (mut verifier, _chain) = h.create_verifier_from_sequencer(
+        &sequencer,
+        SharedL1Chain::from_blocks(h.l1.chain().to_vec()),
+    );
     verifier.initialize().await.expect("initialize");
 
     for i in 1..=3u64 {
@@ -200,45 +192,39 @@ async fn batcher_da_switching() {
     let l1_chain = SharedL1Chain::from_blocks(h.l1.chain().to_vec());
     let mut sequencer = h.create_l2_sequencer(l1_chain);
 
-    let mut block_hashes: Vec<(u64, B256)> = Vec::new();
-
     // Blocks 1-3: submit as calldata (one block per L1 block).
-    for i in 1..=3u64 {
+    for _ in 1..=3u64 {
         let block = sequencer.build_next_block().expect("build calldata block");
-        let hash = sequencer.head().block_info.hash;
-        block_hashes.push((i, hash));
 
         let mut source = ActionL2Source::new();
         source.push(block);
         let mut batcher = h.create_batcher(source, batcher_cfg.clone());
         let frames = batcher.encode_frames().expect("encode calldata frames");
         batcher.submit_frames(&frames);
-        drop(batcher);
+        batcher.flush(&mut h.l1);
         h.l1.mine_block();
     }
 
     // Blocks 4-6: submit as blobs (one block per L1 block).
-    for i in 4..=6u64 {
+    for _ in 4..=6u64 {
         let block = sequencer.build_next_block().expect("build blob block");
-        let hash = sequencer.head().block_info.hash;
-        block_hashes.push((i, hash));
 
         let mut source = ActionL2Source::new();
         source.push(block);
         let mut batcher = h.create_batcher(source, batcher_cfg.clone());
         let frames = batcher.encode_frames().expect("encode blob frames");
         batcher.submit_blob_frames(&frames);
-        drop(batcher);
+        batcher.flush(&mut h.l1);
         h.l1.mine_block();
     }
 
     // The blob verifier handles both calldata (batcher_txs) and blobs
     // (blob_sidecars) from each block, making it capable of deriving the
     // full mixed sequence without any pipeline changes.
-    let (mut verifier, _chain) = h.create_blob_verifier();
-    for (number, hash) in &block_hashes {
-        verifier.register_block_hash(*number, *hash);
-    }
+    let (mut verifier, _chain) = h.create_blob_verifier_from_sequencer(
+        &sequencer,
+        SharedL1Chain::from_blocks(h.l1.chain().to_vec()),
+    );
     verifier.initialize().await.expect("initialize");
 
     let mut total_derived = 0;

--- a/actions/harness/tests/batcher_channels.rs
+++ b/actions/harness/tests/batcher_channels.rs
@@ -67,7 +67,6 @@ async fn channel_timeout_triggers_channel_invalidation() {
     let l1_chain = SharedL1Chain::from_blocks(h.l1.chain().to_vec());
     let mut sequencer = h.create_l2_sequencer(l1_chain);
     let block = sequencer.build_next_block().expect("build L2 block 1");
-    let block_hash = sequencer.head().block_info.hash;
 
     let mut source = ActionL2Source::new();
     source.push(block.clone());
@@ -81,10 +80,12 @@ async fn channel_timeout_triggers_channel_invalidation() {
 
     // Submit ONLY frame 0 in L1 block 1.
     batcher.submit_frames(&frames[..1]);
-    drop(batcher);
+    batcher.flush(&mut h.l1);
 
-    let (mut verifier, chain) = h.create_verifier();
-    verifier.register_block_hash(1, block_hash);
+    let (mut verifier, chain) = h.create_verifier_from_sequencer(
+        &sequencer,
+        SharedL1Chain::from_blocks(h.l1.chain().to_vec()),
+    );
 
     h.mine_and_push(&chain); // L1 block 1: frame 0 only
 
@@ -119,7 +120,7 @@ async fn channel_timeout_triggers_channel_invalidation() {
         let empty_source = ActionL2Source::new();
         let mut late_batcher = h.create_batcher(empty_source, batcher_cfg.clone());
         late_batcher.submit_frames(&frames[1..]);
-        drop(late_batcher);
+        late_batcher.flush(&mut h.l1);
     }
     h.mine_and_push(&chain); // L1 block 5: late frames
 
@@ -134,7 +135,7 @@ async fn channel_timeout_triggers_channel_invalidation() {
     source2.push(block);
     let mut batcher2 = h.create_batcher(source2, batcher_cfg);
     batcher2.advance().expect("resubmit in new channel");
-    drop(batcher2);
+    batcher2.flush(&mut h.l1);
     h.mine_and_push(&chain); // L1 block 6: fresh channel, all frames
 
     let l1_block_6 = block_info_from(h.l1.block_by_number(6).expect("block 6"));
@@ -154,79 +155,90 @@ async fn channel_timeout_triggers_channel_invalidation() {
 /// derives the blocks from the recovery channel.
 ///
 /// This is a simpler variant of [`channel_timeout_triggers_channel_invalidation`]
-/// that focuses purely on the recovery path without verifying the timeout
-/// expiration itself. It can be implemented without the multi-block channel
-/// bank limitation since the recovery channel fits in a single L1 block.
-///
-/// ## Harness requirements
-///
-/// No new methods needed — uses existing `Batcher::advance()` with a fresh
-/// `ChannelDriver` instance for the recovery submission.
+/// that focuses purely on the recovery path. The timeout is induced the same
+/// way as in that test: encode a multi-frame channel, submit only frame 0 in
+/// L1 block 1, then let the channel expire over `channel_timeout + 1` empty
+/// blocks. The recovery submits all frames in a single L1 block so the new
+/// channel completes immediately.
 #[tokio::test]
-#[ignore = "test design issue: batcher.advance() submits all frames in a single L1 \
-            block, so the channel completes immediately and the safe head advances \
-            before the timeout window elapses — needs restructuring to use selective \
-            per-frame submission to make the channel actually expire before recovery"]
 async fn channel_timeout_recovery_resubmits_successfully() {
-    let batcher_cfg = BatcherConfig::default();
+    use base_batcher_encoder::EncoderConfig;
+
+    // Small max_frame_size forces a multi-frame channel so we can hold back
+    // frames to induce a timeout, matching the setup in
+    // channel_timeout_triggers_channel_invalidation.
+    let batcher_cfg = BatcherConfig {
+        encoder: EncoderConfig { max_frame_size: 80, ..EncoderConfig::default() },
+        ..BatcherConfig::default()
+    };
     let rollup_cfg =
         TestRollupConfigBuilder::base_mainnet(&batcher_cfg).with_channel_timeout(2).build();
     let mut h = ActionTestHarness::new(L1MinerConfig::default(), rollup_cfg);
 
-    // Build L2 block 1.
     let l1_chain = SharedL1Chain::from_blocks(h.l1.chain().to_vec());
     let mut sequencer = h.create_l2_sequencer(l1_chain);
     let block = sequencer.build_next_block().expect("build block 1");
-    let block_hash = sequencer.head().block_info.hash;
 
-    // First attempt: submit batch in L1 block 1.
+    // Encode into a multi-frame channel.
     let mut source = ActionL2Source::new();
     source.push(block.clone());
     let mut batcher = h.create_batcher(source, batcher_cfg.clone());
-    batcher.advance().expect("first submit");
-    drop(batcher);
+    let frames = batcher.encode_frames().expect("encode frames");
+    assert!(
+        frames.len() >= 2,
+        "expected multi-frame channel with max_frame_size=80, got {} frames",
+        frames.len()
+    );
 
-    let (mut verifier, chain) = h.create_verifier();
-    verifier.register_block_hash(1, block_hash);
+    // Submit only frame 0 in L1 block 1 — channel stays incomplete.
+    batcher.submit_frames(&frames[..1]);
+    batcher.flush(&mut h.l1);
 
-    h.mine_and_push(&chain); // L1 block 1
+    let (mut verifier, chain) = h.create_verifier_from_sequencer(
+        &sequencer,
+        SharedL1Chain::from_blocks(h.l1.chain().to_vec()),
+    );
+
+    h.mine_and_push(&chain); // L1 block 1: frame 0 only
 
     verifier.initialize().await.expect("initialize");
 
-    // Mine enough empty blocks to expire the channel.
-    // channel_timeout = 2, so after 3 more empty blocks the channel is gone.
+    // Mine channel_timeout + 1 = 3 empty blocks to expire the channel.
     for _ in 0..3 {
-        h.mine_and_push(&chain);
+        h.mine_and_push(&chain); // L1 blocks 2, 3, 4
     }
 
-    // Step through all L1 blocks so far.
+    // Step the pipeline through all L1 blocks. The channel is pruned once
+    // L1 block 3 is processed (3 − 1 = 2 ≥ channel_timeout = 2).
     for i in 1..=h.l1.latest_number() {
-        let blk = block_info_from(h.l1.block_by_number(i).expect("block"));
+        let blk = block_info_from(h.l1.block_by_number(i).expect("block exists"));
         verifier.act_l1_head_signal(blk).await.expect("signal");
         verifier.act_l2_pipeline_full().await.expect("step");
     }
 
-    // Safe head should still be at genesis (channel timed out).
-    // NOTE: The pipeline may generate deposit-only default blocks instead,
-    // in which case the safe head advances past genesis. Both outcomes are
-    // valid — the key assertion is that the ORIGINAL batch content was not
-    // derived.
+    // The channel timed out — safe head is still at genesis.
+    assert_eq!(
+        verifier.l2_safe().block_info.number,
+        0,
+        "channel should have timed out; safe head must remain at genesis"
+    );
 
-    // Recovery: resubmit in a new channel (all frames in one L1 block).
+    // Recovery: submit all frames in one L1 block so the new channel
+    // completes immediately within the timeout window.
     let mut source2 = ActionL2Source::new();
     source2.push(block);
     let mut batcher2 = h.create_batcher(source2, batcher_cfg);
     batcher2.advance().expect("recovery submit");
-    drop(batcher2);
-    h.mine_and_push(&chain);
+    batcher2.flush(&mut h.l1);
+    h.mine_and_push(&chain); // L1 block 5: fresh channel, all frames
 
     let recovery_blk =
         block_info_from(h.l1.block_by_number(h.l1.latest_number()).expect("recovery block"));
     verifier.act_l1_head_signal(recovery_blk).await.expect("signal recovery");
     let recovered = verifier.act_l2_pipeline_full().await.expect("step recovery");
 
-    // The recovery channel should derive L2 block 1.
-    assert!(recovered >= 1, "recovery channel should derive at least 1 L2 block");
+    assert_eq!(recovered, 1, "recovery channel should derive L2 block 1");
+    assert_eq!(verifier.l2_safe().block_info.number, 1, "safe head should recover to 1");
 }
 
 // ---------------------------------------------------------------------------
@@ -299,7 +311,6 @@ async fn interleaved_channels_correctly_reassembled() {
     let mut batcher_a = h.create_batcher(source_a, batcher_cfg.clone());
     let frames_a = batcher_a.encode_frames().expect("encode channel A");
     assert!(frames_a.len() >= 2, "channel A should have 2+ frames, got {}", frames_a.len());
-    drop(batcher_a);
 
     // Encode channel B (L2 block 2).
     let mut source_b = ActionL2Source::new();
@@ -307,7 +318,6 @@ async fn interleaved_channels_correctly_reassembled() {
     let mut batcher_b = h.create_batcher(source_b, batcher_cfg.clone());
     let frames_b = batcher_b.encode_frames().expect("encode channel B");
     assert!(frames_b.len() >= 2, "channel B should have 2+ frames, got {}", frames_b.len());
-    drop(batcher_b);
 
     // Verify channels have distinct IDs (will fail until ChannelDriver is updated).
     assert_ne!(
@@ -329,7 +339,7 @@ async fn interleaved_channels_correctly_reassembled() {
                 submitter.submit_frames(&frames_b[i..i + 1]);
             }
         }
-        drop(submitter);
+        submitter.flush(&mut h.l1);
     }
 
     // Mine one L1 block containing all interleaved frames.
@@ -387,7 +397,6 @@ async fn multi_block_channel_assembles_across_l1_blocks() {
     let l1_chain = SharedL1Chain::from_blocks(h.l1.chain().to_vec());
     let mut sequencer = h.create_l2_sequencer(l1_chain);
     let block = sequencer.build_next_block().expect("build L2 block 1");
-    let hash1 = sequencer.head().block_info.hash;
 
     let mut source = ActionL2Source::new();
     source.push(block);
@@ -401,10 +410,12 @@ async fn multi_block_channel_assembles_across_l1_blocks() {
 
     // Submit frame 0 only → L1 block 1.
     batcher.submit_frames(&frames[..1]);
-    drop(batcher);
+    batcher.flush(&mut h.l1);
 
-    let (mut verifier, chain) = h.create_verifier();
-    verifier.register_block_hash(1, hash1);
+    let (mut verifier, chain) = h.create_verifier_from_sequencer(
+        &sequencer,
+        SharedL1Chain::from_blocks(h.l1.chain().to_vec()),
+    );
 
     h.mine_and_push(&chain); // L1 block 1: frame 0
 
@@ -425,7 +436,7 @@ async fn multi_block_channel_assembles_across_l1_blocks() {
         let empty_source = ActionL2Source::new();
         let mut batcher2 = h.create_batcher(empty_source, batcher_cfg);
         batcher2.submit_frames(&frames[1..]);
-        drop(batcher2);
+        batcher2.flush(&mut h.l1);
     }
     h.mine_and_push(&chain); // L1 block 2: remaining frames
 

--- a/actions/harness/tests/batcher_sequencer_drift.rs
+++ b/actions/harness/tests/batcher_sequencer_drift.rs
@@ -79,7 +79,7 @@ async fn sequencer_drift_produces_deposit_only_blocks() {
         source.push(block);
         let mut batcher = h.create_batcher(source, batcher_cfg.clone());
         batcher.advance().expect("batcher encode");
-        drop(batcher);
+        batcher.flush(&mut h.l1);
         h.mine_and_push(&chain);
     }
 
@@ -158,7 +158,7 @@ async fn sequencer_drift_forced_empty_blocks_accepted() {
         source.push(block);
         let mut batcher = h.create_batcher(source, batcher_cfg.clone());
         batcher.advance().expect("encode");
-        drop(batcher);
+        batcher.flush(&mut h.l1);
         h.mine_and_push(&chain);
     }
 
@@ -172,7 +172,7 @@ async fn sequencer_drift_forced_empty_blocks_accepted() {
         source.push(block);
         let mut batcher = h.create_batcher(source, batcher_cfg.clone());
         batcher.advance().expect("encode empty block");
-        drop(batcher);
+        batcher.flush(&mut h.l1);
         h.mine_and_push(&chain);
     }
 

--- a/actions/harness/tests/batcher_stress.rs
+++ b/actions/harness/tests/batcher_stress.rs
@@ -39,7 +39,7 @@ fn batcher_stress_large_txs() {
 
     // Submit all frames to L1.
     batcher.submit_frames(&frames);
-    drop(batcher);
+    batcher.flush(&mut h.l1);
 
     // Mine the block containing all frame txs.
     h.l1.mine_block();

--- a/actions/harness/tests/batcher_throttling.rs
+++ b/actions/harness/tests/batcher_throttling.rs
@@ -2,9 +2,9 @@
 
 use base_action_harness::{
     ActionL2Source, ActionTestHarness, BatcherConfig, L1MinerConfig, SharedL1Chain,
+    TestRollupConfigBuilder,
 };
 use base_batcher_core::{ThrottleConfig, ThrottleController, ThrottleStrategy};
-use base_consensus_registry::Registry;
 
 /// When the batcher accumulates frames without submitting them, the total
 /// encoded bytes should exceed a configured threshold and activate
@@ -14,20 +14,8 @@ use base_consensus_registry::Registry;
 async fn test_throttle_activates_when_frames_accumulate() {
     let l1_cfg = L1MinerConfig { block_time: 2 };
     let batcher_cfg = BatcherConfig::default();
-    let rollup_cfg = {
-        let mut rc = Registry::rollup_config(8453).unwrap().clone();
-        rc.batch_inbox_address = batcher_cfg.inbox_address;
-        rc.genesis.system_config.as_mut().unwrap().batcher_address = batcher_cfg.batcher_address;
-        rc.genesis.l2_time = 0;
-        rc.genesis.l1 = Default::default();
-        rc.genesis.l2 = Default::default();
-        rc.hardforks.canyon_time = Some(0);
-        rc.hardforks.delta_time = Some(0);
-        rc.hardforks.ecotone_time = Some(0);
-        rc.hardforks.fjord_time = Some(0);
-        rc
-    };
-    let mut h = ActionTestHarness::new(l1_cfg, rollup_cfg);
+    let rollup_cfg = TestRollupConfigBuilder::base_mainnet(&batcher_cfg).build();
+    let h = ActionTestHarness::new(l1_cfg, rollup_cfg);
     let l1_chain = SharedL1Chain::from_blocks(h.l1.chain().to_vec());
     let mut sequencer = h.create_l2_sequencer(l1_chain);
 
@@ -129,20 +117,8 @@ fn test_throttle_step_strategy_full_intensity() {
 fn test_throttle_batcher_integration() {
     let l1_cfg = L1MinerConfig { block_time: 2 };
     let batcher_cfg = BatcherConfig::default();
-    let rollup_cfg = {
-        let mut rc = Registry::rollup_config(8453).unwrap().clone();
-        rc.batch_inbox_address = batcher_cfg.inbox_address;
-        rc.genesis.system_config.as_mut().unwrap().batcher_address = batcher_cfg.batcher_address;
-        rc.genesis.l2_time = 0;
-        rc.genesis.l1 = Default::default();
-        rc.genesis.l2 = Default::default();
-        rc.hardforks.canyon_time = Some(0);
-        rc.hardforks.delta_time = Some(0);
-        rc.hardforks.ecotone_time = Some(0);
-        rc.hardforks.fjord_time = Some(0);
-        rc
-    };
-    let mut h = ActionTestHarness::new(l1_cfg, rollup_cfg);
+    let rollup_cfg = TestRollupConfigBuilder::base_mainnet(&batcher_cfg).build();
+    let h = ActionTestHarness::new(l1_cfg, rollup_cfg);
     let l1_chain = SharedL1Chain::from_blocks(h.l1.chain().to_vec());
     let mut sequencer = h.create_l2_sequencer(l1_chain);
 

--- a/actions/harness/tests/derivation.rs
+++ b/actions/harness/tests/derivation.rs
@@ -33,7 +33,7 @@ async fn single_l2_block_derived_from_batcher_frame() {
     // Encode the L2 block into a batcher frame and submit to the L1 pending pool.
     let mut batcher = h.create_batcher(source, batcher_cfg);
     batcher.advance().expect("batcher should encode the block");
-    drop(batcher);
+    batcher.flush(&mut h.l1);
 
     // Mine the L1 block that includes the batcher transaction.
     h.l1.mine_block();
@@ -87,7 +87,7 @@ async fn multiple_l1_blocks_each_derive_one_l2_block() {
 
         let mut batcher = h.create_batcher(source, batcher_cfg.clone());
         batcher.advance().expect("batcher advance");
-        drop(batcher);
+        batcher.flush(&mut h.l1);
         h.l1.mine_block();
     }
 
@@ -126,7 +126,7 @@ async fn batch_in_orphaned_l1_block_is_not_derived() {
 
     let mut batcher = h.create_batcher(source, batcher_cfg);
     batcher.advance().expect("batcher encode");
-    drop(batcher);
+    batcher.flush(&mut h.l1);
     h.l1.mine_block();
 
     // Reorg L1 back to genesis; mine an empty replacement block 1'.
@@ -167,7 +167,7 @@ async fn reorg_reverts_derived_safe_head() {
 
     let mut batcher = h.create_batcher(source, batcher_cfg);
     batcher.advance().expect("batcher encode");
-    drop(batcher);
+    batcher.flush(&mut h.l1);
     h.l1.mine_block();
 
     // Create the verifier and derive L2 block 1.
@@ -227,7 +227,7 @@ async fn reorg_and_resubmit_rederives_l2_block() {
     source.push(block1.clone());
     let mut batcher = h.create_batcher(source, batcher_cfg.clone());
     batcher.advance().expect("batcher encode");
-    drop(batcher);
+    batcher.flush(&mut h.l1);
     h.l1.mine_block();
 
     let (mut verifier, chain) = h.create_verifier_from_sequencer(
@@ -268,7 +268,7 @@ async fn reorg_and_resubmit_rederives_l2_block() {
     source2.push(block1);
     let mut batcher = h.create_batcher(source2, batcher_cfg);
     batcher.advance().expect("batcher re-encode on new fork");
-    drop(batcher);
+    batcher.flush(&mut h.l1);
     h.l1.mine_block(); // block 2'
     chain.push(h.l1.tip().clone());
 
@@ -309,7 +309,7 @@ async fn reorg_flip_flop() {
     source.push(block1.clone());
     let mut batcher = h.create_batcher(source, batcher_cfg.clone());
     batcher.advance().expect("A1 batcher encode");
-    drop(batcher);
+    batcher.flush(&mut h.l1);
     h.l1.mine_block(); // A1
 
     let (mut verifier, chain) = h.create_verifier_from_sequencer(
@@ -328,7 +328,7 @@ async fn reorg_flip_flop() {
     source.push(block1.clone());
     let mut batcher = h.create_batcher(source, batcher_cfg.clone());
     batcher.advance().expect("B1 batcher encode");
-    drop(batcher);
+    batcher.flush(&mut h.l1);
     h.l1.mine_block(); // B1
     let fork_b1 = block_info_from(h.l1.tip());
 
@@ -348,7 +348,7 @@ async fn reorg_flip_flop() {
     source.push(block1);
     let mut batcher = h.create_batcher(source, batcher_cfg);
     batcher.advance().expect("A1' batcher encode");
-    drop(batcher);
+    batcher.flush(&mut h.l1);
     h.l1.mine_block(); // A1'
     let fork_a_prime1 = block_info_from(h.l1.tip());
 
@@ -402,7 +402,7 @@ async fn reorg_flip_flop_empty_middle_fork() {
         source.push(block);
         let mut batcher = h.create_batcher(source, batcher_cfg.clone());
         batcher.advance().expect("fork A: encode");
-        drop(batcher);
+        batcher.flush(&mut h.l1);
         h.l1.mine_block();
     }
 
@@ -464,7 +464,7 @@ async fn reorg_flip_flop_empty_middle_fork() {
         source.push(block);
         let mut batcher = h.create_batcher(source, batcher_cfg.clone());
         batcher.advance().expect("fork C: encode");
-        drop(batcher);
+        batcher.flush(&mut h.l1);
         fork_c_blocks.push(h.mine_and_push(&chain));
     }
 
@@ -524,7 +524,7 @@ async fn batch_accepted_at_last_seq_window_block() {
     // epoch 0 with seq_window_size = 4 (valid iff inclusion_block < 4).
     let mut batcher = h.create_batcher(source, batcher_cfg);
     batcher.advance().expect("batcher encode");
-    drop(batcher);
+    batcher.flush(&mut h.l1);
     h.l1.mine_block(); // block 3
 
     let (mut verifier, _chain) = h.create_verifier_from_sequencer(
@@ -684,7 +684,7 @@ async fn l1_deposit_included_in_derived_l2_block() {
     // Submit the batcher frame into the same L1 block as the deposit log.
     let mut batcher = h.create_batcher(source, batcher_cfg);
     batcher.advance().expect("batcher encode");
-    drop(batcher);
+    batcher.flush(&mut h.l1);
     h.l1.mine_block();
 
     // Create verifier AFTER mining so the snapshot contains block 1.
@@ -759,7 +759,7 @@ async fn batcher_key_rotation_accepts_new_batcher() {
         source.push(block);
         let mut batcher = h.create_batcher(source, batcher_a.clone());
         batcher.advance().expect("batcher A encode");
-        drop(batcher);
+        batcher.flush(&mut h.l1);
         h.l1.mine_block();
     }
 
@@ -794,7 +794,7 @@ async fn batcher_key_rotation_accepts_new_batcher() {
     source_a.push(block3.clone());
     let mut batcher = h.create_batcher(source_a, batcher_a.clone());
     batcher.advance().expect("batcher A encode block 3");
-    drop(batcher);
+    batcher.flush(&mut h.l1);
     h.l1.mine_block(); // block 4 — A's frame
     chain.push(h.l1.tip().clone());
 
@@ -808,7 +808,7 @@ async fn batcher_key_rotation_accepts_new_batcher() {
     source_b.push(block3);
     let mut batcher = h.create_batcher(source_b, batcher_b);
     batcher.advance().expect("batcher B encode block 3");
-    drop(batcher);
+    batcher.flush(&mut h.l1);
     h.l1.mine_block(); // block 5 — B's frame
     chain.push(h.l1.tip().clone());
 
@@ -846,7 +846,7 @@ async fn multi_l2_per_l1_epoch() {
         source.push(block);
         let mut batcher = h.create_batcher(source, batcher_cfg.clone());
         batcher.advance().expect("batcher advance");
-        drop(batcher);
+        batcher.flush(&mut h.l1);
 
         h.mine_and_push(&chain);
     }
@@ -905,7 +905,7 @@ async fn batch_past_sequence_window_rejected() {
     // Submit batch in block 3 — past the window.
     let mut batcher = h.create_batcher(source, batcher_cfg);
     batcher.advance().expect("encode");
-    drop(batcher);
+    batcher.flush(&mut h.l1);
     h.l1.mine_block(); // block 3
 
     let (mut verifier, _chain) = h.create_verifier_from_sequencer(
@@ -985,7 +985,7 @@ async fn multi_epoch_sequence() {
         source.push(block.clone());
         let mut batcher = h.create_batcher(source, batcher_cfg.clone());
         batcher.advance().expect("batcher advance");
-        drop(batcher);
+        batcher.flush(&mut h.l1);
         h.mine_and_push(&chain);
     }
 
@@ -1028,7 +1028,7 @@ async fn same_epoch_multi_batch_one_l1_block() {
     // Encode all 3 blocks into one batcher submission (single channel).
     let mut batcher = h.create_batcher(source, batcher_cfg);
     batcher.advance().expect("batcher encode 3 blocks");
-    drop(batcher);
+    batcher.flush(&mut h.l1);
 
     // Mine ONE L1 block containing all 3 batches.
     h.l1.mine_block();
@@ -1077,7 +1077,7 @@ async fn deep_reorg_multi_block() {
         source.push(block.clone());
         let mut batcher = h.create_batcher(source, batcher_cfg.clone());
         batcher.advance().expect("encode");
-        drop(batcher);
+        batcher.flush(&mut h.l1);
         h.l1.mine_block();
     }
 
@@ -1113,7 +1113,7 @@ async fn deep_reorg_multi_block() {
         source.push(block.clone());
         let mut batcher = h.create_batcher(source, batcher_cfg.clone());
         batcher.advance().expect("re-encode");
-        drop(batcher);
+        batcher.flush(&mut h.l1);
         h.mine_and_push(&chain);
     }
 
@@ -1174,7 +1174,7 @@ async fn garbage_frame_data_ignored() {
     // Now submit the real batch.
     let mut batcher = h.create_batcher(source, batcher_cfg);
     batcher.advance().expect("encode");
-    drop(batcher);
+    batcher.flush(&mut h.l1);
     h.mine_and_push(&chain);
 
     let l1_block_2 = block_info_from(h.l1.block_by_number(2).expect("block 2"));
@@ -1241,7 +1241,7 @@ async fn multi_frame_channel_reassembled() {
 
     // Submit ALL frames to the same L1 block (each as a separate tx).
     batcher.submit_frames(&frames);
-    drop(batcher);
+    batcher.flush(&mut h.l1);
     h.mine_and_push(&chain);
 
     verifier.initialize().await.expect("initialize");
@@ -1274,7 +1274,7 @@ async fn single_l2_block_derived_from_span_batch() {
 
     let mut batcher = h.create_batcher(source, batcher_cfg);
     batcher.advance().expect("span batcher advance");
-    drop(batcher);
+    batcher.flush(&mut h.l1);
 
     h.l1.mine_block();
 
@@ -1314,7 +1314,7 @@ async fn three_l2_blocks_derived_from_span_batch() {
 
     let mut batcher = h.create_batcher(source, batcher_cfg);
     batcher.advance().expect("span advance");
-    drop(batcher);
+    batcher.flush(&mut h.l1);
 
     h.l1.mine_block();
 
@@ -1419,7 +1419,7 @@ async fn gpo_params_change_does_not_disrupt_derivation() {
     source.push(block1);
     let mut batcher = h.create_batcher(source, batcher_cfg.clone());
     batcher.advance().expect("encode block 1");
-    drop(batcher);
+    batcher.flush(&mut h.l1);
     h.l1.mine_block();
 
     // L1 block 2: gas-config update log only, no batch.
@@ -1431,7 +1431,7 @@ async fn gpo_params_change_does_not_disrupt_derivation() {
     source.push(block2);
     let mut batcher = h.create_batcher(source, batcher_cfg);
     batcher.advance().expect("encode block 2");
-    drop(batcher);
+    batcher.flush(&mut h.l1);
     h.l1.mine_block();
 
     let (mut verifier, _chain) = h.create_verifier_from_sequencer(
@@ -1479,7 +1479,7 @@ async fn gas_limit_change_does_not_disrupt_derivation() {
     source.push(block1);
     let mut batcher = h.create_batcher(source, batcher_cfg.clone());
     batcher.advance().expect("encode block 1");
-    drop(batcher);
+    batcher.flush(&mut h.l1);
     h.l1.mine_block();
 
     // L1 block 2: gas-limit update log only.
@@ -1491,7 +1491,7 @@ async fn gas_limit_change_does_not_disrupt_derivation() {
     source.push(block2);
     let mut batcher = h.create_batcher(source, batcher_cfg);
     batcher.advance().expect("encode block 2");
-    drop(batcher);
+    batcher.flush(&mut h.l1);
     h.l1.mine_block();
 
     let (mut verifier, _chain) = h.create_verifier_from_sequencer(
@@ -1534,7 +1534,7 @@ async fn garbage_kind_silently_ignored_then_valid_batch_derived(kind: GarbageKin
     let source_empty = ActionL2Source::new();
     let mut batcher = h.create_batcher(source_empty, batcher_cfg.clone());
     batcher.submit_garbage_frames(kind);
-    drop(batcher);
+    batcher.flush(&mut h.l1);
     h.l1.mine_block();
 
     // L1 block 2: valid batch.
@@ -1542,7 +1542,7 @@ async fn garbage_kind_silently_ignored_then_valid_batch_derived(kind: GarbageKin
     source.push(block);
     let mut batcher = h.create_batcher(source, batcher_cfg);
     batcher.advance().expect("encode valid batch");
-    drop(batcher);
+    batcher.flush(&mut h.l1);
     h.l1.mine_block();
 
     let (mut verifier, _chain) = h.create_verifier_from_sequencer(
@@ -1618,7 +1618,7 @@ async fn l2_finalized_advances_via_l1_finalized_signal() {
         source.push(block);
         let mut batcher = h.create_batcher(source, batcher_cfg.clone());
         batcher.advance().expect("encode");
-        drop(batcher);
+        batcher.flush(&mut h.l1);
         h.l1.mine_block();
     }
 
@@ -1772,7 +1772,7 @@ async fn derive_chain_from_near_l1_genesis() {
         source.push(block);
         let mut batcher = h.create_batcher(source, batcher_cfg.clone());
         batcher.advance().expect("encode");
-        drop(batcher);
+        batcher.flush(&mut h.l1);
         h.l1.mine_block(); // mines L1 block 5+i
     }
 
@@ -1829,7 +1829,7 @@ async fn single_l2_block_derived_from_blob() {
     // Encode the L2 block into frames (without submitting to L1 as calldata).
     let mut batcher = h.create_batcher(source, batcher_cfg);
     let frames = batcher.encode_frames().expect("batcher should encode the block");
-    drop(batcher);
+    batcher.flush(&mut h.l1);
 
     // Build the frame data payload: [DERIVATION_VERSION_0] ++ encoded frames.
     let mut frame_data = vec![DERIVATION_VERSION_0];
@@ -1878,7 +1878,7 @@ async fn multiple_l2_blocks_derived_from_blob() {
     // Encode all 3 blocks into a single channel and get the frames.
     let mut batcher = h.create_batcher(all_source, batcher_cfg);
     let frames = batcher.encode_frames().expect("batcher should encode blocks");
-    drop(batcher);
+    batcher.flush(&mut h.l1);
 
     // Build frame data and encode into a blob.
     let mut frame_data = vec![DERIVATION_VERSION_0];
@@ -1961,7 +1961,7 @@ async fn batcher_config_update_rolled_back_on_reorg() {
         source.push(block);
         let mut batcher = h.create_batcher(source, batcher_a.clone());
         batcher.advance().expect("batcher A encode");
-        drop(batcher);
+        batcher.flush(&mut h.l1);
         h.l1.mine_block();
     }
 
@@ -1995,7 +1995,7 @@ async fn batcher_config_update_rolled_back_on_reorg() {
     source_a.push(block3.clone());
     let mut batcher = h.create_batcher(source_a, batcher_a.clone());
     batcher.advance().expect("batcher A encode block 3");
-    drop(batcher);
+    batcher.flush(&mut h.l1);
     h.l1.mine_block();
     chain.push(h.l1.tip().clone());
 
@@ -2028,7 +2028,7 @@ async fn batcher_config_update_rolled_back_on_reorg() {
         source.push(block);
         let mut batcher = h.create_batcher(source, batcher_a.clone());
         batcher.advance().expect("batcher A encode on new fork");
-        drop(batcher);
+        batcher.flush(&mut h.l1);
         h.l1.mine_block();
         chain.push(h.l1.tip().clone());
     }
@@ -2086,7 +2086,7 @@ async fn out_of_order_singular_batches_reordered_by_batch_queue() {
         source.push(block2);
         let mut batcher = h.create_batcher(source, batcher_cfg.clone());
         batcher.advance().expect("submit future batch (block 2)");
-        drop(batcher);
+        batcher.flush(&mut h.l1);
     }
     h.mine_and_push(&chain); // L1 block 1: future batch
 
@@ -2096,7 +2096,7 @@ async fn out_of_order_singular_batches_reordered_by_batch_queue() {
         source.push(block1);
         let mut batcher = h.create_batcher(source, batcher_cfg);
         batcher.advance().expect("submit present batch (block 1)");
-        drop(batcher);
+        batcher.flush(&mut h.l1);
     }
     h.mine_and_push(&chain); // L1 block 2: present batch
 
@@ -2169,7 +2169,7 @@ async fn pipeline_idle_before_l1_signal_derives_after() {
     source.push(block1);
     let mut batcher = h.create_batcher(source, batcher_cfg);
     batcher.advance().expect("encode and submit");
-    drop(batcher);
+    batcher.flush(&mut h.l1);
 
     let (mut verifier, chain) = h.create_verifier_from_sequencer(
         &builder,
@@ -2234,7 +2234,7 @@ async fn pipeline_l1_origin_advance_observable_after_epoch_exhausted() {
 
     let mut batcher = h.create_batcher(source, batcher_cfg);
     batcher.advance().expect("encode and submit both blocks");
-    drop(batcher);
+    batcher.flush(&mut h.l1);
 
     let (mut verifier, chain) = h.create_verifier_from_sequencer(
         &builder,

--- a/actions/harness/tests/finalization.rs
+++ b/actions/harness/tests/finalization.rs
@@ -33,7 +33,7 @@ async fn finalization_advances_with_multiple_l2_blocks_per_epoch() {
         source.push(block.clone());
         let mut batcher = h.create_batcher(source, batcher_cfg.clone());
         batcher.advance().expect("batcher encode");
-        drop(batcher);
+        batcher.flush(&mut h.l1);
         h.l1.mine_block();
     }
 
@@ -114,7 +114,7 @@ async fn finalization_advances_incrementally_with_l1_epochs() {
         source.push(block.clone());
         let mut batcher = h.create_batcher(source, batcher_cfg.clone());
         batcher.advance().expect("batcher encode");
-        drop(batcher);
+        batcher.flush(&mut h.l1);
         h.mine_and_push(&chain);
     }
 
@@ -175,7 +175,7 @@ async fn finalization_does_not_exceed_safe_head() {
         source.push(block);
         let mut batcher = h.create_batcher(source, batcher_cfg.clone());
         batcher.advance().expect("encode");
-        drop(batcher);
+        batcher.flush(&mut h.l1);
         h.l1.mine_block();
     }
 
@@ -238,7 +238,7 @@ async fn finalization_reorg_clears_state() {
         source.push(block);
         let mut batcher = h.create_batcher(source, batcher_cfg.clone());
         batcher.advance().expect("encode");
-        drop(batcher);
+        batcher.flush(&mut h.l1);
         h.l1.mine_block();
     }
 
@@ -289,7 +289,7 @@ async fn finalization_reorg_clears_state() {
     source.push(block1_fresh);
     let mut batcher_fresh = h.create_batcher(source, batcher_cfg.clone());
     batcher_fresh.advance().expect("encode fresh");
-    drop(batcher_fresh);
+    batcher_fresh.flush(&mut h.l1);
     verifier.register_block_hash(1, sequencer_fresh.head().block_info.hash);
     h.l1.mine_block();
 
@@ -344,7 +344,7 @@ async fn finalization_does_not_regress() {
         source.push(block.clone());
         let mut batcher = h.create_batcher(source, batcher_cfg.clone());
         batcher.advance().expect("batcher encode");
-        drop(batcher);
+        batcher.flush(&mut h.l1);
         h.mine_and_push(&chain);
     }
 

--- a/actions/harness/tests/hardfork_activation.rs
+++ b/actions/harness/tests/hardfork_activation.rs
@@ -272,7 +272,7 @@ async fn span_batch_rejected_before_delta() {
     let span_cfg = BatcherConfig { batch_type: BatchType::Span, ..batcher_cfg.clone() };
     let mut batcher = h.create_batcher(source, span_cfg);
     batcher.advance().expect("batcher should encode span batch");
-    drop(batcher);
+    batcher.flush(&mut h.l1);
 
     h.l1.mine_block();
 
@@ -314,7 +314,7 @@ async fn span_batch_derives_after_delta() {
     let span_cfg = BatcherConfig { batch_type: BatchType::Span, ..batcher_cfg.clone() };
     let mut batcher = h.create_batcher(source, span_cfg);
     batcher.advance().expect("batcher encode span batch");
-    drop(batcher);
+    batcher.flush(&mut h.l1);
 
     h.l1.mine_block();
 
@@ -349,7 +349,7 @@ async fn single_batch_derives_with_fjord() {
 
         let mut batcher = h.create_batcher(source, batcher_cfg.clone());
         batcher.advance().expect("batcher advance");
-        drop(batcher);
+        batcher.flush(&mut h.l1);
         h.l1.mine_block();
     }
 
@@ -424,7 +424,7 @@ async fn jovian_derivation_crosses_activation_boundary() {
 
         let mut batcher = h.create_batcher(source, batcher_cfg.clone());
         batcher.advance().expect("batcher encode");
-        drop(batcher);
+        batcher.flush(&mut h.l1);
         h.l1.mine_block();
     }
 

--- a/actions/harness/tests/operator_fees.rs
+++ b/actions/harness/tests/operator_fees.rs
@@ -409,7 +409,7 @@ async fn isthmus_derivation_crosses_operator_fee_boundary() {
 
         let mut batcher = h.create_batcher(source, batcher_cfg.clone());
         batcher.advance().expect("batcher encode");
-        drop(batcher);
+        batcher.flush(&mut h.l1);
         h.l1.mine_block();
     }
 
@@ -489,21 +489,13 @@ async fn jovian_non_empty_transition_batch_generates_deposit_only_block() {
     // Build three L2 blocks — each with 1 user transaction (the sequencer default).
     // Block 3 (ts=6) is the first Jovian block. The batch validator will drop the
     // non-empty batch for that slot with NonEmptyTransitionBlock.
-    let mut block_hashes = Vec::new();
-    for i in 1u64..=3 {
+    for _ in 1u64..=3 {
         let mut source = ActionL2Source::new();
         source.push(builder.build_next_block().expect("build L2 block"));
-        let head = builder.head();
-        if i < 3 {
-            // Register hashes only for blocks 1–2. Block 3 will be replaced by
-            // a pipeline-generated deposit-only block with a different hash, so
-            // the sequencer's hash for that slot is intentionally not registered.
-            block_hashes.push((head.block_info.number, head.block_info.hash));
-        }
 
         let mut batcher = h.create_batcher(source, batcher_cfg.clone());
         batcher.advance().expect("batcher encode");
-        drop(batcher);
+        batcher.flush(&mut h.l1);
         h.l1.mine_block();
     }
 
@@ -511,10 +503,10 @@ async fn jovian_non_empty_transition_batch_generates_deposit_only_block() {
     // (0 + seq_window_size 4 = 4), triggering force-inclusion for L2 slot 3.
     h.l1.mine_block();
 
-    let (mut verifier, _chain) = h.create_verifier();
-    for (number, hash) in &block_hashes {
-        verifier.register_block_hash(*number, *hash);
-    }
+    let (mut verifier, _chain) = h.create_verifier_from_sequencer(
+        &builder,
+        SharedL1Chain::from_blocks(h.l1.chain().to_vec()),
+    );
     verifier.initialize().await.expect("initialize");
 
     // Signal L1 blocks 1–3. Blocks 1–2 are derived from their valid batches.
@@ -695,14 +687,14 @@ async fn operator_fee_config_update_propagates_to_l1_info() {
     }
     let mut batcher = h.create_batcher(source, batcher_cfg.clone());
     batcher.advance().expect("encode blocks 1–5");
-    drop(batcher);
+    batcher.flush(&mut h.l1);
     h.l1.mine_block(); // L1 block 2, ts=24
 
     let mut source = ActionL2Source::new();
     source.push(block6);
     let mut batcher = h.create_batcher(source, batcher_cfg);
     batcher.advance().expect("encode block 6");
-    drop(batcher);
+    batcher.flush(&mut h.l1);
     h.l1.mine_block(); // L1 block 3, ts=36
 
     // Verifier snapshot includes all L1 blocks 0–3.

--- a/actions/harness/tests/unsafe_gossip.rs
+++ b/actions/harness/tests/unsafe_gossip.rs
@@ -38,7 +38,7 @@ async fn test_unsafe_chain_advances_safe_catches_up() {
     }
     let mut batcher = h.create_batcher(source, batcher_cfg);
     batcher.advance().expect("batcher should encode all blocks");
-    drop(batcher);
+    batcher.flush(&mut h.l1);
     h.l1.mine_block();
     let l1_block_1 = block_info_from(h.l1.tip());
 

--- a/crates/batcher/encoder/src/encoder.rs
+++ b/crates/batcher/encoder/src/encoder.rs
@@ -170,6 +170,13 @@ impl BatchEncoder {
                     self.span_accumulator.clear();
                     self.span_raw_bytes = 0;
                     self.span_opened_at_l1 = None;
+                } else {
+                    // Discard the channel we just opened so that the drain logic below
+                    // (`self.current_channel.take()`) short-circuits and returns early.
+                    // Without this, the empty channel (0 frames) would be pushed to
+                    // `ready_channels`, where it can never be confirmed and never removed,
+                    // leaking memory and growing the O(N) scan in `next_submission`.
+                    self.current_channel = None;
                 }
             }
             // On failure (append or add_batch): accumulator is untouched so blocks


### PR DESCRIPTION
## Summary

Un-ignores action tests.
Removes duplicate `BatchType` enum.
Uses batcher crate encoding pipeline, de-duplicating logic in actions tests.
Small fix to batch submission to discard empty channel when span add_batch fails.