### PR TITLE
feat(utilities): Add Runtime Spawner Crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4616,6 +4616,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "base-runtime"
+version = "0.0.0"
+dependencies = [
+ "futures",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-stream",
+ "tokio-util",
+]
+
+[[package]]
 name = "base-test-utils"
 version = "0.0.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -259,6 +259,7 @@ base-comp = { path = "crates/batcher/comp", default-features = false }
 base-jwt = { path = "crates/utilities/jwt" }
 base-health = { path = "crates/utilities/health" }
 base-cli-utils = { path = "crates/utilities/cli" }
+base-runtime = { path = "crates/utilities/runtime", default-features = false }
 base-test-utils = { path = "crates/utilities/test-utils" }
 base-tx-manager = { path = "crates/utilities/tx-manager" }
 base-macros = { path = "crates/utilities/macros", default-features = false }

--- a/crates/utilities/runtime/Cargo.toml
+++ b/crates/utilities/runtime/Cargo.toml
@@ -1,0 +1,36 @@
+[package]
+name = "base-runtime"
+description = "Async runtime abstraction for deterministic batcher and pipeline testing"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+
+[lints]
+workspace = true
+
+[dependencies]
+futures.workspace = true
+thiserror.workspace = true
+
+tokio = { workspace = true, optional = true }
+tokio-util = { workspace = true, optional = true }
+tokio-stream = { workspace = true, optional = true }
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["rt", "macros", "time", "sync"] }
+
+[features]
+default = [ "tokio" ]
+tokio = [
+	"dep:tokio",
+	"dep:tokio-stream",
+	"dep:tokio-util",
+	"tokio/macros",
+	"tokio/rt",
+	"tokio/sync",
+	"tokio/time",
+]
+test-utils = [ "tokio", "tokio/test-util" ]

