### PR TITLE
chore(tests): rename cfg test modules to tests across crates

### DIFF
--- a/crates/batcher/comp/src/brotli.rs
+++ b/crates/batcher/comp/src/brotli.rs
@@ -136,7 +136,7 @@ impl ChannelCompressor for BrotliCompressor {
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
     use alloy_primitives::hex;
     use base_consensus_genesis::MAX_RLP_BYTES_PER_CHANNEL_FJORD;
     use base_protocol::decompress_brotli;

--- a/crates/consensus/derive/src/stages/batch/batch_provider.rs
+++ b/crates/consensus/derive/src/stages/batch/batch_provider.rs
@@ -175,7 +175,7 @@ where
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
     use alloc::{sync::Arc, vec};
 
     use base_consensus_genesis::{HardForkConfig, RollupConfig};

--- a/crates/consensus/derive/src/stages/batch/batch_stream.rs
+++ b/crates/consensus/derive/src/stages/batch/batch_stream.rs
@@ -245,7 +245,7 @@ where
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
     use alloc::vec;
 
     use alloy_consensus::{BlockBody, Header};

--- a/crates/consensus/derive/src/stages/batch/batch_validator.rs
+++ b/crates/consensus/derive/src/stages/batch/batch_validator.rs
@@ -326,7 +326,7 @@ where
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
     use alloc::{sync::Arc, vec, vec::Vec};
 
     use alloy_eips::{BlockNumHash, NumHash};

--- a/crates/consensus/derive/src/stages/channel/channel_assembler.rs
+++ b/crates/consensus/derive/src/stages/channel/channel_assembler.rs
@@ -213,7 +213,7 @@ where
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
     use alloc::{sync::Arc, vec};
 
     use base_consensus_genesis::{

--- a/crates/consensus/derive/src/stages/channel/channel_provider.rs
+++ b/crates/consensus/derive/src/stages/channel/channel_provider.rs
@@ -157,7 +157,7 @@ where
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
     use alloc::{sync::Arc, vec};
 
     use base_consensus_genesis::{HardForkConfig, RollupConfig};

--- a/crates/consensus/derive/src/stages/channel/channel_reader.rs
+++ b/crates/consensus/derive/src/stages/channel/channel_reader.rs
@@ -200,7 +200,7 @@ where
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
     use alloc::vec;
 
     use base_consensus_genesis::HardForkConfig;

--- a/crates/consensus/engine/src/state/core.rs
+++ b/crates/consensus/engine/src/state/core.rs
@@ -181,7 +181,7 @@ impl EngineState {
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
     #[cfg(feature = "metrics")]
     use base_protocol::BlockInfo;
     #[cfg(feature = "metrics")]

--- a/crates/consensus/engine/src/sync/mod.rs
+++ b/crates/consensus/engine/src/sync/mod.rs
@@ -118,7 +118,7 @@ pub async fn find_starting_forkchoice<EngineClient_: EngineClient>(
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
     use alloy_eips::BlockNumHash;
     use alloy_primitives::{B256, b256};
     use alloy_provider::Network;

--- a/crates/consensus/genesis/src/system/config.rs
+++ b/crates/consensus/genesis/src/system/config.rs
@@ -223,7 +223,7 @@ where
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
     use alloc::vec;
 
     use alloy_primitives::{B256, LogData, address, b256, hex};

--- a/crates/consensus/protocol/src/batch/bits.rs
+++ b/crates/consensus/protocol/src/batch/bits.rs
@@ -154,7 +154,7 @@ impl SpanBatchBits {
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
     use proptest::{collection::vec, prelude::any, proptest};
     use rstest::rstest;
 

--- a/crates/consensus/protocol/src/batch/prefix.rs
+++ b/crates/consensus/protocol/src/batch/prefix.rs
@@ -81,7 +81,7 @@ impl SpanBatchPrefix {
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
     use alloc::vec::Vec;
 
     use alloy_primitives::address;

--- a/crates/consensus/protocol/src/batch/raw.rs
+++ b/crates/consensus/protocol/src/batch/raw.rs
@@ -95,7 +95,7 @@ impl RawSpanBatch {
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
     use alloy_primitives::FixedBytes;
 
     use super::*;

--- a/crates/consensus/protocol/src/batch/reader.rs
+++ b/crates/consensus/protocol/src/batch/reader.rs
@@ -128,7 +128,7 @@ impl BatchReader {
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
     use base_consensus_genesis::{
         HardForkConfig, MAX_RLP_BYTES_PER_CHANNEL_BEDROCK, MAX_RLP_BYTES_PER_CHANNEL_FJORD,
     };

--- a/crates/consensus/protocol/src/batch/tx.rs
+++ b/crates/consensus/protocol/src/batch/tx.rs
@@ -40,7 +40,7 @@ impl BatchTransaction {
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
     use alloc::vec;
 
     use super::*;

--- a/crates/consensus/protocol/src/batch/tx_data/eip1559.rs
+++ b/crates/consensus/protocol/src/batch/tx_data/eip1559.rs
@@ -57,7 +57,7 @@ impl SpanBatchEip1559TransactionData {
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
     use alloc::vec::Vec;
 
     use alloy_rlp::{Decodable, Encodable};

--- a/crates/consensus/protocol/src/batch/tx_data/eip2930.rs
+++ b/crates/consensus/protocol/src/batch/tx_data/eip2930.rs
@@ -50,7 +50,7 @@ impl SpanBatchEip2930TransactionData {
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
     use alloc::vec::Vec;
 
     use alloy_rlp::{Decodable, Encodable};

--- a/crates/consensus/protocol/src/batch/tx_data/eip7702.rs
+++ b/crates/consensus/protocol/src/batch/tx_data/eip7702.rs
@@ -65,7 +65,7 @@ impl SpanBatchEip7702TransactionData {
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
     use alloc::{vec, vec::Vec};
 
     use alloy_rlp::{Decodable, Encodable};

--- a/crates/consensus/protocol/src/batch/tx_data/legacy.rs
+++ b/crates/consensus/protocol/src/batch/tx_data/legacy.rs
@@ -47,7 +47,7 @@ impl SpanBatchLegacyTransactionData {
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
     use alloc::vec::Vec;
 
     use alloy_rlp::{Decodable, Encodable as _};

--- a/crates/consensus/protocol/src/batch/type.rs
+++ b/crates/consensus/protocol/src/batch/type.rs
@@ -57,7 +57,7 @@ impl Decodable for BatchType {
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
     use alloc::vec::Vec;
 
     use super::*;

--- a/crates/consensus/protocol/src/brotli.rs
+++ b/crates/consensus/protocol/src/brotli.rs
@@ -74,7 +74,7 @@ pub fn decompress_brotli(
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
     use alloy_primitives::hex;
     use base_consensus_genesis::MAX_RLP_BYTES_PER_CHANNEL_FJORD;
 

--- a/crates/consensus/protocol/src/channel.rs
+++ b/crates/consensus/protocol/src/channel.rs
@@ -199,7 +199,7 @@ impl Channel {
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
     use alloc::{
         string::{String, ToString},
         vec,

--- a/crates/consensus/protocol/src/deposits.rs
+++ b/crates/consensus/protocol/src/deposits.rs
@@ -257,7 +257,7 @@ pub(crate) fn unmarshal_deposit_version0(
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
     use alloc::vec;
 
     use alloy_primitives::{LogData, U64, U128, address, b256, hex};

--- a/crates/consensus/protocol/src/frame.rs
+++ b/crates/consensus/protocol/src/frame.rs
@@ -265,7 +265,7 @@ impl Frame {
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
     use alloc::vec;
 
     use super::*;

--- a/crates/consensus/protocol/src/info/variant.rs
+++ b/crates/consensus/protocol/src/info/variant.rs
@@ -385,7 +385,7 @@ impl L1BlockInfoTx {
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
     use alloc::{string::ToString, vec::Vec};
 
     use alloy_primitives::{address, b256};

--- a/crates/consensus/protocol/src/output_root.rs
+++ b/crates/consensus/protocol/src/output_root.rs
@@ -77,7 +77,7 @@ impl OutputRoot {
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
     use alloy_primitives::{B256, Bytes, b256, bytes};
 
     use super::OutputRoot;

--- a/crates/consensus/service/src/actors/sequencer/origin_selector.rs
+++ b/crates/consensus/service/src/actors/sequencer/origin_selector.rs
@@ -260,7 +260,7 @@ impl L1OriginSelectorProvider for DelayedL1OriginSelectorProvider {
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
     use std::collections::HashSet;
 
     use alloy_eips::NumHash;

--- a/crates/execution/cli/src/lib.rs
+++ b/crates/execution/cli/src/lib.rs
@@ -121,7 +121,7 @@ where
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
     use base_execution_chainspec::{BASE_DEV, BASE_MAINNET};
     use base_node_core::args::RollupArgs;
     use clap::Parser;

--- a/crates/execution/consensus/src/validation/isthmus.rs
+++ b/crates/execution/consensus/src/validation/isthmus.rs
@@ -126,7 +126,7 @@ where
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
     use alloc::sync::Arc;
     use core::str::FromStr;
 

--- a/crates/execution/node/src/engine.rs
+++ b/crates/execution/node/src/engine.rs
@@ -303,7 +303,7 @@ pub fn validate_withdrawals_presence(
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
     use alloy_primitives::{Address, B64, B256, b64};
     use alloy_rpc_types_engine::PayloadAttributes;
     use base_alloy_chains::BaseChainConfig;

--- a/crates/execution/revm/src/api/default_ctx.rs
+++ b/crates/execution/revm/src/api/default_ctx.rs
@@ -27,7 +27,7 @@ impl DefaultOp for OpContext<EmptyDB> {
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
     use revm::{
         ExecuteEvm,
         inspector::{InspectEvm, NoOpInspector},

--- a/crates/execution/revm/src/transaction/error.rs
+++ b/crates/execution/revm/src/transaction/error.rs
@@ -86,7 +86,7 @@ impl<DBError> From<OpTransactionError> for EVMError<DBError, OpTransactionError>
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
     use std::string::ToString;
 
     use super::*;

--- a/crates/execution/rpc/src/eth/receipt.rs
+++ b/crates/execution/rpc/src/eth/receipt.rs
@@ -343,7 +343,7 @@ impl OpReceiptBuilder {
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
     use alloy_consensus::{Block, BlockBody, Eip658Value, TxEip7702, transaction::TransactionMeta};
     use alloy_eips::eip2718::Decodable2718;
     use alloy_primitives::{Address, Bytes, Signature, U256, hex};

--- a/crates/execution/trie/src/error.rs
+++ b/crates/execution/trie/src/error.rs
@@ -144,7 +144,7 @@ impl From<DatabaseError> for OpProofsStorageError {
 pub type OpProofsStorageResult<T> = Result<T, OpProofsStorageError>;
 
 #[cfg(test)]
-mod test {
+mod tests {
     use reth_execution_errors::BlockValidationError;
 
     use super::*;

--- a/crates/proof/fpvm-precompiles/src/precompiles/bls12_g1_add.rs
+++ b/crates/proof/fpvm-precompiles/src/precompiles/bls12_g1_add.rs
@@ -57,7 +57,7 @@ where
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
     use super::*;
     use crate::precompiles::test_utils::{execute_native_precompile, test_accelerated_precompile};
 

--- a/crates/proof/fpvm-precompiles/src/precompiles/bls12_g1_msm.rs
+++ b/crates/proof/fpvm-precompiles/src/precompiles/bls12_g1_msm.rs
@@ -93,7 +93,7 @@ where
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
     use alloy_primitives::hex;
 
     use super::*;

--- a/crates/proof/fpvm-precompiles/src/precompiles/bls12_g2_add.rs
+++ b/crates/proof/fpvm-precompiles/src/precompiles/bls12_g2_add.rs
@@ -57,7 +57,7 @@ where
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
     use super::*;
     use crate::precompiles::test_utils::{execute_native_precompile, test_accelerated_precompile};
 

--- a/crates/proof/fpvm-precompiles/src/precompiles/bls12_g2_msm.rs
+++ b/crates/proof/fpvm-precompiles/src/precompiles/bls12_g2_msm.rs
@@ -94,7 +94,7 @@ where
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
     use alloy_primitives::hex;
 
     use super::*;

--- a/crates/proof/fpvm-precompiles/src/precompiles/bls12_map_fp.rs
+++ b/crates/proof/fpvm-precompiles/src/precompiles/bls12_map_fp.rs
@@ -57,7 +57,7 @@ where
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
     use alloy_primitives::hex;
 
     use super::*;

--- a/crates/proof/fpvm-precompiles/src/precompiles/bls12_map_fp2.rs
+++ b/crates/proof/fpvm-precompiles/src/precompiles/bls12_map_fp2.rs
@@ -57,7 +57,7 @@ where
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
     use alloy_primitives::hex;
 
     use super::*;

--- a/crates/proof/fpvm-precompiles/src/precompiles/bls12_pair.rs
+++ b/crates/proof/fpvm-precompiles/src/precompiles/bls12_pair.rs
@@ -91,7 +91,7 @@ where
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
     use alloy_primitives::hex;
 
     use super::*;

--- a/crates/proof/fpvm-precompiles/src/precompiles/bn128_pair.rs
+++ b/crates/proof/fpvm-precompiles/src/precompiles/bn128_pair.rs
@@ -89,7 +89,7 @@ where
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
     use alloy_primitives::hex;
 
     use super::*;

--- a/crates/proof/fpvm-precompiles/src/precompiles/ecrecover.rs
+++ b/crates/proof/fpvm-precompiles/src/precompiles/ecrecover.rs
@@ -42,7 +42,7 @@ where
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
     use alloy_primitives::hex;
 
     use super::*;

--- a/crates/proof/fpvm-precompiles/src/precompiles/kzg_point_eval.rs
+++ b/crates/proof/fpvm-precompiles/src/precompiles/kzg_point_eval.rs
@@ -43,7 +43,7 @@ where
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
     use alloy_eips::eip4844::VERSIONED_HASH_VERSION_KZG;
     use alloy_primitives::hex;
     use sha2::{Digest, Sha256};

--- a/crates/proof/host/src/kv/disk.rs
+++ b/crates/proof/host/src/kv/disk.rs
@@ -70,7 +70,7 @@ impl TryFrom<DiskKeyValueStore> for MemoryKeyValueStore {
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
     use std::env::temp_dir;
 
     use proptest::{

--- a/crates/proof/mpt/src/list_walker.rs
+++ b/crates/proof/mpt/src/list_walker.rs
@@ -162,7 +162,7 @@ where
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
     use alloc::{collections::BTreeMap, string::String, vec::Vec};
 
     use alloy_consensus::{ReceiptEnvelope, TxEnvelope};

--- a/crates/proof/mpt/src/node.rs
+++ b/crates/proof/mpt/src/node.rs
@@ -618,7 +618,7 @@ impl Decodable for TrieNode {
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
     use alloc::{collections::BTreeMap, vec, vec::Vec};
 
     use alloy_primitives::{b256, bytes, hex, keccak256};

--- a/crates/proof/preimage/src/key.rs
+++ b/crates/proof/preimage/src/key.rs
@@ -147,7 +147,7 @@ impl core::fmt::Display for PreimageKey {
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
     use alloc::string::ToString;
 
     use super::*;

--- a/crates/proof/proof/src/l1/blob_provider.rs
+++ b/crates/proof/proof/src/l1/blob_provider.rs
@@ -159,7 +159,7 @@ fn generate_roots_of_unity() -> [Fr; FIELD_ELEMENTS_PER_BLOB as usize] {
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
     use alloy_eips::eip4844::{FIELD_ELEMENTS_PER_BLOB, env_settings::EnvKzgSettings};
     use ark_ff::{BigInteger, PrimeField};
     use c_kzg::{BYTES_PER_BLOB, Blob, Bytes32, Bytes48};


### PR DESCRIPTION
## Summary

- Unify test module naming across `crates/` by renaming `#[cfg(test)] mod test` to `#[cfg(test)] mod tests`.
- Keep test-module style consistent to reduce review noise and improve maintainability.
- This is a non-functional refactor with no runtime behavior changes.

## Scope

- Affects multiple Rust files under `crates/`.
- Only updates test module declarations (`mod test` -> `mod tests`).
- No changes to production logic, public APIs, or test case behavior.

## Why

- Aligns with the repository’s naming/style convention for test modules.
- Makes code search and future maintenance more consistent.
- Helps keep PR review focused on meaningful logic changes.

## Risk

- Low risk.
- Rename-only change inside `#[cfg(test)]` modules.

## Test Plan

- [x] Verified no remaining `#[cfg(test)] mod test` in `crates/`.
- [x] Verified no linter issues introduced.
- [ ] CI pipeline passes.