### PR TITLE
feat(CHAIN-3559): nitro-verifier x509 chain verification + audit fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1459,11 +1459,27 @@ dependencies = [
 
 [[package]]
 name = "asn1-rs"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5493c3bedbacf7fd7382c6346bbd66687d12bbaad3a89a2d2c303ee6cf20b048"
+dependencies = [
+ "asn1-rs-derive 0.5.1",
+ "asn1-rs-impl",
+ "displaydoc",
+ "nom",
+ "num-traits",
+ "rusticata-macros",
+ "thiserror 1.0.69",
+ "time",
+]
+
+[[package]]
+name = "asn1-rs"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56624a96882bb8c26d61312ae18cb45868e5a9992ea73c58e45c3101e56a1e60"
 dependencies = [
- "asn1-rs-derive",
+ "asn1-rs-derive 0.6.0",
  "asn1-rs-impl",
  "displaydoc",
  "nom",
@@ -1471,6 +1487,18 @@ dependencies = [
  "rusticata-macros",
  "thiserror 2.0.18",
  "time",
+]
+
+[[package]]
+name = "asn1-rs-derive"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "965c2d33e53cb6b267e148a4cb0760bc01f4904c1cd4bb4002a085bb016d1490"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "synstructure",
 ]
 
 [[package]]
@@ -4441,9 +4469,14 @@ dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
  "ciborium",
+ "hex",
+ "p384",
+ "rstest",
  "serde",
  "serde_bytes",
+ "sha2 0.10.9",
  "thiserror 2.0.18",
+ "x509-parser 0.16.0",
 ]
 
 [[package]]
