### PR TITLE
Fix/duplicate dev deps

### DIFF
--- a/crates/batcher/comp/Cargo.toml
+++ b/crates/batcher/comp/Cargo.toml
@@ -29,7 +29,6 @@ alloy-primitives = { workspace = true, optional = true }
 spin.workspace = true
 rstest.workspace = true
 proptest.workspace = true
-alloy-eips.workspace = true
 serde_json.workspace = true
 alloy-consensus.workspace = true
 alloy-sol-types.workspace = true

--- a/crates/client/metering/Cargo.toml
+++ b/crates/client/metering/Cargo.toml
@@ -64,7 +64,6 @@ tracing = { workspace = true, features = ["std"] }
 
 [dev-dependencies]
 # workspace
-base-flashblocks.workspace = true
 base-alloy-flashblocks.workspace = true
 base-node-runner = { workspace = true, features = ["test-utils"] }
 

--- a/crates/client/txpool-tracing/Cargo.toml
+++ b/crates/client/txpool-tracing/Cargo.toml
@@ -41,7 +41,6 @@ derive_more = { workspace = true, features = ["display"] }
 
 [dev-dependencies]
 # workspace
-base-flashblocks.workspace = true
 base-node-runner = { workspace = true, features = ["test-utils"] }
 base-flashblocks-node = { workspace = true, features = ["test-utils"] }
 

--- a/crates/consensus/derive/Cargo.toml
+++ b/crates/consensus/derive/Cargo.toml
@@ -49,7 +49,6 @@ base-consensus-registry.workspace = true
 tracing = { workspace = true, features = ["std"] }
 tokio = { workspace = true, features = ["full"] }
 tracing-subscriber = { workspace = true, features = ["fmt"] }
-base-alloy-consensus = { workspace = true, features = ["k256"] }
 alloy-primitives = { workspace = true, features = ["rlp", "k256", "map", "arbitrary"] }
 
 [features]

--- a/crates/consensus/gossip/Cargo.toml
+++ b/crates/consensus/gossip/Cargo.toml
@@ -55,13 +55,11 @@ metrics = { workspace = true, optional = true }
 tempfile.workspace = true
 multihash.workspace = true
 serde_json = { workspace = true, features = ["std"] }
-alloy-eips = { workspace = true, features = ["std"] }
 alloy-chains = { workspace = true, features = ["std"] }
 
 rand = { workspace = true, features = ["thread_rng"] }
 arbitrary = { workspace = true, features = ["derive"] }
 alloy-primitives = { workspace = true, features = ["arbitrary"] }
-alloy-rpc-types-engine = { workspace = true, features = ["std"] }
 base-alloy-consensus = { workspace = true, features = ["arbitrary", "k256"] }
 alloy-consensus = { workspace = true, features = ["arbitrary", "k256", "std"] }
 

--- a/crates/consensus/peers/Cargo.toml
+++ b/crates/consensus/peers/Cargo.toml
@@ -46,7 +46,6 @@ rstest.workspace = true
 arbtest.workspace = true
 tempfile.workspace = true
 multihash.workspace = true
-serde_json = { workspace = true, features = ["std"] }
 
 arbitrary = { workspace = true, features = ["derive"] }
 alloy-primitives = { workspace = true, features = ["arbitrary"] }

--- a/crates/consensus/protocol/Cargo.toml
+++ b/crates/consensus/protocol/Cargo.toml
@@ -51,9 +51,7 @@ spin.workspace = true
 rstest.workspace = true
 proptest.workspace = true
 serde_json.workspace = true
-alloy-rpc-types-eth.workspace = true
 base-alloy-rpc-types.workspace = true
-base-alloy-consensus.workspace = true
 base-consensus-registry.workspace = true
 brotli = { workspace = true, features = ["std"] }
 tokio = { workspace = true, features = ["full"] }

--- a/crates/consensus/registry/Cargo.toml
+++ b/crates/consensus/registry/Cargo.toml
@@ -30,7 +30,6 @@ spin.workspace = true
 derive_more = { workspace = true, features = ["from", "deref"] }
 
 [dev-dependencies]
