### PR TITLE
chore(ci): remove redundant playwright install step

### DIFF
--- a/.github/workflows/docs-specs-ci.yml
+++ b/.github/workflows/docs-specs-ci.yml
@@ -36,9 +36,9 @@ jobs:
       - name: Install dependencies
         working-directory: docs/specs
         run: bun ci
-      - name: Install Playwright browsers
+      - name: Install Playwright system dependencies
         working-directory: docs/specs
-        run: bunx playwright install chromium --with-deps
+        run: bunx playwright install --with-deps chromium
       - name: Build specs site
         working-directory: docs/specs
         run: bun run build

--- a/docs/specs/package.json
+++ b/docs/specs/package.json
@@ -7,10 +7,12 @@
   },
   "scripts": {
     "dev": "vocs dev",
+    "postinstall": "bunx playwright install chromium",
     "build": "vocs build",
     "preview": "vocs preview"
   },
   "devDependencies": {
+    "playwright": "^1.58.0",
     "rehype-katex": "^7.0.1",
     "remark-math": "^6.0.0",
     "vocs": "^1.4.1"
@@ -22,5 +24,8 @@
     "katex": "0.16.33",
     "mlly": "1.8.0",
     "node-releases": "2.0.27"
-  }
+  },
+  "trustedDependencies": [
+    "playwright"
+  ]
 }


### PR DESCRIPTION
Attempt to get Vercel deploys for the specs site working. We use mermaid which requires Playwright.