### PR TITLE
fix(consensus): Add Sequencer Metrics And Logging

### DIFF
--- a/crates/consensus/engine/src/metrics/mod.rs
+++ b/crates/consensus/engine/src/metrics/mod.rs
@@ -76,6 +76,10 @@ impl Metrics {
     /// Identifier for the counter that tracks the number of times the engine has been reset.
     pub const ENGINE_RESET_COUNT: &str = "base_node_engine_reset_count";
 
+    /// Counter for unsafe head changed since payload build (alertable).
+    pub const SEQUENCER_UNSAFE_HEAD_CHANGED_TOTAL: &str =
+        "base_node_sequencer_unsafe_head_changed_total";
+
     /// Initializes metrics for the engine.
     ///
     /// This does two things:
@@ -110,6 +114,13 @@ impl Metrics {
             metrics::Unit::Count,
             "Engine reset count"
         );
+
+        // Sequencer unsafe head changed counter
+        metrics::describe_counter!(
+            Self::SEQUENCER_UNSAFE_HEAD_CHANGED_TOTAL,
+            metrics::Unit::Count,
+            "Payloads dropped because unsafe head changed between build and seal"
+        );
     }
 
     /// Initializes metrics to `0` so they can be queried immediately by consumers of prometheus
@@ -121,13 +132,20 @@ impl Metrics {
         base_macros::set!(counter, Self::ENGINE_TASK_SUCCESS, Self::CONSOLIDATE_TASK_LABEL, 0);
         base_macros::set!(counter, Self::ENGINE_TASK_SUCCESS, Self::BUILD_TASK_LABEL, 0);
         base_macros::set!(counter, Self::ENGINE_TASK_SUCCESS, Self::FINALIZE_TASK_LABEL, 0);
+        base_macros::set!(counter, Self::ENGINE_TASK_SUCCESS, Self::SEAL_TASK_LABEL, 0);
+        base_macros::set!(counter, Self::ENGINE_TASK_SUCCESS, Self::GET_PAYLOAD_TASK_LABEL, 0);
 
         base_macros::set!(counter, Self::ENGINE_TASK_FAILURE, Self::INSERT_TASK_LABEL, 0);
         base_macros::set!(counter, Self::ENGINE_TASK_FAILURE, Self::CONSOLIDATE_TASK_LABEL, 0);
         base_macros::set!(counter, Self::ENGINE_TASK_FAILURE, Self::BUILD_TASK_LABEL, 0);
         base_macros::set!(counter, Self::ENGINE_TASK_FAILURE, Self::FINALIZE_TASK_LABEL, 0);
+        base_macros::set!(counter, Self::ENGINE_TASK_FAILURE, Self::SEAL_TASK_LABEL, 0);
+        base_macros::set!(counter, Self::ENGINE_TASK_FAILURE, Self::GET_PAYLOAD_TASK_LABEL, 0);
 
         // Engine reset count
         base_macros::set!(counter, Self::ENGINE_RESET_COUNT, 0);
+
+        // Sequencer unsafe head changed
+        base_macros::set!(counter, Self::SEQUENCER_UNSAFE_HEAD_CHANGED_TOTAL, 0);
     }
 }

