### PR TITLE
fix(docker): update devnet Dockerfile Go version and pin git dependencies

### DIFF
--- a/etc/docker/Dockerfile.devnet
+++ b/etc/docker/Dockerfile.devnet
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/docker/library/golang:1.25-alpine AS builder
+FROM public.ecr.aws/docker/library/golang:1.26-alpine AS builder
 
 # Install build dependencies for CGO (required for BLS library)
 RUN apk add --no-cache git make gcc g++ musl-dev linux-headers curl ca-certificates
@@ -17,13 +17,23 @@ RUN ARCH=$(uname -m | sed 's/x86_64/amd64/g' | sed 's/aarch64/arm64/g') && \
 
 # Build eth-beacon-genesis from source (has replace directives, can't use go install)
 WORKDIR /build
-RUN git clone --depth 1 https://github.com/ethpandaops/eth-beacon-genesis.git .
+ARG ETH_BEACON_GENESIS_REPO=https://github.com/ethpandaops/eth-beacon-genesis.git
+ARG ETH_BEACON_GENESIS_COMMIT=f57c0fb4606f9a28e5eecb61546efa9b658183b2
+RUN git init && \
+    git remote add origin $ETH_BEACON_GENESIS_REPO && \
+    git fetch --depth=1 origin $ETH_BEACON_GENESIS_COMMIT && \
+    git reset --hard FETCH_HEAD
 ENV CGO_ENABLED=1
 RUN go build -o /go/bin/eth-genesis-state-generator ./cmd/eth-genesis-state-generator
 
 # Build eth2-val-tools for validator keystore generation
 WORKDIR /build2
-RUN git clone --depth 1 https://github.com/protolambda/eth2-val-tools.git .
+ARG ETH2_VAL_TOOLS_REPO=https://github.com/protolambda/eth2-val-tools.git
+ARG ETH2_VAL_TOOLS_COMMIT=db4f5fa6b8a6096a5f22c0a60f6494bf489c407b
+RUN git init && \
+    git remote add origin $ETH2_VAL_TOOLS_REPO && \
+    git fetch --depth=1 origin $ETH2_VAL_TOOLS_COMMIT && \
+    git reset --hard FETCH_HEAD
 RUN go build -o /go/bin/eth2-val-tools .
 
 FROM public.ecr.aws/docker/library/alpine:3.21


### PR DESCRIPTION
## Summary

- Updates the Go base image in `Dockerfile.devnet` from `1.25-alpine` to `1.26-alpine`
- Pins `eth-beacon-genesis` and `eth2-val-tools` to specific commits using shallow fetch (`git fetch --depth=1 origin $COMMIT`), preventing upstream changes from breaking the build