### PR TITLE
[backport] fix(consensus): Fix Admin API Error Codes And Parameter

### DIFF
--- a/crates/consensus/rpc/src/admin.rs
+++ b/crates/consensus/rpc/src/admin.rs
@@ -56,6 +56,11 @@ where
     }
 }
 
+/// Returns an RPC error indicating the sequencer is not available on this node.
+fn sequencer_unavailable() -> ErrorObject<'static> {
+    ErrorObject::owned(-32001, "sequencer not available on this node", None::<()>)
+}
+
 #[async_trait]
 impl<SequencerAdminAPIClient_> AdminApiServer for AdminRpc<SequencerAdminAPIClient_>
 where
@@ -65,6 +70,8 @@ where
         &self,
         payload: OpExecutionPayloadEnvelope,
     ) -> RpcResult<()> {
+        // Note: intentionally no sequencer guard here. Posting an unsafe payload is a P2P/gossip
+        // operation that is valid on both sequencer and validator nodes.
         base_macros::inc!(gauge, base_consensus_gossip::Metrics::RPC_CALLS, "method" => "admin_postUnsafePayload");
         self.network_sender
             .send(NetworkAdminQuery::PostUnsafePayload { payload })
@@ -75,7 +82,7 @@ where
     async fn admin_sequencer_active(&self) -> RpcResult<bool> {
         // If the sequencer is not enabled (mode runs in validator mode), return an error.
         let Some(ref sequencer_client) = self.sequencer_admin_client else {
-            return Err(ErrorObject::from(ErrorCode::MethodNotFound));
+            return Err(sequencer_unavailable());
         };
 
         sequencer_client
@@ -84,14 +91,14 @@ where
             .map_err(|_| ErrorObject::from(ErrorCode::InternalError))
     }
 
-    async fn admin_start_sequencer(&self) -> RpcResult<()> {
+    async fn admin_start_sequencer(&self, unsafe_head: B256) -> RpcResult<()> {
         // If the sequencer is not enabled (mode runs in validator mode), return an error.
         let Some(ref sequencer_client) = self.sequencer_admin_client else {
-            return Err(ErrorObject::from(ErrorCode::MethodNotFound));
+            return Err(sequencer_unavailable());
         };
 
         sequencer_client
-            .start_sequencer()
+            .start_sequencer(unsafe_head)
             .await
             .map_err(|_| ErrorObject::from(ErrorCode::InternalError))
     }
@@ -99,7 +106,7 @@ where
     async fn admin_stop_sequencer(&self) -> RpcResult<B256> {
         // If the sequencer is not enabled (mode runs in validator mode), return an error.
         let Some(ref sequencer_client) = self.sequencer_admin_client else {
-            return Err(ErrorObject::from(ErrorCode::MethodNotFound));
+            return Err(sequencer_unavailable());
         };
 
         sequencer_client
@@ -111,7 +118,7 @@ where
     async fn admin_conductor_enabled(&self) -> RpcResult<bool> {
         // If the sequencer is not enabled (mode runs in validator mode), return an error.
         let Some(ref sequencer_client) = self.sequencer_admin_client else {
-            return Err(ErrorObject::from(ErrorCode::MethodNotFound));
+            return Err(sequencer_unavailable());
         };
 
         sequencer_client
@@ -123,7 +130,7 @@ where
     async fn admin_recover_mode(&self) -> RpcResult<bool> {
         // If the sequencer is not enabled (mode runs in validator mode), return an error.
         let Some(ref sequencer_client) = self.sequencer_admin_client else {
-            return Err(ErrorObject::from(ErrorCode::MethodNotFound));
+            return Err(sequencer_unavailable());
         };
 
         sequencer_client
@@ -135,7 +142,7 @@ where
     async fn admin_set_recover_mode(&self, mode: bool) -> RpcResult<()> {
         // If the sequencer is not enabled (mode runs in validator mode), return an error.
         let Some(ref sequencer_client) = self.sequencer_admin_client else {
-            return Err(ErrorObject::from(ErrorCode::MethodNotFound));
+            return Err(sequencer_unavailable());
         };
 
         sequencer_client
@@ -147,7 +154,7 @@ where
     async fn admin_override_leader(&self) -> RpcResult<()> {
         // If the sequencer is not enabled (mode runs in validator mode), return an error.
         let Some(ref sequencer_client) = self.sequencer_admin_client else {
-            return Err(ErrorObject::from(ErrorCode::MethodNotFound));
+            return Err(sequencer_unavailable());
         };
 
         sequencer_client
@@ -159,7 +166,7 @@ where
     async fn admin_reset_derivation_pipeline(&self) -> RpcResult<()> {
         // If the sequencer is not enabled (mode runs in validator mode), return an error.
         let Some(ref sequencer_client) = self.sequencer_admin_client else {
-            return Err(ErrorObject::from(ErrorCode::MethodNotFound));
+            return Err(sequencer_unavailable());
         };
 
         sequencer_client

--- a/crates/consensus/rpc/src/client.rs
+++ b/crates/consensus/rpc/src/client.rs
@@ -48,7 +48,7 @@ pub trait SequencerAdminAPIClient: Send + Sync + Debug {
     async fn is_recovery_mode(&self) -> Result<bool, SequencerAdminAPIError>;
 
     /// Start the sequencer.
-    async fn start_sequencer(&self) -> Result<(), SequencerAdminAPIError>;
+    async fn start_sequencer(&self, unsafe_head: B256) -> Result<(), SequencerAdminAPIError>;
 
     /// Stop the sequencer.
     async fn stop_sequencer(&self) -> Result<B256, SequencerAdminAPIError>;

--- a/crates/consensus/rpc/src/jsonrpsee.rs
+++ b/crates/consensus/rpc/src/jsonrpsee.rs
@@ -177,7 +177,7 @@ pub trait AdminApi {
 
     /// Starts the sequencer.
     #[method(name = "startSequencer")]
-    async fn admin_start_sequencer(&self) -> RpcResult<()>;
+    async fn admin_start_sequencer(&self, unsafe_head: B256) -> RpcResult<()>;
 
     /// Stops the sequencer.
     #[method(name = "stopSequencer")]

--- a/crates/consensus/service/src/actors/rpc/sequencer_rpc_client.rs
+++ b/crates/consensus/service/src/actors/rpc/sequencer_rpc_client.rs
@@ -46,12 +46,12 @@ impl SequencerAdminAPIClient for QueuedSequencerAdminAPIClient {
         rx.await.map_err(|_| SequencerAdminAPIError::ResponseError)?
     }
 
-    async fn start_sequencer(&self) -> Result<(), SequencerAdminAPIError> {
+    async fn start_sequencer(&self, unsafe_head: B256) -> Result<(), SequencerAdminAPIError> {
         let (tx, rx) = oneshot::channel();
 
-        self.request_tx.send(SequencerAdminQuery::StartSequencer(tx)).await.map_err(|_| {
-            SequencerAdminAPIError::RequestError("request channel closed".to_string())
-        })?;
+        self.request_tx.send(SequencerAdminQuery::StartSequencer(unsafe_head, tx)).await.map_err(
+            |_| SequencerAdminAPIError::RequestError("request channel closed".to_string()),
+        )?;
         rx.await.map_err(|_| SequencerAdminAPIError::ResponseError)?
     }
 

--- a/crates/consensus/service/src/actors/sequencer/admin_api_impl.rs
+++ b/crates/consensus/service/src/actors/sequencer/admin_api_impl.rs
@@ -12,7 +12,7 @@ pub enum SequencerAdminQuery {
     /// A query to check if the sequencer is active.
     SequencerActive(oneshot::Sender<Result<bool, SequencerAdminAPIError>>),
     /// A query to start the sequencer.
-    StartSequencer(oneshot::Sender<Result<(), SequencerAdminAPIError>>),
+    StartSequencer(B256, oneshot::Sender<Result<(), SequencerAdminAPIError>>),
     /// A query to stop the sequencer.
     StopSequencer(oneshot::Sender<Result<B256, SequencerAdminAPIError>>),
     /// A query to check if the conductor is enabled.
@@ -58,8 +58,8 @@ where
                     warn!(target: "sequencer", "Failed to send response for is_sequencer_active query");
                 }
             }
-            SequencerAdminQuery::StartSequencer(tx) => {
-                if tx.send(self.start_sequencer().await).is_err() {
+            SequencerAdminQuery::StartSequencer(unsafe_head, tx) => {
+                if tx.send(self.start_sequencer(unsafe_head).await).is_err() {
                     warn!(target: "sequencer", "Failed to send response for start_sequencer query");
                 }
             }
@@ -112,13 +112,22 @@ where
     }
 
     /// Starts the sequencer in an idempotent fashion.
-    pub(super) async fn start_sequencer(&mut self) -> Result<(), SequencerAdminAPIError> {
+    ///
+    /// `unsafe_head` identifies the block the caller intends to start sequencing from.
+    /// Note: the forkchoice update to `unsafe_head` is not yet implemented (see TODO in body).
+    pub(super) async fn start_sequencer(
+        &mut self,
+        unsafe_head: B256,
+    ) -> Result<(), SequencerAdminAPIError> {
         if self.is_active {
-            info!(target: "sequencer", "received request to start sequencer, but it is already started");
+            info!(target: "sequencer", unsafe_head = %unsafe_head, "received request to start sequencer, but it is already started");
             return Ok(());
         }
 
-        info!(target: "sequencer", "Starting sequencer");
+        // TODO: call self.engine_client to update the engine forkchoice to unsafe_head before
+        // setting is_active, matching op-node behavior where the caller's intended starting point
+        // is honored. See reset_derivation_pipeline() for the engine_client pattern.
+        info!(target: "sequencer", unsafe_head = %unsafe_head, "Starting sequencer");
         self.is_active = true;
 
         self.update_metrics();

--- a/crates/consensus/service/src/actors/sequencer/tests/admin_api_impl_test.rs
+++ b/crates/consensus/service/src/actors/sequencer/tests/admin_api_impl_test.rs
@@ -104,10 +104,10 @@ async fn test_start_sequencer(
     // start the sequencer
     let result = async {
         match via_channel {
-            false => actor.start_sequencer().await,
+            false => actor.start_sequencer(B256::ZERO).await,
             true => {
                 let (tx, rx) = oneshot::channel();
-                actor.handle_admin_query(SequencerAdminQuery::StartSequencer(tx)).await;
+                actor.handle_admin_query(SequencerAdminQuery::StartSequencer(B256::ZERO, tx)).await;
                 rx.await.unwrap()
             }
         }
@@ -371,7 +371,7 @@ async fn test_handle_admin_query_resilient_to_dropped_receiver() {
     {
         // immediately drop receiver
         let (tx, _rx) = oneshot::channel();
-        queries.push(SequencerAdminQuery::StartSequencer(tx));
+        queries.push(SequencerAdminQuery::StartSequencer(B256::ZERO, tx));
     }
     {
         // immediately drop receiver

--- a/devnet/src/l2/in_process_consensus.rs
+++ b/devnet/src/l2/in_process_consensus.rs
@@ -239,7 +239,13 @@ impl InProcessConsensus {
             .build(self.rpc_url().as_str())
             .wrap_err("Failed to build RPC client")?;
 
-        client.admin_start_sequencer().await.wrap_err("Failed to start sequencer via RPC")?;
+        // Pass `B256::ZERO` because the devnet always starts from genesis, so there is no
+        // meaningful unsafe head to provide. The server currently logs the hash but does not yet
+        // use it to set forkchoice.
+        client
+            .admin_start_sequencer(B256::ZERO)
+            .await
+            .wrap_err("Failed to start sequencer via RPC")?;
         info!("sequencer started via admin RPC");
         Ok(())
     }


### PR DESCRIPTION
## Summary

Backport of #1424 to the v0.6.0 release branch. Fixes two bugs in the base-consensus admin RPC: replaces the incorrect -32601 MethodNotFound error on validator-mode nodes with a proper -32001 server error, and adds the missing unsafe_head: B256 parameter to admin_startSequencer to match the Go control client and op-node reference interface.