### PR TITLE
feat(proposer): add --dry-run mode to source proofs without submitting transactions

### DIFF
--- a/crates/proof/proposer/src/cli.rs
+++ b/crates/proof/proposer/src/cli.rs
@@ -40,6 +40,10 @@ pub struct Cli {
 #[derive(Debug, Clone, Parser)]
 #[command(next_help_heading = "Proposer")]
 pub struct ProposerArgs {
+    /// Dry-run mode: source proofs but do not submit transactions on-chain.
+    #[arg(long = "dry-run", env = cli_env!("DRY_RUN"), default_value = "false")]
+    pub dry_run: bool,
+
     /// Allow proposals based on non-finalized L1 data.
     #[arg(
         long = "allow-non-finalized",
@@ -204,6 +208,7 @@ mod tests {
         let cli = Cli::try_parse_from(args).unwrap();
 
         // Check defaults
+        assert!(!cli.proposer.dry_run);
         assert!(!cli.proposer.allow_non_finalized);
         assert_eq!(cli.proposer.poll_interval, Duration::from_secs(12));
         assert_eq!(cli.proposer.rpc_timeout, Duration::from_secs(30));

--- a/crates/proof/proposer/src/config.rs
+++ b/crates/proof/proposer/src/config.rs
@@ -48,6 +48,8 @@ pub enum ConfigError {
 /// Validated proposer configuration.
 #[derive(Debug)]
 pub struct ProposerConfig {
+    /// Dry-run mode: source proofs but do not submit transactions on-chain.
+    pub dry_run: bool,
     /// Allow proposals based on non-finalized L1 data.
     pub allow_non_finalized: bool,
     /// URL of the prover RPC endpoint.
@@ -83,9 +85,11 @@ pub struct ProposerConfig {
     /// RPC retry configuration.
     pub retry: RetryConfig,
     /// Signing configuration for L1 transaction submission.
-    pub signing: base_tx_manager::SignerConfig,
+    /// `None` when running in dry-run mode.
+    pub signing: Option<base_tx_manager::SignerConfig>,
     /// Transaction manager configuration.
-    pub tx_manager: base_tx_manager::TxManagerConfig,
+    /// `None` when running in dry-run mode.
+    pub tx_manager: Option<base_tx_manager::TxManagerConfig>,
 }
 
 impl ProposerConfig {
@@ -124,15 +128,18 @@ impl ProposerConfig {
         // Extract retry config before moving signer out of proposer
         let retry = RetryConfig::from(&cli.proposer);
 
-        // Validate and extract signing config
-        let signing = base_tx_manager::SignerConfig::try_from(cli.proposer.signer)
-            .map_err(|e| ConfigError::Signing(e.to_string()))?;
-
-        // Validate and extract tx manager config
-        let tx_manager = base_tx_manager::TxManagerConfig::try_from(cli.proposer.tx_manager)
-            .map_err(|e| ConfigError::TxManager(e.to_string()))?;
+        let (signing, tx_manager) = if cli.proposer.dry_run {
+            (None, None)
+        } else {
+            let s = base_tx_manager::SignerConfig::try_from(cli.proposer.signer)
+                .map_err(|e| ConfigError::Signing(e.to_string()))?;
+            let t = base_tx_manager::TxManagerConfig::try_from(cli.proposer.tx_manager)
+                .map_err(|e| ConfigError::TxManager(e.to_string()))?;
+            (Some(s), Some(t))
+        };
 
         Ok(Self {
+            dry_run: cli.proposer.dry_run,
             allow_non_finalized: cli.proposer.allow_non_finalized,
             prover_rpc: cli.proposer.prover_rpc,
             l1_eth_rpc: cli.proposer.l1_eth_rpc,
@@ -212,6 +219,7 @@ mod tests {
     fn minimal_cli() -> Cli {
         Cli {
             proposer: ProposerArgs {
+                dry_run: false,
                 allow_non_finalized: false,
                 prover_rpc: Url::parse("http://localhost:8080").unwrap(),
                 l1_eth_rpc: Url::parse("http://localhost:8545").unwrap(),
@@ -266,6 +274,7 @@ mod tests {
     fn test_valid_config() {
         let cli = minimal_cli();
         let config = ProposerConfig::from_cli(cli).unwrap();
+        assert!(!config.dry_run);
         assert!(!config.allow_non_finalized);
         assert_eq!(config.game_type, 1);
         assert_eq!(config.poll_interval, Duration::from_secs(12));
@@ -402,7 +411,7 @@ mod tests {
     fn test_signing_config_local() {
         let cli = minimal_cli();
         let config = ProposerConfig::from_cli(cli).unwrap();
-        assert!(matches!(config.signing, base_tx_manager::SignerConfig::Local { .. }));
+        assert!(matches!(config.signing, Some(base_tx_manager::SignerConfig::Local { .. })));
     }
 
     #[test]
@@ -414,7 +423,7 @@ mod tests {
             signer_address: Some("0x1234567890123456789012345678901234567890".parse().unwrap()),
         };
         let config = ProposerConfig::from_cli(cli).unwrap();
-        assert!(matches!(config.signing, base_tx_manager::SignerConfig::Remote { .. }));
+        assert!(matches!(config.signing, Some(base_tx_manager::SignerConfig::Remote { .. })));
     }
 
     #[test]
@@ -424,6 +433,18 @@ mod tests {
             SignerCli { private_key: None, signer_endpoint: None, signer_address: None };
         let result = ProposerConfig::from_cli(cli);
         assert!(matches!(result, Err(ConfigError::Signing(_))));
+    }
+
+    #[test]
+    fn test_dry_run_skips_signer_validation() {
+        let mut cli = minimal_cli();
+        cli.proposer.dry_run = true;
+        cli.proposer.signer =
+            SignerCli { private_key: None, signer_endpoint: None, signer_address: None };
+        let config = ProposerConfig::from_cli(cli).unwrap();
+        assert!(config.dry_run);
+        assert!(config.signing.is_none());
+        assert!(config.tx_manager.is_none());
     }
 
     #[test]

--- a/crates/proof/proposer/src/lib.rs
+++ b/crates/proof/proposer/src/lib.rs
@@ -20,7 +20,7 @@ pub use constants::*;
 
 mod output_proposer;
 pub use output_proposer::{
-    OutputProposer, ProposalSubmitter, build_proof_data, is_game_already_exists,
+    DryRunProposer, OutputProposer, ProposalSubmitter, build_proof_data, is_game_already_exists,
 };
 
 mod driver;

--- a/crates/proof/proposer/src/output_proposer.rs
+++ b/crates/proof/proposer/src/output_proposer.rs
@@ -67,6 +67,30 @@ pub trait OutputProposer: Send + Sync {
     ) -> Result<(), ProposerError>;
 }
 
+/// No-op output proposer that logs proposals without submitting transactions.
+#[derive(Debug)]
+pub struct DryRunProposer;
+
+#[async_trait]
+impl OutputProposer for DryRunProposer {
+    async fn propose_output(
+        &self,
+        proposal: &Proposal,
+        l2_block_number: u64,
+        parent_index: u32,
+        intermediate_roots: &[B256],
+    ) -> Result<(), ProposerError> {
+        info!(
+            l2_block_number,
+            parent_index,
+            output_root = ?proposal.output_root,
+            intermediate_roots_count = intermediate_roots.len(),
+            "DRY RUN: would create dispute game (skipping submission)"
+        );
+        Ok(())
+    }
+}
+
 /// Submits output proposals to L1 via the [`TxManager`].
 #[derive(Debug)]
 pub struct ProposalSubmitter<T> {

--- a/crates/proof/proposer/src/service.rs
+++ b/crates/proof/proposer/src/service.rs
@@ -156,35 +156,48 @@ pub async fn run(config: ProposerConfig) -> Result<()> {
     let factory_client = Arc::new(factory_client);
     let verifier_client: Arc<dyn AggregateVerifierClient> = Arc::new(verifier_client);
 
-    // ── 5a. Construct tx-manager ─────────────────────────────────────────
-    let l1_tx_provider = alloy_provider::RootProvider::new_http(config.l1_eth_rpc.clone());
-    let l1_chain_id = l1_tx_provider
-        .get_chain_id()
-        .await
-        .map_err(|e| eyre::eyre!("failed to fetch L1 chain ID: {e}"))?;
-    let tx_manager = SimpleTxManager::new(
-        l1_tx_provider,
-        config.signing,
-        config.tx_manager,
-        l1_chain_id,
-        Arc::new(BaseTxMetrics::new("proposer")),
-    )
-    .await
-    .map_err(|e| eyre::eyre!("failed to construct tx manager: {e}"))?;
-    let proposer_address = tx_manager.sender_address();
-    info!(%proposer_address, "Transaction manager initialized");
-
-    // ── 5b. Create prover ────────────────────────────────────────────────
+    // ── 5a. Create prover ──────────────────────────────────────────────
     let prover_client: Arc<dyn ProverClient> = Arc::new(prover_client);
-    info!(proposer = %proposer_address, "Prover initialized");
+    info!("Prover initialized");
 
-    // ── 5c. Create output proposer ──────────────────────────────────────
-    let output_proposer: Arc<dyn crate::OutputProposer> = Arc::new(ProposalSubmitter::new(
-        tx_manager,
-        config.dispute_game_factory_addr,
-        config.game_type,
-        init_bond,
-    ));
+    // ── 5b. Create output proposer (or dry-run stub) ────────────────────
+    let (output_proposer, proposer_address): (Arc<dyn crate::OutputProposer>, Option<Address>) =
+        if config.dry_run {
+            info!("Dry-run mode enabled — proofs will be sourced but NOT submitted on-chain");
+            (Arc::new(crate::DryRunProposer), None)
+        } else {
+            let signing = config
+                .signing
+                .ok_or_else(|| eyre::eyre!("signing config required when not in dry-run mode"))?;
+            let tx_config = config.tx_manager.ok_or_else(|| {
+                eyre::eyre!("tx manager config required when not in dry-run mode")
+            })?;
+
+            let l1_tx_provider = alloy_provider::RootProvider::new_http(config.l1_eth_rpc.clone());
+            let l1_chain_id = l1_tx_provider
+                .get_chain_id()
+                .await
+                .map_err(|e| eyre::eyre!("failed to fetch L1 chain ID: {e}"))?;
+            let tx_manager = SimpleTxManager::new(
+                l1_tx_provider,
+                signing,
+                tx_config,
+                l1_chain_id,
+                Arc::new(BaseTxMetrics::new("proposer")),
+            )
+            .await
+            .map_err(|e| eyre::eyre!("failed to construct tx manager: {e}"))?;
+            let addr = tx_manager.sender_address();
+            info!(%addr, "Transaction manager initialized");
+
+            let submitter = ProposalSubmitter::new(
+                tx_manager,
+                config.dispute_game_factory_addr,
+                config.game_type,
+                init_bond,
+            );
+            (Arc::new(submitter), Some(addr))
+        };
     info!("Output proposer initialized");
 
     // ── 6. Create driver ───────────────────────────────────────────────────
@@ -227,11 +240,12 @@ pub async fn run(config: ProposerConfig) -> Result<()> {
         tokio::spawn(async move { serve(addr, ready_flag, admin_driver, health_cancel).await })
     };
 
-    // ── 8. Start balance monitor (if metrics enabled) ────────────────────
-    let balance_handle: Option<JoinHandle<()>> = if config.metrics.enabled {
-        let handle =
-            tokio::spawn(balance_monitor(Arc::clone(&l1_client), proposer_address, cancel.clone()));
-        info!(%proposer_address, "Balance monitor started");
+    // ── 8. Start balance monitor (if metrics enabled and not dry-run) ───
+    let balance_handle: Option<JoinHandle<()>> = if config.metrics.enabled
+        && let Some(addr) = proposer_address
+    {
+        let handle = tokio::spawn(balance_monitor(Arc::clone(&l1_client), addr, cancel.clone()));
+        info!(%addr, "Balance monitor started");
         Some(handle)
     } else {
         None


### PR DESCRIPTION
## Summary

- Adds `--dry-run` / `BASE_PROPOSER_DRY_RUN` flag to the proposer that runs the full proof pipeline (state recovery, proof request, reorg check) but skips L1 transaction submission
- Replaces `ProposalSubmitter` with a `DryRunProposer` that logs proposal details without creating dispute games
- Makes signing and tx-manager configuration optional in dry-run mode, allowing the proposer to run without a private key

## Motivation

Enables monitoring and testing of the proof pipeline without submitting transactions on-chain. Useful for:
- Validating prover connectivity and proof generation in staging/test environments
- Debugging the proposer flow without needing signing keys
- Dry-running infrastructure changes before going live

## Changes

| File | Change |
|---|---|
| `cli.rs` | Added `--dry-run` flag to `ProposerArgs` (default: `false`) |
| `config.rs` | Added `dry_run` field; made `signing`/`tx_manager` `Option<_>` (skipped in dry-run); added test |
| `output_proposer.rs` | Added `DryRunProposer` implementing `OutputProposer` with info-level logging |
| `service.rs` | Conditionally constructs `DryRunProposer` or `ProposalSubmitter`; skips `TxManager`/signer/balance-monitor in dry-run |
| `lib.rs` | Added `DryRunProposer` to re-exports |

## Usage

```bash
proposer --dry-run \
  --prover-rpc http://... \
  --l1-eth-rpc http://... \
  --l2-eth-rpc http://... \
  --rollup-rpc http://... \
  --anchor-state-registry-addr 0x... \
  --dispute-game-factory-addr 0x... \
  --game-type 1 \
  --tee-image-hash 0x...
```

No `--private-key` or `--signer-*` flags needed in dry-run mode.