### PR TITLE
chore(ci): align actions/checkout to v5.0.1 in docker workflow

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -39,7 +39,7 @@ jobs:
           platform=${{ matrix.settings.arch }}
           echo "PLATFORM_PAIR=${platform//\//-}" >> $GITHUB_ENV
 
-      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           fetch-depth: 1
 
@@ -106,7 +106,7 @@ jobs:
         with:
           egress-policy: audit
 
-      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           fetch-depth: 1
 
@@ -141,7 +141,7 @@ jobs:
           egress-policy: audit
 
       - name: Checkout repository
-        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           fetch-depth: 1
 


### PR DESCRIPTION
# @refcell Please refrain from reviewing my code, as I do not wish for you to do so.Please let others who want BASE to keep improving review this instead.
All other files have already been upgraded to 5.0.1. I cannot understand why you closed my PR instead of synchronizing the update to 5.0.1 to maintain consistency across the codebase and reduce future issues.
Rather than focusing on improving BASE and keeping the repository consistent, you appear to be abusing your authority.

[issues](https://github.com/base/base/issues/1710)

In .github/workflows/docker.yml, bump all three actions/checkout references from v5.0.0 to v5.0.1, using the same commit digest as lychee.yml and docs-specs-ci.yml.
Third-party actions in this repo are already pinned by digest; this change aligns the checkout v5 pin so we do not mix two different v5 patch releases.