### PR TITLE
test(builder): add standalone build_block unit test with in-memory state

### DIFF
--- a/crates/builder/core/src/flashblocks/context.rs
+++ b/crates/builder/core/src/flashblocks/context.rs
@@ -4,7 +4,7 @@ use std::{sync::Arc, time::Instant};
 use alloy_consensus::{Eip658Value, Transaction};
 use alloy_eips::{Encodable2718, Typed2718};
 use alloy_evm::Database;
-use alloy_primitives::{BlockHash, Bytes, U256};
+use alloy_primitives::{B256, BlockHash, Bytes, U256};
 use alloy_rpc_types_eth::Withdrawals;
 use base_access_lists::FBALBuilderDb;
 use base_alloy_chains::BaseUpgrades;
@@ -967,6 +967,61 @@ impl OpPayloadBuilderCtx {
             ExecutionMeteringLimitExceeded::BlockStateRootTime(_, _, _) => {
                 BuilderMetrics::block_state_root_time_exceeded_total().increment(1);
             }
+        }
+    }
+}
+
+#[cfg(any(test, feature = "test-utils"))]
+impl OpPayloadBuilderCtx {
+    /// Creates a minimal [`OpPayloadBuilderCtx`] for unit tests.
+    ///
+    /// Derives the EVM environment from the given chain spec and parent header,
+    /// using default builder attributes and a no-op cancellation token.
+    pub fn for_test(
+        chain_spec: Arc<OpChainSpec>,
+        parent: Arc<SealedHeader>,
+    ) -> Self {
+        use reth_evm::ConfigureEvm;
+
+        let evm_config = OpEvmConfig::optimism(Arc::clone(&chain_spec));
+        let timestamp = parent.timestamp + 2;
+
+        let attributes = OpPayloadBuilderAttributes {
+            payload_attributes: reth_payload_builder::EthPayloadBuilderAttributes {
+                id: PayloadId::new([0; 8]),
+                parent: parent.hash(),
+                timestamp,
+                parent_beacon_block_root: Some(B256::ZERO),
+                ..Default::default()
+            },
+            gas_limit: Some(parent.gas_limit),
+            ..Default::default()
+        };
+
+        let block_env_attributes = OpNextBlockEnvAttributes {
+            timestamp,
+            suggested_fee_recipient: Default::default(),
+            prev_randao: Default::default(),
+            gas_limit: parent.gas_limit,
+            parent_beacon_block_root: None,
+            extra_data: Default::default(),
+        };
+
+        let evm_env = evm_config
+            .next_evm_env(&parent, &block_env_attributes)
+            .expect("failed to create test evm env");
+
+        let config = PayloadConfig::new(parent, attributes);
+
+        Self {
+            evm_config,
+            chain_spec,
+            config,
+            evm_env,
+            block_env_attributes,
+            cancel: CancellationToken::new(),
+            extra: FlashblocksExtraCtx::default(),
+            builder_config: crate::BuilderConfig::default(),
         }
     }
 }

