### PR TITLE
test(protocol): use frame validity case names in assertions

### DIFF
--- a/crates/consensus/protocol/src/channel.rs
+++ b/crates/consensus/protocol/src/channel.rs
@@ -208,7 +208,6 @@ mod tests {
     use super::*;
 
     struct FrameValidityTestCase {
-        #[allow(dead_code)]
         name: String,
         frames: Vec<Frame>,
         should_error: Vec<bool>,
@@ -217,31 +216,40 @@ mod tests {
     }
 
     fn run_frame_validity_test(test_case: FrameValidityTestCase) {
-        // #[cfg(feature = "std")]
-        // println!("Running test: {}", test_case.name);
-
         let id = [0xFF; 16];
         let block = BlockInfo::default();
         let mut channel = Channel::new(id, block);
+        let case = test_case.name.as_str();
 
         if test_case.frames.len() != test_case.should_error.len()
             || test_case.frames.len() != test_case.sizes.len()
         {
-            panic!("Test case length mismatch");
+            panic!("test case length mismatch (case={case})");
         }
 
         for (i, frame) in test_case.frames.iter().enumerate() {
             let result = channel.add_frame(frame.clone(), block);
             if test_case.should_error[i] {
-                assert!(result.is_err());
+                assert!(
+                    result.is_err(),
+                    "case={case}: frame index {i} expected Err, got {result:?}"
+                );
             } else {
-                assert!(result.is_ok());
+                assert!(result.is_ok(), "case={case}: frame index {i} expected Ok, got {result:?}");
             }
-            assert_eq!(channel.size(), test_case.sizes[i] as usize);
+            assert_eq!(
+                channel.size(),
+                test_case.sizes[i] as usize,
+                "case={case}: frame index {i} channel.size mismatch"
+            );
         }
 
         if let Some(frame_data) = test_case.frame_data {
-            assert_eq!(channel.frame_data().unwrap(), frame_data);
+            assert_eq!(
+                channel.frame_data().unwrap(),
+                frame_data,
+                "case={case}: frame_data mismatch"
+            );
         }
     }
 


### PR DESCRIPTION
## Summary

Improve `Channel` frame-validity unit tests in `crates/consensus/protocol/src/channel.rs` by using each scenario’s `name` in `panic!` / assertion messages instead of silencing `dead_code` on an unused field.

## Motivation

- The `name` field on `FrameValidityTestCase` only labels each scenario, but the only code that would read it (a debug `println!`) was commented out, so the field was never used and triggered `dead_code` (or equivalent unused-field warnings).
- `#[allow(dead_code)]` suppresses the warning without fixing the issue: the label still did not participate in any real behavior, and it makes it easier to hide genuine dead code later.
- These table-driven tests already carry human-readable scenario names; surfacing them on failure paths keeps local runs and CI logs consistent without relying on commented-out prints.

## Benefits

- Failed assertions and panics include **`case=...` and the frame index**, so you do not have to map array indices back to scenarios (e.g. “wrong channel” vs “prune after close”).
- **Removes an unnecessary `allow`**, matching a “fix root causes, avoid lint suppressions” style; future mistakes in the test helper are more likely to be caught by the compiler/linter.
- **No production impact**: changes are confined to `#[cfg(test)]` and do not alter `Channel` runtime logic or protocol semantics.

## Changes

- Remove `#[allow(dead_code)]` from `FrameValidityTestCase::name`.
- Remove the commented-out `println!` debug block.
- Thread `case=...` (and frame index / `Result` where useful) into `run_frame_validity_test` messages.

