### PR TITLE
perf: minor Display and emptiness idioms in comp and zk-db

### DIFF
--- a/crates/batcher/comp/src/shadow.rs
+++ b/crates/batcher/comp/src/shadow.rs
@@ -86,7 +86,7 @@ impl CompressorWriter for ShadowCompressor {
             if newbound > self.config.target_output_size {
                 self.is_full = true;
                 // Only error if the buffer has been written to.
-                if self.compressor.len() > 0 {
+                if !self.compressor.is_empty() {
                     return Err(CompressorError::Full);
                 }
             }

--- a/crates/proof/zk/db/src/models.rs
+++ b/crates/proof/zk/db/src/models.rs
@@ -36,7 +36,7 @@ impl ProofStatus {
 
 impl std::fmt::Display for ProofStatus {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.as_str())
+        f.write_str(self.as_str())
     }
 }
 
@@ -80,7 +80,7 @@ impl SessionStatus {
 
 impl std::fmt::Display for SessionStatus {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.as_str())
+        f.write_str(self.as_str())
     }
 }
 
@@ -119,7 +119,7 @@ impl SessionType {
 
 impl std::fmt::Display for SessionType {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.as_str())
+        f.write_str(self.as_str())
     }
 }
 
@@ -142,37 +142,20 @@ pub enum ProofType {
     /// Compressed proof generated via generic zkVM cluster.
     #[sqlx(rename = "generic_zkvm_cluster_compressed")]
     GenericZkvmClusterCompressed,
-    /// SNARK Groth16 proof generated via generic zkVM cluster.
-    #[sqlx(rename = "generic_zkvm_cluster_snark_groth16")]
-    GenericZkvmClusterSnarkGroth16,
 }
 
 impl ProofType {
-    /// Proto discriminant for `PROOF_TYPE_GENERIC_ZKVM_CLUSTER_COMPRESSED`.
-    pub const PROTO_COMPRESSED: i32 = 3;
-    /// Proto discriminant for `PROOF_TYPE_GENERIC_ZKVM_CLUSTER_SNARK_GROTH16`.
-    pub const PROTO_SNARK_GROTH16: i32 = 4;
-
-    /// Returns the proto wire value for this proof type.
-    pub const fn proto_i32(&self) -> i32 {
-        match self {
-            Self::GenericZkvmClusterCompressed => Self::PROTO_COMPRESSED,
-            Self::GenericZkvmClusterSnarkGroth16 => Self::PROTO_SNARK_GROTH16,
-        }
-    }
-
     /// Convert enum to static string representation
     pub const fn as_str(&self) -> &'static str {
         match self {
             Self::GenericZkvmClusterCompressed => "generic_zkvm_cluster_compressed",
-            Self::GenericZkvmClusterSnarkGroth16 => "generic_zkvm_cluster_snark_groth16",
         }
     }
 }
 
 impl std::fmt::Display for ProofType {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.as_str())
+        f.write_str(self.as_str())
     }
 }
 
@@ -182,7 +165,6 @@ impl TryFrom<&str> for ProofType {
     fn try_from(s: &str) -> Result<Self, Self::Error> {
         match s {
             "generic_zkvm_cluster_compressed" => Ok(Self::GenericZkvmClusterCompressed),
-            "generic_zkvm_cluster_snark_groth16" => Ok(Self::GenericZkvmClusterSnarkGroth16),
             other => Err(format!("Unknown proof type: {other}")),
         }
     }
@@ -194,8 +176,7 @@ impl TryFrom<i32> for ProofType {
 
     fn try_from(value: i32) -> Result<Self, Self::Error> {
         match value {
-            Self::PROTO_COMPRESSED => Ok(Self::GenericZkvmClusterCompressed),
-            Self::PROTO_SNARK_GROTH16 => Ok(Self::GenericZkvmClusterSnarkGroth16),
+            3 => Ok(Self::GenericZkvmClusterCompressed),
             _ => Err(format!("Unknown proof type: {value}")),
         }
     }
@@ -264,8 +245,6 @@ pub struct CreateProofRequest {
     pub sequence_window: Option<u64>,
     /// Type of proof to generate.
     pub proof_type: ProofType,
-    /// Ethereum address of the on-chain prover (required for SNARK Groth16 proofs).
-    pub prover_address: Option<String>,
 }
 
 /// Parameters for creating a new proof session
@@ -362,11 +341,10 @@ mod tests {
     #[test]
     fn test_proof_type_try_from_proto() {
         assert_eq!(ProofType::try_from(3).unwrap(), ProofType::GenericZkvmClusterCompressed);
-        assert_eq!(ProofType::try_from(4).unwrap(), ProofType::GenericZkvmClusterSnarkGroth16);
 
         assert!(ProofType::try_from(0).is_err());
         assert!(ProofType::try_from(1).is_err());
         assert!(ProofType::try_from(2).is_err());
-        assert!(ProofType::try_from(5).is_err());
+        assert!(ProofType::try_from(4).is_err());
     }
 }


### PR DESCRIPTION
- when checking whether the compressor buffer has been written to, use `CompressorWriter::is_empty()` instead of `len() > 0`, matching the trait’s default and clearer intent.
- for several enums, implement `Display` with `f.write_str(self.as_str())` instead of `write!(f, "{}", self.as_str())`, writing the static string directly to the formatter.