### PR TITLE
refactor(tee): extract SignerClient trait from ProverClient

### DIFF
--- a/bin/prover-registrar/src/cli.rs
+++ b/bin/prover-registrar/src/cli.rs
@@ -18,8 +18,9 @@ use base_proof_tee_nitro_attestation_prover::{
     AttestationProofProvider, BoundlessProver, DirectProver,
 };
 use base_proof_tee_registrar::{
-    AwsDiscoveryConfig, AwsTargetGroupDiscovery, BoundlessConfig, DriverConfig, ProvingConfig,
-    RegistrarConfig, RegistrarError, RegistrarMetrics, RegistrationDriver, RegistryContractClient,
+    AwsDiscoveryConfig, AwsTargetGroupDiscovery, BoundlessConfig, DriverConfig, ProverClient,
+    ProvingConfig, RegistrarConfig, RegistrarError, RegistrarMetrics, RegistrationDriver,
+    RegistryContractClient,
 };
 use base_tx_manager::{BaseTxMetrics, SignerConfig, SimpleTxManager, TxManagerConfig};
 use clap::{Args, Parser, ValueEnum};
@@ -387,10 +388,10 @@ impl Cli {
         ));
 
         // ── 8. Build and run driver ──────────────────────────────────────────
+        let signer_client = ProverClient::new(config.prover_timeout);
         let driver_config = DriverConfig {
             registry_address: config.tee_prover_registry_address,
             poll_interval: config.poll_interval,
-            prover_timeout: config.prover_timeout,
             cancel: cancel.clone(),
         };
 
