### PR TITLE
feat(actions): Action Harness Reorg And DerivedBlock

### DIFF
--- a/actions/harness/src/batcher/actor.rs
+++ b/actions/harness/src/batcher/actor.rs
@@ -189,6 +189,30 @@ impl<S: L2BlockProvider> Batcher<S> {
         tokio::task::yield_now().await;
     }
 
+    /// Simulate an L1 reorg back to `block_number`.
+    ///
+    /// Truncates the L1 chain via [`L1Miner::reorg_to`], fires failure
+    /// receipts for every item in `pending` and `staged`, and publishes
+    /// [`L1HeadEvent::NewHead`] to the driver.
+    ///
+    /// Items already confirmed via [`confirm_staged`] (and thus living in
+    /// the driver's own `in_flight` set) are **not** covered — see
+    /// [`L1MinerTxManager::reorg_to`] for details.
+    ///
+    /// This method is synchronous. After returning, call
+    /// `tokio::task::yield_now().await` (or an equivalent) to give the
+    /// driver's `run()` loop a scheduling turn to process the head event.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `block_number` exceeds the current L1 chain tip
+    /// (`ReorgError::BeyondTip`).
+    ///
+    /// [`confirm_staged`]: Batcher::confirm_staged
+    pub fn reorg(&self, block_number: u64, l1: &mut L1Miner) {
+        self.tx_manager.reorg_to(block_number, l1);
+    }
+
     /// Run one full batch cycle through the production [`BatchDriver`] path.
     ///
     /// # Errors

--- a/actions/harness/src/batcher/tx_manager.rs
+++ b/actions/harness/src/batcher/tx_manager.rs
@@ -7,8 +7,9 @@ use alloy_eips::eip4844::Blob;
 use alloy_primitives::{Address, B256, Bloom};
 use alloy_rpc_types_eth::TransactionReceipt;
 use base_batcher_source::L1HeadEvent;
-use base_tx_manager::{SendHandle, SendResponse, TxCandidate, TxManager};
+use base_tx_manager::{SendHandle, SendResponse, TxCandidate, TxManager, TxManagerError};
 use tokio::sync::{mpsc, oneshot};
+use tracing::info;
 
 use crate::{L1Miner, PendingTx};
 
@@ -172,6 +173,55 @@ impl L1MinerTxManager {
         if let Some(tx) = &self.l1_head_tx {
             let _ = tx.send(L1HeadEvent::NewHead(block_number));
         }
+    }
+
+    /// Simulate an L1 reorg back to `block_number`.
+    ///
+    /// Calls [`L1Miner::reorg_to`] to truncate the canonical chain, fires a
+    /// failure receipt for every pending and staged submission (since their
+    /// inclusion block has been discarded or they are no longer valid), and
+    /// publishes [`L1HeadEvent::NewHead`] so the [`BatchDriver`] observes
+    /// the reorg.
+    ///
+    /// Both `pending` (not yet staged) and `staged` (submitted to L1 but not
+    /// yet confirmed) items are drained. This ensures no [`SendHandle`] is
+    /// left dangling, which would block the driver's `in_flight.next()`.
+    ///
+    /// # Ordering
+    ///
+    /// Failure receipts are fired *before* `L1HeadEvent::NewHead` is sent.
+    /// This is intentional: the driver's `select!` loop prioritises receipt
+    /// processing over head events, so firing receipts first ensures the
+    /// driver requeues any failed frames before it advances its L1 head.
+    ///
+    /// # In-flight items
+    ///
+    /// This method only covers items still in the `pending` or `staged`
+    /// queues. Items that have already been confirmed via [`confirm_all`]
+    /// and are living in the driver's own `in_flight` set are not touched.
+    /// Call this method *before* `confirm_staged` (or immediately after a
+    /// yield has let the driver drain `in_flight`) to avoid leaving the
+    /// driver in an inconsistent state.
+    ///
+    /// [`BatchDriver`]: base_batcher_core::BatchDriver
+    /// [`SendHandle`]: base_tx_manager::SendHandle
+    /// [`confirm_all`]: L1MinerTxManager::confirm_all
+    pub fn reorg_to(&self, block_number: u64, l1: &mut L1Miner) {
+        l1.reorg_to(block_number).expect("reorg_to should not fail");
+        let (pending, staged) = {
+            let mut inner = self.inner.lock().unwrap();
+            let pending: Vec<Pending> = inner.pending.drain(..).collect();
+            let staged: Vec<Pending> = inner.staged.drain(..).collect();
+            (pending, staged)
+        };
+        let drained = pending.len() + staged.len();
+        for p in pending.into_iter().chain(staged) {
+            let _ = p.responder.send(Err(TxManagerError::Rpc("reorg".to_string())));
+        }
+        if let Some(tx) = &self.l1_head_tx {
+            let _ = tx.send(L1HeadEvent::NewHead(block_number));
+        }
+        info!(block_number = %block_number, drained = %drained, "simulated L1 reorg");
     }
 
     /// Submit all pending transactions/blobs to `l1`, mine one block, resolve

