### PR TITLE
fix(actions): Fix Action Test Hardfork Triggers

### DIFF
--- a/actions/harness/tests/batcher_blobs.rs
+++ b/actions/harness/tests/batcher_blobs.rs
@@ -237,3 +237,113 @@ async fn batcher_da_switching() {
     assert_eq!(total_derived, 6, "expected 6 L2 blocks derived (3 calldata + 3 blob)");
     assert_eq!(verifier.l2_safe().block_info.number, 6, "safe head should reach L2 block 6");
 }
+
+// ---------------------------------------------------------------------------
+// Blob DA channel timeout
+// ---------------------------------------------------------------------------
+
+/// A blob DA channel that is not completed within `channel_timeout` L1 blocks
+/// is discarded by the pipeline. Late blob frames for the timed-out channel
+/// are silently ignored; a fresh channel submitted inside the window recovers.
+///
+/// This is the blob-DA variant of
+/// `channel_timeout_triggers_channel_invalidation` in `batcher_channels.rs`.
+/// It uses `submit_blob_frames` instead of `submit_frames` throughout.
+///
+/// Setup:
+/// - `max_frame_size = 80` to force a multi-frame channel.
+/// - `channel_timeout = 2` (very tight: expires after 2 L1 blocks).
+/// - Frame 0 submitted as a blob sidecar in L1 block 1.
+/// - L1 blocks 2–4 are empty (channel_timeout + 1 = 3 blocks).
+/// - Remaining frames arrive as blobs in L1 block 5 — channel already timed out.
+/// - Recovery: all frames resubmitted in a fresh channel (L1 block 6).
+///
+/// The safe head must remain at 0 through L1 block 5, then advance to 1 after
+/// the fresh blob channel is processed.
+#[tokio::test]
+async fn blob_da_channel_timeout() {
+    let batcher_cfg = BatcherConfig {
+        encoder: EncoderConfig { max_frame_size: 80, ..EncoderConfig::default() },
+        ..BatcherConfig::default()
+    };
+    let rollup_cfg =
+        TestRollupConfigBuilder::base_mainnet(&batcher_cfg).with_channel_timeout(2).build();
+    let mut h = ActionTestHarness::new(L1MinerConfig::default(), rollup_cfg);
+
+    let l1_chain = SharedL1Chain::from_blocks(h.l1.chain().to_vec());
+    let mut sequencer = h.create_l2_sequencer(l1_chain);
+    let block = sequencer.build_next_block().expect("build L2 block 1");
+
+    // Encode the L2 block into multiple frames (tiny max_frame_size).
+    let mut source = ActionL2Source::new();
+    source.push(block.clone());
+    let mut batcher = h.create_batcher(source, batcher_cfg.clone());
+    let frames = batcher.encode_frames().expect("encode multi-frame channel");
+    assert!(
+        frames.len() >= 2,
+        "expected multi-frame channel with max_frame_size=80, got {} frames",
+        frames.len()
+    );
+
+    // Submit ONLY frame 0 as a blob sidecar in L1 block 1.
+    batcher.submit_blob_frames(&frames[..1]);
+    batcher.flush(&mut h.l1);
+
+    let (mut verifier, chain) = h.create_blob_verifier_from_sequencer(
+        &sequencer,
+        SharedL1Chain::from_blocks(h.l1.chain().to_vec()),
+    );
+
+    h.mine_and_push(&chain); // L1 block 1: blob with frame 0 only
+
+    verifier.initialize().await.expect("initialize");
+    let l1_block_1 = block_info_from(h.l1.block_by_number(1).expect("block 1"));
+    verifier.act_l1_head_signal(l1_block_1).await.expect("signal block 1");
+    verifier.act_l2_pipeline_full().await.expect("step block 1");
+
+    assert_eq!(
+        verifier.l2_safe().block_info.number,
+        0,
+        "incomplete blob channel should not advance safe head"
+    );
+
+    // Mine channel_timeout + 1 = 3 empty L1 blocks to expire the channel.
+    for _ in 0..3 {
+        h.mine_and_push(&chain);
+    }
+    for i in 2..=4 {
+        let blk = block_info_from(h.l1.block_by_number(i).expect("block exists"));
+        verifier.act_l1_head_signal(blk).await.expect("signal empty block");
+        verifier.act_l2_pipeline_full().await.expect("step empty block");
+    }
+
+    // Submit remaining frames as blobs — channel already timed out; silently dropped.
+    {
+        let empty_source = ActionL2Source::new();
+        let mut late_batcher = h.create_batcher(empty_source, batcher_cfg.clone());
+        late_batcher.submit_blob_frames(&frames[1..]);
+        late_batcher.flush(&mut h.l1);
+    }
+    h.mine_and_push(&chain); // L1 block 5: late blob frames
+
+    let l1_block_5 = block_info_from(h.l1.block_by_number(5).expect("block 5"));
+    verifier.act_l1_head_signal(l1_block_5).await.expect("signal block 5");
+    let derived = verifier.act_l2_pipeline_full().await.expect("step block 5");
+    assert_eq!(derived, 0, "late blob frames after channel timeout must be silently dropped");
+
+    // Recovery: resubmit all frames as blobs in a fresh channel.
+    let mut source2 = ActionL2Source::new();
+    source2.push(block);
+    let mut batcher2 = h.create_batcher(source2, batcher_cfg);
+    let recovery_frames = batcher2.encode_frames().expect("encode recovery channel");
+    batcher2.submit_blob_frames(&recovery_frames);
+    batcher2.flush(&mut h.l1);
+    h.mine_and_push(&chain); // L1 block 6: fresh blob channel with all frames
+
+    let l1_block_6 = block_info_from(h.l1.block_by_number(6).expect("block 6"));
+    verifier.act_l1_head_signal(l1_block_6).await.expect("signal block 6");
+    let recovered = verifier.act_l2_pipeline_full().await.expect("step block 6");
+
+    assert_eq!(recovered, 1, "resubmitted blob channel should derive L2 block 1");
+    assert_eq!(verifier.l2_safe().block_info.number, 1, "safe head should recover to 1");
+}

