### PR TITLE
feat(batcher): Add Admin JSON-RPC API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2583,6 +2583,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "base-batcher-admin"
+version = "0.0.0"
+dependencies = [
+ "base-batcher-core",
+ "eyre",
+ "jsonrpsee",
+ "tracing",
+]
+
+[[package]]
 name = "base-batcher-bin"
 version = "0.0.0"
 dependencies = [
@@ -2614,9 +2624,11 @@ dependencies = [
  "base-protocol",
  "base-runtime",
  "base-tx-manager",
+ "derive_more",
  "futures",
  "metrics",
  "rstest",
+ "serde",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -2651,6 +2663,7 @@ dependencies = [
  "base-alloy-consensus",
  "base-alloy-network",
  "base-alloy-rpc-jsonrpsee",
+ "base-batcher-admin",
  "base-batcher-core",
  "base-batcher-encoder",
  "base-batcher-source",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -254,6 +254,7 @@ base-action-harness = { path = "actions/harness" }
 # Batcher
 base-blobs = { path = "crates/batcher/blobs" }
 base-batcher-core = { path = "crates/batcher/core" }
+base-batcher-admin = { path = "crates/batcher/admin" }
 base-batcher-source = { path = "crates/batcher/source" }
 base-batcher-encoder = { path = "crates/batcher/encoder" }
 base-batcher-service = { path = "crates/batcher/service" }

--- a/bin/batcher/src/cli.rs
+++ b/bin/batcher/src/cli.rs
@@ -1,6 +1,9 @@
 //! CLI argument parsing for the Base Batcher binary.
 
-use std::time::Duration;
+use std::{
+    net::{IpAddr, SocketAddr},
+    time::Duration,
+};
 
 use base_batcher_core::ThrottleConfig;
 use base_batcher_service::{BatcherConfig, BatcherService, SecretKey};
@@ -135,6 +138,20 @@ pub(crate) struct BatcherArgs {
     #[arg(long = "no-throttle", env = "BATCHER_NO_THROTTLE")]
     pub no_throttle: bool,
 
+    /// Bind address for the admin JSON-RPC API (default: 127.0.0.1).
+    ///
+    /// Only takes effect when `--admin-port` is also set.
+    #[arg(long = "admin-addr", env = "BATCHER_ADMIN_ADDR", default_value = "127.0.0.1")]
+    pub admin_addr: IpAddr,
+
+    /// Port for the admin JSON-RPC API.
+    ///
+    /// When set, exposes `admin_startBatcher`, `admin_stopBatcher`,
+    /// `admin_flushBatcher`, `admin_getThrottleController`, and related methods.
+    /// When absent (default), the admin API is disabled.
+    #[arg(long = "admin-port", env = "BATCHER_ADMIN_PORT")]
+    pub admin_port: Option<u16>,
+
     /// Logging configuration.
     #[command(flatten)]
     pub logging: LogArgs,
@@ -177,6 +194,7 @@ impl BatcherArgs {
                     ..Default::default()
                 })
             },
+            admin_addr: self.admin_port.map(|port| SocketAddr::new(self.admin_addr, port)),
         })
     }
 

--- a/crates/batcher/admin/Cargo.toml
+++ b/crates/batcher/admin/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "base-batcher-admin"
+description = "Admin JSON-RPC API server for the Base Batcher"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+
+[lints]
+workspace = true
+
+[dependencies]
+eyre.workspace = true
+base-batcher-core.workspace = true
+tracing = { workspace = true, features = ["std"] }
+jsonrpsee = { workspace = true, features = ["server", "macros"] }

--- a/crates/batcher/admin/README.md
+++ b/crates/batcher/admin/README.md
@@ -1,0 +1,1 @@
+Admin JSON-RPC API server for the Base Batcher.

