### PR TITLE
fix(batcher-comp): fix ShadowCompressor bound accumulation in write()

### DIFF
--- a/crates/batcher/comp/src/shadow.rs
+++ b/crates/batcher/comp/src/shadow.rs
@@ -78,7 +78,7 @@ impl CompressorWriter for ShadowCompressor {
         self.shadow.write(data)?;
 
         // The new bound increases by the length of the compressed data.
-        let mut newbound = data.len() as u64;
+        let mut newbound = self.bound + data.len() as u64;
         if newbound > self.config.target_output_size {
             // Don't flush the buffer if there's a chance we're over the size limit.
             self.shadow.flush()?;


### PR DESCRIPTION
## Summary

Fix a logical bug in `ShadowCompressor::write()` where the size bound was reset
to just the current write size instead of being accumulated across all writes.

## Problem

`ShadowCompressor::write()` computed `let mut newbound = data.len() as u64;`

The comment says "The new bound **increases** by the length" but the code
replaced `bound` with only the current batch size on every call.

As a result, `is_full` was never set when many small batches were written —
only when a single batch exceeded `target_output_size` alone. In practice,
small transaction batches never triggered the fullness check, allowing the
channel to silently exceed the configured size limit.

## Fix

Change `data.len() as u64` to `self.bound + data.len() as u64` so the bound
accumulates correctly across writes, matching the comment and the original Go port intent.

## Tests

No existing tests for `ShadowCompressor` in the repository.
