### PR TITLE
feat(signer): Remote Signer Crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2546,6 +2546,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "base-alloy-signer"
+version = "0.0.0"
+dependencies = [
+ "alloy-consensus",
+ "alloy-eips",
+ "alloy-network",
+ "alloy-node-bindings",
+ "alloy-primitives",
+ "alloy-rpc-client",
+ "alloy-rpc-types-eth",
+ "alloy-signer",
+ "alloy-signer-local",
+ "alloy-transport",
+ "alloy-transport-http",
+ "async-trait",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "url",
+]
+
+[[package]]
 name = "base-alloy-upgrades"
 version = "0.0.0"
 dependencies = [
@@ -4576,28 +4598,6 @@ dependencies = [
  "tonic",
  "tracing",
  "tracing-subscriber 0.3.23",
-]
-
-[[package]]
-name = "base-remote-signer"
-version = "0.0.0"
-dependencies = [
- "alloy-consensus",
- "alloy-eips",
- "alloy-network",
- "alloy-node-bindings",
- "alloy-primitives",
- "alloy-rpc-client",
- "alloy-rpc-types-eth",
- "alloy-signer",
- "alloy-signer-local",
- "alloy-transport",
- "alloy-transport-http",
- "async-trait",
- "thiserror 2.0.18",
- "tokio",
- "tracing",
- "url",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4579,6 +4579,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "base-remote-signer"
+version = "0.0.0"
+dependencies = [
+ "alloy-consensus",
+ "alloy-eips",
+ "alloy-network",
+ "alloy-node-bindings",
+ "alloy-primitives",
+ "alloy-rpc-client",
+ "alloy-rpc-types-eth",
+ "alloy-signer",
+ "alloy-signer-local",
+ "alloy-transport",
+ "alloy-transport-http",
+ "async-trait",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "url",
+]
+
+[[package]]
 name = "base-reth-node"
 version = "0.0.0"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2494,6 +2494,7 @@ name = "base-alloy-rpc-jsonrpsee"
 version = "0.0.0"
 dependencies = [
  "alloy-primitives",
+ "alloy-rpc-types-eth",
  "jsonrpsee",
 ]
 
@@ -2554,13 +2555,12 @@ dependencies = [
  "alloy-network",
  "alloy-node-bindings",
  "alloy-primitives",
- "alloy-rpc-client",
  "alloy-rpc-types-eth",
  "alloy-signer",
  "alloy-signer-local",
- "alloy-transport",
- "alloy-transport-http",
  "async-trait",
+ "base-alloy-rpc-jsonrpsee",
+ "jsonrpsee",
  "thiserror 2.0.18",
  "tokio",
  "tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -149,6 +149,7 @@ incremental = false
 [workspace.dependencies]
 # Base Primitives
 base-bundles = { path = "crates/alloy/bundles" }
+base-remote-signer = { path = "crates/alloy/signer" }
 base-alloy-network = { path = "crates/alloy/network" }
 base-alloy-provider = { path = "crates/alloy/provider" }
 base-alloy-upgrades = { path = "crates/alloy/upgrades" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -149,7 +149,7 @@ incremental = false
 [workspace.dependencies]
 # Base Primitives
 base-bundles = { path = "crates/alloy/bundles" }
-base-remote-signer = { path = "crates/alloy/signer" }
+base-alloy-signer = { path = "crates/alloy/signer" }
 base-alloy-network = { path = "crates/alloy/network" }
 base-alloy-provider = { path = "crates/alloy/provider" }
 base-alloy-upgrades = { path = "crates/alloy/upgrades" }

--- a/crates/alloy/rpc-jsonrpsee/Cargo.toml
+++ b/crates/alloy/rpc-jsonrpsee/Cargo.toml
@@ -16,10 +16,11 @@ workspace = true
 [dependencies]
 # Alloy
 alloy-primitives = { workspace = true, features = ["serde"] }
-alloy-rpc-types-eth = { workspace = true, features = ["std", "serde"] }
+alloy-rpc-types-eth = { workspace = true, features = ["std", "serde"], optional = true }
 
 # rpc
 jsonrpsee = { workspace = true, features = ["macros", "server"] }
 
 [features]
-client = [ "jsonrpsee/async-client", "jsonrpsee/client" ]
+client = ["jsonrpsee/async-client", "jsonrpsee/client"]
+signer = ["dep:alloy-rpc-types-eth"]

--- a/crates/alloy/rpc-jsonrpsee/Cargo.toml
+++ b/crates/alloy/rpc-jsonrpsee/Cargo.toml
@@ -22,5 +22,5 @@ alloy-rpc-types-eth = { workspace = true, features = ["std", "serde"], optional 
 jsonrpsee = { workspace = true, features = ["macros", "server"] }
 
 [features]
-client = ["jsonrpsee/async-client", "jsonrpsee/client"]
-signer = ["dep:alloy-rpc-types-eth"]
+client = [ "jsonrpsee/async-client", "jsonrpsee/client" ]
+signer = [ "dep:alloy-rpc-types-eth" ]

--- a/crates/alloy/rpc-jsonrpsee/Cargo.toml
+++ b/crates/alloy/rpc-jsonrpsee/Cargo.toml
@@ -16,6 +16,7 @@ workspace = true
 [dependencies]
 # Alloy
 alloy-primitives = { workspace = true, features = ["serde"] }
+alloy-rpc-types-eth = { workspace = true, features = ["std", "serde"] }
 
 # rpc
 jsonrpsee = { workspace = true, features = ["macros", "server"] }

--- a/crates/alloy/rpc-jsonrpsee/src/lib.rs
+++ b/crates/alloy/rpc-jsonrpsee/src/lib.rs
@@ -8,6 +8,10 @@
 #![cfg_attr(docsrs, feature(doc_cfg))]
 
 mod traits;
+#[cfg(all(feature = "client", feature = "signer"))]
+pub use traits::EthSignerApiClient;
+#[cfg(feature = "signer")]
+pub use traits::EthSignerApiServer;
 #[cfg(feature = "client")]
-pub use traits::{EthSignerApiClient, MinerApiExtClient, OpAdminApiClient};
-pub use traits::{EthSignerApiServer, MinerApiExtServer, OpAdminApiServer};
+pub use traits::{MinerApiExtClient, OpAdminApiClient};
+pub use traits::{MinerApiExtServer, OpAdminApiServer};

--- a/crates/alloy/rpc-jsonrpsee/src/lib.rs
+++ b/crates/alloy/rpc-jsonrpsee/src/lib.rs
@@ -9,5 +9,5 @@
 
 mod traits;
 #[cfg(feature = "client")]
-pub use traits::{MinerApiExtClient, OpAdminApiClient};
-pub use traits::{MinerApiExtServer, OpAdminApiServer};
+pub use traits::{EthSignerApiClient, MinerApiExtClient, OpAdminApiClient};
+pub use traits::{EthSignerApiServer, MinerApiExtServer, OpAdminApiServer};

--- a/crates/alloy/rpc-jsonrpsee/src/traits.rs
+++ b/crates/alloy/rpc-jsonrpsee/src/traits.rs
@@ -1,4 +1,7 @@
-use alloy_primitives::{B256, Bytes, U64};
+#[cfg(feature = "signer")]
+use alloy_primitives::Bytes;
+use alloy_primitives::{B256, U64};
+#[cfg(feature = "signer")]
 use alloy_rpc_types_eth::TransactionRequest;
 use jsonrpsee::{core::RpcResult, proc_macros::rpc};
 
@@ -39,6 +42,7 @@ pub trait MinerApiExt {
     async fn set_gas_limit(&self, gas_limit: U64) -> RpcResult<bool>;
 }
 
+#[cfg(feature = "signer")]
 /// JSON-RPC interface for the `eth_signTransaction` endpoint.
 #[cfg_attr(not(feature = "client"), rpc(server, namespace = "eth"))]
 #[cfg_attr(feature = "client", rpc(server, client, namespace = "eth"))]

--- a/crates/alloy/rpc-jsonrpsee/src/traits.rs
+++ b/crates/alloy/rpc-jsonrpsee/src/traits.rs
@@ -42,8 +42,8 @@ pub trait MinerApiExt {
     async fn set_gas_limit(&self, gas_limit: U64) -> RpcResult<bool>;
 }
 
-#[cfg(feature = "signer")]
 /// JSON-RPC interface for the `eth_signTransaction` endpoint.
+#[cfg(feature = "signer")]
 #[cfg_attr(not(feature = "client"), rpc(server, namespace = "eth"))]
 #[cfg_attr(feature = "client", rpc(server, client, namespace = "eth"))]
 pub trait EthSignerApi {

--- a/crates/alloy/rpc-jsonrpsee/src/traits.rs
+++ b/crates/alloy/rpc-jsonrpsee/src/traits.rs
@@ -1,4 +1,5 @@
-use alloy_primitives::{B256, U64};
+use alloy_primitives::{B256, Bytes, U64};
+use alloy_rpc_types_eth::TransactionRequest;
 use jsonrpsee::{core::RpcResult, proc_macros::rpc};
 
 /// The admin namespace endpoints.
@@ -36,4 +37,13 @@ pub trait MinerApiExt {
     /// Sets the gas limit for future blocks produced by the miner.
     #[method(name = "setGasLimit")]
     async fn set_gas_limit(&self, gas_limit: U64) -> RpcResult<bool>;
+}
+
+/// JSON-RPC interface for the `eth_signTransaction` endpoint.
+#[cfg_attr(not(feature = "client"), rpc(server, namespace = "eth"))]
+#[cfg_attr(feature = "client", rpc(server, client, namespace = "eth"))]
+pub trait EthSignerApi {
+    /// Signs a transaction and returns the RLP-encoded signed envelope.
+    #[method(name = "signTransaction")]
+    async fn sign_transaction(&self, tx: TransactionRequest) -> RpcResult<Bytes>;
 }

--- a/crates/alloy/signer/Cargo.toml
+++ b/crates/alloy/signer/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "base-remote-signer"
+name = "base-alloy-signer"
 description = "Remote transaction signer for EthereumWallet integration via eth_signTransaction"
 
 version.workspace = true

--- a/crates/alloy/signer/Cargo.toml
+++ b/crates/alloy/signer/Cargo.toml
@@ -17,17 +17,18 @@ workspace = true
 # Alloy
 alloy-signer.workspace = true
 alloy-network.workspace = true
-alloy-transport.workspace = true
-alloy-rpc-client.workspace = true
 alloy-primitives.workspace = true
-alloy-transport-http.workspace = true
 alloy-eips = { workspace = true, features = ["std"] }
 alloy-consensus = { workspace = true, features = ["std"] }
 alloy-rpc-types-eth = { workspace = true, features = ["std"] }
 
+# Base
+base-alloy-rpc-jsonrpsee = { workspace = true, features = ["client"] }
+
 # External
 url.workspace = true
 async-trait.workspace = true
+jsonrpsee = { workspace = true, features = ["http-client"] }
 tracing = { workspace = true, features = ["std"] }
 thiserror = { workspace = true, features = ["std"] }
 

--- a/crates/alloy/signer/Cargo.toml
+++ b/crates/alloy/signer/Cargo.toml
@@ -23,7 +23,7 @@ alloy-consensus = { workspace = true, features = ["std"] }
 alloy-rpc-types-eth = { workspace = true, features = ["std"] }
 
 # Base
-base-alloy-rpc-jsonrpsee = { workspace = true, features = ["client"] }
+base-alloy-rpc-jsonrpsee = { workspace = true, features = ["client", "signer"] }
 
 # External
 url.workspace = true

--- a/crates/alloy/signer/Cargo.toml
+++ b/crates/alloy/signer/Cargo.toml
@@ -28,9 +28,9 @@ base-alloy-rpc-jsonrpsee = { workspace = true, features = ["client"] }
 # External
 url.workspace = true
 async-trait.workspace = true
-jsonrpsee = { workspace = true, features = ["http-client"] }
 tracing = { workspace = true, features = ["std"] }
 thiserror = { workspace = true, features = ["std"] }
+jsonrpsee = { workspace = true, features = ["http-client"] }
 
 [dev-dependencies]
 alloy-signer-local.workspace = true

--- a/crates/alloy/signer/Cargo.toml
+++ b/crates/alloy/signer/Cargo.toml
@@ -1,0 +1,37 @@
+[package]
+name = "base-remote-signer"
+description = "Remote transaction signer for EthereumWallet integration via eth_signTransaction"
+
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+exclude.workspace = true
+
+[lints]
+workspace = true
+
+[dependencies]
+# Alloy
+alloy-signer.workspace = true
+alloy-network.workspace = true
+alloy-transport.workspace = true
+alloy-rpc-client.workspace = true
+alloy-primitives.workspace = true
+alloy-transport-http.workspace = true
+alloy-eips = { workspace = true, features = ["std"] }
+alloy-consensus = { workspace = true, features = ["std"] }
+alloy-rpc-types-eth = { workspace = true, features = ["std"] }
+
+# External
+url.workspace = true
+async-trait.workspace = true
+tracing = { workspace = true, features = ["std"] }
+thiserror = { workspace = true, features = ["std"] }
+
+[dev-dependencies]
+alloy-signer-local.workspace = true
+alloy-node-bindings.workspace = true
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }

--- a/crates/alloy/signer/README.md
+++ b/crates/alloy/signer/README.md
@@ -1,4 +1,4 @@
-# `base-remote-signer`
+# `base-alloy-signer`
 
 Remote transaction signer that delegates signing to an external signer sidecar via
 `eth_signTransaction` JSON-RPC.
@@ -15,11 +15,11 @@ Add the dependency to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-base-remote-signer = { workspace = true }
+base-alloy-signer = { workspace = true }
 ```
 
 ```rust,ignore
-use base_remote_signer::RemoteSigner;
+use base_alloy_signer::RemoteSigner;
 use alloy_network::EthereumWallet;
 use alloy_primitives::Address;
 use url::Url;

--- a/crates/alloy/signer/README.md
+++ b/crates/alloy/signer/README.md
@@ -1,0 +1,36 @@
+# `base-remote-signer`
+
+Remote transaction signer that delegates signing to an external signer sidecar via
+`eth_signTransaction` JSON-RPC.
+
+## Overview
+
+Provides `RemoteSigner`, a type that implements alloy's `TxSigner<Signature>` trait by forwarding
+signing requests to an external signer service over HTTP. This allows
+`EthereumWallet::from(remote_signer)` to work seamlessly with the standard alloy signing pipeline.
+
+## Usage
+
+Add the dependency to your `Cargo.toml`:
+
+```toml
+[dependencies]
+base-remote-signer = { workspace = true }
+```
+
+```rust,ignore
+use base_remote_signer::RemoteSigner;
+use alloy_network::EthereumWallet;
+use alloy_primitives::Address;
+use url::Url;
+
+let signer = RemoteSigner::new(
+    Url::parse("http://localhost:8080").unwrap(),
+    "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045".parse::<Address>().unwrap(),
+);
+let wallet = EthereumWallet::from(signer);
+```
+
+## License
+
+Licensed under the [MIT License](https://github.com/base/base/blob/main/LICENSE).

--- a/crates/alloy/signer/README.md
+++ b/crates/alloy/signer/README.md
@@ -27,7 +27,7 @@ use url::Url;
 let signer = RemoteSigner::new(
     Url::parse("http://localhost:8080").unwrap(),
     "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045".parse::<Address>().unwrap(),
-);
+).unwrap();
 let wallet = EthereumWallet::from(signer);
 ```
 

--- a/crates/alloy/signer/src/error.rs
+++ b/crates/alloy/signer/src/error.rs
@@ -8,7 +8,7 @@ use thiserror::Error;
 pub enum RemoteSignerError {
     /// An error occurred during the JSON-RPC call.
     #[error("rpc error: {0}")]
-    Rpc(#[from] jsonrpsee::core::ClientError),
+    Rpc(jsonrpsee::core::ClientError),
     /// Failed to build the JSON-RPC HTTP client.
     #[error("client build error: {0}")]
     Client(jsonrpsee::core::ClientError),

--- a/crates/alloy/signer/src/error.rs
+++ b/crates/alloy/signer/src/error.rs
@@ -1,5 +1,6 @@
 //! Error types for the remote signer.
 
+use alloy_primitives::Address;
 use thiserror::Error;
 
 /// Errors that can occur during remote signing operations.
@@ -11,4 +12,15 @@ pub enum RemoteSignerError {
     /// Failed to decode the signed transaction bytes returned by the signer.
     #[error("failed to decode signed transaction: {0}")]
     Decode(String),
+    /// Failed to recover the signer address from the signature.
+    #[error("failed to recover signer address: {0}")]
+    Recovery(String),
+    /// The recovered signer address does not match the expected address.
+    #[error("signer mismatch: expected {expected}, got {recovered}")]
+    SignerMismatch {
+        /// The expected signer address.
+        expected: Address,
+        /// The recovered signer address.
+        recovered: Address,
+    },
 }

--- a/crates/alloy/signer/src/error.rs
+++ b/crates/alloy/signer/src/error.rs
@@ -8,10 +8,10 @@ use thiserror::Error;
 pub enum RemoteSignerError {
     /// An error occurred during the JSON-RPC call.
     #[error("rpc error: {0}")]
-    Rpc(jsonrpsee::core::ClientError),
+    Rpc(#[source] jsonrpsee::core::ClientError),
     /// Failed to build the JSON-RPC HTTP client.
     #[error("client build error: {0}")]
-    Client(jsonrpsee::core::ClientError),
+    Client(#[source] jsonrpsee::core::ClientError),
     /// Failed to decode the signed transaction bytes returned by the signer.
     #[error("failed to decode signed transaction: {0}")]
     Decode(String),

--- a/crates/alloy/signer/src/error.rs
+++ b/crates/alloy/signer/src/error.rs
@@ -1,6 +1,6 @@
 //! Error types for the remote signer.
 
-use alloy_primitives::Address;
+use alloy_primitives::{Address, B256};
 use thiserror::Error;
 
 /// Errors that can occur during remote signing operations.
@@ -22,5 +22,13 @@ pub enum RemoteSignerError {
         expected: Address,
         /// The recovered signer address.
         recovered: Address,
+    },
+    /// The signed transaction content does not match the original transaction.
+    #[error("signed transaction content mismatch: expected hash {expected}, got {received}")]
+    ContentMismatch {
+        /// The expected signature hash of the original transaction.
+        expected: B256,
+        /// The signature hash found in the signed envelope.
+        received: B256,
     },
 }

--- a/crates/alloy/signer/src/error.rs
+++ b/crates/alloy/signer/src/error.rs
@@ -1,0 +1,14 @@
+//! Error types for the remote signer.
+
+use thiserror::Error;
+
+/// Errors that can occur during remote signing operations.
+#[derive(Debug, Error)]
+pub enum RemoteSignerError {
+    /// An error occurred during RPC transport.
+    #[error("transport error: {0}")]
+    Transport(#[from] alloy_transport::TransportError),
+    /// Failed to decode the signed transaction bytes returned by the signer.
+    #[error("failed to decode signed transaction: {0}")]
+    Decode(String),
+}

--- a/crates/alloy/signer/src/error.rs
+++ b/crates/alloy/signer/src/error.rs
@@ -6,9 +6,12 @@ use thiserror::Error;
 /// Errors that can occur during remote signing operations.
 #[derive(Debug, Error)]
 pub enum RemoteSignerError {
-    /// An error occurred during RPC transport.
-    #[error("transport error: {0}")]
-    Transport(#[from] alloy_transport::TransportError),
+    /// An error occurred during the JSON-RPC call.
+    #[error("rpc error: {0}")]
+    Rpc(#[from] jsonrpsee::core::ClientError),
+    /// Failed to build the JSON-RPC HTTP client.
+    #[error("client build error: {0}")]
+    Client(jsonrpsee::core::ClientError),
     /// Failed to decode the signed transaction bytes returned by the signer.
     #[error("failed to decode signed transaction: {0}")]
     Decode(String),

--- a/crates/alloy/signer/src/lib.rs
+++ b/crates/alloy/signer/src/lib.rs
@@ -4,8 +4,8 @@
     html_favicon_url = "https://avatars.githubusercontent.com/u/16627100?s=200&v=4",
     issue_tracker_base_url = "https://github.com/base/base/issues/"
 )]
+#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
-#![cfg_attr(docsrs, feature(doc_cfg))]
 
 mod error;
 pub use error::RemoteSignerError;

--- a/crates/alloy/signer/src/lib.rs
+++ b/crates/alloy/signer/src/lib.rs
@@ -4,7 +4,7 @@
     html_favicon_url = "https://avatars.githubusercontent.com/u/16627100?s=200&v=4",
     issue_tracker_base_url = "https://github.com/base/base/issues/"
 )]
-#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
 
 mod error;

--- a/crates/alloy/signer/src/lib.rs
+++ b/crates/alloy/signer/src/lib.rs
@@ -1,0 +1,14 @@
+#![doc = include_str!("../README.md")]
+#![doc(
+    html_logo_url = "https://avatars.githubusercontent.com/u/16627100?s=200&v=4",
+    html_favicon_url = "https://avatars.githubusercontent.com/u/16627100?s=200&v=4",
+    issue_tracker_base_url = "https://github.com/base/base/issues/"
+)]
+#![cfg_attr(not(test), warn(unused_crate_dependencies))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
+
+mod error;
+pub use error::RemoteSignerError;
+
+mod signer;
+pub use signer::RemoteSigner;

--- a/crates/alloy/signer/src/signer.rs
+++ b/crates/alloy/signer/src/signer.rs
@@ -4,10 +4,10 @@ use alloy_consensus::{SignableTransaction, TxEnvelope};
 use alloy_eips::Decodable2718;
 use alloy_network::{TransactionBuilder, TxSigner};
 use alloy_primitives::{Address, B256, Bytes, Signature, TxKind};
-use alloy_rpc_client::{ClientBuilder, RpcClient};
 use alloy_rpc_types_eth::TransactionRequest;
-use alloy_transport_http::{Http, reqwest};
 use async_trait::async_trait;
+use base_alloy_rpc_jsonrpsee::EthSignerApiClient;
+use jsonrpsee::http_client::{HttpClient, HttpClientBuilder};
 use tracing::debug;
 use url::Url;
 
@@ -21,32 +21,31 @@ use crate::RemoteSignerError;
 /// signing pipeline:
 ///
 /// ```rust,ignore
-/// let signer = RemoteSigner::new(endpoint, address);
+/// let signer = RemoteSigner::new(endpoint, address).unwrap();
 /// let wallet = EthereumWallet::from(signer);
 /// ```
 #[derive(Debug)]
 pub struct RemoteSigner {
-    /// The alloy RPC client used to communicate with the signer.
-    pub client: RpcClient,
+    /// The jsonrpsee HTTP client used to communicate with the signer.
+    pub client: HttpClient,
     /// The address of the account managed by the remote signer.
     pub address: Address,
 }
 
 impl RemoteSigner {
     /// Creates a new [`RemoteSigner`] with a default HTTP client.
-    pub fn new(endpoint: Url, address: Address) -> Self {
-        let client = ClientBuilder::default().http(endpoint);
-        Self { client, address }
+    pub fn new(endpoint: Url, address: Address) -> Result<Self, RemoteSignerError> {
+        let client = HttpClientBuilder::default()
+            .build(endpoint.as_str())
+            .map_err(RemoteSignerError::Client)?;
+        Ok(Self { client, address })
     }
 
-    /// Creates a new [`RemoteSigner`] with a custom [`reqwest::Client`].
+    /// Creates a new [`RemoteSigner`] with a pre-configured [`HttpClient`].
     ///
-    /// Use this constructor when you need custom TLS configuration (e.g. mTLS)
-    /// or other HTTP client settings.
-    pub fn with_http_client(http_client: reqwest::Client, endpoint: Url, address: Address) -> Self {
-        let transport = Http::with_client(http_client, endpoint);
-        let is_local = transport.guess_local();
-        let client = ClientBuilder::default().transport(transport, is_local);
+    /// Use this constructor when you need custom HTTP client settings
+    /// (e.g. custom TLS configuration, timeouts, or middleware).
+    pub const fn with_client(client: HttpClient, address: Address) -> Self {
         Self { client, address }
     }
 
@@ -151,11 +150,9 @@ impl TxSigner<Signature> for RemoteSigner {
 
         debug!(address = %self.address, "signing transaction via remote signer");
 
-        let bytes: Bytes = self
-            .client
-            .request::<_, Bytes>("eth_signTransaction", (request,))
+        let bytes: Bytes = EthSignerApiClient::sign_transaction(&self.client, request)
             .await
-            .map_err(|e| alloy_signer::Error::other(RemoteSignerError::Transport(e)))?;
+            .map_err(|e| alloy_signer::Error::other(RemoteSignerError::Rpc(e)))?;
 
         let envelope = TxEnvelope::decode_2718(&mut bytes.as_ref())
             .map_err(|e| alloy_signer::Error::other(RemoteSignerError::Decode(e.to_string())))?;
@@ -189,7 +186,7 @@ mod tests {
     }
 
     fn test_signer(address: Address) -> RemoteSigner {
-        RemoteSigner::new(Url::parse("http://127.0.0.1:1").unwrap(), address)
+        RemoteSigner::new(Url::parse("http://127.0.0.1:1").unwrap(), address).unwrap()
     }
 
     fn default_test_tx() -> TxEip1559 {
@@ -278,7 +275,7 @@ mod tests {
     async fn sign_transaction_roundtrip_with_anvil() {
         let anvil = Anvil::new().spawn();
         let address = anvil.addresses()[0];
-        let signer = RemoteSigner::new(anvil.endpoint_url(), address);
+        let signer = RemoteSigner::new(anvil.endpoint_url(), address).unwrap();
 
         let mut tx = TxEip1559 {
             chain_id: anvil.chain_id(),

--- a/crates/alloy/signer/src/signer.rs
+++ b/crates/alloy/signer/src/signer.rs
@@ -99,6 +99,8 @@ impl RemoteSigner {
             request.authorization_list = Some(auth_list.to_vec());
         }
 
+        request.transaction_type = Some(tx.ty());
+
         request
     }
 
@@ -189,7 +191,7 @@ mod tests {
     }
 
     fn test_signer(address: Address) -> RemoteSigner {
-        RemoteSigner::new(Url::parse("http://localhost:8080").unwrap(), address)
+        RemoteSigner::new(Url::parse("http://127.0.0.1:1").unwrap(), address)
     }
 
     fn default_test_tx() -> TxEip1559 {
@@ -230,6 +232,7 @@ mod tests {
         assert_eq!(request.max_priority_fee_per_gas, Some(10));
         assert_eq!(request.value, Some(U256::from(1000)));
         assert_eq!(request.chain_id, Some(1));
+        assert_eq!(request.transaction_type, Some(2));
     }
 
     #[test]
@@ -270,6 +273,7 @@ mod tests {
 
         assert_eq!(request.gas_price, Some(50));
         assert_eq!(request.nonce, Some(5));
+        assert_eq!(request.transaction_type, Some(0));
     }
 
     #[tokio::test]
@@ -335,7 +339,7 @@ mod tests {
 
     #[tokio::test]
     async fn sign_transaction_transport_failure() {
-        // test_signer points at localhost:8080 which is not running.
+        // test_signer points at 127.0.0.1:1 which is not running.
         let signer = test_signer(Address::repeat_byte(0x01));
         let mut tx = default_test_tx();
 

--- a/crates/alloy/signer/src/signer.rs
+++ b/crates/alloy/signer/src/signer.rs
@@ -27,9 +27,9 @@ use crate::RemoteSignerError;
 #[derive(Debug)]
 pub struct RemoteSigner {
     /// The alloy RPC client used to communicate with the signer.
-    client: RpcClient,
+    pub client: RpcClient,
     /// The address of the account managed by the remote signer.
-    address: Address,
+    pub address: Address,
 }
 
 impl RemoteSigner {
@@ -45,7 +45,8 @@ impl RemoteSigner {
     /// or other HTTP client settings.
     pub fn with_http_client(http_client: reqwest::Client, endpoint: Url, address: Address) -> Self {
         let transport = Http::with_client(http_client, endpoint);
-        let client = ClientBuilder::default().transport(transport, false);
+        let is_local = transport.guess_local();
+        let client = ClientBuilder::default().transport(transport, is_local);
         Self { client, address }
     }
 
@@ -115,10 +116,7 @@ impl RemoteSigner {
     ) -> Result<(), RemoteSignerError> {
         let received = envelope.signature_hash();
         if received != *expected_hash {
-            return Err(RemoteSignerError::ContentMismatch {
-                expected: *expected_hash,
-                received,
-            });
+            return Err(RemoteSignerError::ContentMismatch { expected: *expected_hash, received });
         }
         Ok(())
     }

--- a/crates/alloy/signer/src/signer.rs
+++ b/crates/alloy/signer/src/signer.rs
@@ -43,33 +43,15 @@ impl RemoteSigner {
     ///
     /// Use this constructor when you need custom TLS configuration (e.g. mTLS)
     /// or other HTTP client settings.
-    pub fn with_http_client(
-        http_client: reqwest::Client,
-        endpoint: Url,
-        address: Address,
-    ) -> Self {
+    pub fn with_http_client(http_client: reqwest::Client, endpoint: Url, address: Address) -> Self {
         let transport = Http::with_client(http_client, endpoint);
         let client = ClientBuilder::default().transport(transport, false);
         Self { client, address }
     }
 
-    /// Extracts the signature from a [`TxEnvelope`].
-    const fn extract_signature(envelope: &TxEnvelope) -> Signature {
-        match envelope {
-            TxEnvelope::Legacy(tx) => *tx.signature(),
-            TxEnvelope::Eip2930(tx) => *tx.signature(),
-            TxEnvelope::Eip1559(tx) => *tx.signature(),
-            TxEnvelope::Eip4844(tx) => *tx.signature(),
-            TxEnvelope::Eip7702(tx) => *tx.signature(),
-        }
-    }
-
     /// Builds a [`TransactionRequest`] from a [`SignableTransaction`] for submission
     /// to the remote signer's `eth_signTransaction` endpoint.
-    fn build_tx_request(
-        &self,
-        tx: &dyn SignableTransaction<Signature>,
-    ) -> TransactionRequest {
+    pub fn build_tx_request(&self, tx: &dyn SignableTransaction<Signature>) -> TransactionRequest {
         let mut request = TransactionRequest::default()
             .with_nonce(tx.nonce())
             .with_gas_limit(tx.gas_limit())
@@ -137,18 +119,31 @@ impl TxSigner<Signature> for RemoteSigner {
         let envelope = TxEnvelope::decode_2718(&mut bytes.as_ref())
             .map_err(|e| alloy_signer::Error::other(RemoteSignerError::Decode(e.to_string())))?;
 
-        Ok(Self::extract_signature(&envelope))
+        let signature = *envelope.signature();
+        let hash = tx.signature_hash();
+        let recovered = signature
+            .recover_address_from_prehash(&hash)
+            .map_err(|e| alloy_signer::Error::other(RemoteSignerError::Recovery(e.to_string())))?;
+
+        if recovered != self.address {
+            return Err(alloy_signer::Error::other(RemoteSignerError::SignerMismatch {
+                expected: self.address,
+                recovered,
+            }));
+        }
+
+        Ok(signature)
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-
-    use alloy_consensus::TxEip1559;
+    use alloy_consensus::{TxEip1559, TxLegacy};
     use alloy_network::EthereumWallet;
     use alloy_node_bindings::Anvil;
     use alloy_primitives::U256;
+
+    use super::*;
 
     #[test]
     fn address_returns_configured_address() {
@@ -166,7 +161,7 @@ mod tests {
         let from = Address::repeat_byte(0x01);
         let to = Address::repeat_byte(0x02);
         let signer = test_signer(from);
-        let mut tx = TxEip1559 {
+        let tx = TxEip1559 {
             chain_id: 1,
             nonce: 42,
             gas_limit: 21_000,
@@ -177,7 +172,7 @@ mod tests {
             ..Default::default()
         };
 
-        let request = signer.build_tx_request(&mut tx);
+        let request = signer.build_tx_request(&tx);
 
         assert_eq!(request.from, Some(from));
         assert_eq!(request.nonce, Some(42));
@@ -192,7 +187,7 @@ mod tests {
     fn build_tx_request_handles_create() {
         let from = Address::repeat_byte(0x01);
         let signer = test_signer(from);
-        let mut tx = TxEip1559 {
+        let tx = TxEip1559 {
             chain_id: 1,
             nonce: 0,
             gas_limit: 100_000,
@@ -202,19 +197,17 @@ mod tests {
             ..Default::default()
         };
 
-        let request = signer.build_tx_request(&mut tx);
+        let request = signer.build_tx_request(&tx);
 
         assert_eq!(request.to, Some(TxKind::Create));
     }
 
     #[test]
     fn build_tx_request_handles_legacy_gas_price() {
-        use alloy_consensus::TxLegacy;
-
         let from = Address::repeat_byte(0x01);
         let to = Address::repeat_byte(0x02);
         let signer = test_signer(from);
-        let mut tx = TxLegacy {
+        let tx = TxLegacy {
             chain_id: Some(1),
             nonce: 5,
             gas_limit: 21_000,
@@ -224,7 +217,7 @@ mod tests {
             ..Default::default()
         };
 
-        let request = signer.build_tx_request(&mut tx);
+        let request = signer.build_tx_request(&tx);
 
         assert_eq!(request.gas_price, Some(50));
         assert_eq!(request.nonce, Some(5));
@@ -247,16 +240,11 @@ mod tests {
             ..Default::default()
         };
 
-        let sig = signer
-            .sign_transaction(&mut tx)
-            .await
-            .expect("signing should succeed");
+        let sig = signer.sign_transaction(&mut tx).await.expect("signing should succeed");
 
         // Verify the signature recovers to the expected address.
         let hash = tx.signature_hash();
-        let recovered = sig
-            .recover_address_from_prehash(&hash)
-            .expect("should recover address");
+        let recovered = sig.recover_address_from_prehash(&hash).expect("should recover address");
         assert_eq!(recovered, address);
     }
 

--- a/crates/alloy/signer/src/signer.rs
+++ b/crates/alloy/signer/src/signer.rs
@@ -1,0 +1,272 @@
+//! Remote signer implementation that delegates signing to an external signer sidecar.
+
+use alloy_consensus::{SignableTransaction, TxEnvelope};
+use alloy_eips::Decodable2718;
+use alloy_network::{TransactionBuilder, TxSigner};
+use alloy_primitives::{Address, Bytes, Signature, TxKind};
+use alloy_rpc_client::{ClientBuilder, RpcClient};
+use alloy_rpc_types_eth::TransactionRequest;
+use alloy_transport_http::{Http, reqwest};
+use async_trait::async_trait;
+use tracing::debug;
+use url::Url;
+
+use crate::RemoteSignerError;
+
+/// A remote transaction signer that delegates signing to an external signer sidecar
+/// via the `eth_signTransaction` JSON-RPC method.
+///
+/// Implements alloy's [`TxSigner<Signature>`] trait, allowing it to be used with
+/// [`alloy_network::EthereumWallet`] for seamless integration with the standard
+/// signing pipeline:
+///
+/// ```rust,ignore
+/// let signer = RemoteSigner::new(endpoint, address);
+/// let wallet = EthereumWallet::from(signer);
+/// ```
+#[derive(Debug)]
+pub struct RemoteSigner {
+    /// The alloy RPC client used to communicate with the signer.
+    client: RpcClient,
+    /// The address of the account managed by the remote signer.
+    address: Address,
+}
+
+impl RemoteSigner {
+    /// Creates a new [`RemoteSigner`] with a default HTTP client.
+    pub fn new(endpoint: Url, address: Address) -> Self {
+        let client = ClientBuilder::default().http(endpoint);
+        Self { client, address }
+    }
+
+    /// Creates a new [`RemoteSigner`] with a custom [`reqwest::Client`].
+    ///
+    /// Use this constructor when you need custom TLS configuration (e.g. mTLS)
+    /// or other HTTP client settings.
+    pub fn with_http_client(
+        http_client: reqwest::Client,
+        endpoint: Url,
+        address: Address,
+    ) -> Self {
+        let transport = Http::with_client(http_client, endpoint);
+        let client = ClientBuilder::default().transport(transport, false);
+        Self { client, address }
+    }
+
+    /// Extracts the signature from a [`TxEnvelope`].
+    const fn extract_signature(envelope: &TxEnvelope) -> Signature {
+        match envelope {
+            TxEnvelope::Legacy(tx) => *tx.signature(),
+            TxEnvelope::Eip2930(tx) => *tx.signature(),
+            TxEnvelope::Eip1559(tx) => *tx.signature(),
+            TxEnvelope::Eip4844(tx) => *tx.signature(),
+            TxEnvelope::Eip7702(tx) => *tx.signature(),
+        }
+    }
+
+    /// Builds a [`TransactionRequest`] from a [`SignableTransaction`] for submission
+    /// to the remote signer's `eth_signTransaction` endpoint.
+    fn build_tx_request(
+        &self,
+        tx: &dyn SignableTransaction<Signature>,
+    ) -> TransactionRequest {
+        let mut request = TransactionRequest::default()
+            .with_nonce(tx.nonce())
+            .with_gas_limit(tx.gas_limit())
+            .with_value(tx.value())
+            .with_input(tx.input().clone());
+
+        request.set_from(self.address);
+
+        match tx.kind() {
+            TxKind::Call(addr) => request.set_to(addr),
+            TxKind::Create => request = request.into_create(),
+        }
+
+        if let Some(chain_id) = tx.chain_id() {
+            request = request.with_chain_id(chain_id);
+        }
+
+        if let Some(gas_price) = tx.gas_price() {
+            request = request.with_gas_price(gas_price);
+        }
+
+        if let Some(max_priority_fee) = tx.max_priority_fee_per_gas() {
+            request = request.with_max_fee_per_gas(tx.max_fee_per_gas());
+            request = request.with_max_priority_fee_per_gas(max_priority_fee);
+        }
+
+        if let Some(access_list) = tx.access_list() {
+            request = request.with_access_list(access_list.clone());
+        }
+
+        if let Some(max_blob_fee) = tx.max_fee_per_blob_gas() {
+            request.max_fee_per_blob_gas = Some(max_blob_fee);
+        }
+
+        if let Some(blob_hashes) = tx.blob_versioned_hashes()
+            && !blob_hashes.is_empty()
+        {
+            request.blob_versioned_hashes = Some(blob_hashes.to_vec());
+        }
+
+        request
+    }
+}
+
+#[async_trait]
+impl TxSigner<Signature> for RemoteSigner {
+    fn address(&self) -> Address {
+        self.address
+    }
+
+    async fn sign_transaction(
+        &self,
+        tx: &mut dyn SignableTransaction<Signature>,
+    ) -> alloy_signer::Result<Signature> {
+        let request = self.build_tx_request(tx);
+
+        debug!(address = %self.address, "signing transaction via remote signer");
+
+        let bytes: Bytes = self
+            .client
+            .request::<_, Bytes>("eth_signTransaction", (request,))
+            .await
+            .map_err(|e| alloy_signer::Error::other(RemoteSignerError::Transport(e)))?;
+
+        let envelope = TxEnvelope::decode_2718(&mut bytes.as_ref())
+            .map_err(|e| alloy_signer::Error::other(RemoteSignerError::Decode(e.to_string())))?;
+
+        Ok(Self::extract_signature(&envelope))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use alloy_consensus::TxEip1559;
+    use alloy_network::EthereumWallet;
+    use alloy_node_bindings::Anvil;
+    use alloy_primitives::U256;
+
+    #[test]
+    fn address_returns_configured_address() {
+        let address = Address::repeat_byte(0x42);
+        let signer = test_signer(address);
+        assert_eq!(signer.address(), address);
+    }
+
+    fn test_signer(address: Address) -> RemoteSigner {
+        RemoteSigner::new(Url::parse("http://localhost:8080").unwrap(), address)
+    }
+
+    #[test]
+    fn build_tx_request_maps_eip1559_fields() {
+        let from = Address::repeat_byte(0x01);
+        let to = Address::repeat_byte(0x02);
+        let signer = test_signer(from);
+        let mut tx = TxEip1559 {
+            chain_id: 1,
+            nonce: 42,
+            gas_limit: 21_000,
+            max_fee_per_gas: 100,
+            max_priority_fee_per_gas: 10,
+            to: TxKind::Call(to),
+            value: U256::from(1000),
+            ..Default::default()
+        };
+
+        let request = signer.build_tx_request(&mut tx);
+
+        assert_eq!(request.from, Some(from));
+        assert_eq!(request.nonce, Some(42));
+        assert_eq!(request.gas, Some(21_000));
+        assert_eq!(request.max_fee_per_gas, Some(100));
+        assert_eq!(request.max_priority_fee_per_gas, Some(10));
+        assert_eq!(request.value, Some(U256::from(1000)));
+        assert_eq!(request.chain_id, Some(1));
+    }
+
+    #[test]
+    fn build_tx_request_handles_create() {
+        let from = Address::repeat_byte(0x01);
+        let signer = test_signer(from);
+        let mut tx = TxEip1559 {
+            chain_id: 1,
+            nonce: 0,
+            gas_limit: 100_000,
+            max_fee_per_gas: 100,
+            max_priority_fee_per_gas: 10,
+            to: TxKind::Create,
+            ..Default::default()
+        };
+
+        let request = signer.build_tx_request(&mut tx);
+
+        assert_eq!(request.to, Some(TxKind::Create));
+    }
+
+    #[test]
+    fn build_tx_request_handles_legacy_gas_price() {
+        use alloy_consensus::TxLegacy;
+
+        let from = Address::repeat_byte(0x01);
+        let to = Address::repeat_byte(0x02);
+        let signer = test_signer(from);
+        let mut tx = TxLegacy {
+            chain_id: Some(1),
+            nonce: 5,
+            gas_limit: 21_000,
+            gas_price: 50,
+            to: TxKind::Call(to),
+            value: U256::from(500),
+            ..Default::default()
+        };
+
+        let request = signer.build_tx_request(&mut tx);
+
+        assert_eq!(request.gas_price, Some(50));
+        assert_eq!(request.nonce, Some(5));
+    }
+
+    #[tokio::test]
+    async fn sign_transaction_roundtrip_with_anvil() {
+        let anvil = Anvil::new().spawn();
+        let address = anvil.addresses()[0];
+        let signer = RemoteSigner::new(anvil.endpoint_url(), address);
+
+        let mut tx = TxEip1559 {
+            chain_id: anvil.chain_id(),
+            nonce: 0,
+            gas_limit: 21_000,
+            max_fee_per_gas: 1_000_000_000,
+            max_priority_fee_per_gas: 1_000_000_000,
+            to: TxKind::Call(Address::ZERO),
+            value: U256::from(100),
+            ..Default::default()
+        };
+
+        let sig = signer
+            .sign_transaction(&mut tx)
+            .await
+            .expect("signing should succeed");
+
+        // Verify the signature recovers to the expected address.
+        let hash = tx.signature_hash();
+        let recovered = sig
+            .recover_address_from_prehash(&hash)
+            .expect("should recover address");
+        assert_eq!(recovered, address);
+    }
+
+    #[tokio::test]
+    async fn ethereum_wallet_from_remote_signer() {
+        let anvil = Anvil::new().spawn();
+        let address = anvil.addresses()[0];
+        let signer = RemoteSigner::new(anvil.endpoint_url(), address);
+
+        // Verify that RemoteSigner can be used with EthereumWallet.
+        let _wallet = EthereumWallet::from(signer);
+    }
+}

--- a/crates/alloy/signer/src/signer.rs
+++ b/crates/alloy/signer/src/signer.rs
@@ -1,5 +1,7 @@
 //! Remote signer implementation that delegates signing to an external signer sidecar.
 
+use std::time::Duration;
+
 use alloy_consensus::{SignableTransaction, TxEnvelope};
 use alloy_eips::Decodable2718;
 use alloy_network::{TransactionBuilder, TxSigner};
@@ -36,6 +38,7 @@ impl RemoteSigner {
     /// Creates a new [`RemoteSigner`] with a default HTTP client.
     pub fn new(endpoint: Url, address: Address) -> Result<Self, RemoteSignerError> {
         let client = HttpClientBuilder::default()
+            .request_timeout(Duration::from_secs(5))
             .build(endpoint.as_str())
             .map_err(RemoteSignerError::Client)?;
         Ok(Self { client, address })
@@ -148,7 +151,13 @@ impl TxSigner<Signature> for RemoteSigner {
     ) -> alloy_signer::Result<Signature> {
         let request = self.build_tx_request(tx);
 
-        debug!(address = %self.address, "signing transaction via remote signer");
+        debug!(
+            address = %self.address,
+            nonce = ?request.nonce,
+            chain_id = ?request.chain_id,
+            tx_type = ?request.transaction_type,
+            "signing transaction via remote signer",
+        );
 
         let bytes: Bytes = EthSignerApiClient::sign_transaction(&self.client, request)
             .await

--- a/crates/alloy/signer/src/signer.rs
+++ b/crates/alloy/signer/src/signer.rs
@@ -3,7 +3,7 @@
 use alloy_consensus::{SignableTransaction, TxEnvelope};
 use alloy_eips::Decodable2718;
 use alloy_network::{TransactionBuilder, TxSigner};
-use alloy_primitives::{Address, Bytes, Signature, TxKind};
+use alloy_primitives::{Address, B256, Bytes, Signature, TxKind};
 use alloy_rpc_client::{ClientBuilder, RpcClient};
 use alloy_rpc_types_eth::TransactionRequest;
 use alloy_transport_http::{Http, reqwest};
@@ -73,8 +73,11 @@ impl RemoteSigner {
             request = request.with_gas_price(gas_price);
         }
 
-        if let Some(max_priority_fee) = tx.max_priority_fee_per_gas() {
+        if tx.is_dynamic_fee() {
             request = request.with_max_fee_per_gas(tx.max_fee_per_gas());
+        }
+
+        if let Some(max_priority_fee) = tx.max_priority_fee_per_gas() {
             request = request.with_max_priority_fee_per_gas(max_priority_fee);
         }
 
@@ -92,7 +95,28 @@ impl RemoteSigner {
             request.blob_versioned_hashes = Some(blob_hashes.to_vec());
         }
 
+        if let Some(auth_list) = tx.authorization_list()
+            && !auth_list.is_empty()
+        {
+            request.authorization_list = Some(auth_list.to_vec());
+        }
+
         request
+    }
+
+    /// Verifies that the signature recovers to the expected signer address.
+    pub fn verify_signature(
+        &self,
+        signature: &Signature,
+        hash: &B256,
+    ) -> Result<(), RemoteSignerError> {
+        let recovered = signature
+            .recover_address_from_prehash(hash)
+            .map_err(|e| RemoteSignerError::Recovery(e.to_string()))?;
+        if recovered != self.address {
+            return Err(RemoteSignerError::SignerMismatch { expected: self.address, recovered });
+        }
+        Ok(())
     }
 }
 
@@ -121,16 +145,7 @@ impl TxSigner<Signature> for RemoteSigner {
 
         let signature = *envelope.signature();
         let hash = tx.signature_hash();
-        let recovered = signature
-            .recover_address_from_prehash(&hash)
-            .map_err(|e| alloy_signer::Error::other(RemoteSignerError::Recovery(e.to_string())))?;
-
-        if recovered != self.address {
-            return Err(alloy_signer::Error::other(RemoteSignerError::SignerMismatch {
-                expected: self.address,
-                recovered,
-            }));
-        }
+        self.verify_signature(&signature, &hash).map_err(alloy_signer::Error::other)?;
 
         Ok(signature)
     }
@@ -142,6 +157,8 @@ mod tests {
     use alloy_network::EthereumWallet;
     use alloy_node_bindings::Anvil;
     use alloy_primitives::U256;
+    use alloy_signer::SignerSync;
+    use alloy_signer_local::PrivateKeySigner;
 
     use super::*;
 
@@ -256,5 +273,33 @@ mod tests {
 
         // Verify that RemoteSigner can be used with EthereumWallet.
         let _wallet = EthereumWallet::from(signer);
+    }
+
+    #[test]
+    fn verify_signature_rejects_mismatch() {
+        let real_signer = PrivateKeySigner::random();
+        let wrong_address = Address::repeat_byte(0x42);
+        let remote = test_signer(wrong_address);
+
+        let hash = B256::repeat_byte(0x01);
+        let sig = real_signer.sign_hash_sync(&hash).unwrap();
+
+        let err = remote.verify_signature(&sig, &hash).unwrap_err();
+        assert!(matches!(
+            err,
+            RemoteSignerError::SignerMismatch { expected, recovered }
+                if expected == wrong_address && recovered == real_signer.address()
+        ));
+    }
+
+    #[test]
+    fn verify_signature_accepts_match() {
+        let real_signer = PrivateKeySigner::random();
+        let remote = test_signer(real_signer.address());
+
+        let hash = B256::repeat_byte(0x01);
+        let sig = real_signer.sign_hash_sync(&hash).unwrap();
+
+        remote.verify_signature(&sig, &hash).unwrap();
     }
 }

--- a/crates/alloy/signer/src/signer.rs
+++ b/crates/alloy/signer/src/signer.rs
@@ -69,12 +69,10 @@ impl RemoteSigner {
             request = request.with_chain_id(chain_id);
         }
 
-        if let Some(gas_price) = tx.gas_price() {
-            request = request.with_gas_price(gas_price);
-        }
-
         if tx.is_dynamic_fee() {
             request = request.with_max_fee_per_gas(tx.max_fee_per_gas());
+        } else if let Some(gas_price) = tx.gas_price() {
+            request = request.with_gas_price(gas_price);
         }
 
         if let Some(max_priority_fee) = tx.max_priority_fee_per_gas() {
@@ -102,6 +100,25 @@ impl RemoteSigner {
         }
 
         request
+    }
+
+    /// Verifies that the signed envelope's transaction content matches the original
+    /// transaction by comparing signature hashes.
+    ///
+    /// This provides defense-in-depth beyond signature verification, ensuring
+    /// the remote signer did not alter the transaction content.
+    pub fn verify_envelope_content(
+        envelope: &TxEnvelope,
+        expected_hash: &B256,
+    ) -> Result<(), RemoteSignerError> {
+        let received = envelope.signature_hash();
+        if received != *expected_hash {
+            return Err(RemoteSignerError::ContentMismatch {
+                expected: *expected_hash,
+                received,
+            });
+        }
+        Ok(())
     }
 
     /// Verifies that the signature recovers to the expected signer address.
@@ -143,8 +160,10 @@ impl TxSigner<Signature> for RemoteSigner {
         let envelope = TxEnvelope::decode_2718(&mut bytes.as_ref())
             .map_err(|e| alloy_signer::Error::other(RemoteSignerError::Decode(e.to_string())))?;
 
-        let signature = *envelope.signature();
         let hash = tx.signature_hash();
+        Self::verify_envelope_content(&envelope, &hash).map_err(alloy_signer::Error::other)?;
+
+        let signature = *envelope.signature();
         self.verify_signature(&signature, &hash).map_err(alloy_signer::Error::other)?;
 
         Ok(signature)
@@ -171,6 +190,19 @@ mod tests {
 
     fn test_signer(address: Address) -> RemoteSigner {
         RemoteSigner::new(Url::parse("http://localhost:8080").unwrap(), address)
+    }
+
+    fn default_test_tx() -> TxEip1559 {
+        TxEip1559 {
+            chain_id: 1,
+            nonce: 0,
+            gas_limit: 21_000,
+            max_fee_per_gas: 100,
+            max_priority_fee_per_gas: 10,
+            to: TxKind::Call(Address::ZERO),
+            value: U256::from(100),
+            ..Default::default()
+        }
     }
 
     #[test]
@@ -265,11 +297,9 @@ mod tests {
         assert_eq!(recovered, address);
     }
 
-    #[tokio::test]
-    async fn ethereum_wallet_from_remote_signer() {
-        let anvil = Anvil::new().spawn();
-        let address = anvil.addresses()[0];
-        let signer = RemoteSigner::new(anvil.endpoint_url(), address);
+    #[test]
+    fn ethereum_wallet_from_remote_signer() {
+        let signer = test_signer(Address::repeat_byte(0x01));
 
         // Verify that RemoteSigner can be used with EthereumWallet.
         let _wallet = EthereumWallet::from(signer);
@@ -301,5 +331,41 @@ mod tests {
         let sig = real_signer.sign_hash_sync(&hash).unwrap();
 
         remote.verify_signature(&sig, &hash).unwrap();
+    }
+
+    #[tokio::test]
+    async fn sign_transaction_transport_failure() {
+        // test_signer points at localhost:8080 which is not running.
+        let signer = test_signer(Address::repeat_byte(0x01));
+        let mut tx = default_test_tx();
+
+        signer.sign_transaction(&mut tx).await.unwrap_err();
+    }
+
+    #[test]
+    fn verify_envelope_content_rejects_mismatch() {
+        let key = PrivateKeySigner::random();
+        let tx = default_test_tx();
+
+        let sig = key.sign_hash_sync(&tx.signature_hash()).unwrap();
+        let signed = tx.into_signed(sig);
+        let envelope = TxEnvelope::from(signed);
+
+        let wrong_hash = B256::repeat_byte(0xff);
+        let err = RemoteSigner::verify_envelope_content(&envelope, &wrong_hash).unwrap_err();
+        assert!(matches!(err, RemoteSignerError::ContentMismatch { .. }));
+    }
+
+    #[test]
+    fn verify_envelope_content_accepts_match() {
+        let key = PrivateKeySigner::random();
+        let tx = default_test_tx();
+
+        let expected_hash = tx.signature_hash();
+        let sig = key.sign_hash_sync(&expected_hash).unwrap();
+        let signed = tx.into_signed(sig);
+        let envelope = TxEnvelope::from(signed);
+
+        RemoteSigner::verify_envelope_content(&envelope, &expected_hash).unwrap();
     }
 }

--- a/crates/consensus/sources/src/signer/remote/cert.rs
+++ b/crates/consensus/sources/src/signer/remote/cert.rs
@@ -135,8 +135,7 @@ impl RemoteSigner {
                 match self.build_http_client() {
                     Ok(new_client) => {
                         let transport = Http::with_client(new_client, self.endpoint.clone());
-                        let is_local = transport.guess_local();
-                        let new_client = ClientBuilder::default().transport(transport, is_local);
+                        let new_client = ClientBuilder::default().transport(transport, false);
 
                         // Update the client with the new TLS configuration. We're using a blocking
                         // write here because the handler is synchronous.

--- a/crates/consensus/sources/src/signer/remote/cert.rs
+++ b/crates/consensus/sources/src/signer/remote/cert.rs
@@ -135,7 +135,8 @@ impl RemoteSigner {
                 match self.build_http_client() {
                     Ok(new_client) => {
                         let transport = Http::with_client(new_client, self.endpoint.clone());
-                        let new_client = ClientBuilder::default().transport(transport, false);
+                        let is_local = transport.guess_local();
+                        let new_client = ClientBuilder::default().transport(transport, is_local);
 
                         // Update the client with the new TLS configuration. We're using a blocking
                         // write here because the handler is synchronous.


### PR DESCRIPTION
### What changed? Why?

Adds a new `base-alloy-signer` crate that provides `RemoteSigner`, a type implementing alloy's `TxSigner<Signature>` trait by delegating signing to an external signer sidecar via `eth_signTransaction` JSON-RPC over HTTP.

This allows services that need to sign transactions to offload key management to a dedicated signer sidecar (e.g. an enclave-backed service), keeping private keys out of the main application process.

**New crate: `base-alloy-signer`**
- `RemoteSigner` — wraps a jsonrpsee HTTP client and target address; implements `TxSigner<Signature>` so it plugs directly into `EthereumWallet::from(remote_signer)`
- `build_tx_request` — converts any `SignableTransaction` into a `TransactionRequest` for the RPC call
- Defense-in-depth verification after signing: checks that the returned envelope's signature hash matches the original transaction and that the signature recovers to the expected address
- `RemoteSignerError` — typed error variants for RPC failures, decoding errors, signer mismatches, and content mismatches

**Extended: `base-alloy-rpc-jsonrpsee`**
- New `signer` feature flag gating `EthSignerApi` trait (`eth_signTransaction` endpoint) — provides both `EthSignerApiServer` and `EthSignerApiClient`
- New `alloy-rpc-types-eth` optional dependency behind the `signer` feature

### Notes to reviewers

The `RemoteSigner` is intentionally kept thin — it only handles signing, not nonce management or gas estimation. Those responsibilities remain with the caller/provider. The `EthSignerApiServer` trait is exported so that a signer sidecar binary can implement the server side independently.

### How has it been tested?

- Unit tests for `build_tx_request` covering EIP-1559, legacy, and contract-creation transactions
- Signature verification tests (accept valid, reject mismatched signer)
- Envelope content verification tests (accept matching hash, reject tampered content)
- Transport failure test (unreachable endpoint returns error)
- Integration test: `sign_transaction_roundtrip_with_anvil` — spins up an Anvil instance and performs a full sign-and-verify round trip
- `EthereumWallet::from(remote_signer)` compiles and constructs successfully

### Change management ([definitions](http://go/change-management))

type=routine<!--routine,nonroutine,emergency-->
risk=low<!--low,medium,high-->
impact=sev5<!--sev5,sev4,sev3,sev2,sev1-->

### Backwards Compatibility ([learn more](http://go/backwards-compatibility))

backwards_compatible=true<!-- true false -->

<!-- Automatically merge your PR once the necessary approvals have been received (you probably want this) -->

automerge=false