### PR TITLE
docs(specs): add V1 upgrade overview

### DIFF
--- a/docs/specs/pages/reference/configurability.md
+++ b/docs/specs/pages/reference/configurability.md
@@ -11,6 +11,7 @@ There are four categories of Base configuration:
 
 | Parameter | Description | Administrator |
 |-----------|-------------|---------------|
+<<<<<<< HEAD
 | [Batch Inbox Address](glossary.md#batch-inbox) | L1 address where [batcher transactions](glossary.md#batcher-transaction) are posted | Static |
 | [Batcher Hash](glossary.md#batcher-hash) | Versioned hash of the authorized batcher sender(s) | [System Config Owner](#admin-roles) |
 | Chain ID | Unique chain ID for transaction signature validation | Static |

--- a/docs/specs/pages/reference/configurability.md
+++ b/docs/specs/pages/reference/configurability.md
@@ -11,7 +11,6 @@ There are four categories of Base configuration:
 
 | Parameter | Description | Administrator |
 |-----------|-------------|---------------|
-<<<<<<< HEAD
 | [Batch Inbox Address](glossary.md#batch-inbox) | L1 address where [batcher transactions](glossary.md#batcher-transaction) are posted | Static |
 | [Batcher Hash](glossary.md#batcher-hash) | Versioned hash of the authorized batcher sender(s) | [System Config Owner](#admin-roles) |
 | Chain ID | Unique chain ID for transaction signature validation | Static |

--- a/docs/specs/pages/reference/glossary.md
+++ b/docs/specs/pages/reference/glossary.md
@@ -431,6 +431,18 @@ The gas limit may not be set to a value larger than the
 [maximum gas limit](../protocol/consensus/derivation.md#system-configuration). This is to ensure that L2 blocks are fault
 provable and of reasonable size to be processed by the client software.
 
+### Customizable Feature
+
+[customizable-feature]: glossary.md#customizable-feature
+
+A **Customizable Feature** is a component of Base that is maintained as a production-grade
+element of the stack behind some sort of toggle. A Customizable Feature is distinct from other
+types of feature-flagged code because it is part of the mainline Base and is intended to remain
+as a supported configuration option indefinitely. Unlike short-lived feature flags, which exist
+only to keep develop releasable while work is in progress, customizable features are permanent,
+user-facing options. They must be fully documented, tested in all supported modes, and designed for
+long-term maintainability.
+
 ## Batch Submission
 
 [batch-submission]: glossary.md#batch-submission

--- a/docs/specs/pages/reference/glossary.md
+++ b/docs/specs/pages/reference/glossary.md
@@ -424,12 +424,10 @@ The **L2 Gas Limit** defines the maximum amount of gas that can be used in a sin
 This parameter ensures that L2 blocks remain of reasonable size to be processed and proven.
 
 Changes to the L2 gas limit are fully applied in the first L2 block with the L1 origin that
-introduced the change, as opposed to the 1/1024 adjustments towards a target as seen in limit
-updates of L1 blocks.
+introduced the change.
 
 The gas limit may not be set to a value larger than the
-[maximum gas limit](../protocol/consensus/derivation.md#system-configuration). This is to ensure that L2 blocks are fault
-provable and of reasonable size to be processed by the client software.
+[maximum gas limit](../protocol/consensus/derivation.md#system-configuration). This is to ensure that L2 blocks are provable and can be processed by consensus and execution software.
 
 ### Customizable Feature
 

--- a/docs/specs/pages/reference/glossary.md
+++ b/docs/specs/pages/reference/glossary.md
@@ -428,19 +428,6 @@ introduced the change.
 
 The gas limit may not be set to a value larger than the
 [maximum gas limit](../protocol/consensus/derivation.md#system-configuration). This is to ensure that L2 blocks are provable and can be processed by consensus and execution software.
-
-### Customizable Feature
-
-[customizable-feature]: glossary.md#customizable-feature
-
-A **Customizable Feature** is a component of Base that is maintained as a production-grade
-element of the stack behind some sort of toggle. A Customizable Feature is distinct from other
-types of feature-flagged code because it is part of the mainline Base and is intended to remain
-as a supported configuration option indefinitely. Unlike short-lived feature flags, which exist
-only to keep develop releasable while work is in progress, customizable features are permanent,
-user-facing options. They must be fully documented, tested in all supported modes, and designed for
-long-term maintainability.
-
 ## Batch Submission
 
 [batch-submission]: glossary.md#batch-submission

--- a/docs/specs/pages/upgrades/v1/exec-engine.md
+++ b/docs/specs/pages/upgrades/v1/exec-engine.md
@@ -1,0 +1,84 @@
+# V1: Execution Engine
+
+## EVM Changes
+
+### Transaction Gas Limit Cap
+
+[EIP-7825](https://eips.ethereum.org/EIPS/eip-7825) introduces a protocol-level maximum gas limit
+of 16,777,216 (2^24) per transaction. Transactions exceeding this cap are rejected during validation.
+
+Base adopts the same cap as L1 to maximize Ethereum equivalence.
+
+### Upper-Bound MODEXP
+
+[EIP-7823](https://eips.ethereum.org/EIPS/eip-7823) caps MODEXP precompile inputs to a maximum of
+1024 bytes per field. Calls with larger inputs are rejected.
+
+### MODEXP Gas Cost Increase
+
+[EIP-7883](https://eips.ethereum.org/EIPS/eip-7883) raises the MODEXP precompile minimum gas cost
+from 200 to 500 and triples the general cost calculation.
+
+### CLZ Opcode
+
+[EIP-7939](https://eips.ethereum.org/EIPS/eip-7939) adds a new `CLZ` opcode that counts the number
+of leading zero bits in a 256-bit word, returning 256 if the input is zero.
+
+### secp256r1 Precompile Gas Cost
+
+[EIP-7951](https://eips.ethereum.org/EIPS/eip-7951) specifies the secp256r1 precompile at address `0x100`
+with a gas cost of 3,450.
+
+Base already has the `p256Verify` precompile at the same address (added in Fjord via
+[RIP-7212](https://github.com/ethereum/RIPs/blob/master/RIPS/rip-7212.md)) with a gas cost of 3,450.
+From V1, the gas cost increases to 6,900 to match the L1 gas cost specified in EIP-7951, maintaining
+strict equivalence with L1 precompile pricing.
+
+## Networking Changes
+
+### eth/69
+
+[EIP-7642](https://eips.ethereum.org/EIPS/eip-7642) updates the Ethereum wire protocol to version 69,
+removing legacy fields from the `Status` message and simplifying the handshake.
+
+### Remove Account Balances & Receipts
+
+The `FlashblocksMetadata` payload transmitted over the Flashblocks WebSocket is simplified in V1.
+The `new_account_balances` and `receipts` fields are removed. The `access_list` field remains but
+will not be populated in V1.
+
+**Before:**
+
+```json
+{
+  "block_number": 43403718,
+  "new_account_balances": {
+    "0x4200000000000000000000000000000000000006": "0x35277a9715c6df1c99de"
+  },
+  "receipts": {
+    "0x1ef9be45b3f7d44de9d98767ddb7c0e330b21777b67a3c79d469be9ffab091dd": {
+      "cumulativeGasUsed": "0x177d7bd",
+      "logs": [],
+      "status": "0x1",
+      "type": "0x2"
+    }
+  },
+  "access_list": null
+}
+```
+
+**After:**
+
+```json
+{
+  "block_number": 43403718,
+  "access_list": null
+}
+```
+
+## RPC Changes
+
+### eth_config RPC Method
+
+[EIP-7910](https://eips.ethereum.org/EIPS/eip-7910) introduces the `eth_config` JSON-RPC method,
+which returns chain configuration parameters such as fork activation timestamps.

--- a/docs/specs/pages/upgrades/v1/overview.md
+++ b/docs/specs/pages/upgrades/v1/overview.md
@@ -1,0 +1,30 @@
+# V1
+
+## Summary
+
+- Add Fusaka Support
+- Simplify Flashblocks Websocket Format
+- Enable TEE & ZK Proofs
+
+## Activation Timestamps
+
+| Network | Activation timestamp |
+| --- | --- |
+| `mainnet` | TBD |
+| `sepolia` | TBD |
+
+## Execution Layer
+
+- [EIP-7823: Upper-Bound MODEXP](/upgrades/v1/exec-engine#upper-bound-modexp)
+- [EIP-7825: Transaction Gas Limit Cap](/upgrades/v1/exec-engine#transaction-gas-limit-cap)
+- [EIP-7883: MODEXP Gas Cost Increase](/upgrades/v1/exec-engine#modexp-gas-cost-increase)
+- [EIP-7939: CLZ Opcode](/upgrades/v1/exec-engine#clz-opcode)
+- [EIP-7951: secp256r1 Precompile](/upgrades/v1/exec-engine#secp256r1-precompile-gas-cost)
+- [EIP-7642: eth/69](/upgrades/v1/exec-engine#eth69)
+- [EIP-7910: eth_config RPC Method](/upgrades/v1/exec-engine#eth_config-rpc-method)
+- [Remove Account Balances & Receipts](/upgrades/v1/exec-engine#remove-account-balances--receipts)
+
+## Proofs
+
+- TEE
+- ZK

--- a/docs/specs/pages/upgrades/v1/overview.md
+++ b/docs/specs/pages/upgrades/v1/overview.md
@@ -15,14 +15,14 @@
 
 ## Execution Layer
 
-- [EIP-7823: Upper-Bound MODEXP](exec-engine.md#upper-bound-modexp)
-- [EIP-7825: Transaction Gas Limit Cap](exec-engine.md#transaction-gas-limit-cap)
-- [EIP-7883: MODEXP Gas Cost Increase](exec-engine.md#modexp-gas-cost-increase)
-- [EIP-7939: CLZ Opcode](exec-engine.md#clz-opcode)
-- [EIP-7951: secp256r1 Precompile](exec-engine.md#secp256r1-precompile-gas-cost)
-- [EIP-7642: eth/69](exec-engine.md#eth69)
-- [EIP-7910: eth_config RPC Method](exec-engine.md#eth_config-rpc-method)
-- [Remove Account Balances & Receipts](exec-engine.md#remove-account-balances--receipts)
+- [EIP-7823: Upper-Bound MODEXP](/upgrades/v1/exec-engine#upper-bound-modexp)
+- [EIP-7825: Transaction Gas Limit Cap](/upgrades/v1/exec-engine#transaction-gas-limit-cap)
+- [EIP-7883: MODEXP Gas Cost Increase](/upgrades/v1/exec-engine#modexp-gas-cost-increase)
+- [EIP-7939: CLZ Opcode](/upgrades/v1/exec-engine#clz-opcode)
+- [EIP-7951: secp256r1 Precompile](/upgrades/v1/exec-engine#secp256r1-precompile-gas-cost)
+- [EIP-7642: eth/69](/upgrades/v1/exec-engine#eth69)
+- [EIP-7910: eth_config RPC Method](/upgrades/v1/exec-engine#eth_config-rpc-method)
+- [Remove Account Balances & Receipts](/upgrades/v1/exec-engine#remove-account-balances--receipts)
 
 ## Proofs
 

--- a/docs/specs/pages/upgrades/v1/overview.md
+++ b/docs/specs/pages/upgrades/v1/overview.md
@@ -15,14 +15,14 @@
 
 ## Execution Layer
 
-- [EIP-7823: Upper-Bound MODEXP](/upgrades/v1/exec-engine#upper-bound-modexp)
-- [EIP-7825: Transaction Gas Limit Cap](/upgrades/v1/exec-engine#transaction-gas-limit-cap)
-- [EIP-7883: MODEXP Gas Cost Increase](/upgrades/v1/exec-engine#modexp-gas-cost-increase)
-- [EIP-7939: CLZ Opcode](/upgrades/v1/exec-engine#clz-opcode)
-- [EIP-7951: secp256r1 Precompile](/upgrades/v1/exec-engine#secp256r1-precompile-gas-cost)
-- [EIP-7642: eth/69](/upgrades/v1/exec-engine#eth69)
-- [EIP-7910: eth_config RPC Method](/upgrades/v1/exec-engine#eth_config-rpc-method)
-- [Remove Account Balances & Receipts](/upgrades/v1/exec-engine#remove-account-balances--receipts)
+- [EIP-7823: Upper-Bound MODEXP](exec-engine.md#upper-bound-modexp)
+- [EIP-7825: Transaction Gas Limit Cap](exec-engine.md#transaction-gas-limit-cap)
+- [EIP-7883: MODEXP Gas Cost Increase](exec-engine.md#modexp-gas-cost-increase)
+- [EIP-7939: CLZ Opcode](exec-engine.md#clz-opcode)
+- [EIP-7951: secp256r1 Precompile](exec-engine.md#secp256r1-precompile-gas-cost)
+- [EIP-7642: eth/69](exec-engine.md#eth69)
+- [EIP-7910: eth_config RPC Method](exec-engine.md#eth_config-rpc-method)
+- [Remove Account Balances & Receipts](exec-engine.md#remove-account-balances--receipts)
 
 ## Proofs
 

--- a/docs/specs/vocs.config.ts
+++ b/docs/specs/vocs.config.ts
@@ -192,6 +192,7 @@ const sidebar: SidebarItem[] = [
   {
     text: 'Upgrades',
     items: [
+      { text: 'V1', link: '/upgrades/v1/overview' },
       { text: 'Jovian', link: '/upgrades/jovian/overview' },
       { text: 'Isthmus', link: '/upgrades/isthmus/overview' },
       { text: 'Pectra Blob Schedule (Sepolia)', link: '/upgrades/pectra-blob-schedule/overview' },

--- a/docs/specs/vocs.config.ts
+++ b/docs/specs/vocs.config.ts
@@ -134,7 +134,7 @@ function sectionItemWithoutDirs(
 
 const hiddenProtocolFiles = ['access-lists.md']
 
-const protocolTodoExcludedDirs = ['bridging', 'consensus', 'execution', 'fault-proof']
+const protocolTodoExcludedDirs = ['bridging', 'configuration', 'consensus', 'execution', 'fault-proof']
 
 const protocolTodoExcludedFiles = [
   ...hiddenProtocolFiles,


### PR DESCRIPTION
Adds the V1 upgrade spec pages:

- Overview with summary, activation timestamps, execution layer changes, and proofs section
- Exec engine page covering EVM changes (EIP-7823, 7825, 7883, 7939, 7951), networking (eth/69, Flashblocks metadata simplification), and RPC (eth_config)