### PR TITLE
chore(proofs): Consensus Address

### DIFF
--- a/bin/prover/zk/src/cli.rs
+++ b/bin/prover/zk/src/cli.rs
@@ -38,8 +38,8 @@ pub(crate) struct Cli {
 /// ZK prover service for proving Base blocks.
 #[derive(Parser, Debug)]
 struct ZkArgs {
-    #[arg(long, env = "OP_NODE_ADDRESS")]
-    op_node_address: String,
+    #[arg(long, env = "BASE_CONSENSUS_ADDRESS")]
+    base_consensus_address: String,
 
     #[arg(long, env = "L1_NODE_ADDRESS")]
     l1_node_address: String,
@@ -182,7 +182,7 @@ impl ZkArgs {
         let artifact_storage = self.resolve_artifact_storage()?;
 
         let config = BackendConfig::GenericZkvm {
-            op_node_url: self.op_node_address.clone(),
+            op_node_url: self.base_consensus_address.clone(),
             l1_node_url: l1_url.clone(),
             l1_beacon_url: beacon_url.clone(),
             l2_node_url: l2_url.clone(),

--- a/bin/prover/zk/src/cli.rs
+++ b/bin/prover/zk/src/cli.rs
@@ -182,7 +182,7 @@ impl ZkArgs {
         let artifact_storage = self.resolve_artifact_storage()?;
 
         let config = BackendConfig::GenericZkvm {
-            op_node_url: self.base_consensus_address.clone(),
+            base_consensus_url: self.base_consensus_address.clone(),
             l1_node_url: l1_url.clone(),
             l1_beacon_url: beacon_url.clone(),
             l2_node_url: l2_url.clone(),

--- a/crates/proof/zk/service/src/backends/traits.rs
+++ b/crates/proof/zk/service/src/backends/traits.rs
@@ -69,10 +69,10 @@ impl From<ProofType> for BackendType {
 /// Configuration for initializing a proving backend.
 #[derive(Debug, Clone)]
 pub enum BackendConfig {
-    /// Generic zkVM backend settings (`op_node_url=<url>`, `cluster_rpc=<url>`).
+    /// Generic zkVM backend settings (`base_consensus_url=<url>`, `cluster_rpc=<url>`).
     GenericZkvm {
-        /// OP node RPC URL used for rollup-specific chain state.
-        op_node_url: String,
+        /// Base consensus node RPC URL used for rollup-specific chain state.
+        base_consensus_url: String,
         /// L1 execution node RPC URL used for L1 state queries.
         l1_node_url: String,
         /// L1 beacon node URL used for beacon chain data.


### PR DESCRIPTION
## Summary

Renames the `OP_NODE_ADDRESS` environment variable in `bin/prover/zk/src/cli.rs` to `BASE_CONSENSUS_ADDRESS`, along with its corresponding field `op_node_address` to `base_consensus_address`. The old `OP_` prefix was inconsistent with adjacent `BASE_`-prefixed vars and the project's naming conventions. Note this is a breaking change for any deployments currently setting `OP_NODE_ADDRESS`.

Closes #1597.