### PR TITLE
docs: fix incorrect crate reference in flashblocks-node tests README

### DIFF
--- a/crates/client/flashblocks-node/tests/README.md
+++ b/crates/client/flashblocks-node/tests/README.md
@@ -1,6 +1,6 @@
 ## Flashblocks RPC Integration Tests
 
-The suites under this directory exercise `base-flashblocks-rpc` the same way external
+The suites under this directory exercise `base-flashblocks-node` the same way external
 consumers do — by linking against the published library instead of the crate's `cfg(test)` build.
 Running them from `tests/` ensures:
 


### PR DESCRIPTION
The README in `crates/client/flashblocks-node/tests/README.md` referenced `base-flashblocks-rpc`, which does not exist in the repository or dependencies.

None of the tests in this directory import or use `base-flashblocks-rpc`.