### PR TITLE
ktlo(execution): Rename Stale Op-Reth And OP_ References

### DIFF
--- a/crates/execution/chainspec/README.md
+++ b/crates/execution/chainspec/README.md
@@ -15,7 +15,7 @@ hardfork schedule:
 
 - `BASE_MAINNET` - Base Mainnet (chain ID 8453), with London and Canyon variable base fee params.
 - `BASE_SEPOLIA` - Base Sepolia testnet (chain ID 84532), with equivalent hardfork schedule.
-- `OP_DEV` - Local dev chain with all hardforks active at genesis, prefunded test accounts.
+- `BASE_DEV` - Local dev chain with all hardforks active at genesis, prefunded test accounts.
 
 The genesis header is derived at startup from the genesis JSON using `make_op_genesis_header`,
 which computes the correct state root, storage root, and other fields for Base.
@@ -48,7 +48,7 @@ base-execution-chainspec = { workspace = true }
 Access the pre-built chain specs:
 
 ```rust,ignore
-use base_execution_chainspec::{BASE_MAINNET, BASE_SEPOLIA, OP_DEV};
+use base_execution_chainspec::{BASE_DEV, BASE_MAINNET, BASE_SEPOLIA};
 
 let spec = BASE_MAINNET.clone();
 println!("chain: {}", spec.chain());

--- a/crates/execution/chainspec/src/dev.rs
+++ b/crates/execution/chainspec/src/dev.rs
@@ -11,11 +11,11 @@ use reth_primitives_traits::{SealedHeader, sync::LazyLock};
 
 use crate::OpChainSpec;
 
-/// OP dev testnet specification
+/// Base dev testnet specification
 ///
 /// Includes 20 prefunded accounts with `10_000` ETH each derived from mnemonic "test test test test
 /// test test test test test test test junk".
-pub static OP_DEV: LazyLock<Arc<OpChainSpec>> = LazyLock::new(|| {
+pub static BASE_DEV: LazyLock<Arc<OpChainSpec>> = LazyLock::new(|| {
     let genesis = serde_json::from_str(BaseChainConfig::devnet().genesis_json)
         .expect("Can't deserialize Dev testnet genesis json");
     let hardforks = DEV_HARDFORKS.clone();

--- a/crates/execution/chainspec/src/lib.rs
+++ b/crates/execution/chainspec/src/lib.rs
@@ -26,7 +26,7 @@ mod builder;
 pub use builder::OpChainSpecBuilder;
 
 mod dev;
-pub use dev::OP_DEV;
+pub use dev::BASE_DEV;
 
 mod spec;
 pub use spec::{OpChainSpec, OpGenesisInfo, SUPPORTED_CHAINS};

--- a/crates/execution/chainspec/src/spec.rs
+++ b/crates/execution/chainspec/src/spec.rs
@@ -19,7 +19,7 @@ use reth_network_peers::NodeRecord;
 use reth_primitives_traits::SealedHeader;
 
 use crate::{
-    BASE_DEVNET_0_SEPOLIA_DEV_0, BASE_MAINNET, BASE_SEPOLIA, OP_DEV, compute_jovian_base_fee,
+    BASE_DEV, BASE_DEVNET_0_SEPOLIA_DEV_0, BASE_MAINNET, BASE_SEPOLIA, compute_jovian_base_fee,
     decode_holocene_base_fee,
 };
 
@@ -115,7 +115,7 @@ impl OpChainSpec {
     /// Parses a chain name into an [`OpChainSpec`], if recognized.
     pub fn parse_chain(s: &str) -> Option<Arc<Self>> {
         match s {
-            "dev" => Some(OP_DEV.clone()),
+            "dev" => Some(BASE_DEV.clone()),
             "base" => Some(BASE_MAINNET.clone()),
             "base_sepolia" | "base-sepolia" => Some(BASE_SEPOLIA.clone()),
             "base-devnet-0-sepolia-dev-0" => Some(BASE_DEVNET_0_SEPOLIA_DEV_0.clone()),

--- a/crates/execution/cli/src/lib.rs
+++ b/crates/execution/cli/src/lib.rs
@@ -37,7 +37,7 @@ use reth_node_core::{
 use reth_node_metrics as _;
 use reth_rpc_server_types::{DefaultRpcModuleValidator, RpcModuleValidator};
 
-/// The main op-reth cli interface.
+/// The main base-reth cli interface.
 ///
 /// This is the entrypoint to the executable.
 #[derive(Debug, Parser)]
@@ -122,7 +122,7 @@ where
 
 #[cfg(test)]
 mod test {
-    use base_execution_chainspec::{BASE_MAINNET, OP_DEV};
+    use base_execution_chainspec::{BASE_DEV, BASE_MAINNET};
     use base_node_core::args::RollupArgs;
     use clap::Parser;
     use reth_cli_commands::{NodeCommand, node::NoArgs};
@@ -131,8 +131,8 @@ mod test {
 
     #[test]
     fn parse_dev() {
-        let cmd = NodeCommand::<OpChainSpecParser, NoArgs>::parse_from(["op-reth", "--dev"]);
-        let chain = OP_DEV.clone();
+        let cmd = NodeCommand::<OpChainSpecParser, NoArgs>::parse_from(["base-reth", "--dev"]);
+        let chain = BASE_DEV.clone();
         assert_eq!(cmd.chain.chain, chain.chain);
         assert_eq!(cmd.chain.genesis_hash(), chain.genesis_hash());
         assert_eq!(
@@ -155,7 +155,7 @@ mod test {
         // SAFETY: this is a single-test context; no other thread concurrently reads this var.
         unsafe { std::env::set_var("OTEL_EXPORTER_OTLP_PROTOCOL", "http") };
         let cmd = Cli::<OpChainSpecParser, RollupArgs>::parse_from([
-            "op-reth",
+            "base-reth",
             "node",
             "--chain",
             "base",

--- a/crates/execution/hardforks/Cargo.toml
+++ b/crates/execution/hardforks/Cargo.toml
@@ -6,7 +6,7 @@ rust-version.workspace = true
 license.workspace = true
 homepage.workspace = true
 repository.workspace = true
-description = "Base hardforks used in op-reth"
+description = "Base hardforks used in base-reth"
 
 [lints]
 workspace = true

--- a/crates/execution/payload/Cargo.toml
+++ b/crates/execution/payload/Cargo.toml
@@ -6,7 +6,7 @@ rust-version.workspace = true
 license.workspace = true
 homepage.workspace = true
 repository.workspace = true
-description = "A payload builder for op-reth that builds optimistic payloads."
+description = "A payload builder for base-reth that builds Base payloads."
 
 [lints]
 workspace = true


### PR DESCRIPTION
## Summary

Several execution crates contained stale `op-reth` and `OP_`-prefixed identifiers that predate Base's divergence from OP Stack. This renames the `OP_DEV` constant to `BASE_DEV` across `chainspec` and updates all call sites, replaces hardcoded `"op-reth"` strings in CLI tests and doc comments with `"base-reth"`, and corrects the `description` fields in `hardforks/Cargo.toml` and `payload/Cargo.toml`. No behavior is changed; this is a pure naming cleanup to align with Base project conventions.

Closes #1599.