### PR TITLE
feat(batcher): Implement Runtime Log Level Changes

### DIFF
--- a/bin/batcher/src/cli.rs
+++ b/bin/batcher/src/cli.rs
@@ -34,7 +34,8 @@ pub(crate) struct Cli {
 impl Cli {
     /// Run the batcher CLI.
     pub(crate) fn run(self) -> eyre::Result<()> {
-        let log_reload = LogConfig::from(self.args.logging.clone()).init_tracing_subscriber_with_reload()?;
+        let log_reload =
+            LogConfig::from(self.args.logging.clone()).init_tracing_subscriber_with_reload()?;
         base_cli_utils::MetricsConfig::from(self.args.metrics.clone()).init_with(|| {
             base_cli_utils::register_version_metrics!();
         })?;

--- a/bin/batcher/src/cli.rs
+++ b/bin/batcher/src/cli.rs
@@ -8,7 +8,7 @@ use std::{
 use alloy_signer_local::PrivateKeySigner;
 use base_batcher_core::ThrottleConfig;
 use base_batcher_service::{BatcherConfig, BatcherService};
-use base_cli_utils::{LogConfig, RuntimeManager};
+use base_cli_utils::{LogConfig, LogReloadHandle, RuntimeManager};
 use base_runtime::TokioRuntime;
 use clap::{Args, Parser};
 use tracing::info;
@@ -34,11 +34,11 @@ pub(crate) struct Cli {
 impl Cli {
     /// Run the batcher CLI.
     pub(crate) fn run(self) -> eyre::Result<()> {
-        LogConfig::from(self.args.logging.clone()).init_tracing_subscriber()?;
+        let log_reload = LogConfig::from(self.args.logging.clone()).init_tracing_subscriber_with_reload()?;
         base_cli_utils::MetricsConfig::from(self.args.metrics.clone()).init_with(|| {
             base_cli_utils::register_version_metrics!();
         })?;
-        RuntimeManager::run_until_ctrl_c(self.args.exec())
+        RuntimeManager::run_until_ctrl_c(self.args.exec(log_reload))
     }
 }
 
@@ -209,7 +209,7 @@ impl BatcherArgs {
     }
 
     /// Execute the batcher.
-    async fn exec(self) -> eyre::Result<()> {
+    async fn exec(self, log_reload: LogReloadHandle) -> eyre::Result<()> {
         let config = self.into_config()?;
         info!(
             l1_rpc = %config.l1_rpc_url,
@@ -220,7 +220,13 @@ impl BatcherArgs {
         let rt = TokioRuntime::new();
         let _signal_handle = RuntimeManager::install_signal_handler(rt.token().clone());
 
-        let service = BatcherService::new(config);
+        let setter = log_reload.into_setter();
+        let log_setter = std::sync::Arc::new(
+            move |level: &str| -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+                setter(level).map_err(|e| e.to_string().into())
+            },
+        );
+        let service = BatcherService::new(config).with_log_setter(log_setter);
         service.setup(rt).await?.run().await
     }
 }

--- a/crates/batcher/admin/src/api.rs
+++ b/crates/batcher/admin/src/api.rs
@@ -8,7 +8,6 @@ use jsonrpsee::{
     proc_macros::rpc,
     types::ErrorObjectOwned,
 };
-use tracing::warn;
 
 #[rpc(server, namespace = "admin")]
 pub trait BatcherAdminApi {
@@ -68,6 +67,7 @@ impl BatcherAdminApiServerImpl {
         let code = match e {
             AdminError::NotSupported(_) => -32601,
             AdminError::ChannelClosed => -32001,
+            AdminError::SetLogLevel(_) => -32602,
         };
         ErrorObjectOwned::owned(code, e.to_string(), None::<()>)
     }
@@ -108,7 +108,6 @@ impl BatcherAdminApiServer for BatcherAdminApiServerImpl {
     }
 
     async fn set_log_level(&self, level: String) -> RpcResult<()> {
-        warn!(level = %level, "admin_setLogLevel called but not yet supported");
         self.handle.set_log_level(level).map_err(Self::admin_error)
     }
 }
@@ -128,5 +127,11 @@ mod tests {
     fn admin_error_channel_closed_uses_server_error_code() {
         let err = BatcherAdminApiServerImpl::admin_error(AdminError::ChannelClosed);
         assert_eq!(err.code(), -32001);
+    }
+
+    #[test]
+    fn admin_error_set_log_level_uses_invalid_params_code() {
+        let err = BatcherAdminApiServerImpl::admin_error(AdminError::SetLogLevel("bad".to_string()));
+        assert_eq!(err.code(), -32602);
     }
 }

--- a/crates/batcher/admin/src/api.rs
+++ b/crates/batcher/admin/src/api.rs
@@ -131,7 +131,8 @@ mod tests {
 
     #[test]
     fn admin_error_set_log_level_uses_invalid_params_code() {
-        let err = BatcherAdminApiServerImpl::admin_error(AdminError::SetLogLevel("bad".to_string()));
+        let err =
+            BatcherAdminApiServerImpl::admin_error(AdminError::SetLogLevel("bad".to_string()));
         assert_eq!(err.code(), -32602);
     }
 }

--- a/crates/batcher/core/src/admin.rs
+++ b/crates/batcher/core/src/admin.rs
@@ -7,7 +7,8 @@ use std::sync::Arc;
 /// The setter receives the raw level string from the JSON-RPC caller and is
 /// responsible for parsing it and applying it to the global subscriber. An
 /// error from the setter is surfaced as [`AdminError::SetLogLevel`].
-pub type LogSetter = Arc<dyn Fn(&str) -> Result<(), Box<dyn std::error::Error + Send + Sync>> + Send + Sync>;
+pub type LogSetter =
+    Arc<dyn Fn(&str) -> Result<(), Box<dyn std::error::Error + Send + Sync>> + Send + Sync>;
 
 use tokio::sync::{mpsc, oneshot};
 
@@ -211,11 +212,12 @@ mod tests {
         use std::sync::atomic::{AtomicBool, Ordering};
         let called = Arc::new(AtomicBool::new(false));
         let called_clone = Arc::clone(&called);
-        let setter: Arc<dyn Fn(&str) -> Result<(), Box<dyn std::error::Error + Send + Sync>> + Send + Sync> =
-            Arc::new(move |_level: &str| {
-                called_clone.store(true, Ordering::Relaxed);
-                Ok(())
-            });
+        let setter: Arc<
+            dyn Fn(&str) -> Result<(), Box<dyn std::error::Error + Send + Sync>> + Send + Sync,
+        > = Arc::new(move |_level: &str| {
+            called_clone.store(true, Ordering::Relaxed);
+            Ok(())
+        });
         let (handle, _rx) = AdminHandle::channel();
         let handle = handle.with_log_setter(setter);
         handle.set_log_level("debug".to_string()).unwrap();
@@ -224,8 +226,9 @@ mod tests {
 
     #[test]
     fn set_log_level_returns_set_log_level_error_on_setter_failure() {
-        let setter: Arc<dyn Fn(&str) -> Result<(), Box<dyn std::error::Error + Send + Sync>> + Send + Sync> =
-            Arc::new(|_: &str| Err("bad level".into()));
+        let setter: Arc<
+            dyn Fn(&str) -> Result<(), Box<dyn std::error::Error + Send + Sync>> + Send + Sync,
+        > = Arc::new(|_: &str| Err("bad level".into()));
         let (handle, _rx) = AdminHandle::channel();
         let handle = handle.with_log_setter(setter);
         let err = handle.set_log_level("notavalidlevel".to_string()).unwrap_err();

--- a/crates/batcher/core/src/admin.rs
+++ b/crates/batcher/core/src/admin.rs
@@ -1,5 +1,14 @@
 //! Admin command channel for runtime control of the batch driver.
 
+use std::sync::Arc;
+
+/// Type-erased setter for the global log level.
+///
+/// The setter receives the raw level string from the JSON-RPC caller and is
+/// responsible for parsing it and applying it to the global subscriber. An
+/// error from the setter is surfaced as [`AdminError::SetLogLevel`].
+pub type LogSetter = Arc<dyn Fn(&str) -> Result<(), Box<dyn std::error::Error + Send + Sync>> + Send + Sync>;
+
 use tokio::sync::{mpsc, oneshot};
 
 use crate::{ThrottleConfig, ThrottleInfo, ThrottleStrategy};
@@ -32,6 +41,9 @@ pub enum AdminError {
     /// The requested operation is not yet supported.
     #[error("not yet supported: {0}")]
     NotSupported(&'static str),
+    /// The log level setter failed (e.g. unknown level string or subscriber error).
+    #[error("failed to set log level: {0}")]
+    SetLogLevel(String),
 }
 
 /// Result type alias for admin operations.
@@ -74,16 +86,29 @@ pub enum AdminCommand {
 ///
 /// Create with [`AdminHandle::channel`]; wire the returned
 /// [`mpsc::Receiver`] into the driver via [`BatchDriver::with_admin_rx`].
-#[derive(Clone, Debug)]
+/// Optionally attach a log-level setter via [`AdminHandle::with_log_setter`]
+/// to enable `admin_setLogLevel`.
+#[derive(Clone, derive_more::Debug)]
 pub struct AdminHandle {
     tx: mpsc::Sender<AdminCommand>,
+    #[debug(skip)]
+    log_setter: Option<LogSetter>,
 }
 
 impl AdminHandle {
     /// Create a matched `(AdminHandle, Receiver)` pair.
     pub fn channel() -> (Self, mpsc::Receiver<AdminCommand>) {
         let (tx, rx) = mpsc::channel(ADMIN_CHANNEL_CAPACITY);
-        (Self { tx }, rx)
+        (Self { tx, log_setter: None }, rx)
+    }
+
+    /// Attach a runtime log-level setter.
+    ///
+    /// The setter is called by [`set_log_level`](Self::set_log_level) with the
+    /// raw level string from the JSON-RPC caller. It should parse the level and
+    /// apply it to the global subscriber.
+    pub fn with_log_setter(self, setter: LogSetter) -> Self {
+        Self { log_setter: Some(setter), ..self }
     }
 
     /// Resume block ingestion if currently paused.
@@ -138,14 +163,15 @@ impl AdminHandle {
         rx.await.map_err(|_| AdminError::ChannelClosed)
     }
 
-    /// Dynamic log level changes require a `tracing-subscriber` reload handle
-    /// threaded from the CLI through `BatcherService`.
+    /// Change the global log level at runtime.
     ///
-    /// Returns an error immediately so callers know the level was not changed.
-    /// No command is ever sent to the driver. A future chunk implements this
-    /// by modifying `base-cli-utils` to expose a reload handle.
-    pub fn set_log_level(&self, _level: String) -> AdminResult<()> {
-        Err(AdminError::NotSupported("set_log_level"))
+    /// Requires a setter to have been attached via [`with_log_setter`](Self::with_log_setter).
+    /// Returns [`AdminError::NotSupported`] when no setter is configured and
+    /// [`AdminError::SetLogLevel`] when the setter itself fails (e.g. unknown
+    /// level string).
+    pub fn set_log_level(&self, level: String) -> AdminResult<()> {
+        let setter = self.log_setter.as_ref().ok_or(AdminError::NotSupported("set_log_level"))?;
+        setter(&level).map_err(|e| AdminError::SetLogLevel(e.to_string()))
     }
 
     async fn send(&self, cmd: AdminCommand) -> AdminResult<()> {
@@ -174,9 +200,35 @@ mod tests {
     }
 
     #[test]
-    fn set_log_level_returns_not_supported() {
+    fn set_log_level_returns_not_supported_without_setter() {
         let (handle, _rx) = AdminHandle::channel();
         let err = handle.set_log_level("debug".to_string()).unwrap_err();
         assert!(matches!(err, AdminError::NotSupported(_)));
+    }
+
+    #[test]
+    fn set_log_level_calls_setter_when_configured() {
+        use std::sync::atomic::{AtomicBool, Ordering};
+        let called = Arc::new(AtomicBool::new(false));
+        let called_clone = Arc::clone(&called);
+        let setter: Arc<dyn Fn(&str) -> Result<(), Box<dyn std::error::Error + Send + Sync>> + Send + Sync> =
+            Arc::new(move |_level: &str| {
+                called_clone.store(true, Ordering::Relaxed);
+                Ok(())
+            });
+        let (handle, _rx) = AdminHandle::channel();
+        let handle = handle.with_log_setter(setter);
+        handle.set_log_level("debug".to_string()).unwrap();
+        assert!(called.load(Ordering::Relaxed));
+    }
+
+    #[test]
+    fn set_log_level_returns_set_log_level_error_on_setter_failure() {
+        let setter: Arc<dyn Fn(&str) -> Result<(), Box<dyn std::error::Error + Send + Sync>> + Send + Sync> =
+            Arc::new(|_: &str| Err("bad level".into()));
+        let (handle, _rx) = AdminHandle::channel();
+        let handle = handle.with_log_setter(setter);
+        let err = handle.set_log_level("notavalidlevel".to_string()).unwrap_err();
+        assert!(matches!(err, AdminError::SetLogLevel(_)));
     }
 }

--- a/crates/batcher/core/src/lib.rs
+++ b/crates/batcher/core/src/lib.rs
@@ -33,6 +33,7 @@ pub use event::DriverEvent;
 mod admin;
 pub use admin::{
     ADMIN_CHANNEL_CAPACITY, AdminCommand, AdminError, AdminHandle, AdminResult, BatcherStatus,
+    LogSetter,
 };
 
 mod driver;

--- a/crates/batcher/service/src/service.rs
+++ b/crates/batcher/service/src/service.rs
@@ -8,8 +8,8 @@ use base_alloy_consensus::OpBlock;
 use base_alloy_network::Base;
 use base_batcher_admin::AdminServer;
 use base_batcher_core::{
-    AdminHandle, BatchDriver, DaThrottle, NoopThrottleClient, ThrottleClient, ThrottleConfig,
-    ThrottleController, ThrottleStrategy,
+    AdminHandle, BatchDriver, DaThrottle, LogSetter, NoopThrottleClient, ThrottleClient,
+    ThrottleConfig, ThrottleController, ThrottleStrategy,
 };
 use base_batcher_encoder::BatchEncoder;
 use base_batcher_source::{BlockSubscription, HybridBlockSource, HybridL1HeadSource, SourceError};
@@ -135,16 +135,27 @@ impl ReadyBatcher {
 /// Wires the encoder, block source, L1 head source, transaction manager, and driver.
 /// Call [`setup`](Self::setup) to initialise all components, then call
 /// [`ReadyBatcher::run`] to enter the submission loop.
-#[derive(Debug)]
+#[derive(derive_more::Debug)]
 pub struct BatcherService {
     /// Full batcher configuration.
     config: BatcherConfig,
+    /// Optional runtime log-level setter, provided via [`with_log_setter`](Self::with_log_setter).
+    #[debug(skip)]
+    log_setter: Option<LogSetter>,
 }
 
 impl BatcherService {
     /// Create a new [`BatcherService`] from the given configuration.
-    pub const fn new(config: BatcherConfig) -> Self {
-        Self { config }
+    pub fn new(config: BatcherConfig) -> Self {
+        Self { config, log_setter: None }
+    }
+
+    /// Attach a runtime log-level setter so that `admin_setLogLevel` works.
+    ///
+    /// The setter is forwarded to the admin handle and called when the
+    /// `admin_setLogLevel` JSON-RPC method is invoked.
+    pub fn with_log_setter(self, setter: LogSetter) -> Self {
+        Self { log_setter: Some(setter), ..self }
     }
 
     /// Build a block subscription for the given optional L2 WebSocket URL.
@@ -430,6 +441,10 @@ impl BatcherService {
         let admin_server = match self.config.admin_addr {
             Some(addr) => {
                 let (admin_handle, admin_rx) = AdminHandle::channel();
+                let admin_handle = match self.log_setter {
+                    Some(setter) => admin_handle.with_log_setter(setter),
+                    None => admin_handle,
+                };
                 driver = driver.with_admin_rx(admin_rx);
                 Some(AdminServer::spawn(addr, admin_handle).await?)
             }

--- a/crates/utilities/cli/src/lib.rs
+++ b/crates/utilities/cli/src/lib.rs
@@ -26,7 +26,7 @@ pub use logging::{
 };
 
 mod tracing;
-pub use tracing::{LogfmtFormatter, init_test_tracing};
+pub use tracing::{LogReloadHandle, LogfmtFormatter, init_test_tracing};
 
 mod version;
 pub use version::Version;

--- a/crates/utilities/cli/src/tracing.rs
+++ b/crates/utilities/cli/src/tracing.rs
@@ -1,8 +1,13 @@
 //! Tracing subscriber initialization for CLI applications.
 
-use std::{fmt, io, sync::Once};
+use std::{
+    fmt,
+    io,
+    sync::{Arc, Once},
+};
 
 use tracing::Subscriber;
+use tracing::level_filters::LevelFilter;
 use tracing_appender::rolling::{RollingFileAppender, Rotation};
 use tracing_subscriber::{
     EnvFilter, Layer,
@@ -13,10 +18,41 @@ use tracing_subscriber::{
     },
     layer::SubscriberExt,
     registry::LookupSpan,
+    reload,
     util::SubscriberInitExt,
 };
 
 use crate::{FileLogConfig, LogConfig, LogFormat, LogRotation, StdoutLogConfig};
+
+type SetterFn = Arc<dyn Fn(&str) -> eyre::Result<()> + Send + Sync>;
+
+/// A handle for changing the global log level at runtime.
+///
+/// Created by [`LogConfig::init_tracing_subscriber_with_reload`] and passed
+/// into the admin server so that `admin_setLogLevel` works without restarting.
+#[derive(Clone)]
+pub struct LogReloadHandle {
+    setter: SetterFn,
+}
+
+impl LogReloadHandle {
+    /// Change the global log level to `level` (e.g. `"debug"`, `"info"`).
+    pub fn set_level(&self, level: &str) -> eyre::Result<()> {
+        (self.setter)(level)
+    }
+
+    /// Convert into a raw setter closure for use in crates that do not
+    /// depend on `base-cli-utils`.
+    pub fn into_setter(self) -> SetterFn {
+        self.setter
+    }
+}
+
+impl fmt::Debug for LogReloadHandle {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("LogReloadHandle").finish_non_exhaustive()
+    }
+}
 
 /// Custom logfmt formatter for tracing events.
 ///
@@ -84,6 +120,48 @@ impl LogConfig {
             .add_directive("discv5=error".parse().expect("valid directive"));
 
         self.init_tracing_subscriber_with_filter(filter)
+    }
+
+    /// Initialize the tracing subscriber and return a [`LogReloadHandle`] for
+    /// runtime log level changes.
+    ///
+    /// This sets the global default subscriber. Should only be called once.
+    /// Pass the returned handle to the admin server so that
+    /// `admin_setLogLevel` can take effect without a process restart.
+    pub fn init_tracing_subscriber_with_reload(&self) -> eyre::Result<LogReloadHandle> {
+        let base_filter = EnvFilter::builder()
+            .with_default_directive(self.global_level.into())
+            .from_env_lossy()
+            .add_directive("discv5=error".parse().expect("valid directive"));
+
+        let (reload_filter, reload_handle) = reload::Layer::new(base_filter);
+
+        let stdout_layer = self.stdout_logs.as_ref().map(build_stdout_layer);
+        let file_layer = self.file_logs.as_ref().map(build_file_layer);
+
+        tracing_subscriber::registry()
+            .with(reload_filter)
+            .with(stdout_layer)
+            .with(file_layer)
+            .try_init()
+            .map_err(|e| eyre::eyre!("Failed to initialize tracing subscriber: {}", e))?;
+
+        let setter = Arc::new(move |level: &str| -> eyre::Result<()> {
+            let new_filter = EnvFilter::builder()
+                .with_default_directive(
+                    level
+                        .parse::<LevelFilter>()
+                        .map_err(|e| eyre::eyre!("invalid log level {:?}: {}", level, e))?
+                        .into(),
+                )
+                .from_env_lossy()
+                .add_directive("discv5=error".parse().expect("valid directive"));
+            reload_handle
+                .reload(new_filter)
+                .map_err(|e| eyre::eyre!("reload failed: {}", e))
+        });
+
+        Ok(LogReloadHandle { setter })
     }
 
     /// Initialize the tracing subscriber with a custom filter.

--- a/crates/utilities/cli/src/tracing.rs
+++ b/crates/utilities/cli/src/tracing.rs
@@ -1,13 +1,11 @@
 //! Tracing subscriber initialization for CLI applications.
 
 use std::{
-    fmt,
-    io,
+    fmt, io,
     sync::{Arc, Once},
 };
 
-use tracing::Subscriber;
-use tracing::level_filters::LevelFilter;
+use tracing::{Subscriber, level_filters::LevelFilter};
 use tracing_appender::rolling::{RollingFileAppender, Rotation};
 use tracing_subscriber::{
     EnvFilter, Layer,
@@ -156,9 +154,7 @@ impl LogConfig {
                 )
                 .from_env_lossy()
                 .add_directive("discv5=error".parse().expect("valid directive"));
-            reload_handle
-                .reload(new_filter)
-                .map_err(|e| eyre::eyre!("reload failed: {}", e))
+            reload_handle.reload(new_filter).map_err(|e| eyre::eyre!("reload failed: {}", e))
         });
 
         Ok(LogReloadHandle { setter })


### PR DESCRIPTION
## Summary

The `admin_setLogLevel` JSON-RPC endpoint previously returned a `NotSupported` error. This PR wires a `tracing_subscriber` reload handle from the CLI entrypoint through `BatcherService` and into the admin server, so operators can change the global log level at runtime without restarting the batcher. A new `LogReloadHandle` type is added to `base-cli-utils` via `init_tracing_subscriber_with_reload`, which wraps the `EnvFilter` in a `reload::Layer` and exposes a type-erased `LogSetter` callback that `AdminHandle` stores and invokes on demand. The `AdminError::SetLogLevel` variant surfaces setter failures as a distinct JSON-RPC error code (`-32602`).