### PR TITLE
chore(nitro-enclave): use tracing for print_real_config_hashes test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4698,6 +4698,7 @@ dependencies = [
  "tokio",
  "tokio-vsock",
  "tracing",
+ "tracing-subscriber 0.3.23",
  "x509-cert",
  "zip 8.3.1",
 ]

--- a/crates/proof/tee/nitro-enclave/Cargo.toml
+++ b/crates/proof/tee/nitro-enclave/Cargo.toml
@@ -63,6 +63,7 @@ hex.workspace = true
 serde_json.workspace = true
 base-consensus-registry.workspace = true
 tokio = { workspace = true, features = ["macros", "rt"] }
+tracing-subscriber = { workspace = true, features = ["fmt"] }
 
 [package.metadata.cargo-udeps.ignore]
 normal = ["aws-nitro-enclaves-nsm-api"]

--- a/crates/proof/tee/nitro-enclave/src/types.rs
+++ b/crates/proof/tee/nitro-enclave/src/types.rs
@@ -361,6 +361,7 @@ pub struct TeeProofResult {
 mod tests {
     use alloy_primitives::{address, b256};
     use base_consensus_registry::Registry;
+    use tracing::info;
 
     use super::*;
 
@@ -637,12 +638,17 @@ mod tests {
         assert_eq!(rollup_config.hardforks.regolith_time, Some(0));
     }
 
-    /// Print config hashes for supported chains so they can be hardcoded in the
+    /// Emit config hashes for supported chains (via `tracing`) so they can be hardcoded in the
     /// enclave server. Run with:
     /// `cargo test -p base-proof-tee-nitro-enclave print_real_config_hashes -- --nocapture --ignored`
     #[test]
     #[ignore]
     fn print_real_config_hashes() {
+        let _ = tracing_subscriber::fmt()
+            .with_max_level(tracing::Level::INFO)
+            .with_test_writer()
+            .try_init();
+
         let chains: &[(u64, &str)] =
             &[(8453, "Base Mainnet"), (84532, "Base Sepolia"), (11763072, "Sepolia Alpha")];
 
@@ -652,7 +658,12 @@ mod tests {
             let mut per_chain = PerChainConfig::from_rollup_config(rollup)
                 .unwrap_or_else(|| panic!("missing system_config for {name} ({chain_id})"));
             per_chain.force_defaults();
-            println!("{name} ({chain_id}): {:?}", per_chain.hash());
+            info!(
+                chain_id,
+                name = %name,
+                config_hash = ?per_chain.hash(),
+                "per-chain config hash for enclave server hardcoding",
+            );
         }
     }
 }


### PR DESCRIPTION
## Summary

Replace `println!` in the ignored `print_real_config_hashes` test with `tracing::info!` and a minimal in-test `tracing_subscriber` setup.

## Motivation

- `println!` does not follow the repo convention of structured tracing (static message + key/value fields).
- `tracing` alone does not print without a subscriber; the test needs a small `fmt` + `with_test_writer()` init so output still shows with `cargo test … -- --nocapture --ignored`.

## Changes

- `types.rs` (`#[cfg(test)]`): `info!(chain_id, name = %name, config_hash = ?…, "…")`; document that output is via tracing.
- `Cargo.toml`: add `tracing-subscriber` under `[dev-dependencies]` with `features = ["fmt"]`.
- `Cargo.lock`: updated for the new dev dependency (if applicable).