--- a/crates/batcher/admin/src/api.rs
+++ b/crates/batcher/admin/src/api.rs
@@ -1,0 +1,132 @@
+//! Admin JSON-RPC trait and server implementation.
+
+use base_batcher_core::{
+    AdminError, AdminHandle, BatcherStatus, ThrottleConfig, ThrottleInfo, ThrottleStrategy,
+};
+use jsonrpsee::{
+    core::{RpcResult, async_trait},
+    proc_macros::rpc,
+    types::ErrorObjectOwned,
+};
+use tracing::warn;
+
+#[rpc(server, namespace = "admin")]
+pub trait BatcherAdminApi {
+    /// Resume block ingestion after a previous stop.
+    #[method(name = "startBatcher")]
+    async fn start_batcher(&self) -> RpcResult<()>;
+
+    /// Pause block ingestion without stopping the driver task.
+    #[method(name = "stopBatcher")]
+    async fn stop_batcher(&self) -> RpcResult<()>;
+
+    /// Force-close the current encoding channel, submitting any buffered frames.
+    #[method(name = "flushBatcher")]
+    async fn flush_batcher(&self) -> RpcResult<()>;
+
+    /// Read the current throttle controller state.
+    #[method(name = "getThrottleController")]
+    async fn get_throttle_controller(&self) -> RpcResult<ThrottleInfo>;
+
+    /// Replace the throttle strategy and configuration.
+    ///
+    /// `config` sets the full throttle configuration; all fields are required.
+    #[method(name = "setThrottleController")]
+    async fn set_throttle_controller(
+        &self,
+        strategy: ThrottleStrategy,
+        config: ThrottleConfig,
+    ) -> RpcResult<()>;
+
+    /// Clear the throttle dedup cache so limits are re-applied unconditionally.
+    #[method(name = "resetThrottleController")]
+    async fn reset_throttle_controller(&self) -> RpcResult<()>;
+
+    /// Read the current driver runtime state.
+    #[method(name = "getBatcherStatus")]
+    async fn get_batcher_status(&self) -> RpcResult<BatcherStatus>;
+
+    /// Set the log level (not yet supported; returns an error).
+    #[method(name = "setLogLevel")]
+    async fn set_log_level(&self, level: String) -> RpcResult<()>;
+}
+
+/// Concrete implementation of [`BatcherAdminApiServer`] backed by an [`AdminHandle`].
+#[derive(Debug)]
+pub struct BatcherAdminApiServerImpl {
+    handle: AdminHandle,
+}
+
+impl BatcherAdminApiServerImpl {
+    /// Create a new server implementation backed by `handle`.
+    pub const fn new(handle: AdminHandle) -> Self {
+        Self { handle }
+    }
+
+    /// Convert an [`AdminError`] into a JSON-RPC error object.
+    fn admin_error(e: AdminError) -> ErrorObjectOwned {
+        let code = match e {
+            AdminError::NotSupported(_) => -32601,
+            AdminError::ChannelClosed => -32001,
+        };
+        ErrorObjectOwned::owned(code, e.to_string(), None::<()>)
+    }
+}
+
+#[async_trait]
+impl BatcherAdminApiServer for BatcherAdminApiServerImpl {
+    async fn start_batcher(&self) -> RpcResult<()> {
+        self.handle.resume().await.map_err(Self::admin_error)
+    }
+
+    async fn stop_batcher(&self) -> RpcResult<()> {
+        self.handle.pause().await.map_err(Self::admin_error)
+    }
+
+    async fn flush_batcher(&self) -> RpcResult<()> {
+        self.handle.flush().await.map_err(Self::admin_error)
+    }
+
+    async fn get_throttle_controller(&self) -> RpcResult<ThrottleInfo> {
+        self.handle.get_throttle_info().await.map_err(Self::admin_error)
+    }
+
+    async fn set_throttle_controller(
+        &self,
+        strategy: ThrottleStrategy,
+        config: ThrottleConfig,
+    ) -> RpcResult<()> {
+        self.handle.set_throttle(strategy, config).await.map_err(Self::admin_error)
+    }
+
+    async fn reset_throttle_controller(&self) -> RpcResult<()> {
+        self.handle.reset_throttle().await.map_err(Self::admin_error)
+    }
+
+    async fn get_batcher_status(&self) -> RpcResult<BatcherStatus> {
+        self.handle.get_status().await.map_err(Self::admin_error)
+    }
+
+    async fn set_log_level(&self, level: String) -> RpcResult<()> {
+        warn!(level = %level, "admin_setLogLevel called but not yet supported");
+        self.handle.set_log_level(level).map_err(Self::admin_error)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn admin_error_not_supported_uses_method_not_found_code() {
+        let err = BatcherAdminApiServerImpl::admin_error(AdminError::NotSupported("test"));
+        assert_eq!(err.code(), -32601);
+        assert!(err.message().contains("not yet supported"));
+    }
+
+    #[test]
+    fn admin_error_channel_closed_uses_server_error_code() {
+        let err = BatcherAdminApiServerImpl::admin_error(AdminError::ChannelClosed);
+        assert_eq!(err.code(), -32001);
+    }
+}

--- a/crates/batcher/admin/src/lib.rs
+++ b/crates/batcher/admin/src/lib.rs
@@ -1,0 +1,14 @@
+#![doc = include_str!("../README.md")]
+#![doc(
+    html_logo_url = "https://avatars.githubusercontent.com/u/16627100?s=200&v=4",
+    html_favicon_url = "https://avatars.githubusercontent.com/u/16627100?s=200&v=4",
+    issue_tracker_base_url = "https://github.com/base/base/issues/"
+)]
+#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
+#![cfg_attr(not(test), warn(unused_crate_dependencies))]
+
+mod api;
+pub use api::{BatcherAdminApiServer, BatcherAdminApiServerImpl};
+
+mod server;
+pub use server::AdminServer;

