### PR TITLE
fix(ci): Prevent Lychee Merge Group Cancellation

### DIFF
--- a/.github/workflows/lychee.yml
+++ b/.github/workflows/lychee.yml
@@ -2,6 +2,8 @@ name: Lychee Checks
 
 on:
   push:
+    branches-ignore:
+      - 'gh-readonly-queue/**'
   pull_request:
   merge_group:
   workflow_dispatch:


### PR DESCRIPTION
## Summary

The Lychee link-checker workflow triggered on bare \`push:\` events with no branch filter, which caused it to fire on GitHub's merge queue branches (\`gh-readonly-queue/**\`) in addition to the \`merge_group\` event. Since both events share the same \`github.ref\`, the shared concurrency group with \`cancel-in-progress: true\` caused one run to cancel the other, leaving the \`merge_group\` check red. This adds a \`branches-ignore\` filter to the \`push\` trigger so only the \`merge_group\` event handles merge queue refs.