### PR TITLE
chore(workspace): Remove Local Safe Head

### DIFF
--- a/crates/consensus/engine/src/metrics/mod.rs
+++ b/crates/consensus/engine/src/metrics/mod.rs
@@ -33,8 +33,6 @@ base_metrics::define_metrics! {
 impl Metrics {
     /// Unsafe block label.
     pub const UNSAFE_BLOCK_LABEL: &str = "unsafe";
-    /// Local-safe block label.
-    pub const LOCAL_SAFE_BLOCK_LABEL: &str = "local-safe";
     /// Safe block label.
     pub const SAFE_BLOCK_LABEL: &str = "safe";
     /// Finalized block label.

--- a/crates/consensus/engine/src/state/core.rs
+++ b/crates/consensus/engine/src/state/core.rs
@@ -17,18 +17,15 @@ use crate::Metrics;
 /// The state tracks blocks at different safety levels, listed from least to most safe:
 ///
 /// 1. **Unsafe** - Most recent blocks from P2P network (unverified)
-/// 2. **Local-safe** - Derived from L1 data, completed span-batch
-/// 3. **Safe** - Derived from L1 data and cross-verified to have safe L1 dependencies
-/// 4. **Finalized** - Derived from finalized L1 data only
+/// 2. **Safe** - Derived from L1 data
+/// 3. **Finalized** - Derived from finalized L1 data only
 ///
 /// See the [Base specifications](https://specs.optimism.io) for detailed safety definitions.
 #[derive(Default, Debug, Copy, Clone, PartialEq, Eq)]
 pub struct EngineSyncState {
     /// Most recent block found on the P2P network (lowest safety level).
     unsafe_head: L2BlockInfo,
-    /// Derived from L1 data as a completed span-batch, but not yet cross-verified.
-    local_safe_head: L2BlockInfo,
-    /// Derived from L1 data and cross-verified to have safe L1 dependencies.
+    /// Derived from L1 data.
     safe_head: L2BlockInfo,
     /// Derived from finalized L1 data with only finalized dependencies (highest safety level).
     finalized_head: L2BlockInfo,
@@ -38,11 +35,6 @@ impl EngineSyncState {
     /// Returns the current unsafe head.
     pub const fn unsafe_head(&self) -> L2BlockInfo {
         self.unsafe_head
-    }
-
-    /// Returns the current local safe head.
-    pub const fn local_safe_head(&self) -> L2BlockInfo {
-        self.local_safe_head
     }
 
     /// Returns the current safe head.
@@ -77,10 +69,6 @@ impl EngineSyncState {
             Metrics::block_labels(Metrics::UNSAFE_BLOCK_LABEL)
                 .set(unsafe_head.block_info.number as f64);
         }
-        if let Some(local_safe_head) = sync_state_update.local_safe_head {
-            Metrics::block_labels(Metrics::LOCAL_SAFE_BLOCK_LABEL)
-                .set(local_safe_head.block_info.number as f64);
-        }
         if let Some(safe_head) = sync_state_update.safe_head {
             Metrics::block_labels(Metrics::SAFE_BLOCK_LABEL)
                 .set(safe_head.block_info.number as f64);
@@ -92,7 +80,6 @@ impl EngineSyncState {
 
         Self {
             unsafe_head: sync_state_update.unsafe_head.unwrap_or(self.unsafe_head),
-            local_safe_head: sync_state_update.local_safe_head.unwrap_or(self.local_safe_head),
             safe_head: sync_state_update.safe_head.unwrap_or(self.safe_head),
             finalized_head: sync_state_update.finalized_head.unwrap_or(self.finalized_head),
         }
@@ -104,13 +91,9 @@ impl EngineSyncState {
 pub struct EngineSyncStateUpdate {
     /// Most recent block found on the p2p network
     pub unsafe_head: Option<L2BlockInfo>,
-    /// Derived from L1, and known to be a completed span-batch,
-    /// but not cross-verified yet.
-    pub local_safe_head: Option<L2BlockInfo>,
-    /// Derived from L1 and cross-verified to have cross-safe dependencies.
+    /// Derived from L1 data.
     pub safe_head: Option<L2BlockInfo>,
-    /// Derived from finalized L1 data,
-    /// and cross-verified to only have finalized dependencies.
+    /// Derived from finalized L1 data.
     pub finalized_head: Option<L2BlockInfo>,
 }
 
@@ -164,14 +147,6 @@ mod tests {
             });
         }
 
-        /// Set the local safe head.
-        pub fn set_local_safe_head(&mut self, local_safe_head: L2BlockInfo) {
-            self.sync_state = self.sync_state.apply_update(EngineSyncStateUpdate {
-                local_safe_head: Some(local_safe_head),
-                ..Default::default()
-            });
-        }
-
         /// Set the safe head.
         pub fn set_safe_head(&mut self, safe_head: L2BlockInfo) {
             self.sync_state = self.sync_state.apply_update(EngineSyncStateUpdate {
@@ -191,9 +166,8 @@ mod tests {
 
     #[rstest]
     #[case::set_unsafe(EngineState::set_unsafe_head, Metrics::UNSAFE_BLOCK_LABEL, 1)]
-    #[case::set_local_safe(EngineState::set_local_safe_head, Metrics::LOCAL_SAFE_BLOCK_LABEL, 2)]
-    #[case::set_safe_head(EngineState::set_safe_head, Metrics::SAFE_BLOCK_LABEL, 3)]
-    #[case::set_finalized_head(EngineState::set_finalized_head, Metrics::FINALIZED_BLOCK_LABEL, 4)]
+    #[case::set_safe_head(EngineState::set_safe_head, Metrics::SAFE_BLOCK_LABEL, 2)]
+    #[case::set_finalized_head(EngineState::set_finalized_head, Metrics::FINALIZED_BLOCK_LABEL, 3)]
     #[cfg(feature = "metrics")]
     fn test_chain_label_metrics(
         #[case] set_fn: impl Fn(&mut EngineState, L2BlockInfo),

--- a/crates/consensus/engine/src/task_queue/core.rs
+++ b/crates/consensus/engine/src/task_queue/core.rs
@@ -90,7 +90,6 @@ impl<EngineClient_: EngineClient> Engine<EngineClient_> {
             Arc::clone(&config),
             EngineSyncStateUpdate {
                 unsafe_head: Some(start.un_safe),
-                local_safe_head: Some(start.safe),
                 safe_head: Some(start.safe),
                 finalized_head: Some(start.finalized),
             },
@@ -272,7 +271,6 @@ mod tests {
         let mut engine = Engine::new(EngineState::default(), state_tx, queue_tx);
         let update = EngineSyncStateUpdate {
             unsafe_head: Some(head),
-            local_safe_head: Some(safe),
             safe_head: Some(safe),
             finalized_head: Some(finalized),
         };

--- a/crates/consensus/engine/src/task_queue/tasks/consolidate/task.rs
+++ b/crates/consensus/engine/src/task_queue/tasks/consolidate/task.rs
@@ -127,7 +127,6 @@ impl<EngineClient_: EngineClient> ConsolidateTask<EngineClient_> {
             EngineSyncStateUpdate {
                 unsafe_head: Some(*safe_l2),
                 safe_head: Some(*safe_l2),
-                local_safe_head: Some(*safe_l2),
                 ..Default::default()
             },
         )
@@ -207,7 +206,6 @@ impl<EngineClient_: EngineClient> ConsolidateTask<EngineClient_> {
                     // Apply a transient update to the safe head.
                     state.sync_state = state.sync_state.apply_update(EngineSyncStateUpdate {
                         safe_head: Some(block_info),
-                        local_safe_head: Some(block_info),
                         ..Default::default()
                     });
 
@@ -228,11 +226,7 @@ impl<EngineClient_: EngineClient> ConsolidateTask<EngineClient_> {
                     SynchronizeTask::new(
                         Arc::clone(&self.client),
                         Arc::clone(&self.cfg),
-                        EngineSyncStateUpdate {
-                            safe_head: Some(block_info),
-                            local_safe_head: Some(block_info),
-                            ..Default::default()
-                        },
+                        EngineSyncStateUpdate { safe_head: Some(block_info), ..Default::default() },
                     )
                     .execute(state)
                     .await

--- a/crates/consensus/engine/src/task_queue/tasks/insert/task.rs
+++ b/crates/consensus/engine/src/task_queue/tasks/insert/task.rs
@@ -132,7 +132,6 @@ impl<EngineClient_: EngineClient> EngineTaskExt for InsertTask<EngineClient_> {
             Arc::clone(&self.rollup_config),
             EngineSyncStateUpdate {
                 unsafe_head: Some(new_unsafe_ref),
-                local_safe_head: self.is_payload_safe.then_some(new_unsafe_ref),
                 safe_head: self.is_payload_safe.then_some(new_unsafe_ref),
                 ..Default::default()
             },

--- a/crates/consensus/engine/src/test_utils/engine_state.rs
+++ b/crates/consensus/engine/src/test_utils/engine_state.rs
@@ -8,7 +8,6 @@ use crate::{EngineState, EngineSyncStateUpdate};
 #[derive(Debug)]
 pub struct TestEngineStateBuilder {
     unsafe_head: L2BlockInfo,
-    local_safe_head: Option<L2BlockInfo>,
     safe_head: Option<L2BlockInfo>,
     finalized_head: Option<L2BlockInfo>,
     el_sync_finished: bool,
@@ -29,13 +28,7 @@ impl TestEngineStateBuilder {
             seq_num: 0,
         };
 
-        Self {
-            unsafe_head: genesis,
-            local_safe_head: None,
-            safe_head: None,
-            finalized_head: None,
-            el_sync_finished: true,
-        }
+        Self { unsafe_head: genesis, safe_head: None, finalized_head: None, el_sync_finished: true }
     }
 
     /// Sets the unsafe head
@@ -67,10 +60,8 @@ impl TestEngineStateBuilder {
     pub fn build(self) -> EngineState {
         let mut state = EngineState::default();
 
-        // Set unsafe head (required)
         state.sync_state = state.sync_state.apply_update(EngineSyncStateUpdate {
             unsafe_head: Some(self.unsafe_head),
-            local_safe_head: Some(self.local_safe_head.unwrap_or(self.unsafe_head)),
             safe_head: Some(self.safe_head.unwrap_or(self.unsafe_head)),
             finalized_head: Some(self.finalized_head.unwrap_or(self.unsafe_head)),
         });

--- a/crates/consensus/protocol/src/sync.rs
+++ b/crates/consensus/protocol/src/sync.rs
@@ -51,10 +51,6 @@ pub struct SyncStatus {
     /// This points to the L2 block that was derived fully from finalized L1 information, thus
     /// irreversible.
     pub finalized_l2: L2BlockInfo,
-    /// Local safe L2 block ref.
-    ///
-    /// This is an L2 block derived from L1, not yet cross-verified.
-    pub local_safe_l2: L2BlockInfo,
 }
 
 #[cfg(test)]
@@ -115,7 +111,6 @@ mod tests {
             ),
             safe_l2: L2BlockInfo::default(),
             finalized_l2: L2BlockInfo::default(),
-            local_safe_l2: L2BlockInfo::default(),
         };
 
         let json = serde_json::to_string(&status).unwrap();

--- a/crates/consensus/rpc/src/rollup.rs
+++ b/crates/consensus/rpc/src/rollup.rs
@@ -57,7 +57,6 @@ impl<EngineRpcClient_: EngineRpcClient> RollupRpc<EngineRpcClient_> {
             safe_l1: l1_sync_status.safe_l1.unwrap_or_default(),
             finalized_l1: l1_sync_status.finalized_l1.unwrap_or_default(),
             unsafe_l2: l2_sync_status.sync_state.unsafe_head(),
-            local_safe_l2: l2_sync_status.sync_state.local_safe_head(),
             safe_l2: l2_sync_status.sync_state.safe_head(),
             finalized_l2: l2_sync_status.sync_state.finalized_head(),
         }

--- a/crates/consensus/service/src/actors/engine/engine_request_processor.rs
+++ b/crates/consensus/service/src/actors/engine/engine_request_processor.rs
@@ -320,7 +320,6 @@ where
                 // do nothing, leaving el_sync_finished = false permanently.
                 let probe_update = EngineSyncStateUpdate {
                     unsafe_head: Some(head),
-                    local_safe_head: Some(safe),
                     safe_head: Some(safe),
                     finalized_head: Some(finalized),
                 };


### PR DESCRIPTION
## Summary

Removes `local_safe_head ` from the engine state machine, sync status types, RPC surface, and all associated metrics. This field was scaffolding for the OP interop supervisor — a feature that was abandoned and never implemented in the Base stack. The field was always set identically to `safe_head` and never gated any engine decision, making it dead code.

The `op_syncStatus` RPC response no longer includes `local_safe_head `. All other behavior is unchanged.

> [!WARNING]
> **Breaking change:** The `local_safe_head ` field is removed from the `op_syncStatus` JSON response. Clients or dashboards reading this field will need to be updated.