### PR TITLE
fix(audit): prevent event key collisions across bundle lifecycle events

### DIFF
--- a/crates/infra/audit/src/storage.rs
+++ b/crates/infra/audit/src/storage.rs
@@ -509,6 +509,43 @@ mod tests {
     }
 
     #[test]
+    fn test_generate_event_key_is_unique_across_bundle_lifecycle_events() {
+        let bundle = create_bundle_from_txn_data();
+        let bundle_id = Uuid::new_v5(&Uuid::NAMESPACE_OID, bundle.bundle_hash().as_slice());
+
+        let received = BundleEvent::Received { bundle_id, bundle: Box::new(bundle.clone()) };
+        let cancelled = BundleEvent::Cancelled { bundle_id };
+        let builder_included = BundleEvent::BuilderIncluded {
+            bundle_id,
+            builder: "test-builder".to_string(),
+            block_number: 12345,
+            flashblock_index: 1,
+        };
+        let block_included = BundleEvent::BlockIncluded {
+            bundle_id,
+            block_number: 12345,
+            block_hash: TxHash::from([2u8; 32]),
+        };
+        let dropped_timed_out = BundleEvent::Dropped { bundle_id, reason: DropReason::TimedOut };
+        let dropped_reverted = BundleEvent::Dropped { bundle_id, reason: DropReason::Reverted };
+
+        let keys = vec![
+            received.generate_event_key(),
+            cancelled.generate_event_key(),
+            builder_included.generate_event_key(),
+            block_included.generate_event_key(),
+            dropped_timed_out.generate_event_key(),
+            dropped_reverted.generate_event_key(),
+        ];
+
+        for i in 0..keys.len() {
+            for j in (i + 1)..keys.len() {
+                assert_ne!(keys[i], keys[j], "event key collision between {i} and {j}");
+            }
+        }
+    }
+
+    #[test]
     fn test_update_transaction_metadata_transform_adds_new_bundle() {
         let metadata = TransactionMetadata { bundle_ids: vec![] };
         let bundle = create_bundle_from_txn_data();

--- a/crates/infra/audit/src/types.rs
+++ b/crates/infra/audit/src/types.rs
@@ -118,15 +118,20 @@ impl BundleEvent {
     /// Generates a unique event key for this event.
     pub fn generate_event_key(&self) -> String {
         match self {
-            Self::BlockIncluded { bundle_id, block_hash, .. } => {
-                format!("{bundle_id}-{block_hash}")
+            Self::Received { bundle_id, .. } => format!("{bundle_id}-received"),
+            Self::Cancelled { bundle_id, .. } => format!("{bundle_id}-cancelled"),
+            Self::BuilderIncluded { bundle_id, builder, block_number, flashblock_index } => {
+                format!("{bundle_id}-builder-included-{builder}-{block_number}-{flashblock_index}")
             }
-            _ => {
-                format!(
-                    "{}-{}",
-                    self.bundle_id(),
-                    Uuid::new_v5(&Uuid::NAMESPACE_OID, self.bundle_id().as_bytes())
-                )
+            Self::BlockIncluded { bundle_id, block_hash, .. } => {
+                format!("{bundle_id}-block-included-{block_hash}")
+            }
+            Self::Dropped { bundle_id, reason } => {
+                let reason = match reason {
+                    DropReason::TimedOut => "timed-out",
+                    DropReason::Reverted => "reverted",
+                };
+                format!("{bundle_id}-dropped-{reason}")
             }
         }
     }


### PR DESCRIPTION
## Summary

Fix event key collisions in audit bundle lifecycle events.

Previously, `BundleEvent::generate_event_key()` produced the same key for multiple non-`BlockIncluded` events of the same `bundle_id`, which caused valid events to be dropped by deduplication logic in bundle history storage.

## Changes

- Updated event key generation in `crates/infra/audit/src/types.rs` to include event kind and relevant event-specific fields.
- Added a regression test in `crates/infra/audit/src/storage.rs` to verify key uniqueness across lifecycle events for the same bundle.

## Impact

This preserves complete bundle history and prevents accidental deduplication of distinct events.
