### PR TITLE
chore(batcher): Remove Manual Trait Impls

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2727,6 +2727,7 @@ name = "base-batcher-admin"
 version = "0.0.0"
 dependencies = [
  "base-batcher-core",
+ "derive_more",
  "eyre",
  "jsonrpsee",
  "tracing",
@@ -2812,6 +2813,7 @@ dependencies = [
  "base-consensus-rpc",
  "base-runtime",
  "base-tx-manager",
+ "derive_more",
  "eyre",
  "futures",
  "httpmock",
@@ -2832,6 +2834,7 @@ dependencies = [
  "base-alloy-consensus",
  "base-protocol",
  "base-runtime",
+ "derive_more",
  "futures",
  "thiserror 2.0.18",
  "tokio",
@@ -3163,6 +3166,7 @@ dependencies = [
  "base-consensus-genesis",
  "base-protocol",
  "brotli",
+ "derive_more",
  "miniz_oxide 0.9.1",
  "proptest",
  "rand 0.9.2",

--- a/crates/batcher/admin/Cargo.toml
+++ b/crates/batcher/admin/Cargo.toml
@@ -15,4 +15,5 @@ workspace = true
 eyre.workspace = true
 base-batcher-core.workspace = true
 tracing = { workspace = true, features = ["std"] }
+derive_more = { workspace = true, features = ["debug"] }
 jsonrpsee = { workspace = true, features = ["server", "macros"] }

--- a/crates/batcher/admin/src/server.rs
+++ b/crates/batcher/admin/src/server.rs
@@ -1,6 +1,6 @@
 //! Admin JSON-RPC HTTP server lifecycle.
 
-use std::{fmt, net::SocketAddr};
+use std::net::SocketAddr;
 
 use base_batcher_core::AdminHandle;
 use eyre::Context;
@@ -13,14 +13,10 @@ use crate::{BatcherAdminApiServer, BatcherAdminApiServerImpl};
 ///
 /// Holds the jsonrpsee [`ServerHandle`] for the server's lifetime.
 /// Dropping this value stops the server from accepting new connections.
+#[derive(derive_more::Debug)]
 pub struct AdminServer {
+    #[debug(skip)]
     handle: ServerHandle,
-}
-
-impl fmt::Debug for AdminServer {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("AdminServer").finish_non_exhaustive()
-    }
 }
 
 impl AdminServer {

--- a/crates/batcher/comp/Cargo.toml
+++ b/crates/batcher/comp/Cargo.toml
@@ -20,6 +20,7 @@ base-protocol.workspace = true
 base-alloy-consensus.workspace = true
 base-consensus-genesis.workspace = true
 rand = { workspace = true, features = ["small_rng"] }
+derive_more = { workspace = true, features = ["debug"] }
 
 brotli = { workspace = true, optional = true }
 alloy-primitives = { workspace = true, optional = true }

--- a/crates/batcher/comp/src/channel_out.rs
+++ b/crates/batcher/comp/src/channel_out.rs
@@ -1,6 +1,6 @@
 //! Contains the `ChannelOut` primitive for Base.
 
-use alloc::{fmt, sync::Arc, vec, vec::Vec};
+use alloc::{sync::Arc, vec, vec::Vec};
 
 use alloy_rlp::Encodable;
 use base_consensus_genesis::RollupConfig;
@@ -36,6 +36,7 @@ pub enum ChannelOutError {
 }
 
 /// [`ChannelOut`] constructs a channel from compressed, encoded batch data.
+#[derive(derive_more::Debug)]
 pub struct ChannelOut<C>
 where
     C: ChannelCompressor,
@@ -44,6 +45,7 @@ where
     pub id: ChannelId,
     /// The [`RollupConfig`] used to check the max RLP bytes per channel when
     /// encoding and accepting batches.
+    #[debug(skip)]
     pub config: Arc<RollupConfig>,
     /// The rlp length of the channel.
     pub rlp_length: u64,
@@ -52,18 +54,8 @@ where
     /// The frame number.
     pub frame_number: u16,
     /// The compressor.
+    #[debug(skip)]
     pub compressor: C,
-}
-
-impl<C: ChannelCompressor> fmt::Debug for ChannelOut<C> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("ChannelOut")
-            .field("id", &self.id)
-            .field("rlp_length", &self.rlp_length)
-            .field("frame_number", &self.frame_number)
-            .field("closed", &self.closed)
-            .finish_non_exhaustive()
-    }
 }
 
 impl<C> ChannelOut<C>

--- a/crates/batcher/core/Cargo.toml
+++ b/crates/batcher/core/Cargo.toml
@@ -29,7 +29,7 @@ thiserror = { workspace = true, features = ["std"] }
 serde = { workspace = true, features = ["derive", "std"] }
 alloy-primitives = { workspace = true, features = ["std"] }
 tokio = { workspace = true, features = ["sync", "macros", "rt"] }
-derive_more = { workspace = true, features = ["display", "from_str"] }
+derive_more = { workspace = true, features = ["debug", "display", "from_str"] }
 
 # optional — activated by the `test-utils` feature
 async-trait = { workspace = true, optional = true }

--- a/crates/batcher/core/src/admin.rs
+++ b/crates/batcher/core/src/admin.rs
@@ -38,6 +38,7 @@ pub enum AdminError {
 pub type AdminResult<T> = Result<T, AdminError>;
 
 /// Commands the admin HTTP server can send to the running driver task.
+#[derive(derive_more::Debug)]
 pub enum AdminCommand {
     /// Resume block ingestion after a [`Pause`](Self::Pause).
     Resume,
@@ -50,6 +51,7 @@ pub enum AdminCommand {
         /// The new throttle strategy to apply.
         strategy: ThrottleStrategy,
         /// The new throttle configuration to apply.
+        #[debug(skip)]
         config: ThrottleConfig,
     },
     /// Clear the throttle dedup cache so limits are re-applied unconditionally.
@@ -57,29 +59,15 @@ pub enum AdminCommand {
     /// Read current throttle state; reply sent via the embedded oneshot sender.
     GetThrottleInfo {
         /// Channel to send the throttle info snapshot back on.
+        #[debug(skip)]
         reply: oneshot::Sender<ThrottleInfo>,
     },
     /// Read current driver runtime state; reply sent via the embedded oneshot sender.
     GetStatus {
         /// Channel to send the batcher status back on.
+        #[debug(skip)]
         reply: oneshot::Sender<BatcherStatus>,
     },
-}
-
-impl std::fmt::Debug for AdminCommand {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::Resume => write!(f, "Resume"),
-            Self::Pause => write!(f, "Pause"),
-            Self::Flush => write!(f, "Flush"),
-            Self::SetThrottle { strategy, .. } => {
-                f.debug_struct("SetThrottle").field("strategy", strategy).finish()
-            }
-            Self::ResetThrottle => write!(f, "ResetThrottle"),
-            Self::GetThrottleInfo { .. } => f.debug_struct("GetThrottleInfo").finish(),
-            Self::GetStatus { .. } => f.debug_struct("GetStatus").finish(),
-        }
-    }
 }
 
 /// Cloneable handle to the driver's admin command channel.

--- a/crates/batcher/service/Cargo.toml
+++ b/crates/batcher/service/Cargo.toml
@@ -23,6 +23,7 @@ base-batcher-admin.workspace = true
 base-alloy-network.workspace = true
 base-batcher-source.workspace = true
 base-batcher-encoder.workspace = true
+derive_more = { workspace = true, features = ["debug"] }
 tracing = { workspace = true, features = ["std"] }
 base-runtime = { workspace = true, features = ["tokio"] }
 alloy-signer-local.workspace = true

--- a/crates/batcher/service/src/l1_source.rs
+++ b/crates/batcher/service/src/l1_source.rs
@@ -8,14 +8,10 @@ use base_batcher_source::{L1HeadPolling, L1HeadSubscription, SourceError};
 use futures::{StreamExt, stream::BoxStream};
 
 /// Polling source that fetches the latest L1 head block number from an L1 RPC endpoint.
+#[derive(derive_more::Debug)]
 pub struct RpcL1HeadPollingSource {
+    #[debug(skip)]
     provider: Arc<dyn Provider + Send + Sync>,
-}
-
-impl std::fmt::Debug for RpcL1HeadPollingSource {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("RpcL1HeadPollingSource").finish_non_exhaustive()
-    }
 }
 
 impl RpcL1HeadPollingSource {
@@ -40,8 +36,11 @@ impl L1HeadPolling for RpcL1HeadPollingSource {
 ///
 /// [`HybridL1HeadSource`]: base_batcher_source::HybridL1HeadSource
 /// [`take_stream`]: L1HeadSubscription::take_stream
+#[derive(derive_more::Debug)]
 pub struct WsL1HeadSubscription {
+    #[debug(skip)]
     _provider: Arc<dyn std::any::Any + Send + Sync>,
+    #[debug("{:?}", stream.as_ref().map(|_| "<stream>"))]
     stream: Option<BoxStream<'static, Result<u64, SourceError>>>,
 }
 
@@ -52,14 +51,6 @@ impl WsL1HeadSubscription {
         stream: BoxStream<'static, Result<u64, SourceError>>,
     ) -> Self {
         Self { _provider: provider, stream: Some(stream) }
-    }
-}
-
-impl std::fmt::Debug for WsL1HeadSubscription {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("WsL1HeadSubscription")
-            .field("stream", &self.stream.as_ref().map(|_| "<stream>"))
-            .finish_non_exhaustive()
     }
 }
 

