### PR TITLE
fix(actions): Fix Batcher Confirm Lifecycle

### DIFF
--- a/actions/harness/src/batcher/actor.rs
+++ b/actions/harness/src/batcher/actor.rs
@@ -3,7 +3,8 @@ use std::sync::Arc;
 use alloy_eips::eip4844::Blob;
 use alloy_primitives::{Address, B256, Bytes};
 use base_batcher_encoder::{
-    BatchEncoder, BatchPipeline, BatchType, EncoderConfig, ReorgError, StepError, StepResult,
+    BatchEncoder, BatchPipeline, BatchType, EncoderConfig, FrameEncoder, ReorgError, StepError,
+    StepResult, SubmissionId,
 };
 use base_blobs::BlobEncoder;
 use base_comp::BatchComposeError;
@@ -107,6 +108,20 @@ pub struct Batcher<S: L2BlockProvider> {
     config: BatcherConfig,
     pending_txs: Vec<PendingTx>,
     pending_blobs: Vec<(B256, Box<Blob>)>,
+    /// Submissions drained from the pipeline but not yet confirmed.
+    ///
+    /// Each entry is `(id, frame_count)` so that [`flush`](Batcher::flush)
+    /// can confirm only the submissions whose frames were fully covered by
+    /// [`submit_frames`](Batcher::submit_frames) / [`submit_blob_frames`](Batcher::submit_blob_frames),
+    /// and requeue the rest.
+    pending_submissions: Vec<(SubmissionId, usize)>,
+    /// Running count of frames buffered since the last [`flush`](Batcher::flush).
+    ///
+    /// Incremented by [`submit_frames`](Batcher::submit_frames) and
+    /// [`submit_blob_frames`](Batcher::submit_blob_frames). Consumed frame-by-frame
+    /// in [`flush`](Batcher::flush) to determine which submission IDs are fully
+    /// covered and should be confirmed vs. requeued.
+    submitted_frame_count: usize,
 }
 
 impl<S: L2BlockProvider> Batcher<S> {
@@ -121,7 +136,15 @@ impl<S: L2BlockProvider> Batcher<S> {
         let mut encoder_config = config.encoder.clone();
         encoder_config.batch_type = config.batch_type;
         let pipeline = BatchEncoder::new(rollup_config, encoder_config);
-        Self { l2_source, pipeline, config, pending_txs: Vec::new(), pending_blobs: Vec::new() }
+        Self {
+            l2_source,
+            pipeline,
+            config,
+            pending_txs: Vec::new(),
+            pending_blobs: Vec::new(),
+            pending_submissions: Vec::new(),
+            submitted_frame_count: 0,
+        }
     }
 
     /// Drain all available L2 blocks and encode them into frames without
@@ -169,6 +192,8 @@ impl<S: L2BlockProvider> Batcher<S> {
 
         let mut frames = Vec::new();
         while let Some(sub) = self.pipeline.next_submission() {
+            let frame_count = sub.frames.len();
+            self.pending_submissions.push((sub.id, frame_count));
             frames.extend(sub.frames);
         }
 
@@ -181,20 +206,26 @@ impl<S: L2BlockProvider> Batcher<S> {
     /// Each frame is buffered as a separate [`PendingTx`]. Call [`flush`] to
     /// drain them into an [`L1Miner`].
     ///
+    /// # Ordering invariant
+    ///
+    /// `frames` must be an **in-order prefix** of the slice returned by the most
+    /// recent [`encode_frames`](Batcher::encode_frames) call. [`flush`] accounts
+    /// for submitted frames by consuming a positional counter (`submitted_frame_count`)
+    /// against the ordered list of pending submissions — it has no way to detect
+    /// which individual frames were passed here. Submitting an out-of-order subset
+    /// (e.g. `&frames[1..]` while skipping frame 0) will cause [`flush`] to confirm
+    /// the wrong submission IDs and requeue the wrong ones.
+    ///
     /// [`flush`]: Batcher::flush
     pub fn submit_frames(&mut self, frames: &[Arc<Frame>]) {
         for frame in frames {
-            let encoded = frame.encode();
-            let mut input = Vec::with_capacity(1 + encoded.len());
-            input.push(DERIVATION_VERSION_0);
-            input.extend_from_slice(&encoded);
-
             self.pending_txs.push(PendingTx {
                 from: self.config.batcher_address,
                 to: self.config.inbox_address,
-                input: Bytes::from(input),
+                input: FrameEncoder::to_calldata(frame),
             });
         }
+        self.submitted_frame_count += frames.len();
         info!(frames = frames.len(), "batcher buffered frames");
     }
 
@@ -203,6 +234,11 @@ impl<S: L2BlockProvider> Batcher<S> {
     /// Each frame is encoded into one blob using [`BlobEncoder::encode_frames`].
     /// Call [`flush`] to drain them into an [`L1Miner`].
     ///
+    /// # Ordering invariant
+    ///
+    /// Same constraint as [`submit_frames`](Batcher::submit_frames): `frames` must
+    /// be an in-order prefix of the [`encode_frames`](Batcher::encode_frames) output.
+    ///
     /// [`flush`]: Batcher::flush
     pub fn submit_blob_frames(&mut self, frames: &[Arc<Frame>]) {
         let blobs =
@@ -210,10 +246,28 @@ impl<S: L2BlockProvider> Batcher<S> {
         for blob in blobs {
             self.pending_blobs.push((B256::ZERO, Box::new(blob)));
         }
+        self.submitted_frame_count += frames.len();
         info!(frames = frames.len(), "batcher buffered frames as blobs");
     }
 
-    /// Drain all pending transactions and blobs into the given [`L1Miner`].
+    /// Drain all pending transactions and blobs into the given [`L1Miner`], then
+    /// confirm or requeue each buffered submission with the encoding pipeline.
+    ///
+    /// Submissions are confirmed only when every frame they contain was actually
+    /// passed to [`submit_frames`](Batcher::submit_frames) or
+    /// [`submit_blob_frames`](Batcher::submit_blob_frames). Submissions whose
+    /// frames were not (fully) submitted are requeued so the encoder can rewind
+    /// their frame cursor and re-emit them on the next drain.
+    ///
+    /// This distinction matters for partial-frame tests (e.g., channel timeout
+    /// scenarios that submit only the first frame and let the rest expire): without
+    /// requeue, the encoder would incorrectly treat unsubmitted frames as confirmed,
+    /// permanently corrupting its internal block deque and `pending` map.
+    ///
+    /// The `l1_block` passed to [`BatchPipeline::confirm`] is `u64::MAX` — matching
+    /// the value already used by `encode_frames` to force-close the channel. The
+    /// [`BatchEncoder`] implementation does not use the `l1_block` argument to
+    /// `confirm()`, so the exact value is irrelevant here.
     pub fn flush(&mut self, l1: &mut L1Miner) {
         for tx in self.pending_txs.drain(..) {
             l1.submit_tx(tx);
@@ -221,6 +275,39 @@ impl<S: L2BlockProvider> Batcher<S> {
         for (hash, blob) in self.pending_blobs.drain(..) {
             l1.enqueue_blob(hash, blob);
         }
+
+        // Walk submissions in drain order. Each submission contributed `frame_count`
+        // frames to the flat frame list returned by `encode_frames()`. Consume
+        // `submitted_frame_count` one submission at a time: if this submission's
+        // frames were fully covered, confirm it; otherwise requeue it so the
+        // encoder rewinds the frame cursor for future re-submission.
+        let mut remaining = self.submitted_frame_count;
+        for (id, frame_count) in self.pending_submissions.drain(..) {
+            if remaining >= frame_count {
+                remaining -= frame_count;
+                self.pipeline.confirm(id, u64::MAX);
+            } else {
+                self.pipeline.requeue(id);
+            }
+        }
+        self.submitted_frame_count = 0;
+    }
+
+    /// Drain any submissions that were requeued by the last [`flush`](Batcher::flush).
+    ///
+    /// After a partial-frame flush, the encoder rewinds the frame cursor for
+    /// unsubmitted submissions. Calling this method pulls those frames back out of
+    /// the pipeline so they can be re-submitted via [`submit_frames`](Batcher::submit_frames).
+    ///
+    /// Returns an empty [`Vec`] when no requeued submissions are pending.
+    pub fn drain_requeued_frames(&mut self) -> Vec<Arc<Frame>> {
+        let mut frames = Vec::new();
+        while let Some(sub) = self.pipeline.next_submission() {
+            let frame_count = sub.frames.len();
+            self.pending_submissions.push((sub.id, frame_count));
+            frames.extend(sub.frames);
+        }
+        frames
     }
 
     /// Encode and submit all frames as blobs in one step.

--- a/actions/harness/tests/batcher_channels.rs
+++ b/actions/harness/tests/batcher_channels.rs
@@ -4,6 +4,7 @@ use base_action_harness::{
     ActionL2Source, ActionTestHarness, BatcherConfig, L1MinerConfig, SharedL1Chain,
     TestRollupConfigBuilder, block_info_from,
 };
+use base_batcher_encoder::EncoderConfig;
 
 // ---------------------------------------------------------------------------
 // A. Channel timeout — first frame's inclusion span exceeds channel_timeout
@@ -53,8 +54,6 @@ use base_action_harness::{
 /// ID generation.
 #[tokio::test]
 async fn channel_timeout_triggers_channel_invalidation() {
-    use base_batcher_encoder::EncoderConfig;
-
     let batcher_cfg = BatcherConfig {
         encoder: EncoderConfig { max_frame_size: 80, ..EncoderConfig::default() },
         ..BatcherConfig::default()
@@ -162,8 +161,6 @@ async fn channel_timeout_triggers_channel_invalidation() {
 /// channel completes immediately.
 #[tokio::test]
 async fn channel_timeout_recovery_resubmits_successfully() {
-    use base_batcher_encoder::EncoderConfig;
-
     // Small max_frame_size forces a multi-frame channel so we can hold back
     // frames to induce a timeout, matching the setup in
     // channel_timeout_triggers_channel_invalidation.
@@ -288,7 +285,6 @@ async fn channel_timeout_recovery_resubmits_successfully() {
 /// so they all appear in L1 block 1.
 #[tokio::test]
 async fn interleaved_channels_correctly_reassembled() {
-    use base_batcher_encoder::EncoderConfig;
     let batcher_cfg = BatcherConfig {
         // Small max_frame_size forces each block's batch data to spill across multiple frames,
         // producing distinct channel IDs per encoder instance (BatchEncoder randomizes per channel).
@@ -386,7 +382,6 @@ async fn interleaved_channels_correctly_reassembled() {
 /// derives L2 block 1.  The safe head advances to 1.
 #[tokio::test]
 async fn multi_block_channel_assembles_across_l1_blocks() {
-    use base_batcher_encoder::EncoderConfig;
     let batcher_cfg = BatcherConfig {
         encoder: EncoderConfig { max_frame_size: 80, ..EncoderConfig::default() },
         ..BatcherConfig::default()
@@ -446,4 +441,147 @@ async fn multi_block_channel_assembles_across_l1_blocks() {
 
     assert_eq!(derived, 1, "multi-block channel must yield 1 L2 block");
     assert_eq!(verifier.l2_safe().block_info.number, 1, "safe head must advance to 1");
+}
+
+// ---------------------------------------------------------------------------
+// E. Confirm / requeue lifecycle
+// ---------------------------------------------------------------------------
+
+/// Verifies that the **prefix length** passed to [`Batcher::submit_frames`]
+/// is what determines which submissions are confirmed on [`Batcher::flush`],
+/// not which frames were submitted.
+///
+/// [`flush`] consumes a positional counter (`submitted_frame_count`) against
+/// the ordered list of pending submissions built by [`encode_frames`]. It has
+/// no per-frame identity tracking, so the confirmed/requeued boundary is always
+/// a prefix of that ordered list. Submitting an out-of-order subset (e.g.
+/// `&frames[1..]` while skipping frame 0) would confirm the wrong submissions.
+///
+/// ## Scenario
+///
+/// 1. Encode one L2 block into ≥3 frames (one submission per frame with the
+///    default `target_num_frames = 1`).
+/// 2. Submit **zero** frames and flush → all N submissions requeued;
+///    `drain_requeued_frames` returns all N frames.
+/// 3. Submit a **two-frame prefix** of those requeued frames and flush → 2
+///    submissions confirmed, N−2 requeued; `drain_requeued_frames` returns
+///    the N−2 remaining frames.
+/// 4. Submit all remaining frames and flush → everything confirmed;
+///    `drain_requeued_frames` returns empty.
+///
+/// [`encode_frames`]: base_action_harness::Batcher::encode_frames
+/// [`flush`]: base_action_harness::Batcher::flush
+#[tokio::test]
+async fn submit_frames_prefix_length_determines_confirm_boundary() {
+    let batcher_cfg = BatcherConfig {
+        // Small max_frame_size ensures ≥3 frames so we can walk through
+        // zero, mid-point, and full prefix lengths in one test.
+        encoder: EncoderConfig { max_frame_size: 60, ..EncoderConfig::default() },
+        ..BatcherConfig::default()
+    };
+    let rollup_cfg = TestRollupConfigBuilder::base_mainnet(&batcher_cfg).build();
+    let mut h = ActionTestHarness::new(L1MinerConfig::default(), rollup_cfg);
+
+    let l1_chain = SharedL1Chain::from_blocks(h.l1.chain().to_vec());
+    let mut sequencer = h.create_l2_sequencer(l1_chain);
+    let block = sequencer.build_next_block().expect("build L2 block");
+
+    let mut source = ActionL2Source::new();
+    source.push(block);
+    let mut batcher = h.create_batcher(source, batcher_cfg);
+    let frames = batcher.encode_frames().expect("encode frames");
+    let n = frames.len();
+    assert!(n >= 3, "need ≥3 frames; got {n} (decrease max_frame_size)");
+
+    // --- Step 1: zero-length prefix → all submissions requeued ---
+    // submit_frames is not called, so submitted_frame_count stays 0.
+    // flush requeues every pending submission.
+    batcher.flush(&mut h.l1);
+    let after_zero = batcher.drain_requeued_frames();
+    assert_eq!(after_zero.len(), n, "zero-prefix flush must requeue all {n} submissions");
+
+    // --- Step 2: two-frame prefix → exactly 2 submissions confirmed ---
+    batcher.submit_frames(&after_zero[..2]);
+    batcher.flush(&mut h.l1);
+    let after_two = batcher.drain_requeued_frames();
+    assert_eq!(
+        after_two.len(),
+        n - 2,
+        "two-frame prefix must confirm 2 submissions and requeue the remaining {}",
+        n - 2
+    );
+
+    // --- Step 3: remaining frames → all confirmed, nothing left ---
+    batcher.submit_frames(&after_two);
+    batcher.flush(&mut h.l1);
+    let after_full = batcher.drain_requeued_frames();
+    assert!(
+        after_full.is_empty(),
+        "after submitting all remaining frames, drain_requeued_frames must return empty"
+    );
+}
+
+/// Verifies that [`Batcher::flush`] correctly confirms only the submissions
+/// whose frames were fully covered by [`Batcher::submit_frames`], and requeues
+/// the rest.
+///
+/// ## Scenario
+///
+/// 1. Encode one L2 block into a multi-frame channel.
+/// 2. Submit only frame 0 — with `target_num_frames = 1` each submission holds
+///    one frame, so submission 0 is **confirmed** and submissions 1..N are **requeued**.
+/// 3. Call [`Batcher::drain_requeued_frames`] to pull the requeued frames back
+///    out of the pipeline. Verify the count is N−1 (all but the confirmed one).
+/// 4. Submit ALL frames this time and flush. The submission is now **confirmed**.
+/// 5. Call [`Batcher::drain_requeued_frames`] again — must return empty because
+///    the channel is fully confirmed and there is nothing left to re-drain.
+#[tokio::test]
+async fn confirm_lifecycle_requeues_partial_submissions() {
+    let batcher_cfg = BatcherConfig {
+        encoder: EncoderConfig { max_frame_size: 80, ..EncoderConfig::default() },
+        ..BatcherConfig::default()
+    };
+    let rollup_cfg = TestRollupConfigBuilder::base_mainnet(&batcher_cfg).build();
+    let mut h = ActionTestHarness::new(L1MinerConfig::default(), rollup_cfg);
+
+    let l1_chain = SharedL1Chain::from_blocks(h.l1.chain().to_vec());
+    let mut sequencer = h.create_l2_sequencer(l1_chain);
+    let block = sequencer.build_next_block().expect("build L2 block");
+
+    let mut source = ActionL2Source::new();
+    source.push(block);
+    let mut batcher = h.create_batcher(source, batcher_cfg);
+    let frames = batcher.encode_frames().expect("encode frames");
+    assert!(
+        frames.len() >= 2,
+        "need ≥2 frames for partial-submit test; got {} (increase payload or decrease max_frame_size)",
+        frames.len()
+    );
+
+    // --- Step 1: partial submit → requeue ---
+    batcher.submit_frames(&frames[..1]);
+    batcher.flush(&mut h.l1);
+
+    // With target_num_frames = 1 (the default), each BatchSubmission holds
+    // exactly one frame. Submitting frame 0 fully covers submission 0, so it
+    // is confirmed. Submissions 1..N are not covered and are requeued.
+    // drain_requeued_frames() must return the N-1 unsubmitted frames.
+    let requeued = batcher.drain_requeued_frames();
+    assert_eq!(
+        requeued.len(),
+        frames.len() - 1,
+        "requeued frame count must equal total frames minus the one submitted (which was confirmed)"
+    );
+
+    // --- Step 2: full submit → confirm ---
+    batcher.submit_frames(&requeued);
+    batcher.flush(&mut h.l1);
+
+    // All frames confirmed — nothing left to re-drain.
+    let after_confirm = batcher.drain_requeued_frames();
+    assert!(
+        after_confirm.is_empty(),
+        "after full confirm, drain_requeued_frames() must return empty; got {}",
+        after_confirm.len()
+    );
 }

--- a/crates/batcher/core/Cargo.toml
+++ b/crates/batcher/core/Cargo.toml
@@ -20,7 +20,6 @@ base-batcher-source.workspace = true
 base-batcher-encoder.workspace = true
 tracing = { workspace = true, features = ["std"] }
 thiserror = { workspace = true, features = ["std"] }
-base-protocol = { workspace = true, features = ["std"] }
 alloy-primitives = { workspace = true, features = ["std"] }
 tokio = { workspace = true, features = ["sync", "macros", "rt"] }
 
@@ -29,4 +28,5 @@ async-trait.workspace = true
 alloy-consensus = { workspace = true, features = ["std"] }
 alloy-rpc-types-eth = { workspace = true, features = ["std"] }
 base-alloy-consensus = { workspace = true, features = ["std"] }
+base-protocol = { workspace = true, features = ["std"] }
 tokio = { workspace = true, features = ["macros", "rt", "time"] }

--- a/crates/batcher/core/src/driver.rs
+++ b/crates/batcher/core/src/driver.rs
@@ -3,10 +3,9 @@
 use std::{future::Future, pin::Pin, sync::Arc};
 
 use alloy_primitives::{Address, Bytes, U256};
-use base_batcher_encoder::{BatchPipeline, DaType, StepResult, SubmissionId};
+use base_batcher_encoder::{BatchPipeline, DaType, FrameEncoder, StepResult, SubmissionId};
 use base_batcher_source::{L2BlockEvent, UnsafeBlockSource};
 use base_blobs::BlobEncoder;
-use base_protocol::DERIVATION_VERSION_0;
 use base_tx_manager::{TxCandidate, TxManager};
 use futures::stream::{FuturesUnordered, StreamExt};
 use tokio::sync::Semaphore;
@@ -186,16 +185,10 @@ where
                     },
                     DaType::Calldata => {
                         // Calldata mode: one frame per submission (enforced by
-                        // EncoderConfig::validate). Encode as
-                        // [DERIVATION_VERSION_0] ++ frame.encode().
-                        let frame = &sub.frames[0];
-                        let encoded = frame.encode();
-                        let mut data = Vec::with_capacity(1 + encoded.len());
-                        data.push(DERIVATION_VERSION_0);
-                        data.extend_from_slice(&encoded);
+                        // EncoderConfig::validate).
                         TxCandidate {
                             to: Some(self.inbox),
-                            tx_data: Bytes::from(data),
+                            tx_data: FrameEncoder::to_calldata(&sub.frames[0]),
                             value: U256::ZERO,
                             gas_limit: 0,
                             blobs: vec![].into(),

--- a/crates/batcher/encoder/README.md
+++ b/crates/batcher/encoder/README.md
@@ -8,7 +8,7 @@ L1 submission frames. No async, no I/O, no tokio dependency.
 ## Usage
 
 ```rust,ignore
-use base_batcher_encoder::{BatchEncoder, EncoderConfig, StepResult};
+use base_batcher_encoder::{BatchEncoder, EncoderConfig, FrameEncoder, StepResult};
 
 let mut encoder = BatchEncoder::new(rollup_config, EncoderConfig::default());
 
@@ -25,7 +25,35 @@ loop {
 
 // Drain ready submissions.
 while let Some(sub) = encoder.next_submission() {
-    // Submit to L1...
+    for frame in &sub.frames {
+        // Encode as L1 calldata:
+        let calldata = FrameEncoder::to_calldata(frame);
+        // Or pack into EIP-4844 blobs via base-blobs::BlobEncoder.
+    }
     encoder.confirm(sub.id, l1_block_number);
+    // Call encoder.requeue(sub.id) if submission fails and frames must be retried.
 }
 ```
+
+## Confirm / requeue lifecycle
+
+Every submission drained from `next_submission()` **must** be resolved with either
+`confirm(id, l1_block)` or `requeue(id)`:
+
+- `confirm` prunes the submission's frames from the channel's pending set. Once all
+  frames of a channel are confirmed, the channel is finalized and its L2 blocks are
+  removed from the encoder's input queue, keeping memory bounded.
+- `requeue` rewinds the channel's frame cursor so the same frames are re-emitted on the
+  next `next_submission()` call. Use this when an L1 transaction fails or is dropped.
+
+Failing to call either will cause the encoder's internal `pending` map and block deque
+to grow without bound.
+
+## Frame encoding
+
+`FrameEncoder::to_calldata(frame)` produces the exact byte sequence the derivation
+pipeline expects: `[DERIVATION_VERSION_0] ++ frame.encode()`. Both `BatchDriver` (the
+production async driver in `base-batcher-core`) and the action-test `Batcher` harness use
+this shared implementation so the framing logic is defined exactly once.
+
+For EIP-4844 blob submission, use `base_blobs::BlobEncoder::encode_frames(&frames)`.

--- a/crates/batcher/encoder/src/config.rs
+++ b/crates/batcher/encoder/src/config.rs
@@ -1,103 +1,6 @@
-//! Core types for the batcher encoding pipeline.
+//! Encoder configuration and its validation error type.
 
-use std::sync::Arc;
-
-use alloy_primitives::B256;
-pub use base_protocol::BatchType;
-use base_protocol::{ChannelId, Frame};
-
-/// Identifies a batch submission for receipt tracking.
-///
-/// Monotonically increasing per [`BatchEncoder`](crate::BatchEncoder) instance,
-/// including across [`BatchPipeline::reset`](crate::BatchPipeline::reset) calls.
-/// The counter is intentionally **not** reset to 0 on reset so that post-reset
-/// submissions can never share an ID with any pre-reset in-flight submission,
-/// eliminating stale-confirm collisions.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
-pub struct SubmissionId(pub u64);
-
-/// Selects how batch frames are encoded for L1 submission.
-///
-/// The driver uses this field on each [`BatchSubmission`] to determine whether
-/// frames should be packed into EIP-4844 blobs or sent as transaction calldata.
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
-pub enum DaType {
-    /// Frames are packed into EIP-4844 blobs, one blob per frame (default).
-    #[default]
-    Blob,
-    /// Each frame is sent as a single calldata transaction
-    /// (`[DERIVATION_VERSION_0] ++ frame.encode()`).
-    ///
-    /// When using calldata mode, set
-    /// [`EncoderConfig::target_num_frames`] to `1` so that each
-    /// [`BatchSubmission`] contains exactly one frame.
-    Calldata,
-}
-
-/// A single L1 transaction's worth of batch data: one or more frames encoded as blobs.
-///
-/// Contains up to [`EncoderConfig::target_num_frames`] frames, each mapping to one
-/// EIP-4844 blob. Cancun supports up to 6 blobs per transaction; Isthmus (EIP-7892)
-/// supports up to 21.
-#[derive(Debug)]
-pub struct BatchSubmission {
-    /// The unique identifier for this submission.
-    pub id: SubmissionId,
-    /// The channel this submission belongs to.
-    pub channel_id: ChannelId,
-    /// How frames in this submission should be encoded for L1.
-    pub da_type: DaType,
-    /// Frames to include in this L1 transaction.
-    /// Each frame maps to one EIP-4844 blob. Shared via [`Arc`] to avoid
-    /// deep copies of the frame payload when handing off to the driver.
-    pub frames: Vec<Arc<Frame>>,
-}
-
-/// Result of a [`BatchPipeline::step`](crate::BatchPipeline::step) call.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum StepResult {
-    /// One block was encoded into the current channel.
-    BlockEncoded,
-    /// The current channel reached a closure trigger and was moved to the submission queue.
-    ChannelClosed,
-    /// No work available: no pending blocks and all open channels are already at capacity
-    /// or awaiting confirmation.
-    Idle,
-}
-
-/// Returned by [`BatchPipeline::step`](crate::BatchPipeline::step) when a block cannot be
-/// encoded and the pipeline cannot continue.
-///
-/// Batch composition failure is fatal: a block that cannot be serialised into a
-/// [`SingleBatch`](base_consensus_genesis::batch::SingleBatch) would be silently absent
-/// from the submitted data, breaking the contiguous L2 block sequence required by the
-/// derivation spec. The batcher must halt rather than skip such a block.
-#[derive(Debug, thiserror::Error)]
-pub enum StepError {
-    /// The block could not be converted to a [`SingleBatch`].
-    #[error("batch composition failed for block at cursor {cursor}: {source}")]
-    CompositionFailed {
-        /// Index of the block in the encoder's input queue.
-        cursor: usize,
-        /// Underlying composition error.
-        #[source]
-        source: base_comp::BatchComposeError,
-    },
-}
-
-/// Returned by [`BatchPipeline::add_block`](crate::BatchPipeline::add_block) when a reorg
-/// is detected.
-#[derive(Debug, thiserror::Error)]
-pub enum ReorgError {
-    /// The block's parent hash does not match the current tip.
-    #[error("parent hash mismatch: expected {expected}, got {got}")]
-    ParentMismatch {
-        /// The expected parent hash (current tip).
-        expected: B256,
-        /// The actual parent hash from the incoming block.
-        got: B256,
-    },
-}
+use crate::{BatchType, DaType};
 
 /// Configuration for the [`BatchEncoder`](crate::BatchEncoder).
 #[derive(Debug, Clone)]
@@ -140,7 +43,8 @@ pub struct EncoderConfig {
     /// Default: 1 (one blob per transaction).
     pub target_num_frames: usize,
 
-    /// Whether to encode blocks as individual [`SingleBatch`](base_consensus_genesis::batch::SingleBatch)es
+    /// Whether to encode blocks as individual
+    /// [`SingleBatch`](base_consensus_genesis::batch::SingleBatch)es
     /// or accumulate them into a single [`SpanBatch`](base_protocol::SpanBatch).
     ///
     /// Default: [`BatchType::Single`].
@@ -149,8 +53,8 @@ pub struct EncoderConfig {
     /// How frames should be encoded for L1 submission.
     ///
     /// When set to [`DaType::Calldata`], set [`target_num_frames`] to `1` so
-    /// that each [`BatchSubmission`] contains exactly one frame (one calldata
-    /// tx per frame matches the derivation protocol).
+    /// that each [`BatchSubmission`](crate::BatchSubmission) contains exactly one frame
+    /// (one calldata tx per frame matches the derivation protocol).
     ///
     /// Default: [`DaType::Blob`].
     ///

--- a/crates/batcher/encoder/src/lib.rs
+++ b/crates/batcher/encoder/src/lib.rs
@@ -7,11 +7,17 @@
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
 
-mod types;
-pub use types::{
-    BatchSubmission, BatchType, DaType, EncoderConfig, EncoderConfigError, ReorgError, StepError,
-    StepResult, SubmissionId,
-};
+mod submission;
+pub use submission::{BatchSubmission, BatchType, DaType, FrameEncoder, SubmissionId};
+
+mod step;
+pub use step::{StepError, StepResult};
+
+mod reorg;
+pub use reorg::ReorgError;
+
+mod config;
+pub use config::{EncoderConfig, EncoderConfigError};
 
 mod pipeline;
 pub use pipeline::BatchPipeline;

--- a/crates/batcher/encoder/src/reorg.rs
+++ b/crates/batcher/encoder/src/reorg.rs
@@ -1,0 +1,17 @@
+//! Reorg detection error type.
+
+use alloy_primitives::B256;
+
+/// Returned by [`BatchPipeline::add_block`](crate::BatchPipeline::add_block) when a reorg
+/// is detected.
+#[derive(Debug, thiserror::Error)]
+pub enum ReorgError {
+    /// The block's parent hash does not match the current tip.
+    #[error("parent hash mismatch: expected {expected}, got {got}")]
+    ParentMismatch {
+        /// The expected parent hash (current tip).
+        expected: B256,
+        /// The actual parent hash from the incoming block.
+        got: B256,
+    },
+}

--- a/crates/batcher/encoder/src/step.rs
+++ b/crates/batcher/encoder/src/step.rs
@@ -1,0 +1,33 @@
+//! Step result and error types for the batcher pipeline.
+
+/// Result of a [`BatchPipeline::step`](crate::BatchPipeline::step) call.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum StepResult {
+    /// One block was encoded into the current channel.
+    BlockEncoded,
+    /// The current channel reached a closure trigger and was moved to the submission queue.
+    ChannelClosed,
+    /// No work available: no pending blocks and all open channels are already at capacity
+    /// or awaiting confirmation.
+    Idle,
+}
+
+/// Returned by [`BatchPipeline::step`](crate::BatchPipeline::step) when a block cannot be
+/// encoded and the pipeline cannot continue.
+///
+/// Batch composition failure is fatal: a block that cannot be serialised into a
+/// [`SingleBatch`](base_consensus_genesis::batch::SingleBatch) would be silently absent
+/// from the submitted data, breaking the contiguous L2 block sequence required by the
+/// derivation spec. The batcher must halt rather than skip such a block.
+#[derive(Debug, thiserror::Error)]
+pub enum StepError {
+    /// The block could not be converted to a [`SingleBatch`].
+    #[error("batch composition failed for block at cursor {cursor}: {source}")]
+    CompositionFailed {
+        /// Index of the block in the encoder's input queue.
+        cursor: usize,
+        /// Underlying composition error.
+        #[source]
+        source: base_comp::BatchComposeError,
+    },
+}

--- a/crates/batcher/encoder/src/submission.rs
+++ b/crates/batcher/encoder/src/submission.rs
@@ -1,0 +1,77 @@
+//! Submission identifier, DA type, batch submission, and frame encoding.
+
+use std::sync::Arc;
+
+use alloy_primitives::Bytes;
+pub use base_protocol::BatchType;
+use base_protocol::{ChannelId, DERIVATION_VERSION_0, Frame};
+
+/// Identifies a batch submission for receipt tracking.
+///
+/// Monotonically increasing per [`BatchEncoder`](crate::BatchEncoder) instance,
+/// including across [`BatchPipeline::reset`](crate::BatchPipeline::reset) calls.
+/// The counter is intentionally **not** reset to 0 on reset so that post-reset
+/// submissions can never share an ID with any pre-reset in-flight submission,
+/// eliminating stale-confirm collisions.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct SubmissionId(pub u64);
+
+/// Selects how batch frames are encoded for L1 submission.
+///
+/// The driver uses this field on each [`BatchSubmission`] to determine whether
+/// frames should be packed into EIP-4844 blobs or sent as transaction calldata.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum DaType {
+    /// Frames are packed into EIP-4844 blobs, one blob per frame (default).
+    #[default]
+    Blob,
+    /// Each frame is sent as a single calldata transaction
+    /// (`[DERIVATION_VERSION_0] ++ frame.encode()`).
+    ///
+    /// When using calldata mode, set
+    /// [`EncoderConfig::target_num_frames`](crate::EncoderConfig::target_num_frames) to `1`
+    /// so that each [`BatchSubmission`] contains exactly one frame.
+    Calldata,
+}
+
+/// A single L1 transaction's worth of batch data: one or more frames encoded as blobs.
+///
+/// Contains up to [`EncoderConfig::target_num_frames`](crate::EncoderConfig::target_num_frames)
+/// frames, each mapping to one EIP-4844 blob. Cancun supports up to 6 blobs per transaction;
+/// Isthmus (EIP-7892) supports up to 21.
+#[derive(Debug)]
+pub struct BatchSubmission {
+    /// The unique identifier for this submission.
+    pub id: SubmissionId,
+    /// The channel this submission belongs to.
+    pub channel_id: ChannelId,
+    /// How frames in this submission should be encoded for L1.
+    pub da_type: DaType,
+    /// Frames to include in this L1 transaction.
+    /// Each frame maps to one EIP-4844 blob. Shared via [`Arc`] to avoid
+    /// deep copies of the frame payload when handing off to the driver.
+    pub frames: Vec<Arc<Frame>>,
+}
+
+/// Encodes batch frames for L1 submission.
+///
+/// This unit type groups the frame-encoding utilities used by both the production
+/// `BatchDriver` (in `base-batcher-core`) and the action-test harness, so the framing
+/// logic is defined exactly once.
+#[derive(Debug)]
+pub struct FrameEncoder;
+
+impl FrameEncoder {
+    /// Encode a single frame as L1 calldata.
+    ///
+    /// Prepends the [`DERIVATION_VERSION_0`] byte to the encoded frame, producing
+    /// the exact byte sequence the derivation pipeline expects to find in a batcher
+    /// transaction's calldata field.
+    pub fn to_calldata(frame: &Frame) -> Bytes {
+        let encoded = frame.encode();
+        let mut data = Vec::with_capacity(1 + encoded.len());
+        data.push(DERIVATION_VERSION_0);
+        data.extend_from_slice(&encoded);
+        Bytes::from(data)
+    }
+}


### PR DESCRIPTION
## Summary

Splits the batcher encoder's types.rs into per-type modules (submission.rs, step.rs, reorg.rs, config.rs) per project conventions, and adds FrameEncoder as a unit struct housing the calldata framing logic so both BatchDriver and the test harness share a single implementation instead of duplicating it.

Fixes the confirm/requeue lifecycle in the action test harness Batcher. Previously, encode_frames drained submission IDs from the pipeline but flush confirmed them all unconditionally, even for frames that were never passed to submit_frames. flush now tracks (SubmissionId, frame_count) pairs alongside a submitted_frame_count counter and confirms only submissions whose full frame count was covered, requeueing the rest so the encoder correctly rewinds its frame cursor. A new drain_requeued_frames method exposes requeued submissions for re-submission.

Adds a confirm_lifecycle_requeues_partial_submissions test that directly exercises both paths: partial submit triggers requeue and the remaining frames are recoverable, full submit triggers confirm and leaves nothing to re-drain.