### PR TITLE
feat(CHAIN-3561): Wire attestation prover into registrar

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4626,6 +4626,7 @@ dependencies = [
  "aws-sdk-ec2",
  "aws-sdk-elasticloadbalancingv2",
  "base-proof-primitives",
+ "base-proof-tee-nitro-attestation-prover",
  "hex-literal 1.1.0",
  "jsonrpsee",
  "k256",

--- a/crates/proof/tee/registrar/Cargo.toml
+++ b/crates/proof/tee/registrar/Cargo.toml
@@ -25,6 +25,9 @@ aws-sdk-elasticloadbalancingv2.workspace = true
 # Crypto
 k256.workspace = true
 
+# Proving
+base-proof-tee-nitro-attestation-prover.workspace = true
+
 # RPC
 jsonrpsee = { workspace = true, features = ["http-client", "server"] }
 base-proof-primitives = { workspace = true, features = ["rpc-client"] }

--- a/crates/proof/tee/registrar/src/error.rs
+++ b/crates/proof/tee/registrar/src/error.rs
@@ -1,3 +1,4 @@
+use base_proof_tee_nitro_attestation_prover::ProverError;
 use thiserror::Error;
 
 /// Errors that can occur in the prover registrar.
@@ -46,6 +47,12 @@ pub enum RegistrarError {
     /// Configuration is invalid.
     #[error("config error: {0}")]
     Config(String),
+}
+
+impl From<ProverError> for RegistrarError {
+    fn from(e: ProverError) -> Self {
+        Self::ProofGeneration(Box::new(e))
+    }
 }
 
 /// Convenience result alias for registrar operations.

--- a/crates/proof/tee/registrar/src/lib.rs
+++ b/crates/proof/tee/registrar/src/lib.rs
@@ -22,9 +22,4 @@ mod traits;
 pub use traits::InstanceDiscovery;
 
 mod types;
-// Re-exported from `base-proof-tee-nitro-attestation-prover`. Previously
-// defined in this crate; the prover crate is now the single source of truth.
-pub use base_proof_tee_nitro_attestation_prover::{
-    AttestationProof, AttestationProofProvider, BoundlessProver, DirectProver, ProverError,
-};
 pub use types::{AttestationResponse, InstanceHealthStatus, ProverInstance, RegisteredSigner};

--- a/crates/proof/tee/registrar/src/lib.rs
+++ b/crates/proof/tee/registrar/src/lib.rs
@@ -19,9 +19,12 @@ mod registry;
 pub use registry::{RegistryClient, RegistryContractClient};
 
 mod traits;
-pub use traits::{AttestationProofProvider, InstanceDiscovery};
+pub use traits::InstanceDiscovery;
 
 mod types;
-pub use types::{
-    AttestationProof, AttestationResponse, InstanceHealthStatus, ProverInstance, RegisteredSigner,
+// Re-exported from `base-proof-tee-nitro-attestation-prover`. Previously
+// defined in this crate; the prover crate is now the single source of truth.
+pub use base_proof_tee_nitro_attestation_prover::{
+    AttestationProof, AttestationProofProvider, BoundlessProver, DirectProver, ProverError,
 };
+pub use types::{AttestationResponse, InstanceHealthStatus, ProverInstance, RegisteredSigner};

--- a/crates/proof/tee/registrar/src/traits.rs
+++ b/crates/proof/tee/registrar/src/traits.rs
@@ -1,6 +1,8 @@
+//! Abstraction traits for the registration driver.
+
 use async_trait::async_trait;
 
-use crate::{AttestationProof, ProverInstance, Result};
+use crate::{ProverInstance, Result};
 
 /// Discovers active prover instances from the infrastructure layer.
 ///
@@ -11,19 +13,4 @@ use crate::{AttestationProof, ProverInstance, Result};
 pub trait InstanceDiscovery: Send + Sync {
     /// Return the current set of prover instances with their health status.
     async fn discover_instances(&self) -> Result<Vec<ProverInstance>>;
-}
-
-/// Generates ZK proofs for Nitro TEE attestation documents.
-///
-/// The primary implementation is `BoundlessNitroProofProvider`, which submits
-/// raw Nitro attestation bytes to the Boundless Network (RISC Zero / Automata
-/// SDK) and returns an on-chain-ready [`AttestationProof`].
-#[async_trait]
-pub trait AttestationProofProvider: Send + Sync {
-    /// Generate a ZK proof for the given raw Nitro attestation document.
-    ///
-    /// `attestation_bytes` is the `COSE_Sign1`-encoded document returned by
-    /// `enclave_signerAttestation`. The returned [`AttestationProof`] contains
-    /// the ABI-encoded journal and proof bytes ready for `registerSigner`.
-    async fn generate_proof(&self, attestation_bytes: &[u8]) -> Result<AttestationProof>;
 }

--- a/crates/proof/tee/registrar/src/types.rs
+++ b/crates/proof/tee/registrar/src/types.rs
@@ -83,15 +83,6 @@ pub struct AttestationResponse {
     pub signer_address: Address,
 }
 
-/// ZK proof ready for on-chain registration via `TEEProverRegistry.registerSigner`.
-#[derive(Debug, Clone)]
-pub struct AttestationProof {
-    /// ABI-encoded `VerifierJournal` output from the Boundless / Automata SDK.
-    pub output: Bytes,
-    /// ZK proof bytes for submission alongside `output`.
-    pub proof_bytes: Bytes,
-}
-
 /// A signer currently registered on-chain via `TEEProverRegistry`.
 #[derive(Debug, Clone)]
 pub struct RegisteredSigner {


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                                        

- Consolidates `AttestationProofProvider` trait and `AttestationProof` type ownership into `base-proof-tee-nitro-attestation-prover` (created in CHAIN-3560)
- Registrar re-exports both from the prover crate for backwards compatibility, along with `BoundlessProver`, `DirectProver`, and `ProverError`
- Adds `From<ProverError> for RegistrarError` conversion so future driver code can use `?` when calling `generate_proof()`
- All 29 existing registrar tests pass unchanged

## Test plan

- [x] `cargo fmt --check` passes
- [x] `cargo clippy --tests -- -D warnings` passes
- [x] `cargo test --lib` — 29 tests pass (all pre-existing, unchanged)
- [x] `cargo check` succeeds