--- a/crates/batcher/admin/src/server.rs
+++ b/crates/batcher/admin/src/server.rs
@@ -1,0 +1,42 @@
+//! Admin JSON-RPC HTTP server lifecycle.
+
+use std::{fmt, net::SocketAddr};
+
+use base_batcher_core::AdminHandle;
+use eyre::Context;
+use jsonrpsee::server::{Server, ServerHandle};
+use tracing::info;
+
+use crate::{BatcherAdminApiServer, BatcherAdminApiServerImpl};
+
+/// A running admin JSON-RPC HTTP server.
+///
+/// Holds the jsonrpsee [`ServerHandle`] for the server's lifetime.
+/// Dropping this value stops the server from accepting new connections.
+pub struct AdminServer {
+    handle: ServerHandle,
+}
+
+impl fmt::Debug for AdminServer {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("AdminServer").finish_non_exhaustive()
+    }
+}
+
+impl AdminServer {
+    /// Bind and start the admin server on the given socket address.
+    pub async fn spawn(addr: SocketAddr, admin_handle: AdminHandle) -> eyre::Result<Self> {
+        let server =
+            Server::builder().build(addr).await.wrap_err("failed to bind admin RPC server")?;
+        let addr = server.local_addr().wrap_err("failed to get admin server local address")?;
+        let module = BatcherAdminApiServerImpl::new(admin_handle).into_rpc();
+        let handle = server.start(module);
+        info!(addr = %addr, "admin RPC server listening");
+        Ok(Self { handle })
+    }
+
+    /// Future that resolves when the server stops.
+    pub async fn stopped(&self) {
+        self.handle.clone().stopped().await;
+    }
+}

--- a/crates/batcher/core/Cargo.toml
+++ b/crates/batcher/core/Cargo.toml
@@ -26,8 +26,10 @@ futures.workspace = true
 metrics.workspace = true
 tracing = { workspace = true, features = ["std"] }
 thiserror = { workspace = true, features = ["std"] }
+serde = { workspace = true, features = ["derive", "std"] }
 alloy-primitives = { workspace = true, features = ["std"] }
 tokio = { workspace = true, features = ["sync", "macros", "rt"] }
+derive_more = { workspace = true, features = ["display", "from_str"] }
 
 # optional — activated by the `test-utils` feature
 async-trait = { workspace = true, optional = true }
@@ -37,11 +39,11 @@ alloy-rpc-types-eth = { workspace = true, features = ["std"], optional = true }
 [dev-dependencies]
 rstest.workspace = true
 async-trait.workspace = true
+base-protocol = { workspace = true, features = ["std"] }
 alloy-consensus = { workspace = true, features = ["std"] }
+base-runtime = { workspace = true, features = ["test-utils"] }
 alloy-rpc-types-eth = { workspace = true, features = ["std"] }
 base-alloy-consensus = { workspace = true, features = ["std"] }
-base-runtime = { workspace = true, features = ["test-utils"] }
-base-protocol = { workspace = true, features = ["std"] }
 tokio = { workspace = true, features = ["macros", "rt", "time"] }
 
 [[test]]

