### PR TITLE
docs: fix path to default rollup config in UPGRADES(checklist)

### DIFF
--- a/docs/guides/UPGRADES.md
+++ b/docs/guides/UPGRADES.md
@@ -390,7 +390,7 @@ forks.push((BaseUpgrade::V1.boxed(), self[BaseUpgrade::V1]));  // <-- add
 - [ ] `is_X_active_at_timestamp` added to `BaseUpgrades` trait
 - [ ] Timestamp constants added to `mainnet.rs`, `sepolia.rs`, `devnet_0_sepolia_dev_0.rs`; re-exported from `lib.rs`
 - [ ] Registry fixtures (`base_mainnet.rs`, `base_sepolia.rs`) updated
-- [ ] Default rollup config updated (`defaults.rs`)
+- [ ] Default rollup config updated (`base_sepolia.rs`)
 - [ ] Upgrade consistency tests pass
 
 ### Required when EVM execution changes


### PR DESCRIPTION
## Description:
Step 7 of the guide in `docs/guides/UPGRADES.md` explicitly states that the default Rollup configuration in the file `crates/consensus/registry/src/test_utils/base_sepolia.rs` (the `default_rollup_config()` function for development scenarios) must be updated. However, the final checklist listed the file `defaults.rs`, which does not match the text of the guide or the actual file.

## Changes:
The checklist entry has been updated to point to the same file referenced in step 7, so the checklist and step-by-step instructions now refer to the same artifact.