### PR TITLE
fix: install mold linker for Linux release builds

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -56,6 +56,14 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y libclang-dev pkg-config
 
+      - name: Install mold linker (Linux)
+        if: matrix.target.os == 'linux'
+        run: |
+          MOLD_VERSION="2.30.0"
+          ARCH="$(uname -m)"
+          curl -sSfL "https://github.com/rui314/mold/releases/download/v${MOLD_VERSION}/mold-${MOLD_VERSION}-${ARCH}-linux.tar.gz" \
+            | sudo tar -xz --strip-components=1 -C /usr/local
+
       - name: Install lld linker (macOS)
         if: matrix.target.os == 'macos'
         run: |

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -59,7 +59,7 @@ jobs:
       - name: Install mold linker (Linux)
         if: matrix.target.os == 'linux'
         run: |
-          MOLD_VERSION="2.30.0"
+          MOLD_VERSION="2.40.4"
           ARCH="$(uname -m)"
           curl -sSfL "https://github.com/rui314/mold/releases/download/v${MOLD_VERSION}/mold-${MOLD_VERSION}-${ARCH}-linux.tar.gz" \
             | sudo tar -xz --strip-components=1 -C /usr/local

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -58,11 +58,7 @@ jobs:
 
       - name: Install mold linker (Linux)
         if: matrix.target.os == 'linux'
-        run: |
-          MOLD_VERSION="2.40.4"
-          ARCH="$(uname -m)"
-          curl -sSfL "https://github.com/rui314/mold/releases/download/v${MOLD_VERSION}/mold-${MOLD_VERSION}-${ARCH}-linux.tar.gz" \
-            | sudo tar -xz --strip-components=1 -C /usr/local
+        uses: rui314/setup-mold@725a8794d15fc7563f59595bd9556495c0564878 # v1
 
       - name: Install lld linker (macOS)
         if: matrix.target.os == 'macos'


### PR DESCRIPTION
The `.cargo/config.toml` specifies mold as the linker for Linux targets but the release workflow never installed it, causing `cannot find 'ld'` failures.

Installs mold v2.30.0 (matching the version in Ubuntu 24.04 used by our Dockerfiles) via curl from GitHub releases.