--- a/crates/batcher/core/src/admin.rs
+++ b/crates/batcher/core/src/admin.rs
@@ -1,0 +1,194 @@
+//! Admin command channel for runtime control of the batch driver.
+
+use tokio::sync::{mpsc, oneshot};
+
+use crate::{ThrottleConfig, ThrottleInfo, ThrottleStrategy};
+
+/// Capacity of the admin command channel.
+///
+/// 32 is generous for an infrequently-used admin API; commands are processed
+/// in the main driver loop on every iteration so the channel rarely fills.
+pub const ADMIN_CHANNEL_CAPACITY: usize = 32;
+
+/// Runtime state snapshot returned by [`AdminCommand::GetStatus`].
+///
+/// Serialised directly as the `admin_getBatcherStatus` JSON-RPC response.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct BatcherStatus {
+    /// Whether block ingestion is currently paused via the admin API.
+    pub paused: bool,
+    /// Number of L1 transactions submitted but not yet confirmed.
+    pub in_flight: usize,
+    /// Estimated unsubmitted DA backlog in bytes.
+    pub da_backlog_bytes: u64,
+}
+
+/// Errors produced by admin operations.
+#[derive(Debug, thiserror::Error)]
+pub enum AdminError {
+    /// The driver task has exited and the command channel is closed.
+    #[error("admin channel closed: driver has shut down")]
+    ChannelClosed,
+    /// The requested operation is not yet supported.
+    #[error("not yet supported: {0}")]
+    NotSupported(&'static str),
+}
+
+/// Result type alias for admin operations.
+pub type AdminResult<T> = Result<T, AdminError>;
+
+/// Commands the admin HTTP server can send to the running driver task.
+pub enum AdminCommand {
+    /// Resume block ingestion after a [`Pause`](Self::Pause).
+    Resume,
+    /// Pause block ingestion without stopping the driver task.
+    Pause,
+    /// Force-close the current encoding channel (equivalent to a flush event).
+    Flush,
+    /// Replace the throttle strategy and configuration.
+    SetThrottle {
+        /// The new throttle strategy to apply.
+        strategy: ThrottleStrategy,
+        /// The new throttle configuration to apply.
+        config: ThrottleConfig,
+    },
+    /// Clear the throttle dedup cache so limits are re-applied unconditionally.
+    ResetThrottle,
+    /// Read current throttle state; reply sent via the embedded oneshot sender.
+    GetThrottleInfo {
+        /// Channel to send the throttle info snapshot back on.
+        reply: oneshot::Sender<ThrottleInfo>,
+    },
+    /// Read current driver runtime state; reply sent via the embedded oneshot sender.
+    GetStatus {
+        /// Channel to send the batcher status back on.
+        reply: oneshot::Sender<BatcherStatus>,
+    },
+}
+
+impl std::fmt::Debug for AdminCommand {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Resume => write!(f, "Resume"),
+            Self::Pause => write!(f, "Pause"),
+            Self::Flush => write!(f, "Flush"),
+            Self::SetThrottle { strategy, .. } => {
+                f.debug_struct("SetThrottle").field("strategy", strategy).finish()
+            }
+            Self::ResetThrottle => write!(f, "ResetThrottle"),
+            Self::GetThrottleInfo { .. } => f.debug_struct("GetThrottleInfo").finish(),
+            Self::GetStatus { .. } => f.debug_struct("GetStatus").finish(),
+        }
+    }
+}
+
+/// Cloneable handle to the driver's admin command channel.
+///
+/// Create with [`AdminHandle::channel`]; wire the returned
+/// [`mpsc::Receiver`] into the driver via [`BatchDriver::with_admin_rx`].
+#[derive(Clone, Debug)]
+pub struct AdminHandle {
+    tx: mpsc::Sender<AdminCommand>,
+}
+
+impl AdminHandle {
+    /// Create a matched `(AdminHandle, Receiver)` pair.
+    pub fn channel() -> (Self, mpsc::Receiver<AdminCommand>) {
+        let (tx, rx) = mpsc::channel(ADMIN_CHANNEL_CAPACITY);
+        (Self { tx }, rx)
+    }
+
+    /// Resume block ingestion if currently paused.
+    pub async fn resume(&self) -> AdminResult<()> {
+        self.send(AdminCommand::Resume).await
+    }
+
+    /// Pause block ingestion without stopping the driver task.
+    ///
+    /// In-flight submissions continue to resolve; no new blocks are ingested
+    /// until [`resume`](Self::resume) is called.
+    pub async fn pause(&self) -> AdminResult<()> {
+        self.send(AdminCommand::Pause).await
+    }
+
+    /// Force-close the current encoding channel, submitting any buffered frames.
+    pub async fn flush(&self) -> AdminResult<()> {
+        self.send(AdminCommand::Flush).await
+    }
+
+    /// Replace the throttle strategy and configuration.
+    ///
+    /// The full [`ThrottleConfig`] is required — partial updates are not
+    /// supported. Callers that want to change only one field should call
+    /// [`get_throttle_info`](Self::get_throttle_info) first to read the
+    /// current config, adjust the desired field, and pass the result here.
+    pub async fn set_throttle(
+        &self,
+        strategy: ThrottleStrategy,
+        config: ThrottleConfig,
+    ) -> AdminResult<()> {
+        self.send(AdminCommand::SetThrottle { strategy, config }).await
+    }
+
+    /// Clear the throttle dedup cache so limits are re-applied unconditionally
+    /// on the next driver iteration.
+    pub async fn reset_throttle(&self) -> AdminResult<()> {
+        self.send(AdminCommand::ResetThrottle).await
+    }
+
+    /// Read the current throttle controller state.
+    pub async fn get_throttle_info(&self) -> AdminResult<ThrottleInfo> {
+        let (tx, rx) = oneshot::channel();
+        self.send(AdminCommand::GetThrottleInfo { reply: tx }).await?;
+        rx.await.map_err(|_| AdminError::ChannelClosed)
+    }
+
+    /// Read the current driver runtime state.
+    pub async fn get_status(&self) -> AdminResult<BatcherStatus> {
+        let (tx, rx) = oneshot::channel();
+        self.send(AdminCommand::GetStatus { reply: tx }).await?;
+        rx.await.map_err(|_| AdminError::ChannelClosed)
+    }
+
+    /// Dynamic log level changes require a `tracing-subscriber` reload handle
+    /// threaded from the CLI through `BatcherService`.
+    ///
+    /// Returns an error immediately so callers know the level was not changed.
+    /// No command is ever sent to the driver. A future chunk implements this
+    /// by modifying `base-cli-utils` to expose a reload handle.
+    pub fn set_log_level(&self, _level: String) -> AdminResult<()> {
+        Err(AdminError::NotSupported("set_log_level"))
+    }
+
+    async fn send(&self, cmd: AdminCommand) -> AdminResult<()> {
+        self.tx.send(cmd).await.map_err(|_| AdminError::ChannelClosed)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn resume_returns_channel_closed_when_rx_dropped() {
+        let (handle, rx) = AdminHandle::channel();
+        drop(rx);
+        let err = handle.resume().await.unwrap_err();
+        assert!(matches!(err, AdminError::ChannelClosed));
+    }
+
+    #[tokio::test]
+    async fn get_status_returns_channel_closed_when_rx_dropped() {
+        let (handle, rx) = AdminHandle::channel();
+        drop(rx);
+        let err = handle.get_status().await.unwrap_err();
+        assert!(matches!(err, AdminError::ChannelClosed));
+    }
+
+    #[test]
+    fn set_log_level_returns_not_supported() {
+        let (handle, _rx) = AdminHandle::channel();
+        let err = handle.set_log_level("debug".to_string()).unwrap_err();
+        assert!(matches!(err, AdminError::NotSupported(_)));
+    }
+}

--- a/crates/batcher/core/src/driver.rs
+++ b/crates/batcher/core/src/driver.rs
@@ -9,11 +9,12 @@ use base_batcher_source::{
 };
 use base_runtime::Runtime;
 use base_tx_manager::TxManager;
+use tokio::sync::mpsc;
 use tracing::{debug, error, info, warn};
 
 use crate::{
-    BatchDriverConfig, BatchDriverError, DaThrottle, SubmissionQueue, ThrottleClient,
-    event::DriverEvent,
+    AdminCommand, BatchDriverConfig, BatchDriverError, BatcherStatus, DaThrottle, SubmissionQueue,
+    ThrottleClient, ThrottleController, event::DriverEvent,
 };
 
 /// Async orchestration loop for the batcher.
@@ -54,6 +55,10 @@ where
     /// Maximum wall-clock time to wait for in-flight submissions to settle
     /// when draining on cancellation or source exhaustion.
     drain_timeout: Duration,
+    /// Whether block ingestion is currently paused via the admin API.
+    paused: bool,
+    /// Admin command channel, wired in via [`Self::with_admin_rx`].
+    admin_rx: Option<mpsc::Receiver<AdminCommand>>,
 }
 
 impl<R, P, S, TM, TC, L> BatchDriver<R, P, S, TM, TC, L>
