### PR TITLE
fix: remove access list from metadata v1

### DIFF
--- a/crates/builder/core/src/flashblocks/payload.rs
+++ b/crates/builder/core/src/flashblocks/payload.rs
@@ -1098,13 +1098,13 @@ where
 
     // finalize and build the FAL
     let fal_builder = std::mem::take(&mut info.extra.access_list_builder);
-    let access_list = fal_builder.build(min_tx_index, max_tx_index);
+    let _access_list = fal_builder.build(min_tx_index, max_tx_index);
 
     let metadata: FlashblocksMetadata =
         if ctx.chain_spec.is_base_v1_active_at_timestamp(ctx.attributes().timestamp()) {
             FlashblocksMetadata {
                 block_number: ctx.parent().number + 1,
-                access_list: Some(access_list),
+                access_list: None,
                 receipts: None,
                 new_account_balances: None,
             }

--- a/crates/builder/core/tests/flashblocks.rs
+++ b/crates/builder/core/tests/flashblocks.rs
@@ -143,8 +143,8 @@ async fn test_flashblock_metadata_post_base_v1() -> eyre::Result<()> {
             "post-V1 flashblock metadata must not contain new_account_balances"
         );
         assert!(
-            fb.metadata.get("access_list").is_some(),
-            "post-V1 flashblock metadata must contain access_list"
+            fb.metadata.get("access_list").is_none(),
+            "post-V1 flashblock metadata must not contain access_list"
         );
     }
 


### PR DESCRIPTION
We decided to remove these to make fewer changes in Base fork v1.