### PR TITLE
fix: use fast proofs sync if within 1024 blocks of tip

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5453,7 +5453,7 @@ dependencies = [
  "bitflags 2.11.0",
  "cexpr",
  "clang-sys",
- "itertools 0.13.0",
+ "itertools 0.11.0",
  "proc-macro2",
  "quote",
  "regex",
@@ -13328,7 +13328,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
 dependencies = [
  "heck",
- "itertools 0.14.0",
+ "itertools 0.11.0",
  "log",
  "multimap",
  "petgraph",
@@ -13349,7 +13349,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.11.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -13362,7 +13362,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.11.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",

--- a/crates/execution/exex/src/lib.rs
+++ b/crates/execution/exex/src/lib.rs
@@ -21,9 +21,8 @@ use reth_execution_types::Chain;
 use reth_exex::{ExExContext, ExExEvent, ExExNotification, ExExNotificationsStream};
 use reth_node_api::{FullNodeComponents, NodePrimitives, NodeTypes};
 use reth_provider::{BlockNumReader, BlockReader, TransactionVariant};
-use reth_trie::{HashedPostStateSorted, updates::TrieUpdatesSorted};
-pub use sync_target::{CachedBlockTrieData, SyncTarget};
-use tokio::{sync::watch, task};
+pub use sync_target::{CachedBlockTrieData, SyncTarget, SyncTargetState};
+use tokio::task;
 use tracing::{debug, error, info};
 
 // Safety threshold for maximum blocks to prune automatically on startup.
@@ -228,7 +227,7 @@ where
                 best_block,
                 "Storage behind tip, starting sync immediately"
             );
-            sync_target.set_target(best_block);
+            sync_target.update_state(SyncTargetState::SyncUpTo { to: best_block });
         }
 
         let prune_task = OpProofStoragePrunerTask::new(
@@ -241,16 +240,10 @@ where
             .task_executor()
             .spawn_with_graceful_shutdown_signal(|signal| Box::pin(prune_task.run(signal)));
 
-        let collector = LiveTrieCollector::new(
-            self.ctx.evm_config().clone(),
-            self.ctx.provider().clone(),
-            &self.storage,
-        );
-
         self.ctx.notifications.set_without_head();
 
         while let Some(notification) = self.ctx.notifications.try_next().await? {
-            self.handle_notification(notification, &collector, &sync_target)?;
+            self.handle_notification(notification, &sync_target)?;
         }
 
         Ok(())
@@ -310,7 +303,6 @@ where
     fn spawn_sync_task(&self) -> Arc<SyncTarget> {
         let sync_target = Arc::new(SyncTarget::new());
         let task_sync_target = Arc::clone(&sync_target);
-        let target_rx = sync_target.subscribe();
 
         let task_storage = self.storage.clone();
         let task_provider = self.ctx.provider().clone();
@@ -325,7 +317,6 @@ where
                     LiveTrieCollector::new(task_evm_config, task_provider.clone(), &storage);
                 Self::sync_loop(
                     task_sync_target,
-                    target_rx,
                     task_storage,
                     task_provider,
                     &task_collector,
@@ -340,7 +331,6 @@ where
 
     async fn sync_loop(
         sync_target: Arc<SyncTarget>,
-        mut target_rx: watch::Receiver<u64>,
         storage: OpProofsStorage<Storage>,
         provider: Node::Provider,
         collector: &LiveTrieCollector<'_, Node::Evm, Node::Provider, Storage>,
@@ -349,25 +339,104 @@ where
         info!(target: "base::exex", "Starting proofs storage sync loop");
 
         loop {
-            let target = sync_target.target();
+            let Some(state) = sync_target.take_state() else {
+                sync_target.notified().await;
+                continue;
+            };
+
+            match state {
+                SyncTargetState::Revert { revert_to } => {
+                    Self::handle_revert(&storage, collector, revert_to);
+                }
+                SyncTargetState::RevertThenSync { revert_to, sync_to } => {
+                    Self::handle_revert(&storage, collector, revert_to);
+                    Self::sync_forward(
+                        &sync_target,
+                        &storage,
+                        &provider,
+                        collector,
+                        verification_interval,
+                        sync_to,
+                    )
+                    .await;
+                }
+                SyncTargetState::SyncUpTo { to } => {
+                    Self::sync_forward(
+                        &sync_target,
+                        &storage,
+                        &provider,
+                        collector,
+                        verification_interval,
+                        to,
+                    )
+                    .await;
+                }
+            }
+        }
+    }
+
+    fn handle_revert(
+        storage: &OpProofsStorage<Storage>,
+        collector: &LiveTrieCollector<'_, Node::Evm, Node::Provider, Storage>,
+        revert_to: BlockWithParent,
+    ) {
+        let latest = match storage.get_latest_block_number() {
+            Ok(Some((n, _))) => n,
+            Ok(None) => return,
+            Err(e) => {
+                error!(target: "base::exex", error = ?e, "Failed to get latest block during revert");
+                return;
+            }
+        };
+
+        if latest >= revert_to.block.number {
+            info!(
+                target: "base::exex",
+                revert_to = revert_to.block.number,
+                latest,
+                "Reverting proofs storage"
+            );
+            if let Err(e) = collector.unwind_history(revert_to) {
+                error!(target: "base::exex", error = ?e, "Failed to revert proofs storage");
+            }
+        } else {
+            debug!(
+                target: "base::exex",
+                revert_to = revert_to.block.number,
+                latest,
+                "Revert target beyond stored blocks, skipping"
+            );
+        }
+    }
+
+    async fn sync_forward(
+        sync_target: &SyncTarget,
+        storage: &OpProofsStorage<Storage>,
+        provider: &Node::Provider,
+        collector: &LiveTrieCollector<'_, Node::Evm, Node::Provider, Storage>,
+        verification_interval: u64,
+        target: u64,
+    ) {
+        loop {
+            // Check for higher-priority state (e.g. revert) before processing.
+            if sync_target.has_pending_state() {
+                return;
+            }
+
             let latest = match storage.get_latest_block_number() {
                 Ok(Some((n, _))) => n,
                 Ok(None) => {
-                    error!(target: "base::exex", "No blocks stored in proofs storage during sync loop");
-                    continue;
+                    error!(target: "base::exex", "No blocks stored in proofs storage during sync");
+                    return;
                 }
                 Err(e) => {
                     error!(target: "base::exex", error = ?e, "Failed to get latest block");
-                    continue;
+                    return;
                 }
             };
 
             if latest >= target {
-                if target_rx.changed().await.is_err() {
-                    error!(target: "base::exex", "Sync target watch channel closed, exiting sync loop");
-                    return;
-                }
-                continue;
+                return;
             }
 
             let end = (latest + SYNC_BLOCKS_BATCH_SIZE as u64).min(target);
@@ -382,15 +451,11 @@ where
 
             for block_num in (latest + 1)..=end {
                 let cached = sync_target.take(block_num);
-                if let Err(e) = Self::process_block(
-                    block_num,
-                    cached,
-                    collector,
-                    &provider,
-                    verification_interval,
-                ) {
+                if let Err(e) =
+                    Self::process_block(block_num, cached, collector, provider, verification_interval)
+                {
                     error!(target: "base::exex", block_number = block_num, error = ?e, "Block processing failed");
-                    break;
+                    return;
                 }
             }
 
@@ -458,28 +523,17 @@ where
     fn handle_notification(
         &self,
         notification: ExExNotification<Primitives>,
-        collector: &LiveTrieCollector<'_, Node::Evm, Node::Provider, Storage>,
         sync_target: &SyncTarget,
     ) -> eyre::Result<()> {
-        let latest_stored = match self.storage.get_latest_block_number()? {
-            Some((n, _)) => n,
-            None => {
-                return Err(eyre::eyre!("No blocks stored in proofs storage"));
-            }
-        };
-
         match &notification {
             ExExNotification::ChainCommitted { new } => {
-                self.handle_chain_committed(Arc::clone(new), latest_stored, sync_target)?
+                self.handle_chain_committed(Arc::clone(new), sync_target)?
             }
-            ExExNotification::ChainReorged { old, new } => self.handle_chain_reorged(
-                Arc::clone(old),
-                Arc::clone(new),
-                latest_stored,
-                collector,
-            )?,
+            ExExNotification::ChainReorged { old, new } => {
+                self.handle_chain_reorged(Arc::clone(old), Arc::clone(new), sync_target)?
+            }
             ExExNotification::ChainReverted { old } => {
-                self.handle_chain_reverted(Arc::clone(old), latest_stored, collector)?
+                self.handle_chain_reverted(Arc::clone(old), sync_target)?
             }
         }
 
@@ -500,7 +554,6 @@ where
     fn handle_chain_committed(
         &self,
         new: Arc<Chain<Primitives>>,
-        latest_stored: u64,
         sync_target: &SyncTarget,
     ) -> eyre::Result<()> {
         debug!(
@@ -509,16 +562,6 @@ where
             block_hash = ?new.tip().hash(),
             "ChainCommitted notification received",
         );
-
-        if new.tip().number() <= latest_stored {
-            debug!(
-                target: "base::exex",
-                block_number = new.tip().number(),
-                latest_stored,
-                "Already processed, skipping"
-            );
-            return Ok(());
-        }
 
         // Cache trie data for all blocks in the chain so the sync loop can
         // use pre-computed data even when it is many blocks behind.
@@ -549,11 +592,10 @@ where
             total_blocks,
             cached_count,
             missing = total_blocks - cached_count,
-            latest_stored,
             "Cached notification trie data"
         );
 
-        sync_target.set_target(new.tip().number());
+        sync_target.update_state(SyncTargetState::SyncUpTo { to: new.tip().number() });
         Ok(())
     }
 
@@ -561,8 +603,7 @@ where
         &self,
         old: Arc<Chain<Primitives>>,
         new: Arc<Chain<Primitives>>,
-        latest_stored: u64,
-        collector: &LiveTrieCollector<'_, Node::Evm, Node::Provider, Storage>,
+        sync_target: &SyncTarget,
     ) -> eyre::Result<()> {
         info!(
             target: "base::exex",
@@ -573,48 +614,43 @@ where
             "ChainReorged notification received",
         );
 
-        if old.first().number() > latest_stored {
-            debug!(target: "base::exex", "Reorg beyond stored blocks, skipping");
-            return Ok(());
-        }
-
-        // find the common ancestor
-        let mut block_updates: Vec<(
-            BlockWithParent,
-            Arc<TrieUpdatesSorted>,
-            Arc<HashedPostStateSorted>,
-        )> = Vec::with_capacity(new.len());
-        for block_number in new.blocks().keys() {
-            // verify if the fork point matches
-            if old.fork_block() != new.fork_block() {
-                return Err(eyre::eyre!(
-                    "Fork blocks do not match: old fork block {:?}, new fork block {:?}",
-                    old.fork_block(),
-                    new.fork_block()
-                ));
-            }
-
-            let block = new
-                .blocks()
-                .get(block_number)
-                .ok_or_else(|| eyre::eyre!("Missing block {} in new chain", block_number))?;
-            let trie_data = new
-                .trie_data_at(*block_number)
-                .ok_or_else(|| {
-                    eyre::eyre!("Missing Trie data for block {} in new chain", block_number)
-                })?
-                .get();
-            let trie_updates = &trie_data.trie_updates;
-            let hashed_state = &trie_data.hashed_state;
-
-            block_updates.push((
-                block.block_with_parent(),
-                Arc::clone(trie_updates),
-                Arc::clone(hashed_state),
+        if old.fork_block() != new.fork_block() {
+            return Err(eyre::eyre!(
+                "Fork blocks do not match: old fork block {:?}, new fork block {:?}",
+                old.fork_block(),
+                new.fork_block()
             ));
         }
 
-        collector.unwind_and_store_block_updates(block_updates)?;
+        let first_old = old.first().block_with_parent();
+
+        // Invalidate any cached blocks from the old chain.
+        sync_target.clear_from(first_old.block.number);
+
+        // Cache trie data for all blocks in the new chain.
+        for (&block_number, block) in new.blocks() {
+            if let Some(trie_data) = new.trie_data_at(block_number) {
+                sync_target.insert(
+                    block_number,
+                    CachedBlockTrieData {
+                        block_with_parent: block.block_with_parent(),
+                        trie_data: trie_data.clone(),
+                    },
+                );
+            } else {
+                debug!(
+                    target: "base::exex",
+                    block_number,
+                    "Reorged block missing trie data"
+                );
+            }
+        }
+
+        sync_target
+            .update_state(SyncTargetState::RevertThenSync {
+                revert_to: first_old,
+                sync_to: new.tip().number(),
+            });
 
         Ok(())
     }
@@ -622,8 +658,7 @@ where
     fn handle_chain_reverted(
         &self,
         old: Arc<Chain<Primitives>>,
-        latest_stored: u64,
-        collector: &LiveTrieCollector<'_, Node::Evm, Node::Provider, Storage>,
+        sync_target: &SyncTarget,
     ) -> eyre::Result<()> {
         info!(
             target: "base::exex",
@@ -632,17 +667,12 @@ where
             "ChainReverted notification received",
         );
 
-        if old.first().number() > latest_stored {
-            debug!(
-                target: "base::exex",
-                first_block_number = old.first().number(),
-                latest_stored = latest_stored,
-                "Fork block number is greater than latest stored, skipping",
-            );
-            return Ok(());
-        }
+        let first_old = old.first().block_with_parent();
 
-        collector.unwind_history(old.first().block_with_parent())?;
+        // Invalidate any cached blocks that are being reverted.
+        sync_target.clear_from(first_old.block.number);
+
+        sync_target.update_state(SyncTargetState::Revert { revert_to: first_old });
         Ok(())
     }
 }
@@ -774,11 +804,6 @@ mod tests {
         let (ctx, _handle) =
             reth_exex_test_utils::test_exex_context().await.expect("exex test context");
 
-        let collector = LiveTrieCollector::new(
-            ctx.components.components.evm_config.clone(),
-            ctx.components.provider.clone(),
-            &proofs,
-        );
         let exex = build_test_exex(ctx, proofs.clone());
 
         let new_chain = Arc::new(mk_chain_with_updates(1, 1, None));
@@ -786,15 +811,16 @@ mod tests {
 
         let sync_target = SyncTarget::new();
 
-        exex.handle_notification(notif, &collector, &sync_target).expect("handle chain commit");
+        exex.handle_notification(notif, &sync_target).expect("handle chain commit");
 
         // Committed blocks are cached in sync target, not stored directly
-        assert_eq!(sync_target.target(), 1);
         assert!(sync_target.take(1).is_some(), "block 1 should be cached");
+        let state = sync_target.take_state().expect("should have pending state");
+        assert!(matches!(state, SyncTargetState::SyncUpTo { to: 1 }));
     }
 
     #[tokio::test]
-    async fn handle_notification_chain_committed_skips_already_processed() {
+    async fn handle_notification_chain_committed_caches_already_stored_blocks() {
         // MDBX proofs storage
         let dir = tempdir_path();
         let store = Arc::new(MdbxProofsStorage::new(dir.as_path()).expect("env"));
@@ -808,27 +834,23 @@ mod tests {
         let (ctx, _handle) =
             reth_exex_test_utils::test_exex_context().await.expect("exex test context");
 
-        let collector = LiveTrieCollector::new(
-            ctx.components.components.evm_config.clone(),
-            ctx.components.provider.clone(),
-            &proofs,
-        );
-
         let exex = build_test_exex(ctx, proofs.clone());
 
         let sync_target = SyncTarget::new();
 
-        // Try to handle notification for block 5 which is already stored
+        // Handle notification for block 5 which is already stored - still caches
         let new_chain = Arc::new(mk_chain_with_updates(5, 5, Some(hash_for_num(10))));
         let notif = ExExNotification::ChainCommitted { new: new_chain };
-        exex.handle_notification(notif, &collector, &sync_target).expect("handle chain commit");
+        exex.handle_notification(notif, &sync_target).expect("handle chain commit");
 
-        // Target should not have been updated since block 5 <= latest_stored
-        assert_eq!(sync_target.target(), 0);
+        // State is set (sync loop will see latest >= target and skip)
+        let state = sync_target.take_state().expect("should have pending state");
+        assert!(matches!(state, SyncTargetState::SyncUpTo { to: 5 }));
 
+        // Storage is unchanged (notification handler doesn't write to storage)
         let latest = proofs.get_latest_block_number().expect("get latest block").expect("ok");
         assert_eq!(latest.0, 5);
-        assert_eq!(latest.1, hash_for_num(5)); // block was not updated
+        assert_eq!(latest.1, hash_for_num(5));
     }
 
     #[tokio::test]
@@ -844,18 +866,9 @@ mod tests {
         let (ctx, _handle) =
             reth_exex_test_utils::test_exex_context().await.expect("exex test context");
 
-        let collector = LiveTrieCollector::new(
-            ctx.components.components.evm_config.clone(),
-            ctx.components.provider.clone(),
-            &proofs,
-        );
-
         let exex = build_test_exex(ctx, proofs.clone());
 
         let sync_target = SyncTarget::new();
-
-        let latest = proofs.get_latest_block_number().expect("get latest block").expect("ok").0;
-        assert_eq!(latest, 10);
 
         // Now the tip is 10, and we want to reorg from block 6..12
         let old_chain = Arc::new(mk_chain_with_updates(6, 10, None));
@@ -864,13 +877,28 @@ mod tests {
         // Notification: chain reorged 6..12
         let notif = ExExNotification::ChainReorged { new: new_chain, old: old_chain };
 
-        exex.handle_notification(notif, &collector, &sync_target).expect("handle chain re-orged");
+        exex.handle_notification(notif, &sync_target).expect("handle chain re-orged");
+
+        // Should have RevertThenSync state
+        let state = sync_target.take_state().expect("should have pending state");
+        assert!(matches!(
+            state,
+            SyncTargetState::RevertThenSync { revert_to, sync_to: 12 }
+            if revert_to.block.number == 6
+        ));
+
+        // New chain blocks should be cached
+        for n in 6..=12 {
+            assert!(sync_target.take(n).is_some(), "block {} should be cached", n);
+        }
+
+        // Storage unchanged (sync loop handles the actual revert)
         let latest = proofs.get_latest_block_number().expect("get latest block").expect("ok").0;
-        assert_eq!(latest, 12);
+        assert_eq!(latest, 10);
     }
 
     #[tokio::test]
-    async fn handle_notification_chain_reorged_skips_beyond_stored_blocks() {
+    async fn handle_notification_chain_reorged_beyond_stored_blocks() {
         // MDBX proofs storage
         let dir = tempdir_path();
         let store = Arc::new(MdbxProofsStorage::new(dir.as_path()).expect("env"));
@@ -882,27 +910,29 @@ mod tests {
         let (ctx, _handle) =
             reth_exex_test_utils::test_exex_context().await.expect("exex test context");
 
-        let collector = LiveTrieCollector::new(
-            ctx.components.components.evm_config.clone(),
-            ctx.components.provider.clone(),
-            &proofs,
-        );
-
         let exex = build_test_exex(ctx, proofs.clone());
 
         let sync_target = SyncTarget::new();
 
-        let latest = proofs.get_latest_block_number().expect("get latest block").expect("ok").0;
-        assert_eq!(latest, 10);
-
         // Now the tip is 10, and we want to reorg from block 12..15
+        // Both chains share the same fork block (block 11)
         let old_chain = Arc::new(mk_chain_with_updates(12, 15, None));
-        let new_chain = Arc::new(mk_chain_with_updates(10, 20, None));
+        let new_chain = Arc::new(mk_chain_with_updates(12, 20, None));
 
-        // Notification: chain reorged 12..15
+        // Notification: chain reorged 12..20
         let notif = ExExNotification::ChainReorged { new: new_chain, old: old_chain };
 
-        exex.handle_notification(notif, &collector, &sync_target).expect("handle chain re-orged");
+        exex.handle_notification(notif, &sync_target).expect("handle chain re-orged");
+
+        // State is set; sync loop will detect revert is beyond stored blocks
+        let state = sync_target.take_state().expect("should have pending state");
+        assert!(matches!(
+            state,
+            SyncTargetState::RevertThenSync { revert_to, sync_to: 20 }
+            if revert_to.block.number == 12
+        ));
+
+        // Storage unchanged
         let latest = proofs.get_latest_block_number().expect("get latest block").expect("ok").0;
         assert_eq!(latest, 10);
     }
@@ -920,18 +950,9 @@ mod tests {
         let (ctx, _handle) =
             reth_exex_test_utils::test_exex_context().await.expect("exex test context");
 
-        let collector = LiveTrieCollector::new(
-            ctx.components.components.evm_config.clone(),
-            ctx.components.provider.clone(),
-            &proofs,
-        );
-
         let exex = build_test_exex(ctx, proofs.clone());
 
         let sync_target = SyncTarget::new();
-
-        let latest = proofs.get_latest_block_number().expect("get latest block").expect("ok").0;
-        assert_eq!(latest, 10);
 
         // Now the tip is 10, and we want to revert from block 9..10
         let old_chain = Arc::new(mk_chain_with_updates(9, 10, None));
@@ -939,13 +960,23 @@ mod tests {
         // Notification: chain reverted 9..10
         let notif = ExExNotification::ChainReverted { old: old_chain };
 
-        exex.handle_notification(notif, &collector, &sync_target).expect("handle chain reverted");
+        exex.handle_notification(notif, &sync_target).expect("handle chain reverted");
+
+        // Should have Revert state
+        let state = sync_target.take_state().expect("should have pending state");
+        assert!(matches!(
+            state,
+            SyncTargetState::Revert { revert_to }
+            if revert_to.block.number == 9
+        ));
+
+        // Storage unchanged (sync loop handles the actual revert)
         let latest = proofs.get_latest_block_number().expect("get latest block").expect("ok").0;
-        assert_eq!(latest, 8);
+        assert_eq!(latest, 10);
     }
 
     #[tokio::test]
-    async fn handle_notification_chain_reverted_skips_beyond_stored_blocks() {
+    async fn handle_notification_chain_reverted_beyond_stored_blocks() {
         // MDBX proofs storage
         let dir = tempdir_path();
         let store = Arc::new(MdbxProofsStorage::new(dir.as_path()).expect("env"));
@@ -957,18 +988,9 @@ mod tests {
         let (ctx, _handle) =
             reth_exex_test_utils::test_exex_context().await.expect("exex test context");
 
-        let collector = LiveTrieCollector::new(
-            ctx.components.components.evm_config.clone(),
-            ctx.components.provider.clone(),
-            &proofs,
-        );
-
         let exex = build_test_exex(ctx, proofs.clone());
 
         let sync_target = SyncTarget::new();
-
-        let latest = proofs.get_latest_block_number().expect("get latest block").expect("ok").0;
-        assert_eq!(latest, 5);
 
         // Now the tip is 5, and we want to revert from block 9..10
         let old_chain = Arc::new(mk_chain_with_updates(9, 10, None));
@@ -976,7 +998,17 @@ mod tests {
         // Notification: chain reverted 9..10
         let notif = ExExNotification::ChainReverted { old: old_chain };
 
-        exex.handle_notification(notif, &collector, &sync_target).expect("handle chain reverted");
+        exex.handle_notification(notif, &sync_target).expect("handle chain reverted");
+
+        // State is set; sync loop will detect revert is beyond stored blocks
+        let state = sync_target.take_state().expect("should have pending state");
+        assert!(matches!(
+            state,
+            SyncTargetState::Revert { revert_to }
+            if revert_to.block.number == 9
+        ));
+
+        // Storage unchanged
         let latest = proofs.get_latest_block_number().expect("get latest block").expect("ok").0;
         assert_eq!(latest, 5);
     }
@@ -1040,33 +1072,6 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn handle_notification_errors_on_empty_storage() {
-        // MDBX proofs storage
-        let dir = tempdir_path();
-        let store = Arc::new(MdbxProofsStorage::new(dir.as_path()).expect("env"));
-        let proofs: OpProofsStorage<Arc<MdbxProofsStorage>> = Arc::clone(&store).into();
-
-        let (ctx, _handle) =
-            reth_exex_test_utils::test_exex_context().await.expect("exex test context");
-
-        let collector = LiveTrieCollector::new(
-            ctx.components.components.evm_config.clone(),
-            ctx.components.provider.clone(),
-            &proofs,
-        );
-
-        let exex = build_test_exex(ctx, proofs.clone());
-
-        // Any notification will do
-        let new_chain = Arc::new(mk_chain_with_updates(1, 5, None));
-        let notif = ExExNotification::ChainCommitted { new: new_chain };
-
-        let sync_target = SyncTarget::new();
-        let err = exex.handle_notification(notif, &collector, &sync_target).unwrap_err();
-        assert_eq!(err.to_string(), "No blocks stored in proofs storage");
-    }
-
-    #[tokio::test]
     async fn handle_notification_schedules_async_on_gap() {
         // MDBX proofs storage
         let dir = tempdir_path();
@@ -1078,11 +1083,6 @@ mod tests {
         let (ctx, _handle) =
             reth_exex_test_utils::test_exex_context().await.expect("exex test context");
 
-        let collector = LiveTrieCollector::new(
-            ctx.components.components.evm_config.clone(),
-            ctx.components.provider.clone(),
-            &proofs,
-        );
         let exex = build_test_exex(ctx, proofs.clone());
 
         // Notification: chain committed 5..10 (Blocks 1,2,3,4 are missing from storage)
@@ -1092,11 +1092,15 @@ mod tests {
         let sync_target = SyncTarget::new();
 
         // Process notification
-        exex.handle_notification(notif, &collector, &sync_target)
+        exex.handle_notification(notif, &sync_target)
             .expect("handle chain commit should return ok immediately");
 
-        // Verify the sync target was updated to the tip of the new chain
-        assert_eq!(sync_target.target(), 10, "Should have scheduled sync to block 10");
+        // Verify the sync target state was set
+        let state = sync_target.take_state().expect("should have pending state");
+        assert!(
+            matches!(state, SyncTargetState::SyncUpTo { to: 10 }),
+            "Should have scheduled sync to block 10"
+        );
 
         // Verify Main Thread did NOT process it
         // Because we didn't spawn the actual worker thread in this test, storage should still be at

--- a/crates/execution/exex/src/lib.rs
+++ b/crates/execution/exex/src/lib.rs
@@ -7,6 +7,7 @@
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
 
+mod sync_target;
 use std::{sync::Arc, time::Duration};
 
 use alloy_consensus::BlockHeader;
@@ -17,11 +18,12 @@ use base_execution_trie::{
 };
 use futures::TryStreamExt;
 use reth_execution_types::Chain;
-use reth_exex::{ExExContext, ExExEvent, ExExNotification};
+use reth_exex::{ExExContext, ExExEvent, ExExNotification, ExExNotificationsStream};
 use reth_node_api::{FullNodeComponents, NodePrimitives, NodeTypes};
 use reth_provider::{BlockNumReader, BlockReader, TransactionVariant};
-use reth_trie::{HashedPostStateSorted, SortedTrieData, updates::TrieUpdatesSorted};
-use tokio::{sync::watch, task, time};
+use reth_trie::{HashedPostStateSorted, updates::TrieUpdatesSorted};
+pub use sync_target::{CachedBlockTrieData, SyncTarget};
+use tokio::{sync::watch, task};
 use tracing::{debug, error, info};
 
 // Safety threshold for maximum blocks to prune automatically on startup.
@@ -31,12 +33,6 @@ const MAX_PRUNE_BLOCKS_STARTUP: u64 = 1000;
 
 /// How many blocks to process in a single batch before yielding. Default is 50 blocks.
 const SYNC_BLOCKS_BATCH_SIZE: usize = 50;
-
-/// How close to tip before we process blocks in real-time vs batch. Default is 1024 blocks.
-const REAL_TIME_BLOCKS_THRESHOLD: u64 = 1024;
-
-/// How long to sleep when sync task is caught up. Default is 5 seconds.
-const SYNC_IDLE_SLEEP_SECS: u64 = 5;
 
 /// Default proofs history window: 1 month of blocks at 2s block time
 const DEFAULT_PROOFS_HISTORY_WINDOW: u64 = 1_296_000;
@@ -219,7 +215,7 @@ where
     /// Main execution loop for the `ExEx`
     pub async fn run(mut self) -> eyre::Result<()> {
         self.ensure_initialized()?;
-        let sync_target_tx = self.spawn_sync_task();
+        let sync_target = self.spawn_sync_task();
 
         // If storage is behind tip, start syncing immediately rather than waiting
         // for the first notification.
@@ -232,7 +228,7 @@ where
                 best_block,
                 "Storage behind tip, starting sync immediately"
             );
-            sync_target_tx.send(best_block)?;
+            sync_target.set_target(best_block);
         }
 
         let prune_task = OpProofStoragePrunerTask::new(
@@ -251,8 +247,10 @@ where
             &self.storage,
         );
 
+        self.ctx.notifications.set_without_head();
+
         while let Some(notification) = self.ctx.notifications.try_next().await? {
-            self.handle_notification(notification, &collector, &sync_target_tx)?;
+            self.handle_notification(notification, &collector, &sync_target)?;
         }
 
         Ok(())
@@ -303,13 +301,21 @@ where
         Ok(())
     }
 
-    /// Spawn the background sync task and return the target sender
-    fn spawn_sync_task(&self) -> watch::Sender<u64> {
-        let (sync_target_tx, sync_target_rx) = watch::channel(0u64);
+    /// Spawn the background sync task and return the shared [`SyncTarget`].
+    ///
+    /// The sync target buffers trie data from notifications so the sync loop
+    /// can use pre-computed data for blocks even when it is many blocks behind
+    /// the chain tip. Blocks whose trie data was evicted from the cache fall
+    /// back to full execution.
+    fn spawn_sync_task(&self) -> Arc<SyncTarget> {
+        let sync_target = Arc::new(SyncTarget::new());
+        let task_sync_target = Arc::clone(&sync_target);
+        let target_rx = sync_target.subscribe();
 
         let task_storage = self.storage.clone();
         let task_provider = self.ctx.provider().clone();
         let task_evm_config = self.ctx.evm_config().clone();
+        let verification_interval = self.verification_interval;
 
         self.ctx.task_executor().spawn_critical_task(
             "base::exex::proofs_storage_sync_loop",
@@ -317,24 +323,33 @@ where
                 let storage = task_storage.clone();
                 let task_collector =
                     LiveTrieCollector::new(task_evm_config, task_provider.clone(), &storage);
-                Self::sync_loop(sync_target_rx, task_storage, task_provider, &task_collector).await;
+                Self::sync_loop(
+                    task_sync_target,
+                    target_rx,
+                    task_storage,
+                    task_provider,
+                    &task_collector,
+                    verification_interval,
+                )
+                .await;
             },
         );
 
-        sync_target_tx
+        sync_target
     }
 
-    /// Background sync loop that processes blocks up to the target
     async fn sync_loop(
-        mut sync_target_rx: watch::Receiver<u64>,
+        sync_target: Arc<SyncTarget>,
+        mut target_rx: watch::Receiver<u64>,
         storage: OpProofsStorage<Storage>,
         provider: Node::Provider,
         collector: &LiveTrieCollector<'_, Node::Evm, Node::Provider, Storage>,
+        verification_interval: u64,
     ) {
-        debug!(target: "base::exex", "Starting proofs storage sync loop");
+        info!(target: "base::exex", "Starting proofs storage sync loop");
 
         loop {
-            let target = *sync_target_rx.borrow_and_update();
+            let target = sync_target.target();
             let latest = match storage.get_latest_block_number() {
                 Ok(Some((n, _))) => n,
                 Ok(None) => {
@@ -348,47 +363,95 @@ where
             };
 
             if latest >= target {
-                time::sleep(Duration::from_secs(SYNC_IDLE_SLEEP_SECS)).await;
+                if target_rx.changed().await.is_err() {
+                    error!(target: "base::exex", "Sync target watch channel closed, exiting sync loop");
+                    return;
+                }
                 continue;
             }
 
-            // Process one batch
-            if let Err(e) =
-                Self::process_batch(latest, target, &provider, collector, SYNC_BLOCKS_BATCH_SIZE)
-            {
-                error!(target: "base::exex", error = ?e, "Batch processing failed");
+            let end = (latest + SYNC_BLOCKS_BATCH_SIZE as u64).min(target);
+            info!(
+                target: "base::exex",
+                start = latest + 1,
+                end,
+                target,
+                batch_size = end - latest,
+                "Processing proofs storage sync batch"
+            );
+
+            for block_num in (latest + 1)..=end {
+                let cached = sync_target.take(block_num);
+                if let Err(e) = Self::process_block(
+                    block_num,
+                    cached,
+                    collector,
+                    &provider,
+                    verification_interval,
+                ) {
+                    error!(target: "base::exex", block_number = block_num, error = ?e, "Block processing failed");
+                    break;
+                }
             }
 
-            // Yield to allow other tasks to run
-            debug!(target: "base::exex", latest_stored = latest, target, "Batch processed, yielding");
+            info!(target: "base::exex", latest_stored = latest, target, "Batch processed, yielding");
             task::yield_now().await;
         }
     }
 
-    /// Process a batch of blocks from start to target (up to `batch_size`)
-    fn process_batch(
-        start: u64,
-        target: u64,
-        provider: &Node::Provider,
+    fn process_block(
+        block_number: u64,
+        cached: Option<CachedBlockTrieData>,
         collector: &LiveTrieCollector<'_, Node::Evm, Node::Provider, Storage>,
-        batch_size: usize,
+        provider: &Node::Provider,
+        verification_interval: u64,
     ) -> eyre::Result<()> {
-        let end = (start + batch_size as u64).min(target);
-        debug!(
-            target: "base::exex",
-            start,
-            end,
-            "Processing proofs storage sync batch"
-        );
+        let should_verify =
+            verification_interval > 0 && block_number.is_multiple_of(verification_interval);
 
-        for block_num in (start + 1)..=end {
-            let block = provider
-                .recovered_block(block_num.into(), TransactionVariant::NoHash)?
-                .ok_or_else(|| eyre::eyre!("Missing block {}", block_num))?;
+        if let Some(cached) = cached {
+            let sorted = cached.trie_data.get();
+            if !should_verify {
+                debug!(
+                    target: "base::exex",
+                    block_number,
+                    "Using pre-computed state from notification"
+                );
 
-            collector.execute_and_store_block_updates(&block)?;
+                collector.store_block_updates(
+                    cached.block_with_parent,
+                    (*sorted.trie_updates).clone(),
+                    (*sorted.hashed_state).clone(),
+                )?;
+
+                return Ok(());
+            }
+
+            info!(
+                target: "base::exex",
+                block_number,
+                verification_interval,
+                "Periodic verification: performing full block execution despite cached data"
+            );
+        } else {
+            debug!(
+                target: "base::exex",
+                block_number,
+                "No cached trie data, falling back to full execution"
+            );
         }
 
+        debug!(
+            target: "base::exex",
+            block_number,
+            "Fetching block from provider for execution",
+        );
+
+        let block = provider
+            .recovered_block(block_number.into(), TransactionVariant::NoHash)?
+            .ok_or_else(|| eyre::eyre!("Missing block {} in provider", block_number))?;
+
+        collector.execute_and_store_block_updates(&block)?;
         Ok(())
     }
 
@@ -396,7 +459,7 @@ where
         &self,
         notification: ExExNotification<Primitives>,
         collector: &LiveTrieCollector<'_, Node::Evm, Node::Provider, Storage>,
-        sync_target_tx: &watch::Sender<u64>,
+        sync_target: &SyncTarget,
     ) -> eyre::Result<()> {
         let latest_stored = match self.storage.get_latest_block_number()? {
             Some((n, _)) => n,
@@ -406,12 +469,9 @@ where
         };
 
         match &notification {
-            ExExNotification::ChainCommitted { new } => self.handle_chain_committed(
-                Arc::clone(new),
-                latest_stored,
-                collector,
-                sync_target_tx,
-            )?,
+            ExExNotification::ChainCommitted { new } => {
+                self.handle_chain_committed(Arc::clone(new), latest_stored, sync_target)?
+            }
             ExExNotification::ChainReorged { old, new } => self.handle_chain_reorged(
                 Arc::clone(old),
                 Arc::clone(new),
@@ -424,7 +484,14 @@ where
         }
 
         if let Some(committed_chain) = notification.committed_chain() {
-            self.ctx.events.send(ExExEvent::FinishedHeight(committed_chain.tip().num_hash()))?;
+            let tip = committed_chain.tip().num_hash();
+            debug!(
+                target: "base::exex",
+                block_number = tip.number,
+                block_hash = ?tip.hash,
+                "Sending FinishedHeight event"
+            );
+            self.ctx.events.send(ExExEvent::FinishedHeight(tip))?;
         }
 
         Ok(())
@@ -434,8 +501,7 @@ where
         &self,
         new: Arc<Chain<Primitives>>,
         latest_stored: u64,
-        collector: &LiveTrieCollector<'_, Node::Evm, Node::Provider, Storage>,
-        sync_target_tx: &watch::Sender<u64>,
+        sync_target: &SyncTarget,
     ) -> eyre::Result<()> {
         debug!(
             target: "base::exex",
@@ -444,7 +510,6 @@ where
             "ChainCommitted notification received",
         );
 
-        // If tip is not newer than what we have, nothing to do.
         if new.tip().number() <= latest_stored {
             debug!(
                 target: "base::exex",
@@ -455,111 +520,40 @@ where
             return Ok(());
         }
 
-        let best_block = self.ctx.provider().best_block_number()?;
-        let is_sequential = new.tip().number() == latest_stored + 1;
-        let is_near_tip =
-            best_block.saturating_sub(new.tip().number()) < REAL_TIME_BLOCKS_THRESHOLD;
-
-        if is_sequential && is_near_tip {
-            debug!(
-                target: "base::exex",
-                block_number = new.tip().number(),
-                latest_stored,
-                best_block,
-                "Processing in real-time"
-            );
-
-            // Process each block from latest_stored + 1 to tip
-            let start = latest_stored.saturating_add(1);
-            for block_number in start..=new.tip().number() {
-                self.process_block(block_number, Some(new.as_ref()), collector)?;
-            }
-        } else {
-            debug!(
-                target: "base::exex",
-                block_number = new.tip().number(),
-                latest_stored,
-                best_block,
-                is_sequential,
-                is_near_tip,
-                "Scheduling batch processing via sync task"
-            );
-
-            // Update the sync target to the new tip
-            sync_target_tx.send(new.tip().number())?;
-        }
-
-        Ok(())
-    }
-
-    /// Process a single block - either from chain or provider
-    fn process_block(
-        &self,
-        block_number: u64,
-        chain: Option<&Chain<Primitives>>,
-        collector: &LiveTrieCollector<'_, Node::Evm, Node::Provider, Storage>,
-    ) -> eyre::Result<()> {
-        // Check if this block should be verified via full execution
-        let should_verify = self.verification_interval > 0
-            && block_number.is_multiple_of(self.verification_interval);
-
-        // Try to get block data from the chain first
-        // 1. Fast Path: Try to use pre-computed state from the notification
-        if let Some(block) = chain.and_then(|c| c.blocks().get(&block_number)) {
-            // Check if we have BOTH trie updates and hashed state.
-            // If either is missing, we fall back to execution to ensure data integrity.
-            if let Some((trie_updates, hashed_state)) =
-                chain.and_then(|c| c.trie_data_at(block_number)).map(|d| {
-                    let SortedTrieData { hashed_state, trie_updates } = d.get();
-                    (trie_updates, hashed_state)
-                })
-            {
-                // Use fast path only if we're not scheduled to verify this block
-                if !should_verify {
-                    debug!(
-                        target: "base::exex",
-                        block_number,
-                        "Using pre-computed state updates from notification"
-                    );
-
-                    collector.store_block_updates(
-                        block.block_with_parent(),
-                        (**trie_updates).clone(),
-                        (**hashed_state).clone(),
-                    )?;
-
-                    return Ok(());
-                }
-
-                info!(
+        // Cache trie data for all blocks in the chain so the sync loop can
+        // use pre-computed data even when it is many blocks behind.
+        let total_blocks = new.blocks().len();
+        let mut cached_count = 0usize;
+        for (&block_number, block) in new.blocks() {
+            if let Some(trie_data) = new.trie_data_at(block_number) {
+                sync_target.insert(
+                    block_number,
+                    CachedBlockTrieData {
+                        block_with_parent: block.block_with_parent(),
+                        trie_data: trie_data.clone(),
+                    },
+                );
+                cached_count += 1;
+            } else {
+                debug!(
                     target: "base::exex",
                     block_number,
-                    verification_interval = self.verification_interval,
-                    "Periodic verification: performing full block execution"
+                    "Notification block missing trie data"
                 );
             }
-
-            debug!(
-                target: "base::exex",
-                block_number,
-                "Block present in notification but state updates missing, falling back to execution"
-            );
         }
 
-        // 2. Slow Path: Block not in chain (or state missing), fetch from provider and execute
         debug!(
             target: "base::exex",
-            block_number,
-            "Fetching block from provider for execution",
+            tip = new.tip().number(),
+            total_blocks,
+            cached_count,
+            missing = total_blocks - cached_count,
+            latest_stored,
+            "Cached notification trie data"
         );
 
-        let block = self
-            .ctx
-            .provider()
-            .recovered_block(block_number.into(), TransactionVariant::NoHash)?
-            .ok_or_else(|| eyre::eyre!("Missing block {} in provider", block_number))?;
-
-        collector.execute_and_store_block_updates(&block)?;
+        sync_target.set_target(new.tip().number());
         Ok(())
     }
 
@@ -571,6 +565,7 @@ where
         collector: &LiveTrieCollector<'_, Node::Evm, Node::Provider, Storage>,
     ) -> eyre::Result<()> {
         info!(
+            target: "base::exex",
             old_block_number = old.tip().number(),
             old_block_hash = ?old.tip().hash(),
             new_block_number = new.tip().number(),
@@ -727,7 +722,17 @@ mod tests {
         Chain::new(blocks, execution_outcome, trie_data)
     }
 
-    // Init_storage to the genesis block
+    /// Store blocks directly into proofs storage (bypasses the sync loop).
+    fn store_blocks<S: OpProofsStore>(from: u64, to: u64, storage: &OpProofsStorage<S>) {
+        for n in from..=to {
+            let chain = mk_chain_with_updates(n, n, None);
+            let block = chain.blocks().get(&n).unwrap();
+            storage
+                .store_trie_updates(block.block_with_parent(), BlockStateDiff::default())
+                .expect("store trie update");
+        }
+    }
+
     fn init_storage<S: OpProofsStore>(storage: OpProofsStorage<S>) {
         let genesis_block = NumHash::new(0, b256(0x00));
         storage
@@ -776,16 +781,16 @@ mod tests {
         );
         let exex = build_test_exex(ctx, proofs.clone());
 
-        // Notification: chain committed 1..5
         let new_chain = Arc::new(mk_chain_with_updates(1, 1, None));
         let notif = ExExNotification::ChainCommitted { new: new_chain };
 
-        let (sync_target_tx, _) = tokio::sync::watch::channel(0u64);
+        let sync_target = SyncTarget::new();
 
-        exex.handle_notification(notif, &collector, &sync_target_tx).expect("handle chain commit");
+        exex.handle_notification(notif, &collector, &sync_target).expect("handle chain commit");
 
-        let latest = proofs.get_latest_block_number().expect("get latest block").expect("ok").0;
-        assert_eq!(latest, 1);
+        // Committed blocks are cached in sync target, not stored directly
+        assert_eq!(sync_target.target(), 1);
+        assert!(sync_target.take(1).is_some(), "block 1 should be cached");
     }
 
     #[tokio::test]
@@ -796,6 +801,9 @@ mod tests {
         let proofs: OpProofsStorage<Arc<MdbxProofsStorage>> = Arc::clone(&store).into();
 
         init_storage(proofs.clone());
+
+        // Pre-store blocks 1..5 so storage is at block 5
+        store_blocks(1, 5, &proofs);
 
         let (ctx, _handle) =
             reth_exex_test_utils::test_exex_context().await.expect("exex test context");
@@ -808,22 +816,16 @@ mod tests {
 
         let exex = build_test_exex(ctx, proofs.clone());
 
-        let (sync_target_tx, _) = tokio::sync::watch::channel(0u64);
-        // Process blocks 1..5 sequentially to trigger real-time path (synchronous)
-        for i in 1..=5 {
-            let new_chain = Arc::new(mk_chain_with_updates(i, i, None));
-            let notif = ExExNotification::ChainCommitted { new: new_chain };
-            exex.handle_notification(notif, &collector, &sync_target_tx)
-                .expect("handle chain commit");
-        }
+        let sync_target = SyncTarget::new();
 
-        let latest = proofs.get_latest_block_number().expect("get latest block").expect("ok").0;
-        assert_eq!(latest, 5);
-
-        // Try to handle already processed notification
+        // Try to handle notification for block 5 which is already stored
         let new_chain = Arc::new(mk_chain_with_updates(5, 5, Some(hash_for_num(10))));
         let notif = ExExNotification::ChainCommitted { new: new_chain };
-        exex.handle_notification(notif, &collector, &sync_target_tx).expect("handle chain commit");
+        exex.handle_notification(notif, &collector, &sync_target).expect("handle chain commit");
+
+        // Target should not have been updated since block 5 <= latest_stored
+        assert_eq!(sync_target.target(), 0);
+
         let latest = proofs.get_latest_block_number().expect("get latest block").expect("ok");
         assert_eq!(latest.0, 5);
         assert_eq!(latest.1, hash_for_num(5)); // block was not updated
@@ -837,6 +839,7 @@ mod tests {
         let proofs: OpProofsStorage<Arc<MdbxProofsStorage>> = Arc::clone(&store).into();
 
         init_storage(proofs.clone());
+        store_blocks(1, 10, &proofs);
 
         let (ctx, _handle) =
             reth_exex_test_utils::test_exex_context().await.expect("exex test context");
@@ -849,14 +852,7 @@ mod tests {
 
         let exex = build_test_exex(ctx, proofs.clone());
 
-        let (sync_target_tx, _) = tokio::sync::watch::channel(0u64);
-
-        for i in 1..=10 {
-            let new_chain = Arc::new(mk_chain_with_updates(i, i, None));
-            let notif = ExExNotification::ChainCommitted { new: new_chain };
-            exex.handle_notification(notif, &collector, &sync_target_tx)
-                .expect("handle chain commit");
-        }
+        let sync_target = SyncTarget::new();
 
         let latest = proofs.get_latest_block_number().expect("get latest block").expect("ok").0;
         assert_eq!(latest, 10);
@@ -868,8 +864,7 @@ mod tests {
         // Notification: chain reorged 6..12
         let notif = ExExNotification::ChainReorged { new: new_chain, old: old_chain };
 
-        exex.handle_notification(notif, &collector, &sync_target_tx)
-            .expect("handle chain re-orged");
+        exex.handle_notification(notif, &collector, &sync_target).expect("handle chain re-orged");
         let latest = proofs.get_latest_block_number().expect("get latest block").expect("ok").0;
         assert_eq!(latest, 12);
     }
@@ -882,6 +877,7 @@ mod tests {
         let proofs: OpProofsStorage<Arc<MdbxProofsStorage>> = Arc::clone(&store).into();
 
         init_storage(proofs.clone());
+        store_blocks(1, 10, &proofs);
 
         let (ctx, _handle) =
             reth_exex_test_utils::test_exex_context().await.expect("exex test context");
@@ -894,15 +890,7 @@ mod tests {
 
         let exex = build_test_exex(ctx, proofs.clone());
 
-        let (sync_target_tx, _) = tokio::sync::watch::channel(0u64);
-
-        for i in 1..=10 {
-            let new_chain = Arc::new(mk_chain_with_updates(i, i, None));
-            let notif = ExExNotification::ChainCommitted { new: new_chain };
-
-            exex.handle_notification(notif, &collector, &sync_target_tx)
-                .expect("handle chain commit");
-        }
+        let sync_target = SyncTarget::new();
 
         let latest = proofs.get_latest_block_number().expect("get latest block").expect("ok").0;
         assert_eq!(latest, 10);
@@ -914,8 +902,7 @@ mod tests {
         // Notification: chain reorged 12..15
         let notif = ExExNotification::ChainReorged { new: new_chain, old: old_chain };
 
-        exex.handle_notification(notif, &collector, &sync_target_tx)
-            .expect("handle chain re-orged");
+        exex.handle_notification(notif, &collector, &sync_target).expect("handle chain re-orged");
         let latest = proofs.get_latest_block_number().expect("get latest block").expect("ok").0;
         assert_eq!(latest, 10);
     }
@@ -928,6 +915,7 @@ mod tests {
         let proofs: OpProofsStorage<Arc<MdbxProofsStorage>> = Arc::clone(&store).into();
 
         init_storage(proofs.clone());
+        store_blocks(1, 10, &proofs);
 
         let (ctx, _handle) =
             reth_exex_test_utils::test_exex_context().await.expect("exex test context");
@@ -940,15 +928,7 @@ mod tests {
 
         let exex = build_test_exex(ctx, proofs.clone());
 
-        let (sync_target_tx, _) = tokio::sync::watch::channel(0u64);
-
-        for i in 1..=10 {
-            let new_chain = Arc::new(mk_chain_with_updates(i, i, None));
-            let notif = ExExNotification::ChainCommitted { new: new_chain };
-
-            exex.handle_notification(notif, &collector, &sync_target_tx)
-                .expect("handle chain commit");
-        }
+        let sync_target = SyncTarget::new();
 
         let latest = proofs.get_latest_block_number().expect("get latest block").expect("ok").0;
         assert_eq!(latest, 10);
@@ -959,8 +939,7 @@ mod tests {
         // Notification: chain reverted 9..10
         let notif = ExExNotification::ChainReverted { old: old_chain };
 
-        exex.handle_notification(notif, &collector, &sync_target_tx)
-            .expect("handle chain reverted");
+        exex.handle_notification(notif, &collector, &sync_target).expect("handle chain reverted");
         let latest = proofs.get_latest_block_number().expect("get latest block").expect("ok").0;
         assert_eq!(latest, 8);
     }
@@ -973,6 +952,7 @@ mod tests {
         let proofs: OpProofsStorage<Arc<MdbxProofsStorage>> = Arc::clone(&store).into();
 
         init_storage(proofs.clone());
+        store_blocks(1, 5, &proofs);
 
         let (ctx, _handle) =
             reth_exex_test_utils::test_exex_context().await.expect("exex test context");
@@ -985,27 +965,18 @@ mod tests {
 
         let exex = build_test_exex(ctx, proofs.clone());
 
-        let (sync_target_tx, _) = tokio::sync::watch::channel(0u64);
-
-        for i in 1..=5 {
-            let new_chain = Arc::new(mk_chain_with_updates(i, i, None));
-            let notif = ExExNotification::ChainCommitted { new: new_chain };
-
-            exex.handle_notification(notif, &collector, &sync_target_tx)
-                .expect("handle chain commit");
-        }
+        let sync_target = SyncTarget::new();
 
         let latest = proofs.get_latest_block_number().expect("get latest block").expect("ok").0;
         assert_eq!(latest, 5);
 
-        // Now the tip is 10, and we want to revert from block 9..10
+        // Now the tip is 5, and we want to revert from block 9..10
         let old_chain = Arc::new(mk_chain_with_updates(9, 10, None));
 
         // Notification: chain reverted 9..10
         let notif = ExExNotification::ChainReverted { old: old_chain };
 
-        exex.handle_notification(notif, &collector, &sync_target_tx)
-            .expect("handle chain reverted");
+        exex.handle_notification(notif, &collector, &sync_target).expect("handle chain reverted");
         let latest = proofs.get_latest_block_number().expect("get latest block").expect("ok").0;
         assert_eq!(latest, 5);
     }
@@ -1090,8 +1061,8 @@ mod tests {
         let new_chain = Arc::new(mk_chain_with_updates(1, 5, None));
         let notif = ExExNotification::ChainCommitted { new: new_chain };
 
-        let (sync_target_tx, _) = tokio::sync::watch::channel(0u64);
-        let err = exex.handle_notification(notif, &collector, &sync_target_tx).unwrap_err();
+        let sync_target = SyncTarget::new();
+        let err = exex.handle_notification(notif, &collector, &sync_target).unwrap_err();
         assert_eq!(err.to_string(), "No blocks stored in proofs storage");
     }
 
@@ -1118,19 +1089,14 @@ mod tests {
         let new_chain = Arc::new(mk_chain_with_updates(5, 10, None));
         let notif = ExExNotification::ChainCommitted { new: new_chain };
 
-        let (sync_target_tx, mut sync_target_rx) = tokio::sync::watch::channel(0u64);
+        let sync_target = SyncTarget::new();
 
         // Process notification
-        exex.handle_notification(notif, &collector, &sync_target_tx)
+        exex.handle_notification(notif, &collector, &sync_target)
             .expect("handle chain commit should return ok immediately");
 
-        // Verify async signal was sent
-        // The target in the channel should now be 10 (the tip of the new chain)
-        assert_eq!(
-            *sync_target_rx.borrow_and_update(),
-            10,
-            "Should have scheduled sync to block 10"
-        );
+        // Verify the sync target was updated to the tip of the new chain
+        assert_eq!(sync_target.target(), 10, "Should have scheduled sync to block 10");
 
         // Verify Main Thread did NOT process it
         // Because we didn't spawn the actual worker thread in this test, storage should still be at

--- a/crates/execution/exex/src/lib.rs
+++ b/crates/execution/exex/src/lib.rs
@@ -347,9 +347,11 @@ where
             match state {
                 SyncTargetState::Revert { revert_to } => {
                     Self::handle_revert(&storage, collector, revert_to);
+                    sync_target.mark_revert_complete(&revert_to);
                 }
                 SyncTargetState::RevertThenSync { revert_to, sync_to } => {
                     Self::handle_revert(&storage, collector, revert_to);
+                    sync_target.mark_revert_complete(&revert_to);
                     Self::sync_forward(
                         &sync_target,
                         &storage,
@@ -892,7 +894,7 @@ mod tests {
 
         // New chain blocks should be cached
         for n in 6..=12 {
-            assert!(sync_target.take(n).is_some(), "block {} should be cached", n);
+            assert!(sync_target.take(n).is_some(), "block {n} should be cached");
         }
 
         // Storage unchanged (sync loop handles the actual revert)

--- a/crates/execution/exex/src/lib.rs
+++ b/crates/execution/exex/src/lib.rs
@@ -451,9 +451,13 @@ where
 
             for block_num in (latest + 1)..=end {
                 let cached = sync_target.take(block_num);
-                if let Err(e) =
-                    Self::process_block(block_num, cached, collector, provider, verification_interval)
-                {
+                if let Err(e) = Self::process_block(
+                    block_num,
+                    cached,
+                    collector,
+                    provider,
+                    verification_interval,
+                ) {
                     error!(target: "base::exex", block_number = block_num, error = ?e, "Block processing failed");
                     return;
                 }
@@ -646,11 +650,10 @@ where
             }
         }
 
-        sync_target
-            .update_state(SyncTargetState::RevertThenSync {
-                revert_to: first_old,
-                sync_to: new.tip().number(),
-            });
+        sync_target.update_state(SyncTargetState::RevertThenSync {
+            revert_to: first_old,
+            sync_to: new.tip().number(),
+        });
 
         Ok(())
     }

--- a/crates/execution/exex/src/sync_target.rs
+++ b/crates/execution/exex/src/sync_target.rs
@@ -59,17 +59,12 @@ impl SyncTargetState {
                 Self::RevertThenSync { revert_to, sync_to }
             }
 
-            // If we're currently reverting and syncing, replace the sync to value with the new
+            // If we're currently reverting, replace the sync to value with the new
             // state.
             (
-                Self::RevertThenSync { revert_to, .. },
+                Self::RevertThenSync { revert_to, .. } | Self::Revert { revert_to },
                 Self::SyncUpTo { to },
             ) => Self::RevertThenSync { revert_to: *revert_to, sync_to: to },
-
-            // If we're currently reverting without syncing, add the sync target.
-            (Self::Revert { revert_to }, Self::SyncUpTo { to }) => {
-                Self::RevertThenSync { revert_to: *revert_to, sync_to: to }
-            }
         };
     }
 }
@@ -120,6 +115,32 @@ impl SyncTarget {
     /// Used by the sync loop to consume the next action to perform.
     pub fn take_state(&self) -> Option<SyncTargetState> {
         self.state.lock().expect("SyncTarget lock poisoned").take()
+    }
+
+    /// Notify the sync target that a revert has been processed up to the given block.
+    ///
+    /// Only strips the revert portion if the pending revert target is at or above
+    /// `reverted_to` (i.e. already covered by the completed revert). If a deeper
+    /// revert arrived while processing, the pending state is left unchanged.
+    ///
+    /// - Covered `RevertThenSync` → `SyncUpTo` (keeps the sync target)
+    /// - Covered `Revert` → `None`
+    /// - Deeper revert or other states → unchanged
+    pub fn mark_revert_complete(&self, reverted_to: &BlockWithParent) {
+        let mut state = self.state.lock().expect("SyncTarget lock poisoned");
+        match &*state {
+            Some(SyncTargetState::RevertThenSync { revert_to, sync_to })
+                if revert_to.block.number >= reverted_to.block.number =>
+            {
+                *state = Some(SyncTargetState::SyncUpTo { to: *sync_to });
+            }
+            Some(SyncTargetState::Revert { revert_to })
+                if revert_to.block.number >= reverted_to.block.number =>
+            {
+                *state = None;
+            }
+            _ => {}
+        }
     }
 
     /// Check if there is a pending state without consuming it.
@@ -197,6 +218,18 @@ impl SyncTarget {
                 "Cleared cached entries from block onward"
             );
         }
+    }
+}
+
+impl std::fmt::Debug for SyncTarget {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("SyncTarget")
+            .field(
+                "has_pending_state",
+                &self.state.lock().expect("SyncTarget lock poisoned").is_some(),
+            )
+            .field("cached_blocks", &self.cache.lock().expect("SyncTarget lock poisoned").len())
+            .finish()
     }
 }
 
@@ -348,6 +381,87 @@ mod tests {
         ));
     }
 
+    // ---- mark_revert_complete tests ----
+
+    #[test]
+    fn mark_revert_complete_clears_covered_revert() {
+        let target = SyncTarget::new();
+        let revert_to = block_with_parent(5);
+        target.update_state(SyncTargetState::Revert { revert_to });
+
+        target.mark_revert_complete(&block_with_parent(5));
+        assert!(!target.has_pending_state());
+    }
+
+    #[test]
+    fn mark_revert_complete_strips_covered_revert_then_sync() {
+        let target = SyncTarget::new();
+        let revert_to = block_with_parent(5);
+        target.update_state(SyncTargetState::RevertThenSync { revert_to, sync_to: 20 });
+
+        target.mark_revert_complete(&block_with_parent(5));
+        let state = target.take_state().expect("should have state");
+        assert!(matches!(state, SyncTargetState::SyncUpTo { to: 20 }));
+    }
+
+    #[test]
+    fn mark_revert_complete_keeps_deeper_revert() {
+        let target = SyncTarget::new();
+        // A deeper revert (block 3) arrived while we were reverting to block 5
+        let revert_to = block_with_parent(3);
+        target.update_state(SyncTargetState::Revert { revert_to });
+
+        target.mark_revert_complete(&block_with_parent(5));
+        let state = target.take_state().expect("should still have state");
+        assert!(matches!(
+            state,
+            SyncTargetState::Revert { revert_to } if revert_to.block.number == 3
+        ));
+    }
+
+    #[test]
+    fn mark_revert_complete_keeps_deeper_revert_then_sync() {
+        let target = SyncTarget::new();
+        let revert_to = block_with_parent(3);
+        target.update_state(SyncTargetState::RevertThenSync { revert_to, sync_to: 20 });
+
+        target.mark_revert_complete(&block_with_parent(5));
+        let state = target.take_state().expect("should still have state");
+        assert!(matches!(
+            state,
+            SyncTargetState::RevertThenSync { revert_to, sync_to: 20 }
+            if revert_to.block.number == 3
+        ));
+    }
+
+    #[test]
+    fn mark_revert_complete_clears_shallower_revert() {
+        let target = SyncTarget::new();
+        // Pending revert to block 8 is shallower than what we reverted to (block 5)
+        let revert_to = block_with_parent(8);
+        target.update_state(SyncTargetState::Revert { revert_to });
+
+        target.mark_revert_complete(&block_with_parent(5));
+        assert!(!target.has_pending_state());
+    }
+
+    #[test]
+    fn mark_revert_complete_noop_on_sync_up_to() {
+        let target = SyncTarget::new();
+        target.update_state(SyncTargetState::SyncUpTo { to: 20 });
+
+        target.mark_revert_complete(&block_with_parent(5));
+        let state = target.take_state().expect("should still have state");
+        assert!(matches!(state, SyncTargetState::SyncUpTo { to: 20 }));
+    }
+
+    #[test]
+    fn mark_revert_complete_noop_on_empty() {
+        let target = SyncTarget::new();
+        target.mark_revert_complete(&block_with_parent(5));
+        assert!(!target.has_pending_state());
+    }
+
     // ---- Cache tests ----
 
     #[test]
@@ -443,7 +557,7 @@ mod tests {
         let target = SyncTarget::new();
         target.insert(1, dummy_cached_data(1));
         target.update_state(SyncTargetState::SyncUpTo { to: 5 });
-        let debug_str = format!("{:?}", target);
+        let debug_str = format!("{target:?}");
         assert!(debug_str.contains("SyncTarget"));
         assert!(debug_str.contains("has_pending_state"));
         assert!(debug_str.contains("cached_blocks"));
@@ -467,17 +581,5 @@ mod tests {
 
         let result = handle.await.expect("task should complete");
         assert!(matches!(result, Some(SyncTargetState::SyncUpTo { to: 42 })));
-    }
-}
-
-impl std::fmt::Debug for SyncTarget {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("SyncTarget")
-            .field(
-                "has_pending_state",
-                &self.state.lock().expect("SyncTarget lock poisoned").is_some(),
-            )
-            .field("cached_blocks", &self.cache.lock().expect("SyncTarget lock poisoned").len())
-            .finish()
     }
 }

--- a/crates/execution/exex/src/sync_target.rs
+++ b/crates/execution/exex/src/sync_target.rs
@@ -48,26 +48,27 @@ pub enum SyncTargetState {
 }
 
 impl SyncTargetState {
-    fn apply_next(&mut self, new: SyncTargetState) {
+    const fn apply_next(&mut self, new: Self) {
         *self = match (&*self, new) {
             // If we are just syncing to tip already, replace with the new state.
-            (SyncTargetState::SyncUpTo { .. }, new) => new,
+            (Self::SyncUpTo { .. }, new) => new,
 
             // If the new state is a revert, replace with the new state.
-            (_, SyncTargetState::Revert { revert_to }) => SyncTargetState::Revert { revert_to },
-            (_, SyncTargetState::RevertThenSync { revert_to, sync_to }) => {
-                SyncTargetState::RevertThenSync { revert_to, sync_to }
+            (_, Self::Revert { revert_to }) => Self::Revert { revert_to },
+            (_, Self::RevertThenSync { revert_to, sync_to }) => {
+                Self::RevertThenSync { revert_to, sync_to }
             }
 
             // If we're currently reverting and syncing, replace the sync to value with the new
             // state.
-            (SyncTargetState::RevertThenSync { .. }, SyncTargetState::SyncUpTo { to }) => {
-                SyncTargetState::SyncUpTo { to }
-            }
+            (
+                Self::RevertThenSync { revert_to, .. },
+                Self::SyncUpTo { to },
+            ) => Self::RevertThenSync { revert_to: *revert_to, sync_to: to },
 
             // If we're currently reverting without syncing, add the sync target.
-            (SyncTargetState::Revert { revert_to }, SyncTargetState::SyncUpTo { to }) => {
-                SyncTargetState::RevertThenSync { revert_to: *revert_to, sync_to: to }
+            (Self::Revert { revert_to }, Self::SyncUpTo { to }) => {
+                Self::RevertThenSync { revert_to: *revert_to, sync_to: to }
             }
         };
     }
@@ -97,11 +98,7 @@ impl Default for SyncTarget {
 impl SyncTarget {
     /// Create a new `SyncTarget` with no cached data and no pending state.
     pub fn new() -> Self {
-        Self {
-            cache: Mutex::new(BTreeMap::new()),
-            state: Mutex::new(None),
-            notify: Notify::new(),
-        }
+        Self { cache: Mutex::new(BTreeMap::new()), state: Mutex::new(None), notify: Notify::new() }
     }
 
     /// Update the sync target state and wake the sync loop.
@@ -200,6 +197,276 @@ impl SyncTarget {
                 "Cleared cached entries from block onward"
             );
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use alloy_consensus::private::alloy_primitives::B256;
+    use alloy_eips::{NumHash, eip1898::BlockWithParent};
+    use reth_trie::{HashedPostStateSorted, LazyTrieData, updates::TrieUpdatesSorted};
+
+    use super::*;
+
+    fn b256(byte: u8) -> B256 {
+        B256::new([byte; 32])
+    }
+
+    fn block_with_parent(num: u64) -> BlockWithParent {
+        BlockWithParent::new(b256(num.wrapping_sub(1) as u8), NumHash::new(num, b256(num as u8)))
+    }
+
+    fn dummy_cached_data(num: u64) -> CachedBlockTrieData {
+        CachedBlockTrieData {
+            block_with_parent: block_with_parent(num),
+            trie_data: LazyTrieData::ready(
+                Arc::new(HashedPostStateSorted::default()),
+                Arc::new(TrieUpdatesSorted::default()),
+            ),
+        }
+    }
+
+    // ---- SyncTargetState::apply_next tests ----
+
+    #[test]
+    fn apply_next_sync_replaced_by_sync() {
+        let mut state = SyncTargetState::SyncUpTo { to: 10 };
+        state.apply_next(SyncTargetState::SyncUpTo { to: 20 });
+        assert!(matches!(state, SyncTargetState::SyncUpTo { to: 20 }));
+    }
+
+    #[test]
+    fn apply_next_sync_replaced_by_revert() {
+        let mut state = SyncTargetState::SyncUpTo { to: 10 };
+        let revert_to = block_with_parent(5);
+        state.apply_next(SyncTargetState::Revert { revert_to });
+        assert!(
+            matches!(state, SyncTargetState::Revert { revert_to } if revert_to.block.number == 5)
+        );
+    }
+
+    #[test]
+    fn apply_next_sync_replaced_by_revert_then_sync() {
+        let mut state = SyncTargetState::SyncUpTo { to: 10 };
+        let revert_to = block_with_parent(5);
+        state.apply_next(SyncTargetState::RevertThenSync { revert_to, sync_to: 20 });
+        assert!(matches!(
+            state,
+            SyncTargetState::RevertThenSync { revert_to, sync_to: 20 }
+            if revert_to.block.number == 5
+        ));
+    }
+
+    #[test]
+    fn apply_next_revert_then_sync_keeps_revert_on_new_sync() {
+        let revert_to = block_with_parent(5);
+        let mut state = SyncTargetState::RevertThenSync { revert_to, sync_to: 10 };
+        state.apply_next(SyncTargetState::SyncUpTo { to: 30 });
+        assert!(matches!(
+            state,
+            SyncTargetState::RevertThenSync { revert_to, sync_to: 30 }
+            if revert_to.block.number == 5
+        ));
+    }
+
+    #[test]
+    fn apply_next_revert_then_sync_replaced_by_new_revert() {
+        let revert_to = block_with_parent(5);
+        let mut state = SyncTargetState::RevertThenSync { revert_to, sync_to: 10 };
+        let new_revert = block_with_parent(3);
+        state.apply_next(SyncTargetState::Revert { revert_to: new_revert });
+        assert!(matches!(
+            state,
+            SyncTargetState::Revert { revert_to } if revert_to.block.number == 3
+        ));
+    }
+
+    #[test]
+    fn apply_next_revert_gains_sync_target() {
+        let revert_to = block_with_parent(5);
+        let mut state = SyncTargetState::Revert { revert_to };
+        state.apply_next(SyncTargetState::SyncUpTo { to: 15 });
+        assert!(matches!(
+            state,
+            SyncTargetState::RevertThenSync { revert_to, sync_to: 15 }
+            if revert_to.block.number == 5
+        ));
+    }
+
+    #[test]
+    fn apply_next_revert_replaced_by_revert_then_sync() {
+        let revert_to = block_with_parent(5);
+        let mut state = SyncTargetState::Revert { revert_to };
+        let new_revert = block_with_parent(3);
+        state.apply_next(SyncTargetState::RevertThenSync { revert_to: new_revert, sync_to: 20 });
+        assert!(matches!(
+            state,
+            SyncTargetState::RevertThenSync { revert_to, sync_to: 20 }
+            if revert_to.block.number == 3
+        ));
+    }
+
+    // ---- SyncTarget state management tests ----
+
+    #[test]
+    fn new_sync_target_has_no_state() {
+        let target = SyncTarget::new();
+        assert!(!target.has_pending_state());
+        assert!(target.take_state().is_none());
+    }
+
+    #[test]
+    fn update_state_sets_pending() {
+        let target = SyncTarget::new();
+        target.update_state(SyncTargetState::SyncUpTo { to: 10 });
+        assert!(target.has_pending_state());
+    }
+
+    #[test]
+    fn take_state_clears_pending() {
+        let target = SyncTarget::new();
+        target.update_state(SyncTargetState::SyncUpTo { to: 10 });
+        let state = target.take_state();
+        assert!(matches!(state, Some(SyncTargetState::SyncUpTo { to: 10 })));
+        assert!(!target.has_pending_state());
+    }
+
+    #[test]
+    fn update_state_merges_with_existing() {
+        let target = SyncTarget::new();
+        let revert_to = block_with_parent(5);
+        target.update_state(SyncTargetState::Revert { revert_to });
+        target.update_state(SyncTargetState::SyncUpTo { to: 20 });
+
+        let state = target.take_state().expect("should have state");
+        assert!(matches!(
+            state,
+            SyncTargetState::RevertThenSync { revert_to, sync_to: 20 }
+            if revert_to.block.number == 5
+        ));
+    }
+
+    // ---- Cache tests ----
+
+    #[test]
+    fn insert_and_take_cached_data() {
+        let target = SyncTarget::new();
+        target.insert(42, dummy_cached_data(42));
+
+        let taken = target.take(42);
+        assert!(taken.is_some());
+        assert_eq!(taken.unwrap().block_with_parent.block.number, 42);
+
+        // Second take returns None (was removed)
+        assert!(target.take(42).is_none());
+    }
+
+    #[test]
+    fn take_nonexistent_block_returns_none() {
+        let target = SyncTarget::new();
+        assert!(target.take(999).is_none());
+    }
+
+    #[test]
+    fn clear_from_removes_blocks_at_and_above() {
+        let target = SyncTarget::new();
+        for n in 1..=10 {
+            target.insert(n, dummy_cached_data(n));
+        }
+
+        target.clear_from(6);
+
+        // Blocks 1..=5 remain
+        for n in 1..=5 {
+            assert!(target.take(n).is_some(), "block {n} should still be cached");
+        }
+        // Blocks 6..=10 removed
+        for n in 6..=10 {
+            assert!(target.take(n).is_none(), "block {n} should have been cleared");
+        }
+    }
+
+    #[test]
+    fn clear_from_at_start_clears_everything() {
+        let target = SyncTarget::new();
+        for n in 5..=10 {
+            target.insert(n, dummy_cached_data(n));
+        }
+        target.clear_from(5);
+        for n in 5..=10 {
+            assert!(target.take(n).is_none());
+        }
+    }
+
+    #[test]
+    fn clear_from_beyond_cache_is_noop() {
+        let target = SyncTarget::new();
+        for n in 1..=5 {
+            target.insert(n, dummy_cached_data(n));
+        }
+        target.clear_from(100);
+        for n in 1..=5 {
+            assert!(target.take(n).is_some());
+        }
+    }
+
+    #[test]
+    fn cache_evicts_oldest_when_full() {
+        let target = SyncTarget::new();
+
+        // Fill to capacity + 10
+        for n in 1..=(CACHE_CAPACITY as u64 + 10) {
+            target.insert(n, dummy_cached_data(n));
+        }
+
+        // Oldest 10 blocks should have been evicted
+        for n in 1..=10 {
+            assert!(target.take(n).is_none(), "block {n} should have been evicted");
+        }
+
+        // Block 11 onward should still be present
+        assert!(target.take(11).is_some());
+        assert!(target.take(CACHE_CAPACITY as u64 + 10).is_some());
+    }
+
+    #[test]
+    fn default_creates_empty_sync_target() {
+        let target = SyncTarget::default();
+        assert!(!target.has_pending_state());
+        assert!(target.take(0).is_none());
+    }
+
+    #[test]
+    fn debug_impl_does_not_panic() {
+        let target = SyncTarget::new();
+        target.insert(1, dummy_cached_data(1));
+        target.update_state(SyncTargetState::SyncUpTo { to: 5 });
+        let debug_str = format!("{:?}", target);
+        assert!(debug_str.contains("SyncTarget"));
+        assert!(debug_str.contains("has_pending_state"));
+        assert!(debug_str.contains("cached_blocks"));
+    }
+
+    #[tokio::test]
+    async fn notified_wakes_on_update_state() {
+        let target = Arc::new(SyncTarget::new());
+        let target_clone = Arc::clone(&target);
+
+        // Spawn a task that waits for notification
+        let handle = tokio::spawn(async move {
+            target_clone.notified().await;
+            target_clone.take_state()
+        });
+
+        // Give the task time to start waiting
+        tokio::task::yield_now().await;
+
+        target.update_state(SyncTargetState::SyncUpTo { to: 42 });
+
+        let result = handle.await.expect("task should complete");
+        assert!(matches!(result, Some(SyncTargetState::SyncUpTo { to: 42 })));
     }
 }
 

--- a/crates/execution/exex/src/sync_target.rs
+++ b/crates/execution/exex/src/sync_target.rs
@@ -2,12 +2,15 @@
 //!
 //! Buffers trie data from exex notifications so the sync loop can use
 //! pre-computed data even when it is many blocks behind the chain tip.
+//! Routes committed, reverted, and reorged notifications through a
+//! [`SyncTargetState`] state machine so the sync loop is the single
+//! writer to proofs storage.
 
 use std::{collections::BTreeMap, sync::Mutex};
 
 use alloy_eips::eip1898::BlockWithParent;
 use reth_trie::LazyTrieData;
-use tokio::sync::watch;
+use tokio::sync::Notify;
 use tracing::debug;
 
 /// Maximum number of blocks to cache trie data for.
@@ -22,21 +25,67 @@ pub struct CachedBlockTrieData {
     pub trie_data: LazyTrieData,
 }
 
+/// The state of the sync target, describing what the sync loop should do next.
+#[derive(Debug)]
+pub enum SyncTargetState {
+    /// Sync forward to a specific block number.
+    SyncUpTo {
+        /// The target block number to sync up to.
+        to: u64,
+    },
+    /// Revert to a specific block, then sync forward to a target.
+    RevertThenSync {
+        /// The first block to remove (inclusive) during the revert.
+        revert_to: BlockWithParent,
+        /// The target block number to sync up to after reverting.
+        sync_to: u64,
+    },
+    /// Revert to a specific block without syncing forward.
+    Revert {
+        /// The first block to remove (inclusive) during the revert.
+        revert_to: BlockWithParent,
+    },
+}
+
+impl SyncTargetState {
+    fn apply_next(&mut self, new: SyncTargetState) {
+        *self = match (&*self, new) {
+            // If we are just syncing to tip already, replace with the new state.
+            (SyncTargetState::SyncUpTo { .. }, new) => new,
+
+            // If the new state is a revert, replace with the new state.
+            (_, SyncTargetState::Revert { revert_to }) => SyncTargetState::Revert { revert_to },
+            (_, SyncTargetState::RevertThenSync { revert_to, sync_to }) => {
+                SyncTargetState::RevertThenSync { revert_to, sync_to }
+            }
+
+            // If we're currently reverting and syncing, replace the sync to value with the new
+            // state.
+            (SyncTargetState::RevertThenSync { .. }, SyncTargetState::SyncUpTo { to }) => {
+                SyncTargetState::SyncUpTo { to }
+            }
+
+            // If we're currently reverting without syncing, add the sync target.
+            (SyncTargetState::Revert { revert_to }, SyncTargetState::SyncUpTo { to }) => {
+                SyncTargetState::RevertThenSync { revert_to: *revert_to, sync_to: to }
+            }
+        };
+    }
+}
+
 /// Sync target that buffers trie data from recent exex notifications.
 ///
-/// Uses a `watch` channel to signal target changes to the sync loop. Unlike
-/// `Notify`, `watch::Receiver::changed()` will always detect updates that
-/// occurred since the last call — even if the receiver was busy processing
-/// blocks at the time of the update. This eliminates the race condition where
-/// `Notify::notify_waiters()` fires while the sync loop is not awaiting, causing
-/// the notification to be permanently lost.
+/// Routes all notification types (committed, reverted, reorged) through a
+/// [`SyncTargetState`] state machine so the sync loop is the single writer
+/// to proofs storage. Uses a [`Notify`] to wake the sync loop when new
+/// state is available.
 ///
 /// Trie data is accumulated in a bounded [`BTreeMap`] so the sync loop
 /// can still use pre-computed trie data for blocks from earlier notifications.
 pub struct SyncTarget {
     cache: Mutex<BTreeMap<u64, CachedBlockTrieData>>,
-    target_tx: watch::Sender<u64>,
-    target_rx: watch::Receiver<u64>,
+    state: Mutex<Option<SyncTargetState>>,
+    notify: Notify,
 }
 
 impl Default for SyncTarget {
@@ -46,29 +95,49 @@ impl Default for SyncTarget {
 }
 
 impl SyncTarget {
-    /// Create a new `SyncTarget` with no cached data and target 0.
+    /// Create a new `SyncTarget` with no cached data and no pending state.
     pub fn new() -> Self {
-        let (target_tx, target_rx) = watch::channel(0u64);
-        Self { cache: Mutex::new(BTreeMap::new()), target_tx, target_rx }
+        Self {
+            cache: Mutex::new(BTreeMap::new()),
+            state: Mutex::new(None),
+            notify: Notify::new(),
+        }
     }
 
-    /// Set the sync target block number and wake the sync loop.
+    /// Update the sync target state and wake the sync loop.
     ///
-    /// Only advances the target forward; ignored if `target` is not greater
-    /// than the current value.
-    pub fn set_target(&self, target: u64) {
-        let current = *self.target_tx.borrow();
-        if target > current {
-            debug!(
-                target: "base::exex::sync_target",
-                prev_target = current,
-                new_target = target,
-                cached_blocks = self.cache.lock().expect("SyncTarget lock poisoned").len(),
-                "Sync target advanced"
-            );
-            // send() always succeeds while we hold the receiver.
-            self.target_tx.send(target).expect("watch receiver dropped");
+    /// If there is already a pending state, the new state is merged using
+    /// [`SyncTargetState::apply_next`].
+    pub fn update_state(&self, new: SyncTargetState) {
+        let mut state = self.state.lock().expect("SyncTarget lock poisoned");
+        match state.as_mut() {
+            Some(current) => current.apply_next(new),
+            None => *state = Some(new),
         }
+        drop(state);
+        self.notify.notify_one();
+    }
+
+    /// Take the current pending state, leaving `None` in its place.
+    ///
+    /// Used by the sync loop to consume the next action to perform.
+    pub fn take_state(&self) -> Option<SyncTargetState> {
+        self.state.lock().expect("SyncTarget lock poisoned").take()
+    }
+
+    /// Check if there is a pending state without consuming it.
+    ///
+    /// Used by the sync loop to interrupt forward sync when a higher-priority
+    /// state (e.g. revert) arrives.
+    pub fn has_pending_state(&self) -> bool {
+        self.state.lock().expect("SyncTarget lock poisoned").is_some()
+    }
+
+    /// Wait for a state change notification.
+    ///
+    /// Returns immediately if a notification arrived since the last call.
+    pub async fn notified(&self) {
+        self.notify.notified().await;
     }
 
     /// Insert cached trie data for a block.
@@ -98,11 +167,6 @@ impl SyncTarget {
         );
     }
 
-    /// Get the current sync target block number.
-    pub fn target(&self) -> u64 {
-        *self.target_tx.borrow()
-    }
-
     /// Take cached trie data for a specific block, removing it from the cache.
     pub fn take(&self, block_number: u64) -> Option<CachedBlockTrieData> {
         let result = self.cache.lock().expect("SyncTarget lock poisoned").remove(&block_number);
@@ -122,20 +186,30 @@ impl SyncTarget {
         result
     }
 
-    /// Subscribe to target changes.
+    /// Remove all cached entries at or above the given block number.
     ///
-    /// Returns a `watch::Receiver` that the sync loop uses to detect new
-    /// targets. Unlike `Notify`, a `watch` channel retains the latest value
-    /// so no update is ever missed.
-    pub fn subscribe(&self) -> watch::Receiver<u64> {
-        self.target_rx.clone()
+    /// Used when a revert or reorg invalidates cached blocks.
+    pub fn clear_from(&self, block_number: u64) {
+        let mut cache = self.cache.lock().expect("SyncTarget lock poisoned");
+        let removed = cache.split_off(&block_number);
+        if !removed.is_empty() {
+            debug!(
+                target: "base::exex::sync_target",
+                block_number,
+                cleared = removed.len(),
+                "Cleared cached entries from block onward"
+            );
+        }
     }
 }
 
 impl std::fmt::Debug for SyncTarget {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("SyncTarget")
-            .field("target", &*self.target_tx.borrow())
+            .field(
+                "has_pending_state",
+                &self.state.lock().expect("SyncTarget lock poisoned").is_some(),
+            )
             .field("cached_blocks", &self.cache.lock().expect("SyncTarget lock poisoned").len())
             .finish()
     }

--- a/crates/execution/exex/src/sync_target.rs
+++ b/crates/execution/exex/src/sync_target.rs
@@ -1,0 +1,142 @@
+//! Sync target with trie data cache for the background sync loop.
+//!
+//! Buffers trie data from exex notifications so the sync loop can use
+//! pre-computed data even when it is many blocks behind the chain tip.
+
+use std::{collections::BTreeMap, sync::Mutex};
+
+use alloy_eips::eip1898::BlockWithParent;
+use reth_trie::LazyTrieData;
+use tokio::sync::watch;
+use tracing::debug;
+
+/// Maximum number of blocks to cache trie data for.
+const CACHE_CAPACITY: usize = 1024;
+
+/// Cached trie data for a single block.
+#[derive(Debug)]
+pub struct CachedBlockTrieData {
+    /// The block identifier with its parent hash.
+    pub block_with_parent: BlockWithParent,
+    /// The lazy trie data (hashed state + trie updates).
+    pub trie_data: LazyTrieData,
+}
+
+/// Sync target that buffers trie data from recent exex notifications.
+///
+/// Uses a `watch` channel to signal target changes to the sync loop. Unlike
+/// `Notify`, `watch::Receiver::changed()` will always detect updates that
+/// occurred since the last call — even if the receiver was busy processing
+/// blocks at the time of the update. This eliminates the race condition where
+/// `Notify::notify_waiters()` fires while the sync loop is not awaiting, causing
+/// the notification to be permanently lost.
+///
+/// Trie data is accumulated in a bounded [`BTreeMap`] so the sync loop
+/// can still use pre-computed trie data for blocks from earlier notifications.
+pub struct SyncTarget {
+    cache: Mutex<BTreeMap<u64, CachedBlockTrieData>>,
+    target_tx: watch::Sender<u64>,
+    target_rx: watch::Receiver<u64>,
+}
+
+impl Default for SyncTarget {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl SyncTarget {
+    /// Create a new `SyncTarget` with no cached data and target 0.
+    pub fn new() -> Self {
+        let (target_tx, target_rx) = watch::channel(0u64);
+        Self { cache: Mutex::new(BTreeMap::new()), target_tx, target_rx }
+    }
+
+    /// Set the sync target block number and wake the sync loop.
+    ///
+    /// Only advances the target forward; ignored if `target` is not greater
+    /// than the current value.
+    pub fn set_target(&self, target: u64) {
+        let current = *self.target_tx.borrow();
+        if target > current {
+            debug!(
+                target: "base::exex::sync_target",
+                prev_target = current,
+                new_target = target,
+                cached_blocks = self.cache.lock().expect("SyncTarget lock poisoned").len(),
+                "Sync target advanced"
+            );
+            // send() always succeeds while we hold the receiver.
+            self.target_tx.send(target).expect("watch receiver dropped");
+        }
+    }
+
+    /// Insert cached trie data for a block.
+    ///
+    /// Evicts the oldest entries when the cache exceeds capacity.
+    pub fn insert(&self, block_number: u64, data: CachedBlockTrieData) {
+        let mut cache = self.cache.lock().expect("SyncTarget lock poisoned");
+        cache.insert(block_number, data);
+        let mut evicted = 0u64;
+        while cache.len() > CACHE_CAPACITY {
+            cache.pop_first();
+            evicted += 1;
+        }
+        if evicted > 0 {
+            debug!(
+                target: "base::exex::sync_target",
+                block_number,
+                evicted,
+                "Cache full, evicted oldest entries"
+            );
+        }
+        debug!(
+            target: "base::exex::sync_target",
+            block_number,
+            cached_blocks = cache.len(),
+            "Cached trie data for block"
+        );
+    }
+
+    /// Get the current sync target block number.
+    pub fn target(&self) -> u64 {
+        *self.target_tx.borrow()
+    }
+
+    /// Take cached trie data for a specific block, removing it from the cache.
+    pub fn take(&self, block_number: u64) -> Option<CachedBlockTrieData> {
+        let result = self.cache.lock().expect("SyncTarget lock poisoned").remove(&block_number);
+        if result.is_some() {
+            debug!(
+                target: "base::exex::sync_target",
+                block_number,
+                "Cache hit: trie data found for block"
+            );
+        } else {
+            debug!(
+                target: "base::exex::sync_target",
+                block_number,
+                "Cache miss: no trie data for block, will re-execute"
+            );
+        }
+        result
+    }
+
+    /// Subscribe to target changes.
+    ///
+    /// Returns a `watch::Receiver` that the sync loop uses to detect new
+    /// targets. Unlike `Notify`, a `watch` channel retains the latest value
+    /// so no update is ever missed.
+    pub fn subscribe(&self) -> watch::Receiver<u64> {
+        self.target_rx.clone()
+    }
+}
+
+impl std::fmt::Debug for SyncTarget {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("SyncTarget")
+            .field("target", &*self.target_tx.borrow())
+            .field("cached_blocks", &self.cache.lock().expect("SyncTarget lock poisoned").len())
+            .finish()
+    }
+}

--- a/crates/execution/trie/src/live.rs
+++ b/crates/execution/trie/src/live.rs
@@ -12,7 +12,7 @@ use reth_provider::{
 };
 use reth_revm::database::StateProviderDatabase;
 use reth_trie_common::{HashedPostStateSorted, updates::TrieUpdatesSorted};
-use tracing::info;
+use tracing::{info, warn};
 
 use crate::{
     BlockStateDiff, OpProofsStorage, OpProofsStorageError, OpProofsStore,
@@ -145,9 +145,26 @@ where
         let start = Instant::now();
         let mut operation_durations = OperationDurations::default();
 
-        let storage_result = self
+        let storage_result = match self
             .storage
-            .store_trie_updates(block, BlockStateDiff { sorted_trie_updates, sorted_post_state })?;
+            .store_trie_updates(block, BlockStateDiff { sorted_trie_updates, sorted_post_state })
+        {
+            Ok(res) => res,
+            Err(OpProofsStorageError::OutOfOrder {
+                block_number,
+                latest_block_hash,
+                parent_block_hash,
+            }) => {
+                warn!(
+                    block_number,
+                    ?latest_block_hash,
+                    ?parent_block_hash,
+                    "Skipping out of order block updates"
+                );
+                return Ok(());
+            }
+            Err(e) => return Err(e),
+        };
 
         let write_duration = start.elapsed();
         operation_durations.total_duration_seconds = write_duration;


### PR DESCRIPTION
# Description

ExEx notifications sometimes include `TrieUpdates` and `HashedPostState` if they are close to the tip of the chain. However, the current proofs ExEx would only attempt to extract these if it's applying a single block extension. When we're using `base-consensus follow`, we're always ~512 blocks behind, so we almost never use the fast syncing path unless we're close to tip.

This PR modifies the ExEx proofs syncing process. Notifications are now processed immediately. Most notifications should be `CanonicalChainCommitted` which tell the ExEx to sync forward to a block.

The `SyncTarget` struct keeps track of two things:
- the `SyncTargetState`: a state machine that tells the ExEx what to do next
- a cache of block number to `CachedBlockTrieData`: this keeps the execution/state root result of the latest 1024 blocks that we receive

When we receive a revert/reorg notification, we clear the cache, and update the state machine with a RevertThenSync or Revert state. When the sync loop processes this state, it removes data for these blocks from the database, then continues syncing to tip.