### PR TITLE
chore(tx-manager): Osaka-only for blob sidecars

### DIFF
--- a/crates/utilities/tx-manager/src/blob.rs
+++ b/crates/utilities/tx-manager/src/blob.rs
@@ -1,17 +1,14 @@
 //! EIP-4844 blob transaction sidecar construction.
 //!
 //! [`BlobTxBuilder`] wraps alloy's KZG sidecar API to produce
-//! [`BlobTransactionSidecar`] (legacy, 1 proof/blob) or
-//! [`BlobTransactionSidecarVariant::Eip7594`] (cell proofs, 128 proofs/blob)
-//! depending on a configurable activation timestamp.
+//! [`BlobTransactionSidecarEip7594`] sidecars
+//! (cell proofs, 128 proofs/blob) on all supported networks.
 
 use std::sync::Arc;
 
 use alloy_eips::{
-    eip4844::{Blob, BlobTransactionSidecar, env_settings::EnvKzgSettings},
-    eip7594::{
-        BlobTransactionSidecarEip7594, BlobTransactionSidecarVariant, MAX_BLOBS_PER_TX_FUSAKA,
-    },
+    eip4844::{Blob, env_settings::EnvKzgSettings},
+    eip7594::{BlobTransactionSidecarEip7594, MAX_BLOBS_PER_TX_FUSAKA},
 };
 
 use crate::TxManagerError;
@@ -21,83 +18,33 @@ use crate::TxManagerError;
 /// Set to [`MAX_BLOBS_PER_TX_FUSAKA`] (6), the Fusaka per-transaction limit.
 pub const MAX_BLOBS_PER_TX: usize = MAX_BLOBS_PER_TX_FUSAKA as usize;
 
