### PR TITLE
fix: prevent index out of bounds in try_derive_empty_batch

### DIFF
--- a/crates/consensus/derive/src/stages/batch/batch_validator.rs
+++ b/crates/consensus/derive/src/stages/batch/batch_validator.rs
@@ -145,6 +145,10 @@ where
         &mut self,
         parent: &L2BlockInfo,
     ) -> PipelineResult<SingleBatch> {
+        // Ensure we have at least one L1 block to derive from.
+        if self.l1_blocks.is_empty() {
+            return Err(PipelineError::MissingOrigin.crit());
+        }
         let epoch = self.l1_blocks[0];
 
         // If the current epoch is too old compared to the L1 block we are at,


### PR DESCRIPTION
The try_derive_empty_batch function in BatchValidator was accessing l1_blocks[0] without checking if the vector is empty, which could cause a panic. This adds a bounds check and returns MissingOrigin error when no L1 blocks are available.