--- a/crates/batcher/service/src/service.rs
+++ b/crates/batcher/service/src/service.rs
@@ -99,15 +99,12 @@ type ServiceDriver = BatchDriver<
 /// Created by [`BatcherService::setup`]. All connections are live and the
 /// rollup config has been fetched. Call [`run`](Self::run) to enter the
 /// main driver loop, or spawn it in a background task for in-process use.
+#[derive(derive_more::Debug)]
 pub struct ReadyBatcher {
+    #[debug(skip)]
     driver: ServiceDriver,
+    #[debug(skip)]
     admin_server: Option<AdminServer>,
-}
-
-impl std::fmt::Debug for ReadyBatcher {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("ReadyBatcher").finish_non_exhaustive()
-    }
 }
 
 impl ReadyBatcher {

--- a/crates/batcher/service/src/source.rs
+++ b/crates/batcher/service/src/source.rs
@@ -15,19 +15,16 @@ use base_batcher_source::{PollingSource, SourceError};
 /// When created with `new_from`, it first catches up sequentially from the
 /// given block number before switching to `Latest` polling. This avoids
 /// missing blocks between `safe_head + 1` and `latest` on batcher restart.
+#[derive(derive_more::Debug)]
 pub struct RpcPollingSource {
     /// The L2 RPC provider.
+    #[debug(skip)]
     provider: Arc<dyn Provider<Base> + Send + Sync>,
     /// When `Some(n)`, the next `unsafe_head` call fetches block `n`
     /// sequentially (for startup catchup). Cleared when `n` is strictly
     /// greater than the current latest (i.e. block `n` hasn't been produced yet).
+    #[debug(skip)]
     next_sequential: Mutex<Option<u64>>,
-}
-
-impl std::fmt::Debug for RpcPollingSource {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("RpcPollingSource").finish_non_exhaustive()
-    }
 }
 
 impl RpcPollingSource {

--- a/crates/batcher/service/src/subscription.rs
+++ b/crates/batcher/service/src/subscription.rs
@@ -18,8 +18,11 @@ use futures::{StreamExt, stream::BoxStream};
 ///
 /// [`HybridBlockSource`]: base_batcher_source::HybridBlockSource
 /// [`take_stream`]: BlockSubscription::take_stream
+#[derive(derive_more::Debug)]
 pub struct WsBlockSubscription {
+    #[debug(skip)]
     _provider: Arc<dyn std::any::Any + Send + Sync>,
+    #[debug("{:?}", stream.as_ref().map(|_| "<stream>"))]
     stream: Option<BoxStream<'static, Result<OpBlock, SourceError>>>,
 }
 
@@ -33,14 +36,6 @@ impl WsBlockSubscription {
         stream: BoxStream<'static, Result<OpBlock, SourceError>>,
     ) -> Self {
         Self { _provider: provider, stream: Some(stream) }
-    }
-}
-
-impl std::fmt::Debug for WsBlockSubscription {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("WsBlockSubscription")
-            .field("stream", &self.stream.as_ref().map(|_| "<stream>"))
-            .finish_non_exhaustive()
     }
 }
 

