### PR TITLE
fix: Skip risc0 Metal kernel builds via Justfile and document prove feature gate

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -1,7 +1,8 @@
-# Skip risc0-sys Metal GPU kernel compilation on macOS. These kernels are only
-# needed for GPU-accelerated local proving, which is not a supported path —
-# proving goes through Bonsai (remote) or dev-mode (mock).
-export RISC0_SKIP_BUILD_KERNELS := "1"
+# On macOS, skip risc0-sys kernel compilation for check/clippy commands.
+# The kernels require Xcode (Metal) on macOS but are only needed for linking
+# (cargo build), not for type-checking (cargo check/clippy). CI builds run
+# on Linux where CPU kernels compile without issue.
+_skip_kernels := if os() == "macos" { "RISC0_SKIP_BUILD_KERNELS=1" } else { "" }
 
 set positional-arguments := true
 
@@ -178,15 +179,15 @@ format-fix:
 
 # Checks clippy
 check-clippy: build-contracts
-    cargo clippy --workspace --all-targets -- -D warnings
+    {{_skip_kernels}} cargo clippy --workspace --all-targets -- -D warnings
 
 # Checks clippy with ci profile for minimal disk usage
 check-clippy-ci: build-contracts
-    cargo clippy --locked --workspace --all-targets --profile ci -- -D warnings
+    {{_skip_kernels}} cargo clippy --locked --workspace --all-targets --profile ci -- -D warnings
 
 # Fixes any clippy issues
 clippy-fix:
-    cargo clippy --workspace --all-targets --fix --allow-dirty --allow-staged
+    {{_skip_kernels}} cargo clippy --workspace --all-targets --fix --allow-dirty --allow-staged
 
 # Builds the workspace with release
 build:

--- a/Justfile
+++ b/Justfile
@@ -1,3 +1,8 @@
+# Skip risc0-sys Metal GPU kernel compilation on macOS. These kernels are only
+# needed for GPU-accelerated local proving, which is not a supported path —
+# proving goes through Bonsai (remote) or dev-mode (mock).
+export RISC0_SKIP_BUILD_KERNELS := "1"
+
 set positional-arguments := true
 
 mod tee 'crates/proof/tee'

--- a/Justfile
+++ b/Justfile
@@ -174,7 +174,7 @@ check-format:
 
 # Fixes any formatting issues
 format-fix:
-    cargo fix --allow-dirty --allow-staged --workspace
+    {{_skip_kernels}} cargo fix --allow-dirty --allow-staged --workspace
     cargo +nightly fmt --all
 
 # Checks clippy
@@ -220,7 +220,7 @@ clean:
 # Checks if there are any unused dependencies
 check-udeps: build-contracts
     @command -v cargo-udeps >/dev/null 2>&1 || cargo install cargo-udeps
-    cargo +nightly udeps --locked --workspace --all-features --all-targets
+    {{_skip_kernels}} cargo +nightly udeps --locked --workspace --all-features --all-targets
 
 # Checks crate dependency boundary rules
 check-crate-deps:

--- a/crates/proof/tee/nitro-attestation-prover/Cargo.toml
+++ b/crates/proof/tee/nitro-attestation-prover/Cargo.toml
@@ -20,8 +20,10 @@ thiserror.workspace = true
 async-trait.workspace = true
 alloy-primitives.workspace = true
 
-# Proving backends (behind `prove` feature to avoid pulling in risc0-sys
-# and its Metal kernel build requirement on macOS)
+# Proving backends (behind `prove` feature). This serves two purposes:
+# 1. Avoids pulling in risc0-sys and its Metal kernel build on macOS
+# 2. Reduces compile times for consumers that only need the trait/types/errors
+#    (e.g. the registrar library compiles in seconds without `prove`)
 url = { workspace = true, optional = true }
 tracing = { workspace = true, optional = true }
 boundless-market = { workspace = true, optional = true }

--- a/crates/proof/tee/nitro-attestation-prover/src/lib.rs
+++ b/crates/proof/tee/nitro-attestation-prover/src/lib.rs
@@ -7,6 +7,9 @@ pub use error::{ProverError, Result};
 mod types;
 pub use types::{AttestationProof, AttestationProofProvider};
 
+// Prover implementations are behind the `prove` feature to avoid pulling in
+// risc0-sys (Metal kernel builds on macOS) and to reduce compile times for
+// consumers that only need the trait, types, and error definitions.
 #[cfg(feature = "prove")]
 mod direct;
 #[cfg(feature = "prove")]


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                                        
                                                                                                                                                                                                                                                    
- Sets `RISC0_SKIP_BUILD_KERNELS=1` globally in the Justfile so all `just` commands (`ci`, `build-ci`, `check-clippy`, etc.) skip `risc0-sys` Metal GPU kernel compilation on macOS — these kernels are only needed for GPU-accelerated local proving, which is not a supported path (proving uses Bonsai remote or dev-mode)
- Adds comments in `Cargo.toml` and `lib.rs` explaining the dual purpose of the `prove` feature gate: avoiding Metal kernel builds AND reducing compile times for consumers that only need the trait / types / errors

## Context

Follow-up to CHAIN-3595. The feature gate correctly prevents `risc0-sys` from being compiled when the `prove` feature is not enabled, but the registrar binary (`bin/prover-registrar`) legitimately enables `prove` and is in `default-members`. The `Justfile` env var ensures Metal kernel compilation is skipped regardless.

## Test plan

- [x] `just check-clippy` passes on macOS without Xcode Metal tools
- [x] `cargo check -p base-proof-tee-registrar-bin` builds clean
- [x] No impact on Bonsai remote proving, Boundless, or dev-mode