### PR TITLE
chore(docker): add rust-builder-base image and publish workflow

### DIFF
--- a/.github/workflows/docker-rust-base.yml
+++ b/.github/workflows/docker-rust-base.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - main
+    paths:
+      - 'etc/docker/Dockerfile.rust-base'
+      - '.github/workflows/docker-rust-base.yml'
   workflow_dispatch: {}
 
 env:

--- a/.github/workflows/docker-rust-base.yml
+++ b/.github/workflows/docker-rust-base.yml
@@ -1,0 +1,115 @@
+name: Docker Rust Base
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch: {}
+
+env:
+  RUST_BASE_IMAGE: ghcr.io/${{ github.repository_owner }}/rust-builder-base
+  RUST_BASE_TAG: 1.93-mold-2.40.4
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        settings:
+          - arch: linux/amd64
+            runs-on: ubuntu-24.04
+          - arch: linux/arm64
+            runs-on: ubuntu-24.04-arm
+
+    runs-on: ${{ matrix.settings.runs-on }}
+
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@002fdce3c6a235733a90a27c80493a3241e56863 # v2.12.1
+        with:
+          egress-policy: audit
+
+      - name: Prepare
+        run: |
+          platform=${{ matrix.settings.arch }}
+          echo "PLATFORM_PAIR=${platform//\//-}" >> $GITHUB_ENV
+
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
+
+      - name: Login to GHCR
+        uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3.6.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push rust-builder-base
+        id: build
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
+        with:
+          context: .
+          file: etc/docker/Dockerfile.rust-base
+          platforms: ${{ matrix.settings.arch }}
+          outputs: type=image,push-by-digest=true,name-canonical=true,push=true
+          cache-from: type=registry,ref=${{ env.RUST_BASE_IMAGE }}:cache-${{ env.PLATFORM_PAIR }}
+          cache-to: type=registry,ref=${{ env.RUST_BASE_IMAGE }}:cache-${{ env.PLATFORM_PAIR }},mode=max
+
+      - name: Export digest
+        run: |
+          mkdir -p ${{ runner.temp }}/rust-base-digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "${{ runner.temp }}/rust-base-digests/${digest#sha256:}"
+
+      - name: Upload digest
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: rust-base-digests-${{ env.PLATFORM_PAIR }}
+          path: ${{ runner.temp }}/rust-base-digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  merge:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    needs:
+      - build
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@002fdce3c6a235733a90a27c80493a3241e56863 # v2.12.1
+        with:
+          egress-policy: audit
+
+      - name: Download digests
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          path: ${{ runner.temp }}/rust-base-digests
+          pattern: rust-base-digests-*
+          merge-multiple: true
+
+      - name: Log into the Container registry
+        uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3.6.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
+
+      - name: Create manifest list and push
+        working-directory: ${{ runner.temp }}/rust-base-digests
+        run: |
+          docker buildx imagetools create \
+            -t ${{ env.RUST_BASE_IMAGE }}:${{ env.RUST_BASE_TAG }} \
+            $(printf '${{ env.RUST_BASE_IMAGE }}@sha256:%s ' *)

--- a/.github/workflows/docker-rust-base.yml
+++ b/.github/workflows/docker-rust-base.yml
@@ -39,9 +39,10 @@ jobs:
           egress-policy: audit
 
       - name: Prepare
+        env:
+          ARCH: ${{ matrix.settings.arch }}
         run: |
-          platform=${{ matrix.settings.arch }}
-          echo "PLATFORM_PAIR=${platform//\//-}" >> $GITHUB_ENV
+          echo "PLATFORM_PAIR=${ARCH//\//-}" >> $GITHUB_ENV
           echo "RUST_BASE_TAG=${{ env.RUST_VERSION }}" >> $GITHUB_ENV
 
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
@@ -56,12 +57,19 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@318604b99e75e41977312d83839a89be02ca4893 # v5.9.0
+        with:
+          images: ${{ env.RUST_BASE_IMAGE }}
+
       - name: Build and push rust-builder-base
         id: build
         uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
         with:
           context: .
           file: etc/docker/Dockerfile.rust-base
