### PR TITLE
fix(ci): Flush Auto-Mine Before Confirmation Count

### DIFF
--- a/crates/utilities/tx-manager/tests/reorg.rs
+++ b/crates/utilities/tx-manager/tests/reorg.rs
@@ -279,11 +279,17 @@ async fn deep_reorg_past_confirmation_depth_removes_receipt() {
     // Snapshot before sending tx.
     let snap = snapshot(manager.provider()).await;
 
-    // Send tx, auto-mine includes it.
+    // Send tx. Force-mine one block immediately to flush Anvil's auto-mine,
+    // which may not have committed the tx under CI load. After this call the
+    // tx is guaranteed to be in a block regardless of whether auto-mine fired
+    // synchronously or was deferred.
     let (tx_hash, send_state) = publish_simple_tx(&manager).await;
+    mine_block(manager.provider()).await;
 
-    // Mine 2 extra blocks for full confirmation (tx_block + 3 <= tip + 1).
-    mine_blocks(manager.provider(), 2).await;
+    // Mine 3 more blocks so the confirmation check has a 1-block margin.
+    // After the flush the tx is at block B; tip reaches B+3, so
+    // tx_block + 3 <= tip + 1 holds (B+3 <= B+4) for any value of B.
+    mine_blocks(manager.provider(), 3).await;
 
     let receipt = query(&send_state, &manager, tx_hash, 3).await;
     assert!(receipt.is_some(), "receipt should be fully confirmed before reorg");


### PR DESCRIPTION
## Summary

The `deep_reorg_past_confirmation_depth_removes_receipt` test was flaking under CI load because Anvil's instant auto-mine does not always commit the mined block before returning the `eth_sendRawTransaction` response. When mining is deferred, the first explicit `evm_mine` call picks up the pending transaction, reducing the effective tip height by one block and causing the confirmation check (`tx_block + 3 <= tip + 1`) to fail with `4 <= 3`. The fix follows the flush pattern already established in `send_lifecycle.rs`: a single `mine_block` call after publish guarantees the transaction is committed before counting confirmation depth, and mining three blocks instead of two ensures a one-block margin under both sync and async auto-mine behavior.