### PR TITLE
feat(proposer): gate proving pipeline on V1 hardfork activation

### DIFF
--- a/crates/proof/proposer/src/driver/handle.rs
+++ b/crates/proof/proposer/src/driver/handle.rs
@@ -209,6 +209,7 @@ mod tests {
             PipelineConfig {
                 max_parallel_proofs: 2,
                 max_retries: 3,
+                v1_hardfork_timestamp: None,
                 driver: DriverConfig {
                     poll_interval: Duration::from_secs(3600),
                     block_interval: 512,

--- a/crates/proof/proposer/src/driver/pipeline.rs
+++ b/crates/proof/proposer/src/driver/pipeline.rs
@@ -177,6 +177,12 @@ where
     /// Returns `true` if the V1 hardfork is active based on the current wall
     /// clock time, or if no hardfork timestamp is configured (i.e. the gate
     /// is disabled).
+    ///
+    /// NOTE: This intentionally uses [`SystemTime`] (real wall clock) rather
+    /// than `tokio::time::Instant`, because hardfork activation is anchored to
+    /// a Unix timestamp and must reflect real-world time regardless of the
+    /// tokio runtime's clock state.  Tests that assert on this method use
+    /// extreme sentinel values (0 / `u64::MAX`) so they are wall-clock safe.
     fn is_v1_hardfork_active(&self) -> bool {
         self.config.v1_hardfork_timestamp.is_none_or(|ts| {
             let now = SystemTime::now().duration_since(UNIX_EPOCH).unwrap_or_default().as_secs();
@@ -832,15 +838,13 @@ mod tests {
             cancel.clone(),
         );
 
-        let cancel_clone = cancel.clone();
-        let handle = tokio::spawn(async move {
-            // Let the pipeline run for a bit, then cancel.
-            tokio::time::sleep(Duration::from_secs(5)).await;
-            cancel_clone.cancel();
-            pipeline.run().await
-        });
+        // Spawn the pipeline so it starts processing ticks, then cancel
+        // from this task after giving it time to run.
+        let handle = tokio::spawn(async move { pipeline.run().await });
 
-        // Start the pipeline run and wait for it to complete.
+        tokio::time::sleep(Duration::from_secs(5)).await;
+        cancel.cancel();
+
         let result = handle.await.expect("task should not panic");
         assert!(result.is_ok());
     }
@@ -951,12 +955,12 @@ mod tests {
             cancel.clone(),
         );
 
-        let cancel_clone = cancel.clone();
-        let handle = tokio::spawn(async move {
-            tokio::time::sleep(Duration::from_secs(5)).await;
-            cancel_clone.cancel();
-            pipeline.run().await
-        });
+        // Spawn the pipeline so it starts processing ticks with the hardfork
+        // gate active, then cancel from this task after giving it time to run.
+        let handle = tokio::spawn(async move { pipeline.run().await });
+
+        tokio::time::sleep(Duration::from_secs(5)).await;
+        cancel.cancel();
 
         let result = handle.await.expect("task should not panic");
         assert!(result.is_ok(), "pipeline should run normally with a past hardfork timestamp");

--- a/crates/proof/proposer/src/driver/pipeline.rs
+++ b/crates/proof/proposer/src/driver/pipeline.rs
@@ -20,6 +20,7 @@
 use std::{
     collections::{BTreeMap, BTreeSet},
     sync::Arc,
+    time::{SystemTime, UNIX_EPOCH},
 };
 
 use alloy_primitives::B256;
@@ -50,6 +51,10 @@ pub struct PipelineConfig {
     pub max_retries: u32,
     /// Base driver configuration.
     pub driver: DriverConfig,
+    /// Optional Unix timestamp at which the V1 hardfork activates.
+    /// When set, the pipeline will not perform any work until this
+    /// timestamp has been reached.
+    pub v1_hardfork_timestamp: Option<u64>,
 }
 
 /// Mutable state for the coordinator loop.
@@ -169,11 +174,22 @@ where
         self.cancel = cancel;
     }
 
+    /// Returns `true` if the V1 hardfork is active based on the current wall
+    /// clock time, or if no hardfork timestamp is configured (i.e. the gate
+    /// is disabled).
+    fn is_v1_hardfork_active(&self) -> bool {
+        self.config.v1_hardfork_timestamp.is_none_or(|ts| {
+            let now = SystemTime::now().duration_since(UNIX_EPOCH).unwrap_or_default().as_secs();
+            now >= ts
+        })
+    }
+
     /// Runs the parallel proving pipeline until cancelled.
     pub async fn run(&self) -> Result<()> {
         info!(
             max_parallel_proofs = self.config.max_parallel_proofs,
             block_interval = self.config.driver.block_interval,
+            v1_hardfork_timestamp = self.config.v1_hardfork_timestamp,
             "Starting parallel proving pipeline"
         );
 
@@ -214,6 +230,14 @@ where
     /// Executes one pipeline tick: recover state, dispatch new proofs, submit
     /// completed results.
     async fn tick(&self, state: &mut PipelineState) -> Result<()> {
+        if !self.is_v1_hardfork_active() {
+            debug!(
+                v1_hardfork_timestamp = self.config.v1_hardfork_timestamp,
+                "V1 hardfork not yet active, skipping tick"
+            );
+            return Ok(());
+        }
+
         if let Some((recovered, safe_head)) = self.try_recover_and_plan().await {
             state.prune_stale(recovered.l2_block_number);
             self.dispatch_proofs(&recovered, safe_head, state).await?;
@@ -769,6 +793,7 @@ mod tests {
             PipelineConfig {
                 max_parallel_proofs: 2,
                 max_retries: 3,
+                v1_hardfork_timestamp: None,
                 driver: DriverConfig {
                     poll_interval: Duration::from_secs(3600),
                     block_interval: 512,
@@ -795,6 +820,7 @@ mod tests {
             PipelineConfig {
                 max_parallel_proofs: 2,
                 max_retries: 3,
+                v1_hardfork_timestamp: None,
                 driver: DriverConfig {
                     poll_interval: Duration::from_millis(100),
                     block_interval: 512,
@@ -817,5 +843,122 @@ mod tests {
         // Start the pipeline run and wait for it to complete.
         let result = handle.await.expect("task should not panic");
         assert!(result.is_ok());
+    }
+
+    #[tokio::test(flavor = "current_thread", start_paused = true)]
+    async fn test_hardfork_gate_none_always_active() {
+        let cancel = CancellationToken::new();
+        let pipeline = test_pipeline(
+            PipelineConfig {
+                max_parallel_proofs: 2,
+                max_retries: 3,
+                v1_hardfork_timestamp: None,
+                driver: DriverConfig::default(),
+            },
+            0,
+            cancel,
+        );
+
+        assert!(pipeline.is_v1_hardfork_active(), "gate should be active when no timestamp is set");
+    }
+
+    #[tokio::test(flavor = "current_thread", start_paused = true)]
+    async fn test_hardfork_gate_past_timestamp_active() {
+        let cancel = CancellationToken::new();
+        // Timestamp 0 is always in the past.
+        let pipeline = test_pipeline(
+            PipelineConfig {
+                max_parallel_proofs: 2,
+                max_retries: 3,
+                v1_hardfork_timestamp: Some(0),
+                driver: DriverConfig::default(),
+            },
+            0,
+            cancel,
+        );
+
+        assert!(
+            pipeline.is_v1_hardfork_active(),
+            "gate should be active when timestamp is in the past"
+        );
+    }
+
+    #[tokio::test(flavor = "current_thread", start_paused = true)]
+    async fn test_hardfork_gate_future_timestamp_inactive() {
+        let cancel = CancellationToken::new();
+        let pipeline = test_pipeline(
+            PipelineConfig {
+                max_parallel_proofs: 2,
+                max_retries: 3,
+                v1_hardfork_timestamp: Some(u64::MAX),
+                driver: DriverConfig::default(),
+            },
+            0,
+            cancel,
+        );
+
+        assert!(
+            !pipeline.is_v1_hardfork_active(),
+            "gate should be inactive when timestamp is in the future"
+        );
+    }
+
+    #[tokio::test(flavor = "current_thread", start_paused = true)]
+    async fn test_tick_skipped_when_hardfork_inactive() {
+        let cancel = CancellationToken::new();
+        // Safe head at 512: would normally dispatch proofs.
+        let pipeline = test_pipeline(
+            PipelineConfig {
+                max_parallel_proofs: 2,
+                max_retries: 3,
+                v1_hardfork_timestamp: Some(u64::MAX),
+                driver: DriverConfig {
+                    poll_interval: Duration::from_millis(100),
+                    block_interval: 512,
+                    intermediate_block_interval: 512,
+                    ..Default::default()
+                },
+            },
+            512,
+            cancel,
+        );
+
+        let mut state = PipelineState::new();
+        let result = pipeline.tick(&mut state).await;
+
+        assert!(result.is_ok(), "tick should return Ok even when gate is inactive");
+        assert!(state.inflight.is_empty(), "no proofs should be dispatched when gate is inactive");
+        assert!(state.proved.is_empty(), "no proofs should be completed when gate is inactive");
+    }
+
+    #[tokio::test(flavor = "current_thread", start_paused = true)]
+    async fn test_pipeline_runs_with_past_hardfork_timestamp() {
+        let cancel = CancellationToken::new();
+        // Same setup as test_pipeline_proves_and_submits but with a past timestamp.
+        let pipeline = test_pipeline(
+            PipelineConfig {
+                max_parallel_proofs: 2,
+                max_retries: 3,
+                v1_hardfork_timestamp: Some(0),
+                driver: DriverConfig {
+                    poll_interval: Duration::from_millis(100),
+                    block_interval: 512,
+                    intermediate_block_interval: 512,
+                    ..Default::default()
+                },
+            },
+            512,
+            cancel.clone(),
+        );
+
+        let cancel_clone = cancel.clone();
+        let handle = tokio::spawn(async move {
+            tokio::time::sleep(Duration::from_secs(5)).await;
+            cancel_clone.cancel();
+            pipeline.run().await
+        });
+
+        let result = handle.await.expect("task should not panic");
+        assert!(result.is_ok(), "pipeline should run normally with a past hardfork timestamp");
     }
 }

--- a/crates/proof/proposer/src/service.rs
+++ b/crates/proof/proposer/src/service.rs
@@ -99,7 +99,12 @@ pub async fn run(config: ProposerConfig) -> Result<()> {
     // Fetch chain configuration from op-node
     info!("Fetching chain configuration from rollup RPC...");
     let chain_config = rollup_client.rollup_config().await?;
-    info!(chain_id = %chain_config.l2_chain_id.id(), "Chain configuration loaded");
+    let v1_hardfork_timestamp = chain_config.hardforks.base.v1;
+    info!(
+        chain_id = %chain_config.l2_chain_id.id(),
+        v1_hardfork_timestamp,
+        "Chain configuration loaded"
+    );
 
     let prover_client = HttpClientBuilder::default()
         .request_timeout(crate::constants::PROVER_TIMEOUT)
@@ -206,6 +211,7 @@ pub async fn run(config: ProposerConfig) -> Result<()> {
     let pipeline_config = PipelineConfig {
         max_parallel_proofs: config.max_parallel_proofs,
         max_retries: 3,
+        v1_hardfork_timestamp,
         driver: DriverConfig {
             poll_interval: config.poll_interval,
             block_interval,


### PR DESCRIPTION
## Summary

- Adds a `v1_hardfork_timestamp` field to `PipelineConfig` that gates the proving pipeline, preventing any proof work until the V1 hardfork activation timestamp is reached.
- Wires the timestamp from the chain's rollup config (`chain_config.hardforks.base.v1`) through service startup into the pipeline config.
- Includes tests covering the gate logic (no timestamp, past timestamp, future timestamp, tick skip behavior, and end-to-end pipeline run with a past timestamp).