--- a/crates/consensus/engine/src/task_queue/tasks/get_payload/task.rs
+++ b/crates/consensus/engine/src/task_queue/tasks/get_payload/task.rs
@@ -149,12 +149,13 @@ impl<EngineClient_: EngineClient> EngineTaskExt for GetPayloadTask<EngineClient_
         let res = if unsafe_block_info.hash != parent_block_info.hash
             || unsafe_block_info.number != parent_block_info.number
         {
-            info!(
+            warn!(
                 target: "engine",
                 unsafe_block_info = ?unsafe_block_info,
                 parent_block_info = ?parent_block_info,
                 "GetPayload attributes parent does not match unsafe head, returning rebuild error"
             );
+            base_macros::inc!(counter, crate::Metrics::SEQUENCER_UNSAFE_HEAD_CHANGED_TOTAL);
             Err(SealTaskError::UnsafeHeadChangedSinceBuild)
         } else {
             self.get_payload(&self.cfg, &self.engine, self.payload_id, &self.attributes).await

--- a/crates/consensus/service/src/actors/sequencer/actor.rs
+++ b/crates/consensus/service/src/actors/sequencer/actor.rs
@@ -25,7 +25,10 @@ use crate::{
             build::{PayloadBuilder, UnsealedPayloadHandle},
             conductor::Conductor,
             error::SequencerActorError,
-            metrics::{update_seal_duration_metrics, update_total_transactions_sequenced},
+            metrics::{
+                inc_seal_error, inc_seal_pipeline_overlap, update_seal_duration_metrics,
+                update_total_transactions_sequenced,
+            },
             origin_selector::OriginSelector,
             recovery::RecoveryModeGuard,
             seal::PayloadSealer,
@@ -186,6 +189,7 @@ where
                     if let Some(handle) = next_payload_to_seal.take() {
                         if self.sealer.is_some() {
                             error!(target: "sequencer", "Seal pipeline did not complete before next block was sealed");
+                            inc_seal_pipeline_overlap();
                             self.sealer = None;
                         }
 
@@ -198,9 +202,12 @@ where
                             Err(SequencerActorError::EngineError(EngineClientError::SealError(err))) => {
                                 if err.is_fatal() {
                                     error!(target: "sequencer", error = ?err, "Critical seal task error occurred");
+                                    inc_seal_error(true);
                                     self.cancellation_token.cancel();
                                     return Err(SequencerActorError::EngineError(EngineClientError::SealError(err)));
                                 }
+                                warn!(target: "sequencer", error = ?err, "Non-fatal seal error, dropping block");
+                                inc_seal_error(false);
                             }
                             Err(other_err) => {
                                 error!(target: "sequencer", error = ?other_err, "Unexpected error sealing payload");
@@ -246,7 +253,8 @@ where
                         }
                         Ok(false) => {}
                         Err(err) => {
-                            warn!(target: "sequencer", error = ?err, "Seal step failed, will retry");
+                            let step = self.sealer.as_ref().map(|s| s.state.label()).unwrap_or("unknown");
+                            warn!(target: "sequencer", error = ?err, step, "Seal step failed, will retry");
                         }
                     }
                 }

--- a/crates/consensus/service/src/actors/sequencer/admin_api_impl.rs
+++ b/crates/consensus/service/src/actors/sequencer/admin_api_impl.rs
@@ -3,7 +3,10 @@ use base_consensus_derive::AttributesBuilder;
 use base_consensus_rpc::SequencerAdminAPIError;
 use tokio::sync::oneshot;
 
-use super::{SequencerActor, metrics::{inc_start_rejected, inc_stop_deferred}};
+use super::{
+    SequencerActor,
+    metrics::{inc_start_rejected, inc_stop_deferred},
+};
 use crate::{Conductor, OriginSelector, SequencerEngineClient, UnsafePayloadGossipClient};
 
 /// The query types to the sequencer actor for the admin api.

--- a/crates/consensus/service/src/actors/sequencer/admin_api_impl.rs
+++ b/crates/consensus/service/src/actors/sequencer/admin_api_impl.rs
@@ -3,7 +3,7 @@ use base_consensus_derive::AttributesBuilder;
 use base_consensus_rpc::SequencerAdminAPIError;
 use tokio::sync::oneshot;
 
-use super::SequencerActor;
+use super::{SequencerActor, metrics::{inc_start_rejected, inc_stop_deferred}};
 use crate::{Conductor, OriginSelector, SequencerEngineClient, UnsafePayloadGossipClient};
 
 /// The query types to the sequencer actor for the admin api.
@@ -131,10 +131,12 @@ where
                 Ok(true) => {}
                 Ok(false) => {
                     warn!(target: "sequencer", "Not the conductor leader, refusing to start sequencer");
+                    inc_start_rejected("not_leader");
                     return Err(SequencerAdminAPIError::NotLeader);
                 }
                 Err(err) => {
                     error!(target: "sequencer", error = %err, "Failed to check conductor leadership");
+                    inc_start_rejected("leadership_check_failed");
                     return Err(SequencerAdminAPIError::RequestError(err.to_string()));
                 }
             }
@@ -163,6 +165,7 @@ where
 
         if self.sealer.is_some() {
             info!(target: "sequencer", "Seal pipeline in-flight, deferring stop response");
+            inc_stop_deferred();
             self.pending_stop = Some(tx);
         } else {
             let result = self.resolve_stop_head().await;

--- a/crates/consensus/service/src/actors/sequencer/metrics.rs
+++ b/crates/consensus/service/src/actors/sequencer/metrics.rs
@@ -71,3 +71,44 @@ pub(super) fn update_total_transactions_sequenced(transaction_count: u64) {
     metrics::counter!(crate::Metrics::SEQUENCER_TOTAL_TRANSACTIONS_SEQUENCED)
         .increment(transaction_count);
 }
+
+#[inline]
+pub(super) fn inc_seal_step_retry(step: &'static str) {
+    base_macros::inc!(counter, crate::Metrics::SEQUENCER_SEAL_STEP_RETRIES_TOTAL, "step" => step);
+}
+
+#[inline]
+pub(super) fn update_seal_step_duration(step: &'static str, duration: Duration) {
+    base_macros::set!(gauge, crate::Metrics::SEQUENCER_SEAL_STEP_DURATION, "step", step, duration);
+}
+
+#[inline]
+pub(super) fn inc_seal_pipeline_overlap() {
+    base_macros::inc!(counter, crate::Metrics::SEQUENCER_SEAL_PIPELINE_OVERLAP_TOTAL);
+}
+
+#[inline]
+pub(super) fn inc_seal_error(fatal: bool) {
+    let label = if fatal { "true" } else { "false" };
+    base_macros::inc!(counter, crate::Metrics::SEQUENCER_SEAL_ERROR_TOTAL, "fatal" => label);
+}
+
+#[inline]
+pub(super) fn inc_start_rejected(reason: &'static str) {
+    base_macros::inc!(counter, crate::Metrics::SEQUENCER_START_REJECTED_TOTAL, "reason" => reason);
+}
+
+#[inline]
+pub(super) fn inc_stop_deferred() {
+    base_macros::inc!(counter, crate::Metrics::SEQUENCER_STOP_DEFERRED_TOTAL);
+}
+
+#[inline]
+pub(super) fn inc_recovery_mode_block() {
+    base_macros::inc!(counter, crate::Metrics::SEQUENCER_RECOVERY_MODE_BLOCKS_TOTAL);
+}
+
+#[inline]
+pub(super) fn inc_drift_empty_block() {
+    base_macros::inc!(counter, crate::Metrics::SEQUENCER_DRIFT_EMPTY_BLOCKS_TOTAL);
+}

--- a/crates/consensus/service/src/actors/sequencer/pool.rs
+++ b/crates/consensus/service/src/actors/sequencer/pool.rs
@@ -6,6 +6,8 @@ use base_alloy_rpc_types_engine::OpPayloadAttributes;
 use base_consensus_genesis::RollupConfig;
 use base_protocol::BlockInfo;
 
+use super::metrics::{inc_drift_empty_block, inc_recovery_mode_block};
+
 /// The `PoolActivation` type identifies if the transaction pool should be enabled.
 #[derive(Debug, Clone)]
 pub struct PoolActivation {
@@ -29,6 +31,7 @@ impl PoolActivation {
     ) -> bool {
         if recovery_mode {
             warn!(target: "sequencer", "Sequencer is in recovery mode, producing empty block");
+            inc_recovery_mode_block();
             return false;
         }
 
@@ -37,6 +40,13 @@ impl PoolActivation {
         if attributes.payload_attributes.timestamp
             > l1_origin.timestamp + self.rollup_config.max_sequencer_drift(l1_origin.timestamp)
         {
+            warn!(
+                target: "sequencer",
+                l2_timestamp = attributes.payload_attributes.timestamp,
+                l1_timestamp = l1_origin.timestamp,
+                "L2 timestamp beyond sequencer drift, producing empty block"
+            );
+            inc_drift_empty_block();
             return false;
         }
 

--- a/crates/consensus/service/src/actors/sequencer/seal.rs
+++ b/crates/consensus/service/src/actors/sequencer/seal.rs
@@ -11,7 +11,10 @@ use crate::{
     UnsafePayloadGossipClient,
     actors::{
         SequencerEngineClient,
-        sequencer::{conductor::Conductor, metrics::{inc_seal_step_retry, update_seal_step_duration}},
+        sequencer::{
+            conductor::Conductor,
+            metrics::{inc_seal_step_retry, update_seal_step_duration},
+        },
     },
 };
 

--- a/crates/consensus/service/src/actors/sequencer/seal.rs
+++ b/crates/consensus/service/src/actors/sequencer/seal.rs
@@ -3,11 +3,16 @@
 //! Tracks a sealed payload through the commit → gossip → insert pipeline,
 //! retrying the current step on failure without rebuilding the payload.
 
+use std::time::Instant;
+
 use base_alloy_rpc_types_engine::OpExecutionPayloadEnvelope;
 
 use crate::{
     UnsafePayloadGossipClient,
-    actors::{SequencerEngineClient, sequencer::conductor::Conductor},
+    actors::{
+        SequencerEngineClient,
+        sequencer::{conductor::Conductor, metrics::{inc_seal_step_retry, update_seal_step_duration}},
+    },
 };
 
 /// Tracks where a sealed payload is in the commit → gossip → insert pipeline.
@@ -19,6 +24,17 @@ pub enum SealState {
     Committed,
     /// Gossiped to peers. Ready for engine insertion.
     Gossiped,
+}
+
+impl SealState {
+    /// Returns a static label string for metrics (matches the metric label values).
+    pub const fn label(&self) -> &'static str {
+        match self {
+            Self::Sealed => "conductor",
+            Self::Committed => "gossip",
+            Self::Gossiped => "insert",
+        }
+    }
 }
 
 /// Drives a sealed payload through the commit → gossip → insert pipeline.
@@ -59,7 +75,10 @@ impl PayloadSealer {
         G: UnsafePayloadGossipClient,
         E: SequencerEngineClient,
     {
-        match self.state {
+        let step_label = self.state.label();
+        let step_start = Instant::now();
+
+        let result = match self.state {
             SealState::Sealed => {
                 if let Some(conductor) = conductor {
                     conductor
@@ -85,7 +104,14 @@ impl PayloadSealer {
                     .map_err(SealStepError::Insert)?;
                 Ok(true)
             }
+        };
+
+        match &result {
+            Ok(_) => update_seal_step_duration(step_label, step_start.elapsed()),
+            Err(_) => inc_seal_step_retry(step_label),
         }
+
+        result
     }
 }
 

--- a/crates/consensus/service/src/metrics/mod.rs
+++ b/crates/consensus/service/src/metrics/mod.rs
@@ -48,9 +48,8 @@ impl Metrics {
     /// Counter for seal errors labeled by fatal ("true"|"false").
     pub const SEQUENCER_SEAL_ERROR_TOTAL: &str = "base_node_sequencer_seal_errors_total";
     /// Counter for sequencer start rejections labeled by reason.
-    pub const SEQUENCER_START_REJECTED_TOTAL: &str =
-        "base_node_sequencer_start_rejected_total";
-    /// Counter for deferred stop_sequencer responses due to in-flight seal pipeline.
+    pub const SEQUENCER_START_REJECTED_TOTAL: &str = "base_node_sequencer_start_rejected_total";
+    /// Counter for deferred `stop_sequencer` responses due to in-flight seal pipeline.
     pub const SEQUENCER_STOP_DEFERRED_TOTAL: &str = "base_node_sequencer_stop_deferred_total";
     /// Counter for blocks sequenced in recovery mode (always empty blocks).
     pub const SEQUENCER_RECOVERY_MODE_BLOCKS_TOTAL: &str =
@@ -132,10 +131,7 @@ impl Metrics {
             Self::SEQUENCER_SEAL_PIPELINE_OVERLAP_TOTAL,
             "Seal pipeline overlaps: pipeline not complete before next block tick"
         );
-        metrics::describe_counter!(
-            Self::SEQUENCER_SEAL_ERROR_TOTAL,
-            "Seal errors by fatality"
-        );
+        metrics::describe_counter!(Self::SEQUENCER_SEAL_ERROR_TOTAL, "Seal errors by fatality");
         metrics::describe_counter!(
             Self::SEQUENCER_START_REJECTED_TOTAL,
             "Sequencer start rejections by reason"

--- a/crates/consensus/service/src/metrics/mod.rs
+++ b/crates/consensus/service/src/metrics/mod.rs
@@ -37,6 +37,28 @@ impl Metrics {
     pub const SEQUENCER_TOTAL_TRANSACTIONS_SEQUENCED: &str =
         "base_node_sequencer_total_transactions_sequenced";
 
+    /// Counter for seal pipeline step retries, labeled by step ("conductor"|"gossip"|"insert").
+    pub const SEQUENCER_SEAL_STEP_RETRIES_TOTAL: &str =
+        "base_node_sequencer_seal_step_retries_total";
+    /// Gauge for seal pipeline step duration, labeled by step.
+    pub const SEQUENCER_SEAL_STEP_DURATION: &str = "base_node_sequencer_seal_step_duration";
+    /// Counter for seal pipeline overlaps (previous not complete when next block tick fires).
+    pub const SEQUENCER_SEAL_PIPELINE_OVERLAP_TOTAL: &str =
+        "base_node_sequencer_seal_pipeline_overlap_total";
+    /// Counter for seal errors labeled by fatal ("true"|"false").
+    pub const SEQUENCER_SEAL_ERROR_TOTAL: &str = "base_node_sequencer_seal_errors_total";
+    /// Counter for sequencer start rejections labeled by reason.
+    pub const SEQUENCER_START_REJECTED_TOTAL: &str =
+        "base_node_sequencer_start_rejected_total";
+    /// Counter for deferred stop_sequencer responses due to in-flight seal pipeline.
+    pub const SEQUENCER_STOP_DEFERRED_TOTAL: &str = "base_node_sequencer_stop_deferred_total";
+    /// Counter for blocks sequenced in recovery mode (always empty blocks).
+    pub const SEQUENCER_RECOVERY_MODE_BLOCKS_TOTAL: &str =
+        "base_node_sequencer_recovery_mode_blocks_total";
+    /// Counter for empty blocks produced due to sequencer drift threshold.
+    pub const SEQUENCER_DRIFT_EMPTY_BLOCKS_TOTAL: &str =
+        "base_node_sequencer_drift_empty_blocks_total";
+
     /// Initializes metrics for the node service.
     ///
     /// This does two things:
@@ -96,6 +118,40 @@ impl Metrics {
             metrics::Unit::Count,
             "Total count of sequenced transactions"
         );
+
+        metrics::describe_counter!(
+            Self::SEQUENCER_SEAL_STEP_RETRIES_TOTAL,
+            "Sequencer seal step retries by step"
+        );
+        metrics::describe_gauge!(
+            Self::SEQUENCER_SEAL_STEP_DURATION,
+            metrics::Unit::Seconds,
+            "Sequencer seal step duration by step"
+        );
+        metrics::describe_counter!(
+            Self::SEQUENCER_SEAL_PIPELINE_OVERLAP_TOTAL,
+            "Seal pipeline overlaps: pipeline not complete before next block tick"
+        );
+        metrics::describe_counter!(
+            Self::SEQUENCER_SEAL_ERROR_TOTAL,
+            "Seal errors by fatality"
+        );
+        metrics::describe_counter!(
+            Self::SEQUENCER_START_REJECTED_TOTAL,
+            "Sequencer start rejections by reason"
+        );
+        metrics::describe_counter!(
+            Self::SEQUENCER_STOP_DEFERRED_TOTAL,
+            "Deferred stop_sequencer responses due to in-flight seal pipeline"
+        );
+        metrics::describe_counter!(
+            Self::SEQUENCER_RECOVERY_MODE_BLOCKS_TOTAL,
+            "Blocks sequenced in recovery mode"
+        );
+        metrics::describe_counter!(
+            Self::SEQUENCER_DRIFT_EMPTY_BLOCKS_TOTAL,
+            "Empty blocks produced due to sequencer drift threshold"
+        );
     }
 
     /// Initializes metrics to `0` so they can be queried immediately by consumers of prometheus
@@ -110,5 +166,23 @@ impl Metrics {
 
         // Sequencer: reset total transactions sequenced
         base_macros::set!(counter, Self::SEQUENCER_TOTAL_TRANSACTIONS_SEQUENCED, 0);
+
+        base_macros::set!(counter, Self::SEQUENCER_SEAL_STEP_RETRIES_TOTAL, "step", "conductor", 0);
+        base_macros::set!(counter, Self::SEQUENCER_SEAL_STEP_RETRIES_TOTAL, "step", "gossip", 0);
+        base_macros::set!(counter, Self::SEQUENCER_SEAL_STEP_RETRIES_TOTAL, "step", "insert", 0);
+        base_macros::set!(counter, Self::SEQUENCER_SEAL_ERROR_TOTAL, "fatal", "true", 0);
+        base_macros::set!(counter, Self::SEQUENCER_SEAL_ERROR_TOTAL, "fatal", "false", 0);
+        base_macros::set!(counter, Self::SEQUENCER_SEAL_PIPELINE_OVERLAP_TOTAL, 0);
+        base_macros::set!(counter, Self::SEQUENCER_START_REJECTED_TOTAL, "reason", "not_leader", 0);
+        base_macros::set!(
+            counter,
+            Self::SEQUENCER_START_REJECTED_TOTAL,
+            "reason",
+            "leadership_check_failed",
+            0
+        );
+        base_macros::set!(counter, Self::SEQUENCER_STOP_DEFERRED_TOTAL, 0);
+        base_macros::set!(counter, Self::SEQUENCER_RECOVERY_MODE_BLOCKS_TOTAL, 0);
+        base_macros::set!(counter, Self::SEQUENCER_DRIFT_EMPTY_BLOCKS_TOTAL, 0);
     }
 }


### PR DESCRIPTION
## Summary

This is a follow-up to PR #1513, which restructured the sequencer's block lifecycle into a retryable two-phase pipeline but left several new code paths without observability. This PR adds 9 new counters and gauges covering seal step retries (labeled by step), step durations, pipeline overlaps, seal errors by fatality, start rejections by reason, deferred stop responses, recovery-mode blocks, and drift-induced empty blocks. It also fills in the missing SEAL and GET_PAYLOAD zero-inits for engine task counters, promotes the UnsafeHeadChangedSinceBuild log from info to warn, and adds a structured step field to the seal-step retry warning.