### PR TITLE
Fix: nitro attestation prover guest build fixes for riscv32im-risc0 target

### DIFF
--- a/crates/proof/tee/nitro-attestation-prover/guest/.cargo/config.toml
+++ b/crates/proof/tee/nitro-attestation-prover/guest/.cargo/config.toml
@@ -1,0 +1,6 @@
+# The risc0 toolchain ships an older rustc (1.91) than the workspace MSRV (1.93).
+# The --ignore-rust-version flag is required when invoking cargo build.
+
+[build]
+# Tell getrandom 0.3 to use the "custom" backend provided by risc0-zkvm-platform.
+rustflags = ['--cfg', 'getrandom_backend="custom"']

--- a/crates/proof/tee/nitro-attestation-prover/guest/Justfile
+++ b/crates/proof/tee/nitro-attestation-prover/guest/Justfile
@@ -4,7 +4,7 @@ default:
 
 # Build the guest ELF with the risc0 toolchain
 build:
-    cargo +risc0 build --release --target riscv32im-risc0-zkvm-elf
+    cargo +risc0 build --release --target riscv32im-risc0-zkvm-elf --ignore-rust-version
     @echo "ELF built at: target/riscv32im-risc0-zkvm-elf/release/base-proof-tee-nitro-verifier-guest"
     @ls -lh target/riscv32im-risc0-zkvm-elf/release/base-proof-tee-nitro-verifier-guest
 

--- a/crates/proof/tee/nitro-attestation-prover/guest/src/atomic_shims.rs
+++ b/crates/proof/tee/nitro-attestation-prover/guest/src/atomic_shims.rs
@@ -1,0 +1,88 @@
+//! Atomic operation shims for the riscv32im zkVM target.
+//!
+//! The riscv32im ISA lacks the "A" (atomics) extension, so LLVM emits calls to
+//! `__atomic_*` builtins for any `core::sync::atomic` usage. The risc0 zkVM is
+//! single-threaded, so these can be safely implemented as plain memory
+//! operations.
+
+use core::ptr;
+
+#[unsafe(no_mangle)]
+unsafe extern "C" fn __atomic_load_1(src: *const u8, _ordering: i32) -> u8 {
+    unsafe { ptr::read_volatile(src) }
+}
+
+#[unsafe(no_mangle)]
+unsafe extern "C" fn __atomic_load_4(src: *const u32, _ordering: i32) -> u32 {
+    unsafe { ptr::read_volatile(src) }
+}
+
+#[unsafe(no_mangle)]
+unsafe extern "C" fn __atomic_store_1(dst: *mut u8, val: u8, _ordering: i32) {
+    unsafe { ptr::write_volatile(dst, val) }
+}
+
+#[unsafe(no_mangle)]
+unsafe extern "C" fn __atomic_store_4(dst: *mut u32, val: u32, _ordering: i32) {
+    unsafe { ptr::write_volatile(dst, val) }
+}
+
+#[unsafe(no_mangle)]
+unsafe extern "C" fn __atomic_fetch_add_4(dst: *mut u32, val: u32, _ordering: i32) -> u32 {
+    unsafe {
+        let old = ptr::read_volatile(dst);
+        ptr::write_volatile(dst, old.wrapping_add(val));
+        old
+    }
+}
+
+#[unsafe(no_mangle)]
+unsafe extern "C" fn __atomic_fetch_sub_4(dst: *mut u32, val: u32, _ordering: i32) -> u32 {
+    unsafe {
+        let old = ptr::read_volatile(dst);
+        ptr::write_volatile(dst, old.wrapping_sub(val));
+        old
+    }
+}
+
+#[unsafe(no_mangle)]
+unsafe extern "C" fn __atomic_compare_exchange_1(
+    dst: *mut u8,
+    expected: *mut u8,
+    desired: u8,
+    _weak: bool,
+    _success_ordering: i32,
+    _failure_ordering: i32,
+) -> bool {
+    unsafe {
+        let old = ptr::read_volatile(dst);
+        if old == ptr::read(expected) {
+            ptr::write_volatile(dst, desired);
+            true
+        } else {
+            ptr::write(expected, old);
+            false
+        }
+    }
+}
+
+#[unsafe(no_mangle)]
+unsafe extern "C" fn __atomic_compare_exchange_4(
+    dst: *mut u32,
+    expected: *mut u32,
+    desired: u32,
+    _weak: bool,
+    _success_ordering: i32,
+    _failure_ordering: i32,
+) -> bool {
+    unsafe {
+        let old = ptr::read_volatile(dst);
+        if old == ptr::read(expected) {
+            ptr::write_volatile(dst, desired);
+            true
+        } else {
+            ptr::write(expected, old);
+            false
+        }
+    }
+}

--- a/crates/proof/tee/nitro-attestation-prover/guest/src/main.rs
+++ b/crates/proof/tee/nitro-attestation-prover/guest/src/main.rs
@@ -4,9 +4,11 @@
 // with the risc0 toolchain:
 //
 //   rzup install
-//   cargo +risc0 build --release --target riscv32im-risc0-zkvm-elf
+//   cargo +risc0 build --release --target riscv32im-risc0-zkvm-elf --ignore-rust-version
 //
 // The resulting ELF is loaded at runtime by DirectProver / BoundlessProver.
+
+mod atomic_shims;
 
 use std::io::Read;
 


### PR DESCRIPTION
# Summary
- Add `atomic_shims.rs` with single-threaded atomic operation implementations for the `riscv32im` zkVM target, which lacks the "A" (atomics) ISA extension.
- Configure `getrandom_backend="custom"` via `.cargo/config.toml` so `getrandom` 0.3 uses the `risc0-zkvm-platform` backend.
- Pass `--ignore-rust-version` in the build command to accommodate the older `rustc` (1.91) shipped by the `risc0` toolchain vs. the workspace MSRV (1.93).