### PR TITLE
refactor: migrate consensus enginer/providers/rpc/service to define_metrics!

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -62,7 +62,7 @@ checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
 dependencies = [
  "cfg-if",
  "cipher",
- "cpufeatures",
+ "cpufeatures 0.2.17",
 ]
 
 [[package]]
@@ -142,9 +142,9 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "alloy"
-version = "1.7.3"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4973038846323e4e69a433916522195dce2947770076c03078fc21c80ea0f1c4"
+checksum = "50ab0cd8afe573d1f7dc2353698a51b1f93aec362c8211e28cfd3948c6adba39"
 dependencies = [
  "alloy-consensus",
  "alloy-contract",
@@ -165,9 +165,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-chains"
-version = "0.2.32"
+version = "0.2.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9247f0a399ef71aeb68f497b2b8fb348014f742b50d3b83b1e00dfe1b7d64b3d"
+checksum = "f4e9e31d834fe25fe991b8884e4b9f0e59db4a97d86e05d1464d6899c013cd62"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -180,9 +180,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-consensus"
-version = "1.7.3"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0c0dc44157867da82c469c13186015b86abef209bf0e41625e4b68bac61d728"
+checksum = "7f16daaf7e1f95f62c6c3bf8a3fc3d78b08ae9777810c0bb5e94966c7cd57ef0"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -208,9 +208,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-consensus-any"
-version = "1.7.3"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba4cdb42df3871cd6b346d6a938ec2ba69a9a0f49d1f82714bc5c48349268434"
+checksum = "118998d9015332ab1b4720ae1f1e3009491966a0349938a1f43ff45a8a4c6299"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -223,9 +223,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-contract"
-version = "1.7.3"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca63b7125a981415898ffe2a2a696c83696c9c6bdb1671c8a912946bbd8e49e7"
+checksum = "7ac9e0c34dc6bce643b182049cdfcca1b8ce7d9c260cbdd561f511873b7e26cd"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -241,6 +241,7 @@ dependencies = [
  "futures-util",
  "serde_json",
  "thiserror 2.0.18",
+ "tracing",
 ]
 
 [[package]]
@@ -334,9 +335,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-eips"
-version = "1.7.3"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9f7ef09f21bd1e9cb8a686f168cb4a206646804567f0889eadb8dcc4c9288c8"
+checksum = "e6ef28c9fdad22d4eec52d894f5f2673a0895f1e5ef196734568e68c0f6caca8"
 dependencies = [
  "alloy-eip2124",
  "alloy-eip2930",
@@ -356,7 +357,6 @@ dependencies = [
  "serde",
  "serde_with",
  "sha2 0.10.9",
- "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -382,9 +382,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-genesis"
-version = "1.7.3"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c9cf3b99f46615fbf7dc1add0c96553abb7bf88fc9ec70dfbe7ad0b47ba7fe8"
+checksum = "bbf9480307b09d22876efb67d30cadd9013134c21f3a17ec9f93fd7536d38024"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -436,9 +436,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-json-rpc"
-version = "1.7.3"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff42cd777eea61f370c0b10f2648a1c81e0b783066cd7269228aa993afd487f7"
+checksum = "422d110f1c40f1f8d0e5562b0b649c35f345fccb7093d9f02729943dcd1eef71"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
@@ -451,9 +451,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-network"
-version = "1.7.3"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cbca04f9b410fdc51aaaf88433cbac761213905a65fe832058bcf6690585762"
+checksum = "7197a66d94c4de1591cdc16a9bcea5f8cccd0da81b865b49aef97b1b4016e0fa"
 dependencies = [
  "alloy-consensus",
  "alloy-consensus-any",
@@ -477,9 +477,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-network-primitives"
-version = "1.7.3"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42d6d15e069a8b11f56bef2eccbad2a873c6dd4d4c81d04dda29710f5ea52f04"
+checksum = "eb82711d59a43fdfd79727c99f270b974c784ec4eb5728a0d0d22f26716c87ef"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -490,9 +490,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-node-bindings"
-version = "1.7.3"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "091dc8117d84de3a9ac7ec97f2c4d83987e24d485b478d26aa1ec455d7d52f7d"
+checksum = "a9b2fda91b56bb08907cd44c5068130360e027e46a8c17612d386869fa7940be"
 dependencies = [
  "alloy-genesis",
  "alloy-hardforks 0.2.13",
@@ -543,9 +543,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-provider"
-version = "1.7.3"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d181c8cc7cf4805d7e589bf4074d56d55064fa1a979f005a45a62b047616d870"
+checksum = "bf6b18b929ef1d078b834c3631e9c925177f3b23ddc6fa08a722d13047205876"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -579,7 +579,7 @@ dependencies = [
  "lru 0.16.3",
  "parking_lot",
  "pin-project",
- "reqwest 0.12.28",
+ "reqwest 0.13.2",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -591,9 +591,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-pubsub"
-version = "1.7.3"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8bd82953194dec221aa4cbbbb0b1e2df46066fe9d0333ac25b43a311e122d13"
+checksum = "5ad54073131e7292d4e03e1aa2287730f737280eb160d8b579fb31939f558c11"
 dependencies = [
  "alloy-json-rpc",
  "alloy-primitives",
@@ -635,9 +635,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-client"
-version = "1.7.3"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2792758a93ae32a32e9047c843d536e1448044f78422d71bf7d7c05149e103f"
+checksum = "94fcc9604042ca80bd37aa5e232ea1cd851f337e31e2babbbb345bc0b1c30de3"
 dependencies = [
  "alloy-json-rpc",
  "alloy-primitives",
@@ -648,7 +648,7 @@ dependencies = [
  "alloy-transport-ws",
  "futures",
  "pin-project",
- "reqwest 0.12.28",
+ "reqwest 0.13.2",
  "serde",
  "serde_json",
  "tokio",
@@ -661,9 +661,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types"
-version = "1.7.3"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7bdcbf9dfd5eea8bfeb078b1d906da8cd3a39c4d4dbe7a628025648e323611f6"
+checksum = "4faad925d3a669ffc15f43b3deec7fbdf2adeb28a4d6f9cf4bc661698c0f8f4b"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-debug",
@@ -676,9 +676,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-admin"
-version = "1.7.3"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42325c117af3a9e49013f881c1474168db57978e02085fc9853a1c89e0562740"
+checksum = "b38080c2b01ad1bacbd3583cf7f6f800e5e0ffc11eaddaad7321225733a2d818"
 dependencies = [
  "alloy-genesis",
  "alloy-primitives",
@@ -688,9 +688,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-anvil"
-version = "1.7.3"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0a3100b76987c1b1dc81f3abe592b7edc29e92b1242067a69d65e0030b35cf9"
+checksum = "47df51bedb3e6062cb9981187a51e86d0d64a4de66eb0855e9efe6574b044ddf"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -700,9 +700,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-any"
-version = "1.7.3"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd720b63f82b457610f2eaaf1f32edf44efffe03ae25d537632e7d23e7929e1a"
+checksum = "3823026d1ed239a40f12364fac50726c8daf1b6ab8077a97212c5123910429ed"
 dependencies = [
  "alloy-consensus-any",
  "alloy-rpc-types-eth",
@@ -711,9 +711,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-beacon"
-version = "1.7.3"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a22e13215866f5dfd5d3278f4c41f1fad9410dc68ce39022f58593c873c26f8"
+checksum = "f526dbd7bb039327cfd0ccf18c8a29ffd7402616b0c7a0239512bf8417d544c7"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -731,9 +731,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-debug"
-version = "1.7.3"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1b21e1ad18ff1b31ff1030e046462ab8168cf8894e6778cd805c8bdfe2bd649"
+checksum = "2145138f3214928f08cd13da3cb51ef7482b5920d8ac5a02ecd4e38d1a8f6d1e"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -743,9 +743,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-engine"
-version = "1.7.3"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4ac61f03f1edabccde1c687b5b25fff28f183afee64eaa2e767def3929e4457"
+checksum = "bb9b97b6e7965679ad22df297dda809b11cebc13405c1b537e5cffecc95834fa"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -764,9 +764,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-eth"
-version = "1.7.3"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b2dc411f13092f237d2bf6918caf80977fc2f51485f9b90cb2a2f956912c8c9"
+checksum = "59c095f92c4e1ff4981d89e9aa02d5f98c762a1980ab66bec49c44be11349da2"
 dependencies = [
  "alloy-consensus",
  "alloy-consensus-any",
@@ -786,9 +786,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-mev"
-version = "1.7.3"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe85bf3be739126aa593dca9fb3ab13ca93fa7873e6f2247be64d7f2cb15f34a"
+checksum = "8eae9c65ff60dcc262247b6ebb5ad391ddf36d09029802c1768c5723e0cfa2f4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -801,9 +801,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-trace"
-version = "1.7.3"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ad79f1e27e161943b5a4f99fe5534ef0849876214be411e0032c12f38e94daa"
+checksum = "2e5a4d010f86cd4e01e5205ec273911e538e1738e76d8bafe9ecd245910ea5a3"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -815,9 +815,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-txpool"
-version = "1.7.3"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d459f902a2313737bc66d18ed094c25d2aeb268b74d98c26bbbda2aa44182ab0"
+checksum = "942d26a2ca8891b26de4a8529d21091e21c1093e27eb99698f1a86405c76b1ff"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -827,9 +827,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-serde"
-version = "1.7.3"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2ce1e0dbf7720eee747700e300c99aac01b1a95bb93f493a01e78ee28bb1a37"
+checksum = "11ece63b89294b8614ab3f483560c08d016930f842bf36da56bf0b764a15c11e"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -839,9 +839,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer"
-version = "1.7.3"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2425c6f314522c78e8198979c8cbf6769362be4da381d4152ea8eefce383535d"
+checksum = "43f447aefab0f1c0649f71edc33f590992d4e122bc35fb9cdbbf67d4421ace85"
 dependencies = [
  "alloy-primitives",
  "async-trait",
@@ -854,9 +854,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer-local"
-version = "1.7.3"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3ecb71ee53d8d9c3fa7bac17542c8116ebc7a9726c91b1bf333ec3d04f5a789"
+checksum = "f721f4bf2e4812e5505aaf5de16ef3065a8e26b9139ac885862d00b5a55a659a"
 dependencies = [
  "alloy-consensus",
  "alloy-network",
@@ -946,9 +946,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport"
-version = "1.7.3"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa186e560d523d196580c48bf00f1bf62e63041f28ecf276acc22f8b27bb9f53"
+checksum = "8098f965442a9feb620965ba4b4be5e2b320f4ec5a3fff6bfa9e1ff7ef42bed1"
 dependencies = [
  "alloy-json-rpc",
  "auto_impl",
@@ -969,9 +969,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport-http"
-version = "1.7.3"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa501ad58dd20acddbfebc65b52e60f05ebf97c52fa40d1b35e91f5e2da0ad0e"
+checksum = "e8597d36d546e1dab822345ad563243ec3920e199322cb554ce56c8ef1a1e2e7"
 dependencies = [
  "alloy-json-rpc",
  "alloy-rpc-types-engine",
@@ -984,7 +984,7 @@ dependencies = [
  "jsonwebtoken",
  "opentelemetry",
  "opentelemetry-http",
- "reqwest 0.12.28",
+ "reqwest 0.13.2",
  "serde_json",
  "tower",
  "tracing",
@@ -994,9 +994,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport-ipc"
-version = "1.7.3"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2ef85688e5ac2da72afc804e0a1f153a1f309f05a864b1998bbbed7804dbaab"
+checksum = "a1bd98c3870b8a44b79091dde5216a81d58ffbc1fd8ed61b776f9fee0f3bdf20"
 dependencies = [
  "alloy-json-rpc",
  "alloy-pubsub",
@@ -1014,18 +1014,20 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport-ws"
-version = "1.7.3"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9f00445db69d63298e2b00a0ea1d859f00e6424a3144ffc5eba9c31da995e16"
+checksum = "ec3ab7a72b180992881acc112628b7668337a19ce15293ee974600ea7b693691"
 dependencies = [
  "alloy-pubsub",
  "alloy-transport",
  "futures",
  "http 1.4.0",
+ "rustls 0.23.37",
  "serde_json",
  "tokio",
- "tokio-tungstenite 0.26.2",
+ "tokio-tungstenite 0.28.0",
  "tracing",
+ "url",
  "ws_stream_wasm",
 ]
 
@@ -1051,11 +1053,11 @@ dependencies = [
 
 [[package]]
 name = "alloy-tx-macros"
-version = "1.7.3"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fa0c53e8c1e1ef4d01066b01c737fb62fc9397ab52c6e7bb5669f97d281b9bc"
+checksum = "d69722eddcdf1ce096c3ab66cf8116999363f734eb36fe94a148f4f71c85da84"
 dependencies = [
- "darling 0.21.3",
+ "darling 0.23.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -1213,7 +1215,7 @@ checksum = "3c3610892ee6e0cbce8ae2700349fcf8f98adb0dbfbee85aec3c9179d29cc072"
 dependencies = [
  "base64ct",
  "blake2",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "password-hash",
 ]
 
@@ -1645,9 +1647,9 @@ dependencies = [
 
 [[package]]
 name = "astral-tokio-tar"
-version = "0.5.6"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec179a06c1769b1e42e1e2cbe74c7dcdb3d6383c838454d063eaac5bbb7ebbe5"
+checksum = "3c23f3af104b40a3430ccb90ed5f7bd877a8dc5c26fc92fde51a22b40890dcf9"
 dependencies = [
  "filetime",
  "futures-core",
@@ -3352,7 +3354,7 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror 2.0.18",
- "toml 1.0.7+spec-1.1.0",
+ "toml 1.1.0+spec-1.1.0",
  "tracing",
 ]
 
@@ -4700,7 +4702,7 @@ dependencies = [
  "tokio-vsock",
  "tracing",
  "x509-cert",
- "zip 8.3.1",
+ "zip 8.4.0",
 ]
 
 [[package]]
@@ -6140,9 +6142,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.57"
+version = "1.2.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a0dd1ca384932ff3641c8718a02769f1698e7563dc6974ffd03346116310423"
+checksum = "e1e928d4b69e3077709075a938a05ffbedfa53a84c8f766efbf8220bb1ff60e1"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -6185,7 +6187,7 @@ checksum = "c3613f74bd2eac03dad61bd53dbe620703d4371614fe0bc3b9f04dd36fe4e818"
 dependencies = [
  "cfg-if",
  "cipher",
- "cpufeatures",
+ "cpufeatures 0.2.17",
 ]
 
 [[package]]
@@ -6315,9 +6317,9 @@ dependencies = [
 
 [[package]]
 name = "cmake"
-version = "0.1.57"
+version = "0.1.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75443c44cd6b379beb8c5b45d85d0773baf31cce901fe7bb252f4eff3008ef7d"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
 dependencies = [
  "cc",
 ]
@@ -6486,7 +6488,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "531185e432bb31db1ecda541e9e7ab21468d4d844ad7505e0546a49b4945d49b"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "proptest",
  "serde_core",
 ]
@@ -6621,6 +6623,15 @@ name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
@@ -6794,9 +6805,9 @@ dependencies = [
 
 [[package]]
 name = "crypto-bigint"
-version = "0.7.2"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9b6a7421484856c90cb2e996b91068d608539bb4e6f0a111b16d70678824d09"
+checksum = "42a0d26b245348befa0c121944541476763dcc46ede886c88f9d12e1697d27c3"
 dependencies = [
  "cpubits",
  "ctutils",
@@ -6832,7 +6843,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "21f41f23de7d24cdbda7f0c4d9c0351f99a4ceb258ef30e5c1927af8987ffe5a"
 dependencies = [
- "crypto-bigint 0.7.2",
+ "crypto-bigint 0.7.3",
  "libm",
  "rand_core 0.10.0",
 ]
@@ -6888,7 +6899,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "curve25519-dalek-derive",
  "digest 0.10.7",
  "fiat-crypto",
@@ -6920,16 +6931,6 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.21.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cdf337090841a411e2a7f3deb9187445851f91b309c0c0a29e05f74a00a48c0"
-dependencies = [
- "darling_core 0.21.3",
- "darling_macro 0.21.3",
-]
-
-[[package]]
-name = "darling"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
@@ -6954,21 +6955,6 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.21.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1247195ecd7e3c85f83c8d2a366e4210d588e802133e1e355180a9870b517ea4"
-dependencies = [
- "fnv",
- "ident_case",
- "proc-macro2",
- "quote",
- "serde",
- "strsim",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "darling_core"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
@@ -6976,6 +6962,7 @@ dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
+ "serde",
  "strsim",
  "syn 2.0.117",
 ]
@@ -6987,17 +6974,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
  "darling_core 0.20.11",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "darling_macro"
-version = "0.21.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
-dependencies = [
- "darling_core 0.21.3",
  "quote",
  "syn 2.0.117",
 ]
@@ -7853,7 +7829,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c853bd72c9e5787f8aafc3df2907c2ed03cff3150c3acd94e2e53a98ab70a8ab"
 dependencies = [
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "ring",
  "sha2 0.10.9",
 ]
@@ -9833,7 +9809,7 @@ dependencies = [
  "rsa 0.10.0-rc.17",
  "sec1",
  "sha1 0.10.6",
- "sha1 0.11.0-rc.5",
+ "sha1 0.11.0",
  "sha2 0.10.9",
  "signature 2.2.0",
  "signature 3.0.0-rc.10",
@@ -9878,14 +9854,15 @@ dependencies = [
 
 [[package]]
 name = "ipconfig"
-version = "0.3.2"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b58db92f96b720de98181bbbe63c831e87005ab460c1bf306eb2622b4707997f"
+checksum = "4d40460c0ce33d6ce4b0630ad68ff63d6661961c48b6dba35e5a4d81cfb48222"
 dependencies = [
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "widestring",
- "windows-sys 0.48.0",
- "winreg",
+ "windows-registry",
+ "windows-result",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9899,9 +9876,9 @@ dependencies = [
 
 [[package]]
 name = "iri-string"
-version = "0.7.10"
+version = "0.7.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c91338f0783edbd6195decb37bae672fd3b165faffb89bf7b9e6942f8b1a731a"
+checksum = "d8e7418f59cc01c88316161279a7f665217ae316b388e58a0d10e29f54f1e5eb"
 dependencies = [
  "memchr",
  "serde",
@@ -10255,14 +10232,14 @@ version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb26cec98cce3a3d96cbb7bced3c4b16e3d13f27ec56dbd62cbc8f39cfb9d653"
 dependencies = [
- "cpufeatures",
+ "cpufeatures 0.2.17",
 ]
 
 [[package]]
 name = "keccak-asm"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b646a74e746cd25045aa0fd42f4f7f78aa6d119380182c7e63a5593c4ab8df6f"
+checksum = "fa468878266ad91431012b3e5ef1bf9b170eab22883503a318d46857afa4579a"
 dependencies = [
  "digest 0.10.7",
  "sha3-asm",
@@ -10550,9 +10527,9 @@ dependencies = [
 
 [[package]]
 name = "libp2p-gossipsub"
-version = "0.49.3"
+version = "0.49.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cef64c3bdfaee9561319a289d778e9f8c56bd8e10f5d1059289ebb085ef09d7"
+checksum = "a538e571cd38f504f761c61b8f79127489ea7a7d6f05c41ca15d31ffb5726326"
 dependencies = [
  "async-channel",
  "asynchronous-codec",
@@ -10842,9 +10819,9 @@ dependencies = [
 
 [[package]]
 name = "libredox"
-version = "0.1.14"
+version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1744e39d1d6a9948f4f388969627434e31128196de472883b39f148769bfe30a"
+checksum = "7ddbf48fd451246b1f8c2610bd3b4ac0cc6e149d89832867093ab69a17194f08"
 dependencies = [
  "bitflags 2.11.0",
  "libc",
@@ -11400,9 +11377,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.1.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
+checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
 dependencies = [
  "libc",
  "log",
@@ -11858,9 +11835,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf97ec579c3c42f953ef76dbf8d55ac91fb219dde70e49aa4a6b7d74e9919050"
+checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
 
 [[package]]
 name = "num-derive"
@@ -12984,7 +12961,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf"
 dependencies = [
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "opaque-debug",
  "universal-hash",
 ]
@@ -12996,7 +12973,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "opaque-debug",
  "universal-hash",
 ]
@@ -13139,7 +13116,7 @@ version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
 dependencies = [
- "toml_edit 0.25.5+spec-1.1.0",
+ "toml_edit 0.25.8+spec-1.1.0",
 ]
 
 [[package]]
@@ -13222,9 +13199,9 @@ dependencies = [
 
 [[package]]
 name = "proptest"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37566cb3fdacef14c0737f9546df7cfeadbfbc9fef10991038bf5015d0c80532"
+checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
 dependencies = [
  "bit-set 0.8.0",
  "bit-vec 0.8.0",
@@ -13950,11 +13927,9 @@ dependencies = [
  "http-body-util",
  "hyper 1.8.1",
  "hyper-rustls 0.27.7",
- "hyper-tls",
  "hyper-util",
  "js-sys",
  "log",
- "native-tls",
  "percent-encoding",
  "pin-project-lite",
  "quinn",
@@ -13966,7 +13941,6 @@ dependencies = [
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
- "tokio-native-tls",
  "tokio-rustls 0.26.4",
  "tokio-util",
  "tower",
@@ -17494,13 +17468,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "87ed3e93fc7e473e464b9726f4759659e72bc8665e4b8ea227547024f416d905"
 dependencies = [
  "const-oid 0.10.2",
- "crypto-bigint 0.7.2",
+ "crypto-bigint 0.7.3",
  "crypto-primes",
  "digest 0.11.2",
  "pkcs1 0.8.0-rc.4",
  "pkcs8 0.11.0-rc.11",
  "rand_core 0.10.0",
- "sha2 0.11.0-rc.5",
+ "sha2 0.11.0",
  "signature 3.0.0-rc.10",
  "zeroize",
 ]
@@ -18291,9 +18265,9 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "1.0.4"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8bbf91e5a4d6315eee45e704372590b30e260ee83af6639d64557f51b067776"
+checksum = "876ac351060d4f882bb1032b6369eb0aef79ad9df1ea8bc404874d8cc3d0cd98"
 dependencies = [
  "serde_core",
 ]
@@ -18407,18 +18381,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest 0.10.7",
 ]
 
 [[package]]
 name = "sha1"
-version = "0.11.0-rc.5"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b167252f3c126be0d8926639c4c4706950f01445900c4b3db0fd7e89fcb750a"
+checksum = "aacc4cc499359472b4abe1bf11d0b12e688af9a805fa5e3016f9a386dc2d0214"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.3.0",
  "digest 0.11.2",
 ]
 
@@ -18435,18 +18409,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest 0.10.7",
 ]
 
 [[package]]
 name = "sha2"
-version = "0.11.0-rc.5"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c5f3b1e2dc8aad28310d8410bd4d7e180eca65fca176c52ab00d364475d0024"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.3.0",
  "digest 0.11.2",
 ]
 
@@ -18462,9 +18436,9 @@ dependencies = [
 
 [[package]]
 name = "sha3-asm"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b31139435f327c93c6038ed350ae4588e2c70a13d50599509fee6349967ba35a"
+checksum = "59cbb88c189d6352cc8ae96a39d19c7ecad8f7330b29461187f2587fdc2988d5"
 dependencies = [
  "cc",
  "cfg-if",
@@ -18547,9 +18521,9 @@ dependencies = [
 
 [[package]]
 name = "simd-adler32"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
 name = "simdutf8"
@@ -19347,9 +19321,9 @@ dependencies = [
 
 [[package]]
 name = "testcontainers"
-version = "0.27.1"
+version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1c0624faaa317c56d6d19136580be889677259caf5c897941c6f446b4655068"
+checksum = "0bd36b06a2a6c0c3c81a83be1ab05fe86460d054d4d51bf513bc56b3e15bdc22"
 dependencies = [
  "astral-tokio-tar",
  "async-trait",
@@ -19672,22 +19646,6 @@ dependencies = [
 
 [[package]]
 name = "tokio-tungstenite"
-version = "0.26.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a9daff607c6d2bf6c16fd681ccb7eecc83e4e2cdc1ca067ffaadfca5de7f084"
-dependencies = [
- "futures-util",
- "log",
- "rustls 0.23.37",
- "rustls-pki-types",
- "tokio",
- "tokio-rustls 0.26.4",
- "tungstenite 0.26.2",
- "webpki-roots 0.26.11",
-]
-
-[[package]]
-name = "tokio-tungstenite"
 version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d25a406cddcc431a75d3d9afc6a7c0f7428d4891dd973e4d54c56b46127bf857"
@@ -19752,7 +19710,7 @@ checksum = "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863"
 dependencies = [
  "indexmap 2.13.0",
  "serde_core",
- "serde_spanned 1.0.4",
+ "serde_spanned 1.1.0",
  "toml_datetime 0.7.5+spec-1.1.0",
  "toml_parser",
  "toml_writer",
@@ -19761,13 +19719,13 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "1.0.7+spec-1.1.0"
+version = "1.1.0+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd28d57d8a6f6e458bc0b8784f8fdcc4b99a437936056fa122cb234f18656a96"
+checksum = "f8195ca05e4eb728f4ba94f3e3291661320af739c4e43779cbdfae82ab239fcc"
 dependencies = [
  "serde_core",
- "serde_spanned 1.0.4",
- "toml_datetime 1.0.1+spec-1.1.0",
+ "serde_spanned 1.1.0",
+ "toml_datetime 1.1.0+spec-1.1.0",
  "toml_parser",
  "winnow 1.0.0",
 ]
@@ -19792,9 +19750,9 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "1.0.1+spec-1.1.0"
+version = "1.1.0+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b320e741db58cac564e26c607d3cc1fdc4a88fd36c879568c07856ed83ff3e9"
+checksum = "97251a7c317e03ad83774a8752a7e81fb6067740609f75ea2b585b569a59198f"
 dependencies = [
  "serde_core",
 ]
@@ -19815,21 +19773,21 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.25.5+spec-1.1.0"
+version = "0.25.8+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ca1a40644a28bce036923f6a431df0b34236949d111cc07cb6dca830c9ef2e1"
+checksum = "16bff38f1d86c47f9ff0647e6838d7bb362522bdf44006c7068c2b1e606f1f3c"
 dependencies = [
  "indexmap 2.13.0",
- "toml_datetime 1.0.1+spec-1.1.0",
+ "toml_datetime 1.1.0+spec-1.1.0",
  "toml_parser",
  "winnow 1.0.0",
 ]
 
 [[package]]
 name = "toml_parser"
-version = "1.0.10+spec-1.1.0"
+version = "1.1.0+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7df25b4befd31c4816df190124375d5a20c6b6921e2cad937316de3fccd63420"
+checksum = "2334f11ee363607eb04df9b8fc8a13ca1715a72ba8662a26ac285c98aabb4011"
 dependencies = [
  "winnow 1.0.0",
 ]
@@ -19842,9 +19800,9 @@ checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "toml_writer"
-version = "1.0.7+spec-1.1.0"
+version = "1.1.0+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f17aaa1c6e3dc22b1da4b6bba97d066e354c7945cac2f7852d4e4e7ca7a6b56d"
+checksum = "d282ade6016312faf3e41e57ebbba0c073e4056dab1232ab1cb624199648f8ed"
 
 [[package]]
 name = "tonic"
@@ -20233,25 +20191,6 @@ dependencies = [
 
 [[package]]
 name = "tungstenite"
-version = "0.26.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4793cb5e56680ecbb1d843515b23b6de9a75eb04b66643e256a396d43be33c13"
-dependencies = [
- "bytes",
- "data-encoding",
- "http 1.4.0",
- "httparse",
- "log",
- "rand 0.9.2",
- "rustls 0.23.37",
- "rustls-pki-types",
- "sha1 0.10.6",
- "thiserror 2.0.18",
- "utf-8",
-]
-
-[[package]]
-name = "tungstenite"
 version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8628dcc84e5a09eb3d8423d6cb682965dea9133204e8fb3efee74c2a0c259442"
@@ -20399,9 +20338,9 @@ checksum = "7df058c713841ad818f1dc5d3fd88063241cc61f49f5fbea4b951e8cf5a8d71d"
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.12.0"
+version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
+checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
 
 [[package]]
 name = "unicode-truncate"
@@ -20567,9 +20506,9 @@ dependencies = [
 
 [[package]]
 name = "uuid"
-version = "1.22.0"
+version = "1.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a68d3c8f01c0cfa54a75291d83601161799e4a89a39e0929f4b0354d88757a37"
+checksum = "5ac8b6f42ead25368cf5b098aeb3dc8a1a2c05a3eee8a9a1a68c640edbfc79d9"
 dependencies = [
  "atomic",
  "getrandom 0.4.2",
@@ -21539,16 +21478,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "winreg"
-version = "0.50.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
-dependencies = [
- "cfg-if",
- "windows-sys 0.48.0",
-]
-
-[[package]]
 name = "wiremock"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -21988,9 +21917,9 @@ dependencies = [
 
 [[package]]
 name = "zip"
-version = "8.3.1"
+version = "8.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c546feb4481b0fbafb4ef0d79b6204fc41c6f9884b1b73b1d73f82442fc0845"
+checksum = "7756d0206d058333667493c4014f545f4b9603c4330ccd6d9b3f86dcab59f7d9"
 dependencies = [
  "crc32fast",
  "flate2",
@@ -22061,9 +21990,9 @@ checksum = "cb8a0807f7c01457d0379ba880ba6322660448ddebc890ce29bb64da71fb40f9"
 
 [[package]]
 name = "zune-jpeg"
-version = "0.5.14"
+version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b7a1c0af6e5d8d1363f4994b7a091ccf963d8b694f7da5b0b9cceb82da2c0a6"
+checksum = "27bc9d5b815bc103f142aa054f561d9187d191692ec7c2d1e2b4737f8dbd7296"
 dependencies = [
  "zune-core",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -62,7 +62,7 @@ checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
 dependencies = [
  "cfg-if",
  "cipher",
- "cpufeatures 0.2.17",
+ "cpufeatures",
 ]
 
 [[package]]
@@ -142,9 +142,9 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "alloy"
-version = "1.8.3"
+version = "1.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50ab0cd8afe573d1f7dc2353698a51b1f93aec362c8211e28cfd3948c6adba39"
+checksum = "4973038846323e4e69a433916522195dce2947770076c03078fc21c80ea0f1c4"
 dependencies = [
  "alloy-consensus",
  "alloy-contract",
@@ -165,9 +165,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-chains"
-version = "0.2.33"
+version = "0.2.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4e9e31d834fe25fe991b8884e4b9f0e59db4a97d86e05d1464d6899c013cd62"
+checksum = "9247f0a399ef71aeb68f497b2b8fb348014f742b50d3b83b1e00dfe1b7d64b3d"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -180,9 +180,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-consensus"
-version = "1.8.3"
+version = "1.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f16daaf7e1f95f62c6c3bf8a3fc3d78b08ae9777810c0bb5e94966c7cd57ef0"
+checksum = "b0c0dc44157867da82c469c13186015b86abef209bf0e41625e4b68bac61d728"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -208,9 +208,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-consensus-any"
-version = "1.8.3"
+version = "1.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "118998d9015332ab1b4720ae1f1e3009491966a0349938a1f43ff45a8a4c6299"
+checksum = "ba4cdb42df3871cd6b346d6a938ec2ba69a9a0f49d1f82714bc5c48349268434"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -223,9 +223,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-contract"
-version = "1.8.3"
+version = "1.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ac9e0c34dc6bce643b182049cdfcca1b8ce7d9c260cbdd561f511873b7e26cd"
+checksum = "ca63b7125a981415898ffe2a2a696c83696c9c6bdb1671c8a912946bbd8e49e7"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -241,7 +241,6 @@ dependencies = [
  "futures-util",
  "serde_json",
  "thiserror 2.0.18",
- "tracing",
 ]
 
 [[package]]
@@ -335,9 +334,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-eips"
-version = "1.8.3"
+version = "1.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6ef28c9fdad22d4eec52d894f5f2673a0895f1e5ef196734568e68c0f6caca8"
+checksum = "b9f7ef09f21bd1e9cb8a686f168cb4a206646804567f0889eadb8dcc4c9288c8"
 dependencies = [
  "alloy-eip2124",
  "alloy-eip2930",
@@ -357,6 +356,7 @@ dependencies = [
  "serde",
  "serde_with",
  "sha2 0.10.9",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -382,9 +382,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-genesis"
-version = "1.8.3"
+version = "1.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbf9480307b09d22876efb67d30cadd9013134c21f3a17ec9f93fd7536d38024"
+checksum = "7c9cf3b99f46615fbf7dc1add0c96553abb7bf88fc9ec70dfbe7ad0b47ba7fe8"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -436,9 +436,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-json-rpc"
-version = "1.8.3"
+version = "1.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "422d110f1c40f1f8d0e5562b0b649c35f345fccb7093d9f02729943dcd1eef71"
+checksum = "ff42cd777eea61f370c0b10f2648a1c81e0b783066cd7269228aa993afd487f7"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
@@ -451,9 +451,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-network"
-version = "1.8.3"
+version = "1.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7197a66d94c4de1591cdc16a9bcea5f8cccd0da81b865b49aef97b1b4016e0fa"
+checksum = "8cbca04f9b410fdc51aaaf88433cbac761213905a65fe832058bcf6690585762"
 dependencies = [
  "alloy-consensus",
  "alloy-consensus-any",
@@ -477,9 +477,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-network-primitives"
-version = "1.8.3"
+version = "1.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb82711d59a43fdfd79727c99f270b974c784ec4eb5728a0d0d22f26716c87ef"
+checksum = "42d6d15e069a8b11f56bef2eccbad2a873c6dd4d4c81d04dda29710f5ea52f04"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -490,9 +490,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-node-bindings"
-version = "1.8.3"
+version = "1.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9b2fda91b56bb08907cd44c5068130360e027e46a8c17612d386869fa7940be"
+checksum = "091dc8117d84de3a9ac7ec97f2c4d83987e24d485b478d26aa1ec455d7d52f7d"
 dependencies = [
  "alloy-genesis",
  "alloy-hardforks 0.2.13",
@@ -543,9 +543,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-provider"
-version = "1.8.3"
+version = "1.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf6b18b929ef1d078b834c3631e9c925177f3b23ddc6fa08a722d13047205876"
+checksum = "d181c8cc7cf4805d7e589bf4074d56d55064fa1a979f005a45a62b047616d870"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -579,7 +579,7 @@ dependencies = [
  "lru 0.16.3",
  "parking_lot",
  "pin-project",
- "reqwest 0.13.2",
+ "reqwest 0.12.28",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -591,9 +591,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-pubsub"
-version = "1.8.3"
+version = "1.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ad54073131e7292d4e03e1aa2287730f737280eb160d8b579fb31939f558c11"
+checksum = "e8bd82953194dec221aa4cbbbb0b1e2df46066fe9d0333ac25b43a311e122d13"
 dependencies = [
  "alloy-json-rpc",
  "alloy-primitives",
@@ -635,9 +635,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-client"
-version = "1.8.3"
+version = "1.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94fcc9604042ca80bd37aa5e232ea1cd851f337e31e2babbbb345bc0b1c30de3"
+checksum = "f2792758a93ae32a32e9047c843d536e1448044f78422d71bf7d7c05149e103f"
 dependencies = [
  "alloy-json-rpc",
  "alloy-primitives",
@@ -648,7 +648,7 @@ dependencies = [
  "alloy-transport-ws",
  "futures",
  "pin-project",
- "reqwest 0.13.2",
+ "reqwest 0.12.28",
  "serde",
  "serde_json",
  "tokio",
@@ -661,9 +661,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types"
-version = "1.8.3"
+version = "1.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4faad925d3a669ffc15f43b3deec7fbdf2adeb28a4d6f9cf4bc661698c0f8f4b"
+checksum = "7bdcbf9dfd5eea8bfeb078b1d906da8cd3a39c4d4dbe7a628025648e323611f6"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-debug",
@@ -676,9 +676,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-admin"
-version = "1.8.3"
+version = "1.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b38080c2b01ad1bacbd3583cf7f6f800e5e0ffc11eaddaad7321225733a2d818"
+checksum = "42325c117af3a9e49013f881c1474168db57978e02085fc9853a1c89e0562740"
 dependencies = [
  "alloy-genesis",
  "alloy-primitives",
@@ -688,9 +688,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-anvil"
-version = "1.8.3"
+version = "1.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47df51bedb3e6062cb9981187a51e86d0d64a4de66eb0855e9efe6574b044ddf"
+checksum = "e0a3100b76987c1b1dc81f3abe592b7edc29e92b1242067a69d65e0030b35cf9"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -700,9 +700,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-any"
-version = "1.8.3"
+version = "1.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3823026d1ed239a40f12364fac50726c8daf1b6ab8077a97212c5123910429ed"
+checksum = "dd720b63f82b457610f2eaaf1f32edf44efffe03ae25d537632e7d23e7929e1a"
 dependencies = [
  "alloy-consensus-any",
  "alloy-rpc-types-eth",
@@ -711,9 +711,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-beacon"
-version = "1.8.3"
+version = "1.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f526dbd7bb039327cfd0ccf18c8a29ffd7402616b0c7a0239512bf8417d544c7"
+checksum = "4a22e13215866f5dfd5d3278f4c41f1fad9410dc68ce39022f58593c873c26f8"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -731,9 +731,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-debug"
-version = "1.8.3"
+version = "1.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2145138f3214928f08cd13da3cb51ef7482b5920d8ac5a02ecd4e38d1a8f6d1e"
+checksum = "e1b21e1ad18ff1b31ff1030e046462ab8168cf8894e6778cd805c8bdfe2bd649"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -743,9 +743,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-engine"
-version = "1.8.3"
+version = "1.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb9b97b6e7965679ad22df297dda809b11cebc13405c1b537e5cffecc95834fa"
+checksum = "e4ac61f03f1edabccde1c687b5b25fff28f183afee64eaa2e767def3929e4457"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -764,9 +764,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-eth"
-version = "1.8.3"
+version = "1.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59c095f92c4e1ff4981d89e9aa02d5f98c762a1980ab66bec49c44be11349da2"
+checksum = "9b2dc411f13092f237d2bf6918caf80977fc2f51485f9b90cb2a2f956912c8c9"
 dependencies = [
  "alloy-consensus",
  "alloy-consensus-any",
@@ -786,9 +786,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-mev"
-version = "1.8.3"
+version = "1.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8eae9c65ff60dcc262247b6ebb5ad391ddf36d09029802c1768c5723e0cfa2f4"
+checksum = "fe85bf3be739126aa593dca9fb3ab13ca93fa7873e6f2247be64d7f2cb15f34a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -801,9 +801,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-trace"
-version = "1.8.3"
+version = "1.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e5a4d010f86cd4e01e5205ec273911e538e1738e76d8bafe9ecd245910ea5a3"
+checksum = "1ad79f1e27e161943b5a4f99fe5534ef0849876214be411e0032c12f38e94daa"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -815,9 +815,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-txpool"
-version = "1.8.3"
+version = "1.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "942d26a2ca8891b26de4a8529d21091e21c1093e27eb99698f1a86405c76b1ff"
+checksum = "d459f902a2313737bc66d18ed094c25d2aeb268b74d98c26bbbda2aa44182ab0"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -827,9 +827,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-serde"
-version = "1.8.3"
+version = "1.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11ece63b89294b8614ab3f483560c08d016930f842bf36da56bf0b764a15c11e"
+checksum = "e2ce1e0dbf7720eee747700e300c99aac01b1a95bb93f493a01e78ee28bb1a37"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -839,9 +839,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer"
-version = "1.8.3"
+version = "1.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43f447aefab0f1c0649f71edc33f590992d4e122bc35fb9cdbbf67d4421ace85"
+checksum = "2425c6f314522c78e8198979c8cbf6769362be4da381d4152ea8eefce383535d"
 dependencies = [
  "alloy-primitives",
  "async-trait",
@@ -854,9 +854,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer-local"
-version = "1.8.3"
+version = "1.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f721f4bf2e4812e5505aaf5de16ef3065a8e26b9139ac885862d00b5a55a659a"
+checksum = "c3ecb71ee53d8d9c3fa7bac17542c8116ebc7a9726c91b1bf333ec3d04f5a789"
 dependencies = [
  "alloy-consensus",
  "alloy-network",
@@ -946,9 +946,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport"
-version = "1.8.3"
+version = "1.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8098f965442a9feb620965ba4b4be5e2b320f4ec5a3fff6bfa9e1ff7ef42bed1"
+checksum = "fa186e560d523d196580c48bf00f1bf62e63041f28ecf276acc22f8b27bb9f53"
 dependencies = [
  "alloy-json-rpc",
  "auto_impl",
@@ -969,9 +969,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport-http"
-version = "1.8.3"
+version = "1.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8597d36d546e1dab822345ad563243ec3920e199322cb554ce56c8ef1a1e2e7"
+checksum = "aa501ad58dd20acddbfebc65b52e60f05ebf97c52fa40d1b35e91f5e2da0ad0e"
 dependencies = [
  "alloy-json-rpc",
  "alloy-rpc-types-engine",
@@ -984,7 +984,7 @@ dependencies = [
  "jsonwebtoken",
  "opentelemetry",
  "opentelemetry-http",
- "reqwest 0.13.2",
+ "reqwest 0.12.28",
  "serde_json",
  "tower",
  "tracing",
@@ -994,9 +994,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport-ipc"
-version = "1.8.3"
+version = "1.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1bd98c3870b8a44b79091dde5216a81d58ffbc1fd8ed61b776f9fee0f3bdf20"
+checksum = "c2ef85688e5ac2da72afc804e0a1f153a1f309f05a864b1998bbbed7804dbaab"
 dependencies = [
  "alloy-json-rpc",
  "alloy-pubsub",
@@ -1014,20 +1014,18 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport-ws"
-version = "1.8.3"
+version = "1.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec3ab7a72b180992881acc112628b7668337a19ce15293ee974600ea7b693691"
+checksum = "b9f00445db69d63298e2b00a0ea1d859f00e6424a3144ffc5eba9c31da995e16"
 dependencies = [
  "alloy-pubsub",
  "alloy-transport",
  "futures",
  "http 1.4.0",
- "rustls 0.23.37",
  "serde_json",
  "tokio",
- "tokio-tungstenite 0.28.0",
+ "tokio-tungstenite 0.26.2",
  "tracing",
- "url",
  "ws_stream_wasm",
 ]
 
@@ -1053,11 +1051,11 @@ dependencies = [
 
 [[package]]
 name = "alloy-tx-macros"
-version = "1.8.3"
+version = "1.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d69722eddcdf1ce096c3ab66cf8116999363f734eb36fe94a148f4f71c85da84"
+checksum = "6fa0c53e8c1e1ef4d01066b01c737fb62fc9397ab52c6e7bb5669f97d281b9bc"
 dependencies = [
- "darling 0.23.0",
+ "darling 0.21.3",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -1215,7 +1213,7 @@ checksum = "3c3610892ee6e0cbce8ae2700349fcf8f98adb0dbfbee85aec3c9179d29cc072"
 dependencies = [
  "base64ct",
  "blake2",
- "cpufeatures 0.2.17",
+ "cpufeatures",
  "password-hash",
 ]
 
@@ -1647,9 +1645,9 @@ dependencies = [
 
 [[package]]
 name = "astral-tokio-tar"
-version = "0.6.0"
+version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c23f3af104b40a3430ccb90ed5f7bd877a8dc5c26fc92fde51a22b40890dcf9"
+checksum = "ec179a06c1769b1e42e1e2cbe74c7dcdb3d6383c838454d063eaac5bbb7ebbe5"
 dependencies = [
  "filetime",
  "futures-core",
@@ -3354,7 +3352,7 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror 2.0.18",
- "toml 1.1.0+spec-1.1.0",
+ "toml 1.0.7+spec-1.1.0",
  "tracing",
 ]
 
@@ -4702,7 +4700,7 @@ dependencies = [
  "tokio-vsock",
  "tracing",
  "x509-cert",
- "zip 8.4.0",
+ "zip 8.3.1",
 ]
 
 [[package]]
@@ -6142,9 +6140,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.58"
+version = "1.2.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1e928d4b69e3077709075a938a05ffbedfa53a84c8f766efbf8220bb1ff60e1"
+checksum = "7a0dd1ca384932ff3641c8718a02769f1698e7563dc6974ffd03346116310423"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -6187,7 +6185,7 @@ checksum = "c3613f74bd2eac03dad61bd53dbe620703d4371614fe0bc3b9f04dd36fe4e818"
 dependencies = [
  "cfg-if",
  "cipher",
- "cpufeatures 0.2.17",
+ "cpufeatures",
 ]
 
 [[package]]
@@ -6317,9 +6315,9 @@ dependencies = [
 
 [[package]]
 name = "cmake"
-version = "0.1.58"
+version = "0.1.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
+checksum = "75443c44cd6b379beb8c5b45d85d0773baf31cce901fe7bb252f4eff3008ef7d"
 dependencies = [
  "cc",
 ]
@@ -6488,7 +6486,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "531185e432bb31db1ecda541e9e7ab21468d4d844ad7505e0546a49b4945d49b"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.2.17",
+ "cpufeatures",
  "proptest",
  "serde_core",
 ]
@@ -6623,15 +6621,6 @@ name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "cpufeatures"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
@@ -6805,9 +6794,9 @@ dependencies = [
 
 [[package]]
 name = "crypto-bigint"
-version = "0.7.3"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42a0d26b245348befa0c121944541476763dcc46ede886c88f9d12e1697d27c3"
+checksum = "e9b6a7421484856c90cb2e996b91068d608539bb4e6f0a111b16d70678824d09"
 dependencies = [
  "cpubits",
  "ctutils",
@@ -6843,7 +6832,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "21f41f23de7d24cdbda7f0c4d9c0351f99a4ceb258ef30e5c1927af8987ffe5a"
 dependencies = [
- "crypto-bigint 0.7.3",
+ "crypto-bigint 0.7.2",
  "libm",
  "rand_core 0.10.0",
 ]
@@ -6899,7 +6888,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.2.17",
+ "cpufeatures",
  "curve25519-dalek-derive",
  "digest 0.10.7",
  "fiat-crypto",
@@ -6931,6 +6920,16 @@ dependencies = [
 
 [[package]]
 name = "darling"
+version = "0.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cdf337090841a411e2a7f3deb9187445851f91b309c0c0a29e05f74a00a48c0"
+dependencies = [
+ "darling_core 0.21.3",
+ "darling_macro 0.21.3",
+]
+
+[[package]]
+name = "darling"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
@@ -6955,6 +6954,21 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
+version = "0.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1247195ecd7e3c85f83c8d2a366e4210d588e802133e1e355180a9870b517ea4"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "strsim",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "darling_core"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
@@ -6962,7 +6976,6 @@ dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
- "serde",
  "strsim",
  "syn 2.0.117",
 ]
@@ -6974,6 +6987,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
  "darling_core 0.20.11",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
+dependencies = [
+ "darling_core 0.21.3",
  "quote",
  "syn 2.0.117",
 ]
@@ -7829,7 +7853,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c853bd72c9e5787f8aafc3df2907c2ed03cff3150c3acd94e2e53a98ab70a8ab"
 dependencies = [
- "cpufeatures 0.2.17",
+ "cpufeatures",
  "ring",
  "sha2 0.10.9",
 ]
@@ -9809,7 +9833,7 @@ dependencies = [
  "rsa 0.10.0-rc.17",
  "sec1",
  "sha1 0.10.6",
- "sha1 0.11.0",
+ "sha1 0.11.0-rc.5",
  "sha2 0.10.9",
  "signature 2.2.0",
  "signature 3.0.0-rc.10",
@@ -9854,15 +9878,14 @@ dependencies = [
 
 [[package]]
 name = "ipconfig"
-version = "0.3.4"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d40460c0ce33d6ce4b0630ad68ff63d6661961c48b6dba35e5a4d81cfb48222"
+checksum = "b58db92f96b720de98181bbbe63c831e87005ab460c1bf306eb2622b4707997f"
 dependencies = [
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "widestring",
- "windows-registry",
- "windows-result",
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
+ "winreg",
 ]
 
 [[package]]
@@ -9876,9 +9899,9 @@ dependencies = [
 
 [[package]]
 name = "iri-string"
-version = "0.7.11"
+version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8e7418f59cc01c88316161279a7f665217ae316b388e58a0d10e29f54f1e5eb"
+checksum = "c91338f0783edbd6195decb37bae672fd3b165faffb89bf7b9e6942f8b1a731a"
 dependencies = [
  "memchr",
  "serde",
@@ -10232,14 +10255,14 @@ version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb26cec98cce3a3d96cbb7bced3c4b16e3d13f27ec56dbd62cbc8f39cfb9d653"
 dependencies = [
- "cpufeatures 0.2.17",
+ "cpufeatures",
 ]
 
 [[package]]
 name = "keccak-asm"
-version = "0.1.6"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa468878266ad91431012b3e5ef1bf9b170eab22883503a318d46857afa4579a"
+checksum = "b646a74e746cd25045aa0fd42f4f7f78aa6d119380182c7e63a5593c4ab8df6f"
 dependencies = [
  "digest 0.10.7",
  "sha3-asm",
@@ -10527,9 +10550,9 @@ dependencies = [
 
 [[package]]
 name = "libp2p-gossipsub"
-version = "0.49.4"
+version = "0.49.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a538e571cd38f504f761c61b8f79127489ea7a7d6f05c41ca15d31ffb5726326"
+checksum = "4cef64c3bdfaee9561319a289d778e9f8c56bd8e10f5d1059289ebb085ef09d7"
 dependencies = [
  "async-channel",
  "asynchronous-codec",
@@ -10819,9 +10842,9 @@ dependencies = [
 
 [[package]]
 name = "libredox"
-version = "0.1.15"
+version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ddbf48fd451246b1f8c2610bd3b4ac0cc6e149d89832867093ab69a17194f08"
+checksum = "1744e39d1d6a9948f4f388969627434e31128196de472883b39f148769bfe30a"
 dependencies = [
  "bitflags 2.11.0",
  "libc",
@@ -11377,9 +11400,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.2.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
+checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
 dependencies = [
  "libc",
  "log",
@@ -11835,9 +11858,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.2.1"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
+checksum = "cf97ec579c3c42f953ef76dbf8d55ac91fb219dde70e49aa4a6b7d74e9919050"
 
 [[package]]
 name = "num-derive"
@@ -12961,7 +12984,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf"
 dependencies = [
- "cpufeatures 0.2.17",
+ "cpufeatures",
  "opaque-debug",
  "universal-hash",
 ]
@@ -12973,7 +12996,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.2.17",
+ "cpufeatures",
  "opaque-debug",
  "universal-hash",
 ]
@@ -13116,7 +13139,7 @@ version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
 dependencies = [
- "toml_edit 0.25.8+spec-1.1.0",
+ "toml_edit 0.25.5+spec-1.1.0",
 ]
 
 [[package]]
@@ -13199,9 +13222,9 @@ dependencies = [
 
 [[package]]
 name = "proptest"
-version = "1.11.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
+checksum = "37566cb3fdacef14c0737f9546df7cfeadbfbc9fef10991038bf5015d0c80532"
 dependencies = [
  "bit-set 0.8.0",
  "bit-vec 0.8.0",
@@ -13927,9 +13950,11 @@ dependencies = [
  "http-body-util",
  "hyper 1.8.1",
  "hyper-rustls 0.27.7",
+ "hyper-tls",
  "hyper-util",
  "js-sys",
  "log",
+ "native-tls",
  "percent-encoding",
  "pin-project-lite",
  "quinn",
@@ -13941,6 +13966,7 @@ dependencies = [
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
+ "tokio-native-tls",
  "tokio-rustls 0.26.4",
  "tokio-util",
  "tower",
@@ -17468,13 +17494,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "87ed3e93fc7e473e464b9726f4759659e72bc8665e4b8ea227547024f416d905"
 dependencies = [
  "const-oid 0.10.2",
- "crypto-bigint 0.7.3",
+ "crypto-bigint 0.7.2",
  "crypto-primes",
  "digest 0.11.2",
  "pkcs1 0.8.0-rc.4",
  "pkcs8 0.11.0-rc.11",
  "rand_core 0.10.0",
- "sha2 0.11.0",
+ "sha2 0.11.0-rc.5",
  "signature 3.0.0-rc.10",
  "zeroize",
 ]
@@ -18265,9 +18291,9 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "1.1.0"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "876ac351060d4f882bb1032b6369eb0aef79ad9df1ea8bc404874d8cc3d0cd98"
+checksum = "f8bbf91e5a4d6315eee45e704372590b30e260ee83af6639d64557f51b067776"
 dependencies = [
  "serde_core",
 ]
@@ -18381,18 +18407,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.2.17",
+ "cpufeatures",
  "digest 0.10.7",
 ]
 
 [[package]]
 name = "sha1"
-version = "0.11.0"
+version = "0.11.0-rc.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aacc4cc499359472b4abe1bf11d0b12e688af9a805fa5e3016f9a386dc2d0214"
+checksum = "3b167252f3c126be0d8926639c4c4706950f01445900c4b3db0fd7e89fcb750a"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.3.0",
+ "cpufeatures",
  "digest 0.11.2",
 ]
 
@@ -18409,18 +18435,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.2.17",
+ "cpufeatures",
  "digest 0.10.7",
 ]
 
 [[package]]
 name = "sha2"
-version = "0.11.0"
+version = "0.11.0-rc.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+checksum = "7c5f3b1e2dc8aad28310d8410bd4d7e180eca65fca176c52ab00d364475d0024"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.3.0",
+ "cpufeatures",
  "digest 0.11.2",
 ]
 
@@ -18436,9 +18462,9 @@ dependencies = [
 
 [[package]]
 name = "sha3-asm"
-version = "0.1.6"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59cbb88c189d6352cc8ae96a39d19c7ecad8f7330b29461187f2587fdc2988d5"
+checksum = "b31139435f327c93c6038ed350ae4588e2c70a13d50599509fee6349967ba35a"
 dependencies = [
  "cc",
  "cfg-if",
@@ -18521,9 +18547,9 @@ dependencies = [
 
 [[package]]
 name = "simd-adler32"
-version = "0.3.9"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
 
 [[package]]
 name = "simdutf8"
@@ -19321,9 +19347,9 @@ dependencies = [
 
 [[package]]
 name = "testcontainers"
-version = "0.27.2"
+version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bd36b06a2a6c0c3c81a83be1ab05fe86460d054d4d51bf513bc56b3e15bdc22"
+checksum = "c1c0624faaa317c56d6d19136580be889677259caf5c897941c6f446b4655068"
 dependencies = [
  "astral-tokio-tar",
  "async-trait",
@@ -19646,6 +19672,22 @@ dependencies = [
 
 [[package]]
 name = "tokio-tungstenite"
+version = "0.26.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a9daff607c6d2bf6c16fd681ccb7eecc83e4e2cdc1ca067ffaadfca5de7f084"
+dependencies = [
+ "futures-util",
+ "log",
+ "rustls 0.23.37",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls 0.26.4",
+ "tungstenite 0.26.2",
+ "webpki-roots 0.26.11",
+]
+
+[[package]]
+name = "tokio-tungstenite"
 version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d25a406cddcc431a75d3d9afc6a7c0f7428d4891dd973e4d54c56b46127bf857"
@@ -19710,7 +19752,7 @@ checksum = "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863"
 dependencies = [
  "indexmap 2.13.0",
  "serde_core",
- "serde_spanned 1.1.0",
+ "serde_spanned 1.0.4",
  "toml_datetime 0.7.5+spec-1.1.0",
  "toml_parser",
  "toml_writer",
@@ -19719,13 +19761,13 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "1.1.0+spec-1.1.0"
+version = "1.0.7+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8195ca05e4eb728f4ba94f3e3291661320af739c4e43779cbdfae82ab239fcc"
+checksum = "dd28d57d8a6f6e458bc0b8784f8fdcc4b99a437936056fa122cb234f18656a96"
 dependencies = [
  "serde_core",
- "serde_spanned 1.1.0",
- "toml_datetime 1.1.0+spec-1.1.0",
+ "serde_spanned 1.0.4",
+ "toml_datetime 1.0.1+spec-1.1.0",
  "toml_parser",
  "winnow 1.0.0",
 ]
@@ -19750,9 +19792,9 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "1.1.0+spec-1.1.0"
+version = "1.0.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97251a7c317e03ad83774a8752a7e81fb6067740609f75ea2b585b569a59198f"
+checksum = "9b320e741db58cac564e26c607d3cc1fdc4a88fd36c879568c07856ed83ff3e9"
 dependencies = [
  "serde_core",
 ]
@@ -19773,21 +19815,21 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.25.8+spec-1.1.0"
+version = "0.25.5+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16bff38f1d86c47f9ff0647e6838d7bb362522bdf44006c7068c2b1e606f1f3c"
+checksum = "8ca1a40644a28bce036923f6a431df0b34236949d111cc07cb6dca830c9ef2e1"
 dependencies = [
  "indexmap 2.13.0",
- "toml_datetime 1.1.0+spec-1.1.0",
+ "toml_datetime 1.0.1+spec-1.1.0",
  "toml_parser",
  "winnow 1.0.0",
 ]
 
 [[package]]
 name = "toml_parser"
-version = "1.1.0+spec-1.1.0"
+version = "1.0.10+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2334f11ee363607eb04df9b8fc8a13ca1715a72ba8662a26ac285c98aabb4011"
+checksum = "7df25b4befd31c4816df190124375d5a20c6b6921e2cad937316de3fccd63420"
 dependencies = [
  "winnow 1.0.0",
 ]
@@ -19800,9 +19842,9 @@ checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "toml_writer"
-version = "1.1.0+spec-1.1.0"
+version = "1.0.7+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d282ade6016312faf3e41e57ebbba0c073e4056dab1232ab1cb624199648f8ed"
+checksum = "f17aaa1c6e3dc22b1da4b6bba97d066e354c7945cac2f7852d4e4e7ca7a6b56d"
 
 [[package]]
 name = "tonic"
@@ -20191,6 +20233,25 @@ dependencies = [
 
 [[package]]
 name = "tungstenite"
+version = "0.26.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4793cb5e56680ecbb1d843515b23b6de9a75eb04b66643e256a396d43be33c13"
+dependencies = [
+ "bytes",
+ "data-encoding",
+ "http 1.4.0",
+ "httparse",
+ "log",
+ "rand 0.9.2",
+ "rustls 0.23.37",
+ "rustls-pki-types",
+ "sha1 0.10.6",
+ "thiserror 2.0.18",
+ "utf-8",
+]
+
+[[package]]
+name = "tungstenite"
 version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8628dcc84e5a09eb3d8423d6cb682965dea9133204e8fb3efee74c2a0c259442"
@@ -20338,9 +20399,9 @@ checksum = "7df058c713841ad818f1dc5d3fd88063241cc61f49f5fbea4b951e8cf5a8d71d"
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.13.2"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
+checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
 
 [[package]]
 name = "unicode-truncate"
@@ -20506,9 +20567,9 @@ dependencies = [
 
 [[package]]
 name = "uuid"
-version = "1.23.0"
+version = "1.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ac8b6f42ead25368cf5b098aeb3dc8a1a2c05a3eee8a9a1a68c640edbfc79d9"
+checksum = "a68d3c8f01c0cfa54a75291d83601161799e4a89a39e0929f4b0354d88757a37"
 dependencies = [
  "atomic",
  "getrandom 0.4.2",
@@ -21478,6 +21539,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "winreg"
+version = "0.50.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
+dependencies = [
+ "cfg-if",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "wiremock"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -21917,9 +21988,9 @@ dependencies = [
 
 [[package]]
 name = "zip"
-version = "8.4.0"
+version = "8.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7756d0206d058333667493c4014f545f4b9603c4330ccd6d9b3f86dcab59f7d9"
+checksum = "5c546feb4481b0fbafb4ef0d79b6204fc41c6f9884b1b73b1d73f82442fc0845"
 dependencies = [
  "crc32fast",
  "flate2",
@@ -21990,9 +22061,9 @@ checksum = "cb8a0807f7c01457d0379ba880ba6322660448ddebc890ce29bb64da71fb40f9"
 
 [[package]]
 name = "zune-jpeg"
-version = "0.5.15"
+version = "0.5.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27bc9d5b815bc103f142aa054f561d9187d191692ec7c2d1e2b4737f8dbd7296"
+checksum = "0b7a1c0af6e5d8d1363f4994b7a091ccf963d8b694f7da5b0b9cceb82da2c0a6"
 dependencies = [
  "zune-core",
 ]

--- a/crates/consensus/disc/src/driver.rs
+++ b/crates/consensus/disc/src/driver.rs
@@ -280,7 +280,7 @@ impl Discv5Driver {
                             discv5::Event::Discovered(enr) => {
                                 if EnrValidation::validate(&enr, chain_id).is_valid() {
                                     debug!(target: "discovery", enr = ?enr, "Valid ENR discovered, forwarding to swarm");
-                                    Metrics::discovery_event("discovered").increment(1.0);
+                                    Metrics::discovery_events("discovered").increment(1.0);
                                     store.add_enr(enr.clone());
                                     let sender = enr_sender.clone();
                                     tokio::spawn(async move {
@@ -293,7 +293,7 @@ impl Discv5Driver {
                             discv5::Event::SessionEstablished(enr, addr) => {
                                 if EnrValidation::validate(&enr, chain_id).is_valid() {
                                     debug!(target: "discovery", addr = ?addr, enr = ?enr, "Session established with valid ENR, forwarding to swarm");
-                                    Metrics::discovery_event("session_established").increment(1.0);
+                                    Metrics::discovery_events("session_established").increment(1.0);
                                     store.add_enr(enr.clone());
                                     let sender = enr_sender.clone();
                                     tokio::spawn(async move {
@@ -306,7 +306,7 @@ impl Discv5Driver {
                             discv5::Event::UnverifiableEnr { enr, .. } => {
                                 if EnrValidation::validate(&enr, chain_id).is_valid() {
                                     debug!(target: "discovery", enr = ?enr, "Valid ENR discovered, forwarding to swarm");
-                                    Metrics::discovery_event("unverifiable_enr").increment(1.0);
+                                    Metrics::discovery_events("unverifiable_enr").increment(1.0);
                                     store.add_enr(enr.clone());
                                     let sender = enr_sender.clone();
                                     tokio::spawn(async move {
@@ -323,7 +323,7 @@ impl Discv5Driver {
                     _ = interval.tick() => {
                         let id = NodeId::random();
                         trace!(target: "discovery", node_id = %id, "Finding random node");
-                        Metrics::find_node_request().increment(1.0);
+                        Metrics::find_node_requests().increment(1.0);
                         let fut = self.disc.find_node(id);
                         let enr_sender = enr_sender.clone();
                         tokio::spawn(async move {

--- a/crates/consensus/disc/src/driver.rs
+++ b/crates/consensus/disc/src/driver.rs
@@ -280,7 +280,7 @@ impl Discv5Driver {
                             discv5::Event::Discovered(enr) => {
                                 if EnrValidation::validate(&enr, chain_id).is_valid() {
                                     debug!(target: "discovery", enr = ?enr, "Valid ENR discovered, forwarding to swarm");
-                                    Metrics::discovery_events("discovered").increment(1.0);
+                                    Metrics::discovery_event("discovered").increment(1.0);
                                     store.add_enr(enr.clone());
                                     let sender = enr_sender.clone();
                                     tokio::spawn(async move {
@@ -293,7 +293,7 @@ impl Discv5Driver {
                             discv5::Event::SessionEstablished(enr, addr) => {
                                 if EnrValidation::validate(&enr, chain_id).is_valid() {
                                     debug!(target: "discovery", addr = ?addr, enr = ?enr, "Session established with valid ENR, forwarding to swarm");
-                                    Metrics::discovery_events("session_established").increment(1.0);
+                                    Metrics::discovery_event("session_established").increment(1.0);
                                     store.add_enr(enr.clone());
                                     let sender = enr_sender.clone();
                                     tokio::spawn(async move {
@@ -306,7 +306,7 @@ impl Discv5Driver {
                             discv5::Event::UnverifiableEnr { enr, .. } => {
                                 if EnrValidation::validate(&enr, chain_id).is_valid() {
                                     debug!(target: "discovery", enr = ?enr, "Valid ENR discovered, forwarding to swarm");
-                                    Metrics::discovery_events("unverifiable_enr").increment(1.0);
+                                    Metrics::discovery_event("unverifiable_enr").increment(1.0);
                                     store.add_enr(enr.clone());
                                     let sender = enr_sender.clone();
                                     tokio::spawn(async move {
@@ -323,7 +323,7 @@ impl Discv5Driver {
                     _ = interval.tick() => {
                         let id = NodeId::random();
                         trace!(target: "discovery", node_id = %id, "Finding random node");
-                        Metrics::find_node_requests().increment(1.0);
+                        Metrics::find_node_request().increment(1.0);
                         let fut = self.disc.find_node(id);
                         let enr_sender = enr_sender.clone();
                         tokio::spawn(async move {

--- a/crates/consensus/disc/src/metrics.rs
+++ b/crates/consensus/disc/src/metrics.rs
@@ -1,18 +1,14 @@
 //! Metrics for the discovery service.
 
 base_metrics::define_metrics! {
-    base_node_disc
-
+    base_node
     #[describe("Events received by the discv5 service")]
-    #[label(r#type)]
-    discovery_event: gauge,
-
-    #[describe("Requests made to find a node through the discv5 peer discovery service")]
-    find_node_request: gauge,
-
+    #[label(kind)]
+    discovery_events: gauge,
+    #[describe("Number of FIND_NODE requests made through the discv5 peer discovery service")]
+    find_node_requests: gauge,
     #[describe("Observations of elapsed time to store ENRs in the on-disk bootstore")]
     enr_store_time: histogram,
-
     #[describe("Number of peers connected to the discv5 service")]
     discovery_peer_count: gauge,
 }
@@ -23,6 +19,7 @@ impl Metrics {
     /// This does two things:
     /// * Describes various metrics.
     /// * Initializes metrics to 0 so they can be queried immediately.
+    #[cfg(feature = "metrics")]
     pub fn init() {
         Self::describe();
         Self::zero();
@@ -31,13 +28,10 @@ impl Metrics {
     /// Initializes metrics to `0` so they can be queried immediately by consumers of prometheus
     /// metrics.
     pub fn zero() {
-        // Discovery Event
-        Self::discovery_event("discovered").set(0);
-        Self::discovery_event("session_established").set(0);
-        Self::discovery_event("unverifiable_enr").set(0);
-
-        // Peer Counts
-        Self::discovery_peer_count().set(0);
-        Self::find_node_request().set(0);
+        Self::discovery_events("discovered").set(0.0);
+        Self::discovery_events("session_established").set(0.0);
+        Self::discovery_events("unverifiable_enr").set(0.0);
+        Self::find_node_requests().set(0.0);
+        Self::discovery_peer_count().set(0.0);
     }
 }

--- a/crates/consensus/disc/src/metrics.rs
+++ b/crates/consensus/disc/src/metrics.rs
@@ -1,14 +1,18 @@
 //! Metrics for the discovery service.
 
 base_metrics::define_metrics! {
-    base_node
+    base_node_disc
+
     #[describe("Events received by the discv5 service")]
-    #[label(kind)]
-    discovery_events: gauge,
-    #[describe("Number of FIND_NODE requests made through the discv5 peer discovery service")]
-    find_node_requests: gauge,
+    #[label(r#type)]
+    discovery_event: gauge,
+
+    #[describe("Requests made to find a node through the discv5 peer discovery service")]
+    find_node_request: gauge,
+
     #[describe("Observations of elapsed time to store ENRs in the on-disk bootstore")]
     enr_store_time: histogram,
+
     #[describe("Number of peers connected to the discv5 service")]
     discovery_peer_count: gauge,
 }
@@ -28,10 +32,10 @@ impl Metrics {
     /// Initializes metrics to `0` so they can be queried immediately by consumers of prometheus
     /// metrics.
     pub fn zero() {
-        Self::discovery_events("discovered").set(0.0);
-        Self::discovery_events("session_established").set(0.0);
-        Self::discovery_events("unverifiable_enr").set(0.0);
-        Self::find_node_requests().set(0.0);
+        Self::discovery_event("discovered").set(0.0);
+        Self::discovery_event("session_established").set(0.0);
+        Self::discovery_event("unverifiable_enr").set(0.0);
+        Self::find_node_request().set(0.0);
         Self::discovery_peer_count().set(0.0);
     }
 }

--- a/crates/consensus/engine/src/client.rs
+++ b/crates/consensus/engine/src/client.rs
@@ -1,6 +1,6 @@
 //! An Engine API Client.
 
-use std::{future::Future, sync::Arc, time::Instant};
+use std::{future::Future, sync::Arc};
 
 use alloy_eips::{BlockId, eip1898::BlockNumberOrTag};
 use alloy_network::{Ethereum, Network};
@@ -380,24 +380,8 @@ async fn record_call_time<T, Err>(
     f: impl Future<Output = Result<T, Err>>,
     metric_label: &'static str,
 ) -> Result<T, Err> {
-    // Await on the future and track its duration.
-    let start = Instant::now();
-    let result = f.await?;
-
-    // Record the call duration.
-    #[cfg(feature = "metrics")]
-    {
-        let duration = start.elapsed();
-        base_metrics::record!(
-            histogram,
-            Metrics::ENGINE_METHOD_REQUEST_DURATION,
-            "method",
-            metric_label,
-            duration.as_secs_f64()
-        );
-    }
-    #[cfg(not(feature = "metrics"))]
-    let _ = (start, metric_label);
+    let result =
+        base_metrics::time!(Metrics::engine_method_request_duration(metric_label), { f.await? });
 
     Ok(result)
 }

--- a/crates/consensus/engine/src/metrics/mod.rs
+++ b/crates/consensus/engine/src/metrics/mod.rs
@@ -3,36 +3,28 @@
 //! Provides metric identifiers and labels for monitoring engine performance,
 //! task execution, and block progression through safety levels.
 
-/// Metrics container with constants for Prometheus metric collection.
-///
-/// Contains identifiers for gauges, counters, and histograms used to monitor
-/// engine operations when the `metrics` feature is enabled. Metrics track:
-///
-/// - Block progression through safety levels (unsafe → finalized)
-/// - Task execution success/failure rates by type
-/// - Engine API method call latencies
-///
-/// # Usage
-///
-/// ```rust,ignore
-/// use metrics::{counter, gauge, histogram};
-/// use base_consensus_engine::Metrics;
-///
-/// // Track successful task execution
-/// counter!(Metrics::ENGINE_TASK_SUCCESS, "task" => Metrics::INSERT_TASK_LABEL);
-///
-/// // Record block height at safety level
-/// gauge!(Metrics::BLOCK_LABELS, block_num as f64, "level" => Metrics::SAFE_BLOCK_LABEL);
-///
-/// // Time Engine API calls
-/// histogram!(Metrics::ENGINE_METHOD_REQUEST_DURATION, duration.as_secs_f64());
-/// ```
-#[derive(Debug, Clone)]
-pub struct Metrics;
+base_metrics::define_metrics! {
+    base_node
+    #[describe("Blockchain head labels")]
+    #[label(label)]
+    block_labels: gauge,
+    #[describe("Engine tasks successfully executed")]
+    #[label(task)]
+    engine_task_count: counter,
+    #[describe("Engine tasks failed")]
+    #[label(task)]
+    #[label(severity)]
+    engine_task_failure: counter,
+    #[describe("Engine method request duration")]
+    #[label(method)]
+    engine_method_request_duration: histogram,
+    #[describe("Engine reset count")]
+    engine_reset_count: counter,
+    #[describe("Payloads dropped because unsafe head changed between build and seal")]
+    sequencer_unsafe_head_changed_total: counter,
+}
 
 impl Metrics {
-    /// Identifier for the gauge that tracks block labels.
-    pub const BLOCK_LABELS: &str = "base_node_block_labels";
     /// Unsafe block label.
     pub const UNSAFE_BLOCK_LABEL: &str = "unsafe";
     /// Cross-unsafe block label.
@@ -43,11 +35,6 @@ impl Metrics {
     pub const SAFE_BLOCK_LABEL: &str = "safe";
     /// Finalized block label.
     pub const FINALIZED_BLOCK_LABEL: &str = "finalized";
-
-    /// Identifier for the counter that records engine task counts.
-    pub const ENGINE_TASK_SUCCESS: &str = "base_node_engine_task_count";
-    /// Identifier for the counter that records engine task counts.
-    pub const ENGINE_TASK_FAILURE: &str = "base_node_engine_task_failure";
 
     /// Insert task label.
     pub const INSERT_TASK_LABEL: &str = "insert";
@@ -64,21 +51,21 @@ impl Metrics {
     /// Finalize task label.
     pub const FINALIZE_TASK_LABEL: &str = "finalize";
 
-    /// Identifier for the histogram that tracks engine method call time.
-    pub const ENGINE_METHOD_REQUEST_DURATION: &str = "base_node_engine_method_request_duration";
+    /// Temporary severity label.
+    pub const TEMPORARY_SEVERITY_LABEL: &str = "temporary";
+    /// Critical severity label.
+    pub const CRITICAL_SEVERITY_LABEL: &str = "critical";
+    /// Reset severity label.
+    pub const RESET_SEVERITY_LABEL: &str = "reset";
+    /// Flush severity label.
+    pub const FLUSH_SEVERITY_LABEL: &str = "flush";
+
     /// `engine_forkchoiceUpdatedV<N>` label
     pub const FORKCHOICE_UPDATE_METHOD: &str = "engine_forkchoiceUpdated";
     /// `engine_newPayloadV<N>` label.
     pub const NEW_PAYLOAD_METHOD: &str = "engine_newPayload";
     /// `engine_getPayloadV<N>` label.
     pub const GET_PAYLOAD_METHOD: &str = "engine_getPayload";
-
-    /// Identifier for the counter that tracks the number of times the engine has been reset.
-    pub const ENGINE_RESET_COUNT: &str = "base_node_engine_reset_count";
-
-    /// Counter for unsafe head changed since payload build (alertable).
-    pub const SEQUENCER_UNSAFE_HEAD_CHANGED_TOTAL: &str =
-        "base_node_sequencer_unsafe_head_changed_total";
 
     /// Initializes metrics for the engine.
     ///
@@ -91,61 +78,35 @@ impl Metrics {
         Self::zero();
     }
 
-    /// Describes metrics used in [`base_consensus_engine`][crate].
-    #[cfg(feature = "metrics")]
-    pub fn describe() {
-        // Block labels
-        metrics::describe_gauge!(Self::BLOCK_LABELS, "Blockchain head labels");
-
-        // Engine task counts
-        metrics::describe_counter!(Self::ENGINE_TASK_SUCCESS, "Engine tasks successfully executed");
-        metrics::describe_counter!(Self::ENGINE_TASK_FAILURE, "Engine tasks failed");
-
-        // Engine method request duration histogram
-        metrics::describe_histogram!(
-            Self::ENGINE_METHOD_REQUEST_DURATION,
-            metrics::Unit::Seconds,
-            "Engine method request duration"
-        );
-
-        // Engine reset counter
-        metrics::describe_counter!(
-            Self::ENGINE_RESET_COUNT,
-            metrics::Unit::Count,
-            "Engine reset count"
-        );
-
-        // Sequencer unsafe head changed counter
-        metrics::describe_counter!(
-            Self::SEQUENCER_UNSAFE_HEAD_CHANGED_TOTAL,
-            metrics::Unit::Count,
-            "Payloads dropped because unsafe head changed between build and seal"
-        );
-    }
-
     /// Initializes metrics to `0` so they can be queried immediately by consumers of prometheus
     /// metrics.
-    #[cfg(feature = "metrics")]
     pub fn zero() {
-        // Engine task counts
-        base_metrics::set!(counter, Self::ENGINE_TASK_SUCCESS, Self::INSERT_TASK_LABEL, 0);
-        base_metrics::set!(counter, Self::ENGINE_TASK_SUCCESS, Self::CONSOLIDATE_TASK_LABEL, 0);
-        base_metrics::set!(counter, Self::ENGINE_TASK_SUCCESS, Self::BUILD_TASK_LABEL, 0);
-        base_metrics::set!(counter, Self::ENGINE_TASK_SUCCESS, Self::FINALIZE_TASK_LABEL, 0);
-        base_metrics::set!(counter, Self::ENGINE_TASK_SUCCESS, Self::SEAL_TASK_LABEL, 0);
-        base_metrics::set!(counter, Self::ENGINE_TASK_SUCCESS, Self::GET_PAYLOAD_TASK_LABEL, 0);
+        Self::engine_task_count(Self::INSERT_TASK_LABEL).absolute(0);
+        Self::engine_task_count(Self::CONSOLIDATE_TASK_LABEL).absolute(0);
+        Self::engine_task_count(Self::BUILD_TASK_LABEL).absolute(0);
+        Self::engine_task_count(Self::FINALIZE_TASK_LABEL).absolute(0);
+        Self::engine_task_count(Self::SEAL_TASK_LABEL).absolute(0);
+        Self::engine_task_count(Self::GET_PAYLOAD_TASK_LABEL).absolute(0);
 
-        base_metrics::set!(counter, Self::ENGINE_TASK_FAILURE, Self::INSERT_TASK_LABEL, 0);
-        base_metrics::set!(counter, Self::ENGINE_TASK_FAILURE, Self::CONSOLIDATE_TASK_LABEL, 0);
-        base_metrics::set!(counter, Self::ENGINE_TASK_FAILURE, Self::BUILD_TASK_LABEL, 0);
-        base_metrics::set!(counter, Self::ENGINE_TASK_FAILURE, Self::FINALIZE_TASK_LABEL, 0);
-        base_metrics::set!(counter, Self::ENGINE_TASK_FAILURE, Self::SEAL_TASK_LABEL, 0);
-        base_metrics::set!(counter, Self::ENGINE_TASK_FAILURE, Self::GET_PAYLOAD_TASK_LABEL, 0);
+        for task in [
+            Self::INSERT_TASK_LABEL,
+            Self::CONSOLIDATE_TASK_LABEL,
+            Self::BUILD_TASK_LABEL,
+            Self::FINALIZE_TASK_LABEL,
+            Self::SEAL_TASK_LABEL,
+            Self::GET_PAYLOAD_TASK_LABEL,
+        ] {
+            for severity in [
+                Self::TEMPORARY_SEVERITY_LABEL,
+                Self::CRITICAL_SEVERITY_LABEL,
+                Self::RESET_SEVERITY_LABEL,
+                Self::FLUSH_SEVERITY_LABEL,
+            ] {
+                Self::engine_task_failure(task, severity).absolute(0);
+            }
+        }
 
-        // Engine reset count
-        base_metrics::set!(counter, Self::ENGINE_RESET_COUNT, 0);
-
-        // Sequencer unsafe head changed
-        base_metrics::set!(counter, Self::SEQUENCER_UNSAFE_HEAD_CHANGED_TOTAL, 0);
+        Self::engine_reset_count().absolute(0);
+        Self::sequencer_unsafe_head_changed_total().absolute(0);
     }
 }

--- a/crates/consensus/engine/src/state/core.rs
+++ b/crates/consensus/engine/src/state/core.rs
@@ -82,31 +82,24 @@ impl EngineSyncState {
     /// is not specified. Returns the new sync state.
     pub fn apply_update(self, sync_state_update: EngineSyncStateUpdate) -> Self {
         if let Some(unsafe_head) = sync_state_update.unsafe_head {
-            Self::update_block_label_metric(
-                Metrics::UNSAFE_BLOCK_LABEL,
-                unsafe_head.block_info.number,
-            );
+            Metrics::block_labels(Metrics::UNSAFE_BLOCK_LABEL)
+                .set(unsafe_head.block_info.number as f64);
         }
         if let Some(cross_unsafe_head) = sync_state_update.cross_unsafe_head {
-            Self::update_block_label_metric(
-                Metrics::CROSS_UNSAFE_BLOCK_LABEL,
-                cross_unsafe_head.block_info.number,
-            );
+            Metrics::block_labels(Metrics::CROSS_UNSAFE_BLOCK_LABEL)
+                .set(cross_unsafe_head.block_info.number as f64);
         }
         if let Some(local_safe_head) = sync_state_update.local_safe_head {
-            Self::update_block_label_metric(
-                Metrics::LOCAL_SAFE_BLOCK_LABEL,
-                local_safe_head.block_info.number,
-            );
+            Metrics::block_labels(Metrics::LOCAL_SAFE_BLOCK_LABEL)
+                .set(local_safe_head.block_info.number as f64);
         }
         if let Some(safe_head) = sync_state_update.safe_head {
-            Self::update_block_label_metric(Metrics::SAFE_BLOCK_LABEL, safe_head.block_info.number);
+            Metrics::block_labels(Metrics::SAFE_BLOCK_LABEL)
+                .set(safe_head.block_info.number as f64);
         }
         if let Some(finalized_head) = sync_state_update.finalized_head {
-            Self::update_block_label_metric(
-                Metrics::FINALIZED_BLOCK_LABEL,
-                finalized_head.block_info.number,
-            );
+            Metrics::block_labels(Metrics::FINALIZED_BLOCK_LABEL)
+                .set(finalized_head.block_info.number as f64);
         }
 
         Self {
@@ -119,18 +112,6 @@ impl EngineSyncState {
             finalized_head: sync_state_update.finalized_head.unwrap_or(self.finalized_head),
         }
     }
-
-    /// Updates a block label metric, keyed by the label.
-    #[cfg(feature = "metrics")]
-    #[inline]
-    fn update_block_label_metric(label: &'static str, number: u64) {
-        base_metrics::set!(gauge, Metrics::BLOCK_LABELS, "label", label, number as f64);
-    }
-
-    /// Updates a block label metric, keyed by the label.
-    #[cfg(not(feature = "metrics"))]
-    #[inline]
-    const fn update_block_label_metric(_label: &'static str, _number: u64) {}
 }
 
 /// Specifies how to update the sync state of the engine.
@@ -250,7 +231,7 @@ mod tests {
         #[case] number: u64,
     ) {
         let handle = PrometheusBuilder::new().install_recorder().unwrap();
-        crate::Metrics::init();
+        Metrics::init();
 
         let mut state = EngineState::default();
         set_fn(
@@ -262,7 +243,7 @@ mod tests {
         );
 
         assert!(handle.render().contains(
-            format!("base_node_block_labels{{label=\"{label_name}\"}} {number}").as_str()
+            format!("base_node.block_labels{{label=\"{label_name}\"}} {number}").as_str()
         ));
     }
 }

--- a/crates/consensus/engine/src/state/core.rs
+++ b/crates/consensus/engine/src/state/core.rs
@@ -175,7 +175,7 @@ mod tests {
     impl EngineState {
         /// Set the unsafe head.
         pub fn set_unsafe_head(&mut self, unsafe_head: L2BlockInfo) {
-            self.sync_state.apply_update(EngineSyncStateUpdate {
+            self.sync_state = self.sync_state.apply_update(EngineSyncStateUpdate {
                 unsafe_head: Some(unsafe_head),
                 ..Default::default()
             });
@@ -183,7 +183,7 @@ mod tests {
 
         /// Set the cross-verified unsafe head.
         pub fn set_cross_unsafe_head(&mut self, cross_unsafe_head: L2BlockInfo) {
-            self.sync_state.apply_update(EngineSyncStateUpdate {
+            self.sync_state = self.sync_state.apply_update(EngineSyncStateUpdate {
                 cross_unsafe_head: Some(cross_unsafe_head),
                 ..Default::default()
             });
@@ -191,7 +191,7 @@ mod tests {
 
         /// Set the local safe head.
         pub fn set_local_safe_head(&mut self, local_safe_head: L2BlockInfo) {
-            self.sync_state.apply_update(EngineSyncStateUpdate {
+            self.sync_state = self.sync_state.apply_update(EngineSyncStateUpdate {
                 local_safe_head: Some(local_safe_head),
                 ..Default::default()
             });
@@ -199,7 +199,7 @@ mod tests {
 
         /// Set the safe head.
         pub fn set_safe_head(&mut self, safe_head: L2BlockInfo) {
-            self.sync_state.apply_update(EngineSyncStateUpdate {
+            self.sync_state = self.sync_state.apply_update(EngineSyncStateUpdate {
                 safe_head: Some(safe_head),
                 ..Default::default()
             });
@@ -207,7 +207,7 @@ mod tests {
 
         /// Set the finalized head.
         pub fn set_finalized_head(&mut self, finalized_head: L2BlockInfo) {
-            self.sync_state.apply_update(EngineSyncStateUpdate {
+            self.sync_state = self.sync_state.apply_update(EngineSyncStateUpdate {
                 finalized_head: Some(finalized_head),
                 ..Default::default()
             });
@@ -243,7 +243,7 @@ mod tests {
         );
 
         assert!(handle.render().contains(
-            format!("base_node.block_labels{{label=\"{label_name}\"}} {number}").as_str()
+            format!("base_node_block_labels{{label=\"{label_name}\"}} {number}").as_str()
         ));
     }
 }

--- a/crates/consensus/engine/src/task_queue/core.rs
+++ b/crates/consensus/engine/src/task_queue/core.rs
@@ -8,11 +8,9 @@ use thiserror::Error;
 use tokio::sync::watch::Sender;
 
 use super::EngineTaskExt;
-#[cfg(feature = "metrics")]
-use crate::Metrics;
 use crate::{
     EngineClient, EngineState, EngineSyncStateUpdate, EngineTask, EngineTaskError,
-    EngineTaskErrorSeverity, SyncStartError, SynchronizeTask, SynchronizeTaskError,
+    EngineTaskErrorSeverity, Metrics, SyncStartError, SynchronizeTask, SynchronizeTaskError,
     find_starting_forkchoice, task_queue::EngineTaskErrors,
 };
 
@@ -141,7 +139,7 @@ impl<EngineClient_: EngineClient> Engine<EngineClient_> {
             .map_transactions(|t| t.inner.inner.into_inner());
         let system_config = to_system_config(&l2_safe_block, &config)?;
 
-        base_metrics::inc!(counter, Metrics::ENGINE_RESET_COUNT);
+        Metrics::engine_reset_count().increment(1);
 
         Ok((start.safe, l1_origin_info, system_config))
     }

--- a/crates/consensus/engine/src/task_queue/tasks/get_payload/task.rs
+++ b/crates/consensus/engine/src/task_queue/tasks/get_payload/task.rs
@@ -10,7 +10,7 @@ use derive_more::Constructor;
 use tokio::sync::mpsc;
 
 use super::super::SealTaskError;
-use crate::{EngineClient, EngineGetPayloadVersion, EngineState, EngineTaskExt};
+use crate::{EngineClient, EngineGetPayloadVersion, EngineState, EngineTaskExt, Metrics};
 
 /// Task for fetching a sealed payload from the engine without inserting it.
 ///
@@ -155,7 +155,7 @@ impl<EngineClient_: EngineClient> EngineTaskExt for GetPayloadTask<EngineClient_
                 parent_block_info = ?parent_block_info,
                 "GetPayload attributes parent does not match unsafe head, returning rebuild error"
             );
-            base_metrics::inc!(counter, crate::Metrics::SEQUENCER_UNSAFE_HEAD_CHANGED_TOTAL);
+            Metrics::sequencer_unsafe_head_changed_total().increment(1);
             Err(SealTaskError::UnsafeHeadChangedSinceBuild)
         } else {
             self.get_payload(&self.cfg, &self.engine, self.payload_id, &self.attributes).await

--- a/crates/consensus/engine/src/task_queue/tasks/task.rs
+++ b/crates/consensus/engine/src/task_queue/tasks/task.rs
@@ -77,6 +77,18 @@ pub enum EngineTaskErrors {
     Finalize(#[from] FinalizeTaskError),
 }
 
+impl EngineTaskErrorSeverity {
+    /// Returns a static string label for use in metrics.
+    pub const fn as_label(self) -> &'static str {
+        match self {
+            Self::Temporary => "temporary",
+            Self::Critical => "critical",
+            Self::Reset => "reset",
+            Self::Flush => "flush",
+        }
+    }
+}
+
 impl EngineTaskError for EngineTaskErrors {
     fn severity(&self) -> EngineTaskErrorSeverity {
         match self {
@@ -219,7 +231,7 @@ impl<EngineClient_: EngineClient> EngineTaskExt for EngineTask<EngineClient_> {
         while let Err(e) = self.execute_inner(state).await {
             let severity = e.severity();
 
-            Metrics::engine_task_failure(self.task_metrics_label(), severity.to_string())
+            Metrics::engine_task_failure(self.task_metrics_label(), severity.as_label())
                 .increment(1);
 
             match severity {

--- a/crates/consensus/engine/src/task_queue/tasks/task.rs
+++ b/crates/consensus/engine/src/task_queue/tasks/task.rs
@@ -12,7 +12,7 @@ use tokio::task::yield_now;
 use super::{BuildTask, ConsolidateTask, FinalizeTask, GetPayloadTask, InsertTask};
 use crate::{
     BuildTaskError, ConsolidateTaskError, EngineClient, EngineState, FinalizeTaskError,
-    InsertTaskError,
+    InsertTaskError, Metrics,
     task_queue::{SealTask, SealTaskError},
 };
 
@@ -127,15 +127,14 @@ impl<EngineClient_: EngineClient> EngineTask<EngineClient_> {
         Ok(())
     }
 
-    #[cfg(feature = "metrics")]
     const fn task_metrics_label(&self) -> &'static str {
         match self {
-            Self::Insert(_) => crate::Metrics::INSERT_TASK_LABEL,
-            Self::Consolidate(_) => crate::Metrics::CONSOLIDATE_TASK_LABEL,
-            Self::Build(_) => crate::Metrics::BUILD_TASK_LABEL,
-            Self::Seal(_) => crate::Metrics::SEAL_TASK_LABEL,
-            Self::GetPayload(_) => crate::Metrics::GET_PAYLOAD_TASK_LABEL,
-            Self::Finalize(_) => crate::Metrics::FINALIZE_TASK_LABEL,
+            Self::Insert(_) => Metrics::INSERT_TASK_LABEL,
+            Self::Consolidate(_) => Metrics::CONSOLIDATE_TASK_LABEL,
+            Self::Build(_) => Metrics::BUILD_TASK_LABEL,
+            Self::Seal(_) => Metrics::SEAL_TASK_LABEL,
+            Self::GetPayload(_) => Metrics::GET_PAYLOAD_TASK_LABEL,
+            Self::Finalize(_) => Metrics::FINALIZE_TASK_LABEL,
         }
     }
 }
@@ -220,11 +219,8 @@ impl<EngineClient_: EngineClient> EngineTaskExt for EngineTask<EngineClient_> {
         while let Err(e) = self.execute_inner(state).await {
             let severity = e.severity();
 
-            base_metrics::inc!(
-                counter,
-                crate::Metrics::ENGINE_TASK_FAILURE,
-                self.task_metrics_label() => severity.to_string()
-            );
+            Metrics::engine_task_failure(self.task_metrics_label(), severity.to_string())
+                .increment(1);
 
             match severity {
                 EngineTaskErrorSeverity::Temporary => {
@@ -250,7 +246,7 @@ impl<EngineClient_: EngineClient> EngineTaskExt for EngineTask<EngineClient_> {
             }
         }
 
-        base_metrics::inc!(counter, crate::Metrics::ENGINE_TASK_SUCCESS, self.task_metrics_label());
+        Metrics::engine_task_count(self.task_metrics_label()).increment(1);
 
         Ok(())
     }

--- a/crates/consensus/providers-alloy/src/beacon_client.rs
+++ b/crates/consensus/providers-alloy/src/beacon_client.rs
@@ -10,9 +10,7 @@ use async_trait::async_trait;
 use c_kzg::Blob;
 use thiserror::Error;
 
-#[cfg(feature = "metrics")]
-use crate::Metrics;
-use crate::blobs::BoxedBlob;
+use crate::{Metrics, blobs::BoxedBlob};
 
 /// The config spec engine api method.
 const SPEC_METHOD: &str = "eth/v1/config/spec";
@@ -221,7 +219,7 @@ impl BeaconClient for OnlineBeaconClient {
     }
 
     async fn slot_interval(&self) -> Result<APIConfigResponse, Self::Error> {
-        base_metrics::inc!(gauge, Metrics::BEACON_CLIENT_REQUESTS, "method" => "spec");
+        Metrics::beacon_requests("spec").increment(1);
 
         // Use the l1 slot duration if provided
         if let Some(l1_slot_duration) = self.l1_slot_duration {
@@ -235,14 +233,14 @@ impl BeaconClient for OnlineBeaconClient {
         .await;
 
         if result.is_err() {
-            base_metrics::inc!(gauge, Metrics::BEACON_CLIENT_ERRORS, "method" => "spec");
+            Metrics::beacon_errors("spec").increment(1);
         }
 
         Ok(result?)
     }
 
     async fn genesis_time(&self) -> Result<APIGenesisResponse, Self::Error> {
-        base_metrics::inc!(gauge, Metrics::BEACON_CLIENT_REQUESTS, "method" => "genesis");
+        Metrics::beacon_requests("genesis").increment(1);
 
         let result = async {
             let first = self.inner.get(format!("{}/{}", self.base, GENESIS_METHOD)).send().await?;
@@ -251,7 +249,7 @@ impl BeaconClient for OnlineBeaconClient {
         .await;
 
         if result.is_err() {
-            base_metrics::inc!(gauge, Metrics::BEACON_CLIENT_ERRORS, "method" => "genesis");
+            Metrics::beacon_errors("genesis").increment(1);
         }
 
         Ok(result?)
@@ -262,13 +260,13 @@ impl BeaconClient for OnlineBeaconClient {
         slot: u64,
         blob_hashes: &[B256],
     ) -> Result<Vec<BoxedBlob>, BeaconClientError> {
-        base_metrics::inc!(gauge, Metrics::BEACON_CLIENT_REQUESTS, "method" => "blobs");
+        Metrics::beacon_requests("blobs").increment(1);
 
         // Try to get the blobs from the blobs endpoint.
         let result = self.filtered_beacon_blobs(slot, blob_hashes).await;
 
         if result.is_err() {
-            base_metrics::inc!(gauge, Metrics::BEACON_CLIENT_ERRORS, "method" => "blobs");
+            Metrics::beacon_errors("blobs").increment(1);
         }
 
         result

--- a/crates/consensus/providers-alloy/src/blobs.rs
+++ b/crates/consensus/providers-alloy/src/blobs.rs
@@ -9,9 +9,7 @@ use base_consensus_derive::{BlobProvider, BlobProviderError};
 use base_protocol::BlockInfo;
 use tracing::warn;
 
-use crate::BeaconClient;
-#[cfg(feature = "metrics")]
-use crate::Metrics;
+use crate::{BeaconClient, Metrics};
 
 /// A boxed blob.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -88,7 +86,7 @@ impl<B: BeaconClient> OnlineBlobProvider<B> {
         slot: u64,
         blob_hashes: &[B256],
     ) -> Result<Vec<BoxedBlob>, BlobProviderError> {
-        base_metrics::inc!(gauge, Metrics::BLOB_FETCHES);
+        Metrics::blob_fetches().increment(1);
 
         let result =
             self.beacon_client.filtered_beacon_blobs(slot, blob_hashes).await.map_err(|e| {
@@ -107,9 +105,8 @@ impl<B: BeaconClient> OnlineBlobProvider<B> {
                 BlobProviderError::BlobNotFound { slot: missing_slot, reason: e.to_string() }
             });
 
-        #[cfg(feature = "metrics")]
         if result.is_err() {
-            base_metrics::inc!(gauge, Metrics::BLOB_FETCH_ERRORS);
+            Metrics::blob_fetch_errors().increment(1);
         }
 
         result

--- a/crates/consensus/providers-alloy/src/chain_provider.rs
+++ b/crates/consensus/providers-alloy/src/chain_provider.rs
@@ -12,7 +12,6 @@ use base_consensus_derive::{ChainProvider, PipelineError, PipelineErrorKind, Res
 use base_protocol::BlockInfo;
 use lru::LruCache;
 
-#[cfg(feature = "metrics")]
 use crate::Metrics;
 
 /// The [`AlloyChainProvider`] is a concrete implementation of the [`ChainProvider`] trait, providing
@@ -64,13 +63,12 @@ impl AlloyChainProvider {
 
     /// Returns the latest L2 block number.
     pub async fn latest_block_number(&mut self) -> Result<u64, RpcError<TransportErrorKind>> {
-        base_metrics::inc!(gauge, Metrics::CHAIN_PROVIDER_RPC_CALLS, "method" => "block_number");
+        Metrics::chain_rpc_calls("block_number").increment(1);
 
         let result = self.inner.get_block_number().await;
 
-        #[cfg(feature = "metrics")]
         if result.is_err() {
-            base_metrics::inc!(gauge, Metrics::CHAIN_PROVIDER_RPC_ERRORS, "method" => "block_number");
+            Metrics::chain_rpc_errors("block_number").increment(1);
         }
 
         result
@@ -154,20 +152,20 @@ impl ChainProvider for AlloyChainProvider {
 
     async fn header_by_hash(&mut self, hash: B256) -> Result<Header, Self::Error> {
         if let Some(header) = self.header_by_hash_cache.get(&hash) {
-            base_metrics::inc!(gauge, Metrics::CHAIN_PROVIDER_CACHE_HITS, "cache" => "header_by_hash");
+            Metrics::chain_cache_hits("header_by_hash").increment(1);
             return Ok(header.clone());
         }
 
-        base_metrics::inc!(gauge, Metrics::CHAIN_PROVIDER_CACHE_MISSES, "cache" => "header_by_hash");
+        Metrics::chain_cache_misses("header_by_hash").increment(1);
 
-        base_metrics::inc!(gauge, Metrics::CHAIN_PROVIDER_RPC_CALLS, "method" => "header_by_hash");
+        Metrics::chain_rpc_calls("header_by_hash").increment(1);
 
         let block = self
             .inner
             .get_block_by_hash(hash)
             .await
             .inspect_err(|_e| {
-                base_metrics::inc!(gauge, Metrics::CHAIN_PROVIDER_RPC_ERRORS, "method" => "header_by_hash");
+                Metrics::chain_rpc_errors("header_by_hash").increment(1);
             })?
             .ok_or(AlloyChainProviderError::BlockNotFound(hash.into()))?;
         let header = block.header.into_consensus();
@@ -177,20 +175,20 @@ impl ChainProvider for AlloyChainProvider {
 
         self.header_by_hash_cache.put(hash, header.clone());
 
-        base_metrics::inc!(gauge, Metrics::CACHE_ENTRIES, "cache" => "header_by_hash");
+        Metrics::cache_entries("header_by_hash").increment(1);
 
         Ok(header)
     }
 
     async fn block_info_by_number(&mut self, number: u64) -> Result<BlockInfo, Self::Error> {
-        base_metrics::inc!(gauge, Metrics::CHAIN_PROVIDER_RPC_CALLS, "method" => "block_by_number");
+        Metrics::chain_rpc_calls("block_by_number").increment(1);
 
         let block = self
             .inner
             .get_block_by_number(number.into())
             .await
             .inspect_err(|_e| {
-                base_metrics::inc!(gauge, Metrics::CHAIN_PROVIDER_RPC_ERRORS, "method" => "block_by_number");
+                Metrics::chain_rpc_errors("block_by_number").increment(1);
             })?
             .ok_or(AlloyChainProviderError::BlockNotFound(number.into()))?;
         let header = block.header.into_consensus();
@@ -206,20 +204,20 @@ impl ChainProvider for AlloyChainProvider {
 
     async fn receipts_by_hash(&mut self, hash: B256) -> Result<Vec<Receipt>, Self::Error> {
         if let Some(receipts) = self.receipts_by_hash_cache.get(&hash) {
-            base_metrics::inc!(gauge, Metrics::CHAIN_PROVIDER_CACHE_HITS, "cache" => "receipts_by_hash");
+            Metrics::chain_cache_hits("receipts_by_hash").increment(1);
             return Ok(receipts.clone());
         }
 
-        base_metrics::inc!(gauge, Metrics::CHAIN_PROVIDER_CACHE_MISSES, "cache" => "receipts_by_hash");
+        Metrics::chain_cache_misses("receipts_by_hash").increment(1);
 
-        base_metrics::inc!(gauge, Metrics::CHAIN_PROVIDER_RPC_CALLS, "method" => "receipts_by_hash");
+        Metrics::chain_rpc_calls("receipts_by_hash").increment(1);
 
         let receipts = self
             .inner
             .get_block_receipts(hash.into())
             .await
             .inspect_err(|_e| {
-                base_metrics::inc!(gauge, Metrics::CHAIN_PROVIDER_RPC_ERRORS, "method" => "receipts_by_hash");
+                Metrics::chain_rpc_errors("receipts_by_hash").increment(1);
             })?
             .ok_or(AlloyChainProviderError::BlockNotFound(hash.into()))?;
         let consensus_receipts = receipts
@@ -230,7 +228,7 @@ impl ChainProvider for AlloyChainProvider {
 
         self.receipts_by_hash_cache.put(hash, consensus_receipts.clone());
 
-        base_metrics::inc!(gauge, Metrics::CACHE_ENTRIES, "cache" => "receipts_by_hash");
+        Metrics::cache_entries("receipts_by_hash").increment(1);
 
         Ok(consensus_receipts)
     }
@@ -241,13 +239,13 @@ impl ChainProvider for AlloyChainProvider {
     ) -> Result<(BlockInfo, Vec<TxEnvelope>), Self::Error> {
         if let Some(block_info_and_txs) = self.block_info_and_transactions_by_hash_cache.get(&hash)
         {
-            base_metrics::inc!(gauge, Metrics::CHAIN_PROVIDER_CACHE_HITS, "cache" => "block_info_and_tx");
+            Metrics::chain_cache_hits("block_info_and_tx").increment(1);
             return Ok(block_info_and_txs.clone());
         }
 
-        base_metrics::inc!(gauge, Metrics::CHAIN_PROVIDER_CACHE_MISSES, "cache" => "block_info_and_tx");
+        Metrics::chain_cache_misses("block_info_and_tx").increment(1);
 
-        base_metrics::inc!(gauge, Metrics::CHAIN_PROVIDER_RPC_CALLS, "method" => "block_by_hash");
+        Metrics::chain_rpc_calls("block_by_hash").increment(1);
 
         let block = self
             .inner
@@ -255,7 +253,7 @@ impl ChainProvider for AlloyChainProvider {
             .full()
             .await
             .inspect_err(|_e| {
-                base_metrics::inc!(gauge, Metrics::CHAIN_PROVIDER_RPC_ERRORS, "method" => "block_by_hash");
+                Metrics::chain_rpc_errors("block_by_hash").increment(1);
             })?
             .ok_or(AlloyChainProviderError::BlockNotFound(hash.into()))?
             .into_consensus()
@@ -274,7 +272,7 @@ impl ChainProvider for AlloyChainProvider {
         self.block_info_and_transactions_by_hash_cache
             .put(hash, (block_info, block.body.transactions.clone()));
 
-        base_metrics::inc!(gauge, Metrics::CACHE_ENTRIES, "cache" => "block_info_and_tx");
+        Metrics::cache_entries("block_info_and_tx").increment(1);
 
         Ok((block_info, block.body.transactions))
     }

--- a/crates/consensus/providers-alloy/src/l2_chain_provider.rs
+++ b/crates/consensus/providers-alloy/src/l2_chain_provider.rs
@@ -22,7 +22,6 @@ use http_body_util::Full;
 use lru::LruCache;
 use tower::ServiceBuilder;
 
-#[cfg(feature = "metrics")]
 use crate::Metrics;
 
 /// The [`AlloyL2ChainProvider`] is a concrete implementation of the [`L2ChainProvider`] trait,
@@ -106,13 +105,12 @@ impl AlloyL2ChainProvider {
         &mut self,
         id: BlockId,
     ) -> Result<Option<L2BlockInfo>, RpcError<TransportErrorKind>> {
-        #[cfg(feature = "metrics")]
         let method_name = match id {
             BlockId::Number(_) => "l2_block_ref_by_number",
             BlockId::Hash(_) => "l2_block_ref_by_hash",
         };
 
-        base_metrics::inc!(gauge, Metrics::L2_CHAIN_PROVIDER_REQUESTS, "method" => method_name);
+        Metrics::l2_chain_requests(method_name).increment(1);
 
         let result = async {
             let block = match id {
@@ -150,9 +148,8 @@ impl AlloyL2ChainProvider {
         }
         .await;
 
-        #[cfg(feature = "metrics")]
         if result.is_err() {
-            base_metrics::inc!(gauge, Metrics::L2_CHAIN_PROVIDER_ERRORS, "method" => method_name);
+            Metrics::l2_chain_errors(method_name).increment(1);
         }
 
         result
@@ -233,7 +230,7 @@ impl BatchValidationProvider for AlloyL2ChainProvider {
             return Ok(block.clone());
         }
 
-        base_metrics::inc!(gauge, Metrics::L2_CHAIN_PROVIDER_REQUESTS, "method" => "l2_block_ref_by_number");
+        Metrics::l2_chain_requests("l2_block_ref_by_number").increment(1);
 
         let block = self
             .inner
@@ -241,7 +238,7 @@ impl BatchValidationProvider for AlloyL2ChainProvider {
             .full()
             .await
             .map_err(|e| {
-                base_metrics::inc!(gauge, Metrics::L2_CHAIN_PROVIDER_ERRORS, "method" => "l2_block_ref_by_number");
+                Metrics::l2_chain_errors("l2_block_ref_by_number").increment(1);
                 AlloyL2ChainProviderError::Transport(e)
             })?
             .ok_or(AlloyL2ChainProviderError::BlockNotFound(number))?

--- a/crates/consensus/providers-alloy/src/metrics.rs
+++ b/crates/consensus/providers-alloy/src/metrics.rs
@@ -1,49 +1,46 @@
 //! Metrics for the Alloy providers.
 
-/// Container for metrics.
-#[derive(Debug, Clone)]
-pub struct Metrics;
+base_metrics::define_metrics! {
+    base_providers
+    #[describe("Number of cache hits in chain provider")]
+    #[label(cache)]
+    chain_cache_hits: gauge,
+    #[describe("Number of cache misses in chain provider")]
+    #[label(cache)]
+    chain_cache_misses: gauge,
+    #[describe("Number of RPC calls made by chain provider")]
+    #[label(method)]
+    chain_rpc_calls: gauge,
+    #[describe("Number of RPC errors in chain provider")]
+    #[label(method)]
+    chain_rpc_errors: gauge,
+    #[describe("Number of requests made to beacon client")]
+    #[label(method)]
+    beacon_requests: gauge,
+    #[describe("Number of errors in beacon client requests")]
+    #[label(method)]
+    beacon_errors: gauge,
+    #[describe("Number of requests made to L2 chain provider")]
+    #[label(method)]
+    l2_chain_requests: gauge,
+    #[describe("Number of errors in L2 chain provider requests")]
+    #[label(method)]
+    l2_chain_errors: gauge,
+    #[describe("Number of blob sidecar fetches")]
+    blob_fetches: gauge,
+    #[describe("Number of blob sidecar fetch errors")]
+    blob_fetch_errors: gauge,
+    #[describe("Duration of provider requests in seconds")]
+    request_duration: histogram,
+    #[describe("Number of active entries in provider caches")]
+    #[label(cache)]
+    cache_entries: gauge,
+    #[describe("Memory usage of provider caches in bytes")]
+    #[label(cache)]
+    cache_memory_bytes: gauge,
+}
 
 impl Metrics {
-    /// Identifier for the gauge that tracks chain provider cache hits.
-    pub const CHAIN_PROVIDER_CACHE_HITS: &str = "base_providers_chain_cache_hits";
-
-    /// Identifier for the gauge that tracks chain provider cache misses.
-    pub const CHAIN_PROVIDER_CACHE_MISSES: &str = "base_providers_chain_cache_misses";
-
-    /// Identifier for the gauge that tracks chain provider RPC calls.
-    pub const CHAIN_PROVIDER_RPC_CALLS: &str = "base_providers_chain_rpc_calls";
-
-    /// Identifier for the gauge that tracks chain provider RPC errors.
-    pub const CHAIN_PROVIDER_RPC_ERRORS: &str = "base_providers_chain_rpc_errors";
-
-    /// Identifier for the gauge that tracks beacon client requests.
-    pub const BEACON_CLIENT_REQUESTS: &str = "base_providers_beacon_requests";
-
-    /// Identifier for the gauge that tracks beacon client errors.
-    pub const BEACON_CLIENT_ERRORS: &str = "base_providers_beacon_errors";
-
-    /// Identifier for the gauge that tracks L2 chain provider requests.
-    pub const L2_CHAIN_PROVIDER_REQUESTS: &str = "base_providers_l2_chain_requests";
-
-    /// Identifier for the gauge that tracks L2 chain provider errors.
-    pub const L2_CHAIN_PROVIDER_ERRORS: &str = "base_providers_l2_chain_errors";
-
-    /// Identifier for the gauge that tracks blob fetches.
-    pub const BLOB_FETCHES: &str = "base_providers_blob_fetches";
-
-    /// Identifier for the gauge that tracks blob fetch errors.
-    pub const BLOB_FETCH_ERRORS: &str = "base_providers_blob_fetch_errors";
-
-    /// Identifier for the histogram that tracks provider request duration.
-    pub const PROVIDER_REQUEST_DURATION: &str = "base_providers_request_duration";
-
-    /// Identifier for the gauge that tracks active cache entries.
-    pub const CACHE_ENTRIES: &str = "base_providers_cache_entries";
-
-    /// Identifier for the gauge that tracks cache memory usage.
-    pub const CACHE_MEMORY_USAGE: &str = "base_providers_cache_memory_bytes";
-
     /// Initializes metrics for the Alloy providers.
     ///
     /// This does two things:
@@ -55,161 +52,54 @@ impl Metrics {
         Self::zero();
     }
 
-    /// Describes metrics used in [`base_consensus_providers`][crate].
-    #[cfg(feature = "metrics")]
-    pub fn describe() {
-        metrics::describe_gauge!(
-            Self::CHAIN_PROVIDER_CACHE_HITS,
-            "Number of cache hits in chain provider"
-        );
-        metrics::describe_gauge!(
-            Self::CHAIN_PROVIDER_CACHE_MISSES,
-            "Number of cache misses in chain provider"
-        );
-        metrics::describe_gauge!(
-            Self::CHAIN_PROVIDER_RPC_CALLS,
-            "Number of RPC calls made by chain provider"
-        );
-        metrics::describe_gauge!(
-            Self::CHAIN_PROVIDER_RPC_ERRORS,
-            "Number of RPC errors in chain provider"
-        );
-        metrics::describe_gauge!(
-            Self::BEACON_CLIENT_REQUESTS,
-            "Number of requests made to beacon client"
-        );
-        metrics::describe_gauge!(
-            Self::BEACON_CLIENT_ERRORS,
-            "Number of errors in beacon client requests"
-        );
-        metrics::describe_gauge!(
-            Self::L2_CHAIN_PROVIDER_REQUESTS,
-            "Number of requests made to L2 chain provider"
-        );
-        metrics::describe_gauge!(
-            Self::L2_CHAIN_PROVIDER_ERRORS,
-            "Number of errors in L2 chain provider requests"
-        );
-        metrics::describe_gauge!(Self::BLOB_FETCHES, "Number of blob sidecar fetches");
-        metrics::describe_gauge!(Self::BLOB_FETCH_ERRORS, "Number of blob sidecar fetch errors");
-        metrics::describe_histogram!(
-            Self::PROVIDER_REQUEST_DURATION,
-            "Duration of provider requests in seconds"
-        );
-        metrics::describe_gauge!(
-            Self::CACHE_ENTRIES,
-            "Number of active entries in provider caches"
-        );
-        metrics::describe_gauge!(
-            Self::CACHE_MEMORY_USAGE,
-            "Memory usage of provider caches in bytes"
-        );
-    }
-
     /// Initializes metrics to `0` so they can be queried immediately by consumers of prometheus
     /// metrics.
-    #[cfg(feature = "metrics")]
     pub fn zero() {
-        // Chain provider cache metrics
-        base_metrics::set!(gauge, Self::CHAIN_PROVIDER_CACHE_HITS, "cache", "header_by_hash", 0);
-        base_metrics::set!(gauge, Self::CHAIN_PROVIDER_CACHE_HITS, "cache", "receipts_by_hash", 0);
-        base_metrics::set!(gauge, Self::CHAIN_PROVIDER_CACHE_HITS, "cache", "block_info_and_tx", 0);
-        base_metrics::set!(gauge, Self::CHAIN_PROVIDER_CACHE_HITS, "cache", "block_by_number", 0);
+        Self::chain_cache_hits("header_by_hash").set(0.0);
+        Self::chain_cache_hits("receipts_by_hash").set(0.0);
+        Self::chain_cache_hits("block_info_and_tx").set(0.0);
+        Self::chain_cache_hits("block_by_number").set(0.0);
 
-        base_metrics::set!(gauge, Self::CHAIN_PROVIDER_CACHE_MISSES, "cache", "header_by_hash", 0);
-        base_metrics::set!(
-            gauge,
-            Self::CHAIN_PROVIDER_CACHE_MISSES,
-            "cache",
-            "receipts_by_hash",
-            0
-        );
-        base_metrics::set!(
-            gauge,
-            Self::CHAIN_PROVIDER_CACHE_MISSES,
-            "cache",
-            "block_info_and_tx",
-            0
-        );
-        base_metrics::set!(gauge, Self::CHAIN_PROVIDER_CACHE_MISSES, "cache", "block_by_number", 0);
+        Self::chain_cache_misses("header_by_hash").set(0.0);
+        Self::chain_cache_misses("receipts_by_hash").set(0.0);
+        Self::chain_cache_misses("block_info_and_tx").set(0.0);
+        Self::chain_cache_misses("block_by_number").set(0.0);
 
-        // RPC call metrics
-        base_metrics::set!(gauge, Self::CHAIN_PROVIDER_RPC_CALLS, "method", "header_by_hash", 0);
-        base_metrics::set!(gauge, Self::CHAIN_PROVIDER_RPC_CALLS, "method", "receipts_by_hash", 0);
-        base_metrics::set!(gauge, Self::CHAIN_PROVIDER_RPC_CALLS, "method", "block_by_hash", 0);
-        base_metrics::set!(gauge, Self::CHAIN_PROVIDER_RPC_CALLS, "method", "block_number", 0);
+        Self::chain_rpc_calls("header_by_hash").set(0.0);
+        Self::chain_rpc_calls("receipts_by_hash").set(0.0);
+        Self::chain_rpc_calls("block_by_hash").set(0.0);
+        Self::chain_rpc_calls("block_number").set(0.0);
 
-        // RPC error metrics
-        base_metrics::set!(gauge, Self::CHAIN_PROVIDER_RPC_ERRORS, "method", "header_by_hash", 0);
-        base_metrics::set!(gauge, Self::CHAIN_PROVIDER_RPC_ERRORS, "method", "receipts_by_hash", 0);
-        base_metrics::set!(gauge, Self::CHAIN_PROVIDER_RPC_ERRORS, "method", "block_by_hash", 0);
-        base_metrics::set!(gauge, Self::CHAIN_PROVIDER_RPC_ERRORS, "method", "block_number", 0);
+        Self::chain_rpc_errors("header_by_hash").set(0.0);
+        Self::chain_rpc_errors("receipts_by_hash").set(0.0);
+        Self::chain_rpc_errors("block_by_hash").set(0.0);
+        Self::chain_rpc_errors("block_number").set(0.0);
 
-        // Beacon client metrics
-        base_metrics::set!(gauge, Self::BEACON_CLIENT_REQUESTS, "method", "spec", 0);
-        base_metrics::set!(gauge, Self::BEACON_CLIENT_REQUESTS, "method", "genesis", 0);
-        base_metrics::set!(gauge, Self::BEACON_CLIENT_REQUESTS, "method", "blob_sidecars", 0);
+        Self::beacon_requests("spec").set(0.0);
+        Self::beacon_requests("genesis").set(0.0);
+        Self::beacon_requests("blob_sidecars").set(0.0);
 
-        base_metrics::set!(gauge, Self::BEACON_CLIENT_ERRORS, "method", "spec", 0);
-        base_metrics::set!(gauge, Self::BEACON_CLIENT_ERRORS, "method", "genesis", 0);
-        base_metrics::set!(gauge, Self::BEACON_CLIENT_ERRORS, "method", "blob_sidecars", 0);
+        Self::beacon_errors("spec").set(0.0);
+        Self::beacon_errors("genesis").set(0.0);
+        Self::beacon_errors("blob_sidecars").set(0.0);
 
-        // L2 chain provider metrics
-        base_metrics::set!(
-            gauge,
-            Self::L2_CHAIN_PROVIDER_REQUESTS,
-            "method",
-            "l2_block_ref_by_label",
-            0
-        );
-        base_metrics::set!(
-            gauge,
-            Self::L2_CHAIN_PROVIDER_REQUESTS,
-            "method",
-            "l2_block_ref_by_hash",
-            0
-        );
-        base_metrics::set!(
-            gauge,
-            Self::L2_CHAIN_PROVIDER_REQUESTS,
-            "method",
-            "l2_block_ref_by_number",
-            0
-        );
+        Self::l2_chain_requests("l2_block_ref_by_label").set(0.0);
+        Self::l2_chain_requests("l2_block_ref_by_hash").set(0.0);
+        Self::l2_chain_requests("l2_block_ref_by_number").set(0.0);
 
-        base_metrics::set!(
-            gauge,
-            Self::L2_CHAIN_PROVIDER_ERRORS,
-            "method",
-            "l2_block_ref_by_label",
-            0
-        );
-        base_metrics::set!(
-            gauge,
-            Self::L2_CHAIN_PROVIDER_ERRORS,
-            "method",
-            "l2_block_ref_by_hash",
-            0
-        );
-        base_metrics::set!(
-            gauge,
-            Self::L2_CHAIN_PROVIDER_ERRORS,
-            "method",
-            "l2_block_ref_by_number",
-            0
-        );
+        Self::l2_chain_errors("l2_block_ref_by_label").set(0.0);
+        Self::l2_chain_errors("l2_block_ref_by_hash").set(0.0);
+        Self::l2_chain_errors("l2_block_ref_by_number").set(0.0);
 
-        // Blob sidecar metrics
-        base_metrics::set!(gauge, Self::BLOB_FETCHES, 0);
-        base_metrics::set!(gauge, Self::BLOB_FETCH_ERRORS, 0);
+        Self::blob_fetches().set(0.0);
+        Self::blob_fetch_errors().set(0.0);
 
-        // Cache metrics
-        base_metrics::set!(gauge, Self::CACHE_ENTRIES, "cache", "header_by_hash", 0);
-        base_metrics::set!(gauge, Self::CACHE_ENTRIES, "cache", "receipts_by_hash", 0);
-        base_metrics::set!(gauge, Self::CACHE_ENTRIES, "cache", "block_info_and_tx", 0);
+        Self::cache_entries("header_by_hash").set(0.0);
+        Self::cache_entries("receipts_by_hash").set(0.0);
+        Self::cache_entries("block_info_and_tx").set(0.0);
 
-        base_metrics::set!(gauge, Self::CACHE_MEMORY_USAGE, "cache", "header_by_hash", 0);
-        base_metrics::set!(gauge, Self::CACHE_MEMORY_USAGE, "cache", "receipts_by_hash", 0);
-        base_metrics::set!(gauge, Self::CACHE_MEMORY_USAGE, "cache", "block_info_and_tx", 0);
+        Self::cache_memory_bytes("header_by_hash").set(0.0);
+        Self::cache_memory_bytes("receipts_by_hash").set(0.0);
+        Self::cache_memory_bytes("block_info_and_tx").set(0.0);
     }
 }

--- a/crates/consensus/providers-alloy/src/metrics.rs
+++ b/crates/consensus/providers-alloy/src/metrics.rs
@@ -4,32 +4,32 @@ base_metrics::define_metrics! {
     base_providers
     #[describe("Number of cache hits in chain provider")]
     #[label(cache)]
-    chain_cache_hits: gauge,
+    chain_cache_hits: counter,
     #[describe("Number of cache misses in chain provider")]
     #[label(cache)]
-    chain_cache_misses: gauge,
+    chain_cache_misses: counter,
     #[describe("Number of RPC calls made by chain provider")]
     #[label(method)]
-    chain_rpc_calls: gauge,
+    chain_rpc_calls: counter,
     #[describe("Number of RPC errors in chain provider")]
     #[label(method)]
-    chain_rpc_errors: gauge,
+    chain_rpc_errors: counter,
     #[describe("Number of requests made to beacon client")]
     #[label(method)]
-    beacon_requests: gauge,
+    beacon_requests: counter,
     #[describe("Number of errors in beacon client requests")]
     #[label(method)]
-    beacon_errors: gauge,
+    beacon_errors: counter,
     #[describe("Number of requests made to L2 chain provider")]
     #[label(method)]
-    l2_chain_requests: gauge,
+    l2_chain_requests: counter,
     #[describe("Number of errors in L2 chain provider requests")]
     #[label(method)]
-    l2_chain_errors: gauge,
+    l2_chain_errors: counter,
     #[describe("Number of blob sidecar fetches")]
-    blob_fetches: gauge,
+    blob_fetches: counter,
     #[describe("Number of blob sidecar fetch errors")]
-    blob_fetch_errors: gauge,
+    blob_fetch_errors: counter,
     #[describe("Duration of provider requests in seconds")]
     request_duration: histogram,
     #[describe("Number of active entries in provider caches")]
@@ -55,44 +55,44 @@ impl Metrics {
     /// Initializes metrics to `0` so they can be queried immediately by consumers of prometheus
     /// metrics.
     pub fn zero() {
-        Self::chain_cache_hits("header_by_hash").set(0.0);
-        Self::chain_cache_hits("receipts_by_hash").set(0.0);
-        Self::chain_cache_hits("block_info_and_tx").set(0.0);
-        Self::chain_cache_hits("block_by_number").set(0.0);
+        Self::chain_cache_hits("header_by_hash").absolute(0);
+        Self::chain_cache_hits("receipts_by_hash").absolute(0);
+        Self::chain_cache_hits("block_info_and_tx").absolute(0);
+        Self::chain_cache_hits("block_by_number").absolute(0);
 
-        Self::chain_cache_misses("header_by_hash").set(0.0);
-        Self::chain_cache_misses("receipts_by_hash").set(0.0);
-        Self::chain_cache_misses("block_info_and_tx").set(0.0);
-        Self::chain_cache_misses("block_by_number").set(0.0);
+        Self::chain_cache_misses("header_by_hash").absolute(0);
+        Self::chain_cache_misses("receipts_by_hash").absolute(0);
+        Self::chain_cache_misses("block_info_and_tx").absolute(0);
+        Self::chain_cache_misses("block_by_number").absolute(0);
 
-        Self::chain_rpc_calls("header_by_hash").set(0.0);
-        Self::chain_rpc_calls("receipts_by_hash").set(0.0);
-        Self::chain_rpc_calls("block_by_hash").set(0.0);
-        Self::chain_rpc_calls("block_number").set(0.0);
+        Self::chain_rpc_calls("header_by_hash").absolute(0);
+        Self::chain_rpc_calls("receipts_by_hash").absolute(0);
+        Self::chain_rpc_calls("block_by_hash").absolute(0);
+        Self::chain_rpc_calls("block_number").absolute(0);
 
-        Self::chain_rpc_errors("header_by_hash").set(0.0);
-        Self::chain_rpc_errors("receipts_by_hash").set(0.0);
-        Self::chain_rpc_errors("block_by_hash").set(0.0);
-        Self::chain_rpc_errors("block_number").set(0.0);
+        Self::chain_rpc_errors("header_by_hash").absolute(0);
+        Self::chain_rpc_errors("receipts_by_hash").absolute(0);
+        Self::chain_rpc_errors("block_by_hash").absolute(0);
+        Self::chain_rpc_errors("block_number").absolute(0);
 
-        Self::beacon_requests("spec").set(0.0);
-        Self::beacon_requests("genesis").set(0.0);
-        Self::beacon_requests("blob_sidecars").set(0.0);
+        Self::beacon_requests("spec").absolute(0);
+        Self::beacon_requests("genesis").absolute(0);
+        Self::beacon_requests("blobs").absolute(0);
 
-        Self::beacon_errors("spec").set(0.0);
-        Self::beacon_errors("genesis").set(0.0);
-        Self::beacon_errors("blob_sidecars").set(0.0);
+        Self::beacon_errors("spec").absolute(0);
+        Self::beacon_errors("genesis").absolute(0);
+        Self::beacon_errors("blobs").absolute(0);
 
-        Self::l2_chain_requests("l2_block_ref_by_label").set(0.0);
-        Self::l2_chain_requests("l2_block_ref_by_hash").set(0.0);
-        Self::l2_chain_requests("l2_block_ref_by_number").set(0.0);
+        Self::l2_chain_requests("l2_block_ref_by_label").absolute(0);
+        Self::l2_chain_requests("l2_block_ref_by_hash").absolute(0);
+        Self::l2_chain_requests("l2_block_ref_by_number").absolute(0);
 
-        Self::l2_chain_errors("l2_block_ref_by_label").set(0.0);
-        Self::l2_chain_errors("l2_block_ref_by_hash").set(0.0);
-        Self::l2_chain_errors("l2_block_ref_by_number").set(0.0);
+        Self::l2_chain_errors("l2_block_ref_by_label").absolute(0);
+        Self::l2_chain_errors("l2_block_ref_by_hash").absolute(0);
+        Self::l2_chain_errors("l2_block_ref_by_number").absolute(0);
 
-        Self::blob_fetches().set(0.0);
-        Self::blob_fetch_errors().set(0.0);
+        Self::blob_fetches().absolute(0);
+        Self::blob_fetch_errors().absolute(0);
 
         Self::cache_entries("header_by_hash").set(0.0);
         Self::cache_entries("receipts_by_hash").set(0.0);

--- a/crates/consensus/service/src/actors/derivation/actor.rs
+++ b/crates/consensus/service/src/actors/derivation/actor.rs
@@ -14,12 +14,10 @@ use thiserror::Error;
 use tokio::{select, sync::mpsc};
 use tokio_util::sync::{CancellationToken, WaitForCancellationFuture};
 
-#[cfg(feature = "metrics")]
-use crate::Metrics;
 use crate::{
     CancellableContext, DerivationActorRequest, DerivationEngineClient, DerivationState,
-    DerivationStateMachine, DerivationStateTransitionError, DerivationStateUpdate, NodeActor,
-    actors::derivation::L2Finalizer,
+    DerivationStateMachine, DerivationStateTransitionError, DerivationStateUpdate, Metrics,
+    NodeActor, actors::derivation::L2Finalizer,
 };
 
 /// The [`NodeActor`] for the derivation sub-routine.
@@ -99,7 +97,7 @@ where
     /// Handles a [`Signal`] received over the derivation signal receiver channel.
     async fn signal(&mut self, signal: Signal) {
         if let Signal::Reset(ResetSignal { l1_origin: _l1_origin, .. }) = signal {
-            base_metrics::set!(counter, Metrics::DERIVATION_L1_ORIGIN, _l1_origin.number);
+            Metrics::derivation_l1_origin().absolute(_l1_origin.number);
             // Clear the finalization queue on reset.
             self.finalizer.clear();
             // Discard any in-flight derived_from so that a stale pre-reset L1 inclusion
@@ -146,7 +144,7 @@ where
                     let origin =
                         self.pipeline.origin().ok_or(PipelineError::MissingOrigin.crit())?.number;
 
-                    base_metrics::set!(counter, Metrics::DERIVATION_L1_ORIGIN, origin);
+                    Metrics::derivation_l1_origin().absolute(origin);
                     debug!(target: "derivation", l1_block = origin, "Advanced L1 origin");
                 }
                 StepResult::OriginAdvanceErr(e) | StepResult::StepFailed(e) => {
@@ -202,7 +200,7 @@ where
                                         "L1 reorg detected! Expected: {expected} | New: {new}"
                                     );
 
-                                    base_metrics::inc!(counter, Metrics::L1_REORG_COUNT);
+                                    Metrics::l1_reorg_count().increment(1);
                                 }
                                 self.engine_client.reset_engine_forkchoice().await.map_err(|e| {
                                     error!(target: "derivation", ?e, "Failed to send reset request");
@@ -215,7 +213,7 @@ where
                         }
                         PipelineErrorKind::Critical(_) => {
                             error!(target: "derivation", error = %e, "Critical derivation error");
-                            base_metrics::inc!(counter, Metrics::DERIVATION_CRITICAL_ERROR);
+                            Metrics::derivation_critical_errors().increment(1);
                             return Err(e.into());
                         }
                     }

--- a/crates/consensus/service/src/actors/sequencer/actor.rs
+++ b/crates/consensus/service/src/actors/sequencer/actor.rs
@@ -18,7 +18,7 @@ use tokio::{
 use tokio_util::sync::{CancellationToken, WaitForCancellationFuture};
 
 use crate::{
-    CancellableContext, NodeActor, SequencerAdminQuery, UnsafePayloadGossipClient,
+    CancellableContext, Metrics, NodeActor, SequencerAdminQuery, UnsafePayloadGossipClient,
     actors::{
         SequencerEngineClient,
         engine::EngineClientError,
@@ -26,10 +26,6 @@ use crate::{
             build::{PayloadBuilder, UnsealedPayloadHandle},
             conductor::Conductor,
             error::SequencerActorError,
-            metrics::{
-                inc_seal_error, inc_stale_build_discarded, update_seal_duration_metrics,
-                update_total_transactions_sequenced,
-            },
             origin_selector::OriginSelector,
             recovery::RecoveryModeGuard,
             seal::PayloadSealer,
@@ -124,8 +120,9 @@ where
             .get_sealed_payload(handle.payload_id, handle.attributes_with_parent.clone())
             .await?;
 
-        update_seal_duration_metrics(seal_request_start.elapsed());
-        update_total_transactions_sequenced(handle.attributes_with_parent.count_transactions());
+        Metrics::sequencer_block_building_seal_task_duration().set(seal_request_start.elapsed());
+        Metrics::sequencer_total_transactions_sequenced()
+            .increment(handle.attributes_with_parent.count_transactions());
 
         Ok(PayloadSealer::new(envelope))
     }
@@ -153,7 +150,7 @@ where
                 current_head_num = current_head.block_info.number,
                 "Stale build detected: unsafe head advanced past build parent, discarding"
             );
-            inc_stale_build_discarded();
+            Metrics::sequencer_stale_build_discarded_total().increment(1);
             return Ok(None);
         }
 
@@ -167,7 +164,7 @@ where
                 actual_hash = %current_head.block_info.hash,
                 "Stale build detected: unsafe head reorged at same height, discarding"
             );
-            inc_stale_build_discarded();
+            Metrics::sequencer_stale_build_discarded_total().increment(1);
             return Ok(None);
         }
 
@@ -180,14 +177,14 @@ where
             Err(SequencerActorError::EngineError(EngineClientError::SealError(err))) => {
                 if err.is_fatal() {
                     error!(target: "sequencer", error = ?err, "Critical seal task error occurred");
-                    inc_seal_error(true);
+                    Metrics::sequencer_seal_errors_total("true").increment(1);
                     self.cancellation_token.cancel();
                     return Err(SequencerActorError::EngineError(EngineClientError::SealError(
                         err,
                     )));
                 }
                 warn!(target: "sequencer", error = ?err, "Non-fatal seal error, dropping block");
-                inc_seal_error(false);
+                Metrics::sequencer_seal_errors_total("false").increment(1);
                 Ok(None)
             }
             Err(other_err) => {

--- a/crates/consensus/service/src/actors/sequencer/admin_api_impl.rs
+++ b/crates/consensus/service/src/actors/sequencer/admin_api_impl.rs
@@ -3,12 +3,8 @@ use base_consensus_derive::AttributesBuilder;
 use base_consensus_rpc::SequencerAdminAPIError;
 use tokio::sync::oneshot;
 
-use super::{
-    SequencerActor,
-    build::UnsealedPayloadHandle,
-    metrics::{inc_start_rejected, inc_stop_deferred},
-};
-use crate::{Conductor, OriginSelector, SequencerEngineClient, UnsafePayloadGossipClient};
+use super::{SequencerActor, build::UnsealedPayloadHandle};
+use crate::{Conductor, Metrics, OriginSelector, SequencerEngineClient, UnsafePayloadGossipClient};
 
 /// The query types to the sequencer actor for the admin api.
 #[derive(Debug)]
@@ -143,12 +139,12 @@ where
                 Ok(true) => {}
                 Ok(false) => {
                     warn!(target: "sequencer", "Not the conductor leader, refusing to start sequencer");
-                    inc_start_rejected("not_leader");
+                    Metrics::sequencer_start_rejected_total("not_leader").increment(1);
                     return Err(SequencerAdminAPIError::NotLeader);
                 }
                 Err(err) => {
                     error!(target: "sequencer", error = %err, "Failed to check conductor leadership");
-                    inc_start_rejected("leadership_check_failed");
+                    Metrics::sequencer_start_rejected_total("leadership_check_failed").increment(1);
                     return Err(SequencerAdminAPIError::RequestError(err.to_string()));
                 }
             }
@@ -201,7 +197,7 @@ where
 
         if self.sealer.is_some() {
             info!(target: "sequencer", "Seal pipeline in-flight, deferring stop response");
-            inc_stop_deferred();
+            Metrics::sequencer_stop_deferred_total().increment(1);
             self.pending_stop = Some(tx);
         } else {
             let result = self.resolve_stop_head().await;

--- a/crates/consensus/service/src/actors/sequencer/build.rs
+++ b/crates/consensus/service/src/actors/sequencer/build.rs
@@ -12,15 +12,11 @@ use base_consensus_genesis::RollupConfig;
 use base_protocol::{BlockInfo, L2BlockInfo, OpAttributesWithParent};
 
 use crate::{
-    PoolActivation,
+    Metrics, PoolActivation,
     actors::{
         SequencerEngineClient,
         sequencer::{
-            error::SequencerActorError,
-            metrics::{
-                update_attributes_build_duration_metrics, update_block_build_duration_metrics,
-            },
-            origin_selector::OriginSelector,
+            error::SequencerActorError, origin_selector::OriginSelector,
             recovery::RecoveryModeGuard,
         },
     },
@@ -96,14 +92,14 @@ impl<A: AttributesBuilder, O: OriginSelector, E: SequencerEngineClient> PayloadB
             return Ok(None);
         };
 
-        update_attributes_build_duration_metrics(attributes_build_start.elapsed());
+        Metrics::sequencer_attributes_build_duration().set(attributes_build_start.elapsed());
 
         let build_request_start = Instant::now();
 
         let payload_id =
             self.engine_client.start_build_block(attributes_with_parent.clone()).await?;
 
-        update_block_build_duration_metrics(build_request_start.elapsed());
+        Metrics::sequencer_block_building_start_task_duration().set(build_request_start.elapsed());
 
         Ok(Some(UnsealedPayloadHandle { payload_id, attributes_with_parent }))
     }

--- a/crates/consensus/service/src/actors/sequencer/metrics.rs
+++ b/crates/consensus/service/src/actors/sequencer/metrics.rs
@@ -1,9 +1,10 @@
-use std::time::Duration;
+//! Metrics helpers for the sequencer actor.
 
 use base_consensus_derive::AttributesBuilder;
 
 use crate::{
-    Conductor, OriginSelector, SequencerActor, SequencerEngineClient, UnsafePayloadGossipClient,
+    Conductor, Metrics, OriginSelector, SequencerActor, SequencerEngineClient,
+    UnsafePayloadGossipClient,
 };
 
 /// `SequencerActor` metrics-related method implementations.
@@ -30,95 +31,8 @@ where
 {
     /// Updates the metrics for the sequencer actor.
     pub(super) fn update_metrics(&self) {
-        // no-op if disabled.
-        #[cfg(feature = "metrics")]
-        {
-            let state_flags: [(&str, String); 2] = [
-                ("active", self.is_active.to_string()),
-                ("recovery", self.recovery_mode.get().to_string()),
-            ];
-
-            let gauge = metrics::gauge!(crate::Metrics::SEQUENCER_STATE, &state_flags);
-            gauge.set(1);
-        }
+        let active = if self.is_active { "true" } else { "false" };
+        let recovery = if self.recovery_mode.get() { "true" } else { "false" };
+        Metrics::sequencer_state(active, recovery).set(1.0);
     }
-}
-
-#[inline]
-pub(super) fn update_attributes_build_duration_metrics(_duration: Duration) {
-    // Log the attributes build duration, if metrics are enabled.
-    base_metrics::set!(gauge, crate::Metrics::SEQUENCER_ATTRIBUTES_BUILDER_DURATION, _duration);
-}
-
-#[inline]
-pub(super) fn update_block_build_duration_metrics(_duration: Duration) {
-    base_metrics::set!(
-        gauge,
-        crate::Metrics::SEQUENCER_BLOCK_BUILDING_START_TASK_DURATION,
-        _duration
-    );
-}
-
-#[inline]
-pub(super) fn update_seal_duration_metrics(_duration: Duration) {
-    // Log the block building seal task duration, if metrics are enabled.
-    base_metrics::set!(
-        gauge,
-        crate::Metrics::SEQUENCER_BLOCK_BUILDING_SEAL_TASK_DURATION,
-        _duration
-    );
-}
-
-#[inline]
-pub(super) fn update_total_transactions_sequenced(_transaction_count: u64) {
-    #[cfg(feature = "metrics")]
-    metrics::counter!(crate::Metrics::SEQUENCER_TOTAL_TRANSACTIONS_SEQUENCED)
-        .increment(_transaction_count);
-}
-
-#[inline]
-pub(super) fn inc_seal_step_retry(_step: &'static str) {
-    base_metrics::inc!(counter, crate::Metrics::SEQUENCER_SEAL_STEP_RETRIES_TOTAL, "step" => _step);
-}
-
-#[inline]
-pub(super) fn update_seal_step_duration(_step: &'static str, _duration: Duration) {
-    base_metrics::set!(
-        gauge,
-        crate::Metrics::SEQUENCER_SEAL_STEP_DURATION,
-        "step",
-        _step,
-        _duration
-    );
-}
-
-#[inline]
-pub(super) fn inc_seal_error(fatal: bool) {
-    let _label = if fatal { "true" } else { "false" };
-    base_metrics::inc!(counter, crate::Metrics::SEQUENCER_SEAL_ERROR_TOTAL, "fatal" => _label);
-}
-
-#[inline]
-pub(super) fn inc_start_rejected(_reason: &'static str) {
-    base_metrics::inc!(counter, crate::Metrics::SEQUENCER_START_REJECTED_TOTAL, "reason" => _reason);
-}
-
-#[inline]
-pub(super) fn inc_stop_deferred() {
-    base_metrics::inc!(counter, crate::Metrics::SEQUENCER_STOP_DEFERRED_TOTAL);
-}
-
-#[inline]
-pub(super) fn inc_recovery_mode_block() {
-    base_metrics::inc!(counter, crate::Metrics::SEQUENCER_RECOVERY_MODE_BLOCKS_TOTAL);
-}
-
-#[inline]
-pub(super) fn inc_drift_empty_block() {
-    base_metrics::inc!(counter, crate::Metrics::SEQUENCER_DRIFT_EMPTY_BLOCKS_TOTAL);
-}
-
-#[inline]
-pub(super) fn inc_stale_build_discarded() {
-    base_metrics::inc!(counter, crate::Metrics::SEQUENCER_STALE_BUILD_DISCARDED_TOTAL);
 }

--- a/crates/consensus/service/src/actors/sequencer/pool.rs
+++ b/crates/consensus/service/src/actors/sequencer/pool.rs
@@ -6,7 +6,7 @@ use base_alloy_rpc_types_engine::OpPayloadAttributes;
 use base_consensus_genesis::RollupConfig;
 use base_protocol::BlockInfo;
 
-use super::metrics::{inc_drift_empty_block, inc_recovery_mode_block};
+use crate::Metrics;
 
 /// The `PoolActivation` type identifies if the transaction pool should be enabled.
 #[derive(Debug, Clone)]
@@ -31,7 +31,7 @@ impl PoolActivation {
     ) -> bool {
         if recovery_mode {
             warn!(target: "sequencer", "Sequencer is in recovery mode, producing empty block");
-            inc_recovery_mode_block();
+            Metrics::sequencer_recovery_mode_blocks_total().increment(1);
             return false;
         }
 
@@ -46,7 +46,7 @@ impl PoolActivation {
                 l1_timestamp = l1_origin.timestamp,
                 "L2 timestamp beyond sequencer drift, producing empty block"
             );
-            inc_drift_empty_block();
+            Metrics::sequencer_drift_empty_blocks_total().increment(1);
             return false;
         }
 

--- a/crates/consensus/service/src/actors/sequencer/seal.rs
+++ b/crates/consensus/service/src/actors/sequencer/seal.rs
@@ -8,14 +8,8 @@ use std::time::Instant;
 use base_alloy_rpc_types_engine::OpExecutionPayloadEnvelope;
 
 use crate::{
-    UnsafePayloadGossipClient,
-    actors::{
-        SequencerEngineClient,
-        sequencer::{
-            conductor::Conductor,
-            metrics::{inc_seal_step_retry, update_seal_step_duration},
-        },
-    },
+    Metrics, UnsafePayloadGossipClient,
+    actors::{SequencerEngineClient, sequencer::conductor::Conductor},
 };
 
 /// Tracks where a sealed payload is in the commit → gossip → insert pipeline.
@@ -110,8 +104,8 @@ impl PayloadSealer {
         };
 
         match &result {
-            Ok(_) => update_seal_step_duration(step_label, step_start.elapsed()),
-            Err(_) => inc_seal_step_retry(step_label),
+            Ok(_) => Metrics::sequencer_seal_step_duration(step_label).set(step_start.elapsed()),
+            Err(_) => Metrics::sequencer_seal_step_retries_total(step_label).increment(1),
         }
 
         result

--- a/crates/consensus/service/src/metrics/mod.rs
+++ b/crates/consensus/service/src/metrics/mod.rs
@@ -1,64 +1,50 @@
 //! Metrics for the node service
 
-/// Container for metrics.
-#[derive(Debug, Clone)]
-pub struct Metrics;
+base_metrics::define_metrics! {
+    base_node
+    #[describe("L1 reorg count")]
+    l1_reorg_count: counter,
+    #[describe("Derivation pipeline L1 origin")]
+    derivation_l1_origin: counter,
+    #[describe("Critical errors in the derivation pipeline")]
+    derivation_critical_errors: counter,
+    #[describe("Tracks sequencer state flags")]
+    #[label(active)]
+    #[label(recovery)]
+    sequencer_state: gauge,
+    #[describe("Duration of the sequencer attributes builder")]
+    sequencer_attributes_build_duration: gauge,
+    #[describe("Duration of the sequencer block building start task")]
+    sequencer_block_building_start_task_duration: gauge,
+    #[describe("Duration of the sequencer block building seal task")]
+    sequencer_block_building_seal_task_duration: gauge,
+    #[describe("Duration of the sequencer conductor commitment")]
+    sequencer_conductor_commitment_duration: gauge,
+    #[describe("Total count of sequenced transactions")]
+    sequencer_total_transactions_sequenced: counter,
+    #[describe("Sequencer seal step retries by step")]
+    #[label(step)]
+    sequencer_seal_step_retries_total: counter,
+    #[describe("Sequencer seal step duration by step")]
+    #[label(step)]
+    sequencer_seal_step_duration: gauge,
+    #[describe("Seal errors by fatality")]
+    #[label(fatal)]
+    sequencer_seal_errors_total: counter,
+    #[describe("Sequencer start rejections by reason")]
+    #[label(reason)]
+    sequencer_start_rejected_total: counter,
+    #[describe("Deferred stop_sequencer responses due to in-flight seal pipeline")]
+    sequencer_stop_deferred_total: counter,
+    #[describe("Blocks sequenced in recovery mode")]
+    sequencer_recovery_mode_blocks_total: counter,
+    #[describe("Empty blocks produced due to sequencer drift threshold")]
+    sequencer_drift_empty_blocks_total: counter,
+    #[describe("Pre-built payloads discarded because the unsafe head advanced past their parent")]
+    sequencer_stale_build_discarded_total: counter,
+}
 
 impl Metrics {
-    /// Identifier for the counter that tracks the number of times the L1 has reorganized.
-    pub const L1_REORG_COUNT: &str = "base_node_l1_reorg_count";
-
-    /// Identifier for the counter that tracks the L1 origin of the derivation pipeline.
-    pub const DERIVATION_L1_ORIGIN: &str = "base_node_derivation_l1_origin";
-
-    /// Identifier for the counter of critical derivation errors (strictly for alerting.)
-    pub const DERIVATION_CRITICAL_ERROR: &str = "base_node_derivation_critical_errors";
-
-    /// Identifier for the counter that tracks sequencer state flags.
-    pub const SEQUENCER_STATE: &str = "base_node_sequencer_state";
-
-    /// Gauge for the sequencer's attributes builder duration.
-    pub const SEQUENCER_ATTRIBUTES_BUILDER_DURATION: &str =
-        "base_node_sequencer_attributes_build_duration";
-
-    /// Gauge for the sequencer's block building start task duration.
-    pub const SEQUENCER_BLOCK_BUILDING_START_TASK_DURATION: &str =
-        "base_node_sequencer_block_building_start_task_duration";
-
-    /// Gauge for the sequencer's block building seal task duration.
-    pub const SEQUENCER_BLOCK_BUILDING_SEAL_TASK_DURATION: &str =
-        "base_node_sequencer_block_building_seal_task_duration";
-
-    /// Gauge for the sequencer's conductor commitment duration.
-    pub const SEQUENCER_CONDUCTOR_COMMITMENT_DURATION: &str =
-        "base_node_sequencer_conductor_commitment_duration";
-
-    /// Total number of transactions of sequenced by sequencer.
-    pub const SEQUENCER_TOTAL_TRANSACTIONS_SEQUENCED: &str =
-        "base_node_sequencer_total_transactions_sequenced";
-
-    /// Counter for seal pipeline step retries, labeled by step ("conductor"|"gossip"|"insert").
-    pub const SEQUENCER_SEAL_STEP_RETRIES_TOTAL: &str =
-        "base_node_sequencer_seal_step_retries_total";
-    /// Gauge for seal pipeline step duration, labeled by step.
-    pub const SEQUENCER_SEAL_STEP_DURATION: &str = "base_node_sequencer_seal_step_duration";
-    /// Counter for seal errors labeled by fatal ("true"|"false").
-    pub const SEQUENCER_SEAL_ERROR_TOTAL: &str = "base_node_sequencer_seal_errors_total";
-    /// Counter for sequencer start rejections labeled by reason.
-    pub const SEQUENCER_START_REJECTED_TOTAL: &str = "base_node_sequencer_start_rejected_total";
-    /// Counter for deferred `stop_sequencer` responses due to in-flight seal pipeline.
-    pub const SEQUENCER_STOP_DEFERRED_TOTAL: &str = "base_node_sequencer_stop_deferred_total";
-    /// Counter for blocks sequenced in recovery mode (always empty blocks).
-    pub const SEQUENCER_RECOVERY_MODE_BLOCKS_TOTAL: &str =
-        "base_node_sequencer_recovery_mode_blocks_total";
-    /// Counter for empty blocks produced due to sequencer drift threshold.
-    pub const SEQUENCER_DRIFT_EMPTY_BLOCKS_TOTAL: &str =
-        "base_node_sequencer_drift_empty_blocks_total";
-    /// Counter for pre-built payloads discarded because the unsafe head advanced past their
-    /// parent before sealing (stale build detection).
-    pub const SEQUENCER_STALE_BUILD_DISCARDED_TOTAL: &str =
-        "base_node_sequencer_stale_build_discarded_total";
-
     /// Initializes metrics for the node service.
     ///
     /// This does two things:
@@ -70,128 +56,23 @@ impl Metrics {
         Self::zero();
     }
 
-    /// Describes metrics used in [`base-consensus-node`][crate].
-    #[cfg(feature = "metrics")]
-    pub fn describe() {
-        // L1 reorg count
-        metrics::describe_counter!(Self::L1_REORG_COUNT, metrics::Unit::Count, "L1 reorg count");
-
-        // Derivation L1 origin
-        metrics::describe_counter!(Self::DERIVATION_L1_ORIGIN, "Derivation pipeline L1 origin");
-
-        // Derivation critical error
-        metrics::describe_counter!(
-            Self::DERIVATION_CRITICAL_ERROR,
-            "Critical errors in the derivation pipeline"
-        );
-
-        // Sequencer state
-        metrics::describe_counter!(Self::SEQUENCER_STATE, "Tracks sequencer state flags");
-
-        // Sequencer attributes builder duration
-        metrics::describe_gauge!(
-            Self::SEQUENCER_ATTRIBUTES_BUILDER_DURATION,
-            "Duration of the sequencer attributes builder"
-        );
-
-        // Sequencer block building job duration
-        metrics::describe_gauge!(
-            Self::SEQUENCER_BLOCK_BUILDING_START_TASK_DURATION,
-            "Duration of the sequencer block building start task"
-        );
-
-        // Sequencer block building job duration
-        metrics::describe_gauge!(
-            Self::SEQUENCER_BLOCK_BUILDING_SEAL_TASK_DURATION,
-            "Duration of the sequencer block building seal task"
-        );
-
-        // Sequencer conductor commitment duration
-        metrics::describe_gauge!(
-            Self::SEQUENCER_CONDUCTOR_COMMITMENT_DURATION,
-            "Duration of the sequencer conductor commitment"
-        );
-
-        // Sequencer total transactions sequenced
-        metrics::describe_counter!(
-            Self::SEQUENCER_TOTAL_TRANSACTIONS_SEQUENCED,
-            metrics::Unit::Count,
-            "Total count of sequenced transactions"
-        );
-
-        metrics::describe_counter!(
-            Self::SEQUENCER_SEAL_STEP_RETRIES_TOTAL,
-            "Sequencer seal step retries by step"
-        );
-        metrics::describe_gauge!(
-            Self::SEQUENCER_SEAL_STEP_DURATION,
-            metrics::Unit::Seconds,
-            "Sequencer seal step duration by step"
-        );
-        metrics::describe_counter!(Self::SEQUENCER_SEAL_ERROR_TOTAL, "Seal errors by fatality");
-        metrics::describe_counter!(
-            Self::SEQUENCER_START_REJECTED_TOTAL,
-            "Sequencer start rejections by reason"
-        );
-        metrics::describe_counter!(
-            Self::SEQUENCER_STOP_DEFERRED_TOTAL,
-            "Deferred stop_sequencer responses due to in-flight seal pipeline"
-        );
-        metrics::describe_counter!(
-            Self::SEQUENCER_RECOVERY_MODE_BLOCKS_TOTAL,
-            "Blocks sequenced in recovery mode"
-        );
-        metrics::describe_counter!(
-            Self::SEQUENCER_DRIFT_EMPTY_BLOCKS_TOTAL,
-            "Empty blocks produced due to sequencer drift threshold"
-        );
-        metrics::describe_counter!(
-            Self::SEQUENCER_STALE_BUILD_DISCARDED_TOTAL,
-            "Pre-built payloads discarded because the unsafe head advanced past their parent"
-        );
-    }
-
     /// Initializes metrics to `0` so they can be queried immediately by consumers of prometheus
     /// metrics.
-    #[cfg(feature = "metrics")]
     pub fn zero() {
-        // L1 reorg reset count
-        base_metrics::set!(counter, Self::L1_REORG_COUNT, 0);
+        Self::l1_reorg_count().absolute(0);
+        Self::derivation_critical_errors().absolute(0);
+        Self::sequencer_total_transactions_sequenced().absolute(0);
 
-        // Derivation critical error
-        base_metrics::set!(counter, Self::DERIVATION_CRITICAL_ERROR, 0);
-
-        // Sequencer: reset total transactions sequenced
-        base_metrics::set!(counter, Self::SEQUENCER_TOTAL_TRANSACTIONS_SEQUENCED, 0);
-
-        base_metrics::set!(
-            counter,
-            Self::SEQUENCER_SEAL_STEP_RETRIES_TOTAL,
-            "step",
-            "conductor",
-            0
-        );
-        base_metrics::set!(counter, Self::SEQUENCER_SEAL_STEP_RETRIES_TOTAL, "step", "gossip", 0);
-        base_metrics::set!(counter, Self::SEQUENCER_SEAL_STEP_RETRIES_TOTAL, "step", "insert", 0);
-        base_metrics::set!(counter, Self::SEQUENCER_SEAL_ERROR_TOTAL, "fatal", "true", 0);
-        base_metrics::set!(counter, Self::SEQUENCER_SEAL_ERROR_TOTAL, "fatal", "false", 0);
-        base_metrics::set!(
-            counter,
-            Self::SEQUENCER_START_REJECTED_TOTAL,
-            "reason",
-            "not_leader",
-            0
-        );
-        base_metrics::set!(
-            counter,
-            Self::SEQUENCER_START_REJECTED_TOTAL,
-            "reason",
-            "leadership_check_failed",
-            0
-        );
-        base_metrics::set!(counter, Self::SEQUENCER_STOP_DEFERRED_TOTAL, 0);
-        base_metrics::set!(counter, Self::SEQUENCER_RECOVERY_MODE_BLOCKS_TOTAL, 0);
-        base_metrics::set!(counter, Self::SEQUENCER_DRIFT_EMPTY_BLOCKS_TOTAL, 0);
-        base_metrics::set!(counter, Self::SEQUENCER_STALE_BUILD_DISCARDED_TOTAL, 0);
+        Self::sequencer_seal_step_retries_total("conductor").absolute(0);
+        Self::sequencer_seal_step_retries_total("gossip").absolute(0);
+        Self::sequencer_seal_step_retries_total("insert").absolute(0);
+        Self::sequencer_seal_errors_total("true").absolute(0);
+        Self::sequencer_seal_errors_total("false").absolute(0);
+        Self::sequencer_start_rejected_total("not_leader").absolute(0);
+        Self::sequencer_start_rejected_total("leadership_check_failed").absolute(0);
+        Self::sequencer_stop_deferred_total().absolute(0);
+        Self::sequencer_recovery_mode_blocks_total().absolute(0);
+        Self::sequencer_drift_empty_blocks_total().absolute(0);
+        Self::sequencer_stale_build_discarded_total().absolute(0);
     }
 }


### PR DESCRIPTION
### Description
Migrate consensus crates to use the new metrics api defined in https://github.com/base/base/pull/1694 