### PR TITLE
refactor(CHAIN-3557): Remove K8s StatefulSet discovery mode

### DIFF
--- a/bin/prover-registrar/src/cli.rs
+++ b/bin/prover-registrar/src/cli.rs
@@ -5,22 +5,11 @@ use std::time::Duration;
 use alloy_primitives::Address;
 use alloy_signer_local::PrivateKeySigner;
 use base_proof_tee_registrar::{
-    AwsDiscoveryConfig, BoundlessConfig, DiscoveryConfig, K8sDiscoveryConfig, RegistrarConfig,
-    RegistrarError, RemoteSignerConfig, SigningConfig,
+    AwsDiscoveryConfig, BoundlessConfig, RegistrarConfig, RegistrarError, RemoteSignerConfig,
+    SigningConfig,
 };
-use clap::{ArgGroup, Args, Parser, ValueEnum};
+use clap::{ArgGroup, Args, Parser};
 use url::Url;
-
-/// Discovery backend selection.
-#[derive(ValueEnum, Clone, Debug, PartialEq, Eq)]
-pub(crate) enum DiscoveryMode {
-    /// K8s `StatefulSet` DNS enumeration (preferred — no AWS SDK calls required).
-    #[value(name = "k8s")]
-    K8s,
-    /// AWS ALB target group polling (fallback — supports `Initial` warm-up window).
-    #[value(name = "aws")]
-    Aws,
-}
 
 /// Prover Registrar — automated TEE signer registration service.
 #[derive(Parser)]
@@ -45,37 +34,13 @@ pub(crate) struct Cli {
     tee_prover_registry_address: Address,
 
     // ── Discovery ─────────────────────────────────────────────────────────────
-    /// Discovery backend: `k8s` (K8s `StatefulSet` DNS) or `aws` (ALB target group).
-    #[arg(long, env = "REGISTRAR_DISCOVERY_MODE")]
-    discovery_mode: DiscoveryMode,
+    /// AWS ALB target group ARN for prover instance discovery.
+    #[arg(long, env = "REGISTRAR_TARGET_GROUP_ARN")]
+    target_group_arn: String,
 
-    /// K8s `StatefulSet` name for prover pods (e.g. `prover`). Required for `k8s` mode.
-    #[arg(
-        long,
-        env = "REGISTRAR_PROVER_STATEFULSET_NAME",
-        required_if_eq("discovery_mode", "k8s")
-    )]
-    prover_statefulset_name: Option<String>,
-
-    /// Headless K8s Service name used for pod DNS (e.g. `prover-headless`). Required for `k8s` mode.
-    #[arg(long, env = "REGISTRAR_PROVER_SERVICE_NAME", required_if_eq("discovery_mode", "k8s"))]
-    prover_service_name: Option<String>,
-
-    /// K8s namespace of the prover `StatefulSet` (e.g. `provers`). Required for `k8s` mode.
-    #[arg(long, env = "REGISTRAR_PROVER_NAMESPACE", required_if_eq("discovery_mode", "k8s"))]
-    prover_namespace: Option<String>,
-
-    /// Number of `StatefulSet` replicas to enumerate. Required for `k8s` mode.
-    #[arg(long, env = "REGISTRAR_PROVER_REPLICAS", required_if_eq("discovery_mode", "k8s"))]
-    prover_replicas: Option<usize>,
-
-    /// AWS ALB target group ARN for prover instance discovery. Required for `aws` mode.
-    #[arg(long, env = "REGISTRAR_TARGET_GROUP_ARN", required_if_eq("discovery_mode", "aws"))]
-    target_group_arn: Option<String>,
-
-    /// AWS region (e.g. `us-east-1`). Required for `aws` mode.
-    #[arg(long, env = "REGISTRAR_AWS_REGION", required_if_eq("discovery_mode", "aws"))]
-    aws_region: Option<String>,
+    /// AWS region (e.g. `us-east-1`).
+    #[arg(long, env = "REGISTRAR_AWS_REGION")]
+    aws_region: String,
 
     /// JSON-RPC port to poll on each prover instance.
     #[arg(long, env = "REGISTRAR_PROVER_PORT", default_value_t = 8000)]
@@ -172,57 +137,10 @@ impl Cli {
             }
         };
 
