### PR TITLE
feat(CHAIN-3455): Registration driver with Boundless / Direct proving and full binary wiring

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4684,12 +4684,14 @@ dependencies = [
  "aws-sdk-elasticloadbalancingv2",
  "base-proof-primitives",
  "base-proof-tee-nitro-attestation-prover",
+ "base-tx-manager",
  "hex-literal 1.1.0",
  "jsonrpsee",
  "k256",
  "rstest",
  "thiserror 2.0.18",
  "tokio",
+ "tokio-util",
  "tracing",
  "url",
 ]
@@ -4699,11 +4701,21 @@ name = "base-proof-tee-registrar-bin"
 version = "0.0.0"
 dependencies = [
  "alloy-primitives",
+ "alloy-provider",
  "alloy-signer-local",
+ "aws-config",
+ "aws-sdk-ec2",
+ "aws-sdk-elasticloadbalancingv2",
+ "base-proof-tee-nitro-attestation-prover",
  "base-proof-tee-registrar",
+ "base-tx-manager",
  "clap",
  "eyre",
+ "hex",
+ "rstest",
  "tokio",
+ "tokio-util",
+ "tracing",
  "url",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4706,6 +4706,7 @@ dependencies = [
  "aws-config",
  "aws-sdk-ec2",
  "aws-sdk-elasticloadbalancingv2",
+ "base-cli-utils",
  "base-proof-tee-nitro-attestation-prover",
  "base-proof-tee-registrar",
  "base-tx-manager",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4712,6 +4712,7 @@ dependencies = [
  "clap",
  "eyre",
  "hex",
+ "humantime",
  "rstest",
  "tokio",
  "tokio-util",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4716,6 +4716,7 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
+ "tracing-subscriber 0.3.23",
  "url",
 ]
 

--- a/bin/prover-registrar/Cargo.toml
+++ b/bin/prover-registrar/Cargo.toml
@@ -36,6 +36,7 @@ hex.workspace = true
 url.workspace = true
 eyre.workspace = true
 tracing.workspace = true
+tracing-subscriber.workspace = true
 tokio-util.workspace = true
 tokio = { workspace = true, features = ["full"] }
 clap = { workspace = true, features = ["derive", "env"] }

--- a/bin/prover-registrar/Cargo.toml
+++ b/bin/prover-registrar/Cargo.toml
@@ -20,7 +20,7 @@ workspace = true
 base-cli-utils.workspace = true
 base-tx-manager.workspace = true
 base-proof-tee-registrar.workspace = true
-base-proof-tee-nitro-attestation-prover.workspace = true
+base-proof-tee-nitro-attestation-prover = { workspace = true, features = ["prove"] }
 
 # Alloy
 alloy-provider.workspace = true

--- a/bin/prover-registrar/Cargo.toml
+++ b/bin/prover-registrar/Cargo.toml
@@ -16,10 +16,29 @@ path = "src/main.rs"
 workspace = true
 
 [dependencies]
-url.workspace = true
-eyre.workspace = true
+# Internal
+base-tx-manager.workspace = true
+base-proof-tee-registrar.workspace = true
+base-proof-tee-nitro-attestation-prover.workspace = true
+
+# Alloy
 alloy-primitives.workspace = true
 alloy-signer-local.workspace = true
-base-proof-tee-registrar.workspace = true
+alloy-provider.workspace = true
+
+# AWS
+aws-config = { workspace = true, features = ["default-https-client", "rt-tokio"] }
+aws-sdk-ec2.workspace = true
+aws-sdk-elasticloadbalancingv2.workspace = true
+
+# CLI / runtime
+hex.workspace = true
+url.workspace = true
+eyre.workspace = true
+tracing.workspace = true
+tokio-util.workspace = true
 tokio = { workspace = true, features = ["full"] }
 clap = { workspace = true, features = ["derive", "env"] }
+
+[dev-dependencies]
+rstest.workspace = true

--- a/bin/prover-registrar/Cargo.toml
+++ b/bin/prover-registrar/Cargo.toml
@@ -17,28 +17,29 @@ workspace = true
 
 [dependencies]
 # Internal
+base-cli-utils.workspace = true
 base-tx-manager.workspace = true
 base-proof-tee-registrar.workspace = true
 base-proof-tee-nitro-attestation-prover.workspace = true
 
 # Alloy
+alloy-provider.workspace = true
 alloy-primitives.workspace = true
 alloy-signer-local.workspace = true
-alloy-provider.workspace = true
 
 # AWS
-aws-config = { workspace = true, features = ["default-https-client", "rt-tokio"] }
 aws-sdk-ec2.workspace = true
 aws-sdk-elasticloadbalancingv2.workspace = true
+aws-config = { workspace = true, features = ["default-https-client", "rt-tokio"] }
 
 # CLI / runtime
 hex.workspace = true
 url.workspace = true
 eyre.workspace = true
-humantime.workspace = true
 tracing.workspace = true
-tracing-subscriber.workspace = true
+humantime.workspace = true
 tokio-util.workspace = true
+tracing-subscriber.workspace = true
 tokio = { workspace = true, features = ["full"] }
 clap = { workspace = true, features = ["derive", "env"] }
 

--- a/bin/prover-registrar/Cargo.toml
+++ b/bin/prover-registrar/Cargo.toml
@@ -35,6 +35,7 @@ aws-sdk-elasticloadbalancingv2.workspace = true
 hex.workspace = true
 url.workspace = true
 eyre.workspace = true
+humantime.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true
 tokio-util.workspace = true

--- a/bin/prover-registrar/src/cli.rs
+++ b/bin/prover-registrar/src/cli.rs
@@ -139,10 +139,6 @@ struct BoundlessArgs {
     )]
     boundless_verifier_program_url: Option<Url>,
 
-    /// Minimum price in wei per cycle for Boundless proof requests.
-    #[arg(long, env = "REGISTRAR_BOUNDLESS_MIN_PRICE", default_value_t = 100_000)]
-    boundless_min_price: u64,
-
     /// Maximum price in wei per cycle for Boundless proof requests.
     #[arg(long, env = "REGISTRAR_BOUNDLESS_MAX_PRICE", default_value_t = 1_000_000)]
     boundless_max_price: u64,
@@ -216,25 +212,26 @@ impl Cli {
         // Build proving config based on mode.
         let proving = match self.proving_mode {
             ProvingMode::Boundless => {
-                if self.boundless.boundless_min_price > self.boundless.boundless_max_price {
-                    return Err(RegistrarError::Config(
-                        "--boundless-min-price must not exceed --boundless-max-price".into(),
-                    ));
-                }
                 if self.boundless.boundless_timeout_secs == 0 {
                     return Err(RegistrarError::Config(
                         "--boundless-timeout-secs must be greater than 0".into(),
                     ));
                 }
 
+                let boundless_key =
+                    self.boundless.boundless_private_key.as_deref().ok_or_else(|| {
+                        RegistrarError::Config("--boundless-private-key is required".into())
+                    })?;
+                let image_id_hex = self
+                    .image_id
+                    .as_deref()
+                    .ok_or_else(|| RegistrarError::Config("--image-id is required".into()))?;
+
                 ProvingConfig::Boundless(Box::new(BoundlessConfig {
                     rpc_url: self.boundless.boundless_rpc_url.ok_or_else(|| {
                         RegistrarError::Config("--boundless-rpc-url is required".into())
                     })?,
-                    signer: parse_private_key(
-                        "--boundless-private-key",
-                        self.boundless.boundless_private_key.as_deref().unwrap_or(""),
-                    )?,
+                    signer: parse_private_key("--boundless-private-key", boundless_key)?,
                     verifier_program_url: self
                         .boundless
                         .boundless_verifier_program_url
@@ -243,8 +240,7 @@ impl Cli {
                                 "--boundless-verifier-program-url is required".into(),
                             )
                         })?,
-                    image_id: parse_image_id(self.image_id.as_deref().unwrap_or(""))?,
-                    min_price: self.boundless.boundless_min_price,
+                    image_id: parse_image_id(image_id_hex)?,
                     max_price: self.boundless.boundless_max_price,
                     poll_interval: Duration::from_secs(self.boundless.boundless_poll_interval_secs),
                     timeout: Duration::from_secs(self.boundless.boundless_timeout_secs),
@@ -331,9 +327,17 @@ impl Cli {
             config.l1_rpc_url.clone(),
         );
 
-        // Build proof provider based on proving mode.
+        // Cancel the driver's token on ctrl-c so the inner loop observes
+        // shutdown and in-flight operations can complete gracefully.
         let cancel = CancellationToken::new();
+        let cancel_on_signal = cancel.clone();
+        tokio::spawn(async move {
+            let _ = tokio::signal::ctrl_c().await;
+            info!("received ctrl-c, shutting down");
+            cancel_on_signal.cancel();
+        });
 
+        // Build proof provider and run the driver.
         match config.proving {
             ProvingConfig::Boundless(ref boundless) => {
                 let proof_provider = BoundlessProver {
@@ -347,7 +351,7 @@ impl Cli {
                     trusted_certs_prefix_len: DEFAULT_TRUSTED_CERTS_PREFIX,
                 };
 
-                let driver = RegistrationDriver::new(
+                RegistrationDriver::new(
                     discovery,
                     proof_provider,
                     registry,
@@ -355,16 +359,10 @@ impl Cli {
                     config.tee_prover_registry_address,
                     config.poll_interval,
                     config.prover_timeout,
-                    cancel.clone(),
-                );
-
-                tokio::select! {
-                    result = driver.run() => result?,
-                    _ = tokio::signal::ctrl_c() => {
-                        info!("received ctrl-c, shutting down");
-                        cancel.cancel();
-                    }
-                }
+                    cancel,
+                )
+                .run()
+                .await?;
             }
             ProvingConfig::Direct { ref elf_path } => {
                 let elf = std::fs::read(elf_path).map_err(|e| {
@@ -375,7 +373,7 @@ impl Cli {
                 })?;
                 let proof_provider = DirectProver::new(elf, DEFAULT_TRUSTED_CERTS_PREFIX)?;
 
-                let driver = RegistrationDriver::new(
+                RegistrationDriver::new(
                     discovery,
                     proof_provider,
                     registry,
@@ -383,16 +381,10 @@ impl Cli {
                     config.tee_prover_registry_address,
                     config.poll_interval,
                     config.prover_timeout,
-                    cancel.clone(),
-                );
-
-                tokio::select! {
-                    result = driver.run() => result?,
-                    _ = tokio::signal::ctrl_c() => {
-                        info!("received ctrl-c, shutting down");
-                        cancel.cancel();
-                    }
-                }
+                    cancel,
+                )
+                .run()
+                .await?;
             }
         }
 
@@ -574,14 +566,6 @@ mod tests {
     fn zero_duration_fails_into_config(#[case] flag: &str, #[case] value: &str) {
         let mut args = boundless_args();
         args.extend([flag, value]);
-        let result = Cli::try_parse_from(args).expect("clap should parse these args").into_config();
-        assert!(result.is_err());
-    }
-
-    #[rstest]
-    fn inverted_price_bounds_fail_into_config() {
-        let mut args = boundless_args();
-        args.extend(["--boundless-min-price", "9999", "--boundless-max-price", "1"]);
         let result = Cli::try_parse_from(args).expect("clap should parse these args").into_config();
         assert!(result.is_err());
     }

--- a/bin/prover-registrar/src/cli.rs
+++ b/bin/prover-registrar/src/cli.rs
@@ -2,7 +2,7 @@
 
 use std::{path::PathBuf, sync::Arc, time::Duration};
 
-use alloy_primitives::{Address, B256};
+use alloy_primitives::Address;
 use alloy_provider::RootProvider;
 use alloy_signer_local::PrivateKeySigner;
 use base_proof_tee_nitro_attestation_prover::{
@@ -10,85 +10,72 @@ use base_proof_tee_nitro_attestation_prover::{
 };
 use base_proof_tee_registrar::{
     AwsDiscoveryConfig, AwsTargetGroupDiscovery, BoundlessConfig, ProvingConfig, RegistrarConfig,
-    RegistrarError, RegistrationDriver, RegistryContractClient, RemoteSignerConfig, SigningConfig,
+    RegistrarError, RegistrationDriver, RegistryContractClient,
 };
 use base_tx_manager::{NoopTxMetrics, SignerConfig, SimpleTxManager, TxManagerConfig};
-use clap::{ArgGroup, Args, Parser, ValueEnum};
+use clap::{Args, Parser, ValueEnum};
 use tokio_util::sync::CancellationToken;
 use tracing::info;
 use url::Url;
+
+// Generate `SignerCli` and `TxManagerCli` structs with env-var-backed CLI args.
+base_tx_manager::define_signer_cli!("BASE_REGISTRAR");
+base_tx_manager::define_tx_manager_cli!("BASE_REGISTRAR");
 
 /// Default trusted certificate prefix length (root cert only).
 const DEFAULT_TRUSTED_CERTS_PREFIX: u8 = 1;
 
 /// Prover Registrar — automated TEE signer registration service.
 #[derive(Parser)]
-#[command(
-    name = "prover-registrar",
-    version,
-    about,
-    group(
-        ArgGroup::new("signing_method")
-            .required(true)
-            .args(["private_key", "signer_endpoint"])
-    )
-)]
+#[command(name = "prover-registrar", version, about)]
 pub(crate) struct Cli {
     // ── L1 ────────────────────────────────────────────────────────────────────
     /// L1 Ethereum RPC endpoint.
-    #[arg(long, env = "REGISTRAR_L1_RPC_URL")]
+    #[arg(long, env = "BASE_REGISTRAR_L1_RPC_URL")]
     l1_rpc_url: Url,
 
     /// `TEEProverRegistry` contract address on L1.
-    #[arg(long, env = "REGISTRAR_TEE_PROVER_REGISTRY_ADDRESS")]
+    #[arg(long, env = "BASE_REGISTRAR_TEE_PROVER_REGISTRY_ADDRESS")]
     tee_prover_registry_address: Address,
 
     /// L1 chain ID (used to validate the RPC connection).
-    #[arg(long, env = "REGISTRAR_L1_CHAIN_ID")]
+    #[arg(long, env = "BASE_REGISTRAR_L1_CHAIN_ID")]
     l1_chain_id: u64,
 
     // ── Discovery ─────────────────────────────────────────────────────────────
     /// AWS ALB target group ARN for prover instance discovery.
-    #[arg(long, env = "REGISTRAR_TARGET_GROUP_ARN")]
+    #[arg(long, env = "BASE_REGISTRAR_TARGET_GROUP_ARN")]
     target_group_arn: String,
 
     /// AWS region (e.g. `us-east-1`).
-    #[arg(long, env = "REGISTRAR_AWS_REGION")]
+    #[arg(long, env = "BASE_REGISTRAR_AWS_REGION")]
     aws_region: String,
 
     /// JSON-RPC port to poll on each prover instance.
-    #[arg(long, env = "REGISTRAR_PROVER_PORT", default_value_t = 8000)]
+    #[arg(long, env = "BASE_REGISTRAR_PROVER_PORT", default_value_t = 8000)]
     prover_port: u16,
 
     // ── Signing ───────────────────────────────────────────────────────────────
-    /// HTTP signer sidecar URL (production). Mutually exclusive with `--private-key`.
-    #[arg(
-        long,
-        env = "REGISTRAR_SIGNER_ENDPOINT",
-        conflicts_with = "private_key",
-        requires = "signer_address"
-    )]
-    signer_endpoint: Option<Url>,
+    /// Signer configuration (local private key or remote sidecar).
+    #[command(flatten)]
+    signer: SignerCli,
 
-    /// Manager address for signing txs (required with `--signer-endpoint`).
-    #[arg(long, env = "REGISTRAR_SIGNER_ADDRESS", requires = "signer_endpoint")]
-    signer_address: Option<Address>,
-
-    /// Hex-encoded private key. **Local development only** — use signer sidecar in production.
-    #[arg(long, env = "REGISTRAR_PRIVATE_KEY", conflicts_with = "signer_endpoint")]
-    private_key: Option<String>,
+    // ── Transaction Manager ───────────────────────────────────────────────────
+    /// Transaction manager configuration (fee limits, confirmations, timeouts).
+    #[command(flatten)]
+    tx_manager: TxManagerCli,
 
     // ── Proving ───────────────────────────────────────────────────────────────
     /// ZK proving backend.
-    #[arg(long, env = "REGISTRAR_PROVING_MODE")]
+    #[arg(long, env = "BASE_REGISTRAR_PROVING_MODE")]
     proving_mode: ProvingMode,
 
     /// Hex-encoded guest program image ID (required for Boundless mode).
-    #[arg(long, env = "REGISTRAR_IMAGE_ID", required_if_eq("proving_mode", "boundless"))]
+    #[arg(long, env = "BASE_REGISTRAR_IMAGE_ID", required_if_eq("proving_mode", "boundless"))]
     image_id: Option<String>,
 
     /// Path to the guest ELF binary on disk (required for Direct mode).
-    #[arg(long, env = "REGISTRAR_ELF_PATH", required_if_eq("proving_mode", "direct"))]
+    #[arg(long, env = "BASE_REGISTRAR_ELF_PATH", required_if_eq("proving_mode", "direct"))]
     elf_path: Option<PathBuf>,
 
     // ── Boundless ─────────────────────────────────────────────────────────────
@@ -97,15 +84,15 @@ pub(crate) struct Cli {
 
     // ── Polling / Server ──────────────────────────────────────────────────────
     /// Interval between discovery and registration poll cycles, in seconds.
-    #[arg(long, env = "REGISTRAR_POLL_INTERVAL_SECS", default_value_t = 30)]
+    #[arg(long, env = "BASE_REGISTRAR_POLL_INTERVAL_SECS", default_value_t = 30)]
     poll_interval_secs: u64,
 
     /// Timeout for JSON-RPC calls to prover instances, in seconds.
-    #[arg(long, env = "REGISTRAR_PROVER_TIMEOUT_SECS", default_value_t = 30)]
+    #[arg(long, env = "BASE_REGISTRAR_PROVER_TIMEOUT_SECS", default_value_t = 30)]
     prover_timeout_secs: u64,
 
     /// Port for the health check and Prometheus metrics HTTP server.
-    #[arg(long, env = "REGISTRAR_HEALTH_PORT", default_value_t = 7300)]
+    #[arg(long, env = "BASE_REGISTRAR_HEALTH_PORT", default_value_t = 7300)]
     health_port: u16,
 }
 
@@ -122,13 +109,17 @@ pub(crate) enum ProvingMode {
 #[derive(Args)]
 struct BoundlessArgs {
     /// Boundless Network RPC URL.
-    #[arg(long, env = "REGISTRAR_BOUNDLESS_RPC_URL", required_if_eq("proving_mode", "boundless"))]
+    #[arg(
+        long,
+        env = "BASE_REGISTRAR_BOUNDLESS_RPC_URL",
+        required_if_eq("proving_mode", "boundless")
+    )]
     boundless_rpc_url: Option<Url>,
 
     /// Hex-encoded private key for Boundless Network proving fees.
     #[arg(
         long,
-        env = "REGISTRAR_BOUNDLESS_PRIVATE_KEY",
+        env = "BASE_REGISTRAR_BOUNDLESS_PRIVATE_KEY",
         required_if_eq("proving_mode", "boundless")
     )]
     boundless_private_key: Option<String>,
@@ -136,25 +127,25 @@ struct BoundlessArgs {
     /// IPFS URL of the Nitro attestation verifier ELF uploaded via `nitro-attest-cli`.
     #[arg(
         long,
-        env = "REGISTRAR_BOUNDLESS_VERIFIER_PROGRAM_URL",
+        env = "BASE_REGISTRAR_BOUNDLESS_VERIFIER_PROGRAM_URL",
         required_if_eq("proving_mode", "boundless")
     )]
     boundless_verifier_program_url: Option<Url>,
 
     /// Maximum price in wei per cycle for Boundless proof requests.
-    #[arg(long, env = "REGISTRAR_BOUNDLESS_MAX_PRICE", default_value_t = 1_000_000)]
+    #[arg(long, env = "BASE_REGISTRAR_BOUNDLESS_MAX_PRICE", default_value_t = 1_000_000)]
     boundless_max_price: u64,
 
     /// Interval between Boundless fulfillment status checks, in seconds.
-    #[arg(long, env = "REGISTRAR_BOUNDLESS_POLL_INTERVAL_SECS", default_value_t = 5)]
+    #[arg(long, env = "BASE_REGISTRAR_BOUNDLESS_POLL_INTERVAL_SECS", default_value_t = 5)]
     boundless_poll_interval_secs: u64,
 
     /// Proof generation timeout in seconds.
-    #[arg(long, env = "REGISTRAR_BOUNDLESS_TIMEOUT_SECS", default_value_t = 600)]
+    #[arg(long, env = "BASE_REGISTRAR_BOUNDLESS_TIMEOUT_SECS", default_value_t = 600)]
     boundless_timeout_secs: u64,
 
     /// `NitroEnclaveVerifier` contract address for certificate caching (optional).
-    #[arg(long, env = "REGISTRAR_NITRO_VERIFIER_ADDRESS")]
+    #[arg(long, env = "BASE_REGISTRAR_NITRO_VERIFIER_ADDRESS")]
     nitro_verifier_address: Option<Address>,
 }
 
@@ -189,27 +180,17 @@ fn parse_image_id(s: &str) -> std::result::Result<[u32; 8], RegistrarError> {
 impl Cli {
     /// Validate the CLI arguments for logical conflicts and parse into a [`RegistrarConfig`].
     pub(crate) fn into_config(self) -> std::result::Result<RegistrarConfig, RegistrarError> {
-        // Validate signing config and resolve to SigningConfig.
-        let signing = match (&self.private_key, &self.signer_endpoint, &self.signer_address) {
-            (Some(pk), None, None) => SigningConfig::Local(parse_private_key("--private-key", pk)?),
-            (None, Some(endpoint), Some(address)) => SigningConfig::Remote(RemoteSignerConfig {
-                endpoint: endpoint.clone(),
-                address: *address,
-            }),
-            _ => {
-                return Err(RegistrarError::Config(
-                    "provide either --private-key or both --signer-endpoint and \
-                     --signer-address"
-                        .into(),
-                ));
-            }
-        };
-
         let discovery = AwsDiscoveryConfig {
             target_group_arn: self.target_group_arn,
             aws_region: self.aws_region,
             port: self.prover_port,
         };
+
+        // Convert signing and tx manager config via the macro-generated TryFrom impls.
+        let signing = SignerConfig::try_from(self.signer)
+            .map_err(|e| RegistrarError::Config(format!("signer: {e}")))?;
+        let tx_manager = TxManagerConfig::try_from(self.tx_manager)
+            .map_err(|e| RegistrarError::Config(format!("tx-manager: {e}")))?;
 
         // Build proving config based on mode.
         let proving = match self.proving_mode {
@@ -275,6 +256,7 @@ impl Cli {
             l1_chain_id: self.l1_chain_id,
             discovery,
             signing,
+            tx_manager,
             proving,
             poll_interval: Duration::from_secs(self.poll_interval_secs),
             prover_timeout: Duration::from_secs(self.prover_timeout_secs),
@@ -291,18 +273,10 @@ impl Cli {
         // Build L1 provider.
         let provider = RootProvider::new_http(config.l1_rpc_url.clone());
 
-        // Build signing config for SimpleTxManager.
-        let signer_config = match &config.signing {
-            SigningConfig::Local(pk) => SignerConfig::local(B256::new(pk.to_bytes().0)),
-            SigningConfig::Remote(cfg) => {
-                SignerConfig::Remote { endpoint: cfg.endpoint.clone(), address: cfg.address }
-            }
-        };
-
         let tx_manager = SimpleTxManager::new(
             provider,
-            signer_config,
-            TxManagerConfig::default(),
+            config.signing,
+            config.tx_manager,
             config.l1_chain_id,
             Arc::new(NoopTxMetrics),
         )
@@ -519,22 +493,26 @@ mod tests {
     #[rstest]
     fn local_key_returns_local_signing() {
         let config = Cli::parse_from(boundless_args()).into_config().unwrap();
-        assert!(matches!(config.signing, SigningConfig::Local(_)));
+        assert!(matches!(config.signing, SignerConfig::Local { .. }));
     }
 
     #[rstest]
     fn remote_signer_returns_remote_signing() {
         let config = Cli::parse_from(remote_signer_args()).into_config().unwrap();
-        assert!(matches!(config.signing, SigningConfig::Remote(_)));
+        assert!(matches!(config.signing, SignerConfig::Remote { .. }));
     }
 
     // ── Clap-level validation failures ──────────────────────────────────
 
     #[rstest]
-    fn no_signing_method_fails_clap_parse() {
+    fn no_signing_method_succeeds_clap_parse_but_fails_config() {
         let mut args = direct_args();
         args.retain(|a| *a != "--private-key" && *a != TEST_PRIVATE_KEY);
-        assert!(Cli::try_parse_from(args).is_err());
+        // The signer macro doesn't require signing args at clap level;
+        // the TryFrom conversion catches it.
+        if let Ok(cli) = Cli::try_parse_from(args) {
+            assert!(cli.into_config().is_err());
+        }
     }
 
     #[rstest]
@@ -582,6 +560,13 @@ mod tests {
             panic!("expected Boundless proving config");
         };
         assert_eq!(b.image_id, [1, 2, 3, 4, 5, 6, 7, 8]);
+    }
+
+    #[rstest]
+    fn tx_manager_config_has_defaults() {
+        let config = Cli::parse_from(boundless_args()).into_config().unwrap();
+        assert_eq!(config.tx_manager.num_confirmations, 10);
+        assert_eq!(config.tx_manager.fee_limit_multiplier, 5);
     }
 
     // ── parse_image_id unit tests ───────────────────────────────────────

--- a/bin/prover-registrar/src/cli.rs
+++ b/bin/prover-registrar/src/cli.rs
@@ -9,8 +9,8 @@ use base_proof_tee_nitro_attestation_prover::{
     AttestationProofProvider, BoundlessProver, DirectProver,
 };
 use base_proof_tee_registrar::{
-    AwsDiscoveryConfig, AwsTargetGroupDiscovery, BoundlessConfig, ProvingConfig, RegistrarConfig,
-    RegistrarError, RegistrationDriver, RegistryContractClient,
+    AwsDiscoveryConfig, AwsTargetGroupDiscovery, BoundlessConfig, DriverConfig, ProvingConfig,
+    RegistrarConfig, RegistrarError, RegistrationDriver, RegistryContractClient,
 };
 use base_tx_manager::{NoopTxMetrics, SignerConfig, SimpleTxManager, TxManagerConfig};
 use clap::{Args, Parser, ValueEnum};
@@ -337,18 +337,16 @@ impl Cli {
             }
         };
 
-        RegistrationDriver::new(
-            discovery,
-            proof_provider,
-            registry,
-            tx_manager,
-            config.tee_prover_registry_address,
-            config.poll_interval,
-            config.prover_timeout,
+        let driver_config = DriverConfig {
+            registry_address: config.tee_prover_registry_address,
+            poll_interval: config.poll_interval,
+            prover_timeout: config.prover_timeout,
             cancel,
-        )
-        .run()
-        .await?;
+        };
+
+        RegistrationDriver::new(discovery, proof_provider, registry, tx_manager, driver_config)
+            .run()
+            .await?;
 
         Ok(())
     }

--- a/bin/prover-registrar/src/cli.rs
+++ b/bin/prover-registrar/src/cli.rs
@@ -5,7 +5,9 @@ use std::{path::PathBuf, sync::Arc, time::Duration};
 use alloy_primitives::{Address, B256};
 use alloy_provider::RootProvider;
 use alloy_signer_local::PrivateKeySigner;
-use base_proof_tee_nitro_attestation_prover::{BoundlessProver, DirectProver};
+use base_proof_tee_nitro_attestation_prover::{
+    AttestationProofProvider, BoundlessProver, DirectProver,
+};
 use base_proof_tee_registrar::{
     AwsDiscoveryConfig, AwsTargetGroupDiscovery, BoundlessConfig, ProvingConfig, RegistrarConfig,
     RegistrarError, RegistrationDriver, RegistryContractClient, RemoteSignerConfig, SigningConfig,
@@ -337,33 +339,19 @@ impl Cli {
             cancel_on_signal.cancel();
         });
 
-        // Build proof provider and run the driver.
-        match config.proving {
-            ProvingConfig::Boundless(ref boundless) => {
-                let proof_provider = BoundlessProver {
-                    rpc_url: boundless.rpc_url.clone(),
-                    signer: boundless.signer.clone(),
-                    verifier_program_url: boundless.verifier_program_url.clone(),
-                    image_id: boundless.image_id,
-                    max_price: boundless.max_price,
-                    poll_interval: boundless.poll_interval,
-                    timeout: boundless.timeout,
-                    trusted_certs_prefix_len: DEFAULT_TRUSTED_CERTS_PREFIX,
-                };
-
-                RegistrationDriver::new(
-                    discovery,
-                    proof_provider,
-                    registry,
-                    tx_manager,
-                    config.tee_prover_registry_address,
-                    config.poll_interval,
-                    config.prover_timeout,
-                    cancel,
-                )
-                .run()
-                .await?;
-            }
+        // Build proof provider based on proving mode (type-erased so the
+        // driver construction is not duplicated per variant).
+        let proof_provider: Box<dyn AttestationProofProvider> = match config.proving {
+            ProvingConfig::Boundless(ref boundless) => Box::new(BoundlessProver {
+                rpc_url: boundless.rpc_url.clone(),
+                signer: boundless.signer.clone(),
+                verifier_program_url: boundless.verifier_program_url.clone(),
+                image_id: boundless.image_id,
+                max_price: boundless.max_price,
+                poll_interval: boundless.poll_interval,
+                timeout: boundless.timeout,
+                trusted_certs_prefix_len: DEFAULT_TRUSTED_CERTS_PREFIX,
+            }),
             ProvingConfig::Direct { ref elf_path } => {
                 let elf = std::fs::read(elf_path).map_err(|e| {
                     RegistrarError::Config(format!(
@@ -371,22 +359,22 @@ impl Cli {
                         elf_path.display()
                     ))
                 })?;
-                let proof_provider = DirectProver::new(elf, DEFAULT_TRUSTED_CERTS_PREFIX)?;
-
-                RegistrationDriver::new(
-                    discovery,
-                    proof_provider,
-                    registry,
-                    tx_manager,
-                    config.tee_prover_registry_address,
-                    config.poll_interval,
-                    config.prover_timeout,
-                    cancel,
-                )
-                .run()
-                .await?;
+                Box::new(DirectProver::new(elf, DEFAULT_TRUSTED_CERTS_PREFIX)?)
             }
-        }
+        };
+
+        RegistrationDriver::new(
+            discovery,
+            proof_provider,
+            registry,
+            tx_manager,
+            config.tee_prover_registry_address,
+            config.poll_interval,
+            config.prover_timeout,
+            cancel,
+        )
+        .run()
+        .await?;
 
         Ok(())
     }

--- a/bin/prover-registrar/src/cli.rs
+++ b/bin/prover-registrar/src/cli.rs
@@ -18,7 +18,8 @@ use tokio_util::sync::CancellationToken;
 use tracing::info;
 use url::Url;
 
-// Generate `SignerCli` and `TxManagerCli` structs with env-var-backed CLI args.
+// Generate env-var helper and CLI structs with the `BASE_REGISTRAR_` prefix.
+base_cli_utils::define_cli_env!("BASE_REGISTRAR");
 base_tx_manager::define_signer_cli!("BASE_REGISTRAR");
 base_tx_manager::define_tx_manager_cli!("BASE_REGISTRAR");
 
@@ -31,28 +32,28 @@ const DEFAULT_TRUSTED_CERTS_PREFIX: u8 = 1;
 pub(crate) struct Cli {
     // ── L1 ────────────────────────────────────────────────────────────────────
     /// L1 Ethereum RPC endpoint.
-    #[arg(long, env = "BASE_REGISTRAR_L1_RPC_URL")]
+    #[arg(long, env = cli_env!("L1_RPC_URL"))]
     l1_rpc_url: Url,
 
     /// `TEEProverRegistry` contract address on L1.
-    #[arg(long, env = "BASE_REGISTRAR_TEE_PROVER_REGISTRY_ADDRESS")]
+    #[arg(long, env = cli_env!("TEE_PROVER_REGISTRY_ADDRESS"))]
     tee_prover_registry_address: Address,
 
     /// L1 chain ID (used to validate the RPC connection).
-    #[arg(long, env = "BASE_REGISTRAR_L1_CHAIN_ID")]
+    #[arg(long, env = cli_env!("L1_CHAIN_ID"))]
     l1_chain_id: u64,
 
     // ── Discovery ─────────────────────────────────────────────────────────────
     /// AWS ALB target group ARN for prover instance discovery.
-    #[arg(long, env = "BASE_REGISTRAR_TARGET_GROUP_ARN")]
+    #[arg(long, env = cli_env!("TARGET_GROUP_ARN"))]
     target_group_arn: String,
 
     /// AWS region (e.g. `us-east-1`).
-    #[arg(long, env = "BASE_REGISTRAR_AWS_REGION")]
+    #[arg(long, env = cli_env!("AWS_REGION"))]
     aws_region: String,
 
     /// JSON-RPC port to poll on each prover instance.
-    #[arg(long, env = "BASE_REGISTRAR_PROVER_PORT", default_value_t = 8000)]
+    #[arg(long, env = cli_env!("PROVER_PORT"), default_value_t = 8000)]
     prover_port: u16,
 
     // ── Signing ───────────────────────────────────────────────────────────────
@@ -67,15 +68,15 @@ pub(crate) struct Cli {
 
     // ── Proving ───────────────────────────────────────────────────────────────
     /// ZK proving backend.
-    #[arg(long, env = "BASE_REGISTRAR_PROVING_MODE")]
+    #[arg(long, env = cli_env!("PROVING_MODE"))]
     proving_mode: ProvingMode,
 
     /// Hex-encoded guest program image ID (required for Boundless mode).
-    #[arg(long, env = "BASE_REGISTRAR_IMAGE_ID", required_if_eq("proving_mode", "boundless"))]
+    #[arg(long, env = cli_env!("IMAGE_ID"), required_if_eq("proving_mode", "boundless"))]
     image_id: Option<String>,
 
     /// Path to the guest ELF binary on disk (required for Direct mode).
-    #[arg(long, env = "BASE_REGISTRAR_ELF_PATH", required_if_eq("proving_mode", "direct"))]
+    #[arg(long, env = cli_env!("ELF_PATH"), required_if_eq("proving_mode", "direct"))]
     elf_path: Option<PathBuf>,
 
     // ── Boundless ─────────────────────────────────────────────────────────────
@@ -84,15 +85,15 @@ pub(crate) struct Cli {
 
     // ── Polling / Server ──────────────────────────────────────────────────────
     /// Interval between discovery and registration poll cycles, in seconds.
-    #[arg(long, env = "BASE_REGISTRAR_POLL_INTERVAL_SECS", default_value_t = 30)]
+    #[arg(long, env = cli_env!("POLL_INTERVAL_SECS"), default_value_t = 30)]
     poll_interval_secs: u64,
 
     /// Timeout for JSON-RPC calls to prover instances, in seconds.
-    #[arg(long, env = "BASE_REGISTRAR_PROVER_TIMEOUT_SECS", default_value_t = 30)]
+    #[arg(long, env = cli_env!("PROVER_TIMEOUT_SECS"), default_value_t = 30)]
     prover_timeout_secs: u64,
 
     /// Port for the health check and Prometheus metrics HTTP server.
-    #[arg(long, env = "BASE_REGISTRAR_HEALTH_PORT", default_value_t = 7300)]
+    #[arg(long, env = cli_env!("HEALTH_PORT"), default_value_t = 7300)]
     health_port: u16,
 }
 
@@ -111,7 +112,7 @@ struct BoundlessArgs {
     /// Boundless Network RPC URL.
     #[arg(
         long,
-        env = "BASE_REGISTRAR_BOUNDLESS_RPC_URL",
+        env = cli_env!("BOUNDLESS_RPC_URL"),
         required_if_eq("proving_mode", "boundless")
     )]
     boundless_rpc_url: Option<Url>,
@@ -119,7 +120,7 @@ struct BoundlessArgs {
     /// Hex-encoded private key for Boundless Network proving fees.
     #[arg(
         long,
-        env = "BASE_REGISTRAR_BOUNDLESS_PRIVATE_KEY",
+        env = cli_env!("BOUNDLESS_PRIVATE_KEY"),
         required_if_eq("proving_mode", "boundless")
     )]
     boundless_private_key: Option<String>,
@@ -127,25 +128,25 @@ struct BoundlessArgs {
     /// IPFS URL of the Nitro attestation verifier ELF uploaded via `nitro-attest-cli`.
     #[arg(
         long,
-        env = "BASE_REGISTRAR_BOUNDLESS_VERIFIER_PROGRAM_URL",
+        env = cli_env!("BOUNDLESS_VERIFIER_PROGRAM_URL"),
         required_if_eq("proving_mode", "boundless")
     )]
     boundless_verifier_program_url: Option<Url>,
 
     /// Maximum price in wei per cycle for Boundless proof requests.
-    #[arg(long, env = "BASE_REGISTRAR_BOUNDLESS_MAX_PRICE", default_value_t = 1_000_000)]
+    #[arg(long, env = cli_env!("BOUNDLESS_MAX_PRICE"), default_value_t = 1_000_000)]
     boundless_max_price: u64,
 
     /// Interval between Boundless fulfillment status checks, in seconds.
-    #[arg(long, env = "BASE_REGISTRAR_BOUNDLESS_POLL_INTERVAL_SECS", default_value_t = 5)]
+    #[arg(long, env = cli_env!("BOUNDLESS_POLL_INTERVAL_SECS"), default_value_t = 5)]
     boundless_poll_interval_secs: u64,
 
     /// Proof generation timeout in seconds.
-    #[arg(long, env = "BASE_REGISTRAR_BOUNDLESS_TIMEOUT_SECS", default_value_t = 600)]
+    #[arg(long, env = cli_env!("BOUNDLESS_TIMEOUT_SECS"), default_value_t = 600)]
     boundless_timeout_secs: u64,
 
     /// `NitroEnclaveVerifier` contract address for certificate caching (optional).
-    #[arg(long, env = "BASE_REGISTRAR_NITRO_VERIFIER_ADDRESS")]
+    #[arg(long, env = cli_env!("NITRO_VERIFIER_ADDRESS"))]
     nitro_verifier_address: Option<Address>,
 }
 

--- a/bin/prover-registrar/src/cli.rs
+++ b/bin/prover-registrar/src/cli.rs
@@ -1,15 +1,23 @@
 //! CLI argument parsing and config construction for the prover registrar.
 
-use std::time::Duration;
+use std::{path::PathBuf, sync::Arc, time::Duration};
 
-use alloy_primitives::Address;
+use alloy_primitives::{Address, B256};
+use alloy_provider::RootProvider;
 use alloy_signer_local::PrivateKeySigner;
+use base_proof_tee_nitro_attestation_prover::{BoundlessProver, DirectProver};
 use base_proof_tee_registrar::{
-    AwsDiscoveryConfig, BoundlessConfig, RegistrarConfig, RegistrarError, RemoteSignerConfig,
-    SigningConfig,
+    AwsDiscoveryConfig, AwsTargetGroupDiscovery, BoundlessConfig, ProvingConfig, RegistrarConfig,
+    RegistrarError, RegistrationDriver, RegistryContractClient, RemoteSignerConfig, SigningConfig,
 };
-use clap::{ArgGroup, Args, Parser};
+use base_tx_manager::{NoopTxMetrics, SignerConfig, SimpleTxManager, TxManagerConfig};
+use clap::{ArgGroup, Args, Parser, ValueEnum};
+use tokio_util::sync::CancellationToken;
+use tracing::info;
 use url::Url;
+
+/// Default trusted certificate prefix length (root cert only).
+const DEFAULT_TRUSTED_CERTS_PREFIX: u8 = 1;
 
 /// Prover Registrar — automated TEE signer registration service.
 #[derive(Parser)]
@@ -32,6 +40,10 @@ pub(crate) struct Cli {
     /// `TEEProverRegistry` contract address on L1.
     #[arg(long, env = "REGISTRAR_TEE_PROVER_REGISTRY_ADDRESS")]
     tee_prover_registry_address: Address,
+
+    /// L1 chain ID (used to validate the RPC connection).
+    #[arg(long, env = "REGISTRAR_L1_CHAIN_ID")]
+    l1_chain_id: u64,
 
     // ── Discovery ─────────────────────────────────────────────────────────────
     /// AWS ALB target group ARN for prover instance discovery.
@@ -64,6 +76,19 @@ pub(crate) struct Cli {
     #[arg(long, env = "REGISTRAR_PRIVATE_KEY", conflicts_with = "signer_endpoint")]
     private_key: Option<String>,
 
+    // ── Proving ───────────────────────────────────────────────────────────────
+    /// ZK proving backend.
+    #[arg(long, env = "REGISTRAR_PROVING_MODE")]
+    proving_mode: ProvingMode,
+
+    /// Hex-encoded guest program image ID (required for Boundless mode).
+    #[arg(long, env = "REGISTRAR_IMAGE_ID", required_if_eq("proving_mode", "boundless"))]
+    image_id: Option<String>,
+
+    /// Path to the guest ELF binary on disk (required for Direct mode).
+    #[arg(long, env = "REGISTRAR_ELF_PATH", required_if_eq("proving_mode", "direct"))]
+    elf_path: Option<PathBuf>,
+
     // ── Boundless ─────────────────────────────────────────────────────────────
     #[command(flatten)]
     boundless: BoundlessArgs,
@@ -73,25 +98,46 @@ pub(crate) struct Cli {
     #[arg(long, env = "REGISTRAR_POLL_INTERVAL_SECS", default_value_t = 30)]
     poll_interval_secs: u64,
 
+    /// Timeout for JSON-RPC calls to prover instances, in seconds.
+    #[arg(long, env = "REGISTRAR_PROVER_TIMEOUT_SECS", default_value_t = 30)]
+    prover_timeout_secs: u64,
+
     /// Port for the health check and Prometheus metrics HTTP server.
     #[arg(long, env = "REGISTRAR_HEALTH_PORT", default_value_t = 7300)]
     health_port: u16,
+}
+
+/// ZK proving backend selector.
+#[derive(Clone, Copy, Debug, ValueEnum)]
+pub(crate) enum ProvingMode {
+    /// Boundless marketplace proving.
+    Boundless,
+    /// Direct proving via risc0 `default_prover()` (Bonsai remote or dev-mode).
+    Direct,
 }
 
 /// Boundless Network CLI arguments.
 #[derive(Args)]
 struct BoundlessArgs {
     /// Boundless Network RPC URL.
-    #[arg(long, env = "REGISTRAR_BOUNDLESS_RPC_URL")]
-    boundless_rpc_url: Url,
+    #[arg(long, env = "REGISTRAR_BOUNDLESS_RPC_URL", required_if_eq("proving_mode", "boundless"))]
+    boundless_rpc_url: Option<Url>,
 
     /// Hex-encoded private key for Boundless Network proving fees.
-    #[arg(long, env = "REGISTRAR_BOUNDLESS_PRIVATE_KEY")]
-    boundless_private_key: String,
+    #[arg(
+        long,
+        env = "REGISTRAR_BOUNDLESS_PRIVATE_KEY",
+        required_if_eq("proving_mode", "boundless")
+    )]
+    boundless_private_key: Option<String>,
 
     /// IPFS URL of the Nitro attestation verifier ELF uploaded via `nitro-attest-cli`.
-    #[arg(long, env = "REGISTRAR_BOUNDLESS_VERIFIER_PROGRAM_URL")]
-    boundless_verifier_program_url: Url,
+    #[arg(
+        long,
+        env = "REGISTRAR_BOUNDLESS_VERIFIER_PROGRAM_URL",
+        required_if_eq("proving_mode", "boundless")
+    )]
+    boundless_verifier_program_url: Option<Url>,
 
     /// Minimum price in wei per cycle for Boundless proof requests.
     #[arg(long, env = "REGISTRAR_BOUNDLESS_MIN_PRICE", default_value_t = 100_000)]
@@ -100,6 +146,10 @@ struct BoundlessArgs {
     /// Maximum price in wei per cycle for Boundless proof requests.
     #[arg(long, env = "REGISTRAR_BOUNDLESS_MAX_PRICE", default_value_t = 1_000_000)]
     boundless_max_price: u64,
+
+    /// Interval between Boundless fulfillment status checks, in seconds.
+    #[arg(long, env = "REGISTRAR_BOUNDLESS_POLL_INTERVAL_SECS", default_value_t = 5)]
+    boundless_poll_interval_secs: u64,
 
     /// Proof generation timeout in seconds.
     #[arg(long, env = "REGISTRAR_BOUNDLESS_TIMEOUT_SECS", default_value_t = 600)]
@@ -111,16 +161,36 @@ struct BoundlessArgs {
 }
 
 /// Parse a hex-encoded secp256k1 private key string into a [`PrivateKeySigner`].
-fn parse_private_key(field: &str, s: &str) -> Result<PrivateKeySigner, RegistrarError> {
+fn parse_private_key(
+    field: &str,
+    s: &str,
+) -> std::result::Result<PrivateKeySigner, RegistrarError> {
     s.strip_prefix("0x")
         .unwrap_or(s)
         .parse::<PrivateKeySigner>()
         .map_err(|e| RegistrarError::Config(format!("{field}: {e}")))
 }
 
+/// Parse a hex-encoded image ID string into `[u32; 8]`.
+fn parse_image_id(s: &str) -> std::result::Result<[u32; 8], RegistrarError> {
+    let hex = s.strip_prefix("0x").unwrap_or(s);
+    let bytes: [u8; 32] = hex::decode(hex)
+        .map_err(|e| RegistrarError::Config(format!("--image-id: {e}")))?
+        .try_into()
+        .map_err(|v: Vec<u8>| {
+            RegistrarError::Config(format!("--image-id: expected 32 bytes, got {}", v.len()))
+        })?;
+
+    let mut id = [0u32; 8];
+    for (i, chunk) in bytes.chunks_exact(4).enumerate() {
+        id[i] = u32::from_be_bytes(chunk.try_into().unwrap());
+    }
+    Ok(id)
+}
+
 impl Cli {
     /// Validate the CLI arguments for logical conflicts and parse into a [`RegistrarConfig`].
-    pub(crate) fn into_config(self) -> Result<RegistrarConfig, RegistrarError> {
+    pub(crate) fn into_config(self) -> std::result::Result<RegistrarConfig, RegistrarError> {
         // Validate signing config and resolve to SigningConfig.
         let signing = match (&self.private_key, &self.signer_endpoint, &self.signer_address) {
             (Some(pk), None, None) => SigningConfig::Local(parse_private_key("--private-key", pk)?),
@@ -143,17 +213,51 @@ impl Cli {
             port: self.prover_port,
         };
 
-        if self.boundless.boundless_min_price > self.boundless.boundless_max_price {
-            return Err(RegistrarError::Config(
-                "--boundless-min-price must not exceed --boundless-max-price".into(),
-            ));
-        }
+        // Build proving config based on mode.
+        let proving = match self.proving_mode {
+            ProvingMode::Boundless => {
+                if self.boundless.boundless_min_price > self.boundless.boundless_max_price {
+                    return Err(RegistrarError::Config(
+                        "--boundless-min-price must not exceed --boundless-max-price".into(),
+                    ));
+                }
+                if self.boundless.boundless_timeout_secs == 0 {
+                    return Err(RegistrarError::Config(
+                        "--boundless-timeout-secs must be greater than 0".into(),
+                    ));
+                }
 
-        if self.boundless.boundless_timeout_secs == 0 {
-            return Err(RegistrarError::Config(
-                "--boundless-timeout-secs must be greater than 0".into(),
-            ));
-        }
+                ProvingConfig::Boundless(Box::new(BoundlessConfig {
+                    rpc_url: self.boundless.boundless_rpc_url.ok_or_else(|| {
+                        RegistrarError::Config("--boundless-rpc-url is required".into())
+                    })?,
+                    signer: parse_private_key(
+                        "--boundless-private-key",
+                        self.boundless.boundless_private_key.as_deref().unwrap_or(""),
+                    )?,
+                    verifier_program_url: self
+                        .boundless
+                        .boundless_verifier_program_url
+                        .ok_or_else(|| {
+                            RegistrarError::Config(
+                                "--boundless-verifier-program-url is required".into(),
+                            )
+                        })?,
+                    image_id: parse_image_id(self.image_id.as_deref().unwrap_or(""))?,
+                    min_price: self.boundless.boundless_min_price,
+                    max_price: self.boundless.boundless_max_price,
+                    poll_interval: Duration::from_secs(self.boundless.boundless_poll_interval_secs),
+                    timeout: Duration::from_secs(self.boundless.boundless_timeout_secs),
+                    nitro_verifier_address: self.boundless.nitro_verifier_address,
+                }))
+            }
+            ProvingMode::Direct => {
+                let elf_path = self.elf_path.ok_or_else(|| {
+                    RegistrarError::Config("--elf-path is required for direct mode".into())
+                })?;
+                ProvingConfig::Direct { elf_path }
+            }
+        };
 
         if self.poll_interval_secs == 0 {
             return Err(RegistrarError::Config(
@@ -161,35 +265,137 @@ impl Cli {
             ));
         }
 
+        if self.prover_timeout_secs == 0 {
+            return Err(RegistrarError::Config(
+                "--prover-timeout-secs must be greater than 0".into(),
+            ));
+        }
+
         Ok(RegistrarConfig {
             l1_rpc_url: self.l1_rpc_url,
             tee_prover_registry_address: self.tee_prover_registry_address,
+            l1_chain_id: self.l1_chain_id,
             discovery,
             signing,
-            boundless: BoundlessConfig {
-                rpc_url: self.boundless.boundless_rpc_url,
-                signer: parse_private_key(
-                    "--boundless-private-key",
-                    &self.boundless.boundless_private_key,
-                )?,
-                verifier_program_url: self.boundless.boundless_verifier_program_url,
-                min_price: self.boundless.boundless_min_price,
-                max_price: self.boundless.boundless_max_price,
-                timeout: Duration::from_secs(self.boundless.boundless_timeout_secs),
-                nitro_verifier_address: self.boundless.nitro_verifier_address,
-            },
+            proving,
             poll_interval: Duration::from_secs(self.poll_interval_secs),
+            prover_timeout: Duration::from_secs(self.prover_timeout_secs),
             health_port: self.health_port,
         })
     }
 
     /// Run the registrar service.
     pub(crate) async fn run(self) -> eyre::Result<()> {
-        let _config = self.into_config()?;
-        // TODO(CHAIN-3455): start RegistrationDriver. When wiring up the driver,
-        // this binary crate will need `aws-config` with features
-        // `["default-https-client", "rt-tokio"]` to construct real AWS SDK clients
-        // for AwsTargetGroupDiscovery.
+        let config = self.into_config()?;
+
+        info!(config = ?config, "starting prover registrar");
+
+        // Build L1 provider.
+        let provider = RootProvider::new_http(config.l1_rpc_url.clone());
+
+        // Build signing config for SimpleTxManager.
+        let signer_config = match &config.signing {
+            SigningConfig::Local(pk) => SignerConfig::local(B256::new(pk.to_bytes().0)),
+            SigningConfig::Remote(cfg) => {
+                SignerConfig::Remote { endpoint: cfg.endpoint.clone(), address: cfg.address }
+            }
+        };
+
+        let tx_manager = SimpleTxManager::new(
+            provider,
+            signer_config,
+            TxManagerConfig::default(),
+            config.l1_chain_id,
+            Arc::new(NoopTxMetrics),
+        )
+        .await?;
+
+        // Build AWS SDK clients for discovery.
+        let aws_config = aws_config::defaults(aws_config::BehaviorVersion::latest())
+            .region(aws_config::Region::new(config.discovery.aws_region.clone()))
+            .load()
+            .await;
+        let elb_client = aws_sdk_elasticloadbalancingv2::Client::new(&aws_config);
+        let ec2_client = aws_sdk_ec2::Client::new(&aws_config);
+
+        let discovery = AwsTargetGroupDiscovery::new(
+            elb_client,
+            ec2_client,
+            config.discovery.target_group_arn.clone(),
+            config.discovery.port,
+        );
+
+        // Build registry client.
+        let registry = RegistryContractClient::new(
+            config.tee_prover_registry_address,
+            config.l1_rpc_url.clone(),
+        );
+
+        // Build proof provider based on proving mode.
+        let cancel = CancellationToken::new();
+
+        match config.proving {
+            ProvingConfig::Boundless(ref boundless) => {
+                let proof_provider = BoundlessProver {
+                    rpc_url: boundless.rpc_url.clone(),
+                    signer: boundless.signer.clone(),
+                    verifier_program_url: boundless.verifier_program_url.clone(),
+                    image_id: boundless.image_id,
+                    max_price: boundless.max_price,
+                    poll_interval: boundless.poll_interval,
+                    timeout: boundless.timeout,
+                    trusted_certs_prefix_len: DEFAULT_TRUSTED_CERTS_PREFIX,
+                };
+
+                let driver = RegistrationDriver::new(
+                    discovery,
+                    proof_provider,
+                    registry,
+                    tx_manager,
+                    config.tee_prover_registry_address,
+                    config.poll_interval,
+                    config.prover_timeout,
+                    cancel.clone(),
+                );
+
+                tokio::select! {
+                    result = driver.run() => result?,
+                    _ = tokio::signal::ctrl_c() => {
+                        info!("received ctrl-c, shutting down");
+                        cancel.cancel();
+                    }
+                }
+            }
+            ProvingConfig::Direct { ref elf_path } => {
+                let elf = std::fs::read(elf_path).map_err(|e| {
+                    RegistrarError::Config(format!(
+                        "failed to read ELF at {}: {e}",
+                        elf_path.display()
+                    ))
+                })?;
+                let proof_provider = DirectProver::new(elf, DEFAULT_TRUSTED_CERTS_PREFIX)?;
+
+                let driver = RegistrationDriver::new(
+                    discovery,
+                    proof_provider,
+                    registry,
+                    tx_manager,
+                    config.tee_prover_registry_address,
+                    config.poll_interval,
+                    config.prover_timeout,
+                    cancel.clone(),
+                );
+
+                tokio::select! {
+                    result = driver.run() => result?,
+                    _ = tokio::signal::ctrl_c() => {
+                        info!("received ctrl-c, shutting down");
+                        cancel.cancel();
+                    }
+                }
+            }
+        }
+
         Ok(())
     }
 }
@@ -198,163 +404,228 @@ impl Cli {
 mod tests {
     use std::time::Duration;
 
+    use rstest::rstest;
+
     use super::*;
 
-    fn base_args() -> Vec<&'static str> {
+    // ── Shared test constants ───────────────────────────────────────────
+
+    const TEST_L1_RPC: &str = "http://localhost:8545";
+    const TEST_L1_CHAIN_ID: &str = "1";
+    const TEST_REGISTRY_ADDR: &str = "0x0000000000000000000000000000000000000001";
+    const TEST_TARGET_GROUP_ARN: &str =
+        "arn:aws:elasticloadbalancing:us-east-1:123456789012:targetgroup/prover/abc123";
+    const TEST_AWS_REGION: &str = "us-east-1";
+    const TEST_PRIVATE_KEY: &str =
+        "0x0101010101010101010101010101010101010101010101010101010101010101";
+    const TEST_BOUNDLESS_RPC: &str = "http://localhost:9545";
+    const TEST_BOUNDLESS_KEY: &str =
+        "0202020202020202020202020202020202020202020202020202020202020202";
+    const TEST_VERIFIER_URL: &str =
+        "ipfs://bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi";
+    const TEST_IMAGE_ID: &str =
+        "0x0000000100000002000000030000000400000005000000060000000700000008";
+    const TEST_ELF_PATH: &str = "/tmp/guest.elf";
+    const TEST_SIGNER_ENDPOINT: &str = "http://localhost:8546";
+    const TEST_SIGNER_ADDR: &str = "0x0000000000000000000000000000000000000002";
+
+    const DEFAULT_POLL_INTERVAL_SECS: u64 = 30;
+    const DEFAULT_PROVER_TIMEOUT_SECS: u64 = 30;
+    const DEFAULT_PROVER_PORT: u16 = 8000;
+
+    // ── Arg builders ────────────────────────────────────────────────────
+
+    /// Common args shared by all modes (L1, discovery, signing via local key).
+    fn common_args() -> Vec<&'static str> {
         vec![
             "prover-registrar",
             "--l1-rpc-url",
-            "http://localhost:8545",
+            TEST_L1_RPC,
+            "--l1-chain-id",
+            TEST_L1_CHAIN_ID,
             "--tee-prover-registry-address",
-            "0x0000000000000000000000000000000000000001",
+            TEST_REGISTRY_ADDR,
             "--target-group-arn",
-            "arn:aws:elasticloadbalancing:us-east-1:123456789012:targetgroup/prover/abc123",
+            TEST_TARGET_GROUP_ARN,
             "--aws-region",
-            "us-east-1",
+            TEST_AWS_REGION,
             "--private-key",
-            "0x0101010101010101010101010101010101010101010101010101010101010101",
-            "--boundless-rpc-url",
-            "http://localhost:9545",
-            "--boundless-private-key",
-            "0202020202020202020202020202020202020202020202020202020202020202",
-            "--boundless-verifier-program-url",
-            "ipfs://bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi",
+            TEST_PRIVATE_KEY,
         ]
     }
 
-    fn remote_args() -> Vec<&'static str> {
+    /// Boundless-mode args: common + boundless proving.
+    fn boundless_args() -> Vec<&'static str> {
+        let mut args = common_args();
+        args.extend([
+            "--proving-mode",
+            "boundless",
+            "--image-id",
+            TEST_IMAGE_ID,
+            "--boundless-rpc-url",
+            TEST_BOUNDLESS_RPC,
+            "--boundless-private-key",
+            TEST_BOUNDLESS_KEY,
+            "--boundless-verifier-program-url",
+            TEST_VERIFIER_URL,
+        ]);
+        args
+    }
+
+    /// Direct-mode args: common + direct proving.
+    fn direct_args() -> Vec<&'static str> {
+        let mut args = common_args();
+        args.extend(["--proving-mode", "direct", "--elf-path", TEST_ELF_PATH]);
+        args
+    }
+
+    /// Remote signer + boundless proving.
+    fn remote_signer_args() -> Vec<&'static str> {
         vec![
             "prover-registrar",
             "--l1-rpc-url",
-            "http://localhost:8545",
+            TEST_L1_RPC,
+            "--l1-chain-id",
+            TEST_L1_CHAIN_ID,
             "--tee-prover-registry-address",
-            "0x0000000000000000000000000000000000000001",
+            TEST_REGISTRY_ADDR,
             "--target-group-arn",
-            "arn:aws:elasticloadbalancing:us-east-1:123456789012:targetgroup/prover/abc123",
+            TEST_TARGET_GROUP_ARN,
             "--aws-region",
-            "us-east-1",
+            TEST_AWS_REGION,
             "--signer-endpoint",
-            "http://localhost:8546",
+            TEST_SIGNER_ENDPOINT,
             "--signer-address",
-            "0x0000000000000000000000000000000000000002",
+            TEST_SIGNER_ADDR,
+            "--proving-mode",
+            "boundless",
+            "--image-id",
+            TEST_IMAGE_ID,
             "--boundless-rpc-url",
-            "http://localhost:9545",
+            TEST_BOUNDLESS_RPC,
             "--boundless-private-key",
-            "0202020202020202020202020202020202020202020202020202020202020202",
+            TEST_BOUNDLESS_KEY,
             "--boundless-verifier-program-url",
-            "ipfs://bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi",
+            TEST_VERIFIER_URL,
         ]
     }
 
-    #[test]
-    fn valid_local_key_config() {
-        assert!(Cli::parse_from(base_args()).into_config().is_ok());
+    // ── Happy-path parsing ──────────────────────────────────────────────
+
+    #[rstest]
+    #[case::boundless(boundless_args())]
+    #[case::direct(direct_args())]
+    #[case::remote_signer(remote_signer_args())]
+    fn valid_config_parses(#[case] args: Vec<&str>) {
+        assert!(Cli::parse_from(args).into_config().is_ok());
     }
 
-    #[test]
-    fn valid_remote_signer_config() {
-        assert!(Cli::parse_from(remote_args()).into_config().is_ok());
+    // ── Proving mode variants ───────────────────────────────────────────
+
+    #[rstest]
+    fn boundless_mode_returns_boundless_proving() {
+        let config = Cli::parse_from(boundless_args()).into_config().unwrap();
+        assert!(matches!(config.proving, ProvingConfig::Boundless(_)));
     }
 
-    #[test]
-    fn into_config_local_returns_local_signing() {
-        let config = Cli::parse_from(base_args()).into_config().unwrap();
+    #[rstest]
+    fn direct_mode_returns_direct_proving() {
+        let config = Cli::parse_from(direct_args()).into_config().unwrap();
+        assert!(matches!(config.proving, ProvingConfig::Direct { .. }));
+    }
+
+    // ── Signing mode variants ───────────────────────────────────────────
+
+    #[rstest]
+    fn local_key_returns_local_signing() {
+        let config = Cli::parse_from(boundless_args()).into_config().unwrap();
         assert!(matches!(config.signing, SigningConfig::Local(_)));
     }
 
-    #[test]
-    fn into_config_remote_returns_remote_signing() {
-        let config = Cli::parse_from(remote_args()).into_config().unwrap();
+    #[rstest]
+    fn remote_signer_returns_remote_signing() {
+        let config = Cli::parse_from(remote_signer_args()).into_config().unwrap();
         assert!(matches!(config.signing, SigningConfig::Remote(_)));
     }
 
-    #[test]
+    // ── Clap-level validation failures ──────────────────────────────────
+
+    #[rstest]
     fn no_signing_method_fails_clap_parse() {
-        let args = vec![
-            "prover-registrar",
-            "--l1-rpc-url",
-            "http://localhost:8545",
-            "--tee-prover-registry-address",
-            "0x0000000000000000000000000000000000000001",
-            "--target-group-arn",
-            "arn:aws:elasticloadbalancing:us-east-1:123456789012:targetgroup/prover/abc123",
-            "--aws-region",
-            "us-east-1",
-            "--boundless-rpc-url",
-            "http://localhost:9545",
-            "--boundless-private-key",
-            "0202020202020202020202020202020202020202020202020202020202020202",
-            "--boundless-verifier-program-url",
-            "ipfs://bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi",
-        ];
+        let mut args = direct_args();
+        args.retain(|a| *a != "--private-key" && *a != TEST_PRIVATE_KEY);
         assert!(Cli::try_parse_from(args).is_err());
     }
 
-    #[test]
+    #[rstest]
     fn signer_endpoint_without_address_fails_clap_parse() {
-        let args = vec![
-            "prover-registrar",
-            "--l1-rpc-url",
-            "http://localhost:8545",
-            "--tee-prover-registry-address",
-            "0x0000000000000000000000000000000000000001",
-            "--target-group-arn",
-            "arn:aws:elasticloadbalancing:us-east-1:123456789012:targetgroup/prover/abc123",
-            "--aws-region",
-            "us-east-1",
-            "--signer-endpoint",
-            "http://localhost:8546",
-            "--boundless-rpc-url",
-            "http://localhost:9545",
-            "--boundless-private-key",
-            "0202020202020202020202020202020202020202020202020202020202020202",
-            "--boundless-verifier-program-url",
-            "ipfs://bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi",
-        ];
+        let mut args = direct_args();
+        args.retain(|a| *a != "--private-key" && *a != TEST_PRIVATE_KEY);
+        args.extend(["--signer-endpoint", TEST_SIGNER_ENDPOINT]);
         assert!(Cli::try_parse_from(args).is_err());
     }
 
-    #[test]
-    fn zero_poll_interval_fails_into_config() {
-        let mut args = base_args();
-        args.extend(["--poll-interval-secs", "0"]);
-        assert!(
-            Cli::try_parse_from(args).expect("clap should parse these args").into_config().is_err()
-        );
+    // ── into_config validation failures (parametrized) ──────────────────
+
+    #[rstest]
+    #[case::zero_poll_interval("--poll-interval-secs", "0")]
+    #[case::zero_prover_timeout("--prover-timeout-secs", "0")]
+    #[case::zero_boundless_timeout("--boundless-timeout-secs", "0")]
+    fn zero_duration_fails_into_config(#[case] flag: &str, #[case] value: &str) {
+        let mut args = boundless_args();
+        args.extend([flag, value]);
+        let result = Cli::try_parse_from(args).expect("clap should parse these args").into_config();
+        assert!(result.is_err());
     }
 
-    #[test]
-    fn zero_boundless_timeout_fails_into_config() {
-        let mut args = base_args();
-        args.extend(["--boundless-timeout-secs", "0"]);
-        assert!(
-            Cli::try_parse_from(args).expect("clap should parse these args").into_config().is_err()
-        );
-    }
-
-    #[test]
+    #[rstest]
     fn inverted_price_bounds_fail_into_config() {
-        let mut args = base_args();
+        let mut args = boundless_args();
         args.extend(["--boundless-min-price", "9999", "--boundless-max-price", "1"]);
-        assert!(
-            Cli::try_parse_from(args).expect("clap should parse these args").into_config().is_err()
-        );
+        let result = Cli::try_parse_from(args).expect("clap should parse these args").into_config();
+        assert!(result.is_err());
     }
 
-    #[test]
-    fn poll_interval_returns_duration() {
-        let config = Cli::parse_from(base_args()).into_config().unwrap();
-        assert_eq!(config.poll_interval, Duration::from_secs(30));
+    // ── Field value checks ──────────────────────────────────────────────
+
+    #[rstest]
+    fn default_durations() {
+        let config = Cli::parse_from(boundless_args()).into_config().unwrap();
+        assert_eq!(config.poll_interval, Duration::from_secs(DEFAULT_POLL_INTERVAL_SECS));
+        assert_eq!(config.prover_timeout, Duration::from_secs(DEFAULT_PROVER_TIMEOUT_SECS));
     }
 
-    #[test]
+    #[rstest]
     fn discovery_config_fields() {
-        let config = Cli::parse_from(base_args()).into_config().unwrap();
-        assert_eq!(
-            config.discovery.target_group_arn,
-            "arn:aws:elasticloadbalancing:us-east-1:123456789012:targetgroup/prover/abc123"
-        );
-        assert_eq!(config.discovery.aws_region, "us-east-1");
-        assert_eq!(config.discovery.port, 8000);
+        let config = Cli::parse_from(boundless_args()).into_config().unwrap();
+        assert_eq!(config.discovery.target_group_arn, TEST_TARGET_GROUP_ARN);
+        assert_eq!(config.discovery.aws_region, TEST_AWS_REGION);
+        assert_eq!(config.discovery.port, DEFAULT_PROVER_PORT);
+    }
+
+    #[rstest]
+    fn image_id_parsed_correctly() {
+        let config = Cli::parse_from(boundless_args()).into_config().unwrap();
+        let ProvingConfig::Boundless(b) = &config.proving else {
+            panic!("expected Boundless proving config");
+        };
+        assert_eq!(b.image_id, [1, 2, 3, 4, 5, 6, 7, 8]);
+    }
+
+    // ── parse_image_id unit tests ───────────────────────────────────────
+
+    #[rstest]
+    #[case::with_prefix("0x0000000100000002000000030000000400000005000000060000000700000008", [1,2,3,4,5,6,7,8])]
+    #[case::without_prefix("0000000100000002000000030000000400000005000000060000000700000008", [1,2,3,4,5,6,7,8])]
+    fn parse_image_id_valid(#[case] input: &str, #[case] expected: [u32; 8]) {
+        assert_eq!(parse_image_id(input).unwrap(), expected);
+    }
+
+    #[rstest]
+    #[case::too_short("00000001")]
+    #[case::invalid_hex("zzzz")]
+    #[case::empty("")]
+    fn parse_image_id_invalid(#[case] input: &str) {
+        assert!(parse_image_id(input).is_err());
     }
 }

--- a/bin/prover-registrar/src/main.rs
+++ b/bin/prover-registrar/src/main.rs
@@ -7,6 +7,8 @@ mod cli;
 
 #[tokio::main]
 async fn main() {
+    tracing_subscriber::fmt::init();
+
     if let Err(err) = cli::Cli::parse().run().await {
         eprintln!("Error: {err:?}");
         std::process::exit(1);

--- a/crates/proof/tee/nitro-attestation-prover/src/types.rs
+++ b/crates/proof/tee/nitro-attestation-prover/src/types.rs
@@ -25,6 +25,13 @@ pub trait AttestationProofProvider: Send + Sync {
     async fn generate_proof(&self, attestation_bytes: &[u8]) -> Result<AttestationProof>;
 }
 
+#[async_trait]
+impl AttestationProofProvider for Box<dyn AttestationProofProvider> {
+    async fn generate_proof(&self, attestation_bytes: &[u8]) -> Result<AttestationProof> {
+        (**self).generate_proof(attestation_bytes).await
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use rstest::rstest;

--- a/crates/proof/tee/registrar/Cargo.toml
+++ b/crates/proof/tee/registrar/Cargo.toml
@@ -28,12 +28,17 @@ k256.workspace = true
 # Proving
 base-proof-tee-nitro-attestation-prover.workspace = true
 
+# Transaction management
+base-tx-manager.workspace = true
+
 # RPC
 jsonrpsee = { workspace = true, features = ["http-client", "server"] }
 base-proof-primitives = { workspace = true, features = ["rpc-client"] }
 
 # Async
 async-trait.workspace = true
+tokio-util.workspace = true
+tokio = { workspace = true, features = ["time", "macros"] }
 
 # Error
 thiserror.workspace = true

--- a/crates/proof/tee/registrar/src/config.rs
+++ b/crates/proof/tee/registrar/src/config.rs
@@ -73,8 +73,6 @@ pub struct BoundlessConfig {
     pub verifier_program_url: Url,
     /// Expected image ID of the guest program (hex-encoded `[u32; 8]`).
     pub image_id: [u32; 8],
-    /// Minimum price in wei per cycle for Boundless proof requests.
-    pub min_price: u64,
     /// Maximum price in wei per cycle for Boundless proof requests.
     pub max_price: u64,
     /// Interval between fulfillment status checks.
@@ -92,7 +90,6 @@ impl std::fmt::Debug for BoundlessConfig {
             .field("signer", &self.signer.address())
             .field("verifier_program_url", &self.verifier_program_url)
             .field("image_id", &self.image_id)
-            .field("min_price", &self.min_price)
             .field("max_price", &self.max_price)
             .field("poll_interval", &self.poll_interval)
             .field("timeout", &self.timeout)

--- a/crates/proof/tee/registrar/src/config.rs
+++ b/crates/proof/tee/registrar/src/config.rs
@@ -2,49 +2,8 @@ use std::{path::PathBuf, time::Duration};
 
 use alloy_primitives::Address;
 use alloy_signer_local::PrivateKeySigner;
+use base_tx_manager::{SignerConfig, TxManagerConfig};
 use url::Url;
-
-/// HTTP signer sidecar configuration (production).
-#[derive(Clone)]
-pub struct RemoteSignerConfig {
-    /// Signer sidecar JSON-RPC endpoint URL.
-    pub endpoint: Url,
-    /// Manager address for signing registration transactions.
-    pub address: Address,
-}
-
-impl std::fmt::Debug for RemoteSignerConfig {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("RemoteSignerConfig")
-            .field("endpoint", &url_origin(&self.endpoint))
-            .field("address", &self.address)
-            .finish()
-    }
-}
-
-/// Resolved signing configuration for L1 transaction submission.
-#[derive(Clone)]
-pub enum SigningConfig {
-    /// HTTP signer sidecar (production).
-    Remote(RemoteSignerConfig),
-    /// Direct in-process private key. **Development / testing only.**
-    Local(PrivateKeySigner),
-}
-
-impl std::fmt::Debug for SigningConfig {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::Remote(config) => f
-                .debug_struct("Remote")
-                .field("endpoint", &url_origin(&config.endpoint))
-                .field("address", &config.address)
-                .finish(),
-            Self::Local(signer) => {
-                f.debug_struct("Local").field("address", &signer.address()).finish()
-            }
-        }
-    }
-}
 
 /// AWS ALB target group discovery configuration.
 ///
@@ -114,7 +73,7 @@ pub enum ProvingConfig {
 ///
 /// Constructed by the CLI layer (`bin/prover-registrar`), which handles argument
 /// parsing, validation, and signing config resolution before building this type.
-#[derive(Clone)]
+#[derive(Debug)]
 pub struct RegistrarConfig {
     // ── L1 ────────────────────────────────────────────────────────────────────
     /// L1 Ethereum RPC endpoint.
@@ -126,9 +85,11 @@ pub struct RegistrarConfig {
     // ── Discovery ─────────────────────────────────────────────────────────────
     /// AWS ALB target group discovery configuration.
     pub discovery: AwsDiscoveryConfig,
-    // ── Signing ───────────────────────────────────────────────────────────────
-    /// Resolved signing configuration.
-    pub signing: SigningConfig,
+    // ── Signing / Tx Manager ──────────────────────────────────────────────────
+    /// Signing configuration (local private key or remote sidecar).
+    pub signing: SignerConfig,
+    /// Transaction manager configuration (fee limits, confirmations, timeouts).
+    pub tx_manager: TxManagerConfig,
     // ── Proving ───────────────────────────────────────────────────────────────
     /// ZK proving backend configuration.
     pub proving: ProvingConfig,
@@ -149,20 +110,4 @@ pub(crate) fn url_origin(url: &Url) -> String {
         s.push_str(&format!(":{port}"));
     }
     s
-}
-
-impl std::fmt::Debug for RegistrarConfig {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("RegistrarConfig")
-            .field("l1_rpc_url", &url_origin(&self.l1_rpc_url))
-            .field("tee_prover_registry_address", &self.tee_prover_registry_address)
-            .field("l1_chain_id", &self.l1_chain_id)
-            .field("discovery", &self.discovery)
-            .field("signing", &self.signing)
-            .field("proving", &self.proving)
-            .field("poll_interval", &self.poll_interval)
-            .field("prover_timeout", &self.prover_timeout)
-            .field("health_port", &self.health_port)
-            .finish()
-    }
 }

--- a/crates/proof/tee/registrar/src/config.rs
+++ b/crates/proof/tee/registrar/src/config.rs
@@ -1,4 +1,4 @@
-use std::time::Duration;
+use std::{path::PathBuf, time::Duration};
 
 use alloy_primitives::Address;
 use alloy_signer_local::PrivateKeySigner;
@@ -71,10 +71,14 @@ pub struct BoundlessConfig {
     pub signer: PrivateKeySigner,
     /// IPFS URL of the Nitro attestation verifier ELF uploaded via `nitro-attest-cli`.
     pub verifier_program_url: Url,
+    /// Expected image ID of the guest program (hex-encoded `[u32; 8]`).
+    pub image_id: [u32; 8],
     /// Minimum price in wei per cycle for Boundless proof requests.
     pub min_price: u64,
     /// Maximum price in wei per cycle for Boundless proof requests.
     pub max_price: u64,
+    /// Interval between fulfillment status checks.
+    pub poll_interval: Duration,
     /// Proof generation timeout.
     pub timeout: Duration,
     /// `NitroEnclaveVerifier` contract address for certificate caching (optional).
@@ -87,12 +91,26 @@ impl std::fmt::Debug for BoundlessConfig {
             .field("rpc_url", &url_origin(&self.rpc_url))
             .field("signer", &self.signer.address())
             .field("verifier_program_url", &self.verifier_program_url)
+            .field("image_id", &self.image_id)
             .field("min_price", &self.min_price)
             .field("max_price", &self.max_price)
+            .field("poll_interval", &self.poll_interval)
             .field("timeout", &self.timeout)
             .field("nitro_verifier_address", &self.nitro_verifier_address)
             .finish()
     }
+}
+
+/// ZK proving backend configuration.
+#[derive(Clone, Debug)]
+pub enum ProvingConfig {
+    /// Boundless marketplace proving (production).
+    Boundless(Box<BoundlessConfig>),
+    /// Direct proving via `risc0_zkvm::default_prover()` (Bonsai remote or dev-mode).
+    Direct {
+        /// Path to the guest ELF binary on disk.
+        elf_path: PathBuf,
+    },
 }
 
 /// Runtime configuration for the prover registrar.
@@ -106,18 +124,22 @@ pub struct RegistrarConfig {
     pub l1_rpc_url: Url,
     /// `TEEProverRegistry` contract address on L1.
     pub tee_prover_registry_address: Address,
+    /// L1 chain ID (validated against the RPC provider at startup).
+    pub l1_chain_id: u64,
     // ── Discovery ─────────────────────────────────────────────────────────────
     /// AWS ALB target group discovery configuration.
     pub discovery: AwsDiscoveryConfig,
     // ── Signing ───────────────────────────────────────────────────────────────
     /// Resolved signing configuration.
     pub signing: SigningConfig,
-    // ── Boundless ─────────────────────────────────────────────────────────────
-    /// Boundless Network configuration.
-    pub boundless: BoundlessConfig,
+    // ── Proving ───────────────────────────────────────────────────────────────
+    /// ZK proving backend configuration.
+    pub proving: ProvingConfig,
     // ── Polling / Server ──────────────────────────────────────────────────────
     /// Interval between discovery and registration poll cycles.
     pub poll_interval: Duration,
+    /// Timeout for JSON-RPC calls to prover instances.
+    pub prover_timeout: Duration,
     /// Port for the health check and Prometheus metrics HTTP server.
     pub health_port: u16,
 }
@@ -137,10 +159,12 @@ impl std::fmt::Debug for RegistrarConfig {
         f.debug_struct("RegistrarConfig")
             .field("l1_rpc_url", &url_origin(&self.l1_rpc_url))
             .field("tee_prover_registry_address", &self.tee_prover_registry_address)
+            .field("l1_chain_id", &self.l1_chain_id)
             .field("discovery", &self.discovery)
             .field("signing", &self.signing)
-            .field("boundless", &self.boundless)
+            .field("proving", &self.proving)
             .field("poll_interval", &self.poll_interval)
+            .field("prover_timeout", &self.prover_timeout)
             .field("health_port", &self.health_port)
             .finish()
     }

--- a/crates/proof/tee/registrar/src/config.rs
+++ b/crates/proof/tee/registrar/src/config.rs
@@ -73,7 +73,6 @@ pub enum ProvingConfig {
 ///
 /// Constructed by the CLI layer (`bin/prover-registrar`), which handles argument
 /// parsing, validation, and signing config resolution before building this type.
-#[derive(Debug)]
 pub struct RegistrarConfig {
     // ── L1 ────────────────────────────────────────────────────────────────────
     /// L1 Ethereum RPC endpoint.
@@ -100,6 +99,23 @@ pub struct RegistrarConfig {
     pub prover_timeout: Duration,
     /// Port for the health check and Prometheus metrics HTTP server.
     pub health_port: u16,
+}
+
+impl std::fmt::Debug for RegistrarConfig {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("RegistrarConfig")
+            .field("l1_rpc_url", &url_origin(&self.l1_rpc_url))
+            .field("tee_prover_registry_address", &self.tee_prover_registry_address)
+            .field("l1_chain_id", &self.l1_chain_id)
+            .field("discovery", &self.discovery)
+            .field("signing", &self.signing)
+            .field("tx_manager", &self.tx_manager)
+            .field("proving", &self.proving)
+            .field("poll_interval", &self.poll_interval)
+            .field("prover_timeout", &self.prover_timeout)
+            .field("health_port", &self.health_port)
+            .finish()
+    }
 }
 
 /// Format only the `scheme://host:port` of a URL, dropping the path and query

--- a/crates/proof/tee/registrar/src/driver.rs
+++ b/crates/proof/tee/registrar/src/driver.rs
@@ -9,7 +9,7 @@ use std::{fmt, time::Duration};
 use alloy_primitives::{Address, Bytes};
 use alloy_sol_types::SolCall;
 use base_proof_tee_nitro_attestation_prover::AttestationProofProvider;
-use base_tx_manager::{SimpleTxManager, TxCandidate, TxManager};
+use base_tx_manager::{TxCandidate, TxManager};
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, info, warn};
 
@@ -23,18 +23,18 @@ use crate::{
 ///
 /// Generic over the discovery, proof generation, and registry backends so
 /// each can be mocked independently in tests.
-pub struct RegistrationDriver<D, P, R> {
+pub struct RegistrationDriver<D, P, R, T> {
     discovery: D,
     proof_provider: P,
     registry: R,
-    tx_manager: SimpleTxManager,
+    tx_manager: T,
     registry_address: Address,
     poll_interval: Duration,
     prover_timeout: Duration,
     cancel: CancellationToken,
 }
 
-impl<D, P, R> fmt::Debug for RegistrationDriver<D, P, R> {
+impl<D, P, R, T> fmt::Debug for RegistrationDriver<D, P, R, T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("RegistrationDriver")
             .field("registry_address", &self.registry_address)
@@ -44,11 +44,12 @@ impl<D, P, R> fmt::Debug for RegistrationDriver<D, P, R> {
     }
 }
 
-impl<D, P, R> RegistrationDriver<D, P, R>
+impl<D, P, R, T> RegistrationDriver<D, P, R, T>
 where
     D: InstanceDiscovery,
     P: AttestationProofProvider,
     R: RegistryClient,
+    T: TxManager,
 {
     /// Creates a new registration driver.
     #[allow(clippy::too_many_arguments)]
@@ -56,7 +57,7 @@ where
         discovery: D,
         proof_provider: P,
         registry: R,
-        tx_manager: SimpleTxManager,
+        tx_manager: T,
         registry_address: Address,
         poll_interval: Duration,
         prover_timeout: Duration,

--- a/crates/proof/tee/registrar/src/driver.rs
+++ b/crates/proof/tee/registrar/src/driver.rs
@@ -1,0 +1,178 @@
+//! Registration driver — core orchestration loop.
+//!
+//! Discovers prover instances, checks on-chain registration status, generates
+//! ZK proofs for unregistered signers, and submits registration transactions
+//! to L1 via [`SimpleTxManager`].
+
+use std::{fmt, time::Duration};
+
+use alloy_primitives::{Address, Bytes};
+use alloy_sol_types::SolCall;
+use base_proof_tee_nitro_attestation_prover::AttestationProofProvider;
+use base_tx_manager::{SimpleTxManager, TxCandidate, TxManager};
+use tokio_util::sync::CancellationToken;
+use tracing::{debug, info, warn};
+
+use crate::{
+    InstanceDiscovery, ProverClient, ProverInstance, RegistrarError, RegistryClient, Result,
+    registry::ITEEProverRegistry,
+};
+
+/// Core registration loop tying together discovery, attestation polling,
+/// ZK proof generation, and on-chain submission.
+///
+/// Generic over the discovery, proof generation, and registry backends so
+/// each can be mocked independently in tests.
+pub struct RegistrationDriver<D, P, R> {
+    discovery: D,
+    proof_provider: P,
+    registry: R,
+    tx_manager: SimpleTxManager,
+    registry_address: Address,
+    poll_interval: Duration,
+    prover_timeout: Duration,
+    cancel: CancellationToken,
+}
+
+impl<D, P, R> fmt::Debug for RegistrationDriver<D, P, R> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("RegistrationDriver")
+            .field("registry_address", &self.registry_address)
+            .field("poll_interval", &self.poll_interval)
+            .field("prover_timeout", &self.prover_timeout)
+            .finish_non_exhaustive()
+    }
+}
+
+impl<D, P, R> RegistrationDriver<D, P, R>
+where
+    D: InstanceDiscovery,
+    P: AttestationProofProvider,
+    R: RegistryClient,
+{
+    /// Creates a new registration driver.
+    #[allow(clippy::too_many_arguments)]
+    pub const fn new(
+        discovery: D,
+        proof_provider: P,
+        registry: R,
+        tx_manager: SimpleTxManager,
+        registry_address: Address,
+        poll_interval: Duration,
+        prover_timeout: Duration,
+        cancel: CancellationToken,
+    ) -> Self {
+        Self {
+            discovery,
+            proof_provider,
+            registry,
+            tx_manager,
+            registry_address,
+            poll_interval,
+            prover_timeout,
+            cancel,
+        }
+    }
+
+    /// Runs the registration loop until cancelled.
+    ///
+    /// Each tick discovers instances, filters by health status, and attempts
+    /// registration for any unregistered signers. Individual instance failures
+    /// are logged and skipped — the loop continues with the next instance.
+    pub async fn run(&self) -> Result<()> {
+        info!(
+            poll_interval = ?self.poll_interval,
+            registry = %self.registry_address,
+            "starting registration driver"
+        );
+
+        loop {
+            tokio::select! {
+                () = self.cancel.cancelled() => {
+                    info!("registration driver received shutdown signal");
+                    break;
+                }
+                () = tokio::time::sleep(self.poll_interval) => {
+                    if let Err(e) = self.step().await {
+                        warn!(error = %e, "registration step failed");
+                    }
+                }
+            }
+        }
+
+        info!("registration driver stopped");
+        Ok(())
+    }
+
+    /// Single registration cycle: discover → filter → register.
+    async fn step(&self) -> Result<()> {
+        let instances = self.discovery.discover_instances().await?;
+        let registerable: Vec<_> =
+            instances.iter().filter(|i| i.health_status.should_register()).collect();
+
+        if registerable.is_empty() {
+            return Ok(());
+        }
+
+        info!(
+            total = instances.len(),
+            registerable = registerable.len(),
+            "discovered prover instances"
+        );
+
+        for instance in registerable {
+            if let Err(e) = self.process_instance(instance).await {
+                warn!(
+                    error = %e,
+                    instance = %instance.instance_id,
+                    endpoint = %instance.endpoint,
+                    "failed to process instance"
+                );
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Processes a single instance: fetch attestation, check registration,
+    /// generate proof if needed, submit transaction.
+    async fn process_instance(&self, instance: &ProverInstance) -> Result<()> {
+        let client = ProverClient::new(&instance.endpoint, self.prover_timeout)?;
+        let response = client.get_attestation_response().await?;
+
+        if self.registry.is_registered(response.signer_address).await? {
+            debug!(signer = %response.signer_address, "already registered, skipping");
+            return Ok(());
+        }
+
+        info!(
+            signer = %response.signer_address,
+            instance = %instance.instance_id,
+            "generating proof for unregistered signer"
+        );
+
+        let proof = self.proof_provider.generate_proof(&response.attestation_bytes).await?;
+
+        let calldata = ITEEProverRegistry::registerSignerCall {
+            output: proof.output,
+            proofBytes: proof.proof_bytes,
+        }
+        .abi_encode();
+
+        let candidate = TxCandidate {
+            tx_data: Bytes::from(calldata),
+            to: Some(self.registry_address),
+            ..Default::default()
+        };
+
+        let receipt = self.tx_manager.send(candidate).await.map_err(RegistrarError::from)?;
+
+        info!(
+            signer = %response.signer_address,
+            tx_hash = %receipt.transaction_hash,
+            "signer registered successfully"
+        );
+
+        Ok(())
+    }
+}

--- a/crates/proof/tee/registrar/src/driver.rs
+++ b/crates/proof/tee/registrar/src/driver.rs
@@ -163,7 +163,7 @@ where
 
         // Only fetch the full NSM attestation document when registration is needed.
         let attestation_bytes = client.signer_attestation().await?;
-        let proof = self.proof_provider.generate_proof(&Bytes::from(attestation_bytes)).await?;
+        let proof = self.proof_provider.generate_proof(&attestation_bytes).await?;
 
         // Check cancellation before submitting the transaction — avoid starting
         // new on-chain work if shutdown is in progress.

--- a/crates/proof/tee/registrar/src/driver.rs
+++ b/crates/proof/tee/registrar/src/driver.rs
@@ -2,7 +2,7 @@
 //!
 //! Discovers prover instances, checks on-chain registration status, generates
 //! ZK proofs for unregistered signers, and submits registration transactions
-//! to L1 via [`SimpleTxManager`].
+//! to L1 via the [`TxManager`].
 
 use std::{fmt, time::Duration};
 
@@ -18,29 +18,36 @@ use crate::{
     registry::ITEEProverRegistry,
 };
 
+/// Runtime parameters for the [`RegistrationDriver`] that are not
+/// trait-based dependencies.
+#[derive(Debug, Clone)]
+pub struct DriverConfig {
+    /// `TEEProverRegistry` contract address on L1.
+    pub registry_address: Address,
+    /// Interval between discovery and registration poll cycles.
+    pub poll_interval: Duration,
+    /// Timeout for JSON-RPC calls to prover instances.
+    pub prover_timeout: Duration,
+    /// Cancellation token for graceful shutdown.
+    pub cancel: CancellationToken,
+}
+
 /// Core registration loop tying together discovery, attestation polling,
 /// ZK proof generation, and on-chain submission.
 ///
-/// Generic over the discovery, proof generation, and registry backends so
-/// each can be mocked independently in tests.
+/// Generic over the discovery, proof generation, registry, and transaction
+/// manager backends so each can be mocked independently in tests.
 pub struct RegistrationDriver<D, P, R, T> {
     discovery: D,
     proof_provider: P,
     registry: R,
     tx_manager: T,
-    registry_address: Address,
-    poll_interval: Duration,
-    prover_timeout: Duration,
-    cancel: CancellationToken,
+    config: DriverConfig,
 }
 
 impl<D, P, R, T> fmt::Debug for RegistrationDriver<D, P, R, T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("RegistrationDriver")
-            .field("registry_address", &self.registry_address)
-            .field("poll_interval", &self.poll_interval)
-            .field("prover_timeout", &self.prover_timeout)
-            .finish_non_exhaustive()
+        f.debug_struct("RegistrationDriver").field("config", &self.config).finish_non_exhaustive()
     }
 }
 
@@ -52,27 +59,14 @@ where
     T: TxManager,
 {
     /// Creates a new registration driver.
-    #[allow(clippy::too_many_arguments)]
     pub const fn new(
         discovery: D,
         proof_provider: P,
         registry: R,
         tx_manager: T,
-        registry_address: Address,
-        poll_interval: Duration,
-        prover_timeout: Duration,
-        cancel: CancellationToken,
+        config: DriverConfig,
     ) -> Self {
-        Self {
-            discovery,
-            proof_provider,
-            registry,
-            tx_manager,
-            registry_address,
-            poll_interval,
-            prover_timeout,
-            cancel,
-        }
+        Self { discovery, proof_provider, registry, tx_manager, config }
     }
 
     /// Runs the registration loop until cancelled.
@@ -82,8 +76,8 @@ where
     /// the loop continues with the next instance.
     pub async fn run(&self) -> Result<()> {
         info!(
-            poll_interval = ?self.poll_interval,
-            registry = %self.registry_address,
+            poll_interval = ?self.config.poll_interval,
+            registry = %self.config.registry_address,
             "starting registration driver"
         );
 
@@ -93,11 +87,11 @@ where
             }
 
             tokio::select! {
-                () = self.cancel.cancelled() => {
+                () = self.config.cancel.cancelled() => {
                     info!("registration driver received shutdown signal");
                     break;
                 }
-                () = tokio::time::sleep(self.poll_interval) => {}
+                () = tokio::time::sleep(self.config.poll_interval) => {}
             }
         }
 
@@ -122,7 +116,7 @@ where
         );
 
         for instance in registerable {
-            if self.cancel.is_cancelled() {
+            if self.config.cancel.is_cancelled() {
                 break;
             }
 
@@ -139,35 +133,41 @@ where
         Ok(())
     }
 
-    /// Processes a single instance: fetch attestation, check registration,
-    /// generate proof if needed, submit transaction.
+    /// Processes a single instance: check registration first (cheap), then
+    /// fetch attestation and generate proof only if needed.
     async fn process_instance(&self, instance: &ProverInstance) -> Result<()> {
-        let client = ProverClient::new(&instance.endpoint, self.prover_timeout)?;
-        let response = client.get_attestation_response().await?;
+        let client = ProverClient::new(&instance.endpoint, self.config.prover_timeout)?;
 
-        if self.registry.is_registered(response.signer_address).await? {
-            debug!(signer = %response.signer_address, "already registered, skipping");
+        // Fetch only the public key (cheap RPC) and derive the address to
+        // check registration before triggering the expensive NSM attestation call.
+        let public_key = client.signer_public_key().await?;
+        let signer_address = ProverClient::derive_address(&public_key)?;
+
+        if self.registry.is_registered(signer_address).await? {
+            debug!(signer = %signer_address, "already registered, skipping");
             return Ok(());
         }
 
         // Check cancellation before the most expensive operation (proof generation
         // can take minutes via Boundless).
-        if self.cancel.is_cancelled() {
+        if self.config.cancel.is_cancelled() {
             debug!("shutdown requested, skipping proof generation");
             return Ok(());
         }
 
         info!(
-            signer = %response.signer_address,
+            signer = %signer_address,
             instance = %instance.instance_id,
             "generating proof for unregistered signer"
         );
 
-        let proof = self.proof_provider.generate_proof(&response.attestation_bytes).await?;
+        // Only fetch the full NSM attestation document when registration is needed.
+        let attestation_bytes = client.signer_attestation().await?;
+        let proof = self.proof_provider.generate_proof(&Bytes::from(attestation_bytes)).await?;
 
         // Check cancellation before submitting the transaction — avoid starting
         // new on-chain work if shutdown is in progress.
-        if self.cancel.is_cancelled() {
+        if self.config.cancel.is_cancelled() {
             debug!("shutdown requested, skipping transaction submission");
             return Ok(());
         }
@@ -180,14 +180,14 @@ where
 
         let candidate = TxCandidate {
             tx_data: Bytes::from(calldata),
-            to: Some(self.registry_address),
+            to: Some(self.config.registry_address),
             ..Default::default()
         };
 
         let receipt = self.tx_manager.send(candidate).await.map_err(RegistrarError::from)?;
 
         info!(
-            signer = %response.signer_address,
+            signer = %signer_address,
             tx_hash = %receipt.transaction_hash,
             "signer registered successfully"
         );

--- a/crates/proof/tee/registrar/src/driver.rs
+++ b/crates/proof/tee/registrar/src/driver.rs
@@ -76,9 +76,9 @@ where
 
     /// Runs the registration loop until cancelled.
     ///
-    /// Each tick discovers instances, filters by health status, and attempts
-    /// registration for any unregistered signers. Individual instance failures
-    /// are logged and skipped — the loop continues with the next instance.
+    /// Runs `step()` immediately on startup, then waits `poll_interval` between
+    /// subsequent ticks. Individual instance failures are logged and skipped —
+    /// the loop continues with the next instance.
     pub async fn run(&self) -> Result<()> {
         info!(
             poll_interval = ?self.poll_interval,
@@ -87,16 +87,16 @@ where
         );
 
         loop {
+            if let Err(e) = self.step().await {
+                warn!(error = %e, "registration step failed");
+            }
+
             tokio::select! {
                 () = self.cancel.cancelled() => {
                     info!("registration driver received shutdown signal");
                     break;
                 }
-                () = tokio::time::sleep(self.poll_interval) => {
-                    if let Err(e) = self.step().await {
-                        warn!(error = %e, "registration step failed");
-                    }
-                }
+                () = tokio::time::sleep(self.poll_interval) => {}
             }
         }
 
@@ -121,6 +121,10 @@ where
         );
 
         for instance in registerable {
+            if self.cancel.is_cancelled() {
+                break;
+            }
+
             if let Err(e) = self.process_instance(instance).await {
                 warn!(
                     error = %e,
@@ -145,6 +149,13 @@ where
             return Ok(());
         }
 
+        // Check cancellation before the most expensive operation (proof generation
+        // can take minutes via Boundless).
+        if self.cancel.is_cancelled() {
+            debug!("shutdown requested, skipping proof generation");
+            return Ok(());
+        }
+
         info!(
             signer = %response.signer_address,
             instance = %instance.instance_id,
@@ -152,6 +163,13 @@ where
         );
 
         let proof = self.proof_provider.generate_proof(&response.attestation_bytes).await?;
+
+        // Check cancellation before submitting the transaction — avoid starting
+        // new on-chain work if shutdown is in progress.
+        if self.cancel.is_cancelled() {
+            debug!("shutdown requested, skipping transaction submission");
+            return Ok(());
+        }
 
         let calldata = ITEEProverRegistry::registerSignerCall {
             output: proof.output,

--- a/crates/proof/tee/registrar/src/error.rs
+++ b/crates/proof/tee/registrar/src/error.rs
@@ -45,6 +45,10 @@ pub enum RegistrarError {
     #[error("signing error")]
     Signing(#[source] Box<dyn std::error::Error + Send + Sync>),
 
+    /// Transaction submission or confirmation failed (RPC, nonce, fee, timeout).
+    #[error("transaction error")]
+    Transaction(#[source] Box<dyn std::error::Error + Send + Sync>),
+
     /// Configuration is invalid.
     #[error("config error: {0}")]
     Config(String),
@@ -58,7 +62,7 @@ impl From<ProverError> for RegistrarError {
 
 impl From<TxManagerError> for RegistrarError {
     fn from(e: TxManagerError) -> Self {
-        Self::Signing(Box::new(e))
+        Self::Transaction(Box::new(e))
     }
 }
 

--- a/crates/proof/tee/registrar/src/error.rs
+++ b/crates/proof/tee/registrar/src/error.rs
@@ -1,4 +1,5 @@
 use base_proof_tee_nitro_attestation_prover::ProverError;
+use base_tx_manager::TxManagerError;
 use thiserror::Error;
 
 /// Errors that can occur in the prover registrar.
@@ -52,6 +53,12 @@ pub enum RegistrarError {
 impl From<ProverError> for RegistrarError {
     fn from(e: ProverError) -> Self {
         Self::ProofGeneration(Box::new(e))
+    }
+}
+
+impl From<TxManagerError> for RegistrarError {
+    fn from(e: TxManagerError) -> Self {
+        Self::Signing(Box::new(e))
     }
 }
 

--- a/crates/proof/tee/registrar/src/lib.rs
+++ b/crates/proof/tee/registrar/src/lib.rs
@@ -3,11 +3,15 @@
 
 mod config;
 pub use config::{
-    AwsDiscoveryConfig, BoundlessConfig, RegistrarConfig, RemoteSignerConfig, SigningConfig,
+    AwsDiscoveryConfig, BoundlessConfig, ProvingConfig, RegistrarConfig, RemoteSignerConfig,
+    SigningConfig,
 };
 
 mod discovery;
 pub use discovery::AwsTargetGroupDiscovery;
+
+mod driver;
+pub use driver::RegistrationDriver;
 
 mod error;
 pub use error::{RegistrarError, Result};

--- a/crates/proof/tee/registrar/src/lib.rs
+++ b/crates/proof/tee/registrar/src/lib.rs
@@ -8,7 +8,7 @@ mod discovery;
 pub use discovery::AwsTargetGroupDiscovery;
 
 mod driver;
-pub use driver::RegistrationDriver;
+pub use driver::{DriverConfig, RegistrationDriver};
 
 mod error;
 pub use error::{RegistrarError, Result};

--- a/crates/proof/tee/registrar/src/lib.rs
+++ b/crates/proof/tee/registrar/src/lib.rs
@@ -2,10 +2,7 @@
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
 
 mod config;
-pub use config::{
-    AwsDiscoveryConfig, BoundlessConfig, ProvingConfig, RegistrarConfig, RemoteSignerConfig,
-    SigningConfig,
-};
+pub use config::{AwsDiscoveryConfig, BoundlessConfig, ProvingConfig, RegistrarConfig};
 
 mod discovery;
 pub use discovery::AwsTargetGroupDiscovery;


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                                        
                                                                                                                                                                                                                                                    
- Adds `RegistrationDriver` to the registrar library crate — core orchestration loop that discovers prover instances, generates ZK proofs for unregistered signers, and submits `registerSigner` transactions to L1 via `SimpleTxManager`.
- Adds `--proving-mode boundless|direct` CLI flag with conditional args (`--image-id` for Boundless, `--elf-path` for Direct), `--l1-chain-id`, `--prover-timeout-secs`
- Replaces the `TODO(CHAIN-3455)` in the binary with full component construction: AWS SDK clients, proof provider, tx manager, driver loop with ctrl-c shutdown
- Extends `RegistrarConfig` with `ProvingConfig` enum, `l1_chain_id`, `prover_timeout`
- Transaction signing uses `base-tx-manager`'s `SimpleTxManager` (CHAIN-3454 cancelled)
- Follows the proposer driver's `tokio::select!` + `CancellationToken` pattern

## Test plan

- [x] `cargo fmt --check` passes
- [x] `cargo clippy --tests -- -D warnings` passes
- [x] Registrar lib: 29 tests pass (all pre-existing, unchanged)
- [x] Binary CLI: 21 tests pass (rstest parametrized, shared constants, parse_image_id coverage)
- [ ] Integration test with Anvil L1 fork (deferred — requires mock prover instances)
- [ ] Deregistration logic (CHAIN-3456)
- [ ] Health checks and metrics (CHAIN-3457)