### PR TITLE
feat(CHAIN-3560): Attestation prover crate with DirectProver and BoundlessProver backends

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4582,7 +4582,6 @@ version = "0.0.0"
 dependencies = [
  "alloy-primitives",
  "alloy-signer-local",
- "alloy-sol-types",
  "async-trait",
  "base-proof-tee-nitro-verifier",
  "boundless-market",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,12 +3,39 @@
 version = 4
 
 [[package]]
+name = "addchain"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e33f6a175ec6a9e0aca777567f9ff7c3deefc255660df887e7fa3585e9801d8"
+dependencies = [
+ "num-bigint 0.3.3",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "addr2line"
+version = "0.24.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dfbe277e56a376000877090da837660b4427aad530e3028d44e0bffe4f89a1c1"
+dependencies = [
+ "cpp_demangle",
+ "fallible-iterator",
+ "gimli 0.31.1",
+ "memmap2",
+ "object 0.36.7",
+ "rustc-demangle",
+ "smallvec",
+ "typed-arena",
+]
+
+[[package]]
 name = "addr2line"
 version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b5d307320b3181d6d7954e663bd7c774a838b8220fe0593c86d9fb09f498b4b"
 dependencies = [
- "gimli",
+ "gimli 0.32.3",
 ]
 
 [[package]]
@@ -114,6 +141,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
+name = "alloy"
+version = "1.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4973038846323e4e69a433916522195dce2947770076c03078fc21c80ea0f1c4"
+dependencies = [
+ "alloy-consensus",
+ "alloy-contract",
+ "alloy-core",
+ "alloy-eips",
+ "alloy-network",
+ "alloy-node-bindings",
+ "alloy-provider",
+ "alloy-rpc-client",
+ "alloy-rpc-types",
+ "alloy-serde",
+ "alloy-signer",
+ "alloy-signer-local",
+ "alloy-transport",
+ "alloy-transport-http",
+ "alloy-trie",
+]
+
+[[package]]
 name = "alloy-chains"
 version = "0.2.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -191,6 +241,19 @@ dependencies = [
  "futures-util",
  "serde_json",
  "thiserror 2.0.18",
+]
+
+[[package]]
+name = "alloy-core"
+version = "1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23e8604b0c092fabc80d075ede181c9b9e596249c70b99253082d7e689836529"
+dependencies = [
+ "alloy-dyn-abi",
+ "alloy-json-abi",
+ "alloy-primitives",
+ "alloy-rlp",
+ "alloy-sol-types",
 ]
 
 [[package]]
@@ -490,9 +553,11 @@ dependencies = [
  "alloy-json-rpc",
  "alloy-network",
  "alloy-network-primitives",
+ "alloy-node-bindings",
  "alloy-primitives",
  "alloy-pubsub",
  "alloy-rpc-client",
+ "alloy-rpc-types-anvil",
  "alloy-rpc-types-debug",
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
@@ -1177,6 +1242,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "ark-crypto-primitives"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e0c292754729c8a190e50414fd1a37093c786c709899f29c9f7daccecfa855e"
+dependencies = [
+ "ahash",
+ "ark-crypto-primitives-macros",
+ "ark-ec",
+ "ark-ff 0.5.0",
+ "ark-relations",
+ "ark-serialize 0.5.0",
+ "ark-snark",
+ "ark-std 0.5.0",
+ "blake2",
+ "derivative",
+ "digest 0.10.7",
+ "fnv",
+ "merlin",
+ "sha2 0.10.9",
+]
+
+[[package]]
+name = "ark-crypto-primitives-macros"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7e89fe77d1f0f4fe5b96dfc940923d88d17b6a773808124f21e764dfb063c6a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "ark-ec"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1191,7 +1289,7 @@ dependencies = [
  "fnv",
  "hashbrown 0.15.5",
  "itertools 0.13.0",
- "num-bigint",
+ "num-bigint 0.4.6",
  "num-integer",
  "num-traits",
  "zeroize",
@@ -1208,7 +1306,7 @@ dependencies = [
  "ark-serialize 0.3.0",
  "ark-std 0.3.0",
  "derivative",
- "num-bigint",
+ "num-bigint 0.4.6",
  "num-traits",
  "paste",
  "rustc_version 0.3.3",
@@ -1228,7 +1326,7 @@ dependencies = [
  "derivative",
  "digest 0.10.7",
  "itertools 0.10.5",
- "num-bigint",
+ "num-bigint 0.4.6",
  "num-traits",
  "paste",
  "rustc_version 0.4.1",
@@ -1249,7 +1347,7 @@ dependencies = [
  "digest 0.10.7",
  "educe",
  "itertools 0.13.0",
- "num-bigint",
+ "num-bigint 0.4.6",
  "num-traits",
  "paste",
  "zeroize",
@@ -1291,7 +1389,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db2fd794a08ccb318058009eefdf15bcaaaaf6f8161eb3345f907222bac38b20"
 dependencies = [
- "num-bigint",
+ "num-bigint 0.4.6",
  "num-traits",
  "quote",
  "syn 1.0.109",
@@ -1303,7 +1401,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7abe79b0e4288889c4574159ab790824d0033b9fdcb2a112a3182fac2e514565"
 dependencies = [
- "num-bigint",
+ "num-bigint 0.4.6",
  "num-traits",
  "proc-macro2",
  "quote",
@@ -1316,11 +1414,26 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09be120733ee33f7693ceaa202ca41accd5653b779563608f1234f78ae07c4b3"
 dependencies = [
- "num-bigint",
+ "num-bigint 0.4.6",
  "num-traits",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "ark-groth16"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88f1d0f3a534bb54188b8dcc104307db6c56cdae574ddc3212aec0625740fc7e"
+dependencies = [
+ "ark-crypto-primitives",
+ "ark-ec",
+ "ark-ff 0.5.0",
+ "ark-poly",
+ "ark-relations",
+ "ark-serialize 0.5.0",
+ "ark-std 0.5.0",
 ]
 
 [[package]]
@@ -1349,7 +1462,7 @@ dependencies = [
  "ark-relations",
  "ark-std 0.5.0",
  "educe",
- "num-bigint",
+ "num-bigint 0.4.6",
  "num-integer",
  "num-traits",
  "tracing",
@@ -1385,7 +1498,7 @@ checksum = "adb7b85a02b83d2f22f89bd5cac66c9c89474240cb6207cb1efc16d098e822a5"
 dependencies = [
  "ark-std 0.4.0",
  "digest 0.10.7",
- "num-bigint",
+ "num-bigint 0.4.6",
 ]
 
 [[package]]
@@ -1398,7 +1511,7 @@ dependencies = [
  "ark-std 0.5.0",
  "arrayvec",
  "digest 0.10.7",
- "num-bigint",
+ "num-bigint 0.4.6",
 ]
 
 [[package]]
@@ -1410,6 +1523,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "ark-snark"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d368e2848c2d4c129ce7679a7d0d2d612b6a274d3ea6a13bad4445d61b381b88"
+dependencies = [
+ "ark-ff 0.5.0",
+ "ark-relations",
+ "ark-serialize 0.5.0",
+ "ark-std 0.5.0",
 ]
 
 [[package]]
@@ -1441,6 +1566,12 @@ dependencies = [
  "num-traits",
  "rand 0.8.5",
 ]
+
+[[package]]
+name = "arraydeque"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d902e3d592a523def97af8f317b08ce16b7ab854c1985a0c671e6f15cebc236"
 
 [[package]]
 name = "arrayref"
@@ -1664,6 +1795,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89cbf775b137e9b968e67227ef7f775587cde3fd31b0d8599dbd0f598a48340"
 dependencies = [
  "bytemuck",
+]
+
+[[package]]
+name = "atomic-polyfill"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cf2bce30dfe09ef0bfaef228b9d414faaf7e563035494d7fe092dba54b300f4"
+dependencies = [
+ "critical-section",
 ]
 
 [[package]]
@@ -2325,11 +2465,11 @@ version = "0.3.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb531853791a215d7c62a30daf0dde835f381ab5de4589cfe7c649d2cbe92bd6"
 dependencies = [
- "addr2line",
+ "addr2line 0.25.1",
  "cfg-if",
  "libc",
  "miniz_oxide 0.8.9",
- "object",
+ "object 0.37.3",
  "rustc-demangle",
  "windows-link",
 ]
@@ -4433,7 +4573,25 @@ dependencies = [
  "tower",
  "tracing",
  "x509-cert",
- "zip",
+ "zip 8.2.0",
+]
+
+[[package]]
+name = "base-proof-tee-nitro-attestation-prover"
+version = "0.0.0"
+dependencies = [
+ "alloy-primitives",
+ "alloy-signer-local",
+ "alloy-sol-types",
+ "async-trait",
+ "base-proof-tee-nitro-verifier",
+ "boundless-market",
+ "risc0-ethereum-contracts 3.0.1 (git+https://github.com/risc0/risc0-ethereum?tag=v3.0.1)",
+ "risc0-zkvm",
+ "rstest",
+ "thiserror 2.0.18",
+ "tracing",
+ "url",
 ]
 
 [[package]]
@@ -4848,7 +5006,7 @@ name = "base-zk-client"
 version = "0.0.0"
 dependencies = [
  "async-trait",
- "prost",
+ "prost 0.14.3",
  "rstest",
  "thiserror 2.0.18",
  "tokio",
@@ -5184,6 +5342,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "block"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d8c1fef690941d3e7788d328517591fecc684c084084702d6ff1641e993699a"
+
+[[package]]
 name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5243,7 +5407,7 @@ dependencies = [
  "boa_macros",
  "boa_string",
  "indexmap 2.13.0",
- "num-bigint",
+ "num-bigint 0.4.6",
  "rustc-hash",
 ]
 
@@ -5277,7 +5441,7 @@ dependencies = [
  "indexmap 2.13.0",
  "intrusive-collections",
  "itertools 0.14.0",
- "num-bigint",
+ "num-bigint 0.4.6",
  "num-integer",
  "num-traits",
  "num_enum",
@@ -5353,7 +5517,7 @@ dependencies = [
  "boa_macros",
  "fast-float2",
  "icu_properties",
- "num-bigint",
+ "num-bigint 0.4.6",
  "num-traits",
  "regress",
  "rustc-hash",
@@ -5424,7 +5588,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85a885520bf6249ab931a764ffdb87b0ceef48e6e7d807cfdb21b751e086e1ad"
 dependencies = [
- "prost",
+ "prost 0.14.3",
  "prost-types",
  "tonic",
  "tonic-prost",
@@ -5440,7 +5604,7 @@ dependencies = [
  "base64 0.22.1",
  "bollard-buildkit-proto",
  "bytes",
- "prost",
+ "prost 0.14.3",
  "serde",
  "serde_json",
  "serde_repr",
@@ -5468,6 +5632,59 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "boundless-market"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f56a871828b537886d3425879a6f6d5f83033a55a2f75cbd7c7c3298efd13eb"
+dependencies = [
+ "alloy",
+ "alloy-chains",
+ "alloy-primitives",
+ "alloy-sol-types",
+ "anyhow",
+ "async-stream",
+ "async-trait",
+ "auto_impl",
+ "aws-config",
+ "aws-sdk-s3",
+ "borsh",
+ "bytemuck",
+ "bytes",
+ "chrono",
+ "clap",
+ "dashmap",
+ "derive_builder",
+ "futures",
+ "futures-util",
+ "hex",
+ "moka",
+ "rand 0.9.2",
+ "reqwest 0.13.2",
+ "reqwest-middleware",
+ "reqwest-retry",
+ "risc0-aggregation",
+ "risc0-binfmt",
+ "risc0-ethereum-contracts 3.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "risc0-zkvm",
+ "rmp-serde",
+ "serde",
+ "serde_json",
+ "sha2 0.10.9",
+ "siwe",
+ "tempfile",
+ "thiserror 2.0.18",
+ "time",
+ "tokio",
+ "tokio-tungstenite 0.24.0",
+ "toml 0.8.23",
+ "tower",
+ "tracing",
+ "url",
+ "utoipa",
+ "uuid",
 ]
 
 [[package]]
@@ -5639,6 +5856,15 @@ dependencies = [
 
 [[package]]
 name = "cargo-platform"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e35af189006b9c0f00a064685c727031e3ed2d8020f7ba284d78cc2671bd36ea"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "cargo-platform"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "87a0c0e6148f11f01f32650a2ea02d532b2ad4e81d8bd41e6e565b5adc5e6082"
@@ -5649,12 +5875,26 @@ dependencies = [
 
 [[package]]
 name = "cargo_metadata"
+version = "0.19.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd5eb614ed4c27c5d706420e4320fbe3216ab31fa1c33cd8246ac36dae4479ba"
+dependencies = [
+ "camino",
+ "cargo-platform 0.1.9",
+ "semver 1.0.27",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "cargo_metadata"
 version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef987d17b0a113becdd19d3d0022d04d7ef41f9efe4f3fb63ac44ba61df3ade9"
 dependencies = [
  "camino",
- "cargo-platform",
+ "cargo-platform 0.3.2",
  "semver 1.0.27",
  "serde",
  "serde_json",
@@ -5874,6 +6114,15 @@ name = "cmov"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de0758edba32d61d1fd9f4d69491b47604b91ee2f7e6b33de7e54ca4ebe55dc3"
+
+[[package]]
+name = "cobs"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fa961b519f0b462e3a3b4a34b64d119eeaca1d59af726fe450bbba07a9fc0a1"
+dependencies = [
+ "thiserror 2.0.18",
+]
 
 [[package]]
 name = "coins-bip32"
@@ -6103,13 +6352,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "core-graphics-types"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45390e6114f68f718cc7a830514a96f903cccd70d02a8f6d9f643ac4ba45afaf"
+dependencies = [
+ "bitflags 1.3.2",
+ "core-foundation 0.9.4",
+ "libc",
+]
+
+[[package]]
 name = "core-models"
 version = "0.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0940496e5c83c54f3b753d5317daec82e8edac71c33aaa1f666d76f518de2444"
 dependencies = [
  "hax-lib",
- "pastey",
+ "pastey 0.1.1",
  "rand 0.9.2",
 ]
 
@@ -6127,6 +6387,15 @@ name = "cow-utils"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "417bef24afe1460300965a25ff4a24b8b45ad011948302ec221e8a0a81eb2c79"
+
+[[package]]
+name = "cpp_demangle"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2bb79cb74d735044c972aae58ed0aaa9a837e85b01106a54c39e42e97f62253"
+dependencies = [
+ "cfg-if",
+]
 
 [[package]]
 name = "cpubits"
@@ -6570,7 +6839,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ab67060fc6b8ef687992d439ca0fa36e7ed17e9a0b16b25b601e8757df720de"
 dependencies = [
  "data-encoding",
- "syn 1.0.109",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -6658,7 +6927,7 @@ dependencies = [
  "asn1-rs",
  "displaydoc",
  "nom",
- "num-bigint",
+ "num-bigint 0.4.6",
  "num-traits",
  "rusticata-macros",
 ]
@@ -6869,6 +7138,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "directories"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16f5094c54661b38d03bd7e50df373292118db60b585c08a411c6d840017fe7d"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
 name = "dirs"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6965,6 +7243,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "docker-generate"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccf673e0848ef09fa4aeeba78e681cf651c0c7d35f76ee38cec8e55bc32fa111"
+
+[[package]]
 name = "docker_credential"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7001,6 +7285,26 @@ name = "downcast"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1435fa1053d8b2fbbe9be7e97eca7f33d37b28409959813daefc1446a14247f1"
+
+[[package]]
+name = "downcast-rs"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
+
+[[package]]
+name = "downloader"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ac1e888d6830712d565b2f3a974be3200be9296bc1b03db8251a4cbf18a4a34"
+dependencies = [
+ "digest 0.10.7",
+ "futures",
+ "rand 0.8.5",
+ "reqwest 0.12.28",
+ "thiserror 1.0.69",
+ "tokio",
+]
 
 [[package]]
 name = "dtoa"
@@ -7117,6 +7421,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "elf"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4445909572dbd556c457c849c4ca58623d84b27c8fff1e74b0b4227d8b90d17b"
+
+[[package]]
 name = "elliptic-curve"
 version = "0.13.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7137,6 +7447,18 @@ dependencies = [
  "subtle",
  "zeroize",
 ]
+
+[[package]]
+name = "embedded-io"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef1a6892d9eef45c8fa6b9e0086428a2cca8491aca8f787c534a3d6d0bcb3ced"
+
+[[package]]
+name = "embedded-io"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
 
 [[package]]
 name = "encode_unicode"
@@ -7180,6 +7502,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1e6a265c649f3f5979b601d26f1d05ada116434c87741c9493cb56218f76cbc"
 dependencies = [
  "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "enum-map"
+version = "2.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6866f3bfdf8207509a033af1a75a7b08abda06bbaaeae6669323fd5a097df2e9"
+dependencies = [
+ "enum-map-derive",
+]
+
+[[package]]
+name = "enum-map-derive"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f282cfdfe92516eb26c2af8589c274c7c17681f5ecc03c18255fe741c6aa64eb"
+dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -7242,6 +7584,17 @@ name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "erased-serde"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2add8a07dd6a8d93ff627029c51de145e12686fbc36ecb298ac22e74cf02dec"
+dependencies = [
+ "serde",
+ "serde_core",
+ "typeid",
+]
 
 [[package]]
 name = "errno"
@@ -7399,6 +7752,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fallible-iterator"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
+
+[[package]]
 name = "fancy-regex"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7498,8 +7857,26 @@ version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
 dependencies = [
+ "bitvec",
+ "byteorder",
+ "ff_derive",
  "rand_core 0.6.4",
  "subtle",
+]
+
+[[package]]
+name = "ff_derive"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f10d12652036b0e99197587c6ba87a8fc3031986499973c030d8b44fcc151b60"
+dependencies = [
+ "addchain",
+ "num-bigint 0.3.3",
+ "num-integer",
+ "num-traits",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -7660,7 +8037,28 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
 dependencies = [
- "foreign-types-shared",
+ "foreign-types-shared 0.1.1",
+]
+
+[[package]]
+name = "foreign-types"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d737d9aa519fb7b749cbc3b962edcf310a8dd1f4b67c91c4f83975dbdd17d965"
+dependencies = [
+ "foreign-types-macros",
+ "foreign-types-shared 0.3.1",
+]
+
+[[package]]
+name = "foreign-types-macros"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a5c6c585bc94aaf2c7b51dd4c2ba22680844aba4c687be581871a6f518c5742"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -7668,6 +8066,12 @@ name = "foreign-types-shared"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa9a19cbb55df58761df49b23516a86d432839add4af60fc256da840f66ed35b"
 
 [[package]]
 name = "form_urlencoded"
@@ -7868,6 +8272,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42012b0f064e01aa58b545fe3727f90f7dd4020f4a3ea735b50344965f5a57e9"
 
 [[package]]
+name = "gdbstub"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5bafc7e33650ab9f05dcc16325f05d56b8d10393114e31a19a353b86fa60cfe7"
+dependencies = [
+ "bitflags 2.11.0",
+ "cfg-if",
+ "log",
+ "managed",
+ "num-traits",
+ "pastey 0.2.1",
+]
+
+[[package]]
+name = "gdbstub_arch"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c02bfe7bd65f42bcda751456869dfa1eb2bd1c36e309b9ec27f4888d41cf258"
+dependencies = [
+ "gdbstub",
+ "num-traits",
+]
+
+[[package]]
 name = "generator"
 version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7964,6 +8392,17 @@ checksum = "f0d8a4362ccb29cb0b265253fb0a2728f592895ee6854fd9bc13f2ffda266ff1"
 dependencies = [
  "opaque-debug",
  "polyval",
+]
+
+[[package]]
+name = "gimli"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
+dependencies = [
+ "fallible-iterator",
+ "indexmap 2.13.0",
+ "stable_deref_trait",
 ]
 
 [[package]]
@@ -8143,6 +8582,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d23bd4e7b5eda0d0f3a307e8b381fdc8ba9000f26fbe912250c0a4cc3956364a"
 
 [[package]]
+name = "hash32"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0c35f58762feb77d74ebe43bdbc3210f09be9fe6742234d573bacc26ed92b67"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8212,7 +8660,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74d9ba66d1739c68e0219b2b2238b5c4145f491ebf181b9c6ab561a19352ae86"
 dependencies = [
  "hax-lib-macros",
- "num-bigint",
+ "num-bigint 0.4.6",
  "num-traits",
 ]
 
@@ -8274,6 +8722,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "54b4a22553d4242c49fddb9ba998a99962b5cc6f22cb5a3482bec22522403ce4"
 dependencies = [
  "http 1.4.0",
+]
+
+[[package]]
+name = "heapless"
+version = "0.7.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdc6457c0eb62c71aac4bc17216026d8410337c4126773b9c5daba343f17964f"
+dependencies = [
+ "atomic-polyfill",
+ "hash32",
+ "rustc_version 0.4.1",
+ "serde",
+ "spin 0.9.8",
+ "stable_deref_trait",
 ]
 
 [[package]]
@@ -8957,6 +9419,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "include_bytes_aligned"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ee796ad498c8d9a1d68e477df8f754ed784ef875de1414ebdaf169f70a6a784"
+
+[[package]]
 name = "include_dir"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9175,6 +9643,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "inventory"
+version = "0.3.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "009ae045c87e7082cb72dab0ccd01ae075dd00141ddc108f43a0ea150a9e7227"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "ipconfig"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9216,6 +9693,15 @@ name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
 dependencies = [
  "either",
 ]
@@ -9562,6 +10048,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf36173d4167ed999940f804952e6b08197cae5ad5d572eb4db150ce8ad5d58f"
 
 [[package]]
+name = "lazy-regex"
+version = "3.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bae91019476d3ec7147de9aa291cadb6d870abf2f3015d2da73a90325ac1496"
+dependencies = [
+ "lazy-regex-proc_macros",
+ "once_cell",
+ "regex",
+]
+
+[[package]]
+name = "lazy-regex-proc_macros"
+version = "3.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4de9c1e1439d8b7b3061b2d209809f447ca33241733d9a3c01eabf2dc8d94358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "regex",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9668,6 +10177,26 @@ checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
 dependencies = [
  "cfg-if",
  "windows-link",
+]
+
+[[package]]
+name = "liblzma"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6033b77c21d1f56deeae8014eb9fbe7bdf1765185a6c508b5ca82eeaed7f899"
+dependencies = [
+ "liblzma-sys",
+]
+
+[[package]]
+name = "liblzma-sys"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f2db66f3268487b5033077f266da6777d057949b8f93c8ad82e441df25e6186"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
 ]
 
 [[package]]
@@ -10272,6 +10801,79 @@ dependencies = [
 ]
 
 [[package]]
+name = "malachite"
+version = "0.4.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fbdf9cb251732db30a7200ebb6ae5d22fe8e11397364416617d2c2cf0c51cb5"
+dependencies = [
+ "malachite-base",
+ "malachite-float",
+ "malachite-nz",
+ "malachite-q",
+]
+
+[[package]]
+name = "malachite-base"
+version = "0.4.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ea0ed76adf7defc1a92240b5c36d5368cfe9251640dcce5bd2d0b7c1fd87aeb"
+dependencies = [
+ "hashbrown 0.14.5",
+ "itertools 0.11.0",
+ "libm",
+ "ryu",
+]
+
+[[package]]
+name = "malachite-float"
+version = "0.4.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af9d20db1c73759c1377db7b27575df6f2eab7368809dd62c0a715dc1bcc39f7"
+dependencies = [
+ "itertools 0.11.0",
+ "malachite-base",
+ "malachite-nz",
+ "malachite-q",
+]
+
+[[package]]
+name = "malachite-nz"
+version = "0.4.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34a79feebb2bc9aa7762047c8e5495269a367da6b5a90a99882a0aeeac1841f7"
+dependencies = [
+ "itertools 0.11.0",
+ "libm",
+ "malachite-base",
+]
+
+[[package]]
+name = "malachite-q"
+version = "0.4.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50f235d5747b1256b47620f5640c2a17a88c7569eebdf27cd9cb130e1a619191"
+dependencies = [
+ "itertools 0.11.0",
+ "malachite-base",
+ "malachite-nz",
+]
+
+[[package]]
+name = "malloc_buf"
+version = "0.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62bb907fe88d54d8d9ce32a3cceab4218ed2f6b7d35617cafe9adf84e43919cb"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "managed"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ca88d725a0a943b096803bd34e73a4437208b6077654cc4ecb2947a5f91618d"
+
+[[package]]
 name = "mappings"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10309,6 +10911,16 @@ name = "matchit"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
+
+[[package]]
+name = "matrixmultiply"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a06de3016e9fae57a36fd14dba131fccf49f74b40b7fbdb472f96e361ec71a08"
+dependencies = [
+ "autocfg",
+ "rawpointer",
+]
 
 [[package]]
 name = "md-5"
@@ -10393,6 +11005,33 @@ dependencies = [
  "serde",
  "tokio",
  "tracing",
+]
+
+[[package]]
+name = "merlin"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58c38e2799fc0978b65dfff8023ec7843e2330bb462f19198840b34b6582397d"
+dependencies = [
+ "byteorder",
+ "keccak",
+ "rand_core 0.6.4",
+ "zeroize",
+]
+
+[[package]]
+name = "metal"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ecfd3296f8c56b7c1f6fbac3c71cefa9d78ce009850c45000015f206dc7fa21"
+dependencies = [
+ "bitflags 2.11.0",
+ "block",
+ "core-graphics-types",
+ "foreign-types 0.5.0",
+ "log",
+ "objc",
+ "paste",
 ]
 
 [[package]]
@@ -10693,6 +11332,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "ndarray"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "882ed72dce9365842bf196bdeedf5055305f11fc8c03dee7bb0194a6cad34841"
+dependencies = [
+ "matrixmultiply",
+ "num-complex",
+ "num-integer",
+ "num-traits",
+ "portable-atomic",
+ "portable-atomic-util",
+ "rawpointer",
+ "rayon",
+]
+
+[[package]]
 name = "netlink-packet-core"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10798,6 +11453,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b93853da6d84c2e3c7d730d6473e8817692dd89be387eb01b94d7f108ecb5b8c"
 
 [[package]]
+name = "no_std_strings"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5b0c77c1b780822bc749a33e39aeb2c07584ab93332303babeabb645298a76e"
+
+[[package]]
 name = "nohash-hasher"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10870,11 +11531,22 @@ version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
 dependencies = [
- "num-bigint",
+ "num-bigint 0.4.6",
  "num-complex",
  "num-integer",
  "num-iter",
  "num-rational",
+ "num-traits",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f6f7833f2cbf2360a6cfd58cd41a53aa7a90bd4c202f5b1c7dd2ed73c57b2c3"
+dependencies = [
+ "autocfg",
+ "num-integer",
  "num-traits",
 ]
 
@@ -10958,7 +11630,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
 dependencies = [
- "num-bigint",
+ "num-bigint 0.4.6",
  "num-integer",
  "num-traits",
 ]
@@ -11015,6 +11687,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "nvtx"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad2e855e8019f99e4b94ac33670eb4e4f570a2e044f3749a0b2c7f83b841e52c"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "nybbles"
 version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11027,6 +11708,15 @@ dependencies = [
  "ruint",
  "serde",
  "smallvec",
+]
+
+[[package]]
+name = "objc"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "915b1b472bc21c53464d6c8461c9d3af805ba1ef837e1cac254428f4a77177b1"
+dependencies = [
+ "malloc_buf",
 ]
 
 [[package]]
@@ -11110,6 +11800,17 @@ dependencies = [
  "bitflags 2.11.0",
  "objc2",
  "objc2-core-foundation",
+]
+
+[[package]]
+name = "object"
+version = "0.36.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87"
+dependencies = [
+ "flate2",
+ "memchr",
+ "ruzstd",
 ]
 
 [[package]]
@@ -11282,7 +11983,7 @@ checksum = "951c002c75e16ea2c65b8c7e4d3d51d5530d8dfa7d060b4776828c88cfb18ecf"
 dependencies = [
  "bitflags 2.11.0",
  "cfg-if",
- "foreign-types",
+ "foreign-types 0.3.2",
  "libc",
  "once_cell",
  "openssl-macros",
@@ -11378,7 +12079,7 @@ dependencies = [
  "opentelemetry-http",
  "opentelemetry-proto",
  "opentelemetry_sdk",
- "prost",
+ "prost 0.14.3",
  "reqwest 0.12.28",
  "thiserror 2.0.18",
  "tokio",
@@ -11394,7 +12095,7 @@ checksum = "a7175df06de5eaee9909d4805a3d07e28bb752c34cab57fa9cff549da596b30f"
 dependencies = [
  "opentelemetry",
  "opentelemetry_sdk",
- "prost",
+ "prost 0.14.3",
  "tonic",
  "tonic-prost",
 ]
@@ -11614,6 +12315,12 @@ name = "pastey"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "35fb2e5f958ec131621fdd531e9fc186ed768cbe395337403ae56c17a74c68ec"
+
+[[package]]
+name = "pastey"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b867cad97c0791bbd3aaa6472142568c6c9e8f71937e98379f584cfb0cf35bec"
 
 [[package]]
 name = "path-tree"
@@ -12023,6 +12730,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
+name = "portable-atomic-util"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "091397be61a01d4be58e7841595bd4bfedb15f1cd54977d79b8271e94ed799a3"
+dependencies = [
+ "portable-atomic",
+]
+
+[[package]]
+name = "postcard"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6764c3b5dd454e283a30e6dfe78e9b31096d9e32036b5d1eaac7a6119ccb9a24"
+dependencies = [
+ "cobs",
+ "embedded-io 0.4.0",
+ "embedded-io 0.6.1",
+ "heapless",
+ "serde",
+]
+
+[[package]]
 name = "potential_utf"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12048,7 +12777,7 @@ dependencies = [
  "flate2",
  "num",
  "paste",
- "prost",
+ "prost 0.14.3",
 ]
 
 [[package]]
@@ -12132,7 +12861,7 @@ version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
 dependencies = [
- "toml_edit",
+ "toml_edit 0.25.4+spec-1.1.0",
 ]
 
 [[package]]
@@ -12255,12 +12984,22 @@ dependencies = [
 
 [[package]]
 name = "prost"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2796faa41db3ec313a31f7624d9286acf277b52de526150b7e69f3debf891ee5"
+dependencies = [
+ "bytes",
+ "prost-derive 0.13.5",
+]
+
+[[package]]
+name = "prost"
 version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2ea70524a2f82d518bce41317d0fae74151505651af45faf1ffbd6fd33f0568"
 dependencies = [
  "bytes",
- "prost-derive",
+ "prost-derive 0.14.3",
 ]
 
 [[package]]
@@ -12275,13 +13014,26 @@ dependencies = [
  "multimap",
  "petgraph",
  "prettyplease",
- "prost",
+ "prost 0.14.3",
  "prost-types",
  "pulldown-cmark",
  "pulldown-cmark-to-cmark",
  "regex",
  "syn 2.0.117",
  "tempfile",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
+dependencies = [
+ "anyhow",
+ "itertools 0.14.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -12303,7 +13055,21 @@ version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8991c4cbdb8bc5b11f0b074ffe286c30e523de90fee5ba8132f1399f23cb3dd7"
 dependencies = [
- "prost",
+ "prost 0.14.3",
+]
+
+[[package]]
+name = "puffin"
+version = "0.19.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa9dae7b05c02ec1a6bc9bcf20d8bc64a7dcbf57934107902a872014899b741f"
+dependencies = [
+ "anyhow",
+ "byteorder",
+ "cfg-if",
+ "itertools 0.10.5",
+ "once_cell",
+ "parking_lot",
 ]
 
 [[package]]
@@ -12656,6 +13422,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rawpointer"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
+
+[[package]]
 name = "rayon"
 version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12878,7 +13650,7 @@ dependencies = [
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
- "wasm-streams",
+ "wasm-streams 0.4.2",
  "web-sys",
  "webpki-roots 1.0.6",
 ]
@@ -12893,6 +13665,7 @@ dependencies = [
  "bytes",
  "encoding_rs",
  "futures-core",
+ "futures-util",
  "h2 0.4.13",
  "http 1.4.0",
  "http-body 1.0.1",
@@ -12903,6 +13676,7 @@ dependencies = [
  "js-sys",
  "log",
  "mime",
+ "mime_guess",
  "percent-encoding",
  "pin-project-lite",
  "quinn",
@@ -12914,13 +13688,50 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tokio-rustls 0.26.4",
+ "tokio-util",
  "tower",
  "tower-http",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "wasm-streams 0.5.0",
  "web-sys",
+]
+
+[[package]]
+name = "reqwest-middleware"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "199dda04a536b532d0cc04d7979e39b1c763ea749bf91507017069c00b96056f"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "http 1.4.0",
+ "reqwest 0.13.2",
+ "thiserror 2.0.18",
+ "tower-service",
+]
+
+[[package]]
+name = "reqwest-retry"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe2412db2af7d2268e7a5406be0431f37d9eb67ff390f35b395716f5f06c2eaa"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "futures",
+ "getrandom 0.2.17",
+ "http 1.4.0",
+ "hyper 1.8.1",
+ "reqwest 0.13.2",
+ "reqwest-middleware",
+ "retry-policies",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "wasmtimer",
 ]
 
 [[package]]
@@ -13224,7 +14035,7 @@ dependencies = [
  "reth-node-api",
  "reth-primitives-traits",
  "reth-tracing",
- "ringbuffer",
+ "ringbuffer 0.16.0",
  "serde",
  "serde_json",
  "tokio",
@@ -15580,6 +16391,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "retry-policies"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46a4bd6027df676bcb752d3724db0ea3c0c5fc1dd0376fec51ac7dcaf9cc69be"
+dependencies = [
+ "rand 0.9.2",
+]
+
+[[package]]
 name = "revm"
 version = "34.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -15817,6 +16637,12 @@ dependencies = [
 
 [[package]]
 name = "ringbuffer"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3df6368f71f205ff9c33c076d170dd56ebf68e8161c733c0caa07a7a5509ed53"
+
+[[package]]
+name = "ringbuffer"
 version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57b0b88a509053cbfd535726dcaaceee631313cef981266119527a1d110f6d2b"
@@ -15828,6 +16654,393 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd124222d17ad93a644ed9d011a40f4fb64aa54275c08cc216524a9ea82fb09f"
 dependencies = [
  "digest 0.10.7",
+]
+
+[[package]]
+name = "risc0-aggregation"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b37f9050c74d66eb953591e88a60f2d347e99b121e7330eabb0f29c4053d2a36"
+dependencies = [
+ "alloy-primitives",
+ "alloy-sol-types",
+ "bytemuck",
+ "hex",
+ "risc0-binfmt",
+ "risc0-zkp",
+ "risc0-zkvm",
+ "serde",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "risc0-binfmt"
+version = "3.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1883f0c5d19b865f395209a137dcb29e56dc49951424967b8d0114c129f46e77"
+dependencies = [
+ "anyhow",
+ "borsh",
+ "bytemuck",
+ "derive_more",
+ "elf",
+ "lazy_static",
+ "postcard",
+ "rand 0.9.2",
+ "risc0-zkp",
+ "risc0-zkvm-platform",
+ "ruint",
+ "semver 1.0.27",
+ "serde",
+ "tracing",
+]
+
+[[package]]
+name = "risc0-build"
+version = "3.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f89937fa1c424b188cc4cabf65335736eca9c1e3df79c127f48636f55682f3a4"
+dependencies = [
+ "anyhow",
+ "cargo_metadata 0.19.2",
+ "derive_builder",
+ "dirs",
+ "docker-generate",
+ "hex",
+ "risc0-binfmt",
+ "risc0-zkos-v1compat",
+ "risc0-zkp",
+ "risc0-zkvm-platform",
+ "rzup",
+ "semver 1.0.27",
+ "serde",
+ "serde_json",
+ "stability",
+ "tempfile",
+]
+
+[[package]]
+name = "risc0-build-kernel"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaaa3e04c71e4244354dd9e3f8b89378cfecfbb03f9c72de4e2e7e0482b30c9a"
+dependencies = [
+ "cc",
+ "directories",
+ "hex",
+ "rayon",
+ "sha2 0.10.9",
+ "tempfile",
+]
+
+[[package]]
+name = "risc0-circuit-keccak"
+version = "4.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f543c60287fece797a5da4209384ab1bfebd9644fcfe591e11b1aa85f1a02f8"
+dependencies = [
+ "anyhow",
+ "bytemuck",
+ "cfg-if",
+ "keccak",
+ "liblzma",
+ "paste",
+ "rayon",
+ "risc0-binfmt",
+ "risc0-circuit-keccak-sys",
+ "risc0-circuit-recursion",
+ "risc0-core",
+ "risc0-sys",
+ "risc0-zkp",
+ "tracing",
+]
+
+[[package]]
+name = "risc0-circuit-keccak-sys"
+version = "4.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8eae53a7bf1c09828dfd46ed5c942cefbf4bef3c4400f6758001569a834c462"
+dependencies = [
+ "cc",
+ "derive_more",
+ "glob",
+ "risc0-build-kernel",
+ "risc0-core",
+ "risc0-sys",
+]
+
+[[package]]
+name = "risc0-circuit-recursion"
+version = "4.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2347e909c6b2a65584b5898f3802eec5b8c1b4b45329edfdd8587b6a04dd3357"
+dependencies = [
+ "anyhow",
+ "bytemuck",
+ "cfg-if",
+ "downloader",
+ "hex",
+ "lazy-regex",
+ "metal",
+ "rand 0.9.2",
+ "rayon",
+ "risc0-circuit-recursion-sys",
+ "risc0-core",
+ "risc0-sys",
+ "risc0-zkp",
+ "serde",
+ "sha2 0.10.9",
+ "tracing",
+ "zip 2.4.2",
+]
+
+[[package]]
+name = "risc0-circuit-recursion-sys"
+version = "4.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "132be7ccca4b39ec957cc37d5083ca2aee171407922352002c9812452a890b39"
+dependencies = [
+ "glob",
+ "risc0-build-kernel",
+ "risc0-core",
+ "risc0-sys",
+]
+
+[[package]]
+name = "risc0-circuit-rv32im"
+version = "4.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61676419814a818fdb5e10066b13c5488b3f54aa9668794bd06c99bc91bff1f2"
+dependencies = [
+ "anyhow",
+ "bit-vec 0.8.0",
+ "bytemuck",
+ "byteorder",
+ "cfg-if",
+ "derive_more",
+ "enum-map",
+ "gdbstub",
+ "gdbstub_arch",
+ "malachite",
+ "num-derive",
+ "num-traits",
+ "paste",
+ "postcard",
+ "rand 0.9.2",
+ "rayon",
+ "ringbuffer 0.15.0",
+ "risc0-binfmt",
+ "risc0-circuit-rv32im-sys",
+ "risc0-core",
+ "risc0-sys",
+ "risc0-zkp",
+ "serde",
+ "smallvec",
+ "tracing",
+ "wide",
+]
+
+[[package]]
+name = "risc0-circuit-rv32im-sys"
+version = "4.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69d677ec41e475534e18e58889ef0626dcdabf5e918804ef847da0c0bbf300b3"
+dependencies = [
+ "cc",
+ "derive_more",
+ "glob",
+ "risc0-build-kernel",
+ "risc0-core",
+ "risc0-sys",
+]
+
+[[package]]
+name = "risc0-core"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5b956a976b8ce4713694dcc6c370b522a42ccef4ba45da5b6e57dbf26cdb7b1"
+dependencies = [
+ "bytemuck",
+ "nvtx",
+ "puffin",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "risc0-ethereum-contracts"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a604f09f459f456fd9ef4919c6efcaa6a787a6f9ffcd76cfc81eae1860584a1"
+dependencies = [
+ "alloy",
+ "alloy-primitives",
+ "alloy-sol-types",
+ "anyhow",
+ "cfg-if",
+ "hex",
+ "risc0-aggregation",
+ "risc0-zkvm",
+ "serde",
+ "thiserror 2.0.18",
+ "tracing",
+]
+
+[[package]]
+name = "risc0-ethereum-contracts"
+version = "3.0.1"
+source = "git+https://github.com/risc0/risc0-ethereum?tag=v3.0.1#365e7b2db4f620fa256580c27558d2623362b9ae"
+dependencies = [
+ "alloy",
+ "alloy-sol-types",
+ "anyhow",
+ "cfg-if",
+ "risc0-zkvm",
+ "thiserror 2.0.18",
+ "tracing",
+]
+
+[[package]]
+name = "risc0-groth16"
+version = "3.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc57e76bb87193d154ac5ee6ee352fbd7edabddab36f02a81f40a048e5ca14f9"
+dependencies = [
+ "anyhow",
+ "ark-bn254",
+ "ark-ec",
+ "ark-ff 0.5.0",
+ "ark-groth16",
+ "ark-serialize 0.5.0",
+ "bytemuck",
+ "cfg-if",
+ "hex",
+ "num-bigint 0.4.6",
+ "num-traits",
+ "risc0-binfmt",
+ "risc0-core",
+ "risc0-zkp",
+ "rzup",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "tracing",
+]
+
+[[package]]
+name = "risc0-sys"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "960c8295fbb87e1e73e332f8f7de2fba0252377575042d9d3e9a4eb50a38e078"
+dependencies = [
+ "anyhow",
+ "risc0-build-kernel",
+]
+
+[[package]]
+name = "risc0-zkos-v1compat"
+version = "2.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8bd70cb45b5d37d025f25663b87c6b9dc9df7f413ee2068531a57f50b0eb95db"
+dependencies = [
+ "include_bytes_aligned",
+ "no_std_strings",
+ "risc0-zkvm-platform",
+]
+
+[[package]]
+name = "risc0-zkp"
+version = "3.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f40d362a6c146ec6dc69208f539b92fd86e47b0dbc2083801423034a38155a2"
+dependencies = [
+ "anyhow",
+ "blake2",
+ "borsh",
+ "bytemuck",
+ "cfg-if",
+ "digest 0.10.7",
+ "ff",
+ "hex",
+ "hex-literal 0.4.1",
+ "metal",
+ "ndarray",
+ "parking_lot",
+ "paste",
+ "rand 0.9.2",
+ "rand_core 0.9.5",
+ "rayon",
+ "risc0-core",
+ "risc0-sys",
+ "risc0-zkvm-platform",
+ "serde",
+ "sha2 0.10.9",
+ "stability",
+ "tracing",
+]
+
+[[package]]
+name = "risc0-zkvm"
+version = "3.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22b7eafb5d85be59cbd9da83f662cf47d834f1b836e14f675d1530b12c666867"
+dependencies = [
+ "addr2line 0.24.2",
+ "anyhow",
+ "bincode 1.3.3",
+ "borsh",
+ "bytemuck",
+ "bytes",
+ "derive_more",
+ "elf",
+ "enum-map",
+ "gdbstub",
+ "gdbstub_arch",
+ "gimli 0.31.1",
+ "hex",
+ "keccak",
+ "lazy-regex",
+ "num-bigint 0.4.6",
+ "num-traits",
+ "object 0.36.7",
+ "prost 0.13.5",
+ "rand 0.9.2",
+ "rayon",
+ "risc0-binfmt",
+ "risc0-build",
+ "risc0-circuit-keccak",
+ "risc0-circuit-recursion",
+ "risc0-circuit-rv32im",
+ "risc0-core",
+ "risc0-groth16",
+ "risc0-zkos-v1compat",
+ "risc0-zkp",
+ "risc0-zkvm-platform",
+ "rrs-lib",
+ "rustc-demangle",
+ "rzup",
+ "semver 1.0.27",
+ "serde",
+ "sha2 0.10.9",
+ "stability",
+ "tempfile",
+ "tracing",
+ "typetag",
+]
+
+[[package]]
+name = "risc0-zkvm-platform"
+version = "2.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4db893788c416287e2e1a87e6b8f5302511a04a45329e699d6a32a16874fd24f"
+dependencies = [
+ "bytemuck",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "getrandom 0.3.4",
+ "libm",
+ "num_enum",
+ "paste",
+ "stability",
 ]
 
 [[package]]
@@ -15902,6 +17115,16 @@ name = "route-recognizer"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "afab94fb28594581f62d981211a9a4d53cc8130bbcbbb89a0440d9b8e81a7746"
+
+[[package]]
+name = "rrs-lib"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4382d3af3a4ebdae7f64ba6edd9114fff92c89808004c4943b393377a25d001"
+dependencies = [
+ "downcast-rs",
+ "paste",
+]
 
 [[package]]
 name = "rsa"
@@ -15999,10 +17222,11 @@ dependencies = [
  "ark-ff 0.3.0",
  "ark-ff 0.4.2",
  "ark-ff 0.5.0",
+ "borsh",
  "bytes",
  "fastrlp 0.3.1",
  "fastrlp 0.4.0",
- "num-bigint",
+ "num-bigint 0.4.6",
  "num-integer",
  "num-traits",
  "parity-scale-codec",
@@ -16056,7 +17280,7 @@ dependencies = [
  "libcrux-ml-kem",
  "log",
  "md5",
- "num-bigint",
+ "num-bigint 0.4.6",
  "p256",
  "p384",
  "p521",
@@ -16316,6 +17540,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ruzstd"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fad02996bfc73da3e301efe90b1837be9ed8f4a462b6ed410aa35d00381de89f"
+dependencies = [
+ "twox-hash",
+]
+
+[[package]]
 name = "rw-stream-sink"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -16337,6 +17570,34 @@ name = "ryu-js"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd29631678d6fb0903b69223673e122c32e9ae559d0960a38d574695ebc0ea15"
+
+[[package]]
+name = "rzup"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d2aed296f203fa64bcb4b52069356dd86d6ec578593985b919b6995bee1f0ae"
+dependencies = [
+ "hex",
+ "rsa 0.9.10",
+ "semver 1.0.27",
+ "serde",
+ "serde_with",
+ "sha2 0.10.9",
+ "strum 0.27.2",
+ "tempfile",
+ "thiserror 2.0.18",
+ "toml 0.8.23",
+ "yaml-rust2",
+]
+
+[[package]]
+name = "safe_arch"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96b02de82ddbe1b636e6170c21be622223aea188ef2e139be0a5b219ec215323"
+dependencies = [
+ "bytemuck",
+]
 
 [[package]]
 name = "salsa20"
@@ -16680,6 +17941,15 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "serde_spanned"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8bbf91e5a4d6315eee45e704372590b30e260ee83af6639d64557f51b067776"
@@ -16966,7 +18236,7 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d585997b0ac10be3c5ee635f1bab02d512760d14b7c468801ac8a01d9ae5f1d"
 dependencies = [
- "num-bigint",
+ "num-bigint 0.4.6",
  "num-traits",
  "thiserror 2.0.18",
  "time",
@@ -16977,6 +18247,23 @@ name = "siphasher"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
+
+[[package]]
+name = "siwe"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95bdefc0eedf06440b27092fbfe33f2cb493ad6a3423aa12cfe7f2aac44bd618"
+dependencies = [
+ "hex",
+ "http 1.4.0",
+ "iri-string",
+ "k256",
+ "rand 0.8.5",
+ "serde",
+ "sha3",
+ "thiserror 1.0.69",
+ "time",
+]
 
 [[package]]
 name = "sketches-ddsketch"
@@ -17338,6 +18625,16 @@ dependencies = [
  "bytes",
  "pem-rfc7468 0.7.0",
  "sha2 0.10.9",
+]
+
+[[package]]
+name = "stability"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d904e7009df136af5297832a3ace3370cd14ff1546a232f4f185036c2736fcac"
+dependencies = [
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -18014,6 +19311,20 @@ dependencies = [
 
 [[package]]
 name = "tokio-tungstenite"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edc5f74e248dc973e0dbb7b74c7e0d6fcc301c694ff50049504004ef4d0cdcd9"
+dependencies = [
+ "futures-util",
+ "log",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+ "tungstenite 0.24.0",
+]
+
+[[package]]
+name = "tokio-tungstenite"
 version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a9daff607c6d2bf6c16fd681ccb7eecc83e4e2cdc1ca067ffaadfca5de7f084"
@@ -18076,13 +19387,25 @@ dependencies = [
 
 [[package]]
 name = "toml"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+dependencies = [
+ "serde",
+ "serde_spanned 0.6.9",
+ "toml_datetime 0.6.11",
+ "toml_edit 0.22.27",
+]
+
+[[package]]
+name = "toml"
 version = "0.9.12+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863"
 dependencies = [
  "indexmap 2.13.0",
  "serde_core",
- "serde_spanned",
+ "serde_spanned 1.0.4",
  "toml_datetime 0.7.5+spec-1.1.0",
  "toml_parser",
  "toml_writer",
@@ -18097,11 +19420,20 @@ checksum = "399b1124a3c9e16766831c6bba21e50192572cdd98706ea114f9502509686ffc"
 dependencies = [
  "indexmap 2.13.0",
  "serde_core",
- "serde_spanned",
+ "serde_spanned 1.0.4",
  "toml_datetime 1.0.0+spec-1.1.0",
  "toml_parser",
  "toml_writer",
  "winnow",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -18124,6 +19456,20 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap 2.13.0",
+ "serde",
+ "serde_spanned 0.6.9",
+ "toml_datetime 0.6.11",
+ "toml_write",
+ "winnow",
+]
+
+[[package]]
+name = "toml_edit"
 version = "0.25.4+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7193cbd0ce53dc966037f54351dbbcf0d5a642c7f0038c382ef9e677ce8c13f2"
@@ -18142,6 +19488,12 @@ checksum = "702d4415e08923e7e1ef96cd5727c0dfed80b4d2fa25db9647fe5eb6f7c5a4c4"
 dependencies = [
  "winnow",
 ]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "toml_writer"
@@ -18197,7 +19549,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a55376a0bbaa4975a3f10d009ad763d8f4108f067c7c2e74f3001fb49778d309"
 dependencies = [
  "bytes",
- "prost",
+ "prost 0.14.3",
  "tonic",
 ]
 
@@ -18517,6 +19869,25 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "tungstenite"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18e5b8366ee7a95b16d32197d0b2604b43a0be89dc5fac9f8e96ccafbaedda8a"
+dependencies = [
+ "byteorder",
+ "bytes",
+ "data-encoding",
+ "http 1.4.0",
+ "httparse",
+ "log",
+ "native-tls",
+ "rand 0.8.5",
+ "sha1 0.10.6",
+ "thiserror 1.0.69",
+ "utf-8",
+]
+
+[[package]]
+name = "tungstenite"
 version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4793cb5e56680ecbb1d843515b23b6de9a75eb04b66643e256a396d43be33c13"
@@ -18555,6 +19926,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "twox-hash"
+version = "1.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
+dependencies = [
+ "cfg-if",
+ "static_assertions",
+]
+
+[[package]]
+name = "typed-arena"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6af6ae20167a9ece4bcb41af5b80f8a1f1df981f6391189ce00fd257af04126a"
+
+[[package]]
 name = "typed-path"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -18571,6 +19958,30 @@ name = "typenum"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+
+[[package]]
+name = "typetag"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be2212c8a9b9bcfca32024de14998494cf9a5dfa59ea1b829de98bac374b86bf"
+dependencies = [
+ "erased-serde",
+ "inventory",
+ "once_cell",
+ "serde",
+ "typetag-impl",
+]
+
+[[package]]
+name = "typetag-impl"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27a7a9b72ba121f6f1f6c3632b85604cac41aedb5ddc70accbebb6cac83de846"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "ucd-trie"
@@ -18781,6 +20192,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
+name = "utoipa"
+version = "5.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fcc29c80c21c31608227e0912b2d7fddba57ad76b606890627ba8ee7964e993"
+dependencies = [
+ "indexmap 2.13.0",
+ "serde",
+ "serde_json",
+ "utoipa-gen",
+]
+
+[[package]]
+name = "utoipa-gen"
+version = "5.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d79d08d92ab8af4c5e8a6da20c47ae3f61a0f1dabc1997cdf2d082b757ca08b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "uuid"
 version = "1.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -18813,7 +20247,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b849a1f6d8639e8de261e81ee0fc881e3e3620db1af9f2e0da015d4382ceaf75"
 dependencies = [
  "anyhow",
- "cargo_metadata",
+ "cargo_metadata 0.23.1",
  "derive_builder",
  "regex",
  "rustversion",
@@ -19048,6 +20482,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-streams"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d1ec4f6517c9e11ae630e200b2b65d193279042e28edd4a2cda233e46670bbb"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
 name = "wasmparser"
 version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -19255,6 +20702,16 @@ checksum = "5d4a4db5077702ca3015d3d02d74974948aba2ad9e12ab7df718ee64ccd7e97d"
 dependencies = [
  "libredox",
  "wasite",
+]
+
+[[package]]
+name = "wide"
+version = "0.7.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce5da8ecb62bcd8ec8b7ea19f69a51275e91299be594ea5cc6ef7819e16cd03"
+dependencies = [
+ "bytemuck",
+ "safe_arch",
 ]
 
 [[package]]
@@ -19978,6 +21435,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0637d3a5566a82fa5214bae89087bc8c9fb94cd8e8a3c07feb691bb8d9c632db"
 
 [[package]]
+name = "yaml-rust2"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2462ea039c445496d8793d052e13787f2b90e750b833afee748e601c17621ed9"
+dependencies = [
+ "arraydeque",
+ "encoding_rs",
+ "hashlink 0.10.0",
+]
+
+[[package]]
 name = "yamux"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -20139,6 +21607,23 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "zip"
+version = "2.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fabe6324e908f85a1c52063ce7aa26b68dcb7eb6dbc83a2d148403c9bc3eba50"
+dependencies = [
+ "arbitrary",
+ "crc32fast",
+ "crossbeam-utils",
+ "displaydoc",
+ "flate2",
+ "indexmap 2.13.0",
+ "memchr",
+ "thiserror 2.0.18",
+ "zopfli",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4590,6 +4590,7 @@ dependencies = [
  "risc0-zkvm",
  "rstest",
  "thiserror 2.0.18",
+ "tokio",
  "tracing",
  "url",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4586,7 +4586,7 @@ dependencies = [
  "async-trait",
  "base-proof-tee-nitro-verifier",
  "boundless-market",
- "risc0-ethereum-contracts 3.0.1 (git+https://github.com/risc0/risc0-ethereum?tag=v3.0.1)",
+ "risc0-ethereum-contracts",
  "risc0-zkvm",
  "rstest",
  "thiserror 2.0.18",
@@ -5668,7 +5668,7 @@ dependencies = [
  "reqwest-retry",
  "risc0-aggregation",
  "risc0-binfmt",
- "risc0-ethereum-contracts 3.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "risc0-ethereum-contracts",
  "risc0-zkvm",
  "rmp-serde",
  "serde",
@@ -16882,20 +16882,6 @@ dependencies = [
  "risc0-aggregation",
  "risc0-zkvm",
  "serde",
- "thiserror 2.0.18",
- "tracing",
-]
-
-[[package]]
-name = "risc0-ethereum-contracts"
-version = "3.0.1"
-source = "git+https://github.com/risc0/risc0-ethereum?tag=v3.0.1#365e7b2db4f620fa256580c27558d2623362b9ae"
-dependencies = [
- "alloy",
- "alloy-sol-types",
- "anyhow",
- "cfg-if",
- "risc0-zkvm",
  "thiserror 2.0.18",
  "tracing",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -425,8 +425,8 @@ aws-sdk-elasticloadbalancingv2 = { version = "1.109.0", default-features = false
 
 # risc0 / boundless
 boundless-market = "1.1"
-risc0-zkvm = { version = "^3.0", default-features = false }
 risc0-ethereum-contracts = "3.0.1"
+risc0-zkvm = { version = "^3.0", default-features = false }
 
 # crypto
 sha3 = "0.10"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -426,7 +426,7 @@ aws-sdk-elasticloadbalancingv2 = { version = "1.109.0", default-features = false
 # risc0 / boundless
 boundless-market = "1.1"
 risc0-zkvm = { version = "^3.0", default-features = false }
-risc0-ethereum-contracts = { git = "https://github.com/risc0/risc0-ethereum", tag = "v3.0.1" }
+risc0-ethereum-contracts = "3.0.1"
 
 # crypto
 sha3 = "0.10"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ members = [
   "crates/proof/tee/client",
   "crates/proof/tee/registrar",
   "crates/proof/tee/nitro-verifier",
+  "crates/proof/tee/nitro-attestation-prover",
   "crates/proof/zk/client",
   "crates/proof/zk/db",
   "crates/proof/zk/outbox",
@@ -239,6 +240,7 @@ base-proof = { path = "crates/proof/proof", default-features = false }
 base-proof-mpt = { path = "crates/proof/mpt", default-features = false }
 base-proof-host = { path = "crates/proof/host", default-features = false }
 base-proof-tee-nitro-verifier = { path = "crates/proof/tee/nitro-verifier" }
+base-proof-tee-nitro-attestation-prover = { path = "crates/proof/tee/nitro-attestation-prover" }
 base-proof-client = { path = "crates/proof/client", default-features = false }
 base-proof-driver = { path = "crates/proof/driver", default-features = false }
 base-proof-executor = { path = "crates/proof/executor", default-features = false }
@@ -420,6 +422,11 @@ aws-sdk-s3 = { version = "1.106.0", default-features = false }
 aws-sdk-ec2 = { version = "1.217.0", default-features = false }
 aws-credential-types = { version = "1.1.7", default-features = false }
 aws-sdk-elasticloadbalancingv2 = { version = "1.109.0", default-features = false }
+
+# risc0 / boundless
+boundless-market = "1.1"
+risc0-zkvm = { version = "^3.0", default-features = false }
+risc0-ethereum-contracts = { git = "https://github.com/risc0/risc0-ethereum", tag = "v3.0.1" }
 
 # crypto
 sha3 = "0.10"

--- a/crates/proof/tee/nitro-attestation-prover/Cargo.toml
+++ b/crates/proof/tee/nitro-attestation-prover/Cargo.toml
@@ -22,7 +22,6 @@ base-proof-tee-nitro-verifier.workspace = true
 
 # Types
 url.workspace = true
-alloy-sol-types.workspace = true
 alloy-primitives.workspace = true
 alloy-signer-local.workspace = true
 

--- a/crates/proof/tee/nitro-attestation-prover/Cargo.toml
+++ b/crates/proof/tee/nitro-attestation-prover/Cargo.toml
@@ -1,0 +1,35 @@
+[package]
+name = "base-proof-tee-nitro-attestation-prover"
+description = "ZK attestation prover for AWS Nitro Enclave attestation documents"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+
+[lints]
+workspace = true
+
+[dependencies]
+# Proving
+boundless-market.workspace = true
+risc0-ethereum-contracts.workspace = true
+risc0-zkvm = { workspace = true, features = ["prove"] }
+
+# Verification types
+base-proof-tee-nitro-verifier.workspace = true
+
+# Types
+url.workspace = true
+alloy-sol-types.workspace = true
+alloy-primitives.workspace = true
+alloy-signer-local.workspace = true
+
+# Async / error / tracing
+tracing.workspace = true
+thiserror.workspace = true
+async-trait.workspace = true
+
+[dev-dependencies]
+rstest.workspace = true

--- a/crates/proof/tee/nitro-attestation-prover/Cargo.toml
+++ b/crates/proof/tee/nitro-attestation-prover/Cargo.toml
@@ -30,6 +30,7 @@ alloy-signer-local.workspace = true
 tracing.workspace = true
 thiserror.workspace = true
 async-trait.workspace = true
+tokio = { workspace = true, features = ["rt"] }
 
 [dev-dependencies]
 rstest.workspace = true

--- a/crates/proof/tee/nitro-attestation-prover/README.md
+++ b/crates/proof/tee/nitro-attestation-prover/README.md
@@ -1,0 +1,26 @@
+# base-proof-tee-nitro-attestation-prover
+
+ZK attestation prover for AWS Nitro Enclave attestation documents.
+
+Wraps [`base-proof-tee-nitro-verifier`] verification logic inside a RISC Zero
+ZK guest program and provides two proving backends for generating on-chain
+verifiable proofs:
+
+- **`DirectProver`** — uses `risc0_zkvm::default_prover()` which routes to
+  Bonsai remote proving (`BONSAI_API_KEY`), dev-mode (`RISC0_DEV_MODE=1`),
+  or local CPU proving as a fallback.
+- **`BoundlessProver`** — submits proof requests to the Boundless marketplace
+  for decentralised proving.
+
+The guest ELF is loaded at runtime (from disk or IPFS) rather than embedded at
+compile time, so the risc0 toolchain is not required for building this crate.
+
+## Modules
+
+- **`error`** — [`ProverError`] enum covering verification, risc0, and
+  Boundless failures.
+- **`types`** — [`AttestationProof`] output type and
+  [`AttestationProofProvider`] trait.
+- **`direct`** — [`DirectProver`] implementation using `default_prover()`.
+- **`boundless`** — [`BoundlessProver`] implementation using the Boundless
+  marketplace.

--- a/crates/proof/tee/nitro-attestation-prover/guest/Cargo.toml
+++ b/crates/proof/tee/nitro-attestation-prover/guest/Cargo.toml
@@ -8,3 +8,11 @@ edition = "2024"
 [dependencies]
 risc0-zkvm = { version = "^3.0", default-features = false, features = ["std"] }
 base-proof-tee-nitro-verifier = { path = "../../nitro-verifier" }
+
+[lints.rust]
+missing-docs = "warn"
+unused-must-use = "deny"
+rust-2018-idioms = "deny"
+
+[lints.clippy]
+all = { level = "warn", priority = -1 }

--- a/crates/proof/tee/nitro-attestation-prover/guest/Cargo.toml
+++ b/crates/proof/tee/nitro-attestation-prover/guest/Cargo.toml
@@ -1,0 +1,10 @@
+[workspace]
+
+[package]
+name = "base-nitro-verifier-guest"
+version = "0.0.0"
+edition = "2024"
+
+[dependencies]
+risc0-zkvm = { version = "^3.0", default-features = false, features = ["std"] }
+base-proof-tee-nitro-verifier = { path = "../../nitro-verifier" }

--- a/crates/proof/tee/nitro-attestation-prover/guest/Cargo.toml
+++ b/crates/proof/tee/nitro-attestation-prover/guest/Cargo.toml
@@ -1,7 +1,7 @@
 [workspace]
 
 [package]
-name = "base-nitro-verifier-guest"
+name = "base-proof-tee-nitro-verifier-guest"
 version = "0.0.0"
 edition = "2024"
 

--- a/crates/proof/tee/nitro-attestation-prover/guest/Justfile
+++ b/crates/proof/tee/nitro-attestation-prover/guest/Justfile
@@ -1,0 +1,13 @@
+# Default recipe to display help information
+default:
+    @just --list
+
+# Build the guest ELF with the risc0 toolchain
+build:
+    cargo +risc0 build --release --target riscv32im-risc0-zkvm-elf
+    @echo "ELF built at: target/riscv32im-risc0-zkvm-elf/release/base-proof-tee-nitro-verifier-guest"
+    @ls -lh target/riscv32im-risc0-zkvm-elf/release/base-proof-tee-nitro-verifier-guest
+
+# Install the risc0 toolchain via rzup
+install-toolchain:
+    rzup install

--- a/crates/proof/tee/nitro-attestation-prover/guest/README.md
+++ b/crates/proof/tee/nitro-attestation-prover/guest/README.md
@@ -1,0 +1,26 @@
+# Nitro Verifier Guest Program
+
+RISC Zero guest program that verifies AWS Nitro Enclave attestation documents
+inside the zkVM.
+
+This directory is a **standalone Cargo workspace** (note the `[workspace]` in
+`Cargo.toml`) and is intentionally **not** a member of the repository workspace.
+The guest targets `riscv32im-risc0-zkvm-elf` and requires the risc0 toolchain,
+so including it in the main workspace would break normal `cargo build` / `cargo
+check` invocations for everyone who doesn't have that toolchain installed.
+
+## Building
+
+```sh
+# Install the risc0 toolchain
+rzup install
+
+# Compile the guest ELF
+cargo +risc0 build --release --target riscv32im-risc0-zkvm-elf
+
+# The ELF is at:
+# target/riscv32im-risc0-zkvm-elf/release/base-nitro-verifier-guest
+```
+
+The resulting ELF is loaded at runtime by `DirectProver` or `BoundlessProver`
+in the host crate. It is not embedded at compile time.

--- a/crates/proof/tee/nitro-attestation-prover/guest/README.md
+++ b/crates/proof/tee/nitro-attestation-prover/guest/README.md
@@ -19,7 +19,7 @@ rzup install
 cargo +risc0 build --release --target riscv32im-risc0-zkvm-elf
 
 # The ELF is at:
-# target/riscv32im-risc0-zkvm-elf/release/base-nitro-verifier-guest
+# target/riscv32im-risc0-zkvm-elf/release/base-proof-tee-nitro-verifier-guest
 ```
 
 The resulting ELF is loaded at runtime by `DirectProver` or `BoundlessProver`

--- a/crates/proof/tee/nitro-attestation-prover/guest/src/main.rs
+++ b/crates/proof/tee/nitro-attestation-prover/guest/src/main.rs
@@ -1,0 +1,24 @@
+// RISC Zero guest program for Nitro attestation verification.
+//
+// NOT compiled by the host crate — exists as source for manual compilation
+// with the risc0 toolchain:
+//
+//   rzup install
+//   cargo +risc0 build --release --target riscv32im-risc0-zkvm-elf
+//
+// The resulting ELF is loaded at runtime by DirectProver / BoundlessProver.
+
+use std::io::Read;
+
+use base_proof_tee_nitro_verifier::{AttestationVerifier, VerifierInput};
+use risc0_zkvm::guest::env;
+
+fn main() {
+    let mut input_bytes = Vec::new();
+    env::stdin().read_to_end(&mut input_bytes).unwrap();
+
+    let input = VerifierInput::decode(&input_bytes).unwrap();
+    let journal = AttestationVerifier::verify(&input).unwrap();
+
+    env::commit_slice(&journal.encode());
+}

--- a/crates/proof/tee/nitro-attestation-prover/guest/src/main.rs
+++ b/crates/proof/tee/nitro-attestation-prover/guest/src/main.rs
@@ -15,10 +15,10 @@ use risc0_zkvm::guest::env;
 
 fn main() {
     let mut input_bytes = Vec::new();
-    env::stdin().read_to_end(&mut input_bytes).unwrap();
+    env::stdin().read_to_end(&mut input_bytes).expect("failed to read guest stdin");
 
-    let input = VerifierInput::decode(&input_bytes).unwrap();
-    let journal = AttestationVerifier::verify(&input).unwrap();
+    let input = VerifierInput::decode(&input_bytes).expect("failed to decode VerifierInput");
+    let journal = AttestationVerifier::verify(&input).expect("attestation verification failed");
 
     env::commit_slice(&journal.encode());
 }

--- a/crates/proof/tee/nitro-attestation-prover/src/boundless.rs
+++ b/crates/proof/tee/nitro-attestation-prover/src/boundless.rs
@@ -47,7 +47,7 @@ pub struct BoundlessProver {
 impl fmt::Debug for BoundlessProver {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("BoundlessProver")
-            .field("rpc_url", &self.rpc_url)
+            .field("rpc_url", &self.rpc_url.origin().unicode_serialization())
             .field("signer", &self.signer.address())
             .field("verifier_program_url", &self.verifier_program_url)
             .field("image_id", &self.image_id)
@@ -208,7 +208,19 @@ mod tests {
         assert_eq!(cloned.timeout, prover.timeout);
     }
 
-    // ── Debug shows address, not raw key ────────────────────────────────
+    // ── Debug redaction ──────────────────────────────────────────────────
+
+    #[rstest]
+    fn debug_redacts_rpc_url_path() {
+        let api_key = "s3cret-api-key-12345";
+        let rpc_with_key = format!("https://mainnet.infura.io/v3/{api_key}");
+        let mut prover = prover();
+        prover.rpc_url = Url::parse(&rpc_with_key).unwrap();
+
+        let debug = format!("{prover:?}");
+        assert!(!debug.contains(api_key), "RPC URL path (API key) must not appear in Debug output");
+        assert!(debug.contains("mainnet.infura.io"), "RPC host should still be visible");
+    }
 
     #[rstest]
     fn debug_shows_address_not_key(prover: BoundlessProver) {

--- a/crates/proof/tee/nitro-attestation-prover/src/boundless.rs
+++ b/crates/proof/tee/nitro-attestation-prover/src/boundless.rs
@@ -7,7 +7,6 @@ use std::{fmt, time::Duration};
 
 use alloy_primitives::{Bytes, U256};
 use alloy_signer_local::PrivateKeySigner;
-use alloy_sol_types::SolValue;
 use base_proof_tee_nitro_verifier::VerifierInput;
 use boundless_market::{
     Client,
@@ -66,7 +65,7 @@ impl AttestationProofProvider for BoundlessProver {
             trustedCertsPrefixLen: self.trusted_certs_prefix_len,
             attestationReport: Bytes::copy_from_slice(attestation_bytes),
         };
-        let input_bytes = SolValue::abi_encode(&input);
+        let input_bytes = input.encode();
 
         let image_id = Digest::from(self.image_id);
 

--- a/crates/proof/tee/nitro-attestation-prover/src/boundless.rs
+++ b/crates/proof/tee/nitro-attestation-prover/src/boundless.rs
@@ -1,0 +1,226 @@
+//! [`BoundlessProver`] — proving backend using the Boundless marketplace.
+//!
+//! Submits proof requests to the Boundless decentralised proving marketplace
+//! and polls for fulfillment with a configurable timeout.
+
+use std::{fmt, time::Duration};
+
+use alloy_primitives::{Bytes, U256};
+use alloy_signer_local::PrivateKeySigner;
+use alloy_sol_types::SolValue;
+use base_proof_tee_nitro_verifier::VerifierInput;
+use boundless_market::{
+    Client,
+    contracts::Predicate,
+    request_builder::{OfferParams, RequestParams, RequirementParams},
+};
+use risc0_zkvm::sha::Digest;
+use tracing::{info, warn};
+use url::Url;
+
+use crate::{AttestationProof, AttestationProofProvider, ProverError, Result};
+
+/// Attestation prover using the Boundless marketplace.
+///
+/// Submits proof requests with a guest program URL (IPFS or HTTP) and
+/// polls for fulfillment within a configurable timeout.
+#[derive(Clone)]
+pub struct BoundlessProver {
+    /// Ethereum RPC URL for the Boundless settlement chain.
+    pub rpc_url: Url,
+    /// Signer for Boundless Network proving fees.
+    pub signer: PrivateKeySigner,
+    /// URL (IPFS or HTTP) where the guest ELF is hosted.
+    pub verifier_program_url: Url,
+    /// Expected image ID of the guest program.
+    pub image_id: [u32; 8],
+    /// Maximum price (in wei) willing to pay for proving.
+    pub max_price: u64,
+    /// Interval between fulfillment status checks.
+    pub poll_interval: Duration,
+    /// Maximum time to wait for proof fulfillment.
+    pub timeout: Duration,
+    /// Number of trusted certificates in the chain (typically 1 for root-only).
+    pub trusted_certs_prefix_len: u8,
+}
+
+impl fmt::Debug for BoundlessProver {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("BoundlessProver")
+            .field("rpc_url", &self.rpc_url)
+            .field("signer", &self.signer.address())
+            .field("verifier_program_url", &self.verifier_program_url)
+            .field("image_id", &self.image_id)
+            .field("max_price", &self.max_price)
+            .field("poll_interval", &self.poll_interval)
+            .field("timeout", &self.timeout)
+            .field("trusted_certs_prefix_len", &self.trusted_certs_prefix_len)
+            .finish()
+    }
+}
+
+#[async_trait::async_trait]
+impl AttestationProofProvider for BoundlessProver {
+    async fn generate_proof(&self, attestation_bytes: &[u8]) -> Result<AttestationProof> {
+        let input = VerifierInput {
+            trustedCertsPrefixLen: self.trusted_certs_prefix_len,
+            attestationReport: Bytes::copy_from_slice(attestation_bytes),
+        };
+        let input_bytes = SolValue::abi_encode(&input);
+
+        let image_id = Digest::from(self.image_id);
+
+        info!(
+            image_id = ?self.image_id,
+            input_len = input_bytes.len(),
+            "submitting proof request to Boundless"
+        );
+
+        let client = Client::builder()
+            .with_rpc_url(self.rpc_url.clone())
+            .with_private_key(self.signer.clone())
+            .build()
+            .await
+            .map_err(|e| ProverError::Boundless(format!("failed to build client: {e}")))?;
+
+        // Build request parameters: program URL + stdin input + predicate.
+        let params = RequestParams::new()
+            .with_program_url(self.verifier_program_url.clone())
+            .map_err(|e| ProverError::Boundless(format!("invalid program URL: {e}")))?
+            .with_stdin(input_bytes)
+            .with_image_id(image_id)
+            .with_requirements(
+                RequirementParams::builder().predicate(Predicate::prefix_match(image_id, [])),
+            )
+            .with_offer(OfferParams::builder().max_price(U256::from(self.max_price)));
+
+        let (request_id, expires_at) = client
+            .submit_onchain(params)
+            .await
+            .map_err(|e| ProverError::Boundless(format!("failed to submit request: {e}")))?;
+
+        info!(request_id = %request_id, "proof request submitted, waiting for fulfillment");
+
+        // Compute the expiry from timeout: pick the sooner of expires_at and
+        // now + timeout.
+        let timeout_at = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs()
+            .saturating_add(self.timeout.as_secs());
+        let effective_expiry = expires_at.min(timeout_at);
+
+        let fulfillment = client
+            .wait_for_request_fulfillment(request_id, self.poll_interval, effective_expiry)
+            .await
+            .map_err(|e| {
+                warn!(error = %e, request_id = %request_id, "proof fulfillment failed");
+                ProverError::Boundless(format!("fulfillment failed: {e}"))
+            })?;
+
+        let data = fulfillment
+            .data()
+            .map_err(|e| ProverError::Boundless(format!("failed to decode fulfillment: {e}")))?;
+        let journal = data
+            .journal()
+            .ok_or_else(|| ProverError::Boundless("fulfillment missing journal".into()))?;
+
+        let output = Bytes::copy_from_slice(journal);
+        let proof_bytes = Bytes::copy_from_slice(&fulfillment.seal);
+
+        info!(
+            journal_len = output.len(),
+            seal_len = proof_bytes.len(),
+            "proof fulfilled successfully"
+        );
+
+        Ok(AttestationProof { output, proof_bytes })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::str::FromStr;
+
+    use rstest::{fixture, rstest};
+
+    use super::*;
+
+    const TEST_RPC_URL: &str = "http://localhost:8545";
+    const TEST_PROGRAM_URL: &str = "https://example.com/guest.bin";
+    /// Well-known Hardhat/Anvil account #0 private key (not a real secret).
+    const TEST_PRIVATE_KEY: &str =
+        "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80";
+    const TEST_IMAGE_ID: [u32; 8] = [1, 2, 3, 4, 5, 6, 7, 8];
+    const TEST_MAX_PRICE_WEI: u64 = 1_000_000_000;
+    const TEST_POLL_INTERVAL: Duration = Duration::from_secs(5);
+    const TEST_TIMEOUT: Duration = Duration::from_secs(300);
+    const DEFAULT_TRUSTED_PREFIX: u8 = 1;
+
+    #[fixture]
+    fn prover() -> BoundlessProver {
+        BoundlessProver {
+            rpc_url: Url::parse(TEST_RPC_URL).unwrap(),
+            signer: PrivateKeySigner::from_str(TEST_PRIVATE_KEY).unwrap(),
+            verifier_program_url: Url::parse(TEST_PROGRAM_URL).unwrap(),
+            image_id: TEST_IMAGE_ID,
+            max_price: TEST_MAX_PRICE_WEI,
+            poll_interval: TEST_POLL_INTERVAL,
+            timeout: TEST_TIMEOUT,
+            trusted_certs_prefix_len: DEFAULT_TRUSTED_PREFIX,
+        }
+    }
+
+    // ── Construction ────────────────────────────────────────────────────
+
+    #[rstest]
+    fn struct_construction(prover: BoundlessProver) {
+        let debug = format!("{prover:?}");
+        assert!(debug.contains("BoundlessProver"));
+    }
+
+    // ── Field access ────────────────────────────────────────────────────
+
+    #[rstest]
+    fn fields_preserve_values(prover: BoundlessProver) {
+        assert_eq!(prover.rpc_url, Url::parse(TEST_RPC_URL).unwrap());
+        assert_eq!(
+            prover.signer.address(),
+            PrivateKeySigner::from_str(TEST_PRIVATE_KEY).unwrap().address()
+        );
+        assert_eq!(prover.verifier_program_url, Url::parse(TEST_PROGRAM_URL).unwrap());
+        assert_eq!(prover.image_id, TEST_IMAGE_ID);
+        assert_eq!(prover.max_price, TEST_MAX_PRICE_WEI);
+        assert_eq!(prover.poll_interval, TEST_POLL_INTERVAL);
+        assert_eq!(prover.timeout, TEST_TIMEOUT);
+        assert_eq!(prover.trusted_certs_prefix_len, DEFAULT_TRUSTED_PREFIX);
+    }
+
+    // ── Clone ───────────────────────────────────────────────────────────
+
+    #[rstest]
+    fn clone_preserves_values(prover: BoundlessProver) {
+        let cloned = prover.clone();
+        assert_eq!(cloned.rpc_url, prover.rpc_url);
+        assert_eq!(cloned.signer.address(), prover.signer.address());
+        assert_eq!(cloned.image_id, prover.image_id);
+        assert_eq!(cloned.max_price, prover.max_price);
+        assert_eq!(cloned.timeout, prover.timeout);
+    }
+
+    // ── Debug shows address, not raw key ────────────────────────────────
+
+    #[rstest]
+    fn debug_shows_address_not_key(prover: BoundlessProver) {
+        let debug = format!("{prover:?}");
+        let expected_addr = format!("{:?}", prover.signer.address());
+        assert!(
+            debug.contains(&expected_addr),
+            "Debug should show the signer address, got: {debug}"
+        );
+        assert!(
+            !debug.contains(TEST_PRIVATE_KEY),
+            "raw private key must not appear in Debug output"
+        );
+    }
+}

--- a/crates/proof/tee/nitro-attestation-prover/src/direct.rs
+++ b/crates/proof/tee/nitro-attestation-prover/src/direct.rs
@@ -1,0 +1,129 @@
+//! [`DirectProver`] — proving backend using `risc0_zkvm::default_prover()`.
+//!
+//! Routes automatically based on environment variables:
+//! - `BONSAI_API_KEY` + `BONSAI_API_URL` → remote Bonsai proving (Groth16)
+//! - `RISC0_DEV_MODE=1` → mock/fake prover (testing)
+//!
+//! Local CPU proving without Bonsai is not supported for on-chain proofs —
+//! Groth16 compression requires the Bonsai service or Docker with ceremony
+//! files.
+
+use alloy_primitives::Bytes;
+use alloy_sol_types::SolValue;
+use base_proof_tee_nitro_verifier::VerifierInput;
+use risc0_zkvm::{ExecutorEnv, ProverOpts, compute_image_id, default_prover};
+
+use crate::{AttestationProof, AttestationProofProvider, ProverError, Result};
+
+/// Attestation prover using the RISC Zero default prover.
+///
+/// The default prover routes to Bonsai remote proving or dev-mode depending
+/// on environment variable configuration. Always requests Groth16 receipts
+/// for on-chain verifiability.
+///
+/// **Note:** the proving call is synchronous and may block the async
+/// executor. In production (Bonsai), the underlying HTTP client manages
+/// this; in dev-mode the mock prover is near-instant.
+#[derive(Debug)]
+pub struct DirectProver {
+    elf: Vec<u8>,
+    image_id: [u32; 8],
+    trusted_certs_prefix_len: u8,
+}
+
+impl DirectProver {
+    /// Creates a new [`DirectProver`] from raw guest ELF bytes.
+    ///
+    /// Computes the image ID from the ELF. The `trusted_certs_prefix_len`
+    /// controls how many certificates in the chain are treated as trusted
+    /// (typically 1 for root-only).
+    pub fn new(elf: Vec<u8>, trusted_certs_prefix_len: u8) -> Result<Self> {
+        let digest = compute_image_id(&elf)
+            .map_err(|e| ProverError::ImageId(format!("failed to compute image ID: {e}")))?;
+        let image_id: [u32; 8] = digest.into();
+
+        Ok(Self { elf, image_id, trusted_certs_prefix_len })
+    }
+
+    /// Returns the computed image ID for this guest ELF.
+    pub const fn image_id(&self) -> &[u32; 8] {
+        &self.image_id
+    }
+}
+
+#[async_trait::async_trait]
+impl AttestationProofProvider for DirectProver {
+    async fn generate_proof(&self, attestation_bytes: &[u8]) -> Result<AttestationProof> {
+        let input = VerifierInput {
+            trustedCertsPrefixLen: self.trusted_certs_prefix_len,
+            attestationReport: Bytes::copy_from_slice(attestation_bytes),
+        };
+        let input_bytes = SolValue::abi_encode(&input);
+
+        let env = ExecutorEnv::builder()
+            .write_slice(&input_bytes)
+            .build()
+            .map_err(|e| ProverError::Risc0(format!("failed to build executor env: {e}")))?;
+
+        let prover = default_prover();
+        let prove_info = prover
+            .prove_with_opts(env, &self.elf, &ProverOpts::groth16())
+            .map_err(|e| ProverError::Risc0(format!("proving failed: {e}")))?;
+
+        let journal = Bytes::copy_from_slice(&prove_info.receipt.journal.bytes);
+        let seal = risc0_ethereum_contracts::encode_seal(&prove_info.receipt)
+            .map_err(|e| ProverError::Risc0(format!("failed to encode seal: {e}")))?;
+
+        Ok(AttestationProof { output: journal, proof_bytes: Bytes::from(seal) })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use rstest::rstest;
+
+    use super::*;
+
+    /// Default trusted certificate prefix length (root-only).
+    const DEFAULT_TRUSTED_PREFIX: u8 = 1;
+
+    // ── DirectProver::new() error paths ─────────────────────────────────
+
+    #[rstest]
+    fn new_with_empty_elf_returns_image_id_error() {
+        let result = DirectProver::new(vec![], DEFAULT_TRUSTED_PREFIX);
+
+        let err = result.unwrap_err();
+        assert!(matches!(err, ProverError::ImageId(_)));
+        assert!(
+            err.to_string().contains("image ID"),
+            "error message should mention image ID: {err}"
+        );
+    }
+
+    #[rstest]
+    fn new_with_garbage_bytes_returns_image_id_error() {
+        let garbage = vec![0xDE, 0xAD, 0xBE, 0xEF];
+        let result = DirectProver::new(garbage, DEFAULT_TRUSTED_PREFIX);
+
+        let err = result.unwrap_err();
+        assert!(matches!(err, ProverError::ImageId(_)));
+    }
+
+    #[rstest]
+    #[case::single_zero(vec![0x00])]
+    #[case::short_header(vec![0x7F, 0x45, 0x4C, 0x46])] // ELF magic without body
+    #[case::random_noise(vec![0xFF; 64])]
+    fn new_with_invalid_elf_variants_rejected(#[case] bad_elf: Vec<u8>) {
+        let result = DirectProver::new(bad_elf, DEFAULT_TRUSTED_PREFIX);
+        assert!(result.is_err(), "invalid ELF should be rejected");
+    }
+
+    // ── DirectProver::new() with different trusted prefix lengths ───────
+
+    #[rstest]
+    fn new_rejects_invalid_elf_regardless_of_prefix(#[values(0, 1, 2, 5)] trusted_prefix: u8) {
+        let result = DirectProver::new(vec![], trusted_prefix);
+        assert!(result.is_err());
+    }
+}

--- a/crates/proof/tee/nitro-attestation-prover/src/direct.rs
+++ b/crates/proof/tee/nitro-attestation-prover/src/direct.rs
@@ -21,9 +21,8 @@ use crate::{AttestationProof, AttestationProofProvider, ProverError, Result};
 /// on environment variable configuration. Always requests Groth16 receipts
 /// for on-chain verifiability.
 ///
-/// **Note:** the proving call is synchronous and may block the async
-/// executor. In production (Bonsai), the underlying HTTP client manages
-/// this; in dev-mode the mock prover is near-instant.
+/// Proving is offloaded to a blocking task via [`tokio::task::spawn_blocking`]
+/// to avoid stalling the async executor.
 #[derive(Debug)]
 pub struct DirectProver {
     elf: Vec<u8>,
@@ -54,27 +53,40 @@ impl DirectProver {
 #[async_trait::async_trait]
 impl AttestationProofProvider for DirectProver {
     async fn generate_proof(&self, attestation_bytes: &[u8]) -> Result<AttestationProof> {
-        let input = VerifierInput {
-            trustedCertsPrefixLen: self.trusted_certs_prefix_len,
-            attestationReport: Bytes::copy_from_slice(attestation_bytes),
-        };
-        let input_bytes = SolValue::abi_encode(&input);
+        let elf = self.elf.clone();
+        let trusted_certs_prefix_len = self.trusted_certs_prefix_len;
+        let attestation_owned = attestation_bytes.to_vec();
 
-        let env = ExecutorEnv::builder()
-            .write_slice(&input_bytes)
-            .build()
-            .map_err(|e| ProverError::Risc0(format!("failed to build executor env: {e}")))?;
+        // Proving is synchronous and potentially long-running (Bonsai HTTP
+        // polling or local CPU). Offload to a blocking thread so we don't
+        // stall the async executor.
+        let (journal_bytes, seal) = tokio::task::spawn_blocking(move || {
+            let input = VerifierInput {
+                trustedCertsPrefixLen: trusted_certs_prefix_len,
+                attestationReport: Bytes::copy_from_slice(&attestation_owned),
+            };
+            let input_bytes = SolValue::abi_encode(&input);
 
-        let prover = default_prover();
-        let prove_info = prover
-            .prove_with_opts(env, &self.elf, &ProverOpts::groth16())
-            .map_err(|e| ProverError::Risc0(format!("proving failed: {e}")))?;
+            let env = ExecutorEnv::builder()
+                .write_slice(&input_bytes)
+                .build()
+                .map_err(|e| ProverError::Risc0(format!("failed to build executor env: {e}")))?;
 
-        let journal = Bytes::copy_from_slice(&prove_info.receipt.journal.bytes);
-        let seal = risc0_ethereum_contracts::encode_seal(&prove_info.receipt)
-            .map_err(|e| ProverError::Risc0(format!("failed to encode seal: {e}")))?;
+            let prover = default_prover();
+            let prove_info = prover
+                .prove_with_opts(env, &elf, &ProverOpts::groth16())
+                .map_err(|e| ProverError::Risc0(format!("proving failed: {e}")))?;
 
-        Ok(AttestationProof { output: journal, proof_bytes: Bytes::from(seal) })
+            let journal = prove_info.receipt.journal.bytes.clone();
+            let seal = risc0_ethereum_contracts::encode_seal(&prove_info.receipt)
+                .map_err(|e| ProverError::Risc0(format!("failed to encode seal: {e}")))?;
+
+            Ok::<_, ProverError>((journal, seal))
+        })
+        .await
+        .map_err(|e| ProverError::Risc0(format!("proving task panicked: {e}")))??;
+
+        Ok(AttestationProof { output: Bytes::from(journal_bytes), proof_bytes: Bytes::from(seal) })
     }
 }
 

--- a/crates/proof/tee/nitro-attestation-prover/src/direct.rs
+++ b/crates/proof/tee/nitro-attestation-prover/src/direct.rs
@@ -11,7 +11,6 @@
 use std::sync::Arc;
 
 use alloy_primitives::Bytes;
-use alloy_sol_types::SolValue;
 use base_proof_tee_nitro_verifier::VerifierInput;
 use risc0_zkvm::{ExecutorEnv, ProverOpts, compute_image_id, default_prover};
 
@@ -65,9 +64,9 @@ impl AttestationProofProvider for DirectProver {
         let (journal_bytes, seal) = tokio::task::spawn_blocking(move || {
             let input = VerifierInput {
                 trustedCertsPrefixLen: trusted_certs_prefix_len,
-                attestationReport: Bytes::copy_from_slice(&attestation_owned),
+                attestationReport: Bytes::from(attestation_owned),
             };
-            let input_bytes = SolValue::abi_encode(&input);
+            let input_bytes = input.encode();
 
             let env = ExecutorEnv::builder()
                 .write_slice(&input_bytes)

--- a/crates/proof/tee/nitro-attestation-prover/src/direct.rs
+++ b/crates/proof/tee/nitro-attestation-prover/src/direct.rs
@@ -8,6 +8,8 @@
 //! Groth16 compression requires the Bonsai service or Docker with ceremony
 //! files.
 
+use std::sync::Arc;
+
 use alloy_primitives::Bytes;
 use alloy_sol_types::SolValue;
 use base_proof_tee_nitro_verifier::VerifierInput;
@@ -25,7 +27,7 @@ use crate::{AttestationProof, AttestationProofProvider, ProverError, Result};
 /// to avoid stalling the async executor.
 #[derive(Debug)]
 pub struct DirectProver {
-    elf: Vec<u8>,
+    elf: Arc<[u8]>,
     image_id: [u32; 8],
     trusted_certs_prefix_len: u8,
 }
@@ -41,7 +43,7 @@ impl DirectProver {
             .map_err(|e| ProverError::ImageId(format!("failed to compute image ID: {e}")))?;
         let image_id: [u32; 8] = digest.into();
 
-        Ok(Self { elf, image_id, trusted_certs_prefix_len })
+        Ok(Self { elf: Arc::from(elf), image_id, trusted_certs_prefix_len })
     }
 
     /// Returns the computed image ID for this guest ELF.
@@ -53,7 +55,7 @@ impl DirectProver {
 #[async_trait::async_trait]
 impl AttestationProofProvider for DirectProver {
     async fn generate_proof(&self, attestation_bytes: &[u8]) -> Result<AttestationProof> {
-        let elf = self.elf.clone();
+        let elf = Arc::clone(&self.elf);
         let trusted_certs_prefix_len = self.trusted_certs_prefix_len;
         let attestation_owned = attestation_bytes.to_vec();
 

--- a/crates/proof/tee/nitro-attestation-prover/src/error.rs
+++ b/crates/proof/tee/nitro-attestation-prover/src/error.rs
@@ -1,0 +1,76 @@
+//! Error types for attestation proof generation.
+
+use thiserror::Error;
+
+/// Errors that can occur during attestation proof generation.
+#[derive(Debug, Error)]
+pub enum ProverError {
+    /// The underlying attestation verifier rejected the input.
+    #[error("verifier error: {0}")]
+    Verifier(#[from] base_proof_tee_nitro_verifier::VerifierError),
+
+    /// RISC Zero proving failed (Bonsai, dev-mode, or local).
+    #[error("risc0 error: {0}")]
+    Risc0(String),
+
+    /// Boundless marketplace interaction failed.
+    #[error("boundless error: {0}")]
+    Boundless(String),
+
+    /// The guest ELF or image ID is invalid.
+    #[error("image ID error: {0}")]
+    ImageId(String),
+}
+
+/// Convenience result alias for prover operations.
+pub type Result<T, E = ProverError> = std::result::Result<T, E>;
+
+#[cfg(test)]
+mod tests {
+    use base_proof_tee_nitro_verifier::VerifierError;
+    use rstest::rstest;
+
+    use super::*;
+
+    // ── From conversion ─────────────────────────────────────────────────
+
+    #[rstest]
+    fn from_verifier_error() {
+        let verifier_err = VerifierError::ContentValidation("bad field".into());
+        let prover_err = ProverError::from(verifier_err);
+
+        assert!(matches!(prover_err, ProverError::Verifier(_)));
+        assert!(prover_err.to_string().contains("bad field"));
+    }
+
+    // ── Display formatting ──────────────────────────────────────────────
+
+    #[rstest]
+    #[case::verifier(
+        ProverError::Verifier(VerifierError::Cbor("decode failed".into())),
+        "verifier error: CBOR error: decode failed"
+    )]
+    #[case::risc0(
+        ProverError::Risc0("segment fault".into()),
+        "risc0 error: segment fault"
+    )]
+    #[case::boundless(
+        ProverError::Boundless("timeout".into()),
+        "boundless error: timeout"
+    )]
+    #[case::image_id(
+        ProverError::ImageId("not an ELF".into()),
+        "image ID error: not an ELF"
+    )]
+    fn display_formatting(#[case] error: ProverError, #[case] expected: &str) {
+        assert_eq!(error.to_string(), expected);
+    }
+
+    // ── Result alias ────────────────────────────────────────────────────
+
+    #[rstest]
+    fn result_alias_defaults_to_prover_error() {
+        let err: Result<u32> = Err(ProverError::Risc0("fail".into()));
+        assert!(matches!(err, Err(ProverError::Risc0(_))));
+    }
+}

--- a/crates/proof/tee/nitro-attestation-prover/src/lib.rs
+++ b/crates/proof/tee/nitro-attestation-prover/src/lib.rs
@@ -1,0 +1,14 @@
+#![doc = include_str!("../README.md")]
+#![cfg_attr(not(test), warn(unused_crate_dependencies))]
+
+mod error;
+pub use error::{ProverError, Result};
+
+mod types;
+pub use types::{AttestationProof, AttestationProofProvider};
+
+mod direct;
+pub use direct::DirectProver;
+
+mod boundless;
+pub use boundless::BoundlessProver;

--- a/crates/proof/tee/nitro-attestation-prover/src/types.rs
+++ b/crates/proof/tee/nitro-attestation-prover/src/types.rs
@@ -1,0 +1,64 @@
+//! Core types and trait for attestation proof generation.
+
+use alloy_primitives::Bytes;
+use async_trait::async_trait;
+
+use crate::Result;
+
+/// A generated attestation proof ready for on-chain submission.
+#[derive(Debug, Clone)]
+pub struct AttestationProof {
+    /// ABI-encoded [`VerifierJournal`](base_proof_tee_nitro_verifier::VerifierJournal)
+    /// containing the verified attestation data.
+    pub output: Bytes,
+    /// Groth16 seal bytes for on-chain verification.
+    pub proof_bytes: Bytes,
+}
+
+/// Trait for generating ZK proofs over Nitro attestation documents.
+///
+/// Implementors wrap the attestation verification logic inside a ZK proving
+/// backend and return a proof suitable for on-chain submission.
+#[async_trait]
+pub trait AttestationProofProvider: Send + Sync {
+    /// Generates a ZK proof for the given raw attestation document bytes.
+    async fn generate_proof(&self, attestation_bytes: &[u8]) -> Result<AttestationProof>;
+}
+
+#[cfg(test)]
+mod tests {
+    use rstest::rstest;
+
+    use super::*;
+
+    #[rstest]
+    fn proof_fields_accessible() {
+        let journal = Bytes::from_static(b"journal-data");
+        let seal = Bytes::from_static(b"seal-data");
+
+        let proof = AttestationProof { output: journal.clone(), proof_bytes: seal.clone() };
+
+        assert_eq!(proof.output, journal);
+        assert_eq!(proof.proof_bytes, seal);
+    }
+
+    #[rstest]
+    fn proof_clone() {
+        let proof = AttestationProof {
+            output: Bytes::from_static(b"j"),
+            proof_bytes: Bytes::from_static(b"s"),
+        };
+        let cloned = proof.clone();
+
+        assert_eq!(proof.output, cloned.output);
+        assert_eq!(proof.proof_bytes, cloned.proof_bytes);
+    }
+
+    #[rstest]
+    fn proof_debug_format() {
+        let proof = AttestationProof { output: Bytes::new(), proof_bytes: Bytes::new() };
+        // Ensure Debug is implemented and doesn't panic.
+        let debug = format!("{proof:?}");
+        assert!(debug.contains("AttestationProof"));
+    }
+}

--- a/deny.toml
+++ b/deny.toml
@@ -186,6 +186,19 @@ skip = [
 
     "half",
     "memoffset",
+
+    # risc0/boundless transitive dependency mismatches
+    "alloy-hardforks",
+    "cargo-platform",
+    "cargo_metadata",
+    "foreign-types",
+    "foreign-types-shared",
+    "num-bigint",
+    "pastey",
+    "ringbuffer",
+    "tracing-subscriber",
+    "wasm-streams",
+    "zip",
 ]
 
 [sources]

--- a/deny.toml
+++ b/deny.toml
@@ -199,6 +199,10 @@ skip = [
     "tracing-subscriber",
     "wasm-streams",
     "zip",
+    "addr2line",
+    "embedded-io",
+    "gimli",
+    "object",
 ]
 
 [sources]


### PR DESCRIPTION
## Summary

- Adds `base-proof-tee-nitro-attestation-prover` crate wrapping `base-proof-tee-nitro-verifier` verification logic inside a RISC Zero ZK guest program with two proving backends:
  - **`DirectProver`** — uses `risc0_zkvm::default_prover()` (Bonsai remote / dev-mode)
  - **`BoundlessProver`** — submits proof requests to the Boundless marketplace
- Defines the `AttestationProofProvider` trait and `AttestationProof` type that CHAIN-3561 will wire into the registrar
- Guest ELF loaded at runtime (not embedded via `build.rs`) so the risc0 toolchain is not required for CI/dev builds

## Test plan

- [x] `cargo +nightly fmt --check` passes
- [x] `cargo clippy --tests -- -D warnings` passes (zero warnings)
- [x] `cargo test --lib` — 22 unit tests pass (error variants, image ID rejection, config construction, Debug key redaction)
- [ ] Integration test with `RISC0_DEV_MODE=1` and compiled guest ELF (requires risc0 toolchain)
- [ ] End-to-end Boundless marketplace test on testnet