### PR TITLE
refactor(builder): remove dead BasicPayloadJobGeneratorConfig from generator

### DIFF
--- a/crates/builder/core/src/flashblocks/generator.rs
+++ b/crates/builder/core/src/flashblocks/generator.rs
@@ -7,9 +7,7 @@ use std::{
 use alloy_primitives::B256;
 use futures::{Future, FutureExt};
 use parking_lot::Mutex;
-use reth_basic_payload_builder::{
-    BasicPayloadJobGeneratorConfig, HeaderForPayload, PayloadConfig, PrecachedState,
-};
+use reth_basic_payload_builder::{HeaderForPayload, PayloadConfig, PrecachedState};
 use reth_node_api::{NodePrimitives, PayloadBuilderAttributes, PayloadKind};
 use reth_payload_builder::{
     KeepPayloadJobAlive, PayloadBuilderError, PayloadJob, PayloadJobGenerator,
@@ -35,8 +33,6 @@ pub struct BlockPayloadJobGenerator<Client, Tasks, Builder> {
     client: Client,
     /// How to spawn building tasks
     executor: Tasks,
-    /// The configuration for the job generator.
-    _config: BasicPayloadJobGeneratorConfig,
     /// The type responsible for building payloads.
     ///
     /// See [`PayloadBuilder`]
@@ -59,7 +55,6 @@ impl<Client, Tasks, Builder> BlockPayloadJobGenerator<Client, Tasks, Builder> {
     pub fn with_builder(
         client: Client,
         executor: Tasks,
-        config: BasicPayloadJobGeneratorConfig,
         builder: Builder,
         ensure_only_one_payload: bool,
         extra_block_deadline: std::time::Duration,
@@ -67,7 +62,6 @@ impl<Client, Tasks, Builder> BlockPayloadJobGenerator<Client, Tasks, Builder> {
         Self {
             client,
             executor,
-            _config: config,
             builder,
             ensure_only_one_payload,
             last_payload: Arc::new(Mutex::new(CancellationToken::new())),
@@ -728,7 +722,6 @@ mod tests {
 
         let client = MockEthProvider::default();
         let executor = TokioTaskExecutor::default();
-        let config = BasicPayloadJobGeneratorConfig::default();
         let builder = MockBuilder::<OpPrimitives>::new();
 
         let (start, count) = (1, 10);
@@ -743,7 +736,6 @@ mod tests {
         let generator = BlockPayloadJobGenerator::with_builder(
             client.clone(),
             executor,
-            config,
             builder.clone(),
             false,
             std::time::Duration::from_secs(1),

--- a/crates/builder/core/src/flashblocks/service.rs
+++ b/crates/builder/core/src/flashblocks/service.rs
@@ -7,7 +7,6 @@ use base_node_core::{
 };
 use base_node_runner::{BaseNode, OpNodeTypes, PayloadServiceBuilder as BasePayloadServiceBuilder};
 use derive_more::Debug;
-use reth_basic_payload_builder::BasicPayloadJobGeneratorConfig;
 use reth_node_api::NodeTypes;
 use reth_node_builder::{
     BuilderContext,
@@ -53,12 +52,9 @@ impl FlashblocksServiceBuilder {
             built_payload_tx,
             ws_pub,
         );
-        let payload_job_config = BasicPayloadJobGeneratorConfig::default();
-
         let payload_generator = BlockPayloadJobGenerator::with_builder(
             ctx.provider().clone(),
             ctx.task_executor().clone(),
-            payload_job_config,
             payload_builder,
             true,
             self.0.block_time_leeway,


### PR DESCRIPTION
## Summary

- Removes the unused `_config: BasicPayloadJobGeneratorConfig` field from `BlockPayloadJobGenerator`
- Removes the corresponding constructor parameter and the `default()` construction in `service.rs`

## Context

This field was copied from reth's `BasicPayloadJobGenerator` when the flashblocks generator was first created but was **never used**. The upstream config contains `extradata`, `max_gas_limit`, `deadline`, and `max_payload_tasks`, none of which apply to the flashblocks builder, which uses its own `BuilderConfig` for all timing, budgets, and resource limits.