+          labels: ${{ steps.meta.outputs.labels }}
           platforms: ${{ matrix.settings.arch }}
           outputs: type=image,push-by-digest=true,name-canonical=true,push=true
           build-args: |
@@ -134,3 +142,7 @@ jobs:
             -t ${{ env.RUST_BASE_IMAGE }}:${{ env.RUST_BASE_TAG }} \
             $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
             $(printf '${{ env.RUST_BASE_IMAGE }}@sha256:%s ' *)
+
+      - name: Inspect image
+        run: |
+          docker buildx imagetools inspect ${{ env.RUST_BASE_IMAGE }}:${{ steps.meta.outputs.version }}

--- a/.github/workflows/docker-rust-base.yml
+++ b/.github/workflows/docker-rust-base.yml
@@ -12,7 +12,6 @@ on:
 env:
   RUST_BASE_IMAGE: ghcr.io/${{ github.repository_owner }}/rust-builder-base
   RUST_VERSION: "1.93"
-  MOLD_VERSION: "2.40.4"
 
 permissions:
   contents: read
@@ -43,7 +42,7 @@ jobs:
         run: |
           platform=${{ matrix.settings.arch }}
           echo "PLATFORM_PAIR=${platform//\//-}" >> $GITHUB_ENV
-          echo "RUST_BASE_TAG=${{ env.RUST_VERSION }}-mold-${{ env.MOLD_VERSION }}" >> $GITHUB_ENV
+          echo "RUST_BASE_TAG=${{ env.RUST_VERSION }}" >> $GITHUB_ENV
 
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
@@ -67,7 +66,6 @@ jobs:
           outputs: type=image,push-by-digest=true,name-canonical=true,push=true
           build-args: |
             RUST_VERSION=${{ env.RUST_VERSION }}
-            MOLD_VERSION=${{ env.MOLD_VERSION }}
           cache-from: type=registry,ref=${{ env.RUST_BASE_IMAGE }}:cache-${{ env.PLATFORM_PAIR }}
           cache-to: type=registry,ref=${{ env.RUST_BASE_IMAGE }}:cache-${{ env.PLATFORM_PAIR }},mode=max
 
@@ -100,7 +98,9 @@ jobs:
 
       - name: Prepare
         run: |
-          echo "RUST_BASE_TAG=${{ env.RUST_VERSION }}-mold-${{ env.MOLD_VERSION }}" >> $GITHUB_ENV
+          echo "RUST_BASE_TAG=${{ env.RUST_VERSION }}" >> $GITHUB_ENV
+
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
       - name: Download digests
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
@@ -119,9 +119,18 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
 
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@318604b99e75e41977312d83839a89be02ca4893 # v5.9.0
+        with:
+          images: ${{ env.RUST_BASE_IMAGE }}
+          tags: |
+            type=sha,format=long
+
       - name: Create manifest list and push
         working-directory: ${{ runner.temp }}/rust-base-digests
         run: |
           docker buildx imagetools create \
             -t ${{ env.RUST_BASE_IMAGE }}:${{ env.RUST_BASE_TAG }} \
+            $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
             $(printf '${{ env.RUST_BASE_IMAGE }}@sha256:%s ' *)

--- a/.github/workflows/docker-rust-base.yml
+++ b/.github/workflows/docker-rust-base.yml
@@ -8,7 +8,8 @@ on:
 
 env:
   RUST_BASE_IMAGE: ghcr.io/${{ github.repository_owner }}/rust-builder-base
-  RUST_BASE_TAG: 1.93-mold-2.40.4
+  RUST_VERSION: "1.93"
+  MOLD_VERSION: "2.40.4"
 
 permissions:
   contents: read
@@ -39,6 +40,7 @@ jobs:
         run: |
           platform=${{ matrix.settings.arch }}
           echo "PLATFORM_PAIR=${platform//\//-}" >> $GITHUB_ENV
+          echo "RUST_BASE_TAG=${{ env.RUST_VERSION }}-mold-${{ env.MOLD_VERSION }}" >> $GITHUB_ENV
 
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
@@ -60,6 +62,9 @@ jobs:
           file: etc/docker/Dockerfile.rust-base
           platforms: ${{ matrix.settings.arch }}
           outputs: type=image,push-by-digest=true,name-canonical=true,push=true