--- a/crates/utilities/runtime/README.md
+++ b/crates/utilities/runtime/README.md
@@ -1,0 +1,69 @@
+# base-runtime
+
+base-runtime provides an async runtime abstraction for deterministic testing of base
+components such as the batch submission pipeline and the hybrid block source. The crate
+defines three composable traits — `Clock`, `Spawner`, and `Cancellation` — and a blanket
+`Runtime` supertrait that combines all three. Components accept a single `R: Runtime`
+bound rather than concrete tokio types, which makes them testable without wall-clock time
+or real concurrency.
+
+This design was inspired by the [commonware](https://github.com/commonwarexyz/monorepo)
+project's [commonware-runtime](https://crates.io/crates/commonware-runtime) crate, which
+uses a `Runner`/`Context` abstraction to decouple application logic from the underlying
+executor. Commonware ships two implementations — a production tokio-backed runtime and a
+deterministic simulator — allowing the same application code to be driven with full
+control over scheduling and time. base-runtime follows the same pattern but is scoped
+to the capabilities the base batch driver and derivation pipeline actually require:
+virtual time, task spawning, and structured cancellation.
+
+The production implementation, `TokioRuntime`, wraps `tokio::time`, `tokio::spawn`, and
+`tokio_util::sync::CancellationToken`. It supports child cancellation tokens so that
+individual pipeline stages can be shut down independently while a parent runtime remains
+live. The test implementation, `DeterministicRuntime`, is also backed by tokio but uses
+tokio's paused-clock mode, requiring `#[tokio::test(start_paused = true)]`. Virtual time
+only advances when `advance_time` is called explicitly, so timer-driven logic — polling
+intervals, channel timeouts, backoff delays — can be exercised at precise granularity in
+tests that complete in real milliseconds. Cancellation in `DeterministicRuntime` uses
+`tokio::sync::watch` rather than `CancellationToken`, which allows the signal to remain
+valid even when no receivers are subscribed at the moment `cancel` is called.
+
+The `tokio::select!` macro is fully compatible with this abstraction because it generates
+standard `std::task::Poll` code rather than calling into any tokio-specific executor API.
+Any future returned by `Clock::sleep`, `Clock::interval`, or `Cancellation::cancelled`
+can appear as a `select!` arm without modification.
+
+## Usage
+
+### Production
+
+```rust
+use base_runtime::TokioRuntime;
+
+let rt = TokioRuntime::new();
+// Pass rt into BatchDriver::new(...) or HybridBlockSource::new(...)
+```
+
+### Deterministic tests
+
+```rust
+use base_runtime::DeterministicRuntime;
+use std::time::Duration;
+
+#[tokio::test(start_paused = true)]
+async fn test_timer_fires_on_advance() {
+    let rt = DeterministicRuntime::new();
+    let rt2 = rt.clone();
+
+    let (tx, mut rx) = tokio::sync::oneshot::channel::<()>();
+    tokio::spawn(async move {
+        rt2.sleep(Duration::from_secs(5)).await;
+        let _ = tx.send(());
+    });
+
+    tokio::task::yield_now().await;
+    assert!(rx.try_recv().is_err(), "timer must not fire without advance");
+
+    rt.advance_time(Duration::from_secs(5)).await;
+    assert!(rx.try_recv().is_ok(), "timer must fire after advance");
+}
+```

--- a/crates/utilities/runtime/src/cancellation.rs
+++ b/crates/utilities/runtime/src/cancellation.rs
@@ -1,0 +1,45 @@
+//! Cancellation signal abstraction replacing `tokio_util::sync::CancellationToken`.
+
+use std::{future::Future, pin::Pin};
+
+/// A shareable cancellation signal.
+///
+/// Replaces `tokio_util::sync::CancellationToken`. The primary usage pattern —
+/// `runtime.cancelled()` as a `tokio::select!` arm — is preserved exactly:
+///
+/// ```rust,ignore
+/// tokio::select! {
+///     biased;
+///     _ = self.runtime.cancelled() => { return Ok(()); }
+///     event = self.source.next() => { /* ... */ }
+/// }
+/// ```
+///
+/// # Cancel safety
+///
+/// The future returned by [`cancelled`](Cancellation::cancelled) is
+/// cancel-safe: dropping and recreating it does not miss a cancellation that
+/// was signalled while the future was not being polled. Each call to
+/// `cancelled()` checks the current state immediately on first poll.
+pub trait Cancellation: Clone + Send + Sync + 'static {
+    /// Returns a cancel-safe future that resolves when cancellation is signalled.
+    ///
+    /// If cancellation was already signalled before this future is polled, it
+    /// resolves immediately on the first poll.
+    ///
+    /// The returned future is `'static`: it does not borrow `self`.
+    fn cancelled(&self) -> Pin<Box<dyn Future<Output = ()> + Send>>;
+
+    /// Signal cancellation. All futures from [`cancelled`](Cancellation::cancelled)
+    /// will resolve on their next poll.
+    ///
+    /// Idempotent: calling `cancel` multiple times is safe.
+    fn cancel(&self);
+
+    /// Non-blocking check: has cancellation been signalled?
+    fn is_cancelled(&self) -> bool;
+
+    /// Returns a child handle that is cancelled when the parent is cancelled,
+    /// but can also be cancelled independently without affecting the parent.
+    fn child(&self) -> Self;
+}

--- a/crates/utilities/runtime/src/clock.rs
+++ b/crates/utilities/runtime/src/clock.rs
@@ -1,0 +1,43 @@
+//! Time abstraction: current virtual time, sleeping, and interval ticking.
+
+use std::{future::Future, pin::Pin, time::Duration};
+
+use futures::stream::BoxStream;
+
+/// A monotonic time source with sleep and interval primitives.
+///
+/// [`TokioRuntime`] wraps `tokio::time` directly. [`DeterministicRuntime`]
+/// only advances when [`DeterministicRuntime::advance_time`] is called, so
+/// timers never fire spontaneously in tests.
+///
+/// # Replacing `tokio::time::Interval`
+///
+/// [`interval`](Clock::interval) returns a `BoxStream<'static, ()>`. At call
+/// sites, replace `self.interval.tick().await` with
+/// `use futures::StreamExt; self.interval.next().await`.
+///
+/// [`TokioRuntime`]: crate::TokioRuntime
+/// [`DeterministicRuntime`]: crate::DeterministicRuntime
+pub trait Clock: Send + Sync + 'static {
+    /// Returns elapsed virtual time since this runtime was created.
+    ///
+    /// For [`TokioRuntime`] this is wall-clock elapsed time. For
+    /// [`DeterministicRuntime`] it accumulates only via
+    /// [`advance_time`](crate::DeterministicRuntime::advance_time).
+    ///
+    /// [`TokioRuntime`]: crate::TokioRuntime
+    fn now(&self) -> Duration;
+
+    /// Returns a future that resolves after `duration` of virtual time has passed.
+    ///
+    /// The returned future is `'static`: it does not borrow `self`.
+    fn sleep(&self, duration: Duration) -> Pin<Box<dyn Future<Output = ()> + Send>>;
+
+    /// Returns a stream that yields `()` every `period` of virtual time.
+    ///
+    /// The first tick fires immediately, matching `tokio::time::interval`
+    /// default behaviour. Subsequent ticks only fire after each `period`
+    /// elapses (or after [`advance_time`](crate::DeterministicRuntime::advance_time)
+    /// covers that period in tests).
+    fn interval(&self, period: Duration) -> BoxStream<'static, ()>;
+}

