### PR TITLE
feat(chains): schedule Base V1 activation on Alpha devnet

### DIFF
--- a/crates/alloy/chains/src/chain.rs
+++ b/crates/alloy/chains/src/chain.rs
@@ -273,10 +273,12 @@ mod tests {
         let devnet_forks = BaseChainUpgrades::devnet();
         assert!(devnet_forks.is_base_v1_active_at_timestamp(0));
 
-        // V1 is not scheduled on devnet-0-sepolia-dev-0 yet
+        // V1 is scheduled on devnet-0-sepolia-dev-0 at 1774890000
         let devnet0_forks = BaseChainUpgrades::base_devnet_0_sepolia_dev_0();
         assert!(!devnet0_forks.is_base_v1_active_at_timestamp(0));
-        assert!(!devnet0_forks.is_base_v1_active_at_timestamp(u64::MAX));
+        assert!(!devnet0_forks.is_base_v1_active_at_timestamp(1_774_889_999));
+        assert!(devnet0_forks.is_base_v1_active_at_timestamp(1_774_890_000));
+        assert!(devnet0_forks.is_base_v1_active_at_timestamp(u64::MAX));
     }
 
     #[test]
@@ -296,7 +298,7 @@ mod tests {
         let devnet0_forks = BaseChainUpgrades::base_devnet_0_sepolia_dev_0();
         assert_eq!(
             devnet0_forks.ethereum_fork_activation(EthereumHardfork::Osaka),
-            ForkCondition::Never
+            ForkCondition::Timestamp(1_774_890_000)
         );
     }
 

--- a/crates/alloy/chains/src/config.rs
+++ b/crates/alloy/chains/src/config.rs
@@ -273,7 +273,7 @@ const ALPHA: BaseChainConfig = BaseChainConfig {
     pectra_blob_schedule_timestamp: Some(1_742_486_400),
     isthmus_timestamp: 1_744_300_800,
     jovian_timestamp: 1_762_185_600,
-    base_v1_timestamp: None,
+    base_v1_timestamp: Some(1_774_890_000),
 
     genesis_l1_hash: b256!("86252c512dc5bd7201d0532b31d50696ba84344a7cda545e04a98073a8e13d87"),
     genesis_l1_number: 4_344_216,


### PR DESCRIPTION
Schedule Base V1 activation on base-devnet-0-sepolia-dev-0 (Alpha) at timestamp 1774890000 (Monday March 30, 2026 1pm ET).