@@ -93,6 +98,8 @@ where
             l1_head_source: Some(l1_head_source),
             safe_head_rx: None,
             drain_timeout: config.drain_timeout,
+            paused: false,
+            admin_rx: None,
         }
     }
 
@@ -103,6 +110,16 @@ where
     /// free blocks that are confirmed safe on L2.
     pub fn with_safe_head_rx(mut self, rx: tokio::sync::watch::Receiver<u64>) -> Self {
         self.safe_head_rx = Some(rx);
+        self
+    }
+
+    /// Wire an admin command channel into the driver.
+    ///
+    /// When set, the driver processes admin commands as part of its main
+    /// `select!` loop. When absent, the admin arm is permanently pending and
+    /// the driver behaves as if no admin server is configured.
+    pub fn with_admin_rx(mut self, rx: mpsc::Receiver<AdminCommand>) -> Self {
+        self.admin_rx = Some(rx);
         self
     }
 
@@ -227,6 +244,11 @@ where
 
     /// Block on the next external event using a biased `tokio::select!`.
     ///
+    /// Admin commands are handled inline in the loop — only non-admin events
+    /// are returned to the caller. When paused via [`AdminCommand::Pause`],
+    /// the source arm still fires but `Block`, `Flush`, and `Reorg` events are
+    /// silently discarded; source errors and exhaustion are still propagated.
+    ///
     /// Non-fatal L1 head source errors loop internally to avoid polluting the
     /// return type with a no-op variant.
     async fn next_event(&mut self) -> Result<DriverEvent, BatchDriverError> {
@@ -237,12 +259,55 @@ where
                 _ = self.runtime.cancelled() => DriverEvent::Shutdown,
 
                 event = self.source.next() => match event {
+                    Ok(L2BlockEvent::Block(_) | L2BlockEvent::Flush | L2BlockEvent::Reorg { .. })
+                        if self.paused =>
+                    {
+                        continue;
+                    }
                     Ok(L2BlockEvent::Block(block)) => DriverEvent::Block(block),
                     Ok(L2BlockEvent::Flush) => DriverEvent::Flush,
                     Ok(L2BlockEvent::Reorg { new_safe_head }) => DriverEvent::Reorg(new_safe_head),
                     Err(SourceError::Exhausted) => DriverEvent::Shutdown,
                     Err(e) => return Err(e.into()),
                 },
+
+                cmd = Self::next_admin_cmd(&mut self.admin_rx) => {
+                    match cmd {
+                        AdminCommand::Flush => return Ok(DriverEvent::Flush),
+                        AdminCommand::Pause => {
+                            self.paused = true;
+                            info!(paused = true, "batcher paused via admin");
+                        }
+                        AdminCommand::Resume => {
+                            self.paused = false;
+                            info!(paused = false, "batcher resumed via admin");
+                        }
+                        AdminCommand::SetThrottle { strategy, config } => {
+                            self.throttle.set_controller(
+                                ThrottleController::new(config, strategy)
+                            );
+                            info!("throttle controller replaced via admin");
+                        }
+                        AdminCommand::ResetThrottle => {
+                            self.throttle.reset();
+                            info!("throttle controller reset via admin");
+                        }
+                        AdminCommand::GetThrottleInfo { reply } => {
+                            let _ = reply.send(
+                                self.throttle.snapshot(self.pipeline.da_backlog_bytes())
+                            );
+                        }
+                        AdminCommand::GetStatus { reply } => {
+                            let _ = reply.send(BatcherStatus {
+                                paused: self.paused,
+                                in_flight: self.submissions.in_flight_count(),
+                                da_backlog_bytes: self.pipeline.da_backlog_bytes(),
+                            });
+                        }
+                    }
+                    // All commands except Flush loop to await the next real event.
+                    continue;
+                }
 
                 Some((id, outcome)) = self.submissions.next_settled() => {
                     DriverEvent::Receipt(id, outcome)
@@ -286,6 +351,20 @@ where
                 }
             };
             return Ok(event);
