### PR TITLE
refactor(tx-manager): make nonce manager generic over provider trait

### DIFF
--- a/crates/utilities/tx-manager/src/manager.rs
+++ b/crates/utilities/tx-manager/src/manager.rs
@@ -148,7 +148,7 @@ pub struct SimpleTxManager {
     /// Validated runtime configuration.
     config: TxManagerConfig,
     /// Nonce manager for sequential nonce allocation.
-    nonce_manager: NonceManager,
+    nonce_manager: NonceManager<RootProvider>,
     /// Chain ID for transaction construction.
     chain_id: u64,
     /// Shutdown flag shared across the manager and any spawned background
@@ -258,7 +258,7 @@ impl SimpleTxManager {
     }
 
     /// Returns a reference to the nonce manager.
-    pub const fn nonce_manager(&self) -> &NonceManager {
+    pub const fn nonce_manager(&self) -> &NonceManager<RootProvider> {
         &self.nonce_manager
     }
 

--- a/crates/utilities/tx-manager/src/nonce.rs
+++ b/crates/utilities/tx-manager/src/nonce.rs
@@ -3,7 +3,7 @@
 use std::{collections::BTreeSet, sync::Arc, time::Duration};
 
 use alloy_primitives::Address;
-use alloy_provider::{Provider, RootProvider};
+use alloy_provider::Provider;
 use tokio::sync::{Mutex, OwnedMutexGuard};
 use tracing::{debug, info, warn};
 
@@ -54,14 +54,14 @@ pub struct NonceState {
 /// returned [`NonceGuard`], ensuring sequential nonce assignment even
 /// under concurrent access.
 #[derive(Debug, Clone)]
-pub struct NonceManager {
+pub struct NonceManager<P> {
     inner: Arc<Mutex<NonceState>>,
-    provider: RootProvider,
+    provider: P,
     address: Address,
     rpc_timeout: Duration,
 }
 
-impl NonceManager {
+impl<P: Provider> NonceManager<P> {
     /// Creates a new [`NonceManager`] with no cached nonce.
     ///
     /// The `rpc_timeout` bounds the `get_transaction_count` RPC call
@@ -69,7 +69,7 @@ impl NonceManager {
     ///
     /// The first call to [`next_nonce`](Self::next_nonce) will fetch the
     /// current transaction count from the provider.
-    pub fn new(provider: RootProvider, address: Address, rpc_timeout: Duration) -> Self {
+    pub fn new(provider: P, address: Address, rpc_timeout: Duration) -> Self {
         Self { inner: Arc::new(Mutex::new(NonceState::default())), provider, address, rpc_timeout }
     }
 
@@ -365,10 +365,11 @@ mod tests {
     };
 
     use alloy_node_bindings::Anvil;
+    use alloy_provider::RootProvider;
 
     use super::*;
 
-    impl NonceManager {
+    impl NonceManager<RootProvider> {
         /// Creates a [`NonceManager`] with the cache pre-seeded to `nonce`.
         ///
         /// Test-only: allows exercising edge-case nonce values (e.g.

--- a/crates/utilities/tx-manager/tests/nonce.rs
+++ b/crates/utilities/tx-manager/tests/nonce.rs
@@ -13,7 +13,7 @@ use rayon::prelude::*;
 
 /// Helper: spawns an Anvil instance and returns a [`NonceManager`] wired to
 /// the first default account.
-fn setup() -> (NonceManager, alloy_node_bindings::AnvilInstance) {
+fn setup() -> (NonceManager<RootProvider>, alloy_node_bindings::AnvilInstance) {
     let anvil = Anvil::new().spawn();
     let url = anvil.endpoint_url();
     let provider = RootProvider::new_http(url);


### PR DESCRIPTION
### What changed? Why?

Makes `NonceManager` generic over a provider trait (`P: Provider`) instead of being hardcoded to `RootProvider`.

- `NonceManager` now takes a type parameter `P` and stores `provider: P` instead of `provider: RootProvider`
- The `impl` block is bounded by `P: Provider`, so any provider implementation can be used
- `SimpleTxManager` concretizes the type as `NonceManager<RootProvider>` to preserve its existing API
- `RootProvider` import moved from the main module to the test module where it's still needed for the test-only `seeded` constructor

This decouples the nonce manager from a specific provider type, enabling easier testing with mock providers and reuse in contexts that don't use `RootProvider`.

### Notes to reviewers

Pure refactor — no behavioral changes. All existing tests pass without modification (only type annotations updated).

### How has it been tested?

Existing unit and integration tests in `crates/utilities/tx-manager/` continue to pass.

### Change management ([definitions](http://go/change-management))

type=routine<!--routine,nonroutine,emergency-->
risk=low<!--low,medium,high-->
impact=sev5<!--sev5,sev4,sev3,sev2,sev1-->

### Backwards Compatibility ([learn more](http://go/backwards-compatibility))

backwards_compatible=true<!-- true false -->

<!-- Automatically merge your PR once the necessary approvals have been received (you probably want this) -->

automerge=false