### PR TITLE
Fix incorrect comment in l1block.rs

### DIFF
--- a/crates/execution/revm/src/l1block.rs
+++ b/crates/execution/revm/src/l1block.rs
@@ -144,7 +144,7 @@ impl L1BlockInfo {
             ..Default::default()
         };
 
-        // Post-Ecotone
+        // Pre-Ecotone
         if !spec_id.is_enabled_in(OpSpecId::ECOTONE) {
             out.l1_base_fee_scalar = db.storage(L1_BLOCK_CONTRACT, L1_SCALAR_SLOT)?;
             out.l1_fee_overhead = Some(db.storage(L1_BLOCK_CONTRACT, L1_OVERHEAD_SLOT)?);


### PR DESCRIPTION
The comment said "Post-Ecotone" but the condition `!spec_id.is_enabled_in(OpSpecId::ECOTONE)` checks when Ecotone is NOT active, so it's actually pre-Ecotone logic.