### PR TITLE
feat(batcher): Lazy Compressor Write Eliminates O(N²)

### DIFF
--- a/crates/batcher/comp/src/brotli.rs
+++ b/crates/batcher/comp/src/brotli.rs
@@ -1,6 +1,7 @@
 //! Contains brotli compression utilities.
 
 use alloc::vec::Vec;
+use core::cell::{Cell, RefCell};
 
 use brotli::enc::{BrotliCompress, BrotliEncoderParams};
 
@@ -37,14 +38,31 @@ pub enum BrotliCompressionError {
 }
 
 /// The brotli compressor.
+///
+/// Raw input bytes are accumulated on every [`CompressorWriter::write`] call
+/// without compressing them.  Compression is deferred until [`len`],
+/// [`ChannelCompressor::get_compressed`], or [`CompressorWriter::read`] is
+/// called, at which point the entire accumulated buffer is compressed once and
+/// the result is cached.  Subsequent queries return the cached value in O(1)
+/// until the next write invalidates it.
+///
+/// This eliminates the O(N²) re-compress-from-scratch behaviour that the
+/// previous eager implementation exhibited when filling a channel with many
+/// incremental block writes.
+///
+/// [`len`]: CompressorWriter::len
 #[derive(Debug, Clone)]
 pub struct BrotliCompressor {
-    /// The compressed bytes.
-    compressed: Vec<u8>,
-    /// The raw bytes (need to store on reset).
+    /// The lazily-materialised compressed bytes.  Valid (non-dirty) only when
+    /// `dirty` is `false`.
+    compressed: RefCell<Vec<u8>>,
+    /// The raw accumulated input bytes.
     raw: Vec<u8>,
     /// Marks that the compressor is closed.
     closed: bool,
+    /// Set to `true` when `raw` has been extended since the last compression
+    /// run, indicating that `compressed` is stale.
+    dirty: Cell<bool>,
     /// The compression level.
     pub level: BrotliLevel,
 }
