### PR TITLE
fix(stale): Update Stale Workflow Exemptions And Timing

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -12,6 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       issues: write
+      pull-requests: write
     steps:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@95d9a5deda9de15063e7595e9719c11c38c90ae2 # v2.13.2
@@ -23,7 +24,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
         run: |
-          MAINTAINERS="refcell danyalprout cody-wang-cb haardikk21 meyer9 wlawt niran mw2000"
+          MAINTAINERS="refcell danyalprout cody-wang-cb haardikk21 meyer9 wlawt niran mw2000 kmchicoine jackchuma BrianBland 0x00101010 jowparks leopoldjoy"
           for maintainer in $MAINTAINERS; do
             gh issue list \
               --repo "$REPO" \
@@ -32,6 +33,25 @@ jobs:
               --json number \
               --jq '.[].number' | while read -r issue_num; do
                 gh issue edit "$issue_num" \
+                  --repo "$REPO" \
+                  --add-label "M-prevent-stale" 2>/dev/null || true
+            done
+          done
+
+      - name: Exempt core maintainer PRs from stale
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+        run: |
+          MAINTAINERS="refcell danyalprout cody-wang-cb haardikk21 meyer9 wlawt niran mw2000 kmchicoine jackchuma BrianBland 0x00101010 jowparks leopoldjoy"
+          for maintainer in $MAINTAINERS; do
+            gh pr list \
+              --repo "$REPO" \
+              --author "$maintainer" \
+              --state open \
+              --json number \
+              --jq '.[].number' | while read -r pr_num; do
+                gh pr edit "$pr_num" \
                   --repo "$REPO" \
                   --add-label "M-prevent-stale" 2>/dev/null || true
             done
@@ -52,8 +72,8 @@ jobs:
 
       - uses: actions/stale@5f858e3efba33a5ca4407a664cc011ad407f2008 # v10.1.0
         with:
-          days-before-stale: 14
-          days-before-close: 5
+          days-before-stale: 5
+          days-before-close: 1
           stale-issue-message: 'This issue has been automatically marked as stale because it has not had recent activity. It will be closed if no further activity occurs. Thank you for your contributions.'
           stale-pr-message: 'This pull request has been automatically marked as stale because it has not had recent activity. It will be closed if no further activity occurs. Thank you for your contributions.'
           close-issue-message: 'This issue was closed because it has been inactive for 5 days since being marked as stale.'
@@ -61,4 +81,4 @@ jobs:
           stale-issue-label: F-stale
           stale-pr-label: F-stale
           exempt-issue-labels: 'M-keep-open,M-prevent-stale'
-          exempt-pr-labels: M-keep-open
+          exempt-pr-labels: 'M-keep-open,M-prevent-stale'


### PR DESCRIPTION
## Summary
Updates the stale labeling workflow to mark issues and PRs stale after 5 days of inactivity and close them 1 day after being marked stale. Extends stale exemption to maintainer-authored PRs by auto-applying the M-prevent-stale label at the start of each run, mirroring the existing behavior for issues. Expands the exempt maintainers list to include Kaley Chicoine, Jack Chuma, Brian Bland, Francis Li, Joe Parks, and Leopold Joy.