### PR TITLE
chore(docker): mirror proxyd base images 

### DIFF
--- a/etc/docker/Dockerfile.proxyd
+++ b/etc/docker/Dockerfile.proxyd
@@ -1,11 +1,11 @@
-FROM golang:1.23-alpine3.20 AS builder
+FROM public.ecr.aws/docker/library/golang:1.23-alpine3.20 AS builder
 RUN apk add --no-cache make git gcc musl-dev
 WORKDIR /app
 RUN git clone --depth 1 --branch release-rb https://github.com/base/infra-routing.git .
 WORKDIR /app/proxyd
 RUN go build -o /bin/proxyd ./cmd/proxyd
 
-FROM alpine:3.20
+FROM public.ecr.aws/docker/library/alpine:3.20
 RUN apk add --no-cache ca-certificates curl
 COPY --from=builder /bin/proxyd /bin/proxyd
 ENTRYPOINT ["/bin/proxyd"]


### PR DESCRIPTION
  Switch `etc/docker/Dockerfile.proxyd` from Docker Hub official images to the AWS Public ECR mirror.                                     
                                                                                                                                          
  This follows the same fix already merged for the repo’s other Dockerfiles (`#1250`, `#1259`, `#1285`, `#1286`). `proxyd` was still      
  pulling `golang:1.23-alpine3.20` and `alpine:3.20` from Docker Hub, so it remained exposed to the same pull-limit and reliability issues those PRs addressed.                                                                                                                    
                                                                                                                                          
  The change is intentionally narrow: it keeps the exact same image tags and only swaps the registry host to `public.ecr.aws/docker/library/...`, so the build stays functionally the same while the pull path becomes more reliable.   