### PR TITLE
feat: allow transactions to be specified in action tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2501,6 +2501,7 @@ version = "0.0.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
+ "alloy-hardforks 0.4.7",
  "alloy-primitives",
  "alloy-rlp",
  "alloy-rpc-types-eth",
@@ -2509,6 +2510,7 @@ dependencies = [
  "alloy-trie",
  "async-trait",
  "base-alloy-consensus",
+ "base-alloy-upgrades",
  "base-batcher-core",
  "base-batcher-encoder",
  "base-batcher-source",

--- a/actions/harness/Cargo.toml
+++ b/actions/harness/Cargo.toml
@@ -19,6 +19,7 @@ alloy-rlp.workspace = true
 alloy-eips.workspace = true
 async-trait.workspace = true
 alloy-signer.workspace = true
+alloy-hardforks.workspace = true
 alloy-primitives.workspace = true
 alloy-trie = { workspace = true, features = ["ethereum"] }
 alloy-consensus = { workspace = true, features = ["std"] }
@@ -28,6 +29,7 @@ base-revm = { workspace = true, features = ["std"] }
 base-protocol = { workspace = true, features = ["std"] }
 base-execution-evm.workspace = true
 base-alloy-consensus = { workspace = true, features = ["std", "evm"] }
+base-alloy-upgrades.workspace = true
 base-execution-chainspec.workspace = true
 base-consensus-genesis = { workspace = true, features = ["std"] }
 base-consensus-derive = { workspace = true, features = ["test-utils"] }

--- a/actions/harness/src/harness.rs
+++ b/actions/harness/src/harness.rs
@@ -88,7 +88,7 @@ impl ActionTestHarness {
     ///
     /// The returned sequencer generates real [`OpBlock`]s with a proper
     /// L1-info deposit transaction (first tx) and signed EIP-1559 user
-    /// transactions. Call `build_next_block()` once per L2 block to advance
+    /// transactions. Call `build_next_block_with_single_transaction()` once per L2 block to advance
     /// the sequencer.
     ///
     /// After mining new L1 blocks, push them to the [`SharedL1Chain`] returned
@@ -143,7 +143,7 @@ impl ActionTestHarness {
         let mut sequencer = self.create_l2_sequencer(chain);
         let mut source = ActionL2Source::new();
         for _ in 0..n {
-            source.push(sequencer.build_next_block());
+            source.push(sequencer.build_next_block_with_single_transaction());
         }
         source
     }

--- a/actions/harness/src/l2.rs
+++ b/actions/harness/src/l2.rs
@@ -5,11 +5,13 @@ use std::{
 
 use alloy_consensus::{Header, SignableTransaction};
 use alloy_eips::BlockNumHash;
+use alloy_hardforks::ForkCondition;
 use alloy_primitives::{Address, B256, Bytes, TxKind, U256};
 use alloy_signer::SignerSync;
 use alloy_signer_local::PrivateKeySigner;
 use alloy_trie::{EMPTY_ROOT_HASH, TrieAccount, root::state_root_unhashed};
 use base_alloy_consensus::{OpBlock, OpTxEnvelope};
+use base_alloy_upgrades::BaseUpgrade;
 use base_consensus_genesis::{L1ChainConfig, RollupConfig, SystemConfig};
 use base_execution_chainspec::OpChainSpecBuilder;
 use base_execution_evm::OpEvmConfig;
@@ -42,6 +44,83 @@ pub const TEST_ACCOUNT_ADDRESS: Address =
 
 /// Initial balance for the test account (1 ETH).
 const TEST_ACCOUNT_BALANCE: U256 = U256::from_limbs([1_000_000_000_000_000_000u64, 0, 0, 0]);
+
+/// A test account with nonce tracking and signing capability.
+///
+/// Wraps a [`PrivateKeySigner`] with an auto-incrementing nonce so callers
+/// can build correctly-sequenced signed transactions without manual bookkeeping.
+/// Shared via [`Arc`] so the sequencer and external test code stay in sync.
+#[derive(Debug)]
+pub struct TestAccount {
+    signer: PrivateKeySigner,
+    nonce: u64,
+}
+
+impl TestAccount {
+    /// Create a new test account from a private key with nonce starting at 0.
+    pub fn new(key: B256) -> Self {
+        let signer = PrivateKeySigner::from_bytes(&key).expect("valid key");
+        Self { signer, nonce: 0 }
+    }
+
+    /// Return the address derived from this account's private key.
+    pub const fn address(&self) -> Address {
+        self.signer.address()
+    }
+
+    /// Sign a pre-built EIP-1559 transaction without modifying the nonce.
+    ///
+    /// The caller is responsible for setting the correct nonce in the
+    /// transaction fields before calling this method.
+    pub fn sign_tx(
+        &mut self,
+        tx: alloy_consensus::TxEip1559,
+    ) -> Result<OpTxEnvelope, alloy_signer::Error> {
+        let sig = self.signer.sign_hash_sync(&tx.signature_hash())?;
+        Ok(OpTxEnvelope::Eip1559(tx.into_signed(sig)))
+    }
+
+    /// Creates and signs a minimal EIP-1559 transfer, auto-incrementing the nonce.
+    pub fn create_eip1559_tx(&mut self, chain_id: u64) -> OpTxEnvelope {
+        self.create_tx(chain_id, TxKind::Call(Address::ZERO), Bytes::new(), U256::from(1), 21_000)
+    }
+
+    /// Creates and signs a custom EIP-1559 transaction, auto-incrementing the nonce.
+    ///
+    /// The caller provides the destination, calldata, value, and gas limit.
+    /// Chain-level fields (`chain_id`, `nonce`, fee caps) are filled in automatically.
+    pub fn create_tx(
+        &mut self,
+        chain_id: u64,
+        to: TxKind,
+        input: Bytes,
+        value: U256,
+        gas_limit: u64,
+    ) -> OpTxEnvelope {
+        let tx = alloy_consensus::TxEip1559 {
+            chain_id,
+            nonce: self.nonce,
+            max_fee_per_gas: 1_000_000_000,
+            max_priority_fee_per_gas: 1_000_000,
+            gas_limit,
+            to,
+            value,
+            input,
+            access_list: Default::default(),
+        };
+        let sig = self
+            .signer
+            .sign_hash_sync(&tx.signature_hash())
+            .expect("test account signing must not fail");
+        self.nonce += 1;
+        OpTxEnvelope::Eip1559(tx.into_signed(sig))
+    }
+
+    /// Return the current nonce.
+    pub const fn nonce(&self) -> u64 {
+        self.nonce
+    }
+}
 
 /// Error type returned by [`L2Sequencer`].
 #[derive(Debug, thiserror::Error)]
@@ -155,12 +234,8 @@ pub struct L2Sequencer {
     l1_chain_config: L1ChainConfig,
     /// Current system config (updated on epoch changes or key rotation).
     system_config: SystemConfig,
-    /// Signer for user transactions.
-    signer: PrivateKeySigner,
-    /// Number of user EIP-1559 transactions to include per block.
-    user_txs_per_block: usize,
-    /// Per-account nonce for the test signer.
-    nonce: u64,
+    /// Test account used for signing user transactions.
+    test_account: Arc<Mutex<TestAccount>>,
     /// In-memory EVM database carrying state across blocks.
     db: InMemoryDB,
     /// Optional pinned L1 origin. When set, epoch selection is bypassed and
@@ -178,8 +253,7 @@ impl L2Sequencer {
         rollup_config: RollupConfig,
         system_config: SystemConfig,
     ) -> Self {
-        let signer = PrivateKeySigner::from_bytes(&TEST_ACCOUNT_KEY)
-            .expect("TEST_ACCOUNT_KEY is a valid secp256k1 scalar");
+        let test_account = Arc::new(Mutex::new(TestAccount::new(TEST_ACCOUNT_KEY)));
 
         let mut db = InMemoryDB::default();
         db.insert_account_info(
@@ -193,24 +267,32 @@ impl L2Sequencer {
             rollup_config,
             l1_chain_config: L1ChainConfig::default(),
             system_config,
-            signer,
-            user_txs_per_block: 1,
-            nonce: 0,
+            test_account,
             db,
             l1_origin_pin: None,
             block_hashes: SharedBlockHashRegistry::new(),
         }
     }
 
-    /// Set the number of signed user transactions included per block.
-    pub const fn with_user_txs_per_block(mut self, n: usize) -> Self {
-        self.user_txs_per_block = n;
-        self
-    }
-
     /// Return the current unsafe L2 head.
     pub const fn head(&self) -> L2BlockInfo {
         self.head
+    }
+
+    /// Return a shared handle to the sequencer's test account.
+    ///
+    /// External test code can use this to build signed transactions with
+    /// correct nonce tracking, independent of the sequencer.
+    pub fn test_account(&self) -> Arc<Mutex<TestAccount>> {
+        Arc::clone(&self.test_account)
+    }
+
+    /// Returns a reference to the sequencer's in-memory EVM database.
+    ///
+    /// Callers can inspect account state and storage written by executed
+    /// transactions.
+    pub const fn db(&self) -> &InMemoryDB {
+        &self.db
     }
 
     /// Return the sequencer's shared block-hash registry.
@@ -246,11 +328,16 @@ impl L2Sequencer {
     ///
     /// [`build_next_block`]: L2Sequencer::build_next_block
     pub fn build_empty_block(&mut self) -> OpBlock {
-        let saved = self.user_txs_per_block;
-        self.user_txs_per_block = 0;
-        let result = self.build_next_block();
-        self.user_txs_per_block = saved;
-        result
+        self.build_next_block_with_transactions(vec![])
+    }
+
+    /// Build the next L2 block with a single transaction.
+    pub fn build_next_block_with_single_transaction(&mut self) -> OpBlock {
+        let tx = {
+            let mut account = self.test_account.lock().expect("test account lock poisoned");
+            account.create_eip1559_tx(self.rollup_config.l2_chain_id.id())
+        };
+        self.build_next_block_with_transactions(vec![tx])
     }
 
     /// Build the next L2 block and advance the internal head.
@@ -265,8 +352,11 @@ impl L2Sequencer {
     /// the error.
     ///
     /// [`try_build_next_block`]: L2Sequencer::try_build_next_block
-    pub fn build_next_block(&mut self) -> OpBlock {
-        self.try_build_next_block()
+    pub fn build_next_block_with_transactions(
+        &mut self,
+        transactions: Vec<OpTxEnvelope>,
+    ) -> OpBlock {
+        self.try_build_next_block_with_transactions(transactions)
             .unwrap_or_else(|e| panic!("L2Sequencer::build_next_block failed: {e}"))
     }
 
@@ -276,7 +366,11 @@ impl L2Sequencer {
     /// callers that need to inspect the failure reason.
     ///
     /// [`build_next_block`]: L2Sequencer::build_next_block
-    pub fn try_build_next_block(&mut self) -> Result<OpBlock, L2SequencerError> {
+    pub fn try_build_next_block_with_transactions(
+        &mut self,
+        transactions: Vec<OpTxEnvelope>,
+    ) -> Result<OpBlock, L2SequencerError> {
+        let mut transactions = transactions;
         let next_number = self.head.block_info.number + 1;
         let next_timestamp = self.head.block_info.timestamp + self.rollup_config.block_time;
         let parent_hash = self.head.block_info.hash;
@@ -320,25 +414,7 @@ impl L2Sequencer {
             next_timestamp,
         )?;
 
-        let mut transactions: Vec<OpTxEnvelope> = vec![OpTxEnvelope::Deposit(deposit_tx)];
-
-        // Build signed EIP-1559 user transactions.
-        for _ in 0..self.user_txs_per_block {
-            let tx = alloy_consensus::TxEip1559 {
-                chain_id: self.rollup_config.l2_chain_id.id(),
-                nonce: self.nonce,
-                max_fee_per_gas: 1_000_000_000,
-                max_priority_fee_per_gas: 1_000_000,
-                gas_limit: 21_000,
-                to: TxKind::Call(Address::ZERO),
-                value: U256::from(1u64),
-                input: Bytes::new(),
-                access_list: Default::default(),
-            };
-            let sig = self.signer.sign_hash_sync(&tx.signature_hash())?;
-            self.nonce += 1;
-            transactions.push(OpTxEnvelope::Eip1559(tx.into_signed(sig)));
-        }
+        transactions.insert(0, OpTxEnvelope::Deposit(deposit_tx));
 
         // Execute transactions against the in-memory EVM.
         let (state_root, gas_used) =
@@ -387,9 +463,14 @@ impl L2Sequencer {
         timestamp: u64,
         parent_hash: B256,
     ) -> Result<(B256, u64), L2SequencerError> {
-        let chain_spec = Arc::new(
-            OpChainSpecBuilder::base_mainnet().chain(self.rollup_config.l2_chain_id).build(),
-        );
+        let mut spec_builder =
+            OpChainSpecBuilder::base_mainnet().chain(self.rollup_config.l2_chain_id);
+
+        if let Some(ts) = self.rollup_config.hardforks.base.v1 {
+            spec_builder = spec_builder.with_fork(BaseUpgrade::V1, ForkCondition::Timestamp(ts));
+        }
+
+        let chain_spec = Arc::new(spec_builder.build());
         let evm_config = OpEvmConfig::optimism(chain_spec);
 
         let header = Header {
@@ -402,9 +483,11 @@ impl L2Sequencer {
         };
 
         let mut cumulative_gas_used = 0u64;
+        let default_sender =
+            self.test_account.lock().expect("test account lock poisoned").address();
 
         for tx in transactions {
-            let sender = tx_sender(tx, &self.signer);
+            let sender = tx_sender(tx, default_sender);
             let op_tx: OpTransaction<TxEnv> = OpTransaction::from_recovered_tx(tx, sender);
 
             let evm_env =
@@ -429,11 +512,11 @@ impl L2Sequencer {
 /// Determine the sender address for a transaction.
 ///
 /// Deposit transactions carry an explicit `from` field. Signed user
-/// transactions are always from [`TEST_ACCOUNT_ADDRESS`] in this test harness.
-const fn tx_sender(tx: &OpTxEnvelope, signer: &PrivateKeySigner) -> Address {
+/// transactions are always from the given `default_sender` in this test harness.
+const fn tx_sender(tx: &OpTxEnvelope, default_sender: Address) -> Address {
     match tx {
         OpTxEnvelope::Deposit(sealed) => sealed.inner().from,
-        _ => signer.address(),
+        _ => default_sender,
     }
 }
 
@@ -476,6 +559,6 @@ fn compute_state_root(db: &InMemoryDB) -> B256 {
 
 impl L2BlockProvider for L2Sequencer {
     fn next_block(&mut self) -> Option<OpBlock> {
-        Some(self.build_next_block())
+        Some(self.build_next_block_with_single_transaction())
     }
 }

--- a/actions/harness/src/lib.rs
+++ b/actions/harness/src/lib.rs
@@ -14,7 +14,7 @@ pub use miner::{
 mod l2;
 pub use l2::{
     ActionL2Source, L2Sequencer, L2SequencerError, SharedBlockHashRegistry, TEST_ACCOUNT_ADDRESS,
-    TEST_ACCOUNT_KEY,
+    TEST_ACCOUNT_KEY, TestAccount,
 };
 
 mod harness;

--- a/actions/harness/tests/base_v1_activation.rs
+++ b/actions/harness/tests/base_v1_activation.rs
@@ -33,7 +33,7 @@ async fn base_v1_derivation_crosses_activation_boundary() {
 
     let mut batcher = Batcher::new(ActionL2Source::new(), &h.rollup_config, batcher_cfg.clone());
     for _ in 1..=4u64 {
-        batcher.push_block(builder.build_next_block());
+        batcher.push_block(builder.build_next_block_with_single_transaction());
         batcher.advance(&mut h.l1).await;
     }
 

--- a/actions/harness/tests/batch_submission.rs
+++ b/actions/harness/tests/batch_submission.rs
@@ -87,7 +87,7 @@ async fn batcher_reorg_during_submission() {
     // Build L2 block 1.
     let l1_chain = SharedL1Chain::from_blocks(h.l1.chain().to_vec());
     let mut sequencer = h.create_l2_sequencer(l1_chain);
-    let block = sequencer.build_next_block();
+    let block = sequencer.build_next_block_with_single_transaction();
 
     let (mut verifier, chain) = h.create_verifier_from_sequencer(
         &sequencer,

--- a/actions/harness/tests/batcher_blobs.rs
+++ b/actions/harness/tests/batcher_blobs.rs
@@ -23,7 +23,7 @@ async fn batcher_blob_da_end_to_end() {
     // One block per L1 inclusion block.
     let mut batcher = Batcher::new(ActionL2Source::new(), &h.rollup_config, batcher_cfg.clone());
     for _ in 1..=3u64 {
-        batcher.push_block(sequencer.build_next_block());
+        batcher.push_block(sequencer.build_next_block_with_single_transaction());
         batcher.advance(&mut h.l1).await;
     }
 
@@ -59,7 +59,7 @@ async fn batcher_multi_blob_packing() {
 
     let l1_chain = SharedL1Chain::from_blocks(h.l1.chain().to_vec());
     let mut sequencer = h.create_l2_sequencer(l1_chain);
-    let block = sequencer.build_next_block();
+    let block = sequencer.build_next_block_with_single_transaction();
 
     let mut source = ActionL2Source::new();
     source.push(block);
@@ -108,7 +108,7 @@ async fn batcher_calldata_da() {
     // One block per L1 inclusion block.
     let mut batcher = Batcher::new(ActionL2Source::new(), &h.rollup_config, batcher_cfg.clone());
     for _ in 1..=3u64 {
-        batcher.push_block(sequencer.build_next_block());
+        batcher.push_block(sequencer.build_next_block_with_single_transaction());
         batcher.advance(&mut h.l1).await;
     }
 
@@ -151,14 +151,14 @@ async fn batcher_da_switching() {
     let mut calldata_batcher =
         Batcher::new(ActionL2Source::new(), &h.rollup_config, calldata_cfg.clone());
     for _ in 1..=3u64 {
-        calldata_batcher.push_block(sequencer.build_next_block());
+        calldata_batcher.push_block(sequencer.build_next_block_with_single_transaction());
         calldata_batcher.advance(&mut h.l1).await;
     }
 
     // Blocks 4-6: submit as blobs.
     let mut blob_batcher = Batcher::new(ActionL2Source::new(), &h.rollup_config, blob_cfg.clone());
     for _ in 4..=6u64 {
-        blob_batcher.push_block(sequencer.build_next_block());
+        blob_batcher.push_block(sequencer.build_next_block_with_single_transaction());
         blob_batcher.advance(&mut h.l1).await;
     }
 
@@ -212,7 +212,7 @@ async fn blob_da_channel_timeout() {
 
     let l1_chain = SharedL1Chain::from_blocks(h.l1.chain().to_vec());
     let mut sequencer = h.create_l2_sequencer(l1_chain);
-    let block = sequencer.build_next_block();
+    let block = sequencer.build_next_block_with_single_transaction();
 
     // Encode the L2 block into multiple frames (tiny max_frame_size).
     let mut source = ActionL2Source::new();

--- a/actions/harness/tests/batcher_channels.rs
+++ b/actions/harness/tests/batcher_channels.rs
@@ -29,7 +29,7 @@ async fn channel_timeout_triggers_channel_invalidation() {
 
     let l1_chain = SharedL1Chain::from_blocks(h.l1.chain().to_vec());
     let mut sequencer = h.create_l2_sequencer(l1_chain);
-    let block = sequencer.build_next_block();
+    let block = sequencer.build_next_block_with_single_transaction();
 
     // Create verifier before any mining so all future blocks are pushed to chain.
     let (mut verifier, chain) = h.create_verifier_from_sequencer(
@@ -117,7 +117,7 @@ async fn channel_timeout_recovery_resubmits_successfully() {
 
     let l1_chain = SharedL1Chain::from_blocks(h.l1.chain().to_vec());
     let mut sequencer = h.create_l2_sequencer(l1_chain);
-    let block = sequencer.build_next_block();
+    let block = sequencer.build_next_block_with_single_transaction();
 
     // Create verifier before any mining so all future blocks are pushed to chain.
     let (mut verifier, chain) = h.create_verifier_from_sequencer(
@@ -198,8 +198,8 @@ async fn interleaved_channels_correctly_reassembled() {
 
     let l1_chain = SharedL1Chain::from_blocks(h.l1.chain().to_vec());
     let mut sequencer = h.create_l2_sequencer(l1_chain);
-    let block_a = sequencer.build_next_block();
-    let block_b = sequencer.build_next_block();
+    let block_a = sequencer.build_next_block_with_single_transaction();
+    let block_b = sequencer.build_next_block_with_single_transaction();
 
     // Batcher A: block 1 in its own channel (distinct random channel ID).
     let mut source_a = ActionL2Source::new();
@@ -267,7 +267,7 @@ async fn multi_block_channel_assembles_across_l1_blocks() {
 
     let l1_chain = SharedL1Chain::from_blocks(h.l1.chain().to_vec());
     let mut sequencer = h.create_l2_sequencer(l1_chain);
-    let block = sequencer.build_next_block();
+    let block = sequencer.build_next_block_with_single_transaction();
 
     // Create verifier before any mining so all future blocks are pushed to chain.
     let (mut verifier, chain) = h.create_verifier_from_sequencer(
@@ -345,7 +345,7 @@ async fn multi_frame_channel_with_empty_l1_gap_derives_correctly() {
 
     let l1_chain = SharedL1Chain::from_blocks(h.l1.chain().to_vec());
     let mut sequencer = h.create_l2_sequencer(l1_chain);
-    let block = sequencer.build_next_block();
+    let block = sequencer.build_next_block_with_single_transaction();
 
     // Create verifier before any mining so all future blocks are pushed to chain.
     let (mut verifier, chain) = h.create_verifier_from_sequencer(

--- a/actions/harness/tests/batcher_hardfork_transitions.rs
+++ b/actions/harness/tests/batcher_hardfork_transitions.rs
@@ -57,13 +57,13 @@ async fn span_batch_with_non_empty_transition_block_rejected() {
     let l1_chain = SharedL1Chain::from_blocks(h.l1.chain().to_vec());
     let mut builder = h.create_l2_sequencer(l1_chain);
 
-    // Build 4 L2 blocks. build_next_block() includes a user transaction in
+    // Build 4 L2 blocks. build_next_block_with_single_transaction() includes a user transaction in
     // every block. Block 3 (ts=6) is the first Jovian block, which must be
     // deposit-only — including a user tx here is the deliberate error.
-    let block1 = builder.build_next_block(); // ts=2
-    let block2 = builder.build_next_block(); // ts=4
-    let block3_invalid = builder.build_next_block(); // ts=6
-    let block4 = builder.build_next_block(); // ts=8
+    let block1 = builder.build_next_block_with_single_transaction(); // ts=2
+    let block2 = builder.build_next_block_with_single_transaction(); // ts=4
+    let block3_invalid = builder.build_next_block_with_single_transaction(); // ts=6
+    let block4 = builder.build_next_block_with_single_transaction(); // ts=8
 
     let (mut verifier, chain) = h.create_verifier_from_sequencer(
         &builder,
@@ -110,10 +110,10 @@ async fn span_batch_with_non_empty_transition_block_rejected() {
     {
         let l1_chain2 = SharedL1Chain::from_blocks(h.l1.chain().to_vec());
         let mut builder2 = h.create_l2_sequencer(l1_chain2);
-        let _rb1 = builder2.build_next_block();
-        let _rb2 = builder2.build_next_block();
+        let _rb1 = builder2.build_next_block_with_single_transaction();
+        let _rb2 = builder2.build_next_block_with_single_transaction();
         let block3_empty = builder2.build_empty_block();
-        let block4_recovery = builder2.build_next_block();
+        let block4_recovery = builder2.build_next_block_with_single_transaction();
 
         let span_cfg = BatcherConfig { batch_type: BatchType::Span, ..batcher_cfg };
         let mut source = ActionL2Source::new();
@@ -160,8 +160,8 @@ async fn mixed_singular_and_span_batches_after_delta() {
     let l1_chain = SharedL1Chain::from_blocks(h.l1.chain().to_vec());
     let mut builder = h.create_l2_sequencer(l1_chain);
 
-    let block1 = builder.build_next_block();
-    let block2 = builder.build_next_block();
+    let block1 = builder.build_next_block_with_single_transaction();
+    let block2 = builder.build_next_block_with_single_transaction();
 
     let (mut verifier, chain) = h.create_verifier_from_sequencer(
         &builder,
@@ -265,7 +265,7 @@ async fn granite_channel_timeout_enforced() {
 
     let l1_chain = SharedL1Chain::from_blocks(h.l1.chain().to_vec());
     let mut sequencer = h.create_l2_sequencer(l1_chain);
-    let block = sequencer.build_next_block();
+    let block = sequencer.build_next_block_with_single_transaction();
 
     let (mut verifier, chain) = h.create_verifier_from_sequencer(
         &sequencer,
@@ -412,16 +412,16 @@ async fn jovian_single_batch_transition_block_deposit_only() {
     let l1_chain = SharedL1Chain::from_blocks(h.l1.chain().to_vec());
     let mut builder = h.create_l2_sequencer(l1_chain);
 
-    // Build 4 L2 blocks. build_next_block() includes a user transaction in
+    // Build 4 L2 blocks. build_next_block_with_single_transaction() includes a user transaction in
     // every block. Block 3 (ts=6) is the first Jovian block — including a
     // user tx is the deliberate error that derivation must handle.
-    let block1 = builder.build_next_block(); // ts=2
-    let block2 = builder.build_next_block(); // ts=4
-    let block3_invalid = builder.build_next_block(); // ts=6
-    let block4 = builder.build_next_block(); // ts=8
+    let block1 = builder.build_next_block_with_single_transaction(); // ts=2
+    let block2 = builder.build_next_block_with_single_transaction(); // ts=4
+    let block3_invalid = builder.build_next_block_with_single_transaction(); // ts=6
+    let block4 = builder.build_next_block_with_single_transaction(); // ts=8
 
     // Precondition: block 3 must contain at least one user transaction (deposits
-    // don't count). If build_next_block() ever started returning empty blocks,
+    // don't count). If build_next_block_with_single_transaction() ever started returning empty blocks,
     // this test would silently stop exercising the NonEmptyTransitionBlock path.
     assert!(
         block3_invalid.body.transactions.len() > 1,

--- a/actions/harness/tests/batcher_sequencer_drift.rs
+++ b/actions/harness/tests/batcher_sequencer_drift.rs
@@ -80,7 +80,7 @@ async fn sequencer_drift_produces_deposit_only_blocks() {
     // Collect all 8 blocks and batch them in one L1 block.
     let mut source = ActionL2Source::new();
     for _ in 1u64..=8 {
-        source.push(sequencer.build_next_block());
+        source.push(sequencer.build_next_block_with_single_transaction());
     }
     let mut batcher = Batcher::new(source, &h.rollup_config, batcher_cfg.clone());
     batcher.advance(&mut h.l1).await;
@@ -166,7 +166,7 @@ async fn sequencer_drift_forced_empty_blocks_accepted() {
     // (over drift, ts=2100, 2400). block_time=300 s, max_drift=1800 s.
     let mut source = ActionL2Source::new();
     for _ in 1u64..=6 {
-        source.push(sequencer.build_next_block());
+        source.push(sequencer.build_next_block_with_single_transaction());
     }
     // Build empty blocks past the drift boundary. The empty block has only
     // the deposit tx — the batcher encodes it but the pipeline drops it

--- a/actions/harness/tests/derivation.rs
+++ b/actions/harness/tests/derivation.rs
@@ -29,7 +29,7 @@ async fn single_l2_block_derived_from_batcher_frame() {
     let l1_chain = SharedL1Chain::from_blocks(h.l1.chain().to_vec());
     let mut builder = h.create_l2_sequencer(l1_chain);
     let mut source = ActionL2Source::new();
-    source.push(builder.build_next_block());
+    source.push(builder.build_next_block_with_single_transaction());
     Batcher::new(source, &h.rollup_config, batcher_cfg.clone()).advance(&mut h.l1).await;
 
     // Create the verifier AFTER mining so the SharedL1Chain snapshot already
@@ -80,7 +80,7 @@ async fn multiple_l1_blocks_each_derive_one_l2_block() {
 
     let mut batcher = Batcher::new(ActionL2Source::new(), &h.rollup_config, batcher_cfg.clone());
     for _ in 1..=L2_BLOCK_COUNT {
-        batcher.push_block(builder.build_next_block());
+        batcher.push_block(builder.build_next_block_with_single_transaction());
         batcher.advance(&mut h.l1).await;
     }
 
@@ -117,7 +117,7 @@ async fn batch_in_orphaned_l1_block_is_not_derived() {
     let l1_chain = SharedL1Chain::from_blocks(h.l1.chain().to_vec());
     let mut builder = h.create_l2_sequencer(l1_chain);
     let mut source = ActionL2Source::new();
-    source.push(builder.build_next_block());
+    source.push(builder.build_next_block_with_single_transaction());
     Batcher::new(source, &h.rollup_config, batcher_cfg.clone()).advance(&mut h.l1).await;
 
     // Reorg L1 back to genesis; mine an empty replacement block 1'.
@@ -157,7 +157,7 @@ async fn reorg_reverts_derived_safe_head() {
     let l1_chain = SharedL1Chain::from_blocks(h.l1.chain().to_vec());
     let mut builder = h.create_l2_sequencer(l1_chain);
     let mut source = ActionL2Source::new();
-    source.push(builder.build_next_block());
+    source.push(builder.build_next_block_with_single_transaction());
     Batcher::new(source, &h.rollup_config, batcher_cfg.clone()).advance(&mut h.l1).await;
 
     // Create the verifier and derive L2 block 1.
@@ -214,7 +214,7 @@ async fn reorg_and_resubmit_rederives_l2_block() {
     // --- Pre-reorg: derive L2 block 1 from L1 block 1. ---
     let l1_chain = SharedL1Chain::from_blocks(h.l1.chain().to_vec());
     let mut builder = h.create_l2_sequencer(l1_chain);
-    let block1 = builder.build_next_block();
+    let block1 = builder.build_next_block_with_single_transaction();
 
     {
         let mut source = ActionL2Source::new();
@@ -289,7 +289,7 @@ async fn reorg_flip_flop() {
     // epoch info is the same (all forks reference L1 genesis as epoch 0).
     let l1_chain = SharedL1Chain::from_blocks(h.l1.chain().to_vec());
     let mut sequencer = h.create_l2_sequencer(l1_chain);
-    let block1 = sequencer.build_next_block();
+    let block1 = sequencer.build_next_block_with_single_transaction();
 
     // Shared reset helpers — computed once, valid across all forks because
     // genesis is immutable.
@@ -381,8 +381,8 @@ async fn reorg_flip_flop_empty_middle_fork() {
     // and their encoded batch frames are valid on any fork sharing genesis.
     let l1_chain = SharedL1Chain::from_blocks(h.l1.chain().to_vec());
     let mut builder = h.create_l2_sequencer(l1_chain);
-    let block1 = builder.build_next_block();
-    let block2 = builder.build_next_block();
+    let block1 = builder.build_next_block_with_single_transaction();
+    let block2 = builder.build_next_block_with_single_transaction();
 
     // Shared reset targets — valid across all forks because genesis is immutable.
     let l1_genesis = block_info_from(h.l1.chain().first().expect("genesis always present"));
@@ -504,7 +504,7 @@ async fn batch_accepted_at_last_seq_window_block() {
     // Build L2 block 1 referencing L1 genesis (epoch 0).
     let l1_chain = SharedL1Chain::from_blocks(h.l1.chain().to_vec());
     let mut builder = h.create_l2_sequencer(l1_chain);
-    let block1 = builder.build_next_block();
+    let block1 = builder.build_next_block_with_single_transaction();
 
     // Mine 2 empty L1 blocks (no batch yet).
     h.mine_l1_blocks(2); // blocks 1 and 2
@@ -559,7 +559,7 @@ async fn l1_deposit_included_in_derived_l2_block() {
     // Build L2 block 1 from the sequencer.
     let l1_chain = SharedL1Chain::from_blocks(h.l1.chain().to_vec());
     let mut sequencer = h.create_l2_sequencer(l1_chain);
-    let block1 = sequencer.build_next_block();
+    let block1 = sequencer.build_next_block_with_single_transaction();
 
     // Enqueue a user deposit log: from=0xAA..AA, to=0xBB..BB, value=1 ETH, gas=100k.
     h.l1.enqueue_user_deposit(&UserDeposit {
@@ -641,9 +641,9 @@ async fn batcher_key_rotation_accepts_new_batcher() {
     // stay in epoch 0 (genesis ts=0), so the builder picks the same L1 origin.
     let l1_chain = SharedL1Chain::from_blocks(h.l1.chain().to_vec());
     let mut builder = h.create_l2_sequencer(l1_chain);
-    let block1 = builder.build_next_block();
-    let block2 = builder.build_next_block();
-    let block3 = builder.build_next_block();
+    let block1 = builder.build_next_block_with_single_transaction();
+    let block2 = builder.build_next_block_with_single_transaction();
+    let block3 = builder.build_next_block_with_single_transaction();
 
     // --- L1 blocks 1-2: batcher A submits → L2 blocks 1-2 derived. ---
     let mut batcher = Batcher::new(ActionL2Source::new(), &h.rollup_config, batcher_a.clone());
@@ -729,7 +729,7 @@ async fn multi_l2_per_l1_epoch() {
 
     let mut batcher = Batcher::new(ActionL2Source::new(), &h.rollup_config, batcher_cfg.clone());
     for _ in 1..=L2_COUNT {
-        batcher.push_block(builder.build_next_block());
+        batcher.push_block(builder.build_next_block_with_single_transaction());
         batcher.advance(&mut h.l1).await;
         chain.push(h.l1.tip().clone());
     }
@@ -775,7 +775,7 @@ async fn batch_past_sequence_window_rejected() {
     // Build L2 block 1 (epoch 0).
     let l1_chain = SharedL1Chain::from_blocks(h.l1.chain().to_vec());
     let mut builder = h.create_l2_sequencer(l1_chain);
-    let block1 = builder.build_next_block();
+    let block1 = builder.build_next_block_with_single_transaction();
 
     // Mine 2 empty L1 blocks (seq_window=3, so valid inclusion is blocks 1 and 2 only).
     // Batch is valid if inclusion_block < epoch + seq_window = 0 + 3 = 3.
@@ -848,7 +848,7 @@ async fn multi_epoch_sequence() {
 
     let mut blocks = Vec::new();
     for _ in 0..12 {
-        let block = builder.build_next_block();
+        let block = builder.build_next_block_with_single_transaction();
         blocks.push(block);
     }
 
@@ -904,7 +904,7 @@ async fn same_epoch_multi_batch_one_l1_block() {
 
     let mut source = ActionL2Source::new();
     for _ in 1..=3u64 {
-        let block = builder.build_next_block();
+        let block = builder.build_next_block_with_single_transaction();
         source.push(block);
     }
 
@@ -947,7 +947,7 @@ async fn deep_reorg_multi_block() {
     // Build 5 L2 blocks.
     let mut blocks = Vec::new();
     for _ in 0..5 {
-        let block = builder.build_next_block();
+        let block = builder.build_next_block_with_single_transaction();
         blocks.push(block);
     }
 
@@ -1018,7 +1018,7 @@ async fn garbage_frame_data_ignored() {
 
     let l1_chain = SharedL1Chain::from_blocks(h.l1.chain().to_vec());
     let mut builder = h.create_l2_sequencer(l1_chain);
-    let block = builder.build_next_block();
+    let block = builder.build_next_block_with_single_transaction();
 
     let (mut verifier, chain) = h.create_verifier_from_sequencer(
         &builder,
@@ -1087,7 +1087,7 @@ async fn multi_frame_channel_reassembled() {
 
     let l1_chain = SharedL1Chain::from_blocks(h.l1.chain().to_vec());
     let mut builder = h.create_l2_sequencer(l1_chain);
-    let block = builder.build_next_block();
+    let block = builder.build_next_block_with_single_transaction();
 
     let (mut verifier, chain) = h.create_verifier_from_sequencer(
         &builder,
@@ -1141,7 +1141,7 @@ async fn single_l2_block_derived_from_span_batch() {
     let l1_chain = SharedL1Chain::from_blocks(h.l1.chain().to_vec());
     let mut sequencer = h.create_l2_sequencer(l1_chain);
     let mut source = ActionL2Source::new();
-    source.push(sequencer.build_next_block());
+    source.push(sequencer.build_next_block_with_single_transaction());
     Batcher::new(source, &h.rollup_config, batcher_cfg.clone()).advance(&mut h.l1).await;
 
     let (mut verifier, _chain) = h.create_verifier_from_sequencer(
@@ -1177,7 +1177,7 @@ async fn three_l2_blocks_derived_from_span_batch() {
 
     let mut source = ActionL2Source::new();
     for _ in 1..=3u64 {
-        let block = sequencer.build_next_block();
+        let block = sequencer.build_next_block_with_single_transaction();
         source.push(block);
     }
     Batcher::new(source, &h.rollup_config, batcher_cfg.clone()).advance(&mut h.l1).await;
@@ -1218,8 +1218,8 @@ async fn gpo_params_change_does_not_disrupt_derivation() {
 
     let l1_chain = SharedL1Chain::from_blocks(h.l1.chain().to_vec());
     let mut sequencer = h.create_l2_sequencer(l1_chain);
-    let block1 = sequencer.build_next_block();
-    let block2 = sequencer.build_next_block();
+    let block1 = sequencer.build_next_block_with_single_transaction();
+    let block2 = sequencer.build_next_block_with_single_transaction();
 
     // L1 block 1: batch for L2 block 1.
     {
@@ -1274,8 +1274,8 @@ async fn gas_limit_change_does_not_disrupt_derivation() {
 
     let l1_chain = SharedL1Chain::from_blocks(h.l1.chain().to_vec());
     let mut sequencer = h.create_l2_sequencer(l1_chain);
-    let block1 = sequencer.build_next_block();
-    let block2 = sequencer.build_next_block();
+    let block1 = sequencer.build_next_block_with_single_transaction();
+    let block2 = sequencer.build_next_block_with_single_transaction();
 
     // L1 block 1: batch for L2 block 1.
     {
@@ -1329,7 +1329,7 @@ async fn garbage_payload_silently_ignored_then_valid_batch_derived(
 
     let l1_chain = SharedL1Chain::from_blocks(h.l1.chain().to_vec());
     let mut sequencer = h.create_l2_sequencer(l1_chain);
-    let block = sequencer.build_next_block();
+    let block = sequencer.build_next_block_with_single_transaction();
 
     // L1 block 1: garbage frame only.
     h.l1.submit_tx(PendingTx {
@@ -1436,8 +1436,8 @@ async fn l2_finalized_advances_via_l1_finalized_signal() {
     let l1_chain = SharedL1Chain::from_blocks(h.l1.chain().to_vec());
     let mut sequencer = h.create_l2_sequencer(l1_chain);
 
-    let block1 = sequencer.build_next_block();
-    let block2 = sequencer.build_next_block();
+    let block1 = sequencer.build_next_block_with_single_transaction();
+    let block2 = sequencer.build_next_block_with_single_transaction();
 
     let mut batcher = Batcher::new(ActionL2Source::new(), &h.rollup_config, batcher_cfg.clone());
     for block in [block1, block2] {
@@ -1499,7 +1499,7 @@ async fn sequencer_pin_l1_origin_keeps_epoch_and_empty_block() {
     // Build 3 L2 blocks — all must reference epoch 0 even though L1 blocks 1
     // and 2 are available.
     for _ in 0..3 {
-        let _block = sequencer.build_next_block();
+        let _block = sequencer.build_next_block_with_single_transaction();
         assert_eq!(
             sequencer.head().l1_origin.number,
             0,
@@ -1518,7 +1518,7 @@ async fn sequencer_pin_l1_origin_keeps_epoch_and_empty_block() {
 
     // Clear the pin — automatic epoch selection resumes.
     sequencer.clear_l1_origin_pin();
-    let _block = sequencer.build_next_block();
+    let _block = sequencer.build_next_block_with_single_transaction();
     // With block_time=2 and L1 block 1 at ts=12, the first unpinned block's
     // timestamp (current head ts + 2) is well below 12, so the epoch remains
     // at 0. Regardless, we just verify the pin was cleared without error.
@@ -1589,7 +1589,7 @@ async fn derive_chain_from_near_l1_genesis() {
     // Build 2 L2 blocks and batch them into L1 blocks #6 and #7.
     let mut batcher = Batcher::new(ActionL2Source::new(), &rollup_cfg, batcher_cfg.clone());
     for _ in 1..=2u64 {
-        let block = sequencer.build_next_block();
+        let block = sequencer.build_next_block_with_single_transaction();
         // With block_time=2 and L1 block 6 at ts=72, L2 block ts < 72
         // so the epoch stays at 5.
         assert_eq!(sequencer.head().l1_origin.number, 5, "epoch should stay at 5");
@@ -1644,7 +1644,7 @@ async fn single_l2_block_derived_from_blob() {
     let l1_chain = SharedL1Chain::from_blocks(h.l1.chain().to_vec());
     let mut builder = h.create_l2_sequencer(l1_chain);
     let mut source = ActionL2Source::new();
-    source.push(builder.build_next_block());
+    source.push(builder.build_next_block_with_single_transaction());
     Batcher::new(source, &h.rollup_config, batcher_cfg.clone()).advance(&mut h.l1).await;
 
     // Create the blob verifier AFTER mining so the snapshot contains the blob.
@@ -1676,7 +1676,7 @@ async fn multiple_l2_blocks_derived_from_blob() {
 
     let mut source = ActionL2Source::new();
     for _ in 1..=L2_BLOCK_COUNT {
-        source.push(builder.build_next_block());
+        source.push(builder.build_next_block_with_single_transaction());
     }
 
     // Encode all 3 blocks into a single blob channel and mine.
@@ -1736,9 +1736,9 @@ async fn batcher_config_update_rolled_back_on_reorg() {
     // Build L2 blocks 1, 2, 3 upfront from the L1 genesis state.
     let l1_chain = SharedL1Chain::from_blocks(h.l1.chain().to_vec());
     let mut builder = h.create_l2_sequencer(l1_chain);
-    let block1 = builder.build_next_block();
-    let block2 = builder.build_next_block();
-    let block3 = builder.build_next_block();
+    let block1 = builder.build_next_block_with_single_transaction();
+    let block2 = builder.build_next_block_with_single_transaction();
+    let block3 = builder.build_next_block_with_single_transaction();
 
     // Clone blocks for resubmission on the new fork after reorg.
     let block1_clone = block1.clone();
@@ -1854,8 +1854,8 @@ async fn out_of_order_singular_batches_reordered_by_batch_queue() {
     let mut builder = h.create_l2_sequencer(l1_chain);
 
     // Build 2 L2 blocks in epoch 0 (both reference L1 genesis as L1 origin).
-    let block1 = builder.build_next_block();
-    let block2 = builder.build_next_block();
+    let block1 = builder.build_next_block_with_single_transaction();
+    let block2 = builder.build_next_block_with_single_transaction();
 
     let (mut verifier, chain) = h.create_verifier_from_sequencer(
         &builder,
@@ -1942,7 +1942,7 @@ async fn pipeline_idle_before_l1_signal_derives_after() {
 
     let l1_chain = SharedL1Chain::from_blocks(h.l1.chain().to_vec());
     let mut builder = h.create_l2_sequencer(l1_chain);
-    let block1 = builder.build_next_block();
+    let block1 = builder.build_next_block_with_single_transaction();
 
     let (mut verifier, chain) = h.create_verifier_from_sequencer(
         &builder,
@@ -2006,8 +2006,8 @@ async fn pipeline_l1_origin_advance_observable_after_epoch_exhausted() {
     let mut builder = h.create_l2_sequencer(l1_chain);
 
     // Build 2 L2 blocks and submit them in a single L1 channel (same L1 block).
-    let block1 = builder.build_next_block();
-    let block2 = builder.build_next_block();
+    let block1 = builder.build_next_block_with_single_transaction();
+    let block2 = builder.build_next_block_with_single_transaction();
 
     let (mut verifier, chain) = h.create_verifier_from_sequencer(
         &builder,
@@ -2097,7 +2097,7 @@ async fn span_batch_crossing_l1_epoch_boundary() {
     // Blocks 1–5 (ts=2..10) reference epoch 0; block 6 (ts=12) references epoch 1.
     let mut source = ActionL2Source::new();
     for _ in 1..=6u64 {
-        source.push(builder.build_next_block());
+        source.push(builder.build_next_block_with_single_transaction());
     }
     assert_eq!(builder.head().l1_origin.number, 1, "block 6 must reference epoch 1");
 
@@ -2159,8 +2159,8 @@ async fn out_of_order_span_batches_reordered_by_batch_queue() {
     let l1_chain = SharedL1Chain::from_blocks(h.l1.chain().to_vec());
     let mut builder = h.create_l2_sequencer(l1_chain);
 
-    let block1 = builder.build_next_block();
-    let block2 = builder.build_next_block();
+    let block1 = builder.build_next_block_with_single_transaction();
+    let block2 = builder.build_next_block_with_single_transaction();
 
     let (mut verifier, chain) = h.create_verifier_from_sequencer(
         &builder,
@@ -2245,8 +2245,8 @@ async fn large_l1_gaps_within_sequence_window() {
     let mut builder = h.create_l2_sequencer(l1_chain);
 
     // Build 2 L2 blocks in epoch 0 (both reference L1 genesis as their origin).
-    let block1 = builder.build_next_block();
-    let block2 = builder.build_next_block();
+    let block1 = builder.build_next_block_with_single_transaction();
+    let block2 = builder.build_next_block_with_single_transaction();
 
     let (mut verifier, chain) = h.create_verifier_from_sequencer(
         &builder,

--- a/actions/harness/tests/ecotone_activation.rs
+++ b/actions/harness/tests/ecotone_activation.rs
@@ -45,7 +45,7 @@ fn ecotone_l1_info_format_transitions_at_activation() {
     let mut builder = h.create_l2_sequencer(l1_chain);
 
     // Block 1: ts=2 — pre-Ecotone. Expect Bedrock format.
-    let block1 = builder.build_next_block();
+    let block1 = builder.build_next_block_with_single_transaction();
     let info1 = ActionTestHarness::l1_info_from_block(&block1);
     assert!(
         matches!(info1, L1BlockInfoTx::Bedrock(_)),
@@ -53,7 +53,7 @@ fn ecotone_l1_info_format_transitions_at_activation() {
     );
 
     // Block 2: ts=4 — still pre-Ecotone. Expect Bedrock format.
-    let block2 = builder.build_next_block();
+    let block2 = builder.build_next_block_with_single_transaction();
     let info2 = ActionTestHarness::l1_info_from_block(&block2);
     assert!(
         matches!(info2, L1BlockInfoTx::Bedrock(_)),
@@ -73,7 +73,7 @@ fn ecotone_l1_info_format_transitions_at_activation() {
 
     // Block 4: ts=8 — second Ecotone block. L1Block contract now upgraded.
     // Sequencer sends Ecotone-format L1 info tx.
-    let block4 = builder.build_next_block();
+    let block4 = builder.build_next_block_with_single_transaction();
     let info4 = ActionTestHarness::l1_info_from_block(&block4);
     assert!(
         matches!(info4, L1BlockInfoTx::Ecotone(_)),
@@ -130,14 +130,14 @@ async fn ecotone_activation_block_user_txs_accepted_at_batch_layer() {
 
     // Blocks 1 and 2: pre-Ecotone, user txs OK.
     for _ in 1..=2u64 {
-        batcher.push_block(builder.build_next_block());
+        batcher.push_block(builder.build_next_block_with_single_transaction());
         batcher.advance(&mut h.l1).await;
     }
 
     // Block 3 at ts=6 (first Ecotone): build WITH a user tx. Unlike Jovian,
     // Ecotone has no NonEmptyTransitionBlock batch check, so this batch is
     // accepted and block 3 is NOT deposit-only.
-    let block3_with_user_tx = builder.build_next_block();
+    let block3_with_user_tx = builder.build_next_block_with_single_transaction();
     assert_eq!(
         block3_with_user_tx.header.timestamp, ecotone_time,
         "block 3 must land exactly at ecotone_time"
@@ -146,7 +146,7 @@ async fn ecotone_activation_block_user_txs_accepted_at_batch_layer() {
     batcher.advance(&mut h.l1).await;
 
     // Block 4: post-Ecotone, user txs OK.
-    batcher.push_block(builder.build_next_block());
+    batcher.push_block(builder.build_next_block_with_single_transaction());
     batcher.advance(&mut h.l1).await;
 
     let (mut verifier, _chain) = h.create_verifier_from_sequencer(
@@ -221,7 +221,7 @@ async fn ecotone_derivation_crosses_activation_boundary() {
             // the pipeline prepends the Ecotone upgrade transactions here.
             builder.build_empty_block()
         } else {
-            builder.build_next_block()
+            builder.build_next_block_with_single_transaction()
         };
         batcher.push_block(block);
         batcher.advance(&mut h.l1).await;

--- a/actions/harness/tests/finalization.rs
+++ b/actions/harness/tests/finalization.rs
@@ -24,7 +24,7 @@ async fn finalization_advances_with_multiple_l2_blocks_per_epoch() {
 
     let mut blocks = Vec::new();
     for _ in 0..3 {
-        let block = sequencer.build_next_block();
+        let block = sequencer.build_next_block_with_single_transaction();
         blocks.push(block);
     }
     // All blocks should reference epoch 0.
@@ -96,7 +96,7 @@ async fn finalization_advances_incrementally_with_l1_epochs() {
     let mut blocks = Vec::new();
     let mut last_epoch_0_number = 0u64;
     for i in 1..=6u64 {
-        let block = sequencer.build_next_block();
+        let block = sequencer.build_next_block_with_single_transaction();
         let head = sequencer.head();
         blocks.push(block);
         if head.l1_origin.number == 0 {
@@ -168,8 +168,8 @@ async fn finalization_does_not_exceed_safe_head() {
     let l1_chain = SharedL1Chain::from_blocks(h.l1.chain().to_vec());
     let mut sequencer = h.create_l2_sequencer(l1_chain);
 
-    let block1 = sequencer.build_next_block();
-    let block2 = sequencer.build_next_block();
+    let block1 = sequencer.build_next_block_with_single_transaction();
+    let block2 = sequencer.build_next_block_with_single_transaction();
 
     // Submit each block via the batcher.
     let mut batcher = Batcher::new(ActionL2Source::new(), &h.rollup_config, batcher_cfg.clone());
@@ -230,8 +230,8 @@ async fn finalization_reorg_clears_state() {
     let l1_chain = SharedL1Chain::from_blocks(h.l1.chain().to_vec());
     let mut sequencer = h.create_l2_sequencer(l1_chain);
 
-    let block1 = sequencer.build_next_block();
-    let block2 = sequencer.build_next_block();
+    let block1 = sequencer.build_next_block_with_single_transaction();
+    let block2 = sequencer.build_next_block_with_single_transaction();
 
     // Submit and mine.
     let mut batcher = Batcher::new(ActionL2Source::new(), &h.rollup_config, batcher_cfg.clone());
@@ -280,7 +280,7 @@ async fn finalization_reorg_clears_state() {
     // Build a new L2 block on the fresh fork.
     let l1_chain_fresh = SharedL1Chain::from_blocks(h.l1.chain().to_vec());
     let mut sequencer_fresh = h.create_l2_sequencer(l1_chain_fresh);
-    let block1_fresh = sequencer_fresh.build_next_block();
+    let block1_fresh = sequencer_fresh.build_next_block_with_single_transaction();
 
     // Register the block hash before mining so the verifier can validate it.
     verifier.register_block_hash(1, block1_fresh.header.hash_slow());
@@ -329,7 +329,7 @@ async fn finalization_does_not_regress() {
 
     let mut blocks = Vec::new();
     for _ in 0..6 {
-        let block = sequencer.build_next_block();
+        let block = sequencer.build_next_block_with_single_transaction();
         blocks.push(block);
     }
 

--- a/actions/harness/tests/hardfork_activation.rs
+++ b/actions/harness/tests/hardfork_activation.rs
@@ -268,8 +268,8 @@ async fn span_batch_rejected_before_delta() {
 
     // Both blocks in one source, one advance produces a span batch.
     let mut source = ActionL2Source::new();
-    source.push(builder.build_next_block());
-    source.push(builder.build_next_block());
+    source.push(builder.build_next_block_with_single_transaction());
+    source.push(builder.build_next_block_with_single_transaction());
     let mut batcher = Batcher::new(source, &h.rollup_config, span_cfg);
     batcher.advance(&mut h.l1).await;
 
@@ -312,8 +312,8 @@ async fn span_batch_derives_after_delta() {
 
     // Both blocks in one source → one span batch in one L1 block.
     let mut source = ActionL2Source::new();
-    source.push(builder.build_next_block());
-    source.push(builder.build_next_block());
+    source.push(builder.build_next_block_with_single_transaction());
+    source.push(builder.build_next_block_with_single_transaction());
     let mut batcher = Batcher::new(source, &h.rollup_config, span_cfg);
     batcher.advance(&mut h.l1).await;
 
@@ -347,7 +347,7 @@ async fn single_batch_derives_with_fjord() {
 
     let mut batcher = Batcher::new(ActionL2Source::new(), &h.rollup_config, batcher_cfg.clone());
     for _ in 0..2 {
-        batcher.push_block(builder.build_next_block());
+        batcher.push_block(builder.build_next_block_with_single_transaction());
         batcher.advance(&mut h.l1).await;
     }
 
@@ -409,7 +409,7 @@ async fn jovian_derivation_crosses_activation_boundary() {
             // First Jovian block: must contain no user transactions.
             builder.build_empty_block()
         } else {
-            builder.build_next_block()
+            builder.build_next_block_with_single_transaction()
         };
         batcher.push_block(block);
         batcher.advance(&mut h.l1).await;

--- a/actions/harness/tests/holocene_activation.rs
+++ b/actions/harness/tests/holocene_activation.rs
@@ -62,7 +62,7 @@ async fn holocene_derivation_crosses_activation_boundary() {
     // so user txs are valid in all blocks including block 3.
     let mut batcher = Batcher::new(ActionL2Source::new(), &h.rollup_config, batcher_cfg.clone());
     for _ in 1..=4u64 {
-        batcher.push_block(builder.build_next_block());
+        batcher.push_block(builder.build_next_block_with_single_transaction());
         batcher.advance(&mut h.l1).await;
         chain.push(h.l1.tip().clone());
     }
@@ -129,7 +129,7 @@ async fn holocene_non_sequential_frame_pruned_channel_never_completes() {
 
     let l1_chain = SharedL1Chain::from_blocks(h.l1.chain().to_vec());
     let mut sequencer = h.create_l2_sequencer(l1_chain);
-    let block = sequencer.build_next_block();
+    let block = sequencer.build_next_block_with_single_transaction();
 
     // Encode the block into frames without mining.
     let mut source = ActionL2Source::new();
@@ -236,8 +236,8 @@ async fn holocene_new_channel_abandons_incomplete_old_channel() {
     let l1_chain = SharedL1Chain::from_blocks(h.l1.chain().to_vec());
     let mut sequencer = h.create_l2_sequencer(l1_chain);
 
-    let block_a = sequencer.build_next_block();
-    let block_b = sequencer.build_next_block();
+    let block_a = sequencer.build_next_block_with_single_transaction();
+    let block_b = sequencer.build_next_block_with_single_transaction();
 
     // Encode channel A (block A) and channel B (block B) separately.
     // Each Batcher instance generates a distinct random channel ID.
@@ -348,7 +348,7 @@ async fn holocene_non_sequential_frame_pruned_then_recovery_succeeds() {
 
     let l1_chain = SharedL1Chain::from_blocks(h.l1.chain().to_vec());
     let mut sequencer = h.create_l2_sequencer(l1_chain);
-    let block = sequencer.build_next_block();
+    let block = sequencer.build_next_block_with_single_transaction();
 
     // Encode the block into frames without mining.
     let mut source = ActionL2Source::new();
@@ -405,7 +405,7 @@ async fn holocene_non_sequential_frame_pruned_then_recovery_succeeds() {
     // -- Recovery: new Batcher (new channel ID) re-submits all frames in order.
     // `block` was cloned into `source` above (line 372), so the original value
     // is still valid here — same L2 block 1 with the same transactions and
-    // timestamp. The sequencer has not advanced since build_next_block().
+    // timestamp. The sequencer has not advanced since build_next_block_with_single_transaction().
     let mut recovery_source = ActionL2Source::new();
     recovery_source.push(block);
     let mut batcher2 = Batcher::new(recovery_source, &h.rollup_config, batcher_cfg.clone());

--- a/actions/harness/tests/operator_fees.rs
+++ b/actions/harness/tests/operator_fees.rs
@@ -40,7 +40,7 @@ fn operator_fee_not_encoded_before_isthmus() {
         let mut builder = h.create_l2_sequencer(l1_chain);
 
         // Build one block and verify it uses the Ecotone format with zero operator fees.
-        let block = builder.build_next_block();
+        let block = builder.build_next_block_with_single_transaction();
         let l1_info = ActionTestHarness::l1_info_from_block(&block);
 
         assert!(
@@ -91,7 +91,7 @@ fn operator_fee_encoded_in_l1_info_from_isthmus_onward() {
 
         // Build one block and verify it uses the active post-Isthmus format with
         // the configured operator fee params.
-        let block = builder.build_next_block();
+        let block = builder.build_next_block_with_single_transaction();
         let l1_info = ActionTestHarness::l1_info_from_block(&block);
 
         let expected_format = matches!(
@@ -153,7 +153,7 @@ fn l1_info_format_transitions_at_isthmus_boundary() {
 
     // Stage 1: Blocks 1-2 (ts=2, 4) — pre-Isthmus → Ecotone format, zero operator fees.
     for i in 1u64..=2 {
-        let block = builder.build_next_block();
+        let block = builder.build_next_block_with_single_transaction();
         let l1_info = ActionTestHarness::l1_info_from_block(&block);
 
         assert!(
@@ -170,7 +170,7 @@ fn l1_info_format_transitions_at_isthmus_boundary() {
     // the upgrade deposit transactions land in the same block to upgrade the
     // L1Block contract, enabling the Isthmus format from block 4 onwards.
     {
-        let block = builder.build_next_block();
+        let block = builder.build_next_block_with_single_transaction();
         let l1_info = ActionTestHarness::l1_info_from_block(&block);
 
         assert!(
@@ -191,7 +191,7 @@ fn l1_info_format_transitions_at_isthmus_boundary() {
 
     // Stage 3: Block 4 (ts=8) — second Isthmus block, Isthmus format, fees active.
     {
-        let block = builder.build_next_block();
+        let block = builder.build_next_block_with_single_transaction();
         let l1_info = ActionTestHarness::l1_info_from_block(&block);
 
         assert!(
@@ -254,7 +254,7 @@ fn l1_info_format_transitions_at_jovian_boundary() {
 
     // Stage 1: Blocks 1-2 (ts=2, 4) — Isthmus active, Jovian not yet → Isthmus format.
     for i in 1u64..=2 {
-        let block = builder.build_next_block();
+        let block = builder.build_next_block_with_single_transaction();
         let l1_info = ActionTestHarness::l1_info_from_block(&block);
 
         assert!(
@@ -285,7 +285,7 @@ fn l1_info_format_transitions_at_jovian_boundary() {
     // The operator fee scalar and constant are unchanged; only the EVM formula
     // differs (gas * scalar * 100 vs gas * scalar / 1_000_000 for Isthmus).
     {
-        let block = builder.build_next_block();
+        let block = builder.build_next_block_with_single_transaction();
         let l1_info = ActionTestHarness::l1_info_from_block(&block);
 
         assert!(
@@ -362,7 +362,7 @@ async fn isthmus_derivation_crosses_operator_fee_boundary() {
     let mut batcher = Batcher::new(ActionL2Source::new(), &h.rollup_config, batcher_cfg.clone());
     for _ in 0..4u64 {
         // All blocks carry user transactions — Isthmus allows user txs at transition.
-        batcher.push_block(builder.build_next_block());
+        batcher.push_block(builder.build_next_block_with_single_transaction());
         batcher.advance(&mut h.l1).await;
     }
 
@@ -438,7 +438,7 @@ async fn jovian_non_empty_transition_batch_generates_deposit_only_block() {
     // non-empty batch for that slot with NonEmptyTransitionBlock.
     let mut batcher = Batcher::new(ActionL2Source::new(), &h.rollup_config, batcher_cfg.clone());
     for _ in 1u64..=3 {
-        batcher.push_block(builder.build_next_block());
+        batcher.push_block(builder.build_next_block_with_single_transaction());
         batcher.advance(&mut h.l1).await;
     }
 
@@ -571,12 +571,12 @@ async fn operator_fee_config_update_propagates_to_l1_info() {
     // L2 blocks 1–5 (ts=2,4,6,8,10): epoch 0, OLD config.
     let mut epoch0_blocks: Vec<base_alloy_consensus::OpBlock> = Vec::new();
     for _ in 0..5 {
-        let block = sequencer.build_next_block();
+        let block = sequencer.build_next_block_with_single_transaction();
         epoch0_blocks.push(block);
     }
 
     // L2 block 6 (ts=12): epoch 1, epoch change — NEW config from L1 block 1's receipts.
-    let block6 = sequencer.build_next_block();
+    let block6 = sequencer.build_next_block_with_single_transaction();
 
     let batcher_cfg = BatcherConfig {
         encoder: EncoderConfig { da_type: DaType::Calldata, ..batcher_cfg.encoder.clone() },

--- a/actions/harness/tests/unsafe_gossip.rs
+++ b/actions/harness/tests/unsafe_gossip.rs
@@ -29,7 +29,7 @@ async fn test_unsafe_chain_advances_safe_catches_up() {
     let mut sequencer = h.create_l2_sequencer(l1_chain);
     let mut blocks = Vec::with_capacity(L2_BLOCK_COUNT as usize);
     for _ in 0..L2_BLOCK_COUNT {
-        blocks.push(sequencer.build_next_block());
+        blocks.push(sequencer.build_next_block_with_single_transaction());
     }
 
     // Create the verifier before any mining so chain updates are visible.
@@ -102,9 +102,9 @@ async fn test_out_of_order_gossip_is_dropped() {
     // Build 3 sequential L2 blocks (we will inject block 3 first, skipping 1 & 2).
     let l1_chain = SharedL1Chain::from_blocks(h.l1.chain().to_vec());
     let mut sequencer = h.create_l2_sequencer(l1_chain);
-    let block1 = sequencer.build_next_block();
-    let _block2 = sequencer.build_next_block();
-    let block3 = sequencer.build_next_block();
+    let block1 = sequencer.build_next_block_with_single_transaction();
+    let _block2 = sequencer.build_next_block_with_single_transaction();
+    let block3 = sequencer.build_next_block_with_single_transaction();
 
     let (mut verifier, _chain) = h.create_verifier_from_sequencer(
         &sequencer,


### PR DESCRIPTION
Allows action tests to specify the transactions to be included. This allows testing EVM behavior before and after a hardfork.