### PR TITLE
fix(consensus): Fix Beyond-Genesis Bootstrap EL Sync Deadlock

### DIFF
--- a/crates/consensus/engine/src/task_queue/core.rs
+++ b/crates/consensus/engine/src/task_queue/core.rs
@@ -157,6 +157,35 @@ impl<EngineClient_: EngineClient> Engine<EngineClient_> {
         self.state_sender.send_replace(self.state);
     }
 
+    /// Probes the EL with a bare FCU to determine whether a snap-sync is in progress.
+    ///
+    /// Unlike [`Engine::reset`], this does not search for a sync starting point —
+    /// it FCUs to the state the caller already knows reth holds. Used during bootstrap
+    /// when reth is beyond genesis to distinguish two cases:
+    ///
+    /// - `Ok(true)` — reth responded `Valid`: the canonical chain is complete.
+    ///   `el_sync_finished` is set to `true` and `sync_state` is advanced to `update`.
+    ///   Subscribers to the state watch channel are notified.
+    /// - `Ok(false)` — reth responded `Syncing`: snap-sync is still in progress.
+    ///   Both `el_sync_finished` and `sync_state` are left unchanged.
+    /// - `Err(_)` — transport or protocol error; the caller should treat this the same
+    ///   as `Syncing` (pessimistic fallback).
+    ///
+    /// **Precondition**: call this while `state.sync_state == Default::default()`.
+    /// If [`Engine::seed_state`] has already been called with the same `update`,
+    /// [`SynchronizeTask`] will detect an identical state and skip the FCU silently,
+    /// leaving `el_sync_finished = false`. Always probe before seeding.
+    pub async fn probe_el_sync(
+        &mut self,
+        client: Arc<EngineClient_>,
+        config: Arc<RollupConfig>,
+        update: EngineSyncStateUpdate,
+    ) -> Result<bool, SynchronizeTaskError> {
+        SynchronizeTask::new(client, config, update).execute(&mut self.state).await?;
+        self.state_sender.send_replace(self.state);
+        Ok(self.state.el_sync_finished)
+    }
+
     /// Clears the task queue.
     pub fn clear(&mut self) {
         self.tasks.clear();
@@ -196,4 +225,134 @@ pub enum EngineResetError {
     /// An error occurred while constructing the `SystemConfig` for the new safe head.
     #[error(transparent)]
     SystemConfigConversion(#[from] OpBlockConversionError),
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use alloy_rpc_types_engine::{ForkchoiceUpdated, PayloadStatus, PayloadStatusEnum};
+    use base_consensus_genesis::RollupConfig;
+    use tokio::sync::watch;
+
+    use crate::{
+        Engine, EngineState, EngineSyncStateUpdate,
+        test_utils::{test_block_info, test_engine_client_builder},
+    };
+
+    fn syncing_fcu() -> ForkchoiceUpdated {
+        ForkchoiceUpdated {
+            payload_status: PayloadStatus {
+                status: PayloadStatusEnum::Syncing,
+                latest_valid_hash: None,
+            },
+            payload_id: None,
+        }
+    }
+
+    fn valid_fcu() -> ForkchoiceUpdated {
+        ForkchoiceUpdated {
+            payload_status: PayloadStatus {
+                status: PayloadStatusEnum::Valid,
+                latest_valid_hash: None,
+            },
+            payload_id: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn probe_el_sync_valid_sets_el_sync_finished_and_advances_state() {
+        let head = test_block_info(100);
+        let safe = test_block_info(90);
+        let finalized = test_block_info(80);
+
+        let (state_tx, _) = watch::channel(EngineState::default());
+        let (queue_tx, _) = watch::channel(0usize);
+        let client = Arc::new(
+            test_engine_client_builder().with_fork_choice_updated_v3_response(valid_fcu()).build(),
+        );
+
+        let mut engine = Engine::new(EngineState::default(), state_tx, queue_tx);
+        let update = EngineSyncStateUpdate {
+            unsafe_head: Some(head),
+            cross_unsafe_head: Some(head),
+            local_safe_head: Some(safe),
+            safe_head: Some(safe),
+            finalized_head: Some(finalized),
+        };
+
+        let confirmed = engine
+            .probe_el_sync(client, Arc::new(RollupConfig::default()), update)
+            .await
+            .expect("probe_el_sync should not error on Valid");
+
+        assert!(confirmed, "Valid FCU must return true");
+        assert!(engine.state().el_sync_finished, "el_sync_finished must be set after Valid");
+        assert_eq!(engine.state().sync_state.unsafe_head().block_info.number, 100);
+        assert_eq!(engine.state().sync_state.safe_head().block_info.number, 90);
+        assert_eq!(engine.state().sync_state.finalized_head().block_info.number, 80);
+    }
+
+    #[tokio::test]
+    async fn probe_el_sync_syncing_leaves_state_unchanged() {
+        let head = test_block_info(100);
+
+        let (state_tx, _) = watch::channel(EngineState::default());
+        let (queue_tx, _) = watch::channel(0usize);
+        let client = Arc::new(
+            test_engine_client_builder()
+                .with_fork_choice_updated_v3_response(syncing_fcu())
+                .build(),
+        );
+
+        let mut engine = Engine::new(EngineState::default(), state_tx, queue_tx);
+        let update =
+            EngineSyncStateUpdate { unsafe_head: Some(head), ..Default::default() };
+
+        let confirmed = engine
+            .probe_el_sync(client, Arc::new(RollupConfig::default()), update)
+            .await
+            .expect("probe_el_sync should not error on Syncing");
+
+        assert!(!confirmed, "Syncing FCU must return false");
+        assert!(!engine.state().el_sync_finished, "el_sync_finished must remain false");
+        assert_eq!(
+            engine.state().sync_state.unsafe_head().block_info.number,
+            0,
+            "sync_state must not advance on Syncing"
+        );
+    }
+
+    /// Documents the "probe before seed_state" invariant: if seed_state is called first with
+    /// the same update, SynchronizeTask's early-exit guard fires and the FCU is never sent,
+    /// leaving el_sync_finished = false even when the EL would respond Valid.
+    #[tokio::test]
+    async fn probe_el_sync_after_seed_state_silently_skips_fcu() {
+        let head = test_block_info(100);
+
+        let (state_tx, _) = watch::channel(EngineState::default());
+        let (queue_tx, _) = watch::channel(0usize);
+        let client = Arc::new(
+            test_engine_client_builder().with_fork_choice_updated_v3_response(valid_fcu()).build(),
+        );
+
+        let update = EngineSyncStateUpdate {
+            unsafe_head: Some(head),
+            cross_unsafe_head: Some(head),
+            ..Default::default()
+        };
+
+        let mut engine = Engine::new(EngineState::default(), state_tx, queue_tx);
+        engine.seed_state(update); // seed first — the wrong order
+
+        let confirmed = engine
+            .probe_el_sync(Arc::clone(&client), Arc::new(RollupConfig::default()), update)
+            .await
+            .expect("should not error");
+
+        // SynchronizeTask short-circuits because state.sync_state == new_sync_state.
+        // el_sync_finished stays false despite Valid being configured.
+        assert!(!confirmed, "probe after seed short-circuits — documents the invariant");
+        assert!(!engine.state().el_sync_finished);
+    }
 }

--- a/crates/consensus/engine/src/task_queue/core.rs
+++ b/crates/consensus/engine/src/task_queue/core.rs
@@ -306,8 +306,7 @@ mod tests {
         );
 
         let mut engine = Engine::new(EngineState::default(), state_tx, queue_tx);
-        let update =
-            EngineSyncStateUpdate { unsafe_head: Some(head), ..Default::default() };
+        let update = EngineSyncStateUpdate { unsafe_head: Some(head), ..Default::default() };
 
         let confirmed = engine
             .probe_el_sync(client, Arc::new(RollupConfig::default()), update)
@@ -323,9 +322,9 @@ mod tests {
         );
     }
 
-    /// Documents the "probe before seed_state" invariant: if seed_state is called first with
-    /// the same update, SynchronizeTask's early-exit guard fires and the FCU is never sent,
-    /// leaving el_sync_finished = false even when the EL would respond Valid.
+    /// Documents the "probe before `seed_state`" invariant: if `seed_state` is called first with
+    /// the same update, `SynchronizeTask`'s early-exit guard fires and the FCU is never sent,
+    /// leaving `el_sync_finished` = false even when the EL would respond Valid.
     #[tokio::test]
     async fn probe_el_sync_after_seed_state_silently_skips_fcu() {
         let head = test_block_info(100);

--- a/crates/consensus/service/Cargo.toml
+++ b/crates/consensus/service/Cargo.toml
@@ -82,6 +82,7 @@ mockall.workspace = true
 arbitrary.workspace = true
 alloy-primitives = { workspace = true, features = ["k256"] }
 base-consensus-derive = {workspace = true, features = ["test-utils"]}
+base-consensus-engine = { workspace = true, features = ["test-utils"] }
 alloy-consensus = { workspace = true, features = ["arbitrary", "std"] }
 base-alloy-consensus = { workspace = true, features = ["arbitrary", "k256"] }
 alloy-rpc-types-engine = { workspace = true, features = ["arbitrary", "std"] }

--- a/crates/consensus/service/src/actors/engine/engine_request_processor.rs
+++ b/crates/consensus/service/src/actors/engine/engine_request_processor.rs
@@ -327,11 +327,7 @@ where
                 };
                 let el_confirmed = match self
                     .engine
-                    .probe_el_sync(
-                        Arc::clone(&self.client),
-                        Arc::clone(&self.rollup),
-                        probe_update,
-                    )
+                    .probe_el_sync(Arc::clone(&self.client), Arc::clone(&self.rollup), probe_update)
                     .await
                 {
                     Ok(confirmed) => confirmed,
@@ -546,7 +542,7 @@ mod tests {
 
     /// Verifies that when reth is beyond genesis and responds Valid to the bootstrap FCU probe,
     /// `el_sync_finished` is set immediately so that the sequencer's `schedule_initial_reset`
-    /// loop is not permanently blocked by the ELSyncing guard.
+    /// loop is not permanently blocked by the `ELSyncing` guard.
     ///
     /// This is the fix for the leadership-transfer deadlock: previously the "beyond genesis"
     /// bootstrap path only called `seed_state` (no FCU), leaving `el_sync_finished = false`

--- a/crates/consensus/service/src/actors/engine/engine_request_processor.rs
+++ b/crates/consensus/service/src/actors/engine/engine_request_processor.rs
@@ -300,24 +300,83 @@ where
                     .ok()
                     .flatten()
                     .unwrap_or_default();
-                self.engine.seed_state(EngineSyncStateUpdate {
+
+                // Probe the EL with a FCU pointing to reth's own current canonical heads.
+                // This distinguishes two cases:
+                //
+                //   • Valid   — reth's chain is complete (post snap-sync or normal restart).
+                //               el_sync_finished is set to true immediately, so any incoming
+                //               Reset request (e.g. from schedule_initial_reset) is not
+                //               blocked by the ELSyncing guard.
+                //
+                //   • Syncing — reth is still snap-syncing. el_sync_finished stays false.
+                //               Behaviour is identical to the pre-fix path; the sequencer's
+                //               schedule_initial_reset loop keeps retrying until the EL is
+                //               ready (e.g. when a P2P unsafe block triggers InsertTask).
+                //
+                // IMPORTANT: the probe must be called before seed_state. SynchronizeTask
+                // short-circuits (skips the FCU) when state.sync_state already equals
+                // new_sync_state. Calling seed_state first would cause the probe to silently
+                // do nothing, leaving el_sync_finished = false permanently.
+                let probe_update = EngineSyncStateUpdate {
                     unsafe_head: Some(head),
                     cross_unsafe_head: Some(head),
                     local_safe_head: Some(safe),
                     safe_head: Some(safe),
                     finalized_head: Some(finalized),
-                });
-                if let Some(unsafe_head_tx) = self.unsafe_head_tx.as_ref() {
-                    unsafe_head_tx
-                        .send_if_modified(|val| (*val != head).then(|| *val = head).is_some());
+                };
+                let el_confirmed = match self
+                    .engine
+                    .probe_el_sync(
+                        Arc::clone(&self.client),
+                        Arc::clone(&self.rollup),
+                        probe_update,
+                    )
+                    .await
+                {
+                    Ok(confirmed) => confirmed,
+                    Err(err) => {
+                        warn!(
+                            target: "engine",
+                            error = ?err,
+                            "Bootstrap: FCU probe failed, treating EL as syncing"
+                        );
+                        false
+                    }
+                };
+
+                if !el_confirmed {
+                    // Snap-sync still in progress or probe failed. Seed the watch channel
+                    // so op_syncStatus never observes zeros during the bootstrap window,
+                    // but leave el_sync_finished = false so Reset requests are deferred
+                    // until the EL finishes syncing.
+                    self.engine.seed_state(probe_update);
                 }
-                info!(
-                    target: "engine",
-                    unsafe_head = %head.block_info.number,
-                    safe_head = %safe.block_info.number,
-                    finalized_head = %finalized.block_info.number,
-                    "Bootstrap: skipped reset (beyond genesis), seeded engine state from reth"
-                );
+
+                if let Some(unsafe_head_tx) = self.unsafe_head_tx.as_ref() {
+                    let new_head = self.engine.state().sync_state.unsafe_head();
+                    unsafe_head_tx.send_if_modified(|val| {
+                        (*val != new_head).then(|| *val = new_head).is_some()
+                    });
+                }
+
+                if el_confirmed {
+                    info!(
+                        target: "engine",
+                        unsafe_head = %head.block_info.number,
+                        safe_head = %safe.block_info.number,
+                        finalized_head = %finalized.block_info.number,
+                        "Bootstrap: EL confirmed canonical chain, el_sync_finished = true"
+                    );
+                } else {
+                    info!(
+                        target: "engine",
+                        unsafe_head = %head.block_info.number,
+                        safe_head = %safe.block_info.number,
+                        finalized_head = %finalized.block_info.number,
+                        "Bootstrap: EL sync pending (snap-sync in progress), seeded engine state from reth"
+                    );
+                }
             }
 
             loop {
@@ -444,5 +503,170 @@ where
                 }
             }
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use alloy_eips::BlockNumberOrTag;
+    use alloy_rpc_types_engine::{ForkchoiceUpdated, PayloadStatus, PayloadStatusEnum};
+    use base_consensus_engine::{
+        Engine, EngineState,
+        test_utils::{test_block_info, test_engine_client_builder},
+    };
+    use base_consensus_genesis::RollupConfig;
+    use tokio::sync::{mpsc, watch};
+
+    use crate::{
+        EngineClientError, EngineProcessingRequest, EngineProcessor, EngineRequestReceiver,
+        ResetRequest, actors::engine::client::MockEngineDerivationClient,
+    };
+
+    fn valid_fcu() -> ForkchoiceUpdated {
+        ForkchoiceUpdated {
+            payload_status: PayloadStatus {
+                status: PayloadStatusEnum::Valid,
+                latest_valid_hash: None,
+            },
+            payload_id: None,
+        }
+    }
+
+    fn syncing_fcu() -> ForkchoiceUpdated {
+        ForkchoiceUpdated {
+            payload_status: PayloadStatus {
+                status: PayloadStatusEnum::Syncing,
+                latest_valid_hash: None,
+            },
+            payload_id: None,
+        }
+    }
+
+    /// Verifies that when reth is beyond genesis and responds Valid to the bootstrap FCU probe,
+    /// `el_sync_finished` is set immediately so that the sequencer's `schedule_initial_reset`
+    /// loop is not permanently blocked by the ELSyncing guard.
+    ///
+    /// This is the fix for the leadership-transfer deadlock: previously the "beyond genesis"
+    /// bootstrap path only called `seed_state` (no FCU), leaving `el_sync_finished = false`
+    /// forever when no P2P unsafe blocks arrived.
+    #[tokio::test]
+    async fn bootstrap_beyond_genesis_valid_fcu_sets_el_sync_finished() {
+        let head = test_block_info(100);
+        let safe = test_block_info(90);
+        let finalized = test_block_info(80);
+
+        let client = Arc::new(
+            test_engine_client_builder()
+                .with_block_info_by_tag(BlockNumberOrTag::Latest, head)
+                .with_block_info_by_tag(BlockNumberOrTag::Safe, safe)
+                .with_block_info_by_tag(BlockNumberOrTag::Finalized, finalized)
+                .with_fork_choice_updated_v3_response(valid_fcu())
+                .build(),
+        );
+
+        let mut mock_derivation = MockEngineDerivationClient::new();
+        // Called by send_derivation_actor_safe_head_if_updated in the first drain() loop.
+        mock_derivation.expect_send_new_engine_safe_head().returning(|_| Ok(()));
+        // Called by mark_el_sync_complete_and_notify_derivation_actor after el_sync_finished
+        // becomes true; finalized_head is non-default so reset() is skipped.
+        mock_derivation.expect_notify_sync_completed().returning(|_| Ok(()));
+
+        let (state_tx, state_rx) = watch::channel(EngineState::default());
+        let (queue_tx, _) = watch::channel(0usize);
+        let engine = Engine::new(EngineState::default(), state_tx, queue_tx);
+
+        let processor = EngineProcessor::new(
+            Arc::clone(&client),
+            Arc::new(RollupConfig::default()),
+            mock_derivation,
+            engine,
+            None, // validator mode — no unsafe_head_tx needed
+        );
+
+        let (req_tx, req_rx) = mpsc::channel(8);
+        let handle = processor.start(req_rx);
+
+        // probe_el_sync calls state_sender.send_replace with el_sync_finished=true during
+        // the bootstrap, before the main loop starts. wait_for resolves as soon as the watch
+        // channel carries a value satisfying the predicate.
+        state_rx
+            .clone()
+            .wait_for(|s| s.el_sync_finished)
+            .await
+            .expect("state channel closed before el_sync_finished was set");
+
+        // Drop sender to cleanly terminate the spawned task.
+        drop(req_tx);
+        let result = handle.await.expect("task panicked");
+        assert!(
+            matches!(result, Err(crate::EngineError::ChannelClosed)),
+            "expected ChannelClosed on clean shutdown, got {result:?}"
+        );
+    }
+
+    /// Verifies that when reth is mid-snap-sync (FCU returns Syncing), `el_sync_finished`
+    /// stays false and a subsequent Reset request is correctly deferred with `ELSyncing`.
+    ///
+    /// This is the pre-existing snap-sync-in-progress path; the fix must not regress it.
+    #[tokio::test]
+    async fn bootstrap_beyond_genesis_syncing_fcu_defers_reset() {
+        let head = test_block_info(100);
+        let safe = test_block_info(90);
+        let finalized = test_block_info(80);
+
+        let client = Arc::new(
+            test_engine_client_builder()
+                .with_block_info_by_tag(BlockNumberOrTag::Latest, head)
+                .with_block_info_by_tag(BlockNumberOrTag::Safe, safe)
+                .with_block_info_by_tag(BlockNumberOrTag::Finalized, finalized)
+                .with_fork_choice_updated_v3_response(syncing_fcu())
+                .build(),
+        );
+
+        let mut mock_derivation = MockEngineDerivationClient::new();
+        // Called by send_derivation_actor_safe_head_if_updated after seed_state seeds safe_head.
+        mock_derivation.expect_send_new_engine_safe_head().returning(|_| Ok(()));
+        // notify_sync_completed must NOT be called: el_sync_finished is still false.
+
+        let (state_tx, state_rx) = watch::channel(EngineState::default());
+        let (queue_tx, _) = watch::channel(0usize);
+        let engine = Engine::new(EngineState::default(), state_tx, queue_tx);
+
+        let processor = EngineProcessor::new(
+            Arc::clone(&client),
+            Arc::new(RollupConfig::default()),
+            mock_derivation,
+            engine,
+            None,
+        );
+
+        let (req_tx, req_rx) = mpsc::channel(8);
+        let handle = processor.start(req_rx);
+
+        // In the Syncing path, seed_state sets unsafe_head to reth's reported latest block.
+        // Wait for that state to be published before sending the Reset.
+        state_rx
+            .clone()
+            .wait_for(|s| s.sync_state.unsafe_head().block_info.number > 0)
+            .await
+            .expect("state channel closed before seed_state published");
+
+        // Send a Reset — the ELSyncing guard must fire and return ELSyncing.
+        let (result_tx, mut result_rx) = mpsc::channel(1);
+        req_tx
+            .send(EngineProcessingRequest::Reset(Box::new(ResetRequest { result_tx })))
+            .await
+            .expect("failed to send reset request");
+
+        let response = result_rx.recv().await.expect("response channel closed");
+        assert!(
+            matches!(response, Err(EngineClientError::ELSyncing)),
+            "expected ELSyncing while snap-sync is in progress, got {response:?}"
+        );
+
+        drop(req_tx);
+        let _ = handle.await;
     }
 }


### PR DESCRIPTION
## Summary

When the consensus node restarts after a conductor leadership transfer, the engine bootstrap code took the "beyond genesis" path which called only `seed_state()` with no forkchoice update, leaving `el_sync_finished` permanently false. This caused every `ResetRequest` from the sequencer's `schedule_initial_reset` loop to be rejected with `ELSyncing`, permanently stalling the sequencer as long as no P2P unsafe blocks arrived to trigger a `SynchronizeTask` FCU. The fix adds `Engine::probe_el_sync()`, which calls `SynchronizeTask::execute()` directly before `seed_state()` is ever called, bypassing the early-exit guard that would silently skip the FCU if state had already been seeded. On a Valid EL response `el_sync_finished` is set immediately and `seed_state()` is skipped; on Syncing the node falls back to the existing P2P-driven sync path.