### PR TITLE
fix(gossip): Add timeout to sync request reading to prevent deadlock

### DIFF
--- a/crates/consensus/gossip/src/driver.rs
+++ b/crates/consensus/gossip/src/driver.rs
@@ -156,7 +156,7 @@ where
 
                 tokio::spawn(async move {
                     let mut buffer = Vec::new();
-                    let Ok(bytes_received) = inbound_stream.read_to_end(&mut buffer).await else {
+                    let Ok(bytes_received) = read_frame_with_timeout(&mut inbound_stream, Duration::from_secs(5)).await else {
                         error!(target: "gossip", peer_id = %peer_id, "Failed to read the sync request");
                         return;
                     };


### PR DESCRIPTION
## Problem
The sync request/response handler uses `read_to_end()` to read incoming requests. This creates a deadlock because:
- Client sends request and waits for response (doesn't close the stream)
- Server reads until EOF (which never comes)
- Request hangs forever, accumulating tokio::spawn tasks

## Solution
Replace the unbounded read_to_end() with a timeout-based read. The handler will now:
- Attempt to read the incoming request with a 5-second timeout
- If data is received within the timeout, process the request and send response
- If timeout expires, close the connection and clean up the task
- Return to accepting new requests immediately

## Impact
- All sync requests now complete within 5 seconds or fail fast
- No more hanging tasks or resource leaks
- Normal requests are unaffected (they complete immediately)