### PR TITLE
docs(builder): remove #![allow(missing_docs)] and add doc comments

### DIFF
--- a/crates/builder/core/src/execution.rs
+++ b/crates/builder/core/src/execution.rs
@@ -73,14 +73,18 @@ pub struct TxResources {
 /// These can operate in dry-run or enforcement mode via the execution metering mode setting.
 #[derive(Debug, Error, Clone)]
 pub enum ExecutionMeteringLimitExceeded {
+    /// A single transaction's predicted execution time exceeded its per-tx limit.
     #[error("transaction execution time exceeded: tx_time_us={0} limit_us={1}")]
     TransactionExecutionTime(u128, u128),
+    /// Cumulative flashblock execution time would exceed the per-flashblock limit.
     #[error(
         "flashblock execution time exceeded: flashblock_used_us={0} tx_time_us={1} limit_us={2}"
     )]
     FlashblockExecutionTime(u128, u128, u128),
+    /// A single transaction's predicted state root time exceeded its per-tx limit.
     #[error("transaction state root time exceeded: tx_time_us={0} limit_us={1}")]
     TransactionStateRootTime(u128, u128),
+    /// Cumulative state root time would exceed the per-block limit.
     #[error("block state root time exceeded: cumulative_us={0} tx_time_us={1} block_limit_us={2}")]
     BlockStateRootTime(u128, u128, u128),
 }
@@ -190,6 +194,7 @@ pub enum TxnOutcome {
     RevertedAndExcluded,
 }
 