--- a/crates/batcher/source/Cargo.toml
+++ b/crates/batcher/source/Cargo.toml
@@ -18,6 +18,7 @@ tracing = { workspace = true, features = ["std"] }
 thiserror = { workspace = true, features = ["std"] }
 tokio = { workspace = true, features = ["macros"] }
 base-protocol = { workspace = true, features = ["std"] }
+derive_more = { workspace = true, features = ["debug"] }
 base-runtime = { workspace = true, features = ["tokio"] }
 alloy-primitives = { workspace = true, features = ["std"] }
 base-alloy-consensus = { workspace = true, features = ["std"] }

--- a/crates/batcher/source/src/hybrid.rs
+++ b/crates/batcher/source/src/hybrid.rs
@@ -15,27 +15,26 @@ use crate::{BlockSubscription, L2BlockEvent, PollingSource, SourceError, UnsafeB
 ///
 /// Deduplicates blocks by hash and detects reorgs when the same block number
 /// yields different hashes from different sources.
+#[derive(derive_more::Debug)]
 pub struct HybridBlockSource<S, P> {
     /// The block stream returned by `S::take_stream`.
     ///
     /// Declared before `_subscription` so it is dropped first, ensuring the
     /// stream's underlying transport is released before the provider is torn down.
+    #[debug(skip)]
     sub: BoxStream<'static, Result<OpBlock, SourceError>>,
     /// The original subscription, kept alive so its resources remain open.
+    #[debug(skip)]
     _subscription: S,
     /// Polling source for fetching the unsafe head.
+    #[debug(skip)]
     poller: P,
     /// Polling interval stream, yielding `()` every `poll_interval`.
+    #[debug(skip)]
     interval: BoxStream<'static, ()>,
     /// Block number to hash mapping for deduplication and reorg detection.
     /// Bounded to a sliding window of recent blocks; old entries are pruned.
     seen: HashMap<u64, B256>,
-}
-
-impl<S, P> std::fmt::Debug for HybridBlockSource<S, P> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("HybridBlockSource").field("seen", &self.seen).finish_non_exhaustive()
-    }
 }
 
 impl<S, P> HybridBlockSource<S, P>

