### PR TITLE
fix(builder): guard against division by zero in flashblocks_per_block 

### DIFF
--- a/crates/builder/core/src/config.rs
+++ b/crates/builder/core/src/config.rs
@@ -73,6 +73,9 @@ impl BuilderConfig {
         if self.block_time.as_millis() == 0 {
             return 0;
         }
+        if self.flashblocks_interval.as_millis() == 0 {
+            return 0;
+        }
         (self.block_time.as_millis() / self.flashblocks_interval.as_millis()) as u64
     }
 }


### PR DESCRIPTION
## Summary

Fix a divide-by-zero panic in `BuilderConfig::flashblocks_per_block()`.

The function guarded against `block_time == 0` but not `flashblocks_interval == 0`.  
If `flashblocks_interval` is set to `Duration::ZERO`, any non-zero `block_time` triggers an integer division by zero, which panics in both debug and release builds.

## Change

Added a guard before the division:
```rust
if self.flashblocks_interval.as_millis() == 0 {
    return 0;
}
