### PR TITLE
feat(flashblocks): add log-level filtering and gasUsed to newFlashblockTransactions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4043,6 +4043,7 @@ dependencies = [
  "revm-database",
  "rstest",
  "serde",
+ "serde_json",
  "thiserror 2.0.18",
  "tokio",
  "tokio-stream",

--- a/crates/execution/flashblocks/Cargo.toml
+++ b/crates/execution/flashblocks/Cargo.toml
@@ -85,6 +85,7 @@ derive_more = { workspace = true, features = ["from"] }
 [dev-dependencies]
 rstest.workspace = true
 alloy-eips.workspace = true
+serde_json.workspace = true
 base-execution-chainspec.workspace = true
 
 [features]

--- a/crates/execution/flashblocks/src/pending_blocks.rs
+++ b/crates/execution/flashblocks/src/pending_blocks.rs
@@ -429,12 +429,12 @@ impl PendingBlocks {
             .iter()
             .map(|tx| {
                 let tx_hash = tx.tx_hash();
-                let logs = self
+                let (logs, gas_used) = self
                     .transaction_receipts
                     .get(&tx_hash)
-                    .map(|receipt| receipt.inner.logs().to_vec())
+                    .map(|receipt| (receipt.inner.logs().to_vec(), Some(receipt.inner.gas_used)))
                     .unwrap_or_default();
-                TransactionWithLogs { transaction: tx.clone(), logs }
+                TransactionWithLogs { transaction: tx.clone(), logs, gas_used }
             })
             .collect()
     }
@@ -491,12 +491,45 @@ impl PendingBlocks {
             .skip(prev_count)
             .map(|tx| {
                 let tx_hash = tx.tx_hash();
-                let logs = self
+                let (logs, gas_used) = self
                     .transaction_receipts
                     .get(&tx_hash)
-                    .map(|receipt| receipt.inner.logs().to_vec())
+                    .map(|receipt| (receipt.inner.logs().to_vec(), Some(receipt.inner.gas_used)))
                     .unwrap_or_default();
-                TransactionWithLogs { transaction: tx.clone(), logs }
+                TransactionWithLogs { transaction: tx.clone(), logs, gas_used }
+            })
+            .collect()
+    }
+
+    /// Returns transactions with their associated logs from only the latest flashblock (delta),
+    /// filtered to include only transactions where at least one log matches the given filter.
+    ///
+    /// When a transaction matches, all of its logs are returned (not just the matching ones).
+    /// This preserves full transaction context for subscribers who need complete log sets.
+    pub fn get_latest_flashblock_transactions_with_logs_filtered(
+        &self,
+        filter: &Filter,
+    ) -> Vec<TransactionWithLogs> {
+        let prev_count = self.previous_flashblocks_tx_count();
+
+        self.transactions
+            .iter()
+            .skip(prev_count)
+            .filter_map(|tx| {
+                let tx_hash = tx.tx_hash();
+                let receipt = self.transaction_receipts.get(&tx_hash)?;
+                let logs = receipt.inner.logs();
+
+                let has_match = logs.iter().any(|log| filter.matches(&log.inner));
+                if !has_match {
+                    return None;
+                }
+
+                Some(TransactionWithLogs {
+                    transaction: tx.clone(),
+                    logs: logs.to_vec(),
+                    gas_used: Some(receipt.inner.gas_used),
+                })
             })
             .collect()
     }
@@ -844,6 +877,65 @@ mod tests {
         assert_eq!(result.inner.blob_gas_used, 0);
     }
 
+    fn test_receipt_with_log_and_topic(
+        tx_hash: B256,
+        log_address: Address,
+        topic0: B256,
+    ) -> OpTransactionReceipt {
+        let log = Log {
+            inner: PrimitiveLog {
+                address: log_address,
+                data: LogData::new_unchecked(vec![topic0], Bytes::new()),
+            },
+            block_hash: Some(B256::ZERO),
+            block_number: Some(1),
+            block_timestamp: None,
+            transaction_hash: Some(tx_hash),
+            transaction_index: Some(0),
+            log_index: Some(0),
+            removed: false,
+        };
+
+        OpTransactionReceipt {
+            inner: alloy_rpc_types_eth::TransactionReceipt {
+                inner: ReceiptWithBloom {
+                    receipt: OpReceipt::Legacy(Receipt {
+                        status: alloy_consensus::Eip658Value::Eip658(true),
+                        cumulative_gas_used: 21_000,
+                        logs: vec![log],
+                    }),
+                    logs_bloom: Bloom::default(),
+                },
+                transaction_hash: tx_hash,
+                transaction_index: Some(0),
+                block_hash: Some(B256::ZERO),
+                block_number: Some(1),
+                gas_used: 21_000,
+                effective_gas_price: 1_000_000_000,
+                blob_gas_used: None,
+                blob_gas_price: None,
+                from: Address::ZERO,
+                to: None,
+                contract_address: None,
+            },
+            l1_block_info: Default::default(),
+        }
+    }
+
+    fn build_pending_blocks_with_topics(entries: &[(B256, Address, B256)]) -> PendingBlocks {
+        let header = Sealed::new_unchecked(Header::default(), B256::ZERO);
+        let mut builder = PendingBlocksBuilder::new();
+        builder.with_flashblocks([test_flashblock()]);
+        builder.with_header(header);
+
+        for &(hash, addr, topic) in entries {
+            builder.with_transaction(test_transaction_with_hash(hash));
+            builder.with_receipt(hash, test_receipt_with_log_and_topic(hash, addr, topic));
+        }
+
+        builder.build().expect("build should succeed")
+    }
+
     #[test]
     fn get_pending_logs_returns_logs_in_transaction_order() {
         let hash_a = B256::with_last_byte(0xAA);
@@ -864,5 +956,164 @@ mod tests {
         assert_eq!(logs[0].address(), addr_a);
         assert_eq!(logs[1].address(), addr_b);
         assert_eq!(logs[2].address(), addr_c);
+    }
+
+    #[test]
+    fn filtered_transactions_returns_only_matching_by_address() {
+        let hash_a = B256::with_last_byte(0xAA);
+        let hash_b = B256::with_last_byte(0xBB);
+        let hash_c = B256::with_last_byte(0xCC);
+
+        let addr_a = Address::with_last_byte(0x0A);
+        let addr_b = Address::with_last_byte(0x0B);
+        let addr_c = Address::with_last_byte(0x0C);
+
+        let pending =
+            build_pending_blocks_with_logs(&[(hash_a, addr_a), (hash_b, addr_b), (hash_c, addr_c)]);
+
+        let filter = Filter::new().address(addr_b);
+        let txs = pending.get_latest_flashblock_transactions_with_logs_filtered(&filter);
+
+        assert_eq!(txs.len(), 1);
+        assert_eq!(txs[0].transaction.tx_hash(), hash_b);
+        assert_eq!(txs[0].logs.len(), 1);
+        assert_eq!(txs[0].logs[0].address(), addr_b);
+    }
+
+    #[test]
+    fn filtered_transactions_returns_only_matching_by_topic0() {
+        let hash_a = B256::with_last_byte(0xAA);
+        let hash_b = B256::with_last_byte(0xBB);
+
+        let addr = Address::with_last_byte(0x01);
+        let topic_transfer = B256::with_last_byte(0x01);
+        let topic_approval = B256::with_last_byte(0x02);
+
+        let pending = build_pending_blocks_with_topics(&[
+            (hash_a, addr, topic_transfer),
+            (hash_b, addr, topic_approval),
+        ]);
+
+        let filter = Filter::new().event_signature(topic_transfer);
+        let txs = pending.get_latest_flashblock_transactions_with_logs_filtered(&filter);
+
+        assert_eq!(txs.len(), 1);
+        assert_eq!(txs[0].transaction.tx_hash(), hash_a);
+    }
+
+    #[test]
+    fn filtered_transactions_returns_all_logs_when_any_matches() {
+        let hash_a = B256::with_last_byte(0xAA);
+        let addr_match = Address::with_last_byte(0x0A);
+        let addr_other = Address::with_last_byte(0x0B);
+
+        let log_match = Log {
+            inner: PrimitiveLog {
+                address: addr_match,
+                data: LogData::new_unchecked(vec![], Bytes::new()),
+            },
+            block_hash: Some(B256::ZERO),
+            block_number: Some(1),
+            block_timestamp: None,
+            transaction_hash: Some(hash_a),
+            transaction_index: Some(0),
+            log_index: Some(0),
+            removed: false,
+        };
+        let log_other = Log {
+            inner: PrimitiveLog {
+                address: addr_other,
+                data: LogData::new_unchecked(vec![], Bytes::new()),
+            },
+            block_hash: Some(B256::ZERO),
+            block_number: Some(1),
+            block_timestamp: None,
+            transaction_hash: Some(hash_a),
+            transaction_index: Some(0),
+            log_index: Some(1),
+            removed: false,
+        };
+
+        let receipt = OpTransactionReceipt {
+            inner: alloy_rpc_types_eth::TransactionReceipt {
+                inner: ReceiptWithBloom {
+                    receipt: OpReceipt::Legacy(Receipt {
+                        status: alloy_consensus::Eip658Value::Eip658(true),
+                        cumulative_gas_used: 42_000,
+                        logs: vec![log_match, log_other],
+                    }),
+                    logs_bloom: Bloom::default(),
+                },
+                transaction_hash: hash_a,
+                transaction_index: Some(0),
+                block_hash: Some(B256::ZERO),
+                block_number: Some(1),
+                gas_used: 42_000,
+                effective_gas_price: 1_000_000_000,
+                blob_gas_used: None,
+                blob_gas_price: None,
+                from: Address::ZERO,
+                to: None,
+                contract_address: None,
+            },
+            l1_block_info: Default::default(),
+        };
+
+        let header = Sealed::new_unchecked(Header::default(), B256::ZERO);
+        let mut builder = PendingBlocksBuilder::new();
+        builder.with_flashblocks([test_flashblock()]);
+        builder.with_header(header);
+        builder.with_transaction(test_transaction_with_hash(hash_a));
+        builder.with_receipt(hash_a, receipt);
+        let pending = builder.build().expect("build should succeed");
+
+        let filter = Filter::new().address(addr_match);
+        let txs = pending.get_latest_flashblock_transactions_with_logs_filtered(&filter);
+
+        assert_eq!(txs.len(), 1);
+        assert_eq!(txs[0].logs.len(), 2, "should return ALL logs, not just matching");
+        assert_eq!(txs[0].logs[0].address(), addr_match);
+        assert_eq!(txs[0].logs[1].address(), addr_other);
+    }
+
+    #[test]
+    fn filtered_transactions_returns_none_when_no_match() {
+        let hash_a = B256::with_last_byte(0xAA);
+        let addr_a = Address::with_last_byte(0x0A);
+        let addr_unrelated = Address::with_last_byte(0xFF);
+
+        let pending = build_pending_blocks_with_logs(&[(hash_a, addr_a)]);
+
+        let filter = Filter::new().address(addr_unrelated);
+        let txs = pending.get_latest_flashblock_transactions_with_logs_filtered(&filter);
+
+        assert!(txs.is_empty());
+    }
+
+    #[test]
+    fn filtered_transactions_populates_gas_used() {
+        let hash_a = B256::with_last_byte(0xAA);
+        let addr_a = Address::with_last_byte(0x0A);
+
+        let pending = build_pending_blocks_with_logs(&[(hash_a, addr_a)]);
+
+        let filter = Filter::new().address(addr_a);
+        let txs = pending.get_latest_flashblock_transactions_with_logs_filtered(&filter);
+
+        assert_eq!(txs.len(), 1);
+        assert_eq!(txs[0].gas_used, Some(21_000));
+    }
+
+    #[test]
+    fn unfiltered_transactions_populates_gas_used() {
+        let hash_a = B256::with_last_byte(0xAA);
+        let addr_a = Address::with_last_byte(0x0A);
+
+        let pending = build_pending_blocks_with_logs(&[(hash_a, addr_a)]);
+
+        let txs = pending.get_latest_flashblock_transactions_with_logs();
+
+        assert_eq!(txs.len(), 1);
+        assert_eq!(txs[0].gas_used, Some(21_000));
     }
 }

--- a/crates/execution/flashblocks/src/pending_blocks.rs
+++ b/crates/execution/flashblocks/src/pending_blocks.rs
@@ -1116,4 +1116,28 @@ mod tests {
         assert_eq!(txs.len(), 1);
         assert_eq!(txs[0].gas_used, Some(21_000));
     }
+
+    #[test]
+    fn filtered_transactions_with_combined_address_and_topic() {
+        let hash_a = B256::with_last_byte(0xAA);
+        let hash_b = B256::with_last_byte(0xBB);
+        let hash_c = B256::with_last_byte(0xCC);
+
+        let addr_usdc = Address::with_last_byte(0x0A);
+        let addr_weth = Address::with_last_byte(0x0B);
+        let topic_transfer = B256::with_last_byte(0x01);
+        let topic_approval = B256::with_last_byte(0x02);
+
+        let pending = build_pending_blocks_with_topics(&[
+            (hash_a, addr_usdc, topic_transfer),
+            (hash_b, addr_usdc, topic_approval),
+            (hash_c, addr_weth, topic_transfer),
+        ]);
+
+        let filter = Filter::new().address(addr_usdc).event_signature(topic_transfer);
+        let txs = pending.get_latest_flashblock_transactions_with_logs_filtered(&filter);
+
+        assert_eq!(txs.len(), 1);
+        assert_eq!(txs[0].transaction.tx_hash(), hash_a);
+    }
 }

