### PR TITLE
fix(consensus): Detect And Discard Stale Pre-Built Payloads

### DIFF
--- a/crates/consensus/service/src/actors/sequencer/actor.rs
+++ b/crates/consensus/service/src/actors/sequencer/actor.rs
@@ -27,7 +27,8 @@ use crate::{
             conductor::Conductor,
             error::SequencerActorError,
             metrics::{
-                inc_seal_error, update_seal_duration_metrics, update_total_transactions_sequenced,
+                inc_seal_error, inc_stale_build_discarded, update_seal_duration_metrics,
+                update_total_transactions_sequenced,
             },
             origin_selector::OriginSelector,
             recovery::RecoveryModeGuard,
@@ -127,6 +128,74 @@ where
         update_total_transactions_sequenced(handle.attributes_with_parent.count_transactions());
 
         Ok(PayloadSealer::new(envelope))
+    }
+
+    /// Attempts to seal a pre-built payload, first checking whether it is still fresh.
+    ///
+    /// If the unsafe head has advanced past the handle's parent since build time (a P2P block
+    /// arrived while the build was in-flight), the handle is discarded and `Ok(None)` is
+    /// returned so the caller can restart with [`PayloadBuilder::build`].
+    ///
+    /// On success returns the new [`PayloadSealer`] together with the elapsed seal duration so
+    /// the caller can reschedule the ticker accurately. On a non-fatal seal error returns
+    /// `Ok(None)`. On a fatal error the cancellation token is triggered and `Err` is returned.
+    pub(super) async fn try_seal_handle(
+        &self,
+        handle: UnsealedPayloadHandle,
+    ) -> Result<Option<(PayloadSealer, Duration)>, SequencerActorError> {
+        let current_head = self.engine_client.get_unsafe_head().await?;
+        let build_parent = handle.attributes_with_parent.parent().block_info;
+
+        if current_head.block_info.number > build_parent.number {
+            warn!(
+                target: "sequencer",
+                parent_num = build_parent.number,
+                current_head_num = current_head.block_info.number,
+                "Stale build detected: unsafe head advanced past build parent, discarding"
+            );
+            inc_stale_build_discarded();
+            return Ok(None);
+        }
+
+        if current_head.block_info.number == build_parent.number
+            && current_head.block_info.hash != build_parent.hash
+        {
+            warn!(
+                target: "sequencer",
+                parent_num = build_parent.number,
+                expected_hash = %build_parent.hash,
+                actual_hash = %current_head.block_info.hash,
+                "Stale build detected: unsafe head reorged at same height, discarding"
+            );
+            inc_stale_build_discarded();
+            return Ok(None);
+        }
+
+        // Staleness check above is best-effort: if the unsafe head advances between the
+        // get_unsafe_head() call and seal_payload() below, the EL's own validation is
+        // the final safety gate.
+        let seal_start = Instant::now();
+        match self.seal_payload(&handle).await {
+            Ok(sealer) => Ok(Some((sealer, seal_start.elapsed()))),
+            Err(SequencerActorError::EngineError(EngineClientError::SealError(err))) => {
+                if err.is_fatal() {
+                    error!(target: "sequencer", error = ?err, "Critical seal task error occurred");
+                    inc_seal_error(true);
+                    self.cancellation_token.cancel();
+                    return Err(SequencerActorError::EngineError(EngineClientError::SealError(
+                        err,
+                    )));
+                }
+                warn!(target: "sequencer", error = ?err, "Non-fatal seal error, dropping block");
+                inc_seal_error(false);
+                Ok(None)
+            }
+            Err(other_err) => {
+                error!(target: "sequencer", error = ?other_err, "Unexpected error sealing payload");
+                self.cancellation_token.cancel();
+                Err(other_err)
+            }
+        }
     }
 
     /// Schedules the initial engine reset request and waits for the unsafe head to be updated.
