### PR TITLE
chore(metrics): add version info gauge to registrar, fix proposer error handling

### DIFF
--- a/bin/prover-registrar/src/cli.rs
+++ b/bin/prover-registrar/src/cli.rs
@@ -317,7 +317,7 @@ impl Cli {
         metrics_config
             .init_with(|| {
                 base_cli_utils::register_version_metrics!();
-                RegistrarMetrics::record_startup();
+                RegistrarMetrics::record_startup(env!("CARGO_PKG_VERSION"));
             })
             .wrap_err("failed to install Prometheus recorder")?;
 

--- a/crates/proof/proposer/src/service.rs
+++ b/crates/proof/proposer/src/service.rs
@@ -19,7 +19,7 @@ use base_proof_rpc::{
     RollupProvider,
 };
 use base_tx_manager::{BaseTxMetrics, SimpleTxManager, TxManager};
-use eyre::Result;
+use eyre::{Result, WrapErr};
 use jsonrpsee::http_client::HttpClientBuilder;
 use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
@@ -50,7 +50,7 @@ pub async fn run(config: ProposerConfig) -> Result<()> {
     let signal_handle = RuntimeManager::install_signal_handler(cancel.clone());
 
     // ── 2. Metrics recorder and HTTP server (if enabled) ─────────────────
-    config.metrics.init().map_err(|e| eyre::eyre!("failed to install Prometheus recorder: {e}"))?;
+    config.metrics.init().wrap_err("failed to install Prometheus recorder")?;
 
     // Record startup metrics (no-ops if no recorder installed).
     record_startup_metrics(env!("CARGO_PKG_VERSION"));

--- a/crates/proof/proposer/src/service.rs
+++ b/crates/proof/proposer/src/service.rs
@@ -50,7 +50,7 @@ pub async fn run(config: ProposerConfig) -> Result<()> {
     let signal_handle = RuntimeManager::install_signal_handler(cancel.clone());
 
     // ── 2. Metrics recorder and HTTP server (if enabled) ─────────────────
-    config.metrics.init().expect("failed to install Prometheus recorder");
+    config.metrics.init().map_err(|e| eyre::eyre!("failed to install Prometheus recorder: {e}"))?;
 
     // Record startup metrics (no-ops if no recorder installed).
     record_startup_metrics(env!("CARGO_PKG_VERSION"));

--- a/crates/proof/tee/registrar/src/metrics.rs
+++ b/crates/proof/tee/registrar/src/metrics.rs
@@ -5,6 +5,9 @@
 pub struct RegistrarMetrics;
 
 impl RegistrarMetrics {
+    /// Gauge: registrar build info, labelled with `version`.
+    pub const INFO: &str = "base_registrar_info";
+
     /// Gauge: registrar is running (set to 1 at startup, 0 on shutdown).
     pub const UP: &str = "base_registrar_up";
 
@@ -20,10 +23,12 @@ impl RegistrarMetrics {
     /// Counter: total number of processing errors encountered.
     pub const PROCESSING_ERRORS_TOTAL: &str = "base_registrar_processing_errors_total";
 
-    /// Sets the UP gauge to 1. Called once at startup inside the metrics
-    /// recorder's `init_with` callback (version info is handled separately
-    /// by `register_version_metrics!`).
-    pub fn record_startup() {
+    /// Label key for version.
+    pub const LABEL_VERSION: &str = "version";
+
+    /// Records startup metrics (INFO gauge with version label, UP gauge set to 1).
+    pub fn record_startup(version: &str) {
+        metrics::gauge!(Self::INFO, Self::LABEL_VERSION => version.to_string()).set(1.0);
         metrics::gauge!(Self::UP).set(1.0);
     }
 
@@ -44,10 +49,11 @@ mod tests {
 
     #[rstest]
     fn record_startup_does_not_panic() {
-        RegistrarMetrics::record_startup();
+        RegistrarMetrics::record_startup("0.0.0-test");
     }
 
     #[rstest]
+    #[case::info(RegistrarMetrics::INFO)]
     #[case::up(RegistrarMetrics::UP)]
     #[case::registrations(RegistrarMetrics::REGISTRATIONS_TOTAL)]
     #[case::deregistrations(RegistrarMetrics::DEREGISTRATIONS_TOTAL)]


### PR DESCRIPTION
## Summary

- Add a `base_registrar_info` gauge labelled with the build version to the registrar startup metrics, matching the existing proposer pattern (`base_proposer_info`).
- Replace `.expect()` with proper error propagation (`map_err` + `?`) in the proposer metrics initialisation to avoid panics on recorder install failure.
- Update registrar metrics tests to cover the new `INFO` constant and `version` parameter.