### PR TITLE
chore(nitro): move handle_connection into NitroEnclave impl block

### DIFF
--- a/crates/proof/tee/nitro/src/enclave/mod.rs
+++ b/crates/proof/tee/nitro/src/enclave/mod.rs
@@ -81,10 +81,7 @@ impl NitroEnclave {
     }
 
     /// Handle a single vsock connection: read request, dispatch, write response.
-    async fn handle_connection(
-        &self,
-        mut stream: tokio_vsock::VsockStream,
-    ) -> eyre::Result<()> {
+    async fn handle_connection(&self, mut stream: tokio_vsock::VsockStream) -> eyre::Result<()> {
         let request: EnclaveRequest =
             timeout(REQUEST_READ_TIMEOUT, Frame::read(&mut stream)).await??;
 

--- a/crates/proof/tee/nitro/src/enclave/mod.rs
+++ b/crates/proof/tee/nitro/src/enclave/mod.rs
@@ -32,9 +32,18 @@ pub use server::Server;
 /// Fixed vsock port the enclave listens on.
 pub const VSOCK_PORT: u32 = 8000;
 
+/// Deadline for receiving a complete request frame from the host.
+///
+/// Must be generous enough to cover large [`EnclaveRequest::Prove`] payloads,
+/// which include the full preimage bundle and can be many megabytes over vsock.
+/// A single timeout applies to all request types because the request type is
+/// unknown until the frame has been fully read.
+#[cfg(target_os = "linux")]
+const REQUEST_READ_TIMEOUT: Duration = Duration::from_secs(5 * 60);
+
 /// Nitro Enclave runtime.
 #[cfg(target_os = "linux")]
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct NitroEnclave {
     server: Arc<Server>,
 }
@@ -57,9 +66,9 @@ impl NitroEnclave {
             let (stream, peer) = listener.accept().await?;
             debug!(cid = peer.cid(), port = peer.port(), "accepted connection");
 
-            let server = Arc::clone(&self.server);
+            let enclave = self.clone();
             tokio::spawn(async move {
-                if let Err(e) = handle_connection(stream, &server).await {
+                if let Err(e) = enclave.handle_connection(stream).await {
                     warn!(
                         error = %e,
                         cid = peer.cid(),
@@ -70,47 +79,39 @@ impl NitroEnclave {
             });
         }
     }
-}
 
-/// Deadline for receiving a complete request frame from the host.
-///
-/// Must be generous enough to cover large [`EnclaveRequest::Prove`] payloads,
-/// which include the full preimage bundle and can be many megabytes over vsock.
-/// A single timeout applies to all request types because the request type is
-/// unknown until the frame has been fully read.
-#[cfg(target_os = "linux")]
-const REQUEST_READ_TIMEOUT: Duration = Duration::from_secs(5 * 60);
+    /// Handle a single vsock connection: read request, dispatch, write response.
+    async fn handle_connection(
+        &self,
+        mut stream: tokio_vsock::VsockStream,
+    ) -> eyre::Result<()> {
+        let request: EnclaveRequest =
+            timeout(REQUEST_READ_TIMEOUT, Frame::read(&mut stream)).await??;
 
-#[cfg(target_os = "linux")]
-async fn handle_connection(
-    mut stream: tokio_vsock::VsockStream,
-    server: &Server,
-) -> eyre::Result<()> {
-    let request: EnclaveRequest = timeout(REQUEST_READ_TIMEOUT, Frame::read(&mut stream)).await??;
+        match request {
+            EnclaveRequest::Prove(preimages) => {
+                let response = match self.server.prove(preimages).await {
+                    Ok(result) => EnclaveResponse::Prove(Box::new(result)),
+                    Err(e) => EnclaveResponse::Error(e.to_string()),
+                };
+                Frame::write(&mut stream, &response).await?;
+            }
+            EnclaveRequest::SignerPublicKey => {
+                let key = self.server.signer_public_key();
+                Frame::write(&mut stream, &EnclaveResponse::SignerPublicKey(key)).await?;
+            }
+            EnclaveRequest::SignerAttestation => {
+                // nsm_init() and nsm_process_request() are blocking FFI calls; use
+                // block_in_place so they do not stall the async executor.
+                let result = tokio::task::block_in_place(|| self.server.signer_attestation());
+                let response = match result {
+                    Ok(doc) => EnclaveResponse::SignerAttestation(doc),
+                    Err(e) => EnclaveResponse::Error(e.to_string()),
+                };
+                Frame::write(&mut stream, &response).await?;
+            }
+        }
 
-    match request {
-        EnclaveRequest::Prove(preimages) => {
-            let response = match server.prove(preimages).await {
-                Ok(result) => EnclaveResponse::Prove(Box::new(result)),
-                Err(e) => EnclaveResponse::Error(e.to_string()),
-            };
-            Frame::write(&mut stream, &response).await?;
-        }
-        EnclaveRequest::SignerPublicKey => {
-            let key = server.signer_public_key();
-            Frame::write(&mut stream, &EnclaveResponse::SignerPublicKey(key)).await?;
-        }
-        EnclaveRequest::SignerAttestation => {
-            // nsm_init() and nsm_process_request() are blocking FFI calls; use
-            // block_in_place so they do not stall the async executor.
-            let result = tokio::task::block_in_place(|| server.signer_attestation());
-            let response = match result {
-                Ok(doc) => EnclaveResponse::SignerAttestation(doc),
-                Err(e) => EnclaveResponse::Error(e.to_string()),
-            };
-            Frame::write(&mut stream, &response).await?;
-        }
+        Ok(())
     }
-
-    Ok(())
 }


### PR DESCRIPTION
## Summary

- Moves the bare `handle_connection` function into a method on `NitroEnclave`, per project convention of placing functions as methods on a type rather than as bare functions.
- Derives `Clone` on `NitroEnclave` (cheap — only field is `Arc<Server>`) so spawned tasks can call `self.handle_connection()`.
- Relocates `REQUEST_READ_TIMEOUT` constant above the struct definition.

No behavioral changes — pure refactor.