### PR TITLE
chore(workspace): Remove Cross Unsafe Head

### DIFF
--- a/crates/consensus/engine/src/metrics/mod.rs
+++ b/crates/consensus/engine/src/metrics/mod.rs
@@ -33,8 +33,6 @@ base_metrics::define_metrics! {
 impl Metrics {
     /// Unsafe block label.
     pub const UNSAFE_BLOCK_LABEL: &str = "unsafe";
-    /// Cross-unsafe block label.
-    pub const CROSS_UNSAFE_BLOCK_LABEL: &str = "cross-unsafe";
     /// Local-safe block label.
     pub const LOCAL_SAFE_BLOCK_LABEL: &str = "local-safe";
     /// Safe block label.

--- a/crates/consensus/engine/src/state/core.rs
+++ b/crates/consensus/engine/src/state/core.rs
@@ -17,18 +17,15 @@ use crate::Metrics;
 /// The state tracks blocks at different safety levels, listed from least to most safe:
 ///
 /// 1. **Unsafe** - Most recent blocks from P2P network (unverified)
-/// 2. **Cross-unsafe** - Unsafe blocks with cross-layer verification
-/// 3. **Local-safe** - Derived from L1 data, completed span-batch
-/// 4. **Safe** - Cross-verified with safe L1 dependencies
-/// 5. **Finalized** - Derived from finalized L1 data only
+/// 2. **Local-safe** - Derived from L1 data, completed span-batch
+/// 3. **Safe** - Derived from L1 data and cross-verified to have safe L1 dependencies
+/// 4. **Finalized** - Derived from finalized L1 data only
 ///
 /// See the [Base specifications](https://specs.optimism.io) for detailed safety definitions.
 #[derive(Default, Debug, Copy, Clone, PartialEq, Eq)]
 pub struct EngineSyncState {
     /// Most recent block found on the P2P network (lowest safety level).
     unsafe_head: L2BlockInfo,
-    /// Cross-verified unsafe head.
-    cross_unsafe_head: L2BlockInfo,
     /// Derived from L1 data as a completed span-batch, but not yet cross-verified.
     local_safe_head: L2BlockInfo,
     /// Derived from L1 data and cross-verified to have safe L1 dependencies.
@@ -41,11 +38,6 @@ impl EngineSyncState {
     /// Returns the current unsafe head.
     pub const fn unsafe_head(&self) -> L2BlockInfo {
         self.unsafe_head
-    }
-
-    /// Returns the current cross-verified unsafe head.
-    pub const fn cross_unsafe_head(&self) -> L2BlockInfo {
-        self.cross_unsafe_head
     }
 
     /// Returns the current local safe head.
@@ -85,10 +77,6 @@ impl EngineSyncState {
             Metrics::block_labels(Metrics::UNSAFE_BLOCK_LABEL)
                 .set(unsafe_head.block_info.number as f64);
         }
-        if let Some(cross_unsafe_head) = sync_state_update.cross_unsafe_head {
-            Metrics::block_labels(Metrics::CROSS_UNSAFE_BLOCK_LABEL)
-                .set(cross_unsafe_head.block_info.number as f64);
-        }
         if let Some(local_safe_head) = sync_state_update.local_safe_head {
             Metrics::block_labels(Metrics::LOCAL_SAFE_BLOCK_LABEL)
                 .set(local_safe_head.block_info.number as f64);
@@ -104,9 +92,6 @@ impl EngineSyncState {
 
         Self {
             unsafe_head: sync_state_update.unsafe_head.unwrap_or(self.unsafe_head),
-            cross_unsafe_head: sync_state_update
-                .cross_unsafe_head
-                .unwrap_or(self.cross_unsafe_head),
             local_safe_head: sync_state_update.local_safe_head.unwrap_or(self.local_safe_head),
             safe_head: sync_state_update.safe_head.unwrap_or(self.safe_head),
             finalized_head: sync_state_update.finalized_head.unwrap_or(self.finalized_head),
@@ -119,8 +104,6 @@ impl EngineSyncState {
 pub struct EngineSyncStateUpdate {
     /// Most recent block found on the p2p network
     pub unsafe_head: Option<L2BlockInfo>,
-    /// Cross-verified unsafe head
-    pub cross_unsafe_head: Option<L2BlockInfo>,
     /// Derived from L1, and known to be a completed span-batch,
     /// but not cross-verified yet.
     pub local_safe_head: Option<L2BlockInfo>,
@@ -181,14 +164,6 @@ mod tests {
             });
         }
 
-        /// Set the cross-verified unsafe head.
-        pub fn set_cross_unsafe_head(&mut self, cross_unsafe_head: L2BlockInfo) {
-            self.sync_state = self.sync_state.apply_update(EngineSyncStateUpdate {
-                cross_unsafe_head: Some(cross_unsafe_head),
-                ..Default::default()
-            });
-        }
-
         /// Set the local safe head.
         pub fn set_local_safe_head(&mut self, local_safe_head: L2BlockInfo) {
             self.sync_state = self.sync_state.apply_update(EngineSyncStateUpdate {
@@ -216,14 +191,9 @@ mod tests {
 
     #[rstest]
     #[case::set_unsafe(EngineState::set_unsafe_head, Metrics::UNSAFE_BLOCK_LABEL, 1)]
-    #[case::set_cross_unsafe(
-        EngineState::set_cross_unsafe_head,
-        Metrics::CROSS_UNSAFE_BLOCK_LABEL,
-        2
-    )]
-    #[case::set_local_safe(EngineState::set_local_safe_head, Metrics::LOCAL_SAFE_BLOCK_LABEL, 3)]
-    #[case::set_safe_head(EngineState::set_safe_head, Metrics::SAFE_BLOCK_LABEL, 4)]
-    #[case::set_finalized_head(EngineState::set_finalized_head, Metrics::FINALIZED_BLOCK_LABEL, 5)]
+    #[case::set_local_safe(EngineState::set_local_safe_head, Metrics::LOCAL_SAFE_BLOCK_LABEL, 2)]
+    #[case::set_safe_head(EngineState::set_safe_head, Metrics::SAFE_BLOCK_LABEL, 3)]
+    #[case::set_finalized_head(EngineState::set_finalized_head, Metrics::FINALIZED_BLOCK_LABEL, 4)]
     #[cfg(feature = "metrics")]
     fn test_chain_label_metrics(
         #[case] set_fn: impl Fn(&mut EngineState, L2BlockInfo),

--- a/crates/consensus/engine/src/task_queue/core.rs
+++ b/crates/consensus/engine/src/task_queue/core.rs
@@ -90,7 +90,6 @@ impl<EngineClient_: EngineClient> Engine<EngineClient_> {
             Arc::clone(&config),
             EngineSyncStateUpdate {
                 unsafe_head: Some(start.un_safe),
-                cross_unsafe_head: Some(start.un_safe),
                 local_safe_head: Some(start.safe),
                 safe_head: Some(start.safe),
                 finalized_head: Some(start.finalized),
@@ -273,7 +272,6 @@ mod tests {
         let mut engine = Engine::new(EngineState::default(), state_tx, queue_tx);
         let update = EngineSyncStateUpdate {
             unsafe_head: Some(head),
-            cross_unsafe_head: Some(head),
             local_safe_head: Some(safe),
             safe_head: Some(safe),
             finalized_head: Some(finalized),
@@ -333,11 +331,7 @@ mod tests {
             test_engine_client_builder().with_fork_choice_updated_v3_response(valid_fcu()).build(),
         );
 
-        let update = EngineSyncStateUpdate {
-            unsafe_head: Some(head),
-            cross_unsafe_head: Some(head),
-            ..Default::default()
-        };
+        let update = EngineSyncStateUpdate { unsafe_head: Some(head), ..Default::default() };
 
         let mut engine = Engine::new(EngineState::default(), state_tx, queue_tx);
         engine.seed_state(update); // seed first — the wrong order

--- a/crates/consensus/engine/src/task_queue/tasks/consolidate/task.rs
+++ b/crates/consensus/engine/src/task_queue/tasks/consolidate/task.rs
@@ -117,16 +117,15 @@ impl<EngineClient_: EngineClient> ConsolidateTask<EngineClient_> {
 
         let fcu_start = Instant::now();
 
-        // We intentionally set unsafe_head and cross_unsafe_head to safe_l2 to ensure the
-        // engine observes a self-consistent head state. This is required to correctly handle
-        // reorgs (where unsafe may be ahead on a non-canonical fork) and to trigger EL sync when
-        // the local unsafe head lags behind the safe head.
+        // We intentionally set unsafe_head to safe_l2 to ensure the engine observes a
+        // self-consistent head state. This is required to correctly handle reorgs (where unsafe
+        // may be ahead on a non-canonical fork) and to trigger EL sync when the local unsafe head
+        // lags behind the safe head.
         SynchronizeTask::new(
             Arc::clone(&self.client),
             Arc::clone(&self.cfg),
             EngineSyncStateUpdate {
                 unsafe_head: Some(*safe_l2),
-                cross_unsafe_head: Some(*safe_l2),
                 safe_head: Some(*safe_l2),
                 local_safe_head: Some(*safe_l2),
                 ..Default::default()

--- a/crates/consensus/engine/src/task_queue/tasks/insert/task.rs
+++ b/crates/consensus/engine/src/task_queue/tasks/insert/task.rs
@@ -131,7 +131,6 @@ impl<EngineClient_: EngineClient> EngineTaskExt for InsertTask<EngineClient_> {
             Arc::clone(&self.client),
             Arc::clone(&self.rollup_config),
             EngineSyncStateUpdate {
-                cross_unsafe_head: Some(new_unsafe_ref),
                 unsafe_head: Some(new_unsafe_ref),
                 local_safe_head: self.is_payload_safe.then_some(new_unsafe_ref),
                 safe_head: self.is_payload_safe.then_some(new_unsafe_ref),

--- a/crates/consensus/engine/src/test_utils/engine_state.rs
+++ b/crates/consensus/engine/src/test_utils/engine_state.rs
@@ -8,7 +8,6 @@ use crate::{EngineState, EngineSyncStateUpdate};
 #[derive(Debug)]
 pub struct TestEngineStateBuilder {
     unsafe_head: L2BlockInfo,
-    cross_unsafe_head: Option<L2BlockInfo>,
     local_safe_head: Option<L2BlockInfo>,
     safe_head: Option<L2BlockInfo>,
     finalized_head: Option<L2BlockInfo>,
@@ -32,7 +31,6 @@ impl TestEngineStateBuilder {
 
         Self {
             unsafe_head: genesis,
-            cross_unsafe_head: None,
             local_safe_head: None,
             safe_head: None,
             finalized_head: None,
@@ -43,13 +41,6 @@ impl TestEngineStateBuilder {
     /// Sets the unsafe head
     pub const fn with_unsafe_head(mut self, block: L2BlockInfo) -> Self {
         self.unsafe_head = block;
-        self
-    }
-
-    /// Sets the cross-unsafe head
-    #[allow(dead_code)]
-    pub const fn with_cross_unsafe_head(mut self, block: L2BlockInfo) -> Self {
-        self.cross_unsafe_head = Some(block);
         self
     }
 
@@ -79,7 +70,6 @@ impl TestEngineStateBuilder {
         // Set unsafe head (required)
         state.sync_state = state.sync_state.apply_update(EngineSyncStateUpdate {
             unsafe_head: Some(self.unsafe_head),
-            cross_unsafe_head: Some(self.cross_unsafe_head.unwrap_or(self.unsafe_head)),
             local_safe_head: Some(self.local_safe_head.unwrap_or(self.unsafe_head)),
             safe_head: Some(self.safe_head.unwrap_or(self.unsafe_head)),
             finalized_head: Some(self.finalized_head.unwrap_or(self.unsafe_head)),

--- a/crates/consensus/protocol/src/sync.rs
+++ b/crates/consensus/protocol/src/sync.rs
@@ -40,28 +40,20 @@ pub struct SyncStatus {
     /// This is the absolute tip of the L2 chain, pointing to block data that has not been
     /// submitted to L1 yet. The sequencer is building this, and verifiers may also be ahead of
     /// the safe L2 block if they sync blocks via p2p or other offchain sources.
-    /// This is considered to only be local-unsafe, see `cross_unsafe_l2` for cross-L2
-    /// guarantees.
     pub unsafe_l2: L2BlockInfo,
     /// The safe L2 block ref.
     ///
     /// This points to the L2 block that was derived from the L1 chain.
     /// This point may still reorg if the L1 chain reorgs.
-    /// This is considered to be cross-safe, see `local_safe_l2` to ignore cross-L2
-    /// guarantees.
     pub safe_l2: L2BlockInfo,
     /// The finalized L2 block ref.
     ///
     /// This points to the L2 block that was derived fully from finalized L1 information, thus
     /// irreversible.
     pub finalized_l2: L2BlockInfo,
-    /// Cross unsafe L2 block ref.
-    ///
-    /// This is an unsafe L2 block, that has been verified to match cross-L2 dependencies.
-    pub cross_unsafe_l2: L2BlockInfo,
     /// Local safe L2 block ref.
     ///
-    /// This is an L2 block derived from L1, not yet verified to have valid cross-L2 dependencies.
+    /// This is an L2 block derived from L1, not yet cross-verified.
     pub local_safe_l2: L2BlockInfo,
 }
 
@@ -123,7 +115,6 @@ mod tests {
             ),
             safe_l2: L2BlockInfo::default(),
             finalized_l2: L2BlockInfo::default(),
-            cross_unsafe_l2: L2BlockInfo::default(),
             local_safe_l2: L2BlockInfo::default(),
         };
 

--- a/crates/consensus/rpc/src/rollup.rs
+++ b/crates/consensus/rpc/src/rollup.rs
@@ -57,7 +57,6 @@ impl<EngineRpcClient_: EngineRpcClient> RollupRpc<EngineRpcClient_> {
             safe_l1: l1_sync_status.safe_l1.unwrap_or_default(),
             finalized_l1: l1_sync_status.finalized_l1.unwrap_or_default(),
             unsafe_l2: l2_sync_status.sync_state.unsafe_head(),
-            cross_unsafe_l2: l2_sync_status.sync_state.cross_unsafe_head(),
             local_safe_l2: l2_sync_status.sync_state.local_safe_head(),
             safe_l2: l2_sync_status.sync_state.safe_head(),
             finalized_l2: l2_sync_status.sync_state.finalized_head(),

--- a/crates/consensus/service/src/actors/engine/engine_request_processor.rs
+++ b/crates/consensus/service/src/actors/engine/engine_request_processor.rs
@@ -320,7 +320,6 @@ where
                 // do nothing, leaving el_sync_finished = false permanently.
                 let probe_update = EngineSyncStateUpdate {
                     unsafe_head: Some(head),
-                    cross_unsafe_head: Some(head),
                     local_safe_head: Some(safe),
                     safe_head: Some(safe),
                     finalized_head: Some(finalized),


### PR DESCRIPTION
## Summary

Removes `cross_unsafe_head` from the engine state machine, sync status types, RPC surface, and all associated metrics. This field was scaffolding for the OP interop supervisor — a feature that was abandoned and never implemented in the Base stack. The field was always set identically to `unsafe_head` and never gated any engine decision, making it dead code.

The `op_syncStatus` RPC response no longer includes `cross_unsafe_l2`. All other behavior is unchanged.

> [!WARNING]
> **Breaking change:** The `cross_unsafe_l2` field is removed from the `op_syncStatus` JSON response. Clients or dashboards reading this field will need to be updated.