### PR TITLE
feat(workspace): add cli prefix helper macro

### DIFF
--- a/crates/proof/challenge/src/cli.rs
+++ b/crates/proof/challenge/src/cli.rs
@@ -11,6 +11,7 @@ use base_cli_utils::CliStyles;
 use clap::Parser;
 use url::Url;
 
+base_cli_utils::define_cli_env!("BASE_CHALLENGER");
 base_cli_utils::define_log_args!("BASE_CHALLENGER");
 base_cli_utils::define_metrics_args!("BASE_CHALLENGER", 7310);
 base_tx_manager::define_signer_cli!("BASE_CHALLENGER");
@@ -50,43 +51,43 @@ impl std::fmt::Debug for Cli {
 #[command(next_help_heading = "Challenger")]
 pub struct ChallengerArgs {
     /// URL of the L1 Ethereum RPC endpoint.
-    #[arg(long = "l1-eth-rpc", env = "BASE_CHALLENGER_L1_ETH_RPC")]
+    #[arg(long = "l1-eth-rpc", env = cli_env!("L1_ETH_RPC"))]
     pub l1_eth_rpc: Url,
 
     /// URL of the L2 Ethereum RPC endpoint.
-    #[arg(long = "l2-eth-rpc", env = "BASE_CHALLENGER_L2_ETH_RPC")]
+    #[arg(long = "l2-eth-rpc", env = cli_env!("L2_ETH_RPC"))]
     pub l2_eth_rpc: Url,
 
     /// URL of the rollup RPC endpoint.
-    #[arg(long = "rollup-rpc", env = "BASE_CHALLENGER_ROLLUP_RPC")]
+    #[arg(long = "rollup-rpc", env = cli_env!("ROLLUP_RPC"))]
     pub rollup_rpc: Url,
 
     /// Address of the `DisputeGameFactory` contract on L1.
-    #[arg(long = "dispute-game-factory-addr", env = "BASE_CHALLENGER_DISPUTE_GAME_FACTORY_ADDR")]
+    #[arg(long = "dispute-game-factory-addr", env = cli_env!("DISPUTE_GAME_FACTORY_ADDR"))]
     pub dispute_game_factory_addr: Address,
 
     /// Address of the `AnchorStateRegistry` contract on L1.
-    #[arg(long = "anchor-state-registry-addr", env = "BASE_CHALLENGER_ANCHOR_STATE_REGISTRY_ADDR")]
+    #[arg(long = "anchor-state-registry-addr", env = cli_env!("ANCHOR_STATE_REGISTRY_ADDR"))]
     pub anchor_state_registry_addr: Address,
 
     /// Polling interval for new dispute games (e.g., "12s", "1m").
     #[arg(
         long = "poll-interval",
-        env = "BASE_CHALLENGER_POLL_INTERVAL",
+        env = cli_env!("POLL_INTERVAL"),
         default_value = "12s",
         value_parser = humantime::parse_duration
     )]
     pub poll_interval: Duration,
 
     /// URL of the ZK proof service endpoint.
-    #[arg(long = "zk-proof-service-endpoint", env = "BASE_CHALLENGER_ZK_PROOF_SERVICE_ENDPOINT")]
+    #[arg(long = "zk-proof-service-endpoint", env = cli_env!("ZK_PROOF_SERVICE_ENDPOINT"))]
     pub zk_proof_service_endpoint: Url,
 
     /// Timeout for establishing the initial gRPC connection to the ZK proof
     /// service (e.g., "10s", "1m").
     #[arg(
         long = "zk-connect-timeout",
-        env = "BASE_CHALLENGER_ZK_CONNECT_TIMEOUT",
+        env = cli_env!("ZK_CONNECT_TIMEOUT"),
         default_value = "10s",
         value_parser = humantime::parse_duration
     )]
@@ -96,7 +97,7 @@ pub struct ChallengerArgs {
     /// (e.g., "30s", "1m").
     #[arg(
         long = "zk-request-timeout",
-        env = "BASE_CHALLENGER_ZK_REQUEST_TIMEOUT",
+        env = cli_env!("ZK_REQUEST_TIMEOUT"),
         default_value = "30s",
         value_parser = humantime::parse_duration
     )]
