### PR TITLE
fix(release): include release branches in version detection

### DIFF
--- a/etc/scripts/release/start-release.sh
+++ b/etc/scripts/release/start-release.sh
@@ -24,12 +24,24 @@ fi
 main() {
     echo "=== Start Release (bump: $BUMP_TYPE) ==="
 
-    # Get latest FINAL tag (exact vX.Y.Z, exclude RCs and other suffixes)
-    CURRENT_VERSION=$(git tag -l 'v[0-9]*.[0-9]*.[0-9]*' \
-        | grep -Ex 'v[0-9]+\.[0-9]+\.[0-9]+' | sort -V | tail -1 | sed 's/^v//')
+    # For major/minor bumps, include release branch names so we don't
+    # collide with an in-progress release that hasn't been tagged yet.
+    # For patch bumps, use only final tags so we patch the latest
+    # *completed* release, not an in-progress one.
+    TAG_VERSIONS=$(git tag -l 'v[0-9]*.[0-9]*.[0-9]*' \
+        | grep -Ex 'v[0-9]+\.[0-9]+\.[0-9]+' || true)
+
+    if [[ "$BUMP_TYPE" == "patch" ]]; then
+        CURRENT_VERSION=$(echo "$TAG_VERSIONS" | sort -V | tail -1 | sed 's/^v//')
+    else
+        BRANCH_VERSIONS=$(git ls-remote --heads origin 'releases/v*' \
+            | sed -n 's|.*refs/heads/releases/\(v[0-9]*\.[0-9]*\.[0-9]*\)$|\1|p' || true)
+        CURRENT_VERSION=$(printf '%s\n' $TAG_VERSIONS $BRANCH_VERSIONS \
+            | sort -Vu | tail -1 | sed 's/^v//')
+    fi
 
     if [[ -z "$CURRENT_VERSION" ]]; then
-        echo "Error: No final release tags found. Cannot determine current version." >&2
+        echo "Error: No release tags or release branches found. Cannot determine current version." >&2
         exit 1
     fi
 


### PR DESCRIPTION
## Summary
- The start-release script only looked at final tags to determine the current version. If a release branch exists without a final tag (e.g. `releases/v0.6.0` with only RC tags), the script would try to create that same version again and fail.
- Now includes release branch names as a version source so the script correctly bumps past versions that are in progress.

## Test plan
- [x] Verified locally that the new logic picks up `0.6.0` from the existing `releases/v0.6.0` branch, so a minor bump correctly produces `0.7.0`