### PR TITLE
consensus: reject invalid Jovian EIP-1559 params with zero denominator

### DIFF
--- a/crates/alloy/consensus/src/extra/jovian.rs
+++ b/crates/alloy/consensus/src/extra/jovian.rs
@@ -33,11 +33,14 @@ impl JovianExtraData {
         let denominator: [u8; 4] = extra_data[1..5].try_into().expect("sufficient length");
         let elasticity: [u8; 4] = extra_data[5..9].try_into().expect("sufficient length");
         let min_base_fee: [u8; 8] = extra_data[9..17].try_into().expect("sufficient length");
-        Ok((
-            u32::from_be_bytes(elasticity),
-            u32::from_be_bytes(denominator),
-            u64::from_be_bytes(min_base_fee),
-        ))
+        let elasticity = u32::from_be_bytes(elasticity);
+        let denominator = u32::from_be_bytes(denominator);
+
+        if denominator == 0 && elasticity != 0 {
+            return Err(EIP1559ParamError::ZeroDenominator);
+        }
+
+        Ok((elasticity, denominator, u64::from_be_bytes(min_base_fee)))
     }
 
     /// Encodes the EIP-1559 parameters into Jovian `extra_data` bytes.
@@ -90,5 +93,13 @@ mod tests {
         let extra_data = [0u8; 8];
         let res = JovianExtraData::decode(&extra_data);
         assert_eq!(res.unwrap_err(), EIP1559ParamError::InvalidExtraDataLength);
+    }
+
+    #[test]
+    fn test_decode_rejects_zero_denominator_with_non_zero_elasticity() {
+        let extra_data =
+            Bytes::copy_from_slice(&[1, 0, 0, 0, 0, 0, 0, 0, 8, 0, 0, 0, 0, 0, 0, 0, 0]);
+        let res = JovianExtraData::decode(&extra_data);
+        assert_eq!(res.unwrap_err(), EIP1559ParamError::ZeroDenominator);
     }
 }


### PR DESCRIPTION
## Summary

This PR fixes a validation gap in Jovian EIP-1559 extra-data decoding.

`JovianExtraData::decode` previously accepted an invalid parameter combination (`denominator == 0` with `elasticity != 0`).  
This should be rejected early as invalid input.

## Changes

- Added semantic validation in `JovianExtraData::decode` for:
  - `denominator == 0 && elasticity != 0`
- Return `EIP1559ParamError::ZeroDenominator` for that case.
- Added regression test:
  - `test_decode_rejects_zero_denominator_with_non_zero_elasticity`

## Impact

Prevents malformed Jovian `extra_data` from being treated as valid and propagating into downstream base-fee logic.
