### PR TITLE
feat(metrics): enable Prometheus for consensus follow and batcher

### DIFF
--- a/bin/batcher/src/cli.rs
+++ b/bin/batcher/src/cli.rs
@@ -31,6 +31,9 @@ impl Cli {
     /// Run the batcher CLI.
     pub(crate) fn run(self) -> eyre::Result<()> {
         LogConfig::from(self.args.logging.clone()).init_tracing_subscriber()?;
+        base_cli_utils::MetricsConfig::from(self.args.metrics.clone()).init_with(|| {
+            base_cli_utils::register_version_metrics!();
+        })?;
         RuntimeManager::run_until_ctrl_c(self.args.exec())
     }
 }
@@ -174,7 +177,6 @@ impl BatcherArgs {
                     ..Default::default()
                 })
             },
-            metrics_port: self.metrics.port,
         })
     }
 

--- a/bin/consensus/src/cli.rs
+++ b/bin/consensus/src/cli.rs
@@ -96,6 +96,10 @@ pub struct Follow {
     #[command(flatten)]
     pub logging: LogArgs,
 
+    /// Metrics configuration.
+    #[command(flatten)]
+    pub metrics: MetricsArgs,
+
     /// Gate sync behind proofs progress via `debug_proofsSyncStatus`.
     #[arg(long = "proofs", env = "BASE_NODE_PROOFS")]
     pub proofs: bool,
@@ -132,6 +136,15 @@ impl Follow {
         // Initialize logging from global arguments.
         LogConfig::from(self.logging.clone()).init_tracing_subscriber()?;
 
+        // Initialize unified metrics for the follow-node subsystems.
+        base_cli_utils::MetricsConfig::from(self.metrics.clone()).init_with(|| {
+            base_consensus_engine::Metrics::init();
+            base_consensus_node::Metrics::init();
+            base_consensus_derive::Metrics::init();
+            base_consensus_providers::Metrics::init();
+            base_cli_utils::register_version_metrics!();
+        })?;
+
         // Run the subcommand.
         RuntimeManager::run_until_ctrl_c(self.exec())
     }
@@ -139,6 +152,10 @@ impl Follow {
     /// Run the Follow subcommand.
     pub async fn exec(&self) -> eyre::Result<()> {
         let cfg = self.l2_config.load(&self.l2_chain_id).map_err(|e| eyre::eyre!("{e}"))?;
+
+        if self.metrics.enabled {
+            init_rollup_config_metrics(&cfg);
+        }
 
         if !self.proofs {
             warn!(

--- a/crates/batcher/service/src/config.rs
+++ b/crates/batcher/service/src/config.rs
@@ -66,8 +66,6 @@ pub struct BatcherConfig {
     pub resubmission_timeout: Duration,
     /// Throttle configuration (optional).
     pub throttle: Option<ThrottleConfig>,
-    /// Metrics server port.
-    pub metrics_port: u16,
 }
 
 impl Default for BatcherConfig {
@@ -85,7 +83,6 @@ impl Default for BatcherConfig {
             num_confirmations: 1,
             resubmission_timeout: Duration::from_secs(48),
             throttle: Some(ThrottleConfig::default()),
-            metrics_port: 7300,
         }
     }
 }

--- a/crates/batcher/service/src/service.rs
+++ b/crates/batcher/service/src/service.rs
@@ -14,7 +14,7 @@ use base_batcher_encoder::BatchEncoder;
 use base_batcher_source::{BlockSubscription, HybridBlockSource, HybridL1HeadSource, SourceError};
 use base_consensus_genesis::RollupConfig;
 use base_runtime::TokioRuntime;
-use base_tx_manager::{NoopTxMetrics, SignerConfig, SimpleTxManager, TxManagerConfig};
+use base_tx_manager::{BaseTxMetrics, SignerConfig, SimpleTxManager, TxManagerConfig};
 use futures::{StreamExt, future::BoxFuture, stream::BoxStream};
 use serde_json::Value;
 use tokio_util::sync::CancellationToken;
@@ -357,7 +357,7 @@ impl BatcherService {
             signer_config,
             tx_manager_config,
             l1_chain_id,
-            Arc::new(NoopTxMetrics),
+            Arc::new(BaseTxMetrics::new("batcher")),
         )
         .await
         .map_err(|e| eyre::eyre!("failed to create tx manager: {e}"))?;


### PR DESCRIPTION
## Summary
- start the shared Prometheus server for base-consensus follow
- start the shared Prometheus server for base-batcher and register version metrics
- switch the batcher tx manager to BaseTxMetrics and remove the unused batcher service metrics port config