### PR TITLE
fix(batch): queue epoch number underflow

### DIFF
--- a/crates/consensus/derive/src/stages/batch/batch_queue.rs
+++ b/crates/consensus/derive/src/stages/batch/batch_queue.rs
@@ -110,10 +110,10 @@ where
         // Note: epoch origin can now be one block ahead of the L2 Safe Head
         // This is in the case where we auto generate all batches in an epoch & advance the epoch
         // but don't advance the L2 Safe Head's epoch
-        if parent.l1_origin != epoch.id() && parent.l1_origin.number != epoch.number - 1 {
+        if parent.l1_origin != epoch.id() && parent.l1_origin.number != epoch.number.saturating_sub(1) {
             return Err(PipelineErrorKind::Reset(ResetError::L1OriginMismatch(
                 parent.l1_origin.number,
-                epoch.number - 1,
+                epoch.number.saturating_sub(1),
             )));
         }
 


### PR DESCRIPTION
## Summary

Fix a `u64` underflow in `BatchQueue::derive_next_batch`.

`derive_next_batch` used `epoch.number - 1` (plain `u64` subtraction) when checking the L1 origin mismatch condition. If `epoch.number == 0` (e.g. L1 genesis block), this underflows:
- **debug**: panic ("attempt to subtract with overflow")
- **release**: wraps to `u64::MAX`, producing a wrong error message

The same guard in `batch_validator.rs` already correctly uses `epoch.number.saturating_sub(1)` — this brings `batch_queue.rs` in line with that.

## Change

Replaced two raw `epoch.number - 1` with `epoch.number.saturating_sub(1)` in `derive_next_batch`.

## Impact

Prevents runtime panic when `epoch.number == 0` and the L1 origin mismatch branch is taken.
