### PR TITLE
feat(actions): Internalize Harness Method Panics

### DIFF
--- a/actions/harness/src/batcher/actor.rs
+++ b/actions/harness/src/batcher/actor.rs
@@ -44,24 +44,6 @@ pub enum BatcherError {
     /// The L2 source was exhausted before any blocks could be batched.
     #[error("no L2 blocks available to batch")]
     NoBlocks,
-    /// [`Batcher::wait_until_pending`] did not observe `expected` pending frames
-    /// within the polling iteration limit.
-    #[error("timed out waiting for {expected} pending frames after encoding; got {got}")]
-    EncodingTimeout {
-        /// Minimum number of pending frames the caller was waiting for.
-        expected: usize,
-        /// Actual number of pending frames observed when the timeout elapsed.
-        got: usize,
-    },
-    /// [`Batcher::wait_until_requeued`] did not observe `expected` pending frames
-    /// within the polling iteration limit after a reorg.
-    #[error("timed out waiting for {expected} requeued frames after reorg; got {got}")]
-    RequeueTimeout {
-        /// Minimum number of requeued frames the caller was waiting for.
-        expected: usize,
-        /// Actual number of pending frames observed when the timeout elapsed.
-        got: usize,
-    },
 }
 
 /// Batcher actor that drives a persistent [`BatchDriver`] through [`L1Miner`].
