### PR TITLE
docs: hyphenate post-state leaf phrasing in fault dispute game spec

### DIFF
--- a/docs/specs/pages/protocol/fault-proof/stage-one/fault-dispute-game.md
+++ b/docs/specs/pages/protocol/fault-proof/stage-one/fault-dispute-game.md
@@ -353,13 +353,13 @@ proposal in the `PreimageOracle`. This involves:
 
 1. Creating a merkle proof for the agreed upon prestate leaf (not necessary if the invalid leaf is the first one, the
    setup state of the matrix is constant.) within the proposal's merkle root.
-2. Creating a merkle proof for the disputed post state leaf within the proposal's merkle root.
+2. Creating a merkle proof for the disputed post-state leaf within the proposal's merkle root.
 3. Computing the state matrix at the agreed upon prestate (not necessary if the invalid leaf is the first one, the
    setup state of the matrix is constant.)
 
 The challenger then submits this data to the `PreimageOracle`, where the post state leaf's claimed input is absorbed into
 the pre state leaf's state matrix and the SHA3 permutation is executed on-chain. After that, the resulting state matrix
-is hashed and compared with the proposer's claim in the post state leaf. If the hash does not match, the proposal
+is hashed and compared with the proposer's claim in the post-state leaf. If the hash does not match, the proposal
 is marked as challenged, and it may not be finalized. If, after the challenge period is concluded, a proposal has no
 challenges, it may be finalized and the preimage part may be placed into the authorized mappings for the FPVM to read.
 


### PR DESCRIPTION
## Problem

This PR applies a small wording fix in the fault dispute game spec.

## Changed

- Replaced `post state leaf` with `post-state leaf` in two places.

## Why

`post-state` is a compound modifier before a noun, so hyphenation is the correct and clearer form.