### PR TITLE
feat(basectl): Conductor Dashboard EL and Restart

### DIFF
--- a/crates/infra/basectl/Cargo.toml
+++ b/crates/infra/basectl/Cargo.toml
@@ -9,7 +9,7 @@ workspace = true
 
 [dependencies]
 dirs = { workspace = true }
-tokio = { workspace = true }
+tokio = { workspace = true, features = ["process"] }
 chrono = { workspace = true }
 anyhow = { workspace = true }
 ratatui = { workspace = true }

--- a/crates/infra/basectl/src/app/views/conductor.rs
+++ b/crates/infra/basectl/src/app/views/conductor.rs
@@ -9,7 +9,7 @@ use tokio::sync::mpsc;
 use crate::{
     app::{Action, Resources, View},
     commands::common::COLOR_BASE_BLUE,
-    rpc::{ConductorNodeStatus, transfer_conductor_leader},
+    rpc::{ConductorNodeStatus, restart_conductor_node, transfer_conductor_leader},
     tui::{Keybinding, Toast},
 };
 
@@ -17,6 +17,7 @@ const KEYBINDINGS: &[Keybinding] = &[
     Keybinding { key: "←/→", description: "Select node" },
     Keybinding { key: "t", description: "Transfer (any peer)" },
     Keybinding { key: "Enter", description: "Transfer to selected" },
+    Keybinding { key: "r", description: "Restart selected node" },
     Keybinding { key: "Esc", description: "Back to home" },
     Keybinding { key: "?", description: "Toggle help" },
 ];
@@ -48,6 +49,16 @@ impl ConductorView {
         self.op_rx = Some(rx);
         self.op_pending = true;
         tokio::spawn(transfer_conductor_leader(nodes.clone(), target_name, tx));
+    }
+
+    fn start_restart(&mut self, resources: &Resources) {
+        let Some(ref nodes) = resources.config.conductors else { return };
+        let idx = self.selected.min(nodes.len().saturating_sub(1));
+        let node = nodes[idx].clone();
+        let (tx, rx) = mpsc::channel(1);
+        self.op_rx = Some(rx);
+        self.op_pending = true;
+        tokio::spawn(restart_conductor_node(node, tx));
     }
 }
 
@@ -86,6 +97,9 @@ impl View for ConductorView {
                 let idx = self.selected.min(node_count - 1);
                 let target = resources.conductor.nodes[idx].name.clone();
                 self.start_transfer(resources, Some(target));
+            }
+            KeyCode::Char('r') if !self.op_pending && node_count > 0 => {
+                self.start_restart(resources);
             }
             _ => {}
         }
