### PR TITLE
fix(tee): add feature gate for tls cert bypass

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3589,6 +3589,7 @@ dependencies = [
  "jsonrpsee",
  "rustls 0.23.37",
  "thiserror 2.0.18",
+ "tracing",
 ]
 
 [[package]]

--- a/bin/proposer/Cargo.toml
+++ b/bin/proposer/Cargo.toml
@@ -20,3 +20,6 @@ eyre.workspace = true
 base-proposer.workspace = true
 tokio = { workspace = true, features = ["full"] }
 clap = { workspace = true, features = ["derive", "env"] }
+
+[features]
+insecure-tls = [ "base-proposer/insecure-tls" ]

--- a/crates/proof/proposer/Cargo.toml
+++ b/crates/proof/proposer/Cargo.toml
@@ -74,8 +74,8 @@ base-cli-utils.workspace = true
 metrics.workspace = true
 metrics-exporter-prometheus.workspace = true
 
-# TLS
-rustls = { workspace = true, features = ["ring"] }
+# TLS (insecure-tls only)
+rustls = { workspace = true, features = ["ring"], optional = true }
 
 # Misc
 hex.workspace = true
@@ -89,3 +89,6 @@ axum = { workspace = true, features = ["http1", "json", "tokio"] }
 [dev-dependencies]
 reqwest = { workspace = true, features = ["json"] }
 tokio = { workspace = true, features = ["test-util"] }
+
+[features]
+insecure-tls = [ "base-proof-rpc/insecure-tls", "dep:rustls" ]

