### PR TITLE
fix: backport linker fixes from release branch

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -57,6 +57,10 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y libclang-dev pkg-config
 
+      - name: Install mold linker (Linux)
+        if: matrix.target.os == 'linux'
+        uses: rui314/setup-mold@725a8794d15fc7563f59595bd9556495c0564878 # v1
+
       - name: Install lld linker (macOS)
         if: matrix.target.os == 'macos'
         run: |

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -57,6 +57,19 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y libclang-dev pkg-config
 
+      - name: Install lld linker (macOS)
+        if: matrix.target.os == 'macos'
+        run: |
+          # llvm@15 is pre-installed on GH runners and includes ld64.lld.
+          # Create a symlink so .cargo/config.toml's /opt/homebrew/opt/lld/ path resolves.
+          LLD_BIN="$(brew --prefix llvm@15)/bin/ld64.lld"
+          if [ -x "$LLD_BIN" ]; then
+            sudo mkdir -p /opt/homebrew/opt/lld/bin
+            sudo ln -sf "$LLD_BIN" /opt/homebrew/opt/lld/bin/ld64.lld
+          else
+            brew install lld
+          fi
+
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@4305c38b25d97ef35a8ad1f985ccf2d2242004f2 # stable
 


### PR DESCRIPTION
Cherry-picks #1722 and #1723 from `releases/v0.6.0` to main.

- Install lld linker for macOS release builds
- Install mold linker for Linux release builds via `setup-mold` action