### PR TITLE
feat(tee): validate preimage oracle data in nitro enclave

### DIFF
--- a/crates/proof/proof/Cargo.toml
+++ b/crates/proof/proof/Cargo.toml
@@ -51,19 +51,21 @@ ark-ff.workspace = true
 ark-bls12-381.workspace = true
 
 # `std` feature dependencies
+c-kzg = { workspace = true, optional = true }
 tokio = { workspace = true, features = ["full"], optional = true }
 
 [dev-dependencies]
 rand.workspace = true
-c-kzg.workspace = true
 rayon.workspace = true
 rstest.workspace = true
 tokio = { workspace = true, features = ["full"] }
+c-kzg = { workspace = true, features = [] }
 alloy-eips = { workspace = true, features = ["kzg"] }
 
 [features]
 std = [
 	"alloy-consensus/std",
+	"alloy-eips/kzg",
 	"alloy-eips/std",
 	"alloy-evm/std",
 	"alloy-primitives/std",
@@ -82,6 +84,7 @@ std = [
 	"base-proof-preimage/std",
 	"base-protocol/std",
 	"base-revm/std",
+	"dep:c-kzg",
 	"dep:tokio",
 	"serde/std",
 	"serde_json/std",

--- a/crates/proof/proof/src/errors.rs
+++ b/crates/proof/proof/src/errors.rs
@@ -110,6 +110,13 @@ pub enum OracleProviderError {
     /// * `0` - The unknown chain ID that was encountered
     #[error("Unknown chain ID: {0}")]
     UnknownChainId(u64),
+    /// Blob KZG commitment verification failed.
+    ///
+    /// This error occurs when the KZG commitment computed from a reconstructed
+    /// blob does not match the commitment fetched from the oracle. This indicates
+    /// that the blob field elements were tampered with or corrupted.
+    #[error("Blob verification failed: {0}")]
+    BlobVerification(String),
 }
 
 impl From<OracleProviderError> for PipelineErrorKind {

--- a/crates/proof/proof/src/l1/blob_provider.rs
+++ b/crates/proof/proof/src/l1/blob_provider.rs
@@ -1,5 +1,7 @@
 //! Contains the concrete implementation of the [`BlobProvider`] trait for the client program.
 
+#[cfg(feature = "std")]
+use alloc::string::ToString;
 use alloc::{boxed::Box, sync::Arc, vec::Vec};
 use core::str::FromStr;
 
@@ -75,6 +77,25 @@ impl<T: CommsClient> OracleBlobProvider<T> {
                 .await
                 .map_err(OracleProviderError::Preimage)?;
             blob[(i as usize) << 5..(i as usize + 1) << 5].copy_from_slice(field_element.as_ref());
+        }
+
+        // Verify that the reconstructed blob matches the fetched commitment by recomputing
+        // the KZG commitment and comparing. This prevents a compromised host from supplying
+        // fake field elements that would reconstruct into a different blob.
+        #[cfg(feature = "std")]
+        {
+            let kzg_blob = c_kzg::Blob::new(blob.0);
+            let kzg = alloy_eips::eip4844::env_settings::EnvKzgSettings::Default;
+            let computed = kzg
+                .get()
+                .blob_to_kzg_commitment(&kzg_blob)
+                .map_err(|e| OracleProviderError::BlobVerification(e.to_string()))?;
+            if computed.as_slice() != commitment {
+                return Err(OracleProviderError::BlobVerification(alloc::format!(
+                    "commitment mismatch for blob {}",
+                    blob_hash
+                )));
+            }
         }
 
         info!(

--- a/crates/proof/proof/src/l1/blob_provider.rs
+++ b/crates/proof/proof/src/l1/blob_provider.rs
@@ -92,8 +92,7 @@ impl<T: CommsClient> OracleBlobProvider<T> {
                 .map_err(|e| OracleProviderError::BlobVerification(e.to_string()))?;
             if computed.as_slice() != commitment {
                 return Err(OracleProviderError::BlobVerification(alloc::format!(
-                    "commitment mismatch for blob {}",
-                    blob_hash
+                    "commitment mismatch for blob {blob_hash}"
                 )));
             }
         }

--- a/crates/proof/tee/nitro-enclave/Cargo.toml
+++ b/crates/proof/tee/nitro-enclave/Cargo.toml
@@ -14,7 +14,7 @@ workspace = true
 [dependencies]
 # base
 base-alloy-evm.workspace = true
-base-proof-client.workspace = true
+base-proof-client = { workspace = true, features = ["std"] }
 base-proof-preimage = { workspace = true, features = ["serde"] }
 
 # alloy

--- a/crates/proof/tee/nitro-enclave/src/error.rs
+++ b/crates/proof/tee/nitro-enclave/src/error.rs
@@ -1,5 +1,6 @@
 //! Error types for enclave server operations.
 
+use base_proof_preimage::PreimageKey;
 use thiserror::Error;
 
 /// Errors that can occur during NSM operations.
@@ -165,6 +166,9 @@ pub enum NitroError {
     /// Unsupported chain ID.
     #[error("unsupported chain ID: {0}")]
     UnsupportedChain(u64),
+    /// A preimage's content does not match its hash-based key.
+    #[error("preimage hash mismatch for key {0}")]
+    InvalidPreimage(PreimageKey),
 }
 
 /// A specialized Result type for nitro enclave operations.

--- a/crates/proof/tee/nitro-enclave/src/oracle.rs
+++ b/crates/proof/tee/nitro-enclave/src/oracle.rs
@@ -2,12 +2,15 @@
 
 use std::{collections::HashMap, fmt, sync::Arc};
 
+use alloy_primitives::keccak256;
 use async_trait::async_trait;
 use base_proof_preimage::{
-    FlushableCache, HintWriterClient, PreimageKey, PreimageOracleClient, WitnessOracle,
+    FlushableCache, HintWriterClient, PreimageKey, PreimageKeyType, PreimageOracleClient,
+    WitnessOracle,
     errors::{PreimageOracleError, PreimageOracleResult, WitnessOracleResult},
 };
 use parking_lot::RwLock;
+use sha2::Digest;
 
 use crate::NitroError;
 
@@ -26,13 +29,55 @@ pub struct Oracle {
 
 impl Oracle {
     /// Construct an [`Oracle`] from an iterator of `(key, value)` pairs.
-    pub fn new(preimages: impl IntoIterator<Item = (PreimageKey, Vec<u8>)>) -> Self {
-        Self { preimages: Arc::new(RwLock::new(preimages.into_iter().collect())) }
+    ///
+    /// Every preimage with a hash-based key type (Keccak256, Sha256) is verified
+    /// against its key before being accepted. Returns an error if any preimage
+    /// fails validation.
+    pub fn new(preimages: impl IntoIterator<Item = (PreimageKey, Vec<u8>)>) -> crate::Result<Self> {
+        let map: HashMap<PreimageKey, Vec<u8>> = preimages.into_iter().collect();
+        Self::check_preimages(&map)?;
+        Ok(Self { preimages: Arc::new(RwLock::new(map)) })
     }
 
     /// Construct an empty [`Oracle`] for witness capture.
     pub fn empty() -> Self {
         Self { preimages: Arc::new(RwLock::new(HashMap::new())) }
+    }
+
+    /// Verify that a preimage's content matches its key for hash-based key types.
+    ///
+    /// For [`PreimageKeyType::Keccak256`] keys the keccak256 digest of `value`
+    /// must produce a key equal to `key`. For [`PreimageKeyType::Sha256`] keys
+    /// the SHA-256 digest is checked instead. Local and GlobalGeneric keys are
+    /// context-dependent and cannot be verified by hash, so they are accepted
+    /// without validation.
+    ///
+    /// Blob and Precompile keys use composite hashing schemes that cannot be
+    /// validated with the value alone, so they are also accepted as-is.
+    fn check_preimage(key: &PreimageKey, value: &[u8]) -> crate::Result<()> {
+        let expected_hash: Option<[u8; 32]> = match key.key_type() {
+            PreimageKeyType::Keccak256 => Some(keccak256(value).0),
+            PreimageKeyType::Sha256 => Some(sha2::Sha256::digest(value).into()),
+            PreimageKeyType::Local | PreimageKeyType::GlobalGeneric => None,
+            // Blob keys are `keccak256(commitment ++ z)` and precompile keys are
+            // `keccak256(address ++ input)` — neither can be re-derived from the
+            // stored value alone, so we skip them.
+            PreimageKeyType::Blob | PreimageKeyType::Precompile => None,
+        };
+
+        if let Some(hash) = expected_hash {
+            if key != &PreimageKey::new(hash, key.key_type()) {
+                return Err(NitroError::InvalidPreimage(*key));
+            }
+        }
+        Ok(())
+    }
+
+    fn check_preimages(preimages: &HashMap<PreimageKey, Vec<u8>>) -> crate::Result<()> {
+        for (key, value) in preimages {
+            Self::check_preimage(key, value)?;
+        }
+        Ok(())
     }
 
     /// Consume the oracle and return all captured preimages.
@@ -103,18 +148,74 @@ impl WitnessOracle for Oracle {
 
 #[cfg(test)]
 mod tests {
+    use alloy_primitives::keccak256;
     use base_proof_preimage::PreimageKeyType;
+    use sha2::Digest;
 
     use super::*;
 
     #[test]
-    fn new_roundtrip() {
+    fn new_roundtrip_local() {
         let key = PreimageKey::new([1u8; 32], PreimageKeyType::Local);
         let value = vec![0xAB; 128];
 
-        let oracle = Oracle::new(vec![(key, value.clone())]);
+        let oracle = Oracle::new(vec![(key, value.clone())]).unwrap();
         let read = oracle.preimages.read();
         assert_eq!(read.get(&key).unwrap(), &value);
+    }
+
+    #[test]
+    fn new_accepts_valid_keccak256() {
+        let value = b"hello world";
+        let digest = keccak256(value).0;
+        let key = PreimageKey::new(digest, PreimageKeyType::Keccak256);
+
+        let oracle = Oracle::new(vec![(key, value.to_vec())]);
+        assert!(oracle.is_ok());
+    }
+
+    #[test]
+    fn new_accepts_valid_sha256() {
+        let value = b"hello world";
+        let digest: [u8; 32] = sha2::Sha256::digest(value).into();
+        let key = PreimageKey::new(digest, PreimageKeyType::Sha256);
+
+        let oracle = Oracle::new(vec![(key, value.to_vec())]);
+        assert!(oracle.is_ok());
+    }
+
+    #[test]
+    fn new_rejects_invalid_keccak256() {
+        let value = b"hello world";
+        let wrong_key = PreimageKey::new([0xAA; 32], PreimageKeyType::Keccak256);
+
+        let result = Oracle::new(vec![(wrong_key, value.to_vec())]);
+        assert!(matches!(result, Err(NitroError::InvalidPreimage(_))));
+    }
+
+    #[test]
+    fn new_rejects_invalid_sha256() {
+        let value = b"hello world";
+        let wrong_key = PreimageKey::new([0xBB; 32], PreimageKeyType::Sha256);
+
+        let result = Oracle::new(vec![(wrong_key, value.to_vec())]);
+        assert!(matches!(result, Err(NitroError::InvalidPreimage(_))));
+    }
+
+    #[test]
+    fn new_accepts_local_without_hash_check() {
+        let key = PreimageKey::new([0xFF; 32], PreimageKeyType::Local);
+        let value = vec![0xDE, 0xAD];
+
+        assert!(Oracle::new(vec![(key, value)]).is_ok());
+    }
+
+    #[test]
+    fn new_accepts_global_generic_without_hash_check() {
+        let key = PreimageKey::new([0xFF; 32], PreimageKeyType::GlobalGeneric);
+        let value = vec![0xBE, 0xEF];
+
+        assert!(Oracle::new(vec![(key, value)]).is_ok());
     }
 
     #[tokio::test]

--- a/crates/proof/tee/nitro-enclave/src/oracle.rs
+++ b/crates/proof/tee/nitro-enclave/src/oracle.rs
@@ -48,7 +48,7 @@ impl Oracle {
     ///
     /// For [`PreimageKeyType::Keccak256`] keys the keccak256 digest of `value`
     /// must produce a key equal to `key`. For [`PreimageKeyType::Sha256`] keys
-    /// the SHA-256 digest is checked instead. Local and GlobalGeneric keys are
+    /// the SHA-256 digest is checked instead. Local and `GlobalGeneric` keys are
     /// context-dependent and cannot be verified by hash, so they are accepted
     /// without validation.
     ///
@@ -58,17 +58,20 @@ impl Oracle {
         let expected_hash: Option<[u8; 32]> = match key.key_type() {
             PreimageKeyType::Keccak256 => Some(keccak256(value).0),
             PreimageKeyType::Sha256 => Some(sha2::Sha256::digest(value).into()),
-            PreimageKeyType::Local | PreimageKeyType::GlobalGeneric => None,
             // Blob keys are `keccak256(commitment ++ z)` and precompile keys are
             // `keccak256(address ++ input)` — neither can be re-derived from the
-            // stored value alone, so we skip them.
-            PreimageKeyType::Blob | PreimageKeyType::Precompile => None,
+            // stored value alone, so we skip verifying them here and instead verify them
+            // during derivation.
+            PreimageKeyType::Local
+            | PreimageKeyType::GlobalGeneric
+            | PreimageKeyType::Blob
+            | PreimageKeyType::Precompile => None,
         };
 
-        if let Some(hash) = expected_hash {
-            if key != &PreimageKey::new(hash, key.key_type()) {
-                return Err(NitroError::InvalidPreimage(*key));
-            }
+        if let Some(hash) = expected_hash
+            && key != &PreimageKey::new(hash, key.key_type())
+        {
+            return Err(NitroError::InvalidPreimage(*key));
         }
         Ok(())
     }

--- a/crates/proof/tee/nitro-enclave/src/server.rs
+++ b/crates/proof/tee/nitro-enclave/src/server.rs
@@ -145,7 +145,7 @@ impl Server {
         &self,
         preimages: impl IntoIterator<Item = (PreimageKey, Vec<u8>)>,
     ) -> Result<TeeProofResult> {
-        let oracle = Oracle::new(preimages);
+        let oracle = Oracle::new(preimages)?;
 
         let boot_info =
             BootInfo::load(&oracle).await.map_err(|e| NitroError::ProofPipeline(e.to_string()))?;


### PR DESCRIPTION
## Summary

Closes the trust boundary gap in the nitro-enclave oracle: previously the enclave accepted all host-supplied preimages without verification, allowing a compromised host to fabricate any output root.

- **Preimage hash validation**: `Oracle::new()` now verifies every Keccak256/Sha256-keyed preimage against its key before accepting it (mirrors [op-succinct's `check_preimage()`](https://github.com/succinctlabs/op-succinct/blob/main/utils/client/src/witness/preimage_store.rs))
- **Blob KZG commitment verification**: After reconstructing a blob from its 4096 field elements, `OracleBlobProvider::get_blob()` recomputes the KZG commitment and compares it to the fetched commitment (gated behind `#[cfg(feature = "std")]` to preserve `no_std` compatibility)
- Adds `NitroError::InvalidPreimage` and `OracleProviderError::BlobVerification` error variants
- Enables `std` feature on `base-proof-client` in the nitro-enclave to activate blob verification

### Trust chain after this PR

| Data path | Validation |
|-----------|-----------|
| L1/L2 trie nodes | Keccak256 key = hash of value ✅ |
| Sha256-keyed preimages | Sha256 key = hash of value ✅ |
| Blob commitments | Sha256 key validated ✅ |
| Blob field elements | KZG commitment recomputed from reconstructed blob ✅ |
| Local/GlobalGeneric keys | No hash to verify (context-dependent, same as op-succinct) |

### Testing

- 7 new unit tests for preimage validation (valid/invalid keccak256, sha256, local, global_generic)
- All 34 nitro-enclave tests pass
- All 7 base-proof tests pass (including `test_roots_of_unity`)
- Builds clean with and without `std` feature