### PR TITLE
fix(consensus): Validate Unsafe Head On Sequencer Start

### DIFF
--- a/crates/consensus/engine/src/task_queue/core.rs
+++ b/crates/consensus/engine/src/task_queue/core.rs
@@ -114,6 +114,10 @@ impl<EngineClient_: EngineClient> Engine<EngineClient_> {
             }
         }
 
+        // Broadcast the updated state so watch-channel subscribers (e.g. op_syncStatus RPC)
+        // see the new forkchoice immediately, without waiting for a task to pass through drain().
+        self.state_sender.send_replace(self.state);
+
         // Find the new safe head's L1 origin and SystemConfig.
         let origin_block = start
             .safe

--- a/crates/consensus/service/src/actors/engine/engine_request_processor.rs
+++ b/crates/consensus/service/src/actors/engine/engine_request_processor.rs
@@ -229,6 +229,33 @@ where
         mut request_channel: mpsc::Receiver<EngineProcessingRequest>,
     ) -> JoinHandle<Result<(), EngineError>> {
         tokio::spawn(async move {
+            // Bootstrap: pre-populate the engine watch channels by performing an initial reset.
+            // Without this, external callers (op_syncStatus, admin_startSequencer) would always
+            // observe a zero unsafe head until the first engine task completes. On nodes where
+            // the sequencer starts stopped (e.g. devnet), no tasks arrive until after
+            // admin_startSequencer is called — creating a deadlock.
+            //
+            // We call engine.reset() directly (bypassing EngineProcessor::reset() and
+            // mark_el_sync_complete_and_notify_derivation_actor) so that we do NOT start
+            // derivation here. The el_sync_finished / el_sync_complete gate is preserved:
+            // if the EL responds with Valid, el_sync_finished is set to true and the first
+            // drain() iteration will trigger mark_el_sync_complete_and_notify_derivation_actor
+            // normally. If the EL is still syncing (Syncing response), el_sync_finished stays
+            // false and derivation waits — exactly the same as before.
+            match self.engine.reset(Arc::clone(&self.client), Arc::clone(&self.rollup)).await {
+                Ok(_) => {
+                    if let Some(unsafe_head_tx) = self.unsafe_head_tx.as_ref() {
+                        let new_head = self.engine.state().sync_state.unsafe_head();
+                        unsafe_head_tx.send_if_modified(|val| {
+                            (*val != new_head).then(|| *val = new_head).is_some()
+                        });
+                    }
+                }
+                Err(err) => {
+                    warn!(target: "engine", ?err, "Engine startup bootstrap failed; will initialize on first task");
+                }
+            }
+
             loop {
                 // Attempt to drain all outstanding tasks from the engine queue before adding new
                 // ones.

--- a/crates/consensus/service/src/actors/sequencer/admin_api_impl.rs
+++ b/crates/consensus/service/src/actors/sequencer/admin_api_impl.rs
@@ -111,8 +111,12 @@ where
 
     /// Starts the sequencer in an idempotent fashion.
     ///
-    /// `unsafe_head` identifies the block the caller intends to start sequencing from.
-    /// Note: the forkchoice update to `unsafe_head` is not yet implemented (see TODO in body).
+    /// `unsafe_head` is a safety guard: it must match the engine's current unsafe head hash.
+    /// This prevents split-brain situations where two nodes attempt to start sequencing from
+    /// different chain tips. Activation is rejected when:
+    ///
+    /// - The engine has not yet received a forkchoice update (`unsafe_head == B256::ZERO`).
+    /// - `unsafe_head` does not match the engine's current unsafe head hash.
     ///
     /// When a conductor is configured, this checks `conductor_leader` before activating,
     /// matching op-node's `Start()` behavior. If the node is not the leader the call returns
@@ -140,9 +144,25 @@ where
             }
         }
 
-        // TODO: call self.engine_client to update the engine forkchoice to unsafe_head before
-        // setting is_active, matching op-node behavior where the caller's intended starting point
-        // is honored. See reset_derivation_pipeline() for the engine_client pattern.
+        let engine_head = self.engine_client.get_unsafe_head().await.map_err(|e| {
+            error!(target: "sequencer", error = %e, "Failed to fetch engine unsafe head");
+            SequencerAdminAPIError::RequestError(e.to_string())
+        })?;
+
+        if engine_head.block_info.hash == B256::ZERO {
+            return Err(SequencerAdminAPIError::RequestError(
+                "no prestate: engine unsafe head is uninitialized, cannot safely start sequencer"
+                    .to_string(),
+            ));
+        }
+
+        if unsafe_head != engine_head.block_info.hash {
+            return Err(SequencerAdminAPIError::RequestError(format!(
+                "block hash mismatch: engine unsafe head is {}, caller requested {}",
+                engine_head.block_info.hash, unsafe_head,
+            )));
+        }
+
         info!(target: "sequencer", unsafe_head = %unsafe_head, "Starting sequencer");
         self.is_active = true;
 

--- a/crates/consensus/service/src/actors/sequencer/tests/admin_api_impl_test.rs
+++ b/crates/consensus/service/src/actors/sequencer/tests/admin_api_impl_test.rs
@@ -98,15 +98,27 @@ async fn test_start_sequencer_no_conductor(
     #[values(true, false)] already_started: bool,
     #[values(true, false)] via_channel: bool,
 ) {
+    let test_hash = B256::from([1u8; 32]);
+    let engine_head = L2BlockInfo {
+        block_info: BlockInfo { hash: test_hash, ..Default::default() },
+        ..Default::default()
+    };
+
+    let mut client = MockSequencerEngineClient::new();
+    // .returning() (not .return_once()) allows 0 or 1 calls: the already-started case
+    // returns early before reaching the engine check.
+    client.expect_get_unsafe_head().returning(move || Ok(engine_head));
+
     let mut actor = test_actor();
+    actor.engine_client = Arc::new(client);
     actor.is_active = already_started;
 
     let result = async {
         match via_channel {
-            false => actor.start_sequencer(B256::ZERO).await,
+            false => actor.start_sequencer(test_hash).await,
             true => {
                 let (tx, rx) = oneshot::channel();
-                actor.handle_admin_query(SequencerAdminQuery::StartSequencer(B256::ZERO, tx)).await;
+                actor.handle_admin_query(SequencerAdminQuery::StartSequencer(test_hash, tx)).await;
                 rx.await.unwrap()
             }
         }
@@ -121,19 +133,29 @@ async fn test_start_sequencer_no_conductor(
 #[rstest]
 #[tokio::test]
 async fn test_start_sequencer_conductor_is_leader(#[values(true, false)] via_channel: bool) {
+    let test_hash = B256::from([1u8; 32]);
+    let engine_head = L2BlockInfo {
+        block_info: BlockInfo { hash: test_hash, ..Default::default() },
+        ..Default::default()
+    };
+
     let mut conductor = MockConductor::new();
     conductor.expect_leader().times(1).return_once(|| Ok(true));
 
+    let mut client = MockSequencerEngineClient::new();
+    client.expect_get_unsafe_head().times(1).return_once(move || Ok(engine_head));
+
     let mut actor = test_actor();
     actor.conductor = Some(conductor);
+    actor.engine_client = Arc::new(client);
     actor.is_active = false;
 
     let result = async {
         match via_channel {
-            false => actor.start_sequencer(B256::ZERO).await,
+            false => actor.start_sequencer(test_hash).await,
             true => {
                 let (tx, rx) = oneshot::channel();
-                actor.handle_admin_query(SequencerAdminQuery::StartSequencer(B256::ZERO, tx)).await;
+                actor.handle_admin_query(SequencerAdminQuery::StartSequencer(test_hash, tx)).await;
                 rx.await.unwrap()
             }
         }
@@ -229,6 +251,112 @@ async fn test_start_sequencer_already_active_skips_leader_check(
 
     assert!(result.is_ok());
     assert!(actor.is_active);
+}
+
+/// Engine returns a zero hash: sequencer refuses to activate (engine not yet initialized).
+#[rstest]
+#[tokio::test]
+async fn test_start_sequencer_engine_not_initialized(#[values(true, false)] via_channel: bool) {
+    let mut client = MockSequencerEngineClient::new();
+    client
+        .expect_get_unsafe_head()
+        .times(1)
+        .return_once(|| Ok(L2BlockInfo::default())); // hash == B256::ZERO
+
+    let mut actor = test_actor();
+    actor.engine_client = Arc::new(client);
+    actor.is_active = false;
+
+    let result = async {
+        match via_channel {
+            false => actor.start_sequencer(B256::from([1u8; 32])).await,
+            true => {
+                let (tx, rx) = oneshot::channel();
+                actor
+                    .handle_admin_query(SequencerAdminQuery::StartSequencer(
+                        B256::from([1u8; 32]),
+                        tx,
+                    ))
+                    .await;
+                rx.await.unwrap()
+            }
+        }
+    }
+    .await;
+
+    assert!(matches!(result.unwrap_err(), SequencerAdminAPIError::RequestError(_)));
+    assert!(!actor.is_active);
+}
+
+/// Caller's `unsafe_head` does not match the engine's current unsafe head: sequencer refuses.
+#[rstest]
+#[tokio::test]
+async fn test_start_sequencer_unsafe_head_mismatch(#[values(true, false)] via_channel: bool) {
+    let requested_hash = B256::from([1u8; 32]);
+    let engine_hash = B256::from([2u8; 32]);
+    let engine_head = L2BlockInfo {
+        block_info: BlockInfo { hash: engine_hash, ..Default::default() },
+        ..Default::default()
+    };
+
+    let mut client = MockSequencerEngineClient::new();
+    client.expect_get_unsafe_head().times(1).return_once(move || Ok(engine_head));
+
+    let mut actor = test_actor();
+    actor.engine_client = Arc::new(client);
+    actor.is_active = false;
+
+    let result = async {
+        match via_channel {
+            false => actor.start_sequencer(requested_hash).await,
+            true => {
+                let (tx, rx) = oneshot::channel();
+                actor
+                    .handle_admin_query(SequencerAdminQuery::StartSequencer(requested_hash, tx))
+                    .await;
+                rx.await.unwrap()
+            }
+        }
+    }
+    .await;
+
+    assert!(matches!(result.unwrap_err(), SequencerAdminAPIError::RequestError(_)));
+    assert!(!actor.is_active);
+}
+
+/// Engine client returns an error when fetching the unsafe head: sequencer refuses to activate.
+#[rstest]
+#[tokio::test]
+async fn test_start_sequencer_engine_client_error(#[values(true, false)] via_channel: bool) {
+    let mut client = MockSequencerEngineClient::new();
+    client
+        .expect_get_unsafe_head()
+        .times(1)
+        .return_once(|| Err(EngineClientError::RequestError("rpc failure".to_string())));
+
+    let mut actor = test_actor();
+    actor.engine_client = Arc::new(client);
+    actor.is_active = false;
+
+    let result = async {
+        match via_channel {
+            false => actor.start_sequencer(B256::from([1u8; 32])).await,
+            true => {
+                let (tx, rx) = oneshot::channel();
+                actor
+                    .handle_admin_query(SequencerAdminQuery::StartSequencer(
+                        B256::from([1u8; 32]),
+                        tx,
+                    ))
+                    .await;
+                rx.await.unwrap()
+            }
+        }
+    }
+    .await;
+
+    assert!(matches!(result.unwrap_err(), SequencerAdminAPIError::RequestError(_)));
+    assert!(!actor.is_active);
 }
 
 #[rstest]

--- a/crates/consensus/service/src/actors/sequencer/tests/admin_api_impl_test.rs
+++ b/crates/consensus/service/src/actors/sequencer/tests/admin_api_impl_test.rs
@@ -258,10 +258,7 @@ async fn test_start_sequencer_already_active_skips_leader_check(
 #[tokio::test]
 async fn test_start_sequencer_engine_not_initialized(#[values(true, false)] via_channel: bool) {
     let mut client = MockSequencerEngineClient::new();
-    client
-        .expect_get_unsafe_head()
-        .times(1)
-        .return_once(|| Ok(L2BlockInfo::default())); // hash == B256::ZERO
+    client.expect_get_unsafe_head().times(1).return_once(|| Ok(L2BlockInfo::default())); // hash == B256::ZERO
 
     let mut actor = test_actor();
     actor.engine_client = Arc::new(client);

--- a/devnet/src/l2/in_process_consensus.rs
+++ b/devnet/src/l2/in_process_consensus.rs
@@ -19,7 +19,7 @@ use base_consensus_node::{
     EngineConfig, L1ConfigBuilder, NetworkConfig, NodeMode, RollupNodeBuilder, SequencerConfig,
 };
 use base_consensus_peers::{PeerScoreLevel, SecretKeyLoader};
-use base_consensus_rpc::{AdminApiClient, OpP2PApiClient, RpcBuilder};
+use base_consensus_rpc::{AdminApiClient, OpP2PApiClient, RollupNodeApiClient, RpcBuilder};
 use base_consensus_sources::BlockSigner;
 use eyre::{Result, WrapErr};
 use jsonrpsee::http_client::HttpClientBuilder;
@@ -239,14 +239,28 @@ impl InProcessConsensus {
             .build(self.rpc_url().as_str())
             .wrap_err("Failed to build RPC client")?;
 
-        // Pass `B256::ZERO` because the devnet always starts from genesis, so there is no
-        // meaningful unsafe head to provide. The server currently logs the hash but does not yet
-        // use it to set forkchoice.
+        // The consensus node validates that the provided hash matches the engine's actual unsafe
+        // head before activating the sequencer. Poll sync status until the engine is initialized
+        // (non-zero unsafe head hash), then pass the real value.
+        let mut unsafe_head = B256::ZERO;
+        for _ in 0..40 {
+            match client.op_sync_status().await {
+                Ok(status) if status.unsafe_l2.block_info.hash != B256::ZERO => {
+                    unsafe_head = status.unsafe_l2.block_info.hash;
+                    break;
+                }
+                _ => tokio::time::sleep(std::time::Duration::from_millis(250)).await,
+            }
+        }
+        if unsafe_head == B256::ZERO {
+            return Err(eyre::eyre!("Engine unsafe head did not initialize within 10s"));
+        }
+
         client
-            .admin_start_sequencer(B256::ZERO)
+            .admin_start_sequencer(unsafe_head)
             .await
             .wrap_err("Failed to start sequencer via RPC")?;
-        info!("sequencer started via admin RPC");
+        info!(unsafe_head = %unsafe_head, "sequencer started via admin RPC");
         Ok(())
     }
 


### PR DESCRIPTION
## Summary

The `start_sequencer` handler accepted any caller-supplied `unsafe_head` hash but ignored it, activating unconditionally after the conductor check. This adds two validation guards matching op-node's `Sequencer.Start()` behavior: activation is rejected when the engine unsafe head is uninitialized (no forkchoice update received yet), and rejected when the caller's hash does not match the engine's current unsafe head. The latter prevents split-brain situations where two nodes attempt to sequence from different chain tips. Three new tests cover the uninitialized, mismatch, and engine client error cases, and two existing success-path tests are updated to supply a matching non-zero hash.