### PR TITLE
fix(ci): Skip Claude Review For External Contributor PRs

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -19,6 +19,8 @@ jobs:
     name: Review PR
     # Note: This job runs on the BaseRunnerGroup to be able to access LLM Gateway
     # It will not work on other runners
+    # Skip for external contributor PRs (forks) — secrets and runner group are unavailable
+    if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on:
       group: BaseRunnerGroup
     steps:


### PR DESCRIPTION
## Summary
The Claude code review job was failing for external contributor PRs because the BaseRunnerGroup and LLM Gateway secrets are unavailable to fork-based pull requests. This adds an if condition to skip the job entirely when the PR head repo differs from the base repo, so external contributor CI no longer fails on this step.