### PR TITLE
fix(batcher-core): fail fast when max_pending_transactions is zero

### DIFF
--- a/crates/batcher/core/src/driver.rs
+++ b/crates/batcher/core/src/driver.rs
@@ -606,4 +606,20 @@ mod tests {
             );
         });
     }
+
+    #[test]
+    #[should_panic(expected = "max_pending must be greater than zero")]
+    fn test_build_with_zero_max_pending_panics() {
+        Runner::start(Config::seeded(0), |ctx| async move {
+            let recorded = Arc::new(Mutex::new(Recorded::default()));
+            let pipeline = TrackingPipeline::new(Arc::clone(&recorded));
+
+            let _driver = DriverFixture::build_with_max_pending(
+                ctx.clone(),
+                pipeline,
+                ImmediateConfirmTxManager { l1_block: 1 },
+                0,
+            );
+        });
+    }
 }

--- a/crates/batcher/core/src/submissions.rs
+++ b/crates/batcher/core/src/submissions.rs
@@ -33,6 +33,7 @@ pub struct SubmissionQueue<TM: TxManager> {
 impl<TM: TxManager> SubmissionQueue<TM> {
     /// Create a new [`SubmissionQueue`].
     pub fn new(tx_manager: TM, inbox: Address, max_pending: usize) -> Self {
+        assert!(max_pending > 0, "max_pending must be greater than zero");
         Self {
             tx_manager,
             in_flight: FuturesUnordered::new(),


### PR DESCRIPTION
## Summary

Fail fast on invalid `max_pending_transactions = 0` in `base-batcher-core`.

## Problem

`SubmissionQueue` accepted `max_pending = 0`, which created a zero-capacity semaphore.  
In this state, `submit_pending()` could never acquire a permit, so submissions were silently blocked forever.

## Fix

- Added an explicit runtime assertion in `SubmissionQueue::new`:
  - `max_pending must be greater than zero`
- This turns a silent runtime stall into an immediate, actionable configuration error.

## Tests

Added a regression test in `driver.rs`:

- `test_build_with_zero_max_pending_panics`

The test verifies that building the driver with `max_pending_transactions = 0` fails immediately.
