### PR TITLE
feat(basectl): stderr tracing for flashblocks --json

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5307,6 +5307,8 @@ dependencies = [
  "clap",
  "rustls 0.23.37",
  "tokio",
+ "tracing",
+ "tracing-subscriber 0.3.23",
 ]
 
 [[package]]

--- a/bin/basectl/Cargo.toml
+++ b/bin/basectl/Cargo.toml
@@ -13,7 +13,9 @@ workspace = true
 
 [dependencies]
 anyhow = { workspace = true }
+tracing = { workspace = true, features = ["std"] }
 basectl-cli = { workspace = true }
-rustls = { workspace = true, features = ["ring"] }
 clap = { workspace = true, features = ["derive"] }
+rustls = { workspace = true, features = ["ring"] }
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
+tracing-subscriber = { workspace = true, features = ["fmt"] }

--- a/bin/basectl/src/main.rs
+++ b/bin/basectl/src/main.rs
@@ -4,6 +4,18 @@ mod cli;
 
 use basectl_cli::{ChainConfig, ViewId, run_app, run_app_with_view, run_flashblocks_json};
 use clap::Parser;
+use tracing::Level;
+
+/// Install a stderr-only tracing subscriber for `--json` flashblocks mode so structured logs
+/// (Toast + `warn!` in `basectl-cli`) do not pollute stdout JSON lines.
+fn init_flashblocks_json_tracing() {
+    let _ = tracing_subscriber::fmt()
+        .with_writer(std::io::stderr)
+        .with_max_level(Level::WARN)
+        .with_target(false)
+        .without_time()
+        .try_init();
+}
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
@@ -16,7 +28,10 @@ async fn main() -> anyhow::Result<()> {
 
     match cli.command {
         Some(cli::Commands::Config) => run_app_with_view(chain_config, ViewId::Config).await,
-        Some(cli::Commands::Flashblocks { json: true }) => run_flashblocks_json(chain_config).await,
+        Some(cli::Commands::Flashblocks { json: true }) => {
+            init_flashblocks_json_tracing();
+            run_flashblocks_json(chain_config).await
+        }
         Some(cli::Commands::Flashblocks { json: false }) => {
             run_app_with_view(chain_config, ViewId::Flashblocks).await
         }

--- a/crates/infra/basectl/src/app/runner.rs
+++ b/crates/infra/basectl/src/app/runner.rs
@@ -4,6 +4,7 @@ use anyhow::Result;
 use base_alloy_flashblocks::Flashblock;
 use base_consensus_genesis::SystemConfig;
 use tokio::sync::{mpsc, watch};
+use tracing::warn;
 
 use super::{App, Resources, ViewId, views::create_view};
 use crate::{
@@ -131,9 +132,14 @@ pub async fn run_flashblocks_json(config: ChainConfig) -> Result<()> {
     let (_, url_rx) = watch::channel(config.flashblocks_ws.to_string());
     tokio::spawn(run_flashblock_ws(url_rx, tx, toast_tx));
 
+    // JSON lines go to stdout only. Toast and other diagnostics use `tracing` (the `basectl`
+    // binary installs a stderr subscriber before calling this when `--json` is set).
     tokio::spawn(async move {
         while let Some(toast) = toast_rx.recv().await {
-            eprintln!("connection status: {}", toast.message);
+            warn!(
+                message = %toast.message,
+                "connection status",
+            );
         }
     });
 


### PR DESCRIPTION
- Install a stderr-only `tracing` subscriber when running `basectl flashblocks --json`, so structured diagnostics do not mix with JSON lines on stdout.
- Replace Toast `eprintln!` with `tracing::warn!` using structured fields (`message`), matching repository tracing conventions.
- Add `tracing` / `tracing-subscriber` dependencies to the `basectl` binary crate.
