### PR TITLE
chore(proposer): remove unused init_bond from DriverConfig and ProposalSubmitter

### DIFF
--- a/crates/proof/proposer/src/driver/core.rs
+++ b/crates/proof/proposer/src/driver/core.rs
@@ -6,7 +6,7 @@
 
 use std::{sync::Arc, time::Duration};
 
-use alloy_primitives::{B256, U256};
+use alloy_primitives::B256;
 use base_proof_contracts::{
     AggregateVerifierClient, AnchorStateRegistryClient, DisputeGameFactoryClient,
 };
@@ -34,8 +34,6 @@ pub struct DriverConfig {
     pub block_interval: u64,
     /// Number of L2 blocks between intermediate output root checkpoints.
     pub intermediate_block_interval: u64,
-    /// ETH bond required to create a dispute game.
-    pub init_bond: U256,
     /// Game type ID for `AggregateVerifier` dispute games.
     pub game_type: u32,
     /// If true, use `safe_l2` (derived from L1 but L1 not yet finalized).
@@ -49,7 +47,6 @@ impl Default for DriverConfig {
             poll_interval: Duration::from_secs(12),
             block_interval: 512,
             intermediate_block_interval: 512,
-            init_bond: U256::ZERO,
             game_type: 0,
             allow_non_finalized: false,
         }

--- a/crates/proof/proposer/src/output_proposer.rs
+++ b/crates/proof/proposer/src/output_proposer.rs
@@ -6,7 +6,7 @@
 
 use std::sync::LazyLock;
 
-use alloy_primitives::{Address, B256, Bytes, U256};
+use alloy_primitives::{Address, B256, Bytes};
 use async_trait::async_trait;
 use base_enclave::ProofEncoder;
 use base_proof_contracts::{
@@ -73,18 +73,12 @@ pub struct ProposalSubmitter<T> {
     tx_manager: T,
     factory_address: Address,
     game_type: u32,
-    init_bond: U256,
 }
 
 impl<T: TxManager> ProposalSubmitter<T> {
     /// Creates a new [`ProposalSubmitter`] backed by the given transaction manager.
-    pub const fn new(
-        tx_manager: T,
-        factory_address: Address,
-        game_type: u32,
-        init_bond: U256,
-    ) -> Self {
-        Self { tx_manager, factory_address, game_type, init_bond }
+    pub const fn new(tx_manager: T, factory_address: Address, game_type: u32) -> Self {
+        Self { tx_manager, factory_address, game_type }
     }
 }
 
@@ -110,12 +104,8 @@ impl<T: TxManager + 'static> OutputProposer for ProposalSubmitter<T> {
             "Creating dispute game"
         );
 
-        let candidate = TxCandidate {
-            tx_data: calldata,
-            to: Some(self.factory_address),
-            value: self.init_bond,
-            ..Default::default()
-        };
+        let candidate =
+            TxCandidate { tx_data: calldata, to: Some(self.factory_address), ..Default::default() };
 
         let receipt = self.tx_manager.send(candidate).await.map_err(classify_tx_manager_error)?;
 
@@ -138,7 +128,7 @@ impl<T: TxManager + 'static> OutputProposer for ProposalSubmitter<T> {
 #[cfg(test)]
 mod tests {
     use alloy_consensus::{Eip658Value, Receipt, ReceiptEnvelope, ReceiptWithBloom};
-    use alloy_primitives::{Address, Bloom};
+    use alloy_primitives::{Address, Bloom, U256};
     use alloy_rpc_types_eth::TransactionReceipt;
     use base_enclave::PROOF_TYPE_TEE;
     use base_tx_manager::{SendHandle, SendResponse, TxManagerError};
@@ -274,8 +264,7 @@ mod tests {
     async fn propose_output_success() {
         let tx_hash = B256::repeat_byte(0xAA);
         let mock = MockTxManager::new(Ok(receipt_with_status(true, tx_hash)));
-        let submitter =
-            ProposalSubmitter::new(mock, Address::repeat_byte(0x01), 1, U256::from(100));
+        let submitter = ProposalSubmitter::new(mock, Address::repeat_byte(0x01), 1);
 
         let proposal = test_proposal();
         let result = submitter.propose_output(&proposal, 200, 0, &[]).await;
@@ -286,8 +275,7 @@ mod tests {
     async fn propose_output_reverted() {
         let tx_hash = B256::repeat_byte(0xBB);
         let mock = MockTxManager::new(Ok(receipt_with_status(false, tx_hash)));
-        let submitter =
-            ProposalSubmitter::new(mock, Address::repeat_byte(0x01), 1, U256::from(100));
+        let submitter = ProposalSubmitter::new(mock, Address::repeat_byte(0x01), 1);
 
         let proposal = test_proposal();
         let err = submitter.propose_output(&proposal, 200, 0, &[]).await.unwrap_err();
@@ -297,8 +285,7 @@ mod tests {
     #[tokio::test]
     async fn propose_output_tx_manager_error() {
         let mock = MockTxManager::new(Err(TxManagerError::NonceTooLow));
-        let submitter =
-            ProposalSubmitter::new(mock, Address::repeat_byte(0x01), 1, U256::from(100));
+        let submitter = ProposalSubmitter::new(mock, Address::repeat_byte(0x01), 1);
 
         let proposal = test_proposal();
         let err = submitter.propose_output(&proposal, 200, 0, &[]).await.unwrap_err();

--- a/crates/proof/proposer/src/service.rs
+++ b/crates/proof/proposer/src/service.rs
@@ -154,9 +154,6 @@ pub async fn run(config: ProposerConfig) -> Result<()> {
         "Read BLOCK_INTERVAL and INTERMEDIATE_BLOCK_INTERVAL from AggregateVerifier"
     );
 
-    let init_bond = factory_client.init_bonds(config.game_type).await?;
-    info!(init_bond = %init_bond, game_type = config.game_type, "Read initBond from DisputeGameFactory");
-
     // Wrap in Arc for shared ownership.
     let factory_client = Arc::new(factory_client);
     let verifier_client: Arc<dyn AggregateVerifierClient> = Arc::new(verifier_client);
@@ -188,7 +185,6 @@ pub async fn run(config: ProposerConfig) -> Result<()> {
         tx_manager,
         config.dispute_game_factory_addr,
         config.game_type,
-        init_bond,
     ));
     info!("Output proposer initialized");
 
@@ -197,7 +193,6 @@ pub async fn run(config: ProposerConfig) -> Result<()> {
         poll_interval: config.poll_interval,
         block_interval,
         intermediate_block_interval,
-        init_bond,
         game_type: config.game_type,
         allow_non_finalized: config.allow_non_finalized,
     };


### PR DESCRIPTION
## Summary

- Remove the unused `init_bond` field from `DriverConfig` and `ProposalSubmitter`, along with the `init_bonds()` method from the `DisputeGameFactoryClient` trait and all its implementations (concrete + mocks).
- Remove the `factory_client.init_bonds()` call at proposer startup in `service.rs` and the `init_bond` parameter passed to `ProposalSubmitter::new()`.
- Clean up unused `U256` imports that were only needed for `init_bond`.