--- a/crates/execution/flashblocks/src/rpc/pubsub.rs
+++ b/crates/execution/flashblocks/src/rpc/pubsub.rs
@@ -156,6 +156,38 @@ impl<Eth, FB> EthPubSub<Eth, FB> {
         )
     }
 
+    /// Returns a stream that yields full transactions with logs from only the latest flashblock,
+    /// filtered to include only transactions where at least one log matches the filter.
+    fn new_flashblock_transactions_filtered_stream(
+        flashblocks_state: Arc<FB>,
+        filter: Filter,
+    ) -> impl Stream<Item = TransactionWithLogs>
+    where
+        FB: FlashblocksAPI + Send + Sync + 'static,
+    {
+        futures::StreamExt::flat_map(
+            StreamExt::filter_map(
+                BroadcastStream::new(flashblocks_state.subscribe_to_flashblocks()),
+                move |result| {
+                    let pending_blocks = match result {
+                        Ok(blocks) => blocks,
+                        Err(err) => {
+                            error!(
+                                message = "Error in flashblocks stream for filtered transactions",
+                                error = %err
+                            );
+                            return None;
+                        }
+                    };
+                    let txs = pending_blocks
+                        .get_latest_flashblock_transactions_with_logs_filtered(&filter);
+                    if txs.is_empty() { None } else { Some(txs) }
+                },
+            ),
+            stream::iter,
+        )
+    }
+
     /// Returns a stream that yields individual transaction hashes from only the latest flashblock.
     ///
     /// Each hash is emitted as a separate stream item (one hash per WebSocket message).
