### PR TITLE
Fix: harden TEE registrar resilience against race conditions, false-negative fee bumps, and tx retry failures

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4652,6 +4652,7 @@ version = "0.0.0"
 dependencies = [
  "alloy-primitives",
  "alloy-signer-local",
+ "anyhow",
  "async-trait",
  "base-proof-tee-nitro-verifier",
  "boundless-market",

--- a/crates/proof/tee/nitro-attestation-prover/Cargo.toml
+++ b/crates/proof/tee/nitro-attestation-prover/Cargo.toml
@@ -33,6 +33,7 @@ tokio = { workspace = true, features = ["rt"], optional = true }
 risc0-zkvm = { workspace = true, features = ["prove"], optional = true }
 
 [dev-dependencies]
+anyhow.workspace = true
 rstest.workspace = true
 
 [features]

--- a/crates/proof/tee/nitro-attestation-prover/src/boundless.rs
+++ b/crates/proof/tee/nitro-attestation-prover/src/boundless.rs
@@ -55,6 +55,26 @@ impl fmt::Debug for BoundlessProver {
     }
 }
 
+impl BoundlessProver {
+    /// Checks whether an error from the Boundless SDK is the
+    /// `RequestIsNotLocked` revert caused by the TOCTOU race in
+    /// `get_status()`.
+    ///
+    /// Because the SDK wraps the contract revert in opaque error types
+    /// we must resort to string matching. Both `Display` and `Debug`
+    /// representations are searched case-insensitively to be resilient
+    /// against upstream formatting changes.
+    fn is_request_not_locked_error(e: &dyn std::error::Error) -> bool {
+        const NEEDLE: &str = "requestisnotlocked";
+        let display = format!("{e}");
+        if display.to_ascii_lowercase().contains(NEEDLE) {
+            return true;
+        }
+        let debug = format!("{e:?}");
+        debug.to_ascii_lowercase().contains(NEEDLE)
+    }
+}
+
 #[async_trait::async_trait]
 impl AttestationProofProvider for BoundlessProver {
     async fn generate_proof(&self, attestation_bytes: &[u8]) -> Result<AttestationProof> {
@@ -151,21 +171,48 @@ impl AttestationProofProvider for BoundlessProver {
         );
 
         // Wait for marketplace fulfillment (prover completes the proof).
-        let _fulfillment = client
-            .wait_for_request_fulfillment(request_id, self.poll_interval, effective_expiry)
-            .await
-            .map_err(|e| {
-                warn!(
-                    error = %e,
-                    error_debug = ?e,
-                    request_id = %request_id,
-                    effective_expiry,
-                    timeout = ?self.timeout,
-                    poll_interval = ?self.poll_interval,
-                    "proof fulfillment failed"
-                );
-                ProverError::Boundless(format!("fulfillment failed: {e}"))
-            })?;
+        //
+        // The Boundless SDK has a race condition in `get_status()`: it calls
+        // `is_locked()` then `requestDeadline()` as separate RPC calls. If
+        // the request is fulfilled between these calls, `requestDeadline()`
+        // reverts with `RequestIsNotLocked` and the SDK treats it as fatal.
+        // We retry immediately on this specific error since the next poll
+        // will find the request fulfilled via the `is_fulfilled()` check
+        // that runs first. No sleep is needed — the request is already
+        // fulfilled; we just need the SDK to re-enter its poll loop.
+        const MAX_RACE_RETRIES: u32 = 3;
+        let mut race_retries = 0;
+        let _fulfillment = loop {
+            match client
+                .wait_for_request_fulfillment(request_id, self.poll_interval, effective_expiry)
+                .await
+            {
+                Ok(f) => break f,
+                Err(e) => {
+                    if Self::is_request_not_locked_error(&e) && race_retries < MAX_RACE_RETRIES {
+                        race_retries += 1;
+                        warn!(
+                            error = %e,
+                            request_id = %request_id,
+                            retry = race_retries,
+                            max_retries = MAX_RACE_RETRIES,
+                            "RequestIsNotLocked race condition, retrying fulfillment poll"
+                        );
+                        continue;
+                    }
+                    warn!(
+                        error = %e,
+                        error_debug = ?e,
+                        request_id = %request_id,
+                        effective_expiry,
+                        timeout = ?self.timeout,
+                        poll_interval = ?self.poll_interval,
+                        "proof fulfillment failed"
+                    );
+                    return Err(ProverError::Boundless(format!("fulfillment failed: {e}")));
+                }
+            }
+        };
 
         info!(request_id = %request_id, "fulfillment confirmed, fetching set inclusion receipt");
 
@@ -310,5 +357,113 @@ mod tests {
             !debug.contains(TEST_PRIVATE_KEY),
             "raw private key must not appear in Debug output"
         );
+    }
+
+    // ── is_request_not_locked_error ─────────────────────────────────────
+    //
+    // These tests construct the *real* Boundless SDK error types that the
+    // `RequestIsNotLocked` Solidity custom error produces in production.
+    // If a `boundless-market` upgrade changes the Display/Debug formatting
+    // of `ClientError` → `MarketError` → `TxnErr` →
+    // `IBoundlessMarketErrors::RequestIsNotLocked`, these tests will fail
+    // and alert us that the string-matching needle needs updating.
+
+    mod request_not_locked {
+        use alloy_primitives::U256;
+        use boundless_market::{
+            client::ClientError,
+            contracts::{
+                IBoundlessMarket::{self, IBoundlessMarketErrors},
+                TxnErr,
+                boundless_market::MarketError,
+            },
+        };
+
+        use super::*;
+
+        /// Arbitrary request ID used in error construction.
+        const TEST_REQUEST_ID: U256 = U256::from_limbs([42, 0, 0, 0]);
+
+        /// Build a `ClientError` wrapping `RequestIsNotLocked` through the
+        /// **production** path: `TxnErr` → `anyhow::Error` →
+        /// `MarketError::Error` → `ClientError::MarketError`.
+        fn production_path_error() -> ClientError {
+            let revert =
+                IBoundlessMarketErrors::RequestIsNotLocked(IBoundlessMarket::RequestIsNotLocked {
+                    requestId: TEST_REQUEST_ID,
+                });
+            let txn_err = TxnErr::BoundlessMarketErr(revert);
+            // Production wraps TxnErr in anyhow::Error, then into MarketError::Error.
+            let market_err = MarketError::Error(anyhow::Error::from(txn_err));
+            ClientError::MarketError(market_err)
+        }
+
+        /// Build a `ClientError` wrapping `RequestIsNotLocked` through the
+        /// **direct** path: `TxnErr` → `MarketError::TxnError` →
+        /// `ClientError::MarketError`.
+        fn direct_path_error() -> ClientError {
+            let revert =
+                IBoundlessMarketErrors::RequestIsNotLocked(IBoundlessMarket::RequestIsNotLocked {
+                    requestId: TEST_REQUEST_ID,
+                });
+            let txn_err = TxnErr::BoundlessMarketErr(revert);
+            let market_err = MarketError::TxnError(txn_err);
+            ClientError::MarketError(market_err)
+        }
+
+        /// Build a `ClientError` for a **different** Solidity error
+        /// (`RequestIsLocked`) to verify we don't false-positive.
+        fn different_revert_error() -> ClientError {
+            let revert =
+                IBoundlessMarketErrors::RequestIsLocked(IBoundlessMarket::RequestIsLocked {
+                    requestId: TEST_REQUEST_ID,
+                });
+            let txn_err = TxnErr::BoundlessMarketErr(revert);
+            let market_err = MarketError::Error(anyhow::Error::from(txn_err));
+            ClientError::MarketError(market_err)
+        }
+
+        /// Production error chain (anyhow-wrapped) matches.
+        #[rstest]
+        fn matches_production_path() {
+            let err = production_path_error();
+            assert!(
+                BoundlessProver::is_request_not_locked_error(&err),
+                "should detect RequestIsNotLocked through production error chain. \
+                 Display: {err}, Debug: {err:?}"
+            );
+        }
+
+        /// Direct error chain (`MarketError::TxnError`) matches.
+        #[rstest]
+        fn matches_direct_path() {
+            let err = direct_path_error();
+            assert!(
+                BoundlessProver::is_request_not_locked_error(&err),
+                "should detect RequestIsNotLocked through direct error chain. \
+                 Display: {err}, Debug: {err:?}"
+            );
+        }
+
+        /// A different revert (`RequestIsLocked`) must NOT match.
+        #[rstest]
+        fn rejects_different_revert() {
+            let err = different_revert_error();
+            assert!(
+                !BoundlessProver::is_request_not_locked_error(&err),
+                "should NOT match RequestIsLocked (different error). \
+                 Display: {err}, Debug: {err:?}"
+            );
+        }
+
+        /// Plain `std::io::Error` must NOT match.
+        #[rstest]
+        fn rejects_unrelated_error() {
+            let err = std::io::Error::new(std::io::ErrorKind::TimedOut, "connection timed out");
+            assert!(
+                !BoundlessProver::is_request_not_locked_error(&err),
+                "should NOT match an unrelated I/O error"
+            );
+        }
     }
 }

