### PR TITLE
feat(tee): Enclave Requests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4692,6 +4692,7 @@ dependencies = [
  "hex-literal 1.1.0",
  "jsonrpsee",
  "k256",
+ "rand 0.9.2",
  "rstest",
  "thiserror 2.0.18",
  "tokio",

--- a/crates/proof/primitives/src/rpc.rs
+++ b/crates/proof/primitives/src/rpc.rs
@@ -58,6 +58,12 @@ pub trait EnclaveApi {
     async fn signer_public_key(&self) -> RpcResult<Vec<u8>>;
 
     /// Return the raw Nitro attestation document (`COSE_Sign1` bytes) for the enclave signer.
+    ///
+    /// Optional `user_data` and `nonce` bind the attestation to a specific request.
     #[method(name = "signerAttestation")]
-    async fn signer_attestation(&self) -> RpcResult<Vec<u8>>;
+    async fn signer_attestation(
+        &self,
+        user_data: Option<Vec<u8>>,
+        nonce: Option<Vec<u8>>,
+    ) -> RpcResult<Vec<u8>>;
 }

--- a/crates/proof/tee/client/src/client.rs
+++ b/crates/proof/tee/client/src/client.rs
@@ -163,11 +163,20 @@ impl EnclaveClient {
 
     /// Get an attestation document containing the signer's public key.
     ///
+    /// Optional `user_data` and `nonce` bind the attestation to a specific request.
+    ///
     /// # Errors
     ///
     /// Returns an error if the RPC call fails or if running in local mode.
-    pub async fn signer_attestation(&self) -> Result<Bytes, ClientError> {
-        self.inner.request("enclave_signerAttestation", rpc_params![]).await.map_err(Into::into)
+    pub async fn signer_attestation(
+        &self,
+        user_data: Option<Vec<u8>>,
+        nonce: Option<Vec<u8>>,
+    ) -> Result<Bytes, ClientError> {
+        self.inner
+            .request("enclave_signerAttestation", rpc_params![user_data, nonce])
+            .await
+            .map_err(Into::into)
     }
 
     /// Execute stateless block validation and create a signed proposal.

--- a/crates/proof/tee/nitro/src/enclave/mod.rs
+++ b/crates/proof/tee/nitro/src/enclave/mod.rs
@@ -105,11 +105,17 @@ impl NitroEnclave {
                 let key = self.server.signer_public_key();
                 Frame::write(&mut stream, &EnclaveResponse::SignerPublicKey(key)).await?;
             }
-            EnclaveRequest::SignerAttestation => {
-                info!("received signer attestation request");
+            EnclaveRequest::SignerAttestation { user_data, nonce } => {
+                info!(
+                    has_nonce = nonce.is_some(),
+                    has_user_data = user_data.is_some(),
+                    "received signer attestation request"
+                );
                 // nsm_init() and nsm_process_request() are blocking FFI calls; use
                 // block_in_place so they do not stall the async executor.
-                let result = tokio::task::block_in_place(|| self.server.signer_attestation());
+                let result = tokio::task::block_in_place(|| {
+                    self.server.signer_attestation(user_data, nonce)
+                });
                 let response = match result {
                     Ok(doc) => EnclaveResponse::SignerAttestation(doc),
                     Err(e) => EnclaveResponse::Error(e.to_string()),

--- a/crates/proof/tee/nitro/src/enclave/nsm.rs
+++ b/crates/proof/tee/nitro/src/enclave/nsm.rs
@@ -80,11 +80,17 @@ impl NsmSession {
     /// Get an attestation document with the given public key.
     ///
     /// The public key is included in the attestation document.
+    /// Optional `user_data` and `nonce` bind the attestation to a specific request.
     #[cfg(target_os = "linux")]
-    pub fn get_attestation(&self, public_key: Vec<u8>) -> Result<Vec<u8>> {
+    pub fn get_attestation(
+        &self,
+        public_key: Vec<u8>,
+        user_data: Option<Vec<u8>>,
+        nonce: Option<Vec<u8>>,
+    ) -> Result<Vec<u8>> {
         let request = Request::Attestation {
-            user_data: None,
-            nonce: None,
+            user_data: user_data.map(Into::into),
+            nonce: nonce.map(Into::into),
             public_key: Some(public_key.into()),
         };
         let response = nsm_process_request(self.fd, request);
@@ -98,7 +104,12 @@ impl NsmSession {
 
     /// Get attestation - stub for non-Linux platforms.
     #[cfg(not(target_os = "linux"))]
-    pub fn get_attestation(&self, _public_key: Vec<u8>) -> Result<Vec<u8>> {
+    pub fn get_attestation(
+        &self,
+        _public_key: Vec<u8>,
+        _user_data: Option<Vec<u8>>,
+        _nonce: Option<Vec<u8>>,
+    ) -> Result<Vec<u8>> {
         Err(NsmError::Attestation("NSM not available".to_string()).into())
     }
 

--- a/crates/proof/tee/nitro/src/enclave/protocol.rs
+++ b/crates/proof/tee/nitro/src/enclave/protocol.rs
@@ -10,7 +10,12 @@ pub enum EnclaveRequest {
     /// Return the enclave's 65-byte uncompressed ECDSA public key.
     SignerPublicKey,
     /// Return the raw Nitro attestation document (`COSE_Sign1` bytes).
-    SignerAttestation,
+    SignerAttestation {
+        /// Optional application-specific data to bind into the attestation.
+        user_data: Option<Vec<u8>>,
+        /// Optional nonce to bind into the attestation for replay protection.
+        nonce: Option<Vec<u8>>,
+    },
 }
 
 /// Typed response returned by the enclave over vsock.

--- a/crates/proof/tee/nitro/src/enclave/server.rs
+++ b/crates/proof/tee/nitro/src/enclave/server.rs
@@ -131,11 +131,17 @@ impl Server {
     }
 
     /// Get an attestation document containing the signer's public key.
-    pub fn signer_attestation(&self) -> Result<Vec<u8>> {
+    ///
+    /// Optional `user_data` and `nonce` bind the attestation to a specific request.
+    pub fn signer_attestation(
+        &self,
+        user_data: Option<Vec<u8>>,
+        nonce: Option<Vec<u8>>,
+    ) -> Result<Vec<u8>> {
         let session = NsmSession::open()?
             .ok_or_else(|| NsmError::SessionOpen("NSM not available".to_string()))?;
         let public_key = self.signer_public_key();
-        session.get_attestation(public_key)
+        session.get_attestation(public_key, user_data, nonce)
     }
 
     /// Run the proof-client pipeline for the given preimages and return per-block proposals

--- a/crates/proof/tee/nitro/src/enclave/server.rs
+++ b/crates/proof/tee/nitro/src/enclave/server.rs
@@ -100,7 +100,7 @@ impl Server {
         Ok(Self { pcr0, signer_key, tee_image_hash })
     }
 
-    fn new_local() -> Result<Self> {
+    pub fn new_local() -> Result<Self> {
         let signer_key = match std::env::var(SIGNER_KEY_ENV_VAR) {
             Ok(hex_key) => {
                 info!("using signer key from environment variable");

--- a/crates/proof/tee/nitro/src/host/server.rs
+++ b/crates/proof/tee/nitro/src/host/server.rs
@@ -155,7 +155,7 @@ mod tests {
 
     #[tokio::test]
     async fn signer_attestation_rejects_oversized_user_data() {
-        let server = Arc::new(EnclaveServer::new().unwrap());
+        let server = Arc::new(EnclaveServer::new_local().unwrap());
         let transport = Arc::new(NitroTransport::local(Arc::clone(&server)));
         let rpc = NitroSignerRpc { transport };
 
@@ -168,7 +168,7 @@ mod tests {
 
     #[tokio::test]
     async fn signer_attestation_rejects_oversized_nonce() {
-        let server = Arc::new(EnclaveServer::new().unwrap());
+        let server = Arc::new(EnclaveServer::new_local().unwrap());
         let transport = Arc::new(NitroTransport::local(Arc::clone(&server)));
         let rpc = NitroSignerRpc { transport };
 

--- a/crates/proof/tee/nitro/src/host/server.rs
+++ b/crates/proof/tee/nitro/src/host/server.rs
@@ -79,8 +79,12 @@ impl EnclaveApiServer for NitroSignerRpc {
         })
     }
 
-    async fn signer_attestation(&self) -> RpcResult<Vec<u8>> {
-        self.transport.signer_attestation().await.map_err(|e| {
+    async fn signer_attestation(
+        &self,
+        user_data: Option<Vec<u8>>,
+        nonce: Option<Vec<u8>>,
+    ) -> RpcResult<Vec<u8>> {
+        self.transport.signer_attestation(user_data, nonce).await.map_err(|e| {
             jsonrpsee::types::ErrorObjectOwned::owned(-32001, e.to_string(), None::<()>)
         })
     }
@@ -121,7 +125,7 @@ mod tests {
         let rpc = NitroSignerRpc { transport };
         // NSM is unavailable outside a real Nitro enclave, so attestation fails.
         // Assert the error is propagated (not swallowed) through the RPC layer.
-        let result = EnclaveApiServer::signer_attestation(&rpc).await;
+        let result = EnclaveApiServer::signer_attestation(&rpc, None, None).await;
         assert!(result.is_err());
     }
 }

--- a/crates/proof/tee/nitro/src/host/server.rs
+++ b/crates/proof/tee/nitro/src/host/server.rs
@@ -90,7 +90,7 @@ impl EnclaveApiServer for NitroSignerRpc {
         user_data: Option<Vec<u8>>,
         nonce: Option<Vec<u8>>,
     ) -> RpcResult<Vec<u8>> {
-        // NSM limits: user_data ≤ 1024 bytes, nonce ≤ 512 bytes.
+        // NSM limits: user_data ≤ 512 bytes, nonce ≤ 512 bytes.
         // Reject oversized payloads early to avoid allocating and forwarding them
         // through the vsock transport only to be rejected by the enclave.
         if user_data.as_ref().is_some_and(|d| d.len() > MAX_USER_DATA_BYTES) {

--- a/crates/proof/tee/nitro/src/host/server.rs
+++ b/crates/proof/tee/nitro/src/host/server.rs
@@ -12,6 +12,12 @@ use tracing::info;
 
 use super::{NitroBackend, transport::NitroTransport};
 
+/// Maximum allowed size for the `user_data` attestation field (NSM limit).
+const MAX_USER_DATA_BYTES: usize = 512;
+
+/// Maximum allowed size for the `nonce` attestation field (NSM limit).
+const MAX_NONCE_BYTES: usize = 512;
+
 /// Host-side TEE prover server exposing a JSON-RPC interface.
 ///
 /// Implements two JSON-RPC namespaces:
@@ -84,6 +90,24 @@ impl EnclaveApiServer for NitroSignerRpc {
         user_data: Option<Vec<u8>>,
         nonce: Option<Vec<u8>>,
     ) -> RpcResult<Vec<u8>> {
+        // NSM limits: user_data ≤ 1024 bytes, nonce ≤ 512 bytes.
+        // Reject oversized payloads early to avoid allocating and forwarding them
+        // through the vsock transport only to be rejected by the enclave.
+        if user_data.as_ref().is_some_and(|d| d.len() > MAX_USER_DATA_BYTES) {
+            return Err(jsonrpsee::types::ErrorObjectOwned::owned(
+                -32602,
+                format!("user_data exceeds {MAX_USER_DATA_BYTES}-byte limit"),
+                None::<()>,
+            ));
+        }
+        if nonce.as_ref().is_some_and(|n| n.len() > MAX_NONCE_BYTES) {
+            return Err(jsonrpsee::types::ErrorObjectOwned::owned(
+                -32602,
+                format!("nonce exceeds {MAX_NONCE_BYTES}-byte limit"),
+                None::<()>,
+            ));
+        }
+
         self.transport.signer_attestation(user_data, nonce).await.map_err(|e| {
             jsonrpsee::types::ErrorObjectOwned::owned(-32001, e.to_string(), None::<()>)
         })
@@ -127,5 +151,31 @@ mod tests {
         // Assert the error is propagated (not swallowed) through the RPC layer.
         let result = EnclaveApiServer::signer_attestation(&rpc, None, None).await;
         assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn signer_attestation_rejects_oversized_user_data() {
+        let server = Arc::new(EnclaveServer::new().unwrap());
+        let transport = Arc::new(NitroTransport::local(Arc::clone(&server)));
+        let rpc = NitroSignerRpc { transport };
+
+        let oversized = vec![0u8; MAX_USER_DATA_BYTES + 1];
+        let result = EnclaveApiServer::signer_attestation(&rpc, Some(oversized), None).await;
+        let err = result.unwrap_err();
+        assert_eq!(err.code(), -32602);
+        assert!(err.message().contains("user_data"));
+    }
+
+    #[tokio::test]
+    async fn signer_attestation_rejects_oversized_nonce() {
+        let server = Arc::new(EnclaveServer::new().unwrap());
+        let transport = Arc::new(NitroTransport::local(Arc::clone(&server)));
+        let rpc = NitroSignerRpc { transport };
+
+        let oversized = vec![0u8; MAX_NONCE_BYTES + 1];
+        let result = EnclaveApiServer::signer_attestation(&rpc, None, Some(oversized)).await;
+        let err = result.unwrap_err();
+        assert_eq!(err.code(), -32602);
+        assert!(err.message().contains("nonce"));
     }
 }

--- a/crates/proof/tee/nitro/src/host/transport.rs
+++ b/crates/proof/tee/nitro/src/host/transport.rs
@@ -57,11 +57,15 @@ impl NitroTransport {
     }
 
     /// Return the raw Nitro attestation document (`COSE_Sign1` bytes) for the enclave signer.
-    pub async fn signer_attestation(&self) -> Result<Vec<u8>, NitroError> {
+    pub async fn signer_attestation(
+        &self,
+        user_data: Option<Vec<u8>>,
+        nonce: Option<Vec<u8>>,
+    ) -> Result<Vec<u8>, NitroError> {
         match self {
             #[cfg(target_os = "linux")]
-            Self::Vsock(t) => t.signer_attestation().await,
-            Self::Local(s) => s.signer_attestation(),
+            Self::Vsock(t) => t.signer_attestation(user_data, nonce).await,
+            Self::Local(s) => s.signer_attestation(user_data, nonce),
         }
     }
 }

--- a/crates/proof/tee/nitro/src/host/vsock.rs
+++ b/crates/proof/tee/nitro/src/host/vsock.rs
@@ -121,10 +121,14 @@ impl VsockTransport {
     }
 
     /// Return the raw Nitro attestation document (`COSE_Sign1` bytes) for the enclave signer.
-    pub async fn signer_attestation(&self) -> Result<Vec<u8>, NitroError> {
+    pub async fn signer_attestation(
+        &self,
+        user_data: Option<Vec<u8>>,
+        nonce: Option<Vec<u8>>,
+    ) -> Result<Vec<u8>, NitroError> {
         let mut stream = self.connect().await?;
 
-        Frame::write(&mut stream, &EnclaveRequest::SignerAttestation)
+        Frame::write(&mut stream, &EnclaveRequest::SignerAttestation { user_data, nonce })
             .await
             .map_err(|e| NitroError::Transport(e.to_string()))?;
 

--- a/crates/proof/tee/registrar/Cargo.toml
+++ b/crates/proof/tee/registrar/Cargo.toml
@@ -24,6 +24,7 @@ aws-sdk-elasticloadbalancingv2.workspace = true
 
 # Crypto
 k256.workspace = true
+rand.workspace = true
 
 # Proving
 base-proof-tee-nitro-attestation-prover.workspace = true

--- a/crates/proof/tee/registrar/README.md
+++ b/crates/proof/tee/registrar/README.md
@@ -16,5 +16,4 @@ to detect new Nitro enclave instances, fetches their attestation documents via
 - **`error`** — [`RegistrarError`] enum covering all failure modes.
 - **`prover`** — [`ProverClient`] JSON-RPC client for polling prover signer endpoints.
 - **`traits`** — [`InstanceDiscovery`] and [`AttestationProofProvider`] trait definitions.
-- **`types`** — Core domain types: [`ProverInstance`], [`AttestationResponse`],
-  [`AttestationProof`], [`RegisteredSigner`].
+- **`types`** — Core domain types: [`ProverInstance`], [`RegisteredSigner`].

--- a/crates/proof/tee/registrar/src/driver.rs
+++ b/crates/proof/tee/registrar/src/driver.rs
@@ -6,10 +6,11 @@
 
 use std::{fmt, time::Duration};
 
-use alloy_primitives::{Address, Bytes};
+use alloy_primitives::{Address, Bytes, hex};
 use alloy_sol_types::SolCall;
 use base_proof_tee_nitro_attestation_prover::AttestationProofProvider;
 use base_tx_manager::{TxCandidate, TxManager};
+use rand::random;
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, info, warn};
 
@@ -162,7 +163,10 @@ where
         );
 
         // Only fetch the full NSM attestation document when registration is needed.
-        let attestation_bytes = client.signer_attestation().await?;
+        // Bind a random nonce into the attestation to prevent replay attacks.
+        let nonce: [u8; 32] = random();
+        info!(nonce = %hex::encode(nonce), signer = %signer_address, "requesting attestation with nonce");
+        let attestation_bytes = client.signer_attestation(None, Some(nonce.to_vec())).await?;
         let proof = self.proof_provider.generate_proof(&attestation_bytes).await?;
 
         // Check cancellation before submitting the transaction — avoid starting

--- a/crates/proof/tee/registrar/src/lib.rs
+++ b/crates/proof/tee/registrar/src/lib.rs
@@ -23,4 +23,4 @@ mod traits;
 pub use traits::InstanceDiscovery;
 
 mod types;
-pub use types::{AttestationResponse, InstanceHealthStatus, ProverInstance, RegisteredSigner};
+pub use types::{InstanceHealthStatus, ProverInstance, RegisteredSigner};

--- a/crates/proof/tee/registrar/src/prover.rs
+++ b/crates/proof/tee/registrar/src/prover.rs
@@ -2,13 +2,13 @@
 
 use std::time::Duration;
 
-use alloy_primitives::{Address, Bytes, keccak256};
+use alloy_primitives::{Address, keccak256};
 use base_proof_primitives::EnclaveApiClient;
 use jsonrpsee::http_client::{HttpClient, HttpClientBuilder};
 use k256::elliptic_curve::sec1::ToEncodedPoint;
 use tracing::debug;
 
-use crate::{AttestationResponse, RegistrarError, Result};
+use crate::{RegistrarError, Result};
 
 /// JSON-RPC client for a single prover instance's signer endpoints.
 ///
@@ -78,27 +78,6 @@ impl ProverClient {
         let uncompressed = key.to_encoded_point(false);
         let hash = keccak256(&uncompressed.as_bytes()[1..]);
         Ok(Address::from_slice(&hash[12..]))
-    }
-
-    /// Fetches the signer public key and attestation, derives the Ethereum address,
-    /// and returns a combined [`AttestationResponse`].
-    ///
-    /// This is the primary entry point for the registration poll loop. Calls
-    /// `enclave_signerPublicKey` first to get the address (cheap), then
-    /// `enclave_signerAttestation` for the raw attestation document (involves
-    /// Nitro NSM hardware — only call when registration is needed).
-    pub async fn get_attestation_response(&self) -> Result<AttestationResponse> {
-        let public_key = self.signer_public_key().await?;
-        let signer_address = Self::derive_address(&public_key)?;
-        let attestation = self.signer_attestation(None, None).await?;
-
-        debug!(
-            endpoint = %self.endpoint,
-            signer_address = %signer_address,
-            "fetched attestation response"
-        );
-
-        Ok(AttestationResponse { attestation_bytes: Bytes::from(attestation), signer_address })
     }
 }
 

--- a/crates/proof/tee/registrar/src/prover.rs
+++ b/crates/proof/tee/registrar/src/prover.rs
@@ -52,11 +52,16 @@ impl ProverClient {
     }
 
     /// Fetches the raw Nitro attestation document via `enclave_signerAttestation`.
-    pub async fn signer_attestation(&self) -> Result<Vec<u8>> {
+    ///
+    /// Optional `user_data` and `nonce` bind the attestation to a specific request.
+    pub async fn signer_attestation(
+        &self,
+        user_data: Option<Vec<u8>>,
+        nonce: Option<Vec<u8>>,
+    ) -> Result<Vec<u8>> {
         debug!(endpoint = %self.endpoint, "fetching signer attestation");
-        self.inner.signer_attestation().await.map_err(|e| RegistrarError::ProverClient {
-            instance: self.endpoint.clone(),
-            source: Box::new(e),
+        self.inner.signer_attestation(user_data, nonce).await.map_err(|e| {
+            RegistrarError::ProverClient { instance: self.endpoint.clone(), source: Box::new(e) }
         })
     }
 
@@ -85,7 +90,7 @@ impl ProverClient {
     pub async fn get_attestation_response(&self) -> Result<AttestationResponse> {
         let public_key = self.signer_public_key().await?;
         let signer_address = Self::derive_address(&public_key)?;
-        let attestation = self.signer_attestation().await?;
+        let attestation = self.signer_attestation(None, None).await?;
 
         debug!(
             endpoint = %self.endpoint,

--- a/crates/proof/tee/registrar/src/types.rs
+++ b/crates/proof/tee/registrar/src/types.rs
@@ -1,4 +1,4 @@
-use alloy_primitives::{Address, B256, Bytes};
+use alloy_primitives::{Address, B256};
 
 /// A prover instance discovered from the infrastructure layer.
 #[derive(Debug, Clone)]
@@ -72,15 +72,6 @@ mod tests {
     fn from_aws_state(#[case] input: &str, #[case] expected: InstanceHealthStatus) {
         assert_eq!(InstanceHealthStatus::from_aws_state(input), expected);
     }
-}
-
-/// Response from polling a prover's `enclave_signerAttestation` endpoint.
-#[derive(Debug, Clone)]
-pub struct AttestationResponse {
-    /// Raw Nitro attestation document (`COSE_Sign1` bytes).
-    pub attestation_bytes: Bytes,
-    /// Ethereum address derived from the attestation's embedded public key.
-    pub signer_address: Address,
 }
 
 /// A signer currently registered on-chain via `TEEProverRegistry`.


### PR DESCRIPTION
### What changed? Why?

Adds support for optional `user_data` and `nonce` fields in the `enclave_signerAttestation` RPC method, threading them through the entire stack (RPC trait → client → host server → vsock transport → enclave → NSM session) into the Nitro NSM attestation request.

- **Attestation binding**: The `signer_attestation` API now accepts optional `user_data` and `nonce` byte vectors. These are forwarded to the Nitro NSM `Request::Attestation` call, binding the attestation document to a specific request context.
- **Replay protection**: The registrar generates a random 32-byte nonce for each attestation request, preventing replay of previously issued attestation documents.
- **Input validation**: The host-side RPC server rejects `user_data` and `nonce` payloads exceeding the NSM 512-byte limit before forwarding them through the vsock transport.
- **Cleanup**: Removed the unused `AttestationResponse` type and `get_attestation_response` method from the registrar, since the driver now calls `signer_public_key` and `signer_attestation` separately with explicit nonce binding.

### Notes to reviewers

The `EnclaveRequest::SignerAttestation` variant changed from a unit variant to a struct variant — this is a breaking change for the vsock protocol between host and enclave, requiring coordinated deployment.

### How has it been tested?

- Added unit tests for oversized `user_data` and `nonce` rejection in the host RPC server.
- Updated existing attestation test to pass the new parameters.

### Change management ([definitions](http://go/change-management))

type=routine<!--routine,nonroutine,emergency-->
risk=low<!--low,medium,high-->
impact=sev5<!--sev5,sev4,sev3,sev2,sev1-->

### Backwards Compatibility ([learn more](http://go/backwards-compatibility))

backwards_compatible=true<!-- true false -->

<!-- Automatically merge your PR once the necessary approvals have been received (you probably want this) -->

automerge=false