### PR TITLE
chore(ci): fix nitro udeps false positives; add execution/client udeps recipes

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -224,6 +224,34 @@ check-udeps: build-contracts
     @command -v cargo-udeps >/dev/null 2>&1 || cargo install cargo-udeps
     {{_skip_kernels}} cargo +nightly udeps --locked --workspace --all-features --all-targets
 
+# Same flags as `check-udeps`, scoped to `crates/execution/*` workspace packages (library names).
+check-udeps-execution: build-contracts
+    #!/usr/bin/env bash
+    set -euo pipefail
+    command -v cargo-udeps >/dev/null 2>&1 || cargo install cargo-udeps
+    pkgs=(
+        base-engine-tree base-execution-chainspec base-execution-cli base-execution-consensus
+        base-execution-evm base-execution-exex base-execution-forks base-execution-payload-builder
+        base-execution-primitives base-execution-rpc base-execution-storage base-execution-trie
+        base-flashblocks base-node-core base-node-runner base-revm base-txpool-rpc
+    )
+    args=()
+    for p in "${pkgs[@]}"; do args+=(-p "$p"); done
+    {{_skip_kernels}} cargo +nightly udeps --locked --all-features --all-targets "${args[@]}"
+
+# Same flags as `check-udeps`, scoped to `crates/client/*` workspace packages (library names).
+check-udeps-client: build-contracts
+    #!/usr/bin/env bash
+    set -euo pipefail
+    command -v cargo-udeps >/dev/null 2>&1 || cargo install cargo-udeps
+    pkgs=(
+        base-bundle-extension base-client-cli base-flashblocks-node base-metering
+        base-proofs-extension base-tx-forwarding base-txpool-tracing
+    )
+    args=()
+    for p in "${pkgs[@]}"; do args+=(-p "$p"); done
+    {{_skip_kernels}} cargo +nightly udeps --locked --all-features --all-targets "${args[@]}"
+
 # Checks crate dependency boundary rules
 check-crate-deps:
     ./etc/scripts/ci/check-crate-deps.sh

--- a/bin/prover/nitro-enclave/Cargo.toml
+++ b/bin/prover/nitro-enclave/Cargo.toml
@@ -20,3 +20,6 @@ eyre.workspace = true
 base-proof-tee-nitro-enclave.workspace = true
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 
+[package.metadata.cargo-udeps.ignore]
+# Enclave binary: `cargo-udeps` depinfo can miss `main.rs` when the workspace is checked from non-Linux hosts.
+normal = ["base-proof-tee-nitro-enclave", "eyre", "tokio"]

--- a/crates/proof/tee/nitro-enclave/Cargo.toml
+++ b/crates/proof/tee/nitro-enclave/Cargo.toml
@@ -65,4 +65,6 @@ base-consensus-registry.workspace = true
 tokio = { workspace = true, features = ["macros", "rt"] }
 
 [package.metadata.cargo-udeps.ignore]
-normal = ["aws-nitro-enclaves-nsm-api"]
+# `aws-nitro-enclaves-nsm-api`: linked for NSM; depinfo can miss FFI.
+# `eyre`: used in `runtime` behind `cfg(target_os = "linux")`; depinfo on macOS/CI hosts misses it.
+normal = ["aws-nitro-enclaves-nsm-api", "eyre"]


### PR DESCRIPTION

https://github.com/base/base/issues/1766

This PR fixes `cargo-udeps` false positives for the Nitro enclave crates and adds `just` recipes to run the same `check-udeps` flags against `crates/execution/*` and `crates/client/*` package sets.

- **Workspace `check-udeps` was failing** on typical dev/CI hosts (e.g. macOS): `cargo-udeps` uses depinfo and does not see `eyre` used inside `runtime` when that code is behind `cfg(target_os = "linux")`, so it reported `eyre` as unused for `base-proof-tee-nitro-enclave`.
- The **enclave binary** `base-prover-nitro-enclave` was similarly flagged: dependencies used only from `main.rs` were not attributed, so `base-proof-tee-nitro-enclave`, `eyre`, and `tokio` looked unused even though they are required at runtime.
- **Directory-scoped checks** for `execution/*` and `client/*` were not available as explicit `just` targets; reviewers and contributors had to rely on the full workspace run only.
- **Restores a green `just check-udeps` / CI-equivalent path** without removing real dependencies.
- **Documents intent** in `Cargo.toml` via `package.metadata.cargo-udeps.ignore` and short comments, so future refactors know these are tool limitations, not dead code.
- **Faster, focused feedback**: `just check-udeps-execution` and `just check-udeps-client` reuse the same flags as `check-udeps` (`--locked`, `--all-features`, `--all-targets`, nightly `cargo-udeps`, `build-contracts`, macOS `RISC0_SKIP_BUILD_KERNELS` when applicable) but limit scope to those subtrees’ library packages.

- `crates/proof/tee/nitro-enclave/Cargo.toml` — extend `cargo-udeps` ignore for `eyre` 
- `bin/prover/nitro-enclave/Cargo.toml` — `cargo-udeps` ignore for binary false positives
- `Justfile` — `check-udeps-execution`, `check-udeps-client`.