### PR TITLE
fix(proposer): verify on-chain root claims against canonical output roots during recovery

### DIFF
--- a/crates/proof/proposer/src/driver/handle.rs
+++ b/crates/proof/proposer/src/driver/handle.rs
@@ -147,6 +147,8 @@ where
 mod tests {
     use std::{sync::Arc, time::Duration};
 
+    use std::collections::HashMap;
+
     use alloy_primitives::{B256, Bytes, U256};
     use async_trait::async_trait;
     use base_proof_primitives::{ProofResult, Proposal, ProverClient};
@@ -200,7 +202,10 @@ mod tests {
         let l1 = Arc::new(MockL1 { latest_block_number: 1000 });
         let l2 = Arc::new(MockL2 { block_not_found: true, canonical_hash: None });
         let prover: Arc<dyn ProverClient> = Arc::new(InstantMockProver);
-        let rollup = Arc::new(MockRollupClient { sync_status: test_sync_status(200, B256::ZERO) });
+        let rollup = Arc::new(MockRollupClient {
+            sync_status: test_sync_status(200, B256::ZERO),
+            output_roots: HashMap::new(),
+        });
         let anchor_registry =
             Arc::new(MockAnchorStateRegistry { anchor_root: test_anchor_root(0) });
         let factory = Arc::new(MockDisputeGameFactory::with_count(0));

--- a/crates/proof/proposer/src/driver/handle.rs
+++ b/crates/proof/proposer/src/driver/handle.rs
@@ -145,9 +145,7 @@ where
 
 #[cfg(test)]
 mod tests {
-    use std::{sync::Arc, time::Duration};
-
-    use std::collections::HashMap;
+    use std::{collections::HashMap, sync::Arc, time::Duration};
 
     use alloy_primitives::{B256, Bytes, U256};
     use async_trait::async_trait;

--- a/crates/proof/proposer/src/driver/pipeline.rs
+++ b/crates/proof/proposer/src/driver/pipeline.rs
@@ -1459,11 +1459,7 @@ mod tests {
         );
         info_map.insert(
             proxy_addr(1),
-            GameInfo {
-                root_claim: B256::repeat_byte(0xDE),
-                l2_block_number: 200,
-                parent_index: 0,
-            },
+            GameInfo { root_claim: B256::repeat_byte(0xDE), l2_block_number: 200, parent_index: 0 },
         );
 
         let mut output_roots = HashMap::new();
@@ -1496,19 +1492,11 @@ mod tests {
         let mut info_map = HashMap::new();
         info_map.insert(
             proxy_addr(0),
-            GameInfo {
-                root_claim: B256::repeat_byte(0xAA),
-                l2_block_number: 100,
-                parent_index: 0,
-            },
+            GameInfo { root_claim: B256::repeat_byte(0xAA), l2_block_number: 100, parent_index: 0 },
         );
         info_map.insert(
             proxy_addr(1),
-            GameInfo {
-                root_claim: B256::repeat_byte(0xBB),
-                l2_block_number: 200,
-                parent_index: 0,
-            },
+            GameInfo { root_claim: B256::repeat_byte(0xBB), l2_block_number: 200, parent_index: 0 },
         );
 
         let mut output_roots = HashMap::new();

--- a/crates/proof/proposer/src/driver/pipeline.rs
+++ b/crates/proof/proposer/src/driver/pipeline.rs
@@ -636,6 +636,33 @@ where
                 }
             };
 
+            // Verify the on-chain root_claim matches the canonical output root
+            // from the rollup node.  Games with mismatched roots are skipped so
+            // we never chain off an incorrect proposal.
+            match self.rollup_client.output_at_block(game_info.l2_block_number).await {
+                // Root matches — safe to chain off this game.
+                Ok(canonical) if canonical.output_root == game_info.root_claim => {}
+                // Mismatch — this game proposed an incorrect root. Skip it and
+                // keep scanning for an older game with a valid root.
+                Ok(canonical) => {
+                    warn!(
+                        game_index,
+                        game_proxy = %game.proxy,
+                        on_chain_root = ?game_info.root_claim,
+                        canonical_root = ?canonical.output_root,
+                        l2_block_number = game_info.l2_block_number,
+                        "Output root mismatch, skipping game"
+                    );
+                    continue;
+                }
+                // RPC failure is transient — bubble up so the caller retries
+                // the entire recovery on the next tick rather than silently
+                // skipping a potentially valid game.
+                Err(e) => {
+                    return Err(ProposerError::Rpc(e));
+                }
+            }
+
             let idx: u32 = game_index.try_into().map_err(|_| {
                 ProposerError::Contract(format!("game index {game_index} exceeds u32"))
             })?;
@@ -1028,6 +1055,7 @@ mod tests {
             Arc::new(MockProver { delay: Duration::from_millis(10) });
         let rollup = Arc::new(MockRollupClient {
             sync_status: test_sync_status(safe_block_number, B256::ZERO),
+            output_roots: HashMap::new(),
         });
         let anchor_registry =
             Arc::new(MockAnchorStateRegistry { anchor_root: test_anchor_root(0) });
@@ -1256,12 +1284,30 @@ mod tests {
         MockAnchorStateRegistry,
         MockDisputeGameFactory,
     > {
+        recovery_pipeline_with_roots(game_type, factory, verifier, HashMap::new())
+    }
+
+    fn recovery_pipeline_with_roots(
+        game_type: u32,
+        factory: MockDisputeGameFactory,
+        verifier: MockAggregateVerifier,
+        output_roots: HashMap<u64, B256>,
+    ) -> ProvingPipeline<
+        MockL1,
+        MockL2,
+        MockRollupClient,
+        MockAnchorStateRegistry,
+        MockDisputeGameFactory,
+    > {
         let cancel = CancellationToken::new();
         let l1 = Arc::new(MockL1 { latest_block_number: 1000 });
         let l2 = Arc::new(MockL2 { block_not_found: true, canonical_hash: None });
         let prover: Arc<dyn ProverClient> =
             Arc::new(MockProver { delay: Duration::from_millis(1) });
-        let rollup = Arc::new(MockRollupClient { sync_status: test_sync_status(0, B256::ZERO) });
+        let rollup = Arc::new(MockRollupClient {
+            sync_status: test_sync_status(0, B256::ZERO),
+            output_roots,
+        });
         let anchor_registry =
             Arc::new(MockAnchorStateRegistry { anchor_root: test_anchor_root(0) });
 
@@ -1301,6 +1347,7 @@ mod tests {
     async fn test_scan_range_finds_matching_game() {
         let target_game_type = 42u32;
         let matching_proxy = proxy_addr(2);
+        let root = B256::repeat_byte(0xAA);
 
         // 3 games: indices 0, 1 have wrong type; index 2 matches.
         let games = vec![
@@ -1312,25 +1359,31 @@ mod tests {
         let mut info_map = HashMap::new();
         info_map.insert(
             matching_proxy,
-            GameInfo { root_claim: B256::repeat_byte(0xAA), l2_block_number: 512, parent_index: 0 },
+            GameInfo { root_claim: root, l2_block_number: 512, parent_index: 0 },
         );
 
-        let pipeline = recovery_pipeline(
+        let mut output_roots = HashMap::new();
+        output_roots.insert(512, root);
+
+        let pipeline = recovery_pipeline_with_roots(
             target_game_type,
             MockDisputeGameFactory::with_games(games),
             MockAggregateVerifier::with_game_info(info_map),
+            output_roots,
         );
 
         let result = pipeline.scan_range_for_recovery(3, 3).await.unwrap();
         let state = result.expect("should find the matching game");
         assert_eq!(state.game_index, 2);
         assert_eq!(state.l2_block_number, 512);
-        assert_eq!(state.output_root, B256::repeat_byte(0xAA));
+        assert_eq!(state.output_root, root);
     }
 
     #[tokio::test(flavor = "current_thread", start_paused = true)]
     async fn test_scan_range_returns_most_recent_match() {
         let target_game_type = 42u32;
+        let root_1 = B256::repeat_byte(0x01);
+        let root_3 = B256::repeat_byte(0x03);
 
         // Two matching games: index 1 and index 3.  Scan should return index 3
         // (most recent) because indices are walked highest-first.
@@ -1344,17 +1397,22 @@ mod tests {
         let mut info_map = HashMap::new();
         info_map.insert(
             proxy_addr(1),
-            GameInfo { root_claim: B256::repeat_byte(0x01), l2_block_number: 100, parent_index: 0 },
+            GameInfo { root_claim: root_1, l2_block_number: 100, parent_index: 0 },
         );
         info_map.insert(
             proxy_addr(3),
-            GameInfo { root_claim: B256::repeat_byte(0x03), l2_block_number: 300, parent_index: 1 },
+            GameInfo { root_claim: root_3, l2_block_number: 300, parent_index: 1 },
         );
 
-        let pipeline = recovery_pipeline(
+        let mut output_roots = HashMap::new();
+        output_roots.insert(100, root_1);
+        output_roots.insert(300, root_3);
+
+        let pipeline = recovery_pipeline_with_roots(
             target_game_type,
             MockDisputeGameFactory::with_games(games),
             MockAggregateVerifier::with_game_info(info_map),
+            output_roots,
         );
 
         let result = pipeline.scan_range_for_recovery(4, 4).await.unwrap();
@@ -1383,9 +1441,96 @@ mod tests {
     }
 
     #[tokio::test(flavor = "current_thread", start_paused = true)]
+    async fn test_scan_range_skips_mismatched_output_root() {
+        let target_game_type = 42u32;
+        let valid_root = B256::repeat_byte(0xBB);
+
+        // Two matching games by type: index 1 (mismatched root) and index 0
+        // (valid root).  Scan should skip index 1 and return index 0.
+        let games = vec![
+            GameAtIndex { game_type: target_game_type, timestamp: 1, proxy: proxy_addr(0) },
+            GameAtIndex { game_type: target_game_type, timestamp: 2, proxy: proxy_addr(1) },
+        ];
+
+        let mut info_map = HashMap::new();
+        info_map.insert(
+            proxy_addr(0),
+            GameInfo { root_claim: valid_root, l2_block_number: 100, parent_index: 0 },
+        );
+        info_map.insert(
+            proxy_addr(1),
+            GameInfo {
+                root_claim: B256::repeat_byte(0xDE),
+                l2_block_number: 200,
+                parent_index: 0,
+            },
+        );
+
+        let mut output_roots = HashMap::new();
+        output_roots.insert(100, valid_root);
+        output_roots.insert(200, B256::repeat_byte(0xAB));
+
+        let pipeline = recovery_pipeline_with_roots(
+            target_game_type,
+            MockDisputeGameFactory::with_games(games),
+            MockAggregateVerifier::with_game_info(info_map),
+            output_roots,
+        );
+
+        let result = pipeline.scan_range_for_recovery(2, 2).await.unwrap();
+        let state = result.expect("should find valid match after skipping mismatch");
+        assert_eq!(state.game_index, 0);
+        assert_eq!(state.l2_block_number, 100);
+        assert_eq!(state.output_root, valid_root);
+    }
+
+    #[tokio::test(flavor = "current_thread", start_paused = true)]
+    async fn test_scan_range_returns_none_when_all_roots_mismatch() {
+        let target_game_type = 42u32;
+
+        let games = vec![
+            GameAtIndex { game_type: target_game_type, timestamp: 1, proxy: proxy_addr(0) },
+            GameAtIndex { game_type: target_game_type, timestamp: 2, proxy: proxy_addr(1) },
+        ];
+
+        let mut info_map = HashMap::new();
+        info_map.insert(
+            proxy_addr(0),
+            GameInfo {
+                root_claim: B256::repeat_byte(0xAA),
+                l2_block_number: 100,
+                parent_index: 0,
+            },
+        );
+        info_map.insert(
+            proxy_addr(1),
+            GameInfo {
+                root_claim: B256::repeat_byte(0xBB),
+                l2_block_number: 200,
+                parent_index: 0,
+            },
+        );
+
+        let mut output_roots = HashMap::new();
+        output_roots.insert(100, B256::repeat_byte(0x11));
+        output_roots.insert(200, B256::repeat_byte(0x22));
+
+        let pipeline = recovery_pipeline_with_roots(
+            target_game_type,
+            MockDisputeGameFactory::with_games(games),
+            MockAggregateVerifier::with_game_info(info_map),
+            output_roots,
+        );
+
+        let result = pipeline.scan_range_for_recovery(2, 2).await.unwrap();
+        assert!(result.is_none(), "all roots mismatch — should return None");
+    }
+
+    #[tokio::test(flavor = "current_thread", start_paused = true)]
     async fn test_recovery_cache_hit_equal_game_count() {
         let target_game_type = 42u32;
         let matching_proxy = proxy_addr(0);
+        let root = B256::repeat_byte(0xBB);
 
         let games =
             vec![GameAtIndex { game_type: target_game_type, timestamp: 1, proxy: matching_proxy }];
@@ -1393,13 +1538,17 @@ mod tests {
         let mut info_map = HashMap::new();
         info_map.insert(
             matching_proxy,
-            GameInfo { root_claim: B256::repeat_byte(0xBB), l2_block_number: 256, parent_index: 0 },
+            GameInfo { root_claim: root, l2_block_number: 256, parent_index: 0 },
         );
 
-        let pipeline = recovery_pipeline(
+        let mut output_roots = HashMap::new();
+        output_roots.insert(256, root);
+
+        let pipeline = recovery_pipeline_with_roots(
             target_game_type,
             MockDisputeGameFactory::with_games(games),
             MockAggregateVerifier::with_game_info(info_map),
+            output_roots,
         );
 
         // First call: cold start, populates the cache.
@@ -1421,6 +1570,8 @@ mod tests {
     #[tokio::test(flavor = "current_thread", start_paused = true)]
     async fn test_recovery_incremental_new_matching_game() {
         let target_game_type = 42u32;
+        let root_0 = B256::repeat_byte(0x01);
+        let root_1 = B256::repeat_byte(0x02);
 
         // Start with one matching game.
         let games = vec![
@@ -1432,21 +1583,26 @@ mod tests {
         let mut info_map = HashMap::new();
         info_map.insert(
             proxy_addr(0),
-            GameInfo { root_claim: B256::repeat_byte(0x01), l2_block_number: 100, parent_index: 0 },
+            GameInfo { root_claim: root_0, l2_block_number: 100, parent_index: 0 },
         );
         info_map.insert(
             proxy_addr(1),
-            GameInfo { root_claim: B256::repeat_byte(0x02), l2_block_number: 200, parent_index: 0 },
+            GameInfo { root_claim: root_1, l2_block_number: 200, parent_index: 0 },
         );
+
+        let mut output_roots = HashMap::new();
+        output_roots.insert(100, root_0);
+        output_roots.insert(200, root_1);
 
         // Build factory with override: first call sees count=1, but the full
         // Vec has 2 entries so game_at_index(1) works.
         let factory = MockDisputeGameFactory { games: games.clone(), game_count_override: Some(1) };
 
-        let pipeline = recovery_pipeline(
+        let pipeline = recovery_pipeline_with_roots(
             target_game_type,
             factory,
             MockAggregateVerifier::with_game_info(info_map),
+            output_roots.clone(),
         );
 
         // First call: cold start with count=1, finds game at index 0.
@@ -1462,29 +1618,22 @@ mod tests {
         // build a new pipeline with game_count_override=2.
         let factory2 = MockDisputeGameFactory { games, game_count_override: Some(2) };
 
-        let pipeline2 = recovery_pipeline(
+        let pipeline2 = recovery_pipeline_with_roots(
             target_game_type,
             factory2,
             MockAggregateVerifier::with_game_info({
                 let mut m = HashMap::new();
                 m.insert(
                     proxy_addr(0),
-                    GameInfo {
-                        root_claim: B256::repeat_byte(0x01),
-                        l2_block_number: 100,
-                        parent_index: 0,
-                    },
+                    GameInfo { root_claim: root_0, l2_block_number: 100, parent_index: 0 },
                 );
                 m.insert(
                     proxy_addr(1),
-                    GameInfo {
-                        root_claim: B256::repeat_byte(0x02),
-                        l2_block_number: 200,
-                        parent_index: 0,
-                    },
+                    GameInfo { root_claim: root_1, l2_block_number: 200, parent_index: 0 },
                 );
                 m
             }),
+            output_roots,
         );
 
         // Incremental scan: cache says count was 1, now it's 2.  The new game
@@ -1498,6 +1647,7 @@ mod tests {
     #[tokio::test(flavor = "current_thread", start_paused = true)]
     async fn test_recovery_incremental_no_new_match_returns_cached() {
         let target_game_type = 42u32;
+        let root = B256::repeat_byte(0xCC);
 
         // Game at index 0 matches, game at index 1 does NOT match.
         let games = vec![
@@ -1508,16 +1658,20 @@ mod tests {
         let mut info_map = HashMap::new();
         info_map.insert(
             proxy_addr(0),
-            GameInfo { root_claim: B256::repeat_byte(0xCC), l2_block_number: 512, parent_index: 0 },
+            GameInfo { root_claim: root, l2_block_number: 512, parent_index: 0 },
         );
+
+        let mut output_roots = HashMap::new();
+        output_roots.insert(512, root);
 
         // First call: factory reports count=1, finds game at index 0.
         let factory1 =
             MockDisputeGameFactory { games: games.clone(), game_count_override: Some(1) };
-        let pipeline1 = recovery_pipeline(
+        let pipeline1 = recovery_pipeline_with_roots(
             target_game_type,
             factory1,
             MockAggregateVerifier::with_game_info(info_map.clone()),
+            output_roots.clone(),
         );
 
         let mut cache: Option<CachedRecovery> = None;
@@ -1527,10 +1681,11 @@ mod tests {
         // Second call: factory reports count=2, but the new game (index 1) has
         // a different type.  Should return cached state.
         let factory2 = MockDisputeGameFactory { games, game_count_override: Some(2) };
-        let pipeline2 = recovery_pipeline(
+        let pipeline2 = recovery_pipeline_with_roots(
             target_game_type,
             factory2,
             MockAggregateVerifier::with_game_info(info_map),
+            output_roots,
         );
 
         let state2 = pipeline2.recover_latest_state(&mut cache).await.unwrap();
@@ -1545,6 +1700,8 @@ mod tests {
     #[tokio::test(flavor = "current_thread", start_paused = true)]
     async fn test_recovery_cache_invalidation_count_decreased() {
         let target_game_type = 42u32;
+        let root_0 = B256::repeat_byte(0x10);
+        let root_2 = B256::repeat_byte(0x30);
 
         // Seed the cache as if count was 5 and we found a game.
         let mut cache = Some(CachedRecovery {
@@ -1567,17 +1724,22 @@ mod tests {
         let mut info_map = HashMap::new();
         info_map.insert(
             proxy_addr(0),
-            GameInfo { root_claim: B256::repeat_byte(0x10), l2_block_number: 100, parent_index: 0 },
+            GameInfo { root_claim: root_0, l2_block_number: 100, parent_index: 0 },
         );
         info_map.insert(
             proxy_addr(2),
-            GameInfo { root_claim: B256::repeat_byte(0x30), l2_block_number: 300, parent_index: 0 },
+            GameInfo { root_claim: root_2, l2_block_number: 300, parent_index: 0 },
         );
 
-        let pipeline = recovery_pipeline(
+        let mut output_roots = HashMap::new();
+        output_roots.insert(100, root_0);
+        output_roots.insert(300, root_2);
+
+        let pipeline = recovery_pipeline_with_roots(
             target_game_type,
             MockDisputeGameFactory::with_games(games),
             MockAggregateVerifier::with_game_info(info_map),
+            output_roots,
         );
 
         let state = pipeline.recover_latest_state(&mut cache).await.unwrap();
@@ -1633,6 +1795,7 @@ mod tests {
     #[tokio::test(flavor = "current_thread", start_paused = true)]
     async fn test_recovery_incremental_delta_exceeds_lookback_triggers_full_scan() {
         let target_game_type = 42u32;
+        let root = B256::repeat_byte(0xFF);
 
         // Seed the cache as if count was 1.
         let mut cache = Some(CachedRecovery {
@@ -1661,17 +1824,17 @@ mod tests {
         let mut info_map = HashMap::new();
         info_map.insert(
             proxy_addr(last_idx as u64),
-            GameInfo {
-                root_claim: B256::repeat_byte(0xFF),
-                l2_block_number: 9999,
-                parent_index: 0,
-            },
+            GameInfo { root_claim: root, l2_block_number: 9999, parent_index: 0 },
         );
 
-        let pipeline = recovery_pipeline(
+        let mut output_roots = HashMap::new();
+        output_roots.insert(9999, root);
+
+        let pipeline = recovery_pipeline_with_roots(
             target_game_type,
             MockDisputeGameFactory::with_games(games),
             MockAggregateVerifier::with_game_info(info_map),
+            output_roots,
         );
 
         let state = pipeline.recover_latest_state(&mut cache).await.unwrap();

--- a/crates/proof/proposer/src/test_utils.rs
+++ b/crates/proof/proposer/src/test_utils.rs
@@ -81,9 +81,9 @@ impl L2Provider for MockL2 {
     }
 }
 
-/// Mock rollup client that returns a configurable `SyncStatus`.
 pub(crate) struct MockRollupClient {
     pub sync_status: SyncStatus,
+    pub output_roots: std::collections::HashMap<u64, B256>,
 }
 
 #[async_trait]
@@ -95,10 +95,12 @@ impl RollupProvider for MockRollupClient {
         Ok(self.sync_status.clone())
     }
     async fn output_at_block(&self, block_number: u64) -> RpcResult<OutputAtBlock> {
-        Ok(OutputAtBlock {
-            output_root: B256::repeat_byte(block_number as u8),
-            block_ref: test_l2_block_ref(block_number, B256::repeat_byte(block_number as u8)),
-        })
+        let root = self
+            .output_roots
+            .get(&block_number)
+            .copied()
+            .unwrap_or_else(|| B256::repeat_byte(block_number as u8));
+        Ok(OutputAtBlock { output_root: root, block_ref: test_l2_block_ref(block_number, root) })
     }
 }
 

--- a/crates/proof/rpc/src/rollup_client.rs
+++ b/crates/proof/rpc/src/rollup_client.rs
@@ -112,8 +112,7 @@ impl RollupClient {
         // Create provider directly without fillers (read-only operations)
         let provider = RootProvider::new(rpc_client);
 
-        let output_cache =
-            MeteredCache::with_capacity("rollup_output_at_block", config.cache_size);
+        let output_cache = MeteredCache::with_capacity("rollup_output_at_block", config.cache_size);
 
         Ok(Self { provider, output_cache, retry_config: config.retry_config })
     }

--- a/crates/proof/rpc/src/rollup_client.rs
+++ b/crates/proof/rpc/src/rollup_client.rs
@@ -13,7 +13,8 @@ use url::Url;
 
 use super::{
     HttpProvider,
-    config::RetryConfig,
+    cache::MeteredCache,
+    config::{DEFAULT_CACHE_SIZE, RetryConfig},
     error::{RpcError, RpcResult},
     traits::RollupProvider,
     types::{OutputAtBlock, SyncStatus},
@@ -26,6 +27,8 @@ pub struct RollupClientConfig {
     pub endpoint: Url,
     /// Request timeout.
     pub timeout: Duration,
+    /// Cache size for output-at-block responses.
+    pub cache_size: usize,
     /// Retry configuration.
     pub retry_config: RetryConfig,
     /// Skip TLS certificate verification.
@@ -38,6 +41,7 @@ impl RollupClientConfig {
         Self {
             endpoint,
             timeout: Duration::from_secs(30),
+            cache_size: DEFAULT_CACHE_SIZE,
             retry_config: RetryConfig::default(),
             skip_tls_verify: false,
         }
@@ -46,6 +50,12 @@ impl RollupClientConfig {
     /// Sets the request timeout.
     pub const fn with_timeout(mut self, timeout: Duration) -> Self {
         self.timeout = timeout;
+        self
+    }
+
+    /// Sets the cache size for output-at-block responses.
+    pub const fn with_cache_size(mut self, cache_size: usize) -> Self {
+        self.cache_size = cache_size;
         self
     }
 
@@ -66,13 +76,17 @@ impl RollupClientConfig {
 pub struct RollupClient {
     /// The underlying HTTP provider.
     provider: HttpProvider,
+    /// Cache for `optimism_outputAtBlock` responses keyed by L2 block number.
+    output_cache: MeteredCache<u64, OutputAtBlock>,
     /// Retry configuration.
     retry_config: RetryConfig,
 }
 
 impl std::fmt::Debug for RollupClient {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("RollupClient").finish_non_exhaustive()
+        f.debug_struct("RollupClient")
+            .field("output_cache_entries", &self.output_cache.entry_count())
+            .finish_non_exhaustive()
     }
 }
 
@@ -98,7 +112,15 @@ impl RollupClient {
         // Create provider directly without fillers (read-only operations)
         let provider = RootProvider::new(rpc_client);
 
-        Ok(Self { provider, retry_config: config.retry_config })
+        let output_cache =
+            MeteredCache::with_capacity("rollup_output_at_block", config.cache_size);
+
+        Ok(Self { provider, output_cache, retry_config: config.retry_config })
+    }
+
+    /// Returns the output-at-block cache.
+    pub const fn output_cache(&self) -> &MeteredCache<u64, OutputAtBlock> {
+        &self.output_cache
     }
 }
 
@@ -146,9 +168,13 @@ impl RollupProvider for RollupClient {
     }
 
     async fn output_at_block(&self, block_number: u64) -> RpcResult<OutputAtBlock> {
+        if let Some(cached) = self.output_cache.get(&block_number).await {
+            return Ok(cached);
+        }
+
         let backoff = self.retry_config.to_backoff_builder();
 
-        (|| async {
+        let output = (|| async {
             self.provider
                 .raw_request::<_, OutputAtBlock>(
                     "optimism_outputAtBlock".into(),
@@ -164,7 +190,11 @@ impl RollupProvider for RollupClient {
         .notify(|err, dur| {
             tracing::debug!(error = %err, delay = ?dur, "Retrying RollupClient::output_at_block");
         })
-        .await
+        .await?;
+
+        self.output_cache.insert(block_number, output.clone()).await;
+
+        Ok(output)
     }
 }
 


### PR DESCRIPTION
## Summary

- **Verify output roots during recovery**: `scan_range_for_recovery` now calls `rollup_client.output_at_block()` for each candidate game and compares the canonical `output_root` against the game's `root_claim`. Games with mismatched roots are skipped, preventing the proposer from chaining off an incorrect proposal after a restart.
- **Propagate RPC errors instead of skipping**: If `output_at_block` fails due to a transient RPC error, the error is propagated so the caller retries recovery on the next tick, rather than silently skipping a potentially valid game.
- **Cache `output_at_block` responses**: Adds a `MeteredCache<u64, OutputAtBlock>` to `RollupClient` (following the existing `L1Client`/`L2Client` pattern) so repeated recovery scans across ticks don't re-fetch the same block's output root.

## Changes

| File | Change |
|------|--------|
| `crates/proof/proposer/src/driver/pipeline.rs` | Added output root verification logic in `scan_range_for_recovery`; updated 7 existing tests to provide matching output roots; added 2 new tests (`test_scan_range_skips_mismatched_output_root`, `test_scan_range_returns_none_when_all_roots_mismatch`) |
| `crates/proof/rpc/src/rollup_client.rs` | Added `cache_size` to `RollupClientConfig`; added `MeteredCache<u64, OutputAtBlock>` to `RollupClient` with cache-first lookup in `output_at_block` |
| `crates/proof/proposer/src/test_utils.rs` | Added `output_roots: HashMap<u64, B256>` to `MockRollupClient` for per-block overrides |
| `crates/proof/proposer/src/driver/handle.rs` | Updated `MockRollupClient` construction with new `output_roots` field |

## Testing

- All LSP diagnostics pass on modified files
- 2 new tests cover mismatch-skip and all-mismatch-none scenarios
- 7 existing recovery tests updated to work with the new verification logic