@@ -53,7 +71,29 @@ impl BrotliCompressor {
     /// Creates a new brotli compressor with the given compression level.
     pub fn new(level: impl Into<BrotliLevel>) -> Self {
         let level = level.into();
-        Self { compressed: Vec::new(), raw: Vec::new(), closed: false, level }
+        Self {
+            compressed: RefCell::new(Vec::new()),
+            raw: Vec::new(),
+            closed: false,
+            dirty: Cell::new(false),
+            level,
+        }
+    }
+
+    /// Compresses `raw` into `compressed` if the dirty flag is set, then
+    /// clears the flag.  All three of [`len`], [`get_compressed`], and
+    /// [`read`] call this before accessing the compressed buffer.
+    ///
+    /// [`len`]: CompressorWriter::len
+    /// [`get_compressed`]: ChannelCompressor::get_compressed
+    /// [`read`]: CompressorWriter::read
+    fn ensure_compressed(&self) -> CompressorResult<()> {
+        if self.dirty.get() {
+            let c = Self::compress(&self.raw, self.level).map_err(|_| CompressorError::Brotli)?;
+            *self.compressed.borrow_mut() = c;
+            self.dirty.set(false);
+        }
+        Ok(())
     }
 
     /// Compresses the given bytes data using the Brotli compressor implemented
@@ -86,14 +126,11 @@ impl CompressorWriter for BrotliCompressor {
         if self.closed {
             return Err(CompressorError::Brotli);
         }
-
-        // First append the new data to the raw buffer.
+        // Accumulate raw bytes without compressing.  Compression is deferred
+        // to the first call that actually needs the compressed output.
         self.raw.extend_from_slice(data);
-
-        // Compress the raw buffer.
-        self.compressed =
-            Self::compress(&self.raw, self.level).map_err(|_| CompressorError::Brotli)?;
-
+        self.compressed.borrow_mut().clear();
+        self.dirty.set(true);
         Ok(data.len())
     }
 
@@ -102,7 +139,6 @@ impl CompressorWriter for BrotliCompressor {
     }
 
     fn close(&mut self) -> CompressorResult<()> {
-        self.flush()?;
         self.closed = true;
         Ok(())
     }
@@ -110,24 +146,31 @@ impl CompressorWriter for BrotliCompressor {
     fn reset(&mut self) {
         self.closed = false;
         self.raw.clear();
-        self.compressed.clear();
+        self.compressed.borrow_mut().clear();
+        self.dirty.set(false);
     }
 
     fn read(&mut self, buf: &mut [u8]) -> CompressorResult<usize> {
-        let len = self.compressed.len().min(buf.len());
-        buf[..len].copy_from_slice(&self.compressed[..len]);
-        self.compressed.drain(..len);
+        self.ensure_compressed()?;
+        let mut compressed = self.compressed.borrow_mut();
+        let len = compressed.len().min(buf.len());
+        buf[..len].copy_from_slice(&compressed[..len]);
+        compressed.drain(..len);
         Ok(len)
     }
 
     fn len(&self) -> usize {
-        self.compressed.len()
+        // Silently ignore compression errors; callers will encounter them on
+        // the next read() or get_compressed() call.
+        let _ = self.ensure_compressed();
+        self.compressed.borrow().len()
     }
 }
 
 impl ChannelCompressor for BrotliCompressor {
     fn get_compressed(&self) -> Vec<u8> {
-        self.compressed.clone()
+        let _ = self.ensure_compressed();
+        self.compressed.borrow().clone()
     }
 
     fn channel_version_byte(&self) -> Option<u8> {

--- a/crates/batcher/comp/src/shadow.rs
+++ b/crates/batcher/comp/src/shadow.rs
@@ -102,15 +102,13 @@ impl CompressorWriter for ShadowCompressor {
     }
 
     fn flush(&mut self) -> CompressorResult<()> {
-        // Only the shadow compressor needs to be flushed. The main compressor
-        // (both `BrotliCompressor` and `ZlibCompressor`) re-compresses the
-        // entire accumulated raw buffer on every `write()` call, so its
-        // `compressed` output is always fully up-to-date. There is no internal
-        // streaming state that could strand data — `flush()` and `close()` are
-        // no-ops on the underlying compressors. The shadow, however, is flushed
-        // during `write()` for accurate size estimation, so we forward `flush()`
-        // to it here to keep the estimate current.
-        self.shadow.flush()
+        // Both the shadow and main compressors use lazy compression: they
+        // accumulate raw bytes on write() and only materialise the compressed
+        // output when len(), get_compressed(), or read() is called.  flush()
+        // is therefore a no-op on both underlying compressors, but we forward
+        // it to each for API completeness.
+        self.shadow.flush()?;
+        self.compressor.flush()
     }
 
     fn close(&mut self) -> CompressorResult<()> {

--- a/crates/batcher/comp/src/zlib.rs
+++ b/crates/batcher/comp/src/zlib.rs
@@ -1,6 +1,7 @@
 //! Contains ZLIB compression and decompression primitives for Base.
 
 use alloc::vec::Vec;
+use core::cell::{Cell, RefCell};
 
 use miniz_oxide::inflate::DecompressError;
 
@@ -10,19 +11,32 @@ use crate::{ChannelCompressor, CompressorResult, CompressorWriter};
 const BEST_ZLIB_COMPRESSION: u8 = 9;
 
 /// The ZLIB compressor.
+///
+/// Raw input bytes are accumulated on every [`CompressorWriter::write`] call
+/// without compressing them.  Compression is deferred until [`len`],
+/// [`ChannelCompressor::get_compressed`], or [`CompressorWriter::read`] is
+/// called, at which point the entire accumulated buffer is compressed once and
+/// the result is cached.  Subsequent queries return the cached value in O(1)
+/// until the next write invalidates it.
+///
+/// [`len`]: CompressorWriter::len
 #[derive(Debug, Clone, Default)]
 #[non_exhaustive]
 pub struct ZlibCompressor {
     /// Holds a non-compressed buffer.
     buffer: Vec<u8>,
-    /// The compressed buffer.
-    compressed: Vec<u8>,
+    /// The lazily-materialised compressed buffer.  Valid only when `dirty` is
+    /// `false`.
+    compressed: RefCell<Vec<u8>>,
+    /// Set to `true` when `buffer` has been extended since the last
+    /// compression run.
+    dirty: Cell<bool>,
 }
 
 impl ZlibCompressor {
     /// Create a new ZLIB compressor.
     pub const fn new() -> Self {
-        Self { buffer: Vec::new(), compressed: Vec::new() }
+        Self { buffer: Vec::new(), compressed: RefCell::new(Vec::new()), dirty: Cell::new(false) }
     }
 
     /// Compress `data` using ZLIB deflate.
@@ -34,13 +48,24 @@ impl ZlibCompressor {
     pub fn decompress(data: &[u8]) -> Result<Vec<u8>, DecompressError> {
         miniz_oxide::inflate::decompress_to_vec(data)
     }
+
+    /// Compresses `buffer` into `compressed` if the dirty flag is set, then
+    /// clears the flag.
+    fn ensure_compressed(&self) {
+        if self.dirty.get() {
+            *self.compressed.borrow_mut() = Self::compress(&self.buffer);
+            self.dirty.set(false);
+        }
+    }
 }
 
 impl CompressorWriter for ZlibCompressor {
     fn write(&mut self, data: &[u8]) -> CompressorResult<usize> {
+        // Accumulate raw bytes without compressing.  Compression is deferred
+        // to the first call that actually needs the compressed output.
         self.buffer.extend_from_slice(data);
-        self.compressed.clear();
-        self.compressed.extend_from_slice(&Self::compress(&self.buffer));
+        self.compressed.borrow_mut().clear();
+        self.dirty.set(true);
         Ok(data.len())
     }
 
@@ -54,22 +79,27 @@ impl CompressorWriter for ZlibCompressor {
 
     fn reset(&mut self) {
         self.buffer.clear();
-        self.compressed.clear();
+        self.compressed.borrow_mut().clear();
+        self.dirty.set(false);
     }
 
     fn len(&self) -> usize {
-        self.compressed.len()
+        self.ensure_compressed();
+        self.compressed.borrow().len()
     }
 
     fn read(&mut self, buf: &mut [u8]) -> CompressorResult<usize> {
-        let len = self.compressed.len().min(buf.len());
-        buf[..len].copy_from_slice(&self.compressed[..len]);
+        self.ensure_compressed();
+        let compressed = self.compressed.borrow();
+        let len = compressed.len().min(buf.len());
+        buf[..len].copy_from_slice(&compressed[..len]);
         Ok(len)
     }
 }
 
 impl ChannelCompressor for ZlibCompressor {
     fn get_compressed(&self) -> Vec<u8> {
-        self.compressed.clone()
+        self.ensure_compressed();
+        self.compressed.borrow().clone()
     }
 }


### PR DESCRIPTION
## Summary

Both BrotliCompressor and ZlibCompressor previously re-compressed the entire accumulated raw buffer on every write() call, making channel filling O(N²) in the number of block writes; ShadowCompressor doubled this by running two such instances in parallel. This PR makes write() lazy by simply accumulating raw bytes and deferring compression to the first len(), get_compressed(), or read() call, using a dirty flag and a RefCell-backed cache to avoid redundant work. Subsequent queries return the cached result in O(1) until the next write invalidates it, reducing total compression work per channel to O(N). ShadowCompressor::flush() is updated to forward to both underlying compressors with a corrected comment reflecting the new semantics.