### PR TITLE
fix(workspace): build issues

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,9 +1,3 @@
-[env]
-# Skip compiling Metal GPU kernels from source (risc0-sys).
-# Pre-built kernels are still available; this only avoids requiring
-# the `xcrun metal` toolchain (full Xcode) on macOS developer machines.
-RISC0_SKIP_BUILD_KERNELS = "1"
-
 # Faster linkers: mold on Linux, lld on macOS.
 # Prerequisites:
 #   Linux:  apt install mold  (or already provided by CI setup-mold action)

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,3 +1,9 @@
+[env]
+# Skip compiling Metal GPU kernels from source (risc0-sys).
+# Pre-built kernels are still available; this only avoids requiring
+# the `xcrun metal` toolchain (full Xcode) on macOS developer machines.
+RISC0_SKIP_BUILD_KERNELS = "1"
+
 # Faster linkers: mold on Linux, lld on macOS.
 # Prerequisites:
 #   Linux:  apt install mold  (or already provided by CI setup-mold action)

--- a/Justfile
+++ b/Justfile
@@ -1,5 +1,8 @@
 set positional-arguments := true
 
+# Skip risc0 Metal kernel compilation on macOS (avoids requiring full Xcode).
+export RISC0_SKIP_BUILD_KERNELS := if os() == "macos" { "1" } else { "0" }
+
 mod tee 'crates/proof/tee'
 mod actions 'actions'
 # Docker-based local devnet management
@@ -83,16 +86,7 @@ check-deny:
     cargo deny check bans --hide-inclusion-graph
 
 # Fixes formatting and clippy issues
-fix: build-contracts
-    #!/usr/bin/env bash
-    set -euo pipefail
-    # Skip risc0 Metal kernel compilation on macOS (avoids requiring full Xcode).
-    if [[ "$(uname -s)" == "Darwin" ]]; then
-        export RISC0_SKIP_BUILD_KERNELS=1
-    fi
-    just format-fix
-    just clippy-fix
-    just zepter-fix
+fix: build-contracts format-fix clippy-fix zepter-fix
 
 # Runs zepter feature checks, installing zepter if necessary
 zepter:

--- a/Justfile
+++ b/Justfile
@@ -83,7 +83,16 @@ check-deny:
     cargo deny check bans --hide-inclusion-graph
 
 # Fixes formatting and clippy issues
-fix: build-contracts format-fix clippy-fix zepter-fix
+fix: build-contracts
+    #!/usr/bin/env bash
+    set -euo pipefail
+    # Skip risc0 Metal kernel compilation on macOS (avoids requiring full Xcode).
+    if [[ "$(uname -s)" == "Darwin" ]]; then
+        export RISC0_SKIP_BUILD_KERNELS=1
+    fi
+    just format-fix
+    just clippy-fix
+    just zepter-fix
 
 # Runs zepter feature checks, installing zepter if necessary
 zepter:


### PR DESCRIPTION
### What changed? Why?

- Added `RISC0_SKIP_BUILD_KERNELS=1` (conditionally, only on macOS) to the `Justfile` to skip compiling Metal GPU kernels from source (`risc0-sys`). Pre-built kernels are still available; this only avoids requiring the `xcrun metal` toolchain (full Xcode) on macOS developer machines, fixing build failures for developers without the full Xcode installation.

### Notes to reviewers

Single-line env export added to the Justfile, conditionally set to `"1"` on macOS and `"0"` otherwise. No effect on CI (Linux) or on GPU kernel availability at runtime — only skips the source build step when using Just commands locally on macOS.

### How has it been tested?

- Verified local `cargo build` succeeds on macOS without full Xcode installed

### Change management ([definitions](http://go/change-management))

type=routine<!--routine,nonroutine,emergency-->
risk=low<!--low,medium,high-->
impact=sev5<!--sev5,sev4,sev3,sev2,sev1-->

### Backwards Compatibility ([learn more](http://go/backwards-compatibility))

backwards_compatible=true<!-- true false -->

<!-- Automatically merge your PR once the necessary approvals have been received (you probably want this) -->

automerge=false