### PR TITLE
fix(consensus): Continue Past Malformed System Config Logs

### DIFF
--- a/crates/consensus/derive/src/attributes/stateful.rs
+++ b/crates/consensus/derive/src/attributes/stateful.rs
@@ -101,12 +101,16 @@ where
                 derive_deposits(epoch.hash, &receipts, self.rollup_cfg.deposit_contract_address)
                     .await
                     .map_err(|e| PipelineError::BadEncoding(e).crit())?;
-            if let Err(err) = sys_config.update_with_receipts(
+            let (updates, errors) = sys_config.update_with_receipts(
                 &receipts,
                 self.rollup_cfg.l1_system_config_address,
                 self.rollup_cfg.is_ecotone_active(header.timestamp),
-            ) {
-                warn!(target: "attributes", error = ?err, block_number = epoch.number, "Failed to update system config, continuing");
+            );
+            for kind in &updates {
+                info!(target: "attributes", epoch = epoch.number, %kind, "Applied system config update");
+            }
+            for err in &errors {
+                warn!(target: "attributes", error = ?err, epoch = epoch.number, "Malformed system config update (skipped)");
             }
             l1_header = header;
             deposit_transactions = deposits;

--- a/crates/consensus/derive/src/stages/traversal/indexed.rs
+++ b/crates/consensus/derive/src/stages/traversal/indexed.rs
@@ -100,27 +100,13 @@ impl<F: ChainProvider> IndexedTraversal<F> {
         let receipts =
             self.data_source.receipts_by_hash(block_info.hash).await.map_err(Into::into)?;
 
-        let addr = self.rollup_config.l1_system_config_address;
-        let active = self.rollup_config.is_ecotone_active(block_info.timestamp);
-        match self.system_config.update_with_receipts(&receipts[..], addr, active) {
-            Ok(true) => {
-                base_macros::set!(
-                    gauge,
-                    crate::Metrics::PIPELINE_LATEST_SYS_CONFIG_UPDATE,
-                    block_info.number as f64
-                );
-                info!(target: "traversal", block_number = block_info.number, "System config updated");
-            }
-            Ok(false) => { /* Ignore, no update applied */ }
-            Err(err) => {
-                warn!(target: "traversal", error = ?err, block_number = block_info.number, "Failed to update system config, continuing");
-                base_macros::set!(
-                    gauge,
-                    crate::Metrics::PIPELINE_SYS_CONFIG_UPDATE_ERROR,
-                    block_info.number as f64
-                );
-            }
-        }
+        super::update_system_config_with_receipts(
+            &mut self.system_config,
+            &receipts,
+            self.rollup_config.l1_system_config_address,
+            self.rollup_config.is_ecotone_active(block_info.timestamp),
+            block_info.number,
+        );
 
         // Update the origin block.
         self.update_origin(block_info);

--- a/crates/consensus/derive/src/stages/traversal/mod.rs
+++ b/crates/consensus/derive/src/stages/traversal/mod.rs
@@ -9,6 +9,10 @@
 //! - [`PollingTraversal`]: An active traversal stage that polls for the next block through its
 //!   provider.
 
+use alloy_consensus::Receipt;
+use alloy_primitives::Address;
+use base_consensus_genesis::SystemConfig;
+
 mod indexed;
 pub use indexed::IndexedTraversal;
 
@@ -22,4 +26,35 @@ pub enum TraversalStage {
     Managed,
     /// An active traversal stage that polls for the next block through its provider.
     Polling,
+}
+
+/// Updates the system config with receipts, logging each applied update and any errors,
+/// and setting the appropriate metrics gauges.
+fn update_system_config_with_receipts(
+    system_config: &mut SystemConfig,
+    receipts: &[Receipt],
+    l1_system_config_address: Address,
+    ecotone_active: bool,
+    block_number: u64,
+) {
+    let (updates, errors) =
+        system_config.update_with_receipts(receipts, l1_system_config_address, ecotone_active);
+    for kind in &updates {
+        info!(target: "traversal", %kind, block_number, "Applied system config update");
+    }
+    if !updates.is_empty() {
+        base_macros::set!(
+            gauge,
+            crate::Metrics::PIPELINE_LATEST_SYS_CONFIG_UPDATE,
+            block_number as f64
+        );
+    }
+    for err in &errors {
+        warn!(target: "traversal", error = ?err, block_number, "Malformed system config update (skipped)");
+        base_macros::set!(
+            gauge,
+            crate::Metrics::PIPELINE_SYS_CONFIG_UPDATE_ERROR,
+            block_number as f64
+        );
+    }
 }

--- a/crates/consensus/derive/src/stages/traversal/polling.rs
+++ b/crates/consensus/derive/src/stages/traversal/polling.rs
@@ -108,27 +108,13 @@ impl<F: ChainProvider + Send> OriginAdvancer for PollingTraversal<F> {
         let receipts =
             self.data_source.receipts_by_hash(next_l1_origin.hash).await.map_err(Into::into)?;
 
-        let addr = self.rollup_config.l1_system_config_address;
-        let active = self.rollup_config.is_ecotone_active(next_l1_origin.timestamp);
-        match self.system_config.update_with_receipts(&receipts[..], addr, active) {
-            Ok(true) => {
-                base_macros::set!(
-                    gauge,
-                    crate::Metrics::PIPELINE_LATEST_SYS_CONFIG_UPDATE,
-                    next_l1_origin.number as f64
-                );
-                info!(target: "l1_traversal", block_number = next_l1_origin.number, "System config updated");
-            }
-            Ok(false) => { /* Ignore, no update applied */ }
-            Err(err) => {
-                warn!(target: "l1_traversal", error = ?err, block_number = next_l1_origin.number, "Failed to update system config, continuing");
-                base_macros::set!(
-                    gauge,
-                    crate::Metrics::PIPELINE_SYS_CONFIG_UPDATE_ERROR,
-                    next_l1_origin.number as f64
-                );
-            }
-        }
+        super::update_system_config_with_receipts(
+            &mut self.system_config,
+            &receipts,
+            self.rollup_config.l1_system_config_address,
+            self.rollup_config.is_ecotone_active(next_l1_origin.timestamp),
+            next_l1_origin.number,
+        );
 
         let prev_block_holocene = self.rollup_config.is_holocene_active(block.timestamp);
         let next_block_holocene = self.rollup_config.is_holocene_active(next_l1_origin.timestamp);

--- a/crates/consensus/genesis/Cargo.toml
+++ b/crates/consensus/genesis/Cargo.toml
@@ -27,7 +27,7 @@ base-alloy-chains.workspace = true
 # Misc
 tracing.workspace = true
 thiserror.workspace = true
-derive_more = { workspace = true, features = ["from", "try_from"] }
+derive_more = { workspace = true, features = ["display", "from", "try_from"] }
 
 # `revm` feature
 base-revm = { workspace = true, optional = true }

--- a/crates/consensus/genesis/src/system/config.rs
+++ b/crates/consensus/genesis/src/system/config.rs
@@ -1,6 +1,7 @@
 //! Contains the [`SystemConfig`] type.
 
 use alloc::vec::Vec;
+
 use alloy_consensus::{Eip658Value, Receipt};
 #[cfg(feature = "serde")]
 use alloy_primitives::B256;

--- a/crates/consensus/genesis/src/system/config.rs
+++ b/crates/consensus/genesis/src/system/config.rs
@@ -1,5 +1,6 @@
 //! Contains the [`SystemConfig`] type.
 
+use alloc::vec::Vec;
 use alloy_consensus::{Eip658Value, Receipt};
 #[cfg(feature = "serde")]
 use alloy_primitives::B256;
@@ -120,33 +121,35 @@ impl<'a> serde::Deserialize<'a> for SystemConfig {
 impl SystemConfig {
     /// Filters all L1 receipts to find config updates and applies the config updates.
     ///
-    /// Returns `true` if any config updates were applied, `false` otherwise.
+    /// Each config update log is applied independently. Malformed or invalid updates are
+    /// skipped so that subsequent valid updates in the same block are still processed.
+    /// This matches the op-node reference behavior in `UpdateSystemConfigWithL1Receipts`.
+    ///
+    /// Returns the successfully applied update kinds and any errors encountered.
     pub fn update_with_receipts(
         &mut self,
         receipts: &[Receipt],
         l1_system_config_address: Address,
         ecotone_active: bool,
-    ) -> Result<bool, SystemConfigUpdateError> {
-        let mut updated = false;
-        for receipt in receipts {
-            if Eip658Value::Eip658(false) == receipt.status {
-                continue;
-            }
-
-            receipt.logs.iter().try_for_each(|log| {
+    ) -> (Vec<SystemConfigUpdateKind>, Vec<SystemConfigUpdateError>) {
+        receipts
+            .iter()
+            .filter(|r| r.status != Eip658Value::Eip658(false))
+            .flat_map(|r| &r.logs)
+            .filter(|log| {
                 let topics = log.topics();
-                if log.address == l1_system_config_address
+                log.address == l1_system_config_address
                     && !topics.is_empty()
                     && topics[0] == CONFIG_UPDATE_TOPIC
-                {
-                    // Safety: Error is bubbled up by the trailing `?`
-                    self.process_config_update_log(log, ecotone_active)?;
-                    updated = true;
+            })
+            .map(|log| self.process_config_update_log(log, ecotone_active))
+            .fold((Vec::new(), Vec::new()), |(mut updates, mut errors), result| {
+                match result {
+                    Ok(kind) => updates.push(kind),
+                    Err(e) => errors.push(e),
                 }
-                Ok::<(), SystemConfigUpdateError>(())
-            })?;
-        }
-        Ok(updated)
+                (updates, errors)
+            })
     }
 
     /// Returns the eip1559 parameters from a [`SystemConfig`] encoded as a [B64].
@@ -226,6 +229,17 @@ mod test {
 
     use super::*;
     use crate::{CONFIG_UPDATE_EVENT_VERSION_0, HardForkConfig};
+
+    const BATCHER_UPDATE_TYPE: B256 =
+        b256!("0000000000000000000000000000000000000000000000000000000000000000");
+    const GAS_CONFIG_UPDATE_TYPE: B256 =
+        b256!("0000000000000000000000000000000000000000000000000000000000000001");
+    const GAS_LIMIT_UPDATE_TYPE: B256 =
+        b256!("0000000000000000000000000000000000000000000000000000000000000002");
+    const EIP1559_UPDATE_TYPE: B256 =
+        b256!("0000000000000000000000000000000000000000000000000000000000000004");
+    const OPERATOR_FEE_UPDATE_TYPE: B256 =
+        b256!("0000000000000000000000000000000000000000000000000000000000000005");
 
     #[test]
     #[cfg(feature = "serde")]
@@ -386,18 +400,16 @@ mod test {
         let l1_system_config_address = Address::ZERO;
         let ecotone_active = false;
 
-        let updated = system_config
-            .update_with_receipts(&receipts, l1_system_config_address, ecotone_active)
-            .unwrap();
-        assert!(!updated);
+        let (updates, errors) =
+            system_config.update_with_receipts(&receipts, l1_system_config_address, ecotone_active);
+        assert!(updates.is_empty());
+        assert!(errors.is_empty());
 
         assert_eq!(system_config, SystemConfig::default());
     }
 
     #[test]
     fn test_system_config_update_with_receipts_batcher_address() {
-        const UPDATE_TYPE: B256 =
-            b256!("0000000000000000000000000000000000000000000000000000000000000000");
         let mut system_config = SystemConfig::default();
         let l1_system_config_address = Address::ZERO;
         let ecotone_active = false;
@@ -408,7 +420,7 @@ mod test {
                 vec![
                     CONFIG_UPDATE_TOPIC,
                     CONFIG_UPDATE_EVENT_VERSION_0,
-                    UPDATE_TYPE,
+                    BATCHER_UPDATE_TYPE,
                 ],
                 hex!("00000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000beef").into()
             )
@@ -420,10 +432,13 @@ mod test {
             cumulative_gas_used: 0,
         };
 
-        let updated = system_config
-            .update_with_receipts(&[receipt], l1_system_config_address, ecotone_active)
-            .unwrap();
-        assert!(updated);
+        let (updates, errors) = system_config.update_with_receipts(
+            &[receipt],
+            l1_system_config_address,
+            ecotone_active,
+        );
+        assert_eq!(updates, vec![SystemConfigUpdateKind::Batcher]);
+        assert!(errors.is_empty());
 
         assert_eq!(
             system_config.batcher_address,
@@ -433,9 +448,6 @@ mod test {
 
     #[test]
     fn test_system_config_update_batcher_log() {
-        const UPDATE_TYPE: B256 =
-            b256!("0000000000000000000000000000000000000000000000000000000000000000");
-
         let mut system_config = SystemConfig::default();
 
         let update_log = Log {
@@ -444,7 +456,7 @@ mod test {
                 vec![
                     CONFIG_UPDATE_TOPIC,
                     CONFIG_UPDATE_EVENT_VERSION_0,
-                    UPDATE_TYPE,
+                    BATCHER_UPDATE_TYPE,
                 ],
                 hex!("00000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000beef").into()
             )
@@ -461,9 +473,6 @@ mod test {
 
     #[test]
     fn test_system_config_update_gas_config_log() {
-        const UPDATE_TYPE: B256 =
-            b256!("0000000000000000000000000000000000000000000000000000000000000001");
-
         let mut system_config = SystemConfig::default();
 
         let update_log = Log {
@@ -472,13 +481,13 @@ mod test {
                 vec![
                     CONFIG_UPDATE_TOPIC,
                     CONFIG_UPDATE_EVENT_VERSION_0,
-                    UPDATE_TYPE,
+                    GAS_CONFIG_UPDATE_TYPE,
                 ],
                 hex!("00000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000040000000000000000000000000000000000000000000000000000000000000babe000000000000000000000000000000000000000000000000000000000000beef").into()
             )
         };
 
-        // Update the batcher address.
+        // Update the gas config.
         system_config.process_config_update_log(&update_log, false).unwrap();
 
         assert_eq!(system_config.overhead, U256::from(0xbabe));
@@ -487,9 +496,6 @@ mod test {
 
     #[test]
     fn test_system_config_update_gas_config_log_ecotone() {
-        const UPDATE_TYPE: B256 =
-            b256!("0000000000000000000000000000000000000000000000000000000000000001");
-
         let mut system_config = SystemConfig::default();
 
         let update_log = Log {
@@ -498,13 +504,13 @@ mod test {
                 vec![
                     CONFIG_UPDATE_TOPIC,
                     CONFIG_UPDATE_EVENT_VERSION_0,
-                    UPDATE_TYPE,
+                    GAS_CONFIG_UPDATE_TYPE,
                 ],
                 hex!("00000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000040000000000000000000000000000000000000000000000000000000000000babe000000000000000000000000000000000000000000000000000000000000beef").into()
             )
         };
 
-        // Update the gas limit.
+        // Update the gas config (ecotone).
         system_config.process_config_update_log(&update_log, true).unwrap();
 
         assert_eq!(system_config.overhead, U256::from(0));
@@ -513,9 +519,6 @@ mod test {
 
     #[test]
     fn test_system_config_update_gas_limit_log() {
-        const UPDATE_TYPE: B256 =
-            b256!("0000000000000000000000000000000000000000000000000000000000000002");
-
         let mut system_config = SystemConfig::default();
 
         let update_log = Log {
@@ -524,7 +527,7 @@ mod test {
                 vec![
                     CONFIG_UPDATE_TOPIC,
                     CONFIG_UPDATE_EVENT_VERSION_0,
-                    UPDATE_TYPE,
+                    GAS_LIMIT_UPDATE_TYPE,
                 ],
                 hex!("00000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000beef").into()
             )
@@ -538,9 +541,6 @@ mod test {
 
     #[test]
     fn test_system_config_update_eip1559_params_log() {
-        const UPDATE_TYPE: B256 =
-            b256!("0000000000000000000000000000000000000000000000000000000000000004");
-
         let mut system_config = SystemConfig::default();
         let update_log = Log {
             address: Address::ZERO,
@@ -548,7 +548,7 @@ mod test {
                 vec![
                     CONFIG_UPDATE_TOPIC,
                     CONFIG_UPDATE_EVENT_VERSION_0,
-                    UPDATE_TYPE,
+                    EIP1559_UPDATE_TYPE,
                 ],
                 hex!("000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000babe0000beef").into()
             )
@@ -563,17 +563,14 @@ mod test {
 
     #[test]
     fn test_system_config_update_operator_fee_log() {
-        const UPDATE_TYPE: B256 =
-            b256!("0000000000000000000000000000000000000000000000000000000000000005");
-
         let mut system_config = SystemConfig::default();
-        let update_log  = Log {
+        let update_log = Log {
             address: Address::ZERO,
             data: LogData::new_unchecked(
                 vec![
                     CONFIG_UPDATE_TOPIC,
                     CONFIG_UPDATE_EVENT_VERSION_0,
-                    UPDATE_TYPE,
+                    OPERATOR_FEE_UPDATE_TYPE,
                 ],
                 hex!("0000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000babe000000000000beef").into()
             )
@@ -584,5 +581,53 @@ mod test {
 
         assert_eq!(system_config.operator_fee_scalar, Some(0xbabe_u32));
         assert_eq!(system_config.operator_fee_constant, Some(0xbeef_u64));
+    }
+
+    #[test]
+    fn test_update_with_receipts_continues_past_malformed_log() {
+        let mut system_config = SystemConfig::default();
+        let l1_system_config_address = Address::ZERO;
+
+        // Malformed batcher update: non-zero upper 12 bytes in batcher hash
+        let malformed_log = Log {
+            address: Address::ZERO,
+            data: LogData::new_unchecked(
+                vec![
+                    CONFIG_UPDATE_TOPIC,
+                    CONFIG_UPDATE_EVENT_VERSION_0,
+                    BATCHER_UPDATE_TYPE,
+                ],
+                // ABI-encoded address with dirty upper bytes — will fail address decoding
+                hex!("00000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000020dead00000000000000000000000000000000000000000000000000000000beef").into()
+            )
+        };
+
+        // Valid gas limit update (different type to prove the malformed one didn't apply)
+        let valid_log = Log {
+            address: Address::ZERO,
+            data: LogData::new_unchecked(
+                vec![
+                    CONFIG_UPDATE_TOPIC,
+                    CONFIG_UPDATE_EVENT_VERSION_0,
+                    GAS_LIMIT_UPDATE_TYPE,
+                ],
+                hex!("00000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000beef").into()
+            )
+        };
+
+        let receipt = Receipt {
+            logs: vec![malformed_log, valid_log],
+            status: Eip658Value::Eip658(true),
+            cumulative_gas_used: 0,
+        };
+
+        let (updates, errors) =
+            system_config.update_with_receipts(&[receipt], l1_system_config_address, false);
+        assert_eq!(updates, vec![SystemConfigUpdateKind::GasLimit]);
+        assert_eq!(errors.len(), 1);
+        // Malformed batcher update was skipped — address unchanged.
+        assert_eq!(system_config.batcher_address, Address::ZERO);
+        // Valid gas limit update was still applied.
+        assert_eq!(system_config.gas_limit, 0xbeef_u64);
     }
 }

--- a/crates/consensus/genesis/src/system/kind.rs
+++ b/crates/consensus/genesis/src/system/kind.rs
@@ -1,7 +1,7 @@
 //! Contains the kind of system config update.
 
 /// Represents type of update to the system config.
-#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, derive_more::TryFrom)]
+#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, derive_more::Display, derive_more::TryFrom)]
 #[try_from(repr)]
 #[repr(u64)]
 pub enum SystemConfigUpdateKind {


### PR DESCRIPTION
## Summary

SystemConfig::update_with_receipts used try_for_each which short-circuited on the first malformed config update log, silently dropping any subsequent valid updates in the same block. This changes each log to be processed independently so valid updates are applied and malformed ones are skipped, matching the op-node reference behavior in UpdateSystemConfigWithL1Receipts. The return type is refactored from Result<bool, SystemConfigUpdateError> to (Vec<SystemConfigUpdateKind>, Vec<SystemConfigUpdateError>) so callers get full visibility into what succeeded and what failed. A regression test is included that confirms a valid gas limit update survives a preceding malformed batcher update in the same block.

Ported from ethereum-optimism/optimism#19688.