### PR TITLE
fix(mempool): prevent panic in mempool rebroadcaster

### DIFF
--- a/crates/infra/mempool-rebroadcaster/src/rebroadcaster.rs
+++ b/crates/infra/mempool-rebroadcaster/src/rebroadcaster.rs
@@ -194,11 +194,13 @@ impl Rebroadcaster {
         for (account, nonce_txns) in &content.pending {
             for (nonce, txn) in nonce_txns {
                 if self.is_underpriced(txn, base_fee, gas_price) {
-                    filtered_content.pending.get_mut(account).unwrap().remove(nonce);
+                    if let Some(pending_account) = filtered_content.pending.get_mut(account) {
+                        pending_account.remove(nonce);
+                    }
                 }
             }
 
-            if filtered_content.pending.get(account).unwrap().is_empty() {
+            if filtered_content.pending.get(account).map_or(true, |txns| txns.is_empty()) {
                 filtered_content.pending.remove(account);
             }
         }
@@ -206,11 +208,13 @@ impl Rebroadcaster {
         for (account, nonce_txns) in &content.queued {
             for (nonce, txn) in nonce_txns {
                 if self.is_underpriced(txn, base_fee, gas_price) {
-                    filtered_content.queued.get_mut(account).unwrap().remove(nonce);
+                    if let Some(queued_account) = filtered_content.queued.get_mut(account) {
+                        queued_account.remove(nonce);
+                    }
                 }
             }
 
-            if filtered_content.queued.get(account).unwrap().is_empty() {
+            if filtered_content.queued.get(account).map_or(true, |txns| txns.is_empty()) {
                 filtered_content.queued.remove(account);
             }
         }


### PR DESCRIPTION
## Problem
The [filter_underpriced_txns](cci:1://file:///base/crates/infra/mempool-rebroadcaster/src/rebroadcaster.rs:184:4-222:5) function in mempool rebroadcaster calls `.unwrap()` on HashMap `get_mut()` and `get()` results without checking if the key exists. This can panic when iterating over accounts that were removed from `filtered_content` in previous iterations.

## Fix
Replaced all `.unwrap()` calls with safe Option handling using `if let Some()` for mutable access and `map_or(true, |txns| txns.is_empty())` for empty checks.

## Why this is safe
The fix maintains the same logic but prevents panics by safely handling cases where keys might not exist in the filtered HashMap. The `map_or(true, ...)` pattern ensures removal happens when the key doesn't exist or when the transaction list is empty.