--- a/crates/builder/core/src/flashblocks/context.rs
+++ b/crates/builder/core/src/flashblocks/context.rs
@@ -977,12 +977,7 @@ impl OpPayloadBuilderCtx {
     ///
     /// Derives the EVM environment from the given chain spec and parent header,
     /// using default builder attributes and a no-op cancellation token.
-    pub fn for_test(
-        chain_spec: Arc<OpChainSpec>,
-        parent: Arc<SealedHeader>,
-    ) -> Self {
-        use reth_evm::ConfigureEvm;
-
+    pub fn for_test(chain_spec: Arc<OpChainSpec>, parent: Arc<SealedHeader>) -> Self {
         let evm_config = OpEvmConfig::optimism(Arc::clone(&chain_spec));
         let timestamp = parent.timestamp + 2;
 
@@ -1003,7 +998,7 @@ impl OpPayloadBuilderCtx {
             suggested_fee_recipient: Default::default(),
             prev_randao: Default::default(),
             gas_limit: parent.gas_limit,
-            parent_beacon_block_root: None,
+            parent_beacon_block_root: Some(B256::ZERO),
             extra_data: Default::default(),
         };
 

--- a/crates/builder/core/src/flashblocks/payload.rs
+++ b/crates/builder/core/src/flashblocks/payload.rs
@@ -1197,7 +1197,7 @@ mod tests {
     use reth_provider::noop::NoopProvider;
     use reth_revm::{State, database::StateProviderDatabase};
 
-    use super::FlashblocksMetadata;
+    use super::{FlashblocksMetadata, build_block};
     use crate::{ExecutionInfo, flashblocks::context::OpPayloadBuilderCtx};
 
     /// Creates a minimal [`OpChainSpec`] with all L1 hardforks through Cancun
@@ -1214,22 +1214,15 @@ mod tests {
         });
         let genesis = serde_json::from_value(genesis).expect("valid genesis");
 
-        let inner = ChainSpec::builder()
-            .chain(901.into())
-            .genesis(genesis)
-            .cancun_activated()
-            .build();
+        let inner =
+            ChainSpec::builder().chain(901.into()).genesis(genesis).cancun_activated().build();
 
         Arc::new(OpChainSpec { inner })
     }
 
     /// Builds a sealed genesis header consistent with [`minimal_chain_spec`].
     fn genesis_header() -> Arc<SealedHeader> {
-        let header = Header {
-            gas_limit: 30_000_000,
-            timestamp: 0,
-            ..Default::default()
-        };
+        let header = Header { gas_limit: 30_000_000, timestamp: 0, ..Default::default() };
         Arc::new(SealedHeader::seal_slow(header))
     }
 
@@ -1241,8 +1234,6 @@ mod tests {
     /// no node, no disk, no network.
     #[test]
     fn build_block_empty_no_state_root() {
-        use super::build_block;
-
         let chain_spec = minimal_chain_spec();
         let parent = genesis_header();
         let ctx = OpPayloadBuilderCtx::for_test(chain_spec, Arc::clone(&parent));
@@ -1256,11 +1247,7 @@ mod tests {
                 .expect("build_block should succeed for an empty block");
 
         // Block number must be parent + 1.
-        assert_eq!(
-            payload.block().number,
-            parent.number + 1,
-            "block number should be parent + 1"
-        );
+        assert_eq!(payload.block().number, parent.number + 1, "block number should be parent + 1");
 
         // No transactions were executed, so gas used must be zero.
         assert_eq!(payload.block().gas_used, 0, "empty block should use zero gas");

--- a/crates/builder/core/src/flashblocks/payload.rs
+++ b/crates/builder/core/src/flashblocks/payload.rs
@@ -899,7 +899,7 @@ struct FlashblocksMetadata {
     access_list: Option<FlashblockAccessList>,
 }
 
-fn execute_pre_steps<DB>(
+pub(crate) fn execute_pre_steps<DB>(
     state: &mut State<DB>,
     ctx: &OpPayloadBuilderCtx,
 ) -> Result<ExecutionInfo, PayloadBuilderError>
@@ -918,7 +918,7 @@ where
     Ok(info)
 }
 
-pub(super) fn build_block<DB, P>(
+pub(crate) fn build_block<DB, P>(
     state: &mut State<DB>,
     ctx: &OpPayloadBuilderCtx,
     info: &mut ExecutionInfo,
@@ -1185,12 +1185,89 @@ where
 
 #[cfg(test)]
 mod tests {
-    use alloy_consensus::Receipt;
+    use std::sync::Arc;
+
+    use alloy_consensus::{Header, Receipt};
     use alloy_primitives::{Address, B256, Log, U256, map::foldhash::HashMap};
     use base_alloy_consensus::OpReceipt;
     use base_alloy_flashblocks::Metadata;
+    use base_execution_chainspec::OpChainSpec;
+    use reth_chainspec::ChainSpec;
+    use reth_primitives_traits::SealedHeader;
+    use reth_provider::noop::NoopProvider;
+    use reth_revm::{State, database::StateProviderDatabase};
 
     use super::FlashblocksMetadata;
+    use crate::{ExecutionInfo, flashblocks::context::OpPayloadBuilderCtx};
+
+    /// Creates a minimal [`OpChainSpec`] with all L1 hardforks through Cancun
+    /// active at genesis but **no** OP-specific hardforks (Bedrock, Canyon,
+    /// Ecotone, Holocene, Isthmus, Jovian are all absent).
+    ///
+    /// This keeps `build_block` on the simplest code paths: no blob fields,
+    /// default extra data, no withdrawals root calculation.
+    fn minimal_chain_spec() -> Arc<OpChainSpec> {
+        let genesis: serde_json::Value = serde_json::json!({
+            "config": { "chainId": 901 },
+            "gasLimit": "0x1C9C380",
+            "timestamp": "0x0"
+        });
+        let genesis = serde_json::from_value(genesis).expect("valid genesis");
+
+        let inner = ChainSpec::builder()
+            .chain(901.into())
+            .genesis(genesis)
+            .cancun_activated()
+            .build();
+
+        Arc::new(OpChainSpec { inner })
+    }
+
+    /// Builds a sealed genesis header consistent with [`minimal_chain_spec`].
+    fn genesis_header() -> Arc<SealedHeader> {
+        let header = Header {
+            gas_limit: 30_000_000,
+            timestamp: 0,
+            ..Default::default()
+        };
+        Arc::new(SealedHeader::seal_slow(header))
+    }
+
+    /// Verify that [`build_block`] produces a valid empty block when called
+    /// with no transactions and `calculate_state_root = false`.
+    ///
+    /// This exercises the full block-assembly path (receipts root, logs bloom,
+    /// header construction, flashblocks payload) using only in-memory state —
+    /// no node, no disk, no network.
+    #[test]
+    fn build_block_empty_no_state_root() {
+        use super::build_block;
+
+        let chain_spec = minimal_chain_spec();
+        let parent = genesis_header();
+        let ctx = OpPayloadBuilderCtx::for_test(chain_spec, Arc::clone(&parent));
+
+        let db = StateProviderDatabase::new(NoopProvider::default());
+        let mut state = State::builder().with_database(db).with_bundle_update().build();
+        let mut info = ExecutionInfo::default();
+
+        let (payload, fb_payload) =
+            build_block::<_, NoopProvider>(&mut state, &ctx, &mut info, false)
+                .expect("build_block should succeed for an empty block");
+
+        // Block number must be parent + 1.
+        assert_eq!(
+            payload.block().number,
+            parent.number + 1,
+            "block number should be parent + 1"
+        );
+
+        // No transactions were executed, so gas used must be zero.
+        assert_eq!(payload.block().gas_used, 0, "empty block should use zero gas");
+
+        // The flashblocks payload must reference the same block.
+        assert_eq!(fb_payload.diff.block_hash, payload.block().hash(), "hash mismatch");
+    }
 
     /// Pin the JSON field names and structure of [`FlashblocksMetadata`].
     ///

--- a/crates/builder/core/src/test_utils/instance.rs
+++ b/crates/builder/core/src/test_utils/instance.rs
@@ -296,7 +296,9 @@ pub fn default_node_config() -> NodeConfig<OpChainSpec> {
     node_config_with_chain_spec(chain_spec())
 }
 
-fn chain_spec() -> Arc<OpChainSpec> {
+/// Returns the default test chain spec, lazily initialized from the embedded
+/// genesis template.
+pub fn chain_spec() -> Arc<OpChainSpec> {
     static CHAIN_SPEC: LazyLock<Arc<OpChainSpec>> = LazyLock::new(|| {
         let genesis = include_str!("./artifacts/genesis.json.tmpl");
         let genesis = serde_json::from_str(genesis).expect("invalid genesis JSON");


### PR DESCRIPTION
## Summary

- Add `OpPayloadBuilderCtx::for_test(chain_spec, parent)` constructor behind `#[cfg(any(test, feature = "test-utils"))]` so the builder hot path can be tested without booting a full reth node
- Widen `build_block` and `execute_pre_steps` from `pub(super)` / private to `pub(crate)` so tests elsewhere in the crate can call them directly
- Expose `test_utils::instance::chain_spec()` as `pub` for reuse by test constructors
- Add `build_block_empty_no_state_root` test that verifies empty-block assembly (header, receipts root, flashblocks payload) using `State<StateProviderDatabase<NoopProvider>>` — no disk, no network, no `LocalInstance`

## Test plan

```
cargo test -p base-builder-core --lib
# 44 passed, 0 failed
cargo clippy -p base-builder-core --tests
# 0 warnings
```