### PR TITLE
chore(builder): log clearMeteringInformation RPC

### DIFF
--- a/crates/builder/metering/src/ext.rs
+++ b/crates/builder/metering/src/ext.rs
@@ -7,6 +7,7 @@ use jsonrpsee::{
     core::{RpcResult, async_trait},
     proc_macros::rpc,
 };
+use tracing::info;
 
 /// RPC trait for metering-related operations.
 #[cfg_attr(not(test), rpc(server, namespace = "base"))]
@@ -59,6 +60,10 @@ impl BaseApiExtServer for MeteringStoreExt {
     }
 
     async fn clear_metering_information(&self) -> RpcResult<()> {
+        info!(
+            rpc_method = "base_clearMeteringInformation",
+            "Clearing builder metering information"
+        );
         self.store.clear();
         Ok(())
     }


### PR DESCRIPTION
## Summary
- add a structured info log when the builder receives `base_clearMeteringInformation`
- keep the change at the RPC boundary so we can tell when the method was invoked

## Testing
- cargo test -p base-builder-metering