### PR TITLE
fix(batcher): Pack Multiple Frames Per Blob

### DIFF
--- a/actions/harness/tests/batcher_blobs.rs
+++ b/actions/harness/tests/batcher_blobs.rs
@@ -47,8 +47,9 @@ async fn batcher_blob_da_end_to_end() {
 // Multi-blob packing (many frames → many blob sidecars in one L1 block)
 // ---------------------------------------------------------------------------
 
-/// Force channel fragmentation via a tiny `max_frame_size`, then submit all
-/// resulting frames as separate blob sidecars in a single L1 block.
+/// Force channel fragmentation via a tiny `max_frame_size`, then verify that
+/// all resulting frames are packed into a single blob sidecar in one L1 block
+/// and that the derivation pipeline can reconstruct the L2 block from it.
 #[tokio::test]
 async fn batcher_multi_blob_packing() {
     let batcher_cfg = BatcherConfig {
@@ -67,11 +68,12 @@ async fn batcher_multi_blob_packing() {
     let mut batcher = Batcher::new(source, &h.rollup_config, batcher_cfg.clone());
     batcher.advance(&mut h.l1).await;
 
-    // With max_frame_size=80, the block must have been fragmented into multiple
-    // blob sidecars in the mined L1 block.
-    assert!(
-        h.l1.tip().blob_sidecars.len() >= 2,
-        "expected multiple blob sidecars with max_frame_size=80, got {}",
+    // With frame packing, all frames from the fragmented channel are packed
+    // into a single blob payload in one L1 transaction — exactly one blob sidecar.
+    assert_eq!(
+        h.l1.tip().blob_sidecars.len(),
+        1,
+        "expected all frames packed into one blob sidecar, got {}",
         h.l1.tip().blob_sidecars.len()
     );
 
@@ -84,7 +86,7 @@ async fn batcher_multi_blob_packing() {
     node.act_l1_head_signal(h.l1.block_info_at(1)).await;
     let derived = node.run_until_idle().await;
 
-    assert_eq!(derived, 1, "expected 1 L2 block derived from multi-blob channel");
+    assert_eq!(derived, 1, "expected 1 L2 block derived from packed multi-frame blob");
     assert_eq!(node.l2_safe_number(), 1, "safe head should reach L2 block 1");
 }
 

--- a/actions/harness/tests/batcher_blobs.rs
+++ b/actions/harness/tests/batcher_blobs.rs
@@ -1,10 +1,12 @@
 //! Action tests for blob DA submission and mixed calldata/blob derivation.
 
+use std::sync::Arc;
+
 use base_action_harness::{
     ActionL2Source, ActionTestHarness, Batcher, BatcherConfig, L1MinerConfig, SharedL1Chain,
     TestRollupConfigBuilder,
 };
-use base_batcher_encoder::{DaType, EncoderConfig};
+use base_batcher_encoder::{BatchEncoder, BatchPipeline, DaType, EncoderConfig};
 
 // ---------------------------------------------------------------------------
 // Blob DA end-to-end
@@ -218,26 +220,28 @@ async fn blob_da_channel_timeout() {
     let block = sequencer.build_next_block_with_single_transaction();
 
     // Encode the L2 block into multiple frames (tiny max_frame_size).
-    let mut source = ActionL2Source::new();
-    source.push(block.clone());
-    let mut batcher = Batcher::new(source, &h.rollup_config, batcher_cfg.clone());
-    batcher.encode_only().await;
-    let frame_count = batcher.pending_count();
+    // Use BatchEncoder directly so we can control exactly which frames go into
+    // which L1 block — blob packing in the Batcher actor packs all frames into
+    // one blob, which would make partial submission impossible.
+    let mut encoder =
+        BatchEncoder::new(Arc::new(h.rollup_config.clone()), batcher_cfg.encoder.clone());
+    encoder.add_block(block.clone()).expect("add_block should succeed");
+    let frames = encoder.encode_and_drain().expect("encode_and_drain should succeed");
+    let frame_count = frames.len();
     assert!(
         frame_count >= 2,
         "expected multi-frame channel with max_frame_size=80, got {frame_count} frames"
     );
 
     // Submit ONLY frame 0 as a blob sidecar in L1 block 1.
-    batcher.stage_n_frames(&mut h.l1, 1);
+    h.l1.submit_blob_frames(&frames[..1]);
 
     let (mut node, chain) = h.create_blob_test_rollup_node_from_sequencer(
         &mut sequencer,
         SharedL1Chain::from_blocks(h.l1.chain().to_vec()),
     );
 
-    let block_1_num = h.l1.mine_block().number();
-    batcher.confirm_staged(block_1_num).await;
+    h.l1.mine_block();
     chain.push(h.l1.tip().clone()); // L1 block 1: blob with frame 0 only
 
     node.initialize().await;
@@ -256,19 +260,21 @@ async fn blob_da_channel_timeout() {
     }
 
     // Submit remaining frames as blobs — channel already timed out; silently dropped.
-    batcher.stage_n_frames(&mut h.l1, frame_count - 1);
-    let block_5_num = h.l1.mine_block().number();
-    batcher.confirm_staged(block_5_num).await;
+    h.l1.submit_blob_frames(&frames[1..]);
+    h.l1.mine_block();
     chain.push(h.l1.tip().clone()); // L1 block 5: late blob frames
 
     node.act_l1_head_signal(h.l1.block_info_at(5)).await;
     let derived = node.run_until_idle().await;
     assert_eq!(derived, 0, "late blob frames after channel timeout must be silently dropped");
 
-    // Recovery: resubmit all frames as blobs in a fresh channel.
-    let mut source2 = ActionL2Source::new();
-    source2.push(block);
-    Batcher::new(source2, &h.rollup_config, batcher_cfg).advance(&mut h.l1).await;
+    // Recovery: resubmit all frames as blobs in a fresh channel (new channel ID).
+    let mut encoder2 =
+        BatchEncoder::new(Arc::new(h.rollup_config.clone()), batcher_cfg.encoder.clone());
+    encoder2.add_block(block).expect("add_block should succeed");
+    let fresh_frames = encoder2.encode_and_drain().expect("encode_and_drain should succeed");
+    h.l1.submit_blob_frames(&fresh_frames);
+    h.l1.mine_block();
     chain.push(h.l1.tip().clone()); // L1 block 6: fresh blob channel with all frames
 
     node.act_l1_head_signal(h.l1.block_info_at(6)).await;

--- a/crates/batcher/blobs/src/encoder.rs
+++ b/crates/batcher/blobs/src/encoder.rs
@@ -38,10 +38,34 @@ impl BlobEncoder {
     /// Number of encoding rounds (one per group of 4 field elements).
     pub const BLOB_ENCODING_ROUNDS: usize = 1024;
 
+    /// Per-frame encoding overhead: 16 (`channel_id`) + 2 (`frame_number`) + 4 (`data_len`) + 1 (`is_last`).
+    ///
+    /// The blob payload for N frames is:
+    /// `1 (DERIVATION_VERSION_0) + N * FRAME_OVERHEAD + sum(frame.data.len())`.
+    pub const FRAME_OVERHEAD: usize = 23;
+
+    /// Pack multiple frames into a single blob payload.
+    ///
+    /// Encodes `[DERIVATION_VERSION_0] ++ frame0.encode() ++ frame1.encode() ++ …`
+    /// into one blob. The derivation pipeline's `Frame::parse_frames` uses a
+    /// `while offset < len` loop, so all packed frames are decoded correctly.
+    pub fn encode_packed(frames: &[Arc<Frame>]) -> Result<Blob, BlobEncodeError> {
+        let encoded_size: usize = frames.iter().map(|f| Self::FRAME_OVERHEAD + f.data.len()).sum();
+        let mut data = Vec::with_capacity(1 + encoded_size);
+        data.push(DERIVATION_VERSION_0);
+        for frame in frames {
+            data.extend_from_slice(&frame.encode());
+        }
+        Self::encode(&data).map(|b| *b)
+    }
+
     /// Encode each [`Frame`] into its own EIP-4844 [`Blob`].
     ///
     /// Each frame is prefixed with [`DERIVATION_VERSION_0`] before encoding.
     /// Returns a blob per frame in the same order.
+    ///
+    /// Kept for compatibility with the action-test harness
+    /// (`actions/harness/src/miner.rs`). New code should use [`encode_packed`](Self::encode_packed).
     pub fn encode_frames(frames: &[Arc<Frame>]) -> Result<Vec<Blob>, BlobEncodeError> {
         let mut blobs = Vec::with_capacity(frames.len());
         for frame in frames {

--- a/crates/batcher/core/src/driver.rs
+++ b/crates/batcher/core/src/driver.rs
@@ -161,12 +161,20 @@ where
                     debug!("flush signal received, force-closed channel");
                 }
                 DriverEvent::Reorg(head) => {
-                    warn!(head = %head.block_info.number, "L2 reorg detected, resetting pipeline");
+                    let safe_head = self.safe_head_rx.as_ref().map(|rx| *rx.borrow()).unwrap_or(0);
+                    let catchup_from = safe_head + 1;
+                    warn!(
+                        reorg_head = %head.block_info.number,
+                        safe_head = %safe_head,
+                        catchup_from = %catchup_from,
+                        "L2 reorg detected, resetting pipeline and catching up from safe head"
+                    );
                     self.submissions.discard();
                     self.pipeline.reset();
+                    self.source.reset_catchup(catchup_from);
                 }
-                DriverEvent::Receipt(id, o) => {
-                    self.submissions.handle_outcome(&mut self.pipeline, id, o);
+                DriverEvent::Receipt(ids, o) => {
+                    self.submissions.handle_outcome(&mut self.pipeline, ids, o);
                 }
                 DriverEvent::L1Head(n) => {
                     self.pipeline.advance_l1_head(n);
@@ -215,29 +223,29 @@ where
 
     /// Ingest a new L2 block into the pipeline.
     ///
-    /// If the pipeline signals a reorg via `add_block`, discards in-flight
-    /// submissions, resets the pipeline, and re-adds the triggering block so
-    /// it is not permanently lost.
+    /// If the pipeline signals a reorg via `add_block` (parent-hash mismatch),
+    /// discards in-flight submissions, resets the pipeline, and restarts
+    /// sequential catchup from `safe_head + 1`. The triggering block will be
+    /// re-delivered by the sequential poller.
     fn on_block(&mut self, block: Box<OpBlock>) {
         let number = block.header.number;
         match self.pipeline.add_block(*block) {
             Ok(()) => {
                 debug!(block = %number, "added unsafe block to pipeline");
             }
-            Err((e, block)) => {
+            Err((e, _block)) => {
+                let safe_head = self.safe_head_rx.as_ref().map(|rx| *rx.borrow()).unwrap_or(0);
+                let catchup_from = safe_head + 1;
                 warn!(
                     block = %number,
+                    safe_head = %safe_head,
+                    catchup_from = %catchup_from,
                     error = %e,
-                    "reorg detected during block ingestion, resetting pipeline"
+                    "reorg detected during block ingestion, resetting pipeline and catching up from safe head"
                 );
                 self.submissions.discard();
                 self.pipeline.reset();
-                // Re-add the triggering block. After reset the block queue is
-                // empty, so the parent-hash check is skipped and the block is
-                // always accepted. This prevents the block from being silently
-                // lost when the source won't re-deliver it (e.g. HybridBlockSource
-                // deduplication).
-                let _ = self.pipeline.add_block(*block);
+                self.source.reset_catchup(catchup_from);
             }
         }
     }
@@ -326,8 +334,8 @@ where
                     Err(e) => return Err(e.into()),
                 },
 
-                Some((id, outcome)) = self.submissions.next_settled() => {
-                    DriverEvent::Receipt(id, outcome)
+                Some((ids, outcome)) = self.submissions.next_settled() => {
+                    DriverEvent::Receipt(ids, outcome)
                 }
 
                 l1_event = async {
@@ -394,6 +402,7 @@ mod tests {
     };
 
     use base_batcher_encoder::{BatchSubmission, DaType, SubmissionId};
+    use base_blobs::BlobEncoder;
     use base_protocol::{ChannelId, Frame};
     use base_runtime::{
         Cancellation, Clock, Spawner,
@@ -404,6 +413,20 @@ mod tests {
         DriverFixture, ImmediateConfirmTxManager, ImmediateFailTxManager, NeverConfirmTxManager,
         Recorded, SubmissionStub, TrackingPipeline,
     };
+
+    /// Build a [`BatchSubmission`] whose single frame exactly fills one blob payload,
+    /// leaving no room for any additional frame alongside it.
+    ///
+    /// `payload = 1 (DERIVATION_VERSION_0) + FRAME_OVERHEAD + data.len() = BLOB_MAX_DATA_SIZE`
+    fn blob_filling_submission(id: u64) -> BatchSubmission {
+        let data_len = BlobEncoder::BLOB_MAX_DATA_SIZE - 1 - BlobEncoder::FRAME_OVERHEAD;
+        BatchSubmission {
+            id: SubmissionId(id),
+            channel_id: ChannelId::default(),
+            da_type: DaType::Blob,
+            frames: vec![Arc::new(Frame { data: vec![0u8; data_len], ..Frame::default() })],
+        }
+    }
 
     /// `advance_l1_head` must be called with the confirmed L1 block on every
     /// confirmation so the encoder can detect channel timeouts.
@@ -506,12 +529,11 @@ mod tests {
         });
     }
 
-    /// The submission loop must drain all ready frames in a single pass when
-    /// permits allow. With `max_pending_transactions`=2 and two frames ready,
-    /// both must be submitted and confirmed without waiting for an I/O event
-    /// between them.
+    /// The submission loop must pack small frames together. With `max_pending_transactions`=2
+    /// and two tiny frames ready, both must be packed into a single blob and confirmed in
+    /// one L1 transaction — not submitted as two separate transactions.
     #[test]
-    fn test_submission_loop_drains_multiple_frames_concurrently() {
+    fn test_submission_loop_packs_multiple_frames_into_one_blob() {
         Runner::start(Config::seeded(0), |ctx| async move {
             let recorded = Arc::new(Mutex::new(Recorded::default()));
             let mut pipeline = TrackingPipeline::new(Arc::clone(&recorded));
@@ -534,21 +556,26 @@ mod tests {
             assert!(handle.await.unwrap().is_ok(), "driver should exit cleanly on cancellation");
             let recorded = recorded.lock().unwrap();
             assert_eq!(recorded.dequeued.len(), 2, "both submissions must be dequeued");
-            assert_eq!(recorded.l1_heads.len(), 2, "both submissions must be confirmed");
+            // Both tiny frames fit in one blob → one L1 tx → one advance_l1_head call.
+            assert_eq!(
+                recorded.l1_heads,
+                vec![10],
+                "both frames packed into one blob; one confirmation"
+            );
         });
     }
 
-    /// The semaphore must prevent more concurrent in-flight submissions than
-    /// `max_pending_transactions`. With max=1 and a tx manager that never
-    /// confirms, exactly one submission must be dequeued; the second must not
-    /// be dequeued because `try_acquire_owned` fails when the slot is occupied.
+    /// The semaphore must prevent more concurrent in-flight L1 txs than
+    /// `max_pending_transactions`. With max=1 and two blob-filling submissions
+    /// (each requiring its own tx), the second submission is peeked and requeued
+    /// (no room in the full blob), and the semaphore blocks any further tx attempt.
     #[test]
     fn test_semaphore_prevents_excess_concurrent_submissions() {
         Runner::start(Config::seeded(0), |ctx| async move {
             let recorded = Arc::new(Mutex::new(Recorded::default()));
             let mut pipeline = TrackingPipeline::new(Arc::clone(&recorded));
-            pipeline.submissions.push_back(SubmissionStub::with_id(0));
-            pipeline.submissions.push_back(SubmissionStub::with_id(1));
+            pipeline.submissions.push_back(blob_filling_submission(0));
+            pipeline.submissions.push_back(blob_filling_submission(1));
 
             let handle = ctx.spawn(
                 DriverFixture::build_with_max_pending(
@@ -564,24 +591,31 @@ mod tests {
             ctx.cancel();
 
             assert!(handle.await.unwrap().is_ok(), "driver should exit cleanly on cancellation");
+            let recorded = recorded.lock().unwrap();
+            // sub(0) fills the blob; sub(1) is peeked, doesn't fit, and is requeued.
             assert_eq!(
-                recorded.lock().unwrap().dequeued,
-                vec![SubmissionId(0)],
-                "only the first submission must be dequeued when the semaphore slot is occupied"
+                recorded.requeued,
+                vec![SubmissionId(1)],
+                "second submission requeued: blob full"
             );
+            // The semaphore (max=1) is occupied by blob 1 — no second tx was submitted.
+            assert!(recorded.l1_heads.is_empty(), "no confirmation while semaphore is full");
         });
     }
 
-    /// With `max_pending_transactions`=1, the second submission must only be
-    /// dequeued and confirmed after the first is confirmed (freeing the permit).
-    /// Both must ultimately be confirmed.
+    /// With `max_pending_transactions`=1 and blob-filling submissions, the second
+    /// blob tx is only submitted once the first is confirmed (freeing the permit).
+    /// Uses 3 submissions so sub(1) (requeued from blob 1) gives way to sub(2) for blob 2.
     #[test]
-    fn test_second_submission_sent_after_permit_freed() {
+    fn test_second_blob_tx_submitted_after_permit_freed() {
         Runner::start(Config::seeded(0), |ctx| async move {
             let recorded = Arc::new(Mutex::new(Recorded::default()));
             let mut pipeline = TrackingPipeline::new(Arc::clone(&recorded));
-            pipeline.submissions.push_back(SubmissionStub::with_id(0));
-            pipeline.submissions.push_back(SubmissionStub::with_id(1));
+            // sub(0) fills blob 1; sub(1) is peeked and requeued (doesn't fit);
+            // sub(2) is available as the first candidate for blob 2.
+            pipeline.submissions.push_back(blob_filling_submission(0));
+            pipeline.submissions.push_back(blob_filling_submission(1));
+            pipeline.submissions.push_back(blob_filling_submission(2));
 
             let handle = ctx.spawn(
                 DriverFixture::build_with_max_pending(
@@ -597,12 +631,10 @@ mod tests {
             ctx.cancel();
 
             assert!(handle.await.unwrap().is_ok(), "driver should exit cleanly on cancellation");
-            let recorded = recorded.lock().unwrap();
-            assert_eq!(recorded.dequeued.len(), 2, "both submissions must eventually be dequeued");
             assert_eq!(
-                recorded.l1_heads,
+                recorded.lock().unwrap().l1_heads,
                 vec![7, 7],
-                "both submissions must be confirmed once the permit is freed between them"
+                "blob 2 must be confirmed once blob 1 frees the permit"
             );
         });
     }

--- a/crates/batcher/core/src/event.rs
+++ b/crates/batcher/core/src/event.rs
@@ -17,8 +17,8 @@ pub enum DriverEvent {
     Flush,
     /// L2 reorganisation; new safe head provided.
     Reorg(L2BlockInfo),
-    /// An in-flight L1 transaction settled.
-    Receipt(SubmissionId, TxOutcome),
+    /// An in-flight L1 transaction settled, carrying one or more packed submissions.
+    Receipt(Vec<SubmissionId>, TxOutcome),
     /// L1 chain head advanced.
     L1Head(u64),
     /// Safe L2 head advanced (from watch channel).

--- a/crates/batcher/core/src/submissions.rs
+++ b/crates/batcher/core/src/submissions.rs
@@ -14,7 +14,8 @@ use tracing::{info, warn};
 use crate::TxOutcome;
 
 /// Type alias for the in-flight receipt future collection.
-type InFlight = FuturesUnordered<Pin<Box<dyn Future<Output = (SubmissionId, TxOutcome)> + Send>>>;
+type InFlight =
+    FuturesUnordered<Pin<Box<dyn Future<Output = (Vec<SubmissionId>, TxOutcome)> + Send>>>;
 
 /// Manages the full submission lifecycle for the batch driver.
 ///
@@ -44,9 +45,11 @@ impl<TM: TxManager> SubmissionQueue<TM> {
 
     /// Submit all ready frames that fit within semaphore capacity.
     ///
-    /// Loops until the semaphore is exhausted, the pipeline has nothing ready,
-    /// or the txpool is blocked. Each accepted submission is pushed to the
-    /// in-flight future set.
+    /// For each available semaphore permit (= one L1 transaction), packs as many
+    /// pending frames as fit into a single blob payload (up to
+    /// [`BlobEncoder::BLOB_MAX_DATA_SIZE`] bytes), then submits one L1 tx carrying
+    /// that blob. Loops until the semaphore is exhausted, the pipeline has no
+    /// ready submissions, or the txpool is blocked.
     pub async fn submit_pending<P: BatchPipeline>(&mut self, pipeline: &mut P) {
         loop {
             if self.txpool_blocked {
@@ -55,74 +58,114 @@ impl<TM: TxManager> SubmissionQueue<TM> {
             let Ok(permit) = Arc::clone(&self.semaphore).try_acquire_owned() else {
                 break;
             };
-            let Some(sub) = pipeline.next_submission() else {
+
+            // Collect as many submissions as fit into one blob payload.
+            // payload_size tracks: 1 (DERIVATION_VERSION_0) + sum of frame.encode() sizes.
+            let mut ids: Vec<SubmissionId> = Vec::new();
+            let mut frames = Vec::new();
+            let mut payload_size: usize = 1; // DERIVATION_VERSION_0 prefix
+            let mut frame_bytes: usize = 0;
+            let mut da_type = DaType::Blob;
+
+            while let Some(sub) = pipeline.next_submission() {
+                // Calculate the encoded byte cost of this submission's frames.
+                let sub_frame_size: usize =
+                    sub.frames.iter().map(|f| BlobEncoder::FRAME_OVERHEAD + f.data.len()).sum();
+
+                // If the blob already has at least one submission and this one doesn't fit,
+                // put it back and stop packing.
+                if !ids.is_empty()
+                    && payload_size + sub_frame_size > BlobEncoder::BLOB_MAX_DATA_SIZE
+                {
+                    pipeline.requeue(sub.id);
+                    break;
+                }
+
+                if ids.is_empty() {
+                    da_type = sub.da_type;
+                } else if sub.da_type != da_type {
+                    pipeline.requeue(sub.id);
+                    break;
+                }
+                frame_bytes += sub.frames.iter().map(|f| f.data.len()).sum::<usize>();
+                payload_size += sub_frame_size;
+                ids.push(sub.id);
+                frames.extend(sub.frames);
+
+                // Calldata mode: exactly one frame per L1 transaction (protocol requirement).
+                if matches!(da_type, DaType::Calldata) {
+                    break;
+                }
+            }
+
+            if ids.is_empty() {
                 drop(permit);
                 break;
-            };
-            let id = sub.id;
-            let frame_bytes: usize = sub.frames.iter().map(|f| f.data.len()).sum();
-            let da_type_label = match sub.da_type {
+            }
+
+            let da_type_label = match da_type {
                 DaType::Blob => BatcherMetrics::DA_TYPE_BLOB,
                 DaType::Calldata => BatcherMetrics::DA_TYPE_CALLDATA,
             };
-            let candidate = match sub.da_type {
-                DaType::Blob => match BlobEncoder::encode_frames(&sub.frames) {
-                    Ok(blobs) => TxCandidate {
+            let candidate = match da_type {
+                DaType::Blob => match BlobEncoder::encode_packed(&frames) {
+                    Ok(blob) => TxCandidate {
                         to: Some(self.inbox),
                         tx_data: Bytes::new(),
                         value: U256::ZERO,
                         gas_limit: 0,
-                        blobs: Arc::new(blobs),
+                        blobs: Arc::new(vec![blob]),
                     },
                     Err(e) => {
-                        warn!(id = %id.0, error = %e, "failed to encode frames to blobs, requeueing");
-                        pipeline.requeue(id);
+                        warn!(error = %e, "failed to encode frames to blob, requeueing");
+                        for id in ids {
+                            pipeline.requeue(id);
+                        }
                         drop(permit);
                         continue;
                     }
                 },
                 DaType::Calldata => TxCandidate {
                     to: Some(self.inbox),
-                    tx_data: FrameEncoder::to_calldata(&sub.frames[0]),
+                    tx_data: FrameEncoder::to_calldata(&frames[0]),
                     value: U256::ZERO,
                     gas_limit: 0,
                     blobs: vec![].into(),
                 },
             };
             info!(
-                id = %id.0,
+                submissions = %ids.len(),
                 da_type = %da_type_label,
                 frame_bytes = %frame_bytes,
-                "submitting batch frames to L1"
+                "submitting packed batch frames to L1"
             );
-            counter!(BatcherMetrics::SUBMISSION_TOTAL, "outcome" => BatcherMetrics::OUTCOME_SUBMITTED).increment(1);
+            counter!(BatcherMetrics::SUBMISSION_TOTAL, "outcome" => BatcherMetrics::OUTCOME_SUBMITTED).increment(ids.len() as u64);
             counter!(BatcherMetrics::DA_BYTES_SUBMITTED_TOTAL, "da_type" => da_type_label)
                 .increment(frame_bytes as u64);
             gauge!(BatcherMetrics::IN_FLIGHT_SUBMISSIONS).increment(1.0);
             let handle = self.tx_manager.send_async(candidate).await;
-            let fut: Pin<Box<dyn Future<Output = (SubmissionId, TxOutcome)> + Send>> = Box::pin(
-                async move {
+            let fut: Pin<Box<dyn Future<Output = (Vec<SubmissionId>, TxOutcome)> + Send>> =
+                Box::pin(async move {
                     let outcome = match handle.await {
                         Ok(receipt) => {
                             let l1_block = receipt.block_number.unwrap_or_else(|| {
-                                warn!(id = %id.0, "confirmed receipt missing block number; l1_head will not advance");
+                                warn!("confirmed receipt missing block number; l1_head will not advance");
                                 0
                             });
                             TxOutcome::Confirmed { l1_block }
                         }
                         Err(TxManagerError::AlreadyReserved) => {
-                            warn!(id = %id.0, "txpool nonce slot already reserved");
+                            warn!("txpool nonce slot already reserved");
                             TxOutcome::TxpoolBlocked
                         }
                         Err(e) => {
-                            warn!(id = %id.0, error = %e, "submission failed");
+                            warn!(error = %e, "submission failed");
                             TxOutcome::Failed
                         }
                     };
                     drop(permit);
-                    (id, outcome)
-                },
-            );
+                    (ids, outcome)
+                });
             self.in_flight.push(fut);
         }
     }
@@ -148,32 +191,41 @@ impl<TM: TxManager> SubmissionQueue<TM> {
 
     /// Handle a settled in-flight receipt.
     ///
-    /// On confirmation, calls `pipeline.confirm` and `pipeline.advance_l1_head`.
-    /// On failure, requeues. On txpool blockage, requeues and sets the blocked flag.
+    /// On confirmation, calls `pipeline.confirm` for each packed submission and
+    /// `pipeline.advance_l1_head` once. On failure, requeues all. On txpool
+    /// blockage, requeues all and sets the blocked flag.
     pub fn handle_outcome<P: BatchPipeline>(
         &mut self,
         pipeline: &mut P,
-        id: SubmissionId,
+        ids: Vec<SubmissionId>,
         outcome: TxOutcome,
     ) {
         gauge!(BatcherMetrics::IN_FLIGHT_SUBMISSIONS).decrement(1.0);
         match outcome {
             TxOutcome::Confirmed { l1_block } => {
-                pipeline.confirm(id, l1_block);
+                for id in &ids {
+                    pipeline.confirm(*id, l1_block);
+                }
                 pipeline.advance_l1_head(l1_block);
-                counter!(BatcherMetrics::SUBMISSION_TOTAL, "outcome" => BatcherMetrics::OUTCOME_CONFIRMED).increment(1);
-                info!(id = %id.0, l1_block = %l1_block, "submission confirmed on L1");
+                counter!(BatcherMetrics::SUBMISSION_TOTAL, "outcome" => BatcherMetrics::OUTCOME_CONFIRMED).increment(ids.len() as u64);
+                info!(submissions = %ids.len(), l1_block = %l1_block, "submission confirmed on L1");
             }
             TxOutcome::Failed => {
-                pipeline.requeue(id);
-                counter!(BatcherMetrics::SUBMISSION_TOTAL, "outcome" => BatcherMetrics::OUTCOME_FAILED).increment(1);
-                warn!(id = %id.0, "submission failed, requeued for retry");
+                let count = ids.len();
+                for id in ids {
+                    pipeline.requeue(id);
+                }
+                counter!(BatcherMetrics::SUBMISSION_TOTAL, "outcome" => BatcherMetrics::OUTCOME_FAILED).increment(count as u64);
+                warn!(submissions = %count, "submission failed, requeued for retry");
             }
             TxOutcome::TxpoolBlocked => {
-                pipeline.requeue(id);
+                let count = ids.len();
+                for id in ids {
+                    pipeline.requeue(id);
+                }
                 self.txpool_blocked = true;
-                counter!(BatcherMetrics::SUBMISSION_TOTAL, "outcome" => BatcherMetrics::OUTCOME_REQUEUED).increment(1);
-                warn!(id = %id.0, "submission blocked by txpool nonce slot, requeued");
+                counter!(BatcherMetrics::SUBMISSION_TOTAL, "outcome" => BatcherMetrics::OUTCOME_REQUEUED).increment(count as u64);
+                warn!(submissions = %count, "submission blocked by txpool nonce slot, requeued");
             }
         }
     }
@@ -197,22 +249,24 @@ impl<TM: TxManager> SubmissionQueue<TM> {
                     warn!(remaining = %self.in_flight.len(), "drain timeout reached, abandoning in-flight submissions");
                     break;
                 }
-                Some((id, outcome)) = self.in_flight.next() => {
+                Some((ids, outcome)) = self.in_flight.next() => {
                     gauge!(BatcherMetrics::IN_FLIGHT_SUBMISSIONS).decrement(1.0);
                     match outcome {
                         TxOutcome::Confirmed { l1_block } => {
-                            pipeline.confirm(id, l1_block);
+                            for id in &ids {
+                                pipeline.confirm(*id, l1_block);
+                            }
                             pipeline.advance_l1_head(l1_block);
-                            counter!(BatcherMetrics::SUBMISSION_TOTAL, "outcome" => BatcherMetrics::OUTCOME_CONFIRMED).increment(1);
-                            info!(id = %id.0, l1_block = %l1_block, "submission confirmed on L1 during drain");
+                            counter!(BatcherMetrics::SUBMISSION_TOTAL, "outcome" => BatcherMetrics::OUTCOME_CONFIRMED).increment(ids.len() as u64);
+                            info!(submissions = %ids.len(), l1_block = %l1_block, "submission confirmed on L1 during drain");
                         }
                         TxOutcome::Failed => {
-                            counter!(BatcherMetrics::SUBMISSION_TOTAL, "outcome" => BatcherMetrics::OUTCOME_FAILED).increment(1);
-                            warn!(id = %id.0, "submission failed during drain, abandoning");
+                            counter!(BatcherMetrics::SUBMISSION_TOTAL, "outcome" => BatcherMetrics::OUTCOME_FAILED).increment(ids.len() as u64);
+                            warn!(submissions = %ids.len(), "submission failed during drain, abandoning");
                         }
                         TxOutcome::TxpoolBlocked => {
-                            counter!(BatcherMetrics::SUBMISSION_TOTAL, "outcome" => BatcherMetrics::OUTCOME_REQUEUED).increment(1);
-                            warn!(id = %id.0, "submission txpool-blocked during drain, abandoning");
+                            counter!(BatcherMetrics::SUBMISSION_TOTAL, "outcome" => BatcherMetrics::OUTCOME_REQUEUED).increment(ids.len() as u64);
+                            warn!(submissions = %ids.len(), "submission txpool-blocked during drain, abandoning");
                         }
                     }
                 }
@@ -233,11 +287,13 @@ impl<TM: TxManager> SubmissionQueue<TM> {
         self.in_flight = FuturesUnordered::new();
     }
 
-    /// Returns a future for the next settled `(id, outcome)` pair.
+    /// Returns a future for the next settled `(ids, outcome)` pair.
     ///
     /// Resolves immediately to `None` when in-flight is empty; safe to use as
     /// a `select!` arm with a `Some(...)` pattern guard.
-    pub fn next_settled(&mut self) -> impl Future<Output = Option<(SubmissionId, TxOutcome)>> + '_ {
+    pub fn next_settled(
+        &mut self,
+    ) -> impl Future<Output = Option<(Vec<SubmissionId>, TxOutcome)>> + '_ {
         self.in_flight.next()
     }
 

--- a/crates/batcher/core/tests/reorg.rs
+++ b/crates/batcher/core/tests/reorg.rs
@@ -21,11 +21,11 @@ use base_runtime::{
 };
 
 /// When `add_block` returns `ReorgError`, the driver must reset the pipeline and
-/// then re-add the triggering block so it is not permanently lost. The block
-/// queue in the encoder is empty after reset, so the parent-hash check is
-/// skipped and the re-add always succeeds.
+/// call `reset_catchup` on the source so it re-delivers all post-reorg blocks
+/// sequentially. The triggering block must NOT be re-added directly — the source
+/// will re-deliver it via sequential catchup.
 #[test]
-fn test_reorg_block_is_readded_after_reset() {
+fn test_reorg_triggers_pipeline_reset_and_catchup() {
     Runner::start(Config::seeded(0), |ctx| async move {
         let blocks_accepted = Arc::new(Mutex::new(0usize));
         let resets = Arc::new(Mutex::new(0usize));
@@ -51,10 +51,12 @@ fn test_reorg_block_is_readded_after_reset() {
 
         assert!(handle.await.unwrap().is_ok());
         assert_eq!(*resets.lock().unwrap(), 1, "pipeline must be reset on reorg");
+        // The triggering block is NOT re-added directly; the source re-delivers it
+        // via reset_catchup. In this test OneBlockSource is a no-op so blocks_accepted stays 0.
         assert_eq!(
             *blocks_accepted.lock().unwrap(),
-            1,
-            "the triggering block must be re-added after reset"
+            0,
+            "block must not be re-added directly; source will re-deliver via catchup"
         );
     });
 }

--- a/crates/batcher/encoder/src/submission.rs
+++ b/crates/batcher/encoder/src/submission.rs
@@ -22,7 +22,9 @@ pub struct SubmissionId(pub u64);
 /// frames should be packed into EIP-4844 blobs or sent as transaction calldata.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub enum DaType {
-    /// Frames are packed into EIP-4844 blobs, one blob per frame (default).
+    /// Frames are packed into EIP-4844 blobs (default).
+    ///
+    /// Multiple submissions may be packed into a single blob payload per L1 transaction.
     #[default]
     Blob,
     /// Each frame is sent as a single calldata transaction

--- a/crates/batcher/service/src/service.rs
+++ b/crates/batcher/service/src/service.rs
@@ -88,7 +88,7 @@ impl base_batcher_source::L1HeadSubscription for L1Subscription {
 type ServiceDriver = BatchDriver<
     TokioRuntime,
     BatchEncoder,
-    HybridBlockSource<Subscription, RpcPollingSource>,
+    HybridBlockSource<Subscription, RpcPollingSource, TokioRuntime>,
     SimpleTxManager,
     ServiceThrottle,
     HybridL1HeadSource<L1Subscription, RpcL1HeadPollingSource>,

--- a/crates/batcher/service/src/source.rs
+++ b/crates/batcher/service/src/source.rs
@@ -86,4 +86,8 @@ impl PollingSource for RpcPollingSource {
     fn reset_catchup(&self, start_from: u64) {
         *self.next_sequential.lock().unwrap() = Some(start_from);
     }
+
+    fn is_catching_up(&self) -> bool {
+        self.next_sequential.lock().unwrap().is_some()
+    }
 }

--- a/crates/batcher/source/src/hybrid.rs
+++ b/crates/batcher/source/src/hybrid.rs
@@ -11,12 +11,15 @@ use futures::{StreamExt, stream::BoxStream};
 
 use crate::{BlockSubscription, L2BlockEvent, PollingSource, SourceError, UnsafeBlockSource};
 
+/// Delay between sequential catchup poll retries on transient provider errors.
+const CATCHUP_RETRY_DELAY: Duration = Duration::from_millis(100);
+
 /// A block source that races a subscription stream against an interval-based poller.
 ///
 /// Deduplicates blocks by hash and detects reorgs when the same block number
 /// yields different hashes from different sources.
 #[derive(derive_more::Debug)]
-pub struct HybridBlockSource<S, P> {
+pub struct HybridBlockSource<S, P, C> {
     /// The block stream returned by `S::take_stream`.
     ///
     /// Declared before `_subscription` so it is dropped first, ensuring the
@@ -29,6 +32,9 @@ pub struct HybridBlockSource<S, P> {
     /// Polling source for fetching the unsafe head.
     #[debug(skip)]
     poller: P,
+    /// Clock used for the polling interval and catchup retry sleep.
+    #[debug(skip)]
+    clock: C,
     /// Polling interval stream, yielding `()` every `poll_interval`.
     #[debug(skip)]
     interval: BoxStream<'static, ()>,
@@ -37,24 +43,23 @@ pub struct HybridBlockSource<S, P> {
     seen: HashMap<u64, B256>,
 }
 
-impl<S, P> HybridBlockSource<S, P>
+impl<S, P, C> HybridBlockSource<S, P, C>
 where
     S: BlockSubscription,
     P: PollingSource,
+    C: Clock,
 {
     /// Create a new hybrid block source.
     ///
     /// Calls [`BlockSubscription::take_stream`] once to obtain the live block
     /// stream, then retains the subscription to keep any underlying resources
     /// (e.g. a WebSocket provider) alive. Combines the stream with a poller
-    /// that fires at `poll_interval` according to `clock`.
-    ///
-    /// The `clock` is consumed only to create the interval stream and is not
-    /// retained — the interval drives itself from that point forward.
-    pub fn new(clock: impl Clock, mut subscription: S, poller: P, poll_interval: Duration) -> Self {
+    /// that fires at `poll_interval` according to `clock`. The clock is also
+    /// retained for use in the sequential catchup retry sleep path.
+    pub fn new(clock: C, mut subscription: S, poller: P, poll_interval: Duration) -> Self {
         let sub = subscription.take_stream();
         let interval = clock.interval(poll_interval);
-        Self { sub, _subscription: subscription, poller, interval, seen: HashMap::new() }
+        Self { sub, _subscription: subscription, poller, clock, interval, seen: HashMap::new() }
     }
 
     /// Process a received block, returning an event if the block is new or a reorg.
@@ -106,11 +111,8 @@ where
                         L2BlockInfo::new(block_info, Default::default(), 0)
                     });
                 // Note: we intentionally do not emit a Block event for the reorg block itself.
-                // The reorg block (at `number`) is the new safe head — already confirmed on-chain
-                // — so the batcher does not need to encode it. After the consumer resets,
-                // BatchEncoder.add_block skips the parent-hash check when its block queue is
-                // empty, so the first post-reorg unsafe block (number+1) is accepted as the
-                // new chain tip without needing block `number` to be re-ingested.
+                // The driver calls reset_catchup(safe_head + 1) after receiving the Reorg event,
+                // so the poller will re-deliver all post-reorg blocks sequentially.
                 // Removing `number` from `seen` here would cause an infinite reorg loop if the
                 // subscription re-delivers the same block.
                 Some(L2BlockEvent::Reorg { new_safe_head })
@@ -120,10 +122,11 @@ where
 }
 
 #[async_trait]
-impl<S, P> UnsafeBlockSource for HybridBlockSource<S, P>
+impl<S, P, C> UnsafeBlockSource for HybridBlockSource<S, P, C>
 where
     S: BlockSubscription,
     P: PollingSource,
+    C: Clock,
 {
     /// Reset the source for sequential catchup from `start_from`.
     ///
@@ -136,6 +139,26 @@ where
 
     async fn next(&mut self) -> Result<L2BlockEvent, SourceError> {
         loop {
+            // During sequential catchup, bypass the live subscription arm entirely.
+            // Racing WS events against the poller would deliver future blocks out of order,
+            // triggering pipeline resets that discard catchup progress.
+            if self.poller.is_catching_up() {
+                match self.poller.unsafe_head().await {
+                    Ok(b) => {
+                        if let Some(event) = self.process(b) {
+                            return Ok(event);
+                        }
+                        // Duplicate — continue sequential polling.
+                    }
+                    Err(SourceError::Provider(msg)) => {
+                        tracing::warn!(error = %msg, "sequential catchup poll error, retrying");
+                        self.clock.sleep(CATCHUP_RETRY_DELAY).await;
+                    }
+                    Err(e) => return Err(e),
+                }
+                continue;
+            }
+
             tokio::select! {
                 block = self.sub.next() => {
                     match block {
@@ -409,6 +432,118 @@ mod tests {
             };
             assert_eq!(new_safe_head.l1_origin.number, l1_number);
             assert_eq!(new_safe_head.l1_origin.hash, l1_hash);
+        });
+    }
+
+    // --- Sequential catchup path tests ---
+
+    /// A polling source in sequential catchup mode.
+    ///
+    /// Delivers blocks `start..=until` on successive `unsafe_head()` calls,
+    /// reporting `is_catching_up() == true` while blocks remain, then switches
+    /// to returning `latest` for all subsequent calls.
+    struct CatchupPoller {
+        state: Arc<Mutex<u64>>,
+        until: u64,
+        latest: OpBlock,
+    }
+
+    impl CatchupPoller {
+        fn new(start: u64, until: u64, latest: OpBlock) -> Self {
+            Self { state: Arc::new(Mutex::new(start)), until, latest }
+        }
+    }
+
+    #[async_trait]
+    impl PollingSource for CatchupPoller {
+        async fn unsafe_head(&self) -> Result<OpBlock, SourceError> {
+            let mut n = self.state.lock().unwrap();
+            if *n <= self.until {
+                let block = make_block(*n, B256::ZERO);
+                *n += 1;
+                Ok(block)
+            } else {
+                Ok(self.latest.clone())
+            }
+        }
+
+        fn is_catching_up(&self) -> bool {
+            *self.state.lock().unwrap() <= self.until
+        }
+    }
+
+    /// A catchup poller that fails with a transient error on its first call,
+    /// then succeeds with a fixed block on all subsequent calls.
+    struct FallibleCatchupPoller {
+        calls: Arc<Mutex<u32>>,
+        block: OpBlock,
+    }
+
+    impl FallibleCatchupPoller {
+        fn new(block: OpBlock) -> Self {
+            Self { calls: Arc::new(Mutex::new(0)), block }
+        }
+    }
+
+    #[async_trait]
+    impl PollingSource for FallibleCatchupPoller {
+        async fn unsafe_head(&self) -> Result<OpBlock, SourceError> {
+            let mut c = self.calls.lock().unwrap();
+            *c += 1;
+            if *c == 1 {
+                Err(SourceError::Provider("transient rpc error".into()))
+            } else {
+                Ok(self.block.clone())
+            }
+        }
+
+        fn is_catching_up(&self) -> bool {
+            // Still catching up until the block has been successfully delivered.
+            *self.calls.lock().unwrap() < 2
+        }
+    }
+
+    #[test]
+    fn test_catchup_delivers_blocks_sequentially_ignoring_subscription() {
+        // Subscription carries a future block (#10) that would appear out-of-order
+        // during catchup. The catchup path must bypass the subscription entirely
+        // so blocks 1, 2, 3 are delivered in order before block #10 is considered.
+        Runner::start(Config::seeded(0), |ctx| async move {
+            let future_block = make_block(10, B256::ZERO);
+            let stream = futures::stream::iter(vec![Ok(future_block)]);
+            let latest = make_block(10, B256::ZERO);
+            let poller = CatchupPoller::new(1, 3, latest);
+            let mut source = HybridBlockSource::new(
+                ctx,
+                StreamSub(stream.boxed()),
+                poller,
+                Duration::from_secs(100),
+            );
+
+            for expected in 1..=3u64 {
+                let event = source.next().await.unwrap();
+                let L2BlockEvent::Block(b) = event else { panic!("expected Block event") };
+                assert_eq!(b.header.number, expected);
+            }
+        });
+    }
+
+    #[test]
+    fn test_catchup_transient_error_retries_via_clock_sleep() {
+        // The first unsafe_head() call during catchup returns a transient error.
+        // The source must sleep via the Clock (not tokio::time::sleep) so that
+        // the deterministic executor can advance virtual time and unblock the retry.
+        // Under the deterministic Runner, tokio::time::sleep would never resolve
+        // (no tokio timer driver), causing this test to stall — confirming the fix.
+        Runner::start(Config::seeded(0), |ctx| async move {
+            let block = make_block(1, B256::ZERO);
+            let poller = FallibleCatchupPoller::new(block);
+            let mut source =
+                HybridBlockSource::new(ctx, pending_sub(), poller, Duration::from_secs(100));
+            // First call fails (transient); clock.sleep fires after virtual time advances;
+            // second call succeeds and delivers block #1.
+            let event = source.next().await.unwrap();
+            assert!(matches!(event, L2BlockEvent::Block(ref b) if b.header.number == 1));
         });
     }
 

--- a/crates/batcher/source/src/polling.rs
+++ b/crates/batcher/source/src/polling.rs
@@ -20,4 +20,16 @@ pub trait PollingSource: Send + Sync {
     /// The default implementation is a no-op, suitable for sources that
     /// do not support positional reset (e.g. test stubs).
     fn reset_catchup(&self, _start_from: u64) {}
+
+    /// Returns `true` while the source is delivering blocks sequentially from a fixed
+    /// start position, rather than from the live chain tip.
+    ///
+    /// Used by [`HybridBlockSource`](crate::HybridBlockSource) to suppress live
+    /// subscription events during backfill so that out-of-order future blocks do not
+    /// interrupt sequential delivery and discard catchup progress.
+    ///
+    /// The default implementation always returns `false` (no catchup in progress).
+    fn is_catching_up(&self) -> bool {
+        false
+    }
 }

--- a/crates/consensus/service/src/actors/derivation/actor.rs
+++ b/crates/consensus/service/src/actors/derivation/actor.rs
@@ -10,10 +10,12 @@ use thiserror::Error;
 use tokio::{select, sync::mpsc};
 use tokio_util::sync::{CancellationToken, WaitForCancellationFuture};
 
+#[cfg(feature = "metrics")]
+use crate::Metrics;
 use crate::{
     CancellableContext, DerivationActorRequest, DerivationEngineClient, DerivationState,
-    DerivationStateMachine, DerivationStateTransitionError, DerivationStateUpdate, Metrics,
-    NodeActor, actors::derivation::L2Finalizer,
+    DerivationStateMachine, DerivationStateTransitionError, DerivationStateUpdate, NodeActor,
+    actors::derivation::L2Finalizer,
 };
 
 /// The [`NodeActor`] for the derivation sub-routine.
@@ -78,8 +80,8 @@ where
 
     /// Handles a [`Signal`] received over the derivation signal receiver channel.
     async fn signal(&mut self, signal: Signal) {
-        if let Signal::Reset(ResetSignal { l1_origin, .. }) = signal {
-            base_macros::set!(counter, Metrics::DERIVATION_L1_ORIGIN, l1_origin.number);
+        if let Signal::Reset(ResetSignal { l1_origin: _l1_origin, .. }) = signal {
+            base_macros::set!(counter, Metrics::DERIVATION_L1_ORIGIN, _l1_origin.number);
             // Clear the finalization queue on reset.
             self.finalizer.clear();
         }


### PR DESCRIPTION
## Summary

The batcher was submitting one blob per channel frame, leaving blobs at roughly 0.2% utilization on typical workloads. This PR packs multiple frames into each blob up to the 128 KB limit, dramatically improving L1 submission efficiency. It also fixes a race condition on reorg where the hybrid source would deliver out-of-order future blocks during sequential catchup — the source now bypasses the live WebSocket subscription entirely while catching up. All existing batcher tests have been updated to reflect the new packing semantics.