### PR TITLE
ci: use shallow clones in GitHub Actions workflows

### DIFF
--- a/.github/workflows/action-tests.yml
+++ b/.github/workflows/action-tests.yml
@@ -27,6 +27,8 @@ jobs:
         with:
           egress-policy: audit
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 1
       - uses: ./.github/actions/setup
         with:
           free-disk: "true"

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -34,7 +34,7 @@ jobs:
 
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
-          submodules: recursive
+          fetch-depth: 1
 
       # Cache based on Cargo files and crates source, not the whole repo
       # This allows iterating on benchmark workflow without rebuilding binaries
@@ -97,6 +97,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           path: node-reth
+          fetch-depth: 1
 
       - name: Checkout benchmark repo
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -105,6 +106,7 @@ jobs:
           ref: ${{ env.BENCHMARK_REF }}
           path: benchmark
           submodules: true
+          fetch-depth: 1
 
       - name: Set up Go
         uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # v6.1.0

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -49,6 +49,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           ref: ${{ inputs.tag }}
+          fetch-depth: 1
 
       - name: Install system dependencies (Linux)
         if: matrix.target.os == 'linux'
@@ -113,6 +114,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           ref: ${{ inputs.tag }}
+          fetch-depth: 1
 
       - name: Prepare image labels
         id: image-labels

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,8 @@ jobs:
         with:
           egress-policy: audit
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 1
       - uses: ./.github/actions/setup
         with:
           rust-cache-shared-key: "stable"
@@ -41,6 +43,8 @@ jobs:
         with:
           egress-policy: audit
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 1
       - uses: ./.github/actions/setup
         with:
           free-disk: "true"
@@ -92,6 +96,8 @@ jobs:
         with:
           egress-policy: audit
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 1
       - uses: ./.github/actions/setup
         with:
           toolchain: nightly
@@ -109,6 +115,8 @@ jobs:
         with:
           egress-policy: audit
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 1
       - uses: ./.github/actions/setup
         with:
           free-disk: "true"
@@ -133,6 +141,8 @@ jobs:
           egress-policy: audit
 
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 1
       - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
         id: filter
         with:
@@ -158,6 +168,8 @@ jobs:
 
       - name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 1
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
@@ -183,6 +195,8 @@ jobs:
         with:
           egress-policy: audit
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 1
       - uses: ./.github/actions/setup
         with:
           free-disk: "true"
@@ -201,6 +215,8 @@ jobs:
         with:
           egress-policy: audit
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 1
       - uses: ./.github/actions/setup
         with:
           toolchain: nightly
@@ -220,6 +236,8 @@ jobs:
         with:
           egress-policy: audit
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 1
       - uses: ./.github/actions/setup
       - run: just check-crate-deps
 
@@ -232,6 +250,8 @@ jobs:
         with:
           egress-policy: audit
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 1
       - uses: ./.github/actions/setup
         with:
           free-disk: "true"
@@ -248,6 +268,8 @@ jobs:
         with:
           egress-policy: audit
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 1
       - uses: ./.github/actions/setup
         with:
           native-deps: "true"

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -36,6 +36,8 @@ jobs:
             ${{ vars.LLM_GATEWAY_HOSTNAME }}:443
 
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 1
       - name: Run Claude Code
         id: claude-review
         uses: anthropics/claude-code-action@1b8ee3b94104046d71fde52ec3557651ad8c0d71 # v1.0.29

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -40,6 +40,8 @@ jobs:
           echo "PLATFORM_PAIR=${platform//\//-}" >> $GITHUB_ENV
 
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          fetch-depth: 1
 
       - name: Prepare image labels
         id: image-labels
@@ -99,6 +101,8 @@ jobs:
 
       - name: Checkout repository
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          fetch-depth: 1
 
       - name: Download digests
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0

--- a/.github/workflows/docs-specs-ci.yml
+++ b/.github/workflows/docs-specs-ci.yml
@@ -27,6 +27,8 @@ jobs:
         with:
           egress-policy: audit
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+        with:
+          fetch-depth: 1
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: "22"

--- a/.github/workflows/lychee.yml
+++ b/.github/workflows/lychee.yml
@@ -27,6 +27,8 @@ jobs:
         with:
           egress-policy: audit
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+        with:
+          fetch-depth: 1
       - uses: lycheeverse/lychee-action@8646ba30535128ac92d33dfc9133794bfdd9b411 # v2.8.0
         with:
           args: --config ./lychee.toml .

--- a/.github/workflows/no-std.yml
+++ b/.github/workflows/no-std.yml
@@ -28,6 +28,8 @@ jobs:
           egress-policy: audit
 
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 1
 
       - uses: ./.github/actions/setup
         with:
@@ -53,6 +55,8 @@ jobs:
           egress-policy: audit
 
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 1
 
       - uses: ./.github/actions/setup
         with:

--- a/.github/workflows/zepter.yml
+++ b/.github/workflows/zepter.yml
@@ -23,5 +23,7 @@ jobs:
           egress-policy: audit
 
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 1
       - uses: extractions/setup-just@e33e0265a09d6d736e2ee1e0eb685ef1de4669ff # v3
       - run: just zepter


### PR DESCRIPTION
## Summary

- Add `fetch-depth: 1` to all `actions/checkout` steps that don't require full git history, so workflows only clone the HEAD commit of the relevant branch instead of pulling every branch and all history.
- Remove unused `submodules: recursive` from the benchmark `build-binaries` checkout — no `.gitmodules` exists in this repo. The external benchmark repo checkout keeps `submodules: true` since that repo may legitimately use them.

## Intentionally unchanged

- **ci.yml test job** — already uses `fetch-depth: ${{ github.event_name == 'pull_request' && 0 || 1 }}` for PR diff computation
- **start-release, publish-release, create-rc** — need `fetch-depth: 0` + `fetch-tags: true` for release tagging
- **stale.yml** — no checkout step