### PR TITLE
fix(consensus): Walk Back System Config On Reset

### DIFF
--- a/actions/harness/src/node.rs
+++ b/actions/harness/src/node.rs
@@ -15,7 +15,7 @@ use base_consensus_derive::{
     PipelineErrorKind, ResetSignal, Signal, SignalReceiver, StatefulAttributesBuilder, StepResult,
 };
 use base_consensus_engine::{EngineForkchoiceVersion, EngineNewPayloadVersion};
-use base_consensus_genesis::{RollupConfig, SystemConfig};
+use base_consensus_genesis::RollupConfig;
 use base_consensus_safedb::{
     SafeDB, SafeDBError, SafeDBReader, SafeHeadListener, SafeHeadResponse,
 };
@@ -230,12 +230,8 @@ impl<P: Pipeline + SignalReceiver + Debug + Send> TestRollupNode<P> {
     /// [`step`]: TestRollupNode::step
     /// [`run_until_idle`]: TestRollupNode::run_until_idle
     pub async fn initialize(&mut self) {
-        let l1_origin = self.pipeline.origin().unwrap_or_default();
         self.pipeline
-            .signal(
-                ActivationSignal { l2_safe_head: self.safe_head, l1_origin, system_config: None }
-                    .signal(),
-            )
+            .signal(ActivationSignal { l2_safe_head: self.safe_head }.signal())
             .await
             .expect("TestRollupNode: initialize signal failed");
         self.run_until_idle().await;
@@ -386,17 +382,9 @@ impl<P: Pipeline + SignalReceiver + Debug + Send> TestRollupNode<P> {
     /// Sends a [`ResetSignal`] to the pipeline, resets all head pointers,
     /// clears all per-block metadata, and replaces the engine with a fresh
     /// instance that will re-execute from genesis on the new fork.
-    pub async fn act_reset(
-        &mut self,
-        l1_origin: BlockInfo,
-        l2_safe_head: L2BlockInfo,
-        system_config: SystemConfig,
-    ) {
+    pub async fn act_reset(&mut self, l2_safe_head: L2BlockInfo) {
         self.pipeline
-            .signal(
-                ResetSignal { l1_origin, l2_safe_head, system_config: Some(system_config) }
-                    .signal(),
-            )
+            .signal(ResetSignal { l2_safe_head }.signal())
             .await
             .expect("TestRollupNode: act_reset signal failed");
         self.safe_head = l2_safe_head;

--- a/actions/harness/tests/derivation.rs
+++ b/actions/harness/tests/derivation.rs
@@ -198,11 +198,9 @@ async fn reorg_reverts_derived_safe_head() {
     chain.push(h.l1.tip().clone());
 
     // Reset the pipeline: revert safe head and L1 origin to genesis.
-    let l1_genesis = block_info_from(h.l1.chain().first().expect("genesis always present"));
     let l2_genesis = h.l2_genesis();
-    let genesis_sys_cfg = rollup_cfg.genesis.system_config.unwrap_or_default();
 
-    node.act_reset(l1_genesis, l2_genesis, genesis_sys_cfg).await;
+    node.act_reset(l2_genesis).await;
     // Drain the reset origin (genesis has no batch data).
     node.run_until_idle().await;
 
@@ -255,11 +253,9 @@ async fn reorg_and_resubmit_rederives_l2_block() {
     chain.push(h.l1.tip().clone());
 
     // Reset pipeline to genesis.
-    let l1_genesis = block_info_from(h.l1.chain().first().expect("genesis always present"));
     let l2_genesis = h.l2_genesis();
-    let genesis_sys_cfg = rollup_cfg.genesis.system_config.unwrap_or_default();
 
-    node.act_reset(l1_genesis, l2_genesis, genesis_sys_cfg).await;
+    node.act_reset(l2_genesis).await;
     node.run_until_idle().await;
 
     // Step over the empty block 1' — nothing derived.
@@ -308,9 +304,7 @@ async fn reorg_flip_flop() {
 
     // Shared reset helpers — computed once, valid across all forks because
     // genesis is immutable.
-    let l1_genesis = block_info_from(h.l1.chain().first().expect("genesis always present"));
     let l2_genesis = h.l2_genesis();
-    let genesis_sys_cfg = rollup_cfg.genesis.system_config.unwrap_or_default();
 
     // --- Phase 1: Fork A canonical (genesis → A1 with batch). ---
     {
@@ -341,7 +335,7 @@ async fn reorg_flip_flop() {
     chain.truncate_to(0);
     chain.push(h.l1.tip().clone());
 
-    node.act_reset(l1_genesis, l2_genesis, genesis_sys_cfg).await;
+    node.act_reset(l2_genesis).await;
     node.run_until_idle().await;
     node.act_l1_head_signal(fork_b1).await;
     let derived = node.run_until_idle().await;
@@ -360,7 +354,7 @@ async fn reorg_flip_flop() {
     chain.truncate_to(0);
     chain.push(h.l1.tip().clone());
 
-    node.act_reset(l1_genesis, l2_genesis, genesis_sys_cfg).await;
+    node.act_reset(l2_genesis).await;
     node.run_until_idle().await;
     node.act_l1_head_signal(fork_a_prime1).await;
     let derived = node.run_until_idle().await;
@@ -400,9 +394,7 @@ async fn reorg_flip_flop_empty_middle_fork() {
     let block2 = builder.build_next_block_with_single_transaction();
 
     // Shared reset targets — valid across all forks because genesis is immutable.
-    let l1_genesis = block_info_from(h.l1.chain().first().expect("genesis always present"));
     let l2_genesis = h.l2_genesis();
-    let genesis_sys_cfg = rollup_cfg.genesis.system_config.unwrap_or_default();
 
     // --- Fork A: mine A1 (batch for L2 block 1) and A2 (batch for L2 block 2). ---
     let mut batcher_a = Batcher::new(ActionL2Source::new(), &h.rollup_config, batcher_cfg.clone());
@@ -433,7 +425,7 @@ async fn reorg_flip_flop_empty_middle_fork() {
         fork_b_blocks.push(h.mine_and_push(&chain));
     }
 
-    node.act_reset(l1_genesis, l2_genesis, genesis_sys_cfg).await;
+    node.act_reset(l2_genesis).await;
     // act_reset sets safe_head and finalized_head to the reset target (l2_genesis).
     // Per the OP Stack spec, unsafe_head is NOT clamped to safe_head on reset —
     // it is re-discovered by walking back from the current tip to the first block
@@ -467,7 +459,7 @@ async fn reorg_flip_flop_empty_middle_fork() {
         chain.push(h.l1.tip().clone());
     }
 
-    node.act_reset(l1_genesis, l2_genesis, genesis_sys_cfg).await;
+    node.act_reset(l2_genesis).await;
     assert_eq!(node.l2_safe_number(), 0, "reset to C: safe head = 0");
     assert_eq!(node.l2_finalized_number(), 0, "reset to C: finalized head = 0");
     // unsafe_head unchanged by act_reset (spec-compliant: re-discover, don't clamp).
@@ -986,10 +978,8 @@ async fn deep_reorg_multi_block() {
     h.l1.reorg_to(0).expect("reorg to genesis");
     chain.truncate_to(0);
 
-    let l1_genesis = block_info_from(h.l1.chain().first().expect("genesis"));
     let l2_genesis = h.l2_genesis();
-    let genesis_sys_cfg = rollup_cfg.genesis.system_config.unwrap_or_default();
-    node.act_reset(l1_genesis, l2_genesis, genesis_sys_cfg).await;
+    node.act_reset(l2_genesis).await;
     node.run_until_idle().await;
 
     assert_eq!(node.l2_safe_number(), 0, "safe head reverted to genesis");
@@ -1750,7 +1740,6 @@ async fn batcher_config_update_rolled_back_on_reorg() {
     let rollup_cfg = TestRollupConfigBuilder::base_mainnet(&batcher_a)
         .with_l1_system_config_address(l1_sys_cfg_addr)
         .build();
-    let genesis_sys_cfg = rollup_cfg.genesis.system_config.unwrap_or_default();
     let mut h = ActionTestHarness::new(L1MinerConfig::default(), rollup_cfg.clone());
 
     // Build L2 blocks 1, 2, 3 upfront from the L1 genesis state.
@@ -1814,10 +1803,9 @@ async fn batcher_config_update_rolled_back_on_reorg() {
     h.l1.reorg_to(0).expect("reorg to genesis");
     chain.truncate_to(0);
 
-    let l1_genesis = block_info_from(h.l1.chain().first().expect("genesis always present"));
     let l2_genesis = h.l2_genesis();
 
-    node.act_reset(l1_genesis, l2_genesis, genesis_sys_cfg).await;
+    node.act_reset(l2_genesis).await;
     // Drain the reset origin (genesis has no batch data).
     node.run_until_idle().await;
 

--- a/actions/harness/tests/finalization.rs
+++ b/actions/harness/tests/finalization.rs
@@ -2,7 +2,7 @@
 
 use base_action_harness::{
     ActionL2Source, ActionTestHarness, Batcher, BatcherConfig, L1MinerConfig, SharedL1Chain,
-    TestRollupConfigBuilder, block_info_from,
+    TestRollupConfigBuilder,
 };
 use base_batcher_encoder::{DaType, EncoderConfig};
 
@@ -266,11 +266,9 @@ async fn finalization_reorg_clears_state() {
     assert_eq!(node.l2_finalized_number(), 2, "pre-reset finalized = 2");
 
     // Simulate a reorg by resetting the pipeline to genesis.
-    let l1_genesis = block_info_from(h.l1.chain().first().expect("genesis always present"));
     let l2_genesis = h.l2_genesis();
-    let genesis_sys_cfg = rollup_cfg.genesis.system_config.unwrap_or_default();
 
-    node.act_reset(l1_genesis, l2_genesis, genesis_sys_cfg).await;
+    node.act_reset(l2_genesis).await;
     node.run_until_idle().await;
 
     // After reset, finalized head should be back to genesis (block 0).

--- a/crates/consensus/derive/src/lib.rs
+++ b/crates/consensus/derive/src/lib.rs
@@ -43,7 +43,7 @@ mod traits;
 pub use traits::{
     AttributesBuilder, AttributesProvider, BatchValidationProviderDerive, BlobProvider,
     ChainProvider, DataAvailabilityProvider, L2ChainProvider, NextAttributes, OriginAdvancer,
-    OriginProvider, Pipeline, ResetProvider, SignalReceiver,
+    OriginProvider, Pipeline, ResetProvider, SignalReceiver, StageReset,
 };
 
 mod types;

--- a/crates/consensus/derive/src/pipeline/builder.rs
+++ b/crates/consensus/derive/src/pipeline/builder.rs
@@ -162,6 +162,9 @@ where
         // Compose the stage stack.
         let mut l1_traversal = IndexedTraversal::new(chain_provider, Arc::clone(&rollup_config));
         l1_traversal.block = Some(builder.origin.expect("origin must be set"));
+        if let Some(system_config) = rollup_config.genesis.system_config {
+            l1_traversal.system_config = system_config;
+        }
         let l1_retrieval = L1Retrieval::new(l1_traversal, dap_source);
         let frame_queue = FrameQueue::new(l1_retrieval, Arc::clone(&rollup_config));
         let channel_provider = ChannelProvider::new(Arc::clone(&rollup_config), frame_queue);

--- a/crates/consensus/derive/src/pipeline/core.rs
+++ b/crates/consensus/derive/src/pipeline/core.rs
@@ -3,21 +3,22 @@
 use alloc::{boxed::Box, collections::VecDeque, string::ToString, sync::Arc};
 use core::fmt::Debug;
 
+use alloy_eips::BlockNumHash;
 use async_trait::async_trait;
 use base_consensus_genesis::{RollupConfig, SystemConfig};
-use base_protocol::{BlockInfo, L2BlockInfo, OpAttributesWithParent};
+use base_protocol::{BatchValidationProvider, BlockInfo, L2BlockInfo, OpAttributesWithParent};
 
 use crate::{
     ActivationSignal, L2ChainProvider, Metrics, NextAttributes, OriginAdvancer, OriginProvider,
     Pipeline, PipelineError, PipelineErrorKind, PipelineResult, ResetSignal, Signal,
-    SignalReceiver, StepResult,
+    SignalReceiver, StageReset, StepResult,
 };
 
 /// The derivation pipeline is responsible for deriving L2 inputs from L1 data.
 #[derive(Debug)]
 pub struct DerivationPipeline<S, P>
 where
-    S: NextAttributes + SignalReceiver + OriginProvider + OriginAdvancer + Debug + Send,
+    S: NextAttributes + StageReset + OriginProvider + OriginAdvancer + Debug + Send,
     P: L2ChainProvider + Send + Sync + Debug,
 {
     /// A handle to the next attributes.
@@ -34,7 +35,7 @@ where
 
 impl<S, P> DerivationPipeline<S, P>
 where
-    S: NextAttributes + SignalReceiver + OriginProvider + OriginAdvancer + Debug + Send,
+    S: NextAttributes + StageReset + OriginProvider + OriginAdvancer + Debug + Send,
     P: L2ChainProvider + Send + Sync + Debug,
 {
     /// Creates a new instance of the [`DerivationPipeline`].
@@ -45,11 +46,53 @@ where
     ) -> Self {
         Self { attributes, prepared: VecDeque::new(), rollup_config, l2_chain_provider }
     }
+
+    /// Walks back the L2 chain from `l2_safe_head` until the walked-back block's L1 origin
+    /// is at most `channel_timeout` L1 blocks behind the safe head's L1 origin, then returns
+    /// that block's L1 origin and system config.
+    ///
+    /// This matches op-node's `initialReset` behavior: using the system config from a
+    /// potentially older L2 block ensures we see any batcher-address changes that could
+    /// affect channels still open within the channel timeout window.
+    async fn initial_reset(
+        &mut self,
+        l2_safe_head: L2BlockInfo,
+    ) -> PipelineResult<(BlockNumHash, SystemConfig)>
+    where
+        <P as BatchValidationProvider>::Error: Into<PipelineErrorKind>,
+    {
+        let channel_timeout =
+            self.rollup_config.channel_timeout(l2_safe_head.block_info.timestamp);
+        let l1_origin_number = l2_safe_head.l1_origin.number;
+        let mut current = l2_safe_head;
+
+        loop {
+            if current.block_info.number == self.rollup_config.genesis.l2.number {
+                break;
+            }
+            if current.l1_origin.number + channel_timeout <= l1_origin_number {
+                break;
+            }
+            current = self
+                .l2_chain_provider
+                .l2_block_info_by_number(current.block_info.number - 1)
+                .await
+                .map_err(Into::into)?;
+        }
+
+        let system_config = self
+            .l2_chain_provider
+            .system_config_by_number(current.block_info.number, Arc::clone(&self.rollup_config))
+            .await
+            .map_err(Into::into)?;
+
+        Ok((current.l1_origin, system_config))
+    }
 }
 
 impl<S, P> OriginProvider for DerivationPipeline<S, P>
 where
-    S: NextAttributes + SignalReceiver + OriginProvider + OriginAdvancer + Debug + Send,
+    S: NextAttributes + StageReset + OriginProvider + OriginAdvancer + Debug + Send,
     P: L2ChainProvider + Send + Sync + Debug,
 {
     fn origin(&self) -> Option<BlockInfo> {
@@ -59,7 +102,7 @@ where
 
 impl<S, P> Iterator for DerivationPipeline<S, P>
 where
-    S: NextAttributes + SignalReceiver + OriginProvider + OriginAdvancer + Debug + Send + Sync,
+    S: NextAttributes + StageReset + OriginProvider + OriginAdvancer + Debug + Send + Sync,
     P: L2ChainProvider + Send + Sync + Debug,
 {
     type Item = OpAttributesWithParent;
@@ -74,36 +117,26 @@ where
 #[async_trait]
 impl<S, P> SignalReceiver for DerivationPipeline<S, P>
 where
-    S: NextAttributes + SignalReceiver + OriginProvider + OriginAdvancer + Debug + Send + Sync,
+    S: NextAttributes + StageReset + OriginProvider + OriginAdvancer + Debug + Send + Sync,
     P: L2ChainProvider + Send + Sync + Debug,
+    <P as BatchValidationProvider>::Error: Into<PipelineErrorKind>,
 {
-    /// Signals the pipeline by calling the [`SignalReceiver::signal`] method.
+    /// Signals the pipeline by dispatching typed [`StageReset`] methods to the stage chain.
     ///
-    /// During a [`Signal::Reset`], each stage is recursively called from the top-level
-    /// [`crate::stages::AttributesQueue`] to the bottom [`crate::PollingTraversal`]
-    /// with a head-recursion pattern. This effectively clears the internal state
-    /// of each stage in the pipeline from bottom on up.
+    /// During a [`Signal::Reset`], [`initial_reset`] walks back the L2 chain to find the
+    /// correct L1 origin and system config before propagating the reset downward. This fixes
+    /// a bug where the pipeline used the system config from exactly the safe head block,
+    /// missing batcher-address changes within the channel timeout window.
     ///
-    /// [`Signal::Activation`] does a similar thing to the reset, with different
-    /// holocene-specific reset rules.
+    /// [`Signal::Activation`] performs a soft reset (clears buffers, preserves origin/config).
     ///
-    /// ### Parameters
-    ///
-    /// The `signal` is contains the signal variant with any necessary parameters.
+    /// [`initial_reset`]: Self::initial_reset
     async fn signal(&mut self, signal: Signal) -> PipelineResult<()> {
         match signal {
-            mut s @ Signal::Reset(ResetSignal { l2_safe_head, .. })
-            | mut s @ Signal::Activation(ActivationSignal { l2_safe_head, .. }) => {
-                let system_config = self
-                    .l2_chain_provider
-                    .system_config_by_number(
-                        l2_safe_head.block_info.number,
-                        Arc::clone(&self.rollup_config),
-                    )
-                    .await
-                    .map_err(Into::into)?;
-                s = s.with_system_config(system_config);
-                match self.attributes.signal(s).await {
+            Signal::Reset(ResetSignal { l2_safe_head }) => {
+                let (l1_origin, system_config) =
+                    self.initial_reset(l2_safe_head).await?;
+                match self.attributes.reset(l1_origin, system_config).await {
                     Ok(()) => trace!(target: "pipeline", "Stages reset"),
                     Err(err) => {
                         if let PipelineErrorKind::Temporary(PipelineError::Eof) = err {
@@ -115,8 +148,24 @@ where
                     }
                 }
             }
-            Signal::FlushChannel | Signal::ProvideBlock(_) => {
-                self.attributes.signal(signal).await?;
+            Signal::Activation(ActivationSignal { l2_safe_head: _ }) => {
+                match self.attributes.activate().await {
+                    Ok(()) => trace!(target: "pipeline", "Stages activated"),
+                    Err(err) => {
+                        if let PipelineErrorKind::Temporary(PipelineError::Eof) = err {
+                            trace!(target: "pipeline", "Stages activated with EOF");
+                        } else {
+                            error!(target: "pipeline", error = ?err, "Stage activation errored");
+                            return Err(err);
+                        }
+                    }
+                }
+            }
+            Signal::FlushChannel => {
+                self.attributes.flush_channel().await?;
+            }
+            Signal::ProvideBlock(block) => {
+                self.attributes.provide_block(block).await?;
             }
         }
         Metrics::pipeline_signals(signal.to_string()).increment(1.0);
@@ -127,7 +176,7 @@ where
 #[async_trait]
 impl<S, P> Pipeline for DerivationPipeline<S, P>
 where
-    S: NextAttributes + SignalReceiver + OriginProvider + OriginAdvancer + Debug + Send + Sync,
+    S: NextAttributes + StageReset + OriginProvider + OriginAdvancer + Debug + Send + Sync,
     P: L2ChainProvider + Send + Sync + Debug,
 {
     /// Peeks at the next prepared [`OpAttributesWithParent`] from the pipeline.
@@ -206,6 +255,7 @@ where
 mod tests {
     use alloc::{string::ToString, sync::Arc};
 
+    use alloy_eips::BlockNumHash;
     use alloy_rpc_types_engine::PayloadAttributes;
     use base_alloy_rpc_types_engine::OpPayloadAttributes;
     use base_consensus_genesis::{RollupConfig, SystemConfig};
@@ -307,7 +357,7 @@ mod tests {
         let attributes = TestNextAttributes::default();
         let mut pipeline = DerivationPipeline::new(attributes, rollup_config, l2_chain_provider);
 
-        // Signal the pipeline to reset.
+        // Signal the pipeline to activate.
         let result = pipeline.signal(ActivationSignal::default().signal()).await;
         assert!(result.is_ok());
     }
@@ -319,7 +369,7 @@ mod tests {
         let attributes = TestNextAttributes::default();
         let mut pipeline = DerivationPipeline::new(attributes, rollup_config, l2_chain_provider);
 
-        // Signal the pipeline to reset.
+        // Signal the pipeline to flush channel.
         let result = pipeline.signal(Signal::FlushChannel).await;
         assert!(result.is_ok());
     }
@@ -331,7 +381,7 @@ mod tests {
         let attributes = TestNextAttributes::default();
         let mut pipeline = DerivationPipeline::new(attributes, rollup_config, l2_chain_provider);
 
-        // Signal the pipeline to reset.
+        // Signal the pipeline to reset — fails because system config is not found.
         let result = pipeline.signal(ResetSignal::default().signal()).await.unwrap_err();
         assert_eq!(result, PipelineError::Provider("System config not found".to_string()).temp());
     }
@@ -346,6 +396,27 @@ mod tests {
 
         // Signal the pipeline to reset.
         let result = pipeline.signal(ResetSignal::default().signal()).await;
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_derivation_pipeline_initial_reset_walks_back() {
+        let rollup_config = Arc::new(RollupConfig {
+            // channel_timeout = 100 so the walk-back will stop at genesis (block 0)
+            ..Default::default()
+        });
+        let mut l2_chain_provider = TestL2ChainProvider::default();
+        l2_chain_provider.system_configs.insert(0, SystemConfig::default());
+        let attributes = TestNextAttributes::default();
+        let mut pipeline =
+            DerivationPipeline::new(attributes, rollup_config, l2_chain_provider);
+
+        // With L2 safe head at genesis (block 0), initial_reset should stop at genesis.
+        let l2_safe_head = L2BlockInfo {
+            l1_origin: BlockNumHash { number: 5, hash: Default::default() },
+            ..Default::default()
+        };
+        let result = pipeline.initial_reset(l2_safe_head).await;
         assert!(result.is_ok());
     }
 }

--- a/crates/consensus/derive/src/pipeline/core.rs
+++ b/crates/consensus/derive/src/pipeline/core.rs
@@ -61,8 +61,7 @@ where
     where
         <P as BatchValidationProvider>::Error: Into<PipelineErrorKind>,
     {
-        let channel_timeout =
-            self.rollup_config.channel_timeout(l2_safe_head.block_info.timestamp);
+        let channel_timeout = self.rollup_config.channel_timeout(l2_safe_head.block_info.timestamp);
         let l1_origin_number = l2_safe_head.l1_origin.number;
         let mut current = l2_safe_head;
 
@@ -134,8 +133,7 @@ where
     async fn signal(&mut self, signal: Signal) -> PipelineResult<()> {
         match signal {
             Signal::Reset(ResetSignal { l2_safe_head }) => {
-                let (l1_origin, system_config) =
-                    self.initial_reset(l2_safe_head).await?;
+                let (l1_origin, system_config) = self.initial_reset(l2_safe_head).await?;
                 match self.attributes.reset(l1_origin, system_config).await {
                     Ok(()) => trace!(target: "pipeline", "Stages reset"),
                     Err(err) => {
@@ -408,8 +406,7 @@ mod tests {
         let mut l2_chain_provider = TestL2ChainProvider::default();
         l2_chain_provider.system_configs.insert(0, SystemConfig::default());
         let attributes = TestNextAttributes::default();
-        let mut pipeline =
-            DerivationPipeline::new(attributes, rollup_config, l2_chain_provider);
+        let mut pipeline = DerivationPipeline::new(attributes, rollup_config, l2_chain_provider);
 
         // With L2 safe head at genesis (block 0), initial_reset should stop at genesis.
         let l2_safe_head = L2BlockInfo {

--- a/crates/consensus/derive/src/stages/attributes_queue.rs
+++ b/crates/consensus/derive/src/stages/attributes_queue.rs
@@ -3,13 +3,11 @@
 use alloc::{boxed::Box, sync::Arc};
 use core::fmt::Debug;
 
+use alloy_eips::BlockNumHash;
 use async_trait::async_trait;
 use base_alloy_rpc_types_engine::OpPayloadAttributes;
-use base_consensus_genesis::RollupConfig;
+use base_consensus_genesis::{RollupConfig, SystemConfig};
 use base_protocol::{BlockInfo, L2BlockInfo, OpAttributesWithParent, SingleBatch};
-
-use alloy_eips::BlockNumHash;
-use base_consensus_genesis::SystemConfig;
 
 use crate::{
     Metrics,
@@ -186,7 +184,11 @@ where
     P: AttributesProvider + OriginAdvancer + OriginProvider + StageReset + Send + Debug,
     AB: AttributesBuilder + Send + Debug,
 {
-    async fn reset(&mut self, l1_origin: BlockNumHash, system_config: SystemConfig) -> PipelineResult<()> {
+    async fn reset(
+        &mut self,
+        l1_origin: BlockNumHash,
+        system_config: SystemConfig,
+    ) -> PipelineResult<()> {
         self.prev.reset(l1_origin, system_config).await?;
         self.batch = None;
         self.is_last_in_span = false;
@@ -215,10 +217,9 @@ where
 mod tests {
     use alloc::{sync::Arc, vec, vec::Vec};
 
+    use alloy_eips::BlockNumHash;
     use alloy_primitives::{Address, B256, Bytes, b256};
     use alloy_rpc_types_engine::PayloadAttributes;
-
-    use alloy_eips::BlockNumHash;
     use base_consensus_genesis::SystemConfig;
 
     use super::*;

--- a/crates/consensus/derive/src/stages/attributes_queue.rs
+++ b/crates/consensus/derive/src/stages/attributes_queue.rs
@@ -8,14 +8,17 @@ use base_alloy_rpc_types_engine::OpPayloadAttributes;
 use base_consensus_genesis::RollupConfig;
 use base_protocol::{BlockInfo, L2BlockInfo, OpAttributesWithParent, SingleBatch};
 
+use alloy_eips::BlockNumHash;
+use base_consensus_genesis::SystemConfig;
+
 use crate::{
     Metrics,
     errors::{PipelineError, ResetError},
     traits::{
         AttributesBuilder, AttributesProvider, NextAttributes, OriginAdvancer, OriginProvider,
-        SignalReceiver,
+        StageReset,
     },
-    types::{PipelineResult, Signal},
+    types::PipelineResult,
 };
 
 /// [`AttributesQueue`] accepts batches from the [`BatchQueue`] stage
@@ -34,7 +37,7 @@ use crate::{
 #[derive(Debug)]
 pub struct AttributesQueue<P, AB>
 where
-    P: AttributesProvider + OriginAdvancer + OriginProvider + SignalReceiver + Debug,
+    P: AttributesProvider + OriginAdvancer + OriginProvider + StageReset + Debug,
     AB: AttributesBuilder + Debug,
 {
     /// The rollup config.
@@ -51,7 +54,7 @@ where
 
 impl<P, AB> AttributesQueue<P, AB>
 where
-    P: AttributesProvider + OriginAdvancer + OriginProvider + SignalReceiver + Debug,
+    P: AttributesProvider + OriginAdvancer + OriginProvider + StageReset + Debug,
     AB: AttributesBuilder + Debug,
 {
     /// Create a new [`AttributesQueue`] stage.
@@ -145,7 +148,7 @@ where
 #[async_trait]
 impl<P, AB> OriginAdvancer for AttributesQueue<P, AB>
 where
-    P: AttributesProvider + OriginAdvancer + OriginProvider + SignalReceiver + Debug + Send,
+    P: AttributesProvider + OriginAdvancer + OriginProvider + StageReset + Debug + Send,
     AB: AttributesBuilder + Debug + Send,
 {
     async fn advance_origin(&mut self) -> PipelineResult<()> {
@@ -156,7 +159,7 @@ where
 #[async_trait]
 impl<P, AB> NextAttributes for AttributesQueue<P, AB>
 where
-    P: AttributesProvider + OriginAdvancer + OriginProvider + SignalReceiver + Debug + Send,
+    P: AttributesProvider + OriginAdvancer + OriginProvider + StageReset + Debug + Send,
     AB: AttributesBuilder + Debug + Send,
 {
     async fn next_attributes(
@@ -169,7 +172,7 @@ where
 
 impl<P, AB> OriginProvider for AttributesQueue<P, AB>
 where
-    P: AttributesProvider + OriginAdvancer + OriginProvider + SignalReceiver + Debug,
+    P: AttributesProvider + OriginAdvancer + OriginProvider + StageReset + Debug,
     AB: AttributesBuilder + Debug,
 {
     fn origin(&self) -> Option<BlockInfo> {
@@ -178,27 +181,33 @@ where
 }
 
 #[async_trait]
-impl<P, AB> SignalReceiver for AttributesQueue<P, AB>
+impl<P, AB> StageReset for AttributesQueue<P, AB>
 where
-    P: AttributesProvider + OriginAdvancer + OriginProvider + SignalReceiver + Send + Debug,
+    P: AttributesProvider + OriginAdvancer + OriginProvider + StageReset + Send + Debug,
     AB: AttributesBuilder + Send + Debug,
 {
-    async fn signal(&mut self, signal: Signal) -> PipelineResult<()> {
-        match signal {
-            s @ Signal::Reset(_) | s @ Signal::Activation(_) => {
-                self.prev.signal(s).await?;
-                self.batch = None;
-                self.is_last_in_span = false;
-            }
-            s @ Signal::FlushChannel => {
-                self.batch = None;
-                self.prev.signal(s).await?;
-            }
-            s @ Signal::ProvideBlock(_) => {
-                self.prev.signal(s).await?;
-            }
-        }
+    async fn reset(&mut self, l1_origin: BlockNumHash, system_config: SystemConfig) -> PipelineResult<()> {
+        self.prev.reset(l1_origin, system_config).await?;
+        self.batch = None;
+        self.is_last_in_span = false;
         Ok(())
+    }
+
+    async fn activate(&mut self) -> PipelineResult<()> {
+        self.prev.activate().await?;
+        self.batch = None;
+        self.is_last_in_span = false;
+        Ok(())
+    }
+
+    async fn flush_channel(&mut self) -> PipelineResult<()> {
+        // Clear batch first, then propagate.
+        self.batch = None;
+        self.prev.flush_channel().await
+    }
+
+    async fn provide_block(&mut self, block: BlockInfo) -> PipelineResult<()> {
+        self.prev.provide_block(block).await
     }
 }
 
@@ -209,11 +218,14 @@ mod tests {
     use alloy_primitives::{Address, B256, Bytes, b256};
     use alloy_rpc_types_engine::PayloadAttributes;
 
+    use alloy_eips::BlockNumHash;
+    use base_consensus_genesis::SystemConfig;
+
     use super::*;
     use crate::{
+        StageReset,
         errors::{BuilderError, PipelineErrorKind},
         test_utils::{TestAttributesBuilder, TestAttributesProvider, new_test_attributes_provider},
-        types::ResetSignal,
     };
 
     fn default_optimism_payload_attributes() -> OpPayloadAttributes {
@@ -250,7 +262,7 @@ mod tests {
         let mut attributes_queue = new_attributes_queue(None, None, vec![], vec![]);
         attributes_queue.batch = Some(SingleBatch::default());
         assert!(!attributes_queue.prev.flushed);
-        attributes_queue.signal(Signal::FlushChannel).await.unwrap();
+        attributes_queue.flush_channel().await.unwrap();
         assert!(attributes_queue.prev.flushed);
         assert!(attributes_queue.batch.is_none());
     }
@@ -263,7 +275,7 @@ mod tests {
         let mut aq = AttributesQueue::new(Arc::new(cfg), mock, mock_builder);
         aq.batch = Some(SingleBatch::default());
         assert!(!aq.prev.reset);
-        aq.signal(ResetSignal::default().signal()).await.unwrap();
+        aq.reset(BlockNumHash::default(), SystemConfig::default()).await.unwrap();
         assert!(aq.batch.is_none());
         assert!(aq.prev.reset);
     }

--- a/crates/consensus/derive/src/stages/batch/batch_provider.rs
+++ b/crates/consensus/derive/src/stages/batch/batch_provider.rs
@@ -3,14 +3,12 @@
 use alloc::{boxed::Box, sync::Arc};
 use core::fmt::Debug;
 
+use alloy_eips::BlockNumHash;
 use async_trait::async_trait;
-use base_consensus_genesis::RollupConfig;
+use base_consensus_genesis::{RollupConfig, SystemConfig};
 use base_protocol::{BlockInfo, L2BlockInfo, SingleBatch};
 
 use super::NextBatchProvider;
-use alloy_eips::BlockNumHash;
-use base_consensus_genesis::SystemConfig;
-
 use crate::{
     AttributesProvider, BatchQueue, BatchValidator, L2ChainProvider, OriginAdvancer,
     OriginProvider, PipelineError, PipelineResult, StageReset,
@@ -138,7 +136,11 @@ where
     P: NextBatchProvider + OriginAdvancer + OriginProvider + StageReset + Send + Debug,
     F: L2ChainProvider + Clone + Send + Debug,
 {
-    async fn reset(&mut self, l1_origin: BlockNumHash, system_config: SystemConfig) -> PipelineResult<()> {
+    async fn reset(
+        &mut self,
+        l1_origin: BlockNumHash,
+        system_config: SystemConfig,
+    ) -> PipelineResult<()> {
         self.attempt_update()?;
 
         if let Some(batch_validator) = self.batch_validator.as_mut() {
@@ -217,11 +219,9 @@ where
 mod tests {
     use alloc::{sync::Arc, vec};
 
-    use base_consensus_genesis::{HardForkConfig, RollupConfig};
-    use base_protocol::BlockInfo;
-
     use alloy_eips::BlockNumHash;
-    use base_consensus_genesis::SystemConfig;
+    use base_consensus_genesis::{HardForkConfig, RollupConfig, SystemConfig};
+    use base_protocol::BlockInfo;
 
     use super::BatchProvider;
     use crate::{

--- a/crates/consensus/derive/src/stages/batch/batch_provider.rs
+++ b/crates/consensus/derive/src/stages/batch/batch_provider.rs
@@ -8,9 +8,12 @@ use base_consensus_genesis::RollupConfig;
 use base_protocol::{BlockInfo, L2BlockInfo, SingleBatch};
 
 use super::NextBatchProvider;
+use alloy_eips::BlockNumHash;
+use base_consensus_genesis::SystemConfig;
+
 use crate::{
     AttributesProvider, BatchQueue, BatchValidator, L2ChainProvider, OriginAdvancer,
-    OriginProvider, PipelineError, PipelineResult, Signal, SignalReceiver,
+    OriginProvider, PipelineError, PipelineResult, StageReset,
 };
 
 /// The [`BatchProvider`] stage is a mux between the [`BatchQueue`] and [`BatchValidator`] stages.
@@ -24,7 +27,7 @@ use crate::{
 #[derive(Debug)]
 pub struct BatchProvider<P, F>
 where
-    P: NextBatchProvider + OriginAdvancer + OriginProvider + SignalReceiver + Debug,
+    P: NextBatchProvider + OriginAdvancer + OriginProvider + StageReset + Debug,
     F: L2ChainProvider + Clone + Debug,
 {
     /// The rollup configuration.
@@ -50,7 +53,7 @@ where
 
 impl<P, F> BatchProvider<P, F>
 where
-    P: NextBatchProvider + OriginAdvancer + OriginProvider + SignalReceiver + Debug,
+    P: NextBatchProvider + OriginAdvancer + OriginProvider + StageReset + Debug,
     F: L2ChainProvider + Clone + Debug,
 {
     /// Creates a new [`BatchProvider`] with the given configuration and previous stage.
@@ -95,7 +98,7 @@ where
 #[async_trait]
 impl<P, F> OriginAdvancer for BatchProvider<P, F>
 where
-    P: NextBatchProvider + OriginAdvancer + OriginProvider + SignalReceiver + Send + Debug,
+    P: NextBatchProvider + OriginAdvancer + OriginProvider + StageReset + Send + Debug,
     F: L2ChainProvider + Clone + Send + Debug,
 {
     async fn advance_origin(&mut self) -> PipelineResult<()> {
@@ -113,7 +116,7 @@ where
 
 impl<P, F> OriginProvider for BatchProvider<P, F>
 where
-    P: NextBatchProvider + OriginAdvancer + OriginProvider + SignalReceiver + Debug,
+    P: NextBatchProvider + OriginAdvancer + OriginProvider + StageReset + Debug,
     F: L2ChainProvider + Clone + Debug,
 {
     fn origin(&self) -> Option<BlockInfo> {
@@ -130,18 +133,54 @@ where
 }
 
 #[async_trait]
-impl<P, F> SignalReceiver for BatchProvider<P, F>
+impl<P, F> StageReset for BatchProvider<P, F>
 where
-    P: NextBatchProvider + OriginAdvancer + OriginProvider + SignalReceiver + Send + Debug,
+    P: NextBatchProvider + OriginAdvancer + OriginProvider + StageReset + Send + Debug,
     F: L2ChainProvider + Clone + Send + Debug,
 {
-    async fn signal(&mut self, signal: Signal) -> PipelineResult<()> {
+    async fn reset(&mut self, l1_origin: BlockNumHash, system_config: SystemConfig) -> PipelineResult<()> {
         self.attempt_update()?;
 
         if let Some(batch_validator) = self.batch_validator.as_mut() {
-            batch_validator.signal(signal).await
+            batch_validator.reset(l1_origin, system_config).await
         } else if let Some(batch_queue) = self.batch_queue.as_mut() {
-            batch_queue.signal(signal).await
+            batch_queue.reset(l1_origin, system_config).await
+        } else {
+            Err(PipelineError::NotEnoughData.temp())
+        }
+    }
+
+    async fn activate(&mut self) -> PipelineResult<()> {
+        self.attempt_update()?;
+
+        if let Some(batch_validator) = self.batch_validator.as_mut() {
+            batch_validator.activate().await
+        } else if let Some(batch_queue) = self.batch_queue.as_mut() {
+            batch_queue.activate().await
+        } else {
+            Err(PipelineError::NotEnoughData.temp())
+        }
+    }
+
+    async fn flush_channel(&mut self) -> PipelineResult<()> {
+        self.attempt_update()?;
+
+        if let Some(batch_validator) = self.batch_validator.as_mut() {
+            batch_validator.flush_channel().await
+        } else if let Some(batch_queue) = self.batch_queue.as_mut() {
+            batch_queue.flush_channel().await
+        } else {
+            Err(PipelineError::NotEnoughData.temp())
+        }
+    }
+
+    async fn provide_block(&mut self, block: BlockInfo) -> PipelineResult<()> {
+        self.attempt_update()?;
+
+        if let Some(batch_validator) = self.batch_validator.as_mut() {
+            batch_validator.provide_block(block).await
+        } else if let Some(batch_queue) = self.batch_queue.as_mut() {
+            batch_queue.provide_block(block).await
         } else {
             Err(PipelineError::NotEnoughData.temp())
         }
@@ -151,7 +190,7 @@ where
 #[async_trait]
 impl<P, F> AttributesProvider for BatchProvider<P, F>
 where
-    P: NextBatchProvider + OriginAdvancer + OriginProvider + SignalReceiver + Debug + Send,
+    P: NextBatchProvider + OriginAdvancer + OriginProvider + StageReset + Debug + Send,
     F: L2ChainProvider + Clone + Send + Debug,
 {
     fn is_last_in_span(&self) -> bool {
@@ -181,11 +220,14 @@ mod tests {
     use base_consensus_genesis::{HardForkConfig, RollupConfig};
     use base_protocol::BlockInfo;
 
+    use alloy_eips::BlockNumHash;
+    use base_consensus_genesis::SystemConfig;
+
     use super::BatchProvider;
     use crate::{
+        StageReset,
         test_utils::{TestL2ChainProvider, TestNextBatchProvider},
-        traits::{OriginProvider, SignalReceiver},
-        types::ResetSignal,
+        traits::OriginProvider,
     };
 
     #[test]
@@ -318,7 +360,7 @@ mod tests {
         let mut batch_provider = BatchProvider::new(cfg, provider, l2_provider);
 
         // Reset the batch provider.
-        batch_provider.signal(ResetSignal::default().signal()).await.unwrap();
+        batch_provider.reset(BlockNumHash::default(), SystemConfig::default()).await.unwrap();
 
         let Some(bq) = batch_provider.batch_queue else {
             panic!("Expected BatchQueue");
@@ -337,7 +379,7 @@ mod tests {
         let mut batch_provider = BatchProvider::new(cfg, provider, l2_provider);
 
         // Reset the batch provider.
-        batch_provider.signal(ResetSignal::default().signal()).await.unwrap();
+        batch_provider.reset(BlockNumHash::default(), SystemConfig::default()).await.unwrap();
 
         let Some(bv) = batch_provider.batch_validator else {
             panic!("Expected BatchValidator");

--- a/crates/consensus/derive/src/stages/batch/batch_queue.rs
+++ b/crates/consensus/derive/src/stages/batch/batch_queue.rs
@@ -10,10 +10,13 @@ use base_protocol::{
 };
 
 use super::NextBatchProvider;
+use alloy_eips::BlockNumHash;
+use base_consensus_genesis::SystemConfig;
+
 use crate::{
     errors::{PipelineEncodingError, PipelineError, PipelineErrorKind, ResetError},
-    traits::{AttributesProvider, L2ChainProvider, OriginAdvancer, OriginProvider, SignalReceiver},
-    types::{PipelineResult, ResetSignal, Signal},
+    traits::{AttributesProvider, L2ChainProvider, OriginAdvancer, OriginProvider, StageReset},
+    types::PipelineResult,
 };
 
 /// [`BatchQueue`] is responsible for ordering unordered batches
@@ -33,7 +36,7 @@ use crate::{
 #[derive(Debug)]
 pub struct BatchQueue<P, BF>
 where
-    P: NextBatchProvider + OriginAdvancer + OriginProvider + SignalReceiver + Debug,
+    P: NextBatchProvider + OriginAdvancer + OriginProvider + StageReset + Debug,
     BF: L2ChainProvider + Debug,
 {
     /// The rollup config.
@@ -61,7 +64,7 @@ where
 
 impl<P, BF> BatchQueue<P, BF>
 where
-    P: NextBatchProvider + OriginAdvancer + OriginProvider + SignalReceiver + Debug,
+    P: NextBatchProvider + OriginAdvancer + OriginProvider + StageReset + Debug,
     BF: L2ChainProvider + Debug,
 {
     /// Creates a new [`BatchQueue`] stage.
@@ -264,7 +267,7 @@ where
 #[async_trait]
 impl<P, BF> OriginAdvancer for BatchQueue<P, BF>
 where
-    P: NextBatchProvider + OriginAdvancer + OriginProvider + SignalReceiver + Send + Debug,
+    P: NextBatchProvider + OriginAdvancer + OriginProvider + StageReset + Send + Debug,
     BF: L2ChainProvider + Send + Debug,
 {
     async fn advance_origin(&mut self) -> PipelineResult<()> {
@@ -275,7 +278,7 @@ where
 #[async_trait]
 impl<P, BF> AttributesProvider for BatchQueue<P, BF>
 where
-    P: NextBatchProvider + OriginAdvancer + OriginProvider + SignalReceiver + Send + Debug,
+    P: NextBatchProvider + OriginAdvancer + OriginProvider + StageReset + Send + Debug,
     BF: L2ChainProvider + Send + Debug,
 {
     /// Returns the next valid batch upon the given safe head.
@@ -422,7 +425,7 @@ where
 
 impl<P, BF> OriginProvider for BatchQueue<P, BF>
 where
-    P: NextBatchProvider + OriginAdvancer + OriginProvider + SignalReceiver + Debug,
+    P: NextBatchProvider + OriginAdvancer + OriginProvider + StageReset + Debug,
     BF: L2ChainProvider + Debug,
 {
     fn origin(&self) -> Option<BlockInfo> {
@@ -431,34 +434,42 @@ where
 }
 
 #[async_trait]
-impl<P, BF> SignalReceiver for BatchQueue<P, BF>
+impl<P, BF> StageReset for BatchQueue<P, BF>
 where
-    P: NextBatchProvider + OriginAdvancer + OriginProvider + SignalReceiver + Send + Debug,
+    P: NextBatchProvider + OriginAdvancer + OriginProvider + StageReset + Send + Debug,
     BF: L2ChainProvider + Send + Debug,
 {
-    async fn signal(&mut self, signal: Signal) -> PipelineResult<()> {
-        match signal {
-            s @ Signal::Reset(ResetSignal { l1_origin, .. }) => {
-                self.prev.signal(s).await?;
-                self.origin = Some(l1_origin);
-                self.batches.clear();
-                // Include the new origin as an origin to build on.
-                // This is only for the initialization case.
-                // During normal resets we will later throw out this block.
-                self.l1_blocks.clear();
-                self.l1_blocks.push(l1_origin);
-                self.next_spans.clear();
-            }
-            s @ Signal::Activation(_) | s @ Signal::FlushChannel => {
-                self.prev.signal(s).await?;
-                self.batches.clear();
-                self.next_spans.clear();
-            }
-            s @ Signal::ProvideBlock(_) => {
-                self.prev.signal(s).await?;
-            }
+    async fn reset(&mut self, l1_origin: BlockNumHash, system_config: SystemConfig) -> PipelineResult<()> {
+        self.prev.reset(l1_origin, system_config).await?;
+        self.origin = self.prev.origin();
+        self.batches.clear();
+        // Include the new origin as an origin to build on.
+        // This is only for the initialization case.
+        // During normal resets we will later throw out this block.
+        self.l1_blocks.clear();
+        if let Some(origin) = self.origin {
+            self.l1_blocks.push(origin);
         }
+        self.next_spans.clear();
         Ok(())
+    }
+
+    async fn activate(&mut self) -> PipelineResult<()> {
+        self.prev.activate().await?;
+        self.batches.clear();
+        self.next_spans.clear();
+        Ok(())
+    }
+
+    async fn flush_channel(&mut self) -> PipelineResult<()> {
+        self.prev.flush_channel().await?;
+        self.batches.clear();
+        self.next_spans.clear();
+        Ok(())
+    }
+
+    async fn provide_block(&mut self, block: BlockInfo) -> PipelineResult<()> {
+        self.prev.provide_block(block).await
     }
 }
 
@@ -471,14 +482,15 @@ mod tests {
     use alloy_primitives::{Address, B256, Bytes, TxKind, U256, address, b256};
     use alloy_rlp::{BytesMut, Encodable};
     use base_alloy_consensus::{OpBlock, OpTxEnvelope, OpTxType, TxDeposit};
-    use base_consensus_genesis::{ChainGenesis, HardForkConfig, MAX_RLP_BYTES_PER_CHANNEL_FJORD};
+    use base_consensus_genesis::{ChainGenesis, HardForkConfig, MAX_RLP_BYTES_PER_CHANNEL_FJORD, SystemConfig};
     use base_protocol::{BatchReader, L1BlockInfoBedrock, L1BlockInfoTx};
     use tracing::Level;
     use tracing_subscriber::layer::SubscriberExt;
 
     use super::*;
-    use crate::test_utils::{
-        CollectingLayer, TestL2ChainProvider, TestNextBatchProvider, TraceStorage,
+    use crate::{
+        StageReset,
+        test_utils::{CollectingLayer, TestL2ChainProvider, TestNextBatchProvider, TraceStorage},
     };
 
     fn new_batch_reader() -> BatchReader {
@@ -517,7 +529,7 @@ mod tests {
             batch: Batch::Single(SingleBatch::default()),
         });
         assert!(!bq.prev.reset);
-        bq.signal(ResetSignal::default().signal()).await.unwrap();
+        bq.reset(BlockNumHash::default(), SystemConfig::default()).await.unwrap();
         assert!(bq.prev.reset);
         assert_eq!(bq.origin, Some(BlockInfo::default()));
         assert!(bq.batches.is_empty());
@@ -537,7 +549,7 @@ mod tests {
             inclusion_block: BlockInfo::default(),
             batch: Batch::Single(SingleBatch::default()),
         });
-        bq.signal(Signal::FlushChannel).await.unwrap();
+        bq.flush_channel().await.unwrap();
         assert!(bq.prev.flushed);
         assert!(bq.batches.is_empty());
         assert!(!bq.l1_blocks.is_empty());

--- a/crates/consensus/derive/src/stages/batch/batch_queue.rs
+++ b/crates/consensus/derive/src/stages/batch/batch_queue.rs
@@ -3,16 +3,14 @@
 use alloc::{boxed::Box, sync::Arc, vec::Vec};
 use core::fmt::Debug;
 
+use alloy_eips::BlockNumHash;
 use async_trait::async_trait;
-use base_consensus_genesis::RollupConfig;
+use base_consensus_genesis::{RollupConfig, SystemConfig};
 use base_protocol::{
     Batch, BatchValidity, BatchWithInclusionBlock, BlockInfo, L2BlockInfo, SingleBatch,
 };
 
 use super::NextBatchProvider;
-use alloy_eips::BlockNumHash;
-use base_consensus_genesis::SystemConfig;
-
 use crate::{
     errors::{PipelineEncodingError, PipelineError, PipelineErrorKind, ResetError},
     traits::{AttributesProvider, L2ChainProvider, OriginAdvancer, OriginProvider, StageReset},
@@ -439,7 +437,11 @@ where
     P: NextBatchProvider + OriginAdvancer + OriginProvider + StageReset + Send + Debug,
     BF: L2ChainProvider + Send + Debug,
 {
-    async fn reset(&mut self, l1_origin: BlockNumHash, system_config: SystemConfig) -> PipelineResult<()> {
+    async fn reset(
+        &mut self,
+        l1_origin: BlockNumHash,
+        system_config: SystemConfig,
+    ) -> PipelineResult<()> {
         self.prev.reset(l1_origin, system_config).await?;
         self.origin = self.prev.origin();
         self.batches.clear();
@@ -482,7 +484,9 @@ mod tests {
     use alloy_primitives::{Address, B256, Bytes, TxKind, U256, address, b256};
     use alloy_rlp::{BytesMut, Encodable};
     use base_alloy_consensus::{OpBlock, OpTxEnvelope, OpTxType, TxDeposit};
-    use base_consensus_genesis::{ChainGenesis, HardForkConfig, MAX_RLP_BYTES_PER_CHANNEL_FJORD, SystemConfig};
+    use base_consensus_genesis::{
+        ChainGenesis, HardForkConfig, MAX_RLP_BYTES_PER_CHANNEL_FJORD, SystemConfig,
+    };
     use base_protocol::{BatchReader, L1BlockInfoBedrock, L1BlockInfoTx};
     use tracing::Level;
     use tracing_subscriber::layer::SubscriberExt;

--- a/crates/consensus/derive/src/stages/batch/batch_stream.rs
+++ b/crates/consensus/derive/src/stages/batch/batch_stream.rs
@@ -10,9 +10,12 @@ use base_protocol::{
     SpanBatchError,
 };
 
+use alloy_eips::BlockNumHash;
+use base_consensus_genesis::SystemConfig;
+
 use crate::{
     L2ChainProvider, Metrics, NextBatchProvider, OriginAdvancer, OriginProvider, PipelineError,
-    PipelineResult, Signal, SignalReceiver,
+    PipelineResult, StageReset,
 };
 
 /// Provides [`Batch`]es for the [`BatchStream`] stage.
@@ -37,7 +40,7 @@ pub trait BatchStreamProvider {
 #[derive(Debug)]
 pub struct BatchStream<P, BF>
 where
-    P: BatchStreamProvider + OriginAdvancer + OriginProvider + SignalReceiver + Debug,
+    P: BatchStreamProvider + OriginAdvancer + OriginProvider + StageReset + Debug,
     BF: L2ChainProvider + Debug,
 {
     /// The previous stage in the derivation pipeline.
@@ -55,7 +58,7 @@ where
 
 impl<P, BF> BatchStream<P, BF>
 where
-    P: BatchStreamProvider + OriginAdvancer + OriginProvider + SignalReceiver + Debug,
+    P: BatchStreamProvider + OriginAdvancer + OriginProvider + StageReset + Debug,
     BF: L2ChainProvider + Debug,
 {
     /// Create a new [`BatchStream`] stage.
@@ -103,7 +106,7 @@ where
 #[async_trait]
 impl<P, BF> NextBatchProvider for BatchStream<P, BF>
 where
-    P: BatchStreamProvider + OriginAdvancer + OriginProvider + SignalReceiver + Send + Debug,
+    P: BatchStreamProvider + OriginAdvancer + OriginProvider + StageReset + Send + Debug,
     BF: L2ChainProvider + Send + Debug,
 {
     fn flush(&mut self) {
@@ -199,7 +202,7 @@ where
 #[async_trait]
 impl<P, BF> OriginAdvancer for BatchStream<P, BF>
 where
-    P: BatchStreamProvider + OriginAdvancer + OriginProvider + SignalReceiver + Send + Debug,
+    P: BatchStreamProvider + OriginAdvancer + OriginProvider + StageReset + Send + Debug,
     BF: L2ChainProvider + Send + Debug,
 {
     async fn advance_origin(&mut self) -> PipelineResult<()> {
@@ -209,7 +212,7 @@ where
 
 impl<P, BF> OriginProvider for BatchStream<P, BF>
 where
-    P: BatchStreamProvider + OriginAdvancer + OriginProvider + SignalReceiver + Debug,
+    P: BatchStreamProvider + OriginAdvancer + OriginProvider + StageReset + Debug,
     BF: L2ChainProvider + Debug,
 {
     fn origin(&self) -> Option<BlockInfo> {
@@ -218,15 +221,36 @@ where
 }
 
 #[async_trait]
-impl<P, BF> SignalReceiver for BatchStream<P, BF>
+impl<P, BF> StageReset for BatchStream<P, BF>
 where
-    P: BatchStreamProvider + OriginAdvancer + OriginProvider + SignalReceiver + Debug + Send,
+    P: BatchStreamProvider + OriginAdvancer + OriginProvider + StageReset + Debug + Send,
     BF: L2ChainProvider + Send + Debug,
 {
-    async fn signal(&mut self, signal: Signal) -> PipelineResult<()> {
-        self.prev.signal(signal).await?;
+    async fn reset(&mut self, l1_origin: BlockNumHash, system_config: SystemConfig) -> PipelineResult<()> {
+        self.prev.reset(l1_origin, system_config).await?;
         self.buffer.clear();
-        self.span.take();
+        self.span = None;
+        Ok(())
+    }
+
+    async fn activate(&mut self) -> PipelineResult<()> {
+        self.prev.activate().await?;
+        self.buffer.clear();
+        self.span = None;
+        Ok(())
+    }
+
+    async fn flush_channel(&mut self) -> PipelineResult<()> {
+        self.prev.flush_channel().await?;
+        self.buffer.clear();
+        self.span = None;
+        Ok(())
+    }
+
+    async fn provide_block(&mut self, block: BlockInfo) -> PipelineResult<()> {
+        self.prev.provide_block(block).await?;
+        self.buffer.clear();
+        self.span = None;
         Ok(())
     }
 }
@@ -239,14 +263,14 @@ mod tests {
     use alloy_eips::{BlockNumHash, NumHash};
     use alloy_primitives::{FixedBytes, b256};
     use base_alloy_consensus::OpBlock;
-    use base_consensus_genesis::{ChainGenesis, HardForkConfig};
+    use base_consensus_genesis::{ChainGenesis, HardForkConfig, SystemConfig};
     use base_protocol::{SingleBatch, SpanBatchElement};
     use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 
     use super::*;
     use crate::{
+        StageReset,
         test_utils::{CollectingLayer, TestBatchStreamProvider, TestL2ChainProvider, TraceStorage},
-        types::ResetSignal,
     };
 
     #[tokio::test]
@@ -278,7 +302,7 @@ mod tests {
         stream.buffer.push_back(SingleBatch::default());
         stream.span = Some(SpanBatch::default());
         assert!(!stream.prev.reset);
-        stream.signal(ResetSignal::default().signal()).await.unwrap();
+        stream.reset(BlockNumHash::default(), SystemConfig::default()).await.unwrap();
         assert!(stream.prev.reset);
         assert!(stream.buffer.is_empty());
         assert!(stream.span.is_none());
@@ -296,7 +320,7 @@ mod tests {
         stream.buffer.push_back(SingleBatch::default());
         stream.span = Some(SpanBatch::default());
         assert!(!stream.prev.flushed);
-        stream.signal(Signal::FlushChannel).await.unwrap();
+        stream.flush_channel().await.unwrap();
         assert!(stream.prev.flushed);
         assert!(stream.buffer.is_empty());
         assert!(stream.span.is_none());

--- a/crates/consensus/derive/src/stages/batch/batch_stream.rs
+++ b/crates/consensus/derive/src/stages/batch/batch_stream.rs
@@ -3,15 +3,13 @@
 use alloc::{boxed::Box, collections::VecDeque, string::ToString, sync::Arc};
 use core::fmt::Debug;
 
+use alloy_eips::BlockNumHash;
 use async_trait::async_trait;
-use base_consensus_genesis::RollupConfig;
+use base_consensus_genesis::{RollupConfig, SystemConfig};
 use base_protocol::{
     Batch, BatchValidity, BatchWithInclusionBlock, BlockInfo, L2BlockInfo, SingleBatch, SpanBatch,
     SpanBatchError,
 };
-
-use alloy_eips::BlockNumHash;
-use base_consensus_genesis::SystemConfig;
 
 use crate::{
     L2ChainProvider, Metrics, NextBatchProvider, OriginAdvancer, OriginProvider, PipelineError,
@@ -226,7 +224,11 @@ where
     P: BatchStreamProvider + OriginAdvancer + OriginProvider + StageReset + Debug + Send,
     BF: L2ChainProvider + Send + Debug,
 {
-    async fn reset(&mut self, l1_origin: BlockNumHash, system_config: SystemConfig) -> PipelineResult<()> {
+    async fn reset(
+        &mut self,
+        l1_origin: BlockNumHash,
+        system_config: SystemConfig,
+    ) -> PipelineResult<()> {
         self.prev.reset(l1_origin, system_config).await?;
         self.buffer.clear();
         self.span = None;

--- a/crates/consensus/derive/src/stages/batch/batch_validator.rs
+++ b/crates/consensus/derive/src/stages/batch/batch_validator.rs
@@ -8,11 +8,14 @@ use base_consensus_genesis::RollupConfig;
 use base_protocol::{Batch, BatchValidity, BlockInfo, L2BlockInfo, SingleBatch};
 
 use super::NextBatchProvider;
+use alloy_eips::BlockNumHash;
+use base_consensus_genesis::SystemConfig;
+
 use crate::{
     Metrics,
     errors::{PipelineError, PipelineErrorKind, ResetError},
-    traits::{AttributesProvider, OriginAdvancer, OriginProvider, SignalReceiver},
-    types::{PipelineResult, ResetSignal, Signal},
+    traits::{AttributesProvider, OriginAdvancer, OriginProvider, StageReset},
+    types::PipelineResult,
 };
 
 /// The [`BatchValidator`] stage is responsible for validating the [`SingleBatch`]es from
@@ -23,7 +26,7 @@ use crate::{
 #[derive(Debug)]
 pub struct BatchValidator<P>
 where
-    P: NextBatchProvider + OriginAdvancer + OriginProvider + SignalReceiver + Debug,
+    P: NextBatchProvider + OriginAdvancer + OriginProvider + StageReset + Debug,
 {
     /// The rollup configuration.
     pub cfg: Arc<RollupConfig>,
@@ -42,7 +45,7 @@ where
 
 impl<P> BatchValidator<P>
 where
-    P: NextBatchProvider + OriginAdvancer + OriginProvider + SignalReceiver + Debug,
+    P: NextBatchProvider + OriginAdvancer + OriginProvider + StageReset + Debug,
 {
     /// Create a new [`BatchValidator`] stage.
     pub const fn new(cfg: Arc<RollupConfig>, prev: P) -> Self {
@@ -188,7 +191,7 @@ where
 #[async_trait]
 impl<P> AttributesProvider for BatchValidator<P>
 where
-    P: NextBatchProvider + OriginAdvancer + OriginProvider + SignalReceiver + Send + Debug,
+    P: NextBatchProvider + OriginAdvancer + OriginProvider + StageReset + Send + Debug,
 {
     async fn next_batch(&mut self, parent: L2BlockInfo) -> PipelineResult<SingleBatch> {
         // Update the L1 origin blocks within the stage.
@@ -274,7 +277,7 @@ where
 
 impl<P> OriginProvider for BatchValidator<P>
 where
-    P: NextBatchProvider + OriginAdvancer + OriginProvider + SignalReceiver + Debug,
+    P: NextBatchProvider + OriginAdvancer + OriginProvider + StageReset + Debug,
 {
     fn origin(&self) -> Option<BlockInfo> {
         self.prev.origin()
@@ -284,7 +287,7 @@ where
 #[async_trait]
 impl<P> OriginAdvancer for BatchValidator<P>
 where
-    P: NextBatchProvider + OriginAdvancer + OriginProvider + SignalReceiver + Send + Debug,
+    P: NextBatchProvider + OriginAdvancer + OriginProvider + StageReset + Send + Debug,
 {
     async fn advance_origin(&mut self) -> PipelineResult<()> {
         self.prev.advance_origin().await
@@ -292,26 +295,33 @@ where
 }
 
 #[async_trait]
-impl<P> SignalReceiver for BatchValidator<P>
+impl<P> StageReset for BatchValidator<P>
 where
-    P: NextBatchProvider + OriginAdvancer + OriginProvider + SignalReceiver + Send + Debug,
+    P: NextBatchProvider + OriginAdvancer + OriginProvider + StageReset + Send + Debug,
 {
-    async fn signal(&mut self, signal: Signal) -> PipelineResult<()> {
-        match signal {
-            s @ Signal::Reset(ResetSignal { l1_origin, .. }) => {
-                self.prev.signal(s).await?;
-                self.origin = Some(l1_origin);
-                // Include the new origin as an origin to build on.
-                // This is only for the initialization case.
-                // During normal resets we will later throw out this block.
-                self.l1_blocks.clear();
-                self.l1_blocks.push(l1_origin);
-            }
-            s @ Signal::Activation(_) | s @ Signal::FlushChannel | s @ Signal::ProvideBlock(_) => {
-                self.prev.signal(s).await?;
-            }
+    async fn reset(&mut self, l1_origin: BlockNumHash, system_config: SystemConfig) -> PipelineResult<()> {
+        self.prev.reset(l1_origin, system_config).await?;
+        self.origin = self.prev.origin();
+        // Include the new origin as an origin to build on.
+        // This is only for the initialization case.
+        // During normal resets we will later throw out this block.
+        self.l1_blocks.clear();
+        if let Some(origin) = self.origin {
+            self.l1_blocks.push(origin);
         }
         Ok(())
+    }
+
+    async fn activate(&mut self) -> PipelineResult<()> {
+        self.prev.activate().await
+    }
+
+    async fn flush_channel(&mut self) -> PipelineResult<()> {
+        self.prev.flush_channel().await
+    }
+
+    async fn provide_block(&mut self, block: BlockInfo) -> PipelineResult<()> {
+        self.prev.provide_block(block).await
     }
 }
 
@@ -319,16 +329,16 @@ where
 mod tests {
     use alloc::{sync::Arc, vec, vec::Vec};
 
-    use alloy_eips::{BlockNumHash, NumHash};
+    use alloy_eips::BlockNumHash;
     use alloy_primitives::B256;
-    use base_consensus_genesis::{HardForkConfig, RollupConfig};
+    use base_consensus_genesis::{HardForkConfig, RollupConfig, SystemConfig};
     use base_protocol::{Batch, BlockInfo, L2BlockInfo, SingleBatch, SpanBatch};
     use tracing::Level;
     use tracing_subscriber::layer::SubscriberExt;
 
     use crate::{
         AttributesProvider, BatchValidator, NextBatchProvider, OriginAdvancer, PipelineError,
-        PipelineErrorKind, PipelineResult, ResetError, ResetSignal, Signal, SignalReceiver,
+        PipelineErrorKind, PipelineResult, ResetError, StageReset,
         test_utils::{CollectingLayer, TestNextBatchProvider, TraceStorage},
     };
 
@@ -354,18 +364,10 @@ mod tests {
         mock.origin = Some(BlockInfo::default());
         let mut bv = BatchValidator::new(cfg, mock);
 
-        // Reset the pipeline to add the L1 origin to the stage.
-        bv.signal(Signal::Reset(ResetSignal {
-            l1_origin: BlockInfo { number: 1, ..Default::default() },
-            l2_safe_head: L2BlockInfo::new(
-                BlockInfo::default(),
-                NumHash::new(1, Default::default()),
-                0,
-            ),
-            system_config: None,
-        }))
-        .await
-        .unwrap();
+        // Set up state as if the pipeline was reset with l1_origin = block #1.
+        bv.origin = Some(BlockInfo { number: 1, ..Default::default() });
+        bv.l1_blocks.clear();
+        bv.l1_blocks.push(BlockInfo { number: 1, ..Default::default() });
 
         let mock_parent = L2BlockInfo {
             l1_origin: BlockNumHash { number: 2, ..Default::default() },
@@ -383,18 +385,10 @@ mod tests {
         mock.origin = Some(BlockInfo { number: 2, ..Default::default() });
         let mut bv = BatchValidator::new(cfg, mock);
 
-        // Reset the pipeline to add the L1 origin to the stage.
-        bv.signal(Signal::Reset(ResetSignal {
-            l1_origin: BlockInfo { number: 1, ..Default::default() },
-            l2_safe_head: L2BlockInfo::new(
-                BlockInfo::default(),
-                NumHash::new(1, Default::default()),
-                0,
-            ),
-            system_config: None,
-        }))
-        .await
-        .unwrap();
+        // Set up state as if the pipeline was reset with l1_origin = block #1.
+        bv.origin = Some(BlockInfo { number: 1, ..Default::default() });
+        bv.l1_blocks.clear();
+        bv.l1_blocks.push(BlockInfo { number: 1, ..Default::default() });
 
         let mock_parent = L2BlockInfo {
             l1_origin: BlockNumHash { number: 1, ..Default::default() },
@@ -412,18 +406,10 @@ mod tests {
         mock.origin = Some(BlockInfo { number: 2, ..Default::default() });
         let mut bv = BatchValidator::new(cfg, mock);
 
-        // Reset the pipeline to add the L1 origin to the stage.
-        bv.signal(Signal::Reset(ResetSignal {
-            l1_origin: BlockInfo { number: 1, ..Default::default() },
-            l2_safe_head: L2BlockInfo::new(
-                BlockInfo::default(),
-                NumHash::new(1, Default::default()),
-                0,
-            ),
-            system_config: None,
-        }))
-        .await
-        .unwrap();
+        // Set up state as if the pipeline was reset with l1_origin = block #1.
+        bv.origin = Some(BlockInfo { number: 1, ..Default::default() });
+        bv.l1_blocks.clear();
+        bv.l1_blocks.push(BlockInfo { number: 1, ..Default::default() });
 
         let mock_parent = L2BlockInfo {
             l1_origin: BlockNumHash { number: 2, ..Default::default() },
@@ -533,12 +519,7 @@ mod tests {
         let mut bv = BatchValidator::new(cfg, mock);
 
         // Reset the pipeline to add the L1 origin to the stage.
-        bv.signal(Signal::Reset(ResetSignal {
-            l1_origin: BlockInfo { number: 1, ..Default::default() },
-            ..Default::default()
-        }))
-        .await
-        .unwrap();
+        bv.reset(BlockNumHash { number: 1, ..Default::default() }, SystemConfig::default()).await.unwrap();
         bv.l1_blocks.push(BlockInfo { number: 1, ..Default::default() });
 
         // Grab the next batch.
@@ -559,12 +540,7 @@ mod tests {
         let mut bv = BatchValidator::new(cfg, mock);
 
         // Reset the pipeline to add the L1 origin to the stage.
-        bv.signal(Signal::Reset(ResetSignal {
-            l1_origin: BlockInfo { number: 1, ..Default::default() },
-            ..Default::default()
-        }))
-        .await
-        .unwrap();
+        bv.reset(BlockNumHash { number: 1, ..Default::default() }, SystemConfig::default()).await.unwrap();
 
         // Advance the origin of the previous stage to block #6.
         for _ in 0..6 {
@@ -598,12 +574,7 @@ mod tests {
         let mut bv = BatchValidator::new(cfg, mock);
 
         // Reset the pipeline to add the L1 origin to the stage.
-        bv.signal(Signal::Reset(ResetSignal {
-            l1_origin: BlockInfo { number: 1, ..Default::default() },
-            ..Default::default()
-        }))
-        .await
-        .unwrap();
+        bv.reset(BlockNumHash { number: 1, ..Default::default() }, SystemConfig::default()).await.unwrap();
 
         // Advance the origin of the previous stage to block #6.
         for _ in 0..6 {

--- a/crates/consensus/derive/src/stages/batch/batch_validator.rs
+++ b/crates/consensus/derive/src/stages/batch/batch_validator.rs
@@ -3,14 +3,12 @@
 use alloc::{boxed::Box, sync::Arc, vec::Vec};
 use core::fmt::Debug;
 
+use alloy_eips::BlockNumHash;
 use async_trait::async_trait;
-use base_consensus_genesis::RollupConfig;
+use base_consensus_genesis::{RollupConfig, SystemConfig};
 use base_protocol::{Batch, BatchValidity, BlockInfo, L2BlockInfo, SingleBatch};
 
 use super::NextBatchProvider;
-use alloy_eips::BlockNumHash;
-use base_consensus_genesis::SystemConfig;
-
 use crate::{
     Metrics,
     errors::{PipelineError, PipelineErrorKind, ResetError},
@@ -299,7 +297,11 @@ impl<P> StageReset for BatchValidator<P>
 where
     P: NextBatchProvider + OriginAdvancer + OriginProvider + StageReset + Send + Debug,
 {
-    async fn reset(&mut self, l1_origin: BlockNumHash, system_config: SystemConfig) -> PipelineResult<()> {
+    async fn reset(
+        &mut self,
+        l1_origin: BlockNumHash,
+        system_config: SystemConfig,
+    ) -> PipelineResult<()> {
         self.prev.reset(l1_origin, system_config).await?;
         self.origin = self.prev.origin();
         // Include the new origin as an origin to build on.
@@ -519,7 +521,9 @@ mod tests {
         let mut bv = BatchValidator::new(cfg, mock);
 
         // Reset the pipeline to add the L1 origin to the stage.
-        bv.reset(BlockNumHash { number: 1, ..Default::default() }, SystemConfig::default()).await.unwrap();
+        bv.reset(BlockNumHash { number: 1, ..Default::default() }, SystemConfig::default())
+            .await
+            .unwrap();
         bv.l1_blocks.push(BlockInfo { number: 1, ..Default::default() });
 
         // Grab the next batch.
@@ -540,7 +544,9 @@ mod tests {
         let mut bv = BatchValidator::new(cfg, mock);
 
         // Reset the pipeline to add the L1 origin to the stage.
-        bv.reset(BlockNumHash { number: 1, ..Default::default() }, SystemConfig::default()).await.unwrap();
+        bv.reset(BlockNumHash { number: 1, ..Default::default() }, SystemConfig::default())
+            .await
+            .unwrap();
 
         // Advance the origin of the previous stage to block #6.
         for _ in 0..6 {
@@ -574,7 +580,9 @@ mod tests {
         let mut bv = BatchValidator::new(cfg, mock);
 
         // Reset the pipeline to add the L1 origin to the stage.
-        bv.reset(BlockNumHash { number: 1, ..Default::default() }, SystemConfig::default()).await.unwrap();
+        bv.reset(BlockNumHash { number: 1, ..Default::default() }, SystemConfig::default())
+            .await
+            .unwrap();
 
         // Advance the origin of the previous stage to block #6.
         for _ in 0..6 {

--- a/crates/consensus/derive/src/stages/channel/channel_assembler.rs
+++ b/crates/consensus/derive/src/stages/channel/channel_assembler.rs
@@ -14,8 +14,8 @@ use super::{ChannelReaderProvider, NextFrameProvider};
 use crate::{
     Metrics,
     errors::PipelineError,
-    traits::{OriginAdvancer, OriginProvider, SignalReceiver},
-    types::{PipelineResult, Signal},
+    traits::{OriginAdvancer, OriginProvider, StageReset},
+    types::PipelineResult,
 };
 
 /// The [`ChannelAssembler`] stage is responsible for assembling the [`Frame`]s from the
@@ -27,7 +27,7 @@ use crate::{
 #[derive(Debug)]
 pub struct ChannelAssembler<P>
 where
-    P: NextFrameProvider + OriginAdvancer + OriginProvider + SignalReceiver + Debug,
+    P: NextFrameProvider + OriginAdvancer + OriginProvider + StageReset + Debug,
 {
     /// The rollup configuration.
     pub cfg: Arc<RollupConfig>,
@@ -39,7 +39,7 @@ where
 
 impl<P> ChannelAssembler<P>
 where
-    P: NextFrameProvider + OriginAdvancer + OriginProvider + SignalReceiver + Debug,
+    P: NextFrameProvider + OriginAdvancer + OriginProvider + StageReset + Debug,
 {
     /// Creates a new [`ChannelAssembler`] stage with the given configuration and previous stage.
     pub const fn new(cfg: Arc<RollupConfig>, prev: P) -> Self {
@@ -64,7 +64,7 @@ where
 #[async_trait]
 impl<P> ChannelReaderProvider for ChannelAssembler<P>
 where
-    P: NextFrameProvider + OriginAdvancer + OriginProvider + SignalReceiver + Send + Debug,
+    P: NextFrameProvider + OriginAdvancer + OriginProvider + StageReset + Send + Debug,
 {
     async fn next_data(&mut self) -> PipelineResult<Option<Bytes>> {
         let origin = self.origin().ok_or(PipelineError::MissingOrigin.crit())?;
@@ -171,7 +171,7 @@ where
 #[async_trait]
 impl<P> OriginAdvancer for ChannelAssembler<P>
 where
-    P: NextFrameProvider + OriginAdvancer + OriginProvider + SignalReceiver + Send + Debug,
+    P: NextFrameProvider + OriginAdvancer + OriginProvider + StageReset + Send + Debug,
 {
     async fn advance_origin(&mut self) -> PipelineResult<()> {
         self.prev.advance_origin().await
@@ -180,7 +180,7 @@ where
 
 impl<P> OriginProvider for ChannelAssembler<P>
 where
-    P: NextFrameProvider + OriginAdvancer + OriginProvider + SignalReceiver + Debug,
+    P: NextFrameProvider + OriginAdvancer + OriginProvider + StageReset + Debug,
 {
     fn origin(&self) -> Option<BlockInfo> {
         self.prev.origin()
@@ -188,12 +188,34 @@ where
 }
 
 #[async_trait]
-impl<P> SignalReceiver for ChannelAssembler<P>
+impl<P> StageReset for ChannelAssembler<P>
 where
-    P: NextFrameProvider + OriginAdvancer + OriginProvider + SignalReceiver + Send + Debug,
+    P: NextFrameProvider + OriginAdvancer + OriginProvider + StageReset + Send + Debug,
 {
-    async fn signal(&mut self, signal: Signal) -> PipelineResult<()> {
-        self.prev.signal(signal).await?;
+    async fn reset(
+        &mut self,
+        l1_origin: alloy_eips::BlockNumHash,
+        system_config: base_consensus_genesis::SystemConfig,
+    ) -> PipelineResult<()> {
+        self.prev.reset(l1_origin, system_config).await?;
+        self.channel = None;
+        Ok(())
+    }
+
+    async fn activate(&mut self) -> PipelineResult<()> {
+        self.prev.activate().await?;
+        self.channel = None;
+        Ok(())
+    }
+
+    async fn flush_channel(&mut self) -> PipelineResult<()> {
+        self.prev.flush_channel().await?;
+        self.channel = None;
+        Ok(())
+    }
+
+    async fn provide_block(&mut self, block: BlockInfo) -> PipelineResult<()> {
+        self.prev.provide_block(block).await?;
         self.channel = None;
         Ok(())
     }

--- a/crates/consensus/derive/src/stages/channel/channel_bank.rs
+++ b/crates/consensus/derive/src/stages/channel/channel_bank.rs
@@ -10,7 +10,7 @@ use base_protocol::{BlockInfo, Channel, ChannelId, Frame};
 
 use crate::{
     ChannelReaderProvider, NextFrameProvider, OriginAdvancer, OriginProvider, PipelineError,
-    PipelineErrorKind, PipelineResult, Signal, SignalReceiver,
+    PipelineErrorKind, PipelineResult, StageReset,
 };
 
 /// The maximum size of a channel bank.
@@ -33,7 +33,7 @@ pub(crate) const FJORD_MAX_CHANNEL_BANK_SIZE: usize = 1_000_000_000;
 #[derive(Debug)]
 pub struct ChannelBank<P>
 where
-    P: NextFrameProvider + OriginAdvancer + OriginProvider + SignalReceiver + Debug,
+    P: NextFrameProvider + OriginAdvancer + OriginProvider + StageReset + Debug,
 {
     /// The rollup configuration.
     pub cfg: Arc<RollupConfig>,
@@ -47,7 +47,7 @@ where
 
 impl<P> ChannelBank<P>
 where
-    P: NextFrameProvider + OriginAdvancer + OriginProvider + SignalReceiver + Debug,
+    P: NextFrameProvider + OriginAdvancer + OriginProvider + StageReset + Debug,
 {
     /// Create a new [`ChannelBank`] stage.
     pub fn new(cfg: Arc<RollupConfig>, prev: P) -> Self {
@@ -182,7 +182,7 @@ where
 #[async_trait]
 impl<P> OriginAdvancer for ChannelBank<P>
 where
-    P: NextFrameProvider + OriginAdvancer + OriginProvider + SignalReceiver + Send + Debug,
+    P: NextFrameProvider + OriginAdvancer + OriginProvider + StageReset + Send + Debug,
 {
     async fn advance_origin(&mut self) -> PipelineResult<()> {
         self.prev.advance_origin().await
@@ -192,7 +192,7 @@ where
 #[async_trait]
 impl<P> ChannelReaderProvider for ChannelBank<P>
 where
-    P: NextFrameProvider + OriginAdvancer + OriginProvider + SignalReceiver + Send + Debug,
+    P: NextFrameProvider + OriginAdvancer + OriginProvider + StageReset + Send + Debug,
 {
     async fn next_data(&mut self) -> PipelineResult<Option<Bytes>> {
         match self.read() {
@@ -219,7 +219,7 @@ where
 
 impl<P> OriginProvider for ChannelBank<P>
 where
-    P: NextFrameProvider + OriginAdvancer + OriginProvider + SignalReceiver + Debug,
+    P: NextFrameProvider + OriginAdvancer + OriginProvider + StageReset + Debug,
 {
     fn origin(&self) -> Option<BlockInfo> {
         self.prev.origin()
@@ -227,14 +227,12 @@ where
 }
 
 #[async_trait]
-impl<P> SignalReceiver for ChannelBank<P>
+impl<P> StageReset for ChannelBank<P>
 where
-    P: NextFrameProvider + OriginAdvancer + OriginProvider + SignalReceiver + Send + Debug,
+    P: NextFrameProvider + OriginAdvancer + OriginProvider + StageReset + Send + Debug,
 {
-    /// Handle a pipeline signal.
-    ///
-    /// `Reset`, `Activation`, and `FlushChannel` clear the channel bank because they represent
-    /// a discontinuity in the L1 data stream (reorg, hardfork boundary, or explicit flush).
+    /// Reset clears all buffered channel state. This represents a discontinuity in the L1 data
+    /// stream (reorg, hardfork boundary, or explicit flush).
     ///
     /// `ProvideBlock` is intentionally **not** cleared here, diverging from kona's upstream
     /// `ChannelBank` which clears unconditionally on all signals. Channels can span multiple
@@ -242,18 +240,33 @@ where
     /// channels before their frames have all arrived, breaking channel timeout detection.
     /// This matches op-node's `channel_bank.go`, where only `Reset()` discards channel state
     /// and normal L1 block advancement leaves channels intact.
-    async fn signal(&mut self, signal: Signal) -> PipelineResult<()> {
-        match signal {
-            Signal::Reset(_) | Signal::Activation(_) | Signal::FlushChannel => {
-                self.prev.signal(signal).await?;
-                self.channels.clear();
-                self.channel_queue = VecDeque::with_capacity(10);
-            }
-            Signal::ProvideBlock(_) => {
-                self.prev.signal(signal).await?;
-            }
-        }
+    async fn reset(
+        &mut self,
+        l1_origin: alloy_eips::BlockNumHash,
+        system_config: base_consensus_genesis::SystemConfig,
+    ) -> PipelineResult<()> {
+        self.prev.reset(l1_origin, system_config).await?;
+        self.channels.clear();
+        self.channel_queue = VecDeque::with_capacity(10);
         Ok(())
+    }
+
+    async fn activate(&mut self) -> PipelineResult<()> {
+        self.prev.activate().await?;
+        self.channels.clear();
+        self.channel_queue = VecDeque::with_capacity(10);
+        Ok(())
+    }
+
+    async fn flush_channel(&mut self) -> PipelineResult<()> {
+        self.prev.flush_channel().await?;
+        self.channels.clear();
+        self.channel_queue = VecDeque::with_capacity(10);
+        Ok(())
+    }
+
+    async fn provide_block(&mut self, block: BlockInfo) -> PipelineResult<()> {
+        self.prev.provide_block(block).await
     }
 }
 
@@ -266,10 +279,10 @@ mod tests {
     use tracing_subscriber::layer::SubscriberExt;
 
     use super::*;
-    use crate::{
-        test_utils::{CollectingLayer, TestNextFrameProvider, TraceStorage},
-        types::{ActivationSignal, ResetSignal},
-    };
+    use alloy_eips::BlockNumHash;
+    use base_consensus_genesis::SystemConfig;
+
+    use crate::test_utils::{CollectingLayer, TestNextFrameProvider, TraceStorage};
 
     #[test]
     fn test_try_read_channel_at_index_missing_channel() {
@@ -432,7 +445,7 @@ mod tests {
         channel_bank.channels.insert([0xFF; 16], Channel::default());
         channel_bank.channel_queue.push_back([0xFF; 16]);
         assert!(!channel_bank.prev.reset);
-        channel_bank.signal(ResetSignal::default().signal()).await.unwrap();
+        channel_bank.reset(BlockNumHash::default(), SystemConfig::default()).await.unwrap();
         assert_eq!(channel_bank.channels.len(), 0);
         assert_eq!(channel_bank.channel_queue.len(), 0);
         assert!(channel_bank.prev.reset);
@@ -448,7 +461,7 @@ mod tests {
         channel_bank.channels.insert([0xFF; 16], Channel::default());
         channel_bank.channel_queue.push_back([0xFF; 16]);
         assert!(!channel_bank.prev.reset);
-        channel_bank.signal(ActivationSignal::default().signal()).await.unwrap();
+        channel_bank.activate().await.unwrap();
         assert_eq!(channel_bank.channels.len(), 0, "Activation must clear channels");
         assert_eq!(channel_bank.channel_queue.len(), 0, "Activation must clear channel queue");
         assert!(channel_bank.prev.reset, "Activation must propagate to prev stage");
@@ -464,7 +477,7 @@ mod tests {
         channel_bank.channels.insert([0xFF; 16], Channel::default());
         channel_bank.channel_queue.push_back([0xFF; 16]);
         assert!(!channel_bank.prev.reset);
-        channel_bank.signal(Signal::FlushChannel).await.unwrap();
+        channel_bank.flush_channel().await.unwrap();
         assert_eq!(channel_bank.channels.len(), 0, "FlushChannel must clear channels");
         assert_eq!(channel_bank.channel_queue.len(), 0, "FlushChannel must clear channel queue");
         assert!(channel_bank.prev.reset, "FlushChannel must propagate to prev stage");
@@ -483,7 +496,7 @@ mod tests {
         channel_bank.channels.insert([0xFF; 16], Channel::default());
         channel_bank.channel_queue.push_back([0xFF; 16]);
         assert!(!channel_bank.prev.reset);
-        channel_bank.signal(Signal::ProvideBlock(BlockInfo::default())).await.unwrap();
+        channel_bank.provide_block(BlockInfo::default()).await.unwrap();
         assert_eq!(channel_bank.channels.len(), 1, "ProvideBlock must not clear channels");
         assert_eq!(
             channel_bank.channel_queue.len(),
@@ -504,7 +517,7 @@ mod tests {
         channel_bank.channel_queue.push_back([0xAA; 16]);
         for i in 0u64..5 {
             channel_bank
-                .signal(Signal::ProvideBlock(BlockInfo { number: i, ..Default::default() }))
+                .provide_block(BlockInfo { number: i, ..Default::default() })
                 .await
                 .unwrap();
             assert_eq!(channel_bank.channels.len(), 1, "channels must survive ProvideBlock #{i}");
@@ -528,13 +541,13 @@ mod tests {
         // Advance a few L1 blocks — channels must survive.
         for i in 0u64..3 {
             channel_bank
-                .signal(Signal::ProvideBlock(BlockInfo { number: i, ..Default::default() }))
+                .provide_block(BlockInfo { number: i, ..Default::default() })
                 .await
                 .unwrap();
         }
         assert_eq!(channel_bank.channels.len(), 1, "channels must survive ProvideBlock signals");
         // A Reset (e.g. reorg) must now clear everything.
-        channel_bank.signal(ResetSignal::default().signal()).await.unwrap();
+        channel_bank.reset(BlockNumHash::default(), SystemConfig::default()).await.unwrap();
         assert_eq!(channel_bank.channels.len(), 0, "Reset must clear channels after ProvideBlock");
         assert_eq!(
             channel_bank.channel_queue.len(),

--- a/crates/consensus/derive/src/stages/channel/channel_bank.rs
+++ b/crates/consensus/derive/src/stages/channel/channel_bank.rs
@@ -274,14 +274,12 @@ where
 mod tests {
     use alloc::{vec, vec::Vec};
 
-    use base_consensus_genesis::HardForkConfig;
+    use alloy_eips::BlockNumHash;
+    use base_consensus_genesis::{HardForkConfig, SystemConfig};
     use tracing::Level;
     use tracing_subscriber::layer::SubscriberExt;
 
     use super::*;
-    use alloy_eips::BlockNumHash;
-    use base_consensus_genesis::SystemConfig;
-
     use crate::test_utils::{CollectingLayer, TestNextFrameProvider, TraceStorage};
 
     #[test]

--- a/crates/consensus/derive/src/stages/channel/channel_provider.rs
+++ b/crates/consensus/derive/src/stages/channel/channel_provider.rs
@@ -3,16 +3,17 @@
 use alloc::{boxed::Box, sync::Arc};
 use core::fmt::Debug;
 
+use alloy_eips::BlockNumHash;
 use alloy_primitives::Bytes;
 use async_trait::async_trait;
-use base_consensus_genesis::RollupConfig;
+use base_consensus_genesis::{RollupConfig, SystemConfig};
 use base_protocol::BlockInfo;
 
 use super::{ChannelAssembler, ChannelBank, ChannelReaderProvider, NextFrameProvider};
 use crate::{
     errors::PipelineError,
-    traits::{OriginAdvancer, OriginProvider, SignalReceiver},
-    types::{PipelineResult, Signal},
+    traits::{OriginAdvancer, OriginProvider, StageReset},
+    types::PipelineResult,
 };
 
 /// The [`ChannelProvider`] stage is a mux between the [`ChannelBank`] and [`ChannelAssembler`]
@@ -24,7 +25,7 @@ use crate::{
 #[derive(Debug)]
 pub struct ChannelProvider<P>
 where
-    P: NextFrameProvider + OriginAdvancer + OriginProvider + SignalReceiver + Debug,
+    P: NextFrameProvider + OriginAdvancer + OriginProvider + StageReset + Debug,
 {
     /// The rollup configuration.
     pub cfg: Arc<RollupConfig>,
@@ -47,7 +48,7 @@ where
 
 impl<P> ChannelProvider<P>
 where
-    P: NextFrameProvider + OriginAdvancer + OriginProvider + SignalReceiver + Debug,
+    P: NextFrameProvider + OriginAdvancer + OriginProvider + StageReset + Debug,
 {
     /// Creates a new [`ChannelProvider`] with the given configuration and previous stage.
     pub const fn new(cfg: Arc<RollupConfig>, prev: P) -> Self {
@@ -88,7 +89,7 @@ where
 #[async_trait]
 impl<P> OriginAdvancer for ChannelProvider<P>
 where
-    P: NextFrameProvider + OriginAdvancer + OriginProvider + SignalReceiver + Send + Debug,
+    P: NextFrameProvider + OriginAdvancer + OriginProvider + StageReset + Send + Debug,
 {
     async fn advance_origin(&mut self) -> PipelineResult<()> {
         self.attempt_update()?;
@@ -105,7 +106,7 @@ where
 
 impl<P> OriginProvider for ChannelProvider<P>
 where
-    P: NextFrameProvider + OriginAdvancer + OriginProvider + SignalReceiver + Debug,
+    P: NextFrameProvider + OriginAdvancer + OriginProvider + StageReset + Debug,
 {
     fn origin(&self) -> Option<BlockInfo> {
         self.channel_assembler.as_ref().map_or_else(
@@ -121,17 +122,53 @@ where
 }
 
 #[async_trait]
-impl<P> SignalReceiver for ChannelProvider<P>
+impl<P> StageReset for ChannelProvider<P>
 where
-    P: NextFrameProvider + OriginAdvancer + OriginProvider + SignalReceiver + Send + Debug,
+    P: NextFrameProvider + OriginAdvancer + OriginProvider + StageReset + Send + Debug,
 {
-    async fn signal(&mut self, signal: Signal) -> PipelineResult<()> {
+    async fn reset(&mut self, l1_origin: BlockNumHash, system_config: SystemConfig) -> PipelineResult<()> {
         self.attempt_update()?;
 
         if let Some(channel_assembler) = self.channel_assembler.as_mut() {
-            channel_assembler.signal(signal).await
+            channel_assembler.reset(l1_origin, system_config).await
         } else if let Some(channel_bank) = self.channel_bank.as_mut() {
-            channel_bank.signal(signal).await
+            channel_bank.reset(l1_origin, system_config).await
+        } else {
+            Err(PipelineError::NotEnoughData.temp())
+        }
+    }
+
+    async fn activate(&mut self) -> PipelineResult<()> {
+        self.attempt_update()?;
+
+        if let Some(channel_assembler) = self.channel_assembler.as_mut() {
+            channel_assembler.activate().await
+        } else if let Some(channel_bank) = self.channel_bank.as_mut() {
+            channel_bank.activate().await
+        } else {
+            Err(PipelineError::NotEnoughData.temp())
+        }
+    }
+
+    async fn flush_channel(&mut self) -> PipelineResult<()> {
+        self.attempt_update()?;
+
+        if let Some(channel_assembler) = self.channel_assembler.as_mut() {
+            channel_assembler.flush_channel().await
+        } else if let Some(channel_bank) = self.channel_bank.as_mut() {
+            channel_bank.flush_channel().await
+        } else {
+            Err(PipelineError::NotEnoughData.temp())
+        }
+    }
+
+    async fn provide_block(&mut self, block: BlockInfo) -> PipelineResult<()> {
+        self.attempt_update()?;
+
+        if let Some(channel_assembler) = self.channel_assembler.as_mut() {
+            channel_assembler.provide_block(block).await
+        } else if let Some(channel_bank) = self.channel_bank.as_mut() {
+            channel_bank.provide_block(block).await
         } else {
             Err(PipelineError::NotEnoughData.temp())
         }
@@ -141,7 +178,7 @@ where
 #[async_trait]
 impl<P> ChannelReaderProvider for ChannelProvider<P>
 where
-    P: NextFrameProvider + OriginAdvancer + OriginProvider + SignalReceiver + Send + Debug,
+    P: NextFrameProvider + OriginAdvancer + OriginProvider + StageReset + Send + Debug,
 {
     async fn next_data(&mut self) -> PipelineResult<Option<Bytes>> {
         self.attempt_update()?;
@@ -163,9 +200,12 @@ mod tests {
     use base_consensus_genesis::{HardForkConfig, RollupConfig};
     use base_protocol::BlockInfo;
 
+    use alloy_eips::BlockNumHash;
+    use base_consensus_genesis::SystemConfig;
+
     use crate::{
-        ChannelProvider, ChannelReaderProvider, OriginProvider, PipelineError, ResetSignal,
-        SignalReceiver, test_utils::TestNextFrameProvider,
+        ChannelProvider, ChannelReaderProvider, OriginProvider, PipelineError, StageReset,
+        test_utils::TestNextFrameProvider,
     };
 
     #[test]
@@ -324,7 +364,7 @@ mod tests {
         assert!(channel_bank.channel_queue.len() == 1);
 
         // Reset the channel provider.
-        channel_provider.signal(ResetSignal::default().signal()).await.unwrap();
+        channel_provider.reset(BlockNumHash::default(), SystemConfig::default()).await.unwrap();
 
         // Ensure the channel queue is empty after reset.
         let Some(channel_bank) = channel_provider.channel_bank.as_mut() else {
@@ -358,7 +398,7 @@ mod tests {
         assert!(channel_assembler.channel.is_some());
 
         // Reset the channel provider.
-        channel_provider.signal(ResetSignal::default().signal()).await.unwrap();
+        channel_provider.reset(BlockNumHash::default(), SystemConfig::default()).await.unwrap();
 
         // Ensure the channel assembler is empty after reset.
         let Some(channel_assembler) = channel_provider.channel_assembler.as_mut() else {

--- a/crates/consensus/derive/src/stages/channel/channel_provider.rs
+++ b/crates/consensus/derive/src/stages/channel/channel_provider.rs
@@ -126,7 +126,11 @@ impl<P> StageReset for ChannelProvider<P>
 where
     P: NextFrameProvider + OriginAdvancer + OriginProvider + StageReset + Send + Debug,
 {
-    async fn reset(&mut self, l1_origin: BlockNumHash, system_config: SystemConfig) -> PipelineResult<()> {
+    async fn reset(
+        &mut self,
+        l1_origin: BlockNumHash,
+        system_config: SystemConfig,
+    ) -> PipelineResult<()> {
         self.attempt_update()?;
 
         if let Some(channel_assembler) = self.channel_assembler.as_mut() {
@@ -197,11 +201,9 @@ where
 mod tests {
     use alloc::{sync::Arc, vec};
 
-    use base_consensus_genesis::{HardForkConfig, RollupConfig};
-    use base_protocol::BlockInfo;
-
     use alloy_eips::BlockNumHash;
-    use base_consensus_genesis::SystemConfig;
+    use base_consensus_genesis::{HardForkConfig, RollupConfig, SystemConfig};
+    use base_protocol::BlockInfo;
 
     use crate::{
         ChannelProvider, ChannelReaderProvider, OriginProvider, PipelineError, StageReset,

--- a/crates/consensus/derive/src/stages/channel/channel_reader.rs
+++ b/crates/consensus/derive/src/stages/channel/channel_reader.rs
@@ -168,7 +168,11 @@ impl<P> StageReset for ChannelReader<P>
 where
     P: ChannelReaderProvider + OriginAdvancer + OriginProvider + StageReset + Debug + Send,
 {
-    async fn reset(&mut self, l1_origin: BlockNumHash, system_config: SystemConfig) -> PipelineResult<()> {
+    async fn reset(
+        &mut self,
+        l1_origin: BlockNumHash,
+        system_config: SystemConfig,
+    ) -> PipelineResult<()> {
         self.prev.reset(l1_origin, system_config).await?;
         self.next_channel();
         Ok(())
@@ -199,10 +203,8 @@ where
 mod tests {
     use alloc::vec;
 
-    use base_consensus_genesis::HardForkConfig;
-
     use alloy_eips::BlockNumHash;
-    use base_consensus_genesis::SystemConfig;
+    use base_consensus_genesis::{HardForkConfig, SystemConfig};
 
     use super::*;
     use crate::{errors::PipelineErrorKind, test_utils::TestChannelReaderProvider};

--- a/crates/consensus/derive/src/stages/channel/channel_reader.rs
+++ b/crates/consensus/derive/src/stages/channel/channel_reader.rs
@@ -3,17 +3,18 @@
 use alloc::{boxed::Box, string::ToString, sync::Arc};
 use core::fmt::Debug;
 
+use alloy_eips::BlockNumHash;
 use alloy_primitives::Bytes;
 use async_trait::async_trait;
 use base_consensus_genesis::{
-    MAX_RLP_BYTES_PER_CHANNEL_BEDROCK, MAX_RLP_BYTES_PER_CHANNEL_FJORD, RollupConfig,
+    MAX_RLP_BYTES_PER_CHANNEL_BEDROCK, MAX_RLP_BYTES_PER_CHANNEL_FJORD, RollupConfig, SystemConfig,
 };
 use base_protocol::{Batch, BatchReader, BlockInfo};
 use tracing::{debug, warn};
 
 use crate::{
     BatchStreamProvider, Metrics, OriginAdvancer, OriginProvider, PipelineError, PipelineResult,
-    Signal, SignalReceiver,
+    StageReset,
 };
 
 /// The [`ChannelReader`] provider trait.
@@ -38,7 +39,7 @@ pub trait ChannelReaderProvider {
 #[derive(Debug)]
 pub struct ChannelReader<P>
 where
-    P: ChannelReaderProvider + OriginAdvancer + OriginProvider + SignalReceiver + Debug,
+    P: ChannelReaderProvider + OriginAdvancer + OriginProvider + StageReset + Debug,
 {
     /// The previous stage of the derivation pipeline.
     pub prev: P,
@@ -50,7 +51,7 @@ where
 
 impl<P> ChannelReader<P>
 where
-    P: ChannelReaderProvider + OriginAdvancer + OriginProvider + SignalReceiver + Debug,
+    P: ChannelReaderProvider + OriginAdvancer + OriginProvider + StageReset + Debug,
 {
     /// Create a new [`ChannelReader`] stage.
     pub const fn new(prev: P, cfg: Arc<RollupConfig>) -> Self {
@@ -88,7 +89,7 @@ where
 #[async_trait]
 impl<P> OriginAdvancer for ChannelReader<P>
 where
-    P: ChannelReaderProvider + OriginAdvancer + OriginProvider + SignalReceiver + Send + Debug,
+    P: ChannelReaderProvider + OriginAdvancer + OriginProvider + StageReset + Send + Debug,
 {
     async fn advance_origin(&mut self) -> PipelineResult<()> {
         self.prev.advance_origin().await
@@ -98,7 +99,7 @@ where
 #[async_trait]
 impl<P> BatchStreamProvider for ChannelReader<P>
 where
-    P: ChannelReaderProvider + OriginAdvancer + OriginProvider + SignalReceiver + Send + Debug,
+    P: ChannelReaderProvider + OriginAdvancer + OriginProvider + StageReset + Send + Debug,
 {
     /// This method is called by the `BatchStream` if an invalid span batch is found.
     /// In the case of an invalid span batch, the associated channel must be flushed.
@@ -155,7 +156,7 @@ where
 
 impl<P> OriginProvider for ChannelReader<P>
 where
-    P: ChannelReaderProvider + OriginAdvancer + OriginProvider + SignalReceiver + Debug,
+    P: ChannelReaderProvider + OriginAdvancer + OriginProvider + StageReset + Debug,
 {
     fn origin(&self) -> Option<BlockInfo> {
         self.prev.origin()
@@ -163,23 +164,33 @@ where
 }
 
 #[async_trait]
-impl<P> SignalReceiver for ChannelReader<P>
+impl<P> StageReset for ChannelReader<P>
 where
-    P: ChannelReaderProvider + OriginAdvancer + OriginProvider + SignalReceiver + Debug + Send,
+    P: ChannelReaderProvider + OriginAdvancer + OriginProvider + StageReset + Debug + Send,
 {
-    async fn signal(&mut self, signal: Signal) -> PipelineResult<()> {
-        match signal {
-            Signal::FlushChannel => {
-                // Drop the current in-progress channel.
-                warn!(target: "channel_reader", "Flushed channel");
-                self.next_batch = None;
-                Metrics::pipeline_batch_reader_set().set(0);
-            }
-            s => {
-                self.prev.signal(s).await?;
-                self.next_channel();
-            }
-        }
+    async fn reset(&mut self, l1_origin: BlockNumHash, system_config: SystemConfig) -> PipelineResult<()> {
+        self.prev.reset(l1_origin, system_config).await?;
+        self.next_channel();
+        Ok(())
+    }
+
+    async fn activate(&mut self) -> PipelineResult<()> {
+        self.prev.activate().await?;
+        self.next_channel();
+        Ok(())
+    }
+
+    async fn flush_channel(&mut self) -> PipelineResult<()> {
+        // Drop the current in-progress channel. Does NOT propagate to prev.
+        warn!(target: "channel_reader", "Flushed channel");
+        self.next_batch = None;
+        Metrics::pipeline_batch_reader_set().set(0);
+        Ok(())
+    }
+
+    async fn provide_block(&mut self, block: BlockInfo) -> PipelineResult<()> {
+        self.prev.provide_block(block).await?;
+        self.next_channel();
         Ok(())
     }
 }
@@ -190,10 +201,11 @@ mod tests {
 
     use base_consensus_genesis::HardForkConfig;
 
+    use alloy_eips::BlockNumHash;
+    use base_consensus_genesis::SystemConfig;
+
     use super::*;
-    use crate::{
-        errors::PipelineErrorKind, test_utils::TestChannelReaderProvider, types::ResetSignal,
-    };
+    use crate::{errors::PipelineErrorKind, test_utils::TestChannelReaderProvider};
 
     fn new_compressed_batch_data() -> Bytes {
         let file_contents =
@@ -211,7 +223,7 @@ mod tests {
             new_compressed_batch_data(),
             MAX_RLP_BYTES_PER_CHANNEL_FJORD as usize,
         ));
-        reader.signal(Signal::FlushChannel).await.unwrap();
+        reader.flush_channel().await.unwrap();
         assert!(reader.next_batch.is_none());
     }
 
@@ -224,7 +236,7 @@ mod tests {
             MAX_RLP_BYTES_PER_CHANNEL_FJORD as usize,
         ));
         assert!(!reader.prev.reset);
-        reader.signal(ResetSignal::default().signal()).await.unwrap();
+        reader.reset(BlockNumHash::default(), SystemConfig::default()).await.unwrap();
         assert!(reader.next_batch.is_none());
         assert!(reader.prev.reset);
     }

--- a/crates/consensus/derive/src/stages/frame_queue.rs
+++ b/crates/consensus/derive/src/stages/frame_queue.rs
@@ -221,10 +221,8 @@ where
 pub(crate) mod tests {
     use alloc::vec;
 
-    use base_consensus_genesis::HardForkConfig;
-
     use alloy_eips::BlockNumHash;
-    use base_consensus_genesis::SystemConfig;
+    use base_consensus_genesis::{HardForkConfig, SystemConfig};
 
     use super::*;
     use crate::test_utils::TestFrameQueueProvider;

--- a/crates/consensus/derive/src/stages/frame_queue.rs
+++ b/crates/consensus/derive/src/stages/frame_queue.rs
@@ -10,7 +10,7 @@ use base_protocol::{BlockInfo, Frame};
 
 use crate::{
     Metrics, NextFrameProvider, OriginAdvancer, OriginProvider, PipelineError, PipelineResult,
-    Signal, SignalReceiver,
+    StageReset,
 };
 
 /// Provides data frames for the [`FrameQueue`] stage.
@@ -32,7 +32,7 @@ pub trait FrameQueueProvider {
 #[derive(Debug)]
 pub struct FrameQueue<P>
 where
-    P: FrameQueueProvider + OriginAdvancer + OriginProvider + SignalReceiver + Debug,
+    P: FrameQueueProvider + OriginAdvancer + OriginProvider + StageReset + Debug,
 {
     /// The previous stage in the pipeline.
     pub prev: P,
@@ -44,7 +44,7 @@ where
 
 impl<P> FrameQueue<P>
 where
-    P: FrameQueueProvider + OriginAdvancer + OriginProvider + SignalReceiver + Debug,
+    P: FrameQueueProvider + OriginAdvancer + OriginProvider + StageReset + Debug,
 {
     /// Create a new [`FrameQueue`] stage with the given previous [`L1Retrieval`] stage.
     ///
@@ -149,7 +149,7 @@ where
 #[async_trait]
 impl<P> OriginAdvancer for FrameQueue<P>
 where
-    P: FrameQueueProvider + OriginAdvancer + OriginProvider + SignalReceiver + Send + Debug,
+    P: FrameQueueProvider + OriginAdvancer + OriginProvider + StageReset + Send + Debug,
 {
     async fn advance_origin(&mut self) -> PipelineResult<()> {
         self.prev.advance_origin().await
@@ -159,7 +159,7 @@ where
 #[async_trait]
 impl<P> NextFrameProvider for FrameQueue<P>
 where
-    P: FrameQueueProvider + OriginAdvancer + OriginProvider + SignalReceiver + Send + Debug,
+    P: FrameQueueProvider + OriginAdvancer + OriginProvider + StageReset + Send + Debug,
 {
     async fn next_frame(&mut self) -> PipelineResult<Frame> {
         self.load_frames().await?;
@@ -176,7 +176,7 @@ where
 
 impl<P> OriginProvider for FrameQueue<P>
 where
-    P: FrameQueueProvider + OriginAdvancer + OriginProvider + SignalReceiver + Debug,
+    P: FrameQueueProvider + OriginAdvancer + OriginProvider + StageReset + Debug,
 {
     fn origin(&self) -> Option<BlockInfo> {
         self.prev.origin()
@@ -184,12 +184,34 @@ where
 }
 
 #[async_trait]
-impl<P> SignalReceiver for FrameQueue<P>
+impl<P> StageReset for FrameQueue<P>
 where
-    P: FrameQueueProvider + OriginAdvancer + OriginProvider + SignalReceiver + Send + Debug,
+    P: FrameQueueProvider + OriginAdvancer + OriginProvider + StageReset + Send + Debug,
 {
-    async fn signal(&mut self, signal: Signal) -> PipelineResult<()> {
-        self.prev.signal(signal).await?;
+    async fn reset(
+        &mut self,
+        l1_origin: alloy_eips::BlockNumHash,
+        system_config: base_consensus_genesis::SystemConfig,
+    ) -> PipelineResult<()> {
+        self.prev.reset(l1_origin, system_config).await?;
+        self.queue = VecDeque::default();
+        Ok(())
+    }
+
+    async fn activate(&mut self) -> PipelineResult<()> {
+        self.prev.activate().await?;
+        self.queue = VecDeque::default();
+        Ok(())
+    }
+
+    async fn flush_channel(&mut self) -> PipelineResult<()> {
+        self.prev.flush_channel().await?;
+        self.queue = VecDeque::default();
+        Ok(())
+    }
+
+    async fn provide_block(&mut self, block: BlockInfo) -> PipelineResult<()> {
+        self.prev.provide_block(block).await?;
         self.queue = VecDeque::default();
         Ok(())
     }
@@ -201,15 +223,18 @@ pub(crate) mod tests {
 
     use base_consensus_genesis::HardForkConfig;
 
+    use alloy_eips::BlockNumHash;
+    use base_consensus_genesis::SystemConfig;
+
     use super::*;
-    use crate::{test_utils::TestFrameQueueProvider, types::ResetSignal};
+    use crate::test_utils::TestFrameQueueProvider;
 
     #[tokio::test]
     async fn test_frame_queue_reset() {
         let mock = TestFrameQueueProvider::new(vec![]);
         let mut frame_queue = FrameQueue::new(mock, Default::default());
         assert!(!frame_queue.prev.reset);
-        frame_queue.signal(ResetSignal::default().signal()).await.unwrap();
+        frame_queue.reset(BlockNumHash::default(), SystemConfig::default()).await.unwrap();
         assert_eq!(frame_queue.queue.len(), 0);
         assert!(frame_queue.prev.reset);
     }

--- a/crates/consensus/derive/src/stages/l1_retrieval.rs
+++ b/crates/consensus/derive/src/stages/l1_retrieval.rs
@@ -2,13 +2,15 @@
 
 use alloc::boxed::Box;
 
+use alloy_eips::BlockNumHash;
 use alloy_primitives::Address;
 use async_trait::async_trait;
+use base_consensus_genesis::SystemConfig;
 use base_protocol::BlockInfo;
 
 use crate::{
-    ActivationSignal, DataAvailabilityProvider, FrameQueueProvider, OriginAdvancer, OriginProvider,
-    PipelineError, PipelineErrorKind, PipelineResult, ResetSignal, Signal, SignalReceiver,
+    DataAvailabilityProvider, FrameQueueProvider, OriginAdvancer, OriginProvider, PipelineError,
+    PipelineErrorKind, PipelineResult, StageReset,
 };
 
 /// Provides L1 blocks for the [`L1Retrieval`] stage.
@@ -38,7 +40,7 @@ pub trait L1RetrievalProvider {
 pub struct L1Retrieval<DAP, P>
 where
     DAP: DataAvailabilityProvider,
-    P: L1RetrievalProvider + OriginAdvancer + OriginProvider + SignalReceiver,
+    P: L1RetrievalProvider + OriginAdvancer + OriginProvider + StageReset,
 {
     /// The previous stage in the pipeline.
     pub prev: P,
@@ -51,7 +53,7 @@ where
 impl<DAP, P> L1Retrieval<DAP, P>
 where
     DAP: DataAvailabilityProvider,
-    P: L1RetrievalProvider + OriginAdvancer + OriginProvider + SignalReceiver,
+    P: L1RetrievalProvider + OriginAdvancer + OriginProvider + StageReset,
 {
     /// Creates a new [`L1Retrieval`] stage with the previous [`PollingTraversal`] stage and given
     /// [`DataAvailabilityProvider`].
@@ -66,7 +68,7 @@ where
 impl<DAP, P> OriginAdvancer for L1Retrieval<DAP, P>
 where
     DAP: DataAvailabilityProvider + Send,
-    P: L1RetrievalProvider + OriginAdvancer + OriginProvider + SignalReceiver + Send,
+    P: L1RetrievalProvider + OriginAdvancer + OriginProvider + StageReset + Send,
 {
     async fn advance_origin(&mut self) -> PipelineResult<()> {
         self.prev.advance_origin().await
@@ -77,7 +79,7 @@ where
 impl<DAP, P> FrameQueueProvider for L1Retrieval<DAP, P>
 where
     DAP: DataAvailabilityProvider + Send,
-    P: L1RetrievalProvider + OriginAdvancer + OriginProvider + SignalReceiver + Send,
+    P: L1RetrievalProvider + OriginAdvancer + OriginProvider + StageReset + Send,
 {
     type Item = DAP::Item;
 
@@ -109,7 +111,7 @@ where
 impl<DAP, P> OriginProvider for L1Retrieval<DAP, P>
 where
     DAP: DataAvailabilityProvider,
-    P: L1RetrievalProvider + OriginAdvancer + OriginProvider + SignalReceiver,
+    P: L1RetrievalProvider + OriginAdvancer + OriginProvider + StageReset,
 {
     fn origin(&self) -> Option<BlockInfo> {
         self.prev.origin()
@@ -117,22 +119,35 @@ where
 }
 
 #[async_trait]
-impl<DAP, P> SignalReceiver for L1Retrieval<DAP, P>
+impl<DAP, P> StageReset for L1Retrieval<DAP, P>
 where
     DAP: DataAvailabilityProvider + Send,
-    P: L1RetrievalProvider + OriginAdvancer + OriginProvider + SignalReceiver + Send,
+    P: L1RetrievalProvider + OriginAdvancer + OriginProvider + StageReset + Send,
 {
-    async fn signal(&mut self, signal: Signal) -> PipelineResult<()> {
-        self.prev.signal(signal).await?;
-        match signal {
-            Signal::Reset(ResetSignal { l1_origin, .. })
-            | Signal::Activation(ActivationSignal { l1_origin, .. }) => {
-                self.provider.clear();
-                self.next = Some(l1_origin);
-            }
-            _ => {}
-        }
+    async fn reset(
+        &mut self,
+        l1_origin: BlockNumHash,
+        system_config: SystemConfig,
+    ) -> PipelineResult<()> {
+        self.prev.reset(l1_origin, system_config).await?;
+        self.provider.clear();
+        self.next = self.prev.origin();
         Ok(())
+    }
+
+    async fn activate(&mut self) -> PipelineResult<()> {
+        self.prev.activate().await?;
+        self.provider.clear();
+        self.next = self.prev.origin();
+        Ok(())
+    }
+
+    async fn flush_channel(&mut self) -> PipelineResult<()> {
+        self.prev.flush_channel().await
+    }
+
+    async fn provide_block(&mut self, block: BlockInfo) -> PipelineResult<()> {
+        self.prev.provide_block(block).await
     }
 }
 
@@ -140,7 +155,9 @@ where
 mod tests {
     use alloc::vec;
 
+    use alloy_eips::BlockNumHash;
     use alloy_primitives::Bytes;
+    use base_consensus_genesis::SystemConfig;
 
     use super::*;
     use crate::test_utils::{TestDAP, TraversalTestHelper};
@@ -153,7 +170,7 @@ mod tests {
         retrieval.prev.block = None;
         assert!(retrieval.prev.block.is_none());
         retrieval.next = None;
-        retrieval.signal(Signal::FlushChannel).await.unwrap();
+        retrieval.flush_channel().await.unwrap();
         assert!(retrieval.next.is_none());
         assert!(retrieval.prev.block.is_none());
     }
@@ -166,15 +183,10 @@ mod tests {
         retrieval.prev.block = None;
         assert!(retrieval.prev.block.is_none());
         retrieval.next = None;
-        retrieval
-            .signal(
-                ActivationSignal { system_config: Some(Default::default()), ..Default::default() }
-                    .signal(),
-            )
-            .await
-            .unwrap();
-        assert!(retrieval.next.is_some());
-        assert_eq!(retrieval.prev.block, Some(BlockInfo::default()));
+        retrieval.activate().await.unwrap();
+        // activate() is a no-op for traversal, but L1Retrieval sets self.next from prev.origin()
+        assert!(retrieval.next.is_none());
+        assert!(retrieval.prev.block.is_none());
         // Provider must be cleared on activation to flush stale data.
         assert!(retrieval.provider.results.is_empty());
     }
@@ -187,26 +199,32 @@ mod tests {
         retrieval.prev.block = None;
         assert!(retrieval.prev.block.is_none());
         retrieval.next = None;
-        retrieval
-            .signal(
-                ResetSignal { system_config: Some(Default::default()), ..Default::default() }
-                    .signal(),
-            )
-            .await
-            .unwrap();
+        retrieval.reset(BlockNumHash::default(), SystemConfig::default()).await.unwrap();
         assert!(retrieval.next.is_some());
         assert_eq!(retrieval.prev.block, Some(BlockInfo::default()));
         // Provider must be cleared on reset to flush stale data.
         assert!(retrieval.provider.results.is_empty());
     }
 
-    async fn test_l1_retrieval_clears_stale_data(signal: Signal) {
+    async fn test_l1_retrieval_clears_stale_data_reset() {
         let traversal = TraversalTestHelper::new_populated();
-        // Pre-load a stale entry that should never be served after activation or reset.
+        // Pre-load a stale entry that should never be served after reset.
         let dap = TestDAP { results: vec![Ok(Bytes::from_static(b"stale"))] };
         let mut retrieval = L1Retrieval::new(traversal, dap);
         retrieval.next = Some(BlockInfo::default());
-        retrieval.signal(signal).await.unwrap();
+        retrieval.reset(BlockNumHash::default(), SystemConfig::default()).await.unwrap();
+        // next_data must not return the stale bytes; the cleared provider yields EOF.
+        let err = retrieval.next_data().await.unwrap_err();
+        assert_eq!(err, PipelineError::Eof.temp());
+    }
+
+    async fn test_l1_retrieval_clears_stale_data_activate() {
+        let traversal = TraversalTestHelper::new_populated();
+        // Pre-load a stale entry that should never be served after activation.
+        let dap = TestDAP { results: vec![Ok(Bytes::from_static(b"stale"))] };
+        let mut retrieval = L1Retrieval::new(traversal, dap);
+        retrieval.next = Some(BlockInfo::default());
+        retrieval.activate().await.unwrap();
         // next_data must not return the stale bytes; the cleared provider yields EOF.
         let err = retrieval.next_data().await.unwrap_err();
         assert_eq!(err, PipelineError::Eof.temp());
@@ -215,18 +233,13 @@ mod tests {
     /// Regression test: stale DAP data loaded before a reset must not be returned after the reset.
     #[tokio::test]
     async fn test_l1_retrieval_reset_clears_stale_data() {
-        let reset_signal =
-            ResetSignal { system_config: Some(Default::default()), ..Default::default() }.signal();
-        test_l1_retrieval_clears_stale_data(reset_signal).await;
+        test_l1_retrieval_clears_stale_data_reset().await;
     }
 
     /// Regression test: stale DAP data loaded before an activation must not be returned after it.
     #[tokio::test]
     async fn test_l1_retrieval_activation_clears_stale_data() {
-        let activation_signal =
-            ActivationSignal { system_config: Some(Default::default()), ..Default::default() }
-                .signal();
-        test_l1_retrieval_clears_stale_data(activation_signal).await;
+        test_l1_retrieval_clears_stale_data_activate().await;
     }
 
     #[tokio::test]

--- a/crates/consensus/derive/src/stages/traversal/indexed.rs
+++ b/crates/consensus/derive/src/stages/traversal/indexed.rs
@@ -132,11 +132,8 @@ impl<F: ChainProvider + Send> StageReset for IndexedTraversal<F> {
         l1_origin: BlockNumHash,
         system_config: SystemConfig,
     ) -> PipelineResult<()> {
-        let block = self
-            .data_source
-            .block_info_by_number(l1_origin.number)
-            .await
-            .map_err(Into::into)?;
+        let block =
+            self.data_source.block_info_by_number(l1_origin.number).await.map_err(Into::into)?;
         self.update_origin(block);
         self.system_config = system_config;
         Ok(())
@@ -448,7 +445,7 @@ mod tests {
         assert_eq!(traversal.system_config.batcher_address, new_batcher);
     }
 
-    /// After a reset, batcher_address is restored to the system config provided.
+    /// After a reset, `batcher_address` is restored to the system config provided.
     #[tokio::test]
     async fn test_reorg_signal_restores_batcher_address() {
         let addr_a = address!("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");

--- a/crates/consensus/derive/src/stages/traversal/indexed.rs
+++ b/crates/consensus/derive/src/stages/traversal/indexed.rs
@@ -2,14 +2,15 @@
 
 use alloc::{boxed::Box, sync::Arc};
 
+use alloy_eips::BlockNumHash;
 use alloy_primitives::Address;
 use async_trait::async_trait;
 use base_consensus_genesis::{RollupConfig, SystemConfig};
 use base_protocol::BlockInfo;
 
 use crate::{
-    ActivationSignal, ChainProvider, L1RetrievalProvider, Metrics, OriginAdvancer, OriginProvider,
-    PipelineError, PipelineResult, ResetError, ResetSignal, Signal, SignalReceiver,
+    ChainProvider, L1RetrievalProvider, Metrics, OriginAdvancer, OriginProvider, PipelineError,
+    PipelineResult, ResetError, StageReset,
 };
 
 /// The [`IndexedTraversal`] stage of the derivation pipeline.
@@ -125,19 +126,34 @@ impl<F: ChainProvider> OriginProvider for IndexedTraversal<F> {
 }
 
 #[async_trait]
-impl<F: ChainProvider + Send> SignalReceiver for IndexedTraversal<F> {
-    async fn signal(&mut self, signal: Signal) -> PipelineResult<()> {
-        match signal {
-            Signal::Reset(ResetSignal { l1_origin, system_config, .. })
-            | Signal::Activation(ActivationSignal { l1_origin, system_config, .. }) => {
-                self.update_origin(l1_origin);
-                self.system_config = system_config.expect("System config must be provided.");
-            }
-            Signal::ProvideBlock(block_info) => self.provide_next_block(block_info).await?,
-            _ => {}
-        }
-
+impl<F: ChainProvider + Send> StageReset for IndexedTraversal<F> {
+    async fn reset(
+        &mut self,
+        l1_origin: BlockNumHash,
+        system_config: SystemConfig,
+    ) -> PipelineResult<()> {
+        let block = self
+            .data_source
+            .block_info_by_number(l1_origin.number)
+            .await
+            .map_err(Into::into)?;
+        self.update_origin(block);
+        self.system_config = system_config;
         Ok(())
+    }
+
+    async fn activate(&mut self) -> PipelineResult<()> {
+        // Activation is a no-op for the traversal stage: the L1 origin and system config
+        // are preserved as-is; only higher stages need to clear their buffers.
+        Ok(())
+    }
+
+    async fn flush_channel(&mut self) -> PipelineResult<()> {
+        Ok(())
+    }
+
+    async fn provide_block(&mut self, block_info: BlockInfo) -> PipelineResult<()> {
+        self.provide_next_block(block_info).await
     }
 }
 
@@ -146,6 +162,7 @@ mod tests {
     use alloc::vec;
 
     use alloy_consensus::Receipt;
+    use alloy_eips::BlockNumHash;
     use alloy_primitives::{B256, Bytes, Log, LogData, U256, address, b256};
     use base_consensus_genesis::{CONFIG_UPDATE_EVENT_VERSION_0, CONFIG_UPDATE_TOPIC};
 
@@ -226,18 +243,11 @@ mod tests {
         let mut traversal = new_test_managed(blocks, receipts);
         let cfg = SystemConfig::default();
         traversal.done = true;
-        assert!(
-            traversal
-                .signal(Signal::Activation(ActivationSignal {
-                    system_config: Some(cfg),
-                    ..Default::default()
-                }))
-                .await
-                .is_ok()
-        );
+        assert!(traversal.activate().await.is_ok());
+        // activate() is a no-op — origin and done flag remain unchanged.
         assert_eq!(traversal.origin(), Some(BlockInfo::default()));
         assert_eq!(traversal.system_config, cfg);
-        assert!(!traversal.done);
+        assert!(traversal.done);
     }
 
     #[tokio::test]
@@ -247,15 +257,7 @@ mod tests {
         let mut traversal = new_test_managed(blocks, receipts);
         let cfg = SystemConfig::default();
         traversal.done = true;
-        assert!(
-            traversal
-                .signal(Signal::Reset(ResetSignal {
-                    system_config: Some(cfg),
-                    ..Default::default()
-                }))
-                .await
-                .is_ok()
-        );
+        assert!(traversal.reset(BlockNumHash::default(), cfg).await.is_ok());
         assert_eq!(traversal.origin(), Some(BlockInfo::default()));
         assert_eq!(traversal.system_config, cfg);
         assert!(!traversal.done);
@@ -446,9 +448,7 @@ mod tests {
         assert_eq!(traversal.system_config.batcher_address, new_batcher);
     }
 
-    /// After a `ConfigUpdate` log changes `batcher_address` from A → B, sending a
-    /// `Signal::Reset` with a `SystemConfig` containing address A restores the
-    /// batcher address back to A. This models L1 reorg rollback behavior.
+    /// After a reset, batcher_address is restored to the system config provided.
     #[tokio::test]
     async fn test_reorg_signal_restores_batcher_address() {
         let addr_a = address!("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
@@ -472,11 +472,9 @@ mod tests {
         let addr_b = address!("000000000000000000000000000000000000bEEF");
         assert_eq!(traversal.batcher_addr(), addr_b);
 
-        // Simulate L1 reorg: send a Reset signal with a SystemConfig that has ADDR_A.
+        // Simulate L1 reorg: reset with a SystemConfig that has ADDR_A.
         let reset_config = SystemConfig { batcher_address: addr_a, ..SystemConfig::default() };
-        let signal =
-            Signal::Reset(ResetSignal { system_config: Some(reset_config), ..Default::default() });
-        assert!(traversal.signal(signal).await.is_ok());
+        assert!(traversal.reset(BlockNumHash::default(), reset_config).await.is_ok());
 
         // After reset, batcher_addr() must be restored to ADDR_A.
         assert_eq!(traversal.batcher_addr(), addr_a);

--- a/crates/consensus/derive/src/stages/traversal/polling.rs
+++ b/crates/consensus/derive/src/stages/traversal/polling.rs
@@ -2,14 +2,15 @@
 
 use alloc::{boxed::Box, sync::Arc};
 
+use alloy_eips::BlockNumHash;
 use alloy_primitives::Address;
 use async_trait::async_trait;
 use base_consensus_genesis::{RollupConfig, SystemConfig};
 use base_protocol::BlockInfo;
 
 use crate::{
-    ActivationSignal, ChainProvider, L1RetrievalProvider, Metrics, OriginAdvancer, OriginProvider,
-    PipelineError, PipelineResult, ResetError, ResetSignal, Signal, SignalReceiver,
+    ChainProvider, L1RetrievalProvider, Metrics, OriginAdvancer, OriginProvider, PipelineError,
+    PipelineResult, ResetError, StageReset,
 };
 
 /// The [`PollingTraversal`] stage of the derivation pipeline.
@@ -131,23 +132,35 @@ impl<F: ChainProvider> OriginProvider for PollingTraversal<F> {
 }
 
 #[async_trait]
-impl<F: ChainProvider + Send> SignalReceiver for PollingTraversal<F> {
-    async fn signal(&mut self, signal: Signal) -> PipelineResult<()> {
-        match signal {
-            Signal::Reset(ResetSignal { l1_origin, system_config, .. })
-            | Signal::Activation(ActivationSignal { l1_origin, system_config, .. }) => {
-                self.update_origin(l1_origin);
-                self.system_config = system_config.expect("System config must be provided.");
-            }
-            Signal::ProvideBlock(_) => {
-                /* Not supported in this stage. */
-                warn!(target: "traversal", "ProvideBlock signal not supported in PollingTraversal stage.");
-                return Err(PipelineError::UnsupportedSignal.temp());
-            }
-            _ => {}
-        }
-
+impl<F: ChainProvider + Send> StageReset for PollingTraversal<F> {
+    async fn reset(
+        &mut self,
+        l1_origin: BlockNumHash,
+        system_config: SystemConfig,
+    ) -> PipelineResult<()> {
+        let block = self
+            .data_source
+            .block_info_by_number(l1_origin.number)
+            .await
+            .map_err(Into::into)?;
+        self.update_origin(block);
+        self.system_config = system_config;
         Ok(())
+    }
+
+    async fn activate(&mut self) -> PipelineResult<()> {
+        // Activation is a no-op for the traversal stage: the L1 origin and system config
+        // are preserved as-is; only higher stages need to clear their buffers.
+        Ok(())
+    }
+
+    async fn flush_channel(&mut self) -> PipelineResult<()> {
+        Ok(())
+    }
+
+    async fn provide_block(&mut self, _block: BlockInfo) -> PipelineResult<()> {
+        warn!(target: "traversal", "ProvideBlock signal not supported in PollingTraversal stage.");
+        Err(PipelineError::UnsupportedSignal.temp())
     }
 }
 
@@ -155,6 +168,7 @@ impl<F: ChainProvider + Send> SignalReceiver for PollingTraversal<F> {
 pub(crate) mod tests {
     use alloc::vec;
 
+    use alloy_eips::BlockNumHash;
     use alloy_primitives::{address, b256};
 
     use super::*;
@@ -174,7 +188,7 @@ pub(crate) mod tests {
         let mut traversal = TraversalTestHelper::new_from_blocks(blocks, receipts);
         assert!(traversal.advance_origin().await.is_ok());
         traversal.done = true;
-        assert!(traversal.signal(Signal::FlushChannel).await.is_ok());
+        assert!(traversal.flush_channel().await.is_ok());
         assert_eq!(traversal.origin(), Some(BlockInfo::default()));
         assert!(traversal.done);
     }
@@ -187,17 +201,11 @@ pub(crate) mod tests {
         assert!(traversal.advance_origin().await.is_ok());
         let cfg = SystemConfig::default();
         traversal.done = true;
-        assert!(
-            traversal
-                .signal(
-                    ActivationSignal { system_config: Some(cfg), ..Default::default() }.signal()
-                )
-                .await
-                .is_ok()
-        );
+        assert!(traversal.activate().await.is_ok());
+        // activate() is a no-op — origin and done flag remain unchanged.
         assert_eq!(traversal.origin(), Some(BlockInfo::default()));
         assert_eq!(traversal.system_config, cfg);
-        assert!(!traversal.done);
+        assert!(traversal.done);
     }
 
     #[tokio::test]
@@ -209,10 +217,7 @@ pub(crate) mod tests {
         let cfg = SystemConfig::default();
         traversal.done = true;
         assert!(
-            traversal
-                .signal(ResetSignal { system_config: Some(cfg), ..Default::default() }.signal())
-                .await
-                .is_ok()
+            traversal.reset(BlockNumHash::default(), cfg).await.is_ok()
         );
         assert_eq!(traversal.origin(), Some(BlockInfo::default()));
         assert_eq!(traversal.system_config, cfg);

--- a/crates/consensus/derive/src/stages/traversal/polling.rs
+++ b/crates/consensus/derive/src/stages/traversal/polling.rs
@@ -196,7 +196,7 @@ pub(crate) mod tests {
         let receipts = TraversalTestHelper::new_receipts();
         let mut traversal = TraversalTestHelper::new_from_blocks(blocks, receipts);
         assert!(traversal.advance_origin().await.is_ok());
-        let cfg = SystemConfig::default();
+        let cfg = traversal.system_config;
         traversal.done = true;
         assert!(traversal.activate().await.is_ok());
         // activate() is a no-op — origin and done flag remain unchanged.

--- a/crates/consensus/derive/src/stages/traversal/polling.rs
+++ b/crates/consensus/derive/src/stages/traversal/polling.rs
@@ -138,11 +138,8 @@ impl<F: ChainProvider + Send> StageReset for PollingTraversal<F> {
         l1_origin: BlockNumHash,
         system_config: SystemConfig,
     ) -> PipelineResult<()> {
-        let block = self
-            .data_source
-            .block_info_by_number(l1_origin.number)
-            .await
-            .map_err(Into::into)?;
+        let block =
+            self.data_source.block_info_by_number(l1_origin.number).await.map_err(Into::into)?;
         self.update_origin(block);
         self.system_config = system_config;
         Ok(())
@@ -216,9 +213,7 @@ pub(crate) mod tests {
         assert!(traversal.advance_origin().await.is_ok());
         let cfg = SystemConfig::default();
         traversal.done = true;
-        assert!(
-            traversal.reset(BlockNumHash::default(), cfg).await.is_ok()
-        );
+        assert!(traversal.reset(BlockNumHash::default(), cfg).await.is_ok());
         assert_eq!(traversal.origin(), Some(BlockInfo::default()));
         assert_eq!(traversal.system_config, cfg);
         assert!(!traversal.done);

--- a/crates/consensus/derive/src/test_utils/attributes_queue.rs
+++ b/crates/consensus/derive/src/test_utils/attributes_queue.rs
@@ -10,9 +10,7 @@ use base_protocol::{BlockInfo, L2BlockInfo, SingleBatch};
 
 use crate::{
     errors::{PipelineError, PipelineErrorKind},
-    traits::{
-        AttributesBuilder, AttributesProvider, OriginAdvancer, OriginProvider, StageReset,
-    },
+    traits::{AttributesBuilder, AttributesProvider, OriginAdvancer, OriginProvider, StageReset},
     types::PipelineResult,
 };
 

--- a/crates/consensus/derive/src/test_utils/attributes_queue.rs
+++ b/crates/consensus/derive/src/test_utils/attributes_queue.rs
@@ -5,14 +5,15 @@ use alloc::{boxed::Box, vec::Vec};
 use alloy_eips::BlockNumHash;
 use async_trait::async_trait;
 use base_alloy_rpc_types_engine::OpPayloadAttributes;
+use base_consensus_genesis::SystemConfig;
 use base_protocol::{BlockInfo, L2BlockInfo, SingleBatch};
 
 use crate::{
     errors::{PipelineError, PipelineErrorKind},
     traits::{
-        AttributesBuilder, AttributesProvider, OriginAdvancer, OriginProvider, SignalReceiver,
+        AttributesBuilder, AttributesProvider, OriginAdvancer, OriginProvider, StageReset,
     },
-    types::{PipelineResult, Signal},
+    types::PipelineResult,
 };
 
 /// A mock implementation of the [`AttributesBuilder`] for testing.
@@ -67,13 +68,22 @@ impl OriginAdvancer for TestAttributesProvider {
 }
 
 #[async_trait]
-impl SignalReceiver for TestAttributesProvider {
-    async fn signal(&mut self, signal: Signal) -> PipelineResult<()> {
-        match signal {
-            Signal::FlushChannel => self.flushed = true,
-            Signal::Reset { .. } => self.reset = true,
-            _ => {}
-        }
+impl StageReset for TestAttributesProvider {
+    async fn reset(&mut self, _: BlockNumHash, _: SystemConfig) -> PipelineResult<()> {
+        self.reset = true;
+        Ok(())
+    }
+
+    async fn activate(&mut self) -> PipelineResult<()> {
+        Ok(())
+    }
+
+    async fn flush_channel(&mut self) -> PipelineResult<()> {
+        self.flushed = true;
+        Ok(())
+    }
+
+    async fn provide_block(&mut self, _: BlockInfo) -> PipelineResult<()> {
         Ok(())
     }
 }

--- a/crates/consensus/derive/src/test_utils/batch_provider.rs
+++ b/crates/consensus/derive/src/test_utils/batch_provider.rs
@@ -5,11 +5,14 @@ use alloc::{boxed::Box, vec::Vec};
 use async_trait::async_trait;
 use base_protocol::{Batch, BlockInfo, L2BlockInfo};
 
+use alloy_eips::BlockNumHash;
+use base_consensus_genesis::SystemConfig;
+
 use crate::{
     errors::PipelineError,
     stages::NextBatchProvider,
-    traits::{OriginAdvancer, OriginProvider, SignalReceiver},
-    types::{PipelineResult, Signal},
+    traits::{OriginAdvancer, OriginProvider, StageReset},
+    types::PipelineResult,
 };
 
 /// A mock provider for the [`NextBatchProvider`] stage.
@@ -65,13 +68,22 @@ impl OriginAdvancer for TestNextBatchProvider {
 }
 
 #[async_trait]
-impl SignalReceiver for TestNextBatchProvider {
-    async fn signal(&mut self, signal: Signal) -> PipelineResult<()> {
-        match signal {
-            Signal::Reset { .. } => self.reset = true,
-            Signal::FlushChannel => self.flushed = true,
-            _ => {}
-        }
+impl StageReset for TestNextBatchProvider {
+    async fn reset(&mut self, _: BlockNumHash, _: SystemConfig) -> PipelineResult<()> {
+        self.reset = true;
+        Ok(())
+    }
+
+    async fn activate(&mut self) -> PipelineResult<()> {
+        Ok(())
+    }
+
+    async fn flush_channel(&mut self) -> PipelineResult<()> {
+        self.flushed = true;
+        Ok(())
+    }
+
+    async fn provide_block(&mut self, _: BlockInfo) -> PipelineResult<()> {
         Ok(())
     }
 }

--- a/crates/consensus/derive/src/test_utils/batch_provider.rs
+++ b/crates/consensus/derive/src/test_utils/batch_provider.rs
@@ -2,11 +2,10 @@
 
 use alloc::{boxed::Box, vec::Vec};
 
-use async_trait::async_trait;
-use base_protocol::{Batch, BlockInfo, L2BlockInfo};
-
 use alloy_eips::BlockNumHash;
+use async_trait::async_trait;
 use base_consensus_genesis::SystemConfig;
+use base_protocol::{Batch, BlockInfo, L2BlockInfo};
 
 use crate::{
     errors::PipelineError,

--- a/crates/consensus/derive/src/test_utils/batch_stream.rs
+++ b/crates/consensus/derive/src/test_utils/batch_stream.rs
@@ -4,13 +4,12 @@
 
 use alloc::{boxed::Box, vec::Vec};
 
+use alloy_eips::BlockNumHash;
 use async_trait::async_trait;
+use base_consensus_genesis::SystemConfig;
 use base_protocol::{Batch, BlockInfo};
 
-use crate::{
-    BatchStreamProvider, OriginAdvancer, OriginProvider, PipelineError, PipelineResult, Signal,
-    SignalReceiver,
-};
+use crate::{BatchStreamProvider, OriginAdvancer, OriginProvider, PipelineError, PipelineResult, StageReset};
 
 /// A mock provider for the [`BatchStream`] stage.
 ///
@@ -57,13 +56,22 @@ impl OriginAdvancer for TestBatchStreamProvider {
 }
 
 #[async_trait]
-impl SignalReceiver for TestBatchStreamProvider {
-    async fn signal(&mut self, signal: Signal) -> PipelineResult<()> {
-        match signal {
-            Signal::Reset { .. } => self.reset = true,
-            Signal::FlushChannel => self.flushed = true,
-            _ => {}
-        }
+impl StageReset for TestBatchStreamProvider {
+    async fn reset(&mut self, _: BlockNumHash, _: SystemConfig) -> PipelineResult<()> {
+        self.reset = true;
+        Ok(())
+    }
+
+    async fn activate(&mut self) -> PipelineResult<()> {
+        Ok(())
+    }
+
+    async fn flush_channel(&mut self) -> PipelineResult<()> {
+        self.flushed = true;
+        Ok(())
+    }
+
+    async fn provide_block(&mut self, _: BlockInfo) -> PipelineResult<()> {
         Ok(())
     }
 }

--- a/crates/consensus/derive/src/test_utils/batch_stream.rs
+++ b/crates/consensus/derive/src/test_utils/batch_stream.rs
@@ -9,7 +9,9 @@ use async_trait::async_trait;
 use base_consensus_genesis::SystemConfig;
 use base_protocol::{Batch, BlockInfo};
 
-use crate::{BatchStreamProvider, OriginAdvancer, OriginProvider, PipelineError, PipelineResult, StageReset};
+use crate::{
+    BatchStreamProvider, OriginAdvancer, OriginProvider, PipelineError, PipelineResult, StageReset,
+};
 
 /// A mock provider for the [`BatchStream`] stage.
 ///

--- a/crates/consensus/derive/src/test_utils/channel_provider.rs
+++ b/crates/consensus/derive/src/test_utils/channel_provider.rs
@@ -4,14 +4,16 @@
 
 use alloc::{boxed::Box, vec::Vec};
 
+use alloy_eips::BlockNumHash;
 use async_trait::async_trait;
+use base_consensus_genesis::SystemConfig;
 use base_protocol::{BlockInfo, Frame};
 
 use crate::{
     errors::PipelineError,
     stages::NextFrameProvider,
-    traits::{OriginAdvancer, OriginProvider, SignalReceiver},
-    types::{PipelineResult, Signal},
+    traits::{OriginAdvancer, OriginProvider, StageReset},
+    types::PipelineResult,
 };
 
 /// A mock [`NextFrameProvider`] for testing the [`ChannelBank`] stage.
@@ -59,8 +61,23 @@ impl NextFrameProvider for TestNextFrameProvider {
 }
 
 #[async_trait]
-impl SignalReceiver for TestNextFrameProvider {
-    async fn signal(&mut self, _: Signal) -> PipelineResult<()> {
+impl StageReset for TestNextFrameProvider {
+    async fn reset(&mut self, _: BlockNumHash, _: SystemConfig) -> PipelineResult<()> {
+        self.reset = true;
+        Ok(())
+    }
+
+    async fn activate(&mut self) -> PipelineResult<()> {
+        self.reset = true;
+        Ok(())
+    }
+
+    async fn flush_channel(&mut self) -> PipelineResult<()> {
+        self.reset = true;
+        Ok(())
+    }
+
+    async fn provide_block(&mut self, _: BlockInfo) -> PipelineResult<()> {
         self.reset = true;
         Ok(())
     }

--- a/crates/consensus/derive/src/test_utils/channel_reader.rs
+++ b/crates/consensus/derive/src/test_utils/channel_reader.rs
@@ -4,13 +4,15 @@
 
 use alloc::{boxed::Box, vec::Vec};
 
+use alloy_eips::BlockNumHash;
 use alloy_primitives::Bytes;
 use async_trait::async_trait;
+use base_consensus_genesis::SystemConfig;
 use base_protocol::BlockInfo;
 
 use crate::{
-    ChannelReaderProvider, OriginAdvancer, OriginProvider, PipelineError, PipelineResult, Signal,
-    SignalReceiver,
+    ChannelReaderProvider, OriginAdvancer, OriginProvider, PipelineError, PipelineResult,
+    StageReset,
 };
 
 /// A mock [`ChannelReaderProvider`] for testing the [`ChannelReader`] stage.
@@ -54,8 +56,23 @@ impl ChannelReaderProvider for TestChannelReaderProvider {
 }
 
 #[async_trait]
-impl SignalReceiver for TestChannelReaderProvider {
-    async fn signal(&mut self, _: Signal) -> PipelineResult<()> {
+impl StageReset for TestChannelReaderProvider {
+    async fn reset(&mut self, _: BlockNumHash, _: SystemConfig) -> PipelineResult<()> {
+        self.reset = true;
+        Ok(())
+    }
+
+    async fn activate(&mut self) -> PipelineResult<()> {
+        self.reset = true;
+        Ok(())
+    }
+
+    async fn flush_channel(&mut self) -> PipelineResult<()> {
+        self.reset = true;
+        Ok(())
+    }
+
+    async fn provide_block(&mut self, _: BlockInfo) -> PipelineResult<()> {
         self.reset = true;
         Ok(())
     }

--- a/crates/consensus/derive/src/test_utils/frame_queue.rs
+++ b/crates/consensus/derive/src/test_utils/frame_queue.rs
@@ -2,13 +2,14 @@
 
 use alloc::{boxed::Box, vec::Vec};
 
+use alloy_eips::BlockNumHash;
 use alloy_primitives::Bytes;
 use async_trait::async_trait;
+use base_consensus_genesis::SystemConfig;
 use base_protocol::BlockInfo;
 
 use crate::{
-    FrameQueueProvider, OriginAdvancer, OriginProvider, PipelineError, PipelineResult, Signal,
-    SignalReceiver,
+    FrameQueueProvider, OriginAdvancer, OriginProvider, PipelineError, PipelineResult, StageReset,
 };
 
 /// A mock [`FrameQueueProvider`] for testing the frame queue stage.
@@ -59,8 +60,23 @@ impl FrameQueueProvider for TestFrameQueueProvider {
 }
 
 #[async_trait]
-impl SignalReceiver for TestFrameQueueProvider {
-    async fn signal(&mut self, _: Signal) -> PipelineResult<()> {
+impl StageReset for TestFrameQueueProvider {
+    async fn reset(&mut self, _: BlockNumHash, _: SystemConfig) -> PipelineResult<()> {
+        self.reset = true;
+        Ok(())
+    }
+
+    async fn activate(&mut self) -> PipelineResult<()> {
+        self.reset = true;
+        Ok(())
+    }
+
+    async fn flush_channel(&mut self) -> PipelineResult<()> {
+        self.reset = true;
+        Ok(())
+    }
+
+    async fn provide_block(&mut self, _: BlockInfo) -> PipelineResult<()> {
         self.reset = true;
         Ok(())
     }

--- a/crates/consensus/derive/src/test_utils/pipeline.rs
+++ b/crates/consensus/derive/src/test_utils/pipeline.rs
@@ -10,13 +10,16 @@ use base_protocol::{BlockInfo, L2BlockInfo, OpAttributesWithParent};
 use crate::{
     AttributesQueue, BatchStream, ChannelProvider, ChannelReader, DerivationPipeline, FrameQueue,
     L1Retrieval, NextAttributes, OriginAdvancer, OriginProvider, PipelineBuilder, PipelineError,
-    PollingTraversal, Signal, SignalReceiver,
+    PollingTraversal, StageReset,
     test_utils::{TestAttributesBuilder, TestDAP},
 };
 use crate::{
     BatchProvider, PipelineResult,
     test_utils::{TestChainProvider, TestL2ChainProvider},
 };
+
+use alloy_eips::BlockNumHash;
+use base_consensus_genesis::SystemConfig;
 
 /// A fully custom [`NextAttributes`].
 #[derive(Default, Debug, Clone)]
@@ -26,9 +29,20 @@ pub struct TestNextAttributes {
 }
 
 #[async_trait::async_trait]
-impl SignalReceiver for TestNextAttributes {
-    /// Resets the derivation stage to its initial state.
-    async fn signal(&mut self, _: Signal) -> PipelineResult<()> {
+impl StageReset for TestNextAttributes {
+    async fn reset(&mut self, _: BlockNumHash, _: SystemConfig) -> PipelineResult<()> {
+        Ok(())
+    }
+
+    async fn activate(&mut self) -> PipelineResult<()> {
+        Ok(())
+    }
+
+    async fn flush_channel(&mut self) -> PipelineResult<()> {
+        Ok(())
+    }
+
+    async fn provide_block(&mut self, _: BlockInfo) -> PipelineResult<()> {
         Ok(())
     }
 }

--- a/crates/consensus/derive/src/test_utils/pipeline.rs
+++ b/crates/consensus/derive/src/test_utils/pipeline.rs
@@ -3,7 +3,8 @@
 
 use alloc::{boxed::Box, sync::Arc};
 
-use base_consensus_genesis::RollupConfig;
+use alloy_eips::BlockNumHash;
+use base_consensus_genesis::{RollupConfig, SystemConfig};
 use base_protocol::{BlockInfo, L2BlockInfo, OpAttributesWithParent};
 
 // Re-export these types used internally to the test pipeline.
@@ -17,9 +18,6 @@ use crate::{
     BatchProvider, PipelineResult,
     test_utils::{TestChainProvider, TestL2ChainProvider},
 };
-
-use alloy_eips::BlockNumHash;
-use base_consensus_genesis::SystemConfig;
 
 /// A fully custom [`NextAttributes`].
 #[derive(Default, Debug, Clone)]

--- a/crates/consensus/derive/src/traits/mod.rs
+++ b/crates/consensus/derive/src/traits/mod.rs
@@ -17,4 +17,4 @@ mod reset;
 pub use reset::ResetProvider;
 
 mod stages;
-pub use stages::{OriginAdvancer, OriginProvider, SignalReceiver};
+pub use stages::{OriginAdvancer, OriginProvider, SignalReceiver, StageReset};

--- a/crates/consensus/derive/src/traits/stages.rs
+++ b/crates/consensus/derive/src/traits/stages.rs
@@ -2,10 +2,37 @@
 
 use alloc::boxed::Box;
 
+use alloy_eips::BlockNumHash;
 use async_trait::async_trait;
+use base_consensus_genesis::SystemConfig;
 use base_protocol::BlockInfo;
 
 use crate::{PipelineResult, Signal};
+
+/// Provides typed reset/activation/signal operations for pipeline stages.
+///
+/// This trait replaces the generic [`SignalReceiver`] for internal stage-to-stage
+/// communication, allowing the pipeline core to dispatch typed operations with
+/// the correct parameters at each level, rather than threading signal fields
+/// (like `l1_origin` and `system_config`) through every signal variant.
+#[async_trait]
+pub trait StageReset {
+    /// Resets the stage to the given L1 origin and system config.
+    async fn reset(
+        &mut self,
+        l1_origin: BlockNumHash,
+        system_config: SystemConfig,
+    ) -> PipelineResult<()>;
+
+    /// Performs a hardfork activation soft-reset of the stage.
+    async fn activate(&mut self) -> PipelineResult<()>;
+
+    /// Flushes the currently active channel.
+    async fn flush_channel(&mut self) -> PipelineResult<()>;
+
+    /// Provides a new L1 block to the traversal stage.
+    async fn provide_block(&mut self, block: BlockInfo) -> PipelineResult<()>;
+}
 
 /// Providers a way for the pipeline to accept a signal from the driver.
 #[async_trait]

--- a/crates/consensus/derive/src/types/signals.rs
+++ b/crates/consensus/derive/src/types/signals.rs
@@ -4,7 +4,6 @@
 //! of the pipeline. They allow the pipeline driver to perform actions such as
 //! resetting all stages in the pipeline through message passing.
 
-use base_consensus_genesis::SystemConfig;
 use base_protocol::{BlockInfo, L2BlockInfo};
 
 /// A signal to send to the pipeline.
@@ -31,38 +30,17 @@ impl core::fmt::Display for Signal {
     }
 }
 
-impl Signal {
-    /// Sets the [`SystemConfig`] for the signal.
-    pub const fn with_system_config(self, system_config: SystemConfig) -> Self {
-        match self {
-            Self::Reset(reset) => reset.with_system_config(system_config).signal(),
-            Self::Activation(activation) => activation.with_system_config(system_config).signal(),
-            Self::FlushChannel => Self::FlushChannel,
-            Self::ProvideBlock(block) => Self::ProvideBlock(block),
-        }
-    }
-}
-
 /// A pipeline reset signal.
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
 pub struct ResetSignal {
     /// The L2 safe head to reset to.
     pub l2_safe_head: L2BlockInfo,
-    /// The L1 origin to reset to.
-    pub l1_origin: BlockInfo,
-    /// The optional [`SystemConfig`] to reset with.
-    pub system_config: Option<SystemConfig>,
 }
 
 impl ResetSignal {
     /// Creates a new [`Signal::Reset`] from the [`ResetSignal`].
     pub const fn signal(self) -> Signal {
         Signal::Reset(self)
-    }
-
-    /// Sets the [`SystemConfig`] for the signal.
-    pub const fn with_system_config(self, system_config: SystemConfig) -> Self {
-        Self { system_config: Some(system_config), ..self }
     }
 }
 
@@ -71,21 +49,12 @@ impl ResetSignal {
 pub struct ActivationSignal {
     /// The L2 safe head to reset to.
     pub l2_safe_head: L2BlockInfo,
-    /// The L1 origin to reset to.
-    pub l1_origin: BlockInfo,
-    /// The optional [`SystemConfig`] to reset with.
-    pub system_config: Option<SystemConfig>,
 }
 
 impl ActivationSignal {
     /// Creates a new [`Signal::Activation`] from the [`ActivationSignal`].
     pub const fn signal(self) -> Signal {
         Signal::Activation(self)
-    }
-
-    /// Sets the [`SystemConfig`] for the signal.
-    pub const fn with_system_config(self, system_config: SystemConfig) -> Self {
-        Self { system_config: Some(system_config), ..self }
     }
 }
 
@@ -103,24 +72,5 @@ mod tests {
     fn test_activation_signal() {
         let signal = ActivationSignal::default();
         assert_eq!(signal.signal(), Signal::Activation(signal));
-    }
-
-    #[test]
-    fn test_signal_with_system_config() {
-        let signal = ResetSignal::default();
-        let system_config = SystemConfig::default();
-        assert_eq!(
-            signal.with_system_config(system_config).signal(),
-            Signal::Reset(ResetSignal { system_config: Some(system_config), ..signal })
-        );
-
-        let signal = ActivationSignal::default();
-        let system_config = SystemConfig::default();
-        assert_eq!(
-            signal.with_system_config(system_config).signal(),
-            Signal::Activation(ActivationSignal { system_config: Some(system_config), ..signal })
-        );
-
-        assert_eq!(Signal::FlushChannel.with_system_config(system_config), Signal::FlushChannel);
     }
 }

--- a/crates/consensus/engine/src/task_queue/core.rs
+++ b/crates/consensus/engine/src/task_queue/core.rs
@@ -115,7 +115,7 @@ impl<EngineClient_: EngineClient> Engine<EngineClient_> {
         // see the new forkchoice immediately, without waiting for a task to pass through drain().
         self.state_sender.send_replace(self.state);
 
-        base_metrics::inc!(counter, Metrics::ENGINE_RESET_COUNT);
+        Metrics::engine_reset_count().increment(1);
 
         Ok(start.safe)
     }

--- a/crates/consensus/engine/src/task_queue/core.rs
+++ b/crates/consensus/engine/src/task_queue/core.rs
@@ -2,8 +2,8 @@
 
 use std::{collections::BinaryHeap, sync::Arc};
 
-use base_consensus_genesis::{RollupConfig, SystemConfig};
-use base_protocol::{BlockInfo, L2BlockInfo, OpBlockConversionError, to_system_config};
+use base_consensus_genesis::RollupConfig;
+use base_protocol::{L2BlockInfo, OpBlockConversionError};
 use thiserror::Error;
 use tokio::sync::watch::Sender;
 
@@ -78,7 +78,7 @@ impl<EngineClient_: EngineClient> Engine<EngineClient_> {
         &mut self,
         client: Arc<EngineClient_>,
         config: Arc<RollupConfig>,
-    ) -> Result<(L2BlockInfo, BlockInfo, SystemConfig), EngineResetError> {
+    ) -> Result<L2BlockInfo, EngineResetError> {
         // Clear any outstanding tasks to prepare for the reset.
         self.clear();
 
@@ -115,32 +115,9 @@ impl<EngineClient_: EngineClient> Engine<EngineClient_> {
         // see the new forkchoice immediately, without waiting for a task to pass through drain().
         self.state_sender.send_replace(self.state);
 
-        // Find the new safe head's L1 origin and SystemConfig.
-        let origin_block = start
-            .safe
-            .l1_origin
-            .number
-            .saturating_sub(config.channel_timeout(start.safe.block_info.timestamp));
-        let l1_origin_info: BlockInfo = client
-            .get_l1_block(origin_block.into())
-            .await
-            .map_err(SyncStartError::RpcError)?
-            .ok_or(SyncStartError::BlockNotFound(origin_block.into()))?
-            .into_consensus()
-            .into();
-        let l2_safe_block = client
-            .get_l2_block(start.safe.block_info.hash.into())
-            .full()
-            .await
-            .map_err(SyncStartError::RpcError)?
-            .ok_or(SyncStartError::BlockNotFound(origin_block.into()))?
-            .into_consensus()
-            .map_transactions(|t| t.inner.inner.into_inner());
-        let system_config = to_system_config(&l2_safe_block, &config)?;
+        base_metrics::inc!(counter, Metrics::ENGINE_RESET_COUNT);
 
-        Metrics::engine_reset_count().increment(1);
-
-        Ok((start.safe, l1_origin_info, system_config))
+        Ok(start.safe)
     }
 
     /// Seeds the engine sync state from an external source without sending a forkchoice update.

--- a/crates/consensus/providers-alloy/src/pipeline.rs
+++ b/crates/consensus/providers-alloy/src/pipeline.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use base_consensus_derive::{
-    DerivationPipeline, EthereumDataSource, IndexedAttributesQueueStage, L2ChainProvider,
+    DerivationPipeline, EthereumDataSource, IndexedAttributesQueueStage,
     OriginProvider, Pipeline, PipelineBuilder, PipelineErrorKind, PipelineResult,
     PolledAttributesQueueStage, ResetSignal, Signal, SignalReceiver, StatefulAttributesBuilder,
     StepResult,
@@ -60,34 +60,21 @@ impl OnlinePipeline {
         cfg: Arc<RollupConfig>,
         l1_cfg: Arc<L1ChainConfig>,
         l2_safe_head: L2BlockInfo,
-        l1_origin: BlockInfo,
         blob_provider: OnlineBlobProvider<OnlineBeaconClient>,
         chain_provider: AlloyChainProvider,
-        mut l2_chain_provider: AlloyL2ChainProvider,
+        l2_chain_provider: AlloyL2ChainProvider,
     ) -> PipelineResult<Self> {
         let mut pipeline = Self::new_polled(
             Arc::clone(&cfg),
             Arc::clone(&l1_cfg),
             blob_provider,
             chain_provider,
-            l2_chain_provider.clone(),
+            l2_chain_provider,
         );
 
         // Reset the pipeline to populate the initial L1/L2 cursor and system configuration in L1
         // Traversal.
-        pipeline
-            .signal(
-                ResetSignal {
-                    l2_safe_head,
-                    l1_origin,
-                    system_config: l2_chain_provider
-                        .system_config_by_number(l2_safe_head.block_info.number, Arc::clone(&cfg))
-                        .await
-                        .ok(),
-                }
-                .signal(),
-            )
-            .await?;
+        pipeline.signal(ResetSignal { l2_safe_head }.signal()).await?;
 
         Ok(pipeline)
     }

--- a/crates/consensus/providers-alloy/src/pipeline.rs
+++ b/crates/consensus/providers-alloy/src/pipeline.rs
@@ -5,10 +5,9 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use base_consensus_derive::{
-    DerivationPipeline, EthereumDataSource, IndexedAttributesQueueStage,
-    OriginProvider, Pipeline, PipelineBuilder, PipelineErrorKind, PipelineResult,
-    PolledAttributesQueueStage, ResetSignal, Signal, SignalReceiver, StatefulAttributesBuilder,
-    StepResult,
+    DerivationPipeline, EthereumDataSource, IndexedAttributesQueueStage, OriginProvider, Pipeline,
+    PipelineBuilder, PipelineErrorKind, PipelineResult, PolledAttributesQueueStage, ResetSignal,
+    Signal, SignalReceiver, StatefulAttributesBuilder, StepResult,
 };
 use base_consensus_genesis::{L1ChainConfig, RollupConfig, SystemConfig};
 use base_protocol::{BlockInfo, L2BlockInfo, OpAttributesWithParent};

--- a/crates/consensus/service/src/actors/derivation/actor.rs
+++ b/crates/consensus/service/src/actors/derivation/actor.rs
@@ -96,8 +96,8 @@ where
 
     /// Handles a [`Signal`] received over the derivation signal receiver channel.
     async fn signal(&mut self, signal: Signal) {
-        if let Signal::Reset(ResetSignal { l1_origin: _l1_origin, .. }) = signal {
-            Metrics::derivation_l1_origin().absolute(_l1_origin.number);
+        if let Signal::Reset(ResetSignal { l2_safe_head: _reset_safe_head }) = signal {
+            base_metrics::set!(counter, Metrics::DERIVATION_L1_ORIGIN, _reset_safe_head.l1_origin.number);
             // Clear the finalization queue on reset.
             self.finalizer.clear();
             // Discard any in-flight derived_from so that a stale pre-reset L1 inclusion
@@ -165,30 +165,13 @@ where
                         PipelineErrorKind::Reset(e) => {
                             warn!(target: "derivation", error = %e, "Derivation pipeline is being reset");
 
-                            let system_config = self
-                                .pipeline
-                                .system_config_by_number(
-                                    self.derivation_state_machine
-                                        .last_confirmed_safe_head()
-                                        .block_info
-                                        .number,
-                                )
-                                .await?;
-
                             if matches!(e, ResetError::HoloceneActivation) {
-                                let l1_origin = self
-                                    .pipeline
-                                    .origin()
-                                    .ok_or(PipelineError::MissingOrigin.crit())?;
-
                                 self.pipeline
                                     .signal(
                                         ActivationSignal {
                                             l2_safe_head: self
                                                 .derivation_state_machine
                                                 .last_confirmed_safe_head(),
-                                            l1_origin,
-                                            system_config: Some(system_config),
                                         }
                                         .signal(),
                                     )

--- a/crates/consensus/service/src/actors/derivation/actor.rs
+++ b/crates/consensus/service/src/actors/derivation/actor.rs
@@ -97,11 +97,7 @@ where
     /// Handles a [`Signal`] received over the derivation signal receiver channel.
     async fn signal(&mut self, signal: Signal) {
         if let Signal::Reset(ResetSignal { l2_safe_head: _reset_safe_head }) = signal {
-            base_metrics::set!(
-                counter,
-                Metrics::DERIVATION_L1_ORIGIN,
-                _reset_safe_head.l1_origin.number
-            );
+            Metrics::derivation_l1_origin().absolute(_reset_safe_head.l1_origin.number);
             // Clear the finalization queue on reset.
             self.finalizer.clear();
             // Discard any in-flight derived_from so that a stale pre-reset L1 inclusion

--- a/crates/consensus/service/src/actors/derivation/actor.rs
+++ b/crates/consensus/service/src/actors/derivation/actor.rs
@@ -97,7 +97,11 @@ where
     /// Handles a [`Signal`] received over the derivation signal receiver channel.
     async fn signal(&mut self, signal: Signal) {
         if let Signal::Reset(ResetSignal { l2_safe_head: _reset_safe_head }) = signal {
-            base_metrics::set!(counter, Metrics::DERIVATION_L1_ORIGIN, _reset_safe_head.l1_origin.number);
+            base_metrics::set!(
+                counter,
+                Metrics::DERIVATION_L1_ORIGIN,
+                _reset_safe_head.l1_origin.number
+            );
             // Clear the finalization queue on reset.
             self.finalizer.clear();
             // Discard any in-flight derived_from so that a stale pre-reset L1 inclusion

--- a/crates/consensus/service/src/actors/engine/engine_request_processor.rs
+++ b/crates/consensus/service/src/actors/engine/engine_request_processor.rs
@@ -107,11 +107,11 @@ where
     /// Resets the inner [`Engine`] and propagates the reset to the derivation actor.
     async fn reset(&mut self) -> Result<(), EngineError> {
         // Reset the engine.
-        let (l2_safe_head, l1_origin, system_config) =
+        let l2_safe_head =
             self.engine.reset(Arc::clone(&self.client), Arc::clone(&self.rollup)).await?;
 
         // Signal the derivation actor to reset.
-        let signal = ResetSignal { l2_safe_head, l1_origin, system_config: Some(system_config) };
+        let signal = ResetSignal { l2_safe_head };
         match self.derivation_client.send_signal(signal.signal()).await {
             Ok(_) => info!(target: "engine", "Sent reset signal to derivation actor"),
             Err(err) => {

--- a/crates/proof/driver/src/pipeline.rs
+++ b/crates/proof/driver/src/pipeline.rs
@@ -60,10 +60,7 @@ where
                             warn!(target: "client_derivation_driver", error = ?e, "Failed to step derivation pipeline due to reset");
 
                             if matches!(e, ResetError::HoloceneActivation) {
-                                self.signal(
-                                    ActivationSignal { l2_safe_head }.signal(),
-                                )
-                                .await?;
+                                self.signal(ActivationSignal { l2_safe_head }.signal()).await?;
                             } else {
                                 // Flushes cache if a reorg is detected.
                                 if matches!(e, ResetError::ReorgDetected(_, _)) {

--- a/crates/proof/driver/src/pipeline.rs
+++ b/crates/proof/driver/src/pipeline.rs
@@ -58,20 +58,10 @@ where
                         }
                         PipelineErrorKind::Reset(e) => {
                             warn!(target: "client_derivation_driver", error = ?e, "Failed to step derivation pipeline due to reset");
-                            let system_config = self
-                                .system_config_by_number(l2_safe_head.block_info.number)
-                                .await?;
 
                             if matches!(e, ResetError::HoloceneActivation) {
-                                let l1_origin =
-                                    self.origin().ok_or(PipelineError::MissingOrigin.crit())?;
                                 self.signal(
-                                    ActivationSignal {
-                                        l2_safe_head,
-                                        l1_origin,
-                                        system_config: Some(system_config),
-                                    }
-                                    .signal(),
+                                    ActivationSignal { l2_safe_head }.signal(),
                                 )
                                 .await?;
                             } else {
@@ -82,17 +72,7 @@ where
 
                                 // Reset the pipeline to the initial L2 safe head and L1 origin,
                                 // and try again.
-                                let l1_origin =
-                                    self.origin().ok_or(PipelineError::MissingOrigin.crit())?;
-                                self.signal(
-                                    ResetSignal {
-                                        l2_safe_head,
-                                        l1_origin,
-                                        system_config: Some(system_config),
-                                    }
-                                    .signal(),
-                                )
-                                .await?;
+                                self.signal(ResetSignal { l2_safe_head }.signal()).await?;
                             }
                         }
                         PipelineErrorKind::Critical(_) => {

--- a/crates/proof/proof/src/l1/pipeline.rs
+++ b/crates/proof/proof/src/l1/pipeline.rs
@@ -15,7 +15,7 @@ use base_consensus_genesis::{L1ChainConfig, RollupConfig, SystemConfig};
 use base_proof_driver::{DriverPipeline, PipelineCursor};
 use base_proof_executor::TrieDBProvider;
 use base_proof_preimage::{CommsClient, FlushableCache};
-use base_protocol::{BlockInfo, L2BlockInfo, OpAttributesWithParent};
+use base_protocol::{BatchValidationProvider, BlockInfo, L2BlockInfo, OpAttributesWithParent};
 use spin::RwLock;
 
 use crate::{
@@ -65,7 +65,10 @@ where
         da_provider: DA,
         chain_provider: L1,
         l2_chain_provider: L2,
-    ) -> PipelineResult<Self> {
+    ) -> PipelineResult<Self>
+    where
+        <L2 as BatchValidationProvider>::Error: Into<PipelineErrorKind>,
+    {
         let attributes = StatefulAttributesBuilder::new(
             Arc::clone(&cfg),
             l1_cfg,
@@ -155,6 +158,7 @@ where
     L1: ChainProvider + Send + Sync + Debug + Clone,
     L2: L2ChainProvider + Send + Sync + Debug + Clone,
     DA: DataAvailabilityProvider + Send + Sync + Debug + Clone,
+    <L2 as BatchValidationProvider>::Error: Into<PipelineErrorKind>,
 {
     /// Flushes the cache on re-org.
     fn flush(&mut self) {
@@ -169,6 +173,7 @@ where
     L1: ChainProvider + Send + Sync + Debug + Clone,
     L2: L2ChainProvider + Send + Sync + Debug + Clone,
     DA: DataAvailabilityProvider + Send + Sync + Debug + Clone,
+    <L2 as BatchValidationProvider>::Error: Into<PipelineErrorKind>,
 {
     /// Receives a signal from the driver.
     async fn signal(&mut self, signal: Signal) -> PipelineResult<()> {

--- a/crates/proof/proof/src/l1/pipeline.rs
+++ b/crates/proof/proof/src/l1/pipeline.rs
@@ -64,7 +64,7 @@ where
         caching_oracle: Arc<O>,
         da_provider: DA,
         chain_provider: L1,
-        mut l2_chain_provider: L2,
+        l2_chain_provider: L2,
     ) -> PipelineResult<Self> {
         let attributes = StatefulAttributesBuilder::new(
             Arc::clone(&cfg),
@@ -72,8 +72,6 @@ where
             l2_chain_provider.clone(),
             chain_provider.clone(),
         );
-
-        let cfg_for_reset = Arc::clone(&cfg);
 
         let mut pipeline = PipelineBuilder::new()
             .rollup_config(cfg)
@@ -84,21 +82,9 @@ where
             .origin(sync_start.read().origin())
             .build_polled();
 
-        // Reset the pipeline to populate the initial system configuration in L1 Traversal.
+        // Reset the pipeline to populate the initial L1/L2 cursor in L1 Traversal.
         let l2_safe_head = *sync_start.read().l2_safe_head();
-        pipeline
-            .signal(
-                ResetSignal {
-                    l2_safe_head,
-                    l1_origin: sync_start.read().origin(),
-                    system_config: l2_chain_provider
-                        .system_config_by_number(l2_safe_head.block_info.number, cfg_for_reset)
-                        .await
-                        .ok(),
-                }
-                .signal(),
-            )
-            .await?;
+        pipeline.signal(ResetSignal { l2_safe_head }.signal()).await?;
 
         Ok(Self { pipeline, caching_oracle })
     }


### PR DESCRIPTION
## Summary

Ports kona PR ethereum-optimism/optimism#19792. The pipeline was reading the system config from exactly the L2 safe head block on reset, which missed batcher address changes within the channel timeout window and could cause derivation to diverge from op-node. The fix adds an `initial_reset` walk on `Signal::Reset` that steps back through L2 parents until the block's L1 origin is at most `channel_timeout` blocks behind the safe head's L1 origin, then reads the system config from that older block. As part of this change, all internal pipeline stages now implement a typed `StageReset` trait (replacing `SignalReceiver`), and `ResetSignal`/`ActivationSignal` are simplified to carry only `l2_safe_head`.