### PR TITLE
backport: fix(metering): decouple state root time from pending state size (#1236)

### DIFF
--- a/crates/client/metering/src/meter.rs
+++ b/crates/client/metering/src/meter.rs
@@ -12,17 +12,17 @@ use eyre::{Result as EyreResult, eyre};
 use reth_evm::{ConfigureEvm, execute::BlockBuilder};
 use reth_primitives_traits::{Account, SealedHeader};
 use reth_revm::{database::StateProviderDatabase, db::State, primitives::KECCAK_EMPTY};
-use reth_trie_common::TrieInput;
-use revm_database::states::{BundleState, bundle_state::BundleRetention};
+use reth_trie_common::{HashedPostState, TrieInput};
+use revm_database::states::{BundleState, CacheState, bundle_state::BundleRetention};
 
 use crate::{metrics::Metrics, transaction::validate_tx};
 
-/// Computes the pending trie input from the bundle state.
+/// Computes the pending trie input from a pre-built [`HashedPostState`].
 ///
 /// This function records metrics for cache misses and compute duration.
 pub(crate) fn compute_pending_trie_input<SP>(
     state_provider: &SP,
-    bundle_state: &BundleState,
+    hashed_state: HashedPostState,
     metrics: &Metrics,
 ) -> EyreResult<PendingTrieInput>
 where
@@ -31,13 +31,31 @@ where
     metrics.pending_trie_cache_misses.increment(1);
     let start = Instant::now();
 
-    let hashed = state_provider.hashed_post_state(bundle_state);
-    let (_state_root, trie_updates) = state_provider.state_root_with_updates(hashed.clone())?;
+    let (_state_root, trie_updates) =
+        state_provider.state_root_with_updates(hashed_state.clone())?;
 
     let elapsed = start.elapsed();
     metrics.pending_trie_compute_duration.record(elapsed.as_secs_f64());
 
-    Ok(PendingTrieInput { trie_updates, hashed_state: hashed })
+    Ok(PendingTrieInput { trie_updates, hashed_state })
+}
+
+/// Converts a pending [`BundleState`] into a [`CacheState`] for use with
+/// `with_cached_prestate()`.
+fn cache_state_from_bundle_state(bundle_state: &BundleState) -> CacheState {
+    CacheState {
+        accounts: bundle_state
+            .state
+            .iter()
+            .map(|(&address, account)| (address, account.into()))
+            .collect(),
+        contracts: bundle_state
+            .contracts
+            .iter()
+            .map(|(&hash, code)| (hash, code.clone()))
+            .collect(),
+        ..Default::default()
+    }
 }
 
 /// Pre-computed trie input from pending state for efficient state root calculation.
@@ -122,7 +140,8 @@ where
                 metrics.pending_trie_cache_hits.increment(1);
                 Ok(cached.clone())
             } else {
-                compute_pending_trie_input(&state_provider, &ps.bundle_state, &metrics)
+                let hashed = state_provider.hashed_post_state(&ps.bundle_state);
+                compute_pending_trie_input(&state_provider, hashed, &metrics)
             }
         })
         .transpose()?;
@@ -130,20 +149,31 @@ where
     // Create state database
     let state_db = StateProviderDatabase::new(state_provider);
 
-    // Track bundle state changes. If metering with pending state, include it as bundle prestate.
+    // Track bundle state changes. When metering on top of pending flashblocks, seed execution
+    // from a cache prestate instead of `with_bundle_prestate()`. The two approaches produce
+    // identical execution results, but differ in what `take_bundle()` returns:
+    //
+    // - `with_bundle_prestate()`: `take_bundle()` includes the pending prestate in its output,
+    //   so `hashed_post_state()` generates prefix sets for every pending path. The trie walker
+    //   then rebuilds all of them — even though `prepend_cached` already provides those nodes —
+    //   making state root time proportional to pending state size.
+    //
+    // - `with_cached_prestate()`: `take_bundle()` returns only the bundle's delta, so prefix
+    //   sets cover only bundle-changed paths. The trie walker skips pending paths (reusing
+    //   cached nodes) and state root time is proportional to bundle size alone.
     let mut db = if let Some(ref ps) = pending_state {
         State::builder()
             .with_database(state_db)
             .with_bundle_update()
-            .with_bundle_prestate(ps.bundle_state.clone())
+            .with_cached_prestate(cache_state_from_bundle_state(&ps.bundle_state))
             .build()
     } else {
         State::builder().with_database(state_db).with_bundle_update().build()
     };
 
     // Override sender nonces to match their first transaction's nonce and collect
