### PR TITLE
feat(consensus): Remove L1WatcherActor Provider Bound

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2517,6 +2517,7 @@ dependencies = [
  "base-blobs",
  "base-consensus-derive",
  "base-consensus-genesis",
+ "base-consensus-node",
  "base-consensus-registry",
  "base-execution-chainspec",
  "base-execution-evm",

--- a/actions/harness/Cargo.toml
+++ b/actions/harness/Cargo.toml
@@ -18,6 +18,7 @@ thiserror.workspace = true
 alloy-rlp.workspace = true
 alloy-eips.workspace = true
 async-trait.workspace = true
+base-consensus-node.workspace = true
 alloy-signer.workspace = true
 alloy-hardforks.workspace = true
 alloy-primitives.workspace = true

--- a/actions/harness/src/lib.rs
+++ b/actions/harness/src/lib.rs
@@ -32,8 +32,9 @@ pub use test_rollup_config::TestRollupConfigBuilder;
 
 mod providers;
 pub use providers::{
-    ActionBlobDataSource, ActionBlobProvider, ActionDataSource, ActionL1ChainProvider,
-    ActionL2ChainProvider, L1ProviderError, L2ProviderError, SharedL1Chain,
+    ActionBlobDataSource, ActionBlobProvider, ActionDataSource, ActionL1BlockFetcher,
+    ActionL1ChainProvider, ActionL1FetcherError, ActionL2ChainProvider, L1ProviderError,
+    L2ProviderError, SharedL1Chain,
 };
 
 mod verifier;

--- a/actions/harness/src/providers/l1.rs
+++ b/actions/harness/src/providers/l1.rs
@@ -45,6 +45,16 @@ impl SharedL1Chain {
         self.0.lock().expect("chain lock poisoned").get(number as usize).cloned()
     }
 
+    /// Return the tip (latest) block, or `None` if the chain is empty.
+    pub fn tip(&self) -> Option<L1Block> {
+        self.0.lock().expect("chain lock poisoned").last().cloned()
+    }
+
+    /// Look up a block by hash, returning a clone if it exists.
+    pub fn block_by_hash(&self, hash: alloy_primitives::B256) -> Option<L1Block> {
+        self.0.lock().expect("chain lock poisoned").iter().find(|b| b.hash() == hash).cloned()
+    }
+
     fn with<R>(&self, f: impl FnOnce(&[L1Block]) -> R) -> R {
         let g = self.0.lock().expect("chain lock poisoned");
         f(&g)

--- a/actions/harness/src/providers/l1_block_fetcher.rs
+++ b/actions/harness/src/providers/l1_block_fetcher.rs
@@ -1,0 +1,64 @@
+//! In-memory [`L1BlockFetcher`] implementation for action tests.
+
+use alloy_eips::{BlockId, BlockNumberOrTag};
+use alloy_rpc_types_eth::{Block, Filter, Header, Log};
+use async_trait::async_trait;
+use base_consensus_node::L1BlockFetcher;
+
+use crate::{L1Block, SharedL1Chain};
+
+/// Error type for [`ActionL1BlockFetcher`].
+#[derive(Debug, thiserror::Error)]
+#[error("action L1 block fetcher error: {0}")]
+pub struct ActionL1FetcherError(String);
+
+/// In-memory [`L1BlockFetcher`] backed by [`SharedL1Chain`].
+///
+/// Used to satisfy the [`L1BlockFetcher`] bound on [`L1WatcherActor`] in
+/// action tests without requiring a live Ethereum RPC endpoint.
+///
+/// - `get_logs` returns an empty `Vec` in all cases. Most action tests do not
+///   emit signer-rotation logs, so this is the correct behaviour for the
+///   current test suite.
+/// - `get_block` looks the block up by number or hash in the shared chain and
+///   converts it to an [`alloy_rpc_types_eth::Block`].
+///
+/// [`L1WatcherActor`]: base_consensus_node::L1WatcherActor
+#[derive(Debug, Clone)]
+pub struct ActionL1BlockFetcher {
+    chain: SharedL1Chain,
+}
+
+impl ActionL1BlockFetcher {
+    /// Create a new fetcher backed by the given shared chain.
+    pub const fn new(chain: SharedL1Chain) -> Self {
+        Self { chain }
+    }
+}
+
+fn l1_block_to_rpc(b: L1Block) -> Block {
+    let hash = b.hash();
+    Block { header: Header { inner: b.header, hash, ..Default::default() }, ..Default::default() }
+}
+
+#[async_trait]
+impl L1BlockFetcher for ActionL1BlockFetcher {
+    type Error = ActionL1FetcherError;
+
+    async fn get_logs(&self, _filter: Filter) -> Result<Vec<Log>, Self::Error> {
+        // Most action tests do not emit signer-rotation logs. Return empty.
+        Ok(vec![])
+    }
+
+    async fn get_block(&self, id: BlockId) -> Result<Option<Block>, Self::Error> {
+        let l1_block = match id {
+            BlockId::Hash(hash_id) => self.chain.block_by_hash(hash_id.block_hash),
+            BlockId::Number(tag) => match tag {
+                BlockNumberOrTag::Number(n) => self.chain.get_block(n),
+                BlockNumberOrTag::Latest => self.chain.tip(),
+                _ => None,
+            },
+        };
+        Ok(l1_block.map(l1_block_to_rpc))
+    }
+}

--- a/actions/harness/src/providers/mod.rs
+++ b/actions/harness/src/providers/mod.rs
@@ -1,6 +1,9 @@
 mod l1;
 pub use l1::{ActionDataSource, ActionL1ChainProvider, L1ProviderError, SharedL1Chain};
 
+mod l1_block_fetcher;
+pub use l1_block_fetcher::{ActionL1BlockFetcher, ActionL1FetcherError};
+
 mod l2;
 pub use l2::{ActionL2ChainProvider, L2ProviderError};
 

--- a/crates/consensus/service/src/actors/l1_watcher/actor.rs
+++ b/crates/consensus/service/src/actors/l1_watcher/actor.rs
@@ -5,7 +5,6 @@ use std::sync::Arc;
 
 use alloy_eips::BlockId;
 use alloy_primitives::Address;
-use alloy_provider::Provider;
 use async_trait::async_trait;
 use base_consensus_genesis::{
     RollupConfig, SystemConfigLog, SystemConfigUpdate, UnsafeBlockSignerUpdate,
@@ -22,7 +21,7 @@ use tokio::{
 };
 use tokio_util::sync::{CancellationToken, WaitForCancellationFuture};
 
-use super::L1WatcherDerivationClient;
+use super::{L1BlockFetcher, L1WatcherDerivationClient};
 use crate::{
     NodeActor,
     actors::{CancellableContext, l1_watcher::error::L1WatcherActorError},
@@ -33,7 +32,7 @@ use crate::{
 pub struct L1WatcherActor<BlockStream, L1Provider, L1WatcherDerivationClient_>
 where
     BlockStream: Stream<Item = BlockInfo> + Unpin + Send,
-    L1Provider: Provider,
+    L1Provider: L1BlockFetcher,
     L1WatcherDerivationClient_: L1WatcherDerivationClient,
 {
     /// The [`RollupConfig`] to tell if ecotone is active.
@@ -60,7 +59,7 @@ impl<BlockStream, L1Provider, L1WatcherDerivationClient_>
     L1WatcherActor<BlockStream, L1Provider, L1WatcherDerivationClient_>
 where
     BlockStream: Stream<Item = BlockInfo> + Unpin + Send,
-    L1Provider: Provider,
+    L1Provider: L1BlockFetcher,
     L1WatcherDerivationClient_: L1WatcherDerivationClient,
 {
     /// Instantiate a new [`L1WatcherActor`].
@@ -95,7 +94,7 @@ impl<BlockStream, L1Provider, L1WatcherDerivationClient_> NodeActor
     for L1WatcherActor<BlockStream, L1Provider, L1WatcherDerivationClient_>
 where
     BlockStream: Stream<Item = BlockInfo> + Unpin + Send + 'static,
-    L1Provider: Provider + 'static,
+    L1Provider: L1BlockFetcher + 'static,
     L1WatcherDerivationClient_: L1WatcherDerivationClient + 'static,
 {
     type Error = L1WatcherActorError<BlockInfo>;
@@ -134,7 +133,11 @@ where
                         // If the update is an Unsafe block signer update, send the address
                         // to the block signer sender.
                         let filter_address =  self.rollup_config.l1_system_config_address;
-                        let logs = self.l1_provider .get_logs(&alloy_rpc_types_eth::Filter::new().address(filter_address).select(head_block_info.hash)).await?;
+                        let logs = self.l1_provider.get_logs(
+                            alloy_rpc_types_eth::Filter::new()
+                                .address(filter_address)
+                                .select(head_block_info.hash),
+                        ).await.map_err(|e| L1WatcherActorError::Fetcher(e.to_string()))?;
                         let ecotone_active = self.rollup_config.is_ecotone_active(head_block_info.timestamp);
                         for log in logs {
                             let sys_cfg_log = SystemConfigLog::new(log.into(), ecotone_active);
@@ -222,7 +225,7 @@ impl<BlockStream, L1Provider, L1WatcherDerivationClient_> CancellableContext
     for L1WatcherActor<BlockStream, L1Provider, L1WatcherDerivationClient_>
 where
     BlockStream: Stream<Item = BlockInfo> + Unpin + Send + 'static,
-    L1Provider: Provider,
+    L1Provider: L1BlockFetcher,
     L1WatcherDerivationClient_: L1WatcherDerivationClient + 'static,
 {
     fn cancelled(&self) -> WaitForCancellationFuture<'_> {

--- a/crates/consensus/service/src/actors/l1_watcher/error.rs
+++ b/crates/consensus/service/src/actors/l1_watcher/error.rs
@@ -1,7 +1,6 @@
 use std::sync::mpsc::SendError;
 
 use alloy_eips::BlockId;
-use alloy_transport::TransportError;
 use thiserror::Error;
 
 use crate::DerivationClientError;
@@ -12,9 +11,9 @@ pub enum L1WatcherActorError<T> {
     /// Error sending the head update event.
     #[error("Error sending the head update event: {0}")]
     SendError(#[from] SendError<T>),
-    /// Error in the transport layer.
-    #[error("Transport error: {0}")]
-    Transport(#[from] TransportError),
+    /// Error from the L1 block fetcher.
+    #[error("L1 block fetcher error: {0}")]
+    Fetcher(String),
     /// The L1 block was not found.
     #[error("L1 block not found: {0}")]
     L1BlockNotFound(BlockId),

--- a/crates/consensus/service/src/actors/l1_watcher/fetcher.rs
+++ b/crates/consensus/service/src/actors/l1_watcher/fetcher.rs
@@ -1,0 +1,46 @@
+//! Narrow provider trait for [`super::L1WatcherActor`].
+
+use alloy_eips::BlockId;
+use alloy_rpc_types_eth::{Block, Filter, Log};
+use async_trait::async_trait;
+
+/// A narrow trait exposing only the two L1 RPC methods used by [`super::L1WatcherActor`].
+///
+/// Replacing the broad [`alloy_provider::Provider`] bound with this trait makes
+/// in-process test implementations straightforward — a test double only needs
+/// to implement `get_logs` and `get_block` rather than the full ~30-method
+/// provider interface.
+#[async_trait]
+pub trait L1BlockFetcher: Send + Sync + 'static {
+    /// Error type returned by all fetch operations.
+    type Error: std::fmt::Display + std::fmt::Debug + Send;
+
+    /// Return all logs matching `filter`.
+    async fn get_logs(&self, filter: Filter) -> Result<Vec<Log>, Self::Error>;
+
+    /// Return the block identified by `id`, or `None` if it does not exist.
+    async fn get_block(&self, id: BlockId) -> Result<Option<Block>, Self::Error>;
+}
+
+/// Wraps an [`alloy_provider::Provider`] to implement [`L1BlockFetcher`].
+///
+/// Construct this with the production L1 provider and pass it to
+/// [`super::L1WatcherActor::new`] in place of the bare provider.
+#[derive(Debug)]
+pub struct AlloyL1BlockFetcher<P>(pub P);
+
+#[async_trait]
+impl<P> L1BlockFetcher for AlloyL1BlockFetcher<P>
+where
+    P: alloy_provider::Provider + 'static,
+{
+    type Error = alloy_transport::TransportError;
+
+    async fn get_logs(&self, filter: Filter) -> Result<Vec<Log>, Self::Error> {
+        Ok(self.0.get_logs(&filter).await?)
+    }
+
+    async fn get_block(&self, id: BlockId) -> Result<Option<Block>, Self::Error> {
+        self.0.get_block(id).await
+    }
+}

--- a/crates/consensus/service/src/actors/l1_watcher/mod.rs
+++ b/crates/consensus/service/src/actors/l1_watcher/mod.rs
@@ -9,3 +9,6 @@ pub use client::{L1WatcherDerivationClient, QueuedL1WatcherDerivationClient};
 
 mod error;
 pub use error::L1WatcherActorError;
+
+mod fetcher;
+pub use fetcher::{AlloyL1BlockFetcher, L1BlockFetcher};

--- a/crates/consensus/service/src/actors/mod.rs
+++ b/crates/consensus/service/src/actors/mod.rs
@@ -29,8 +29,8 @@ pub use derivation::{
 
 mod l1_watcher;
 pub use l1_watcher::{
-    BlockStream, L1WatcherActor, L1WatcherActorError, L1WatcherDerivationClient,
-    QueuedL1WatcherDerivationClient,
+    AlloyL1BlockFetcher, BlockStream, L1BlockFetcher, L1WatcherActor, L1WatcherActorError,
+    L1WatcherDerivationClient, QueuedL1WatcherDerivationClient,
 };
 
 mod network;

--- a/crates/consensus/service/src/lib.rs
+++ b/crates/consensus/service/src/lib.rs
@@ -17,8 +17,8 @@ pub use service::{
 
 mod actors;
 pub use actors::{
-    BlockStream, BuildRequest, CancellableContext, Conductor, ConductorClient, ConductorError,
-    DelayedL1OriginSelectorProvider, DelegateDerivationActor, DelegateL2Client,
+    AlloyL1BlockFetcher, BlockStream, BuildRequest, CancellableContext, Conductor, ConductorClient,
+    ConductorError, DelayedL1OriginSelectorProvider, DelegateDerivationActor, DelegateL2Client,
     DelegateL2ClientError, DelegateL2DerivationActor, DerivationActor, DerivationActorRequest,
     DerivationClientError, DerivationClientResult, DerivationDelegateClient,
     DerivationDelegateClientError, DerivationEngineClient, DerivationError, DerivationState,
@@ -26,18 +26,18 @@ pub use actors::{
     EngineActorRequest, EngineClientError, EngineClientResult, EngineConfig,
     EngineDerivationClient, EngineError, EngineProcessingRequest, EngineProcessor,
     EngineRequestReceiver, EngineRpcProcessor, EngineRpcRequest, EngineRpcRequestReceiver,
-    GetPayloadRequest, L1OriginSelector, L1OriginSelectorError, L1OriginSelectorProvider,
-    L1WatcherActor, L1WatcherActorError, L1WatcherDerivationClient, L2SourceClient, NetworkActor,
-    NetworkActorError, NetworkBuilder, NetworkBuilderError, NetworkConfig, NetworkDriver,
-    NetworkDriverError, NetworkEngineClient, NetworkHandler, NetworkInboundData, NodeActor,
-    OriginSelector, PayloadBuilder, PayloadSealer, PendingStopSender, PoolActivation,
-    QueuedDerivationEngineClient, QueuedEngineDerivationClient, QueuedEngineRpcClient,
-    QueuedL1WatcherDerivationClient, QueuedNetworkEngineClient, QueuedSequencerAdminAPIClient,
-    QueuedSequencerEngineClient, QueuedUnsafePayloadGossipClient, RecoveryModeGuard, ResetRequest,
-    RpcActor, RpcActorError, RpcContext, SealRequest, SealState, SealStepError, SequencerActor,
-    SequencerActorError, SequencerAdminQuery, SequencerConfig, SequencerEngineClient,
-    UnsafePayloadGossipClient, UnsafePayloadGossipClientError, UnsealedPayloadHandle,
-    UpgradeActivations,
+    GetPayloadRequest, L1BlockFetcher, L1OriginSelector, L1OriginSelectorError,
+    L1OriginSelectorProvider, L1WatcherActor, L1WatcherActorError, L1WatcherDerivationClient,
+    L2SourceClient, NetworkActor, NetworkActorError, NetworkBuilder, NetworkBuilderError,
+    NetworkConfig, NetworkDriver, NetworkDriverError, NetworkEngineClient, NetworkHandler,
+    NetworkInboundData, NodeActor, OriginSelector, PayloadBuilder, PayloadSealer,
+    PendingStopSender, PoolActivation, QueuedDerivationEngineClient, QueuedEngineDerivationClient,
+    QueuedEngineRpcClient, QueuedL1WatcherDerivationClient, QueuedNetworkEngineClient,
+    QueuedSequencerAdminAPIClient, QueuedSequencerEngineClient, QueuedUnsafePayloadGossipClient,
+    RecoveryModeGuard, ResetRequest, RpcActor, RpcActorError, RpcContext, SealRequest, SealState,
+    SealStepError, SequencerActor, SequencerActorError, SequencerAdminQuery, SequencerConfig,
+    SequencerEngineClient, UnsafePayloadGossipClient, UnsafePayloadGossipClientError,
+    UnsealedPayloadHandle, UpgradeActivations,
 };
 
 mod metrics;

--- a/crates/consensus/service/src/service/follow.rs
+++ b/crates/consensus/service/src/service/follow.rs
@@ -11,10 +11,10 @@ use tokio_util::sync::CancellationToken;
 
 use super::LocalEngineActor;
 use crate::{
-    BlockStream, DelegateL2Client, DelegateL2DerivationActor, EngineActor, EngineActorRequest,
-    EngineConfig, EngineProcessor, EngineRpcProcessor, L1Config, L1WatcherActor, NodeActor,
-    QueuedDerivationEngineClient, QueuedEngineDerivationClient, QueuedEngineRpcClient,
-    QueuedL1WatcherDerivationClient, RpcActor, RpcContext,
+    AlloyL1BlockFetcher, BlockStream, DelegateL2Client, DelegateL2DerivationActor, EngineActor,
+    EngineActorRequest, EngineConfig, EngineProcessor, EngineRpcProcessor, L1Config,
+    L1WatcherActor, NodeActor, QueuedDerivationEngineClient, QueuedEngineDerivationClient,
+    QueuedEngineRpcClient, QueuedL1WatcherDerivationClient, RpcActor, RpcContext,
     service::node::{FINALIZED_STREAM_POLL_INTERVAL, HEAD_STREAM_POLL_INTERVAL},
 };
 
@@ -158,7 +158,7 @@ impl FollowNode {
         // Create the [`L1WatcherActor`]. Previously known as the DA watcher actor.
         let l1_watcher = L1WatcherActor::new(
             Arc::clone(&self.config),
-            self.l1_config.engine_provider.clone(),
+            AlloyL1BlockFetcher(self.l1_config.engine_provider.clone()),
             l1_query_rx,
             l1_head_updates_tx,
             QueuedL1WatcherDerivationClient { derivation_actor_request_tx },

--- a/crates/consensus/service/src/service/node.rs
+++ b/crates/consensus/service/src/service/node.rs
@@ -18,10 +18,10 @@ use tokio_util::sync::CancellationToken;
 
 use super::LocalEngineActor;
 use crate::{
-    ConductorClient, DelayedL1OriginSelectorProvider, DelegateDerivationActor, DerivationActor,
-    DerivationDelegateClient, DerivationError, EngineActor, EngineActorRequest, EngineConfig,
-    EngineProcessor, EngineRpcProcessor, L1OriginSelector, L1WatcherActor, NetworkActor,
-    NetworkBuilder, NetworkConfig, NodeActor, NodeMode, PayloadBuilder,
+    AlloyL1BlockFetcher, ConductorClient, DelayedL1OriginSelectorProvider, DelegateDerivationActor,
+    DerivationActor, DerivationDelegateClient, DerivationError, EngineActor, EngineActorRequest,
+    EngineConfig, EngineProcessor, EngineRpcProcessor, L1OriginSelector, L1WatcherActor,
+    NetworkActor, NetworkBuilder, NetworkConfig, NodeActor, NodeMode, PayloadBuilder,
     QueuedDerivationEngineClient, QueuedEngineDerivationClient, QueuedEngineRpcClient,
     QueuedL1WatcherDerivationClient, QueuedNetworkEngineClient, QueuedSequencerAdminAPIClient,
     QueuedSequencerEngineClient, RecoveryModeGuard, RpcActor, RpcContext, SequencerActor,
@@ -323,7 +323,7 @@ impl RollupNode {
         // Create the [`L1WatcherActor`]. Previously known as the DA watcher actor.
         let l1_watcher = L1WatcherActor::new(
             Arc::clone(&self.config),
-            self.l1_config.engine_provider.clone(),
+            AlloyL1BlockFetcher(self.l1_config.engine_provider.clone()),
             l1_query_rx,
             l1_head_updates_tx.clone(),
             QueuedL1WatcherDerivationClient { derivation_actor_request_tx },


### PR DESCRIPTION
## Summary

Replaces the broad `alloy_provider::Provider` bound on `L1WatcherActor` with a narrow `L1BlockFetcher` trait that exposes only the two methods the actor actually uses: `get_logs` for scanning `SystemConfig` update events and `get_block` for answering `L1WatcherQueries::L1State` RPC queries. An `AlloyL1BlockFetcher<P>` wrapper is provided so production call sites in `RollupNode` and `FollowNode` continue to work without modification. An `ActionL1BlockFetcher` backed by `SharedL1Chain` is added to the action harness so the actor can be instantiated in tests without a live Ethereum RPC endpoint.

Closes #1558