@@ -240,21 +272,25 @@ where
                     pipe_from_stream(sink, stream).await;
                 });
             }
-            BaseSubscriptionKind::NewFlashblockTransactions => {
-                // Extract full_transactions param, default to false (hash only)
-                let full = match params {
-                    Some(Params::Bool(full)) => full,
-                    _ => false,
-                };
-
-                if full {
+            BaseSubscriptionKind::NewFlashblockTransactions => match params {
+                Some(Params::Logs(filter)) => {
+                    let stream = Self::new_flashblock_transactions_filtered_stream(
+                        Arc::clone(&self.flashblocks_state),
+                        *filter,
+                    );
+                    tokio::spawn(async move {
+                        pipe_from_stream(sink, stream).await;
+                    });
+                }
+                Some(Params::Bool(true)) => {
                     let stream = Self::new_flashblock_transactions_full_stream(Arc::clone(
                         &self.flashblocks_state,
                     ));
                     tokio::spawn(async move {
                         pipe_from_stream(sink, stream).await;
                     });
-                } else {
+                }
+                _ => {
                     let stream = Self::new_flashblock_transactions_hash_stream(Arc::clone(
                         &self.flashblocks_state,
                     ));
@@ -262,7 +298,7 @@ where
                         pipe_from_stream(sink, stream).await;
                     });
                 }
-            }
+            },
         }
 
         Ok(())

