### PR TITLE
chore(docker): mirror proxyd base images

### DIFF
--- a/etc/docker/Dockerfile.proxyd
+++ b/etc/docker/Dockerfile.proxyd
@@ -1,11 +1,11 @@
-FROM golang:1.23-alpine3.20 AS builder
+FROM public.ecr.aws/docker/library/golang:1.23-alpine3.20 AS builder
 RUN apk add --no-cache make git gcc musl-dev
 WORKDIR /app
 RUN git clone --depth 1 --branch release-rb https://github.com/base/infra-routing.git .
 WORKDIR /app/proxyd
 RUN go build -o /bin/proxyd ./cmd/proxyd
 
-FROM alpine:3.20
+FROM public.ecr.aws/docker/library/alpine:3.20
 RUN apk add --no-cache ca-certificates curl
 COPY --from=builder /bin/proxyd /bin/proxyd
 ENTRYPOINT ["/bin/proxyd"]


### PR DESCRIPTION
Switch proxyd base images from Docker Hub to the public ECR mirror, matching the mirrored image strategy already used by adjacent Dockerfiles.