### PR TITLE
chore(basectl): Add Safe And Finalized L2 Head

### DIFF
--- a/crates/infra/basectl/src/app/views/conductor.rs
+++ b/crates/infra/basectl/src/app/views/conductor.rs
@@ -24,7 +24,7 @@ const KEYBINDINGS: &[Keybinding] = &[
 /// HA conductor cluster status view.
 ///
 /// Renders a fixed grid with one column per conductor node and rows for
-/// role (leader / follower / offline), unsafe L2 block, and P2P peer count.
+/// role (leader / follower / offline), unsafe/safe/finalized L2 block, and P2P peer count.
 /// The user can navigate columns with `←`/`→` and trigger leadership transfers
 /// with `t` (any peer) or `Enter` (selected node). A footer bar always shows
 /// the available key bindings. When no conductor configuration is present
@@ -256,6 +256,40 @@ fn render_cluster_table(
     }
     let l2_row = Row::new(l2_cells).height(1);
 
+    // ── Safe L2 row ────────────────────────────────────────────────────────
+    let mut safe_l2_cells = vec![
+        Cell::from("Safe L2")
+            .style(Style::default().fg(Color::White).add_modifier(Modifier::BOLD)),
+    ];
+    for node in nodes {
+        let (label, style) = match node.safe_l2_block {
+            Some(n) if node.is_leader == Some(true) => {
+                (format!("   #{n}"), Style::default().fg(Color::Yellow))
+            }
+            Some(n) => (format!("   #{n}"), Style::default().fg(Color::White)),
+            None => ("   ?".to_string(), Style::default().fg(Color::DarkGray)),
+        };
+        safe_l2_cells.push(Cell::from(label).style(style));
+    }
+    let safe_l2_row = Row::new(safe_l2_cells).height(1);
+
+    // ── Finalized L2 row ───────────────────────────────────────────────────
+    let mut finalized_l2_cells = vec![
+        Cell::from("Finalized L2")
+            .style(Style::default().fg(Color::White).add_modifier(Modifier::BOLD)),
+    ];
+    for node in nodes {
+        let (label, style) = match node.finalized_l2_block {
+            Some(n) if node.is_leader == Some(true) => {
+                (format!("   #{n}"), Style::default().fg(Color::Yellow))
+            }
+            Some(n) => (format!("   #{n}"), Style::default().fg(Color::White)),
+            None => ("   ?".to_string(), Style::default().fg(Color::DarkGray)),
+        };
+        finalized_l2_cells.push(Cell::from(label).style(style));
+    }
+    let finalized_l2_row = Row::new(finalized_l2_cells).height(1);
+
     // ── P2P peers row ──────────────────────────────────────────────────────
     let mut peers_cells = vec![
         Cell::from("P2P Peers")
@@ -271,7 +305,7 @@ fn render_cluster_table(
     }
     let peers_row = Row::new(peers_cells).height(1);
 
-    let rows = vec![role_row, l2_row, peers_row];
+    let rows = vec![role_row, l2_row, safe_l2_row, finalized_l2_row, peers_row];
     let table = Table::new(rows, constraints).header(header).row_highlight_style(Style::default());
 
     f.render_stateful_widget(table, inner, &mut TableState::default());

--- a/crates/infra/basectl/src/app/views/conductor.rs
+++ b/crates/infra/basectl/src/app/views/conductor.rs
@@ -258,8 +258,7 @@ fn render_cluster_table(
 
     // ── Safe L2 row ────────────────────────────────────────────────────────
     let mut safe_l2_cells = vec![
-        Cell::from("Safe L2")
-            .style(Style::default().fg(Color::White).add_modifier(Modifier::BOLD)),
+        Cell::from("Safe L2").style(Style::default().fg(Color::White).add_modifier(Modifier::BOLD)),
     ];
     for node in nodes {
         let (label, style) = match node.safe_l2_block {

--- a/crates/infra/basectl/src/rpc.rs
+++ b/crates/infra/basectl/src/rpc.rs
@@ -626,6 +626,10 @@ pub(crate) struct ConductorNodeStatus {
     pub is_leader: Option<bool>,
     /// Unsafe L2 block number from `optimism_syncStatus`. `None` means unreachable.
     pub unsafe_l2_block: Option<u64>,
+    /// Safe L2 block number from `optimism_syncStatus`. `None` means unreachable.
+    pub safe_l2_block: Option<u64>,
+    /// Finalized L2 block number from `optimism_syncStatus`. `None` means unreachable.
+    pub finalized_l2_block: Option<u64>,
     /// Number of connected P2P peers from `opp2p_peerStats`. `None` means unreachable.
     pub peer_count: Option<u32>,
 }
@@ -734,13 +738,20 @@ pub(crate) async fn run_conductor_poller(
         let statuses = futures::future::join_all(clients.iter().map(
             |(name, conductor_client, cl_client)| async move {
                 let is_leader = ConductorApiClient::conductor_leader(conductor_client).await.ok();
-                let unsafe_l2_block = RollupNodeApiClient::op_sync_status(cl_client)
-                    .await
-                    .ok()
-                    .map(|s| s.unsafe_l2.block_info.number);
+                let sync = RollupNodeApiClient::op_sync_status(cl_client).await.ok();
+                let unsafe_l2_block = sync.as_ref().map(|s| s.unsafe_l2.block_info.number);
+                let safe_l2_block = sync.as_ref().map(|s| s.safe_l2.block_info.number);
+                let finalized_l2_block = sync.as_ref().map(|s| s.finalized_l2.block_info.number);
                 let peer_count =
                     OpP2PApiClient::opp2p_peer_stats(cl_client).await.ok().map(|s| s.connected);
-                ConductorNodeStatus { name: name.clone(), is_leader, unsafe_l2_block, peer_count }
+                ConductorNodeStatus {
+                    name: name.clone(),
+                    is_leader,
+                    unsafe_l2_block,
+                    safe_l2_block,
+                    finalized_l2_block,
+                    peer_count,
+                }
             },
         ))
         .await;


### PR DESCRIPTION
## Summary

The HA conductor dashboard now displays safe and finalized L2 block numbers alongside the existing unsafe head row. All three values come from the single existing `optimism_syncStatus` call, so no additional RPC overhead is introduced. The new rows follow the same color conventions as the unsafe head row, with yellow highlighting for the leader node and gray for unreachable nodes.