### PR TITLE
fix: remove duplicate dev-dependencies

### DIFF
--- a/crates/alloy/flashblocks/Cargo.toml
+++ b/crates/alloy/flashblocks/Cargo.toml
@@ -28,4 +28,3 @@ thiserror = { workspace = true, features = ["std"] }
 
 [dev-dependencies]
 rstest.workspace = true
-alloy-primitives = { workspace = true, features = ["serde"] }

--- a/crates/batcher/core/Cargo.toml
+++ b/crates/batcher/core/Cargo.toml
@@ -39,11 +39,9 @@ alloy-rpc-types-eth = { workspace = true, features = ["std"], optional = true }
 [dev-dependencies]
 rstest.workspace = true
 async-trait.workspace = true
-base-protocol = { workspace = true, features = ["std"] }
 alloy-consensus = { workspace = true, features = ["std"] }
 base-runtime = { workspace = true, features = ["test-utils"] }
 alloy-rpc-types-eth = { workspace = true, features = ["std"] }
-base-alloy-consensus = { workspace = true, features = ["std"] }
 tokio = { workspace = true, features = ["macros", "rt", "time"] }
 
 [[test]]

--- a/crates/builder/core/Cargo.toml
+++ b/crates/builder/core/Cargo.toml
@@ -207,7 +207,6 @@ base-builder-core = { path = ".", features = ["test-utils"] }
 
 # reth
 reth-ipc.workspace = true
-base-execution-rpc = { workspace = true, features = ["client"] }
 reth-node-builder = { workspace = true, features = ["test-utils"] }
 
 # alloy

--- a/crates/builder/metering/Cargo.toml
+++ b/crates/builder/metering/Cargo.toml
@@ -22,4 +22,3 @@ base-builder-core.workspace = true
 base-node-runner.workspace = true
 
 [dev-dependencies]
-alloy-primitives.workspace = true

--- a/crates/builder/publish/Cargo.toml
+++ b/crates/builder/publish/Cargo.toml
@@ -23,5 +23,4 @@ tokio = { workspace = true, features = ["net", "sync", "macros", "rt"] }
 
 [dev-dependencies]
 rstest.workspace = true
-tokio-tungstenite.workspace = true
 tokio = { workspace = true, features = ["net", "sync", "macros", "rt", "test-util"] }


### PR DESCRIPTION
Remove dependencies that are listed in both [dependencies] and [dev-dependencies]:
- base-alloy-flashblocks: alloy-primitives
- base-batcher-core: base-alloy-consensus, base-protocol
- base-builder-core: base-execution-rpc
- base-builder-metering: alloy-primitives
- base-builder-publish: tokio-tungstenite