### PR TITLE
fix(tx-manager): reorg edge case

### DIFF
--- a/crates/utilities/tx-manager/src/manager.rs
+++ b/crates/utilities/tx-manager/src/manager.rs
@@ -1453,18 +1453,21 @@ impl SimpleTxManager {
         num_confirmations: u64,
         network_timeout: Duration,
     ) -> TxManagerResult<Option<TransactionReceipt>> {
-        // Fetch tip *before* the receipt so that a reorg between the two
-        // calls can only undercount confirmations (safe), never overcount.
-        let tip_height = tokio::time::timeout(network_timeout, provider.get_block_number())
-            .await
+        // Fetch tip and receipt in parallel. The canonical block hash check
+        // below ensures the receipt is on the canonical chain, so call order
+        // no longer matters for reorg safety.
+        let (tip_result, receipt_result) = tokio::join!(
+            tokio::time::timeout(network_timeout, provider.get_block_number()),
+            tokio::time::timeout(network_timeout, provider.get_transaction_receipt(tx_hash)),
+        );
+
+        let tip_height = tip_result
             .map_err(|_| TxManagerError::Rpc("get_block_number timed out".into()))?
             .map_err(|e| RpcErrorClassifier::classify_rpc_error(&e.to_string()))?;
 
-        let receipt_opt =
-            tokio::time::timeout(network_timeout, provider.get_transaction_receipt(tx_hash))
-                .await
-                .map_err(|_| TxManagerError::Rpc("get_transaction_receipt timed out".into()))?
-                .map_err(|e| RpcErrorClassifier::classify_rpc_error(&e.to_string()))?;
+        let receipt_opt = receipt_result
+            .map_err(|_| TxManagerError::Rpc("get_transaction_receipt timed out".into()))?
+            .map_err(|e| RpcErrorClassifier::classify_rpc_error(&e.to_string()))?;
 
         let receipt = match receipt_opt {
             Some(r) => r,
@@ -1484,7 +1487,40 @@ impl SimpleTxManager {
             }
         };
 
-        // Receipt exists with a block number — record as mined.
+        // Verify the receipt is on the canonical chain by comparing its block
+        // hash against the canonical block at the same height.
+        let receipt_block_hash = match receipt.block_hash {
+            Some(hash) => hash,
+            None => {
+                send_state.tx_not_mined(tx_hash);
+                debug!(tx_hash = %tx_hash, "receipt has no block hash, treating as not mined");
+                return Ok(None);
+            }
+        };
+
+        let canonical_header = tokio::time::timeout(
+            network_timeout,
+            provider.get_header_by_number(BlockNumberOrTag::Number(tx_block)),
+        )
+        .await
+        .map_err(|_| TxManagerError::Rpc("get_header_by_number timed out".into()))?
+        .map_err(|e| RpcErrorClassifier::classify_rpc_error(&e.to_string()))?;
+
+        let is_canonical =
+            canonical_header.as_ref().is_some_and(|header| header.hash == receipt_block_hash);
+
+        if !is_canonical {
+            send_state.tx_not_mined(tx_hash);
+            debug!(
+                tx_hash = %tx_hash,
+                tx_block = %tx_block,
+                receipt_block_hash = %receipt_block_hash,
+                "receipt block hash does not match canonical chain",
+            );
+            return Ok(None);
+        }
+
+        // Receipt is on the canonical chain — record as mined.
         send_state.tx_mined(tx_hash);
 
         // Check confirmation depth: tx_block + num_confirmations <= tip + 1

--- a/crates/utilities/tx-manager/src/manager.rs
+++ b/crates/utilities/tx-manager/src/manager.rs
@@ -1498,16 +1498,16 @@ impl SimpleTxManager {
             }
         };
 
