### PR TITLE
feat(bundle): wire bundle validation, RPC, and maintenance into node

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -7,6 +7,9 @@ max-threads = 1
 [test-groups.builder-integration]
 max-threads = 1
 
+[test-groups.devnet]
+max-threads = 1
+
 [[profile.default.overrides]]
 filter = 'test(system_test_)'
 test-group = 'system-test-serial'
@@ -17,6 +20,13 @@ filter = 'binary(e2e_testsuite)'
 test-group = 'e2e-tests'
 
 [[profile.default.overrides]]
-filter = 'package(base-builder-core) & (binary(data_availability) | binary(flashblocks) | binary(txpool))'
+filter = 'package(base-builder-core) & (binary(data_availability) | binary(flashblocks) | binary(txpool) | binary(bundles))'
 test-group = 'builder-integration'
 retries = 1
+
+[[profile.default.overrides]]
+filter = 'package(devnet)'
+test-group = 'devnet'
+retries = 1
+slow-timeout = { period = "120s", terminate-after = 3 }
+

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3036,6 +3036,7 @@ dependencies = [
  "base-node-runner",
  "base-txpool",
  "reth-chain-state",
+ "reth-provider",
  "tokio",
  "tokio-stream",
  "tracing",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3038,7 +3038,6 @@ dependencies = [
  "reth-chain-state",
  "tokio",
  "tokio-stream",
- "tokio-util",
  "tracing",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3030,6 +3030,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "base-bundle-extension"
+version = "0.0.0"
+dependencies = [
+ "base-node-runner",
+ "base-txpool",
+ "reth-chain-state",
+ "tokio",
+ "tokio-stream",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "base-bundles"
 version = "0.0.0"
 dependencies = [
@@ -4849,6 +4862,7 @@ dependencies = [
 name = "base-reth-node"
 version = "0.0.0"
 dependencies = [
+ "base-bundle-extension",
  "base-cli-utils",
  "base-execution-cli",
  "base-flashblocks",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7136,6 +7136,7 @@ dependencies = [
  "base-alloy-rpc-types",
  "base-batcher-service",
  "base-builder-core",
+ "base-bundle-extension",
  "base-consensus-disc",
  "base-consensus-genesis",
  "base-consensus-gossip",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -177,6 +177,7 @@ base-builder-publish = { path = "crates/builder/publish" }
 base-builder-metering = { path = "crates/builder/metering" }
 
 # Client
+base-bundle-extension = { path = "crates/client/bundle" }
 base-client-cli = { path = "crates/client/cli" }
 base-metering = { path = "crates/client/metering" }
 base-tx-forwarding = { path = "crates/client/tx-forwarding" }

--- a/bin/node/Cargo.toml
+++ b/bin/node/Cargo.toml
@@ -26,6 +26,7 @@ base-tx-forwarding.workspace = true
 base-txpool-tracing.workspace = true
 base-flashblocks-node.workspace = true
 base-proofs-extension.workspace = true
+base-bundle-extension.workspace = true
 
 # reth
 base-node-core.workspace = true

--- a/bin/node/src/main.rs
+++ b/bin/node/src/main.rs
@@ -5,6 +5,7 @@
 
 pub mod cli;
 
+use base_bundle_extension::BundleExtension;
 use base_execution_cli::{Cli, chainspec::OpChainSpecParser};
 use base_flashblocks::FlashblocksConfig;
 use base_flashblocks_node::FlashblocksExtension;
@@ -60,6 +61,7 @@ fn main() {
             MeteringConfig::disabled()
         };
         runner.install_ext::<MeteringExtension>(metering_config);
+        runner.install_ext::<BundleExtension>(());
         runner.install_ext::<TxForwardingExtension>((&args).into());
         runner.install_ext::<FlashblocksExtension>(flashblocks_config);
         runner.install_ext::<ProofsHistoryExtension>(args.rollup_args);

--- a/crates/builder/core/src/flashblocks/context.rs
+++ b/crates/builder/core/src/flashblocks/context.rs
@@ -484,7 +484,6 @@ impl OpPayloadBuilderCtx {
         let block_timestamp = self.attributes().timestamp();
 
         while let Some(tx) = best_txs.next(()) {
-
             if let Some(target) = tx.target_block_number()
                 && target != block_number
             {

--- a/crates/builder/core/src/flashblocks/context.rs
+++ b/crates/builder/core/src/flashblocks/context.rs
@@ -516,8 +516,9 @@ impl OpPayloadBuilderCtx {
                     tx_hash = ?tx.hash(),
                     block = block_number,
                     timestamp = block_timestamp,
-                    "deferring bundle tx: not yet valid"
+                    "skipping bundle tx: not yet valid"
                 );
+                best_txs.mark_invalid(tx.sender(), tx.nonce());
                 continue;
             }
 

--- a/crates/builder/core/src/flashblocks/context.rs
+++ b/crates/builder/core/src/flashblocks/context.rs
@@ -16,7 +16,7 @@ use base_execution_payload_builder::error::OpPayloadBuilderError;
 use base_execution_primitives::{OpReceipt, OpTransactionSigned};
 use base_node_core::OpPayloadBuilderAttributes;
 use base_revm::{L1BlockInfo, OpSpecId};
-use base_txpool::estimated_da_size::DataAvailabilitySized;
+use base_txpool::{BundleTransaction, estimated_da_size::DataAvailabilitySized};
 use reth_basic_payload_builder::PayloadConfig;
 use reth_chainspec::{EthChainSpec, EthereumHardforks};
 use reth_evm::{
@@ -481,6 +481,47 @@ impl OpPayloadBuilderCtx {
         );
 
         while let Some(tx) = best_txs.next(()) {
+            // Skip bundle transactions that are not valid for this block.
+            let block_number = as_u64_saturated!(self.evm_env.block_env.number);
+            let block_timestamp = self.attributes().timestamp();
+
+            if let Some(target) = tx.target_block_number()
+                && target != block_number
+            {
+                trace!(
+                    target: "payload_builder",
+                    tx_hash = ?tx.hash(),
+                    target_block = target,
+                    current_block = block_number,
+                    "skipping bundle tx: wrong target block"
+                );
+                best_txs.mark_invalid(tx.sender(), tx.nonce());
+                continue;
+            }
+
+            if tx.is_bundle_expired(block_number, block_timestamp) {
+                trace!(
+                    target: "payload_builder",
+                    tx_hash = ?tx.hash(),
+                    block = block_number,
+                    timestamp = block_timestamp,
+                    "skipping bundle tx: expired"
+                );
+                best_txs.mark_invalid(tx.sender(), tx.nonce());
+                continue;
+            }
+
+            if tx.is_bundle_not_yet_valid(block_timestamp) {
+                trace!(
+                    target: "payload_builder",
+                    tx_hash = ?tx.hash(),
+                    block = block_number,
+                    timestamp = block_timestamp,
+                    "deferring bundle tx: not yet valid"
+                );
+                continue;
+            }
+
             let tx_da_size = tx.estimated_da_size();
             let tx = tx.into_consensus();
             let tx_hash = tx.tx_hash();

--- a/crates/builder/core/src/flashblocks/context.rs
+++ b/crates/builder/core/src/flashblocks/context.rs
@@ -480,10 +480,10 @@ impl OpPayloadBuilderCtx {
             execution_metering_mode = ?self.builder_config.execution_metering_mode,
         );
 
+        let block_number = as_u64_saturated!(self.evm_env.block_env.number);
+        let block_timestamp = self.attributes().timestamp();
+
         while let Some(tx) = best_txs.next(()) {
-            // Skip bundle transactions that are not valid for this block.
-            let block_number = as_u64_saturated!(self.evm_env.block_env.number);
-            let block_timestamp = self.attributes().timestamp();
 
             if let Some(target) = tx.target_block_number()
                 && target != block_number

--- a/crates/builder/core/src/test_utils/instance.rs
+++ b/crates/builder/core/src/test_utils/instance.rs
@@ -10,6 +10,7 @@ use std::sync::{Arc, LazyLock};
 
 use alloy_primitives::B256;
 use alloy_provider::{Identity, ProviderBuilder, RootProvider};
+use async_trait::async_trait;
 use base_alloy_flashblocks::FlashblocksPayloadV1;
 use base_alloy_network::Base;
 use base_execution_chainspec::OpChainSpec;
@@ -65,8 +66,37 @@ pub struct LocalInstance {
     runtime: Option<Runtime>,
     exit_future: NodeExitFuture,
     _node_handle: Box<dyn Any + Send>,
+    pool_handle: Arc<dyn ExternalTransactionPool>,
     pool_observer: TransactionPoolObserver,
     metering_provider: SharedMeteringProvider,
+}
+
+struct PoolHandle<P> {
+    pool: P,
+}
+
+impl<P: core::fmt::Debug> core::fmt::Debug for PoolHandle<P> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("PoolHandle").field("pool", &self.pool).finish()
+    }
+}
+
+#[async_trait]
+pub trait ExternalTransactionPool: Send + Sync + core::fmt::Debug {
+    async fn add_external_transaction(&self, tx: BasePooledTransaction) -> eyre::Result<()>;
+}
+
+#[async_trait]
+impl<P> ExternalTransactionPool for PoolHandle<P>
+where
+    P: TransactionPool<Transaction = BasePooledTransaction> + Send + Sync + core::fmt::Debug,
+{
+    async fn add_external_transaction(&self, tx: BasePooledTransaction) -> eyre::Result<()> {
+        TransactionPool::add_external_transaction(&self.pool, tx)
+            .await
+            .map(|_| ())
+            .map_err(|err| eyre::eyre!("pool rejected transaction: {err}"))
+    }
 }
 
 impl LocalInstance {
@@ -96,6 +126,8 @@ impl LocalInstance {
         let (rpc_ready_tx, rpc_ready_rx) = oneshot::channel::<()>();
         let (txpool_ready_tx, txpool_ready_rx) =
             oneshot::channel::<AllTransactionsEvents<BasePooledTransaction>>();
+        let (pool_handle_tx, pool_handle_rx) =
+            oneshot::channel::<Arc<dyn ExternalTransactionPool>>();
 
         let da_config = builder_config.da_config.clone();
         let gas_limit_config = builder_config.gas_limit_config.clone();
@@ -128,6 +160,10 @@ impl LocalInstance {
                     .send(ctx.pool.all_transactions_event_listener())
                     .expect("Failed to send txpool ready signal");
 
+                let pool_handle: Arc<dyn ExternalTransactionPool> =
+                    Arc::new(PoolHandle { pool: ctx.pool });
+                pool_handle_tx.send(pool_handle).expect("Failed to send pool handle");
+
                 Ok(())
             });
 
@@ -139,12 +175,14 @@ impl LocalInstance {
         // Wait for all required components to be ready
         rpc_ready_rx.await.expect("Failed to receive ready signal");
         let pool_monitor = txpool_ready_rx.await.expect("Failed to receive txpool ready signal");
+        let pool_handle = pool_handle_rx.await.expect("Failed to receive pool handle");
 
         Ok(Self {
             builder_config,
             node_config,
             exit_future,
             _node_handle: node_handle,
+            pool_handle,
             runtime: Some(runtime),
             pool_observer: TransactionPoolObserver::new(pool_monitor),
             metering_provider,
@@ -195,6 +233,10 @@ impl LocalInstance {
 
     pub const fn pool(&self) -> &TransactionPoolObserver {
         &self.pool_observer
+    }
+
+    pub fn pool_handle(&self) -> Arc<dyn ExternalTransactionPool> {
+        Arc::clone(&self.pool_handle)
     }
 
     pub fn metering_provider(&self) -> &SharedMeteringProvider {

--- a/crates/builder/core/src/traits.rs
+++ b/crates/builder/core/src/traits.rs
@@ -4,7 +4,7 @@ use alloy_consensus::Header;
 use base_execution_chainspec::OpChainSpec;
 use base_execution_primitives::{OpPrimitives, OpTransactionSigned};
 use base_node_core::OpEngineTypes;
-use base_txpool::OpPooledTx;
+use base_txpool::{BundleTransaction, OpPooledTx};
 use reth_node_api::{FullNodeTypes, NodeTypes};
 use reth_payload_util::PayloadTransactions;
 use reth_provider::{BlockReaderIdExt, ChainSpecProvider, StateProviderFactory};
@@ -29,22 +29,23 @@ impl<T> NodeBounds for T where
 }
 
 pub trait PoolBounds:
-    TransactionPool<Transaction: OpPooledTx<Consensus = OpTransactionSigned>>
+    TransactionPool<Transaction: OpPooledTx<Consensus = OpTransactionSigned> + BundleTransaction>
     + TransactionPoolExt
     + Unpin
     + 'static
 where
-    <Self as TransactionPool>::Transaction: OpPooledTx,
+    <Self as TransactionPool>::Transaction: OpPooledTx + BundleTransaction,
 {
 }
 
 impl<T> PoolBounds for T
 where
-    T: TransactionPool<Transaction: OpPooledTx<Consensus = OpTransactionSigned>>
-        + TransactionPoolExt
+    T: TransactionPool<
+            Transaction: OpPooledTx<Consensus = OpTransactionSigned> + BundleTransaction,
+        > + TransactionPoolExt
         + Unpin
         + 'static,
-    <Self as TransactionPool>::Transaction: OpPooledTx,
+    <Self as TransactionPool>::Transaction: OpPooledTx + BundleTransaction,
 {
 }
 
@@ -65,11 +66,13 @@ impl<T> ClientBounds for T where
 }
 
 pub trait PayloadTxsBounds:
-    PayloadTransactions<Transaction: OpPooledTx<Consensus = OpTransactionSigned>>
+    PayloadTransactions<Transaction: OpPooledTx<Consensus = OpTransactionSigned> + BundleTransaction>
 {
 }
 
 impl<T> PayloadTxsBounds for T where
-    T: PayloadTransactions<Transaction: OpPooledTx<Consensus = OpTransactionSigned>>
+    T: PayloadTransactions<
+        Transaction: OpPooledTx<Consensus = OpTransactionSigned> + BundleTransaction,
+    >
 {
 }

--- a/crates/builder/core/tests/bundles.rs
+++ b/crates/builder/core/tests/bundles.rs
@@ -18,8 +18,32 @@ async fn insert_bundle_transaction<P: Protocol>(
     min_timestamp: Option<u64>,
     max_timestamp: Option<u64>,
 ) -> eyre::Result<TxHash> {
-    let recovered =
-        driver.create_transaction().with_signer(signer).random_valid_transfer().build().await;
+    insert_bundle_transaction_with_nonce(
+        pool,
+        driver,
+        signer,
+        None,
+        target_block_number,
+        min_timestamp,
+        max_timestamp,
+    )
+    .await
+}
+
+async fn insert_bundle_transaction_with_nonce<P: Protocol>(
+    pool: &Arc<dyn ExternalTransactionPool>,
+    driver: &ChainDriver<P>,
+    signer: &PrivateKeySigner,
+    nonce: Option<u64>,
+    target_block_number: Option<u64>,
+    min_timestamp: Option<u64>,
+    max_timestamp: Option<u64>,
+) -> eyre::Result<TxHash> {
+    let mut builder = driver.create_transaction().with_signer(signer).random_valid_transfer();
+    if let Some(n) = nonce {
+        builder = builder.with_nonce(n);
+    }
+    let recovered = builder.build().await;
     let tx_hash = TxHash::from(*recovered.tx_hash());
     let encoded_len = recovered.encode_2718_len();
     let pool_tx = BasePooledTransaction::new(recovered, encoded_len).with_bundle_metadata(
@@ -122,5 +146,92 @@ async fn normal_transaction_is_unaffected_by_bundle_checks() -> eyre::Result<()>
     let tx_hash = *tx.tx_hash();
 
     assert!(block.transactions.hashes().any(|hash| hash == tx_hash));
+    Ok(())
+}
+
+#[tokio::test]
+async fn two_valid_bundles_from_same_sender_are_both_included() -> eyre::Result<()> {
+    let rbuilder = setup_test_instance().await?;
+    let driver = rbuilder.driver().await?;
+    let signer = driver.fund_accounts(1, ONE_ETH).await?.remove(0);
+    let latest = driver.latest().await?;
+    let target_block = latest.header.number + 1;
+    let pool = rbuilder.pool_handle();
+
+    let tx_hash_0 = insert_bundle_transaction_with_nonce(
+        &pool,
+        &driver,
+        &signer,
+        Some(0),
+        Some(target_block),
+        None,
+        None,
+    )
+    .await?;
+
+    let tx_hash_1 = insert_bundle_transaction_with_nonce(
+        &pool,
+        &driver,
+        &signer,
+        Some(1),
+        Some(target_block),
+        None,
+        None,
+    )
+    .await?;
+
+    let block = driver.build_new_block_with_current_timestamp(None).await?;
+
+    assert_eq!(block.header.number, target_block);
+    assert!(block.transactions.hashes().any(|hash| hash == tx_hash_0));
+    assert!(block.transactions.hashes().any(|hash| hash == tx_hash_1));
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn valid_and_invalid_bundle_from_same_sender() -> eyre::Result<()> {
+    let rbuilder = setup_test_instance().await?;
+    let driver = rbuilder.driver().await?;
+    let signer = driver.fund_accounts(1, ONE_ETH).await?.remove(0);
+    let latest = driver.latest().await?;
+    let target_block = latest.header.number + 1;
+    let wrong_target = target_block + 5;
+    let pool = rbuilder.pool_handle();
+
+    let valid_tx_hash = insert_bundle_transaction_with_nonce(
+        &pool,
+        &driver,
+        &signer,
+        Some(0),
+        Some(target_block),
+        None,
+        None,
+    )
+    .await?;
+
+    let invalid_tx_hash = insert_bundle_transaction_with_nonce(
+        &pool,
+        &driver,
+        &signer,
+        Some(1),
+        Some(wrong_target),
+        None,
+        None,
+    )
+    .await?;
+
+    let block = driver.build_new_block_with_current_timestamp(None).await?;
+
+    assert_eq!(block.header.number, target_block);
+    assert!(
+        block.transactions.hashes().any(|hash| hash == valid_tx_hash),
+        "valid bundle tx should be included"
+    );
+    assert!(
+        block.transactions.hashes().all(|hash| hash != invalid_tx_hash),
+        "wrong-target bundle tx should be excluded"
+    );
+
     Ok(())
 }

--- a/crates/builder/core/tests/bundles.rs
+++ b/crates/builder/core/tests/bundles.rs
@@ -1,0 +1,126 @@
+#![allow(missing_docs)]
+
+use std::sync::Arc;
+
+use alloy_eips::eip2718::Encodable2718;
+use alloy_primitives::TxHash;
+use base_builder_core::test_utils::{
+    ChainDriver, ChainDriverExt, ExternalTransactionPool, ONE_ETH, PrivateKeySigner, Protocol,
+    TransactionBuilderExt, setup_test_instance,
+};
+use base_txpool::{BasePooledTransaction, unix_time_millis};
+
+async fn insert_bundle_transaction<P: Protocol>(
+    pool: &Arc<dyn ExternalTransactionPool>,
+    driver: &ChainDriver<P>,
+    signer: &PrivateKeySigner,
+    target_block_number: Option<u64>,
+    min_timestamp: Option<u64>,
+    max_timestamp: Option<u64>,
+) -> eyre::Result<TxHash> {
+    let recovered =
+        driver.create_transaction().with_signer(signer).random_valid_transfer().build().await;
+    let tx_hash = TxHash::from(*recovered.tx_hash());
+    let encoded_len = recovered.encode_2718_len();
+    let pool_tx = BasePooledTransaction::new(recovered, encoded_len).with_bundle_metadata(
+        target_block_number,
+        min_timestamp,
+        max_timestamp,
+    );
+
+    pool.add_external_transaction(pool_tx).await?;
+
+    Ok(tx_hash)
+}
+
+#[tokio::test]
+async fn bundle_tx_targeting_current_block_is_included() -> eyre::Result<()> {
+    let rbuilder = setup_test_instance().await?;
+    let driver = rbuilder.driver().await?;
+    let signer = driver.fund_accounts(1, ONE_ETH).await?.remove(0);
+    let latest = driver.latest().await?;
+    let target_block = latest.header.number + 1;
+    let pool = rbuilder.pool_handle();
+
+    let tx_hash =
+        insert_bundle_transaction(&pool, &driver, &signer, Some(target_block), None, None).await?;
+
+    let block = driver.build_new_block_with_current_timestamp(None).await?;
+
+    assert_eq!(block.header.number, target_block);
+    assert!(block.transactions.hashes().any(|hash| hash == tx_hash));
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn bundle_tx_targeting_different_block_is_excluded() -> eyre::Result<()> {
+    let rbuilder = setup_test_instance().await?;
+    let driver = rbuilder.driver().await?;
+    let signer = driver.fund_accounts(1, ONE_ETH).await?.remove(0);
+    let latest = driver.latest().await?;
+    let target_block = latest.header.number + 2;
+    let pool = rbuilder.pool_handle();
+
+    let tx_hash =
+        insert_bundle_transaction(&pool, &driver, &signer, Some(target_block), None, None).await?;
+
+    let block = driver.build_new_block_with_current_timestamp(None).await?;
+
+    assert!(block.transactions.hashes().all(|hash| hash != tx_hash));
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn expired_bundle_tx_is_excluded() -> eyre::Result<()> {
+    let rbuilder = setup_test_instance().await?;
+    let driver = rbuilder.driver().await?;
+    let signer = driver.fund_accounts(1, ONE_ETH).await?.remove(0);
+    let pool = rbuilder.pool_handle();
+    let max_timestamp = unix_time_millis().saturating_sub(1_000) as u64;
+
+    let tx_hash =
+        insert_bundle_transaction(&pool, &driver, &signer, None, None, Some(max_timestamp)).await?;
+
+    let block = driver.build_new_block_with_current_timestamp(None).await?;
+
+    assert!(block.transactions.hashes().all(|hash| hash != tx_hash));
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn future_bundle_tx_is_deferred_but_not_invalidated() -> eyre::Result<()> {
+    let rbuilder = setup_test_instance().await?;
+    let driver = rbuilder.driver().await?;
+    let signer = driver.fund_accounts(1, ONE_ETH).await?.remove(0);
+    let pool = rbuilder.pool_handle();
+    let min_timestamp = unix_time_millis().saturating_add(60_000) as u64;
+
+    let tx_hash =
+        insert_bundle_transaction(&pool, &driver, &signer, None, Some(min_timestamp), None).await?;
+
+    let block = driver.build_new_block_with_current_timestamp(None).await?;
+
+    assert!(block.transactions.hashes().all(|hash| hash != tx_hash));
+    assert!(rbuilder.pool().exists(tx_hash));
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn normal_transaction_is_unaffected_by_bundle_checks() -> eyre::Result<()> {
+    let rbuilder = setup_test_instance().await?;
+    let driver = rbuilder.driver().await?;
+    let signer = driver.fund_accounts(1, ONE_ETH).await?.remove(0);
+
+    let tx =
+        driver.create_transaction().with_signer(&signer).random_valid_transfer().send().await?;
+
+    let block = driver.build_new_block_with_current_timestamp(None).await?;
+    let tx_hash = *tx.tx_hash();
+
+    assert!(block.transactions.hashes().any(|hash| hash == tx_hash));
+    Ok(())
+}

--- a/crates/builder/core/tests/bundles.rs
+++ b/crates/builder/core/tests/bundles.rs
@@ -190,14 +190,15 @@ async fn two_valid_bundles_from_same_sender_are_both_included() -> eyre::Result<
 }
 
 #[tokio::test]
-async fn valid_and_invalid_bundle_from_same_sender() -> eyre::Result<()> {
+async fn expired_bundle_excluded_while_valid_bundle_included_for_same_sender() -> eyre::Result<()> {
     let rbuilder = setup_test_instance().await?;
     let driver = rbuilder.driver().await?;
     let signer = driver.fund_accounts(1, ONE_ETH).await?.remove(0);
     let latest = driver.latest().await?;
     let target_block = latest.header.number + 1;
-    let wrong_target = target_block + 5;
     let pool = rbuilder.pool_handle();
+
+    let expired_timestamp = 1u64;
 
     let valid_tx_hash = insert_bundle_transaction_with_nonce(
         &pool,
@@ -210,14 +211,14 @@ async fn valid_and_invalid_bundle_from_same_sender() -> eyre::Result<()> {
     )
     .await?;
 
-    let invalid_tx_hash = insert_bundle_transaction_with_nonce(
+    let expired_tx_hash = insert_bundle_transaction_with_nonce(
         &pool,
         &driver,
         &signer,
         Some(1),
-        Some(wrong_target),
+        Some(target_block),
         None,
-        None,
+        Some(expired_timestamp),
     )
     .await?;
 
@@ -229,8 +230,8 @@ async fn valid_and_invalid_bundle_from_same_sender() -> eyre::Result<()> {
         "valid bundle tx should be included"
     );
     assert!(
-        block.transactions.hashes().all(|hash| hash != invalid_tx_hash),
-        "wrong-target bundle tx should be excluded"
+        block.transactions.hashes().all(|hash| hash != expired_tx_hash),
+        "expired bundle tx should be excluded"
     );
 
     Ok(())

--- a/crates/client/bundle/Cargo.toml
+++ b/crates/client/bundle/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "base-bundle-extension"
+description = "Bundle Extension for Base node"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+
+[dependencies]
+tokio = { workspace = true }
+base-txpool = { workspace = true }
+tracing = { workspace = true }
+tokio-stream = { workspace = true }
+reth-chain-state = { workspace = true }
+base-node-runner = { workspace = true }
+tokio-util = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/client/bundle/Cargo.toml
+++ b/crates/client/bundle/Cargo.toml
@@ -15,7 +15,6 @@ tracing = { workspace = true }
 tokio-stream = { workspace = true }
 reth-chain-state = { workspace = true }
 base-node-runner = { workspace = true }
-tokio-util = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/client/bundle/Cargo.toml
+++ b/crates/client/bundle/Cargo.toml
@@ -9,10 +9,12 @@ homepage.workspace = true
 repository.workspace = true
 
 [dependencies]
+# workspace
 tokio = { workspace = true }
-base-txpool = { workspace = true }
 tracing = { workspace = true }
+base-txpool = { workspace = true }
 tokio-stream = { workspace = true }
+reth-provider = { workspace = true }
 reth-chain-state = { workspace = true }
 base-node-runner = { workspace = true }
 

--- a/crates/client/bundle/README.md
+++ b/crates/client/bundle/README.md
@@ -1,0 +1,3 @@
+# base-bundle-extension
+
+Wires `eth_sendBundle` RPC support and bundle transaction lifecycle management.

--- a/crates/client/bundle/src/extension.rs
+++ b/crates/client/bundle/src/extension.rs
@@ -36,7 +36,10 @@ impl BaseNodeExtension for BundleExtension {
             let pool = ctx.pool().clone();
             let events = BroadcastStream::new(ctx.provider().subscribe_to_canonical_state());
 
-            tokio::spawn(maintain_bundle_transactions(pool, events, current_block_number));
+            ctx.task_executor.spawn_critical_task(
+                "bundle-maintenance",
+                maintain_bundle_transactions(pool, events, current_block_number),
+            );
             info!("Bundle maintenance task spawned");
             Ok(())
         })

--- a/crates/client/bundle/src/extension.rs
+++ b/crates/client/bundle/src/extension.rs
@@ -1,0 +1,46 @@
+//! Wires the `eth_sendBundle` RPC and bundle transaction maintenance task.
+
+use std::sync::{Arc, atomic::AtomicU64};
+
+use base_node_runner::{BaseNodeExtension, BaseRpcContext, FromExtensionConfig, NodeHooks};
+use base_txpool::{SendBundleApiImpl, SendBundleApiServer, maintain_bundle_transactions};
+use reth_chain_state::CanonStateSubscriptions;
+use tokio_stream::wrappers::BroadcastStream;
+use tokio_util::sync::CancellationToken;
+use tracing::info;
+
+/// Extension that enables `eth_sendBundle` RPC support and bundle lifecycle management.
+#[derive(Debug)]
+pub struct BundleExtension;
+
+impl FromExtensionConfig for BundleExtension {
+    type Config = ();
+
+    fn from_config(_config: Self::Config) -> Self {
+        Self
+    }
+}
+
+impl BaseNodeExtension for BundleExtension {
+    fn apply(self: Box<Self>, hooks: NodeHooks) -> NodeHooks {
+        let current_block_number = Arc::new(AtomicU64::new(0));
+        let block_number_for_rpc = Arc::clone(&current_block_number);
+
+        let hooks = hooks.add_rpc_module(move |ctx: &mut BaseRpcContext<'_>| {
+            let api = SendBundleApiImpl::new(ctx.pool().clone(), true, block_number_for_rpc);
+            ctx.modules.merge_configured(api.into_rpc())?;
+            info!("eth_sendBundle RPC enabled");
+            Ok(())
+        });
+
+        hooks.add_node_started_hook(move |ctx| {
+            let pool = ctx.pool().clone();
+            let cancel = CancellationToken::new();
+            let events = BroadcastStream::new(ctx.provider().subscribe_to_canonical_state());
+
+            tokio::spawn(maintain_bundle_transactions(pool, events, cancel, current_block_number));
+            info!("Bundle maintenance task spawned");
+            Ok(())
+        })
+    }
+}

--- a/crates/client/bundle/src/extension.rs
+++ b/crates/client/bundle/src/extension.rs
@@ -1,10 +1,14 @@
 //! Wires the `eth_sendBundle` RPC and bundle transaction maintenance task.
 
-use std::sync::{Arc, atomic::AtomicU64};
+use std::sync::{
+    Arc,
+    atomic::{AtomicU64, Ordering},
+};
 
 use base_node_runner::{BaseNodeExtension, BaseRpcContext, FromExtensionConfig, NodeHooks};
 use base_txpool::{SendBundleApiImpl, SendBundleApiServer, maintain_bundle_transactions};
 use reth_chain_state::CanonStateSubscriptions;
+use reth_provider::BlockNumReader;
 use tokio_stream::wrappers::BroadcastStream;
 use tracing::info;
 
@@ -33,6 +37,9 @@ impl BaseNodeExtension for BundleExtension {
         });
 
         hooks.add_node_started_hook(move |ctx| {
+            let latest = ctx.provider().best_block_number().unwrap_or(0);
+            current_block_number.store(latest, Ordering::Release);
+
             let pool = ctx.pool().clone();
             let events = BroadcastStream::new(ctx.provider().subscribe_to_canonical_state());
 

--- a/crates/client/bundle/src/extension.rs
+++ b/crates/client/bundle/src/extension.rs
@@ -6,7 +6,6 @@ use base_node_runner::{BaseNodeExtension, BaseRpcContext, FromExtensionConfig, N
 use base_txpool::{SendBundleApiImpl, SendBundleApiServer, maintain_bundle_transactions};
 use reth_chain_state::CanonStateSubscriptions;
 use tokio_stream::wrappers::BroadcastStream;
-use tokio_util::sync::CancellationToken;
 use tracing::info;
 
 /// Extension that enables `eth_sendBundle` RPC support and bundle lifecycle management.
@@ -35,10 +34,9 @@ impl BaseNodeExtension for BundleExtension {
 
         hooks.add_node_started_hook(move |ctx| {
             let pool = ctx.pool().clone();
-            let cancel = CancellationToken::new();
             let events = BroadcastStream::new(ctx.provider().subscribe_to_canonical_state());
 
-            tokio::spawn(maintain_bundle_transactions(pool, events, cancel, current_block_number));
+            tokio::spawn(maintain_bundle_transactions(pool, events, current_block_number));
             info!("Bundle maintenance task spawned");
             Ok(())
         })

--- a/crates/client/bundle/src/lib.rs
+++ b/crates/client/bundle/src/lib.rs
@@ -1,0 +1,4 @@
+#![doc = include_str!("../README.md")]
+
+mod extension;
+pub use extension::BundleExtension;

--- a/crates/txpool/src/bundle/maintain.rs
+++ b/crates/txpool/src/bundle/maintain.rs
@@ -1,3 +1,8 @@
+use std::sync::{
+    Arc,
+    atomic::{AtomicU64, Ordering},
+};
+
 use alloy_consensus::BlockHeader;
 use futures::StreamExt;
 use reth_provider::CanonStateNotification;
@@ -8,7 +13,8 @@ use tracing::{debug, trace, warn};
 
 use crate::transaction::BundleTransaction;
 
-/// Evicts expired bundle transactions from the pool on each new committed block.
+/// Evicts expired bundle transactions from the pool on each new committed block
+/// and keeps the shared `current_block_number` in sync with the chain tip.
 ///
 /// Transactions with `max_timestamp` before the block timestamp or
 /// `target_block_number` before the block number are removed.
@@ -20,6 +26,7 @@ pub async fn maintain_bundle_transactions<P, N>(
     pool: P,
     mut events: BroadcastStream<CanonStateNotification<N>>,
     cancel: CancellationToken,
+    current_block_number: Arc<AtomicU64>,
 ) where
     P: TransactionPool + 'static,
     P::Transaction: BundleTransaction,
@@ -43,6 +50,8 @@ pub async fn maintain_bundle_transactions<P, N>(
         let tip = notification.tip();
         let block_number = tip.number();
         let block_timestamp = tip.timestamp();
+
+        current_block_number.store(block_number, Ordering::Release);
 
         let expired: Vec<_> = pool
             .pooled_transactions()

--- a/crates/txpool/src/bundle/maintain.rs
+++ b/crates/txpool/src/bundle/maintain.rs
@@ -8,7 +8,6 @@ use futures::StreamExt;
 use reth_provider::CanonStateNotification;
 use reth_transaction_pool::TransactionPool;
 use tokio_stream::wrappers::BroadcastStream;
-use tokio_util::sync::CancellationToken;
 use tracing::{debug, trace, warn};
 
 use crate::transaction::BundleTransaction;
@@ -25,7 +24,6 @@ use crate::transaction::BundleTransaction;
 pub async fn maintain_bundle_transactions<P, N>(
     pool: P,
     mut events: BroadcastStream<CanonStateNotification<N>>,
-    cancel: CancellationToken,
     current_block_number: Arc<AtomicU64>,
 ) where
     P: TransactionPool + 'static,
@@ -33,18 +31,16 @@ pub async fn maintain_bundle_transactions<P, N>(
     N: reth_node_api::NodePrimitives,
 {
     loop {
-        let notification = tokio::select! {
-            _ = cancel.cancelled() => break,
-            maybe = events.next() => {
-                match maybe {
-                    Some(Ok(notification)) => notification,
-                    Some(Err(tokio_stream::wrappers::errors::BroadcastStreamRecvError::Lagged(n))) => {
-                        warn!(missed = n, "canon state stream lagged, some blocks were not checked for bundle expiry");
-                        continue;
-                    }
-                    None => break,
-                }
+        let notification = match events.next().await {
+            Some(Ok(notification)) => notification,
+            Some(Err(tokio_stream::wrappers::errors::BroadcastStreamRecvError::Lagged(n))) => {
+                warn!(
+                    missed = n,
+                    "canon state stream lagged, some blocks were not checked for bundle expiry"
+                );
+                continue;
             }
+            None => break,
         };
 
         let tip = notification.tip();

--- a/devnet/Cargo.toml
+++ b/devnet/Cargo.toml
@@ -19,6 +19,7 @@ base-txpool-rpc.workspace = true
 base-flashblocks.workspace = true
 base-tx-forwarding.workspace = true
 base-txpool-tracing.workspace = true
+base-bundle-extension.workspace = true
 base-flashblocks-node.workspace = true
 base-consensus-rpc = { workspace = true, features = ["client"] }
 base-protocol = { workspace = true, features = ["serde", "std"] }

--- a/devnet/src/l2/in_process_client.rs
+++ b/devnet/src/l2/in_process_client.rs
@@ -6,6 +6,7 @@ use std::{any::Any, net::SocketAddr, path::PathBuf, sync::Arc};
 
 use alloy_primitives::hex::ToHexExt;
 use alloy_rpc_types_engine::JwtSecret;
+use base_bundle_extension::BundleExtension;
 use base_execution_chainspec::OpChainSpec;
 use base_flashblocks::FlashblocksConfig;
 use base_flashblocks_node::FlashblocksExtension;
@@ -250,6 +251,9 @@ impl InProcessClient {
         let txpool_rpc_config =
             TxPoolRpcConfig { sequencer_rpc: Some(config.builder_rpc_url.clone()) };
         extensions.push(Box::new(TxPoolRpcExtension::from_config(txpool_rpc_config)));
+
+        // Bundle extension (eth_sendBundle RPC + maintenance task)
+        extensions.push(Box::new(BundleExtension::from_config(())));
 
         // TxPool tracing extension (tracing disabled for client)
         let txpool_config = TxpoolConfig {

--- a/devnet/tests/bundles.rs
+++ b/devnet/tests/bundles.rs
@@ -1,0 +1,337 @@
+//! End-to-end tests for `eth_sendBundle`.
+
+use std::time::Duration;
+
+use alloy_consensus::SignableTransaction;
+use alloy_eips::eip2718::Encodable2718;
+use alloy_primitives::{Address, B256, Bytes, U256};
+use alloy_provider::{Provider, RootProvider};
+use alloy_rpc_client::RpcClient;
+use alloy_signer::SignerSync;
+use alloy_signer_local::PrivateKeySigner;
+use base_alloy_network::{Base, TransactionBuilder};
+use base_alloy_rpc_types::OpTransactionRequest;
+use base_txpool::{MAX_BUNDLE_ADVANCE_BLOCKS, unix_time_millis};
+use devnet::{DevnetBuilder, config::ANVIL_ACCOUNT_1};
+use eyre::{Result, WrapErr};
+use tokio::time::{sleep, timeout};
+
+const L1_CHAIN_ID: u64 = 1337;
+const L2_CHAIN_ID: u64 = 84538453;
+const BLOCK_PRODUCTION_TIMEOUT: Duration = Duration::from_secs(30);
+const BLOCK_POLL_INTERVAL: Duration = Duration::from_millis(500);
+const TX_RECEIPT_TIMEOUT: Duration = Duration::from_secs(60);
+
+#[derive(Clone, Debug, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+struct BundleRequest {
+    txs: Vec<Bytes>,
+    block_number: Option<u64>,
+    min_timestamp: Option<u64>,
+    max_timestamp: Option<u64>,
+    reverting_tx_hashes: Option<Vec<B256>>,
+    replacement_uuid: Option<String>,
+    builders: Option<Vec<String>>,
+}
+
+fn create_signed_eip1559_tx(
+    signer: &PrivateKeySigner,
+    chain_id: u64,
+    nonce: u64,
+    recipient: Address,
+) -> Result<(Address, Bytes, B256)> {
+    let sender = signer.address();
+
+    let tx_request = OpTransactionRequest::default()
+        .from(sender)
+        .to(recipient)
+        .value(U256::from(1_000_000_000u64))
+        .transaction_type(2)
+        .with_gas_limit(21000)
+        .with_max_fee_per_gas(1_000_000_000)
+        .with_max_priority_fee_per_gas(1_000_000)
+        .with_chain_id(chain_id)
+        .with_nonce(nonce);
+
+    let tx = tx_request
+        .build_typed_tx()
+        .map_err(|e| eyre::eyre!("invalid transaction request: {e:?}"))?;
+    let signature = signer.sign_hash_sync(&tx.signature_hash())?;
+    let signed_tx = tx.into_signed(signature);
+    let tx_hash = *signed_tx.hash();
+    let raw_tx: Bytes = signed_tx.encoded_2718().into();
+
+    Ok((sender, raw_tx, tx_hash))
+}
+
+async fn wait_for_block(provider: &RootProvider<Base>, min_block: u64) -> Result<u64> {
+    let result = timeout(BLOCK_PRODUCTION_TIMEOUT, async {
+        loop {
+            let block = provider.get_block_number().await?;
+            if block >= min_block {
+                return Ok::<_, eyre::Error>(block);
+            }
+            sleep(BLOCK_POLL_INTERVAL).await;
+        }
+    })
+    .await
+    .wrap_err("Block production timed out")??;
+
+    Ok(result)
+}
+
+async fn wait_for_balance(provider: &RootProvider<Base>, address: Address) -> Result<()> {
+    timeout(Duration::from_secs(15), async {
+        loop {
+            let balance = provider.get_balance(address).await?;
+            if balance > U256::ZERO {
+                return Ok::<_, eyre::Error>(());
+            }
+            sleep(Duration::from_millis(500)).await;
+        }
+    })
+    .await
+    .wrap_err("Timed out waiting for balance")??;
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_send_bundle_accepts_valid_bundle() -> Result<()> {
+    let devnet = DevnetBuilder::new()
+        .with_l1_chain_id(L1_CHAIN_ID)
+        .with_l2_chain_id(L2_CHAIN_ID)
+        .build()
+        .await?;
+
+    let builder_provider = devnet.l2_builder_provider()?;
+    let client_provider = devnet.l2_client_provider()?;
+
+    wait_for_block(&builder_provider, 2).await?;
+    wait_for_block(&client_provider, 2).await?;
+
+    let private_key_hex = format!("0x{}", hex::encode(ANVIL_ACCOUNT_1.private_key.as_slice()));
+    let signer: PrivateKeySigner = private_key_hex.parse()?;
+    let sender = signer.address();
+
+    wait_for_balance(&client_provider, sender).await?;
+
+    let nonce = client_provider.get_transaction_count(sender).await?;
+    let recipient: Address = "0x000000000000000000000000000000000000dEaD".parse()?;
+    let (_, raw_tx, expected_tx_hash) =
+        create_signed_eip1559_tx(&signer, L2_CHAIN_ID, nonce, recipient)?;
+
+    let current_block = builder_provider.get_block_number().await?;
+    let target_block = current_block + 1;
+
+    let request = BundleRequest {
+        txs: vec![raw_tx],
+        block_number: Some(target_block),
+        min_timestamp: None,
+        max_timestamp: None,
+        reverting_tx_hashes: None,
+        replacement_uuid: None,
+        builders: None,
+    };
+
+    let rpc_client = RpcClient::builder().http(devnet.l2_client_rpc_url()?);
+    let bundle_hash: B256 = rpc_client.request("eth_sendBundle", (request,)).await?;
+    assert_eq!(bundle_hash, expected_tx_hash, "Bundle returned unexpected hash");
+
+    let receipt = timeout(TX_RECEIPT_TIMEOUT, async {
+        loop {
+            if let Some(receipt) =
+                builder_provider.get_transaction_receipt(expected_tx_hash).await?
+            {
+                return Ok::<_, eyre::Error>(receipt);
+            }
+            sleep(Duration::from_secs(1)).await;
+        }
+    })
+    .await
+    .wrap_err("Transaction receipt timed out")?
+    .wrap_err("Failed to get transaction receipt")?;
+
+    assert_eq!(receipt.inner.transaction_hash, expected_tx_hash);
+    assert_eq!(receipt.inner.block_number, Some(target_block));
+    assert_eq!(receipt.inner.from, sender);
+    assert_eq!(receipt.inner.to, Some(recipient));
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_send_bundle_rejects_invalid_bundle() -> Result<()> {
+    let devnet = DevnetBuilder::new()
+        .with_l1_chain_id(L1_CHAIN_ID)
+        .with_l2_chain_id(L2_CHAIN_ID)
+        .build()
+        .await?;
+
+    let client_provider = devnet.l2_client_provider()?;
+    wait_for_block(&client_provider, 2).await?;
+
+    let rpc_client = RpcClient::builder().http(devnet.l2_client_rpc_url()?);
+
+    let empty_request = BundleRequest {
+        txs: vec![],
+        block_number: None,
+        min_timestamp: None,
+        max_timestamp: None,
+        reverting_tx_hashes: None,
+        replacement_uuid: None,
+        builders: None,
+    };
+
+    let empty_result: Result<B256, _> =
+        rpc_client.request("eth_sendBundle", (empty_request,)).await;
+    let empty_err = empty_result.expect_err("Expected empty bundle to fail");
+    let empty_err_str = empty_err.to_string();
+    assert!(
+        empty_err_str.contains("exactly 1 transaction") || empty_err_str.contains("-32602"),
+        "Unexpected error for empty bundle: {empty_err_str}"
+    );
+
+    let current_block = client_provider.get_block_number().await?;
+    let far_block = current_block + MAX_BUNDLE_ADVANCE_BLOCKS + 1;
+    let far_request = BundleRequest {
+        txs: vec![Bytes::from_static(b"tx")],
+        block_number: Some(far_block),
+        min_timestamp: None,
+        max_timestamp: None,
+        reverting_tx_hashes: None,
+        replacement_uuid: None,
+        builders: None,
+    };
+
+    let far_result: Result<B256, _> = rpc_client.request("eth_sendBundle", (far_request,)).await;
+    let far_err = far_result.expect_err("Expected far-future block bundle to fail");
+    let far_err_str = far_err.to_string();
+    assert!(
+        far_err_str.contains("too far ahead") || far_err_str.contains("-32602"),
+        "Unexpected error for far-future bundle: {far_err_str}"
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_send_bundle_included_only_in_target_block() -> Result<()> {
+    let devnet = DevnetBuilder::new()
+        .with_l1_chain_id(L1_CHAIN_ID)
+        .with_l2_chain_id(L2_CHAIN_ID)
+        .build()
+        .await?;
+
+    let builder_provider = devnet.l2_builder_provider()?;
+    let client_provider = devnet.l2_client_provider()?;
+
+    wait_for_block(&builder_provider, 2).await?;
+    wait_for_block(&client_provider, 2).await?;
+
+    let private_key_hex = format!("0x{}", hex::encode(ANVIL_ACCOUNT_1.private_key.as_slice()));
+    let signer: PrivateKeySigner = private_key_hex.parse()?;
+    let sender = signer.address();
+
+    wait_for_balance(&client_provider, sender).await?;
+
+    let nonce = client_provider.get_transaction_count(sender).await?;
+    let recipient: Address = "0x000000000000000000000000000000000000bEEF".parse()?;
+    let (_, raw_tx, expected_tx_hash) =
+        create_signed_eip1559_tx(&signer, L2_CHAIN_ID, nonce, recipient)?;
+
+    let current_block = builder_provider.get_block_number().await?;
+    let target_block = current_block + 2;
+
+    let request = BundleRequest {
+        txs: vec![raw_tx],
+        block_number: Some(target_block),
+        min_timestamp: None,
+        max_timestamp: None,
+        reverting_tx_hashes: None,
+        replacement_uuid: None,
+        builders: None,
+    };
+
+    let rpc_client = RpcClient::builder().http(devnet.l2_client_rpc_url()?);
+    let bundle_hash: B256 = rpc_client.request("eth_sendBundle", (request,)).await?;
+    assert_eq!(bundle_hash, expected_tx_hash, "Bundle returned unexpected hash");
+
+    wait_for_block(&builder_provider, target_block - 1).await?;
+    let early_receipt = builder_provider.get_transaction_receipt(expected_tx_hash).await?;
+    assert!(early_receipt.is_none(), "Bundle tx should not be included before target block");
+
+    let receipt = timeout(TX_RECEIPT_TIMEOUT, async {
+        loop {
+            if let Some(receipt) =
+                builder_provider.get_transaction_receipt(expected_tx_hash).await?
+            {
+                return Ok::<_, eyre::Error>(receipt);
+            }
+            sleep(Duration::from_secs(1)).await;
+        }
+    })
+    .await
+    .wrap_err("Transaction receipt timed out")?
+    .wrap_err("Failed to get transaction receipt")?;
+
+    assert_eq!(receipt.inner.block_number, Some(target_block));
+    assert_eq!(receipt.inner.from, sender);
+    assert_eq!(receipt.inner.to, Some(recipient));
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_expired_bundle_is_not_included() -> Result<()> {
+    let devnet = DevnetBuilder::new()
+        .with_l1_chain_id(L1_CHAIN_ID)
+        .with_l2_chain_id(L2_CHAIN_ID)
+        .build()
+        .await?;
+
+    let builder_provider = devnet.l2_builder_provider()?;
+    let client_provider = devnet.l2_client_provider()?;
+
+    wait_for_block(&builder_provider, 2).await?;
+    wait_for_block(&client_provider, 2).await?;
+
+    let private_key_hex = format!("0x{}", hex::encode(ANVIL_ACCOUNT_1.private_key.as_slice()));
+    let signer: PrivateKeySigner = private_key_hex.parse()?;
+    let sender = signer.address();
+
+    wait_for_balance(&client_provider, sender).await?;
+
+    let nonce = client_provider.get_transaction_count(sender).await?;
+    let recipient: Address = "0x000000000000000000000000000000000000Cafe".parse()?;
+    let (_, raw_tx, expected_tx_hash) =
+        create_signed_eip1559_tx(&signer, L2_CHAIN_ID, nonce, recipient)?;
+
+    let current_block = builder_provider.get_block_number().await?;
+    let target_block = current_block + 2;
+    let max_timestamp = unix_time_millis() as u64 + 500;
+
+    let request = BundleRequest {
+        txs: vec![raw_tx],
+        block_number: Some(target_block),
+        min_timestamp: None,
+        max_timestamp: Some(max_timestamp),
+        reverting_tx_hashes: None,
+        replacement_uuid: None,
+        builders: None,
+    };
+
+    let rpc_client = RpcClient::builder().http(devnet.l2_client_rpc_url()?);
+    let bundle_hash: B256 = rpc_client.request("eth_sendBundle", (request,)).await?;
+    assert_eq!(bundle_hash, expected_tx_hash, "Bundle returned unexpected hash");
+
+    wait_for_block(&builder_provider, target_block + 1).await?;
+
+    for _ in 0..6 {
+        let receipt = builder_provider.get_transaction_receipt(expected_tx_hash).await?;
+        assert!(receipt.is_none(), "Expired bundle tx should not be included");
+        sleep(Duration::from_millis(500)).await;
+    }
+
+    Ok(())
+}

--- a/devnet/tests/bundles.rs
+++ b/devnet/tests/bundles.rs
@@ -11,6 +11,7 @@ use alloy_signer::SignerSync;
 use alloy_signer_local::PrivateKeySigner;
 use base_alloy_network::{Base, TransactionBuilder};
 use base_alloy_rpc_types::OpTransactionRequest;
+use base_tx_forwarding::TxForwardingConfig;
 use base_txpool::{MAX_BUNDLE_ADVANCE_BLOCKS, unix_time_millis};
 use devnet::{DevnetBuilder, config::ANVIL_ACCOUNT_1};
 use eyre::{Result, WrapErr};
@@ -101,6 +102,7 @@ async fn test_send_bundle_accepts_valid_bundle() -> Result<()> {
     let devnet = DevnetBuilder::new()
         .with_l1_chain_id(L1_CHAIN_ID)
         .with_l2_chain_id(L2_CHAIN_ID)
+        .with_tx_forwarding(TxForwardingConfig::new(vec![]))
         .build()
         .await?;
 
@@ -122,7 +124,9 @@ async fn test_send_bundle_accepts_valid_bundle() -> Result<()> {
         create_signed_eip1559_tx(&signer, L2_CHAIN_ID, nonce, recipient)?;
 
     let current_block = builder_provider.get_block_number().await?;
-    let target_block = current_block + 1;
+    // Use +3 to give enough lead time for the bundle to propagate from client
+    // to builder before the target block is built.
+    let target_block = current_block + 3;
 
     let request = BundleRequest {
         txs: vec![raw_tx],
@@ -165,6 +169,7 @@ async fn test_send_bundle_rejects_invalid_bundle() -> Result<()> {
     let devnet = DevnetBuilder::new()
         .with_l1_chain_id(L1_CHAIN_ID)
         .with_l2_chain_id(L2_CHAIN_ID)
+        .with_tx_forwarding(TxForwardingConfig::new(vec![]))
         .build()
         .await?;
 
@@ -220,6 +225,7 @@ async fn test_send_bundle_included_only_in_target_block() -> Result<()> {
     let devnet = DevnetBuilder::new()
         .with_l1_chain_id(L1_CHAIN_ID)
         .with_l2_chain_id(L2_CHAIN_ID)
+        .with_tx_forwarding(TxForwardingConfig::new(vec![]))
         .build()
         .await?;
 
@@ -287,6 +293,7 @@ async fn test_expired_bundle_is_not_included() -> Result<()> {
     let devnet = DevnetBuilder::new()
         .with_l1_chain_id(L1_CHAIN_ID)
         .with_l2_chain_id(L2_CHAIN_ID)
+        .with_tx_forwarding(TxForwardingConfig::new(vec![]))
         .build()
         .await?;
 


### PR DESCRIPTION
## Summary

Stacked on #1265. Wires the bundle transaction infrastructure into the builder and client nodes:

- **Builder validation**: Skip bundle txs during block building when target_block_number doesn't match, bundle is expired (max_timestamp), or not yet valid (min_timestamp). Not-yet-valid bundles are deferred without permanent invalidation.
- **Bundle extension**: New `base-bundle-extension` crate that registers `eth_sendBundle` RPC (always enabled, no config flags) and spawns the `maintain_bundle_transactions` background task.
- **Block number sync**: The maintenance task now updates the shared `current_block_number` AtomicU64 on each canonical block, keeping RPC validation accurate.

## Test Plan

**Builder integration tests** (5 tests in `crates/builder/core/tests/bundles.rs`):
- Bundle tx targeting current block is included
- Bundle tx targeting wrong block is excluded  
- Expired bundle tx is excluded
- Not-yet-valid bundle tx is deferred (stays in pool)
- Normal tx is unaffected by bundle checks

**Devnet e2e tests** (4 tests in `devnet/tests/bundles.rs`):
- Valid bundle accepted and included in target block
- Invalid bundles rejected (empty txs, block too far ahead)
- Bundle targets specific block number only
- Expired bundles cleaned up by maintenance task

`just check` passes (fmt, udeps, clippy, 3150 tests).