### PR TITLE
refactor(builder): consolidate flashblock timing and remove dead config

### DIFF
--- a/bin/builder/src/cli.rs
+++ b/bin/builder/src/cli.rs
@@ -25,13 +25,6 @@ pub struct FlashblocksArgs {
     /// flashblock block time in milliseconds
     #[arg(long = "flashblocks.block-time", default_value = "250", env = "FLASHBLOCK_BLOCK_TIME")]
     pub flashblocks_block_time: u64,
-
-    /// Time by which blocks would be completed earlier in milliseconds.
-    ///
-    /// This time is used to account for latencies and would be deducted from total block
-    /// building time before calculating number of fbs.
-    #[arg(long = "flashblocks.leeway-time", default_value = "75", env = "FLASHBLOCK_LEEWAY_TIME")]
-    pub flashblocks_leeway_time: u64,
 }
 
 impl Default for FlashblocksArgs {
@@ -40,7 +33,6 @@ impl Default for FlashblocksArgs {
             flashblocks_port: 1111,
             flashblocks_addr: "127.0.0.1".to_string(),
             flashblocks_block_time: 250,
-            flashblocks_leeway_time: 75,
         }
     }
 }
@@ -81,10 +73,6 @@ pub struct Args {
     #[arg(long = "builder.execution-metering-mode", value_enum, default_value = "off")]
     pub execution_metering_mode: ExecutionMeteringMode,
 
-    /// How much extra time to wait for the block building job to complete and not get garbage collected
-    #[arg(long = "builder.extra-block-deadline-secs", default_value = "20")]
-    pub extra_block_deadline_secs: u64,
-
     /// Whether to enable TIPS Resource Metering
     #[arg(long = "builder.enable-resource-metering", default_value = "false")]
     pub enable_resource_metering: bool,
@@ -96,10 +84,6 @@ pub struct Args {
     /// Buffer size for tx data store (LRU eviction when full)
     #[arg(long = "builder.tx-data-store-buffer-size", default_value = "10000")]
     pub tx_data_store_buffer_size: usize,
-
-    /// Inverted sampling frequency in blocks. 1 - each block, 100 - every 100th block.
-    #[arg(long = "telemetry.sampling-ratio", env = "SAMPLING_RATIO", default_value = "100")]
-    pub sampling_ratio: u64,
 
     /// Flashblocks configuration
     #[command(flatten)]
@@ -127,11 +111,9 @@ impl Default for Args {
             flashblock_execution_time_budget_us: None,
             block_state_root_time_budget_us: None,
             execution_metering_mode: ExecutionMeteringMode::Off,
-            extra_block_deadline_secs: 20,
             enable_resource_metering: false,
             max_uncompressed_block_size: None,
             tx_data_store_buffer_size: 10000,
-            sampling_ratio: 100,
             flashblocks: FlashblocksArgs::default(),
         }
     }
@@ -152,15 +134,10 @@ impl Args {
 
         Ok(BuilderConfig {
             block_time: Duration::from_millis(self.chain_block_time),
-            block_time_leeway: Duration::from_secs(self.extra_block_deadline_secs),
             da_config: Default::default(),
             gas_limit_config: Default::default(),
-            sampling_ratio: self.sampling_ratio,
             flashblocks_ws_addr,
             flashblocks_interval: Duration::from_millis(self.flashblocks.flashblocks_block_time),
-            flashblocks_leeway_time: Duration::from_millis(
-                self.flashblocks.flashblocks_leeway_time,
-            ),
             max_gas_per_txn: self.max_gas_per_txn,
             max_execution_time_per_tx_us: self.max_execution_time_per_tx_us,
             max_state_root_time_per_tx_us: self.max_state_root_time_per_tx_us,
@@ -215,16 +192,6 @@ mod tests {
     }
 
     #[rstest]
-    #[case::leeway_30s(30, 30)]
-    #[case::leeway_10s(10, 10)]
-    #[case::leeway_0s(0, 0)]
-    fn extra_block_deadline_maps_to_leeway(#[case] input_secs: u64, #[case] expected_secs: u64) {
-        let args = Args { extra_block_deadline_secs: input_secs, ..Default::default() };
-        let config = convert(args);
-        assert_eq!(config.block_time_leeway, Duration::from_secs(expected_secs));
-    }
-
-    #[rstest]
     #[case::interval_500ms(500, 500)]
     #[case::interval_200ms(200, 200)]
     #[case::interval_250ms(250, 250)]
@@ -275,20 +242,13 @@ mod tests {
         let args = Args {
             chain_block_time: 2000,
             max_gas_per_txn: Some(100000),
-            extra_block_deadline_secs: 10,
-            flashblocks: FlashblocksArgs {
-                flashblocks_block_time: 200,
-                flashblocks_leeway_time: 50,
-                ..Default::default()
-            },
+            flashblocks: FlashblocksArgs { flashblocks_block_time: 200, ..Default::default() },
             ..Default::default()
         };
         let config = convert(args);
 
         assert_eq!(config.block_time, Duration::from_millis(2000));
         assert_eq!(config.max_gas_per_txn, Some(100000));
-        assert_eq!(config.block_time_leeway, Duration::from_secs(10));
         assert_eq!(config.flashblocks_interval, Duration::from_millis(200));
-        assert_eq!(config.flashblocks_leeway_time, Duration::from_millis(50));
     }
 }

--- a/crates/builder/core/src/config.rs
+++ b/crates/builder/core/src/config.rs
@@ -25,22 +25,12 @@ pub struct BuilderConfig {
     /// Gas limit configuration for the payload builder
     pub gas_limit_config: OpGasLimitConfig,
 
-    /// Extra time allowed for payload building before garbage collection.
-    pub block_time_leeway: Duration,
-
-    /// Inverted sampling frequency in blocks. 1 - each block, 100 - every 100th block.
-    pub sampling_ratio: u64,
-
     /// The address of the websockets endpoint that listens for subscriptions to
     /// new flashblocks updates.
     pub flashblocks_ws_addr: SocketAddr,
 
     /// How often a flashblock is produced. This is independent of the block time of the chain.
     pub flashblocks_interval: Duration,
-
-    /// How much time would be deducted from block build time to account for latencies.
-    /// This value would be deducted from first flashblock and it shouldn't be more than interval.
-    pub flashblocks_leeway_time: Duration,
 
     /// Maximum gas a transaction can use before being excluded.
     pub max_gas_per_txn: Option<u64>,
@@ -81,13 +71,10 @@ impl core::fmt::Debug for BuilderConfig {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         f.debug_struct("Config")
             .field("block_time", &self.block_time)
-            .field("block_time_leeway", &self.block_time_leeway)
             .field("da_config", &self.da_config)
             .field("gas_limit_config", &self.gas_limit_config)
-            .field("sampling_ratio", &self.sampling_ratio)
             .field("flashblocks_ws_addr", &self.flashblocks_ws_addr)
             .field("flashblocks_interval", &self.flashblocks_interval)
-            .field("flashblocks_leeway_time", &self.flashblocks_leeway_time)
             .field("max_gas_per_txn", &self.max_gas_per_txn)
             .field("max_execution_time_per_tx_us", &self.max_execution_time_per_tx_us)
             .field("max_state_root_time_per_tx_us", &self.max_state_root_time_per_tx_us)
@@ -104,13 +91,10 @@ impl Default for BuilderConfig {
     fn default() -> Self {
         Self {
             block_time: Duration::from_secs(2),
-            block_time_leeway: Duration::from_millis(500),
             da_config: OpDAConfig::default(),
             gas_limit_config: OpGasLimitConfig::default(),
             flashblocks_ws_addr: SocketAddr::new(Ipv4Addr::UNSPECIFIED.into(), 1111),
             flashblocks_interval: Duration::from_millis(250),
-            flashblocks_leeway_time: Duration::from_millis(50),
-            sampling_ratio: 100,
             max_gas_per_txn: None,
             max_execution_time_per_tx_us: None,
             max_state_root_time_per_tx_us: None,
@@ -130,7 +114,6 @@ impl BuilderConfig {
         Self {
             flashblocks_ws_addr: SocketAddr::new(Ipv4Addr::LOCALHOST.into(), 0),
             flashblocks_interval: Duration::from_millis(200),
-            flashblocks_leeway_time: Duration::from_millis(100),
             block_time: Duration::from_secs(1),
             ..Self::default()
         }
@@ -147,13 +130,6 @@ impl BuilderConfig {
     #[must_use]
     pub const fn with_max_gas_per_txn(mut self, max_gas: Option<u64>) -> Self {
         self.max_gas_per_txn = max_gas;
-        self
-    }
-
-    /// Sets the flashblocks leeway time in milliseconds.
-    #[must_use]
-    pub const fn with_flashblocks_leeway_time_ms(mut self, ms: u64) -> Self {
-        self.flashblocks_leeway_time = Duration::from_millis(ms);
         self
     }
 

--- a/crates/builder/core/src/flashblocks/context.rs
+++ b/crates/builder/core/src/flashblocks/context.rs
@@ -78,48 +78,16 @@ pub struct FlashblocksExtraCtx {
     pub flashblock_index: u64,
     /// Target flashblock count per block
     pub target_flashblock_count: u64,
-    /// Total gas left for the current flashblock
-    pub target_gas_for_batch: u64,
-    /// Total DA bytes left for the current flashblock
-    pub target_da_for_batch: Option<u64>,
-    /// Total DA footprint left for the current flashblock
-    pub target_da_footprint_for_batch: Option<u64>,
     /// Target execution time for the current flashblock in microseconds
     pub target_execution_time_for_batch_us: Option<u128>,
-    /// Target state root time for the current flashblock in microseconds
-    pub target_state_root_time_for_batch_us: Option<u128>,
-    /// Gas limit per flashblock
-    pub gas_per_batch: u64,
-    /// DA bytes limit per flashblock
-    pub da_per_batch: Option<u64>,
-    /// DA footprint limit per flashblock
-    pub da_footprint_per_batch: Option<u64>,
-    /// Execution time limit per flashblock in microseconds
-    pub execution_time_per_batch_us: Option<u128>,
-    /// State root time limit per flashblock in microseconds
-    pub state_root_time_per_batch_us: Option<u128>,
 }
 
 impl FlashblocksExtraCtx {
-    /// Creates the next flashblock context with updated gas and DA targets.
-    ///
-    /// Increments the flashblock index and sets new target limits for the
-    /// next flashblock batch iteration.
-    pub const fn next(
-        self,
-        target_gas_for_batch: u64,
-        target_da_for_batch: Option<u64>,
-        target_da_footprint_for_batch: Option<u64>,
-        target_execution_time_for_batch_us: Option<u128>,
-        target_state_root_time_for_batch_us: Option<u128>,
-    ) -> Self {
+    /// Creates the next flashblock context with an incremented index.
+    pub const fn next(self, target_execution_time_for_batch_us: Option<u128>) -> Self {
         Self {
             flashblock_index: self.flashblock_index + 1,
-            target_gas_for_batch,
-            target_da_for_batch,
-            target_da_footprint_for_batch,
             target_execution_time_for_batch_us,
-            target_state_root_time_for_batch_us,
             ..self
         }
     }

--- a/crates/builder/core/src/flashblocks/generator.rs
+++ b/crates/builder/core/src/flashblocks/generator.rs
@@ -6,9 +6,7 @@ use std::{
 use alloy_primitives::B256;
 use futures::{Future, FutureExt};
 use parking_lot::Mutex;
-use reth_basic_payload_builder::{
-    BasicPayloadJobGeneratorConfig, HeaderForPayload, PayloadConfig, PrecachedState,
-};
+use reth_basic_payload_builder::{HeaderForPayload, PayloadConfig, PrecachedState};
 use reth_node_api::{NodePrimitives, PayloadBuilderAttributes, PayloadKind};
 use reth_payload_builder::{
     KeepPayloadJobAlive, PayloadBuilderError, PayloadJob, PayloadJobGenerator,
@@ -34,8 +32,6 @@ pub struct BlockPayloadJobGenerator<Client, Tasks, Builder> {
     client: Client,
     /// How to spawn building tasks
     executor: Tasks,
-    /// The configuration for the job generator.
-    _config: BasicPayloadJobGeneratorConfig,
     /// The type responsible for building payloads.
     ///
     /// See [`PayloadBuilder`]
@@ -44,8 +40,7 @@ pub struct BlockPayloadJobGenerator<Client, Tasks, Builder> {
     ensure_only_one_payload: bool,
     /// The last payload being processed
     last_payload: Arc<Mutex<CancellationToken>>,
-    /// The extra block deadline in seconds
-    extra_block_deadline: std::time::Duration,
+    block_time: std::time::Duration,
     /// Stored `cached_reads` for new payload jobs.
     pre_cached: Option<PrecachedState>,
 }
@@ -58,19 +53,17 @@ impl<Client, Tasks, Builder> BlockPayloadJobGenerator<Client, Tasks, Builder> {
     pub fn with_builder(
         client: Client,
         executor: Tasks,
-        config: BasicPayloadJobGeneratorConfig,
         builder: Builder,
         ensure_only_one_payload: bool,
-        extra_block_deadline: std::time::Duration,
+        block_time: std::time::Duration,
     ) -> Self {
         Self {
             client,
             executor,
-            _config: config,
             builder,
             ensure_only_one_payload,
             last_payload: Arc::new(Mutex::new(CancellationToken::new())),
-            extra_block_deadline,
+            block_time,
             pre_cached: None,
         }
     }
@@ -146,11 +139,19 @@ where
         // sequencer would send an avalanche of FCUs/getBlockByNumber on
         // each batcher update (with 10m channel it's ~800 FCUs at once).
         // At such moment it can happen that the time b/w FCU and ensuing
-        // getPayload would be on the scale of ~2.5s. Therefore we should
-        // "remember" the payloads long enough to accommodate this corner-case
-        // (without it we are losing blocks). Postponing the deadline for 5s
-        // (not just 0.5s) because of that.
-        let deadline = job_deadline(attributes.timestamp()) + self.extra_block_deadline;
+        // getPayload would be on the scale of ~2.5s. We add `block_time`
+        // (typically 2s) beyond the target timestamp to accommodate this
+        // corner-case without losing blocks.
+        let deadline = match SystemTime::now().duration_since(UNIX_EPOCH) {
+            Ok(d) => {
+                let duration_until = attributes.timestamp().saturating_sub(d.as_secs()).max(1);
+                Duration::from_secs(duration_until) + self.block_time
+            }
+            Err(e) => {
+                warn!(error = %e, "System clock went backward, using block-time deadline");
+                self.block_time
+            }
+        };
 
         let deadline = Box::pin(tokio::time::sleep(deadline));
 
@@ -451,26 +452,6 @@ impl<T: Clone> Default for BlockCell<T> {
     }
 }
 
-fn job_deadline(unix_timestamp_secs: u64) -> std::time::Duration {
-    let unix_now = match SystemTime::now().duration_since(UNIX_EPOCH) {
-        Ok(d) => d.as_secs(),
-        Err(e) => {
-            warn!(error = %e, "System clock went backward, returning zero deadline");
-            return Duration::ZERO;
-        }
-    };
-
-    // Safe subtraction that handles the case where timestamp is in the past
-    let duration_until = unix_timestamp_secs.saturating_sub(unix_now);
-
-    if duration_until == 0 {
-        // Enforce a minimum block time of 1 second by rounding up any duration less than 1 second
-        Duration::from_secs(1)
-    } else {
-        Duration::from_secs(duration_until)
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use alloy_eips::eip7685::Requests;
@@ -645,34 +626,11 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_job_deadline() {
-        // Test future deadline
-        let now = SystemTime::now().duration_since(UNIX_EPOCH).unwrap();
-        let future_timestamp = now + Duration::from_secs(2);
-        // 2 seconds from now
-        let deadline = job_deadline(future_timestamp.as_secs());
-        assert!(deadline <= Duration::from_secs(2));
-        assert!(deadline > Duration::from_secs(0));
-
-        // Test past deadline
-        let past_timestamp = now - Duration::from_secs(10);
-        let deadline = job_deadline(past_timestamp.as_secs());
-        // Should default to 1 second when timestamp is in the past
-        assert_eq!(deadline, Duration::from_secs(1));
-
-        // Test current timestamp
-        let deadline = job_deadline(now.as_secs());
-        // Should use 1 second when timestamp is current
-        assert_eq!(deadline, Duration::from_secs(1));
-    }
-
-    #[tokio::test]
     async fn test_payload_generator() -> eyre::Result<()> {
         let mut rng = rng();
 
         let client = MockEthProvider::default();
         let executor = TokioTaskExecutor::default();
-        let config = BasicPayloadJobGeneratorConfig::default();
         let builder = MockBuilder::<OpPrimitives>::new();
 
         let (start, count) = (1, 10);
@@ -687,7 +645,6 @@ mod tests {
         let generator = BlockPayloadJobGenerator::with_builder(
             client.clone(),
             executor,
-            config,
             builder.clone(),
             false,
             std::time::Duration::from_secs(1),

--- a/crates/builder/core/src/flashblocks/mod.rs
+++ b/crates/builder/core/src/flashblocks/mod.rs
@@ -18,6 +18,9 @@ pub use handler::PayloadHandler;
 mod context;
 pub use context::{FlashblocksExtraCtx, OpPayloadBuilderCtx};
 
+mod schedule;
+pub use schedule::FlashblockSchedule;
+
 mod payload;
 pub use payload::FlashblocksExecutionInfo;
 

--- a/crates/builder/core/src/flashblocks/payload.rs
+++ b/crates/builder/core/src/flashblocks/payload.rs
@@ -1,8 +1,7 @@
 use core::time::Duration;
 use std::{
-    ops::{Div, Rem},
     sync::Arc,
-    time::Instant,
+    time::{Instant, SystemTime, UNIX_EPOCH},
 };
 
 use alloy_consensus::{
@@ -49,12 +48,11 @@ use tracing::{debug, error, info, metadata::Level, span, warn};
 use crate::{
     BuilderConfig, ExecutionInfo, PayloadBuilder, ResourceLimits,
     flashblocks::{
-        FlashblocksExtraCtx,
+        FlashblockSchedule, FlashblocksExtraCtx,
         best_txs::BestFlashblocksTxs,
         context::OpPayloadBuilderCtx,
         generator::{BlockCell, BuildArguments},
     },
-    metrics::BuilderMetrics,
     traits::{ClientBounds, PoolBounds},
 };
 
@@ -70,6 +68,8 @@ type NextBestFlashblocksTxs<Pool> = BestFlashblocksTxs<
             >,
     >,
 >;
+
+const SPAN_SAMPLING_RATIO: u64 = 100;
 
 /// Execution information specific to flashblocks.
 ///
@@ -101,8 +101,6 @@ pub(super) struct OpPayloadBuilder<Pool, Client> {
     pub ws_pub: Arc<WebSocketPublisher>,
     /// System configuration for the builder
     pub config: BuilderConfig,
-    /// The metrics for the builder
-    pub metrics: Arc<BuilderMetrics>,
 }
 
 impl<Pool, Client> OpPayloadBuilder<Pool, Client> {
@@ -114,9 +112,8 @@ impl<Pool, Client> OpPayloadBuilder<Pool, Client> {
         config: BuilderConfig,
         payload_tx: mpsc::Sender<OpBuiltPayload>,
         ws_pub: Arc<WebSocketPublisher>,
-        metrics: Arc<BuilderMetrics>,
     ) -> Self {
-        Self { evm_config, pool, client, payload_tx, ws_pub, config, metrics }
+        Self { evm_config, pool, client, payload_tx, ws_pub, config }
     }
 }
 
@@ -230,8 +227,7 @@ where
             publish_guard,
         } = args;
 
-        // We log only every Nth block based on sampling ratio to reduce usage
-        let span = if config.parent_header.number.is_multiple_of(self.config.sampling_ratio) {
+        let span = if config.parent_header.number.is_multiple_of(SPAN_SAMPLING_RATIO) {
             span!(Level::INFO, "build_payload")
         } else {
             tracing::Span::none()
@@ -239,7 +235,6 @@ where
         let _entered = span.enter();
         span.record("payload_id", config.attributes.payload_attributes.id.to_string());
 
-        let timestamp = config.attributes.timestamp();
         let mut ctx = self
             .get_op_payload_builder_ctx(
                 config,
@@ -264,9 +259,19 @@ where
         ctx.metrics.sequencer_tx_duration.record(sequencer_tx_time);
         ctx.metrics.sequencer_tx_gauge.set(sequencer_tx_time);
 
-        // We adjust our flashblocks timings based on time_drift if dynamic adjustment enable
-        let (flashblocks_per_block, first_flashblock_offset) =
-            self.calculate_flashblocks(timestamp);
+        // Compute flashblock schedule from target block timestamp.
+        // Capture the deadline as a single Instant so the same schedule is
+        // used for both the early-exit gate and the main build loop.
+        let timestamp = ctx.attributes().timestamp();
+        let target_time = UNIX_EPOCH + Duration::from_secs(timestamp);
+        let available_time = target_time
+            .duration_since(SystemTime::now())
+            .map_or(Duration::ZERO, |duration| duration.min(self.config.block_time));
+        let deadline = Instant::now() + available_time;
+        let schedule = FlashblockSchedule::new(deadline, self.config.flashblocks_interval);
+        let now = Instant::now();
+        let flashblocks_per_block =
+            if schedule.should_build_next(now) { schedule.remaining_count(now) } else { 0 };
 
         let skip_flashblocks_building = ctx.attributes().no_tx_pool || flashblocks_per_block == 0;
 
@@ -291,13 +296,6 @@ where
             let flashblock_byte_size =
                 self.ws_pub.publish(&fb_payload).map_err(PayloadBuilderError::other)?;
             ctx.metrics.flashblock_byte_size_histogram.record(flashblock_byte_size as f64);
-            ctx.metrics
-                .first_flashblock_time_offset
-                .record(first_flashblock_offset.as_millis() as f64);
-            ctx.metrics
-                .reduced_flashblocks_number
-                .record(self.config.flashblocks_per_block().saturating_sub(flashblocks_per_block)
-                    as f64);
         } else {
             info!(
                 target: "payload_builder",
@@ -332,7 +330,10 @@ where
 
             return Ok(());
         }
-
+        let now = Instant::now();
+        let flashblocks_per_block =
+            if schedule.should_build_next(now) { schedule.remaining_count(now) } else { 0 };
+        let first_flashblock_offset = schedule.interval();
         info!(
             target: "payload_builder",
             message = "Performed flashblocks timing derivation",
@@ -340,34 +341,35 @@ where
             first_flashblock_offset = first_flashblock_offset.as_millis(),
             flashblocks_interval = self.config.flashblocks_interval.as_millis(),
         );
+        ctx.metrics.reduced_flashblocks_number.record(
+            self.config.flashblocks_per_block().saturating_sub(flashblocks_per_block) as f64,
+        );
+        ctx.metrics.first_flashblock_time_offset.record(first_flashblock_offset.as_millis() as f64);
 
-        let gas_per_batch = ctx.block_gas_limit() / flashblocks_per_block;
-        let da_per_batch = ctx
-            .builder_config
-            .da_config
-            .max_da_block_size()
-            .map(|da_limit| da_limit / flashblocks_per_block);
-        let da_footprint_per_batch =
-            info.da_footprint_scalar.map(|_| ctx.block_gas_limit() / flashblocks_per_block);
-        let execution_time_per_batch_us = ctx.builder_config.flashblock_execution_time_budget_us;
-        let state_root_time_per_batch_us = ctx
-            .builder_config
-            .block_state_root_time_budget_us
-            .map(|budget| budget / flashblocks_per_block as u128);
+        // Time may have expired during fallback block build; skip flashblock loop.
+        if flashblocks_per_block == 0 {
+            self.record_flashblocks_metrics(
+                &ctx,
+                &info,
+                flashblocks_per_block,
+                &span,
+                "Time expired during fallback block build, building 0 flashblocks",
+            );
+
+            finalized_cell.set(payload);
+            let total_block_building_time = block_build_start_time.elapsed();
+            ctx.metrics.total_block_built_duration.record(total_block_building_time);
+            ctx.metrics.total_block_built_gauge.set(total_block_building_time);
+
+            return Ok(());
+        }
 
         let extra = FlashblocksExtraCtx {
             flashblock_index: 1,
             target_flashblock_count: flashblocks_per_block,
-            target_gas_for_batch: gas_per_batch,
-            target_da_for_batch: da_per_batch,
-            target_da_footprint_for_batch: da_footprint_per_batch,
-            target_execution_time_for_batch_us: execution_time_per_batch_us,
-            target_state_root_time_for_batch_us: state_root_time_per_batch_us,
-            gas_per_batch,
-            da_per_batch,
-            da_footprint_per_batch,
-            execution_time_per_batch_us,
-            state_root_time_per_batch_us,
+            target_execution_time_for_batch_us: ctx
+                .builder_config
+                .flashblock_execution_time_budget_us,
         };
 
         let mut fb_cancel = block_cancel.child_token();
@@ -455,6 +457,7 @@ where
                     &publish_guard,
                     &fb_span,
                     &mut executed_sender_nonces,
+                    &schedule,
                 )
                 .await
             {
@@ -516,13 +519,30 @@ where
         publish_guard: &parking_lot::Mutex<()>,
         span: &tracing::Span,
         executed_sender_nonces: &mut HashMap<Address, u64>,
+        schedule: &FlashblockSchedule,
     ) -> eyre::Result<Option<FlashblocksExtraCtx>> {
         let flashblock_index = ctx.flashblock_index();
-        let target_gas_for_batch = ctx.extra.target_gas_for_batch;
-        let mut target_da_for_batch = ctx.extra.target_da_for_batch;
-        let mut target_da_footprint_for_batch = ctx.extra.target_da_footprint_for_batch;
-        let mut target_state_root_time_for_batch_us = ctx.extra.target_state_root_time_for_batch_us;
-        let flashblock_execution_time_limit_us = ctx.extra.execution_time_per_batch_us;
+        let now = Instant::now();
+        let remaining_flashblocks = schedule.remaining_count(now).max(1);
+        let remaining_gas = ctx.block_gas_limit().saturating_sub(info.cumulative_gas_used);
+        let target_gas_for_batch =
+            info.cumulative_gas_used + (remaining_gas / remaining_flashblocks);
+        let target_da_for_batch = ctx.builder_config.da_config.max_da_block_size().map(|max| {
+            let remaining_da = max.saturating_sub(info.cumulative_da_bytes_used);
+            info.cumulative_da_bytes_used + (remaining_da / remaining_flashblocks)
+        });
+        let target_da_footprint_for_batch = info.da_footprint_scalar.map(|_| {
+            let remaining_footprint =
+                ctx.block_gas_limit().saturating_sub(info.cumulative_gas_used);
+            info.cumulative_gas_used + (remaining_footprint / remaining_flashblocks)
+        });
+        let target_state_root_time_for_batch_us =
+            ctx.builder_config.block_state_root_time_budget_us.map(|budget| {
+                let remaining_time = budget.saturating_sub(info.cumulative_state_root_time_us);
+                info.cumulative_state_root_time_us
+                    + (remaining_time / remaining_flashblocks as u128)
+            });
+        let flashblock_execution_time_limit_us = ctx.extra.target_execution_time_for_batch_us;
         let block_state_root_time_limit_us = target_state_root_time_for_batch_us;
 
         info!(
@@ -689,39 +709,8 @@ where
                     .flashblock_num_tx_histogram
                     .record(info.executed_transactions.len() as f64);
 
-                // Update bundle_state for next iteration
-                if let Some(da_limit) = ctx.extra.da_per_batch {
-                    if let Some(da) = target_da_for_batch.as_mut() {
-                        *da += da_limit;
-                    } else {
-                        error!(
-                            "Builder end up in faulty invariant, if da_per_batch is set then total_da_per_batch must be set"
-                        );
-                    }
-                }
-
-                let target_gas_for_batch = ctx.extra.target_gas_for_batch + ctx.extra.gas_per_batch;
-
-                if let (Some(footprint), Some(da_footprint_limit)) =
-                    (target_da_footprint_for_batch.as_mut(), ctx.extra.da_footprint_per_batch)
-                {
-                    *footprint += da_footprint_limit;
-                }
-
-                if let (Some(time), Some(time_per_batch)) = (
-                    target_state_root_time_for_batch_us.as_mut(),
-                    ctx.extra.state_root_time_per_batch_us,
-                ) {
-                    *time += time_per_batch;
-                }
-
-                let next_extra = ctx.extra.clone().next(
-                    target_gas_for_batch,
-                    target_da_for_batch,
-                    target_da_footprint_for_batch,
-                    ctx.extra.execution_time_per_batch_us,
-                    target_state_root_time_for_batch_us,
-                );
+                let next_extra =
+                    ctx.extra.clone().next(ctx.extra.target_execution_time_for_batch_us);
 
                 info!(
                     target: "payload_builder",
@@ -803,48 +792,6 @@ where
         finalized_cell.set(final_payload);
 
         Ok(())
-    }
-
-    /// Calculate number of flashblocks, taking time drift into account.
-    pub(super) fn calculate_flashblocks(&self, timestamp: u64) -> (u64, Duration) {
-        // We use this system time to determine remaining time to build a block
-        // Things to consider:
-        // FCU(a) - FCU with attributes
-        // FCU(a) could arrive with `block_time - fb_time < delay`. In this case we could only produce 1 flashblock
-        // FCU(a) could arrive with `delay < fb_time` - in this case we will shrink first flashblock
-        // FCU(a) could arrive with `fb_time < delay < block_time - fb_time` - in this case we will issue less flashblocks
-        let target_time = std::time::SystemTime::UNIX_EPOCH + Duration::from_secs(timestamp)
-            - self.config.flashblocks_leeway_time;
-        let now = std::time::SystemTime::now();
-        let Some(time_drift) =
-            target_time.duration_since(now).ok().filter(|duration| duration.as_millis() > 0)
-        else {
-            // in this case, we have no time to produce any flashblocks
-            return (0, Duration::ZERO);
-        };
-
-        self.metrics.flashblocks_time_drift.record(
-            self.config.block_time.as_millis().saturating_sub(time_drift.as_millis()) as f64,
-        );
-        debug!(
-            target: "payload_builder",
-            message = "Time drift for building round",
-            ?target_time,
-            time_drift = self.config.block_time.as_millis().saturating_sub(time_drift.as_millis()),
-            ?timestamp
-        );
-        // This is extra check to ensure that we would account at least for block time in case we have any timer discrepancies.
-        let time_drift = time_drift.min(self.config.block_time);
-        let interval = self.config.flashblocks_interval.as_millis() as u64;
-        let time_drift = time_drift.as_millis() as u64;
-        let first_flashblock_offset = time_drift.rem(interval);
-        if first_flashblock_offset == 0 {
-            // We have perfect division, so we use interval as first fb offset
-            (time_drift.div(interval), Duration::from_millis(interval))
-        } else {
-            // Non-perfect division, so we account for it.
-            (time_drift.div(interval) + 1, Duration::from_millis(first_flashblock_offset))
-        }
     }
 }
 

--- a/crates/builder/core/src/flashblocks/schedule.rs
+++ b/crates/builder/core/src/flashblocks/schedule.rs
@@ -1,0 +1,133 @@
+//! Flashblock timing schedule for deadline-based build pacing.
+//!
+//! [`FlashblockSchedule`] tracks how many flashblocks can still fit before the
+//! block deadline and provides budget-division helpers.  All time queries accept
+//! an explicit `now` parameter so callers can capture `Instant::now()` once and
+//! get consistent answers from both [`should_build_next`](FlashblockSchedule::should_build_next)
+//! and [`remaining_count`](FlashblockSchedule::remaining_count).
+
+use core::time::Duration;
+use std::time::Instant;
+
+/// Timing schedule for flashblock production within a single block.
+///
+/// Created once per block from the block deadline and the configured
+/// flashblock interval.  Methods that depend on the current time take an
+/// explicit `now: Instant` parameter to avoid TOCTOU inconsistencies.
+#[derive(Debug, Clone, Copy)]
+pub struct FlashblockSchedule {
+    deadline: Instant,
+    interval: Duration,
+}
+
+impl FlashblockSchedule {
+    /// Creates a new schedule.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `interval` is zero — a zero-interval schedule cannot
+    /// produce any flashblocks and indicates a configuration error.
+    pub fn new(deadline: Instant, interval: Duration) -> Self {
+        assert!(!interval.is_zero(), "flashblock interval must be non-zero");
+        Self { deadline, interval }
+    }
+
+    /// Returns `true` if there is enough time remaining to build at least
+    /// one more flashblock.
+    pub fn should_build_next(&self, now: Instant) -> bool {
+        now + self.interval <= self.deadline
+    }
+
+    /// Returns how many flashblocks can still be produced before the deadline.
+    ///
+    /// Uses ceiling division so that a partial remaining interval still counts
+    /// as one flashblock.  This means `remaining_count` may return `1` when
+    /// [`should_build_next`](Self::should_build_next) returns `false` (less
+    /// than a full interval remains).  Callers that enter a build loop should
+    /// gate on `should_build_next` first; callers that divide budgets use the
+    /// `.max(1)` at their call site to avoid division-by-zero.
+    pub fn remaining_count(&self, now: Instant) -> u64 {
+        let remaining = self.deadline.saturating_duration_since(now);
+        remaining.as_millis().div_ceil(self.interval.as_millis()) as u64
+    }
+
+    /// The configured flashblock interval.
+    pub const fn interval(&self) -> Duration {
+        self.interval
+    }
+
+    /// The absolute block deadline.
+    pub const fn deadline(&self) -> Instant {
+        self.deadline
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use core::time::Duration;
+    use std::time::Instant;
+
+    use super::FlashblockSchedule;
+
+    #[test]
+    fn test_normal_schedule() {
+        let now = Instant::now();
+        let schedule =
+            FlashblockSchedule::new(now + Duration::from_secs(2), Duration::from_millis(200));
+
+        assert!(schedule.should_build_next(now));
+        assert_eq!(schedule.remaining_count(now), 10);
+    }
+
+    #[test]
+    fn test_late_fcu() {
+        let now = Instant::now();
+        let schedule =
+            FlashblockSchedule::new(now + Duration::from_millis(800), Duration::from_millis(200));
+
+        assert!(schedule.should_build_next(now));
+        assert_eq!(schedule.remaining_count(now), 4);
+    }
+
+    #[test]
+    fn test_very_late_fcu() {
+        let now = Instant::now();
+        let schedule =
+            FlashblockSchedule::new(now + Duration::from_millis(100), Duration::from_millis(200));
+
+        assert!(!schedule.should_build_next(now));
+        assert_eq!(schedule.remaining_count(now), 1);
+    }
+
+    #[test]
+    #[should_panic(expected = "flashblock interval must be non-zero")]
+    fn test_zero_interval_panics() {
+        FlashblockSchedule::new(Instant::now() + Duration::from_millis(500), Duration::ZERO);
+    }
+
+    #[test]
+    fn test_expired_deadline() {
+        let now = Instant::now();
+        let schedule =
+            FlashblockSchedule::new(now - Duration::from_millis(1), Duration::from_millis(200));
+
+        assert!(!schedule.should_build_next(now));
+        assert_eq!(schedule.remaining_count(now), 0);
+    }
+
+    #[test]
+    fn test_remaining_count_and_should_build_next_consistent() {
+        let now = Instant::now();
+        let schedule =
+            FlashblockSchedule::new(now + Duration::from_millis(250), Duration::from_millis(200));
+
+        // 250ms remaining, 200ms interval → one full interval fits, partial rounds up
+        assert!(schedule.should_build_next(now));
+        assert_eq!(schedule.remaining_count(now), 2);
+
+        // After 100ms, 150ms remaining → should_build_next is false but div_ceil yields 1
+        let later = now + Duration::from_millis(100);
+        assert!(!schedule.should_build_next(later));
+        assert_eq!(schedule.remaining_count(later), 1);
+    }
+}

--- a/crates/builder/core/src/flashblocks/service.rs
+++ b/crates/builder/core/src/flashblocks/service.rs
@@ -7,7 +7,6 @@ use base_node_core::{
 };
 use base_node_runner::{BaseNode, OpNodeTypes, PayloadServiceBuilder as BasePayloadServiceBuilder};
 use derive_more::Debug;
-use reth_basic_payload_builder::BasicPayloadJobGeneratorConfig;
 use reth_node_api::NodeTypes;
 use reth_node_builder::{
     BuilderContext,
@@ -20,7 +19,6 @@ use tracing::info;
 use super::{PayloadHandler, generator::BlockPayloadJobGenerator, payload::OpPayloadBuilder};
 use crate::{
     BuilderConfig,
-    metrics::BuilderMetrics,
     traits::{NodeBounds, PoolBounds},
 };
 
@@ -42,7 +40,6 @@ impl FlashblocksServiceBuilder {
         Node: NodeBounds,
         Pool: PoolBounds,
     {
-        let metrics = Arc::new(BuilderMetrics::default());
         let (built_payload_tx, built_payload_rx) = tokio::sync::mpsc::channel(16);
 
         let ws_pub: Arc<WebSocketPublisher> =
@@ -54,17 +51,13 @@ impl FlashblocksServiceBuilder {
             self.0.clone(),
             built_payload_tx,
             ws_pub,
-            metrics,
         );
-        let payload_job_config = BasicPayloadJobGeneratorConfig::default();
-
         let payload_generator = BlockPayloadJobGenerator::with_builder(
             ctx.provider().clone(),
             ctx.task_executor().clone(),
-            payload_job_config,
             payload_builder,
             true,
-            self.0.block_time_leeway,
+            self.0.block_time,
         );
 
         let (payload_service, payload_builder_handle) =

--- a/crates/builder/core/src/lib.rs
+++ b/crates/builder/core/src/lib.rs
@@ -32,8 +32,8 @@ pub use metering::{MeteringProvider, NoopMeteringProvider, SharedMeteringProvide
 mod flashblocks;
 pub use flashblocks::{
     BestFlashblocksTxs, BlockCell, BlockPayloadJob, BlockPayloadJobGenerator, BuildArguments,
-    FlashblocksExecutionInfo, FlashblocksExtraCtx, FlashblocksServiceBuilder, OpPayloadBuilderCtx,
-    PayloadBuilder, PayloadHandler, ResolvePayload, WaitForValue,
+    FlashblockSchedule, FlashblocksExecutionInfo, FlashblocksExtraCtx, FlashblocksServiceBuilder,
+    OpPayloadBuilderCtx, PayloadBuilder, PayloadHandler, ResolvePayload, WaitForValue,
 };
 
 mod extension;

--- a/crates/builder/core/src/metrics.rs
+++ b/crates/builder/core/src/metrics.rs
@@ -88,8 +88,6 @@ pub struct BuilderMetrics {
     pub reduced_flashblocks_number: Histogram,
     /// How much less flashblocks we issued in reality, comparing to calculated number for block
     pub missing_flashblocks_count: Histogram,
-    /// How much time we have deducted from block building time
-    pub flashblocks_time_drift: Histogram,
     /// Time offset we used for first flashblock
     pub first_flashblock_time_offset: Histogram,
     /// Count of the number of times transactions had metering information

--- a/crates/builder/core/tests/flashblocks.rs
+++ b/crates/builder/core/tests/flashblocks.rs
@@ -18,8 +18,7 @@ use base_builder_core::{
 /// `take_bundle()` emptied the bundle state, producing an always-empty map.
 #[tokio::test]
 async fn test_flashblock_metadata_balances_and_receipts() -> eyre::Result<()> {
-    let config =
-        BuilderConfig::for_tests().with_block_time_ms(1000).with_flashblocks_leeway_time_ms(50);
+    let config = BuilderConfig::for_tests().with_block_time_ms(1000);
     let rbuilder = setup_test_instance_with_builder_config(config).await?;
     let driver = rbuilder.driver().await?;
     let flashblocks_listener = rbuilder.spawn_flashblocks_listener();
@@ -113,8 +112,7 @@ async fn test_flashblock_metadata_balances_and_receipts() -> eyre::Result<()> {
 /// receipts and balance diffs, replacing them with a flashblock access list.
 #[tokio::test]
 async fn test_flashblock_metadata_post_base_v1() -> eyre::Result<()> {
-    let config =
-        BuilderConfig::for_tests().with_block_time_ms(1000).with_flashblocks_leeway_time_ms(50);
+    let config = BuilderConfig::for_tests().with_block_time_ms(1000);
     let node_config = default_node_config_with_base_v1();
     let rbuilder = setup_test_instance_with_node_config(config, node_config).await?;
     let driver = rbuilder.driver().await?;
@@ -245,8 +243,7 @@ async fn smoke_dynamic_unichain() -> eyre::Result<()> {
 
 #[tokio::test]
 async fn smoke_classic_unichain() -> eyre::Result<()> {
-    let config =
-        BuilderConfig::for_tests().with_block_time_ms(1000).with_flashblocks_leeway_time_ms(50);
+    let config = BuilderConfig::for_tests().with_block_time_ms(1000);
     let rbuilder = setup_test_instance_with_builder_config(config).await?;
     let driver = rbuilder.driver().await?;
     let flashblocks_listener = rbuilder.spawn_flashblocks_listener();
@@ -270,8 +267,7 @@ async fn smoke_classic_unichain() -> eyre::Result<()> {
 
 #[tokio::test]
 async fn smoke_classic_base() -> eyre::Result<()> {
-    let config =
-        BuilderConfig::for_tests().with_block_time_ms(2000).with_flashblocks_leeway_time_ms(50);
+    let config = BuilderConfig::for_tests().with_block_time_ms(2000);
     let rbuilder = setup_test_instance_with_builder_config(config).await?;
     let driver = rbuilder.driver().await?;
     let flashblocks_listener = rbuilder.spawn_flashblocks_listener();
@@ -320,8 +316,7 @@ async fn unichain_dynamic_with_lag() -> eyre::Result<()> {
 
 #[tokio::test]
 async fn dynamic_with_full_block_lag() -> eyre::Result<()> {
-    let config =
-        BuilderConfig::for_tests().with_block_time_ms(1000).with_flashblocks_leeway_time_ms(0);
+    let config = BuilderConfig::for_tests().with_block_time_ms(1000);
     let rbuilder = setup_test_instance_with_builder_config(config).await?;
     let driver = rbuilder.driver().await?;
     let flashblocks_listener = rbuilder.spawn_flashblocks_listener();


### PR DESCRIPTION
## Summary

- Introduce `FlashblockSchedule`, an `Instant`-based struct that replaces the old `SystemTime` + leeway-time arithmetic for flashblock timing
- Recompute per-flashblock resource budgets dynamically from remaining capacity instead of fixed upfront slices, letting the builder self-correct when earlier flashblocks under- or over-consume gas/DA/time
- Remove dead configuration superseded by the new approach: `block_time_leeway`, `flashblocks_leeway_time`, `sampling_ratio`, `extra_block_deadline_secs`, and the unused `BasicPayloadJobGeneratorConfig` field

## Changes

### New: `FlashblockSchedule` (`schedule.rs`)
Lightweight timing abstraction with `should_build_next()`, `remaining_count()`, `interval()`, and `deadline()`. Constructed once per block from `block_build_start_time + block_time` and the flashblock interval. Unit tests cover normal schedule, late FCU, very late FCU, zero interval, and expired deadline.

### Changed: Dynamic budget recomputation (`payload.rs`)
Previously, budgets were sliced upfront (`gas_per_batch = block_gas_limit / flashblocks_per_block`) and accumulated by fixed increments each iteration. Now each call to `build_next_flashblock` recomputes from remaining resources:
```
remaining_gas / schedule.remaining_count()
```
This applies to gas, DA bytes, DA footprint, and state root time budgets.

### Changed: Generator deadline (`generator.rs`)
Inlined `job_deadline()` and replaced `extra_block_deadline` with `block_time` for the payload job GC deadline. Removed the `BasicPayloadJobGeneratorConfig` field (was stored as `_config` — never read).

### Removed: Dead config fields
| Field | Replacement |
|-------|------------|
| `block_time_leeway` | `block_time` (used directly for GC deadline) |
| `flashblocks_leeway_time` | Absorbed into `FlashblockSchedule` |
| `sampling_ratio` | `SPAN_SAMPLING_RATIO` constant (was only used for span creation frequency) |
| `extra_block_deadline_secs` | Removed CLI arg |
| `BasicPayloadJobGeneratorConfig` | Removed unused field |