### PR TITLE
fix(proofs): Several Fixes To Base-Proof

### DIFF
--- a/crates/consensus/protocol/src/batch/reader.rs
+++ b/crates/consensus/protocol/src/batch/reader.rs
@@ -5,7 +5,7 @@ use alloc::vec::Vec;
 use alloy_primitives::Bytes;
 use alloy_rlp::Decodable;
 use base_consensus_genesis::RollupConfig;
-use miniz_oxide::inflate::decompress_to_vec_zlib;
+use miniz_oxide::inflate::{TINFLStatus, decompress_to_vec_zlib_with_limit};
 
 use crate::{Batch, BrotliDecompressionError, decompress_brotli};
 
@@ -24,9 +24,6 @@ pub enum DecompressionError {
     /// A zlib decompression error.
     #[error("zlib decompression error")]
     ZlibError,
-    /// The RLP data is too large for the configured maximum.
-    #[error("the RLP data is too large: {0} bytes, maximum allowed: {1} bytes")]
-    RlpTooLarge(usize, usize),
 }
 
 /// Batch Reader provides a function that iteratively consumes batches from the reader.
@@ -73,34 +70,56 @@ impl BatchReader {
     }
 
     /// Helper method to decompress the data contained in the reader.
+    /// No-op if the data has already been decompressed.
     pub fn decompress(&mut self) -> Result<(), DecompressionError> {
-        if let Some(data) = self.data.take() {
-            // Peek at the data to determine the compression type.
-            if data.is_empty() {
-                return Err(DecompressionError::EmptyData);
-            }
-
-            let compression_type = data[0];
-            if (compression_type & 0x0F) == Self::ZLIB_DEFLATE_COMPRESSION_METHOD
-                || (compression_type & 0x0F) == Self::ZLIB_RESERVED_COMPRESSION_METHOD
-            {
-                self.decompressed =
-                    decompress_to_vec_zlib(&data).map_err(|_| DecompressionError::ZlibError)?;
-
-                // Check the size of the decompressed channel RLP.
-                if self.decompressed.len() > self.max_rlp_bytes_per_channel {
-                    return Err(DecompressionError::RlpTooLarge(
-                        self.decompressed.len(),
-                        self.max_rlp_bytes_per_channel,
-                    ));
+        if !self.decompressed.is_empty() {
+            return Ok(());
+        }
+        match self.data.take() {
+            None => Err(DecompressionError::EmptyData),
+            Some(data) if data.is_empty() => Err(DecompressionError::EmptyData),
+            Some(data) => {
+                // Peek at the data to determine the compression type.
+                let compression_type = data[0];
+                if (compression_type & 0x0F) == Self::ZLIB_DEFLATE_COMPRESSION_METHOD
+                    || (compression_type & 0x0F) == Self::ZLIB_RESERVED_COMPRESSION_METHOD
+                {
+                    self.decompress_zlib(data)
+                } else if compression_type == Self::CHANNEL_VERSION_BROTLI {
+                    self.decompress_brotli(data)
+                } else {
+                    Err(DecompressionError::UnsupportedType(compression_type))
                 }
-            } else if compression_type == Self::CHANNEL_VERSION_BROTLI {
-                self.brotli_used = true;
-                self.decompressed = decompress_brotli(&data[1..], self.max_rlp_bytes_per_channel)?;
-            } else {
-                return Err(DecompressionError::UnsupportedType(compression_type));
             }
         }
+    }
+
+    fn decompress_zlib(&mut self, data: Vec<u8>) -> Result<(), DecompressionError> {
+        // Decompress with a limit to prevent zip-bomb attacks.
+        // Per spec, if decompressed data exceeds the limit, the output is
+        // truncated to max_rlp_bytes_per_channel bytes (not rejected).
+        match decompress_to_vec_zlib_with_limit(&data, self.max_rlp_bytes_per_channel) {
+            Ok(decompressed) => {
+                self.decompressed = decompressed;
+            }
+            Err(e) if e.status == TINFLStatus::HasMoreOutput || !e.output.is_empty() => {
+                // Either: limit reached — truncate per spec and keep partial output.
+                // Or: decompression error with partial output — keep it so
+                // batches decoded before the error point are accepted.
+                self.decompressed = e.output;
+            }
+            Err(_) => {
+                return Err(DecompressionError::ZlibError);
+            }
+        }
+        Ok(())
+    }
+
+    fn decompress_brotli(&mut self, data: Vec<u8>) -> Result<(), DecompressionError> {
+        self.brotli_used = true;
+        // Note: the first byte of the channel data is the Brotli channel version but not part of
+        // the compressed data, so it's skipped here but not for zlib.
+        self.decompressed = decompress_brotli(&data[1..], self.max_rlp_bytes_per_channel)?;
         Ok(())
     }
 
@@ -131,6 +150,10 @@ impl BatchReader {
 mod tests {
     use base_consensus_genesis::{
         HardForkConfig, MAX_RLP_BYTES_PER_CHANNEL_BEDROCK, MAX_RLP_BYTES_PER_CHANNEL_FJORD,
+    };
+    use miniz_oxide::{
+        deflate::{CompressionLevel, compress_to_vec_zlib},
+        inflate::decompress_to_vec_zlib,
     };
 
     use super::*;
@@ -164,5 +187,65 @@ mod tests {
             })
             .unwrap();
         assert_eq!(reader.cursor, decompressed_len);
+    }
+
+    /// Builds zlib-compressed channel data containing `n` copies of the same
+    /// batch by duplicating the decompressed RLP content from the test fixture.
+    fn new_multi_batch_compressed_data(n: usize) -> (Bytes, usize) {
+        let raw = new_compressed_batch_data();
+        let single = decompress_to_vec_zlib(&raw).unwrap();
+
+        let mut multi = alloc::vec::Vec::with_capacity(single.len() * n);
+        for _ in 0..n {
+            multi.extend_from_slice(&single);
+        }
+        let decompressed_len = multi.len();
+        (compress_to_vec_zlib(&multi, CompressionLevel::BestSpeed.into()).into(), decompressed_len)
+    }
+
+    #[test]
+    fn test_zlib_truncation_instead_of_rejection() {
+        let raw = new_compressed_batch_data();
+        let decompressed_len = decompress_to_vec_zlib(&raw).unwrap().len();
+        assert!(decompressed_len > 1, "test data must decompress to >1 byte");
+
+        // Set limit below decompressed size — should truncate, not error.
+        let limit = decompressed_len / 2;
+        let mut reader = BatchReader::new(raw, limit);
+        assert!(reader.decompress().is_ok());
+        assert_eq!(reader.decompressed.len(), limit);
+    }
+
+    #[test]
+    fn test_zlib_truncation_yields_decodable_batches() {
+        let n = 3;
+        let (compressed, full_len) = new_multi_batch_compressed_data(n);
+        let single_batch_len = full_len / n;
+
+        // Full decompression should yield all n batches.
+        let mut reader = BatchReader::new(compressed.clone(), full_len);
+        let mut count = 0;
+        while reader.next_batch(&RollupConfig::default()).is_some() {
+            count += 1;
+        }
+        assert_eq!(count, n, "should decode {n} batches from full channel");
+
+        // Truncate to just under the last batch — should yield n-1 batches.
+        let limit = full_len - 1;
+        let mut reader = BatchReader::new(compressed, limit);
+        let mut count = 0;
+        while reader.next_batch(&RollupConfig::default()).is_some() {
+            count += 1;
+        }
+        assert_eq!(
+            count,
+            n - 1,
+            "truncated channel should yield {exp} batches (cursor at {cursor}, \
+             single batch is {single_batch_len} bytes, limit {limit})",
+            exp = n - 1,
+            cursor = reader.cursor,
+        );
+        // First n-1 batches should have been fully consumed.
+        assert_eq!(reader.cursor, single_batch_len * (n - 1));
     }
 }

--- a/crates/consensus/protocol/src/brotli.rs
+++ b/crates/consensus/protocol/src/brotli.rs
@@ -7,16 +7,14 @@ use alloc_no_stdlib::{
     AllocatedStackMemory, Allocator, SliceWrapper, SliceWrapperMut, StackAllocator, bzero,
     declare_stack_allocator_struct, define_stack_allocator_traits, static_array,
 };
-use brotli::{BrotliState, HuffmanCode};
+use brotli::{BrotliResult, BrotliState, HuffmanCode};
 
-use crate::MAX_SPAN_BATCH_ELEMENTS;
-
-/// A frame decompression error.
-#[derive(thiserror::Error, Debug, PartialEq, Eq)]
+/// A brotli decompression error.
+#[derive(thiserror::Error, Debug)]
 pub enum BrotliDecompressionError {
-    /// The buffer exceeds the [`MAX_SPAN_BATCH_ELEMENTS`] protocol parameter.
-    #[error("The batch exceeds the maximum number of elements: {max_size}", max_size = MAX_SPAN_BATCH_ELEMENTS)]
-    BatchTooLarge,
+    /// Brotli decompression failed due to corrupt or invalid data.
+    #[error("brotli decompression failed: {0:?}")]
+    DecompressionFailed(BrotliResult),
 }
 
 /// Decompresses the given bytes data using the Brotli decompressor implemented
@@ -35,41 +33,53 @@ pub fn decompress_brotli(
     let hc_allocator = MemPool::<HuffmanCode>::new_allocator(&mut hc_buffer, bzero);
     let mut brotli_state = BrotliState::new(u8_allocator, u32_allocator, hc_allocator);
 
-    // Setup the decompressor inputs and outputs
-    let mut output = vec![0; data.len()];
+    // Setup the decompressor inputs and outputs.
+    // Cap initial buffer at the limit to prevent over-allocation.
+    let mut output = vec![0; core::cmp::min(data.len(), max_rlp_bytes_per_channel)];
     let mut available_in = data.len();
     let mut input_offset = 0;
     let mut available_out = output.len();
     let mut output_offset = 0;
     let mut written = 0;
 
-    // Decompress the data stream until success or failure
-    while let brotli::BrotliResult::NeedsMoreOutput = brotli::BrotliDecompressStream(
-        &mut available_in,
-        &mut input_offset,
-        data,
-        &mut available_out,
-        &mut output_offset,
-        &mut output,
-        &mut written,
-        &mut brotli_state,
-    ) {
-        // Resize the output buffer to double the size, following standard
-        // practice for buffer resizing in streams.
+    // Decompress the data stream until success or failure.
+    // The output buffer is grown as needed, capped at max_rlp_bytes_per_channel.
+    // Per spec, if decompressed data exceeds the limit, the output is truncated
+    // to max_rlp_bytes_per_channel bytes (not rejected).
+    loop {
+        let result = brotli::BrotliDecompressStream(
+            &mut available_in,
+            &mut input_offset,
+            data,
+            &mut available_out,
+            &mut output_offset,
+            &mut output,
+            &mut written,
+            &mut brotli_state,
+        );
         let old_len = output.len();
-        let new_len = old_len * 2;
 
-        if new_len > max_rlp_bytes_per_channel {
-            return Err(BrotliDecompressionError::BatchTooLarge);
+        match result {
+            // Buffer was already grown to the limit on a previous iteration, but the decompressor
+            // filled it and still has more to produce: stop per spec.
+            BrotliResult::NeedsMoreOutput if old_len >= max_rlp_bytes_per_channel => break,
+            // Enlarge output buffer to continue decompression.
+            BrotliResult::NeedsMoreOutput => {
+                let new_len = core::cmp::min((old_len * 2).max(1), max_rlp_bytes_per_channel);
+                output.resize(new_len, 0);
+                available_out += new_len - old_len;
+            }
+            // No output: error.
+            _ if written == 0 => {
+                return Err(BrotliDecompressionError::DecompressionFailed(result));
+            }
+            // Success, NeedsMoreInput or ResultFailure with some output written: return partial
+            // data.
+            _ => break,
         }
-
-        output.resize(new_len, 0);
-        available_out += old_len;
     }
 
-    // Truncate the output buffer to the written bytes
     output.truncate(written);
-
     Ok(output)
 }
 
@@ -102,5 +112,56 @@ mod tests {
         let decompressed =
             decompress_brotli(&raw_batch, MAX_RLP_BYTES_PER_CHANNEL_FJORD as usize).unwrap();
         assert_eq!(decompressed, raw_batch_decompressed);
+    }
+
+    #[test]
+    fn test_brotli_truncation_instead_of_rejection() {
+        // Use the small test data to verify truncation behavior.
+        let expected = hex!("75ed184249e9bc19675e");
+        let compressed = hex!("8b048075ed184249e9bc19675e03");
+        let full_len = expected.len();
+
+        // Full limit — should decompress fully.
+        let decompressed = decompress_brotli(&compressed, full_len).unwrap();
+        assert_eq!(decompressed, expected);
+
+        // Limit smaller than data — should truncate, not error.
+        let limit = full_len / 2;
+        let decompressed = decompress_brotli(&compressed, limit).unwrap();
+        assert!(
+            decompressed.len() <= limit,
+            "truncated output ({}) should not exceed limit ({})",
+            decompressed.len(),
+            limit
+        );
+    }
+
+    #[test]
+    fn test_brotli_buffer_doubling_regression() {
+        // Regression test for the buffer-doubling bug: the old code doubled the
+        // output buffer and rejected if the doubled size exceeded the limit,
+        // even if the actual decompressed data fit within the limit.
+        //
+        // Example: 100 bytes of data, initial buffer = compressed.len() (small),
+        // buffer doubles past 100 -> old code returns BatchTooLarge.
+        let data = alloc::vec![0xAA; 100];
+        let compressed = {
+            let params = brotli::enc::BrotliEncoderParams::default();
+            let mut output = alloc::vec::Vec::new();
+            let mut input = &data[..];
+            brotli::BrotliCompress(&mut input, &mut output, &params).unwrap();
+            output
+        };
+
+        // Limit = exact decompressed size. The old code would error because
+        // internal buffer doubling would overshoot.
+        let result = decompress_brotli(&compressed, data.len());
+        assert!(result.is_ok(), "decompression at exact limit should succeed");
+        assert_eq!(result.unwrap(), data);
+
+        // Limit = data.len() + 1 — also succeeds.
+        let result = decompress_brotli(&compressed, data.len() + 1);
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), data);
     }
 }

--- a/crates/proof/client/src/prologue.rs
+++ b/crates/proof/client/src/prologue.rs
@@ -56,11 +56,6 @@ where
         let l1_config = boot.l1_config;
         let rollup_config = Arc::new(boot.rollup_config);
 
-        if boot.agreed_l2_output_root == boot.claimed_l2_output_root {
-            info!("trace extension detected");
-            return Err(FaultProofProgramError::TraceExtension);
-        }
-
         let safe_head_hash =
             fetch_safe_head_hash(oracle.as_ref(), boot.agreed_l2_output_root).await?;
 
@@ -88,9 +83,31 @@ where
             });
         }
 
