### PR TITLE
fix(builder): remove unused anyhow dep and move reth-testing-utils to dev-dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2916,7 +2916,6 @@ dependencies = [
  "alloy-sol-types",
  "alloy-transport",
  "alloy-transport-http",
- "anyhow",
  "async-trait",
  "base-access-lists",
  "base-alloy-chains",

--- a/crates/builder/core/Cargo.toml
+++ b/crates/builder/core/Cargo.toml
@@ -89,7 +89,6 @@ reth-chain-state.workspace = true
 reth-payload-util.workspace = true
 reth-node-builder.workspace = true
 reth-network-peers.workspace = true
-reth-testing-utils.workspace = true
 reth-tracing-otlp.workspace = true
 base-execution-evm.workspace = true
 reth-node-ethereum.workspace = true
@@ -183,7 +182,6 @@ eyre.workspace = true
 tower.workspace = true
 either.workspace = true
 chrono.workspace = true
-anyhow.workspace = true
 dashmap.workspace = true
 dirs-next.workspace = true
 secp256k1.workspace = true
@@ -214,6 +212,7 @@ base-builder-core = { path = ".", features = ["test-utils"] }
 
 # reth
 reth-ipc.workspace = true
+reth-testing-utils.workspace = true
 reth-node-builder = { workspace = true, features = ["test-utils"] }
 
 # metrics


### PR DESCRIPTION
## Summary

- Removes unused `anyhow` dependency from `base-builder-core` (zero usages in source, crate uses `eyre` exclusively)
- Moves `reth-testing-utils` from `[dependencies]` to `[dev-dependencies]` (only used in `#[cfg(test)]` in `generator.rs`)

## Motivation

`anyhow` adds redundant compile-time overhead — the crate (and 25 of 31 workspace crates) uses `eyre` for error handling. `reth-testing-utils` pulls test scaffolding (random block generators) into release builds unnecessarily.

## Changes

`Cargo.toml` only — no source code changes.