### PR TITLE
fix(actions): Use //! Inner Doc Comments

### DIFF
--- a/actions/harness/tests/base_v1_activation.rs
+++ b/actions/harness/tests/base_v1_activation.rs
@@ -1,4 +1,4 @@
-#![doc = "Action tests for Base V1 (Osaka) hardfork activation."]
+//! Action tests for Base V1 (Osaka) hardfork activation.
 
 use base_action_harness::{
     ActionL2Source, ActionTestHarness, Batcher, BatcherConfig, DaType, EncoderConfig,

--- a/actions/harness/tests/batch_submission.rs
+++ b/actions/harness/tests/batch_submission.rs
@@ -1,4 +1,4 @@
-#![doc = "Action tests for L2 batch submission via the Batcher actor."]
+//! Action tests for L2 batch submission via the Batcher actor.
 
 use base_action_harness::{
     ActionL2Source, ActionTestHarness, BatchType, Batcher, BatcherConfig, BatcherError, DaType,

--- a/actions/harness/tests/batcher_blobs.rs
+++ b/actions/harness/tests/batcher_blobs.rs
@@ -1,4 +1,4 @@
-#![doc = "Action tests for blob DA submission and mixed calldata/blob derivation."]
+//! Action tests for blob DA submission and mixed calldata/blob derivation.
 
 use base_action_harness::{
     ActionL2Source, ActionTestHarness, Batcher, BatcherConfig, DaType, EncoderConfig,

--- a/actions/harness/tests/batcher_channels.rs
+++ b/actions/harness/tests/batcher_channels.rs
@@ -1,4 +1,4 @@
-#![doc = "Action tests for channel timeout and interleaving scenarios."]
+//! Action tests for channel timeout and interleaving scenarios.
 
 use base_action_harness::{
     ActionL2Source, ActionTestHarness, Batcher, BatcherConfig, DaType, EncoderConfig,

--- a/actions/harness/tests/batcher_hardfork_transitions.rs
+++ b/actions/harness/tests/batcher_hardfork_transitions.rs
@@ -1,4 +1,4 @@
-#![doc = "Action tests for batch format transitions across hardfork boundaries."]
+//! Action tests for batch format transitions across hardfork boundaries.
 
 use base_action_harness::{
     ActionL2Source, ActionTestHarness, BatchType, Batcher, BatcherConfig, DaType, DerivedBlock,

--- a/actions/harness/tests/batcher_sequencer_drift.rs
+++ b/actions/harness/tests/batcher_sequencer_drift.rs
@@ -1,4 +1,4 @@
-#![doc = "TDD action test skeletons for sequencer drift scenarios."]
+//! TDD action test skeletons for sequencer drift scenarios.
 
 use base_action_harness::{
     ActionL2Source, ActionTestHarness, Batcher, BatcherConfig, DaType, EncoderConfig,

--- a/actions/harness/tests/derivation.rs
+++ b/actions/harness/tests/derivation.rs
@@ -1,4 +1,4 @@
-#![doc = "Action tests for L2 derivation via the verifier pipeline."]
+//! Action tests for L2 derivation via the verifier pipeline.
 
 use std::sync::Arc;
 

--- a/actions/harness/tests/ecotone_activation.rs
+++ b/actions/harness/tests/ecotone_activation.rs
@@ -1,4 +1,4 @@
-#![doc = "Action tests for the Ecotone hardfork activation boundary."]
+//! Action tests for the Ecotone hardfork activation boundary.
 
 use base_action_harness::{
     ActionL2Source, ActionTestHarness, Batcher, BatcherConfig, DaType, EncoderConfig,

--- a/actions/harness/tests/finalization.rs
+++ b/actions/harness/tests/finalization.rs
@@ -1,4 +1,4 @@
-#![doc = "Action tests for L2 finalization via the verifier pipeline."]
+//! Action tests for L2 finalization via the verifier pipeline.
 
 use base_action_harness::{
     ActionL2Source, ActionTestHarness, Batcher, BatcherConfig, DaType, EncoderConfig,

--- a/actions/harness/tests/hardfork_activation.rs
+++ b/actions/harness/tests/hardfork_activation.rs
@@ -1,4 +1,4 @@
-#![doc = "Action tests for hardfork activation gating and cascade semantics."]
+//! Action tests for hardfork activation gating and cascade semantics.
 
 use base_action_harness::{
     ActionL2Source, ActionTestHarness, BatchType, Batcher, BatcherConfig, DaType, EncoderConfig,

--- a/actions/harness/tests/holocene_activation.rs
+++ b/actions/harness/tests/holocene_activation.rs
@@ -1,4 +1,4 @@
-#![doc = "Action tests for the Holocene hardfork activation and Holocene-specific protocol changes."]
+//! Action tests for the Holocene hardfork activation and Holocene-specific protocol changes.
 
 use base_action_harness::{
     ActionL2Source, ActionTestHarness, Batcher, BatcherConfig, DaType, EncoderConfig,

--- a/actions/harness/tests/l1_mining.rs
+++ b/actions/harness/tests/l1_mining.rs
@@ -1,4 +1,4 @@
-#![doc = "Action tests for L1 block mining."]
+//! Action tests for L1 block mining.
 
 use alloy_primitives::{Address, Bytes};
 use base_action_harness::{Action, ActionTestHarness, L1MinerConfig, PendingTx};

--- a/actions/harness/tests/operator_fees.rs
+++ b/actions/harness/tests/operator_fees.rs
@@ -1,4 +1,4 @@
-#![doc = "Action tests for operator fee encoding and hardfork activation."]
+//! Action tests for operator fee encoding and hardfork activation.
 
 use alloy_primitives::{Address, B256, LogData};
 use base_action_harness::{

--- a/actions/harness/tests/unsafe_gossip.rs
+++ b/actions/harness/tests/unsafe_gossip.rs
@@ -1,4 +1,4 @@
-#![doc = "Action tests for L2 unsafe-head gossip simulation."]
+//! Action tests for L2 unsafe-head gossip simulation.
 
 use base_action_harness::{
     ActionL2Source, ActionTestHarness, Batcher, BatcherConfig, DaType, EncoderConfig,


### PR DESCRIPTION
## Summary

The action test files in `actions/harness/tests/` were using the `#![doc = "..."]` attribute form for module-level documentation instead of the idiomatic `//!` inner doc comment syntax. This replaces all fourteen instances with proper `//!` comments, consistent with Rust convention and the project's `mod.rs` style guidelines. The `#[doc = "..."]` attribute form inside `cfg_if!` macro invocations in other crates is left unchanged, as it is the only valid syntax in that context.