### PR TITLE
derive(guard): FrameQueue::prune against empty queue underflow

### DIFF
--- a/crates/consensus/derive/src/stages/frame_queue.rs
+++ b/crates/consensus/derive/src/stages/frame_queue.rs
@@ -60,7 +60,7 @@ where
 
     /// Prunes frames if Holocene is active.
     pub fn prune(&mut self, origin: BlockInfo) {
-        if !self.is_holocene_active(origin) {
+        if !self.is_holocene_active(origin) || self.queue.len() < 2 {
             return;
         }
 
@@ -340,6 +340,21 @@ pub(crate) mod tests {
             .build();
         assert.holocene_active(true);
         assert.next_frames().await;
+    }
+
+    #[tokio::test]
+    async fn test_holocene_prune_empty_queue_no_panic() {
+        let cfg = Arc::new(RollupConfig {
+            hardforks: HardForkConfig { holocene_time: Some(0), ..Default::default() },
+            ..Default::default()
+        });
+        let mut mock = TestFrameQueueProvider::new(vec![]);
+        mock.set_origin(BlockInfo::default());
+        let mut frame_queue = FrameQueue::new(mock, cfg);
+
+        frame_queue.prune(BlockInfo::default());
+
+        assert!(frame_queue.queue.is_empty());
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

Fix an edge-case underflow in `FrameQueue::prune`.

`prune` used `self.queue.len() - 1` in the loop condition.  
If called with an empty queue while Holocene is active, this can underflow and cause a runtime panic.

## Changes

- Added an early return in `prune` when:
  - Holocene is inactive, or
  - `queue.len() < 2`.
- Added regression test:
  - `test_holocene_prune_empty_queue_no_panic`.

## Impact

Prevents panic on empty queue pruning and keeps pruning logic unchanged for normal multi-frame queues.