--- a/crates/batcher/source/src/l1_hybrid.rs
+++ b/crates/batcher/source/src/l1_hybrid.rs
@@ -10,28 +10,25 @@ use crate::{L1HeadEvent, L1HeadPolling, L1HeadSource, L1HeadSubscription, Source
 ///
 /// Deduplicates head numbers so that the same block number is only reported once.
 /// Stale reads (same or lower block number than last reported) are also silently dropped.
+#[derive(derive_more::Debug)]
 pub struct HybridL1HeadSource<S, P> {
     /// The head number stream returned by `S::take_stream`.
     ///
     /// Declared before `_subscription` so it is dropped first, ensuring the
     /// stream's underlying transport is released before the provider is torn down.
+    #[debug(skip)]
     sub: BoxStream<'static, Result<u64, SourceError>>,
     /// The original subscription, kept alive so its resources remain open.
+    #[debug(skip)]
     _subscription: S,
     /// Polling source for fetching the latest L1 head block number.
+    #[debug(skip)]
     poller: P,
     /// Polling interval timer.
+    #[debug(skip)]
     interval: Interval,
     /// Last reported head number for deduplication.
     last_head: Option<u64>,
-}
-
-impl<S, P> std::fmt::Debug for HybridL1HeadSource<S, P> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("HybridL1HeadSource")
-            .field("last_head", &self.last_head)
-            .finish_non_exhaustive()
-    }
 }
 
 impl<S, P> HybridL1HeadSource<S, P>


### PR DESCRIPTION
## Summary

Removes manual debug trait implementations, using `derive_more` instead.