### PR TITLE
Fix(proofs): panic when `proofs_history` enabled without storage path

### DIFF
--- a/crates/client/proofs/src/proofs.rs
+++ b/crates/client/proofs/src/proofs.rs
@@ -42,9 +42,16 @@ impl BaseNodeExtension for ProofsHistoryExtension {
         let proofs_history_verification_interval = args.proofs_history_verification_interval;
 
         if proofs_history_enabled {
-            let path = args
-                .proofs_history_storage_path
-                .expect("Path must be provided if not using in-memory storage");
+            let path = match args.proofs_history_storage_path {
+                Some(path) => path,
+                None => {
+                    error!(
+                        target: "reth::cli",
+                        "proofs_history is enabled but no storage path provided; disabling proofs history"
+                    );
+                    return hooks;
+                }
+            };
             info!(target: "reth::cli", "Using on-disk storage for proofs history");
 
             let mdbx = match MdbxProofsStorage::new(&path)


### PR DESCRIPTION
Avoid panic when `proofs_history` is enabled without providing a storage path.

The CLI allows `--proofs-history` without requiring a storage path, but the previous implementation used `expect(...)`, causing a crash at startup.

This change replaces the panic with a graceful fallback by disabling proofs history and logging an explicit error.