### PR TITLE
fix(derive): prevent prune underflow on empty frame queue

### DIFF
--- a/crates/consensus/derive/src/stages/frame_queue.rs
+++ b/crates/consensus/derive/src/stages/frame_queue.rs
@@ -65,7 +65,7 @@ where
         }
 
         let mut i = 0;
-        while i < self.queue.len() - 1 {
+        while i + 1 < self.queue.len() {
             let prev_frame = &self.queue[i];
             let next_frame = &self.queue[i + 1];
             let extends_channel = prev_frame.id == next_frame.id;
@@ -551,5 +551,19 @@ pub(crate) mod tests {
             .build();
         assert.holocene_active(true);
         assert.next_frames().await;
+    }
+
+    #[test]
+    fn test_holocene_prune_empty_queue_no_panic() {
+        let cfg = Arc::new(RollupConfig {
+            hardforks: HardForkConfig { holocene_time: Some(0), ..Default::default() },
+            ..Default::default()
+        });
+        let mock = TestFrameQueueProvider::new(vec![]);
+        let mut frame_queue = FrameQueue::new(mock, cfg);
+
+        frame_queue.prune(BlockInfo::default());
+
+        assert!(frame_queue.queue.is_empty());
     }
 }


### PR DESCRIPTION
## Summary
Fix an edge-case bug in `FrameQueue::prune` where an empty queue could trigger unsigned underflow in the loop bound (`len() - 1`).

## What changed
- Replaced the prune loop condition with a safe bound:
  - from: `i < self.queue.len() - 1`
  - to: `i + 1 < self.queue.len()`
- Added a regression test:
  - `test_holocene_prune_empty_queue_no_panic`

## Impact
This prevents potential panics/undefined behavior in Holocene pruning when the frame queue is empty, improving robustness of the derivation pipeline without changing normal behavior.
