### PR TITLE
ktlo(ci): Disable Benchmark Workflow Temporarily

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -21,6 +21,7 @@ permissions:
 jobs:
   # Build base-reth-node and base-builder together, cached by source hash
   build-binaries:
+    if: false # Disabled: workflow consistently failing in CI — remove this line to re-enable
     name: Build binaries
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
## Summary

The benchmark CI workflow has been consistently failing and is blocking routine development. This disables the workflow by adding a single \`if: false\` condition to the entry job. To re-enable, simply remove that one line.