### PR TITLE
fix(payload): drop useless_let_if_seq allow and inline extra_data

### DIFF
--- a/crates/execution/payload/src/lib.rs
+++ b/crates/execution/payload/src/lib.rs
@@ -6,7 +6,6 @@
 )]
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
 #![cfg_attr(docsrs, feature(doc_cfg))]
-#![allow(clippy::useless_let_if_seq)]
 
 extern crate alloc;
 

--- a/crates/execution/payload/src/payload.rs
+++ b/crates/execution/payload/src/payload.rs
@@ -450,29 +450,27 @@ where
         parent: &SealedHeader<H>,
         chain_spec: &ChainSpec,
     ) -> Result<Self, PayloadBuilderError> {
-        let extra_data = if chain_spec.is_jovian_active_at_timestamp(attributes.timestamp()) {
-            attributes
-                .get_jovian_extra_data(
-                    chain_spec.base_fee_params_at_timestamp(attributes.timestamp()),
-                )
-                .map_err(PayloadBuilderError::other)?
-        } else if chain_spec.is_holocene_active_at_timestamp(attributes.timestamp()) {
-            attributes
-                .get_holocene_extra_data(
-                    chain_spec.base_fee_params_at_timestamp(attributes.timestamp()),
-                )
-                .map_err(PayloadBuilderError::other)?
-        } else {
-            Default::default()
-        };
-
         Ok(Self {
             timestamp: attributes.timestamp(),
             suggested_fee_recipient: attributes.suggested_fee_recipient(),
             prev_randao: attributes.prev_randao(),
             gas_limit: attributes.gas_limit.unwrap_or_else(|| parent.gas_limit()),
             parent_beacon_block_root: attributes.parent_beacon_block_root(),
-            extra_data,
+            extra_data: if chain_spec.is_jovian_active_at_timestamp(attributes.timestamp()) {
+                attributes
+                    .get_jovian_extra_data(
+                        chain_spec.base_fee_params_at_timestamp(attributes.timestamp()),
+                    )
+                    .map_err(PayloadBuilderError::other)?
+            } else if chain_spec.is_holocene_active_at_timestamp(attributes.timestamp()) {
+                attributes
+                    .get_holocene_extra_data(
+                        chain_spec.base_fee_params_at_timestamp(attributes.timestamp()),
+                    )
+                    .map_err(PayloadBuilderError::other)?
+            } else {
+                Default::default()
+            },
         })
     }
 }


### PR DESCRIPTION
## Summary

- Remove crate-level `#![allow(clippy::useless_let_if_seq)]` from `crates/execution/payload/src/lib.rs`.
- Refactor `OpNextBlockEnvAttributes::build_next_env` in `crates/execution/payload/src/payload.rs` to compute `extra_data` inline in the `Ok(Self { ... })` initializer instead of using an intermediate `let`.
- Behavior is unchanged; this satisfies Clippy without suppressing the lint for the whole crate.

## Motivation

- Prefer fixing the triggering pattern over blanket lint suppression at the crate root.

## Risk

- Low. Equivalent control flow and error propagation (`?`) are preserved.

## Test Plan

- [x] `cargo clippy -p base-execution-payload-builder --all-targets`