### PR TITLE
chore(proposer): add debug logging for proof results and tx submission

### DIFF
--- a/crates/proof/proposer/src/driver/core.rs
+++ b/crates/proof/proposer/src/driver/core.rs
@@ -293,9 +293,7 @@ where
         };
 
         info!(
-            starting_block = starting_block_number,
-            target_block,
-            l1_head = ?l1_head.hash,
+            request = ?request,
             "Sending proof request to prover"
         );
 
@@ -310,6 +308,21 @@ where
                 ));
             }
         };
+
+        debug!(
+            output_root = ?aggregate_proposal.output_root,
+            l2_block_number = ?aggregate_proposal.l2_block_number,
+            l1_origin_number = ?aggregate_proposal.l1_origin_number,
+            l1_origin_hash = ?aggregate_proposal.l1_origin_hash,
+            prev_output_root = ?aggregate_proposal.prev_output_root,
+            "Received aggregate proposal from TEE prover"
+        );
+
+        debug!(
+            count = proposals.len(),
+            proposals = ?proposals.iter().map(|p| (p.l2_block_number, p.output_root)).collect::<Vec<_>>(),
+            "Received per-block proposals from TEE prover"
+        );
 
         // Reorg detection: verify the claimed output root matches the canonical chain.
         let canonical_output =
@@ -427,7 +440,7 @@ where
                     );
                 } else {
                     warn!(
-                        error = %e,
+                        error = ?e,
                         l2_block_number,
                         "Failed to create dispute game"
                     );

--- a/crates/proof/proposer/src/output_proposer.rs
+++ b/crates/proof/proposer/src/output_proposer.rs
@@ -130,6 +130,7 @@ impl<T: TxManager + 'static> OutputProposer for ProposalSubmitter<T> {
             l2_block_number,
             factory = %self.factory_address,
             game_type = self.game_type,
+            calldata = %calldata,
             parent_index,
             "Creating dispute game"
         );
@@ -140,6 +141,11 @@ impl<T: TxManager + 'static> OutputProposer for ProposalSubmitter<T> {
             value: self.init_bond,
             ..Default::default()
         };
+        
+        info!(
+            tx = ?candidate,
+            "Sending tx candidate",
+        );
 
         let receipt = self.tx_manager.send(candidate).await.map_err(classify_tx_manager_error)?;
 

--- a/crates/proof/proposer/src/output_proposer.rs
+++ b/crates/proof/proposer/src/output_proposer.rs
@@ -141,7 +141,7 @@ impl<T: TxManager + 'static> OutputProposer for ProposalSubmitter<T> {
             value: self.init_bond,
             ..Default::default()
         };
-        
+
         info!(
             tx = ?candidate,
             "Sending tx candidate",


### PR DESCRIPTION
## Summary

- Add `debug!` logging for aggregate and per-block proposals after TEE proof completion in the driver, including output roots, block numbers, and L1 origin context.
- Add calldata and tx candidate logging in the output proposer for dispute game creation.
- Log the full `ProofRequest` struct instead of individual fields when sending proof requests.
- Switch dispute game creation error logging from `Display` to `Debug` format for richer context.