+          build-args: |
+            RUST_VERSION=${{ env.RUST_VERSION }}
+            MOLD_VERSION=${{ env.MOLD_VERSION }}
           cache-from: type=registry,ref=${{ env.RUST_BASE_IMAGE }}:cache-${{ env.PLATFORM_PAIR }}
           cache-to: type=registry,ref=${{ env.RUST_BASE_IMAGE }}:cache-${{ env.PLATFORM_PAIR }},mode=max
 
@@ -89,6 +94,10 @@ jobs:
         uses: step-security/harden-runner@002fdce3c6a235733a90a27c80493a3241e56863 # v2.12.1
         with:
           egress-policy: audit
+
+      - name: Prepare
+        run: |
+          echo "RUST_BASE_TAG=${{ env.RUST_VERSION }}-mold-${{ env.MOLD_VERSION }}" >> $GITHUB_ENV
 
       - name: Download digests
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0

--- a/etc/docker/Dockerfile.rust-base
+++ b/etc/docker/Dockerfile.rust-base
@@ -1,4 +1,5 @@
-FROM public.ecr.aws/docker/library/rust:1.93-trixie
+ARG RUST_VERSION=1.93
+FROM public.ecr.aws/docker/library/rust:${RUST_VERSION}-trixie
 WORKDIR /app
 ARG MOLD_VERSION=2.40.4
 ARG MOLD_SHA256_AARCH64=c799b9ccae8728793da2186718fbe53b76400a9da396184fac0c64aa3298ec37

--- a/etc/docker/Dockerfile.rust-base
+++ b/etc/docker/Dockerfile.rust-base
@@ -1,0 +1,22 @@
+FROM public.ecr.aws/docker/library/rust:1.93-trixie
+WORKDIR /app
+ARG MOLD_VERSION=2.40.4
+ARG MOLD_SHA256_AARCH64=c799b9ccae8728793da2186718fbe53b76400a9da396184fac0c64aa3298ec37
+ARG MOLD_SHA256_ARM=d82792748a81202423ddd2496fc8719404fe694493abdef691cc080392ee44bf
+ARG MOLD_SHA256_X86_64=4c999e19ffa31afa5aa429c679b665d5e2ca5a6b6832ad4b79668e8dcf3d8ec1
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+      git libclang-dev pkg-config curl build-essential && \
+    rm -rf /var/lib/apt/lists/*
+RUN set -eux; \
+    case "$(uname -m)" in \
+      x86_64) MOLD_ARCH=x86_64; MOLD_SHA256="${MOLD_SHA256_X86_64}" ;; \
+      aarch64|arm64) MOLD_ARCH=aarch64; MOLD_SHA256="${MOLD_SHA256_AARCH64}" ;; \
+      armv7l|armv6l) MOLD_ARCH=arm; MOLD_SHA256="${MOLD_SHA256_ARM}" ;; \
+      *) echo "unsupported architecture: $(uname -m)" >&2; exit 1 ;; \
+    esac; \
+    curl -fsSL "https://github.com/rui314/mold/releases/download/v${MOLD_VERSION}/mold-${MOLD_VERSION}-${MOLD_ARCH}-linux.tar.gz" -o /tmp/mold.tar.gz; \
+    echo "${MOLD_SHA256}  /tmp/mold.tar.gz" | sha256sum -c -; \
+    tar -xzf /tmp/mold.tar.gz -C /tmp; \
+    cp /tmp/mold-${MOLD_VERSION}-${MOLD_ARCH}-linux/bin/* /usr/local/bin/; \
+    rm -rf /tmp/mold*


### PR DESCRIPTION
Adds `etc/docker/Dockerfile.rust-base` and a dedicated `.github/workflows/docker-rust-base.yml` that builds and publishes `ghcr.io/base/rust-builder-base:1.93` as a multi-arch image (amd64 + arm64).

This is PR 1 of 2. PR 2 will update the 7 service Dockerfiles to use this base image.