-/// Builder for EIP-4844 blob-carrying transaction sidecars.
-///
-/// Wraps alloy's KZG primitives to construct either legacy (1 proof/blob)
-/// or EIP-7594 cell-proof (128 proofs/blob) sidecars based on a
-/// configurable activation timestamp.
-#[derive(Debug, Clone)]
-pub struct BlobTxBuilder {
-    /// Unix timestamp at or after which cell proofs are used.
-    /// `u64::MAX` disables cell proofs (always legacy).
-    pub cell_proofs_activation_timestamp: u64,
-}
+/// Builder for Osaka-era EIP-4844 blob sidecars.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct BlobTxBuilder;
 
 impl BlobTxBuilder {
     /// Creates a new [`BlobTxBuilder`].
-    ///
-    /// Pass `u64::MAX` to disable cell proofs (always produce legacy sidecars).
     #[must_use]
-    pub const fn new(cell_proofs_activation_timestamp: u64) -> Self {
-        Self { cell_proofs_activation_timestamp }
+    pub const fn new() -> Self {
+        Self
     }
 
-    /// Returns `true` when EIP-7594 cell proofs should be used.
-    ///
-    /// Cell proofs are active when `block_timestamp` is at or past the
-    /// configured activation timestamp.
-    #[must_use]
-    pub const fn should_use_cell_proofs(&self, block_timestamp: u64) -> bool {
-        if self.cell_proofs_activation_timestamp == u64::MAX {
-            return false;
-        }
-        block_timestamp >= self.cell_proofs_activation_timestamp
-    }
-
-    /// Returns `true` when `sidecar`'s proof variant matches what
-    /// [`should_use_cell_proofs`](Self::should_use_cell_proofs) would select
-    /// for the given `block_timestamp`.
-    ///
-    /// Use this to detect stale cached sidecars across fork boundaries
-    /// (e.g. the `cell_proofs_activation_timestamp` was crossed during an
-    /// active send loop).
-    #[must_use]
-    pub const fn is_sidecar_valid(
-        &self,
-        sidecar: &BlobTransactionSidecarVariant,
-        block_timestamp: u64,
-    ) -> bool {
-        self.should_use_cell_proofs(block_timestamp) == sidecar.is_eip7594()
-    }
-
-    /// Builds a [`BlobTransactionSidecarVariant`], automatically selecting
-    /// legacy or EIP-7594 cell proofs based on [`should_use_cell_proofs`](Self::should_use_cell_proofs).
+    /// Builds an Osaka-era EIP-7594 cell-proof sidecar.
     ///
     /// # Errors
     ///
     /// Returns [`TxManagerError::Unsupported`] if KZG computation fails.
-    pub fn make_sidecar_auto(
+    pub fn build_sidecar(
         &self,
         blobs: Arc<Vec<Blob>>,
-        block_timestamp: u64,
-    ) -> Result<BlobTransactionSidecarVariant, TxManagerError> {
+    ) -> Result<BlobTransactionSidecarEip7594, TxManagerError> {
         let settings = EnvKzgSettings::Default;
         let kzg = settings.get();
         let blobs = Arc::unwrap_or_clone(blobs);
 
-        if self.should_use_cell_proofs(block_timestamp) {
-            let eip7594 = BlobTransactionSidecarEip7594::try_from_blobs_with_settings(blobs, kzg)
-                .map_err(|e| {
-                TxManagerError::Unsupported(format!("EIP-7594 cell proof computation failed: {e}"))
-            })?;
-            Ok(BlobTransactionSidecarVariant::Eip7594(eip7594))
-        } else {
-            let sidecar = BlobTransactionSidecar::try_from_blobs_with_settings(blobs, kzg)
-                .map_err(|e| {
-                    TxManagerError::Unsupported(format!("KZG sidecar construction failed: {e}"))
-                })?;
-            Ok(BlobTransactionSidecarVariant::Eip4844(sidecar))
-        }
+        BlobTransactionSidecarEip7594::try_from_blobs_with_settings(blobs, kzg).map_err(|e| {
+            TxManagerError::Unsupported(format!("EIP-7594 cell proof computation failed: {e}"))
+        })
     }
 }
 
@@ -108,108 +55,23 @@ mod tests {
 
     use super::*;
 
-    /// Helper: creates a builder with cell proofs disabled.
-    fn legacy_builder() -> BlobTxBuilder {
-        BlobTxBuilder::new(u64::MAX)
-    }
-
-    /// Helper: creates a builder with cell proofs always active.
-    fn cell_proofs_builder() -> BlobTxBuilder {
-        BlobTxBuilder::new(0)
+    fn builder() -> BlobTxBuilder {
+        BlobTxBuilder::new()
     }
 
     #[rstest]
     #[case::single_blob(1)]
     #[case::two_blobs(2)]
     #[case::six_blobs(6)]
-    fn make_sidecar_auto_n_blobs_legacy(#[case] n: usize) {
-        let builder = legacy_builder();
-        let variant = builder.make_sidecar_auto(Arc::new(vec![Blob::default(); n]), 0).unwrap();
-        let sidecar = variant.as_eip4844().expect("expected Eip4844 variant");
-        assert_eq!(sidecar.blobs.len(), n);
-        assert_eq!(sidecar.commitments.len(), n);
-        assert_eq!(sidecar.proofs.len(), n);
-    }
-
-    #[test]
-    fn versioned_hashes_use_0x01_version_byte() {
-        let builder = legacy_builder();
-        let variant =
-            builder.make_sidecar_auto(Arc::new(vec![Blob::default(), Blob::default()]), 0).unwrap();
-        for hash in variant.versioned_hashes() {
-            assert_eq!(hash.0[0], 0x01, "versioned hash should start with 0x01, got: {hash}");
-        }
-    }
-
-    #[rstest]
-    #[case::disabled(u64::MAX, 1_000_000, false)]
-    #[case::past(1_000, 1_001, true)]
-    #[case::exactly_at_activation(1_000, 1_000, true)]
-    #[case::one_second_before(1_000, 999, false)]
-    #[case::future(u64::MAX - 1, 1_000_000, false)]
-    fn should_use_cell_proofs(
-        #[case] activation: u64,
-        #[case] block_ts: u64,
-        #[case] expected: bool,
-    ) {
-        let builder = BlobTxBuilder::new(activation);
-        assert_eq!(builder.should_use_cell_proofs(block_ts), expected);
-    }
-
-    #[test]
-    fn make_sidecar_auto_legacy() {
-        let builder = legacy_builder();
-        let variant = builder.make_sidecar_auto(Arc::new(vec![Blob::default()]), 0).unwrap();
-        assert!(variant.is_eip4844(), "expected Eip4844 variant");
-        let sidecar = variant.as_eip4844().unwrap();
-        assert_eq!(sidecar.proofs.len(), 1);
-    }
-
-    #[test]
-    fn make_sidecar_auto_cell_proofs() {
-        let builder = cell_proofs_builder();
-        let variant = builder.make_sidecar_auto(Arc::new(vec![Blob::default()]), 1_000).unwrap();
-        assert!(variant.is_eip7594(), "expected Eip7594 variant");
-        let sidecar = variant.as_eip7594().unwrap();
-        // 128 cell proofs per blob.
-        assert_eq!(sidecar.cell_proofs.len(), CELLS_PER_EXT_BLOB);
+    fn build_sidecar_n_blobs_uses_cell_proofs(#[case] n: usize) {
+        let builder = builder();
+        let sidecar = builder.build_sidecar(Arc::new(vec![Blob::default(); n])).unwrap();
+        assert_eq!(sidecar.cell_proofs.len(), n * CELLS_PER_EXT_BLOB);
     }
 
     #[test]
     fn blob_tx_builder_is_send_and_sync() {
         fn assert_send_sync<T: Send + Sync>() {}
         assert_send_sync::<BlobTxBuilder>();
-    }
-
-    // ── is_sidecar_valid ────────────────────────────────────────────────
-
-    #[rstest]
-    #[case::matches_legacy_before_activation(999, 999, true)]
-    #[case::matches_cell_proofs_after_activation(1_000, 1_000, true)]
-    #[case::rejects_legacy_after_activation(999, 1_000, false)]
-    #[case::rejects_cell_proofs_before_activation(1_000, 999, false)]
-    fn is_sidecar_valid(#[case] build_ts: u64, #[case] validate_ts: u64, #[case] expected: bool) {
-        let builder = BlobTxBuilder::new(1_000);
-        let sidecar = builder.make_sidecar_auto(Arc::new(vec![Blob::default()]), build_ts).unwrap();
-        assert_eq!(builder.is_sidecar_valid(&sidecar, validate_ts), expected);
-    }
-
-    #[test]
-    fn sidecar_cache_invalidated_across_fork_transition() {
-        let builder = BlobTxBuilder::new(1_000);
-        let blobs = Arc::new(vec![Blob::default()]);
-
-        // Build pre-fork sidecar.
-        let pre_fork = builder.make_sidecar_auto(Arc::clone(&blobs), 999).unwrap();
-        assert!(pre_fork.is_eip4844());
-        assert!(builder.is_sidecar_valid(&pre_fork, 999));
-
-        // After fork activation the cached sidecar is stale.
-        assert!(!builder.is_sidecar_valid(&pre_fork, 1_000));
-
-        // Rebuild with post-fork timestamp produces a valid sidecar.
-        let post_fork = builder.make_sidecar_auto(blobs, 1_000).unwrap();
-        assert!(post_fork.is_eip7594());
-        assert!(builder.is_sidecar_valid(&post_fork, 1_000));
     }
 }

--- a/crates/utilities/tx-manager/src/config.rs
+++ b/crates/utilities/tx-manager/src/config.rs
@@ -115,9 +115,6 @@ pub struct TxManagerConfig {
     pub confirmation_timeout: Duration,
     /// Minimum blob base fee (in wei) to use for blob transactions.
     pub min_blob_fee: u128,
-    /// Unix timestamp at or after which cell proofs (EIP-7594, 128 proofs/blob)
-    /// are used instead of legacy KZG proofs (1 proof/blob). `u64::MAX` disables.
-    pub cell_proofs_activation_timestamp: u64,
 }
 
 impl Default for TxManagerConfig {
@@ -136,7 +133,6 @@ impl Default for TxManagerConfig {
             tx_not_in_mempool_timeout: Duration::from_secs(120),
             confirmation_timeout: Duration::from_secs(300),
             min_blob_fee: 1_000_000_000, // 1 gwei
-            cell_proofs_activation_timestamp: u64::MAX,
         }
     }
 }
@@ -303,11 +299,6 @@ mod tests {
     #[test]
     fn default_min_blob_fee_is_one_gwei() {
         assert_eq!(TxManagerConfig::default().min_blob_fee, 1_000_000_000);
-    }
-
-    #[test]
-    fn default_cell_proofs_activation_disabled() {
-        assert_eq!(TxManagerConfig::default().cell_proofs_activation_timestamp, u64::MAX);
     }
 
     #[test]

--- a/crates/utilities/tx-manager/src/fees.rs
+++ b/crates/utilities/tx-manager/src/fees.rs
@@ -268,12 +268,6 @@ pub struct GasPriceCaps {
     /// Used as the `suggested` baseline in [`FeeCalculator::check_limits`]
     /// so the blob fee ceiling mirrors the gas fee ceiling behaviour.
     pub raw_blob_fee_cap: Option<u128>,
-    /// Timestamp of the latest block used to derive these fee estimates.
-    ///
-    /// Threaded to [`BlobTxBuilder::make_sidecar_auto`] so the
-    /// legacy-vs-cell-proof decision is deterministic with respect to
-    /// chain state rather than wall-clock time.
-    pub block_timestamp: u64,
 }
 
 #[cfg(test)]
@@ -294,7 +288,6 @@ mod tests {
         assert_eq!(caps.raw_gas_fee_cap, 0);
         assert!(caps.blob_fee_cap.is_none());
         assert!(caps.raw_blob_fee_cap.is_none());
-        assert_eq!(caps.block_timestamp, 0);
     }
 
     #[test]

--- a/crates/utilities/tx-manager/src/macros.rs
+++ b/crates/utilities/tx-manager/src/macros.rs
@@ -8,8 +8,8 @@
 /// base_tx_manager::define_tx_manager_cli!("BASE_CHALLENGER_TX_MANAGER");
 /// ```
 ///
-/// The generated struct has twelve fields covering confirmations, fee limits,
-/// timeouts, and polling intervals. Each env-backed field uses
+/// The generated struct exposes confirmations, fee limits, timeouts, polling
+/// intervals, and blob fee controls. Each env-backed field uses
 /// `concat!($prefix, "_", "FIELD_NAME")` — e.g., with prefix
 /// `"BASE_CHALLENGER_TX_MANAGER"` the num-confirmations field reads from
 /// `BASE_CHALLENGER_TX_MANAGER_NUM_CONFIRMATIONS`.
@@ -162,15 +162,6 @@ macro_rules! define_tx_manager_cli {
             )]
             pub min_blob_fee_gwei: String,
 
-            /// Unix timestamp at or after which EIP-7594 cell proofs (128
-            /// proofs/blob) are used instead of legacy KZG proofs (1 proof/blob).
-            /// Set to the maximum u64 value to disable.
-            #[arg(
-                long = "tx-manager.cell-proofs-activation-timestamp",
-                env = concat!($prefix, "_", "CELL_PROOFS_ACTIVATION_TIMESTAMP"),
-                default_value_t = u64::MAX
-            )]
-            pub cell_proofs_activation_timestamp: u64,
         }
 
         impl Default for TxManagerCli {
@@ -206,7 +197,6 @@ macro_rules! define_tx_manager_cli {
                     tx_not_in_mempool_timeout: cli.tx_not_in_mempool_timeout,
                     confirmation_timeout: cli.confirmation_timeout,
                     min_blob_fee,
-                    cell_proofs_activation_timestamp: cli.cell_proofs_activation_timestamp,
                 };
                 config.validate()?;
                 Ok(config)

--- a/crates/utilities/tx-manager/src/manager.rs
+++ b/crates/utilities/tx-manager/src/manager.rs
@@ -41,7 +41,7 @@ use std::{
     time::{Duration, Instant},
 };
 
-use alloy_eips::{BlockNumberOrTag, Encodable2718, eip7594::BlobTransactionSidecarVariant};
+use alloy_eips::{BlockNumberOrTag, Encodable2718, eip7594::BlobTransactionSidecarEip7594};
 use alloy_network::{Ethereum, EthereumWallet, NetworkWallet, TransactionBuilder};
 use alloy_primitives::{Address, B256, Bytes};
 use alloy_provider::{Provider, RootProvider};
@@ -91,7 +91,7 @@ pub struct PreparedTx {
     /// copy rather than a deep clone (~800 KB per blob). One deep clone per
     /// `craft_tx` call is unavoidable because alloy's
     /// `TransactionRequest::sidecar` requires an owned value.
-    pub sidecar: Option<Arc<BlobTransactionSidecarVariant>>,
+    pub sidecar: Option<Arc<BlobTransactionSidecarEip7594>>,
 }
 
 /// Mutable fee-bump state tracked across iterations in the send loop.
@@ -115,7 +115,7 @@ struct BumpState {
     nonce: u64,
     /// Cached blob sidecar. See [`PreparedTx::sidecar`] for rationale on
     /// the `Arc` wrapper.
-    sidecar: Option<Arc<BlobTransactionSidecarVariant>>,
+    sidecar: Option<Arc<BlobTransactionSidecarEip7594>>,
 }
 
 impl BumpState {
@@ -229,7 +229,7 @@ impl SimpleTxManager {
 
         let address = <EthereumWallet as NetworkWallet<Ethereum>>::default_signer_address(&wallet);
         let nonce_manager = NonceManager::new(provider.clone(), address, config.network_timeout);
-        let blob_builder = BlobTxBuilder::new(config.cell_proofs_activation_timestamp);
+        let blob_builder = BlobTxBuilder::new();
         Ok(Self {
             provider,
             wallet,
@@ -384,7 +384,7 @@ impl SimpleTxManager {
         fee_overrides: Option<FeeOverride>,
         mut initial_caps: Option<GasPriceCaps>,
         nonce_override: Option<u64>,
-        cached_sidecar: Option<Arc<BlobTransactionSidecarVariant>>,
+        cached_sidecar: Option<Arc<BlobTransactionSidecarEip7594>>,
     ) -> TxManagerResult<PreparedTx> {
         (|| {
             let caps = initial_caps.take();
@@ -514,15 +514,12 @@ impl SimpleTxManager {
             None => (None, None),
         };
 
-        let block_timestamp = latest_block.header.timestamp;
-
         Ok(GasPriceCaps {
             gas_tip_cap: tip_cap,
             gas_fee_cap,
             raw_gas_fee_cap,
             blob_fee_cap,
             raw_blob_fee_cap,
-            block_timestamp,
         })
     }
 
@@ -665,7 +662,7 @@ impl SimpleTxManager {
         fee_overrides: Option<FeeOverride>,
         caps: Option<GasPriceCaps>,
         nonce_override: Option<u64>,
-        cached_sidecar: Option<Arc<BlobTransactionSidecarVariant>>,
+        cached_sidecar: Option<Arc<BlobTransactionSidecarEip7594>>,
     ) -> TxManagerResult<PreparedTx> {
         let is_blob = !candidate.blobs.is_empty();
 
@@ -749,33 +746,13 @@ impl SimpleTxManager {
         // Step 4b: Attach blob sidecar and blob-specific fields.
         //
         // Reuse a cached sidecar when available (fee bump iterations) to
-        // avoid recomputing KZG proofs from the same blob data. If the
-        // cached sidecar's proof variant no longer matches the current
-        // block timestamp (e.g. fork activation crossed mid-send-loop),
-        // discard it and rebuild.
+        // avoid recomputing KZG proofs from the same blob data.
         let built_sidecar = if is_blob {
-            let sidecar =
-                match cached_sidecar {
-                    Some(cached)
-                        if self.blob_builder.is_sidecar_valid(&cached, caps.block_timestamp) =>
-                    {
-                        cached
-                    }
-                    cached => {
-                        if let Some(ref stale) = cached {
-                            info!(
-                                block_timestamp = caps.block_timestamp,
-                                cached_is_eip7594 = stale.is_eip7594(),
-                                "cached sidecar proof type stale, rebuilding"
-                            );
-                        }
-                        Arc::new(self.blob_builder.make_sidecar_auto(
-                            Arc::clone(&candidate.blobs),
-                            caps.block_timestamp,
-                        )?)
-                    }
-                };
-            tx_request.sidecar = Some((*sidecar).clone());
+            let sidecar = match cached_sidecar {
+                Some(cached) => cached,
+                None => Arc::new(self.blob_builder.build_sidecar(Arc::clone(&candidate.blobs))?),
+            };
+            tx_request.sidecar = Some((*sidecar).clone().into());
             tx_request.populate_blob_hashes();
             tx_request.max_fee_per_blob_gas = blob_fee_cap;
             Some(sidecar)
@@ -1718,7 +1695,6 @@ mod tests {
             raw_gas_fee_cap: 15_000_000_000_000,
             blob_fee_cap: None,
             raw_blob_fee_cap: None,
-            block_timestamp: 0,
         };
 
         let prepared = manager

--- a/crates/utilities/tx-manager/tests/craft_tx.rs
+++ b/crates/utilities/tx-manager/tests/craft_tx.rs
@@ -3,7 +3,7 @@
 use std::sync::Arc;
 
 use alloy_consensus::{SignableTransaction, TxEip1559, TxEip4844Variant, TxEnvelope};
-use alloy_eips::{Decodable2718, eip4844::Blob};
+use alloy_eips::{Decodable2718, eip4844::Blob, eip7594::CELLS_PER_EXT_BLOB};
 use alloy_network::{EthereumWallet, TxSigner};
 use alloy_node_bindings::Anvil;
 use alloy_primitives::{Address, B256, Bytes, Signature, TxKind, U256};
@@ -214,10 +214,8 @@ async fn craft_tx_produces_valid_signed_blob_transaction() {
 }
 
 #[tokio::test]
-async fn craft_tx_produces_cell_proof_sidecar_when_enabled() {
-    let config =
-        TxManagerConfig { cell_proofs_activation_timestamp: 0, ..TxManagerConfig::default() };
-    let (manager, anvil) = setup_with_config(config).await;
+async fn craft_tx_produces_cell_proof_sidecar_by_default() {
+    let (manager, anvil) = setup().await;
 
     let to = Address::with_last_byte(0x42);
     let candidate =
@@ -226,9 +224,9 @@ async fn craft_tx_produces_cell_proof_sidecar_when_enabled() {
     let prepared =
         manager.craft_tx(&candidate, None).await.expect("should craft cell-proof blob tx");
 
-    // The cached sidecar must use the EIP-7594 (cell proofs) variant.
+    // The cached sidecar must use Osaka-era cell proofs.
     let sidecar = prepared.sidecar.as_ref().expect("sidecar should be Some for blob tx");
-    assert!(sidecar.is_eip7594(), "expected EIP-7594 cell-proof sidecar");
+    assert_eq!(sidecar.cell_proofs.len(), CELLS_PER_EXT_BLOB);
 
     // On the wire it is still EIP-4844 type — cell proofs are sidecar-internal.
     let envelope =

--- a/crates/utilities/tx-manager/tests/custom_prefix.rs
+++ b/crates/utilities/tx-manager/tests/custom_prefix.rs
@@ -31,6 +31,7 @@ fn env_vars_use_custom_prefix() {
         ("tx-manager.tx-send-timeout", "CUSTOM_PREFIX_TX_SEND_TIMEOUT"),
         ("tx-manager.tx-not-in-mempool-timeout", "CUSTOM_PREFIX_TX_NOT_IN_MEMPOOL_TIMEOUT"),
         ("tx-manager.confirmation-timeout", "CUSTOM_PREFIX_CONFIRMATION_TIMEOUT"),
+        ("tx-manager.min-blob-fee", "CUSTOM_PREFIX_MIN_BLOB_FEE"),
     ];
 
     for (long_name, expected_env) in cases {


### PR DESCRIPTION
## Summary
Remove legacy sidecar and cell-proof activation options from tx-manager, Osaka is activated on all networks it isn't worth supporting pre Osaka