### PR TITLE
fix(challenger): use tx manager cli in challenger

### DIFF
--- a/crates/proof/challenge/src/cli.rs
+++ b/crates/proof/challenge/src/cli.rs
@@ -14,6 +14,7 @@ use url::Url;
 base_cli_utils::define_log_args!("BASE_CHALLENGER");
 base_cli_utils::define_metrics_args!("BASE_CHALLENGER", 7310);
 base_tx_manager::define_signer_cli!("BASE_CHALLENGER");
+base_tx_manager::define_tx_manager_cli!("BASE_CHALLENGER");
 
 /// Challenger - ZK-proof dispute game challenger for Base.
 #[derive(Parser)]
@@ -105,6 +106,10 @@ pub struct ChallengerArgs {
     #[command(flatten)]
     pub signer: SignerCli,
 
+    /// Transaction manager configuration (fee limits, confirmations, timeouts).
+    #[command(flatten)]
+    pub tx_manager: TxManagerCli,
+
     /// Number of past games to scan on startup.
     #[arg(long = "lookback-games", env = "BASE_CHALLENGER_LOOKBACK_GAMES", default_value = "1000")]
     pub lookback_games: u64,
@@ -131,6 +136,7 @@ impl std::fmt::Debug for ChallengerArgs {
             .field("zk_connect_timeout", &self.zk_connect_timeout)
             .field("zk_request_timeout", &self.zk_request_timeout)
             .field("signer", &self.signer)
+            .field("tx_manager", &self.tx_manager)
             .field("lookback_games", &self.lookback_games)
             .field("health_addr", &self.health_addr)
             .field("health_port", &self.health_port)

--- a/crates/proof/challenge/src/config.rs
+++ b/crates/proof/challenge/src/config.rs
@@ -4,7 +4,7 @@ use std::{fmt, net::SocketAddr, ops::Deref, time::Duration};
 
 use alloy_primitives::Address;
 use base_cli_utils::{LogConfig, MetricsConfig};
-use base_tx_manager::SignerConfig;
+use base_tx_manager::{SignerConfig, TxManagerConfig};
 use thiserror::Error;
 use url::Url;
 
@@ -77,6 +77,9 @@ pub enum ConfigError {
     /// Invalid signing configuration.
     #[error("invalid signing config: {0}")]
     Signer(#[from] base_tx_manager::ConfigError),
+    /// Invalid transaction manager configuration.
+    #[error("invalid tx manager config: {0}")]
+    TxManager(base_tx_manager::ConfigError),
 }
 
 /// Validated challenger configuration.
@@ -102,6 +105,8 @@ pub struct ChallengerConfig {
     pub zk_request_timeout: Duration,
     /// Signing configuration for L1 transaction submission.
     pub signing: SignerConfig,
+    /// Transaction manager configuration (fee limits, confirmations, timeouts).
+    pub tx_manager: TxManagerConfig,
     /// Number of past games to scan on startup.
     pub lookback_games: u64,
     /// Health server socket address.
@@ -186,6 +191,10 @@ impl ChallengerConfig {
         // Validate and extract signing config
         let signing = SignerConfig::try_from(cli.challenger.signer)?;
 
+        // Validate and extract tx manager config
+        let tx_manager =
+            TxManagerConfig::try_from(cli.challenger.tx_manager).map_err(ConfigError::TxManager)?;
+
         let health_addr = SocketAddr::new(cli.challenger.health_addr, cli.challenger.health_port);
 
         Ok(Self {
@@ -199,6 +208,7 @@ impl ChallengerConfig {
             zk_connect_timeout: cli.challenger.zk_connect_timeout,
             zk_request_timeout: cli.challenger.zk_request_timeout,
             signing,
+            tx_manager,
             lookback_games: cli.challenger.lookback_games,
             health_addr,
             log: LogConfig::from(cli.logging),
@@ -267,6 +277,9 @@ mod tests {
         assert_eq!(config.lookback_games, 1000);
         assert_eq!(config.health_addr, "0.0.0.0:8080".parse::<SocketAddr>().unwrap());
         assert!(matches!(config.signing, SignerConfig::Remote { .. }));
+        assert_eq!(config.tx_manager.num_confirmations, 10);
+        assert_eq!(config.tx_manager.safe_abort_nonce_too_low_count, 3);
+        assert_eq!(config.tx_manager.fee_limit_multiplier, 5);
     }
 
     #[rstest]

--- a/crates/proof/challenge/src/lib.rs
+++ b/crates/proof/challenge/src/lib.rs
@@ -7,7 +7,7 @@
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 
 mod cli;
-pub use cli::{ChallengerArgs, Cli, LogArgs, MetricsArgs, SignerCli};
+pub use cli::{ChallengerArgs, Cli, LogArgs, MetricsArgs, SignerCli, TxManagerCli};
 
 mod config;
 pub use config::{ChallengerConfig, ConfigError, UrlValidationError, Validated};

--- a/crates/proof/challenge/src/service.rs
+++ b/crates/proof/challenge/src/service.rs
@@ -3,7 +3,7 @@
 use std::sync::{Arc, atomic::AtomicBool};
 
 use alloy_provider::{Provider, RootProvider};
-use base_tx_manager::{NoopTxMetrics, SimpleTxManager, TxManagerConfig};
+use base_tx_manager::{NoopTxMetrics, SimpleTxManager};
 use eyre::Result;
 use tracing::info;
 
@@ -60,7 +60,7 @@ impl ChallengerService {
         let tx_manager = SimpleTxManager::new(
             l1_provider,
             signer_config,
-            TxManagerConfig::default(),
+            config.tx_manager,
             chain_id,
             Arc::new(NoopTxMetrics),
         )


### PR DESCRIPTION
### What changed? Why?

The challenger service was hardcoding `TxManagerConfig::default()` instead of using CLI-configurable transaction manager settings. This meant operators had no way to tune fee limits, confirmation counts, or other tx manager parameters for the challenger.

This PR:
- Adds `TxManagerCli` (via the `define_tx_manager_cli!` macro) to the challenger's CLI args
- Threads the validated `TxManagerConfig` through `ChallengerConfig` into `ChallengerService`
- Replaces the hardcoded `TxManagerConfig::default()` in `SimpleTxManager::new` with the user-provided config
- Adds a `ConfigError::TxManager` variant for tx manager validation errors
- Updates tests to assert on the new tx manager config fields

### Notes to reviewers

Follows the same pattern already used for `SignerCli` / `SignerConfig`.

### How has it been tested?

Existing config parsing test updated with assertions on `tx_manager` fields (`num_confirmations`, `safe_abort_nonce_too_low_count`, `fee_limit_multiplier`).

### Change management ([definitions](http://go/change-management))

type=routine<!--routine,nonroutine,emergency-->
risk=low<!--low,medium,high-->
impact=sev5<!--sev5,sev4,sev3,sev2,sev1-->

### Backwards Compatibility ([learn more](http://go/backwards-compatibility))

backwards_compatible=true<!-- true false -->

<!-- Automatically merge your PR once the necessary approvals have been received (you probably want this) -->

automerge=false