### PR TITLE
fix(proposer): improve proposer retry handling

### DIFF
--- a/crates/proof/proposer/src/rpc/l2_client_ext.rs
+++ b/crates/proof/proposer/src/rpc/l2_client_ext.rs
@@ -20,17 +20,7 @@ impl ProverL2Provider for L2Client {
                     (BlockNumberOrTag::Number(block_number),),
                 )
                 .await
-                .map_err(|e| {
-                    // Truncate the error to avoid logging multi-MB witness JSON in error messages.
-                    let msg = e.to_string();
-                    let truncated = if msg.len() > 500 {
-                        let end = msg.floor_char_boundary(500);
-                        format!("{}... (truncated)", &msg[..end])
-                    } else {
-                        msg
-                    };
-                    RpcError::WitnessNotFound(format!("Block {block_number}: {truncated}"))
-                })
+                .map_err(RpcError::from)
         })
         .retry(backoff)
         .when(|e| e.is_retryable())
@@ -38,6 +28,7 @@ impl ProverL2Provider for L2Client {
             tracing::debug!(error = %err, delay = ?dur, "Retrying L2Client::execution_witness");
         })
         .await
+        .map_err(|e| RpcError::WitnessNotFound(format!("Block {block_number}: {e}")))
     }
 
     async fn db_get(&self, key: B256) -> RpcResult<Bytes> {
@@ -47,7 +38,7 @@ impl ProverL2Provider for L2Client {
             self.provider()
                 .raw_request::<_, Bytes>("debug_dbGet".into(), (key,))
                 .await
-                .map_err(|e| RpcError::InvalidResponse(format!("Failed to db_get key {key}: {e}")))
+                .map_err(RpcError::from)
         })
         .retry(backoff)
         .when(|e| e.is_retryable())
@@ -55,5 +46,6 @@ impl ProverL2Provider for L2Client {
             tracing::debug!(error = %err, delay = ?dur, "Retrying L2Client::db_get");
         })
         .await
+        .map_err(|e| RpcError::InvalidResponse(format!("Failed to db_get key {key}: {e}")))
     }
 }

--- a/crates/proof/proposer/src/rpc/reth_client.rs
+++ b/crates/proof/proposer/src/rpc/reth_client.rs
@@ -200,14 +200,15 @@ impl ProverL2Provider for RethL2Client {
                     (BlockNumberOrTag::Number(block_number),),
                 )
                 .await
-                .map_err(|e| RpcError::WitnessNotFound(format!("Block {block_number}: {e}")))
+                .map_err(RpcError::from)
         })
         .retry(backoff)
         .when(|e| e.is_retryable())
         .notify(|err, dur| {
             tracing::debug!(error = %err, delay = ?dur, "Retrying RethL2Client::execution_witness");
         })
-        .await?;
+        .await
+        .map_err(|e| RpcError::WitnessNotFound(format!("Block {block_number}: {e}")))?;
 
         tracing::info!(
             block_number,

--- a/crates/proof/rpc/src/error.rs
+++ b/crates/proof/rpc/src/error.rs
@@ -58,13 +58,33 @@ impl RpcError {
     }
 }
 