+        }
+    }
+
+    /// Returns the next admin command, or parks forever if no channel is wired.
+    ///
+    /// Takes only the `Option<Receiver>` to avoid a full `&mut self` borrow
+    /// conflicting with the other `select!` arms.
+    async fn next_admin_cmd(rx: &mut Option<mpsc::Receiver<AdminCommand>>) -> AdminCommand {
+        match rx {
+            Some(rx) => match rx.recv().await {
+                Some(cmd) => cmd,
+                None => std::future::pending().await,
+            },
+            None => std::future::pending().await,
         }
     }
 }

--- a/crates/batcher/core/src/lib.rs
+++ b/crates/batcher/core/src/lib.rs
@@ -15,7 +15,7 @@ pub use outcome::TxOutcome;
 
 mod throttle;
 pub use throttle::{
-    DaThrottle, ThrottleConfig, ThrottleController, ThrottleParams, ThrottleStrategy,
+    DaThrottle, ThrottleConfig, ThrottleController, ThrottleInfo, ThrottleParams, ThrottleStrategy,
 };
 
 mod throttle_client;
@@ -30,7 +30,13 @@ pub use config::BatchDriverConfig;
 mod event;
 pub use event::DriverEvent;
 
+mod admin;
+pub use admin::{
+    ADMIN_CHANNEL_CAPACITY, AdminCommand, AdminError, AdminHandle, AdminResult, BatcherStatus,
+};
+
 mod driver;
+pub use base_batcher_encoder::BatcherMetrics;
 pub use driver::BatchDriver;
 
 pub mod test_utils;

--- a/crates/batcher/core/src/throttle.rs
+++ b/crates/batcher/core/src/throttle.rs
@@ -4,7 +4,7 @@
 ///
 /// Defaults match the op-batcher reference implementation:
 /// 1 MB threshold, full intensity, linear strategy.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct ThrottleConfig {
     /// Backlog threshold in bytes at which throttling activates.
     /// Default: 1,000,000 bytes (1 MB).
@@ -59,13 +59,26 @@ impl ThrottleParams {
 }
 
 /// Strategy for calculating throttle intensity from DA backlog.
-#[derive(Debug, Clone)]
+#[derive(
+    Debug,
+    Clone,
+    PartialEq,
+    Eq,
+    derive_more::Display,
+    derive_more::FromStr,
+    serde::Serialize,
+    serde::Deserialize,
+)]
+#[serde(rename_all = "lowercase")]
 pub enum ThrottleStrategy {
     /// No throttling.
+    #[display("off")]
     Off,
     /// Step function: either 0 or `max_intensity` when above threshold.
+    #[display("step")]
     Step,
     /// Linear interpolation between 0 and `max_intensity` based on backlog.
+    #[display("linear")]
     Linear,
 }
 
