### PR TITLE
chore(batcher): Make Approx Compr Ratio Configurable

### DIFF
--- a/bin/batcher/src/cli.rs
+++ b/bin/batcher/src/cli.rs
@@ -105,11 +105,7 @@ pub(crate) struct BatcherArgs {
     /// Only relevant when `--batch-type=span`. Should be slightly below the
     /// typical observed ratio to avoid creating a small leftover frame.
     /// Matches op-batcher's `--approx-compr-ratio` default.
-    #[arg(
-        long = "approx-compr-ratio",
-        default_value = "0.6",
-        env = "BATCHER_APPROX_COMPR_RATIO"
-    )]
+    #[arg(long = "approx-compr-ratio", default_value = "0.6", env = "BATCHER_APPROX_COMPR_RATIO")]
     pub approx_compr_ratio: f64,
 
     /// Maximum number of in-flight (unconfirmed) transactions.

--- a/bin/batcher/src/cli.rs
+++ b/bin/batcher/src/cli.rs
@@ -100,6 +100,18 @@ pub(crate) struct BatcherArgs {
     #[arg(long = "target-num-frames", default_value = "1", env = "BATCHER_TARGET_NUM_FRAMES")]
     pub target_num_frames: usize,
 
+    /// Approximate compression ratio used for span batch size estimation.
+    ///
+    /// Only relevant when `--batch-type=span`. Should be slightly below the
+    /// typical observed ratio to avoid creating a small leftover frame.
+    /// Matches op-batcher's `--approx-compr-ratio` default.
+    #[arg(
+        long = "approx-compr-ratio",
+        default_value = "0.6",
+        env = "BATCHER_APPROX_COMPR_RATIO"
+    )]
+    pub approx_compr_ratio: f64,
+
     /// Maximum number of in-flight (unconfirmed) transactions.
     #[arg(
         long = "max-pending-transactions",
@@ -171,6 +183,7 @@ impl BatcherArgs {
             max_channel_duration: self.max_channel_duration,
             sub_safety_margin: self.sub_safety_margin,
             target_num_frames: self.target_num_frames,
+            approx_compr_ratio: self.approx_compr_ratio,
             ..base_batcher_encoder::EncoderConfig::default()
         };
         encoder_config.validate()?;

--- a/crates/batcher/encoder/src/config.rs
+++ b/crates/batcher/encoder/src/config.rs
@@ -60,6 +60,16 @@ pub struct EncoderConfig {
     ///
     /// [`target_num_frames`]: EncoderConfig::target_num_frames
     pub da_type: DaType,
+
+    /// Approximate compression ratio used when estimating span batch compressed size.
+    ///
+    /// Applied as `raw_bytes * approx_compr_ratio` to predict compressed output size
+    /// without actually compressing. Should be slightly below the typical observed ratio
+    /// to avoid creating a small leftover frame. Also passed to the `ShadowCompressor`
+    /// as the ratio hint used when operating in [`BatchType::Single`] mode.
+    ///
+    /// Default: `0.6` (matches op-batcher's `--approx-compr-ratio` default).
+    pub approx_compr_ratio: f64,
 }
 
 impl Default for EncoderConfig {
@@ -72,6 +82,7 @@ impl Default for EncoderConfig {
             target_num_frames: 1,
             batch_type: BatchType::Single,
             da_type: DaType::Blob,
+            approx_compr_ratio: 0.6,
         }
     }
 }

--- a/crates/batcher/encoder/src/config.rs
+++ b/crates/batcher/encoder/src/config.rs
@@ -106,6 +106,11 @@ impl EncoderConfig {
                 target_num_frames: self.target_num_frames,
             });
         }
+        if self.approx_compr_ratio <= 0.0 || self.approx_compr_ratio > 1.0 {
+            return Err(EncoderConfigError::InvalidApproxComprRatio {
+                approx_compr_ratio: self.approx_compr_ratio,
+            });
+        }
         Ok(())
     }
 }
@@ -136,6 +141,19 @@ pub enum EncoderConfigError {
     CalldataRequiresSingleFrame {
         /// The configured target number of frames.
         target_num_frames: usize,
+    },
+    /// `approx_compr_ratio <= 0.0 || approx_compr_ratio > 1.0`.
+    ///
+    /// A ratio ≤ 0.0 causes `compressed_estimate` to always be 0, so the span
+    /// accumulator never triggers a size-based channel close, growing unboundedly in
+    /// memory until timeout. A ratio > 1.0 overestimates compressed size, causing
+    /// channels to close after a single block and producing many tiny span batches.
+    ///
+    /// Use a value in the range `(0.0, 1.0]`.
+    #[error("approx_compr_ratio ({approx_compr_ratio}) must be in the range (0.0, 1.0]")]
+    InvalidApproxComprRatio {
+        /// The configured approximate compression ratio.
+        approx_compr_ratio: f64,
     },
 }
 