-        let canonical_header = tokio::time::timeout(
+        let canonical_block = tokio::time::timeout(
             network_timeout,
-            provider.get_header_by_number(BlockNumberOrTag::Number(tx_block)),
+            provider.get_block_by_number(BlockNumberOrTag::Number(tx_block)),
         )
         .await
-        .map_err(|_| TxManagerError::Rpc("get_header_by_number timed out".into()))?
+        .map_err(|_| TxManagerError::Rpc("get_block_by_number timed out".into()))?
         .map_err(|e| RpcErrorClassifier::classify_rpc_error(&e.to_string()))?;
 
         let is_canonical =
-            canonical_header.as_ref().is_some_and(|header| header.hash == receipt_block_hash);
+            canonical_block.as_ref().is_some_and(|block| block.header.hash == receipt_block_hash);
 
         if !is_canonical {
             send_state.tx_not_mined(tx_hash);

--- a/crates/utilities/tx-manager/tests/reorg.rs
+++ b/crates/utilities/tx-manager/tests/reorg.rs
@@ -137,8 +137,8 @@ async fn query_receipt_returns_none_after_reorg_removes_tx() {
     );
 }
 
-/// Tx is reorged into a different block. Documents current behavior:
-/// `query_receipt` performs no block hash validation.
+/// Tx is reorged into a different block. The receipt is accepted because the
+/// re-included tx's block hash matches the canonical chain after the reorg.
 #[tokio::test]
 async fn query_receipt_returns_receipt_after_reorg_reinclusion() {
     let config = TxManagerConfig { num_confirmations: 1, ..TxManagerConfig::default() };
@@ -200,7 +200,8 @@ async fn query_receipt_returns_receipt_after_reorg_reinclusion() {
         "block hash should change after reorg reinclusion",
     );
 
-    // query_receipt should still return Some (no block hash validation).
+    // query_receipt validates the receipt's block hash against the canonical
+    // chain. The re-included tx is on the canonical chain, so it should pass.
     let result = query(&send_state, &manager, tx_hash, 1).await;
     assert!(result.is_some(), "receipt should exist after reinclusion");
 }

--- a/crates/utilities/tx-manager/tests/send_lifecycle.rs
+++ b/crates/utilities/tx-manager/tests/send_lifecycle.rs
@@ -254,8 +254,8 @@ async fn query_receipt_returns_confirmed_receipt() {
         manager.publish_tx(&send_state, &prepared.raw_tx, None).await.expect("should publish tx");
 
     // Mine an extra block so tip_height is strictly ahead of the tx block.
-    // query_receipt fetches tip_height before the receipt (for reorg safety),
-    // so under CI load the tip may be stale on a single-call test.
+    // query_receipt fetches tip_height and receipt in parallel, so under CI
+    // load the tip may be stale on a single-call test.
     mine_block(&manager).await;
 
     // With num_confirmations = 1 and the extra block mined above,


### PR DESCRIPTION
### What changed? Why?

`query_receipt` in `SimpleTxManager` had a reorg edge case where a receipt could be returned for a transaction that was no longer on the canonical chain. This change adds canonical chain validation by comparing the receipt's block hash against the block hash at the same height on the canonical chain. If they differ, the receipt is treated as not mined.

Additionally, the tip height and receipt fetches are now done in parallel via `tokio::join!` instead of sequentially. The new block hash check makes call ordering irrelevant for reorg safety, so parallelizing is both safe and faster.

**Changes:**
- Fetch `get_block_number` and `get_transaction_receipt` in parallel using `tokio::join!`
- After receiving a receipt, fetch the canonical block at the receipt's block height and compare block hashes
- If the receipt's block hash doesn't match the canonical chain, call `tx_not_mined` and return `None`
- Update reorg and lifecycle tests to reflect the new validation behavior

### Notes to reviewers

### How has it been tested?

- Existing reorg integration tests updated to cover the new canonical chain validation
- `query_receipt_returns_none_after_reorg_removes_tx` — verifies receipt is rejected when tx is dropped from canonical chain
- `query_receipt_returns_receipt_after_reorg_reinclusion` — verifies receipt is accepted when re-included tx's block hash matches canonical chain

### Change management ([definitions](http://go/change-management))

type=routine<!--routine,nonroutine,emergency-->
risk=low<!--low,medium,high-->
impact=sev5<!--sev5,sev4,sev3,sev2,sev1-->

### Backwards Compatibility ([learn more](http://go/backwards-compatibility))

backwards_compatible=true<!-- true false -->

<!-- Automatically merge your PR once the necessary approvals have been received (you probably want this) -->

automerge=false