### PR TITLE
feat(batcher): add --stopped flag to start batcher paused

### DIFF
--- a/bin/batcher/src/cli.rs
+++ b/bin/batcher/src/cli.rs
@@ -128,6 +128,10 @@ pub(crate) struct BatcherArgs {
     )]
     pub resubmission_timeout_secs: u64,
 
+    /// Start the batcher in a paused state until resumed via the admin API.
+    #[arg(long = "stopped", env = "OP_BATCHER_STOPPED")]
+    pub stopped: bool,
+
     /// DA backlog threshold in bytes at which throttling activates.
     ///
     /// When the estimated unsubmitted DA backlog exceeds this value, the batcher
@@ -195,6 +199,7 @@ impl BatcherArgs {
             max_pending_transactions: self.max_pending_transactions,
             num_confirmations: self.num_confirmations,
             resubmission_timeout: Duration::from_secs(self.resubmission_timeout_secs),
+            stopped: self.stopped,
             throttle: if self.no_throttle {
                 None
             } else {

--- a/crates/batcher/core/src/driver.rs
+++ b/crates/batcher/core/src/driver.rs
@@ -113,6 +113,12 @@ where
         self
     }
 
+    /// Set the initial paused state for block ingestion.
+    pub const fn with_paused(mut self, paused: bool) -> Self {
+        self.paused = paused;
+        self
+    }
+
     /// Wire an admin command channel into the driver.
     ///
     /// When set, the driver processes admin commands as part of its main

--- a/crates/batcher/core/src/driver.rs
+++ b/crates/batcher/core/src/driver.rs
@@ -55,7 +55,7 @@ where
     /// Maximum wall-clock time to wait for in-flight submissions to settle
     /// when draining on cancellation or source exhaustion.
     drain_timeout: Duration,
-    /// Whether block ingestion is currently paused via the admin API.
+    /// Whether block ingestion is currently paused.
     paused: bool,
     /// Admin command channel, wired in via [`Self::with_admin_rx`].
     admin_rx: Option<mpsc::Receiver<AdminCommand>>,
@@ -114,6 +114,9 @@ where
     }
 
     /// Set the initial paused state for block ingestion.
+    ///
+    /// The full paused-state transition is applied when [`run`](Self::run)
+    /// starts, so startup semantics match the admin pause path.
     pub const fn with_paused(mut self, paused: bool) -> Self {
         self.paused = paused;
         self
@@ -138,6 +141,10 @@ where
     /// When draining (after cancellation or source exhaustion), the I/O phase is
     /// replaced by a bounded drain of all in-flight receipts.
     pub async fn run(mut self) -> Result<(), BatchDriverError> {
+        if self.paused {
+            self.enter_paused_state("startup");
+        }
+
         let mut draining = false;
         loop {
             self.drain_encoding()?;
@@ -196,6 +203,18 @@ where
                 }
             }
         }
+    }
+
+    /// Apply the full paused-state transition.
+    ///
+    /// This matches the semantics of the admin pause path: in-flight
+    /// submissions are discarded, the pipeline is reset, and new `Block` /
+    /// `Flush` source events are ignored until resume.
+    fn enter_paused_state(&mut self, reason: &'static str) {
+        self.submissions.discard();
+        self.pipeline.reset();
+        self.paused = true;
+        info!(paused = true, reason, "batcher entered paused state");
     }
 
     /// Drain encoding steps synchronously up to [`Self::STEP_BUDGET`].
@@ -263,8 +282,9 @@ where
     /// arm so control-plane operations (pause, resume, flush) are never starved
     /// by sustained block throughput.
     ///
-    /// [`AdminCommand::Pause`] immediately discards in-flight submissions and
-    /// resets the pipeline, then drops `Block` and `Flush` source events until
+    /// [`AdminCommand::Pause`] applies the same paused-state transition used
+    /// for startup with `with_paused(true)`: discard in-flight submissions,
+    /// reset the pipeline, then drop `Block` and `Flush` source events until
     /// [`AdminCommand::Resume`] is received. Reorg events propagate regardless
     /// of pause state. On resume the source is reset to catch up sequentially
     /// from the last known safe L2 head.