@@ -174,5 +192,26 @@ mod tests {
         let msg = err.to_string();
         assert!(msg.contains(&sub_safety_margin.to_string()));
         assert!(msg.contains(&max_channel_duration.to_string()));
+    }
+
+    #[rstest]
+    #[case(0.1)] // low but valid
+    #[case(0.6)] // default
+    #[case(1.0)] // exactly 1.0: upper bound is inclusive
+    fn validate_approx_compr_ratio_ok(#[case] approx_compr_ratio: f64) {
+        let cfg = EncoderConfig { approx_compr_ratio, ..EncoderConfig::default() };
+        assert!(cfg.validate().is_ok());
+    }
+
+    #[rstest]
+    #[case(0.0)] // exactly 0: compressed_estimate always 0
+    #[case(-1.0)] // negative: nonsensical ratio
+    #[case(1.1)] // above 1: overestimates compressed size
+    #[case(f64::INFINITY)]
+    fn validate_approx_compr_ratio_err(#[case] approx_compr_ratio: f64) {
+        let cfg = EncoderConfig { approx_compr_ratio, ..EncoderConfig::default() };
+        let err = cfg.validate().unwrap_err();
+        assert!(matches!(err, EncoderConfigError::InvalidApproxComprRatio { .. }));
+        assert!(err.to_string().contains("approx_compr_ratio"));
     }
 }

--- a/crates/batcher/encoder/src/encoder.rs
+++ b/crates/batcher/encoder/src/encoder.rs
@@ -6,15 +6,6 @@ use std::{
     sync::Arc,
 };
 
-/// Approximate compression ratio used by the `ShadowCompressor` (Brotli-10).
-/// Must stay in sync with the `approx_compr_ratio` value in `BatchEncoder::open_new_channel`.
-const APPROX_COMPR_RATIO: f64 = 0.6;
-
-/// Approximate bytes of per-block overhead when encoding as part of a [`SpanBatch`].
-/// Accounts for the fixed fields carried per singular batch (parent hash, epoch number,
-/// epoch hash, timestamp) plus RLP framing. Used for span accumulator size estimation.
-const SPAN_BATCH_PER_BLOCK_OVERHEAD: usize = 50;
-
 use alloy_eips::eip2718::Encodable2718;
 use alloy_primitives::B256;
 use base_alloy_consensus::{OpBlock, OpTxEnvelope};
@@ -65,7 +56,7 @@ pub struct BatchEncoder {
     /// flushed as a single [`SpanBatch`] when `close_current_channel()` is called.
     span_accumulator: Vec<(SingleBatch, u64)>,
     /// Running sum of the estimated raw (uncompressed) byte size of all blocks currently
-    /// in `span_accumulator`. Incremented by `SPAN_BATCH_PER_BLOCK_OVERHEAD` plus raw
+    /// in `span_accumulator`. Incremented by [`Self::SPAN_BATCH_PER_BLOCK_OVERHEAD`] plus raw
     /// transaction bytes for each block pushed in `step()`, and reset to zero when the
     /// accumulator is drained. Avoids an O(N·M) re-scan of the accumulator on every step.
     span_raw_bytes: usize,
@@ -95,6 +86,11 @@ impl fmt::Debug for BatchEncoder {
 }
 
 impl BatchEncoder {
+    /// Approximate bytes of per-block overhead when encoding as part of a [`SpanBatch`].
+    /// Accounts for the fixed fields carried per singular batch (parent hash, epoch number,
+    /// epoch hash, timestamp) plus RLP framing. Used for span accumulator size estimation.
+    pub const SPAN_BATCH_PER_BLOCK_OVERHEAD: usize = 50;
+
     /// Create a new [`BatchEncoder`].
     pub fn new(rollup_config: Arc<RollupConfig>, config: EncoderConfig) -> Self {
         Self {
@@ -295,7 +291,7 @@ impl BatchEncoder {
             target_output_size: self.config.target_frame_size as u64,
             kind: CompressorType::Shadow,
             compression_algo: CompressionAlgo::Brotli10,
-            approx_compr_ratio: APPROX_COMPR_RATIO,
+            approx_compr_ratio: self.config.approx_compr_ratio,
         };
         let compressor = ShadowCompressor::from(compressor_config);
 
@@ -386,7 +382,7 @@ impl BatchPipeline for BatchEncoder {
                 let seq_num = l1_info.sequence_number();
                 // Maintain a running byte counter so the size check below is O(1) per
                 // step rather than O(N·M) over the entire accumulator.
-                let block_raw_bytes = SPAN_BATCH_PER_BLOCK_OVERHEAD
+                let block_raw_bytes = Self::SPAN_BATCH_PER_BLOCK_OVERHEAD
                     + single_batch.transactions.iter().map(|tx| tx.len()).sum::<usize>();
                 self.span_raw_bytes += block_raw_bytes;
                 self.span_accumulator.push((single_batch, seq_num));
@@ -408,7 +404,7 @@ impl BatchPipeline for BatchEncoder {
                 // The compressed estimate uses the same ratio as the ShadowCompressor so that
                 // the size trigger fires at roughly the same threshold as Single mode.
                 let compressed_estimate =
-                    (self.span_raw_bytes as f64 * APPROX_COMPR_RATIO) as usize;
+                    (self.span_raw_bytes as f64 * self.config.approx_compr_ratio) as usize;
                 let size_target =
                     self.config.target_frame_size.saturating_mul(self.config.target_num_frames);
 


### PR DESCRIPTION
## Summary

Promotes the hardcoded `APPROX_COMPR_RATIO` constant in the encoder to a field on `EncoderConfig`, wired through the batcher CLI as `--approx-compr-ratio` / `BATCHER_APPROX_COMPR_RATIO` with a default of `0.6`, matching op-batcher's `--approx-compr-ratio` flag. The `SPAN_BATCH_PER_BLOCK_OVERHEAD` constant is moved inside `BatchEncoder` as a `pub` associated constant since it belongs logically to that type.