### PR TITLE
fix(protocol): correct estimated_size accounting when pruning future 

### DIFF
--- a/crates/consensus/protocol/src/channel.rs
+++ b/crates/consensus/protocol/src/channel.rs
@@ -121,8 +121,12 @@ impl Channel {
             // closing frame.
             if self.last_frame_number < self.highest_frame_number {
                 self.inputs.retain(|id, frame| {
-                    self.estimated_size -= frame.size();
-                    *id < self.last_frame_number
+                    if *id < self.last_frame_number {
+                        true
+                    } else {
+                        self.estimated_size -= frame.size();
+                        false
+                    }
                 });
                 self.highest_frame_number = self.last_frame_number;
             }
@@ -315,6 +319,23 @@ mod test {
                 should_error: vec![false, false],
                 sizes: vec![205, 409],
                 frame_data: Some(b"sevenfour".to_vec().into()),
+            },
+            // Frames arrive out of order: frame 2 (non-last) before frame 0 (non-last),
+            // then the closing frame 1. The prune path inside `add_frame` must remove
+            // frame 2 and correctly adjust `estimated_size` only for removed frames,
+            // not for the retained frame 0.
+            FrameValidityTestCase {
+                name: "prune future frames on out-of-order close".to_string(),
+                frames: vec![
+                    Frame { id, number: 2, is_last: false, data: b"two".to_vec() },
+                    Frame { id, number: 0, is_last: false, data: b"zero".to_vec() },
+                    Frame { id, number: 1, is_last: true, data: b"one".to_vec() },
+                ],
+                should_error: vec![false, false, false],
+                // After frame 2 (3+200=203), after frame 0 (203+204=407),
+                // after frame 1 closes: prune removes frame 2 (-203), add frame 1 (+203) → 407.
+                sizes: vec![203, 407, 407],
+                frame_data: Some(b"zeroone".to_vec().into()),
             },
             FrameValidityTestCase {
                 name: "multiple valid frames, no data".to_string(),


### PR DESCRIPTION
## Summary

Fixes a logical bug in `Channel::add_frame` where `estimated_size` was incorrectly decremented for **retained** frames during the out-of-order closing-frame prune path.

## Problem

When a closing frame (`is_last = true`) arrives with a frame number **lower** than the highest previously ingested frame number, `add_frame` prunes the out-of-range frames via `HashMap::retain`. The closure unconditionally subtracted `frame.size()` from `estimated_size` for **every** iterated entry — including frames that were being **kept** — and only then returned the boolean that decided whether the entry was removed:

```rust
// BEFORE (buggy)
self.inputs.retain(|id, frame| {
    self.estimated_size -= frame.size(); // runs for kept frames too
    *id < self.last_frame_number
});
```

This leaves `estimated_size` lower than the actual bytes held in `self.inputs`.

## Impact

`estimated_size` is the value returned by `Channel::size()`, which `ChannelBank::prune` accumulates across all channels to decide whether the bank exceeds `MAX_CHANNEL_BANK_SIZE` / `FJORD_MAX_CHANNEL_BANK_SIZE`. An underestimated size means the channel bank can **silently exceed its memory limit** when channels with out-of-order frames are present. Under adversarial or unusual L1 data ordering this could lead to unbounded memory growth in the derivation pipeline.

## Fix

Gate the `estimated_size` decrement on the retain predicate — only frames that are actually **removed** (`id >= last_frame_number`) should reduce the counter:

```rust
// AFTER (fixed)
self.inputs.retain(|id, frame| {
    if *id < self.last_frame_number {
        true
    } else {
        self.estimated_size -= frame.size();
        false
    }
});
```

## Test

Added a new `FrameValidityTestCase` — `"prune future frames on out-of-order close"` — that exercises this exact code path:

1. Ingest frame 2 (non-last) → `estimated_size = 203`
2. Ingest frame 0 (non-last) → `estimated_size = 407`
3. Ingest frame 1 (`is_last = true`) → triggers prune of frame 2, retains frame 0 → `estimated_size = 407`

With the bug the final size would be `203` (frame 0's contribution is erroneously zeroed out). The test asserts `407` and verifies `frame_data` returns `b"zeroone"` (frames 0 + 1 concatenated).

## Files changed

- `crates/consensus/protocol/src/channel.rs`
`