### PR TITLE
fix(actions): Consolidate Helpers, Remove Stale Refs

### DIFF
--- a/actions/harness/src/harness.rs
+++ b/actions/harness/src/harness.rs
@@ -1,13 +1,14 @@
 use std::sync::Arc;
 
 use alloy_eips::BlockNumHash;
+use base_alloy_consensus::{OpBlock, OpTxEnvelope};
 use base_consensus_genesis::{L1ChainConfig, RollupConfig};
-use base_protocol::{BlockInfo, L2BlockInfo};
+use base_protocol::{BlockInfo, L1BlockInfoTx, L2BlockInfo};
 
 use crate::{
     ActionBlobDataSource, ActionDataSource, ActionL1ChainProvider, ActionL2ChainProvider,
-    BlobVerifierPipeline, L1Miner, L1MinerConfig, L2Sequencer, L2Verifier, SharedL1Chain,
-    VerifierPipeline, block_info_from,
+    ActionL2Source, BlobVerifierPipeline, L1Miner, L1MinerConfig, L2Sequencer, L2Verifier,
+    SharedL1Chain, VerifierPipeline, block_info_from,
 };
 
 /// Top-level test harness that owns all actors for a single action test.
@@ -109,6 +110,42 @@ impl ActionTestHarness {
         let system_config = self.rollup_config.genesis.system_config.unwrap_or_default();
 
         L2Sequencer::new(genesis_head, l1_chain, self.rollup_config.clone(), system_config)
+    }
+
+    /// Decode the [`L1BlockInfoTx`] from the first deposit transaction of an
+    /// [`OpBlock`].
+    ///
+    /// Every L2 block begins with an L1 info deposit whose calldata encodes the
+    /// active [`L1BlockInfoTx`] variant (Bedrock / Ecotone / Isthmus / Jovian).
+    /// Use this to assert that the correct format is used at hardfork boundaries.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the first transaction is not a deposit or if the calldata
+    /// cannot be decoded.
+    pub fn l1_info_from_block(block: &OpBlock) -> L1BlockInfoTx {
+        let OpTxEnvelope::Deposit(sealed) = &block.body.transactions[0] else {
+            panic!("first transaction must be a deposit");
+        };
+        L1BlockInfoTx::decode_calldata(sealed.inner().input.as_ref())
+            .expect("L1 info calldata must decode")
+    }
+
+    /// Build an [`ActionL2Source`] pre-populated with `n` real [`OpBlock`]s
+    /// starting from L2 genesis.
+    ///
+    /// Use this when a test needs a ready-made block source and does not
+    /// require direct access to the underlying [`L2Sequencer`].
+    ///
+    /// [`OpBlock`]: base_alloy_consensus::OpBlock
+    pub fn create_l2_source(&self, n: u64) -> ActionL2Source {
+        let chain = SharedL1Chain::from_blocks(self.l1.chain().to_vec());
+        let mut sequencer = self.create_l2_sequencer(chain);
+        let mut source = ActionL2Source::new();
+        for _ in 0..n {
+            source.push(sequencer.build_next_block());
+        }
+        source
     }
 
     /// Create an [`L2Verifier`] wired to the harness's L1 chain.

--- a/actions/harness/src/lib.rs
+++ b/actions/harness/src/lib.rs
@@ -7,7 +7,9 @@ mod action;
 pub use action::{Action, L2BlockProvider};
 
 mod miner;
-pub use miner::{L1Block, L1Miner, L1MinerConfig, PendingTx, ReorgError, block_info_from};
+pub use miner::{
+    L1Block, L1Miner, L1MinerConfig, PendingTx, ReorgError, UserDeposit, block_info_from,
+};
 
 mod l2;
 pub use l2::{

--- a/actions/harness/src/miner.rs
+++ b/actions/harness/src/miner.rs
@@ -21,6 +21,27 @@ pub fn block_info_from(block: &L1Block) -> BlockInfo {
     }
 }
 
