### PR TITLE
docs(builder-core): remove missing_docs allow and document public API

### DIFF
--- a/crates/builder/core/src/execution.rs
+++ b/crates/builder/core/src/execution.rs
@@ -73,14 +73,18 @@ pub struct TxResources {
 /// These can operate in dry-run or enforcement mode via the execution metering mode setting.
 #[derive(Debug, Error, Clone)]
 pub enum ExecutionMeteringLimitExceeded {
+    /// Per-transaction execution time exceeded the predicted limit (`tx_time_us`, `limit_us`).
     #[error("transaction execution time exceeded: tx_time_us={0} limit_us={1}")]
     TransactionExecutionTime(u128, u128),
+    /// Flashblock cumulative execution time would exceed the budget (`flashblock_used_us`, `tx_time_us`, `limit_us`).
     #[error(
         "flashblock execution time exceeded: flashblock_used_us={0} tx_time_us={1} limit_us={2}"
     )]
     FlashblockExecutionTime(u128, u128, u128),
+    /// Per-transaction state-root time exceeded the predicted limit (`tx_time_us`, `limit_us`).
     #[error("transaction state root time exceeded: tx_time_us={0} limit_us={1}")]
     TransactionStateRootTime(u128, u128),
+    /// Cumulative block state-root time would exceed the block budget (`cumulative_us`, `tx_time_us`, `block_limit_us`).
     #[error("block state root time exceeded: cumulative_us={0} tx_time_us={1} block_limit_us={2}")]
     BlockStateRootTime(u128, u128, u128),
 }
@@ -190,6 +194,7 @@ pub enum TxnOutcome {
     RevertedAndExcluded,
 }
 
+/// Accumulated execution state while building a block (transactions, receipts, limits, fees).
 #[derive(Default, Debug)]
 pub struct ExecutionInfo {
     /// All executed transactions (unrecovered).

--- a/crates/builder/core/src/flashblocks/best_txs.rs
+++ b/crates/builder/core/src/flashblocks/best_txs.rs
@@ -37,6 +37,7 @@ where
     T: PoolTransaction,
     I: Iterator<Item = Arc<ValidPoolTransaction<T>>>,
 {
+    /// Wraps Reth's best-transactions iterator for flashblock builds.
     pub fn new(inner: reth_payload_util::BestPayloadTransactions<T, I>) -> Self {
         Self { inner, committed_transactions: Default::default() }
     }

--- a/crates/builder/core/src/flashblocks/context.rs
+++ b/crates/builder/core/src/flashblocks/context.rs
@@ -96,6 +96,7 @@ impl FlashblockSelectionOutcome {
     }
 }
 
+/// Per-flashblock counters for transaction selection, rejections, and fee bounds.
 #[derive(Debug, Default)]
 pub struct FlashblockDiagnostics {
     /// Whether the flashblock timer or block cancel fired during execution.

--- a/crates/builder/core/src/flashblocks/generator.rs
+++ b/crates/builder/core/src/flashblocks/generator.rs
@@ -303,6 +303,7 @@ where
     Builder::Attributes: Unpin + Clone,
     Builder::BuiltPayload: Unpin + Clone,
 {
+    /// Spawns a blocking payload build and stores a oneshot for completion.
     pub fn spawn_build_job(&mut self) {
         let builder = self.builder.clone();
         let payload_config = self.config.clone();
@@ -372,6 +373,7 @@ impl<T> std::fmt::Debug for ResolvePayload<T> {
 }
 
 impl<T> ResolvePayload<T> {
+    /// Builds a future that completes when `future` yields a value from the cell.
     pub const fn new(future: WaitForValue<T>) -> Self {
         Self { future }
     }
@@ -398,16 +400,19 @@ pub struct BlockCell<T> {
 }
 
 impl<T: Clone> BlockCell<T> {
+    /// Creates an empty cell; use [`BlockCell::set`] and [`BlockCell::wait_for_value`].
     pub fn new() -> Self {
         Self { inner: Arc::new(Mutex::new(None)), notify: Arc::new(Notify::new()) }
     }
 
+    /// Stores `value` and notifies one waiter.
     pub fn set(&self, value: T) {
         let mut inner = self.inner.lock();
         *inner = Some(value);
         self.notify.notify_one();
     }
 
+    /// Returns a clone of the current value, if any.
     pub fn get(&self) -> Option<T> {
         let inner = self.inner.lock();
         inner.clone()

--- a/crates/builder/core/src/lib.rs
+++ b/crates/builder/core/src/lib.rs
@@ -1,4 +1,3 @@
-#![allow(missing_docs)]
 #![doc = include_str!("../README.md")]
 #![doc(
     html_logo_url = "https://avatars.githubusercontent.com/u/16627100?s=200&v=4",

--- a/crates/builder/core/src/metrics.rs
+++ b/crates/builder/core/src/metrics.rs
@@ -285,6 +285,7 @@ impl BuilderMetrics {
         }
     }
 
+    /// Records payload-builder simulation counters and histograms from a build attempt.
     pub fn set_payload_builder_metrics(
         &self,
         payload_transaction_simulation_time: impl IntoF64 + Copy,

--- a/crates/builder/core/src/traits.rs
+++ b/crates/builder/core/src/traits.rs
@@ -10,6 +10,7 @@ use reth_payload_util::PayloadTransactions;
 use reth_provider::{BlockReaderIdExt, ChainSpecProvider, StateProviderFactory};
 use reth_transaction_pool::{TransactionPool, TransactionPoolExt};
 
+/// [`FullNodeTypes`] specialized for Base (`OpEngineTypes`, `OpChainSpec`, `OpPrimitives`).
 pub trait NodeBounds:
     FullNodeTypes<
     Types: NodeTypes<Payload = OpEngineTypes, ChainSpec = OpChainSpec, Primitives = OpPrimitives>,
@@ -17,7 +18,8 @@ pub trait NodeBounds:
 {
 }
 
-impl<T> NodeBounds for T where
+impl<T> NodeBounds for T
+where
     T: FullNodeTypes<
         Types: NodeTypes<
             Payload = OpEngineTypes,
@@ -28,6 +30,7 @@ impl<T> NodeBounds for T where
 {
 }
 
+/// [`TransactionPool`] bounds for Base (`OpPooledTx`, bundles, pool extensions).
 pub trait PoolBounds:
     TransactionPool<Transaction: OpPooledTx<Consensus = OpTransactionSigned> + BundleTransaction>
     + TransactionPoolExt
@@ -49,6 +52,7 @@ where
 {
 }
 
+/// Provider and reader traits used by the builder (`StateProviderFactory`, `OpChainSpec`, headers).
 pub trait ClientBounds:
     StateProviderFactory
     + ChainSpecProvider<ChainSpec = OpChainSpec>
@@ -65,6 +69,7 @@ impl<T> ClientBounds for T where
 {
 }
 
+/// [`PayloadTransactions`] stream whose items are Base pooled transactions (optionally bundled).
 pub trait PayloadTxsBounds:
     PayloadTransactions<Transaction: OpPooledTx<Consensus = OpTransactionSigned> + BundleTransaction>
 {


### PR DESCRIPTION
- Prefer documenting exported API over blanket lint suppression, consistent with repo guidelines.
- Remove crate-level `#![allow(missing_docs)]` from `crates/builder/core/src/lib.rs`.
- Add brief `rustdoc` for previously undocumented public items so the workspace `missing-docs` lint stays clean without suppressing it.


- [x] `cargo check -p base-builder-core`
- [x] `cargo clippy -p base-builder-core`