### PR TITLE
feat(proof): use boot l1_head as l1_origin in enclave proposals

### DIFF
--- a/crates/proof/challenge/src/driver.rs
+++ b/crates/proof/challenge/src/driver.rs
@@ -336,10 +336,10 @@ impl<L2: L2Provider, P: ZkProofProvider, T: TxManager> Driver<L2, P, T> {
 
         // Fetch L1 finalized head and compute agreed L2 state concurrently.
         let (l1_head_result, output_root_result) = tokio::join!(
-            tee.l1_head_provider.finalized_head_hash(),
+            tee.l1_head_provider.finalized_head(),
             self.validator.compute_output_root_with_hash(start_block_number),
         );
-        let l1_head = l1_head_result?;
+        let (l1_head, l1_head_number) = l1_head_result?;
         let (agreed_l2_head_hash, agreed_l2_output_root) = output_root_result?;
 
         // The claimed root is the (wrong) on-chain root at the invalid index.
@@ -360,6 +360,7 @@ impl<L2: L2Provider, P: ZkProofProvider, T: TxManager> Driver<L2, P, T> {
             claimed_l2_block_number,
             proposer: self.submitter.sender_address(),
             intermediate_block_interval: candidate.intermediate_block_interval,
+            l1_head_number,
         };
 
         let result = tee.provider.prove(request).await.map_err(|e| eyre::eyre!(e))?;

--- a/crates/proof/challenge/src/tee.rs
+++ b/crates/proof/challenge/src/tee.rs
@@ -5,11 +5,11 @@ use alloy_provider::{Provider, RootProvider};
 use alloy_rpc_types_eth::BlockNumberOrTag;
 use async_trait::async_trait;
 
-/// Trait for fetching the L1 finalized head hash.
+/// Trait for fetching the L1 finalized head.
 #[async_trait]
 pub trait L1HeadProvider: Send + Sync + std::fmt::Debug {
-    /// Returns the hash of the current L1 finalized block.
-    async fn finalized_head_hash(&self) -> eyre::Result<B256>;
+    /// Returns the hash and block number of the current L1 finalized block.
+    async fn finalized_head(&self) -> eyre::Result<(B256, u64)>;
 }
 
 /// [`L1HeadProvider`] backed by an RPC [`RootProvider`].
@@ -27,12 +27,12 @@ impl RpcL1HeadProvider {
 
 #[async_trait]
 impl L1HeadProvider for RpcL1HeadProvider {
-    async fn finalized_head_hash(&self) -> eyre::Result<B256> {
+    async fn finalized_head(&self) -> eyre::Result<(B256, u64)> {
         let block = self
             .provider
             .get_block_by_number(BlockNumberOrTag::Finalized)
             .await?
             .ok_or_else(|| eyre::eyre!("L1 finalized block not found"))?;
-        Ok(block.header.hash)
+        Ok((block.header.hash, block.header.number))
     }
 }

--- a/crates/proof/challenge/src/test_utils.rs
+++ b/crates/proof/challenge/src/test_utils.rs
@@ -354,15 +354,15 @@ impl ProverClient for MockTeeProofProvider {
 /// Mock L1 head provider for testing the driver.
 #[derive(Debug)]
 pub struct MockL1HeadProvider {
-    /// Queue of results returned by [`finalized_head_hash`](L1HeadProvider::finalized_head_hash).
-    pub results: Mutex<VecDeque<eyre::Result<B256>>>,
+    /// Queue of results returned by [`finalized_head`](L1HeadProvider::finalized_head).
+    pub results: Mutex<VecDeque<eyre::Result<(B256, u64)>>>,
 }
 
 impl MockL1HeadProvider {
-    /// Creates a mock that returns a single successful hash.
-    pub fn success(hash: B256) -> Self {
+    /// Creates a mock that returns a single successful hash and block number.
+    pub fn success(hash: B256, number: u64) -> Self {
         let mut q = VecDeque::new();
-        q.push_back(Ok(hash));
+        q.push_back(Ok((hash, number)));
         Self { results: Mutex::new(q) }
     }
 
@@ -376,7 +376,7 @@ impl MockL1HeadProvider {
 
 #[async_trait]
 impl L1HeadProvider for MockL1HeadProvider {
-    async fn finalized_head_hash(&self) -> eyre::Result<B256> {
+    async fn finalized_head(&self) -> eyre::Result<(B256, u64)> {
         self.results.lock().unwrap().pop_front().expect("MockL1HeadProvider has no more results")
     }
 }

--- a/crates/proof/challenge/tests/driver.rs
+++ b/crates/proof/challenge/tests/driver.rs
@@ -826,7 +826,7 @@ async fn test_step_invalid_game_tee_proof_succeeds() {
     let verifier = Arc::new(MockAggregateVerifier { games: verifier_games });
 
     let l1_hash = B256::repeat_byte(0xAA);
-    let l1_head = Arc::new(MockL1HeadProvider::success(l1_hash));
+    let l1_head = Arc::new(MockL1HeadProvider::success(l1_hash, 100));
 
     let aggregate_proposal = Proposal {
         output_root: root_20,

--- a/crates/proof/host/src/kv/boot.rs
+++ b/crates/proof/host/src/kv/boot.rs
@@ -1,8 +1,8 @@
 use alloy_primitives::B256;
 use base_proof::{
-    INTERMEDIATE_BLOCK_INTERVAL_KEY, L1_CONFIG_KEY, L1_HEAD_KEY, L2_CHAIN_ID_KEY,
-    L2_CLAIM_BLOCK_NUMBER_KEY, L2_CLAIM_KEY, L2_OUTPUT_ROOT_KEY, L2_ROLLUP_CONFIG_KEY,
-    PROPOSER_KEY,
+    INTERMEDIATE_BLOCK_INTERVAL_KEY, L1_CONFIG_KEY, L1_HEAD_KEY, L1_HEAD_NUMBER_KEY,
+    L2_CHAIN_ID_KEY, L2_CLAIM_BLOCK_NUMBER_KEY, L2_CLAIM_KEY, L2_OUTPUT_ROOT_KEY,
+    L2_ROLLUP_CONFIG_KEY, PROPOSER_KEY,
 };
 use base_proof_preimage::PreimageKey;
 
@@ -44,6 +44,7 @@ impl KeyValueStore for BootKeyValueStore {
             INTERMEDIATE_BLOCK_INTERVAL_KEY => {
                 Some(self.cfg.request.intermediate_block_interval.to_be_bytes().to_vec())
             }
+            L1_HEAD_NUMBER_KEY => Some(self.cfg.request.l1_head_number.to_be_bytes().to_vec()),
             _ => None,
         }
     }

--- a/crates/proof/primitives/src/proof.rs
+++ b/crates/proof/primitives/src/proof.rs
@@ -63,6 +63,12 @@ pub struct ProofRequest {
     /// constructing the aggregate proof journal.
     #[cfg_attr(feature = "serde", serde(default))]
     pub intermediate_block_interval: u64,
+    /// Block number of the L1 head.
+    ///
+    /// Stored alongside `l1_head` (the hash) so the enclave can reference the
+    /// L1 head block number without an extra lookup.
+    #[cfg_attr(feature = "serde", serde(default))]
+    pub l1_head_number: u64,
 }
 
 /// A proof request bundled with the witness data needed to fulfill it.

--- a/crates/proof/proof/src/boot.rs
+++ b/crates/proof/proof/src/boot.rs
@@ -298,9 +298,23 @@ impl BootInfo {
         };
 
         // Load intermediate block interval (optional — defaults to 0 for backwards compatibility).
-        let intermediate_block_interval = match oracle
-            .get(PreimageKey::new_local(INTERMEDIATE_BLOCK_INTERVAL_KEY.to()))
-            .await
+        let intermediate_block_interval =
+            match oracle.get(PreimageKey::new_local(INTERMEDIATE_BLOCK_INTERVAL_KEY.to())).await {
+                Ok(bytes) => u64::from_be_bytes(
+                    bytes.as_slice().try_into().map_err(OracleProviderError::SliceConversion)?,
+                ),
+                Err(e) => {
+                    debug!(
+                        target: "boot_loader",
+                        error = %e,
+                        "Intermediate block interval preimage not found, defaulting to 0"
+                    );
+                    0
+                }
+            };
+
+        // Load L1 head block number (optional — defaults to 0 for backwards compatibility).
+        let l1_head_number = match oracle.get(PreimageKey::new_local(L1_HEAD_NUMBER_KEY.to())).await
         {
             Ok(bytes) => u64::from_be_bytes(
                 bytes.as_slice().try_into().map_err(OracleProviderError::SliceConversion)?,
@@ -309,27 +323,11 @@ impl BootInfo {
                 debug!(
                     target: "boot_loader",
                     error = %e,
-                    "Intermediate block interval preimage not found, defaulting to 0"
+                    "L1 head number preimage not found, defaulting to 0"
                 );
                 0
             }
         };
-
-        // Load L1 head block number (optional — defaults to 0 for backwards compatibility).
-        let l1_head_number =
-            match oracle.get(PreimageKey::new_local(L1_HEAD_NUMBER_KEY.to())).await {
-                Ok(bytes) => u64::from_be_bytes(
-                    bytes.as_slice().try_into().map_err(OracleProviderError::SliceConversion)?,
-                ),
-                Err(e) => {
-                    debug!(
-                        target: "boot_loader",
-                        error = %e,
-                        "L1 head number preimage not found, defaulting to 0"
-                    );
-                    0
-                }
-            };
 
         Ok(Self {
             l1_head,

--- a/crates/proof/proof/src/boot.rs
+++ b/crates/proof/proof/src/boot.rs
@@ -73,6 +73,12 @@ pub const PROPOSER_KEY: U256 = U256::from_be_slice(&[8]);
 /// `AggregateVerifier`'s `INTERMEDIATE_BLOCK_INTERVAL`.
 pub const INTERMEDIATE_BLOCK_INTERVAL_KEY: U256 = U256::from_be_slice(&[9]);
 
+/// The local key identifier for the L1 head block number.
+///
+/// This key retrieves the block number corresponding to `L1_HEAD_KEY`, allowing
+/// the enclave to reference the L1 head number without an extra lookup.
+pub const L1_HEAD_NUMBER_KEY: U256 = U256::from_be_slice(&[10]);
+
 /// The boot information for the client program.
 ///
 /// [`BootInfo`] contains all the essential parameters needed to initialize the fault proof
@@ -162,6 +168,12 @@ pub struct BootInfo {
     /// constructing the aggregate proof journal. Defaults to 0 when not set.
     #[serde(default)]
     pub intermediate_block_interval: u64,
+    /// The block number of the L1 head.
+    ///
+    /// Stored alongside `l1_head` so the enclave can reference the L1 head
+    /// block number without an extra lookup. Defaults to 0 when not set.
+    #[serde(default)]
+    pub l1_head_number: u64,
 }
 
 impl BootInfo {
@@ -315,6 +327,30 @@ impl BootInfo {
             }
         };
 
+        // Load L1 head block number (optional — defaults to 0 for backwards compatibility).
+        let l1_head_number = match oracle.get(PreimageKey::new_local(L1_HEAD_NUMBER_KEY.to())).await
+        {
+            Ok(bytes) if bytes.len() == 8 => {
+                u64::from_be_bytes(bytes.as_slice().try_into().expect("length checked"))
+            }
+            Ok(bytes) => {
+                warn!(
+                    target: "boot_loader",
+                    len = bytes.len(),
+                    "L1 head number preimage has unexpected length, defaulting to 0"
+                );
+                0
+            }
+            Err(e) => {
+                debug!(
+                    target: "boot_loader",
+                    error = %e,
+                    "L1 head number preimage not found, defaulting to 0"
+                );
+                0
+            }
+        };
+
         Ok(Self {
             l1_head,
             agreed_l2_output_root: l2_output_root,
@@ -325,6 +361,7 @@ impl BootInfo {
             l1_config,
             proposer,
             intermediate_block_interval,
+            l1_head_number,
         })
     }
 }

--- a/crates/proof/proof/src/boot.rs
+++ b/crates/proof/proof/src/boot.rs
@@ -282,14 +282,10 @@ impl BootInfo {
 
         // Load proposer address (optional — defaults to zero for backwards compatibility).
         let proposer = match oracle.get(PreimageKey::new_local(PROPOSER_KEY.to())).await {
-            Ok(bytes) if bytes.len() == 20 => Address::from_slice(&bytes),
             Ok(bytes) => {
-                warn!(
-                    target: "boot_loader",
-                    len = bytes.len(),
-                    "Proposer preimage has unexpected length, defaulting to Address::ZERO"
-                );
-                Address::ZERO
+                let buf: [u8; 20] =
+                    bytes.as_slice().try_into().map_err(OracleProviderError::SliceConversion)?;
+                Address::from(buf)
             }
             Err(e) => {
                 debug!(
@@ -306,17 +302,9 @@ impl BootInfo {
             .get(PreimageKey::new_local(INTERMEDIATE_BLOCK_INTERVAL_KEY.to()))
             .await
         {
-            Ok(bytes) if bytes.len() == 8 => {
-                u64::from_be_bytes(bytes.as_slice().try_into().expect("length checked"))
-            }
-            Ok(bytes) => {
-                warn!(
-                    target: "boot_loader",
-                    len = bytes.len(),
-                    "Intermediate block interval preimage has unexpected length, defaulting to 0"
-                );
-                0
-            }
+            Ok(bytes) => u64::from_be_bytes(
+                bytes.as_slice().try_into().map_err(OracleProviderError::SliceConversion)?,
+            ),
             Err(e) => {
                 debug!(
                     target: "boot_loader",
@@ -328,28 +316,20 @@ impl BootInfo {
         };
 
         // Load L1 head block number (optional — defaults to 0 for backwards compatibility).
-        let l1_head_number = match oracle.get(PreimageKey::new_local(L1_HEAD_NUMBER_KEY.to())).await
-        {
-            Ok(bytes) if bytes.len() == 8 => {
-                u64::from_be_bytes(bytes.as_slice().try_into().expect("length checked"))
-            }
-            Ok(bytes) => {
-                warn!(
-                    target: "boot_loader",
-                    len = bytes.len(),
-                    "L1 head number preimage has unexpected length, defaulting to 0"
-                );
-                0
-            }
-            Err(e) => {
-                debug!(
-                    target: "boot_loader",
-                    error = %e,
-                    "L1 head number preimage not found, defaulting to 0"
-                );
-                0
-            }
-        };
+        let l1_head_number =
+            match oracle.get(PreimageKey::new_local(L1_HEAD_NUMBER_KEY.to())).await {
+                Ok(bytes) => u64::from_be_bytes(
+                    bytes.as_slice().try_into().map_err(OracleProviderError::SliceConversion)?,
+                ),
+                Err(e) => {
+                    debug!(
+                        target: "boot_loader",
+                        error = %e,
+                        "L1 head number preimage not found, defaulting to 0"
+                    );
+                    0
+                }
+            };
 
         Ok(Self {
             l1_head,

--- a/crates/proof/proposer/src/driver/pipeline.rs
+++ b/crates/proof/proposer/src/driver/pipeline.rs
@@ -538,6 +538,7 @@ where
             claimed_l2_block_number: target_block,
             proposer: self.config.driver.proposer_address,
             intermediate_block_interval: self.config.driver.intermediate_block_interval,
+            l1_head_number: l1_head.number,
         };
 
         info!(request = ?request, "Built proof request for parallel proving");

--- a/crates/proof/tee/nitro/src/enclave/server.rs
+++ b/crates/proof/tee/nitro/src/enclave/server.rs
@@ -174,10 +174,10 @@ impl Server {
         let mut proposals = Vec::with_capacity(block_results.len());
         let mut prev_output_root = agreed_l2_output_root;
 
+        let l1_origin_hash = boot_info.l1_head;
+        let l1_origin_number = boot_info.l1_head_number;
         for (l2_info, output_root) in &block_results {
             let l2_block_number = U256::from(l2_info.block_info.number);
-            let l1_origin_hash = l2_info.l1_origin.hash;
-            let l1_origin_number = U256::from(l2_info.l1_origin.number);
 
             let journal = ProofJournal {
                 proposer: boot_info.proposer,
@@ -200,7 +200,7 @@ impl Server {
                 output_root: *output_root,
                 signature: Bytes::from(signature.to_vec()),
                 l1_origin_hash,
-                l1_origin_number,
+                l1_origin_number: U256::from(l1_origin_number),
                 l2_block_number,
                 prev_output_root,
                 config_hash,
@@ -226,7 +226,7 @@ impl Server {
 
             let journal = ProofJournal {
                 proposer: boot_info.proposer,
-                l1_origin_hash: last.l1_origin_hash,
+                l1_origin_hash,
                 prev_output_root: agreed_l2_output_root,
                 starting_l2_block: first
                     .l2_block_number
@@ -245,8 +245,8 @@ impl Server {
             Proposal {
                 output_root: last.output_root,
                 signature: Bytes::from(signature.to_vec()),
-                l1_origin_hash: last.l1_origin_hash,
-                l1_origin_number: last.l1_origin_number,
+                l1_origin_hash,
+                l1_origin_number: U256::from(l1_origin_number),
                 l2_block_number: last.l2_block_number,
                 prev_output_root: agreed_l2_output_root,
                 config_hash,


### PR DESCRIPTION
## Summary

- Adds `l1_head_number: u64` to `ProofRequest` and `BootInfo` so the enclave can reference the L1 head block number without an extra lookup
- Threads the value through the full pipeline: proposer/challenge driver → `BootKeyValueStore` (preimage key slot 10) → `BootInfo::load()` with backward-compatible default of `0`
- Updates `L1HeadProvider` trait from `finalized_head_hash() → B256` to `finalized_head() → (B256, u64)` to carry the block number alongside the hash
- Uses `boot_info.l1_head` and `boot_info.l1_head_number` as the `l1_origin_hash` and `l1_origin_number` in enclave proposals, replacing the per-block `l2_info.l1_origin` values

## Motivation

Previously, each enclave proposal used the per-L2-block L1 origin from derivation (`l2_info.l1_origin`). This changes proposals to use the boot-time L1 head hash and number, which is the L1 block that the proof was generated against. This ensures consistency: the `l1_origin` in proposals reflects the L1 head that was committed to in the proof request, not the per-block derivation origin.

## Changes

| File | Change |
|---|---|
| `crates/proof/primitives/src/proof.rs` | Add `l1_head_number: u64` to `ProofRequest` |
| `crates/proof/proof/src/boot.rs` | Add `L1_HEAD_NUMBER_KEY = 10`, `l1_head_number` field to `BootInfo`, oracle loading with backward-compat default |
| `crates/proof/host/src/kv/boot.rs` | Add `L1_HEAD_NUMBER_KEY` → bytes mapping in `BootKeyValueStore` |
| `crates/proof/proposer/src/driver/pipeline.rs` | Set `l1_head_number: l1_head.number` in request construction |
| `crates/proof/challenge/src/tee.rs` | Update `L1HeadProvider` trait: `finalized_head() → (B256, u64)` |
| `crates/proof/challenge/src/driver.rs` | Destructure and pass `l1_head_number` to `TeeProofRequest` |
| `crates/proof/challenge/src/test_utils.rs` | Update `MockL1HeadProvider` to match new trait |
| `crates/proof/challenge/tests/driver.rs` | Update mock construction call |
| `crates/proof/tee/nitro/src/enclave/server.rs` | Use `boot_info.l1_head` / `boot_info.l1_head_number` as `l1_origin` in proposals instead of per-block `l2_info.l1_origin` |