### PR TITLE
Fix inconsistent contract naming

### DIFF
--- a/docs/specs/pages/protocol/fault-proof/stage-one/bridge-integration.md
+++ b/docs/specs/pages/protocol/fault-proof/stage-one/bridge-integration.md
@@ -238,7 +238,7 @@ roles: the `PROPOSER` and a `CHALLENGER` (or set of challengers). Each interacti
 In the event that we'd like to switch back to permissioned proposals, we can change the `RESPECTED_GAME_TYPE` in the
 `OptimismPortal` to a deployment of the `PermissionedFaultDisputeGame`.
 
-### Roles - `PermissionedDisputeGame`
+### Roles - `PermissionedFaultDisputeGame`
 
 - `PROPOSER` - Actor that can create a `PermissionedFaultDisputeGame` and participate in the games they've created.
 - `CHALLENGER` - Actor(s) that can participate in a `PermissionedFaultDisputeGame`.


### PR DESCRIPTION
Fixed an inconsistency in contract naming within the `bridge-integration.md` spec. The section header previously referred to `PermissionedDisputeGame`, while the correct contract name used elsewhere in the document is `PermissionedFaultDisputeGame`.

Changes:
Updated section header:
`### Roles - PermissionedDisputeGame` -> `### Roles - PermissionedFaultDisputeGame`

Rationale:
Aligns the section title with the canonical contract name used throughout the document, improving clarity and consistency.