### PR TITLE
chore: fix upgrade_from_chain_and_timestamp to include v1

### DIFF
--- a/crates/alloy/chains/Cargo.toml
+++ b/crates/alloy/chains/Cargo.toml
@@ -18,7 +18,6 @@ rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
 # alloy
-alloy-chains.workspace = true
 alloy-primitives.workspace = true
 alloy-hardforks.workspace = true
 
@@ -26,9 +25,11 @@ alloy-hardforks.workspace = true
 auto_impl.workspace = true
 serde = { workspace = true, optional = true }
 
+[dev-dependencies]
+alloy-chains.workspace = true
+
 [features]
 serde = [
-	"alloy-chains/serde",
 	"alloy-hardforks/serde",
 	"alloy-primitives/serde",
 	"dep:serde",

--- a/crates/alloy/chains/Cargo.toml
+++ b/crates/alloy/chains/Cargo.toml
@@ -29,8 +29,4 @@ serde = { workspace = true, optional = true }
 alloy-chains.workspace = true
 
 [features]
-serde = [
-	"alloy-hardforks/serde",
-	"alloy-primitives/serde",
-	"dep:serde",
-]
+serde = [ "alloy-hardforks/serde", "alloy-primitives/serde", "dep:serde" ]

--- a/crates/alloy/chains/src/hardfork.rs
+++ b/crates/alloy/chains/src/hardfork.rs
@@ -1,4 +1,3 @@
-use alloy_chains::Chain;
 use alloy_hardforks::{ForkCondition, hardfork};
 
 use crate::BaseChainConfig;
@@ -36,27 +35,6 @@ hardfork!(
 );
 
 impl BaseUpgrade {
-    /// Reverse lookup to find the hardfork given a chain ID and block timestamp.
-    /// Returns the active hardfork at the given timestamp for the specified Base chain.
-    ///
-    /// Note: standalone upgrades like [`BaseUpgrade::V1`] are not included here because
-    /// they do not participate in the sequential cascade and have no scheduled activation
-    /// timestamp on production chains. Use [`crate::BaseUpgrades::is_base_v1_active_at_timestamp`]
-    /// to check those independently.
-    pub fn from_chain_and_timestamp(chain: Chain, timestamp: u64) -> Option<Self> {
-        let cfg = BaseChainConfig::by_chain_id(chain.id())?;
-        Some(match timestamp {
-            _ if timestamp < cfg.canyon_timestamp => Self::Regolith,
-            _ if timestamp < cfg.ecotone_timestamp => Self::Canyon,
-            _ if timestamp < cfg.fjord_timestamp => Self::Ecotone,
-            _ if timestamp < cfg.granite_timestamp => Self::Fjord,
-            _ if timestamp < cfg.holocene_timestamp => Self::Granite,
-            _ if timestamp < cfg.isthmus_timestamp => Self::Holocene,
-            _ if timestamp < cfg.jovian_timestamp => Self::Isthmus,
-            _ => Self::Jovian,
-        })
-    }
-
     /// Returns the list of hardforks with their activation conditions for the given chain config.
     pub const fn forks_for(cfg: &BaseChainConfig) -> [(Self, ForkCondition); 10] {
         let v1 = match cfg.base_v1_timestamp {
@@ -105,6 +83,7 @@ impl BaseUpgrade {
 
 #[cfg(test)]
 mod tests {
+    use alloy_chains::Chain;
     use core::str::FromStr;
 
     use super::*;
@@ -139,6 +118,23 @@ mod tests {
     #[test]
     fn check_nonexistent_hardfork_from_str() {
         assert!(BaseUpgrade::from_str("not a hardfork").is_err());
+    }
+
+    /// Reverse lookup to find the upgrade given a chain ID and block timestamp.
+    /// Returns the active upgrade at the given timestamp for the specified Base chain.
+    fn upgrade_from_chain_and_timestamp(chain: Chain, timestamp: u64) -> Option<BaseUpgrade> {
+        let cfg = BaseChainConfig::by_chain_id(chain.id())?;
+        Some(match timestamp {
+            _ if timestamp < cfg.canyon_timestamp => BaseUpgrade::Regolith,
+            _ if timestamp < cfg.ecotone_timestamp => BaseUpgrade::Canyon,
+            _ if timestamp < cfg.fjord_timestamp => BaseUpgrade::Ecotone,
+            _ if timestamp < cfg.granite_timestamp => BaseUpgrade::Fjord,
+            _ if timestamp < cfg.holocene_timestamp => BaseUpgrade::Granite,
+            _ if timestamp < cfg.isthmus_timestamp => BaseUpgrade::Holocene,
+            _ if timestamp < cfg.jovian_timestamp => BaseUpgrade::Isthmus,
+            _ if cfg.base_v1_timestamp.is_some_and(|v1| timestamp >= v1) => BaseUpgrade::V1,
+            _ => BaseUpgrade::Jovian,
+        })
     }
 
     #[test]
@@ -178,12 +174,12 @@ mod tests {
 
         for (chain_id, timestamp, expected) in test_cases {
             assert_eq!(
-                BaseUpgrade::from_chain_and_timestamp(chain_id, timestamp),
+                upgrade_from_chain_and_timestamp(chain_id, timestamp),
                 Some(expected),
                 "chain {chain_id} at timestamp {timestamp}"
             );
         }
 
-        assert_eq!(BaseUpgrade::from_chain_and_timestamp(Chain::from_id(999999), 1000000), None);
+        assert_eq!(upgrade_from_chain_and_timestamp(Chain::from_id(999999), 1000000), None);
     }
 }

--- a/crates/alloy/chains/src/hardfork.rs
+++ b/crates/alloy/chains/src/hardfork.rs
@@ -83,8 +83,9 @@ impl BaseUpgrade {
 
 #[cfg(test)]
 mod tests {
-    use alloy_chains::Chain;
     use core::str::FromStr;
+
+    use alloy_chains::Chain;
 
     use super::*;
 

--- a/crates/consensus/genesis/Cargo.toml
+++ b/crates/consensus/genesis/Cargo.toml
@@ -59,6 +59,7 @@ std = [
 	"derive_more/std",
 	"serde?/std",
 	"thiserror/std",
+	"tracing/std",
 ]
 arbitrary = [
 	"alloy-chains/arbitrary",

--- a/crates/execution/chainspec/Cargo.toml
+++ b/crates/execution/chainspec/Cargo.toml
@@ -70,6 +70,7 @@ serde = [
 	"alloy-eips/serde",
 	"alloy-hardforks/serde",
 	"alloy-primitives/serde",
+	"base-alloy-chains/serde",
 	"base-alloy-consensus/serde",
 	"base-alloy-rpc-types/serde",
 	"base-execution-forks/serde",

--- a/docs/guides/UPGRADES.md
+++ b/docs/guides/UPGRADES.md
@@ -212,8 +212,7 @@ fn is_base_v1_active_at_timestamp(&self, timestamp: u64) -> bool {
 **Files:**
 - [`crates/alloy/chains/src/hardfork.rs`](../../crates/alloy/chains/src/hardfork.rs) (mainnet, sepolia, devnet constants)
 - [`crates/alloy/chains/src/lib.rs`](../../crates/alloy/chains/src/lib.rs)
-- [`crates/consensus/registry/src/test_utils/base_mainnet.rs`](https://github.com/base/base/blob/main/crates/consensus/registry/src/test_utils/base_mainnet.rs)
-- [`crates/consensus/registry/src/test_utils/base_sepolia.rs`](https://github.com/base/base/blob/main/crates/consensus/registry/src/test_utils/base_sepolia.rs)
+- [`crates/consensus/registry/src/test_utils/mod.rs`](https://github.com/base/base/blob/main/crates/consensus/registry/src/test_utils/mod.rs)
 
 Add named constants once an activation timestamp is confirmed:
 
@@ -245,7 +244,7 @@ Until an activation timestamp is confirmed, leave `base: None` and the chain arr
 
 ### 7. Update the default rollup config
 
-**File:** [`crates/consensus/registry/src/test_utils/base_sepolia.rs`](https://github.com/base/base/blob/main/crates/consensus/registry/src/test_utils/base_sepolia.rs)
+**File:** [`crates/consensus/registry/src/test_utils/mod.rs`](https://github.com/base/base/blob/main/crates/consensus/registry/src/test_utils/mod.rs)
 
 The `default_rollup_config()` function sets all upgrades active at genesis for dev use. Add the new upgrade:
 
@@ -387,7 +386,7 @@ forks.push((BaseUpgrade::V1.boxed(), self[BaseUpgrade::V1]));  // <-- add
 - [ ] `is_X_active` + `is_first_X_block` added to `RollupConfig`; `upgrade_activation` arm added; previous terminal upgrade cascades to new one (unless standalone)
 - [ ] `is_X_active_at_timestamp` added to `BaseUpgrades` trait
 - [ ] Timestamp constants added to `mainnet.rs`, `sepolia.rs`, `devnet_0_sepolia_dev_0.rs`; re-exported from `lib.rs`
-- [ ] Registry fixtures (`base_mainnet.rs`, `base_sepolia.rs`) updated
+- [ ] Registry fixtures (`test_utils/mod.rs`) updated
 - [ ] Default rollup config updated (`defaults.rs`)
 - [ ] Upgrade consistency tests pass
 


### PR DESCRIPTION
### Description
Add V1 support to this method and move it into the test mod as that's the only place it's used.