--- a/actions/harness/tests/batcher_blobs.rs
+++ b/actions/harness/tests/batcher_blobs.rs
@@ -254,7 +254,7 @@ async fn batcher_da_switching() {
 /// - `max_frame_size = 80` to force a multi-frame channel.
 /// - `channel_timeout = 2` (very tight: expires after 2 L1 blocks).
 /// - Frame 0 submitted as a blob sidecar in L1 block 1.
-/// - L1 blocks 2–4 are empty (channel_timeout + 1 = 3 blocks).
+/// - L1 blocks 2–4 are empty (`channel_timeout` + 1 = 3 blocks).
 /// - Remaining frames arrive as blobs in L1 block 5 — channel already timed out.
 /// - Recovery: all frames resubmitted in a fresh channel (L1 block 6).
 ///

--- a/actions/harness/tests/batcher_hardfork_transitions.rs
+++ b/actions/harness/tests/batcher_hardfork_transitions.rs
@@ -1,0 +1,213 @@
+#![doc = "Action tests for batch format transitions across hardfork boundaries."]
+
+use base_action_harness::{
+    ActionL2Source, ActionTestHarness, BatchType, BatcherConfig, L1MinerConfig, SharedL1Chain,
+    TestRollupConfigBuilder, block_info_from,
+};
+use base_consensus_genesis::HardForkConfig;
+
+// ---------------------------------------------------------------------------
+// A. Span batch with non-empty hardfork transition block is rejected
+//
+// op-e2e ref: TestHardforkMiddleOfSpanBatch
+// ---------------------------------------------------------------------------
+
+/// A span batch covering blocks 1–4 where block 3 is the first Jovian block
+/// but **contains user transactions** (which is illegal for the upgrade block)
+/// is partially rejected. The pipeline derives blocks 1–2 from the span batch,
+/// then fails on block 3 (NonEmptyTransitionBlock → FlushChannel under Holocene),
+/// dropping the span batch's channel. Blocks 3–4 are never derived from the
+/// span batch.
+///
+/// This demonstrates the **all-or-nothing** failure mode for span batches: a
+/// single bad block mid-span loses the remaining blocks in the channel, forcing
+/// a re-submission of blocks 3–4. This is the key difference from singular
+/// batches where only the offending block is dropped and all others derive fine
+/// (tested in `jovian_non_empty_transition_batch_generates_deposit_only_block`).
+///
+/// Recovery: blocks 3 (empty) and 4 are resubmitted as a corrected span batch
+/// in a new channel; safe head advances to 4.
+///
+/// Note: `NonEmptyTransitionBlock` only fires for the first Jovian block, not
+/// for earlier hardforks like Ecotone or Isthmus.
+#[tokio::test]
+async fn span_batch_with_non_empty_transition_block_rejected() {
+    // All forks through Isthmus active at genesis. Jovian activates at ts=6
+    // (L2 block 3 with block_time=2). Because only Jovian is "new" at ts=6,
+    // `is_first_jovian_block(6)` returns true and the NonEmptyTransitionBlock
+    // check fires for block 3 alone.
+    let jovian_time = 6u64;
+    let hardforks = HardForkConfig {
+        canyon_time: Some(0),
+        delta_time: Some(0),
+        ecotone_time: Some(0),
+        fjord_time: Some(0),
+        granite_time: Some(0),
+        holocene_time: Some(0),
+        isthmus_time: Some(0),
+        jovian_time: Some(jovian_time),
+        ..Default::default()
+    };
+    let batcher_cfg = BatcherConfig::default();
+    let rollup_cfg =
+        TestRollupConfigBuilder::base_mainnet(&batcher_cfg).with_hardforks(hardforks).build();
+    let mut h = ActionTestHarness::new(L1MinerConfig::default(), rollup_cfg);
+
+    let l1_chain = SharedL1Chain::from_blocks(h.l1.chain().to_vec());
+    let mut builder = h.create_l2_sequencer(l1_chain);
+
+    // Build 4 L2 blocks. build_next_block() includes a user transaction in
+    // every block. Block 3 (ts=6) is the first Jovian block, which must be
+    // deposit-only — including a user tx here is the deliberate error.
+    let block1 = builder.build_next_block().expect("build L2 block 1"); // ts=2
+    let block2 = builder.build_next_block().expect("build L2 block 2"); // ts=4
+    let block3_invalid = builder.build_next_block().expect("build L2 block 3 (invalid)"); // ts=6
+    let block4 = builder.build_next_block().expect("build L2 block 4"); // ts=8
+
+    let (mut verifier, chain) = h.create_verifier_from_sequencer(
+        &builder,
+        SharedL1Chain::from_blocks(h.l1.chain().to_vec()),
+    );
+
+    // --- Phase 1: submit all 4 blocks as one span batch (block 3 has user txs) ---
+    {
+        let span_cfg = BatcherConfig { batch_type: BatchType::Span, ..batcher_cfg.clone() };
+        let mut source = ActionL2Source::new();
+        source.push(block1.clone());
+        source.push(block2.clone());
+        source.push(block3_invalid);
+        source.push(block4.clone());
+        let mut batcher = h.create_batcher(source, span_cfg);
+        batcher.advance().expect("encode span batch with invalid block 3");
+        batcher.flush(&mut h.l1);
+    }
+    h.mine_and_push(&chain); // L1 block 1: span batch with invalid block 3
+
+    verifier.initialize().await.expect("initialize");
+    let l1_block_1 = block_info_from(h.l1.block_by_number(1).expect("block 1"));
+    verifier.act_l1_head_signal(l1_block_1).await.expect("signal block 1");
+    verifier.act_l2_pipeline_full().await.expect("pipeline after block 1");
+
+    // Under Holocene, when the pipeline reaches block 3 in the span batch and
+    // detects a user tx in the upgrade block, it sends FlushChannel (via
+    // BatchStream::flush), discarding the channel entirely. Blocks 1 and 2 were
+    // already emitted as individual batches before the failure, so safe head is 2.
+    assert_eq!(
+        verifier.l2_safe().block_info.number,
+        2,
+        "blocks 1 and 2 should derive before span batch fails on block 3"
+    );
+
+    // --- Phase 2: resubmit blocks 3–4 with block 3 correctly empty ---
+    //
+    // The primary builder is now at block 4; build_empty_block() on it would
+    // produce block 5 (wrong timestamp). Instead, create a fresh sequencer
+    // starting from genesis, advance it to block 2's state, then build the
+    // correct recovery blocks 3 (empty, ts=6) and 4 (user tx, ts=8).
+    //
+    // The Holocene BatchValidator overwrites each singular batch's parent_hash
+    // with the current chain head before validating, so the recovery blocks
+    // only need the correct timestamps and user-tx content — not the exact
+    // parent hashes from the primary sequencer's chain.
+    {
+        let l1_chain2 = SharedL1Chain::from_blocks(h.l1.chain().to_vec());
+        let mut builder2 = h.create_l2_sequencer(l1_chain2);
+        let _rb1 = builder2.build_next_block().expect("advance recovery builder past block 1");
+        let _rb2 = builder2.build_next_block().expect("advance recovery builder past block 2");
+        let block3_empty = builder2.build_empty_block().expect("build empty block 3 for recovery");
+        let block4_recovery = builder2.build_next_block().expect("build recovery block 4");
+
+        let span_cfg = BatcherConfig { batch_type: BatchType::Span, ..batcher_cfg };
+        let mut source = ActionL2Source::new();
+        source.push(block3_empty);
+        source.push(block4_recovery);
+        let mut batcher = h.create_batcher(source, span_cfg);
+        batcher.advance().expect("encode recovery span batch");
+        batcher.flush(&mut h.l1);
+    }
+    h.mine_and_push(&chain); // L1 block 2: recovery span batch (blocks 3–4)
+
+    let l1_block_2 = block_info_from(h.l1.block_by_number(2).expect("block 2"));
+    verifier.act_l1_head_signal(l1_block_2).await.expect("signal block 2");
+    verifier.act_l2_pipeline_full().await.expect("pipeline after block 2");
+
+    assert_eq!(
+        verifier.l2_safe().block_info.number,
+        4,
+        "after recovery submission, safe head must reach block 4"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// B. Mixed singular and span batches in the same derivation run
+//
+// op-e2e ref: TestMixOfBatchesAfterHardfork
+// ---------------------------------------------------------------------------
+
+/// After Fjord (which cascades to activate Delta), the pipeline must accept
+/// **both** singular and span batches in the same derivation run. This test
+/// submits block 1 as a singular batch in L1 block 1 and block 2 as a span
+/// batch in L1 block 2.
+///
+/// Prior to Delta, span batches are rejected outright (`SpanBatchPreDelta`).
+/// After Delta, both formats are valid. The derivation pipeline must derive
+/// all 2 L2 blocks regardless of which format each batch uses.
+#[tokio::test]
+async fn mixed_singular_and_span_batches_after_delta() {
+    let batcher_cfg = BatcherConfig::default();
+    // Fjord cascades: Canyon, Delta, Ecotone, Fjord all active at genesis.
+    let hardforks = HardForkConfig { fjord_time: Some(0), ..Default::default() };
+    let rollup_cfg =
+        TestRollupConfigBuilder::base_mainnet(&batcher_cfg).with_hardforks(hardforks).build();
+    let mut h = ActionTestHarness::new(L1MinerConfig::default(), rollup_cfg);
+
+    let l1_chain = SharedL1Chain::from_blocks(h.l1.chain().to_vec());
+    let mut builder = h.create_l2_sequencer(l1_chain);
+
+    let block1 = builder.build_next_block().expect("build L2 block 1");
+    let block2 = builder.build_next_block().expect("build L2 block 2");
+
+    let (mut verifier, chain) = h.create_verifier_from_sequencer(
+        &builder,
+        SharedL1Chain::from_blocks(h.l1.chain().to_vec()),
+    );
+
+    // L1 block 1: block 1 as a SINGULAR batch.
+    {
+        let singular_cfg = BatcherConfig { batch_type: BatchType::Single, ..batcher_cfg.clone() };
+        let mut source = ActionL2Source::new();
+        source.push(block1);
+        let mut batcher = h.create_batcher(source, singular_cfg);
+        batcher.advance().expect("encode singular batch");
+        batcher.flush(&mut h.l1);
+    }
+    h.mine_and_push(&chain); // L1 block 1: singular batch for L2 block 1
+
+    // L1 block 2: block 2 as a SPAN batch.
+    {
+        let span_cfg = BatcherConfig { batch_type: BatchType::Span, ..batcher_cfg };
+        let mut source = ActionL2Source::new();
+        source.push(block2);
+        let mut batcher = h.create_batcher(source, span_cfg);
+        batcher.advance().expect("encode span batch");
+        batcher.flush(&mut h.l1);
+    }
+    h.mine_and_push(&chain); // L1 block 2: span batch for L2 block 2
+
+    verifier.initialize().await.expect("initialize");
+
+    // Drive derivation L1 block by block. The first batch (singular) derives
+    // L2 block 1; the second (span) derives L2 block 2.
+    for i in 1..=2u64 {
+        let blk = block_info_from(h.l1.block_by_number(i).expect("block exists"));
+        verifier.act_l1_head_signal(blk).await.expect("signal");
+        let derived = verifier.act_l2_pipeline_full().await.expect("pipeline");
+        assert_eq!(derived, 1, "L1 block {i} should derive exactly one L2 block");
+    }
+
+    assert_eq!(
+        verifier.l2_safe().block_info.number,
+        2,
+        "mixed singular + span batches must both derive; safe head should reach 2"
+    );
+}

--- a/actions/harness/tests/batcher_hardfork_transitions.rs
+++ b/actions/harness/tests/batcher_hardfork_transitions.rs
@@ -15,7 +15,7 @@ use base_consensus_genesis::HardForkConfig;
 /// A span batch covering blocks 1–4 where block 3 is the first Jovian block
 /// but **contains user transactions** (which is illegal for the upgrade block)
 /// is partially rejected. The pipeline derives blocks 1–2 from the span batch,
-/// then fails on block 3 (NonEmptyTransitionBlock → FlushChannel under Holocene),
+/// then fails on block 3 (`NonEmptyTransitionBlock` → `FlushChannel` under Holocene),
 /// dropping the span batch's channel. Blocks 3–4 are never derived from the
 /// span batch.
 ///

--- a/actions/harness/tests/derivation.rs
+++ b/actions/harness/tests/derivation.rs
@@ -2283,3 +2283,286 @@ async fn pipeline_l1_origin_advance_observable_after_epoch_exhausted() {
         "safe head must not change: origin advanced but empty block 2 has no batch"
     );
 }
+
+// ── Span batch: multi-epoch crossing ──────────────────────────────────────────
+
+/// A single span batch encoding L2 blocks that span two L1 epochs is correctly
+/// derived by the pipeline.
+///
+/// With `block_time=2` and L1 `block_time=12`, L2 blocks 1–5 (ts=2..10)
+/// reference epoch 0 (L1 genesis) and L2 block 6 (ts=12) references epoch 1
+/// (L1 block 1). All 6 blocks are encoded together in one span batch and
+/// submitted in L1 block 2.
+///
+/// The `SpanBatch::get_single_batch` implementation encodes the epoch
+/// transition internally; this test exercises that path and verifies that
+/// the `BatchQueue` correctly emits all 6 blocks in order.
+///
+/// Mirrors [`multi_epoch_sequence`] which uses singular batches for the same
+/// block set.
+#[tokio::test]
+async fn span_batch_crossing_l1_epoch_boundary() {
+    let batcher_cfg = BatcherConfig { batch_type: BatchType::Span, ..BatcherConfig::default() };
+    let rollup_cfg = TestRollupConfigBuilder::base_mainnet(&batcher_cfg).build();
+    let mut h = ActionTestHarness::new(L1MinerConfig::default(), rollup_cfg);
+
+    // Mine L1 block 1 at ts=12 so the sequencer can advance to epoch 1 when
+    // building L2 block 6 (ts=12).
+    h.mine_l1_blocks(1);
+
+    let l1_chain = SharedL1Chain::from_blocks(h.l1.chain().to_vec());
+    let mut builder = h.create_l2_sequencer(l1_chain);
+
+    // Blocks 1–5 (ts=2..10) reference epoch 0; block 6 (ts=12) references epoch 1.
+    let mut source = ActionL2Source::new();
+    for _ in 1..=6u64 {
+        source.push(builder.build_next_block().expect("build L2 block"));
+    }
+    assert_eq!(builder.head().l1_origin.number, 1, "block 6 must reference epoch 1");
+
+    let (mut verifier, chain) = h.create_verifier_from_sequencer(
+        &builder,
+        SharedL1Chain::from_blocks(h.l1.chain().to_vec()),
+    );
+
+    // Encode all 6 blocks as a single span batch and submit in L1 block 2.
+    let mut batcher = h.create_batcher(source, batcher_cfg);
+    batcher.advance().expect("encode multi-epoch span batch");
+    batcher.flush(&mut h.l1);
+    h.mine_and_push(&chain); // L1 block 2: span batch for all 6 L2 blocks
+
+    verifier.initialize().await.expect("initialize");
+
+    // L1 block 1: epoch-providing only, no batches → nothing derived.
+    let l1_block_1 = block_info_from(h.l1.block_by_number(1).expect("block 1"));
+    verifier.act_l1_head_signal(l1_block_1).await.expect("signal block 1");
+    verifier.act_l2_pipeline_full().await.expect("pipeline block 1");
+
+    // L1 block 2: contains the span batch. The BatchQueue has both epoch 0
+    // (L1 block 0→1) and epoch 1 (L1 block 1→2) boundaries available, so
+    // it emits all 6 L2 blocks in one pipeline run.
+    let l1_block_2 = block_info_from(h.l1.block_by_number(2).expect("block 2"));
+    verifier.act_l1_head_signal(l1_block_2).await.expect("signal block 2");
+    let derived = verifier.act_l2_pipeline_full().await.expect("pipeline block 2");
+
+    assert_eq!(
+        derived, 6,
+        "all 6 L2 blocks must be derived from a single span batch crossing the epoch boundary"
+    );
+    assert_eq!(
+        verifier.l2_safe().block_info.number,
+        6,
+        "safe head must reach block 6 after span batch crosses epoch 0 → 1"
+    );
+}
+
+/// The [`BatchQueue`] reorders span batches submitted in reverse L1 order.
+///
+/// This is the span-batch variant of
+/// [`out_of_order_singular_batches_reordered_by_batch_queue`]. The span batch
+/// for L2 block 2 is submitted in L1 block 1 (a "future" batch); the span
+/// batch for L2 block 1 arrives in L1 block 2 (the expected-next batch).
+///
+/// The `BatchQueue` must:
+/// 1. Buffer the future span batch on L1 block 1 (no blocks derived).
+/// 2. Derive L2 block 1 from the expected-next span batch on L1 block 2.
+/// 3. Pop the buffered span batch and derive L2 block 2 in the same run.
+///
+/// [`BatchQueue`]: base_consensus_derive::BatchQueue
+#[tokio::test]
+async fn out_of_order_span_batches_reordered_by_batch_queue() {
+    let span_cfg = BatcherConfig { batch_type: BatchType::Span, ..BatcherConfig::default() };
+    let rollup_cfg = TestRollupConfigBuilder::base_mainnet(&span_cfg).build();
+    let mut h = ActionTestHarness::new(L1MinerConfig::default(), rollup_cfg);
+
+    let l1_chain = SharedL1Chain::from_blocks(h.l1.chain().to_vec());
+    let mut builder = h.create_l2_sequencer(l1_chain);
+
+    let block1 = builder.build_next_block().expect("build L2 block 1");
+    let block2 = builder.build_next_block().expect("build L2 block 2");
+
+    let (mut verifier, chain) = h.create_verifier_from_sequencer(
+        &builder,
+        SharedL1Chain::from_blocks(h.l1.chain().to_vec()),
+    );
+
+    // L1 block 1: span batch for L2 block 2 (future batch, submitted out of order).
+    {
+        let mut source = ActionL2Source::new();
+        source.push(block2);
+        let mut batcher = h.create_batcher(source, span_cfg.clone());
+        batcher.advance().expect("encode future span batch");
+        batcher.flush(&mut h.l1);
+    }
+    h.mine_and_push(&chain); // L1 block 1: future span batch
+
+    // L1 block 2: span batch for L2 block 1 (the expected-next batch).
+    {
+        let mut source = ActionL2Source::new();
+        source.push(block1);
+        let mut batcher = h.create_batcher(source, span_cfg);
+        batcher.advance().expect("encode present span batch");
+        batcher.flush(&mut h.l1);
+    }
+    h.mine_and_push(&chain); // L1 block 2: present span batch
+
+    verifier.initialize().await.expect("initialize");
+
+    // Signal L1 block 1: span batch for block 2 is a future batch (ts=4 >
+    // expected ts=2). The BatchQueue buffers it; no attributes produced.
+    let l1_block_1 = block_info_from(h.l1.block_by_number(1).expect("block 1"));
+    verifier.act_l1_head_signal(l1_block_1).await.expect("signal block 1");
+    let (_, hit) = verifier
+        .act_l2_pipeline_until(|r| matches!(r, StepResult::PreparedAttributes), 500)
+        .await
+        .expect("step block 1");
+    assert!(!hit, "future span batch must be buffered; no blocks derived from L1 block 1");
+    assert_eq!(verifier.l2_safe().block_info.number, 0, "safe head must remain at genesis");
+
+    // Signal L1 block 2: expected-next span batch (block 1) arrives.
+    let l1_block_2 = block_info_from(h.l1.block_by_number(2).expect("block 2"));
+    verifier.act_l1_head_signal(l1_block_2).await.expect("signal block 2");
+
+    // First PreparedAttributes: L2 block 1 (earliest timestamp) must derive first.
+    let (_, hit1) = verifier
+        .act_l2_pipeline_until(|r| matches!(r, StepResult::PreparedAttributes), 500)
+        .await
+        .expect("step for block 1 attributes");
+    assert!(hit1, "pipeline must derive block 1 when its span batch arrives");
+    assert_eq!(
+        verifier.l2_safe().block_info.number,
+        1,
+        "BatchQueue must reorder: block 1 derived before the buffered span batch for block 2"
+    );
+
+    // Second PreparedAttributes: buffered block-2 span batch now matches expected-next.
+    let (_, hit2) = verifier
+        .act_l2_pipeline_until(|r| matches!(r, StepResult::PreparedAttributes), 500)
+        .await
+        .expect("step for block 2 attributes");
+    assert!(hit2, "buffered span batch for block 2 must derive after block 1 is safe");
+    assert_eq!(verifier.l2_safe().block_info.number, 2, "safe head must reach block 2");
+}
+
+// ── Large L1 gaps ──────────────────────────────────────────────────────────────
+
+/// Batches submitted after a long gap of empty L1 blocks are accepted and
+/// derived correctly as long as the gap is within the sequence window.
+///
+/// Two L2 blocks are built in epoch 0. The batches are withheld for 15 L1
+/// blocks and then submitted in L1 block 16. Because Base mainnet's default
+/// `seq_window_size` is large enough to accommodate 16 L1 blocks, both
+/// batches are accepted and both L2 blocks derive.
+///
+/// This exercises the pipeline's L1 traversal over many empty blocks — the
+/// common mainnet scenario during periods of L1 congestion.
+///
+/// op-e2e ref: `LargeL1Gaps`
+#[tokio::test]
+async fn large_l1_gaps_within_sequence_window() {
+    let batcher_cfg = BatcherConfig::default();
+    let rollup_cfg = TestRollupConfigBuilder::base_mainnet(&batcher_cfg).build();
+    let mut h = ActionTestHarness::new(L1MinerConfig::default(), rollup_cfg);
+
+    let l1_chain = SharedL1Chain::from_blocks(h.l1.chain().to_vec());
+    let mut builder = h.create_l2_sequencer(l1_chain);
+
+    // Build 2 L2 blocks in epoch 0 (both reference L1 genesis as their origin).
+    let block1 = builder.build_next_block().expect("build block 1");
+    let block2 = builder.build_next_block().expect("build block 2");
+
+    let (mut verifier, chain) = h.create_verifier_from_sequencer(
+        &builder,
+        SharedL1Chain::from_blocks(h.l1.chain().to_vec()),
+    );
+
+    // Mine 15 empty L1 blocks with no batch data.
+    for _ in 0..15 {
+        h.mine_and_push(&chain); // L1 blocks 1–15: all empty
+    }
+
+    // Submit both batches together in L1 block 16 — still inside the window.
+    let mut source = ActionL2Source::new();
+    source.push(block1);
+    source.push(block2);
+    let mut batcher = h.create_batcher(source, batcher_cfg);
+    batcher.advance().expect("encode batches");
+    batcher.flush(&mut h.l1);
+    h.mine_and_push(&chain); // L1 block 16: batches for L2 blocks 1 and 2
+
+    verifier.initialize().await.expect("initialize");
+
+    // Drive derivation through all 16 L1 blocks. The pipeline traverses 15
+    // empty blocks before finding the channel in block 16.
+    for i in 1..=16u64 {
+        let blk = block_info_from(h.l1.block_by_number(i).expect("block exists"));
+        verifier.act_l1_head_signal(blk).await.expect("signal");
+        verifier.act_l2_pipeline_full().await.expect("pipeline");
+    }
+
+    assert_eq!(
+        verifier.l2_safe().block_info.number,
+        2,
+        "both L2 blocks must derive even after 15 empty L1 blocks before the batch"
+    );
+}
+
+// ── Sequence-window exhaustion ─────────────────────────────────────────────────
+
+/// When no batches are submitted across many L1 blocks the derivation pipeline
+/// generates deposit-only default blocks for every expired epoch, ensuring the
+/// L2 chain always makes forward progress.
+///
+/// Configuration:
+/// - `seq_window_size = 4` (small window so epochs expire quickly)
+/// - Zero batches submitted
+/// - 20 empty L1 blocks mined
+///
+/// Expected result: the safe head advances well past genesis as the pipeline
+/// synthesises deposit-only blocks for each expired epoch.
+///
+/// op-e2e ref: `ExtendedTimeWithoutL1Batches`
+#[tokio::test]
+async fn extended_sequence_window_exhaustion_fills_with_deposit_only_blocks() {
+    const SEQ_WINDOW: u64 = 4;
+    let batcher_cfg = BatcherConfig::default();
+    let rollup_cfg = TestRollupConfigBuilder::base_mainnet(&batcher_cfg)
+        .with_seq_window_size(SEQ_WINDOW)
+        .build();
+    let mut h = ActionTestHarness::new(L1MinerConfig::default(), rollup_cfg);
+
+    let l1_chain = SharedL1Chain::from_blocks(h.l1.chain().to_vec());
+    let builder = h.create_l2_sequencer(l1_chain);
+    let (mut verifier, chain) = h.create_verifier_from_sequencer(
+        &builder,
+        SharedL1Chain::from_blocks(h.l1.chain().to_vec()),
+    );
+
+    // Mine 20 empty L1 blocks — no batches submitted anywhere.
+    for _ in 0..20 {
+        h.mine_and_push(&chain);
+    }
+
+    verifier.initialize().await.expect("initialize");
+
+    let mut total_derived = 0;
+    for i in 1..=20u64 {
+        let blk = block_info_from(h.l1.block_by_number(i).expect("block exists"));
+        verifier.act_l1_head_signal(blk).await.expect("signal");
+        total_derived += verifier.act_l2_pipeline_full().await.expect("pipeline");
+    }
+
+    // With no batches, the pipeline generates deposit-only blocks for each
+    // expired sequence window. The safe head must advance past genesis.
+    assert!(
+        verifier.l2_safe().block_info.number > 0,
+        "safe head must advance past genesis via deposit-only blocks when \
+         sequence windows expire; got {}",
+        verifier.l2_safe().block_info.number
+    );
+    assert!(
+        total_derived > 0,
+        "pipeline must have generated deposit-only blocks for expired epochs; \
+         total_derived = {total_derived}"
+    );
+}

--- a/actions/harness/tests/ecotone_activation.rs
+++ b/actions/harness/tests/ecotone_activation.rs
@@ -1,0 +1,278 @@
+#![doc = "Action tests for the Ecotone hardfork activation boundary."]
+
+use base_action_harness::{
+    ActionL2Source, ActionTestHarness, BatcherConfig, L1MinerConfig, SharedL1Chain,
+    TestRollupConfigBuilder, block_info_from,
+};
+use base_alloy_consensus::{OpBlock, OpTxEnvelope};
+use base_consensus_genesis::HardForkConfig;
+use base_protocol::L1BlockInfoTx;
+
+/// Decode the [`L1BlockInfoTx`] from the first (deposit) transaction of an [`OpBlock`].
+fn l1_info_from_block(block: &OpBlock) -> L1BlockInfoTx {
+    let OpTxEnvelope::Deposit(sealed) = &block.body.transactions[0] else {
+        panic!("first transaction must be a deposit");
+    };
+    L1BlockInfoTx::decode_calldata(sealed.inner().input.as_ref())
+        .expect("L1 info calldata must decode")
+}
+
+// ---------------------------------------------------------------------------
+// A. L1 info format transitions at Ecotone activation
+//
+// op-e2e ref: ecotone_fork_test.go
+// ---------------------------------------------------------------------------
+
+/// The L1 info deposit transaction changes format at Ecotone activation in
+/// **two steps**:
+///
+/// 1. Before Ecotone: `L1BlockInfoTx::Bedrock` (no blob base fee, 4-byte
+///    `setL1BlockValues` selector).
+/// 2. At the **first** Ecotone block: still `Bedrock` format, because the
+///    L1Block contract has not yet been upgraded (upgrade transactions are
+///    placed *after* the L1 info deposit, so the contract is still on the old
+///    ABI for the first block).
+/// 3. From the **second** Ecotone block onward: `L1BlockInfoTx::Ecotone`
+///    (with `blob_base_fee`, `blob_base_fee_scalar`, new selector).
+///
+/// `operator_fees.rs` tests the Isthmus→Jovian transition; this covers the
+/// earlier pre-Ecotone → Ecotone boundary.
+#[test]
+fn ecotone_l1_info_format_transitions_at_activation() {
+    let batcher_cfg = BatcherConfig::default();
+
+    // Canyon and Delta active at genesis; Ecotone activates at ts=6 (block 3,
+    // block_time=2). All earlier forks silent so they don't interfere.
+    let ecotone_time = 6u64;
+    let hardforks = HardForkConfig {
+        canyon_time: Some(0),
+        delta_time: Some(0),
+        ecotone_time: Some(ecotone_time),
+        ..Default::default()
+    };
+    let rollup_cfg =
+        TestRollupConfigBuilder::base_mainnet(&batcher_cfg).with_hardforks(hardforks).build();
+    let h = ActionTestHarness::new(L1MinerConfig::default(), rollup_cfg);
+    let l1_chain = SharedL1Chain::from_blocks(h.l1.chain().to_vec());
+    let mut builder = h.create_l2_sequencer(l1_chain);
+
+    // Block 1: ts=2 — pre-Ecotone. Expect Bedrock format.
+    let block1 = builder.build_next_block().expect("build block 1");
+    let info1 = l1_info_from_block(&block1);
+    assert!(
+        matches!(info1, L1BlockInfoTx::Bedrock(_)),
+        "block 1 (pre-Ecotone ts=2) must use Bedrock format, got {info1:?}"
+    );
+
+    // Block 2: ts=4 — still pre-Ecotone. Expect Bedrock format.
+    let block2 = builder.build_next_block().expect("build block 2");
+    let info2 = l1_info_from_block(&block2);
+    assert!(
+        matches!(info2, L1BlockInfoTx::Bedrock(_)),
+        "block 2 (pre-Ecotone ts=4) must use Bedrock format, got {info2:?}"
+    );
+
+    // Block 3: ts=6 — FIRST Ecotone block. Protocol rule: L1Block contract
+    // upgrade tx is appended AFTER the L1 info deposit, so the contract is
+    // still on the Bedrock ABI. The sequencer sends a Bedrock-format L1 info tx.
+    let block3 = builder.build_empty_block().expect("build empty block 3 (first Ecotone)");
+    assert_eq!(block3.header.timestamp, ecotone_time, "block 3 must be at ecotone_time");
+    let info3 = l1_info_from_block(&block3);
+    assert!(
+        matches!(info3, L1BlockInfoTx::Bedrock(_)),
+        "block 3 (first Ecotone ts=6) must still use Bedrock format, got {info3:?}"
+    );
+
+    // Block 4: ts=8 — second Ecotone block. L1Block contract now upgraded.
+    // Sequencer sends Ecotone-format L1 info tx.
+    let block4 = builder.build_next_block().expect("build block 4 (post-Ecotone)");
+    let info4 = l1_info_from_block(&block4);
+    assert!(
+        matches!(info4, L1BlockInfoTx::Ecotone(_)),
+        "block 4 (post-Ecotone ts=8) must use Ecotone format, got {info4:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// B. Ecotone activation block user txs are accepted at the batch layer
+//
+// op-e2e ref: ecotone_fork_test.go
+// ---------------------------------------------------------------------------
+
+/// Unlike the Jovian hardfork, Ecotone does **not** enforce an empty first block
+/// at the batch-validation layer. There is no `NonEmptyTransitionBlock` check
+/// for Ecotone; the constraint is enforced at the sequencer level
+/// (`should_use_tx_pool()` returns `false` for the first Ecotone block).
+///
+/// This test verifies that a batch that *includes* user transactions for the
+/// Ecotone activation block (ts=6) is **accepted** by the pipeline and all 4
+/// L2 blocks derive successfully:
+///
+/// - Blocks 1–2: pre-Ecotone, user txs accepted.
+/// - Block 3 (ts=6): batch with user txs accepted; pipeline also injects
+///   Ecotone upgrade transactions via `StatefulAttributesBuilder`.
+/// - Block 4 (ts=8): derives normally after block 3.
+///
+/// `operator_fees.rs` mirrors this kind of test for the Isthmus→Jovian boundary
+/// where `NonEmptyTransitionBlock` *does* fire.
+#[tokio::test]
+async fn ecotone_activation_block_user_txs_accepted_at_batch_layer() {
+    let batcher_cfg = BatcherConfig::default();
+
+    // Canyon and Delta active at genesis; Ecotone at ts=6 (block 3).
+    // Fjord must be active so the batcher's brotli-compressed frames are
+    // accepted by the pipeline's BatchReader.
+    let ecotone_time = 6u64;
+    let hardforks = HardForkConfig {
+        canyon_time: Some(0),
+        delta_time: Some(0),
+        ecotone_time: Some(ecotone_time),
+        fjord_time: Some(0),
+        ..Default::default()
+    };
+    let rollup_cfg =
+        TestRollupConfigBuilder::base_mainnet(&batcher_cfg).with_hardforks(hardforks).build();
+    let mut h = ActionTestHarness::new(L1MinerConfig::default(), rollup_cfg);
+
+    let l1_chain = SharedL1Chain::from_blocks(h.l1.chain().to_vec());
+    let mut builder = h.create_l2_sequencer(l1_chain);
+
+    // Blocks 1 and 2: pre-Ecotone, user txs OK.
+    for i in 1..=2u64 {
+        let block = builder.build_next_block().expect("build pre-Ecotone block");
+
+        let mut source = ActionL2Source::new();
+        source.push(block);
+        let mut batcher = h.create_batcher(source, batcher_cfg.clone());
+        batcher.advance().expect("encode pre-Ecotone batch");
+        batcher.flush(&mut h.l1);
+        h.l1.mine_block(); // L1 blocks 1 and 2
+        let _ = i;
+    }
+
+    // Block 3 at ts=6 (first Ecotone): build WITH a user tx. Unlike Jovian,
+    // Ecotone has no NonEmptyTransitionBlock batch check, so this batch is
+    // accepted and block 3 is NOT deposit-only.
+    let block3_with_user_tx = builder.build_next_block().expect("build block 3 with user tx");
+    assert_eq!(
+        block3_with_user_tx.header.timestamp, ecotone_time,
+        "block 3 must land exactly at ecotone_time"
+    );
+
+    let mut source3 = ActionL2Source::new();
+    source3.push(block3_with_user_tx);
+    let mut batcher3 = h.create_batcher(source3, batcher_cfg.clone());
+    batcher3.advance().expect("encode block 3 batch");
+    batcher3.flush(&mut h.l1);
+    h.l1.mine_block(); // L1 block 3: batch for block 3 with user tx
+
+    // Block 4: post-Ecotone, user txs OK.
+    let block4 = builder.build_next_block().expect("build post-Ecotone block 4");
+    let mut source4 = ActionL2Source::new();
+    source4.push(block4);
+    let mut batcher4 = h.create_batcher(source4, batcher_cfg);
+    batcher4.advance().expect("encode block 4 batch");
+    batcher4.flush(&mut h.l1);
+    h.l1.mine_block(); // L1 block 4
+
+    let (mut verifier, _chain) = h.create_verifier_from_sequencer(
+        &builder,
+        SharedL1Chain::from_blocks(h.l1.chain().to_vec()),
+    );
+    verifier.initialize().await.expect("initialize");
+
+    // Drive derivation through all 4 L1 blocks.
+    for i in 1..=4u64 {
+        let blk = block_info_from(h.l1.block_by_number(i).expect("block exists"));
+        verifier.act_l1_head_signal(blk).await.expect("signal");
+        verifier.act_l2_pipeline_full().await.expect("pipeline");
+    }
+
+    // Ecotone has no NonEmptyTransitionBlock batch check, so block 3's batch
+    // (with user txs) is accepted. All 4 blocks must derive: block 3 is NOT
+    // deposit-only, unlike the Jovian transition block.
+    assert_eq!(
+        verifier.l2_safe().block_info.number,
+        4,
+        "safe head must reach block 4; Ecotone has no batch-level empty-block enforcement"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// C. Derivation through the Ecotone activation boundary
+//
+// op-e2e ref: ecotone_fork_test.go
+// ---------------------------------------------------------------------------
+
+/// Full end-to-end derivation through the Ecotone activation boundary,
+/// following the same pattern as `jovian_derivation_crosses_activation_boundary`
+/// in `hardfork_activation.rs`.
+///
+/// - Canyon and Delta active at genesis (via Fjord cascade ensures brotli is
+///   accepted by the verifier's `BatchReader`).
+/// - Ecotone activates at ts=6 (L2 block 3, `block_time=2`).
+/// - Blocks 1–2: pre-Ecotone, submitted with user transactions.
+/// - Block 3: first Ecotone block — submitted **empty** (no user txs) because
+///   the pipeline prepends Ecotone upgrade transactions to this block.
+/// - Block 4: post-Ecotone, user txs OK.
+///
+/// All 4 L2 blocks must be derived.
+#[tokio::test]
+async fn ecotone_derivation_crosses_activation_boundary() {
+    let batcher_cfg = BatcherConfig::default();
+
+    // All forks through Delta active at genesis so that at ts=6 only Ecotone
+    // is "new". Fjord must be active so the batcher's brotli compression is
+    // accepted. Ecotone activates at ts=6 (block 3).
+    let ecotone_time = 6u64;
+    let hardforks = HardForkConfig {
+        canyon_time: Some(0),
+        delta_time: Some(0),
+        ecotone_time: Some(ecotone_time),
+        fjord_time: Some(0),
+        ..Default::default()
+    };
+    let rollup_cfg =
+        TestRollupConfigBuilder::base_mainnet(&batcher_cfg).with_hardforks(hardforks).build();
+    let mut h = ActionTestHarness::new(L1MinerConfig::default(), rollup_cfg);
+
+    let l1_chain = SharedL1Chain::from_blocks(h.l1.chain().to_vec());
+    let mut builder = h.create_l2_sequencer(l1_chain);
+
+    // Build and submit 4 L2 blocks individually (one batch per L1 block).
+    for i in 1..=4u64 {
+        let block = if i == 3 {
+            // First Ecotone block: must be deposit-only (no user txs) because
+            // the pipeline prepends the Ecotone upgrade transactions here.
+            builder.build_empty_block().expect("build empty first-Ecotone block")
+        } else {
+            builder.build_next_block().expect("build L2 block with user tx")
+        };
+
+        let mut source = ActionL2Source::new();
+        source.push(block);
+        let mut batcher = h.create_batcher(source, batcher_cfg.clone());
+        batcher.advance().expect("encode batch");
+        batcher.flush(&mut h.l1);
+        h.l1.mine_block();
+    }
+
+    let (mut verifier, _chain) = h.create_verifier_from_sequencer(
+        &builder,
+        SharedL1Chain::from_blocks(h.l1.chain().to_vec()),
+    );
+    verifier.initialize().await.expect("initialize");
+
+    for i in 1..=4u64 {
+        let blk = block_info_from(h.l1.block_by_number(i).expect("block exists"));
+        verifier.act_l1_head_signal(blk).await.expect("signal");
+        let derived = verifier.act_l2_pipeline_full().await.expect("pipeline");
+        assert_eq!(derived, 1, "L1 block {i} should derive exactly one L2 block");
+    }
+
+    assert_eq!(
+        verifier.l2_safe().block_info.number,
+        4,
+        "derivation must succeed through the Ecotone activation boundary"
+    );
+}

--- a/actions/harness/tests/ecotone_activation.rs
+++ b/actions/harness/tests/ecotone_activation.rs
@@ -29,7 +29,7 @@ fn l1_info_from_block(block: &OpBlock) -> L1BlockInfoTx {
 /// 1. Before Ecotone: `L1BlockInfoTx::Bedrock` (no blob base fee, 4-byte
 ///    `setL1BlockValues` selector).
 /// 2. At the **first** Ecotone block: still `Bedrock` format, because the
-///    L1Block contract has not yet been upgraded (upgrade transactions are
+///    `L1Block` contract has not yet been upgraded (upgrade transactions are
 ///    placed *after* the L1 info deposit, so the contract is still on the old
 ///    ABI for the first block).
 /// 3. From the **second** Ecotone block onward: `L1BlockInfoTx::Ecotone`

--- a/actions/harness/tests/holocene_activation.rs
+++ b/actions/harness/tests/holocene_activation.rs
@@ -1,0 +1,324 @@
+#![doc = "Action tests for the Holocene hardfork activation and Holocene-specific protocol changes."]
+
+use base_action_harness::{
+    ActionL2Source, ActionTestHarness, BatcherConfig, L1MinerConfig, SharedL1Chain,
+    TestRollupConfigBuilder, block_info_from,
+};
+use base_batcher_encoder::EncoderConfig;
+use base_consensus_genesis::HardForkConfig;
+
+// ---------------------------------------------------------------------------
+// A. Basic derivation through the Holocene activation boundary
+//
+// op-e2e ref: holocene_activation_test.go
+// ---------------------------------------------------------------------------
+
+/// Full end-to-end derivation through the Holocene activation boundary.
+///
+/// Holocene does **not** inject upgrade transactions (unlike Ecotone, Fjord,
+/// Isthmus, and Jovian), but it does switch the channel provider from
+/// [`ChannelBank`] to [`ChannelAssembler`] and changes frame-pruning semantics.
+///
+/// Configuration (`block_time=2`):
+/// - All forks through Granite active at genesis.
+/// - Holocene activates at ts=6 (L2 block 3).
+/// - Blocks 1–2: pre-Holocene.
+/// - Block 3: first Holocene block — user txs are still fine (no upgrade tx constraint).
+/// - Block 4: post-Holocene.
+///
+/// All 4 blocks must derive successfully.
+///
+/// [`ChannelBank`]: base_consensus_derive::stages::ChannelBank
+/// [`ChannelAssembler`]: base_consensus_derive::stages::ChannelAssembler
+#[tokio::test]
+async fn holocene_derivation_crosses_activation_boundary() {
+    let batcher_cfg = BatcherConfig::default();
+
+    // All forks through Granite at genesis; Holocene at ts=6 (block 3).
+    // Fjord is needed so the batcher's brotli compression is accepted.
+    let holocene_time = 6u64;
+    let hardforks = HardForkConfig {
+        canyon_time: Some(0),
+        delta_time: Some(0),
+        ecotone_time: Some(0),
+        fjord_time: Some(0),
+        granite_time: Some(0),
+        holocene_time: Some(holocene_time),
+        ..Default::default()
+    };
+    let rollup_cfg =
+        TestRollupConfigBuilder::base_mainnet(&batcher_cfg).with_hardforks(hardforks).build();
+    let mut h = ActionTestHarness::new(L1MinerConfig::default(), rollup_cfg);
+
+    let l1_chain = SharedL1Chain::from_blocks(h.l1.chain().to_vec());
+    let mut builder = h.create_l2_sequencer(l1_chain);
+
+    // Build and submit 4 L2 blocks; no upgrade-tx constraint at Holocene,
+    // so user txs are valid in all blocks including block 3.
+    for _ in 1..=4u64 {
+        let block = builder.build_next_block().expect("build L2 block");
+        let mut source = ActionL2Source::new();
+        source.push(block);
+        let mut batcher = h.create_batcher(source, batcher_cfg.clone());
+        batcher.advance().expect("encode batch");
+        batcher.flush(&mut h.l1);
+        h.l1.mine_block();
+    }
+
+    let (mut verifier, _chain) = h.create_verifier_from_sequencer(
+        &builder,
+        SharedL1Chain::from_blocks(h.l1.chain().to_vec()),
+    );
+    verifier.initialize().await.expect("initialize");
+
+    for i in 1..=4u64 {
+        let blk = block_info_from(h.l1.block_by_number(i).expect("block exists"));
+        verifier.act_l1_head_signal(blk).await.expect("signal");
+        let derived = verifier.act_l2_pipeline_full().await.expect("pipeline");
+        assert_eq!(derived, 1, "L1 block {i} should derive exactly one L2 block at/after Holocene");
+    }
+
+    assert_eq!(
+        verifier.l2_safe().block_info.number,
+        4,
+        "all 4 L2 blocks must derive through the Holocene boundary"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// B. Holocene frame pruning: non-sequential frame is dropped
+//
+// op-e2e ref: holocene_frame_test.go
+// ---------------------------------------------------------------------------
+
+/// Under Holocene, [`FrameQueue::prune`] enforces sequential frame numbers
+/// within the same channel. If frame 0 is followed by frame 2 (skipping
+/// frame 1), the [`FrameQueue`] prunes frame 2 immediately. The channel
+/// can never complete and no L2 block is derived.
+///
+/// Pre-Holocene, the frames would sit in the [`ChannelBank`] until the
+/// channel timeout — the timing is different, but the channel also fails to
+/// complete.
+///
+/// Setup:
+/// - `max_frame_size=80` forces at least 3 frames for 1 L2 block.
+/// - Submit frame 0 and frame 2 in L1 block 1 (skipping frame 1).
+/// - Mine enough empty L1 blocks to exhaust any in-progress channel.
+/// - Verify safe head never advances.
+///
+/// [`FrameQueue::prune`]: base_consensus_derive::stages::FrameQueue::prune
+/// [`ChannelBank`]: base_consensus_derive::stages::ChannelBank
+#[tokio::test]
+async fn holocene_non_sequential_frame_pruned_channel_never_completes() {
+    let batcher_cfg = BatcherConfig {
+        encoder: EncoderConfig { max_frame_size: 80, ..EncoderConfig::default() },
+        ..BatcherConfig::default()
+    };
+    let rollup_cfg = TestRollupConfigBuilder::base_mainnet(&batcher_cfg)
+        .with_hardforks(HardForkConfig {
+            canyon_time: Some(0),
+            delta_time: Some(0),
+            ecotone_time: Some(0),
+            fjord_time: Some(0),
+            granite_time: Some(0),
+            holocene_time: Some(0), // active from genesis
+            ..Default::default()
+        })
+        .with_channel_timeout(10) // generous timeout so the channel doesn't expire naturally
+        .build();
+    let mut h = ActionTestHarness::new(L1MinerConfig::default(), rollup_cfg);
+
+    let l1_chain = SharedL1Chain::from_blocks(h.l1.chain().to_vec());
+    let mut sequencer = h.create_l2_sequencer(l1_chain);
+    let block = sequencer.build_next_block().expect("build L2 block 1");
+
+    let mut source = ActionL2Source::new();
+    source.push(block);
+    let mut batcher = h.create_batcher(source, batcher_cfg.clone());
+    let frames = batcher.encode_frames().expect("encode multi-frame channel");
+    assert!(
+        frames.len() >= 3,
+        "need ≥3 frames to skip frame 1; got {} (decrease max_frame_size)",
+        frames.len()
+    );
+
+    // Submit frame 0 and frame 2 in the same L1 block — skipping frame 1.
+    // Under Holocene, FrameQueue::prune removes frame 2 because
+    // frame 0.number + 1 != frame 2.number (0 + 1 = 1 ≠ 2).
+    {
+        let empty_source = ActionL2Source::new();
+        let mut submitter = h.create_batcher(empty_source, batcher_cfg.clone());
+        submitter.submit_frames(&frames[0..1]); // frame 0
+        submitter.submit_frames(&frames[2..3]); // frame 2 (non-sequential)
+        submitter.flush(&mut h.l1);
+    }
+
+    let (mut verifier, chain) = h.create_verifier_from_sequencer(
+        &sequencer,
+        SharedL1Chain::from_blocks(h.l1.chain().to_vec()),
+    );
+
+    h.mine_and_push(&chain); // L1 block 1: frames 0 and 2
+
+    verifier.initialize().await.expect("initialize");
+    let l1_block_1 = block_info_from(h.l1.block_by_number(1).expect("block 1"));
+    verifier.act_l1_head_signal(l1_block_1).await.expect("signal block 1");
+    verifier.act_l2_pipeline_full().await.expect("pipeline block 1");
+
+    // Frame 2 is pruned by FrameQueue — channel 0 only has frame 0.
+    // Channel is incomplete; safe head stays at genesis.
+    assert_eq!(
+        verifier.l2_safe().block_info.number,
+        0,
+        "channel with missing frame 1 must never complete under Holocene"
+    );
+
+    // Mine additional empty L1 blocks past the channel timeout to confirm
+    // the channel is permanently abandoned (not just waiting for more frames).
+    for _ in 0..12 {
+        h.mine_and_push(&chain);
+    }
+    for i in 2..=h.l1.latest_number() {
+        let blk = block_info_from(h.l1.block_by_number(i).expect("block exists"));
+        verifier.act_l1_head_signal(blk).await.expect("signal");
+        verifier.act_l2_pipeline_full().await.expect("pipeline");
+    }
+
+    assert_eq!(
+        verifier.l2_safe().block_info.number,
+        0,
+        "safe head must remain at genesis: non-sequential frame was pruned, channel never completed"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// C. Holocene: new channel (frame 0) abandons incomplete old channel
+//
+// op-e2e ref: holocene_frame_test.go
+// ---------------------------------------------------------------------------
+
+/// Under Holocene frame pruning, when a new channel (different channel ID,
+/// `frame_number=0`) arrives while the previous channel is still incomplete,
+/// all frames of the old channel are drained and discarded. The new channel
+/// assembles and derives its L2 block.
+///
+/// This tests the rule in [`FrameQueue::prune`]:
+/// > If frames are in different channels, and the current channel is not
+/// > last, walk back and drop all prev frames.
+///
+/// Setup:
+/// - Encode two L2 blocks into two separate channels (A and B, distinct IDs).
+/// - Submit only frame 0 of channel A in L1 block 1.
+/// - Submit all frames of channel B (starting at frame 0) in L1 block 2.
+///
+/// Under Holocene, channel A's incomplete frames are discarded when channel
+/// B's frame 0 arrives. Channel B assembles and derives L2 block 2, but L2
+/// block 1 (from the abandoned channel A) is never derived.
+///
+/// [`FrameQueue::prune`]: base_consensus_derive::stages::FrameQueue::prune
+#[tokio::test]
+async fn holocene_new_channel_abandons_incomplete_old_channel() {
+    let batcher_cfg = BatcherConfig {
+        encoder: EncoderConfig { max_frame_size: 80, ..EncoderConfig::default() },
+        ..BatcherConfig::default()
+    };
+    let rollup_cfg = TestRollupConfigBuilder::base_mainnet(&batcher_cfg)
+        .with_hardforks(HardForkConfig {
+            canyon_time: Some(0),
+            delta_time: Some(0),
+            ecotone_time: Some(0),
+            fjord_time: Some(0),
+            granite_time: Some(0),
+            holocene_time: Some(0),
+            ..Default::default()
+        })
+        .with_channel_timeout(10)
+        .build();
+    let mut h = ActionTestHarness::new(L1MinerConfig::default(), rollup_cfg);
+
+    let l1_chain = SharedL1Chain::from_blocks(h.l1.chain().to_vec());
+    let mut sequencer = h.create_l2_sequencer(l1_chain);
+
+    let block_a = sequencer.build_next_block().expect("build L2 block A");
+    let block_b = sequencer.build_next_block().expect("build L2 block B");
+
+    // Encode channel A (block A) and channel B (block B) separately.
+    // Each encoder instance generates a distinct random channel ID.
+    let frames_a = {
+        let mut source = ActionL2Source::new();
+        source.push(block_a);
+        let mut batcher = h.create_batcher(source, batcher_cfg.clone());
+        batcher.encode_frames().expect("encode channel A")
+    };
+    let frames_b = {
+        let mut source = ActionL2Source::new();
+        source.push(block_b);
+        let mut batcher = h.create_batcher(source, batcher_cfg.clone());
+        batcher.encode_frames().expect("encode channel B")
+    };
+
+    assert!(frames_a.len() >= 2, "channel A needs ≥2 frames; got {}", frames_a.len());
+
+    // Channels must have distinct IDs for the pruning rule to apply.
+    assert_ne!(frames_a[0].id, frames_b[0].id, "channel A and B must have distinct IDs");
+
+    let (mut verifier, chain) = h.create_verifier_from_sequencer(
+        &sequencer,
+        SharedL1Chain::from_blocks(h.l1.chain().to_vec()),
+    );
+
+    // L1 block 1: only frame 0 of channel A (channel is incomplete).
+    {
+        let empty_source = ActionL2Source::new();
+        let mut submitter = h.create_batcher(empty_source, batcher_cfg.clone());
+        submitter.submit_frames(&frames_a[0..1]);
+        submitter.flush(&mut h.l1);
+    }
+    h.mine_and_push(&chain);
+
+    verifier.initialize().await.expect("initialize");
+    let l1_block_1 = block_info_from(h.l1.block_by_number(1).expect("block 1"));
+    verifier.act_l1_head_signal(l1_block_1).await.expect("signal block 1");
+    verifier.act_l2_pipeline_full().await.expect("pipeline block 1");
+
+    // Channel A is open but incomplete — safe head stays at genesis.
+    assert_eq!(
+        verifier.l2_safe().block_info.number,
+        0,
+        "channel A only has frame 0; safe head must stay at genesis"
+    );
+
+    // L1 block 2: ALL frames of channel B (starts with frame 0, different ID).
+    // Under Holocene pruning: channel A's frame 0 is in the queue. When
+    // channel B's frame 0 arrives (different ID, B is not last), the queue
+    // drains all of channel A's frames. Channel B assembles and derives.
+    {
+        let empty_source = ActionL2Source::new();
+        let mut submitter = h.create_batcher(empty_source, batcher_cfg.clone());
+        for frame in &frames_b {
+            submitter.submit_frames(std::slice::from_ref(frame));
+        }
+        submitter.flush(&mut h.l1);
+    }
+    h.mine_and_push(&chain);
+
+    let l1_block_2 = block_info_from(h.l1.block_by_number(2).expect("block 2"));
+    verifier.act_l1_head_signal(l1_block_2).await.expect("signal block 2");
+    verifier.act_l2_pipeline_full().await.expect("pipeline block 2");
+
+    // Channel A was abandoned (Holocene pruning). Channel B derived block B.
+    // Block A was never derived since channel A was discarded.
+    // The BatchQueue can only emit blocks in order, so if block 1 (from channel A)
+    // was never derived, block 2 (from channel B) cannot be derived either unless
+    // block 1 has been accounted for. The pipeline will stall.
+    //
+    // Safe head remains at genesis because block 1 is missing — channel B's
+    // block 2 is a future batch from the perspective of the batch queue
+    // (expected_timestamp = genesis + block_time = 2, but block B is ts=4).
+    assert_eq!(
+        verifier.l2_safe().block_info.number,
+        0,
+        "channel A was abandoned; block A (L2 block 1) never derived; \
+         block B (L2 block 2) is a future batch and cannot be emitted"
+    );
+}


### PR DESCRIPTION
## Summary

Adds 14 high-priority action tests from the op-e2e gap analysis and fixes three tests that had incorrect hardfork assumptions.

NonEmptyTransitionBlock fires only for is_first_jovian_block(), not for Isthmus or Ecotone. batcher_hardfork_transitions.rs and holocene_activation.rs both used isthmus_time as the trigger, causing the invalid span batch to be accepted and safe_head to reach 4 instead of 2. Both now use jovian_time with isthmus_time at genesis. The recovery phase in both tests also constructed the corrected block from the wrong sequencer head (block 4 instead of block 2), producing block 5 with the wrong timestamp; fixed by using a fresh sequencer advanced to block 2. ecotone_activation_block_must_be_empty was failing with safe_head=0 because brotli-compressed frames were rejected without fjord_time=0; fixed by adding Fjord at genesis and updating the comment to clarify that Ecotone has no batch-level empty-block enforcement.