### PR TITLE
docs: fix incorrect dispute game reference

### DIFF
--- a/docs/specs/pages/protocol/fault-proof/stage-one/bridge-integration.md
+++ b/docs/specs/pages/protocol/fault-proof/stage-one/bridge-integration.md
@@ -172,8 +172,7 @@ the withdrawal was proven against.
 
 **Trusted `GameType`**
 The `DisputeGameFactory` can create many different types of dispute games, delineated by their `GameType`. The game
-type of the dispute game fetched from the factory's list at `_disputeGameIndex` must be of type `RESPECTED_GAME_TYPE`.
-The call should revert on all other game types it encounters.
+type of the dispute game referenced by the stored `ProvenWithdrawal` (the game the withdrawal was proven against) must be `RESPECTED_GAME_TYPE`.
 
 **Respected Game Type Updated**
 A withdrawal may never be finalized if the dispute game was created before the respected game type was last updated.


### PR DESCRIPTION
Fixed an incorrect formulation of the invariant for `finalizeWithdrawalTransaction`.

The previous description referred to obtaining the `dispute` game via `_disputeGameIndex`, which is incorrect, since finalization does not accept an index and does not call `DisputeGameFactory`.

Behavior updated:

It is now explicitly stated that `disputeGame`, stored in `ProvenWithdrawal` during the `proveWithdrawalTransaction` phase, is used. The logic has been aligned with the actual flow: `prove` - `store` - `finalize`

This makes the specification consistent with the contracts and the rest of the documentation.