### PR TITLE
Fix enclave to sample intermediate roots at the configured interval

### DIFF
--- a/crates/proof/challenge/src/driver.rs
+++ b/crates/proof/challenge/src/driver.rs
@@ -359,6 +359,7 @@ impl<L2: L2Provider, P: ZkProofProvider, T: TxManager> Driver<L2, P, T> {
             claimed_l2_output_root,
             claimed_l2_block_number,
             proposer: self.submitter.sender_address(),
+            intermediate_block_interval: candidate.intermediate_block_interval,
         };
 
         let result = tee.provider.prove(request).await.map_err(|e| eyre::eyre!(e))?;

--- a/crates/proof/host/src/kv/boot.rs
+++ b/crates/proof/host/src/kv/boot.rs
@@ -1,7 +1,8 @@
 use alloy_primitives::B256;
 use base_proof::{
-    L1_CONFIG_KEY, L1_HEAD_KEY, L2_CHAIN_ID_KEY, L2_CLAIM_BLOCK_NUMBER_KEY, L2_CLAIM_KEY,
-    L2_OUTPUT_ROOT_KEY, L2_ROLLUP_CONFIG_KEY, PROPOSER_KEY,
+    INTERMEDIATE_BLOCK_INTERVAL_KEY, L1_CONFIG_KEY, L1_HEAD_KEY, L2_CHAIN_ID_KEY,
+    L2_CLAIM_BLOCK_NUMBER_KEY, L2_CLAIM_KEY, L2_OUTPUT_ROOT_KEY, L2_ROLLUP_CONFIG_KEY,
+    PROPOSER_KEY,
 };
 use base_proof_preimage::PreimageKey;
 
@@ -40,6 +41,9 @@ impl KeyValueStore for BootKeyValueStore {
                 Some(serialized)
             }
             PROPOSER_KEY => Some(self.cfg.request.proposer.to_vec()),
+            INTERMEDIATE_BLOCK_INTERVAL_KEY => {
+                Some(self.cfg.request.intermediate_block_interval.to_be_bytes().to_vec())
+            }
             _ => None,
         }
     }

--- a/crates/proof/primitives/src/proof.rs
+++ b/crates/proof/primitives/src/proof.rs
@@ -57,6 +57,12 @@ pub struct ProofRequest {
     /// the actual `msg.sender` (gameCreator).
     #[cfg_attr(feature = "serde", serde(default))]
     pub proposer: Address,
+    /// Number of L2 blocks between intermediate output root checkpoints.
+    ///
+    /// Used by the enclave to sample the correct intermediate roots when
+    /// constructing the aggregate proof journal.
+    #[cfg_attr(feature = "serde", serde(default))]
+    pub intermediate_block_interval: u64,
 }
 
 /// A proof request bundled with the witness data needed to fulfill it.

--- a/crates/proof/proof/src/boot.rs
+++ b/crates/proof/proof/src/boot.rs
@@ -305,7 +305,14 @@ impl BootInfo {
                 );
                 0
             }
