### PR TITLE
refactor(tx-manager): Zeroize Private Key

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2197,9 +2197,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-types"
-version = "1.4.6"
+version = "1.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2b1117b3b2bbe166d11199b540ceed0d0f7676e36e7b962b5a437a9971eac75"
+checksum = "9d73dbfbaa8e4bc57b9045137680b958d274823509a360abfd8e1d514d40c95c"
 dependencies = [
  "base64-simd",
  "bytes",
@@ -4714,6 +4714,7 @@ dependencies = [
  "tokio",
  "tracing",
  "url",
+ "zeroize",
 ]
 
 [[package]]
@@ -5359,9 +5360,9 @@ dependencies = [
 
 [[package]]
 name = "bollard"
-version = "0.20.1"
+version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "227aa051deec8d16bd9c34605e7aaf153f240e35483dd42f6f78903847934738"
+checksum = "ee04c4c84f1f811b017f2fbb7dd8815c976e7ca98593de9c1e2afad0f636bff4"
 dependencies = [
  "async-stream",
  "base64 0.22.1",
@@ -6961,9 +6962,9 @@ dependencies = [
 
 [[package]]
 name = "doctest-file"
-version = "1.0.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aac81fa3e28d21450aa4d2ac065992ba96a1d7303efbce51a95f4fd175b67562"
+checksum = "c2db04e74f0a9a93103b50e90b96024c9b2bdca8bce6a632ec71b88736d3d359"
 
 [[package]]
 name = "document-features"
@@ -9084,9 +9085,9 @@ dependencies = [
 
 [[package]]
 name = "instability"
-version = "0.3.11"
+version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "357b7205c6cd18dd2c86ed312d1e70add149aea98e7ef72b9fdf0270e555c11d"
+checksum = "5eb2d60ef19920a3a9193c3e371f726ec1dafc045dac788d0fb3704272458971"
 dependencies = [
  "darling 0.23.0",
  "indoc",
@@ -10969,9 +10970,9 @@ dependencies = [
 
 [[package]]
 name = "num_enum"
-version = "0.7.5"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1207a7e20ad57b847bbddc6776b968420d38292bbfe2089accff5e19e82454c"
+checksum = "5d0bca838442ec211fa11de3a8b0e0e8f3a4522575b5c4c06ed722e005036f26"
 dependencies = [
  "num_enum_derive",
  "rustversion",
@@ -10979,9 +10980,9 @@ dependencies = [
 
 [[package]]
 name = "num_enum_derive"
-version = "0.7.5"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff32365de1b6743cb203b710788263c44a03de03802daf96092f2da4fe6ba4d7"
+checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -17892,9 +17893,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa5fdc3bce6191a1dbc8c02d5c8bffcf557bafa17c124c5264a458f1b0613fa"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
 dependencies = [
  "tinyvec_macros",
 ]

--- a/crates/batcher/service/src/service.rs
+++ b/crates/batcher/service/src/service.rs
@@ -340,7 +340,7 @@ impl BatcherService {
         );
 
         // Build the signer config from the configured private key.
-        let signer_config = SignerConfig::Local { private_key: self.config.batcher_private_key.0 };
+        let signer_config = SignerConfig::local(self.config.batcher_private_key.0);
 
         // Fetch L1 chain ID and construct the tx manager.
         let l1_chain_id = l1_provider

--- a/crates/utilities/tx-manager/Cargo.toml
+++ b/crates/utilities/tx-manager/Cargo.toml
@@ -27,6 +27,7 @@ base-alloy-signer.workspace = true
 url.workspace = true
 backon.workspace = true
 metrics.workspace = true
+zeroize.workspace = true
 thiserror.workspace = true
 tracing = { workspace = true, features = ["std"] }
 tokio = { workspace = true, features = ["sync", "time"] }

--- a/crates/utilities/tx-manager/README.md
+++ b/crates/utilities/tx-manager/README.md
@@ -208,7 +208,7 @@ use base_tx_manager::{BaseTxMetrics, SignerConfig, SimpleTxManager, TxCandidate,
 
 // Create a SimpleTxManager with a provider, signer config, and tx-manager config.
 let provider = RootProvider::new_http("http://localhost:8545".parse()?);
-let signer_config = SignerConfig::Local { private_key: B256::repeat_byte(0x01) };
+let signer_config = SignerConfig::local(B256::repeat_byte(0x01));
 let config = TxManagerConfig::default();
 let chain_id = 1;
 let manager = SimpleTxManager::new(provider, signer_config, config, chain_id, Arc::new(BaseTxMetrics::new("my_service"))).await?;

--- a/crates/utilities/tx-manager/src/signer_config.rs
+++ b/crates/utilities/tx-manager/src/signer_config.rs
@@ -69,11 +69,8 @@ impl SignerConfig {
     pub fn build_wallet(self) -> Result<EthereumWallet, TxManagerError> {
         match self {
             Self::Local { private_key } => {
-                let mut key = B256::new(*private_key);
-                let result = PrivateKeySigner::from_bytes(&key);
-                key.0.zeroize();
-                let signer =
-                    result.map_err(|e| TxManagerError::WalletConstruction(e.to_string()))?;
+                let signer = PrivateKeySigner::from_slice(&*private_key)
+                    .map_err(|e| TxManagerError::WalletConstruction(e.to_string()))?;
                 Ok(EthereumWallet::new(signer))
             }
             Self::Remote { endpoint, address } => {

--- a/crates/utilities/tx-manager/src/signer_config.rs
+++ b/crates/utilities/tx-manager/src/signer_config.rs
@@ -7,7 +7,7 @@ use alloy_primitives::{Address, B256};
 use alloy_signer_local::PrivateKeySigner;
 use base_alloy_signer::RemoteSigner;
 use url::Url;
-use zeroize::Zeroizing;
+use zeroize::{Zeroize, Zeroizing};
 
 use crate::TxManagerError;
 
@@ -54,8 +54,10 @@ impl SignerConfig {
     ///
     /// The key bytes are wrapped in [`Zeroizing`] internally so callers do not
     /// need to depend on the `zeroize` crate.
-    pub fn local(private_key: B256) -> Self {
-        Self::Local { private_key: Zeroizing::new(private_key.0) }
+    pub fn local(mut private_key: B256) -> Self {
+        let config = Self::Local { private_key: Zeroizing::new(private_key.0) };
+        private_key.0.zeroize();
+        config
     }
 
     /// Builds an [`EthereumWallet`] from this configuration.
@@ -67,8 +69,11 @@ impl SignerConfig {
     pub fn build_wallet(self) -> Result<EthereumWallet, TxManagerError> {
         match self {
             Self::Local { private_key } => {
-                let signer = PrivateKeySigner::from_bytes(&B256::new(*private_key))
-                    .map_err(|e| TxManagerError::WalletConstruction(e.to_string()))?;
+                let mut key = B256::new(*private_key);
+                let result = PrivateKeySigner::from_bytes(&key);
+                key.0.zeroize();
+                let signer =
+                    result.map_err(|e| TxManagerError::WalletConstruction(e.to_string()))?;
                 Ok(EthereumWallet::new(signer))
             }
             Self::Remote { endpoint, address } => {

--- a/crates/utilities/tx-manager/src/signer_config.rs
+++ b/crates/utilities/tx-manager/src/signer_config.rs
@@ -7,6 +7,7 @@ use alloy_primitives::{Address, B256};
 use alloy_signer_local::PrivateKeySigner;
 use base_alloy_signer::RemoteSigner;
 use url::Url;
+use zeroize::Zeroizing;
 
 use crate::TxManagerError;
 
@@ -17,9 +18,12 @@ use crate::TxManagerError;
 /// sites do not need to duplicate private-key parsing or remote-signer setup.
 pub enum SignerConfig {
     /// Local signer backed by a raw secp256k1 private key.
+    ///
+    /// The key bytes are wrapped in [`Zeroizing`] so they are securely erased
+    /// from memory when this variant is dropped.
     Local {
-        /// The 32-byte private key.
-        private_key: B256,
+        /// The 32-byte private key, zeroized on drop.
+        private_key: Zeroizing<[u8; 32]>,
     },
     /// Remote signer sidecar via `eth_signTransaction` JSON-RPC.
     Remote {
@@ -46,6 +50,14 @@ impl fmt::Debug for SignerConfig {
 }
 
 impl SignerConfig {
+    /// Creates a [`Local`](Self::Local) signer config from a raw private key.
+    ///
+    /// The key bytes are wrapped in [`Zeroizing`] internally so callers do not
+    /// need to depend on the `zeroize` crate.
+    pub fn local(private_key: B256) -> Self {
+        Self::Local { private_key: Zeroizing::new(private_key.0) }
+    }
+
     /// Builds an [`EthereumWallet`] from this configuration.
     ///
     /// # Errors
@@ -55,7 +67,7 @@ impl SignerConfig {
     pub fn build_wallet(self) -> Result<EthereumWallet, TxManagerError> {
         match self {
             Self::Local { private_key } => {
-                let signer = PrivateKeySigner::from_bytes(&private_key)
+                let signer = PrivateKeySigner::from_bytes(&B256::new(*private_key))
                     .map_err(|e| TxManagerError::WalletConstruction(e.to_string()))?;
                 Ok(EthereumWallet::new(signer))
             }
@@ -75,14 +87,13 @@ mod tests {
     #[test]
     fn local_valid_key_produces_wallet() {
         // Use a well-known non-zero private key.
-        let key = B256::repeat_byte(0x01);
-        let config = SignerConfig::Local { private_key: key };
+        let config = SignerConfig::local(B256::repeat_byte(0x01));
         assert!(config.build_wallet().is_ok());
     }
 
     #[test]
     fn local_zero_key_returns_error() {
-        let config = SignerConfig::Local { private_key: B256::ZERO };
+        let config = SignerConfig::local(B256::ZERO);
         let err = config.build_wallet().expect_err("zero key should fail");
         assert!(
             matches!(err, TxManagerError::WalletConstruction(_)),

--- a/crates/utilities/tx-manager/tests/craft_tx.rs
+++ b/crates/utilities/tx-manager/tests/craft_tx.rs
@@ -362,8 +362,7 @@ async fn new_with_signer_config_local_creates_functional_manager() {
     let anvil = Anvil::new().spawn();
     let provider = RootProvider::new_http(anvil.endpoint_url());
     let private_key = anvil.keys()[0].clone();
-    let signer_config =
-        SignerConfig::local(B256::from_slice(&private_key.to_bytes()));
+    let signer_config = SignerConfig::local(B256::from_slice(&private_key.to_bytes()));
     let manager = SimpleTxManager::new(
         provider,
         signer_config,

--- a/crates/utilities/tx-manager/tests/craft_tx.rs
+++ b/crates/utilities/tx-manager/tests/craft_tx.rs
@@ -363,7 +363,7 @@ async fn new_with_signer_config_local_creates_functional_manager() {
     let provider = RootProvider::new_http(anvil.endpoint_url());
     let private_key = anvil.keys()[0].clone();
     let signer_config =
-        SignerConfig::Local { private_key: B256::from_slice(&private_key.to_bytes()) };
+        SignerConfig::local(B256::from_slice(&private_key.to_bytes()));
     let manager = SimpleTxManager::new(
         provider,
         signer_config,


### PR DESCRIPTION
### What changed? Why?

Wraps the private key bytes in `SignerConfig::Local` with `Zeroizing<[u8; 32]>` (from the `zeroize` crate) so that key material is securely erased from memory when the signer config is dropped. This prevents private keys from lingering in memory after use.

Key changes:
- Changed `SignerConfig::Local { private_key: B256 }` to store `Zeroizing<[u8; 32]>` instead
- Added a `SignerConfig::local(B256)` constructor that copies the key into `Zeroizing` and immediately zeroizes the source `B256`
- Migrated all call sites (batcher service, tests, README) from direct struct construction to the new `local()` constructor
- Updated `build_wallet` to use `from_slice` instead of `from_bytes` to work with the new wrapped type

### Notes to reviewers

The `local()` constructor zeroizes the caller's `B256` after copying into `Zeroizing`, so the key exists in plaintext only inside the `Zeroizing` wrapper going forward.

### How has it been tested?

Existing unit tests updated and passing (`local_valid_key_produces_wallet`, `local_zero_key_returns_error`, `new_with_signer_config_local_creates_functional_manager`).

### Change management ([definitions](http://go/change-management))

type=routine<!--routine,nonroutine,emergency-->
risk=low<!--low,medium,high-->
impact=sev5<!--sev5,sev4,sev3,sev2,sev1-->

### Backwards Compatibility ([learn more](http://go/backwards-compatibility))

backwards_compatible=true<!-- true false -->

<!-- Automatically merge your PR once the necessary approvals have been received (you probably want this) -->

automerge=false