### PR TITLE
fix(registrar): use isRegisteredSigner instead of isValidSigner for registration check

### DIFF
--- a/crates/proof/contracts/src/tee_prover_registry.rs
+++ b/crates/proof/contracts/src/tee_prover_registry.rs
@@ -22,8 +22,13 @@ sol! {
         /// Deregisters a signer.
         function deregisterSigner(address signer) external;
 
-        /// Returns `true` if the signer is currently registered.
+        /// Returns `true` if the signer is registered AND its image hash matches
+        /// the contract's current expected image hash.
         function isValidSigner(address signer) external view returns (bool);
+
+        /// Returns `true` if the signer has been registered, regardless of
+        /// whether its image hash matches the current expected value.
+        function isRegisteredSigner(address signer) external view returns (bool);
 
         /// Returns all currently registered signer addresses.
         function getRegisteredSigners() external view returns (address[]);
@@ -33,8 +38,13 @@ sol! {
 /// Reads registration state from the on-chain `TEEProverRegistry`.
 #[async_trait]
 pub trait TEEProverRegistryClient: Send + Sync {
-    /// Returns `true` if `signer` is currently registered on-chain.
+    /// Returns `true` if `signer` is registered AND its image hash matches
+    /// the contract's current expected image hash.
     async fn is_valid_signer(&self, signer: Address) -> Result<bool, ContractError>;
+
+    /// Returns `true` if `signer` has been registered, regardless of whether
+    /// its image hash matches the current expected value.
+    async fn is_registered_signer(&self, signer: Address) -> Result<bool, ContractError>;
 
     /// Fetches the complete set of registered signer addresses.
     async fn get_registered_signers(&self) -> Result<Vec<Address>, ContractError>;
@@ -60,6 +70,13 @@ impl TEEProverRegistryClient for TEEProverRegistryContractClient {
     async fn is_valid_signer(&self, signer: Address) -> Result<bool, ContractError> {
         self.contract.isValidSigner(signer).call().await.map_err(|e| ContractError::Call {
             context: format!("isValidSigner({signer})"),
+            source: e,
+        })
+    }
+
+    async fn is_registered_signer(&self, signer: Address) -> Result<bool, ContractError> {
+        self.contract.isRegisteredSigner(signer).call().await.map_err(|e| ContractError::Call {
+            context: format!("isRegisteredSigner({signer})"),
             source: e,
         })
     }
@@ -105,6 +122,7 @@ mod tests {
         assert_ne!(ITEEProverRegistry::registerSignerCall::SELECTOR, [0u8; 4]);
         assert_ne!(ITEEProverRegistry::deregisterSignerCall::SELECTOR, [0u8; 4]);
         assert_ne!(ITEEProverRegistry::isValidSignerCall::SELECTOR, [0u8; 4]);
+        assert_ne!(ITEEProverRegistry::isRegisteredSignerCall::SELECTOR, [0u8; 4]);
         assert_ne!(ITEEProverRegistry::getRegisteredSignersCall::SELECTOR, [0u8; 4]);
     }
 }

--- a/crates/proof/tee/registrar/src/registry.rs
+++ b/crates/proof/tee/registrar/src/registry.rs
@@ -50,7 +50,7 @@ fn map_contract_error(e: ContractError) -> RegistrarError {
 #[async_trait]
 impl RegistryClient for RegistryContractClient {
     async fn is_registered(&self, signer: Address) -> Result<bool> {
-        self.inner.is_valid_signer(signer).await.map_err(map_contract_error)
+        self.inner.is_registered_signer(signer).await.map_err(map_contract_error)
     }
 
     async fn get_registered_signers(&self) -> Result<Vec<Address>> {


### PR DESCRIPTION
## Summary

- Fixes an infinite re-registration loop in the TEE Prover Registrar caused by `is_registered()` calling the contract's `isValidSigner()` instead of `isRegisteredSigner()`
- `isValidSigner()` checks both registration status **and** PCR0 image hash match — when the enclave's PCR0 hash differs from the contract's `TEE_IMAGE_HASH`, it returns `false` for already-registered signers, triggering wasteful proof re-generation every ~17 minutes
- Switches to `isRegisteredSigner()` which only checks whether the signer is registered, breaking the loop

## Details

**Root cause:** The Solidity `isValidSigner(address)` function on `TEEProverRegistry` checks:
1. `isRegisteredSigner[signer]` — is the signer registered?
2. `signerImageHash[signer] == _getExpectedImageHash()` — does the signer's PCR0 hash match the contract's current `TEE_IMAGE_HASH`?

When the contract's `TEE_IMAGE_HASH` is updated but existing signers still have their old PCR0 hash, `isValidSigner` returns `false` even though the signer is registered. This caused the registrar to enter an infinite loop: generate proof (~15 min) → register (succeeds, but signer already registered) → check `isValidSigner` → returns `false` → generate proof again → repeat.

**Evidence:** On Sepolia, 4 signers were registered on `TEEProverRegistry` (`0x460a...`). Two had matching PCR0 hashes (`isValidSigner=true`), and two had mismatched hashes (`isValidSigner=false`, `isRegisteredSigner=true`). The latter two were re-registered multiple times (blocks 10555829, 10555832, 10555947).

**Fix:** Added `isRegisteredSigner(address)` to the `TEEProverRegistryClient` trait and `sol!` interface, and changed `RegistryContractClient::is_registered()` to call it instead of `is_valid_signer()`.

## Changes

- `crates/proof/contracts/src/tee_prover_registry.rs` — Added `isRegisteredSigner` to sol! interface, trait, and implementation
- `crates/proof/tee/registrar/src/registry.rs` — Changed `is_registered` to call `is_registered_signer` instead of `is_valid_signer`