### PR TITLE
Fix proof journal to use proposer address instead of enclave signer address

### DIFF
--- a/crates/proof/challenge/src/driver.rs
+++ b/crates/proof/challenge/src/driver.rs
@@ -358,6 +358,7 @@ impl<L2: L2Provider, P: ZkProofProvider, T: TxManager> Driver<L2, P, T> {
             agreed_l2_output_root,
             claimed_l2_output_root,
             claimed_l2_block_number,
+            proposer: self.submitter.sender_address(),
         };
 
         let result = tee.provider.prove(request).await.map_err(|e| eyre::eyre!(e))?;

--- a/crates/proof/challenge/src/submitter.rs
+++ b/crates/proof/challenge/src/submitter.rs
@@ -21,6 +21,11 @@ impl<T: TxManager> ChallengeSubmitter<T> {
         Self { tx_manager }
     }
 
+    /// Returns the address that will submit transactions on-chain.
+    pub fn sender_address(&self) -> Address {
+        self.tx_manager.sender_address()
+    }
+
     /// Submits a `nullify()` transaction to the given dispute game contract.
     ///
     /// Returns the transaction hash on success, or an error if the transaction

--- a/crates/proof/host/src/kv/boot.rs
+++ b/crates/proof/host/src/kv/boot.rs
@@ -1,7 +1,7 @@
 use alloy_primitives::B256;
 use base_proof::{
     L1_CONFIG_KEY, L1_HEAD_KEY, L2_CHAIN_ID_KEY, L2_CLAIM_BLOCK_NUMBER_KEY, L2_CLAIM_KEY,
-    L2_OUTPUT_ROOT_KEY, L2_ROLLUP_CONFIG_KEY,
+    L2_OUTPUT_ROOT_KEY, L2_ROLLUP_CONFIG_KEY, PROPOSER_KEY,
 };
 use base_proof_preimage::PreimageKey;
 
@@ -39,6 +39,7 @@ impl KeyValueStore for BootKeyValueStore {
                 let serialized = serde_json::to_vec(&self.cfg.prover.l1_config).ok()?;
                 Some(serialized)
             }
+            PROPOSER_KEY => Some(self.cfg.request.proposer.to_vec()),
             _ => None,
         }
     }

--- a/crates/proof/primitives/src/proof.rs
+++ b/crates/proof/primitives/src/proof.rs
@@ -1,6 +1,6 @@
 use alloc::vec::Vec;
 
-use alloy_primitives::B256;
+use alloy_primitives::{Address, B256};
 use base_proof_preimage::PreimageKey;
 
 use crate::Proposal;
@@ -51,6 +51,12 @@ pub struct ProofRequest {
     pub claimed_l2_output_root: B256,
     /// L2 block number that the claimed output root commits to.
     pub claimed_l2_block_number: u64,
+    /// Address of the proposer that will submit the proof transaction on-chain.
+    ///
+    /// Included in the proof journal so on-chain verification can match it against
+    /// the actual `msg.sender` (gameCreator).
+    #[cfg_attr(feature = "serde", serde(default))]
+    pub proposer: Address,
 }
 
 /// A proof request bundled with the witness data needed to fulfill it.

--- a/crates/proof/proof/src/boot.rs
+++ b/crates/proof/proof/src/boot.rs
@@ -255,10 +255,7 @@ impl BootInfo {
         );
 
         // Load proposer address (optional — defaults to zero for backwards compatibility).
-        let proposer = match oracle
-            .get(PreimageKey::new_local(PROPOSER_KEY.to()))
-            .await
-        {
+        let proposer = match oracle.get(PreimageKey::new_local(PROPOSER_KEY.to())).await {
             Ok(bytes) if bytes.len() == 20 => Address::from_slice(&bytes),
             _ => Address::ZERO,
         };

--- a/crates/proof/proof/src/boot.rs
+++ b/crates/proof/proof/src/boot.rs
@@ -1,7 +1,7 @@
 //! This module contains the prologue phase of the client program, pulling in the boot information
 //! through the `PreimageOracle` ABI as local keys.
 
-use alloy_primitives::{B256, U256};
+use alloy_primitives::{Address, B256, U256};
 use base_consensus_genesis::{L1ChainConfig, RollupConfig};
 use base_consensus_registry::Registry;
 use base_proof_preimage::{PreimageKey, PreimageOracleClient};
@@ -57,6 +57,13 @@ pub const L2_ROLLUP_CONFIG_KEY: U256 = U256::from_be_slice(&[6]);
 /// the preimage oracle when no hardcoded configuration is available for the
 /// given chain ID. Oracle-loaded configs require additional validation.
 pub const L1_CONFIG_KEY: U256 = U256::from_be_slice(&[7]);
+
+/// The local key identifier for the proposer address.
+///
+/// This key retrieves the address of the proposer that will submit the proof
+/// transaction on-chain. The enclave includes this address in the proof journal
+/// so on-chain verification can match it against the actual `msg.sender`.
+pub const PROPOSER_KEY: U256 = U256::from_be_slice(&[8]);
 
 /// The boot information for the client program.
 ///
@@ -132,6 +139,15 @@ pub struct BootInfo {
     ///
     /// **Security**: Loaded from registry (secure) or oracle (requires validation).
     pub l1_config: L1ChainConfig,
+    /// The proposer address that will submit the proof transaction on-chain.
+    ///
+    /// Included in the proof journal so on-chain verification can match it against
+    /// the actual `msg.sender` (gameCreator). Defaults to `Address::ZERO` when not set.
+    ///
+    /// **Security**: User-submitted input; the on-chain contract validates that the
+    /// transaction sender matches this value.
+    #[serde(default)]
+    pub proposer: Address,
 }
 
 impl BootInfo {
@@ -238,6 +254,15 @@ impl BootInfo {
             "Successfully loaded boot information"
         );
 
+        // Load proposer address (optional — defaults to zero for backwards compatibility).
+        let proposer = match oracle
+            .get(PreimageKey::new_local(PROPOSER_KEY.to()))
+            .await
+        {
+            Ok(bytes) if bytes.len() == 20 => Address::from_slice(&bytes),
+            _ => Address::ZERO,
+        };
+
         Ok(Self {
             l1_head,
             agreed_l2_output_root: l2_output_root,
@@ -246,6 +271,7 @@ impl BootInfo {
             chain_id,
             rollup_config,
             l1_config,
+            proposer,
         })
     }
 }

--- a/crates/proof/proof/src/boot.rs
+++ b/crates/proof/proof/src/boot.rs
@@ -265,7 +265,14 @@ impl BootInfo {
                 );
                 Address::ZERO
             }