-        // Build discovery config from mode and corresponding arguments.
-        let discovery = match self.discovery_mode {
-            DiscoveryMode::K8s => {
-                let statefulset_name = self.prover_statefulset_name.ok_or_else(|| {
-                    RegistrarError::Config(
-                        "--prover-statefulset-name is required for k8s discovery mode".into(),
-                    )
-                })?;
-                let service_name = self.prover_service_name.ok_or_else(|| {
-                    RegistrarError::Config(
-                        "--prover-service-name is required for k8s discovery mode".into(),
-                    )
-                })?;
-                let namespace = self.prover_namespace.ok_or_else(|| {
-                    RegistrarError::Config(
-                        "--prover-namespace is required for k8s discovery mode".into(),
-                    )
-                })?;
-                let replicas = self.prover_replicas.ok_or_else(|| {
-                    RegistrarError::Config(
-                        "--prover-replicas is required for k8s discovery mode".into(),
-                    )
-                })?;
-                if replicas == 0 {
-                    return Err(RegistrarError::Config(
-                        "--prover-replicas must be greater than 0".into(),
-                    ));
-                }
-                DiscoveryConfig::K8s(K8sDiscoveryConfig {
-                    statefulset_name,
-                    service_name,
-                    namespace,
-                    replicas,
-                    port: self.prover_port,
-                })
-            }
-            DiscoveryMode::Aws => {
-                let target_group_arn = self.target_group_arn.ok_or_else(|| {
-                    RegistrarError::Config(
-                        "--target-group-arn is required for aws discovery mode".into(),
-                    )
-                })?;
-                let aws_region = self.aws_region.ok_or_else(|| {
-                    RegistrarError::Config("--aws-region is required for aws discovery mode".into())
-                })?;
-                DiscoveryConfig::Aws(AwsDiscoveryConfig {
-                    target_group_arn,
-                    aws_region,
-                    port: self.prover_port,
-                })
-            }
+        let discovery = AwsDiscoveryConfig {
+            target_group_arn: self.target_group_arn,
+            aws_region: self.aws_region,
+            port: self.prover_port,
         };
 
         if self.boundless.boundless_min_price > self.boundless.boundless_max_price {
@@ -271,7 +189,7 @@ impl Cli {
         // TODO(CHAIN-3455): start RegistrationDriver. When wiring up the driver,
         // this binary crate will need `aws-config` with features
         // `["default-https-client", "rt-tokio"]` to construct real AWS SDK clients
-        // for AwsTargetGroupDiscovery in `aws` discovery mode.
+        // for AwsTargetGroupDiscovery.
         Ok(())
     }
 }
@@ -289,16 +207,10 @@ mod tests {
             "http://localhost:8545",
             "--tee-prover-registry-address",
             "0x0000000000000000000000000000000000000001",
-            "--discovery-mode",
-            "k8s",
-            "--prover-statefulset-name",
-            "prover",
-            "--prover-service-name",
-            "prover-headless",
-            "--prover-namespace",
-            "provers",
-            "--prover-replicas",
-            "4",
+            "--target-group-arn",
+            "arn:aws:elasticloadbalancing:us-east-1:123456789012:targetgroup/prover/abc123",
+            "--aws-region",
+            "us-east-1",
             "--private-key",
             "0x0101010101010101010101010101010101010101010101010101010101010101",
             "--boundless-rpc-url",
@@ -317,16 +229,10 @@ mod tests {
             "http://localhost:8545",
             "--tee-prover-registry-address",
             "0x0000000000000000000000000000000000000001",
-            "--discovery-mode",
-            "k8s",
-            "--prover-statefulset-name",
-            "prover",
-            "--prover-service-name",
-            "prover-headless",
-            "--prover-namespace",
-            "provers",
-            "--prover-replicas",
-            "4",
+            "--target-group-arn",
+            "arn:aws:elasticloadbalancing:us-east-1:123456789012:targetgroup/prover/abc123",
+            "--aws-region",
+            "us-east-1",
             "--signer-endpoint",
             "http://localhost:8546",
             "--signer-address",
@@ -340,43 +246,14 @@ mod tests {
         ]
     }
 
-    fn aws_args() -> Vec<&'static str> {
-        vec![
-            "prover-registrar",
-            "--l1-rpc-url",
-            "http://localhost:8545",
-            "--tee-prover-registry-address",
-            "0x0000000000000000000000000000000000000001",
-            "--discovery-mode",
-            "aws",
-            "--target-group-arn",
-            "arn:aws:elasticloadbalancing:us-east-1:123456789012:targetgroup/prover/abc123",
-            "--aws-region",
-            "us-east-1",
-            "--private-key",
-            "0x0101010101010101010101010101010101010101010101010101010101010101",
-            "--boundless-rpc-url",
-            "http://localhost:9545",
-            "--boundless-private-key",
-            "0202020202020202020202020202020202020202020202020202020202020202",
-            "--boundless-verifier-program-url",
-            "ipfs://bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi",
-        ]
-    }
-
     #[test]
-    fn valid_local_key_k8s_config_into_config() {
+    fn valid_local_key_config() {
         assert!(Cli::parse_from(base_args()).into_config().is_ok());
     }
 
     #[test]
-    fn valid_remote_signer_k8s_config_into_config() {
+    fn valid_remote_signer_config() {
         assert!(Cli::parse_from(remote_args()).into_config().is_ok());
-    }
-
-    #[test]
-    fn valid_aws_discovery_config_into_config() {
-        assert!(Cli::parse_from(aws_args()).into_config().is_ok());
     }
 
     #[test]
@@ -392,18 +269,6 @@ mod tests {
     }
 
     #[test]
-    fn into_config_k8s_returns_k8s_discovery() {
-        let config = Cli::parse_from(base_args()).into_config().unwrap();
-        assert!(matches!(config.discovery, DiscoveryConfig::K8s(_)));
-    }
-
-    #[test]
-    fn into_config_aws_returns_aws_discovery() {
-        let config = Cli::parse_from(aws_args()).into_config().unwrap();
-        assert!(matches!(config.discovery, DiscoveryConfig::Aws(_)));
-    }
-
-    #[test]
     fn no_signing_method_fails_clap_parse() {
         let args = vec![
             "prover-registrar",
@@ -411,16 +276,10 @@ mod tests {
             "http://localhost:8545",
             "--tee-prover-registry-address",
             "0x0000000000000000000000000000000000000001",
-            "--discovery-mode",
-            "k8s",
-            "--prover-statefulset-name",
-            "prover",
-            "--prover-service-name",
-            "prover-headless",
-            "--prover-namespace",
-            "provers",
-            "--prover-replicas",
-            "4",
+            "--target-group-arn",
+            "arn:aws:elasticloadbalancing:us-east-1:123456789012:targetgroup/prover/abc123",
+            "--aws-region",
+            "us-east-1",
             "--boundless-rpc-url",
             "http://localhost:9545",
             "--boundless-private-key",
@@ -432,23 +291,17 @@ mod tests {
     }
 
     #[test]
-    fn signer_endpoint_without_address_fails_into_config() {
+    fn signer_endpoint_without_address_fails_clap_parse() {
         let args = vec![
             "prover-registrar",
             "--l1-rpc-url",
             "http://localhost:8545",
             "--tee-prover-registry-address",
             "0x0000000000000000000000000000000000000001",
-            "--discovery-mode",
-            "k8s",
-            "--prover-statefulset-name",
-            "prover",
-            "--prover-service-name",
-            "prover-headless",
-            "--prover-namespace",
-            "provers",
-            "--prover-replicas",
-            "4",
+            "--target-group-arn",
+            "arn:aws:elasticloadbalancing:us-east-1:123456789012:targetgroup/prover/abc123",
+            "--aws-region",
+            "us-east-1",
             "--signer-endpoint",
             "http://localhost:8546",
             "--boundless-rpc-url",
@@ -459,93 +312,6 @@ mod tests {
             "ipfs://bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi",
         ];
         assert!(Cli::try_parse_from(args).is_err());
-    }
-
-    #[test]
-    fn k8s_mode_without_statefulset_name_fails_clap_parse() {
-        let args = vec![
-            "prover-registrar",
-            "--l1-rpc-url",
-            "http://localhost:8545",
-            "--tee-prover-registry-address",
-            "0x0000000000000000000000000000000000000001",
-            "--discovery-mode",
-            "k8s",
-            "--prover-service-name",
-            "prover-headless",
-            "--prover-namespace",
-            "provers",
-            "--prover-replicas",
-            "4",
-            "--private-key",
-            "0x0101010101010101010101010101010101010101010101010101010101010101",
-            "--boundless-rpc-url",
-            "http://localhost:9545",
-            "--boundless-private-key",
-            "0202020202020202020202020202020202020202020202020202020202020202",
-            "--boundless-verifier-program-url",
-            "ipfs://bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi",
-        ];
-        assert!(Cli::try_parse_from(args).is_err());
-    }
-
-    #[test]
-    fn aws_mode_without_target_group_arn_fails_clap_parse() {
-        let args = vec![
-            "prover-registrar",
-            "--l1-rpc-url",
-            "http://localhost:8545",
-            "--tee-prover-registry-address",
-            "0x0000000000000000000000000000000000000001",
-            "--discovery-mode",
-            "aws",
-            "--aws-region",
-            "us-east-1",
-            "--private-key",
-            "0x0101010101010101010101010101010101010101010101010101010101010101",
-            "--boundless-rpc-url",
-            "http://localhost:9545",
-            "--boundless-private-key",
-            "0202020202020202020202020202020202020202020202020202020202020202",
-            "--boundless-verifier-program-url",
-            "ipfs://bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi",
-        ];
-        assert!(Cli::try_parse_from(args).is_err());
-    }
-
-    #[test]
-    fn aws_mode_without_region_fails_clap_parse() {
-        let args = vec![
-            "prover-registrar",
-            "--l1-rpc-url",
-            "http://localhost:8545",
-            "--tee-prover-registry-address",
-            "0x0000000000000000000000000000000000000001",
-            "--discovery-mode",
-            "aws",
-            "--target-group-arn",
-            "arn:aws:elasticloadbalancing:us-east-1:123456789012:targetgroup/prover/abc123",
-            "--private-key",
-            "0x0101010101010101010101010101010101010101010101010101010101010101",
-            "--boundless-rpc-url",
-            "http://localhost:9545",
-            "--boundless-private-key",
-            "0202020202020202020202020202020202020202020202020202020202020202",
-            "--boundless-verifier-program-url",
-            "ipfs://bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi",
-        ];
-        assert!(Cli::try_parse_from(args).is_err());
-    }
-
-    #[test]
-    fn zero_replicas_fails_into_config() {
-        let mut args = base_args();
-        // Replace the existing --prover-replicas value with 0.
-        let idx = args.iter().position(|a| *a == "--prover-replicas").unwrap();
-        args[idx + 1] = "0";
-        assert!(
-            Cli::try_parse_from(args).expect("clap should parse these args").into_config().is_err()
-        );
     }
 
     #[test]
@@ -582,16 +348,13 @@ mod tests {
     }
 
     #[test]
-    fn aws_discovery_config_fields() {
-        let config = Cli::parse_from(aws_args()).into_config().unwrap();
-        let DiscoveryConfig::Aws(aws) = config.discovery else {
-            panic!("expected Aws discovery config");
-        };
+    fn discovery_config_fields() {
+        let config = Cli::parse_from(base_args()).into_config().unwrap();
         assert_eq!(
-            aws.target_group_arn,
+            config.discovery.target_group_arn,
             "arn:aws:elasticloadbalancing:us-east-1:123456789012:targetgroup/prover/abc123"
         );
-        assert_eq!(aws.aws_region, "us-east-1");
-        assert_eq!(aws.port, 8000);
+        assert_eq!(config.discovery.aws_region, "us-east-1");
+        assert_eq!(config.discovery.port, 8000);
     }
 }

--- a/crates/proof/tee/registrar/src/config.rs
+++ b/crates/proof/tee/registrar/src/config.rs
@@ -46,26 +46,6 @@ impl std::fmt::Debug for SigningConfig {
     }
 }
 
-/// K8s `StatefulSet` discovery configuration.
-///
-/// Contains the parameters needed to construct a [`K8sStatefulSetDiscovery`]
-/// at runtime. The driver builds the discovery implementation from this config.
-///
-/// [`K8sStatefulSetDiscovery`]: crate::K8sStatefulSetDiscovery
-#[derive(Clone, Debug)]
-pub struct K8sDiscoveryConfig {
-    /// K8s `StatefulSet` name (e.g. `"prover"`).
-    pub statefulset_name: String,
-    /// Headless Service name used for pod DNS (e.g. `"prover-headless"`).
-    pub service_name: String,
-    /// Namespace of the prover `StatefulSet` (e.g. `"provers"`).
-    pub namespace: String,
-    /// Number of `StatefulSet` replicas to enumerate.
-    pub replicas: usize,
-    /// JSON-RPC port to poll on each prover pod.
-    pub port: u16,
-}
-
 /// AWS ALB target group discovery configuration.
 ///
 /// Contains the parameters needed to construct an [`AwsTargetGroupDiscovery`]
@@ -80,25 +60,6 @@ pub struct AwsDiscoveryConfig {
     pub aws_region: String,
     /// JSON-RPC port to poll on each prover instance.
     pub port: u16,
-}
-
-/// Discovery backend configuration.
-///
-/// Selected at startup via `--discovery-mode`. Only the active variant's
-/// parameters are required; unused variant fields are never read.
-///
-/// Both variants wrap plain config structs — the runtime discovery
-/// implementations ([`K8sStatefulSetDiscovery`], [`AwsTargetGroupDiscovery`])
-/// are constructed from these by the driver.
-///
-/// [`K8sStatefulSetDiscovery`]: crate::K8sStatefulSetDiscovery
-/// [`AwsTargetGroupDiscovery`]: crate::AwsTargetGroupDiscovery
-#[derive(Clone, Debug)]
-pub enum DiscoveryConfig {
-    /// K8s `StatefulSet` DNS enumeration (preferred).
-    K8s(K8sDiscoveryConfig),
-    /// AWS ALB target group polling (fallback).
-    Aws(AwsDiscoveryConfig),
 }
 
 /// Boundless Network configuration for ZK proof generation.
@@ -146,8 +107,8 @@ pub struct RegistrarConfig {
     /// `TEEProverRegistry` contract address on L1.
     pub tee_prover_registry_address: Address,
     // ── Discovery ─────────────────────────────────────────────────────────────
-    /// Discovery backend configuration.
-    pub discovery: DiscoveryConfig,
+    /// AWS ALB target group discovery configuration.
+    pub discovery: AwsDiscoveryConfig,
     // ── Signing ───────────────────────────────────────────────────────────────
     /// Resolved signing configuration.
     pub signing: SigningConfig,

--- a/crates/proof/tee/registrar/src/discovery.rs
+++ b/crates/proof/tee/registrar/src/discovery.rs
@@ -1,4 +1,4 @@
-//! K8s `StatefulSet` and AWS ALB target group instance discovery.
+//! AWS ALB target group instance discovery.
 
 use std::collections::HashMap;
 
@@ -7,73 +7,7 @@ use aws_sdk_ec2::Client as Ec2Client;
 use aws_sdk_elasticloadbalancingv2::Client as ElbClient;
 use tracing::{debug, warn};
 
-use crate::{
-    InstanceDiscovery, InstanceHealthStatus, K8sDiscoveryConfig, ProverInstance, RegistrarError,
-    Result,
-};
-
-/// Discovers prover pods by enumerating a K8s `StatefulSet`'s deterministic DNS names.
-///
-/// `StatefulSet` pods receive stable DNS names of the form:
-/// `{name}-{i}.{svc}.{ns}.svc.cluster.local`
-///
-/// Discovery requires no API calls — pod endpoints are fully deterministic
-/// from the `StatefulSet` name, headless service name, namespace, replica count,
-/// and port alone. K8s pod readiness gates proposal traffic independently;
-/// the registrar polls every enumerated pod each cycle regardless.
-///
-/// Constructed from a [`K8sDiscoveryConfig`] via [`Self::from_config`].
-#[derive(Debug)]
-pub struct K8sStatefulSetDiscovery {
-    /// The K8s `StatefulSet` discovery configuration.
-    pub config: K8sDiscoveryConfig,
-}
-
-impl K8sStatefulSetDiscovery {
-    /// Creates a new discovery instance from the given config.
-    pub const fn from_config(config: K8sDiscoveryConfig) -> Self {
-        Self { config }
-    }
-
-    /// Returns the pod DNS endpoint for replica index `i`.
-    ///
-    /// Format: `{name}-{i}.{svc}.{ns}.svc.cluster.local:{port}`
-    pub fn pod_endpoint(&self, i: usize) -> String {
-        format!(
-            "{}-{}.{}.{}.svc.cluster.local:{}",
-            self.config.statefulset_name,
-            i,
-            self.config.service_name,
-            self.config.namespace,
-            self.config.port
-        )
-    }
-}
-
-#[async_trait]
-impl InstanceDiscovery for K8sStatefulSetDiscovery {
-    /// Returns one [`ProverInstance`] per replica, all marked [`InstanceHealthStatus::Healthy`].
-    ///
-    /// Unlike the AWS path where the ALB provides real health status, K8s discovery
-    /// has no liveness signal — pod DNS names are deterministic regardless of
-    /// whether a pod is actually running. The registrar's downstream poll loop
-    /// (`ProverClient`) handles unreachable pods by returning connection errors,
-    /// which the driver treats as per-instance failures without stopping the cycle.
-    async fn discover_instances(&self) -> Result<Vec<ProverInstance>> {
-        let instances = (0..self.config.replicas)
-            .map(|i| {
-                let endpoint = self.pod_endpoint(i);
-                debug!(pod = %endpoint, "discovered prover pod");
-                ProverInstance {
-                    instance_id: endpoint.clone(),
-                    endpoint,
-                    health_status: InstanceHealthStatus::Healthy,
-                }
-            })
-            .collect();
-        Ok(instances)
-    }
-}
+use crate::{InstanceDiscovery, InstanceHealthStatus, ProverInstance, RegistrarError, Result};
 
 /// Discovers prover instances via AWS Elastic Load Balancing target groups.
 ///
@@ -102,8 +36,7 @@ impl AwsTargetGroupDiscovery {
 
     /// Assembles [`ProverInstance`] objects from ELB target data and EC2 IP data.
     ///
-    /// Returns **all** discovered instances regardless of health status, matching
-    /// the behavior of `K8sStatefulSetDiscovery` which also returns every replica.
+    /// Returns **all** discovered instances regardless of health status.
     /// The caller (registration driver) decides which instances to act on based on
     /// [`InstanceHealthStatus::should_register`].
     ///
@@ -193,8 +126,7 @@ impl InstanceDiscovery for AwsTargetGroupDiscovery {
         }
 
         // Collect all instance IDs for EC2 lookup (not just registerable ones),
-        // so that discover_instances returns the full set — consistent with
-        // K8sStatefulSetDiscovery which returns all replicas.
+        // so that discover_instances returns the full set.
         let all_ids: Vec<String> = targets.iter().map(|(id, _)| id.clone()).collect();
 
         // Resolve private IPs for all instances in a single EC2 call.
@@ -235,139 +167,71 @@ mod tests {
 
     use super::*;
 
-    fn four_replica_discovery() -> K8sStatefulSetDiscovery {
-        K8sStatefulSetDiscovery::from_config(K8sDiscoveryConfig {
-            statefulset_name: "prover".into(),
-            service_name: "prover-headless".into(),
-            namespace: "provers".into(),
-            replicas: 4,
-            port: 8000,
-        })
+    fn make_ips(pairs: &[(&str, &str)]) -> HashMap<String, String> {
+        pairs.iter().map(|(id, ip)| (id.to_string(), ip.to_string())).collect()
+    }
+
+    fn make_targets(pairs: &[(&str, InstanceHealthStatus)]) -> Vec<(String, InstanceHealthStatus)> {
+        pairs.iter().map(|(id, s)| (id.to_string(), *s)).collect()
     }
 
     #[rstest]
-    #[case::ordinal_zero(0, "prover-0.prover-headless.provers.svc.cluster.local:8000")]
-    #[case::last_ordinal(3, "prover-3.prover-headless.provers.svc.cluster.local:8000")]
-    fn pod_endpoint_format(#[case] ordinal: usize, #[case] expected: &str) {
-        assert_eq!(four_replica_discovery().pod_endpoint(ordinal), expected);
+    #[case::healthy("i-001", "10.0.0.1", InstanceHealthStatus::Healthy)]
+    #[case::initial("i-002", "10.0.0.2", InstanceHealthStatus::Initial)]
+    #[case::unhealthy("i-003", "10.0.0.3", InstanceHealthStatus::Unhealthy)]
+    #[case::draining("i-004", "10.0.0.4", InstanceHealthStatus::Draining)]
+    fn assemble_single_instance_preserves_status(
+        #[case] id: &str,
+        #[case] ip: &str,
+        #[case] status: InstanceHealthStatus,
+    ) {
+        let targets = make_targets(&[(id, status)]);
+        let ips = make_ips(&[(id, ip)]);
+        let instances = AwsTargetGroupDiscovery::assemble_prover_instances(&targets, &ips, 8000);
+        assert_eq!(instances.len(), 1);
+        assert_eq!(instances[0].instance_id, id);
+        assert_eq!(instances[0].endpoint, format!("{ip}:8000"));
+        assert_eq!(instances[0].health_status, status);
     }
 
-    #[rstest]
-    #[case::zero(0)]
-    #[case::one(1)]
-    #[case::four(4)]
-    #[tokio::test]
-    async fn discover_instances_returns_one_per_replica(#[case] replicas: usize) {
-        let d = K8sStatefulSetDiscovery::from_config(K8sDiscoveryConfig {
-            statefulset_name: "prover".into(),
-            service_name: "prover-headless".into(),
-            namespace: "provers".into(),
-            replicas,
-            port: 8000,
-        });
-        let instances = d.discover_instances().await.unwrap();
-        assert_eq!(instances.len(), replicas);
+    #[test]
+    fn assemble_drops_instance_missing_from_ip_map() {
+        let targets = make_targets(&[("i-005", InstanceHealthStatus::Healthy)]);
+        let ips = HashMap::new();
+        let instances = AwsTargetGroupDiscovery::assemble_prover_instances(&targets, &ips, 8000);
+        assert!(instances.is_empty());
     }
 
-    #[tokio::test]
-    async fn all_discovered_instances_are_healthy() {
-        let instances = four_replica_discovery().discover_instances().await.unwrap();
-        assert!(instances.iter().all(|i| i.health_status == InstanceHealthStatus::Healthy));
+    #[test]
+    fn assemble_empty_targets_returns_empty() {
+        let instances =
+            AwsTargetGroupDiscovery::assemble_prover_instances(&[], &HashMap::new(), 8000);
+        assert!(instances.is_empty());
     }
 
-    #[tokio::test]
-    async fn instance_ids_match_pod_endpoints() {
-        let d = four_replica_discovery();
-        let instances = d.discover_instances().await.unwrap();
-        for (i, inst) in instances.iter().enumerate() {
-            assert_eq!(inst.instance_id, d.pod_endpoint(i));
-        }
+    #[test]
+    fn assemble_port_appears_in_endpoint() {
+        let targets = make_targets(&[("i-006", InstanceHealthStatus::Healthy)]);
+        let ips = make_ips(&[("i-006", "10.0.0.6")]);
+        let instances = AwsTargetGroupDiscovery::assemble_prover_instances(&targets, &ips, 9999);
+        assert_eq!(instances[0].endpoint, "10.0.0.6:9999");
     }
 
-    #[tokio::test]
-    async fn endpoints_match_pod_endpoints() {
-        let d = four_replica_discovery();
-        let instances = d.discover_instances().await.unwrap();
-        for (i, inst) in instances.iter().enumerate() {
-            assert_eq!(inst.endpoint, d.pod_endpoint(i));
-        }
-    }
-
-    mod aws {
-        use super::*;
-
-        fn make_ips(pairs: &[(&str, &str)]) -> HashMap<String, String> {
-            pairs.iter().map(|(id, ip)| (id.to_string(), ip.to_string())).collect()
-        }
-
-        fn make_targets(
-            pairs: &[(&str, InstanceHealthStatus)],
-        ) -> Vec<(String, InstanceHealthStatus)> {
-            pairs.iter().map(|(id, s)| (id.to_string(), *s)).collect()
-        }
-
-        #[rstest]
-        #[case::healthy("i-001", "10.0.0.1", InstanceHealthStatus::Healthy)]
-        #[case::initial("i-002", "10.0.0.2", InstanceHealthStatus::Initial)]
-        #[case::unhealthy("i-003", "10.0.0.3", InstanceHealthStatus::Unhealthy)]
-        #[case::draining("i-004", "10.0.0.4", InstanceHealthStatus::Draining)]
-        fn assemble_single_instance_preserves_status(
-            #[case] id: &str,
-            #[case] ip: &str,
-            #[case] status: InstanceHealthStatus,
-        ) {
-            let targets = make_targets(&[(id, status)]);
-            let ips = make_ips(&[(id, ip)]);
-            let instances =
-                AwsTargetGroupDiscovery::assemble_prover_instances(&targets, &ips, 8000);
-            assert_eq!(instances.len(), 1);
-            assert_eq!(instances[0].instance_id, id);
-            assert_eq!(instances[0].endpoint, format!("{ip}:8000"));
-            assert_eq!(instances[0].health_status, status);
-        }
-
-        #[test]
-        fn assemble_drops_instance_missing_from_ip_map() {
-            let targets = make_targets(&[("i-005", InstanceHealthStatus::Healthy)]);
-            let ips = HashMap::new();
-            let instances =
-                AwsTargetGroupDiscovery::assemble_prover_instances(&targets, &ips, 8000);
-            assert!(instances.is_empty());
-        }
-
-        #[test]
-        fn assemble_empty_targets_returns_empty() {
-            let instances =
-                AwsTargetGroupDiscovery::assemble_prover_instances(&[], &HashMap::new(), 8000);
-            assert!(instances.is_empty());
-        }
-
-        #[test]
-        fn assemble_port_appears_in_endpoint() {
-            let targets = make_targets(&[("i-006", InstanceHealthStatus::Healthy)]);
-            let ips = make_ips(&[("i-006", "10.0.0.6")]);
-            let instances =
-                AwsTargetGroupDiscovery::assemble_prover_instances(&targets, &ips, 9999);
-            assert_eq!(instances[0].endpoint, "10.0.0.6:9999");
-        }
-
-        #[test]
-        fn assemble_returns_all_statuses() {
-            let targets = make_targets(&[
-                ("i-010", InstanceHealthStatus::Healthy),
-                ("i-011", InstanceHealthStatus::Initial),
-                ("i-012", InstanceHealthStatus::Unhealthy),
-                ("i-013", InstanceHealthStatus::Draining),
-            ]);
-            let ips = make_ips(&[
-                ("i-010", "10.0.1.0"),
-                ("i-011", "10.0.1.1"),
-                ("i-012", "10.0.1.2"),
-                ("i-013", "10.0.1.3"),
-            ]);
-            let instances =
-                AwsTargetGroupDiscovery::assemble_prover_instances(&targets, &ips, 8000);
-            assert_eq!(instances.len(), 4);
-        }
+    #[test]
+    fn assemble_returns_all_statuses() {
+        let targets = make_targets(&[
+            ("i-010", InstanceHealthStatus::Healthy),
+            ("i-011", InstanceHealthStatus::Initial),
+            ("i-012", InstanceHealthStatus::Unhealthy),
+            ("i-013", InstanceHealthStatus::Draining),
+        ]);
+        let ips = make_ips(&[
+            ("i-010", "10.0.1.0"),
+            ("i-011", "10.0.1.1"),
+            ("i-012", "10.0.1.2"),
+            ("i-013", "10.0.1.3"),
+        ]);
+        let instances = AwsTargetGroupDiscovery::assemble_prover_instances(&targets, &ips, 8000);
+        assert_eq!(instances.len(), 4);
     }
 }

--- a/crates/proof/tee/registrar/src/lib.rs
+++ b/crates/proof/tee/registrar/src/lib.rs
@@ -3,12 +3,11 @@
 
 mod config;
 pub use config::{
-    AwsDiscoveryConfig, BoundlessConfig, DiscoveryConfig, K8sDiscoveryConfig, RegistrarConfig,
-    RemoteSignerConfig, SigningConfig,
+    AwsDiscoveryConfig, BoundlessConfig, RegistrarConfig, RemoteSignerConfig, SigningConfig,
 };
 
 mod discovery;
-pub use discovery::{AwsTargetGroupDiscovery, K8sStatefulSetDiscovery};
+pub use discovery::AwsTargetGroupDiscovery;
 
 mod error;
 pub use error::{RegistrarError, Result};

--- a/crates/proof/tee/registrar/src/prover.rs
+++ b/crates/proof/tee/registrar/src/prover.rs
@@ -27,10 +27,8 @@ pub struct ProverClient {
 impl ProverClient {
     /// Creates a new client for the prover at the given endpoint.
     ///
-    /// `endpoint` is a `host:port` string (e.g.
-    /// `"prover-0.prover-headless.provers.svc.cluster.local:8000"` in K8s mode
-    /// or `"10.0.1.5:8000"` in AWS mode). An `http://` scheme is prepended
-    /// automatically.
+    /// `endpoint` is a `host:port` string (e.g. `"10.0.1.5:8000"`).
+    /// An `http://` scheme is prepended automatically.
     pub fn new(endpoint: &str, timeout: Duration) -> Result<Self> {
         let url = format!("http://{endpoint}");
         let inner =

--- a/crates/proof/tee/registrar/src/traits.rs
+++ b/crates/proof/tee/registrar/src/traits.rs
@@ -4,10 +4,9 @@ use crate::{AttestationProof, ProverInstance, Result};
 
 /// Discovers active prover instances from the infrastructure layer.
 ///
-/// Implementations: [`K8sStatefulSetDiscovery`] (K8s `StatefulSet` DNS enumeration)
-/// and [`AwsTargetGroupDiscovery`] (AWS ALB target group polling). Selected at
-/// runtime via `--discovery-mode`. A static list implementation may be substituted
-/// for local testing.
+/// The primary implementation is [`AwsTargetGroupDiscovery`], which queries
+/// an ALB target group via the AWS SDK. Other implementations (e.g., a static
+/// list for local testing) can be substituted.
 #[async_trait]
 pub trait InstanceDiscovery: Send + Sync {
     /// Return the current set of prover instances with their health status.

--- a/crates/proof/tee/registrar/src/types.rs
+++ b/crates/proof/tee/registrar/src/types.rs
@@ -3,15 +3,9 @@ use alloy_primitives::{Address, B256, Bytes};
 /// A prover instance discovered from the infrastructure layer.
 #[derive(Debug, Clone)]
 pub struct ProverInstance {
-    /// Unique identifier for the instance.
-    ///
-    /// K8s mode: pod DNS name (`{name}-{i}.{svc}.{ns}.svc.cluster.local:{port}`).
-    /// AWS mode: EC2 instance ID (e.g. `i-0abc123def456`).
+    /// EC2 instance ID (e.g. `i-0abc123def456`).
     pub instance_id: String,
-    /// HTTP connection endpoint used to contact the instance.
-    ///
-    /// K8s mode: same as `instance_id` (pod DNS:port).
-    /// AWS mode: private IP and port (e.g. `10.0.1.5:8000`).
+    /// Private IP and port for HTTP connection (e.g. `10.0.1.5:8000`).
     pub endpoint: String,
     /// Current health status of the instance.
     pub health_status: InstanceHealthStatus,

--- a/crates/proof/tee/registrar/src/types.rs
+++ b/crates/proof/tee/registrar/src/types.rs
@@ -14,13 +14,13 @@ pub struct ProverInstance {
 /// Health status of a discovered prover instance.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum InstanceHealthStatus {
-    /// ALB health checks are in progress (AWS mode only — instance just started).
+    /// ALB health checks are in progress — instance just started.
     Initial,
     /// Instance is reachable and passing health checks.
     Healthy,
     /// Instance did not respond to the poll or is failing health checks.
     Unhealthy,
-    /// ALB is draining connections from this instance (AWS mode only).
+    /// ALB is draining connections from this instance.
     Draining,
 }
 


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                                        
                                                           
Removes `K8sStatefulSetDiscovery` and the `--discovery-mode` CLI flag, leaving `AwsTargetGroupDiscovery` as the sole discovery backend. Our AWS infrastructure does not support running Nitro enclaves on K8s, so the K8s discovery path cannot be used in practice and adds unnecessary code complexity.

- Remove `K8sStatefulSetDiscovery`, `K8sDiscoveryConfig`, `DiscoveryConfig` enum
- `--target-group-arn` and `--aws-region` are now always-required args (no conditional `required_if_eq`)
- Remove all K8s-related CLI args, config types, and tests
- `InstanceDiscovery` trait preserved for future modularity

## Test plan

- [x] `cargo clippy -p base-proof-tee-registrar -p base-proof-tee-registrar-bin -- -D warnings` passes clean
- [x] `cargo test -p base-proof-tee-registrar -p base-proof-tee-registrar-bin` — all tests passing
- [x] AWS discovery args are now required (no `--discovery-mode` needed)