### PR TITLE
fix(flashblocks): correct max_tx_index off-by-one in FAL range

### DIFF
--- a/crates/builder/core/src/flashblocks/payload.rs
+++ b/crates/builder/core/src/flashblocks/payload.rs
@@ -1059,7 +1059,7 @@ where
         new_transactions.clone().into_iter().map(|tx| tx.encoded_2718().into()).collect::<Vec<_>>();
 
     let min_tx_index = info.extra.last_flashblock_index as u64;
-    let max_tx_index = min_tx_index + new_transactions_encoded.len() as u64;
+    let max_tx_index = min_tx_index + new_transactions_encoded.len().saturating_sub(1) as u64;
 
     let new_receipts = info.receipts[info.extra.last_flashblock_index..].to_vec();
     info.extra.last_flashblock_index = info.executed_transactions.len();


### PR DESCRIPTION
## Summary

Fix a small off-by-one bug in flashblocks FAL index range calculation.

## Bug

`max_tx_index` was computed as:

`min_tx_index + new_transactions_encoded.len()`

This produces an exclusive-style upper bound while the field is used as an inclusive max index.

## Fix

Use:

`min_tx_index + new_transactions_encoded.len().saturating_sub(1) as u64`

This keeps the range correct and safe for empty slices.
