### PR TITLE
perf(cli): extract reth-node-core into base-reth-cli crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2879,6 +2879,7 @@ dependencies = [
  "base-execution-cli",
  "base-node-core",
  "base-node-runner",
+ "base-reth-cli",
  "base-txpool-rpc",
  "clap",
  "eyre",
@@ -3138,7 +3139,6 @@ dependencies = [
  "metrics",
  "metrics-exporter-prometheus",
  "metrics-process",
- "reth-node-core",
  "rstest",
  "serde",
  "serde_json",
@@ -4904,6 +4904,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "base-reth-cli"
+version = "0.0.0"
+dependencies = [
+ "reth-node-core",
+]
+
+[[package]]
 name = "base-reth-node"
 version = "0.0.0"
 dependencies = [
@@ -4916,6 +4923,7 @@ dependencies = [
  "base-node-core",
  "base-node-runner",
  "base-proofs-extension",
+ "base-reth-cli",
  "base-tx-forwarding",
  "base-txpool-rpc",
  "base-txpool-tracing",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4785,7 +4785,6 @@ dependencies = [
  "alloy-primitives",
  "alloy-provider",
  "alloy-rpc-client",
- "alloy-rpc-types",
  "alloy-rpc-types-eth",
  "alloy-signer-local",
  "alloy-sol-types",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -286,10 +286,11 @@ base-comp = { path = "crates/batcher/comp", default-features = false }
 base-jwt = { path = "crates/utilities/jwt" }
 base-health = { path = "crates/utilities/health" }
 base-cli-utils = { path = "crates/utilities/cli" }
-base-runtime = { path = "crates/utilities/runtime", default-features = false }
+base-reth-cli = { path = "crates/utilities/reth-cli" }
 base-test-utils = { path = "crates/utilities/test-utils" }
 base-tx-manager = { path = "crates/utilities/tx-manager" }
 base-macros = { path = "crates/utilities/macros", default-features = false }
+base-runtime = { path = "crates/utilities/runtime", default-features = false }
 
 # revm
 revm = { version = "34.0.0", default-features = false }

--- a/bin/builder/Cargo.toml
+++ b/bin/builder/Cargo.toml
@@ -17,11 +17,11 @@ workspace = true
 
 [dependencies]
 # workspace
-base-cli-utils = { workspace = true, features = ["reth"] }
 base-txpool-rpc.workspace = true
 base-node-runner.workspace = true
 base-builder-core.workspace = true
 base-builder-metering.workspace = true
+base-cli-utils = { workspace = true, features = ["reth"] }
 
 # reth
 base-node-core.workspace = true

--- a/bin/builder/Cargo.toml
+++ b/bin/builder/Cargo.toml
@@ -17,13 +17,14 @@ workspace = true
 
 [dependencies]
 # workspace
+base-cli-utils.workspace = true
 base-txpool-rpc.workspace = true
 base-node-runner.workspace = true
 base-builder-core.workspace = true
 base-builder-metering.workspace = true
-base-cli-utils = { workspace = true, features = ["reth"] }
 
 # reth
+base-reth-cli.workspace = true
 base-node-core.workspace = true
 reth-cli-util.workspace = true
 base-execution-cli = { workspace = true, features = ["otlp"] }

--- a/bin/builder/Cargo.toml
+++ b/bin/builder/Cargo.toml
@@ -17,7 +17,7 @@ workspace = true
 
 [dependencies]
 # workspace
-base-cli-utils.workspace = true
+base-cli-utils = { workspace = true, features = ["reth"] }
 base-txpool-rpc.workspace = true
 base-node-runner.workspace = true
 base-builder-core.workspace = true

--- a/bin/builder/src/main.rs
+++ b/bin/builder/src/main.rs
@@ -20,7 +20,7 @@ static ALLOC: reth_cli_util::allocator::Allocator = reth_cli_util::allocator::ne
 
 fn main() {
     base_cli_utils::init_common!();
-    base_cli_utils::init_reth!();
+    base_reth_cli::init_reth!();
 
     let cli = base_cli_utils::parse_cli!(BuilderCli);
 

--- a/bin/node/Cargo.toml
+++ b/bin/node/Cargo.toml
@@ -18,7 +18,6 @@ workspace = true
 [dependencies]
 # workspace
 base-metering.workspace = true
-base-cli-utils = { workspace = true, features = ["reth"] }
 base-txpool-rpc.workspace = true
 base-flashblocks.workspace = true
 base-node-runner.workspace = true
@@ -27,6 +26,7 @@ base-txpool-tracing.workspace = true
 base-flashblocks-node.workspace = true
 base-proofs-extension.workspace = true
 base-bundle-extension.workspace = true
+base-cli-utils = { workspace = true, features = ["reth"] }
 
 # reth
 base-node-core.workspace = true

--- a/bin/node/Cargo.toml
+++ b/bin/node/Cargo.toml
@@ -18,7 +18,7 @@ workspace = true
 [dependencies]
 # workspace
 base-metering.workspace = true
-base-cli-utils.workspace = true
+base-cli-utils = { workspace = true, features = ["reth"] }
 base-txpool-rpc.workspace = true
 base-flashblocks.workspace = true
 base-node-runner.workspace = true

--- a/bin/node/Cargo.toml
+++ b/bin/node/Cargo.toml
@@ -18,6 +18,7 @@ workspace = true
 [dependencies]
 # workspace
 base-metering.workspace = true
+base-cli-utils.workspace = true
 base-txpool-rpc.workspace = true
 base-flashblocks.workspace = true
 base-node-runner.workspace = true
@@ -26,9 +27,9 @@ base-txpool-tracing.workspace = true
 base-flashblocks-node.workspace = true
 base-proofs-extension.workspace = true
 base-bundle-extension.workspace = true
-base-cli-utils = { workspace = true, features = ["reth"] }
 
 # reth
+base-reth-cli.workspace = true
 base-node-core.workspace = true
 reth-cli-util.workspace = true
 base-execution-cli = { workspace = true, features = ["otlp"] }

--- a/bin/node/src/main.rs
+++ b/bin/node/src/main.rs
@@ -23,7 +23,7 @@ static ALLOC: reth_cli_util::allocator::Allocator = reth_cli_util::allocator::ne
 
 fn main() {
     base_cli_utils::init_common!();
-    base_cli_utils::init_reth!();
+    base_reth_cli::init_reth!();
 
     let cli = base_cli_utils::parse_cli!(NodeCli);
 

--- a/crates/proof/proposer/Cargo.toml
+++ b/crates/proof/proposer/Cargo.toml
@@ -17,7 +17,6 @@ alloy-eips.workspace = true
 alloy-contract.workspace = true
 alloy-provider.workspace = true
 alloy-transport.workspace = true
-alloy-rpc-types.workspace = true
 alloy-consensus.workspace = true
 alloy-sol-types.workspace = true
 alloy-primitives.workspace = true

--- a/crates/utilities/cli/Cargo.toml
+++ b/crates/utilities/cli/Cargo.toml
@@ -13,7 +13,7 @@ workspace = true
 
 [dependencies]
 # reth
-reth-node-core.workspace = true
+reth-node-core = { workspace = true, optional = true }
 
 # cli
 clap = { workspace = true, features = ["derive"] }
@@ -42,3 +42,6 @@ serde_json = { workspace = true, features = ["std"] }
 [target.'cfg(unix)'.dependencies]
 libc.workspace = true
 backtrace.workspace = true
+
+[features]
+reth = ["dep:reth-node-core"]

--- a/crates/utilities/cli/Cargo.toml
+++ b/crates/utilities/cli/Cargo.toml
@@ -44,4 +44,4 @@ libc.workspace = true
 backtrace.workspace = true
 
 [features]
-reth = ["dep:reth-node-core"]
+reth = [ "dep:reth-node-core" ]

--- a/crates/utilities/cli/Cargo.toml
+++ b/crates/utilities/cli/Cargo.toml
@@ -12,9 +12,6 @@ repository.workspace = true
 workspace = true
 
 [dependencies]
-# reth
-reth-node-core = { workspace = true, optional = true }
-
 # cli
 clap = { workspace = true, features = ["derive"] }
 
@@ -43,5 +40,3 @@ serde_json = { workspace = true, features = ["std"] }
 libc.workspace = true
 backtrace.workspace = true
 
-[features]
-reth = [ "dep:reth-node-core" ]

--- a/crates/utilities/cli/README.md
+++ b/crates/utilities/cli/README.md
@@ -3,12 +3,11 @@
 <a href="https://github.com/base/base/actions/workflows/ci.yml"><img src="https://github.com/base/base/actions/workflows/ci.yml/badge.svg?label=ci" alt="CI"></a>
 <a href="https://github.com/base/base/blob/main/LICENSE"><img src="https://img.shields.io/badge/License-MIT-d1d1f6.svg?label=license&labelColor=2a2f35" alt="MIT License"></a>
 
-CLI utilities for the Base Reth node.
+CLI utilities for Base binaries.
 
 ## Overview
 
 - **`parse_cli!`**: Parses CLI arguments with package version/description from Cargo.toml.
-- **`init_reth_version!`**: Initializes Reth's global version metadata for P2P identification.
 - **`register_version_metrics!`**: Registers `base_info{version="..."}` Prometheus metric.
 - **`define_log_args!`**: Generates a `LogArgs` struct with env-var-prefixed logging flags.
 - **`define_metrics_args!`**: Generates a `MetricsArgs` struct with env-var-prefixed Prometheus flags.
@@ -27,14 +26,9 @@ base-cli-utils = { git = "https://github.com/base/base" }
 use base_execution_cli::Cli;
 
 fn main() {
-    // Initialize Reth version metadata for P2P identification
-    base_cli_utils::init_reth_version!();
-
-    // Parse CLI with package version/description from Cargo.toml
     let cli = base_cli_utils::parse_cli!(Cli<ChainSpecParser, Args>);
 
     cli.run(|builder, args| async move {
-        // Register version metrics after node starts
         base_cli_utils::register_version_metrics!();
         // ...
     });

--- a/crates/utilities/cli/src/version.rs
+++ b/crates/utilities/cli/src/version.rs
@@ -7,53 +7,12 @@ use metrics::gauge;
 pub struct Version;
 
 impl Version {
-    /// Initializes Reth's global version metadata using the binary's package info.
-    ///
-    /// This sets up the client name, P2P version string, and extra data fields
-    /// that Reth uses for network identification and logging.
-    ///
-    /// ### Panics
-    ///
-    /// Panics if unable to initialize version metadata.
-    #[cfg(feature = "reth")]
-    pub fn init_reth(version: &'static str, pkg_name: &'static str) {
-        use reth_node_core::version::{
-            RethCliVersionConsts, default_reth_version_metadata, try_init_version_metadata,
-        };
-
-        let default = default_reth_version_metadata();
-        let client_version = format!("base/v{version}");
-
-        try_init_version_metadata(RethCliVersionConsts {
-            name_client: pkg_name.to_string().into(),
-            cargo_pkg_version: format!("{}/{}", default.cargo_pkg_version, version).into(),
-            p2p_client_version: format!("{}/{}", default.p2p_client_version, client_version).into(),
-            extra_data: format!("{}/{}", default.extra_data, client_version).into(),
-            ..default
-        })
-        .expect("Unable to init version metadata");
-    }
-
     /// Exposes version information over Prometheus as `base_info{version="..."}`.
     pub fn register_metrics(version: &'static str) {
         let labels: [(&str, &str); 1] = [("version", version)];
         let gauge = gauge!("base_info", &labels);
         gauge.set(1);
     }
-}
-
-/// Initializes Reth's global version metadata.
-///
-/// Use this in execution layer binaries (base-node-reth, base-builder) that need
-/// Reth's global version metadata initialized for P2P identification and logging.
-///
-/// This macro must be called from the binary crate to capture the correct package metadata.
-#[cfg(feature = "reth")]
-#[macro_export]
-macro_rules! init_reth {
-    () => {
-        $crate::Version::init_reth(env!("CARGO_PKG_VERSION"), env!("CARGO_PKG_NAME"))
-    };
 }
 
 /// Registers version information as Prometheus metrics (`base_info{version="..."}`).

--- a/crates/utilities/cli/src/version.rs
+++ b/crates/utilities/cli/src/version.rs
@@ -1,9 +1,6 @@
 //! Contains node versioning info.
 
 use metrics::gauge;
-use reth_node_core::version::{
-    RethCliVersionConsts, default_reth_version_metadata, try_init_version_metadata,
-};
 
 /// Encapsulates versioning utilities for Base binaries.
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
@@ -18,7 +15,12 @@ impl Version {
     /// ### Panics
     ///
     /// Panics if unable to initialize version metadata.
+    #[cfg(feature = "reth")]
     pub fn init_reth(version: &'static str, pkg_name: &'static str) {
+        use reth_node_core::version::{
+            RethCliVersionConsts, default_reth_version_metadata, try_init_version_metadata,
+        };
+
         let default = default_reth_version_metadata();
         let client_version = format!("base/v{version}");
 
@@ -46,6 +48,7 @@ impl Version {
 /// Reth's global version metadata initialized for P2P identification and logging.
 ///
 /// This macro must be called from the binary crate to capture the correct package metadata.
+#[cfg(feature = "reth")]
 #[macro_export]
 macro_rules! init_reth {
     () => {

--- a/crates/utilities/reth-cli/Cargo.toml
+++ b/crates/utilities/reth-cli/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "base-reth-cli"
+description = "Reth CLI Utilities"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+
+[lints]
+workspace = true
+
+[dependencies]
+reth-node-core.workspace = true

--- a/crates/utilities/reth-cli/README.md
+++ b/crates/utilities/reth-cli/README.md
@@ -1,0 +1,24 @@
+# `base-reth-cli`
+
+Reth-specific CLI utilities for Base execution layer binaries.
+
+## Overview
+
+- **`init_reth!`**: Initializes Reth's global version metadata for P2P identification and logging.
+
+## Usage
+
+```toml
+[dependencies]
+base-reth-cli = { git = "https://github.com/base/base" }
+```
+
+```rust,ignore
+fn main() {
+    base_reth_cli::init_reth!();
+}
+```
+
+## License
+
+Licensed under the [MIT License](https://github.com/base/base/blob/main/LICENSE).

--- a/crates/utilities/reth-cli/src/lib.rs
+++ b/crates/utilities/reth-cli/src/lib.rs
@@ -1,0 +1,11 @@
+#![doc = include_str!("../README.md")]
+#![doc(
+    html_logo_url = "https://avatars.githubusercontent.com/u/16627100?s=200&v=4",
+    html_favicon_url = "https://avatars.githubusercontent.com/u/16627100?s=200&v=4",
+    issue_tracker_base_url = "https://github.com/base/base/issues/"
+)]
+#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
+#![cfg_attr(not(test), warn(unused_crate_dependencies))]
+
+mod version;
+pub use version::Version;

--- a/crates/utilities/reth-cli/src/version.rs
+++ b/crates/utilities/reth-cli/src/version.rs
@@ -1,0 +1,46 @@
+//! Reth version initialization utilities.
+
+use reth_node_core::version::{
+    RethCliVersionConsts, default_reth_version_metadata, try_init_version_metadata,
+};
+
+/// Reth version initialization for Base execution layer binaries.
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub struct Version;
+
+impl Version {
+    /// Initializes Reth's global version metadata using the binary's package info.
+    ///
+    /// This sets up the client name, P2P version string, and extra data fields
+    /// that Reth uses for network identification and logging.
+    ///
+    /// ### Panics
+    ///
+    /// Panics if unable to initialize version metadata.
+    pub fn init_reth(version: &'static str, pkg_name: &'static str) {
+        let default = default_reth_version_metadata();
+        let client_version = format!("base/v{version}");
+
+        try_init_version_metadata(RethCliVersionConsts {
+            name_client: pkg_name.to_string().into(),
+            cargo_pkg_version: format!("{}/{}", default.cargo_pkg_version, version).into(),
+            p2p_client_version: format!("{}/{}", default.p2p_client_version, client_version).into(),
+            extra_data: format!("{}/{}", default.extra_data, client_version).into(),
+            ..default
+        })
+        .expect("Unable to init version metadata");
+    }
+}
+
+/// Initializes Reth's global version metadata.
+///
+/// Use this in execution layer binaries (base-node-reth, base-builder) that need
+/// Reth's global version metadata initialized for P2P identification and logging.
+///
+/// This macro must be called from the binary crate to capture the correct package metadata.
+#[macro_export]
+macro_rules! init_reth {
+    () => {
+        $crate::Version::init_reth(env!("CARGO_PKG_VERSION"), env!("CARGO_PKG_NAME"))
+    };
+}


### PR DESCRIPTION
## Summary

- Extracts `reth-node-core`-dependent code (`init_reth!` macro, `Version::init_reth()`) from `base-cli-utils` into a new `base-reth-cli` crate
- Only `bin/node` and `bin/builder` depend on `base-reth-cli` (they call `init_reth!()`)
- The other 11 consumer binaries (including both prover binaries) no longer compile `reth-node-core` and its ~639 transitive dependencies

## Motivation

`base-cli-utils` depended on `reth-node-core` solely for `init_reth!()`, used by only 2 of 13 consumer binaries. All 13 were paying the compilation cost of 803 transitive dependencies (reth networking, database, discovery, engine crates) for functionality they never use.

## Impact

| Crate | Deps Before | Deps After | Reduction |
|---|---|---|---|
| `base-cli-utils` | 803 | **164** | **-639** |
| `base-prover-nitro` | ~1031 | **659** | **-372** |
| `base-prover-zk` | ~1031 | **366** | **-665** |

## Changes

**New crate: `base-reth-cli`** (`crates/utilities/reth-cli/`)
- `Version::init_reth()` and `init_reth!` macro moved here
- Depends on `reth-node-core`

**Modified:**
- `crates/utilities/cli/Cargo.toml` — removed `reth-node-core` dependency entirely
- `crates/utilities/cli/src/version.rs` — removed `init_reth()` and `init_reth!` macro (kept `register_metrics` / `register_version_metrics!`)
- `bin/node/Cargo.toml` — added `base-reth-cli`, plain `base-cli-utils` (no feature flag)
- `bin/builder/Cargo.toml` — same
- `bin/{node,builder}/src/main.rs` — `base_cli_utils::init_reth!()` → `base_reth_cli::init_reth!()`
- `Cargo.toml` (workspace) — added `base-reth-cli` to workspace dependencies

## Verification

```
cargo check -p base-cli-utils   ✅
cargo check -p base-reth-cli    ✅
cargo check -p base-reth-node   ✅
cargo check -p base-builder-bin ✅
```