+        // If the claim targets the safe head block itself, no derivation is needed. This is the
+        // trace-extension leaf case where the trace is capped at the root-claim block number.
+        // The only valid output root here is the agreed output root (a zero-step transition).
+        if boot.claimed_l2_block_number == safe_head.number {
+            if boot.claimed_l2_output_root != boot.agreed_l2_output_root {
+                error!(
+                    claimed = boot.claimed_l2_block_number,
+                    safe = safe_head.number,
+                    expected_output_root = ?boot.agreed_l2_output_root,
+                    claimed_output_root = ?boot.claimed_l2_output_root,
+                    "claimed output root does not match agreed output root at safe head"
+                );
+                return Err(FaultProofProgramError::InvalidClaim {
+                    computed: boot.agreed_l2_output_root,
+                    claimed: boot.claimed_l2_output_root,
+                });
+            }
+            info!("trace extension detected");
+            return Err(FaultProofProgramError::TraceExtension);
+        }
+
         let cursor = new_oracle_pipeline_cursor(
             rollup_config.as_ref(),
             safe_head,
+            boot.agreed_l2_output_root,
             &mut l1_provider,
             &mut l2_provider,
         )

--- a/crates/proof/proof/src/l1/pipeline.rs
+++ b/crates/proof/proof/src/l1/pipeline.rs
@@ -137,9 +137,14 @@ where
 
         let safe_header = l2_provider.header_by_hash(l2_head_hash)?.seal_slow();
 