-    // account info for pre-flight validation. load_cache_account reads from bundle
-    // prestate (pending flashblocks) when available, so balances reflect pending state.
+    // account info for pre-flight validation. `load_cache_account` reads from the
+    // cached pending prestate when available, so balances reflect pending state.
     let mut first_nonces: HashMap<Address, u64> = HashMap::new();
     for tx in bundle.transactions() {
         first_nonces.entry(tx.signer()).or_insert_with(|| tx.nonce());
@@ -256,8 +286,9 @@ where
         }
     }
 
-    // Calculate state root and measure its calculation time. The bundle already includes
-    // pending state if it was provided via with_bundle_prestate.
+    // Calculate state root and measure its calculation time. If pending flashblocks were present,
+    // `bundle_update` now contains only this bundle's delta; the cached pending trie is prepended
+    // below so state-root work stays incremental.
     db.merge_transitions(BundleRetention::Reverts);
     let bundle_update = db.take_bundle();
 
@@ -276,8 +307,17 @@ where
     let hashed_state = state_provider.hashed_post_state(&bundle_update);
 
     if let Some(cached_trie) = pending_trie {
-        // Prepend cached pending trie so state root calculation only performs I/O
-        // for this bundle's changes, not for pending flashblocks.
+        // Build the trie input so the state root reflects canonical + pending + bundle.
+        //
+        // `from_state` generates prefix sets only for bundle-changed paths.
+        // `prepend_cached` merges the pending state's trie nodes and hashed values
+        // WITHOUT adding prefix sets — so the trie walker reuses cached nodes for
+        // pending-only paths and only rebuilds paths the bundle actually changed.
+        //
+        // Note: `prepend_cached` (not `prepend_self`) is essential here.
+        // `prepend_self` would merge prefix sets from the pending state, causing the
+        // walker to redundantly rebuild every pending path and defeating the
+        // optimization.
         let mut trie_input = TrieInput::from_state(hashed_state);
         trie_input.prepend_cached(cached_trie.trie_updates, cached_trie.hashed_state);
         let _ = state_provider.state_root_from_nodes_with_updates(trie_input)?;
@@ -775,6 +815,56 @@ mod tests {
         Ok(())
     }
 
+    /// Verifies pending flashblock prestate is loaded into the execution cache, not the output
+    /// bundle. This keeps later trie prefix invalidation scoped to the simulated bundle delta.
+    #[test]
+    fn cached_prestate_does_not_leak_into_bundle_output() -> eyre::Result<()> {
+        let pending_bundle = BundleState::new(
+            [(
+                Account::Alice.address(),
+                Some(AccountInfo {
+                    balance: U256::from(1_000_000_000_000_000_000u128),
+                    nonce: 0,
+                    code_hash: KECCAK_EMPTY,
+                    code: None,
+                    account_id: None,
+                }),
+                Some(AccountInfo {
+                    balance: U256::from(1_000_000_000_000_000_000u128),
+                    nonce: 5,
+                    code_hash: KECCAK_EMPTY,
+                    code: None,
+                    account_id: None,
+                }),
+                Default::default(),
+            )],
+            Vec::<Vec<(Address, Option<Option<AccountInfo>>, Vec<(U256, U256)>)>>::new(),
+            Vec::<(B256, Bytecode)>::new(),
+        );
+
+        let mut db = State::builder()
+            .with_bundle_update()
+            .with_cached_prestate(cache_state_from_bundle_state(&pending_bundle))
+            .build();
+
+        let pending_account = db.load_cache_account(Account::Alice.address())?;
+        assert_eq!(
+            pending_account.account.as_ref().expect("pending account").info.nonce,
+            5,
+            "execution must read the pending prestate nonce from the cache"
+        );
+
+        db.merge_transitions(BundleRetention::Reverts);
+        let bundle_update = db.take_bundle();
+
+        assert!(
+            bundle_update.state().is_empty(),
+            "cached prestate must not be included in the simulated bundle output"
+        );
+
+        Ok(())
+    }
+
     /// Verifies that nonce overrides are rejected when too far ahead of on-chain state.
     #[tokio::test]
     async fn meter_bundle_err_nonce_too_far_ahead() -> eyre::Result<()> {
@@ -931,6 +1021,100 @@ mod tests {
         assert!(
             result.unwrap_err().to_string().contains("Insufficient funds"),
             "Expected insufficient funds error"
+        );
+
+        Ok(())
+    }
+
+    /// Exercises the full optimized path: pending state with a cached trie input.
+    ///
+    /// Computes a real [`PendingTrieInput`] from pending state, then meters a bundle
+    /// on top of it. This covers the `prepend_cached` code path with the
+    /// `with_cached_prestate` change, verifying the two work correctly together.
+    #[tokio::test]
+    async fn meter_bundle_with_pending_state_and_cached_trie() -> eyre::Result<()> {
+        let harness = TestHarness::new().await?;
+        let latest = harness.latest_block();
+        let header = latest.sealed_header().clone();
+
+        // Build pending state: Alice sent a tx (nonce advanced to 1, balance decreased)
+        let pending_balance = U256::from(999_999_999_999_000_000_000_000u128);
+        let bundle_state = BundleState::new(
+            [(
+                Account::Alice.address(),
+                Some(AccountInfo {
+                    balance: U256::from(1_000_000u128) * U256::from(10u128).pow(U256::from(18)),
+                    nonce: 0,
+                    code_hash: KECCAK_EMPTY,
+                    code: None,
+                    account_id: None,
+                }),
+                Some(AccountInfo {
+                    balance: pending_balance,
+                    nonce: 1,
+                    code_hash: KECCAK_EMPTY,
+                    code: None,
+                    account_id: None,
+                }),
+                Default::default(),
+            )],
+            Vec::<Vec<(Address, Option<Option<AccountInfo>>, Vec<(U256, U256)>)>>::new(),
+            Vec::<(B256, Bytecode)>::new(),
+        );
+
+        // Compute the pending trie input
+        let state_provider = harness
+            .blockchain_provider()
+            .state_by_block_hash(latest.hash())
+            .context("getting state provider for trie")?;
+        let hashed = state_provider.hashed_post_state(&bundle_state);
+        let trie_input = compute_pending_trie_input(&state_provider, hashed, &Metrics::default())?;
+        drop(state_provider);
+
+        let pending_state = PendingState { bundle_state, trie_input: Some(trie_input) };
+
+        // Create a bundle tx: Alice (nonce=1 from pending) sends to a random address
+        let to = Address::random();
+        let signed_tx = TransactionBuilder::default()
+            .signer(Account::Alice.signer_b256())
+            .chain_id(harness.chain_id())
+            .nonce(1)
+            .to(to)
+            .value(1_000)
+            .gas_limit(21_000)
+            .max_fee_per_gas(MIN_BASEFEE as u128)
+            .max_priority_fee_per_gas(0)
+            .into_eip1559();
+
+        let tx = OpTransactionSigned::Eip1559(
+            signed_tx.as_eip1559().expect("eip1559 transaction").clone(),
+        );
+        let parsed_bundle = create_parsed_bundle(vec![tx])?;
+
+        let state_provider = harness
+            .blockchain_provider()
+            .state_by_block_hash(latest.hash())
+            .context("getting state provider")?;
+
+        let output = meter_bundle(
+            state_provider,
+            harness.chain_spec(),
+            parsed_bundle,
+            &header,
+            header.parent_beacon_block_root(),
+            Some(pending_state),
+            L1BlockInfo::default(),
+        )?;
+
+        assert_eq!(output.results.len(), 1);
+        assert_eq!(output.total_gas_used, 21_000);
+        assert!(output.total_time_us > 0);
+        assert!(output.state_root_time_us > 0);
+        assert!(
+            output.total_time_us >= output.state_root_time_us,
+            "total_time_us ({}) should be >= state_root_time_us ({})",
+            output.total_time_us,
+            output.state_root_time_us
         );
 
         Ok(())

--- a/crates/client/metering/src/rpc.rs
+++ b/crates/client/metering/src/rpc.rs
@@ -147,15 +147,12 @@ where
         let pending_state = if let Some(pb) = pending_blocks.as_ref() {
             let bundle_state = pb.get_bundle_state();
 
-            // Build a temporary PendingState without trie_input to get the cached trie
-            let temp_state = PendingState { bundle_state: bundle_state.clone(), trie_input: None };
-
             // Ensure the pending trie input is cached for reuse across bundle simulations
             let payload_id = pb.payload_id();
             let fb_index = state_flashblock_index.unwrap();
             let trie_input = self
                 .pending_trie_cache
-                .ensure_cached(payload_id, fb_index, &temp_state, &*state_provider)
+                .ensure_cached(payload_id, fb_index, &bundle_state, &*state_provider)
                 .map_err(|e| {
                     error!(error = %e, "Failed to cache pending trie input");
                     jsonrpsee::types::ErrorObjectOwned::owned(

--- a/crates/client/metering/src/trie_cache.rs
+++ b/crates/client/metering/src/trie_cache.rs
@@ -10,8 +10,9 @@ use alloy_rpc_types_engine::PayloadId;
 use arc_swap::ArcSwap;
 use eyre::Result as EyreResult;
 use reth_provider::StateProvider;
+use revm_database::states::BundleState;
 
-use crate::{PendingState, PendingTrieInput, meter::compute_pending_trie_input, metrics::Metrics};
+use crate::{PendingTrieInput, meter::compute_pending_trie_input, metrics::Metrics};
 
 /// Internal cache entry for a single flashblock's pending trie input.
 #[derive(Debug, Clone)]
@@ -51,7 +52,7 @@ impl PendingTrieCache {
         &self,
         payload_id: PayloadId,
         flashblock_index: u64,
-        pending_state: &PendingState,
+        bundle_state: &BundleState,
         canonical_state_provider: &dyn StateProvider,
     ) -> EyreResult<PendingTrieInput> {
         let cached_entry = self.cache.load();
@@ -64,11 +65,9 @@ impl PendingTrieCache {
         }
 
         // Cache miss - compute the trie input with metrics
-        let trie_input = compute_pending_trie_input(
-            canonical_state_provider,
-            &pending_state.bundle_state,
-            &self.metrics,
-        )?;
+        let hashed = canonical_state_provider.hashed_post_state(bundle_state);
+        let trie_input =
+            compute_pending_trie_input(canonical_state_provider, hashed, &self.metrics)?;
 
         // Store the new entry, replacing any previous cached entry
         self.cache.store(Arc::new(Some(CachedEntry {
@@ -91,7 +90,7 @@ impl Default for PendingTrieCache {
 mod tests {
     use alloy_primitives::{Address, B256, U256};
     use base_node_runner::test_utils::{Account, TestHarness};
-    use reth_provider::StateProviderFactory;
+    use reth_provider::{HashedPostStateProvider, StateProviderFactory};
     use reth_revm::{bytecode::Bytecode, primitives::KECCAK_EMPTY, state::AccountInfo};
     use revm_database::states::BundleState;
 
@@ -134,22 +133,21 @@ mod tests {
         let payload_a = PayloadId::new([1; 8]);
         let payload_b = PayloadId::new([2; 8]);
 
-        let state_a =
-            PendingState { bundle_state: bundle_with_nonce(alice, 0, 1), trie_input: None };
-        let state_b =
-            PendingState { bundle_state: bundle_with_nonce(alice, 0, 2), trie_input: None };
+        let bundle_a = bundle_with_nonce(alice, 0, 1);
+        let bundle_b = bundle_with_nonce(alice, 0, 2);
 
+        let hashed_b = state_provider.hashed_post_state(&bundle_b);
         let expected = crate::meter::compute_pending_trie_input(
             &*state_provider,
-            &state_b.bundle_state,
+            hashed_b,
             &Metrics::default(),
         )?;
 
         let cache = PendingTrieCache::new();
-        cache.ensure_cached(payload_a, flashblock_index, &state_a, &*state_provider)?;
+        cache.ensure_cached(payload_a, flashblock_index, &bundle_a, &*state_provider)?;
 
         let result =
-            cache.ensure_cached(payload_b, flashblock_index, &state_b, &*state_provider)?;
+            cache.ensure_cached(payload_b, flashblock_index, &bundle_b, &*state_provider)?;
 
         assert_eq!(
             result.hashed_state, expected.hashed_state,


### PR DESCRIPTION
## Summary

Backport of #1236 onto `releases/v0.6.0`.

- Use `with_cached_prestate()` instead of `with_bundle_prestate()` when seeding execution with pending flashblock state
- revm's `State::take_bundle()` includes any preloaded bundle prestate in its output, causing `hashed_post_state()` to generate prefix sets for every pending-state path — the trie walker then rebuilds all of those paths even though `prepend_cached` should skip them
- By loading pending state into the cache instead, `take_bundle()` returns only the bundle's incremental delta, so prefix sets cover only bundle-changed paths and `prepend_cached` works as designed

## Test plan

Cherry-pick of fe9fa6ae5 applied cleanly with no conflicts.