### PR TITLE
fix(builder): use u64 for reverted_gas_used to prevent integer truncation

### DIFF
--- a/crates/builder/core/src/flashblocks/context.rs
+++ b/crates/builder/core/src/flashblocks/context.rs
@@ -593,7 +593,7 @@ impl OpPayloadBuilderCtx {
         let mut num_txs_simulated = 0;
         let mut num_txs_simulated_success = 0;
         let mut num_txs_simulated_fail = 0;
-        let mut reverted_gas_used = 0;
+        let mut reverted_gas_used: u64 = 0;
         let base_fee = self.base_fee();
         let mut diag = FlashblockDiagnostics::default();
 
@@ -823,7 +823,7 @@ impl OpPayloadBuilderCtx {
             } else {
                 log_txn(Ok(TxnOutcome::Reverted));
                 num_txs_simulated_fail += 1;
-                reverted_gas_used += gas_used as i32;
+                reverted_gas_used += gas_used;
                 BuilderMetrics::reverted_tx_gas_used().record(gas_used as f64);
             }
 


### PR DESCRIPTION
The reverted_gas_used accumulator was implicitly typed as i32 and used `gas_used as i32` for each reverted transaction. Since gas_used is u64, this truncated values above i32::MAX and introduced a signed type for inherently unsigned data. 

Using u64 directly and dropping the unnecessary cast.