### PR TITLE
docs: fix typo 'gives use' -> 'gives us' in derivation spec

### DIFF
--- a/docs/specs/pages/protocol/consensus/derivation.md
+++ b/docs/specs/pages/protocol/consensus/derivation.md
@@ -220,7 +220,7 @@ Channels might be too large to fit in a single [batcher transaction][g-batcher-t
 into chunks known as [channel frames][g-channel-frame]. A single batcher transaction can also carry multiple frames
 (belonging to the same or to different channels).
 
-This design gives use the maximum flexibility in how we aggregate batches into channels, and split channels over batcher
+This design gives us the maximum flexibility in how we aggregate batches into channels, and split channels over batcher
 transactions. It notably allows us to maximize data utilization in a batcher transaction: for instance it allows us to
 pack the final (small) frame of one channel with one or more frames from the next channel.
 


### PR DESCRIPTION
## What changed

Fix a one-letter typo in the batch submission wire format section of the derivation spec.

- `gives use the maximum flexibility` → `gives us the maximum flexibility`

Text-only change. No code or behavior changes.
