### PR TITLE
fix(consensus): Use Jsonrpsee Trait for ConductorClient

### DIFF
--- a/crates/consensus/rpc/src/jsonrpsee.rs
+++ b/crates/consensus/rpc/src/jsonrpsee.rs
@@ -224,6 +224,21 @@ pub trait ConductorApi {
     #[method(name = "leader")]
     async fn conductor_leader(&self) -> RpcResult<bool>;
 
+    /// Returns whether the conductor is active.
+    #[method(name = "active")]
+    async fn conductor_active(&self) -> RpcResult<bool>;
+
+    /// Commits an unsafe payload to the conductor.
+    #[method(name = "commitUnsafePayload")]
+    async fn conductor_commit_unsafe_payload(
+        &self,
+        payload: OpExecutionPayloadEnvelope,
+    ) -> RpcResult<()>;
+
+    /// Overrides the leader of the conductor.
+    #[method(name = "overrideLeader")]
+    async fn conductor_override_leader(&self) -> RpcResult<()>;
+
     /// Transfers Raft leadership to any available peer.
     #[method(name = "transferLeader")]
     async fn conductor_transfer_leader(&self) -> RpcResult<()>;

--- a/crates/consensus/service/src/actors/sequencer/conductor.rs
+++ b/crates/consensus/service/src/actors/sequencer/conductor.rs
@@ -1,9 +1,12 @@
 use std::fmt::Debug;
 
-use alloy_rpc_client::ReqwestClient;
-use alloy_transport::{RpcError, TransportErrorKind};
 use async_trait::async_trait;
 use base_alloy_rpc_types_engine::OpExecutionPayloadEnvelope;
+use base_consensus_rpc::ConductorApiClient;
+use jsonrpsee::{
+    core::ClientError,
+    http_client::{HttpClient, HttpClientBuilder},
+};
 use url::Url;
 
 /// Trait for interacting with the conductor service.
@@ -16,6 +19,9 @@ pub trait Conductor: Debug + Send + Sync {
     /// Check if this node is the conductor leader.
     async fn leader(&self) -> Result<bool, ConductorError>;
 
+    /// Check if the conductor is active.
+    async fn active(&self) -> Result<bool, ConductorError>;
+
     /// Commit an unsafe payload to the conductor.
     async fn commit_unsafe_payload(
         &self,
@@ -26,51 +32,47 @@ pub trait Conductor: Debug + Send + Sync {
     async fn override_leader(&self) -> Result<(), ConductorError>;
 }
 
-/// A client for communicating with the conductor service via RPC
+/// A client for communicating with the conductor service via RPC.
 #[derive(Debug, Clone)]
 pub struct ConductorClient {
-    /// The inner RPC provider
-    rpc: ReqwestClient,
+    /// The inner HTTP client.
+    inner: HttpClient,
 }
 
 #[async_trait]
 impl Conductor for ConductorClient {
-    /// Check if this node is the conductor leader.
     async fn leader(&self) -> Result<bool, ConductorError> {
-        self.rpc.request("conductor_leader", ()).await.map_err(Into::into)
+        Ok(self.inner.conductor_leader().await?)
     }
 
-    /// Commit an unsafe payload to the conductor.
+    async fn active(&self) -> Result<bool, ConductorError> {
+        Ok(self.inner.conductor_active().await?)
+    }
+
     async fn commit_unsafe_payload(
         &self,
         payload: &OpExecutionPayloadEnvelope,
     ) -> Result<(), ConductorError> {
-        self.rpc.request("conductor_commitUnsafePayload", [payload]).await.map_err(Into::into)
+        Ok(self.inner.conductor_commit_unsafe_payload(payload.clone()).await?)
     }
 
-    /// Override the leader of the conductor.
     async fn override_leader(&self) -> Result<(), ConductorError> {
-        self.rpc.request("conductor_overrideLeader", ()).await.map_err(Into::into)
+        Ok(self.inner.conductor_override_leader().await?)
     }
 }
 
 impl ConductorClient {
-    /// Creates a new conductor client using HTTP transport
-    pub fn new_http(url: Url) -> Self {
-        let rpc = ReqwestClient::new_http(url);
-        Self { rpc }
-    }
-
-    /// Check if the conductor is active.
-    pub async fn conductor_active(&self) -> Result<bool, ConductorError> {
-        self.rpc.request("conductor_active", ()).await.map_err(Into::into)
+    /// Creates a new conductor client using HTTP transport.
+    pub fn new_http(url: Url) -> Result<Self, ConductorError> {
+        let inner = HttpClientBuilder::default().build(url)?;
+        Ok(Self { inner })
     }
 }
 
-/// Error type for conductor operations
+/// Error type for conductor operations.
 #[derive(Debug, thiserror::Error)]
 pub enum ConductorError {
     /// An error occurred while making an RPC call to the conductor.
     #[error("RPC error: {0}")]
-    Rpc(#[from] RpcError<TransportErrorKind>),
+    Rpc(#[from] ClientError),
 }

--- a/crates/consensus/service/src/actors/sequencer/tests/actor_test.rs
+++ b/crates/consensus/service/src/actors/sequencer/tests/actor_test.rs
@@ -2,12 +2,12 @@ use std::sync::Arc;
 
 use alloy_primitives::B256;
 use alloy_rpc_types_engine::ExecutionPayloadV1;
-use alloy_transport::RpcError;
 use base_alloy_rpc_types_engine::{
     OpExecutionPayload, OpExecutionPayloadEnvelope, OpPayloadAttributes,
 };
 use base_consensus_derive::{BuilderError, PipelineErrorKind, test_utils::TestAttributesBuilder};
 use base_protocol::{BlockInfo, L2BlockInfo, OpAttributesWithParent};
+use jsonrpsee::core::ClientError;
 use rstest::rstest;
 
 #[cfg(test)]
@@ -43,7 +43,7 @@ fn dummy_envelope() -> OpExecutionPayloadEnvelope {
 }
 
 fn conductor_rpc_error() -> ConductorError {
-    ConductorError::Rpc(RpcError::local_usage_str("test conductor error"))
+    ConductorError::Rpc(ClientError::Custom("test conductor error".to_string()))
 }
 
 fn dummy_attributes_with_parent() -> OpAttributesWithParent {

--- a/crates/consensus/service/src/actors/sequencer/tests/admin_api_impl_test.rs
+++ b/crates/consensus/service/src/actors/sequencer/tests/admin_api_impl_test.rs
@@ -1,9 +1,9 @@
 use std::sync::Arc;
 
 use alloy_primitives::B256;
-use alloy_transport::RpcError;
 use base_consensus_rpc::SequencerAdminAPIError;
 use base_protocol::{BlockInfo, L2BlockInfo};
+use jsonrpsee::core::ClientError;
 use rstest::rstest;
 use tokio::sync::oneshot;
 
@@ -218,7 +218,7 @@ async fn test_start_sequencer_conductor_leader_rpc_error(#[values(true, false)] 
     conductor
         .expect_leader()
         .times(1)
-        .return_once(|| Err(ConductorError::Rpc(RpcError::local_usage_str("rpc error"))));
+        .return_once(|| Err(ConductorError::Rpc(ClientError::Custom("rpc error".to_string()))));
 
     let mut actor = test_actor();
     actor.conductor = Some(conductor);
@@ -515,7 +515,7 @@ async fn test_override_leader(
         } else if conductor_error {
             let mut conductor = MockConductor::new();
             conductor.expect_override_leader().times(1).return_once(move || {
-                Err(ConductorError::Rpc(RpcError::local_usage_str(conductor_error_string)))
+                Err(ConductorError::Rpc(ClientError::Custom(conductor_error_string.to_string())))
             });
             let mut actor = test_actor();
             actor.conductor = Some(conductor);

--- a/crates/consensus/service/src/service/node.rs
+++ b/crates/consensus/service/src/service/node.rs
@@ -405,8 +405,13 @@ impl RollupNode {
             L1OriginSelector::new(Arc::clone(&self.config), delayed_l1_provider);
 
         // Conditionally add conductor if configured
-        let conductor =
-            self.sequencer_config.conductor_rpc_url.clone().map(ConductorClient::new_http);
+        let conductor = self
+            .sequencer_config
+            .conductor_rpc_url
+            .clone()
+            .map(ConductorClient::new_http)
+            .transpose()
+            .map_err(|e| format!("Failed to create conductor client: {e}"))?;
 
         // Create the L1 Watcher actor
 


### PR DESCRIPTION
## Summary

Extends \`ConductorApi\` in \`base-consensus-rpc\` with the missing \`active\`, \`commitUnsafePayload\`, and \`overrideLeader\` methods so the generated \`ConductorApiClient\` covers all methods the conductor actually calls. Rewrites \`ConductorClient\` to use \`HttpClientBuilder\` and delegate to \`ConductorApiClient\`, replacing untyped string method dispatch with the strongly-typed trait pattern already used elsewhere in the workspace. Moves \`active()\` onto the \`Conductor\` trait so it is accessible via \`dyn Conductor\` and testable through the mock. Closes #1642.