### PR TITLE
fix(tx-manager): skip fee bump when original tx already mined

### DIFF
--- a/crates/utilities/tx-manager/src/manager.rs
+++ b/crates/utilities/tx-manager/src/manager.rs
@@ -1160,6 +1160,16 @@ impl SimpleTxManager {
         receipt_tx: &mpsc::Sender<TransactionReceipt>,
         state: &mut BumpState,
     ) -> Option<TxManagerError> {
+        // If the receipt-polling task has already detected the original tx
+        // on-chain, skip the fee bump entirely. This avoids a race where
+        // `estimate_gas` on the replacement tx reverts because the
+        // original calldata has already executed (e.g. `GameAlreadyExists`),
+        // producing noisy error logs even though the proposal will succeed.
+        if send_state.is_waiting_for_confirmation() {
+            info!("skipping fee bump — original tx already mined, awaiting confirmation");
+            return None;
+        }
+
         let result = self.handle_fee_bump(candidate, send_state, receipt_tx, state).await;
         Self::apply_bump_result_with_suppression(result, state, send_state)
     }


### PR DESCRIPTION
## Summary

- Skip fee bump attempts when the receipt-polling task has already detected the original tx on-chain, eliminating a race condition that produced noisy error logs on every proposal cycle.

## Problem

The TxManager runs two concurrent tasks after publishing a transaction:
1. **Receipt poller** — watches L1 for the tx to be mined and confirmed
2. **Fee bump timer** — periodically resubmits with higher gas price

When the original tx lands on-chain before the fee bump timer fires but before the receipt poller confirms it to required depth, the fee bump re-estimates gas against calldata that already executed. For the proposer, this means `estimate_gas` simulates `createWithInitData()` on a game that already exists, causing a `GameAlreadyExists` revert. This produces `error!("gas estimation reverted")` and `error!("non-retryable error during fee bump")` on every single proposal cycle — even though all proposals succeed.

## Fix

Check `is_waiting_for_confirmation()` at the top of `try_fee_bump()`. If the original tx is already mined, skip the fee bump entirely. The existing `apply_bump_result_with_suppression` remains as a safety net for transactions that get mined *during* the bump attempt.

## Evidence

Datadog logs for release `2026-03-29T11-07-56.484Z-f3f4b90` show this pattern repeating on every proposal cycle (~5 min intervals):

```
1. tx published
2. [~20s] fee bump timer fires
3. gas price increase computed → OK
4. gas estimation reverted → ERROR (GameAlreadyExists)
5. non-retryable error during fee bump → ERROR
6. Receipt poller confirms original tx → success
```

Closes #1772