--- a/actions/harness/src/lib.rs
+++ b/actions/harness/src/lib.rs
@@ -33,4 +33,6 @@ pub use providers::{
 
 mod verifier;
 pub use base_consensus_derive::StepResult;
-pub use verifier::{BlobVerifierPipeline, DerivedBlock, L2Verifier, VerifierError, VerifierPipeline};
+pub use verifier::{
+    BlobVerifierPipeline, DerivedBlock, L2Verifier, VerifierError, VerifierPipeline,
+};

--- a/actions/harness/src/lib.rs
+++ b/actions/harness/src/lib.rs
@@ -33,4 +33,4 @@ pub use providers::{
 
 mod verifier;
 pub use base_consensus_derive::StepResult;
-pub use verifier::{BlobVerifierPipeline, L2Verifier, VerifierError, VerifierPipeline};
+pub use verifier::{BlobVerifierPipeline, DerivedBlock, L2Verifier, VerifierError, VerifierPipeline};

--- a/actions/harness/src/verifier.rs
+++ b/actions/harness/src/verifier.rs
@@ -90,7 +90,7 @@ impl DerivedBlock {
     /// They are force-generated when a submitted batch is rejected (e.g.
     /// `NonEmptyTransitionBlock` at a hardfork boundary) or when the
     /// sequencer window expires without a valid batch.
-    pub fn is_deposit_only(&self) -> bool {
+    pub const fn is_deposit_only(&self) -> bool {
         self.user_tx_count == 0
     }
 }
@@ -690,11 +690,8 @@ impl<P: Pipeline + SignalReceiver + Debug + Send> L2Verifier<P> {
     ///
     /// [`act_l2_pipeline_full`]: L2Verifier::act_l2_pipeline_full
     pub fn derived_block(&self, number: u64) -> Option<DerivedBlock> {
-        let tx_count = self
-            .derived_tx_counts
-            .iter()
-            .find(|(n, _)| *n == number)
-            .map(|(_, c)| *c)?;
+        let tx_count =
+            self.derived_tx_counts.iter().find(|(n, _)| *n == number).map(|(_, c)| *c)?;
         let user_tx_count = self
             .derived_user_tx_counts
             .iter()

--- a/actions/harness/src/verifier.rs
+++ b/actions/harness/src/verifier.rs
@@ -55,6 +55,46 @@ pub enum VerifierError {
     GossipDecodeFailed,
 }
 
+/// A lightweight view of a derived L2 block's transaction counts.
+///
+/// Returned by [`L2Verifier::derived_block`]. Use [`is_deposit_only`] to assert
+/// that derivation force-generated a deposit-only block rather than consuming a
+/// submitted batch (e.g. after a `NonEmptyTransitionBlock` rejection or a
+/// sequencer-drift violation).
+///
+/// [`is_deposit_only`]: DerivedBlock::is_deposit_only
+#[derive(Debug, Clone, Copy)]
+pub struct DerivedBlock {
+    /// L2 block number.
+    pub number: u64,
+    /// Total number of transactions as recorded in the payload attributes.
+    ///
+    /// Reflects `attributes.transactions.len()`. Is `0` when the attribute
+    /// list was `None` (not an empty `Vec`), which does not occur for normal
+    /// derived blocks but can happen in test-only synthetic attributes.
+    pub tx_count: usize,
+    /// Number of user transactions (excludes the L1 info deposit, which is
+    /// identified by the `0x7E` type prefix).
+    ///
+    /// `0` means the block is deposit-only. When `attributes.transactions`
+    /// was `None`, this field defaults to `0` (see [`derived_block`]).
+    ///
+    /// [`derived_block`]: L2Verifier::derived_block
+    pub user_tx_count: usize,
+}
+
+impl DerivedBlock {
+    /// Returns `true` if this block contains no user transactions.
+    ///
+    /// Deposit-only blocks contain only the mandatory L1 info deposit.
+    /// They are force-generated when a submitted batch is rejected (e.g.
+    /// `NonEmptyTransitionBlock` at a hardfork boundary) or when the
+    /// sequencer window expires without a valid batch.
+    pub fn is_deposit_only(&self) -> bool {
+        self.user_tx_count == 0
+    }
+}
+
 /// In-process rollup node for action tests.
 ///
 /// `L2Verifier` couples the real 8-stage derivation pipeline with an in-memory
@@ -376,6 +416,7 @@ impl<P: Pipeline + SignalReceiver + Debug + Send> L2Verifier<P> {
         // Clear stale finalization state so a subsequent act_l1_finalized_signal
         // cannot promote an L2 block that no longer exists on the canonical chain.
         self.safe_head_history.clear();
+        self.derived_tx_counts.clear();
         self.derived_user_tx_counts.clear();
         self.derived_l1_info_txs.clear();
         self.finalized_head = l2_safe_head;
@@ -631,6 +672,36 @@ impl<P: Pipeline + SignalReceiver + Debug + Send> L2Verifier<P> {
     /// generated at a hardfork upgrade boundary.
     pub fn derived_user_tx_counts(&self) -> &[(u64, usize)] {
         &self.derived_user_tx_counts
+    }
+
+    /// Look up the derived-block summary for the given L2 block number.
+    ///
+    /// Returns `None` if no block with that number has been derived in this
+    /// session (i.e. it was never produced by [`act_l2_pipeline_full`]).
+    ///
+    /// Use [`DerivedBlock::is_deposit_only`] to assert that derivation
+    /// force-generated a deposit-only block rather than consuming a submitted
+    /// batch.
+    ///
+    /// When the payload attributes had `transactions: None`, the returned
+    /// `DerivedBlock::user_tx_count` defaults to `0` (deposit-only by
+    /// convention). In practice every derived block has a non-`None`
+    /// transaction list because the L1 info deposit is always included.
+    ///
+    /// [`act_l2_pipeline_full`]: L2Verifier::act_l2_pipeline_full
+    pub fn derived_block(&self, number: u64) -> Option<DerivedBlock> {
+        let tx_count = self
+            .derived_tx_counts
+            .iter()
+            .find(|(n, _)| *n == number)
+            .map(|(_, c)| *c)?;
+        let user_tx_count = self
+            .derived_user_tx_counts
+            .iter()
+            .find(|(n, _)| *n == number)
+            .map(|(_, c)| *c)
+            .unwrap_or(0);
+        Some(DerivedBlock { number, tx_count, user_tx_count })
     }
 
     /// Return the decoded L1 info transactions for each derived L2 block.

--- a/actions/harness/tests/batch_submission.rs
+++ b/actions/harness/tests/batch_submission.rs
@@ -71,17 +71,24 @@ async fn batcher_errors_when_no_l2_blocks_async() {
 // Batcher: L1 reorg during submission
 // ---------------------------------------------------------------------------
 
-/// An L1 reorg discards a block containing batcher submissions and truncates
-/// the canonical chain. After recovery — creating a new `Batcher` and
-/// resubmitting the same L2 data on the new fork — the verifier re-derives
-/// the L2 block and advances safe head back to 1.
+/// An L1 reorg fires failure receipts for frames that were staged but not yet
+/// confirmed, causing the [`BatchDriver`] to requeue them in the encoder
+/// pipeline and resubmit on the new fork — **without creating a new
+/// [`Batcher`]**.
 ///
-/// Note: in this test the reorg is called after `confirm_staged` has already
-/// drained all staged items, so `reorg_to` fires zero failure receipts. The
-/// test covers L1 chain truncation and re-derivation on a new fork. A test that
-/// exercises the failure-receipt path (reorg called while items are still in
-/// `staged`) would require calling `reorg` between `stage_n_frames` and
-/// `confirm_staged`.
+/// Sequence:
+/// 1. Encode and stage all frames; mine L1 block 1 (original).
+/// 2. Reorg to genesis **before** calling `confirm_staged` — frames are still
+///    in `staged`, so `reorg_to` fires `Err(TxManagerError::Rpc("reorg"))` on
+///    each oneshot responder.
+/// 3. The driver processes each `Receipt(id, Failed)` → `pipeline.requeue(id)`
+///    rewinds the encoder channel cursor. On the next loop iteration, the driver
+///    calls `submit_pending()` → `send_async()` and the frames are back in the
+///    `L1MinerTxManager` pending queue.
+/// 4. The same batcher stages the requeued frames and mines a new L1 block on
+///    the new fork. The verifier re-derives L2 block 1 from this block.
+///
+/// [`BatchDriver`]: base_batcher_core::BatchDriver
 #[tokio::test]
 async fn batcher_reorg_during_submission() {
     let batcher_cfg = BatcherConfig {
@@ -96,95 +103,68 @@ async fn batcher_reorg_during_submission() {
     let mut sequencer = h.create_l2_sequencer(l1_chain);
     let block = sequencer.build_next_block().expect("build L2 block 1");
 
-    // Create a verifier sharing the sequencer's block-hash registry.
     let (mut verifier, chain) = h.create_verifier_from_sequencer(
         &sequencer,
         SharedL1Chain::from_blocks(h.l1.chain().to_vec()),
     );
 
-    // Batcher: encode + stage + mine L1 block 1.
+    // Encode and stage all frames; mine L1 block 1 (original).
+    // Do NOT call confirm_staged — frames remain in `staged` so the reorg
+    // below fires failure receipts for them.
     let mut source = ActionL2Source::new();
-    source.push(block.clone());
-    let mut batcher = Batcher::new(source, &h.rollup_config, batcher_cfg.clone());
+    source.push(block);
+    let mut batcher = Batcher::new(source, &h.rollup_config, batcher_cfg);
     batcher.encode_only().await.expect("encode");
     batcher.stage_n_frames(&mut h.l1, usize::MAX);
-    let block_1_num = h.l1.mine_block().number();
+    h.l1.mine_block(); // L1 block 1 (original, about to be reorged)
     chain.push(h.l1.tip().clone());
-    batcher.confirm_staged(block_1_num).await;
 
-    // Derive through the verifier: safe head should advance to 1.
-    verifier.initialize().await.expect("initialize");
-    let l1_block_1 = block_info_from(h.l1.block_by_number(1).expect("block 1"));
-    verifier.act_l1_head_signal(l1_block_1).await.expect("signal block 1");
-    verifier.act_l2_pipeline_full().await.expect("step block 1");
-    assert_eq!(
-        verifier.l2_safe().block_info.number,
-        1,
-        "safe head should be 1 after initial submission"
-    );
-
-    // --- L1 reorg back to genesis ---
+    // --- L1 reorg back to genesis (frames still in staged) ---
+    // reorg_to fires Err(TxManagerError::Rpc("reorg")) for every staged item
+    // and sends L1HeadEvent::NewHead(0). The driver's select! loop processes
+    // each Receipt(id, Failed) → pipeline.requeue(id), rewinding the channel
+    // cursor without re-encoding.
     batcher.reorg(0, &mut h.l1);
-    // Give the driver several scheduling turns to process the L1HeadEvent::NewHead(0)
-    // that reorg() sends via the l1_head channel. The reorg fires 0 failure receipts
-    // here (pending and staged are both empty after confirm_staged), so the driver
-    // only needs to process the head event. A single yield suffices on a
-    // current_thread runtime; the extra yields guard against any scheduling races
-    // when running under other executor configurations.
-    for _ in 0..5 {
+    // Yield to let the driver work through two loop iterations:
+    //   iteration 1: next_event() picks up Receipt(id, Failed) per frame → requeue
+    //   iteration 2: submit_pending() calls send_async() for requeued frames
+    //                → frames are back in L1MinerTxManager::pending
+    for _ in 0..10 {
         tokio::task::yield_now().await;
     }
 
-    // Mine an empty replacement block on the new fork. This gives the pipeline
-    // an L1 block to advance to after reset — without it the pipeline loops
-    // infinitely between AdvancedOrigin (at genesis, resetting no_progress)
-    // and NotEnoughData (trying to fetch the now-missing old block 1).
+    // Verify the driver actually requeued the frames before we try to stage them.
+    assert!(
+        batcher.pending_count() > 0,
+        "driver must have requeued frames after reorg; pending queue is empty"
+    );
+
+    // Mine an empty replacement block on the new fork, then resubmit the
+    // requeued frames using the same Batcher (no drop/recreate required).
     h.l1.mine_block(); // block 1' (empty, on new fork)
-    let l1_block_1_prime = block_info_from(h.l1.tip());
     chain.truncate_to(0);
     chain.push(h.l1.tip().clone());
 
-    // Reset the verifier pipeline to genesis.
-    let l1_genesis = block_info_from(h.l1.chain().first().expect("genesis"));
-    let l2_genesis = h.l2_genesis();
-    let genesis_sys_cfg = h.rollup_config.genesis.system_config.unwrap_or_default();
-    verifier.act_reset(l1_genesis, l2_genesis, genesis_sys_cfg).await.expect("reset");
-    // Drain the reset origin (genesis has no batch data).
-    let genesis_derived = verifier.act_l2_pipeline_full().await.expect("drain genesis after reset");
-    assert_eq!(genesis_derived, 0, "genesis drain after reset must derive no L2 blocks");
+    batcher.stage_n_frames(&mut h.l1, usize::MAX);
+    let recovery_num = h.l1.mine_block().number();
+    chain.push(h.l1.tip().clone());
+    batcher.confirm_staged(recovery_num).await;
 
-    // Step over the empty block 1' — nothing derived.
-    verifier.act_l1_head_signal(l1_block_1_prime).await.expect("signal empty block 1'");
+    // Verify the verifier re-derives L2 block 1 from the new-fork submission.
+    verifier.initialize().await.expect("initialize");
+
+    let blk_1_prime = block_info_from(h.l1.block_by_number(1).expect("block 1'"));
+    verifier.act_l1_head_signal(blk_1_prime).await.expect("signal empty block 1'");
     let empty = verifier.act_l2_pipeline_full().await.expect("step empty block 1'");
     assert_eq!(empty, 0, "empty block 1' has no batch data");
-    assert_eq!(
-        verifier.l2_safe().block_info.number,
-        0,
-        "safe head should revert to genesis after reorg"
-    );
 
-    // --- Recovery: new Batcher resubmits on the new fork ---
-    // Drop the old batcher before creating batcher2. `Drop` cancels the token
-    // and calls `JoinHandle::abort()`, which *schedules* the abort but does not
-    // await it. On a current_thread runtime the old task is only actually polled
-    // to completion on the next yield inside batcher2's encode_only(). This is
-    // safe because batcher2 constructs a fresh L1MinerTxManager (new Arc), so
-    // there is no shared mutable state between the two driver tasks.
-    drop(batcher);
-    let mut source2 = ActionL2Source::new();
-    source2.push(block);
-    let mut batcher2 = Batcher::new(source2, &h.rollup_config, batcher_cfg);
-    batcher2.advance(&mut h.l1).await.expect("recovery advance");
-    chain.push(h.l1.tip().clone());
-
-    let recovery_block =
-        block_info_from(h.l1.block_by_number(h.l1.latest_number()).expect("recovery block"));
-    verifier.act_l1_head_signal(recovery_block).await.expect("signal recovery block");
+    let recovery_blk = block_info_from(h.l1.block_by_number(recovery_num).expect("recovery block"));
+    verifier.act_l1_head_signal(recovery_blk).await.expect("signal recovery block");
     let derived = verifier.act_l2_pipeline_full().await.expect("step recovery");
-    assert_eq!(derived, 1, "recovery channel should derive L2 block 1");
+    assert_eq!(derived, 1, "same-batcher resubmission must derive L2 block 1");
     assert_eq!(
         verifier.l2_safe().block_info.number,
         1,
-        "safe head should recover to 1 after resubmission on new fork"
+        "safe head must recover to 1 after same-batcher resubmission on new fork"
     );
 }

--- a/actions/harness/tests/batch_submission.rs
+++ b/actions/harness/tests/batch_submission.rs
@@ -1,8 +1,8 @@
 #![doc = "Action tests for L2 batch submission via the Batcher actor."]
 
 use base_action_harness::{
-    ActionL2Source, ActionTestHarness, BatchType, Batcher, BatcherConfig, BatcherError,
-    SharedL1Chain,
+    ActionL2Source, ActionTestHarness, BatchType, Batcher, BatcherConfig, BatcherError, DaType,
+    EncoderConfig, L1MinerConfig, SharedL1Chain, TestRollupConfigBuilder, block_info_from,
 };
 
 /// Build an [`ActionL2Source`] pre-populated with `n` real [`OpBlock`]s from
@@ -65,4 +65,126 @@ async fn batcher_errors_when_no_l2_blocks_async() {
     let mut batcher = Batcher::new(source, &h.rollup_config, cfg);
     let err = batcher.advance(&mut h.l1).await.expect_err("should fail with no blocks");
     assert!(matches!(err, BatcherError::NoBlocks));
+}
+
+// ---------------------------------------------------------------------------
+// Batcher: L1 reorg during submission
+// ---------------------------------------------------------------------------
+
+/// An L1 reorg discards a block containing batcher submissions and truncates
+/// the canonical chain. After recovery — creating a new `Batcher` and
+/// resubmitting the same L2 data on the new fork — the verifier re-derives
+/// the L2 block and advances safe head back to 1.
+///
+/// Note: in this test the reorg is called after `confirm_staged` has already
+/// drained all staged items, so `reorg_to` fires zero failure receipts. The
+/// test covers L1 chain truncation and re-derivation on a new fork. A test that
+/// exercises the failure-receipt path (reorg called while items are still in
+/// `staged`) would require calling `reorg` between `stage_n_frames` and
+/// `confirm_staged`.
+#[tokio::test]
+async fn batcher_reorg_during_submission() {
+    let batcher_cfg = BatcherConfig {
+        encoder: EncoderConfig { da_type: DaType::Calldata, ..EncoderConfig::default() },
+        ..BatcherConfig::default()
+    };
+    let rollup_cfg = TestRollupConfigBuilder::base_mainnet(&batcher_cfg).build();
+    let mut h = ActionTestHarness::new(L1MinerConfig::default(), rollup_cfg);
+
+    // Build L2 block 1.
+    let l1_chain = SharedL1Chain::from_blocks(h.l1.chain().to_vec());
+    let mut sequencer = h.create_l2_sequencer(l1_chain);
+    let block = sequencer.build_next_block().expect("build L2 block 1");
+
+    // Create a verifier sharing the sequencer's block-hash registry.
+    let (mut verifier, chain) = h.create_verifier_from_sequencer(
+        &sequencer,
+        SharedL1Chain::from_blocks(h.l1.chain().to_vec()),
+    );
+
+    // Batcher: encode + stage + mine L1 block 1.
+    let mut source = ActionL2Source::new();
+    source.push(block.clone());
+    let mut batcher = Batcher::new(source, &h.rollup_config, batcher_cfg.clone());
+    batcher.encode_only().await.expect("encode");
+    batcher.stage_n_frames(&mut h.l1, usize::MAX);
+    let block_1_num = h.l1.mine_block().number();
+    chain.push(h.l1.tip().clone());
+    batcher.confirm_staged(block_1_num).await;
+
+    // Derive through the verifier: safe head should advance to 1.
+    verifier.initialize().await.expect("initialize");
+    let l1_block_1 = block_info_from(h.l1.block_by_number(1).expect("block 1"));
+    verifier.act_l1_head_signal(l1_block_1).await.expect("signal block 1");
+    verifier.act_l2_pipeline_full().await.expect("step block 1");
+    assert_eq!(
+        verifier.l2_safe().block_info.number,
+        1,
+        "safe head should be 1 after initial submission"
+    );
+
+    // --- L1 reorg back to genesis ---
+    batcher.reorg(0, &mut h.l1);
+    // Give the driver several scheduling turns to process the L1HeadEvent::NewHead(0)
+    // that reorg() sends via the l1_head channel. The reorg fires 0 failure receipts
+    // here (pending and staged are both empty after confirm_staged), so the driver
+    // only needs to process the head event. A single yield suffices on a
+    // current_thread runtime; the extra yields guard against any scheduling races
+    // when running under other executor configurations.
+    for _ in 0..5 {
+        tokio::task::yield_now().await;
+    }
+
+    // Mine an empty replacement block on the new fork. This gives the pipeline
+    // an L1 block to advance to after reset — without it the pipeline loops
+    // infinitely between AdvancedOrigin (at genesis, resetting no_progress)
+    // and NotEnoughData (trying to fetch the now-missing old block 1).
+    h.l1.mine_block(); // block 1' (empty, on new fork)
+    let l1_block_1_prime = block_info_from(h.l1.tip());
+    chain.truncate_to(0);
+    chain.push(h.l1.tip().clone());
+
+    // Reset the verifier pipeline to genesis.
+    let l1_genesis = block_info_from(h.l1.chain().first().expect("genesis"));
+    let l2_genesis = h.l2_genesis();
+    let genesis_sys_cfg = h.rollup_config.genesis.system_config.unwrap_or_default();
+    verifier.act_reset(l1_genesis, l2_genesis, genesis_sys_cfg).await.expect("reset");
+    // Drain the reset origin (genesis has no batch data).
+    let genesis_derived = verifier.act_l2_pipeline_full().await.expect("drain genesis after reset");
+    assert_eq!(genesis_derived, 0, "genesis drain after reset must derive no L2 blocks");
+
+    // Step over the empty block 1' — nothing derived.
+    verifier.act_l1_head_signal(l1_block_1_prime).await.expect("signal empty block 1'");
+    let empty = verifier.act_l2_pipeline_full().await.expect("step empty block 1'");
+    assert_eq!(empty, 0, "empty block 1' has no batch data");
+    assert_eq!(
+        verifier.l2_safe().block_info.number,
+        0,
+        "safe head should revert to genesis after reorg"
+    );
+
+    // --- Recovery: new Batcher resubmits on the new fork ---
+    // Drop the old batcher before creating batcher2. `Drop` cancels the token
+    // and calls `JoinHandle::abort()`, which *schedules* the abort but does not
+    // await it. On a current_thread runtime the old task is only actually polled
+    // to completion on the next yield inside batcher2's encode_only(). This is
+    // safe because batcher2 constructs a fresh L1MinerTxManager (new Arc), so
+    // there is no shared mutable state between the two driver tasks.
+    drop(batcher);
+    let mut source2 = ActionL2Source::new();
+    source2.push(block);
+    let mut batcher2 = Batcher::new(source2, &h.rollup_config, batcher_cfg);
+    batcher2.advance(&mut h.l1).await.expect("recovery advance");
+    chain.push(h.l1.tip().clone());
+
+    let recovery_block =
+        block_info_from(h.l1.block_by_number(h.l1.latest_number()).expect("recovery block"));
+    verifier.act_l1_head_signal(recovery_block).await.expect("signal recovery block");
+    let derived = verifier.act_l2_pipeline_full().await.expect("step recovery");
+    assert_eq!(derived, 1, "recovery channel should derive L2 block 1");
+    assert_eq!(
+        verifier.l2_safe().block_info.number,
+        1,
+        "safe head should recover to 1 after resubmission on new fork"
+    );
 }

--- a/actions/harness/tests/batcher_channels.rs
+++ b/actions/harness/tests/batcher_channels.rs
@@ -329,3 +329,103 @@ async fn multi_block_channel_assembles_across_l1_blocks() {
     assert_eq!(derived, 1, "multi-block channel must yield 1 L2 block");
     assert_eq!(verifier.l2_safe().block_info.number, 1, "safe head must advance to 1");
 }
+
+// ---------------------------------------------------------------------------
+// E. Multi-frame channel with an empty L1 gap between submissions
+// ---------------------------------------------------------------------------
+
+/// Frames from a single channel are submitted to L1 in two separate L1 blocks
+/// with an **empty L1 block** between them. The derivation pipeline must
+/// correctly reassemble the channel across the gap.
+///
+/// Note: `encode_only()` sends a `Flush` event that closes the channel
+/// immediately, so all frames are in the pending queue before any L1 head
+/// events arrive. This means this test exercises the multi-frame split
+/// submission scenario (frame 0 in block 1, empty block 2, rest in block 3),
+/// not duration-based channel closure — that would require the channel to
+/// remain open while L1 blocks are mined.
+#[tokio::test]
+async fn multi_frame_channel_with_empty_l1_gap_derives_correctly() {
+    let batcher_cfg = BatcherConfig {
+        encoder: EncoderConfig {
+            da_type: DaType::Calldata,
+            max_frame_size: 80,
+            ..EncoderConfig::default()
+        },
+        ..BatcherConfig::default()
+    };
+    let rollup_cfg = TestRollupConfigBuilder::base_mainnet(&batcher_cfg).build();
+    let mut h = ActionTestHarness::new(L1MinerConfig::default(), rollup_cfg);
+
+    let l1_chain = SharedL1Chain::from_blocks(h.l1.chain().to_vec());
+    let mut sequencer = h.create_l2_sequencer(l1_chain);
+    let block = sequencer.build_next_block().expect("build L2 block 1");
+
+    // Create verifier before any mining so all future blocks are pushed to chain.
+    let (mut verifier, chain) = h.create_verifier_from_sequencer(
+        &sequencer,
+        SharedL1Chain::from_blocks(h.l1.chain().to_vec()),
+    );
+
+    // Encode block — produces multiple frames with max_frame_size=80.
+    // The Flush from encode_only() closes the channel; frames become pending.
+    let mut source = ActionL2Source::new();
+    source.push(block);
+    let mut batcher = Batcher::new(source, &h.rollup_config, batcher_cfg.clone());
+    batcher.encode_only().await.expect("encode");
+
+    let frame_count = batcher.pending_count();
+    assert!(
+        frame_count >= 2,
+        "expected multi-frame channel with max_frame_size=80, got {frame_count} frames",
+    );
+
+    // L1 block 1: submit only frame 0.
+    batcher.stage_n_frames(&mut h.l1, 1);
+    let block_1_num = h.l1.mine_block().number();
+    chain.push(h.l1.tip().clone());
+    batcher.confirm_staged(block_1_num).await;
+
+    verifier.initialize().await.expect("initialize");
+    let l1_block_1 = block_info_from(h.l1.block_by_number(1).expect("block 1"));
+    verifier.act_l1_head_signal(l1_block_1).await.expect("signal block 1");
+    verifier.act_l2_pipeline_full().await.expect("step block 1");
+
+    assert_eq!(
+        verifier.l2_safe().block_info.number,
+        0,
+        "incomplete channel after block 1; safe head must stay at genesis"
+    );
+
+    // Mine an empty L1 block 2. The channel was already closed by encode_only()
+    // (which sent Flush), so no staged items are confirmed here. The call to
+    // confirm_staged is used solely to advance the driver's L1 head to block 2
+    // via L1HeadEvent::NewHead — confirm_all fires zero receipts and just sends
+    // the head event. The remaining frames are already in `pending`.
+    h.l1.mine_block();
+    chain.push(h.l1.tip().clone());
+    batcher.confirm_staged(h.l1.latest_number()).await;
+
+    // L1 block 3: submit the remaining frames.
+    let remaining = batcher.pending_count();
+    batcher.stage_n_frames(&mut h.l1, remaining);
+    let block_3_num = h.l1.mine_block().number();
+    chain.push(h.l1.tip().clone());
+    batcher.confirm_staged(block_3_num).await;
+
+    // Signal verifier for all L1 blocks. Track the total L2 blocks derived
+    // to confirm exactly one block was produced across the 3-block span.
+    let mut total_derived = 0usize;
+    for i in 2..=h.l1.latest_number() {
+        let blk = block_info_from(h.l1.block_by_number(i).expect("block exists"));
+        verifier.act_l1_head_signal(blk).await.expect("signal block");
+        total_derived += verifier.act_l2_pipeline_full().await.expect("step block");
+    }
+
+    assert_eq!(total_derived, 1, "exactly one L2 block must be derived across the 3-block span");
+    assert_eq!(
+        verifier.l2_safe().block_info.number,
+        1,
+        "frames split across 3 L1 blocks (with an empty intermediate block) must derive L2 block 1"
+    );
+}

--- a/actions/harness/tests/batcher_hardfork_transitions.rs
+++ b/actions/harness/tests/batcher_hardfork_transitions.rs
@@ -1,10 +1,10 @@
 #![doc = "Action tests for batch format transitions across hardfork boundaries."]
 
 use base_action_harness::{
-    ActionL2Source, ActionTestHarness, BatchType, Batcher, BatcherConfig, DaType, EncoderConfig,
-    L1MinerConfig, SharedL1Chain, TestRollupConfigBuilder, block_info_from,
+    ActionL2Source, ActionTestHarness, BatchType, Batcher, BatcherConfig, DaType, DerivedBlock,
+    EncoderConfig, L1MinerConfig, SharedL1Chain, TestRollupConfigBuilder, block_info_from,
 };
-use base_consensus_genesis::HardForkConfig;
+use base_consensus_genesis::{GRANITE_CHANNEL_TIMEOUT, HardForkConfig};
 
 // ---------------------------------------------------------------------------
 // A. Span batch with non-empty hardfork transition block is rejected
@@ -219,5 +219,306 @@ async fn mixed_singular_and_span_batches_after_delta() {
         verifier.l2_safe().block_info.number,
         2,
         "mixed singular + span batches must both derive; safe head should reach 2"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// C. Granite channel timeout enforcement
+//
+// Verifies that the post-Granite 50-block channel timeout is enforced.
+// ---------------------------------------------------------------------------
+
+/// After Granite activates, the channel timeout drops from 300 to 50 blocks.
+/// A channel whose first frame is included in L1 block 1 must time out when
+/// 51 or more additional L1 blocks pass without the channel being completed
+/// (i.e., origin.number > `open_block` + 50).
+///
+/// Setup: All forks through Fjord active at genesis; Granite activates at
+/// timestamp 6 (L2 block 3 with `block_time=2`). Because the default L1
+/// `block_time` is 12 seconds, L1 block 1's timestamp is 12 — well past
+/// Granite activation — so the 50-block timeout applies from the first L1
+/// block that contains batch data.
+///
+/// Phase 1: encode one L2 block into a multi-frame channel (`max_frame_size=80`),
+/// submit only frame 0 in L1 block 1, then mine 51 more empty L1 blocks.
+/// The channel's `open_block_number` is 1 and `1 + 50 = 51 < 52`, so the
+/// channel is timed out by the time the pipeline reaches L1 block 52.
+///
+/// Phase 2 (recovery): a new batcher submits all frames in a single L1 block
+/// and derivation advances the safe head to 1.
+#[tokio::test]
+async fn granite_channel_timeout_enforced() {
+    // All forks through Fjord at genesis, Granite at timestamp 6.
+    // The pre-Granite channel_timeout (300) is never exercised because every
+    // L1 origin processed by the pipeline has timestamp >= 12 > 6.
+    let hardforks = HardForkConfig {
+        canyon_time: Some(0),
+        delta_time: Some(0),
+        ecotone_time: Some(0),
+        fjord_time: Some(0),
+        granite_time: Some(6),
+        ..Default::default()
+    };
+    let batcher_cfg = BatcherConfig {
+        encoder: EncoderConfig {
+            da_type: DaType::Calldata,
+            max_frame_size: 80,
+            ..EncoderConfig::default()
+        },
+        ..BatcherConfig::default()
+    };
+    let rollup_cfg =
+        TestRollupConfigBuilder::base_mainnet(&batcher_cfg).with_hardforks(hardforks).build();
+
+    // Verify the config has the expected timeout values.
+    assert_eq!(
+        rollup_cfg.granite_channel_timeout, GRANITE_CHANNEL_TIMEOUT,
+        "granite_channel_timeout must be {GRANITE_CHANNEL_TIMEOUT}"
+    );
+    assert_eq!(
+        rollup_cfg.channel_timeout, 300,
+        "pre-Granite channel_timeout must be 300 (Base mainnet default)"
+    );
+
+    let mut h = ActionTestHarness::new(L1MinerConfig::default(), rollup_cfg);
+
+    let l1_chain = SharedL1Chain::from_blocks(h.l1.chain().to_vec());
+    let mut sequencer = h.create_l2_sequencer(l1_chain);
+    let block = sequencer.build_next_block().expect("build L2 block 1");
+
+    let (mut verifier, chain) = h.create_verifier_from_sequencer(
+        &sequencer,
+        SharedL1Chain::from_blocks(h.l1.chain().to_vec()),
+    );
+
+    // Encode block into multiple frames (max_frame_size=80 forces multi-frame).
+    let mut source = ActionL2Source::new();
+    source.push(block.clone());
+    let mut batcher = Batcher::new(source, &h.rollup_config, batcher_cfg.clone());
+    batcher.encode_only().await.expect("encode");
+
+    let frame_count = batcher.pending_count();
+    assert!(
+        frame_count >= 2,
+        "expected multi-frame channel with max_frame_size=80, got {frame_count} frames",
+    );
+
+    // L1 block 1: submit only frame 0. Channel opens at block 1.
+    batcher.stage_n_frames(&mut h.l1, 1);
+    let block_1_num = h.l1.mine_block().number();
+    chain.push(h.l1.tip().clone());
+    batcher.confirm_staged(block_1_num).await;
+
+    verifier.initialize().await.expect("initialize");
+    let l1_block_1 = block_info_from(h.l1.block_by_number(1).expect("block 1"));
+    verifier.act_l1_head_signal(l1_block_1).await.expect("signal block 1");
+    verifier.act_l2_pipeline_full().await.expect("step block 1");
+
+    assert_eq!(
+        verifier.l2_safe().block_info.number,
+        0,
+        "incomplete channel should not advance safe head"
+    );
+
+    // Mine 51 empty L1 blocks (blocks 2..=52). After block 52, the channel
+    // opened at block 1 has been open for 51 blocks: 1 + 50 = 51 < 52,
+    // triggering timeout under Granite's 50-block limit.
+    for _ in 0..51 {
+        h.mine_and_push(&chain);
+    }
+
+    // Signal all empty blocks to the verifier.
+    for i in 2..=52u64 {
+        let blk = block_info_from(h.l1.block_by_number(i).expect("block exists"));
+        verifier.act_l1_head_signal(blk).await.expect("signal empty block");
+        verifier.act_l2_pipeline_full().await.expect("step empty block");
+    }
+
+    assert_eq!(
+        verifier.l2_safe().block_info.number,
+        0,
+        "channel must have timed out under Granite's 50-block limit; safe head stays at 0"
+    );
+
+    // Submit remaining frames — they arrive after the channel timed out.
+    // ChannelBank silently drops frames for timed-out channels (lazy eviction:
+    // the timeout check fires in read() before any frame is delivered). If the
+    // timed-out entry was already flushed, the late frames would create a new
+    // incomplete channel starting from a non-zero frame number, which can also
+    // never become ready. Either way, no L2 block is derived.
+    batcher.stage_n_frames(&mut h.l1, frame_count - 1);
+    let late_block_num = h.l1.mine_block().number();
+    chain.push(h.l1.tip().clone());
+    batcher.confirm_staged(late_block_num).await;
+
+    let late_blk = block_info_from(h.l1.block_by_number(late_block_num).expect("late block"));
+    verifier.act_l1_head_signal(late_blk).await.expect("signal late block");
+    let derived = verifier.act_l2_pipeline_full().await.expect("step late block");
+    assert_eq!(derived, 0, "late non-zero frames after timeout create an incomplete channel; no L2 block derived");
+    assert_eq!(
+        verifier.l2_safe().block_info.number,
+        0,
+        "safe head must still be at genesis before recovery; channel timed out"
+    );
+
+    // --- Recovery: new batcher, all frames in one L1 block ---
+    let mut source2 = ActionL2Source::new();
+    source2.push(block);
+    Batcher::new(source2, &h.rollup_config, batcher_cfg)
+        .advance(&mut h.l1)
+        .await
+        .expect("recovery advance");
+    chain.push(h.l1.tip().clone());
+
+    let recovery_num = h.l1.latest_number();
+    let recovery_blk = block_info_from(h.l1.block_by_number(recovery_num).expect("recovery block"));
+    verifier.act_l1_head_signal(recovery_blk).await.expect("signal recovery");
+    let recovered = verifier.act_l2_pipeline_full().await.expect("step recovery");
+
+    assert_eq!(recovered, 1, "recovery channel should derive L2 block 1");
+    assert_eq!(verifier.l2_safe().block_info.number, 1, "safe head should recover to 1");
+}
+
+// ---------------------------------------------------------------------------
+// D. Jovian SingleBatch transition block is deposit-only
+//
+// op-e2e ref: TestHardforkMiddleOfSingularBatch
+// ---------------------------------------------------------------------------
+
+/// When a `SingleBatch` is submitted for the first Jovian upgrade block (block 3
+/// at ts=6) containing user transactions, derivation drops the batch
+/// (`NonEmptyTransitionBlock`) and generates a deposit-only block in its place
+/// once the sequencer window expires. Unlike span batches (test A above), only
+/// the offending block is dropped — the remaining singular batches for blocks
+/// 1, 2, and 4 derive successfully.
+///
+/// Setup: all forks through Isthmus active at genesis, Jovian at timestamp 6
+/// (L2 block 3 with `block_time=2`). Each L2 block is submitted as a separate
+/// `SingleBatch` channel. A small `seq_window_size` (4) ensures the sequencer
+/// window expires quickly so the pipeline can force-generate the deposit-only
+/// block for block 3 without mining thousands of L1 blocks.
+///
+/// After the pipeline drops block 3's batch and the sequencer window expires,
+/// it auto-generates a deposit-only block 3 and then derives block 4 from its
+/// submitted batch. Safe head reaches 4.
+#[tokio::test]
+async fn jovian_single_batch_transition_block_deposit_only() {
+    let jovian_time = 6u64;
+    let hardforks = HardForkConfig {
+        canyon_time: Some(0),
+        delta_time: Some(0),
+        ecotone_time: Some(0),
+        fjord_time: Some(0),
+        granite_time: Some(0),
+        holocene_time: Some(0),
+        isthmus_time: Some(0),
+        jovian_time: Some(jovian_time),
+        ..Default::default()
+    };
+    let batcher_cfg = BatcherConfig {
+        batch_type: BatchType::Single,
+        encoder: EncoderConfig { da_type: DaType::Calldata, ..EncoderConfig::default() },
+        ..BatcherConfig::default()
+    };
+    // Use a small seq_window_size so the pipeline can force-generate deposit-only
+    // blocks without needing to mine thousands of empty L1 blocks.
+    //
+    // L1 block_time=2 ensures L1 timestamps closely track L2 timestamps and
+    // don't create a wide gap that would generate many spurious empty L2 blocks
+    // when the sequencer window expires.
+    let rollup_cfg = TestRollupConfigBuilder::base_mainnet(&batcher_cfg)
+        .with_hardforks(hardforks)
+        .with_seq_window_size(4)
+        .build();
+    let l1_config = L1MinerConfig { block_time: 2 };
+    let mut h = ActionTestHarness::new(l1_config, rollup_cfg);
+
+    // The sequencer is initialized with the L1 chain at genesis (before any
+    // L1 blocks are mined). As a result every L2 block built by `builder` will
+    // have L1 origin = genesis (block 0). This means the sequencer window
+    // [0, 0 + seq_window_size) governs *all* four L2 blocks, which is the
+    // behaviour the deposit-only assertion relies on.
+    let l1_chain = SharedL1Chain::from_blocks(h.l1.chain().to_vec());
+    let mut builder = h.create_l2_sequencer(l1_chain);
+
+    // Build 4 L2 blocks. build_next_block() includes a user transaction in
+    // every block. Block 3 (ts=6) is the first Jovian block — including a
+    // user tx is the deliberate error that derivation must handle.
+    let block1 = builder.build_next_block().expect("build L2 block 1"); // ts=2
+    let block2 = builder.build_next_block().expect("build L2 block 2"); // ts=4
+    let block3_invalid = builder.build_next_block().expect("build L2 block 3 (invalid)"); // ts=6
+    let block4 = builder.build_next_block().expect("build L2 block 4"); // ts=8
+
+    // Precondition: block 3 must contain at least one user transaction (deposits
+    // don't count). If build_next_block() ever started returning empty blocks,
+    // this test would silently stop exercising the NonEmptyTransitionBlock path.
+    assert!(
+        block3_invalid.body.transactions.len() > 1,
+        "block 3 must have deposit tx + at least one user tx to trigger NonEmptyTransitionBlock; \
+         got {} txs",
+        block3_invalid.body.transactions.len(),
+    );
+
+    let (mut verifier, chain) = h.create_verifier_from_sequencer(
+        &builder,
+        SharedL1Chain::from_blocks(h.l1.chain().to_vec()),
+    );
+
+    // Submit each block as a separate SingleBatch channel, one L1 block each.
+    // L1 blocks 1–4 each contain one singular batch.
+    for (i, block) in [block1, block2, block3_invalid, block4].into_iter().enumerate() {
+        let mut source = ActionL2Source::new();
+        source.push(block);
+        Batcher::new(source, &h.rollup_config, batcher_cfg.clone())
+            .advance(&mut h.l1)
+            .await
+            .unwrap_or_else(|e| panic!("encode singular batch for L2 block {}: {e}", i + 1));
+        chain.push(h.l1.tip().clone());
+    }
+
+    // Mine additional empty L1 blocks so the sequencer window (size=4) expires
+    // for block 3's epoch. The sequencer is initialized with only L1 genesis in
+    // its view, so all L2 blocks have L1 origin = genesis (epoch 0). The window
+    // expires at L1 block 0 + 4 = 4; the pipeline generates the deposit-only block
+    // when processing L1 block 5 (the first block past the window). We already
+    // have L1 blocks 1–4 from batch submission; mine 2 more (blocks 5-6) to
+    // ensure the window expires before the pipeline tip.
+    for _ in 0..2 {
+        h.mine_and_push(&chain);
+    }
+
+    verifier.initialize().await.expect("initialize");
+
+    // Signal all L1 blocks to the verifier and drive derivation.
+    let tip = h.l1.latest_number();
+    for i in 1..=tip {
+        let blk = block_info_from(h.l1.block_by_number(i).expect("block exists"));
+        verifier.act_l1_head_signal(blk).await.expect("signal");
+        verifier.act_l2_pipeline_full().await.expect("pipeline");
+    }
+
+    // With singular batches and the Holocene batch validator: the pipeline
+    // derives blocks 1 and 2 from their submitted batches; drops block 3's
+    // batch (NonEmptyTransitionBlock for the first Jovian block containing
+    // user txs); force-generates a deposit-only block 3 once the sequencer
+    // window expires; then derives block 4 from its submitted batch.
+    assert_eq!(
+        verifier.l2_safe().block_info.number,
+        4,
+        "singular batches: safe head must reach 4 (block 3 replaced with deposit-only)"
+    );
+
+    // Verify that block 3 is genuinely deposit-only — not that the pipeline
+    // accepted the invalid batch and derived a normal block. Without this
+    // assertion, removing the NonEmptyTransitionBlock validation would still
+    // produce safe_head == 4.
+    let block3: DerivedBlock = verifier
+        .derived_block(3)
+        .expect("block 3 must have been derived before safe head reached 4");
+    assert!(
+        block3.is_deposit_only(),
+        "block 3 must be deposit-only (NonEmptyTransitionBlock batch dropped); \
+         got {} user txs",
+        block3.user_tx_count,
     );
 }

--- a/actions/harness/tests/batcher_hardfork_transitions.rs
+++ b/actions/harness/tests/batcher_hardfork_transitions.rs
@@ -354,7 +354,10 @@ async fn granite_channel_timeout_enforced() {
     let late_blk = block_info_from(h.l1.block_by_number(late_block_num).expect("late block"));
     verifier.act_l1_head_signal(late_blk).await.expect("signal late block");
     let derived = verifier.act_l2_pipeline_full().await.expect("step late block");
-    assert_eq!(derived, 0, "late non-zero frames after timeout create an incomplete channel; no L2 block derived");
+    assert_eq!(
+        derived, 0,
+        "late non-zero frames after timeout create an incomplete channel; no L2 block derived"
+    );
     assert_eq!(
         verifier.l2_safe().block_info.number,
         0,

--- a/actions/harness/tests/holocene_activation.rs
+++ b/actions/harness/tests/holocene_activation.rs
@@ -322,3 +322,124 @@ async fn holocene_new_channel_abandons_incomplete_old_channel() {
          block B (L2 block 2) is a future batch and cannot be emitted"
     );
 }
+
+// ---------------------------------------------------------------------------
+// D. Holocene frame pruning: non-sequential frame pruned, then recovery
+//
+// op-e2e ref: holocene_frame_test.go (extended)
+// ---------------------------------------------------------------------------
+
+/// Same scenario as [`holocene_non_sequential_frame_pruned_channel_never_completes`]:
+/// a non-sequential frame causes the channel to be pruned and the safe head
+/// stays at genesis.
+///
+/// The **recovery step** creates a brand-new [`Batcher`] (new channel ID) that
+/// re-encodes the same L2 block and submits all frames sequentially in one L1
+/// block. After the verifier processes the new L1 block the safe head must
+/// advance to 1, proving the pipeline recovers once valid data arrives.
+///
+/// [`Batcher`]: base_action_harness::Batcher
+#[tokio::test]
+async fn holocene_non_sequential_frame_pruned_then_recovery_succeeds() {
+    let batcher_cfg = BatcherConfig {
+        encoder: EncoderConfig {
+            max_frame_size: 80,
+            da_type: DaType::Calldata,
+            ..EncoderConfig::default()
+        },
+        ..BatcherConfig::default()
+    };
+    let rollup_cfg = TestRollupConfigBuilder::base_mainnet(&batcher_cfg)
+        .with_hardforks(HardForkConfig {
+            canyon_time: Some(0),
+            delta_time: Some(0),
+            ecotone_time: Some(0),
+            fjord_time: Some(0),
+            granite_time: Some(0),
+            holocene_time: Some(0),
+            ..Default::default()
+        })
+        .with_channel_timeout(10)
+        .build();
+    let mut h = ActionTestHarness::new(L1MinerConfig::default(), rollup_cfg);
+
+    let l1_chain = SharedL1Chain::from_blocks(h.l1.chain().to_vec());
+    let mut sequencer = h.create_l2_sequencer(l1_chain);
+    let block = sequencer.build_next_block().expect("build L2 block 1");
+
+    // Encode the block into frames without mining.
+    let mut source = ActionL2Source::new();
+    source.push(block.clone());
+    let mut batcher = Batcher::new(source, &h.rollup_config, batcher_cfg.clone());
+    batcher.encode_only().await.expect("encode multi-frame channel");
+    let frame_count = batcher.pending_count();
+    assert!(frame_count >= 3, "need ≥3 frames to skip frame 1; got {frame_count}");
+
+    let (mut verifier, chain) = h.create_verifier_from_sequencer(
+        &sequencer,
+        SharedL1Chain::from_blocks(h.l1.chain().to_vec()),
+    );
+
+    // Submit frame 0 and frame 2 in the same L1 block — skipping frame 1.
+    batcher.stage_n_frames(&mut h.l1, 1); // frame 0
+    batcher.drop_n_frames(1); // drop frame 1
+    batcher.stage_n_frames(&mut h.l1, 1); // frame 2 (non-sequential)
+    let block_1_num = h.l1.mine_block().number();
+    batcher.confirm_staged(block_1_num).await;
+    chain.push(h.l1.tip().clone());
+
+    verifier.initialize().await.expect("initialize");
+    let l1_block_1 = block_info_from(h.l1.block_by_number(1).expect("block 1"));
+    verifier.act_l1_head_signal(l1_block_1).await.expect("signal block 1");
+    verifier.act_l2_pipeline_full().await.expect("pipeline block 1");
+
+    // Channel is broken — safe head stays at genesis.
+    assert_eq!(
+        verifier.l2_safe().block_info.number,
+        0,
+        "channel with missing frame 1 must never complete under Holocene"
+    );
+
+    // Mine empty L1 blocks to confirm the broken channel never completes.
+    // Under Holocene, FrameQueue::prune drops frame 2 immediately upon arrival
+    // (non-sequential after frame 0), so the channel is permanently broken
+    // regardless of timeout. We mine fewer than channel_timeout (10) blocks:
+    // recovery does not require the broken channel to expire — it relies on
+    // ChannelAssembler unconditionally replacing its active channel when a new
+    // channel's frame 0 arrives (regardless of timeout state).
+    for _ in 0..5 {
+        h.mine_and_push(&chain);
+    }
+    for i in 2..=h.l1.latest_number() {
+        let blk = block_info_from(h.l1.block_by_number(i).expect("block exists"));
+        verifier.act_l1_head_signal(blk).await.expect("signal");
+        verifier.act_l2_pipeline_full().await.expect("pipeline");
+    }
+    assert_eq!(
+        verifier.l2_safe().block_info.number,
+        0,
+        "safe head must remain at genesis: broken channel was pruned, no recovery submitted yet"
+    );
+
+    // -- Recovery: new Batcher (new channel ID) re-submits all frames in order.
+    // `block` was cloned into `source` above (line 372), so the original value
+    // is still valid here — same L2 block 1 with the same transactions and
+    // timestamp. The sequencer has not advanced since build_next_block().
+    let mut recovery_source = ActionL2Source::new();
+    recovery_source.push(block);
+    let mut batcher2 = Batcher::new(recovery_source, &h.rollup_config, batcher_cfg.clone());
+    batcher2.advance(&mut h.l1).await.expect("recovery batch");
+    chain.push(h.l1.tip().clone());
+
+    let recovery_block_num = h.l1.latest_number();
+    let recovery_blk =
+        block_info_from(h.l1.block_by_number(recovery_block_num).expect("recovery block"));
+    verifier.act_l1_head_signal(recovery_blk).await.expect("signal recovery block");
+    verifier.act_l2_pipeline_full().await.expect("pipeline recovery block");
+
+    assert_eq!(
+        verifier.l2_safe().block_info.number,
+        1,
+        "safe head must advance to 1 after clean recovery submission"
+    );
+}


### PR DESCRIPTION
## Summary

Adds reorg simulation support to the batcher test harness via a new `Batcher::reorg()` method and `L1MinerTxManager::reorg_to()`, which truncates the L1 chain, fires failure receipts for all pending and staged items, and signals the driver with the new head. A new `DerivedBlock` type (with `is_deposit_only()`) and `L2Verifier::derived_block()` accessor allow tests to inspect whether derivation force-generated a deposit-only block rather than silently accepting an invalid batch.

Five new action tests are added: L1 reorg with verifier re-derivation on the new fork, multi-frame channel reassembly across an empty L1 gap, Granite channel timeout enforcement with late-frame handling, Jovian deposit-only transition block validation (using `DerivedBlock` to confirm the batch was actually dropped), and Holocene non-sequential frame pruning with recovery.

Also fixes `act_reset` not clearing `derived_tx_counts`, which left stale pre-reorg block data visible after a pipeline reset, and adds `Debug`, `Clone`, and `Copy` derives to `DerivedBlock`.