### PR TITLE
fix(tee): prevent auto fallback to local mode in production

### DIFF
--- a/bin/prover/src/cli.rs
+++ b/bin/prover/src/cli.rs
@@ -192,7 +192,7 @@ impl NitroLocalArgs {
             enable_experimental_witness_endpoint: self.server.enable_experimental_witness_endpoint,
         };
 
-        let enclave_server = Arc::new(Server::new()?);
+        let enclave_server = Arc::new(Server::new_local()?);
         let transport = Arc::new(NitroTransport::local(enclave_server));
         let server = NitroProverServer::new(prover_config, transport);
 

--- a/crates/proof/tee/nitro/src/enclave/nsm.rs
+++ b/crates/proof/tee/nitro/src/enclave/nsm.rs
@@ -5,7 +5,7 @@ use aws_nitro_enclaves_nsm_api::api::{Request, Response};
 #[cfg(target_os = "linux")]
 use aws_nitro_enclaves_nsm_api::driver::{nsm_exit, nsm_init, nsm_process_request};
 use rand_08::{CryptoRng, RngCore};
-use tracing::warn;
+use tracing::debug;
 
 use crate::error::{NsmError, Result};
 
@@ -34,7 +34,7 @@ impl NsmSession {
     pub fn open() -> Result<Option<Self>> {
         let fd = nsm_init();
         if fd < 0 {
-            warn!("failed to open Nitro Secure Module session, running in local mode");
+            debug!("failed to open Nitro Secure Module session");
             Ok(None)
         } else {
             Ok(Some(Self { fd }))
@@ -46,7 +46,7 @@ impl NsmSession {
     /// On non-Linux platforms, always returns `None` (local mode).
     #[cfg(not(target_os = "linux"))]
     pub fn open() -> Result<Option<Self>> {
-        warn!("NSM not available on this platform, running in local mode");
+        debug!("NSM not available on this platform");
         Ok(None)
     }
 

--- a/crates/proof/tee/nitro/src/enclave/server.rs
+++ b/crates/proof/tee/nitro/src/enclave/server.rs
@@ -5,7 +5,7 @@ use base_alloy_evm::OpEvmFactory;
 use base_proof_client::{BootInfo, Prologue};
 use base_proof_preimage::PreimageKey;
 use base_proof_primitives::{ProofJournal, ProofResult, Proposal};
-use tracing::{info, warn};
+use tracing::info;
 
 use crate::{
     Oracle,
@@ -65,23 +65,19 @@ pub struct Server {
 }
 
 impl Server {
-    /// Create a new server instance.
+    /// Create a new server instance that requires NSM.
     ///
-    /// In enclave mode (NSM available): reads PCR0, keccak256-hashes it to derive
-    /// `tee_image_hash`, and uses the hardware RNG for key generation.
-    ///
-    /// In local mode (no NSM): uses the OS RNG and sets `tee_image_hash` to zero.
+    /// Reads PCR0, keccak256-hashes it to derive `tee_image_hash`, and uses the
+    /// hardware RNG for key generation. Returns an error if NSM is unavailable.
     pub fn new() -> Result<Self> {
-        NsmSession::open()?.map_or_else(
-            || {
-                warn!("running in local mode without NSM");
-                Self::new_local()
-            },
-            |session| Self::new_enclave(&session),
-        )
+        let session = NsmSession::open()?.ok_or_else(|| {
+            NsmError::SessionOpen("NSM device unavailable; cannot run in enclave mode".into())
+        })?;
+        Self::new_enclave(&session)
     }
 
-    fn new_enclave(session: &NsmSession) -> Result<Self> {
+    /// Create a new server from an existing NSM session.
+    pub fn new_enclave(session: &NsmSession) -> Result<Self> {
         let pcr0 = session.describe_pcr0()?;
         if pcr0.len() != PCR0_LENGTH {
             return Err(NsmError::DescribePcr(format!(
@@ -100,7 +96,11 @@ impl Server {
         Ok(Self { pcr0, signer_key, tee_image_hash })
     }
 
-    fn new_local() -> Result<Self> {
+    /// Create a new server instance in local mode for development.
+    ///
+    /// Uses the OS RNG and sets `tee_image_hash` to zero. Optionally reads a
+    /// signer key from the `OP_ENCLAVE_SIGNER_KEY` environment variable.
+    pub fn new_local() -> Result<Self> {
         let signer_key = match std::env::var(SIGNER_KEY_ENV_VAR) {
             Ok(hex_key) => {
                 info!("using signer key from environment variable");
@@ -254,9 +254,7 @@ mod tests {
 
     #[test]
     fn test_server_new_local_mode() {
-        let server = Server::new().expect("failed to create server");
-
-        #[cfg(not(target_os = "linux"))]
+        let server = Server::new_local().expect("failed to create server");
         assert!(server.is_local_mode());
 
         let public_key = server.signer_public_key();
@@ -265,8 +263,15 @@ mod tests {
     }
 
     #[test]
+    #[cfg(not(target_os = "linux"))]
+    fn test_server_new_requires_nsm() {
+        let result = Server::new();
+        assert!(result.is_err());
+    }
+
+    #[test]
     fn test_signer_address_consistency() {
-        let server = Server::new().expect("failed to create server");
+        let server = Server::new_local().expect("failed to create server");
 
         let addr1 = server.signer_address();
         let addr2 = server.signer_address();

--- a/crates/proof/tee/nitro/src/host/backend.rs
+++ b/crates/proof/tee/nitro/src/host/backend.rs
@@ -62,7 +62,7 @@ mod tests {
 
     #[tokio::test]
     async fn backend_create_oracle_returns_empty() {
-        let server = Arc::new(Server::new().unwrap());
+        let server = Arc::new(Server::new_local().unwrap());
         let transport = Arc::new(NitroTransport::local(server));
         let backend = NitroBackend::new(transport);
 

--- a/crates/proof/tee/nitro/src/host/server.rs
+++ b/crates/proof/tee/nitro/src/host/server.rs
@@ -95,7 +95,7 @@ mod tests {
 
     #[tokio::test]
     async fn signer_public_key_routed_to_transport() {
-        let server = Arc::new(EnclaveServer::new().unwrap());
+        let server = Arc::new(EnclaveServer::new_local().unwrap());
         let transport = Arc::new(NitroTransport::local(Arc::clone(&server)));
         let expected = server.signer_public_key();
 
@@ -115,7 +115,7 @@ mod tests {
 
     #[tokio::test]
     async fn signer_attestation_routed_to_transport() {
-        let server = Arc::new(EnclaveServer::new().unwrap());
+        let server = Arc::new(EnclaveServer::new_local().unwrap());
         let transport = Arc::new(NitroTransport::local(Arc::clone(&server)));
 
         let rpc = NitroSignerRpc { transport };


### PR DESCRIPTION
### What changed? Why?

`Server::new()` previously fell back silently to local mode when NSM was unavailable. This is dangerous in production — a misconfigured enclave would run without hardware attestation and sign with a zeroed `tee_image_hash`, with no clear signal that anything is wrong.

This PR makes the mode selection explicit:
- **`Server::new()`** now requires NSM and returns an error if the device is unavailable, preventing accidental local-mode operation in production.
- **`Server::new_local()`** is made `pub` for intentional local/development use, with zero `tee_image_hash` and OS RNG.
- **`Server::new_enclave()`** is made `pub` for callers that already hold an `NsmSession`.
- The prover CLI (`NitroLocalArgs`) now explicitly calls `Server::new_local()`.
- NSM-unavailable log messages are downgraded from `warn` to `debug` since `NsmSession::open()` returning `None` is no longer used as a fallback trigger.

### Notes to reviewers

The only behavioral change is in `Server::new()` — it now fails instead of silently degrading. All other call sites that need local mode have been updated to use `new_local()` explicitly.

### How has it been tested?

- Existing tests updated to call `Server::new_local()` directly.
- New test `test_server_new_requires_nsm` (non-Linux only) verifies that `Server::new()` returns an error when NSM is unavailable.

### Change management ([definitions](http://go/change-management))

type=routine<!--routine,nonroutine,emergency-->
risk=low<!--low,medium,high-->
impact=sev5<!--sev5,sev4,sev3,sev2,sev1-->

### Backwards Compatibility ([learn more](http://go/backwards-compatibility))

backwards_compatible=true<!-- true false -->

<!-- Automatically merge your PR once the necessary approvals have been received (you probably want this) -->

automerge=false