-            Err(_) => Address::ZERO,
+            Err(e) => {
+                debug!(
+                    target: "boot_loader",
+                    error = %e,
+                    "Proposer preimage not found, defaulting to Address::ZERO"
+                );
+                Address::ZERO
+            }
         };
 
         Ok(Self {

--- a/crates/proof/proof/src/boot.rs
+++ b/crates/proof/proof/src/boot.rs
@@ -257,7 +257,15 @@ impl BootInfo {
         // Load proposer address (optional — defaults to zero for backwards compatibility).
         let proposer = match oracle.get(PreimageKey::new_local(PROPOSER_KEY.to())).await {
             Ok(bytes) if bytes.len() == 20 => Address::from_slice(&bytes),
-            _ => Address::ZERO,
+            Ok(bytes) => {
+                warn!(
+                    target: "boot_loader",
+                    len = bytes.len(),
+                    "Proposer preimage has unexpected length, defaulting to Address::ZERO"
+                );
+                Address::ZERO
+            }
+            Err(_) => Address::ZERO,
         };
 
         Ok(Self {

--- a/crates/proof/proposer/src/driver/core.rs
+++ b/crates/proof/proposer/src/driver/core.rs
@@ -6,7 +6,7 @@
 
 use std::{sync::Arc, time::Duration};
 
-use alloy_primitives::{B256, U256};
+use alloy_primitives::{Address, B256, U256};
 use base_proof_contracts::{
     AggregateVerifierClient, AnchorStateRegistryClient, DisputeGameFactoryClient,
 };
@@ -40,6 +40,9 @@ pub struct DriverConfig {
     /// If true, use `safe_l2` (derived from L1 but L1 not yet finalized).
     /// If false (default), use `finalized_l2` (derived from finalized L1).
     pub allow_non_finalized: bool,
+    /// Address of the proposer that submits proof transactions on-chain.
+    /// Included in the proof journal so the enclave signs over the correct `msg.sender`.
+    pub proposer_address: Address,
 }
 
 impl Default for DriverConfig {
@@ -51,6 +54,7 @@ impl Default for DriverConfig {
             init_bond: U256::ZERO,
             game_type: 0,
             allow_non_finalized: false,
+            proposer_address: Address::ZERO,
         }
     }
 }
@@ -290,6 +294,7 @@ where
             agreed_l2_output_root,
             claimed_l2_output_root: claimed_output.output_root,
             claimed_l2_block_number: target_block,
+            proposer: self.config.proposer_address,
         };
 
         info!(

--- a/crates/proof/proposer/src/service.rs
+++ b/crates/proof/proposer/src/service.rs
@@ -208,6 +208,7 @@ pub async fn run(config: ProposerConfig) -> Result<()> {
         init_bond,
         game_type: config.game_type,
         allow_non_finalized: config.allow_non_finalized,
+        proposer_address: proposer_address.unwrap_or_default(),
     };
     let driver = Driver::new(
         driver_config,

--- a/crates/proof/tee/nitro/src/enclave/server.rs
+++ b/crates/proof/tee/nitro/src/enclave/server.rs
@@ -180,7 +180,7 @@ impl Server {
             let l1_origin_number = U256::from(l2_info.l1_origin.number);
 
             let journal = ProofJournal {
-                proposer: self.signer_key.address(),
+                proposer: boot_info.proposer,
                 l1_origin_hash,
                 prev_output_root,
                 starting_l2_block: l2_block_number
@@ -219,7 +219,7 @@ impl Server {
                 proposals[..proposals.len() - 1].iter().map(|p| p.output_root).collect();
 
             let journal = ProofJournal {
-                proposer: self.signer_key.address(),
+                proposer: boot_info.proposer,
                 l1_origin_hash: last.l1_origin_hash,
                 prev_output_root: agreed_l2_output_root,
                 starting_l2_block: first


### PR DESCRIPTION
The enclave was using its own signer key address as the `proposer` field in the `ProofJournal`. On-chain, [`AggregateVerifier`](https://github.com/base/contracts/blob/main/src/multiproof/AggregateVerifier.sol) recomputes the journal with `gameCreator()` (the actual transaction sender / KMS key), causing a hash mismatch that made `ecrecover` return a garbage address and every dispute game creation revert with `SignerNotRegistered`.

Fix: thread the proposer address from the proposer service through the existing preimage pipeline to the enclave, so the journal is signed with the correct address. No changes to the `ProverBackend` trait, transport layer, or vsock protocol — the address flows through `BootInfo` preimages.

Changes:
- Add `proposer: Address` to `ProofRequest` and `BootInfo`
- Serve it via `BootKeyValueStore` as preimage key 8
- Read it in enclave `Server::prove` from `boot_info.proposer`
- Set it from `tx_manager.sender_address()` in the proposer driver