@@ -6644,11 +6677,25 @@ dependencies = [
 
 [[package]]
 name = "der-parser"
+version = "9.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cd0a5c643689626bec213c4d8bd4d96acc8ffdb4ad4bb6bc16abf27d5f4b553"
+dependencies = [
+ "asn1-rs 0.6.2",
+ "displaydoc",
+ "nom",
+ "num-bigint",
+ "num-traits",
+ "rusticata-macros",
+]
+
+[[package]]
+name = "der-parser"
 version = "10.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07da5016415d5a3c4dd39b11ed26f915f52fc4e0dc197d87908bc916e51bc1a6"
 dependencies = [
- "asn1-rs",
+ "asn1-rs 0.7.1",
  "displaydoc",
  "nom",
  "num-bigint",
@@ -10012,7 +10059,7 @@ dependencies = [
  "rustls 0.23.37",
  "rustls-webpki 0.103.9",
  "thiserror 2.0.18",
- "x509-parser",
+ "x509-parser 0.17.0",
  "yasna",
 ]
 
@@ -11116,11 +11163,20 @@ dependencies = [
 
 [[package]]
 name = "oid-registry"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8d8034d9489cdaf79228eb9f6a3b8d7bb32ba00d6645ebd48eef4077ceb5bd9"
+dependencies = [
+ "asn1-rs 0.6.2",
+]
+
+[[package]]
+name = "oid-registry"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12f40cff3dde1b6087cc5d5f5d4d65712f34016a03ed60e9c08dcc392736b5b7"
 dependencies = [
- "asn1-rs",
+ "asn1-rs 0.7.1",
 ]
 
 [[package]]
@@ -19918,16 +19974,33 @@ dependencies = [
 
 [[package]]
 name = "x509-parser"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcbc162f30700d6f3f82a24bf7cc62ffe7caea42c0b2cba8bf7f3ae50cf51f69"
+dependencies = [
+ "asn1-rs 0.6.2",
+ "data-encoding",
+ "der-parser 9.0.0",
+ "lazy_static",
+ "nom",
+ "oid-registry 0.7.1",
+ "rusticata-macros",
+ "thiserror 1.0.69",
+ "time",
+]
+
+[[package]]
+name = "x509-parser"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4569f339c0c402346d4a75a9e39cf8dad310e287eef1ff56d4c68e5067f53460"
 dependencies = [
- "asn1-rs",
+ "asn1-rs 0.7.1",
  "data-encoding",
- "der-parser",
+ "der-parser 10.0.0",
  "lazy_static",
  "nom",
- "oid-registry",
+ "oid-registry 0.8.1",
  "rusticata-macros",
  "thiserror 2.0.18",
  "time",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1459,27 +1459,11 @@ dependencies = [
 
 [[package]]
 name = "asn1-rs"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5493c3bedbacf7fd7382c6346bbd66687d12bbaad3a89a2d2c303ee6cf20b048"
-dependencies = [
- "asn1-rs-derive 0.5.1",
- "asn1-rs-impl",
- "displaydoc",
- "nom",
- "num-traits",
- "rusticata-macros",
- "thiserror 1.0.69",
- "time",
-]
-
-[[package]]
-name = "asn1-rs"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56624a96882bb8c26d61312ae18cb45868e5a9992ea73c58e45c3101e56a1e60"
 dependencies = [
- "asn1-rs-derive 0.6.0",
+ "asn1-rs-derive",
  "asn1-rs-impl",
  "displaydoc",
  "nom",
@@ -1487,18 +1471,6 @@ dependencies = [
  "rusticata-macros",
  "thiserror 2.0.18",
  "time",
-]
-
-[[package]]
-name = "asn1-rs-derive"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "965c2d33e53cb6b267e148a4cb0760bc01f4904c1cd4bb4002a085bb016d1490"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
- "synstructure",
 ]
 
 [[package]]
@@ -4476,7 +4448,7 @@ dependencies = [
  "serde_bytes",
  "sha2 0.10.9",
  "thiserror 2.0.18",
- "x509-parser 0.16.0",
+ "x509-parser",
 ]
 
 [[package]]
@@ -6596,7 +6568,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ab67060fc6b8ef687992d439ca0fa36e7ed17e9a0b16b25b601e8757df720de"
 dependencies = [
  "data-encoding",
- "syn 2.0.117",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -6677,25 +6649,11 @@ dependencies = [
 
 [[package]]
 name = "der-parser"
-version = "9.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cd0a5c643689626bec213c4d8bd4d96acc8ffdb4ad4bb6bc16abf27d5f4b553"
-dependencies = [
- "asn1-rs 0.6.2",
- "displaydoc",
- "nom",
- "num-bigint",
- "num-traits",
- "rusticata-macros",
-]
-
-[[package]]
-name = "der-parser"
 version = "10.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07da5016415d5a3c4dd39b11ed26f915f52fc4e0dc197d87908bc916e51bc1a6"
 dependencies = [
- "asn1-rs 0.7.1",
+ "asn1-rs",
  "displaydoc",
  "nom",
  "num-bigint",
@@ -10059,7 +10017,7 @@ dependencies = [
  "rustls 0.23.37",
  "rustls-webpki 0.103.9",
  "thiserror 2.0.18",
- "x509-parser 0.17.0",
+ "x509-parser",
  "yasna",
 ]
 
@@ -11163,20 +11121,11 @@ dependencies = [
 
 [[package]]
 name = "oid-registry"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8d8034d9489cdaf79228eb9f6a3b8d7bb32ba00d6645ebd48eef4077ceb5bd9"
-dependencies = [
- "asn1-rs 0.6.2",
-]
-
-[[package]]
-name = "oid-registry"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12f40cff3dde1b6087cc5d5f5d4d65712f34016a03ed60e9c08dcc392736b5b7"
 dependencies = [
- "asn1-rs 0.7.1",
+ "asn1-rs",
 ]
 
 [[package]]
@@ -19974,33 +19923,16 @@ dependencies = [
 
 [[package]]
 name = "x509-parser"
-version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcbc162f30700d6f3f82a24bf7cc62ffe7caea42c0b2cba8bf7f3ae50cf51f69"
-dependencies = [
- "asn1-rs 0.6.2",
- "data-encoding",
- "der-parser 9.0.0",
- "lazy_static",
- "nom",
- "oid-registry 0.7.1",
- "rusticata-macros",
- "thiserror 1.0.69",
- "time",
-]
-
-[[package]]
-name = "x509-parser"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4569f339c0c402346d4a75a9e39cf8dad310e287eef1ff56d4c68e5067f53460"
 dependencies = [
- "asn1-rs 0.7.1",
+ "asn1-rs",
  "data-encoding",
- "der-parser 10.0.0",
+ "der-parser",
  "lazy_static",
  "nom",
- "oid-registry 0.8.1",
+ "oid-registry",
  "rusticata-macros",
  "thiserror 2.0.18",
  "time",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -424,11 +424,13 @@ aws-sdk-elasticloadbalancingv2 = { version = "1.109.0", default-features = false
 # crypto
 sha3 = "0.10"
 k256 = "0.13"
+p384 = "0.13"
 zeroize = "1"
 ciborium = "0.2"
 x509-cert = "0.2"
 rustls = "0.23.35"
 secp256k1 = "0.30"
+x509-parser = "0.16"
 rustls-pki-types = "1.0"
 sha2 = { version = "0.10", default-features = false }
 c-kzg = { version = "2.1.5", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -430,7 +430,7 @@ ciborium = "0.2"
 x509-cert = "0.2"
 rustls = "0.23.35"
 secp256k1 = "0.30"
-x509-parser = "0.16"
+x509-parser = "0.17"
 rustls-pki-types = "1.0"
 sha2 = { version = "0.10", default-features = false }
 c-kzg = { version = "2.1.5", default-features = false }

--- a/crates/proof/tee/nitro-verifier/Cargo.toml
+++ b/crates/proof/tee/nitro-verifier/Cargo.toml
@@ -15,7 +15,12 @@ workspace = true
 # Parsing
 ciborium.workspace = true
 serde_bytes.workspace = true
+x509-parser.workspace = true
 serde = { workspace = true, features = ["derive"] }
+
+# Crypto
+sha2.workspace = true
+p384 = { workspace = true, features = ["ecdsa"] }
 
 # Types
 alloy-sol-types.workspace = true
@@ -23,3 +28,7 @@ alloy-primitives = { workspace = true, default-features = false }
 
 # Error
 thiserror.workspace = true
+
+[dev-dependencies]
+hex.workspace = true
+rstest.workspace = true

--- a/crates/proof/tee/nitro-verifier/src/error.rs
+++ b/crates/proof/tee/nitro-verifier/src/error.rs
@@ -17,13 +17,21 @@ pub enum VerifierError {
     #[error("attestation format error: {0}")]
     AttestationFormat(String),
 
-    /// Certificate chain verification failed.
+    /// x509 certificate parsing failed.
+    #[error("x509 parse error: {0}")]
+    X509Parse(String),
+
+    /// Certificate chain verification failed (M-01 checks).
     #[error("certificate verification error: {0}")]
     CertificateVerification(String),
 
     /// COSE signature verification failed.
     #[error("signature verification error: {0}")]
     SignatureVerification(String),
+
+    /// Attestation content validation failed (M-02 checks).
+    #[error("content validation error: {0}")]
+    ContentValidation(String),
 }
 
 /// Convenience result alias for verifier operations.

--- a/crates/proof/tee/nitro-verifier/src/lib.rs
+++ b/crates/proof/tee/nitro-verifier/src/lib.rs
@@ -12,3 +12,9 @@ pub use types::{
     BatchVerifierJournal, Bytes48, Pcr, VerificationResult, VerifierInput, VerifierJournal,
     ZkCoProcessorConfig, ZkCoProcessorType,
 };
+
+mod verify;
+pub use verify::AttestationVerifier;
+
+mod x509;
+pub use x509::CertChain;

--- a/crates/proof/tee/nitro-verifier/src/types.rs
+++ b/crates/proof/tee/nitro-verifier/src/types.rs
@@ -8,6 +8,8 @@ use alloy_sol_types::{SolValue, sol};
 use serde_bytes::ByteArray;
 
 sol! {
+    #![sol(all_derives)]
+
     /// Supported zero-knowledge proof coprocessor types.
     ///
     /// All variants must be present to match the on-chain `INitroEnclaveVerifier.sol`

--- a/crates/proof/tee/nitro-verifier/src/verify.rs
+++ b/crates/proof/tee/nitro-verifier/src/verify.rs
@@ -6,14 +6,15 @@
 //! side effects.
 
 use alloy_primitives::Bytes;
-use p384::ecdsa::signature::Verifier;
-use p384::ecdsa::{Signature, VerifyingKey};
+use p384::ecdsa::{Signature, VerifyingKey, signature::Verifier};
 use serde_bytes::ByteBuf;
 
-use crate::attestation::{AttestationDocument, AttestationReport};
-use crate::types::{Bytes48, Pcr, VerificationResult, VerifierJournal};
-use crate::x509::CertChain;
-use crate::{Result, VerifierError, VerifierInput};
+use crate::{
+    Result, VerifierError, VerifierInput,
+    attestation::{AttestationDocument, AttestationReport},
+    types::{Bytes48, Pcr, VerificationResult, VerifierJournal},
+    x509::CertChain,
+};
 
 /// Attestation report verifier.
 ///
@@ -319,6 +320,14 @@ mod tests {
         let mut doc = valid_doc();
         doc.pcrs.insert(31, ByteArray::new([0u8; 48]));
         assert!(AttestationVerifier::validate_attestation_content(&doc).is_ok());
+    }
+
+    #[rstest]
+    fn m02_public_key_empty_rejected() {
+        let mut doc = valid_doc();
+        doc.public_key = Some(ByteBuf::from(vec![]));
+        let err = AttestationVerifier::validate_attestation_content(&doc).unwrap_err();
+        assert!(err.to_string().contains("public_key"));
     }
 
     #[rstest]

--- a/crates/proof/tee/nitro-verifier/src/verify.rs
+++ b/crates/proof/tee/nitro-verifier/src/verify.rs
@@ -1,0 +1,356 @@
+//! Top-level attestation verification orchestrating COSE parsing, certificate
+//! chain validation, signature verification, and content validation.
+//!
+//! [`AttestationVerifier::verify`] is the ZK guest entry point — called from the
+//! RISC Zero guest program in CHAIN-3560. It must be deterministic with no
+//! side effects.
+
+use alloy_primitives::Bytes;
+use p384::ecdsa::signature::Verifier;
+use p384::ecdsa::{Signature, VerifyingKey};
+use serde_bytes::ByteBuf;
+
+use crate::attestation::{AttestationDocument, AttestationReport};
+use crate::types::{Bytes48, Pcr, VerificationResult, VerifierJournal};
+use crate::x509::CertChain;
+use crate::{Result, VerifierError, VerifierInput};
+
+/// Attestation report verifier.
+///
+/// Entry point for end-to-end Nitro attestation verification including
+/// COSE parsing, M-02 content validation, x509 chain validation (M-01),
+/// COSE signature verification, and journal construction.
+#[derive(Debug)]
+pub struct AttestationVerifier;
+
+impl AttestationVerifier {
+    /// Verifies a Nitro attestation report end-to-end.
+    ///
+    /// 1. Parses the `COSE_Sign1` envelope and attestation document
+    /// 2. Validates attestation content (M-02 checks)
+    /// 3. Verifies the x509 certificate chain (M-01 checks)
+    /// 4. Verifies the COSE signature against the leaf certificate's public key
+    /// 5. Extracts verified data into a `VerifierJournal`
+    pub fn verify(input: &VerifierInput) -> Result<VerifierJournal> {
+        // 1. Parse attestation report.
+        let report = AttestationReport::parse(&input.attestationReport)?;
+
+        // 2. Validate attestation content (M-02).
+        Self::validate_attestation_content(&report.doc)?;
+
+        // 3. Extract and verify certificate chain.
+        let cert_chain_der = report.cert_chain_der();
+        let chain = CertChain::from_der(&cert_chain_der)?;
+
+        let trusted_prefix_len = input.trustedCertsPrefixLen as usize;
+        let certs = chain.verify_chain(trusted_prefix_len, report.doc.timestamp)?;
+
+        // 4. Verify COSE signature against the leaf certificate's public key.
+        let leaf_pk_bytes = chain.leaf_public_key()?;
+        let sig_structure = report.cose.sig_structure()?;
+        Self::verify_cose_signature(leaf_pk_bytes, &sig_structure, &report.cose.signature)?;
+
+        // 5. Build the journal.
+        let pcrs = report
+            .doc
+            .pcrs
+            .iter()
+            .map(|(&index, value)| Pcr { index, value: Bytes48::from(value) })
+            .collect::<Vec<_>>();
+
+        Ok(VerifierJournal {
+            result: VerificationResult::Success,
+            trustedCertsPrefixLen: input.trustedCertsPrefixLen,
+            timestamp: report.doc.timestamp,
+            certs,
+            userData: Self::optional_bytes(&report.doc.user_data),
+            nonce: Self::optional_bytes(&report.doc.nonce),
+            publicKey: Self::optional_bytes(&report.doc.public_key),
+            pcrs,
+            moduleId: report.doc.module_id,
+        })
+    }
+
+    /// Verifies the COSE signature over the `Sig_structure` using the leaf cert's P384 key.
+    fn verify_cose_signature(
+        leaf_pk_bytes: &[u8],
+        sig_structure: &[u8],
+        signature_bytes: &[u8],
+    ) -> Result<()> {
+        let verifying_key = VerifyingKey::from_sec1_bytes(leaf_pk_bytes).map_err(|e| {
+            VerifierError::SignatureVerification(format!("invalid leaf public key: {e}"))
+        })?;
+
+        let signature = Signature::from_slice(signature_bytes).map_err(|e| {
+            VerifierError::SignatureVerification(format!("invalid COSE signature: {e}"))
+        })?;
+
+        verifying_key.verify(sig_structure, &signature).map_err(|e| {
+            VerifierError::SignatureVerification(format!("COSE signature verification failed: {e}"))
+        })
+    }
+
+    /// Converts an optional `ByteBuf` to `Bytes`, defaulting to empty.
+    fn optional_bytes(opt: &Option<ByteBuf>) -> Bytes {
+        opt.as_ref().map_or_else(Bytes::new, |b| Bytes::copy_from_slice(b.as_ref()))
+    }
+
+    /// Validates attestation document content (M-02 audit checks).
+    ///
+    /// Per `NitroValidator.sol` reference:
+    /// - `module_id` non-empty
+    /// - `timestamp` non-zero
+    /// - `digest` == `"SHA384"`
+    /// - `cabundle` has >= 1 certificate
+    /// - PCR count between 1 and 32, each index 0-31
+    /// - `public_key`: null or 1-1024 bytes (present-but-empty is rejected, matching Solidity)
+    /// - `user_data`: null or <= 512 bytes
+    /// - `nonce`: null or <= 512 bytes
+    fn validate_attestation_content(doc: &AttestationDocument) -> Result<()> {
+        if doc.module_id.is_empty() {
+            return Err(VerifierError::ContentValidation("module_id is empty".into()));
+        }
+
+        if doc.timestamp == 0 {
+            return Err(VerifierError::ContentValidation("timestamp is zero".into()));
+        }
+
+        if doc.digest != "SHA384" {
+            return Err(VerifierError::ContentValidation(format!(
+                "unsupported digest algorithm: '{}' (expected 'SHA384')",
+                doc.digest
+            )));
+        }
+
+        if doc.cabundle.is_empty() {
+            return Err(VerifierError::ContentValidation("cabundle is empty".into()));
+        }
+
+        // PCR count: 1-32, each index 0-31.
+        // PCR sizes are statically enforced as 48 bytes by `ByteArray<48>`.
+        let pcr_count = doc.pcrs.len();
+        if pcr_count == 0 || pcr_count > 32 {
+            return Err(VerifierError::ContentValidation(format!(
+                "PCR count {pcr_count} out of range (must be 1-32)"
+            )));
+        }
+        for &index in doc.pcrs.keys() {
+            if index > 31 {
+                return Err(VerifierError::ContentValidation(format!(
+                    "PCR index {index} out of range (must be 0-31)"
+                )));
+            }
+        }
+
+        // Optional field size limits. public_key min=1 means present-but-empty is
+        // rejected, matching Solidity where `pubkeyLen == 0` means absent (null).
+        if let Some(pk) = &doc.public_key
+            && (pk.is_empty() || pk.len() > 1024)
+        {
+            return Err(VerifierError::ContentValidation(format!(
+                "public_key length {} out of range (1-1024)",
+                pk.len()
+            )));
+        }
+        if let Some(ud) = &doc.user_data
+            && ud.len() > 512
+        {
+            return Err(VerifierError::ContentValidation(format!(
+                "user_data length {} exceeds maximum (512)",
+                ud.len()
+            )));
+        }
+        if let Some(n) = &doc.nonce
+            && n.len() > 512
+        {
+            return Err(VerifierError::ContentValidation(format!(
+                "nonce length {} exceeds maximum (512)",
+                n.len()
+            )));
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+
+    use alloy_sol_types::SolValue;
+    use rstest::{fixture, rstest};
+    use serde_bytes::{ByteArray, ByteBuf};
+
+    use super::*;
+
+    /// Full attestation `COSE_Sign1` from `NitroValidator.t.sol` `test_DecodeAttestationTbs`.
+    const ATTESTATION_HEX: &str = "8444a1013822a0591144a9696d6f64756c655f69647827692d30646533386232623638353363633965382d656e633031393336383565376665653764383566646967657374665348413338346974696d657374616d701b000001937de1c5436470637273b0005830ec74bfbe7f7445a6c7610e152935e028276f638042b74797b119648e13f7a3675796b721034c320f140ea001b41aeae2015830fa2593b59f3e4fc7daba5cbdddfd3449d67cd02d43bb1128885e8f38b914d081dccdb68fff6d5b7a76bcb866a18a74a302583056ba201a72e36cd051e95e5c4724c899039b711770f4d9d4fe7a1de007119a10b364badcd35e90f728a5bdc9109057230358303c9cadd84f0d027d6a5370c3de4af9179824fd6f3f02ebab723ee4439c75d8f5183e1c55f523415d44e9e6580b06655204583098bdf1bde262272618ccd73279e8ee00dd2c36974bd253de55413a25ceb2cd7221421207c2c09dde609f87481b6f6c940558300000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000658300000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000758300000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000858300000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000958300000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000a58300000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000b58300000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000c58300000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000d58300000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000e58300000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000f58300000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000006b63657274696669636174655902803082027c30820201a00302010202100193685e7fee7d8500000000674b3bd8300a06082a8648ce3d04030330818e310b30090603550406130255533113301106035504080c0a57617368696e67746f6e3110300e06035504070c0753656174746c65310f300d060355040a0c06416d617a6f6e310c300a060355040b0c034157533139303706035504030c30692d30646533386232623638353363633965382e75732d656173742d312e6177732e6e6974726f2d656e636c61766573301e170d3234313133303136323234355a170d3234313133303139323234385a308193310b30090603550406130255533113301106035504080c0a57617368696e67746f6e3110300e06035504070c0753656174746c65310f300d060355040a0c06416d617a6f6e310c300a060355040b0c03415753313e303c06035504030c35692d30646533386232623638353363633965382d656e63303139333638356537666565376438352e75732d656173742d312e6177733076301006072a8648ce3d020106052b810400220362000461d930c61be969237398264901d6a37282cfd42c0694d012d9143cc86a339d567913dae552bad2f10d47c50d4e670247f0344983cbdc2d2e0045d4ccbdff59ef7a26ebf1be83a81e24a651c92008fe9f465757792a0877fba02c8b5e1eb2ed90a31d301b300c0603551d130101ff04023000300b0603551d0f0404030206c0300a06082a8648ce3d0403030369003066023100e48f39a39b444a6e5ea7a38b808198a2318dd531ed62faf4a9223f71f27dff4a5e495e32dd10f250bbaf1f892a4d328f023100d09fc8e48e233b9e972eecb94798865664dbeb0d75b29041f482777a4b7cae133483dcc9d35509c4967be51db37a745468636162756e646c65845902153082021130820196a003020102021100f93175681b90afe11d46ccb4e4e7f856300a06082a8648ce3d0403033049310b3009060355040613025553310f300d060355040a0c06416d617a6f6e310c300a060355040b0c03415753311b301906035504030c126177732e6e6974726f2d656e636c61766573301e170d3139313032383133323830355a170d3439313032383134323830355a3049310b3009060355040613025553310f300d060355040a0c06416d617a6f6e310c300a060355040b0c03415753311b301906035504030c126177732e6e6974726f2d656e636c617665733076301006072a8648ce3d020106052b8104002203620004fc0254eba608c1f36870e29ada90be46383292736e894bfff672d989444b5051e534a4b1f6dbe3c0bc581a32b7b176070ede12d69a3fea211b66e752cf7dd1dd095f6f1370f4170843d9dc100121e4cf63012809664487c9796284304dc53ff4a3423040300f0603551d130101ff040530030101ff301d0603551d0e041604149025b50dd90547e796c396fa729dcf99a9df4b96300e0603551d0f0101ff040403020186300a06082a8648ce3d0403030369003066023100a37f2f91a1c9bd5ee7b8627c1698d255038e1f0343f95b63a9628c3d39809545a11ebcbf2e3b55d8aeee71b4c3d6adf3023100a2f39b1605b27028a5dd4ba069b5016e65b4fbde8fe0061d6a53197f9cdaf5d943bc61fc2beb03cb6fee8d2302f3dff65902c2308202be30820244a003020102021056bfc987fd05ac99c475061b1a65eedc300a06082a8648ce3d0403033049310b3009060355040613025553310f300d060355040a0c06416d617a6f6e310c300a060355040b0c03415753311b301906035504030c126177732e6e6974726f2d656e636c61766573301e170d3234313132383036303734355a170d3234313231383037303734355a3064310b3009060355040613025553310f300d060355040a0c06416d617a6f6e310c300a060355040b0c034157533136303406035504030c2d636264383238303866646138623434642e75732d656173742d312e6177732e6e6974726f2d656e636c617665733076301006072a8648ce3d020106052b81040022036200040713751f4391a24bf27d688c9fdde4b7eec0c4922af63f242186269602eca12354e79356170287baa07dd84fa89834726891f9b4b27032b3e86000d32471a79fbf1a30c1982ad4ed069ad96a7e11d9ae2b5cd6a93ad613ee559ed7f6385a9a89a381d53081d230120603551d130101ff040830060101ff020102301f0603551d230418301680149025b50dd90547e796c396fa729dcf99a9df4b96301d0603551d0e04160414bfbd54a168f57f7391b66ca60a2836f30acfb9a1300e0603551d0f0101ff040403020186306c0603551d1f046530633061a05fa05d865b687474703a2f2f6177732d6e6974726f2d656e636c617665732d63726c2e73332e616d617a6f6e6177732e636f6d2f63726c2f61623439363063632d376436332d343262642d396539662d3539333338636236376638342e63726c300a06082a8648ce3d0403030368003065023100c05dfd13378b1eecd926b0c3ba8da01eec89ec5502ae7ca73cb958557ca323057962fff2681993a0ab223b6eacf11033023035664252d7f9e2c89c988cc4164d390f898a5e8ac2e99dc58595aa4c624e93face7964026a99b4bcca7088b51250ccc459031a308203163082029ba003020102021100cb286a4a4a09207f8b0c14950dcd6861300a06082a8648ce3d0403033064310b3009060355040613025553310f300d060355040a0c06416d617a6f6e310c300a060355040b0c034157533136303406035504030c2d636264383238303866646138623434642e75732d656173742d312e6177732e6e6974726f2d656e636c61766573301e170d3234313133303033313435345a170d3234313230363031313435345a308189313c303a06035504030c33343762313739376131663031386266302e7a6f6e616c2e75732d656173742d312e6177732e6e6974726f2d656e636c61766573310c300a060355040b0c03415753310f300d060355040a0c06416d617a6f6e310b3009060355040613025553310b300906035504080c0257413110300e06035504070c0753656174746c653076301006072a8648ce3d020106052b810400220362000423959f700ef87dcbdba686449d944f2a89ad22aa03d73cf93d28853f2fb6a80b0cc714d3090e34cda8234eef8f804e46c0dcb216062afba3e2b36a693660d9965e2370308b8e1ffad8542ddbe3e733077481b0cbc747d8c7beb7612820d4fe95a381ea3081e730120603551d130101ff040830060101ff020101301f0603551d23041830168014bfbd54a168f57f7391b66ca60a2836f30acfb9a1301d0603551d0e04160414bbf52a3a42fdc4f301f72536b90e65aaa1b70a99300e0603551d0f0101ff0404030201863081800603551d1f047930773075a073a071866f687474703a2f2f63726c2d75732d656173742d312d6177732d6e6974726f2d656e636c617665732e73332e75732d656173742d312e616d617a6f6e6177732e636f6d2f63726c2f30366434386638652d326330382d343738312d613634352d6231646534303261656662382e63726c300a06082a8648ce3d0403030369003066023100fa31509230632a002939201eb5686b52d79f0276db5c2b954bed324caa5c3271a60d25e2e05a5e6700e488a074af4ecd02310084770462c2ef86dcdb11fa8a31dcf770866cbd28822b682a112b98c09a30e35e94affd3482bf8b01b59a0a7775b4af185902c3308202bf30820245a003020102021500c8925d382506d820d93d2c704a7523c4ba2ddfaa300a06082a8648ce3d040303308189313c303a06035504030c33343762313739376131663031386266302e7a6f6e616c2e75732d656173742d312e6177732e6e6974726f2d656e636c61766573310c300a060355040b0c03415753310f300d060355040a0c06416d617a6f6e310b3009060355040613025553310b300906035504080c0257413110300e06035504070c0753656174746c65301e170d3234313133303132343133315a170d3234313230313132343133315a30818e310b30090603550406130255533113301106035504080c0a57617368696e67746f6e3110300e06035504070c0753656174746c65310f300d060355040a0c06416d617a6f6e310c300a060355040b0c034157533139303706035504030c30692d30646533386232623638353363633965382e75732d656173742d312e6177732e6e6974726f2d656e636c617665733076301006072a8648ce3d020106052b8104002203620004466754b5718024df3564bcd722361e7c65a4922eda7b1f826758e30afac40b04a281062897d085311fd509b70a6bbc5f8280f86ae2ff255ad147146fc97b7afb16064f0712d335c1d473b716be320be625e91c5870973084b3a0005bc020c7b2a366306430120603551d130101ff040830060101ff020100300e0603551d0f0101ff040403020204301d0603551d0e04160414345c86a9ec55bc30cafd923d6b73111d9c57abc0301f0603551d23041830168014bbf52a3a42fdc4f301f72536b90e65aaa1b70a99300a06082a8648ce3d0403030368003065023100aba82c02f40acb9846012bf070578217eeb2ebbfd16414948438cf67eeab6f64cdc5a152998766c88b2cdebd5a97ebd402307421611ed511567bc8e6a0a2805b981ef38dc3bd6a6c661522802b5c5d658cc4fcc9b5e8df148b161d366926896736836a7075626c69635f6b657958410433a4701fa871b188983d570e2c2d8cf98fd66eb19ba8ca7617bc8e20e152a5d7f0205eae76e608ce855077e4565be69db4471ef72857253742f9602c11ff04e569757365725f64617461f6656e6f6e6365f65860874e67088943e85654beb78443c747def2c3736bf93e2b52d033b3e936a04ead91f7b5a1229a1615f237f138f64399418b8046b6e40cd93e750b58f5e1aded45ebf3f103b9ea19a9b874142b576638dad2da142254ae913664649be22e0b83f9";
+
+    // ── Fixtures ────────────────────────────────────────────────────────
+
+    #[fixture]
+    fn attestation_input() -> VerifierInput {
+        let bytes = hex::decode(ATTESTATION_HEX).unwrap();
+        VerifierInput {
+            trustedCertsPrefixLen: 1,
+            attestationReport: Bytes::copy_from_slice(&bytes),
+        }
+    }
+
+    /// A minimal valid `AttestationDocument` for M-02 unit tests.
+    fn valid_doc() -> AttestationDocument {
+        let mut pcrs = BTreeMap::new();
+        pcrs.insert(0, ByteArray::new([0u8; 48]));
+        AttestationDocument {
+            module_id: "test-module".into(),
+            timestamp: 1_700_000_000_000,
+            digest: "SHA384".into(),
+            pcrs,
+            certificate: ByteBuf::from(vec![0x30]),
+            cabundle: vec![ByteBuf::from(vec![0x30])],
+            public_key: None,
+            user_data: None,
+            nonce: None,
+        }
+    }
+
+    // ── End-to-end happy path ───────────────────────────────────────────
+
+    #[rstest]
+    fn verify_full_attestation_report(attestation_input: VerifierInput) {
+        let journal = AttestationVerifier::verify(&attestation_input).unwrap();
+
+        assert_eq!(journal.result, VerificationResult::Success);
+        assert_eq!(journal.trustedCertsPrefixLen, 1);
+        assert_eq!(journal.timestamp, 0x000001937de1c543);
+        assert_eq!(journal.moduleId, "i-0de38b2b6853cc9e8-enc0193685e7fee7d85");
+        assert_eq!(journal.certs.len(), 5);
+        assert_eq!(journal.pcrs.len(), 16);
+        assert!(journal.userData.is_empty());
+        assert!(journal.nonce.is_empty());
+        assert!(!journal.publicKey.is_empty());
+
+        // ABI round-trip.
+        let encoded = SolValue::abi_encode(&journal);
+        let decoded = VerifierJournal::decode(&encoded).unwrap();
+        assert_eq!(decoded.moduleId, journal.moduleId);
+        assert_eq!(decoded.timestamp, journal.timestamp);
+    }
+
+    #[rstest]
+    fn verify_with_zero_trusted_prefix() {
+        let bytes = hex::decode(ATTESTATION_HEX).unwrap();
+        let input = VerifierInput {
+            trustedCertsPrefixLen: 0,
+            attestationReport: Bytes::copy_from_slice(&bytes),
+        };
+        let journal = AttestationVerifier::verify(&input).unwrap();
+        assert_eq!(journal.result, VerificationResult::Success);
+    }
+
+    // ── End-to-end error tests ──────────────────────────────────────────
+
+    #[rstest]
+    fn corrupted_attestation_rejected() {
+        let input = VerifierInput {
+            trustedCertsPrefixLen: 0,
+            attestationReport: Bytes::copy_from_slice(&[0xDE, 0xAD]),
+        };
+        assert!(AttestationVerifier::verify(&input).is_err());
+    }
+
+    // ── M-02: validate_attestation_content unit tests ───────────────────
+
+    #[rstest]
+    fn m02_valid_doc_passes() {
+        assert!(AttestationVerifier::validate_attestation_content(&valid_doc()).is_ok());
+    }
+
+    #[rstest]
+    fn m02_empty_module_id_rejected() {
+        let mut doc = valid_doc();
+        doc.module_id = String::new();
+        let err = AttestationVerifier::validate_attestation_content(&doc).unwrap_err();
+        assert!(err.to_string().contains("module_id"));
+    }
+
+    #[rstest]
+    fn m02_zero_timestamp_rejected() {
+        let mut doc = valid_doc();
+        doc.timestamp = 0;
+        let err = AttestationVerifier::validate_attestation_content(&doc).unwrap_err();
+        assert!(err.to_string().contains("timestamp"));
+    }
+
+    #[rstest]
+    fn m02_wrong_digest_rejected() {
+        let mut doc = valid_doc();
+        doc.digest = "SHA256".into();
+        let err = AttestationVerifier::validate_attestation_content(&doc).unwrap_err();
+        assert!(err.to_string().contains("SHA384"));
+    }
+
+    #[rstest]
+    fn m02_empty_cabundle_rejected() {
+        let mut doc = valid_doc();
+        doc.cabundle.clear();
+        let err = AttestationVerifier::validate_attestation_content(&doc).unwrap_err();
+        assert!(err.to_string().contains("cabundle"));
+    }
+
+    #[rstest]
+    fn m02_empty_pcrs_rejected() {
+        let mut doc = valid_doc();
+        doc.pcrs.clear();
+        let err = AttestationVerifier::validate_attestation_content(&doc).unwrap_err();
+        assert!(err.to_string().contains("PCR count"));
+    }
+
+    #[rstest]
+    fn m02_pcr_index_out_of_range_rejected() {
+        let mut doc = valid_doc();
+        doc.pcrs.insert(32, ByteArray::new([0u8; 48]));
+        let err = AttestationVerifier::validate_attestation_content(&doc).unwrap_err();
+        assert!(err.to_string().contains("PCR index"));
+    }
+
+    #[rstest]
+    fn m02_pcr_index_31_accepted() {
+        let mut doc = valid_doc();
+        doc.pcrs.insert(31, ByteArray::new([0u8; 48]));
+        assert!(AttestationVerifier::validate_attestation_content(&doc).is_ok());
+    }
+
+    #[rstest]
+    fn m02_public_key_too_large_rejected() {
+        let mut doc = valid_doc();
+        doc.public_key = Some(ByteBuf::from(vec![0u8; 1025]));
+        let err = AttestationVerifier::validate_attestation_content(&doc).unwrap_err();
+        assert!(err.to_string().contains("public_key"));
+    }
+
+    #[rstest]
+    fn m02_user_data_too_large_rejected() {
+        let mut doc = valid_doc();
+        doc.user_data = Some(ByteBuf::from(vec![0u8; 513]));
+        let err = AttestationVerifier::validate_attestation_content(&doc).unwrap_err();
+        assert!(err.to_string().contains("user_data"));
+    }
+
+    #[rstest]
+    fn m02_nonce_too_large_rejected() {
+        let mut doc = valid_doc();
+        doc.nonce = Some(ByteBuf::from(vec![0u8; 513]));
+        let err = AttestationVerifier::validate_attestation_content(&doc).unwrap_err();
+        assert!(err.to_string().contains("nonce"));
+    }
+
+    #[rstest]
+    fn m02_valid_optional_fields_accepted() {
+        let mut doc = valid_doc();
+        doc.public_key = Some(ByteBuf::from(vec![0x04; 65]));
+        doc.user_data = Some(ByteBuf::from(vec![0u8; 512]));
+        doc.nonce = Some(ByteBuf::from(vec![0u8; 256]));
+        assert!(AttestationVerifier::validate_attestation_content(&doc).is_ok());
+    }
+}

--- a/crates/proof/tee/nitro-verifier/src/x509.rs
+++ b/crates/proof/tee/nitro-verifier/src/x509.rs
@@ -1,0 +1,513 @@
+//! X.509 certificate chain validation for AWS Nitro Enclave attestations.
+//!
+//! Verifies the certificate chain from root CA through intermediates to the
+//! leaf enclave certificate. Only P384/ECDSA-SHA384 is supported — this is
+//! the algorithm used by all Nitro Enclave certificate chains and enforced
+//! by `CertManager.sol` on-chain.
+//!
+//! Includes M-01 audit fixes: `basicConstraints`, `keyUsage`, path length
+//! constraints, subject/issuer chain consistency, and validity period checks.
+
+use alloy_primitives::B256;
+use p384::ecdsa::signature::Verifier;
+use p384::ecdsa::{Signature, VerifyingKey};
+use sha2::{Digest, Sha256};
+use x509_parser::certificate::X509Certificate;
+use x509_parser::oid_registry::{
+    OID_KEY_TYPE_EC_PUBLIC_KEY, OID_NIST_EC_P384, OID_SIG_ECDSA_WITH_SHA384,
+};
+use x509_parser::prelude::FromDer;
+
+use crate::{Result, VerifierError};
+
+/// Parsed DER certificate with its raw bytes.
+#[derive(Debug)]
+struct ParsedCert<'a> {
+    /// The parsed x509 certificate.
+    cert: X509Certificate<'a>,
+    /// The original DER bytes (for hashing).
+    der: &'a [u8],
+}
+
+/// A certificate chain validator for Nitro Enclave attestations.
+///
+/// Parses DER-encoded certificates and verifies the chain from root to leaf,
+/// including signature verification (P384/ECDSA-SHA384), x509 content
+/// validation (M-01 audit fixes), and certificate digest accumulation.
+#[derive(Debug)]
+pub struct CertChain<'a> {
+    /// Parsed certificates in chain order: root → intermediates → leaf.
+    certs: Vec<ParsedCert<'a>>,
+}
+
+impl<'a> CertChain<'a> {
+    /// Parses DER-encoded certificates into a certificate chain.
+    ///
+    /// The certificates must be in chain order: root → intermediates → leaf.
+    pub fn from_der(certs: &[&'a [u8]]) -> Result<Self> {
+        if certs.is_empty() {
+            return Err(VerifierError::X509Parse("empty certificate chain".into()));
+        }
+
+        let parsed = certs
+            .iter()
+            .enumerate()
+            .map(|(i, der)| {
+                let (_, cert) = X509Certificate::from_der(der)
+                    .map_err(|e| VerifierError::X509Parse(format!("certificate {i}: {e}")))?;
+                Ok(ParsedCert { cert, der })
+            })
+            .collect::<Result<Vec<_>>>()?;
+
+        Ok(Self { certs: parsed })
+    }
+
+    /// Verifies the certificate chain and returns accumulated cert digests.
+    ///
+    /// Skips verification of the first `trusted_prefix_len` certificates
+    /// (they are already trusted on-chain). Verifies from `trusted_prefix_len`
+    /// through the leaf certificate.
+    ///
+    /// Returns a `Vec<B256>` of accumulated path digests (one per cert),
+    /// matching the on-chain `VerifierJournal.certs` field.
+    pub fn verify_chain(&self, trusted_prefix_len: usize, timestamp: u64) -> Result<Vec<B256>> {
+        if trusted_prefix_len > self.certs.len() {
+            return Err(VerifierError::CertificateVerification(format!(
+                "trusted prefix length {trusted_prefix_len} exceeds chain length {}",
+                self.certs.len()
+            )));
+        }
+
+        let mut digests = Vec::with_capacity(self.certs.len());
+        // Accumulate path digests for all certs (including trusted prefix).
+        let mut path_digest = B256::ZERO;
+
+        for (i, parsed) in self.certs.iter().enumerate() {
+            // A cert is a leaf only if it's the last in a multi-cert chain.
+            // A single-cert chain (root only) is treated as CA, not leaf.
+            let is_leaf = i == self.certs.len() - 1 && self.certs.len() > 1;
+            let cert_digest = B256::from_slice(Sha256::digest(parsed.der).as_slice());
+
+            // Accumulate: path_digest = sha256(parent_path_digest || cert_digest)
+            if i == 0 {
+                path_digest = cert_digest;
+            } else {
+                let mut hasher = Sha256::new();
+                hasher.update(path_digest.as_slice());
+                hasher.update(cert_digest.as_slice());
+                path_digest = B256::from_slice(hasher.finalize().as_slice());
+            }
+            digests.push(path_digest);
+
+            // Skip validation for trusted prefix certs.
+            if i < trusted_prefix_len {
+                continue;
+            }
+
+            // Validate x509 content (M-01 audit fixes).
+            Self::validate_cert_content(&parsed.cert, is_leaf)?;
+
+            // Validate validity period.
+            Self::check_validity(&parsed.cert, timestamp, i)?;
+
+            // Validate issuer/subject chain consistency and path length.
+            if i > 0 {
+                let parent_cert = &self.certs[i - 1].cert;
+
+                if parsed.cert.issuer() != parent_cert.subject() {
+                    return Err(VerifierError::CertificateVerification(format!(
+                        "certificate {i}: issuer does not match parent subject"
+                    )));
+                }
+
+                // Check path length constraint from parent's basicConstraints.
+                let parent_bc = parent_cert.basic_constraints().map_err(|e| {
+                    VerifierError::CertificateVerification(format!(
+                        "certificate {}: parent basicConstraints parse: {e}",
+                        i - 1
+                    ))
+                })?;
+                if let Some(bc) = parent_bc {
+                    let remaining = self.certs.len() - 1 - i;
+                    if let Some(max) = bc.value.path_len_constraint
+                        && (remaining as u32) > max
+                    {
+                        return Err(VerifierError::CertificateVerification(format!(
+                            "certificate {i}: path length constraint violated \
+                             (max={max}, remaining intermediates={remaining})"
+                        )));
+                    }
+                }
+            }
+
+            // Verify signature (parent signs child, root is self-signed).
+            let parent = if i == 0 { &parsed.cert } else { &self.certs[i - 1].cert };
+            Self::verify_signature(parent, parsed, i)?;
+        }
+
+        Ok(digests)
+    }
+
+    /// Returns the public key bytes from the leaf certificate.
+    pub fn leaf_public_key(&self) -> Result<&[u8]> {
+        let leaf = self.certs.last().ok_or_else(|| {
+            VerifierError::CertificateVerification("empty certificate chain".into())
+        })?;
+        Ok(leaf.cert.public_key().subject_public_key.data.as_ref())
+    }
+
+    /// Validates x509 certificate content (M-01 audit checks).
+    ///
+    /// For CA certificates (non-leaf):
+    /// - `basicConstraints` must exist with `cA=true`
+    /// - `keyUsage` must include `keyCertSign`
+    ///
+    /// For the leaf certificate:
+    /// - `basicConstraints`: `cA` must be `false` (or absent)
+    /// - `keyUsage`: must include `digital_signature` if present
+    fn validate_cert_content(cert: &X509Certificate<'_>, is_leaf: bool) -> Result<()> {
+        // Check algorithm is ECDSA-SHA384 over P384.
+        let sig_oid = cert.signature_algorithm.oid();
+        if *sig_oid != OID_SIG_ECDSA_WITH_SHA384 {
+            return Err(VerifierError::CertificateVerification(format!(
+                "unsupported signature algorithm: {sig_oid}"
+            )));
+        }
+
+        let pk_algorithm = &cert.public_key().algorithm;
+        if pk_algorithm.algorithm != OID_KEY_TYPE_EC_PUBLIC_KEY {
+            return Err(VerifierError::CertificateVerification(format!(
+                "unsupported public key algorithm: {}",
+                pk_algorithm.algorithm
+            )));
+        }
+
+        // Verify the EC curve is P-384 (secp384r1). The algorithm parameters
+        // OID must be 1.3.132.0.34. Without this check, a P-256 key would pass
+        // the above EC key type check but use a weaker curve.
+        let curve_oid =
+            pk_algorithm.parameters.as_ref().and_then(|p| p.as_oid().ok()).ok_or_else(|| {
+                VerifierError::CertificateVerification(
+                    "EC public key missing curve parameters OID".into(),
+                )
+            })?;
+        if curve_oid != OID_NIST_EC_P384 {
+            return Err(VerifierError::CertificateVerification(format!(
+                "unsupported EC curve: {curve_oid} (expected P-384)"
+            )));
+        }
+
+        // Parse extensions.
+        let basic_constraints = cert.basic_constraints().map_err(|e| {
+            VerifierError::CertificateVerification(format!("basicConstraints parse: {e}"))
+        })?;
+
+        let key_usage = cert
+            .key_usage()
+            .map_err(|e| VerifierError::CertificateVerification(format!("keyUsage parse: {e}")))?;
+
+        if is_leaf {
+            // Leaf: cA must NOT be true.
+            if let Some(bc) = basic_constraints
+                && bc.value.ca
+            {
+                return Err(VerifierError::CertificateVerification(
+                    "leaf certificate has cA=true".into(),
+                ));
+            }
+            // Leaf: keyUsage should include digitalSignature if present.
+            if let Some(ku) = key_usage
+                && !ku.value.digital_signature()
+            {
+                return Err(VerifierError::CertificateVerification(
+                    "leaf certificate keyUsage missing digitalSignature".into(),
+                ));
+            }
+        } else {
+            // CA: basicConstraints must exist with cA=true.
+            let bc = basic_constraints.ok_or_else(|| {
+                VerifierError::CertificateVerification(
+                    "CA certificate missing basicConstraints".into(),
+                )
+            })?;
+            if !bc.value.ca {
+                return Err(VerifierError::CertificateVerification(
+                    "CA certificate has cA=false".into(),
+                ));
+            }
+            // CA: keyUsage must exist and include keyCertSign.
+            let ku = key_usage.ok_or_else(|| {
+                VerifierError::CertificateVerification("CA certificate missing keyUsage".into())
+            })?;
+            if !ku.value.key_cert_sign() {
+                return Err(VerifierError::CertificateVerification(
+                    "CA certificate keyUsage missing keyCertSign".into(),
+                ));
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Checks certificate validity period against a Unix timestamp (milliseconds).
+    fn check_validity(
+        cert: &X509Certificate<'_>,
+        timestamp_ms: u64,
+        cert_index: usize,
+    ) -> Result<()> {
+        let timestamp_secs = (timestamp_ms / 1000) as i64;
+
+        let not_before = cert.validity().not_before.timestamp();
+        let not_after = cert.validity().not_after.timestamp();
+
+        if timestamp_secs < not_before {
+            return Err(VerifierError::CertificateVerification(format!(
+                "certificate {cert_index}: not yet valid (notBefore={not_before}, \
+                 timestamp={timestamp_secs})"
+            )));
+        }
+
+        if timestamp_secs > not_after {
+            return Err(VerifierError::CertificateVerification(format!(
+                "certificate {cert_index}: expired (notAfter={not_after}, \
+                 timestamp={timestamp_secs})"
+            )));
+        }
+
+        Ok(())
+    }
+
+    /// Verifies that `parent` signed the `child` certificate using P384/ECDSA-SHA384.
+    fn verify_signature(
+        parent: &X509Certificate<'_>,
+        child: &ParsedCert<'_>,
+        child_index: usize,
+    ) -> Result<()> {
+        // Extract the parent's public key (uncompressed P384 point).
+        let pk_bytes = parent.public_key().subject_public_key.data.as_ref();
+        let verifying_key = VerifyingKey::from_sec1_bytes(pk_bytes).map_err(|e| {
+            VerifierError::SignatureVerification(format!(
+                "certificate {child_index}: invalid parent public key: {e}"
+            ))
+        })?;
+
+        // The signature on the child's TBS (to-be-signed) certificate.
+        let sig_bytes = child.cert.signature_value.data.as_ref();
+        let signature = Signature::from_der(sig_bytes).map_err(|e| {
+            VerifierError::SignatureVerification(format!(
+                "certificate {child_index}: invalid DER signature: {e}"
+            ))
+        })?;
+
+        // The TBS data to verify.
+        let tbs = child.cert.tbs_certificate.as_ref();
+
+        verifying_key.verify(tbs, &signature).map_err(|e| {
+            VerifierError::SignatureVerification(format!(
+                "certificate {child_index}: signature verification failed: {e}"
+            ))
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use rstest::{fixture, rstest};
+
+    use super::*;
+
+    // ── Real AWS Nitro cert DER hex (from NitroValidator.t.sol) ──────────
+
+    /// Root CA (self-signed, P384). Validity: 2019-10-28 to 2049-10-28.
+    const ROOT_HEX: &str = "3082021130820196a003020102021100f93175681b90afe11d46ccb4e4e7f856300a06082a8648ce3d0403033049310b3009060355040613025553310f300d060355040a0c06416d617a6f6e310c300a060355040b0c03415753311b301906035504030c126177732e6e6974726f2d656e636c61766573301e170d3139313032383133323830355a170d3439313032383134323830355a3049310b3009060355040613025553310f300d060355040a0c06416d617a6f6e310c300a060355040b0c03415753311b301906035504030c126177732e6e6974726f2d656e636c617665733076301006072a8648ce3d020106052b8104002203620004fc0254eba608c1f36870e29ada90be46383292736e894bfff672d989444b5051e534a4b1f6dbe3c0bc581a32b7b176070ede12d69a3fea211b66e752cf7dd1dd095f6f1370f4170843d9dc100121e4cf63012809664487c9796284304dc53ff4a3423040300f0603551d130101ff040530030101ff301d0603551d0e041604149025b50dd90547e796c396fa729dcf99a9df4b96300e0603551d0f0101ff040403020186300a06082a8648ce3d0403030369003066023100a37f2f91a1c9bd5ee7b8627c1698d255038e1f0343f95b63a9628c3d39809545a11ebcbf2e3b55d8aeee71b4c3d6adf3023100a2f39b1605b27028a5dd4ba069b5016e65b4fbde8fe0061d6a53197f9cdaf5d943bc61fc2beb03cb6fee8d2302f3dff6";
+
+    /// Intermediate 1 (signed by root). Validity: 2024-11-28 to 2024-12-18.
+    const INTER1_HEX: &str = "308202be30820244a003020102021056bfc987fd05ac99c475061b1a65eedc300a06082a8648ce3d0403033049310b3009060355040613025553310f300d060355040a0c06416d617a6f6e310c300a060355040b0c03415753311b301906035504030c126177732e6e6974726f2d656e636c61766573301e170d3234313132383036303734355a170d3234313231383037303734355a3064310b3009060355040613025553310f300d060355040a0c06416d617a6f6e310c300a060355040b0c034157533136303406035504030c2d636264383238303866646138623434642e75732d656173742d312e6177732e6e6974726f2d656e636c617665733076301006072a8648ce3d020106052b81040022036200040713751f4391a24bf27d688c9fdde4b7eec0c4922af63f242186269602eca12354e79356170287baa07dd84fa89834726891f9b4b27032b3e86000d32471a79fbf1a30c1982ad4ed069ad96a7e11d9ae2b5cd6a93ad613ee559ed7f6385a9a89a381d53081d230120603551d130101ff040830060101ff020102301f0603551d230418301680149025b50dd90547e796c396fa729dcf99a9df4b96301d0603551d0e04160414bfbd54a168f57f7391b66ca60a2836f30acfb9a1300e0603551d0f0101ff040403020186306c0603551d1f046530633061a05fa05d865b687474703a2f2f6177732d6e6974726f2d656e636c617665732d63726c2e73332e616d617a6f6e6177732e636f6d2f63726c2f61623439363063632d376436332d343262642d396539662d3539333338636236376638342e63726c300a06082a8648ce3d0403030368003065023100c05dfd13378b1eecd926b0c3ba8da01eec89ec5502ae7ca73cb958557ca323057962fff2681993a0ab223b6eacf11033023035664252d7f9e2c89c988cc4164d390f898a5e8ac2e99dc58595aa4c624e93face7964026a99b4bcca7088b51250ccc4";
+
+    /// Intermediate 2 (signed by inter1). Validity: 2024-11-30 to 2024-12-06.
+    const INTER2_HEX: &str = "308203163082029ba003020102021100cb286a4a4a09207f8b0c14950dcd6861300a06082a8648ce3d0403033064310b3009060355040613025553310f300d060355040a0c06416d617a6f6e310c300a060355040b0c034157533136303406035504030c2d636264383238303866646138623434642e75732d656173742d312e6177732e6e6974726f2d656e636c61766573301e170d3234313133303033313435345a170d3234313230363031313435345a308189313c303a06035504030c33343762313739376131663031386266302e7a6f6e616c2e75732d656173742d312e6177732e6e6974726f2d656e636c61766573310c300a060355040b0c03415753310f300d060355040a0c06416d617a6f6e310b3009060355040613025553310b300906035504080c0257413110300e06035504070c0753656174746c653076301006072a8648ce3d020106052b810400220362000423959f700ef87dcbdba686449d944f2a89ad22aa03d73cf93d28853f2fb6a80b0cc714d3090e34cda8234eef8f804e46c0dcb216062afba3e2b36a693660d9965e2370308b8e1ffad8542ddbe3e733077481b0cbc747d8c7beb7612820d4fe95a381ea3081e730120603551d130101ff040830060101ff020101301f0603551d23041830168014bfbd54a168f57f7391b66ca60a2836f30acfb9a1301d0603551d0e04160414bbf52a3a42fdc4f301f72536b90e65aaa1b70a99300e0603551d0f0101ff0404030201863081800603551d1f047930773075a073a071866f687474703a2f2f63726c2d75732d656173742d312d6177732d6e6974726f2d656e636c617665732e73332e75732d656173742d312e616d617a6f6e6177732e636f6d2f63726c2f30366434386638652d326330382d343738312d613634352d6231646534303261656662382e63726c300a06082a8648ce3d0403030369003066023100fa31509230632a002939201eb5686b52d79f0276db5c2b954bed324caa5c3271a60d25e2e05a5e6700e488a074af4ecd02310084770462c2ef86dcdb11fa8a31dcf770866cbd28822b682a112b98c09a30e35e94affd3482bf8b01b59a0a7775b4af18";
+
+    /// Intermediate 3 (signed by inter2). Validity: 2024-11-30 to 2024-12-01.
+    const INTER3_HEX: &str = "308202bf30820245a003020102021500c8925d382506d820d93d2c704a7523c4ba2ddfaa300a06082a8648ce3d040303308189313c303a06035504030c33343762313739376131663031386266302e7a6f6e616c2e75732d656173742d312e6177732e6e6974726f2d656e636c61766573310c300a060355040b0c03415753310f300d060355040a0c06416d617a6f6e310b3009060355040613025553310b300906035504080c0257413110300e06035504070c0753656174746c65301e170d3234313133303132343133315a170d3234313230313132343133315a30818e310b30090603550406130255533113301106035504080c0a57617368696e67746f6e3110300e06035504070c0753656174746c65310f300d060355040a0c06416d617a6f6e310c300a060355040b0c034157533139303706035504030c30692d30646533386232623638353363633965382e75732d656173742d312e6177732e6e6974726f2d656e636c617665733076301006072a8648ce3d020106052b8104002203620004466754b5718024df3564bcd722361e7c65a4922eda7b1f826758e30afac40b04a281062897d085311fd509b70a6bbc5f8280f86ae2ff255ad147146fc97b7afb16064f0712d335c1d473b716be320be625e91c5870973084b3a0005bc020c7b2a366306430120603551d130101ff040830060101ff020100300e0603551d0f0101ff040403020204301d0603551d0e04160414345c86a9ec55bc30cafd923d6b73111d9c57abc0301f0603551d23041830168014bbf52a3a42fdc4f301f72536b90e65aaa1b70a99300a06082a8648ce3d0403030368003065023100aba82c02f40acb9846012bf070578217eeb2ebbfd16414948438cf67eeab6f64cdc5a152998766c88b2cdebd5a97ebd402307421611ed511567bc8e6a0a2805b981ef38dc3bd6a6c661522802b5c5d658cc4fcc9b5e8df148b161d366926896736836a";
+
+    /// Leaf enclave cert (signed by inter3). Validity: 2024-11-30T16:22 to 2024-11-30T19:22.
+    const LEAF_HEX: &str = "3082027c30820201a00302010202100193685e7fee7d8500000000674b3bd8300a06082a8648ce3d04030330818e310b30090603550406130255533113301106035504080c0a57617368696e67746f6e3110300e06035504070c0753656174746c65310f300d060355040a0c06416d617a6f6e310c300a060355040b0c034157533139303706035504030c30692d30646533386232623638353363633965382e75732d656173742d312e6177732e6e6974726f2d656e636c61766573301e170d3234313133303136323234355a170d3234313133303139323234385a308193310b30090603550406130255533113301106035504080c0a57617368696e67746f6e3110300e06035504070c0753656174746c65310f300d060355040a0c06416d617a6f6e310c300a060355040b0c03415753313e303c06035504030c35692d30646533386232623638353363633965382d656e63303139333638356537666565376438352e75732d656173742d312e6177733076301006072a8648ce3d020106052b810400220362000461d930c61be969237398264901d6a37282cfd42c0694d012d9143cc86a339d567913dae552bad2f10d47c50d4e670247f0344983cbdc2d2e0045d4ccbdff59ef7a26ebf1be83a81e24a651c92008fe9f465757792a0877fba02c8b5e1eb2ed90a31d301b300c0603551d130101ff04023000300b0603551d0f0404030206c0300a06082a8648ce3d0403030369003066023100e48f39a39b444a6e5ea7a38b808198a2318dd531ed62faf4a9223f71f27dff4a5e495e32dd10f250bbaf1f892a4d328f023100d09fc8e48e233b9e972eecb94798865664dbeb0d75b29041f482777a4b7cae133483dcc9d35509c4967be51db37a7454";
+
+    /// Attestation timestamp (within all cert validity windows).
+    /// 0x000001937de1c543 = 1732931765571 ms = 2024-11-30T16:22:45Z.
+    const VALID_TIMESTAMP_MS: u64 = 0x000001937de1c543;
+
+    // ── Fixtures ────────────────────────────────────────────────────────
+
+    /// Full 5-cert chain (root → 3 intermediates → leaf) from real Nitro attestation.
+    #[fixture]
+    fn full_chain_der() -> Vec<Vec<u8>> {
+        [ROOT_HEX, INTER1_HEX, INTER2_HEX, INTER3_HEX, LEAF_HEX]
+            .iter()
+            .map(|h| hex::decode(h).unwrap())
+            .collect()
+    }
+
+    /// Root-only DER bytes.
+    #[fixture]
+    fn root_der() -> Vec<u8> {
+        hex::decode(ROOT_HEX).unwrap()
+    }
+
+    // ── Happy-path tests ────────────────────────────────────────────────
+
+    #[rstest]
+    fn root_ca_self_signed_verifies(root_der: Vec<u8>) {
+        let certs = vec![root_der.as_slice()];
+        let chain = CertChain::from_der(&certs).unwrap();
+        // Root validity: 2019-10-28 to 2049-10-28.
+        let digests = chain.verify_chain(0, 1_700_000_000_000).unwrap();
+        assert_eq!(digests.len(), 1);
+        let expected = B256::from_slice(Sha256::digest(&root_der).as_slice());
+        assert_eq!(digests[0], expected);
+    }
+
+    #[rstest]
+    fn full_chain_verifies_all_untrusted(full_chain_der: Vec<Vec<u8>>) {
+        let refs: Vec<&[u8]> = full_chain_der.iter().map(|c| c.as_slice()).collect();
+        let chain = CertChain::from_der(&refs).unwrap();
+        let digests = chain.verify_chain(0, VALID_TIMESTAMP_MS).unwrap();
+        assert_eq!(digests.len(), 5);
+    }
+
+    #[rstest]
+    #[case::root_trusted(1)]
+    #[case::root_and_inter1_trusted(2)]
+    #[case::root_inter1_inter2_trusted(3)]
+    #[case::all_but_leaf_trusted(4)]
+    #[case::all_trusted(5)]
+    fn full_chain_with_trusted_prefix(full_chain_der: Vec<Vec<u8>>, #[case] prefix_len: usize) {
+        let refs: Vec<&[u8]> = full_chain_der.iter().map(|c| c.as_slice()).collect();
+        let chain = CertChain::from_der(&refs).unwrap();
+        let digests = chain.verify_chain(prefix_len, VALID_TIMESTAMP_MS).unwrap();
+        assert_eq!(digests.len(), 5);
+    }
+
+    #[rstest]
+    fn digests_are_accumulated_path_hashes(full_chain_der: Vec<Vec<u8>>) {
+        let refs: Vec<&[u8]> = full_chain_der.iter().map(|c| c.as_slice()).collect();
+        let chain = CertChain::from_der(&refs).unwrap();
+        let digests = chain.verify_chain(5, 0).unwrap();
+
+        // First digest = sha256(root_der).
+        let root_hash = B256::from_slice(Sha256::digest(&full_chain_der[0]).as_slice());
+        assert_eq!(digests[0], root_hash);
+
+        // Second digest = sha256(root_hash || sha256(inter1_der)).
+        let inter1_hash = B256::from_slice(Sha256::digest(&full_chain_der[1]).as_slice());
+        let mut hasher = Sha256::new();
+        hasher.update(root_hash.as_slice());
+        hasher.update(inter1_hash.as_slice());
+        let expected = B256::from_slice(hasher.finalize().as_slice());
+        assert_eq!(digests[1], expected);
+    }
+
+    #[rstest]
+    fn leaf_public_key_is_extractable(full_chain_der: Vec<Vec<u8>>) {
+        let refs: Vec<&[u8]> = full_chain_der.iter().map(|c| c.as_slice()).collect();
+        let chain = CertChain::from_der(&refs).unwrap();
+        let pk = chain.leaf_public_key().unwrap();
+        // P384 uncompressed point = 0x04 || 48-byte x || 48-byte y = 97 bytes.
+        assert_eq!(pk.len(), 97);
+        assert_eq!(pk[0], 0x04);
+    }
+
+    // ── Parsing error tests ─────────────────────────────────────────────
+
+    #[rstest]
+    fn empty_chain_rejected() {
+        assert!(CertChain::from_der(&[]).is_err());
+    }
+
+    #[rstest]
+    fn invalid_der_rejected() {
+        let garbage = vec![0xDE, 0xAD, 0xBE, 0xEF];
+        let result = CertChain::from_der(&[&garbage]);
+        assert!(result.is_err());
+    }
+
+    // ── Trusted prefix boundary tests ───────────────────────────────────
+
+    #[rstest]
+    fn trusted_prefix_skips_validation(root_der: Vec<u8>) {
+        let certs = vec![root_der.as_slice()];
+        let chain = CertChain::from_der(&certs).unwrap();
+        // All trusted → timestamp 0 is fine (validation skipped).
+        let digests = chain.verify_chain(1, 0).unwrap();
+        assert_eq!(digests.len(), 1);
+    }
+
+    #[rstest]
+    fn trusted_prefix_exceeding_chain_length_fails(root_der: Vec<u8>) {
+        let certs = vec![root_der.as_slice()];
+        let chain = CertChain::from_der(&certs).unwrap();
+        assert!(chain.verify_chain(5, 0).is_err());
+    }
+
+    // ── M-01: Validity period checks ────────────────────────────────────
+
+    #[rstest]
+    fn expired_cert_rejected(full_chain_der: Vec<Vec<u8>>) {
+        let refs: Vec<&[u8]> = full_chain_der.iter().map(|c| c.as_slice()).collect();
+        let chain = CertChain::from_der(&refs).unwrap();
+        // Far future: all intermediate certs are expired.
+        let far_future_ms = 2_000_000_000_000;
+        let err = chain.verify_chain(0, far_future_ms).unwrap_err();
+        assert!(err.to_string().contains("expired"), "expected expiry error, got: {err}");
+    }
+
+    #[rstest]
+    fn not_yet_valid_cert_rejected(full_chain_der: Vec<Vec<u8>>) {
+        let refs: Vec<&[u8]> = full_chain_der.iter().map(|c| c.as_slice()).collect();
+        let chain = CertChain::from_der(&refs).unwrap();
+        // Far past: intermediate certs are not yet valid (root is valid from 2019).
+        // Start from index 1 to skip root (root valid since 2019).
+        let far_past_ms = 1_000_000_000_000; // 2001
+        let err = chain.verify_chain(1, far_past_ms).unwrap_err();
+        assert!(
+            err.to_string().contains("not yet valid"),
+            "expected not-yet-valid error, got: {err}"
+        );
+    }
+
+    // ── M-01: Chain ordering ────────────────────────────────────────────
+
+    #[rstest]
+    fn wrong_chain_order_rejected(full_chain_der: Vec<Vec<u8>>) {
+        // Swap intermediate1 and intermediate2 → issuer/subject mismatch.
+        let refs: Vec<&[u8]> = vec![
+            &full_chain_der[0],
+            &full_chain_der[2], // inter2 where inter1 should be
+            &full_chain_der[1], // inter1 where inter2 should be
+            &full_chain_der[3],
+            &full_chain_der[4],
+        ];
+        let chain = CertChain::from_der(&refs).unwrap();
+        let err = chain.verify_chain(0, VALID_TIMESTAMP_MS).unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("issuer") || msg.contains("signature"),
+            "expected issuer or signature error, got: {msg}"
+        );
+    }
+
+    // ── M-01: Tampered cert rejected ────────────────────────────────────
+
+    #[rstest]
+    fn tampered_cert_signature_fails(full_chain_der: Vec<Vec<u8>>) {
+        let mut tampered = full_chain_der;
+        // Flip a byte in the middle of inter1 to corrupt it.
+        let mid = tampered[1].len() / 2;
+        tampered[1][mid] ^= 0xFF;
+        let refs: Vec<&[u8]> = tampered.iter().map(|c| c.as_slice()).collect();
+        // Parsing may succeed (DER is tolerant) but signature verification must fail.
+        if let Ok(chain) = CertChain::from_der(&refs) {
+            assert!(chain.verify_chain(0, VALID_TIMESTAMP_MS).is_err());
+        }
+    }
+}

--- a/crates/proof/tee/nitro-verifier/src/x509.rs
+++ b/crates/proof/tee/nitro-verifier/src/x509.rs
@@ -9,14 +9,13 @@
 //! constraints, subject/issuer chain consistency, and validity period checks.
 
 use alloy_primitives::B256;
-use p384::ecdsa::signature::Verifier;
-use p384::ecdsa::{Signature, VerifyingKey};
+use p384::ecdsa::{Signature, VerifyingKey, signature::Verifier};
 use sha2::{Digest, Sha256};
-use x509_parser::certificate::X509Certificate;
-use x509_parser::oid_registry::{
-    OID_KEY_TYPE_EC_PUBLIC_KEY, OID_NIST_EC_P384, OID_SIG_ECDSA_WITH_SHA384,
+use x509_parser::{
+    certificate::X509Certificate,
+    oid_registry::{OID_KEY_TYPE_EC_PUBLIC_KEY, OID_NIST_EC_P384, OID_SIG_ECDSA_WITH_SHA384},
+    prelude::FromDer,
 };
-use x509_parser::prelude::FromDer;
 
 use crate::{Result, VerifierError};
 


### PR DESCRIPTION
## Summary
- Add `x509.rs`: P384/ECDSA-SHA384 certificate chain validation with M-01 audit fixes (basicConstraints, keyUsage, path length, issuer/subject consistency, validity period, EC curve OID enforcement)
- Add `verify.rs`: top-level `AttestationVerifier::verify()` with M-02 content validation (module_id, timestamp, digest, cabundle, PCR bounds, optional field size limits) and COSE signature verification
- Add `X509Parse` and `ContentValidation` error variants
- Add `p384`, `sha2`, `x509-parser` dependencies; `rstest` + `hex` dev-dependencies
- 39 tests using rstest with real AWS Nitro certificates from NitroValidator.t.sol

## Test plan
- [x] `cargo fmt -p base-proof-tee-nitro-verifier --check`
- [x] `cargo clippy -p base-proof-tee-nitro-verifier --tests -- -D warnings`
- [x] `cargo test -p base-proof-tee-nitro-verifier --lib` (39 passed)
- [x] End-to-end: real attestation report parsed, chain verified, COSE sig verified, journal ABI round-tripped
- [x] M-01 negative tests: expired cert, not-yet-valid, wrong chain order, tampered cert
- [x] M-02 negative tests: empty module_id, zero timestamp, wrong digest, empty cabundle, PCR bounds, field size limits