### PR TITLE
fix(prover-nitro-enclave): use Linux-only deps for real main

### DIFF
--- a/bin/prover/nitro-enclave/Cargo.toml
+++ b/bin/prover/nitro-enclave/Cargo.toml
@@ -15,7 +15,7 @@ path = "src/main.rs"
 [lints]
 workspace = true
 
-[dependencies]
+[target.'cfg(target_os = "linux")'.dependencies]
 eyre.workspace = true
 base-proof-tee-nitro-enclave.workspace = true
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }


### PR DESCRIPTION
[issue:](https://github.com/base/base/issues/1758)

The binary's async main, eyre return type, and NitroEnclave import are #[cfg(target_os = "linux")]; non-Linux builds only compile a panic stub.

Put eyre, base-proof-tee-nitro-enclave, and tokio under [target.'cfg(target_os = "linux")'.dependencies] so cargo-udeps does not flag them on other hosts.


## Summary

Scope `base-prover-nitro-enclave` runtime dependencies to Linux only, matching `main.rs` cfg split.

## Motivation

On non-Linux targets, only the `panic!(...)` stub `main` is compiled; `tokio`, `eyre`, and `base-proof-tee-nitro-enclave` are unused in depinfo. Unconditional `[dependencies]` causes `cargo udeps` false positives on macOS and similar CI matrices.

## Changes

- `bin/prover/nitro-enclave/Cargo.toml`: replace top-level `[dependencies]` with `[target.'cfg(target_os = "linux")'.dependencies]` for `eyre`, `base-proof-tee-nitro-enclave`, and `tokio` (waterfall-sorted).


## Verification

- `cargo check -p base-prover-nitro-enclave`
- `RISC0_SKIP_BUILD_KERNELS=1 cargo +nightly udeps --locked -p base-prover-nitro-enclave --all-features --all-targets`