### PR TITLE
fix(broadcast): handle non-RPC broadcast errors without panic in mempool rebroadcaster

### DIFF
--- a/crates/infra/mempool-rebroadcaster/src/rebroadcaster.rs
+++ b/crates/infra/mempool-rebroadcaster/src/rebroadcaster.rs
@@ -112,8 +112,11 @@ impl Rebroadcaster {
                 .await;
 
             if let Err(e) = result {
-                let err_msg = e.as_error_resp().unwrap().message.to_string();
-                if !IGNORED_ERRORS.contains(&err_msg.as_str()) {
+                let err_msg = e
+                    .as_error_resp()
+                    .map(|resp| resp.message.to_ascii_lowercase())
+                    .unwrap_or_else(|| e.to_string().to_ascii_lowercase());
+                if !IGNORED_ERRORS.iter().any(|ignored| err_msg.contains(ignored)) {
                     output.unexpected_failed_geth_to_reth += 1;
                     error!(
                         tx = ?hash,
@@ -138,8 +141,11 @@ impl Rebroadcaster {
                 .await;
 
             if let Err(e) = result {
-                let err_msg = e.as_error_resp().unwrap().message.to_string();
-                if !IGNORED_ERRORS.contains(&err_msg.as_str()) {
+                let err_msg = e
+                    .as_error_resp()
+                    .map(|resp| resp.message.to_ascii_lowercase())
+                    .unwrap_or_else(|| e.to_string().to_ascii_lowercase());
+                if !IGNORED_ERRORS.iter().any(|ignored| err_msg.contains(ignored)) {
                     output.unexpected_failed_reth_to_geth += 1;
                     error!(
                         tx = ?hash,


### PR DESCRIPTION
## Summary

This PR fixes a runtime error path in `mempool-rebroadcaster` when rebroadcasting transactions between nodes.

Previously, the rebroadcast loop called `e.as_error_resp().unwrap()` on send failures.  
For non-RPC errors (e.g. transport/network failures), this can panic and terminate the run.

## What changed

- Replaced `as_error_resp().unwrap()` with safe handling:
  - use RPC message when available
  - fallback to `e.to_string()` otherwise
- Normalized error text to lowercase
- Switched ignored-error matching from exact equality to substring matching for robust classification

## Impact

- Prevents panic on non-RPC provider errors
- Keeps rebroadcast cycle resilient under transient network failures
- Preserves existing behavior for known ignorable errors
