### PR TITLE
refactor(challenger): clean up

### DIFF
--- a/crates/proof/challenge/src/config.rs
+++ b/crates/proof/challenge/src/config.rs
@@ -97,6 +97,53 @@ pub enum SigningConfig {
     },
 }
 
+impl SigningConfig {
+    /// Validates and builds a [`SigningConfig`] from CLI arguments.
+    ///
+    /// Exactly one of `private_key` or (`signer_endpoint` + `signer_address`) must be provided.
+    pub fn build(
+        private_key: Option<&str>,
+        signer_endpoint: Option<Url>,
+        signer_address: Option<&Address>,
+    ) -> Result<Self, ConfigError> {
+        match (private_key, signer_endpoint, signer_address) {
+            (Some(pk), None, None) => {
+                let hex_str = pk.strip_prefix("0x").unwrap_or(pk);
+                let key_bytes = Zeroizing::new(
+                    hex::decode(hex_str)
+                        .map_err(|e| ConfigError::Signing(format!("invalid private key hex: {e}")))?,
+                );
+                let signing_key = SigningKey::from_slice(&key_bytes)
+                    .map_err(|e| ConfigError::Signing(format!("invalid private key: {e}")))?;
+                let signer = PrivateKeySigner::from_signing_key(signing_key);
+                Ok(Self::Local { signer })
+            }
+            (None, Some(endpoint), Some(address)) => {
+                let endpoint =
+                    Validated::try_from(endpoint).map_err(|e| ConfigError::InvalidUrl {
+                        field: "signer-endpoint",
+                        reason: e.to_string(),
+                    })?;
+                Ok(Self::Remote { endpoint, address: *address })
+            }
+            (None, None, None) => Err(ConfigError::Signing(
+                "one of CHALLENGER_PRIVATE_KEY or (--signer-endpoint + --signer-address) must be provided"
+                    .to_string(),
+            )),
+            (Some(_), Some(_), _) | (Some(_), _, Some(_)) => Err(ConfigError::Signing(
+                "CHALLENGER_PRIVATE_KEY is mutually exclusive with --signer-endpoint/--signer-address"
+                    .to_string(),
+            )),
+            (None, Some(_), None) => {
+                Err(ConfigError::Signing("--signer-endpoint requires --signer-address".to_string()))
+            }
+            (None, None, Some(_)) => {
+                Err(ConfigError::Signing("--signer-address requires --signer-endpoint".to_string()))
+            }
+        }
+    }
+}
+
 impl std::fmt::Debug for SigningConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
@@ -222,7 +269,7 @@ impl ChallengerConfig {
         }
 
         // Validate and extract signing config
-        let signing = build_signing_config(
+        let signing = SigningConfig::build(
             private_key.as_deref().map(String::as_str),
             cli.challenger.signer_endpoint,
             cli.challenger.signer_address.as_ref(),
@@ -246,51 +293,6 @@ impl ChallengerConfig {
             log: LogConfig::from(cli.logging),
             metrics: cli.metrics.into(),
         })
-    }
-}
-
-/// Validate and build [`SigningConfig`] from CLI arguments.
-///
-/// Exactly one of `private_key` or (`signer_endpoint` + `signer_address`) must be provided.
-fn build_signing_config(
-    private_key: Option<&str>,
-    signer_endpoint: Option<Url>,
-    signer_address: Option<&Address>,
-) -> Result<SigningConfig, ConfigError> {
-    match (private_key, signer_endpoint, signer_address) {
-        (Some(pk), None, None) => {
-            let hex_str = pk.strip_prefix("0x").unwrap_or(pk);
-            let key_bytes = Zeroizing::new(
-                hex::decode(hex_str)
-                    .map_err(|e| ConfigError::Signing(format!("invalid private key hex: {e}")))?,
-            );
-            let signing_key = SigningKey::from_slice(&key_bytes)
-                .map_err(|e| ConfigError::Signing(format!("invalid private key: {e}")))?;
-            let signer = PrivateKeySigner::from_signing_key(signing_key);
-            Ok(SigningConfig::Local { signer })
-        }
-        (None, Some(endpoint), Some(address)) => {
-            let endpoint =
-                Validated::try_from(endpoint).map_err(|e| ConfigError::InvalidUrl {
-                    field: "signer-endpoint",
-                    reason: e.to_string(),
-                })?;
-            Ok(SigningConfig::Remote { endpoint, address: *address })
-        }
-        (None, None, None) => Err(ConfigError::Signing(
-            "one of CHALLENGER_PRIVATE_KEY or (--signer-endpoint + --signer-address) must be provided"
-                .to_string(),
-        )),
-        (Some(_), Some(_), _) | (Some(_), _, Some(_)) => Err(ConfigError::Signing(
-            "CHALLENGER_PRIVATE_KEY is mutually exclusive with --signer-endpoint/--signer-address"
-                .to_string(),
-        )),
-        (None, Some(_), None) => {
-            Err(ConfigError::Signing("--signer-endpoint requires --signer-address".to_string()))
-        }
-        (None, None, Some(_)) => {
-            Err(ConfigError::Signing("--signer-address requires --signer-endpoint".to_string()))
-        }
     }
 }
 
