### PR TITLE
fix(docker): add missing tags param to rust-builder-base build step

### DIFF
--- a/.github/workflows/docker-rust-base.yml
+++ b/.github/workflows/docker-rust-base.yml
@@ -69,6 +69,7 @@ jobs:
         with:
           context: .
           file: etc/docker/Dockerfile.rust-base
+          tags: ${{ env.RUST_BASE_IMAGE }}
           labels: ${{ steps.meta.outputs.labels }}
           platforms: ${{ matrix.settings.arch }}
           outputs: type=image,push-by-digest=true,name-canonical=true,push=true


### PR DESCRIPTION
## Summary
- Add missing `tags` parameter to `build-push-action` in `docker-rust-base.yml`
- Fixes `tag is needed when pushing to registry` error in https://github.com/base/base/actions/runs/23146809711

## Test plan
- [ ] Re-run the Docker Rust Base workflow and confirm it passes