--- a/crates/proof/proposer/src/cli.rs
+++ b/crates/proof/proposer/src/cli.rs
@@ -99,6 +99,7 @@ pub struct ProposerArgs {
     pub rollup_rpc: Url,
 
     /// Skip TLS certificate verification.
+    #[cfg(feature = "insecure-tls")]
     #[arg(
         long = "skip-tls-verify",
         env = cli_env!("SKIP_TLS_VERIFY"),
@@ -208,6 +209,7 @@ mod tests {
         assert_eq!(cli.proposer.poll_interval, Duration::from_secs(12));
         assert_eq!(cli.proposer.rpc_timeout, Duration::from_secs(30));
         assert_eq!(cli.proposer.rollup_rpc.as_str(), "http://localhost:7545/");
+        #[cfg(feature = "insecure-tls")]
         assert!(!cli.proposer.skip_tls_verify);
         assert!(!cli.proposer.wait_node_sync);
         assert_eq!(cli.proposer.game_type, 1);

--- a/crates/proof/proposer/src/config.rs
+++ b/crates/proof/proposer/src/config.rs
@@ -71,6 +71,7 @@ pub struct ProposerConfig {
     /// URL of the rollup RPC endpoint.
     pub rollup_rpc: Url,
     /// Skip TLS certificate verification.
+    #[cfg(feature = "insecure-tls")]
     pub skip_tls_verify: bool,
     /// Wait for node sync before starting.
     pub wait_node_sync: bool,
@@ -147,6 +148,7 @@ impl ProposerConfig {
             signing,
             tx_manager,
             rollup_rpc: cli.proposer.rollup_rpc,
+            #[cfg(feature = "insecure-tls")]
             skip_tls_verify: cli.proposer.skip_tls_verify,
             wait_node_sync: cli.proposer.wait_node_sync,
             log: LogConfig::from(cli.logging),
@@ -227,6 +229,7 @@ mod tests {
                 poll_interval: Duration::from_secs(12),
                 rpc_timeout: Duration::from_secs(30),
                 rollup_rpc: Url::parse("http://localhost:7545").unwrap(),
+                #[cfg(feature = "insecure-tls")]
                 skip_tls_verify: false,
                 wait_node_sync: false,
                 rpc_max_retries: 5,

--- a/crates/proof/proposer/src/service.rs
+++ b/crates/proof/proposer/src/service.rs
@@ -53,8 +53,7 @@ use crate::{
 pub async fn run(config: ProposerConfig) -> Result<()> {
     config.log.init_tracing_subscriber()?;
 
-    // Install the default rustls CryptoProvider before any TLS connections are created.
-    // Required by rustls 0.23+ when custom TLS configs are used (e.g. skip_tls_verify).
+    // Install the default rustls CryptoProvider for insecure-tls custom TLS configs.
     #[cfg(feature = "insecure-tls")]
     let _ = rustls::crypto::ring::default_provider().install_default();
 

--- a/crates/proof/proposer/src/service.rs
+++ b/crates/proof/proposer/src/service.rs
@@ -55,6 +55,7 @@ pub async fn run(config: ProposerConfig) -> Result<()> {
 
     // Install the default rustls CryptoProvider before any TLS connections are created.
     // Required by rustls 0.23+ when custom TLS configs are used (e.g. skip_tls_verify).
+    #[cfg(feature = "insecure-tls")]
     let _ = rustls::crypto::ring::default_provider().install_default();
 
     info!(version = env!("CARGO_PKG_VERSION"), "Proposer starting");
@@ -73,8 +74,9 @@ pub async fn run(config: ProposerConfig) -> Result<()> {
     let l1_config = L1ClientConfig::new(config.l1_eth_rpc.clone())
         .with_timeout(config.rpc_timeout)
         .with_retry_config(config.retry.clone())
-        .with_skip_tls_verify(config.skip_tls_verify)
         .with_metrics_prefix("base_proposer");
+    #[cfg(feature = "insecure-tls")]
+    let l1_config = l1_config.with_skip_tls_verify(config.skip_tls_verify);
     let l1_client = Arc::new(L1Client::new(l1_config)?);
     info!(endpoint = %config.l1_eth_rpc, "L1 client initialized");
 
@@ -82,8 +84,9 @@ pub async fn run(config: ProposerConfig) -> Result<()> {
     let l2_config = L2ClientConfig::new(config.l2_eth_rpc.clone())
         .with_timeout(config.rpc_timeout)
         .with_retry_config(config.retry.clone())
-        .with_skip_tls_verify(config.skip_tls_verify)
         .with_metrics_prefix("base_proposer");
+    #[cfg(feature = "insecure-tls")]
+    let l2_config = l2_config.with_skip_tls_verify(config.skip_tls_verify);
     let l2_client = Arc::new(L2Client::new(l2_config)?);
     info!(endpoint = %config.l2_eth_rpc, "L2 client initialized");
 
@@ -91,8 +94,9 @@ pub async fn run(config: ProposerConfig) -> Result<()> {
     let rollup_rpc = config.rollup_rpc.clone();
     let rollup_config = RollupClientConfig::new(rollup_rpc.clone())
         .with_timeout(config.rpc_timeout)
-        .with_retry_config(config.retry.clone())
-        .with_skip_tls_verify(config.skip_tls_verify);
+        .with_retry_config(config.retry.clone());
+    #[cfg(feature = "insecure-tls")]
+    let rollup_config = rollup_config.with_skip_tls_verify(config.skip_tls_verify);
     let rollup_client = Arc::new(RollupClient::new(rollup_config)?);
     info!(endpoint = %rollup_rpc, "Rollup client initialized");
 

--- a/crates/proof/rpc/Cargo.toml
+++ b/crates/proof/rpc/Cargo.toml
@@ -54,4 +54,4 @@ moka = { workspace = true, features = ["future"] }
 tokio = { workspace = true, features = ["test-util"] }
 
 [features]
-insecure-tls = []
+insecure-tls = [] # cfg-only flag; no additional deps needed

--- a/crates/proof/rpc/Cargo.toml
+++ b/crates/proof/rpc/Cargo.toml
@@ -52,3 +52,6 @@ moka = { workspace = true, features = ["future"] }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["test-util"] }
+
+[features]
+insecure-tls = []

--- a/crates/proof/rpc/src/l1_client.rs
+++ b/crates/proof/rpc/src/l1_client.rs
@@ -34,6 +34,7 @@ pub struct L1ClientConfig {
     /// Retry configuration.
     pub retry_config: RetryConfig,
     /// Skip TLS certificate verification.
+    #[cfg(feature = "insecure-tls")]
     pub skip_tls_verify: bool,
     /// Optional Prometheus metrics prefix for cache counters.
     pub metrics_prefix: Option<String>,
@@ -47,6 +48,7 @@ impl L1ClientConfig {
             timeout: Duration::from_secs(30),
             cache_size: DEFAULT_CACHE_SIZE,
             retry_config: RetryConfig::default(),
+            #[cfg(feature = "insecure-tls")]
             skip_tls_verify: false,
             metrics_prefix: None,
         }
@@ -71,6 +73,7 @@ impl L1ClientConfig {
     }
 
     /// Sets whether to skip TLS certificate verification.
+    #[cfg(feature = "insecure-tls")]
     pub const fn with_skip_tls_verify(mut self, skip: bool) -> Self {
         self.skip_tls_verify = skip;
         self
@@ -108,12 +111,14 @@ impl L1Client {
     /// Creates a new L1 client from the given configuration.
     pub fn new(config: L1ClientConfig) -> RpcResult<Self> {
         // Create reqwest Client with timeout
-        let mut builder = Client::builder().timeout(config.timeout);
-
-        if config.skip_tls_verify {
+        let builder = Client::builder().timeout(config.timeout);
+        #[cfg(feature = "insecure-tls")]
+        let builder = if config.skip_tls_verify {
             tracing::warn!("TLS certificate verification is disabled for L1 RPC connection");
-            builder = builder.danger_accept_invalid_certs(true);
-        }
+            builder.danger_accept_invalid_certs(true)
+        } else {
+            builder
+        };
 
         let client = builder
             .build()

--- a/crates/proof/rpc/src/l2_client.rs
+++ b/crates/proof/rpc/src/l2_client.rs
@@ -50,6 +50,7 @@ pub struct L2ClientConfig {
     /// Retry configuration.
     pub retry_config: RetryConfig,
     /// Skip TLS certificate verification.
+    #[cfg(feature = "insecure-tls")]
     pub skip_tls_verify: bool,
     /// Optional Prometheus metrics prefix for cache counters.
     pub metrics_prefix: Option<String>,
@@ -63,6 +64,7 @@ impl L2ClientConfig {
             timeout: Duration::from_secs(30),
             cache_size: DEFAULT_CACHE_SIZE,
             retry_config: RetryConfig::default(),
+            #[cfg(feature = "insecure-tls")]
             skip_tls_verify: false,
             metrics_prefix: None,
         }
@@ -87,6 +89,7 @@ impl L2ClientConfig {
     }
 
     /// Sets whether to skip TLS certificate verification.
+    #[cfg(feature = "insecure-tls")]
     pub const fn with_skip_tls_verify(mut self, skip: bool) -> Self {
         self.skip_tls_verify = skip;
         self
@@ -127,12 +130,14 @@ impl L2Client {
     /// Creates a new L2 client from the given configuration.
     pub fn new(config: L2ClientConfig) -> RpcResult<Self> {
         // Create reqwest Client with timeout
-        let mut builder = Client::builder().timeout(config.timeout);
-
-        if config.skip_tls_verify {
+        let builder = Client::builder().timeout(config.timeout);
+        #[cfg(feature = "insecure-tls")]
+        let builder = if config.skip_tls_verify {
             tracing::warn!("TLS certificate verification is disabled for L2 RPC connection");
-            builder = builder.danger_accept_invalid_certs(true);
-        }
+            builder.danger_accept_invalid_certs(true)
+        } else {
+            builder
+        };
 
         let client = builder
             .build()

--- a/crates/proof/rpc/src/rollup_client.rs
+++ b/crates/proof/rpc/src/rollup_client.rs
@@ -29,6 +29,7 @@ pub struct RollupClientConfig {
     /// Retry configuration.
     pub retry_config: RetryConfig,
     /// Skip TLS certificate verification.
+    #[cfg(feature = "insecure-tls")]
     pub skip_tls_verify: bool,
 }
 
@@ -39,6 +40,7 @@ impl RollupClientConfig {
             endpoint,
             timeout: Duration::from_secs(30),
             retry_config: RetryConfig::default(),
+            #[cfg(feature = "insecure-tls")]
             skip_tls_verify: false,
         }
     }
@@ -56,6 +58,7 @@ impl RollupClientConfig {
     }
 
     /// Sets whether to skip TLS certificate verification.
+    #[cfg(feature = "insecure-tls")]
     pub const fn with_skip_tls_verify(mut self, skip: bool) -> Self {
         self.skip_tls_verify = skip;
         self
@@ -80,12 +83,14 @@ impl RollupClient {
     /// Creates a new rollup client from the given configuration.
     pub fn new(config: RollupClientConfig) -> RpcResult<Self> {
         // Create reqwest Client with timeout
-        let mut builder = Client::builder().timeout(config.timeout);
-
-        if config.skip_tls_verify {
+        let builder = Client::builder().timeout(config.timeout);
+        #[cfg(feature = "insecure-tls")]
+        let builder = if config.skip_tls_verify {
             tracing::warn!("TLS certificate verification is disabled for rollup RPC connection");
-            builder = builder.danger_accept_invalid_certs(true);
-        }
+            builder.danger_accept_invalid_certs(true)
+        } else {
+            builder
+        };
 
         let client = builder
             .build()

--- a/crates/proof/tee/client/Cargo.toml
+++ b/crates/proof/tee/client/Cargo.toml
@@ -22,8 +22,8 @@ jsonrpsee = { workspace = true, features = ["http-client"] }
 thiserror.workspace = true
 
 # TLS (insecure-tls only)
-rustls = { workspace = true, features = ["std", "tls12"], optional = true }
 tracing = { workspace = true, optional = true }
+rustls = { workspace = true, features = ["std", "tls12"], optional = true }
 
 [features]
 insecure-tls = [ "dep:rustls", "dep:tracing" ]

--- a/crates/proof/tee/client/Cargo.toml
+++ b/crates/proof/tee/client/Cargo.toml
@@ -21,5 +21,9 @@ jsonrpsee = { workspace = true, features = ["http-client"] }
 # Error handling
 thiserror.workspace = true
 
-# TLS
-rustls = { workspace = true, features = ["std", "tls12"] }
+# TLS (insecure-tls only)
+rustls = { workspace = true, features = ["std", "tls12"], optional = true }
+tracing = { workspace = true, optional = true }
+
+[features]
+insecure-tls = [ "dep:rustls", "dep:tracing" ]

--- a/crates/proof/tee/client/src/client.rs
+++ b/crates/proof/tee/client/src/client.rs
@@ -1,5 +1,6 @@
 //! Enclave RPC client.
 
+#[cfg(feature = "insecure-tls")]
 use std::sync::Arc;
 
 use alloy_primitives::Bytes;
@@ -14,6 +15,7 @@ use jsonrpsee::{
 use crate::client_error::ClientError;
 
 /// Module for insecure TLS configuration that skips certificate verification.
+#[cfg(feature = "insecure-tls")]
 mod danger {
     use rustls::{
         DigitallySignedStruct, Error, SignatureScheme,
@@ -128,6 +130,7 @@ impl EnclaveClient {
     /// # Errors
     ///
     /// Returns an error if the HTTP client cannot be created.
+    #[cfg(feature = "insecure-tls")]
     pub fn with_tls_config(
         url: &str,
         max_request_size: u32,
@@ -136,6 +139,8 @@ impl EnclaveClient {
         let builder = HttpClientBuilder::default().max_request_size(max_request_size);
 
         let inner = if skip_tls_verify {
+            tracing::warn!("TLS certificate verification is disabled for enclave RPC connection");
+
             let tls_config = rustls::ClientConfig::builder()
                 .dangerous()
                 .with_custom_certificate_verifier(Arc::new(danger::NoCertificateVerification))


### PR DESCRIPTION
### What changed? Why?

Gates all TLS certificate verification bypass (`skip_tls_verify` / `danger_accept_invalid_certs`) behind an `insecure-tls` Cargo feature flag across the proposer, proof RPC, and TEE client crates.

Previously, the insecure TLS bypass code was always compiled in — the `skip_tls_verify` field, CLI arg, config plumbing, and the `danger` module with `NoCertificateVerification` were all present in every build. This meant `rustls` was a required dependency even when the feature was never used, and the dangerous code path was always reachable.

With this change:
- The `skip_tls_verify` config field, CLI flag, and `with_skip_tls_verify` builder methods are `#[cfg(feature = "insecure-tls")]`-gated
- The `rustls` dependency is made optional in `base-proposer` and `base-tee-client`, only pulled in when `insecure-tls` is enabled
- The `danger` module (custom `NoCertificateVerification` verifier) in the TEE client is fully gated
- The feature propagates through the crate dependency chain: `bin/proposer → base-proposer → base-proof-rpc`
- Default (production) builds compile with no TLS bypass code at all

### Notes to reviewers

The `insecure-tls` feature is additive — enabling it adds the `--skip-tls-verify` CLI flag and the associated plumbing. Without the feature, none of that code is compiled.

### How has it been tested?

- Verified the crate compiles without the feature (no TLS bypass code present)
- Verified the crate compiles with `--features insecure-tls` (all bypass plumbing available)
- Existing unit tests pass in both configurations (`#[cfg(feature = "insecure-tls")]` added to relevant test assertions)

### Change management ([definitions](http://go/change-management))

type=routine<!--routine,nonroutine,emergency-->
risk=low<!--low,medium,high-->
impact=sev5<!--sev5,sev4,sev3,sev2,sev1-->

### Backwards Compatibility ([learn more](http://go/backwards-compatibility))

backwards_compatible=true<!-- true false -->

<!-- Automatically merge your PR once the necessary approvals have been received (you probably want this) -->

automerge=false