### PR TITLE
fix(builder): gate testcontainers behind test-utils feature

### DIFF
--- a/crates/builder/core/Cargo.toml
+++ b/crates/builder/core/Cargo.toml
@@ -56,6 +56,7 @@ test-utils = [
 	"reth-transaction-pool/test-utils",
 	"reth-trie/test-utils",
 	"rlimit",
+	"testcontainers",
 ]
 
 [dependencies]
@@ -190,7 +191,7 @@ serde_with.workspace = true
 parking_lot.workspace = true
 derive_more.workspace = true
 shellexpand.workspace = true
-testcontainers.workspace = true
+testcontainers = { workspace = true, optional = true }
 tar = { workspace = true, optional = true }
 ctor = { workspace = true, optional = true }
 hyper = { workspace = true, optional = true }


### PR DESCRIPTION
testcontainers was listed as an unconditional dependency despite only being used in test_utils/external.rs (behind #[cfg(any(test, feature = "test-utils"))]). 

This will make it optional and activate it via the test-utils feature to avoid pulling Docker/bollard deps into production builds.

Removes about ~60 unique crates (7.3%) from prod dep tree