### PR TITLE
feat: add zedinet chainspec (chain ID 763360, Hoodi L1)

### DIFF
--- a/crates/execution/chainspec/src/base_zedinet.rs
+++ b/crates/execution/chainspec/src/base_zedinet.rs
@@ -1,0 +1,14 @@
+//! Chain specification for the Base zedinet network.
+
+use alloc::sync::Arc;
+
+use reth_primitives_traits::sync::LazyLock;
+
+use crate::OpChainSpec;
+
+/// The Base zedinet spec
+pub static BASE_ZEDINET: LazyLock<Arc<OpChainSpec>> = LazyLock::new(|| {
+    let genesis = serde_json::from_str(include_str!("../res/genesis/base-zedinet.json"))
+        .expect("Can't deserialize Base zedinet genesis json");
+    OpChainSpec::from_genesis(genesis).into()
+});

--- a/crates/execution/chainspec/src/lib.rs
+++ b/crates/execution/chainspec/src/lib.rs
@@ -16,6 +16,9 @@ pub use base::BASE_MAINNET;
 mod base_devnet_0_sepolia_dev_0;
 pub use base_devnet_0_sepolia_dev_0::BASE_DEVNET_0_SEPOLIA_DEV_0;
 
+mod base_zedinet;
+pub use base_zedinet::BASE_ZEDINET;
+
 mod base_sepolia;
 pub use base_sepolia::BASE_SEPOLIA;
 

--- a/crates/execution/chainspec/src/spec.rs
+++ b/crates/execution/chainspec/src/spec.rs
@@ -18,13 +18,13 @@ use reth_network_peers::NodeRecord;
 use reth_primitives_traits::SealedHeader;
 
 use crate::{
-    BASE_DEVNET_0_SEPOLIA_DEV_0, BASE_MAINNET, BASE_SEPOLIA, OP_DEV, compute_jovian_base_fee,
-    decode_holocene_base_fee,
+    BASE_DEVNET_0_SEPOLIA_DEV_0, BASE_MAINNET, BASE_SEPOLIA, BASE_ZEDINET, OP_DEV,
+    compute_jovian_base_fee, decode_holocene_base_fee,
 };
 
 /// All supported chain names for the CLI.
 pub const SUPPORTED_CHAINS: &[&str] =
-    &["base", "base_sepolia", "base-sepolia", "base-devnet-0-sepolia-dev-0", "dev"];
+    &["base", "base_sepolia", "base-sepolia", "base-devnet-0-sepolia-dev-0", "base-zedinet", "dev"];
 
 /// Genesis info extracted from a Base genesis config.
 #[derive(Default, Debug)]
@@ -118,6 +118,7 @@ impl OpChainSpec {
             "base" => Some(BASE_MAINNET.clone()),
             "base_sepolia" | "base-sepolia" => Some(BASE_SEPOLIA.clone()),
             "base-devnet-0-sepolia-dev-0" => Some(BASE_DEVNET_0_SEPOLIA_DEV_0.clone()),
+            "base-zedinet" => Some(BASE_ZEDINET.clone()),
             _ => None,
         }
     }


### PR DESCRIPTION
## Summary

- Registers `base-zedinet` as a named built-in chain in the reth chainspec
- Chain ID 763360 (`0xBA5E0`), settles to Hoodi L1 (chain ID 560048)
- Genesis JSON from op-deployer v0.5.0 with all forks active at genesis (devnet profile)
- Hardfork schedule read from genesis JSON via `From<Genesis>` — no hardfork statics added

## Files changed

- `crates/execution/chainspec/res/genesis/base-zedinet.json` — genesis from op-deployer
- `crates/execution/chainspec/src/base_zedinet.rs` — chainspec module using `from_genesis`
- `crates/execution/chainspec/src/lib.rs` — register `BASE_ZEDINET`
- `crates/execution/chainspec/src/spec.rs` — add `"base-zedinet"` to `SUPPORTED_CHAINS` and `parse_chain`

## Test plan

- [ ] `cargo check -p base-execution-chainspec` succeeds
- [ ] `base-reth-node --chain base-zedinet --help` does not error

## Notes

- Genesis hash is computed at runtime via `seal_slow` and will be hardcoded in a follow-up Phase 2 PR once confirmed

🤖 Generated with [Claude Code](https://claude.com/claude-code)