@@ -162,14 +144,23 @@ impl<S: L2BlockProvider> Batcher<S> {
     /// blocks and calls [`send_async`] for each submission. After this returns,
     /// [`pending_count`] reflects how many frame transactions are waiting.
     ///
-    /// # Errors
+    /// # Panics
     ///
-    /// Returns [`BatcherError::NoBlocks`] if the L2 source is empty.
+    /// Panics if the L2 source is empty. Use [`try_advance`] if you need to
+    /// test the empty-source error path.
     ///
     /// [`advance`]: Batcher::advance
+    /// [`try_advance`]: Batcher::try_advance
     /// [`pending_count`]: Batcher::pending_count
     /// [`send_async`]: crate::L1MinerTxManager::send_async
-    pub async fn encode_only(&mut self) -> Result<(), BatcherError> {
+    pub async fn encode_only(&mut self) {
+        self.try_encode_only().await.unwrap_or_else(|e| panic!("Batcher::encode_only failed: {e}"))
+    }
+
+    /// Fallible variant of [`encode_only`] that returns an error instead of panicking.
+    ///
+    /// [`encode_only`]: Batcher::encode_only
+    async fn try_encode_only(&mut self) -> Result<(), BatcherError> {
         let mut block_count = 0u64;
         while let Some(block) = self.l2_source.next_block() {
             self.block_tx.send(L2BlockEvent::Block(Box::new(block))).expect("driver task alive");
@@ -241,22 +232,25 @@ impl<S: L2BlockProvider> Batcher<S> {
     /// Intended to be called after [`encode_only`] when a test needs to inspect
     /// or act on pending frames before mining.
     ///
-    /// # Errors
+    /// # Panics
     ///
-    /// Returns [`BatcherError::EncodingTimeout`] if `pending_count()` does not
-    /// reach `min_frames` within the polling iteration limit.
+    /// Panics if `pending_count()` does not reach `min_frames` within the
+    /// polling iteration limit (20 yields).
     ///
     /// [`BatchDriver`]: base_batcher_core::BatchDriver
     /// [`send_async`]: crate::L1MinerTxManager::send_async
     /// [`encode_only`]: Batcher::encode_only
-    pub async fn wait_until_pending(&self, min_frames: usize) -> Result<(), BatcherError> {
+    pub async fn wait_until_pending(&self, min_frames: usize) {
         for _ in 0..20 {
             if self.pending_count() >= min_frames {
-                return Ok(());
+                return;
             }
             tokio::task::yield_now().await;
         }
-        Err(BatcherError::EncodingTimeout { expected: min_frames, got: self.pending_count() })
+        panic!(
+            "timed out waiting for {min_frames} pending frames after encoding; got {}",
+            self.pending_count()
+        );
     }
 
     /// Wait until at least `expected` frames are back in the pending queue
@@ -268,32 +262,47 @@ impl<S: L2BlockProvider> Batcher<S> {
     /// [`send_async`] to return them to the pending queue. This method polls
     /// [`pending_count`] until the condition is satisfied.
     ///
-    /// # Errors
+    /// # Panics
     ///
-    /// Returns [`BatcherError::RequeueTimeout`] if `pending_count()` does not
-    /// reach `expected` within the polling iteration limit.
+    /// Panics if `pending_count()` does not reach `expected` within the
+    /// polling iteration limit (20 yields).
     ///
     /// [`send_async`]: crate::L1MinerTxManager::send_async
     /// [`pending_count`]: Batcher::pending_count
-    pub async fn wait_until_requeued(&self, expected: usize) -> Result<(), BatcherError> {
+    pub async fn wait_until_requeued(&self, expected: usize) {
         for _ in 0..20 {
             if self.pending_count() >= expected {
-                return Ok(());
+                return;
             }
             tokio::task::yield_now().await;
         }
-        Err(BatcherError::RequeueTimeout { expected, got: self.pending_count() })
+        panic!(
+            "timed out waiting for {expected} requeued frames after reorg; got {}",
+            self.pending_count()
+        );
     }
 
     /// Run one full batch cycle through the production [`BatchDriver`] path.
     ///
-    /// # Errors
+    /// # Panics
     ///
-    /// Returns [`BatcherError::NoBlocks`] if the L2 source is empty.
+    /// Panics if the L2 source is empty. Use [`try_advance`] to test the
+    /// empty-source error path.
+    ///
+    /// [`try_advance`]: Batcher::try_advance
+    pub async fn advance(&mut self, l1: &mut L1Miner) {
+        self.try_advance(l1).await.unwrap_or_else(|e| panic!("Batcher::advance failed: {e}"))
+    }
+
+    /// Fallible variant of [`advance`] — returns an error instead of panicking.
+    ///
+    /// Use this when a test needs to assert that `advance` fails (e.g. to
+    /// verify that [`BatcherError::NoBlocks`] is returned for an empty source).
+    /// For the common happy-path case prefer [`advance`].
     ///
     /// [`advance`]: Batcher::advance
-    pub async fn advance(&mut self, l1: &mut L1Miner) -> Result<(), BatcherError> {
-        self.encode_only().await?;
+    pub async fn try_advance(&mut self, l1: &mut L1Miner) -> Result<(), BatcherError> {
+        self.try_encode_only().await?;
 
         // Mine one L1 block: submits all pending txs/blobs, fires receipt
         // oneshots, and publishes the block number to the L1 head watch.

--- a/actions/harness/src/l2.rs
+++ b/actions/harness/src/l2.rs
@@ -240,8 +240,12 @@ impl L2Sequencer {
     /// then restores the original count. Useful for simulating forced-empty
     /// blocks at the sequencer drift boundary.
     ///
+    /// # Panics
+    ///
+    /// Panics if the block cannot be built (e.g. missing L1 block data).
+    ///
     /// [`build_next_block`]: L2Sequencer::build_next_block
-    pub fn build_empty_block(&mut self) -> Result<OpBlock, L2SequencerError> {
+    pub fn build_empty_block(&mut self) -> OpBlock {
         let saved = self.user_txs_per_block;
         self.user_txs_per_block = 0;
         let result = self.build_next_block();
@@ -253,7 +257,26 @@ impl L2Sequencer {
     ///
     /// Returns a fully-formed [`OpBlock`] containing the L1-info deposit and
     /// any configured user transactions, with a real state root and block hash.
-    pub fn build_next_block(&mut self) -> Result<OpBlock, L2SequencerError> {
+    ///
+    /// # Panics
+    ///
+    /// Panics if the block cannot be built (e.g. missing L1 block data or EVM
+    /// execution failure). Use [`try_build_next_block`] if you need to inspect
+    /// the error.
+    ///
+    /// [`try_build_next_block`]: L2Sequencer::try_build_next_block
+    pub fn build_next_block(&mut self) -> OpBlock {
+        self.try_build_next_block()
+            .unwrap_or_else(|e| panic!("L2Sequencer::build_next_block failed: {e}"))
+    }
+
+    /// Build the next L2 block, returning an error instead of panicking.
+    ///
+    /// Prefer [`build_next_block`] in test code; this method exists for
+    /// callers that need to inspect the failure reason.
+    ///
+    /// [`build_next_block`]: L2Sequencer::build_next_block
+    pub fn try_build_next_block(&mut self) -> Result<OpBlock, L2SequencerError> {
         let next_number = self.head.block_info.number + 1;
         let next_timestamp = self.head.block_info.timestamp + self.rollup_config.block_time;
         let parent_hash = self.head.block_info.hash;
@@ -453,9 +476,6 @@ fn compute_state_root(db: &InMemoryDB) -> B256 {
 
 impl L2BlockProvider for L2Sequencer {
     fn next_block(&mut self) -> Option<OpBlock> {
-        Some(
-            self.build_next_block()
-                .unwrap_or_else(|e| panic!("L2Sequencer::next_block failed: {e}")),
-        )
+        Some(self.build_next_block())
     }
 }

--- a/actions/harness/src/verifier.rs
+++ b/actions/harness/src/verifier.rs
@@ -50,9 +50,6 @@ pub enum VerifierError {
     /// A pipeline signal failed.
     #[error("signal error: {0}")]
     Signal(Box<PipelineErrorKind>),
-    /// The gossiped block has no L1 info deposit as its first transaction.
-    #[error("gossip receive: missing or invalid L1 info deposit in block")]
-    GossipDecodeFailed,
 }
 
 /// A lightweight view of a derived L2 block's transaction counts.
@@ -308,7 +305,7 @@ impl<P: Pipeline + SignalReceiver + Debug + Send> L2Verifier<P> {
             .expect("initialize signal failed");
 
         // Drain the genesis L1 block (no batcher data; sets IndexedTraversal::done = true).
-        self.act_l2_pipeline_full().await.expect("initialize pipeline drain failed");
+        self.act_l2_pipeline_full().await;
     }
 
     /// Return the current L2 safe head.
@@ -450,12 +447,12 @@ impl<P: Pipeline + SignalReceiver + Debug + Send> L2Verifier<P> {
     /// Returns the number of L2 attributes that were applied (i.e. how many L2
     /// blocks were derived).
     ///
-    /// # Errors
+    /// # Panics
     ///
-    /// Returns [`VerifierError::Pipeline`] if the pipeline returns a
-    /// non-transient error, or if `NotEnoughData` is returned more than
-    /// 1 000 consecutive times without progress (indicating a stuck pipeline).
-    pub async fn act_l2_pipeline_full(&mut self) -> Result<usize, VerifierError> {
+    /// Panics if the pipeline returns a non-transient error, or if
+    /// `NotEnoughData` is returned more than 1 000 consecutive times without
+    /// progress (indicating a stuck pipeline).
+    pub async fn act_l2_pipeline_full(&mut self) -> usize {
         let mut derived = 0;
         let mut no_progress = 0usize;
         loop {
@@ -485,14 +482,12 @@ impl<P: Pipeline + SignalReceiver + Debug + Send> L2Verifier<P> {
                             // no-progress loops.
                             no_progress += 1;
                             if no_progress > 1_000 {
-                                return Err(VerifierError::Pipeline(Box::new(
-                                    PipelineError::Provider(
-                                        "pipeline stuck: 1000 consecutive no-progress without derivation".into()
-                                    ).temp()
-                                )));
+                                panic!(
+                                    "pipeline stuck: 1000 consecutive no-progress without derivation"
+                                );
                             }
                         }
-                        _ => return Err(VerifierError::Pipeline(Box::new(err))),
+                        _ => panic!("act_l2_pipeline_full: pipeline error: {err}"),
                     }
                 }
                 StepResult::OriginAdvanceErr(err) => {
@@ -501,12 +496,12 @@ impl<P: Pipeline + SignalReceiver + Debug + Send> L2Verifier<P> {
                             // Traversal exhausted — no more L1 blocks to advance to.
                             break;
                         }
-                        _ => return Err(VerifierError::Pipeline(Box::new(err))),
+                        _ => panic!("act_l2_pipeline_full: origin advance error: {err}"),
                     }
                 }
             }
         }
-        Ok(derived)
+        derived
     }
 
     /// Execute exactly one derivation step and return the raw [`StepResult`].
@@ -736,24 +731,24 @@ impl<P: Pipeline + SignalReceiver + Debug + Send> L2Verifier<P> {
     /// Only advances `unsafe_head` if `block.header.number` is exactly
     /// `unsafe_head.number + 1` — gaps and out-of-order gossip are silently dropped.
     ///
-    /// # Errors
+    /// # Panics
     ///
-    /// Returns [`VerifierError::GossipDecodeFailed`] if the first transaction is
-    /// not a valid L1 info deposit (i.e. the block was not produced by a
-    /// well-formed sequencer).
+    /// Panics if the first transaction is not a valid L1 info deposit (i.e. the
+    /// block was not produced by a well-formed sequencer).
     ///
     /// [`register_block_hash`]: L2Verifier::register_block_hash
-    pub fn act_l2_unsafe_gossip_receive(&mut self, block: &OpBlock) -> Result<(), VerifierError> {
+    pub fn act_l2_unsafe_gossip_receive(&mut self, block: &OpBlock) {
         // Only accept the strictly next block; gaps and duplicates are dropped silently.
         if block.header.number != self.unsafe_head.block_info.number + 1 {
-            return Ok(());
+            return;
         }
         let hash = block.header.hash_slow();
         // Auto-register so parent_hash chaining works in later derivation.
         self.block_hashes.insert(block.header.number, hash);
 
-        let l1_origin =
-            self.l1_origin_from_block(block).ok_or(VerifierError::GossipDecodeFailed)?;
+        let l1_origin = self.l1_origin_from_block(block).unwrap_or_else(|| {
+            panic!("act_l2_unsafe_gossip_receive: missing or invalid L1 info deposit in block")
+        });
         let seq_num =
             if l1_origin == self.unsafe_head.l1_origin { self.unsafe_head.seq_num + 1 } else { 0 };
         self.unsafe_head = L2BlockInfo {
@@ -766,7 +761,6 @@ impl<P: Pipeline + SignalReceiver + Debug + Send> L2Verifier<P> {
             l1_origin,
             seq_num,
         };
-        Ok(())
     }
 
     /// Decode the L1 epoch from the first deposit transaction in an [`OpBlock`].

--- a/actions/harness/tests/batch_submission.rs
+++ b/actions/harness/tests/batch_submission.rs
@@ -14,7 +14,7 @@ fn make_source(h: &ActionTestHarness, n: u64) -> ActionL2Source {
     let mut sequencer = h.create_l2_sequencer(chain);
     let mut source = ActionL2Source::new();
     for _ in 0..n {
-        source.push(sequencer.build_next_block().expect("build L2 block"));
+        source.push(sequencer.build_next_block());
     }
     source
 }
@@ -30,7 +30,7 @@ async fn batcher_mines_block_with_submissions() {
 
     let source = make_source(&h, 3);
     let mut batcher = Batcher::new(source, &h.rollup_config, cfg);
-    batcher.advance(&mut h.l1).await.expect("advance should succeed");
+    batcher.advance(&mut h.l1).await;
 
     assert!(h.l1.latest_number() >= 1, "at least one L1 block should be mined");
     // Default EncoderConfig uses DaType::Blob, so submissions appear as blob sidecars.
@@ -47,7 +47,7 @@ async fn batcher_span_batch_mode() {
 
     let source = make_source(&h, 3);
     let mut batcher = Batcher::new(source, &h.rollup_config, cfg);
-    batcher.advance(&mut h.l1).await.expect("advance span should succeed");
+    batcher.advance(&mut h.l1).await;
 
     assert!(h.l1.latest_number() >= 1, "at least one L1 block should be mined");
     assert!(
@@ -63,7 +63,7 @@ async fn batcher_errors_when_no_l2_blocks_async() {
 
     let source = ActionL2Source::new(); // empty
     let mut batcher = Batcher::new(source, &h.rollup_config, cfg);
-    let err = batcher.advance(&mut h.l1).await.expect_err("should fail with no blocks");
+    let err = batcher.try_advance(&mut h.l1).await.expect_err("should fail with no blocks");
     assert!(matches!(err, BatcherError::NoBlocks));
 }
 
@@ -101,7 +101,7 @@ async fn batcher_reorg_during_submission() {
     // Build L2 block 1.
     let l1_chain = SharedL1Chain::from_blocks(h.l1.chain().to_vec());
     let mut sequencer = h.create_l2_sequencer(l1_chain);
-    let block = sequencer.build_next_block().expect("build L2 block 1");
+    let block = sequencer.build_next_block();
 
     let (mut verifier, chain) = h.create_verifier_from_sequencer(
         &sequencer,
@@ -114,7 +114,7 @@ async fn batcher_reorg_during_submission() {
     let mut source = ActionL2Source::new();
     source.push(block);
     let mut batcher = Batcher::new(source, &h.rollup_config, batcher_cfg);
-    batcher.encode_only().await.expect("encode");
+    batcher.encode_only().await;
     batcher.stage_n_frames(&mut h.l1, usize::MAX);
     h.l1.mine_block(); // L1 block 1 (original, about to be reorged)
     chain.push(h.l1.tip().clone());
@@ -125,7 +125,7 @@ async fn batcher_reorg_during_submission() {
     // each Receipt(id, Failed) → pipeline.requeue(id), rewinding the channel
     // cursor without re-encoding.
     batcher.reorg(0, &mut h.l1);
-    batcher.wait_until_requeued(1).await.expect("driver must requeue frames after reorg");
+    batcher.wait_until_requeued(1).await;
 
     // Mine an empty replacement block on the new fork, then resubmit the
     // requeued frames using the same Batcher (no drop/recreate required).
@@ -142,11 +142,11 @@ async fn batcher_reorg_during_submission() {
     verifier.initialize().await;
 
     verifier.act_l1_head_signal(h.l1.block_info_at(1)).await;
-    let empty = verifier.act_l2_pipeline_full().await.expect("step empty block 1'");
+    let empty = verifier.act_l2_pipeline_full().await;
     assert_eq!(empty, 0, "empty block 1' has no batch data");
 
     verifier.act_l1_head_signal(h.l1.block_info_at(recovery_num)).await;
-    let derived = verifier.act_l2_pipeline_full().await.expect("step recovery");
+    let derived = verifier.act_l2_pipeline_full().await;
     assert_eq!(derived, 1, "same-batcher resubmission must derive L2 block 1");
     assert_eq!(
         verifier.l2_safe_number(),

--- a/actions/harness/tests/batcher_blobs.rs
+++ b/actions/harness/tests/batcher_blobs.rs
@@ -22,11 +22,11 @@ async fn batcher_blob_da_end_to_end() {
 
     // One Batcher per L2 block so each lands in a separate L1 block.
     for _ in 1..=3u64 {
-        let block = sequencer.build_next_block().expect("build L2 block");
+        let block = sequencer.build_next_block();
         let mut source = ActionL2Source::new();
         source.push(block);
         let mut batcher = Batcher::new(source, &h.rollup_config, batcher_cfg.clone());
-        batcher.advance(&mut h.l1).await.expect("advance");
+        batcher.advance(&mut h.l1).await;
     }
 
     let (mut verifier, _chain) = h.create_blob_verifier_from_sequencer(
@@ -37,7 +37,7 @@ async fn batcher_blob_da_end_to_end() {
 
     for i in 1..=3u64 {
         verifier.act_l1_head_signal(h.l1.block_info_at(i)).await;
-        let derived = verifier.act_l2_pipeline_full().await.expect("derive pipeline");
+        let derived = verifier.act_l2_pipeline_full().await;
         assert_eq!(derived, 1, "L1 block {i} should derive exactly one L2 block via blob DA");
     }
 
@@ -61,12 +61,12 @@ async fn batcher_multi_blob_packing() {
 
     let l1_chain = SharedL1Chain::from_blocks(h.l1.chain().to_vec());
     let mut sequencer = h.create_l2_sequencer(l1_chain);
-    let block = sequencer.build_next_block().expect("build L2 block");
+    let block = sequencer.build_next_block();
 
     let mut source = ActionL2Source::new();
     source.push(block);
     let mut batcher = Batcher::new(source, &h.rollup_config, batcher_cfg.clone());
-    batcher.advance(&mut h.l1).await.expect("advance");
+    batcher.advance(&mut h.l1).await;
 
     // With max_frame_size=80, the block must have been fragmented into multiple
     // blob sidecars in the mined L1 block.
@@ -83,7 +83,7 @@ async fn batcher_multi_blob_packing() {
     verifier.initialize().await;
 
     verifier.act_l1_head_signal(h.l1.block_info_at(1)).await;
-    let derived = verifier.act_l2_pipeline_full().await.expect("step after L1 block 1");
+    let derived = verifier.act_l2_pipeline_full().await;
 
     assert_eq!(derived, 1, "expected 1 L2 block derived from multi-blob channel");
     assert_eq!(verifier.l2_safe_number(), 1, "safe head should reach L2 block 1");
@@ -109,11 +109,11 @@ async fn batcher_calldata_da() {
 
     // One Batcher per L2 block so each lands in a separate L1 block.
     for _ in 1..=3u64 {
-        let block = sequencer.build_next_block().expect("build L2 block");
+        let block = sequencer.build_next_block();
         let mut source = ActionL2Source::new();
         source.push(block);
         let mut batcher = Batcher::new(source, &h.rollup_config, batcher_cfg.clone());
-        batcher.advance(&mut h.l1).await.expect("advance");
+        batcher.advance(&mut h.l1).await;
     }
 
     let (mut verifier, _chain) = h.create_verifier_from_sequencer(
@@ -124,7 +124,7 @@ async fn batcher_calldata_da() {
 
     for i in 1..=3u64 {
         verifier.act_l1_head_signal(h.l1.block_info_at(i)).await;
-        let derived = verifier.act_l2_pipeline_full().await.expect("derive pipeline");
+        let derived = verifier.act_l2_pipeline_full().await;
         assert_eq!(derived, 1, "L1 block {i} should derive exactly one L2 block via calldata DA");
     }
 
@@ -153,20 +153,20 @@ async fn batcher_da_switching() {
 
     // Blocks 1-3: submit as calldata.
     for _ in 1..=3u64 {
-        let block = sequencer.build_next_block().expect("build calldata block");
+        let block = sequencer.build_next_block();
         let mut source = ActionL2Source::new();
         source.push(block);
         let mut batcher = Batcher::new(source, &h.rollup_config, calldata_cfg.clone());
-        batcher.advance(&mut h.l1).await.expect("advance calldata");
+        batcher.advance(&mut h.l1).await;
     }
 
     // Blocks 4-6: submit as blobs.
     for _ in 4..=6u64 {
-        let block = sequencer.build_next_block().expect("build blob block");
+        let block = sequencer.build_next_block();
         let mut source = ActionL2Source::new();
         source.push(block);
         let mut batcher = Batcher::new(source, &h.rollup_config, blob_cfg.clone());
-        batcher.advance(&mut h.l1).await.expect("advance blob");
+        batcher.advance(&mut h.l1).await;
     }
 
     let (mut verifier, _chain) = h.create_blob_verifier_from_sequencer(
@@ -178,7 +178,7 @@ async fn batcher_da_switching() {
     let mut total_derived = 0;
     for i in 1..=6u64 {
         verifier.act_l1_head_signal(h.l1.block_info_at(i)).await;
-        total_derived += verifier.act_l2_pipeline_full().await.expect("derive pipeline");
+        total_derived += verifier.act_l2_pipeline_full().await;
     }
 
     assert_eq!(total_derived, 6, "expected 6 L2 blocks derived (3 calldata + 3 blob)");
@@ -219,13 +219,13 @@ async fn blob_da_channel_timeout() {
 
     let l1_chain = SharedL1Chain::from_blocks(h.l1.chain().to_vec());
     let mut sequencer = h.create_l2_sequencer(l1_chain);
-    let block = sequencer.build_next_block().expect("build L2 block 1");
+    let block = sequencer.build_next_block();
 
     // Encode the L2 block into multiple frames (tiny max_frame_size).
     let mut source = ActionL2Source::new();
     source.push(block.clone());
     let mut batcher = Batcher::new(source, &h.rollup_config, batcher_cfg.clone());
-    batcher.encode_only().await.expect("encode multi-frame channel");
+    batcher.encode_only().await;
     let frame_count = batcher.pending_count();
     assert!(
         frame_count >= 2,
@@ -246,7 +246,7 @@ async fn blob_da_channel_timeout() {
 
     verifier.initialize().await;
     verifier.act_l1_head_signal(h.l1.block_info_at(1)).await;
-    verifier.act_l2_pipeline_full().await.expect("step block 1");
+    verifier.act_l2_pipeline_full().await;
 
     assert_eq!(
         verifier.l2_safe_number(),
@@ -260,7 +260,7 @@ async fn blob_da_channel_timeout() {
     }
     for i in 2..=4 {
         verifier.act_l1_head_signal(h.l1.block_info_at(i)).await;
-        verifier.act_l2_pipeline_full().await.expect("step empty block");
+        verifier.act_l2_pipeline_full().await;
     }
 
     // Submit remaining frames as blobs — channel already timed out; silently dropped.
@@ -270,20 +270,17 @@ async fn blob_da_channel_timeout() {
     chain.push(h.l1.tip().clone()); // L1 block 5: late blob frames
 
     verifier.act_l1_head_signal(h.l1.block_info_at(5)).await;
-    let derived = verifier.act_l2_pipeline_full().await.expect("step block 5");
+    let derived = verifier.act_l2_pipeline_full().await;
     assert_eq!(derived, 0, "late blob frames after channel timeout must be silently dropped");
 
     // Recovery: resubmit all frames as blobs in a fresh channel.
     let mut source2 = ActionL2Source::new();
     source2.push(block);
-    Batcher::new(source2, &h.rollup_config, batcher_cfg)
-        .advance(&mut h.l1)
-        .await
-        .expect("encode recovery channel");
+    Batcher::new(source2, &h.rollup_config, batcher_cfg).advance(&mut h.l1).await;
     chain.push(h.l1.tip().clone()); // L1 block 6: fresh blob channel with all frames
 
     verifier.act_l1_head_signal(h.l1.block_info_at(6)).await;
-    let recovered = verifier.act_l2_pipeline_full().await.expect("step block 6");
+    let recovered = verifier.act_l2_pipeline_full().await;
 
     assert_eq!(recovered, 1, "resubmitted blob channel should derive L2 block 1");
     assert_eq!(verifier.l2_safe_number(), 1, "safe head should recover to 1");

--- a/actions/harness/tests/batcher_channels.rs
+++ b/actions/harness/tests/batcher_channels.rs
@@ -29,7 +29,7 @@ async fn channel_timeout_triggers_channel_invalidation() {
 
     let l1_chain = SharedL1Chain::from_blocks(h.l1.chain().to_vec());
     let mut sequencer = h.create_l2_sequencer(l1_chain);
-    let block = sequencer.build_next_block().expect("build L2 block 1");
+    let block = sequencer.build_next_block();
 
     // Create verifier before any mining so all future blocks are pushed to chain.
     let (mut verifier, chain) = h.create_verifier_from_sequencer(
@@ -41,7 +41,7 @@ async fn channel_timeout_triggers_channel_invalidation() {
     let mut source = ActionL2Source::new();
     source.push(block.clone());
     let mut batcher = Batcher::new(source, &h.rollup_config, batcher_cfg.clone());
-    batcher.encode_only().await.expect("encode");
+    batcher.encode_only().await;
 
     let frame_count = batcher.pending_count();
     assert!(
@@ -57,7 +57,7 @@ async fn channel_timeout_triggers_channel_invalidation() {
 
     verifier.initialize().await;
     verifier.act_l1_head_signal(h.l1.block_info_at(1)).await;
-    verifier.act_l2_pipeline_full().await.expect("step block 1");
+    verifier.act_l2_pipeline_full().await;
 
     assert_eq!(verifier.l2_safe_number(), 0, "incomplete channel should not advance safe head");
 
@@ -68,7 +68,7 @@ async fn channel_timeout_triggers_channel_invalidation() {
 
     for i in 2..=4 {
         verifier.act_l1_head_signal(h.l1.block_info_at(i)).await;
-        verifier.act_l2_pipeline_full().await.expect("step empty block");
+        verifier.act_l2_pipeline_full().await;
     }
 
     // Submit the remaining frames — they should be silently ignored (channel timed out).
@@ -78,18 +78,18 @@ async fn channel_timeout_triggers_channel_invalidation() {
     batcher.confirm_staged(block_5_num).await;
 
     verifier.act_l1_head_signal(h.l1.block_info_at(5)).await;
-    let derived = verifier.act_l2_pipeline_full().await.expect("step block 5");
+    let derived = verifier.act_l2_pipeline_full().await;
     assert_eq!(derived, 0, "late frames after channel timeout must be ignored");
 
     // Recovery: new Batcher (new BatchEncoder = new channel ID) with all frames in one L1 block.
     let mut source2 = ActionL2Source::new();
     source2.push(block);
     let mut batcher2 = Batcher::new(source2, &h.rollup_config, batcher_cfg.clone());
-    batcher2.advance(&mut h.l1).await.expect("recovery advance");
+    batcher2.advance(&mut h.l1).await;
     chain.push(h.l1.tip().clone());
 
     verifier.act_l1_head_signal(h.l1.block_info_at(6)).await;
-    let recovered = verifier.act_l2_pipeline_full().await.expect("step block 6");
+    let recovered = verifier.act_l2_pipeline_full().await;
 
     assert_eq!(recovered, 1, "resubmitted channel should derive L2 block 1");
     assert_eq!(verifier.l2_safe_number(), 1, "safe head should recover to 1");
@@ -117,7 +117,7 @@ async fn channel_timeout_recovery_resubmits_successfully() {
 
     let l1_chain = SharedL1Chain::from_blocks(h.l1.chain().to_vec());
     let mut sequencer = h.create_l2_sequencer(l1_chain);
-    let block = sequencer.build_next_block().expect("build block 1");
+    let block = sequencer.build_next_block();
 
     // Create verifier before any mining so all future blocks are pushed to chain.
     let (mut verifier, chain) = h.create_verifier_from_sequencer(
@@ -129,7 +129,7 @@ async fn channel_timeout_recovery_resubmits_successfully() {
     let mut source = ActionL2Source::new();
     source.push(block.clone());
     let mut batcher = Batcher::new(source, &h.rollup_config, batcher_cfg.clone());
-    batcher.encode_only().await.expect("encode");
+    batcher.encode_only().await;
 
     let frame_count = batcher.pending_count();
     assert!(
@@ -152,7 +152,7 @@ async fn channel_timeout_recovery_resubmits_successfully() {
 
     for i in 1..=h.l1.latest_number() {
         verifier.act_l1_head_signal(h.l1.block_info_at(i)).await;
-        verifier.act_l2_pipeline_full().await.expect("step");
+        verifier.act_l2_pipeline_full().await;
     }
 
     assert_eq!(
@@ -165,11 +165,11 @@ async fn channel_timeout_recovery_resubmits_successfully() {
     let mut source2 = ActionL2Source::new();
     source2.push(block);
     let mut batcher2 = Batcher::new(source2, &h.rollup_config, batcher_cfg.clone());
-    batcher2.advance(&mut h.l1).await.expect("recovery advance");
+    batcher2.advance(&mut h.l1).await;
     chain.push(h.l1.tip().clone());
 
     verifier.act_l1_head_signal(h.l1.block_info_at(h.l1.latest_number())).await;
-    let recovered = verifier.act_l2_pipeline_full().await.expect("step recovery");
+    let recovered = verifier.act_l2_pipeline_full().await;
 
     assert_eq!(recovered, 1, "recovery channel should derive L2 block 1");
     assert_eq!(verifier.l2_safe_number(), 1, "safe head should recover to 1");
@@ -198,20 +198,20 @@ async fn interleaved_channels_correctly_reassembled() {
 
     let l1_chain = SharedL1Chain::from_blocks(h.l1.chain().to_vec());
     let mut sequencer = h.create_l2_sequencer(l1_chain);
-    let block_a = sequencer.build_next_block().expect("build block A");
-    let block_b = sequencer.build_next_block().expect("build block B");
+    let block_a = sequencer.build_next_block();
+    let block_b = sequencer.build_next_block();
 
     // Batcher A: block 1 in its own channel (distinct random channel ID).
     let mut source_a = ActionL2Source::new();
     source_a.push(block_a);
     let mut batcher_a = Batcher::new(source_a, &h.rollup_config, batcher_cfg.clone());
-    batcher_a.encode_only().await.expect("encode A");
+    batcher_a.encode_only().await;
 
     // Batcher B: block 2 in its own channel (distinct random channel ID).
     let mut source_b = ActionL2Source::new();
     source_b.push(block_b);
     let mut batcher_b = Batcher::new(source_b, &h.rollup_config, batcher_cfg.clone());
-    batcher_b.encode_only().await.expect("encode B");
+    batcher_b.encode_only().await;
 
     let n_a = batcher_a.pending_count();
     let n_b = batcher_b.pending_count();
@@ -240,7 +240,7 @@ async fn interleaved_channels_correctly_reassembled() {
     verifier.initialize().await;
 
     verifier.act_l1_head_signal(h.l1.block_info_at(1)).await;
-    let derived = verifier.act_l2_pipeline_full().await.expect("step block 1");
+    let derived = verifier.act_l2_pipeline_full().await;
 
     assert_eq!(derived, 2, "expected 2 L2 blocks derived from interleaved channels");
     assert_eq!(verifier.l2_safe_number(), 2);
@@ -267,7 +267,7 @@ async fn multi_block_channel_assembles_across_l1_blocks() {
 
     let l1_chain = SharedL1Chain::from_blocks(h.l1.chain().to_vec());
     let mut sequencer = h.create_l2_sequencer(l1_chain);
-    let block = sequencer.build_next_block().expect("build L2 block 1");
+    let block = sequencer.build_next_block();
 
     // Create verifier before any mining so all future blocks are pushed to chain.
     let (mut verifier, chain) = h.create_verifier_from_sequencer(
@@ -279,7 +279,7 @@ async fn multi_block_channel_assembles_across_l1_blocks() {
     let mut source = ActionL2Source::new();
     source.push(block);
     let mut batcher = Batcher::new(source, &h.rollup_config, batcher_cfg.clone());
-    batcher.encode_only().await.expect("encode");
+    batcher.encode_only().await;
 
     let frame_count = batcher.pending_count();
     assert!(
@@ -295,7 +295,7 @@ async fn multi_block_channel_assembles_across_l1_blocks() {
 
     verifier.initialize().await;
     verifier.act_l1_head_signal(h.l1.block_info_at(1)).await;
-    verifier.act_l2_pipeline_full().await.expect("step block 1");
+    verifier.act_l2_pipeline_full().await;
 
     assert_eq!(
         verifier.l2_safe_number(),
@@ -310,7 +310,7 @@ async fn multi_block_channel_assembles_across_l1_blocks() {
     batcher.confirm_staged(block_2_num).await;
 
     verifier.act_l1_head_signal(h.l1.block_info_at(2)).await;
-    let derived = verifier.act_l2_pipeline_full().await.expect("step block 2");
+    let derived = verifier.act_l2_pipeline_full().await;
 
     assert_eq!(derived, 1, "multi-block channel must yield 1 L2 block");
     assert_eq!(verifier.l2_safe_number(), 1, "safe head must advance to 1");
@@ -345,7 +345,7 @@ async fn multi_frame_channel_with_empty_l1_gap_derives_correctly() {
 
     let l1_chain = SharedL1Chain::from_blocks(h.l1.chain().to_vec());
     let mut sequencer = h.create_l2_sequencer(l1_chain);
-    let block = sequencer.build_next_block().expect("build L2 block 1");
+    let block = sequencer.build_next_block();
 
     // Create verifier before any mining so all future blocks are pushed to chain.
     let (mut verifier, chain) = h.create_verifier_from_sequencer(
@@ -358,7 +358,7 @@ async fn multi_frame_channel_with_empty_l1_gap_derives_correctly() {
     let mut source = ActionL2Source::new();
     source.push(block);
     let mut batcher = Batcher::new(source, &h.rollup_config, batcher_cfg.clone());
-    batcher.encode_only().await.expect("encode");
+    batcher.encode_only().await;
 
     let frame_count = batcher.pending_count();
     assert!(
@@ -374,7 +374,7 @@ async fn multi_frame_channel_with_empty_l1_gap_derives_correctly() {
 
     verifier.initialize().await;
     verifier.act_l1_head_signal(h.l1.block_info_at(1)).await;
-    verifier.act_l2_pipeline_full().await.expect("step block 1");
+    verifier.act_l2_pipeline_full().await;
 
     assert_eq!(
         verifier.l2_safe_number(),
@@ -403,7 +403,7 @@ async fn multi_frame_channel_with_empty_l1_gap_derives_correctly() {
     let mut total_derived = 0usize;
     for i in 2..=h.l1.latest_number() {
         verifier.act_l1_head_signal(h.l1.block_info_at(i)).await;
-        total_derived += verifier.act_l2_pipeline_full().await.expect("step block");
+        total_derived += verifier.act_l2_pipeline_full().await;
     }
 
     assert_eq!(total_derived, 1, "exactly one L2 block must be derived across the 3-block span");

--- a/actions/harness/tests/batcher_hardfork_transitions.rs
+++ b/actions/harness/tests/batcher_hardfork_transitions.rs
@@ -62,10 +62,10 @@ async fn span_batch_with_non_empty_transition_block_rejected() {
     // Build 4 L2 blocks. build_next_block() includes a user transaction in
     // every block. Block 3 (ts=6) is the first Jovian block, which must be
     // deposit-only — including a user tx here is the deliberate error.
-    let block1 = builder.build_next_block().expect("build L2 block 1"); // ts=2
-    let block2 = builder.build_next_block().expect("build L2 block 2"); // ts=4
-    let block3_invalid = builder.build_next_block().expect("build L2 block 3 (invalid)"); // ts=6
-    let block4 = builder.build_next_block().expect("build L2 block 4"); // ts=8
+    let block1 = builder.build_next_block(); // ts=2
+    let block2 = builder.build_next_block(); // ts=4
+    let block3_invalid = builder.build_next_block(); // ts=6
+    let block4 = builder.build_next_block(); // ts=8
 
     let (mut verifier, chain) = h.create_verifier_from_sequencer(
         &builder,
@@ -80,16 +80,13 @@ async fn span_batch_with_non_empty_transition_block_rejected() {
         source.push(block2.clone());
         source.push(block3_invalid);
         source.push(block4.clone());
-        Batcher::new(source, &h.rollup_config, span_cfg)
-            .advance(&mut h.l1)
-            .await
-            .expect("encode span batch with invalid block 3");
+        Batcher::new(source, &h.rollup_config, span_cfg).advance(&mut h.l1).await;
     }
     chain.push(h.l1.tip().clone()); // L1 block 1: span batch with invalid block 3
 
     verifier.initialize().await;
     verifier.act_l1_head_signal(h.l1.block_info_at(1)).await;
-    verifier.act_l2_pipeline_full().await.expect("pipeline after block 1");
+    verifier.act_l2_pipeline_full().await;
 
     // Under Holocene, when the pipeline reaches block 3 in the span batch and
     // detects a user tx in the upgrade block, it sends FlushChannel (via
@@ -115,24 +112,21 @@ async fn span_batch_with_non_empty_transition_block_rejected() {
     {
         let l1_chain2 = SharedL1Chain::from_blocks(h.l1.chain().to_vec());
         let mut builder2 = h.create_l2_sequencer(l1_chain2);
-        let _rb1 = builder2.build_next_block().expect("advance recovery builder past block 1");
-        let _rb2 = builder2.build_next_block().expect("advance recovery builder past block 2");
-        let block3_empty = builder2.build_empty_block().expect("build empty block 3 for recovery");
-        let block4_recovery = builder2.build_next_block().expect("build recovery block 4");
+        let _rb1 = builder2.build_next_block();
+        let _rb2 = builder2.build_next_block();
+        let block3_empty = builder2.build_empty_block();
+        let block4_recovery = builder2.build_next_block();
 
         let span_cfg = BatcherConfig { batch_type: BatchType::Span, ..batcher_cfg };
         let mut source = ActionL2Source::new();
         source.push(block3_empty);
         source.push(block4_recovery);
-        Batcher::new(source, &h.rollup_config, span_cfg)
-            .advance(&mut h.l1)
-            .await
-            .expect("encode recovery span batch");
+        Batcher::new(source, &h.rollup_config, span_cfg).advance(&mut h.l1).await;
     }
     chain.push(h.l1.tip().clone()); // L1 block 2: recovery span batch (blocks 3–4)
 
     verifier.act_l1_head_signal(h.l1.block_info_at(2)).await;
-    verifier.act_l2_pipeline_full().await.expect("pipeline after block 2");
+    verifier.act_l2_pipeline_full().await;
 
     assert_eq!(
         verifier.l2_safe_number(),
@@ -170,8 +164,8 @@ async fn mixed_singular_and_span_batches_after_delta() {
     let l1_chain = SharedL1Chain::from_blocks(h.l1.chain().to_vec());
     let mut builder = h.create_l2_sequencer(l1_chain);
 
-    let block1 = builder.build_next_block().expect("build L2 block 1");
-    let block2 = builder.build_next_block().expect("build L2 block 2");
+    let block1 = builder.build_next_block();
+    let block2 = builder.build_next_block();
 
     let (mut verifier, chain) = h.create_verifier_from_sequencer(
         &builder,
@@ -183,10 +177,7 @@ async fn mixed_singular_and_span_batches_after_delta() {
         let singular_cfg = BatcherConfig { batch_type: BatchType::Single, ..batcher_cfg.clone() };
         let mut source = ActionL2Source::new();
         source.push(block1);
-        Batcher::new(source, &h.rollup_config, singular_cfg)
-            .advance(&mut h.l1)
-            .await
-            .expect("encode singular batch");
+        Batcher::new(source, &h.rollup_config, singular_cfg).advance(&mut h.l1).await;
     }
     chain.push(h.l1.tip().clone()); // L1 block 1: singular batch for L2 block 1
 
@@ -195,10 +186,7 @@ async fn mixed_singular_and_span_batches_after_delta() {
         let span_cfg = BatcherConfig { batch_type: BatchType::Span, ..batcher_cfg };
         let mut source = ActionL2Source::new();
         source.push(block2);
-        Batcher::new(source, &h.rollup_config, span_cfg)
-            .advance(&mut h.l1)
-            .await
-            .expect("encode span batch");
+        Batcher::new(source, &h.rollup_config, span_cfg).advance(&mut h.l1).await;
     }
     chain.push(h.l1.tip().clone()); // L1 block 2: span batch for L2 block 2
 
@@ -208,7 +196,7 @@ async fn mixed_singular_and_span_batches_after_delta() {
     // L2 block 1; the second (span) derives L2 block 2.
     for i in 1..=2u64 {
         verifier.act_l1_head_signal(h.l1.block_info_at(i)).await;
-        let derived = verifier.act_l2_pipeline_full().await.expect("pipeline");
+        let derived = verifier.act_l2_pipeline_full().await;
         assert_eq!(derived, 1, "L1 block {i} should derive exactly one L2 block");
     }
 
@@ -281,7 +269,7 @@ async fn granite_channel_timeout_enforced() {
 
     let l1_chain = SharedL1Chain::from_blocks(h.l1.chain().to_vec());
     let mut sequencer = h.create_l2_sequencer(l1_chain);
-    let block = sequencer.build_next_block().expect("build L2 block 1");
+    let block = sequencer.build_next_block();
 
     let (mut verifier, chain) = h.create_verifier_from_sequencer(
         &sequencer,
@@ -292,7 +280,7 @@ async fn granite_channel_timeout_enforced() {
     let mut source = ActionL2Source::new();
     source.push(block.clone());
     let mut batcher = Batcher::new(source, &h.rollup_config, batcher_cfg.clone());
-    batcher.encode_only().await.expect("encode");
+    batcher.encode_only().await;
 
     let frame_count = batcher.pending_count();
     assert!(
@@ -308,7 +296,7 @@ async fn granite_channel_timeout_enforced() {
 
     verifier.initialize().await;
     verifier.act_l1_head_signal(h.l1.block_info_at(1)).await;
-    verifier.act_l2_pipeline_full().await.expect("step block 1");
+    verifier.act_l2_pipeline_full().await;
 
     assert_eq!(verifier.l2_safe_number(), 0, "incomplete channel should not advance safe head");
 
@@ -322,7 +310,7 @@ async fn granite_channel_timeout_enforced() {
     // Signal all empty blocks to the verifier.
     for i in 2..=52u64 {
         verifier.act_l1_head_signal(h.l1.block_info_at(i)).await;
-        verifier.act_l2_pipeline_full().await.expect("step empty block");
+        verifier.act_l2_pipeline_full().await;
     }
 
     assert_eq!(
@@ -343,7 +331,7 @@ async fn granite_channel_timeout_enforced() {
     batcher.confirm_staged(late_block_num).await;
 
     verifier.act_l1_head_signal(h.l1.block_info_at(late_block_num)).await;
-    let derived = verifier.act_l2_pipeline_full().await.expect("step late block");
+    let derived = verifier.act_l2_pipeline_full().await;
     assert_eq!(
         derived, 0,
         "late non-zero frames after timeout create an incomplete channel; no L2 block derived"
@@ -357,15 +345,12 @@ async fn granite_channel_timeout_enforced() {
     // --- Recovery: new batcher, all frames in one L1 block ---
     let mut source2 = ActionL2Source::new();
     source2.push(block);
-    Batcher::new(source2, &h.rollup_config, batcher_cfg)
-        .advance(&mut h.l1)
-        .await
-        .expect("recovery advance");
+    Batcher::new(source2, &h.rollup_config, batcher_cfg).advance(&mut h.l1).await;
     chain.push(h.l1.tip().clone());
 
     let recovery_num = h.l1.latest_number();
     verifier.act_l1_head_signal(h.l1.block_info_at(recovery_num)).await;
-    let recovered = verifier.act_l2_pipeline_full().await.expect("step recovery");
+    let recovered = verifier.act_l2_pipeline_full().await;
 
     assert_eq!(recovered, 1, "recovery channel should derive L2 block 1");
     assert_eq!(verifier.l2_safe_number(), 1, "safe head should recover to 1");
@@ -436,10 +421,10 @@ async fn jovian_single_batch_transition_block_deposit_only() {
     // Build 4 L2 blocks. build_next_block() includes a user transaction in
     // every block. Block 3 (ts=6) is the first Jovian block — including a
     // user tx is the deliberate error that derivation must handle.
-    let block1 = builder.build_next_block().expect("build L2 block 1"); // ts=2
-    let block2 = builder.build_next_block().expect("build L2 block 2"); // ts=4
-    let block3_invalid = builder.build_next_block().expect("build L2 block 3 (invalid)"); // ts=6
-    let block4 = builder.build_next_block().expect("build L2 block 4"); // ts=8
+    let block1 = builder.build_next_block(); // ts=2
+    let block2 = builder.build_next_block(); // ts=4
+    let block3_invalid = builder.build_next_block(); // ts=6
+    let block4 = builder.build_next_block(); // ts=8
 
     // Precondition: block 3 must contain at least one user transaction (deposits
     // don't count). If build_next_block() ever started returning empty blocks,
@@ -458,13 +443,10 @@ async fn jovian_single_batch_transition_block_deposit_only() {
 
     // Submit each block as a separate SingleBatch channel, one L1 block each.
     // L1 blocks 1–4 each contain one singular batch.
-    for (i, block) in [block1, block2, block3_invalid, block4].into_iter().enumerate() {
+    for block in [block1, block2, block3_invalid, block4] {
         let mut source = ActionL2Source::new();
         source.push(block);
-        Batcher::new(source, &h.rollup_config, batcher_cfg.clone())
-            .advance(&mut h.l1)
-            .await
-            .unwrap_or_else(|e| panic!("encode singular batch for L2 block {}: {e}", i + 1));
+        Batcher::new(source, &h.rollup_config, batcher_cfg.clone()).advance(&mut h.l1).await;
         chain.push(h.l1.tip().clone());
     }
 
@@ -485,7 +467,7 @@ async fn jovian_single_batch_transition_block_deposit_only() {
     let tip = h.l1.latest_number();
     for i in 1..=tip {
         verifier.act_l1_head_signal(h.l1.block_info_at(i)).await;
-        verifier.act_l2_pipeline_full().await.expect("pipeline");
+        verifier.act_l2_pipeline_full().await;
     }
 
     // With singular batches and the Holocene batch validator: the pipeline

--- a/actions/harness/tests/batcher_sequencer_drift.rs
+++ b/actions/harness/tests/batcher_sequencer_drift.rs
@@ -82,10 +82,10 @@ async fn sequencer_drift_produces_deposit_only_blocks() {
     // Collect all 8 blocks and batch them in one L1 block.
     let mut source = ActionL2Source::new();
     for _ in 1u64..=8 {
-        source.push(sequencer.build_next_block().expect("build L2 block"));
+        source.push(sequencer.build_next_block());
     }
     let mut batcher = Batcher::new(source, &h.rollup_config, batcher_cfg.clone());
-    batcher.advance(&mut h.l1).await.expect("batcher advance");
+    batcher.advance(&mut h.l1).await;
     chain.push(h.l1.tip().clone());
 
     // Mine 2 extra empty L1 blocks (seq_window_size=2, batch epoch=0, batch
@@ -101,7 +101,7 @@ async fn sequencer_drift_produces_deposit_only_blocks() {
     let mut total_derived = 0;
     for i in 1..=h.l1.latest_number() {
         verifier.act_l1_head_signal(h.l1.block_info_at(i)).await;
-        total_derived += verifier.act_l2_pipeline_full().await.expect("step");
+        total_derived += verifier.act_l2_pipeline_full().await;
     }
 
     // The pipeline should derive blocks for all L2 slots. Blocks 1-6 use the
@@ -168,17 +168,17 @@ async fn sequencer_drift_forced_empty_blocks_accepted() {
     // (over drift, ts=2100, 2400). block_time=300 s, max_drift=1800 s.
     let mut source = ActionL2Source::new();
     for _ in 1u64..=6 {
-        source.push(sequencer.build_next_block().expect("build normal block"));
+        source.push(sequencer.build_next_block());
     }
     // Build empty blocks past the drift boundary. The empty block has only
     // the deposit tx — the batcher encodes it but the pipeline drops it
     // (stale epoch) and produces a default block.
     for _ in 7u64..=8 {
-        source.push(sequencer.build_empty_block().expect("build empty block"));
+        source.push(sequencer.build_empty_block());
     }
 
     let mut batcher = Batcher::new(source, &h.rollup_config, batcher_cfg.clone());
-    batcher.advance(&mut h.l1).await.expect("batcher advance");
+    batcher.advance(&mut h.l1).await;
     chain.push(h.l1.tip().clone());
 
     verifier.initialize().await;
@@ -186,7 +186,7 @@ async fn sequencer_drift_forced_empty_blocks_accepted() {
     let mut total_derived = 0;
     for i in 1..=h.l1.latest_number() {
         verifier.act_l1_head_signal(h.l1.block_info_at(i)).await;
-        total_derived += verifier.act_l2_pipeline_full().await.expect("step");
+        total_derived += verifier.act_l2_pipeline_full().await;
     }
 
     // All 8 blocks should be derived: 6 normal + 2 empty (pipeline-generated

--- a/actions/harness/tests/derivation.rs
+++ b/actions/harness/tests/derivation.rs
@@ -31,11 +31,8 @@ async fn single_l2_block_derived_from_batcher_frame() {
     let l1_chain = SharedL1Chain::from_blocks(h.l1.chain().to_vec());
     let mut builder = h.create_l2_sequencer(l1_chain);
     let mut source = ActionL2Source::new();
-    source.push(builder.build_next_block().expect("build L2 block 1"));
-    Batcher::new(source, &h.rollup_config, batcher_cfg.clone())
-        .advance(&mut h.l1)
-        .await
-        .expect("advance");
+    source.push(builder.build_next_block());
+    Batcher::new(source, &h.rollup_config, batcher_cfg.clone()).advance(&mut h.l1).await;
 
     // Create the verifier AFTER mining so the SharedL1Chain snapshot already
     // contains both genesis and block 1.
@@ -54,7 +51,7 @@ async fn single_l2_block_derived_from_batcher_frame() {
     verifier.act_l1_head_signal(l1_block_1).await;
 
     // Step the pipeline until it is idle.
-    let derived = verifier.act_l2_pipeline_full().await.expect("pipeline step should succeed");
+    let derived = verifier.act_l2_pipeline_full().await;
 
     assert_eq!(derived, 1, "expected exactly one L2 block to be derived");
     assert_eq!(verifier.l2_safe_number(), 1, "safe head should be L2 block 1");
@@ -85,11 +82,8 @@ async fn multiple_l1_blocks_each_derive_one_l2_block() {
 
     for _ in 1..=L2_BLOCK_COUNT {
         let mut source = ActionL2Source::new();
-        source.push(builder.build_next_block().expect("build block"));
-        Batcher::new(source, &h.rollup_config, batcher_cfg.clone())
-            .advance(&mut h.l1)
-            .await
-            .expect("advance");
+        source.push(builder.build_next_block());
+        Batcher::new(source, &h.rollup_config, batcher_cfg.clone()).advance(&mut h.l1).await;
     }
 
     let (mut verifier, _chain) = h.create_verifier_from_sequencer(
@@ -101,7 +95,7 @@ async fn multiple_l1_blocks_each_derive_one_l2_block() {
     // Drive derivation one L1 block at a time.
     for i in 1..=L2_BLOCK_COUNT {
         verifier.act_l1_head_signal(h.l1.block_info_at(i)).await;
-        let derived = verifier.act_l2_pipeline_full().await.expect("pipeline ok");
+        let derived = verifier.act_l2_pipeline_full().await;
         assert_eq!(derived, 1, "L1 block {i} should derive exactly one L2 block");
     }
 
@@ -125,11 +119,8 @@ async fn batch_in_orphaned_l1_block_is_not_derived() {
     let l1_chain = SharedL1Chain::from_blocks(h.l1.chain().to_vec());
     let mut builder = h.create_l2_sequencer(l1_chain);
     let mut source = ActionL2Source::new();
-    source.push(builder.build_next_block().expect("build block 1"));
-    Batcher::new(source, &h.rollup_config, batcher_cfg.clone())
-        .advance(&mut h.l1)
-        .await
-        .expect("advance");
+    source.push(builder.build_next_block());
+    Batcher::new(source, &h.rollup_config, batcher_cfg.clone()).advance(&mut h.l1).await;
 
     // Reorg L1 back to genesis; mine an empty replacement block 1'.
     h.l1.reorg_to(0).expect("reorg to genesis");
@@ -145,7 +136,7 @@ async fn batch_in_orphaned_l1_block_is_not_derived() {
 
     verifier.initialize().await;
     verifier.act_l1_head_signal(l1_block_1_prime).await;
-    let derived = verifier.act_l2_pipeline_full().await.expect("step");
+    let derived = verifier.act_l2_pipeline_full().await;
 
     assert_eq!(derived, 0, "batch was in orphaned block; nothing should be derived");
     assert_eq!(verifier.l2_safe_number(), 0, "safe head remains at genesis");
@@ -168,11 +159,8 @@ async fn reorg_reverts_derived_safe_head() {
     let l1_chain = SharedL1Chain::from_blocks(h.l1.chain().to_vec());
     let mut builder = h.create_l2_sequencer(l1_chain);
     let mut source = ActionL2Source::new();
-    source.push(builder.build_next_block().expect("build block 1"));
-    Batcher::new(source, &h.rollup_config, batcher_cfg.clone())
-        .advance(&mut h.l1)
-        .await
-        .expect("advance");
+    source.push(builder.build_next_block());
+    Batcher::new(source, &h.rollup_config, batcher_cfg.clone()).advance(&mut h.l1).await;
 
     // Create the verifier and derive L2 block 1.
     let (mut verifier, chain) = h.create_verifier_from_sequencer(
@@ -183,7 +171,7 @@ async fn reorg_reverts_derived_safe_head() {
 
     verifier.initialize().await;
     verifier.act_l1_head_signal(l1_block_1).await;
-    let derived = verifier.act_l2_pipeline_full().await.expect("step");
+    let derived = verifier.act_l2_pipeline_full().await;
     assert_eq!(derived, 1, "L2 block 1 derived before reorg");
     assert_eq!(verifier.l2_safe_number(), 1);
 
@@ -203,11 +191,11 @@ async fn reorg_reverts_derived_safe_head() {
 
     verifier.act_reset(l1_genesis, l2_genesis, genesis_sys_cfg).await;
     // Drain the reset origin (genesis has no batch data).
-    verifier.act_l2_pipeline_full().await.expect("drain genesis after reset");
+    verifier.act_l2_pipeline_full().await;
 
     // Signal the new fork's empty block 1' and step.
     verifier.act_l1_head_signal(l1_block_1_prime).await;
-    let derived = verifier.act_l2_pipeline_full().await.expect("step after reorg");
+    let derived = verifier.act_l2_pipeline_full().await;
 
     assert_eq!(derived, 0, "no batch in reorged fork");
     assert_eq!(verifier.l2_safe_number(), 0, "safe head reverted to genesis");
@@ -228,15 +216,12 @@ async fn reorg_and_resubmit_rederives_l2_block() {
     // --- Pre-reorg: derive L2 block 1 from L1 block 1. ---
     let l1_chain = SharedL1Chain::from_blocks(h.l1.chain().to_vec());
     let mut builder = h.create_l2_sequencer(l1_chain);
-    let block1 = builder.build_next_block().expect("build block 1");
+    let block1 = builder.build_next_block();
 
     {
         let mut source = ActionL2Source::new();
         source.push(block1.clone());
-        Batcher::new(source, &h.rollup_config, batcher_cfg.clone())
-            .advance(&mut h.l1)
-            .await
-            .expect("advance block 1");
+        Batcher::new(source, &h.rollup_config, batcher_cfg.clone()).advance(&mut h.l1).await;
     }
 
     let (mut verifier, chain) = h.create_verifier_from_sequencer(
@@ -245,7 +230,7 @@ async fn reorg_and_resubmit_rederives_l2_block() {
     );
     verifier.initialize().await;
     verifier.act_l1_head_signal(h.l1.tip_info()).await;
-    let derived = verifier.act_l2_pipeline_full().await.expect("step");
+    let derived = verifier.act_l2_pipeline_full().await;
     assert_eq!(derived, 1);
     assert_eq!(verifier.l2_safe_number(), 1);
 
@@ -262,11 +247,11 @@ async fn reorg_and_resubmit_rederives_l2_block() {
     let genesis_sys_cfg = rollup_cfg.genesis.system_config.unwrap_or_default();
 
     verifier.act_reset(l1_genesis, l2_genesis, genesis_sys_cfg).await;
-    verifier.act_l2_pipeline_full().await.expect("drain genesis after reset");
+    verifier.act_l2_pipeline_full().await;
 
     // Step over the empty block 1' — nothing derived.
     verifier.act_l1_head_signal(l1_block_1_prime).await;
-    let empty = verifier.act_l2_pipeline_full().await.expect("step over block 1'");
+    let empty = verifier.act_l2_pipeline_full().await;
     assert_eq!(empty, 0, "block 1' has no batch; nothing derived");
     assert_eq!(verifier.l2_safe_number(), 0);
 
@@ -276,16 +261,13 @@ async fn reorg_and_resubmit_rederives_l2_block() {
     {
         let mut source = ActionL2Source::new();
         source.push(block1);
-        Batcher::new(source, &h.rollup_config, batcher_cfg.clone())
-            .advance(&mut h.l1)
-            .await
-            .expect("resubmit block 1");
+        Batcher::new(source, &h.rollup_config, batcher_cfg.clone()).advance(&mut h.l1).await;
     }
     chain.push(h.l1.tip().clone());
 
     // Derive L2 block 1 from the resubmitted batch in L1 block 2'.
     verifier.act_l1_head_signal(h.l1.tip_info()).await;
-    let rederived = verifier.act_l2_pipeline_full().await.expect("step block 2'");
+    let rederived = verifier.act_l2_pipeline_full().await;
 
     assert_eq!(rederived, 1, "L2 block 1 re-derived from resubmitted batch");
     assert_eq!(verifier.l2_safe_number(), 1, "safe head recovered to 1");
@@ -310,7 +292,7 @@ async fn reorg_flip_flop() {
     // epoch info is the same (all forks reference L1 genesis as epoch 0).
     let l1_chain = SharedL1Chain::from_blocks(h.l1.chain().to_vec());
     let mut sequencer = h.create_l2_sequencer(l1_chain);
-    let block1 = sequencer.build_next_block().expect("build block 1");
+    let block1 = sequencer.build_next_block();
 
     // Shared reset helpers — computed once, valid across all forks because
     // genesis is immutable.
@@ -322,10 +304,7 @@ async fn reorg_flip_flop() {
     {
         let mut source = ActionL2Source::new();
         source.push(block1.clone());
-        Batcher::new(source, &h.rollup_config, batcher_cfg.clone())
-            .advance(&mut h.l1)
-            .await
-            .expect("A1 advance");
+        Batcher::new(source, &h.rollup_config, batcher_cfg.clone()).advance(&mut h.l1).await;
     }
 
     let (mut verifier, chain) = h.create_verifier_from_sequencer(
@@ -334,7 +313,7 @@ async fn reorg_flip_flop() {
     );
     verifier.initialize().await;
     verifier.act_l1_head_signal(h.l1.tip_info()).await;
-    let derived = verifier.act_l2_pipeline_full().await.expect("step A");
+    let derived = verifier.act_l2_pipeline_full().await;
     assert_eq!(derived, 1, "phase 1: L2 block 1 derived from fork A");
     assert_eq!(verifier.l2_safe_number(), 1);
 
@@ -343,10 +322,7 @@ async fn reorg_flip_flop() {
     {
         let mut source = ActionL2Source::new();
         source.push(block1.clone());
-        Batcher::new(source, &h.rollup_config, batcher_cfg.clone())
-            .advance(&mut h.l1)
-            .await
-            .expect("B1 advance");
+        Batcher::new(source, &h.rollup_config, batcher_cfg.clone()).advance(&mut h.l1).await;
     }
     let fork_b1 = h.l1.tip_info();
 
@@ -354,9 +330,9 @@ async fn reorg_flip_flop() {
     chain.push(h.l1.tip().clone());
 
     verifier.act_reset(l1_genesis, l2_genesis, genesis_sys_cfg).await;
-    verifier.act_l2_pipeline_full().await.expect("drain genesis (reset to B)");
+    verifier.act_l2_pipeline_full().await;
     verifier.act_l1_head_signal(fork_b1).await;
-    let derived = verifier.act_l2_pipeline_full().await.expect("step B");
+    let derived = verifier.act_l2_pipeline_full().await;
     assert_eq!(derived, 1, "phase 2: L2 block 1 re-derived from fork B");
     assert_eq!(verifier.l2_safe_number(), 1);
 
@@ -365,10 +341,7 @@ async fn reorg_flip_flop() {
     {
         let mut source = ActionL2Source::new();
         source.push(block1);
-        Batcher::new(source, &h.rollup_config, batcher_cfg.clone())
-            .advance(&mut h.l1)
-            .await
-            .expect("A1' advance");
+        Batcher::new(source, &h.rollup_config, batcher_cfg.clone()).advance(&mut h.l1).await;
     }
     let fork_a_prime1 = h.l1.tip_info();
 
@@ -376,9 +349,9 @@ async fn reorg_flip_flop() {
     chain.push(h.l1.tip().clone());
 
     verifier.act_reset(l1_genesis, l2_genesis, genesis_sys_cfg).await;
-    verifier.act_l2_pipeline_full().await.expect("drain genesis (reset to A')");
+    verifier.act_l2_pipeline_full().await;
     verifier.act_l1_head_signal(fork_a_prime1).await;
-    let derived = verifier.act_l2_pipeline_full().await.expect("step A'");
+    let derived = verifier.act_l2_pipeline_full().await;
     assert_eq!(derived, 1, "phase 3: L2 block 1 re-derived from fork A'");
     assert_eq!(verifier.l2_safe_number(), 1);
 }
@@ -411,8 +384,8 @@ async fn reorg_flip_flop_empty_middle_fork() {
     // and their encoded batch frames are valid on any fork sharing genesis.
     let l1_chain = SharedL1Chain::from_blocks(h.l1.chain().to_vec());
     let mut builder = h.create_l2_sequencer(l1_chain);
-    let block1 = builder.build_next_block().expect("build block 1");
-    let block2 = builder.build_next_block().expect("build block 2");
+    let block1 = builder.build_next_block();
+    let block2 = builder.build_next_block();
 
     // Shared reset targets — valid across all forks because genesis is immutable.
     let l1_genesis = block_info_from(h.l1.chain().first().expect("genesis always present"));
@@ -423,10 +396,7 @@ async fn reorg_flip_flop_empty_middle_fork() {
     for block in [block1.clone(), block2.clone()] {
         let mut source = ActionL2Source::new();
         source.push(block);
-        Batcher::new(source, &h.rollup_config, batcher_cfg.clone())
-            .advance(&mut h.l1)
-            .await
-            .expect("fork A: advance");
+        Batcher::new(source, &h.rollup_config, batcher_cfg.clone()).advance(&mut h.l1).await;
     }
 
     let (mut verifier, chain) = h.create_verifier_from_sequencer(
@@ -437,7 +407,7 @@ async fn reorg_flip_flop_empty_middle_fork() {
 
     for i in 1u64..=2 {
         verifier.act_l1_head_signal(h.l1.block_info_at(i)).await;
-        let derived = verifier.act_l2_pipeline_full().await.expect("fork A: step");
+        let derived = verifier.act_l2_pipeline_full().await;
         assert_eq!(derived, 1, "fork A: L2 block {i} derived");
         assert_eq!(
             verifier.l2_safe().l1_origin.number,
@@ -466,12 +436,12 @@ async fn reorg_flip_flop_empty_middle_fork() {
     assert_eq!(verifier.l2_finalized_number(), 0, "reset to B: finalized head = 0");
     assert_eq!(verifier.l2_unsafe_number(), 0, "reset to B: unsafe head = 0");
 
-    let drained = verifier.act_l2_pipeline_full().await.expect("drain genesis after reset to B");
+    let drained = verifier.act_l2_pipeline_full().await;
     assert_eq!(drained, 0, "reset drain must produce no L2 blocks");
 
     for (i, blk_info) in fork_b_blocks.into_iter().enumerate() {
         verifier.act_l1_head_signal(blk_info).await;
-        let derived = verifier.act_l2_pipeline_full().await.expect("fork B: step");
+        let derived = verifier.act_l2_pipeline_full().await;
         assert_eq!(derived, 0, "fork B block {}: empty, nothing derived", i + 1);
     }
     assert_eq!(verifier.l2_safe_number(), 0, "fork B: safe head = 0");
@@ -484,10 +454,7 @@ async fn reorg_flip_flop_empty_middle_fork() {
     for block in [block1, block2] {
         let mut source = ActionL2Source::new();
         source.push(block);
-        Batcher::new(source, &h.rollup_config, batcher_cfg.clone())
-            .advance(&mut h.l1)
-            .await
-            .expect("fork C: advance");
+        Batcher::new(source, &h.rollup_config, batcher_cfg.clone()).advance(&mut h.l1).await;
         fork_c_blocks.push(h.l1.tip_info());
         chain.push(h.l1.tip().clone());
     }
@@ -498,12 +465,12 @@ async fn reorg_flip_flop_empty_middle_fork() {
     // unsafe_head unchanged by act_reset (spec-compliant: re-discover, don't clamp).
     assert_eq!(verifier.l2_unsafe_number(), 0, "reset to C: unsafe head = 0");
 
-    let drained = verifier.act_l2_pipeline_full().await.expect("drain genesis after reset to C");
+    let drained = verifier.act_l2_pipeline_full().await;
     assert_eq!(drained, 0, "reset drain must produce no L2 blocks");
 
     for (i, blk_info) in fork_c_blocks.into_iter().enumerate() {
         verifier.act_l1_head_signal(blk_info).await;
-        let derived = verifier.act_l2_pipeline_full().await.expect("fork C: step");
+        let derived = verifier.act_l2_pipeline_full().await;
         assert_eq!(derived, 1, "fork C: L2 block {} re-derived", i + 1);
         assert_eq!(
             verifier.l2_safe().l1_origin.number,
@@ -541,7 +508,7 @@ async fn batch_accepted_at_last_seq_window_block() {
     // Build L2 block 1 referencing L1 genesis (epoch 0).
     let l1_chain = SharedL1Chain::from_blocks(h.l1.chain().to_vec());
     let mut builder = h.create_l2_sequencer(l1_chain);
-    let block1 = builder.build_next_block().expect("build block 1");
+    let block1 = builder.build_next_block();
 
     // Mine 2 empty L1 blocks (no batch yet).
     h.mine_l1_blocks(2); // blocks 1 and 2
@@ -551,10 +518,7 @@ async fn batch_accepted_at_last_seq_window_block() {
     {
         let mut source = ActionL2Source::new();
         source.push(block1);
-        Batcher::new(source, &h.rollup_config, batcher_cfg.clone())
-            .advance(&mut h.l1)
-            .await
-            .expect("advance block 1");
+        Batcher::new(source, &h.rollup_config, batcher_cfg.clone()).advance(&mut h.l1).await;
     }
 
     let (mut verifier, _chain) = h.create_verifier_from_sequencer(
@@ -566,7 +530,7 @@ async fn batch_accepted_at_last_seq_window_block() {
     // Signal blocks 1, 2, 3 and step after each.
     for i in 1..=SEQ_WINDOW - 1 {
         verifier.act_l1_head_signal(h.l1.block_info_at(i)).await;
-        verifier.act_l2_pipeline_full().await.expect("step");
+        verifier.act_l2_pipeline_full().await;
     }
 
     assert_eq!(verifier.l2_safe_number(), 1, "batch in last valid L1 block must be derived");
@@ -695,7 +659,7 @@ async fn l1_deposit_included_in_derived_l2_block() {
     // Build L2 block 1 from the sequencer.
     let l1_chain = SharedL1Chain::from_blocks(h.l1.chain().to_vec());
     let mut sequencer = h.create_l2_sequencer(l1_chain);
-    let block1 = sequencer.build_next_block().expect("build L2 block 1");
+    let block1 = sequencer.build_next_block();
 
     // Enqueue a user deposit log: from=0xAA..AA, to=0xBB..BB, value=1 ETH, gas=100k.
     h.l1.enqueue_log(user_deposit_log(
@@ -712,10 +676,7 @@ async fn l1_deposit_included_in_derived_l2_block() {
     {
         let mut source = ActionL2Source::new();
         source.push(block1);
-        Batcher::new(source, &h.rollup_config, batcher_cfg.clone())
-            .advance(&mut h.l1)
-            .await
-            .expect("advance block 1");
+        Batcher::new(source, &h.rollup_config, batcher_cfg.clone()).advance(&mut h.l1).await;
     }
 
     // Create verifier AFTER mining so the snapshot contains block 1.
@@ -727,7 +688,7 @@ async fn l1_deposit_included_in_derived_l2_block() {
 
     verifier.initialize().await;
     verifier.act_l1_head_signal(l1_block_1).await;
-    let derived = verifier.act_l2_pipeline_full().await.expect("pipeline step should succeed");
+    let derived = verifier.act_l2_pipeline_full().await;
 
     assert_eq!(derived, 1, "expected exactly one L2 block to be derived");
     assert_eq!(verifier.l2_safe_number(), 1, "safe head should be L2 block 1");
@@ -783,18 +744,15 @@ async fn batcher_key_rotation_accepts_new_batcher() {
     // stay in epoch 0 (genesis ts=0), so the builder picks the same L1 origin.
     let l1_chain = SharedL1Chain::from_blocks(h.l1.chain().to_vec());
     let mut builder = h.create_l2_sequencer(l1_chain);
-    let block1 = builder.build_next_block().expect("build block 1");
-    let block2 = builder.build_next_block().expect("build block 2");
-    let block3 = builder.build_next_block().expect("build block 3");
+    let block1 = builder.build_next_block();
+    let block2 = builder.build_next_block();
+    let block3 = builder.build_next_block();
 
     // --- L1 blocks 1-2: batcher A submits → L2 blocks 1-2 derived. ---
     for block in [block1, block2] {
         let mut source = ActionL2Source::new();
         source.push(block);
-        Batcher::new(source, &h.rollup_config, batcher_a.clone())
-            .advance(&mut h.l1)
-            .await
-            .expect("batcher A advance");
+        Batcher::new(source, &h.rollup_config, batcher_a.clone()).advance(&mut h.l1).await;
     }
 
     // --- L1 block 3: rotation log only, no batch. ---
@@ -812,28 +770,25 @@ async fn batcher_key_rotation_accepts_new_batcher() {
     // Drive derivation through blocks 1-2 (batcher A frames derived).
     for i in 1u64..=2 {
         verifier.act_l1_head_signal(h.l1.block_info_at(i)).await;
-        verifier.act_l2_pipeline_full().await.expect("step");
+        verifier.act_l2_pipeline_full().await;
     }
     assert_eq!(verifier.l2_safe_number(), 2, "blocks 1-2 derived with batcher A");
 
     // Step over the rotation block — no batch, but system config updates to B.
     verifier.act_l1_head_signal(h.l1.block_info_at(3)).await;
-    let rotation_derived = verifier.act_l2_pipeline_full().await.expect("step rotation block");
+    let rotation_derived = verifier.act_l2_pipeline_full().await;
     assert_eq!(rotation_derived, 0, "rotation block contains no batch");
 
     // --- L1 block 4: batcher A submits for L2 block 3 — must be ignored. ---
     {
         let mut source = ActionL2Source::new();
         source.push(block3.clone());
-        Batcher::new(source, &h.rollup_config, batcher_a.clone())
-            .advance(&mut h.l1)
-            .await
-            .expect("batcher A advance block 3");
+        Batcher::new(source, &h.rollup_config, batcher_a.clone()).advance(&mut h.l1).await;
     }
     chain.push(h.l1.tip().clone());
 
     verifier.act_l1_head_signal(h.l1.tip_info()).await;
-    let derived_a = verifier.act_l2_pipeline_full().await.expect("step block 4");
+    let derived_a = verifier.act_l2_pipeline_full().await;
     assert_eq!(derived_a, 0, "batcher A frame must be ignored after key rotation");
     assert_eq!(verifier.l2_safe_number(), 2, "safe head must not advance");
 
@@ -841,15 +796,12 @@ async fn batcher_key_rotation_accepts_new_batcher() {
     {
         let mut source = ActionL2Source::new();
         source.push(block3);
-        Batcher::new(source, &h.rollup_config, batcher_b.clone())
-            .advance(&mut h.l1)
-            .await
-            .expect("batcher B advance block 3");
+        Batcher::new(source, &h.rollup_config, batcher_b.clone()).advance(&mut h.l1).await;
     }
     chain.push(h.l1.tip().clone());
 
     verifier.act_l1_head_signal(h.l1.tip_info()).await;
-    let derived_b = verifier.act_l2_pipeline_full().await.expect("step block 5");
+    let derived_b = verifier.act_l2_pipeline_full().await;
     assert_eq!(derived_b, 1, "batcher B frame must be derived after key rotation");
     assert_eq!(verifier.l2_safe_number(), 3, "safe head advances to 3");
 }
@@ -879,13 +831,10 @@ async fn multi_l2_per_l1_epoch() {
     );
 
     for _ in 1..=L2_COUNT {
-        let block = builder.build_next_block().expect("build L2 block");
+        let block = builder.build_next_block();
         let mut source = ActionL2Source::new();
         source.push(block);
-        Batcher::new(source, &h.rollup_config, batcher_cfg.clone())
-            .advance(&mut h.l1)
-            .await
-            .expect("advance");
+        Batcher::new(source, &h.rollup_config, batcher_cfg.clone()).advance(&mut h.l1).await;
         chain.push(h.l1.tip().clone());
     }
 
@@ -893,7 +842,7 @@ async fn multi_l2_per_l1_epoch() {
 
     for i in 1..=L2_COUNT {
         verifier.act_l1_head_signal(h.l1.block_info_at(i)).await;
-        let derived = verifier.act_l2_pipeline_full().await.expect("step");
+        let derived = verifier.act_l2_pipeline_full().await;
         assert_eq!(derived, 1, "L1 block {i} should derive exactly one L2 block");
     }
 
@@ -930,7 +879,7 @@ async fn batch_past_sequence_window_rejected() {
     // Build L2 block 1 (epoch 0).
     let l1_chain = SharedL1Chain::from_blocks(h.l1.chain().to_vec());
     let mut builder = h.create_l2_sequencer(l1_chain);
-    let block1 = builder.build_next_block().expect("build block 1");
+    let block1 = builder.build_next_block();
 
     // Mine 2 empty L1 blocks (seq_window=3, so valid inclusion is blocks 1 and 2 only).
     // Batch is valid if inclusion_block < epoch + seq_window = 0 + 3 = 3.
@@ -941,10 +890,7 @@ async fn batch_past_sequence_window_rejected() {
     {
         let mut source = ActionL2Source::new();
         source.push(block1);
-        Batcher::new(source, &h.rollup_config, batcher_cfg.clone())
-            .advance(&mut h.l1)
-            .await
-            .expect("advance block 1");
+        Batcher::new(source, &h.rollup_config, batcher_cfg.clone()).advance(&mut h.l1).await;
     }
 
     let (mut verifier, _chain) = h.create_verifier_from_sequencer(
@@ -956,7 +902,7 @@ async fn batch_past_sequence_window_rejected() {
     let mut total_derived = 0;
     for i in 1..=SEQ_WINDOW {
         verifier.act_l1_head_signal(h.l1.block_info_at(i)).await;
-        total_derived += verifier.act_l2_pipeline_full().await.expect("step");
+        total_derived += verifier.act_l2_pipeline_full().await;
     }
 
     // The pipeline generates deposit-only blocks to fill the epoch when the
@@ -1006,7 +952,7 @@ async fn multi_epoch_sequence() {
 
     let mut blocks = Vec::new();
     for _ in 0..12 {
-        let block = builder.build_next_block().expect("build L2 block");
+        let block = builder.build_next_block();
         blocks.push(block);
     }
 
@@ -1024,10 +970,7 @@ async fn multi_epoch_sequence() {
     for block in &blocks {
         let mut source = ActionL2Source::new();
         source.push(block.clone());
-        Batcher::new(source, &h.rollup_config, batcher_cfg.clone())
-            .advance(&mut h.l1)
-            .await
-            .expect("advance");
+        Batcher::new(source, &h.rollup_config, batcher_cfg.clone()).advance(&mut h.l1).await;
         chain.push(h.l1.tip().clone());
     }
 
@@ -1038,7 +981,7 @@ async fn multi_epoch_sequence() {
     let mut total_derived = 0;
     for i in 1..=(2 + 12) {
         verifier.act_l1_head_signal(h.l1.block_info_at(i)).await;
-        total_derived += verifier.act_l2_pipeline_full().await.expect("step");
+        total_derived += verifier.act_l2_pipeline_full().await;
     }
 
     assert_eq!(total_derived, 12, "all 12 L2 blocks should be derived");
@@ -1065,15 +1008,12 @@ async fn same_epoch_multi_batch_one_l1_block() {
 
     let mut source = ActionL2Source::new();
     for _ in 1..=3u64 {
-        let block = builder.build_next_block().expect("build");
+        let block = builder.build_next_block();
         source.push(block);
     }
 
     // Encode all 3 blocks into one batcher submission (single channel) and mine.
-    Batcher::new(source, &h.rollup_config, batcher_cfg.clone())
-        .advance(&mut h.l1)
-        .await
-        .expect("advance");
+    Batcher::new(source, &h.rollup_config, batcher_cfg.clone()).advance(&mut h.l1).await;
 
     // Create verifier after mining so the snapshot includes the inclusion block.
     let (mut verifier, _chain) = h.create_verifier_from_sequencer(
@@ -1083,7 +1023,7 @@ async fn same_epoch_multi_batch_one_l1_block() {
     verifier.initialize().await;
 
     verifier.act_l1_head_signal(h.l1.block_info_at(1)).await;
-    let derived = verifier.act_l2_pipeline_full().await.expect("step");
+    let derived = verifier.act_l2_pipeline_full().await;
 
     assert_eq!(derived, 3, "all 3 L2 blocks should be derived from one L1 block");
     assert_eq!(verifier.l2_safe_number(), 3);
@@ -1111,7 +1051,7 @@ async fn deep_reorg_multi_block() {
     // Build 5 L2 blocks.
     let mut blocks = Vec::new();
     for _ in 0..5 {
-        let block = builder.build_next_block().expect("build");
+        let block = builder.build_next_block();
         blocks.push(block);
     }
 
@@ -1119,10 +1059,7 @@ async fn deep_reorg_multi_block() {
     for block in &blocks {
         let mut source = ActionL2Source::new();
         source.push(block.clone());
-        Batcher::new(source, &h.rollup_config, batcher_cfg.clone())
-            .advance(&mut h.l1)
-            .await
-            .expect("advance");
+        Batcher::new(source, &h.rollup_config, batcher_cfg.clone()).advance(&mut h.l1).await;
     }
 
     // Create verifier with all 5 L1 inclusion blocks visible.
@@ -1134,7 +1071,7 @@ async fn deep_reorg_multi_block() {
 
     for i in 1..=5u64 {
         verifier.act_l1_head_signal(h.l1.block_info_at(i)).await;
-        verifier.act_l2_pipeline_full().await.expect("step");
+        verifier.act_l2_pipeline_full().await;
     }
     assert_eq!(verifier.l2_safe_number(), 5, "pre-reorg: 5 L2 blocks derived");
 
@@ -1146,7 +1083,7 @@ async fn deep_reorg_multi_block() {
     let l2_genesis = h.l2_genesis();
     let genesis_sys_cfg = rollup_cfg.genesis.system_config.unwrap_or_default();
     verifier.act_reset(l1_genesis, l2_genesis, genesis_sys_cfg).await;
-    verifier.act_l2_pipeline_full().await.expect("drain after reset");
+    verifier.act_l2_pipeline_full().await;
 
     assert_eq!(verifier.l2_safe_number(), 0, "safe head reverted to genesis");
 
@@ -1154,17 +1091,14 @@ async fn deep_reorg_multi_block() {
     for block in &blocks {
         let mut source = ActionL2Source::new();
         source.push(block.clone());
-        Batcher::new(source, &h.rollup_config, batcher_cfg.clone())
-            .advance(&mut h.l1)
-            .await
-            .expect("re-submit");
+        Batcher::new(source, &h.rollup_config, batcher_cfg.clone()).advance(&mut h.l1).await;
         chain.push(h.l1.tip().clone());
     }
 
     // Drive derivation on the new fork.
     for i in 1..=5u64 {
         verifier.act_l1_head_signal(h.l1.block_info_at(i)).await;
-        verifier.act_l2_pipeline_full().await.expect("step");
+        verifier.act_l2_pipeline_full().await;
     }
 
     assert_eq!(verifier.l2_safe_number(), 5, "post-reorg: 5 L2 blocks recovered");
@@ -1187,7 +1121,7 @@ async fn garbage_frame_data_ignored() {
 
     let l1_chain = SharedL1Chain::from_blocks(h.l1.chain().to_vec());
     let mut builder = h.create_l2_sequencer(l1_chain);
-    let block = builder.build_next_block().expect("build L2 block 1");
+    let block = builder.build_next_block();
 
     let (mut verifier, chain) = h.create_verifier_from_sequencer(
         &builder,
@@ -1210,7 +1144,7 @@ async fn garbage_frame_data_ignored() {
     h.mine_and_push(&chain);
 
     verifier.act_l1_head_signal(h.l1.block_info_at(1)).await;
-    let derived = verifier.act_l2_pipeline_full().await.expect("step over garbage");
+    let derived = verifier.act_l2_pipeline_full().await;
     assert_eq!(derived, 0, "garbage frame must be silently ignored");
     assert_eq!(verifier.l2_safe_number(), 0);
 
@@ -1218,15 +1152,12 @@ async fn garbage_frame_data_ignored() {
     {
         let mut source = ActionL2Source::new();
         source.push(block);
-        Batcher::new(source, &h.rollup_config, batcher_cfg.clone())
-            .advance(&mut h.l1)
-            .await
-            .expect("advance real batch");
+        Batcher::new(source, &h.rollup_config, batcher_cfg.clone()).advance(&mut h.l1).await;
     }
     chain.push(h.l1.tip().clone());
 
     verifier.act_l1_head_signal(h.l1.block_info_at(2)).await;
-    let derived = verifier.act_l2_pipeline_full().await.expect("step real block");
+    let derived = verifier.act_l2_pipeline_full().await;
     assert_eq!(derived, 1, "real frame after garbage must still be derived");
     assert_eq!(verifier.l2_safe_number(), 1);
 }
@@ -1259,7 +1190,7 @@ async fn multi_frame_channel_reassembled() {
 
     let l1_chain = SharedL1Chain::from_blocks(h.l1.chain().to_vec());
     let mut builder = h.create_l2_sequencer(l1_chain);
-    let block = builder.build_next_block().expect("build L2 block 1");
+    let block = builder.build_next_block();
 
     let (mut verifier, chain) = h.create_verifier_from_sequencer(
         &builder,
@@ -1271,7 +1202,7 @@ async fn multi_frame_channel_reassembled() {
     let mut source = ActionL2Source::new();
     source.push(block);
     let mut batcher = Batcher::new(source, &h.rollup_config, batcher_cfg.clone());
-    batcher.encode_only().await.expect("encode");
+    batcher.encode_only().await;
     assert!(
         batcher.pending_count() >= 2,
         "expected at least 2 frame submissions with max_frame_size=80, got {}",
@@ -1287,7 +1218,7 @@ async fn multi_frame_channel_reassembled() {
 
     verifier.initialize().await;
     verifier.act_l1_head_signal(h.l1.block_info_at(1)).await;
-    let derived = verifier.act_l2_pipeline_full().await.expect("step block 1");
+    let derived = verifier.act_l2_pipeline_full().await;
     assert_eq!(derived, 1, "multi-frame channel should be reassembled and derived");
     assert_eq!(verifier.l2_safe_number(), 1);
 }
@@ -1313,11 +1244,8 @@ async fn single_l2_block_derived_from_span_batch() {
     let l1_chain = SharedL1Chain::from_blocks(h.l1.chain().to_vec());
     let mut sequencer = h.create_l2_sequencer(l1_chain);
     let mut source = ActionL2Source::new();
-    source.push(sequencer.build_next_block().expect("build L2 block 1"));
-    Batcher::new(source, &h.rollup_config, batcher_cfg.clone())
-        .advance(&mut h.l1)
-        .await
-        .expect("advance");
+    source.push(sequencer.build_next_block());
+    Batcher::new(source, &h.rollup_config, batcher_cfg.clone()).advance(&mut h.l1).await;
 
     let (mut verifier, _chain) = h.create_verifier_from_sequencer(
         &sequencer,
@@ -1326,7 +1254,7 @@ async fn single_l2_block_derived_from_span_batch() {
     verifier.initialize().await;
 
     verifier.act_l1_head_signal(h.l1.tip_info()).await;
-    let derived = verifier.act_l2_pipeline_full().await.expect("step");
+    let derived = verifier.act_l2_pipeline_full().await;
 
     assert_eq!(derived, 1, "expected one L2 block from span batch");
     assert_eq!(verifier.l2_safe_number(), 1);
@@ -1352,13 +1280,10 @@ async fn three_l2_blocks_derived_from_span_batch() {
 
     let mut source = ActionL2Source::new();
     for _ in 1..=3u64 {
-        let block = sequencer.build_next_block().expect("build L2 block");
+        let block = sequencer.build_next_block();
         source.push(block);
     }
-    Batcher::new(source, &h.rollup_config, batcher_cfg.clone())
-        .advance(&mut h.l1)
-        .await
-        .expect("advance");
+    Batcher::new(source, &h.rollup_config, batcher_cfg.clone()).advance(&mut h.l1).await;
 
     let (mut verifier, _chain) = h.create_verifier_from_sequencer(
         &sequencer,
@@ -1367,7 +1292,7 @@ async fn three_l2_blocks_derived_from_span_batch() {
     verifier.initialize().await;
 
     verifier.act_l1_head_signal(h.l1.tip_info()).await;
-    let derived = verifier.act_l2_pipeline_full().await.expect("step");
+    let derived = verifier.act_l2_pipeline_full().await;
 
     assert_eq!(derived, 3, "expected 3 L2 blocks from span batch");
     assert_eq!(verifier.l2_safe_number(), 3);
@@ -1455,17 +1380,14 @@ async fn gpo_params_change_does_not_disrupt_derivation() {
 
     let l1_chain = SharedL1Chain::from_blocks(h.l1.chain().to_vec());
     let mut sequencer = h.create_l2_sequencer(l1_chain);
-    let block1 = sequencer.build_next_block().expect("build block 1");
-    let block2 = sequencer.build_next_block().expect("build block 2");
+    let block1 = sequencer.build_next_block();
+    let block2 = sequencer.build_next_block();
 
     // L1 block 1: batch for L2 block 1.
     {
         let mut source = ActionL2Source::new();
         source.push(block1);
-        Batcher::new(source, &h.rollup_config, batcher_cfg.clone())
-            .advance(&mut h.l1)
-            .await
-            .expect("advance block 1");
+        Batcher::new(source, &h.rollup_config, batcher_cfg.clone()).advance(&mut h.l1).await;
     }
 
     // L1 block 2: gas-config update log only, no batch.
@@ -1476,10 +1398,7 @@ async fn gpo_params_change_does_not_disrupt_derivation() {
     {
         let mut source = ActionL2Source::new();
         source.push(block2);
-        Batcher::new(source, &h.rollup_config, batcher_cfg.clone())
-            .advance(&mut h.l1)
-            .await
-            .expect("advance block 2");
+        Batcher::new(source, &h.rollup_config, batcher_cfg.clone()).advance(&mut h.l1).await;
     }
 
     let (mut verifier, _chain) = h.create_verifier_from_sequencer(
@@ -1490,7 +1409,7 @@ async fn gpo_params_change_does_not_disrupt_derivation() {
 
     for i in 1u64..=3 {
         verifier.act_l1_head_signal(h.l1.block_info_at(i)).await;
-        verifier.act_l2_pipeline_full().await.expect("step");
+        verifier.act_l2_pipeline_full().await;
     }
 
     assert_eq!(verifier.l2_safe_number(), 2, "both L2 blocks derived after GPO config update");
@@ -1517,17 +1436,14 @@ async fn gas_limit_change_does_not_disrupt_derivation() {
 
     let l1_chain = SharedL1Chain::from_blocks(h.l1.chain().to_vec());
     let mut sequencer = h.create_l2_sequencer(l1_chain);
-    let block1 = sequencer.build_next_block().expect("build block 1");
-    let block2 = sequencer.build_next_block().expect("build block 2");
+    let block1 = sequencer.build_next_block();
+    let block2 = sequencer.build_next_block();
 
     // L1 block 1: batch for L2 block 1.
     {
         let mut source = ActionL2Source::new();
         source.push(block1);
-        Batcher::new(source, &h.rollup_config, batcher_cfg.clone())
-            .advance(&mut h.l1)
-            .await
-            .expect("advance block 1");
+        Batcher::new(source, &h.rollup_config, batcher_cfg.clone()).advance(&mut h.l1).await;
     }
 
     // L1 block 2: gas-limit update log only.
@@ -1538,10 +1454,7 @@ async fn gas_limit_change_does_not_disrupt_derivation() {
     {
         let mut source = ActionL2Source::new();
         source.push(block2);
-        Batcher::new(source, &h.rollup_config, batcher_cfg.clone())
-            .advance(&mut h.l1)
-            .await
-            .expect("advance block 2");
+        Batcher::new(source, &h.rollup_config, batcher_cfg.clone()).advance(&mut h.l1).await;
     }
 
     let (mut verifier, _chain) = h.create_verifier_from_sequencer(
@@ -1552,7 +1465,7 @@ async fn gas_limit_change_does_not_disrupt_derivation() {
 
     for i in 1u64..=3 {
         verifier.act_l1_head_signal(h.l1.block_info_at(i)).await;
-        verifier.act_l2_pipeline_full().await.expect("step");
+        verifier.act_l2_pipeline_full().await;
     }
 
     assert_eq!(verifier.l2_safe_number(), 2, "both L2 blocks derived after gas-limit update");
@@ -1578,7 +1491,7 @@ async fn garbage_payload_silently_ignored_then_valid_batch_derived(
 
     let l1_chain = SharedL1Chain::from_blocks(h.l1.chain().to_vec());
     let mut sequencer = h.create_l2_sequencer(l1_chain);
-    let block = sequencer.build_next_block().expect("build L2 block 1");
+    let block = sequencer.build_next_block();
 
     // L1 block 1: garbage frame only.
     h.l1.submit_tx(PendingTx {
@@ -1592,10 +1505,7 @@ async fn garbage_payload_silently_ignored_then_valid_batch_derived(
     {
         let mut source = ActionL2Source::new();
         source.push(block);
-        Batcher::new(source, &h.rollup_config, batcher_cfg.clone())
-            .advance(&mut h.l1)
-            .await
-            .expect("advance valid batch");
+        Batcher::new(source, &h.rollup_config, batcher_cfg.clone()).advance(&mut h.l1).await;
     }
 
     let (mut verifier, _chain) = h.create_verifier_from_sequencer(
@@ -1606,13 +1516,13 @@ async fn garbage_payload_silently_ignored_then_valid_batch_derived(
 
     // Block 1: garbage — must not advance the safe head.
     verifier.act_l1_head_signal(h.l1.block_info_at(1)).await;
-    let derived_garbage = verifier.act_l2_pipeline_full().await.expect("step garbage");
+    let derived_garbage = verifier.act_l2_pipeline_full().await;
     assert_eq!(derived_garbage, 0, "garbage frame must be silently ignored");
     assert_eq!(verifier.l2_safe_number(), 0);
 
     // Block 2: valid batch — must be derived after the garbage.
     verifier.act_l1_head_signal(h.l1.block_info_at(2)).await;
-    let derived_real = verifier.act_l2_pipeline_full().await.expect("step valid");
+    let derived_real = verifier.act_l2_pipeline_full().await;
     assert_eq!(derived_real, 1, "valid batch after garbage must still be derived");
     assert_eq!(verifier.l2_safe_number(), 1);
 }
@@ -1688,16 +1598,13 @@ async fn l2_finalized_advances_via_l1_finalized_signal() {
     let l1_chain = SharedL1Chain::from_blocks(h.l1.chain().to_vec());
     let mut sequencer = h.create_l2_sequencer(l1_chain);
 
-    let block1 = sequencer.build_next_block().expect("build block 1");
-    let block2 = sequencer.build_next_block().expect("build block 2");
+    let block1 = sequencer.build_next_block();
+    let block2 = sequencer.build_next_block();
 
     for block in [block1, block2] {
         let mut source = ActionL2Source::new();
         source.push(block);
-        Batcher::new(source, &h.rollup_config, batcher_cfg.clone())
-            .advance(&mut h.l1)
-            .await
-            .expect("advance");
+        Batcher::new(source, &h.rollup_config, batcher_cfg.clone()).advance(&mut h.l1).await;
     }
 
     let (mut verifier, _chain) = h.create_verifier_from_sequencer(
@@ -1712,7 +1619,7 @@ async fn l2_finalized_advances_via_l1_finalized_signal() {
     // Derive both L2 blocks.
     for i in 1u64..=2 {
         verifier.act_l1_head_signal(h.l1.block_info_at(i)).await;
-        verifier.act_l2_pipeline_full().await.expect("step");
+        verifier.act_l2_pipeline_full().await;
     }
     assert_eq!(verifier.l2_safe_number(), 2);
 
@@ -1754,7 +1661,7 @@ async fn sequencer_pin_l1_origin_keeps_epoch_and_empty_block() {
     // Build 3 L2 blocks — all must reference epoch 0 even though L1 blocks 1
     // and 2 are available.
     for _ in 0..3 {
-        let _block = sequencer.build_next_block().expect("pinned build");
+        let _block = sequencer.build_next_block();
         assert_eq!(
             sequencer.head().l1_origin.number,
             0,
@@ -1763,7 +1670,7 @@ async fn sequencer_pin_l1_origin_keeps_epoch_and_empty_block() {
     }
 
     // build_empty_block with the pin active: only 1 transaction (deposit).
-    let empty = sequencer.build_empty_block().expect("empty block");
+    let empty = sequencer.build_empty_block();
     assert_eq!(
         empty.body.transactions.len(),
         1,
@@ -1773,7 +1680,7 @@ async fn sequencer_pin_l1_origin_keeps_epoch_and_empty_block() {
 
     // Clear the pin — automatic epoch selection resumes.
     sequencer.clear_l1_origin_pin();
-    let _block = sequencer.build_next_block().expect("unpinned build");
+    let _block = sequencer.build_next_block();
     // With block_time=2 and L1 block 1 at ts=12, the first unpinned block's
     // timestamp (current head ts + 2) is well below 12, so the epoch remains
     // at 0. Regardless, we just verify the pin was cleared without error.
@@ -1843,16 +1750,13 @@ async fn derive_chain_from_near_l1_genesis() {
 
     // Build 2 L2 blocks and batch them into L1 blocks #6 and #7.
     for _ in 1..=2u64 {
-        let block = sequencer.build_next_block().expect("build L2 block");
+        let block = sequencer.build_next_block();
         // With block_time=2 and L1 block 6 at ts=72, L2 block ts < 72
         // so the epoch stays at 5.
         assert_eq!(sequencer.head().l1_origin.number, 5, "epoch should stay at 5");
         let mut source = ActionL2Source::new();
         source.push(block);
-        Batcher::new(source, &rollup_cfg, batcher_cfg.clone())
-            .advance(&mut h.l1)
-            .await
-            .expect("advance"); // mines L1 block 5+i
+        Batcher::new(source, &rollup_cfg, batcher_cfg.clone()).advance(&mut h.l1).await; // mines L1 block 5+i
     }
 
     // Build the verifier components manually to anchor derivation at L1 block #5.
@@ -1878,7 +1782,7 @@ async fn derive_chain_from_near_l1_genesis() {
     // Signal L1 blocks #6 and #7, each containing one batch.
     for i in 6u64..=7 {
         verifier.act_l1_head_signal(h.l1.block_info_at(i)).await;
-        verifier.act_l2_pipeline_full().await.expect("step");
+        verifier.act_l2_pipeline_full().await;
     }
 
     assert_eq!(
@@ -1902,11 +1806,8 @@ async fn single_l2_block_derived_from_blob() {
     let l1_chain = SharedL1Chain::from_blocks(h.l1.chain().to_vec());
     let mut builder = h.create_l2_sequencer(l1_chain);
     let mut source = ActionL2Source::new();
-    source.push(builder.build_next_block().expect("build L2 block 1"));
-    Batcher::new(source, &h.rollup_config, batcher_cfg.clone())
-        .advance(&mut h.l1)
-        .await
-        .expect("advance");
+    source.push(builder.build_next_block());
+    Batcher::new(source, &h.rollup_config, batcher_cfg.clone()).advance(&mut h.l1).await;
 
     // Create the blob verifier AFTER mining so the snapshot contains the blob.
     let (mut verifier, _chain) = h.create_blob_verifier_from_sequencer(
@@ -1917,7 +1818,7 @@ async fn single_l2_block_derived_from_blob() {
 
     verifier.initialize().await;
     verifier.act_l1_head_signal(l1_block_1).await;
-    let derived = verifier.act_l2_pipeline_full().await.expect("pipeline step should succeed");
+    let derived = verifier.act_l2_pipeline_full().await;
 
     assert_eq!(derived, 1, "expected exactly one L2 block to be derived");
     assert_eq!(verifier.l2_safe_number(), 1, "safe head should be L2 block 1");
@@ -1937,14 +1838,11 @@ async fn multiple_l2_blocks_derived_from_blob() {
 
     let mut source = ActionL2Source::new();
     for _ in 1..=L2_BLOCK_COUNT {
-        source.push(builder.build_next_block().expect("build block"));
+        source.push(builder.build_next_block());
     }
 
     // Encode all 3 blocks into a single blob channel and mine.
-    Batcher::new(source, &h.rollup_config, batcher_cfg.clone())
-        .advance(&mut h.l1)
-        .await
-        .expect("advance");
+    Batcher::new(source, &h.rollup_config, batcher_cfg.clone()).advance(&mut h.l1).await;
 
     // Create the blob verifier.
     let (mut verifier, _chain) = h.create_blob_verifier_from_sequencer(
@@ -1955,7 +1853,7 @@ async fn multiple_l2_blocks_derived_from_blob() {
 
     verifier.initialize().await;
     verifier.act_l1_head_signal(l1_block_1).await;
-    let derived = verifier.act_l2_pipeline_full().await.expect("pipeline step should succeed");
+    let derived = verifier.act_l2_pipeline_full().await;
 
     assert_eq!(derived, L2_BLOCK_COUNT as usize, "expected 3 L2 blocks to be derived");
     assert_eq!(verifier.l2_safe_number(), L2_BLOCK_COUNT, "safe head should be L2 block 3");
@@ -2001,9 +1899,9 @@ async fn batcher_config_update_rolled_back_on_reorg() {
     // Build L2 blocks 1, 2, 3 upfront from the L1 genesis state.
     let l1_chain = SharedL1Chain::from_blocks(h.l1.chain().to_vec());
     let mut builder = h.create_l2_sequencer(l1_chain);
-    let block1 = builder.build_next_block().expect("build block 1");
-    let block2 = builder.build_next_block().expect("build block 2");
-    let block3 = builder.build_next_block().expect("build block 3");
+    let block1 = builder.build_next_block();
+    let block2 = builder.build_next_block();
+    let block3 = builder.build_next_block();
 
     // Clone blocks for resubmission on the new fork after reorg.
     let block1_clone = block1.clone();
@@ -2013,10 +1911,7 @@ async fn batcher_config_update_rolled_back_on_reorg() {
     for block in [block1, block2] {
         let mut source = ActionL2Source::new();
         source.push(block);
-        Batcher::new(source, &h.rollup_config, batcher_a.clone())
-            .advance(&mut h.l1)
-            .await
-            .expect("batcher A advance");
+        Batcher::new(source, &h.rollup_config, batcher_a.clone()).advance(&mut h.l1).await;
     }
 
     // --- Phase 3: Rotate config (L1 block 3 — config update log only). ---
@@ -2033,28 +1928,25 @@ async fn batcher_config_update_rolled_back_on_reorg() {
     // Drive derivation through L1 blocks 1-2.
     for i in 1u64..=2 {
         verifier.act_l1_head_signal(h.l1.block_info_at(i)).await;
-        verifier.act_l2_pipeline_full().await.expect("step");
+        verifier.act_l2_pipeline_full().await;
     }
     assert_eq!(verifier.l2_safe_number(), 2, "blocks 1-2 derived with batcher A");
 
     // Step over the rotation block — no batch, but system config updates to B.
     verifier.act_l1_head_signal(h.l1.block_info_at(3)).await;
-    let rotation_derived = verifier.act_l2_pipeline_full().await.expect("step rotation block");
+    let rotation_derived = verifier.act_l2_pipeline_full().await;
     assert_eq!(rotation_derived, 0, "rotation block contains no batch");
 
     // --- Phase 4: Verify old batcher is now ignored (L1 block 4). ---
     {
         let mut source = ActionL2Source::new();
         source.push(block3.clone());
-        Batcher::new(source, &h.rollup_config, batcher_a.clone())
-            .advance(&mut h.l1)
-            .await
-            .expect("batcher A advance block 3");
+        Batcher::new(source, &h.rollup_config, batcher_a.clone()).advance(&mut h.l1).await;
     }
     chain.push(h.l1.tip().clone());
 
     verifier.act_l1_head_signal(h.l1.tip_info()).await;
-    let derived_a = verifier.act_l2_pipeline_full().await.expect("step block 4");
+    let derived_a = verifier.act_l2_pipeline_full().await;
     assert_eq!(derived_a, 0, "batcher A frame must be ignored after key rotation");
     assert_eq!(verifier.l2_safe_number(), 2, "safe head must not advance");
 
@@ -2070,7 +1962,7 @@ async fn batcher_config_update_rolled_back_on_reorg() {
 
     verifier.act_reset(l1_genesis, l2_genesis, genesis_sys_cfg).await;
     // Drain the reset origin (genesis has no batch data).
-    verifier.act_l2_pipeline_full().await.expect("drain genesis after reset");
+    verifier.act_l2_pipeline_full().await;
 
     // --- Phase 6: New fork — re-mine blocks 1-2 with batcher A, then block 3'
     //     also with batcher A (no config update log). ---
@@ -2080,17 +1972,14 @@ async fn batcher_config_update_rolled_back_on_reorg() {
     for block in resubmit_blocks {
         let mut source = ActionL2Source::new();
         source.push(block);
-        Batcher::new(source, &h.rollup_config, batcher_a.clone())
-            .advance(&mut h.l1)
-            .await
-            .expect("batcher A advance on new fork");
+        Batcher::new(source, &h.rollup_config, batcher_a.clone()).advance(&mut h.l1).await;
         chain.push(h.l1.tip().clone());
     }
 
     // Drive derivation through L1 blocks 1', 2', 3' on the new fork.
     for i in 1u64..=3 {
         verifier.act_l1_head_signal(h.l1.block_info_at(i)).await;
-        verifier.act_l2_pipeline_full().await.expect("step");
+        verifier.act_l2_pipeline_full().await;
     }
     assert_eq!(
         verifier.l2_safe_number(),
@@ -2128,8 +2017,8 @@ async fn out_of_order_singular_batches_reordered_by_batch_queue() {
     let mut builder = h.create_l2_sequencer(l1_chain);
 
     // Build 2 L2 blocks in epoch 0 (both reference L1 genesis as L1 origin).
-    let block1 = builder.build_next_block().expect("build L2 block 1");
-    let block2 = builder.build_next_block().expect("build L2 block 2");
+    let block1 = builder.build_next_block();
+    let block2 = builder.build_next_block();
 
     let (mut verifier, chain) = h.create_verifier_from_sequencer(
         &builder,
@@ -2140,10 +2029,7 @@ async fn out_of_order_singular_batches_reordered_by_batch_queue() {
     {
         let mut source = ActionL2Source::new();
         source.push(block2);
-        Batcher::new(source, &h.rollup_config, batcher_cfg.clone())
-            .advance(&mut h.l1)
-            .await
-            .expect("submit future batch (block 2)");
+        Batcher::new(source, &h.rollup_config, batcher_cfg.clone()).advance(&mut h.l1).await;
     }
     chain.push(h.l1.tip().clone()); // L1 block 1: future batch
 
@@ -2151,10 +2037,7 @@ async fn out_of_order_singular_batches_reordered_by_batch_queue() {
     {
         let mut source = ActionL2Source::new();
         source.push(block1);
-        Batcher::new(source, &h.rollup_config, batcher_cfg.clone())
-            .advance(&mut h.l1)
-            .await
-            .expect("submit present batch (block 1)");
+        Batcher::new(source, &h.rollup_config, batcher_cfg.clone()).advance(&mut h.l1).await;
     }
     chain.push(h.l1.tip().clone()); // L1 block 2: present batch
 
@@ -2222,7 +2105,7 @@ async fn pipeline_idle_before_l1_signal_derives_after() {
 
     let l1_chain = SharedL1Chain::from_blocks(h.l1.chain().to_vec());
     let mut builder = h.create_l2_sequencer(l1_chain);
-    let block1 = builder.build_next_block().expect("build L2 block 1");
+    let block1 = builder.build_next_block();
 
     let (mut verifier, chain) = h.create_verifier_from_sequencer(
         &builder,
@@ -2231,10 +2114,7 @@ async fn pipeline_idle_before_l1_signal_derives_after() {
     {
         let mut source = ActionL2Source::new();
         source.push(block1);
-        Batcher::new(source, &h.rollup_config, batcher_cfg.clone())
-            .advance(&mut h.l1)
-            .await
-            .expect("encode and submit");
+        Batcher::new(source, &h.rollup_config, batcher_cfg.clone()).advance(&mut h.l1).await;
     }
     chain.push(h.l1.tip().clone());
     verifier.initialize().await;
@@ -2289,8 +2169,8 @@ async fn pipeline_l1_origin_advance_observable_after_epoch_exhausted() {
     let mut builder = h.create_l2_sequencer(l1_chain);
 
     // Build 2 L2 blocks and submit them in a single L1 channel (same L1 block).
-    let block1 = builder.build_next_block().expect("build L2 block 1");
-    let block2 = builder.build_next_block().expect("build L2 block 2");
+    let block1 = builder.build_next_block();
+    let block2 = builder.build_next_block();
 
     let (mut verifier, chain) = h.create_verifier_from_sequencer(
         &builder,
@@ -2301,10 +2181,7 @@ async fn pipeline_l1_origin_advance_observable_after_epoch_exhausted() {
         let mut source = ActionL2Source::new();
         source.push(block1);
         source.push(block2);
-        Batcher::new(source, &h.rollup_config, batcher_cfg.clone())
-            .advance(&mut h.l1)
-            .await
-            .expect("encode and submit both blocks");
+        Batcher::new(source, &h.rollup_config, batcher_cfg.clone()).advance(&mut h.l1).await;
     }
     chain.push(h.l1.tip().clone()); // L1 block 1: carries the channel for blocks 1 & 2
     h.mine_and_push(&chain); // L1 block 2: empty — used only for origin advance
@@ -2383,7 +2260,7 @@ async fn span_batch_crossing_l1_epoch_boundary() {
     // Blocks 1–5 (ts=2..10) reference epoch 0; block 6 (ts=12) references epoch 1.
     let mut source = ActionL2Source::new();
     for _ in 1..=6u64 {
-        source.push(builder.build_next_block().expect("build L2 block"));
+        source.push(builder.build_next_block());
     }
     assert_eq!(builder.head().l1_origin.number, 1, "block 6 must reference epoch 1");
 
@@ -2393,23 +2270,20 @@ async fn span_batch_crossing_l1_epoch_boundary() {
     );
 
     // Encode all 6 blocks as a single span batch and submit in L1 block 2.
-    Batcher::new(source, &h.rollup_config, batcher_cfg)
-        .advance(&mut h.l1)
-        .await
-        .expect("encode multi-epoch span batch");
+    Batcher::new(source, &h.rollup_config, batcher_cfg).advance(&mut h.l1).await;
     chain.push(h.l1.tip().clone()); // L1 block 2: span batch for all 6 L2 blocks
 
     verifier.initialize().await;
 
     // L1 block 1: epoch-providing only, no batches → nothing derived.
     verifier.act_l1_head_signal(h.l1.block_info_at(1)).await;
-    verifier.act_l2_pipeline_full().await.expect("pipeline block 1");
+    verifier.act_l2_pipeline_full().await;
 
     // L1 block 2: contains the span batch. The BatchQueue has both epoch 0
     // (L1 block 0→1) and epoch 1 (L1 block 1→2) boundaries available, so
     // it emits all 6 L2 blocks in one pipeline run.
     verifier.act_l1_head_signal(h.l1.block_info_at(2)).await;
-    let derived = verifier.act_l2_pipeline_full().await.expect("pipeline block 2");
+    let derived = verifier.act_l2_pipeline_full().await;
 
     assert_eq!(
         derived, 6,
@@ -2448,8 +2322,8 @@ async fn out_of_order_span_batches_reordered_by_batch_queue() {
     let l1_chain = SharedL1Chain::from_blocks(h.l1.chain().to_vec());
     let mut builder = h.create_l2_sequencer(l1_chain);
 
-    let block1 = builder.build_next_block().expect("build L2 block 1");
-    let block2 = builder.build_next_block().expect("build L2 block 2");
+    let block1 = builder.build_next_block();
+    let block2 = builder.build_next_block();
 
     let (mut verifier, chain) = h.create_verifier_from_sequencer(
         &builder,
@@ -2460,10 +2334,7 @@ async fn out_of_order_span_batches_reordered_by_batch_queue() {
     {
         let mut source = ActionL2Source::new();
         source.push(block2);
-        Batcher::new(source, &h.rollup_config, span_cfg.clone())
-            .advance(&mut h.l1)
-            .await
-            .expect("encode future span batch");
+        Batcher::new(source, &h.rollup_config, span_cfg.clone()).advance(&mut h.l1).await;
     }
     chain.push(h.l1.tip().clone()); // L1 block 1: future span batch
 
@@ -2471,10 +2342,7 @@ async fn out_of_order_span_batches_reordered_by_batch_queue() {
     {
         let mut source = ActionL2Source::new();
         source.push(block1);
-        Batcher::new(source, &h.rollup_config, span_cfg)
-            .advance(&mut h.l1)
-            .await
-            .expect("encode present span batch");
+        Batcher::new(source, &h.rollup_config, span_cfg).advance(&mut h.l1).await;
     }
     chain.push(h.l1.tip().clone()); // L1 block 2: present span batch
 
@@ -2541,8 +2409,8 @@ async fn large_l1_gaps_within_sequence_window() {
     let mut builder = h.create_l2_sequencer(l1_chain);
 
     // Build 2 L2 blocks in epoch 0 (both reference L1 genesis as their origin).
-    let block1 = builder.build_next_block().expect("build block 1");
-    let block2 = builder.build_next_block().expect("build block 2");
+    let block1 = builder.build_next_block();
+    let block2 = builder.build_next_block();
 
     let (mut verifier, chain) = h.create_verifier_from_sequencer(
         &builder,
@@ -2558,10 +2426,7 @@ async fn large_l1_gaps_within_sequence_window() {
     let mut source = ActionL2Source::new();
     source.push(block1);
     source.push(block2);
-    Batcher::new(source, &h.rollup_config, batcher_cfg)
-        .advance(&mut h.l1)
-        .await
-        .expect("encode batches");
+    Batcher::new(source, &h.rollup_config, batcher_cfg).advance(&mut h.l1).await;
     chain.push(h.l1.tip().clone()); // L1 block 16: batches for L2 blocks 1 and 2
 
     verifier.initialize().await;
@@ -2570,7 +2435,7 @@ async fn large_l1_gaps_within_sequence_window() {
     // empty blocks before finding the channel in block 16.
     for i in 1..=16u64 {
         verifier.act_l1_head_signal(h.l1.block_info_at(i)).await;
-        verifier.act_l2_pipeline_full().await.expect("pipeline");
+        verifier.act_l2_pipeline_full().await;
     }
 
     assert_eq!(
@@ -2621,7 +2486,7 @@ async fn extended_sequence_window_exhaustion_fills_with_deposit_only_blocks() {
     let mut total_derived = 0;
     for i in 1..=20u64 {
         verifier.act_l1_head_signal(h.l1.block_info_at(i)).await;
-        total_derived += verifier.act_l2_pipeline_full().await.expect("pipeline");
+        total_derived += verifier.act_l2_pipeline_full().await;
     }
 
     // With no batches, the pipeline generates deposit-only blocks for each

--- a/actions/harness/tests/ecotone_activation.rs
+++ b/actions/harness/tests/ecotone_activation.rs
@@ -57,7 +57,7 @@ fn ecotone_l1_info_format_transitions_at_activation() {
     let mut builder = h.create_l2_sequencer(l1_chain);
 
     // Block 1: ts=2 — pre-Ecotone. Expect Bedrock format.
-    let block1 = builder.build_next_block().expect("build block 1");
+    let block1 = builder.build_next_block();
     let info1 = l1_info_from_block(&block1);
     assert!(
         matches!(info1, L1BlockInfoTx::Bedrock(_)),
@@ -65,7 +65,7 @@ fn ecotone_l1_info_format_transitions_at_activation() {
     );
 
     // Block 2: ts=4 — still pre-Ecotone. Expect Bedrock format.
-    let block2 = builder.build_next_block().expect("build block 2");
+    let block2 = builder.build_next_block();
     let info2 = l1_info_from_block(&block2);
     assert!(
         matches!(info2, L1BlockInfoTx::Bedrock(_)),
@@ -75,7 +75,7 @@ fn ecotone_l1_info_format_transitions_at_activation() {
     // Block 3: ts=6 — FIRST Ecotone block. Protocol rule: L1Block contract
     // upgrade tx is appended AFTER the L1 info deposit, so the contract is
     // still on the Bedrock ABI. The sequencer sends a Bedrock-format L1 info tx.
-    let block3 = builder.build_empty_block().expect("build empty block 3 (first Ecotone)");
+    let block3 = builder.build_empty_block();
     assert_eq!(block3.header.timestamp, ecotone_time, "block 3 must be at ecotone_time");
     let info3 = l1_info_from_block(&block3);
     assert!(
@@ -85,7 +85,7 @@ fn ecotone_l1_info_format_transitions_at_activation() {
 
     // Block 4: ts=8 — second Ecotone block. L1Block contract now upgraded.
     // Sequencer sends Ecotone-format L1 info tx.
-    let block4 = builder.build_next_block().expect("build block 4 (post-Ecotone)");
+    let block4 = builder.build_next_block();
     let info4 = l1_info_from_block(&block4);
     assert!(
         matches!(info4, L1BlockInfoTx::Ecotone(_)),
@@ -142,19 +142,16 @@ async fn ecotone_activation_block_user_txs_accepted_at_batch_layer() {
 
     // Blocks 1 and 2: pre-Ecotone, user txs OK.
     for _ in 1..=2u64 {
-        let block = builder.build_next_block().expect("build pre-Ecotone block");
+        let block = builder.build_next_block();
         let mut source = ActionL2Source::new();
         source.push(block);
-        Batcher::new(source, &h.rollup_config, batcher_cfg.clone())
-            .advance(&mut h.l1)
-            .await
-            .expect("advance pre-Ecotone batch");
+        Batcher::new(source, &h.rollup_config, batcher_cfg.clone()).advance(&mut h.l1).await;
     }
 
     // Block 3 at ts=6 (first Ecotone): build WITH a user tx. Unlike Jovian,
     // Ecotone has no NonEmptyTransitionBlock batch check, so this batch is
     // accepted and block 3 is NOT deposit-only.
-    let block3_with_user_tx = builder.build_next_block().expect("build block 3 with user tx");
+    let block3_with_user_tx = builder.build_next_block();
     assert_eq!(
         block3_with_user_tx.header.timestamp, ecotone_time,
         "block 3 must land exactly at ecotone_time"
@@ -162,19 +159,13 @@ async fn ecotone_activation_block_user_txs_accepted_at_batch_layer() {
 
     let mut source3 = ActionL2Source::new();
     source3.push(block3_with_user_tx);
-    Batcher::new(source3, &h.rollup_config, batcher_cfg.clone())
-        .advance(&mut h.l1)
-        .await
-        .expect("advance block 3 batch");
+    Batcher::new(source3, &h.rollup_config, batcher_cfg.clone()).advance(&mut h.l1).await;
 
     // Block 4: post-Ecotone, user txs OK.
-    let block4 = builder.build_next_block().expect("build post-Ecotone block 4");
+    let block4 = builder.build_next_block();
     let mut source4 = ActionL2Source::new();
     source4.push(block4);
-    Batcher::new(source4, &h.rollup_config, batcher_cfg)
-        .advance(&mut h.l1)
-        .await
-        .expect("advance block 4 batch");
+    Batcher::new(source4, &h.rollup_config, batcher_cfg).advance(&mut h.l1).await;
 
     let (mut verifier, _chain) = h.create_verifier_from_sequencer(
         &builder,
@@ -185,7 +176,7 @@ async fn ecotone_activation_block_user_txs_accepted_at_batch_layer() {
     // Drive derivation through all 4 L1 blocks.
     for i in 1..=4u64 {
         verifier.act_l1_head_signal(h.l1.block_info_at(i)).await;
-        verifier.act_l2_pipeline_full().await.expect("pipeline");
+        verifier.act_l2_pipeline_full().await;
     }
 
     // Ecotone has no NonEmptyTransitionBlock batch check, so block 3's batch
@@ -247,17 +238,14 @@ async fn ecotone_derivation_crosses_activation_boundary() {
         let block = if i == 3 {
             // First Ecotone block: must be deposit-only (no user txs) because
             // the pipeline prepends the Ecotone upgrade transactions here.
-            builder.build_empty_block().expect("build empty first-Ecotone block")
+            builder.build_empty_block()
         } else {
-            builder.build_next_block().expect("build L2 block with user tx")
+            builder.build_next_block()
         };
 
         let mut source = ActionL2Source::new();
         source.push(block);
-        Batcher::new(source, &h.rollup_config, batcher_cfg.clone())
-            .advance(&mut h.l1)
-            .await
-            .expect("advance batch");
+        Batcher::new(source, &h.rollup_config, batcher_cfg.clone()).advance(&mut h.l1).await;
     }
 
     let (mut verifier, _chain) = h.create_verifier_from_sequencer(
@@ -268,7 +256,7 @@ async fn ecotone_derivation_crosses_activation_boundary() {
 
     for i in 1..=4u64 {
         verifier.act_l1_head_signal(h.l1.block_info_at(i)).await;
-        let derived = verifier.act_l2_pipeline_full().await.expect("pipeline");
+        let derived = verifier.act_l2_pipeline_full().await;
         assert_eq!(derived, 1, "L1 block {i} should derive exactly one L2 block");
     }
 

--- a/actions/harness/tests/finalization.rs
+++ b/actions/harness/tests/finalization.rs
@@ -24,7 +24,7 @@ async fn finalization_advances_with_multiple_l2_blocks_per_epoch() {
 
     let mut blocks = Vec::new();
     for _ in 0..3 {
-        let block = sequencer.build_next_block().expect("build L2 block");
+        let block = sequencer.build_next_block();
         blocks.push(block);
     }
     // All blocks should reference epoch 0.
@@ -35,7 +35,7 @@ async fn finalization_advances_with_multiple_l2_blocks_per_epoch() {
         let mut source = ActionL2Source::new();
         source.push(block);
         let mut batcher = Batcher::new(source, &h.rollup_config, batcher_cfg.clone());
-        batcher.advance(&mut h.l1).await.expect("advance");
+        batcher.advance(&mut h.l1).await;
     }
 
     // Create verifier after mining so it observes the hashes the sequencer already registered.
@@ -51,7 +51,7 @@ async fn finalization_advances_with_multiple_l2_blocks_per_epoch() {
     // Derive all 3 L2 blocks.
     for i in 1..=3u64 {
         verifier.act_l1_head_signal(h.l1.block_info_at(i)).await;
-        verifier.act_l2_pipeline_full().await.expect("step");
+        verifier.act_l2_pipeline_full().await;
     }
     assert_eq!(verifier.l2_safe_number(), 3, "safe head should reach L2 block 3");
 
@@ -97,7 +97,7 @@ async fn finalization_advances_incrementally_with_l1_epochs() {
     let mut blocks = Vec::new();
     let mut last_epoch_0_number = 0u64;
     for i in 1..=6u64 {
-        let block = sequencer.build_next_block().expect("build L2 block");
+        let block = sequencer.build_next_block();
         let head = sequencer.head();
         blocks.push(block);
         if head.l1_origin.number == 0 {
@@ -116,7 +116,7 @@ async fn finalization_advances_incrementally_with_l1_epochs() {
         let mut source = ActionL2Source::new();
         source.push(block);
         let mut batcher = Batcher::new(source, &h.rollup_config, batcher_cfg.clone());
-        batcher.advance(&mut h.l1).await.expect("advance");
+        batcher.advance(&mut h.l1).await;
         chain.push(h.l1.tip().clone());
     }
 
@@ -126,7 +126,7 @@ async fn finalization_advances_incrementally_with_l1_epochs() {
     // blocks 2-7 contain batches.
     for i in 1..=(1 + 6) {
         verifier.act_l1_head_signal(h.l1.block_info_at(i)).await;
-        verifier.act_l2_pipeline_full().await.expect("step");
+        verifier.act_l2_pipeline_full().await;
     }
     assert_eq!(verifier.l2_safe_number(), 6, "safe head should reach L2 block 6");
 
@@ -170,15 +170,15 @@ async fn finalization_does_not_exceed_safe_head() {
     let l1_chain = SharedL1Chain::from_blocks(h.l1.chain().to_vec());
     let mut sequencer = h.create_l2_sequencer(l1_chain);
 
-    let block1 = sequencer.build_next_block().expect("build block 1");
-    let block2 = sequencer.build_next_block().expect("build block 2");
+    let block1 = sequencer.build_next_block();
+    let block2 = sequencer.build_next_block();
 
     // Submit each block via the batcher.
     for block in [block1, block2] {
         let mut source = ActionL2Source::new();
         source.push(block);
         let mut batcher = Batcher::new(source, &h.rollup_config, batcher_cfg.clone());
-        batcher.advance(&mut h.l1).await.expect("advance");
+        batcher.advance(&mut h.l1).await;
     }
 
     // Mine many more L1 blocks without any corresponding L2 derivation data.
@@ -193,7 +193,7 @@ async fn finalization_does_not_exceed_safe_head() {
     // Derive only 2 L2 blocks.
     for i in 1..=2u64 {
         verifier.act_l1_head_signal(h.l1.block_info_at(i)).await;
-        verifier.act_l2_pipeline_full().await.expect("step");
+        verifier.act_l2_pipeline_full().await;
     }
     assert_eq!(verifier.l2_safe_number(), 2, "safe head should be 2");
 
@@ -233,15 +233,15 @@ async fn finalization_reorg_clears_state() {
     let l1_chain = SharedL1Chain::from_blocks(h.l1.chain().to_vec());
     let mut sequencer = h.create_l2_sequencer(l1_chain);
 
-    let block1 = sequencer.build_next_block().expect("build block 1");
-    let block2 = sequencer.build_next_block().expect("build block 2");
+    let block1 = sequencer.build_next_block();
+    let block2 = sequencer.build_next_block();
 
     // Submit and mine.
     for block in [block1, block2] {
         let mut source = ActionL2Source::new();
         source.push(block);
         let mut batcher = Batcher::new(source, &h.rollup_config, batcher_cfg.clone());
-        batcher.advance(&mut h.l1).await.expect("advance");
+        batcher.advance(&mut h.l1).await;
     }
 
     let (mut verifier, chain) = h.create_verifier_from_sequencer(
@@ -253,7 +253,7 @@ async fn finalization_reorg_clears_state() {
     // Derive both L2 blocks.
     for i in 1..=2u64 {
         verifier.act_l1_head_signal(h.l1.block_info_at(i)).await;
-        verifier.act_l2_pipeline_full().await.expect("step");
+        verifier.act_l2_pipeline_full().await;
     }
     assert_eq!(verifier.l2_safe_number(), 2);
 
@@ -268,7 +268,7 @@ async fn finalization_reorg_clears_state() {
     let genesis_sys_cfg = rollup_cfg.genesis.system_config.unwrap_or_default();
 
     verifier.act_reset(l1_genesis, l2_genesis, genesis_sys_cfg).await;
-    verifier.act_l2_pipeline_full().await.expect("drain genesis after reset");
+    verifier.act_l2_pipeline_full().await;
 
     // After reset, finalized head should be back to genesis (block 0).
     assert_eq!(
@@ -284,7 +284,7 @@ async fn finalization_reorg_clears_state() {
     // Build a new L2 block on the fresh fork.
     let l1_chain_fresh = SharedL1Chain::from_blocks(h.l1.chain().to_vec());
     let mut sequencer_fresh = h.create_l2_sequencer(l1_chain_fresh);
-    let block1_fresh = sequencer_fresh.build_next_block().expect("build fresh block 1");
+    let block1_fresh = sequencer_fresh.build_next_block();
 
     // Register the block hash before mining so the verifier can validate it.
     verifier.register_block_hash(1, block1_fresh.header.hash_slow());
@@ -292,7 +292,7 @@ async fn finalization_reorg_clears_state() {
     let mut source = ActionL2Source::new();
     source.push(block1_fresh);
     let mut batcher = Batcher::new(source, &h.rollup_config, batcher_cfg.clone());
-    batcher.advance(&mut h.l1).await.expect("advance after reorg");
+    batcher.advance(&mut h.l1).await;
 
     // Push the new block to the shared chain.
     chain.truncate_to(0);
@@ -300,7 +300,7 @@ async fn finalization_reorg_clears_state() {
 
     let l1_block_1_new = h.l1.block_info_at(1);
     verifier.act_l1_head_signal(l1_block_1_new).await;
-    verifier.act_l2_pipeline_full().await.expect("derive after reset");
+    verifier.act_l2_pipeline_full().await;
 
     assert_eq!(verifier.l2_safe_number(), 1, "safe head re-derived to 1");
 
@@ -333,7 +333,7 @@ async fn finalization_does_not_regress() {
 
     let mut blocks = Vec::new();
     for _ in 0..6 {
-        let block = sequencer.build_next_block().expect("build L2 block");
+        let block = sequencer.build_next_block();
         blocks.push(block);
     }
 
@@ -347,7 +347,7 @@ async fn finalization_does_not_regress() {
         let mut source = ActionL2Source::new();
         source.push(block);
         let mut batcher = Batcher::new(source, &h.rollup_config, batcher_cfg.clone());
-        batcher.advance(&mut h.l1).await.expect("advance");
+        batcher.advance(&mut h.l1).await;
         chain.push(h.l1.tip().clone());
     }
 
@@ -356,7 +356,7 @@ async fn finalization_does_not_regress() {
     // Derive all L2 blocks. L1 block 1 is epoch-providing, blocks 2-7 have batches.
     for i in 1..=(1 + 6) {
         verifier.act_l1_head_signal(h.l1.block_info_at(i)).await;
-        verifier.act_l2_pipeline_full().await.expect("step");
+        verifier.act_l2_pipeline_full().await;
     }
     assert_eq!(verifier.l2_safe_number(), 6, "safe head should be 6");
 

--- a/actions/harness/tests/hardfork_activation.rs
+++ b/actions/harness/tests/hardfork_activation.rs
@@ -274,10 +274,10 @@ async fn span_batch_rejected_before_delta() {
 
     // Both blocks in one source, one advance produces a span batch.
     let mut source = ActionL2Source::new();
-    source.push(builder.build_next_block().expect("build L2 block 1"));
-    source.push(builder.build_next_block().expect("build L2 block 2"));
+    source.push(builder.build_next_block());
+    source.push(builder.build_next_block());
     let mut batcher = Batcher::new(source, &h.rollup_config, span_cfg);
-    batcher.advance(&mut h.l1).await.expect("advance");
+    batcher.advance(&mut h.l1).await;
 
     let (mut verifier, _chain) = h.create_verifier_from_sequencer(
         &builder,
@@ -285,7 +285,7 @@ async fn span_batch_rejected_before_delta() {
     );
     verifier.initialize().await;
     verifier.act_l1_head_signal(h.l1.tip_info()).await;
-    verifier.act_l2_pipeline_full().await.expect("pipeline");
+    verifier.act_l2_pipeline_full().await;
 
     assert_eq!(
         verifier.l2_safe_number(),
@@ -318,10 +318,10 @@ async fn span_batch_derives_after_delta() {
 
     // Both blocks in one source → one span batch in one L1 block.
     let mut source = ActionL2Source::new();
-    source.push(builder.build_next_block().expect("build L2 block 1"));
-    source.push(builder.build_next_block().expect("build L2 block 2"));
+    source.push(builder.build_next_block());
+    source.push(builder.build_next_block());
     let mut batcher = Batcher::new(source, &h.rollup_config, span_cfg);
-    batcher.advance(&mut h.l1).await.expect("advance");
+    batcher.advance(&mut h.l1).await;
 
     let (mut verifier, _chain) = h.create_verifier_from_sequencer(
         &builder,
@@ -329,7 +329,7 @@ async fn span_batch_derives_after_delta() {
     );
     verifier.initialize().await;
     verifier.act_l1_head_signal(h.l1.tip_info()).await;
-    let derived = verifier.act_l2_pipeline_full().await.expect("pipeline");
+    let derived = verifier.act_l2_pipeline_full().await;
 
     assert_eq!(derived, 2, "expected 2 L2 blocks derived from span batch");
     assert_eq!(verifier.l2_safe_number(), 2, "safe head should advance to block 2");
@@ -353,9 +353,9 @@ async fn single_batch_derives_with_fjord() {
 
     for _ in 0..2 {
         let mut source = ActionL2Source::new();
-        source.push(builder.build_next_block().expect("build L2 block"));
+        source.push(builder.build_next_block());
         let mut batcher = Batcher::new(source, &h.rollup_config, batcher_cfg.clone());
-        batcher.advance(&mut h.l1).await.expect("advance");
+        batcher.advance(&mut h.l1).await;
     }
 
     let (mut verifier, _chain) = h.create_verifier_from_sequencer(
@@ -366,7 +366,7 @@ async fn single_batch_derives_with_fjord() {
 
     for i in 1..=2u64 {
         verifier.act_l1_head_signal(h.l1.block_info_at(i)).await;
-        let derived = verifier.act_l2_pipeline_full().await.expect("pipeline");
+        let derived = verifier.act_l2_pipeline_full().await;
         assert_eq!(derived, 1, "L1 block {i} should derive exactly one L2 block");
     }
 
@@ -413,15 +413,15 @@ async fn jovian_derivation_crosses_activation_boundary() {
     for i in 1..=4u64 {
         let block = if i == 3 {
             // First Jovian block: must contain no user transactions.
-            builder.build_empty_block().expect("build empty Jovian transition block")
+            builder.build_empty_block()
         } else {
-            builder.build_next_block().expect("build L2 block")
+            builder.build_next_block()
         };
 
         let mut source = ActionL2Source::new();
         source.push(block);
         let mut batcher = Batcher::new(source, &h.rollup_config, batcher_cfg.clone());
-        batcher.advance(&mut h.l1).await.expect("advance");
+        batcher.advance(&mut h.l1).await;
     }
 
     let (mut verifier, _chain) = h.create_verifier_from_sequencer(
@@ -432,7 +432,7 @@ async fn jovian_derivation_crosses_activation_boundary() {
 
     for i in 1..=4u64 {
         verifier.act_l1_head_signal(h.l1.block_info_at(i)).await;
-        let derived = verifier.act_l2_pipeline_full().await.expect("pipeline");
+        let derived = verifier.act_l2_pipeline_full().await;
         assert_eq!(derived, 1, "L1 block {i} should derive exactly one L2 block");
     }
 

--- a/actions/harness/tests/holocene_activation.rs
+++ b/actions/harness/tests/holocene_activation.rs
@@ -63,13 +63,10 @@ async fn holocene_derivation_crosses_activation_boundary() {
     // Build and submit 4 L2 blocks; no upgrade-tx constraint at Holocene,
     // so user txs are valid in all blocks including block 3.
     for _ in 1..=4u64 {
-        let block = builder.build_next_block().expect("build L2 block");
+        let block = builder.build_next_block();
         let mut source = ActionL2Source::new();
         source.push(block);
-        Batcher::new(source, &h.rollup_config, batcher_cfg.clone())
-            .advance(&mut h.l1)
-            .await
-            .expect("encode batch");
+        Batcher::new(source, &h.rollup_config, batcher_cfg.clone()).advance(&mut h.l1).await;
         chain.push(h.l1.tip().clone());
     }
 
@@ -77,7 +74,7 @@ async fn holocene_derivation_crosses_activation_boundary() {
 
     for i in 1..=4u64 {
         verifier.act_l1_head_signal(h.l1.block_info_at(i)).await;
-        let derived = verifier.act_l2_pipeline_full().await.expect("pipeline");
+        let derived = verifier.act_l2_pipeline_full().await;
         assert_eq!(derived, 1, "L1 block {i} should derive exactly one L2 block at/after Holocene");
     }
 
@@ -137,13 +134,13 @@ async fn holocene_non_sequential_frame_pruned_channel_never_completes() {
 
     let l1_chain = SharedL1Chain::from_blocks(h.l1.chain().to_vec());
     let mut sequencer = h.create_l2_sequencer(l1_chain);
-    let block = sequencer.build_next_block().expect("build L2 block 1");
+    let block = sequencer.build_next_block();
 
     // Encode the block into frames without mining.
     let mut source = ActionL2Source::new();
     source.push(block);
     let mut batcher = Batcher::new(source, &h.rollup_config, batcher_cfg.clone());
-    batcher.encode_only().await.expect("encode multi-frame channel");
+    batcher.encode_only().await;
     let frame_count = batcher.pending_count();
     assert!(
         frame_count >= 3,
@@ -167,7 +164,7 @@ async fn holocene_non_sequential_frame_pruned_channel_never_completes() {
 
     verifier.initialize().await;
     verifier.act_l1_head_signal(h.l1.block_info_at(1)).await;
-    verifier.act_l2_pipeline_full().await.expect("pipeline block 1");
+    verifier.act_l2_pipeline_full().await;
 
     // Frame 2 is pruned by FrameQueue — channel 0 only has frame 0.
     // Channel is incomplete; safe head stays at genesis.
@@ -184,7 +181,7 @@ async fn holocene_non_sequential_frame_pruned_channel_never_completes() {
     }
     for i in 2..=h.l1.latest_number() {
         verifier.act_l1_head_signal(h.l1.block_info_at(i)).await;
-        verifier.act_l2_pipeline_full().await.expect("pipeline");
+        verifier.act_l2_pipeline_full().await;
     }
 
     assert_eq!(
@@ -246,20 +243,20 @@ async fn holocene_new_channel_abandons_incomplete_old_channel() {
     let l1_chain = SharedL1Chain::from_blocks(h.l1.chain().to_vec());
     let mut sequencer = h.create_l2_sequencer(l1_chain);
 
-    let block_a = sequencer.build_next_block().expect("build L2 block A");
-    let block_b = sequencer.build_next_block().expect("build L2 block B");
+    let block_a = sequencer.build_next_block();
+    let block_b = sequencer.build_next_block();
 
     // Encode channel A (block A) and channel B (block B) separately.
     // Each Batcher instance generates a distinct random channel ID.
     let mut source_a = ActionL2Source::new();
     source_a.push(block_a);
     let mut batcher_a = Batcher::new(source_a, &h.rollup_config, batcher_cfg.clone());
-    batcher_a.encode_only().await.expect("encode channel A");
+    batcher_a.encode_only().await;
 
     let mut source_b = ActionL2Source::new();
     source_b.push(block_b);
     let mut batcher_b = Batcher::new(source_b, &h.rollup_config, batcher_cfg.clone());
-    batcher_b.encode_only().await.expect("encode channel B");
+    batcher_b.encode_only().await;
 
     let n_a = batcher_a.pending_count();
     let n_b = batcher_b.pending_count();
@@ -278,7 +275,7 @@ async fn holocene_new_channel_abandons_incomplete_old_channel() {
 
     verifier.initialize().await;
     verifier.act_l1_head_signal(h.l1.block_info_at(1)).await;
-    verifier.act_l2_pipeline_full().await.expect("pipeline block 1");
+    verifier.act_l2_pipeline_full().await;
 
     // Channel A is open but incomplete — safe head stays at genesis.
     assert_eq!(
@@ -299,7 +296,7 @@ async fn holocene_new_channel_abandons_incomplete_old_channel() {
     chain.push(h.l1.tip().clone()); // L1 block 2: all frames of channel B
 
     verifier.act_l1_head_signal(h.l1.block_info_at(2)).await;
-    verifier.act_l2_pipeline_full().await.expect("pipeline block 2");
+    verifier.act_l2_pipeline_full().await;
 
     // Channel A was abandoned (Holocene pruning). Channel B derived block B.
     // Block A was never derived since channel A was discarded.
@@ -360,13 +357,13 @@ async fn holocene_non_sequential_frame_pruned_then_recovery_succeeds() {
 
     let l1_chain = SharedL1Chain::from_blocks(h.l1.chain().to_vec());
     let mut sequencer = h.create_l2_sequencer(l1_chain);
-    let block = sequencer.build_next_block().expect("build L2 block 1");
+    let block = sequencer.build_next_block();
 
     // Encode the block into frames without mining.
     let mut source = ActionL2Source::new();
     source.push(block.clone());
     let mut batcher = Batcher::new(source, &h.rollup_config, batcher_cfg.clone());
-    batcher.encode_only().await.expect("encode multi-frame channel");
+    batcher.encode_only().await;
     let frame_count = batcher.pending_count();
     assert!(frame_count >= 3, "need ≥3 frames to skip frame 1; got {frame_count}");
 
@@ -385,7 +382,7 @@ async fn holocene_non_sequential_frame_pruned_then_recovery_succeeds() {
 
     verifier.initialize().await;
     verifier.act_l1_head_signal(h.l1.block_info_at(1)).await;
-    verifier.act_l2_pipeline_full().await.expect("pipeline block 1");
+    verifier.act_l2_pipeline_full().await;
 
     // Channel is broken — safe head stays at genesis.
     assert_eq!(
@@ -406,7 +403,7 @@ async fn holocene_non_sequential_frame_pruned_then_recovery_succeeds() {
     }
     for i in 2..=h.l1.latest_number() {
         verifier.act_l1_head_signal(h.l1.block_info_at(i)).await;
-        verifier.act_l2_pipeline_full().await.expect("pipeline");
+        verifier.act_l2_pipeline_full().await;
     }
     assert_eq!(
         verifier.l2_safe_number(),
@@ -421,12 +418,12 @@ async fn holocene_non_sequential_frame_pruned_then_recovery_succeeds() {
     let mut recovery_source = ActionL2Source::new();
     recovery_source.push(block);
     let mut batcher2 = Batcher::new(recovery_source, &h.rollup_config, batcher_cfg.clone());
-    batcher2.advance(&mut h.l1).await.expect("recovery batch");
+    batcher2.advance(&mut h.l1).await;
     chain.push(h.l1.tip().clone());
 
     let recovery_block_num = h.l1.latest_number();
     verifier.act_l1_head_signal(h.l1.block_info_at(recovery_block_num)).await;
-    verifier.act_l2_pipeline_full().await.expect("pipeline recovery block");
+    verifier.act_l2_pipeline_full().await;
 
     assert_eq!(
         verifier.l2_safe_number(),

--- a/actions/harness/tests/operator_fees.rs
+++ b/actions/harness/tests/operator_fees.rs
@@ -56,7 +56,7 @@ fn operator_fee_not_encoded_before_isthmus() {
     let mut builder = h.create_l2_sequencer(l1_chain);
 
     // Build one block and verify it uses the Ecotone format with zero operator fees.
-    let block = builder.build_next_block().expect("build block");
+    let block = builder.build_next_block();
     let l1_info = l1_info_from_block(&block);
 
     assert!(
@@ -98,7 +98,7 @@ fn operator_fee_encoded_in_l1_info_post_isthmus() {
     let mut builder = h.create_l2_sequencer(l1_chain);
 
     // Build one block and verify it uses the Isthmus format with the configured fee params.
-    let block = builder.build_next_block().expect("build block");
+    let block = builder.build_next_block();
     let l1_info = l1_info_from_block(&block);
 
     assert!(
@@ -155,7 +155,7 @@ fn l1_info_format_transitions_at_isthmus_boundary() {
 
     // Stage 1: Blocks 1-2 (ts=2, 4) — pre-Isthmus → Ecotone format, zero operator fees.
     for i in 1u64..=2 {
-        let block = builder.build_next_block().expect("build pre-Isthmus block");
+        let block = builder.build_next_block();
         let l1_info = l1_info_from_block(&block);
 
         assert!(
@@ -172,7 +172,7 @@ fn l1_info_format_transitions_at_isthmus_boundary() {
     // the upgrade deposit transactions land in the same block to upgrade the
     // L1Block contract, enabling the Isthmus format from block 4 onwards.
     {
-        let block = builder.build_next_block().expect("build first Isthmus block");
+        let block = builder.build_next_block();
         let l1_info = l1_info_from_block(&block);
 
         assert!(
@@ -193,7 +193,7 @@ fn l1_info_format_transitions_at_isthmus_boundary() {
 
     // Stage 3: Block 4 (ts=8) — second Isthmus block, Isthmus format, fees active.
     {
-        let block = builder.build_next_block().expect("build second Isthmus block");
+        let block = builder.build_next_block();
         let l1_info = l1_info_from_block(&block);
 
         assert!(
@@ -256,7 +256,7 @@ fn l1_info_format_transitions_at_jovian_boundary() {
 
     // Stage 1: Blocks 1-2 (ts=2, 4) — Isthmus active, Jovian not yet → Isthmus format.
     for i in 1u64..=2 {
-        let block = builder.build_next_block().expect("build pre-Jovian block");
+        let block = builder.build_next_block();
         let l1_info = l1_info_from_block(&block);
 
         assert!(
@@ -272,7 +272,7 @@ fn l1_info_format_transitions_at_jovian_boundary() {
     // branch and falls through to the Isthmus branch. The block must be empty
     // because the batch validator enforces `NonEmptyTransitionBlock` for Jovian.
     {
-        let block = builder.build_empty_block().expect("build empty first Jovian block");
+        let block = builder.build_empty_block();
         let l1_info = l1_info_from_block(&block);
 
         assert!(
@@ -287,7 +287,7 @@ fn l1_info_format_transitions_at_jovian_boundary() {
     // The operator fee scalar and constant are unchanged; only the EVM formula
     // differs (gas * scalar * 100 vs gas * scalar / 1_000_000 for Isthmus).
     {
-        let block = builder.build_next_block().expect("build second Jovian block");
+        let block = builder.build_next_block();
         let l1_info = l1_info_from_block(&block);
 
         assert!(
@@ -364,9 +364,9 @@ async fn isthmus_derivation_crosses_operator_fee_boundary() {
     for _ in 0..4u64 {
         // All blocks carry user transactions — Isthmus allows user txs at transition.
         let mut source = ActionL2Source::new();
-        source.push(builder.build_next_block().expect("build L2 block"));
+        source.push(builder.build_next_block());
         let mut batcher = Batcher::new(source, &h.rollup_config, batcher_cfg.clone());
-        batcher.advance(&mut h.l1).await.expect("advance");
+        batcher.advance(&mut h.l1).await;
     }
 
     let (mut verifier, _chain) = h.create_verifier_from_sequencer(
@@ -377,7 +377,7 @@ async fn isthmus_derivation_crosses_operator_fee_boundary() {
 
     for i in 1..=4u64 {
         verifier.act_l1_head_signal(h.l1.block_info_at(i)).await;
-        let derived = verifier.act_l2_pipeline_full().await.expect("pipeline");
+        let derived = verifier.act_l2_pipeline_full().await;
         assert_eq!(derived, 1, "L1 block {i} must derive exactly one L2 block");
     }
 
@@ -441,9 +441,9 @@ async fn jovian_non_empty_transition_batch_generates_deposit_only_block() {
     // non-empty batch for that slot with NonEmptyTransitionBlock.
     for _ in 1u64..=3 {
         let mut source = ActionL2Source::new();
-        source.push(builder.build_next_block().expect("build L2 block"));
+        source.push(builder.build_next_block());
         let mut batcher = Batcher::new(source, &h.rollup_config, batcher_cfg.clone());
-        batcher.advance(&mut h.l1).await.expect("advance");
+        batcher.advance(&mut h.l1).await;
     }
 
     // Mine L1 block 4 (no batch). This closes the epoch-0 sequencing window
@@ -461,7 +461,7 @@ async fn jovian_non_empty_transition_batch_generates_deposit_only_block() {
     // stalls waiting for more L1 data (the seq window has not yet closed).
     for i in 1u64..=3 {
         verifier.act_l1_head_signal(h.l1.block_info_at(i)).await;
-        verifier.act_l2_pipeline_full().await.expect("pipeline");
+        verifier.act_l2_pipeline_full().await;
     }
     assert_eq!(
         verifier.l2_safe_number(),
@@ -472,7 +472,7 @@ async fn jovian_non_empty_transition_batch_generates_deposit_only_block() {
     // Signal L1 block 4. The epoch-0 window is now closed, so the pipeline
     // force-includes L2 slot 3 as a deposit-only block.
     verifier.act_l1_head_signal(h.l1.block_info_at(4)).await;
-    verifier.act_l2_pipeline_full().await.expect("pipeline block 4");
+    verifier.act_l2_pipeline_full().await;
 
     assert!(
         verifier.l2_safe_number() >= 3,
@@ -608,12 +608,11 @@ async fn operator_fee_config_update_propagates_to_l1_info() {
     // L2 blocks 1–5 (ts=2,4,6,8,10): epoch 0, OLD config.
     let mut epoch0_blocks: Vec<base_alloy_consensus::OpBlock> = Vec::new();
     for _ in 0..5 {
-        let block = sequencer.build_next_block().expect("build epoch-0 block");
-        epoch0_blocks.push(block);
+        epoch0_blocks.push(sequencer.build_next_block());
     }
 
     // L2 block 6 (ts=12): epoch 1, epoch change — NEW config from L1 block 1's receipts.
-    let block6 = sequencer.build_next_block().expect("build block 6");
+    let block6 = sequencer.build_next_block();
 
     let batcher_cfg = BatcherConfig {
         encoder: EncoderConfig { da_type: DaType::Calldata, ..batcher_cfg.encoder.clone() },
@@ -627,7 +626,7 @@ async fn operator_fee_config_update_propagates_to_l1_info() {
             source.push(block);
         }
         let mut batcher = Batcher::new(source, &h.rollup_config, batcher_cfg.clone());
-        batcher.advance(&mut h.l1).await.expect("advance blocks 1–5"); // L1 block 2, ts=24
+        batcher.advance(&mut h.l1).await; // L1 block 2, ts=24
     }
 
     // Batch block 6 into L1 block 3.
@@ -635,7 +634,7 @@ async fn operator_fee_config_update_propagates_to_l1_info() {
         let mut source = ActionL2Source::new();
         source.push(block6);
         let mut batcher = Batcher::new(source, &h.rollup_config, batcher_cfg.clone());
-        batcher.advance(&mut h.l1).await.expect("advance block 6"); // L1 block 3, ts=36
+        batcher.advance(&mut h.l1).await; // L1 block 3, ts=36
     }
 
     // Verifier snapshot includes all L1 blocks 0–3.
@@ -647,7 +646,7 @@ async fn operator_fee_config_update_propagates_to_l1_info() {
 
     for i in 1u64..=3 {
         verifier.act_l1_head_signal(h.l1.block_info_at(i)).await;
-        verifier.act_l2_pipeline_full().await.expect("step");
+        verifier.act_l2_pipeline_full().await;
     }
 
     assert_eq!(verifier.l2_safe_number(), 6, "all 6 L2 blocks must be derived");

--- a/actions/harness/tests/unsafe_gossip.rs
+++ b/actions/harness/tests/unsafe_gossip.rs
@@ -29,7 +29,7 @@ async fn test_unsafe_chain_advances_safe_catches_up() {
     let mut sequencer = h.create_l2_sequencer(l1_chain);
     let mut blocks = Vec::with_capacity(L2_BLOCK_COUNT as usize);
     for _ in 0..L2_BLOCK_COUNT {
-        blocks.push(sequencer.build_next_block().expect("build L2 block"));
+        blocks.push(sequencer.build_next_block());
     }
 
     // Create the verifier before any mining so chain updates are visible.
@@ -46,7 +46,7 @@ async fn test_unsafe_chain_advances_safe_catches_up() {
         source.push(block.clone());
     }
     let mut batcher = Batcher::new(source, &h.rollup_config, batcher_cfg.clone());
-    batcher.advance(&mut h.l1).await.expect("batcher should submit all blocks");
+    batcher.advance(&mut h.l1).await;
     chain.push(h.l1.tip().clone());
     let l1_block_1 = h.l1.tip_info();
 
@@ -56,7 +56,7 @@ async fn test_unsafe_chain_advances_safe_catches_up() {
 
     // --- Phase 2: Gossip each block into the verifier. ---
     for block in &blocks {
-        verifier.act_l2_unsafe_gossip_receive(block).expect("gossip receive should succeed");
+        verifier.act_l2_unsafe_gossip_receive(block);
     }
 
     assert_eq!(
@@ -72,7 +72,7 @@ async fn test_unsafe_chain_advances_safe_catches_up() {
 
     // --- Phase 3+4: Signal L1 head and run derivation. ---
     verifier.act_l1_head_signal(l1_block_1).await;
-    let derived = verifier.act_l2_pipeline_full().await.expect("pipeline full should succeed");
+    let derived = verifier.act_l2_pipeline_full().await;
 
     assert_eq!(derived, L2_BLOCK_COUNT as usize, "expected {L2_BLOCK_COUNT} L2 blocks derived");
     assert_eq!(
@@ -102,9 +102,9 @@ async fn test_out_of_order_gossip_is_dropped() {
     // Build 3 sequential L2 blocks (we will inject block 3 first, skipping 1 & 2).
     let l1_chain = SharedL1Chain::from_blocks(h.l1.chain().to_vec());
     let mut sequencer = h.create_l2_sequencer(l1_chain);
-    let block1 = sequencer.build_next_block().expect("build block 1");
-    let _block2 = sequencer.build_next_block().expect("build block 2");
-    let block3 = sequencer.build_next_block().expect("build block 3");
+    let block1 = sequencer.build_next_block();
+    let _block2 = sequencer.build_next_block();
+    let block3 = sequencer.build_next_block();
 
     let (mut verifier, _chain) = h.create_verifier_from_sequencer(
         &sequencer,
@@ -113,7 +113,7 @@ async fn test_out_of_order_gossip_is_dropped() {
     verifier.initialize().await;
 
     // Inject block 3 first — gap-jump; must be dropped.
-    verifier.act_l2_unsafe_gossip_receive(&block3).expect("out-of-order gossip must not error");
+    verifier.act_l2_unsafe_gossip_receive(&block3);
     assert_eq!(
         verifier.l2_unsafe_number(),
         0,
@@ -121,7 +121,7 @@ async fn test_out_of_order_gossip_is_dropped() {
     );
 
     // Inject block 1 — sequential; must advance.
-    verifier.act_l2_unsafe_gossip_receive(&block1).expect("in-order gossip must succeed");
+    verifier.act_l2_unsafe_gossip_receive(&block1);
     assert_eq!(
         verifier.l2_unsafe_number(),
         1,
@@ -129,7 +129,7 @@ async fn test_out_of_order_gossip_is_dropped() {
     );
 
     // Inject block 3 again — still a gap (unsafe_head=1, next expected=2); must be dropped.
-    verifier.act_l2_unsafe_gossip_receive(&block3).expect("gap gossip must not error");
+    verifier.act_l2_unsafe_gossip_receive(&block3);
     assert_eq!(
         verifier.l2_unsafe_number(),
         1,


### PR DESCRIPTION
## Summary

Harness actor methods (`build_next_block`, `build_empty_block`, `advance`, `encode_only`, `act_l2_pipeline_full`) previously returned `Result` or `Option`, requiring test authors to chain `.expect()` at every call site. Since any failure in a test harness is a test failure, panicking internally is the correct behavior. This PR moves the assertions inside the methods so call sites are clean. A `try_advance` variant is preserved for the handful of tests that exercise error paths explicitly.