### PR TITLE
chore: activate osaka alongside base v1

### DIFF
--- a/crates/alloy/upgrades/src/chain.rs
+++ b/crates/alloy/upgrades/src/chain.rs
@@ -74,6 +74,7 @@ impl EthereumHardforks for BaseChainUpgrades {
             Shanghai if forks_len <= Canyon.idx() => ForkCondition::Never,
             Cancun if forks_len <= Ecotone.idx() => ForkCondition::Never,
             Prague if forks_len <= Isthmus.idx() => ForkCondition::Never,
+            Osaka if forks_len <= V1.idx() => ForkCondition::Never,
             _ => self[fork],
         }
     }
@@ -114,7 +115,7 @@ impl Index<EthereumHardfork> for BaseChainUpgrades {
     fn index(&self, hf: EthereumHardfork) -> &Self::Output {
         match hf {
             // Dao Hardfork is not needed for BaseChainUpgrades
-            Dao | Osaka | Bpo1 | Bpo2 | Bpo3 | Bpo4 | Bpo5 | Amsterdam => &ForkCondition::Never,
+            Dao | Bpo1 | Bpo2 | Bpo3 | Bpo4 | Bpo5 | Amsterdam => &ForkCondition::Never,
             Frontier | Homestead | Tangerine | SpuriousDragon | Byzantium | Constantinople
             | Petersburg | Istanbul | MuirGlacier | Berlin => &ForkCondition::ZERO_BLOCK,
             London | ArrowGlacier | GrayGlacier => &self[Bedrock],
@@ -126,6 +127,7 @@ impl Index<EthereumHardfork> for BaseChainUpgrades {
             Shanghai => &self[Canyon],
             Cancun => &self[Ecotone],
             Prague => &self[Isthmus],
+            Osaka => &self[V1],
             _ => unreachable!(),
         }
     }
@@ -274,6 +276,27 @@ mod tests {
         assert!(
             devnet0_forks
                 .is_base_v1_active_at_timestamp(BASE_DEVNET_0_SEPOLIA_DEV_0_JOVIAN_TIMESTAMP)
+        );
+    }
+
+    #[test]
+    fn osaka_tracks_base_v1_activation() {
+        let base_mainnet_forks = BaseChainUpgrades::mainnet();
+        assert_eq!(
+            base_mainnet_forks.ethereum_fork_activation(EthereumHardfork::Osaka),
+            ForkCondition::Never
+        );
+
+        let devnet_forks = BaseChainUpgrades::devnet();
+        assert_eq!(
+            devnet_forks.ethereum_fork_activation(EthereumHardfork::Osaka),
+            ForkCondition::ZERO_TIMESTAMP
+        );
+
+        let devnet0_forks = BaseChainUpgrades::base_devnet_0_sepolia_dev_0();
+        assert_eq!(
+            devnet0_forks.ethereum_fork_activation(EthereumHardfork::Osaka),
+            ForkCondition::Never
         );
     }
 

--- a/crates/execution/evm/src/l1.rs
+++ b/crates/execution/evm/src/l1.rs
@@ -294,7 +294,9 @@ pub fn parse_l1_info_tx_jovian(data: &[u8]) -> Result<L1BlockInfo, OpBlockExecut
 /// Returns the [`OpSpecId`] at the given timestamp using the [`BaseUpgrades`] trait from
 /// `base-execution-forks`.
 fn op_spec_id(chain_spec: &impl BaseUpgrades, timestamp: u64) -> OpSpecId {
-    if chain_spec.is_jovian_active_at_timestamp(timestamp) {
+    if chain_spec.is_base_v1_active_at_timestamp(timestamp) {
+        OpSpecId::BASE_V1
+    } else if chain_spec.is_jovian_active_at_timestamp(timestamp) {
         OpSpecId::JOVIAN
     } else if chain_spec.is_isthmus_active_at_timestamp(timestamp) {
         OpSpecId::ISTHMUS

--- a/crates/execution/hardforks/src/chain.rs
+++ b/crates/execution/hardforks/src/chain.rs
@@ -57,14 +57,21 @@ impl BaseChainUpgradesExt for BaseChainUpgrades {
         forks.push((BaseUpgrade::Holocene.boxed(), self[BaseUpgrade::Holocene]));
 
         let isthmus = self[BaseUpgrade::Isthmus];
-        forks.push((EthereumHardfork::Prague.boxed(), isthmus));
-        forks.push((BaseUpgrade::Isthmus.boxed(), isthmus));
+        if !matches!(isthmus, ForkCondition::Never) {
+            forks.push((EthereumHardfork::Prague.boxed(), isthmus));
+            forks.push((BaseUpgrade::Isthmus.boxed(), isthmus));
+        }
 
-        forks.push((BaseUpgrade::Jovian.boxed(), self[BaseUpgrade::Jovian]));
+        let jovian = self[BaseUpgrade::Jovian];
+        if !matches!(jovian, ForkCondition::Never) {
+            forks.push((BaseUpgrade::Jovian.boxed(), jovian));
+        }
 
         let base_v1 = self[BaseUpgrade::V1];
-        forks.push((EthereumHardfork::Osaka.boxed(), base_v1));
-        forks.push((BaseUpgrade::V1.boxed(), base_v1));
+        if !matches!(base_v1, ForkCondition::Never) {
+            forks.push((EthereumHardfork::Osaka.boxed(), base_v1));
+            forks.push((BaseUpgrade::V1.boxed(), base_v1));
+        }
 
         ChainHardforks::new(forks)
     }

--- a/crates/execution/hardforks/src/chain.rs
+++ b/crates/execution/hardforks/src/chain.rs
@@ -10,7 +10,8 @@ pub trait BaseChainUpgradesExt {
     /// Expands Base hardforks into a full [`ChainHardforks`] including implied Ethereum entries.
     ///
     /// Pre-Bedrock Ethereum hardforks are set to block 0. Paired Ethereum hardforks
-    /// use their Base counterpart's timestamp: Shanghai=Canyon, Cancun=Ecotone, Prague=Isthmus.
+    /// use their Base counterpart's timestamp:
+    /// Shanghai=Canyon, Cancun=Ecotone, Prague=Isthmus, Osaka=V1.
     fn to_chain_hardforks(&self) -> ChainHardforks;
 }
 
@@ -62,9 +63,8 @@ impl BaseChainUpgradesExt for BaseChainUpgrades {
         forks.push((BaseUpgrade::Jovian.boxed(), self[BaseUpgrade::Jovian]));
 
         let base_v1 = self[BaseUpgrade::V1];
-        if base_v1 != ForkCondition::Never {
-            forks.push((BaseUpgrade::V1.boxed(), base_v1));
-        }
+        forks.push((EthereumHardfork::Osaka.boxed(), base_v1));
+        forks.push((BaseUpgrade::V1.boxed(), base_v1));
 
         ChainHardforks::new(forks)
     }
@@ -85,3 +85,23 @@ pub static BASE_MAINNET_HARDFORKS: Lazy<ChainHardforks> =
 /// Base devnet-0-sepolia-dev-0 list of hardforks.
 pub static BASE_DEVNET_0_SEPOLIA_DEV_0_HARDFORKS: Lazy<ChainHardforks> =
     Lazy::new(|| BaseChainUpgrades::base_devnet_0_sepolia_dev_0().to_chain_hardforks());
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn base_v1_expands_to_osaka() {
+        let hardforks =
+            BaseChainUpgrades::new(BaseUpgrade::devnet().into_iter().map(|(fork, cond)| {
+                if fork == BaseUpgrade::V1 {
+                    (fork, ForkCondition::Timestamp(1_000_000))
+                } else {
+                    (fork, cond)
+                }
+            }))
+            .to_chain_hardforks();
+        assert_eq!(hardforks.get(BaseUpgrade::V1), Some(ForkCondition::Timestamp(1_000_000)));
+        assert_eq!(hardforks.get(EthereumHardfork::Osaka), hardforks.get(BaseUpgrade::V1));
+    }
+}

--- a/crates/execution/revm/src/precompiles.rs
+++ b/crates/execution/revm/src/precompiles.rs
@@ -36,7 +36,7 @@ impl OpPrecompiles {
             OpSpecId::FJORD => fjord(),
             OpSpecId::GRANITE | OpSpecId::HOLOCENE => granite(),
             OpSpecId::ISTHMUS => isthmus(),
-            OpSpecId::OSAKA | OpSpecId::JOVIAN | OpSpecId::BASE_V1 => jovian(),
+            OpSpecId::JOVIAN | OpSpecId::BASE_V1 => jovian(),
         };
 
         Self { inner: EthPrecompiles { precompiles, spec: SpecId::default() }, spec }

--- a/crates/execution/revm/src/spec.rs
+++ b/crates/execution/revm/src/spec.rs
@@ -1,7 +1,7 @@
 //! Contains the `[OpSpecId]` type and its implementation.
 use core::str::FromStr;
 
-use revm::primitives::hardfork::{SpecId, UnknownHardfork, name as eth_name};
+use revm::primitives::hardfork::{SpecId, UnknownHardfork};
 
 /// Base spec id.
 #[repr(u8)]
@@ -30,8 +30,6 @@ pub enum OpSpecId {
     JOVIAN,
     /// Base V1 spec id.
     BASE_V1,
-    /// Osaka spec id.
-    OSAKA,
 }
 
 impl OpSpecId {
@@ -41,8 +39,8 @@ impl OpSpecId {
             Self::BEDROCK | Self::REGOLITH => SpecId::MERGE,
             Self::CANYON => SpecId::SHANGHAI,
             Self::ECOTONE | Self::FJORD | Self::GRANITE | Self::HOLOCENE => SpecId::CANCUN,
-            Self::ISTHMUS | Self::JOVIAN | Self::BASE_V1 => SpecId::PRAGUE,
-            Self::OSAKA => SpecId::OSAKA,
+            Self::ISTHMUS | Self::JOVIAN => SpecId::PRAGUE,
+            Self::BASE_V1 => SpecId::OSAKA,
         }
     }
 
@@ -73,7 +71,6 @@ impl FromStr for OpSpecId {
             name::ISTHMUS => Ok(Self::ISTHMUS),
             name::JOVIAN => Ok(Self::JOVIAN),
             name::BASE_V1 => Ok(Self::BASE_V1),
-            eth_name::OSAKA => Ok(Self::OSAKA),
             _ => Err(UnknownHardfork),
         }
     }
@@ -92,7 +89,6 @@ impl From<OpSpecId> for &'static str {
             OpSpecId::ISTHMUS => name::ISTHMUS,
             OpSpecId::JOVIAN => name::JOVIAN,
             OpSpecId::BASE_V1 => name::BASE_V1,
-            OpSpecId::OSAKA => eth_name::OSAKA,
         }
     }
 }