@@ -111,15 +112,15 @@ pub struct ChallengerArgs {
     pub tx_manager: TxManagerCli,
 
     /// Number of past games to scan on startup.
-    #[arg(long = "lookback-games", env = "BASE_CHALLENGER_LOOKBACK_GAMES", default_value = "1000")]
+    #[arg(long = "lookback-games", env = cli_env!("LOOKBACK_GAMES"), default_value = "1000")]
     pub lookback_games: u64,
 
     /// Health server bind address.
-    #[arg(long = "health.addr", env = "BASE_CHALLENGER_HEALTH_ADDR", default_value = "0.0.0.0")]
+    #[arg(long = "health.addr", env = cli_env!("HEALTH_ADDR"), default_value = "0.0.0.0")]
     pub health_addr: IpAddr,
 
     /// Health server port.
-    #[arg(long = "health.port", env = "BASE_CHALLENGER_HEALTH_PORT", default_value = "8080")]
+    #[arg(long = "health.port", env = cli_env!("HEALTH_PORT"), default_value = "8080")]
     pub health_port: u16,
 }
 

--- a/crates/proof/proposer/src/cli.rs
+++ b/crates/proof/proposer/src/cli.rs
@@ -7,6 +7,7 @@ use base_cli_utils::CliStyles;
 use clap::Parser;
 use url::Url;
 
+base_cli_utils::define_cli_env!("BASE_PROPOSER");
 base_cli_utils::define_log_args!("BASE_PROPOSER");
 base_cli_utils::define_metrics_args!("BASE_PROPOSER", 7300);
 base_tx_manager::define_signer_cli!("BASE_PROPOSER");
@@ -42,7 +43,7 @@ pub struct ProposerArgs {
     /// Allow proposals based on non-finalized L1 data.
     #[arg(
         long = "allow-non-finalized",
-        env = "BASE_PROPOSER_ALLOW_NON_FINALIZED",
+        env = cli_env!("ALLOW_NON_FINALIZED"),
         default_value = "false"
     )]
     pub allow_non_finalized: bool,
@@ -50,7 +51,7 @@ pub struct ProposerArgs {
     /// URL of the enclave RPC endpoint.
     #[arg(
         long = "enclave-rpc",
-        env = "BASE_PROPOSER_ENCLAVE_RPC",
+        env = cli_env!("ENCLAVE_RPC"),
         value_parser = parse_url
     )]
     pub enclave_rpc: Url,
@@ -58,7 +59,7 @@ pub struct ProposerArgs {
     /// URL of the L1 Ethereum RPC endpoint.
     #[arg(
         long = "l1-eth-rpc",
-        env = "BASE_PROPOSER_L1_ETH_RPC",
+        env = cli_env!("L1_ETH_RPC"),
         value_parser = parse_url
     )]
     pub l1_eth_rpc: Url,
@@ -66,19 +67,19 @@ pub struct ProposerArgs {
     /// URL of the L2 Ethereum RPC endpoint.
     #[arg(
         long = "l2-eth-rpc",
-        env = "BASE_PROPOSER_L2_ETH_RPC",
+        env = cli_env!("L2_ETH_RPC"),
         value_parser = parse_url
     )]
     pub l2_eth_rpc: Url,
 
     /// Use reth-specific RPC calls for L2.
-    #[arg(long = "l2-reth", env = "BASE_PROPOSER_L2_RETH", default_value = "false")]
+    #[arg(long = "l2-reth", env = cli_env!("L2_RETH"), default_value = "false")]
     pub l2_reth: bool,
 
     /// Address of the `AnchorStateRegistry` contract on L1.
     #[arg(
         long = "anchor-state-registry-addr",
-        env = "BASE_PROPOSER_ANCHOR_STATE_REGISTRY_ADDR",
+        env = cli_env!("ANCHOR_STATE_REGISTRY_ADDR"),
         value_parser = parse_address
     )]
     pub anchor_state_registry_addr: Address,
