### PR TITLE
perf(flashblocks) parse JSON once, share Arc<Value> across subscribers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -20662,6 +20662,7 @@ dependencies = [
  "axum",
  "backoff",
  "brotli",
+ "criterion",
  "futures",
  "http 1.4.0",
  "metrics",

--- a/bin/websocket-proxy/src/main.rs
+++ b/bin/websocket-proxy/src/main.rs
@@ -15,8 +15,8 @@ use tokio::{
 use tokio_util::sync::CancellationToken;
 use tracing::{error, info, trace, warn};
 use websocket_proxy::{
-    Authentication, InMemoryRateLimit, Metrics, RateLimit, Registry, Server, SubscriberOptions,
-    WebsocketSubscriber,
+    Authentication, BroadcastMessage, InMemoryRateLimit, Metrics, RateLimit, Registry, Server,
+    SubscriberOptions, WebsocketSubscriber,
 };
 
 base_cli_utils::define_log_args!("WEBSOCKET_PROXY");
@@ -200,7 +200,7 @@ async fn main() {
     let metrics = Arc::new(Metrics::default());
     let metrics_clone = Arc::clone(&metrics);
 
-    let (send, _rec) = broadcast::channel(args.message_buffer_size);
+    let (send, _rec) = broadcast::channel::<Arc<BroadcastMessage>>(args.message_buffer_size);
     let sender = send.clone();
 
     let listener = move |data: String| {
@@ -222,7 +222,7 @@ async fn main() {
             data.into_bytes()
         };
 
-        match send.send(message_data.into()) {
+        match send.send(BroadcastMessage::new(Message::Binary(message_data.into()))) {
             Ok(_) => {
                 metrics_clone.broadcast_queue_size.set(send.len() as f64);
             }
@@ -271,7 +271,7 @@ async fn main() {
             loop {
                 tokio::select! {
                     _ = interval.tick() => {
-                        match ping_sender.send(Message::Ping(vec![].into())) {
+                        match ping_sender.send(BroadcastMessage::new(Message::Ping(vec![].into()))) {
                             Ok(_) => {
                                 trace!(message = "sent ping to all clients");
                                 ping_metrics.broadcast_queue_size.set(ping_sender.len() as f64);

--- a/crates/infra/websocket-proxy/Cargo.toml
+++ b/crates/infra/websocket-proxy/Cargo.toml
@@ -30,5 +30,10 @@ serde = { workspace = true, features = ["derive", "std"] }
 thiserror = { workspace = true, features = ["std"] }
 axum = { workspace = true, features = ["ws", "query", "tokio", "http1"] }
 
+[[bench]]
+name = "filter"
+harness = false
+
 [dev-dependencies]
 reqwest.workspace = true
+criterion = { workspace = true, features = ["html_reports"] }

--- a/crates/infra/websocket-proxy/benches/filter.rs
+++ b/crates/infra/websocket-proxy/benches/filter.rs
@@ -1,0 +1,91 @@
+use std::sync::{Arc, OnceLock};
+
+use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
+use websocket_proxy::FilterType;
+
+/// Realistic flashblock payload adapted from filter.rs unit tests.
+fn make_payload() -> Vec<u8> {
+    br#"{
+  "payload_id": "0x0307de8ff1df8ed8",
+  "index": 0,
+  "diff": {
+    "transactions": [
+      "0x7ef90104a0799b8b5182a2612920c032590217fd987cdcf1e07a2de17907e02eea535cc30694deaddeaddeaddeaddeaddeaddeaddeaddead00019442000000000000000000000000000000000000158080830f424080b8b0098999be0000044d000a118b000000000000000000000000683f28fc0000000000813aea000000000000000000000000000000000000000000000000000000000000094a0000000000000000000000000000000000000000000000000000000000000001f10c9d7f8fab954891476f8daa9189f45ee736b02bc43cb190e4f891c82e7edf000000000000000000000000fc56e7272eebbba5bc6c544e159483c4a38f8ba3000000000000000000000000"
+    ]
+  },
+  "metadata": {
+    "block_number": 26600873,
+    "new_account_balances": {
+      "0x336f495c2d3d764f541426228178a2369c9b78db": "0x13fbe85edc90000",
+      "0x4200000000000000000000000000000000000007": "0xf61bc4ad468f1bd"
+    },
+    "receipts": {
+      "0x3fb39b336c13a09d04a34f72cd88a7b0066d65dcf246288ac5bdbba33376eb41": {
+        "Deposit": {
+          "logs": [
+            {
+              "address": "0x4200000000000000000000000000000000000010",
+              "topics": [
+                "0xb0444523268717a02698be47d0803aa7468c00acbed2f8bd93a0459cde61dd89",
+                "0x0000000000000000000000000000000000000000000000000000000000000000"
+              ]
+            }
+          ]
+        }
+      }
+    }
+  }
+}"#
+    .to_vec()
+}
+
+/// Benchmark: N subscribers each call `matches` independently (baseline — parses N times).
+fn bench_filter_no_cache(c: &mut Criterion) {
+    let payload = make_payload();
+    let filter =
+        FilterType::new_addresses(vec!["0x4200000000000000000000000000000000000010".to_string()]);
+
+    let mut g = c.benchmark_group("filter_n_subscribers");
+
+    for n in [1usize, 10, 50, 100] {
+        g.bench_with_input(BenchmarkId::new("matches_no_cache", n), &n, |b, &n| {
+            b.iter(|| {
+                for _ in 0..n {
+                    let _ = filter.matches(std::hint::black_box(&payload), false);
+                }
+            });
+        });
+    }
+
+    g.finish();
+}
+
+/// Benchmark: N subscribers share one `OnceLock` per message (parse once, reuse Arc<Value>).
+fn bench_filter_with_cache(c: &mut Criterion) {
+    let payload = make_payload();
+    let filter =
+        FilterType::new_addresses(vec!["0x4200000000000000000000000000000000000010".to_string()]);
+
+    let mut g = c.benchmark_group("filter_n_subscribers");
+
+    for n in [1usize, 10, 50, 100] {
+        g.bench_with_input(BenchmarkId::new("matches_with_cache", n), &n, |b, &n| {
+            b.iter(|| {
+                // One OnceLock per broadcast message; reset each outer iteration.
+                let cache: OnceLock<Option<Arc<serde_json::Value>>> = OnceLock::new();
+                for _ in 0..n {
+                    let _ = filter.matches_with_cache(
+                        std::hint::black_box(&payload),
+                        false,
+                        std::hint::black_box(&cache),
+                    );
+                }
+            });
+        });
+    }
+
+    g.finish();
+}
+
+criterion_group!(benches, bench_filter_no_cache, bench_filter_with_cache);
+criterion_main!(benches);

--- a/crates/infra/websocket-proxy/benches/filter.rs
+++ b/crates/infra/websocket-proxy/benches/filter.rs
@@ -1,60 +1,95 @@
 use std::sync::{Arc, OnceLock};
 
-use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
+use criterion::{Criterion, criterion_group, criterion_main};
 use websocket_proxy::FilterType;
 
-/// Realistic flashblock payload adapted from filter.rs unit tests.
-fn make_payload() -> Vec<u8> {
-    br#"{
+/// Transaction hex string used to pad payloads to the desired size.
+const TX_HEX: &str = "0x7ef90104a0799b8b5182a2612920c032590217fd987cdcf1e07a2de17907e02eea535cc30694deaddeaddeaddeaddeaddeaddeaddeaddead00019442000000000000000000000000000000000000158080830f424080b8b0098999be0000044d000a118b000000000000000000000000683f28fc0000000000813aea000000000000000000000000000000000000000000000000000000000000094a0000000000000000000000000000000000000000000000000000000000000001f10c9d7f8fab954891476f8daa9189f45ee736b02bc43cb190e4f891c82e7edf000000000000000000000000fc56e7272eebbba5bc6c544e159483c4a38f8ba3000000000000000000000000";
+
+/// Build a flashblock JSON payload of approximately `target_bytes`.
+///
+/// Grows the payload by repeating transaction entries in `diff.transactions`.
+/// The matching address (`0x4200…0010`) is always present in `metadata.receipts`
+/// so filter benchmarks see consistent match behaviour at every size.
+fn make_payload_sized(target_bytes: usize) -> Vec<u8> {
+    // Each entry: quoted TX_HEX + leading comma-space ≈ TX_HEX.len() + 4 bytes.
+    let per_tx = TX_HEX.len() + 4;
+    // Fixed JSON overhead (outer structure + metadata + one receipt): ~550 bytes.
+    let fixed_overhead = 550_usize;
+    let tx_count = target_bytes.saturating_sub(fixed_overhead).div_ceil(per_tx).max(1);
+
+    let mut transactions = String::with_capacity(tx_count * per_tx);
+    for i in 0..tx_count {
+        if i > 0 {
+            transactions.push_str(",\n      ");
+        }
+        transactions.push('"');
+        transactions.push_str(TX_HEX);
+        transactions.push('"');
+    }
+
+    format!(
+        r#"{{
   "payload_id": "0x0307de8ff1df8ed8",
   "index": 0,
-  "diff": {
+  "diff": {{
     "transactions": [
-      "0x7ef90104a0799b8b5182a2612920c032590217fd987cdcf1e07a2de17907e02eea535cc30694deaddeaddeaddeaddeaddeaddeaddeaddead00019442000000000000000000000000000000000000158080830f424080b8b0098999be0000044d000a118b000000000000000000000000683f28fc0000000000813aea000000000000000000000000000000000000000000000000000000000000094a0000000000000000000000000000000000000000000000000000000000000001f10c9d7f8fab954891476f8daa9189f45ee736b02bc43cb190e4f891c82e7edf000000000000000000000000fc56e7272eebbba5bc6c544e159483c4a38f8ba3000000000000000000000000"
+      {transactions}
     ]
-  },
-  "metadata": {
+  }},
+  "metadata": {{
     "block_number": 26600873,
-    "new_account_balances": {
+    "new_account_balances": {{
       "0x336f495c2d3d764f541426228178a2369c9b78db": "0x13fbe85edc90000",
       "0x4200000000000000000000000000000000000007": "0xf61bc4ad468f1bd"
-    },
-    "receipts": {
-      "0x3fb39b336c13a09d04a34f72cd88a7b0066d65dcf246288ac5bdbba33376eb41": {
-        "Deposit": {
+    }},
+    "receipts": {{
+      "0x3fb39b336c13a09d04a34f72cd88a7b0066d65dcf246288ac5bdbba33376eb41": {{
+        "Deposit": {{
           "logs": [
-            {
+            {{
               "address": "0x4200000000000000000000000000000000000010",
               "topics": [
                 "0xb0444523268717a02698be47d0803aa7468c00acbed2f8bd93a0459cde61dd89",
                 "0x0000000000000000000000000000000000000000000000000000000000000000"
               ]
-            }
+            }}
           ]
-        }
-      }
-    }
-  }
-}"#
-    .to_vec()
+        }}
+      }}
+    }}
+  }}
+}}"#
+    )
+    .into_bytes()
 }
+
+/// Target payload sizes to sweep: 1 KB, 10 KB, 100 KB, 1 MB, 2 MB.
+const PAYLOAD_TARGETS: &[usize] = &[1_024, 10_240, 102_400, 1_048_576, 2_097_152];
+
+/// Subscriber counts to sweep.
+const SUBSCRIBER_COUNTS: &[usize] = &[1, 10, 50, 100];
 
 /// Benchmark: N subscribers each call `matches` independently (baseline — parses N times).
 fn bench_filter_no_cache(c: &mut Criterion) {
-    let payload = make_payload();
     let filter =
         FilterType::new_addresses(vec!["0x4200000000000000000000000000000000000010".to_string()]);
 
     let mut g = c.benchmark_group("filter_n_subscribers");
 
-    for n in [1usize, 10, 50, 100] {
-        g.bench_with_input(BenchmarkId::new("matches_no_cache", n), &n, |b, &n| {
-            b.iter(|| {
-                for _ in 0..n {
-                    let _ = filter.matches(std::hint::black_box(&payload), false);
-                }
+    for &target in PAYLOAD_TARGETS {
+        let payload = make_payload_sized(target);
+        let size_kb = payload.len() / 1024;
+
+        for &n in SUBSCRIBER_COUNTS {
+            g.bench_function(format!("matches_no_cache/size={size_kb}KB/n={n}"), |b| {
+                b.iter(|| {
+                    for _ in 0..n {
+                        let _ = filter.matches(std::hint::black_box(&payload), false);
+                    }
+                });
             });
-        });
+        }
     }
 
     g.finish();
@@ -62,26 +97,30 @@ fn bench_filter_no_cache(c: &mut Criterion) {
 
 /// Benchmark: N subscribers share one `OnceLock` per message (parse once, reuse Arc<Value>).
 fn bench_filter_with_cache(c: &mut Criterion) {
-    let payload = make_payload();
     let filter =
         FilterType::new_addresses(vec!["0x4200000000000000000000000000000000000010".to_string()]);
 
     let mut g = c.benchmark_group("filter_n_subscribers");
 
-    for n in [1usize, 10, 50, 100] {
-        g.bench_with_input(BenchmarkId::new("matches_with_cache", n), &n, |b, &n| {
-            b.iter(|| {
-                // One OnceLock per broadcast message; reset each outer iteration.
-                let cache: OnceLock<Option<Arc<serde_json::Value>>> = OnceLock::new();
-                for _ in 0..n {
-                    let _ = filter.matches_with_cache(
-                        std::hint::black_box(&payload),
-                        false,
-                        std::hint::black_box(&cache),
-                    );
-                }
+    for &target in PAYLOAD_TARGETS {
+        let payload = make_payload_sized(target);
+        let size_kb = payload.len() / 1024;
+
+        for &n in SUBSCRIBER_COUNTS {
+            g.bench_function(format!("matches_with_cache/size={size_kb}KB/n={n}"), |b| {
+                b.iter(|| {
+                    // One OnceLock per broadcast message; reset each outer iteration.
+                    let cache: OnceLock<Option<Arc<serde_json::Value>>> = OnceLock::new();
+                    for _ in 0..n {
+                        let _ = filter.matches_with_cache(
+                            std::hint::black_box(&payload),
+                            false,
+                            std::hint::black_box(&cache),
+                        );
+                    }
+                });
             });
-        });
+        }
     }
 
     g.finish();

--- a/crates/infra/websocket-proxy/src/filter.rs
+++ b/crates/infra/websocket-proxy/src/filter.rs
@@ -1,4 +1,8 @@
-use std::{collections::HashSet, io::Write, sync::Arc};
+use std::{
+    collections::HashSet,
+    io::Write,
+    sync::{Arc, OnceLock},
+};
 
 use brotli::DecompressorWriter;
 use serde_json::{self, Value};
@@ -90,43 +94,9 @@ impl FilterType {
         if let Self::None = self {
             return true;
         }
-
-        let uncompressed_data = if enable_compression {
-            let mut uncompressed_bytes = Vec::new();
-            {
-                let mut decoder = DecompressorWriter::new(&mut uncompressed_bytes, 4096);
-                match decoder.write_all(payload) {
-                    Ok(_) => (),
-                    Err(e) => {
-                        info!(error = %e, "error while decoding payload");
-                        return false;
-                    }
-                }
-            }
-            uncompressed_bytes
-        } else {
-            payload.to_owned()
-        };
-
-        let value = String::from_utf8(uncompressed_data);
-        if value.is_err() {
-            return false;
-        }
-
-        let json_result: Result<Value, _> = serde_json::from_str(value.unwrap().as_str());
-        match json_result {
-            Ok(json) => {
-                let result = self.json_matches(&json);
-                trace!(result = result, filter_type = ?self, "Filter result");
-                result
-            }
-            Err(e) => {
-                warn!(
-                    message = "Failed to parse JSON payload for filtering",
-                    error = e.to_string()
-                );
-                false
-            }
+        match parse_payload(payload, enable_compression) {
+            Some(json) => self.matches_parsed(&json),
+            None => false,
         }
     }
 
@@ -153,7 +123,7 @@ impl FilterType {
         &self,
         payload: &[u8],
         enable_compression: bool,
-        cached_json: &std::sync::OnceLock<Option<Arc<Value>>>,
+        cached_json: &OnceLock<Option<Arc<Value>>>,
     ) -> bool {
         if let Self::None = self {
             return true;
@@ -517,8 +487,6 @@ mod tests {
 
     #[test]
     fn test_matches_with_cache_shares_parse() {
-        use std::sync::OnceLock;
-
         let payload = get_test_payload();
         let cache: OnceLock<Option<Arc<Value>>> = OnceLock::new();
 

--- a/crates/infra/websocket-proxy/src/filter.rs
+++ b/crates/infra/websocket-proxy/src/filter.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashSet, io::Write};
+use std::{collections::HashSet, io::Write, sync::Arc};
 
 use brotli::DecompressorWriter;
 use serde_json::{self, Value};
@@ -83,6 +83,9 @@ impl FilterType {
     }
 
     /// Returns `true` if the payload matches this filter's criteria.
+    ///
+    /// Decompresses and parses the payload independently. Prefer [`FilterType::matches_parsed`]
+    /// when a pre-parsed [`Value`] is available so the JSON work is shared across subscribers.
     pub fn matches(&self, payload: &[u8], enable_compression: bool) -> bool {
         if let Self::None = self {
             return true;
@@ -124,6 +127,43 @@ impl FilterType {
                 );
                 false
             }
+        }
+    }
+
+    /// Returns `true` if the pre-parsed JSON value matches this filter's criteria.
+    ///
+    /// Use this instead of [`FilterType::matches`] when the JSON has already been parsed,
+    /// to avoid redundant work per subscriber. [`FilterType::None`] short-circuits without
+    /// inspecting the value.
+    pub fn matches_parsed(&self, json: &Value) -> bool {
+        if let Self::None = self {
+            return true;
+        }
+        let result = self.json_matches(json);
+        trace!(result = result, filter_type = ?self, "Filter result");
+        result
+    }
+
+    /// Checks whether the filter matches against a shared pre-parsed JSON value.
+    ///
+    /// `cached_json` should be an `OnceLock`-backed `Arc<Value>` that is initialised
+    /// at most once per broadcast message regardless of how many subscribers call this.
+    /// Returns `true` for [`FilterType::None`] without touching `cached_json`.
+    pub fn matches_with_cache(
+        &self,
+        payload: &[u8],
+        enable_compression: bool,
+        cached_json: &std::sync::OnceLock<Option<Arc<Value>>>,
+    ) -> bool {
+        if let Self::None = self {
+            return true;
+        }
+
+        let parsed = cached_json.get_or_init(|| parse_payload(payload, enable_compression));
+
+        match parsed {
+            Some(json) => self.matches_parsed(json),
+            None => false,
         }
     }
 
@@ -243,6 +283,42 @@ impl FilterType {
             }
         }
         false
+    }
+}
+
+/// Decompresses (if needed) and JSON-parses `payload`, returning `None` on any error.
+fn parse_payload(payload: &[u8], enable_compression: bool) -> Option<Arc<Value>> {
+    let uncompressed_data = if enable_compression {
+        let mut uncompressed_bytes = Vec::new();
+        {
+            let mut decoder = DecompressorWriter::new(&mut uncompressed_bytes, 4096);
+            match decoder.write_all(payload) {
+                Ok(_) => (),
+                Err(e) => {
+                    info!(error = %e, "error while decoding payload");
+                    return None;
+                }
+            }
+        }
+        uncompressed_bytes
+    } else {
+        payload.to_owned()
+    };
+
+    let text = match String::from_utf8(uncompressed_data) {
+        Ok(s) => s,
+        Err(_) => return None,
+    };
+
+    match serde_json::from_str::<Value>(&text) {
+        Ok(json) => Some(Arc::new(json)),
+        Err(e) => {
+            warn!(
+                message = "Failed to parse JSON payload for filtering",
+                error = e.to_string()
+            );
+            None
+        }
     }
 }
 
@@ -440,5 +516,59 @@ mod tests {
             "0x1111111111111111111111111111111111111111111111111111111111111111".to_string(),
         ]);
         assert!(!filter.matches(&payload, false));
+    }
+
+    #[test]
+    fn test_matches_with_cache_shares_parse() {
+        use std::sync::OnceLock;
+
+        let payload = get_test_payload();
+        let cache: OnceLock<Option<Arc<Value>>> = OnceLock::new();
+
+        let filter_a = FilterType::new_addresses(vec![
+            "0x4200000000000000000000000000000000000010".to_string(),
+        ]);
+        let filter_b = FilterType::new_topics(vec![
+            "0xb0444523268717a02698be47d0803aa7468c00acbed2f8bd93a0459cde61dd89".to_string(),
+        ]);
+        let filter_none = FilterType::None;
+
+        // None filter short-circuits without populating the cache
+        assert!(filter_none.matches_with_cache(&payload, false, &cache));
+        assert!(cache.get().is_none(), "None filter must not populate the cache");
+
+        // First non-None filter initialises the cache
+        assert!(filter_a.matches_with_cache(&payload, false, &cache));
+        assert!(cache.get().is_some(), "Cache should be populated after first non-None filter");
+
+        // Second non-None filter reuses the cached value (same OnceLock)
+        assert!(filter_b.matches_with_cache(&payload, false, &cache));
+    }
+
+    #[test]
+    fn test_matches_parsed_equivalent_to_matches() {
+        let payload = get_test_payload();
+        let json: Value = serde_json::from_slice(&payload).unwrap();
+
+        let filters = vec![
+            FilterType::new_addresses(vec![
+                "0x4200000000000000000000000000000000000010".to_string(),
+            ]),
+            FilterType::new_addresses(vec![
+                "0x1111111111111111111111111111111111111111".to_string(),
+            ]),
+            FilterType::new_topics(vec![
+                "0xb0444523268717a02698be47d0803aa7468c00acbed2f8bd93a0459cde61dd89".to_string(),
+            ]),
+            FilterType::None,
+        ];
+
+        for filter in &filters {
+            assert_eq!(
+                filter.matches(&payload, false),
+                filter.matches_parsed(&json),
+                "matches and matches_parsed disagree for filter {filter:?}"
+            );
+        }
     }
 }

--- a/crates/infra/websocket-proxy/src/filter.rs
+++ b/crates/infra/websocket-proxy/src/filter.rs
@@ -313,10 +313,7 @@ fn parse_payload(payload: &[u8], enable_compression: bool) -> Option<Arc<Value>>
     match serde_json::from_str::<Value>(&text) {
         Ok(json) => Some(Arc::new(json)),
         Err(e) => {
-            warn!(
-                message = "Failed to parse JSON payload for filtering",
-                error = e.to_string()
-            );
+            warn!(message = "Failed to parse JSON payload for filtering", error = e.to_string());
             None
         }
     }

--- a/crates/infra/websocket-proxy/src/registry.rs
+++ b/crates/infra/websocket-proxy/src/registry.rs
@@ -36,7 +36,7 @@ impl BroadcastMessage {
     }
 
     /// Returns a reference to the shared JSON cache used by [`FilterType::matches_with_cache`].
-    pub fn cached_json(&self) -> &OnceLock<Option<Arc<Value>>> {
+    pub const fn cached_json(&self) -> &OnceLock<Option<Arc<Value>>> {
         &self.cached_json
     }
 }

--- a/crates/infra/websocket-proxy/src/registry.rs
+++ b/crates/infra/websocket-proxy/src/registry.rs
@@ -1,7 +1,11 @@
-use std::{sync::Arc, time::Instant};
+use std::{
+    sync::{Arc, OnceLock},
+    time::Instant,
+};
 
 use axum::extract::ws::Message;
 use futures::{SinkExt, stream::StreamExt};
+use serde_json::Value;
 use tokio::{
     sync::broadcast::{Sender, error::RecvError},
     time::{Duration, interval, timeout},
@@ -9,6 +13,33 @@ use tokio::{
 use tracing::{debug, info, trace, warn};
 
 use crate::{client::ClientConnection, metrics::Metrics};
+
+/// A broadcast message that lazily caches the decompressed, parsed JSON representation.
+///
+/// The `OnceLock` ensures that decompression and JSON parsing happen at most once per
+/// broadcast message, regardless of how many subscriber tasks race to filter it. All
+/// subscribers that need the parsed form share the same `Arc<Value>` via the lock.
+#[derive(Debug)]
+pub struct BroadcastMessage {
+    /// The raw WebSocket message as received from the upstream source.
+    pub message: Message,
+    /// Lazily initialised parsed JSON. `None` inside the `OnceLock` means the payload
+    /// could not be decompressed or parsed. Uninitialised means no subscriber has needed
+    /// it yet (or the subscriber has a [`FilterType::None`] filter).
+    cached_json: OnceLock<Option<Arc<Value>>>,
+}
+
+impl BroadcastMessage {
+    /// Wraps a raw [`Message`] in a broadcast envelope with an empty JSON cache.
+    pub fn new(message: Message) -> Arc<Self> {
+        Arc::new(Self { message, cached_json: OnceLock::new() })
+    }
+
+    /// Returns a reference to the shared JSON cache used by [`FilterType::matches_with_cache`].
+    pub fn cached_json(&self) -> &OnceLock<Option<Arc<Value>>> {
+        &self.cached_json
+    }
+}
 
 fn get_message_size(msg: &Message) -> u64 {
     match msg {
@@ -21,7 +52,7 @@ fn get_message_size(msg: &Message) -> u64 {
 /// Manages broadcast subscriptions for connected WebSocket clients.
 #[derive(Clone, Debug)]
 pub struct Registry {
-    sender: Sender<Message>,
+    sender: Sender<Arc<BroadcastMessage>>,
     metrics: Arc<Metrics>,
     compressed: bool,
     ping_enabled: bool,
@@ -32,7 +63,7 @@ pub struct Registry {
 impl Registry {
     /// Creates a new registry with the given broadcast sender and configuration.
     pub const fn new(
-        sender: Sender<Message>,
+        sender: Sender<Arc<BroadcastMessage>>,
         metrics: Arc<Metrics>,
         compressed: bool,
         ping_enabled: bool,
@@ -62,17 +93,31 @@ impl Registry {
             tokio::select! {
                 broadcast_result = receiver.recv() => {
                     match broadcast_result {
-                        Ok(msg) => {
-                            let msg_bytes = match &msg {
+                        Ok(broadcast_msg) => {
+                            let msg_bytes = match &broadcast_msg.message {
                                 Message::Binary(data) => data.as_ref(),
                                 _ => &[],
                             };
-                            if filter.matches(msg_bytes, compressed) {
-                                trace!(message = "filter matched for client", client = client_id, filter = ?filter);
+
+                            // matches_with_cache decompresses and parses the JSON at most once
+                            // across all concurrent subscribers for this message. FilterType::None
+                            // short-circuits without touching the cache.
+                            if filter.matches_with_cache(
+                                msg_bytes,
+                                compressed,
+                                broadcast_msg.cached_json(),
+                            ) {
+                                trace!(
+                                    message = "filter matched for client",
+                                    client = client_id,
+                                    filter = ?filter
+                                );
 
                                 let send_start = Instant::now();
-                                let msg_size = get_message_size(&msg);
-                                let send_result = timeout(self.send_timeout_ms, ws_sender.send(msg)).await;
+                                let msg_size = get_message_size(&broadcast_msg.message);
+                                let msg_clone = broadcast_msg.message.clone();
+                                let send_result =
+                                    timeout(self.send_timeout_ms, ws_sender.send(msg_clone)).await;
                                 let send_duration = send_start.elapsed();
 
                                 metrics.message_send_duration.record(send_duration);
@@ -80,7 +125,10 @@ impl Registry {
                                 match send_result {
                                     Ok(Ok(())) => {
                                         // Success - message sent
-                                        trace!(message = "message sent to client", client = client_id);
+                                        trace!(
+                                            message = "message sent to client",
+                                            client = client_id
+                                        );
                                         metrics.sent_messages.increment(1);
                                         metrics.bytes_broadcasted.increment(msg_size);
                                     }
@@ -156,12 +204,18 @@ impl Registry {
                         match msg {
                             Some(Ok(Message::Pong(_))) => {
                                 if ping_enabled {
-                                    trace!(message = "received pong from client", client = client_id);
+                                    trace!(
+                                        message = "received pong from client",
+                                        client = client_id
+                                    );
                                     last_pong = Instant::now();
                                 }
                             }
                             Some(Ok(Message::Close(_))) => {
-                                trace!(message = "received close from client", client = client_id);
+                                trace!(
+                                    message = "received close from client",
+                                    client = client_id
+                                );
                                 let _ = pong_error_tx.send(());
                                 return;
                             }

--- a/crates/infra/websocket-proxy/tests/integration.rs
+++ b/crates/infra/websocket-proxy/tests/integration.rs
@@ -18,7 +18,9 @@ use tokio::{
 use tokio_tungstenite::connect_async;
 use tokio_util::sync::CancellationToken;
 use tracing::error;
-use websocket_proxy::{Authentication, BroadcastMessage, InMemoryRateLimit, Metrics, Registry, Server};
+use websocket_proxy::{
+    Authentication, BroadcastMessage, InMemoryRateLimit, Metrics, Registry, Server,
+};
 
 struct TestHarness {
     received_messages: Arc<Mutex<HashMap<usize, Vec<String>>>>,
@@ -187,9 +189,8 @@ impl TestHarness {
 
     fn send_messages(&self, messages: Vec<&str>) {
         for message_str in &messages {
-            let message = BroadcastMessage::new(
-                Message::Binary(message_str.as_bytes().to_vec().into()),
-            );
+            let message =
+                BroadcastMessage::new(Message::Binary(message_str.as_bytes().to_vec().into()));
             match self.sender.send(message) {
                 Ok(_) => {}
                 Err(_) => {

--- a/crates/infra/websocket-proxy/tests/integration.rs
+++ b/crates/infra/websocket-proxy/tests/integration.rs
@@ -18,7 +18,7 @@ use tokio::{
 use tokio_tungstenite::connect_async;
 use tokio_util::sync::CancellationToken;
 use tracing::error;
-use websocket_proxy::{Authentication, InMemoryRateLimit, Metrics, Registry, Server};
+use websocket_proxy::{Authentication, BroadcastMessage, InMemoryRateLimit, Metrics, Registry, Server};
 
 struct TestHarness {
     received_messages: Arc<Mutex<HashMap<usize, Vec<String>>>>,
@@ -28,7 +28,7 @@ struct TestHarness {
     server: Server,
     server_addr: SocketAddr,
     client_id_to_handle: HashMap<usize, JoinHandle<()>>,
-    sender: Sender<Message>,
+    sender: Sender<Arc<BroadcastMessage>>,
 }
 
 impl TestHarness {
@@ -42,7 +42,7 @@ impl TestHarness {
     }
 
     fn new_with_auth(addr: SocketAddr, auth: Option<Authentication>) -> Self {
-        let (sender, _) = broadcast::channel(5);
+        let (sender, _) = broadcast::channel::<Arc<BroadcastMessage>>(5);
         let metrics = Arc::new(Metrics::default());
         let registry = Registry::new(
             sender.clone(),
@@ -187,7 +187,9 @@ impl TestHarness {
 
     fn send_messages(&self, messages: Vec<&str>) {
         for message_str in &messages {
-            let message = Message::Binary(message_str.as_bytes().to_vec().into());
+            let message = BroadcastMessage::new(
+                Message::Binary(message_str.as_bytes().to_vec().into()),
+            );
             match self.sender.send(message) {
                 Ok(_) => {}
                 Err(_) => {
@@ -372,7 +374,7 @@ async fn test_authentication_allows_known_api_keys() {
 async fn test_ping_timeout_disconnects_client() {
     let addr = TestHarness::alloc_port().await;
 
-    let (sender, _) = broadcast::channel(5);
+    let (sender, _) = broadcast::channel::<Arc<BroadcastMessage>>(5);
     let metrics = Arc::new(Metrics::default());
     let registry = Registry::new(
         sender.clone(),
@@ -410,7 +412,7 @@ async fn test_ping_timeout_disconnects_client() {
 
     assert_eq!(harness.sender.receiver_count(), 1);
 
-    harness.sender.send(Message::Ping(vec![].into())).unwrap();
+    harness.sender.send(BroadcastMessage::new(Message::Ping(vec![].into()))).unwrap();
     tokio::time::sleep(Duration::from_millis(1500)).await;
 
     assert_eq!(harness.sender.receiver_count(), 0);


### PR DESCRIPTION
Before: each subscriber task independently decompressed and JSON-parsed the full flashblock payload for every incoming broadcast message — O(N × payload) CPU work with N connected clients.

After: introduce `BroadcastMessage` wrapping the raw `Message` alongside a `OnceLock<Option<Arc<Value>>>`. The first non-None-filter subscriber to inspect a given message pays the decompress + `serde_json::from_str` cost; every subsequent subscriber reuses the cached `Arc<Value>`. `FilterType::None` clients short-circuit before touching the lock, paying zero parse cost as before.

Public additions:
- `BroadcastMessage` (registry.rs): the new broadcast envelope
- `FilterType::matches_parsed(&Value) -> bool`
- `FilterType::matches_with_cache(..., &OnceLock<Option<Arc<Value>>>) -> bool`

`Registry::new` now accepts `Sender<Arc<BroadcastMessage>>` instead of `Sender<Message>`; main.rs and integration tests updated accordingly.

No-cache — parse cost × N (O(N × size))

```
  ┌─────────┬─────────┬─────────┬─────────┬─────────┐
  │  Size   │   n=1   │  n=10   │  n=50   │  n=100  │
  ├─────────┼─────────┼─────────┼─────────┼─────────┤
  │ 1 KB    │ 1.27 µs │ 12.6 µs │ 62.8 µs │ 126 µs  │
  ├─────────┼─────────┼─────────┼─────────┼─────────┤
  │ 10 KB   │ 3.07 µs │ 31.1 µs │ 159 µs  │ 313 µs  │
  ├─────────┼─────────┼─────────┼─────────┼─────────┤
  │ 101 KB  │ 21.8 µs │ 219 µs  │ 1.10 ms │ 2.21 ms │
  ├─────────┼─────────┼─────────┼─────────┼─────────┤
  │ 1035 KB │ 196 µs  │ 1.97 ms │ 9.96 ms │ 19.7 ms │
  ├─────────┼─────────┼─────────┼─────────┼─────────┤
  │ 2071 KB │ 389 µs  │ 3.90 ms │ 19.4 ms │ 39.6 ms │
  └─────────┴─────────┴─────────┴─────────┴─────────┘
```

  With-cache — parse once, reuse Arc (O(size + N × tiny))

```
  ┌─────────┬─────────┬─────────┬─────────┬─────────┐
  │  Size   │   n=1   │  n=10   │  n=50   │  n=100  │
  ├─────────┼─────────┼─────────┼─────────┼─────────┤
  │ 1 KB    │ 1.29 µs │ 2.42 µs │ 7.55 µs │ 14.5 µs │
  ├─────────┼─────────┼─────────┼─────────┼─────────┤
  │ 10 KB   │ 3.21 µs │ 4.53 µs │ 10.5 µs │ 16.2 µs │
  ├─────────┼─────────┼─────────┼─────────┼─────────┤
  │ 101 KB  │ 22.5 µs │ 23.6 µs │ 29.2 µs │ 36.0 µs │
  ├─────────┼─────────┼─────────┼─────────┼─────────┤
  │ 1035 KB │ 197 µs  │ 199 µs  │ 203 µs  │ 212 µs  │
  ├─────────┼─────────┼─────────┼─────────┼─────────┤
  │ 2071 KB │ 392 µs  │ 399 µs  │ 406 µs  │ 409 µs  │
  └─────────┴─────────┴─────────┴─────────┴─────────┘
```