### PR TITLE
docs(nitro-attestation-prover): ZK verification pipeline and on-chain trust model

### DIFF
--- a/crates/proof/tee/nitro-attestation-prover/README.md
+++ b/crates/proof/tee/nitro-attestation-prover/README.md
@@ -22,7 +22,7 @@ Nitro hardware to on-chain signer registration:
 
 ### What the ZK proof does (offchain, inside the RISC Zero guest)
 
-1. **Parses the COSE_Sign1 envelope** — decodes the CBOR-encoded attestation
+1. **Parses the `COSE_Sign1` envelope** — decodes the CBOR-encoded attestation
    document from the raw bytes returned by the Nitro Secure Module (NSM).
 2. **Validates attestation content** — checks that the document is well-formed:
    non-empty `module_id`, non-zero `timestamp`, `digest == "SHA384"`, valid
@@ -40,7 +40,7 @@ Nitro hardware to on-chain signer registration:
    These are *proven outputs* — the ZK proof guarantees they were
    extracted from a genuine, unmodified attestation document.
 
-### What the on-chain contract does (TEEProverRegistry)
+### What the on-chain contract does (`TEEProverRegistry`)
 
 The contract calls `NitroEnclaveVerifier.verify()` to check the ZK proof,
 then applies policy checks on the proven journal:

--- a/crates/proof/tee/nitro-attestation-prover/README.md
+++ b/crates/proof/tee/nitro-attestation-prover/README.md
@@ -15,6 +15,51 @@ verifiable proofs:
 The guest ELF is loaded at runtime (from disk or IPFS) rather than embedded at
 compile time, so the risc0 toolchain is not required for building this crate.
 
+## How attestation verification works
+
+The ZK proof pipeline establishes a cryptographic chain of trust from AWS
+Nitro hardware to on-chain signer registration:
+
+### What the ZK proof does (offchain, inside the RISC Zero guest)
+
+1. **Parses the COSE_Sign1 envelope** — decodes the CBOR-encoded attestation
+   document from the raw bytes returned by the Nitro Secure Module (NSM).
+2. **Validates attestation content** — checks that the document is well-formed:
+   non-empty `module_id`, non-zero `timestamp`, `digest == "SHA384"`, valid
+   PCR indices and sizes, and optional field size limits (M-02 audit fix).
+3. **Verifies the x509 certificate chain** — validates the full chain from
+   the AWS Nitro root CA down to the leaf certificate, checking signatures,
+   validity periods, and key usage constraints (M-01 audit fix).
+4. **Verifies the COSE signature** — confirms the attestation document was
+   signed by the leaf certificate's P384 key, proving it came from genuine
+   AWS Nitro hardware and was not tampered with.
+5. **Outputs the verified data as a `VerifierJournal`** — the journal
+   contains the attestation's PCR0 (enclave image hash), public key
+   (signer identity), timestamp, and certificate chain. These are
+   *proven outputs* — the ZK proof guarantees they were extracted from
+   a genuine, unmodified attestation document.
+
+### What the on-chain contract does (TEEProverRegistry)
+
+The contract calls `NitroEnclaveVerifier.verify()` to check the ZK proof,
+then applies policy checks on the proven journal:
+
+- **PCR0 validation** — compares the attestation's PCR0 against
+  `TEE_IMAGE_HASH` from the current `AggregateVerifier` (looked up via
+  `DisputeGameFactory` and `gameType`). Reverts with `PCR0Mismatch` if
+  the enclave image doesn't match.
+- **Freshness check** — rejects attestations older than `MAX_AGE` (60 min).
+- **Signer derivation** — derives the signer address from the attestation's
+  public key (`keccak256` of the uncompressed ECDSA key, truncated to 20 bytes).
+
+### Why this split matters
+
+The ZK proof guarantees **authenticity** (the attestation came from real
+hardware and wasn't modified). The on-chain contract enforces **policy**
+(the enclave is running the expected image). This separation means the ZK
+circuit never needs to change when the expected PCR0 rotates — only the
+on-chain configuration is updated.
+
 ## Modules
 
 - **`error`** — [`ProverError`] enum covering verification, risc0, and

--- a/crates/proof/tee/nitro-attestation-prover/README.md
+++ b/crates/proof/tee/nitro-attestation-prover/README.md
@@ -34,10 +34,11 @@ Nitro hardware to on-chain signer registration:
    signed by the leaf certificate's P384 key, proving it came from genuine
    AWS Nitro hardware and was not tampered with.
 5. **Outputs the verified data as a `VerifierJournal`** — the journal
-   contains the attestation's PCR0 (enclave image hash), public key
-   (signer identity), timestamp, and certificate chain. These are
-   *proven outputs* — the ZK proof guarantees they were extracted from
-   a genuine, unmodified attestation document.
+   contains all Platform Configuration Registers (PCRs, including
+   PCR0 — the enclave image hash), public key (from the attestation
+   document's optional field), timestamp, and certificate chain hashes.
+   These are *proven outputs* — the ZK proof guarantees they were
+   extracted from a genuine, unmodified attestation document.
 
 ### What the on-chain contract does (TEEProverRegistry)
 


### PR DESCRIPTION
## Summary
- Document the 5-step ZK proof verification pipeline (COSE parsing, content validation, x509 chain, signature verification, journal output)
- Explain the offchain / on-chain trust split: ZK proves authenticity, contract enforces policy (PCR0 matching)
- Clarify why the ZK circuit doesn't need to change when PCR0 rotates

## Test plan
- Documentation only, no code changes