### PR TITLE
test(derive): add EthereumDataSource DAP signal contract tests for L1Retrieval

### DIFF
--- a/crates/consensus/derive/src/stages/l1_retrieval.rs
+++ b/crates/consensus/derive/src/stages/l1_retrieval.rs
@@ -140,10 +140,14 @@ where
 mod tests {
     use alloc::vec;
 
-    use alloy_primitives::Bytes;
+    use alloy_primitives::{Address, Bytes};
+    use base_consensus_genesis::RollupConfig;
 
     use super::*;
-    use crate::test_utils::{TestDAP, TraversalTestHelper};
+    use crate::{
+        BlobData, BlobSource, CalldataSource, EthereumDataSource,
+        test_utils::{TestBlobProvider, TestChainProvider, TestDAP, TraversalTestHelper},
+    };
 
     #[tokio::test]
     async fn test_l1_retrieval_flush_channel() {
@@ -227,6 +231,92 @@ mod tests {
             ActivationSignal { system_config: Some(Default::default()), ..Default::default() }
                 .signal();
         test_l1_retrieval_clears_stale_data(activation_signal).await;
+    }
+
+    // --- `EthereumDataSource` contract (same invariant as base/base#1691; extends TestDAP cases) ---
+
+    fn poisoned_ethereum_dap_pre_ecotone() -> EthereumDataSource<TestChainProvider, TestBlobProvider>
+    {
+        let mut chain = TestChainProvider::default();
+        chain.insert_block_with_transactions(0, BlockInfo::default(), vec![]);
+
+        let mut calldata = CalldataSource::new(chain.clone(), Address::ZERO);
+        calldata.calldata.push_back(Bytes::from_static(b"stale-calldata"));
+        calldata.open = true;
+
+        let blob = BlobSource::new(chain, TestBlobProvider::default(), Address::ZERO);
+        EthereumDataSource::new(blob, calldata, &RollupConfig::default())
+    }
+
+    #[tokio::test]
+    async fn test_l1_retrieval_reset_clears_ethereum_dap_stale_calldata_via_next_data() {
+        let traversal = TraversalTestHelper::new_populated();
+        let dap = poisoned_ethereum_dap_pre_ecotone();
+        let mut retrieval = L1Retrieval::new(traversal, dap);
+        retrieval.next = Some(BlockInfo::default());
+
+        retrieval
+            .signal(
+                ResetSignal { system_config: Some(Default::default()), ..Default::default() }
+                    .signal(),
+            )
+            .await
+            .unwrap();
+
+        let err = retrieval.next_data().await.unwrap_err();
+        assert_eq!(err, PipelineError::Eof.temp());
+    }
+
+    #[tokio::test]
+    async fn test_l1_retrieval_activation_clears_ethereum_dap_stale_calldata_via_next_data() {
+        let traversal = TraversalTestHelper::new_populated();
+        let dap = poisoned_ethereum_dap_pre_ecotone();
+        let mut retrieval = L1Retrieval::new(traversal, dap);
+        retrieval.next = Some(BlockInfo::default());
+
+        retrieval
+            .signal(
+                ActivationSignal { system_config: Some(Default::default()), ..Default::default() }
+                    .signal(),
+            )
+            .await
+            .unwrap();
+
+        let err = retrieval.next_data().await.unwrap_err();
+        assert_eq!(err, PipelineError::Eof.temp());
+    }
+
+    #[tokio::test]
+    async fn test_l1_retrieval_reset_clears_ethereum_blob_and_calldata_subsources() {
+        let traversal = TraversalTestHelper::new_populated();
+        let mut chain = TestChainProvider::default();
+        chain.insert_block_with_transactions(0, BlockInfo::default(), vec![]);
+
+        let mut calldata = CalldataSource::new(chain.clone(), Address::ZERO);
+        calldata.calldata.push_back(Bytes::from_static(b"stale"));
+        calldata.open = true;
+
+        let mut blob = BlobSource::new(chain, TestBlobProvider::default(), Address::ZERO);
+        blob.data =
+            vec![BlobData { data: None, calldata: Some(Bytes::from_static(b"blob-stale")) }];
+        blob.open = true;
+
+        let dap = EthereumDataSource::new(blob, calldata, &RollupConfig::default());
+        let mut retrieval = L1Retrieval::new(traversal, dap);
+        retrieval.next = Some(BlockInfo::default());
+
+        retrieval
+            .signal(
+                ResetSignal { system_config: Some(Default::default()), ..Default::default() }
+                    .signal(),
+            )
+            .await
+            .unwrap();
+
+        assert!(retrieval.provider.calldata_source.calldata.is_empty());
+        assert!(!retrieval.provider.calldata_source.open);
+        assert!(retrieval.provider.blob_source.data.is_empty());
+        assert!(!retrieval.provider.blob_source.open);
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary
Extend `L1Retrieval` unit tests in `base-consensus-derive` with contract-style regressions for the production `EthereumDataSource` stack (`CalldataSource` + `BlobSource`). The tests assert that after the pipeline receives a **Reset** or **Activation** signal, the in-memory data-availability layer does not keep serving batch bytes that were buffered before the signal.
## 1. What changed
- **File**: `crates/consensus/derive/src/stages/l1_retrieval.rs`, inside the existing `#[cfg(test)] mod tests` module.
- **New helper**: Build a pre-Ecotone `EthereumDataSource` and poison the **calldata side** with a synthetic deque (`open = true` and non-empty `calldata`) to mimic partially consumed L1 batch buffering.
- **Three new tests**:
  1. After **Reset**, call `next_data()` with a chain fixture that serves an empty transaction list for the staged `BlockInfo`: expect **`PipelineError::Eof`**, not the injected calldata.
  2. After **Activation**, the same `next_data()` expectation (**`Eof`**) to match reset semantics on the real DAP type.
  3. After **Reset**, additionally assert both **`calldata_source` and `blob_source`** internal buffers are empty and their `open` flag is `false` when both sides are poisoned.
No production code paths were modified—tests and clarifying comments only.
## 2. Why it matters
- **Closes the gap between mocks and production**: `TestDAP` already guards the abstract “DAP clears on signal” property; exercising **`EthereumDataSource`** catches mistakes that only appear in concrete `clear()` delegation (e.g., clearing calldata but not blob state, or forgetting to reset `open` so stale buffers are reused).
- **Pins pipeline semantics**: `L1Retrieval` must discard cross-origin intermediate DA state on Reset/Activation via `provider.clear()`. These tests tie that contract to **observable outcomes** (`next_data` plus internal fields), making silent regressions during refactors less likely.
- **Faster diagnosis**: Failures point directly at “stale bytes after signal” or “sub-source not cleared,” which speeds review and debugging.

https://github.com/base/base/issues/1801