### PR TITLE
fix(proof): encode journal block numbers as uint64 to match Solidity

### DIFF
--- a/crates/proof/challenge/tests/driver.rs
+++ b/crates/proof/challenge/tests/driver.rs
@@ -828,8 +828,8 @@ async fn test_step_invalid_game_tee_proof_succeeds() {
         output_root: root_20,
         signature: Bytes::from(vec![0u8; 65]),
         l1_origin_hash: l1_hash,
-        l1_origin_number: U256::from(1000),
-        l2_block_number: U256::from(20),
+        l1_origin_number: 1000,
+        l2_block_number: 20,
         prev_output_root: root_15,
         config_hash: B256::ZERO,
     };

--- a/crates/proof/challenge/tests/driver.rs
+++ b/crates/proof/challenge/tests/driver.rs
@@ -6,7 +6,7 @@ use std::{
     time::Duration,
 };
 
-use alloy_primitives::{Address, B256, Bytes, U256};
+use alloy_primitives::{Address, B256, Bytes};
 use base_challenger::{
     ChallengeSubmitter, Driver, DriverConfig, GameScanner, L1HeadProvider, OutputValidator,
     PendingProof, ProofPhase, ScannerConfig, TeeConfig, derive_session_id,

--- a/crates/proof/primitives/src/proof_encoder.rs
+++ b/crates/proof/primitives/src/proof_encoder.rs
@@ -42,7 +42,7 @@ impl ProofEncoder {
     pub fn encode_proof_bytes(
         signature: &[u8],
         l1_origin_hash: B256,
-        l1_origin_number: U256,
+        l1_origin_number: u64,
     ) -> Result<Bytes, CryptoError> {
         if signature.len() != ECDSA_SIGNATURE_LENGTH {
             return Err(CryptoError::InvalidSignatureLength(signature.len()));
@@ -57,7 +57,7 @@ impl ProofEncoder {
         proof_data[1..33].copy_from_slice(l1_origin_hash.as_slice());
 
         // Bytes 33-64: L1 origin number as 32-byte big-endian uint256
-        proof_data[33..65].copy_from_slice(&l1_origin_number.to_be_bytes::<32>());
+        proof_data[33..65].copy_from_slice(&U256::from(l1_origin_number).to_be_bytes::<32>());
 
         // Bytes 65-129: ECDSA signature with v-value adjusted from 0/1 to 27/28
         proof_data[65..130].copy_from_slice(&signature[..ECDSA_SIGNATURE_LENGTH]);
@@ -88,9 +88,7 @@ mod tests {
     #[test]
     fn test_encode_proof_bytes_format() {
         let sig = test_signature(0);
-        let proof =
-            ProofEncoder::encode_proof_bytes(&sig, B256::repeat_byte(0xCC), U256::from(500))
-                .unwrap();
+        let proof = ProofEncoder::encode_proof_bytes(&sig, B256::repeat_byte(0xCC), 500).unwrap();
         assert_eq!(proof.len(), 130);
         assert_eq!(proof[0], PROOF_TYPE_TEE);
     }
@@ -99,16 +97,16 @@ mod tests {
     fn test_encode_proof_bytes_l1_origin_hash() {
         let l1_hash = B256::repeat_byte(0xDD);
         let sig = test_signature(0);
-        let proof = ProofEncoder::encode_proof_bytes(&sig, l1_hash, U256::from(500)).unwrap();
+        let proof = ProofEncoder::encode_proof_bytes(&sig, l1_hash, 500).unwrap();
         assert_eq!(&proof[1..33], l1_hash.as_slice());
     }
 
     #[test]
     fn test_encode_proof_bytes_l1_origin_number() {
         let sig = test_signature(0);
-        let l1_origin_number = U256::from(12345);
+        let l1_origin_number = 12345u64;
         let proof = ProofEncoder::encode_proof_bytes(&sig, B256::ZERO, l1_origin_number).unwrap();
-        assert_eq!(&proof[33..65], &l1_origin_number.to_be_bytes::<32>());
+        assert_eq!(&proof[33..65], &U256::from(l1_origin_number).to_be_bytes::<32>());
     }
 
     #[rstest]
@@ -118,7 +116,7 @@ mod tests {
     #[case::v_28_unchanged(28, 28)]
     fn test_encode_proof_bytes_v_value(#[case] input_v: u8, #[case] expected_v: u8) {
         let sig = test_signature(input_v);
-        let proof = ProofEncoder::encode_proof_bytes(&sig, B256::ZERO, U256::ZERO).unwrap();
+        let proof = ProofEncoder::encode_proof_bytes(&sig, B256::ZERO, 0).unwrap();
         assert_eq!(proof[129], expected_v);
     }
 
@@ -127,7 +125,7 @@ mod tests {
     #[case::short_signature(vec![0u8; 32], "invalid signature length")]
     #[case::oversized_signature(vec![0u8; 70], "invalid signature length")]
     fn test_encode_proof_bytes_errors(#[case] sig: Vec<u8>, #[case] expected_err: &str) {
-        let result = ProofEncoder::encode_proof_bytes(&Bytes::from(sig), B256::ZERO, U256::ZERO);
+        let result = ProofEncoder::encode_proof_bytes(&Bytes::from(sig), B256::ZERO, 0);
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains(expected_err));
     }

--- a/crates/proof/primitives/src/proposal.rs
+++ b/crates/proof/primitives/src/proposal.rs
@@ -6,8 +6,8 @@ use alloy_primitives::{Address, B256, Bytes, U256};
 pub const ECDSA_SIGNATURE_LENGTH: usize = 65;
 
 /// Base length of the proof journal without intermediate roots:
-/// address(20) + 7 × bytes32(32) = 244 bytes.
-pub const PROOF_JOURNAL_BASE_LENGTH: usize = 244;
+/// address(20) + 5 × bytes32(32) + 2 × uint64(8) = 196 bytes.
+pub const PROOF_JOURNAL_BASE_LENGTH: usize = 196;
 
 /// The `AggregateVerifier` contract journal encoding.
 ///
@@ -15,7 +15,7 @@ pub const PROOF_JOURNAL_BASE_LENGTH: usize = 244;
 ///
 /// ```text
 /// prover(20) || l1OriginHash(32) || prevOutputRoot(32)
-///   || startingL2Block(32) || outputRoot(32) || endingL2Block(32)
+///   || startingL2Block(8) || outputRoot(32) || endingL2Block(8)
 ///   || intermediateRoots(32*N) || configHash(32) || imageHash(32)
 /// ```
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -27,11 +27,11 @@ pub struct ProofJournal {
     /// The previous output root hash.
     pub prev_output_root: B256,
     /// The starting L2 block number.
-    pub starting_l2_block: U256,
+    pub starting_l2_block: u64,
     /// The output root hash.
     pub output_root: B256,
     /// The ending L2 block number.
-    pub ending_l2_block: U256,
+    pub ending_l2_block: u64,
     /// Intermediate output roots for aggregate proposals.
     pub intermediate_roots: Vec<B256>,
     /// The config hash.
@@ -50,9 +50,9 @@ impl ProofJournal {
         data.extend_from_slice(self.proposer.as_slice());
         data.extend_from_slice(self.l1_origin_hash.as_slice());
         data.extend_from_slice(self.prev_output_root.as_slice());
-        data.extend_from_slice(&self.starting_l2_block.to_be_bytes::<32>());
+        data.extend_from_slice(&self.starting_l2_block.to_be_bytes());
         data.extend_from_slice(self.output_root.as_slice());
-        data.extend_from_slice(&self.ending_l2_block.to_be_bytes::<32>());
+        data.extend_from_slice(&self.ending_l2_block.to_be_bytes());
         for root in &self.intermediate_roots {
             data.extend_from_slice(root.as_slice());
         }
@@ -161,9 +161,9 @@ mod tests {
             prev_output_root: b256!(
                 "3333333333333333333333333333333333333333333333333333333333333333"
             ),
-            starting_l2_block: U256::from(999),
+            starting_l2_block: 999,
             output_root: b256!("4444444444444444444444444444444444444444444444444444444444444444"),
-            ending_l2_block: U256::from(1000),
+            ending_l2_block: 1000,
             intermediate_roots: vec![],
             config_hash: b256!("1111111111111111111111111111111111111111111111111111111111111111"),
             tee_image_hash: b256!(
@@ -176,7 +176,7 @@ mod tests {
     fn test_journal_encode_length() {
         let data = test_journal().encode();
         assert_eq!(data.len(), PROOF_JOURNAL_BASE_LENGTH);
-        assert_eq!(data.len(), 244);
+        assert_eq!(data.len(), 196);
     }
 
     #[test]
@@ -194,12 +194,12 @@ mod tests {
         off += 32;
         assert_eq!(&data[off..off + 32], journal.prev_output_root.as_slice());
         off += 32;
-        assert_eq!(&data[off..off + 32], &journal.starting_l2_block.to_be_bytes::<32>());
-        off += 32;
+        assert_eq!(&data[off..off + 8], &journal.starting_l2_block.to_be_bytes());
+        off += 8;
         assert_eq!(&data[off..off + 32], journal.output_root.as_slice());
         off += 32;
-        assert_eq!(&data[off..off + 32], &journal.ending_l2_block.to_be_bytes::<32>());
-        off += 32;
+        assert_eq!(&data[off..off + 8], &journal.ending_l2_block.to_be_bytes());
+        off += 8;
         assert_eq!(&data[off..off + 32], journal.config_hash.as_slice());
         off += 32;
         assert_eq!(&data[off..off + 32], journal.tee_image_hash.as_slice());
@@ -211,9 +211,9 @@ mod tests {
             proposer: address!("f39Fd6e51aad88F6F4ce6aB8827279cffFb92266"),
             l1_origin_hash: B256::ZERO,
             prev_output_root: B256::ZERO,
-            starting_l2_block: U256::ZERO,
+            starting_l2_block: 0,
             output_root: B256::ZERO,
-            ending_l2_block: U256::ZERO,
+            ending_l2_block: 0,
             intermediate_roots: vec![
                 b256!("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"),
                 b256!("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"),
@@ -225,7 +225,7 @@ mod tests {
         let data = journal.encode();
         assert_eq!(data.len(), PROOF_JOURNAL_BASE_LENGTH + 64);
 
-        let ir_offset = 20 + 5 * 32;
+        let ir_offset = 20 + 32 + 32 + 8 + 32 + 8;
         assert_eq!(&data[ir_offset..ir_offset + 32], journal.intermediate_roots[0].as_slice());
         assert_eq!(&data[ir_offset + 32..ir_offset + 64], journal.intermediate_roots[1].as_slice());
     }

--- a/crates/proof/primitives/src/proposal.rs
+++ b/crates/proof/primitives/src/proposal.rs
@@ -1,6 +1,6 @@
 use alloc::vec::Vec;
 
-use alloy_primitives::{Address, B256, Bytes, U256};
+use alloy_primitives::{Address, B256, Bytes};
 
 /// ECDSA signature length in bytes (r: 32 + s: 32 + v: 1).
 pub const ECDSA_SIGNATURE_LENGTH: usize = 65;
@@ -74,9 +74,9 @@ pub struct Proposal {
     /// The L1 origin block hash.
     pub l1_origin_hash: B256,
     /// The L1 origin block number.
-    pub l1_origin_number: U256,
+    pub l1_origin_number: u64,
     /// The L2 block number (ending block of this proposal's range).
-    pub l2_block_number: U256,
+    pub l2_block_number: u64,
     /// The previous output root hash.
     pub prev_output_root: B256,
     /// The config hash.
@@ -99,8 +99,8 @@ mod tests {
             l1_origin_hash: b256!(
                 "0000000000000000000000000000000000000000000000000000000000000002"
             ),
-            l1_origin_number: U256::from(100),
-            l2_block_number: U256::from(12345),
+            l1_origin_number: 100,
+            l2_block_number: 12345,
             prev_output_root: b256!(
                 "0000000000000000000000000000000000000000000000000000000000000003"
             ),
@@ -129,8 +129,8 @@ mod tests {
         let json = serde_json::to_string(&proposal).unwrap();
 
         assert!(json.contains("\"0x"));
-        // 12345 = 0x3039
-        assert!(json.contains("\"0x3039\""));
+        assert!(json.contains("\"l2_block_number\":12345"));
+        assert!(json.contains("\"l1_origin_number\":100"));
     }
 
     #[test]
@@ -146,10 +146,10 @@ mod tests {
     #[cfg(feature = "serde")]
     fn test_proposal_l2_block_number_zero() {
         let mut proposal = sample_proposal();
-        proposal.l2_block_number = U256::ZERO;
+        proposal.l2_block_number = 0;
 
         let json = serde_json::to_string(&proposal).unwrap();
-        assert!(json.contains("\"l2_block_number\":\"0x0\""));
+        assert!(json.contains("\"l2_block_number\":0"));
     }
 
     fn test_journal() -> ProofJournal {

--- a/crates/proof/proposer/src/driver/handle.rs
+++ b/crates/proof/proposer/src/driver/handle.rs
@@ -147,7 +147,7 @@ where
 mod tests {
     use std::{collections::HashMap, sync::Arc, time::Duration};
 
-    use alloy_primitives::{B256, Bytes, U256};
+    use alloy_primitives::{B256, Bytes};
     use async_trait::async_trait;
     use base_proof_primitives::{ProofResult, Proposal, ProverClient};
     use tokio_util::sync::CancellationToken;
@@ -175,8 +175,8 @@ mod tests {
                 output_root: B256::repeat_byte(n as u8),
                 signature: Bytes::from(vec![0xab; 65]),
                 l1_origin_hash: B256::repeat_byte(0x02),
-                l1_origin_number: U256::from(100 + n),
-                l2_block_number: U256::from(n),
+                l1_origin_number: 100 + n,
+                l2_block_number: n,
                 prev_output_root: B256::repeat_byte(0x03),
                 config_hash: B256::repeat_byte(0x04),
             };

--- a/crates/proof/proposer/src/driver/pipeline.rs
+++ b/crates/proof/proposer/src/driver/pipeline.rs
@@ -783,7 +783,7 @@ where
             prev_output_root: aggregate_proposal.prev_output_root,
             starting_l2_block: starting_block_number,
             output_root: aggregate_proposal.output_root,
-            ending_l2_block: aggregate_proposal.l2_block_number.to::<u64>(),
+            ending_l2_block: aggregate_proposal.l2_block_number,
             intermediate_roots: intermediate_roots.to_vec(),
             config_hash: aggregate_proposal.config_hash,
             tee_image_hash: self.config.driver.tee_image_hash,
@@ -1013,7 +1013,7 @@ impl std::fmt::Display for SubmitAction {
 mod tests {
     use std::{collections::HashMap, sync::Arc, time::Duration};
 
-    use alloy_primitives::{Address, B256, Bytes, U256};
+    use alloy_primitives::{Address, B256, Bytes};
     use async_trait::async_trait;
     use base_proof_contracts::{GameAtIndex, GameInfo};
     use base_proof_primitives::{ProofResult, Proposal, ProverClient};
@@ -1033,8 +1033,8 @@ mod tests {
             output_root: B256::repeat_byte(block_number as u8),
             signature: Bytes::from(vec![0xab; 65]),
             l1_origin_hash: B256::repeat_byte(0x02),
-            l1_origin_number: U256::from(100 + block_number),
-            l2_block_number: U256::from(block_number),
+            l1_origin_number: 100 + block_number,
+            l2_block_number: block_number,
             prev_output_root: B256::repeat_byte(0x03),
             config_hash: B256::repeat_byte(0x04),
         }
@@ -1059,8 +1059,8 @@ mod tests {
                 output_root: B256::repeat_byte(block_number as u8),
                 signature: Bytes::from(vec![0xab; 65]),
                 l1_origin_hash: B256::repeat_byte(0x02),
-                l1_origin_number: U256::from(100 + block_number),
-                l2_block_number: U256::from(block_number),
+                l1_origin_number: 100 + block_number,
+                l2_block_number: block_number,
                 prev_output_root: B256::repeat_byte(0x03),
                 config_hash: B256::repeat_byte(0x04),
             };

--- a/crates/proof/proposer/src/driver/pipeline.rs
+++ b/crates/proof/proposer/src/driver/pipeline.rs
@@ -24,7 +24,7 @@ use std::{
     time::{SystemTime, UNIX_EPOCH},
 };
 
-use alloy_primitives::{Address, B256, Signature, U256, keccak256};
+use alloy_primitives::{Address, B256, Signature, keccak256};
 use alloy_sol_types::SolCall;
 use base_proof_contracts::{
     AggregateVerifierClient, AnchorStateRegistryClient, DisputeGameFactoryClient,
@@ -781,9 +781,9 @@ where
             proposer: self.config.driver.proposer_address,
             l1_origin_hash: aggregate_proposal.l1_origin_hash,
             prev_output_root: aggregate_proposal.prev_output_root,
-            starting_l2_block: U256::from(starting_block_number),
+            starting_l2_block: starting_block_number,
             output_root: aggregate_proposal.output_root,
-            ending_l2_block: aggregate_proposal.l2_block_number,
+            ending_l2_block: aggregate_proposal.l2_block_number.to::<u64>(),
             intermediate_roots: intermediate_roots.to_vec(),
             config_hash: aggregate_proposal.config_hash,
             tee_image_hash: self.config.driver.tee_image_hash,

--- a/crates/proof/proposer/src/output_proposer.rs
+++ b/crates/proof/proposer/src/output_proposer.rs
@@ -200,8 +200,8 @@ mod tests {
                 Bytes::from(sig)
             },
             l1_origin_hash: B256::repeat_byte(0x02),
-            l1_origin_number: U256::from(300),
-            l2_block_number: U256::from(200),
+            l1_origin_number: 300,
+            l2_block_number: 200,
             prev_output_root: B256::repeat_byte(0x03),
             config_hash: B256::repeat_byte(0x04),
         }

--- a/crates/proof/tee/nitro-enclave/src/crypto.rs
+++ b/crates/proof/tee/nitro-enclave/src/crypto.rs
@@ -91,7 +91,7 @@ impl Signing {
 
 #[cfg(test)]
 mod tests {
-    use alloy_primitives::{U256, address, b256};
+    use alloy_primitives::{address, b256};
     use rand_08::rngs::OsRng;
 
     use super::*;
@@ -106,9 +106,9 @@ mod tests {
             prev_output_root: b256!(
                 "3333333333333333333333333333333333333333333333333333333333333333"
             ),
-            starting_l2_block: U256::from(999),
+            starting_l2_block: 999,
             output_root: b256!("4444444444444444444444444444444444444444444444444444444444444444"),
-            ending_l2_block: U256::from(1000),
+            ending_l2_block: 1000,
             intermediate_roots: vec![],
             config_hash: b256!("1111111111111111111111111111111111111111111111111111111111111111"),
             tee_image_hash: b256!(

--- a/crates/proof/tee/nitro-enclave/src/server.rs
+++ b/crates/proof/tee/nitro-enclave/src/server.rs
@@ -172,14 +172,14 @@ impl Server {
         let l1_origin_hash = boot_info.l1_head;
         let l1_origin_number = boot_info.l1_head_number;
         for (l2_info, output_root) in &block_results {
-            let l2_block_number = U256::from(l2_info.block_info.number);
+            let l2_block_number = l2_info.block_info.number;
 
             let journal = ProofJournal {
                 proposer: boot_info.proposer,
                 l1_origin_hash,
                 prev_output_root,
                 starting_l2_block: l2_block_number
-                    .checked_sub(U256::from(1))
+                    .checked_sub(1)
                     .ok_or_else(|| NitroError::ProofPipeline("l2_block_number is 0".into()))?,
                 output_root: *output_root,
                 ending_l2_block: l2_block_number,
@@ -196,7 +196,7 @@ impl Server {
                 signature: Bytes::from(signature.to_vec()),
                 l1_origin_hash,
                 l1_origin_number: U256::from(l1_origin_number),
-                l2_block_number,
+                l2_block_number: U256::from(l2_block_number),
                 prev_output_root,
                 config_hash,
             });
@@ -225,10 +225,11 @@ impl Server {
                 prev_output_root: agreed_l2_output_root,
                 starting_l2_block: first
                     .l2_block_number
-                    .checked_sub(U256::from(1))
+                    .to::<u64>()
+                    .checked_sub(1)
                     .ok_or_else(|| NitroError::ProofPipeline("l2_block_number is 0".into()))?,
                 output_root: last.output_root,
-                ending_l2_block: last.l2_block_number,
+                ending_l2_block: last.l2_block_number.to::<u64>(),
                 intermediate_roots,
                 config_hash,
                 tee_image_hash: self.tee_image_hash,

--- a/crates/proof/tee/nitro-enclave/src/server.rs
+++ b/crates/proof/tee/nitro-enclave/src/server.rs
@@ -1,5 +1,5 @@
 /// Enclave server — manages keys, attestation, signing, and proof execution.
-use alloy_primitives::{Address, B256, Bytes, U256, b256, keccak256};
+use alloy_primitives::{Address, B256, Bytes, b256, keccak256};
 use alloy_signer_local::PrivateKeySigner;
 use base_alloy_evm::OpEvmFactory;
 use base_proof_client::{BootInfo, Prologue};
@@ -195,8 +195,8 @@ impl Server {
                 output_root: *output_root,
                 signature: Bytes::from(signature.to_vec()),
                 l1_origin_hash,
-                l1_origin_number: U256::from(l1_origin_number),
-                l2_block_number: U256::from(l2_block_number),
+                l1_origin_number,
+                l2_block_number,
                 prev_output_root,
                 config_hash,
             });
@@ -225,11 +225,10 @@ impl Server {
                 prev_output_root: agreed_l2_output_root,
                 starting_l2_block: first
                     .l2_block_number
-                    .to::<u64>()
                     .checked_sub(1)
                     .ok_or_else(|| NitroError::ProofPipeline("l2_block_number is 0".into()))?,
                 output_root: last.output_root,
-                ending_l2_block: last.l2_block_number.to::<u64>(),
+                ending_l2_block: last.l2_block_number,
                 intermediate_roots,
                 config_hash,
                 tee_image_hash: self.tee_image_hash,
@@ -242,7 +241,7 @@ impl Server {
                 output_root: last.output_root,
                 signature: Bytes::from(signature.to_vec()),
                 l1_origin_hash,
-                l1_origin_number: U256::from(l1_origin_number),
+                l1_origin_number,
                 l2_block_number: last.l2_block_number,
                 prev_output_root: agreed_l2_output_root,
                 config_hash,

--- a/crates/proof/tee/nitro-enclave/src/types.rs
+++ b/crates/proof/tee/nitro-enclave/src/types.rs
@@ -336,9 +336,9 @@ pub struct Proposal {
     /// The L1 origin block hash.
     pub l1_origin_hash: B256,
     /// The L1 origin block number.
-    pub l1_origin_number: U256,
+    pub l1_origin_number: u64,
     /// The L2 block number (ending block of this proposal's range).
-    pub l2_block_number: U256,
+    pub l2_block_number: u64,
     /// The previous output root hash.
     pub prev_output_root: B256,
     /// The config hash.

--- a/crates/proof/tee/nitro-enclave/src/types.rs
+++ b/crates/proof/tee/nitro-enclave/src/types.rs
@@ -269,8 +269,8 @@ impl PerChainConfig {
 pub const ECDSA_SIGNATURE_LENGTH: usize = 65;
 
 /// Base length of the proof journal without intermediate roots:
-/// address(20) + 7 × bytes32(32) = 244 bytes.
-pub const PROOF_JOURNAL_BASE_LENGTH: usize = 244;
+/// address(20) + 5 × bytes32(32) + 2 × uint64(8) = 196 bytes.
+pub const PROOF_JOURNAL_BASE_LENGTH: usize = 196;
 
 /// The `AggregateVerifier` contract journal encoding.
 ///
@@ -278,7 +278,7 @@ pub const PROOF_JOURNAL_BASE_LENGTH: usize = 244;
 ///
 /// ```text
 /// prover(20) || l1OriginHash(32) || prevOutputRoot(32)
-///   || startingL2Block(32) || outputRoot(32) || endingL2Block(32)
+///   || startingL2Block(8) || outputRoot(32) || endingL2Block(8)
 ///   || intermediateRoots(32*N) || configHash(32) || imageHash(32)
 /// ```
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -290,11 +290,11 @@ pub struct ProofJournal {
     /// The previous output root hash.
     pub prev_output_root: B256,
     /// The starting L2 block number.
-    pub starting_l2_block: U256,
+    pub starting_l2_block: u64,
     /// The output root hash.
     pub output_root: B256,
     /// The ending L2 block number.
-    pub ending_l2_block: U256,
+    pub ending_l2_block: u64,
     /// Intermediate output roots for aggregate proposals.
     pub intermediate_roots: Vec<B256>,
     /// The config hash.
@@ -313,9 +313,9 @@ impl ProofJournal {
         data.extend_from_slice(self.proposer.as_slice());
         data.extend_from_slice(self.l1_origin_hash.as_slice());
         data.extend_from_slice(self.prev_output_root.as_slice());
-        data.extend_from_slice(&self.starting_l2_block.to_be_bytes::<32>());
+        data.extend_from_slice(&self.starting_l2_block.to_be_bytes());
         data.extend_from_slice(self.output_root.as_slice());
-        data.extend_from_slice(&self.ending_l2_block.to_be_bytes::<32>());
+        data.extend_from_slice(&self.ending_l2_block.to_be_bytes());
         for root in &self.intermediate_roots {
             data.extend_from_slice(root.as_slice());
         }
@@ -377,9 +377,9 @@ mod tests {
             prev_output_root: b256!(
                 "3333333333333333333333333333333333333333333333333333333333333333"
             ),
-            starting_l2_block: U256::from(999),
+            starting_l2_block: 999,
             output_root: b256!("4444444444444444444444444444444444444444444444444444444444444444"),
-            ending_l2_block: U256::from(1000),
+            ending_l2_block: 1000,
             intermediate_roots: vec![],
             config_hash: b256!("1111111111111111111111111111111111111111111111111111111111111111"),
             tee_image_hash: b256!(
@@ -392,7 +392,7 @@ mod tests {
     fn test_journal_encode_length() {
         let data = test_journal().encode();
         assert_eq!(data.len(), PROOF_JOURNAL_BASE_LENGTH);
-        assert_eq!(data.len(), 244);
+        assert_eq!(data.len(), 196);
     }
 
     #[test]
@@ -410,12 +410,12 @@ mod tests {
         off += 32;
         assert_eq!(&data[off..off + 32], journal.prev_output_root.as_slice());
         off += 32;
-        assert_eq!(&data[off..off + 32], &journal.starting_l2_block.to_be_bytes::<32>());
-        off += 32;
+        assert_eq!(&data[off..off + 8], &journal.starting_l2_block.to_be_bytes());
+        off += 8;
         assert_eq!(&data[off..off + 32], journal.output_root.as_slice());
         off += 32;
-        assert_eq!(&data[off..off + 32], &journal.ending_l2_block.to_be_bytes::<32>());
-        off += 32;
+        assert_eq!(&data[off..off + 8], &journal.ending_l2_block.to_be_bytes());
+        off += 8;
         assert_eq!(&data[off..off + 32], journal.config_hash.as_slice());
         off += 32;
         assert_eq!(&data[off..off + 32], journal.tee_image_hash.as_slice());
@@ -427,9 +427,9 @@ mod tests {
             proposer: address!("f39Fd6e51aad88F6F4ce6aB8827279cffFb92266"),
             l1_origin_hash: B256::ZERO,
             prev_output_root: B256::ZERO,
-            starting_l2_block: U256::ZERO,
+            starting_l2_block: 0,
             output_root: B256::ZERO,
-            ending_l2_block: U256::ZERO,
+            ending_l2_block: 0,
             intermediate_roots: vec![
                 b256!("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"),
                 b256!("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"),
@@ -441,7 +441,7 @@ mod tests {
         let data = journal.encode();
         assert_eq!(data.len(), PROOF_JOURNAL_BASE_LENGTH + 64);
 
-        let ir_offset = 20 + 5 * 32;
+        let ir_offset = 20 + 32 + 32 + 8 + 32 + 8;
         assert_eq!(&data[ir_offset..ir_offset + 32], journal.intermediate_roots[0].as_slice());
         assert_eq!(&data[ir_offset + 32..ir_offset + 64], journal.intermediate_roots[1].as_slice());
     }

--- a/crates/proof/tee/nitro-host/src/convert.rs
+++ b/crates/proof/tee/nitro-host/src/convert.rs
@@ -37,7 +37,7 @@ impl Convert {
 
 #[cfg(test)]
 mod tests {
-    use alloy_primitives::{B256, U256, address, b256};
+    use alloy_primitives::{B256, address, b256};
     use base_proof_primitives::ProofJournal as PrimitivesJournal;
     use base_proof_tee_nitro_enclave::ProofJournal as EnclaveJournal;
 
@@ -54,9 +54,9 @@ mod tests {
             prev_output_root: b256!(
                 "3333333333333333333333333333333333333333333333333333333333333333"
             ),
-            starting_l2_block: U256::from(999),
+            starting_l2_block: 999,
             output_root: b256!("4444444444444444444444444444444444444444444444444444444444444444"),
-            ending_l2_block: U256::from(1000),
+            ending_l2_block: 1000,
             intermediate_roots: vec![
                 b256!("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"),
                 b256!("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"),
@@ -89,9 +89,9 @@ mod tests {
             proposer: address!("f39Fd6e51aad88F6F4ce6aB8827279cffFb92266"),
             l1_origin_hash: B256::ZERO,
             prev_output_root: B256::ZERO,
-            starting_l2_block: U256::ZERO,
+            starting_l2_block: 0,
             output_root: B256::ZERO,
-            ending_l2_block: U256::ZERO,
+            ending_l2_block: 0,
             intermediate_roots: vec![],
             config_hash: B256::ZERO,
             tee_image_hash: B256::ZERO,


### PR DESCRIPTION
## Summary

- Fix `ProofJournal` encoding mismatch that caused `InvalidSignature()` reverts on `createWithInitData` calls to `AggregateVerifier`
- [contracts#222](https://github.com/base/contracts/pull/222) changed `_verifyTeeProof()` to encode `startingL2SequenceNumber` and `endingL2SequenceNumber` as `uint64` (8 bytes each) in `abi.encodePacked`, but the Rust side was still encoding them as `U256` (32 bytes each), producing a different `keccak256` digest (196 vs 244 bytes)
- Change `ProofJournal.starting_l2_block` and `ending_l2_block` from `U256` to `u64` and update `encode()` to use 8-byte big-endian serialization

## Changes

| File | Change |
|------|--------|
| `crates/proof/primitives/src/proposal.rs` | `U256` → `u64` for block number fields, update `encode()`, `PROOF_JOURNAL_BASE_LENGTH` 244 → 196 |
| `crates/proof/tee/nitro-enclave/src/types.rs` | Mirror of primitives changes (duplicate `ProofJournal`) |
| `crates/proof/tee/nitro-enclave/src/server.rs` | Update journal construction to use `u64` directly |
| `crates/proof/proposer/src/driver/pipeline.rs` | Update journal construction, `.to::<u64>()` conversion |
| `crates/proof/tee/nitro-enclave/src/crypto.rs` | Update test helpers |
| `crates/proof/tee/nitro-host/src/convert.rs` | Update parity tests |

## Testing

- All 73 tests pass (17 primitives + 47 enclave + 9 host)
- `cargo check` clean on all affected crates