### PR TITLE
chore(execution): BasePrecompiles Rename

### DIFF
--- a/crates/alloy/evm/src/evm.rs
+++ b/crates/alloy/evm/src/evm.rs
@@ -3,7 +3,7 @@ use core::ops::{Deref, DerefMut};
 use alloy_evm::{Database, Evm, EvmEnv};
 use alloy_primitives::{Address, Bytes};
 use base_revm::{
-    OpContext, OpHaltReason, OpPrecompiles, OpSpecId, OpTransaction, OpTransactionError,
+    OpContext, OpHaltReason, BasePrecompiles, OpSpecId, OpTransaction, OpTransactionError,
 };
 use revm::{
     ExecuteEvm, InspectEvm, Inspector, SystemCallEvm,
@@ -19,7 +19,7 @@ use revm::{
 /// support. [`Inspector`] support is configurable at runtime because it's part of the underlying
 /// [`OpEvm`](base_revm::OpEvm) type.
 #[allow(missing_debug_implementations)] // missing revm::OpContext Debug impl
-pub struct OpEvm<DB: Database, I, P = OpPrecompiles> {
+pub struct OpEvm<DB: Database, I, P = BasePrecompiles> {
     pub(crate) inner:
         base_revm::OpEvm<OpContext<DB>, I, EthInstructions<EthInterpreter, OpContext<DB>>, P>,
     pub(crate) inspect: bool,

--- a/crates/alloy/evm/src/evm.rs
+++ b/crates/alloy/evm/src/evm.rs
@@ -3,7 +3,7 @@ use core::ops::{Deref, DerefMut};
 use alloy_evm::{Database, Evm, EvmEnv};
 use alloy_primitives::{Address, Bytes};
 use base_revm::{
-    OpContext, OpHaltReason, BasePrecompiles, OpSpecId, OpTransaction, OpTransactionError,
+    BasePrecompiles, OpContext, OpHaltReason, OpSpecId, OpTransaction, OpTransactionError,
 };
 use revm::{
     ExecuteEvm, InspectEvm, Inspector, SystemCallEvm,

--- a/crates/alloy/evm/src/factory.rs
+++ b/crates/alloy/evm/src/factory.rs
@@ -1,6 +1,6 @@
 use alloy_evm::{Database, EvmEnv, EvmFactory, precompiles::PrecompilesMap};
 use base_revm::{
-    DefaultOp, OpBuilder, OpContext, OpHaltReason, BasePrecompiles, OpSpecId, OpTransaction,
+    BasePrecompiles, DefaultOp, OpBuilder, OpContext, OpHaltReason, OpSpecId, OpTransaction,
     OpTransactionError,
 };
 use revm::{

--- a/crates/alloy/evm/src/factory.rs
+++ b/crates/alloy/evm/src/factory.rs
@@ -1,6 +1,6 @@
 use alloy_evm::{Database, EvmEnv, EvmFactory, precompiles::PrecompilesMap};
 use base_revm::{
-    DefaultOp, OpBuilder, OpContext, OpHaltReason, OpPrecompiles, OpSpecId, OpTransaction,
+    DefaultOp, OpBuilder, OpContext, OpHaltReason, BasePrecompiles, OpSpecId, OpTransaction,
     OpTransactionError,
 };
 use revm::{
@@ -41,7 +41,7 @@ impl EvmFactory for OpEvmFactory {
                 .with_cfg(input.cfg_env)
                 .build_op_with_inspector(NoOpInspector {})
                 .with_precompiles(PrecompilesMap::from_static(
-                    OpPrecompiles::new_with_spec(spec_id).precompiles(),
+                    BasePrecompiles::new_with_spec(spec_id).precompiles(),
                 )),
             inspect: false,
         }
@@ -61,7 +61,7 @@ impl EvmFactory for OpEvmFactory {
                 .with_cfg(input.cfg_env)
                 .build_op_with_inspector(inspector)
                 .with_precompiles(PrecompilesMap::from_static(
-                    OpPrecompiles::new_with_spec(spec_id).precompiles(),
+                    BasePrecompiles::new_with_spec(spec_id).precompiles(),
                 )),
             inspect: true,
         }

--- a/crates/execution/node/tests/it/builder.rs
+++ b/crates/execution/node/tests/it/builder.rs
@@ -9,7 +9,7 @@ use base_execution_evm::{OpBlockExecutorFactory, OpEvm, OpEvmFactory, OpRethRece
 use base_execution_primitives::OpPrimitives;
 use base_node_core::{OpEvmConfig, OpExecutorBuilder, OpNode, args::RollupArgs};
 use base_revm::{
-    OpContext, OpHaltReason, OpPrecompiles, OpSpecId, OpTransaction, OpTransactionError,
+    OpContext, OpHaltReason, BasePrecompiles, OpSpecId, OpTransaction, OpTransactionError,
 };
 use reth_db::test_utils::create_test_rw_db;
 use reth_evm::{Database, Evm, EvmEnv, EvmFactory, precompiles::PrecompilesMap};
@@ -69,7 +69,7 @@ fn test_setup_custom_precompiles() {
             static INSTANCE: OnceLock<Precompiles> = OnceLock::new();
 
             PrecompilesMap::from_static(INSTANCE.get_or_init(|| {
-                let mut precompiles = OpPrecompiles::new_with_spec(spec_id).precompiles().clone();
+                let mut precompiles = BasePrecompiles::new_with_spec(spec_id).precompiles().clone();
                 // Custom precompile.
                 let precompile = Precompile::new(
                     PrecompileId::custom("custom"),

--- a/crates/execution/node/tests/it/builder.rs
+++ b/crates/execution/node/tests/it/builder.rs
@@ -9,7 +9,7 @@ use base_execution_evm::{OpBlockExecutorFactory, OpEvm, OpEvmFactory, OpRethRece
 use base_execution_primitives::OpPrimitives;
 use base_node_core::{OpEvmConfig, OpExecutorBuilder, OpNode, args::RollupArgs};
 use base_revm::{
-    OpContext, OpHaltReason, BasePrecompiles, OpSpecId, OpTransaction, OpTransactionError,
+    BasePrecompiles, OpContext, OpHaltReason, OpSpecId, OpTransaction, OpTransactionError,
 };
 use reth_db::test_utils::create_test_rw_db;
 use reth_evm::{Database, Evm, EvmEnv, EvmFactory, precompiles::PrecompilesMap};

--- a/crates/execution/revm/README.md
+++ b/crates/execution/revm/README.md
@@ -6,7 +6,7 @@ Base-specific constants, types, and helpers for the revm EVM implementation.
 
 Integrates revm with Base, providing Base-specific EVM execution infrastructure. Includes
 `OpEvm` and associated builder/handler types, `OpTransaction` and `OpTransactionBuilder` for
-transaction handling, `OpPrecompiles` with hardfork-accelerated precompile sets (BLS, BN254,
+transaction handling, `BasePrecompiles` with hardfork-accelerated precompile sets (BLS, BN254,
 Fjord, Granite, Isthmus, Jovian), `L1BlockInfo` for fee calculation, and `OpSpecId` variants
 mapping each hardfork to a revm spec.
 
@@ -20,10 +20,10 @@ base-revm = { workspace = true }
 ```
 
 ```rust,ignore
-use base_revm::{OpBuilder, OpPrecompiles};
+use base_revm::{OpBuilder, BasePrecompiles};
 
 let evm = OpBuilder::new(db)
-    .with_precompiles(OpPrecompiles::jovian())
+    .with_precompiles(BasePrecompiles::jovian())
     .build();
 ```
 

--- a/crates/execution/revm/src/api/builder.rs
+++ b/crates/execution/revm/src/api/builder.rs
@@ -8,11 +8,11 @@ use revm::{
     state::EvmState,
 };
 
-use crate::{L1BlockInfo, OpSpecId, evm::OpEvm, precompiles::OpPrecompiles, transaction::OpTxTr};
+use crate::{L1BlockInfo, OpSpecId, evm::OpEvm, precompiles::BasePrecompiles, transaction::OpTxTr};
 
 /// Type alias for default `OpEvm`
 pub type DefaultOpEvm<CTX, INSP = ()> =
-    OpEvm<CTX, INSP, EthInstructions<EthInterpreter, CTX>, OpPrecompiles>;
+    OpEvm<CTX, INSP, EthInstructions<EthInterpreter, CTX>, BasePrecompiles>;
 
 /// Trait that allows for Base `OpEvm` to be built.
 pub trait OpBuilder: Sized {

--- a/crates/execution/revm/src/evm.rs
+++ b/crates/execution/revm/src/evm.rs
@@ -12,7 +12,7 @@ use revm::{
     interpreter::{InterpreterResult, interpreter::EthInterpreter},
 };
 
-use crate::{OpSpecId, precompiles::OpPrecompiles};
+use crate::{OpSpecId, precompiles::BasePrecompiles};
 
 /// Base EVM extends the [`Evm`] type with Base-specific types and logic.
 #[derive(Debug, Clone)]
@@ -20,7 +20,7 @@ pub struct OpEvm<
     CTX,
     INSP,
     I = EthInstructions<EthInterpreter, CTX>,
-    P = OpPrecompiles,
+    P = BasePrecompiles,
     F = EthFrame<EthInterpreter>,
 >(
     /// Inner EVM type.
@@ -28,7 +28,7 @@ pub struct OpEvm<
 );
 
 impl<CTX: ContextTr<Cfg: Cfg<Spec: Into<OpSpecId> + Clone>>, INSP>
-    OpEvm<CTX, INSP, EthInstructions<EthInterpreter, CTX>, OpPrecompiles>
+    OpEvm<CTX, INSP, EthInstructions<EthInterpreter, CTX>, BasePrecompiles>
 {
     /// Create a new Base EVM.
     pub fn new(ctx: CTX, inspector: INSP) -> Self {
@@ -37,7 +37,7 @@ impl<CTX: ContextTr<Cfg: Cfg<Spec: Into<OpSpecId> + Clone>>, INSP>
             ctx,
             inspector,
             instruction: EthInstructions::new_mainnet_with_spec(spec.into()),
-            precompiles: OpPrecompiles::new_with_spec(spec),
+            precompiles: BasePrecompiles::new_with_spec(spec),
             frame_stack: FrameStack::new_prealloc(8),
         })
     }

--- a/crates/execution/revm/src/lib.rs
+++ b/crates/execution/revm/src/lib.rs
@@ -21,9 +21,7 @@ mod l1block;
 pub use l1block::L1BlockInfo;
 
 mod precompiles;
-pub use precompiles::{
-    OpPrecompiles, base_v1, bls12_381, bn254_pair, fjord, granite, isthmus, jovian,
-};
+pub use precompiles::{BasePrecompiles, bls12_381, bn254_pair};
 
 mod result;
 pub use result::OpHaltReason;

--- a/crates/execution/revm/src/precompiles.rs
+++ b/crates/execution/revm/src/precompiles.rs
@@ -17,14 +17,14 @@ use crate::OpSpecId;
 
 /// Base precompile provider
 #[derive(Debug, Clone)]
-pub struct OpPrecompiles {
+pub struct BasePrecompiles {
     /// Inner precompile provider is same as Ethereums.
     inner: EthPrecompiles,
     /// Spec id of the precompile provider.
     spec: OpSpecId,
 }
 
-impl OpPrecompiles {
+impl BasePrecompiles {
     /// Create a new precompile provider with the given `OpSpec`.
     #[inline]
     pub fn new_with_spec(spec: OpSpecId) -> Self {
@@ -33,11 +33,11 @@ impl OpPrecompiles {
             | OpSpecId::REGOLITH
             | OpSpecId::CANYON
             | OpSpecId::ECOTONE) => Precompiles::new(spec.into_eth_spec().into()),
-            OpSpecId::FJORD => fjord(),
-            OpSpecId::GRANITE | OpSpecId::HOLOCENE => granite(),
-            OpSpecId::ISTHMUS => isthmus(),
-            OpSpecId::JOVIAN => jovian(),
-            OpSpecId::BASE_V1 => base_v1(),
+            OpSpecId::FJORD => Self::fjord(),
+            OpSpecId::GRANITE | OpSpecId::HOLOCENE => Self::granite(),
+            OpSpecId::ISTHMUS => Self::isthmus(),
+            OpSpecId::JOVIAN => Self::jovian(),
+            OpSpecId::BASE_V1 => Self::base_v1(),
         };
 
         Self { inner: EthPrecompiles { precompiles, spec: SpecId::default() }, spec }
@@ -48,89 +48,89 @@ impl OpPrecompiles {
     pub const fn precompiles(&self) -> &'static Precompiles {
         self.inner.precompiles
     }
+
+    /// Returns precompiles for Fjord spec.
+    pub fn fjord() -> &'static Precompiles {
+        static INSTANCE: OnceLock<Precompiles> = OnceLock::new();
+        INSTANCE.get_or_init(|| {
+            let mut precompiles = Precompiles::cancun().clone();
+            // RIP-7212: secp256r1 P256verify
+            precompiles.extend([secp256r1::P256VERIFY]);
+            precompiles
+        })
+    }
+
+    /// Returns precompiles for Granite spec.
+    pub fn granite() -> &'static Precompiles {
+        static INSTANCE: OnceLock<Precompiles> = OnceLock::new();
+        INSTANCE.get_or_init(|| {
+            let mut precompiles = Self::fjord().clone();
+            // Restrict bn254Pairing input size
+            precompiles.extend([bn254_pair::GRANITE]);
+            precompiles
+        })
+    }
+
+    /// Returns precompiles for Isthmus spec.
+    pub fn isthmus() -> &'static Precompiles {
+        static INSTANCE: OnceLock<Precompiles> = OnceLock::new();
+        INSTANCE.get_or_init(|| {
+            let mut precompiles = Self::granite().clone();
+            // Prague bls12 precompiles
+            precompiles.extend(precompile::bls12_381::precompiles());
+            // Isthmus bls12 precompile modifications
+            precompiles.extend([
+                bls12_381::ISTHMUS_G1_MSM,
+                bls12_381::ISTHMUS_G2_MSM,
+                bls12_381::ISTHMUS_PAIRING,
+            ]);
+            precompiles
+        })
+    }
+
+    /// Returns precompiles for Jovian spec.
+    pub fn jovian() -> &'static Precompiles {
+        static INSTANCE: OnceLock<Precompiles> = OnceLock::new();
+        INSTANCE.get_or_init(|| {
+            let mut precompiles = Self::isthmus().clone();
+
+            let mut to_remove = Precompiles::default();
+            to_remove.extend([
+                bn254::pair::ISTANBUL,
+                bls12_381::ISTHMUS_G1_MSM,
+                bls12_381::ISTHMUS_G2_MSM,
+                bls12_381::ISTHMUS_PAIRING,
+            ]);
+
+            // Replace the 4 variable-input precompiles with Jovian versions (reduced limits)
+            precompiles.difference(&to_remove);
+
+            precompiles.extend([
+                bn254_pair::JOVIAN,
+                bls12_381::JOVIAN_G1_MSM,
+                bls12_381::JOVIAN_G2_MSM,
+                bls12_381::JOVIAN_PAIRING,
+            ]);
+
+            precompiles
+        })
+    }
+
+    /// Returns precompiles for the Base V1 spec.
+    pub fn base_v1() -> &'static Precompiles {
+        static INSTANCE: OnceLock<Precompiles> = OnceLock::new();
+        INSTANCE.get_or_init(|| {
+            let mut precompiles = Self::jovian().clone();
+
+            // Base V1 adopts Osaka pricing and bounds for MODEXP and P256VERIFY.
+            precompiles.extend([modexp::OSAKA, secp256r1::P256VERIFY_OSAKA]);
+
+            precompiles
+        })
+    }
 }
 
-/// Returns precompiles for Fjord spec.
-pub fn fjord() -> &'static Precompiles {
-    static INSTANCE: OnceLock<Precompiles> = OnceLock::new();
-    INSTANCE.get_or_init(|| {
-        let mut precompiles = Precompiles::cancun().clone();
-        // RIP-7212: secp256r1 P256verify
-        precompiles.extend([secp256r1::P256VERIFY]);
-        precompiles
-    })
-}
-
-/// Returns precompiles for Granite spec.
-pub fn granite() -> &'static Precompiles {
-    static INSTANCE: OnceLock<Precompiles> = OnceLock::new();
-    INSTANCE.get_or_init(|| {
-        let mut precompiles = fjord().clone();
-        // Restrict bn254Pairing input size
-        precompiles.extend([bn254_pair::GRANITE]);
-        precompiles
-    })
-}
-
-/// Returns precompiles for isthmus spec.
-pub fn isthmus() -> &'static Precompiles {
-    static INSTANCE: OnceLock<Precompiles> = OnceLock::new();
-    INSTANCE.get_or_init(|| {
-        let mut precompiles = granite().clone();
-        // Prague bls12 precompiles
-        precompiles.extend(precompile::bls12_381::precompiles());
-        // Isthmus bls12 precompile modifications
-        precompiles.extend([
-            bls12_381::ISTHMUS_G1_MSM,
-            bls12_381::ISTHMUS_G2_MSM,
-            bls12_381::ISTHMUS_PAIRING,
-        ]);
-        precompiles
-    })
-}
-
-/// Returns precompiles for jovian spec.
-pub fn jovian() -> &'static Precompiles {
-    static INSTANCE: OnceLock<Precompiles> = OnceLock::new();
-    INSTANCE.get_or_init(|| {
-        let mut precompiles = isthmus().clone();
-
-        let mut to_remove = Precompiles::default();
-        to_remove.extend([
-            bn254::pair::ISTANBUL,
-            bls12_381::ISTHMUS_G1_MSM,
-            bls12_381::ISTHMUS_G2_MSM,
-            bls12_381::ISTHMUS_PAIRING,
-        ]);
-
-        // Replace the 4 variable-input precompiles with Jovian versions (reduced limits)
-        precompiles.difference(&to_remove);
-
-        precompiles.extend([
-            bn254_pair::JOVIAN,
-            bls12_381::JOVIAN_G1_MSM,
-            bls12_381::JOVIAN_G2_MSM,
-            bls12_381::JOVIAN_PAIRING,
-        ]);
-
-        precompiles
-    })
-}
-
-/// Returns precompiles for the Base V1 spec.
-pub fn base_v1() -> &'static Precompiles {
-    static INSTANCE: OnceLock<Precompiles> = OnceLock::new();
-    INSTANCE.get_or_init(|| {
-        let mut precompiles = jovian().clone();
-
-        // Base V1 adopts Osaka pricing and bounds for MODEXP and P256VERIFY.
-        precompiles.extend([modexp::OSAKA, secp256r1::P256VERIFY_OSAKA]);
-
-        precompiles
-    })
-}
-
-impl<CTX> PrecompileProvider<CTX> for OpPrecompiles
+impl<CTX> PrecompileProvider<CTX> for BasePrecompiles
 where
     CTX: ContextTr<Cfg: Cfg<Spec = OpSpecId>>,
 {
@@ -165,7 +165,7 @@ where
     }
 }
 
-impl Default for OpPrecompiles {
+impl Default for BasePrecompiles {
     fn default() -> Self {
         Self::new_with_spec(OpSpecId::JOVIAN)
     }
@@ -360,7 +360,7 @@ mod tests {
     }
 
     fn assert_jovian_input_limits(spec: OpSpecId) {
-        let precompiles = OpPrecompiles::new_with_spec(spec);
+        let precompiles = BasePrecompiles::new_with_spec(spec);
         let bn254_pair_precompile = precompiles.precompiles().get(&bn254::pair::ADDRESS).unwrap();
 
         let mut bad_input_len = bn254_pair::JOVIAN_MAX_INPUT_SIZE + 1;
@@ -480,8 +480,8 @@ mod tests {
 
     #[test]
     fn test_get_base_v1_precompile_with_osaka_rules() {
-        let jovian_precompiles = OpPrecompiles::new_with_spec(OpSpecId::JOVIAN);
-        let base_v1_precompiles = OpPrecompiles::new_with_spec(OpSpecId::BASE_V1);
+        let jovian_precompiles = BasePrecompiles::new_with_spec(OpSpecId::JOVIAN);
+        let base_v1_precompiles = BasePrecompiles::new_with_spec(OpSpecId::BASE_V1);
 
         let jovian_p256 =
             jovian_precompiles.precompiles().get(secp256r1::P256VERIFY.address()).unwrap();
@@ -509,14 +509,14 @@ mod tests {
     #[test]
     fn test_cancun_precompiles_in_fjord() {
         // additional to cancun, fjord has p256verify
-        assert_eq!(fjord().difference(Precompiles::cancun()).len(), 1)
+        assert_eq!(BasePrecompiles::fjord().difference(Precompiles::cancun()).len(), 1)
     }
 
     #[test]
     fn test_cancun_precompiles_in_granite() {
         // granite has p256verify (fjord)
         // granite has modification of cancun's bn254 pair (doesn't count as new precompile)
-        assert_eq!(granite().difference(Precompiles::cancun()).len(), 1)
+        assert_eq!(BasePrecompiles::granite().difference(Precompiles::cancun()).len(), 1)
     }
 
     #[test]
@@ -524,7 +524,7 @@ mod tests {
         let new_prague_precompiles = Precompiles::prague().difference(Precompiles::cancun());
 
         // isthmus contains all precompiles that were new in prague, without modifications
-        assert!(new_prague_precompiles.difference(isthmus()).is_empty())
+        assert!(new_prague_precompiles.difference(BasePrecompiles::isthmus()).is_empty())
     }
 
     #[test]
@@ -532,22 +532,22 @@ mod tests {
         let new_prague_precompiles = Precompiles::prague().difference(Precompiles::cancun());
 
         // jovian contains all precompiles that were new in prague, without modifications
-        assert!(new_prague_precompiles.difference(jovian()).is_empty())
+        assert!(new_prague_precompiles.difference(BasePrecompiles::jovian()).is_empty())
     }
 
     /// All the addresses of the precompiles in isthmus should be in jovian
     #[test]
     fn test_isthmus_precompiles_in_jovian() {
-        let new_isthmus_precompiles = isthmus().difference(Precompiles::cancun());
+        let new_isthmus_precompiles = BasePrecompiles::isthmus().difference(Precompiles::cancun());
 
         // jovian contains all precompiles that were new in isthmus, without modifications
-        assert!(new_isthmus_precompiles.difference(jovian()).is_empty())
+        assert!(new_isthmus_precompiles.difference(BasePrecompiles::jovian()).is_empty())
     }
 
     #[test]
     fn test_default_precompiles_matches_jovian() {
-        let jovian = OpPrecompiles::new_with_spec(OpSpecId::JOVIAN).inner.precompiles;
-        let default = OpPrecompiles::default().inner.precompiles;
+        let jovian = BasePrecompiles::new_with_spec(OpSpecId::JOVIAN).inner.precompiles;
+        let default = BasePrecompiles::default().inner.precompiles;
         assert_eq!(jovian.len(), default.len());
 
         let intersection = default.intersection(jovian);

--- a/crates/proof/fpvm-precompiles/src/precompiles/provider.rs
+++ b/crates/proof/fpvm-precompiles/src/precompiles/provider.rs
@@ -4,7 +4,7 @@ use alloc::{boxed::Box, string::String, vec, vec::Vec};
 
 use alloy_primitives::{Address, Bytes};
 use base_proof_preimage::{HintWriterClient, PreimageOracleClient};
-use base_revm::{OpSpecId, fjord, granite, isthmus, jovian};
+use base_revm::{BasePrecompiles, OpSpecId};
 use revm::{
     context::{Cfg, ContextTr, LocalContextTr},
     handler::{EthPrecompiles, PrecompileProvider},
@@ -43,10 +43,10 @@ where
             | OpSpecId::REGOLITH
             | OpSpecId::CANYON
             | OpSpecId::ECOTONE) => Precompiles::new(spec.into_eth_spec().into()),
-            OpSpecId::FJORD => fjord(),
-            OpSpecId::GRANITE | OpSpecId::HOLOCENE => granite(),
-            OpSpecId::ISTHMUS => isthmus(),
-            OpSpecId::JOVIAN | OpSpecId::BASE_V1 => jovian(),
+            OpSpecId::FJORD => BasePrecompiles::fjord(),
+            OpSpecId::GRANITE | OpSpecId::HOLOCENE => BasePrecompiles::granite(),
+            OpSpecId::ISTHMUS => BasePrecompiles::isthmus(),
+            OpSpecId::JOVIAN | OpSpecId::BASE_V1 => BasePrecompiles::jovian(),
         };
 
         let accelerated_precompiles = match spec {

--- a/crates/proof/fpvm-precompiles/src/precompiles/provider.rs
+++ b/crates/proof/fpvm-precompiles/src/precompiles/provider.rs
@@ -36,7 +36,7 @@ where
     O: PreimageOracleClient + Clone + Send + Sync + 'static,
 {
     #[cfg(test)]
-    fn precompiles(&self) -> &'static Precompiles {
+    const fn precompiles(&self) -> &'static Precompiles {
         self.inner.precompiles
     }
 
@@ -304,10 +304,8 @@ mod tests {
     use super::*;
 
     fn make_hw_or() -> (HintWriter<NativeChannel>, OracleReader<NativeChannel>) {
-        let (hint_chan, preimage_chan) = (
-            BidirectionalChannel::new().unwrap(),
-            BidirectionalChannel::new().unwrap(),
-        );
+        let (hint_chan, preimage_chan) =
+            (BidirectionalChannel::new().unwrap(), BidirectionalChannel::new().unwrap());
         (HintWriter::new(hint_chan.client), OracleReader::new(preimage_chan.client))
     }
 

--- a/crates/proof/fpvm-precompiles/src/precompiles/provider.rs
+++ b/crates/proof/fpvm-precompiles/src/precompiles/provider.rs
@@ -35,6 +35,11 @@ where
     H: HintWriterClient + Clone + Send + Sync + 'static,
     O: PreimageOracleClient + Clone + Send + Sync + 'static,
 {
+    #[cfg(test)]
+    fn precompiles(&self) -> &'static Precompiles {
+        self.inner.precompiles
+    }
+
     /// Create a new precompile provider with the given [`OpSpecId`].
     #[inline]
     pub fn new_with_spec(spec: OpSpecId, hint_writer: H, oracle_reader: O) -> Self {
@@ -46,7 +51,8 @@ where
             OpSpecId::FJORD => BasePrecompiles::fjord(),
             OpSpecId::GRANITE | OpSpecId::HOLOCENE => BasePrecompiles::granite(),
             OpSpecId::ISTHMUS => BasePrecompiles::isthmus(),
-            OpSpecId::JOVIAN | OpSpecId::BASE_V1 => BasePrecompiles::jovian(),
+            OpSpecId::JOVIAN => BasePrecompiles::jovian(),
+            OpSpecId::BASE_V1 => BasePrecompiles::base_v1(),
         };
 
         let accelerated_precompiles = match spec {
@@ -287,4 +293,69 @@ where
     ));
 
     base
+}
+
+#[cfg(test)]
+mod tests {
+    use base_proof_preimage::{BidirectionalChannel, HintWriter, NativeChannel, OracleReader};
+    use base_revm::OpSpecId;
+    use revm::precompile::modexp;
+
+    use super::*;
+
+    fn make_hw_or() -> (HintWriter<NativeChannel>, OracleReader<NativeChannel>) {
+        let (hint_chan, preimage_chan) = (
+            BidirectionalChannel::new().unwrap(),
+            BidirectionalChannel::new().unwrap(),
+        );
+        (HintWriter::new(hint_chan.client), OracleReader::new(preimage_chan.client))
+    }
+
+    /// Builds a MODEXP input whose `base_len` exceeds the EIP-7823 limit.
+    fn oversized_modexp_input() -> Vec<u8> {
+        // EIP-7823 caps each of base_len/exp_len/mod_len at 1024 bytes.
+        let over = revm::primitives::eip7823::INPUT_SIZE_LIMIT + 1;
+        let encode = |len: usize| -> [u8; 32] {
+            let mut b = [0u8; 32];
+            b[24..].copy_from_slice(&(len as u64).to_be_bytes());
+            b
+        };
+        let mut input = Vec::with_capacity(96);
+        input.extend_from_slice(&encode(over));
+        input.extend_from_slice(&encode(0)); // exp_len = 0
+        input.extend_from_slice(&encode(1)); // mod_len = 1
+        input
+    }
+
+    #[test]
+    fn test_jovian_and_base_v1_use_different_precompile_sets() {
+        let (hw, or_) = make_hw_or();
+        let jovian = OpFpvmPrecompiles::new_with_spec(OpSpecId::JOVIAN, hw.clone(), or_.clone());
+        let base_v1 = OpFpvmPrecompiles::new_with_spec(OpSpecId::BASE_V1, hw, or_);
+
+        assert!(
+            !core::ptr::eq(jovian.precompiles(), base_v1.precompiles()),
+            "JOVIAN and BASE_V1 must resolve to different static precompile sets",
+        );
+    }
+
+    #[test]
+    fn test_base_v1_modexp_enforces_eip7823_size_limit() {
+        let (hw, or_) = make_hw_or();
+        let jovian = OpFpvmPrecompiles::new_with_spec(OpSpecId::JOVIAN, hw.clone(), or_.clone());
+        let base_v1 = OpFpvmPrecompiles::new_with_spec(OpSpecId::BASE_V1, hw, or_);
+
+        let modexp_berlin = modexp::BERLIN;
+        let addr = modexp_berlin.address();
+        let input = oversized_modexp_input();
+
+        assert!(
+            jovian.precompiles().get(addr).unwrap().execute(&input, u64::MAX).is_ok(),
+            "JOVIAN MODEXP must accept oversized input (Berlin pricing, no EIP-7823 limit)",
+        );
+        assert!(
+            base_v1.precompiles().get(addr).unwrap().execute(&input, u64::MAX).is_err(),
+            "BASE_V1 MODEXP must reject oversized input (Osaka pricing, EIP-7823 limit)",
+        );
+    }
 }

--- a/docs/guides/UPGRADES.md
+++ b/docs/guides/UPGRADES.md
@@ -12,7 +12,7 @@ Upgrade activation flows through three layers:
 
 1. **Config layer** — `HardForkConfig` stores an optional activation timestamp per upgrade. `RollupConfig` embeds it and exposes `is_X_active(timestamp)` helpers.
 2. **Trait layer** — `BaseUpgrade` (enum) and `BaseUpgrades` (trait) provide typed, generic activation checks used by both the consensus and execution layers.
-3. **Execution layer** — `OpSpecId` maps the active upgrade to an EVM spec. `spec_by_timestamp_after_bedrock` and `RollupConfig::spec_id` resolve which spec to use. `OpPrecompiles` routes to the correct precompile set.
+3. **Execution layer** — `OpSpecId` maps the active upgrade to an EVM spec. `spec_by_timestamp_after_bedrock` and `RollupConfig::spec_id` resolve which spec to use. `BasePrecompiles` routes to the correct precompile set.
 
 ---
 
@@ -316,17 +316,15 @@ OpSpecId::BASE_V1 => name::BASE_V1,
 
 **File:** [`crates/execution/revm/src/precompiles.rs`](https://github.com/base/base/blob/main/crates/execution/revm/src/precompiles.rs)
 
-If the upgrade introduces new precompiles, create a new `base_v1()` function. If it reuses the previous set, extend the existing arm:
+If the upgrade introduces new precompiles, add a new `pub fn base_v1()` method on `BasePrecompiles`. If it reuses the previous set, extend the existing arm in `new_with_spec`:
 
 ```rust
 // Reuse previous precompile set
-OpSpecId::JOVIAN | OpSpecId::BASE_V1 => jovian(),
+OpSpecId::JOVIAN | OpSpecId::BASE_V1 => Self::jovian(),
 
 // Or add a new set
-OpSpecId::BASE_V1 => base_v1(),
+OpSpecId::BASE_V1 => Self::base_v1(),
 ```
-
-Export any new precompile module from `lib.rs`.
 
 ---
 


### PR DESCRIPTION
## Summary

Renames `OpPrecompiles` to `BasePrecompiles` across the codebase to better reflect that this type is Base-specific rather than OP Stack generic. The standalone precompile set functions (`fjord`, `granite`, `isthmus`, `jovian`, `base_v1`) are moved inside `impl BasePrecompiles` as static methods, removing them from the public API surface. The `lib.rs` re-export is simplified to a single line. All call sites in `base-revm`, `base-alloy-evm`, `fpvm-precompiles`, and the node integration tests are updated accordingly.