### PR TITLE
fix(metrics): use struct-specific symbols for define_metrics ctor

### DIFF
--- a/crates/utilities/metrics/src/define_metrics.rs
+++ b/crates/utilities/metrics/src/define_metrics.rs
@@ -137,8 +137,11 @@ macro_rules! __define_metrics_impl {
 
         #[cfg(feature = "metrics")]
         const _: () = {
-            #[$crate::__private_ctor::ctor(anonymous, crate_path = $crate::__private_ctor)]
-            fn register_metrics_initializer() {
+            // Name the ctor after the metrics struct so each `define_metrics!` gets a distinct
+            // linker symbol (ctor `anonymous` would reuse the same name for every expansion).
+            #[allow(non_snake_case)]
+            #[$crate::__private_ctor::ctor(crate_path = $crate::__private_ctor)]
+            fn $name() {
                 $crate::register_initializer($name::init);
             }
         };


### PR DESCRIPTION
issues:https://github.com/base/base/issues/1798

## Summary

Adjust the ctor generated by `define_metrics!` under the `metrics` feature: stop using `anonymous`, and use a registration function named after the metrics struct so each expansion gets a distinct linker symbol.

## Motivation

`ctor(anonymous)` can make every expansion share the same symbol, risking linker conflicts or only some `init` callbacks being registered.

## What changed

- Use `ctor(crate_path = $crate::__private_ctor)` without `anonymous`.
- Name the registration function `fn $name()` (aligned with `pub struct $name`).
- Add `#[allow(non_snake_case)]` for PascalCase function names.

## Verification

- `cargo check -p base-builder-core`
- `cargo test -p base-metrics --features metrics`