### PR TITLE
chore(devnet): add set -euo pipefail to consistent-sender script

### DIFF
--- a/etc/scripts/devnet/load/consistent-sender.sh
+++ b/etc/scripts/devnet/load/consistent-sender.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 # Sends consistent transactions every 100-200ms to fill gaps between contender bursts
+set -euo pipefail
 
 RPC_URL="${RPC_URL:-${L2_BUILDER_RPC_URL:-http://localhost:7545}}"
 PRIVATE_KEY="${PRIVATE_KEY:-0x2a871d0798f97d79848a013d4936a73bf4cc922c825d33c1cf7073dff6d409c6}"


### PR DESCRIPTION
- This script does not `source` a shared `common.sh` that already enables strict mode, so it previously ran without `-e`/`-u`/`-pipefail`. The change makes undefined variables, pipeline failures, and non-zero exits fail fast.
- No intentional change to behavior (still loops with async `cast send`).