### PR TITLE
feat(CHAIN-3558): Crate scaffolding — types, COSE parsing, attestation extraction

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4433,6 +4433,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "base-proof-tee-nitro-verifier"
+version = "0.0.0"
+dependencies = [
+ "alloy-primitives",
+ "alloy-sol-types",
+ "ciborium",
+ "rstest",
+ "serde",
+ "serde_bytes",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "base-proof-tee-registrar"
 version = "0.0.0"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4439,7 +4439,6 @@ dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
  "ciborium",
- "rstest",
  "serde",
  "serde_bytes",
  "thiserror 2.0.18",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ members = [
   "crates/proof/tee/nitro",
   "crates/proof/tee/client",
   "crates/proof/tee/registrar",
+  "crates/proof/tee/nitro-verifier",
   "crates/proof/zk/client",
   "crates/proof/zk/db",
   "crates/proof/zk/outbox",
@@ -234,6 +235,7 @@ base-enclave-client = { path = "crates/proof/tee/client" }
 base-proof-contracts = { path = "crates/proof/contracts" }
 base-proof-tee-nitro = { path = "crates/proof/tee/nitro" }
 base-proof-tee-registrar = { path = "crates/proof/tee/registrar" }
+base-proof-tee-nitro-verifier = { path = "crates/proof/tee/nitro-verifier" }
 base-proof = { path = "crates/proof/proof", default-features = false }
 base-proof-mpt = { path = "crates/proof/mpt", default-features = false }
 base-proof-host = { path = "crates/proof/host", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -235,10 +235,10 @@ base-enclave-client = { path = "crates/proof/tee/client" }
 base-proof-contracts = { path = "crates/proof/contracts" }
 base-proof-tee-nitro = { path = "crates/proof/tee/nitro" }
 base-proof-tee-registrar = { path = "crates/proof/tee/registrar" }
-base-proof-tee-nitro-verifier = { path = "crates/proof/tee/nitro-verifier" }
 base-proof = { path = "crates/proof/proof", default-features = false }
 base-proof-mpt = { path = "crates/proof/mpt", default-features = false }
 base-proof-host = { path = "crates/proof/host", default-features = false }
+base-proof-tee-nitro-verifier = { path = "crates/proof/tee/nitro-verifier" }
 base-proof-client = { path = "crates/proof/client", default-features = false }
 base-proof-driver = { path = "crates/proof/driver", default-features = false }
 base-proof-executor = { path = "crates/proof/executor", default-features = false }

--- a/crates/proof/tee/nitro-verifier/Cargo.toml
+++ b/crates/proof/tee/nitro-verifier/Cargo.toml
@@ -19,10 +19,7 @@ serde_bytes.workspace = true
 
 # Types
 alloy-primitives = { workspace = true, default-features = false }
-alloy-sol-types = { workspace = true, features = ["json"] }
+alloy-sol-types.workspace = true
 
 # Error
 thiserror.workspace = true
-
-[dev-dependencies]
-rstest.workspace = true

--- a/crates/proof/tee/nitro-verifier/Cargo.toml
+++ b/crates/proof/tee/nitro-verifier/Cargo.toml
@@ -1,0 +1,28 @@
+[package]
+name = "base-proof-tee-nitro-verifier"
+description = "Pure verification logic for AWS Nitro Enclave attestation documents"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+
+[lints]
+workspace = true
+
+[dependencies]
+# Parsing
+serde = { workspace = true, features = ["derive"] }
+ciborium.workspace = true
+serde_bytes.workspace = true
+
+# Types
+alloy-primitives = { workspace = true, default-features = false }
+alloy-sol-types = { workspace = true, features = ["json"] }
+
+# Error
+thiserror.workspace = true
+
+[dev-dependencies]
+rstest.workspace = true

--- a/crates/proof/tee/nitro-verifier/Cargo.toml
+++ b/crates/proof/tee/nitro-verifier/Cargo.toml
@@ -13,13 +13,13 @@ workspace = true
 
 [dependencies]
 # Parsing
-serde = { workspace = true, features = ["derive"] }
 ciborium.workspace = true
 serde_bytes.workspace = true
+serde = { workspace = true, features = ["derive"] }
 
 # Types
-alloy-primitives = { workspace = true, default-features = false }
 alloy-sol-types.workspace = true
+alloy-primitives = { workspace = true, default-features = false }
 
 # Error
 thiserror.workspace = true

--- a/crates/proof/tee/nitro-verifier/README.md
+++ b/crates/proof/tee/nitro-verifier/README.md
@@ -1,0 +1,15 @@
+# base-proof-tee-nitro-verifier
+
+Pure verification logic for AWS Nitro Enclave attestation documents.
+
+Parses `COSE_Sign1` attestation envelopes, extracts and validates attestation
+documents, and provides Solidity-aligned types for on-chain proof submission.
+This crate has no ZK dependency — it can run natively or inside any ZK VM.
+
+## Modules
+
+- **`attestation`** — `COSE_Sign1` parsing, attestation document extraction, and
+  `AttestationReport` combining both.
+- **`error`** — [`VerifierError`] enum covering parsing and validation failures.
+- **`types`** — Solidity-aligned types generated from `INitroEnclaveVerifier.sol`:
+  [`VerifierInput`], [`VerifierJournal`], [`Pcr`], [`VerificationResult`].

--- a/crates/proof/tee/nitro-verifier/README.md
+++ b/crates/proof/tee/nitro-verifier/README.md
@@ -4,7 +4,8 @@ Pure verification logic for AWS Nitro Enclave attestation documents.
 
 Parses `COSE_Sign1` attestation envelopes, extracts and validates attestation
 documents, and provides Solidity-aligned types for on-chain proof submission.
-This crate has no ZK dependency — it can run natively or inside any ZK VM.
+This crate has no ZK dependency — it can run natively or inside ZK VMs
+that support `std` (e.g. RISC Zero with the `std` feature).
 
 ## Modules
 

--- a/crates/proof/tee/nitro-verifier/src/attestation.rs
+++ b/crates/proof/tee/nitro-verifier/src/attestation.rs
@@ -1,0 +1,261 @@
+//! `COSE_Sign1` parsing and attestation document extraction.
+//!
+//! Adapted from the Automata SDK's `cose.rs` and `doc.rs`, replacing the
+//! unmaintained `serde_cbor` with `ciborium` for CBOR encoding/decoding.
+
+use std::collections::BTreeMap;
+
+use ciborium::Value as CborValue;
+use serde::Deserialize;
+use serde_bytes::{ByteArray, ByteBuf};
+
+use crate::{Result, VerifierError};
+
+/// A parsed `COSE_Sign1` envelope (RFC 8152 Section 4.2).
+///
+/// Contains the raw CBOR-encoded protected header, the attestation document
+/// payload, and the signature. The envelope can be parsed from raw bytes
+/// without verifying the signature — verification is handled separately by
+/// the x509 chain validation in CHAIN-3559.
+#[derive(Debug)]
+pub struct CoseSign1 {
+    /// CBOR-encoded protected header (contains the signature algorithm).
+    pub protected: Vec<u8>,
+    /// Raw attestation document payload (CBOR-encoded `AttestationDocument`).
+    pub payload: Vec<u8>,
+    /// COSE signature bytes.
+    pub signature: Vec<u8>,
+}
+
+impl CoseSign1 {
+    /// Parses a `COSE_Sign1` structure from raw CBOR bytes.
+    ///
+    /// Handles the optional CBOR tag 18 (`COSE_Sign1`) per RFC 8152.
+    /// The input is expected to be a CBOR array of 4 elements:
+    /// `[protected, unprotected, payload, signature]`.
+    pub fn from_bytes(bytes: &[u8]) -> Result<Self> {
+        let value: CborValue = ciborium::de::from_reader(bytes)
+            .map_err(|e| VerifierError::CborDecode(format!("`COSE_Sign1`: {e}")))?;
+
+        // Unwrap optional CBOR tag 18 (`COSE_Sign1`).
+        let array = match value {
+            CborValue::Tag(18, inner) => match *inner {
+                CborValue::Array(a) => a,
+                _ => return Err(VerifierError::CoseFormat("tagged value is not an array".into())),
+            },
+            CborValue::Array(a) => a,
+            _ => return Err(VerifierError::CoseFormat("expected array or tag 18".into())),
+        };
+
+        if array.len() != 4 {
+            return Err(VerifierError::CoseFormat(format!(
+                "expected 4 elements, got {}",
+                array.len()
+            )));
+        }
+
+        let mut iter = array.into_iter();
+        let protected = Self::extract_bytes(iter.next().unwrap(), "protected")?;
+        // Skip unprotected header (element 1) — we don't use it.
+        let _unprotected = iter.next().unwrap();
+        let payload = Self::extract_bytes(iter.next().unwrap(), "payload")?;
+        let signature = Self::extract_bytes(iter.next().unwrap(), "signature")?;
+
+        Ok(Self { protected, payload, signature })
+    }
+
+    /// Constructs the CBOR-encoded `Sig_structure` for signature verification.
+    ///
+    /// Per RFC 8152 Section 4.4, the `Sig_structure` for `COSE_Sign1` is:
+    /// `["Signature1", body_protected, external_aad, payload]`
+    ///
+    /// This is the to-be-signed (TBS) data that the signature covers.
+    pub fn sig_structure(&self) -> Result<Vec<u8>> {
+        let structure = CborValue::Array(vec![
+            CborValue::Text("Signature1".to_string()),
+            CborValue::Bytes(self.protected.clone()),
+            CborValue::Bytes(vec![]), // external_aad — empty
+            CborValue::Bytes(self.payload.clone()),
+        ]);
+
+        let mut buf = Vec::new();
+        ciborium::ser::into_writer(&structure, &mut buf)
+            .map_err(|e| VerifierError::CborDecode(format!("sig_structure encode: {e}")))?;
+        Ok(buf)
+    }
+
+    /// Extracts a byte string from a CBOR value.
+    fn extract_bytes(value: CborValue, field: &str) -> Result<Vec<u8>> {
+        match value {
+            CborValue::Bytes(b) => Ok(b),
+            _ => Err(VerifierError::CoseFormat(format!("{field} is not a byte string"))),
+        }
+    }
+}
+
+/// A parsed AWS Nitro Enclave attestation document.
+///
+/// Deserialized from the CBOR payload inside a `CoseSign1` envelope.
+/// See: <https://docs.aws.amazon.com/enclaves/latest/user/verify-root.html>
+#[derive(Debug, Deserialize)]
+pub struct AttestationDocument {
+    /// AWS Nitro Enclave module identifier.
+    pub module_id: String,
+    /// Attestation timestamp (Unix timestamp in milliseconds).
+    pub timestamp: u64,
+    /// Digest algorithm used (expected: `"SHA384"`).
+    pub digest: String,
+    /// Platform Configuration Registers — integrity measurements.
+    pub pcrs: BTreeMap<u64, ByteArray<48>>,
+    /// DER-encoded leaf certificate for the enclave.
+    pub certificate: ByteBuf,
+    /// DER-encoded CA bundle (root → intermediate chain).
+    pub cabundle: Vec<ByteBuf>,
+    /// Optional public key embedded in the attestation.
+    pub public_key: Option<ByteBuf>,
+    /// Optional user-defined data.
+    pub user_data: Option<ByteBuf>,
+    /// Optional nonce for replay protection.
+    pub nonce: Option<ByteBuf>,
+}
+
+/// A parsed Nitro attestation report combining the COSE envelope and document.
+#[derive(Debug)]
+pub struct AttestationReport {
+    /// The `COSE_Sign1` envelope (for signature verification).
+    pub cose: CoseSign1,
+    /// The parsed attestation document from the COSE payload.
+    pub doc: AttestationDocument,
+}
+
+impl AttestationReport {
+    /// Parses a raw Nitro attestation report (`COSE_Sign1` bytes).
+    ///
+    /// Extracts the `COSE_Sign1` envelope and deserializes the CBOR payload
+    /// into an `AttestationDocument`.
+    pub fn parse(data: &[u8]) -> Result<Self> {
+        let cose = CoseSign1::from_bytes(data)?;
+        let doc: AttestationDocument =
+            ciborium::de::from_reader(cose.payload.as_slice()).map_err(|e| {
+                VerifierError::AttestationFormat(format!("attestation document decode: {e}"))
+            })?;
+        Ok(Self { cose, doc })
+    }
+
+    /// Extracts the DER-encoded certificates from the document (CA bundle + leaf).
+    ///
+    /// Returns the certificates in chain order: root → intermediates → leaf.
+    /// Used by CHAIN-3559 for x509 chain verification.
+    pub fn cert_chain_der(&self) -> Vec<&[u8]> {
+        let mut certs: Vec<&[u8]> = self.doc.cabundle.iter().map(|c| c.as_ref()).collect();
+        certs.push(self.doc.certificate.as_ref());
+        certs
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cose_from_bytes_rejects_empty_input() {
+        assert!(CoseSign1::from_bytes(&[]).is_err());
+    }
+
+    #[test]
+    fn cose_from_bytes_rejects_non_array() {
+        // CBOR integer 42
+        let cbor_int = vec![0x18, 0x2a];
+        assert!(CoseSign1::from_bytes(&cbor_int).is_err());
+    }
+
+    #[test]
+    fn cose_from_bytes_rejects_wrong_length_array() {
+        // CBOR array of 3 byte strings
+        let mut buf = Vec::new();
+        ciborium::ser::into_writer(
+            &CborValue::Array(vec![
+                CborValue::Bytes(vec![]),
+                CborValue::Bytes(vec![]),
+                CborValue::Bytes(vec![]),
+            ]),
+            &mut buf,
+        )
+        .unwrap();
+        assert!(CoseSign1::from_bytes(&buf).is_err());
+    }
+
+    #[test]
+    fn cose_from_bytes_parses_valid_4_element_array() {
+        let mut buf = Vec::new();
+        ciborium::ser::into_writer(
+            &CborValue::Array(vec![
+                CborValue::Bytes(vec![0x01]),       // protected
+                CborValue::Map(vec![]),             // unprotected
+                CborValue::Bytes(vec![0x02, 0x03]), // payload
+                CborValue::Bytes(vec![0x04]),       // signature
+            ]),
+            &mut buf,
+        )
+        .unwrap();
+
+        let cose = CoseSign1::from_bytes(&buf).unwrap();
+        assert_eq!(cose.protected, [0x01]);
+        assert_eq!(cose.payload, [0x02, 0x03]);
+        assert_eq!(cose.signature, [0x04]);
+    }
+
+    #[test]
+    fn cose_from_bytes_handles_tag_18() {
+        let inner = CborValue::Array(vec![
+            CborValue::Bytes(vec![0x01]),
+            CborValue::Map(vec![]),
+            CborValue::Bytes(vec![0x02]),
+            CborValue::Bytes(vec![0x03]),
+        ]);
+        let tagged = CborValue::Tag(18, Box::new(inner));
+
+        let mut buf = Vec::new();
+        ciborium::ser::into_writer(&tagged, &mut buf).unwrap();
+
+        let cose = CoseSign1::from_bytes(&buf).unwrap();
+        assert_eq!(cose.protected, [0x01]);
+    }
+
+    #[test]
+    fn cose_from_bytes_rejects_wrong_tag() {
+        let inner = CborValue::Array(vec![
+            CborValue::Bytes(vec![]),
+            CborValue::Map(vec![]),
+            CborValue::Bytes(vec![]),
+            CborValue::Bytes(vec![]),
+        ]);
+        let tagged = CborValue::Tag(99, Box::new(inner));
+
+        let mut buf = Vec::new();
+        ciborium::ser::into_writer(&tagged, &mut buf).unwrap();
+
+        // Tag 99 is neither Array nor Tag(18, ...) — rejected.
+        assert!(CoseSign1::from_bytes(&buf).is_err());
+    }
+
+    #[test]
+    fn sig_structure_produces_valid_cbor() {
+        let cose = CoseSign1 {
+            protected: vec![0xa1, 0x01, 0x38, 0x22], // {1: -35} (ES384)
+            payload: vec![0x01, 0x02],
+            signature: vec![0x03],
+        };
+
+        let tbs = cose.sig_structure().unwrap();
+        // Should be a valid CBOR array
+        let decoded: CborValue = ciborium::de::from_reader(tbs.as_slice()).unwrap();
+        match decoded {
+            CborValue::Array(elems) => {
+                assert_eq!(elems.len(), 4);
+                assert_eq!(elems[0], CborValue::Text("Signature1".to_string()));
+            }
+            _ => panic!("expected CBOR array"),
+        }
+    }
+}

--- a/crates/proof/tee/nitro-verifier/src/attestation.rs
+++ b/crates/proof/tee/nitro-verifier/src/attestation.rs
@@ -78,7 +78,7 @@ impl CoseSign1 {
             CborValue::Bytes(self.payload.clone()),
         ]);
 
-        let mut buf = Vec::new();
+        let mut buf = Vec::with_capacity(20 + self.protected.len() + self.payload.len());
         ciborium::ser::into_writer(&structure, &mut buf)
             .map_err(|e| VerifierError::Cbor(format!("sig_structure encode: {e}")))?;
         Ok(buf)
@@ -147,9 +147,12 @@ impl AttestationReport {
     /// Returns the certificates in chain order: root → intermediates → leaf.
     /// Used by CHAIN-3559 for x509 chain verification.
     pub fn cert_chain_der(&self) -> Vec<&[u8]> {
-        let mut certs: Vec<&[u8]> = self.doc.cabundle.iter().map(|c| c.as_ref()).collect();
-        certs.push(self.doc.certificate.as_ref());
-        certs
+        self.doc
+            .cabundle
+            .iter()
+            .map(|c| c.as_ref())
+            .chain(std::iter::once(self.doc.certificate.as_ref()))
+            .collect()
     }
 }
 

--- a/crates/proof/tee/nitro-verifier/src/attestation.rs
+++ b/crates/proof/tee/nitro-verifier/src/attestation.rs
@@ -35,7 +35,7 @@ impl CoseSign1 {
     /// `[protected, unprotected, payload, signature]`.
     pub fn from_bytes(bytes: &[u8]) -> Result<Self> {
         let value: CborValue = ciborium::de::from_reader(bytes)
-            .map_err(|e| VerifierError::CborDecode(format!("`COSE_Sign1`: {e}")))?;
+            .map_err(|e| VerifierError::Cbor(format!("`COSE_Sign1`: {e}")))?;
 
         // Unwrap optional CBOR tag 18 (`COSE_Sign1`).
         let array = match value {
@@ -80,7 +80,7 @@ impl CoseSign1 {
 
         let mut buf = Vec::new();
         ciborium::ser::into_writer(&structure, &mut buf)
-            .map_err(|e| VerifierError::CborDecode(format!("sig_structure encode: {e}")))?;
+            .map_err(|e| VerifierError::Cbor(format!("sig_structure encode: {e}")))?;
         Ok(buf)
     }
 

--- a/crates/proof/tee/nitro-verifier/src/error.rs
+++ b/crates/proof/tee/nitro-verifier/src/error.rs
@@ -1,0 +1,30 @@
+//! Error types for Nitro attestation verification.
+
+use thiserror::Error;
+
+/// Errors that can occur during attestation parsing and verification.
+#[derive(Debug, Error)]
+pub enum VerifierError {
+    /// CBOR decoding failed.
+    #[error("CBOR decode error: {0}")]
+    CborDecode(String),
+
+    /// `COSE_Sign1` envelope is malformed.
+    #[error("COSE format error: {0}")]
+    CoseFormat(String),
+
+    /// Attestation document is malformed or has invalid fields.
+    #[error("attestation format error: {0}")]
+    AttestationFormat(String),
+
+    /// Certificate chain verification failed.
+    #[error("certificate verification error: {0}")]
+    CertificateVerification(String),
+
+    /// COSE signature verification failed.
+    #[error("signature verification error: {0}")]
+    SignatureVerification(String),
+}
+
+/// Convenience result alias for verifier operations.
+pub type Result<T, E = VerifierError> = std::result::Result<T, E>;

--- a/crates/proof/tee/nitro-verifier/src/error.rs
+++ b/crates/proof/tee/nitro-verifier/src/error.rs
@@ -5,9 +5,9 @@ use thiserror::Error;
 /// Errors that can occur during attestation parsing and verification.
 #[derive(Debug, Error)]
 pub enum VerifierError {
-    /// CBOR decoding failed.
-    #[error("CBOR decode error: {0}")]
-    CborDecode(String),
+    /// CBOR encoding or decoding failed.
+    #[error("CBOR error: {0}")]
+    Cbor(String),
 
     /// `COSE_Sign1` envelope is malformed.
     #[error("COSE format error: {0}")]

--- a/crates/proof/tee/nitro-verifier/src/lib.rs
+++ b/crates/proof/tee/nitro-verifier/src/lib.rs
@@ -1,0 +1,14 @@
+#![doc = include_str!("../README.md")]
+#![cfg_attr(not(test), warn(unused_crate_dependencies))]
+
+mod attestation;
+pub use attestation::{AttestationDocument, AttestationReport, CoseSign1};
+
+mod error;
+pub use error::{Result, VerifierError};
+
+mod types;
+pub use types::{
+    BatchVerifierJournal, Bytes48, Pcr, VerificationResult, VerifierInput, VerifierJournal,
+    ZkCoProcessorConfig, ZkCoProcessorType,
+};

--- a/crates/proof/tee/nitro-verifier/src/types.rs
+++ b/crates/proof/tee/nitro-verifier/src/types.rs
@@ -106,7 +106,10 @@ impl Bytes48 {
 
     /// Concatenates both halves into a 48-byte `Bytes` value.
     pub fn to_bytes(&self) -> Bytes {
-        [self.first.as_slice(), self.second.as_slice()].concat().into()
+        let mut buf = [0u8; 48];
+        buf[..32].copy_from_slice(self.first.as_slice());
+        buf[32..].copy_from_slice(self.second.as_slice());
+        Bytes::copy_from_slice(&buf)
     }
 }
 
@@ -116,41 +119,21 @@ impl From<&ByteArray<48>> for Bytes48 {
     }
 }
 
-impl VerifierInput {
-    /// ABI-encodes the input for use as ZK guest program input.
-    pub fn encode(&self) -> Vec<u8> {
-        SolValue::abi_encode(self)
-    }
+macro_rules! impl_abi_codec {
+    ($($ty:ty),+ $(,)?) => {$(
+        impl $ty {
+            /// ABI-encodes this value.
+            pub fn encode(&self) -> Vec<u8> {
+                SolValue::abi_encode(self)
+            }
 
-    /// ABI-decodes a `VerifierInput` from raw bytes.
-    pub fn decode(buf: &[u8]) -> crate::Result<Self> {
-        <Self as SolValue>::abi_decode(buf)
-            .map_err(|e| crate::VerifierError::AttestationFormat(e.to_string()))
-    }
+            /// ABI-decodes from raw bytes.
+            pub fn decode(buf: &[u8]) -> crate::Result<Self> {
+                <Self as SolValue>::abi_decode(buf)
+                    .map_err(|e| crate::VerifierError::AttestationFormat(e.to_string()))
+            }
+        }
+    )+};
 }
 
-impl VerifierJournal {
-    /// ABI-encodes the journal for on-chain submission.
-    pub fn encode(&self) -> Vec<u8> {
-        SolValue::abi_encode(self)
-    }
-
-    /// ABI-decodes a `VerifierJournal` from raw bytes.
-    pub fn decode(buf: &[u8]) -> crate::Result<Self> {
-        <Self as SolValue>::abi_decode(buf)
-            .map_err(|e| crate::VerifierError::AttestationFormat(e.to_string()))
-    }
-}
-
-impl BatchVerifierJournal {
-    /// ABI-encodes the batch journal for on-chain submission.
-    pub fn encode(&self) -> Vec<u8> {
-        SolValue::abi_encode(self)
-    }
-
-    /// ABI-decodes a `BatchVerifierJournal` from raw bytes.
-    pub fn decode(buf: &[u8]) -> crate::Result<Self> {
-        <Self as SolValue>::abi_decode(buf)
-            .map_err(|e| crate::VerifierError::AttestationFormat(e.to_string()))
-    }
-}
+impl_abi_codec!(VerifierInput, VerifierJournal, BatchVerifierJournal);

--- a/crates/proof/tee/nitro-verifier/src/types.rs
+++ b/crates/proof/tee/nitro-verifier/src/types.rs
@@ -129,7 +129,7 @@ macro_rules! impl_abi_codec {
 
             /// ABI-decodes from raw bytes.
             pub fn decode(buf: &[u8]) -> crate::Result<Self> {
-                <Self as SolValue>::abi_decode(buf)
+                <Self as SolValue>::abi_decode_validate(buf)
                     .map_err(|e| crate::VerifierError::AttestationFormat(e.to_string()))
             }
         }

--- a/crates/proof/tee/nitro-verifier/src/types.rs
+++ b/crates/proof/tee/nitro-verifier/src/types.rs
@@ -9,12 +9,15 @@ use serde_bytes::ByteArray;
 
 sol! {
     /// Supported zero-knowledge proof coprocessor types.
+    ///
+    /// All variants must be present to match the on-chain `INitroEnclaveVerifier.sol`
+    /// enum ordering for correct ABI encoding, even if not all are used.
     enum ZkCoProcessorType {
         /// Unknown / unset.
         Unknown,
         /// RISC Zero zkVM proving system.
         RiscZero,
-        /// Succinct SP1 proving system.
+        /// Succinct SP1 proving system (not currently used — present for ABI compatibility).
         Succinct,
     }
 

--- a/crates/proof/tee/nitro-verifier/src/types.rs
+++ b/crates/proof/tee/nitro-verifier/src/types.rs
@@ -1,0 +1,153 @@
+//! Solidity-aligned types for the `INitroEnclaveVerifier` on-chain interface.
+//!
+//! Inlined from the contracts repo's `INitroEnclaveVerifier.sol`. ABI encoding
+//! of these types matches exactly what the on-chain verifier expects.
+
+use alloy_primitives::{B128, B256, Bytes};
+use alloy_sol_types::{SolValue, sol};
+use serde_bytes::ByteArray;
+
+sol! {
+    /// Supported zero-knowledge proof coprocessor types.
+    enum ZkCoProcessorType {
+        /// Unknown / unset.
+        Unknown,
+        /// RISC Zero zkVM proving system.
+        RiscZero,
+        /// Succinct SP1 proving system.
+        Succinct,
+    }
+
+    /// Configuration for a specific zero-knowledge coprocessor.
+    struct ZkCoProcessorConfig {
+        /// Latest program ID for single attestation verification.
+        bytes32 verifierId;
+        /// Latest program ID for batch/aggregated verification.
+        bytes32 aggregatorId;
+        /// Default ZK verifier contract address.
+        address zkVerifier;
+    }
+
+    /// Input structure for attestation report verification.
+    struct VerifierInput {
+        /// Number of trusted certificates in the chain.
+        uint8 trustedCertsPrefixLen;
+        /// Raw AWS Nitro Enclave attestation report (`COSE_Sign1` format).
+        bytes attestationReport;
+    }
+
+    /// Output structure containing verified attestation data and metadata.
+    struct VerifierJournal {
+        /// Overall verification result status.
+        VerificationResult result;
+        /// Number of certificates that were trusted during verification.
+        uint8 trustedCertsPrefixLen;
+        /// Attestation timestamp (Unix timestamp in milliseconds).
+        uint64 timestamp;
+        /// Array of certificate hashes in the chain (root to leaf).
+        bytes32[] certs;
+        /// User-defined data embedded in the attestation.
+        bytes userData;
+        /// Cryptographic nonce used for replay protection.
+        bytes nonce;
+        /// Public key extracted from the attestation.
+        bytes publicKey;
+        /// Platform Configuration Registers (integrity measurements).
+        Pcr[] pcrs;
+        /// AWS Nitro Enclave module identifier.
+        string moduleId;
+    }
+
+    /// Public value (journal) structure for batch verification operations.
+    struct BatchVerifierJournal {
+        /// Verification key that was used for batch verification.
+        bytes32 verifierVk;
+        /// Array of verified attestation results.
+        VerifierJournal[] outputs;
+    }
+
+    /// 48-byte data structure for storing PCR values.
+    struct Bytes48 {
+        /// First 32 bytes.
+        bytes32 first;
+        /// Last 16 bytes.
+        bytes16 second;
+    }
+
+    /// Platform Configuration Register (PCR) entry.
+    struct Pcr {
+        /// PCR index number (0-23 for AWS Nitro Enclaves).
+        uint64 index;
+        /// 48-byte PCR measurement value (SHA-384 hash).
+        Bytes48 value;
+    }
+
+    /// Possible attestation verification results.
+    enum VerificationResult {
+        /// Attestation successfully verified.
+        Success,
+        /// Root certificate is not in the trusted set.
+        RootCertNotTrusted,
+        /// One or more intermediate certificates are not trusted.
+        IntermediateCertsNotTrusted,
+        /// Attestation timestamp is outside acceptable range.
+        InvalidTimestamp,
+    }
+}
+
+impl Bytes48 {
+    /// Returns `true` if both halves are zero.
+    pub fn is_zero(&self) -> bool {
+        self.first.is_zero() && self.second.is_zero()
+    }
+
+    /// Concatenates both halves into a 48-byte `Bytes` value.
+    pub fn to_bytes(&self) -> Bytes {
+        [self.first.as_slice(), self.second.as_slice()].concat().into()
+    }
+}
+
+impl From<&ByteArray<48>> for Bytes48 {
+    fn from(input: &ByteArray<48>) -> Self {
+        Self { first: B256::from_slice(&input[..32]), second: B128::from_slice(&input[32..]) }
+    }
+}
+
+impl VerifierInput {
+    /// ABI-encodes the input for use as ZK guest program input.
+    pub fn encode(&self) -> Vec<u8> {
+        SolValue::abi_encode(self)
+    }
+
+    /// ABI-decodes a `VerifierInput` from raw bytes.
+    pub fn decode(buf: &[u8]) -> crate::Result<Self> {
+        <Self as SolValue>::abi_decode(buf)
+            .map_err(|e| crate::VerifierError::AttestationFormat(e.to_string()))
+    }
+}
+
+impl VerifierJournal {
+    /// ABI-encodes the journal for on-chain submission.
+    pub fn encode(&self) -> Vec<u8> {
+        SolValue::abi_encode(self)
+    }
+
+    /// ABI-decodes a `VerifierJournal` from raw bytes.
+    pub fn decode(buf: &[u8]) -> crate::Result<Self> {
+        <Self as SolValue>::abi_decode(buf)
+            .map_err(|e| crate::VerifierError::AttestationFormat(e.to_string()))
+    }
+}
+
+impl BatchVerifierJournal {
+    /// ABI-encodes the batch journal for on-chain submission.
+    pub fn encode(&self) -> Vec<u8> {
+        SolValue::abi_encode(self)
+    }
+
+    /// ABI-decodes a `BatchVerifierJournal` from raw bytes.
+    pub fn decode(buf: &[u8]) -> crate::Result<Self> {
+        <Self as SolValue>::abi_decode(buf)
+            .map_err(|e| crate::VerifierError::AttestationFormat(e.to_string()))
+    }
+}


### PR DESCRIPTION
## Summary

Creates `crates/proof/tee/nitro-verifier/` (`base-proof-tee-nitro-verifier`) — the first crate in our in-house Nitro attestation verifier.

  - **`types.rs`**: Solidity-aligned types (`VerifierInput`, `VerifierJournal`, `Pcr`, `Bytes48`, `VerificationResult`, etc.) inlined via `alloy::sol!` matching our `INitroEnclaveVerifier.sol` contract interface. ABI encode/decode helpers
  included.
  - **`attestation.rs`**: `CoseSign1` parser (using `ciborium` instead of unmaintained `serde_cbor`), `AttestationDocument` CBOR deserialization, `AttestationReport` combining both. Includes `sig_structure()` for signature verification in
  CHAIN-3559.
  - **`error.rs`**: Typed `VerifierError` enum via `thiserror`

  No x509 or signature verification yet — that's CHAIN-3559.

  ## Test plan

  - [x] `cargo clippy -p base-proof-tee-nitro-verifier -- -D warnings` passes clean
  - [x] `cargo test -p base-proof-tee-nitro-verifier` — 7 unit tests + 0 doctest failures
  - [x] COSE parsing: empty input, non-array, wrong length, valid 4-element array, tag 18 handling, wrong tag rejection
  - [x] `sig_structure` produces valid CBOR round-trip

  Closes CHAIN-3558
