### PR TITLE
refactor(challenger): support three dispute paths with game classification

### DIFF
--- a/crates/proof/challenge/src/driver.rs
+++ b/crates/proof/challenge/src/driver.rs
@@ -1,8 +1,16 @@
 //! Main driver loop for the challenger service.
 //!
 //! The [`Driver`] ties together all challenger components — scanning for
-//! invalid dispute games, validating output roots, requesting ZK proofs, and
-//! submitting nullification transactions — into a single polling loop.
+//! invalid dispute games, validating output roots, requesting proofs, and
+//! submitting dispute transactions — into a single polling loop.
+//!
+//! Three dispute paths are supported:
+//!
+//! 1. **Wrong TEE proof** — nullify with a TEE proof (`nullify()`) or
+//!    challenge with a ZK proof (`challenge()`).
+//! 2. **Correct TEE proof challenged with a wrong ZK proof** — nullify
+//!    the fraudulent ZK challenge with a ZK proof (`nullify()`).
+//! 3. **Wrong ZK proposal** — nullify with a ZK proof (`nullify()`).
 
 use std::{
     sync::{
@@ -26,7 +34,7 @@ use tracing::{debug, info, warn};
 use uuid::Uuid;
 
 use crate::{
-    CandidateGame, ChallengeSubmitter, ChallengerMetrics, GameScanner,
+    CandidateGame, ChallengeSubmitter, ChallengerMetrics, DisputeIntent, GameCategory, GameScanner,
     IntermediateValidationParams, L1HeadProvider, OutputValidator, PendingProof, PendingProofs,
     ProofPhase, ProofUpdate, ValidatorError,
 };
@@ -195,7 +203,8 @@ impl<L2: L2Provider, P: ZkProofProvider, T: TxManager> Driver<L2, P, T> {
         }
     }
 
-    /// Processes a single candidate game: validate, prove if invalid, submit.
+    /// Processes a single candidate game by dispatching to the appropriate
+    /// handler based on the game's [`GameCategory`].
     async fn process_candidate(&mut self, candidate: CandidateGame) -> eyre::Result<()> {
         let game_address = candidate.factory.proxy;
 
@@ -205,6 +214,30 @@ impl<L2: L2Provider, P: ZkProofProvider, T: TxManager> Driver<L2, P, T> {
             debug!(game = %game_address, "skipping game with pending proof session");
             return Ok(());
         }
+
+        match candidate.category {
+            GameCategory::InvalidTeeProposal => {
+                self.process_invalid_proposal(candidate, DisputeIntent::Challenge).await
+            }
+            GameCategory::FraudulentZkChallenge { challenged_index } => {
+                self.process_fraudulent_zk_challenge(candidate, challenged_index).await
+            }
+            GameCategory::InvalidZkProposal => {
+                self.process_invalid_proposal(candidate, DisputeIntent::Nullify).await
+            }
+        }
+    }
+
+    /// Fetches intermediate roots and validates them against the local L2 node.
+    ///
+    /// Returns `Ok(Some((result, roots)))` when validation completes, or
+    /// `Ok(None)` when a transient error (e.g. block not yet available) means
+    /// the game should be skipped this tick. Permanent errors are propagated.
+    async fn validate_game(
+        &self,
+        candidate: &CandidateGame,
+    ) -> eyre::Result<Option<(crate::ValidationResult, Vec<B256>)>> {
+        let game_address = candidate.factory.proxy;
 
         let intermediate_roots =
             self.verifier_client.intermediate_output_roots(game_address).await?;
@@ -218,8 +251,8 @@ impl<L2: L2Provider, P: ZkProofProvider, T: TxManager> Driver<L2, P, T> {
             intermediate_roots: &intermediate_roots,
         };
 
-        let result = match self.validator.validate_intermediate_roots(params).await {
-            Ok(r) => r,
+        match self.validator.validate_intermediate_roots(params).await {
+            Ok(result) => Ok(Some((result, intermediate_roots))),
             Err(e) => {
                 match &e {
                     ValidatorError::BlockNotAvailable { .. } => {
@@ -237,8 +270,26 @@ impl<L2: L2Provider, P: ZkProofProvider, T: TxManager> Driver<L2, P, T> {
                         );
                     }
                 }
-                return Ok(());
+                Ok(None)
             }
+        }
+    }
+
+    /// Processes a game whose proposal may contain an invalid intermediate
+    /// root (Path 1: wrong TEE proof, Path 3: wrong ZK proof).
+    ///
+    /// Validates the intermediate roots against the local L2 node. If a
+    /// mismatch is found, initiates a proof with the given `intent`.
+    async fn process_invalid_proposal(
+        &mut self,
+        candidate: CandidateGame,
+        intent: DisputeIntent,
+    ) -> eyre::Result<()> {
+        let game_address = candidate.factory.proxy;
+
+        let result = match self.validate_game(&candidate).await? {
+            Some((result, _)) => result,
+            None => return Ok(()),
         };
 
         if result.is_valid {
@@ -256,23 +307,118 @@ impl<L2: L2Provider, P: ZkProofProvider, T: TxManager> Driver<L2, P, T> {
             game = %game_address,
             invalid_index = invalid_index,
             expected_root = %expected_root,
+            intent = ?intent,
             "invalid intermediate root detected, requesting proof"
         );
 
-        self.initiate_proof(candidate, invalid_index, expected_root).await
+        ChallengerMetrics::games_invalid_total().increment(1);
+        if intent == DisputeIntent::Nullify {
+            ChallengerMetrics::invalid_zk_proposal_detected_total().increment(1);
+        }
+
+        self.initiate_proof(candidate, invalid_index, expected_root, intent).await
+    }
+
+    /// Processes a game whose correct TEE proposal has been challenged with
+    /// a potentially fraudulent ZK proof (Path 2).
+    ///
+    /// Validates the originally proposed root at the challenged index. If the
+    /// original root is correct, the ZK challenge was fraudulent and a ZK
+    /// proof is submitted via `nullify()` to refute it.
+    async fn process_fraudulent_zk_challenge(
+        &mut self,
+        candidate: CandidateGame,
+        challenged_index: u64,
+    ) -> eyre::Result<()> {
+        let game_address = candidate.factory.proxy;
+
+        let (result, intermediate_roots) = match self.validate_game(&candidate).await? {
+            Some(pair) => pair,
+            None => return Ok(()),
+        };
+
+        // For Path 2: If the original proposal's root at the challenged index
+        // is valid, the ZK challenge was fraudulent. If it's invalid, the
+        // challenge was legitimate — skip.
+        //
+        // The validator scans intermediate roots sequentially and reports the
+        // first invalid index. If `first_invalid <= challenged_index`, the
+        // root at the challenged index (or an earlier one) was wrong, so the
+        // ZK challenge was legitimate.
+        if !result.is_valid {
+            match result.invalid_intermediate_index {
+                Some(first_invalid) if (first_invalid as u64) <= challenged_index => {
+                    debug!(
+                        game = %game_address,
+                        challenged_index = challenged_index,
+                        first_invalid_index = first_invalid,
+                        "ZK challenge is legitimate (original root was wrong), skipping"
+                    );
+                    return Ok(());
+                }
+                None => {
+                    // Validation says invalid but no specific index was identified.
+                    // Cannot confirm the challenged root is correct, so skip to
+                    // avoid submitting a potentially wrong nullification.
+                    warn!(
+                        game = %game_address,
+                        challenged_index = challenged_index,
+                        "validation returned invalid without specific index, skipping"
+                    );
+                    return Ok(());
+                }
+                Some(_) => {
+                    // first_invalid > challenged_index: all roots up to and
+                    // including the challenged index are valid, so the ZK
+                    // challenge was fraudulent. Fall through to nullify.
+                }
+            }
+        }
+
+        // The on-chain root at the challenged index is correct.
+        // Use the on-chain root value as `intermediateRootToProve` — the
+        // contract requires it to match `intermediateOutputRoot(index)`.
+        let on_chain_root =
+            intermediate_roots.get(challenged_index as usize).copied().ok_or_else(|| {
+                eyre::eyre!(
+                    "challenged_index {challenged_index} out of bounds \
+                     (game has {} intermediate roots)",
+                    intermediate_roots.len()
+                )
+            })?;
+
+        info!(
+            game = %game_address,
+            challenged_index = challenged_index,
+            on_chain_root = %on_chain_root,
+            "fraudulent ZK challenge detected, nullifying with ZK proof"
+        );
+
+        ChallengerMetrics::fraudulent_zk_challenge_detected_total().increment(1);
+
+        self.initiate_zk_proof(candidate, challenged_index, on_chain_root, DisputeIntent::Nullify)
+            .await
     }
 
     /// Attempts TEE-first proof sourcing with ZK fallback.
+    ///
+    /// The `intent` determines the on-chain action. For Path 1
+    /// ([`DisputeIntent::Challenge`]) the ZK proof targets `challenge()`.
+    /// TEE proofs always use `nullify()` regardless of `intent`.
     async fn initiate_proof(
         &mut self,
         candidate: CandidateGame,
         invalid_index: u64,
         expected_root: B256,
+        intent: DisputeIntent,
     ) -> eyre::Result<()> {
         let game_address = candidate.factory.proxy;
 
         // TEE-first: try if game has a TEE prover and we have a TEE config.
+        // TEE proofs only make sense when the intent is to challenge a TEE
+        // proposal — TEE nullification replaces the bad TEE proof.
         if candidate.tee_prover != Address::ZERO
+            && intent == DisputeIntent::Challenge
             && let Some(tee) = &self.tee
         {
             ChallengerMetrics::tee_proof_attempts_total().increment(1);
@@ -308,8 +454,8 @@ impl<L2: L2Provider, P: ZkProofProvider, T: TxManager> Driver<L2, P, T> {
             ChallengerMetrics::tee_proof_fallback_total().increment(1);
         }
 
-        // ZK fallback (or direct ZK if no TEE prover).
-        self.initiate_zk_proof(candidate, invalid_index, expected_root).await
+        // ZK fallback (or direct ZK if no TEE prover / intent is Nullify).
+        self.initiate_zk_proof(candidate, invalid_index, expected_root, intent).await
     }
 
     /// Attempts to obtain a TEE proof for the given candidate game.
@@ -374,6 +520,7 @@ impl<L2: L2Provider, P: ZkProofProvider, T: TxManager> Driver<L2, P, T> {
         candidate: CandidateGame,
         invalid_index: u64,
         expected_root: B256,
+        intent: DisputeIntent,
     ) -> eyre::Result<()> {
         let game_address = candidate.factory.proxy;
 
@@ -403,7 +550,8 @@ impl<L2: L2Provider, P: ZkProofProvider, T: TxManager> Driver<L2, P, T> {
             "proof job initiated"
         );
 
-        let pending = PendingProof::awaiting(session_id, invalid_index, expected_root, request);
+        let pending =
+            PendingProof::awaiting(session_id, invalid_index, expected_root, request, intent);
         self.pending_proofs.insert(game_address, pending);
 
         if let Err(e) = self.poll_or_submit(game_address).await {
@@ -421,32 +569,57 @@ impl<L2: L2Provider, P: ZkProofProvider, T: TxManager> Driver<L2, P, T> {
     ///   - `Failed` → transitions to `NeedsRetry` so `prove_block` is
     ///     re-initiated.
     ///   - Intermediate (`Created`/`Pending`/`Running`) → returns early.
-    /// - **`ReadyToSubmit`** — submits the nullification tx:
+    /// - **`ReadyToSubmit`** — submits the dispute tx based on the entry's
+    ///   [`DisputeIntent`]:
+    ///   - [`DisputeIntent::Nullify`] → calls `nullify()`.
+    ///   - [`DisputeIntent::Challenge`] → calls `challenge()`.
     ///   - On success → removes the entry.
     ///   - On failure → leaves the entry so it is retried next tick.
     /// - **`NeedsRetry`** — re-initiates `prove_block`:
     ///   - If `retry_count > MAX_PROOF_RETRIES` → drops the entry.
     ///   - Otherwise → calls `prove_block` and transitions to `AwaitingProof`.
     async fn poll_or_submit(&mut self, game_address: Address) -> eyre::Result<()> {
-        let (invalid_index, expected_root) = match self.pending_proofs.get(&game_address) {
-            Some(p) => (p.invalid_index, p.expected_root),
+        let (invalid_index, expected_root, intent) = match self.pending_proofs.get(&game_address) {
+            Some(p) => (p.invalid_index, p.expected_root, p.intent),
             None => return Ok(()),
         };
 
-        // Check if the game is still challengeable before doing any work.
-        let (status, zk_prover) = tokio::try_join!(
-            self.verifier_client.status(game_address),
-            self.verifier_client.zk_prover(game_address),
-        )?;
-        if status != GameScanner::STATUS_IN_PROGRESS {
-            debug!(game = %game_address, status = status, "game no longer in progress, dropping pending proof");
-            self.pending_proofs.remove(&game_address);
-            return Ok(());
-        }
-        if zk_prover != Address::ZERO {
-            debug!(game = %game_address, zk_prover = %zk_prover, "game already challenged, dropping pending proof");
-            self.pending_proofs.remove(&game_address);
-            return Ok(());
+        // Check if the game is still actionable before doing any work.
+        // For Challenge intents, also verify that the TEE proof still exists
+        // and no ZK proof has been submitted yet — fetch in parallel with
+        // status to avoid an extra round-trip.
+        if intent == DisputeIntent::Challenge {
+            let (status, zk_prover, tee_prover) = tokio::try_join!(
+                self.verifier_client.status(game_address),
+                self.verifier_client.zk_prover(game_address),
+                self.verifier_client.tee_prover(game_address),
+            )?;
+            if status != GameScanner::STATUS_IN_PROGRESS {
+                debug!(game = %game_address, status = status, "game no longer in progress, dropping pending proof");
+                self.pending_proofs.remove(&game_address);
+                return Ok(());
+            }
+            if zk_prover != Address::ZERO {
+                debug!(game = %game_address, zk_prover = %zk_prover, "game already challenged, dropping pending proof");
+                self.pending_proofs.remove(&game_address);
+                return Ok(());
+            }
+            if tee_prover == Address::ZERO {
+                debug!(game = %game_address, "game already nullified (both provers zeroed), dropping pending proof");
+                self.pending_proofs.remove(&game_address);
+                return Ok(());
+            }
+        } else {
+            // For Nullify intents (Paths 1-TEE, 2, 3) the contract itself
+            // validates that the target proof type still exists. We only
+            // check the game status and let the contract revert if the
+            // prover state changed between our check and submission.
+            let status = self.verifier_client.status(game_address).await?;
+            if status != GameScanner::STATUS_IN_PROGRESS {
+                debug!(game = %game_address, status = status, "game no longer in progress, dropping pending proof");
+                self.pending_proofs.remove(&game_address);
+                return Ok(());
+            }
         }
 
         // Resolve the proof bytes — either by polling the ZK service or
@@ -456,7 +629,8 @@ impl<L2: L2Provider, P: ZkProofProvider, T: TxManager> Driver<L2, P, T> {
                 info!(
                     game = %game_address,
                     proof_len = proof_bytes.len(),
-                    "proof ready, submitting nullification"
+                    action = intent.label(),
+                    "proof ready, submitting dispute transaction"
                 );
                 proof_bytes
             }
@@ -470,12 +644,12 @@ impl<L2: L2Provider, P: ZkProofProvider, T: TxManager> Driver<L2, P, T> {
             None => return Ok(()),
         };
 
-        // ── Submit nullification ─────────────────────────────────────────
-        match self
+        // ── Submit dispute transaction ────────────────────────────────────
+        let result = self
             .submitter
-            .submit_nullification(game_address, proof_bytes, invalid_index, expected_root)
-            .await
-        {
+            .submit_dispute(game_address, proof_bytes, invalid_index, expected_root, intent)
+            .await;
+        match result {
             Ok(_) => {
                 self.pending_proofs.remove(&game_address);
             }
@@ -483,7 +657,7 @@ impl<L2: L2Provider, P: ZkProofProvider, T: TxManager> Driver<L2, P, T> {
                 warn!(
                     error = %e,
                     game = %game_address,
-                    "nullification tx failed, will retry next tick"
+                    "dispute tx failed, will retry next tick"
                 );
                 // Leave entry as ReadyToSubmit for retry.
             }

--- a/crates/proof/challenge/src/driver.rs
+++ b/crates/proof/challenge/src/driver.rs
@@ -347,7 +347,9 @@ impl<L2: L2Provider, P: ZkProofProvider, T: TxManager> Driver<L2, P, T> {
         // ZK challenge was legitimate.
         if !result.is_valid {
             match result.invalid_intermediate_index {
-                Some(first_invalid) if (first_invalid as u64) <= challenged_index => {
+                Some(first_invalid)
+                    if u64::try_from(first_invalid).unwrap_or(u64::MAX) <= challenged_index =>
+                {
                     debug!(
                         game = %game_address,
                         challenged_index = challenged_index,

--- a/crates/proof/challenge/src/driver.rs
+++ b/crates/proof/challenge/src/driver.rs
@@ -276,8 +276,7 @@ impl<L2: L2Provider, P: ZkProofProvider, T: TxManager> Driver<L2, P, T> {
             && let Some(tee) = &self.tee
         {
             ChallengerMetrics::tee_proof_attempts_total().increment(1);
-            let tee_fut =
-                self.attempt_tee_proof(&candidate, invalid_index, expected_root, tee);
+            let tee_fut = self.attempt_tee_proof(&candidate, invalid_index, expected_root, tee);
             match tokio::time::timeout(tee.request_timeout, tee_fut).await {
                 Err(_elapsed) => {
                     warn!(

--- a/crates/proof/challenge/src/driver.rs
+++ b/crates/proof/challenge/src/driver.rs
@@ -615,13 +615,23 @@ impl<L2: L2Provider, P: ZkProofProvider, T: TxManager> Driver<L2, P, T> {
                 return Ok(());
             }
         } else {
-            // For Nullify intents (Paths 1-TEE, 2, 3) the contract itself
-            // validates that the target proof type still exists. We only
-            // check the game status and let the contract revert if the
-            // prover state changed between our check and submission.
-            let status = self.verifier_client.status(game_address).await?;
+            // For Nullify intents, check status AND prover addresses.
+            // Nullification zeroes the target prover but does NOT change
+            // the game status (it stays IN_PROGRESS), so checking status
+            // alone would cause infinite retries after a successful
+            // nullification.
+            let (status, tee_prover, zk_prover) = tokio::try_join!(
+                self.verifier_client.status(game_address),
+                self.verifier_client.tee_prover(game_address),
+                self.verifier_client.zk_prover(game_address),
+            )?;
             if status != GameScanner::STATUS_IN_PROGRESS {
                 debug!(game = %game_address, status = status, "game no longer in progress, dropping pending proof");
+                self.pending_proofs.remove(&game_address);
+                return Ok(());
+            }
+            if tee_prover == Address::ZERO && zk_prover == Address::ZERO {
+                debug!(game = %game_address, "game already nullified (both provers zeroed), dropping pending proof");
                 self.pending_proofs.remove(&game_address);
                 return Ok(());
             }

--- a/crates/proof/challenge/src/driver.rs
+++ b/crates/proof/challenge/src/driver.rs
@@ -584,10 +584,11 @@ impl<L2: L2Provider, P: ZkProofProvider, T: TxManager> Driver<L2, P, T> {
     ///   - If `retry_count > MAX_PROOF_RETRIES` → drops the entry.
     ///   - Otherwise → calls `prove_block` and transitions to `AwaitingProof`.
     async fn poll_or_submit(&mut self, game_address: Address) -> eyre::Result<()> {
-        let (invalid_index, expected_root, intent) = match self.pending_proofs.get(&game_address) {
-            Some(p) => (p.invalid_index, p.expected_root, p.intent),
-            None => return Ok(()),
-        };
+        let (invalid_index, expected_root, intent, targets_tee) =
+            match self.pending_proofs.get(&game_address) {
+                Some(p) => (p.invalid_index, p.expected_root, p.intent, p.prove_request.is_none()),
+                None => return Ok(()),
+            };
 
         // Check if the game is still actionable before doing any work.
         // For Challenge intents, also verify that the TEE proof still exists
@@ -615,11 +616,19 @@ impl<L2: L2Provider, P: ZkProofProvider, T: TxManager> Driver<L2, P, T> {
                 return Ok(());
             }
         } else {
-            // For Nullify intents, check status AND prover addresses.
-            // Nullification zeroes the target prover but does NOT change
-            // the game status (it stays IN_PROGRESS), so checking status
-            // alone would cause infinite retries after a successful
+            // For Nullify intents, check status AND whether the targeted
+            // prover has been zeroed. Nullification zeroes only the
+            // specific prover (TEE or ZK) but does NOT change the game
+            // status (it stays IN_PROGRESS), so checking status alone
+            // would cause infinite retries after a successful
             // nullification.
+            //
+            // TEE proofs (prove_request == None) target `teeProver`;
+            // ZK proofs target `zkProver`. Checking only the relevant
+            // prover avoids an infinite revert-retry loop in Path 2
+            // (fraudulent ZK challenge on a valid TEE proposal), where
+            // nullification zeroes `zkProver` but leaves `teeProver`
+            // intact.
             let (status, tee_prover, zk_prover) = tokio::try_join!(
                 self.verifier_client.status(game_address),
                 self.verifier_client.tee_prover(game_address),
@@ -630,8 +639,16 @@ impl<L2: L2Provider, P: ZkProofProvider, T: TxManager> Driver<L2, P, T> {
                 self.pending_proofs.remove(&game_address);
                 return Ok(());
             }
-            if tee_prover == Address::ZERO && zk_prover == Address::ZERO {
-                debug!(game = %game_address, "game already nullified (both provers zeroed), dropping pending proof");
+            let target_prover_zeroed =
+                if targets_tee { tee_prover == Address::ZERO } else { zk_prover == Address::ZERO };
+            if target_prover_zeroed {
+                debug!(
+                    game = %game_address,
+                    targets_tee = targets_tee,
+                    tee_prover = %tee_prover,
+                    zk_prover = %zk_prover,
+                    "game already nullified (target prover zeroed), dropping pending proof"
+                );
                 self.pending_proofs.remove(&game_address);
                 return Ok(());
             }

--- a/crates/proof/challenge/src/driver.rs
+++ b/crates/proof/challenge/src/driver.rs
@@ -475,12 +475,16 @@ impl<L2: L2Provider, P: ZkProofProvider, T: TxManager> Driver<L2, P, T> {
             .checked_add(candidate.intermediate_block_interval)
             .ok_or_else(|| eyre::eyre!("claimed_l2_block_number overflow"))?;
 
-        // Fetch L1 finalized head and compute agreed L2 state concurrently.
-        let (l1_head_result, output_root_result) = tokio::join!(
-            tee.l1_head_provider.finalized_head(),
+        // Use the game's stored L1 head (from CWIA) so the enclave signs a
+        // journal whose `l1OriginHash` matches what the on-chain `nullify()`
+        // will use for verification. Look up its block number concurrently
+        // with the agreed L2 state computation.
+        let l1_head = candidate.l1_head;
+        let (l1_head_number_result, output_root_result) = tokio::join!(
+            tee.l1_head_provider.block_number_by_hash(l1_head),
             self.validator.compute_output_root_with_hash(start_block_number),
         );
-        let (l1_head, l1_head_number) = l1_head_result?;
+        let l1_head_number = l1_head_number_result?;
         let (agreed_l2_head_hash, agreed_l2_output_root) = output_root_result?;
 
         let request = TeeProofRequest {
@@ -497,7 +501,9 @@ impl<L2: L2Provider, P: ZkProofProvider, T: TxManager> Driver<L2, P, T> {
 
         let result = tee.provider.prove(request).await.map_err(|e| eyre::eyre!(e))?;
 
-        // Validate that the TEE computed the expected output root and encode the proof.
+        // Validate that the TEE computed the expected output root and encode
+        // the proof in compact format (type + signature only, no L1 origin
+        // data — the contract already has it in CWIA).
         match &result {
             ProofResult::Tee { aggregate_proposal, .. } => {
                 if aggregate_proposal.output_root != expected_root {
@@ -506,12 +512,8 @@ impl<L2: L2Provider, P: ZkProofProvider, T: TxManager> Driver<L2, P, T> {
                         aggregate_proposal.output_root
                     ));
                 }
-                ProofEncoder::encode_proof_bytes(
-                    &aggregate_proposal.signature,
-                    aggregate_proposal.l1_origin_hash,
-                    aggregate_proposal.l1_origin_number,
-                )
-                .map_err(|e| eyre::eyre!("TEE proof encoding failed: {e}"))
+                ProofEncoder::encode_dispute_proof_bytes(&aggregate_proposal.signature)
+                    .map_err(|e| eyre::eyre!("TEE proof encoding failed: {e}"))
             }
             ProofResult::Zk { .. } => Err(eyre::eyre!("TEE provider returned ZK result")),
         }

--- a/crates/proof/challenge/src/driver.rs
+++ b/crates/proof/challenge/src/driver.rs
@@ -259,7 +259,7 @@ impl<L2: L2Provider, P: ZkProofProvider, T: TxManager> Driver<L2, P, T> {
             "invalid intermediate root detected, requesting proof"
         );
 
-        self.initiate_proof(candidate, invalid_index, expected_root, &intermediate_roots).await
+        self.initiate_proof(candidate, invalid_index, expected_root).await
     }
 
     /// Attempts TEE-first proof sourcing with ZK fallback.
@@ -268,7 +268,6 @@ impl<L2: L2Provider, P: ZkProofProvider, T: TxManager> Driver<L2, P, T> {
         candidate: CandidateGame,
         invalid_index: u64,
         expected_root: B256,
-        intermediate_roots: &[B256],
     ) -> eyre::Result<()> {
         let game_address = candidate.factory.proxy;
 
@@ -277,13 +276,8 @@ impl<L2: L2Provider, P: ZkProofProvider, T: TxManager> Driver<L2, P, T> {
             && let Some(tee) = &self.tee
         {
             ChallengerMetrics::tee_proof_attempts_total().increment(1);
-            let tee_fut = self.attempt_tee_proof(
-                &candidate,
-                invalid_index,
-                expected_root,
-                intermediate_roots,
-                tee,
-            );
+            let tee_fut =
+                self.attempt_tee_proof(&candidate, invalid_index, expected_root, tee);
             match tokio::time::timeout(tee.request_timeout, tee_fut).await {
                 Err(_elapsed) => {
                     warn!(
@@ -325,7 +319,6 @@ impl<L2: L2Provider, P: ZkProofProvider, T: TxManager> Driver<L2, P, T> {
         candidate: &CandidateGame,
         invalid_index: u64,
         expected_root: B256,
-        intermediate_roots: &[B256],
         tee: &TeeConfig,
     ) -> eyre::Result<Bytes> {
         let start_block_number = candidate.checkpoint_start_block(invalid_index)?;
@@ -342,21 +335,11 @@ impl<L2: L2Provider, P: ZkProofProvider, T: TxManager> Driver<L2, P, T> {
         let (l1_head, l1_head_number) = l1_head_result?;
         let (agreed_l2_head_hash, agreed_l2_output_root) = output_root_result?;
 
-        // The claimed root is the (wrong) on-chain root at the invalid index.
-        let invalid_idx = usize::try_from(invalid_index)
-            .map_err(|_| eyre::eyre!("invalid_index {invalid_index} overflows usize"))?;
-        let claimed_l2_output_root = *intermediate_roots.get(invalid_idx).ok_or_else(|| {
-            eyre::eyre!(
-                "invalid_index {invalid_index} out of bounds for intermediate_roots (len={})",
-                intermediate_roots.len()
-            )
-        })?;
-
         let request = TeeProofRequest {
             l1_head,
             agreed_l2_head_hash,
             agreed_l2_output_root,
-            claimed_l2_output_root,
+            claimed_l2_output_root: expected_root,
             claimed_l2_block_number,
             proposer: self.submitter.sender_address(),
             intermediate_block_interval: candidate.intermediate_block_interval,

--- a/crates/proof/challenge/src/driver.rs
+++ b/crates/proof/challenge/src/driver.rs
@@ -380,14 +380,15 @@ impl<L2: L2Provider, P: ZkProofProvider, T: TxManager> Driver<L2, P, T> {
         // The on-chain root at the challenged index is correct.
         // Use the on-chain root value as `intermediateRootToProve` — the
         // contract requires it to match `intermediateOutputRoot(index)`.
-        let on_chain_root =
-            intermediate_roots.get(challenged_index as usize).copied().ok_or_else(|| {
-                eyre::eyre!(
-                    "challenged_index {challenged_index} out of bounds \
+        let idx = usize::try_from(challenged_index)
+            .map_err(|_| eyre::eyre!("challenged_index {challenged_index} overflows usize"))?;
+        let on_chain_root = intermediate_roots.get(idx).copied().ok_or_else(|| {
+            eyre::eyre!(
+                "challenged_index {challenged_index} out of bounds \
                      (game has {} intermediate roots)",
-                    intermediate_roots.len()
-                )
-            })?;
+                intermediate_roots.len()
+            )
+        })?;
 
         info!(
             game = %game_address,

--- a/crates/proof/challenge/src/lib.rs
+++ b/crates/proof/challenge/src/lib.rs
@@ -16,7 +16,7 @@ mod driver;
 pub use driver::{Driver, DriverConfig, TeeConfig, derive_session_id};
 
 mod pending;
-pub use pending::{PendingProof, PendingProofs, ProofPhase, ProofUpdate};
+pub use pending::{DisputeIntent, PendingProof, PendingProofs, ProofPhase, ProofUpdate};
 
 mod error;
 pub use error::ChallengeSubmitError;
@@ -25,7 +25,7 @@ mod metrics;
 pub use metrics::ChallengerMetrics;
 
 mod scanner;
-pub use scanner::{CandidateGame, GameScanner, ScannerConfig};
+pub use scanner::{CandidateGame, GameCategory, GameScanner, ScannerConfig};
 
 mod service;
 pub use service::ChallengerService;

--- a/crates/proof/challenge/src/metrics.rs
+++ b/crates/proof/challenge/src/metrics.rs
@@ -31,6 +31,16 @@ base_metrics::define_metrics_struct! {
     #[describe("Latency in seconds for nullify transaction confirmation")]
     nullify_tx_latency_seconds: histogram,
 
+    #[describe("Total number of challenge transactions submitted")]
+    challenge_tx_submitted_total: counter,
+
+    #[describe("Total number of challenge transaction outcomes")]
+    #[label(status)]
+    challenge_tx_outcome_total: counter,
+
+    #[describe("Latency in seconds for challenge transaction confirmation")]
+    challenge_tx_latency_seconds: histogram,
+
     #[describe("Total number of proof retries after failure")]
     proof_retries_total: counter,
 
@@ -45,6 +55,12 @@ base_metrics::define_metrics_struct! {
 
     #[describe("Total number of TEE proof failures that fell back to ZK")]
     tee_proof_fallback_total: counter,
+
+    #[describe("Total number of fraudulent ZK challenges detected (Path 2)")]
+    fraudulent_zk_challenge_detected_total: counter,
+
+    #[describe("Total number of invalid ZK proposals detected (Path 3)")]
+    invalid_zk_proposal_detected_total: counter,
 }
 
 impl ChallengerMetrics {

--- a/crates/proof/challenge/src/pending.rs
+++ b/crates/proof/challenge/src/pending.rs
@@ -1,8 +1,11 @@
 //! Pending proof state machine and collection.
 //!
-//! [`PendingProofs`] tracks in-flight ZK proof sessions keyed by dispute-game
+//! [`PendingProofs`] tracks in-flight proof sessions keyed by dispute-game
 //! address. Each entry moves through a [`ProofPhase`] lifecycle:
 //! `AwaitingProof` → `ReadyToSubmit` (on success) or `NeedsRetry` (on failure).
+//!
+//! Each entry also carries a [`DisputeIntent`] that determines whether the
+//! completed proof will be submitted via `challenge()` or `nullify()` on-chain.
 
 use std::collections::HashMap;
 
@@ -14,6 +17,20 @@ use tracing::warn;
 
 /// Proof type byte for ZK proofs (matches `AggregateVerifier.nullify` discriminator: `0` = TEE, `1` = ZK).
 const ZK_PROOF_TYPE_BYTE: u8 = 0x01;
+
+/// The intended on-chain action for a completed proof.
+///
+/// A TEE proof always targets `nullify()`. A ZK proof may target either
+/// `challenge()` (Path 1: challenging a wrong TEE proposal) or `nullify()`
+/// (Path 2: nullifying a fraudulent ZK challenge, Path 3: nullifying a
+/// wrong ZK proposal).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DisputeIntent {
+    /// Submit via `challenge()` — challenges a TEE proof with a competing ZK proof.
+    Challenge,
+    /// Submit via `nullify()` — nullifies an existing proof.
+    Nullify,
+}
 
 /// Phase of a pending proof: awaiting the ZK service, ready for on-chain
 /// submission, or waiting for a retry after failure.
@@ -47,6 +64,8 @@ pub struct PendingProof {
     pub prove_request: Option<ProveBlockRequest>,
     /// Number of times this proof has been retried after failure.
     pub retry_count: u32,
+    /// The intended on-chain dispute action once the proof is ready.
+    pub intent: DisputeIntent,
 }
 
 impl PendingProof {
@@ -56,6 +75,7 @@ impl PendingProof {
         invalid_index: u64,
         expected_root: B256,
         prove_request: ProveBlockRequest,
+        intent: DisputeIntent,
     ) -> Self {
         Self {
             phase: ProofPhase::AwaitingProof { session_id },
@@ -63,6 +83,7 @@ impl PendingProof {
             expected_root,
             prove_request: Some(prove_request),
             retry_count: 0,
+            intent,
         }
     }
 
@@ -72,6 +93,7 @@ impl PendingProof {
         invalid_index: u64,
         expected_root: B256,
         prove_request: ProveBlockRequest,
+        intent: DisputeIntent,
     ) -> Self {
         Self {
             phase: ProofPhase::ReadyToSubmit { proof_bytes },
@@ -79,6 +101,7 @@ impl PendingProof {
             expected_root,
             prove_request: Some(prove_request),
             retry_count: 0,
+            intent,
         }
     }
 
@@ -86,6 +109,7 @@ impl PendingProof {
     ///
     /// Unlike [`ready`](Self::ready), this sets `prove_request` to `None` since
     /// TEE proofs don't have a ZK session to fall back to on retry failure.
+    /// TEE proofs always target `nullify()`.
     pub const fn ready_tee(proof_bytes: Bytes, invalid_index: u64, expected_root: B256) -> Self {
         Self {
             phase: ProofPhase::ReadyToSubmit { proof_bytes },
@@ -93,6 +117,7 @@ impl PendingProof {
             expected_root,
             prove_request: None,
             retry_count: 0,
+            intent: DisputeIntent::Nullify,
         }
     }
 

--- a/crates/proof/challenge/src/scanner.rs
+++ b/crates/proof/challenge/src/scanner.rs
@@ -1,13 +1,28 @@
 //! Game scanner for the challenger service.
 //!
 //! Scans the [`DisputeGameFactory`](base_proof_contracts::DisputeGameFactoryClient)
-//! for dispute games requiring validation. Each game is evaluated through a
-//! two-stage filter:
+//! for dispute games that require action. Each game is classified into one
+//! of three [`GameCategory`] variants based on its on-chain state:
 //!
-//! 1. **Status** — must be `IN_PROGRESS` ([`GameScanner::STATUS_IN_PROGRESS`]).
-//! 2. **Challenge state** — `zkProver` must be `Address::ZERO` (unchallenged).
+//! 1. **[`InvalidTeeProposal`](GameCategory::InvalidTeeProposal)** —
+//!    TEE-proposed game (`teeProver != 0`, `zkProver == 0`). The driver
+//!    validates the intermediate roots and, if invalid, nullifies with a
+//!    TEE proof or challenges with a ZK proof.
 //!
-//! Games passing both filters are returned as [`CandidateGame`] structs.
+//! 2. **[`FraudulentZkChallenge`](GameCategory::FraudulentZkChallenge)** —
+//!    A TEE-proposed game that has been challenged by a ZK proof
+//!    (`teeProver != 0`, `zkProver != 0`, `counteredByIntermediateRootIndexPlusOne > 0`).
+//!    The driver validates the originally proposed root at the challenged
+//!    index and, if the original was correct, nullifies the ZK challenge
+//!    with a ZK proof.
+//!
+//! 3. **[`InvalidZkProposal`](GameCategory::InvalidZkProposal)** —
+//!    ZK-proposed game (`teeProver == 0`, `zkProver != 0`, unchallenged).
+//!    The driver validates the intermediate roots and, if invalid,
+//!    nullifies with a ZK proof.
+//!
+//! Games that are not `IN_PROGRESS` or have been fully nullified (both
+//! provers zero) are skipped.
 
 use std::{
     collections::HashMap,
@@ -31,7 +46,35 @@ pub struct ScannerConfig {
     pub lookback_games: u64,
 }
 
-/// A dispute game that has been identified as a candidate for challenge.
+/// Classifies why a game was selected as a candidate and what action the
+/// driver should take.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum GameCategory {
+    /// Path 1: TEE-proposed game with a potentially wrong output root.
+    ///
+    /// The driver validates the intermediate roots. If invalid it either
+    /// nullifies with a TEE proof or challenges with a ZK proof.
+    InvalidTeeProposal,
+
+    /// Path 2: A TEE-proposed game was challenged with a potentially
+    /// fraudulent ZK proof.
+    ///
+    /// The driver validates the originally proposed root at the challenged
+    /// index. If the original root was actually correct, a ZK proof is
+    /// submitted via `nullify()` to refute the challenge.
+    FraudulentZkChallenge {
+        /// The 0-based index of the challenged intermediate root.
+        challenged_index: u64,
+    },
+
+    /// Path 3: ZK-proposed game with a potentially wrong output root.
+    ///
+    /// The driver validates the intermediate roots. If invalid it submits
+    /// a ZK proof via `nullify()` to nullify the incorrect ZK proposal.
+    InvalidZkProposal,
+}
+
+/// A dispute game that has been identified as a candidate for action.
 #[derive(Debug, Clone)]
 pub struct CandidateGame {
     /// The factory index of this game.
@@ -46,6 +89,8 @@ pub struct CandidateGame {
     pub intermediate_block_interval: u64,
     /// Address of the TEE prover for this game (`Address::ZERO` if none registered).
     pub tee_prover: Address,
+    /// Classification of this candidate and the action the driver should take.
+    pub category: GameCategory,
 }
 
 impl CandidateGame {
@@ -181,9 +226,10 @@ impl GameScanner {
 
     /// Evaluates a single game at the given factory index.
     ///
-    /// Returns `Some(CandidateGame)` if the game is `IN_PROGRESS` and has not
-    /// been challenged (`zkProver` == zero). Returns `None` if the game should
-    /// be skipped.
+    /// Returns `Some(CandidateGame)` if the game is `IN_PROGRESS` and
+    /// matches one of the three [`GameCategory`] variants. Returns `None`
+    /// if the game should be skipped (resolved, fully nullified, or in
+    /// an unrecognized state).
     pub async fn evaluate_game(&self, index: u64) -> Result<Option<CandidateGame>> {
         let factory = self.factory_client.game_at_index(index).await?;
 
@@ -193,21 +239,20 @@ impl GameScanner {
             return Ok(None);
         }
 
-        let zk_prover = self.verifier_client.zk_prover(factory.proxy).await?;
-        if zk_prover != Address::ZERO {
-            debug!(
-                index = index,
-                zk_prover = %zk_prover,
-                "skipping already-challenged game"
-            );
-            return Ok(None);
-        }
-
-        let (info, starting_block_number, tee_prover) = tokio::try_join!(
+        let (zk_prover, tee_prover, countered_index, info, starting_block_number) = tokio::try_join!(
+            self.verifier_client.zk_prover(factory.proxy),
+            self.verifier_client.tee_prover(factory.proxy),
+            self.verifier_client.countered_index(factory.proxy),
             self.verifier_client.game_info(factory.proxy),
             self.verifier_client.starting_block_number(factory.proxy),
-            self.verifier_client.tee_prover(factory.proxy),
         )?;
+
+        // Classify the game based on its prover state.
+        let category = Self::classify(index, tee_prover, zk_prover, countered_index);
+        let category = match category {
+            Some(c) => c,
+            None => return Ok(None),
+        };
 
         let intermediate_block_interval =
             self.resolve_intermediate_block_interval(factory.game_type).await?;
@@ -219,7 +264,58 @@ impl GameScanner {
             starting_block_number,
             intermediate_block_interval,
             tee_prover,
+            category,
         }))
+    }
+
+    /// Classifies a game into a [`GameCategory`] based on its prover state,
+    /// or returns `None` if the game should be skipped.
+    fn classify(
+        index: u64,
+        tee_prover: Address,
+        zk_prover: Address,
+        countered_index: u64,
+    ) -> Option<GameCategory> {
+        let has_tee = tee_prover != Address::ZERO;
+        let has_zk = zk_prover != Address::ZERO;
+
+        match (has_tee, has_zk, countered_index) {
+            // Path 1: TEE-proposed, unchallenged.
+            (true, false, 0) => Some(GameCategory::InvalidTeeProposal),
+
+            // Path 2: TEE-proposed and challenged by ZK.
+            (true, true, ci) if ci > 0 => {
+                Some(GameCategory::FraudulentZkChallenge { challenged_index: ci - 1 })
+            }
+
+            // TEE + ZK present but no countered index — second proof was added
+            // via `verifyProposalProof`, not via `challenge`. Skip.
+            (true, true, 0) => {
+                debug!(index = index, "skipping game with both proofs verified (no challenge)");
+                None
+            }
+
+            // Path 3: ZK-proposed, unchallenged.
+            (false, true, 0) => Some(GameCategory::InvalidZkProposal),
+
+            // Both provers zeroed — already nullified.
+            (false, false, _) => {
+                debug!(index = index, "skipping nullified game (both provers zeroed)");
+                None
+            }
+
+            // Defensive catch-all for any state not covered above.
+            _ => {
+                debug!(
+                    index = index,
+                    has_tee = has_tee,
+                    has_zk = has_zk,
+                    countered_index = countered_index,
+                    "skipping game in unexpected state"
+                );
+                None
+            }
+        }
     }
 
     /// Resolves the intermediate block interval for a game type, using a cache

--- a/crates/proof/challenge/src/scanner.rs
+++ b/crates/proof/challenge/src/scanner.rs
@@ -29,7 +29,7 @@ use std::{
     sync::{Arc, Mutex},
 };
 
-use alloy_primitives::Address;
+use alloy_primitives::{Address, B256};
 use base_proof_contracts::{
     AggregateVerifierClient, DisputeGameFactoryClient, GameAtIndex, GameInfo,
 };
@@ -87,6 +87,8 @@ pub struct CandidateGame {
     pub starting_block_number: u64,
     /// The intermediate block interval for this game's type.
     pub intermediate_block_interval: u64,
+    /// The L1 head block hash stored at game creation time.
+    pub l1_head: B256,
     /// Address of the TEE prover for this game (`Address::ZERO` if none registered).
     pub tee_prover: Address,
     /// Classification of this candidate and the action the driver should take.
@@ -239,12 +241,13 @@ impl GameScanner {
             return Ok(None);
         }
 
-        let (zk_prover, tee_prover, countered_index, info, starting_block_number) = tokio::try_join!(
+        let (zk_prover, tee_prover, countered_index, info, starting_block_number, l1_head) = tokio::try_join!(
             self.verifier_client.zk_prover(factory.proxy),
             self.verifier_client.tee_prover(factory.proxy),
             self.verifier_client.countered_index(factory.proxy),
             self.verifier_client.game_info(factory.proxy),
             self.verifier_client.starting_block_number(factory.proxy),
+            self.verifier_client.l1_head(factory.proxy),
         )?;
 
         // Classify the game based on its prover state.
@@ -263,6 +266,7 @@ impl GameScanner {
             info,
             starting_block_number,
             intermediate_block_interval,
+            l1_head,
             tee_prover,
             category,
         }))

--- a/crates/proof/challenge/src/scanner.rs
+++ b/crates/proof/challenge/src/scanner.rs
@@ -298,6 +298,17 @@ impl GameScanner {
             // Path 3: ZK-proposed, unchallenged.
             (false, true, 0) => Some(GameCategory::InvalidZkProposal),
 
+            // ZK-only game with a non-zero countered_index — unexpected state.
+            // A ZK-proposed game should not have a challenge counter set.
+            (false, true, ci) if ci > 0 => {
+                debug!(
+                    index = index,
+                    countered_index = ci,
+                    "skipping ZK-only game with unexpected non-zero countered_index"
+                );
+                None
+            }
+
             // Both provers zeroed — already nullified.
             (false, false, _) => {
                 debug!(index = index, "skipping nullified game (both provers zeroed)");

--- a/crates/proof/challenge/src/submitter.rs
+++ b/crates/proof/challenge/src/submitter.rs
@@ -1,15 +1,23 @@
-//! Challenge submission logic for nullifying invalid dispute games.
+//! Challenge submission logic for disputing invalid dispute games.
+//!
+//! Three dispute paths are supported:
+//!
+//! 1. **Wrong TEE proof** — `nullify()` with a TEE proof, or `challenge()`
+//!    with a ZK proof.
+//! 2. **Correct TEE proof challenged with a wrong ZK proof** — `nullify()`
+//!    with a ZK proof to refute the fraudulent challenge.
+//! 3. **Wrong ZK proposal** — `nullify()` with a ZK proof.
 
 use std::time::Instant;
 
 use alloy_primitives::{Address, B256, Bytes, U256};
-use base_proof_contracts::encode_nullify_calldata;
+use base_proof_contracts::{encode_challenge_calldata, encode_nullify_calldata};
 use base_tx_manager::{TxCandidate, TxManager};
 use tracing::info;
 
-use crate::{ChallengeSubmitError, ChallengerMetrics};
+use crate::{ChallengeSubmitError, ChallengerMetrics, DisputeIntent};
 
-/// Submits nullify transactions to dispute game contracts on L1.
+/// Submits dispute transactions (nullify or challenge) to game contracts on L1.
 #[derive(Debug)]
 pub struct ChallengeSubmitter<T> {
     tx_manager: T,
@@ -26,29 +34,47 @@ impl<T: TxManager> ChallengeSubmitter<T> {
         self.tx_manager.sender_address()
     }
 
-    /// Submits a `nullify()` transaction to the given dispute game contract.
+    /// Submits a dispute transaction (`nullify()` or `challenge()`) to the
+    /// given dispute game contract, based on the [`DisputeIntent`].
+    ///
+    /// - [`DisputeIntent::Nullify`] — used across all three dispute paths:
+    ///   TEE nullification of a wrong TEE proof (Path 1), ZK nullification
+    ///   of a fraudulent challenge (Path 2), and ZK nullification of a wrong
+    ///   ZK proposal (Path 3).
+    /// - [`DisputeIntent::Challenge`] — challenges a TEE proof with a
+    ///   competing ZK proof (Path 1). The game resolves as `CHALLENGER_WINS`
+    ///   if the challenge is not nullified.
     ///
     /// Returns the transaction hash on success, or an error if the transaction
     /// manager fails or the transaction reverts on-chain.
-    pub async fn submit_nullification(
+    pub async fn submit_dispute(
         &self,
         game_address: Address,
         proof_bytes: Bytes,
         intermediate_root_index: u64,
         intermediate_root_to_prove: B256,
+        intent: DisputeIntent,
     ) -> Result<B256, ChallengeSubmitError> {
-        let calldata = encode_nullify_calldata(
-            proof_bytes,
-            intermediate_root_index,
-            intermediate_root_to_prove,
-        );
+        let calldata = match intent {
+            DisputeIntent::Nullify => encode_nullify_calldata(
+                proof_bytes,
+                intermediate_root_index,
+                intermediate_root_to_prove,
+            ),
+            DisputeIntent::Challenge => encode_challenge_calldata(
+                proof_bytes,
+                intermediate_root_index,
+                intermediate_root_to_prove,
+            ),
+        };
 
         info!(
             game = %game_address,
+            action = intent.label(),
             intermediate_root_index,
             intermediate_root_to_prove = %intermediate_root_to_prove,
             calldata_len = calldata.len(),
-            "Nullifying dispute game"
+            "submitting dispute transaction"
         );
 
         let candidate = TxCandidate {
@@ -60,10 +86,10 @@ impl<T: TxManager> ChallengeSubmitter<T> {
 
         info!(
             tx = ?candidate,
-            "Sending tx candidate",
+            "sending tx candidate",
         );
 
-        ChallengerMetrics::nullify_tx_submitted_total().increment(1);
+        intent.record_submitted();
         let start = Instant::now();
         let result = self.tx_manager.send(candidate).await;
         let latency = start.elapsed();
@@ -73,8 +99,8 @@ impl<T: TxManager> ChallengeSubmitter<T> {
             Ok(_) => ChallengerMetrics::STATUS_REVERTED,
             Err(_) => ChallengerMetrics::STATUS_ERROR,
         };
-        ChallengerMetrics::nullify_tx_outcome_total(status_label).increment(1);
-        ChallengerMetrics::nullify_tx_latency_seconds().record(latency.as_secs_f64());
+        intent.record_outcome(status_label);
+        intent.record_latency(latency.as_secs_f64());
 
         let receipt = result?;
         let tx_hash = receipt.transaction_hash;
@@ -83,9 +109,44 @@ impl<T: TxManager> ChallengeSubmitter<T> {
             return Err(ChallengeSubmitError::TxReverted { tx_hash });
         }
 
-        info!(tx_hash = %tx_hash, game = %game_address, "nullify transaction confirmed");
+        info!(tx_hash = %tx_hash, game = %game_address, action = intent.label(), "dispute transaction confirmed");
 
         Ok(tx_hash)
+    }
+}
+
+/// Metrics recording helpers for [`DisputeIntent`].
+impl DisputeIntent {
+    /// Returns a human-readable label for logging and metrics.
+    pub const fn label(&self) -> &'static str {
+        match self {
+            Self::Nullify => "nullify",
+            Self::Challenge => "challenge",
+        }
+    }
+
+    /// Records that a dispute transaction has been submitted.
+    pub fn record_submitted(&self) {
+        match self {
+            Self::Nullify => ChallengerMetrics::nullify_tx_submitted_total().increment(1),
+            Self::Challenge => ChallengerMetrics::challenge_tx_submitted_total().increment(1),
+        }
+    }
+
+    /// Records the outcome (success, reverted, error) of a dispute transaction.
+    pub fn record_outcome(&self, status: &'static str) {
+        match self {
+            Self::Nullify => ChallengerMetrics::nullify_tx_outcome_total(status).increment(1),
+            Self::Challenge => ChallengerMetrics::challenge_tx_outcome_total(status).increment(1),
+        }
+    }
+
+    /// Records the latency of a dispute transaction.
+    pub fn record_latency(&self, seconds: f64) {
+        match self {
+            Self::Nullify => ChallengerMetrics::nullify_tx_latency_seconds().record(seconds),
+            Self::Challenge => ChallengerMetrics::challenge_tx_latency_seconds().record(seconds),
+        }
     }
 }
 
@@ -98,17 +159,18 @@ mod tests {
     use crate::test_utils::{MockTxManager, receipt_with_status};
 
     #[tokio::test]
-    async fn submit_nullification_success_returns_tx_hash() {
+    async fn submit_dispute_nullify_success_returns_tx_hash() {
         let tx_hash = B256::repeat_byte(0xAA);
         let mock = MockTxManager::new(Ok(receipt_with_status(true, tx_hash)));
         let submitter = ChallengeSubmitter::new(mock);
 
         let result = submitter
-            .submit_nullification(
+            .submit_dispute(
                 Address::repeat_byte(0x01),
                 Bytes::from(vec![0x00, 0x01]),
                 42,
                 B256::repeat_byte(0xFF),
+                DisputeIntent::Nullify,
             )
             .await;
 
@@ -116,17 +178,18 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn submit_nullification_reverted_returns_error() {
+    async fn submit_dispute_reverted_returns_error() {
         let tx_hash = B256::repeat_byte(0xBB);
         let mock = MockTxManager::new(Ok(receipt_with_status(false, tx_hash)));
         let submitter = ChallengeSubmitter::new(mock);
 
         let result = submitter
-            .submit_nullification(
+            .submit_dispute(
                 Address::repeat_byte(0x01),
                 Bytes::from(vec![0x00]),
                 1,
                 B256::ZERO,
+                DisputeIntent::Nullify,
             )
             .await;
 
@@ -138,16 +201,17 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn submit_nullification_tx_manager_error_propagates() {
+    async fn submit_dispute_tx_manager_error_propagates() {
         let mock = MockTxManager::new(Err(TxManagerError::NonceTooLow));
         let submitter = ChallengeSubmitter::new(mock);
 
         let result = submitter
-            .submit_nullification(
+            .submit_dispute(
                 Address::repeat_byte(0x01),
                 Bytes::from(vec![0x01]),
                 0,
                 B256::ZERO,
+                DisputeIntent::Challenge,
             )
             .await;
 
@@ -156,5 +220,24 @@ mod tests {
             matches!(err, ChallengeSubmitError::TxManager(TxManagerError::NonceTooLow)),
             "expected TxManager(NonceTooLow), got {err:?}",
         );
+    }
+
+    #[tokio::test]
+    async fn submit_dispute_challenge_success_returns_tx_hash() {
+        let tx_hash = B256::repeat_byte(0xCC);
+        let mock = MockTxManager::new(Ok(receipt_with_status(true, tx_hash)));
+        let submitter = ChallengeSubmitter::new(mock);
+
+        let result = submitter
+            .submit_dispute(
+                Address::repeat_byte(0x01),
+                Bytes::from(vec![0x01, 0xDE, 0xAD]),
+                5,
+                B256::repeat_byte(0xAB),
+                DisputeIntent::Challenge,
+            )
+            .await;
+
+        assert_eq!(result.unwrap(), tx_hash);
     }
 }

--- a/crates/proof/challenge/src/tee.rs
+++ b/crates/proof/challenge/src/tee.rs
@@ -1,15 +1,14 @@
-//! L1 head provider abstraction for fetching the finalized L1 block hash.
+//! L1 head provider abstraction for fetching L1 block information.
 
 use alloy_primitives::B256;
 use alloy_provider::{Provider, RootProvider};
-use alloy_rpc_types_eth::BlockNumberOrTag;
 use async_trait::async_trait;
 
-/// Trait for fetching the L1 finalized head.
+/// Trait for fetching L1 block information.
 #[async_trait]
 pub trait L1HeadProvider: Send + Sync + std::fmt::Debug {
-    /// Returns the hash and block number of the current L1 finalized block.
-    async fn finalized_head(&self) -> eyre::Result<(B256, u64)>;
+    /// Returns the block number for the given L1 block hash.
+    async fn block_number_by_hash(&self, hash: B256) -> eyre::Result<u64>;
 }
 
 /// [`L1HeadProvider`] backed by an RPC [`RootProvider`].
@@ -27,12 +26,12 @@ impl RpcL1HeadProvider {
 
 #[async_trait]
 impl L1HeadProvider for RpcL1HeadProvider {
-    async fn finalized_head(&self) -> eyre::Result<(B256, u64)> {
+    async fn block_number_by_hash(&self, hash: B256) -> eyre::Result<u64> {
         let block = self
             .provider
-            .get_block_by_number(BlockNumberOrTag::Finalized)
+            .get_block_by_hash(hash)
             .await?
-            .ok_or_else(|| eyre::eyre!("L1 finalized block not found"))?;
-        Ok((block.header.hash, block.header.number))
+            .ok_or_else(|| eyre::eyre!("L1 block not found for hash {hash}"))?;
+        Ok(block.header.number)
     }
 }

--- a/crates/proof/challenge/src/test_utils.rs
+++ b/crates/proof/challenge/src/test_utils.rs
@@ -43,6 +43,8 @@ pub struct MockGameState {
     pub starting_block_number: u64,
     /// Intermediate output roots for this game.
     pub intermediate_output_roots: Vec<B256>,
+    /// 1-based index of the challenged intermediate root (`0` = unchallenged).
+    pub countered_index: u64,
 }
 
 /// Mock dispute game factory with configurable per-index game data.
@@ -138,6 +140,13 @@ impl AggregateVerifierClient for MockAggregateVerifier {
             .map(|s| s.intermediate_output_roots.clone())
             .ok_or_else(|| ContractError::Validation(format!("unknown game {game_address}")))
     }
+
+    async fn countered_index(&self, game_address: Address) -> Result<u64, ContractError> {
+        self.games
+            .get(&game_address)
+            .map(|s| s.countered_index)
+            .ok_or_else(|| ContractError::Validation(format!("unknown game {game_address}")))
+    }
 }
 
 /// Helper to create an address from a `u64` index.
@@ -152,9 +161,19 @@ pub fn factory_game(index: u64, game_type: u32) -> GameAtIndex {
     GameAtIndex { game_type, timestamp: 1_000_000 + index, proxy: addr(index) }
 }
 
+/// Default TEE prover address used by [`mock_state`].
+///
+/// Every game in the multiproof system is initialized with at least one
+/// prover, so the default mock state uses a non-zero TEE prover to match
+/// the production invariant.
+pub const DEFAULT_TEE_PROVER: Address = Address::new([0xEE; 20]);
+
 /// Helper to build mock game state for the verifier.
+///
+/// Uses [`DEFAULT_TEE_PROVER`] as the TEE prover address. Use
+/// [`mock_state_with_tee`] to override.
 pub const fn mock_state(status: u8, zk_prover: Address, block_number: u64) -> MockGameState {
-    mock_state_with_tee(status, zk_prover, Address::ZERO, block_number)
+    mock_state_with_tee(status, zk_prover, DEFAULT_TEE_PROVER, block_number)
 }
 
 /// Helper to build mock game state with an explicit TEE prover address.
@@ -175,6 +194,7 @@ pub const fn mock_state_with_tee(
         },
         starting_block_number: block_number.saturating_sub(10),
         intermediate_output_roots: vec![],
+        countered_index: 0,
     }
 }
 
@@ -706,9 +726,9 @@ mod tests {
 
     /// Games with a non-zero TEE prover but zero ZK prover are still candidates.
     ///
-    /// The scanner currently filters only on `zk_prover`; a TEE proof alone does
-    /// not mark a game as challenged. This test guards that behaviour so a future
-    /// change to the filtering logic will surface as a test failure.
+    /// A non-zero `teeProver` with `zkProver == ZERO` is the normal initial
+    /// state for an unchallenged game. The scanner should return these as
+    /// candidates.
     #[tokio::test]
     async fn test_scan_tee_prover_nonzero_still_candidate() {
         let tee_addr = Address::repeat_byte(0xEE);
@@ -718,9 +738,9 @@ mod tests {
         });
 
         let mut verifier_games = HashMap::new();
-        // Game 0: IN_PROGRESS, no ZK prover, but has a TEE prover -> still a candidate
+        // Game 0: IN_PROGRESS, no ZK prover, has a TEE prover -> candidate
         verifier_games.insert(addr(0), mock_state_with_tee(0, Address::ZERO, tee_addr, 100));
-        // Game 1: IN_PROGRESS, no ZK prover, no TEE prover -> candidate
+        // Game 1: IN_PROGRESS, no ZK prover, has default TEE prover -> candidate
         verifier_games.insert(addr(1), mock_state(0, Address::ZERO, 200));
 
         let verifier = Arc::new(MockAggregateVerifier { games: verifier_games });
@@ -756,5 +776,126 @@ mod tests {
         assert_eq!(candidates.len(), 1);
         assert_eq!(candidates[0].index, 1);
         assert_eq!(new_last_scanned, None);
+    }
+
+    /// A challenged game (TEE + ZK provers non-zero, `countered_index` > 0) is
+    /// returned as a [`GameCategory::FraudulentZkChallenge`] candidate.
+    #[tokio::test]
+    async fn test_scan_challenged_game_returns_fraudulent_zk_challenge() {
+        use crate::scanner::GameCategory;
+
+        let tee_addr = Address::repeat_byte(0xEE);
+        let zk_addr = Address::repeat_byte(0xCC);
+
+        let factory = Arc::new(MockDisputeGameFactory { games: vec![factory_game(0, 1)] });
+
+        let mut verifier_games = HashMap::new();
+        let mut state = mock_state_with_tee(0, zk_addr, tee_addr, 100);
+        state.countered_index = 3; // 1-based: challenged at 0-based index 2
+        verifier_games.insert(addr(0), state);
+
+        let verifier = Arc::new(MockAggregateVerifier { games: verifier_games });
+        let scanner = GameScanner::new(factory, verifier, ScannerConfig { lookback_games: 1000 });
+
+        let (candidates, _) = scanner.scan(None).await.unwrap();
+
+        assert_eq!(candidates.len(), 1);
+        assert_eq!(
+            candidates[0].category,
+            GameCategory::FraudulentZkChallenge { challenged_index: 2 }
+        );
+    }
+
+    /// A ZK-proposed game (`tee_prover` == 0, `zk_prover` != 0, unchallenged) is
+    /// returned as a [`GameCategory::InvalidZkProposal`] candidate.
+    #[tokio::test]
+    async fn test_scan_zk_proposal_returns_invalid_zk_proposal() {
+        use crate::scanner::GameCategory;
+
+        let zk_addr = Address::repeat_byte(0xCC);
+
+        let factory = Arc::new(MockDisputeGameFactory { games: vec![factory_game(0, 1)] });
+
+        let mut verifier_games = HashMap::new();
+        // tee_prover == ZERO, zk_prover != ZERO, countered_index == 0
+        verifier_games.insert(addr(0), mock_state_with_tee(0, zk_addr, Address::ZERO, 100));
+
+        let verifier = Arc::new(MockAggregateVerifier { games: verifier_games });
+        let scanner = GameScanner::new(factory, verifier, ScannerConfig { lookback_games: 1000 });
+
+        let (candidates, _) = scanner.scan(None).await.unwrap();
+
+        assert_eq!(candidates.len(), 1);
+        assert_eq!(candidates[0].category, GameCategory::InvalidZkProposal);
+    }
+
+    /// A TEE-proposed unchallenged game is returned as
+    /// [`GameCategory::InvalidTeeProposal`].
+    #[tokio::test]
+    async fn test_scan_tee_proposal_returns_invalid_tee_proposal() {
+        use crate::scanner::GameCategory;
+
+        let factory = Arc::new(MockDisputeGameFactory { games: vec![factory_game(0, 1)] });
+
+        let mut verifier_games = HashMap::new();
+        verifier_games.insert(addr(0), mock_state(0, Address::ZERO, 100));
+
+        let verifier = Arc::new(MockAggregateVerifier { games: verifier_games });
+        let scanner = GameScanner::new(factory, verifier, ScannerConfig { lookback_games: 1000 });
+
+        let (candidates, _) = scanner.scan(None).await.unwrap();
+
+        assert_eq!(candidates.len(), 1);
+        assert_eq!(candidates[0].category, GameCategory::InvalidTeeProposal);
+    }
+
+    /// A game with both proofs verified (TEE + ZK, no challenge) is skipped.
+    #[tokio::test]
+    async fn test_scan_both_proofs_verified_skipped() {
+        let tee_addr = Address::repeat_byte(0xEE);
+        let zk_addr = Address::repeat_byte(0xCC);
+
+        let factory = Arc::new(MockDisputeGameFactory { games: vec![factory_game(0, 1)] });
+
+        let mut verifier_games = HashMap::new();
+        // Both provers non-zero, countered_index == 0 (added via verifyProposalProof)
+        verifier_games.insert(addr(0), mock_state_with_tee(0, zk_addr, tee_addr, 100));
+
+        let verifier = Arc::new(MockAggregateVerifier { games: verifier_games });
+        let scanner = GameScanner::new(factory, verifier, ScannerConfig { lookback_games: 1000 });
+
+        let (candidates, _) = scanner.scan(None).await.unwrap();
+
+        assert!(candidates.is_empty(), "game with both proofs should be skipped");
+    }
+
+    /// Games with both `teeProver` and `zkProver` at `Address::ZERO` are
+    /// filtered out. Every game is initialized with at least one prover, so
+    /// both being zero indicates a prior nullification.
+    #[tokio::test]
+    async fn test_scan_filters_nullified_games() {
+        let tee_addr = Address::repeat_byte(0xEE);
+
+        let factory = Arc::new(MockDisputeGameFactory {
+            games: vec![factory_game(0, 1), factory_game(1, 1), factory_game(2, 1)],
+        });
+
+        let mut verifier_games = HashMap::new();
+        // Game 0: both provers zeroed (nullified) → filtered out
+        verifier_games.insert(addr(0), mock_state_with_tee(0, Address::ZERO, Address::ZERO, 100));
+        // Game 1: TEE prover active, ZK prover zero → candidate
+        verifier_games.insert(addr(1), mock_state_with_tee(0, Address::ZERO, tee_addr, 200));
+        // Game 2: both provers zeroed (nullified) → filtered out
+        verifier_games.insert(addr(2), mock_state_with_tee(0, Address::ZERO, Address::ZERO, 300));
+
+        let verifier = Arc::new(MockAggregateVerifier { games: verifier_games });
+
+        let scanner = GameScanner::new(factory, verifier, ScannerConfig { lookback_games: 1000 });
+
+        let (candidates, new_last_scanned) = scanner.scan(None).await.unwrap();
+
+        assert_eq!(candidates.len(), 1, "only the non-nullified game should be a candidate");
+        assert_eq!(candidates[0].index, 1);
+        assert_eq!(new_last_scanned, Some(2));
     }
 }

--- a/crates/proof/challenge/src/test_utils.rs
+++ b/crates/proof/challenge/src/test_utils.rs
@@ -41,6 +41,8 @@ pub struct MockGameState {
     pub game_info: GameInfo,
     /// Starting block number for this game.
     pub starting_block_number: u64,
+    /// L1 head block hash stored at game creation time.
+    pub l1_head: B256,
     /// Intermediate output roots for this game.
     pub intermediate_output_roots: Vec<B256>,
     /// 1-based index of the challenged intermediate root (`0` = unchallenged).
@@ -120,6 +122,13 @@ impl AggregateVerifierClient for MockAggregateVerifier {
             .ok_or_else(|| ContractError::Validation(format!("unknown game {game_address}")))
     }
 
+    async fn l1_head(&self, game_address: Address) -> Result<B256, ContractError> {
+        self.games
+            .get(&game_address)
+            .map(|s| s.l1_head)
+            .ok_or_else(|| ContractError::Validation(format!("unknown game {game_address}")))
+    }
+
     async fn read_block_interval(&self, _impl_address: Address) -> Result<u64, ContractError> {
         Ok(10)
     }
@@ -168,6 +177,9 @@ pub fn factory_game(index: u64, game_type: u32) -> GameAtIndex {
 /// the production invariant.
 pub const DEFAULT_TEE_PROVER: Address = Address::new([0xEE; 20]);
 
+/// Default L1 head hash used by [`mock_state`].
+pub const DEFAULT_L1_HEAD: B256 = B256::repeat_byte(0xAA);
+
 /// Helper to build mock game state for the verifier.
 ///
 /// Uses [`DEFAULT_TEE_PROVER`] as the TEE prover address. Use
@@ -193,6 +205,7 @@ pub const fn mock_state_with_tee(
             parent_index: 0,
         },
         starting_block_number: block_number.saturating_sub(10),
+        l1_head: DEFAULT_L1_HEAD,
         intermediate_output_roots: vec![],
         countered_index: 0,
     }
@@ -377,30 +390,46 @@ impl ProverClient for MockTeeProofProvider {
 /// Mock L1 head provider for testing the driver.
 #[derive(Debug)]
 pub struct MockL1HeadProvider {
-    /// Queue of results returned by [`finalized_head`](L1HeadProvider::finalized_head).
-    pub results: Mutex<VecDeque<eyre::Result<(B256, u64)>>>,
+    /// Queue of `(expected_hash, result)` pairs returned by
+    /// [`block_number_by_hash`](L1HeadProvider::block_number_by_hash).
+    /// When `expected_hash` is `Some`, the mock asserts that the caller
+    /// passes the correct hash.
+    pub block_number_results: Mutex<VecDeque<(Option<B256>, eyre::Result<u64>)>>,
 }
 
 impl MockL1HeadProvider {
-    /// Creates a mock that returns a single successful hash and block number.
+    /// Creates a mock whose [`block_number_by_hash`](L1HeadProvider::block_number_by_hash)
+    /// returns `number` and asserts it is called with `hash`.
     pub fn success(hash: B256, number: u64) -> Self {
-        let mut q = VecDeque::new();
-        q.push_back(Ok((hash, number)));
-        Self { results: Mutex::new(q) }
+        let mut bq = VecDeque::new();
+        bq.push_back((Some(hash), Ok(number)));
+        Self { block_number_results: Mutex::new(bq) }
     }
 
     /// Creates a mock that returns a single error.
     pub fn failure(msg: &str) -> Self {
-        let mut q = VecDeque::new();
-        q.push_back(Err(eyre::eyre!("{msg}")));
-        Self { results: Mutex::new(q) }
+        let mut bq = VecDeque::new();
+        bq.push_back((None, Err(eyre::eyre!("{msg}"))));
+        Self { block_number_results: Mutex::new(bq) }
     }
 }
 
 #[async_trait]
 impl L1HeadProvider for MockL1HeadProvider {
-    async fn finalized_head(&self) -> eyre::Result<(B256, u64)> {
-        self.results.lock().unwrap().pop_front().expect("MockL1HeadProvider has no more results")
+    async fn block_number_by_hash(&self, hash: B256) -> eyre::Result<u64> {
+        let (expected_hash, result) = self
+            .block_number_results
+            .lock()
+            .unwrap()
+            .pop_front()
+            .expect("MockL1HeadProvider has no more block_number_by_hash results");
+        if let Some(expected) = expected_hash {
+            assert_eq!(
+                hash, expected,
+                "MockL1HeadProvider::block_number_by_hash called with unexpected hash"
+            );
+        }
+        result
     }
 }
 

--- a/crates/proof/challenge/tests/driver.rs
+++ b/crates/proof/challenge/tests/driver.rs
@@ -8,12 +8,13 @@ use std::{
 
 use alloy_primitives::{Address, B256, Bytes, U256};
 use base_challenger::{
-    ChallengeSubmitter, Driver, DriverConfig, GameScanner, L1HeadProvider, OutputValidator,
-    PendingProof, ProofPhase, ScannerConfig, TeeConfig, derive_session_id,
+    ChallengeSubmitter, DisputeIntent, Driver, DriverConfig, GameScanner, L1HeadProvider,
+    OutputValidator, PendingProof, ProofPhase, ScannerConfig, TeeConfig, derive_session_id,
     test_utils::{
         MockAggregateVerifier, MockDisputeGameFactory, MockGameState, MockL1HeadProvider,
         MockL2Provider, MockTeeProofProvider, MockTxManager, MockZkProofProvider, addr,
-        build_test_header_and_account, factory_game, mock_state, receipt_with_status,
+        build_test_header_and_account, factory_game, mock_state, mock_state_with_tee,
+        receipt_with_status,
     },
 };
 use base_proof_contracts::{AggregateVerifierClient, ContractError, GameAtIndex};
@@ -107,12 +108,13 @@ fn invalid_game_mocks()
 
     let factory = Arc::new(MockDisputeGameFactory { games: vec![factory_game(0, 1)] });
     let mut verifier_games = HashMap::new();
+    let tee_addr = Address::repeat_byte(0xEE);
     verifier_games.insert(
         addr(0),
         MockGameState {
             status: 0,
             zk_prover: Address::ZERO,
-            tee_prover: Address::ZERO,
+            tee_prover: tee_addr,
             game_info: base_proof_contracts::GameInfo {
                 root_claim: B256::repeat_byte(0x01),
                 l2_block_number: 20,
@@ -120,6 +122,7 @@ fn invalid_game_mocks()
             },
             starting_block_number: 10,
             intermediate_output_roots: vec![root_15, B256::repeat_byte(0xFF)],
+            countered_index: 0,
         },
     );
     let verifier = Arc::new(MockAggregateVerifier { games: verifier_games });
@@ -143,6 +146,7 @@ fn driver_with_ready_proof(
             1,
             B256::repeat_byte(0xEE),
             default_prove_request(),
+            DisputeIntent::Challenge,
         ),
     );
     driver
@@ -168,12 +172,13 @@ async fn test_step_valid_game_skipped() {
     // so expected_count = 0 → trivially valid.
     let factory = Arc::new(MockDisputeGameFactory { games: vec![factory_game(0, 1)] });
     let mut verifier_games = HashMap::new();
+    let tee_addr = Address::repeat_byte(0xEE);
     verifier_games.insert(
         addr(0),
         MockGameState {
             status: 0,
             zk_prover: Address::ZERO,
-            tee_prover: Address::ZERO,
+            tee_prover: tee_addr,
             game_info: base_proof_contracts::GameInfo {
                 root_claim: B256::repeat_byte(0x01),
                 l2_block_number: 14,
@@ -181,6 +186,7 @@ async fn test_step_valid_game_skipped() {
             },
             starting_block_number: 10,
             intermediate_output_roots: vec![],
+            countered_index: 0,
         },
     );
     let verifier = Arc::new(MockAggregateVerifier { games: verifier_games });
@@ -205,12 +211,13 @@ async fn test_step_validation_error_blocks_not_available() {
     // Validator returns BlockNotAvailable → process_candidate skips gracefully.
     let factory = Arc::new(MockDisputeGameFactory { games: vec![factory_game(0, 1)] });
     let mut verifier_games = HashMap::new();
+    let tee_addr = Address::repeat_byte(0xEE);
     verifier_games.insert(
         addr(0),
         MockGameState {
             status: 0,
             zk_prover: Address::ZERO,
-            tee_prover: Address::ZERO,
+            tee_prover: tee_addr,
             game_info: base_proof_contracts::GameInfo {
                 root_claim: B256::repeat_byte(0x01),
                 l2_block_number: 20,
@@ -218,6 +225,7 @@ async fn test_step_validation_error_blocks_not_available() {
             },
             starting_block_number: 10,
             intermediate_output_roots: vec![B256::repeat_byte(0xFF), B256::repeat_byte(0xEE)],
+            countered_index: 0,
         },
     );
     let verifier = Arc::new(MockAggregateVerifier { games: verifier_games });
@@ -296,12 +304,13 @@ async fn test_step_validation_error_skipped() {
     // → process_candidate logs and returns Ok.
     let factory = Arc::new(MockDisputeGameFactory { games: vec![factory_game(0, 1)] });
     let mut verifier_games = HashMap::new();
+    let tee_addr = Address::repeat_byte(0xEE);
     verifier_games.insert(
         addr(0),
         MockGameState {
             status: 0,
             zk_prover: Address::ZERO,
-            tee_prover: Address::ZERO,
+            tee_prover: tee_addr,
             game_info: base_proof_contracts::GameInfo {
                 root_claim: B256::repeat_byte(0x01),
                 l2_block_number: 20,
@@ -310,6 +319,7 @@ async fn test_step_validation_error_skipped() {
             starting_block_number: 10,
             // 2 roots expected at interval=5, provide 2 so count matches
             intermediate_output_roots: vec![B256::ZERO, B256::ZERO],
+            countered_index: 0,
         },
     );
     let verifier = Arc::new(MockAggregateVerifier { games: verifier_games });
@@ -416,7 +426,7 @@ async fn test_step_pending_proof_skips_prove_block() {
     *zk.proof_status.lock().unwrap() = ProofJobStatus::Succeeded as i32;
 
     // Step 2: same game re-discovered → polls existing session, proof succeeds,
-    // nullification submitted, session removed from pending_proofs.
+    // challenge tx submitted, session removed from pending_proofs.
     driver.step().await.unwrap();
     assert!(
         !driver.pending_proofs.contains_key(&addr(0)),
@@ -446,7 +456,7 @@ async fn test_step_nullification_failure_preserves_proof() {
 
     let mut driver = test_driver(factory, verifier, l2, zk, tx_manager);
 
-    // Step 1: proof succeeds, but nullification tx fails.
+    // Step 1: proof succeeds, but dispute tx fails.
     // initiate_proof catches the poll_or_submit error and logs a warning,
     // so the error does not propagate up through process_candidate → step.
     driver.step().await.unwrap();
@@ -455,7 +465,7 @@ async fn test_step_nullification_failure_preserves_proof() {
     let entry = driver.pending_proofs.get(&addr(0)).expect("proof should be preserved");
     assert!(entry.is_ready(), "phase should be ReadyToSubmit after tx failure");
 
-    // Step 2: poll_pending_proofs re-submits, now the tx succeeds.
+    // Step 2: poll_pending_proofs re-submits the challenge tx, now it succeeds.
     driver.step().await.unwrap();
     assert!(
         !driver.pending_proofs.contains_key(&addr(0)),
@@ -484,6 +494,19 @@ async fn test_poll_or_submit_drops_already_challenged_game() {
     assert!(
         !driver.pending_proofs.contains_key(&addr(0)),
         "already-challenged game should be removed from pending_proofs"
+    );
+}
+
+#[tokio::test]
+async fn test_poll_or_submit_drops_nullified_game() {
+    // Game is still IN_PROGRESS but both provers are ZERO (nullified)
+    // — driver should drop the pending proof without attempting submission.
+    let mut driver =
+        driver_with_ready_proof(mock_state_with_tee(0, Address::ZERO, Address::ZERO, 20));
+    driver.step().await.unwrap();
+    assert!(
+        !driver.pending_proofs.contains_key(&addr(0)),
+        "nullified game should be removed from pending_proofs"
     );
 }
 
@@ -531,7 +554,7 @@ async fn test_run_cancellation() {
 async fn test_step_proof_retry_succeeds() {
     // Proof fails on first tick (NeedsRetry), then re-initiated prove_block
     // returns a new session. On the next tick the proof succeeds and
-    // nullification is submitted.
+    // challenge tx is submitted.
     let (l2, factory, verifier) = invalid_game_mocks();
 
     let zk = Arc::new(MockZkProofProvider {
@@ -559,11 +582,11 @@ async fn test_step_proof_retry_succeeds() {
     // Simulate proof succeeding on the retry session.
     *zk.proof_status.lock().unwrap() = ProofJobStatus::Succeeded as i32;
 
-    // Step 2: proof succeeds, nullification submitted, entry removed.
+    // Step 2: proof succeeds, challenge tx submitted, entry removed.
     driver.step().await.unwrap();
     assert!(
         !driver.pending_proofs.contains_key(&addr(0)),
-        "entry should be removed after successful nullification"
+        "entry should be removed after successful challenge submission"
     );
 }
 
@@ -607,48 +630,12 @@ async fn test_step_proof_exceeds_max_retries() {
 ///
 /// The game at `addr(0)` has `tee_prover = 0xEE..EE` and the same block
 /// layout as `invalid_game_mocks()`.
-fn invalid_game_mocks_with_tee()
--> (Arc<MockL2Provider>, Arc<MockDisputeGameFactory>, Arc<MockAggregateVerifier>) {
-    let storage_hash = B256::repeat_byte(0xBB);
-    let (header_15, account_15) = build_test_header_and_account(15, storage_hash);
-    let root_15 =
-        OutputRoot::from_parts(header_15.state_root, storage_hash, header_15.hash_slow()).hash();
-    let (header_20, account_20) = build_test_header_and_account(20, storage_hash);
-
-    let mut l2 = MockL2Provider::new();
-    l2.insert_block(15, header_15, account_15);
-    l2.insert_block(20, header_20, account_20);
-    let l2 = Arc::new(l2);
-
-    let factory = Arc::new(MockDisputeGameFactory { games: vec![factory_game(0, 1)] });
-    let tee_addr = Address::repeat_byte(0xEE);
-    let mut verifier_games = HashMap::new();
-    verifier_games.insert(
-        addr(0),
-        MockGameState {
-            status: 0,
-            zk_prover: Address::ZERO,
-            tee_prover: tee_addr,
-            game_info: base_proof_contracts::GameInfo {
-                root_claim: B256::repeat_byte(0x01),
-                l2_block_number: 20,
-                parent_index: 0,
-            },
-            starting_block_number: 10,
-            intermediate_output_roots: vec![root_15, B256::repeat_byte(0xFF)],
-        },
-    );
-    let verifier = Arc::new(MockAggregateVerifier { games: verifier_games });
-
-    (l2, factory, verifier)
-}
-
 #[tokio::test]
 async fn test_step_invalid_game_tee_fails_zk_fallback() {
     // Game has a TEE prover, TEE provider is configured, but the TEE proof
     // attempt fails (L1 provider is unreachable with dummy). The driver
     // should fall back to ZK and initiate a ZK proof session.
-    let (l2, factory, verifier) = invalid_game_mocks_with_tee();
+    let (l2, factory, verifier) = invalid_game_mocks();
 
     let tee = Arc::new(MockTeeProofProvider::failure("enclave unreachable"));
     let zk = Arc::new(MockZkProofProvider {
@@ -682,46 +669,10 @@ async fn test_step_invalid_game_tee_fails_zk_fallback() {
 }
 
 #[tokio::test]
-async fn test_step_invalid_game_no_tee_prover_zk_only() {
-    // Game has `tee_prover == ZERO`. Even though a TEE provider is
-    // configured, the TEE path should NOT be attempted. Goes straight to ZK.
-    let (l2, factory, verifier) = invalid_game_mocks();
-
-    // This TEE provider should never be called since tee_prover is ZERO.
-    let tee = Arc::new(MockTeeProofProvider::failure("should not be called"));
-    let zk =
-        Arc::new(MockZkProofProvider { session_id: "zk-direct".to_string(), ..Default::default() });
-
-    let tx_manager = default_tx_manager();
-    let mut driver = test_driver_with_tee(
-        factory,
-        verifier,
-        l2,
-        zk,
-        tx_manager,
-        Some(TeeConfig {
-            provider: tee as Arc<dyn ProverClient>,
-            l1_head_provider: Arc::new(MockL1HeadProvider::failure("dummy")),
-            request_timeout: Duration::from_secs(30),
-        }),
-    );
-
-    driver.step().await.unwrap();
-
-    // The ZK proof should be initiated directly (no TEE attempt since
-    // tee_prover == ZERO).
-    let entry = driver.pending_proofs.get(&addr(0)).expect("ZK proof should be pending");
-    assert!(
-        matches!(entry.phase, ProofPhase::AwaitingProof { .. }),
-        "phase should be AwaitingProof (direct ZK)"
-    );
-}
-
-#[tokio::test]
 async fn test_step_invalid_game_no_tee_provider_zk_only() {
     // Game has a TEE prover, but the driver has no TEE provider configured
     // (tee-rpc-url was not set). Should go straight to ZK.
-    let (l2, factory, verifier) = invalid_game_mocks_with_tee();
+    let (l2, factory, verifier) = invalid_game_mocks();
 
     let zk = Arc::new(MockZkProofProvider {
         session_id: "zk-no-provider".to_string(),
@@ -744,8 +695,8 @@ async fn test_step_invalid_game_no_tee_provider_zk_only() {
 #[tokio::test]
 async fn test_step_invalid_game_tee_fails_zk_succeeds() {
     // Game has a TEE prover, TEE proof attempt fails, driver falls back to
-    // ZK, ZK proof succeeds immediately, nullification submitted.
-    let (l2, factory, verifier) = invalid_game_mocks_with_tee();
+    // ZK, ZK proof succeeds immediately, challenge tx submitted.
+    let (l2, factory, verifier) = invalid_game_mocks();
 
     let tee = Arc::new(MockTeeProofProvider::failure("L1 unreachable"));
     let zk = Arc::new(MockZkProofProvider {
@@ -772,13 +723,13 @@ async fn test_step_invalid_game_tee_fails_zk_succeeds() {
     );
 
     // Step: TEE path is attempted (fails due to provider error), falls back to
-    // ZK, proof succeeds immediately, nullification submitted.
+    // ZK, proof succeeds immediately, challenge tx submitted.
     driver.step().await.unwrap();
 
     // Proof was submitted and removed from pending.
     assert!(
         !driver.pending_proofs.contains_key(&addr(0)),
-        "entry should be removed after successful ZK fallback submission"
+        "entry should be removed after successful ZK challenge submission"
     );
 }
 
@@ -817,6 +768,7 @@ async fn test_step_invalid_game_tee_proof_succeeds() {
             starting_block_number: 10,
             // root_15 is correct, index 1 is bogus — invalid_index == 1
             intermediate_output_roots: vec![root_15, B256::repeat_byte(0xFF)],
+            countered_index: 0,
         },
     );
     let verifier = Arc::new(MockAggregateVerifier { games: verifier_games });
@@ -867,4 +819,324 @@ async fn test_step_invalid_game_tee_proof_succeeds() {
         !driver.pending_proofs.contains_key(&addr(0)),
         "no pending ZK proof should exist after successful TEE submission"
     );
+}
+
+#[tokio::test]
+async fn test_step_nullified_game_not_reprocessed() {
+    // Simulate the post-nullification on-chain state: game is still
+    // IN_PROGRESS but both teeProver and zkProver are address(0).
+    // The scanner should filter it out and no proof should be initiated.
+    let storage_hash = B256::repeat_byte(0xBB);
+    let (header_15, account_15) = build_test_header_and_account(15, storage_hash);
+    let root_15 =
+        OutputRoot::from_parts(header_15.state_root, storage_hash, header_15.hash_slow()).hash();
+    let (header_20, account_20) = build_test_header_and_account(20, storage_hash);
+
+    let mut l2 = MockL2Provider::new();
+    l2.insert_block(15, header_15, account_15);
+    l2.insert_block(20, header_20, account_20);
+    let l2 = Arc::new(l2);
+
+    let factory = Arc::new(MockDisputeGameFactory { games: vec![factory_game(0, 1)] });
+    let mut verifier_games = HashMap::new();
+    verifier_games.insert(
+        addr(0),
+        MockGameState {
+            status: 0,
+            zk_prover: Address::ZERO,
+            // Both provers zeroed — this is the state after TEE nullification.
+            tee_prover: Address::ZERO,
+            game_info: base_proof_contracts::GameInfo {
+                root_claim: B256::repeat_byte(0x01),
+                l2_block_number: 20,
+                parent_index: 0,
+            },
+            starting_block_number: 10,
+            intermediate_output_roots: vec![root_15, B256::repeat_byte(0xFF)],
+            countered_index: 0,
+        },
+    );
+    let verifier = Arc::new(MockAggregateVerifier { games: verifier_games });
+
+    // Neither the ZK prover nor the tx manager should be called.
+    let zk = Arc::new(MockZkProofProvider {
+        session_id: "should-not-be-called".to_string(),
+        ..Default::default()
+    });
+    let tx_manager = default_tx_manager();
+
+    let mut driver = test_driver(factory, verifier, l2, zk, tx_manager);
+
+    // Run two steps — the game should be filtered by the scanner on both.
+    driver.step().await.unwrap();
+    driver.step().await.unwrap();
+
+    assert!(driver.pending_proofs.is_empty(), "no proofs should be pending for a nullified game");
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Path 2: Correct TEE proof challenged with wrong ZK proof → nullify ZK
+// ──────────────────────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn test_poll_or_submit_nullify_intent_not_dropped_when_zk_prover_set() {
+    // A pending proof with DisputeIntent::Nullify should NOT be dropped
+    // when zkProver is non-zero (unlike DisputeIntent::Challenge, which
+    // requires zkProver == ZERO).
+    let tee_addr = Address::repeat_byte(0xEE);
+    let zk_addr = Address::repeat_byte(0xCC);
+
+    let (l2, factory, _verifier) = invalid_game_mocks();
+    let mut game_state = mock_state_with_tee(0, zk_addr, tee_addr, 20);
+    game_state.countered_index = 2; // challenged at 0-based index 1
+    let verifier_games = HashMap::from([(addr(0), game_state)]);
+    let verifier = Arc::new(MockAggregateVerifier { games: verifier_games });
+
+    let mut driver = test_driver(factory, verifier, l2, default_zk_prover(), default_tx_manager());
+    driver.pending_proofs.insert(
+        addr(0),
+        PendingProof::ready(
+            Bytes::from_static(&[0x01, 0xDE, 0xAD]),
+            1,
+            B256::repeat_byte(0xEE),
+            default_prove_request(),
+            DisputeIntent::Nullify,
+        ),
+    );
+
+    driver.step().await.unwrap();
+
+    // The pending proof should have been submitted (and removed), not dropped.
+    assert!(
+        !driver.pending_proofs.contains_key(&addr(0)),
+        "nullify intent should be submitted, not dropped due to zk_prover"
+    );
+}
+
+#[tokio::test]
+async fn test_poll_or_submit_challenge_intent_dropped_when_zk_prover_set() {
+    // A pending proof with DisputeIntent::Challenge should be dropped
+    // when zkProver is non-zero (game already challenged).
+    let tee_addr = Address::repeat_byte(0xEE);
+    let zk_addr = Address::repeat_byte(0xCC);
+
+    let (l2, factory, _verifier) = invalid_game_mocks();
+    let game_state = mock_state_with_tee(0, zk_addr, tee_addr, 20);
+    let verifier_games = HashMap::from([(addr(0), game_state)]);
+    let verifier = Arc::new(MockAggregateVerifier { games: verifier_games });
+
+    let tx = MockTxManager::new(Err(TxManagerError::NonceTooLow)); // Should never be called
+    let mut driver = test_driver(factory, verifier, l2, default_zk_prover(), tx);
+    driver.pending_proofs.insert(
+        addr(0),
+        PendingProof::ready(
+            Bytes::from_static(&[0x01, 0xDE, 0xAD]),
+            1,
+            B256::repeat_byte(0xEE),
+            default_prove_request(),
+            DisputeIntent::Challenge,
+        ),
+    );
+
+    driver.step().await.unwrap();
+
+    assert!(
+        !driver.pending_proofs.contains_key(&addr(0)),
+        "challenge intent should be dropped when game is already challenged"
+    );
+}
+
+/// Builds mocks for a Path 2 (`FraudulentZkChallenge`) scenario.
+///
+/// The game at `addr(0)` has both TEE and ZK provers set with
+/// `countered_index = 2` (1-based), meaning the challenged intermediate
+/// root is at 0-based index 1 (block 20).
+///
+/// Layout: starting=10, `l2_block=20`, interval=5, checkpoints at 15 and 20.
+/// `correct_root_at_20` controls whether the on-chain root at index 1
+/// (block 20) matches the L2-computed root:
+/// - `true`: on-chain root is correct → ZK challenge was fraudulent → nullify.
+/// - `false`: on-chain root is bogus → ZK challenge was legitimate → skip.
+fn fraudulent_zk_challenge_mocks(
+    correct_root_at_20: bool,
+) -> (Arc<MockL2Provider>, Arc<MockDisputeGameFactory>, Arc<MockAggregateVerifier>) {
+    let storage_hash = B256::repeat_byte(0xBB);
+    let (header_15, account_15) = build_test_header_and_account(15, storage_hash);
+    let root_15 =
+        OutputRoot::from_parts(header_15.state_root, storage_hash, header_15.hash_slow()).hash();
+    let (header_20, account_20) = build_test_header_and_account(20, storage_hash);
+    let root_20 =
+        OutputRoot::from_parts(header_20.state_root, storage_hash, header_20.hash_slow()).hash();
+
+    let mut l2 = MockL2Provider::new();
+    l2.insert_block(15, header_15, account_15);
+    l2.insert_block(20, header_20, account_20);
+    let l2 = Arc::new(l2);
+
+    let tee_addr = Address::repeat_byte(0xEE);
+    let zk_addr = Address::repeat_byte(0xCC);
+    let factory = Arc::new(MockDisputeGameFactory { games: vec![factory_game(0, 1)] });
+
+    let onchain_root_at_20 = if correct_root_at_20 { root_20 } else { B256::repeat_byte(0xFF) };
+
+    let mut verifier_games = HashMap::new();
+    verifier_games.insert(
+        addr(0),
+        MockGameState {
+            status: 0,
+            zk_prover: zk_addr,
+            tee_prover: tee_addr,
+            game_info: base_proof_contracts::GameInfo {
+                root_claim: B256::repeat_byte(0x01),
+                l2_block_number: 20,
+                parent_index: 0,
+            },
+            starting_block_number: 10,
+            intermediate_output_roots: vec![root_15, onchain_root_at_20],
+            countered_index: 2, // 1-based → challenged_index = 1
+        },
+    );
+    let verifier = Arc::new(MockAggregateVerifier { games: verifier_games });
+
+    (l2, factory, verifier)
+}
+
+#[tokio::test]
+async fn test_step_fraudulent_zk_challenge_legitimate_skips() {
+    // The on-chain root at the challenged index is wrong, meaning the ZK
+    // challenge was legitimate. The driver should skip without initiating
+    // a proof.
+    let (l2, factory, verifier) = fraudulent_zk_challenge_mocks(false);
+
+    let zk = Arc::new(MockZkProofProvider {
+        session_id: "should-not-be-called".to_string(),
+        ..Default::default()
+    });
+
+    let mut driver = test_driver(factory, verifier, l2, zk, default_tx_manager());
+    driver.step().await.unwrap();
+
+    assert!(
+        driver.pending_proofs.is_empty(),
+        "no proof should be initiated when the ZK challenge is legitimate"
+    );
+}
+
+#[tokio::test]
+async fn test_step_fraudulent_zk_challenge_nullifies() {
+    // The on-chain root at the challenged index is correct, meaning the
+    // ZK challenge was fraudulent. The driver should initiate a ZK proof
+    // with DisputeIntent::Nullify.
+    let (l2, factory, verifier) = fraudulent_zk_challenge_mocks(true);
+
+    let zk = Arc::new(MockZkProofProvider {
+        session_id: "nullify-fraudulent".to_string(),
+        ..Default::default()
+    });
+
+    let mut driver = test_driver(factory, verifier, l2, zk, default_tx_manager());
+    driver.step().await.unwrap();
+
+    let entry = driver
+        .pending_proofs
+        .get(&addr(0))
+        .expect("proof should be pending for fraudulent ZK challenge");
+    assert_eq!(
+        entry.intent,
+        DisputeIntent::Nullify,
+        "intent should be Nullify for fraudulent ZK challenge"
+    );
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Path 3: Wrong ZK proposal → nullify with ZK
+// ──────────────────────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn test_step_invalid_zk_proposal_initiates_zk_nullification() {
+    // A game proposed with a ZK proof (tee_prover == ZERO, zk_prover != ZERO)
+    // with invalid intermediate roots should trigger a ZK proof with
+    // DisputeIntent::Nullify.
+    let storage_hash = B256::repeat_byte(0xBB);
+    let (header_15, _account_15) = build_test_header_and_account(15, storage_hash);
+    let root_15 =
+        OutputRoot::from_parts(header_15.state_root, storage_hash, header_15.hash_slow()).hash();
+    let (header_20, account_20) = build_test_header_and_account(20, storage_hash);
+
+    let mut l2 = MockL2Provider::new();
+    l2.insert_block(15, header_15, account_20.clone());
+    l2.insert_block(20, header_20, account_20);
+    let l2 = Arc::new(l2);
+
+    let zk_addr = Address::repeat_byte(0xCC);
+    let factory = Arc::new(MockDisputeGameFactory { games: vec![factory_game(0, 1)] });
+    let mut verifier_games = HashMap::new();
+    verifier_games.insert(
+        addr(0),
+        MockGameState {
+            status: 0,
+            zk_prover: zk_addr,
+            tee_prover: Address::ZERO, // ZK-proposed game
+            game_info: base_proof_contracts::GameInfo {
+                root_claim: B256::repeat_byte(0x01),
+                l2_block_number: 20,
+                parent_index: 0,
+            },
+            starting_block_number: 10,
+            intermediate_output_roots: vec![root_15, B256::repeat_byte(0xFF)],
+            countered_index: 0,
+        },
+    );
+    let verifier = Arc::new(MockAggregateVerifier { games: verifier_games });
+
+    let zk = Arc::new(MockZkProofProvider {
+        session_id: "zk-nullify-session".to_string(),
+        ..Default::default()
+    });
+
+    let mut driver = test_driver(factory, verifier, l2, zk, default_tx_manager());
+    driver.step().await.unwrap();
+
+    // A pending proof should have been created with Nullify intent.
+    let entry = driver.pending_proofs.get(&addr(0));
+    assert!(entry.is_some(), "ZK nullification proof should be pending");
+    let entry = entry.unwrap();
+    assert_eq!(entry.intent, DisputeIntent::Nullify, "intent should be Nullify for ZK proposals");
+}
+
+#[tokio::test]
+async fn test_step_valid_zk_proposal_skipped() {
+    // A ZK-proposed game with valid intermediate roots should not trigger
+    // any action.
+    let factory = Arc::new(MockDisputeGameFactory { games: vec![factory_game(0, 1)] });
+    let zk_addr = Address::repeat_byte(0xCC);
+    let mut verifier_games = HashMap::new();
+    verifier_games.insert(
+        addr(0),
+        MockGameState {
+            status: 0,
+            zk_prover: zk_addr,
+            tee_prover: Address::ZERO,
+            game_info: base_proof_contracts::GameInfo {
+                root_claim: B256::repeat_byte(0x01),
+                l2_block_number: 14,
+                parent_index: 0,
+            },
+            starting_block_number: 10,
+            intermediate_output_roots: vec![],
+            countered_index: 0,
+        },
+    );
+    let verifier = Arc::new(MockAggregateVerifier { games: verifier_games });
+    let l2 = Arc::new(MockL2Provider::new());
+
+    let zk = Arc::new(MockZkProofProvider {
+        session_id: "should-not-be-called".to_string(),
+        ..Default::default()
+    });
+
+    let mut driver = test_driver(factory, verifier, l2, zk, default_tx_manager());
+    driver.step().await.unwrap();
+
+    assert!(driver.pending_proofs.is_empty(), "valid ZK proposal should not trigger any proof");
 }

--- a/crates/proof/challenge/tests/driver.rs
+++ b/crates/proof/challenge/tests/driver.rs
@@ -121,6 +121,7 @@ fn invalid_game_mocks()
                 parent_index: 0,
             },
             starting_block_number: 10,
+            l1_head: B256::repeat_byte(0xAA),
             intermediate_output_roots: vec![root_15, B256::repeat_byte(0xFF)],
             countered_index: 0,
         },
@@ -185,6 +186,7 @@ async fn test_step_valid_game_skipped() {
                 parent_index: 0,
             },
             starting_block_number: 10,
+            l1_head: B256::repeat_byte(0xAA),
             intermediate_output_roots: vec![],
             countered_index: 0,
         },
@@ -224,6 +226,7 @@ async fn test_step_validation_error_blocks_not_available() {
                 parent_index: 0,
             },
             starting_block_number: 10,
+            l1_head: B256::repeat_byte(0xAA),
             intermediate_output_roots: vec![B256::repeat_byte(0xFF), B256::repeat_byte(0xEE)],
             countered_index: 0,
         },
@@ -317,6 +320,7 @@ async fn test_step_validation_error_skipped() {
                 parent_index: 0,
             },
             starting_block_number: 10,
+            l1_head: B256::repeat_byte(0xAA),
             // 2 roots expected at interval=5, provide 2 so count matches
             intermediate_output_roots: vec![B256::ZERO, B256::ZERO],
             countered_index: 0,
@@ -751,6 +755,8 @@ async fn test_step_invalid_game_tee_proof_succeeds() {
     l2.insert_block(20, header_20, account_20);
     let l2 = Arc::new(l2);
 
+    let l1_hash = B256::repeat_byte(0xAA);
+
     let factory = Arc::new(MockDisputeGameFactory { games: vec![factory_game(0, 1)] });
     let tee_addr = Address::repeat_byte(0xEE);
     let mut verifier_games = HashMap::new();
@@ -766,6 +772,7 @@ async fn test_step_invalid_game_tee_proof_succeeds() {
                 parent_index: 0,
             },
             starting_block_number: 10,
+            l1_head: l1_hash,
             // root_15 is correct, index 1 is bogus — invalid_index == 1
             intermediate_output_roots: vec![root_15, B256::repeat_byte(0xFF)],
             countered_index: 0,
@@ -773,7 +780,6 @@ async fn test_step_invalid_game_tee_proof_succeeds() {
     );
     let verifier = Arc::new(MockAggregateVerifier { games: verifier_games });
 
-    let l1_hash = B256::repeat_byte(0xAA);
     let l1_head = Arc::new(MockL1HeadProvider::success(l1_hash, 100));
 
     let aggregate_proposal = Proposal {
@@ -852,6 +858,7 @@ async fn test_step_nullified_game_not_reprocessed() {
                 parent_index: 0,
             },
             starting_block_number: 10,
+            l1_head: B256::repeat_byte(0xAA),
             intermediate_output_roots: vec![root_15, B256::repeat_byte(0xFF)],
             countered_index: 0,
         },
@@ -992,6 +999,7 @@ fn fraudulent_zk_challenge_mocks(
                 parent_index: 0,
             },
             starting_block_number: 10,
+            l1_head: B256::repeat_byte(0xAA),
             intermediate_output_roots: vec![root_15, onchain_root_at_20],
             countered_index: 2, // 1-based → challenged_index = 1
         },
@@ -1083,6 +1091,7 @@ async fn test_step_invalid_zk_proposal_initiates_zk_nullification() {
                 parent_index: 0,
             },
             starting_block_number: 10,
+            l1_head: B256::repeat_byte(0xAA),
             intermediate_output_roots: vec![root_15, B256::repeat_byte(0xFF)],
             countered_index: 0,
         },
@@ -1123,6 +1132,7 @@ async fn test_step_valid_zk_proposal_skipped() {
                 parent_index: 0,
             },
             starting_block_number: 10,
+            l1_head: B256::repeat_byte(0xAA),
             intermediate_output_roots: vec![],
             countered_index: 0,
         },

--- a/crates/proof/contracts/src/aggregate_verifier.rs
+++ b/crates/proof/contracts/src/aggregate_verifier.rs
@@ -4,7 +4,8 @@
 //! addresses, output roots), read configuration such as `BLOCK_INTERVAL`
 //! and `INTERMEDIATE_BLOCK_INTERVAL` from the implementation contract, and
 //! construct state-changing calls like `nullify` via
-//! [`encode_nullify_calldata`].
+//! [`encode_nullify_calldata`] or `challenge` via
+//! [`encode_challenge_calldata`].
 
 use alloy_primitives::{Address, B256, Bytes, U256};
 use alloy_provider::RootProvider;
@@ -52,12 +53,29 @@ sol! {
         /// Returns the intermediate output roots submitted with this game.
         function intermediateOutputRoots() external view returns (bytes memory);
 
+        /// Returns the 1-based index of the challenged intermediate root.
+        ///
+        /// `0` means the game has not been challenged. When non-zero the
+        /// actual 0-based index is `counteredByIntermediateRootIndexPlusOne - 1`.
+        function counteredByIntermediateRootIndexPlusOne() external view returns (uint256);
+
         /// Nullifies an intermediate root checkpoint for the given game.
         ///
         /// The first byte of `proofBytes` is the proof type discriminator:
         /// `0` for TEE, `1` for ZK. Use [`encode_nullify_calldata`] to
         /// construct ABI-encoded calldata for this function.
         function nullify(
+            bytes calldata proofBytes,
+            uint256 intermediateRootIndex,
+            bytes32 intermediateRootToProve
+        ) external;
+
+        /// Challenges the TEE proof with a ZK proof.
+        ///
+        /// The first byte of `proofBytes` must be `1` (ZK). Use
+        /// [`encode_challenge_calldata`] to construct ABI-encoded calldata
+        /// for this function.
+        function challenge(
             bytes calldata proofBytes,
             uint256 intermediateRootIndex,
             bytes32 intermediateRootToProve
@@ -110,6 +128,12 @@ pub trait AggregateVerifierClient: Send + Sync {
         &self,
         game_address: Address,
     ) -> Result<Vec<B256>, ContractError>;
+
+    /// Returns the 1-based index of the challenged intermediate root.
+    ///
+    /// `0` means the game has not been challenged. When non-zero the
+    /// actual 0-based index is `value - 1`.
+    async fn countered_index(&self, game_address: Address) -> Result<u64, ContractError>;
 }
 
 /// Concrete implementation backed by Alloy's sol-generated contract bindings.
@@ -277,6 +301,25 @@ impl AggregateVerifierClient for AggregateVerifierContractClient {
 
         Ok(roots)
     }
+
+    async fn countered_index(&self, game_address: Address) -> Result<u64, ContractError> {
+        let contract =
+            IAggregateVerifier::IAggregateVerifierInstance::new(game_address, &self.provider);
+
+        let value: U256 =
+            contract.counteredByIntermediateRootIndexPlusOne().call().await.map_err(|e| {
+                ContractError::Call {
+                    context: "counteredByIntermediateRootIndexPlusOne failed".into(),
+                    source: e,
+                }
+            })?;
+
+        value.try_into().map_err(|_| {
+            ContractError::Validation(
+                "counteredByIntermediateRootIndexPlusOne overflows u64".into(),
+            )
+        })
+    }
 }
 
 /// Encodes the calldata for `IAggregateVerifier.nullify()`.
@@ -289,6 +332,23 @@ pub fn encode_nullify_calldata(
     intermediate_root_to_prove: B256,
 ) -> Bytes {
     let call = IAggregateVerifier::nullifyCall {
+        proofBytes: proof_bytes,
+        intermediateRootIndex: U256::from(intermediate_root_index),
+        intermediateRootToProve: intermediate_root_to_prove,
+    };
+    Bytes::from(call.abi_encode())
+}
+
+/// Encodes the calldata for `IAggregateVerifier.challenge()`.
+///
+/// Used when challenging a TEE-proven game with a ZK proof. The first
+/// byte of `proof_bytes` must be `1` (ZK).
+pub fn encode_challenge_calldata(
+    proof_bytes: Bytes,
+    intermediate_root_index: u64,
+    intermediate_root_to_prove: B256,
+) -> Bytes {
+    let call = IAggregateVerifier::challengeCall {
         proofBytes: proof_bytes,
         intermediateRootIndex: U256::from(intermediate_root_index),
         intermediateRootToProve: intermediate_root_to_prove,
@@ -340,5 +400,42 @@ mod tests {
         assert!(decoded.proofBytes.is_empty());
         assert_eq!(decoded.intermediateRootIndex, U256::ZERO);
         assert_eq!(decoded.intermediateRootToProve, B256::ZERO);
+    }
+
+    #[test]
+    fn test_encode_challenge_calldata_has_selector() {
+        let calldata = encode_challenge_calldata(
+            Bytes::from(vec![0x01, 0xAA, 0xBB]),
+            42,
+            B256::repeat_byte(0xFF),
+        );
+        assert_eq!(&calldata[..4], &IAggregateVerifier::challengeCall::SELECTOR);
+    }
+
+    #[test]
+    fn test_encode_challenge_calldata_roundtrip() {
+        let proof_bytes = Bytes::from(vec![0x01, 0xDE, 0xAD]);
+        let index = 7u64;
+        let root = B256::repeat_byte(0xAB);
+
+        let calldata = encode_challenge_calldata(proof_bytes.clone(), index, root);
+
+        let decoded = IAggregateVerifier::challengeCall::abi_decode(&calldata)
+            .expect("round-trip decode should succeed");
+
+        assert_eq!(decoded.proofBytes, proof_bytes);
+        assert_eq!(decoded.intermediateRootIndex, U256::from(index));
+        assert_eq!(decoded.intermediateRootToProve, root);
+    }
+
+    #[test]
+    fn test_challenge_and_nullify_selectors_differ() {
+        let calldata_nullify = encode_nullify_calldata(Bytes::from(vec![0x00]), 0, B256::ZERO);
+        let calldata_challenge = encode_challenge_calldata(Bytes::from(vec![0x01]), 0, B256::ZERO);
+        assert_ne!(
+            &calldata_nullify[..4],
+            &calldata_challenge[..4],
+            "nullify and challenge must have different selectors"
+        );
     }
 }

--- a/crates/proof/contracts/src/aggregate_verifier.rs
+++ b/crates/proof/contracts/src/aggregate_verifier.rs
@@ -50,6 +50,9 @@ sol! {
         /// Returns the starting block number.
         function startingBlockNumber() external view returns (uint256);
 
+        /// Returns the L1 head block hash stored in CWIA at game creation time.
+        function l1Head() external pure returns (bytes32);
+
         /// Returns the intermediate output roots submitted with this game.
         function intermediateOutputRoots() external view returns (bytes memory);
 
@@ -111,6 +114,9 @@ pub trait AggregateVerifierClient: Send + Sync {
 
     /// Returns the starting block number for the given game.
     async fn starting_block_number(&self, game_address: Address) -> Result<u64, ContractError>;
+
+    /// Returns the L1 head block hash stored at game creation time.
+    async fn l1_head(&self, game_address: Address) -> Result<B256, ContractError>;
 
     /// Reads `BLOCK_INTERVAL` from the `AggregateVerifier` implementation contract.
     async fn read_block_interval(&self, impl_address: Address) -> Result<u64, ContractError>;
@@ -228,6 +234,17 @@ impl AggregateVerifierClient for AggregateVerifierContractClient {
         block_u256
             .try_into()
             .map_err(|_| ContractError::Validation("startingBlockNumber overflows u64".into()))
+    }
+
+    async fn l1_head(&self, game_address: Address) -> Result<B256, ContractError> {
+        let contract =
+            IAggregateVerifier::IAggregateVerifierInstance::new(game_address, &self.provider);
+
+        contract
+            .l1Head()
+            .call()
+            .await
+            .map_err(|e| ContractError::Call { context: "l1Head failed".into(), source: e })
     }
 
     async fn read_block_interval(&self, impl_address: Address) -> Result<u64, ContractError> {

--- a/crates/proof/contracts/src/lib.rs
+++ b/crates/proof/contracts/src/lib.rs
@@ -8,7 +8,8 @@
 
 mod aggregate_verifier;
 pub use aggregate_verifier::{
-    AggregateVerifierClient, AggregateVerifierContractClient, GameInfo, encode_nullify_calldata,
+    AggregateVerifierClient, AggregateVerifierContractClient, GameInfo, encode_challenge_calldata,
+    encode_nullify_calldata,
 };
 
 mod anchor_state_registry;

--- a/crates/proof/primitives/src/proof_encoder.rs
+++ b/crates/proof/primitives/src/proof_encoder.rs
@@ -30,7 +30,23 @@ pub enum CryptoError {
 pub struct ProofEncoder;
 
 impl ProofEncoder {
-    /// Encodes a TEE proof into the 130-byte format expected by `AggregateVerifier`.
+    /// Normalizes an ECDSA v-value from 0/1 to 27/28.
+    ///
+    /// Values already in the 27/28 range are returned unchanged.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the v-value is not 0, 1, 27, or 28.
+    pub const fn normalize_v(v: u8) -> Result<u8, CryptoError> {
+        match v {
+            0 | 1 => Ok(v + ECDSA_V_OFFSET),
+            27 | 28 => Ok(v),
+            _ => Err(CryptoError::InvalidVValue(v)),
+        }
+    }
+
+    /// Encodes a TEE proof into the 130-byte format expected by
+    /// `AggregateVerifier.initializeWithInitData()`.
     ///
     /// Format: `proofType(1) + l1OriginHash(32) + l1OriginNumber(32) + signature(65)`
     ///
@@ -61,11 +77,37 @@ impl ProofEncoder {
 
         // Bytes 65-129: ECDSA signature with v-value adjusted from 0/1 to 27/28
         proof_data[65..130].copy_from_slice(&signature[..ECDSA_SIGNATURE_LENGTH]);
-        proof_data[129] = match proof_data[129] {
-            0 | 1 => proof_data[129] + ECDSA_V_OFFSET,
-            27 | 28 => proof_data[129],
-            v => return Err(CryptoError::InvalidVValue(v)),
-        };
+        proof_data[129] = Self::normalize_v(proof_data[129])?;
+
+        Ok(Bytes::from(proof_data))
+    }
+
+    /// Encodes a TEE proof into the compact 66-byte format expected by
+    /// `AggregateVerifier.nullify()`, `challenge()`, and `verifyProposalProof()`.
+    ///
+    /// Format: `proofType(1) + signature(65)`
+    ///
+    /// These contract entry-points already have `l1Head` stored in CWIA, so the
+    /// proof bytes do not need to carry `l1OriginHash` or `l1OriginNumber`.
+    /// The contract slices `proofBytes[1:]` to extract the signature, unlike
+    /// `initializeWithInitData` which slices `proof[65:]`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the signature is not exactly 65 bytes or has an invalid v-value.
+    pub fn encode_dispute_proof_bytes(signature: &[u8]) -> Result<Bytes, CryptoError> {
+        if signature.len() != ECDSA_SIGNATURE_LENGTH {
+            return Err(CryptoError::InvalidSignatureLength(signature.len()));
+        }
+
+        let mut proof_data = vec![0u8; 1 + ECDSA_SIGNATURE_LENGTH];
+
+        // Byte 0: proof type (TEE = 0)
+        proof_data[0] = PROOF_TYPE_TEE;
+
+        // Bytes 1-65: ECDSA signature with v-value adjusted from 0/1 to 27/28
+        proof_data[1..66].copy_from_slice(&signature[..ECDSA_SIGNATURE_LENGTH]);
+        proof_data[65] = Self::normalize_v(proof_data[65])?;
 
         Ok(Bytes::from(proof_data))
     }
@@ -128,6 +170,48 @@ mod tests {
     #[case::oversized_signature(vec![0u8; 70], "invalid signature length")]
     fn test_encode_proof_bytes_errors(#[case] sig: Vec<u8>, #[case] expected_err: &str) {
         let result = ProofEncoder::encode_proof_bytes(&Bytes::from(sig), B256::ZERO, U256::ZERO);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains(expected_err));
+    }
+
+    // --- encode_dispute_proof_bytes tests ---
+
+    #[test]
+    fn test_encode_dispute_proof_bytes_format() {
+        let sig = test_signature(0);
+        let proof = ProofEncoder::encode_dispute_proof_bytes(&sig).unwrap();
+        assert_eq!(proof.len(), 66);
+        assert_eq!(proof[0], PROOF_TYPE_TEE);
+    }
+
+    #[test]
+    fn test_encode_dispute_proof_bytes_signature() {
+        let mut raw_sig = vec![0xAB; 65];
+        raw_sig[64] = 1;
+        let proof = ProofEncoder::encode_dispute_proof_bytes(&raw_sig).unwrap();
+        // r and s should be preserved
+        assert_eq!(&proof[1..65], &raw_sig[..64]);
+        // v should be adjusted from 1 to 28
+        assert_eq!(proof[65], 28);
+    }
+
+    #[rstest]
+    #[case::v_zero_adjusted_to_27(0, 27)]
+    #[case::v_one_adjusted_to_28(1, 28)]
+    #[case::v_27_unchanged(27, 27)]
+    #[case::v_28_unchanged(28, 28)]
+    fn test_encode_dispute_proof_bytes_v_value(#[case] input_v: u8, #[case] expected_v: u8) {
+        let sig = test_signature(input_v);
+        let proof = ProofEncoder::encode_dispute_proof_bytes(&sig).unwrap();
+        assert_eq!(proof[65], expected_v);
+    }
+
+    #[rstest]
+    #[case::invalid_v(vec![0xAB; 64].into_iter().chain(core::iter::once(5)).collect::<Vec<_>>(), "invalid ECDSA v-value")]
+    #[case::short_signature(vec![0u8; 32], "invalid signature length")]
+    #[case::oversized_signature(vec![0u8; 70], "invalid signature length")]
+    fn test_encode_dispute_proof_bytes_errors(#[case] sig: Vec<u8>, #[case] expected_err: &str) {
+        let result = ProofEncoder::encode_dispute_proof_bytes(&sig);
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains(expected_err));
     }

--- a/crates/proof/proposer/src/test_utils.rs
+++ b/crates/proof/proposer/src/test_utils.rs
@@ -214,6 +214,9 @@ impl AggregateVerifierClient for MockAggregateVerifier {
     async fn intermediate_output_roots(&self, _: Address) -> Result<Vec<B256>, ContractError> {
         Ok(vec![])
     }
+    async fn countered_index(&self, _: Address) -> Result<u64, ContractError> {
+        Ok(0)
+    }
 }
 
 pub(crate) fn test_l1_block_ref(number: u64) -> L1BlockRef {

--- a/crates/proof/proposer/src/test_utils.rs
+++ b/crates/proof/proposer/src/test_utils.rs
@@ -205,6 +205,9 @@ impl AggregateVerifierClient for MockAggregateVerifier {
     async fn starting_block_number(&self, _: Address) -> Result<u64, ContractError> {
         Ok(0)
     }
+    async fn l1_head(&self, _: Address) -> Result<B256, ContractError> {
+        Ok(B256::ZERO)
+    }
     async fn read_block_interval(&self, _: Address) -> Result<u64, ContractError> {
         Ok(512)
     }


### PR DESCRIPTION
## Summary

Refactors the challenger to classify dispute games into three distinct paths and dispatch to the appropriate handler, replacing the previous single-path nullification-only flow.

### Three dispute paths

1. **Wrong TEE proof** (`InvalidTeeProposal`) — nullify with a TEE proof or challenge with a ZK proof via `challenge()`.
2. **Fraudulent ZK challenge** (`FraudulentZkChallenge`) — a correct TEE proposal was challenged with a wrong ZK proof; nullify the fraudulent challenge with a ZK proof via `nullify()`.
3. **Wrong ZK proposal** (`InvalidZkProposal`) — nullify the incorrect ZK proposal with a ZK proof via `nullify()`.

### Key changes

- **`GameCategory` enum + `classify()` in scanner** — games are now classified based on `teeProver`, `zkProver`, and `counteredByIntermediateRootIndexPlusOne` state. Scanner fetches `countered_index` and `l1_head` alongside existing fields.
- **`DisputeIntent` enum** (`Challenge` | `Nullify`) — attached to each `PendingProof` to drive which on-chain function is called at submission time.
- **Driver dispatch** — `process_candidate` routes to `process_invalid_proposal` (Paths 1 & 3) or `process_fraudulent_zk_challenge` (Path 2). Validation logic extracted into `validate_game`.
- **`poll_or_submit` improvements** — intent-aware liveness checks: Challenge intents verify `teeProver` is still set; Nullify intents check whether the targeted prover has already been zeroed, preventing infinite retry loops.
- **Submitter** — `submit_nullification` → `submit_dispute`, which encodes either `nullify()` or `challenge()` calldata based on `DisputeIntent`.
- **TEE proof sourcing** — uses the game's stored L1 head (from CWIA) instead of fetching the current finalized head; `L1HeadProvider` trait changed from `finalized_head()` to `block_number_by_hash()`. Proof encoding switched to compact format (`encode_dispute_proof_bytes` — type + signature only, no L1 origin data).
- **Contracts** — added `encode_challenge_calldata`, `encode_dispute_proof_bytes`, `countered_index`, and `l1_head` to `AggregateVerifierClient`.
- **Metrics** — new counters for challenge tx submitted/outcome/latency, fraudulent ZK challenge detected, and invalid ZK proposal detected.
- **Tests** — significantly expanded driver and submitter tests covering all three paths, including fraudulent challenge validation edge cases.