### PR TITLE
fix(actions): Persist Batcher Across Loop Iterations

### DIFF
--- a/actions/harness/src/batcher/actor.rs
+++ b/actions/harness/src/batcher/actor.rs
@@ -10,7 +10,9 @@ use base_consensus_genesis::RollupConfig;
 use base_runtime::TokioRuntime;
 use tokio_util::sync::CancellationToken;
 
-use crate::{L1Miner, L1MinerTxManager, L2BlockProvider};
+use base_alloy_consensus::OpBlock;
+
+use crate::{ActionL2Source, L1Miner, L1MinerTxManager, L2BlockProvider};
 
 /// Configuration for the [`Batcher`] actor.
 #[derive(Debug, Clone)]
@@ -313,6 +315,15 @@ impl<S: L2BlockProvider> Batcher<S> {
         tokio::task::yield_now().await;
 
         Ok(())
+    }
+}
+
+impl Batcher<ActionL2Source> {
+    /// Push a block into the L2 source for the next [`advance`] call.
+    ///
+    /// [`advance`]: Batcher::advance
+    pub fn push_block(&mut self, block: OpBlock) {
+        self.l2_source.push(block);
     }
 }
 

--- a/actions/harness/src/batcher/actor.rs
+++ b/actions/harness/src/batcher/actor.rs
@@ -1,5 +1,6 @@
 use std::{sync::Arc, time::Duration};
 
