### PR TITLE
Hardfork matrix

### DIFF
--- a/actions/harness/src/lib.rs
+++ b/actions/harness/src/lib.rs
@@ -22,6 +22,9 @@ mod batcher;
 pub use base_batcher_encoder::{BatchType, DaType, EncoderConfig};
 pub use batcher::{Batcher, BatcherConfig, BatcherError, L1MinerTxManager};
 
+mod matrix;
+pub use matrix::ForkMatrix;
+
 mod test_rollup_config;
 pub use test_rollup_config::TestRollupConfigBuilder;
 

--- a/actions/harness/src/matrix.rs
+++ b/actions/harness/src/matrix.rs
@@ -1,0 +1,408 @@
+use std::{
+    any::Any,
+    panic::{self, AssertUnwindSafe},
+};
+
+use base_consensus_genesis::{BaseHardforkConfig, HardForkConfig};
+
+/// Named hardfork schedules for parametrizing harness tests across protocol upgrades.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct ForkMatrix {
+    forks: Vec<(&'static str, HardForkConfig)>,
+}
+
+impl ForkMatrix {
+    /// Creates a matrix from explicit fork names and schedules.
+    pub fn new(forks: Vec<(&'static str, HardForkConfig)>) -> Self {
+        Self { forks }
+    }
+
+    /// Returns every cumulative hardfork stage supported by the harness.
+    pub fn all() -> Self {
+        Self::new(vec![
+            ("regolith", HardForkConfig { regolith_time: Some(0), ..Default::default() }),
+            (
+                "canyon",
+                HardForkConfig {
+                    regolith_time: Some(0),
+                    canyon_time: Some(0),
+                    ..Default::default()
+                },
+            ),
+            (
+                "delta",
+                HardForkConfig {
+                    regolith_time: Some(0),
+                    canyon_time: Some(0),
+                    delta_time: Some(0),
+                    ..Default::default()
+                },
+            ),
+            (
+                "ecotone",
+                HardForkConfig {
+                    regolith_time: Some(0),
+                    canyon_time: Some(0),
+                    delta_time: Some(0),
+                    ecotone_time: Some(0),
+                    ..Default::default()
+                },
+            ),
+            (
+                "fjord",
+                HardForkConfig {
+                    regolith_time: Some(0),
+                    canyon_time: Some(0),
+                    delta_time: Some(0),
+                    ecotone_time: Some(0),
+                    fjord_time: Some(0),
+                    ..Default::default()
+                },
+            ),
+            (
+                "granite",
+                HardForkConfig {
+                    regolith_time: Some(0),
+                    canyon_time: Some(0),
+                    delta_time: Some(0),
+                    ecotone_time: Some(0),
+                    fjord_time: Some(0),
+                    granite_time: Some(0),
+                    ..Default::default()
+                },
+            ),
+            (
+                "holocene",
+                HardForkConfig {
+                    regolith_time: Some(0),
+                    canyon_time: Some(0),
+                    delta_time: Some(0),
+                    ecotone_time: Some(0),
+                    fjord_time: Some(0),
+                    granite_time: Some(0),
+                    holocene_time: Some(0),
+                    ..Default::default()
+                },
+            ),
+            (
+                "pectra-blob-schedule",
+                HardForkConfig {
+                    regolith_time: Some(0),
+                    canyon_time: Some(0),
+                    delta_time: Some(0),
+                    ecotone_time: Some(0),
+                    fjord_time: Some(0),
+                    granite_time: Some(0),
+                    holocene_time: Some(0),
+                    pectra_blob_schedule_time: Some(0),
+                    ..Default::default()
+                },
+            ),
+            (
+                "isthmus",
+                HardForkConfig {
+                    regolith_time: Some(0),
+                    canyon_time: Some(0),
+                    delta_time: Some(0),
+                    ecotone_time: Some(0),
+                    fjord_time: Some(0),
+                    granite_time: Some(0),
+                    holocene_time: Some(0),
+                    isthmus_time: Some(0),
+                    ..Default::default()
+                },
+            ),
+            (
+                "jovian",
+                HardForkConfig {
+                    regolith_time: Some(0),
+                    canyon_time: Some(0),
+                    delta_time: Some(0),
+                    ecotone_time: Some(0),
+                    fjord_time: Some(0),
+                    granite_time: Some(0),
+                    holocene_time: Some(0),
+                    isthmus_time: Some(0),
+                    jovian_time: Some(0),
+                    ..Default::default()
+                },
+            ),
+            (
+                "base-v1",
+                HardForkConfig {
+                    regolith_time: Some(0),
+                    canyon_time: Some(0),
+                    delta_time: Some(0),
+                    ecotone_time: Some(0),
+                    fjord_time: Some(0),
+                    granite_time: Some(0),
+                    holocene_time: Some(0),
+                    isthmus_time: Some(0),
+                    jovian_time: Some(0),
+                    base: Some(BaseHardforkConfig { v1: Some(0) }),
+                    ..Default::default()
+                },
+            ),
+        ])
+    }
+
+    /// Returns the cumulative forks after Granite and before Isthmus.
+    pub fn pre_isthmus() -> Self {
+        Self::all().retain(|_, hardforks| {
+            hardforks.granite_time.is_some()
+                && hardforks.isthmus_time.is_none()
+                && hardforks.jovian_time.is_none()
+                && hardforks.base.and_then(|base| base.v1).is_none()
+        })
+    }
+
+    /// Returns the cumulative OP hardforks from Isthmus onward.
+    pub fn from_isthmus() -> Self {
+        Self::all().retain(|_, hardforks| {
+            hardforks.isthmus_time.is_some() && hardforks.base.and_then(|base| base.v1).is_none()
+        })
+    }
+
+    /// Returns the OP-style fault-proof forks starting at Granite.
+    ///
+    /// Base V1 is intentionally excluded because it is a standalone Base upgrade,
+    /// not part of the upstream fork progression used by the fault-proof matrix.
+    pub fn from_granite() -> Self {
+        Self::new(vec![
+            (
+                "granite",
+                HardForkConfig {
+                    regolith_time: Some(0),
+                    canyon_time: Some(0),
+                    delta_time: Some(0),
+                    ecotone_time: Some(0),
+                    fjord_time: Some(0),
+                    granite_time: Some(0),
+                    ..Default::default()
+                },
+            ),
+            (
+                "holocene",
+                HardForkConfig {
+                    regolith_time: Some(0),
+                    canyon_time: Some(0),
+                    delta_time: Some(0),
+                    ecotone_time: Some(0),
+                    fjord_time: Some(0),
+                    granite_time: Some(0),
+                    holocene_time: Some(0),
+                    ..Default::default()
+                },
+            ),
+            (
+                "isthmus",
+                HardForkConfig {
+                    regolith_time: Some(0),
+                    canyon_time: Some(0),
+                    delta_time: Some(0),
+                    ecotone_time: Some(0),
+                    fjord_time: Some(0),
+                    granite_time: Some(0),
+                    holocene_time: Some(0),
+                    isthmus_time: Some(0),
+                    ..Default::default()
+                },
+            ),
+            (
+                "jovian",
+                HardForkConfig {
+                    regolith_time: Some(0),
+                    canyon_time: Some(0),
+                    delta_time: Some(0),
+                    ecotone_time: Some(0),
+                    fjord_time: Some(0),
+                    granite_time: Some(0),
+                    holocene_time: Some(0),
+                    isthmus_time: Some(0),
+                    jovian_time: Some(0),
+                    ..Default::default()
+                },
+            ),
+        ])
+    }
+
+    /// Iterates through the named fork schedules.
+    pub fn iter(&self) -> impl Iterator<Item = (&'static str, HardForkConfig)> + '_ {
+        self.forks.iter().copied()
+    }
+
+    /// Keeps only the fork schedules that satisfy the predicate.
+    pub fn retain<F>(mut self, mut predicate: F) -> Self
+    where
+        F: FnMut(&'static str, HardForkConfig) -> bool,
+    {
+        self.forks.retain(|(fork_name, hardforks)| predicate(*fork_name, *hardforks));
+        self
+    }
+
+    /// Runs a test once per configured fork, annotating any panic with the fork name.
+    pub fn run<F>(&self, mut test: F)
+    where
+        F: FnMut(&'static str, HardForkConfig),
+    {
+        for (fork_name, hardforks) in self.iter() {
+            let result = panic::catch_unwind(AssertUnwindSafe(|| test(fork_name, hardforks)));
+            if let Err(payload) = result {
+                panic_with_fork_context(fork_name, payload);
+            }
+        }
+    }
+}
+
+fn panic_with_fork_context(fork_name: &'static str, payload: Box<dyn Any + Send + 'static>) -> ! {
+    let payload_ref = &*payload;
+    if let Some(message) = payload_ref.downcast_ref::<String>() {
+        panic!("fork matrix case `{fork_name}` failed: {message}");
+    }
+    if let Some(message) = payload_ref.downcast_ref::<&str>() {
+        panic!("fork matrix case `{fork_name}` failed: {message}");
+    }
+    panic!("fork matrix case `{fork_name}` failed with a non-string panic payload");
+}
+
+/// Runs the same test body across every schedule in a [`ForkMatrix`].
+#[macro_export]
+macro_rules! test_across_forks {
+    ($matrix:expr, |$fork_name:ident, $hardforks:ident| $body:block) => {{
+        ($matrix).run(|$fork_name, $hardforks| $body);
+    }};
+    ($matrix:expr, |$hardforks:ident| $body:block) => {{
+        ($matrix).run(|_, $hardforks| $body);
+    }};
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use base_consensus_genesis::RollupConfig;
+
+    fn test_rollup_config(hardforks: HardForkConfig) -> RollupConfig {
+        RollupConfig { block_time: 2, hardforks, ..Default::default() }
+    }
+
+    fn panic_message(payload: Box<dyn Any + Send>) -> String {
+        let payload_ref = &*payload;
+        if let Some(message) = payload_ref.downcast_ref::<String>() {
+            return message.clone();
+        }
+        if let Some(message) = payload_ref.downcast_ref::<&str>() {
+            return (*message).to_owned();
+        }
+        "non-string panic payload".to_owned()
+    }
+
+    #[test]
+    fn all_covers_the_supported_hardfork_progression() {
+        let names: Vec<_> = ForkMatrix::all().iter().map(|(name, _)| name).collect();
+        assert_eq!(
+            names,
+            vec![
+                "regolith",
+                "canyon",
+                "delta",
+                "ecotone",
+                "fjord",
+                "granite",
+                "holocene",
+                "pectra-blob-schedule",
+                "isthmus",
+                "jovian",
+                "base-v1",
+            ]
+        );
+    }
+
+    #[test]
+    fn from_granite_matches_the_fault_proof_forks() {
+        let names: Vec<_> = ForkMatrix::from_granite().iter().map(|(name, _)| name).collect();
+        assert_eq!(names, vec!["granite", "holocene", "isthmus", "jovian"]);
+    }
+
+    #[test]
+    fn pre_isthmus_includes_pectra_and_excludes_isthmus_and_later() {
+        let names: Vec<_> = ForkMatrix::pre_isthmus().iter().map(|(name, _)| name).collect();
+        assert_eq!(names, vec!["granite", "holocene", "pectra-blob-schedule"]);
+    }
+
+    #[test]
+    fn from_isthmus_includes_only_op_forks_from_isthmus_onward() {
+        let names: Vec<_> = ForkMatrix::from_isthmus().iter().map(|(name, _)| name).collect();
+        assert_eq!(names, vec!["isthmus", "jovian"]);
+    }
+
+    #[test]
+    fn each_case_is_cumulative_without_enabling_the_next_fork() {
+        for (fork_name, hardforks) in ForkMatrix::all().iter() {
+            let cfg = test_rollup_config(hardforks);
+
+            match fork_name {
+                "regolith" => {
+                    assert!(cfg.is_regolith_active(0));
+                    assert!(!cfg.is_canyon_active(0));
+                }
+                "canyon" => {
+                    assert!(cfg.is_canyon_active(0));
+                    assert!(!cfg.is_delta_active(0));
+                }
+                "delta" => {
+                    assert!(cfg.is_delta_active(0));
+                    assert!(!cfg.is_ecotone_active(0));
+                }
+                "ecotone" => {
+                    assert!(cfg.is_ecotone_active(0));
+                    assert!(!cfg.is_fjord_active(0));
+                }
+                "fjord" => {
+                    assert!(cfg.is_fjord_active(0));
+                    assert!(!cfg.is_granite_active(0));
+                }
+                "granite" => {
+                    assert!(cfg.is_granite_active(0));
+                    assert!(!cfg.is_holocene_active(0));
+                }
+                "holocene" => {
+                    assert!(cfg.is_holocene_active(0));
+                    assert!(!cfg.is_pectra_blob_schedule_active(0));
+                    assert!(!cfg.is_isthmus_active(0));
+                }
+                "pectra-blob-schedule" => {
+                    assert!(cfg.is_holocene_active(0));
+                    assert!(cfg.is_pectra_blob_schedule_active(0));
+                    assert!(!cfg.is_isthmus_active(0));
+                }
+                "isthmus" => {
+                    assert!(cfg.is_isthmus_active(0));
+                    assert!(!cfg.is_jovian_active(0));
+                }
+                "jovian" => {
+                    assert!(cfg.is_jovian_active(0));
+                    assert!(!cfg.is_base_v1_active(0));
+                }
+                "base-v1" => {
+                    assert!(cfg.is_jovian_active(0));
+                    assert!(cfg.is_base_v1_active(0));
+                }
+                _ => unreachable!("unexpected fork {fork_name}"),
+            }
+        }
+    }
+
+    #[test]
+    fn run_includes_the_fork_name_in_panics() {
+        let panic = std::panic::catch_unwind(|| {
+            ForkMatrix::from_granite().run(|fork_name, _| {
+                assert_ne!(fork_name, "granite", "boom");
+            });
+        })
+        .expect_err("granite case must panic");
+
+        let message = panic_message(panic);
+        assert!(message.contains("granite"));
+        assert!(message.contains("boom"));
+    }
+}

--- a/actions/harness/tests/operator_fees.rs
+++ b/actions/harness/tests/operator_fees.rs
@@ -2,8 +2,8 @@
 
 use alloy_primitives::{Address, B256, LogData};
 use base_action_harness::{
-    ActionL2Source, ActionTestHarness, Batcher, BatcherConfig, DaType, EncoderConfig,
-    L1MinerConfig, SharedL1Chain, TestRollupConfigBuilder, block_info_from,
+    ActionL2Source, ActionTestHarness, Batcher, BatcherConfig, DaType, EncoderConfig, ForkMatrix,
+    L1MinerConfig, SharedL1Chain, TestRollupConfigBuilder, block_info_from, test_across_forks,
 };
 use base_alloy_consensus::{OpBlock, OpTxEnvelope};
 use base_consensus_genesis::{CONFIG_UPDATE_EVENT_VERSION_0, CONFIG_UPDATE_TOPIC};
@@ -42,79 +42,87 @@ fn l1_info_from_block(block: &OpBlock) -> L1BlockInfoTx {
 /// `operator_fee_constant` fields are absent from the calldata; the accessors
 /// on [`L1BlockInfoTx`] return zero for pre-Isthmus variants.
 ///
-/// All forks through Holocene are activated at genesis so that only Isthmus
-/// (and later) are absent. This ensures the Ecotone-format assertion reflects
-/// the intended pre-Isthmus state and not an accidentally inactive earlier fork.
+/// This assertion should hold for every post-Granite pre-Isthmus fork. Running
+/// the same test against both Granite and Holocene keeps the invariant covered
+/// as later forks are added to the harness matrix.
 #[test]
 fn operator_fee_not_encoded_before_isthmus() {
     let batcher_cfg = BatcherConfig::default();
-    // Holocene is the latest active fork; Isthmus and Jovian remain None so their
-    // mainnet timestamps are unreachable (L1 miner starts at ts=0).
-    let rollup_cfg = TestRollupConfigBuilder::base_mainnet(&batcher_cfg).through_holocene().build();
-    let h = ActionTestHarness::new(L1MinerConfig::default(), rollup_cfg);
-    let l1_chain = SharedL1Chain::from_blocks(h.l1.chain().to_vec());
-    let mut builder = h.create_l2_sequencer(l1_chain);
+    test_across_forks!(ForkMatrix::pre_isthmus(), |fork_name, hardforks| {
+        let rollup_cfg =
+            TestRollupConfigBuilder::base_mainnet(&batcher_cfg).with_hardforks(hardforks).build();
+        let h = ActionTestHarness::new(L1MinerConfig::default(), rollup_cfg);
+        let l1_chain = SharedL1Chain::from_blocks(h.l1.chain().to_vec());
+        let mut builder = h.create_l2_sequencer(l1_chain);
 
-    // Build one block and verify it uses the Ecotone format with zero operator fees.
-    let block = builder.build_next_block().expect("build block");
-    let l1_info = l1_info_from_block(&block);
+        // Build one block and verify it uses the Ecotone format with zero operator fees.
+        let block = builder.build_next_block().expect("build block");
+        let l1_info = l1_info_from_block(&block);
 
-    assert!(
-        matches!(l1_info, L1BlockInfoTx::Ecotone(_)),
-        "pre-Isthmus L1 info must use Ecotone format, got {l1_info:?}"
-    );
-    assert_eq!(l1_info.operator_fee_scalar(), 0, "operator_fee_scalar must be zero before Isthmus");
-    assert_eq!(
-        l1_info.operator_fee_constant(),
-        0,
-        "operator_fee_constant must be zero before Isthmus"
-    );
+        assert!(
+            matches!(l1_info, L1BlockInfoTx::Ecotone(_)),
+            "{fork_name}: pre-Isthmus L1 info must use Ecotone format, got {l1_info:?}"
+        );
+        assert_eq!(
+            l1_info.operator_fee_scalar(),
+            0,
+            "{fork_name}: operator_fee_scalar must be zero before Isthmus"
+        );
+        assert_eq!(
+            l1_info.operator_fee_constant(),
+            0,
+            "{fork_name}: operator_fee_constant must be zero before Isthmus"
+        );
+    });
 }
 
-/// Post-Isthmus L2 blocks carry an `Isthmus`-format L1 info deposit that
-/// encodes `operator_fee_scalar` and `operator_fee_constant` from the genesis
-/// [`SystemConfig`].
+/// From Isthmus onward, L2 blocks carry the active hardfork's L1 info format
+/// with `operator_fee_scalar` and `operator_fee_constant` encoded from the
+/// genesis [`SystemConfig`].
 ///
-/// Setting `isthmus_time = Some(0)` makes Isthmus active at genesis. Because
-/// `is_first_isthmus_block(ts)` checks
-/// `is_isthmus_active(ts) && !is_isthmus_active(ts − block_time)`, and with
-/// `isthmus_time = 0` the result is `true && !true = false` for every positive
-/// timestamp, no built block is treated as the transition block. Every
-/// sequencer-built block (ts ≥ 2) uses the full Isthmus calldata format.
+/// The matrix keeps the same invariant covered across both currently reachable
+/// post-Isthmus forks: Isthmus itself and Jovian.
 #[test]
-fn operator_fee_encoded_in_l1_info_post_isthmus() {
+fn operator_fee_encoded_in_l1_info_from_isthmus_onward() {
     const OPERATOR_FEE_SCALAR: u32 = 2_000;
     const OPERATOR_FEE_CONSTANT: u64 = 500;
 
     let batcher_cfg = BatcherConfig::default();
-    let mut rollup_cfg =
-        TestRollupConfigBuilder::base_mainnet(&batcher_cfg).through_isthmus().build();
-    let sys_cfg = rollup_cfg.genesis.system_config.as_mut().unwrap();
-    sys_cfg.operator_fee_scalar = Some(OPERATOR_FEE_SCALAR);
-    sys_cfg.operator_fee_constant = Some(OPERATOR_FEE_CONSTANT);
+    test_across_forks!(ForkMatrix::from_isthmus(), |fork_name, hardforks| {
+        let mut rollup_cfg =
+            TestRollupConfigBuilder::base_mainnet(&batcher_cfg).with_hardforks(hardforks).build();
+        let sys_cfg = rollup_cfg.genesis.system_config.as_mut().unwrap();
+        sys_cfg.operator_fee_scalar = Some(OPERATOR_FEE_SCALAR);
+        sys_cfg.operator_fee_constant = Some(OPERATOR_FEE_CONSTANT);
 
-    let h = ActionTestHarness::new(L1MinerConfig::default(), rollup_cfg);
-    let l1_chain = SharedL1Chain::from_blocks(h.l1.chain().to_vec());
-    let mut builder = h.create_l2_sequencer(l1_chain);
+        let h = ActionTestHarness::new(L1MinerConfig::default(), rollup_cfg);
+        let l1_chain = SharedL1Chain::from_blocks(h.l1.chain().to_vec());
+        let mut builder = h.create_l2_sequencer(l1_chain);
 
-    // Build one block and verify it uses the Isthmus format with the configured fee params.
-    let block = builder.build_next_block().expect("build block");
-    let l1_info = l1_info_from_block(&block);
+        // Build one block and verify it uses the active post-Isthmus format with
+        // the configured operator fee params.
+        let block = builder.build_next_block().expect("build block");
+        let l1_info = l1_info_from_block(&block);
 
-    assert!(
-        matches!(l1_info, L1BlockInfoTx::Isthmus(_)),
-        "post-Isthmus L1 info must use Isthmus format, got {l1_info:?}"
-    );
-    assert_eq!(
-        l1_info.operator_fee_scalar(),
-        OPERATOR_FEE_SCALAR,
-        "operator_fee_scalar must match the system config"
-    );
-    assert_eq!(
-        l1_info.operator_fee_constant(),
-        OPERATOR_FEE_CONSTANT,
-        "operator_fee_constant must match the system config"
-    );
+        let expected_format_matches = matches!(
+            (fork_name, &l1_info),
+            ("isthmus", L1BlockInfoTx::Isthmus(_)) | ("jovian", L1BlockInfoTx::Jovian(_))
+        );
+        assert!(
+            expected_format_matches,
+            "{fork_name}: post-Isthmus L1 info must use the active hardfork format, got {l1_info:?}"
+        );
+        assert_eq!(
+            l1_info.operator_fee_scalar(),
+            OPERATOR_FEE_SCALAR,
+            "{fork_name}: operator_fee_scalar must match the system config"
+        );
+        assert_eq!(
+            l1_info.operator_fee_constant(),
+            OPERATOR_FEE_CONSTANT,
+            "{fork_name}: operator_fee_constant must match the system config"
+        );
+    });
 }
 
 /// The L1 info format transitions from `Ecotone` to `Isthmus` across three

--- a/etc/docker/Dockerfile.proxyd
+++ b/etc/docker/Dockerfile.proxyd
@@ -1,11 +1,11 @@
-FROM golang:1.23-alpine3.20 AS builder
+FROM public.ecr.aws/docker/library/golang:1.23-alpine3.20 AS builder
 RUN apk add --no-cache make git gcc musl-dev
 WORKDIR /app
 RUN git clone --depth 1 --branch release-rb https://github.com/base/infra-routing.git .
 WORKDIR /app/proxyd
 RUN go build -o /bin/proxyd ./cmd/proxyd
 
-FROM alpine:3.20
+FROM public.ecr.aws/docker/library/alpine:3.20
 RUN apk add --no-cache ca-certificates curl
 COPY --from=builder /bin/proxyd /bin/proxyd
 ENTRYPOINT ["/bin/proxyd"]


### PR DESCRIPTION
  Add reusable hardfork matrix helpers to the action harness, and migrate operator fee coverage to range-based fork matrices that now pick up newly scheduled pre-Isthmus and post-Isthmus forks automatically.  