### PR TITLE
fix(actions): Persist Batcher Across Activation Tests

### DIFF
--- a/actions/harness/tests/base_v1_activation.rs
+++ b/actions/harness/tests/base_v1_activation.rs
@@ -31,11 +31,9 @@ async fn base_v1_derivation_crosses_activation_boundary() {
     let l1_chain = SharedL1Chain::from_blocks(h.l1.chain().to_vec());
     let mut builder = h.create_l2_sequencer(l1_chain);
 
+    let mut batcher = Batcher::new(ActionL2Source::new(), &h.rollup_config, batcher_cfg.clone());
     for _ in 1..=4u64 {
-        let block = builder.build_next_block();
-        let mut source = ActionL2Source::new();
-        source.push(block);
-        let mut batcher = Batcher::new(source, &h.rollup_config, batcher_cfg.clone());
+        batcher.push_block(builder.build_next_block());
         batcher.advance(&mut h.l1).await;
     }
 


### PR DESCRIPTION
## Summary
The `base_v1_derivation_crosses_activation_boundary` test was constructing a new `Batcher` on every loop iteration, creating a separate channel for each L2 block rather than persisting state across submissions. This follows the established pattern used throughout the action test suite — hoisting `Batcher::new` before the loop and using `push_block` per iteration. The fix aligns with how every other activation boundary test handles multi-block submission.