### PR TITLE
fix(calldata): handle empty calldata submissions without panicking

### DIFF
--- a/crates/batcher/core/src/driver.rs
+++ b/crates/batcher/core/src/driver.rs
@@ -538,6 +538,48 @@ mod tests {
         });
     }
 
+    /// Calldata submissions with an empty frame list must not panic.
+    /// They should be requeued so the pipeline can recover instead of crashing
+    /// on `sub.frames[0]` indexing.
+    #[test]
+    fn test_empty_calldata_submission_requeues_instead_of_panicking() {
+        Runner::start(Config::seeded(0), |ctx| async move {
+            let recorded = Arc::new(Mutex::new(Recorded::default()));
+            let mut pipeline = TrackingPipeline::new(Arc::clone(&recorded));
+            pipeline.submissions.push_back(BatchSubmission {
+                id: SubmissionId(0),
+                channel_id: ChannelId::default(),
+                da_type: DaType::Calldata,
+                frames: vec![],
+            });
+
+            let handle = ctx.spawn(
+                DriverFixture::build(
+                    ctx.clone(),
+                    pipeline,
+                    ImmediateConfirmTxManager { l1_block: 1 },
+                )
+                .run(),
+            );
+
+            ctx.sleep(Duration::from_millis(50)).await;
+            ctx.cancel();
+
+            assert!(handle.await.unwrap().is_ok(), "driver should exit cleanly on cancellation");
+
+            let recorded = recorded.lock().unwrap();
+            assert_eq!(
+                recorded.requeued,
+                vec![SubmissionId(0)],
+                "empty calldata submission must be requeued instead of panicking"
+            );
+            assert!(
+                recorded.l1_heads.is_empty(),
+                "advance_l1_head must not be called for empty calldata submission"
+            );
+        });
+    }
+
     /// The semaphore must prevent more concurrent in-flight submissions than
     /// `max_pending_transactions`. With max=1 and a tx manager that never
     /// confirms, exactly one submission must be dequeued; the second must not

--- a/crates/batcher/core/src/submissions.rs
+++ b/crates/batcher/core/src/submissions.rs
@@ -81,12 +81,21 @@ impl<TM: TxManager> SubmissionQueue<TM> {
                         continue;
                     }
                 },
-                DaType::Calldata => TxCandidate {
-                    to: Some(self.inbox),
-                    tx_data: FrameEncoder::to_calldata(&sub.frames[0]),
-                    value: U256::ZERO,
-                    gas_limit: 0,
-                    blobs: vec![].into(),
+                DaType::Calldata => {
+                    let Some(frame) = sub.frames.first() else {
+                        warn!(id = %id.0, "calldata submission had no frames, requeueing");
+                        pipeline.requeue(id);
+                        drop(permit);
+                        continue;
+                    };
+
+                    TxCandidate {
+                        to: Some(self.inbox),
+                        tx_data: FrameEncoder::to_calldata(frame),
+                        value: U256::ZERO,
+                        gas_limit: 0,
+                        blobs: vec![].into(),
+                    }
                 },
             };
             info!(


### PR DESCRIPTION
## Summary

Fixes an edge-case panic in the batcher submission path for calldata mode.

## Problem

`SubmissionQueue::submit_pending` indexed `sub.frames[0]` directly for `DaType::Calldata`.  
If a malformed submission has an empty `frames` list, this causes an out-of-bounds panic.

## Changes

- Replaced direct indexing with a safe `first()` check.
- If no frame is present, the submission is requeued and processing continues.
- Added a regression test to verify empty calldata submissions are requeued (and do not advance L1 head).

## Impact

Prevents driver crashes on malformed calldata submissions and preserves normal recovery behavior.
