### PR TITLE
feat(challenger): use idempotent proof requests in challenger

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3084,6 +3084,7 @@ dependencies = [
  "tokio-util",
  "tracing",
  "url",
+ "uuid",
 ]
 
 [[package]]

--- a/crates/proof/challenge/Cargo.toml
+++ b/crates/proof/challenge/Cargo.toml
@@ -70,6 +70,7 @@ tokio-util.workspace = true
 # Misc
 url.workspace = true
 humantime.workspace = true
+uuid = { workspace = true, features = ["v5"] }
 axum = { workspace = true, features = ["http1", "tokio"] }
 
 # Test utilities (optional)

--- a/crates/proof/challenge/src/driver.rs
+++ b/crates/proof/challenge/src/driver.rs
@@ -22,6 +22,7 @@ use base_zk_client::{ProofType, ProveBlockRequest, ZkProofProvider};
 use tokio::select;
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, info, warn};
+use uuid::Uuid;
 
 use crate::{
     CandidateGame, ChallengeSubmitter, ChallengerMetrics, GameScanner,
@@ -396,14 +397,16 @@ impl<L2: L2Provider, P: ZkProofProvider, T: TxManager> Driver<L2, P, T> {
         // checkpoint: [prior_checkpoint .. invalid_checkpoint].
         let start_block_number = candidate.checkpoint_start_block(invalid_index)?;
 
+        let session_id = derive_session_id(game_address, invalid_index);
         let request = ProveBlockRequest {
             start_block_number,
             number_of_blocks_to_prove: candidate.intermediate_block_interval,
             sequence_window: None,
             proof_type: ProofType::GenericZkvmClusterCompressed as i32,
+            session_id: Some(session_id),
         };
 
-        let prove_response = self.zk_prover.prove_block(request).await?;
+        let prove_response = self.zk_prover.prove_block(request.clone()).await?;
         let session_id = prove_response.session_id;
 
         info!(
@@ -523,8 +526,8 @@ impl<L2: L2Provider, P: ZkProofProvider, T: TxManager> Driver<L2, P, T> {
             return Ok(());
         }
 
-        let request = match pending.prove_request {
-            Some(req) => req,
+        let request = match &pending.prove_request {
+            Some(req) => req.clone(),
             None => {
                 // TEE proofs have no ZK session to re-initiate — drop the entry.
                 debug!(game = %game_address, "TEE proof has no ZK request, dropping entry");
@@ -562,5 +565,39 @@ impl<L2: L2Provider, P: ZkProofProvider, T: TxManager> Driver<L2, P, T> {
         }
 
         Ok(())
+    }
+}
+
+/// Derives a deterministic session ID from a game address and invalid index.
+///
+/// Uses UUID v5 (SHA-1 namespace hash) over `game_address || invalid_index`
+/// to produce an idempotency key that is stable across retries.
+fn derive_session_id(game_address: Address, invalid_index: u64) -> String {
+    let mut bytes = [0u8; 28];
+    bytes[..20].copy_from_slice(game_address.as_slice());
+    bytes[20..].copy_from_slice(&invalid_index.to_be_bytes());
+    Uuid::new_v5(&Uuid::NAMESPACE_OID, &bytes).to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use alloy_primitives::Address;
+
+    use super::derive_session_id;
+
+    #[test]
+    fn session_id_is_deterministic() {
+        let addr = Address::repeat_byte(0xAA);
+        assert_eq!(derive_session_id(addr, 42), derive_session_id(addr, 42));
+    }
+
+    #[test]
+    fn session_id_differs_for_different_inputs() {
+        let addr = Address::repeat_byte(0xAA);
+        assert_ne!(derive_session_id(addr, 1), derive_session_id(addr, 2));
+        assert_ne!(
+            derive_session_id(Address::repeat_byte(0xBB), 1),
+            derive_session_id(Address::repeat_byte(0xCC), 1),
+        );
     }
 }

--- a/crates/proof/challenge/tests/driver.rs
+++ b/crates/proof/challenge/tests/driver.rs
@@ -86,6 +86,7 @@ const fn default_prove_request() -> ProveBlockRequest {
         number_of_blocks_to_prove: 5,
         sequence_window: None,
         proof_type: ProofType::GenericZkvmClusterCompressed as i32,
+        session_id: None,
     }
 }
 

--- a/crates/proof/zk/client/proto/zk_prover.proto
+++ b/crates/proof/zk/client/proto/zk_prover.proto
@@ -21,6 +21,9 @@ message ProveBlockRequest {
   optional uint64 sequence_window = 3;
   // The type of proof to generate
   ProofType proof_type = 4;
+  // Optional client-supplied idempotency key. When set, the server
+  // may use it to deduplicate concurrent or retried proof requests.
+  optional string session_id = 5;
 }
 
 message ProveBlockResponse {

--- a/crates/proof/zk/client/tests/mock_provider.rs
+++ b/crates/proof/zk/client/tests/mock_provider.rs
@@ -56,6 +56,7 @@ async fn mock_prove_block_returns_session_id() {
         number_of_blocks_to_prove: 1,
         sequence_window: None,
         proof_type: ProofType::KailuaBentoStark.into(),
+        session_id: None,
     };
 
     let response = provider.prove_block(request).await.expect("prove_block should succeed");

--- a/crates/proof/zk/service/src/worker/prover_worker_pool.rs
+++ b/crates/proof/zk/service/src/worker/prover_worker_pool.rs
@@ -41,6 +41,7 @@ impl ProveBlockRequestParams {
             number_of_blocks_to_prove: self.number_of_blocks_to_prove,
             sequence_window: self.sequence_window,
             proof_type,
+            session_id: None,
         })
     }
 }


### PR DESCRIPTION
### What changed? Why?

Adds idempotent proof requests to the challenger by deriving a deterministic session ID from the game address and invalid index, and passing it to the ZK prover as a client-supplied idempotency key.

- Added an optional `session_id` field to the `ProveBlockRequest` proto message
- The challenger derives a UUID v5 from `game_address || invalid_index` using `derive_session_id()`, producing a stable key across retries
- The session ID is attached to proof requests so the server can deduplicate concurrent or retried requests for the same game checkpoint
- Existing callers (worker pool, tests, mock provider) pass `session_id: None` to preserve current behavior

### Notes to reviewers

The proto change adds `session_id` as field number 5 (optional string), which is backwards compatible.

### How has it been tested?

- Unit tests for `derive_session_id` verify determinism and uniqueness across different inputs
- Existing integration tests updated with the new field

### Change management ([definitions](http://go/change-management))

type=routine<!--routine,nonroutine,emergency-->
risk=low<!--low,medium,high-->
impact=sev5<!--sev5,sev4,sev3,sev2,sev1-->

### Backwards Compatibility ([learn more](http://go/backwards-compatibility))

backwards_compatible=true<!-- true false -->

<!-- Automatically merge your PR once the necessary approvals have been received (you probably want this) -->

automerge=false