@@ -101,6 +114,11 @@ impl ThrottleController {
     /// Returns a reference to the throttle configuration.
     pub const fn config(&self) -> &ThrottleConfig {
         &self.config
+    }
+
+    /// Returns the active throttle strategy.
+    pub const fn strategy(&self) -> &ThrottleStrategy {
+        &self.strategy
     }
 
     /// Compute DA size limits from the given intensity.
@@ -156,6 +174,26 @@ impl ThrottleController {
             }
         }
     }
+}
+
+/// Point-in-time snapshot of throttle controller state.
+///
+/// Returned by [`DaThrottle::snapshot`] and serialised directly as the
+/// `admin_getThrottleController` JSON-RPC response.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct ThrottleInfo {
+    /// Active throttle strategy.
+    pub strategy: ThrottleStrategy,
+    /// Backlog threshold in bytes at which throttling activates.
+    pub threshold_bytes: u64,
+    /// Maximum throttle intensity (0.0 to 1.0).
+    pub max_intensity: f64,
+    /// Current throttle intensity (0.0 when not throttling).
+    pub current_intensity: f64,
+    /// Current maximum DA bytes allowed per block.
+    pub max_block_size: u64,
+    /// Current maximum DA bytes allowed per transaction.
+    pub max_tx_size: u64,
 }
 
 /// Wraps a [`ThrottleController`] and a [`ThrottleClient`] with a dedup cache
@@ -216,6 +254,36 @@ impl<TC: crate::ThrottleClient> DaThrottle<TC> {
             self.last_applied = Some(new_limits);
         }
     }
+
+    /// Compute a point-in-time snapshot of the current throttle state.
+    ///
+    /// Params are derived from `backlog_bytes` on demand; no additional
+    /// state is stored in `DaThrottle` beyond what is already tracked.
+    pub fn snapshot(&self, backlog_bytes: u64) -> ThrottleInfo {
+        let params = self.controller.update(backlog_bytes);
+        let config = self.controller.config();
+        ThrottleInfo {
+            strategy: self.controller.strategy().clone(),
+            threshold_bytes: config.threshold_bytes,
+            max_intensity: config.max_intensity,
+            current_intensity: params.map_or(0.0, |p| p.intensity),
+            max_block_size: params.map_or(config.block_size_upper_limit, |p| p.max_block_size),
+            max_tx_size: params.map_or(config.tx_size_upper_limit, |p| p.max_tx_size),
+        }
+    }
+
+    /// Replace the controller and clear the dedup cache so new limits are
+    /// applied unconditionally on the next driver iteration.
+    pub const fn set_controller(&mut self, controller: ThrottleController) {
+        self.controller = controller;
+        self.last_applied = None;
+    }
+
+    /// Clear the dedup cache so the current limits are re-sent to the client
+    /// on the next driver iteration even if they have not changed.
+    pub const fn reset(&mut self) {
+        self.last_applied = None;
+    }
 }
 
 #[cfg(test)]
@@ -261,5 +329,23 @@ mod tests {
                 );
             }
         }
+    }
+
+    #[test]
+    fn strategy_display_parse_roundtrip() {
+        for (input, expected) in [
+            (ThrottleStrategy::Off, "off"),
+            (ThrottleStrategy::Step, "step"),
+            (ThrottleStrategy::Linear, "linear"),
+        ] {
+            assert_eq!(input.to_string(), expected);
+            assert_eq!(expected.parse::<ThrottleStrategy>().unwrap(), input);
+        }
+    }
+
+    #[test]
+    fn strategy_parse_rejects_invalid() {
+        assert!("foo".parse::<ThrottleStrategy>().is_err());
+        assert!("".parse::<ThrottleStrategy>().is_err());
     }
 }

--- a/crates/batcher/service/Cargo.toml
+++ b/crates/batcher/service/Cargo.toml
@@ -19,6 +19,7 @@ tokio-util.workspace = true
 async-trait.workspace = true
 base-tx-manager.workspace = true
 base-batcher-core.workspace = true
+base-batcher-admin.workspace = true
 base-alloy-network.workspace = true
 base-batcher-source.workspace = true
 base-batcher-encoder.workspace = true

--- a/crates/batcher/service/src/config.rs
+++ b/crates/batcher/service/src/config.rs
@@ -1,6 +1,6 @@
 //! Full batcher runtime configuration.
 
-use std::{fmt, str::FromStr, time::Duration};
+use std::{fmt, net::SocketAddr, str::FromStr, time::Duration};
 
 use alloy_primitives::B256;
 use base_batcher_core::ThrottleConfig;
