### PR TITLE
fix(proof): narrow dead_code allow in std-fpvm linux helper

### DIFF
--- a/crates/proof/std-fpvm/src/linux.rs
+++ b/crates/proof/std-fpvm/src/linux.rs
@@ -3,8 +3,14 @@
 use crate::errors::{IOError, IOResult};
 
 /// Converts a return value from a syscall into a [`IOResult`] type.
+///
+/// Only referenced from MIPS64/RISC-V syscall code; other targets compile this crate without
+/// calling it (unit tests still exercise it under `cfg(test)`).
 #[inline(always)]
-#[allow(unused)]
+#[cfg_attr(
+    not(any(target_arch = "mips64", target_arch = "riscv64")),
+    allow(dead_code)
+)]
 pub(crate) const fn from_ret(value: usize) -> IOResult<usize> {
     if value > -4096isize as usize {
         // Truncation of the error value is guaranteed to never occur due to


### PR DESCRIPTION
`fix(proof): narrow dead_code allow in std-fpvm linux helper`

- Narrow lint suppression for `from_ret` in `linux.rs`: replace `#[allow(unused)]` with `cfg_attr` + `dead_code` only when not building for mips64/riscv64; add a one-line doc note.
- Add a short doc note: the helper is used by MIPS64/RISC-V syscall wrappers; on other targets it may be unused in normal builds but remains covered by unit tests under `cfg(test)`.


**Test plan**
- `cargo check -p base-proof-std-fpvm`
- `cargo test -p base-proof-std-fpvm --lib`
- `cargo clippy -p base-proof-std-fpvm -- -D warnings`