+/// Maximum length for error messages stored in [`RpcError`] variants.
+///
+/// RPC error payloads (e.g. from `debug_executionWitness`) can contain multi-MB
+/// JSON responses. Truncating at the conversion boundary prevents large strings
+/// from propagating through retry loops, log lines, and error chains.
+const MAX_ERROR_MSG_LEN: usize = 500;
+
+/// Truncates a string to [`MAX_ERROR_MSG_LEN`], appending a `(truncated)` suffix
+/// if it exceeds the limit.
+fn truncate_error_msg(msg: String) -> String {
+    if msg.len() > MAX_ERROR_MSG_LEN {
+        let end = msg.floor_char_boundary(MAX_ERROR_MSG_LEN);
+        format!("{}... (truncated)", &msg[..end])
+    } else {
+        msg
+    }
+}
+
 impl From<TransportError> for RpcError {
     fn from(err: TransportError) -> Self {
         match err {
             AlloyRpcError::SerError(e) => Self::Serialization(e.to_string()),
             AlloyRpcError::DeserError { err, .. } => Self::InvalidResponse(err.to_string()),
             AlloyRpcError::NullResp => Self::InvalidResponse("null response".into()),
-            AlloyRpcError::ErrorResp(payload) => Self::InvalidResponse(payload.to_string()),
+            AlloyRpcError::ErrorResp(payload) => {
+                Self::InvalidResponse(truncate_error_msg(payload.to_string()))
+            }
             err @ (AlloyRpcError::Transport(_)
             | AlloyRpcError::UnsupportedFeature(_)
             | AlloyRpcError::LocalUsageError(_)) => Self::Transport(err.to_string()),

--- a/crates/proof/rpc/src/error.rs
+++ b/crates/proof/rpc/src/error.rs
@@ -48,6 +48,24 @@ pub enum RpcError {
 }
 
 impl RpcError {
+    /// Maximum length for error messages stored in [`RpcError`] variants.
+    ///
+    /// RPC error payloads (e.g. from `debug_executionWitness`) can contain multi-MB
+    /// JSON responses. Truncating at the conversion boundary prevents large strings
+    /// from propagating through retry loops, log lines, and error chains.
+    pub const MAX_ERROR_MSG_LEN: usize = 500;
+
+    /// Truncates a string to [`Self::MAX_ERROR_MSG_LEN`], appending a `(truncated)`
+    /// suffix if it exceeds the limit.
+    pub fn truncate_msg(mut msg: String) -> String {
+        if msg.len() > Self::MAX_ERROR_MSG_LEN {
+            let end = msg.floor_char_boundary(Self::MAX_ERROR_MSG_LEN);
+            msg.truncate(end);
+            msg.push_str("... (truncated)");
+        }
+        msg
+    }
+
     /// Returns true if this error is transient and the operation should be retried.
     ///
     /// Only transport-level errors (network issues, timeouts, connection failures)
@@ -58,24 +76,6 @@ impl RpcError {
     }
 }
 
-/// Maximum length for error messages stored in [`RpcError`] variants.
-///
-/// RPC error payloads (e.g. from `debug_executionWitness`) can contain multi-MB
-/// JSON responses. Truncating at the conversion boundary prevents large strings
-/// from propagating through retry loops, log lines, and error chains.
-const MAX_ERROR_MSG_LEN: usize = 500;
-
-/// Truncates a string to [`MAX_ERROR_MSG_LEN`], appending a `(truncated)` suffix
-/// if it exceeds the limit.
-fn truncate_error_msg(msg: String) -> String {
-    if msg.len() > MAX_ERROR_MSG_LEN {
-        let end = msg.floor_char_boundary(MAX_ERROR_MSG_LEN);
-        format!("{}... (truncated)", &msg[..end])
-    } else {
-        msg
-    }
-}
-
 impl From<TransportError> for RpcError {
     fn from(err: TransportError) -> Self {
         match err {
@@ -83,7 +83,7 @@ impl From<TransportError> for RpcError {
             AlloyRpcError::DeserError { err, .. } => Self::InvalidResponse(err.to_string()),
             AlloyRpcError::NullResp => Self::InvalidResponse("null response".into()),
             AlloyRpcError::ErrorResp(payload) => {
-                Self::InvalidResponse(truncate_error_msg(payload.to_string()))
+                Self::InvalidResponse(Self::truncate_msg(payload.to_string()))
             }
             err @ (AlloyRpcError::Transport(_)
             | AlloyRpcError::UnsupportedFeature(_)


### PR DESCRIPTION
### What changed? Why?

Fixes the proposer retry handling so that RPC errors are correctly classified for retry decisions.

Previously, raw `TransportError`s were immediately wrapped in domain-specific `RpcError` variants (e.g. `WitnessNotFound`, `InvalidResponse`) *inside* the retry closure. This meant `is_retryable()` was checked against the already-wrapped variant, which could prevent retries from firing on transient transport errors.

Now:
- Inside retry closures, errors convert via `RpcError::from(TransportError)`, preserving the original error category (`Transport`, `InvalidResponse`, etc.) so `is_retryable()` works correctly.
- Domain-specific wrapping (`WitnessNotFound`, `InvalidResponse` with context) is applied *after* retries are exhausted.
- Error message truncation (to avoid multi-MB witness JSON in logs) is centralized in a `truncate_error_msg` helper called from the `From<TransportError>` impl, rather than being duplicated at individual call sites.

### Notes to reviewers

The `L2Client`, `RethL2Client` `execution_witness` and `db_get` methods all follow the same updated pattern.

### How has it been tested?

Existing tests + manual verification of retry behavior with transient RPC failures.

### Change management ([definitions](http://go/change-management))

type=routine<!--routine,nonroutine,emergency-->
risk=low<!--low,medium,high-->
impact=sev5<!--sev5,sev4,sev3,sev2,sev1-->

### Backwards Compatibility ([learn more](http://go/backwards-compatibility))

backwards_compatible=true<!-- true false -->

<!-- Automatically merge your PR once the necessary approvals have been received (you probably want this) -->

automerge=false