### PR TITLE
feat(proof): propagate error_message from failed ZK proof jobs

### DIFF
--- a/crates/proof/challenge/src/pending.rs
+++ b/crates/proof/challenge/src/pending.rs
@@ -223,6 +223,7 @@ impl PendingProofs {
                 ProofUpdate::Ready(proof_bytes)
             }
             ProofJobStatus::Failed => {
+                warn!(game = %game, error_message = ?response.error_message, "proof job failed");
                 pending.retry_count += 1;
                 pending.phase = ProofPhase::NeedsRetry;
                 ProofUpdate::NeedsRetry

--- a/crates/proof/challenge/src/test_utils.rs
+++ b/crates/proof/challenge/src/test_utils.rs
@@ -292,7 +292,7 @@ impl L2Provider for MockL2Provider {
 }
 
 /// Mock ZK proof provider for testing the driver.
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct MockZkProofProvider {
     /// Session ID returned by [`prove_block`](ZkProofProvider::prove_block).
     pub session_id: String,
@@ -300,6 +300,8 @@ pub struct MockZkProofProvider {
     pub proof_status: Mutex<i32>,
     /// Proof receipt bytes returned when status is `Succeeded`.
     pub receipt: Mutex<Vec<u8>>,
+    /// Error message returned when status is `Failed`.
+    pub error_message: Mutex<Option<String>>,
 }
 
 #[async_trait]
@@ -314,7 +316,8 @@ impl ZkProofProvider for MockZkProofProvider {
     async fn get_proof(&self, _request: GetProofRequest) -> Result<GetProofResponse, ZkProofError> {
         let status = *self.proof_status.lock().unwrap();
         let receipt = self.receipt.lock().unwrap().clone();
-        Ok(GetProofResponse { status, receipt })
+        let error_message = self.error_message.lock().unwrap().clone();
+        Ok(GetProofResponse { status, receipt, error_message })
     }
 }
 

--- a/crates/proof/challenge/tests/driver.rs
+++ b/crates/proof/challenge/tests/driver.rs
@@ -69,11 +69,7 @@ fn test_driver_with_tee(
 }
 
 fn default_zk_prover() -> Arc<MockZkProofProvider> {
-    Arc::new(MockZkProofProvider {
-        session_id: "test-session".to_string(),
-        proof_status: Mutex::new(ProofJobStatus::Created as i32),
-        receipt: Mutex::new(vec![]),
-    })
+    Arc::new(MockZkProofProvider { session_id: "test-session".to_string(), ..Default::default() })
 }
 
 fn default_tx_manager() -> MockTxManager {
@@ -190,8 +186,7 @@ async fn test_step_valid_game_skipped() {
     // The ZK prover should NOT be called since the game is valid.
     let zk = Arc::new(MockZkProofProvider {
         session_id: "should-not-be-called".to_string(),
-        proof_status: Mutex::new(ProofJobStatus::Created as i32),
-        receipt: Mutex::new(vec![]),
+        ..Default::default()
     });
 
     let mut driver = test_driver(factory, verifier, l2, zk, default_tx_manager());
@@ -232,8 +227,7 @@ async fn test_step_validation_error_blocks_not_available() {
 
     let zk = Arc::new(MockZkProofProvider {
         session_id: "test-session".to_string(),
-        proof_status: Mutex::new(ProofJobStatus::Created as i32),
-        receipt: Mutex::new(vec![]),
+        ..Default::default()
     });
 
     let mut driver = test_driver(factory, verifier, l2, zk, default_tx_manager());
@@ -251,6 +245,7 @@ async fn test_step_invalid_game_proof_succeeded() {
         session_id: "proof-123".to_string(),
         proof_status: Mutex::new(ProofJobStatus::Succeeded as i32),
         receipt: Mutex::new(vec![0xDE, 0xAD]),
+        ..Default::default()
     });
 
     let tx_hash = B256::repeat_byte(0xCC);
@@ -271,7 +266,7 @@ async fn test_step_invalid_game_proof_failed() {
     let zk = Arc::new(MockZkProofProvider {
         session_id: "proof-fail".to_string(),
         proof_status: Mutex::new(ProofJobStatus::Failed as i32),
-        receipt: Mutex::new(vec![]),
+        ..Default::default()
     });
 
     // tx_manager should NOT be called (proof failed → no submission)
@@ -398,8 +393,8 @@ async fn test_step_pending_proof_skips_prove_block() {
 
     let zk = Arc::new(MockZkProofProvider {
         session_id: "pending-session".to_string(),
-        proof_status: Mutex::new(ProofJobStatus::Created as i32),
         receipt: Mutex::new(vec![0xBE, 0xEF]),
+        ..Default::default()
     });
 
     let tx_hash = B256::repeat_byte(0xDD);
@@ -437,6 +432,7 @@ async fn test_step_nullification_failure_preserves_proof() {
         session_id: "proof-ok".to_string(),
         proof_status: Mutex::new(ProofJobStatus::Succeeded as i32),
         receipt: Mutex::new(vec![0xDE, 0xAD]),
+        ..Default::default()
     });
 
     // First tx call fails (NonceTooLow), second succeeds.
@@ -539,6 +535,7 @@ async fn test_step_proof_retry_succeeds() {
         session_id: "retry-session".to_string(),
         proof_status: Mutex::new(ProofJobStatus::Failed as i32),
         receipt: Mutex::new(vec![0xBE, 0xEF]),
+        ..Default::default()
     });
 
     let tx_hash = B256::repeat_byte(0xDD);
@@ -575,7 +572,7 @@ async fn test_step_proof_exceeds_max_retries() {
     let zk = Arc::new(MockZkProofProvider {
         session_id: "fail-forever".to_string(),
         proof_status: Mutex::new(ProofJobStatus::Failed as i32),
-        receipt: Mutex::new(vec![]),
+        ..Default::default()
     });
 
     let tx_manager = default_tx_manager();
@@ -653,8 +650,7 @@ async fn test_step_invalid_game_tee_fails_zk_fallback() {
     let tee = Arc::new(MockTeeProofProvider::failure("enclave unreachable"));
     let zk = Arc::new(MockZkProofProvider {
         session_id: "zk-fallback".to_string(),
-        proof_status: Mutex::new(ProofJobStatus::Created as i32),
-        receipt: Mutex::new(vec![]),
+        ..Default::default()
     });
 
     let tx_manager = default_tx_manager();
@@ -690,11 +686,8 @@ async fn test_step_invalid_game_no_tee_prover_zk_only() {
 
     // This TEE provider should never be called since tee_prover is ZERO.
     let tee = Arc::new(MockTeeProofProvider::failure("should not be called"));
-    let zk = Arc::new(MockZkProofProvider {
-        session_id: "zk-direct".to_string(),
-        proof_status: Mutex::new(ProofJobStatus::Created as i32),
-        receipt: Mutex::new(vec![]),
-    });
+    let zk =
+        Arc::new(MockZkProofProvider { session_id: "zk-direct".to_string(), ..Default::default() });
 
     let tx_manager = default_tx_manager();
     let mut driver = test_driver_with_tee(
@@ -729,8 +722,7 @@ async fn test_step_invalid_game_no_tee_provider_zk_only() {
 
     let zk = Arc::new(MockZkProofProvider {
         session_id: "zk-no-provider".to_string(),
-        proof_status: Mutex::new(ProofJobStatus::Created as i32),
-        receipt: Mutex::new(vec![]),
+        ..Default::default()
     });
 
     let tx_manager = default_tx_manager();
@@ -757,6 +749,7 @@ async fn test_step_invalid_game_tee_fails_zk_succeeds() {
         session_id: "zk-after-tee-fail".to_string(),
         proof_status: Mutex::new(ProofJobStatus::Succeeded as i32),
         receipt: Mutex::new(vec![0xDE, 0xAD]),
+        ..Default::default()
     });
 
     let tx_hash = B256::repeat_byte(0xCC);
@@ -848,8 +841,7 @@ async fn test_step_invalid_game_tee_proof_succeeds() {
     // ZK prover should NOT be called since TEE proof succeeds.
     let zk = Arc::new(MockZkProofProvider {
         session_id: "should-not-be-called".to_string(),
-        proof_status: Mutex::new(ProofJobStatus::Created as i32),
-        receipt: Mutex::new(vec![]),
+        ..Default::default()
     });
 
     let mut driver = test_driver_with_tee(

--- a/crates/proof/challenge/tests/driver.rs
+++ b/crates/proof/challenge/tests/driver.rs
@@ -386,7 +386,7 @@ async fn test_step_scan_error_propagated() {
 
 #[tokio::test]
 async fn test_step_pending_proof_skips_prove_block() {
-    // First step: proof initiated (status=Created, not ready).
+    // First step: proof initiated (status=Unspecified via Default, not ready).
     // Second step: same game re-discovered → polls existing session,
     // proof succeeds, nullification submitted.
     let (l2, factory, verifier) = invalid_game_mocks();
@@ -402,7 +402,7 @@ async fn test_step_pending_proof_skips_prove_block() {
 
     let mut driver = test_driver(factory, verifier, l2, Arc::clone(&zk), tx_manager);
 
-    // Step 1: proof is initiated but not ready (Created) → session stored.
+    // Step 1: proof is initiated but not ready (Unspecified) → session stored.
     driver.step().await.unwrap();
     assert!(
         driver.pending_proofs.contains_key(&addr(0)),

--- a/crates/proof/zk/client/README.md
+++ b/crates/proof/zk/client/README.md
@@ -102,6 +102,7 @@ impl ZkProofProvider for MockProvider {
         Ok(GetProofResponse {
             status: ProofJobStatus::Succeeded.into(),
             receipt: vec![1, 2, 3],
+            error_message: None,
         })
     }
 }

--- a/crates/proof/zk/client/proto/zk_prover.proto
+++ b/crates/proof/zk/client/proto/zk_prover.proto
@@ -55,4 +55,5 @@ message GetProofRequest {
 message GetProofResponse {
   ProofJobStatus status = 1;
   bytes receipt = 2; // the actual zk proof, only populated if status is SUCCEEDED
+  optional string error_message = 3; // populated when status is FAILED
 }

--- a/crates/proof/zk/client/tests/mock_provider.rs
+++ b/crates/proof/zk/client/tests/mock_provider.rs
@@ -24,6 +24,7 @@ impl ZkProofProvider for MockZkProvider {
         Ok(GetProofResponse {
             status: ProofJobStatus::Succeeded.into(),
             receipt: vec![0xDE, 0xAD, 0xBE, 0xEF],
+            error_message: None,
         })
     }
 }

--- a/crates/proof/zk/service/src/server/get_proof.rs
+++ b/crates/proof/zk/service/src/server/get_proof.rs
@@ -56,33 +56,21 @@ impl ProverServiceServer {
             .ok_or_else(|| Status::not_found("Proof request not found"))?;
 
         // Map database status to proto status
-        let (proto_status, receipt_bytes) = match proof_req.status {
-            ProofStatus::Created => {
-                // Task created but not yet claimed by a worker
-                (ProofJobStatus::Created, vec![])
-            }
-            ProofStatus::Pending => {
-                // Task claimed by worker, waiting for backend to start
-                (ProofJobStatus::Pending, vec![])
-            }
-            ProofStatus::Running => {
-                // Return current status from database. The StatusPoller background
-                // task handles periodic syncing with the backend, avoiding write
-                // amplification on every poll.
-                (ProofJobStatus::Running, vec![])
-            }
+        let (proto_status, receipt_bytes, error_message) = match proof_req.status {
+            ProofStatus::Created => (ProofJobStatus::Created, vec![], None),
+            ProofStatus::Pending => (ProofJobStatus::Pending, vec![], None),
+            // StatusPoller handles periodic syncing with the backend,
+            // avoiding write amplification on every poll.
+            ProofStatus::Running => (ProofJobStatus::Running, vec![], None),
             ProofStatus::Succeeded => {
-                // Already completed, return appropriate receipt based on requested type
                 let receipt_buf = get_receipt_by_type(&proof_req, requested_receipt_type)?;
-                (ProofJobStatus::Succeeded, receipt_buf)
+                (ProofJobStatus::Succeeded, receipt_buf, None)
             }
-            ProofStatus::Failed => {
-                // Failed
-                (ProofJobStatus::Failed, vec![])
-            }
+            ProofStatus::Failed => (ProofJobStatus::Failed, vec![], proof_req.error_message),
         };
 
-        let response = GetProofResponse { status: proto_status.into(), receipt: receipt_bytes };
+        let response =
+            GetProofResponse { status: proto_status.into(), receipt: receipt_bytes, error_message };
 
         Ok(Response::new(response))
     }


### PR DESCRIPTION
## Summary
- Add an `optional string error_message` field to the `GetProofResponse` proto so failure details from the prover backend are surfaced to the challenger.
- Log the error message at `warn` level when a proof job fails, aiding production debugging.
- Derive `Default` on `MockZkProofProvider` and simplify test mock construction throughout the driver tests.