--- a/crates/execution/flashblocks/src/rpc/types.rs
+++ b/crates/execution/flashblocks/src/rpc/types.rs
@@ -5,10 +5,11 @@ use base_alloy_rpc_types::Transaction;
 use derive_more::From;
 use serde::{Deserialize, Serialize};
 
-/// A full transaction object with its associated logs.
+/// A full transaction object with its associated logs and gas usage.
 ///
-/// This is returned by `newFlashblockTransactions` subscription when `full = true`,
-/// providing both the transaction details and logs emitted by its execution.
+/// This is returned by `newFlashblockTransactions` subscription when `full = true`
+/// or when a log filter is provided, giving both the transaction details, logs emitted
+/// by its execution, and gas accounting fields.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct TransactionWithLogs {
@@ -17,6 +18,8 @@ pub struct TransactionWithLogs {
     pub transaction: Transaction,
     /// Logs emitted by this transaction.
     pub logs: Vec<Log>,
+    /// Gas consumed by this transaction's execution.
+    pub gas_used: Option<u64>,
 }
 
 /// Extended subscription kind that includes both standard Ethereum subscription types
@@ -65,10 +68,13 @@ pub enum BaseSubscriptionKind {
     /// confidence than standard `newPendingTransactions` which returns mempool transactions.
     /// Flashblock transactions have been included by the sequencer and are effectively preconfirmed.
     ///
-    /// Accepts an optional boolean parameter:
+    /// Accepts an optional parameter:
     /// - `true`: Returns full transaction objects with their associated logs (as
     ///   [`TransactionWithLogs`])
     /// - `false` (default): Returns only transaction hashes
+    /// - A log filter object (with `address` and/or `topics`): Returns full transaction objects
+    ///   where at least one log matches the filter. All logs are included in the response, not
+    ///   just the matching ones.
     NewFlashblockTransactions,
 }
 

