### PR TITLE
chore(gossip): remove extern crate alloy_rlp; move to dev-dependencies

### DIFF
--- a/crates/consensus/gossip/Cargo.toml
+++ b/crates/consensus/gossip/Cargo.toml
@@ -20,7 +20,6 @@ base-consensus-peers.workspace = true
 base-consensus-genesis.workspace = true
 
 # Alloy
-alloy-rlp = { workspace = true, features = ["std"] }
 alloy-eips = { workspace = true, features = ["std"] }
 alloy-consensus = { workspace = true, features = ["std"] }
 alloy-rpc-types-engine = { workspace = true, features = ["std"] }
@@ -54,10 +53,10 @@ metrics = { workspace = true, optional = true }
 [dev-dependencies]
 tempfile.workspace = true
 multihash.workspace = true
+alloy-rlp = { workspace = true, features = ["std"] }
 serde_json = { workspace = true, features = ["std"] }
-alloy-chains = { workspace = true, features = ["std"] }
-
 rand = { workspace = true, features = ["thread_rng"] }
+alloy-chains = { workspace = true, features = ["std"] }
 arbitrary = { workspace = true, features = ["derive"] }
 alloy-primitives = { workspace = true, features = ["arbitrary"] }
 base-alloy-consensus = { workspace = true, features = ["arbitrary", "k256"] }
@@ -65,9 +64,4 @@ alloy-consensus = { workspace = true, features = ["arbitrary", "k256", "std"] }
 
 [features]
 default = []
-metrics = [
-	"base-consensus-disc/metrics",
-	"base-metrics/metrics",
-	"dep:metrics",
-	"libp2p/metrics",
-]
+metrics = [ "base-consensus-disc/metrics", "dep:metrics", "libp2p/metrics" ]

--- a/crates/consensus/gossip/src/lib.rs
+++ b/crates/consensus/gossip/src/lib.rs
@@ -9,9 +9,6 @@
 
 #[macro_use]
 extern crate tracing;
-// Used in tests
-#[allow(unused_extern_crates)]
-extern crate alloy_rlp;
 
 mod metrics;
 pub use metrics::Metrics;


### PR DESCRIPTION
## Summary
Remove the obsolete `extern crate alloy_rlp` / `unused_extern_crates` workaround in `base-consensus-gossip` and declare `alloy-rlp` only where it is actually used (tests).

## Motivation
- `alloy_rlp` is only used from `#[cfg(test)]` code (e.g. `BufMut` in `block_validity` tests), not from the library target.
- With `unused_crate_dependencies` enabled for non-test builds, keeping `alloy-rlp` in `[dependencies]` triggers warnings.
- `extern crate` plus `#[allow(unused_extern_crates)]` is misleading and out of line with normal 2021-edition `use` style.

## Changes
- **`src/lib.rs`**: Drop `extern crate alloy_rlp` and `#[allow(unused_extern_crates)]` (and the misleading comment). Keep `#[macro_use] extern crate tracing`.
- **`Cargo.toml`**: Remove `alloy-rlp` from `[dependencies]`; add it under `[dev-dependencies]` with `workspace = true` and `features = ["std"]`. Reorder `dev-dependencies` by line length (waterfall) per repo convention.
