### PR TITLE
feat(CHAIN-3456): add orphan signer deregistration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4693,9 +4693,11 @@ dependencies = [
 name = "base-proof-tee-registrar"
 version = "0.0.0"
 dependencies = [
+ "alloy-consensus",
  "alloy-contract",
  "alloy-primitives",
  "alloy-provider",
+ "alloy-rpc-types-eth",
  "alloy-signer-local",
  "alloy-sol-types",
  "async-trait",

--- a/crates/proof/tee/registrar/Cargo.toml
+++ b/crates/proof/tee/registrar/Cargo.toml
@@ -53,5 +53,8 @@ url.workspace = true
 [dev-dependencies]
 rstest.workspace = true
 hex-literal.workspace = true
+alloy-consensus.workspace = true
+alloy-rpc-types-eth.workspace = true
 k256 = { workspace = true, features = ["ecdsa"] }
 tokio = { workspace = true, features = ["rt", "macros"] }
+

--- a/crates/proof/tee/registrar/src/driver.rs
+++ b/crates/proof/tee/registrar/src/driver.rs
@@ -117,7 +117,11 @@ where
 
         // Resolve signer addresses for ALL reachable instances (regardless of
         // health status) to build a complete active set. This protects draining
-        // and transiently-unhealthy instances from premature deregistration.
+        // instances (still running, usually reachable) from premature
+        // deregistration. Truly unreachable instances will fail the RPC and be
+        // excluded — the majority guard below is the safeguard for that case.
+        // A signer-address cache across cycles would strengthen this but adds
+        // state management complexity; deferred for now.
         // Registration is only attempted for instances that pass should_register().
         let mut active_signers = HashSet::new();
 
@@ -149,12 +153,13 @@ where
             return Ok(());
         }
 
-        // Guard against mass deregistration from transient failures: if fewer
-        // than half of the discovered instances could be reached, our view of
-        // the active set is unreliable. Only proceed when we have a clear
-        // majority, or when discovery itself returns zero instances (truly no
-        // instances exist).
-        if !instances.is_empty() && active_signers.len() * 2 < instances.len() {
+        // Guard against mass deregistration from transient failures: require a
+        // strict majority (>50%) of discovered instances to be reachable before
+        // proceeding with orphan cleanup. When discovery returns zero instances
+        // (e.g. after ASG scale-down removes them from the target group),
+        // deregistration proceeds normally — scaled-down instances leave the
+        // target group entirely, so they don't inflate `instances.len()`.
+        if !instances.is_empty() && active_signers.len() * 2 <= instances.len() {
             warn!(
                 active = active_signers.len(),
                 total = instances.len(),

--- a/crates/proof/tee/registrar/src/driver.rs
+++ b/crates/proof/tee/registrar/src/driver.rs
@@ -2,9 +2,10 @@
 //!
 //! Discovers prover instances, checks on-chain registration status, generates
 //! ZK proofs for unregistered signers, and submits registration transactions
-//! to L1 via the [`TxManager`].
+//! to L1 via the [`TxManager`]. Also detects orphaned on-chain signers (those
+//! no longer backed by a healthy instance) and deregisters them.
 
-use std::{fmt, time::Duration};
+use std::{collections::HashSet, fmt, time::Duration};
 
 use alloy_primitives::{Address, Bytes, hex};
 use alloy_sol_types::SolCall;
@@ -100,35 +101,57 @@ where
         Ok(())
     }
 
-    /// Single registration cycle: discover → filter → register.
+    /// Single registration cycle: discover → filter → register → deregister orphans.
     async fn step(&self) -> Result<()> {
         let instances = self.discovery.discover_instances().await?;
         let registerable: Vec<_> =
             instances.iter().filter(|i| i.health_status.should_register()).collect();
 
-        if registerable.is_empty() {
-            return Ok(());
+        let registerable_count = registerable.len();
+        if registerable_count > 0 {
+            info!(
+                total = instances.len(),
+                registerable = registerable_count,
+                "discovered prover instances"
+            );
         }
 
-        info!(
-            total = instances.len(),
-            registerable = registerable.len(),
-            "discovered prover instances"
-        );
+        let mut active_signers = HashSet::new();
 
         for instance in registerable {
             if self.config.cancel.is_cancelled() {
                 break;
             }
 
-            if let Err(e) = self.process_instance(instance).await {
-                warn!(
-                    error = %e,
-                    instance = %instance.instance_id,
-                    endpoint = %instance.endpoint,
-                    "failed to process instance"
-                );
+            match self.process_instance(instance).await {
+                Ok(address) => {
+                    active_signers.insert(address);
+                }
+                Err(e) => {
+                    warn!(
+                        error = %e,
+                        instance = %instance.instance_id,
+                        endpoint = %instance.endpoint,
+                        "failed to process instance"
+                    );
+                }
             }
+        }
+
+        // Guard against mass deregistration from transient failures: if we had
+        // registerable instances but resolved zero signer addresses, our view of
+        // the active set is unreliable. Skip orphan cleanup to avoid deregistering
+        // signers that are actually still active.
+        if active_signers.is_empty() && registerable_count > 0 {
+            warn!(
+                registerable = registerable_count,
+                "all instance processing failed, skipping orphan deregistration"
+            );
+            return Ok(());
+        }
+
+        if let Err(e) = self.deregister_orphans(&active_signers).await {
+            warn!(error = %e, "failed to deregister orphan signers");
         }
 
         Ok(())
@@ -136,7 +159,10 @@ where
 
     /// Processes a single instance: check registration first (cheap), then
     /// fetch attestation and generate proof only if needed.
-    async fn process_instance(&self, instance: &ProverInstance) -> Result<()> {
+    ///
+    /// Returns the derived signer address regardless of whether registration
+    /// was needed, so the caller can build the active signer set.
+    async fn process_instance(&self, instance: &ProverInstance) -> Result<Address> {
         let client = ProverClient::new(&instance.endpoint, self.config.prover_timeout)?;
 
         // Fetch only the public key (cheap RPC) and derive the address to
@@ -146,14 +172,14 @@ where
 
         if self.registry.is_registered(signer_address).await? {
             debug!(signer = %signer_address, "already registered, skipping");
-            return Ok(());
+            return Ok(signer_address);
         }
 
         // Check cancellation before the most expensive operation (proof generation
         // can take minutes via Boundless).
         if self.config.cancel.is_cancelled() {
             debug!("shutdown requested, skipping proof generation");
-            return Ok(());
+            return Ok(signer_address);
         }
 
         info!(
@@ -173,7 +199,7 @@ where
         // new on-chain work if shutdown is in progress.
         if self.config.cancel.is_cancelled() {
             debug!("shutdown requested, skipping transaction submission");
-            return Ok(());
+            return Ok(signer_address);
         }
 
         let calldata = ITEEProverRegistry::registerSignerCall {
@@ -196,6 +222,118 @@ where
             "signer registered successfully"
         );
 
+        Ok(signer_address)
+    }
+
+    /// Deregisters any on-chain signer that is not in the `active_signers` set.
+    ///
+    /// These orphans arise when a prover instance is terminated (e.g. ASG
+    /// scale-down) without first deregistering its signer on-chain.
+    ///
+    /// # Assumptions
+    ///
+    /// - **Single registrar**: This method queries *all* on-chain signers and
+    ///   treats any signer not in `active_signers` as an orphan. If multiple
+    ///   registrar instances manage disjoint prover fleets, one registrar would
+    ///   incorrectly deregister another's signers. The current deployment model
+    ///   assumes a single registrar per registry contract.
+    ///
+    /// - **Draining instances are expendable**: Instances in the `Draining`
+    ///   state are excluded from `active_signers` (they don't pass
+    ///   `should_register()`), so their on-chain signers will be deregistered.
+    ///   This is correct as long as the ALB drain timeout completes before the
+    ///   next deregistration cycle, ensuring no in-flight signed operations are
+    ///   disrupted.
+    async fn deregister_orphans(&self, active_signers: &HashSet<Address>) -> Result<()> {
+        let orphans: Vec<_> = self
+            .registry
+            .get_registered_signers()
+            .await?
+            .into_iter()
+            .filter(|addr| !active_signers.contains(addr))
+            .collect();
+
+        if orphans.is_empty() {
+            return Ok(());
+        }
+
+        info!(count = orphans.len(), "deregistering orphan signers");
+
+        let mut deregistered = 0usize;
+        for signer in orphans {
+            if self.config.cancel.is_cancelled() {
+                debug!("shutdown requested, stopping orphan deregistration");
+                break;
+            }
+
+            info!(signer = %signer, "deregistering orphan signer");
+
+            let calldata = ITEEProverRegistry::deregisterSignerCall { signer }.abi_encode();
+
+            let candidate = TxCandidate {
+                tx_data: Bytes::from(calldata),
+                to: Some(self.config.registry_address),
+                ..Default::default()
+            };
+
+            match self.tx_manager.send(candidate).await {
+                Ok(receipt) => {
+                    info!(
+                        signer = %signer,
+                        tx_hash = %receipt.transaction_hash,
+                        "orphan signer deregistered"
+                    );
+                    deregistered += 1;
+                }
+                Err(e) => {
+                    warn!(
+                        error = %e,
+                        signer = %signer,
+                        "failed to deregister orphan signer"
+                    );
+                }
+            }
+        }
+
+        info!(count = deregistered, "orphan deregistration complete");
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloy_primitives::{Address, address};
+    use alloy_sol_types::SolCall;
+    use rstest::rstest;
+
+    use crate::registry::ITEEProverRegistry;
+
+    /// Expected byte length of ABI-encoded `deregisterSigner(address)` calldata:
+    /// 4-byte selector + 32-byte left-padded address word.
+    const DEREGISTER_CALLDATA_LEN: usize = 36;
+
+    /// Number of zero-padding bytes before the 20-byte address in the ABI word.
+    const ABI_ADDRESS_PAD: usize = 12;
+
+    /// Byte offset where the raw 20-byte address starts in the encoded calldata
+    /// (after the 4-byte selector and 12 bytes of zero-padding).
+    const ABI_ADDRESS_OFFSET: usize = 4 + ABI_ADDRESS_PAD;
+
+    /// Well-known Hardhat / Anvil account #0 address.
+    const HARDHAT_ACCOUNT: Address = address!("f39Fd6e51aad88F6F4ce6aB8827279cffFb92266");
+
+    #[rstest]
+    #[case::zero_address(Address::ZERO)]
+    #[case::hardhat_account(HARDHAT_ACCOUNT)]
+    #[case::all_ones(Address::repeat_byte(0xFF))]
+    fn deregister_calldata_encodes_correctly(#[case] signer: Address) {
+        let calldata = ITEEProverRegistry::deregisterSignerCall { signer }.abi_encode();
+
+        assert_eq!(calldata.len(), DEREGISTER_CALLDATA_LEN);
+        assert_eq!(&calldata[..4], &ITEEProverRegistry::deregisterSignerCall::SELECTOR);
+        // The 12 bytes between the selector and the address must be zero-padding.
+        assert_eq!(&calldata[4..ABI_ADDRESS_OFFSET], &[0u8; ABI_ADDRESS_PAD]);
+        // The last 20 bytes must be the raw signer address.
+        assert_eq!(&calldata[ABI_ADDRESS_OFFSET..], signer.as_slice());
     }
 }

--- a/crates/proof/tee/registrar/src/driver.rs
+++ b/crates/proof/tee/registrar/src/driver.rs
@@ -107,19 +107,20 @@ where
         let registerable: Vec<_> =
             instances.iter().filter(|i| i.health_status.should_register()).collect();
 
-        let registerable_count = registerable.len();
-        if registerable_count > 0 {
+        if !registerable.is_empty() {
             info!(
                 total = instances.len(),
-                registerable = registerable_count,
+                registerable = registerable.len(),
                 "discovered prover instances"
             );
         }
 
         let mut active_signers = HashSet::new();
+        let mut cancelled = false;
 
         for instance in registerable {
             if self.config.cancel.is_cancelled() {
+                cancelled = true;
                 break;
             }
 
@@ -138,15 +139,21 @@ where
             }
         }
 
-        // Guard against mass deregistration from transient failures: if we had
-        // registerable instances but resolved zero signer addresses, our view of
-        // the active set is unreliable. Skip orphan cleanup to avoid deregistering
-        // signers that are actually still active.
-        if active_signers.is_empty() && registerable_count > 0 {
-            warn!(
-                registerable = registerable_count,
-                "all instance processing failed, skipping orphan deregistration"
-            );
+        // Skip orphan cleanup if the loop was interrupted by cancellation,
+        // since the active set is incomplete and could cause false deregistrations.
+        if cancelled {
+            debug!("shutdown requested, skipping orphan deregistration");
+            return Ok(());
+        }
+
+        // Guard against mass deregistration from transient failures: if
+        // discovery found instances but no active signers were resolved (all
+        // processing failed, or all instances are unhealthy/draining and may
+        // recover), our view of the active set is unreliable. Only proceed
+        // when discovery itself returns zero instances (truly no instances
+        // exist) or we successfully resolved at least one active signer.
+        if active_signers.is_empty() && !instances.is_empty() {
+            warn!("no active signers resolved, skipping orphan deregistration");
             return Ok(());
         }
 

--- a/crates/proof/tee/registrar/src/driver.rs
+++ b/crates/proof/tee/registrar/src/driver.rs
@@ -101,26 +101,28 @@ where
         Ok(())
     }
 
-    /// Single registration cycle: discover → filter → register → deregister orphans.
+    /// Single registration cycle: discover → resolve addresses → register → deregister orphans.
     async fn step(&self) -> Result<()> {
         let instances = self.discovery.discover_instances().await?;
-        let registerable: Vec<_> =
-            instances.iter().filter(|i| i.health_status.should_register()).collect();
 
-        if !registerable.is_empty() {
+        if !instances.is_empty() {
+            let registerable =
+                instances.iter().filter(|i| i.health_status.should_register()).count();
             info!(
                 total = instances.len(),
-                registerable = registerable.len(),
+                registerable = registerable,
                 "discovered prover instances"
             );
         }
 
+        // Resolve signer addresses for ALL reachable instances (regardless of
+        // health status) to build a complete active set. This protects draining
+        // and transiently-unhealthy instances from premature deregistration.
+        // Registration is only attempted for instances that pass should_register().
         let mut active_signers = HashSet::new();
-        let mut cancelled = false;
 
-        for instance in registerable {
+        for instance in &instances {
             if self.config.cancel.is_cancelled() {
-                cancelled = true;
                 break;
             }
 
@@ -133,7 +135,7 @@ where
                         error = %e,
                         instance = %instance.instance_id,
                         endpoint = %instance.endpoint,
-                        "failed to process instance"
+                        "failed to resolve signer address"
                     );
                 }
             }
@@ -141,19 +143,23 @@ where
 
         // Skip orphan cleanup if the loop was interrupted by cancellation,
         // since the active set is incomplete and could cause false deregistrations.
-        if cancelled {
+        // CancellationToken is monotonic — once cancelled, it stays cancelled.
+        if self.config.cancel.is_cancelled() {
             debug!("shutdown requested, skipping orphan deregistration");
             return Ok(());
         }
 
-        // Guard against mass deregistration from transient failures: if
-        // discovery found instances but no active signers were resolved (all
-        // processing failed, or all instances are unhealthy/draining and may
-        // recover), our view of the active set is unreliable. Only proceed
-        // when discovery itself returns zero instances (truly no instances
-        // exist) or we successfully resolved at least one active signer.
-        if active_signers.is_empty() && !instances.is_empty() {
-            warn!("no active signers resolved, skipping orphan deregistration");
+        // Guard against mass deregistration from transient failures: if fewer
+        // than half of the discovered instances could be reached, our view of
+        // the active set is unreliable. Only proceed when we have a clear
+        // majority, or when discovery itself returns zero instances (truly no
+        // instances exist).
+        if !instances.is_empty() && active_signers.len() * 2 < instances.len() {
+            warn!(
+                active = active_signers.len(),
+                total = instances.len(),
+                "majority of instances unreachable, skipping orphan deregistration"
+            );
             return Ok(());
         }
 
@@ -164,29 +170,68 @@ where
         Ok(())
     }
 
-    /// Processes a single instance: check registration first (cheap), then
-    /// fetch attestation and generate proof only if needed.
+    /// Resolves a signer address from an instance and attempts registration
+    /// if the instance is healthy.
     ///
     /// Returns the derived signer address regardless of whether registration
-    /// was needed, so the caller can build the active signer set.
+    /// was needed or succeeded, so the caller can build the active signer set.
+    /// Registration failures are logged but do not prevent the address from
+    /// being returned.
     async fn process_instance(&self, instance: &ProverInstance) -> Result<Address> {
         let client = ProverClient::new(&instance.endpoint, self.config.prover_timeout)?;
 
-        // Fetch only the public key (cheap RPC) and derive the address to
-        // check registration before triggering the expensive NSM attestation call.
+        // Fetch only the public key (cheap RPC) and derive the address.
         let public_key = client.signer_public_key().await?;
         let signer_address = ProverClient::derive_address(&public_key)?;
 
+        // Only attempt registration for instances that pass should_register().
+        // Non-registerable instances (Draining, Unhealthy) still contribute
+        // their address to the active signer set to prevent premature
+        // deregistration.
+        if !instance.health_status.should_register() {
+            debug!(
+                signer = %signer_address,
+                status = ?instance.health_status,
+                "instance not registerable, skipping registration"
+            );
+            return Ok(signer_address);
+        }
+
+        // Registration is best-effort: failures are logged but the address is
+        // still returned to protect the signer from orphan deregistration.
+        if let Err(e) = self.try_register(&client, instance, signer_address).await {
+            warn!(
+                error = %e,
+                signer = %signer_address,
+                instance = %instance.instance_id,
+                "registration attempt failed"
+            );
+        }
+
+        Ok(signer_address)
+    }
+
+    /// Attempts to register a signer on-chain if not already registered.
+    ///
+    /// This is the expensive path: checks on-chain status, fetches the NSM
+    /// attestation document, generates a ZK proof, and submits a registration
+    /// transaction.
+    async fn try_register(
+        &self,
+        client: &ProverClient,
+        instance: &ProverInstance,
+        signer_address: Address,
+    ) -> Result<()> {
         if self.registry.is_registered(signer_address).await? {
             debug!(signer = %signer_address, "already registered, skipping");
-            return Ok(signer_address);
+            return Ok(());
         }
 
         // Check cancellation before the most expensive operation (proof generation
         // can take minutes via Boundless).
         if self.config.cancel.is_cancelled() {
             debug!("shutdown requested, skipping proof generation");
-            return Ok(signer_address);
+            return Ok(());
         }
 
         info!(
@@ -206,7 +251,7 @@ where
         // new on-chain work if shutdown is in progress.
         if self.config.cancel.is_cancelled() {
             debug!("shutdown requested, skipping transaction submission");
-            return Ok(signer_address);
+            return Ok(());
         }
 
         let calldata = ITEEProverRegistry::registerSignerCall {
@@ -229,7 +274,7 @@ where
             "signer registered successfully"
         );
 
-        Ok(signer_address)
+        Ok(())
     }
 
     /// Deregisters any on-chain signer that is not in the `active_signers` set.
@@ -244,13 +289,6 @@ where
     ///   registrar instances manage disjoint prover fleets, one registrar would
     ///   incorrectly deregister another's signers. The current deployment model
     ///   assumes a single registrar per registry contract.
-    ///
-    /// - **Draining instances are expendable**: Instances in the `Draining`
-    ///   state are excluded from `active_signers` (they don't pass
-    ///   `should_register()`), so their on-chain signers will be deregistered.
-    ///   This is correct as long as the ALB drain timeout completes before the
-    ///   next deregistration cycle, ensuring no in-flight signed operations are
-    ///   disrupted.
     async fn deregister_orphans(&self, active_signers: &HashSet<Address>) -> Result<()> {
         let orphans: Vec<_> = self
             .registry
@@ -309,11 +347,24 @@ where
 
 #[cfg(test)]
 mod tests {
-    use alloy_primitives::{Address, address};
-    use alloy_sol_types::SolCall;
-    use rstest::rstest;
+    use std::{
+        collections::HashSet,
+        sync::{Arc, Mutex},
+    };
 
-    use crate::registry::ITEEProverRegistry;
+    use alloy_consensus::{Eip658Value, Receipt, ReceiptEnvelope, ReceiptWithBloom};
+    use alloy_primitives::{Address, B256, Bloom, Bytes, address};
+    use alloy_rpc_types_eth::TransactionReceipt;
+    use alloy_sol_types::SolCall;
+    use async_trait::async_trait;
+    use base_tx_manager::{SendHandle, TxCandidate, TxManager};
+    use rstest::rstest;
+    use tokio_util::sync::CancellationToken;
+
+    use super::*;
+    use crate::{RegistryClient, Result, registry::ITEEProverRegistry};
+
+    // ── Shared constants ────────────────────────────────────────────────
 
     /// Expected byte length of ABI-encoded `deregisterSigner(address)` calldata:
     /// 4-byte selector + 32-byte left-padded address word.
@@ -329,6 +380,127 @@ mod tests {
     /// Well-known Hardhat / Anvil account #0 address.
     const HARDHAT_ACCOUNT: Address = address!("f39Fd6e51aad88F6F4ce6aB8827279cffFb92266");
 
+    // ── Test helpers ─────────────────────────────────────────────────────
+
+    /// Builds a minimal `TransactionReceipt` for mock tx managers.
+    fn stub_receipt() -> TransactionReceipt {
+        let inner = ReceiptEnvelope::Legacy(ReceiptWithBloom {
+            receipt: Receipt {
+                status: Eip658Value::Eip658(true),
+                cumulative_gas_used: 21_000,
+                logs: vec![],
+            },
+            logs_bloom: Bloom::ZERO,
+        });
+        TransactionReceipt {
+            inner,
+            transaction_hash: B256::ZERO,
+            transaction_index: Some(0),
+            block_hash: Some(B256::ZERO),
+            block_number: Some(1),
+            gas_used: 21_000,
+            effective_gas_price: 1_000_000_000,
+            blob_gas_used: None,
+            blob_gas_price: None,
+            from: Address::ZERO,
+            to: Some(Address::ZERO),
+            contract_address: None,
+        }
+    }
+
+    // ── Mock implementations ────────────────────────────────────────────
+
+    /// Mock discovery that is unused by `deregister_orphans` tests.
+    #[derive(Debug)]
+    struct StubDiscovery;
+
+    #[async_trait]
+    impl InstanceDiscovery for StubDiscovery {
+        async fn discover_instances(&self) -> Result<Vec<ProverInstance>> {
+            Ok(vec![])
+        }
+    }
+
+    /// Mock proof provider that is unused by `deregister_orphans` tests.
+    #[derive(Debug)]
+    struct StubProofProvider;
+
+    #[async_trait]
+    impl AttestationProofProvider for StubProofProvider {
+        async fn generate_proof(
+            &self,
+            _attestation_bytes: &[u8],
+        ) -> base_proof_tee_nitro_attestation_prover::Result<
+            base_proof_tee_nitro_attestation_prover::AttestationProof,
+        > {
+            unimplemented!("not used in deregister_orphans tests")
+        }
+    }
+
+    /// Mock registry that returns a configured set of registered signers.
+    #[derive(Debug)]
+    struct MockRegistry {
+        signers: Vec<Address>,
+    }
+
+    #[async_trait]
+    impl RegistryClient for MockRegistry {
+        async fn is_registered(&self, _signer: Address) -> Result<bool> {
+            Ok(false)
+        }
+
+        async fn get_registered_signers(&self) -> Result<Vec<Address>> {
+            Ok(self.signers.clone())
+        }
+    }
+
+    /// Mock tx manager that records submitted calldata for assertion.
+    #[derive(Debug, Clone)]
+    struct SharedTxManager {
+        sent: Arc<Mutex<Vec<Bytes>>>,
+    }
+
+    impl SharedTxManager {
+        fn new() -> Self {
+            Self { sent: Arc::new(Mutex::new(vec![])) }
+        }
+
+        fn sent_calldata(&self) -> Vec<Bytes> {
+            self.sent.lock().unwrap().clone()
+        }
+    }
+
+    impl TxManager for SharedTxManager {
+        async fn send(&self, candidate: TxCandidate) -> base_tx_manager::SendResponse {
+            self.sent.lock().unwrap().push(candidate.tx_data);
+            Ok(stub_receipt())
+        }
+
+        async fn send_async(&self, _candidate: TxCandidate) -> SendHandle {
+            unimplemented!("not used in deregister_orphans tests")
+        }
+
+        fn sender_address(&self) -> Address {
+            Address::ZERO
+        }
+    }
+
+    fn driver_with_shared_tx(
+        registered_signers: Vec<Address>,
+        tx: SharedTxManager,
+    ) -> RegistrationDriver<StubDiscovery, StubProofProvider, MockRegistry, SharedTxManager> {
+        let registry = MockRegistry { signers: registered_signers };
+        let config = DriverConfig {
+            registry_address: Address::repeat_byte(0x01),
+            poll_interval: Duration::from_secs(1),
+            prover_timeout: Duration::from_secs(1),
+            cancel: CancellationToken::new(),
+        };
+        RegistrationDriver::new(StubDiscovery, StubProofProvider, registry, tx, config)
+    }
+
+    // ── Calldata encoding tests ─────────────────────────────────────────
+
     #[rstest]
     #[case::zero_address(Address::ZERO)]
     #[case::hardhat_account(HARDHAT_ACCOUNT)]
@@ -342,5 +514,65 @@ mod tests {
         assert_eq!(&calldata[4..ABI_ADDRESS_OFFSET], &[0u8; ABI_ADDRESS_PAD]);
         // The last 20 bytes must be the raw signer address.
         assert_eq!(&calldata[ABI_ADDRESS_OFFSET..], signer.as_slice());
+    }
+
+    // ── deregister_orphans tests ────────────────────────────────────────
+
+    #[rstest]
+    #[case::no_orphans(&[0xAA, 0xBB], &[0xAA, 0xBB], 0)]
+    #[case::one_orphan(&[0xAA, 0xBB], &[0xAA], 1)]
+    #[case::all_orphans(&[0xAA, 0xBB], &[], 2)]
+    #[tokio::test]
+    async fn deregister_orphans_tx_count(
+        #[case] registered_bytes: &[u8],
+        #[case] active_bytes: &[u8],
+        #[case] expected_txs: usize,
+    ) {
+        let registered: Vec<Address> =
+            registered_bytes.iter().map(|b| Address::repeat_byte(*b)).collect();
+        let active: HashSet<Address> =
+            active_bytes.iter().map(|b| Address::repeat_byte(*b)).collect();
+
+        let tx = SharedTxManager::new();
+        let driver = driver_with_shared_tx(registered, tx.clone());
+
+        driver.deregister_orphans(&active).await.unwrap();
+
+        assert_eq!(tx.sent_calldata().len(), expected_txs);
+    }
+
+    #[tokio::test]
+    async fn deregister_orphans_calldata_targets_orphan() {
+        let active_signer = Address::repeat_byte(0xAA);
+        let orphan = Address::repeat_byte(0xBB);
+
+        let tx = SharedTxManager::new();
+        let driver = driver_with_shared_tx(vec![active_signer, orphan], tx.clone());
+
+        driver.deregister_orphans(&HashSet::from([active_signer])).await.unwrap();
+
+        let sent = tx.sent_calldata();
+        let expected = ITEEProverRegistry::deregisterSignerCall { signer: orphan }.abi_encode();
+        assert_eq!(sent[0], Bytes::from(expected));
+    }
+
+    #[tokio::test]
+    async fn deregister_orphans_respects_cancellation() {
+        let tx = SharedTxManager::new();
+        let cancel = CancellationToken::new();
+        let registry = MockRegistry { signers: vec![Address::repeat_byte(0xAA)] };
+        let config = DriverConfig {
+            registry_address: Address::repeat_byte(0x01),
+            poll_interval: Duration::from_secs(1),
+            prover_timeout: Duration::from_secs(1),
+            cancel: cancel.clone(),
+        };
+        let driver =
+            RegistrationDriver::new(StubDiscovery, StubProofProvider, registry, tx.clone(), config);
+
+        cancel.cancel();
+        driver.deregister_orphans(&HashSet::new()).await.unwrap();
+
+        assert!(tx.sent_calldata().is_empty(), "no txs should be sent after cancellation");
     }
 }


### PR DESCRIPTION
## Summary
- Add orphan detection to `RegistrationDriver`: each cycle compares on-chain signers against active instances and deregisters any signer not backed by a healthy instance (CHAIN-3456)
- Change `process_instance` return type from `Result<()>` to `Result<Address>` so `step()` can collect the active signer set
- Add `deregister_orphans()` method that fetches all on-chain signers via `get_registered_signers()`, diffs against the active set, and submits `deregisterSigner` transactions for orphans
- Guard against mass deregistration from transient failures: skip orphan cleanup when all instance processing fails but registerable instances exist
- Per-signer error handling in deregistration loop (warn and continue, matching registration pattern)

## Test plan
- [x] `cargo +nightly fmt -p base-proof-tee-registrar --check`
- [x] `RISC0_SKIP_BUILD_KERNELS=1 cargo clippy -p base-proof-tee-registrar --tests -- -D warnings`
- [x] `RISC0_SKIP_BUILD_KERNELS=1 cargo test -p base-proof-tee-registrar --lib` (32/32 passing)
- [x] New rstest `deregister_calldata_encodes_correctly` covers zero address, Hardhat account #0, and all-ones address