@@ -66,6 +66,11 @@ pub struct BatcherConfig {
     pub resubmission_timeout: Duration,
     /// Throttle configuration (optional).
     pub throttle: Option<ThrottleConfig>,
+    /// Socket address for the admin JSON-RPC API.
+    ///
+    /// When set, the batcher exposes the `admin_*` RPC namespace on this address.
+    /// When `None` (the default), the admin server is disabled.
+    pub admin_addr: Option<SocketAddr>,
 }
 
 impl Default for BatcherConfig {
@@ -83,6 +88,7 @@ impl Default for BatcherConfig {
             num_confirmations: 1,
             resubmission_timeout: Duration::from_secs(48),
             throttle: Some(ThrottleConfig::default()),
+            admin_addr: None,
         }
     }
 }

--- a/crates/batcher/service/src/service.rs
+++ b/crates/batcher/service/src/service.rs
@@ -6,8 +6,9 @@ use alloy_provider::{Provider, ProviderBuilder, RootProvider};
 use alloy_rpc_types_eth::BlockNumberOrTag;
 use base_alloy_consensus::OpBlock;
 use base_alloy_network::Base;
+use base_batcher_admin::AdminServer;
 use base_batcher_core::{
-    BatchDriver, DaThrottle, NoopThrottleClient, ThrottleClient, ThrottleConfig,
+    AdminHandle, BatchDriver, DaThrottle, NoopThrottleClient, ThrottleClient, ThrottleConfig,
     ThrottleController, ThrottleStrategy,
 };
 use base_batcher_encoder::BatchEncoder;
@@ -100,6 +101,7 @@ type ServiceDriver = BatchDriver<
 /// main driver loop, or spawn it in a background task for in-process use.
 pub struct ReadyBatcher {
     driver: ServiceDriver,
+    admin_server: Option<AdminServer>,
 }
 
 impl std::fmt::Debug for ReadyBatcher {
@@ -112,7 +114,20 @@ impl ReadyBatcher {
     /// Run the batch submission loop until the runtime is cancelled.
     pub async fn run(self) -> eyre::Result<()> {
         info!("batcher driver running");
-        self.driver.run().await?;
+        match self.admin_server {
+            Some(admin) => {
+                let driver_run = self.driver.run();
+                tokio::pin!(driver_run);
+                tokio::select! {
+                    r = &mut driver_run => { r?; }
+                    () = admin.stopped() => {
+                        warn!("admin server stopped unexpectedly; batcher continues without admin API");
+                        driver_run.await?;
+                    }
+                }
+            }
+            None => self.driver.run().await?,
+        }
         info!("batcher service shutting down");
         Ok(())
     }
@@ -396,7 +411,7 @@ impl BatcherService {
             .spawn(runtime.token().clone());
 
         // Build the driver — all fallible setup is complete at this point.
-        let driver = BatchDriver::new(
+        let mut driver = BatchDriver::new(
             runtime,
             encoder,
             source,
@@ -411,7 +426,16 @@ impl BatcherService {
         )
         .with_safe_head_rx(safe_head_rx);
 
+        let admin_server = match self.config.admin_addr {
+            Some(addr) => {
+                let (admin_handle, admin_rx) = AdminHandle::channel();
+                driver = driver.with_admin_rx(admin_rx);
+                Some(AdminServer::spawn(addr, admin_handle).await?)
+            }
+            None => None,
+        };
+
         info!("batcher service components initialized");
-        Ok(ReadyBatcher { driver })
+        Ok(ReadyBatcher { driver, admin_server })
     }
 }


### PR DESCRIPTION
## Summary

Adds a runtime admin JSON-RPC API to the batcher, served over a configurable port via `--admin-port` / `BATCHER_ADMIN_PORT`. The API is implemented with jsonrpsee under the `admin_` namespace and exposes pause, resume, flush, and DA throttle control without requiring a batcher restart.

The implementation is split across a new `base-batcher-admin` crate that owns the jsonrpsee server and RPC trait, and additions to `base-batcher-core` that wire an optional mpsc channel into the driver event loop. The `BatchDriver` gains a `paused` flag and an admin command receiver; when paused, block and flush events from the source are discarded while errors still propagate so the driver never hangs on a closed source. The admin server is only spawned when a port is configured, and if it exits unexpectedly the driver continues running without the admin API rather than crashing.

DA throttle control lets callers switch strategy (`off`, `step`, `linear`) and update throttle parameters at runtime, or reset to the compiled-in defaults. A `GetStatus` and `GetThrottleInfo` command return current driver state as JSON.

CLI: `--admin-port <PORT>` / `BATCHER_ADMIN_PORT`.