--- a/crates/execution/flashblocks/src/rpc/types.rs
+++ b/crates/execution/flashblocks/src/rpc/types.rs
@@ -92,3 +92,131 @@ impl ExtendedSubscriptionKind {
         matches!(self, Self::Base(_))
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use alloy_consensus::{Signed, transaction::Recovered};
+    use alloy_primitives::{
+        Address, B256, Bytes, Log as PrimitiveLog, LogData, Signature, TxKind, U256,
+    };
+    use alloy_rpc_types_eth::Log;
+    use base_alloy_consensus::OpTxEnvelope;
+    use base_alloy_rpc_types::Transaction;
+
+    use super::*;
+
+    fn test_transaction_with_logs() -> TransactionWithLogs {
+        let legacy = alloy_consensus::TxLegacy {
+            chain_id: Some(1),
+            nonce: 7,
+            gas_price: 1_000_000_000,
+            gas_limit: 21_000,
+            to: TxKind::Call(Address::with_last_byte(0xBB)),
+            value: U256::from(1_000_000u64),
+            input: Bytes::new(),
+        };
+        let hash = B256::with_last_byte(0xAA);
+        let envelope =
+            OpTxEnvelope::Legacy(Signed::new_unchecked(legacy, Signature::test_signature(), hash));
+        let recovered = Recovered::new_unchecked(envelope, Address::with_last_byte(0xCC));
+        let tx = Transaction {
+            inner: alloy_rpc_types_eth::Transaction {
+                inner: recovered,
+                block_hash: Some(B256::ZERO),
+                block_number: Some(42),
+                transaction_index: Some(3),
+                effective_gas_price: Some(1_000_000_000),
+            },
+            deposit_nonce: None,
+            deposit_receipt_version: None,
+        };
+
+        let log = Log {
+            inner: PrimitiveLog {
+                address: Address::with_last_byte(0xDD),
+                data: LogData::new_unchecked(
+                    vec![B256::with_last_byte(0xEE)],
+                    Bytes::from_static(&[0x01, 0x02]),
+                ),
+            },
+            block_hash: Some(B256::ZERO),
+            block_number: Some(42),
+            block_timestamp: None,
+            transaction_hash: Some(hash),
+            transaction_index: Some(3),
+            log_index: Some(0),
+            removed: false,
+        };
+
+        TransactionWithLogs { transaction: tx, logs: vec![log], gas_used: Some(21_000) }
+    }
+
+    #[test]
+    fn transaction_with_logs_json_format() {
+        let twl = test_transaction_with_logs();
+        let json = serde_json::to_value(&twl).expect("serialization should succeed");
+        let obj = json.as_object().expect("should be a JSON object");
+
+        assert!(obj.contains_key("logs"), "missing 'logs' field");
+        assert!(obj.contains_key("gasUsed"), "missing 'gasUsed' field");
+        assert!(obj.contains_key("nonce"), "missing flattened tx 'nonce' field");
+        assert!(obj.contains_key("gasPrice"), "missing flattened tx 'gasPrice' field");
+        assert!(obj.contains_key("hash"), "missing flattened tx 'hash' field");
+        assert!(obj.contains_key("from"), "missing flattened tx 'from' field");
+        assert!(obj.contains_key("to"), "missing flattened tx 'to' field");
+        assert!(obj.contains_key("value"), "missing flattened tx 'value' field");
+        assert!(obj.contains_key("blockNumber"), "missing flattened tx 'blockNumber' field");
+
+        assert_eq!(obj["gasUsed"], 21_000u64, "gasUsed should be 21000");
+
+        let logs = obj["logs"].as_array().expect("logs should be an array");
+        assert_eq!(logs.len(), 1);
+        let log = logs[0].as_object().expect("log should be a JSON object");
+        assert!(log.contains_key("address"), "log missing 'address' field");
+        assert!(log.contains_key("topics"), "log missing 'topics' field");
+        assert!(log.contains_key("data"), "log missing 'data' field");
+        assert!(log.contains_key("transactionHash"), "log missing 'transactionHash' field");
+    }
+
+    #[test]
+    fn transaction_with_logs_json_roundtrip() {
+        let original = test_transaction_with_logs();
+        let json_str = serde_json::to_string(&original).expect("serialization should succeed");
+        let deserialized: TransactionWithLogs =
+            serde_json::from_str(&json_str).expect("deserialization should succeed");
+
+        assert_eq!(original, deserialized);
+    }
+
+    #[test]
+    fn transaction_with_logs_json_string_contains_expected_fields() {
+        let twl = test_transaction_with_logs();
+        let json_str = serde_json::to_string(&twl).expect("serialization should succeed");
+
+        assert!(json_str.contains("\"gasUsed\""), "JSON must contain gasUsed key");
+        assert!(json_str.contains("\"logs\""), "JSON must contain logs key");
+        assert!(json_str.contains("\"gasPrice\""), "JSON must contain gasPrice key");
+        assert!(json_str.contains("\"nonce\""), "JSON must contain nonce key");
+        assert!(json_str.contains("\"hash\""), "JSON must contain hash key");
+        assert!(json_str.contains("\"from\""), "JSON must contain from key");
+        assert!(json_str.contains("\"to\""), "JSON must contain to key");
+        assert!(json_str.contains("\"blockNumber\""), "JSON must contain blockNumber key");
+        assert!(json_str.contains("\"topics\""), "JSON must contain topics key in logs");
+        assert!(json_str.contains("\"address\""), "JSON must contain address key in logs");
+        assert!(
+            json_str.contains("\"transactionHash\""),
+            "JSON must contain transactionHash key in logs"
+        );
+    }
+
+    #[test]
+    fn transaction_with_logs_gas_used_none_serialization() {
+        let mut twl = test_transaction_with_logs();
+        twl.gas_used = None;
+        let json = serde_json::to_value(&twl).expect("serialization should succeed");
+        let obj = json.as_object().expect("should be a JSON object");
+
+        assert!(obj.contains_key("gasUsed"), "gasUsed key should be present even when None");
+        assert!(obj["gasUsed"].is_null(), "gasUsed should be null when None");
+    }
+}