@@ -282,10 +302,7 @@ where
                     match cmd {
                         AdminCommand::Flush => return Ok(DriverEvent::Flush),
                         AdminCommand::Pause => {
-                            self.submissions.discard();
-                            self.pipeline.reset();
-                            self.paused = true;
-                            info!(paused = true, "batcher paused via admin");
+                            self.enter_paused_state("admin");
                         }
                         AdminCommand::Resume => {
                             let safe_head =

--- a/crates/batcher/core/tests/pause_resume.rs
+++ b/crates/batcher/core/tests/pause_resume.rs
@@ -123,6 +123,35 @@ fn test_resume_triggers_catchup_from_safe_head() {
     });
 }
 
+/// Starting paused must apply the same reset semantics as `AdminCommand::Pause`
+/// and report `paused = true` immediately via the admin API.
+#[test]
+fn test_starting_paused_applies_pause_semantics() {
+    Runner::start(Config::seeded(0), |ctx| async move {
+        let recorded = Arc::new(Mutex::new(Recorded::default()));
+        let pipeline = TrackingPipeline::new(Arc::clone(&recorded));
+        let (admin_handle, admin_rx) = AdminHandle::channel();
+
+        let driver =
+            DriverFixture::build(ctx.clone(), pipeline, ImmediateConfirmTxManager { l1_block: 1 })
+                .with_paused(true)
+                .with_admin_rx(admin_rx);
+        let handle = ctx.spawn(driver.run());
+
+        ctx.sleep(Duration::from_millis(10)).await;
+        let status = admin_handle.get_status().await.unwrap();
+        ctx.cancel();
+
+        assert!(handle.await.unwrap().is_ok());
+        assert!(status.paused, "driver must report paused=true when started paused");
+        assert_eq!(
+            recorded.lock().unwrap().resets,
+            1,
+            "startup paused state must apply the same pipeline reset semantics as admin pause"
+        );
+    });
+}
+
 /// While paused, `Block` and `Flush` source events must be dropped; the
 /// pipeline must not receive any blocks.
 #[test]

--- a/crates/batcher/service/src/config.rs
+++ b/crates/batcher/service/src/config.rs
@@ -48,6 +48,8 @@ pub struct BatcherConfig {
     pub num_confirmations: usize,
     /// Timeout before resubmitting a transaction.
     pub resubmission_timeout: Duration,
+    /// Start the batcher in a paused state.
+    pub stopped: bool,
     /// Throttle configuration (optional).
     pub throttle: Option<ThrottleConfig>,
     /// Socket address for the admin JSON-RPC API.
@@ -71,6 +73,7 @@ impl Default for BatcherConfig {
             max_pending_transactions: 1,
             num_confirmations: 1,
             resubmission_timeout: Duration::from_secs(48),
+            stopped: false,
             throttle: Some(ThrottleConfig::default()),
             admin_addr: None,
         }

--- a/crates/batcher/service/src/service.rs
+++ b/crates/batcher/service/src/service.rs
@@ -425,7 +425,8 @@ impl BatcherService {
             DaThrottle::new(throttle, throttle_client),
             l1_head_source,
         )
-        .with_safe_head_rx(safe_head_rx);
+        .with_safe_head_rx(safe_head_rx)
+        .with_paused(self.config.stopped);
 
         let admin_server = match self.config.admin_addr {
             Some(addr) => {


### PR DESCRIPTION
## Summary

Adds support for starting the batcher in a paused state, matching the `op-batcher` behavior.

Changes:
- add `stopped: bool` to the batcher service config
- add `--stopped` CLI flag with env `OP_BATCHER_STOPPED`
- wire the flag from CLI args into service config
- initialize `BatchDriver` with `paused = true` when `stopped` is set


## Notes

- no dedicated test was added for this change
- behavior is implemented via the existing pause/resume mechanism in `BatchDriver`

Closes #1608 