### PR TITLE
fix(CHAIN-3595): Feature-gate risc0 proving deps to avoid Metal kernel build on macOS

### DIFF
--- a/crates/proof/tee/nitro-attestation-prover/Cargo.toml
+++ b/crates/proof/tee/nitro-attestation-prover/Cargo.toml
@@ -12,24 +12,34 @@ repository.workspace = true
 workspace = true
 
 [dependencies]
-# Proving
-boundless-market.workspace = true
-risc0-ethereum-contracts.workspace = true
-risc0-zkvm = { workspace = true, features = ["prove"] }
-
-# Verification types
+# Verification types (always available)
 base-proof-tee-nitro-verifier.workspace = true
 
-# Types
-url.workspace = true
-alloy-primitives.workspace = true
-alloy-signer-local.workspace = true
-
-# Async / error / tracing
-tracing.workspace = true
+# Types / traits (always available)
 thiserror.workspace = true
 async-trait.workspace = true
-tokio = { workspace = true, features = ["rt"] }
+alloy-primitives.workspace = true
+
+# Proving backends (behind `prove` feature to avoid pulling in risc0-sys
+# and its Metal kernel build requirement on macOS)
+url = { workspace = true, optional = true }
+tracing = { workspace = true, optional = true }
+boundless-market = { workspace = true, optional = true }
+alloy-signer-local = { workspace = true, optional = true }
+risc0-ethereum-contracts = { workspace = true, optional = true }
+tokio = { workspace = true, features = ["rt"], optional = true }
+risc0-zkvm = { workspace = true, features = ["prove"], optional = true }
 
 [dev-dependencies]
 rstest.workspace = true
+
+[features]
+prove = [
+    "dep:boundless-market",
+    "dep:risc0-ethereum-contracts",
+    "dep:risc0-zkvm",
+    "dep:url",
+    "dep:alloy-signer-local",
+    "dep:tracing",
+    "dep:tokio",
+]

--- a/crates/proof/tee/nitro-attestation-prover/Cargo.toml
+++ b/crates/proof/tee/nitro-attestation-prover/Cargo.toml
@@ -35,11 +35,11 @@ rstest.workspace = true
 
 [features]
 prove = [
-    "dep:boundless-market",
-    "dep:risc0-ethereum-contracts",
-    "dep:risc0-zkvm",
-    "dep:url",
-    "dep:alloy-signer-local",
-    "dep:tracing",
-    "dep:tokio",
+	"dep:alloy-signer-local",
+	"dep:boundless-market",
+	"dep:risc0-ethereum-contracts",
+	"dep:risc0-zkvm",
+	"dep:tokio",
+	"dep:tracing",
+	"dep:url",
 ]

--- a/crates/proof/tee/nitro-attestation-prover/src/lib.rs
+++ b/crates/proof/tee/nitro-attestation-prover/src/lib.rs
@@ -7,8 +7,12 @@ pub use error::{ProverError, Result};
 mod types;
 pub use types::{AttestationProof, AttestationProofProvider};
 
+#[cfg(feature = "prove")]
 mod direct;
+#[cfg(feature = "prove")]
 pub use direct::DirectProver;
 
+#[cfg(feature = "prove")]
 mod boundless;
+#[cfg(feature = "prove")]
 pub use boundless::BoundlessProver;


### PR DESCRIPTION
## Summary

- Gates `risc0-zkvm`, `boundless-market`, `risc0-ethereum-contracts`, and related deps behind an optional `prove` feature on `base-proof-tee-nitro-attestation-prover`
- `DirectProver` and `BoundlessProver` are conditionally compiled with `#[cfg(feature = "prove")]`; the trait, types, and errors remain always-available
- `cargo check` on the workspace no longer triggers `risc0-sys` Metal kernel compilation, which previously required full Xcode on macOS
- The registrar library depends on the prover crate without `prove` (only needs the trait + error types); the binary will enable `prove` when CHAIN-3455 lands

## Test plan

- [x] `cargo check` on full workspace — no Metal/risc0-sys compilation
- [x] `cargo check -p base-proof-tee-nitro-attestation-prover` — compiles without Xcode
- [x] `cargo test --lib` without `prove` — 9 tests pass (error + types)
- [x] `cargo test --lib --features prove` — 23 tests pass (all including prover impls)
- [x] `cargo check -p base-proof-tee-registrar` — builds clean without risc0