### PR TITLE
style(registrar): move cfg(test) module to end of types.rs

### DIFF
--- a/crates/proof/tee/registrar/src/types.rs
+++ b/crates/proof/tee/registrar/src/types.rs
@@ -47,6 +47,15 @@ impl InstanceHealthStatus {
     }
 }
 
+/// A signer currently registered on-chain via `TEEProverRegistry`.
+#[derive(Debug, Clone)]
+pub struct RegisteredSigner {
+    /// The signer's Ethereum address.
+    pub address: Address,
+    /// The `keccak256(PCR0)` measurement hash the signer was registered under.
+    pub pcr0: B256,
+}
+
 #[cfg(test)]
 mod tests {
     use rstest::rstest;
@@ -73,13 +82,4 @@ mod tests {
     fn from_aws_state(#[case] input: &str, #[case] expected: InstanceHealthStatus) {
         assert_eq!(InstanceHealthStatus::from_aws_state(input), expected);
     }
-}
-
-/// A signer currently registered on-chain via `TEEProverRegistry`.
-#[derive(Debug, Clone)]
-pub struct RegisteredSigner {
-    /// The signer's Ethereum address.
-    pub address: Address,
-    /// The `keccak256(PCR0)` measurement hash the signer was registered under.
-    pub pcr0: B256,
 }


### PR DESCRIPTION
- Move `#[cfg(test)] mod tests` to the end of `crates/proof/tee/registrar/src/types.rs`.
- Align file structure with repository convention that test modules should be placed at the end of files.
- Keeps module layout consistent across crates.
- Reduces style-related review feedback and improves readability.