### PR TITLE
feat(batcher): add --data-availability-type CLI flag

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2804,6 +2804,7 @@ dependencies = [
  "base-consensus-genesis",
  "base-metrics",
  "base-protocol",
+ "clap",
  "metrics",
  "rand 0.9.2",
  "rstest",

--- a/bin/batcher/Cargo.toml
+++ b/bin/batcher/Cargo.toml
@@ -18,7 +18,7 @@ workspace = true
 [dependencies]
 base-batcher-core.workspace = true
 base-batcher-service = { workspace = true, features = ["metrics"] }
-base-batcher-encoder.workspace = true
+base-batcher-encoder = { workspace = true, features = ["clap"] }
 base-cli-utils.workspace = true
 base-runtime = { workspace = true, features = ["tokio"] }
 alloy-signer-local.workspace = true

--- a/bin/batcher/src/cli.rs
+++ b/bin/batcher/src/cli.rs
@@ -114,7 +114,7 @@ pub(crate) struct BatcherArgs {
         default_value = "blobs",
         env = "BATCHER_DATA_AVAILABILITY_TYPE"
     )]
-    da_type: DataAvailabilityTypeArg,
+    da_type: base_batcher_encoder::DaType,
 
     /// Approximate compression ratio used for span batch size estimation.
     ///
@@ -213,7 +213,7 @@ impl BatcherArgs {
             sub_safety_margin: self.sub_safety_margin,
             target_num_frames: self.target_num_frames,
             batch_type: self.batch_type.into(),
-            da_type: self.da_type.into(),
+            da_type: self.da_type,
             approx_compr_ratio: self.approx_compr_ratio,
             ..base_batcher_encoder::EncoderConfig::default()
         };
@@ -277,23 +277,6 @@ impl From<BatchTypeArg> for base_batcher_encoder::BatchType {
         }
     }
 }
-
-#[derive(Clone, Copy, Debug, ValueEnum)]
-enum DataAvailabilityTypeArg {
-    #[value(alias = "blob")]
-    Blobs,
-    Calldata,
-}
-
-impl From<DataAvailabilityTypeArg> for base_batcher_encoder::DaType {
-    fn from(value: DataAvailabilityTypeArg) -> Self {
-        match value {
-            DataAvailabilityTypeArg::Blobs => Self::Blob,
-            DataAvailabilityTypeArg::Calldata => Self::Calldata,
-        }
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use clap::Parser;

--- a/bin/batcher/src/cli.rs
+++ b/bin/batcher/src/cli.rs
@@ -106,6 +106,15 @@ pub(crate) struct BatcherArgs {
     /// to be active for the next L2 block at startup.
     #[arg(long = "batch-type", default_value = "single", env = "BATCHER_BATCH_TYPE")]
     batch_type: BatchTypeArg,
+    /// Data availability mode for L1 submissions.
+    ///
+    /// Accepts `blobs` (default) or `calldata`.
+    #[arg(
+        long = "data-availability-type",
+        default_value = "blobs",
+        env = "BATCHER_DATA_AVAILABILITY_TYPE"
+    )]
+    da_type: DataAvailabilityTypeArg,
 
     /// Approximate compression ratio used for span batch size estimation.
     ///
@@ -204,6 +213,7 @@ impl BatcherArgs {
             sub_safety_margin: self.sub_safety_margin,
             target_num_frames: self.target_num_frames,
             batch_type: self.batch_type.into(),
+            da_type: self.da_type.into(),
             approx_compr_ratio: self.approx_compr_ratio,
             ..base_batcher_encoder::EncoderConfig::default()
         };
@@ -268,6 +278,22 @@ impl From<BatchTypeArg> for base_batcher_encoder::BatchType {
     }
 }
 
