### PR TITLE
fix(disc): correct doc comments for Receiver return types

### DIFF
--- a/crates/consensus/disc/src/handler.rs
+++ b/crates/consensus/disc/src/handler.rs
@@ -93,7 +93,7 @@ impl Discv5Handler {
 
     /// Blocking request for the ENRs of the discovery service.
     ///
-    /// Returns `None` if the request could not be sent or received.
+    /// The returned receiver yields `Err` if the request could not be sent or received.
     pub fn table_enrs(&self) -> tokio::sync::oneshot::Receiver<Vec<Enr>> {
         let (tx, rx) = tokio::sync::oneshot::channel();
         let sender = self.sender.clone();
@@ -120,7 +120,7 @@ impl Discv5Handler {
 
     /// Blocking request for the local ENR of the node.
     ///
-    /// Returns `None` if the request could not be sent or received.
+    /// The returned receiver yields `Err` if the request could not be sent or received.
     pub fn local_enr(&self) -> tokio::sync::oneshot::Receiver<Enr> {
         let (tx, rx) = tokio::sync::oneshot::channel();
         let sender = self.sender.clone();
@@ -151,7 +151,7 @@ impl Discv5Handler {
 
     /// Blocking request for the metrics of the discovery service.
     ///
-    /// Returns `None` if the request could not be sent or received.
+    /// The returned receiver yields `Err` if the request could not be sent or received.
     pub fn metrics(&self) -> tokio::sync::oneshot::Receiver<Metrics> {
         let (tx, rx) = tokio::sync::oneshot::channel();
         let sender = self.sender.clone();
@@ -165,7 +165,7 @@ impl Discv5Handler {
 
     /// Blocking request for the discovery service peer count.
     ///
-    /// Returns `None` if the request could not be sent or received.
+    /// The returned receiver yields `Err` if the request could not be sent or received.
     pub fn peer_count(&self) -> tokio::sync::oneshot::Receiver<usize> {
         let (tx, rx) = tokio::sync::oneshot::channel();
         let sender = self.sender.clone();


### PR DESCRIPTION
Four methods in Discv5Handler claimed to return `None` on failure, but they actually return `oneshot::Receiver` which yields `Err(RecvError)` when the sender is dropped. Fixed the doc comments to match the actual behavior.