### PR TITLE
fix: prevent integer overflow in brotli buffer resizing

### DIFF
--- a/crates/consensus/protocol/src/brotli.rs
+++ b/crates/consensus/protocol/src/brotli.rs
@@ -57,7 +57,7 @@ pub fn decompress_brotli(
         // Resize the output buffer to double the size, following standard
         // practice for buffer resizing in streams.
         let old_len = output.len();
-        let new_len = old_len * 2;
+        let new_len = old_len.checked_mul(2).ok_or(BrotliDecompressionError::BatchTooLarge)?;
 
         if new_len > max_rlp_bytes_per_channel {
             return Err(BrotliDecompressionError::BatchTooLarge);


### PR DESCRIPTION
## Why

The buffer resizing logic in decompress_brotli used direct multiplication
(old_len * 2) which could overflow usize for large buffers. This could
cause a panic in debug mode or wrap-around in release mode.

## How

Use checked_mul instead to safely handle the overflow case by returning
BatchTooLarge error when the buffer size calculation overflows.