### PR TITLE
feat(harness): Add ForkMatrix for Parametrized Hardfork

### DIFF
--- a/actions/harness/src/lib.rs
+++ b/actions/harness/src/lib.rs
@@ -24,6 +24,9 @@ mod batcher;
 pub use base_batcher_encoder::{BatchType, DaType, EncoderConfig};
 pub use batcher::{Batcher, BatcherConfig, BatcherError, L1MinerTxManager};
 
+mod matrix;
+pub use matrix::ForkMatrix;
+
 mod test_rollup_config;
 pub use test_rollup_config::TestRollupConfigBuilder;
 

--- a/actions/harness/src/matrix.rs
+++ b/actions/harness/src/matrix.rs
@@ -1,0 +1,260 @@
+use std::{
+    any::Any,
+    panic::{self, AssertUnwindSafe},
+};
+
+use base_consensus_genesis::{BaseHardforkConfig, HardForkConfig};
+
+type ForkSetter = fn(&mut HardForkConfig);
+
+/// All supported hardfork stages in canonical order. Each setter activates
+/// exactly one additional fork; [`ForkMatrix::all`] applies these in sequence
+/// to produce a cumulative snapshot after each step.
+///
+/// To add a new fork: insert one entry here in the correct position. All
+/// matrix constructors update automatically.
+static FORK_PROGRESSION: &[(&str, ForkSetter)] = &[
+    ("regolith", |h| h.regolith_time = Some(0)),
+    ("canyon", |h| h.canyon_time = Some(0)),
+    ("delta", |h| h.delta_time = Some(0)),
+    ("ecotone", |h| h.ecotone_time = Some(0)),
+    ("fjord", |h| h.fjord_time = Some(0)),
+    ("granite", |h| h.granite_time = Some(0)),
+    ("holocene", |h| h.holocene_time = Some(0)),
+    ("pectra-blob-schedule", |h| h.pectra_blob_schedule_time = Some(0)),
+    ("isthmus", |h| h.isthmus_time = Some(0)),
+    ("jovian", |h| h.jovian_time = Some(0)),
+    ("base-v1", |h| h.base.get_or_insert_with(BaseHardforkConfig::default).v1 = Some(0)),
+];
+
+/// Named hardfork schedules for parametrizing harness tests across protocol upgrades.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct ForkMatrix {
+    forks: Vec<(&'static str, HardForkConfig)>,
+}
+
+impl ForkMatrix {
+    /// Returns every cumulative hardfork stage supported by the harness.
+    ///
+    /// Each entry activates one additional fork on top of all previous ones,
+    /// derived automatically from [`FORK_PROGRESSION`].
+    pub fn all() -> Self {
+        Self::build(FORK_PROGRESSION, HardForkConfig::default())
+    }
+
+    /// Returns the cumulative forks from Granite through Holocene (pre-Isthmus).
+    ///
+    /// Includes the `pectra-blob-schedule` compatibility patch, which sits
+    /// between Holocene and Isthmus in the progression.
+    pub fn pre_isthmus() -> Self {
+        Self::all().retain(|_, h| h.granite_time.is_some() && h.isthmus_time.is_none())
+    }
+
+    /// Returns the cumulative OP hardforks from Isthmus onward.
+    ///
+    /// Base-specific forks (e.g. `base-v1`) are excluded.
+    pub fn from_isthmus() -> Self {
+        Self::all().retain(|_, h| h.isthmus_time.is_some() && h.base.is_none())
+    }
+
+    /// Returns the canonical OP fault-proof fork progression from Granite onward.
+    ///
+    /// The `pectra-blob-schedule` compatibility patch (a Base Sepolia-only quirk)
+    /// and Base-specific forks are excluded; this matrix covers only the upstream
+    /// OP mainnet upgrade sequence.
+    pub fn from_granite() -> Self {
+        static PROGRESSION: &[(&str, ForkSetter)] = &[
+            ("granite", |h| h.granite_time = Some(0)),
+            ("holocene", |h| h.holocene_time = Some(0)),
+            ("isthmus", |h| h.isthmus_time = Some(0)),
+            ("jovian", |h| h.jovian_time = Some(0)),
+        ];
+        Self::build(
+            PROGRESSION,
+            HardForkConfig {
+                regolith_time: Some(0),
+                canyon_time: Some(0),
+                delta_time: Some(0),
+                ecotone_time: Some(0),
+                fjord_time: Some(0),
+                ..Default::default()
+            },
+        )
+    }
+
+    /// Iterates through the named fork schedules.
+    pub fn iter(&self) -> impl Iterator<Item = (&'static str, HardForkConfig)> + '_ {
+        self.forks.iter().copied()
+    }
+
+    /// Keeps only the fork schedules matching the predicate.
+    pub fn retain<F>(mut self, mut f: F) -> Self
+    where
+        F: FnMut(&'static str, HardForkConfig) -> bool,
+    {
+        self.forks.retain(|(name, config)| f(name, *config));
+        self
+    }
+
+    /// Runs a test closure once per configured fork, annotating any panic with the fork name.
+    pub fn run<F>(&self, mut test: F)
+    where
+        F: FnMut(&'static str, HardForkConfig),
+    {
+        for (name, config) in self.iter() {
+            if let Err(e) = panic::catch_unwind(AssertUnwindSafe(|| test(name, config))) {
+                Self::panic_with_fork_context(name, e);
+            }
+        }
+    }
+
+    fn build(progression: &[(&'static str, ForkSetter)], base: HardForkConfig) -> Self {
+        let mut config = base;
+        Self {
+            forks: progression
+                .iter()
+                .map(|(name, apply)| {
+                    apply(&mut config);
+                    (*name, config)
+                })
+                .collect(),
+        }
+    }
+
+    fn panic_with_fork_context(fork: &str, payload: Box<dyn Any + Send + 'static>) -> ! {
+        let msg = payload
+            .downcast_ref::<String>()
+            .map(String::as_str)
+            .or_else(|| payload.downcast_ref::<&str>().copied())
+            .unwrap_or("non-string panic payload");
+        panic!("fork matrix case `{fork}` failed: {msg}");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use base_consensus_genesis::RollupConfig;
+
+    use super::*;
+
+    fn rollup_config(hardforks: HardForkConfig) -> RollupConfig {
+        RollupConfig { block_time: 2, hardforks, ..Default::default() }
+    }
+
+    fn panic_message(payload: Box<dyn Any + Send>) -> String {
+        payload
+            .downcast_ref::<String>()
+            .cloned()
+            .or_else(|| payload.downcast_ref::<&str>().map(|s| (*s).to_owned()))
+            .unwrap_or_else(|| "non-string panic payload".to_owned())
+    }
+
+    #[test]
+    fn all_covers_the_supported_hardfork_progression() {
+        let names: Vec<_> = ForkMatrix::all().iter().map(|(name, _)| name).collect();
+        assert_eq!(
+            names,
+            vec![
+                "regolith",
+                "canyon",
+                "delta",
+                "ecotone",
+                "fjord",
+                "granite",
+                "holocene",
+                "pectra-blob-schedule",
+                "isthmus",
+                "jovian",
+                "base-v1",
+            ]
+        );
+    }
+
+    #[test]
+    fn from_granite_matches_the_fault_proof_forks() {
+        let names: Vec<_> = ForkMatrix::from_granite().iter().map(|(name, _)| name).collect();
+        assert_eq!(names, vec!["granite", "holocene", "isthmus", "jovian"]);
+    }
+
+    #[test]
+    fn pre_isthmus_includes_pectra_and_excludes_isthmus_and_later() {
+        let names: Vec<_> = ForkMatrix::pre_isthmus().iter().map(|(name, _)| name).collect();
+        assert_eq!(names, vec!["granite", "holocene", "pectra-blob-schedule"]);
+    }
+
+    #[test]
+    fn from_isthmus_includes_only_op_forks_from_isthmus_onward() {
+        let names: Vec<_> = ForkMatrix::from_isthmus().iter().map(|(name, _)| name).collect();
+        assert_eq!(names, vec!["isthmus", "jovian"]);
+    }
+
+    #[test]
+    fn each_case_is_cumulative_without_enabling_the_next_fork() {
+        for (fork_name, hardforks) in ForkMatrix::all().iter() {
+            let cfg = rollup_config(hardforks);
+            match fork_name {
+                "regolith" => {
+                    assert!(cfg.is_regolith_active(0));
+                    assert!(!cfg.is_canyon_active(0));
+                }
+                "canyon" => {
+                    assert!(cfg.is_canyon_active(0));
+                    assert!(!cfg.is_delta_active(0));
+                }
+                "delta" => {
+                    assert!(cfg.is_delta_active(0));
+                    assert!(!cfg.is_ecotone_active(0));
+                }
+                "ecotone" => {
+                    assert!(cfg.is_ecotone_active(0));
+                    assert!(!cfg.is_fjord_active(0));
+                }
+                "fjord" => {
+                    assert!(cfg.is_fjord_active(0));
+                    assert!(!cfg.is_granite_active(0));
+                }
+                "granite" => {
+                    assert!(cfg.is_granite_active(0));
+                    assert!(!cfg.is_holocene_active(0));
+                }
+                "holocene" => {
+                    assert!(cfg.is_holocene_active(0));
+                    assert!(!cfg.is_pectra_blob_schedule_active(0));
+                    assert!(!cfg.is_isthmus_active(0));
+                }
+                "pectra-blob-schedule" => {
+                    assert!(cfg.is_holocene_active(0));
+                    assert!(cfg.is_pectra_blob_schedule_active(0));
+                    assert!(!cfg.is_isthmus_active(0));
+                }
+                "isthmus" => {
+                    assert!(cfg.is_isthmus_active(0));
+                    assert!(!cfg.is_jovian_active(0));
+                }
+                "jovian" => {
+                    assert!(cfg.is_jovian_active(0));
+                    assert!(!cfg.is_base_v1_active(0));
+                }
+                "base-v1" => {
+                    assert!(cfg.is_jovian_active(0));
+                    assert!(cfg.is_base_v1_active(0));
+                }
+                _ => unreachable!("unexpected fork {fork_name}"),
+            }
+        }
+    }
+
+    #[test]
+    fn run_includes_the_fork_name_in_panics() {
+        let panic = std::panic::catch_unwind(|| {
+            ForkMatrix::from_granite().run(|fork_name, _| {
+                assert_ne!(fork_name, "granite", "boom");
+            });
+        })
+        .expect_err("granite case must panic");
+
+        let message = panic_message(panic);
+        assert!(message.contains("granite"));
+        assert!(message.contains("boom"));
+    }
+}

--- a/actions/harness/src/matrix.rs
+++ b/actions/harness/src/matrix.rs
@@ -3,7 +3,7 @@ use std::{
     panic::{self, AssertUnwindSafe},
 };
 
-use base_consensus_genesis::{BaseHardforkConfig, HardForkConfig};
+use base_consensus_genesis::HardForkConfig;
 
 type ForkSetter = fn(&mut HardForkConfig);
 
@@ -24,7 +24,7 @@ static FORK_PROGRESSION: &[(&str, ForkSetter)] = &[
     ("pectra-blob-schedule", |h| h.pectra_blob_schedule_time = Some(0)),
     ("isthmus", |h| h.isthmus_time = Some(0)),
     ("jovian", |h| h.jovian_time = Some(0)),
-    ("base-v1", |h| h.base.get_or_insert_with(BaseHardforkConfig::default).v1 = Some(0)),
+    ("base-v1", |h| h.base.v1 = Some(0)),
 ];
 
 /// Named hardfork schedules for parametrizing harness tests across protocol upgrades.
@@ -54,7 +54,7 @@ impl ForkMatrix {
     ///
     /// Base-specific forks (e.g. `base-v1`) are excluded.
     pub fn from_isthmus() -> Self {
-        Self::all().retain(|_, h| h.isthmus_time.is_some() && h.base.is_none())
+        Self::all().retain(|_, h| h.isthmus_time.is_some() && h.base.is_empty())
     }
 
     /// Returns the canonical OP fault-proof fork progression from Granite onward.

--- a/actions/harness/tests/operator_fees.rs
+++ b/actions/harness/tests/operator_fees.rs
@@ -2,7 +2,7 @@
 
 use alloy_primitives::Address;
 use base_action_harness::{
-    ActionL2Source, ActionTestHarness, Batcher, BatcherConfig, DaType, EncoderConfig,
+    ActionL2Source, ActionTestHarness, Batcher, BatcherConfig, DaType, EncoderConfig, ForkMatrix,
     L1MinerConfig, SharedL1Chain, TestRollupConfigBuilder,
 };
 use base_protocol::L1BlockInfoTx;
@@ -26,79 +26,93 @@ use base_protocol::L1BlockInfoTx;
 /// `operator_fee_constant` fields are absent from the calldata; the accessors
 /// on [`L1BlockInfoTx`] return zero for pre-Isthmus variants.
 ///
-/// All forks through Holocene are activated at genesis so that only Isthmus
-/// (and later) are absent. This ensures the Ecotone-format assertion reflects
-/// the intended pre-Isthmus state and not an accidentally inactive earlier fork.
+/// This assertion holds for every post-Granite pre-Isthmus fork. Running the
+/// same test across Granite, Holocene, and the pectra-blob-schedule patch keeps
+/// the invariant covered as later forks are added to the harness matrix.
 #[test]
 fn operator_fee_not_encoded_before_isthmus() {
     let batcher_cfg = BatcherConfig::default();
-    // Holocene is the latest active fork; Isthmus and Jovian remain None so their
-    // mainnet timestamps are unreachable (L1 miner starts at ts=0).
-    let rollup_cfg = TestRollupConfigBuilder::base_mainnet(&batcher_cfg).through_holocene().build();
-    let h = ActionTestHarness::new(L1MinerConfig::default(), rollup_cfg);
-    let l1_chain = SharedL1Chain::from_blocks(h.l1.chain().to_vec());
-    let mut builder = h.create_l2_sequencer(l1_chain);
+    ForkMatrix::pre_isthmus().run(|fork_name, hardforks| {
+        let rollup_cfg =
+            TestRollupConfigBuilder::base_mainnet(&batcher_cfg).with_hardforks(hardforks).build();
+        let h = ActionTestHarness::new(L1MinerConfig::default(), rollup_cfg);
+        let l1_chain = SharedL1Chain::from_blocks(h.l1.chain().to_vec());
+        let mut builder = h.create_l2_sequencer(l1_chain);
 
-    // Build one block and verify it uses the Ecotone format with zero operator fees.
-    let block = builder.build_next_block();
-    let l1_info = ActionTestHarness::l1_info_from_block(&block);
+        // Build one block and verify it uses the Ecotone format with zero operator fees.
+        let block = builder.build_next_block();
+        let l1_info = ActionTestHarness::l1_info_from_block(&block);
 
-    assert!(
-        matches!(l1_info, L1BlockInfoTx::Ecotone(_)),
-        "pre-Isthmus L1 info must use Ecotone format, got {l1_info:?}"
-    );
-    assert_eq!(l1_info.operator_fee_scalar(), 0, "operator_fee_scalar must be zero before Isthmus");
-    assert_eq!(
-        l1_info.operator_fee_constant(),
-        0,
-        "operator_fee_constant must be zero before Isthmus"
-    );
+        assert!(
+            matches!(l1_info, L1BlockInfoTx::Ecotone(_)),
+            "{fork_name}: pre-Isthmus L1 info must use Ecotone format, got {l1_info:?}"
+        );
+        assert_eq!(
+            l1_info.operator_fee_scalar(),
+            0,
+            "{fork_name}: operator_fee_scalar must be zero before Isthmus"
+        );
+        assert_eq!(
+            l1_info.operator_fee_constant(),
+            0,
+            "{fork_name}: operator_fee_constant must be zero before Isthmus"
+        );
+    });
 }
 
-/// Post-Isthmus L2 blocks carry an `Isthmus`-format L1 info deposit that
-/// encodes `operator_fee_scalar` and `operator_fee_constant` from the genesis
-/// [`SystemConfig`].
+/// From Isthmus onward, L2 blocks carry the active hardfork's L1 info format
+/// with `operator_fee_scalar` and `operator_fee_constant` encoded from the
+/// genesis [`SystemConfig`].
 ///
-/// Setting `isthmus_time = Some(0)` makes Isthmus active at genesis. Because
-/// `is_first_isthmus_block(ts)` checks
-/// `is_isthmus_active(ts) && !is_isthmus_active(ts − block_time)`, and with
-/// `isthmus_time = 0` the result is `true && !true = false` for every positive
-/// timestamp, no built block is treated as the transition block. Every
-/// sequencer-built block (ts ≥ 2) uses the full Isthmus calldata format.
+/// Setting fork activation times to `Some(0)` makes all forks active at genesis.
+/// Because `is_first_<fork>_block(ts)` checks `is_active(ts) && !is_active(ts −
+/// block_time)`, with activation at 0 the condition is `true && !true = false`
+/// for every positive timestamp — no sequencer-built block is treated as the
+/// transition block. Every block (ts ≥ 2) uses the full active hardfork format.
+///
+/// The matrix keeps the same invariant covered across both reachable post-Isthmus
+/// forks: Isthmus itself and Jovian.
 #[test]
-fn operator_fee_encoded_in_l1_info_post_isthmus() {
+fn operator_fee_encoded_in_l1_info_from_isthmus_onward() {
     const OPERATOR_FEE_SCALAR: u32 = 2_000;
     const OPERATOR_FEE_CONSTANT: u64 = 500;
 
     let batcher_cfg = BatcherConfig::default();
-    let mut rollup_cfg =
-        TestRollupConfigBuilder::base_mainnet(&batcher_cfg).through_isthmus().build();
-    let sys_cfg = rollup_cfg.genesis.system_config.as_mut().unwrap();
-    sys_cfg.operator_fee_scalar = Some(OPERATOR_FEE_SCALAR);
-    sys_cfg.operator_fee_constant = Some(OPERATOR_FEE_CONSTANT);
+    ForkMatrix::from_isthmus().run(|fork_name, hardforks| {
+        let mut rollup_cfg =
+            TestRollupConfigBuilder::base_mainnet(&batcher_cfg).with_hardforks(hardforks).build();
+        let sys_cfg = rollup_cfg.genesis.system_config.as_mut().unwrap();
+        sys_cfg.operator_fee_scalar = Some(OPERATOR_FEE_SCALAR);
+        sys_cfg.operator_fee_constant = Some(OPERATOR_FEE_CONSTANT);
 
-    let h = ActionTestHarness::new(L1MinerConfig::default(), rollup_cfg);
-    let l1_chain = SharedL1Chain::from_blocks(h.l1.chain().to_vec());
-    let mut builder = h.create_l2_sequencer(l1_chain);
+        let h = ActionTestHarness::new(L1MinerConfig::default(), rollup_cfg);
+        let l1_chain = SharedL1Chain::from_blocks(h.l1.chain().to_vec());
+        let mut builder = h.create_l2_sequencer(l1_chain);
 
-    // Build one block and verify it uses the Isthmus format with the configured fee params.
-    let block = builder.build_next_block();
-    let l1_info = ActionTestHarness::l1_info_from_block(&block);
+        // Build one block and verify it uses the active post-Isthmus format with
+        // the configured operator fee params.
+        let block = builder.build_next_block();
+        let l1_info = ActionTestHarness::l1_info_from_block(&block);
 
-    assert!(
-        matches!(l1_info, L1BlockInfoTx::Isthmus(_)),
-        "post-Isthmus L1 info must use Isthmus format, got {l1_info:?}"
-    );
-    assert_eq!(
-        l1_info.operator_fee_scalar(),
-        OPERATOR_FEE_SCALAR,
-        "operator_fee_scalar must match the system config"
-    );
-    assert_eq!(
-        l1_info.operator_fee_constant(),
-        OPERATOR_FEE_CONSTANT,
-        "operator_fee_constant must match the system config"
-    );
+        let expected_format = matches!(
+            (fork_name, &l1_info),
+            ("isthmus", L1BlockInfoTx::Isthmus(_)) | ("jovian", L1BlockInfoTx::Jovian(_))
+        );
+        assert!(
+            expected_format,
+            "{fork_name}: post-Isthmus L1 info must use the active hardfork format, got {l1_info:?}"
+        );
+        assert_eq!(
+            l1_info.operator_fee_scalar(),
+            OPERATOR_FEE_SCALAR,
+            "{fork_name}: operator_fee_scalar must match the system config"
+        );
+        assert_eq!(
+            l1_info.operator_fee_constant(),
+            OPERATOR_FEE_CONSTANT,
+            "{fork_name}: operator_fee_constant must match the system config"
+        );
+    });
 }
 
 /// The L1 info format transitions from `Ecotone` to `Isthmus` across three


### PR DESCRIPTION
## Summary

Replaces #1462.

Adds `ForkMatrix`, a concise test helper for running the same assertion across every hardfork stage without hand-writing cumulative `HardForkConfig` structs.

A single `FORK_PROGRESSION` static drives `all()`: each entry is one `fn(&mut HardForkConfig)` setter; `build()` applies them in sequence to produce a cumulative snapshot after each step. Adding a new fork is a one-line change to the table. The filtered constructors (`pre_isthmus`, `from_isthmus`, `from_granite`) all derive from `all()` or its subset with a single `retain` predicate, so they update automatically.

Migrates the two operator-fee tests that previously fixed a single fork to run across the full relevant slice of the matrix.