@@ -86,19 +87,19 @@ pub struct ProposerArgs {
     /// Address of the `DisputeGameFactory` contract on L1.
     #[arg(
         long = "dispute-game-factory-addr",
-        env = "BASE_PROPOSER_DISPUTE_GAME_FACTORY_ADDR",
+        env = cli_env!("DISPUTE_GAME_FACTORY_ADDR"),
         value_parser = parse_address
     )]
     pub dispute_game_factory_addr: Address,
 
     /// Game type ID for `AggregateVerifier` dispute games.
-    #[arg(long = "game-type", env = "BASE_PROPOSER_GAME_TYPE")]
+    #[arg(long = "game-type", env = cli_env!("GAME_TYPE"))]
     pub game_type: u32,
 
     /// Keccak256 hash of the TEE image PCR0 (0x-prefixed hex).
     #[arg(
         long = "tee-image-hash",
-        env = "BASE_PROPOSER_TEE_IMAGE_HASH",
+        env = cli_env!("TEE_IMAGE_HASH"),
         value_parser = parse_b256
     )]
     pub tee_image_hash: B256,
@@ -106,7 +107,7 @@ pub struct ProposerArgs {
     /// Polling interval for new blocks (e.g., "12s", "1m").
     #[arg(
         long = "poll-interval",
-        env = "BASE_PROPOSER_POLL_INTERVAL",
+        env = cli_env!("POLL_INTERVAL"),
         default_value = "12s",
         value_parser = parse_duration
     )]
@@ -115,7 +116,7 @@ pub struct ProposerArgs {
     /// RPC request timeout (e.g., "30s", "1m").
     #[arg(
         long = "rpc-timeout",
-        env = "BASE_PROPOSER_RPC_TIMEOUT",
+        env = cli_env!("RPC_TIMEOUT"),
         default_value = "30s",
         value_parser = parse_duration
     )]
@@ -124,7 +125,7 @@ pub struct ProposerArgs {
     /// URL of the rollup RPC endpoint.
     #[arg(
         long = "rollup-rpc",
-        env = "BASE_PROPOSER_ROLLUP_RPC",
+        env = cli_env!("ROLLUP_RPC"),
         value_parser = parse_url
     )]
     pub rollup_rpc: Url,
@@ -132,23 +133,23 @@ pub struct ProposerArgs {
     /// Skip TLS certificate verification.
     #[arg(
         long = "skip-tls-verify",
-        env = "BASE_PROPOSER_SKIP_TLS_VERIFY",
+        env = cli_env!("SKIP_TLS_VERIFY"),
         default_value = "false"
     )]
     pub skip_tls_verify: bool,
 
     /// Wait for node sync before starting.
-    #[arg(long = "wait-node-sync", env = "BASE_PROPOSER_WAIT_NODE_SYNC", default_value = "false")]
+    #[arg(long = "wait-node-sync", env = cli_env!("WAIT_NODE_SYNC"), default_value = "false")]
     pub wait_node_sync: bool,
 
     /// Maximum number of retry attempts for RPC operations.
-    #[arg(long = "rpc-max-retries", env = "BASE_PROPOSER_RPC_MAX_RETRIES", default_value = "5")]
+    #[arg(long = "rpc-max-retries", env = cli_env!("RPC_MAX_RETRIES"), default_value = "5")]
     pub rpc_max_retries: u32,
 
     /// Initial delay for exponential backoff (e.g., "100ms", "1s").
     #[arg(
         long = "rpc-retry-initial-delay",
-        env = "BASE_PROPOSER_RPC_RETRY_INITIAL_DELAY",
+        env = cli_env!("RPC_RETRY_INITIAL_DELAY"),
         default_value = "100ms",
         value_parser = parse_duration
     )]
