### PR TITLE
Fix grammar in bridge integration spec

### DIFF
--- a/docs/specs/pages/protocol/fault-proof/stage-one/bridge-integration.md
+++ b/docs/specs/pages/protocol/fault-proof/stage-one/bridge-integration.md
@@ -189,7 +189,7 @@ See ["Air-gap"](#air-gap)
 #### Changed Invariants - `finalizeWithdrawalTransaction`
 
 **Output Proposal Validity**
-Instead of checking if the proven withdrawal's output proposal has existed for longer the legacy finalization period,
+Instead of checking if the proven withdrawal's output proposal has existed for longer than the legacy finalization period,
 we check if the dispute game has resolved in the root claim's favor. A `FaultDisputeGame` must never be considered to
 have resolved in the `rootClaim`'s favor unless its `status()` is equal to `DEFENDER_WINS`.
 


### PR DESCRIPTION
Added missing `than` in comparison (“longer than”) to fix a grammatically incorrect phrase where the original wording broke the intended meaning.