+/// Parameters for a user deposit transaction, passed to [`L1Miner::enqueue_user_deposit`].
+///
+/// Mirrors the fields of the on-chain `OptimismPortal.sol` `TransactionDeposited` event.
+#[derive(Debug, Clone)]
+pub struct UserDeposit {
+    /// The L1 portal contract address that emits the deposit event.
+    pub deposit_contract: Address,
+    /// The L1 sender address.
+    pub from: Address,
+    /// The L2 recipient address.
+    pub to: Address,
+    /// ETH value to mint on L2 (in wei, as u128).
+    pub mint: u128,
+    /// ETH value to transfer on L2.
+    pub value: U256,
+    /// Gas limit for the L2 deposit transaction.
+    pub gas_limit: u64,
+    /// Calldata for the L2 deposit transaction.
+    pub data: Vec<u8>,
+}
+
 /// Error returned by [`L1Miner::reorg_to`].
 #[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
 pub enum ReorgError {
@@ -313,18 +334,9 @@ impl L1Miner {
     /// Mirrors the on-chain `OptimismPortal.sol` `TransactionDeposited` event.
     /// The derivation pipeline reads this from L1 receipts to include the
     /// deposit in the corresponding L2 block's attribute set.
-    pub fn enqueue_user_deposit(
-        &mut self,
-        deposit_contract: Address,
-        from: Address,
-        to: Address,
-        mint: u128,
-        value: U256,
-        gas_limit: u64,
-        data: &[u8],
-    ) {
+    pub fn enqueue_user_deposit(&mut self, deposit: &UserDeposit) {
         // opaqueData: mint(32) + value(32) + gas_limit(8) + isCreation(1) + calldata
-        let opaque_len = 32 + 32 + 8 + 1 + data.len();
+        let opaque_len = 32 + 32 + 8 + 1 + deposit.data.len();
         let opaque_padded = opaque_len.div_ceil(32) * 32;
         let total_len = 64 + opaque_padded; // offset(32) + length(32) + padded opaqueData
 
@@ -333,19 +345,19 @@ impl L1Miner {
         log_data[56..64].copy_from_slice(&(opaque_len as u64).to_be_bytes()); // length
 
         let base = 64;
-        log_data[base + 16..base + 32].copy_from_slice(&mint.to_be_bytes());
-        log_data[base + 32..base + 64].copy_from_slice(&value.to_be_bytes::<32>());
-        log_data[base + 64..base + 72].copy_from_slice(&gas_limit.to_be_bytes());
+        log_data[base + 16..base + 32].copy_from_slice(&deposit.mint.to_be_bytes());
+        log_data[base + 32..base + 64].copy_from_slice(&deposit.value.to_be_bytes::<32>());
+        log_data[base + 64..base + 72].copy_from_slice(&deposit.gas_limit.to_be_bytes());
         log_data[base + 72] = 0; // isCreation: false
-        log_data[base + 73..base + 73 + data.len()].copy_from_slice(data);
+        log_data[base + 73..base + 73 + deposit.data.len()].copy_from_slice(&deposit.data);
 
         let mut from_topic = [0u8; 32];
-        from_topic[12..32].copy_from_slice(from.as_slice());
+        from_topic[12..32].copy_from_slice(deposit.from.as_slice());
         let mut to_topic = [0u8; 32];
-        to_topic[12..32].copy_from_slice(to.as_slice());
+        to_topic[12..32].copy_from_slice(deposit.to.as_slice());
 
         self.enqueue_log(Log {
-            address: deposit_contract,
+            address: deposit.deposit_contract,
             data: LogData::new_unchecked(
                 vec![
                     DEPOSIT_EVENT_ABI_HASH,

--- a/actions/harness/src/miner.rs
+++ b/actions/harness/src/miner.rs
@@ -2,10 +2,11 @@ use std::sync::Arc;
 
 use alloy_consensus::{Header, Receipt};
 use alloy_eips::eip4844::Blob;
-use alloy_primitives::{Address, B256, Bytes, Log};
+use alloy_primitives::{Address, B256, Bytes, Log, LogData, U256};
 use base_batcher_encoder::FrameEncoder;
 use base_blobs::BlobEncoder;
-use base_protocol::{BlockInfo, Frame};
+use base_consensus_genesis::{CONFIG_UPDATE_EVENT_VERSION_0, CONFIG_UPDATE_TOPIC};
+use base_protocol::{BlockInfo, DEPOSIT_EVENT_ABI_HASH, DEPOSIT_EVENT_VERSION_0, Frame};
 use tracing::info;
 
 use crate::Action;
@@ -216,6 +217,145 @@ impl L1Miner {
     /// looks blobs up from this sidecar by versioned hash.
     pub fn enqueue_blob(&mut self, hash: B256, blob: Box<Blob>) {
         self.pending_blobs.push((hash, blob));
+    }
+
+    /// Queue a `ConfigUpdate(Batcher)` log for the next mined block.
+    ///
+    /// Encodes a batcher address rotation to `new_batcher`. The derivation
+    /// pipeline reads this from L1 receipts and updates its internal
+    /// [`SystemConfig`] for subsequent L2 blocks.
+    ///
+    /// [`SystemConfig`]: base_consensus_genesis::SystemConfig
+    pub fn enqueue_batcher_update(&mut self, l1_sys_cfg_addr: Address, new_batcher: Address) {
+        let mut data = [0u8; 96];
+        data[31] = 0x20; // pointer → offset 32
+        data[63] = 0x20; // length  → 32 bytes
+        data[76..96].copy_from_slice(new_batcher.as_slice()); // address, right-aligned
+        self.enqueue_log(Log {
+            address: l1_sys_cfg_addr,
+            data: LogData::new_unchecked(
+                vec![CONFIG_UPDATE_TOPIC, CONFIG_UPDATE_EVENT_VERSION_0, B256::ZERO],
+                data.into(),
+            ),
+        });
+    }
+
+    /// Queue a `ConfigUpdate(GasConfig)` log for the next mined block.
+    ///
+    /// Encodes a GPO `overhead` and `scalar` update. The derivation pipeline
+    /// applies this through the `SystemConfig` update mechanism.
+    pub fn enqueue_gas_config_update(
+        &mut self,
+        l1_sys_cfg_addr: Address,
+        overhead: u64,
+        scalar: u64,
+    ) {
+        let mut data = [0u8; 128];
+        data[31] = 0x20; // pointer = 32
+        data[63] = 0x40; // length  = 64
+        data[88..96].copy_from_slice(&overhead.to_be_bytes());
+        data[120..128].copy_from_slice(&scalar.to_be_bytes());
+        let mut update_type = [0u8; 32];
+        update_type[31] = 1; // GasConfig = 1
+        self.enqueue_log(Log {
+            address: l1_sys_cfg_addr,
+            data: LogData::new_unchecked(
+                vec![CONFIG_UPDATE_TOPIC, CONFIG_UPDATE_EVENT_VERSION_0, B256::from(update_type)],
+                data.into(),
+            ),
+        });
+    }
+
+    /// Queue a `ConfigUpdate(GasLimit)` log for the next mined block.
+    pub fn enqueue_gas_limit_update(&mut self, l1_sys_cfg_addr: Address, gas_limit: u64) {
+        let mut data = [0u8; 96];
+        data[31] = 0x20; // pointer = 32
+        data[63] = 0x20; // length  = 32
+        data[88..96].copy_from_slice(&gas_limit.to_be_bytes());
+        let mut update_type = [0u8; 32];
+        update_type[31] = 2; // GasLimit = 2
+        self.enqueue_log(Log {
+            address: l1_sys_cfg_addr,
+            data: LogData::new_unchecked(
+                vec![CONFIG_UPDATE_TOPIC, CONFIG_UPDATE_EVENT_VERSION_0, B256::from(update_type)],
+                data.into(),
+            ),
+        });
+    }
+
+    /// Queue a `ConfigUpdate(OperatorFee)` log for the next mined block.
+    ///
+    /// Encodes an operator fee update with the given `scalar` and `constant`.
+    pub fn enqueue_operator_fee_update(
+        &mut self,
+        l1_sys_cfg_addr: Address,
+        operator_fee_scalar: u32,
+        operator_fee_constant: u64,
+    ) {
+        let mut data = [0u8; 96];
+        data[31] = 0x20; // pointer = 32
+        data[63] = 0x20; // length  = 32
+        data[84..88].copy_from_slice(&operator_fee_scalar.to_be_bytes());
+        data[88..96].copy_from_slice(&operator_fee_constant.to_be_bytes());
+        let mut update_type = [0u8; 32];
+        update_type[31] = 5; // OperatorFee = 5
+        self.enqueue_log(Log {
+            address: l1_sys_cfg_addr,
+            data: LogData::new_unchecked(
+                vec![CONFIG_UPDATE_TOPIC, CONFIG_UPDATE_EVENT_VERSION_0, B256::from(update_type)],
+                data.into(),
+            ),
+        });
+    }
+
+    /// Queue a `TransactionDeposited` log for the next mined block.
+    ///
+    /// Mirrors the on-chain `OptimismPortal.sol` `TransactionDeposited` event.
+    /// The derivation pipeline reads this from L1 receipts to include the
+    /// deposit in the corresponding L2 block's attribute set.
+    pub fn enqueue_user_deposit(
+        &mut self,
+        deposit_contract: Address,
+        from: Address,
+        to: Address,
+        mint: u128,
+        value: U256,
+        gas_limit: u64,
+        data: &[u8],
+    ) {
+        // opaqueData: mint(32) + value(32) + gas_limit(8) + isCreation(1) + calldata
+        let opaque_len = 32 + 32 + 8 + 1 + data.len();
+        let opaque_padded = opaque_len.div_ceil(32) * 32;
+        let total_len = 64 + opaque_padded; // offset(32) + length(32) + padded opaqueData
+
+        let mut log_data = vec![0u8; total_len];
+        log_data[24..32].copy_from_slice(&32u64.to_be_bytes()); // offset
+        log_data[56..64].copy_from_slice(&(opaque_len as u64).to_be_bytes()); // length
+
+        let base = 64;
+        log_data[base + 16..base + 32].copy_from_slice(&mint.to_be_bytes());
+        log_data[base + 32..base + 64].copy_from_slice(&value.to_be_bytes::<32>());
+        log_data[base + 64..base + 72].copy_from_slice(&gas_limit.to_be_bytes());
+        log_data[base + 72] = 0; // isCreation: false
+        log_data[base + 73..base + 73 + data.len()].copy_from_slice(data);
+
+        let mut from_topic = [0u8; 32];
+        from_topic[12..32].copy_from_slice(from.as_slice());
+        let mut to_topic = [0u8; 32];
+        to_topic[12..32].copy_from_slice(to.as_slice());
+
+        self.enqueue_log(Log {
+            address: deposit_contract,
+            data: LogData::new_unchecked(
+                vec![
+                    DEPOSIT_EVENT_ABI_HASH,
+                    B256::from(from_topic),
+                    B256::from(to_topic),
+                    DEPOSIT_EVENT_VERSION_0,
+                ],
+                log_data.into(),
+            ),
+        });
     }
 
     /// Return the most recently mined block.

--- a/actions/harness/src/test_rollup_config.rs
+++ b/actions/harness/src/test_rollup_config.rs
@@ -11,6 +11,11 @@ pub struct TestRollupConfigBuilder {
 }
 
 impl TestRollupConfigBuilder {
+    /// Returns the Base mainnet [`RollupConfig`] from the chain registry.
+    pub fn mainnet() -> &'static RollupConfig {
+        Registry::rollup_config(8453).expect("Base mainnet config must exist in the registry")
+    }
+
     /// Starts from the Base mainnet config and applies the common harness overrides.
     ///
     /// This preserves the existing harness-test behavior by wiring the test batcher

--- a/actions/harness/src/verifier.rs
+++ b/actions/harness/src/verifier.rs
@@ -353,8 +353,8 @@ impl<P: Pipeline + SignalReceiver + Debug + Send> L2Verifier<P> {
 
     /// Signal the pipeline that a new L1 block is available.
     ///
-    /// This is equivalent to op-e2e's `ActL1HeadSignal`. The [`IndexedTraversal`]
-    /// stage will accept the block only if it is the next sequential block
+    /// The [`IndexedTraversal`] stage will accept the block only if it is the
+    /// next sequential block
     /// (number = current + 1 and `parent_hash` matches).
     ///
     /// [`IndexedTraversal`]: base_consensus_derive::IndexedTraversal
@@ -548,9 +548,8 @@ impl<P: Pipeline + SignalReceiver + Debug + Send> L2Verifier<P> {
     /// or until the pipeline reaches EOF (goes idle), or until `max_steps` is
     /// exhausted.
     ///
-    /// This is the Rust equivalent of op-e2e's `ActL2EventsUntil`. It drives
-    /// the pipeline forward step-by-step and hands each raw [`StepResult`] to
-    /// the caller's predicate. Use it when a test needs to stop at a specific
+    /// Drives the pipeline forward step-by-step and hands each raw
+    /// [`StepResult`] to the caller's predicate. Use it when a test needs to stop at a specific
     /// derivation outcome without knowing in advance how many steps it takes to
     /// get there.
     ///
@@ -723,8 +722,7 @@ impl<P: Pipeline + SignalReceiver + Debug + Send> L2Verifier<P> {
 
     /// Inject an unsafe L2 block as if received via P2P gossip.
     ///
-    /// Equivalent to op-e2e's `ActL2UnsafeGossipReceive`. The block's header is
-    /// used to advance `unsafe_head`; the block hash is also registered in
+    /// The block's header is used to advance `unsafe_head`; the block hash is also registered in
     /// `block_hashes` so that subsequent derivation can build a consistent
     /// `parent_hash` chain without a separate [`register_block_hash`] call.
     ///

--- a/actions/harness/tests/batch_submission.rs
+++ b/actions/harness/tests/batch_submission.rs
@@ -5,20 +5,6 @@ use base_action_harness::{
     EncoderConfig, L1MinerConfig, SharedL1Chain, TestRollupConfigBuilder,
 };
 
-/// Build an [`ActionL2Source`] pre-populated with `n` real [`OpBlock`]s from
-/// the genesis of the given harness.
-///
-/// [`OpBlock`]: base_alloy_consensus::OpBlock
-fn make_source(h: &ActionTestHarness, n: u64) -> ActionL2Source {
-    let chain = SharedL1Chain::from_blocks(h.l1.chain().to_vec());
-    let mut sequencer = h.create_l2_sequencer(chain);
-    let mut source = ActionL2Source::new();
-    for _ in 0..n {
-        source.push(sequencer.build_next_block());
-    }
-    source
-}
-
 // ---------------------------------------------------------------------------
 // Batcher: persistent pipeline end-to-end path
 // ---------------------------------------------------------------------------
@@ -28,7 +14,7 @@ async fn batcher_mines_block_with_submissions() {
     let mut h = ActionTestHarness::default();
     let cfg = BatcherConfig::default();
 
-    let source = make_source(&h, 3);
+    let source = h.create_l2_source(3);
     let mut batcher = Batcher::new(source, &h.rollup_config, cfg);
     batcher.advance(&mut h.l1).await;
 
@@ -45,7 +31,7 @@ async fn batcher_span_batch_mode() {
     let mut h = ActionTestHarness::default();
     let cfg = BatcherConfig { batch_type: BatchType::Span, ..Default::default() };
 
-    let source = make_source(&h, 3);
+    let source = h.create_l2_source(3);
     let mut batcher = Batcher::new(source, &h.rollup_config, cfg);
     batcher.advance(&mut h.l1).await;
 

--- a/actions/harness/tests/batcher_hardfork_transitions.rs
+++ b/actions/harness/tests/batcher_hardfork_transitions.rs
@@ -8,8 +8,6 @@ use base_consensus_genesis::{GRANITE_CHANNEL_TIMEOUT, HardForkConfig};
 
 // ---------------------------------------------------------------------------
 // A. Span batch with non-empty hardfork transition block is rejected
-//
-// op-e2e ref: TestHardforkMiddleOfSpanBatch
 // ---------------------------------------------------------------------------
 
 /// A span batch covering blocks 1–4 where block 3 is the first Jovian block
@@ -137,8 +135,6 @@ async fn span_batch_with_non_empty_transition_block_rejected() {
 
 // ---------------------------------------------------------------------------
 // B. Mixed singular and span batches in the same derivation run
-//
-// op-e2e ref: TestMixOfBatchesAfterHardfork
 // ---------------------------------------------------------------------------
 
 /// After Fjord (which cascades to activate Delta), the pipeline must accept
@@ -358,8 +354,6 @@ async fn granite_channel_timeout_enforced() {
 
 // ---------------------------------------------------------------------------
 // D. Jovian SingleBatch transition block is deposit-only
-//
-// op-e2e ref: TestHardforkMiddleOfSingularBatch
 // ---------------------------------------------------------------------------
 
 /// When a `SingleBatch` is submitted for the first Jovian upgrade block (block 3

--- a/actions/harness/tests/batcher_sequencer_drift.rs
+++ b/actions/harness/tests/batcher_sequencer_drift.rs
@@ -16,8 +16,6 @@ use base_action_harness::{
 /// boundary is dropped. Only deposit-only (default) blocks are produced for
 /// the over-drift slots.
 ///
-/// This is the Rust analogue of op-e2e's `MaxSequencerDriftFnAfterDelta` test.
-///
 /// ## Setup
 ///
 /// - Fjord active → `max_sequencer_drift = 1800 s`, `block_time = 300 s`, L1

--- a/actions/harness/tests/derivation.rs
+++ b/actions/harness/tests/derivation.rs
@@ -3,16 +3,16 @@
 use std::sync::Arc;
 
 use alloy_eips::BlockNumHash;
-use alloy_primitives::{Address, B256, Bytes, LogData, U256};
+use alloy_primitives::{Address, B256, Bytes, U256};
 use base_action_harness::{
     ActionDataSource, ActionL1ChainProvider, ActionL2ChainProvider, ActionL2Source,
     ActionTestHarness, BatchType, Batcher, BatcherConfig, DaType, EncoderConfig, L1MinerConfig,
     L2Sequencer, L2Verifier, PendingTx, SharedL1Chain, StepResult, TestRollupConfigBuilder,
     block_info_from,
 };
-use base_consensus_genesis::{CONFIG_UPDATE_EVENT_VERSION_0, CONFIG_UPDATE_TOPIC, L1ChainConfig};
+use base_consensus_genesis::{L1ChainConfig};
 use base_protocol::{
-    BlockInfo, DEPOSIT_EVENT_ABI_HASH, DEPOSIT_EVENT_VERSION_0, DERIVATION_VERSION_0, L2BlockInfo,
+    BlockInfo, DERIVATION_VERSION_0, L2BlockInfo,
 };
 
 /// The derivation pipeline reads a single batcher frame from L1 and derives
@@ -278,7 +278,6 @@ async fn reorg_and_resubmit_rederives_l2_block() {
 /// L2 block from whichever fork is currently canonical, without accumulating
 /// stale channel or frame data from a previous fork.
 ///
-/// This is the analogue of op-e2e's `ReorgFlipFlop` scenario.
 #[tokio::test]
 async fn reorg_flip_flop() {
     let batcher_cfg = BatcherConfig {
@@ -491,7 +490,6 @@ async fn reorg_flip_flop_empty_middle_fork() {
 /// L1 blocks 1–3 (strictly: `epoch(0) + window(4) > inclusion_block`).
 /// Submitting the batch in block 3 — the final valid slot — must succeed.
 ///
-/// This is the analogue of op-e2e's `BatchInLastPossibleBlocks` scenario.
 #[tokio::test]
 async fn batch_accepted_at_last_seq_window_block() {
     const SEQ_WINDOW: u64 = 4;
@@ -536,102 +534,6 @@ async fn batch_accepted_at_last_seq_window_block() {
     assert_eq!(verifier.l2_safe_number(), 1, "batch in last valid L1 block must be derived");
 }
 
-/// Build a `ConfigUpdate` log encoding a batcher-address rotation.
-///
-/// The log is addressed to `l1_sys_cfg_addr` so that the derivation
-/// pipeline's [`IndexedTraversal`] recognises and applies it when reading
-/// the containing block's receipts via `update_with_receipts`.
-///
-/// Log layout (mirrors the on-chain `SystemConfig.sol` event):
-/// - `topics[0]` = `CONFIG_UPDATE_TOPIC`
-/// - `topics[1]` = `CONFIG_UPDATE_EVENT_VERSION_0` (`B256::ZERO`)
-/// - `topics[2]` = `B256::ZERO` (`UpdateType::BatcherAddress = 0`)
-/// - `data`      = ABI-encoded `bytes`: pointer(0x20) ++ length(0x20) ++
-///   right-aligned 20-byte batcher address
-///
-/// [`IndexedTraversal`]: base_consensus_derive::IndexedTraversal
-fn batcher_update_log(l1_sys_cfg_addr: Address, new_batcher: Address) -> alloy_primitives::Log {
-    // 96 bytes: pointer (32) + length (32) + padded address (32).
-    let mut data = [0u8; 96];
-    data[31] = 0x20; // pointer → offset 32
-    data[63] = 0x20; // length  → 32 bytes
-    data[76..96].copy_from_slice(new_batcher.as_slice()); // address, right-aligned
-
-    alloy_primitives::Log {
-        address: l1_sys_cfg_addr,
-        data: LogData::new_unchecked(
-            vec![CONFIG_UPDATE_TOPIC, CONFIG_UPDATE_EVENT_VERSION_0, B256::ZERO],
-            data.into(),
-        ),
-    }
-}
-
-/// Build a `TransactionDeposited` log encoding a user deposit.
-///
-/// The log is addressed to the rollup config's `deposit_contract_address` so
-/// that the derivation pipeline's attributes builder picks it up and includes
-/// the deposit transaction in the derived L2 block.
-///
-/// Log layout (mirrors the on-chain `OptimismPortal.sol` event):
-/// - `topics[0]` = `DEPOSIT_EVENT_ABI_HASH`
-/// - `topics[1]` = `from` address left-padded to B256
-/// - `topics[2]` = `to` address left-padded to B256
-/// - `topics[3]` = `DEPOSIT_EVENT_VERSION_0` (`B256::ZERO`)
-/// - `data`      = ABI-encoded opaqueData:
-///   offset(32) + length(32) + tightly-packed(mint(32) + value(32) + gas(8) + isCreation(1) + calldata)
-fn user_deposit_log(
-    deposit_contract: Address,
-    from: Address,
-    to: Address,
-    mint: u128,
-    value: U256,
-    gas_limit: u64,
-    data: &[u8],
-) -> alloy_primitives::Log {
-    // opaqueData: mint(32) + value(32) + gas_limit(8) + isCreation(1) + data
-    let opaque_len = 32 + 32 + 8 + 1 + data.len();
-    let opaque_padded = opaque_len.div_ceil(32) * 32;
-    let total_len = 64 + opaque_padded; // offset(32) + length(32) + padded opaqueData
-
-    let mut log_data = vec![0u8; total_len];
-
-    // offset = 32 (right-aligned u64 in 32-byte slot)
-    log_data[24..32].copy_from_slice(&32u64.to_be_bytes());
-    // length of opaqueData
-    log_data[56..64].copy_from_slice(&(opaque_len as u64).to_be_bytes());
-
-    let base = 64;
-    // mint: u128 big-endian in bytes [16..32] of a 32-byte slot (upper 16 bytes are zero)
-    log_data[base + 16..base + 32].copy_from_slice(&mint.to_be_bytes());
-    // value: U256 big-endian in 32 bytes
-    log_data[base + 32..base + 64].copy_from_slice(&value.to_be_bytes::<32>());
-    // gas_limit: u64 big-endian in 8 bytes
-    log_data[base + 64..base + 72].copy_from_slice(&gas_limit.to_be_bytes());
-    // isCreation: 0 (call, not create)
-    log_data[base + 72] = 0;
-    // calldata
-    log_data[base + 73..base + 73 + data.len()].copy_from_slice(data);
-
-    // Build from/to topics: left-padded addresses in B256
-    let mut from_topic = [0u8; 32];
-    from_topic[12..32].copy_from_slice(from.as_slice());
-    let mut to_topic = [0u8; 32];
-    to_topic[12..32].copy_from_slice(to.as_slice());
-
-    alloy_primitives::Log {
-        address: deposit_contract,
-        data: LogData::new_unchecked(
-            vec![
-                DEPOSIT_EVENT_ABI_HASH,
-                B256::from(from_topic),
-                B256::from(to_topic),
-                DEPOSIT_EVENT_VERSION_0,
-            ],
-            log_data.into(),
-        ),
-    }
-}
-
 /// A user deposit log on L1 is processed by the derivation pipeline without
 /// errors.
 ///
@@ -662,7 +564,7 @@ async fn l1_deposit_included_in_derived_l2_block() {
     let block1 = sequencer.build_next_block();
 
     // Enqueue a user deposit log: from=0xAA..AA, to=0xBB..BB, value=1 ETH, gas=100k.
-    h.l1.enqueue_log(user_deposit_log(
+    h.l1.enqueue_user_deposit(
         deposit_contract,
         Address::repeat_byte(0xAA),
         Address::repeat_byte(0xBB),
@@ -670,7 +572,7 @@ async fn l1_deposit_included_in_derived_l2_block() {
         U256::from(1_000_000_000_000_000_000u128), // 1 ETH in wei
         100_000,                                   // gas_limit
         &[],                                       // empty calldata
-    ));
+    );
 
     // Submit the batcher frame into the same L1 block as the deposit log.
     {
@@ -716,9 +618,6 @@ async fn l1_deposit_included_in_derived_l2_block() {
 ///   L1 block 4:    batcher A submits  → IGNORED (0 derived)
 ///   L1 block 5:    batcher B submits  → DERIVED (1 derived)
 ///
-/// This is the acceptance/rejection half of op-e2e's `BatcherKeyRotation`
-/// scenario (the reorg-of-rotation reversal is left for a future test once
-/// receipt log infrastructure is complete).
 ///
 /// [`IndexedTraversal`]: base_consensus_derive::IndexedTraversal
 /// [`SystemConfig`]: base_consensus_genesis::SystemConfig
@@ -758,7 +657,7 @@ async fn batcher_key_rotation_accepts_new_batcher() {
     // --- L1 block 3: rotation log only, no batch. ---
     // After the traversal processes this block and reads the ConfigUpdate log
     // from its receipts, the pipeline's internal batcher address switches to B.
-    h.l1.enqueue_log(batcher_update_log(l1_sys_cfg_addr, batcher_b.batcher_address));
+    h.l1.enqueue_batcher_update(l1_sys_cfg_addr, batcher_b.batcher_address);
     h.l1.mine_block(); // block 3: rotation receipt, no batcher tx
 
     let (mut verifier, chain) = h.create_verifier_from_sequencer(
@@ -1300,65 +1199,6 @@ async fn three_l2_blocks_derived_from_span_batch() {
 
 // ── System-config update tests ─────────────────────────────────────────────────
 
-/// Build a `ConfigUpdate` log encoding a gas-config (overhead + scalar) change.
-///
-/// Log layout mirrors `SystemConfig.sol`:
-/// - `topics[0]` = `CONFIG_UPDATE_TOPIC`
-/// - `topics[1]` = `CONFIG_UPDATE_EVENT_VERSION_0`
-/// - `topics[2]` = `B256` encoding `UpdateType::GasConfig = 1`
-/// - `data`      = 128 bytes: pointer(32=0x20) + length(64=0x40) +
-///   overhead(U256, 32 bytes) + scalar(U256, 32 bytes)
-fn gas_config_update_log(
-    l1_sys_cfg_addr: Address,
-    overhead: u64,
-    scalar: u64,
-) -> alloy_primitives::Log {
-    let mut data = [0u8; 128];
-    data[31] = 0x20; // pointer = 32
-    data[63] = 0x40; // length  = 64
-    // overhead and scalar right-aligned as big-endian u64 in U256 slots.
-    data[88..96].copy_from_slice(&overhead.to_be_bytes());
-    data[120..128].copy_from_slice(&scalar.to_be_bytes());
-
-    let mut update_type = [0u8; 32];
-    update_type[31] = 1; // GasConfig = 1
-
-    alloy_primitives::Log {
-        address: l1_sys_cfg_addr,
-        data: LogData::new_unchecked(
-            vec![CONFIG_UPDATE_TOPIC, CONFIG_UPDATE_EVENT_VERSION_0, B256::from(update_type)],
-            data.into(),
-        ),
-    }
-}
-
-/// Build a `ConfigUpdate` log encoding a gas-limit change.
-///
-/// Log layout mirrors `SystemConfig.sol`:
-/// - `topics[0]` = `CONFIG_UPDATE_TOPIC`
-/// - `topics[1]` = `CONFIG_UPDATE_EVENT_VERSION_0`
-/// - `topics[2]` = `B256` encoding `UpdateType::GasLimit = 2`
-/// - `data`      = 96 bytes: pointer(32=0x20) + length(32=0x20) +
-///   `gas_limit` (U256, 32 bytes)
-fn gas_limit_update_log(l1_sys_cfg_addr: Address, gas_limit: u64) -> alloy_primitives::Log {
-    let mut data = [0u8; 96];
-    data[31] = 0x20; // pointer = 32
-    data[63] = 0x20; // length  = 32
-    // gas_limit right-aligned as big-endian u64 in a U256 slot.
-    data[88..96].copy_from_slice(&gas_limit.to_be_bytes());
-
-    let mut update_type = [0u8; 32];
-    update_type[31] = 2; // GasLimit = 2
-
-    alloy_primitives::Log {
-        address: l1_sys_cfg_addr,
-        data: LogData::new_unchecked(
-            vec![CONFIG_UPDATE_TOPIC, CONFIG_UPDATE_EVENT_VERSION_0, B256::from(update_type)],
-            data.into(),
-        ),
-    }
-}
-
 /// A `GasConfig` system-config update committed to L1 does not disrupt ongoing
 /// derivation.
 ///
@@ -1391,7 +1231,7 @@ async fn gpo_params_change_does_not_disrupt_derivation() {
     }
 
     // L1 block 2: gas-config update log only, no batch.
-    h.l1.enqueue_log(gas_config_update_log(l1_sys_cfg_addr, 2100, 1_000_000));
+    h.l1.enqueue_gas_config_update(l1_sys_cfg_addr, 2100, 1_000_000);
     h.l1.mine_block();
 
     // L1 block 3: batch for L2 block 2.
@@ -1447,7 +1287,7 @@ async fn gas_limit_change_does_not_disrupt_derivation() {
     }
 
     // L1 block 2: gas-limit update log only.
-    h.l1.enqueue_log(gas_limit_update_log(l1_sys_cfg_addr, 60_000_000));
+    h.l1.enqueue_gas_limit_update(l1_sys_cfg_addr, 60_000_000);
     h.l1.mine_block();
 
     // L1 block 3: batch for L2 block 2.
@@ -1878,7 +1718,6 @@ async fn multiple_l2_blocks_derived_from_blob() {
 ///      now accepts it because the config update was rolled back.  Safe head
 ///      advances to 3.
 ///
-/// This is the reorg-reversal half of op-e2e's `BatcherKeyRotation` scenario.
 #[tokio::test]
 async fn batcher_config_update_rolled_back_on_reorg() {
     // --- Phase 1: Setup ---
@@ -1915,7 +1754,7 @@ async fn batcher_config_update_rolled_back_on_reorg() {
     }
 
     // --- Phase 3: Rotate config (L1 block 3 — config update log only). ---
-    h.l1.enqueue_log(batcher_update_log(l1_sys_cfg_addr, batcher_b.batcher_address));
+    h.l1.enqueue_batcher_update(l1_sys_cfg_addr, batcher_b.batcher_address);
     h.l1.mine_block();
 
     // Create verifier after all pre-reorg L1 blocks are mined.
@@ -2395,7 +2234,6 @@ async fn out_of_order_span_batches_reordered_by_batch_queue() {
 /// This exercises the pipeline's L1 traversal over many empty blocks — the
 /// common mainnet scenario during periods of L1 congestion.
 ///
-/// op-e2e ref: `LargeL1Gaps`
 #[tokio::test]
 async fn large_l1_gaps_within_sequence_window() {
     let batcher_cfg = BatcherConfig {
@@ -2459,7 +2297,6 @@ async fn large_l1_gaps_within_sequence_window() {
 /// Expected result: the safe head advances well past genesis as the pipeline
 /// synthesises deposit-only blocks for each expired epoch.
 ///
-/// op-e2e ref: `ExtendedTimeWithoutL1Batches`
 #[tokio::test]
 async fn extended_sequence_window_exhaustion_fills_with_deposit_only_blocks() {
     const SEQ_WINDOW: u64 = 4;

--- a/actions/harness/tests/derivation.rs
+++ b/actions/harness/tests/derivation.rs
@@ -3,17 +3,15 @@
 use std::sync::Arc;
 
 use alloy_eips::BlockNumHash;
-use alloy_primitives::{Address, B256, Bytes, U256};
+use alloy_primitives::{Address, Bytes, U256};
 use base_action_harness::{
     ActionDataSource, ActionL1ChainProvider, ActionL2ChainProvider, ActionL2Source,
     ActionTestHarness, BatchType, Batcher, BatcherConfig, DaType, EncoderConfig, L1MinerConfig,
     L2Sequencer, L2Verifier, PendingTx, SharedL1Chain, StepResult, TestRollupConfigBuilder,
-    block_info_from,
+    UserDeposit, block_info_from,
 };
-use base_consensus_genesis::{L1ChainConfig};
-use base_protocol::{
-    BlockInfo, DERIVATION_VERSION_0, L2BlockInfo,
-};
+use base_consensus_genesis::L1ChainConfig;
+use base_protocol::{BlockInfo, DERIVATION_VERSION_0, L2BlockInfo};
 
 /// The derivation pipeline reads a single batcher frame from L1 and derives
 /// the corresponding L2 block, advancing the safe head from genesis (0) to 1.
@@ -564,15 +562,15 @@ async fn l1_deposit_included_in_derived_l2_block() {
     let block1 = sequencer.build_next_block();
 
     // Enqueue a user deposit log: from=0xAA..AA, to=0xBB..BB, value=1 ETH, gas=100k.
-    h.l1.enqueue_user_deposit(
+    h.l1.enqueue_user_deposit(&UserDeposit {
         deposit_contract,
-        Address::repeat_byte(0xAA),
-        Address::repeat_byte(0xBB),
-        0,                                         // mint
-        U256::from(1_000_000_000_000_000_000u128), // 1 ETH in wei
-        100_000,                                   // gas_limit
-        &[],                                       // empty calldata
-    );
+        from: Address::repeat_byte(0xAA),
+        to: Address::repeat_byte(0xBB),
+        mint: 0,
+        value: U256::from(1_000_000_000_000_000_000u128), // 1 ETH in wei
+        gas_limit: 100_000,
+        data: vec![],
+    });
 
     // Submit the batcher frame into the same L1 block as the deposit log.
     {

--- a/actions/harness/tests/ecotone_activation.rs
+++ b/actions/harness/tests/ecotone_activation.rs
@@ -4,23 +4,11 @@ use base_action_harness::{
     ActionL2Source, ActionTestHarness, Batcher, BatcherConfig, DaType, EncoderConfig,
     L1MinerConfig, SharedL1Chain, TestRollupConfigBuilder,
 };
-use base_alloy_consensus::{OpBlock, OpTxEnvelope};
 use base_consensus_genesis::HardForkConfig;
 use base_protocol::L1BlockInfoTx;
 
-/// Decode the [`L1BlockInfoTx`] from the first (deposit) transaction of an [`OpBlock`].
-fn l1_info_from_block(block: &OpBlock) -> L1BlockInfoTx {
-    let OpTxEnvelope::Deposit(sealed) = &block.body.transactions[0] else {
-        panic!("first transaction must be a deposit");
-    };
-    L1BlockInfoTx::decode_calldata(sealed.inner().input.as_ref())
-        .expect("L1 info calldata must decode")
-}
-
 // ---------------------------------------------------------------------------
 // A. L1 info format transitions at Ecotone activation
-//
-// op-e2e ref: ecotone_fork_test.go
 // ---------------------------------------------------------------------------
 
 /// The L1 info deposit transaction changes format at Ecotone activation in
@@ -58,7 +46,7 @@ fn ecotone_l1_info_format_transitions_at_activation() {
 
     // Block 1: ts=2 — pre-Ecotone. Expect Bedrock format.
     let block1 = builder.build_next_block();
-    let info1 = l1_info_from_block(&block1);
+    let info1 = ActionTestHarness::l1_info_from_block(&block1);
     assert!(
         matches!(info1, L1BlockInfoTx::Bedrock(_)),
         "block 1 (pre-Ecotone ts=2) must use Bedrock format, got {info1:?}"
@@ -66,7 +54,7 @@ fn ecotone_l1_info_format_transitions_at_activation() {
 
     // Block 2: ts=4 — still pre-Ecotone. Expect Bedrock format.
     let block2 = builder.build_next_block();
-    let info2 = l1_info_from_block(&block2);
+    let info2 = ActionTestHarness::l1_info_from_block(&block2);
     assert!(
         matches!(info2, L1BlockInfoTx::Bedrock(_)),
         "block 2 (pre-Ecotone ts=4) must use Bedrock format, got {info2:?}"
@@ -77,7 +65,7 @@ fn ecotone_l1_info_format_transitions_at_activation() {
     // still on the Bedrock ABI. The sequencer sends a Bedrock-format L1 info tx.
     let block3 = builder.build_empty_block();
     assert_eq!(block3.header.timestamp, ecotone_time, "block 3 must be at ecotone_time");
-    let info3 = l1_info_from_block(&block3);
+    let info3 = ActionTestHarness::l1_info_from_block(&block3);
     assert!(
         matches!(info3, L1BlockInfoTx::Bedrock(_)),
         "block 3 (first Ecotone ts=6) must still use Bedrock format, got {info3:?}"
@@ -86,7 +74,7 @@ fn ecotone_l1_info_format_transitions_at_activation() {
     // Block 4: ts=8 — second Ecotone block. L1Block contract now upgraded.
     // Sequencer sends Ecotone-format L1 info tx.
     let block4 = builder.build_next_block();
-    let info4 = l1_info_from_block(&block4);
+    let info4 = ActionTestHarness::l1_info_from_block(&block4);
     assert!(
         matches!(info4, L1BlockInfoTx::Ecotone(_)),
         "block 4 (post-Ecotone ts=8) must use Ecotone format, got {info4:?}"
@@ -95,8 +83,6 @@ fn ecotone_l1_info_format_transitions_at_activation() {
 
 // ---------------------------------------------------------------------------
 // B. Ecotone activation block user txs are accepted at the batch layer
-//
-// op-e2e ref: ecotone_fork_test.go
 // ---------------------------------------------------------------------------
 
 /// Unlike the Jovian hardfork, Ecotone does **not** enforce an empty first block
@@ -187,8 +173,6 @@ async fn ecotone_activation_block_user_txs_accepted_at_batch_layer() {
 
 // ---------------------------------------------------------------------------
 // C. Derivation through the Ecotone activation boundary
-//
-// op-e2e ref: ecotone_fork_test.go
 // ---------------------------------------------------------------------------
 
 /// Full end-to-end derivation through the Ecotone activation boundary,

--- a/actions/harness/tests/hardfork_activation.rs
+++ b/actions/harness/tests/hardfork_activation.rs
@@ -4,8 +4,7 @@ use base_action_harness::{
     ActionL2Source, ActionTestHarness, BatchType, Batcher, BatcherConfig, DaType, EncoderConfig,
     L1MinerConfig, SharedL1Chain, TestRollupConfigBuilder,
 };
-use base_consensus_genesis::{HardForkConfig, RollupConfig};
-use base_consensus_registry::Registry;
+use base_consensus_genesis::HardForkConfig;
 
 // ---------------------------------------------------------------------------
 // Section 1: Base mainnet config — hardfork boundary tests
@@ -20,11 +19,6 @@ use base_consensus_registry::Registry;
 // correct activation semantics.
 // ---------------------------------------------------------------------------
 
-/// Returns the Base mainnet [`RollupConfig`] from the chain registry.
-fn mainnet() -> &'static RollupConfig {
-    Registry::rollup_config(8453).expect("Base mainnet config must exist in the registry")
-}
-
 /// Every hardfork activates at its recorded mainnet timestamp and is inactive
 /// one second before that timestamp.
 ///
@@ -33,7 +27,7 @@ fn mainnet() -> &'static RollupConfig {
 /// activation logic.
 #[test]
 fn each_hardfork_activates_at_its_mainnet_timestamp() {
-    let rc = mainnet();
+    let rc = TestRollupConfigBuilder::mainnet();
 
     let canyon_time = rc.hardforks.canyon_time.expect("canyon_time must be set on mainnet");
     let delta_time = rc.hardforks.delta_time.expect("delta_time must be set on mainnet");
@@ -95,7 +89,7 @@ fn each_hardfork_activates_at_its_mainnet_timestamp() {
 /// trips at a different second, so there is never a spurious simultaneous cascade.
 #[test]
 fn mainnet_hardfork_timestamps_are_strictly_ordered() {
-    let h = &mainnet().hardforks;
+    let h = &TestRollupConfigBuilder::mainnet().hardforks;
 
     let ordered: &[(&str, u64)] = &[
         ("canyon", h.canyon_time.expect("canyon_time")),
@@ -120,7 +114,7 @@ fn mainnet_hardfork_timestamps_are_strictly_ordered() {
 /// and all later forks are not yet active.
 #[test]
 fn cascade_implies_all_preceding_forks_and_no_later_forks() {
-    let rc = mainnet();
+    let rc = TestRollupConfigBuilder::mainnet();
 
     let delta_time = rc.hardforks.delta_time.expect("delta_time");
     let fjord_time = rc.hardforks.fjord_time.expect("fjord_time");
@@ -164,7 +158,7 @@ fn cascade_implies_all_preceding_forks_and_no_later_forks() {
 /// before Fjord the configured value applies; at Fjord the constant applies.
 #[test]
 fn fjord_changes_max_sequencer_drift_at_mainnet_timestamp() {
-    let rc = mainnet();
+    let rc = TestRollupConfigBuilder::mainnet();
     let fjord_time = rc.hardforks.fjord_time.expect("fjord_time");
 
     // One second before Fjord: the rollup config field is used.
@@ -191,7 +185,7 @@ fn fjord_changes_max_sequencer_drift_at_mainnet_timestamp() {
 /// `granite_channel_timeout`. The transition is sharp at the exact fork second.
 #[test]
 fn granite_changes_channel_timeout_at_mainnet_timestamp() {
-    let rc = mainnet();
+    let rc = TestRollupConfigBuilder::mainnet();
     let granite_time = rc.hardforks.granite_time.expect("granite_time");
 
     // One second before Granite: the base channel_timeout field is used.
@@ -218,7 +212,7 @@ fn granite_changes_channel_timeout_at_mainnet_timestamp() {
 /// cascade chain: Jovian does not imply it, and it does not imply Jovian.
 #[test]
 fn base_v1_is_standalone_from_jovian() {
-    let rc = mainnet();
+    let rc = TestRollupConfigBuilder::mainnet();
     let jovian_time = rc.hardforks.jovian_time.expect("jovian_time");
 
     // On mainnet BaseV1 is not yet scheduled, so it's inactive at all times.

--- a/actions/harness/tests/holocene_activation.rs
+++ b/actions/harness/tests/holocene_activation.rs
@@ -8,8 +8,6 @@ use base_consensus_genesis::HardForkConfig;
 
 // ---------------------------------------------------------------------------
 // A. Basic derivation through the Holocene activation boundary
-//
-// op-e2e ref: holocene_activation_test.go
 // ---------------------------------------------------------------------------
 
 /// Full end-to-end derivation through the Holocene activation boundary.
@@ -86,8 +84,6 @@ async fn holocene_derivation_crosses_activation_boundary() {
 
 // ---------------------------------------------------------------------------
 // B. Holocene frame pruning: non-sequential frame is dropped
-//
-// op-e2e ref: holocene_frame_test.go
 // ---------------------------------------------------------------------------
 
 /// Under Holocene, [`FrameQueue::prune`] enforces sequential frame numbers
@@ -192,8 +188,6 @@ async fn holocene_non_sequential_frame_pruned_channel_never_completes() {
 
 // ---------------------------------------------------------------------------
 // C. Holocene: new channel (frame 0) abandons incomplete old channel
-//
-// op-e2e ref: holocene_frame_test.go
 // ---------------------------------------------------------------------------
 
 /// Under Holocene frame pruning, when a new channel (different channel ID,
@@ -316,8 +310,6 @@ async fn holocene_new_channel_abandons_incomplete_old_channel() {
 
 // ---------------------------------------------------------------------------
 // D. Holocene frame pruning: non-sequential frame pruned, then recovery
-//
-// op-e2e ref: holocene_frame_test.go (extended)
 // ---------------------------------------------------------------------------
 
 /// Same scenario as [`holocene_non_sequential_frame_pruned_channel_never_completes`]:

--- a/actions/harness/tests/operator_fees.rs
+++ b/actions/harness/tests/operator_fees.rs
@@ -1,27 +1,11 @@
 #![doc = "Action tests for operator fee encoding and hardfork activation."]
 
-use alloy_primitives::{Address, B256, LogData};
+use alloy_primitives::Address;
 use base_action_harness::{
     ActionL2Source, ActionTestHarness, Batcher, BatcherConfig, DaType, EncoderConfig,
     L1MinerConfig, SharedL1Chain, TestRollupConfigBuilder,
 };
-use base_alloy_consensus::{OpBlock, OpTxEnvelope};
-use base_consensus_genesis::{CONFIG_UPDATE_EVENT_VERSION_0, CONFIG_UPDATE_TOPIC};
 use base_protocol::L1BlockInfoTx;
-
-/// Decode the [`L1BlockInfoTx`] from the first (L1 info deposit) transaction of
-/// an [`OpBlock`].
-///
-/// The first tx in every L2 block is always the L1 info deposit. Its calldata
-/// is the `setL1BlockValues*` ABI-encoded call, from which [`L1BlockInfoTx`]
-/// extracts the epoch information and hardfork-specific fee parameters.
-fn l1_info_from_block(block: &OpBlock) -> L1BlockInfoTx {
-    let OpTxEnvelope::Deposit(sealed) = &block.body.transactions[0] else {
-        panic!("first transaction must be a deposit");
-    };
-    L1BlockInfoTx::decode_calldata(sealed.inner().input.as_ref())
-        .expect("L1 info calldata must decode successfully")
-}
 
 // ---------------------------------------------------------------------------
 // Section 1: L1 info format and operator fee encoding
@@ -57,7 +41,7 @@ fn operator_fee_not_encoded_before_isthmus() {
 
     // Build one block and verify it uses the Ecotone format with zero operator fees.
     let block = builder.build_next_block();
-    let l1_info = l1_info_from_block(&block);
+    let l1_info = ActionTestHarness::l1_info_from_block(&block);
 
     assert!(
         matches!(l1_info, L1BlockInfoTx::Ecotone(_)),
@@ -99,7 +83,7 @@ fn operator_fee_encoded_in_l1_info_post_isthmus() {
 
     // Build one block and verify it uses the Isthmus format with the configured fee params.
     let block = builder.build_next_block();
-    let l1_info = l1_info_from_block(&block);
+    let l1_info = ActionTestHarness::l1_info_from_block(&block);
 
     assert!(
         matches!(l1_info, L1BlockInfoTx::Isthmus(_)),
@@ -156,7 +140,7 @@ fn l1_info_format_transitions_at_isthmus_boundary() {
     // Stage 1: Blocks 1-2 (ts=2, 4) — pre-Isthmus → Ecotone format, zero operator fees.
     for i in 1u64..=2 {
         let block = builder.build_next_block();
-        let l1_info = l1_info_from_block(&block);
+        let l1_info = ActionTestHarness::l1_info_from_block(&block);
 
         assert!(
             matches!(l1_info, L1BlockInfoTx::Ecotone(_)),
@@ -173,7 +157,7 @@ fn l1_info_format_transitions_at_isthmus_boundary() {
     // L1Block contract, enabling the Isthmus format from block 4 onwards.
     {
         let block = builder.build_next_block();
-        let l1_info = l1_info_from_block(&block);
+        let l1_info = ActionTestHarness::l1_info_from_block(&block);
 
         assert!(
             matches!(l1_info, L1BlockInfoTx::Ecotone(_)),
@@ -194,7 +178,7 @@ fn l1_info_format_transitions_at_isthmus_boundary() {
     // Stage 3: Block 4 (ts=8) — second Isthmus block, Isthmus format, fees active.
     {
         let block = builder.build_next_block();
-        let l1_info = l1_info_from_block(&block);
+        let l1_info = ActionTestHarness::l1_info_from_block(&block);
 
         assert!(
             matches!(l1_info, L1BlockInfoTx::Isthmus(_)),
@@ -257,7 +241,7 @@ fn l1_info_format_transitions_at_jovian_boundary() {
     // Stage 1: Blocks 1-2 (ts=2, 4) — Isthmus active, Jovian not yet → Isthmus format.
     for i in 1u64..=2 {
         let block = builder.build_next_block();
-        let l1_info = l1_info_from_block(&block);
+        let l1_info = ActionTestHarness::l1_info_from_block(&block);
 
         assert!(
             matches!(l1_info, L1BlockInfoTx::Isthmus(_)),
@@ -273,7 +257,7 @@ fn l1_info_format_transitions_at_jovian_boundary() {
     // because the batch validator enforces `NonEmptyTransitionBlock` for Jovian.
     {
         let block = builder.build_empty_block();
-        let l1_info = l1_info_from_block(&block);
+        let l1_info = ActionTestHarness::l1_info_from_block(&block);
 
         assert!(
             matches!(l1_info, L1BlockInfoTx::Isthmus(_)),
@@ -288,7 +272,7 @@ fn l1_info_format_transitions_at_jovian_boundary() {
     // differs (gas * scalar * 100 vs gas * scalar / 1_000_000 for Isthmus).
     {
         let block = builder.build_next_block();
-        let l1_info = l1_info_from_block(&block);
+        let l1_info = ActionTestHarness::l1_info_from_block(&block);
 
         assert!(
             matches!(l1_info, L1BlockInfoTx::Jovian(_)),
@@ -503,39 +487,6 @@ async fn jovian_non_empty_transition_batch_generates_deposit_only_block() {
 
 /// Build a `ConfigUpdate` log encoding an `OperatorFee` (type 5) change.
 ///
-/// Log layout mirrors `SystemConfig.sol`:
-/// - `topics[0]` = `CONFIG_UPDATE_TOPIC`
-/// - `topics[1]` = `CONFIG_UPDATE_EVENT_VERSION_0`
-/// - `topics[2]` = `B256` encoding `UpdateType::OperatorFee = 5`
-/// - `data`      = 96 bytes: pointer(32=0x20) + length(32=0x20) +
-///   payload(32 bytes): `[0..20]` zeros | `[20..24]` scalar (u32 BE) |
-///   `[24..32]` constant (u64 BE)
-fn operator_fee_update_log(
-    l1_sys_cfg_addr: Address,
-    operator_fee_scalar: u32,
-    operator_fee_constant: u64,
-) -> alloy_primitives::Log {
-    let mut data = [0u8; 96];
-    data[31] = 0x20; // pointer = 32
-    data[63] = 0x20; // length  = 32
-    // Payload offsets within the 96-byte array:
-    //   payload[20..24] = data[84..88] = scalar (u32 BE)
-    //   payload[24..32] = data[88..96] = constant (u64 BE)
-    data[84..88].copy_from_slice(&operator_fee_scalar.to_be_bytes());
-    data[88..96].copy_from_slice(&operator_fee_constant.to_be_bytes());
-
-    let mut update_type = [0u8; 32];
-    update_type[31] = 5; // OperatorFee = 5
-
-    alloy_primitives::Log {
-        address: l1_sys_cfg_addr,
-        data: LogData::new_unchecked(
-            vec![CONFIG_UPDATE_TOPIC, CONFIG_UPDATE_EVENT_VERSION_0, B256::from(update_type)],
-            data.into(),
-        ),
-    }
-}
-
 /// An `OperatorFee` system-config update committed to L1 is reflected in the
 /// L1 info deposit transactions of derived L2 blocks once the L1 epoch advances
 /// to the block containing the update.
@@ -595,7 +546,7 @@ async fn operator_fee_config_update_propagates_to_l1_info() {
 
     // Pre-mine L1 block 1 (ts=12) with the OperatorFee update so the sequencer
     // can reference epoch 1 when it builds L2 block 6.
-    h.l1.enqueue_log(operator_fee_update_log(l1_sys_cfg_addr, NEW_SCALAR, NEW_CONSTANT));
+    h.l1.enqueue_operator_fee_update(l1_sys_cfg_addr, NEW_SCALAR, NEW_CONSTANT);
     h.l1.mine_block(); // L1 block 1, ts=12
 
     // Snapshot the chain (blocks 0 and 1) before building L2 blocks. The sequencer

--- a/actions/harness/tests/unsafe_gossip.rs
+++ b/actions/harness/tests/unsafe_gossip.rs
@@ -5,7 +5,7 @@ use base_action_harness::{
     L1MinerConfig, SharedL1Chain, TestRollupConfigBuilder,
 };
 
-/// Simulates the full op-e2e gossip pattern:
+/// Simulates the P2P gossip pattern:
 ///
 /// 1. A sequencer builds 5 L2 blocks.
 /// 2. Each block is gossiped to the verifier, advancing `unsafe_head` to 5.


### PR DESCRIPTION
## Summary

Free-floating helper functions across the action test suite have been moved onto framework types: `create_l2_source` and `l1_info_from_block` onto `ActionTestHarness`, `enqueue_*` log-building methods onto `L1Miner`, and `mainnet()` onto `TestRollupConfigBuilder`, so test files contain only test logic. All op-e2e cross-references have been removed from comments throughout the `actions/` directory, as Base's action testing framework is independent of the Optimism Go test suite.