### PR TITLE
chore(nitro-enclave): gate eyre on Linux for udeps on non-Linux  eyre is only referenced from runtime AP

### DIFF
--- a/crates/proof/tee/nitro-enclave/Cargo.toml
+++ b/crates/proof/tee/nitro-enclave/Cargo.toml
@@ -49,13 +49,13 @@ async-trait.workspace = true
 tokio = { workspace = true, features = ["rt", "time", "io-util"] }
 
 # misc
-eyre.workspace = true
 tracing.workspace = true
 rand_08.workspace = true
 thiserror.workspace = true
 parking_lot.workspace = true
 
 [target.'cfg(target_os = "linux")'.dependencies]
+eyre.workspace = true
 tokio-vsock.workspace = true
 tokio = { workspace = true, features = ["rt-multi-thread"] }
 


### PR DESCRIPTION
https://github.com/base/base/issues/1793

On non-Linux hosts, `cargo +nightly udeps -p base-proof-tee-nitro-enclave` (or workspace-wide udeps, e.g. via `just check-udeps`) reports **`eyre` as an unused normal dependency**.

`eyre` is only used in `src/runtime.rs`, and those APIs (e.g. `NitroEnclave::new` / `run`) live entirely under `#[cfg(target_os = "linux")]`. When the crate is built for a non-Linux target, that code is not part of depinfo, yet `eyre` remained listed unconditionally under `[dependencies]`. That disagrees with the cfg split and produces a **cargo-udeps false positive**.
