### PR TITLE
fix(queue): prevent usize underflow in frame_queue prune when queue is empty

### DIFF
--- a/crates/consensus/derive/src/stages/frame_queue.rs
+++ b/crates/consensus/derive/src/stages/frame_queue.rs
@@ -65,6 +65,10 @@ where
         }
 
         let mut i = 0;
+        // Prevent underflow when queue has fewer than 2 elements
+        if self.queue.len() < 2 {
+            return;
+        }
         while i < self.queue.len() - 1 {
             let prev_frame = &self.queue[i];
             let next_frame = &self.queue[i + 1];


### PR DESCRIPTION
## Problem
The [FrameQueue::prune()](cci:1://file:///crates/consensus/derive/src/stages/frame_queue.rs:60:4-111:5) function has an off-by-one error that causes a usize underflow panic. When the queue has fewer than 2 elements, the expression `self.queue.len() - 1` underflows because usize is unsigned in Rust.

## Fix
Added an early return check `if self.queue.len() < 2 { return; }` before the while loop to prevent the underflow. This is safe because the pruning logic requires at least 2 frames to compare.

## Why change is safe
- Early return preserves existing behavior for empty or single-frame queues (nothing to prune)
- The pruning logic only operates on consecutive frame pairs, requiring 2+ frames
- No breaking changes to API or external behavior
- Defensive fix that prevents panic while maintaining correctness