### PR TITLE
refactor(challenger): update env var name for zk prover

### DIFF
--- a/crates/proof/challenge/src/cli.rs
+++ b/crates/proof/challenge/src/cli.rs
@@ -71,9 +71,9 @@ pub struct ChallengerArgs {
     )]
     pub poll_interval: Duration,
 
-    /// URL of the ZK proof service endpoint.
-    #[arg(long = "zk-proof-service-endpoint", env = cli_env!("ZK_PROOF_SERVICE_ENDPOINT"))]
-    pub zk_proof_service_endpoint: Url,
+    /// URL of the ZK RPC endpoint.
+    #[arg(long = "zk-rpc-url", env = cli_env!("ZK_RPC_URL"))]
+    pub zk_rpc_url: Url,
 
     /// Timeout for establishing the initial gRPC connection to the ZK proof
     /// service (e.g., "10s", "1m").
@@ -136,7 +136,7 @@ impl std::fmt::Debug for ChallengerArgs {
             .field("l2_eth_rpc", &self.l2_eth_rpc)
             .field("dispute_game_factory_addr", &self.dispute_game_factory_addr)
             .field("poll_interval", &self.poll_interval)
-            .field("zk_proof_service_endpoint", &self.zk_proof_service_endpoint)
+            .field("zk_rpc_url", &self.zk_rpc_url)
             .field("zk_connect_timeout", &self.zk_connect_timeout)
             .field("zk_request_timeout", &self.zk_request_timeout)
             .field("tee_rpc_url", &self.tee_rpc_url)

--- a/crates/proof/challenge/src/config.rs
+++ b/crates/proof/challenge/src/config.rs
@@ -93,8 +93,8 @@ pub struct ChallengerConfig {
     pub dispute_game_factory_addr: Address,
     /// Polling interval for new dispute games.
     pub poll_interval: Duration,
-    /// URL of the ZK proof service endpoint.
-    pub zk_proof_service_endpoint: Validated<Url>,
+    /// URL of the ZK RPC endpoint.
+    pub zk_rpc_url: Validated<Url>,
     /// Timeout for establishing the initial gRPC connection to the ZK proof service.
     pub zk_connect_timeout: Duration,
     /// Timeout for individual gRPC requests to the ZK proof service.
@@ -141,8 +141,7 @@ impl ChallengerConfig {
         // Validate URLs have scheme and host
         let l1_eth_rpc = validate(cli.challenger.l1_eth_rpc, "l1-eth-rpc")?;
         let l2_eth_rpc = validate(cli.challenger.l2_eth_rpc, "l2-eth-rpc")?;
-        let zk_proof_service_endpoint =
-            validate(cli.challenger.zk_proof_service_endpoint, "zk-proof-service-endpoint")?;
+        let zk_rpc_url = validate(cli.challenger.zk_rpc_url, "zk-rpc-url")?;
         let tee_rpc_url =
             cli.challenger.tee_rpc_url.map(|url| validate(url, "tee-rpc-url")).transpose()?;
 
@@ -214,7 +213,7 @@ impl ChallengerConfig {
             l2_eth_rpc,
             dispute_game_factory_addr: cli.challenger.dispute_game_factory_addr,
             poll_interval: cli.challenger.poll_interval,
-            zk_proof_service_endpoint,
+            zk_rpc_url,
             zk_connect_timeout: cli.challenger.zk_connect_timeout,
             zk_request_timeout: cli.challenger.zk_request_timeout,
             tee_rpc_url,
@@ -251,7 +250,7 @@ mod tests {
             ("--l1-eth-rpc", "http://localhost:8545"),
             ("--l2-eth-rpc", "http://localhost:9545"),
             ("--dispute-game-factory-addr", "0x1234567890123456789012345678901234567890"),
-            ("--zk-proof-service-endpoint", "http://localhost:5000"),
+            ("--zk-rpc-url", "http://localhost:5000"),
         ];
 
         let mut args = vec!["challenger"];
@@ -413,7 +412,7 @@ mod tests {
             "http://localhost:9545",
             "--dispute-game-factory-addr",
             "0x1234567890123456789012345678901234567890",
-            "--zk-proof-service-endpoint",
+            "--zk-rpc-url",
             "http://localhost:5000",
             "--private-key",
             "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80",
@@ -435,7 +434,7 @@ mod tests {
             "http://localhost:9545",
             "--dispute-game-factory-addr",
             "0x1234567890123456789012345678901234567890",
-            "--zk-proof-service-endpoint",
+            "--zk-rpc-url",
             "http://localhost:5000",
             "--signer-endpoint",
             "http://localhost:8546",
@@ -444,18 +443,15 @@ mod tests {
     }
 
     #[test]
-    fn test_zk_proof_endpoint_validated() {
+    fn test_zk_rpc_url_validated() {
         let cli = cli_from_args(&[
-            "--zk-proof-service-endpoint",
+            "--zk-rpc-url",
             "file:///no/host",
             "--private-key",
             "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80",
         ]);
         let result = ChallengerConfig::from_cli(cli);
-        assert!(matches!(
-            result,
-            Err(ConfigError::InvalidUrl { field: "zk-proof-service-endpoint", .. })
-        ));
+        assert!(matches!(result, Err(ConfigError::InvalidUrl { field: "zk-rpc-url", .. })));
     }
 
     #[test]

--- a/crates/proof/challenge/src/service.rs
+++ b/crates/proof/challenge/src/service.rs
@@ -107,12 +107,12 @@ impl ChallengerService {
 
         // ── 6. ZK proof client ───────────────────────────────────────────────
         let zk_config = ZkProofClientConfig {
-            endpoint: config.zk_proof_service_endpoint.as_ref().clone(),
+            endpoint: config.zk_rpc_url.as_ref().clone(),
             connect_timeout: config.zk_connect_timeout,
             request_timeout: config.zk_request_timeout,
         };
         let zk_client = Arc::new(ZkProofClient::new(&zk_config)?);
-        info!(endpoint = %config.zk_proof_service_endpoint, "ZK proof client initialized");
+        info!(endpoint = %config.zk_rpc_url, "ZK proof client initialized");
 
         // ── 6b. TEE enclave client (optional) ────────────────────────────────
         let tee: Option<crate::TeeConfig> = if let Some(ref tee_url) = config.tee_rpc_url {


### PR DESCRIPTION
### What changed? Why?

Renames the ZK prover endpoint configuration from `ZK_PROOF_SERVICE_ENDPOINT` / `--zk-proof-service-endpoint` to `ZK_RPC_URL` / `--zk-rpc-url` for consistency with other RPC URL naming conventions in the codebase (e.g. `--l1-eth-rpc`, `--tee-rpc-url`).

Changes across `cli.rs`, `config.rs`, and `service.rs`:
- CLI arg: `--zk-proof-service-endpoint` → `--zk-rpc-url`
- Env var: `ZK_PROOF_SERVICE_ENDPOINT` → `ZK_RPC_URL`
- Struct field: `zk_proof_service_endpoint` → `zk_rpc_url`
- Updated tests and validation references accordingly

### Notes to reviewers

Straightforward rename, no behavioral changes.

### How has it been tested?

Existing unit tests updated to use the new flag/field names.

### Change management ([definitions](http://go/change-management))

type=routine<!--routine,nonroutine,emergency-->
risk=low<!--low,medium,high-->
impact=sev5<!--sev5,sev4,sev3,sev2,sev1-->

### Backwards Compatibility ([learn more](http://go/backwards-compatibility))

backwards_compatible=true<!-- true false -->

<!-- Automatically merge your PR once the necessary approvals have been received (you probably want this) -->

automerge=false