### PR TITLE
fix(consensus): base v1 is not activated on devnet

### DIFF
--- a/actions/harness/src/test_rollup_config.rs
+++ b/actions/harness/src/test_rollup_config.rs
@@ -1,5 +1,5 @@
 use alloy_primitives::Address;
-use base_consensus_genesis::{BaseHardforkConfig, HardForkConfig, RollupConfig};
+use base_consensus_genesis::{HardForkConfig, RollupConfig};
 use base_consensus_registry::Registry;
 
 use crate::BatcherConfig;
@@ -136,8 +136,8 @@ impl TestRollupConfigBuilder {
     ///
     /// Base V1 is a standalone Base-specific fork, independent of the OP
     /// cascade chain. Chaining after any `through_*` method is fine.
-    pub fn with_base_v1_at(mut self, t: u64) -> Self {
-        self.config.hardforks.base.get_or_insert_with(BaseHardforkConfig::default).v1 = Some(t);
+    pub const fn with_base_v1_at(mut self, t: u64) -> Self {
+        self.config.hardforks.base.v1 = Some(t);
         self
     }
 
@@ -145,7 +145,7 @@ impl TestRollupConfigBuilder {
     ///
     /// `base_mainnet` intentionally keeps the harness's existing "Canyon through
     /// Fjord active" behavior; this opt-in extends that to the later upgrades.
-    pub fn all_forks_active(mut self) -> Self {
+    pub const fn all_forks_active(mut self) -> Self {
         self.config.hardforks.regolith_time = Some(0);
         self.config.hardforks.canyon_time = Some(0);
         self.config.hardforks.delta_time = Some(0);
@@ -156,7 +156,7 @@ impl TestRollupConfigBuilder {
         self.config.hardforks.pectra_blob_schedule_time = Some(0);
         self.config.hardforks.isthmus_time = Some(0);
         self.config.hardforks.jovian_time = Some(0);
-        self.config.hardforks.base.get_or_insert_with(BaseHardforkConfig::default).v1 = Some(0);
+        self.config.hardforks.base.v1 = Some(0);
         self
     }
 

--- a/crates/alloy/upgrades/src/chain.rs
+++ b/crates/alloy/upgrades/src/chain.rs
@@ -140,8 +140,7 @@ mod tests {
 
     use super::*;
     use crate::{
-        BASE_DEVNET_0_SEPOLIA_DEV_0_JOVIAN_TIMESTAMP, BASE_MAINNET_BEDROCK_BLOCK,
-        BASE_MAINNET_CANYON_TIMESTAMP, BASE_MAINNET_ECOTONE_TIMESTAMP,
+        BASE_MAINNET_BEDROCK_BLOCK, BASE_MAINNET_CANYON_TIMESTAMP, BASE_MAINNET_ECOTONE_TIMESTAMP,
         BASE_MAINNET_FJORD_TIMESTAMP, BASE_MAINNET_GRANITE_TIMESTAMP,
         BASE_MAINNET_HOLOCENE_TIMESTAMP, BASE_MAINNET_ISTHMUS_TIMESTAMP,
         BASE_MAINNET_JOVIAN_TIMESTAMP, BASE_MAINNET_REGOLITH_TIMESTAMP, BASE_SEPOLIA_BEDROCK_BLOCK,
@@ -265,16 +264,10 @@ mod tests {
         let devnet_forks = BaseChainUpgrades::devnet();
         assert!(devnet_forks.is_base_v1_active_at_timestamp(0));
 
-        // V1 activates alongside Jovian on devnet-0-sepolia-dev-0
+        // V1 is not scheduled on devnet-0-sepolia-dev-0 (ForkCondition::Never)
         let devnet0_forks = BaseChainUpgrades::base_devnet_0_sepolia_dev_0();
-        assert!(
-            !devnet0_forks
-                .is_base_v1_active_at_timestamp(BASE_DEVNET_0_SEPOLIA_DEV_0_JOVIAN_TIMESTAMP - 1)
-        );
-        assert!(
-            devnet0_forks
-                .is_base_v1_active_at_timestamp(BASE_DEVNET_0_SEPOLIA_DEV_0_JOVIAN_TIMESTAMP)
-        );
+        assert!(!devnet0_forks.is_base_v1_active_at_timestamp(0));
+        assert!(!devnet0_forks.is_base_v1_active_at_timestamp(u64::MAX));
     }
 
     #[test]

--- a/crates/alloy/upgrades/src/hardfork.rs
+++ b/crates/alloy/upgrades/src/hardfork.rs
@@ -158,10 +158,7 @@ impl BaseUpgrade {
                 ForkCondition::Timestamp(BASE_DEVNET_0_SEPOLIA_DEV_0_ISTHMUS_TIMESTAMP),
             ),
             (Self::Jovian, ForkCondition::Timestamp(BASE_DEVNET_0_SEPOLIA_DEV_0_JOVIAN_TIMESTAMP)),
-            // V1 co-activates with Jovian on this devnet. Both resolve to OpSpecId::BASE_V1
-            // since spec_by_timestamp_after_bedrock checks V1 first (newest wins). This is
-            // intentional: V1 is a strict superset of Jovian on this devnet configuration.
-            (Self::V1, ForkCondition::Timestamp(BASE_DEVNET_0_SEPOLIA_DEV_0_JOVIAN_TIMESTAMP)),
+            (Self::V1, ForkCondition::Never),
         ]
     }
 

--- a/crates/consensus/genesis/src/chain/hardfork.rs
+++ b/crates/consensus/genesis/src/chain/hardfork.rs
@@ -15,6 +15,13 @@ pub struct BaseHardforkConfig {
     pub v1: Option<u64>,
 }
 
+impl BaseHardforkConfig {
+    /// Returns true if no Base-specific hardforks are configured.
+    pub const fn is_empty(&self) -> bool {
+        self.v1.is_none()
+    }
+}
+
 /// Hardfork configuration.
 ///
 /// See: <https://github.com/ethereum-optimism/superchain-registry/blob/8ff62ada16e14dd59d0fb94ffb47761c7fa96e01/ops/internal/config/chain.go#L102-L110>
@@ -80,8 +87,11 @@ pub struct HardForkConfig {
     #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
     pub jovian_time: Option<u64>,
     /// `base` contains Base-specific hardfork activation times.
-    #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
-    pub base: Option<BaseHardforkConfig>,
+    #[cfg_attr(
+        feature = "serde",
+        serde(default, skip_serializing_if = "BaseHardforkConfig::is_empty")
+    )]
+    pub base: BaseHardforkConfig,
 }
 
 impl Display for HardForkConfig {
@@ -113,7 +123,7 @@ impl HardForkConfig {
             ("Pectra Blob Schedule", self.pectra_blob_schedule_time),
             ("Isthmus", self.isthmus_time),
             ("Jovian", self.jovian_time),
-            ("Base V1", self.base.and_then(|b| b.v1)),
+            ("Base V1", self.base.v1),
         ]
         .into_iter()
     }
@@ -148,7 +158,7 @@ mod tests {
             pectra_blob_schedule_time: None,
             isthmus_time: None,
             jovian_time: None,
-            base: None,
+            base: BaseHardforkConfig::default(),
         };
 
         let deserialized: HardForkConfig = serde_json::from_str(raw).unwrap();
@@ -195,7 +205,7 @@ mod tests {
             pectra_blob_schedule_time: None,
             isthmus_time: None,
             jovian_time: None,
-            base: None,
+            base: BaseHardforkConfig::default(),
         };
 
         let deserialized: HardForkConfig = toml::from_str(raw).unwrap();
@@ -229,7 +239,7 @@ mod tests {
             pectra_blob_schedule_time: Some(8),
             isthmus_time: Some(9),
             jovian_time: Some(10),
-            base: Some(BaseHardforkConfig { v1: Some(11) }),
+            base: BaseHardforkConfig { v1: Some(11) },
         };
 
         let mut iter = hardforks.iter();

--- a/crates/consensus/genesis/src/rollup.rs
+++ b/crates/consensus/genesis/src/rollup.rs
@@ -280,7 +280,7 @@ impl RollupConfig {
 
     /// Returns true if Base V1 is active at the given timestamp.
     pub fn is_base_v1_active(&self, timestamp: u64) -> bool {
-        self.hardforks.base.as_ref().and_then(|b| b.v1).is_some_and(|t| timestamp >= t)
+        self.hardforks.base.v1.is_some_and(|t| timestamp >= t)
     }
 
     /// Returns true if the timestamp marks the first Base V1 block.
@@ -417,13 +417,9 @@ impl BaseUpgrades for RollupConfig {
                 .unwrap_or(ForkCondition::Never),
             // V1 is standalone: not part of the Base upgrade cascade chain. It only activates
             // when explicitly configured and never implies (or is implied by) Jovian being active.
-            BaseUpgrade::V1 => self
-                .hardforks
-                .base
-                .as_ref()
-                .and_then(|b| b.v1)
-                .map(ForkCondition::Timestamp)
-                .unwrap_or(ForkCondition::Never),
+            BaseUpgrade::V1 => {
+                self.hardforks.base.v1.map(ForkCondition::Timestamp).unwrap_or(ForkCondition::Never)
+            }
             _ => ForkCondition::Never,
         }
     }
@@ -471,10 +467,10 @@ mod tests {
         assert_eq!(config.spec_id(60), base_revm::OpSpecId::ISTHMUS);
         config.hardforks.jovian_time = Some(65);
         assert_eq!(config.spec_id(65), base_revm::OpSpecId::JOVIAN);
-        config.hardforks.base = Some(crate::BaseHardforkConfig { v1: Some(70) });
+        config.hardforks.base = crate::BaseHardforkConfig { v1: Some(70) };
         assert_eq!(config.spec_id(70), base_revm::OpSpecId::BASE_V1);
         // V1 takes precedence over Jovian when both are active at the same timestamp
-        config.hardforks.base = Some(crate::BaseHardforkConfig { v1: Some(65) });
+        config.hardforks.base = crate::BaseHardforkConfig { v1: Some(65) };
         assert_eq!(config.spec_id(65), base_revm::OpSpecId::BASE_V1);
     }
 
@@ -620,7 +616,7 @@ mod tests {
         use crate::BaseHardforkConfig;
         let mut config = RollupConfig::default();
         assert!(!config.is_base_v1_active(0));
-        config.hardforks.base = Some(BaseHardforkConfig { v1: Some(10) });
+        config.hardforks.base = BaseHardforkConfig { v1: Some(10) };
         // V1 does not cascade upward to existing forks
         assert!(!config.is_regolith_active(10));
         assert!(!config.is_canyon_active(10));
@@ -644,7 +640,7 @@ mod tests {
                 pectra_blob_schedule_time: Some(80),
                 isthmus_time: Some(90),
                 jovian_time: Some(100),
-                base: Some(BaseHardforkConfig { v1: Some(110) }),
+                base: BaseHardforkConfig { v1: Some(110) },
             },
             block_time: 2,
             ..Default::default()

--- a/crates/consensus/registry/src/test_utils/base_mainnet.rs
+++ b/crates/consensus/registry/src/test_utils/base_mainnet.rs
@@ -57,7 +57,7 @@ pub const BASE_MAINNET_CONFIG: RollupConfig = RollupConfig {
         pectra_blob_schedule_time: None,
         isthmus_time: Some(BASE_MAINNET_ISTHMUS_TIMESTAMP),
         jovian_time: Some(BASE_MAINNET_JOVIAN_TIMESTAMP),
-        base: None,
+        base: base_consensus_genesis::BaseHardforkConfig { v1: None },
     },
     batch_inbox_address: address!("ff00000000000000000000000000000000008453"),
     deposit_contract_address: address!("49048044d57e1c92a77f79988d21fa8faf74e97e"),

--- a/crates/consensus/registry/src/test_utils/base_sepolia.rs
+++ b/crates/consensus/registry/src/test_utils/base_sepolia.rs
@@ -58,7 +58,7 @@ pub const BASE_SEPOLIA_CONFIG: RollupConfig = RollupConfig {
         pectra_blob_schedule_time: Some(1742486400),
         isthmus_time: Some(BASE_SEPOLIA_ISTHMUS_TIMESTAMP),
         jovian_time: Some(BASE_SEPOLIA_JOVIAN_TIMESTAMP),
-        base: None,
+        base: base_consensus_genesis::BaseHardforkConfig { v1: None },
     },
     batch_inbox_address: address!("ff00000000000000000000000000000000084532"),
     deposit_contract_address: address!("49f53e41452c74589e85ca1677426ba426459e85"),

--- a/crates/proof/tee/core/src/types/config.rs
+++ b/crates/proof/tee/core/src/types/config.rs
@@ -251,7 +251,7 @@ impl PerChainConfig {
                 pectra_blob_schedule_time: None,
                 isthmus_time: Some(0),
                 jovian_time: Some(0),
-                base: Some(BaseHardforkConfig { v1: Some(0) }),
+                base: BaseHardforkConfig { v1: Some(0) },
             },
             chain_op_config: BaseFeeConfig::base_mainnet(),
         }


### PR DESCRIPTION
### Description
- Base V1 should not be activated on `devnet-0-sepolia-dev-0` yet
- Remove the nested optionals on base hardfork activation times