### PR TITLE
feat(builder): replace state root time budgets with state root gas

### DIFF
--- a/bin/builder/src/cli.rs
+++ b/bin/builder/src/cli.rs
@@ -46,7 +46,7 @@ impl Default for FlashblocksArgs {
 }
 
 /// Parameters for rollup configuration
-#[derive(Debug, Clone, PartialEq, Eq, clap::Args)]
+#[derive(Debug, Clone, clap::Args)]
 #[command(next_help_heading = "Rollup")]
 pub struct Args {
     /// Rollup configuration
@@ -65,17 +65,21 @@ pub struct Args {
     #[arg(long = "builder.max-execution-time-per-tx-us")]
     pub max_execution_time_per_tx_us: Option<u128>,
 
-    /// Maximum state root calculation time per transaction in microseconds (requires resource metering)
-    #[arg(long = "builder.max-state-root-time-per-tx-us")]
-    pub max_state_root_time_per_tx_us: Option<u128>,
-
     /// Flashblock-level execution time budget in microseconds (requires resource metering)
     #[arg(long = "builder.flashblock-execution-time-budget-us")]
     pub flashblock_execution_time_budget_us: Option<u128>,
 
-    /// Block-level state root calculation time budget in microseconds (requires resource metering)
-    #[arg(long = "builder.block-state-root-time-budget-us")]
-    pub block_state_root_time_budget_us: Option<u128>,
+    /// Block-level state root gas limit (requires resource metering)
+    #[arg(long = "builder.block-state-root-gas-limit")]
+    pub block_state_root_gas_limit: Option<u64>,
+
+    /// State root gas coefficient (K): controls how excess SR time inflates `sr_gas` cost
+    #[arg(long = "builder.state-root-gas-coefficient", default_value = "0.02")]
+    pub state_root_gas_coefficient: f64,
+
+    /// State root gas anchor in microseconds: SR below this produces no penalty
+    #[arg(long = "builder.state-root-gas-anchor-us", default_value = "5000")]
+    pub state_root_gas_anchor_us: u128,
 
     /// Execution metering mode: off, dry-run, or enforce
     #[arg(long = "builder.execution-metering-mode", value_enum, default_value = "off")]
@@ -128,9 +132,10 @@ impl Default for Args {
             chain_block_time: 1000,
             max_gas_per_txn: None,
             max_execution_time_per_tx_us: None,
-            max_state_root_time_per_tx_us: None,
             flashblock_execution_time_budget_us: None,
-            block_state_root_time_budget_us: None,
+            block_state_root_gas_limit: None,
+            state_root_gas_coefficient: 0.02,
+            state_root_gas_anchor_us: 5000,
             execution_metering_mode: ExecutionMeteringMode::Off,
             extra_block_deadline_secs: 20,
             enable_resource_metering: false,
@@ -169,9 +174,10 @@ impl Args {
             ),
             max_gas_per_txn: self.max_gas_per_txn,
             max_execution_time_per_tx_us: self.max_execution_time_per_tx_us,
-            max_state_root_time_per_tx_us: self.max_state_root_time_per_tx_us,
             flashblock_execution_time_budget_us: self.flashblock_execution_time_budget_us,
-            block_state_root_time_budget_us: self.block_state_root_time_budget_us,
+            block_state_root_gas_limit: self.block_state_root_gas_limit,
+            state_root_gas_coefficient: self.state_root_gas_coefficient,
+            state_root_gas_anchor_us: self.state_root_gas_anchor_us,
             execution_metering_mode: self.execution_metering_mode,
             max_uncompressed_block_size: self.max_uncompressed_block_size,
             metering_wait_duration: self.metering_wait_duration_ms.map(Duration::from_millis),

--- a/crates/builder/core/src/config.rs
+++ b/crates/builder/core/src/config.rs
@@ -48,14 +48,24 @@ pub struct BuilderConfig {
     /// Maximum execution time per transaction in microseconds.
     pub max_execution_time_per_tx_us: Option<u128>,
 
-    /// Maximum state root calculation time per transaction in microseconds.
-    pub max_state_root_time_per_tx_us: Option<u128>,
-
     /// Flashblock-level execution time budget in microseconds.
     pub flashblock_execution_time_budget_us: Option<u128>,
 
-    /// Block-level state root calculation time budget in microseconds.
-    pub block_state_root_time_budget_us: Option<u128>,
+    /// Block-level state root gas limit.
+    ///
+    /// State root gas is a synthetic resource that accumulates like gas but penalizes
+    /// transactions whose simulated state root cost is disproportionate to their gas usage.
+    /// For each metered transaction: `sr_gas = gas_used × (1 + K × max(0, SR_ms - anchor))`.
+    /// Normal transactions (SR ≤ anchor) pay 1:1. State-heavy transactions pay more.
+    pub block_state_root_gas_limit: Option<u64>,
+
+    /// State root gas coefficient (K). Controls how aggressively excess SR time
+    /// inflates the state root gas cost. Default: 0.02.
+    pub state_root_gas_coefficient: f64,
+
+    /// State root gas anchor in microseconds. SR time below this threshold
+    /// produces no penalty (multiplier = 1). Default: 5000 (5ms).
+    pub state_root_gas_anchor_us: u128,
 
     /// Execution metering mode: off, dry-run, or enforce.
     pub execution_metering_mode: ExecutionMeteringMode,
@@ -94,9 +104,10 @@ impl core::fmt::Debug for BuilderConfig {
             .field("flashblocks_leeway_time", &self.flashblocks_leeway_time)
             .field("max_gas_per_txn", &self.max_gas_per_txn)
             .field("max_execution_time_per_tx_us", &self.max_execution_time_per_tx_us)
-            .field("max_state_root_time_per_tx_us", &self.max_state_root_time_per_tx_us)
             .field("flashblock_execution_time_budget_us", &self.flashblock_execution_time_budget_us)
-            .field("block_state_root_time_budget_us", &self.block_state_root_time_budget_us)
+            .field("block_state_root_gas_limit", &self.block_state_root_gas_limit)
+            .field("state_root_gas_coefficient", &self.state_root_gas_coefficient)
+            .field("state_root_gas_anchor_us", &self.state_root_gas_anchor_us)
             .field("execution_metering_mode", &self.execution_metering_mode)
             .field("max_uncompressed_block_size", &self.max_uncompressed_block_size)
             .field("metering_wait_duration", &self.metering_wait_duration)
@@ -118,9 +129,10 @@ impl Default for BuilderConfig {
             sampling_ratio: 100,
             max_gas_per_txn: None,
             max_execution_time_per_tx_us: None,
-            max_state_root_time_per_tx_us: None,
             flashblock_execution_time_budget_us: None,
-            block_state_root_time_budget_us: None,
+            block_state_root_gas_limit: None,
+            state_root_gas_coefficient: 0.02,
+            state_root_gas_anchor_us: 5_000,
             execution_metering_mode: ExecutionMeteringMode::Off,
             max_uncompressed_block_size: None,
             metering_wait_duration: None,

--- a/crates/builder/core/src/execution.rs
+++ b/crates/builder/core/src/execution.rs
@@ -5,7 +5,7 @@
 use core::fmt::Debug;
 
 use ExecutionMeteringLimitExceeded::{
-    BlockStateRootTime, FlashblockExecutionTime, TransactionExecutionTime, TransactionStateRootTime,
+    BlockStateRootGas, FlashblockExecutionTime, TransactionExecutionTime,
 };
 use alloy_primitives::{Address, U256};
 use base_alloy_consensus::OpReceipt;
@@ -40,13 +40,12 @@ pub struct ResourceLimits {
     /// This is a "use it or lose it" budget - unused time does not carry over between
     /// flashblocks. The budget resets at the start of each flashblock.
     pub flashblock_execution_time_limit_us: Option<u128>,
-    /// Maximum state root calculation time per transaction in microseconds (optional).
-    pub tx_state_root_time_limit_us: Option<u128>,
-    /// Maximum cumulative state root calculation time for the block in microseconds (optional).
+    /// Maximum cumulative state root gas for the block (optional).
     ///
-    /// Unlike execution time, state root time is cumulative across the entire block because
-    /// state root is calculated once at the end of the block, not per-flashblock.
-    pub block_state_root_time_limit_us: Option<u128>,
+    /// State root gas is a synthetic resource: `sr_gas = gas_used × (1 + K × max(0, SR_ms - anchor))`.
+    /// Normal transactions pay 1:1 with actual gas. State-heavy transactions pay more.
+    /// Cumulative across the entire block (not per-flashblock).
+    pub block_state_root_gas_limit: Option<u64>,
     /// Maximum cumulative uncompressed (EIP-2718 encoded) block size in bytes (optional).
     pub block_uncompressed_size_limit: Option<u64>,
 }
@@ -63,8 +62,8 @@ pub struct TxResources {
     pub gas_limit: u64,
     /// Predicted execution time in microseconds (from metering data, if available).
     pub execution_time_us: Option<u128>,
-    /// Predicted state root calculation time in microseconds (from metering data, if available).
-    pub state_root_time_us: Option<u128>,
+    /// Computed state root gas for this transaction (from metering data, if available).
+    pub state_root_gas: Option<u64>,
     /// Raw EIP-2718 encoded transaction size in bytes.
     pub uncompressed_size: u64,
 }
@@ -81,12 +80,9 @@ pub enum ExecutionMeteringLimitExceeded {
         "flashblock execution time exceeded: flashblock_used_us={0} tx_time_us={1} limit_us={2}"
     )]
     FlashblockExecutionTime(u128, u128, u128),
-    /// A single transaction's predicted state root time exceeded its per-tx limit.
-    #[error("transaction state root time exceeded: tx_time_us={0} limit_us={1}")]
-    TransactionStateRootTime(u128, u128),
-    /// Cumulative state root time would exceed the per-block limit.
-    #[error("block state root time exceeded: cumulative_us={0} tx_time_us={1} block_limit_us={2}")]
-    BlockStateRootTime(u128, u128, u128),
+    /// Cumulative state root gas would exceed the per-block limit.
+    #[error("block state root gas exceeded: cumulative={0} tx_sr_gas={1} block_limit={2}")]
+    BlockStateRootGas(u64, u64, u64),
 }
 
 /// Error returned when a transaction fails execution or exceeds block limits.
@@ -214,9 +210,9 @@ pub struct ExecutionInfo {
     /// Execution time used in the current flashblock in microseconds.
     /// Reset at the start of each flashblock (see [`ResourceLimits::flashblock_execution_time_limit_us`]).
     pub flashblock_execution_time_us: u128,
-    /// Cumulative state root calculation time in microseconds across the block
-    /// (see [`ResourceLimits::block_state_root_time_limit_us`]).
-    pub cumulative_state_root_time_us: u128,
+    /// Cumulative state root gas across the block
+    /// (see [`ResourceLimits::block_state_root_gas_limit`]).
+    pub cumulative_state_root_gas: u64,
     /// Cumulative uncompressed (EIP-2718 encoded) bytes used in the block
     pub cumulative_uncompressed_bytes: u64,
     /// Tracks fees from executed mempool transactions
@@ -237,7 +233,7 @@ impl ExecutionInfo {
             cumulative_gas_used: 0,
             cumulative_da_bytes_used: 0,
             flashblock_execution_time_us: 0,
-            cumulative_state_root_time_us: 0,
+            cumulative_state_root_gas: 0,
             cumulative_uncompressed_bytes: 0,
             total_fees: U256::ZERO,
             extra: Default::default(),
@@ -341,26 +337,18 @@ impl ExecutionInfo {
             }
         }
 
-        // Check state root time limits (if metering data is available)
-        if let Some(tx_time) = tx.state_root_time_us {
-            // Check per-transaction state root time limit
-            if let Some(tx_limit) = limits.tx_state_root_time_limit_us
-                && tx_time > tx_limit
-            {
-                return Err(TransactionStateRootTime(tx_time, tx_limit).into());
-            }
-
-            // Check block state root time limit (cumulative across the block)
-            if let Some(block_limit) = limits.block_state_root_time_limit_us {
-                let total_time = self.cumulative_state_root_time_us.saturating_add(tx_time);
-                if total_time > block_limit {
-                    return Err(BlockStateRootTime(
-                        self.cumulative_state_root_time_us,
-                        tx_time,
-                        block_limit,
-                    )
-                    .into());
-                }
+        // Check state root gas limit (if metering data is available)
+        if let Some(tx_sr_gas) = tx.state_root_gas
+            && let Some(block_limit) = limits.block_state_root_gas_limit
+        {
+            let total = self.cumulative_state_root_gas.saturating_add(tx_sr_gas);
+            if total > block_limit {
+                return Err(BlockStateRootGas(
+                    self.cumulative_state_root_gas,
+                    tx_sr_gas,
+                    block_limit,
+                )
+                .into());
             }
         }
 
@@ -534,40 +522,20 @@ mod tests {
         assert!(info.is_tx_over_limits(&tx, &limits).is_ok());
     }
 
-    // ==================== State Root Time Tests ====================
+    // ==================== State Root Gas Tests ====================
 
     #[test]
-    fn test_tx_state_root_time_exceeded() {
-        let info = ExecutionInfo::with_capacity(10);
-        let limits =
-            ResourceLimits { tx_state_root_time_limit_us: Some(500_000), ..default_limits() };
-        let tx = TxResources {
-            gas_limit: 21_000,
-            state_root_time_us: Some(600_000), // 0.6s > 0.5s limit
-            ..Default::default()
-        };
-
-        let result = info.is_tx_over_limits(&tx, &limits);
-        assert!(matches!(
-            result,
-            Err(TxnExecutionError::ExecutionMeteringLimitExceeded(
-                ExecutionMeteringLimitExceeded::TransactionStateRootTime(600_000, 500_000)
-            ))
-        ));
-    }
-
-    #[test]
-    fn test_block_state_root_time_exceeded() {
+    fn test_block_state_root_gas_exceeded() {
         let mut info = ExecutionInfo::with_capacity(10);
-        info.cumulative_state_root_time_us = 8_000_000; // 8s already used
+        info.cumulative_state_root_gas = 500_000_000; // 500M already used
 
         let limits = ResourceLimits {
-            block_state_root_time_limit_us: Some(10_000_000), // 10s block limit
+            block_state_root_gas_limit: Some(600_000_000), // 600M limit
             ..default_limits()
         };
         let tx = TxResources {
             gas_limit: 21_000,
-            state_root_time_us: Some(3_000_000), // 3s would exceed (8 + 3 > 10)
+            state_root_gas: Some(200_000_000), // 200M would exceed (500 + 200 > 600)
             ..Default::default()
         };
 
@@ -575,26 +543,25 @@ mod tests {
         assert!(matches!(
             result,
             Err(TxnExecutionError::ExecutionMeteringLimitExceeded(
-                ExecutionMeteringLimitExceeded::BlockStateRootTime(
-                    8_000_000, 3_000_000, 10_000_000
+                ExecutionMeteringLimitExceeded::BlockStateRootGas(
+                    500_000_000,
+                    200_000_000,
+                    600_000_000
                 )
             ))
         ));
     }
 
     #[test]
-    fn test_state_root_time_within_limits() {
+    fn test_state_root_gas_within_limits() {
         let mut info = ExecutionInfo::with_capacity(10);
-        info.cumulative_state_root_time_us = 5_000_000;
+        info.cumulative_state_root_gas = 200_000_000;
 
-        let limits = ResourceLimits {
-            tx_state_root_time_limit_us: Some(1_000_000),
-            block_state_root_time_limit_us: Some(10_000_000),
-            ..default_limits()
-        };
+        let limits =
+            ResourceLimits { block_state_root_gas_limit: Some(600_000_000), ..default_limits() };
         let tx = TxResources {
             gas_limit: 21_000,
-            state_root_time_us: Some(500_000),
+            state_root_gas: Some(50_000_000),
             ..Default::default()
         };
 
@@ -602,14 +569,10 @@ mod tests {
     }
 
     #[test]
-    fn test_state_root_time_no_metering_data_skips_check() {
+    fn test_state_root_gas_no_metering_data_skips_check() {
         let info = ExecutionInfo::with_capacity(10);
-        let limits = ResourceLimits {
-            tx_state_root_time_limit_us: Some(1),
-            block_state_root_time_limit_us: Some(1),
-            ..default_limits()
-        };
-        let tx = TxResources { gas_limit: 21_000, state_root_time_us: None, ..Default::default() };
+        let limits = ResourceLimits { block_state_root_gas_limit: Some(1), ..default_limits() };
+        let tx = TxResources { gas_limit: 21_000, state_root_gas: None, ..Default::default() };
 
         assert!(info.is_tx_over_limits(&tx, &limits).is_ok());
     }
@@ -620,7 +583,7 @@ mod tests {
     fn test_reset_flashblock_execution_time() {
         let mut info = ExecutionInfo::with_capacity(10);
         info.flashblock_execution_time_us = 5_000_000;
-        info.cumulative_state_root_time_us = 3_000_000;
+        info.cumulative_state_root_gas = 300_000_000;
         info.cumulative_gas_used = 1_000_000;
         info.cumulative_da_bytes_used = 50_000;
 
@@ -629,7 +592,7 @@ mod tests {
         // Only execution time should be reset
         assert_eq!(info.flashblock_execution_time_us, 0);
         // Other cumulative values should remain
-        assert_eq!(info.cumulative_state_root_time_us, 3_000_000);
+        assert_eq!(info.cumulative_state_root_gas, 300_000_000);
         assert_eq!(info.cumulative_gas_used, 1_000_000);
         assert_eq!(info.cumulative_da_bytes_used, 50_000);
     }
@@ -661,22 +624,24 @@ mod tests {
     }
 
     #[test]
-    fn test_state_root_time_cumulative_across_flashblocks() {
+    fn test_state_root_gas_cumulative_across_flashblocks() {
         let mut info = ExecutionInfo::with_capacity(10);
-        let limits =
-            ResourceLimits { block_state_root_time_limit_us: Some(10_000_000), ..default_limits() };
+        let limits = ResourceLimits {
+            block_state_root_gas_limit: Some(600_000_000), // 600M
+            ..default_limits()
+        };
 
-        // Simulate multiple flashblocks accumulating state root time
-        info.cumulative_state_root_time_us = 3_000_000;
+        // Simulate multiple flashblocks accumulating state root gas
+        info.cumulative_state_root_gas = 200_000_000;
         info.reset_flashblock_execution_time();
 
-        info.cumulative_state_root_time_us = 6_000_000;
+        info.cumulative_state_root_gas = 400_000_000;
         info.reset_flashblock_execution_time();
 
-        // Flashblock 3: try to add 5s (would be 11s > 10s limit)
+        // Flashblock 3: try to add 300M (would be 700M > 600M limit)
         let tx = TxResources {
             gas_limit: 21_000,
-            state_root_time_us: Some(5_000_000),
+            state_root_gas: Some(300_000_000),
             ..Default::default()
         };
 
@@ -684,7 +649,7 @@ mod tests {
         assert!(matches!(
             result,
             Err(TxnExecutionError::ExecutionMeteringLimitExceeded(
-                ExecutionMeteringLimitExceeded::BlockStateRootTime(_, _, _)
+                ExecutionMeteringLimitExceeded::BlockStateRootGas(_, _, _)
             ))
         ));
     }
@@ -697,7 +662,7 @@ mod tests {
         let limits = ResourceLimits {
             tx_data_limit: Some(100),
             tx_execution_time_limit_us: Some(1_000_000),
-            tx_state_root_time_limit_us: Some(500_000),
+            block_state_root_gas_limit: Some(500_000),
             ..default_limits()
         };
 
@@ -706,7 +671,7 @@ mod tests {
             da_size: 200,
             gas_limit: 21_000,
             execution_time_us: Some(2_000_000),
-            state_root_time_us: Some(1_000_000),
+            state_root_gas: Some(1_000_000),
             uncompressed_size: 0,
         };
 
@@ -724,8 +689,7 @@ mod tests {
             block_data_limit: Some(1_000_000),
             tx_execution_time_limit_us: Some(1_000_000),
             flashblock_execution_time_limit_us: Some(10_000_000),
-            tx_state_root_time_limit_us: Some(500_000),
-            block_state_root_time_limit_us: Some(5_000_000),
+            block_state_root_gas_limit: Some(500_000_000),
             ..Default::default()
         };
 
@@ -733,7 +697,7 @@ mod tests {
             da_size: 500,
             gas_limit: 100_000,
             execution_time_us: Some(100_000),
-            state_root_time_us: Some(50_000),
+            state_root_gas: Some(100_000),
             uncompressed_size: 0,
         };
 
@@ -785,7 +749,7 @@ mod tests {
         assert_eq!(info.cumulative_gas_used, 0);
         assert_eq!(info.cumulative_da_bytes_used, 0);
         assert_eq!(info.flashblock_execution_time_us, 0);
-        assert_eq!(info.cumulative_state_root_time_us, 0);
+        assert_eq!(info.cumulative_state_root_gas, 0);
         assert_eq!(info.cumulative_uncompressed_bytes, 0);
         assert_eq!(info.total_fees, U256::ZERO);
         assert!(info.executed_transactions.is_empty());

--- a/crates/builder/core/src/flashblocks/context.rs
+++ b/crates/builder/core/src/flashblocks/context.rs
@@ -60,11 +60,8 @@ fn record_rejected_tx_priority_fee(reason: &TxnExecutionError, priority_fee: f64
             ExecutionMeteringLimitExceeded::FlashblockExecutionTime(_, _, _) => {
                 "flashblock_execution_time_exceeded"
             }
-            ExecutionMeteringLimitExceeded::TransactionStateRootTime(_, _) => {
-                "tx_state_root_time_exceeded"
-            }
-            ExecutionMeteringLimitExceeded::BlockStateRootTime(_, _, _) => {
-                "block_state_root_time_exceeded"
+            ExecutionMeteringLimitExceeded::BlockStateRootGas(_, _, _) => {
+                "block_state_root_gas_exceeded"
             }
         },
         TxnExecutionError::SequencerTransaction => "sequencer_transaction",
@@ -197,8 +194,7 @@ impl FlashblockDiagnostics {
                 | ExecutionMeteringLimitExceeded::FlashblockExecutionTime(_, _, _) => {
                     self.txs_rejected_execution_time += 1;
                 }
-                ExecutionMeteringLimitExceeded::TransactionStateRootTime(_, _)
-                | ExecutionMeteringLimitExceeded::BlockStateRootTime(_, _, _) => {
+                ExecutionMeteringLimitExceeded::BlockStateRootGas(_, _, _) => {
                     self.txs_rejected_state_root_time += 1;
                 }
             },
@@ -234,8 +230,8 @@ pub struct FlashblocksExtraCtx {
     pub target_da_footprint_for_batch: Option<u64>,
     /// Target execution time for the current flashblock in microseconds
     pub target_execution_time_for_batch_us: Option<u128>,
-    /// Target state root time for the current flashblock in microseconds
-    pub target_state_root_time_for_batch_us: Option<u128>,
+    /// Target state root gas for the current flashblock
+    pub target_state_root_gas_for_batch: Option<u64>,
     /// Gas limit per flashblock
     pub gas_per_batch: u64,
     /// DA bytes limit per flashblock
@@ -244,8 +240,8 @@ pub struct FlashblocksExtraCtx {
     pub da_footprint_per_batch: Option<u64>,
     /// Execution time limit per flashblock in microseconds
     pub execution_time_per_batch_us: Option<u128>,
-    /// State root time limit per flashblock in microseconds
-    pub state_root_time_per_batch_us: Option<u128>,
+    /// State root gas limit per flashblock
+    pub state_root_gas_per_batch: Option<u64>,
 }
 
 impl FlashblocksExtraCtx {
@@ -259,7 +255,7 @@ impl FlashblocksExtraCtx {
         target_da_for_batch: Option<u64>,
         target_da_footprint_for_batch: Option<u64>,
         target_execution_time_for_batch_us: Option<u128>,
-        target_state_root_time_for_batch_us: Option<u128>,
+        target_state_root_gas_for_batch: Option<u64>,
     ) -> Self {
         Self {
             flashblock_index: self.flashblock_index + 1,
@@ -267,7 +263,7 @@ impl FlashblocksExtraCtx {
             target_da_for_batch,
             target_da_footprint_for_batch,
             target_execution_time_for_batch_us,
-            target_state_root_time_for_batch_us,
+            target_state_root_gas_for_batch,
             ..self
         }
     }
@@ -623,7 +619,7 @@ impl OpPayloadBuilderCtx {
             tx_data_limit = ?limits.tx_data_limit,
             block_gas_limit = ?limits.block_gas_limit,
             flashblock_execution_time_limit_us = ?limits.flashblock_execution_time_limit_us,
-            block_state_root_time_limit_us = ?limits.block_state_root_time_limit_us,
+            block_state_root_gas_limit = ?limits.block_state_root_gas_limit,
             execution_metering_mode = ?self.builder_config.execution_metering_mode,
         );
 
@@ -711,18 +707,31 @@ impl OpPayloadBuilderCtx {
                 }
             }
 
-            // Extract predicted execution and state root times from metering data
+            // Extract predicted execution time from metering data
             let predicted_execution_time_us =
                 resource_usage.as_ref().map(|m| m.total_execution_time_us);
             let predicted_state_root_time_us =
                 resource_usage.as_ref().map(|m| m.state_root_time_us);
+
+            // Compute state root gas from metering data:
+            // sr_gas = gas_used × (1 + K × max(0, SR_ms - anchor_ms))
+            let state_root_gas = resource_usage.as_ref().map(|m| {
+                let gas_used = m.total_gas_used;
+                let sr_us = m.state_root_time_us;
+                let anchor_us = self.builder_config.state_root_gas_anchor_us;
+                let k = self.builder_config.state_root_gas_coefficient;
+                let excess_us = sr_us.saturating_sub(anchor_us);
+                let excess_ms = excess_us as f64 / 1000.0;
+                let multiplier = 1.0 + k * excess_ms;
+                (gas_used as f64 * multiplier) as u64
+            });
 
             // Build tx resources struct
             let tx_resources = TxResources {
                 da_size: tx_da_size,
                 gas_limit: tx.gas_limit(),
                 execution_time_us: predicted_execution_time_us,
-                state_root_time_us: predicted_state_root_time_us,
+                state_root_gas,
                 uncompressed_size: tx_uncompressed_size,
             };
 
@@ -894,15 +903,17 @@ impl OpPayloadBuilderCtx {
             // record execution time (use predicted time if available, fall back to actual)
             info.flashblock_execution_time_us +=
                 predicted_execution_time_us.unwrap_or(actual_execution_time_us);
-            // record state root time (only from predictions)
-            if let Some(state_root_time) = predicted_state_root_time_us {
-                info.cumulative_state_root_time_us += state_root_time;
-
-                // Record state root time / gas ratio for anomaly detection
-                if gas_used > 0 {
-                    let ratio = state_root_time as f64 / gas_used as f64;
-                    BuilderMetrics::state_root_time_per_gas_ratio().record(ratio);
-                }
+            // record state root gas (only from predictions)
+            if let Some(sr_gas) = state_root_gas {
+                info.cumulative_state_root_gas += sr_gas;
+                BuilderMetrics::tx_state_root_gas().record(sr_gas as f64);
+            }
+            // record state root time / gas ratio for anomaly detection
+            if let Some(state_root_time) = predicted_state_root_time_us
+                && gas_used > 0
+            {
+                let ratio = state_root_time as f64 / gas_used as f64;
+                BuilderMetrics::state_root_time_per_gas_ratio().record(ratio);
             }
 
             // Push transaction changeset and calculate header bloom filter for receipt.
@@ -944,10 +955,9 @@ impl OpPayloadBuilderCtx {
             }
         }
 
-        // Record cumulative predicted state root time for the block
-        if info.cumulative_state_root_time_us > 0 {
-            BuilderMetrics::block_predicted_state_root_time_us()
-                .record(info.cumulative_state_root_time_us as f64);
+        // Record cumulative state root gas for the block
+        if info.cumulative_state_root_gas > 0 {
+            BuilderMetrics::block_state_root_gas().record(info.cumulative_state_root_gas as f64);
         }
 
         let payload_transaction_simulation_time = execute_txs_start_time.elapsed();
@@ -1005,11 +1015,8 @@ impl OpPayloadBuilderCtx {
             ExecutionMeteringLimitExceeded::FlashblockExecutionTime(_, _, _) => {
                 BuilderMetrics::flashblock_execution_time_exceeded_total().increment(1);
             }
-            ExecutionMeteringLimitExceeded::TransactionStateRootTime(_, _) => {
-                BuilderMetrics::tx_state_root_time_exceeded_total().increment(1);
-            }
-            ExecutionMeteringLimitExceeded::BlockStateRootTime(_, _, _) => {
-                BuilderMetrics::block_state_root_time_exceeded_total().increment(1);
+            ExecutionMeteringLimitExceeded::BlockStateRootGas(_, _, _) => {
+                BuilderMetrics::block_state_root_gas_exceeded_total().increment(1);
             }
         }
     }

--- a/crates/builder/core/src/flashblocks/payload.rs
+++ b/crates/builder/core/src/flashblocks/payload.rs
@@ -345,10 +345,10 @@ where
         let da_footprint_per_batch =
             info.da_footprint_scalar.map(|_| ctx.block_gas_limit() / flashblocks_per_block);
         let execution_time_per_batch_us = ctx.builder_config.flashblock_execution_time_budget_us;
-        let state_root_time_per_batch_us = ctx
+        let state_root_gas_per_batch = ctx
             .builder_config
-            .block_state_root_time_budget_us
-            .map(|budget| budget / flashblocks_per_block as u128);
+            .block_state_root_gas_limit
+            .map(|limit| limit / flashblocks_per_block);
 
         let extra = FlashblocksExtraCtx {
             flashblock_index: 1,
@@ -357,12 +357,12 @@ where
             target_da_for_batch: da_per_batch,
             target_da_footprint_for_batch: da_footprint_per_batch,
             target_execution_time_for_batch_us: execution_time_per_batch_us,
-            target_state_root_time_for_batch_us: state_root_time_per_batch_us,
+            target_state_root_gas_for_batch: state_root_gas_per_batch,
             gas_per_batch,
             da_per_batch,
             da_footprint_per_batch,
             execution_time_per_batch_us,
-            state_root_time_per_batch_us,
+            state_root_gas_per_batch,
         };
 
         let mut fb_cancel = block_cancel.child_token();
@@ -516,9 +516,8 @@ where
         let target_gas_for_batch = ctx.extra.target_gas_for_batch;
         let mut target_da_for_batch = ctx.extra.target_da_for_batch;
         let mut target_da_footprint_for_batch = ctx.extra.target_da_footprint_for_batch;
-        let mut target_state_root_time_for_batch_us = ctx.extra.target_state_root_time_for_batch_us;
+        let mut target_state_root_gas_for_batch = ctx.extra.target_state_root_gas_for_batch;
         let flashblock_execution_time_limit_us = ctx.extra.execution_time_per_batch_us;
-        let block_state_root_time_limit_us = target_state_root_time_for_batch_us;
 
         info!(
             target: "payload_builder",
@@ -531,7 +530,7 @@ where
             block_gas_used = ctx.block_gas_limit(),
             target_da_footprint = target_da_footprint_for_batch,
             flashblock_execution_time_limit_us = ?flashblock_execution_time_limit_us,
-            target_state_root_time_for_batch_us = ?target_state_root_time_for_batch_us,
+            target_state_root_gas_for_batch = ?target_state_root_gas_for_batch,
             "Building flashblock",
         );
         let flashblock_build_start_time = Instant::now();
@@ -577,8 +576,7 @@ where
             block_da_footprint_limit: target_da_footprint_for_batch,
             tx_execution_time_limit_us: ctx.builder_config.max_execution_time_per_tx_us,
             flashblock_execution_time_limit_us,
-            tx_state_root_time_limit_us: ctx.builder_config.max_state_root_time_per_tx_us,
-            block_state_root_time_limit_us,
+            block_state_root_gas_limit: target_state_root_gas_for_batch,
             block_uncompressed_size_limit: ctx.builder_config.max_uncompressed_block_size,
         };
         let diag = ctx
@@ -706,10 +704,9 @@ where
                     *footprint += da_footprint_limit;
                 }
 
-                if let (Some(time), Some(time_per_batch)) = (
-                    target_state_root_time_for_batch_us.as_mut(),
-                    ctx.extra.state_root_time_per_batch_us,
-                ) {
+                if let (Some(time), Some(time_per_batch)) =
+                    (target_state_root_gas_for_batch.as_mut(), ctx.extra.state_root_gas_per_batch)
+                {
                     *time += time_per_batch;
                 }
 
@@ -718,7 +715,7 @@ where
                     target_da_for_batch,
                     target_da_footprint_for_batch,
                     ctx.extra.execution_time_per_batch_us,
-                    target_state_root_time_for_batch_us,
+                    target_state_root_gas_for_batch,
                 );
 
                 let gas_headroom_pct = if limits.block_gas_limit > 0 {
@@ -750,8 +747,8 @@ where
                     current_da = info.cumulative_da_bytes_used,
                     flashblock_exec_time_us = info.flashblock_execution_time_us,
                     exec_time_limit_us = ?limits.flashblock_execution_time_limit_us,
-                    cumulative_state_root_time_us = info.cumulative_state_root_time_us,
-                    state_root_time_limit_us = ?limits.block_state_root_time_limit_us,
+                    cumulative_state_root_gas = info.cumulative_state_root_gas,
+                    state_root_gas_limit = ?limits.block_state_root_gas_limit,
                     target_flashblocks = ctx.target_flashblock_count(),
                 );
 
@@ -776,10 +773,9 @@ where
         BuilderMetrics::payload_num_tx().record(info.executed_transactions.len() as f64);
         BuilderMetrics::payload_num_tx_gauge().set(info.executed_transactions.len() as f64);
 
-        // Record cumulative predicted state root time for the block (observation metric)
-        if info.cumulative_state_root_time_us > 0 {
-            BuilderMetrics::block_predicted_state_root_time_us()
-                .record(info.cumulative_state_root_time_us as f64);
+        // Record cumulative state root gas for the block
+        if info.cumulative_state_root_gas > 0 {
+            BuilderMetrics::block_state_root_gas().record(info.cumulative_state_root_gas as f64);
         }
 
         // Record cumulative uncompressed block size

--- a/crates/builder/core/src/metrics.rs
+++ b/crates/builder/core/src/metrics.rs
@@ -118,20 +118,20 @@ base_metrics::define_metrics! {
     tx_execution_time_exceeded_total: counter,
     #[describe("Transactions that exceeded flashblock execution time budget")]
     flashblock_execution_time_exceeded_total: counter,
-    #[describe("Transactions that exceeded per-tx state root time limit")]
-    tx_state_root_time_exceeded_total: counter,
-    #[describe("Transactions that exceeded block state root time budget")]
-    block_state_root_time_exceeded_total: counter,
+    #[describe("Transactions that exceeded block state root gas limit")]
+    block_state_root_gas_exceeded_total: counter,
     #[describe("Histogram of (predicted - actual) execution time per transaction in microseconds")]
     execution_time_prediction_error_us: histogram,
     #[describe("Distribution of predicted execution times from metering service (microseconds)")]
     tx_predicted_execution_time_us: histogram,
     #[describe("Distribution of actual execution times (microseconds)")]
     tx_actual_execution_time_us: histogram,
+    #[describe("Per-transaction state root gas (computed from metering data)")]
+    tx_state_root_gas: histogram,
+    #[describe("Cumulative state root gas per block")]
+    block_state_root_gas: histogram,
     #[describe("Distribution of predicted state root times from metering service (microseconds)")]
     tx_predicted_state_root_time_us: histogram,
-    #[describe("Cumulative predicted state root time per block (microseconds)")]
-    block_predicted_state_root_time_us: histogram,
     #[describe("Ratio of state_root_time_us / gas_used for each transaction")]
     state_root_time_per_gas_ratio: histogram,
     #[describe("Flashblock selection total")]
@@ -253,12 +253,11 @@ impl BuilderMetrics {
         }
 
         Self::flashblock_state_root_time_used_us(flashblock_index.clone())
-            .record(info.cumulative_state_root_time_us as f64);
-        if let Some(block_state_root_time_limit_us) = limits.block_state_root_time_limit_us {
-            Self::flashblock_state_root_time_headroom_us(flashblock_index.clone()).record(
-                block_state_root_time_limit_us.saturating_sub(info.cumulative_state_root_time_us)
-                    as f64,
-            );
+            .record(info.cumulative_state_root_gas as f64);
+        if let Some(block_state_root_gas_limit) = limits.block_state_root_gas_limit {
+            Self::flashblock_state_root_time_headroom_us(flashblock_index.clone())
+                .record(block_state_root_gas_limit.saturating_sub(info.cumulative_state_root_gas)
+                    as f64);
         }
 
         for (reason, count) in diag.rejection_counts() {
@@ -315,14 +314,14 @@ mod tests {
             cumulative_gas_used: 60,
             cumulative_da_bytes_used: 15,
             flashblock_execution_time_us: 40,
-            cumulative_state_root_time_us: 90,
+            cumulative_state_root_gas: 90,
             ..Default::default()
         };
         let limits = ResourceLimits {
             block_gas_limit: 100,
             block_data_limit: Some(20),
             flashblock_execution_time_limit_us: Some(50),
-            block_state_root_time_limit_us: Some(100),
+            block_state_root_gas_limit: Some(100),
             ..Default::default()
         };
 


### PR DESCRIPTION
## Summary
- Replace per-tx and per-block state root time budgets with a single cumulative **state root gas** resource
- State root gas accumulates like gas but penalizes transactions whose simulated state root cost is disproportionate to their gas usage
- Formula: `sr_gas(tx) = gas_used × (1 + K × max(0, SR_ms - anchor))`

## Motivation
The existing state root time budget sums simulated per-tx state root times, which overestimates actual block finalization by 2–443x depending on block composition. State root gas uses the simulation to scale a gas-like resource rather than treating simulated times as additive costs.

## What changed
- Removed `--builder.max-state-root-time-per-tx-us` and `--builder.block-state-root-time-budget-us`
- Added `--builder.block-state-root-gas-limit`, `--builder.state-root-gas-coefficient` (K, default 0.02), `--builder.state-root-gas-anchor-us` (default 5000 = 5ms)
- Builder computes sr_gas from `MeterBundleResponse.total_gas_used` and `.state_root_time_us`
- New metrics: `tx_state_root_gas`, `block_state_root_gas`, `block_state_root_gas_exceeded_total`

## Calibration
At K=0.02, anchor=5ms (from 30 mainnet blocks with on-chain receipt data):
- Normal ETH transfer (21K gas, 5ms SR): 21K sr_gas (1.0x)
- Bot outlier (40K gas, 50ms SR): 76K sr_gas (1.9x)
- XEN tx (7M gas, 1270ms SR): 183M sr_gas (26.3x)

At budget=600M: all current mainnet blocks pass, max ~5 XEN txs per block.

## Test plan
- [x] All unit tests pass (`cargo test -p base-builder-core --lib`: 42 tests)
- [x] All integration tests pass (`cargo test -p base-builder-core`: 8 tests)
- [x] All builder binary tests pass (`cargo test -p base-builder-bin`: 15 tests)
- [ ] Deploy to Zeronet in dry-run mode, verify sr_gas histogram distribution
- [ ] Validate no transactions rejected with conservative budget (e.g. 2B)

type=routine
risk=low
impact=sev5