@@ -294,16 +363,26 @@ where
                 // next block starts, so the canonical head actually advances.
                 _ = build_ticker.tick(), if self.is_active && self.sealer.is_none() => {
                     if let Some(handle) = next_payload_to_seal.take() {
-                        let seal_start = Instant::now();
-                        match self.seal_payload(&handle).await {
-                            Ok(new_sealer) => {
-                                last_seal_duration = seal_start.elapsed();
+                        // Extract data needed after try_seal_handle consumes the handle.
+                        let parent_beacon_root = handle
+                            .attributes_with_parent
+                            .attributes()
+                            .payload_attributes
+                            .parent_beacon_block_root;
+                        let handle_timestamp = handle
+                            .attributes_with_parent
+                            .attributes()
+                            .payload_attributes
+                            .timestamp;
+                        match self.try_seal_handle(handle).await? {
+                            Some((new_sealer, dur)) => {
+                                last_seal_duration = dur;
                                 // Stash the expected parent for the next build. This is consumed
                                 // in the Ok(true) arm after insert_unsafe_payload is queued,
                                 // ensuring BuildTask is enqueued after InsertTask in the engine.
                                 self.next_build_parent = match L2BlockInfo::from_payload_and_genesis(
                                     new_sealer.envelope.execution_payload.clone(),
-                                    handle.attributes_with_parent.attributes().payload_attributes.parent_beacon_block_root,
+                                    parent_beacon_root,
                                     &self.rollup_config.genesis,
                                 ) {
                                     Ok(parent) => Some(parent),
@@ -321,12 +400,8 @@ where
                                 // Schedule the next tick for the next block's target seal time.
                                 // Use the just-sealed block's timestamp; the next block's
                                 // timestamp is one block_time later.
-                                let next_block_seconds = handle
-                                    .attributes_with_parent
-                                    .attributes()
-                                    .payload_attributes
-                                    .timestamp
-                                    .saturating_add(self.rollup_config.block_time);
+                                let next_block_seconds =
+                                    handle_timestamp.saturating_add(self.rollup_config.block_time);
                                 let next_block_time = UNIX_EPOCH
                                     + Duration::from_secs(next_block_seconds)
                                     - last_seal_duration;
@@ -338,16 +413,9 @@ where
                                 // Ok(true) arm after insert_unsafe_payload has been queued,
                                 // so InsertTask always precedes BuildTask in the engine queue.
                             }
-                            Err(SequencerActorError::EngineError(EngineClientError::SealError(err))) => {
-                                if err.is_fatal() {
-                                    error!(target: "sequencer", error = ?err, "Critical seal task error occurred");
-                                    inc_seal_error(true);
-                                    self.cancellation_token.cancel();
-                                    return Err(SequencerActorError::EngineError(EngineClientError::SealError(err)));
-                                }
-                                warn!(target: "sequencer", error = ?err, "Non-fatal seal error, dropping block");
-                                inc_seal_error(false);
-                                // Rebuild immediately on the current unsafe head.
+                            None => {
+                                // Stale build or non-fatal seal error: rebuild immediately on
+                                // the current unsafe head.
                                 next_payload_to_seal = self.builder.build().await?;
                                 if let Some(ref payload) = next_payload_to_seal {
                                     let next_block_seconds = payload
@@ -366,11 +434,6 @@ where
                                 } else {
                                     build_ticker.reset_immediately();
                                 }
-                            }
-                            Err(other_err) => {
-                                error!(target: "sequencer", error = ?other_err, "Unexpected error sealing payload");
-                                self.cancellation_token.cancel();
-                                return Err(other_err);
                             }
                         }
                     } else {

--- a/crates/consensus/service/src/actors/sequencer/metrics.rs
+++ b/crates/consensus/service/src/actors/sequencer/metrics.rs
@@ -117,3 +117,8 @@ pub(super) fn inc_recovery_mode_block() {
 pub(super) fn inc_drift_empty_block() {
     base_macros::inc!(counter, crate::Metrics::SEQUENCER_DRIFT_EMPTY_BLOCKS_TOTAL);
 }
+
+#[inline]
+pub(super) fn inc_stale_build_discarded() {
+    base_macros::inc!(counter, crate::Metrics::SEQUENCER_STALE_BUILD_DISCARDED_TOTAL);
+}

--- a/crates/consensus/service/src/actors/sequencer/tests/actor_test.rs
+++ b/crates/consensus/service/src/actors/sequencer/tests/actor_test.rs
@@ -1,4 +1,4 @@
-use std::sync::Arc;
+use std::{sync::Arc, time::Duration};
 
 use alloy_primitives::B256;
 use alloy_rpc_types_engine::ExecutionPayloadV1;
@@ -7,15 +7,19 @@ use base_alloy_rpc_types_engine::{
     OpExecutionPayload, OpExecutionPayloadEnvelope, OpPayloadAttributes,
 };
 use base_consensus_derive::{BuilderError, PipelineErrorKind, test_utils::TestAttributesBuilder};
+#[cfg(test)]
+use base_consensus_engine::SealTaskError;
 use base_protocol::{BlockInfo, L2BlockInfo, OpAttributesWithParent};
 use rstest::rstest;
 
 #[cfg(test)]
 use crate::{
-    ConductorError, SealState, SealStepError, SequencerActorError, UnsealedPayloadHandle,
+    ConductorError, SealState, SealStepError, SequencerActorError, UnsafePayloadGossipClientError,
+    UnsealedPayloadHandle,
     actors::{
         MockConductor, MockOriginSelector, MockSequencerEngineClient,
         MockUnsafePayloadGossipClient,
+        engine::EngineClientError,
         sequencer::{PayloadSealer, tests::test_util::test_actor},
     },
 };
@@ -48,6 +52,147 @@ fn conductor_rpc_error() -> ConductorError {
 
 fn dummy_attributes_with_parent() -> OpAttributesWithParent {
     OpAttributesWithParent::new(OpPayloadAttributes::default(), L2BlockInfo::default(), None, false)
+}
+
+fn handle_with_parent_number(number: u64) -> UnsealedPayloadHandle {
+    handle_with_parent(number, B256::ZERO)
+}
+
+fn handle_with_parent(number: u64, hash: B256) -> UnsealedPayloadHandle {
+    let parent = L2BlockInfo {
+        block_info: BlockInfo { number, hash, ..Default::default() },
+        ..Default::default()
+    };
+    UnsealedPayloadHandle {
+        payload_id: Default::default(),
+        attributes_with_parent: OpAttributesWithParent::new(
+            OpPayloadAttributes::default(),
+            parent,
+            None,
+            false,
+        ),
+    }
+}
+
+fn head_at(number: u64) -> L2BlockInfo {
+    head_at_with_hash(number, B256::ZERO)
+}
+
+fn head_at_with_hash(number: u64, hash: B256) -> L2BlockInfo {
+    L2BlockInfo {
+        block_info: BlockInfo { number, hash, ..Default::default() },
+        ..Default::default()
+    }
+}
+
+// --- try_seal_handle tests ---
+
+#[tokio::test]
+async fn test_try_seal_handle_current_head_equals_parent_seals() {
+    // head.number == parent.number AND head.hash == parent.hash → not stale; seal proceeds.
+    // Use a distinct non-zero hash so the hash equality check is actually exercised.
+    let hash = B256::from([0xcc; 32]);
+
+    let mut client = MockSequencerEngineClient::new();
+    client.expect_get_unsafe_head().times(1).return_once(move || Ok(head_at_with_hash(5, hash)));
+    client.expect_get_sealed_payload().times(1).return_once(|_, _| Ok(dummy_envelope()));
+
+    let mut actor = test_actor();
+    actor.engine_client = Arc::new(client);
+
+    let (sealer, dur) = actor.try_seal_handle(handle_with_parent(5, hash)).await.unwrap().unwrap();
+    assert_eq!(sealer.state, SealState::Sealed);
+    assert!(dur < Duration::from_secs(10));
+}
+
+#[tokio::test]
+async fn test_try_seal_handle_current_head_ahead_of_parent_discards() {
+    // head > parent → stale; seal_payload must NOT be called.
+    let mut client = MockSequencerEngineClient::new();
+    client.expect_get_unsafe_head().times(1).return_once(|| Ok(head_at(6)));
+    client.expect_get_sealed_payload().times(0);
+
+    let mut actor = test_actor();
+    actor.engine_client = Arc::new(client);
+
+    let result = actor.try_seal_handle(handle_with_parent_number(5)).await;
+
+    assert!(result.unwrap().is_none());
+}
+
+#[tokio::test]
+async fn test_try_seal_handle_same_height_reorg_discards() {
+    // head.number == parent.number but head.hash != parent.hash → same-height reorg; discard.
+    let parent_hash = B256::from([0xaa; 32]);
+    let reorged_hash = B256::from([0xbb; 32]);
+
+    let mut client = MockSequencerEngineClient::new();
+    client
+        .expect_get_unsafe_head()
+        .times(1)
+        .return_once(move || Ok(head_at_with_hash(5, reorged_hash)));
+    client.expect_get_sealed_payload().times(0);
+
+    let mut actor = test_actor();
+    actor.engine_client = Arc::new(client);
+
+    let result = actor.try_seal_handle(handle_with_parent(5, parent_hash)).await;
+
+    assert!(result.unwrap().is_none());
+}
+
+#[tokio::test]
+async fn test_try_seal_handle_get_unsafe_head_error_propagates() {
+    let mut client = MockSequencerEngineClient::new();
+    client
+        .expect_get_unsafe_head()
+        .times(1)
+        .return_once(|| Err(EngineClientError::RequestError("channel closed".to_string())));
+    client.expect_get_sealed_payload().times(0);
+
+    let mut actor = test_actor();
+    actor.engine_client = Arc::new(client);
+
+    let result = actor.try_seal_handle(handle_with_parent_number(5)).await;
+
+    assert!(result.is_err());
+}
+
+#[tokio::test]
+async fn test_try_seal_handle_fatal_seal_error_cancels_and_propagates() {
+    // A fatal seal error must cancel the token and return Err.
+    let mut client = MockSequencerEngineClient::new();
+    client.expect_get_unsafe_head().times(1).return_once(|| Ok(head_at(5)));
+    client.expect_get_sealed_payload().times(1).return_once(|_, _| {
+        Err(EngineClientError::SealError(SealTaskError::DepositOnlyPayloadFailed))
+    });
+
+    let mut actor = test_actor();
+    actor.engine_client = Arc::new(client);
+
+    let result = actor.try_seal_handle(handle_with_parent_number(5)).await;
+
+    assert!(result.is_err());
+    assert!(actor.cancellation_token.is_cancelled());
+}
+
+#[tokio::test]
+async fn test_try_seal_handle_non_fatal_seal_error_returns_none() {
+    // A non-fatal seal error must return Ok(None) and leave the token uncancelled.
+    let mut client = MockSequencerEngineClient::new();
+    client.expect_get_unsafe_head().times(1).return_once(|| Ok(head_at(5)));
+    client
+        .expect_get_sealed_payload()
+        .times(1)
+        .return_once(|_, _| Err(EngineClientError::SealError(SealTaskError::HoloceneInvalidFlush)));
+
+    let mut actor = test_actor();
+    actor.engine_client = Arc::new(client);
+
+    let result = actor.try_seal_handle(handle_with_parent_number(5)).await;
+
+    assert!(result.unwrap().is_none());
+    assert!(!actor.cancellation_token.is_cancelled());
 }
 
 // --- build tests ---
@@ -117,8 +262,6 @@ async fn test_seal_payload_success_returns_sealer() {
 
 #[tokio::test]
 async fn test_seal_payload_failure_propagates() {
-    use crate::actors::engine::EngineClientError;
-
     let mut client = MockSequencerEngineClient::new();
     client
         .expect_get_sealed_payload()
@@ -215,8 +358,6 @@ async fn test_sealer_conductor_failure_stays_sealed() {
 
 #[tokio::test]
 async fn test_sealer_gossip_failure_stays_committed() {
-    use crate::UnsafePayloadGossipClientError;
-
     let envelope = dummy_envelope();
 
     let mut gossip = MockUnsafePayloadGossipClient::new();
@@ -239,8 +380,6 @@ async fn test_sealer_gossip_failure_stays_committed() {
 
 #[tokio::test]
 async fn test_sealer_insert_failure_stays_gossiped() {
-    use crate::actors::engine::EngineClientError;
-
     let envelope = dummy_envelope();
 
     let mut gossip = MockUnsafePayloadGossipClient::new();

--- a/crates/consensus/service/src/actors/sequencer/tests/actor_test.rs
+++ b/crates/consensus/service/src/actors/sequencer/tests/actor_test.rs
@@ -7,12 +7,10 @@ use base_alloy_rpc_types_engine::{
     OpExecutionPayload, OpExecutionPayloadEnvelope, OpPayloadAttributes,
 };
 use base_consensus_derive::{BuilderError, PipelineErrorKind, test_utils::TestAttributesBuilder};
-#[cfg(test)]
 use base_consensus_engine::SealTaskError;
 use base_protocol::{BlockInfo, L2BlockInfo, OpAttributesWithParent};
 use rstest::rstest;
 
-#[cfg(test)]
 use crate::{
     ConductorError, SealState, SealStepError, SequencerActorError, UnsafePayloadGossipClientError,
     UnsealedPayloadHandle,

--- a/crates/consensus/service/src/metrics/mod.rs
+++ b/crates/consensus/service/src/metrics/mod.rs
@@ -54,6 +54,10 @@ impl Metrics {
     /// Counter for empty blocks produced due to sequencer drift threshold.
     pub const SEQUENCER_DRIFT_EMPTY_BLOCKS_TOTAL: &str =
         "base_node_sequencer_drift_empty_blocks_total";
+    /// Counter for pre-built payloads discarded because the unsafe head advanced past their
+    /// parent before sealing (stale build detection).
+    pub const SEQUENCER_STALE_BUILD_DISCARDED_TOTAL: &str =
+        "base_node_sequencer_stale_build_discarded_total";
 
     /// Initializes metrics for the node service.
     ///
@@ -141,6 +145,10 @@ impl Metrics {
             Self::SEQUENCER_DRIFT_EMPTY_BLOCKS_TOTAL,
             "Empty blocks produced due to sequencer drift threshold"
         );
+        metrics::describe_counter!(
+            Self::SEQUENCER_STALE_BUILD_DISCARDED_TOTAL,
+            "Pre-built payloads discarded because the unsafe head advanced past their parent"
+        );
     }
 
     /// Initializes metrics to `0` so they can be queried immediately by consumers of prometheus
@@ -172,5 +180,6 @@ impl Metrics {
         base_macros::set!(counter, Self::SEQUENCER_STOP_DEFERRED_TOTAL, 0);
         base_macros::set!(counter, Self::SEQUENCER_RECOVERY_MODE_BLOCKS_TOTAL, 0);
         base_macros::set!(counter, Self::SEQUENCER_DRIFT_EMPTY_BLOCKS_TOTAL, 0);
+        base_macros::set!(counter, Self::SEQUENCER_STALE_BUILD_DISCARDED_TOTAL, 0);
     }
 }


### PR DESCRIPTION
## Summary

When a P2P unsafe block arrives while a sequencer build is in-flight, the pre-built payload's parent becomes stale and sealing it would fork the chain from the wrong head. This fix adds a staleness check in a new `try_seal_handle` method that reads the current unsafe head before sealing and discards the handle if the head has advanced past the payload's parent block number. A `SEQUENCER_STALE_BUILD_DISCARDED_TOTAL` counter metric is also added so operators can observe how often this condition occurs. Three unit tests cover the seal, discard, and error-propagation paths of the new method.