@@ -217,6 +213,7 @@ mod tests {
             (
                 OpSpecId::BASE_V1,
                 vec![
+                    (SpecId::OSAKA, true),
                     (SpecId::PRAGUE, true),
                     (SpecId::SHANGHAI, true),
                     (SpecId::CANCUN, true),

--- a/crates/proof/fpvm-precompiles/src/precompiles/provider.rs
+++ b/crates/proof/fpvm-precompiles/src/precompiles/provider.rs
@@ -46,7 +46,7 @@ where
             OpSpecId::FJORD => fjord(),
             OpSpecId::GRANITE | OpSpecId::HOLOCENE => granite(),
             OpSpecId::ISTHMUS => isthmus(),
-            OpSpecId::OSAKA | OpSpecId::JOVIAN | OpSpecId::BASE_V1 => jovian(),
+            OpSpecId::JOVIAN | OpSpecId::BASE_V1 => jovian(),
         };
 
         let accelerated_precompiles = match spec {
@@ -56,7 +56,7 @@ where
             OpSpecId::ECOTONE | OpSpecId::FJORD => accelerated_ecotone::<H, O>(),
             OpSpecId::GRANITE | OpSpecId::HOLOCENE => accelerated_granite::<H, O>(),
             OpSpecId::ISTHMUS => accelerated_isthmus::<H, O>(),
-            OpSpecId::OSAKA | OpSpecId::JOVIAN | OpSpecId::BASE_V1 => accelerated_jovian::<H, O>(),
+            OpSpecId::JOVIAN | OpSpecId::BASE_V1 => accelerated_jovian::<H, O>(),
         };
 
         Self {

--- a/docs/guides/UPGRADES.md
+++ b/docs/guides/UPGRADES.md
@@ -323,7 +323,7 @@ If the upgrade introduces new precompiles, create a new `base_v1()` function. If
 
 ```rust
 // Reuse previous precompile set
-OpSpecId::OSAKA | OpSpecId::JOVIAN | OpSpecId::BASE_V1 => jovian(),
+OpSpecId::JOVIAN | OpSpecId::BASE_V1 => jovian(),
 
 // Or add a new set
 OpSpecId::BASE_V1 => base_v1(),


### PR DESCRIPTION
Builds on top of: https://github.com/base/base/pull/1479

### Description
- Remove Osaka as an OP Spec Id
- Set Osaka (Ethereum) to activate at the same time as Base V1