### PR DESCRIPTION
## Summary

Addresses #1435.

- Adds log-level filtering to the `newFlashblockTransactions` subscription: subscribers can now pass a filter object (with `address` and/or `topics`) to receive only transactions where at least one log matches. When a transaction matches, **all** of its logs are returned (not just the matching ones), preserving full transaction context.
- Adds `gasUsed` field to `TransactionWithLogs` (sourced from the transaction receipt). `effectiveGasPrice` was already present via the `gasPrice` field on the transaction object.
- Fully backwards compatible: `true`/`false` parameters continue to work as before.

## API

```jsonc
// NEW: Filter by contract address
eth_subscribe("newFlashblockTransactions", {"address": "0x..."})

// NEW: Filter by topic0 (event signature)
eth_subscribe("newFlashblockTransactions", {"topics": ["0x..."]})

// NEW: Combined
eth_subscribe("newFlashblockTransactions", {"address": "0x...", "topics": ["0x..."]})

// UNCHANGED
eth_subscribe("newFlashblockTransactions", true)   // full txs, no filter
eth_subscribe("newFlashblockTransactions", false)  // hash only
```

## Changes

| File | Change |
|------|--------|
| `rpc/types.rs` | Added `gas_used: Option<u64>` to `TransactionWithLogs`; updated variant docs |
| `pending_blocks.rs` | Added `get_latest_flashblock_transactions_with_logs_filtered(&Filter)`; updated existing methods to populate `gas_used` |
| `rpc/pubsub.rs` | Added filtered stream method; updated subscribe handler to route `Params::Logs` |

## Tests

Added 7 unit tests covering address filtering, topic0 filtering, all-logs-returned semantics, no-match case, and `gas_used` population for both filtered and unfiltered paths.