### PR TITLE
feat(proof): add SNARK Groth16 proof type and prover address field

### DIFF
--- a/crates/proof/challenge/src/driver.rs
+++ b/crates/proof/challenge/src/driver.rs
@@ -402,12 +402,14 @@ impl<L2: L2Provider, P: ZkProofProvider, T: TxManager> Driver<L2, P, T> {
         let start_block_number = candidate.checkpoint_start_block(invalid_index)?;
 
         let session_id = derive_session_id(game_address, invalid_index);
+        let prover_address = format!("{:#x}", self.submitter.sender_address());
         let request = ProveBlockRequest {
             start_block_number,
             number_of_blocks_to_prove: candidate.intermediate_block_interval,
             sequence_window: None,
-            proof_type: ProofType::GenericZkvmClusterCompressed as i32,
+            proof_type: ProofType::GenericZkvmClusterSnarkGroth16 as i32,
             session_id: Some(session_id),
+            prover_address: Some(prover_address),
         };
 
         let prove_response = self.zk_prover.prove_block(request.clone()).await?;
@@ -576,7 +578,7 @@ impl<L2: L2Provider, P: ZkProofProvider, T: TxManager> Driver<L2, P, T> {
 ///
 /// Uses UUID v5 (SHA-1 namespace hash) over `game_address || invalid_index`
 /// to produce an idempotency key that is stable across retries.
-fn derive_session_id(game_address: Address, invalid_index: u64) -> String {
+pub fn derive_session_id(game_address: Address, invalid_index: u64) -> String {
     let mut bytes = [0u8; 28];
     bytes[..20].copy_from_slice(game_address.as_slice());
     bytes[20..].copy_from_slice(&invalid_index.to_be_bytes());

--- a/crates/proof/challenge/src/driver.rs
+++ b/crates/proof/challenge/src/driver.rs
@@ -407,7 +407,7 @@ impl<L2: L2Provider, P: ZkProofProvider, T: TxManager> Driver<L2, P, T> {
             start_block_number,
             number_of_blocks_to_prove: candidate.intermediate_block_interval,
             sequence_window: None,
-            proof_type: ProofType::GenericZkvmClusterSnarkGroth16 as i32,
+            proof_type: ProofType::GenericZkvmClusterSnarkGroth16.into(),
             session_id: Some(session_id),
             prover_address: Some(prover_address),
         };

--- a/crates/proof/challenge/src/lib.rs
+++ b/crates/proof/challenge/src/lib.rs
@@ -13,7 +13,7 @@ mod config;
 pub use config::{ChallengerConfig, ConfigError, UrlValidationError, Validated};
 
 mod driver;
-pub use driver::{Driver, DriverConfig, TeeConfig};
+pub use driver::{Driver, DriverConfig, TeeConfig, derive_session_id};
 
 mod pending;
 pub use pending::{PendingProof, PendingProofs, ProofPhase, ProofUpdate};

--- a/crates/proof/challenge/src/submitter.rs
+++ b/crates/proof/challenge/src/submitter.rs
@@ -5,7 +5,7 @@ use std::time::Instant;
 use alloy_primitives::{Address, B256, Bytes, U256};
 use base_proof_contracts::encode_nullify_calldata;
 use base_tx_manager::{TxCandidate, TxManager};
-use tracing::{debug, info};
+use tracing::info;
 
 use crate::{ChallengeSubmitError, ChallengerMetrics};
 
@@ -43,7 +43,7 @@ impl<T: TxManager> ChallengeSubmitter<T> {
             intermediate_root_to_prove,
         );
 
-        debug!(
+        info!(
             game = %game_address,
             intermediate_root_index,
             intermediate_root_to_prove = %intermediate_root_to_prove,
@@ -57,6 +57,11 @@ impl<T: TxManager> ChallengeSubmitter<T> {
             value: U256::ZERO,
             ..Default::default()
         };
+
+        info!(
+            tx = ?candidate,
+            "Sending tx candidate",
+        );
 
         metrics::counter!(ChallengerMetrics::NULLIFY_TX_SUBMITTED_TOTAL).increment(1);
         let start = Instant::now();

--- a/crates/proof/challenge/src/submitter.rs
+++ b/crates/proof/challenge/src/submitter.rs
@@ -5,7 +5,7 @@ use std::time::Instant;
 use alloy_primitives::{Address, B256, Bytes, U256};
 use base_proof_contracts::encode_nullify_calldata;
 use base_tx_manager::{TxCandidate, TxManager};
-use tracing::info;
+use tracing::{debug, info};
 
 use crate::{ChallengeSubmitError, ChallengerMetrics};
 
@@ -41,6 +41,14 @@ impl<T: TxManager> ChallengeSubmitter<T> {
             proof_bytes,
             intermediate_root_index,
             intermediate_root_to_prove,
+        );
+
+        debug!(
+            game = %game_address,
+            intermediate_root_index,
+            intermediate_root_to_prove = %intermediate_root_to_prove,
+            calldata_len = calldata.len(),
+            "Nullifying dispute game"
         );
 
         let candidate = TxCandidate {

--- a/crates/proof/challenge/tests/driver.rs
+++ b/crates/proof/challenge/tests/driver.rs
@@ -83,7 +83,7 @@ fn default_prove_request() -> ProveBlockRequest {
         start_block_number: 15,
         number_of_blocks_to_prove: 5,
         sequence_window: None,
-        proof_type: ProofType::GenericZkvmClusterSnarkGroth16 as i32,
+        proof_type: ProofType::GenericZkvmClusterSnarkGroth16.into(),
         session_id: Some(session_id),
         prover_address: Some(format!("{:#x}", addr(0))),
     }

--- a/crates/proof/challenge/tests/driver.rs
+++ b/crates/proof/challenge/tests/driver.rs
@@ -9,7 +9,7 @@ use std::{
 use alloy_primitives::{Address, B256, Bytes, U256};
 use base_challenger::{
     ChallengeSubmitter, Driver, DriverConfig, GameScanner, L1HeadProvider, OutputValidator,
-    PendingProof, ProofPhase, ScannerConfig, TeeConfig,
+    PendingProof, ProofPhase, ScannerConfig, TeeConfig, derive_session_id,
     test_utils::{
         MockAggregateVerifier, MockDisputeGameFactory, MockGameState, MockL1HeadProvider,
         MockL2Provider, MockTeeProofProvider, MockTxManager, MockZkProofProvider, addr,
@@ -76,13 +76,16 @@ fn default_tx_manager() -> MockTxManager {
     MockTxManager::new(Ok(receipt_with_status(true, B256::repeat_byte(0xAA))))
 }
 
-const fn default_prove_request() -> ProveBlockRequest {
+fn default_prove_request() -> ProveBlockRequest {
+    let session_id = derive_session_id(addr(0), 1);
+
     ProveBlockRequest {
         start_block_number: 15,
         number_of_blocks_to_prove: 5,
         sequence_window: None,
-        proof_type: ProofType::GenericZkvmClusterCompressed as i32,
-        session_id: None,
+        proof_type: ProofType::GenericZkvmClusterSnarkGroth16 as i32,
+        session_id: Some(session_id),
+        prover_address: Some(format!("{:#x}", addr(0))),
     }
 }
 

--- a/crates/proof/tee/registrar/src/driver.rs
+++ b/crates/proof/tee/registrar/src/driver.rs
@@ -311,14 +311,23 @@ where
             return Ok(());
         }
 
-        let calldata = ITEEProverRegistry::registerSignerCall {
-            output: proof.output,
-            proofBytes: proof.proof_bytes,
-        }
-        .abi_encode();
+        let calldata = Bytes::from(
+            ITEEProverRegistry::registerSignerCall {
+                output: proof.output,
+                proofBytes: proof.proof_bytes,
+            }
+            .abi_encode(),
+        );
+
+        debug!(
+            signer = %signer_address,
+            registry = %self.config.registry_address,
+            calldata_len = calldata.len(),
+            "Registering signer"
+        );
 
         let candidate = TxCandidate {
-            tx_data: Bytes::from(calldata),
+            tx_data: calldata,
             to: Some(self.config.registry_address),
             ..Default::default()
         };
@@ -348,9 +357,18 @@ where
 
     /// Submits a `deregisterSigner` transaction and returns whether it succeeded.
     async fn submit_deregistration(&self, signer: Address) -> bool {
-        let calldata = ITEEProverRegistry::deregisterSignerCall { signer }.abi_encode();
+        let calldata =
+            Bytes::from(ITEEProverRegistry::deregisterSignerCall { signer }.abi_encode());
+
+        debug!(
+            signer = %signer,
+            registry = %self.config.registry_address,
+            calldata_len = calldata.len(),
+            "Deregistering signer"
+        );
+
         let candidate = TxCandidate {
-            tx_data: Bytes::from(calldata),
+            tx_data: calldata,
             to: Some(self.config.registry_address),
             ..Default::default()
         };

--- a/crates/proof/tee/registrar/src/driver.rs
+++ b/crates/proof/tee/registrar/src/driver.rs
@@ -319,7 +319,7 @@ where
             .abi_encode(),
         );
 
-        debug!(
+        info!(
             signer = %signer_address,
             registry = %self.config.registry_address,
             calldata_len = calldata.len(),
@@ -331,6 +331,11 @@ where
             to: Some(self.config.registry_address),
             ..Default::default()
         };
+
+        info!(
+            tx = ?candidate,
+            "Sending tx candidate",
+        );
 
         let receipt = self.tx_manager.send(candidate).await.map_err(RegistrarError::from)?;
 
@@ -360,7 +365,7 @@ where
         let calldata =
             Bytes::from(ITEEProverRegistry::deregisterSignerCall { signer }.abi_encode());
 
-        debug!(
+        info!(
             signer = %signer,
             registry = %self.config.registry_address,
             calldata_len = calldata.len(),
@@ -372,6 +377,11 @@ where
             to: Some(self.config.registry_address),
             ..Default::default()
         };
+
+        info!(
+            tx = ?candidate,
+            "Sending tx candidate",
+        );
 
         match self.tx_manager.send(candidate).await {
             Ok(receipt) => {

--- a/crates/proof/zk/client/README.md
+++ b/crates/proof/zk/client/README.md
@@ -41,7 +41,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         start_block_number: 42,
         number_of_blocks_to_prove: 1,
         sequence_window: None,
-        proof_type: ProofType::KailuaBentoStark.into(),
+        proof_type: ProofType::GenericZkvmClusterCompressed.into(),
+        session_id: None,
+        prover_address: None,
     };
 
     let response = client.prove_block(request).await?;

--- a/crates/proof/zk/client/proto/zk_prover.proto
+++ b/crates/proof/zk/client/proto/zk_prover.proto
@@ -9,9 +9,9 @@ service ProverService {
 
 enum ProofType {
   PROOF_TYPE_UNSPECIFIED = 0;
-  PROOF_TYPE_KAILUA_BENTO_STARK = 1;
-  PROOF_TYPE_KAILUA_BENTO_SNARK = 2;
+  reserved 1, 2;
   PROOF_TYPE_GENERIC_ZKVM_CLUSTER_COMPRESSED = 3;
+  PROOF_TYPE_GENERIC_ZKVM_CLUSTER_SNARK_GROTH16 = 4;
 }
 
 message ProveBlockRequest {
@@ -21,9 +21,12 @@ message ProveBlockRequest {
   optional uint64 sequence_window = 3;
   // The type of proof to generate
   ProofType proof_type = 4;
-  // Optional client-supplied idempotency key. When set, the server
-  // may use it to deduplicate concurrent or retried proof requests.
+  // Optional: client-provided UUID for idempotent requests.
+  // If provided, a duplicate ID returns the existing session.
+  // If omitted, the server generates a UUID.
   optional string session_id = 5;
+  // Ethereum address of the on-chain prover (required for SNARK_GROTH16 proofs)
+  optional string prover_address = 6;
 }
 
 message ProveBlockResponse {
@@ -36,15 +39,6 @@ enum ReceiptType {
   RECEIPT_TYPE_SNARK = 2;
 }
 
-enum ProofJobStatus {
-  PROOF_JOB_STATUS_UNSPECIFIED = 0;
-  PROOF_JOB_STATUS_CREATED = 1;
-  PROOF_JOB_STATUS_PENDING = 2;
-  PROOF_JOB_STATUS_RUNNING = 3;
-  PROOF_JOB_STATUS_SUCCEEDED = 4;
-  PROOF_JOB_STATUS_FAILED = 5;
-}
-
 message GetProofRequest {
   string session_id = 1;
   // Optional: specify which receipt type to return (STARK or SNARK)
@@ -53,7 +47,16 @@ message GetProofRequest {
 }
 
 message GetProofResponse {
-  ProofJobStatus status = 1;
+  enum Status {
+    STATUS_UNSPECIFIED = 0;
+    STATUS_CREATED = 1;
+    STATUS_PENDING = 2;
+    STATUS_RUNNING = 3;
+    STATUS_SUCCEEDED = 4;
+    STATUS_FAILED = 5;
+  }
+
+  Status status = 1;
   bytes receipt = 2; // the actual zk proof, only populated if status is SUCCEEDED
-  optional string error_message = 3; // populated when status is FAILED
+  optional string error_message = 3; // populated when status is STATUS_FAILED
 }

--- a/crates/proof/zk/client/src/client.rs
+++ b/crates/proof/zk/client/src/client.rs
@@ -8,9 +8,10 @@ use tracing::{debug, warn};
 use url::Url;
 
 use crate::{
+    ProofJobStatus,
     error::ZkProofError,
     proto::{
-        GetProofRequest, GetProofResponse, ProofJobStatus, ProveBlockRequest, ProveBlockResponse,
+        GetProofRequest, GetProofResponse, ProveBlockRequest, ProveBlockResponse,
         prover_service_client::ProverServiceClient,
     },
 };

--- a/crates/proof/zk/client/src/lib.rs
+++ b/crates/proof/zk/client/src/lib.rs
@@ -21,8 +21,8 @@ mod proto {
 #[cfg(feature = "server")]
 pub use proto::prover_service_server;
 pub use proto::{
-    GetProofRequest, GetProofResponse, ProofJobStatus, ProofType, ProveBlockRequest,
-    ProveBlockResponse, ReceiptType,
+    GetProofRequest, GetProofResponse, ProofType, ProveBlockRequest, ProveBlockResponse,
+    ReceiptType, get_proof_response::Status as ProofJobStatus,
 };
 
 mod client;

--- a/crates/proof/zk/client/tests/mock_provider.rs
+++ b/crates/proof/zk/client/tests/mock_provider.rs
@@ -56,8 +56,9 @@ async fn mock_prove_block_returns_session_id() {
         start_block_number: 100,
         number_of_blocks_to_prove: 1,
         sequence_window: None,
-        proof_type: ProofType::KailuaBentoStark.into(),
+        proof_type: ProofType::GenericZkvmClusterCompressed.into(),
         session_id: None,
+        prover_address: None,
     };
 
     let response = provider.prove_block(request).await.expect("prove_block should succeed");

--- a/crates/proof/zk/db/src/models.rs
+++ b/crates/proof/zk/db/src/models.rs
@@ -142,13 +142,30 @@ pub enum ProofType {
     /// Compressed proof generated via generic zkVM cluster.
     #[sqlx(rename = "generic_zkvm_cluster_compressed")]
     GenericZkvmClusterCompressed,
+    /// SNARK Groth16 proof generated via generic zkVM cluster.
+    #[sqlx(rename = "generic_zkvm_cluster_snark_groth16")]
+    GenericZkvmClusterSnarkGroth16,
 }
 
 impl ProofType {
+    /// Proto discriminant for `PROOF_TYPE_GENERIC_ZKVM_CLUSTER_COMPRESSED`.
+    pub const PROTO_COMPRESSED: i32 = 3;
+    /// Proto discriminant for `PROOF_TYPE_GENERIC_ZKVM_CLUSTER_SNARK_GROTH16`.
+    pub const PROTO_SNARK_GROTH16: i32 = 4;
+
+    /// Returns the proto wire value for this proof type.
+    pub const fn proto_i32(&self) -> i32 {
+        match self {
+            Self::GenericZkvmClusterCompressed => Self::PROTO_COMPRESSED,
+            Self::GenericZkvmClusterSnarkGroth16 => Self::PROTO_SNARK_GROTH16,
+        }
+    }
+
     /// Convert enum to static string representation
     pub const fn as_str(&self) -> &'static str {
         match self {
             Self::GenericZkvmClusterCompressed => "generic_zkvm_cluster_compressed",
+            Self::GenericZkvmClusterSnarkGroth16 => "generic_zkvm_cluster_snark_groth16",
         }
     }
 }
@@ -165,6 +182,7 @@ impl TryFrom<&str> for ProofType {
     fn try_from(s: &str) -> Result<Self, Self::Error> {
         match s {
             "generic_zkvm_cluster_compressed" => Ok(Self::GenericZkvmClusterCompressed),
+            "generic_zkvm_cluster_snark_groth16" => Ok(Self::GenericZkvmClusterSnarkGroth16),
             other => Err(format!("Unknown proof type: {other}")),
         }
     }
@@ -176,7 +194,8 @@ impl TryFrom<i32> for ProofType {
 
     fn try_from(value: i32) -> Result<Self, Self::Error> {
         match value {
-            3 => Ok(Self::GenericZkvmClusterCompressed),
+            Self::PROTO_COMPRESSED => Ok(Self::GenericZkvmClusterCompressed),
+            Self::PROTO_SNARK_GROTH16 => Ok(Self::GenericZkvmClusterSnarkGroth16),
             _ => Err(format!("Unknown proof type: {value}")),
         }
     }
@@ -341,10 +360,11 @@ mod tests {
     #[test]
     fn test_proof_type_try_from_proto() {
         assert_eq!(ProofType::try_from(3).unwrap(), ProofType::GenericZkvmClusterCompressed);
+        assert_eq!(ProofType::try_from(4).unwrap(), ProofType::GenericZkvmClusterSnarkGroth16);
 
         assert!(ProofType::try_from(0).is_err());
         assert!(ProofType::try_from(1).is_err());
         assert!(ProofType::try_from(2).is_err());
-        assert!(ProofType::try_from(4).is_err());
+        assert!(ProofType::try_from(5).is_err());
     }
 }

--- a/crates/proof/zk/db/src/models.rs
+++ b/crates/proof/zk/db/src/models.rs
@@ -264,6 +264,8 @@ pub struct CreateProofRequest {
     pub sequence_window: Option<u64>,
     /// Type of proof to generate.
     pub proof_type: ProofType,
+    /// Ethereum address of the on-chain prover (required for SNARK Groth16 proofs).
+    pub prover_address: Option<String>,
 }
 
 /// Parameters for creating a new proof session

--- a/crates/proof/zk/db/src/repo.rs
+++ b/crates/proof/zk/db/src/repo.rs
@@ -68,6 +68,7 @@ impl ProofRequestRepo {
             "number_of_blocks_to_prove": req.number_of_blocks_to_prove,
             "sequence_window": req.sequence_window,
             "proof_type": req.proof_type.as_str(),
+            "prover_address": req.prover_address,
         });
 
         // Start transaction

--- a/crates/proof/zk/service/src/backends/traits.rs
+++ b/crates/proof/zk/service/src/backends/traits.rs
@@ -59,7 +59,9 @@ impl std::str::FromStr for BackendType {
 impl From<ProofType> for BackendType {
     fn from(proof_type: ProofType) -> Self {
         match proof_type {
-            ProofType::GenericZkvmClusterCompressed => Self::GenericZkvm,
+            ProofType::GenericZkvmClusterCompressed | ProofType::GenericZkvmClusterSnarkGroth16 => {
+                Self::GenericZkvm
+            }
         }
     }
 }
@@ -210,6 +212,10 @@ mod tests {
 
         assert_eq!(
             BackendType::from(ProofType::GenericZkvmClusterCompressed),
+            BackendType::GenericZkvm
+        );
+        assert_eq!(
+            BackendType::from(ProofType::GenericZkvmClusterSnarkGroth16),
             BackendType::GenericZkvm
         );
     }

--- a/crates/proof/zk/service/src/server/prove_block.rs
+++ b/crates/proof/zk/service/src/server/prove_block.rs
@@ -20,14 +20,8 @@ impl ProverServiceServer {
             "Attempting to prove base block(s)",
         );
 
-        let proof_type = match prove_block_request.proof_type {
-            3 => ProofType::GenericZkvmClusterCompressed,
-            _ => {
-                return Err(Status::invalid_argument(
-                    "Invalid proof_type: must be PROOF_TYPE_GENERIC_ZKVM_CLUSTER_COMPRESSED (3)",
-                ));
-            }
-        };
+        let proof_type = ProofType::try_from(prove_block_request.proof_type)
+            .map_err(|e| Status::invalid_argument(format!("Invalid proof_type: {e}")))?;
 
         let db_request = CreateProofRequest {
             start_block_number: prove_block_request.start_block_number,

--- a/crates/proof/zk/service/src/server/prove_block.rs
+++ b/crates/proof/zk/service/src/server/prove_block.rs
@@ -23,11 +23,20 @@ impl ProverServiceServer {
         let proof_type = ProofType::try_from(prove_block_request.proof_type)
             .map_err(|e| Status::invalid_argument(format!("Invalid proof_type: {e}")))?;
 
+        if proof_type == ProofType::GenericZkvmClusterSnarkGroth16
+            && prove_block_request.prover_address.is_none()
+        {
+            return Err(Status::invalid_argument(
+                "prover_address is required for SNARK_GROTH16 proofs",
+            ));
+        }
+
         let db_request = CreateProofRequest {
             start_block_number: prove_block_request.start_block_number,
             number_of_blocks_to_prove: prove_block_request.number_of_blocks_to_prove,
             sequence_window: prove_block_request.sequence_window,
             proof_type,
+            prover_address: prove_block_request.prover_address,
         };
 
         let proof_request_id = self

--- a/crates/proof/zk/service/src/worker/prover_worker_pool.rs
+++ b/crates/proof/zk/service/src/worker/prover_worker_pool.rs
@@ -21,28 +21,25 @@ struct ProveBlockRequestParams {
     number_of_blocks_to_prove: u64,
     sequence_window: Option<u64>,
     proof_type: String,
+    prover_address: Option<String>,
 }
 
 impl ProveBlockRequestParams {
-    /// Convert into proto `ProveBlockRequest`, consuming `self`.
-    fn into_proto(self) -> anyhow::Result<ProveBlockRequest> {
-        let proof_type = match self.proof_type.as_str() {
-            "generic_zkvm_cluster_compressed" => 3,
-            _ => {
-                return Err(anyhow::anyhow!(
-                    "Invalid proof_type: {}. Must be 'generic_zkvm_cluster_compressed'",
-                    self.proof_type
-                ));
-            }
-        };
+    /// Convert into proto `ProveBlockRequest` and the parsed [`ProofType`], consuming `self`.
+    fn into_proto(self) -> anyhow::Result<(ProveBlockRequest, ProofType)> {
+        let proof_type =
+            ProofType::try_from(self.proof_type.as_str()).map_err(|e| anyhow::anyhow!(e))?;
 
-        Ok(ProveBlockRequest {
+        let request = ProveBlockRequest {
             start_block_number: self.start_block_number,
             number_of_blocks_to_prove: self.number_of_blocks_to_prove,
             sequence_window: self.sequence_window,
-            proof_type,
+            proof_type: proof_type.proto_i32(),
             session_id: None,
-        })
+            prover_address: self.prover_address,
+        };
+
+        Ok((request, proof_type))
     }
 }
 
@@ -101,24 +98,14 @@ impl TaskQueue for ProverWorkerPool {
                 anyhow::anyhow!("Failed to deserialize ProveBlockRequestParams: {e}")
             })?;
 
-        // Convert to proto (integer proof_type)
-        let params = params_intermediate.into_proto().map_err(|e| {
+        // Convert to proto (integer proof_type) and extract the parsed ProofType
+        let (params, proof_type) = params_intermediate.into_proto().map_err(|e| {
             error!(
                 proof_request_id = %proof_request_id,
                 error = %e,
                 "Failed to convert to ProveBlockRequest"
             );
             e
-        })?;
-
-        // Convert proto proof type to database enum, then to backend type
-        let proof_type = ProofType::try_from(params.proof_type).map_err(|e| {
-            error!(
-                proof_request_id = %proof_request_id,
-                error = %e,
-                "Invalid proof type"
-            );
-            anyhow::anyhow!(e)
         })?;
         let backend_type: BackendType = proof_type.into();
 


### PR DESCRIPTION
## Summary
- Add `GenericZkvmClusterSnarkGroth16` proof type variant across proto, DB models, and service backends to support on-chain SNARK Groth16 proofs.
- Extend `ProveBlockRequest` with an optional `prover_address` field required for Groth16 proof generation, and propagate it through the challenger driver and worker pool.
- Deprecate unused Kailua proof types (`PROOF_TYPE_KAILUA_BENTO_STARK`, `PROOF_TYPE_KAILUA_BENTO_SNARK`) via proto `reserved` and nest `ProofJobStatus` inside `GetProofResponse` as `Status`.
- Refactor hardcoded proof-type match arms to use `TryFrom` conversions consistently, and add proto-constant helpers (`PROTO_COMPRESSED`, `PROTO_SNARK_GROTH16`, `proto_i32()`) on `ProofType`.
- Add structured `debug!` tracing with calldata length for challenge submission and TEE signer registration/deregistration.
- Make `derive_session_id` public and re-export from `base-challenger` lib.