-        let cursor =
-            new_oracle_pipeline_cursor(&cfg, safe_header, &mut l1_provider, &mut l2_provider)
-                .await?;
+        let cursor = new_oracle_pipeline_cursor(
+            &cfg,
+            safe_header,
+            boot_info.agreed_l2_output_root,
+            &mut l1_provider,
+            &mut l2_provider,
+        )
+        .await?;
         l2_provider.set_cursor(Arc::clone(&cursor));
 
         let pipeline = Self::new(

--- a/crates/proof/proof/src/sync.rs
+++ b/crates/proof/proof/src/sync.rs
@@ -18,6 +18,7 @@ use crate::errors::OracleProviderError;
 pub async fn new_oracle_pipeline_cursor<L1, L2>(
     rollup_config: &RollupConfig,
     safe_header: Sealed<Header>,
+    agreed_l2_output_root: B256,
     chain_provider: &mut L1,
     l2_chain_provider: &mut L2,
 ) -> Result<Arc<RwLock<PipelineCursor>>, OracleProviderError>
@@ -41,7 +42,7 @@ where
 
     // Construct the cursor.
     let mut cursor = PipelineCursor::new(channel_timeout, origin);
-    let tip = TipCursor::new(safe_head_info, safe_header, B256::ZERO);
+    let tip = TipCursor::new(safe_head_info, safe_header, agreed_l2_output_root);
     cursor.advance(origin, tip);
 
     // Wrap the cursor in a shared read-write lock


### PR DESCRIPTION
## Summary

Ports three security and correctness fixes from kona-proof (ethereum-optimism/optimism#19775). The trace-extension check now compares claimed block number against the safe head number rather than output root equality, which previously allowed a malicious actor to anchor a claim at a wrong height by reusing the agreed output root. The derivation pipeline cursor is now initialized with the actual agreed L2 output root instead of a zero hash. Batch decompression (both zlib and brotli) now truncates output at the channel size limit instead of rejecting or growing without bound, closing a potential OOM vector.