--- a/crates/proof/tee/registrar/Cargo.toml
+++ b/crates/proof/tee/registrar/Cargo.toml
@@ -38,8 +38,8 @@ jsonrpsee = { workspace = true, features = ["http-client", "server"] }
 base-proof-primitives = { workspace = true, features = ["rpc-client"] }
 
 # Async
-async-trait.workspace = true
 tokio-util.workspace = true
+async-trait.workspace = true
 tokio = { workspace = true, features = ["net", "time", "macros"] }
 
 # Error
@@ -61,8 +61,7 @@ hex-literal.workspace = true
 alloy-consensus.workspace = true
 alloy-rpc-types-eth.workspace = true
 k256 = { workspace = true, features = ["ecdsa"] }
-tokio = { workspace = true, features = ["rt", "macros"] }
+tokio = { workspace = true, features = ["rt", "macros", "test-util"] }
 
 [features]
 metrics = [ "base-metrics/metrics", "base-tx-manager/metrics", "dep:metrics" ]
-

--- a/crates/proof/tee/registrar/src/driver.rs
+++ b/crates/proof/tee/registrar/src/driver.rs
@@ -339,7 +339,85 @@ where
             "Sending tx candidate",
         );
 
-        let receipt = self.tx_manager.send(candidate).await.map_err(RegistrarError::from)?;
+        // Retry tx submission on transient errors to avoid discarding an
+        // expensive proof (~20 min Boundless generation) on a nonce race
+        // or brief network blip.
+        //
+        // Only errors that `TxManagerError::is_retryable()` considers
+        // transient are retried.  Deterministic failures (execution
+        // reverted, insufficient funds, config errors, fee limits, etc.)
+        // abort immediately since retrying with the same calldata and
+        // state cannot succeed.
+        const MAX_TX_RETRIES: u32 = 3;
+        const TX_RETRY_DELAY: Duration = Duration::from_secs(5);
+        let mut tx_retries = 0;
+
+        let receipt = loop {
+            // Check cancellation at the top of each iteration to avoid
+            // starting new on-chain work after shutdown is requested.
+            if self.config.cancel.is_cancelled() {
+                debug!("shutdown requested, aborting tx submission");
+                return Ok(());
+            }
+
+            match self.tx_manager.send(candidate.clone()).await {
+                Ok(receipt) => break receipt,
+                Err(e) => {
+                    // The signer may already be registered despite the error
+                    // (e.g. the tx was mined but the tx manager reported a
+                    // nonce race during fee bumping). Check on-chain state.
+                    match self.registry.is_registered(signer_address).await {
+                        Ok(true) => {
+                            info!(
+                                signer = %signer_address,
+                                error = %e,
+                                "tx error but signer is registered on-chain, treating as success"
+                            );
+                            RegistrarMetrics::registrations_total().increment(1);
+                            return Ok(());
+                        }
+                        Err(registry_err) => {
+                            warn!(
+                                error = %registry_err,
+                                signer = %signer_address,
+                                "failed to query is_registered after tx error"
+                            );
+                        }
+                        Ok(false) => {}
+                    }
+
+                    // Non-retryable errors (execution reverts, insufficient
+                    // funds, config errors, fee limits, etc.) cannot be
+                    // resolved by retrying with the same calldata.
+                    if !e.is_retryable() {
+                        return Err(RegistrarError::from(e));
+                    }
+
+                    tx_retries += 1;
+                    if tx_retries > MAX_TX_RETRIES {
+                        return Err(RegistrarError::from(e));
+                    }
+
+                    warn!(
+                        error = %e,
+                        signer = %signer_address,
+                        retry = tx_retries,
+                        max_retries = MAX_TX_RETRIES,
+                        "tx submission failed, retrying with same proof"
+                    );
+
+                    // Cancellation-aware delay: abort immediately if
+                    // shutdown is requested during the retry wait.
+                    tokio::select! {
+                        () = self.config.cancel.cancelled() => {
+                            debug!("shutdown requested during retry delay");
+                            return Err(RegistrarError::from(e));
+                        }
+                        () = tokio::time::sleep(TX_RETRY_DELAY) => {}
+                    }
+                }
+            }
+        };
 
         if !receipt.inner.status() {
             warn!(
@@ -460,8 +538,11 @@ where
 #[cfg(test)]
 mod tests {
     use std::{
-        collections::{HashMap, HashSet},
-        sync::{Arc, Mutex},
+        collections::{HashMap, HashSet, VecDeque},
+        sync::{
+            Arc, Mutex,
+            atomic::{AtomicU32, Ordering},
+        },
     };
 
     use alloy_consensus::{Eip658Value, Receipt, ReceiptEnvelope, ReceiptWithBloom};
@@ -470,7 +551,7 @@ mod tests {
     use alloy_sol_types::SolCall;
     use async_trait::async_trait;
     use base_proof_tee_nitro_attestation_prover::AttestationProof;
-    use base_tx_manager::{SendHandle, TxCandidate, TxManager};
+    use base_tx_manager::{SendHandle, TxCandidate, TxManager, TxManagerError};
     use hex_literal::hex;
     use k256::ecdsa::SigningKey;
     use rstest::rstest;
@@ -781,6 +862,162 @@ mod tests {
         RegistrationDriver::new(
             MockDiscovery { instances },
             StubProofProvider,
+            registry,
+            tx,
+            signer_client,
+            default_config(cancel),
+        )
+    }
+
+    // ── Configurable mock types for retry tests ────────────────────────
+
+    /// Maximum number of tx submission retries in `try_register`.
+    /// Mirrors the constant in production code.
+    const MAX_TX_RETRIES: u32 = 3;
+
+    /// Default endpoint used in retry tests.
+    const RETRY_TEST_ENDPOINT: &str = "10.0.0.1:8000";
+
+    /// Proof provider that counts `generate_proof` invocations.
+    ///
+    /// Returns the same stub proof as [`StubProofProvider`] but tracks
+    /// how many times it was called, allowing tests to assert that the
+    /// expensive proof generation is not repeated across retries.
+    #[derive(Debug)]
+    struct CountingProofProvider {
+        call_count: AtomicU32,
+    }
+
+    impl CountingProofProvider {
+        fn new() -> Self {
+            Self { call_count: AtomicU32::new(0) }
+        }
+
+        fn call_count(&self) -> u32 {
+            self.call_count.load(Ordering::Relaxed)
+        }
+    }
+
+    #[async_trait]
+    impl AttestationProofProvider for CountingProofProvider {
+        async fn generate_proof(
+            &self,
+            _attestation_bytes: &[u8],
+        ) -> base_proof_tee_nitro_attestation_prover::Result<AttestationProof> {
+            self.call_count.fetch_add(1, Ordering::Relaxed);
+            Ok(AttestationProof {
+                output: Bytes::from_static(b"stub-output"),
+                proof_bytes: Bytes::from_static(b"stub-proof"),
+            })
+        }
+    }
+
+    /// Mock tx manager that returns a configurable sequence of results.
+    ///
+    /// Each call to `send()` pops the next result from `results`. When
+    /// the queue is exhausted, returns a successful receipt.
+    #[derive(Debug, Clone)]
+    struct FailingTxManager {
+        /// FIFO queue of results to return; `None` means success.
+        results: Arc<Mutex<VecDeque<Option<TxManagerError>>>>,
+        /// Records all submitted calldata for assertion.
+        sent: Arc<Mutex<Vec<Bytes>>>,
+    }
+
+    impl FailingTxManager {
+        /// Creates a manager that returns the given errors in order,
+        /// then succeeds on subsequent calls.
+        fn with_errors(errors: Vec<TxManagerError>) -> Self {
+            let results = errors.into_iter().map(Some).collect();
+            Self { results: Arc::new(Mutex::new(results)), sent: Arc::new(Mutex::new(vec![])) }
+        }
+
+        /// Returns the number of `send()` calls made.
+        fn send_count(&self) -> usize {
+            self.sent.lock().unwrap().len()
+        }
+
+        /// Returns all submitted calldata for equality assertions.
+        fn sent_calldata(&self) -> Vec<Bytes> {
+            self.sent.lock().unwrap().clone()
+        }
+    }
+
+    impl TxManager for FailingTxManager {
+        async fn send(&self, candidate: TxCandidate) -> base_tx_manager::SendResponse {
+            self.sent.lock().unwrap().push(candidate.tx_data);
+            let next = self.results.lock().unwrap().pop_front();
+            match next {
+                Some(Some(e)) => Err(e),
+                _ => Ok(stub_receipt()),
+            }
+        }
+
+        async fn send_async(&self, _candidate: TxCandidate) -> SendHandle {
+            panic!("FailingTxManager::send_async is not implemented; retry tests only use send()")
+        }
+
+        fn sender_address(&self) -> Address {
+            Address::ZERO
+        }
+    }
+
+    /// Mock registry with dynamic `is_registered` responses.
+    ///
+    /// The first N calls to `is_registered` return values from `responses`;
+    /// subsequent calls return `default_registered`.
+    #[derive(Debug)]
+    struct DynamicRegistry {
+        /// On-chain signers for `get_registered_signers`.
+        signers: Vec<Address>,
+        /// FIFO queue of `is_registered` return values.
+        responses: Mutex<VecDeque<bool>>,
+        /// Value returned after `responses` is exhausted.
+        default_registered: bool,
+    }
+
+    impl DynamicRegistry {
+        /// Registry where `is_registered` always returns `false`.
+        fn never_registered(signers: Vec<Address>) -> Self {
+            Self { signers, responses: Mutex::new(VecDeque::new()), default_registered: false }
+        }
+
+        /// Registry where the first call returns `false` (initial check),
+        /// then subsequent calls return `true` (signer appeared on-chain).
+        fn registered_after_first_check(signers: Vec<Address>) -> Self {
+            Self {
+                signers,
+                responses: Mutex::new(VecDeque::from([false])),
+                default_registered: true,
+            }
+        }
+    }
+
+    #[async_trait]
+    impl RegistryClient for DynamicRegistry {
+        async fn is_registered(&self, _signer: Address) -> Result<bool> {
+            let next = self.responses.lock().unwrap().pop_front();
+            Ok(next.unwrap_or(self.default_registered))
+        }
+
+        async fn get_registered_signers(&self) -> Result<Vec<Address>> {
+            Ok(self.signers.clone())
+        }
+    }
+
+    /// Builds a driver for tx retry tests with configurable proof provider,
+    /// tx manager, and registry.
+    fn retry_driver<P: AttestationProofProvider>(
+        signer_client: MockSignerClient,
+        registry: DynamicRegistry,
+        tx: FailingTxManager,
+        proof_provider: P,
+        cancel: CancellationToken,
+    ) -> RegistrationDriver<MockDiscovery, P, DynamicRegistry, FailingTxManager, MockSignerClient>
+    {
+        RegistrationDriver::new(
+            MockDiscovery { instances: vec![] },
+            proof_provider,
             registry,
             tx,
             signer_client,
@@ -1133,5 +1370,299 @@ mod tests {
         let result = driver.process_instance(&inst).await;
 
         assert!(result.is_err(), "should fail when attestation count < key count");
+    }
+
+    // ── tx retry tests (Fix C) ──────────────────────────────────────────
+    //
+    // These tests verify the retry loop in `try_register`. Key
+    // invariants:
+    // - The expensive proof is generated exactly once and reused across
+    //   retries (identical calldata in every `send()` call).
+    // - Non-retryable errors abort immediately.
+    // - `is_registered` is checked after each failure to catch false
+    //   negatives.
+    // - Cancellation is respected both at the top of the loop and during
+    //   the retry delay.
+
+    /// Asserts that all calldata entries submitted to the tx manager are
+    /// identical, confirming the same proof is reused across retries.
+    fn assert_all_calldata_identical(sent: &[Bytes]) {
+        if sent.len() < 2 {
+            return;
+        }
+        for (i, entry) in sent.iter().enumerate().skip(1) {
+            assert_eq!(
+                &sent[0], entry,
+                "calldata mismatch: sent[0] != sent[{i}] — proof was regenerated"
+            );
+        }
+    }
+
+    /// Transient errors followed by success: the retry loop should retry
+    /// and eventually succeed. Proof is generated once, same calldata
+    /// across all attempts.
+    #[tokio::test(start_paused = true)]
+    async fn try_register_retries_transient_error_then_succeeds() {
+        let signer_client = MockSignerClient::from_keys(&[(RETRY_TEST_ENDPOINT, &HARDHAT_KEY_0)]);
+        let tx = FailingTxManager::with_errors(vec![
+            TxManagerError::Rpc("transient 1".into()),
+            TxManagerError::Rpc("transient 2".into()),
+        ]);
+        let proof_provider = CountingProofProvider::new();
+        let registry = DynamicRegistry::never_registered(vec![]);
+        let driver = retry_driver(
+            signer_client,
+            registry,
+            tx.clone(),
+            proof_provider,
+            CancellationToken::new(),
+        );
+
+        let inst = instance(RETRY_TEST_ENDPOINT, InstanceHealthStatus::Healthy);
+        let result = driver.process_instance(&inst).await;
+
+        assert!(result.is_ok(), "should succeed after retries: {result:?}");
+        // 2 failed attempts + 1 success = 3 total sends.
+        assert_eq!(tx.send_count(), 3);
+        assert_all_calldata_identical(&tx.sent_calldata());
+        assert_eq!(driver.proof_provider.call_count(), 1, "proof should be generated once");
+    }
+
+    /// Transient error but on-chain check shows signer is already
+    /// registered: should return Ok without retrying.
+    #[tokio::test(start_paused = true)]
+    async fn try_register_already_registered_after_error_returns_ok() {
+        let signer_client = MockSignerClient::from_keys(&[(RETRY_TEST_ENDPOINT, &HARDHAT_KEY_0)]);
+        let tx = FailingTxManager::with_errors(vec![TxManagerError::Rpc("nonce race".into())]);
+        // First `is_registered` call (before proof gen) returns false.
+        // Second call (after tx error) returns true (tx was mined despite error).
+        let registry = DynamicRegistry::registered_after_first_check(vec![]);
+        let driver = retry_driver(
+            signer_client,
+            registry,
+            tx.clone(),
+            StubProofProvider,
+            CancellationToken::new(),
+        );
+
+        let inst = instance(RETRY_TEST_ENDPOINT, InstanceHealthStatus::Healthy);
+        let result = driver.process_instance(&inst).await;
+
+        assert!(result.is_ok(), "should succeed: signer registered on-chain: {result:?}");
+        // Only 1 send attempt — the is_registered check short-circuits retry.
+        assert_eq!(tx.send_count(), 1);
+    }
+
+    /// `ExecutionReverted` aborts immediately without retry.
+    #[tokio::test(start_paused = true)]
+    async fn try_register_execution_reverted_aborts_immediately() {
+        let signer_client = MockSignerClient::from_keys(&[(RETRY_TEST_ENDPOINT, &HARDHAT_KEY_0)]);
+        let tx = FailingTxManager::with_errors(vec![TxManagerError::ExecutionReverted {
+            reason: Some("bad proof".into()),
+            data: None,
+        }]);
+        let registry = DynamicRegistry::never_registered(vec![]);
+        let driver = retry_driver(
+            signer_client,
+            registry,
+            tx.clone(),
+            StubProofProvider,
+            CancellationToken::new(),
+        );
+
+        let inst = instance(RETRY_TEST_ENDPOINT, InstanceHealthStatus::Healthy);
+        let result = driver.process_instance(&inst).await;
+
+        // process_instance logs errors but doesn't propagate them, so it returns Ok.
+        // However, the tx manager should only have been called once (no retry).
+        assert!(result.is_ok());
+        assert_eq!(tx.send_count(), 1, "should not retry after ExecutionReverted");
+    }
+
+    /// `InsufficientFunds` aborts immediately without retry.
+    #[tokio::test(start_paused = true)]
+    async fn try_register_insufficient_funds_aborts_immediately() {
+        let signer_client = MockSignerClient::from_keys(&[(RETRY_TEST_ENDPOINT, &HARDHAT_KEY_0)]);
+        let tx = FailingTxManager::with_errors(vec![TxManagerError::InsufficientFunds]);
+        let registry = DynamicRegistry::never_registered(vec![]);
+        let driver = retry_driver(
+            signer_client,
+            registry,
+            tx.clone(),
+            StubProofProvider,
+            CancellationToken::new(),
+        );
+
+        let inst = instance(RETRY_TEST_ENDPOINT, InstanceHealthStatus::Healthy);
+        let result = driver.process_instance(&inst).await;
+
+        assert!(result.is_ok());
+        assert_eq!(tx.send_count(), 1, "should not retry after InsufficientFunds");
+    }
+
+    /// `FeeLimitExceeded` is non-retryable and aborts immediately.
+    #[tokio::test(start_paused = true)]
+    async fn try_register_fee_limit_exceeded_aborts_immediately() {
+        let signer_client = MockSignerClient::from_keys(&[(RETRY_TEST_ENDPOINT, &HARDHAT_KEY_0)]);
+        let tx = FailingTxManager::with_errors(vec![TxManagerError::FeeLimitExceeded {
+            fee: 500,
+            ceiling: 100,
+        }]);
+        let registry = DynamicRegistry::never_registered(vec![]);
+        let driver = retry_driver(
+            signer_client,
+            registry,
+            tx.clone(),
+            StubProofProvider,
+            CancellationToken::new(),
+        );
+
+        let inst = instance(RETRY_TEST_ENDPOINT, InstanceHealthStatus::Healthy);
+        let result = driver.process_instance(&inst).await;
+
+        assert!(result.is_ok());
+        assert_eq!(tx.send_count(), 1, "should not retry after FeeLimitExceeded");
+    }
+
+    /// Transient errors exhaust all retries: should fail after
+    /// `MAX_TX_RETRIES` + 1 attempts. Same calldata in every attempt.
+    #[tokio::test(start_paused = true)]
+    async fn try_register_exhausts_retries_then_fails() {
+        let signer_client = MockSignerClient::from_keys(&[(RETRY_TEST_ENDPOINT, &HARDHAT_KEY_0)]);
+        // Return more errors than MAX_TX_RETRIES allows.
+        let errors: Vec<TxManagerError> = (0..=MAX_TX_RETRIES)
+            .map(|_| TxManagerError::Rpc("persistent failure".into()))
+            .collect();
+        let tx = FailingTxManager::with_errors(errors);
+        let proof_provider = CountingProofProvider::new();
+        let registry = DynamicRegistry::never_registered(vec![]);
+        let driver = retry_driver(
+            signer_client,
+            registry,
+            tx.clone(),
+            proof_provider,
+            CancellationToken::new(),
+        );
+
+        let inst = instance(RETRY_TEST_ENDPOINT, InstanceHealthStatus::Healthy);
+        let result = driver.process_instance(&inst).await;
+
+        // process_instance catches the error — verify via send count.
+        assert!(result.is_ok());
+        // 1 initial + MAX_TX_RETRIES retries = MAX_TX_RETRIES + 1 total.
+        assert_eq!(
+            tx.send_count(),
+            (MAX_TX_RETRIES + 1) as usize,
+            "should attempt exactly MAX_TX_RETRIES + 1 sends",
+        );
+        assert_all_calldata_identical(&tx.sent_calldata());
+        assert_eq!(driver.proof_provider.call_count(), 1, "proof should be generated once");
+    }
+
+    /// Cancellation during the retry sleep aborts the retry loop without
+    /// sending another transaction.
+    ///
+    /// Uses `start_paused = true` so time advances only when polled.
+    /// The cancel token fires 1 second into the 5-second retry delay,
+    /// then we advance time past the full delay to prove no second send
+    /// occurs.
+    #[tokio::test(start_paused = true)]
+    async fn try_register_cancellation_during_retry_sleep_aborts() {
+        let signer_client = MockSignerClient::from_keys(&[(RETRY_TEST_ENDPOINT, &HARDHAT_KEY_0)]);
+        // Return enough transient errors for multiple retries — but
+        // cancellation should prevent all but the first.
+        let tx = FailingTxManager::with_errors(vec![
+            TxManagerError::Rpc("fail 1".into()),
+            TxManagerError::Rpc("fail 2".into()),
+            TxManagerError::Rpc("fail 3".into()),
+        ]);
+        let registry = DynamicRegistry::never_registered(vec![]);
+        let cancel = CancellationToken::new();
+        let driver =
+            retry_driver(signer_client, registry, tx.clone(), StubProofProvider, cancel.clone());
+
+        let inst = instance(RETRY_TEST_ENDPOINT, InstanceHealthStatus::Healthy);
+
+        // Spawn a task that cancels after 1 second (during the 5s delay).
+        let cancel_handle = cancel.clone();
+        tokio::spawn(async move {
+            tokio::time::sleep(Duration::from_secs(1)).await;
+            cancel_handle.cancel();
+        });
+
+        let result = driver.process_instance(&inst).await;
+
+        assert!(result.is_ok());
+        // Only 1 send: the tokio::select! in the retry delay catches
+        // the cancellation before the sleep completes.
+        assert_eq!(tx.send_count(), 1, "should abort during retry sleep");
+    }
+
+    /// Cancellation before the retry loop starts: no tx is sent at all.
+    #[tokio::test(start_paused = true)]
+    async fn try_register_cancellation_before_loop_sends_nothing() {
+        let signer_client = MockSignerClient::from_keys(&[(RETRY_TEST_ENDPOINT, &HARDHAT_KEY_0)]);
+        let tx = FailingTxManager::with_errors(vec![]);
+        let registry = DynamicRegistry::never_registered(vec![]);
+        let cancel = CancellationToken::new();
+        cancel.cancel(); // Cancel before entering try_register.
+        let driver = retry_driver(signer_client, registry, tx.clone(), StubProofProvider, cancel);
+
+        let inst = instance(RETRY_TEST_ENDPOINT, InstanceHealthStatus::Healthy);
+        let result = driver.process_instance(&inst).await;
+
+        assert!(result.is_ok());
+        assert_eq!(tx.send_count(), 0, "should not send any tx after pre-cancellation");
+    }
+
+    /// Mixed errors: transient → `ExecutionReverted`. The retry loop should
+    /// process the first error (retryable), then abort on the second
+    /// (non-retryable) without further retries.
+    #[tokio::test(start_paused = true)]
+    async fn try_register_transient_then_execution_reverted() {
+        let signer_client = MockSignerClient::from_keys(&[(RETRY_TEST_ENDPOINT, &HARDHAT_KEY_0)]);
+        let tx = FailingTxManager::with_errors(vec![
+            TxManagerError::Rpc("transient".into()),
+            TxManagerError::ExecutionReverted { reason: None, data: None },
+        ]);
+        let registry = DynamicRegistry::never_registered(vec![]);
+        let driver = retry_driver(
+            signer_client,
+            registry,
+            tx.clone(),
+            StubProofProvider,
+            CancellationToken::new(),
+        );
+
+        let inst = instance(RETRY_TEST_ENDPOINT, InstanceHealthStatus::Healthy);
+        let result = driver.process_instance(&inst).await;
+
+        assert!(result.is_ok());
+        // 2 sends: first retryable, second fatal.
+        assert_eq!(tx.send_count(), 2);
+        assert_all_calldata_identical(&tx.sent_calldata());
+    }
+
+    /// Immediate success on first attempt: no retries needed.
+    #[tokio::test(start_paused = true)]
+    async fn try_register_immediate_success() {
+        let signer_client = MockSignerClient::from_keys(&[(RETRY_TEST_ENDPOINT, &HARDHAT_KEY_0)]);
+        let tx = FailingTxManager::with_errors(vec![]); // no errors — immediate success
+        let proof_provider = CountingProofProvider::new();
+        let registry = DynamicRegistry::never_registered(vec![]);
+        let driver = retry_driver(
+            signer_client,
+            registry,
+            tx.clone(),
+            proof_provider,
+            CancellationToken::new(),
+        );
+
+        let inst = instance(RETRY_TEST_ENDPOINT, InstanceHealthStatus::Healthy);
+        let result = driver.process_instance(&inst).await;
+
+        assert!(result.is_ok());
+        assert_eq!(tx.send_count(), 1, "should succeed on first attempt");
+        assert_eq!(driver.proof_provider.call_count(), 1, "proof should be generated once");
     }
 }

--- a/crates/utilities/tx-manager/src/manager.rs
+++ b/crates/utilities/tx-manager/src/manager.rs
@@ -1145,6 +1145,14 @@ impl SimpleTxManager {
     /// Performs a fee bump attempt and applies the result to the tracked state.
     ///
     /// Returns `Some(error)` if the send loop must abort, `None` to continue.
+    ///
+    /// When a bump attempt yields a non-retryable error but the
+    /// receipt-polling task has already recorded a mined tx on
+    /// `send_state`, the abort is suppressed so the send loop can
+    /// deliver the receipt on the next iteration. This avoids a
+    /// false-negative failure report when, for example, a fee bump
+    /// publish gets `NonceTooLow` because the original tx was already
+    /// confirmed.
     async fn try_fee_bump(
         &self,
         candidate: &TxCandidate,
@@ -1153,6 +1161,37 @@ impl SimpleTxManager {
         state: &mut BumpState,
     ) -> Option<TxManagerError> {
         let result = self.handle_fee_bump(candidate, send_state, receipt_tx, state).await;
+        Self::apply_bump_result_with_suppression(result, state, send_state)
+    }
+
+    /// Applies a fee bump result with mined-tx suppression.
+    ///
+    /// If the bump failed with a non-retryable error *but* the original
+    /// tx was already mined ([`SendState::is_waiting_for_confirmation`]),
+    /// the error is suppressed and logged at `info` level (not `error`).
+    /// This prevents false-positive alerts in the benign "tx confirmed
+    /// while we were bumping" case.
+    ///
+    /// On success or retryable error, delegates directly to
+    /// [`apply_bump_result`](Self::apply_bump_result).
+    fn apply_bump_result_with_suppression(
+        result: TxManagerResult<BumpState>,
+        state: &mut BumpState,
+        send_state: &SendState,
+    ) -> Option<TxManagerError> {
+        // Check for mined-tx suppression *before* apply_bump_result so
+        // the `error!` log inside that function is never emitted for the
+        // benign "tx already confirmed" case.
+        if let Err(ref e) = result
+            && !e.is_retryable()
+            && send_state.is_waiting_for_confirmation()
+        {
+            info!(
+                error = %e,
+                "fee bump failed but original tx already mined, suppressing abort"
+            );
+            return None;
+        }
         Self::apply_bump_result(result, state)
     }
 
@@ -1608,7 +1647,9 @@ mod tests {
     use rstest::rstest;
 
     use super::{BumpState, PreparedTx, SimpleTxManager, TxEnvelope};
-    use crate::{GasPriceCaps, NoopTxMetrics, TxCandidate, TxManagerConfig, TxManagerError};
+    use crate::{
+        GasPriceCaps, NoopTxMetrics, SendState, TxCandidate, TxManagerConfig, TxManagerError,
+    };
 
     async fn setup() -> (SimpleTxManager, alloy_node_bindings::AnvilInstance) {
         let anvil = Anvil::new().spawn();
@@ -1683,6 +1724,162 @@ mod tests {
         assert_eq!(state.gas_limit, expected_gas_limit);
         assert_eq!(state.tx_hash, expected_hash);
     }
+
+    // ── apply_bump_result_with_suppression ───────────────────────────
+    //
+    // Tests for `apply_bump_result_with_suppression`, which is the
+    // extracted helper that `try_fee_bump` calls. When a non-retryable
+    // error occurs but the original tx is already mined, the abort is
+    // suppressed so the send loop can deliver the receipt.
+
+    /// Threshold used for `SendState` construction in suppression tests.
+    const SUPPRESSION_NONCE_TOO_LOW_THRESHOLD: u64 = 3;
+
+    /// Hash recorded as a mined tx when simulating a confirmed original.
+    const MINED_TX_HASH: B256 = B256::repeat_byte(0xAA);
+
+    /// Default initial `BumpState` for suppression tests.
+    fn default_bump_state() -> BumpState {
+        BumpState {
+            tip: 100,
+            fee_cap: 1000,
+            blob_fee_cap: None,
+            gas_limit: 21_000,
+            tx_hash: B256::ZERO,
+            nonce: 0,
+            sidecar: None,
+        }
+    }
+
+    /// Creates a `SendState` and optionally marks a tx as mined.
+    fn suppression_send_state(tx_mined: bool) -> SendState {
+        let state =
+            SendState::new(SUPPRESSION_NONCE_TOO_LOW_THRESHOLD).expect("should create send state");
+        if tx_mined {
+            state.tx_mined(MINED_TX_HASH);
+        }
+        state
+    }
+
+    /// Non-retryable errors are suppressed when the original tx is
+    /// mined, and propagated when it is not.
+    #[rstest]
+    #[case::nonce_too_low_mined_suppressed(
+        TxManagerError::NonceTooLow,
+        true,  // tx is mined
+        false, // abort suppressed → no abort
+    )]
+    #[case::nonce_too_low_not_mined_propagates(
+        TxManagerError::NonceTooLow,
+        false, // tx is NOT mined
+        true,  // abort propagates
+    )]
+    #[case::fee_limit_exceeded_mined_suppressed(
+        TxManagerError::FeeLimitExceeded { fee: 500, ceiling: 100 },
+        true,
+        false,
+    )]
+    #[case::fee_limit_exceeded_not_mined_propagates(
+        TxManagerError::FeeLimitExceeded { fee: 500, ceiling: 100 },
+        false,
+        true,
+    )]
+    #[case::insufficient_funds_mined_suppressed(TxManagerError::InsufficientFunds, true, false)]
+    #[case::insufficient_funds_not_mined_propagates(TxManagerError::InsufficientFunds, false, true)]
+    #[case::execution_reverted_mined_suppressed(
+        TxManagerError::ExecutionReverted { reason: Some("revert".into()), data: None },
+        true,
+        false,
+    )]
+    #[case::execution_reverted_not_mined_propagates(
+        TxManagerError::ExecutionReverted { reason: Some("revert".into()), data: None },
+        false,
+        true,
+    )]
+    #[case::channel_closed_mined_suppressed(TxManagerError::ChannelClosed, true, false)]
+    #[case::channel_closed_not_mined_propagates(TxManagerError::ChannelClosed, false, true)]
+    fn bump_result_with_suppression_non_retryable(
+        #[case] error: TxManagerError,
+        #[case] tx_mined: bool,
+        #[case] abort_expected: bool,
+    ) {
+        let send_state = suppression_send_state(tx_mined);
+        assert_eq!(send_state.is_waiting_for_confirmation(), tx_mined);
+
+        let mut state = default_bump_state();
+
+        let abort = SimpleTxManager::apply_bump_result_with_suppression(
+            Err(error),
+            &mut state,
+            &send_state,
+        );
+
+        assert_eq!(
+            abort.is_some(),
+            abort_expected,
+            "abort_expected={abort_expected}, tx_mined={tx_mined}",
+        );
+    }
+
+    /// Retryable errors are never aborted by `apply_bump_result`, so
+    /// suppression is irrelevant — the send loop continues regardless.
+    #[rstest]
+    #[case::rpc_error_mined(TxManagerError::Rpc("transient".into()), true)]
+    #[case::rpc_error_not_mined(TxManagerError::Rpc("transient".into()), false)]
+    #[case::underpriced_mined(TxManagerError::Underpriced, true)]
+    #[case::underpriced_not_mined(TxManagerError::Underpriced, false)]
+    #[case::replacement_underpriced_mined(TxManagerError::ReplacementUnderpriced, true)]
+    #[case::fee_too_low_not_mined(TxManagerError::FeeTooLow, false)]
+    fn bump_result_with_suppression_retryable_never_aborts(
+        #[case] error: TxManagerError,
+        #[case] tx_mined: bool,
+    ) {
+        let send_state = suppression_send_state(tx_mined);
+        let mut state = default_bump_state();
+
+        let abort = SimpleTxManager::apply_bump_result_with_suppression(
+            Err(error),
+            &mut state,
+            &send_state,
+        );
+
+        assert!(abort.is_none(), "retryable errors should never cause an abort");
+    }
+
+    /// Success results pass through to `apply_bump_result` and update
+    /// state, regardless of mined state.
+    #[rstest]
+    #[case::success_not_mined(false)]
+    #[case::success_mined(true)]
+    fn bump_result_with_suppression_success_never_aborts(#[case] tx_mined: bool) {
+        let send_state = suppression_send_state(tx_mined);
+
+        let new_state = BumpState {
+            tip: 200,
+            fee_cap: 2000,
+            blob_fee_cap: None,
+            gas_limit: 50_000,
+            tx_hash: B256::with_last_byte(0x42),
+            nonce: 0,
+            sidecar: None,
+        };
+
+        let mut state = default_bump_state();
+
+        let abort = SimpleTxManager::apply_bump_result_with_suppression(
+            Ok(new_state),
+            &mut state,
+            &send_state,
+        );
+
+        assert!(abort.is_none(), "success should never cause an abort");
+        // State should be updated to the new values.
+        assert_eq!(state.tip, 200);
+        assert_eq!(state.fee_cap, 2000);
+        assert_eq!(state.tx_hash, B256::with_last_byte(0x42));
+    }
+
+    // ── should_reset_nonce_on_send_error ───────────────────────────────
 
     #[rstest]
     #[case::error_before_first_publish(false, Err(TxManagerError::SendTimeout), None, true)]