--- a/crates/utilities/runtime/src/deterministic.rs
+++ b/crates/utilities/runtime/src/deterministic.rs
@@ -1,0 +1,343 @@
+//! Deterministic runtime for reproducible async testing.
+
+use std::{
+    future::Future,
+    pin::Pin,
+    sync::{Arc, Mutex},
+    time::Duration,
+};
+
+use futures::{StreamExt, stream::BoxStream};
+use tokio::sync::watch;
+use tokio_stream::wrappers::IntervalStream;
+
+use crate::{Cancellation, Clock, Spawner, TaskError, TaskHandle};
+
+/// Deterministic runtime for reproducible integration and unit tests.
+///
+/// The clock only advances when [`advance_time`](DeterministicRuntime::advance_time)
+/// is called — timers never fire from wall-clock time. All other async
+/// operations (task spawning, cancellation) use the tokio runtime that backs
+/// the test.
+///
+/// # Requirements
+///
+/// - Must be created and used inside a `#[tokio::test]` context.
+/// - [`advance_time`](DeterministicRuntime::advance_time) requires the tokio
+///   time driver to be paused. Use `#[tokio::test(start_paused = true)]` in
+///   any test that calls `advance_time`.
+///
+/// # Example
+///
+/// ```rust,ignore
+/// #[tokio::test(start_paused = true)]
+/// async fn test_batcher_channel_timeout() {
+///     let rt = DeterministicRuntime::new();
+///     let source = HybridBlockSource::new(rt.clone(), subscription, poller, Duration::from_secs(1));
+///     let driver = BatchDriver::new(rt.clone(), pipeline, source, tx_manager, ...);
+///
+///     tokio::spawn(driver.run());
+///
+///     // Advance 2 seconds of virtual time — fires the polling interval twice.
+///     rt.advance_time(Duration::from_secs(2)).await;
+///
+///     // Assert expected state, then cancel.
+///     rt.cancel();
+/// }
+/// ```
+#[derive(Clone, Debug)]
+pub struct DeterministicRuntime {
+    /// Accumulated virtual time, advanced by `advance_time`.
+    virtual_now: Arc<Mutex<Duration>>,
+    /// Cancellation channel: `true` means cancelled.
+    cancel_tx: Arc<watch::Sender<bool>>,
+}
+
+impl DeterministicRuntime {
+    /// Create a new deterministic runtime with virtual time starting at zero.
+    ///
+    /// Must be called inside a `#[tokio::test]` context.
+    pub fn new() -> Self {
+        // Unused receiver is dropped immediately; the Sender retains the channel.
+        let (cancel_tx, _) = watch::channel(false);
+        Self { virtual_now: Arc::new(Mutex::new(Duration::ZERO)), cancel_tx: Arc::new(cancel_tx) }
+    }
+
+    /// Advance virtual time by `duration` and poll all tasks that become ready.
+    ///
+    /// This calls `tokio::time::advance(duration)` which wakes every
+    /// `tokio::time::sleep` and `tokio::time::interval` future whose deadline
+    /// falls within the advanced window. A final `yield_now` lets woken tasks
+    /// run to their next suspension point before this method returns.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the tokio time driver is not paused. Use
+    /// `#[tokio::test(start_paused = true)]` to ensure time is paused.
+    pub async fn advance_time(&self, duration: Duration) {
+        *self.virtual_now.lock().expect("virtual_now lock poisoned") += duration;
+        tokio::time::advance(duration).await;
+        tokio::task::yield_now().await;
+    }
+}
+
+impl Default for DeterministicRuntime {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Clock for DeterministicRuntime {
+    fn now(&self) -> Duration {
+        *self.virtual_now.lock().expect("virtual_now lock poisoned")
+    }
+
+    fn sleep(&self, duration: Duration) -> Pin<Box<dyn Future<Output = ()> + Send>> {
+        // tokio::time::sleep respects the paused clock and only fires when
+        // advance_time advances past the deadline.
+        Box::pin(tokio::time::sleep(duration))
+    }
+
+    fn interval(&self, period: Duration) -> BoxStream<'static, ()> {
+        // tokio::time::interval also respects the paused clock.
+        IntervalStream::new(tokio::time::interval(period)).map(|_| ()).boxed()
+    }
+}
+
+impl Spawner for DeterministicRuntime {
+    fn spawn<F>(&self, future: F) -> TaskHandle<F::Output>
+    where
+        F: Future + Send + 'static,
+        F::Output: Send + 'static,
+    {
+        let handle = tokio::spawn(future);
+        TaskHandle {
+            inner: Box::pin(async move {
+                handle.await.map_err(|e| {
+                    if e.is_cancelled() { TaskError::Cancelled } else { TaskError::Panicked }
+                })
+            }),
+        }
+    }
+}
+
+impl Cancellation for DeterministicRuntime {
+    fn cancelled(&self) -> Pin<Box<dyn Future<Output = ()> + Send>> {
+        // Subscribe creates a receiver initialised with the *current* value of
+        // the channel. If cancel() was already called (value = true), the very
+        // first borrow() in the returned future returns true immediately, making
+        // this cancel-safe: dropping and recreating the future never misses a
+        // cancellation that happened while it was not being polled.
+        let mut rx = self.cancel_tx.subscribe();
+        Box::pin(async move {
+            // Fast path: already cancelled.
+            if *rx.borrow() {
+                return;
+            }
+            // Slow path: wait for the value to change. changed() is cancel-safe:
+            // if this future is dropped and recreated, the subscribe() above will
+            // start the new receiver at the current (potentially true) value.
+            loop {
+                match rx.changed().await {
+                    Ok(()) => {
+                        if *rx.borrow() {
+                            return;
+                        }
+                    }
+                    // Sender dropped: treat as cancellation.
+                    Err(_) => return,
+                }
+            }
+        })
+    }
+
+    fn cancel(&self) {
+        // send_replace unconditionally updates the stored value even when no
+        // receivers are subscribed, unlike send() which returns Err and leaves
+        // the value unchanged when all receivers have been dropped.
+        self.cancel_tx.send_replace(true);
+    }
+
+    fn is_cancelled(&self) -> bool {
+        *self.cancel_tx.borrow()
+    }
+
+    fn child(&self) -> Self {
+        // Phase 1: children share the same cancellation scope.
+        // A full parent/child DAG (child can cancel independently) can be
+        // added later if needed.
+        self.clone()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use futures::StreamExt;
+
+    use super::DeterministicRuntime;
+    use crate::{Cancellation, Clock, Spawner};
+
+    #[tokio::test(start_paused = true)]
+    async fn sleep_does_not_fire_without_advance() {
+        let rt = DeterministicRuntime::new();
+        let rt2 = rt.clone();
+        let (tx, mut rx) = tokio::sync::oneshot::channel::<()>();
+
+        tokio::spawn(async move {
+            rt2.sleep(Duration::from_secs(5)).await;
+            let _ = tx.send(());
+        });
+
+        tokio::task::yield_now().await;
+        assert!(rx.try_recv().is_err(), "sleep must not fire before advance");
+
+        rt.advance_time(Duration::from_secs(5)).await;
+        assert!(rx.try_recv().is_ok(), "sleep must fire after advance");
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn advance_time_updates_now() {
+        let rt = DeterministicRuntime::new();
+        assert_eq!(rt.now(), Duration::ZERO);
+
+        rt.advance_time(Duration::from_secs(3)).await;
+        assert_eq!(rt.now(), Duration::from_secs(3));
+
+        rt.advance_time(Duration::from_millis(500)).await;
+        assert_eq!(rt.now(), Duration::from_millis(3_500));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn interval_does_not_tick_without_advance() {
+        let rt = DeterministicRuntime::new();
+        let mut stream = rt.interval(Duration::from_secs(1));
+
+        // First tick fires immediately (tokio::time::interval semantics).
+        assert!(stream.next().await.is_some(), "first tick must fire immediately");
+
+        // Second tick must not fire without advancing.
+        let rt2 = rt.clone();
+        let (tx, mut rx) = tokio::sync::oneshot::channel::<()>();
+        tokio::spawn(async move {
+            stream.next().await;
+            let _ = tx.send(());
+        });
+
+        tokio::task::yield_now().await;
+        assert!(rx.try_recv().is_err(), "second tick must not fire before advance");
+
+        rt2.advance_time(Duration::from_secs(1)).await;
+        assert!(rx.try_recv().is_ok(), "second tick must fire after 1s advance");
+    }
+
+    #[tokio::test]
+    async fn cancellation_resolves_after_cancel() {
+        let rt = DeterministicRuntime::new();
+        let rt2 = rt.clone();
+        let (tx, mut rx) = tokio::sync::oneshot::channel::<()>();
+
+        tokio::spawn(async move {
+            rt2.cancelled().await;
+            let _ = tx.send(());
+        });
+
+        tokio::task::yield_now().await;
+        assert!(rx.try_recv().is_err(), "must not be cancelled yet");
+
+        rt.cancel();
+        tokio::task::yield_now().await;
+        assert!(rx.try_recv().is_ok(), "must be cancelled after cancel()");
+    }
+
+    #[tokio::test]
+    async fn is_cancelled_reflects_state() {
+        let rt = DeterministicRuntime::new();
+        assert!(!rt.is_cancelled());
+        rt.cancel();
+        assert!(rt.is_cancelled());
+    }
+
+    #[tokio::test]
+    async fn cancelled_resolves_immediately_if_already_cancelled() {
+        let rt = DeterministicRuntime::new();
+        rt.cancel();
+
+        // cancelled() on an already-cancelled runtime must resolve without
+        // needing any advance or yield.
+        tokio::time::timeout(Duration::from_millis(10), rt.cancelled())
+            .await
+            .expect("cancelled() must resolve immediately when already cancelled");
+    }
+
+    #[tokio::test]
+    async fn cancelled_is_cancel_safe_in_select() {
+        let rt = DeterministicRuntime::new();
+        let rt2 = rt.clone();
+
+        // Drop cancelled() repeatedly without it firing; then cancel and
+        // verify that the very next poll fires despite prior drops.
+        for _ in 0..5 {
+            tokio::select! {
+                biased;
+                _ = rt2.cancelled() => { panic!("must not cancel yet"); }
+                _ = tokio::task::yield_now() => {}
+            }
+        }
+
+        rt.cancel();
+
+        let mut took_cancel = false;
+        tokio::select! {
+            biased;
+            _ = rt2.cancelled() => { took_cancel = true; }
+            _ = std::future::pending::<()>() => {}
+        }
+        assert!(took_cancel, "cancelled() must fire on next poll after cancel()");
+    }
+
+    #[tokio::test]
+    async fn spawned_task_returns_output() {
+        let rt = DeterministicRuntime::new();
+        let handle = rt.spawn(async { 42u32 });
+        assert_eq!(handle.await.unwrap(), 42);
+    }
+
+    #[tokio::test]
+    async fn spawned_task_captures_closure() {
+        let rt = DeterministicRuntime::new();
+        let value = 99u64;
+        let handle = rt.spawn(async move { value * 2 });
+        assert_eq!(handle.await.unwrap(), 198);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn multiple_advances_accumulate() {
+        let rt = DeterministicRuntime::new();
+        let rt2 = rt.clone();
+        let rt3 = rt.clone();
+        let (tx1, mut rx1) = tokio::sync::oneshot::channel::<()>();
+        let (tx2, mut rx2) = tokio::sync::oneshot::channel::<()>();
+
+        tokio::spawn(async move {
+            rt2.sleep(Duration::from_secs(2)).await;
+            let _ = tx1.send(());
+        });
+        tokio::spawn(async move {
+            rt3.sleep(Duration::from_secs(5)).await;
+            let _ = tx2.send(());
+        });
+
+        tokio::task::yield_now().await;
+        assert!(rx1.try_recv().is_err());
+        assert!(rx2.try_recv().is_err());
+
+        rt.advance_time(Duration::from_secs(2)).await;
+        assert!(rx1.try_recv().is_ok(), "2s sleep must fire after 2s advance");
+        assert!(rx2.try_recv().is_err(), "5s sleep must not fire after 2s advance");
+
+        rt.advance_time(Duration::from_secs(3)).await;
+        assert!(rx2.try_recv().is_ok(), "5s sleep must fire after total 5s advance");
+    }
+}

--- a/crates/utilities/runtime/src/lib.rs
+++ b/crates/utilities/runtime/src/lib.rs
@@ -1,0 +1,30 @@
+#![doc = include_str!("../README.md")]
+#![doc(
+    html_logo_url = "https://avatars.githubusercontent.com/u/16627100?s=200&v=4",
+    html_favicon_url = "https://avatars.githubusercontent.com/u/16627100?s=200&v=4",
+    issue_tracker_base_url = "https://github.com/base/base/issues/"
+)]
+#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
+#![cfg_attr(not(test), warn(unused_crate_dependencies))]
+
+mod cancellation;
+pub use cancellation::Cancellation;
+
+mod clock;
+pub use clock::Clock;
+
+mod runtime;
+pub use runtime::Runtime;
+
+mod spawner;
+pub use spawner::{Spawner, TaskError, TaskHandle};
+
+#[cfg(feature = "tokio")]
+mod tokio;
+#[cfg(feature = "tokio")]
+pub use tokio::TokioRuntime;
+
+#[cfg(feature = "test-utils")]
+pub mod deterministic;
+#[cfg(feature = "test-utils")]
+pub use deterministic::DeterministicRuntime;

--- a/crates/utilities/runtime/src/runtime.rs
+++ b/crates/utilities/runtime/src/runtime.rs
@@ -1,0 +1,21 @@
+//! Composite runtime supertrait combining Clock, Spawner, and Cancellation.
+
+use crate::{Cancellation, Clock, Spawner};
+
+/// A complete async runtime providing time, task spawning, and cancellation.
+///
+/// Components that need runtime capabilities accept a single `R: Runtime`
+/// bound rather than three separate trait bounds. In production, use
+/// [`TokioRuntime`]; in tests, use [`DeterministicRuntime`].
+///
+/// # Blanket implementation
+///
+/// Any type that implements [`Clock`] + [`Spawner`] + [`Cancellation`] +
+/// [`Clone`] + [`Send`] + [`Sync`] + `'static` automatically implements
+/// `Runtime`. No manual `impl Runtime for MyRuntime` is needed.
+///
+/// [`TokioRuntime`]: crate::TokioRuntime
+/// [`DeterministicRuntime`]: crate::DeterministicRuntime
+pub trait Runtime: Clock + Spawner + Cancellation + Clone + Send + Sync + 'static {}
+
+impl<T> Runtime for T where T: Clock + Spawner + Cancellation + Clone + Send + Sync + 'static {}

--- a/crates/utilities/runtime/src/spawner.rs
+++ b/crates/utilities/runtime/src/spawner.rs
@@ -1,0 +1,59 @@
+//! Task spawning abstraction replacing `tokio::spawn`.
+
+use std::{
+    fmt,
+    future::Future,
+    pin::Pin,
+    task::{Context, Poll},
+};
+
+use thiserror::Error;
+
+/// Errors from a spawned task.
+#[derive(Debug, Error)]
+pub enum TaskError {
+    /// The task panicked.
+    #[error("task panicked")]
+    Panicked,
+    /// The task was cancelled when the runtime shut down.
+    #[error("task cancelled")]
+    Cancelled,
+}
+
+/// A handle to a background task that can be awaited for its output.
+///
+/// Analogous to `tokio::task::JoinHandle<T>`. Dropping the handle does not
+/// cancel the underlying task (fire-and-forget semantics).
+pub struct TaskHandle<T> {
+    /// The underlying future representing the task's completion.
+    pub inner: Pin<Box<dyn Future<Output = Result<T, TaskError>> + Send>>,
+}
+
+impl<T> fmt::Debug for TaskHandle<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("TaskHandle").finish_non_exhaustive()
+    }
+}
+
+impl<T> Future for TaskHandle<T> {
+    type Output = Result<T, TaskError>;
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        self.inner.as_mut().poll(cx)
+    }
+}
+
+/// Spawn async tasks onto the runtime.
+///
+/// Implementations must be [`Clone`] so that spawner handles can be passed
+/// into spawned tasks to allow further spawning.
+pub trait Spawner: Clone + Send + Sync + 'static {
+    /// Spawn a `Send + 'static` future as a background task.
+    ///
+    /// Returns a [`TaskHandle`] that resolves to the task's output when it
+    /// completes. Dropping the handle does not cancel the task.
+    fn spawn<F>(&self, future: F) -> TaskHandle<F::Output>
+    where
+        F: Future + Send + 'static,
+        F::Output: Send + 'static;
+}

