### PR TITLE
feat(batcher): add --batch-type CLI flag

### DIFF
--- a/bin/batcher/src/cli.rs
+++ b/bin/batcher/src/cli.rs
@@ -10,7 +10,7 @@ use base_batcher_core::ThrottleConfig;
 use base_batcher_service::{BatcherConfig, BatcherService};
 use base_cli_utils::{LogConfig, RuntimeManager};
 use base_runtime::TokioRuntime;
-use clap::{Args, Parser};
+use clap::{Args, Parser, ValueEnum};
 use tracing::info;
 use url::Url;
 
@@ -100,6 +100,13 @@ pub(crate) struct BatcherArgs {
     #[arg(long = "target-num-frames", default_value = "1", env = "BATCHER_TARGET_NUM_FRAMES")]
     pub target_num_frames: usize,
 
+    /// Batch encoding mode.
+    ///
+    /// Accepts `single` / `0` and `span` / `1`. Span batches require Fjord
+    /// to be active for the next L2 block at startup.
+    #[arg(long = "batch-type", default_value = "single", env = "BATCHER_BATCH_TYPE")]
+    batch_type: BatchTypeArg,
+
     /// Approximate compression ratio used for span batch size estimation.
     ///
     /// Only relevant when `--batch-type=span`. Should be slightly below the
@@ -179,6 +186,7 @@ impl BatcherArgs {
             max_channel_duration: self.max_channel_duration,
             sub_safety_margin: self.sub_safety_margin,
             target_num_frames: self.target_num_frames,
+            batch_type: self.batch_type.into(),
             approx_compr_ratio: self.approx_compr_ratio,
             ..base_batcher_encoder::EncoderConfig::default()
         };
@@ -222,5 +230,65 @@ impl BatcherArgs {
 
         let service = BatcherService::new(config);
         service.setup(rt).await?.run().await
+    }
+}
+
+#[derive(Clone, Copy, Debug, ValueEnum)]
+enum BatchTypeArg {
+    #[value(alias = "0")]
+    Single,
+    #[value(alias = "1")]
+    Span,
+}
+
+impl From<BatchTypeArg> for base_batcher_encoder::BatchType {
+    fn from(value: BatchTypeArg) -> Self {
+        match value {
+            BatchTypeArg::Single => Self::Single,
+            BatchTypeArg::Span => Self::Span,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use clap::Parser;
+
+    use super::*;
+
+    fn base_args() -> Vec<&'static str> {
+        vec![
+            "base-batcher",
+            "--l1-rpc-url",
+            "http://localhost:8545",
+            "--l2-rpc-url",
+            "http://localhost:9545",
+            "--rollup-rpc-url",
+            "http://localhost:7545",
+            "--private-key",
+            "0x0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+        ]
+    }
+
+    fn parse_cli(extra: &[&'static str]) -> Cli {
+        let mut args = base_args();
+        args.extend_from_slice(extra);
+        Cli::try_parse_from(args).expect("CLI should parse")
+    }
+
+    #[test]
+    fn into_config_defaults_to_single_batches_and_blobs() {
+        let cli = parse_cli(&[]);
+        let config = cli.args.into_config().expect("config should build");
+
+        assert_eq!(config.encoder_config.batch_type, base_batcher_encoder::BatchType::Single);
+    }
+
+    #[test]
+    fn into_config_accepts_numeric_span_alias() {
+        let cli = parse_cli(&["--batch-type", "1"]);
+        let config = cli.args.into_config().expect("config should build");
+
+        assert_eq!(config.encoder_config.batch_type, base_batcher_encoder::BatchType::Span);
     }
 }

--- a/crates/batcher/encoder/src/config.rs
+++ b/crates/batcher/encoder/src/config.rs
@@ -131,14 +131,12 @@ impl EncoderConfig {
         if matches!(self.batch_type, BatchType::Span)
             && !rollup_config.is_fjord_active(next_l2_timestamp)
         {
-            return match rollup_config.hardforks.fjord_time {
-                Some(fjord_time) => {
+            return rollup_config.hardforks.fjord_time.map_or(
+                Err(EncoderConfigError::SpanBatchRequiresScheduledFjord { next_l2_timestamp }),
+                |fjord_time| {
                     Err(EncoderConfigError::SpanBatchBeforeFjord { next_l2_timestamp, fjord_time })
-                }
-                None => {
-                    Err(EncoderConfigError::SpanBatchRequiresScheduledFjord { next_l2_timestamp })
-                }
-            };
+                },
+            );
         }
 
         Ok(())

--- a/crates/batcher/encoder/src/config.rs
+++ b/crates/batcher/encoder/src/config.rs
@@ -1,5 +1,7 @@
 //! Encoder configuration and its validation error type.
 
+use base_consensus_genesis::RollupConfig;
+
 use crate::{BatchType, DaType};
 
 /// Configuration for the [`BatchEncoder`](crate::BatchEncoder).
@@ -113,6 +115,34 @@ impl EncoderConfig {
         }
         Ok(())
     }
+
+    /// Validate the configuration against the active rollup state.
+    ///
+    /// `next_l2_timestamp` should be the timestamp of the next L2 block the
+    /// batcher may encode. Span batches are only valid once Fjord is active for
+    /// that next block.
+    pub fn validate_for_rollup_config(
+        &self,
+        rollup_config: &RollupConfig,
+        next_l2_timestamp: u64,
+    ) -> Result<(), EncoderConfigError> {
+        self.validate()?;
+
+        if matches!(self.batch_type, BatchType::Span)
+            && !rollup_config.is_fjord_active(next_l2_timestamp)
+        {
+            return match rollup_config.hardforks.fjord_time {
+                Some(fjord_time) => {
+                    Err(EncoderConfigError::SpanBatchBeforeFjord { next_l2_timestamp, fjord_time })
+                }
+                None => {
+                    Err(EncoderConfigError::SpanBatchRequiresScheduledFjord { next_l2_timestamp })
+                }
+            };
+        }
+
+        Ok(())
+    }
 }
 
 /// Errors returned by [`EncoderConfig::validate`].
@@ -155,10 +185,31 @@ pub enum EncoderConfigError {
         /// The configured approximate compression ratio.
         approx_compr_ratio: f64,
     },
+    /// `batch_type == BatchType::Span` before Fjord activates.
+    #[error(
+        "span batches require Fjord to be active for the next L2 block; \
+         next_l2_timestamp ({next_l2_timestamp}) is before fjord_time ({fjord_time})"
+    )]
+    SpanBatchBeforeFjord {
+        /// The timestamp of the next L2 block the batcher may encode.
+        next_l2_timestamp: u64,
+        /// The configured Fjord activation timestamp.
+        fjord_time: u64,
+    },
+    /// `batch_type == BatchType::Span` but Fjord is not scheduled.
+    #[error(
+        "span batches require Fjord to be scheduled and active for the next L2 block; \
+         next_l2_timestamp is {next_l2_timestamp}"
+    )]
+    SpanBatchRequiresScheduledFjord {
+        /// The timestamp of the next L2 block the batcher may encode.
+        next_l2_timestamp: u64,
+    },
 }
 
 #[cfg(test)]
 mod tests {
+    use base_consensus_genesis::HardForkConfig;
     use rstest::rstest;
 
     use super::*;
@@ -213,5 +264,53 @@ mod tests {
         let err = cfg.validate().unwrap_err();
         assert!(matches!(err, EncoderConfigError::InvalidApproxComprRatio { .. }));
         assert!(err.to_string().contains("approx_compr_ratio"));
+    }
+
+    fn rollup_config_with(block_time: u64, fjord_time: Option<u64>) -> RollupConfig {
+        RollupConfig {
+            block_time,
+            hardforks: HardForkConfig { fjord_time, ..HardForkConfig::default() },
+            ..RollupConfig::default()
+        }
+    }
+
+    #[test]
+    fn validate_for_rollup_config_allows_single_before_fjord() {
+        let cfg = EncoderConfig::default();
+        let rollup_config = rollup_config_with(2, Some(100));
+
+        assert!(cfg.validate_for_rollup_config(&rollup_config, 98).is_ok());
+    }
+
+    #[test]
+    fn validate_for_rollup_config_rejects_span_before_fjord() {
+        let cfg = EncoderConfig { batch_type: BatchType::Span, ..EncoderConfig::default() };
+        let rollup_config = rollup_config_with(2, Some(100));
+
+        let err = cfg.validate_for_rollup_config(&rollup_config, 98).unwrap_err();
+        assert!(matches!(
+            err,
+            EncoderConfigError::SpanBatchBeforeFjord { next_l2_timestamp: 98, fjord_time: 100 }
+        ));
+    }
+
+    #[test]
+    fn validate_for_rollup_config_allows_span_at_fjord_activation() {
+        let cfg = EncoderConfig { batch_type: BatchType::Span, ..EncoderConfig::default() };
+        let rollup_config = rollup_config_with(2, Some(100));
+
+        assert!(cfg.validate_for_rollup_config(&rollup_config, 100).is_ok());
+    }
+
+    #[test]
+    fn validate_for_rollup_config_rejects_unscheduled_fjord_for_span() {
+        let cfg = EncoderConfig { batch_type: BatchType::Span, ..EncoderConfig::default() };
+        let rollup_config = rollup_config_with(2, None);
+
+        let err = cfg.validate_for_rollup_config(&rollup_config, 2).unwrap_err();
+        assert!(matches!(
+            err,
+            EncoderConfigError::SpanBatchRequiresScheduledFjord { next_l2_timestamp: 2 }
+        ));
     }
 }