### PR DESCRIPTION
# Summary
Improves the resilience of the TEE Prover Registrar's Boundless marketplace integration with two targeted fixes. Successfully tested end-to-end on Sepolia with a live `registerSigner` transaction.

# Changes

*Commit 1: fix: handle RequestIsNotLocked race condition in Boundless fulfillment polling*

- Problem: The Boundless SDK's get_status() makes two sequential RPC calls (`getRequestStatus()` then `requestDeadline()`). If a request is fulfilled between these calls, `requestDeadline()` reverts with `RequestIsNotLocked`, causing the prover to treat a successful proof as a failure.
- Fix: Added `is_request_not_locked_error()` helper and a retry loop (max 3 retries, immediate) around `wait_for_request_fulfillment`. On `RequestIsNotLocked`, the next `get_status()` call correctly sees `RequestStatus::Fulfilled`.
- Tests: 4 `rstest` cases using real Boundless SDK error types.

*Commit 2: fix: suppress false-negative fee-bump errors and retry tx submission after proof generation*

- Fix B — Tx manager false-negative on fee bump `NonceTooLow`: When the original transaction has already mined but a fee bump gets `NonceTooLow`, `apply_bump_result()` would log an error and abort without checking receipt polling. Fixed by extracting `apply_bump_result_with_suppression()` that checks `is_waiting_for_confirmation()` before treating `NonceTooLow` as fatal.
  - Tests: 18 `rstest` cases covering all `non-retryable/retryable/success` × mined / not-mined combinations.
- Fix C — Tx submission not retried after expensive proof generation: When `tx_manager.send()` fails after ~20 minutes of Boundless proof generation, the driver discarded the proof entirely. Fixed with a retry loop (max 3 attempts, 5s delay) that checks cancellation and on-chain registration status between retries.
  - Tests: 10 `rstest` cases with `CountingProofProvider`, `FailingTxManager`, and `DynamicRegistry` mock types.

# End-to-End Testing
- Tested end-to-end and confirmed to successfully register the TEE prover.

# Test Results
- `base-tx-manager`: 368 passed (278 unit + 90 integration)
- `base-proof-tee-registrar`: 57 passed
- `base-proof-tee-nitro-attestation-prover`: 9 passed (27 with `--features prove`)

# Verification
- `cargo fmt --check — clean`
- `cargo clippy -- -D warnings — clean`
- `cargo check --tests — clean`