@@ -461,7 +463,7 @@ mod tests {
     ) {
         let url = url_str.map(|s| Url::parse(s).unwrap());
         let addr: Option<Address> = addr_str.map(|s| s.parse().unwrap());
-        let result = build_signing_config(pk, url, addr.as_ref());
+        let result = SigningConfig::build(pk, url, addr.as_ref());
         if should_succeed {
             assert!(result.is_ok(), "expected Ok, got {result:?}");
         } else {
@@ -489,7 +491,7 @@ mod tests {
     #[test]
     fn test_signing_config_debug_shows_address() {
         let pk = "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80";
-        let signing = build_signing_config(Some(pk), None, None).unwrap();
+        let signing = SigningConfig::build(Some(pk), None, None).unwrap();
         let debug_output = format!("{signing:?}");
         assert!(debug_output.contains("address"));
         assert!(

--- a/crates/proof/challenge/src/health.rs
+++ b/crates/proof/challenge/src/health.rs
@@ -41,6 +41,13 @@ impl ServerState {
             StatusCode::SERVICE_UNAVAILABLE
         }
     }
+
+    fn router(self) -> Router {
+        Router::new()
+            .route("/healthz", get(Self::liveness))
+            .route("/readyz", get(Self::readiness))
+            .with_state(self)
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -65,12 +72,7 @@ impl HealthServer {
     ///
     /// Returns an error if the TCP listener cannot bind to `addr`.
     pub async fn serve(addr: SocketAddr, ready: Arc<AtomicBool>) -> eyre::Result<()> {
-        let state = ServerState { ready };
-
-        let app = Router::new()
-            .route("/healthz", get(ServerState::liveness))
-            .route("/readyz", get(ServerState::readiness))
-            .with_state(state);
+        let app = ServerState { ready }.router();
 
         let listener = TcpListener::bind(addr).await?;
         info!(%addr, "Health server started");
@@ -101,12 +103,7 @@ mod tests {
         let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
         let addr = listener.local_addr().unwrap();
 
-        let state = ServerState { ready };
-
-        let app = Router::new()
-            .route("/healthz", get(ServerState::liveness))
-            .route("/readyz", get(ServerState::readiness))
-            .with_state(state);
+        let app = ServerState { ready }.router();
 
         let handle = tokio::spawn(async move {
             axum::serve(listener, app).await.unwrap();

--- a/crates/proof/challenge/src/metrics.rs
+++ b/crates/proof/challenge/src/metrics.rs
@@ -1,3 +1,5 @@
+//! Challenger metrics constants and startup recording.
+
 /// Challenger metrics helpers.
 #[derive(Debug)]
 pub struct ChallengerMetrics;

--- a/crates/proof/challenge/src/validator.rs
+++ b/crates/proof/challenge/src/validator.rs
@@ -339,9 +339,8 @@ impl<L2: L2Provider> OutputValidator<L2> {
         }
 
         if intermediate_roots.is_empty() {
-            let mismatch = self.validate_output_roots(game_address, &[]).await?;
             return Ok(ValidationResult {
-                is_valid: mismatch.is_none(),
+                is_valid: true,
                 expected_root: claimed_root,
                 claimed_root,
                 invalid_intermediate_index: None,


### PR DESCRIPTION
### What changed? Why?

Cleanup of the challenge crate:

- **`SigningConfig::build`**: Converted the free function `build_signing_config` into a method on `SigningConfig`, moving the logic closer to the type it constructs.
- **`ServerState::router`**: Extracted the axum router construction into a `router()` method on `ServerState`, eliminating duplicated route setup in `HealthServer::serve` and in tests.
- **`validator.rs`**: When `intermediate_roots` is empty, skip the redundant `validate_output_roots` call (which was called with an empty slice) and return `is_valid: true` directly.
- **`metrics.rs`**: Added missing `//!` module doc comment.

### Notes to reviewers

No behavioral changes — purely structural cleanup.

### How has it been tested?

Existing tests cover all changed paths.

### Change management ([definitions](http://go/change-management))

type=routine<!--routine,nonroutine,emergency-->
risk=low<!--low,medium,high-->
impact=sev5<!--sev5,sev4,sev3,sev2,sev1-->

### Backwards Compatibility ([learn more](http://go/backwards-compatibility))

backwards_compatible=true<!-- true false -->

<!-- Automatically merge your PR once the necessary approvals have been received (you probably want this) -->

automerge=false