@@ -401,10 +402,16 @@ impl Cli {
         ready.store(true, Ordering::SeqCst);
 
         let cancel_guard = cancel.clone().drop_guard();
-        let driver_result =
-            RegistrationDriver::new(discovery, proof_provider, registry, tx_manager, driver_config)
-                .run()
-                .await;
+        let driver_result = RegistrationDriver::new(
+            discovery,
+            proof_provider,
+            registry,
+            tx_manager,
+            signer_client,
+            driver_config,
+        )
+        .run()
+        .await;
         drop(cancel_guard);
 
         // ── 9. Graceful shutdown (always runs, even on driver error) ─────────

--- a/crates/proof/tee/registrar/src/driver.rs
+++ b/crates/proof/tee/registrar/src/driver.rs
@@ -17,7 +17,7 @@ use tracing::{debug, info, warn};
 
 use crate::{
     InstanceDiscovery, ProverClient, ProverInstance, RegistrarError, RegistrarMetrics,
-    RegistryClient, Result, registry::ITEEProverRegistry,
+    RegistryClient, Result, SignerClient, registry::ITEEProverRegistry,
 };
 
 /// Runtime parameters for the [`RegistrationDriver`] that are not
@@ -28,8 +28,6 @@ pub struct DriverConfig {
     pub registry_address: Address,
     /// Interval between discovery and registration poll cycles.
     pub poll_interval: Duration,
-    /// Timeout for JSON-RPC calls to prover instances.
-    pub prover_timeout: Duration,
     /// Cancellation token for graceful shutdown.
     pub cancel: CancellationToken,
 }
@@ -37,28 +35,31 @@ pub struct DriverConfig {
 /// Core registration loop tying together discovery, attestation polling,
 /// ZK proof generation, and on-chain submission.
 ///
-/// Generic over the discovery, proof generation, registry, and transaction
-/// manager backends so each can be mocked independently in tests.
-pub struct RegistrationDriver<D, P, R, T> {
+/// Generic over the discovery, proof generation, registry, transaction
+/// manager, and signer client backends so each can be mocked independently
+/// in tests.
+pub struct RegistrationDriver<D, P, R, T, S> {
     discovery: D,
     proof_provider: P,
     registry: R,
     tx_manager: T,
+    signer_client: S,
     config: DriverConfig,
 }
 
-impl<D, P, R, T> fmt::Debug for RegistrationDriver<D, P, R, T> {
+impl<D, P, R, T, S> fmt::Debug for RegistrationDriver<D, P, R, T, S> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("RegistrationDriver").field("config", &self.config).finish_non_exhaustive()
     }
 }
 
-impl<D, P, R, T> RegistrationDriver<D, P, R, T>
+impl<D, P, R, T, S> RegistrationDriver<D, P, R, T, S>
 where
     D: InstanceDiscovery,
     P: AttestationProofProvider,
     R: RegistryClient,
     T: TxManager,
+    S: SignerClient,
 {
     /// Creates a new registration driver.
     pub const fn new(
@@ -66,9 +67,10 @@ where
         proof_provider: P,
         registry: R,
         tx_manager: T,
+        signer_client: S,
         config: DriverConfig,
     ) -> Self {
-        Self { discovery, proof_provider, registry, tx_manager, config }
+        Self { discovery, proof_provider, registry, tx_manager, signer_client, config }
     }
 
     /// Runs the registration loop until cancelled.
@@ -187,10 +189,8 @@ where
     /// Registration failures are logged but do not prevent the address from
     /// being returned.
     async fn process_instance(&self, instance: &ProverInstance) -> Result<Address> {
-        let client = ProverClient::new(&instance.endpoint, self.config.prover_timeout)?;
-
         // Fetch only the public key (cheap RPC) and derive the address.
-        let public_key = client.signer_public_key().await?;
+        let public_key = self.signer_client.signer_public_key(&instance.endpoint).await?;
         let signer_address = ProverClient::derive_address(&public_key)?;
 
         // Only attempt registration for instances that pass should_register().
@@ -208,7 +208,7 @@ where
 
         // Registration is best-effort: failures are logged but the address is
         // still returned to protect the signer from orphan deregistration.
-        if let Err(e) = self.try_register(&client, instance, signer_address).await {
+        if let Err(e) = self.try_register(instance, signer_address).await {
             warn!(
                 error = %e,
                 signer = %signer_address,
@@ -226,12 +226,7 @@ where
     /// This is the expensive path: checks on-chain status, fetches the NSM
     /// attestation document, generates a ZK proof, and submits a registration
     /// transaction.
-    async fn try_register(
-        &self,
-        client: &ProverClient,
-        instance: &ProverInstance,
-        signer_address: Address,
-    ) -> Result<()> {
+    async fn try_register(&self, instance: &ProverInstance, signer_address: Address) -> Result<()> {
         if self.registry.is_registered(signer_address).await? {
             debug!(signer = %signer_address, "already registered, skipping");
             return Ok(());
@@ -254,7 +249,10 @@ where
         // Bind a random nonce into the attestation to prevent replay attacks.
         let nonce: [u8; 32] = random();
         info!(nonce = %hex::encode(nonce), signer = %signer_address, "requesting attestation with nonce");
-        let attestation_bytes = client.signer_attestation(None, Some(nonce.to_vec())).await?;
+        let attestation_bytes = self
+            .signer_client
+            .signer_attestation(&instance.endpoint, None, Some(nonce.to_vec()))
+            .await?;
         let proof = self.proof_provider.generate_proof(&attestation_bytes).await?;
 
         // Check cancellation before submitting the transaction — avoid starting
@@ -381,7 +379,7 @@ where
 #[cfg(test)]
 mod tests {
     use std::{
-        collections::HashSet,
+        collections::{HashMap, HashSet},
         sync::{Arc, Mutex},
     };
 
@@ -390,12 +388,17 @@ mod tests {
     use alloy_rpc_types_eth::TransactionReceipt;
     use alloy_sol_types::SolCall;
     use async_trait::async_trait;
+    use base_proof_tee_nitro_attestation_prover::AttestationProof;
     use base_tx_manager::{SendHandle, TxCandidate, TxManager};
+    use hex_literal::hex;
+    use k256::ecdsa::SigningKey;
     use rstest::rstest;
     use tokio_util::sync::CancellationToken;
 
     use super::*;
-    use crate::{RegistryClient, Result, registry::ITEEProverRegistry};
+    use crate::{
+        InstanceHealthStatus, RegistryClient, Result, SignerClient, registry::ITEEProverRegistry,
+    };
 
     // ── Shared constants ────────────────────────────────────────────────
 
@@ -413,7 +416,25 @@ mod tests {
     /// Well-known Hardhat / Anvil account #0 address.
     const HARDHAT_ACCOUNT: Address = address!("f39Fd6e51aad88F6F4ce6aB8827279cffFb92266");
 
+    /// Well-known Hardhat / Anvil account #0 private key.
+    const HARDHAT_KEY_0: [u8; 32] =
+        hex!("ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80");
+
+    /// Hardhat / Anvil account #1 private key.
+    const HARDHAT_KEY_1: [u8; 32] =
+        hex!("59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d");
+
+    /// Hardhat / Anvil account #2 private key.
+    const HARDHAT_KEY_2: [u8; 32] =
+        hex!("5de4111afa1a4b94908f83103eb1f1706367c2e68ca870fc3fb9a804cdab365a");
+
     // ── Test helpers ─────────────────────────────────────────────────────
+
+    /// Derives the uncompressed 65-byte public key from a private key.
+    fn public_key_from_private(private_key: &[u8; 32]) -> Vec<u8> {
+        let signing_key = SigningKey::from_slice(private_key).unwrap();
+        signing_key.verifying_key().to_encoded_point(false).as_bytes().to_vec()
+    }
 
     /// Builds a minimal `TransactionReceipt` for mock tx managers.
     fn stub_receipt() -> TransactionReceipt {
@@ -441,20 +462,31 @@ mod tests {
         }
     }
 
-    // ── Mock implementations ────────────────────────────────────────────
-
-    /// Mock discovery that is unused by `deregister_orphans` tests.
-    #[derive(Debug)]
-    struct StubDiscovery;
-
-    #[async_trait]
-    impl InstanceDiscovery for StubDiscovery {
-        async fn discover_instances(&self) -> Result<Vec<ProverInstance>> {
-            Ok(vec![])
+    /// Builds a [`ProverInstance`] with the given endpoint and health status.
+    fn instance(endpoint: &str, status: InstanceHealthStatus) -> ProverInstance {
+        ProverInstance {
+            instance_id: format!("i-{endpoint}"),
+            endpoint: endpoint.to_string(),
+            health_status: status,
         }
     }
 
-    /// Mock proof provider that is unused by `deregister_orphans` tests.
+    // ── Mock implementations ────────────────────────────────────────────
+
+    /// Configurable mock discovery that returns a pre-set list of instances.
+    #[derive(Debug)]
+    struct MockDiscovery {
+        instances: Vec<ProverInstance>,
+    }
+
+    #[async_trait]
+    impl InstanceDiscovery for MockDiscovery {
+        async fn discover_instances(&self) -> Result<Vec<ProverInstance>> {
+            Ok(self.instances.clone())
+        }
+    }
+
+    /// Mock proof provider that returns a dummy proof.
     #[derive(Debug)]
     struct StubProofProvider;
 
@@ -463,23 +495,78 @@ mod tests {
         async fn generate_proof(
             &self,
             _attestation_bytes: &[u8],
-        ) -> base_proof_tee_nitro_attestation_prover::Result<
-            base_proof_tee_nitro_attestation_prover::AttestationProof,
-        > {
-            unimplemented!("not used in deregister_orphans tests")
+        ) -> base_proof_tee_nitro_attestation_prover::Result<AttestationProof> {
+            Ok(AttestationProof {
+                output: Bytes::from_static(b"stub-output"),
+                proof_bytes: Bytes::from_static(b"stub-proof"),
+            })
+        }
+    }
+
+    /// Mock signer client that returns pre-configured public keys per endpoint.
+    ///
+    /// If an endpoint is not in the map, the call returns an error (simulating
+    /// an unreachable instance).
+    #[derive(Debug)]
+    struct MockSignerClient {
+        /// Maps endpoint → uncompressed public key bytes.
+        keys: HashMap<String, Vec<u8>>,
+    }
+
+    impl MockSignerClient {
+        /// Creates a mock with the given endpoint-to-private-key mappings.
+        /// The public key is derived automatically from each private key.
+        fn from_keys(entries: &[(&str, &[u8; 32])]) -> Self {
+            let keys = entries
+                .iter()
+                .map(|(ep, pk)| ((*ep).to_string(), public_key_from_private(pk)))
+                .collect();
+            Self { keys }
+        }
+    }
+
+    #[async_trait]
+    impl SignerClient for MockSignerClient {
+        async fn signer_public_key(&self, endpoint: &str) -> Result<Vec<u8>> {
+            self.keys.get(endpoint).cloned().ok_or_else(|| RegistrarError::ProverClient {
+                instance: endpoint.to_string(),
+                source: "unreachable".into(),
+            })
+        }
+
+        async fn signer_attestation(
+            &self,
+            _endpoint: &str,
+            _user_data: Option<Vec<u8>>,
+            _nonce: Option<Vec<u8>>,
+        ) -> Result<Vec<u8>> {
+            Ok(b"mock-attestation".to_vec())
         }
     }
 
     /// Mock registry that returns a configured set of registered signers.
+    /// Optionally tracks `is_registered` queries.
     #[derive(Debug)]
     struct MockRegistry {
         signers: Vec<Address>,
+        /// When `true`, `is_registered` returns `true` for all queries.
+        all_registered: bool,
+    }
+
+    impl MockRegistry {
+        fn with_signers(signers: Vec<Address>) -> Self {
+            Self { signers, all_registered: false }
+        }
+
+        fn all_registered(signers: Vec<Address>) -> Self {
+            Self { signers, all_registered: true }
+        }
     }
 
     #[async_trait]
     impl RegistryClient for MockRegistry {
         async fn is_registered(&self, _signer: Address) -> Result<bool> {
-            Ok(false)
+            Ok(self.all_registered)
         }
 
         async fn get_registered_signers(&self) -> Result<Vec<Address>> {
@@ -510,7 +597,7 @@ mod tests {
         }
 
         async fn send_async(&self, _candidate: TxCandidate) -> SendHandle {
-            unimplemented!("not used in deregister_orphans tests")
+            unimplemented!("not used in tests")
         }
 
         fn sender_address(&self) -> Address {
@@ -518,18 +605,80 @@ mod tests {
         }
     }
 
+    /// Stub signer client that is unused by `deregister_orphans` tests.
+    #[derive(Debug)]
+    struct StubSignerClient;
+
+    #[async_trait]
+    impl SignerClient for StubSignerClient {
+        async fn signer_public_key(&self, _endpoint: &str) -> Result<Vec<u8>> {
+            unimplemented!("not used in deregister_orphans tests")
+        }
+
+        async fn signer_attestation(
+            &self,
+            _endpoint: &str,
+            _user_data: Option<Vec<u8>>,
+            _nonce: Option<Vec<u8>>,
+        ) -> Result<Vec<u8>> {
+            unimplemented!("not used in deregister_orphans tests")
+        }
+    }
+
+    // ── Driver constructors ─────────────────────────────────────────────
+
+    fn default_config(cancel: CancellationToken) -> DriverConfig {
+        DriverConfig {
+            registry_address: Address::repeat_byte(0x01),
+            poll_interval: Duration::from_secs(1),
+            cancel,
+        }
+    }
+
+    /// Builds a driver for `deregister_orphans` tests (no signer client needed).
     fn driver_with_shared_tx(
         registered_signers: Vec<Address>,
         tx: SharedTxManager,
-    ) -> RegistrationDriver<StubDiscovery, StubProofProvider, MockRegistry, SharedTxManager> {
-        let registry = MockRegistry { signers: registered_signers };
-        let config = DriverConfig {
-            registry_address: Address::repeat_byte(0x01),
-            poll_interval: Duration::from_secs(1),
-            prover_timeout: Duration::from_secs(1),
-            cancel: CancellationToken::new(),
-        };
-        RegistrationDriver::new(StubDiscovery, StubProofProvider, registry, tx, config)
+    ) -> RegistrationDriver<
+        MockDiscovery,
+        StubProofProvider,
+        MockRegistry,
+        SharedTxManager,
+        StubSignerClient,
+    > {
+        let registry = MockRegistry::with_signers(registered_signers);
+        RegistrationDriver::new(
+            MockDiscovery { instances: vec![] },
+            StubProofProvider,
+            registry,
+            tx,
+            StubSignerClient,
+            default_config(CancellationToken::new()),
+        )
+    }
+
+    /// Builds a fully-configured driver for `step()` / `process_instance()` tests.
+    fn step_driver(
+        instances: Vec<ProverInstance>,
+        signer_client: MockSignerClient,
+        registry: MockRegistry,
+        tx: SharedTxManager,
+        cancel: CancellationToken,
+    ) -> RegistrationDriver<
+        MockDiscovery,
+        StubProofProvider,
+        MockRegistry,
+        SharedTxManager,
+        MockSignerClient,
+    > {
+        RegistrationDriver::new(
+            MockDiscovery { instances },
+            StubProofProvider,
+            registry,
+            tx,
+            signer_client,
+            default_config(cancel),
+        )
     }
 
     // ── Calldata encoding tests ─────────────────────────────────────────
@@ -593,19 +742,209 @@ mod tests {
     async fn deregister_orphans_respects_cancellation() {
         let tx = SharedTxManager::new();
         let cancel = CancellationToken::new();
-        let registry = MockRegistry { signers: vec![Address::repeat_byte(0xAA)] };
-        let config = DriverConfig {
-            registry_address: Address::repeat_byte(0x01),
-            poll_interval: Duration::from_secs(1),
-            prover_timeout: Duration::from_secs(1),
-            cancel: cancel.clone(),
-        };
-        let driver =
-            RegistrationDriver::new(StubDiscovery, StubProofProvider, registry, tx.clone(), config);
+        let registry = MockRegistry::with_signers(vec![Address::repeat_byte(0xAA)]);
+        let driver = RegistrationDriver::new(
+            MockDiscovery { instances: vec![] },
+            StubProofProvider,
+            registry,
+            tx.clone(),
+            StubSignerClient,
+            default_config(cancel.clone()),
+        );
 
         cancel.cancel();
         driver.deregister_orphans(&HashSet::new()).await.unwrap();
 
         assert!(tx.sent_calldata().is_empty(), "no txs should be sent after cancellation");
+    }
+
+    // ── process_instance tests ──────────────────────────────────────────
+
+    #[rstest]
+    #[case::healthy_unregistered(InstanceHealthStatus::Healthy, false, 1)]
+    #[case::initial_unregistered(InstanceHealthStatus::Initial, false, 1)]
+    #[case::draining(InstanceHealthStatus::Draining, false, 0)]
+    #[case::unhealthy(InstanceHealthStatus::Unhealthy, false, 0)]
+    #[case::already_registered(InstanceHealthStatus::Healthy, true, 0)]
+    #[tokio::test]
+    async fn process_instance_returns_address_and_correct_tx_count(
+        #[case] status: InstanceHealthStatus,
+        #[case] all_registered: bool,
+        #[case] expected_txs: usize,
+    ) {
+        let ep = "10.0.0.1:8000";
+        let signer_client = MockSignerClient::from_keys(&[(ep, &HARDHAT_KEY_0)]);
+        let tx = SharedTxManager::new();
+        let registry = if all_registered {
+            MockRegistry::all_registered(vec![])
+        } else {
+            MockRegistry::with_signers(vec![])
+        };
+        let driver =
+            step_driver(vec![], signer_client, registry, tx.clone(), CancellationToken::new());
+
+        let inst = instance(ep, status);
+        let addr = driver.process_instance(&inst).await.unwrap();
+
+        assert_eq!(addr, HARDHAT_ACCOUNT);
+        assert_eq!(tx.sent_calldata().len(), expected_txs);
+    }
+
+    // ── step() tests ────────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn step_zero_instances_deregisters_all_onchain_signers() {
+        let orphan = Address::repeat_byte(0xAA);
+        let tx = SharedTxManager::new();
+        let driver = step_driver(
+            vec![], // no discovered instances
+            MockSignerClient::from_keys(&[]),
+            MockRegistry::with_signers(vec![orphan]),
+            tx.clone(),
+            CancellationToken::new(),
+        );
+
+        driver.step().await.unwrap();
+
+        // Zero instances → empty active set → all on-chain signers are orphans.
+        assert_eq!(tx.sent_calldata().len(), 1);
+    }
+
+    #[tokio::test]
+    async fn step_majority_unreachable_skips_orphan_deregistration() {
+        // 3 instances discovered, but only 1 is reachable via MockSignerClient.
+        // active_signers.len() (1) * 2 <= instances.len() (3) → skip deregistration.
+        let ep_reachable = "10.0.0.1:8000";
+        let ep_unreachable_1 = "10.0.0.2:8000";
+        let ep_unreachable_2 = "10.0.0.3:8000";
+
+        let instances = vec![
+            instance(ep_reachable, InstanceHealthStatus::Healthy),
+            instance(ep_unreachable_1, InstanceHealthStatus::Healthy),
+            instance(ep_unreachable_2, InstanceHealthStatus::Healthy),
+        ];
+
+        // Only ep_reachable has a key; the other two will fail signer_public_key.
+        let signer_client = MockSignerClient::from_keys(&[(ep_reachable, &HARDHAT_KEY_0)]);
+        let orphan = Address::repeat_byte(0xBB);
+        let tx = SharedTxManager::new();
+        let driver = step_driver(
+            instances,
+            signer_client,
+            MockRegistry::all_registered(vec![orphan]),
+            tx.clone(),
+            CancellationToken::new(),
+        );
+
+        driver.step().await.unwrap();
+
+        // 1 registration tx for the reachable instance (already registered → 0),
+        // but no deregistration tx because majority guard fires.
+        let sent = tx.sent_calldata();
+        assert!(sent.is_empty(), "expected no txs (majority guard), got {}", sent.len(),);
+    }
+
+    #[tokio::test]
+    async fn step_cancellation_before_loop_skips_orphan_cleanup() {
+        let ep1 = "10.0.0.1:8000";
+        let ep2 = "10.0.0.2:8000";
+
+        let instances = vec![
+            instance(ep1, InstanceHealthStatus::Healthy),
+            instance(ep2, InstanceHealthStatus::Healthy),
+        ];
+
+        let signer_client =
+            MockSignerClient::from_keys(&[(ep1, &HARDHAT_KEY_0), (ep2, &HARDHAT_KEY_1)]);
+
+        let orphan = Address::repeat_byte(0xCC);
+        let cancel = CancellationToken::new();
+        let tx = SharedTxManager::new();
+
+        // All signers already registered so we only care about deregistration.
+        let driver = step_driver(
+            instances,
+            signer_client,
+            MockRegistry::all_registered(vec![orphan]),
+            tx.clone(),
+            cancel.clone(),
+        );
+
+        // Cancel before running step — the loop breaks immediately at the
+        // first `is_cancelled()` check, so no instances are processed.
+        cancel.cancel();
+        driver.step().await.unwrap();
+
+        // Cancellation should prevent orphan deregistration entirely.
+        assert!(tx.sent_calldata().is_empty(), "no txs should be sent after cancellation",);
+    }
+
+    #[tokio::test]
+    async fn step_draining_instance_contributes_to_active_set() {
+        // A draining instance should contribute its address to active_signers
+        // so it isn't deregistered as an orphan, but should not be registered.
+        let ep = "10.0.0.1:8000";
+        let signer_client = MockSignerClient::from_keys(&[(ep, &HARDHAT_KEY_0)]);
+
+        let instances = vec![instance(ep, InstanceHealthStatus::Draining)];
+
+        let tx = SharedTxManager::new();
+        let driver = step_driver(
+            instances,
+            signer_client,
+            // The derived address for HARDHAT_KEY_0 is already on-chain,
+            // so it should NOT be deregistered.
+            MockRegistry::with_signers(vec![HARDHAT_ACCOUNT]),
+            tx.clone(),
+            CancellationToken::new(),
+        );
+
+        driver.step().await.unwrap();
+
+        // No registration (draining) and no deregistration (signer is active).
+        assert!(tx.sent_calldata().is_empty());
+    }
+
+    #[tokio::test]
+    async fn step_healthy_instances_register_and_deregister_orphans() {
+        let ep1 = "10.0.0.1:8000";
+        let ep2 = "10.0.0.2:8000";
+
+        let addr1 = ProverClient::derive_address(&public_key_from_private(&HARDHAT_KEY_0)).unwrap();
+        let addr2 = ProverClient::derive_address(&public_key_from_private(&HARDHAT_KEY_1)).unwrap();
+        let orphan =
+            ProverClient::derive_address(&public_key_from_private(&HARDHAT_KEY_2)).unwrap();
+
+        let instances = vec![
+            instance(ep1, InstanceHealthStatus::Healthy),
+            instance(ep2, InstanceHealthStatus::Healthy),
+        ];
+
+        let signer_client =
+            MockSignerClient::from_keys(&[(ep1, &HARDHAT_KEY_0), (ep2, &HARDHAT_KEY_1)]);
+
+        let tx = SharedTxManager::new();
+        let driver = step_driver(
+            instances,
+            signer_client,
+            // addr1 and addr2 are not yet registered; orphan is on-chain.
+            MockRegistry::with_signers(vec![orphan]),
+            tx.clone(),
+            CancellationToken::new(),
+        );
+
+        driver.step().await.unwrap();
+
+        let sent = tx.sent_calldata();
+        // 2 registration txs (addr1, addr2) + 1 deregistration tx (orphan).
+        assert_eq!(sent.len(), 3, "expected 2 registrations + 1 deregistration");
+
+        // Verify the deregistration calldata targets the orphan.
+        let deregister_expected =
+            ITEEProverRegistry::deregisterSignerCall { signer: orphan }.abi_encode();
+        assert!(
+            sent.iter().any(|s| s[..] == deregister_expected[..]),
+            "expected deregistration of orphan {orphan}, sent: {addr1}, {addr2}",
+        );
     }
 }

--- a/crates/proof/tee/registrar/src/driver.rs
+++ b/crates/proof/tee/registrar/src/driver.rs
@@ -394,7 +394,6 @@ mod tests {
     use k256::ecdsa::SigningKey;
     use rstest::rstest;
     use tokio_util::sync::CancellationToken;
-
     use url::Url;
 
     use super::*;
@@ -469,11 +468,7 @@ mod tests {
     /// Prepends `http://` to form a valid URL automatically.
     fn instance(host_port: &str, status: InstanceHealthStatus) -> ProverInstance {
         let endpoint = Url::parse(&format!("http://{host_port}")).unwrap();
-        ProverInstance {
-            instance_id: format!("i-{host_port}"),
-            endpoint,
-            health_status: status,
-        }
+        ProverInstance { instance_id: format!("i-{host_port}"), endpoint, health_status: status }
     }
 
     // ── Mock implementations ────────────────────────────────────────────

--- a/crates/proof/tee/registrar/src/lib.rs
+++ b/crates/proof/tee/registrar/src/lib.rs
@@ -23,7 +23,7 @@ mod registry;
 pub use registry::{RegistryClient, RegistryContractClient};
 
 mod traits;
-pub use traits::InstanceDiscovery;
+pub use traits::{InstanceDiscovery, SignerClient};
 
 mod types;
 pub use types::{InstanceHealthStatus, ProverInstance, RegisteredSigner};

--- a/crates/proof/tee/registrar/src/prover.rs
+++ b/crates/proof/tee/registrar/src/prover.rs
@@ -27,6 +27,13 @@ pub struct ProverClient {
     /// Timeout applied to all JSON-RPC requests.
     timeout: Duration,
     /// Cached HTTP clients keyed by endpoint URL.
+    ///
+    /// Note: this cache is append-only — entries are never evicted. With
+    /// ephemeral instances (e.g. ASG scale events assigning new IPs), stale
+    /// entries accumulate over the process lifetime. The fleet is small enough
+    /// that this is not a practical concern; if it ever becomes one, a
+    /// `retain_active` method could prune entries not in the current discovered
+    /// set after each poll cycle.
     clients: Mutex<HashMap<Url, HttpClient>>,
 }
 

--- a/crates/proof/tee/registrar/src/prover.rs
+++ b/crates/proof/tee/registrar/src/prover.rs
@@ -1,68 +1,69 @@
 //! JSON-RPC client for polling prover instance signer endpoints.
 
-use std::time::Duration;
+use std::{collections::HashMap, sync::Mutex, time::Duration};
 
 use alloy_primitives::{Address, keccak256};
+use async_trait::async_trait;
 use base_proof_primitives::EnclaveApiClient;
 use jsonrpsee::http_client::{HttpClient, HttpClientBuilder};
 use k256::elliptic_curve::sec1::ToEncodedPoint;
 use tracing::debug;
 
-use crate::{RegistrarError, Result};
+use crate::{RegistrarError, Result, SignerClient};
 
-/// JSON-RPC client for a single prover instance's signer endpoints.
+/// JSON-RPC client for prover instance signer endpoints.
 ///
-/// Wraps a `jsonrpsee` HTTP client configured for the prover's endpoint.
-/// Calls `enclave_signerPublicKey` and `enclave_signerAttestation` to obtain
-/// the signer's public key and Nitro attestation document, then derives the
-/// Ethereum address from the uncompressed public key.
-#[derive(Debug)]
+/// Implements [`SignerClient`] by making HTTP JSON-RPC calls to the prover's
+/// `enclave_signerPublicKey` and `enclave_signerAttestation` endpoints.
+///
+/// HTTP clients are cached per endpoint so that TCP connections are reused
+/// across poll cycles. The `timeout` is configured once at construction and
+/// applied to all requests.
+///
+/// Also provides [`derive_address`](Self::derive_address), a pure-crypto helper
+/// that derives an Ethereum address from a SEC1-encoded public key.
 pub struct ProverClient {
-    /// The raw endpoint string (host:port, without scheme).
-    endpoint: String,
-    /// The underlying `jsonrpsee` HTTP client.
-    inner: HttpClient,
+    /// Timeout applied to all JSON-RPC requests.
+    timeout: Duration,
+    /// Cached HTTP clients keyed by endpoint (`host:port`).
+    clients: Mutex<HashMap<String, HttpClient>>,
+}
+
+impl std::fmt::Debug for ProverClient {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ProverClient")
+            .field("timeout", &self.timeout)
+            .field("cached_clients", &self.clients.lock().map(|c| c.len()).unwrap_or(0))
+            .finish()
+    }
 }
 
 impl ProverClient {
-    /// Creates a new client for the prover at the given endpoint.
+    /// Creates a new client with the given request timeout.
+    pub fn new(timeout: Duration) -> Self {
+        Self { timeout, clients: Mutex::new(HashMap::new()) }
+    }
+
+    /// Returns a cached `jsonrpsee` HTTP client for `endpoint`, building one
+    /// on first access.
     ///
     /// `endpoint` is a `host:port` string (e.g. `"10.0.1.5:8000"`).
     /// An `http://` scheme is prepended automatically.
-    pub fn new(endpoint: &str, timeout: Duration) -> Result<Self> {
+    fn get_or_build_client(&self, endpoint: &str) -> Result<HttpClient> {
+        let mut cache = self.clients.lock().unwrap_or_else(|e| e.into_inner());
+        if let Some(client) = cache.get(endpoint) {
+            return Ok(client.clone());
+        }
         let url = format!("http://{endpoint}");
-        let inner =
-            HttpClientBuilder::default().request_timeout(timeout).build(&url).map_err(|e| {
-                RegistrarError::ProverClient { instance: endpoint.to_string(), source: Box::new(e) }
+        let client = HttpClientBuilder::default()
+            .request_timeout(self.timeout)
+            .build(&url)
+            .map_err(|e| RegistrarError::ProverClient {
+                instance: endpoint.to_string(),
+                source: Box::new(e),
             })?;
-        Ok(Self { endpoint: endpoint.to_string(), inner })
-    }
-
-    /// Fetches the signer's 65-byte uncompressed public key via `enclave_signerPublicKey`.
-    ///
-    /// Uses the generated [`EnclaveApiClient`] trait from `base-proof-primitives`,
-    /// which ensures the method name and return type (`Vec<u8>`) match the server's
-    /// `EnclaveApi` trait at compile time.
-    pub async fn signer_public_key(&self) -> Result<Vec<u8>> {
-        debug!(endpoint = %self.endpoint, "fetching signer public key");
-        self.inner.signer_public_key().await.map_err(|e| RegistrarError::ProverClient {
-            instance: self.endpoint.clone(),
-            source: Box::new(e),
-        })
-    }
-
-    /// Fetches the raw Nitro attestation document via `enclave_signerAttestation`.
-    ///
-    /// Optional `user_data` and `nonce` bind the attestation to a specific request.
-    pub async fn signer_attestation(
-        &self,
-        user_data: Option<Vec<u8>>,
-        nonce: Option<Vec<u8>>,
-    ) -> Result<Vec<u8>> {
-        debug!(endpoint = %self.endpoint, "fetching signer attestation");
-        self.inner.signer_attestation(user_data, nonce).await.map_err(|e| {
-            RegistrarError::ProverClient { instance: self.endpoint.clone(), source: Box::new(e) }
-        })
+        cache.insert(endpoint.to_string(), client.clone());
+        Ok(client)
     }
 
     /// Derives an Ethereum [`Address`] from a SEC1-encoded public key.
@@ -78,6 +79,31 @@ impl ProverClient {
         let uncompressed = key.to_encoded_point(false);
         let hash = keccak256(&uncompressed.as_bytes()[1..]);
         Ok(Address::from_slice(&hash[12..]))
+    }
+}
+
+#[async_trait]
+impl SignerClient for ProverClient {
+    async fn signer_public_key(&self, endpoint: &str) -> Result<Vec<u8>> {
+        debug!(endpoint = %endpoint, "fetching signer public key");
+        let client = self.get_or_build_client(endpoint)?;
+        client.signer_public_key().await.map_err(|e| RegistrarError::ProverClient {
+            instance: endpoint.to_string(),
+            source: Box::new(e),
+        })
+    }
+
+    async fn signer_attestation(
+        &self,
+        endpoint: &str,
+        user_data: Option<Vec<u8>>,
+        nonce: Option<Vec<u8>>,
+    ) -> Result<Vec<u8>> {
+        debug!(endpoint = %endpoint, "fetching signer attestation");
+        let client = self.get_or_build_client(endpoint)?;
+        client.signer_attestation(user_data, nonce).await.map_err(|e| {
+            RegistrarError::ProverClient { instance: endpoint.to_string(), source: Box::new(e) }
+        })
     }
 }
 

--- a/crates/proof/tee/registrar/src/traits.rs
+++ b/crates/proof/tee/registrar/src/traits.rs
@@ -14,3 +14,28 @@ pub trait InstanceDiscovery: Send + Sync {
     /// Return the current set of prover instances with their health status.
     async fn discover_instances(&self) -> Result<Vec<ProverInstance>>;
 }
+
+/// Fetches signer identity data from a prover instance endpoint.
+///
+/// The primary implementation is [`ProverClient`](crate::ProverClient), which
+/// makes JSON-RPC calls to the prover's `enclave_signerPublicKey` and
+/// `enclave_signerAttestation` endpoints. Test code can substitute a mock
+/// to avoid real HTTP calls.
+///
+/// The `endpoint` parameter is a `host:port` string (e.g. `"10.0.1.5:8000"`).
+#[async_trait]
+pub trait SignerClient: Send + Sync {
+    /// Fetches the signer's SEC1-encoded public key from the given endpoint.
+    async fn signer_public_key(&self, endpoint: &str) -> Result<Vec<u8>>;
+
+    /// Fetches the raw Nitro attestation document from the given endpoint.
+    ///
+    /// Optional `user_data` and `nonce` bind the attestation to a specific
+    /// request (e.g. a random nonce for replay protection).
+    async fn signer_attestation(
+        &self,
+        endpoint: &str,
+        user_data: Option<Vec<u8>>,
+        nonce: Option<Vec<u8>>,
+    ) -> Result<Vec<u8>>;
+}


### PR DESCRIPTION
## Summary

- Introduces a `SignerClient` trait (`signer_public_key`, `signer_attestation`) so `RegistrationDriver` no longer depends on the concrete `ProverClient`, enabling mock-based testing of the full registration and deregistration flow.
- Refactors `ProverClient` to cache HTTP clients per endpoint and implement the new trait; moves `prover_timeout` out of `DriverConfig` into `ProverClient` construction.
- Adds comprehensive `step()` and `process_instance()` tests covering healthy/draining/unhealthy instances, majority-guard logic, cancellation, and orphan deregistration.