+/// Accumulated execution state for the current block being built.
 #[derive(Default, Debug)]
 pub struct ExecutionInfo {
     /// All executed transactions (unrecovered).

--- a/crates/builder/core/src/flashblocks/best_txs.rs
+++ b/crates/builder/core/src/flashblocks/best_txs.rs
@@ -37,6 +37,7 @@ where
     T: PoolTransaction,
     I: Iterator<Item = Arc<ValidPoolTransaction<T>>>,
 {
+    /// Creates a new [`BestFlashblocksTxs`] wrapping the given payload transaction iterator.
     pub fn new(inner: reth_payload_util::BestPayloadTransactions<T, I>) -> Self {
         Self { inner, committed_transactions: Default::default() }
     }

--- a/crates/builder/core/src/flashblocks/context.rs
+++ b/crates/builder/core/src/flashblocks/context.rs
@@ -95,6 +95,7 @@ impl FlashblockSelectionOutcome {
     }
 }
 
+/// Per-flashblock diagnostics summarizing transaction selection outcomes.
 #[derive(Debug, Default)]
 pub struct FlashblockDiagnostics {
     /// Whether the flashblock timer or block cancel fired during execution.

--- a/crates/builder/core/src/flashblocks/generator.rs
+++ b/crates/builder/core/src/flashblocks/generator.rs
@@ -303,6 +303,7 @@ where
     Builder::Attributes: Unpin + Clone,
     Builder::BuiltPayload: Unpin + Clone,
 {
+    /// Spawns a blocking task that builds the next payload using the current configuration.
     pub fn spawn_build_job(&mut self) {
         let builder = self.builder.clone();
         let payload_config = self.config.clone();
@@ -372,6 +373,7 @@ impl<T> std::fmt::Debug for ResolvePayload<T> {
 }
 
 impl<T> ResolvePayload<T> {
+    /// Creates a new [`ResolvePayload`] from the given [`WaitForValue`] future.
     pub const fn new(future: WaitForValue<T>) -> Self {
         Self { future }
     }
@@ -398,16 +400,19 @@ pub struct BlockCell<T> {
 }
 
 impl<T: Clone> BlockCell<T> {
+    /// Creates an empty [`BlockCell`].
     pub fn new() -> Self {
         Self { inner: Arc::new(Mutex::new(None)), notify: Arc::new(Notify::new()) }
     }
 
+    /// Stores `value` in the cell, overwriting any previous value, and wakes one waiter.
     pub fn set(&self, value: T) {
         let mut inner = self.inner.lock();
         *inner = Some(value);
         self.notify.notify_one();
     }
 
+    /// Returns a clone of the stored value, or `None` if the cell is empty.
     pub fn get(&self) -> Option<T> {
         let inner = self.inner.lock();
         inner.clone()

--- a/crates/builder/core/src/lib.rs
+++ b/crates/builder/core/src/lib.rs
@@ -1,4 +1,3 @@
-#![allow(missing_docs)]
 #![doc = include_str!("../README.md")]
 #![doc(
     html_logo_url = "https://avatars.githubusercontent.com/u/16627100?s=200&v=4",

--- a/crates/builder/core/src/lib.rs
+++ b/crates/builder/core/src/lib.rs
@@ -39,5 +39,6 @@ pub use flashblocks::{
 mod extension;
 pub use extension::BuilderApiExtension;
 
+/// Shared test infrastructure: local node instances, chain drivers, transaction builders, and pool observers.
 #[cfg(any(test, feature = "test-utils"))]
 pub mod test_utils;

--- a/crates/builder/core/src/metrics.rs
+++ b/crates/builder/core/src/metrics.rs
@@ -1,3 +1,5 @@
+//! Builder metrics collected during block and flashblock construction.
+
 use crate::{ExecutionInfo, FlashblockDiagnostics, ResourceLimits};
 
 const PRIORITY_FEE_THRESHOLDS_WEI: [(&str, u64); 3] =

--- a/crates/builder/core/src/test_utils/apis.rs
+++ b/crates/builder/core/src/test_utils/apis.rs
@@ -18,19 +18,25 @@ use tracing::{debug, info};
 
 use super::DEFAULT_JWT_TOKEN;
 
+/// RPC transport address for connecting to an execution client.
 #[derive(Clone, Debug)]
 pub enum Address {
+    /// Unix IPC socket path.
     Ipc(String),
+    /// HTTP(S) URL endpoint.
     Http(url::Url),
 }
 
+/// Abstraction over RPC transport protocols (IPC, HTTP) for Engine API clients.
 pub trait Protocol {
+    /// Creates a new JSON-RPC client connected via this protocol.
     fn client(
         jwt: JwtSecret,
         address: Address,
     ) -> impl Future<Output = impl SubscriptionClientT + Send + Sync + Unpin + 'static>;
 }
 
+/// HTTP transport protocol marker.
 #[derive(Debug)]
 pub struct Http;
 impl Protocol for Http {
@@ -51,6 +57,7 @@ impl Protocol for Http {
     }
 }
 
+/// IPC transport protocol marker.
 #[derive(Debug)]
 pub struct Ipc;
 impl Protocol for Ipc {
@@ -84,6 +91,7 @@ impl<P: Protocol> EngineApi<P> {
 
 // http specific
 impl EngineApi<Http> {
+    /// Creates an HTTP [`EngineApi`] client from a URL string.
     pub fn with_http(url: &str) -> Self {
         Self {
             address: Address::Http(url.parse().expect("Invalid URL")),
@@ -92,6 +100,7 @@ impl EngineApi<Http> {
         }
     }
 
+    /// Creates an HTTP [`EngineApi`] client targeting `localhost` on the given port.
     pub fn with_localhost_port(port: u16) -> Self {
         Self {
             address: Address::Http(
@@ -102,6 +111,7 @@ impl EngineApi<Http> {
         }
     }
 
+    /// Overrides the port on this client's URL.
     pub fn with_port(mut self, port: u16) -> Self {
         let Address::Http(url) = &mut self.address else {
             unreachable!();
@@ -111,11 +121,13 @@ impl EngineApi<Http> {
         self
     }
 
+    /// Overrides the JWT secret used for authentication.
     pub fn with_jwt_secret(mut self, jwt_secret: &str) -> Self {
         self.jwt_secret = jwt_secret.parse().expect("Invalid JWT");
         self
     }
 
+    /// Returns a reference to the underlying HTTP URL.
     pub fn url(&self) -> &url::Url {
         let Address::Http(url) = &self.address else {
             unreachable!();
@@ -126,6 +138,7 @@ impl EngineApi<Http> {
 
 // ipc specific
 impl EngineApi<Ipc> {
+    /// Creates an IPC [`EngineApi`] client from a socket path.
     pub fn with_ipc(path: &str) -> Self {
         Self {
             address: Address::Ipc(path.into()),
@@ -134,6 +147,7 @@ impl EngineApi<Ipc> {
         }
     }
 
+    /// Returns the IPC socket path.
     pub fn path(&self) -> &str {
         let Address::Ipc(path) = &self.address else {
             unreachable!();
@@ -143,6 +157,7 @@ impl EngineApi<Ipc> {
 }
 
 impl<P: Protocol> EngineApi<P> {
+    /// Fetches an execution payload by its identifier.
     pub async fn get_payload(
         &self,
         payload_id: PayloadId,
@@ -152,6 +167,7 @@ impl<P: Protocol> EngineApi<P> {
             .await?)
     }
 
+    /// Submits a new execution payload for validation.
     pub async fn new_payload(
         &self,
         payload: OpExecutionPayloadV4,
@@ -170,6 +186,7 @@ impl<P: Protocol> EngineApi<P> {
         .await?)
     }
 
+    /// Sends a forkchoice update, optionally triggering a new payload build.
     pub async fn update_forkchoice(
         &self,
         current_head: B256,
@@ -190,8 +207,10 @@ impl<P: Protocol> EngineApi<P> {
     }
 }
 
+/// JSON-RPC interface for block queries used in tests.
 #[rpc(server, client, namespace = "eth")]
 pub trait BlockApi {
+    /// Returns a block by number or tag, optionally including full transactions.
     #[method(name = "getBlockByNumber")]
     async fn get_block_by_number(
         &self,
@@ -200,6 +219,7 @@ pub trait BlockApi {
     ) -> RpcResult<Option<alloy_rpc_types_eth::Block>>;
 }
 
+/// Generates a genesis JSON file from the embedded template, stamped with the current time.
 pub fn generate_genesis(output: Option<String>) -> eyre::Result<()> {
     // Read the template file
     let template = include_str!("artifacts/genesis.json.tmpl");

--- a/crates/builder/core/src/test_utils/contracts.rs
+++ b/crates/builder/core/src/test_utils/contracts.rs
@@ -1,3 +1,4 @@
+/// Solidity ABI bindings for the [`FlashblocksNumber`](https://github.com/Uniswap/flashblocks_number_contract) contract used in integration tests.
 pub mod flashblocks_number_contract {
     use alloy_sol_types::sol;
     sol!(

--- a/crates/builder/core/src/test_utils/driver.rs
+++ b/crates/builder/core/src/test_utils/driver.rs
@@ -89,6 +89,7 @@ impl<RpcProtocol: Protocol> ChainDriver<RpcProtocol> {
 
 // public test api
 impl<RpcProtocol: Protocol> ChainDriver<RpcProtocol> {
+    /// Builds a new block using only sequencer-injected transactions, skipping the mempool.
     pub async fn build_new_block_with_no_tx_pool(&self) -> eyre::Result<Block<Transaction>> {
         self.build_new_block_with_txs_timestamp(vec![], Some(true), None, None, Some(0)).await
     }

--- a/crates/builder/core/src/test_utils/instance.rs
+++ b/crates/builder/core/src/test_utils/instance.rs
@@ -82,7 +82,9 @@ impl<P: core::fmt::Debug> core::fmt::Debug for PoolHandle<P> {
 }
 
 #[async_trait]
+/// Trait for submitting transactions to the pool from outside the node.
 pub trait ExternalTransactionPool: Send + Sync + core::fmt::Debug {
+    /// Submits a pooled transaction as if it arrived from an external peer.
     async fn add_external_transaction(&self, tx: BasePooledTransaction) -> eyre::Result<()>;
 }
 
@@ -196,14 +198,17 @@ impl LocalInstance {
         Self::new(BuilderConfig::for_tests()).await
     }
 
+    /// Returns the Reth node configuration.
     pub const fn node_config(&self) -> &NodeConfig<OpChainSpec> {
         &self.node_config
     }
 
+    /// Returns the builder configuration.
     pub const fn builder_config(&self) -> &BuilderConfig {
         &self.builder_config
     }
 
+    /// Returns the WebSocket URL for the flashblocks publisher.
     pub fn flashblocks_ws_url(&self) -> String {
         let ipaddr = self.builder_config.flashblocks_ws_addr.ip();
         let ipaddr = if ipaddr.is_unspecified() {
@@ -215,38 +220,47 @@ impl LocalInstance {
         format!("ws://{ipaddr}:{port}/")
     }
 
+    /// Spawns a background task that listens for flashblock payloads over WebSocket.
     pub fn spawn_flashblocks_listener(&self) -> FlashblocksListener {
         FlashblocksListener::new(self.flashblocks_ws_url())
     }
 
+    /// Returns the IPC socket path for the regular JSON-RPC server.
     pub fn rpc_ipc(&self) -> &str {
         &self.node_config.rpc.ipcpath
     }
 
+    /// Returns the IPC socket path for the authenticated Engine API server.
     pub fn auth_ipc(&self) -> &str {
         &self.node_config.rpc.auth_ipc_path
     }
 
+    /// Creates an IPC-based [`EngineApi`] client for this instance.
     pub fn engine_api(&self) -> EngineApi<Ipc> {
         EngineApi::<Ipc>::with_ipc(self.auth_ipc())
     }
 
+    /// Returns a reference to the transaction pool observer.
     pub const fn pool(&self) -> &TransactionPoolObserver {
         &self.pool_observer
     }
 
+    /// Returns a cloned handle for submitting external transactions to the pool.
     pub fn pool_handle(&self) -> Arc<dyn ExternalTransactionPool> {
         Arc::clone(&self.pool_handle)
     }
 
+    /// Returns a reference to the shared metering provider.
     pub fn metering_provider(&self) -> &SharedMeteringProvider {
         &self.metering_provider
     }
 
+    /// Creates a [`ChainDriver`] connected to this local instance.
     pub async fn driver(&self) -> eyre::Result<ChainDriver<Ipc>> {
         ChainDriver::<Ipc>::local(self).await
     }
 
+    /// Creates an alloy provider connected to this instance over IPC.
     pub async fn provider(&self) -> eyre::Result<RootProvider<Base>> {
         ProviderBuilder::<Identity, Identity, Base>::default()
             .connect_ipc(self.rpc_ipc().to_string().into())
@@ -277,6 +291,7 @@ impl Future for LocalInstance {
     }
 }
 
+/// Returns the default Reth node configuration used in tests.
 pub fn default_node_config() -> NodeConfig<OpChainSpec> {
     node_config_with_chain_spec(chain_spec())
 }
@@ -360,8 +375,11 @@ fn pool_component() -> OpPoolBuilder<BasePooledTransaction> {
 /// during test execution, eliminating the need for duplicate WebSocket listening code.
 #[derive(Debug)]
 pub struct FlashblocksListener {
+    /// All flashblock payloads received so far.
     pub flashblocks: Arc<Mutex<Vec<FlashblocksPayloadV1>>>,
+    /// Token used to signal the listener task to stop.
     pub cancellation_token: CancellationToken,
+    /// Handle to the spawned listener task.
     pub handle: JoinHandle<eyre::Result<()>>,
 }
 

--- a/crates/builder/core/src/test_utils/instance.rs
+++ b/crates/builder/core/src/test_utils/instance.rs
@@ -81,8 +81,8 @@ impl<P: core::fmt::Debug> core::fmt::Debug for PoolHandle<P> {
     }
 }
 
-#[async_trait]
 /// Trait for submitting transactions to the pool from outside the node.
+#[async_trait]
 pub trait ExternalTransactionPool: Send + Sync + core::fmt::Debug {
     /// Submits a pooled transaction as if it arrived from an external peer.
     async fn add_external_transaction(&self, tx: BasePooledTransaction) -> eyre::Result<()>;

--- a/crates/builder/core/src/test_utils/mod.rs
+++ b/crates/builder/core/src/test_utils/mod.rs
@@ -1,3 +1,5 @@
+//! Test utilities for the Base block builder.
+
 mod apis;
 mod contracts;
 mod driver;
@@ -78,24 +80,29 @@ pub async fn setup_test_instance_with_node_config(
     LocalInstance::new_with_node_config(builder_config, node_config).await
 }
 
-// anvil default key[1]
+/// Hardcoded builder private key (anvil default key[1]).
 pub const BUILDER_PRIVATE_KEY: &str =
     "0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d";
-// anvil default key[0]
+/// Hardcoded funded account private key (anvil default key[0]).
 pub const FUNDED_PRIVATE_KEY: &str =
     "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80";
-// anvil default key[8]
+/// Hardcoded flashblocks contract deployer private key (anvil default key[8]).
 pub const FLASHBLOCKS_DEPLOY_KEY: &str =
     "0xdbda1821b80551c9d65939329250298aa3472ba22feea921c0cf5d620ea67b97";
 
+/// Default block gas limit used in tests.
 pub const DEFAULT_GAS_LIMIT: u64 = 10_000_000;
 
+/// Default EIP-1559 base fee denominator used in tests.
 pub const DEFAULT_DENOMINATOR: u32 = 50;
 
+/// Default EIP-1559 elasticity multiplier used in tests.
 pub const DEFAULT_ELASTICITY: u32 = 2;
+/// Default JWT secret token for authenticating Engine API requests in tests.
 pub const DEFAULT_JWT_TOKEN: &str =
     "688f5d737bad920bdfb2fc2f488d6b6209eebda1dae949a8de91398d932c517a";
 
+/// One ETH expressed in wei (10^18).
 pub const ONE_ETH: u128 = 1_000_000_000_000_000_000;
 
 /// This gets invoked before any tests, when the cargo test framework loads the test library.

--- a/crates/builder/core/src/test_utils/txs.rs
+++ b/crates/builder/core/src/test_utils/txs.rs
@@ -17,6 +17,7 @@ use tracing::debug;
 
 use super::{PrivateKeySigner, funded_signer, sign_op_tx};
 
+/// Builder for constructing and sending EIP-1559 transactions in tests.
 #[derive(Clone, Debug)]
 pub struct TransactionBuilder {
     provider: RootProvider<Base>,
@@ -27,6 +28,7 @@ pub struct TransactionBuilder {
 }
 
 impl TransactionBuilder {
+    /// Creates a new builder with default EIP-1559 parameters for the test chain (chain ID 901).
     pub fn new(provider: RootProvider<Base>) -> Self {
         Self {
             provider,
@@ -37,61 +39,74 @@ impl TransactionBuilder {
         }
     }
 
+    /// Sets the transaction recipient address.
     pub const fn with_to(mut self, to: Address) -> Self {
         self.tx.to = TxKind::Call(to);
         self
     }
 
+    /// Sets the transaction to a contract creation (no recipient).
     pub const fn with_create(mut self) -> Self {
         self.tx.to = TxKind::Create;
         self
     }
 
+    /// Sets the transfer value in wei.
     pub fn with_value(mut self, value: u128) -> Self {
         self.tx.value = U256::from(value);
         self
     }
 
+    /// Sets the private key used to sign the transaction.
     pub fn with_signer(mut self, signer: &PrivateKeySigner) -> Self {
         self.signer = Some(signer.clone());
         self
     }
 
+    /// Overrides the chain ID (default: 901).
     pub const fn with_chain_id(mut self, chain_id: u64) -> Self {
         self.tx.chain_id = chain_id;
         self
     }
 
+    /// Sets an explicit nonce instead of fetching it from the provider.
     pub const fn with_nonce(mut self, nonce: u64) -> Self {
         self.tx.nonce = nonce;
         self
     }
 
+    /// Sets the gas limit for the transaction.
     pub const fn with_gas_limit(mut self, gas_limit: u64) -> Self {
         self.tx.gas_limit = gas_limit;
         self
     }
 
+    /// Sets the EIP-1559 max fee per gas.
     pub const fn with_max_fee_per_gas(mut self, max_fee_per_gas: u128) -> Self {
         self.tx.max_fee_per_gas = max_fee_per_gas;
         self
     }
 
+    /// Sets the EIP-1559 max priority fee per gas (tip).
     pub const fn with_max_priority_fee_per_gas(mut self, max_priority_fee_per_gas: u128) -> Self {
         self.tx.max_priority_fee_per_gas = max_priority_fee_per_gas;
         self
     }
 
+    /// Sets the calldata input bytes.
     pub fn with_input(mut self, input: Bytes) -> Self {
         self.tx.input = input;
         self
     }
 
+    /// Sets calldata that immediately reverts (`PUSH1 0 PUSH1 0 REVERT`).
     pub fn with_revert(mut self) -> Self {
         self.tx.input = hex!("60006000fd").into();
         self
     }
 
+    /// Signs the transaction and returns it as a recovered envelope. Auto-fetches nonce and base
+    /// fee from the provider when not explicitly set.
     pub async fn build(mut self) -> Recovered<OpTxEnvelope> {
         let signer = self.signer.unwrap_or_else(funded_signer);
 
@@ -132,6 +147,7 @@ impl TransactionBuilder {
             .expect("Failed to sign transaction")
     }
 
+    /// Builds, signs, and broadcasts the transaction, returning a pending transaction handle.
     pub async fn send(self) -> eyre::Result<PendingTransactionBuilder<Base>> {
         let provider = self.provider.clone();
         let transaction = self.build().await;
@@ -143,6 +159,8 @@ impl TransactionBuilder {
 
 type ObservationsMap = DashMap<TxHash, VecDeque<TransactionEvent>>;
 
+/// Monitors transaction pool events in the background, recording per-transaction lifecycle
+/// history.
 #[derive(Debug)]
 pub struct TransactionPoolObserver {
     /// Stores a mapping of all observed transactions to their history of events.
@@ -163,6 +181,7 @@ impl Drop for TransactionPoolObserver {
 }
 
 impl TransactionPoolObserver {
+    /// Spawns a background listener that records all pool events from the given stream.
     pub fn new(stream: AllTransactionsEvents<BasePooledTransaction>) -> Self {
         let mut stream = stream;
         let observations = Arc::new(ObservationsMap::new());
@@ -216,34 +235,42 @@ impl TransactionPoolObserver {
         Self { observations, term: Some(term) }
     }
 
+    /// Returns the most recent pool event for the given transaction hash.
     pub fn tx_status(&self, txhash: TxHash) -> Option<TransactionEvent> {
         self.observations.get(&txhash).and_then(|history| history.back().cloned())
     }
 
+    /// Returns `true` if the transaction is currently in the pending sub-pool.
     pub fn is_pending(&self, txhash: TxHash) -> bool {
         matches!(self.tx_status(txhash), Some(TransactionEvent::Pending))
     }
 
+    /// Returns `true` if the transaction is currently queued.
     pub fn is_queued(&self, txhash: TxHash) -> bool {
         matches!(self.tx_status(txhash), Some(TransactionEvent::Queued))
     }
 
+    /// Returns `true` if the transaction has been discarded from the pool.
     pub fn is_dropped(&self, txhash: TxHash) -> bool {
         matches!(self.tx_status(txhash), Some(TransactionEvent::Discarded))
     }
 
+    /// Counts how many observed transactions currently have the given status.
     pub fn count(&self, status: TransactionEvent) -> usize {
         self.observations.iter().filter(|tx| tx.value().back() == Some(&status)).count()
     }
 
+    /// Returns the number of transactions in the pending state.
     pub fn pending_count(&self) -> usize {
         self.count(TransactionEvent::Pending)
     }
 
+    /// Returns the number of transactions in the queued state.
     pub fn queued_count(&self) -> usize {
         self.count(TransactionEvent::Queued)
     }
 
+    /// Returns the number of discarded transactions.
     pub fn dropped_count(&self) -> usize {
         self.count(TransactionEvent::Discarded)
     }
@@ -253,10 +280,12 @@ impl TransactionPoolObserver {
         self.observations.get(&txhash).map(|history| history.iter().cloned().collect())
     }
 
+    /// Logs all observed transaction pool events at debug level.
     pub fn print_all(&self) {
         debug!(observations = ?self.observations, "TxPool");
     }
 
+    /// Returns `true` if the transaction is either pending or queued in the pool.
     pub fn exists(&self, txhash: TxHash) -> bool {
         matches!(
             self.tx_status(txhash),

--- a/crates/builder/core/src/test_utils/utils.rs
+++ b/crates/builder/core/src/test_utils/utils.rs
@@ -21,13 +21,20 @@ use super::{
     sign_op_tx,
 };
 
+/// Extension methods on [`TransactionBuilder`] for common test transaction patterns.
 pub trait TransactionBuilderExt {
+    /// Configures a simple ETH transfer to a random address.
     fn random_valid_transfer(self) -> Self;
+    /// Configures a contract creation whose bytecode immediately reverts.
     fn random_reverting_transaction(self) -> Self;
+    /// Configures a contract creation that consumes approximately 86 220 gas.
     fn random_big_transaction(self) -> Self;
     // flashblocks number methods
+    /// Configures deployment of the `FlashblocksNumber` contract.
     fn deploy_flashblock_number_contract(self) -> Self;
+    /// Configures an `initialize` call on the `FlashblocksNumber` contract.
     fn init_flashblock_number_contract(self, register_builder: bool) -> Self;
+    /// Configures an `addBuilder` call to authorize a builder address.
     fn add_authorized_builder(self, builder: Address) -> Self;
 }
 
@@ -79,15 +86,19 @@ impl TransactionBuilderExt for TransactionBuilder {
     }
 }
 
+/// Extension methods on [`ChainDriver`] for common funding and block-building patterns.
 pub trait ChainDriverExt {
+    /// Funds multiple addresses by minting via deposit transactions in a single block.
     fn fund_many(
         &self,
         addresses: Vec<Address>,
         amount: u128,
     ) -> impl Future<Output = eyre::Result<BlockHash>>;
+    /// Funds a single address by minting via a deposit transaction.
     fn fund(&self, address: Address, amount: u128)
     -> impl Future<Output = eyre::Result<BlockHash>>;
 
+    /// Creates `count` random signers, funds each with `amount` wei, and returns them.
     fn fund_accounts(
         &self,
         count: usize,
@@ -100,10 +111,12 @@ pub trait ChainDriverExt {
         }
     }
 
+    /// Sends a random valid transfer and builds a new block containing it.
     fn build_new_block_with_valid_transaction(
         &self,
     ) -> impl Future<Output = eyre::Result<(TxHash, Block<Transaction>)>>;
 
+    /// Sends a reverting transaction and builds a new block containing it.
     fn build_new_block_with_reverting_transaction(
         &self,
     ) -> impl Future<Output = eyre::Result<(TxHash, Block<Transaction>)>>;
@@ -168,7 +181,9 @@ impl<P: Protocol> ChainDriverExt for ChainDriver<P> {
     }
 }
 
+/// Convenience methods for checking transaction inclusion in blocks.
 pub trait BlockTransactionsExt {
+    /// Returns `true` if the block contains all of the given transaction hashes.
     fn includes(&self, txs: &impl AsTxs) -> bool;
 }
 
@@ -185,7 +200,9 @@ impl BlockTransactionsExt for BlockTransactionHashes<'_, Transaction> {
     }
 }
 
+/// Conversion to a list of transaction hashes for inclusion checks.
 pub trait AsTxs {
+    /// Returns the value as a `Vec<TxHash>`.
     fn as_txs(&self) -> Vec<TxHash>;
 }
 
@@ -201,6 +218,7 @@ impl AsTxs for Vec<TxHash> {
     }
 }
 
+/// Creates a temporary MDBX database suitable for tests.
 pub fn create_test_db(config: NodeConfig<OpChainSpec>) -> Arc<TempDatabase<DatabaseEnv>> {
     let path = reth_node_core::dirs::MaybePlatformPath::<DataDirPath>::from(
         reth_db::test_utils::tempdir_path(),
@@ -231,14 +249,17 @@ pub fn get_available_port() -> u16 {
         .port()
 }
 
+/// Returns the [`PrivateKeySigner`] for the default builder account.
 pub fn builder_signer() -> PrivateKeySigner {
     BUILDER_PRIVATE_KEY.parse().expect("invalid hardcoded builder private key")
 }
 
+/// Returns the [`PrivateKeySigner`] for the default pre-funded account.
 pub fn funded_signer() -> PrivateKeySigner {
     FUNDED_PRIVATE_KEY.parse().expect("invalid hardcoded funded private key")
 }
 
+/// Returns the [`PrivateKeySigner`] for the flashblocks contract deployer account.
 pub fn flashblocks_number_signer() -> PrivateKeySigner {
     FLASHBLOCKS_DEPLOY_KEY
         .parse()

--- a/crates/builder/core/src/traits.rs
+++ b/crates/builder/core/src/traits.rs
@@ -10,6 +10,7 @@ use reth_payload_util::PayloadTransactions;
 use reth_provider::{BlockReaderIdExt, ChainSpecProvider, StateProviderFactory};
 use reth_transaction_pool::{TransactionPool, TransactionPoolExt};
 
+/// Composite trait bound for a full node type compatible with the Base builder.
 pub trait NodeBounds:
     FullNodeTypes<
     Types: NodeTypes<Payload = OpEngineTypes, ChainSpec = OpChainSpec, Primitives = OpPrimitives>,
@@ -28,6 +29,7 @@ impl<T> NodeBounds for T where
 {
 }
 
+/// Composite trait bound for a transaction pool compatible with the Base builder.
 pub trait PoolBounds:
     TransactionPool<Transaction: OpPooledTx<Consensus = OpTransactionSigned> + BundleTransaction>
     + TransactionPoolExt
@@ -49,6 +51,7 @@ where
 {
 }
 
+/// Composite trait bound for state provider clients used by the Base builder.
 pub trait ClientBounds:
     StateProviderFactory
     + ChainSpecProvider<ChainSpec = OpChainSpec>
@@ -65,6 +68,7 @@ impl<T> ClientBounds for T where
 {
 }
 
+/// Composite trait bound for payload transaction iterators used by the Base builder.
 pub trait PayloadTxsBounds:
     PayloadTransactions<Transaction: OpPooledTx<Consensus = OpTransactionSigned> + BundleTransaction>
 {


### PR DESCRIPTION
Remove the blanket allow-lint and add targeted doc comments to all public items that were previously relying on it: trait bounds in traits.rs, `ExecutionInfo`, `FlashblockDiagnostics`, `ExecutionMeteringLimitExceeded` variants, `BlockCell` methods, `BestFlashblocksTxs::new`,
`BlockPayloadJob::spawn_build_job`, and `ResolvePayload::new`.

Also adds the required `//!` module doc to metrics.rs.