### PR TITLE
fix(consensus): Seed Engine State On Beyond Genesis Bootstrap

### DIFF
--- a/crates/consensus/engine/src/task_queue/core.rs
+++ b/crates/consensus/engine/src/task_queue/core.rs
@@ -146,6 +146,17 @@ impl<EngineClient_: EngineClient> Engine<EngineClient_> {
         Ok((start.safe, l1_origin_info, system_config))
     }
 
+    /// Seeds the engine sync state from an external source without sending a forkchoice update.
+    ///
+    /// Pre-populates the [`EngineState`] watch channel so that callers such as `op_syncStatus`
+    /// never observe zeros during the bootstrap window. `el_sync_finished` is left unchanged —
+    /// the engine has not confirmed validity via FCU and the existing reset-deferral logic must
+    /// continue to gate on it.
+    pub fn seed_state(&mut self, update: EngineSyncStateUpdate) {
+        self.state.sync_state = self.state.sync_state.apply_update(update);
+        self.state_sender.send_replace(self.state);
+    }
+
     /// Clears the task queue.
     pub fn clear(&mut self) {
         self.tasks.clear();

--- a/crates/consensus/service/src/actors/engine/engine_request_processor.rs
+++ b/crates/consensus/service/src/actors/engine/engine_request_processor.rs
@@ -4,8 +4,9 @@ use alloy_eips::BlockNumberOrTag;
 use base_alloy_rpc_types_engine::OpExecutionPayloadEnvelope;
 use base_consensus_derive::{ResetSignal, Signal};
 use base_consensus_engine::{
-    BuildTask, ConsolidateInput, ConsolidateTask, Engine, EngineClient, EngineTask,
-    EngineTaskError, EngineTaskErrorSeverity, FinalizeTask, GetPayloadTask, InsertTask, SealTask,
+    BuildTask, ConsolidateInput, ConsolidateTask, Engine, EngineClient, EngineSyncStateUpdate,
+    EngineTask, EngineTaskError, EngineTaskErrorSeverity, FinalizeTask, GetPayloadTask, InsertTask,
+    SealTask,
 };
 use base_consensus_genesis::RollupConfig;
 use base_protocol::L2BlockInfo;
@@ -280,15 +281,42 @@ where
                         warn!(target: "engine", ?err, "Engine startup bootstrap failed; will initialize on first task");
                     }
                 }
-            } else if let (Ok(Some(head)), Some(unsafe_head_tx)) =
-                (reth_head, self.unsafe_head_tx.as_ref())
-            {
-                unsafe_head_tx
-                    .send_if_modified(|val| (*val != head).then(|| *val = head).is_some());
+            } else if let Ok(Some(head)) = reth_head {
+                //   Beyond genesis — reth already has a canonical chain (e.g. after snap sync).
+                //   Query safe and finalized heads optimistically; if unavailable (chain just
+                //   started, nothing finalized yet) fall back to default and let derivation fill
+                //   them in once the first task drains.
+                let safe = self
+                    .client
+                    .l2_block_info_by_label(BlockNumberOrTag::Safe)
+                    .await
+                    .ok()
+                    .flatten()
+                    .unwrap_or_default();
+                let finalized = self
+                    .client
+                    .l2_block_info_by_label(BlockNumberOrTag::Finalized)
+                    .await
+                    .ok()
+                    .flatten()
+                    .unwrap_or_default();
+                self.engine.seed_state(EngineSyncStateUpdate {
+                    unsafe_head: Some(head),
+                    cross_unsafe_head: Some(head),
+                    local_safe_head: Some(safe),
+                    safe_head: Some(safe),
+                    finalized_head: Some(finalized),
+                });
+                if let Some(unsafe_head_tx) = self.unsafe_head_tx.as_ref() {
+                    unsafe_head_tx
+                        .send_if_modified(|val| (*val != head).then(|| *val = head).is_some());
+                }
                 info!(
                     target: "engine",
-                    head = %head.block_info.number,
-                    "Bootstrap: skipped reset (beyond genesis), seeded unsafe head from reth"
+                    unsafe_head = %head.block_info.number,
+                    safe_head = %safe.block_info.number,
+                    finalized_head = %finalized.block_info.number,
+                    "Bootstrap: skipped reset (beyond genesis), seeded engine state from reth"
                 );
             }
 


### PR DESCRIPTION
## Summary

After a Raft conductor leadership transfer, basectl observed \`op_sync_status\` returning \`unsafe_l2.block_info.number = 0\` even though the node was fully synced. The root cause was that the beyond-genesis bootstrap path only seeded \`unsafe_head_tx\` and left the engine task queue's watch channel (\`engine_state_receiver\`) at \`EngineState::default()\` (all zeros). Because \`op_sync_status\` reads from \`engine_state_receiver\` rather than \`unsafe_head_tx\`, it served zeros until the first FCU round-trip completed. This PR adds \`Engine::seed_state()\` which pre-populates the watch channel with the current reth heads (unsafe, safe, finalized) during beyond-genesis bootstrap without sending a forkchoice update or disturbing the \`el_sync_finished\` flag, so \`op_sync_status\` returns the live chain tip immediately after bootstrap.