### PR TITLE
refactor(zk-service): drop unused RateLimiter::available_permits

### DIFF
--- a/crates/proof/zk/service/src/proxy/rate_limit.rs
+++ b/crates/proof/zk/service/src/proxy/rate_limit.rs
@@ -85,12 +85,6 @@ impl RateLimiter {
         debug!(name = %self.name, "Request allowed");
         Some(permit)
     }
-
-    /// Get current available permits (for monitoring)
-    #[allow(dead_code)]
-    pub(super) fn available_permits(&self) -> usize {
-        self.semaphore.available_permits()
-    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary
Remove the never-called `available_permits()` helper from `RateLimiter` in `base-zk-service` and delete its `#[allow(dead_code)]`.
## What changed
| Item | Detail |
|------|--------|
| File | `crates/proof/zk/service/src/proxy/rate_limit.rs` |
| Removed | `available_permits()` (wrapper over `self.semaphore.available_permits()`) |
| Removed | The `#[allow(dead_code)]` on that method |
| Unchanged | `RateLimiter::new`, `acquire`, RPS + concurrency limiting behavior |
## Why this matters
1. **Less confusion**: Avoids a `pub(super)` API that looks monitoring-ready but has no call sites.
2. **Cleaner hygiene**: Stops using `dead_code` to hide unused surface area.
3. **No semantic risk**: Limiting still flows through `acquire` and the same `Semaphore`; only an unused wrapper is removed.
## Verification
cargo +nightly fmt -p base-zk-service
cargo test -p base-zk-service