### PR TITLE
chore(consensus): Chain-Aware Finalized Block Poll Interval

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3409,6 +3409,7 @@ dependencies = [
  "async-stream",
  "async-trait",
  "backon",
+ "base-alloy-chains",
  "base-alloy-consensus",
  "base-alloy-network",
  "base-alloy-provider",

--- a/bin/consensus/src/cli.rs
+++ b/bin/consensus/src/cli.rs
@@ -207,6 +207,7 @@ impl Follow {
             trust_rpc: self.l1_rpc_args.l1_trust_rpc,
             beacon_client: l1_beacon,
             engine_provider: RootProvider::new_http(self.l1_rpc_args.l1_eth_rpc.clone()),
+            finalized_poll_interval: L1Config::default_finalized_poll_interval(cfg.l1_chain_id),
         };
 
         FollowNode::new(

--- a/crates/consensus/service/Cargo.toml
+++ b/crates/consensus/service/Cargo.toml
@@ -40,6 +40,7 @@ alloy-provider = { workspace = true, features = ["reqwest", "reqwest-rustls-tls"
 alloy-transport-http = { workspace = true, features = ["reqwest", "reqwest-rustls-tls", "hyper", "hyper-tls", "jwt-auth"] }
 
 # base-alloy
+base-alloy-chains.workspace = true
 base-alloy-provider.workspace = true
 base-alloy-network.workspace = true
 base-alloy-consensus.workspace = true

--- a/crates/consensus/service/src/service/builder.rs
+++ b/crates/consensus/service/src/service/builder.rs
@@ -1,6 +1,6 @@
 //! Contains the builder for the [`RollupNode`].
 
-use std::sync::Arc;
+use std::{sync::Arc, time::Duration};
 
 use alloy_primitives::Bytes;
 use alloy_provider::RootProvider;
@@ -72,6 +72,11 @@ pub struct RollupNodeBuilder {
     /// Optional configuration for Derivation Delegate mode.
     /// When present, the node does not run derivation, instead trusting the configured delegate.
     pub derivation_delegate_config: Option<DerivationDelegateConfig>,
+    /// Override for the finalized-block poll interval.
+    ///
+    /// When `None`, [`L1Config::default_finalized_poll_interval`] is used to select a
+    /// chain-appropriate default derived from `config.l1_chain_id`.
+    pub finalized_poll_interval: Option<Duration>,
 }
 
 impl RollupNodeBuilder {
@@ -93,6 +98,7 @@ impl RollupNodeBuilder {
             rpc_config,
             sequencer_config: None,
             derivation_delegate_config: None,
+            finalized_poll_interval: None,
         }
     }
 
@@ -109,6 +115,15 @@ impl RollupNodeBuilder {
     /// Appends the [`SequencerConfig`] to the builder.
     pub fn with_sequencer_config(self, sequencer_config: SequencerConfig) -> Self {
         Self { sequencer_config: Some(sequencer_config), ..self }
+    }
+
+    /// Overrides the finalized-block poll interval.
+    ///
+    /// By default the interval is derived from `config.l1_chain_id` via
+    /// [`L1Config::default_finalized_poll_interval`]. Use this method when you need a
+    /// specific interval regardless of chain (e.g. in integration tests).
+    pub fn with_finalized_poll_interval(self, interval: Duration) -> Self {
+        Self { finalized_poll_interval: Some(interval), ..self }
     }
 
     /// Sets the Derivation Delegate configuration, trusting the configured delegate for safe head
@@ -138,11 +153,16 @@ impl RollupNodeBuilder {
             l1_beacon = l1_beacon.with_l1_slot_duration_override(l1_slot_duration);
         }
 
+        let finalized_poll_interval = self
+            .finalized_poll_interval
+            .unwrap_or_else(|| L1Config::default_finalized_poll_interval(self.config.l1_chain_id));
+
         let l1_config = L1Config {
             chain_config: Arc::new(self.l1_config_builder.chain_config),
             trust_rpc: self.l1_config_builder.trust_rpc,
             beacon_client: l1_beacon,
             engine_provider: RootProvider::new_http(self.l1_config_builder.rpc_url.clone()),
+            finalized_poll_interval,
         };
 
         let jwt_secret = self.engine_config.l2_jwt_secret;

--- a/crates/consensus/service/src/service/follow.rs
+++ b/crates/consensus/service/src/service/follow.rs
@@ -14,7 +14,7 @@ use crate::{
     EngineActorRequest, EngineConfig, EngineProcessor, EngineRpcProcessor, L1Config,
     L1WatcherActor, NodeActor, QueuedDerivationEngineClient, QueuedEngineDerivationClient,
     QueuedEngineRpcClient, QueuedL1WatcherDerivationClient, RpcActor, RpcContext,
-    service::node::{FINALIZED_STREAM_POLL_INTERVAL, HEAD_STREAM_POLL_INTERVAL},
+    service::node::HEAD_STREAM_POLL_INTERVAL,
 };
 
 /// A lightweight node that follows another L2 node by polling its execution
@@ -168,7 +168,7 @@ impl FollowNode {
         let finalized_stream = BlockStream::new_as_stream(
             self.l1_config.engine_provider.clone(),
             BlockNumberOrTag::Finalized,
-            Duration::from_secs(FINALIZED_STREAM_POLL_INTERVAL),
+            self.l1_config.finalized_poll_interval,
         )?;
 
         let (l1_head_updates_tx, _l1_head_updates_rx) = watch::channel(None);

--- a/crates/consensus/service/src/service/node.rs
+++ b/crates/consensus/service/src/service/node.rs
@@ -3,6 +3,7 @@ use std::{ops::Not as _, sync::Arc, time::Duration};
 
 use alloy_eips::BlockNumberOrTag;
 use alloy_provider::RootProvider;
+use base_alloy_chains::BaseChainConfig;
 use base_alloy_network::Base;
 use base_consensus_derive::{Pipeline, SignalReceiver, StatefulAttributesBuilder};
 use base_consensus_engine::{Engine, EngineClient, EngineState};
@@ -30,7 +31,6 @@ use crate::{
 
 const DERIVATION_PROVIDER_CACHE_SIZE: usize = 1024;
 pub(crate) const HEAD_STREAM_POLL_INTERVAL: u64 = 4;
-pub(crate) const FINALIZED_STREAM_POLL_INTERVAL: u64 = 60;
 
 /// The configuration for the L1 chain.
 #[derive(Debug, Clone)]
@@ -43,6 +43,30 @@ pub struct L1Config {
     pub beacon_client: OnlineBeaconClient,
     /// The L1 engine provider.
     pub engine_provider: RootProvider,
+    /// How frequently to poll L1 for a new finalized block.
+    ///
+    /// The right value depends on the L1 finality cadence:
+    /// - Ethereum mainnet/Sepolia: one epoch (~384 s = 32 slots × 12 s)
+    /// - Devnet local L1: near-instant finality, poll aggressively (~2 s)
+    pub finalized_poll_interval: Duration,
+}
+
+impl L1Config {
+    /// Returns the recommended finalized-block poll interval for the given L1 chain.
+    pub const fn default_finalized_poll_interval(l1_chain_id: u64) -> Duration {
+        const ETH_MAINNET_L1: u64 = BaseChainConfig::mainnet().l1_chain_id;
+        const ETH_SEPOLIA_L1: u64 = BaseChainConfig::sepolia().l1_chain_id;
+        const DEVNET_L1: u64 = BaseChainConfig::devnet().l1_chain_id;
+
+        match l1_chain_id {
+            // Ethereum mainnet and Sepolia: poll once per L1 epoch (32 slots × 12 s).
+            ETH_MAINNET_L1 | ETH_SEPOLIA_L1 => Duration::from_secs(384),
+            // Devnet local L1: near-instant finality, poll aggressively.
+            DEVNET_L1 => Duration::from_secs(2),
+            // Unknown chains: fall back to a conservative default.
+            _ => Duration::from_secs(60),
+        }
+    }
 }
 
 /// The standard implementation of the [`RollupNode`] service, using the governance approved Base
@@ -361,7 +385,7 @@ impl RollupNode {
         let finalized_stream = BlockStream::new_as_stream(
             self.l1_config.engine_provider.clone(),
             BlockNumberOrTag::Finalized,
-            Duration::from_secs(FINALIZED_STREAM_POLL_INTERVAL),
+            self.l1_config.finalized_poll_interval,
         )?;
 
         // Create the [`L1WatcherActor`]. Previously known as the DA watcher actor.


### PR DESCRIPTION
## Summary

Replaces the hardcoded 60-second `FINALIZED_STREAM_POLL_INTERVAL` constant with a chain-aware `finalized_poll_interval` field on `L1Config`. `L1Config::default_finalized_poll_interval` selects the appropriate interval based on the L1 chain ID: one epoch (~384 s) for Ethereum mainnet and Sepolia, and 2 s for the local devnet where finality is near-instant. Both `RollupNode` and `FollowNode` now read from `l1_config.finalized_poll_interval`, and `RollupNodeBuilder` exposes a `with_finalized_poll_interval` override for testing or custom deployments.