--- a/crates/utilities/runtime/src/tokio.rs
+++ b/crates/utilities/runtime/src/tokio.rs
@@ -39,7 +39,7 @@ impl TokioRuntime {
 
     /// Expose the inner `CancellationToken` for interop with code that has
     /// not yet been migrated to accept `R: Runtime`.
-    pub fn token(&self) -> &CancellationToken {
+    pub const fn token(&self) -> &CancellationToken {
         &self.token
     }
 }

--- a/crates/utilities/runtime/src/tokio.rs
+++ b/crates/utilities/runtime/src/tokio.rs
@@ -1,0 +1,210 @@
+//! Production runtime backed by Tokio.
+
+use std::{future::Future, pin::Pin, time::Duration};
+
+use futures::{StreamExt, stream::BoxStream};
+use tokio_stream::wrappers::IntervalStream;
+use tokio_util::sync::CancellationToken;
+
+use crate::{Cancellation, Clock, Spawner, TaskError, TaskHandle};
+
+/// Production runtime backed by `tokio`.
+///
+/// Wraps `tokio::time` for clock operations, `tokio::spawn` for task
+/// spawning, and `tokio_util::sync::CancellationToken` for cancellation.
+///
+/// Create one instance per logical service and pass it (cloned as needed)
+/// into components like `BatchDriver` and `HybridBlockSource`. All clones
+/// share the same cancellation scope; call [`cancel`](Cancellation::cancel)
+/// on any clone to shut down all components that share this runtime.
+#[derive(Clone, Debug)]
+pub struct TokioRuntime {
+    token: CancellationToken,
+    epoch: std::time::Instant,
+}
+
+impl TokioRuntime {
+    /// Create a new runtime with a fresh cancellation scope.
+    pub fn new() -> Self {
+        Self { token: CancellationToken::new(), epoch: std::time::Instant::now() }
+    }
+
+    /// Wrap an existing `CancellationToken`.
+    ///
+    /// Useful when migrating code that already creates tokens externally.
+    /// The `now()` epoch is set to the current wall-clock instant.
+    pub fn with_token(token: CancellationToken) -> Self {
+        Self { token, epoch: std::time::Instant::now() }
+    }
+
+    /// Expose the inner `CancellationToken` for interop with code that has
+    /// not yet been migrated to accept `R: Runtime`.
+    pub fn token(&self) -> &CancellationToken {
+        &self.token
+    }
+}
+
+impl Default for TokioRuntime {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Clock for TokioRuntime {
+    fn now(&self) -> Duration {
+        self.epoch.elapsed()
+    }
+
+    fn sleep(&self, duration: Duration) -> Pin<Box<dyn Future<Output = ()> + Send>> {
+        Box::pin(tokio::time::sleep(duration))
+    }
+
+    fn interval(&self, period: Duration) -> BoxStream<'static, ()> {
+        IntervalStream::new(tokio::time::interval(period)).map(|_| ()).boxed()
+    }
+}
+
+impl Spawner for TokioRuntime {
+    fn spawn<F>(&self, future: F) -> TaskHandle<F::Output>
+    where
+        F: Future + Send + 'static,
+        F::Output: Send + 'static,
+    {
+        let handle = tokio::spawn(future);
+        TaskHandle {
+            inner: Box::pin(async move {
+                handle.await.map_err(|e| {
+                    if e.is_cancelled() { TaskError::Cancelled } else { TaskError::Panicked }
+                })
+            }),
+        }
+    }
+}
+
+impl Cancellation for TokioRuntime {
+    fn cancelled(&self) -> Pin<Box<dyn Future<Output = ()> + Send>> {
+        // cancelled_owned() takes ownership of a cloned token, producing a
+        // 'static future that does not borrow self.
+        Box::pin(self.token.clone().cancelled_owned())
+    }
+
+    fn cancel(&self) {
+        self.token.cancel();
+    }
+
+    fn is_cancelled(&self) -> bool {
+        self.token.is_cancelled()
+    }
+
+    fn child(&self) -> Self {
+        Self { token: self.token.child_token(), epoch: self.epoch }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use tokio_util::sync::CancellationToken;
+
+    use super::TokioRuntime;
+    use crate::{Cancellation, Clock, Spawner};
+
+    #[tokio::test]
+    async fn cancellation_resolves_after_cancel() {
+        let rt = TokioRuntime::new();
+        let rt2 = rt.clone();
+        let (tx, mut rx) = tokio::sync::oneshot::channel::<()>();
+
+        tokio::spawn(async move {
+            rt2.cancelled().await;
+            let _ = tx.send(());
+        });
+
+        tokio::task::yield_now().await;
+        assert!(rx.try_recv().is_err(), "should not be cancelled yet");
+
+        rt.cancel();
+        tokio::task::yield_now().await;
+        assert!(rx.try_recv().is_ok(), "should be cancelled");
+    }
+
+    #[tokio::test]
+    async fn is_cancelled_reflects_state() {
+        let rt = TokioRuntime::new();
+        assert!(!rt.is_cancelled());
+        rt.cancel();
+        assert!(rt.is_cancelled());
+    }
+
+    #[tokio::test]
+    async fn child_cancels_independently_of_parent() {
+        let parent = TokioRuntime::new();
+        let child = parent.child();
+
+        child.cancel();
+        assert!(child.is_cancelled());
+        assert!(!parent.is_cancelled(), "child cancel must not affect parent");
+    }
+
+    #[tokio::test]
+    async fn parent_cancel_cancels_child() {
+        let parent = TokioRuntime::new();
+        let child = parent.child();
+
+        parent.cancel();
+        assert!(parent.is_cancelled());
+        assert!(child.is_cancelled(), "child must be cancelled when parent is");
+    }
+
+    #[tokio::test]
+    async fn spawned_task_returns_output() {
+        let rt = TokioRuntime::new();
+        let handle = rt.spawn(async { 42u32 });
+        assert_eq!(handle.await.unwrap(), 42);
+    }
+
+    #[tokio::test]
+    async fn now_advances_with_wall_clock() {
+        let rt = TokioRuntime::new();
+        let t0 = rt.now();
+        tokio::time::sleep(Duration::from_millis(10)).await;
+        let t1 = rt.now();
+        assert!(t1 > t0, "now() must advance over real time");
+    }
+
+    #[tokio::test]
+    async fn with_token_bridges_existing_token() {
+        let token = CancellationToken::new();
+        let rt = TokioRuntime::with_token(token.clone());
+
+        token.cancel();
+        assert!(rt.is_cancelled(), "runtime must reflect external token state");
+    }
+
+    #[tokio::test]
+    async fn cancelled_is_cancel_safe_in_select() {
+        let rt = TokioRuntime::new();
+        let rt2 = rt.clone();
+
+        // Run a select loop that drops the cancelled() future on each iteration.
+        // After calling cancel(), the very next poll must resolve.
+        for _ in 0..3 {
+            tokio::select! {
+                biased;
+                _ = rt2.cancelled() => { panic!("must not cancel yet"); }
+                _ = tokio::task::yield_now() => {}
+            }
+        }
+
+        rt.cancel();
+
+        let mut took_cancel = false;
+        tokio::select! {
+            biased;
+            _ = rt2.cancelled() => { took_cancel = true; }
+            _ = std::future::pending::<()>() => {}
+        }
+        assert!(took_cancel, "cancelled() must fire immediately after cancel()");
+    }
+}


### PR DESCRIPTION
## Summary

Introduces the `base-runtime` utility crate, which provides a `Spawner` trait and `TaskHandle` type as a portable abstraction over async task spawning. This replaces direct `tokio::spawn` call sites and adds a `TokioSpawner` implementation backed by the Tokio runtime. The crate also includes a deterministic spawner for testing and clock and cancellation token utilities.