### PR TITLE
refactor(metrics): unify define_metrics with a struct override

### DIFF
--- a/crates/batcher/encoder/src/metrics.rs
+++ b/crates/batcher/encoder/src/metrics.rs
@@ -1,7 +1,8 @@
 //! Batcher metric definitions and label values.
 
-base_metrics::define_metrics_struct! {
-    BatcherMetrics, batcher,
+base_metrics::define_metrics! {
+    batcher,
+    struct = BatcherMetrics,
     #[describe("Total number of encoding channels opened")]
     channel_opened_total: counter,
     #[describe("Total number of encoding channels closed")]

--- a/crates/builder/core/src/metrics.rs
+++ b/crates/builder/core/src/metrics.rs
@@ -3,8 +3,9 @@ use crate::{ExecutionInfo, FlashblockDiagnostics, ResourceLimits};
 const PRIORITY_FEE_THRESHOLDS_WEI: [(&str, u64); 3] =
     [("100wei", 100), ("100kwei", 100_000), ("1mwei", 1_000_000)];
 
-base_metrics::define_metrics_struct! {
-    BuilderMetrics, base_builder,
+base_metrics::define_metrics! {
+    base_builder,
+    struct = BuilderMetrics,
     #[describe("Block built success")]
     block_built_success: counter,
     #[describe("Block synced success")]

--- a/crates/builder/publish/src/metrics.rs
+++ b/crates/builder/publish/src/metrics.rs
@@ -1,5 +1,6 @@
-base_metrics::define_metrics_struct! {
-    PublishingMetrics, base_builder,
+base_metrics::define_metrics! {
+    base_builder,
+    struct = PublishingMetrics,
     #[describe("Total messages sent to subscribers")]
     messages_sent_count: counter,
     #[describe("Active WebSocket connections")]

--- a/crates/execution/rpc/src/metrics.rs
+++ b/crates/execution/rpc/src/metrics.rs
@@ -2,8 +2,9 @@
 
 use std::time::Instant;
 
-base_metrics::define_metrics_struct! {
-    SequencerMetrics, base_rpc.sequencer,
+base_metrics::define_metrics! {
+    base_rpc.sequencer,
+    struct = SequencerMetrics,
     #[describe("How long it takes to forward a transaction to the sequencer")]
     sequencer_forward_latency: histogram,
 }
@@ -16,8 +17,9 @@ impl SequencerMetrics {
     }
 }
 
-base_metrics::define_metrics_struct! {
-    EthApiExtMetrics, base_rpc.eth_api_ext,
+base_metrics::define_metrics! {
+    base_rpc.eth_api_ext,
+    struct = EthApiExtMetrics,
     #[describe("How long it takes to handle a eth_getProof request successfully")]
     get_proof_latency: histogram,
     #[describe("Total number of eth_getProof requests")]
@@ -47,8 +49,9 @@ impl DebugApis {
     }
 }
 
-base_metrics::define_metrics_struct! {
-    DebugApiExtRpcMetrics, base_rpc.debug_api_ext,
+base_metrics::define_metrics! {
+    base_rpc.debug_api_ext,
+    struct = DebugApiExtRpcMetrics,
     #[describe("End-to-end time to handle this API call")]
     #[label(api)]
     latency: histogram,

--- a/crates/execution/rpc/src/miner.rs
+++ b/crates/execution/rpc/src/miner.rs
@@ -6,8 +6,9 @@ use base_execution_payload_builder::config::{OpDAConfig, OpGasLimitConfig};
 use jsonrpsee_core::{RpcResult, async_trait};
 use tracing::debug;
 
-base_metrics::define_metrics_struct! {
-    OpMinerMetrics, base_rpc.miner,
+base_metrics::define_metrics! {
+    base_rpc.miner,
+    struct = OpMinerMetrics,
     #[describe("Max DA tx size set on the miner")]
     max_da_tx_size: gauge,
     #[describe("Max DA block size set on the miner")]

--- a/crates/execution/trie/src/metrics.rs
+++ b/crates/execution/trie/src/metrics.rs
@@ -83,15 +83,17 @@ impl StorageOperation {
     }
 }
 
-base_metrics::define_metrics_struct! {
-    OperationMetrics, optimism_trie.storage.operation,
+base_metrics::define_metrics! {
+    optimism_trie.storage.operation,
+    struct = OperationMetrics,
     #[describe("Duration of storage operations in seconds")]
     #[label(operation)]
     duration_seconds: histogram,
 }
 
-base_metrics::define_metrics_struct! {
-    BlockMetrics, optimism_trie.block,
+base_metrics::define_metrics! {
+    optimism_trie.block,
+    struct = BlockMetrics,
     #[describe("Total time to process a block (end-to-end) in seconds")]
     total_duration_seconds: histogram,
     #[describe("Time spent executing the block (EVM) in seconds")]

--- a/crates/proof/challenge/src/metrics.rs
+++ b/crates/proof/challenge/src/metrics.rs
@@ -1,7 +1,8 @@
 //! Challenger metrics constants.
 
-base_metrics::define_metrics_struct! {
-    ChallengerMetrics, base_challenger,
+base_metrics::define_metrics! {
+    base_challenger,
+    struct = ChallengerMetrics,
 
     #[describe("Challenger is running")]
     up: gauge,

--- a/crates/proof/tee/registrar/src/metrics.rs
+++ b/crates/proof/tee/registrar/src/metrics.rs
@@ -1,7 +1,8 @@
 //! Registrar metrics constants.
 
-base_metrics::define_metrics_struct! {
-    RegistrarMetrics, base_registrar,
+base_metrics::define_metrics! {
+    base_registrar,
+    struct = RegistrarMetrics,
 
     #[describe("Registrar is running")]
     up: gauge,

--- a/crates/txpool/src/forwarder/metrics.rs
+++ b/crates/txpool/src/forwarder/metrics.rs
@@ -1,7 +1,8 @@
 //! Metrics for the transaction forwarder.
 
-base_metrics::define_metrics_struct! {
-    ForwarderMetrics, txpool.forwarder,
+base_metrics::define_metrics! {
+    txpool.forwarder,
+    struct = ForwarderMetrics,
     #[describe("Total RPC batches sent successfully")]
     #[label(builder_url)]
     batches_sent: counter,

--- a/crates/utilities/metrics/README.md
+++ b/crates/utilities/metrics/README.md
@@ -6,8 +6,9 @@ Utility macros and types for recording metrics in base crates.
 
 Provides declarative macros and RAII types used across the Base codebase for consistent
 instrumentation. Includes `define_metrics!` for registering Prometheus metrics in a
-standardized way, `timed!` for automatic duration recording, and `inflight!` for tracking
-in-flight operations.
+standardized way, with optional `struct = ...` naming for custom accessor types,
+`timed!` for automatic duration recording, and `inflight!` for tracking in-flight
+operations.
 
 ## Usage
 
@@ -20,6 +21,19 @@ base-metrics = { workspace = true }
 
 ```rust,ignore
 use base_metrics::define_metrics;
+
+define_metrics! {
+    my.app
+    #[describe("Total requests")]
+    requests_total: counter,
+}
+
+define_metrics! {
+    my.app,
+    struct = MyMetrics,
+    #[describe("Request duration")]
+    request_duration: histogram,
+}
 ```
 
 ## License

--- a/crates/utilities/metrics/src/metrics.rs
+++ b/crates/utilities/metrics/src/metrics.rs
@@ -7,7 +7,8 @@
 ///
 /// The scope is prepended to every metric name with a dot separator.
 /// The scope may contain dots (e.g., `my.app`) by using dot-separated idents.
-/// For a custom struct name, use [`define_metrics_struct!`].
+/// To override the generated struct name, add `struct = MyMetrics,` after the
+/// scope.
 ///
 /// # Attributes
 ///
@@ -23,9 +24,36 @@
 ///     requests_total: counter,
 /// }
 /// Metrics::requests_total().increment(1);
+///
+/// base_metrics::define_metrics! {
+///     my.app,
+///     struct = MyMetrics,
+///     #[describe("Request duration")]
+///     #[label(method)]
+///     request_duration: histogram,
+/// }
+/// MyMetrics::request_duration("GET").record(0.42);
 /// ```
 #[macro_export]
 macro_rules! define_metrics {
+    (
+        $($scope:ident).+, struct = $name:ident,
+        $(
+            #[describe($desc:expr)]
+            $(#[label($label:ident)])*
+            $field:ident : $kind:ident
+        ),*
+        $(,)?
+    ) => {
+        $crate::__define_metrics_impl! {
+            $name, {$($scope).+},
+            $(
+                #[describe($desc)]
+                $(#[label($label)])*
+                $field : $kind
+            ),*
+        }
+    };
     (
         $($scope:ident).+
         $(
@@ -37,41 +65,6 @@ macro_rules! define_metrics {
     ) => {
         $crate::__define_metrics_impl! {
             Metrics, {$($scope).+},
-            $(
-                #[describe($desc)]
-                $(#[label($label)])*
-                $field : $kind
-            ),*
-        }
-    };
-}
-
-/// Like [`define_metrics!`] but with a custom struct name.
-///
-/// # Example
-///
-/// ```ignore
-/// base_metrics::define_metrics_struct! {
-///     MyMetrics, my.app,
-///     #[describe("Request duration")]
-///     #[label(method)]
-///     request_duration: histogram,
-/// }
-/// MyMetrics::request_duration("GET").record(0.42);
-/// ```
-#[macro_export]
-macro_rules! define_metrics_struct {
-    (
-        $name:ident, $($scope:ident).+,
-        $(
-            #[describe($desc:expr)]
-            $(#[label($label:ident)])*
-            $field:ident : $kind:ident
-        ),*
-        $(,)?
-    ) => {
-        $crate::__define_metrics_impl! {
-            $name, {$($scope).+},
             $(
                 #[describe($desc)]
                 $(#[label($label)])*

--- a/crates/utilities/metrics/tests/metrics.rs
+++ b/crates/utilities/metrics/tests/metrics.rs
@@ -57,8 +57,9 @@ fn assert_single_histogram(snap: &[SnapEntry], name: &str, min: f64) {
     }
 }
 
-base_metrics::define_metrics_struct! {
-    AppMetrics, test_app,
+base_metrics::define_metrics! {
+    test_app,
+    struct = AppMetrics,
     #[describe("Total requests")]
     requests_total: counter,
 
@@ -135,8 +136,9 @@ fn describe_registers_descriptions() {
     });
 }
 
-base_metrics::define_metrics_struct! {
-    CustomMetrics, my_service,
+base_metrics::define_metrics! {
+    my_service,
+    struct = CustomMetrics,
     #[describe("Events processed")]
     events: counter,
 }
@@ -154,8 +156,9 @@ fn named_struct() {
     });
 }
 
-base_metrics::define_metrics_struct! {
-    LabeledMetrics, labeled_app,
+base_metrics::define_metrics! {
+    labeled_app,
+    struct = LabeledMetrics,
 
     #[describe("Requests by method")]
     #[label(method)]
@@ -234,8 +237,9 @@ fn single_label_gauge() {
     });
 }
 
-base_metrics::define_metrics_struct! {
-    TwoLabelMetrics, multi_label,
+base_metrics::define_metrics! {
+    multi_label,
+    struct = TwoLabelMetrics,
 
     #[describe("Errors by kind and reason")]
     #[label(kind)]
@@ -271,8 +275,9 @@ fn two_label_counter() {
     });
 }
 
-base_metrics::define_metrics_struct! {
-    TimerMetrics, timer_test,
+base_metrics::define_metrics! {
+    timer_test,
+    struct = TimerMetrics,
     #[describe("Duration")]
     duration: histogram,
 }
@@ -318,8 +323,9 @@ fn timed_stop_is_idempotent() {
     });
 }
 
-base_metrics::define_metrics_struct! {
-    TimeBlockMetrics, time_block,
+base_metrics::define_metrics! {
+    time_block,
+    struct = TimeBlockMetrics,
     #[describe("Duration")]
     duration: histogram,
 }
@@ -337,8 +343,9 @@ fn time_block_records_and_returns_value() {
     });
 }
 
-base_metrics::define_metrics_struct! {
-    InflightMetrics, inflight_test,
+base_metrics::define_metrics! {
+    inflight_test,
+    struct = InflightMetrics,
     #[describe("In-flight operations")]
     in_flight: gauge,
 }
@@ -367,8 +374,8 @@ fn inflight_increments_and_decrements_gauge() {
 
 #[test]
 fn metric_names_use_dot_separator() {
-    base_metrics::define_metrics_struct! {
-        ScopeMetrics, scope_test,
+    base_metrics::define_metrics! {
+        scope_test
         #[describe("A counter")]
         my_counter: counter,
         #[describe("A gauge")]
@@ -378,9 +385,9 @@ fn metric_names_use_dot_separator() {
     }
 
     with_recorder(|snap| {
-        ScopeMetrics::my_counter().increment(1);
-        ScopeMetrics::my_gauge().set(1.0);
-        ScopeMetrics::my_histogram().record(1.0);
+        Metrics::my_counter().increment(1);
+        Metrics::my_gauge().set(1.0);
+        Metrics::my_histogram().record(1.0);
 
         let snapshot = snap.snapshot().into_vec();
         let names: Vec<&str> = snapshot.iter().map(|(ck, _, _, _)| ck.key().name()).collect();
@@ -390,8 +397,9 @@ fn metric_names_use_dot_separator() {
     });
 }
 
-base_metrics::define_metrics_struct! {
-    ParamMetrics, param_test,
+base_metrics::define_metrics! {
+    param_test,
+    struct = ParamMetrics,
 
     #[describe("Counter with string label")]
     #[label(endpoint)]

--- a/crates/utilities/tx-manager/src/metrics.rs
+++ b/crates/utilities/tx-manager/src/metrics.rs
@@ -2,8 +2,9 @@
 
 use std::fmt::Debug;
 
-base_metrics::define_metrics_struct! {
-    TxManagerMetrics, base_tx_manager,
+base_metrics::define_metrics! {
+    base_tx_manager,
+    struct = TxManagerMetrics,
     #[describe("Maximum possible transaction fee in gwei")]
     #[label(name)]
     tx_max_fee_gwei: histogram,


### PR DESCRIPTION
## Summary
Move from duplicate macros to a single one with an argument.

