### PR TITLE
chore(proposer): make max game recovery lookback configurable via CLI

### DIFF
--- a/crates/proof/proposer/README.md
+++ b/crates/proof/proposer/README.md
@@ -59,7 +59,7 @@ flowchart TD
     H -->|Other error| J[Log, next tick retries]
 ```
 
-`recover_latest_game()` walks backwards through the `DisputeGameFactory` (up to `MAX_GAME_RECOVERY_LOOKBACK` entries) to find the most recent game matching the configured `game_type`. Because state is always loaded from chain, the proposer naturally chains off games created by any proposer, handles `GameAlreadyExists` without special recovery logic, and cannot enter stale-state livelocks.
+`recover_latest_game()` walks backwards through the `DisputeGameFactory` (up to `--max-game-recovery-lookback` entries, default 5000) to find the most recent game matching the configured `game_type`. Because state is always loaded from chain, the proposer naturally chains off games created by any proposer, handles `GameAlreadyExists` without special recovery logic, and cannot enter stale-state livelocks.
 
 #### Data Sources
 

--- a/crates/proof/proposer/src/cli.rs
+++ b/crates/proof/proposer/src/cli.rs
@@ -154,6 +154,18 @@ pub struct ProposerArgs {
     )]
     pub max_parallel_proofs: usize,
 
+    /// Maximum number of games to scan backwards when recovering state on startup.
+    /// Must be greater than the maximum number of pending (unresolved) dispute games
+    /// that could exist at any given time. For production deployments with high game
+    /// volume, increase this beyond the default to ensure the proposer can always
+    /// find and resume from its most recent game after a restart.
+    #[arg(
+        long = "max-game-recovery-lookback",
+        env = cli_env!("MAX_GAME_RECOVERY_LOOKBACK"),
+        default_value = "5000"
+    )]
+    pub max_game_recovery_lookback: u64,
+
     /// Transaction manager configuration.
     #[command(flatten)]
     pub tx_manager: TxManagerCli,
@@ -250,6 +262,7 @@ mod tests {
         assert!(!cli.proposer.wait_node_sync);
         assert_eq!(cli.proposer.game_type, 1);
         assert_eq!(cli.proposer.max_parallel_proofs, 1);
+        assert_eq!(cli.proposer.max_game_recovery_lookback, 5000);
 
         assert_eq!(cli.logging.level, 3);
         assert_eq!(cli.logging.stdout_format, LogFormat::Full);

--- a/crates/proof/proposer/src/config.rs
+++ b/crates/proof/proposer/src/config.rs
@@ -95,6 +95,8 @@ pub struct ProposerConfig {
     /// Maximum number of concurrent proof tasks.
     /// When > 1, uses the parallel proving pipeline instead of the sequential driver.
     pub max_parallel_proofs: usize,
+    /// Maximum number of games to scan backwards when recovering state on startup.
+    pub max_game_recovery_lookback: u64,
 }
 
 impl ProposerConfig {
@@ -110,6 +112,14 @@ impl ProposerConfig {
         if cli.proposer.max_parallel_proofs == 0 {
             return Err(ConfigError::OutOfRange {
                 field: "max-parallel-proofs",
+                constraint: "at least 1",
+                value: "0".to_string(),
+            });
+        }
+
+        if cli.proposer.max_game_recovery_lookback == 0 {
+            return Err(ConfigError::OutOfRange {
+                field: "max-game-recovery-lookback",
                 constraint: "at least 1",
                 value: "0".to_string(),
             });
@@ -175,6 +185,7 @@ impl ProposerConfig {
             skip_tls_verify: cli.proposer.skip_tls_verify,
             wait_node_sync: cli.proposer.wait_node_sync,
             max_parallel_proofs: cli.proposer.max_parallel_proofs,
+            max_game_recovery_lookback: cli.proposer.max_game_recovery_lookback,
             log: LogConfig::from(cli.logging),
             metrics: cli.metrics.into(),
             health_addr: cli.health.socket_addr(),
@@ -248,6 +259,7 @@ mod tests {
                     signer_address: None,
                 },
                 max_parallel_proofs: 1,
+                max_game_recovery_lookback: 5000,
                 tx_manager: TxManagerCli::default(),
             },
             logging: LogArgs {
@@ -495,5 +507,31 @@ mod tests {
         cli.proposer.max_parallel_proofs = 8;
         let config = ProposerConfig::from_cli(cli).unwrap();
         assert_eq!(config.max_parallel_proofs, 8);
+    }
+
+    #[test]
+    fn test_max_game_recovery_lookback_zero_rejected() {
+        let mut cli = minimal_cli();
+        cli.proposer.max_game_recovery_lookback = 0;
+        let result = ProposerConfig::from_cli(cli);
+        assert!(matches!(
+            result,
+            Err(ConfigError::OutOfRange { field: "max-game-recovery-lookback", .. })
+        ));
+    }
+
+    #[test]
+    fn test_max_game_recovery_lookback_default() {
+        let cli = minimal_cli();
+        let config = ProposerConfig::from_cli(cli).unwrap();
+        assert_eq!(config.max_game_recovery_lookback, 5000);
+    }
+
+    #[test]
+    fn test_max_game_recovery_lookback_custom() {
+        let mut cli = minimal_cli();
+        cli.proposer.max_game_recovery_lookback = 10000;
+        let config = ProposerConfig::from_cli(cli).unwrap();
+        assert_eq!(config.max_game_recovery_lookback, 10000);
     }
 }

--- a/crates/proof/proposer/src/constants.rs
+++ b/crates/proof/proposer/src/constants.rs
@@ -12,17 +12,3 @@ pub const PROVER_TIMEOUT: Duration = Duration::from_mins(30);
 /// the anchor state registry (i.e., no parent game exists).
 /// This is `uint32.max` per the `DisputeGameFactory` contract.
 pub const NO_PARENT_INDEX: u32 = 0xFFFF_FFFF;
-
-/// Maximum number of games to scan backwards when recovering parent game state
-/// on startup.
-///
-/// IMPORTANT: This value MUST always be greater than the maximum number of pending
-/// (unresolved) dispute games that could exist at any given time. Since games take
-/// 1-7 days to resolve depending on proof type (7 days TEE-only, 1 day TEE+ZK),
-/// a significant backlog can build up during normal operation.
-///
-/// The default of 5000 is suitable for development and testnet environments.
-/// For production deployments with high game volume, this should be increased
-/// further to ensure the proposer can always find and resume from its most recent
-/// game after a restart.
-pub const MAX_GAME_RECOVERY_LOOKBACK: u64 = 5000;

--- a/crates/proof/proposer/src/driver/handle.rs
+++ b/crates/proof/proposer/src/driver/handle.rs
@@ -208,6 +208,7 @@ mod tests {
         let pipeline = ProvingPipeline::new(
             PipelineConfig {
                 max_parallel_proofs: 2,
+                max_game_recovery_lookback: 5000,
                 max_retries: 3,
                 v1_hardfork_timestamp: None,
                 driver: DriverConfig {

--- a/crates/proof/proposer/src/driver/pipeline.rs
+++ b/crates/proof/proposer/src/driver/pipeline.rs
@@ -49,6 +49,8 @@ pub struct PipelineConfig {
     pub max_parallel_proofs: usize,
     /// Maximum retries for a single proof range before full pipeline reset.
     pub max_retries: u32,
+    /// Maximum number of games to scan backwards when recovering state on startup.
+    pub max_game_recovery_lookback: u64,
     /// Base driver configuration.
     pub driver: DriverConfig,
     /// Optional Unix timestamp at which the V1 hardfork activates.
@@ -442,7 +444,7 @@ where
             .await
             .map_err(|e| ProposerError::Contract(format!("recovery game_count failed: {e}")))?;
 
-        let search_count = count.min(crate::constants::MAX_GAME_RECOVERY_LOOKBACK);
+        let search_count = count.min(self.config.max_game_recovery_lookback);
         for i in 0..search_count {
             let game_index = count - 1 - i;
             let game = match self.factory_client.game_at_index(game_index).await {
@@ -799,6 +801,7 @@ mod tests {
         let pipeline = test_pipeline(
             PipelineConfig {
                 max_parallel_proofs: 2,
+                max_game_recovery_lookback: 5000,
                 max_retries: 3,
                 v1_hardfork_timestamp: None,
                 driver: DriverConfig {
@@ -826,6 +829,7 @@ mod tests {
         let pipeline = test_pipeline(
             PipelineConfig {
                 max_parallel_proofs: 2,
+                max_game_recovery_lookback: 5000,
                 max_retries: 3,
                 v1_hardfork_timestamp: None,
                 driver: DriverConfig {
@@ -856,6 +860,7 @@ mod tests {
         let pipeline = test_pipeline(
             PipelineConfig {
                 max_parallel_proofs: 2,
+                max_game_recovery_lookback: 5000,
                 max_retries: 3,
                 v1_hardfork_timestamp: None,
                 driver: DriverConfig::default(),
@@ -874,6 +879,7 @@ mod tests {
         let pipeline = test_pipeline(
             PipelineConfig {
                 max_parallel_proofs: 2,
+                max_game_recovery_lookback: 5000,
                 max_retries: 3,
                 v1_hardfork_timestamp: Some(0),
                 driver: DriverConfig::default(),
@@ -894,6 +900,7 @@ mod tests {
         let pipeline = test_pipeline(
             PipelineConfig {
                 max_parallel_proofs: 2,
+                max_game_recovery_lookback: 5000,
                 max_retries: 3,
                 v1_hardfork_timestamp: Some(u64::MAX),
                 driver: DriverConfig::default(),
@@ -915,6 +922,7 @@ mod tests {
         let pipeline = test_pipeline(
             PipelineConfig {
                 max_parallel_proofs: 2,
+                max_game_recovery_lookback: 5000,
                 max_retries: 3,
                 v1_hardfork_timestamp: Some(u64::MAX),
                 driver: DriverConfig {
@@ -943,6 +951,7 @@ mod tests {
         let pipeline = test_pipeline(
             PipelineConfig {
                 max_parallel_proofs: 2,
+                max_game_recovery_lookback: 5000,
                 max_retries: 3,
                 v1_hardfork_timestamp: Some(0),
                 driver: DriverConfig {

--- a/crates/proof/proposer/src/service.rs
+++ b/crates/proof/proposer/src/service.rs
@@ -196,6 +196,7 @@ pub async fn run(config: ProposerConfig) -> Result<()> {
     // ── 6. Create proving pipeline ─────────────────────────────────────────
     let pipeline_config = PipelineConfig {
         max_parallel_proofs: config.max_parallel_proofs,
+        max_game_recovery_lookback: config.max_game_recovery_lookback,
         max_retries: 3,
         v1_hardfork_timestamp,
         driver: DriverConfig {


### PR DESCRIPTION
## Summary

- Converts the hardcoded `MAX_GAME_RECOVERY_LOOKBACK` constant (`5000`) into a runtime-configurable `--max-game-recovery-lookback` CLI flag, threaded through `ProposerArgs` -> `ProposerConfig` -> `PipelineConfig`.
- Allows production deployments with high game volume to increase the scan window beyond the default, ensuring the proposer can always find and resume from its most recent game after a restart.
- Adds config validation (rejects `0`) and tests covering default, custom, and zero-rejection cases.