### PR TITLE
fix(builder): improve flashblock constraint diagnostics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2778,6 +2778,7 @@ dependencies = [
  "jsonrpsee-types",
  "k256",
  "metrics",
+ "metrics-exporter-prometheus",
  "moka",
  "nanoid",
  "opentelemetry",

--- a/crates/builder/core/Cargo.toml
+++ b/crates/builder/core/Cargo.toml
@@ -209,6 +209,9 @@ reth-ipc.workspace = true
 base-execution-rpc = { workspace = true, features = ["client"] }
 reth-node-builder = { workspace = true, features = ["test-utils"] }
 
+# metrics
+metrics-exporter-prometheus.workspace = true
+
 # alloy
 alloy-provider = { workspace = true, default-features = true, features = ["txpool-api"] }
 

--- a/crates/builder/core/src/flashblocks/context.rs
+++ b/crates/builder/core/src/flashblocks/context.rs
@@ -100,7 +100,7 @@ pub struct FlashblockDiagnostics {
 
 impl FlashblockDiagnostics {
     /// Returns how transaction selection ended for this flashblock.
-    pub const fn selection_outcome(&self) -> &str {
+    pub const fn selection_outcome(&self) -> &'static str {
         if self.cancelled {
             "cancelled"
         } else if self.txs_considered == 0 {
@@ -110,31 +110,25 @@ impl FlashblockDiagnostics {
         }
     }
 
+    /// Returns the rejection counts keyed by their metric/log reason labels.
+    pub const fn rejection_counts(&self) -> [(&'static str, u64); 7] {
+        [
+            ("gas_limit", self.txs_rejected_gas),
+            ("da_size", self.txs_rejected_da),
+            ("da_footprint", self.txs_rejected_da_footprint),
+            ("execution_time", self.txs_rejected_execution_time),
+            ("state_root_time", self.txs_rejected_state_root_time),
+            ("uncompressed_size", self.txs_rejected_uncompressed_size),
+            ("other", self.txs_rejected_other),
+        ]
+    }
+
     /// Returns the distinct rejection categories encountered while scanning the pool.
     pub fn rejection_reasons(&self) -> Vec<&'static str> {
-        let mut reasons = Vec::with_capacity(7);
-        if self.txs_rejected_gas > 0 {
-            reasons.push("gas_limit");
-        }
-        if self.txs_rejected_da > 0 {
-            reasons.push("da_size");
-        }
-        if self.txs_rejected_da_footprint > 0 {
-            reasons.push("da_footprint");
-        }
-        if self.txs_rejected_execution_time > 0 {
-            reasons.push("execution_time");
-        }
-        if self.txs_rejected_state_root_time > 0 {
-            reasons.push("state_root_time");
-        }
-        if self.txs_rejected_uncompressed_size > 0 {
-            reasons.push("uncompressed_size");
-        }
-        if self.txs_rejected_other > 0 {
-            reasons.push("other");
-        }
-        reasons
+        self.rejection_counts()
+            .into_iter()
+            .filter_map(|(reason, count)| (count > 0).then_some(reason))
+            .collect()
     }
 
     /// Total number of rejected transactions across all limit types.
@@ -915,6 +909,28 @@ mod tests {
 
         assert_eq!(diag.rejection_reasons(), vec!["gas_limit", "da_size"]);
         assert_eq!(diag.txs_rejected_total(), 3);
+    }
+
+    #[test]
+    fn diagnostics_report_rejection_counts() {
+        let diag = FlashblockDiagnostics {
+            txs_rejected_gas: 2,
+            txs_rejected_state_root_time: 1,
+            ..Default::default()
+        };
+
+        assert_eq!(
+            diag.rejection_counts(),
+            [
+                ("gas_limit", 2),
+                ("da_size", 0),
+                ("da_footprint", 0),
+                ("execution_time", 0),
+                ("state_root_time", 1),
+                ("uncompressed_size", 0),
+                ("other", 0),
+            ]
+        );
     }
 
     #[test]

--- a/crates/builder/core/src/flashblocks/context.rs
+++ b/crates/builder/core/src/flashblocks/context.rs
@@ -68,6 +68,119 @@ fn record_rejected_tx_priority_fee(reason: &TxnExecutionError, priority_fee: f64
         .record(priority_fee);
 }
 
+/// Diagnostics captured during a single flashblock's transaction execution.
+///
+/// Tracks how transaction selection ended, what limits were hit, and the
+/// priority fee threshold among included transactions.
+#[derive(Debug, Default)]
+pub struct FlashblockDiagnostics {
+    /// Whether the flashblock timer or block cancel fired during execution.
+    pub cancelled: bool,
+    /// Number of transactions considered from the pool.
+    pub txs_considered: u64,
+    /// Number of transactions included in the flashblock.
+    pub txs_included: u64,
+    /// Number rejected by gas limit.
+    pub txs_rejected_gas: u64,
+    /// Number rejected by DA size limits (tx or block).
+    pub txs_rejected_da: u64,
+    /// Number rejected by DA footprint limit.
+    pub txs_rejected_da_footprint: u64,
+    /// Number rejected by execution time limits (tx or flashblock).
+    pub txs_rejected_execution_time: u64,
+    /// Number rejected by state root time limits (tx or block).
+    pub txs_rejected_state_root_time: u64,
+    /// Number rejected by uncompressed size limit.
+    pub txs_rejected_uncompressed_size: u64,
+    /// Number rejected by other reasons.
+    pub txs_rejected_other: u64,
+    /// Minimum effective priority fee (tip per gas) among included transactions.
+    pub min_priority_fee: Option<u64>,
+}
+
+impl FlashblockDiagnostics {
+    /// Returns how transaction selection ended for this flashblock.
+    pub const fn selection_outcome(&self) -> &str {
+        if self.cancelled {
+            "cancelled"
+        } else if self.txs_considered == 0 {
+            "pool_empty"
+        } else {
+            "pool_drained"
+        }
+    }
+
+    /// Returns the distinct rejection categories encountered while scanning the pool.
+    pub fn rejection_reasons(&self) -> Vec<&'static str> {
+        let mut reasons = Vec::with_capacity(7);
+        if self.txs_rejected_gas > 0 {
+            reasons.push("gas_limit");
+        }
+        if self.txs_rejected_da > 0 {
+            reasons.push("da_size");
+        }
+        if self.txs_rejected_da_footprint > 0 {
+            reasons.push("da_footprint");
+        }
+        if self.txs_rejected_execution_time > 0 {
+            reasons.push("execution_time");
+        }
+        if self.txs_rejected_state_root_time > 0 {
+            reasons.push("state_root_time");
+        }
+        if self.txs_rejected_uncompressed_size > 0 {
+            reasons.push("uncompressed_size");
+        }
+        if self.txs_rejected_other > 0 {
+            reasons.push("other");
+        }
+        reasons
+    }
+
+    /// Total number of rejected transactions across all limit types.
+    pub const fn txs_rejected_total(&self) -> u64 {
+        self.txs_rejected_gas
+            + self.txs_rejected_da
+            + self.txs_rejected_da_footprint
+            + self.txs_rejected_execution_time
+            + self.txs_rejected_state_root_time
+            + self.txs_rejected_uncompressed_size
+            + self.txs_rejected_other
+    }
+
+    /// Records a rejected transaction into the appropriate rejection bucket.
+    pub const fn record_rejection(&mut self, err: &TxnExecutionError) {
+        match err {
+            TxnExecutionError::TransactionGasLimitExceeded { .. } => {
+                self.txs_rejected_gas += 1;
+            }
+            TxnExecutionError::TransactionDASizeExceeded(_, _)
+            | TxnExecutionError::BlockDASizeExceeded { .. } => {
+                self.txs_rejected_da += 1;
+            }
+            TxnExecutionError::DAFootprintLimitExceeded { .. } => {
+                self.txs_rejected_da_footprint += 1;
+            }
+            TxnExecutionError::BlockUncompressedSizeExceeded { .. } => {
+                self.txs_rejected_uncompressed_size += 1;
+            }
+            TxnExecutionError::ExecutionMeteringLimitExceeded(inner) => match inner {
+                ExecutionMeteringLimitExceeded::TransactionExecutionTime(_, _)
+                | ExecutionMeteringLimitExceeded::FlashblockExecutionTime(_, _, _) => {
+                    self.txs_rejected_execution_time += 1;
+                }
+                ExecutionMeteringLimitExceeded::TransactionStateRootTime(_, _)
+                | ExecutionMeteringLimitExceeded::BlockStateRootTime(_, _, _) => {
+                    self.txs_rejected_state_root_time += 1;
+                }
+            },
+            _ => {
+                self.txs_rejected_other += 1;
+            }
+        }
+    }
+}
+
 /// Extra context for flashblock payload building.
 ///
 /// Contains flashblock-specific configuration and state for tracking
@@ -448,14 +561,14 @@ impl OpPayloadBuilderCtx {
 
     /// Executes the given best transactions and updates the execution info.
     ///
-    /// Returns `Ok(Some(())` if the job was cancelled.
+    /// Returns diagnostics summarizing transaction selection for the flashblock.
     pub(super) fn execute_best_transactions(
         &self,
         info: &mut ExecutionInfo,
         db: &mut State<impl Database>,
         best_txs: &mut impl PayloadTxsBounds,
         limits: &ResourceLimits,
-    ) -> Result<Option<()>, PayloadBuilderError> {
+    ) -> Result<FlashblockDiagnostics, PayloadBuilderError> {
         let execute_txs_start_time = Instant::now();
         let mut num_txs_considered = 0;
         let mut num_txs_simulated = 0;
@@ -463,6 +576,7 @@ impl OpPayloadBuilderCtx {
         let mut num_txs_simulated_fail = 0;
         let mut reverted_gas_used = 0;
         let base_fee = self.base_fee();
+        let mut diag = FlashblockDiagnostics::default();
 
         let mut fbal_db = FBALBuilderDb::new(&mut *db);
         let min_tx_index = info.executed_transactions.len() as u64;
@@ -538,6 +652,7 @@ impl OpPayloadBuilderCtx {
                         // Don't skip - continue to simulate the transaction
                     } else {
                         // Enforce mode: reject the transaction
+                        diag.record_rejection(&err);
                         let priority_fee = tx.effective_tip_per_gas(base_fee).unwrap_or(0) as f64;
                         record_rejected_tx_priority_fee(&err, priority_fee);
 
@@ -547,6 +662,7 @@ impl OpPayloadBuilderCtx {
                     }
                 } else {
                     // DA size limits, DA footprint, and gas limits are always enforced
+                    diag.record_rejection(&err);
                     self.record_static_limit_exceeded(&err);
 
                     let priority_fee = tx.effective_tip_per_gas(base_fee).unwrap_or(0) as f64;
@@ -575,7 +691,11 @@ impl OpPayloadBuilderCtx {
 
             // check if the job was cancelled, if so we can exit early
             if self.cancel.is_cancelled() {
-                return Ok(Some(()));
+                diag.cancelled = true;
+                diag.txs_considered = num_txs_considered;
+                diag.txs_included =
+                    (info.executed_transactions.len() as u64).saturating_sub(min_tx_index);
+                return Ok(diag);
             }
 
             let tx_simulation_start_time = Instant::now();
@@ -677,6 +797,10 @@ impl OpPayloadBuilderCtx {
                 .expect("fee is always valid; execution succeeded");
             info.total_fees += U256::from(miner_fee) * U256::from(gas_used);
 
+            // track minimum priority fee for diagnostics (saturate u128 -> u64)
+            let fee_u64 = miner_fee.min(u64::MAX as u128) as u64;
+            diag.min_priority_fee = Some(diag.min_priority_fee.map_or(fee_u64, |m| m.min(fee_u64)));
+
             // append sender and transaction to the respective lists
             // and increment the next txn index for the access list
             info.executed_senders.push(tx.signer());
@@ -701,14 +825,18 @@ impl OpPayloadBuilderCtx {
         }
 
         let payload_transaction_simulation_time = execute_txs_start_time.elapsed();
+        let num_txs_considered_metrics = num_txs_considered.min(u32::MAX as u64) as u32;
         self.metrics.set_payload_builder_metrics(
             payload_transaction_simulation_time,
-            num_txs_considered,
+            num_txs_considered_metrics,
             num_txs_simulated,
             num_txs_simulated_success,
             num_txs_simulated_fail,
             reverted_gas_used,
         );
+
+        diag.txs_considered = num_txs_considered;
+        diag.txs_included = (info.executed_transactions.len() as u64).saturating_sub(min_tx_index);
 
         debug!(
             target: "payload_builder",
@@ -717,7 +845,7 @@ impl OpPayloadBuilderCtx {
             txs_applied = num_txs_simulated_success,
             txs_rejected = num_txs_simulated_fail,
         );
-        Ok(None)
+        Ok(diag)
     }
 
     /// Record metrics for a limit that can be evaluated via static analysis (always enforced).
@@ -759,5 +887,42 @@ impl OpPayloadBuilderCtx {
                 self.metrics.block_state_root_time_exceeded_total.increment(1);
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn diagnostics_report_selection_outcome() {
+        let diag = FlashblockDiagnostics::default();
+        assert_eq!(diag.selection_outcome(), "pool_empty");
+
+        let diag =
+            FlashblockDiagnostics { txs_considered: 3, txs_included: 1, ..Default::default() };
+        assert_eq!(diag.selection_outcome(), "pool_drained");
+
+        let diag = FlashblockDiagnostics { cancelled: true, ..Default::default() };
+        assert_eq!(diag.selection_outcome(), "cancelled");
+    }
+
+    #[test]
+    fn diagnostics_report_distinct_rejection_reasons() {
+        let mut diag = FlashblockDiagnostics::default();
+        diag.txs_rejected_gas += 1;
+        diag.txs_rejected_da += 2;
+
+        assert_eq!(diag.rejection_reasons(), vec!["gas_limit", "da_size"]);
+        assert_eq!(diag.txs_rejected_total(), 3);
+    }
+
+    #[test]
+    fn diagnostics_count_included_transactions_from_appended_txs() {
+        let diag =
+            FlashblockDiagnostics { txs_considered: 5, txs_included: 2, ..Default::default() };
+
+        assert_eq!(diag.txs_considered, 5);
+        assert_eq!(diag.txs_included, 2);
     }
 }

--- a/crates/builder/core/src/flashblocks/context.rs
+++ b/crates/builder/core/src/flashblocks/context.rs
@@ -62,7 +62,11 @@ fn record_rejected_tx_priority_fee(reason: &TxnExecutionError, priority_fee: f64
                 "block_state_root_time_exceeded"
             }
         },
-        _ => "unknown",
+        TxnExecutionError::SequencerTransaction => "sequencer_transaction",
+        TxnExecutionError::NonceTooLow => "nonce_too_low",
+        TxnExecutionError::InternalError(_) => "internal_error",
+        TxnExecutionError::EvmError => "evm_error",
+        TxnExecutionError::MaxGasUsageExceeded => "max_gas_usage_exceeded",
     };
     reth_metrics::metrics::histogram!("base_builder_rejected_tx_priority_fee", "reason" => r)
         .record(priority_fee);
@@ -72,6 +76,27 @@ fn record_rejected_tx_priority_fee(reason: &TxnExecutionError, priority_fee: f64
 ///
 /// Tracks how transaction selection ended, what limits were hit, and the
 /// priority fee threshold among included transactions.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FlashblockSelectionOutcome {
+    /// Transaction selection stopped because the flashblock build was cancelled.
+    Cancelled,
+    /// Transaction selection stopped because no pool transaction was considered.
+    PoolEmpty,
+    /// Transaction selection stopped after draining the candidate pool.
+    PoolDrained,
+}
+
+impl FlashblockSelectionOutcome {
+    /// Returns the label used for logs and metrics.
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Cancelled => "cancelled",
+            Self::PoolEmpty => "pool_empty",
+            Self::PoolDrained => "pool_drained",
+        }
+    }
+}
+
 #[derive(Debug, Default)]
 pub struct FlashblockDiagnostics {
     /// Whether the flashblock timer or block cancel fired during execution.
@@ -92,7 +117,7 @@ pub struct FlashblockDiagnostics {
     pub txs_rejected_state_root_time: u64,
     /// Number rejected by uncompressed size limit.
     pub txs_rejected_uncompressed_size: u64,
-    /// Number rejected by other reasons.
+    /// Number rejected or skipped for other reasons.
     pub txs_rejected_other: u64,
     /// Minimum effective priority fee (tip per gas) among included transactions.
     pub min_priority_fee: Option<u64>,
@@ -100,13 +125,13 @@ pub struct FlashblockDiagnostics {
 
 impl FlashblockDiagnostics {
     /// Returns how transaction selection ended for this flashblock.
-    pub const fn selection_outcome(&self) -> &'static str {
+    pub const fn selection_outcome(&self) -> FlashblockSelectionOutcome {
         if self.cancelled {
-            "cancelled"
+            FlashblockSelectionOutcome::Cancelled
         } else if self.txs_considered == 0 {
-            "pool_empty"
+            FlashblockSelectionOutcome::PoolEmpty
         } else {
-            "pool_drained"
+            FlashblockSelectionOutcome::PoolDrained
         }
     }
 
@@ -168,7 +193,11 @@ impl FlashblockDiagnostics {
                     self.txs_rejected_state_root_time += 1;
                 }
             },
-            _ => {
+            TxnExecutionError::SequencerTransaction
+            | TxnExecutionError::NonceTooLow
+            | TxnExecutionError::InternalError(_)
+            | TxnExecutionError::EvmError
+            | TxnExecutionError::MaxGasUsageExceeded => {
                 self.txs_rejected_other += 1;
             }
         }
@@ -678,7 +707,11 @@ impl OpPayloadBuilderCtx {
 
             // A sequencer's block should never contain blob or deposit transactions from the pool.
             if tx.is_eip4844() || tx.is_deposit() {
-                log_txn(Err(TxnExecutionError::SequencerTransaction));
+                let err = TxnExecutionError::SequencerTransaction;
+                diag.record_rejection(&err);
+                let priority_fee = tx.effective_tip_per_gas(base_fee).unwrap_or(0) as f64;
+                record_rejected_tx_priority_fee(&err, priority_fee);
+                log_txn(Err(err));
                 best_txs.mark_invalid(tx.signer(), tx.nonce());
                 continue;
             }
@@ -699,12 +732,22 @@ impl OpPayloadBuilderCtx {
                     if let Some(err) = err.as_invalid_tx_err() {
                         if err.is_nonce_too_low() {
                             // if the nonce is too low, we can skip this transaction
-                            log_txn(Err(TxnExecutionError::NonceTooLow));
+                            let diag_err = TxnExecutionError::NonceTooLow;
+                            diag.record_rejection(&diag_err);
+                            let priority_fee =
+                                tx.effective_tip_per_gas(base_fee).unwrap_or(0) as f64;
+                            record_rejected_tx_priority_fee(&diag_err, priority_fee);
+                            log_txn(Err(diag_err));
                             trace!(target: "payload_builder", %err, ?tx, "skipping nonce too low transaction");
                         } else {
                             // if the transaction is invalid, we can skip it and all of its
                             // descendants
-                            log_txn(Err(TxnExecutionError::InternalError(err.clone())));
+                            let diag_err = TxnExecutionError::InternalError(err.clone());
+                            diag.record_rejection(&diag_err);
+                            let priority_fee =
+                                tx.effective_tip_per_gas(base_fee).unwrap_or(0) as f64;
+                            record_rejected_tx_priority_fee(&diag_err, priority_fee);
+                            log_txn(Err(diag_err));
                             trace!(target: "payload_builder", %err, ?tx, "skipping invalid transaction and its descendants");
                             best_txs.mark_invalid(tx.signer(), tx.nonce());
                         }
@@ -748,7 +791,11 @@ impl OpPayloadBuilderCtx {
             if let Some(max_gas_per_txn) = self.builder_config.max_gas_per_txn
                 && gas_used > max_gas_per_txn
             {
-                log_txn(Err(TxnExecutionError::MaxGasUsageExceeded));
+                let err = TxnExecutionError::MaxGasUsageExceeded;
+                diag.record_rejection(&err);
+                let priority_fee = tx.effective_tip_per_gas(base_fee).unwrap_or(0) as f64;
+                record_rejected_tx_priority_fee(&err, priority_fee);
+                log_txn(Err(err));
                 best_txs.mark_invalid(tx.signer(), tx.nonce());
                 continue;
             }
@@ -819,10 +866,9 @@ impl OpPayloadBuilderCtx {
         }
 
         let payload_transaction_simulation_time = execute_txs_start_time.elapsed();
-        let num_txs_considered_metrics = num_txs_considered.min(u32::MAX as u64) as u32;
         self.metrics.set_payload_builder_metrics(
             payload_transaction_simulation_time,
-            num_txs_considered_metrics,
+            num_txs_considered as f64,
             num_txs_simulated,
             num_txs_simulated_success,
             num_txs_simulated_fail,
@@ -891,14 +937,17 @@ mod tests {
     #[test]
     fn diagnostics_report_selection_outcome() {
         let diag = FlashblockDiagnostics::default();
-        assert_eq!(diag.selection_outcome(), "pool_empty");
+        assert_eq!(diag.selection_outcome(), FlashblockSelectionOutcome::PoolEmpty);
+        assert_eq!(diag.selection_outcome().as_str(), "pool_empty");
 
         let diag =
             FlashblockDiagnostics { txs_considered: 3, txs_included: 1, ..Default::default() };
-        assert_eq!(diag.selection_outcome(), "pool_drained");
+        assert_eq!(diag.selection_outcome(), FlashblockSelectionOutcome::PoolDrained);
+        assert_eq!(diag.selection_outcome().as_str(), "pool_drained");
 
         let diag = FlashblockDiagnostics { cancelled: true, ..Default::default() };
-        assert_eq!(diag.selection_outcome(), "cancelled");
+        assert_eq!(diag.selection_outcome(), FlashblockSelectionOutcome::Cancelled);
+        assert_eq!(diag.selection_outcome().as_str(), "cancelled");
     }
 
     #[test]
@@ -931,6 +980,17 @@ mod tests {
                 ("other", 0),
             ]
         );
+    }
+
+    #[test]
+    fn diagnostics_bucket_other_rejections() {
+        let mut diag = FlashblockDiagnostics::default();
+        diag.record_rejection(&TxnExecutionError::SequencerTransaction);
+        diag.record_rejection(&TxnExecutionError::NonceTooLow);
+        diag.record_rejection(&TxnExecutionError::MaxGasUsageExceeded);
+
+        assert_eq!(diag.txs_rejected_other, 3);
+        assert_eq!(diag.txs_rejected_total(), 3);
     }
 
     #[test]

--- a/crates/builder/core/src/flashblocks/mod.rs
+++ b/crates/builder/core/src/flashblocks/mod.rs
@@ -16,7 +16,7 @@ mod handler;
 pub use handler::PayloadHandler;
 
 mod context;
-pub use context::{FlashblocksExtraCtx, OpPayloadBuilderCtx};
+pub use context::{FlashblockDiagnostics, FlashblocksExtraCtx, OpPayloadBuilderCtx};
 
 mod payload;
 pub use payload::FlashblocksExecutionInfo;

--- a/crates/builder/core/src/flashblocks/mod.rs
+++ b/crates/builder/core/src/flashblocks/mod.rs
@@ -16,7 +16,9 @@ mod handler;
 pub use handler::PayloadHandler;
 
 mod context;
-pub use context::{FlashblockDiagnostics, FlashblocksExtraCtx, OpPayloadBuilderCtx};
+pub use context::{
+    FlashblockDiagnostics, FlashblockSelectionOutcome, FlashblocksExtraCtx, OpPayloadBuilderCtx,
+};
 
 mod payload;
 pub use payload::FlashblocksExecutionInfo;

--- a/crates/builder/core/src/flashblocks/payload.rs
+++ b/crates/builder/core/src/flashblocks/payload.rs
@@ -730,6 +730,7 @@ where
                 } else {
                     0
                 };
+                ctx.metrics.record_flashblock_diagnostics(flashblock_index, &diag, info, &limits);
                 info!(
                     target: "payload_builder",
                     message = "Flashblock built",

--- a/crates/builder/core/src/flashblocks/payload.rs
+++ b/crates/builder/core/src/flashblocks/payload.rs
@@ -735,7 +735,7 @@ where
                     target: "payload_builder",
                     message = "Flashblock built",
                     flashblock_index = flashblock_index,
-                    selection_outcome = diag.selection_outcome(),
+                    selection_outcome = diag.selection_outcome().as_str(),
                     rejection_reasons = ?diag.rejection_reasons(),
                     txs_considered = diag.txs_considered,
                     txs_included = diag.txs_included,

--- a/crates/builder/core/src/flashblocks/payload.rs
+++ b/crates/builder/core/src/flashblocks/payload.rs
@@ -737,6 +737,7 @@ where
                     flashblock_index = flashblock_index,
                     selection_outcome = diag.selection_outcome(),
                     rejection_reasons = ?diag.rejection_reasons(),
+                    txs_considered = diag.txs_considered,
                     txs_included = diag.txs_included,
                     txs_rejected = diag.txs_rejected_total(),
                     min_priority_fee_wei = diag.min_priority_fee.unwrap_or(0),

--- a/crates/builder/core/src/flashblocks/payload.rs
+++ b/crates/builder/core/src/flashblocks/payload.rs
@@ -585,7 +585,8 @@ where
             block_state_root_time_limit_us,
             block_uncompressed_size_limit: ctx.builder_config.max_uncompressed_block_size,
         };
-        ctx.execute_best_transactions(info, state, best_txs, &limits)
+        let diag = ctx
+            .execute_best_transactions(info, state, best_txs, &limits)
             .wrap_err("failed to execute best transactions")?;
         // Extract last transactions
         let new_transactions = info.executed_transactions[info.extra.last_flashblock_index..]
@@ -722,12 +723,30 @@ where
                     target_state_root_time_for_batch_us,
                 );
 
+                let gas_headroom_pct = if limits.block_gas_limit > 0 {
+                    (limits.block_gas_limit.saturating_sub(info.cumulative_gas_used) as f64
+                        / limits.block_gas_limit as f64
+                        * 100.0) as u64
+                } else {
+                    0
+                };
                 info!(
                     target: "payload_builder",
                     message = "Flashblock built",
                     flashblock_index = flashblock_index,
+                    selection_outcome = diag.selection_outcome(),
+                    rejection_reasons = ?diag.rejection_reasons(),
+                    txs_included = diag.txs_included,
+                    txs_rejected = diag.txs_rejected_total(),
+                    min_priority_fee_wei = diag.min_priority_fee.unwrap_or(0),
                     current_gas = info.cumulative_gas_used,
+                    target_gas = limits.block_gas_limit,
+                    gas_headroom_pct = gas_headroom_pct,
                     current_da = info.cumulative_da_bytes_used,
+                    flashblock_exec_time_us = info.flashblock_execution_time_us,
+                    exec_time_limit_us = ?limits.flashblock_execution_time_limit_us,
+                    cumulative_state_root_time_us = info.cumulative_state_root_time_us,
+                    state_root_time_limit_us = ?limits.block_state_root_time_limit_us,
                     target_flashblocks = ctx.target_flashblock_count(),
                 );
 

--- a/crates/builder/core/src/lib.rs
+++ b/crates/builder/core/src/lib.rs
@@ -32,8 +32,9 @@ pub use metering::{MeteringProvider, NoopMeteringProvider, SharedMeteringProvide
 mod flashblocks;
 pub use flashblocks::{
     BestFlashblocksTxs, BlockCell, BlockPayloadJob, BlockPayloadJobGenerator, BuildArguments,
-    FlashblocksExecutionInfo, FlashblocksExtraCtx, FlashblocksServiceBuilder, OpPayloadBuilderCtx,
-    PayloadBuilder, PayloadHandler, ResolvePayload, WaitForValue,
+    FlashblockDiagnostics, FlashblocksExecutionInfo, FlashblocksExtraCtx,
+    FlashblocksServiceBuilder, OpPayloadBuilderCtx, PayloadBuilder, PayloadHandler, ResolvePayload,
+    WaitForValue,
 };
 
 mod extension;

--- a/crates/builder/core/src/lib.rs
+++ b/crates/builder/core/src/lib.rs
@@ -32,9 +32,9 @@ pub use metering::{MeteringProvider, NoopMeteringProvider, SharedMeteringProvide
 mod flashblocks;
 pub use flashblocks::{
     BestFlashblocksTxs, BlockCell, BlockPayloadJob, BlockPayloadJobGenerator, BuildArguments,
-    FlashblockDiagnostics, FlashblocksExecutionInfo, FlashblocksExtraCtx,
-    FlashblocksServiceBuilder, OpPayloadBuilderCtx, PayloadBuilder, PayloadHandler, ResolvePayload,
-    WaitForValue,
+    FlashblockDiagnostics, FlashblockSelectionOutcome, FlashblocksExecutionInfo,
+    FlashblocksExtraCtx, FlashblocksServiceBuilder, OpPayloadBuilderCtx, PayloadBuilder,
+    PayloadHandler, ResolvePayload, WaitForValue,
 };
 
 mod extension;

--- a/crates/builder/core/src/metrics.rs
+++ b/crates/builder/core/src/metrics.rs
@@ -9,8 +9,11 @@ use crate::{ExecutionInfo, FlashblockDiagnostics, ResourceLimits};
 const FLASHBLOCK_INDEX_LABEL: &str = "flashblock_index";
 const OUTCOME_LABEL: &str = "outcome";
 const REASON_LABEL: &str = "reason";
+const THRESHOLD_LABEL: &str = "threshold";
 
 const FLASHBLOCK_SELECTION_TOTAL: &str = "base_builder_flashblock_selection_total";
+const FLASHBLOCK_CONSTRAINED_TOTAL: &str = "base_builder_flashblock_constrained_total";
+const FLASHBLOCK_TXS_CONSIDERED: &str = "base_builder_flashblock_txs_considered";
 const FLASHBLOCK_REJECTIONS_TOTAL: &str = "base_builder_flashblock_rejections_total";
 const FLASHBLOCK_TXS_INCLUDED: &str = "base_builder_flashblock_txs_included";
 const FLASHBLOCK_TXS_REJECTED: &str = "base_builder_flashblock_txs_rejected";
@@ -25,6 +28,8 @@ const FLASHBLOCK_EXECUTION_TIME_HEADROOM_US: &str =
 const FLASHBLOCK_STATE_ROOT_TIME_USED_US: &str = "base_builder_flashblock_state_root_time_used_us";
 const FLASHBLOCK_STATE_ROOT_TIME_HEADROOM_US: &str =
     "base_builder_flashblock_state_root_time_headroom_us";
+const CONSTRAINT_THRESHOLDS_WEI: [(&str, u64); 3] =
+    [("100wei", 100), ("100kwei", 100_000), ("1mwei", 1_000_000)];
 
 /// base-builder metrics
 #[derive(Metrics, Clone)]
@@ -187,6 +192,8 @@ impl BuilderMetrics {
         )
         .increment(1);
 
+        histogram!(FLASHBLOCK_TXS_CONSIDERED, FLASHBLOCK_INDEX_LABEL => flashblock_index.clone())
+            .record(diag.txs_considered as f64);
         histogram!(FLASHBLOCK_TXS_INCLUDED, FLASHBLOCK_INDEX_LABEL => flashblock_index.clone())
             .record(diag.txs_included as f64);
         histogram!(FLASHBLOCK_TXS_REJECTED, FLASHBLOCK_INDEX_LABEL => flashblock_index.clone())
@@ -198,6 +205,16 @@ impl BuilderMetrics {
                 FLASHBLOCK_INDEX_LABEL => flashblock_index.clone(),
             )
             .record(min_priority_fee as f64);
+            for (threshold, threshold_wei) in CONSTRAINT_THRESHOLDS_WEI {
+                if min_priority_fee > threshold_wei {
+                    counter!(
+                        FLASHBLOCK_CONSTRAINED_TOTAL,
+                        FLASHBLOCK_INDEX_LABEL => flashblock_index.clone(),
+                        THRESHOLD_LABEL => threshold,
+                    )
+                    .increment(1);
+                }
+            }
         }
 
         let gas_headroom = limits.block_gas_limit.saturating_sub(info.cumulative_gas_used);
@@ -312,7 +329,7 @@ mod tests {
             txs_included: 3,
             txs_rejected_gas: 2,
             txs_rejected_da: 1,
-            min_priority_fee: Some(42),
+            min_priority_fee: Some(200_000),
             ..Default::default()
         };
         let info = ExecutionInfo {
@@ -346,8 +363,14 @@ mod tests {
             rendered.contains("base_builder_flashblock_txs_included_sum{flashblock_index=\"7\"} 3")
         );
         assert!(
+            rendered.contains("base_builder_flashblock_txs_considered_sum{flashblock_index=\"7\"} 6")
+        );
+        assert!(
             rendered
                 .contains("base_builder_flashblock_gas_headroom_sum{flashblock_index=\"7\"} 40")
         );
+        assert!(rendered.contains(
+            "base_builder_flashblock_constrained_total{flashblock_index=\"7\",threshold=\"100wei\"} 1"
+        ));
     }
 }

--- a/crates/builder/core/src/metrics.rs
+++ b/crates/builder/core/src/metrics.rs
@@ -363,7 +363,8 @@ mod tests {
             rendered.contains("base_builder_flashblock_txs_included_sum{flashblock_index=\"7\"} 3")
         );
         assert!(
-            rendered.contains("base_builder_flashblock_txs_considered_sum{flashblock_index=\"7\"} 6")
+            rendered
+                .contains("base_builder_flashblock_txs_considered_sum{flashblock_index=\"7\"} 6")
         );
         assert!(
             rendered

--- a/crates/builder/core/src/metrics.rs
+++ b/crates/builder/core/src/metrics.rs
@@ -1,8 +1,30 @@
-use metrics::IntoF64;
+use metrics::{IntoF64, counter, histogram};
 use reth_metrics::{
     Metrics,
     metrics::{Counter, Gauge, Histogram},
 };
+
+use crate::{ExecutionInfo, FlashblockDiagnostics, ResourceLimits};
+
+const FLASHBLOCK_INDEX_LABEL: &str = "flashblock_index";
+const OUTCOME_LABEL: &str = "outcome";
+const REASON_LABEL: &str = "reason";
+
+const FLASHBLOCK_SELECTION_TOTAL: &str = "base_builder_flashblock_selection_total";
+const FLASHBLOCK_REJECTIONS_TOTAL: &str = "base_builder_flashblock_rejections_total";
+const FLASHBLOCK_TXS_INCLUDED: &str = "base_builder_flashblock_txs_included";
+const FLASHBLOCK_TXS_REJECTED: &str = "base_builder_flashblock_txs_rejected";
+const FLASHBLOCK_MIN_PRIORITY_FEE_WEI: &str = "base_builder_flashblock_min_priority_fee_wei";
+const FLASHBLOCK_GAS_HEADROOM: &str = "base_builder_flashblock_gas_headroom";
+const FLASHBLOCK_GAS_HEADROOM_PCT: &str = "base_builder_flashblock_gas_headroom_pct";
+const FLASHBLOCK_DA_BYTES_USED: &str = "base_builder_flashblock_da_bytes_used";
+const FLASHBLOCK_DA_HEADROOM_BYTES: &str = "base_builder_flashblock_da_headroom_bytes";
+const FLASHBLOCK_EXECUTION_TIME_USED_US: &str = "base_builder_flashblock_execution_time_used_us";
+const FLASHBLOCK_EXECUTION_TIME_HEADROOM_US: &str =
+    "base_builder_flashblock_execution_time_headroom_us";
+const FLASHBLOCK_STATE_ROOT_TIME_USED_US: &str = "base_builder_flashblock_state_root_time_used_us";
+const FLASHBLOCK_STATE_ROOT_TIME_HEADROOM_US: &str =
+    "base_builder_flashblock_state_root_time_headroom_us";
 
 /// base-builder metrics
 #[derive(Metrics, Clone)]
@@ -149,6 +171,102 @@ pub struct BuilderMetrics {
 }
 
 impl BuilderMetrics {
+    /// Records per-flashblock selection diagnostics as labeled metrics.
+    pub fn record_flashblock_diagnostics(
+        &self,
+        flashblock_index: u64,
+        diag: &FlashblockDiagnostics,
+        info: &ExecutionInfo,
+        limits: &ResourceLimits,
+    ) {
+        let flashblock_index = flashblock_index.to_string();
+        counter!(
+            FLASHBLOCK_SELECTION_TOTAL,
+            FLASHBLOCK_INDEX_LABEL => flashblock_index.clone(),
+            OUTCOME_LABEL => diag.selection_outcome(),
+        )
+        .increment(1);
+
+        histogram!(FLASHBLOCK_TXS_INCLUDED, FLASHBLOCK_INDEX_LABEL => flashblock_index.clone())
+            .record(diag.txs_included as f64);
+        histogram!(FLASHBLOCK_TXS_REJECTED, FLASHBLOCK_INDEX_LABEL => flashblock_index.clone())
+            .record(diag.txs_rejected_total() as f64);
+
+        if let Some(min_priority_fee) = diag.min_priority_fee {
+            histogram!(
+                FLASHBLOCK_MIN_PRIORITY_FEE_WEI,
+                FLASHBLOCK_INDEX_LABEL => flashblock_index.clone(),
+            )
+            .record(min_priority_fee as f64);
+        }
+
+        let gas_headroom = limits.block_gas_limit.saturating_sub(info.cumulative_gas_used);
+        histogram!(FLASHBLOCK_GAS_HEADROOM, FLASHBLOCK_INDEX_LABEL => flashblock_index.clone())
+            .record(gas_headroom as f64);
+        if limits.block_gas_limit > 0 {
+            histogram!(
+                FLASHBLOCK_GAS_HEADROOM_PCT,
+                FLASHBLOCK_INDEX_LABEL => flashblock_index.clone(),
+            )
+            .record(gas_headroom as f64 / limits.block_gas_limit as f64 * 100.0);
+        }
+
+        histogram!(FLASHBLOCK_DA_BYTES_USED, FLASHBLOCK_INDEX_LABEL => flashblock_index.clone())
+            .record(info.cumulative_da_bytes_used as f64);
+        if let Some(block_data_limit) = limits.block_data_limit {
+            histogram!(
+                FLASHBLOCK_DA_HEADROOM_BYTES,
+                FLASHBLOCK_INDEX_LABEL => flashblock_index.clone(),
+            )
+            .record(block_data_limit.saturating_sub(info.cumulative_da_bytes_used) as f64);
+        }
+
+        histogram!(
+            FLASHBLOCK_EXECUTION_TIME_USED_US,
+            FLASHBLOCK_INDEX_LABEL => flashblock_index.clone(),
+        )
+        .record(info.flashblock_execution_time_us as f64);
+        if let Some(flashblock_execution_time_limit_us) = limits.flashblock_execution_time_limit_us
+        {
+            histogram!(
+                FLASHBLOCK_EXECUTION_TIME_HEADROOM_US,
+                FLASHBLOCK_INDEX_LABEL => flashblock_index.clone(),
+            )
+            .record(
+                flashblock_execution_time_limit_us.saturating_sub(info.flashblock_execution_time_us)
+                    as f64,
+            );
+        }
+
+        histogram!(
+            FLASHBLOCK_STATE_ROOT_TIME_USED_US,
+            FLASHBLOCK_INDEX_LABEL => flashblock_index.clone(),
+        )
+        .record(info.cumulative_state_root_time_us as f64);
+        if let Some(block_state_root_time_limit_us) = limits.block_state_root_time_limit_us {
+            histogram!(
+                FLASHBLOCK_STATE_ROOT_TIME_HEADROOM_US,
+                FLASHBLOCK_INDEX_LABEL => flashblock_index.clone(),
+            )
+            .record(
+                block_state_root_time_limit_us.saturating_sub(info.cumulative_state_root_time_us)
+                    as f64,
+            );
+        }
+
+        for (reason, count) in diag.rejection_counts() {
+            if count == 0 {
+                continue;
+            }
+            counter!(
+                FLASHBLOCK_REJECTIONS_TOTAL,
+                FLASHBLOCK_INDEX_LABEL => flashblock_index.clone(),
+                REASON_LABEL => reason,
+            )
+            .increment(count);
+        }
+    }
+
     pub fn set_payload_builder_metrics(
         &self,
         payload_transaction_simulation_time: impl IntoF64 + Copy,
@@ -169,5 +287,67 @@ impl BuilderMetrics {
         self.payload_num_tx_simulated_fail.record(num_txs_simulated_fail);
         self.payload_num_tx_simulated_fail_gauge.set(num_txs_simulated_fail);
         self.payload_reverted_tx_gas_used.set(reverted_gas_used);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::OnceLock;
+
+    use metrics_exporter_prometheus::{PrometheusBuilder, PrometheusHandle};
+
+    use super::*;
+
+    fn metrics_handle() -> &'static PrometheusHandle {
+        static HANDLE: OnceLock<PrometheusHandle> = OnceLock::new();
+        HANDLE.get_or_init(|| PrometheusBuilder::new().install_recorder().unwrap())
+    }
+
+    #[test]
+    fn record_flashblock_diagnostics_emits_labeled_metrics() {
+        let handle = metrics_handle();
+        let metrics = BuilderMetrics::default();
+        let diag = FlashblockDiagnostics {
+            txs_considered: 6,
+            txs_included: 3,
+            txs_rejected_gas: 2,
+            txs_rejected_da: 1,
+            min_priority_fee: Some(42),
+            ..Default::default()
+        };
+        let info = ExecutionInfo {
+            cumulative_gas_used: 60,
+            cumulative_da_bytes_used: 15,
+            flashblock_execution_time_us: 40,
+            cumulative_state_root_time_us: 90,
+            ..Default::default()
+        };
+        let limits = ResourceLimits {
+            block_gas_limit: 100,
+            block_data_limit: Some(20),
+            flashblock_execution_time_limit_us: Some(50),
+            block_state_root_time_limit_us: Some(100),
+            ..Default::default()
+        };
+
+        metrics.record_flashblock_diagnostics(7, &diag, &info, &limits);
+
+        let rendered = handle.render();
+        assert!(rendered.contains(
+            "base_builder_flashblock_selection_total{flashblock_index=\"7\",outcome=\"pool_drained\"} 1"
+        ));
+        assert!(rendered.contains(
+            "base_builder_flashblock_rejections_total{flashblock_index=\"7\",reason=\"gas_limit\"} 2"
+        ));
+        assert!(rendered.contains(
+            "base_builder_flashblock_rejections_total{flashblock_index=\"7\",reason=\"da_size\"} 1"
+        ));
+        assert!(
+            rendered.contains("base_builder_flashblock_txs_included_sum{flashblock_index=\"7\"} 3")
+        );
+        assert!(
+            rendered
+                .contains("base_builder_flashblock_gas_headroom_sum{flashblock_index=\"7\"} 40")
+        );
     }
 }

--- a/crates/builder/core/src/metrics.rs
+++ b/crates/builder/core/src/metrics.rs
@@ -12,7 +12,8 @@ const REASON_LABEL: &str = "reason";
 const THRESHOLD_LABEL: &str = "threshold";
 
 const FLASHBLOCK_SELECTION_TOTAL: &str = "base_builder_flashblock_selection_total";
-const FLASHBLOCK_CONSTRAINED_TOTAL: &str = "base_builder_flashblock_constrained_total";
+const FLASHBLOCK_MIN_PRIORITY_FEE_ABOVE_THRESHOLD_TOTAL: &str =
+    "base_builder_flashblock_min_priority_fee_above_threshold_total";
 const FLASHBLOCK_TXS_CONSIDERED: &str = "base_builder_flashblock_txs_considered";
 const FLASHBLOCK_REJECTIONS_TOTAL: &str = "base_builder_flashblock_rejections_total";
 const FLASHBLOCK_TXS_INCLUDED: &str = "base_builder_flashblock_txs_included";
@@ -28,7 +29,7 @@ const FLASHBLOCK_EXECUTION_TIME_HEADROOM_US: &str =
 const FLASHBLOCK_STATE_ROOT_TIME_USED_US: &str = "base_builder_flashblock_state_root_time_used_us";
 const FLASHBLOCK_STATE_ROOT_TIME_HEADROOM_US: &str =
     "base_builder_flashblock_state_root_time_headroom_us";
-const CONSTRAINT_THRESHOLDS_WEI: [(&str, u64); 3] =
+const PRIORITY_FEE_THRESHOLDS_WEI: [(&str, u64); 3] =
     [("100wei", 100), ("100kwei", 100_000), ("1mwei", 1_000_000)];
 
 /// base-builder metrics
@@ -188,7 +189,7 @@ impl BuilderMetrics {
         counter!(
             FLASHBLOCK_SELECTION_TOTAL,
             FLASHBLOCK_INDEX_LABEL => flashblock_index.clone(),
-            OUTCOME_LABEL => diag.selection_outcome(),
+            OUTCOME_LABEL => diag.selection_outcome().as_str(),
         )
         .increment(1);
 
@@ -205,10 +206,10 @@ impl BuilderMetrics {
                 FLASHBLOCK_INDEX_LABEL => flashblock_index.clone(),
             )
             .record(min_priority_fee as f64);
-            for (threshold, threshold_wei) in CONSTRAINT_THRESHOLDS_WEI {
+            for (threshold, threshold_wei) in PRIORITY_FEE_THRESHOLDS_WEI {
                 if min_priority_fee > threshold_wei {
                     counter!(
-                        FLASHBLOCK_CONSTRAINED_TOTAL,
+                        FLASHBLOCK_MIN_PRIORITY_FEE_ABOVE_THRESHOLD_TOTAL,
                         FLASHBLOCK_INDEX_LABEL => flashblock_index.clone(),
                         THRESHOLD_LABEL => threshold,
                     )
@@ -309,20 +310,14 @@ impl BuilderMetrics {
 
 #[cfg(test)]
 mod tests {
-    use std::sync::OnceLock;
-
-    use metrics_exporter_prometheus::{PrometheusBuilder, PrometheusHandle};
+    use metrics_exporter_prometheus::PrometheusBuilder;
 
     use super::*;
 
-    fn metrics_handle() -> &'static PrometheusHandle {
-        static HANDLE: OnceLock<PrometheusHandle> = OnceLock::new();
-        HANDLE.get_or_init(|| PrometheusBuilder::new().install_recorder().unwrap())
-    }
-
     #[test]
     fn record_flashblock_diagnostics_emits_labeled_metrics() {
-        let handle = metrics_handle();
+        let recorder = PrometheusBuilder::new().build_recorder();
+        let handle = recorder.handle();
         let metrics = BuilderMetrics::default();
         let diag = FlashblockDiagnostics {
             txs_considered: 6,
@@ -347,7 +342,9 @@ mod tests {
             ..Default::default()
         };
 
-        metrics.record_flashblock_diagnostics(7, &diag, &info, &limits);
+        metrics::with_local_recorder(&recorder, || {
+            metrics.record_flashblock_diagnostics(7, &diag, &info, &limits);
+        });
 
         let rendered = handle.render();
         assert!(rendered.contains(
@@ -371,7 +368,7 @@ mod tests {
                 .contains("base_builder_flashblock_gas_headroom_sum{flashblock_index=\"7\"} 40")
         );
         assert!(rendered.contains(
-            "base_builder_flashblock_constrained_total{flashblock_index=\"7\",threshold=\"100wei\"} 1"
+            "base_builder_flashblock_min_priority_fee_above_threshold_total{flashblock_index=\"7\",threshold=\"100wei\"} 1"
         ));
     }
 }

--- a/etc/scripts/release/start-release.sh
+++ b/etc/scripts/release/start-release.sh
@@ -24,12 +24,24 @@ fi
 main() {
     echo "=== Start Release (bump: $BUMP_TYPE) ==="
 
-    # Get latest FINAL tag (exact vX.Y.Z, exclude RCs and other suffixes)
-    CURRENT_VERSION=$(git tag -l 'v[0-9]*.[0-9]*.[0-9]*' \
-        | grep -Ex 'v[0-9]+\.[0-9]+\.[0-9]+' | sort -V | tail -1 | sed 's/^v//')
+    # For major/minor bumps, include release branch names so we don't
+    # collide with an in-progress release that hasn't been tagged yet.
+    # For patch bumps, use only final tags so we patch the latest
+    # *completed* release, not an in-progress one.
+    TAG_VERSIONS=$(git tag -l 'v[0-9]*.[0-9]*.[0-9]*' \
+        | grep -Ex 'v[0-9]+\.[0-9]+\.[0-9]+' || true)
+
+    if [[ "$BUMP_TYPE" == "patch" ]]; then
+        CURRENT_VERSION=$(echo "$TAG_VERSIONS" | sort -V | tail -1 | sed 's/^v//')
+    else
+        BRANCH_VERSIONS=$(git ls-remote --heads origin 'releases/v*' \
+            | sed -n 's|.*refs/heads/releases/\(v[0-9]*\.[0-9]*\.[0-9]*\)$|\1|p' || true)
+        CURRENT_VERSION=$(printf '%s\n' $TAG_VERSIONS $BRANCH_VERSIONS \
+            | sort -Vu | tail -1 | sed 's/^v//')
+    fi
 
     if [[ -z "$CURRENT_VERSION" ]]; then
-        echo "Error: No final release tags found. Cannot determine current version." >&2
+        echo "Error: No release tags or release branches found. Cannot determine current version." >&2
         exit 1
     fi
 


### PR DESCRIPTION
## Summary
- export flashblock diagnostics as a public API and align the API around selection outcome and rejection reasons
- count included transactions correctly, including reverted-but-included transactions
- emit richer flashblock diagnostics and add focused unit tests

## Testing
- cargo test -p base-builder-core --lib

Refs CHAIN-3712