-alloy-eips.workspace = true
 
 [[test]]
 name = "hardfork_consistency"

--- a/crates/consensus/service/Cargo.toml
+++ b/crates/consensus/service/Cargo.toml
@@ -74,10 +74,8 @@ jsonrpsee = { workspace = true, features = ["server", "http-client"] }
 metrics = { workspace = true, optional = true }
 
 [dev-dependencies]
-http.workspace = true
 rand.workspace = true
 rstest.workspace = true
-backon.workspace = true
 anyhow.workspace = true
 mockall.workspace = true
 arbitrary.workspace = true

--- a/crates/consensus/sources/Cargo.toml
+++ b/crates/consensus/sources/Cargo.toml
@@ -46,4 +46,3 @@ default = []
 
 [dev-dependencies]
 tokio.workspace = true
-serde_json = { workspace = true, features = ["std"] }

--- a/crates/execution/flashblocks/Cargo.toml
+++ b/crates/execution/flashblocks/Cargo.toml
@@ -85,5 +85,4 @@ derive_more = { workspace = true, features = ["from"] }
 [dev-dependencies]
 rstest.workspace = true
 alloy-eips.workspace = true
-reth-revm.workspace = true
 base-execution-chainspec.workspace = true

--- a/crates/execution/node/Cargo.toml
+++ b/crates/execution/node/Cargo.toml
@@ -87,7 +87,6 @@ reth-e2e-test-utils = { workspace = true, optional = true }
 
 [dev-dependencies]
 reth-rpc.workspace = true
-reth-tasks.workspace = true
 reth-trie-db.workspace = true
 reth-payload-util.workspace = true
 reth-stages-types.workspace = true
@@ -98,7 +97,6 @@ reth-provider = { workspace = true, features = ["test-utils"] }
 base-node-core = { workspace = true, features = ["test-utils"] }
 reth-node-builder = { workspace = true, features = ["test-utils"] }
 
-futures.workspace = true
 alloy-eips.workspace = true
 alloy-network.workspace = true
 base-alloy-evm.workspace = true

--- a/crates/infra/based/Cargo.toml
+++ b/crates/infra/based/Cargo.toml
@@ -25,5 +25,4 @@ alloy-consensus = { workspace = true, features = ["std"] }
 alloy-rpc-types-eth = { workspace = true, features = ["std"] }
 
 [dev-dependencies]
-tracing = { workspace = true, features = ["std"] }
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }

--- a/crates/proof/tee/nitro-enclave/Cargo.toml
+++ b/crates/proof/tee/nitro-enclave/Cargo.toml
@@ -56,7 +56,6 @@ tokio-vsock.workspace = true
 tokio = { workspace = true, features = ["rt-multi-thread"] }
 
 [dev-dependencies]
-rand_08.workspace = true
 base-enclave.workspace = true
 base-consensus-registry.workspace = true
 tokio = { workspace = true, features = ["macros", "rt"] }

--- a/crates/txpool/Cargo.toml
+++ b/crates/txpool/Cargo.toml
@@ -54,10 +54,8 @@ tokio = { workspace = true, features = ["sync", "rt", "time"] }
 jsonrpsee = { workspace = true, features = ["http-client", "server", "macros"] }
 
 [dev-dependencies]
-alloy-eips.workspace = true
 base-test-utils.workspace = true
 base-execution-chainspec.workspace = true
-reth-primitives-traits.workspace = true
 reth-provider = { workspace = true, features = ["test-utils"] }
 reth-transaction-pool = { workspace = true, features = ["test-utils"] }
 tokio = { workspace = true, features = ["time", "rt-multi-thread", "macros"] }


### PR DESCRIPTION
Remove dependencies that appear in both [dependencies] and [dev-dependencies].
Covers 15 crates across batcher, client, consensus, execution, infra, proof, and txpool.


This clears all remaining duplicates.