+use base_alloy_consensus::OpBlock;
 use base_batcher_core::{
     BatchDriver, BatchDriverConfig, BatchDriverError, DaThrottle, NoopThrottleClient,
     ThrottleConfig, ThrottleController, ThrottleStrategy,
@@ -9,8 +10,6 @@ use base_batcher_source::{ChannelBlockSource, ChannelL1HeadSource, L2BlockEvent}
 use base_consensus_genesis::RollupConfig;
 use base_runtime::TokioRuntime;
 use tokio_util::sync::CancellationToken;
-
-use base_alloy_consensus::OpBlock;
 
 use crate::{ActionL2Source, L1Miner, L1MinerTxManager, L2BlockProvider};
 

--- a/actions/harness/tests/batcher_blobs.rs
+++ b/actions/harness/tests/batcher_blobs.rs
@@ -20,12 +20,10 @@ async fn batcher_blob_da_end_to_end() {
     let l1_chain = SharedL1Chain::from_blocks(h.l1.chain().to_vec());
     let mut sequencer = h.create_l2_sequencer(l1_chain);
 
-    // One Batcher per L2 block so each lands in a separate L1 block.
+    // One block per L1 inclusion block.
+    let mut batcher = Batcher::new(ActionL2Source::new(), &h.rollup_config, batcher_cfg.clone());
     for _ in 1..=3u64 {
-        let block = sequencer.build_next_block();
-        let mut source = ActionL2Source::new();
-        source.push(block);
-        let mut batcher = Batcher::new(source, &h.rollup_config, batcher_cfg.clone());
+        batcher.push_block(sequencer.build_next_block());
         batcher.advance(&mut h.l1).await;
     }
 
@@ -107,12 +105,10 @@ async fn batcher_calldata_da() {
     let l1_chain = SharedL1Chain::from_blocks(h.l1.chain().to_vec());
     let mut sequencer = h.create_l2_sequencer(l1_chain);
 
-    // One Batcher per L2 block so each lands in a separate L1 block.
+    // One block per L1 inclusion block.
+    let mut batcher = Batcher::new(ActionL2Source::new(), &h.rollup_config, batcher_cfg.clone());
     for _ in 1..=3u64 {
-        let block = sequencer.build_next_block();
-        let mut source = ActionL2Source::new();
-        source.push(block);
-        let mut batcher = Batcher::new(source, &h.rollup_config, batcher_cfg.clone());
+        batcher.push_block(sequencer.build_next_block());
         batcher.advance(&mut h.l1).await;
     }
 
@@ -152,21 +148,19 @@ async fn batcher_da_switching() {
     let blob_cfg = BatcherConfig::default(); // DaType::Blob by default
 
     // Blocks 1-3: submit as calldata.
+    let mut calldata_batcher =
+        Batcher::new(ActionL2Source::new(), &h.rollup_config, calldata_cfg.clone());
     for _ in 1..=3u64 {
-        let block = sequencer.build_next_block();
-        let mut source = ActionL2Source::new();
-        source.push(block);
-        let mut batcher = Batcher::new(source, &h.rollup_config, calldata_cfg.clone());
-        batcher.advance(&mut h.l1).await;
+        calldata_batcher.push_block(sequencer.build_next_block());
+        calldata_batcher.advance(&mut h.l1).await;
     }
 
     // Blocks 4-6: submit as blobs.
+    let mut blob_batcher =
+        Batcher::new(ActionL2Source::new(), &h.rollup_config, blob_cfg.clone());
     for _ in 4..=6u64 {
-        let block = sequencer.build_next_block();
-        let mut source = ActionL2Source::new();
-        source.push(block);
-        let mut batcher = Batcher::new(source, &h.rollup_config, blob_cfg.clone());
-        batcher.advance(&mut h.l1).await;
+        blob_batcher.push_block(sequencer.build_next_block());
+        blob_batcher.advance(&mut h.l1).await;
     }
 
     let (mut verifier, _chain) = h.create_blob_verifier_from_sequencer(
@@ -276,7 +270,8 @@ async fn blob_da_channel_timeout() {
     // Recovery: resubmit all frames as blobs in a fresh channel.
     let mut source2 = ActionL2Source::new();
     source2.push(block);
-    Batcher::new(source2, &h.rollup_config, batcher_cfg).advance(&mut h.l1).await;
+    Batcher::new(source2, &h.rollup_config, batcher_cfg)
+        .advance(&mut h.l1).await;
     chain.push(h.l1.tip().clone()); // L1 block 6: fresh blob channel with all frames
 
     verifier.act_l1_head_signal(h.l1.block_info_at(6)).await;

--- a/actions/harness/tests/batcher_blobs.rs
+++ b/actions/harness/tests/batcher_blobs.rs
@@ -156,8 +156,7 @@ async fn batcher_da_switching() {
     }
 
     // Blocks 4-6: submit as blobs.
-    let mut blob_batcher =
-        Batcher::new(ActionL2Source::new(), &h.rollup_config, blob_cfg.clone());
+    let mut blob_batcher = Batcher::new(ActionL2Source::new(), &h.rollup_config, blob_cfg.clone());
     for _ in 4..=6u64 {
         blob_batcher.push_block(sequencer.build_next_block());
         blob_batcher.advance(&mut h.l1).await;
@@ -270,8 +269,7 @@ async fn blob_da_channel_timeout() {
     // Recovery: resubmit all frames as blobs in a fresh channel.
     let mut source2 = ActionL2Source::new();
     source2.push(block);
-    Batcher::new(source2, &h.rollup_config, batcher_cfg)
-        .advance(&mut h.l1).await;
+    Batcher::new(source2, &h.rollup_config, batcher_cfg).advance(&mut h.l1).await;
     chain.push(h.l1.tip().clone()); // L1 block 6: fresh blob channel with all frames
 
     verifier.act_l1_head_signal(h.l1.block_info_at(6)).await;

--- a/actions/harness/tests/batcher_hardfork_transitions.rs
+++ b/actions/harness/tests/batcher_hardfork_transitions.rs
@@ -80,8 +80,7 @@ async fn span_batch_with_non_empty_transition_block_rejected() {
         source.push(block2.clone());
         source.push(block3_invalid);
         source.push(block4.clone());
-        Batcher::new(source, &h.rollup_config, span_cfg)
-            .advance(&mut h.l1).await;
+        Batcher::new(source, &h.rollup_config, span_cfg).advance(&mut h.l1).await;
     }
     chain.push(h.l1.tip().clone()); // L1 block 1: span batch with invalid block 3
 
@@ -122,8 +121,7 @@ async fn span_batch_with_non_empty_transition_block_rejected() {
         let mut source = ActionL2Source::new();
         source.push(block3_empty);
         source.push(block4_recovery);
-        Batcher::new(source, &h.rollup_config, span_cfg)
-            .advance(&mut h.l1).await;
+        Batcher::new(source, &h.rollup_config, span_cfg).advance(&mut h.l1).await;
     }
     chain.push(h.l1.tip().clone()); // L1 block 2: recovery span batch (blocks 3–4)
 
@@ -179,8 +177,7 @@ async fn mixed_singular_and_span_batches_after_delta() {
         let singular_cfg = BatcherConfig { batch_type: BatchType::Single, ..batcher_cfg.clone() };
         let mut source = ActionL2Source::new();
         source.push(block1);
-        Batcher::new(source, &h.rollup_config, singular_cfg)
-            .advance(&mut h.l1).await;
+        Batcher::new(source, &h.rollup_config, singular_cfg).advance(&mut h.l1).await;
     }
     chain.push(h.l1.tip().clone()); // L1 block 1: singular batch for L2 block 1
 
@@ -189,8 +186,7 @@ async fn mixed_singular_and_span_batches_after_delta() {
         let span_cfg = BatcherConfig { batch_type: BatchType::Span, ..batcher_cfg };
         let mut source = ActionL2Source::new();
         source.push(block2);
-        Batcher::new(source, &h.rollup_config, span_cfg)
-            .advance(&mut h.l1).await;
+        Batcher::new(source, &h.rollup_config, span_cfg).advance(&mut h.l1).await;
     }
     chain.push(h.l1.tip().clone()); // L1 block 2: span batch for L2 block 2
 
@@ -349,8 +345,7 @@ async fn granite_channel_timeout_enforced() {
     // --- Recovery: new batcher, all frames in one L1 block ---
     let mut source2 = ActionL2Source::new();
     source2.push(block);
-    Batcher::new(source2, &h.rollup_config, batcher_cfg)
-        .advance(&mut h.l1).await;
+    Batcher::new(source2, &h.rollup_config, batcher_cfg).advance(&mut h.l1).await;
     chain.push(h.l1.tip().clone());
 
     let recovery_num = h.l1.latest_number();
@@ -451,8 +446,7 @@ async fn jovian_single_batch_transition_block_deposit_only() {
     let mut batcher = Batcher::new(ActionL2Source::new(), &h.rollup_config, batcher_cfg.clone());
     for block in [block1, block2, block3_invalid, block4] {
         batcher.push_block(block);
-        batcher
-            .advance(&mut h.l1).await;
+        batcher.advance(&mut h.l1).await;
         chain.push(h.l1.tip().clone());
     }
 

--- a/actions/harness/tests/batcher_hardfork_transitions.rs
+++ b/actions/harness/tests/batcher_hardfork_transitions.rs
@@ -80,7 +80,8 @@ async fn span_batch_with_non_empty_transition_block_rejected() {
         source.push(block2.clone());
         source.push(block3_invalid);
         source.push(block4.clone());
-        Batcher::new(source, &h.rollup_config, span_cfg).advance(&mut h.l1).await;
+        Batcher::new(source, &h.rollup_config, span_cfg)
+            .advance(&mut h.l1).await;
     }
     chain.push(h.l1.tip().clone()); // L1 block 1: span batch with invalid block 3
 
@@ -121,7 +122,8 @@ async fn span_batch_with_non_empty_transition_block_rejected() {
         let mut source = ActionL2Source::new();
         source.push(block3_empty);
         source.push(block4_recovery);
-        Batcher::new(source, &h.rollup_config, span_cfg).advance(&mut h.l1).await;
+        Batcher::new(source, &h.rollup_config, span_cfg)
+            .advance(&mut h.l1).await;
     }
     chain.push(h.l1.tip().clone()); // L1 block 2: recovery span batch (blocks 3–4)
 
@@ -177,7 +179,8 @@ async fn mixed_singular_and_span_batches_after_delta() {
         let singular_cfg = BatcherConfig { batch_type: BatchType::Single, ..batcher_cfg.clone() };
         let mut source = ActionL2Source::new();
         source.push(block1);
-        Batcher::new(source, &h.rollup_config, singular_cfg).advance(&mut h.l1).await;
+        Batcher::new(source, &h.rollup_config, singular_cfg)
+            .advance(&mut h.l1).await;
     }
     chain.push(h.l1.tip().clone()); // L1 block 1: singular batch for L2 block 1
 
@@ -186,7 +189,8 @@ async fn mixed_singular_and_span_batches_after_delta() {
         let span_cfg = BatcherConfig { batch_type: BatchType::Span, ..batcher_cfg };
         let mut source = ActionL2Source::new();
         source.push(block2);
-        Batcher::new(source, &h.rollup_config, span_cfg).advance(&mut h.l1).await;
+        Batcher::new(source, &h.rollup_config, span_cfg)
+            .advance(&mut h.l1).await;
     }
     chain.push(h.l1.tip().clone()); // L1 block 2: span batch for L2 block 2
 
@@ -345,7 +349,8 @@ async fn granite_channel_timeout_enforced() {
     // --- Recovery: new batcher, all frames in one L1 block ---
     let mut source2 = ActionL2Source::new();
     source2.push(block);
-    Batcher::new(source2, &h.rollup_config, batcher_cfg).advance(&mut h.l1).await;
+    Batcher::new(source2, &h.rollup_config, batcher_cfg)
+        .advance(&mut h.l1).await;
     chain.push(h.l1.tip().clone());
 
     let recovery_num = h.l1.latest_number();
@@ -443,10 +448,11 @@ async fn jovian_single_batch_transition_block_deposit_only() {
 
     // Submit each block as a separate SingleBatch channel, one L1 block each.
     // L1 blocks 1–4 each contain one singular batch.
+    let mut batcher = Batcher::new(ActionL2Source::new(), &h.rollup_config, batcher_cfg.clone());
     for block in [block1, block2, block3_invalid, block4] {
-        let mut source = ActionL2Source::new();
-        source.push(block);
-        Batcher::new(source, &h.rollup_config, batcher_cfg.clone()).advance(&mut h.l1).await;
+        batcher.push_block(block);
+        batcher
+            .advance(&mut h.l1).await;
         chain.push(h.l1.tip().clone());
     }
 

--- a/actions/harness/tests/derivation.rs
+++ b/actions/harness/tests/derivation.rs
@@ -32,8 +32,7 @@ async fn single_l2_block_derived_from_batcher_frame() {
     let mut builder = h.create_l2_sequencer(l1_chain);
     let mut source = ActionL2Source::new();
     source.push(builder.build_next_block());
-    Batcher::new(source, &h.rollup_config, batcher_cfg.clone())
-        .advance(&mut h.l1).await;
+    Batcher::new(source, &h.rollup_config, batcher_cfg.clone()).advance(&mut h.l1).await;
 
     // Create the verifier AFTER mining so the SharedL1Chain snapshot already
     // contains both genesis and block 1.
@@ -121,8 +120,7 @@ async fn batch_in_orphaned_l1_block_is_not_derived() {
     let mut builder = h.create_l2_sequencer(l1_chain);
     let mut source = ActionL2Source::new();
     source.push(builder.build_next_block());
-    Batcher::new(source, &h.rollup_config, batcher_cfg.clone())
-        .advance(&mut h.l1).await;
+    Batcher::new(source, &h.rollup_config, batcher_cfg.clone()).advance(&mut h.l1).await;
 
     // Reorg L1 back to genesis; mine an empty replacement block 1'.
     h.l1.reorg_to(0).expect("reorg to genesis");
@@ -162,8 +160,7 @@ async fn reorg_reverts_derived_safe_head() {
     let mut builder = h.create_l2_sequencer(l1_chain);
     let mut source = ActionL2Source::new();
     source.push(builder.build_next_block());
-    Batcher::new(source, &h.rollup_config, batcher_cfg.clone())
-        .advance(&mut h.l1).await;
+    Batcher::new(source, &h.rollup_config, batcher_cfg.clone()).advance(&mut h.l1).await;
 
     // Create the verifier and derive L2 block 1.
     let (mut verifier, chain) = h.create_verifier_from_sequencer(
@@ -224,8 +221,7 @@ async fn reorg_and_resubmit_rederives_l2_block() {
     {
         let mut source = ActionL2Source::new();
         source.push(block1.clone());
-        Batcher::new(source, &h.rollup_config, batcher_cfg.clone())
-            .advance(&mut h.l1).await;
+        Batcher::new(source, &h.rollup_config, batcher_cfg.clone()).advance(&mut h.l1).await;
     }
 
     let (mut verifier, chain) = h.create_verifier_from_sequencer(
@@ -265,8 +261,7 @@ async fn reorg_and_resubmit_rederives_l2_block() {
     {
         let mut source = ActionL2Source::new();
         source.push(block1);
-        Batcher::new(source, &h.rollup_config, batcher_cfg.clone())
-            .advance(&mut h.l1).await;
+        Batcher::new(source, &h.rollup_config, batcher_cfg.clone()).advance(&mut h.l1).await;
     }
     chain.push(h.l1.tip().clone());
 
@@ -309,8 +304,7 @@ async fn reorg_flip_flop() {
     {
         let mut source = ActionL2Source::new();
         source.push(block1.clone());
-        Batcher::new(source, &h.rollup_config, batcher_cfg.clone())
-            .advance(&mut h.l1).await;
+        Batcher::new(source, &h.rollup_config, batcher_cfg.clone()).advance(&mut h.l1).await;
     }
 
     let (mut verifier, chain) = h.create_verifier_from_sequencer(
@@ -328,8 +322,7 @@ async fn reorg_flip_flop() {
     {
         let mut source = ActionL2Source::new();
         source.push(block1.clone());
-        Batcher::new(source, &h.rollup_config, batcher_cfg.clone())
-            .advance(&mut h.l1).await;
+        Batcher::new(source, &h.rollup_config, batcher_cfg.clone()).advance(&mut h.l1).await;
     }
     let fork_b1 = h.l1.tip_info();
 
@@ -348,8 +341,7 @@ async fn reorg_flip_flop() {
     {
         let mut source = ActionL2Source::new();
         source.push(block1);
-        Batcher::new(source, &h.rollup_config, batcher_cfg.clone())
-            .advance(&mut h.l1).await;
+        Batcher::new(source, &h.rollup_config, batcher_cfg.clone()).advance(&mut h.l1).await;
     }
     let fork_a_prime1 = h.l1.tip_info();
 
@@ -526,8 +518,7 @@ async fn batch_accepted_at_last_seq_window_block() {
     {
         let mut source = ActionL2Source::new();
         source.push(block1);
-        Batcher::new(source, &h.rollup_config, batcher_cfg.clone())
-            .advance(&mut h.l1).await;
+        Batcher::new(source, &h.rollup_config, batcher_cfg.clone()).advance(&mut h.l1).await;
     }
 
     let (mut verifier, _chain) = h.create_verifier_from_sequencer(
@@ -685,8 +676,7 @@ async fn l1_deposit_included_in_derived_l2_block() {
     {
         let mut source = ActionL2Source::new();
         source.push(block1);
-        Batcher::new(source, &h.rollup_config, batcher_cfg.clone())
-            .advance(&mut h.l1).await;
+        Batcher::new(source, &h.rollup_config, batcher_cfg.clone()).advance(&mut h.l1).await;
     }
 
     // Create verifier AFTER mining so the snapshot contains block 1.
@@ -793,8 +783,7 @@ async fn batcher_key_rotation_accepts_new_batcher() {
     {
         let mut source = ActionL2Source::new();
         source.push(block3.clone());
-        Batcher::new(source, &h.rollup_config, batcher_a.clone())
-            .advance(&mut h.l1).await;
+        Batcher::new(source, &h.rollup_config, batcher_a.clone()).advance(&mut h.l1).await;
     }
     chain.push(h.l1.tip().clone());
 
@@ -807,8 +796,7 @@ async fn batcher_key_rotation_accepts_new_batcher() {
     {
         let mut source = ActionL2Source::new();
         source.push(block3);
-        Batcher::new(source, &h.rollup_config, batcher_b.clone())
-            .advance(&mut h.l1).await;
+        Batcher::new(source, &h.rollup_config, batcher_b.clone()).advance(&mut h.l1).await;
     }
     chain.push(h.l1.tip().clone());
 
@@ -901,8 +889,7 @@ async fn batch_past_sequence_window_rejected() {
     {
         let mut source = ActionL2Source::new();
         source.push(block1);
-        Batcher::new(source, &h.rollup_config, batcher_cfg.clone())
-            .advance(&mut h.l1).await;
+        Batcher::new(source, &h.rollup_config, batcher_cfg.clone()).advance(&mut h.l1).await;
     }
 
     let (mut verifier, _chain) = h.create_verifier_from_sequencer(
@@ -1025,8 +1012,7 @@ async fn same_epoch_multi_batch_one_l1_block() {
     }
 
     // Encode all 3 blocks into one batcher submission (single channel) and mine.
-    Batcher::new(source, &h.rollup_config, batcher_cfg.clone())
-        .advance(&mut h.l1).await;
+    Batcher::new(source, &h.rollup_config, batcher_cfg.clone()).advance(&mut h.l1).await;
 
     // Create verifier after mining so the snapshot includes the inclusion block.
     let (mut verifier, _chain) = h.create_verifier_from_sequencer(
@@ -1166,8 +1152,7 @@ async fn garbage_frame_data_ignored() {
     {
         let mut source = ActionL2Source::new();
         source.push(block);
-        Batcher::new(source, &h.rollup_config, batcher_cfg.clone())
-            .advance(&mut h.l1).await;
+        Batcher::new(source, &h.rollup_config, batcher_cfg.clone()).advance(&mut h.l1).await;
     }
     chain.push(h.l1.tip().clone());
 
@@ -1260,8 +1245,7 @@ async fn single_l2_block_derived_from_span_batch() {
     let mut sequencer = h.create_l2_sequencer(l1_chain);
     let mut source = ActionL2Source::new();
     source.push(sequencer.build_next_block());
-    Batcher::new(source, &h.rollup_config, batcher_cfg.clone())
-        .advance(&mut h.l1).await;
+    Batcher::new(source, &h.rollup_config, batcher_cfg.clone()).advance(&mut h.l1).await;
 
     let (mut verifier, _chain) = h.create_verifier_from_sequencer(
         &sequencer,
@@ -1299,8 +1283,7 @@ async fn three_l2_blocks_derived_from_span_batch() {
         let block = sequencer.build_next_block();
         source.push(block);
     }
-    Batcher::new(source, &h.rollup_config, batcher_cfg.clone())
-        .advance(&mut h.l1).await;
+    Batcher::new(source, &h.rollup_config, batcher_cfg.clone()).advance(&mut h.l1).await;
 
     let (mut verifier, _chain) = h.create_verifier_from_sequencer(
         &sequencer,
@@ -1404,8 +1387,7 @@ async fn gpo_params_change_does_not_disrupt_derivation() {
     {
         let mut source = ActionL2Source::new();
         source.push(block1);
-        Batcher::new(source, &h.rollup_config, batcher_cfg.clone())
-            .advance(&mut h.l1).await;
+        Batcher::new(source, &h.rollup_config, batcher_cfg.clone()).advance(&mut h.l1).await;
     }
 
     // L1 block 2: gas-config update log only, no batch.
@@ -1416,8 +1398,7 @@ async fn gpo_params_change_does_not_disrupt_derivation() {
     {
         let mut source = ActionL2Source::new();
         source.push(block2);
-        Batcher::new(source, &h.rollup_config, batcher_cfg.clone())
-            .advance(&mut h.l1).await;
+        Batcher::new(source, &h.rollup_config, batcher_cfg.clone()).advance(&mut h.l1).await;
     }
 
     let (mut verifier, _chain) = h.create_verifier_from_sequencer(
@@ -1462,8 +1443,7 @@ async fn gas_limit_change_does_not_disrupt_derivation() {
     {
         let mut source = ActionL2Source::new();
         source.push(block1);
-        Batcher::new(source, &h.rollup_config, batcher_cfg.clone())
-            .advance(&mut h.l1).await;
+        Batcher::new(source, &h.rollup_config, batcher_cfg.clone()).advance(&mut h.l1).await;
     }
 
     // L1 block 2: gas-limit update log only.
@@ -1474,8 +1454,7 @@ async fn gas_limit_change_does_not_disrupt_derivation() {
     {
         let mut source = ActionL2Source::new();
         source.push(block2);
-        Batcher::new(source, &h.rollup_config, batcher_cfg.clone())
-            .advance(&mut h.l1).await;
+        Batcher::new(source, &h.rollup_config, batcher_cfg.clone()).advance(&mut h.l1).await;
     }
 
     let (mut verifier, _chain) = h.create_verifier_from_sequencer(
@@ -1526,8 +1505,7 @@ async fn garbage_payload_silently_ignored_then_valid_batch_derived(
     {
         let mut source = ActionL2Source::new();
         source.push(block);
-        Batcher::new(source, &h.rollup_config, batcher_cfg.clone())
-            .advance(&mut h.l1).await;
+        Batcher::new(source, &h.rollup_config, batcher_cfg.clone()).advance(&mut h.l1).await;
     }
 
     let (mut verifier, _chain) = h.create_verifier_from_sequencer(
@@ -1829,8 +1807,7 @@ async fn single_l2_block_derived_from_blob() {
     let mut builder = h.create_l2_sequencer(l1_chain);
     let mut source = ActionL2Source::new();
     source.push(builder.build_next_block());
-    Batcher::new(source, &h.rollup_config, batcher_cfg.clone())
-        .advance(&mut h.l1).await;
+    Batcher::new(source, &h.rollup_config, batcher_cfg.clone()).advance(&mut h.l1).await;
 
     // Create the blob verifier AFTER mining so the snapshot contains the blob.
     let (mut verifier, _chain) = h.create_blob_verifier_from_sequencer(
@@ -1865,8 +1842,7 @@ async fn multiple_l2_blocks_derived_from_blob() {
     }
 
     // Encode all 3 blocks into a single blob channel and mine.
-    Batcher::new(source, &h.rollup_config, batcher_cfg.clone())
-        .advance(&mut h.l1).await;
+    Batcher::new(source, &h.rollup_config, batcher_cfg.clone()).advance(&mut h.l1).await;
 
     // Create the blob verifier.
     let (mut verifier, _chain) = h.create_blob_verifier_from_sequencer(
@@ -1965,8 +1941,7 @@ async fn batcher_config_update_rolled_back_on_reorg() {
     {
         let mut source = ActionL2Source::new();
         source.push(block3.clone());
-        Batcher::new(source, &h.rollup_config, batcher_a.clone())
-            .advance(&mut h.l1).await;
+        Batcher::new(source, &h.rollup_config, batcher_a.clone()).advance(&mut h.l1).await;
     }
     chain.push(h.l1.tip().clone());
 
@@ -2054,8 +2029,7 @@ async fn out_of_order_singular_batches_reordered_by_batch_queue() {
     {
         let mut source = ActionL2Source::new();
         source.push(block2);
-        Batcher::new(source, &h.rollup_config, batcher_cfg.clone())
-            .advance(&mut h.l1).await;
+        Batcher::new(source, &h.rollup_config, batcher_cfg.clone()).advance(&mut h.l1).await;
     }
     chain.push(h.l1.tip().clone()); // L1 block 1: future batch
 
@@ -2063,8 +2037,7 @@ async fn out_of_order_singular_batches_reordered_by_batch_queue() {
     {
         let mut source = ActionL2Source::new();
         source.push(block1);
-        Batcher::new(source, &h.rollup_config, batcher_cfg.clone())
-            .advance(&mut h.l1).await;
+        Batcher::new(source, &h.rollup_config, batcher_cfg.clone()).advance(&mut h.l1).await;
     }
     chain.push(h.l1.tip().clone()); // L1 block 2: present batch
 
@@ -2141,8 +2114,7 @@ async fn pipeline_idle_before_l1_signal_derives_after() {
     {
         let mut source = ActionL2Source::new();
         source.push(block1);
-        Batcher::new(source, &h.rollup_config, batcher_cfg.clone())
-            .advance(&mut h.l1).await;
+        Batcher::new(source, &h.rollup_config, batcher_cfg.clone()).advance(&mut h.l1).await;
     }
     chain.push(h.l1.tip().clone());
     verifier.initialize().await;
@@ -2209,8 +2181,7 @@ async fn pipeline_l1_origin_advance_observable_after_epoch_exhausted() {
         let mut source = ActionL2Source::new();
         source.push(block1);
         source.push(block2);
-        Batcher::new(source, &h.rollup_config, batcher_cfg.clone())
-            .advance(&mut h.l1).await;
+        Batcher::new(source, &h.rollup_config, batcher_cfg.clone()).advance(&mut h.l1).await;
     }
     chain.push(h.l1.tip().clone()); // L1 block 1: carries the channel for blocks 1 & 2
     h.mine_and_push(&chain); // L1 block 2: empty — used only for origin advance
@@ -2299,8 +2270,7 @@ async fn span_batch_crossing_l1_epoch_boundary() {
     );
 
     // Encode all 6 blocks as a single span batch and submit in L1 block 2.
-    Batcher::new(source, &h.rollup_config, batcher_cfg)
-        .advance(&mut h.l1).await;
+    Batcher::new(source, &h.rollup_config, batcher_cfg).advance(&mut h.l1).await;
     chain.push(h.l1.tip().clone()); // L1 block 2: span batch for all 6 L2 blocks
 
     verifier.initialize().await;
@@ -2364,8 +2334,7 @@ async fn out_of_order_span_batches_reordered_by_batch_queue() {
     {
         let mut source = ActionL2Source::new();
         source.push(block2);
-        Batcher::new(source, &h.rollup_config, span_cfg.clone())
-            .advance(&mut h.l1).await;
+        Batcher::new(source, &h.rollup_config, span_cfg.clone()).advance(&mut h.l1).await;
     }
     chain.push(h.l1.tip().clone()); // L1 block 1: future span batch
 
@@ -2373,8 +2342,7 @@ async fn out_of_order_span_batches_reordered_by_batch_queue() {
     {
         let mut source = ActionL2Source::new();
         source.push(block1);
-        Batcher::new(source, &h.rollup_config, span_cfg)
-            .advance(&mut h.l1).await;
+        Batcher::new(source, &h.rollup_config, span_cfg).advance(&mut h.l1).await;
     }
     chain.push(h.l1.tip().clone()); // L1 block 2: present span batch
 
@@ -2458,8 +2426,7 @@ async fn large_l1_gaps_within_sequence_window() {
     let mut source = ActionL2Source::new();
     source.push(block1);
     source.push(block2);
-    Batcher::new(source, &h.rollup_config, batcher_cfg)
-        .advance(&mut h.l1).await;
+    Batcher::new(source, &h.rollup_config, batcher_cfg).advance(&mut h.l1).await;
     chain.push(h.l1.tip().clone()); // L1 block 16: batches for L2 blocks 1 and 2
 
     verifier.initialize().await;

--- a/actions/harness/tests/derivation.rs
+++ b/actions/harness/tests/derivation.rs
@@ -32,7 +32,8 @@ async fn single_l2_block_derived_from_batcher_frame() {
     let mut builder = h.create_l2_sequencer(l1_chain);
     let mut source = ActionL2Source::new();
     source.push(builder.build_next_block());
-    Batcher::new(source, &h.rollup_config, batcher_cfg.clone()).advance(&mut h.l1).await;
+    Batcher::new(source, &h.rollup_config, batcher_cfg.clone())
+        .advance(&mut h.l1).await;
 
     // Create the verifier AFTER mining so the SharedL1Chain snapshot already
     // contains both genesis and block 1.
@@ -80,10 +81,10 @@ async fn multiple_l1_blocks_each_derive_one_l2_block() {
     let l1_chain = SharedL1Chain::from_blocks(h.l1.chain().to_vec());
     let mut builder = h.create_l2_sequencer(l1_chain);
 
+    let mut batcher = Batcher::new(ActionL2Source::new(), &h.rollup_config, batcher_cfg.clone());
     for _ in 1..=L2_BLOCK_COUNT {
-        let mut source = ActionL2Source::new();
-        source.push(builder.build_next_block());
-        Batcher::new(source, &h.rollup_config, batcher_cfg.clone()).advance(&mut h.l1).await;
+        batcher.push_block(builder.build_next_block());
+        batcher.advance(&mut h.l1).await;
     }
 
     let (mut verifier, _chain) = h.create_verifier_from_sequencer(
@@ -120,7 +121,8 @@ async fn batch_in_orphaned_l1_block_is_not_derived() {
     let mut builder = h.create_l2_sequencer(l1_chain);
     let mut source = ActionL2Source::new();
     source.push(builder.build_next_block());
-    Batcher::new(source, &h.rollup_config, batcher_cfg.clone()).advance(&mut h.l1).await;
+    Batcher::new(source, &h.rollup_config, batcher_cfg.clone())
+        .advance(&mut h.l1).await;
 
     // Reorg L1 back to genesis; mine an empty replacement block 1'.
     h.l1.reorg_to(0).expect("reorg to genesis");
@@ -160,7 +162,8 @@ async fn reorg_reverts_derived_safe_head() {
     let mut builder = h.create_l2_sequencer(l1_chain);
     let mut source = ActionL2Source::new();
     source.push(builder.build_next_block());
-    Batcher::new(source, &h.rollup_config, batcher_cfg.clone()).advance(&mut h.l1).await;
+    Batcher::new(source, &h.rollup_config, batcher_cfg.clone())
+        .advance(&mut h.l1).await;
 
     // Create the verifier and derive L2 block 1.
     let (mut verifier, chain) = h.create_verifier_from_sequencer(
@@ -221,7 +224,8 @@ async fn reorg_and_resubmit_rederives_l2_block() {
     {
         let mut source = ActionL2Source::new();
         source.push(block1.clone());
-        Batcher::new(source, &h.rollup_config, batcher_cfg.clone()).advance(&mut h.l1).await;
+        Batcher::new(source, &h.rollup_config, batcher_cfg.clone())
+            .advance(&mut h.l1).await;
     }
 
     let (mut verifier, chain) = h.create_verifier_from_sequencer(
@@ -261,7 +265,8 @@ async fn reorg_and_resubmit_rederives_l2_block() {
     {
         let mut source = ActionL2Source::new();
         source.push(block1);
-        Batcher::new(source, &h.rollup_config, batcher_cfg.clone()).advance(&mut h.l1).await;
+        Batcher::new(source, &h.rollup_config, batcher_cfg.clone())
+            .advance(&mut h.l1).await;
     }
     chain.push(h.l1.tip().clone());
 
@@ -304,7 +309,8 @@ async fn reorg_flip_flop() {
     {
         let mut source = ActionL2Source::new();
         source.push(block1.clone());
-        Batcher::new(source, &h.rollup_config, batcher_cfg.clone()).advance(&mut h.l1).await;
+        Batcher::new(source, &h.rollup_config, batcher_cfg.clone())
+            .advance(&mut h.l1).await;
     }
 
     let (mut verifier, chain) = h.create_verifier_from_sequencer(
@@ -322,7 +328,8 @@ async fn reorg_flip_flop() {
     {
         let mut source = ActionL2Source::new();
         source.push(block1.clone());
-        Batcher::new(source, &h.rollup_config, batcher_cfg.clone()).advance(&mut h.l1).await;
+        Batcher::new(source, &h.rollup_config, batcher_cfg.clone())
+            .advance(&mut h.l1).await;
     }
     let fork_b1 = h.l1.tip_info();
 
@@ -341,7 +348,8 @@ async fn reorg_flip_flop() {
     {
         let mut source = ActionL2Source::new();
         source.push(block1);
-        Batcher::new(source, &h.rollup_config, batcher_cfg.clone()).advance(&mut h.l1).await;
+        Batcher::new(source, &h.rollup_config, batcher_cfg.clone())
+            .advance(&mut h.l1).await;
     }
     let fork_a_prime1 = h.l1.tip_info();
 
@@ -393,10 +401,10 @@ async fn reorg_flip_flop_empty_middle_fork() {
     let genesis_sys_cfg = rollup_cfg.genesis.system_config.unwrap_or_default();
 
     // --- Fork A: mine A1 (batch for L2 block 1) and A2 (batch for L2 block 2). ---
+    let mut batcher_a = Batcher::new(ActionL2Source::new(), &h.rollup_config, batcher_cfg.clone());
     for block in [block1.clone(), block2.clone()] {
-        let mut source = ActionL2Source::new();
-        source.push(block);
-        Batcher::new(source, &h.rollup_config, batcher_cfg.clone()).advance(&mut h.l1).await;
+        batcher_a.push_block(block);
+        batcher_a.advance(&mut h.l1).await;
     }
 
     let (mut verifier, chain) = h.create_verifier_from_sequencer(
@@ -451,10 +459,10 @@ async fn reorg_flip_flop_empty_middle_fork() {
     h.l1.reorg_to(0).expect("reorg to fork C");
     chain.truncate_to(0);
     let mut fork_c_blocks = Vec::new();
+    let mut batcher_c = Batcher::new(ActionL2Source::new(), &h.rollup_config, batcher_cfg.clone());
     for block in [block1, block2] {
-        let mut source = ActionL2Source::new();
-        source.push(block);
-        Batcher::new(source, &h.rollup_config, batcher_cfg.clone()).advance(&mut h.l1).await;
+        batcher_c.push_block(block);
+        batcher_c.advance(&mut h.l1).await;
         fork_c_blocks.push(h.l1.tip_info());
         chain.push(h.l1.tip().clone());
     }
@@ -518,7 +526,8 @@ async fn batch_accepted_at_last_seq_window_block() {
     {
         let mut source = ActionL2Source::new();
         source.push(block1);
-        Batcher::new(source, &h.rollup_config, batcher_cfg.clone()).advance(&mut h.l1).await;
+        Batcher::new(source, &h.rollup_config, batcher_cfg.clone())
+            .advance(&mut h.l1).await;
     }
 
     let (mut verifier, _chain) = h.create_verifier_from_sequencer(
@@ -676,7 +685,8 @@ async fn l1_deposit_included_in_derived_l2_block() {
     {
         let mut source = ActionL2Source::new();
         source.push(block1);
-        Batcher::new(source, &h.rollup_config, batcher_cfg.clone()).advance(&mut h.l1).await;
+        Batcher::new(source, &h.rollup_config, batcher_cfg.clone())
+            .advance(&mut h.l1).await;
     }
 
     // Create verifier AFTER mining so the snapshot contains block 1.
@@ -749,10 +759,10 @@ async fn batcher_key_rotation_accepts_new_batcher() {
     let block3 = builder.build_next_block();
 
     // --- L1 blocks 1-2: batcher A submits → L2 blocks 1-2 derived. ---
+    let mut batcher = Batcher::new(ActionL2Source::new(), &h.rollup_config, batcher_a.clone());
     for block in [block1, block2] {
-        let mut source = ActionL2Source::new();
-        source.push(block);
-        Batcher::new(source, &h.rollup_config, batcher_a.clone()).advance(&mut h.l1).await;
+        batcher.push_block(block);
+        batcher.advance(&mut h.l1).await;
     }
 
     // --- L1 block 3: rotation log only, no batch. ---
@@ -783,7 +793,8 @@ async fn batcher_key_rotation_accepts_new_batcher() {
     {
         let mut source = ActionL2Source::new();
         source.push(block3.clone());
-        Batcher::new(source, &h.rollup_config, batcher_a.clone()).advance(&mut h.l1).await;
+        Batcher::new(source, &h.rollup_config, batcher_a.clone())
+            .advance(&mut h.l1).await;
     }
     chain.push(h.l1.tip().clone());
 
@@ -796,7 +807,8 @@ async fn batcher_key_rotation_accepts_new_batcher() {
     {
         let mut source = ActionL2Source::new();
         source.push(block3);
-        Batcher::new(source, &h.rollup_config, batcher_b.clone()).advance(&mut h.l1).await;
+        Batcher::new(source, &h.rollup_config, batcher_b.clone())
+            .advance(&mut h.l1).await;
     }
     chain.push(h.l1.tip().clone());
 
@@ -830,11 +842,10 @@ async fn multi_l2_per_l1_epoch() {
         SharedL1Chain::from_blocks(h.l1.chain().to_vec()),
     );
 
+    let mut batcher = Batcher::new(ActionL2Source::new(), &h.rollup_config, batcher_cfg.clone());
     for _ in 1..=L2_COUNT {
-        let block = builder.build_next_block();
-        let mut source = ActionL2Source::new();
-        source.push(block);
-        Batcher::new(source, &h.rollup_config, batcher_cfg.clone()).advance(&mut h.l1).await;
+        batcher.push_block(builder.build_next_block());
+        batcher.advance(&mut h.l1).await;
         chain.push(h.l1.tip().clone());
     }
 
@@ -890,7 +901,8 @@ async fn batch_past_sequence_window_rejected() {
     {
         let mut source = ActionL2Source::new();
         source.push(block1);
-        Batcher::new(source, &h.rollup_config, batcher_cfg.clone()).advance(&mut h.l1).await;
+        Batcher::new(source, &h.rollup_config, batcher_cfg.clone())
+            .advance(&mut h.l1).await;
     }
 
     let (mut verifier, _chain) = h.create_verifier_from_sequencer(
@@ -967,10 +979,10 @@ async fn multi_epoch_sequence() {
     );
 
     // Batch each L2 block into a separate L1 inclusion block.
+    let mut batcher = Batcher::new(ActionL2Source::new(), &h.rollup_config, batcher_cfg.clone());
     for block in &blocks {
-        let mut source = ActionL2Source::new();
-        source.push(block.clone());
-        Batcher::new(source, &h.rollup_config, batcher_cfg.clone()).advance(&mut h.l1).await;
+        batcher.push_block(block.clone());
+        batcher.advance(&mut h.l1).await;
         chain.push(h.l1.tip().clone());
     }
 
@@ -1013,7 +1025,8 @@ async fn same_epoch_multi_batch_one_l1_block() {
     }
 
     // Encode all 3 blocks into one batcher submission (single channel) and mine.
-    Batcher::new(source, &h.rollup_config, batcher_cfg.clone()).advance(&mut h.l1).await;
+    Batcher::new(source, &h.rollup_config, batcher_cfg.clone())
+        .advance(&mut h.l1).await;
 
     // Create verifier after mining so the snapshot includes the inclusion block.
     let (mut verifier, _chain) = h.create_verifier_from_sequencer(
@@ -1056,10 +1069,10 @@ async fn deep_reorg_multi_block() {
     }
 
     // Submit each block's batch individually and mine an L1 block for each.
+    let mut batcher = Batcher::new(ActionL2Source::new(), &h.rollup_config, batcher_cfg.clone());
     for block in &blocks {
-        let mut source = ActionL2Source::new();
-        source.push(block.clone());
-        Batcher::new(source, &h.rollup_config, batcher_cfg.clone()).advance(&mut h.l1).await;
+        batcher.push_block(block.clone());
+        batcher.advance(&mut h.l1).await;
     }
 
     // Create verifier with all 5 L1 inclusion blocks visible.
@@ -1088,10 +1101,11 @@ async fn deep_reorg_multi_block() {
     assert_eq!(verifier.l2_safe_number(), 0, "safe head reverted to genesis");
 
     // Re-submit all 5 batches on the new fork.
+    let mut resubmit_batcher =
+        Batcher::new(ActionL2Source::new(), &h.rollup_config, batcher_cfg.clone());
     for block in &blocks {
-        let mut source = ActionL2Source::new();
-        source.push(block.clone());
-        Batcher::new(source, &h.rollup_config, batcher_cfg.clone()).advance(&mut h.l1).await;
+        resubmit_batcher.push_block(block.clone());
+        resubmit_batcher.advance(&mut h.l1).await;
         chain.push(h.l1.tip().clone());
     }
 
@@ -1152,7 +1166,8 @@ async fn garbage_frame_data_ignored() {
     {
         let mut source = ActionL2Source::new();
         source.push(block);
-        Batcher::new(source, &h.rollup_config, batcher_cfg.clone()).advance(&mut h.l1).await;
+        Batcher::new(source, &h.rollup_config, batcher_cfg.clone())
+            .advance(&mut h.l1).await;
     }
     chain.push(h.l1.tip().clone());
 
@@ -1245,7 +1260,8 @@ async fn single_l2_block_derived_from_span_batch() {
     let mut sequencer = h.create_l2_sequencer(l1_chain);
     let mut source = ActionL2Source::new();
     source.push(sequencer.build_next_block());
-    Batcher::new(source, &h.rollup_config, batcher_cfg.clone()).advance(&mut h.l1).await;
+    Batcher::new(source, &h.rollup_config, batcher_cfg.clone())
+        .advance(&mut h.l1).await;
 
     let (mut verifier, _chain) = h.create_verifier_from_sequencer(
         &sequencer,
@@ -1283,7 +1299,8 @@ async fn three_l2_blocks_derived_from_span_batch() {
         let block = sequencer.build_next_block();
         source.push(block);
     }
-    Batcher::new(source, &h.rollup_config, batcher_cfg.clone()).advance(&mut h.l1).await;
+    Batcher::new(source, &h.rollup_config, batcher_cfg.clone())
+        .advance(&mut h.l1).await;
 
     let (mut verifier, _chain) = h.create_verifier_from_sequencer(
         &sequencer,
@@ -1387,7 +1404,8 @@ async fn gpo_params_change_does_not_disrupt_derivation() {
     {
         let mut source = ActionL2Source::new();
         source.push(block1);
-        Batcher::new(source, &h.rollup_config, batcher_cfg.clone()).advance(&mut h.l1).await;
+        Batcher::new(source, &h.rollup_config, batcher_cfg.clone())
+            .advance(&mut h.l1).await;
     }
 
     // L1 block 2: gas-config update log only, no batch.
@@ -1398,7 +1416,8 @@ async fn gpo_params_change_does_not_disrupt_derivation() {
     {
         let mut source = ActionL2Source::new();
         source.push(block2);
-        Batcher::new(source, &h.rollup_config, batcher_cfg.clone()).advance(&mut h.l1).await;
+        Batcher::new(source, &h.rollup_config, batcher_cfg.clone())
+            .advance(&mut h.l1).await;
     }
 
     let (mut verifier, _chain) = h.create_verifier_from_sequencer(
@@ -1443,7 +1462,8 @@ async fn gas_limit_change_does_not_disrupt_derivation() {
     {
         let mut source = ActionL2Source::new();
         source.push(block1);
-        Batcher::new(source, &h.rollup_config, batcher_cfg.clone()).advance(&mut h.l1).await;
+        Batcher::new(source, &h.rollup_config, batcher_cfg.clone())
+            .advance(&mut h.l1).await;
     }
 
     // L1 block 2: gas-limit update log only.
@@ -1454,7 +1474,8 @@ async fn gas_limit_change_does_not_disrupt_derivation() {
     {
         let mut source = ActionL2Source::new();
         source.push(block2);
-        Batcher::new(source, &h.rollup_config, batcher_cfg.clone()).advance(&mut h.l1).await;
+        Batcher::new(source, &h.rollup_config, batcher_cfg.clone())
+            .advance(&mut h.l1).await;
     }
 
     let (mut verifier, _chain) = h.create_verifier_from_sequencer(
@@ -1505,7 +1526,8 @@ async fn garbage_payload_silently_ignored_then_valid_batch_derived(
     {
         let mut source = ActionL2Source::new();
         source.push(block);
-        Batcher::new(source, &h.rollup_config, batcher_cfg.clone()).advance(&mut h.l1).await;
+        Batcher::new(source, &h.rollup_config, batcher_cfg.clone())
+            .advance(&mut h.l1).await;
     }
 
     let (mut verifier, _chain) = h.create_verifier_from_sequencer(
@@ -1601,10 +1623,10 @@ async fn l2_finalized_advances_via_l1_finalized_signal() {
     let block1 = sequencer.build_next_block();
     let block2 = sequencer.build_next_block();
 
+    let mut batcher = Batcher::new(ActionL2Source::new(), &h.rollup_config, batcher_cfg.clone());
     for block in [block1, block2] {
-        let mut source = ActionL2Source::new();
-        source.push(block);
-        Batcher::new(source, &h.rollup_config, batcher_cfg.clone()).advance(&mut h.l1).await;
+        batcher.push_block(block);
+        batcher.advance(&mut h.l1).await;
     }
 
     let (mut verifier, _chain) = h.create_verifier_from_sequencer(
@@ -1749,14 +1771,14 @@ async fn derive_chain_from_near_l1_genesis() {
     let block_hashes = sequencer.block_hash_registry();
 
     // Build 2 L2 blocks and batch them into L1 blocks #6 and #7.
+    let mut batcher = Batcher::new(ActionL2Source::new(), &rollup_cfg, batcher_cfg.clone());
     for _ in 1..=2u64 {
         let block = sequencer.build_next_block();
         // With block_time=2 and L1 block 6 at ts=72, L2 block ts < 72
         // so the epoch stays at 5.
         assert_eq!(sequencer.head().l1_origin.number, 5, "epoch should stay at 5");
-        let mut source = ActionL2Source::new();
-        source.push(block);
-        Batcher::new(source, &rollup_cfg, batcher_cfg.clone()).advance(&mut h.l1).await; // mines L1 block 5+i
+        batcher.push_block(block);
+        batcher.advance(&mut h.l1).await; // mines L1 block 5+i
     }
 
     // Build the verifier components manually to anchor derivation at L1 block #5.
@@ -1807,7 +1829,8 @@ async fn single_l2_block_derived_from_blob() {
     let mut builder = h.create_l2_sequencer(l1_chain);
     let mut source = ActionL2Source::new();
     source.push(builder.build_next_block());
-    Batcher::new(source, &h.rollup_config, batcher_cfg.clone()).advance(&mut h.l1).await;
+    Batcher::new(source, &h.rollup_config, batcher_cfg.clone())
+        .advance(&mut h.l1).await;
 
     // Create the blob verifier AFTER mining so the snapshot contains the blob.
     let (mut verifier, _chain) = h.create_blob_verifier_from_sequencer(
@@ -1842,7 +1865,8 @@ async fn multiple_l2_blocks_derived_from_blob() {
     }
 
     // Encode all 3 blocks into a single blob channel and mine.
-    Batcher::new(source, &h.rollup_config, batcher_cfg.clone()).advance(&mut h.l1).await;
+    Batcher::new(source, &h.rollup_config, batcher_cfg.clone())
+        .advance(&mut h.l1).await;
 
     // Create the blob verifier.
     let (mut verifier, _chain) = h.create_blob_verifier_from_sequencer(
@@ -1908,10 +1932,10 @@ async fn batcher_config_update_rolled_back_on_reorg() {
     let block2_clone = block2.clone();
 
     // --- Phase 2: Derive blocks 1-2 with batcher A (L1 blocks 1-2). ---
+    let mut batcher = Batcher::new(ActionL2Source::new(), &h.rollup_config, batcher_a.clone());
     for block in [block1, block2] {
-        let mut source = ActionL2Source::new();
-        source.push(block);
-        Batcher::new(source, &h.rollup_config, batcher_a.clone()).advance(&mut h.l1).await;
+        batcher.push_block(block);
+        batcher.advance(&mut h.l1).await;
     }
 
     // --- Phase 3: Rotate config (L1 block 3 — config update log only). ---
@@ -1941,7 +1965,8 @@ async fn batcher_config_update_rolled_back_on_reorg() {
     {
         let mut source = ActionL2Source::new();
         source.push(block3.clone());
-        Batcher::new(source, &h.rollup_config, batcher_a.clone()).advance(&mut h.l1).await;
+        Batcher::new(source, &h.rollup_config, batcher_a.clone())
+            .advance(&mut h.l1).await;
     }
     chain.push(h.l1.tip().clone());
 
@@ -1967,12 +1992,12 @@ async fn batcher_config_update_rolled_back_on_reorg() {
     // --- Phase 6: New fork — re-mine blocks 1-2 with batcher A, then block 3'
     //     also with batcher A (no config update log). ---
     // Re-submit the same L2 blocks that were derived pre-reorg, plus block 3.
-    // Build fresh batchers to create new frames for the new fork.
     let resubmit_blocks = [block1_clone, block2_clone, block3];
+    let mut resubmit_batcher =
+        Batcher::new(ActionL2Source::new(), &h.rollup_config, batcher_a.clone());
     for block in resubmit_blocks {
-        let mut source = ActionL2Source::new();
-        source.push(block);
-        Batcher::new(source, &h.rollup_config, batcher_a.clone()).advance(&mut h.l1).await;
+        resubmit_batcher.push_block(block);
+        resubmit_batcher.advance(&mut h.l1).await;
         chain.push(h.l1.tip().clone());
     }
 
@@ -2029,7 +2054,8 @@ async fn out_of_order_singular_batches_reordered_by_batch_queue() {
     {
         let mut source = ActionL2Source::new();
         source.push(block2);
-        Batcher::new(source, &h.rollup_config, batcher_cfg.clone()).advance(&mut h.l1).await;
+        Batcher::new(source, &h.rollup_config, batcher_cfg.clone())
+            .advance(&mut h.l1).await;
     }
     chain.push(h.l1.tip().clone()); // L1 block 1: future batch
 
@@ -2037,7 +2063,8 @@ async fn out_of_order_singular_batches_reordered_by_batch_queue() {
     {
         let mut source = ActionL2Source::new();
         source.push(block1);
-        Batcher::new(source, &h.rollup_config, batcher_cfg.clone()).advance(&mut h.l1).await;
+        Batcher::new(source, &h.rollup_config, batcher_cfg.clone())
+            .advance(&mut h.l1).await;
     }
     chain.push(h.l1.tip().clone()); // L1 block 2: present batch
 
@@ -2114,7 +2141,8 @@ async fn pipeline_idle_before_l1_signal_derives_after() {
     {
         let mut source = ActionL2Source::new();
         source.push(block1);
-        Batcher::new(source, &h.rollup_config, batcher_cfg.clone()).advance(&mut h.l1).await;
+        Batcher::new(source, &h.rollup_config, batcher_cfg.clone())
+            .advance(&mut h.l1).await;
     }
     chain.push(h.l1.tip().clone());
     verifier.initialize().await;
@@ -2181,7 +2209,8 @@ async fn pipeline_l1_origin_advance_observable_after_epoch_exhausted() {
         let mut source = ActionL2Source::new();
         source.push(block1);
         source.push(block2);
-        Batcher::new(source, &h.rollup_config, batcher_cfg.clone()).advance(&mut h.l1).await;
+        Batcher::new(source, &h.rollup_config, batcher_cfg.clone())
+            .advance(&mut h.l1).await;
     }
     chain.push(h.l1.tip().clone()); // L1 block 1: carries the channel for blocks 1 & 2
     h.mine_and_push(&chain); // L1 block 2: empty — used only for origin advance
@@ -2270,7 +2299,8 @@ async fn span_batch_crossing_l1_epoch_boundary() {
     );
 
     // Encode all 6 blocks as a single span batch and submit in L1 block 2.
-    Batcher::new(source, &h.rollup_config, batcher_cfg).advance(&mut h.l1).await;
+    Batcher::new(source, &h.rollup_config, batcher_cfg)
+        .advance(&mut h.l1).await;
     chain.push(h.l1.tip().clone()); // L1 block 2: span batch for all 6 L2 blocks
 
     verifier.initialize().await;
@@ -2334,7 +2364,8 @@ async fn out_of_order_span_batches_reordered_by_batch_queue() {
     {
         let mut source = ActionL2Source::new();
         source.push(block2);
-        Batcher::new(source, &h.rollup_config, span_cfg.clone()).advance(&mut h.l1).await;
+        Batcher::new(source, &h.rollup_config, span_cfg.clone())
+            .advance(&mut h.l1).await;
     }
     chain.push(h.l1.tip().clone()); // L1 block 1: future span batch
 
@@ -2342,7 +2373,8 @@ async fn out_of_order_span_batches_reordered_by_batch_queue() {
     {
         let mut source = ActionL2Source::new();
         source.push(block1);
-        Batcher::new(source, &h.rollup_config, span_cfg).advance(&mut h.l1).await;
+        Batcher::new(source, &h.rollup_config, span_cfg)
+            .advance(&mut h.l1).await;
     }
     chain.push(h.l1.tip().clone()); // L1 block 2: present span batch
 
@@ -2426,7 +2458,8 @@ async fn large_l1_gaps_within_sequence_window() {
     let mut source = ActionL2Source::new();
     source.push(block1);
     source.push(block2);
-    Batcher::new(source, &h.rollup_config, batcher_cfg).advance(&mut h.l1).await;
+    Batcher::new(source, &h.rollup_config, batcher_cfg)
+        .advance(&mut h.l1).await;
     chain.push(h.l1.tip().clone()); // L1 block 16: batches for L2 blocks 1 and 2
 
     verifier.initialize().await;

--- a/actions/harness/tests/ecotone_activation.rs
+++ b/actions/harness/tests/ecotone_activation.rs
@@ -140,12 +140,12 @@ async fn ecotone_activation_block_user_txs_accepted_at_batch_layer() {
     let l1_chain = SharedL1Chain::from_blocks(h.l1.chain().to_vec());
     let mut builder = h.create_l2_sequencer(l1_chain);
 
+    let mut batcher = Batcher::new(ActionL2Source::new(), &h.rollup_config, batcher_cfg.clone());
+
     // Blocks 1 and 2: pre-Ecotone, user txs OK.
     for _ in 1..=2u64 {
-        let block = builder.build_next_block();
-        let mut source = ActionL2Source::new();
-        source.push(block);
-        Batcher::new(source, &h.rollup_config, batcher_cfg.clone()).advance(&mut h.l1).await;
+        batcher.push_block(builder.build_next_block());
+        batcher.advance(&mut h.l1).await;
     }
 
     // Block 3 at ts=6 (first Ecotone): build WITH a user tx. Unlike Jovian,
@@ -156,16 +156,12 @@ async fn ecotone_activation_block_user_txs_accepted_at_batch_layer() {
         block3_with_user_tx.header.timestamp, ecotone_time,
         "block 3 must land exactly at ecotone_time"
     );
-
-    let mut source3 = ActionL2Source::new();
-    source3.push(block3_with_user_tx);
-    Batcher::new(source3, &h.rollup_config, batcher_cfg.clone()).advance(&mut h.l1).await;
+    batcher.push_block(block3_with_user_tx);
+    batcher.advance(&mut h.l1).await;
 
     // Block 4: post-Ecotone, user txs OK.
-    let block4 = builder.build_next_block();
-    let mut source4 = ActionL2Source::new();
-    source4.push(block4);
-    Batcher::new(source4, &h.rollup_config, batcher_cfg).advance(&mut h.l1).await;
+    batcher.push_block(builder.build_next_block());
+    batcher.advance(&mut h.l1).await;
 
     let (mut verifier, _chain) = h.create_verifier_from_sequencer(
         &builder,
@@ -234,6 +230,7 @@ async fn ecotone_derivation_crosses_activation_boundary() {
     let mut builder = h.create_l2_sequencer(l1_chain);
 
     // Build and submit 4 L2 blocks individually (one batch per L1 block).
+    let mut batcher = Batcher::new(ActionL2Source::new(), &h.rollup_config, batcher_cfg.clone());
     for i in 1..=4u64 {
         let block = if i == 3 {
             // First Ecotone block: must be deposit-only (no user txs) because
@@ -242,10 +239,8 @@ async fn ecotone_derivation_crosses_activation_boundary() {
         } else {
             builder.build_next_block()
         };
-
-        let mut source = ActionL2Source::new();
-        source.push(block);
-        Batcher::new(source, &h.rollup_config, batcher_cfg.clone()).advance(&mut h.l1).await;
+        batcher.push_block(block);
+        batcher.advance(&mut h.l1).await;
     }
 
     let (mut verifier, _chain) = h.create_verifier_from_sequencer(

--- a/actions/harness/tests/finalization.rs
+++ b/actions/harness/tests/finalization.rs
@@ -31,10 +31,9 @@ async fn finalization_advances_with_multiple_l2_blocks_per_epoch() {
     assert_eq!(sequencer.head().l1_origin.number, 0, "all blocks should be in epoch 0");
 
     // Submit each block in a separate L1 inclusion block.
+    let mut batcher = Batcher::new(ActionL2Source::new(), &h.rollup_config, batcher_cfg.clone());
     for block in blocks {
-        let mut source = ActionL2Source::new();
-        source.push(block);
-        let mut batcher = Batcher::new(source, &h.rollup_config, batcher_cfg.clone());
+        batcher.push_block(block);
         batcher.advance(&mut h.l1).await;
     }
 
@@ -112,10 +111,9 @@ async fn finalization_advances_incrementally_with_l1_epochs() {
         SharedL1Chain::from_blocks(h.l1.chain().to_vec()),
     );
 
+    let mut batcher = Batcher::new(ActionL2Source::new(), &h.rollup_config, batcher_cfg.clone());
     for block in blocks {
-        let mut source = ActionL2Source::new();
-        source.push(block);
-        let mut batcher = Batcher::new(source, &h.rollup_config, batcher_cfg.clone());
+        batcher.push_block(block);
         batcher.advance(&mut h.l1).await;
         chain.push(h.l1.tip().clone());
     }
@@ -174,10 +172,9 @@ async fn finalization_does_not_exceed_safe_head() {
     let block2 = sequencer.build_next_block();
 
     // Submit each block via the batcher.
+    let mut batcher = Batcher::new(ActionL2Source::new(), &h.rollup_config, batcher_cfg.clone());
     for block in [block1, block2] {
-        let mut source = ActionL2Source::new();
-        source.push(block);
-        let mut batcher = Batcher::new(source, &h.rollup_config, batcher_cfg.clone());
+        batcher.push_block(block);
         batcher.advance(&mut h.l1).await;
     }
 
@@ -237,10 +234,9 @@ async fn finalization_reorg_clears_state() {
     let block2 = sequencer.build_next_block();
 
     // Submit and mine.
+    let mut batcher = Batcher::new(ActionL2Source::new(), &h.rollup_config, batcher_cfg.clone());
     for block in [block1, block2] {
-        let mut source = ActionL2Source::new();
-        source.push(block);
-        let mut batcher = Batcher::new(source, &h.rollup_config, batcher_cfg.clone());
+        batcher.push_block(block);
         batcher.advance(&mut h.l1).await;
     }
 
@@ -343,10 +339,9 @@ async fn finalization_does_not_regress() {
         SharedL1Chain::from_blocks(h.l1.chain().to_vec()),
     );
 
+    let mut batcher = Batcher::new(ActionL2Source::new(), &h.rollup_config, batcher_cfg.clone());
     for block in blocks {
-        let mut source = ActionL2Source::new();
-        source.push(block);
-        let mut batcher = Batcher::new(source, &h.rollup_config, batcher_cfg.clone());
+        batcher.push_block(block);
         batcher.advance(&mut h.l1).await;
         chain.push(h.l1.tip().clone());
     }

--- a/actions/harness/tests/hardfork_activation.rs
+++ b/actions/harness/tests/hardfork_activation.rs
@@ -351,10 +351,9 @@ async fn single_batch_derives_with_fjord() {
     let l1_chain = SharedL1Chain::from_blocks(h.l1.chain().to_vec());
     let mut builder = h.create_l2_sequencer(l1_chain);
 
+    let mut batcher = Batcher::new(ActionL2Source::new(), &h.rollup_config, batcher_cfg.clone());
     for _ in 0..2 {
-        let mut source = ActionL2Source::new();
-        source.push(builder.build_next_block());
-        let mut batcher = Batcher::new(source, &h.rollup_config, batcher_cfg.clone());
+        batcher.push_block(builder.build_next_block());
         batcher.advance(&mut h.l1).await;
     }
 
@@ -410,6 +409,7 @@ async fn jovian_derivation_crosses_activation_boundary() {
     let l1_chain = SharedL1Chain::from_blocks(h.l1.chain().to_vec());
     let mut builder = h.create_l2_sequencer(l1_chain);
 
+    let mut batcher = Batcher::new(ActionL2Source::new(), &h.rollup_config, batcher_cfg.clone());
     for i in 1..=4u64 {
         let block = if i == 3 {
             // First Jovian block: must contain no user transactions.
@@ -417,10 +417,7 @@ async fn jovian_derivation_crosses_activation_boundary() {
         } else {
             builder.build_next_block()
         };
-
-        let mut source = ActionL2Source::new();
-        source.push(block);
-        let mut batcher = Batcher::new(source, &h.rollup_config, batcher_cfg.clone());
+        batcher.push_block(block);
         batcher.advance(&mut h.l1).await;
     }
 

--- a/actions/harness/tests/holocene_activation.rs
+++ b/actions/harness/tests/holocene_activation.rs
@@ -62,11 +62,10 @@ async fn holocene_derivation_crosses_activation_boundary() {
 
     // Build and submit 4 L2 blocks; no upgrade-tx constraint at Holocene,
     // so user txs are valid in all blocks including block 3.
+    let mut batcher = Batcher::new(ActionL2Source::new(), &h.rollup_config, batcher_cfg.clone());
     for _ in 1..=4u64 {
-        let block = builder.build_next_block();
-        let mut source = ActionL2Source::new();
-        source.push(block);
-        Batcher::new(source, &h.rollup_config, batcher_cfg.clone()).advance(&mut h.l1).await;
+        batcher.push_block(builder.build_next_block());
+        batcher.advance(&mut h.l1).await;
         chain.push(h.l1.tip().clone());
     }
 

--- a/actions/harness/tests/operator_fees.rs
+++ b/actions/harness/tests/operator_fees.rs
@@ -361,11 +361,10 @@ async fn isthmus_derivation_crosses_operator_fee_boundary() {
     let l1_chain = SharedL1Chain::from_blocks(h.l1.chain().to_vec());
     let mut builder = h.create_l2_sequencer(l1_chain);
 
+    let mut batcher = Batcher::new(ActionL2Source::new(), &h.rollup_config, batcher_cfg.clone());
     for _ in 0..4u64 {
         // All blocks carry user transactions — Isthmus allows user txs at transition.
-        let mut source = ActionL2Source::new();
-        source.push(builder.build_next_block());
-        let mut batcher = Batcher::new(source, &h.rollup_config, batcher_cfg.clone());
+        batcher.push_block(builder.build_next_block());
         batcher.advance(&mut h.l1).await;
     }
 
@@ -439,10 +438,9 @@ async fn jovian_non_empty_transition_batch_generates_deposit_only_block() {
     // Build three L2 blocks — each with 1 user transaction (the sequencer default).
     // Block 3 (ts=6) is the first Jovian block. The batch validator will drop the
     // non-empty batch for that slot with NonEmptyTransitionBlock.
+    let mut batcher = Batcher::new(ActionL2Source::new(), &h.rollup_config, batcher_cfg.clone());
     for _ in 1u64..=3 {
-        let mut source = ActionL2Source::new();
-        source.push(builder.build_next_block());
-        let mut batcher = Batcher::new(source, &h.rollup_config, batcher_cfg.clone());
+        batcher.push_block(builder.build_next_block());
         batcher.advance(&mut h.l1).await;
     }
 
@@ -608,7 +606,8 @@ async fn operator_fee_config_update_propagates_to_l1_info() {
     // L2 blocks 1–5 (ts=2,4,6,8,10): epoch 0, OLD config.
     let mut epoch0_blocks: Vec<base_alloy_consensus::OpBlock> = Vec::new();
     for _ in 0..5 {
-        epoch0_blocks.push(sequencer.build_next_block());
+        let block = sequencer.build_next_block();
+        epoch0_blocks.push(block);
     }
 
     // L2 block 6 (ts=12): epoch 1, epoch change — NEW config from L1 block 1's receipts.


### PR DESCRIPTION
## Summary

Action tests were creating a new `Batcher` inside each loop iteration, which spawns and immediately kills a background `BatchDriver` tokio task per block — defeating the purpose of persistent encoder state across batch cycles. This refactor introduces a `push_block` helper on `Batcher<ActionL2Source>` and updates all affected tests to create one `Batcher` before the loop and feed blocks through it. Intentionally separate batchers — covering different configs, post-reorg forks, and recovery scenarios — are left unchanged. The fix reduces unnecessary tokio task churn and makes tests more faithful to real batcher usage.