### PR TITLE
chore(batcher): Refactor Driver Test Structure

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2616,6 +2616,7 @@ dependencies = [
  "base-tx-manager",
  "futures",
  "metrics",
+ "rstest",
  "thiserror 2.0.18",
  "tokio",
  "tracing",

--- a/crates/batcher/core/Cargo.toml
+++ b/crates/batcher/core/Cargo.toml
@@ -12,21 +12,30 @@ repository.workspace = true
 workspace = true
 
 [dependencies]
-futures.workspace = true
-metrics.workspace = true
+# local
 base-blobs.workspace = true
 base-tx-manager.workspace = true
 base-batcher-source.workspace = true
 base-batcher-encoder.workspace = true
-tracing = { workspace = true, features = ["std"] }
-thiserror = { workspace = true, features = ["std"] }
 base-protocol = { workspace = true, features = ["std"] }
 base-runtime = { workspace = true, features = ["tokio"] }
-alloy-primitives = { workspace = true, features = ["std"] }
 base-alloy-consensus = { workspace = true, features = ["std"] }
+
+# external
+futures.workspace = true
+metrics.workspace = true
+tracing = { workspace = true, features = ["std"] }
+thiserror = { workspace = true, features = ["std"] }
+alloy-primitives = { workspace = true, features = ["std"] }
 tokio = { workspace = true, features = ["sync", "macros", "rt"] }
 
+# optional — activated by the `test-utils` feature
+async-trait = { workspace = true, optional = true }
+alloy-consensus = { workspace = true, features = ["std"], optional = true }
+alloy-rpc-types-eth = { workspace = true, features = ["std"], optional = true }
+
 [dev-dependencies]
+rstest.workspace = true
 async-trait.workspace = true
 alloy-consensus = { workspace = true, features = ["std"] }
 alloy-rpc-types-eth = { workspace = true, features = ["std"] }
@@ -34,3 +43,10 @@ base-alloy-consensus = { workspace = true, features = ["std"] }
 base-runtime = { workspace = true, features = ["test-utils"] }
 base-protocol = { workspace = true, features = ["std"] }
 tokio = { workspace = true, features = ["macros", "rt", "time"] }
+
+[[test]]
+name = "driver"
+required-features = ["test-utils"]
+
+[features]
+test-utils = ["dep:async-trait", "dep:alloy-consensus", "dep:alloy-rpc-types-eth"]

--- a/crates/batcher/core/Cargo.toml
+++ b/crates/batcher/core/Cargo.toml
@@ -49,4 +49,8 @@ name = "driver"
 required-features = ["test-utils"]
 
 [features]
-test-utils = ["dep:async-trait", "dep:alloy-consensus", "dep:alloy-rpc-types-eth"]
+test-utils = [
+	"dep:alloy-consensus",
+	"dep:alloy-rpc-types-eth",
+	"dep:async-trait",
+]

--- a/crates/batcher/core/README.md
+++ b/crates/batcher/core/README.md
@@ -1,6 +1,58 @@
-# base-batcher-core
+# `base-batcher-core`
 
-Async orchestration loop for the Base batcher. `BatchDriver` combines a
-`BatchPipeline` (encoding), an `UnsafeBlockSource` (L2 block delivery), and a
-`TxManager` (L1 submission) into a single `tokio::select!` task with
-`FuturesUnordered` receipt tracking and semaphore-based backpressure.
+Async orchestration core for the Base batcher.
+
+`BatchDriver` is the central type exported by this crate. It is generic over a `Runtime`, a
+`BatchPipeline` (frame encoding), an `UnsafeBlockSource` (L2 block delivery), an `L1HeadSource`
+(L1 chain head tracking), a `TxManager` (L1 submission), and a `ThrottleClient` (DA limit
+application). The driver runs a single `tokio::select!` task that reacts to four concurrent
+event streams: new L2 unsafe blocks, settled L1 heads, completed in-flight transaction receipts,
+and a periodic DA throttle tick. Each arm of the loop advances the pipeline or adjusts submission
+pressure without blocking the others.
+
+`BatchDriverConfig` carries the three parameters the driver needs at construction: the batcher
+inbox address on L1, the maximum number of concurrently in-flight transactions, and the drain
+timeout used during shutdown to wait for outstanding receipts before abandoning them.
+
+`SubmissionQueue` owns the entire L1 submission lifecycle. It holds the `TxManager`, a
+`FuturesUnordered` set of in-flight receipt futures, a counting `Semaphore` for backpressure, and
+a boolean txpool-blocked flag. When the driver calls `submit_pending`, the queue loops: it tries
+to acquire a semaphore permit, asks the pipeline for the next ready submission, encodes frames as
+blobs or calldata depending on the `DaType`, and hands the resulting `TxCandidate` to the
+`TxManager`. Each submission spawns a permit-holding future that resolves to a `(SubmissionId,
+TxOutcome)` pair when the transaction settles. Confirmed receipts call `pipeline.confirm` and
+`pipeline.advance_l1_head`. Failed submissions are requeued. A `TxpoolBlocked` outcome sets a
+sticky flag that prevents further submissions until `recover_txpool` successfully cancels the
+stuck transaction. On reorg, `SubmissionQueue::discard` drops all in-flight futures and releases
+their permits so the freshly reset pipeline is not corrupted by stale completions.
+
+`TxOutcome` represents the three terminal states of an L1 submission: `Confirmed { l1_block }`,
+`Failed`, and `TxpoolBlocked`. Failed frames are always requeued for retry; txpool-blocked frames
+are also requeued but submission is suspended until the nonce slot is freed.
+
+The throttle subsystem controls how much DA data the sequencer may include per block and per
+transaction based on the L1 DA backlog. `ThrottleController` takes a `ThrottleConfig` and a
+`ThrottleStrategy` and produces `ThrottleParams` from a raw backlog byte count.
+`ThrottleStrategy::Off` disables throttling entirely. `ThrottleStrategy::Step` applies full
+intensity when the backlog exceeds the configured threshold. `ThrottleStrategy::Linear` grows
+intensity linearly from zero at the threshold to `max_intensity` at twice the threshold, which
+matches the op-batcher reference implementation. `ThrottleParams` carries a fractional `intensity`
+value and the corresponding `max_block_size` and `max_tx_size` byte limits computed by
+interpolating between the upper and lower limits in `ThrottleConfig`. `DaThrottle` wraps a
+`ThrottleController` and a `ThrottleClient` with a last-applied dedup cache so that the
+`miner_setMaxDASize` RPC call is only issued when the computed limits actually change between ticks.
+
+`ThrottleClient` is the async trait that connects the throttle controller to the block builder.
+Its single method, `set_max_da_size`, forwards the per-transaction and per-block byte limits to
+the execution client. The canonical implementation calls the `miner_setMaxDASize` RPC method;
+`NoopThrottleClient` silently discards all calls and is used when throttling is disabled, allowing
+the driver to invoke the same code path in both cases without special casing.
+
+This crate does not perform frame or blob encoding — those are handled by `base-batcher-encoder`
+and `base-blobs`. It does not implement L2 block sourcing or L1 head tracking — those come from
+`base-batcher-source`. Transaction signing, gas estimation, and confirmation polling belong to
+`base-tx-manager`. Service configuration and process startup live in `base-batcher-service`.
+
+## License
+
+Licensed under the [MIT License](https://github.com/base/base/blob/main/LICENSE).

--- a/crates/batcher/core/src/config.rs
+++ b/crates/batcher/core/src/config.rs
@@ -1,0 +1,16 @@
+//! Configuration types for the batch driver.
+
+use std::time::Duration;
+
+/// Configuration for a [`BatchDriver`](crate::BatchDriver) instance.
+#[derive(Debug, Clone)]
+pub struct BatchDriverConfig {
+    /// The batcher inbox address on L1.
+    pub inbox: alloy_primitives::Address,
+    /// Maximum number of in-flight transactions before back-pressure kicks in.
+    pub max_pending_transactions: usize,
+    /// Maximum time to wait for in-flight transactions to settle when draining
+    /// on cancellation or source exhaustion. Submissions that have not
+    /// confirmed within this window are abandoned.
+    pub drain_timeout: Duration,
+}

--- a/crates/batcher/core/src/driver.rs
+++ b/crates/batcher/core/src/driver.rs
@@ -316,7 +316,7 @@ mod tests {
         Runner::start(Config::seeded(0), |ctx| async move {
             let recorded = Arc::new(Mutex::new(Recorded::default()));
             let mut pipeline = TrackingPipeline::new(Arc::clone(&recorded));
-            pipeline.submissions.push_back(SubmissionStub::new());
+            pipeline.submissions.push_back(SubmissionStub::stub());
 
             let handle = ctx.spawn(
                 DriverFixture::build(
@@ -346,7 +346,7 @@ mod tests {
         Runner::start(Config::seeded(0), |ctx| async move {
             let recorded = Arc::new(Mutex::new(Recorded::default()));
             let mut pipeline = TrackingPipeline::new(Arc::clone(&recorded));
-            pipeline.submissions.push_back(SubmissionStub::new());
+            pipeline.submissions.push_back(SubmissionStub::stub());
 
             let handle = ctx
                 .spawn(DriverFixture::build(ctx.clone(), pipeline, ImmediateFailTxManager).run());

--- a/crates/batcher/core/src/driver.rs
+++ b/crates/batcher/core/src/driver.rs
@@ -3,29 +3,18 @@
 use std::time::Duration;
 
 use base_alloy_consensus::OpBlock;
-use base_batcher_encoder::{BatchPipeline, StepResult, SubmissionId};
+use base_batcher_encoder::{BatchPipeline, StepResult};
 use base_batcher_source::{
     L1HeadEvent, L1HeadSource, L2BlockEvent, SourceError, UnsafeBlockSource,
 };
-use base_protocol::L2BlockInfo;
 use base_runtime::Runtime;
 use base_tx_manager::TxManager;
 use tracing::{debug, error, info, warn};
 
-use crate::{BatchDriverError, DaThrottle, SubmissionQueue, ThrottleClient, TxOutcome};
-
-/// Configuration for a [`BatchDriver`] instance.
-#[derive(Debug, Clone)]
-pub struct BatchDriverConfig {
-    /// The batcher inbox address on L1.
-    pub inbox: alloy_primitives::Address,
-    /// Maximum number of in-flight transactions before back-pressure kicks in.
-    pub max_pending_transactions: usize,
-    /// Maximum time to wait for in-flight transactions to settle when draining
-    /// on cancellation or source exhaustion. Submissions that have not
-    /// confirmed within this window are abandoned.
-    pub drain_timeout: Duration,
-}
+use crate::{
+    BatchDriverConfig, BatchDriverError, DaThrottle, SubmissionQueue, ThrottleClient,
+};
+use crate::event::DriverEvent;
 
 /// Async orchestration loop for the batcher.
 ///
@@ -67,31 +56,6 @@ where
     drain_timeout: Duration,
 }
 
-/// Maximum number of encoding steps to run synchronously per outer loop iteration
-/// before yielding to the tokio executor. Prevents a large block backlog from
-/// starving receipt processing and cancellation checks.
-const STEP_BUDGET: usize = 128;
-
-/// Events the driver can receive from external sources during the I/O phase.
-enum DriverEvent {
-    /// Cancellation token fired, or L2 source signalled exhausted.
-    Shutdown,
-    /// New L2 unsafe block from the source.
-    Block(Box<OpBlock>),
-    /// Source requested a force-flush of the current channel.
-    Flush,
-    /// L2 reorganisation; new safe head provided.
-    Reorg(L2BlockInfo),
-    /// An in-flight L1 transaction settled.
-    Receipt(SubmissionId, TxOutcome),
-    /// L1 chain head advanced.
-    L1Head(u64),
-    /// Safe L2 head advanced (from watch channel).
-    SafeHead(u64),
-    /// L1 head source permanently closed (Exhausted or Closed error).
-    L1SourceClosed,
-}
-
 impl<R, P, S, TM, TC, L> BatchDriver<R, P, S, TM, TC, L>
 where
     R: Runtime,
@@ -101,6 +65,11 @@ where
     TC: ThrottleClient,
     L: L1HeadSource,
 {
+    /// Maximum number of encoding steps to run synchronously per outer loop iteration
+    /// before yielding to the tokio executor. Prevents a large block backlog from
+    /// starving receipt processing and cancellation checks.
+    pub const STEP_BUDGET: usize = 128;
+
     /// Create a new [`BatchDriver`].
     pub fn new(
         runtime: R,
@@ -198,11 +167,11 @@ where
         }
     }
 
-    /// Drain encoding steps synchronously up to `STEP_BUDGET`.
+    /// Drain encoding steps synchronously up to [`Self::STEP_BUDGET`].
     ///
     /// Returns `Err` on a fatal [`StepError`](base_batcher_encoder::StepError).
     fn drain_encoding(&mut self) -> Result<(), BatchDriverError> {
-        let mut budget = STEP_BUDGET;
+        let mut budget = Self::STEP_BUDGET;
         let mut steps = 0usize;
         loop {
             match self.pipeline.step() {
@@ -323,379 +292,19 @@ where
 
 #[cfg(test)]
 mod tests {
-    use std::{
-        fmt,
-        sync::{Arc, Mutex},
-        time::Duration,
-    };
+    use std::{sync::{Arc, Mutex}, time::Duration};
 
-    use alloy_consensus::{Eip658Value, Receipt, ReceiptEnvelope, ReceiptWithBloom};
-    use alloy_primitives::{Address, B256, Bloom};
-    use alloy_rpc_types_eth::TransactionReceipt;
-    use async_trait::async_trait;
-    use base_alloy_consensus::OpBlock;
-    use base_batcher_encoder::{
-        BatchPipeline, BatchSubmission, ReorgError, StepError, StepResult, SubmissionId,
-    };
-    use base_batcher_source::{
-        ChannelBlockSource, ChannelL1HeadSource, L1HeadEvent, L1HeadSource, L2BlockEvent,
-        SourceError, UnsafeBlockSource, test_utils::InMemoryBlockSource,
-    };
-    use base_protocol::{BlockInfo, ChannelId, Frame, L2BlockInfo};
+    use base_batcher_encoder::{BatchSubmission, DaType, SubmissionId};
+    use base_protocol::{ChannelId, Frame};
     use base_runtime::{
-        Cancellation, Clock, Runtime, Spawner,
+        Cancellation, Clock, Spawner,
         deterministic::{Config, Runner},
     };
-    use base_tx_manager::{SendHandle, SendResponse, TxCandidate, TxManager, TxManagerError};
-    use tokio::sync::{mpsc, oneshot};
 
-    use super::{BatchDriver, BatchDriverConfig};
-    use crate::{
-        DaThrottle, NoopThrottleClient, ThrottleConfig, ThrottleController, ThrottleStrategy,
-        test_utils::TrackingThrottleClient,
+    use crate::test_utils::{
+        DriverFixture, ImmediateConfirmTxManager, ImmediateFailTxManager, NeverConfirmTxManager,
+        Recorded, SubmissionStub, TrackingPipeline,
     };
-
-    // ---- Shared recording state ----
-
-    #[derive(Debug, Default)]
-    struct Recorded {
-        l1_heads: Vec<u64>,
-        requeued: Vec<SubmissionId>,
-        /// Submission IDs in the order they were dequeued via `next_submission()`.
-        dequeued: Vec<SubmissionId>,
-        /// Number of times `reset()` was called.
-        resets: usize,
-        /// Safe L2 block numbers passed to `prune_safe`.
-        safe_numbers: Vec<u64>,
-        /// Number of times `force_close_channel()` was called.
-        force_close_count: usize,
-    }
-
-    // ---- Pipeline that records advance_l1_head calls via shared state ----
-
-    #[derive(Debug)]
-    struct TrackingPipeline {
-        recorded: Arc<Mutex<Recorded>>,
-        submissions: std::collections::VecDeque<BatchSubmission>,
-        /// Value returned by `da_backlog_bytes()`. Default: 0.
-        da_backlog_bytes_value: u64,
-    }
-
-    impl TrackingPipeline {
-        fn new(recorded: Arc<Mutex<Recorded>>) -> Self {
-            Self { recorded, submissions: Default::default(), da_backlog_bytes_value: 0 }
-        }
-
-        fn with_da_backlog(mut self, value: u64) -> Self {
-            self.da_backlog_bytes_value = value;
-            self
-        }
-    }
-
-    impl BatchPipeline for TrackingPipeline {
-        fn add_block(&mut self, _: OpBlock) -> Result<(), (ReorgError, Box<OpBlock>)> {
-            Ok(())
-        }
-        fn step(&mut self) -> Result<StepResult, StepError> {
-            Ok(StepResult::Idle)
-        }
-        fn next_submission(&mut self) -> Option<BatchSubmission> {
-            let sub = self.submissions.pop_front()?;
-            self.recorded.lock().unwrap().dequeued.push(sub.id);
-            Some(sub)
-        }
-        fn confirm(&mut self, _: SubmissionId, _: u64) {}
-        fn requeue(&mut self, id: SubmissionId) {
-            self.recorded.lock().unwrap().requeued.push(id);
-        }
-        fn force_close_channel(&mut self) {
-            self.recorded.lock().unwrap().force_close_count += 1;
-        }
-        fn advance_l1_head(&mut self, l1_block: u64) {
-            self.recorded.lock().unwrap().l1_heads.push(l1_block);
-        }
-        fn prune_safe(&mut self, safe_l2_number: u64) {
-            self.recorded.lock().unwrap().safe_numbers.push(safe_l2_number);
-        }
-        fn reset(&mut self) {
-            self.recorded.lock().unwrap().resets += 1;
-        }
-        fn da_backlog_bytes(&self) -> u64 {
-            self.da_backlog_bytes_value
-        }
-    }
-
-    // ---- Pipeline that always returns ReorgError from add_block ----
-
-    #[derive(Debug)]
-    struct ReorgPipeline {
-        recorded: Arc<Mutex<Recorded>>,
-    }
-
-    impl ReorgPipeline {
-        fn new(recorded: Arc<Mutex<Recorded>>) -> Self {
-            Self { recorded }
-        }
-    }
-
-    impl BatchPipeline for ReorgPipeline {
-        fn add_block(&mut self, block: OpBlock) -> Result<(), (ReorgError, Box<OpBlock>)> {
-            Err((
-                ReorgError::ParentMismatch { expected: B256::ZERO, got: B256::with_last_byte(1) },
-                Box::new(block),
-            ))
-        }
-        fn step(&mut self) -> Result<StepResult, StepError> {
-            Ok(StepResult::Idle)
-        }
-        fn next_submission(&mut self) -> Option<BatchSubmission> {
-            None
-        }
-        fn confirm(&mut self, _: SubmissionId, _: u64) {}
-        fn requeue(&mut self, _: SubmissionId) {}
-        fn force_close_channel(&mut self) {}
-        fn advance_l1_head(&mut self, _: u64) {}
-        fn prune_safe(&mut self, _: u64) {}
-        fn reset(&mut self) {
-            self.recorded.lock().unwrap().resets += 1;
-        }
-        fn da_backlog_bytes(&self) -> u64 {
-            0
-        }
-    }
-
-    // ---- Source that delivers one block then parks forever ----
-
-    #[derive(Debug)]
-    struct OneBlockSource {
-        delivered: bool,
-    }
-
-    impl OneBlockSource {
-        fn new() -> Self {
-            Self { delivered: false }
-        }
-    }
-
-    #[async_trait]
-    impl UnsafeBlockSource for OneBlockSource {
-        async fn next(&mut self) -> Result<L2BlockEvent, SourceError> {
-            if !self.delivered {
-                self.delivered = true;
-                Ok(L2BlockEvent::Block(Box::default()))
-            } else {
-                std::future::pending().await
-            }
-        }
-    }
-
-    // ---- Source that parks the arm so the submission arm can fire ----
-
-    #[derive(Debug)]
-    struct PendingSource;
-
-    #[async_trait]
-    impl UnsafeBlockSource for PendingSource {
-        async fn next(&mut self) -> Result<L2BlockEvent, SourceError> {
-            std::future::pending().await
-        }
-    }
-
-    // ---- L1 head source that parks forever (default for tests not testing L1 head) ----
-
-    #[derive(Debug)]
-    struct PendingL1HeadSource;
-
-    #[async_trait]
-    impl L1HeadSource for PendingL1HeadSource {
-        async fn next(&mut self) -> Result<L1HeadEvent, SourceError> {
-            std::future::pending().await
-        }
-    }
-
-    // ---- TxManager helpers ----
-
-    fn stub_receipt(block_number: u64) -> TransactionReceipt {
-        let inner = ReceiptEnvelope::Legacy(ReceiptWithBloom {
-            receipt: Receipt {
-                status: Eip658Value::Eip658(true),
-                cumulative_gas_used: 21_000,
-                logs: vec![],
-            },
-            logs_bloom: Bloom::ZERO,
-        });
-        TransactionReceipt {
-            inner,
-            transaction_hash: B256::ZERO,
-            transaction_index: Some(0),
-            block_hash: Some(B256::ZERO),
-            block_number: Some(block_number),
-            gas_used: 21_000,
-            effective_gas_price: 1_000_000_000,
-            blob_gas_used: None,
-            blob_gas_price: None,
-            from: Address::ZERO,
-            to: Some(Address::ZERO),
-            contract_address: None,
-        }
-    }
-
-    /// Immediately confirms every submission at the given L1 block number.
-    #[derive(Debug)]
-    struct ImmediateConfirmTxManager {
-        l1_block: u64,
-    }
-
-    impl TxManager for ImmediateConfirmTxManager {
-        async fn send(&self, _: TxCandidate) -> SendResponse {
-            unreachable!()
-        }
-
-        fn send_async(
-            &self,
-            _: TxCandidate,
-        ) -> impl std::future::Future<Output = SendHandle> + Send {
-            let (tx, rx) = oneshot::channel();
-            let _ = tx.send(Ok(stub_receipt(self.l1_block)));
-            std::future::ready(SendHandle::new(rx))
-        }
-
-        fn sender_address(&self) -> Address {
-            Address::ZERO
-        }
-    }
-
-    /// Immediately fails every submission.
-    #[derive(Debug)]
-    struct ImmediateFailTxManager;
-
-    impl TxManager for ImmediateFailTxManager {
-        async fn send(&self, _: TxCandidate) -> SendResponse {
-            unreachable!()
-        }
-
-        fn send_async(
-            &self,
-            _: TxCandidate,
-        ) -> impl std::future::Future<Output = SendHandle> + Send {
-            let (tx, rx) = oneshot::channel();
-            let _ = tx.send(Err(TxManagerError::ChannelClosed));
-            std::future::ready(SendHandle::new(rx))
-        }
-
-        fn sender_address(&self) -> Address {
-            Address::ZERO
-        }
-    }
-
-    /// Never confirms any submission — the in-flight future parks forever.
-    ///
-    /// This is used to test semaphore backpressure: with this manager, permits
-    /// are consumed but never released, so `try_acquire_owned` will fail once
-    /// the limit is reached and no further submissions will be dequeued.
-    struct NeverConfirmTxManager;
-
-    impl fmt::Debug for NeverConfirmTxManager {
-        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-            f.write_str("NeverConfirmTxManager")
-        }
-    }
-
-    impl TxManager for NeverConfirmTxManager {
-        async fn send(&self, _: TxCandidate) -> SendResponse {
-            unreachable!()
-        }
-
-        fn send_async(
-            &self,
-            _: TxCandidate,
-        ) -> impl std::future::Future<Output = SendHandle> + Send {
-            let (tx, rx) = oneshot::channel();
-            // Keep tx alive by forgetting it — rx parks forever without a tokio runtime.
-            std::mem::forget(tx);
-            std::future::ready(SendHandle::new(rx))
-        }
-
-        fn sender_address(&self) -> Address {
-            Address::ZERO
-        }
-    }
-
-    /// Minimal [`BatchSubmission`] whose single empty frame blob-encodes cleanly.
-    fn make_submission() -> BatchSubmission {
-        make_submission_with_id(0)
-    }
-
-    fn make_submission_with_id(id: u64) -> BatchSubmission {
-        BatchSubmission {
-            id: SubmissionId(id),
-            channel_id: ChannelId::default(),
-            da_type: base_batcher_encoder::DaType::Blob,
-            frames: vec![Arc::new(Frame::default())],
-        }
-    }
-
-    fn noop_throttle() -> ThrottleController {
-        ThrottleController::new(
-            ThrottleConfig { threshold_bytes: 0, max_intensity: 0.0, ..Default::default() },
-            ThrottleStrategy::Off,
-        )
-    }
-
-    fn make_driver<R: Runtime, TM: TxManager>(
-        runtime: R,
-        pipeline: TrackingPipeline,
-        tx_manager: TM,
-    ) -> BatchDriver<
-        R,
-        TrackingPipeline,
-        PendingSource,
-        TM,
-        Arc<NoopThrottleClient>,
-        PendingL1HeadSource,
-    > {
-        BatchDriver::new(
-            runtime,
-            pipeline,
-            PendingSource,
-            tx_manager,
-            BatchDriverConfig {
-                inbox: Address::ZERO,
-                max_pending_transactions: 1,
-                drain_timeout: Duration::from_millis(10),
-            },
-            DaThrottle::new(noop_throttle(), Arc::new(NoopThrottleClient)),
-            PendingL1HeadSource,
-        )
-    }
-
-    fn make_driver_with_max_pending<R: Runtime, TM: TxManager>(
-        runtime: R,
-        pipeline: TrackingPipeline,
-        tx_manager: TM,
-        max_pending: usize,
-    ) -> BatchDriver<
-        R,
-        TrackingPipeline,
-        PendingSource,
-        TM,
-        Arc<NoopThrottleClient>,
-        PendingL1HeadSource,
-    > {
-        BatchDriver::new(
-            runtime,
-            pipeline,
-            PendingSource,
-            tx_manager,
-            BatchDriverConfig {
-                inbox: Address::ZERO,
-                max_pending_transactions: max_pending,
-                drain_timeout: Duration::from_millis(10),
-            },
-            DaThrottle::new(noop_throttle(), Arc::new(NoopThrottleClient)),
-            PendingL1HeadSource,
-        )
-    }
 
     /// `advance_l1_head` must be called with the confirmed L1 block on every
     /// confirmation so the encoder can detect channel timeouts.
@@ -704,10 +313,10 @@ mod tests {
         Runner::start(Config::seeded(0), |ctx| async move {
             let recorded = Arc::new(Mutex::new(Recorded::default()));
             let mut pipeline = TrackingPipeline::new(Arc::clone(&recorded));
-            pipeline.submissions.push_back(make_submission());
+            pipeline.submissions.push_back(SubmissionStub::new());
 
             let handle = ctx.spawn(
-                make_driver(ctx.clone(), pipeline, ImmediateConfirmTxManager { l1_block: 42 })
+                DriverFixture::build(ctx.clone(), pipeline, ImmediateConfirmTxManager { l1_block: 42 })
                     .run(),
             );
 
@@ -730,10 +339,10 @@ mod tests {
         Runner::start(Config::seeded(0), |ctx| async move {
             let recorded = Arc::new(Mutex::new(Recorded::default()));
             let mut pipeline = TrackingPipeline::new(Arc::clone(&recorded));
-            pipeline.submissions.push_back(make_submission());
+            pipeline.submissions.push_back(SubmissionStub::new());
 
             let handle =
-                ctx.spawn(make_driver(ctx.clone(), pipeline, ImmediateFailTxManager).run());
+                ctx.spawn(DriverFixture::build(ctx.clone(), pipeline, ImmediateFailTxManager).run());
 
             ctx.sleep(Duration::from_millis(50)).await;
             ctx.cancel();
@@ -763,12 +372,13 @@ mod tests {
             pipeline.submissions.push_back(BatchSubmission {
                 id: SubmissionId(0),
                 channel_id: ChannelId::default(),
-                da_type: base_batcher_encoder::DaType::Blob,
+                da_type: DaType::Blob,
                 frames: vec![Arc::new(Frame { data: vec![0u8; OVERSIZED], ..Frame::default() })],
             });
 
             let handle = ctx.spawn(
-                make_driver(ctx.clone(), pipeline, ImmediateConfirmTxManager { l1_block: 1 }).run(),
+                DriverFixture::build(ctx.clone(), pipeline, ImmediateConfirmTxManager { l1_block: 1 })
+                    .run(),
             );
 
             ctx.sleep(Duration::from_millis(50)).await;
@@ -798,11 +408,11 @@ mod tests {
         Runner::start(Config::seeded(0), |ctx| async move {
             let recorded = Arc::new(Mutex::new(Recorded::default()));
             let mut pipeline = TrackingPipeline::new(Arc::clone(&recorded));
-            pipeline.submissions.push_back(make_submission_with_id(0));
-            pipeline.submissions.push_back(make_submission_with_id(1));
+            pipeline.submissions.push_back(SubmissionStub::with_id(0));
+            pipeline.submissions.push_back(SubmissionStub::with_id(1));
 
             let handle = ctx.spawn(
-                make_driver_with_max_pending(
+                DriverFixture::build_with_max_pending(
                     ctx.clone(),
                     pipeline,
                     ImmediateConfirmTxManager { l1_block: 10 },
@@ -830,11 +440,12 @@ mod tests {
         Runner::start(Config::seeded(0), |ctx| async move {
             let recorded = Arc::new(Mutex::new(Recorded::default()));
             let mut pipeline = TrackingPipeline::new(Arc::clone(&recorded));
-            pipeline.submissions.push_back(make_submission_with_id(0));
-            pipeline.submissions.push_back(make_submission_with_id(1));
+            pipeline.submissions.push_back(SubmissionStub::with_id(0));
+            pipeline.submissions.push_back(SubmissionStub::with_id(1));
 
             let handle = ctx.spawn(
-                make_driver_with_max_pending(ctx.clone(), pipeline, NeverConfirmTxManager, 1).run(),
+                DriverFixture::build_with_max_pending(ctx.clone(), pipeline, NeverConfirmTxManager, 1)
+                    .run(),
             );
 
             ctx.sleep(Duration::from_millis(50)).await;
@@ -857,11 +468,11 @@ mod tests {
         Runner::start(Config::seeded(0), |ctx| async move {
             let recorded = Arc::new(Mutex::new(Recorded::default()));
             let mut pipeline = TrackingPipeline::new(Arc::clone(&recorded));
-            pipeline.submissions.push_back(make_submission_with_id(0));
-            pipeline.submissions.push_back(make_submission_with_id(1));
+            pipeline.submissions.push_back(SubmissionStub::with_id(0));
+            pipeline.submissions.push_back(SubmissionStub::with_id(1));
 
             let handle = ctx.spawn(
-                make_driver_with_max_pending(
+                DriverFixture::build_with_max_pending(
                     ctx.clone(),
                     pipeline,
                     ImmediateConfirmTxManager { l1_block: 7 },
@@ -881,771 +492,6 @@ mod tests {
                 vec![7, 7],
                 "both submissions must be confirmed once the permit is freed between them"
             );
-        });
-    }
-
-    // ---- Pipeline that fails once then succeeds ----
-
-    /// Pipeline that rejects the first `add_block` call and accepts all subsequent ones.
-    ///
-    /// Used to verify that the driver re-adds the triggering block after `reset()`,
-    /// so the block is not silently lost when the source won't re-deliver it.
-    #[derive(Debug)]
-    struct OneReorgPipeline {
-        /// Number of times `add_block` succeeded (post-reorg re-adds).
-        blocks_accepted: Arc<Mutex<usize>>,
-        /// Whether the next `add_block` call should simulate a reorg.
-        fail_next: bool,
-        resets: Arc<Mutex<usize>>,
-    }
-
-    impl OneReorgPipeline {
-        fn new(blocks_accepted: Arc<Mutex<usize>>, resets: Arc<Mutex<usize>>) -> Self {
-            Self { blocks_accepted, fail_next: true, resets }
-        }
-    }
-
-    impl BatchPipeline for OneReorgPipeline {
-        fn add_block(&mut self, block: OpBlock) -> Result<(), (ReorgError, Box<OpBlock>)> {
-            if self.fail_next {
-                self.fail_next = false;
-                return Err((
-                    ReorgError::ParentMismatch {
-                        expected: B256::ZERO,
-                        got: B256::with_last_byte(1),
-                    },
-                    Box::new(block),
-                ));
-            }
-            *self.blocks_accepted.lock().unwrap() += 1;
-            Ok(())
-        }
-        fn step(&mut self) -> Result<StepResult, StepError> {
-            Ok(StepResult::Idle)
-        }
-        fn next_submission(&mut self) -> Option<BatchSubmission> {
-            None
-        }
-        fn confirm(&mut self, _: SubmissionId, _: u64) {}
-        fn requeue(&mut self, _: SubmissionId) {}
-        fn force_close_channel(&mut self) {}
-        fn advance_l1_head(&mut self, _: u64) {}
-        fn prune_safe(&mut self, _: u64) {}
-        fn reset(&mut self) {
-            *self.resets.lock().unwrap() += 1;
-        }
-        fn da_backlog_bytes(&self) -> u64 {
-            0
-        }
-    }
-
-    /// When `add_block` returns `ReorgError`, the driver must reset the pipeline and
-    /// then re-add the triggering block so it is not permanently lost. The block
-    /// queue in the encoder is empty after reset, so the parent-hash check is
-    /// skipped and the re-add always succeeds.
-    #[test]
-    fn test_reorg_block_is_readded_after_reset() {
-        Runner::start(Config::seeded(0), |ctx| async move {
-            let blocks_accepted = Arc::new(Mutex::new(0usize));
-            let resets = Arc::new(Mutex::new(0usize));
-            let pipeline = OneReorgPipeline::new(Arc::clone(&blocks_accepted), Arc::clone(&resets));
-
-            let driver = BatchDriver::new(
-                ctx.clone(),
-                pipeline,
-                OneBlockSource::new(),
-                ImmediateConfirmTxManager { l1_block: 1 },
-                BatchDriverConfig {
-                    inbox: Address::ZERO,
-                    max_pending_transactions: 1,
-                    drain_timeout: Duration::from_millis(10),
-                },
-                DaThrottle::new(noop_throttle(), Arc::new(NoopThrottleClient)),
-                PendingL1HeadSource,
-            );
-            let handle = ctx.spawn(driver.run());
-
-            ctx.sleep(Duration::from_millis(50)).await;
-            ctx.cancel();
-
-            assert!(handle.await.unwrap().is_ok());
-            assert_eq!(*resets.lock().unwrap(), 1, "pipeline must be reset on reorg");
-            assert_eq!(
-                *blocks_accepted.lock().unwrap(),
-                1,
-                "the triggering block must be re-added after reset"
-            );
-        });
-    }
-
-    /// When `add_block` returns a `ReorgError`, the driver must reset the pipeline
-    /// and discard in-flight futures instead of propagating a fatal error. This
-    /// mirrors the `L2BlockEvent::Reorg` handling path.
-    #[test]
-    fn test_add_block_reorg_resets_pipeline_instead_of_fatal_error() {
-        Runner::start(Config::seeded(0), |ctx| async move {
-            let recorded = Arc::new(Mutex::new(Recorded::default()));
-            let pipeline = ReorgPipeline::new(Arc::clone(&recorded));
-
-            let driver = BatchDriver::new(
-                ctx.clone(),
-                pipeline,
-                OneBlockSource::new(),
-                ImmediateConfirmTxManager { l1_block: 1 },
-                BatchDriverConfig {
-                    inbox: Address::ZERO,
-                    max_pending_transactions: 1,
-                    drain_timeout: Duration::from_millis(10),
-                },
-                DaThrottle::new(noop_throttle(), Arc::new(NoopThrottleClient)),
-                PendingL1HeadSource,
-            );
-            let handle = ctx.spawn(driver.run());
-
-            ctx.sleep(Duration::from_millis(50)).await;
-            ctx.cancel();
-
-            let result = handle.await.unwrap();
-            assert!(result.is_ok(), "driver must not return a fatal error on add_block reorg");
-            assert_eq!(
-                recorded.lock().unwrap().resets,
-                1,
-                "pipeline.reset() must be called when add_block returns ReorgError"
-            );
-        });
-    }
-
-    // ---- Throttle integration tests ----
-
-    /// When the DA backlog exceeds the threshold, the driver must call
-    /// `set_max_da_size` on the throttle client with reduced limits.
-    #[test]
-    fn test_throttle_client_called_on_high_backlog() {
-        Runner::start(Config::seeded(0), |ctx| async move {
-            let recorded = Arc::new(Mutex::new(Recorded::default()));
-            // 2 MB backlog — above the default 1 MB threshold.
-            let pipeline = TrackingPipeline::new(Arc::clone(&recorded)).with_da_backlog(2_000_000);
-
-            let throttle =
-                ThrottleController::new(ThrottleConfig::default(), ThrottleStrategy::Linear);
-            let (throttle_client, throttle_recorded) = TrackingThrottleClient::new();
-
-            let driver = BatchDriver::new(
-                ctx.clone(),
-                pipeline,
-                PendingSource,
-                ImmediateConfirmTxManager { l1_block: 1 },
-                BatchDriverConfig {
-                    inbox: Address::ZERO,
-                    max_pending_transactions: 1,
-                    drain_timeout: Duration::from_millis(10),
-                },
-                DaThrottle::new(throttle, Arc::new(throttle_client)),
-                PendingL1HeadSource,
-            );
-            let handle = ctx.spawn(driver.run());
-
-            ctx.sleep(Duration::from_millis(50)).await;
-            ctx.cancel();
-            assert!(handle.await.unwrap().is_ok());
-
-            let calls = throttle_recorded.lock().unwrap();
-            assert!(!calls.is_empty(), "throttle client must be called when backlog is high");
-            let (max_tx_size, max_block_size) = calls[0];
-            assert!(
-                max_block_size < 130_000,
-                "max_block_size should be below upper limit when throttled, got {max_block_size}"
-            );
-            assert!(
-                max_tx_size < 20_000,
-                "max_tx_size should be below upper limit when throttled, got {max_tx_size}"
-            );
-        });
-    }
-
-    /// When the DA backlog is zero (below threshold), the driver must call
-    /// `set_max_da_size` with the upper limits to reset any previous throttle.
-    #[test]
-    fn test_throttle_client_called_with_upper_limits_on_zero_backlog() {
-        Runner::start(Config::seeded(0), |ctx| async move {
-            let recorded = Arc::new(Mutex::new(Recorded::default()));
-            let pipeline = TrackingPipeline::new(Arc::clone(&recorded)).with_da_backlog(0);
-
-            let throttle =
-                ThrottleController::new(ThrottleConfig::default(), ThrottleStrategy::Linear);
-            let (throttle_client, throttle_recorded) = TrackingThrottleClient::new();
-
-            let driver = BatchDriver::new(
-                ctx.clone(),
-                pipeline,
-                PendingSource,
-                ImmediateConfirmTxManager { l1_block: 1 },
-                BatchDriverConfig {
-                    inbox: Address::ZERO,
-                    max_pending_transactions: 1,
-                    drain_timeout: Duration::from_millis(10),
-                },
-                DaThrottle::new(throttle, Arc::new(throttle_client)),
-                PendingL1HeadSource,
-            );
-            let handle = ctx.spawn(driver.run());
-
-            ctx.sleep(Duration::from_millis(50)).await;
-            ctx.cancel();
-            assert!(handle.await.unwrap().is_ok());
-
-            let calls = throttle_recorded.lock().unwrap();
-            assert!(!calls.is_empty(), "throttle client must be called even with zero backlog");
-            let (max_tx_size, max_block_size) = calls[0];
-            assert_eq!(
-                max_block_size, 130_000,
-                "max_block_size should be the upper limit when not throttling"
-            );
-            assert_eq!(
-                max_tx_size, 20_000,
-                "max_tx_size should be the upper limit when not throttling"
-            );
-        });
-    }
-
-    /// When the DA limits do not change between iterations, the driver must not
-    /// call `set_max_da_size` redundantly. The deduplication check via
-    /// `last_applied_da_limits` ensures the RPC is called at most once for
-    /// identical limits.
-    #[test]
-    fn test_throttle_not_called_redundantly() {
-        Runner::start(Config::seeded(0), |ctx| async move {
-            let recorded = Arc::new(Mutex::new(Recorded::default()));
-            let pipeline = TrackingPipeline::new(Arc::clone(&recorded)).with_da_backlog(0);
-
-            let throttle =
-                ThrottleController::new(ThrottleConfig::default(), ThrottleStrategy::Linear);
-            let (throttle_client, throttle_recorded) = TrackingThrottleClient::new();
-
-            let driver = BatchDriver::new(
-                ctx.clone(),
-                pipeline,
-                PendingSource,
-                ImmediateConfirmTxManager { l1_block: 1 },
-                BatchDriverConfig {
-                    inbox: Address::ZERO,
-                    max_pending_transactions: 1,
-                    drain_timeout: Duration::from_millis(10),
-                },
-                DaThrottle::new(throttle, Arc::new(throttle_client)),
-                PendingL1HeadSource,
-            );
-            let handle = ctx.spawn(driver.run());
-
-            // Run for 100ms to allow multiple loop iterations.
-            ctx.sleep(Duration::from_millis(100)).await;
-            ctx.cancel();
-            assert!(handle.await.unwrap().is_ok());
-
-            let calls = throttle_recorded.lock().unwrap();
-            assert_eq!(
-                calls.len(),
-                1,
-                "set_max_da_size must be called exactly once when limits do not change, got {}",
-                calls.len()
-            );
-        });
-    }
-
-    /// With the Step strategy and full intensity, when backlog is above the
-    /// threshold, the driver must apply the lower DA limits.
-    #[test]
-    fn test_step_strategy_full_intensity_applies_lower_limits() {
-        Runner::start(Config::seeded(0), |ctx| async move {
-            let recorded = Arc::new(Mutex::new(Recorded::default()));
-            // Backlog of 100 — above threshold of 1.
-            let pipeline = TrackingPipeline::new(Arc::clone(&recorded)).with_da_backlog(100);
-
-            let config =
-                ThrottleConfig { threshold_bytes: 1, max_intensity: 1.0, ..Default::default() };
-            let throttle = ThrottleController::new(config, ThrottleStrategy::Step);
-            let (throttle_client, throttle_recorded) = TrackingThrottleClient::new();
-
-            let driver = BatchDriver::new(
-                ctx.clone(),
-                pipeline,
-                PendingSource,
-                ImmediateConfirmTxManager { l1_block: 1 },
-                BatchDriverConfig {
-                    inbox: Address::ZERO,
-                    max_pending_transactions: 1,
-                    drain_timeout: Duration::from_millis(10),
-                },
-                DaThrottle::new(throttle, Arc::new(throttle_client)),
-                PendingL1HeadSource,
-            );
-            let handle = ctx.spawn(driver.run());
-
-            ctx.sleep(Duration::from_millis(50)).await;
-            ctx.cancel();
-            assert!(handle.await.unwrap().is_ok());
-
-            let calls = throttle_recorded.lock().unwrap();
-            assert!(!calls.is_empty(), "throttle client must be called with Step strategy");
-            let (max_tx_size, max_block_size) = calls[0];
-            assert_eq!(
-                max_block_size, 2_000,
-                "Step strategy at full intensity must apply block_size_lower_limit"
-            );
-            assert_eq!(
-                max_tx_size, 150,
-                "Step strategy at full intensity must apply tx_size_lower_limit"
-            );
-        });
-    }
-
-    /// Verifies that when the DA backlog transitions from above the threshold
-    /// (throttle active) to zero (throttle inactive), the driver makes exactly
-    /// two RPC calls: one with reduced limits and one resetting to upper limits.
-    #[test]
-    fn test_throttle_transitions_from_active_to_inactive() {
-        // Pipeline whose DA backlog is controlled from the test via a shared lock.
-        struct DynamicPipeline {
-            backlog: Arc<Mutex<u64>>,
-        }
-
-        impl BatchPipeline for DynamicPipeline {
-            fn add_block(&mut self, _: OpBlock) -> Result<(), (ReorgError, Box<OpBlock>)> {
-                Ok(())
-            }
-
-            fn step(&mut self) -> Result<StepResult, StepError> {
-                Ok(StepResult::Idle)
-            }
-
-            fn next_submission(&mut self) -> Option<BatchSubmission> {
-                None
-            }
-
-            fn confirm(&mut self, _: SubmissionId, _: u64) {}
-
-            fn requeue(&mut self, _: SubmissionId) {}
-
-            fn force_close_channel(&mut self) {}
-
-            fn advance_l1_head(&mut self, _: u64) {}
-
-            fn prune_safe(&mut self, _: u64) {}
-
-            fn reset(&mut self) {}
-
-            fn da_backlog_bytes(&self) -> u64 {
-                *self.backlog.lock().unwrap()
-            }
-        }
-
-        // Source driven by an mpsc channel so the test can wake the driver loop
-        // by sending a dummy block event after changing the backlog.
-        struct ChannelSource {
-            rx: mpsc::UnboundedReceiver<L2BlockEvent>,
-        }
-
-        #[async_trait]
-        impl UnsafeBlockSource for ChannelSource {
-            async fn next(&mut self) -> Result<L2BlockEvent, SourceError> {
-                match self.rx.recv().await {
-                    Some(event) => Ok(event),
-                    // Channel closed: park until the driver is cancelled.
-                    None => std::future::pending().await,
-                }
-            }
-        }
-
-        Runner::start(Config::seeded(0), |ctx| async move {
-            let (source_tx, source_rx) = mpsc::unbounded_channel();
-
-            // Start with 2 MB backlog — above the default 1 MB threshold.
-            let backlog = Arc::new(Mutex::new(2_000_000u64));
-            let pipeline = DynamicPipeline { backlog: Arc::clone(&backlog) };
-
-            let throttle =
-                ThrottleController::new(ThrottleConfig::default(), ThrottleStrategy::Linear);
-            let (throttle_client, throttle_recorded) = TrackingThrottleClient::new();
-
-            let driver = BatchDriver::new(
-                ctx.clone(),
-                pipeline,
-                ChannelSource { rx: source_rx },
-                ImmediateConfirmTxManager { l1_block: 1 },
-                BatchDriverConfig {
-                    inbox: Address::ZERO,
-                    max_pending_transactions: 1,
-                    drain_timeout: Duration::from_millis(10),
-                },
-                DaThrottle::new(throttle, Arc::new(throttle_client)),
-                PendingL1HeadSource,
-            );
-            let handle = ctx.spawn(driver.run());
-
-            // First iteration fires immediately on startup; give it time to complete.
-            ctx.sleep(Duration::from_millis(30)).await;
-
-            // Drop the backlog to zero, then wake the driver by delivering a dummy
-            // block so the select! arm fires and the loop re-runs the throttle check.
-            *backlog.lock().unwrap() = 0;
-            source_tx.send(L2BlockEvent::Block(Box::default())).unwrap();
-
-            ctx.sleep(Duration::from_millis(30)).await;
-            ctx.cancel();
-            assert!(handle.await.unwrap().is_ok());
-
-            let calls = throttle_recorded.lock().unwrap();
-            assert!(
-                calls.len() >= 2,
-                "expected at least 2 throttle calls (activate + deactivate), got {}",
-                calls.len()
-            );
-
-            // First call must have reduced limits (throttle active, backlog was high).
-            let (first_tx, first_block) = calls[0];
-            assert!(
-                first_block < 130_000,
-                "first call should apply throttled block limit, got {first_block}"
-            );
-            assert!(
-                first_tx < 20_000,
-                "first call should apply throttled tx limit, got {first_tx}"
-            );
-
-            // Last call must reset to upper limits (throttle deactivated).
-            let (last_tx, last_block) = *calls.last().unwrap();
-            assert_eq!(last_block, 130_000, "last call should reset block limit to upper bound");
-            assert_eq!(last_tx, 20_000, "last call should reset tx limit to upper bound");
-        }); // Runner::start
-    }
-
-    // ---- L1 head source + safe head watch receiver tests ----
-
-    /// When the L1 head source delivers a new head, the driver must call
-    /// `advance_l1_head` on the pipeline with the new value.
-    #[test]
-    fn test_l1_head_source_advances_pipeline() {
-        Runner::start(Config::seeded(0), |ctx| async move {
-            let recorded = Arc::new(Mutex::new(Recorded::default()));
-            let pipeline = TrackingPipeline::new(Arc::clone(&recorded));
-
-            let (l1_source, l1_tx) = ChannelL1HeadSource::new();
-
-            let driver = BatchDriver::new(
-                ctx.clone(),
-                pipeline,
-                PendingSource,
-                ImmediateConfirmTxManager { l1_block: 1 },
-                BatchDriverConfig {
-                    inbox: Address::ZERO,
-                    max_pending_transactions: 1,
-                    drain_timeout: Duration::from_millis(10),
-                },
-                DaThrottle::new(noop_throttle(), Arc::new(NoopThrottleClient)),
-                l1_source,
-            );
-            let handle = ctx.spawn(driver.run());
-
-            // Send a new L1 head via the channel.
-            l1_tx.send(L1HeadEvent::NewHead(42)).unwrap();
-            ctx.sleep(Duration::from_millis(50)).await;
-            ctx.cancel();
-
-            assert!(handle.await.unwrap().is_ok());
-            let r = recorded.lock().unwrap();
-            assert!(
-                r.l1_heads.contains(&42),
-                "advance_l1_head must be called with the source value, got {:?}",
-                r.l1_heads
-            );
-        });
-    }
-
-    /// When a safe head watch receiver fires, the driver must call
-    /// `prune_safe` on the pipeline with the new value.
-    #[test]
-    fn test_safe_head_watch_prunes_pipeline() {
-        Runner::start(Config::seeded(0), |ctx| async move {
-            let recorded = Arc::new(Mutex::new(Recorded::default()));
-            let pipeline = TrackingPipeline::new(Arc::clone(&recorded));
-
-            let (safe_tx, safe_rx) = tokio::sync::watch::channel(0u64);
-
-            let driver =
-                make_driver(ctx.clone(), pipeline, ImmediateConfirmTxManager { l1_block: 1 })
-                    .with_safe_head_rx(safe_rx);
-            let handle = ctx.spawn(driver.run());
-
-            // Send a new safe head.
-            safe_tx.send(100).unwrap();
-            ctx.sleep(Duration::from_millis(50)).await;
-            ctx.cancel();
-
-            assert!(handle.await.unwrap().is_ok());
-            let r = recorded.lock().unwrap();
-            assert!(
-                r.safe_numbers.contains(&100),
-                "prune_safe must be called with the watch value, got {:?}",
-                r.safe_numbers
-            );
-        });
-    }
-
-    /// When the safe head sender is dropped while the driver is running, the watch
-    /// arm must disable itself rather than spinning. The driver continues running
-    /// and remains cancellable after the sender disappears.
-    #[test]
-    fn test_safe_head_sender_drop_does_not_busyloop() {
-        Runner::start(Config::seeded(0), |ctx| async move {
-            let recorded = Arc::new(Mutex::new(Recorded::default()));
-            let pipeline = TrackingPipeline::new(Arc::clone(&recorded));
-
-            let (safe_tx, safe_rx) = tokio::sync::watch::channel(0u64);
-
-            let driver =
-                make_driver(ctx.clone(), pipeline, ImmediateConfirmTxManager { l1_block: 1 })
-                    .with_safe_head_rx(safe_rx);
-            let handle = ctx.spawn(driver.run());
-
-            // Send one value, then drop the sender while the driver is still running.
-            safe_tx.send(50).unwrap();
-            ctx.sleep(Duration::from_millis(20)).await;
-            drop(safe_tx);
-
-            // Give the driver time to process the drop. If the arm busy-loops,
-            // prune_safe would be called many additional times here.
-            ctx.sleep(Duration::from_millis(50)).await;
-            let prune_count_after_drop = recorded.lock().unwrap().safe_numbers.len();
-
-            // Cancel and wait — driver must exit cleanly, not hang.
-            ctx.cancel();
-            assert!(handle.await.unwrap().is_ok(), "driver must exit cleanly after sender drop");
-
-            let r = recorded.lock().unwrap();
-            assert!(
-                r.safe_numbers.contains(&50),
-                "prune_safe must have been called with the sent value"
-            );
-            // After the sender drops, prune_safe must not be called again.
-            assert_eq!(
-                r.safe_numbers.len(),
-                prune_count_after_drop,
-                "prune_safe must not be called after sender drop (arm must be disabled)"
-            );
-        });
-    }
-
-    /// Without a safe head receiver, confirmation-based L1 head advancement must
-    /// still work normally. The driver uses `PendingL1HeadSource` (parks forever)
-    /// so only submission confirmations drive `advance_l1_head`.
-    #[test]
-    fn test_no_safe_head_receiver_driver_runs_normally() {
-        Runner::start(Config::seeded(0), |ctx| async move {
-            let recorded = Arc::new(Mutex::new(Recorded::default()));
-            let mut pipeline = TrackingPipeline::new(Arc::clone(&recorded));
-            pipeline.submissions.push_back(make_submission());
-
-            // No .with_safe_head_rx() — safe_head remains None.
-            let driver =
-                make_driver(ctx.clone(), pipeline, ImmediateConfirmTxManager { l1_block: 7 });
-            let handle = ctx.spawn(driver.run());
-
-            ctx.sleep(Duration::from_millis(50)).await;
-            ctx.cancel();
-
-            assert!(handle.await.unwrap().is_ok());
-            let r = recorded.lock().unwrap();
-            assert_eq!(r.l1_heads, vec![7], "confirmation-based advance_l1_head must still work");
-            assert!(r.safe_numbers.is_empty(), "prune_safe must not be called without a receiver");
-        });
-    }
-
-    /// When the block source returns `SourceError::Exhausted`, the driver must
-    /// treat it as a graceful shutdown signal: close the current channel,
-    /// drain in-flight submissions within the timeout, then exit cleanly.
-    #[test]
-    fn test_source_exhaustion_shuts_down_driver_gracefully() {
-        Runner::start(Config::seeded(0), |ctx| async move {
-            let recorded = Arc::new(Mutex::new(Recorded::default()));
-            let pipeline = TrackingPipeline::new(Arc::clone(&recorded));
-
-            let driver = BatchDriver::new(
-                ctx.clone(),
-                pipeline,
-                InMemoryBlockSource::new(), // empty → Exhausted immediately
-                ImmediateConfirmTxManager { l1_block: 1 },
-                BatchDriverConfig {
-                    inbox: Address::ZERO,
-                    max_pending_transactions: 1,
-                    drain_timeout: Duration::from_millis(10),
-                },
-                DaThrottle::new(noop_throttle(), Arc::new(NoopThrottleClient)),
-                PendingL1HeadSource,
-            );
-
-            let handle = ctx.spawn(driver.run());
-            ctx.sleep(Duration::from_millis(50)).await;
-
-            let result = handle.await.unwrap();
-            assert!(result.is_ok(), "driver must exit cleanly when source exhausts");
-            assert_eq!(
-                recorded.lock().unwrap().force_close_count,
-                1,
-                "force_close_channel must be called once on source exhaustion shutdown"
-            );
-        });
-    }
-
-    /// When the source delivers `L2BlockEvent::Flush`, the driver must call
-    /// `force_close_channel` immediately. On subsequent shutdown it is called once
-    /// more, giving a total of two calls.
-    #[test]
-    fn test_flush_event_calls_force_close_channel() {
-        Runner::start(Config::seeded(0), |ctx| async move {
-            let recorded = Arc::new(Mutex::new(Recorded::default()));
-            let pipeline = TrackingPipeline::new(Arc::clone(&recorded));
-            let (source, source_tx) = ChannelBlockSource::new();
-
-            let driver = BatchDriver::new(
-                ctx.clone(),
-                pipeline,
-                source,
-                ImmediateConfirmTxManager { l1_block: 1 },
-                BatchDriverConfig {
-                    inbox: Address::ZERO,
-                    max_pending_transactions: 1,
-                    drain_timeout: Duration::from_millis(10),
-                },
-                DaThrottle::new(noop_throttle(), Arc::new(NoopThrottleClient)),
-                PendingL1HeadSource,
-            );
-            let handle = ctx.spawn(driver.run());
-
-            source_tx.send(L2BlockEvent::Flush).unwrap();
-            ctx.sleep(Duration::from_millis(50)).await;
-            ctx.cancel();
-
-            assert!(handle.await.unwrap().is_ok());
-            // Flush arm: +1; Shutdown arm: +1 → total 2
-            assert_eq!(
-                recorded.lock().unwrap().force_close_count,
-                2,
-                "force_close_channel must be called for Flush and again on shutdown"
-            );
-        });
-    }
-
-    /// When the source delivers `L2BlockEvent::Reorg`, the driver must reset the
-    /// pipeline and discard in-flight submissions. This is distinct from the
-    /// `add_block`-triggered reorg path tested in
-    /// `test_reorg_block_is_readded_after_reset`.
-    #[test]
-    fn test_l2_reorg_event_resets_pipeline() {
-        Runner::start(Config::seeded(0), |ctx| async move {
-            let recorded = Arc::new(Mutex::new(Recorded::default()));
-            let pipeline = TrackingPipeline::new(Arc::clone(&recorded));
-            let (source, source_tx) = ChannelBlockSource::new();
-
-            let driver = BatchDriver::new(
-                ctx.clone(),
-                pipeline,
-                source,
-                ImmediateConfirmTxManager { l1_block: 1 },
-                BatchDriverConfig {
-                    inbox: Address::ZERO,
-                    max_pending_transactions: 1,
-                    drain_timeout: Duration::from_millis(10),
-                },
-                DaThrottle::new(noop_throttle(), Arc::new(NoopThrottleClient)),
-                PendingL1HeadSource,
-            );
-            let handle = ctx.spawn(driver.run());
-
-            let reorg_head = L2BlockInfo::new(
-                BlockInfo::new(B256::ZERO, 5, B256::ZERO, 0),
-                Default::default(),
-                0,
-            );
-            source_tx.send(L2BlockEvent::Reorg { new_safe_head: reorg_head }).unwrap();
-            ctx.sleep(Duration::from_millis(50)).await;
-            ctx.cancel();
-
-            assert!(handle.await.unwrap().is_ok());
-            assert_eq!(
-                recorded.lock().unwrap().resets,
-                1,
-                "pipeline must be reset when source delivers a Reorg event"
-            );
-        });
-    }
-
-    /// When the L1 head source is exhausted, the driver must disable that arm and
-    /// continue running — it must not shut down. The L1 head delivered before
-    /// exhaustion must be processed normally.
-    #[test]
-    fn test_l1_source_exhausted_disables_arm_driver_continues() {
-        Runner::start(Config::seeded(0), |ctx| async move {
-            let recorded = Arc::new(Mutex::new(Recorded::default()));
-            let pipeline = TrackingPipeline::new(Arc::clone(&recorded));
-            let (l1_source, l1_tx) = ChannelL1HeadSource::new();
-
-            let driver = BatchDriver::new(
-                ctx.clone(),
-                pipeline,
-                PendingSource,
-                ImmediateConfirmTxManager { l1_block: 1 },
-                BatchDriverConfig {
-                    inbox: Address::ZERO,
-                    max_pending_transactions: 1,
-                    drain_timeout: Duration::from_millis(10),
-                },
-                DaThrottle::new(noop_throttle(), Arc::new(NoopThrottleClient)),
-                l1_source,
-            );
-            let handle = ctx.spawn(driver.run());
-
-            l1_tx.send(L1HeadEvent::NewHead(77)).unwrap();
-            ctx.sleep(Duration::from_millis(20)).await;
-            drop(l1_tx); // triggers Exhausted → L1SourceClosed
-
-            // Driver must still be running after L1 source closes.
-            ctx.sleep(Duration::from_millis(50)).await;
-            ctx.cancel();
-
-            assert!(handle.await.unwrap().is_ok(), "driver must continue after L1 source closes");
-            let r = recorded.lock().unwrap();
-            assert!(
-                r.l1_heads.contains(&77),
-                "L1 head delivered before close must be processed, got {:?}",
-                r.l1_heads
-            );
-        });
-    }
-
-    /// When cancellation fires while a submission is in-flight with a
-    /// `NeverConfirmTxManager`, the drain timeout must fire and the driver must
-    /// exit cleanly. This verifies the `runtime.sleep(drain_timeout)` fix.
-    #[test]
-    fn test_drain_timeout_exits_with_in_flight_submissions() {
-        Runner::start(Config::seeded(0), |ctx| async move {
-            let recorded = Arc::new(Mutex::new(Recorded::default()));
-            let mut pipeline = TrackingPipeline::new(Arc::clone(&recorded));
-            pipeline.submissions.push_back(make_submission());
-
-            let driver = make_driver(ctx.clone(), pipeline, NeverConfirmTxManager);
-            let handle = ctx.spawn(driver.run());
-
-            ctx.sleep(Duration::from_millis(20)).await;
-            ctx.cancel();
-
-            let result = handle.await.unwrap();
-            assert!(
-                result.is_ok(),
-                "driver must exit after drain timeout even with in-flight submissions"
-            );
-            let r = recorded.lock().unwrap();
-            assert_eq!(r.dequeued, vec![SubmissionId(0)], "submission must have been dequeued");
-            assert_eq!(r.force_close_count, 1, "force_close_channel must be called on shutdown");
         });
     }
 }

--- a/crates/batcher/core/src/driver.rs
+++ b/crates/batcher/core/src/driver.rs
@@ -13,8 +13,8 @@ use tracing::{debug, error, info, warn};
 
 use crate::{
     BatchDriverConfig, BatchDriverError, DaThrottle, SubmissionQueue, ThrottleClient,
+    event::DriverEvent,
 };
-use crate::event::DriverEvent;
 
 /// Async orchestration loop for the batcher.
 ///
@@ -292,7 +292,10 @@ where
 
 #[cfg(test)]
 mod tests {
-    use std::{sync::{Arc, Mutex}, time::Duration};
+    use std::{
+        sync::{Arc, Mutex},
+        time::Duration,
+    };
 
     use base_batcher_encoder::{BatchSubmission, DaType, SubmissionId};
     use base_protocol::{ChannelId, Frame};
@@ -316,8 +319,12 @@ mod tests {
             pipeline.submissions.push_back(SubmissionStub::new());
 
             let handle = ctx.spawn(
-                DriverFixture::build(ctx.clone(), pipeline, ImmediateConfirmTxManager { l1_block: 42 })
-                    .run(),
+                DriverFixture::build(
+                    ctx.clone(),
+                    pipeline,
+                    ImmediateConfirmTxManager { l1_block: 42 },
+                )
+                .run(),
             );
 
             ctx.sleep(Duration::from_millis(50)).await;
@@ -341,8 +348,8 @@ mod tests {
             let mut pipeline = TrackingPipeline::new(Arc::clone(&recorded));
             pipeline.submissions.push_back(SubmissionStub::new());
 
-            let handle =
-                ctx.spawn(DriverFixture::build(ctx.clone(), pipeline, ImmediateFailTxManager).run());
+            let handle = ctx
+                .spawn(DriverFixture::build(ctx.clone(), pipeline, ImmediateFailTxManager).run());
 
             ctx.sleep(Duration::from_millis(50)).await;
             ctx.cancel();
@@ -377,8 +384,12 @@ mod tests {
             });
 
             let handle = ctx.spawn(
-                DriverFixture::build(ctx.clone(), pipeline, ImmediateConfirmTxManager { l1_block: 1 })
-                    .run(),
+                DriverFixture::build(
+                    ctx.clone(),
+                    pipeline,
+                    ImmediateConfirmTxManager { l1_block: 1 },
+                )
+                .run(),
             );
 
             ctx.sleep(Duration::from_millis(50)).await;
@@ -444,8 +455,13 @@ mod tests {
             pipeline.submissions.push_back(SubmissionStub::with_id(1));
 
             let handle = ctx.spawn(
-                DriverFixture::build_with_max_pending(ctx.clone(), pipeline, NeverConfirmTxManager, 1)
-                    .run(),
+                DriverFixture::build_with_max_pending(
+                    ctx.clone(),
+                    pipeline,
+                    NeverConfirmTxManager,
+                    1,
+                )
+                .run(),
             );
 
             ctx.sleep(Duration::from_millis(50)).await;

--- a/crates/batcher/core/src/event.rs
+++ b/crates/batcher/core/src/event.rs
@@ -1,0 +1,28 @@
+//! Internal driver event type produced by the `tokio::select!` I/O phase.
+
+use base_alloy_consensus::OpBlock;
+use base_batcher_encoder::SubmissionId;
+use base_protocol::L2BlockInfo;
+
+use crate::TxOutcome;
+
+/// Events the driver can receive from external sources during the I/O phase.
+#[derive(Debug)]
+pub enum DriverEvent {
+    /// Cancellation token fired, or L2 source signalled exhausted.
+    Shutdown,
+    /// New L2 unsafe block from the source.
+    Block(Box<OpBlock>),
+    /// Source requested a force-flush of the current channel.
+    Flush,
+    /// L2 reorganisation; new safe head provided.
+    Reorg(L2BlockInfo),
+    /// An in-flight L1 transaction settled.
+    Receipt(SubmissionId, TxOutcome),
+    /// L1 chain head advanced.
+    L1Head(u64),
+    /// Safe L2 head advanced (from watch channel).
+    SafeHead(u64),
+    /// L1 head source permanently closed (Exhausted or Closed error).
+    L1SourceClosed,
+}

--- a/crates/batcher/core/src/lib.rs
+++ b/crates/batcher/core/src/lib.rs
@@ -24,8 +24,13 @@ pub use throttle_client::{NoopThrottleClient, ThrottleClient};
 mod submissions;
 pub use submissions::SubmissionQueue;
 
+mod config;
+pub use config::BatchDriverConfig;
+
+mod event;
+pub use event::DriverEvent;
+
 mod driver;
-pub use base_batcher_encoder::BatcherMetrics;
-pub use driver::{BatchDriver, BatchDriverConfig};
+pub use driver::BatchDriver;
 
 pub mod test_utils;

--- a/crates/batcher/core/src/submissions.rs
+++ b/crates/batcher/core/src/submissions.rs
@@ -3,15 +3,13 @@
 use std::{future::Future, pin::Pin, sync::Arc};
 
 use alloy_primitives::{Address, Bytes, U256};
-use base_batcher_encoder::{BatchPipeline, DaType, FrameEncoder, SubmissionId};
+use base_batcher_encoder::{BatchPipeline, BatcherMetrics, DaType, FrameEncoder, SubmissionId};
 use base_blobs::BlobEncoder;
 use base_tx_manager::{TxCandidate, TxManager, TxManagerError};
 use futures::stream::{FuturesUnordered, StreamExt};
 use metrics::{counter, gauge};
 use tokio::sync::Semaphore;
 use tracing::{info, warn};
-
-use base_batcher_encoder::BatcherMetrics;
 
 use crate::TxOutcome;
 

--- a/crates/batcher/core/src/submissions.rs
+++ b/crates/batcher/core/src/submissions.rs
@@ -11,7 +11,9 @@ use metrics::{counter, gauge};
 use tokio::sync::Semaphore;
 use tracing::{info, warn};
 
-use crate::{BatcherMetrics, TxOutcome};
+use base_batcher_encoder::BatcherMetrics;
+
+use crate::TxOutcome;
 
 /// Type alias for the in-flight receipt future collection.
 type InFlight = FuturesUnordered<Pin<Box<dyn Future<Output = (SubmissionId, TxOutcome)> + Send>>>;

--- a/crates/batcher/core/src/test_utils/builder.rs
+++ b/crates/batcher/core/src/test_utils/builder.rs
@@ -1,0 +1,75 @@
+//! Factory helpers for constructing test [`BatchDriver`] instances and [`BatchSubmission`] stubs.
+
+use std::{sync::Arc, time::Duration};
+
+use alloy_primitives::Address;
+use base_batcher_encoder::{BatchSubmission, DaType, SubmissionId};
+use base_protocol::{ChannelId, Frame};
+use base_runtime::Runtime;
+use base_tx_manager::TxManager;
+
+use crate::{
+    BatchDriver, BatchDriverConfig, DaThrottle, NoopThrottleClient, ThrottleController,
+    test_utils::{PendingL1HeadSource, PendingSource, TrackingPipeline},
+};
+
+/// Factory methods for [`BatchSubmission`] stubs used in driver tests.
+#[derive(Debug)]
+pub struct SubmissionStub;
+
+impl SubmissionStub {
+    /// Returns a stub submission with id `0`.
+    pub fn new() -> BatchSubmission {
+        Self::with_id(0)
+    }
+
+    /// Returns a stub submission with the given id.
+    pub fn with_id(id: u64) -> BatchSubmission {
+        BatchSubmission {
+            id: SubmissionId(id),
+            channel_id: ChannelId::default(),
+            da_type: DaType::Blob,
+            frames: vec![Arc::new(Frame::default())],
+        }
+    }
+}
+
+/// Factory methods for [`BatchDriver`] instances wired with standard test
+/// components: [`PendingSource`], [`NoopThrottleClient`], and [`PendingL1HeadSource`].
+#[derive(Debug)]
+pub struct DriverFixture;
+
+impl DriverFixture {
+    /// Build a driver with `max_pending_transactions = 1`.
+    pub fn build<R: Runtime, TM: TxManager>(
+        runtime: R,
+        pipeline: TrackingPipeline,
+        tx_manager: TM,
+    ) -> BatchDriver<R, TrackingPipeline, PendingSource, TM, Arc<NoopThrottleClient>, PendingL1HeadSource>
+    {
+        Self::build_with_max_pending(runtime, pipeline, tx_manager, 1)
+    }
+
+    /// Build a driver with a configurable `max_pending_transactions` limit.
+    pub fn build_with_max_pending<R: Runtime, TM: TxManager>(
+        runtime: R,
+        pipeline: TrackingPipeline,
+        tx_manager: TM,
+        max_pending: usize,
+    ) -> BatchDriver<R, TrackingPipeline, PendingSource, TM, Arc<NoopThrottleClient>, PendingL1HeadSource>
+    {
+        BatchDriver::new(
+            runtime,
+            pipeline,
+            PendingSource,
+            tx_manager,
+            BatchDriverConfig {
+                inbox: Address::ZERO,
+                max_pending_transactions: max_pending,
+                drain_timeout: Duration::from_millis(10),
+            },
+            DaThrottle::new(ThrottleController::noop(), Arc::new(NoopThrottleClient)),
+            PendingL1HeadSource,
+        )
+    }
+}

--- a/crates/batcher/core/src/test_utils/builder.rs
+++ b/crates/batcher/core/src/test_utils/builder.rs
@@ -45,8 +45,14 @@ impl DriverFixture {
         runtime: R,
         pipeline: TrackingPipeline,
         tx_manager: TM,
-    ) -> BatchDriver<R, TrackingPipeline, PendingSource, TM, Arc<NoopThrottleClient>, PendingL1HeadSource>
-    {
+    ) -> BatchDriver<
+        R,
+        TrackingPipeline,
+        PendingSource,
+        TM,
+        Arc<NoopThrottleClient>,
+        PendingL1HeadSource,
+    > {
         Self::build_with_max_pending(runtime, pipeline, tx_manager, 1)
     }
 
@@ -56,8 +62,14 @@ impl DriverFixture {
         pipeline: TrackingPipeline,
         tx_manager: TM,
         max_pending: usize,
-    ) -> BatchDriver<R, TrackingPipeline, PendingSource, TM, Arc<NoopThrottleClient>, PendingL1HeadSource>
-    {
+    ) -> BatchDriver<
+        R,
+        TrackingPipeline,
+        PendingSource,
+        TM,
+        Arc<NoopThrottleClient>,
+        PendingL1HeadSource,
+    > {
         BatchDriver::new(
             runtime,
             pipeline,

--- a/crates/batcher/core/src/test_utils/builder.rs
+++ b/crates/batcher/core/src/test_utils/builder.rs
@@ -19,7 +19,7 @@ pub struct SubmissionStub;
 
 impl SubmissionStub {
     /// Returns a stub submission with id `0`.
-    pub fn new() -> BatchSubmission {
+    pub fn stub() -> BatchSubmission {
         Self::with_id(0)
     }
 

--- a/crates/batcher/core/src/test_utils/mod.rs
+++ b/crates/batcher/core/src/test_utils/mod.rs
@@ -2,3 +2,21 @@
 
 mod throttle;
 pub use throttle::{ThrottleCallLog, TrackingThrottleClient};
+
+mod pipeline;
+pub use pipeline::{OneReorgPipeline, Recorded, ReorgPipeline, TrackingPipeline};
+
+#[cfg(any(test, feature = "test-utils"))]
+mod source;
+#[cfg(any(test, feature = "test-utils"))]
+pub use source::{OneBlockSource, PendingL1HeadSource, PendingSource};
+
+#[cfg(any(test, feature = "test-utils"))]
+mod builder;
+#[cfg(any(test, feature = "test-utils"))]
+pub use builder::{DriverFixture, SubmissionStub};
+
+#[cfg(any(test, feature = "test-utils"))]
+mod tx_manager;
+#[cfg(any(test, feature = "test-utils"))]
+pub use tx_manager::{ImmediateConfirmTxManager, ImmediateFailTxManager, NeverConfirmTxManager};

--- a/crates/batcher/core/src/test_utils/pipeline.rs
+++ b/crates/batcher/core/src/test_utils/pipeline.rs
@@ -46,7 +46,7 @@ impl TrackingPipeline {
     }
 
     /// Set the value returned by `da_backlog_bytes`.
-    pub fn with_da_backlog(mut self, value: u64) -> Self {
+    pub const fn with_da_backlog(mut self, value: u64) -> Self {
         self.da_backlog_bytes_value = value;
         self
     }
@@ -106,7 +106,7 @@ pub struct ReorgPipeline {
 
 impl ReorgPipeline {
     /// Create a new pipeline that records resets into `recorded`.
-    pub fn new(recorded: Arc<Mutex<Recorded>>) -> Self {
+    pub const fn new(recorded: Arc<Mutex<Recorded>>) -> Self {
         Self { recorded }
     }
 }
@@ -158,7 +158,7 @@ pub struct OneReorgPipeline {
 
 impl OneReorgPipeline {
     /// Create a new pipeline backed by the given shared counters.
-    pub fn new(blocks_accepted: Arc<Mutex<usize>>, resets: Arc<Mutex<usize>>) -> Self {
+    pub const fn new(blocks_accepted: Arc<Mutex<usize>>, resets: Arc<Mutex<usize>>) -> Self {
         Self { blocks_accepted, fail_next: true, resets }
     }
 }
@@ -168,10 +168,7 @@ impl BatchPipeline for OneReorgPipeline {
         if self.fail_next {
             self.fail_next = false;
             return Err((
-                ReorgError::ParentMismatch {
-                    expected: B256::ZERO,
-                    got: B256::with_last_byte(1),
-                },
+                ReorgError::ParentMismatch { expected: B256::ZERO, got: B256::with_last_byte(1) },
                 Box::new(block),
             ));
         }

--- a/crates/batcher/core/src/test_utils/pipeline.rs
+++ b/crates/batcher/core/src/test_utils/pipeline.rs
@@ -1,0 +1,203 @@
+//! Test [`BatchPipeline`] implementations for action-testing the batch driver.
+
+use std::sync::{Arc, Mutex};
+
+use alloy_primitives::B256;
+use base_alloy_consensus::OpBlock;
+use base_batcher_encoder::{
+    BatchPipeline, BatchSubmission, ReorgError, StepError, StepResult, SubmissionId,
+};
+
+/// Shared recording state populated by the test pipeline implementations.
+#[derive(Debug, Default)]
+pub struct Recorded {
+    /// L1 block numbers passed to `advance_l1_head` in order.
+    pub l1_heads: Vec<u64>,
+    /// Submission IDs passed to `requeue` in order.
+    pub requeued: Vec<SubmissionId>,
+    /// Submission IDs dequeued via `next_submission` in order.
+    pub dequeued: Vec<SubmissionId>,
+    /// Number of times `reset()` was called.
+    pub resets: usize,
+    /// Safe L2 block numbers passed to `prune_safe` in order.
+    pub safe_numbers: Vec<u64>,
+    /// Number of times `force_close_channel()` was called.
+    pub force_close_count: usize,
+}
+
+/// [`BatchPipeline`] that records every significant method call into a shared [`Recorded`].
+///
+/// Submissions are pre-loaded by pushing into [`TrackingPipeline::submissions`] before
+/// handing the pipeline to the driver.
+#[derive(Debug)]
+pub struct TrackingPipeline {
+    /// Shared recording state.
+    pub recorded: Arc<Mutex<Recorded>>,
+    /// Queue of submissions returned by `next_submission` in FIFO order.
+    pub submissions: std::collections::VecDeque<BatchSubmission>,
+    /// Value returned by `da_backlog_bytes`. Default: 0.
+    da_backlog_bytes_value: u64,
+}
+
+impl TrackingPipeline {
+    /// Create a new pipeline that records into `recorded`.
+    pub fn new(recorded: Arc<Mutex<Recorded>>) -> Self {
+        Self { recorded, submissions: Default::default(), da_backlog_bytes_value: 0 }
+    }
+
+    /// Set the value returned by `da_backlog_bytes`.
+    pub fn with_da_backlog(mut self, value: u64) -> Self {
+        self.da_backlog_bytes_value = value;
+        self
+    }
+}
+
+impl BatchPipeline for TrackingPipeline {
+    fn add_block(&mut self, _: OpBlock) -> Result<(), (ReorgError, Box<OpBlock>)> {
+        Ok(())
+    }
+
+    fn step(&mut self) -> Result<StepResult, StepError> {
+        Ok(StepResult::Idle)
+    }
+
+    fn next_submission(&mut self) -> Option<BatchSubmission> {
+        let sub = self.submissions.pop_front()?;
+        self.recorded.lock().unwrap().dequeued.push(sub.id);
+        Some(sub)
+    }
+
+    fn confirm(&mut self, _: SubmissionId, _: u64) {}
+
+    fn requeue(&mut self, id: SubmissionId) {
+        self.recorded.lock().unwrap().requeued.push(id);
+    }
+
+    fn force_close_channel(&mut self) {
+        self.recorded.lock().unwrap().force_close_count += 1;
+    }
+
+    fn advance_l1_head(&mut self, l1_block: u64) {
+        self.recorded.lock().unwrap().l1_heads.push(l1_block);
+    }
+
+    fn prune_safe(&mut self, safe_l2_number: u64) {
+        self.recorded.lock().unwrap().safe_numbers.push(safe_l2_number);
+    }
+
+    fn reset(&mut self) {
+        self.recorded.lock().unwrap().resets += 1;
+    }
+
+    fn da_backlog_bytes(&self) -> u64 {
+        self.da_backlog_bytes_value
+    }
+}
+
+/// [`BatchPipeline`] that always returns [`ReorgError`] from `add_block`.
+///
+/// Used to verify the driver's reorg-on-add path: it must reset the pipeline and
+/// discard in-flight submissions rather than propagating a fatal error.
+#[derive(Debug)]
+pub struct ReorgPipeline {
+    /// Shared recording state (only `resets` is incremented).
+    pub recorded: Arc<Mutex<Recorded>>,
+}
+
+impl ReorgPipeline {
+    /// Create a new pipeline that records resets into `recorded`.
+    pub fn new(recorded: Arc<Mutex<Recorded>>) -> Self {
+        Self { recorded }
+    }
+}
+
+impl BatchPipeline for ReorgPipeline {
+    fn add_block(&mut self, block: OpBlock) -> Result<(), (ReorgError, Box<OpBlock>)> {
+        Err((
+            ReorgError::ParentMismatch { expected: B256::ZERO, got: B256::with_last_byte(1) },
+            Box::new(block),
+        ))
+    }
+
+    fn step(&mut self) -> Result<StepResult, StepError> {
+        Ok(StepResult::Idle)
+    }
+
+    fn next_submission(&mut self) -> Option<BatchSubmission> {
+        None
+    }
+
+    fn confirm(&mut self, _: SubmissionId, _: u64) {}
+    fn requeue(&mut self, _: SubmissionId) {}
+    fn force_close_channel(&mut self) {}
+    fn advance_l1_head(&mut self, _: u64) {}
+    fn prune_safe(&mut self, _: u64) {}
+
+    fn reset(&mut self) {
+        self.recorded.lock().unwrap().resets += 1;
+    }
+
+    fn da_backlog_bytes(&self) -> u64 {
+        0
+    }
+}
+
+/// [`BatchPipeline`] that rejects the first `add_block` call and accepts all subsequent ones.
+///
+/// Used to verify that the driver re-adds the triggering block after `reset()`, so the
+/// block is not silently lost when the source will not re-deliver it.
+#[derive(Debug)]
+pub struct OneReorgPipeline {
+    /// Incremented each time `add_block` succeeds (post-reorg re-adds).
+    pub blocks_accepted: Arc<Mutex<usize>>,
+    /// Whether the next `add_block` call should simulate a reorg.
+    fail_next: bool,
+    /// Incremented each time `reset()` is called.
+    pub resets: Arc<Mutex<usize>>,
+}
+
+impl OneReorgPipeline {
+    /// Create a new pipeline backed by the given shared counters.
+    pub fn new(blocks_accepted: Arc<Mutex<usize>>, resets: Arc<Mutex<usize>>) -> Self {
+        Self { blocks_accepted, fail_next: true, resets }
+    }
+}
+
+impl BatchPipeline for OneReorgPipeline {
+    fn add_block(&mut self, block: OpBlock) -> Result<(), (ReorgError, Box<OpBlock>)> {
+        if self.fail_next {
+            self.fail_next = false;
+            return Err((
+                ReorgError::ParentMismatch {
+                    expected: B256::ZERO,
+                    got: B256::with_last_byte(1),
+                },
+                Box::new(block),
+            ));
+        }
+        *self.blocks_accepted.lock().unwrap() += 1;
+        Ok(())
+    }
+
+    fn step(&mut self) -> Result<StepResult, StepError> {
+        Ok(StepResult::Idle)
+    }
+
+    fn next_submission(&mut self) -> Option<BatchSubmission> {
+        None
+    }
+
+    fn confirm(&mut self, _: SubmissionId, _: u64) {}
+    fn requeue(&mut self, _: SubmissionId) {}
+    fn force_close_channel(&mut self) {}
+    fn advance_l1_head(&mut self, _: u64) {}
+    fn prune_safe(&mut self, _: u64) {}
+
+    fn reset(&mut self) {
+        *self.resets.lock().unwrap() += 1;
+    }
+
+    fn da_backlog_bytes(&self) -> u64 {
+        0
+    }
+}

--- a/crates/batcher/core/src/test_utils/source.rs
+++ b/crates/batcher/core/src/test_utils/source.rs
@@ -1,7 +1,9 @@
 //! Test [`UnsafeBlockSource`] and [`L1HeadSource`] implementations.
 
 use async_trait::async_trait;
-use base_batcher_source::{L1HeadEvent, L1HeadSource, L2BlockEvent, SourceError, UnsafeBlockSource};
+use base_batcher_source::{
+    L1HeadEvent, L1HeadSource, L2BlockEvent, SourceError, UnsafeBlockSource,
+};
 
 /// [`UnsafeBlockSource`] that parks the select arm forever.
 ///
@@ -29,7 +31,7 @@ pub struct OneBlockSource {
 
 impl OneBlockSource {
     /// Create a new source that has not yet delivered its block.
-    pub fn new() -> Self {
+    pub const fn new() -> Self {
         Self { delivered: false }
     }
 }

--- a/crates/batcher/core/src/test_utils/source.rs
+++ b/crates/batcher/core/src/test_utils/source.rs
@@ -1,0 +1,61 @@
+//! Test [`UnsafeBlockSource`] and [`L1HeadSource`] implementations.
+
+use async_trait::async_trait;
+use base_batcher_source::{L1HeadEvent, L1HeadSource, L2BlockEvent, SourceError, UnsafeBlockSource};
+
+/// [`UnsafeBlockSource`] that parks the select arm forever.
+///
+/// Use this in tests that do not exercise the block-delivery path, so that
+/// the driver's source arm never fires and other arms (receipts, L1 head,
+/// safe-head watch) can be tested in isolation.
+#[derive(Debug)]
+pub struct PendingSource;
+
+#[async_trait]
+impl UnsafeBlockSource for PendingSource {
+    async fn next(&mut self) -> Result<L2BlockEvent, SourceError> {
+        std::future::pending().await
+    }
+}
+
+/// [`UnsafeBlockSource`] that delivers exactly one default block then parks forever.
+///
+/// Useful for tests that need a single block ingestion event without the source
+/// signalling exhaustion or causing a shutdown.
+#[derive(Debug)]
+pub struct OneBlockSource {
+    delivered: bool,
+}
+
+impl OneBlockSource {
+    /// Create a new source that has not yet delivered its block.
+    pub fn new() -> Self {
+        Self { delivered: false }
+    }
+}
+
+#[async_trait]
+impl UnsafeBlockSource for OneBlockSource {
+    async fn next(&mut self) -> Result<L2BlockEvent, SourceError> {
+        if !self.delivered {
+            self.delivered = true;
+            Ok(L2BlockEvent::Block(Box::default()))
+        } else {
+            std::future::pending().await
+        }
+    }
+}
+
+/// [`L1HeadSource`] that parks the select arm forever.
+///
+/// Use this as the default L1 head source in driver tests that do not exercise
+/// L1 head advancement, so that only other select arms fire.
+#[derive(Debug)]
+pub struct PendingL1HeadSource;
+
+#[async_trait]
+impl L1HeadSource for PendingL1HeadSource {
+    async fn next(&mut self) -> Result<L1HeadEvent, SourceError> {
+        std::future::pending().await
+    }
+}

--- a/crates/batcher/core/src/test_utils/source.rs
+++ b/crates/batcher/core/src/test_utils/source.rs
@@ -36,6 +36,12 @@ impl OneBlockSource {
     }
 }
 
+impl Default for OneBlockSource {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 #[async_trait]
 impl UnsafeBlockSource for OneBlockSource {
     async fn next(&mut self) -> Result<L2BlockEvent, SourceError> {

--- a/crates/batcher/core/src/test_utils/tx_manager.rs
+++ b/crates/batcher/core/src/test_utils/tx_manager.rs
@@ -6,7 +6,7 @@ use alloy_rpc_types_eth::TransactionReceipt;
 use base_tx_manager::{SendHandle, SendResponse, TxCandidate, TxManager, TxManagerError};
 use tokio::sync::oneshot;
 
-fn stub_receipt(block_number: u64) -> TransactionReceipt {
+const fn stub_receipt(block_number: u64) -> TransactionReceipt {
     let inner = ReceiptEnvelope::Legacy(ReceiptWithBloom {
         receipt: Receipt {
             status: Eip658Value::Eip658(true),

--- a/crates/batcher/core/src/test_utils/tx_manager.rs
+++ b/crates/batcher/core/src/test_utils/tx_manager.rs
@@ -1,0 +1,100 @@
+//! Test [`TxManager`] implementations for controlling submission outcomes in driver tests.
+
+use alloy_consensus::{Eip658Value, Receipt, ReceiptEnvelope, ReceiptWithBloom};
+use alloy_primitives::{Address, B256, Bloom};
+use alloy_rpc_types_eth::TransactionReceipt;
+use base_tx_manager::{SendHandle, SendResponse, TxCandidate, TxManager, TxManagerError};
+use tokio::sync::oneshot;
+
+fn stub_receipt(block_number: u64) -> TransactionReceipt {
+    let inner = ReceiptEnvelope::Legacy(ReceiptWithBloom {
+        receipt: Receipt {
+            status: Eip658Value::Eip658(true),
+            cumulative_gas_used: 21_000,
+            logs: vec![],
+        },
+        logs_bloom: Bloom::ZERO,
+    });
+    TransactionReceipt {
+        inner,
+        transaction_hash: B256::ZERO,
+        transaction_index: Some(0),
+        block_hash: Some(B256::ZERO),
+        block_number: Some(block_number),
+        gas_used: 21_000,
+        effective_gas_price: 1_000_000_000,
+        blob_gas_used: None,
+        blob_gas_price: None,
+        from: Address::ZERO,
+        to: Some(Address::ZERO),
+        contract_address: None,
+    }
+}
+
+/// [`TxManager`] that immediately confirms every submission at a fixed L1 block number.
+#[derive(Debug)]
+pub struct ImmediateConfirmTxManager {
+    /// L1 block number reported in every confirmed receipt.
+    pub l1_block: u64,
+}
+
+impl TxManager for ImmediateConfirmTxManager {
+    async fn send(&self, _: TxCandidate) -> SendResponse {
+        unreachable!()
+    }
+
+    fn send_async(&self, _: TxCandidate) -> impl std::future::Future<Output = SendHandle> + Send {
+        let (tx, rx) = oneshot::channel();
+        let _ = tx.send(Ok(stub_receipt(self.l1_block)));
+        std::future::ready(SendHandle::new(rx))
+    }
+
+    fn sender_address(&self) -> Address {
+        Address::ZERO
+    }
+}
+
+/// [`TxManager`] that immediately fails every submission with [`TxManagerError::ChannelClosed`].
+#[derive(Debug)]
+pub struct ImmediateFailTxManager;
+
+impl TxManager for ImmediateFailTxManager {
+    async fn send(&self, _: TxCandidate) -> SendResponse {
+        unreachable!()
+    }
+
+    fn send_async(&self, _: TxCandidate) -> impl std::future::Future<Output = SendHandle> + Send {
+        let (tx, rx) = oneshot::channel();
+        let _ = tx.send(Err(TxManagerError::ChannelClosed));
+        std::future::ready(SendHandle::new(rx))
+    }
+
+    fn sender_address(&self) -> Address {
+        Address::ZERO
+    }
+}
+
+/// [`TxManager`] that never confirms any submission — the in-flight future parks forever.
+///
+/// Used to test semaphore backpressure: permits are consumed but never released,
+/// so `try_acquire_owned` fails once the limit is reached and no further
+/// submissions are dequeued.
+#[derive(Debug)]
+pub struct NeverConfirmTxManager;
+
+impl TxManager for NeverConfirmTxManager {
+    async fn send(&self, _: TxCandidate) -> SendResponse {
+        unreachable!()
+    }
+
+    fn send_async(&self, _: TxCandidate) -> impl std::future::Future<Output = SendHandle> + Send {
+        let (tx, rx) = oneshot::channel();
+        // Keep tx alive by forgetting it — rx parks forever without a result.
+        std::mem::forget(tx);
+        std::future::ready(SendHandle::new(rx))
+    }
+
+    fn sender_address(&self) -> Address {
+        Address::ZERO
+    }
+}

--- a/crates/batcher/core/src/throttle.rs
+++ b/crates/batcher/core/src/throttle.rs
@@ -88,6 +88,16 @@ impl ThrottleController {
         Self { config, strategy }
     }
 
+    /// Returns a [`ThrottleController`] with [`ThrottleStrategy::Off`] that never throttles.
+    ///
+    /// Useful in tests and configurations where DA backlog throttling should be disabled.
+    pub fn noop() -> Self {
+        Self::new(
+            ThrottleConfig { threshold_bytes: 0, max_intensity: 0.0, ..Default::default() },
+            ThrottleStrategy::Off,
+        )
+    }
+
     /// Returns a reference to the throttle configuration.
     pub const fn config(&self) -> &ThrottleConfig {
         &self.config
@@ -210,56 +220,46 @@ impl<TC: crate::ThrottleClient> DaThrottle<TC> {
 
 #[cfg(test)]
 mod tests {
+    use rstest::rstest;
+
     use super::*;
 
     fn test_config() -> ThrottleConfig {
         ThrottleConfig { threshold_bytes: 1000, max_intensity: 0.8, ..Default::default() }
     }
 
-    #[test]
-    fn off_strategy_returns_none() {
-        let ctrl = ThrottleController::new(test_config(), ThrottleStrategy::Off);
-        assert!(ctrl.update(5000).is_none());
-    }
-
-    #[test]
-    fn step_below_threshold() {
-        let ctrl = ThrottleController::new(test_config(), ThrottleStrategy::Step);
-        assert!(ctrl.update(999).is_none());
-    }
-
-    #[test]
-    fn step_at_threshold() {
-        let ctrl = ThrottleController::new(test_config(), ThrottleStrategy::Step);
-        let params = ctrl.update(1000).unwrap();
-        assert!((params.intensity - 0.8).abs() < f64::EPSILON);
-    }
-
-    #[test]
-    fn linear_below_threshold() {
-        let ctrl = ThrottleController::new(test_config(), ThrottleStrategy::Linear);
-        assert!(ctrl.update(500).is_none());
-    }
-
-    #[test]
-    fn linear_at_threshold_returns_none() {
-        // At exactly the threshold, excess = 0 → intensity = 0.0 → must return None,
-        // not Some with zero intensity (which would trigger a spurious log on startup).
-        let ctrl = ThrottleController::new(test_config(), ThrottleStrategy::Linear);
-        assert!(ctrl.update(1000).is_none());
-    }
-
-    #[test]
-    fn linear_at_max() {
-        let ctrl = ThrottleController::new(test_config(), ThrottleStrategy::Linear);
-        let params = ctrl.update(2000).unwrap();
-        assert!((params.intensity - 0.8).abs() < f64::EPSILON);
-    }
-
-    #[test]
-    fn linear_midpoint() {
-        let ctrl = ThrottleController::new(test_config(), ThrottleStrategy::Linear);
-        let params = ctrl.update(1500).unwrap();
-        assert!((params.intensity - 0.4).abs() < 0.01);
+    /// Verifies `ThrottleController::update` returns the correct result for each
+    /// strategy and backlog combination.
+    ///
+    /// `expected_intensity` is `None` when no throttling should be applied, or
+    /// `Some(intensity)` when throttling must be active with that intensity value.
+    #[rstest]
+    #[case::off_always_none(ThrottleStrategy::Off, 5000, None)]
+    #[case::step_below_threshold(ThrottleStrategy::Step, 999, None)]
+    #[case::step_at_threshold(ThrottleStrategy::Step, 1000, Some(0.8))]
+    #[case::linear_below_threshold(ThrottleStrategy::Linear, 500, None)]
+    // At exactly the threshold, excess = 0 → intensity = 0.0 → must return None,
+    // not Some with zero intensity (which would trigger a spurious log on startup).
+    #[case::linear_at_threshold(ThrottleStrategy::Linear, 1000, None)]
+    #[case::linear_at_max(ThrottleStrategy::Linear, 2000, Some(0.8))]
+    #[case::linear_midpoint(ThrottleStrategy::Linear, 1500, Some(0.4))]
+    fn test_update(
+        #[case] strategy: ThrottleStrategy,
+        #[case] da_backlog_bytes: u64,
+        #[case] expected_intensity: Option<f64>,
+    ) {
+        let ctrl = ThrottleController::new(test_config(), strategy);
+        let result = ctrl.update(da_backlog_bytes);
+        match expected_intensity {
+            None => assert!(result.is_none()),
+            Some(expected) => {
+                let params = result.expect("expected Some result");
+                assert!(
+                    (params.intensity - expected).abs() < 0.01,
+                    "expected intensity {expected}, got {}",
+                    params.intensity
+                );
+            }
+        }
     }
 }

--- a/crates/batcher/core/tests/driver.rs
+++ b/crates/batcher/core/tests/driver.rs
@@ -1,0 +1,740 @@
+//! Integration tests for [`BatchDriver`] end-to-end behaviour.
+
+use std::{
+    sync::{Arc, Mutex},
+    time::Duration,
+};
+
+use alloy_primitives::{Address, B256};
+use async_trait::async_trait;
+use base_alloy_consensus::OpBlock;
+use base_batcher_encoder::{
+    BatchPipeline, BatchSubmission, ReorgError, StepError, StepResult, SubmissionId,
+};
+use base_batcher_source::{
+    ChannelBlockSource, ChannelL1HeadSource, L1HeadEvent, L2BlockEvent, SourceError,
+    UnsafeBlockSource, test_utils::InMemoryBlockSource,
+};
+use base_protocol::{BlockInfo, L2BlockInfo};
+use base_runtime::{
+    Cancellation, Clock, Spawner,
+    deterministic::{Config, Runner},
+};
+use tokio::sync::mpsc;
+
+use base_batcher_core::{
+    BatchDriver, BatchDriverConfig, DaThrottle, NoopThrottleClient, ThrottleConfig,
+    ThrottleController, ThrottleStrategy,
+    test_utils::{
+        DriverFixture, ImmediateConfirmTxManager, ImmediateFailTxManager, NeverConfirmTxManager,
+        OneBlockSource, OneReorgPipeline, PendingL1HeadSource, PendingSource, Recorded,
+        ReorgPipeline, SubmissionStub, TrackingPipeline, TrackingThrottleClient,
+    },
+};
+
+// ---- Reorg tests ----
+
+/// When `add_block` returns `ReorgError`, the driver must reset the pipeline and
+/// then re-add the triggering block so it is not permanently lost. The block
+/// queue in the encoder is empty after reset, so the parent-hash check is
+/// skipped and the re-add always succeeds.
+#[test]
+fn test_reorg_block_is_readded_after_reset() {
+    Runner::start(Config::seeded(0), |ctx| async move {
+        let blocks_accepted = Arc::new(Mutex::new(0usize));
+        let resets = Arc::new(Mutex::new(0usize));
+        let pipeline = OneReorgPipeline::new(Arc::clone(&blocks_accepted), Arc::clone(&resets));
+
+        let driver = BatchDriver::new(
+            ctx.clone(),
+            pipeline,
+            OneBlockSource::new(),
+            ImmediateConfirmTxManager { l1_block: 1 },
+            BatchDriverConfig {
+                inbox: Address::ZERO,
+                max_pending_transactions: 1,
+                drain_timeout: Duration::from_millis(10),
+            },
+            DaThrottle::new(ThrottleController::noop(), Arc::new(NoopThrottleClient)),
+            PendingL1HeadSource,
+        );
+        let handle = ctx.spawn(driver.run());
+
+        ctx.sleep(Duration::from_millis(50)).await;
+        ctx.cancel();
+
+        assert!(handle.await.unwrap().is_ok());
+        assert_eq!(*resets.lock().unwrap(), 1, "pipeline must be reset on reorg");
+        assert_eq!(
+            *blocks_accepted.lock().unwrap(),
+            1,
+            "the triggering block must be re-added after reset"
+        );
+    });
+}
+
+/// When `add_block` returns a `ReorgError`, the driver must reset the pipeline
+/// and discard in-flight futures instead of propagating a fatal error. This
+/// mirrors the `L2BlockEvent::Reorg` handling path.
+#[test]
+fn test_add_block_reorg_resets_pipeline_instead_of_fatal_error() {
+    Runner::start(Config::seeded(0), |ctx| async move {
+        let recorded = Arc::new(Mutex::new(Recorded::default()));
+        let pipeline = ReorgPipeline::new(Arc::clone(&recorded));
+
+        let driver = BatchDriver::new(
+            ctx.clone(),
+            pipeline,
+            OneBlockSource::new(),
+            ImmediateConfirmTxManager { l1_block: 1 },
+            BatchDriverConfig {
+                inbox: Address::ZERO,
+                max_pending_transactions: 1,
+                drain_timeout: Duration::from_millis(10),
+            },
+            DaThrottle::new(ThrottleController::noop(), Arc::new(NoopThrottleClient)),
+            PendingL1HeadSource,
+        );
+        let handle = ctx.spawn(driver.run());
+
+        ctx.sleep(Duration::from_millis(50)).await;
+        ctx.cancel();
+
+        let result = handle.await.unwrap();
+        assert!(result.is_ok(), "driver must not return a fatal error on add_block reorg");
+        assert_eq!(
+            recorded.lock().unwrap().resets,
+            1,
+            "pipeline.reset() must be called when add_block returns ReorgError"
+        );
+    });
+}
+
+// ---- Throttle integration tests ----
+
+/// When the DA backlog exceeds the threshold, the driver must call
+/// `set_max_da_size` on the throttle client with reduced limits.
+#[test]
+fn test_throttle_client_called_on_high_backlog() {
+    Runner::start(Config::seeded(0), |ctx| async move {
+        let recorded = Arc::new(Mutex::new(Recorded::default()));
+        // 2 MB backlog — above the default 1 MB threshold.
+        let pipeline = TrackingPipeline::new(Arc::clone(&recorded)).with_da_backlog(2_000_000);
+
+        let throttle =
+            ThrottleController::new(ThrottleConfig::default(), ThrottleStrategy::Linear);
+        let (throttle_client, throttle_recorded) = TrackingThrottleClient::new();
+
+        let driver = BatchDriver::new(
+            ctx.clone(),
+            pipeline,
+            PendingSource,
+            ImmediateConfirmTxManager { l1_block: 1 },
+            BatchDriverConfig {
+                inbox: Address::ZERO,
+                max_pending_transactions: 1,
+                drain_timeout: Duration::from_millis(10),
+            },
+            DaThrottle::new(throttle, Arc::new(throttle_client)),
+            PendingL1HeadSource,
+        );
+        let handle = ctx.spawn(driver.run());
+
+        ctx.sleep(Duration::from_millis(50)).await;
+        ctx.cancel();
+        assert!(handle.await.unwrap().is_ok());
+
+        let calls = throttle_recorded.lock().unwrap();
+        assert!(!calls.is_empty(), "throttle client must be called when backlog is high");
+        let (max_tx_size, max_block_size) = calls[0];
+        assert!(
+            max_block_size < 130_000,
+            "max_block_size should be below upper limit when throttled, got {max_block_size}"
+        );
+        assert!(
+            max_tx_size < 20_000,
+            "max_tx_size should be below upper limit when throttled, got {max_tx_size}"
+        );
+    });
+}
+
+/// When the DA backlog is zero (below threshold), the driver must call
+/// `set_max_da_size` with the upper limits to reset any previous throttle.
+#[test]
+fn test_throttle_client_called_with_upper_limits_on_zero_backlog() {
+    Runner::start(Config::seeded(0), |ctx| async move {
+        let recorded = Arc::new(Mutex::new(Recorded::default()));
+        let pipeline = TrackingPipeline::new(Arc::clone(&recorded)).with_da_backlog(0);
+
+        let throttle =
+            ThrottleController::new(ThrottleConfig::default(), ThrottleStrategy::Linear);
+        let (throttle_client, throttle_recorded) = TrackingThrottleClient::new();
+
+        let driver = BatchDriver::new(
+            ctx.clone(),
+            pipeline,
+            PendingSource,
+            ImmediateConfirmTxManager { l1_block: 1 },
+            BatchDriverConfig {
+                inbox: Address::ZERO,
+                max_pending_transactions: 1,
+                drain_timeout: Duration::from_millis(10),
+            },
+            DaThrottle::new(throttle, Arc::new(throttle_client)),
+            PendingL1HeadSource,
+        );
+        let handle = ctx.spawn(driver.run());
+
+        ctx.sleep(Duration::from_millis(50)).await;
+        ctx.cancel();
+        assert!(handle.await.unwrap().is_ok());
+
+        let calls = throttle_recorded.lock().unwrap();
+        assert!(!calls.is_empty(), "throttle client must be called even with zero backlog");
+        let (max_tx_size, max_block_size) = calls[0];
+        assert_eq!(
+            max_block_size, 130_000,
+            "max_block_size should be the upper limit when not throttling"
+        );
+        assert_eq!(
+            max_tx_size, 20_000,
+            "max_tx_size should be the upper limit when not throttling"
+        );
+    });
+}
+
+/// `set_max_da_size` must be called exactly once when limits do not change
+/// between driver loop iterations.
+#[test]
+fn test_throttle_not_called_redundantly() {
+    Runner::start(Config::seeded(0), |ctx| async move {
+        let recorded = Arc::new(Mutex::new(Recorded::default()));
+        let pipeline = TrackingPipeline::new(Arc::clone(&recorded)).with_da_backlog(0);
+
+        let throttle =
+            ThrottleController::new(ThrottleConfig::default(), ThrottleStrategy::Linear);
+        let (throttle_client, throttle_recorded) = TrackingThrottleClient::new();
+
+        let driver = BatchDriver::new(
+            ctx.clone(),
+            pipeline,
+            PendingSource,
+            ImmediateConfirmTxManager { l1_block: 1 },
+            BatchDriverConfig {
+                inbox: Address::ZERO,
+                max_pending_transactions: 1,
+                drain_timeout: Duration::from_millis(10),
+            },
+            DaThrottle::new(throttle, Arc::new(throttle_client)),
+            PendingL1HeadSource,
+        );
+        let handle = ctx.spawn(driver.run());
+
+        // Run for 100ms to allow multiple loop iterations.
+        ctx.sleep(Duration::from_millis(100)).await;
+        ctx.cancel();
+        assert!(handle.await.unwrap().is_ok());
+
+        let calls = throttle_recorded.lock().unwrap();
+        assert_eq!(
+            calls.len(),
+            1,
+            "set_max_da_size must be called exactly once when limits do not change, got {}",
+            calls.len()
+        );
+    });
+}
+
+/// With the Step strategy and full intensity, when backlog is above the
+/// threshold, the driver must apply the lower DA limits.
+#[test]
+fn test_step_strategy_full_intensity_applies_lower_limits() {
+    Runner::start(Config::seeded(0), |ctx| async move {
+        let recorded = Arc::new(Mutex::new(Recorded::default()));
+        // Backlog of 100 — above threshold of 1.
+        let pipeline = TrackingPipeline::new(Arc::clone(&recorded)).with_da_backlog(100);
+
+        let config =
+            ThrottleConfig { threshold_bytes: 1, max_intensity: 1.0, ..Default::default() };
+        let throttle = ThrottleController::new(config, ThrottleStrategy::Step);
+        let (throttle_client, throttle_recorded) = TrackingThrottleClient::new();
+
+        let driver = BatchDriver::new(
+            ctx.clone(),
+            pipeline,
+            PendingSource,
+            ImmediateConfirmTxManager { l1_block: 1 },
+            BatchDriverConfig {
+                inbox: Address::ZERO,
+                max_pending_transactions: 1,
+                drain_timeout: Duration::from_millis(10),
+            },
+            DaThrottle::new(throttle, Arc::new(throttle_client)),
+            PendingL1HeadSource,
+        );
+        let handle = ctx.spawn(driver.run());
+
+        ctx.sleep(Duration::from_millis(50)).await;
+        ctx.cancel();
+        assert!(handle.await.unwrap().is_ok());
+
+        let calls = throttle_recorded.lock().unwrap();
+        assert!(!calls.is_empty(), "throttle client must be called with Step strategy");
+        let (max_tx_size, max_block_size) = calls[0];
+        assert_eq!(
+            max_block_size, 2_000,
+            "Step strategy at full intensity must apply block_size_lower_limit"
+        );
+        assert_eq!(
+            max_tx_size, 150,
+            "Step strategy at full intensity must apply tx_size_lower_limit"
+        );
+    });
+}
+
+/// Verifies that when the DA backlog transitions from above the threshold
+/// (throttle active) to zero (throttle inactive), the driver makes exactly
+/// two RPC calls: one with reduced limits and one resetting to upper limits.
+#[test]
+fn test_throttle_transitions_from_active_to_inactive() {
+    // Pipeline whose DA backlog is controlled from the test via a shared lock.
+    struct DynamicPipeline {
+        backlog: Arc<Mutex<u64>>,
+    }
+
+    impl BatchPipeline for DynamicPipeline {
+        fn add_block(&mut self, _: OpBlock) -> Result<(), (ReorgError, Box<OpBlock>)> {
+            Ok(())
+        }
+
+        fn step(&mut self) -> Result<StepResult, StepError> {
+            Ok(StepResult::Idle)
+        }
+
+        fn next_submission(&mut self) -> Option<BatchSubmission> {
+            None
+        }
+
+        fn confirm(&mut self, _: SubmissionId, _: u64) {}
+        fn requeue(&mut self, _: SubmissionId) {}
+        fn force_close_channel(&mut self) {}
+        fn advance_l1_head(&mut self, _: u64) {}
+        fn prune_safe(&mut self, _: u64) {}
+        fn reset(&mut self) {}
+
+        fn da_backlog_bytes(&self) -> u64 {
+            *self.backlog.lock().unwrap()
+        }
+    }
+
+    // Source driven by an mpsc channel so the test can wake the driver loop
+    // by sending a dummy block event after changing the backlog.
+    struct ChannelSource {
+        rx: mpsc::UnboundedReceiver<L2BlockEvent>,
+    }
+
+    #[async_trait]
+    impl UnsafeBlockSource for ChannelSource {
+        async fn next(&mut self) -> Result<L2BlockEvent, SourceError> {
+            match self.rx.recv().await {
+                Some(event) => Ok(event),
+                // Channel closed: park until the driver is cancelled.
+                None => std::future::pending().await,
+            }
+        }
+    }
+
+    Runner::start(Config::seeded(0), |ctx| async move {
+        let (source_tx, source_rx) = mpsc::unbounded_channel();
+
+        // Start with 2 MB backlog — above the default 1 MB threshold.
+        let backlog = Arc::new(Mutex::new(2_000_000u64));
+        let pipeline = DynamicPipeline { backlog: Arc::clone(&backlog) };
+
+        let throttle =
+            ThrottleController::new(ThrottleConfig::default(), ThrottleStrategy::Linear);
+        let (throttle_client, throttle_recorded) = TrackingThrottleClient::new();
+
+        let driver = BatchDriver::new(
+            ctx.clone(),
+            pipeline,
+            ChannelSource { rx: source_rx },
+            ImmediateConfirmTxManager { l1_block: 1 },
+            BatchDriverConfig {
+                inbox: Address::ZERO,
+                max_pending_transactions: 1,
+                drain_timeout: Duration::from_millis(10),
+            },
+            DaThrottle::new(throttle, Arc::new(throttle_client)),
+            PendingL1HeadSource,
+        );
+        let handle = ctx.spawn(driver.run());
+
+        // First iteration fires immediately on startup; give it time to complete.
+        ctx.sleep(Duration::from_millis(30)).await;
+
+        // Drop the backlog to zero, then wake the driver by delivering a dummy
+        // block so the select! arm fires and the loop re-runs the throttle check.
+        *backlog.lock().unwrap() = 0;
+        source_tx.send(L2BlockEvent::Block(Box::default())).unwrap();
+
+        ctx.sleep(Duration::from_millis(30)).await;
+        ctx.cancel();
+        assert!(handle.await.unwrap().is_ok());
+
+        let calls = throttle_recorded.lock().unwrap();
+        assert!(
+            calls.len() >= 2,
+            "expected at least 2 throttle calls (activate + deactivate), got {}",
+            calls.len()
+        );
+
+        // First call must have reduced limits (throttle active, backlog was high).
+        let (first_tx, first_block) = calls[0];
+        assert!(
+            first_block < 130_000,
+            "first call should apply throttled block limit, got {first_block}"
+        );
+        assert!(
+            first_tx < 20_000,
+            "first call should apply throttled tx limit, got {first_tx}"
+        );
+
+        // Last call must reset to upper limits (throttle deactivated).
+        let (last_tx, last_block) = *calls.last().unwrap();
+        assert_eq!(last_block, 130_000, "last call should reset block limit to upper bound");
+        assert_eq!(last_tx, 20_000, "last call should reset tx limit to upper bound");
+    });
+}
+
+// ---- L1 head source + safe head watch receiver tests ----
+
+/// When the L1 head source delivers a new head, the driver must call
+/// `advance_l1_head` on the pipeline with the new value.
+#[test]
+fn test_l1_head_source_advances_pipeline() {
+    Runner::start(Config::seeded(0), |ctx| async move {
+        let recorded = Arc::new(Mutex::new(Recorded::default()));
+        let pipeline = TrackingPipeline::new(Arc::clone(&recorded));
+
+        let (l1_source, l1_tx) = ChannelL1HeadSource::new();
+
+        let driver = BatchDriver::new(
+            ctx.clone(),
+            pipeline,
+            PendingSource,
+            ImmediateConfirmTxManager { l1_block: 1 },
+            BatchDriverConfig {
+                inbox: Address::ZERO,
+                max_pending_transactions: 1,
+                drain_timeout: Duration::from_millis(10),
+            },
+            DaThrottle::new(ThrottleController::noop(), Arc::new(NoopThrottleClient)),
+            l1_source,
+        );
+        let handle = ctx.spawn(driver.run());
+
+        // Send a new L1 head via the channel.
+        l1_tx.send(L1HeadEvent::NewHead(42)).unwrap();
+        ctx.sleep(Duration::from_millis(50)).await;
+        ctx.cancel();
+
+        assert!(handle.await.unwrap().is_ok());
+        let r = recorded.lock().unwrap();
+        assert!(
+            r.l1_heads.contains(&42),
+            "advance_l1_head must be called with the source value, got {:?}",
+            r.l1_heads
+        );
+    });
+}
+
+/// When a safe head watch receiver fires, the driver must call
+/// `prune_safe` on the pipeline with the new value.
+#[test]
+fn test_safe_head_watch_prunes_pipeline() {
+    Runner::start(Config::seeded(0), |ctx| async move {
+        let recorded = Arc::new(Mutex::new(Recorded::default()));
+        let pipeline = TrackingPipeline::new(Arc::clone(&recorded));
+
+        let (safe_tx, safe_rx) = tokio::sync::watch::channel(0u64);
+
+        let driver =
+            DriverFixture::build(ctx.clone(), pipeline, ImmediateConfirmTxManager { l1_block: 1 })
+                .with_safe_head_rx(safe_rx);
+        let handle = ctx.spawn(driver.run());
+
+        // Send a new safe head.
+        safe_tx.send(100).unwrap();
+        ctx.sleep(Duration::from_millis(50)).await;
+        ctx.cancel();
+
+        assert!(handle.await.unwrap().is_ok());
+        let r = recorded.lock().unwrap();
+        assert!(
+            r.safe_numbers.contains(&100),
+            "prune_safe must be called with the watch value, got {:?}",
+            r.safe_numbers
+        );
+    });
+}
+
+/// When the safe head sender is dropped while the driver is running, the watch
+/// arm must disable itself rather than spinning. The driver continues running
+/// and remains cancellable after the sender disappears.
+#[test]
+fn test_safe_head_sender_drop_does_not_busyloop() {
+    Runner::start(Config::seeded(0), |ctx| async move {
+        let recorded = Arc::new(Mutex::new(Recorded::default()));
+        let pipeline = TrackingPipeline::new(Arc::clone(&recorded));
+
+        let (safe_tx, safe_rx) = tokio::sync::watch::channel(0u64);
+
+        let driver =
+            DriverFixture::build(ctx.clone(), pipeline, ImmediateConfirmTxManager { l1_block: 1 })
+                .with_safe_head_rx(safe_rx);
+        let handle = ctx.spawn(driver.run());
+
+        // Send one value, then drop the sender while the driver is still running.
+        safe_tx.send(50).unwrap();
+        ctx.sleep(Duration::from_millis(20)).await;
+        drop(safe_tx);
+
+        // Give the driver time to process the drop. If the arm busy-loops,
+        // prune_safe would be called many additional times here.
+        ctx.sleep(Duration::from_millis(50)).await;
+        let prune_count_after_drop = recorded.lock().unwrap().safe_numbers.len();
+
+        // Cancel and wait — driver must exit cleanly, not hang.
+        ctx.cancel();
+        assert!(handle.await.unwrap().is_ok(), "driver must exit cleanly after sender drop");
+
+        let r = recorded.lock().unwrap();
+        assert!(
+            r.safe_numbers.contains(&50),
+            "prune_safe must have been called with the sent value"
+        );
+        // After the sender drops, prune_safe must not be called again.
+        assert_eq!(
+            r.safe_numbers.len(),
+            prune_count_after_drop,
+            "prune_safe must not be called after sender drop (arm must be disabled)"
+        );
+    });
+}
+
+/// Without a safe head receiver, confirmation-based L1 head advancement must
+/// still work normally. The driver uses `PendingL1HeadSource` (parks forever)
+/// so only submission confirmations drive `advance_l1_head`.
+#[test]
+fn test_no_safe_head_receiver_driver_runs_normally() {
+    Runner::start(Config::seeded(0), |ctx| async move {
+        let recorded = Arc::new(Mutex::new(Recorded::default()));
+        let mut pipeline = TrackingPipeline::new(Arc::clone(&recorded));
+        pipeline.submissions.push_back(SubmissionStub::new());
+
+        // No .with_safe_head_rx() — safe_head remains None.
+        let driver =
+            DriverFixture::build(ctx.clone(), pipeline, ImmediateConfirmTxManager { l1_block: 7 });
+        let handle = ctx.spawn(driver.run());
+
+        ctx.sleep(Duration::from_millis(50)).await;
+        ctx.cancel();
+
+        assert!(handle.await.unwrap().is_ok());
+        let r = recorded.lock().unwrap();
+        assert_eq!(r.l1_heads, vec![7], "confirmation-based advance_l1_head must still work");
+        assert!(r.safe_numbers.is_empty(), "prune_safe must not be called without a receiver");
+    });
+}
+
+// ---- Driver lifecycle tests ----
+
+/// When the block source returns `SourceError::Exhausted`, the driver must
+/// treat it as a graceful shutdown signal: close the current channel,
+/// drain in-flight submissions within the timeout, then exit cleanly.
+#[test]
+fn test_source_exhaustion_shuts_down_driver_gracefully() {
+    Runner::start(Config::seeded(0), |ctx| async move {
+        let recorded = Arc::new(Mutex::new(Recorded::default()));
+        let pipeline = TrackingPipeline::new(Arc::clone(&recorded));
+
+        let driver = BatchDriver::new(
+            ctx.clone(),
+            pipeline,
+            InMemoryBlockSource::new(), // empty → Exhausted immediately
+            ImmediateConfirmTxManager { l1_block: 1 },
+            BatchDriverConfig {
+                inbox: Address::ZERO,
+                max_pending_transactions: 1,
+                drain_timeout: Duration::from_millis(10),
+            },
+            DaThrottle::new(ThrottleController::noop(), Arc::new(NoopThrottleClient)),
+            PendingL1HeadSource,
+        );
+
+        let handle = ctx.spawn(driver.run());
+        ctx.sleep(Duration::from_millis(50)).await;
+
+        let result = handle.await.unwrap();
+        assert!(result.is_ok(), "driver must exit cleanly when source exhausts");
+        assert_eq!(
+            recorded.lock().unwrap().force_close_count,
+            1,
+            "force_close_channel must be called once on source exhaustion shutdown"
+        );
+    });
+}
+
+/// When the source delivers `L2BlockEvent::Flush`, the driver must call
+/// `force_close_channel` immediately. On subsequent shutdown it is called once
+/// more, giving a total of two calls.
+#[test]
+fn test_flush_event_calls_force_close_channel() {
+    Runner::start(Config::seeded(0), |ctx| async move {
+        let recorded = Arc::new(Mutex::new(Recorded::default()));
+        let pipeline = TrackingPipeline::new(Arc::clone(&recorded));
+        let (source, source_tx) = ChannelBlockSource::new();
+
+        let driver = BatchDriver::new(
+            ctx.clone(),
+            pipeline,
+            source,
+            ImmediateConfirmTxManager { l1_block: 1 },
+            BatchDriverConfig {
+                inbox: Address::ZERO,
+                max_pending_transactions: 1,
+                drain_timeout: Duration::from_millis(10),
+            },
+            DaThrottle::new(ThrottleController::noop(), Arc::new(NoopThrottleClient)),
+            PendingL1HeadSource,
+        );
+        let handle = ctx.spawn(driver.run());
+
+        source_tx.send(L2BlockEvent::Flush).unwrap();
+        ctx.sleep(Duration::from_millis(50)).await;
+        ctx.cancel();
+
+        assert!(handle.await.unwrap().is_ok());
+        // Flush arm: +1; Shutdown arm: +1 → total 2
+        assert_eq!(
+            recorded.lock().unwrap().force_close_count,
+            2,
+            "force_close_channel must be called for Flush and again on shutdown"
+        );
+    });
+}
+
+/// When the source delivers `L2BlockEvent::Reorg`, the driver must reset the
+/// pipeline and discard in-flight submissions. This is distinct from the
+/// `add_block`-triggered reorg path tested in
+/// `test_reorg_block_is_readded_after_reset`.
+#[test]
+fn test_l2_reorg_event_resets_pipeline() {
+    Runner::start(Config::seeded(0), |ctx| async move {
+        let recorded = Arc::new(Mutex::new(Recorded::default()));
+        let pipeline = TrackingPipeline::new(Arc::clone(&recorded));
+        let (source, source_tx) = ChannelBlockSource::new();
+
+        let driver = BatchDriver::new(
+            ctx.clone(),
+            pipeline,
+            source,
+            ImmediateConfirmTxManager { l1_block: 1 },
+            BatchDriverConfig {
+                inbox: Address::ZERO,
+                max_pending_transactions: 1,
+                drain_timeout: Duration::from_millis(10),
+            },
+            DaThrottle::new(ThrottleController::noop(), Arc::new(NoopThrottleClient)),
+            PendingL1HeadSource,
+        );
+        let handle = ctx.spawn(driver.run());
+
+        let reorg_head = L2BlockInfo::new(
+            BlockInfo::new(B256::ZERO, 5, B256::ZERO, 0),
+            Default::default(),
+            0,
+        );
+        source_tx.send(L2BlockEvent::Reorg { new_safe_head: reorg_head }).unwrap();
+        ctx.sleep(Duration::from_millis(50)).await;
+        ctx.cancel();
+
+        assert!(handle.await.unwrap().is_ok());
+        assert_eq!(
+            recorded.lock().unwrap().resets,
+            1,
+            "pipeline must be reset when source delivers a Reorg event"
+        );
+    });
+}
+
+/// When the L1 head source is exhausted, the driver must disable that arm and
+/// continue running — it must not shut down. The L1 head delivered before
+/// exhaustion must be processed normally.
+#[test]
+fn test_l1_source_exhausted_disables_arm_driver_continues() {
+    Runner::start(Config::seeded(0), |ctx| async move {
+        let recorded = Arc::new(Mutex::new(Recorded::default()));
+        let pipeline = TrackingPipeline::new(Arc::clone(&recorded));
+        let (l1_source, l1_tx) = ChannelL1HeadSource::new();
+
+        let driver = BatchDriver::new(
+            ctx.clone(),
+            pipeline,
+            PendingSource,
+            ImmediateConfirmTxManager { l1_block: 1 },
+            BatchDriverConfig {
+                inbox: Address::ZERO,
+                max_pending_transactions: 1,
+                drain_timeout: Duration::from_millis(10),
+            },
+            DaThrottle::new(ThrottleController::noop(), Arc::new(NoopThrottleClient)),
+            l1_source,
+        );
+        let handle = ctx.spawn(driver.run());
+
+        l1_tx.send(L1HeadEvent::NewHead(77)).unwrap();
+        ctx.sleep(Duration::from_millis(20)).await;
+        drop(l1_tx); // triggers Exhausted → L1SourceClosed
+
+        // Driver must still be running after L1 source closes.
+        ctx.sleep(Duration::from_millis(50)).await;
+        ctx.cancel();
+
+        assert!(handle.await.unwrap().is_ok(), "driver must continue after L1 source closes");
+        let r = recorded.lock().unwrap();
+        assert!(
+            r.l1_heads.contains(&77),
+            "L1 head delivered before close must be processed, got {:?}",
+            r.l1_heads
+        );
+    });
+}
+
+/// When cancellation fires while a submission is in-flight with a
+/// `NeverConfirmTxManager`, the drain timeout must fire and the driver must
+/// exit cleanly. This verifies the `runtime.sleep(drain_timeout)` fix.
+#[test]
+fn test_drain_timeout_exits_with_in_flight_submissions() {
+    Runner::start(Config::seeded(0), |ctx| async move {
+        let recorded = Arc::new(Mutex::new(Recorded::default()));
+        let mut pipeline = TrackingPipeline::new(Arc::clone(&recorded));
+        pipeline.submissions.push_back(SubmissionStub::new());
+
+        let driver = DriverFixture::build(ctx.clone(), pipeline, NeverConfirmTxManager);
+        let handle = ctx.spawn(driver.run());
+
+        ctx.sleep(Duration::from_millis(20)).await;
+        ctx.cancel();
+
+        let result = handle.await.unwrap();
+        assert!(
+            result.is_ok(),
+            "driver must exit after drain timeout even with in-flight submissions"
+        );
+        let r = recorded.lock().unwrap();
+        assert_eq!(r.dequeued, vec![SubmissionId(0)], "submission must have been dequeued");
+        assert_eq!(r.force_close_count, 1, "force_close_channel must be called on shutdown");
+    });
+}

--- a/crates/batcher/core/tests/driver.rs
+++ b/crates/batcher/core/tests/driver.rs
@@ -8,6 +8,15 @@ use std::{
 use alloy_primitives::{Address, B256};
 use async_trait::async_trait;
 use base_alloy_consensus::OpBlock;
+use base_batcher_core::{
+    BatchDriver, BatchDriverConfig, DaThrottle, NoopThrottleClient, ThrottleConfig,
+    ThrottleController, ThrottleStrategy,
+    test_utils::{
+        DriverFixture, ImmediateConfirmTxManager, ImmediateFailTxManager, NeverConfirmTxManager,
+        OneBlockSource, OneReorgPipeline, PendingL1HeadSource, PendingSource, Recorded,
+        ReorgPipeline, SubmissionStub, TrackingPipeline, TrackingThrottleClient,
+    },
+};
 use base_batcher_encoder::{
     BatchPipeline, BatchSubmission, ReorgError, StepError, StepResult, SubmissionId,
 };
@@ -21,16 +30,6 @@ use base_runtime::{
     deterministic::{Config, Runner},
 };
 use tokio::sync::mpsc;
-
-use base_batcher_core::{
-    BatchDriver, BatchDriverConfig, DaThrottle, NoopThrottleClient, ThrottleConfig,
-    ThrottleController, ThrottleStrategy,
-    test_utils::{
-        DriverFixture, ImmediateConfirmTxManager, ImmediateFailTxManager, NeverConfirmTxManager,
-        OneBlockSource, OneReorgPipeline, PendingL1HeadSource, PendingSource, Recorded,
-        ReorgPipeline, SubmissionStub, TrackingPipeline, TrackingThrottleClient,
-    },
-};
 
 // ---- Reorg tests ----
 
@@ -121,8 +120,7 @@ fn test_throttle_client_called_on_high_backlog() {
         // 2 MB backlog — above the default 1 MB threshold.
         let pipeline = TrackingPipeline::new(Arc::clone(&recorded)).with_da_backlog(2_000_000);
 
-        let throttle =
-            ThrottleController::new(ThrottleConfig::default(), ThrottleStrategy::Linear);
+        let throttle = ThrottleController::new(ThrottleConfig::default(), ThrottleStrategy::Linear);
         let (throttle_client, throttle_recorded) = TrackingThrottleClient::new();
 
         let driver = BatchDriver::new(
@@ -166,8 +164,7 @@ fn test_throttle_client_called_with_upper_limits_on_zero_backlog() {
         let recorded = Arc::new(Mutex::new(Recorded::default()));
         let pipeline = TrackingPipeline::new(Arc::clone(&recorded)).with_da_backlog(0);
 
-        let throttle =
-            ThrottleController::new(ThrottleConfig::default(), ThrottleStrategy::Linear);
+        let throttle = ThrottleController::new(ThrottleConfig::default(), ThrottleStrategy::Linear);
         let (throttle_client, throttle_recorded) = TrackingThrottleClient::new();
 
         let driver = BatchDriver::new(
@@ -211,8 +208,7 @@ fn test_throttle_not_called_redundantly() {
         let recorded = Arc::new(Mutex::new(Recorded::default()));
         let pipeline = TrackingPipeline::new(Arc::clone(&recorded)).with_da_backlog(0);
 
-        let throttle =
-            ThrottleController::new(ThrottleConfig::default(), ThrottleStrategy::Linear);
+        let throttle = ThrottleController::new(ThrottleConfig::default(), ThrottleStrategy::Linear);
         let (throttle_client, throttle_recorded) = TrackingThrottleClient::new();
 
         let driver = BatchDriver::new(
@@ -351,8 +347,7 @@ fn test_throttle_transitions_from_active_to_inactive() {
         let backlog = Arc::new(Mutex::new(2_000_000u64));
         let pipeline = DynamicPipeline { backlog: Arc::clone(&backlog) };
 
-        let throttle =
-            ThrottleController::new(ThrottleConfig::default(), ThrottleStrategy::Linear);
+        let throttle = ThrottleController::new(ThrottleConfig::default(), ThrottleStrategy::Linear);
         let (throttle_client, throttle_recorded) = TrackingThrottleClient::new();
 
         let driver = BatchDriver::new(
@@ -395,10 +390,7 @@ fn test_throttle_transitions_from_active_to_inactive() {
             first_block < 130_000,
             "first call should apply throttled block limit, got {first_block}"
         );
-        assert!(
-            first_tx < 20_000,
-            "first call should apply throttled tx limit, got {first_tx}"
-        );
+        assert!(first_tx < 20_000, "first call should apply throttled tx limit, got {first_tx}");
 
         // Last call must reset to upper limits (throttle deactivated).
         let (last_tx, last_block) = *calls.last().unwrap();
@@ -651,11 +643,8 @@ fn test_l2_reorg_event_resets_pipeline() {
         );
         let handle = ctx.spawn(driver.run());
 
-        let reorg_head = L2BlockInfo::new(
-            BlockInfo::new(B256::ZERO, 5, B256::ZERO, 0),
-            Default::default(),
-            0,
-        );
+        let reorg_head =
+            L2BlockInfo::new(BlockInfo::new(B256::ZERO, 5, B256::ZERO, 0), Default::default(), 0);
         source_tx.send(L2BlockEvent::Reorg { new_safe_head: reorg_head }).unwrap();
         ctx.sleep(Duration::from_millis(50)).await;
         ctx.cancel();

--- a/crates/batcher/core/tests/driver.rs
+++ b/crates/batcher/core/tests/driver.rs
@@ -523,7 +523,7 @@ fn test_no_safe_head_receiver_driver_runs_normally() {
     Runner::start(Config::seeded(0), |ctx| async move {
         let recorded = Arc::new(Mutex::new(Recorded::default()));
         let mut pipeline = TrackingPipeline::new(Arc::clone(&recorded));
-        pipeline.submissions.push_back(SubmissionStub::new());
+        pipeline.submissions.push_back(SubmissionStub::stub());
 
         // No .with_safe_head_rx() — safe_head remains None.
         let driver =
@@ -709,7 +709,7 @@ fn test_drain_timeout_exits_with_in_flight_submissions() {
     Runner::start(Config::seeded(0), |ctx| async move {
         let recorded = Arc::new(Mutex::new(Recorded::default()));
         let mut pipeline = TrackingPipeline::new(Arc::clone(&recorded));
-        pipeline.submissions.push_back(SubmissionStub::new());
+        pipeline.submissions.push_back(SubmissionStub::stub());
 
         let driver = DriverFixture::build(ctx.clone(), pipeline, NeverConfirmTxManager);
         let handle = ctx.spawn(driver.run());


### PR DESCRIPTION
## Summary

Moves large driver integration tests out of the inline cfg(test) block and into crates/batcher/core/tests/driver.rs. Test utility sub-modules are gated behind cfg(any(test, feature = "test-utils")) so integration tests can access shared fixtures via the test-utils feature flag. Free-floating helper functions are replaced with SubmissionStub and DriverFixture unit structs in test_utils/builder.rs per CLAUDE.md conventions. Throttle unit tests are converted to rstest parameterized cases, and DriverEvent is made public.