--- a/crates/batcher/service/src/service.rs
+++ b/crates/batcher/service/src/service.rs
@@ -304,6 +304,9 @@ impl BatcherService {
             .await
             .map_err(|e| eyre::eyre!("optimism_syncStatus RPC failed: {e}"))?;
         let safe_l2_number = sync_status.safe_l2.block_info.number;
+        let next_l2_timestamp =
+            sync_status.safe_l2.block_info.timestamp.saturating_add(rollup_config.block_time);
+        self.config.encoder_config.validate_for_rollup_config(&rollup_config, next_l2_timestamp)?;
         info!(safe_l2 = %safe_l2_number, "fetched safe L2 head");
 
         // Get the current L2 latest block to decide whether historical backfill is needed.


### PR DESCRIPTION
Closes #1605

## Summary

The `BatchEncoder` in `base-batcher-encoder` already supports both `BatchType::Single` and `BatchType::Span`, but the batcher binary hardcoded `BatchType::Single` via `EncoderConfig::default()`. Operators had no way to select span batches without modifying source code and rebuilding.

## Changes

- Added `--batch-type` CLI flag (env: `BATCHER_BATCH_TYPE`, default: `single`) to `BatcherArgs`
- Accepts `single` / `0` and `span` / `1` via `clap` `ValueEnum` with numeric aliases
- Wired `batch_type` through to `EncoderConfig` when constructing the encoder
- Added `validate_for_rollup_config()` to `EncoderConfig` — returns an error if `BatchType::Span` is selected on a chain where Fjord is not yet active
- Validation is called at startup in `BatcherService` using the safe L2 head timestamp

## Notes

Uses `BATCHER_BATCH_TYPE` env var prefix for consistency with the rest of the env vars in this repo (vs `OP_BATCHER_BATCH_TYPE` in the reference op-batcher).