### PR TITLE
fix: prevent panic from SystemTime::now() in dev mode

### DIFF
--- a/crates/execution/node/src/node.rs
+++ b/crates/execution/node/src/node.rs
@@ -134,7 +134,10 @@ impl PayloadAttributesBuilder<OpPayloadAttributes> for BaseLocalPayloadAttribute
 
         let timestamp = std::cmp::max(
             parent.timestamp().saturating_add(1),
-            std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH).unwrap().as_secs(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap_or(std::time::Duration::from_secs(0))
+                .as_secs(),
         );
 
         let default_eip_1559_params = BaseFeeParams::optimism();


### PR DESCRIPTION
Prevent panic from SystemTime::now() in dev mode

## Problem
The [BaseLocalPayloadAttributesBuilder](cci:2://base/crates/execution/node/src/node.rs:116:0-118:1) used `SystemTime::now().duration_since(UNIX_EPOCH).unwrap()` which can panic if system time is set before Unix epoch or if system clocks are corrupted.

## Fix
Replace `unwrap()` with `unwrap_or(Duration::from_secs(0))` to handle the error gracefully and fall back to timestamp 0.

## Why this is safe
- This only affects dev mode payload attributes building
- Fallback to timestamp 0 is reasonable for development
- Parent timestamp + 1 will likely be chosen anyway via `std::cmp::max`
- No impact on production consensus logic