@@ -155,7 +169,7 @@ fn render_footer(f: &mut Frame<'_>, area: Rect, op_pending: bool) {
 
     spans.push(sep.clone());
     if op_pending {
-        spans.push(Span::styled("transferring…", Style::default().fg(Color::Yellow)));
+        spans.push(Span::styled("working…", Style::default().fg(Color::Yellow)));
     } else {
         spans.push(Span::styled("[t]", key_style));
         spans.push(Span::raw(" "));
@@ -164,6 +178,10 @@ fn render_footer(f: &mut Frame<'_>, area: Rect, op_pending: bool) {
         spans.push(Span::styled("[Enter]", key_style));
         spans.push(Span::raw(" "));
         spans.push(Span::styled("transfer to selected", desc_style));
+        spans.push(sep.clone());
+        spans.push(Span::styled("[r]", key_style));
+        spans.push(Span::raw(" "));
+        spans.push(Span::styled("restart selected", desc_style));
     }
 
     spans.push(sep);
@@ -182,7 +200,7 @@ fn render_cluster_table(
     selected: usize,
     op_pending: bool,
 ) {
-    let title = if op_pending { " HA Conductor [transferring…] " } else { " HA Conductor " };
+    let title = if op_pending { " HA Conductor [working…] " } else { " HA Conductor " };
 
     let block = Block::default()
         .title(title)
@@ -225,7 +243,7 @@ fn render_cluster_table(
 
     // ── Role row ───────────────────────────────────────────────────────────
     let mut role_cells = vec![
-        Cell::from("Role").style(Style::default().fg(Color::White).add_modifier(Modifier::BOLD)),
+        Cell::from("  Role").style(Style::default().fg(Color::White).add_modifier(Modifier::BOLD)),
     ];
     for node in nodes {
         let (label, style) = match node.is_leader {
@@ -241,7 +259,7 @@ fn render_cluster_table(
 
     // ── Unsafe L2 row ──────────────────────────────────────────────────────
     let mut l2_cells = vec![
-        Cell::from("Unsafe L2")
+        Cell::from("  Unsafe L2")
             .style(Style::default().fg(Color::White).add_modifier(Modifier::BOLD)),
     ];
     for node in nodes {
@@ -256,9 +274,54 @@ fn render_cluster_table(
     }
     let l2_row = Row::new(l2_cells).height(1);
 
+    // ── Unsafe L2 hash row ────────────────────────────────────────────────
+    let mut l2_hash_cells = vec![
+        Cell::from("  Unsafe Hash")
+            .style(Style::default().fg(Color::White).add_modifier(Modifier::BOLD)),
+    ];
+
+    // ── Fork detection: find leader's unsafe and safe hashes ──────────────
+    let leader_unsafe: Option<(u64, alloy_primitives::B256)> = nodes.iter().find_map(|n| {
+        if n.is_leader == Some(true) {
+            n.unsafe_l2_block.zip(n.unsafe_l2_hash)
+        } else {
+            None
+        }
+    });
+    let leader_safe: Option<(u64, alloy_primitives::B256)> = nodes.iter().find_map(|n| {
+        if n.is_leader == Some(true) {
+            n.safe_l2_block.zip(n.safe_l2_hash)
+        } else {
+            None
+        }
+    });
+
+    for node in nodes {
+        let (label, style) = match node.unsafe_l2_hash {
+            Some(h) if node.is_leader == Some(true) => {
+                let hex = format!("{h:x}");
+                (format!("   0x{}…", &hex[..8]), Style::default().fg(Color::Yellow))
+            }
+            Some(h) => {
+                let hex = format!("{h:x}");
+                // Fork: same block number as leader but different hash.
+                let is_fork = leader_unsafe
+                    .is_some_and(|(lnum, lhash)| node.unsafe_l2_block == Some(lnum) && h != lhash);
+                if is_fork {
+                    (format!("   ⚠ 0x{}…", &hex[..8]), Style::default().fg(Color::Red))
+                } else {
+                    (format!("   0x{}…", &hex[..8]), Style::default().fg(Color::White))
+                }
+            }
+            None => ("   ?".to_string(), Style::default().fg(Color::DarkGray)),
+        };
+        l2_hash_cells.push(Cell::from(label).style(style));
+    }
+    let l2_hash_row = Row::new(l2_hash_cells).height(1);
+
     // ── Safe L2 row ────────────────────────────────────────────────────────
     let mut safe_l2_cells = vec![
-        Cell::from("Safe L2").style(Style::default().fg(Color::White).add_modifier(Modifier::BOLD)),
+        Cell::from("  Safe L2").style(Style::default().fg(Color::White).add_modifier(Modifier::BOLD)),
     ];
     for node in nodes {
         let (label, style) = match node.safe_l2_block {
@@ -272,9 +335,36 @@ fn render_cluster_table(
     }
     let safe_l2_row = Row::new(safe_l2_cells).height(1);
 
+    // ── Safe L2 hash row ──────────────────────────────────────────────────
+    let mut safe_hash_cells = vec![
+        Cell::from("  Safe Hash")
+            .style(Style::default().fg(Color::White).add_modifier(Modifier::BOLD)),
+    ];
+    for node in nodes {
+        let (label, style) = match node.safe_l2_hash {
+            Some(h) if node.is_leader == Some(true) => {
+                let hex = format!("{h:x}");
+                (format!("   0x{}…", &hex[..8]), Style::default().fg(Color::Yellow))
+            }
+            Some(h) => {
+                let hex = format!("{h:x}");
+                let is_fork = leader_safe
+                    .is_some_and(|(lnum, lhash)| node.safe_l2_block == Some(lnum) && h != lhash);
+                if is_fork {
+                    (format!("   ⚠ 0x{}…", &hex[..8]), Style::default().fg(Color::Red))
+                } else {
+                    (format!("   0x{}…", &hex[..8]), Style::default().fg(Color::White))
+                }
+            }
+            None => ("   ?".to_string(), Style::default().fg(Color::DarkGray)),
+        };
+        safe_hash_cells.push(Cell::from(label).style(style));
+    }
+    let safe_hash_row = Row::new(safe_hash_cells).height(1);
+
     // ── Finalized L2 row ───────────────────────────────────────────────────
     let mut finalized_l2_cells = vec![
-        Cell::from("Finalized L2")
+        Cell::from("  Finalized L2")
             .style(Style::default().fg(Color::White).add_modifier(Modifier::BOLD)),
     ];
     for node in nodes {
@@ -289,23 +379,150 @@ fn render_cluster_table(
     }
     let finalized_l2_row = Row::new(finalized_l2_cells).height(1);
 
-    // ── P2P peers row ──────────────────────────────────────────────────────
-    let mut peers_cells = vec![
-        Cell::from("P2P Peers")
+    // ── Active row (conductor) ─────────────────────────────────────────────
+    // `conductor_active` = "sequencer is currently sequencing".
+    // Followers stop their sequencer intentionally — active=false is expected.
+    // Only flag red when the *leader* reports active=false.
+    let mut active_cells = vec![
+        Cell::from("  Active")
             .style(Style::default().fg(Color::White).add_modifier(Modifier::BOLD)),
     ];
     for node in nodes {
-        let (label, style) = match node.peer_count {
+        let (label, style) = match (node.is_leader, node.conductor_active) {
+            (Some(true), Some(true)) => ("   yes", Style::default().fg(Color::Green)),
+            (Some(true), Some(false)) => ("   no", Style::default().fg(Color::Red)),
+            (Some(false), Some(false)) => ("   stopped", Style::default().fg(Color::DarkGray)),
+            (Some(false), Some(true)) => ("   active?", Style::default().fg(Color::Yellow)),
+            _ => ("   ?", Style::default().fg(Color::DarkGray)),
+        };
+        active_cells.push(Cell::from(label).style(style));
+    }
+    let active_row = Row::new(active_cells).height(1);
+
+    // ── CL section header ──────────────────────────────────────────────────
+    let cl_section = section_row("CL", node_count);
+
+    // ── L1 derivation row ──────────────────────────────────────────────────
+    let mut l1_cells = vec![
+        Cell::from("  L1 Derived")
+            .style(Style::default().fg(Color::White).add_modifier(Modifier::BOLD)),
+    ];
+    for node in nodes {
+        let (label, style) = match (node.current_l1_block, node.head_l1_block) {
+            (Some(cur), Some(head)) => {
+                let lag = head.saturating_sub(cur);
+                let color = if lag > 10 { Color::Yellow } else { Color::Green };
+                (format!("   #{cur} / #{head}"), Style::default().fg(color))
+            }
+            _ => ("   ? / ?".to_string(), Style::default().fg(Color::DarkGray)),
+        };
+        l1_cells.push(Cell::from(label).style(style));
+    }
+    let l1_row = Row::new(l1_cells).height(1);
+
+    // ── CL peer count row ──────────────────────────────────────────────────
+    let mut cl_peers_cells = vec![
+        Cell::from("  CL Peers")
+            .style(Style::default().fg(Color::White).add_modifier(Modifier::BOLD)),
+    ];
+    for node in nodes {
+        let (label, style) = match node.cl_peer_count {
             Some(0) => ("   0".to_string(), Style::default().fg(Color::Red)),
             Some(n) => (format!("   {n}"), Style::default().fg(Color::Green)),
             None => ("   ?".to_string(), Style::default().fg(Color::Red)),
         };
-        peers_cells.push(Cell::from(label).style(style));
+        cl_peers_cells.push(Cell::from(label).style(style));
     }
-    let peers_row = Row::new(peers_cells).height(1);
+    let cl_peers_row = Row::new(cl_peers_cells).height(1);
 
-    let rows = vec![role_row, l2_row, safe_l2_row, finalized_l2_row, peers_row];
+    // ── EL section header ──────────────────────────────────────────────────
+    let el_section = section_row("EL", node_count);
+
+    // ── EL block row ───────────────────────────────────────────────────────
+    let mut el_block_cells = vec![
+        Cell::from("  Block")
+            .style(Style::default().fg(Color::White).add_modifier(Modifier::BOLD)),
+    ];
+    for node in nodes {
+        let (label, style) = match node.el_block {
+            Some(n) if node.is_leader == Some(true) => {
+                (format!("   #{n}"), Style::default().fg(Color::Yellow))
+            }
+            Some(n) => (format!("   #{n}"), Style::default().fg(Color::White)),
+            None => ("   -".to_string(), Style::default().fg(Color::DarkGray)),
+        };
+        el_block_cells.push(Cell::from(label).style(style));
+    }
+    let el_block_row = Row::new(el_block_cells).height(1);
+
+    // ── EL syncing row ─────────────────────────────────────────────────────
+    let mut el_syncing_cells = vec![
+        Cell::from("  Syncing")
+            .style(Style::default().fg(Color::White).add_modifier(Modifier::BOLD)),
+    ];
+    for node in nodes {
+        let (label, style) = match node.el_syncing {
+            Some(true) => ("   yes", Style::default().fg(Color::Yellow)),
+            Some(false) => ("   no", Style::default().fg(Color::Green)),
+            None => ("   -", Style::default().fg(Color::DarkGray)),
+        };
+        el_syncing_cells.push(Cell::from(label).style(style));
+    }
+    let el_syncing_row = Row::new(el_syncing_cells).height(1);
+
+    // ── EL peer count row ──────────────────────────────────────────────────
+    let mut el_peers_cells = vec![
+        Cell::from("  EL Peers")
+            .style(Style::default().fg(Color::White).add_modifier(Modifier::BOLD)),
+    ];
+    for node in nodes {
+        let (label, style) = match node.el_peer_count {
+            Some(0) => ("   0".to_string(), Style::default().fg(Color::Red)),
+            Some(n) => (format!("   {n}"), Style::default().fg(Color::Green)),
+            None => ("   -".to_string(), Style::default().fg(Color::DarkGray)),
+        };
+        el_peers_cells.push(Cell::from(label).style(style));
+    }
+    let el_peers_row = Row::new(el_peers_cells).height(1);
+
+    let spacer = Row::new(vec![Cell::from("")]).height(1);
+
+    let rows = vec![
+        // ── Conductor ────────────────────────────────────────────────────
+        role_row,
+        active_row,
+        // ── CL ───────────────────────────────────────────────────────────
+        spacer.clone(),
+        cl_section,
+        l2_row,
+        l2_hash_row,
+        safe_l2_row,
+        safe_hash_row,
+        finalized_l2_row,
+        l1_row,
+        cl_peers_row,
+        // ── EL ───────────────────────────────────────────────────────────
+        spacer,
+        el_section,
+        el_block_row,
+        el_syncing_row,
+        el_peers_row,
+    ];
     let table = Table::new(rows, constraints).header(header).row_highlight_style(Style::default());
 
     f.render_stateful_widget(table, inner, &mut TableState::default());
+}
+
+/// Creates a styled section-separator row for the cluster table.
+///
+/// Renders as `── LABEL ──────────────` in the label column and `──────────────`
+/// in every data column, extending the visual divider fully across all columns.
+fn section_row(label: &str, node_count: usize) -> Row<'static> {
+    let sep_style = Style::default().fg(Color::DarkGray);
+    let heading = format!("── {label} ──────────────");
+    let mut cells = vec![Cell::from(heading).style(sep_style)];
+    for _ in 0..node_count {
+        cells.push(Cell::from("──────────────").style(sep_style));
+    }
+    Row::new(cells).height(1)
 }

--- a/crates/infra/basectl/src/app/views/conductor.rs
+++ b/crates/infra/basectl/src/app/views/conductor.rs
@@ -282,18 +282,10 @@ fn render_cluster_table(
 
     // ── Fork detection: find leader's unsafe and safe hashes ──────────────
     let leader_unsafe: Option<(u64, alloy_primitives::B256)> = nodes.iter().find_map(|n| {
-        if n.is_leader == Some(true) {
-            n.unsafe_l2_block.zip(n.unsafe_l2_hash)
-        } else {
-            None
-        }
+        if n.is_leader == Some(true) { n.unsafe_l2_block.zip(n.unsafe_l2_hash) } else { None }
     });
     let leader_safe: Option<(u64, alloy_primitives::B256)> = nodes.iter().find_map(|n| {
-        if n.is_leader == Some(true) {
-            n.safe_l2_block.zip(n.safe_l2_hash)
-        } else {
-            None
-        }
+        if n.is_leader == Some(true) { n.safe_l2_block.zip(n.safe_l2_hash) } else { None }
     });
 
     for node in nodes {
@@ -321,7 +313,8 @@ fn render_cluster_table(
 
     // ── Safe L2 row ────────────────────────────────────────────────────────
     let mut safe_l2_cells = vec![
-        Cell::from("  Safe L2").style(Style::default().fg(Color::White).add_modifier(Modifier::BOLD)),
+        Cell::from("  Safe L2")
+            .style(Style::default().fg(Color::White).add_modifier(Modifier::BOLD)),
     ];
     for node in nodes {
         let (label, style) = match node.safe_l2_block {
@@ -440,8 +433,7 @@ fn render_cluster_table(
 
     // ── EL block row ───────────────────────────────────────────────────────
     let mut el_block_cells = vec![
-        Cell::from("  Block")
-            .style(Style::default().fg(Color::White).add_modifier(Modifier::BOLD)),
+        Cell::from("  Block").style(Style::default().fg(Color::White).add_modifier(Modifier::BOLD)),
     ];
     for node in nodes {
         let (label, style) = match node.el_block {

--- a/crates/infra/basectl/src/config.rs
+++ b/crates/infra/basectl/src/config.rs
@@ -21,6 +21,27 @@ pub struct ConductorNodeConfig {
     pub server_id: String,
     /// Raft peer address (`host:port`) used when targeting this node for leadership transfer.
     pub raft_addr: String,
+    /// Execution-layer JSON-RPC endpoint for this sequencer's EL node.
+    ///
+    /// If set, the TUI polls `net_peerCount` on this endpoint to show the EL
+    /// peer count separately from the CL P2P peer count.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub el_rpc: Option<Url>,
+    /// Docker container name for the conductor process.
+    ///
+    /// If set, the TUI can restart this container with `r`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub docker_conductor: Option<String>,
+    /// Docker container name for the EL (execution layer) process.
+    ///
+    /// If set, the TUI can restart this container with `r`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub docker_el: Option<String>,
+    /// Docker container name for the CL (consensus layer) process.
+    ///
+    /// If set, the TUI can restart this container with `r`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub docker_cl: Option<String>,
     /// Flashblocks WebSocket endpoint for this sequencer's builder node.
     ///
     /// When set, the command center will automatically reconnect its flashblocks
@@ -168,6 +189,10 @@ impl ChainConfig {
                     cl_rpc: Url::parse("http://localhost:7549").unwrap(),
                     server_id: "sequencer-0".to_string(),
                     raft_addr: "op-conductor-0:5050".to_string(),
+                    el_rpc: Some(Url::parse("http://localhost:7545").unwrap()),
+                    docker_conductor: Some("op-conductor-0".to_string()),
+                    docker_el: Some("base-builder".to_string()),
+                    docker_cl: Some("base-builder-cl".to_string()),
                     flashblocks_ws: Some(Url::parse("ws://localhost:7111").unwrap()),
                 },
                 ConductorNodeConfig {
@@ -176,6 +201,10 @@ impl ChainConfig {
                     cl_rpc: Url::parse("http://localhost:10549").unwrap(),
                     server_id: "sequencer-1".to_string(),
                     raft_addr: "op-conductor-1:5051".to_string(),
+                    el_rpc: Some(Url::parse("http://localhost:10545").unwrap()),
+                    docker_conductor: Some("op-conductor-1".to_string()),
+                    docker_el: Some("base-sequencer-1".to_string()),
+                    docker_cl: Some("base-sequencer-1-cl".to_string()),
                     flashblocks_ws: Some(Url::parse("ws://localhost:10111").unwrap()),
                 },
                 ConductorNodeConfig {
@@ -184,6 +213,10 @@ impl ChainConfig {
                     cl_rpc: Url::parse("http://localhost:11549").unwrap(),
                     server_id: "sequencer-2".to_string(),
                     raft_addr: "op-conductor-2:5052".to_string(),
+                    el_rpc: Some(Url::parse("http://localhost:11545").unwrap()),
+                    docker_conductor: Some("op-conductor-2".to_string()),
+                    docker_el: Some("base-sequencer-2".to_string()),
+                    docker_cl: Some("base-sequencer-2-cl".to_string()),
                     flashblocks_ws: Some(Url::parse("ws://localhost:11111").unwrap()),
                 },
             ]),

--- a/crates/infra/basectl/src/rpc.rs
+++ b/crates/infra/basectl/src/rpc.rs
@@ -11,7 +11,7 @@ use base_alloy_flashblocks::Flashblock;
 use base_alloy_network::Base;
 use base_consensus_rpc::{ConductorApiClient, OpP2PApiClient, RollupNodeApiClient};
 use futures::{StreamExt, stream};
-use jsonrpsee::http_client::HttpClientBuilder;
+use jsonrpsee::{core::client::ClientT, http_client::HttpClientBuilder, rpc_params};
 use tokio::sync::{mpsc, watch};
 use tokio_tungstenite::connect_async;
 use tracing::warn;
@@ -676,16 +676,40 @@ pub(crate) async fn fetch_block_transactions(
 pub(crate) struct ConductorNodeStatus {
     /// Human-readable name for this node.
     pub name: String,
+
+    // ── Conductor ────────────────────────────────────────────────────────
     /// Whether this node is the Raft leader. `None` means the node is unreachable.
     pub is_leader: Option<bool>,
-    /// Unsafe L2 block number from `optimism_syncStatus`. `None` means unreachable.
+    /// Whether the conductor's sequencer is actively sequencing (`conductor_active`).
+    /// Expected to be `false` for followers. `None` means unreachable.
+    pub conductor_active: Option<bool>,
+
+    // ── CL (consensus layer) ─────────────────────────────────────────────
+    /// Unsafe L2 block number from `optimism_syncStatus`.
     pub unsafe_l2_block: Option<u64>,
-    /// Safe L2 block number from `optimism_syncStatus`. `None` means unreachable.
+    /// Unsafe L2 block hash from `optimism_syncStatus`.
+    pub unsafe_l2_hash: Option<alloy_primitives::B256>,
+    /// Safe L2 block number from `optimism_syncStatus`.
     pub safe_l2_block: Option<u64>,
-    /// Finalized L2 block number from `optimism_syncStatus`. `None` means unreachable.
+    /// Safe L2 block hash from `optimism_syncStatus`.
+    pub safe_l2_hash: Option<alloy_primitives::B256>,
+    /// Finalized L2 block number from `optimism_syncStatus`.
     pub finalized_l2_block: Option<u64>,
-    /// Number of connected P2P peers from `opp2p_peerStats`. `None` means unreachable.
-    pub peer_count: Option<u32>,
+    /// L1 derivation cursor block number (`current_l1`).
+    pub current_l1_block: Option<u64>,
+    /// L1 chain head block number (`head_l1`). Compared with `current_l1_block` to show lag.
+    pub head_l1_block: Option<u64>,
+    /// Number of connected CL libp2p peers from `opp2p_peerStats`.
+    pub cl_peer_count: Option<u32>,
+
+    // ── EL (execution layer) ─────────────────────────────────────────────
+    /// Latest block number from `eth_blockNumber`. `None` if `el_rpc` not configured.
+    pub el_block: Option<u64>,
+    /// Whether the EL is snap-syncing (`eth_syncing` returns non-false). `None` if not
+    /// configured.
+    pub el_syncing: Option<bool>,
+    /// Number of connected EL devp2p peers from `net_peerCount`. `None` if not configured.
+    pub el_peer_count: Option<u32>,
 }
 
 /// Finds the current Raft leader and transfers leadership.
@@ -748,6 +772,80 @@ pub(crate) async fn transfer_conductor_leader(
     let _ = result_tx.send(outcome.map_err(|e| e.to_string())).await;
 }
 
+/// Restarts the docker containers for a single conductor cluster node.
+///
+/// Containers are restarted in dependency order — EL → CL → conductor —
+/// waiting for each to become healthy before starting the next. This prevents
+/// op-conductor from crashing on startup because it tries to connect to the EL
+/// before the EL has bound its port.
+pub(crate) async fn restart_conductor_node(
+    node: ConductorNodeConfig,
+    result_tx: mpsc::Sender<Result<String, String>>,
+) {
+    // Dependency order: EL must be healthy before CL starts, CL before conductor.
+    let ordered: &[Option<&str>] = &[
+        node.docker_el.as_deref(),
+        node.docker_cl.as_deref(),
+        node.docker_conductor.as_deref(),
+    ];
+    let containers: Vec<&str> = ordered.iter().filter_map(|c| *c).collect();
+
+    let outcome: anyhow::Result<String> = async {
+        if containers.is_empty() {
+            return Err(anyhow::anyhow!("no docker containers configured for {}", node.name));
+        }
+
+        for container in &containers {
+            // Restart this container.
+            let out = tokio::process::Command::new("docker")
+                .args(["restart", container])
+                .output()
+                .await
+                .map_err(|e| anyhow::anyhow!("docker restart {container}: {e}"))?;
+            if !out.status.success() {
+                let stderr = String::from_utf8_lossy(&out.stderr);
+                return Err(anyhow::anyhow!(
+                    "docker restart {container} failed: {}",
+                    stderr.trim()
+                ));
+            }
+
+            // Wait until Docker reports the container as healthy (or running if
+            // no healthcheck is defined) before moving to the next dependency.
+            for _ in 0..60u32 {
+                tokio::time::sleep(Duration::from_millis(500)).await;
+                let status = tokio::process::Command::new("docker")
+                    .args(["inspect", "--format", "{{.State.Health.Status}}", container])
+                    .output()
+                    .await
+                    .ok()
+                    .and_then(|o| String::from_utf8(o.stdout).ok());
+                match status.as_deref().map(str::trim) {
+                    Some("healthy") => break,
+                    // Container has no healthcheck — treat "running" as ready.
+                    Some("") | None => {
+                        let running = tokio::process::Command::new("docker")
+                            .args(["inspect", "--format", "{{.State.Running}}", container])
+                            .output()
+                            .await
+                            .ok()
+                            .and_then(|o| String::from_utf8(o.stdout).ok());
+                        if running.as_deref().map(str::trim) == Some("true") {
+                            break;
+                        }
+                    }
+                    _ => {} // starting / unhealthy — keep waiting
+                }
+            }
+        }
+
+        Ok(format!("restarted {} ({})", node.name, containers.join(" → ")))
+    }
+    .await;
+
+    let _ = result_tx.send(outcome.map_err(|e| e.to_string())).await;
+}
+
 /// Polls all conductor nodes every 200 ms and forwards status snapshots.
 ///
 /// Builds one pair of HTTP clients per node (conductor RPC + CL RPC) before
@@ -762,7 +860,7 @@ pub(crate) async fn run_conductor_poller(
     const POLL_INTERVAL: Duration = Duration::from_millis(200);
     const RPC_TIMEOUT: Duration = Duration::from_millis(500);
 
-    let clients: Vec<(String, _, _)> = nodes
+    let clients: Vec<(String, _, _, _)> = nodes
         .into_iter()
         .filter_map(|node| {
             let conductor_client = HttpClientBuilder::default()
@@ -779,7 +877,19 @@ pub(crate) async fn run_conductor_poller(
                     warn!(error = %e, node = %node.name, "failed to build CL HTTP client");
                 })
                 .ok()?;
-            Some((node.name, conductor_client, cl_client))
+            let el_client = node
+                .el_rpc
+                .as_ref()
+                .and_then(|url| {
+                    HttpClientBuilder::default()
+                        .request_timeout(RPC_TIMEOUT)
+                        .build(url.as_str())
+                        .inspect_err(|e| {
+                            warn!(error = %e, node = %node.name, "failed to build EL HTTP client");
+                        })
+                        .ok()
+                });
+            Some((node.name, conductor_client, cl_client, el_client))
         })
         .collect();
 
@@ -790,21 +900,60 @@ pub(crate) async fn run_conductor_poller(
         interval.tick().await;
 
         let statuses = futures::future::join_all(clients.iter().map(
-            |(name, conductor_client, cl_client)| async move {
-                let is_leader = ConductorApiClient::conductor_leader(conductor_client).await.ok();
-                let sync = RollupNodeApiClient::op_sync_status(cl_client).await.ok();
-                let unsafe_l2_block = sync.as_ref().map(|s| s.unsafe_l2.block_info.number);
-                let safe_l2_block = sync.as_ref().map(|s| s.safe_l2.block_info.number);
-                let finalized_l2_block = sync.as_ref().map(|s| s.finalized_l2.block_info.number);
-                let peer_count =
-                    OpP2PApiClient::opp2p_peer_stats(cl_client).await.ok().map(|s| s.connected);
+            |(name, conductor_client, cl_client, el_client)| async move {
+                // Fire all RPCs concurrently so a single timed-out node does not
+                // stall the poll for the full sum of all call timeouts (7 × 500 ms).
+                let (is_leader, conductor_active, sync, cl_peer_stats, el_block_r, el_syncing_r, el_peers_r) =
+                    tokio::join!(
+                        ConductorApiClient::conductor_leader(conductor_client),
+                        ConductorApiClient::conductor_active(conductor_client),
+                        RollupNodeApiClient::op_sync_status(cl_client),
+                        OpP2PApiClient::opp2p_peer_stats(cl_client),
+                        async {
+                            if let Some(el) = el_client {
+                                let r: Result<alloy_primitives::U64, _> =
+                                    ClientT::request(el, "eth_blockNumber", rpc_params![]).await;
+                                r.ok().map(|v| v.to::<u64>())
+                            } else {
+                                None
+                            }
+                        },
+                        async {
+                            if let Some(el) = el_client {
+                                let r: Result<serde_json::Value, _> =
+                                    ClientT::request(el, "eth_syncing", rpc_params![]).await;
+                                r.ok().map(|v| !matches!(v, serde_json::Value::Bool(false)))
+                            } else {
+                                None
+                            }
+                        },
+                        async {
+                            if let Some(el) = el_client {
+                                let r: Result<alloy_primitives::U64, _> =
+                                    ClientT::request(el, "net_peerCount", rpc_params![]).await;
+                                r.ok().map(|v| v.to::<u32>())
+                            } else {
+                                None
+                            }
+                        },
+                    );
+
+                let sync = sync.ok();
                 ConductorNodeStatus {
                     name: name.clone(),
-                    is_leader,
-                    unsafe_l2_block,
-                    safe_l2_block,
-                    finalized_l2_block,
-                    peer_count,
+                    is_leader: is_leader.ok(),
+                    conductor_active: conductor_active.ok(),
+                    unsafe_l2_block: sync.as_ref().map(|s| s.unsafe_l2.block_info.number),
+                    unsafe_l2_hash: sync.as_ref().map(|s| s.unsafe_l2.block_info.hash),
+                    safe_l2_block: sync.as_ref().map(|s| s.safe_l2.block_info.number),
+                    safe_l2_hash: sync.as_ref().map(|s| s.safe_l2.block_info.hash),
+                    finalized_l2_block: sync.as_ref().map(|s| s.finalized_l2.block_info.number),
+                    current_l1_block: sync.as_ref().map(|s| s.current_l1.number),
+                    head_l1_block: sync.as_ref().map(|s| s.head_l1.number),
+                    cl_peer_count: cl_peer_stats.ok().map(|s| s.connected),
+                    el_block: el_block_r,
+                    el_syncing: el_syncing_r,
+                    el_peer_count: el_peers_r,
                 }
             },
         ))

--- a/crates/infra/basectl/src/rpc.rs
+++ b/crates/infra/basectl/src/rpc.rs
@@ -783,11 +783,8 @@ pub(crate) async fn restart_conductor_node(
     result_tx: mpsc::Sender<Result<String, String>>,
 ) {
     // Dependency order: EL must be healthy before CL starts, CL before conductor.
-    let ordered: &[Option<&str>] = &[
-        node.docker_el.as_deref(),
-        node.docker_cl.as_deref(),
-        node.docker_conductor.as_deref(),
-    ];
+    let ordered: &[Option<&str>] =
+        &[node.docker_el.as_deref(), node.docker_cl.as_deref(), node.docker_conductor.as_deref()];
     let containers: Vec<&str> = ordered.iter().filter_map(|c| *c).collect();
 
     let outcome: anyhow::Result<String> = async {
@@ -877,18 +874,15 @@ pub(crate) async fn run_conductor_poller(
                     warn!(error = %e, node = %node.name, "failed to build CL HTTP client");
                 })
                 .ok()?;
-            let el_client = node
-                .el_rpc
-                .as_ref()
-                .and_then(|url| {
-                    HttpClientBuilder::default()
-                        .request_timeout(RPC_TIMEOUT)
-                        .build(url.as_str())
-                        .inspect_err(|e| {
-                            warn!(error = %e, node = %node.name, "failed to build EL HTTP client");
-                        })
-                        .ok()
-                });
+            let el_client = node.el_rpc.as_ref().and_then(|url| {
+                HttpClientBuilder::default()
+                    .request_timeout(RPC_TIMEOUT)
+                    .build(url.as_str())
+                    .inspect_err(|e| {
+                        warn!(error = %e, node = %node.name, "failed to build EL HTTP client");
+                    })
+                    .ok()
+            });
             Some((node.name, conductor_client, cl_client, el_client))
         })
         .collect();
@@ -903,40 +897,47 @@ pub(crate) async fn run_conductor_poller(
             |(name, conductor_client, cl_client, el_client)| async move {
                 // Fire all RPCs concurrently so a single timed-out node does not
                 // stall the poll for the full sum of all call timeouts (7 × 500 ms).
-                let (is_leader, conductor_active, sync, cl_peer_stats, el_block_r, el_syncing_r, el_peers_r) =
-                    tokio::join!(
-                        ConductorApiClient::conductor_leader(conductor_client),
-                        ConductorApiClient::conductor_active(conductor_client),
-                        RollupNodeApiClient::op_sync_status(cl_client),
-                        OpP2PApiClient::opp2p_peer_stats(cl_client),
-                        async {
-                            if let Some(el) = el_client {
-                                let r: Result<alloy_primitives::U64, _> =
-                                    ClientT::request(el, "eth_blockNumber", rpc_params![]).await;
-                                r.ok().map(|v| v.to::<u64>())
-                            } else {
-                                None
-                            }
-                        },
-                        async {
-                            if let Some(el) = el_client {
-                                let r: Result<serde_json::Value, _> =
-                                    ClientT::request(el, "eth_syncing", rpc_params![]).await;
-                                r.ok().map(|v| !matches!(v, serde_json::Value::Bool(false)))
-                            } else {
-                                None
-                            }
-                        },
-                        async {
-                            if let Some(el) = el_client {
-                                let r: Result<alloy_primitives::U64, _> =
-                                    ClientT::request(el, "net_peerCount", rpc_params![]).await;
-                                r.ok().map(|v| v.to::<u32>())
-                            } else {
-                                None
-                            }
-                        },
-                    );
+                let (
+                    is_leader,
+                    conductor_active,
+                    sync,
+                    cl_peer_stats,
+                    el_block_r,
+                    el_syncing_r,
+                    el_peers_r,
+                ) = tokio::join!(
+                    ConductorApiClient::conductor_leader(conductor_client),
+                    ConductorApiClient::conductor_active(conductor_client),
+                    RollupNodeApiClient::op_sync_status(cl_client),
+                    OpP2PApiClient::opp2p_peer_stats(cl_client),
+                    async {
+                        if let Some(el) = el_client {
+                            let r: Result<alloy_primitives::U64, _> =
+                                ClientT::request(el, "eth_blockNumber", rpc_params![]).await;
+                            r.ok().map(|v| v.to::<u64>())
+                        } else {
+                            None
+                        }
+                    },
+                    async {
+                        if let Some(el) = el_client {
+                            let r: Result<serde_json::Value, _> =
+                                ClientT::request(el, "eth_syncing", rpc_params![]).await;
+                            r.ok().map(|v| !matches!(v, serde_json::Value::Bool(false)))
+                        } else {
+                            None
+                        }
+                    },
+                    async {
+                        if let Some(el) = el_client {
+                            let r: Result<alloy_primitives::U64, _> =
+                                ClientT::request(el, "net_peerCount", rpc_params![]).await;
+                            r.ok().map(|v| v.to::<u32>())
+                        } else {
+                            None
+                        }
+                    },
+                );
 
                 let sync = sync.ok();
                 ConductorNodeStatus {

--- a/crates/utilities/metrics/src/lib.rs
+++ b/crates/utilities/metrics/src/lib.rs
@@ -29,6 +29,7 @@ pub use registry::initialize_registered_metrics;
 pub use registry::register_initializer;
 #[cfg(not(feature = "metrics"))]
 #[inline(always)]
+/// Initializes all registered metrics. No-op when the `metrics` feature is disabled.
 pub fn initialize_registered_metrics() {}
 
 #[cfg(feature = "metrics")]


### PR DESCRIPTION
## Summary

Expands the basectl conductor TUI dashboard with EL (execution layer) metrics and a node restart action. Each conductor node now shows EL block number, sync status, and peer count alongside the existing CL rows, with CL and EL sections visually separated. A new `r` keybinding restarts the selected node's docker containers in dependency order (EL → CL → conductor), waiting for each to become healthy before starting the next. Hash rows for unsafe and safe L2 blocks are also displayed, with fork detection that highlights diverging hashes in red.

### Updated Dashboard

<img width="729" height="417" alt="Screenshot 2026-03-30 at 11 23 16 AM" src="https://github.com/user-attachments/assets/d4a64d04-62b0-40b5-bf2e-2f2c9d612036" />