### PR TITLE
fix(consensus): Small Sealing Bugs

### DIFF
--- a/crates/consensus/service/src/actors/sequencer/actor.rs
+++ b/crates/consensus/service/src/actors/sequencer/actor.rs
@@ -10,6 +10,7 @@ use async_trait::async_trait;
 use base_consensus_derive::AttributesBuilder;
 use base_consensus_genesis::RollupConfig;
 use base_consensus_rpc::SequencerAdminAPIError;
+use base_protocol::L2BlockInfo;
 use tokio::{
     select,
     sync::{mpsc, oneshot},
@@ -26,8 +27,7 @@ use crate::{
             conductor::Conductor,
             error::SequencerActorError,
             metrics::{
-                inc_seal_error, inc_seal_pipeline_overlap, update_seal_duration_metrics,
-                update_total_transactions_sequenced,
+                inc_seal_error, update_seal_duration_metrics, update_total_transactions_sequenced,
             },
             origin_selector::OriginSelector,
             recovery::RecoveryModeGuard,
@@ -68,6 +68,14 @@ pub struct SequencerActor<
     pub engine_client: Arc<SequencerEngineClient_>,
     /// Whether the sequencer is active.
     pub is_active: bool,
+    /// Expected [`L2BlockInfo`] parent for the next build.
+    ///
+    /// Set in the ticker arm when a seal succeeds (derived from the sealed envelope). Consumed
+    /// in the `Ok(true)` sealer arm via [`PayloadBuilder::build_on`], which is called after
+    /// `insert_unsafe_payload` has already been fire-and-forgot to the engine. This ordering
+    /// guarantees the engine's `InsertTask` is queued before `BuildTask`, so the EL always
+    /// builds on the correct (just-inserted) parent instead of the stale watch value.
+    pub next_build_parent: Option<L2BlockInfo>,
     /// Shared recovery mode flag.
     pub recovery_mode: RecoveryModeGuard,
     /// The rollup configuration.
@@ -126,11 +134,20 @@ where
     /// If the EL is still syncing (snap sync in progress), the engine will defer the reset and
     /// return [`EngineClientError::ELSyncing`]. In that case we wait one block time and retry,
     /// so we never send a `forkchoice_updated` that would abort reth's in-progress EL sync.
-    async fn schedule_initial_reset(&self) -> Result<(), SequencerActorError> {
+    ///
+    /// Admin API queries are serviced throughout — both during reset attempts and during the
+    /// backoff sleep — so that control can reach the sequencer while EL sync is in progress.
+    async fn schedule_initial_reset(
+        &mut self,
+        next_payload: &mut Option<UnsealedPayloadHandle>,
+    ) -> Result<(), SequencerActorError> {
         loop {
             select! {
                 biased;
                 _ = self.cancellation_token.cancelled() => return Ok(()),
+                Some(query) = self.admin_api_rx.recv() => {
+                    self.handle_admin_query(next_payload, query).await;
+                }
                 result = self.engine_client.reset_engine_forkchoice() => match result {
                     Ok(()) => return Ok(()),
                     Err(EngineClientError::ELSyncing) => {
@@ -142,11 +159,19 @@ where
                     }
                 },
             }
-            // Wait one block time before retrying, but honour cancellation.
-            select! {
-                biased;
-                _ = self.cancellation_token.cancelled() => return Ok(()),
-                _ = tokio::time::sleep(Duration::from_secs(self.rollup_config.block_time)) => {}
+            // Wait one block time before retrying the reset, but service admin queries
+            // and honour cancellation throughout the backoff window.
+            let sleep = tokio::time::sleep(Duration::from_secs(self.rollup_config.block_time));
+            tokio::pin!(sleep);
+            loop {
+                select! {
+                    biased;
+                    _ = self.cancellation_token.cancelled() => return Ok(()),
+                    Some(query) = self.admin_api_rx.recv() => {
+                        self.handle_admin_query(next_payload, query).await;
+                    }
+                    _ = &mut sleep => break,
+                }
             }
         }
     }
@@ -183,10 +208,11 @@ where
 
         self.update_metrics();
 
-        // Reset the engine state prior to beginning block building.
-        self.schedule_initial_reset().await?;
-
         let mut next_payload_to_seal: Option<UnsealedPayloadHandle> = None;
+
+        // Reset the engine state prior to beginning block building.
+        // Admin API queries are serviced during this phase (see schedule_initial_reset).
+        self.schedule_initial_reset(&mut next_payload_to_seal).await?;
         let mut last_seal_duration = Duration::from_secs(0);
         loop {
             select! {
@@ -198,58 +224,15 @@ where
                 Some(query) = self.admin_api_rx.recv() => {
                     let active_before = self.is_active;
 
-                    self.handle_admin_query(query).await;
+                    self.handle_admin_query(&mut next_payload_to_seal, query).await;
 
                     if !active_before && self.is_active {
                         build_ticker.reset_immediately();
                     }
                 }
-                _ = build_ticker.tick(), if self.is_active => {
-                    if let Some(handle) = next_payload_to_seal.take() {
-                        if self.sealer.is_some() {
-                            error!(target: "sequencer", "Seal pipeline did not complete before next block was sealed");
-                            inc_seal_pipeline_overlap();
-                            self.sealer = None;
-                        }
-
-                        let seal_start = Instant::now();
-                        match self.seal_payload(&handle).await {
-                            Ok(new_sealer) => {
-                                last_seal_duration = seal_start.elapsed();
-                                self.sealer = Some(new_sealer);
-                            }
-                            Err(SequencerActorError::EngineError(EngineClientError::SealError(err))) => {
-                                if err.is_fatal() {
-                                    error!(target: "sequencer", error = ?err, "Critical seal task error occurred");
-                                    inc_seal_error(true);
-                                    self.cancellation_token.cancel();
-                                    return Err(SequencerActorError::EngineError(EngineClientError::SealError(err)));
-                                }
-                                warn!(target: "sequencer", error = ?err, "Non-fatal seal error, dropping block");
-                                inc_seal_error(false);
-                            }
-                            Err(other_err) => {
-                                error!(target: "sequencer", error = ?other_err, "Unexpected error sealing payload");
-                                self.cancellation_token.cancel();
-                                return Err(other_err);
-                            }
-                        }
-                    }
-
-                    next_payload_to_seal = self.builder.build().await?;
-
-                    if let Some(ref payload) = next_payload_to_seal {
-                        let next_block_seconds = payload.attributes_with_parent.parent().block_info.timestamp.saturating_add(self.rollup_config.block_time);
-                        let next_block_time = UNIX_EPOCH + Duration::from_secs(next_block_seconds) - last_seal_duration;
-                        match next_block_time.duration_since(SystemTime::now()) {
-                            Ok(duration) => build_ticker.reset_after(duration),
-                            Err(_) => build_ticker.reset_immediately(),
-                        };
-                    } else {
-                        build_ticker.reset_immediately();
-                    }
-                }
-                // Drive the seal pipeline (commit → gossip → insert) one step at a time.
+                // Drive the seal pipeline (commit → gossip → insert) one step per iteration.
+                // The ticker arm is gated on `sealer.is_none()` so the two are mutually
+                // exclusive — when a seal is in-flight the ticker cannot fire and interrupt it.
                 Some(result) = async {
                     match self.sealer.as_mut() {
                         Some(s) => Some(s.step(
@@ -263,17 +246,166 @@ where
                     match result {
                         Ok(true) => {
                             self.sealer = None;
+                            // Respond to a pending stop_sequencer request now that the
+                            // in-flight seal is complete.
                             if let Some(tx) = self.pending_stop.take() {
                                 let result = self.resolve_stop_head().await;
                                 if tx.send(result).is_err() {
                                     warn!(target: "sequencer", "Failed to send deferred stop_sequencer response");
                                 }
                             }
+                            // Build the next payload on the correct parent now that
+                            // insert_unsafe_payload has already been fire-and-forgot to the engine.
+                            // next_build_parent was computed from the sealed envelope in the ticker
+                            // arm; using it here ensures InsertTask is enqueued before BuildTask so
+                            // the EL builds on the just-inserted block instead of its grandparent.
+                            if self.is_active {
+                                next_payload_to_seal =
+                                    if let Some(parent) = self.next_build_parent.take() {
+                                        let result = self.builder.build_on(parent).await?;
+                                        // If the build returned None (the just-inserted parent block
+                                        // is not yet indexed by the L2 provider — insert_unsafe_payload
+                                        // is fire-and-forgot), restore next_build_parent so the
+                                        // immediate ticker retry uses build_on with the known correct
+                                        // parent rather than the potentially stale watch head, which
+                                        // could cause the wrong block to be built.
+                                        if result.is_none() {
+                                            self.next_build_parent = Some(parent);
+                                            build_ticker.reset_immediately();
+                                        }
+                                        result
+                                    } else {
+                                        self.builder.build().await?
+                                    };
+                            }
                         }
                         Ok(false) => {}
                         Err(err) => {
                             let step = self.sealer.as_ref().map(|s| s.state.label()).unwrap_or("unknown");
                             warn!(target: "sequencer", error = ?err, step, "Seal step failed, will retry");
+                        }
+                    }
+                }
+                // Tick is gated on `self.sealer.is_none()` to make the ticker and sealer arms
+                // mutually exclusive. In catch-up mode reset_immediately() fires every tick,
+                // making the ticker Poll::Ready at the same time as the sealer's step().await
+                // is Poll::Pending. Disabling the ticker while a seal is in-flight lets the
+                // sealer arm complete all three steps (commit → gossip → insert) before the
+                // next block starts, so the canonical head actually advances.
+                _ = build_ticker.tick(), if self.is_active && self.sealer.is_none() => {
+                    if let Some(handle) = next_payload_to_seal.take() {
+                        let seal_start = Instant::now();
+                        match self.seal_payload(&handle).await {
+                            Ok(new_sealer) => {
+                                last_seal_duration = seal_start.elapsed();
+                                // Stash the expected parent for the next build. This is consumed
+                                // in the Ok(true) arm after insert_unsafe_payload is queued,
+                                // ensuring BuildTask is enqueued after InsertTask in the engine.
+                                self.next_build_parent = match L2BlockInfo::from_payload_and_genesis(
+                                    new_sealer.envelope.execution_payload.clone(),
+                                    handle.attributes_with_parent.attributes().payload_attributes.parent_beacon_block_root,
+                                    &self.rollup_config.genesis,
+                                ) {
+                                    Ok(parent) => Some(parent),
+                                    Err(err) => {
+                                        warn!(
+                                            target: "sequencer",
+                                            error = ?err,
+                                            "Failed to derive L2BlockInfo from sealed payload; \
+                                             next build will fall back to unsafe head watch channel"
+                                        );
+                                        None
+                                    }
+                                };
+                                self.sealer = Some(new_sealer);
+                                // Schedule the next tick for the next block's target seal time.
+                                // Use the just-sealed block's timestamp; the next block's
+                                // timestamp is one block_time later.
+                                let next_block_seconds = handle
+                                    .attributes_with_parent
+                                    .attributes()
+                                    .payload_attributes
+                                    .timestamp
+                                    .saturating_add(self.rollup_config.block_time);
+                                let next_block_time = UNIX_EPOCH
+                                    + Duration::from_secs(next_block_seconds)
+                                    - last_seal_duration;
+                                match next_block_time.duration_since(SystemTime::now()) {
+                                    Ok(duration) => build_ticker.reset_after(duration),
+                                    Err(_) => build_ticker.reset_immediately(),
+                                }
+                                // Do not call build() here. The next payload is built in the
+                                // Ok(true) arm after insert_unsafe_payload has been queued,
+                                // so InsertTask always precedes BuildTask in the engine queue.
+                            }
+                            Err(SequencerActorError::EngineError(EngineClientError::SealError(err))) => {
+                                if err.is_fatal() {
+                                    error!(target: "sequencer", error = ?err, "Critical seal task error occurred");
+                                    inc_seal_error(true);
+                                    self.cancellation_token.cancel();
+                                    return Err(SequencerActorError::EngineError(EngineClientError::SealError(err)));
+                                }
+                                warn!(target: "sequencer", error = ?err, "Non-fatal seal error, dropping block");
+                                inc_seal_error(false);
+                                // Rebuild immediately on the current unsafe head.
+                                next_payload_to_seal = self.builder.build().await?;
+                                if let Some(ref payload) = next_payload_to_seal {
+                                    let next_block_seconds = payload
+                                        .attributes_with_parent
+                                        .parent()
+                                        .block_info
+                                        .timestamp
+                                        .saturating_add(self.rollup_config.block_time);
+                                    let next_block_time = UNIX_EPOCH
+                                        + Duration::from_secs(next_block_seconds)
+                                        - last_seal_duration;
+                                    match next_block_time.duration_since(SystemTime::now()) {
+                                        Ok(duration) => build_ticker.reset_after(duration),
+                                        Err(_) => build_ticker.reset_immediately(),
+                                    }
+                                } else {
+                                    build_ticker.reset_immediately();
+                                }
+                            }
+                            Err(other_err) => {
+                                error!(target: "sequencer", error = ?other_err, "Unexpected error sealing payload");
+                                self.cancellation_token.cancel();
+                                return Err(other_err);
+                            }
+                        }
+                    } else {
+                        // No pre-built payload: bootstrap on first tick, or retry after the
+                        // Ok(true) arm's build_on failed due to the parent block not yet being
+                        // indexed (insert_unsafe_payload is fire-and-forgot). If next_build_parent
+                        // is set, use build_on with the known correct parent rather than reading
+                        // the potentially stale watch head, which could cause the wrong block to
+                        // be built. On failure restore next_build_parent and reset_immediately so
+                        // we retry as soon as the engine indexes the block.
+                        next_payload_to_seal = if let Some(parent) = self.next_build_parent.take() {
+                            let result = self.builder.build_on(parent).await?;
+                            if result.is_none() {
+                                self.next_build_parent = Some(parent);
+                            }
+                            result
+                        } else {
+                            self.builder.build().await?
+                        };
+                        if let Some(ref payload) = next_payload_to_seal {
+                            let next_block_seconds = payload
+                                .attributes_with_parent
+                                .parent()
+                                .block_info
+                                .timestamp
+                                .saturating_add(self.rollup_config.block_time);
+                            let next_block_time = UNIX_EPOCH
+                                + Duration::from_secs(next_block_seconds)
+                                - last_seal_duration;
+                            match next_block_time.duration_since(SystemTime::now()) {
+                                Ok(duration) => build_ticker.reset_after(duration),
+                                Err(_) => build_ticker.reset_immediately(),
+                            }
+                        } else {
+                            build_ticker.reset_immediately();
                         }
                     }
                 }

--- a/crates/consensus/service/src/actors/sequencer/admin_api_impl.rs
+++ b/crates/consensus/service/src/actors/sequencer/admin_api_impl.rs
@@ -5,6 +5,7 @@ use tokio::sync::oneshot;
 
 use super::{
     SequencerActor,
+    build::UnsealedPayloadHandle,
     metrics::{inc_start_rejected, inc_stop_deferred},
 };
 use crate::{Conductor, OriginSelector, SequencerEngineClient, UnsafePayloadGossipClient};
@@ -54,7 +55,11 @@ where
 {
     /// Handles the provided [`SequencerAdminQuery`], sending the response via the provided sender.
     /// This function is used to decouple admin API logic from the response mechanism (channels).
-    pub(super) async fn handle_admin_query(&mut self, query: SequencerAdminQuery) {
+    pub(super) async fn handle_admin_query(
+        &mut self,
+        next_payload: &mut Option<UnsealedPayloadHandle>,
+        query: SequencerAdminQuery,
+    ) {
         match query {
             SequencerAdminQuery::SequencerActive(tx) => {
                 if tx.send(self.is_sequencer_active().await).is_err() {
@@ -67,7 +72,7 @@ where
                 }
             }
             SequencerAdminQuery::StopSequencer(tx) => {
-                self.stop_sequencer(tx).await;
+                self.stop_sequencer(next_payload, tx).await;
             }
             SequencerAdminQuery::ConductorEnabled(tx) => {
                 if tx.send(self.is_conductor_enabled().await).is_err() {
@@ -178,12 +183,18 @@ where
 
     /// Stops the sequencer. If a seal pipeline is in-flight, the response is deferred
     /// until the pipeline completes so the returned hash reflects the fully inserted head.
+    ///
+    /// Any pre-built payload that has not yet been sealed is discarded so that a subsequent
+    /// restart always builds on a fresh, accurate head rather than a potentially stale one.
     pub(super) async fn stop_sequencer(
         &mut self,
+        next_payload: &mut Option<UnsealedPayloadHandle>,
         tx: oneshot::Sender<Result<B256, SequencerAdminAPIError>>,
     ) {
         info!(target: "sequencer", "Stopping sequencer");
         self.is_active = false;
+        // Discard any pre-built payload so a subsequent start_sequencer always builds fresh.
+        next_payload.take();
         self.update_metrics();
 
         if self.sealer.is_some() {

--- a/crates/consensus/service/src/actors/sequencer/admin_api_impl.rs
+++ b/crates/consensus/service/src/actors/sequencer/admin_api_impl.rs
@@ -184,7 +184,7 @@ where
     /// Stops the sequencer. If a seal pipeline is in-flight, the response is deferred
     /// until the pipeline completes so the returned hash reflects the fully inserted head.
     ///
-    /// Any pre-built payload that has not yet been sealed is discarded so that a subsequent
+    /// Any pre-built payload and stashed `next_build_parent` are discarded so that a subsequent
     /// restart always builds on a fresh, accurate head rather than a potentially stale one.
     pub(super) async fn stop_sequencer(
         &mut self,
@@ -193,8 +193,10 @@ where
     ) {
         info!(target: "sequencer", "Stopping sequencer");
         self.is_active = false;
-        // Discard any pre-built payload so a subsequent start_sequencer always builds fresh.
+        // Discard any pre-built payload and stashed parent so a subsequent start_sequencer
+        // always builds on a fresh, accurate head rather than a potentially stale one.
         next_payload.take();
+        self.next_build_parent = None;
         self.update_metrics();
 
         if self.sealer.is_some() {

--- a/crates/consensus/service/src/actors/sequencer/build.rs
+++ b/crates/consensus/service/src/actors/sequencer/build.rs
@@ -58,26 +58,41 @@ pub struct PayloadBuilder<A: AttributesBuilder, O: OriginSelector, E: SequencerE
 impl<A: AttributesBuilder, O: OriginSelector, E: SequencerEngineClient> PayloadBuilder<A, O, E> {
     /// Starts building the next L2 block, returning a handle to the in-flight payload.
     ///
+    /// Uses the engine's current unsafe head (from the watch channel) as the parent.
     /// Returns `Ok(None)` for temporary or reset conditions that should be retried on the
     /// next tick.
     pub async fn build(&mut self) -> Result<Option<UnsealedPayloadHandle>, SequencerActorError> {
         let unsafe_head = self.engine_client.get_unsafe_head().await?;
+        self.build_on(unsafe_head).await
+    }
 
-        let Some(l1_origin) = self.get_next_payload_l1_origin(unsafe_head).await? else {
+    /// Starts building the next L2 block on top of an explicit `parent`, returning a handle to
+    /// the in-flight payload.
+    ///
+    /// Unlike [`Self::build`], this bypasses the watch channel and uses the provided
+    /// `parent` directly. Call this when the correct parent is already known (e.g., the
+    /// block just sealed) to avoid racing against the engine's internal state update.
+    ///
+    /// Returns `Ok(None)` for temporary or reset conditions that should be retried on the
+    /// next tick.
+    pub async fn build_on(
+        &mut self,
+        parent: L2BlockInfo,
+    ) -> Result<Option<UnsealedPayloadHandle>, SequencerActorError> {
+        let Some(l1_origin) = self.get_next_payload_l1_origin(parent).await? else {
             return Ok(None);
         };
 
         info!(
             target: "sequencer",
-            parent_num = unsafe_head.block_info.number,
+            parent_num = parent.block_info.number,
             l1_origin_num = l1_origin.number,
             "Started sequencing new block"
         );
 
         let attributes_build_start = Instant::now();
 
-        let Some(attributes_with_parent) = self.build_attributes(unsafe_head, l1_origin).await?
-        else {
+        let Some(attributes_with_parent) = self.build_attributes(parent, l1_origin).await? else {
             return Ok(None);
         };
 
@@ -149,15 +164,26 @@ impl<A: AttributesBuilder, O: OriginSelector, E: SequencerEngineClient> PayloadB
         {
             Ok(attrs) => attrs,
             Err(PipelineErrorKind::Temporary(_)) => return Ok(None),
-            Err(PipelineErrorKind::Reset(_)) => {
-                if let Err(err) = self.engine_client.reset_engine_forkchoice().await {
-                    error!(target: "sequencer", ?err, "Failed to reset engine");
-                    return Err(SequencerActorError::ChannelClosed);
-                }
-
+            Err(PipelineErrorKind::Reset(err)) => {
+                // The attributes builder returned a reset error. These errors fall into two
+                // categories, neither of which requires an engine reset here:
+                //
+                // 1. L1 origin inconsistency (BlockMismatch / BlockMismatchEpochReset):
+                //    `get_next_payload_l1_origin` already validates L1 origin consistency and
+                //    calls `reset_engine_forkchoice` if it detects a mismatch. If execution
+                //    reaches `build_attributes`, the L1 origin passed in was already validated.
+                //    Any residual mismatch is a transient provider race that resolves on retry.
+                //
+                // 2. BrokenTimeInvariant: the next L2 timestamp would precede the selected L1
+                //    block's timestamp. This is a timing condition — the origin selector will
+                //    pick a different L1 block on the next tick. Engine reset would rewind the
+                //    unsafe head to the safe head, discarding sequenced progress unnecessarily.
+                //
+                // Return Ok(None) and let the ticker retry on the next block interval.
                 warn!(
                     target: "sequencer",
-                    "Resetting engine due to pipeline error while preparing payload attributes"
+                    error = ?err,
+                    "Pipeline reset error while preparing payload attributes, retrying on next tick"
                 );
                 return Ok(None);
             }

--- a/crates/consensus/service/src/actors/sequencer/metrics.rs
+++ b/crates/consensus/service/src/actors/sequencer/metrics.rs
@@ -93,11 +93,6 @@ pub(super) fn update_seal_step_duration(_step: &'static str, _duration: Duration
 }
 
 #[inline]
-pub(super) fn inc_seal_pipeline_overlap() {
-    base_macros::inc!(counter, crate::Metrics::SEQUENCER_SEAL_PIPELINE_OVERLAP_TOTAL);
-}
-
-#[inline]
 pub(super) fn inc_seal_error(fatal: bool) {
     let _label = if fatal { "true" } else { "false" };
     base_macros::inc!(counter, crate::Metrics::SEQUENCER_SEAL_ERROR_TOTAL, "fatal" => _label);

--- a/crates/consensus/service/src/actors/sequencer/tests/actor_test.rs
+++ b/crates/consensus/service/src/actors/sequencer/tests/actor_test.rs
@@ -66,9 +66,9 @@ async fn test_build_unsealed_payload_prepare_payload_attributes_error(
     let unsafe_head = L2BlockInfo::default();
     client.expect_get_unsafe_head().times(1).return_once(move || Ok(unsafe_head));
     client.expect_start_build_block().times(0);
-    if let PipelineErrorKind::Reset(_) = &forced_error {
-        client.expect_reset_engine_forkchoice().times(1).return_once(move || Ok(()));
-    }
+    // Reset pipeline errors no longer trigger engine reset — the attributes builder is stateless
+    // so resetting the engine would only rewind the unsafe head without aiding recovery.
+    client.expect_reset_engine_forkchoice().times(0);
 
     let l1_origin = BlockInfo::default();
     let mut origin_selector = MockOriginSelector::new();

--- a/crates/consensus/service/src/actors/sequencer/tests/admin_api_impl_test.rs
+++ b/crates/consensus/service/src/actors/sequencer/tests/admin_api_impl_test.rs
@@ -26,7 +26,7 @@ async fn test_is_sequencer_active(
             false => actor.is_sequencer_active().await,
             true => {
                 let (tx, rx) = oneshot::channel();
-                actor.handle_admin_query(SequencerAdminQuery::SequencerActive(tx)).await;
+                actor.handle_admin_query(&mut None, SequencerAdminQuery::SequencerActive(tx)).await;
                 rx.await.unwrap()
             }
         }
@@ -53,7 +53,9 @@ async fn test_is_conductor_enabled(
             false => actor.is_conductor_enabled().await,
             true => {
                 let (tx, rx) = oneshot::channel();
-                actor.handle_admin_query(SequencerAdminQuery::ConductorEnabled(tx)).await;
+                actor
+                    .handle_admin_query(&mut None, SequencerAdminQuery::ConductorEnabled(tx))
+                    .await;
                 rx.await.unwrap()
             }
         }
@@ -78,7 +80,7 @@ async fn test_in_recovery_mode(
             false => actor.in_recovery_mode().await,
             true => {
                 let (tx, rx) = oneshot::channel();
-                actor.handle_admin_query(SequencerAdminQuery::RecoveryMode(tx)).await;
+                actor.handle_admin_query(&mut None, SequencerAdminQuery::RecoveryMode(tx)).await;
                 rx.await.unwrap()
             }
         }
@@ -118,7 +120,12 @@ async fn test_start_sequencer_no_conductor(
             false => actor.start_sequencer(test_hash).await,
             true => {
                 let (tx, rx) = oneshot::channel();
-                actor.handle_admin_query(SequencerAdminQuery::StartSequencer(test_hash, tx)).await;
+                actor
+                    .handle_admin_query(
+                        &mut None,
+                        SequencerAdminQuery::StartSequencer(test_hash, tx),
+                    )
+                    .await;
                 rx.await.unwrap()
             }
         }
@@ -155,7 +162,12 @@ async fn test_start_sequencer_conductor_is_leader(#[values(true, false)] via_cha
             false => actor.start_sequencer(test_hash).await,
             true => {
                 let (tx, rx) = oneshot::channel();
-                actor.handle_admin_query(SequencerAdminQuery::StartSequencer(test_hash, tx)).await;
+                actor
+                    .handle_admin_query(
+                        &mut None,
+                        SequencerAdminQuery::StartSequencer(test_hash, tx),
+                    )
+                    .await;
                 rx.await.unwrap()
             }
         }
@@ -182,7 +194,12 @@ async fn test_start_sequencer_conductor_not_leader(#[values(true, false)] via_ch
             false => actor.start_sequencer(B256::ZERO).await,
             true => {
                 let (tx, rx) = oneshot::channel();
-                actor.handle_admin_query(SequencerAdminQuery::StartSequencer(B256::ZERO, tx)).await;
+                actor
+                    .handle_admin_query(
+                        &mut None,
+                        SequencerAdminQuery::StartSequencer(B256::ZERO, tx),
+                    )
+                    .await;
                 rx.await.unwrap()
             }
         }
@@ -212,7 +229,12 @@ async fn test_start_sequencer_conductor_leader_rpc_error(#[values(true, false)] 
             false => actor.start_sequencer(B256::ZERO).await,
             true => {
                 let (tx, rx) = oneshot::channel();
-                actor.handle_admin_query(SequencerAdminQuery::StartSequencer(B256::ZERO, tx)).await;
+                actor
+                    .handle_admin_query(
+                        &mut None,
+                        SequencerAdminQuery::StartSequencer(B256::ZERO, tx),
+                    )
+                    .await;
                 rx.await.unwrap()
             }
         }
@@ -242,7 +264,12 @@ async fn test_start_sequencer_already_active_skips_leader_check(
             false => actor.start_sequencer(B256::ZERO).await,
             true => {
                 let (tx, rx) = oneshot::channel();
-                actor.handle_admin_query(SequencerAdminQuery::StartSequencer(B256::ZERO, tx)).await;
+                actor
+                    .handle_admin_query(
+                        &mut None,
+                        SequencerAdminQuery::StartSequencer(B256::ZERO, tx),
+                    )
+                    .await;
                 rx.await.unwrap()
             }
         }
@@ -270,10 +297,10 @@ async fn test_start_sequencer_engine_not_initialized(#[values(true, false)] via_
             true => {
                 let (tx, rx) = oneshot::channel();
                 actor
-                    .handle_admin_query(SequencerAdminQuery::StartSequencer(
-                        B256::from([1u8; 32]),
-                        tx,
-                    ))
+                    .handle_admin_query(
+                        &mut None,
+                        SequencerAdminQuery::StartSequencer(B256::from([1u8; 32]), tx),
+                    )
                     .await;
                 rx.await.unwrap()
             }
@@ -309,7 +336,10 @@ async fn test_start_sequencer_unsafe_head_mismatch(#[values(true, false)] via_ch
             true => {
                 let (tx, rx) = oneshot::channel();
                 actor
-                    .handle_admin_query(SequencerAdminQuery::StartSequencer(requested_hash, tx))
+                    .handle_admin_query(
+                        &mut None,
+                        SequencerAdminQuery::StartSequencer(requested_hash, tx),
+                    )
                     .await;
                 rx.await.unwrap()
             }
@@ -341,10 +371,10 @@ async fn test_start_sequencer_engine_client_error(#[values(true, false)] via_cha
             true => {
                 let (tx, rx) = oneshot::channel();
                 actor
-                    .handle_admin_query(SequencerAdminQuery::StartSequencer(
-                        B256::from([1u8; 32]),
-                        tx,
-                    ))
+                    .handle_admin_query(
+                        &mut None,
+                        SequencerAdminQuery::StartSequencer(B256::from([1u8; 32]), tx),
+                    )
                     .await;
                 rx.await.unwrap()
             }
@@ -382,10 +412,11 @@ async fn test_stop_sequencer_success(
 
     // stop the sequencer
     let (tx, rx) = oneshot::channel();
+    let mut next_payload = None;
     if via_channel {
-        actor.handle_admin_query(SequencerAdminQuery::StopSequencer(tx)).await;
+        actor.handle_admin_query(&mut next_payload, SequencerAdminQuery::StopSequencer(tx)).await;
     } else {
-        actor.stop_sequencer(tx).await;
+        actor.stop_sequencer(&mut next_payload, tx).await;
     }
     let result = rx.await.unwrap();
     assert!(result.is_ok());
@@ -410,10 +441,11 @@ async fn test_stop_sequencer_error_fetching_unsafe_head(#[values(true, false)] v
     actor.engine_client = Arc::new(client);
 
     let (tx, rx) = oneshot::channel();
+    let mut next_payload = None;
     if via_channel {
-        actor.handle_admin_query(SequencerAdminQuery::StopSequencer(tx)).await;
+        actor.handle_admin_query(&mut next_payload, SequencerAdminQuery::StopSequencer(tx)).await;
     } else {
-        actor.stop_sequencer(tx).await;
+        actor.stop_sequencer(&mut next_payload, tx).await;
     }
     let result = rx.await.unwrap();
     assert!(result.is_err());
@@ -447,7 +479,10 @@ async fn test_set_recovery_mode(
             true => {
                 let (tx, rx) = oneshot::channel();
                 actor
-                    .handle_admin_query(SequencerAdminQuery::SetRecoveryMode(mode_to_set, tx))
+                    .handle_admin_query(
+                        &mut None,
+                        SequencerAdminQuery::SetRecoveryMode(mode_to_set, tx),
+                    )
                     .await;
                 rx.await.unwrap()
             }
@@ -500,7 +535,7 @@ async fn test_override_leader(
             false => actor.override_leader().await,
             true => {
                 let (tx, rx) = oneshot::channel();
-                actor.handle_admin_query(SequencerAdminQuery::OverrideLeader(tx)).await;
+                actor.handle_admin_query(&mut None, SequencerAdminQuery::OverrideLeader(tx)).await;
                 rx.await.unwrap()
             }
         }
@@ -533,7 +568,9 @@ async fn test_reset_derivation_pipeline_success(#[values(true, false)] via_chann
             false => actor.reset_derivation_pipeline().await,
             true => {
                 let (tx, rx) = oneshot::channel();
-                actor.handle_admin_query(SequencerAdminQuery::ResetDerivationPipeline(tx)).await;
+                actor
+                    .handle_admin_query(&mut None, SequencerAdminQuery::ResetDerivationPipeline(tx))
+                    .await;
                 rx.await.unwrap()
             }
         }
@@ -560,7 +597,9 @@ async fn test_reset_derivation_pipeline_error(#[values(true, false)] via_channel
             false => actor.reset_derivation_pipeline().await,
             true => {
                 let (tx, rx) = oneshot::channel();
-                actor.handle_admin_query(SequencerAdminQuery::ResetDerivationPipeline(tx)).await;
+                actor
+                    .handle_admin_query(&mut None, SequencerAdminQuery::ResetDerivationPipeline(tx))
+                    .await;
                 rx.await.unwrap()
             }
         }
@@ -632,7 +671,8 @@ async fn test_handle_admin_query_resilient_to_dropped_receiver() {
     }
 
     // None of these should fail even if the receiver is dropped
+    let mut next_payload = None;
     for query in queries {
-        actor.handle_admin_query(query).await;
+        actor.handle_admin_query(&mut next_payload, query).await;
     }
 }

--- a/crates/consensus/service/src/actors/sequencer/tests/test_util.rs
+++ b/crates/consensus/service/src/actors/sequencer/tests/test_util.rs
@@ -46,5 +46,6 @@ pub(crate) fn test_actor() -> SequencerActor<
         unsafe_payload_gossip_client: MockUnsafePayloadGossipClient::new(),
         sealer: None,
         pending_stop: None,
+        next_build_parent: None,
     }
 }

--- a/crates/consensus/service/src/metrics/mod.rs
+++ b/crates/consensus/service/src/metrics/mod.rs
@@ -42,9 +42,6 @@ impl Metrics {
         "base_node_sequencer_seal_step_retries_total";
     /// Gauge for seal pipeline step duration, labeled by step.
     pub const SEQUENCER_SEAL_STEP_DURATION: &str = "base_node_sequencer_seal_step_duration";
-    /// Counter for seal pipeline overlaps (previous not complete when next block tick fires).
-    pub const SEQUENCER_SEAL_PIPELINE_OVERLAP_TOTAL: &str =
-        "base_node_sequencer_seal_pipeline_overlap_total";
     /// Counter for seal errors labeled by fatal ("true"|"false").
     pub const SEQUENCER_SEAL_ERROR_TOTAL: &str = "base_node_sequencer_seal_errors_total";
     /// Counter for sequencer start rejections labeled by reason.
@@ -127,10 +124,6 @@ impl Metrics {
             metrics::Unit::Seconds,
             "Sequencer seal step duration by step"
         );
-        metrics::describe_counter!(
-            Self::SEQUENCER_SEAL_PIPELINE_OVERLAP_TOTAL,
-            "Seal pipeline overlaps: pipeline not complete before next block tick"
-        );
         metrics::describe_counter!(Self::SEQUENCER_SEAL_ERROR_TOTAL, "Seal errors by fatality");
         metrics::describe_counter!(
             Self::SEQUENCER_START_REJECTED_TOTAL,
@@ -168,7 +161,6 @@ impl Metrics {
         base_macros::set!(counter, Self::SEQUENCER_SEAL_STEP_RETRIES_TOTAL, "step", "insert", 0);
         base_macros::set!(counter, Self::SEQUENCER_SEAL_ERROR_TOTAL, "fatal", "true", 0);
         base_macros::set!(counter, Self::SEQUENCER_SEAL_ERROR_TOTAL, "fatal", "false", 0);
-        base_macros::set!(counter, Self::SEQUENCER_SEAL_PIPELINE_OVERLAP_TOTAL, 0);
         base_macros::set!(counter, Self::SEQUENCER_START_REJECTED_TOTAL, "reason", "not_leader", 0);
         base_macros::set!(
             counter,

--- a/crates/consensus/service/src/service/node.rs
+++ b/crates/consensus/service/src/service/node.rs
@@ -471,6 +471,7 @@ impl RollupNode {
                     unsafe_payload_gossip_client: queued_gossip_client,
                     sealer: None,
                     pending_stop: None,
+                    next_build_parent: None,
                 }),
                 Some(QueuedSequencerAdminAPIClient::new(sequencer_admin_api_tx)),
             )


### PR DESCRIPTION
## Summary

This PR fixes two sequencing bugs that caused the unsafe head to fall behind the safe head under catch-up conditions. The root cause of the first bug was a race between `insert_unsafe_payload` and the next `build()` call: because `insert_unsafe_payload` is fire-and-forgot to the engine, the unsafe-head watch channel still reflects the old (pre-insert) block at the point `build()` reads it, causing the next block to be built on the grandparent rather than the just-sealed parent. The fix introduces a `next_build_parent: Option<L2BlockInfo>` field on `SequencerActor` and a new `PayloadBuilder::build_on(parent)` method. After a successful seal, the sealed envelope's `L2BlockInfo` is derived immediately and stashed as `next_build_parent`; the subsequent build call in the `Ok(true)` sealer arm then uses `build_on` with that explicit parent instead of reading the watch channel, guaranteeing the engine's `InsertTask` is enqueued before `BuildTask`.

The second bug was that the `build_ticker` and sealer arms were not mutually exclusive: in catch-up mode `reset_immediately()` could make the ticker `Poll::Ready` while the sealer's `step().await` was `Poll::Pending`, allowing the ticker arm to fire mid-seal and start a second build before the first three-step pipeline (commit → gossip → insert) completed. The ticker arm is now gated on `self.sealer.is_none()`, making the two arms structurally exclusive. Two additional fixes land alongside these: pipeline reset errors in `build_attributes` (e.g. `BlockMismatch`, `BrokenTimeInvariant`) no longer trigger an engine reset that would rewind the unsafe head to the safe head — they now return `Ok(None)` and retry on the next tick; and `schedule_initial_reset` now services admin API queries throughout both the reset-attempt loop and the backoff sleep so the sequencer remains controllable during EL sync.