### PR TITLE
fix(devnet): Fix Op-Conductor Rollup Config Parsing

### DIFF
--- a/etc/docker/docker-compose.ha.yml
+++ b/etc/docker/docker-compose.ha.yml
@@ -382,7 +382,7 @@ services:
       - ../../.devnet/conductor-0:/data
       - ../../.devnet/l2/configs:/genesis/l2:ro
     command:
-      - --rollup.config=/genesis/l2/rollup.json
+      - --rollup.config=/genesis/l2/rollup-conductor.json
       - --raft.server.id=sequencer-0
       - --raft.storage.dir=/data/raft
       - --raft.bootstrap=true
@@ -418,7 +418,7 @@ services:
       - ../../.devnet/conductor-1:/data
       - ../../.devnet/l2/configs:/genesis/l2:ro
     command:
-      - --rollup.config=/genesis/l2/rollup.json
+      - --rollup.config=/genesis/l2/rollup-conductor.json
       - --raft.server.id=sequencer-1
       - --raft.storage.dir=/data/raft
       - --raft.bootstrap=false
@@ -454,7 +454,7 @@ services:
       - ../../.devnet/conductor-2:/data
       - ../../.devnet/l2/configs:/genesis/l2:ro
     command:
-      - --rollup.config=/genesis/l2/rollup.json
+      - --rollup.config=/genesis/l2/rollup-conductor.json
       - --raft.server.id=sequencer-2
       - --raft.storage.dir=/data/raft
       - --raft.bootstrap=false

--- a/etc/scripts/devnet/setup-l2.sh
+++ b/etc/scripts/devnet/setup-l2.sh
@@ -167,6 +167,10 @@ else
   echo "Base V1 activation block is unset; leaving base.v1 and osakaTime unchanged"
 fi
 
+echo "Writing rollup-conductor.json (base fields stripped for op-conductor compatibility)..."
+jq 'del(.base)' "$OUTPUT_DIR/rollup.json" >"$OUTPUT_DIR/rollup-conductor.json"
+echo "rollup-conductor.json written to $OUTPUT_DIR/rollup-conductor.json"
+
 echo "Extracting L1 addresses..."
 op-deployer inspect l1 \
   --workdir "$OP_DEPLOYER_WORKDIR" \
@@ -213,6 +217,7 @@ echo ""
 echo "Files generated:"
 echo "  L2 genesis: $OUTPUT_DIR/genesis.json"
 echo "  Rollup config: $OUTPUT_DIR/rollup.json"
+echo "  Rollup config (conductor): $OUTPUT_DIR/rollup-conductor.json"
 echo "  L1 addresses: $OUTPUT_DIR/l1-addresses.json"
 echo "  Builder P2P key: $OUTPUT_DIR/builder-p2p-key.txt"
 echo ""


### PR DESCRIPTION
## Summary

op-conductor uses strict JSON unmarshaling and rejects unknown fields, causing all three conductor containers to exit immediately on startup. The devnet rollup.json contains a custom base.v1 field added by setup-l2.sh to track the Base V1 hardfork activation timestamp, which is incompatible with the upstream conductor parser. This fix generates a stripped rollup-conductor.json via jq del(.base) during L2 setup and points all op-conductor services at that file instead.