-            Err(_) => 0,
+            Err(e) => {
+                debug!(
+                    target: "boot_loader",
+                    error = %e,
+                    "Intermediate block interval preimage not found, defaulting to 0"
+                );
+                0
+            }
         };
 
         Ok(Self {

--- a/crates/proof/proof/src/boot.rs
+++ b/crates/proof/proof/src/boot.rs
@@ -65,6 +65,14 @@ pub const L1_CONFIG_KEY: U256 = U256::from_be_slice(&[7]);
 /// so on-chain verification can match it against the actual `msg.sender`.
 pub const PROPOSER_KEY: U256 = U256::from_be_slice(&[8]);
 
+/// The local key identifier for the intermediate block interval.
+///
+/// This key retrieves the number of L2 blocks between intermediate output root
+/// checkpoints. The enclave uses this to sample the correct intermediate roots
+/// when constructing the aggregate proof journal, matching the on-chain
+/// `AggregateVerifier`'s `INTERMEDIATE_BLOCK_INTERVAL`.
+pub const INTERMEDIATE_BLOCK_INTERVAL_KEY: U256 = U256::from_be_slice(&[9]);
+
 /// The boot information for the client program.
 ///
 /// [`BootInfo`] contains all the essential parameters needed to initialize the fault proof
@@ -148,6 +156,12 @@ pub struct BootInfo {
     /// transaction sender matches this value.
     #[serde(default)]
     pub proposer: Address,
+    /// The number of L2 blocks between intermediate output root checkpoints.
+    ///
+    /// Used by the enclave to sample the correct intermediate roots when
+    /// constructing the aggregate proof journal. Defaults to 0 when not set.
+    #[serde(default)]
+    pub intermediate_block_interval: u64,
 }
 
 impl BootInfo {
@@ -275,6 +289,25 @@ impl BootInfo {
             }
         };
 
+        // Load intermediate block interval (optional — defaults to 0 for backwards compatibility).
+        let intermediate_block_interval = match oracle
+            .get(PreimageKey::new_local(INTERMEDIATE_BLOCK_INTERVAL_KEY.to()))
+            .await
+        {
+            Ok(bytes) if bytes.len() == 8 => u64::from_be_bytes(
+                bytes.as_slice().try_into().map_err(OracleProviderError::SliceConversion)?,
+            ),
+            Ok(bytes) => {
+                warn!(
+                    target: "boot_loader",
+                    len = bytes.len(),
+                    "Intermediate block interval preimage has unexpected length, defaulting to 0"
+                );
+                0
+            }
+            Err(_) => 0,
+        };
+
         Ok(Self {
             l1_head,
             agreed_l2_output_root: l2_output_root,
@@ -284,6 +317,7 @@ impl BootInfo {
             rollup_config,
             l1_config,
             proposer,
+            intermediate_block_interval,
         })
     }
 }

--- a/crates/proof/proof/src/boot.rs
+++ b/crates/proof/proof/src/boot.rs
@@ -294,9 +294,9 @@ impl BootInfo {
             .get(PreimageKey::new_local(INTERMEDIATE_BLOCK_INTERVAL_KEY.to()))
             .await
         {
-            Ok(bytes) if bytes.len() == 8 => u64::from_be_bytes(
-                bytes.as_slice().try_into().map_err(OracleProviderError::SliceConversion)?,
-            ),
+            Ok(bytes) if bytes.len() == 8 => {
+                u64::from_be_bytes(bytes.as_slice().try_into().expect("length checked"))
+            }
             Ok(bytes) => {
                 warn!(
                     target: "boot_loader",

--- a/crates/proof/proposer/src/driver/core.rs
+++ b/crates/proof/proposer/src/driver/core.rs
@@ -295,6 +295,7 @@ where
             claimed_l2_output_root: claimed_output.output_root,
             claimed_l2_block_number: target_block,
             proposer: self.config.proposer_address,
+            intermediate_block_interval: self.config.intermediate_block_interval,
         };
 
         info!(

--- a/crates/proof/tee/nitro/src/enclave/server.rs
+++ b/crates/proof/tee/nitro/src/enclave/server.rs
@@ -215,8 +215,10 @@ impl Server {
             let first = &proposals[0];
             let last = proposals.last().unwrap();
 
+            let interval = boot_info.intermediate_block_interval.max(1) as usize;
+            let count = proposals.len() / interval;
             let intermediate_roots: Vec<B256> =
-                proposals[..proposals.len() - 1].iter().map(|p| p.output_root).collect();
+                (1..=count).map(|i| proposals[i * interval - 1].output_root).collect();
 
             let journal = ProofJournal {
                 proposer: boot_info.proposer,

--- a/crates/proof/tee/nitro/src/enclave/server.rs
+++ b/crates/proof/tee/nitro/src/enclave/server.rs
@@ -217,7 +217,7 @@ impl Server {
 
             let interval = boot_info.intermediate_block_interval;
             if interval == 0 {
-                return Err(ProposalError::EmptyProposals.into());
+                return Err(ProposalError::InvalidInterval.into());
             }
             let interval = interval as usize;
             let count = proposals.len() / interval;

--- a/crates/proof/tee/nitro/src/enclave/server.rs
+++ b/crates/proof/tee/nitro/src/enclave/server.rs
@@ -215,7 +215,11 @@ impl Server {
             let first = &proposals[0];
             let last = proposals.last().unwrap();
 
-            let interval = boot_info.intermediate_block_interval.max(1) as usize;
+            let interval = boot_info.intermediate_block_interval;
+            if interval == 0 {
+                return Err(ProposalError::EmptyProposals.into());
+            }
+            let interval = interval as usize;
             let count = proposals.len() / interval;
             let intermediate_roots: Vec<B256> =
                 (1..=count).map(|i| proposals[i * interval - 1].output_root).collect();

--- a/crates/proof/tee/nitro/src/error.rs
+++ b/crates/proof/tee/nitro/src/error.rs
@@ -97,6 +97,9 @@ pub enum ProposalError {
     /// No proposals provided for aggregation.
     #[error("no proposals provided for aggregation")]
     EmptyProposals,
+    /// Intermediate block interval must not be zero.
+    #[error("intermediate_block_interval must not be zero")]
+    InvalidInterval,
     /// Signature verification failed at the given index.
     #[error("invalid signature at proposal index {index}: {reason}")]
     InvalidSignature {


### PR DESCRIPTION
The enclave was including all per-block output roots (N-1) as intermediate roots in the aggregate proof journal, but the on-chain `AggregateVerifier` only includes roots sampled at every `INTERMEDIATE_BLOCK_INTERVAL`. For `block_interval=100` and `intermediate_block_interval=10`, the enclave signed over 99 roots while the contract verified against 10, causing a journal hash mismatch and `ecrecover` returning the wrong signer address.

Fix: thread `intermediate_block_interval` from the proposer through the preimage pipeline (the same pattern as [the proposer address fix](https://github.com/base/base/pull/1575)), and use it in the enclave to sample every Nth root — matching the proposer driver's `extract_intermediate_roots` logic exactly.

Changes:
- Add `intermediate_block_interval` to `ProofRequest` and `BootInfo`
- Serve it via `BootKeyValueStore` as preimage key 9
- Sample roots at the correct interval in enclave `Server::prove`
- Set the field in both proposer driver and challenge driver