### PR TITLE
fix: prevent potential underflow in overlapping blocks calculation

### DIFF
--- a/crates/consensus/protocol/src/batch/span.rs
+++ b/crates/consensus/protocol/src/batch/span.rs
@@ -521,7 +521,8 @@ impl SpanBatch {
         let parent_num = parent_block.block_info.number;
         let next_timestamp = l2_safe_head.block_info.timestamp + cfg.block_time;
         if self.starting_timestamp() < next_timestamp {
-            for i in 0..(l2_safe_head.block_info.number - parent_num) {
+            let overlap_count = l2_safe_head.block_info.number.saturating_sub(parent_num);
+            for i in 0..overlap_count {
                 let safe_block_num = parent_num + i + 1;
                 let safe_block_payload = match fetcher.block_by_number(safe_block_num).await {
                     Ok(p) => p,


### PR DESCRIPTION
## Problem
In [check_batch()](cci:1://file:///base/crates/consensus/protocol/src/batch/span.rs:377:4-585:5) function, the calculation `l2_safe_head.block_info.number - parent_num` could underflow if `parent_num` is greater than `l2_safe_head.block_info.number`. Since block numbers are `u64`, this would cause a wrap-around to a huge number, leading to excessive loop iterations and potential memory exhaustion or hang.

## Fix
Replaced the subtraction with `saturating_sub()` which returns 0 instead of underflowing when the subtrahend is larger than the minuend. This ensures the loop correctly handles edge cases where parent block number calculation might exceed the safe head.

## Why this is safe
`saturating_sub()` is a standard Rust operation that prevents underflow by capping at 0. The fix maintains the same logic for normal cases while gracefully handling the edge case where parent block number is unexpectedly high, preventing the application from hanging or crashing.