### PR TITLE
ktlo(ci): Bump Devnet Tests CI Timeout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -261,7 +261,7 @@ jobs:
   devnet-tests:
     name: Devnet Tests
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 60
     steps:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@95d9a5deda9de15063e7595e9719c11c38c90ae2 # v2.13.2


### PR DESCRIPTION
## Summary

The devnet tests CI job has been timing out due to an overly conservative 30-minute limit. Docker image pulling, building, and running the full devnet test suite consistently requires more headroom. This bumps the `timeout-minutes` on the `devnet-tests` job from 30 to 60 to give it enough runway to complete reliably.