### PR TITLE
chore: update specs to cover v1 edge cases

### DIFF
--- a/docs/specs/pages/upgrades/v1/exec-engine.md
+++ b/docs/specs/pages/upgrades/v1/exec-engine.md
@@ -9,6 +9,14 @@ of 16,777,216 (2^24) per transaction. Transactions exceeding this cap are reject
 
 Base adopts the same cap as L1 to maximize Ethereum equivalence.
 
+:::note
+Deposit transactions will be exempt from the transaction gas limit cap. They are already limited to [20,000,000 gas][gas-market] as that is the most
+gas that can be included in an L1 block.
+:::
+
+
+[gas-market]: ../../protocol/bridging/deposits.md#default-values
+
 ### Upper-Bound MODEXP
 
 [EIP-7823](https://eips.ethereum.org/EIPS/eip-7823) caps MODEXP precompile inputs to a maximum of

--- a/docs/specs/pages/upgrades/v1/overview.md
+++ b/docs/specs/pages/upgrades/v1/overview.md
@@ -2,6 +2,11 @@
 
 ## Summary
 
+:::warning
+Only `base-consensus` and `base-reth-node` will  support the Base V1 hardfork. If you are running
+`op-node`, `op-geth` or any other clients you will need to update prior to the activation date.
+:::
+
 - Add Fusaka Support
 - Simplify Flashblocks Websocket Format
 - Enable TEE & ZK Proofs


### PR DESCRIPTION
### Description
 - Add a warning notice about client deprecation
 - Add a caveat around deposit transactions being exempt from the Osaka limit (but being limited by the guarenteed gas market)