### PR TITLE
refactor(proposer): clean up

### DIFF
--- a/crates/proof/proposer/src/constants.rs
+++ b/crates/proof/proposer/src/constants.rs
@@ -20,9 +20,6 @@ pub const BLOCKHASH_SAFETY_MARGIN: u64 = 100;
 /// Maximum time to wait for a proposal to be included on-chain.
 pub const PROPOSAL_TIMEOUT: Duration = Duration::from_secs(600);
 
-/// Default poll interval for checking new blocks.
-pub const DEFAULT_POLL_INTERVAL: Duration = Duration::from_secs(12);
-
 /// Sentinel value for the parent game index when creating the first game from
 /// the anchor state registry (i.e., no parent game exists).
 /// This is `uint32.max` per the `DisputeGameFactory` contract.

--- a/crates/proof/proposer/src/driver/mod.rs
+++ b/crates/proof/proposer/src/driver/mod.rs
@@ -282,8 +282,11 @@ where
                 }
             };
 
+        // Fetch the safe head once per tick and reuse it throughout.
+        let latest_safe = self.latest_safe_block().await?;
+
         // Generate proofs for blocks in the range.
-        if let Err(e) = self.generate_outputs(starting_block_number).await {
+        if let Err(e) = self.generate_outputs(starting_block_number, &latest_safe).await {
             warn!(error = %e, "Error generating outputs");
             return Err(e);
         }
@@ -294,11 +297,10 @@ where
         if !fresh_roots.is_empty() {
             self.cached_intermediate_roots = fresh_roots;
         }
-        let intermediate_roots = self.cached_intermediate_roots.clone();
 
         // Check if we have enough proofs to aggregate and propose.
-        match self.next_output(starting_block_number, starting_root, &intermediate_roots).await {
-            Ok(Some(proposal)) => {
+        match self.next_output(starting_block_number, starting_root, &latest_safe).await {
+            Ok(Some((proposal, intermediate_roots))) => {
                 self.propose_output(&proposal, parent_index, &intermediate_roots).await;
             }
             Ok(None) => {}
@@ -345,7 +347,11 @@ where
     }
 
     /// Generates single-block proofs, filling the pending queue.
-    async fn generate_outputs(&mut self, starting_block_number: u64) -> Result<(), ProposerError> {
+    async fn generate_outputs(
+        &mut self,
+        starting_block_number: u64,
+        latest_safe: &L2BlockRef,
+    ) -> Result<(), ProposerError> {
         // Clear pending if not contiguous with starting point.
         if let Some(front) = self.pending.front()
             && front.from.number.saturating_sub(1) != starting_block_number
@@ -394,12 +400,7 @@ where
 
             let proposal = self.prover.generate(&block).await?;
 
-            let blocks_behind = match self.latest_safe_block_number().await {
-                Ok(safe_number) if safe_number > proposal.to.number => {
-                    safe_number - proposal.to.number
-                }
-                _ => 0,
-            };
+            let blocks_behind = latest_safe.number.saturating_sub(proposal.to.number);
 
             info!(
                 block_number = proposal.to.number,
@@ -419,13 +420,17 @@ where
     }
 
     /// Determines the next output to propose, aggregating if needed.
+    ///
+    /// On success, returns the proposal along with the intermediate roots to use
+    /// for submission. The intermediate roots are cloned only when a proposal is
+    /// actually ready, avoiding unnecessary allocations on ticks where no
+    /// proposal is produced.
     async fn next_output(
         &mut self,
         starting_block_number: u64,
         starting_root: B256,
-        intermediate_roots: &[B256],
-    ) -> Result<Option<ProverProposal>, ProposerError> {
-        let latest_safe = self.latest_safe_block().await?;
+        latest_safe: &L2BlockRef,
+    ) -> Result<Option<(ProverProposal, Vec<B256>)>, ProposerError> {
         let latest_safe_number = latest_safe.number;
 
         // We need exactly block_interval proofs to propose.
@@ -434,14 +439,11 @@ where
             .ok_or_else(|| ProposerError::Internal("overflow computing target block".into()))?;
 
         // Count pending proposals up to the target block and safe head.
-        let mut count = 0;
-        for p in &self.pending {
-            if p.to.number <= target && p.to.number <= latest_safe_number {
-                count += 1;
-            } else {
-                break;
-            }
-        }
+        let mut count = self
+            .pending
+            .iter()
+            .take_while(|p| p.to.number <= target && p.to.number <= latest_safe_number)
+            .count();
 
         if count == 0 {
             return Ok(None);
@@ -460,6 +462,7 @@ where
         }
 
         // Aggregate proposals in batches.
+        let intermediate_roots = &self.cached_intermediate_roots;
         let prev_block_number = starting_block_number;
         while count > 1 {
             let batch_length = count.min(AGGREGATE_BATCH_SIZE);
@@ -467,7 +470,7 @@ where
 
             // Only include intermediate roots in the final aggregation round.
             let is_final_batch = count == batch_length;
-            let batch_roots = if is_final_batch { intermediate_roots.to_vec() } else { vec![] };
+            let batch_roots = if is_final_batch { intermediate_roots.clone() } else { vec![] };
 
             match self.prover.aggregate(starting_root, prev_block_number, batch, batch_roots).await
             {
@@ -540,7 +543,11 @@ where
             return Ok(None);
         }
 
-        Ok(Some(self.pending[0].clone()))
+        // Clone the intermediate roots only when we're actually going to propose.
+        let roots = self.cached_intermediate_roots.clone();
+        // Pop instead of clone: the pending queue is cleared after submission anyway.
+        let proposal = self.pending.pop_front().unwrap();
+        Ok(Some((proposal, roots)))
     }
 
     /// Returns the latest safe L2 block reference.
@@ -551,11 +558,6 @@ where
         } else {
             Ok(sync_status.finalized_l2)
         }
-    }
-
-    /// Returns the latest safe L2 block number.
-    async fn latest_safe_block_number(&self) -> Result<u64, ProposerError> {
-        self.latest_safe_block().await.map(|b| b.number)
     }
 
     /// Submits a proposal by creating a dispute game via the factory.
@@ -796,8 +798,8 @@ mod tests {
         prover::{Prover, test_helpers::test_proposal},
         test_utils::{
             MockAggregateVerifier, MockAnchorStateRegistry, MockDisputeGameFactory, MockL1, MockL2,
-            MockOutputProposer, MockRollupClient, test_anchor_root, test_per_chain_config,
-            test_sync_status,
+            MockOutputProposer, MockRollupClient, test_anchor_root, test_l2_block_ref,
+            test_per_chain_config, test_sync_status,
         },
     };
 
@@ -932,7 +934,8 @@ mod tests {
         assert_eq!(driver.pending.len(), 3);
 
         // generate_outputs(10): front.from(15) - 1 = 14 != 10, so queue is cleared
-        let result = driver.generate_outputs(10).await;
+        let safe = test_l2_block_ref(200, B256::ZERO);
+        let result = driver.generate_outputs(10, &safe).await;
         assert!(result.is_ok());
         assert_eq!(driver.pending.len(), 0);
     }
@@ -947,7 +950,8 @@ mod tests {
         driver.pending.push_back(test_proposal(12, 12, false));
         assert_eq!(driver.pending.len(), 2);
 
-        let result = driver.generate_outputs(10).await;
+        let safe = test_l2_block_ref(200, B256::ZERO);
+        let result = driver.generate_outputs(10, &safe).await;
         assert!(result.is_ok());
         // Queue preserved (contiguous), no new blocks generated (MockL2 returns BlockNotFound)
         assert_eq!(driver.pending.len(), 2);
@@ -955,11 +959,11 @@ mod tests {
 
     #[tokio::test]
     async fn test_next_output_returns_none_when_empty() {
-        let sync_status = test_sync_status(200, B256::ZERO);
-        let mut driver = test_driver(1000, sync_status, None);
+        let mut driver = test_driver(1000, test_sync_status(200, B256::ZERO), None);
+        let safe = test_l2_block_ref(200, B256::ZERO);
 
         // Empty pending queue
-        let result = driver.next_output(100, B256::ZERO, &[]).await;
+        let result = driver.next_output(100, B256::ZERO, &safe).await;
         assert!(result.is_ok());
         assert!(result.unwrap().is_none());
     }
@@ -968,12 +972,13 @@ mod tests {
     async fn test_next_output_returns_none_when_target_not_reached() {
         // target = 100 + 10 = 110, safe=200, but pending only goes up to 105
         let canonical_hash = B256::repeat_byte(0x30);
-        let sync_status = test_sync_status(200, canonical_hash);
-        let mut driver = test_driver(1000, sync_status, Some(canonical_hash));
+        let safe = test_l2_block_ref(200, canonical_hash);
+        let mut driver =
+            test_driver(1000, test_sync_status(200, canonical_hash), Some(canonical_hash));
 
         driver.pending.push_back(test_proposal(101, 105, false));
 
-        let result = driver.next_output(100, B256::ZERO, &[]).await;
+        let result = driver.next_output(100, B256::ZERO, &safe).await;
         assert!(result.is_ok());
         assert!(result.unwrap().is_none());
     }
@@ -982,12 +987,13 @@ mod tests {
     async fn test_next_output_returns_none_when_target_not_safe() {
         // target = 100 + 10 = 110, but safe_number = 105 (not safe yet)
         let canonical_hash = B256::repeat_byte(0x30);
-        let sync_status = test_sync_status(105, canonical_hash);
-        let mut driver = test_driver(1000, sync_status, Some(canonical_hash));
+        let safe = test_l2_block_ref(105, canonical_hash);
+        let mut driver =
+            test_driver(1000, test_sync_status(105, canonical_hash), Some(canonical_hash));
 
         driver.pending.push_back(test_proposal(101, 110, false));
 
-        let result = driver.next_output(100, B256::ZERO, &[]).await;
+        let result = driver.next_output(100, B256::ZERO, &safe).await;
         assert!(result.is_ok());
         assert!(result.unwrap().is_none());
     }
@@ -996,14 +1002,14 @@ mod tests {
     async fn test_next_output_reorg_detection() {
         // Proposal has to.hash = 0x30, but canonical hash is 0xBB => mismatch
         let canonical_hash = B256::repeat_byte(0xBB);
-        let sync_status = test_sync_status(200, B256::ZERO);
-        let mut driver = test_driver(1000, sync_status, Some(canonical_hash));
+        let safe = test_l2_block_ref(200, B256::ZERO);
+        let mut driver = test_driver(1000, test_sync_status(200, B256::ZERO), Some(canonical_hash));
 
         // test_proposal sets to.hash = B256::repeat_byte(0x30) which != 0xBB
         driver.pending.push_back(test_proposal(101, 110, false));
         assert_eq!(driver.pending.len(), 1);
 
-        let result = driver.next_output(100, B256::ZERO, &[]).await;
+        let result = driver.next_output(100, B256::ZERO, &safe).await;
         assert!(result.is_ok());
         assert!(result.unwrap().is_none());
         // Queue should be cleared due to reorg detection
@@ -1016,14 +1022,15 @@ mod tests {
         // Threshold = 10000 - (8191-100) = 10000 - 8091 = 1909
         // 1000 <= 1909 → rejected (L1 origin too old)
         let canonical_hash = B256::repeat_byte(0x30);
-        let sync_status = test_sync_status(200, canonical_hash);
-        let mut driver = test_driver(10000, sync_status, Some(canonical_hash));
+        let safe = test_l2_block_ref(200, canonical_hash);
+        let mut driver =
+            test_driver(10000, test_sync_status(200, canonical_hash), Some(canonical_hash));
 
         let mut proposal = test_proposal(101, 110, false);
         proposal.to.l1origin.number = 1000;
         driver.pending.push_back(proposal);
 
-        let result = driver.next_output(100, B256::ZERO, &[]).await;
+        let result = driver.next_output(100, B256::ZERO, &safe).await;
         assert!(result.is_ok());
         assert!(result.unwrap().is_none());
         // Queue NOT cleared — blockhash window gating doesn't clear the queue
@@ -1035,34 +1042,35 @@ mod tests {
         // target = 100 + 10 = 110, safe = 200, l1_latest = 1000
         // test_proposal sets l1origin.number = 100 + to_number = 210, well within BLOCKHASH window
         let canonical_hash = B256::repeat_byte(0x30);
-        let sync_status = test_sync_status(200, canonical_hash);
-        let mut driver = test_driver(1000, sync_status, Some(canonical_hash));
+        let safe = test_l2_block_ref(200, canonical_hash);
+        let mut driver =
+            test_driver(1000, test_sync_status(200, canonical_hash), Some(canonical_hash));
 
         driver.pending.push_back(test_proposal(101, 110, false));
         assert_eq!(driver.pending.len(), 1);
 
-        let result = driver.next_output(100, B256::ZERO, &[]).await;
+        let result = driver.next_output(100, B256::ZERO, &safe).await;
         assert!(result.is_ok());
-        let proposal = result.unwrap();
-        assert!(proposal.is_some(), "expected Some(proposal)");
-        let proposal = proposal.unwrap();
+        let output = result.unwrap();
+        assert!(output.is_some(), "expected Some(proposal)");
+        let (proposal, _roots) = output.unwrap();
         assert_eq!(proposal.from.number, 101);
         assert_eq!(proposal.to.number, 110);
-        // Pending still has the item (next_output clones, doesn't pop)
-        assert_eq!(driver.pending.len(), 1);
+        // Pending is now empty (next_output pops the proposal)
+        assert_eq!(driver.pending.len(), 0);
     }
 
     #[tokio::test]
     async fn test_next_output_with_aggregation() {
         let canonical_hash = B256::repeat_byte(0x30);
-        let sync_status = test_sync_status(103, canonical_hash);
+        let safe = test_l2_block_ref(103, canonical_hash);
         let cancel = CancellationToken::new();
 
         let mut driver = test_driver_custom(
             MockEnclaveForAggregation,
             DriverConfig { block_interval: 3, ..Default::default() },
             400,
-            sync_status,
+            test_sync_status(103, canonical_hash),
             Some(canonical_hash),
             Arc::new(MockOutputProposer),
             cancel,
@@ -1075,15 +1083,15 @@ mod tests {
         assert_eq!(driver.pending.len(), 3);
 
         // target = 100 + 3 = 103, safe = 103, all gates pass
-        let result = driver.next_output(100, B256::ZERO, &[]).await;
+        let result = driver.next_output(100, B256::ZERO, &safe).await;
         assert!(result.is_ok());
-        let proposal = result.unwrap();
-        assert!(proposal.is_some(), "expected Some(proposal) after aggregation");
-        let proposal = proposal.unwrap();
+        let output = result.unwrap();
+        assert!(output.is_some(), "expected Some(proposal) after aggregation");
+        let (proposal, _roots) = output.unwrap();
         assert_eq!(proposal.from.number, 101);
         assert_eq!(proposal.to.number, 103);
-        // Pending should have 1 aggregated item
-        assert_eq!(driver.pending.len(), 1);
+        // Pending is empty after pop
+        assert_eq!(driver.pending.len(), 0);
     }
 
     #[tokio::test]

--- a/crates/proof/proposer/src/output_proposer.rs
+++ b/crates/proof/proposer/src/output_proposer.rs
@@ -6,7 +6,10 @@
 //! - **Local**: Signs with an in-process private key via [`EthereumWallet`].
 //! - **Remote**: Calls a signer sidecar's `eth_signTransaction` JSON-RPC method.
 
-use std::{future::Future, sync::Arc};
+use std::{
+    future::Future,
+    sync::{Arc, LazyLock},
+};
 
 use alloy_eips::Encodable2718;
 use alloy_network::{EthereumWallet, TransactionBuilder};
@@ -38,6 +41,10 @@ const fn apply_gas_margin(estimated: u64) -> u64 {
     estimated.saturating_mul(GAS_LIMIT_MULTIPLIER_NUMERATOR) / GAS_LIMIT_MULTIPLIER_DENOMINATOR
 }
 
+/// Hex-encoded `GameAlreadyExists` selector, computed once.
+static GAME_ALREADY_EXISTS_HEX: LazyLock<String> =
+    LazyLock::new(|| alloy_primitives::hex::encode(game_already_exists_selector()));
+
 /// Classifies a contract-interaction error into a structured [`ProposerError`] variant.
 ///
 /// Checks whether the error string contains the `GameAlreadyExists` selector,
@@ -45,8 +52,7 @@ const fn apply_gas_margin(estimated: u64) -> u64 {
 /// [`ProposerError::Contract`] with the provided context.
 fn classify_contract_error(context: &str, err: impl std::fmt::Display) -> ProposerError {
     let msg = err.to_string();
-    let selector_hex = alloy_primitives::hex::encode(game_already_exists_selector());
-    if msg.contains(&selector_hex) || msg.contains("GameAlreadyExists") {
+    if msg.contains(GAME_ALREADY_EXISTS_HEX.as_str()) || msg.contains("GameAlreadyExists") {
         return ProposerError::GameAlreadyExists;
     }
     ProposerError::Contract(format!("{context}: {msg}"))

--- a/crates/proof/proposer/src/prover/mod.rs
+++ b/crates/proof/proposer/src/prover/mod.rs
@@ -35,8 +35,10 @@ const ENCLAVE_TIMEOUT: Duration = Duration::from_secs(600);
 /// Prover for generating TEE-signed proposals.
 #[derive(Debug)]
 pub struct Prover<L1, L2, E> {
-    rollup_config: RollupConfig,
     config_hash: B256,
+    /// Pre-built chain config derived from the rollup config (immutable at runtime).
+    chain_config: ChainConfig,
+    rollup_config: RollupConfig,
     l1_client: Arc<L1>,
     l2_client: Arc<L2>,
     enclave_client: E,
@@ -75,10 +77,12 @@ where
     ) -> Self {
         config.force_defaults();
         let config_hash = config.hash();
+        let chain_config = build_chain_config(&rollup_config);
 
         Self {
-            rollup_config,
             config_hash,
+            chain_config,
+            rollup_config,
             l1_client,
             l2_client,
             enclave_client,
@@ -165,14 +169,13 @@ where
         // Serialize current block transactions (excluding deposits)
         let sequenced_txs = serialize_block_transactions(block, false)?;
 
-        let chain_config = build_chain_config(&self.rollup_config);
         let l1_receipt_envelopes = convert_receipts(l1_receipts);
         let mut repairs = 0usize;
         let proposal = loop {
             // Clones here are acceptable: retries are rare (only on missing trie nodes)
             // and the data is small relative to the enclave RPC cost.
             let request = ExecuteStatelessRequest {
-                config: chain_config.clone(),
+                config: self.chain_config.clone(),
                 config_hash: self.config_hash,
                 l1_origin: l1_origin.inner.clone(),
                 l1_receipts: l1_receipt_envelopes.clone(),
@@ -474,11 +477,11 @@ fn build_chain_config(rollup_config: &RollupConfig) -> ChainConfig {
     config
 }
 
-/// Extracts a missing header hash from enclave error text.
+/// Extracts a `B256` hash following a marker string in an error message.
 ///
-/// Looks for the substring "header not found for hash: 0x...".
-fn extract_missing_header_hash(err: &str) -> Option<B256> {
-    let marker = "header not found for hash:";
+/// Searches for `marker` in `err`, then parses the `0x`-prefixed hex hash
+/// that follows it.
+fn extract_hash_after_marker(err: &str, marker: &str) -> Option<B256> {
     let idx = err.find(marker)?;
     let suffix = err.get(idx + marker.len()..)?.trim_start();
     let mut end = suffix.len();
@@ -495,25 +498,14 @@ fn extract_missing_header_hash(err: &str) -> Option<B256> {
     candidate.parse().ok()
 }
 
+/// Extracts a missing header hash from enclave error text.
+fn extract_missing_header_hash(err: &str) -> Option<B256> {
+    extract_hash_after_marker(err, "header not found for hash:")
+}
+
 /// Extracts a missing trie node hash from enclave error text.
-///
-/// Looks for the substring "trie node not found for hash: 0x...".
 fn extract_missing_trie_hash(err: &str) -> Option<B256> {
-    let marker = "trie node not found for hash:";
-    let idx = err.find(marker)?;
-    let suffix = err.get(idx + marker.len()..)?.trim_start();
-    let mut end = suffix.len();
-    for (i, c) in suffix.char_indices() {
-        if !(c.is_ascii_hexdigit() || c == 'x') {
-            end = i;
-            break;
-        }
-    }
-    let candidate = suffix.get(..end)?.trim_end_matches('"').trim_end_matches(',');
-    if !candidate.starts_with("0x") {
-        return None;
-    }
-    candidate.parse().ok()
+    extract_hash_after_marker(err, "trie node not found for hash:")
 }
 
 #[cfg(test)]


### PR DESCRIPTION
### What changed? Why?

A set of small cleanups and efficiency improvements to the proposer crate. No behavioral changes.

**Driver (`driver/mod.rs`)**
- `latest_safe_block()` is now called once per tick and the resulting `L2BlockRef` is threaded through to both `generate_outputs()` and `next_output()`, eliminating redundant async RPC calls per tick.
- Removed the now-unnecessary `latest_safe_block_number()` helper.
- `next_output()` returns `Option<(ProverProposal, Vec<B256>)>` instead of `Option<ProverProposal>`, bundling the intermediate roots with the proposal so the caller no longer needs to hold a separate clone of `cached_intermediate_roots` on every tick.
- `next_output()` now `pop_front()`s the proposal instead of cloning it, so the pending queue is cleaned up as part of the return path rather than relying on the post-submission clear.
- `cached_intermediate_roots` is cloned only when a proposal is actually ready to submit, avoiding the allocation on no-op ticks.
- Replaced an imperative `for` loop for counting eligible pending proposals with `iter().take_while().count()`.
- Removed the unused `DEFAULT_POLL_INTERVAL` constant.

**Output proposer (`output_proposer.rs`)**
- The `GameAlreadyExists` selector hex string is now computed once via a `LazyLock<String>` static instead of being recomputed on every error-classification call.

**Prover (`prover/mod.rs`)**
- `ChainConfig` is now built once in `Prover::new()` and stored as a field rather than being rebuilt from the rollup config on every `generate()` call.
- Deduplicated `extract_missing_header_hash` and `extract_missing_trie_hash` by extracting a shared `extract_hash_after_marker(err, marker)` helper, removing ~15 lines of duplicated parsing logic.

### Notes to reviewers

All changes are internal refactors with no public API or behavioral differences. Tests have been updated to match the new `next_output` return type and the pop-vs-clone semantics.

### How has it been tested?

Existing unit tests cover all modified paths and have been updated to reflect the new return type and queue behavior.

### Change management ([definitions](http://go/change-management))

type=routine<!--routine,nonroutine,emergency-->
risk=low<!--low,medium,high-->
impact=sev5<!--sev5,sev4,sev3,sev2,sev1-->

### Backwards Compatibility ([learn more](http://go/backwards-compatibility))

backwards_compatible=true<!-- true false -->

<!-- Automatically merge your PR once the necessary approvals have been received (you probably want this) -->

automerge=false