### PR TITLE
fix(basectl): Follow Conductor Leader Flashblocks Endpoint

### DIFF
--- a/crates/infra/basectl/src/app/core.rs
+++ b/crates/infra/basectl/src/app/core.rs
@@ -50,6 +50,15 @@ impl App {
             self.resources.flash.poll();
             self.resources.toasts.poll();
             self.resources.conductor.poll();
+            // When a conductor cluster is configured, bridge the Raft leader's
+            // safe head into the DA tracker each tick.  The conductor poller
+            // already queries `op_sync_status` from every node's CL, so the
+            // leader's value is available here without an extra RPC.  This
+            // ensures the DA monitor advances even before sequencer-0's EL has
+            // P2P-synced blocks that were produced by a different leader.
+            if let Some(safe_head) = self.resources.conductor.leader_safe_l2_block() {
+                self.resources.da.apply_conductor_safe_head(safe_head);
+            }
             self.resources.poll_sys_config();
 
             let action = current_view.tick(&mut self.resources);

--- a/crates/infra/basectl/src/app/resources.rs
+++ b/crates/infra/basectl/src/app/resources.rs
@@ -6,7 +6,7 @@ use tokio::sync::{mpsc, watch};
 
 use crate::{
     commands::common::{DaTracker, FlashblockEntry, LoadingState},
-    config::ChainConfig,
+    config::{ChainConfig, ConductorNodeConfig},
     rpc::{
         BacklogFetchResult, BlockDaInfo, ConductorNodeStatus, L1BlockInfo, L1ConnectionMode,
         TimestampedFlashblock,
@@ -22,7 +22,15 @@ const MAX_RECENT_DA_FLASHBLOCK_IDS: usize = 512;
 pub(crate) struct ConductorState {
     /// Most recent status snapshot for each conductor node.
     pub nodes: Vec<ConductorNodeStatus>,
+    /// Original per-node configs, used to look up each node's flashblocks_ws URL.
+    nodes_config: Vec<ConductorNodeConfig>,
     rx: Option<mpsc::Receiver<Vec<ConductorNodeStatus>>>,
+    /// Sender half of the flashblocks URL watch channel.  When set, `poll`
+    /// derives the current leader's flashblocks endpoint from the polled
+    /// status and pushes a new value whenever the leader changes.  This
+    /// removes the need for a separate `run_conductor_leader_url_tracker`
+    /// task that would duplicate the `conductor_leader` RPC calls.
+    fb_url_tx: Option<watch::Sender<String>>,
 }
 
 impl ConductorState {
@@ -31,13 +39,28 @@ impl ConductorState {
         self.rx = Some(rx);
     }
 
-    /// Drains the latest status snapshot from the background poller.
+    /// Registers the node configs and URL sender used to track leader URL changes.
+    ///
+    /// After this is called, every `poll` will push the leader's `flashblocks_ws`
+    /// URL into `tx` whenever it changes — replacing the separate polling task.
+    pub(crate) fn set_url_sender(
+        &mut self,
+        nodes_config: Vec<ConductorNodeConfig>,
+        tx: watch::Sender<String>,
+    ) {
+        self.nodes_config = nodes_config;
+        self.fb_url_tx = Some(tx);
+    }
+
+    /// Drains the latest status snapshot from the background poller, then
+    /// pushes the leader's flashblocks URL into the watch channel if it changed.
     pub(crate) fn poll(&mut self) {
         let Some(ref mut rx) = self.rx else { return };
         // Drain all pending updates, keeping only the most recent snapshot.
         while let Ok(statuses) = rx.try_recv() {
             self.nodes = statuses;
         }
+        self.push_leader_url();
     }
 
     /// Returns the safe L2 block number reported by the current Raft leader, if known.
@@ -46,6 +69,26 @@ impl ConductorState {
             .iter()
             .find(|n| n.is_leader == Some(true))
             .and_then(|n| n.safe_l2_block)
+    }
+
+    /// Derives the leader's flashblocks URL from the current status snapshot
+    /// and sends it on the watch channel if it differs from the current value.
+    fn push_leader_url(&self) {
+        let Some(ref tx) = self.fb_url_tx else { return };
+        let leader = self.nodes.iter().find(|n| n.is_leader == Some(true));
+        let Some(leader) = leader else { return };
+        let Some(config) = self.nodes_config.iter().find(|c| c.name == leader.name) else {
+            return;
+        };
+        let Some(ref url) = config.flashblocks_ws else { return };
+        let url_str = url.to_string();
+        tx.send_if_modified(|current| {
+            if *current == url_str {
+                return false;
+            }
+            *current = url_str;
+            true
+        });
     }
 }
 

--- a/crates/infra/basectl/src/app/resources.rs
+++ b/crates/infra/basectl/src/app/resources.rs
@@ -2,7 +2,7 @@ use std::collections::{HashSet, VecDeque};
 
 use base_alloy_flashblocks::Flashblock;
 use base_consensus_genesis::SystemConfig;
-use tokio::sync::mpsc;
+use tokio::sync::{mpsc, watch};
 
 use crate::{
     commands::common::{DaTracker, FlashblockEntry, LoadingState},
@@ -38,6 +38,14 @@ impl ConductorState {
         while let Ok(statuses) = rx.try_recv() {
             self.nodes = statuses;
         }
+    }
+
+    /// Returns the safe L2 block number reported by the current Raft leader, if known.
+    pub(crate) fn leader_safe_l2_block(&self) -> Option<u64> {
+        self.nodes
+            .iter()
+            .find(|n| n.is_leader == Some(true))
+            .and_then(|n| n.safe_l2_block)
     }
 }
 
@@ -100,6 +108,7 @@ pub(crate) struct FlashState {
     pub paused: bool,
     last_flashblock: Option<(u64, u64)>,
     fb_rx: Option<mpsc::Receiver<TimestampedFlashblock>>,
+    url_rx: Option<watch::Receiver<String>>,
 }
 
 impl Resources {
@@ -185,6 +194,19 @@ impl DaState {
     /// Sets the channel for receiving L1 connection mode updates.
     pub(crate) fn set_l1_mode_channel(&mut self, rx: mpsc::Receiver<L1ConnectionMode>) {
         self.l1_mode_rx = Some(rx);
+    }
+
+    /// Advances the safe head from the conductor leader's sync status.
+    ///
+    /// Called each tick when a conductor cluster is configured so the DA
+    /// tracker does not have to wait for sequencer-0's EL to P2P-sync
+    /// new blocks produced by whichever sequencer currently holds leadership.
+    pub(crate) fn apply_conductor_safe_head(&mut self, safe_block: u64) {
+        if self.loaded {
+            self.tracker.update_safe_head(safe_block);
+        } else {
+            self.buffered_safe_heads.push(safe_block);
+        }
     }
 
     /// Drains all pending messages from background channels and updates state.
@@ -365,6 +387,7 @@ impl FlashState {
             paused: false,
             last_flashblock: None,
             fb_rx: None,
+            url_rx: None,
         }
     }
 
@@ -373,8 +396,31 @@ impl FlashState {
         self.fb_rx = Some(fb_rx);
     }
 
+    /// Sets the watch receiver used to detect flashblocks endpoint changes.
+    ///
+    /// When the watched URL changes (i.e. a new Raft leader is elected and
+    /// `run_conductor_leader_url_tracker` pushes its endpoint), `poll` resets
+    /// `last_flashblock` so the first flashblock from the new leader is not
+    /// compared against the previous leader's index, preventing spurious
+    /// missed-flashblock counts.
+    pub(crate) fn set_url_rx(&mut self, rx: watch::Receiver<String>) {
+        self.url_rx = Some(rx);
+    }
+
     /// Drains pending flashblocks from the channel unless paused.
     pub(crate) fn poll(&mut self) {
+        // Reset missed-flashblock tracking when the flashblocks endpoint changes
+        // (i.e. leadership transferred to a different sequencer).  Each clone of
+        // the watch receiver tracks its own "seen" state independently, so this
+        // fires exactly once per URL change regardless of when the WS tasks
+        // consume their own copies of the notification.
+        if let Some(ref mut rx) = self.url_rx
+            && rx.has_changed().unwrap_or(false)
+        {
+            let _ = rx.borrow_and_update();
+            self.last_flashblock = None;
+        }
+
         if self.paused {
             return;
         }

--- a/crates/infra/basectl/src/app/resources.rs
+++ b/crates/infra/basectl/src/app/resources.rs
@@ -22,7 +22,7 @@ const MAX_RECENT_DA_FLASHBLOCK_IDS: usize = 512;
 pub(crate) struct ConductorState {
     /// Most recent status snapshot for each conductor node.
     pub nodes: Vec<ConductorNodeStatus>,
-    /// Original per-node configs, used to look up each node's flashblocks_ws URL.
+    /// Original per-node configs, used to look up each node's `flashblocks_ws` URL.
     nodes_config: Vec<ConductorNodeConfig>,
     rx: Option<mpsc::Receiver<Vec<ConductorNodeStatus>>>,
     /// Sender half of the flashblocks URL watch channel.  When set, `poll`
@@ -65,10 +65,7 @@ impl ConductorState {
 
     /// Returns the safe L2 block number reported by the current Raft leader, if known.
     pub(crate) fn leader_safe_l2_block(&self) -> Option<u64> {
-        self.nodes
-            .iter()
-            .find(|n| n.is_leader == Some(true))
-            .and_then(|n| n.safe_l2_block)
+        self.nodes.iter().find(|n| n.is_leader == Some(true)).and_then(|n| n.safe_l2_block)
     }
 
     /// Derives the leader's flashblocks URL from the current status snapshot

--- a/crates/infra/basectl/src/app/runner.rs
+++ b/crates/infra/basectl/src/app/runner.rs
@@ -12,8 +12,8 @@ use crate::{
     rpc::{
         BacklogFetchResult, BlockDaInfo, ConductorNodeStatus, L1BlockInfo, L1ConnectionMode,
         TimestampedFlashblock, fetch_initial_backlog_with_progress, run_block_fetcher,
-        run_conductor_leader_url_tracker, run_conductor_poller, run_flashblock_ws,
-        run_flashblock_ws_timestamped, run_l1_blob_watcher, run_safe_head_poller,
+        run_conductor_poller, run_flashblock_ws, run_flashblock_ws_timestamped, run_l1_blob_watcher,
+        run_safe_head_poller,
     },
     tui::Toast,
 };
@@ -114,9 +114,11 @@ fn start_background_services(config: &ChainConfig, resources: &mut Resources) {
         resources.conductor.set_channel(conductor_rx);
         tokio::spawn(run_conductor_poller(conductor_nodes.clone(), conductor_tx));
 
-        // Spawn the leader URL tracker only when nodes carry flashblocks endpoints.
+        // Wire the URL sender into ConductorState so that the existing
+        // conductor poll (200 ms) drives flashblocks URL changes instead of
+        // a separate task that would duplicate the conductor_leader RPCs.
         if conductor_nodes.iter().any(|n| n.flashblocks_ws.is_some()) {
-            tokio::spawn(run_conductor_leader_url_tracker(conductor_nodes, fb_url_tx));
+            resources.conductor.set_url_sender(conductor_nodes, fb_url_tx);
         }
     }
 }

--- a/crates/infra/basectl/src/app/runner.rs
+++ b/crates/infra/basectl/src/app/runner.rs
@@ -49,6 +49,19 @@ fn start_background_services(config: &ChainConfig, resources: &mut Resources) {
     let (toast_tx, toast_rx) = mpsc::channel::<Toast>(50);
 
     resources.flash.set_channel(fb_rx);
+
+    // Create a watch channel seeded with the configured flashblocks URL.
+    // If a conductor cluster is configured and all nodes carry flashblocks_ws
+    // endpoints, `run_conductor_leader_url_tracker` will push the current
+    // leader's URL into this channel so both subscriber tasks switch over
+    // immediately on every leadership change.
+    let (fb_url_tx, fb_url_rx) = watch::channel(config.flashblocks_ws.to_string());
+
+    // Give FlashState a clone so it can detect URL changes and reset its
+    // last-flashblock tracking state (avoids spurious missed-flashblock counts
+    // when the first flashblock from the new leader arrives mid-block).
+    resources.flash.set_url_rx(fb_url_rx.clone());
+
     resources.da.set_channels(
         da_fb_rx,
         sync_rx,
@@ -58,13 +71,6 @@ fn start_background_services(config: &ChainConfig, resources: &mut Resources) {
         l1_block_rx,
     );
     resources.toasts.set_channel(toast_rx);
-
-    // Create a watch channel seeded with the configured flashblocks URL.
-    // If a conductor cluster is configured and all nodes carry flashblocks_ws
-    // endpoints, `run_conductor_leader_url_tracker` will push the current
-    // leader's URL into this channel so both subscriber tasks switch over
-    // immediately on every leadership change.
-    let (fb_url_tx, fb_url_rx) = watch::channel(config.flashblocks_ws.to_string());
 
     tokio::spawn(run_flashblock_ws_timestamped(fb_url_rx.clone(), fb_tx, toast_tx.clone()));
     tokio::spawn(run_flashblock_ws(fb_url_rx, da_fb_tx, toast_tx.clone()));

--- a/crates/infra/basectl/src/app/runner.rs
+++ b/crates/infra/basectl/src/app/runner.rs
@@ -12,8 +12,8 @@ use crate::{
     rpc::{
         BacklogFetchResult, BlockDaInfo, ConductorNodeStatus, L1BlockInfo, L1ConnectionMode,
         TimestampedFlashblock, fetch_initial_backlog_with_progress, run_block_fetcher,
-        run_conductor_poller, run_flashblock_ws, run_flashblock_ws_timestamped, run_l1_blob_watcher,
-        run_safe_head_poller,
+        run_conductor_poller, run_flashblock_ws, run_flashblock_ws_timestamped,
+        run_l1_blob_watcher, run_safe_head_poller,
     },
     tui::Toast,
 };

--- a/crates/infra/basectl/src/app/runner.rs
+++ b/crates/infra/basectl/src/app/runner.rs
@@ -3,7 +3,7 @@ use std::io::Write;
 use anyhow::Result;
 use base_alloy_flashblocks::Flashblock;
 use base_consensus_genesis::SystemConfig;
-use tokio::sync::mpsc;
+use tokio::sync::{mpsc, watch};
 
 use super::{App, Resources, ViewId, views::create_view};
 use crate::{
@@ -12,8 +12,8 @@ use crate::{
     rpc::{
         BacklogFetchResult, BlockDaInfo, ConductorNodeStatus, L1BlockInfo, L1ConnectionMode,
         TimestampedFlashblock, fetch_initial_backlog_with_progress, run_block_fetcher,
-        run_conductor_poller, run_flashblock_ws, run_flashblock_ws_timestamped,
-        run_l1_blob_watcher, run_safe_head_poller,
+        run_conductor_leader_url_tracker, run_conductor_poller, run_flashblock_ws,
+        run_flashblock_ws_timestamped, run_l1_blob_watcher, run_safe_head_poller,
     },
     tui::Toast,
 };
@@ -59,13 +59,15 @@ fn start_background_services(config: &ChainConfig, resources: &mut Resources) {
     );
     resources.toasts.set_channel(toast_rx);
 
-    tokio::spawn(run_flashblock_ws_timestamped(
-        config.flashblocks_ws.to_string(),
-        fb_tx,
-        toast_tx.clone(),
-    ));
+    // Create a watch channel seeded with the configured flashblocks URL.
+    // If a conductor cluster is configured and all nodes carry flashblocks_ws
+    // endpoints, `run_conductor_leader_url_tracker` will push the current
+    // leader's URL into this channel so both subscriber tasks switch over
+    // immediately on every leadership change.
+    let (fb_url_tx, fb_url_rx) = watch::channel(config.flashblocks_ws.to_string());
 
-    tokio::spawn(run_flashblock_ws(config.flashblocks_ws.to_string(), da_fb_tx, toast_tx.clone()));
+    tokio::spawn(run_flashblock_ws_timestamped(fb_url_rx.clone(), fb_tx, toast_tx.clone()));
+    tokio::spawn(run_flashblock_ws(fb_url_rx, da_fb_tx, toast_tx.clone()));
 
     tokio::spawn(run_block_fetcher(
         config.rpc.to_string(),
@@ -104,7 +106,12 @@ fn start_background_services(config: &ChainConfig, resources: &mut Resources) {
     if let Some(conductor_nodes) = config.conductors.clone() {
         let (conductor_tx, conductor_rx) = mpsc::channel::<Vec<ConductorNodeStatus>>(4);
         resources.conductor.set_channel(conductor_rx);
-        tokio::spawn(run_conductor_poller(conductor_nodes, conductor_tx));
+        tokio::spawn(run_conductor_poller(conductor_nodes.clone(), conductor_tx));
+
+        // Spawn the leader URL tracker only when nodes carry flashblocks endpoints.
+        if conductor_nodes.iter().any(|n| n.flashblocks_ws.is_some()) {
+            tokio::spawn(run_conductor_leader_url_tracker(conductor_nodes, fb_url_tx));
+        }
     }
 }
 
@@ -113,7 +120,8 @@ pub async fn run_flashblocks_json(config: ChainConfig) -> Result<()> {
     let (tx, mut rx) = mpsc::channel::<Flashblock>(100);
     let (toast_tx, mut toast_rx) = mpsc::channel::<Toast>(50);
 
-    tokio::spawn(run_flashblock_ws(config.flashblocks_ws.to_string(), tx, toast_tx));
+    let (_, url_rx) = watch::channel(config.flashblocks_ws.to_string());
+    tokio::spawn(run_flashblock_ws(url_rx, tx, toast_tx));
 
     tokio::spawn(async move {
         while let Some(toast) = toast_rx.recv().await {

--- a/crates/infra/basectl/src/config.rs
+++ b/crates/infra/basectl/src/config.rs
@@ -21,6 +21,13 @@ pub struct ConductorNodeConfig {
     pub server_id: String,
     /// Raft peer address (`host:port`) used when targeting this node for leadership transfer.
     pub raft_addr: String,
+    /// Flashblocks WebSocket endpoint for this sequencer's builder node.
+    ///
+    /// When set, the command center will automatically reconnect its flashblocks
+    /// stream to the current Raft leader's endpoint whenever leadership changes,
+    /// rather than staying connected to the original leader's now-idle socket.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub flashblocks_ws: Option<Url>,
 }
 
 /// Monitoring configuration for a chain watched by basectl.
@@ -161,6 +168,7 @@ impl ChainConfig {
                     cl_rpc: Url::parse("http://localhost:7549").unwrap(),
                     server_id: "sequencer-0".to_string(),
                     raft_addr: "op-conductor-0:5050".to_string(),
+                    flashblocks_ws: Some(Url::parse("ws://localhost:7111").unwrap()),
                 },
                 ConductorNodeConfig {
                     name: "op-conductor-1".to_string(),
@@ -168,6 +176,7 @@ impl ChainConfig {
                     cl_rpc: Url::parse("http://localhost:10549").unwrap(),
                     server_id: "sequencer-1".to_string(),
                     raft_addr: "op-conductor-1:5051".to_string(),
+                    flashblocks_ws: Some(Url::parse("ws://localhost:10111").unwrap()),
                 },
                 ConductorNodeConfig {
                     name: "op-conductor-2".to_string(),
@@ -175,6 +184,7 @@ impl ChainConfig {
                     cl_rpc: Url::parse("http://localhost:11549").unwrap(),
                     server_id: "sequencer-2".to_string(),
                     raft_addr: "op-conductor-2:5052".to_string(),
+                    flashblocks_ws: Some(Url::parse("ws://localhost:11111").unwrap()),
                 },
             ]),
         }

--- a/crates/infra/basectl/src/rpc.rs
+++ b/crates/infra/basectl/src/rpc.rs
@@ -12,7 +12,7 @@ use base_alloy_network::Base;
 use base_consensus_rpc::{ConductorApiClient, OpP2PApiClient, RollupNodeApiClient};
 use futures::{StreamExt, stream};
 use jsonrpsee::http_client::HttpClientBuilder;
-use tokio::sync::mpsc;
+use tokio::sync::{mpsc, watch};
 use tokio_tungstenite::connect_async;
 use tracing::warn;
 
@@ -83,8 +83,17 @@ pub(crate) async fn run_safe_head_poller(
     }
 }
 
+/// Connects to the URL in `url_rx`, forwarding decoded flashblocks to `tx`.
+///
+/// Reconnects automatically on disconnection or error (exponential backoff).
+/// If `url_rx` emits a new value while connected, the current connection is
+/// dropped immediately and a fresh connection is opened to the new URL with
+/// no backoff delay.  This is the mechanism used to follow conductor leader
+/// changes: when a new Raft leader is elected, the caller pushes the new
+/// leader's flashblocks endpoint into the watch channel and the loop here
+/// switches over without waiting for the old socket to time out.
 async fn run_flashblock_ws_inner<T: Send + 'static>(
-    url: &str,
+    url_rx: &mut watch::Receiver<String>,
     tx: &mpsc::Sender<T>,
     toast_tx: &mpsc::Sender<Toast>,
     map_fb: impl Fn(Flashblock) -> T,
@@ -92,34 +101,52 @@ async fn run_flashblock_ws_inner<T: Send + 'static>(
     let mut delay = WS_RECONNECT_INITIAL_DELAY;
 
     loop {
-        match connect_async(url).await {
+        let url = url_rx.borrow_and_update().clone();
+
+        match connect_async(url.as_str()).await {
             Ok((ws_stream, _)) => {
                 delay = WS_RECONNECT_INITIAL_DELAY;
                 let (_, mut read) = ws_stream.split();
+                let mut leader_changed = false;
 
-                while let Some(msg) = read.next().await {
-                    let msg = match msg {
-                        Ok(m) => m,
-                        Err(e) => {
-                            warn!(error = %e, "Flashblock WebSocket connection error");
-                            let _ = toast_tx.try_send(Toast::warning("WebSocket disconnected"));
+                loop {
+                    tokio::select! {
+                        msg_opt = read.next() => {
+                            let msg = match msg_opt {
+                                Some(Ok(m)) => m,
+                                Some(Err(e)) => {
+                                    warn!(error = %e, "Flashblock WebSocket connection error");
+                                    let _ = toast_tx.try_send(Toast::warning("WebSocket disconnected"));
+                                    break;
+                                }
+                                None => break,
+                            };
+                            if !msg.is_binary() && !msg.is_text() {
+                                continue;
+                            }
+                            let fb = match Flashblock::try_decode_message(msg.into_data()) {
+                                Ok(fb) => fb,
+                                Err(_) => continue,
+                            };
+                            if tx.send(map_fb(fb)).await.is_err() {
+                                return;
+                            }
+                        }
+                        Ok(()) = url_rx.changed() => {
+                            leader_changed = true;
                             break;
                         }
-                    };
-                    if !msg.is_binary() && !msg.is_text() {
-                        continue;
                     }
-                    let fb = match Flashblock::try_decode_message(msg.into_data()) {
-                        Ok(fb) => fb,
-                        Err(_) => continue,
-                    };
-                    if tx.send(map_fb(fb)).await.is_err() {
-                        return;
-                    }
+                }
+
+                if leader_changed {
+                    // Skip backoff: reconnect immediately to the new leader.
+                    delay = WS_RECONNECT_INITIAL_DELAY;
+                    continue;
                 }
             }
             Err(e) => {
-                warn!(error = %e, "Failed to connect to flashblock WebSocket");
+                warn!(error = %e, url = %url, "Failed to connect to flashblock WebSocket");
                 let _ = toast_tx.try_send(Toast::warning(format!(
                     "WebSocket connection failed, retrying in {}s",
                     delay.as_secs()
@@ -127,18 +154,25 @@ async fn run_flashblock_ws_inner<T: Send + 'static>(
             }
         }
 
-        tokio::time::sleep(delay).await;
-        delay = (delay * 2).min(WS_RECONNECT_MAX_DELAY);
+        // Exponential backoff, but skip the remainder if the URL changes.
+        tokio::select! {
+            _ = tokio::time::sleep(delay) => {
+                delay = (delay * 2).min(WS_RECONNECT_MAX_DELAY);
+            }
+            Ok(()) = url_rx.changed() => {
+                delay = WS_RECONNECT_INITIAL_DELAY;
+            }
+        }
     }
 }
 
 /// Subscribes to flashblocks via WebSocket and forwards raw flashblocks.
 pub(crate) async fn run_flashblock_ws(
-    url: String,
+    mut url_rx: watch::Receiver<String>,
     tx: mpsc::Sender<Flashblock>,
     toast_tx: mpsc::Sender<Toast>,
 ) {
-    run_flashblock_ws_inner(&url, &tx, &toast_tx, |fb| fb).await;
+    run_flashblock_ws_inner(&mut url_rx, &tx, &toast_tx, |fb| fb).await;
 }
 
 /// A flashblock paired with its local receive timestamp.
@@ -152,15 +186,68 @@ pub(crate) struct TimestampedFlashblock {
 
 /// Subscribes to flashblocks via WebSocket and forwards timestamped flashblocks.
 pub(crate) async fn run_flashblock_ws_timestamped(
-    url: String,
+    mut url_rx: watch::Receiver<String>,
     tx: mpsc::Sender<TimestampedFlashblock>,
     toast_tx: mpsc::Sender<Toast>,
 ) {
-    run_flashblock_ws_inner(&url, &tx, &toast_tx, |fb| TimestampedFlashblock {
+    run_flashblock_ws_inner(&mut url_rx, &tx, &toast_tx, |fb| TimestampedFlashblock {
         flashblock: fb,
         received_at: chrono::Local::now(),
     })
     .await;
+}
+
+/// Polls the conductor cluster and pushes the current Raft leader's flashblocks
+/// WebSocket URL into `url_tx` whenever leadership changes.
+///
+/// Only conductor nodes that have a `flashblocks_ws` configured are considered.
+/// The task exits immediately if no such nodes exist.
+pub(crate) async fn run_conductor_leader_url_tracker(
+    nodes: Vec<ConductorNodeConfig>,
+    url_tx: watch::Sender<String>,
+) {
+    const POLL_INTERVAL: Duration = Duration::from_millis(500);
+    const RPC_TIMEOUT: Duration = Duration::from_millis(500);
+
+    // Pre-build one HTTP client per node (only for nodes that have a flashblocks_ws).
+    let clients: Vec<(String, _)> = nodes
+        .into_iter()
+        .filter_map(|node| {
+            let flashblocks_ws = node.flashblocks_ws?.to_string();
+            let client = HttpClientBuilder::default()
+                .request_timeout(RPC_TIMEOUT)
+                .build(node.conductor_rpc.as_str())
+                .inspect_err(|e| {
+                    warn!(error = %e, node = %node.name, "failed to build conductor HTTP client for URL tracker");
+                })
+                .ok()?;
+            Some((flashblocks_ws, client))
+        })
+        .collect();
+
+    if clients.is_empty() {
+        return;
+    }
+
+    let mut interval = tokio::time::interval(POLL_INTERVAL);
+    interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+
+    loop {
+        interval.tick().await;
+
+        for (flashblocks_ws, conductor_client) in &clients {
+            if ConductorApiClient::conductor_leader(conductor_client).await.unwrap_or(false) {
+                url_tx.send_if_modified(|current| {
+                    if *current == *flashblocks_ws {
+                        return false;
+                    }
+                    *current = flashblocks_ws.clone();
+                    true
+                });
+                break;
+            }
+        }
+    }
 }
 
 /// Summary of the initial DA backlog between safe and latest blocks.

--- a/crates/infra/basectl/src/rpc.rs
+++ b/crates/infra/basectl/src/rpc.rs
@@ -217,54 +217,6 @@ pub(crate) async fn run_flashblock_ws_timestamped(
 ///
 /// Only conductor nodes that have a `flashblocks_ws` configured are considered.
 /// The task exits immediately if no such nodes exist.
-pub(crate) async fn run_conductor_leader_url_tracker(
-    nodes: Vec<ConductorNodeConfig>,
-    url_tx: watch::Sender<String>,
-) {
-    const POLL_INTERVAL: Duration = Duration::from_millis(500);
-    const RPC_TIMEOUT: Duration = Duration::from_millis(500);
-
-    // Pre-build one HTTP client per node (only for nodes that have a flashblocks_ws).
-    let clients: Vec<(String, _)> = nodes
-        .into_iter()
-        .filter_map(|node| {
-            let flashblocks_ws = node.flashblocks_ws?.to_string();
-            let client = HttpClientBuilder::default()
-                .request_timeout(RPC_TIMEOUT)
-                .build(node.conductor_rpc.as_str())
-                .inspect_err(|e| {
-                    warn!(error = %e, node = %node.name, "failed to build conductor HTTP client for URL tracker");
-                })
-                .ok()?;
-            Some((flashblocks_ws, client))
-        })
-        .collect();
-
-    if clients.is_empty() {
-        return;
-    }
-
-    let mut interval = tokio::time::interval(POLL_INTERVAL);
-    interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
-
-    loop {
-        interval.tick().await;
-
-        for (flashblocks_ws, conductor_client) in &clients {
-            if ConductorApiClient::conductor_leader(conductor_client).await.unwrap_or(false) {
-                url_tx.send_if_modified(|current| {
-                    if *current == *flashblocks_ws {
-                        return false;
-                    }
-                    *current = flashblocks_ws.clone();
-                    true
-                });
-                break;
-            }
-        }
-    }
-}
-
 /// Summary of the initial DA backlog between safe and latest blocks.
 #[derive(Debug, Clone)]
 pub(crate) struct InitialBacklog {

--- a/crates/infra/basectl/src/rpc.rs
+++ b/crates/infra/basectl/src/rpc.rs
@@ -103,54 +103,69 @@ async fn run_flashblock_ws_inner<T: Send + 'static>(
     loop {
         let url = url_rx.borrow_and_update().clone();
 
-        match connect_async(url.as_str()).await {
-            Ok((ws_stream, _)) => {
-                delay = WS_RECONNECT_INITIAL_DELAY;
-                let (_, mut read) = ws_stream.split();
-                let mut leader_changed = false;
+        // Wrap connect_async in a select so a second leader change that
+        // arrives while a TCP handshake is already in progress (e.g. rapid
+        // successive transfers, or non-localhost endpoints that stall rather
+        // than immediately refuse) is acted on without waiting for the
+        // handshake to resolve.
+        tokio::select! {
+            result = connect_async(url.as_str()) => {
+                match result {
+                    Ok((ws_stream, _)) => {
+                        delay = WS_RECONNECT_INITIAL_DELAY;
+                        let (_, mut read) = ws_stream.split();
+                        let mut leader_changed = false;
 
-                loop {
-                    tokio::select! {
-                        msg_opt = read.next() => {
-                            let msg = match msg_opt {
-                                Some(Ok(m)) => m,
-                                Some(Err(e)) => {
-                                    warn!(error = %e, "Flashblock WebSocket connection error");
-                                    let _ = toast_tx.try_send(Toast::warning("WebSocket disconnected"));
+                        loop {
+                            tokio::select! {
+                                msg_opt = read.next() => {
+                                    let msg = match msg_opt {
+                                        Some(Ok(m)) => m,
+                                        Some(Err(e)) => {
+                                            warn!(error = %e, "Flashblock WebSocket connection error");
+                                            let _ = toast_tx.try_send(Toast::warning("WebSocket disconnected"));
+                                            break;
+                                        }
+                                        None => break,
+                                    };
+                                    if !msg.is_binary() && !msg.is_text() {
+                                        continue;
+                                    }
+                                    let fb = match Flashblock::try_decode_message(msg.into_data()) {
+                                        Ok(fb) => fb,
+                                        Err(_) => continue,
+                                    };
+                                    if tx.send(map_fb(fb)).await.is_err() {
+                                        return;
+                                    }
+                                }
+                                Ok(()) = url_rx.changed() => {
+                                    leader_changed = true;
                                     break;
                                 }
-                                None => break,
-                            };
-                            if !msg.is_binary() && !msg.is_text() {
-                                continue;
-                            }
-                            let fb = match Flashblock::try_decode_message(msg.into_data()) {
-                                Ok(fb) => fb,
-                                Err(_) => continue,
-                            };
-                            if tx.send(map_fb(fb)).await.is_err() {
-                                return;
                             }
                         }
-                        Ok(()) = url_rx.changed() => {
-                            leader_changed = true;
-                            break;
+
+                        if leader_changed {
+                            // Skip backoff: reconnect immediately to the new leader.
+                            delay = WS_RECONNECT_INITIAL_DELAY;
+                            continue;
                         }
                     }
-                }
-
-                if leader_changed {
-                    // Skip backoff: reconnect immediately to the new leader.
-                    delay = WS_RECONNECT_INITIAL_DELAY;
-                    continue;
+                    Err(e) => {
+                        warn!(error = %e, url = %url, "Failed to connect to flashblock WebSocket");
+                        let _ = toast_tx.try_send(Toast::warning(format!(
+                            "WebSocket connection failed, retrying in {}s",
+                            delay.as_secs()
+                        )));
+                    }
                 }
             }
-            Err(e) => {
-                warn!(error = %e, url = %url, "Failed to connect to flashblock WebSocket");
-                let _ = toast_tx.try_send(Toast::warning(format!(
-                    "WebSocket connection failed, retrying in {}s",
-                    delay.as_secs()
-                )));
+            Ok(()) = url_rx.changed() => {
+                // URL changed while connecting; abandon this attempt and
+                // reconnect to the new leader immediately, without backoff.
+                delay = WS_RECONNECT_INITIAL_DELAY;
+                continue;
             }
         }
 


### PR DESCRIPTION
## Summary

When op-conductor leadership transfers to a different sequencer node, the basectl command center was silently stalling because the flashblocks WebSocket remained connected to the previous leader's idle port. This adds a \`flashblocks_ws\` field to \`ConductorNodeConfig\` so each conductor node can advertise its builder's WebSocket endpoint, and introduces a new \`run_conductor_leader_url_tracker\` task that polls the conductor cluster every 500 ms and pushes the current Raft leader's URL into a \`tokio::sync::watch\` channel. Both WS subscriber tasks now hold a watch receiver and use \`tokio::select!\` to drop their current connection and reconnect to the new leader immediately on any leadership change, bypassing the normal reconnect backoff.