+#[derive(Clone, Copy, Debug, ValueEnum)]
+enum DataAvailabilityTypeArg {
+    #[value(alias = "blob")]
+    Blobs,
+    Calldata,
+}
+
+impl From<DataAvailabilityTypeArg> for base_batcher_encoder::DaType {
+    fn from(value: DataAvailabilityTypeArg) -> Self {
+        match value {
+            DataAvailabilityTypeArg::Blobs => Self::Blob,
+            DataAvailabilityTypeArg::Calldata => Self::Calldata,
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use clap::Parser;
@@ -308,5 +334,29 @@ mod tests {
         let config = cli.args.into_config().expect("config should build");
 
         assert_eq!(config.encoder_config.batch_type, base_batcher_encoder::BatchType::Span);
+    }
+
+    #[test]
+    fn into_config_defaults_to_blob_da() {
+        let cli = parse_cli(&[]);
+        let config = cli.args.into_config().expect("config should build");
+
+        assert_eq!(config.encoder_config.da_type, base_batcher_encoder::DaType::Blob);
+    }
+
+    #[test]
+    fn into_config_accepts_calldata_da_mode() {
+        let cli = parse_cli(&["--data-availability-type", "calldata"]);
+        let config = cli.args.into_config().expect("config should build");
+
+        assert_eq!(config.encoder_config.da_type, base_batcher_encoder::DaType::Calldata);
+    }
+
+    #[test]
+    fn cli_rejects_auto_da_mode_for_now() {
+        let mut args = base_args();
+        args.extend_from_slice(["--data-availability-type", "auto"].as_slice());
+
+        assert!(Cli::try_parse_from(args).is_err());
     }
 }

--- a/crates/batcher/encoder/Cargo.toml
+++ b/crates/batcher/encoder/Cargo.toml
@@ -12,8 +12,8 @@ repository.workspace = true
 workspace = true
 
 [features]
-clap = ["dep:clap"]
-metrics = ["base-metrics/metrics", "dep:metrics"]
+clap = [ "dep:clap" ]
+metrics = [ "base-metrics/metrics", "dep:metrics" ]
 
 [dependencies]
 tracing = { workspace = true, features = ["std"] }

--- a/crates/batcher/encoder/Cargo.toml
+++ b/crates/batcher/encoder/Cargo.toml
@@ -13,6 +13,7 @@ workspace = true
 
 [features]
 clap = ["dep:clap"]
+metrics = ["base-metrics/metrics", "dep:metrics"]
 
 [dependencies]
 tracing = { workspace = true, features = ["std"] }
@@ -31,6 +32,3 @@ clap = { workspace = true, features = ["derive"], optional = true }
 [dev-dependencies]
 alloy-consensus = { workspace = true, features = ["std"] }
 rstest.workspace = true
-
-[features]
-metrics = [ "base-metrics/metrics", "dep:metrics" ]

--- a/crates/batcher/encoder/Cargo.toml
+++ b/crates/batcher/encoder/Cargo.toml
@@ -11,6 +11,9 @@ repository.workspace = true
 [lints]
 workspace = true
 
+[features]
+clap = ["dep:clap"]
+
 [dependencies]
 tracing = { workspace = true, features = ["std"] }
 base-comp = { workspace = true, features = ["std"] }
@@ -23,6 +26,7 @@ metrics = { workspace = true, optional = true }
 rand = { workspace = true, features = ["std", "small_rng"] }
 base-alloy-consensus = { workspace = true, features = ["std"] }
 base-consensus-genesis = { workspace = true, features = ["std"] }
+clap = { workspace = true, features = ["derive"], optional = true }
 
 [dev-dependencies]
 alloy-consensus = { workspace = true, features = ["std"] }

--- a/crates/batcher/encoder/src/submission.rs
+++ b/crates/batcher/encoder/src/submission.rs
@@ -21,11 +21,13 @@ pub struct SubmissionId(pub u64);
 /// The driver uses this field on each [`BatchSubmission`] to determine whether
 /// frames should be packed into EIP-4844 blobs or sent as transaction calldata.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+#[cfg_attr(feature = "clap", derive(clap::ValueEnum))]
 pub enum DaType {
     /// Frames are packed into EIP-4844 blobs (default).
     ///
     /// Multiple submissions may be packed into a single blob payload per L1 transaction.
     #[default]
+    #[cfg_attr(feature = "clap", value(name = "blobs", alias = "blob"))]
     Blob,
     /// Each frame is sent as a single calldata transaction
     /// (`[DERIVATION_VERSION_0] ++ frame.encode()`).


### PR DESCRIPTION
Closes #1606

## Summary

The batcher hardcoded blob mode for L1 submissions. Operators had no way to select calldata DA without modifying source code — needed for testnets and devnets without EIP-4844 blob support.

## Changes

- Added `--data-availability-type` CLI flag (env: `BATCHER_DATA_AVAILABILITY_TYPE`, default: `blobs`) to `BatcherArgs`
- Accepts `blobs` and `calldata` via `clap` `ValueEnum`
- `auto` is intentionally not implemented — tracked separately as dynamic cost-based DA switching (#1612)
- Wired `da_type` through to `EncoderConfig`
- Default remains `DaType::Blob` since Base mainnet is blob-first

## Notes

- Uses `BATCHER_DATA_AVAILABILITY_TYPE` prefix for consistency with the rest of the env vars in this repo
- This PR touches the same file as #1634 (`bin/batcher/src/cli.rs`). If that PR merges first, I'll rebase and resolve any conflicts.