@@ -157,7 +158,7 @@ pub struct ProposerArgs {
     /// Maximum delay between retry attempts (e.g., "10s", "1m").
     #[arg(
         long = "rpc-retry-max-delay",
-        env = "BASE_PROPOSER_RPC_RETRY_MAX_DELAY",
+        env = cli_env!("RPC_RETRY_MAX_DELAY"),
         default_value = "10s",
         value_parser = parse_duration
     )]
@@ -180,7 +181,7 @@ pub struct RpcServerArgs {
     #[arg(
         id = "rpc_enable_admin",
         long = "rpc.enable-admin",
-        env = "BASE_PROPOSER_RPC_ENABLE_ADMIN",
+        env = cli_env!("RPC_ENABLE_ADMIN"),
         default_value = "false"
     )]
     pub enable_admin: bool,
@@ -189,7 +190,7 @@ pub struct RpcServerArgs {
     #[arg(
         id = "rpc_addr",
         long = "rpc.addr",
-        env = "BASE_PROPOSER_RPC_ADDR",
+        env = cli_env!("RPC_ADDR"),
         default_value = "127.0.0.1"
     )]
     pub addr: IpAddr,
@@ -198,7 +199,7 @@ pub struct RpcServerArgs {
     #[arg(
         id = "rpc_port",
         long = "rpc.port",
-        env = "BASE_PROPOSER_RPC_PORT",
+        env = cli_env!("RPC_PORT"),
         default_value = "8545"
     )]
     pub port: u16,

--- a/crates/utilities/cli/src/macros.rs
+++ b/crates/utilities/cli/src/macros.rs
@@ -182,3 +182,30 @@ macro_rules! define_log_args {
         }
     };
 }
+
+/// Generates a local `cli_env!` macro that prepends a fixed component prefix to
+/// every env-var suffix, so you can write `env = cli_env!("L1_ETH_RPC")` instead
+/// of `env = "BASE_CHALLENGER_L1_ETH_RPC"`.
+///
+/// # Usage
+///
+/// ```rust,ignore
+/// base_cli_utils::define_cli_env!("BASE_CHALLENGER");
+///
+/// #[arg(long = "l1-eth-rpc", env = cli_env!("L1_ETH_RPC"))]
+/// pub l1_eth_rpc: Url,
+/// // expands to env = "BASE_CHALLENGER_L1_ETH_RPC"
+/// ```
+#[macro_export]
+macro_rules! define_cli_env {
+    ($prefix:literal) => {
+        $crate::define_cli_env!(@dollar $prefix $);
+    };
+    (@dollar $prefix:literal $d:tt) => {
+        macro_rules! cli_env {
+            ($d var:literal) => {
+                concat!($prefix, "_", $d var)
+            };
+        }
+    };
+}


### PR DESCRIPTION
### What changed? Why?

Adds a `define_cli_env!` macro to `base-cli-utils` that generates a local `cli_env!` helper for prefixing environment variable names in clap `#[arg]` attributes.

Instead of repeating the full prefix in every env var string (e.g., `env = "BASE_CHALLENGER_L1_ETH_RPC"`), crates now call `define_cli_env!("BASE_CHALLENGER")` once and then use `env = cli_env!("L1_ETH_RPC")` on each field. This reduces duplication, prevents typo-related bugs, and makes it easy to update a crate's env prefix in one place.

Migrates the challenger and proposer CLI definitions to use the new macro.

### Notes to reviewers

The `define_cli_env!` macro uses the `@dollar` internal-rule pattern to forward `$` into the nested `macro_rules!` expansion. This is a standard technique for macros that emit other macros.

### How has it been tested?

Existing tests and CI. The macro is purely compile-time (`concat!`), so any expansion error would be a build failure.

### Change management ([definitions](http://go/change-management))

type=routine<!--routine,nonroutine,emergency-->
risk=low<!--low,medium,high-->
impact=sev5<!--sev5,sev4,sev3,sev2,sev1-->

### Backwards Compatibility ([learn more](http://go/backwards-compatibility))

backwards_compatible=true<!-- true false -->

<!-- Automatically merge your PR once the necessary approvals have been received (you probably want this) -->

automerge=false