### PR TITLE
Fix latency calculations

### DIFF
--- a/crates/infra/load-tests/examples/sepolia-alpha.yaml
+++ b/crates/infra/load-tests/examples/sepolia-alpha.yaml
@@ -6,7 +6,7 @@ rpc: https://base-sepolia-alpha.cbhq.net
 
 sender_count: 10
 target_gps: 2100000
-duration: "10s"
+duration: "30s"
 seed: 12345
 
 # 0.01 ETH per account (covers gas for 10s at 2.1M GPS; drained after test)

--- a/crates/infra/load-tests/src/rpc/client.rs
+++ b/crates/infra/load-tests/src/rpc/client.rs
@@ -6,7 +6,7 @@ use alloy_provider::{
     Identity, Provider, ProviderBuilder, RootProvider,
     fillers::{ChainIdFiller, FillProvider, JoinFill, WalletFiller},
 };
-use alloy_rpc_types::{BlockId, BlockNumberOrTag};
+use alloy_rpc_types::BlockNumberOrTag;
 use base_alloy_network::Base;
 use base_alloy_rpc_types::OpTransactionReceipt;
 use tracing::instrument;
@@ -22,11 +22,8 @@ pub trait ReceiptProvider: Send + Sync {
     /// Fetches the current block number.
     fn get_block_number(&self) -> impl Future<Output = Result<u64>> + Send;
 
-    /// Fetches all transaction receipts for a given block.
-    fn get_block_receipts(
-        &self,
-        block_number: u64,
-    ) -> impl Future<Output = Result<Option<Vec<OpTransactionReceipt>>>> + Send;
+    /// Fetches transaction hashes from the pending block.
+    fn get_pending_block_tx_hashes(&self) -> impl Future<Output = Result<Vec<TxHash>>> + Send;
 
     /// Fetches the transaction receipt for a given hash.
     fn get_transaction_receipt(
@@ -79,10 +76,20 @@ impl RpcClient {
         self.provider.get_chain_id().await.map_err(|e| BaselineError::Rpc(e.to_string()))
     }
 
-    /// Fetches the balance of an address.
+    /// Fetches the balance of an address at the latest block.
     #[instrument(skip(self), fields(address = %address))]
     pub async fn get_balance(&self, address: Address) -> Result<U256> {
         self.provider.get_balance(address).await.map_err(|e| BaselineError::Rpc(e.to_string()))
+    }
+
+    /// Fetches the balance of an address including pending transactions.
+    #[instrument(skip(self), fields(address = %address))]
+    pub async fn get_pending_balance(&self, address: Address) -> Result<U256> {
+        self.provider
+            .get_balance(address)
+            .block_id(BlockNumberOrTag::Pending.into())
+            .await
+            .map_err(|e| BaselineError::Rpc(e.to_string()))
     }
 
     /// Fetches the nonce (transaction count) for an address.
@@ -118,16 +125,17 @@ impl RpcClient {
         self.provider.get_gas_price().await.map_err(|e| BaselineError::Rpc(e.to_string()))
     }
 
-    /// Fetches all transaction receipts for a given block number.
-    #[instrument(skip(self), fields(block_number = block_number))]
-    pub async fn get_block_receipts(
-        &self,
-        block_number: u64,
-    ) -> Result<Option<Vec<OpTransactionReceipt>>> {
-        self.provider
-            .get_block_receipts(BlockId::Number(BlockNumberOrTag::Number(block_number)))
+    /// Fetches transaction hashes from the pending block via `eth_getBlockByNumber("pending")`.
+    #[instrument(skip(self))]
+    pub async fn get_pending_block_tx_hashes(&self) -> Result<Vec<TxHash>> {
+        let block = self
+            .provider
+            .get_block_by_number(BlockNumberOrTag::Pending)
+            .hashes()
             .await
-            .map_err(|e| BaselineError::Rpc(e.to_string()))
+            .map_err(|e| BaselineError::Rpc(e.to_string()))?;
+
+        Ok(block.map(|b| b.transactions.hashes().collect()).unwrap_or_default())
     }
 }
 
@@ -142,11 +150,8 @@ impl ReceiptProvider for RpcClient {
         self.get_block_number().await
     }
 
-    async fn get_block_receipts(
-        &self,
-        block_number: u64,
-    ) -> Result<Option<Vec<OpTransactionReceipt>>> {
-        self.get_block_receipts(block_number).await
+    async fn get_pending_block_tx_hashes(&self) -> Result<Vec<TxHash>> {
+        self.get_pending_block_tx_hashes().await
     }
 
     async fn get_transaction_receipt(

--- a/crates/infra/load-tests/src/runner/confirmer.rs
+++ b/crates/infra/load-tests/src/runner/confirmer.rs
@@ -252,9 +252,8 @@ impl Confirmer {
             return;
         }
 
-        let futures = to_lookup.iter().map(|(tx_hash, _, _, _)| {
-            client.get_transaction_receipt(*tx_hash)
-        });
+        let futures =
+            to_lookup.iter().map(|(tx_hash, _, _, _)| client.get_transaction_receipt(*tx_hash));
         let results = join_all(futures).await;
 
         for ((tx_hash, from, submit_time, included_at), result) in

--- a/crates/infra/load-tests/src/runner/confirmer.rs
+++ b/crates/infra/load-tests/src/runner/confirmer.rs
@@ -10,7 +10,7 @@ use std::{
 use alloy_primitives::{Address, TxHash};
 use futures::future::join_all;
 use tokio::sync::mpsc;
-use tracing::{debug, trace, warn};
+use tracing::{debug, warn};
 
 use crate::{metrics::TransactionMetrics, rpc::ReceiptProvider};
 
@@ -18,9 +18,8 @@ use crate::{metrics::TransactionMetrics, rpc::ReceiptProvider};
 /// Sized for ~2 seconds of throughput at 1000 TPS.
 const PENDING_CHANNEL_BUFFER: usize = 2000;
 
-/// Initial block lookback window on first poll.
-/// Catches transactions confirmed between submission and confirmer startup.
-const INITIAL_BLOCK_LOOKBACK: u64 = 5;
+/// Maximum number of concurrent receipt lookups per poll cycle.
+const MAX_RECEIPT_LOOKUPS: usize = 50;
 
 /// Tracks pending transactions and collects confirmation metrics.
 #[derive(Debug)]
@@ -32,8 +31,7 @@ pub struct Confirmer {
     stop_flag: Arc<AtomicBool>,
     poll_interval: Duration,
     max_pending_age: Duration,
-    last_checked_block: u64,
-    max_straggler_lookups: usize,
+    straggler_age: Duration,
     pending_rx: Option<mpsc::Receiver<PendingTx>>,
     pending_tx: mpsc::Sender<PendingTx>,
 }
@@ -44,6 +42,9 @@ struct PendingTx {
     tx_hash: TxHash,
     from: Address,
     submit_time: Instant,
+    /// Set when the tx is first seen in a pending/latest block.
+    /// Used as the definitive latency endpoint.
+    included_at: Option<Instant>,
 }
 
 /// Handle for submitting transactions to the confirmer.
@@ -63,7 +64,7 @@ impl ConfirmerHandle {
         }
         self.total_in_flight.fetch_add(1, Ordering::SeqCst);
 
-        let pending = PendingTx { tx_hash, from, submit_time: Instant::now() };
+        let pending = PendingTx { tx_hash, from, submit_time: Instant::now(), included_at: None };
 
         if self.pending_tx.send(pending).await.is_err() {
             if let Some(counter) = self.in_flight_per_sender.get(&from) {
@@ -107,10 +108,9 @@ impl Confirmer {
             in_flight_per_sender: Arc::new(in_flight_map),
             total_in_flight: Arc::new(AtomicU64::new(0)),
             stop_flag,
-            poll_interval: Duration::from_millis(500),
+            poll_interval: Duration::from_millis(100),
             max_pending_age: Duration::from_secs(60),
-            last_checked_block: 0,
-            max_straggler_lookups: 10,
+            straggler_age: Duration::from_secs(10),
             pending_rx: Some(pending_rx),
             pending_tx,
         }
@@ -167,6 +167,10 @@ impl Confirmer {
     }
 
     async fn poll_confirmations(&mut self, client: &impl ReceiptProvider) {
+        if self.pending.is_empty() {
+            return;
+        }
+
         let now = Instant::now();
         let mut confirmed = Vec::new();
         let mut expired = Vec::new();
@@ -177,65 +181,13 @@ impl Confirmer {
             }
         }
 
-        let current_block = match client.get_block_number().await {
-            Ok(block) => block,
-            Err(e) => {
-                warn!(error = %e, "failed to get current block number");
-                return;
-            }
-        };
+        // Phase 1: Check pending block for tx inclusion.
+        // Records the inclusion timestamp but doesn't yet have gas metrics.
+        self.check_pending_block(client).await;
 
-        let start_block = if self.last_checked_block == 0 {
-            current_block.saturating_sub(INITIAL_BLOCK_LOOKBACK)
-        } else {
-            self.last_checked_block + 1
-        };
-
-        let mut found_in_blocks = HashSet::new();
-
-        for block_num in start_block..=current_block {
-            match client.get_block_receipts(block_num).await {
-                Ok(Some(receipts)) => {
-                    trace!(
-                        block = block_num,
-                        receipt_count = receipts.len(),
-                        "fetched block receipts"
-                    );
-                    for receipt in receipts {
-                        let tx_hash = receipt.inner.transaction_hash;
-                        if let Some(pending) = self.pending.get(&tx_hash) {
-                            found_in_blocks.insert(tx_hash);
-                            let latency = pending.submit_time.elapsed();
-                            let metrics = TransactionMetrics::new(
-                                tx_hash,
-                                latency,
-                                receipt.inner.gas_used,
-                                receipt.inner.effective_gas_price,
-                                receipt.inner.block_number.unwrap_or(block_num),
-                            );
-                            debug!(
-                                tx_hash = %tx_hash,
-                                latency_ms = latency.as_millis(),
-                                block = block_num,
-                                "confirmed via block receipts"
-                            );
-                            let _ = self.metrics_tx.send(metrics).await;
-                            confirmed.push((tx_hash, pending.from));
-                        }
-                    }
-                }
-                Ok(None) => {
-                    trace!(block = block_num, "no receipts for block");
-                }
-                Err(e) => {
-                    warn!(block = block_num, error = %e, "failed to get block receipts");
-                }
-            }
-        }
-
-        self.last_checked_block = current_block;
-
-        self.lookup_stragglers(client, &found_in_blocks, &mut confirmed).await;
+        // Phase 2: Fetch receipts for txns that have been included (have included_at set)
+        // or are old enough to be stragglers.
+        self.fetch_receipts(client, &mut confirmed).await;
 
         let confirmed_hashes: HashSet<TxHash> = confirmed.iter().map(|(hash, _)| *hash).collect();
 
@@ -245,7 +197,6 @@ impl Confirmer {
         }
 
         for tx_hash in expired {
-            // Skip if already processed as confirmed to avoid double-decrement
             if confirmed_hashes.contains(&tx_hash) {
                 continue;
             }
@@ -256,37 +207,67 @@ impl Confirmer {
         }
     }
 
-    /// Looks up individual receipts for old pending transactions not found in recent blocks.
-    ///
-    /// Block receipt fetching may miss transactions confirmed in blocks before the lookback
-    /// window. This fallback queries receipts directly for transactions pending longer than
-    /// 10 seconds, limited to `max_straggler_lookups` per poll to bound RPC load.
-    async fn lookup_stragglers(
+    /// Polls `eth_getBlock("pending")` and marks matching transactions with an inclusion timestamp.
+    async fn check_pending_block(&mut self, client: &impl ReceiptProvider) {
+        let tx_hashes = match client.get_pending_block_tx_hashes().await {
+            Ok(hashes) => hashes,
+            Err(e) => {
+                warn!(error = %e, "failed to get pending block");
+                return;
+            }
+        };
+
+        let now = Instant::now();
+        for tx_hash in &tx_hashes {
+            if let Some(pending) = self.pending.get_mut(tx_hash)
+                && pending.included_at.is_none()
+            {
+                pending.included_at = Some(now);
+                debug!(tx_hash = %tx_hash, "tx detected in pending block");
+            }
+        }
+    }
+
+    /// Fetches individual receipts for transactions that have been included in a block
+    /// or have been pending long enough to be stragglers.
+    async fn fetch_receipts(
         &self,
         client: &impl ReceiptProvider,
-        already_found: &HashSet<TxHash>,
         confirmed: &mut Vec<(TxHash, Address)>,
     ) {
         let now = Instant::now();
-        let old_pending: Vec<_> = self
+
+        let to_lookup: Vec<_> = self
             .pending
             .iter()
-            .filter(|(hash, pending)| {
-                !already_found.contains(*hash)
-                    && now.duration_since(pending.submit_time) > Duration::from_secs(10)
+            .filter(|(_, pending)| {
+                pending.included_at.is_some()
+                    || now.duration_since(pending.submit_time) > self.straggler_age
             })
-            .take(self.max_straggler_lookups)
-            .map(|(hash, pending)| (*hash, pending.from, pending.submit_time))
+            .take(MAX_RECEIPT_LOOKUPS)
+            .map(|(hash, pending)| (*hash, pending.from, pending.submit_time, pending.included_at))
             .collect();
 
-        let futures =
-            old_pending.iter().map(|(tx_hash, _, _)| client.get_transaction_receipt(*tx_hash));
+        if to_lookup.is_empty() {
+            return;
+        }
+
+        let futures = to_lookup.iter().map(|(tx_hash, _, _, _)| {
+            client.get_transaction_receipt(*tx_hash)
+        });
         let results = join_all(futures).await;
 
-        for ((tx_hash, from, submit_time), result) in old_pending.into_iter().zip(results) {
+        for ((tx_hash, from, submit_time, included_at), result) in
+            to_lookup.into_iter().zip(results)
+        {
             match result {
                 Ok(Some(receipt)) => {
-                    let latency = submit_time.elapsed();
+                    // Use inclusion timestamp if available for accurate latency,
+                    // otherwise fall back to time-since-submission.
+                    let latency = included_at
+                        .map(|t| t.duration_since(submit_time))
+                        .unwrap_or_else(|| submit_time.elapsed());
+
                     let metrics = TransactionMetrics::new(
                         tx_hash,
                         latency,
@@ -297,14 +278,14 @@ impl Confirmer {
                     debug!(
                         tx_hash = %tx_hash,
                         latency_ms = latency.as_millis(),
-                        "confirmed via straggler lookup"
+                        "tx confirmed"
                     );
                     let _ = self.metrics_tx.send(metrics).await;
                     confirmed.push((tx_hash, from));
                 }
                 Ok(None) => {}
                 Err(e) => {
-                    warn!(tx_hash = %tx_hash, error = %e, "straggler lookup failed");
+                    warn!(tx_hash = %tx_hash, error = %e, "receipt lookup failed");
                 }
             }
         }

--- a/crates/infra/load-tests/src/runner/load_runner.rs
+++ b/crates/infra/load-tests/src/runner/load_runner.rs
@@ -353,6 +353,18 @@ impl LoadRunner {
             }
         }
 
+        for (address, nonce_manager) in &self.nonce_managers {
+            match nonce_manager.next_nonce().await {
+                Ok(guard) => {
+                    guard.rollback();
+                    debug!(address = %address, "nonce manager pre-warmed");
+                }
+                Err(e) => {
+                    warn!(address = %address, error = %e, "failed to pre-warm nonce manager");
+                }
+            }
+        }
+
         const METRICS_CHANNEL_BUFFER: usize = 2000;
         let (metrics_tx, mut metrics_rx) =
             mpsc::channel::<TransactionMetrics>(METRICS_CHANNEL_BUFFER);
@@ -660,15 +672,16 @@ impl LoadRunner {
         let max_fee = gas_price.saturating_mul(2).min(self.config.max_gas_price);
         let max_priority_fee = (gas_price / 10).max(1);
         let drain_gas_limit = 21_000u128;
-        // Use gas_limit * max_fee + buffer to ensure the tx value + gas cost never exceeds balance.
-        // The buffer covers any rounding in the node's cost validation.
-        let drain_gas_cost = U256::from(drain_gas_limit * max_fee + 10_000);
+        // L1 data fee on OP Stack can be significant (0.0001-0.001 ETH depending on L1 gas prices).
+        // Use 0.001 ETH (1e15 wei) buffer to be safe. We may leave dust in accounts.
+        let l1_fee_buffer = 1_000_000_000_000_000u128;
+        let drain_gas_cost = U256::from(drain_gas_limit * max_fee + l1_fee_buffer);
 
         let mut pending_txs = Vec::new();
         let mut total_drained = U256::ZERO;
 
         for account in self.accounts.accounts() {
-            let balance = self.client.get_balance(account.address).await?;
+            let balance = self.client.get_pending_balance(account.address).await?;
             if balance <= drain_gas_cost {
                 debug!(
                     address = %account.address,

--- a/crates/infra/load-tests/src/workload/payloads/transfer.rs
+++ b/crates/infra/load-tests/src/workload/payloads/transfer.rs
@@ -28,10 +28,7 @@ impl TransferPayload {
 
 impl Default for TransferPayload {
     fn default() -> Self {
-        Self {
-            min_value: U256::from(1_000_000_000_000_000u64),
-            max_value: U256::from(10_000_000_000_000_000u64),
-        }
+        Self { min_value: U256::from(1_000u64), max_value: U256::from(100_000u64) }
     }
 }
 


### PR DESCRIPTION
Changes:
- Fix nonce race condition at startup by pre-warming nonce managers before load test begins.
- Fix drain failures by querying pending balance instead of latest balance, accounting for in-flight transactions.
- Increase L1 fee buffer from 50M to 1e15 wei to handle variable L1 data costs on OP Stack.
- Replaced eth_getBlockReceipts confirmer with one that polls eth_getBlock("pending") so latency is measured as the actual time between submission and pending-block inclusion rather than an arbitrary straggler timeout.