### PR TITLE
fix(ci): Fast Devnet Tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -279,10 +279,6 @@ jobs:
           rust-cache-shared-key: "stable"
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
-      - name: Cache docker images
-        uses: ScribeMD/docker-cache@fb28c93772363301b8d0a6072ce850224b73f74e # 0.5.0
-        with:
-          key: docker-${{ runner.os }}-${{ hashFiles('devnet/src/images.rs', 'etc/docker/Dockerfile.devnet') }}
       - name: Pre-pull docker images
         run: just devnet pull-images
       - name: Run devnet tests

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -86,6 +86,47 @@ jobs:
           if-no-files-found: error
           retention-days: 1
 
+  warm-devnet-cache:
+    strategy:
+      matrix:
+        target: [builder, consensus, batcher]
+
+    runs-on: ubuntu-24.04
+
+    permissions:
+      contents: read
+      packages: write
+
+    env:
+      PROFILE: dev
+
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@002fdce3c6a235733a90a27c80493a3241e56863 # v2.12.1
+        with:
+          egress-policy: audit
+
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          fetch-depth: 1
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
+
+      - name: Login to GHCR
+        uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3.6.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Warm devnet image cache
+        run: |
+          docker buildx bake -f etc/docker/docker-bake.hcl ${{ matrix.target }} \
+            --set ${{ matrix.target }}.platform=linux/amd64 \
+            --set ${{ matrix.target }}.output=type=cacheonly \
+            --set ${{ matrix.target }}.cache-to=type=registry,ref=${{ env.REGISTRY_IMAGE }}:cache-${{ matrix.target }}-linux-amd64,mode=max
+
   merge:
     runs-on: ubuntu-latest
     permissions:

--- a/etc/docker/Justfile
+++ b/etc/docker/Justfile
@@ -72,7 +72,7 @@ build-image target='client' profile='release':
     ./etc/docker/build-rust-images.sh {{ target }} {{ profile }}
 
 # Prepares Docker images needed for devnet tests
-pull-images: (_build-rust-images "devnet" "dev")
+pull-images:
     docker build -t devnet-setup:local -f etc/docker/Dockerfile.devnet .
     docker pull ghcr.io/paradigmxyz/reth:v1.11.3
     docker pull sigp/lighthouse:v8.0.1

--- a/etc/docker/docker-bake.hcl
+++ b/etc/docker/docker-bake.hcl
@@ -59,12 +59,20 @@ target "builder" {
   inherits = ["_rust-service-common"]
   target = "builder"
   tags = ["base-builder:local"]
+  cache-from = [
+    "type=registry,ref=${REGISTRY_IMAGE}:cache-${PLATFORM_PAIR}",
+    "type=registry,ref=${REGISTRY_IMAGE}:cache-builder-${PLATFORM_PAIR}",
+  ]
 }
 
 target "consensus" {
   inherits = ["_rust-service-common"]
   target = "consensus"
   tags = ["base-consensus:local"]
+  cache-from = [
+    "type=registry,ref=${REGISTRY_IMAGE}:cache-${PLATFORM_PAIR}",
+    "type=registry,ref=${REGISTRY_IMAGE}:cache-consensus-${PLATFORM_PAIR}",
+  ]
 }
 
 target "proposer" {
@@ -95,4 +103,8 @@ target "batcher" {
   inherits = ["_rust-service-common"]
   target = "batcher"
   tags = ["base-batcher:local"]
+  cache-from = [
+    "type=registry,ref=${REGISTRY_IMAGE}:cache-${PLATFORM_PAIR}",
+    "type=registry,ref=${REGISTRY_IMAGE}:cache-batcher-${PLATFORM_PAIR}",
+  ]
 }


### PR DESCRIPTION
## Summary

The devnet CI job was rebuilding builder, consensus, and batcher from scratch on every run because only the client image had a registry cache entry, and all Rust service builds used PROFILE=release while devnet tests require PROFILE=dev, causing guaranteed cache misses.

This adds a warm-devnet-cache job to docker.yml that builds each of the three Rust service targets in parallel with PROFILE=dev and writes their layers to dedicated per-target registry cache tags. docker-bake.hcl is updated so builder, consensus, and batcher each read from both the shared base cache and their own cache tag. The broken ScribeMD local docker-cache step is removed from ci.yml, and pull-images in the Justfile no longer rebuilds the Rust services since they are now served from the registry cache.