### PR TITLE
feat(basectl): Validator Node Stats View

### DIFF
--- a/crates/infra/basectl/src/app/core.rs
+++ b/crates/infra/basectl/src/app/core.rs
@@ -50,6 +50,7 @@ impl App {
             self.resources.flash.poll();
             self.resources.toasts.poll();
             self.resources.conductor.poll();
+            self.resources.validators.poll();
             // When a conductor cluster is configured, bridge the Raft leader's
             // safe head into the DA tracker each tick.  The conductor poller
             // already queries `op_sync_status` from every node's CL, so the

--- a/crates/infra/basectl/src/app/resources.rs
+++ b/crates/infra/basectl/src/app/resources.rs
@@ -9,7 +9,7 @@ use crate::{
     config::{ChainConfig, ConductorNodeConfig},
     rpc::{
         BacklogFetchResult, BlockDaInfo, ConductorNodeStatus, L1BlockInfo, L1ConnectionMode,
-        TimestampedFlashblock,
+        TimestampedFlashblock, ValidatorNodeStatus,
     },
     tui::ToastState,
 };
@@ -89,6 +89,29 @@ impl ConductorState {
     }
 }
 
+/// State for validator node monitoring.
+#[derive(Debug, Default)]
+pub(crate) struct ValidatorState {
+    /// Most recent status snapshot for each validator node.
+    pub nodes: Vec<ValidatorNodeStatus>,
+    rx: Option<mpsc::Receiver<Vec<ValidatorNodeStatus>>>,
+}
+
+impl ValidatorState {
+    /// Sets the channel for receiving validator status updates.
+    pub(crate) fn set_channel(&mut self, rx: mpsc::Receiver<Vec<ValidatorNodeStatus>>) {
+        self.rx = Some(rx);
+    }
+
+    /// Drains the latest status snapshot from the background poller.
+    pub(crate) fn poll(&mut self) {
+        let Some(ref mut rx) = self.rx else { return };
+        while let Ok(statuses) = rx.try_recv() {
+            self.nodes = statuses;
+        }
+    }
+}
+
 /// Shared resources available to all TUI views.
 #[derive(Debug)]
 pub(crate) struct Resources {
@@ -102,6 +125,8 @@ pub(crate) struct Resources {
     pub toasts: ToastState,
     /// HA conductor cluster monitoring state.
     pub conductor: ConductorState,
+    /// Validator node monitoring state.
+    pub validators: ValidatorState,
     /// L1 system config fetched from the contract.
     pub system_config: Option<SystemConfig>,
     sys_config_rx: Option<mpsc::Receiver<SystemConfig>>,
@@ -160,6 +185,7 @@ impl Resources {
             flash: FlashState::new(),
             toasts: ToastState::new(),
             conductor: ConductorState::default(),
+            validators: ValidatorState::default(),
             system_config: None,
             sys_config_rx: None,
         }

--- a/crates/infra/basectl/src/app/runner.rs
+++ b/crates/infra/basectl/src/app/runner.rs
@@ -11,9 +11,9 @@ use crate::{
     l1_client::fetch_full_system_config,
     rpc::{
         BacklogFetchResult, BlockDaInfo, ConductorNodeStatus, L1BlockInfo, L1ConnectionMode,
-        TimestampedFlashblock, fetch_initial_backlog_with_progress, run_block_fetcher,
-        run_conductor_poller, run_flashblock_ws, run_flashblock_ws_timestamped,
-        run_l1_blob_watcher, run_safe_head_poller,
+        TimestampedFlashblock, ValidatorNodeStatus, fetch_initial_backlog_with_progress,
+        run_block_fetcher, run_conductor_poller, run_flashblock_ws, run_flashblock_ws_timestamped,
+        run_l1_blob_watcher, run_safe_head_poller, run_validator_poller,
     },
     tui::Toast,
 };
@@ -120,6 +120,12 @@ fn start_background_services(config: &ChainConfig, resources: &mut Resources) {
         if conductor_nodes.iter().any(|n| n.flashblocks_ws.is_some()) {
             resources.conductor.set_url_sender(conductor_nodes, fb_url_tx);
         }
+    }
+
+    if let Some(validator_nodes) = config.validators.clone() {
+        let (validator_tx, validator_rx) = mpsc::channel::<Vec<ValidatorNodeStatus>>(4);
+        resources.validators.set_channel(validator_rx);
+        tokio::spawn(run_validator_poller(validator_nodes, validator_tx));
     }
 }
 

--- a/crates/infra/basectl/src/app/views/conductor.rs
+++ b/crates/infra/basectl/src/app/views/conductor.rs
@@ -9,7 +9,7 @@ use tokio::sync::mpsc;
 use crate::{
     app::{Action, Resources, View},
     commands::common::COLOR_BASE_BLUE,
-    rpc::{ConductorNodeStatus, restart_conductor_node, transfer_conductor_leader},
+    rpc::{ConductorNodeStatus, ValidatorNodeStatus, restart_conductor_node, transfer_conductor_leader},
     tui::{Keybinding, Toast},
 };
 
@@ -117,12 +117,36 @@ impl View for ConductorView {
         let footer_area = chunks[1];
 
         let nodes = &resources.conductor.nodes;
+        let validators = &resources.validators.nodes;
 
-        if nodes.is_empty() {
-            render_unconfigured(frame, content_area);
+        if validators.is_empty() {
+            if nodes.is_empty() {
+                render_unconfigured(frame, content_area);
+            } else {
+                let selected = self.selected.min(nodes.len().saturating_sub(1));
+                render_cluster_table(frame, content_area, nodes, selected, self.op_pending);
+            }
         } else {
-            let selected = self.selected.min(nodes.len().saturating_sub(1));
-            render_cluster_table(frame, content_area, nodes, selected, self.op_pending);
+            // Conductor table: 2 border + 1 header + 16 data rows = 19 lines.
+            // Validator table: 2 border + 1 header + 14 data rows = 17 lines.
+            let conductor_height = 19u16;
+            let validator_height = 17u16;
+            let sections = Layout::default()
+                .direction(Direction::Vertical)
+                .constraints([
+                    Constraint::Length(conductor_height),
+                    Constraint::Length(validator_height),
+                    Constraint::Min(0),
+                ])
+                .split(content_area);
+
+            if nodes.is_empty() {
+                render_unconfigured(frame, sections[0]);
+            } else {
+                let selected = self.selected.min(nodes.len().saturating_sub(1));
+                render_cluster_table(frame, sections[0], nodes, selected, self.op_pending);
+            }
+            render_validator_table(frame, sections[1], validators);
         }
 
         render_footer(frame, footer_area, self.op_pending);
@@ -483,6 +507,221 @@ fn render_cluster_table(
         // ── Conductor ────────────────────────────────────────────────────
         role_row,
         active_row,
+        // ── CL ───────────────────────────────────────────────────────────
+        spacer.clone(),
+        cl_section,
+        l2_row,
+        l2_hash_row,
+        safe_l2_row,
+        safe_hash_row,
+        finalized_l2_row,
+        l1_row,
+        cl_peers_row,
+        // ── EL ───────────────────────────────────────────────────────────
+        spacer,
+        el_section,
+        el_block_row,
+        el_syncing_row,
+        el_peers_row,
+    ];
+    let table = Table::new(rows, constraints).header(header).row_highlight_style(Style::default());
+
+    f.render_stateful_widget(table, inner, &mut TableState::default());
+}
+
+fn render_validator_table(
+    f: &mut Frame<'_>,
+    area: Rect,
+    nodes: &[ValidatorNodeStatus],
+) {
+    let block = Block::default()
+        .title(" Validators ")
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(COLOR_BASE_BLUE));
+
+    let inner = block.inner(area);
+    f.render_widget(block, area);
+
+    let node_count = nodes.len();
+    let label_pct = 15u16;
+    let node_pct = (100u16 - label_pct) / node_count as u16;
+
+    let mut constraints = vec![Constraint::Percentage(label_pct)];
+    for _ in 0..node_count {
+        constraints.push(Constraint::Percentage(node_pct));
+    }
+
+    // ── Header row: node names ─────────────────────────────────────────────
+    let mut header_cells = vec![Cell::from("")];
+    for node in nodes {
+        let style = Style::default().fg(Color::White).add_modifier(Modifier::BOLD);
+        header_cells.push(Cell::from(node.name.as_str()).style(style));
+    }
+    let header = Row::new(header_cells)
+        .style(Style::default().fg(Color::White).add_modifier(Modifier::BOLD))
+        .height(1);
+
+    // ── CL section header ──────────────────────────────────────────────────
+    let cl_section = section_row("CL", node_count);
+
+    // ── Unsafe L2 row ──────────────────────────────────────────────────────
+    let mut l2_cells = vec![
+        Cell::from("  Unsafe L2")
+            .style(Style::default().fg(Color::White).add_modifier(Modifier::BOLD)),
+    ];
+    for node in nodes {
+        let (label, style) = match node.unsafe_l2_block {
+            Some(n) => (format!("   #{n}"), Style::default().fg(Color::White)),
+            None => ("   ?".to_string(), Style::default().fg(Color::DarkGray)),
+        };
+        l2_cells.push(Cell::from(label).style(style));
+    }
+    let l2_row = Row::new(l2_cells).height(1);
+
+    // ── Unsafe L2 hash row ────────────────────────────────────────────────
+    let mut l2_hash_cells = vec![
+        Cell::from("  Unsafe Hash")
+            .style(Style::default().fg(Color::White).add_modifier(Modifier::BOLD)),
+    ];
+    for node in nodes {
+        let (label, style) = match node.unsafe_l2_hash {
+            Some(h) => {
+                let hex = format!("{h:x}");
+                (format!("   0x{}…", &hex[..8]), Style::default().fg(Color::White))
+            }
+            None => ("   ?".to_string(), Style::default().fg(Color::DarkGray)),
+        };
+        l2_hash_cells.push(Cell::from(label).style(style));
+    }
+    let l2_hash_row = Row::new(l2_hash_cells).height(1);
+
+    // ── Safe L2 row ────────────────────────────────────────────────────────
+    let mut safe_l2_cells = vec![
+        Cell::from("  Safe L2")
+            .style(Style::default().fg(Color::White).add_modifier(Modifier::BOLD)),
+    ];
+    for node in nodes {
+        let (label, style) = match node.safe_l2_block {
+            Some(n) => (format!("   #{n}"), Style::default().fg(Color::White)),
+            None => ("   ?".to_string(), Style::default().fg(Color::DarkGray)),
+        };
+        safe_l2_cells.push(Cell::from(label).style(style));
+    }
+    let safe_l2_row = Row::new(safe_l2_cells).height(1);
+
+    // ── Safe L2 hash row ──────────────────────────────────────────────────
+    let mut safe_hash_cells = vec![
+        Cell::from("  Safe Hash")
+            .style(Style::default().fg(Color::White).add_modifier(Modifier::BOLD)),
+    ];
+    for node in nodes {
+        let (label, style) = match node.safe_l2_hash {
+            Some(h) => {
+                let hex = format!("{h:x}");
+                (format!("   0x{}…", &hex[..8]), Style::default().fg(Color::White))
+            }
+            None => ("   ?".to_string(), Style::default().fg(Color::DarkGray)),
+        };
+        safe_hash_cells.push(Cell::from(label).style(style));
+    }
+    let safe_hash_row = Row::new(safe_hash_cells).height(1);
+
+    // ── Finalized L2 row ───────────────────────────────────────────────────
+    let mut finalized_l2_cells = vec![
+        Cell::from("  Finalized L2")
+            .style(Style::default().fg(Color::White).add_modifier(Modifier::BOLD)),
+    ];
+    for node in nodes {
+        let (label, style) = match node.finalized_l2_block {
+            Some(n) => (format!("   #{n}"), Style::default().fg(Color::White)),
+            None => ("   ?".to_string(), Style::default().fg(Color::DarkGray)),
+        };
+        finalized_l2_cells.push(Cell::from(label).style(style));
+    }
+    let finalized_l2_row = Row::new(finalized_l2_cells).height(1);
+
+    // ── L1 derivation row ──────────────────────────────────────────────────
+    let mut l1_cells = vec![
+        Cell::from("  L1 Derived")
+            .style(Style::default().fg(Color::White).add_modifier(Modifier::BOLD)),
+    ];
+    for node in nodes {
+        let (label, style) = match (node.current_l1_block, node.head_l1_block) {
+            (Some(cur), Some(head)) => {
+                let lag = head.saturating_sub(cur);
+                let color = if lag > 10 { Color::Yellow } else { Color::Green };
+                (format!("   #{cur} / #{head}"), Style::default().fg(color))
+            }
+            _ => ("   ? / ?".to_string(), Style::default().fg(Color::DarkGray)),
+        };
+        l1_cells.push(Cell::from(label).style(style));
+    }
+    let l1_row = Row::new(l1_cells).height(1);
+
+    // ── CL peer count row ──────────────────────────────────────────────────
+    let mut cl_peers_cells = vec![
+        Cell::from("  CL Peers")
+            .style(Style::default().fg(Color::White).add_modifier(Modifier::BOLD)),
+    ];
+    for node in nodes {
+        let (label, style) = match node.cl_peer_count {
+            Some(0) => ("   0".to_string(), Style::default().fg(Color::Red)),
+            Some(n) => (format!("   {n}"), Style::default().fg(Color::Green)),
+            None => ("   ?".to_string(), Style::default().fg(Color::Red)),
+        };
+        cl_peers_cells.push(Cell::from(label).style(style));
+    }
+    let cl_peers_row = Row::new(cl_peers_cells).height(1);
+
+    // ── EL section header ──────────────────────────────────────────────────
+    let el_section = section_row("EL", node_count);
+
+    // ── EL block row ───────────────────────────────────────────────────────
+    let mut el_block_cells = vec![
+        Cell::from("  Block").style(Style::default().fg(Color::White).add_modifier(Modifier::BOLD)),
+    ];
+    for node in nodes {
+        let (label, style) = match node.el_block {
+            Some(n) => (format!("   #{n}"), Style::default().fg(Color::White)),
+            None => ("   -".to_string(), Style::default().fg(Color::DarkGray)),
+        };
+        el_block_cells.push(Cell::from(label).style(style));
+    }
+    let el_block_row = Row::new(el_block_cells).height(1);
+
+    // ── EL syncing row ─────────────────────────────────────────────────────
+    let mut el_syncing_cells = vec![
+        Cell::from("  Syncing")
+            .style(Style::default().fg(Color::White).add_modifier(Modifier::BOLD)),
+    ];
+    for node in nodes {
+        let (label, style) = match node.el_syncing {
+            Some(true) => ("   yes", Style::default().fg(Color::Yellow)),
+            Some(false) => ("   no", Style::default().fg(Color::Green)),
+            None => ("   -", Style::default().fg(Color::DarkGray)),
+        };
+        el_syncing_cells.push(Cell::from(label).style(style));
+    }
+    let el_syncing_row = Row::new(el_syncing_cells).height(1);
+
+    // ── EL peer count row ──────────────────────────────────────────────────
+    let mut el_peers_cells = vec![
+        Cell::from("  EL Peers")
+            .style(Style::default().fg(Color::White).add_modifier(Modifier::BOLD)),
+    ];
+    for node in nodes {
+        let (label, style) = match node.el_peer_count {
+            Some(0) => ("   0".to_string(), Style::default().fg(Color::Red)),
+            Some(n) => (format!("   {n}"), Style::default().fg(Color::Green)),
+            None => ("   -".to_string(), Style::default().fg(Color::DarkGray)),
+        };
+        el_peers_cells.push(Cell::from(label).style(style));
+    }
+    let el_peers_row = Row::new(el_peers_cells).height(1);
+
+    let spacer = Row::new(vec![Cell::from("")]).height(1);
+
+    let rows = vec![
         // ── CL ───────────────────────────────────────────────────────────
         spacer.clone(),
         cl_section,

--- a/crates/infra/basectl/src/app/views/conductor.rs
+++ b/crates/infra/basectl/src/app/views/conductor.rs
@@ -9,7 +9,9 @@ use tokio::sync::mpsc;
 use crate::{
     app::{Action, Resources, View},
     commands::common::COLOR_BASE_BLUE,
-    rpc::{ConductorNodeStatus, ValidatorNodeStatus, restart_conductor_node, transfer_conductor_leader},
+    rpc::{
+        ConductorNodeStatus, ValidatorNodeStatus, restart_conductor_node, transfer_conductor_leader,
+    },
     tui::{Keybinding, Toast},
 };
 
@@ -529,11 +531,7 @@ fn render_cluster_table(
     f.render_stateful_widget(table, inner, &mut TableState::default());
 }
 
-fn render_validator_table(
-    f: &mut Frame<'_>,
-    area: Rect,
-    nodes: &[ValidatorNodeStatus],
-) {
+fn render_validator_table(f: &mut Frame<'_>, area: Rect, nodes: &[ValidatorNodeStatus]) {
     let block = Block::default()
         .title(" Validators ")
         .borders(Borders::ALL)
@@ -570,10 +568,10 @@ fn render_validator_table(
             .style(Style::default().fg(Color::White).add_modifier(Modifier::BOLD)),
     ];
     for node in nodes {
-        let (label, style) = match node.unsafe_l2_block {
-            Some(n) => (format!("   #{n}"), Style::default().fg(Color::White)),
-            None => ("   ?".to_string(), Style::default().fg(Color::DarkGray)),
-        };
+        let (label, style) = node.unsafe_l2_block.map_or_else(
+            || ("   ?".to_string(), Style::default().fg(Color::DarkGray)),
+            |n| (format!("   #{n}"), Style::default().fg(Color::White)),
+        );
         l2_cells.push(Cell::from(label).style(style));
     }
     let l2_row = Row::new(l2_cells).height(1);
@@ -584,13 +582,13 @@ fn render_validator_table(
             .style(Style::default().fg(Color::White).add_modifier(Modifier::BOLD)),
     ];
     for node in nodes {
-        let (label, style) = match node.unsafe_l2_hash {
-            Some(h) => {
+        let (label, style) = node.unsafe_l2_hash.map_or_else(
+            || ("   ?".to_string(), Style::default().fg(Color::DarkGray)),
+            |h| {
                 let hex = format!("{h:x}");
                 (format!("   0x{}…", &hex[..8]), Style::default().fg(Color::White))
-            }
-            None => ("   ?".to_string(), Style::default().fg(Color::DarkGray)),
-        };
+            },
+        );
         l2_hash_cells.push(Cell::from(label).style(style));
     }
     let l2_hash_row = Row::new(l2_hash_cells).height(1);
@@ -601,10 +599,10 @@ fn render_validator_table(
             .style(Style::default().fg(Color::White).add_modifier(Modifier::BOLD)),
     ];
     for node in nodes {
-        let (label, style) = match node.safe_l2_block {
-            Some(n) => (format!("   #{n}"), Style::default().fg(Color::White)),
-            None => ("   ?".to_string(), Style::default().fg(Color::DarkGray)),
-        };
+        let (label, style) = node.safe_l2_block.map_or_else(
+            || ("   ?".to_string(), Style::default().fg(Color::DarkGray)),
+            |n| (format!("   #{n}"), Style::default().fg(Color::White)),
+        );
         safe_l2_cells.push(Cell::from(label).style(style));
     }
     let safe_l2_row = Row::new(safe_l2_cells).height(1);
@@ -615,13 +613,13 @@ fn render_validator_table(
             .style(Style::default().fg(Color::White).add_modifier(Modifier::BOLD)),
     ];
     for node in nodes {
-        let (label, style) = match node.safe_l2_hash {
-            Some(h) => {
+        let (label, style) = node.safe_l2_hash.map_or_else(
+            || ("   ?".to_string(), Style::default().fg(Color::DarkGray)),
+            |h| {
                 let hex = format!("{h:x}");
                 (format!("   0x{}…", &hex[..8]), Style::default().fg(Color::White))
-            }
-            None => ("   ?".to_string(), Style::default().fg(Color::DarkGray)),
-        };
+            },
+        );
         safe_hash_cells.push(Cell::from(label).style(style));
     }
     let safe_hash_row = Row::new(safe_hash_cells).height(1);
@@ -632,10 +630,10 @@ fn render_validator_table(
             .style(Style::default().fg(Color::White).add_modifier(Modifier::BOLD)),
     ];
     for node in nodes {
-        let (label, style) = match node.finalized_l2_block {
-            Some(n) => (format!("   #{n}"), Style::default().fg(Color::White)),
-            None => ("   ?".to_string(), Style::default().fg(Color::DarkGray)),
-        };
+        let (label, style) = node.finalized_l2_block.map_or_else(
+            || ("   ?".to_string(), Style::default().fg(Color::DarkGray)),
+            |n| (format!("   #{n}"), Style::default().fg(Color::White)),
+        );
         finalized_l2_cells.push(Cell::from(label).style(style));
     }
     let finalized_l2_row = Row::new(finalized_l2_cells).height(1);
@@ -681,10 +679,10 @@ fn render_validator_table(
         Cell::from("  Block").style(Style::default().fg(Color::White).add_modifier(Modifier::BOLD)),
     ];
     for node in nodes {
-        let (label, style) = match node.el_block {
-            Some(n) => (format!("   #{n}"), Style::default().fg(Color::White)),
-            None => ("   -".to_string(), Style::default().fg(Color::DarkGray)),
-        };
+        let (label, style) = node.el_block.map_or_else(
+            || ("   -".to_string(), Style::default().fg(Color::DarkGray)),
+            |n| (format!("   #{n}"), Style::default().fg(Color::White)),
+        );
         el_block_cells.push(Cell::from(label).style(style));
     }
     let el_block_row = Row::new(el_block_cells).height(1);

--- a/crates/infra/basectl/src/config.rs
+++ b/crates/infra/basectl/src/config.rs
@@ -8,6 +8,24 @@ use base_consensus_registry::Registry;
 use serde::{Deserialize, Serialize};
 use url::Url;
 
+/// Configuration for a single validator (non-sequencing) node in the local devnet.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ValidatorNodeConfig {
+    /// Human-readable name for this node (e.g. "base-client").
+    pub name: String,
+    /// Consensus-layer JSON-RPC endpoint (serves `optimism_*` and `opp2p_*` methods).
+    pub cl_rpc: Url,
+    /// Execution-layer JSON-RPC endpoint for this node.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub el_rpc: Option<Url>,
+    /// Docker container name for the EL process.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub docker_el: Option<String>,
+    /// Docker container name for the CL process.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub docker_cl: Option<String>,
+}
+
 /// Configuration for a single node in an HA conductor cluster.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ConductorNodeConfig {
@@ -87,6 +105,9 @@ pub struct ChainConfig {
     /// HA conductor cluster nodes, if this chain runs an op-conductor setup.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub conductors: Option<Vec<ConductorNodeConfig>>,
+    /// Validator (non-sequencing) nodes to monitor alongside the conductor cluster.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub validators: Option<Vec<ValidatorNodeConfig>>,
 }
 
 impl ChainConfig {
@@ -126,6 +147,7 @@ struct ChainConfigOverride {
     batcher_address: Option<Address>,
     l1_blob_target: Option<u64>,
     conductors: Option<Vec<ConductorNodeConfig>>,
+    validators: Option<Vec<ValidatorNodeConfig>>,
 }
 
 impl ChainConfig {
@@ -143,6 +165,7 @@ impl ChainConfig {
             batcher_address: Some("0x5050F69a9786F081509234F1a7F4684b5E5b76C9".parse().unwrap()),
             l1_blob_target: 14,
             conductors: None,
+            validators: None,
         }
     }
 
@@ -160,6 +183,7 @@ impl ChainConfig {
             batcher_address: Some("0xfc56E7272EEBBBA5bC6c544e159483C4a38f8bA3".parse().unwrap()),
             l1_blob_target: 14,
             conductors: None,
+            validators: None,
         }
     }
 
@@ -220,6 +244,13 @@ impl ChainConfig {
                     flashblocks_ws: Some(Url::parse("ws://localhost:11111").unwrap()),
                 },
             ]),
+            validators: Some(vec![ValidatorNodeConfig {
+                name: "base-client".to_string(),
+                cl_rpc: Url::parse("http://localhost:8549").unwrap(),
+                el_rpc: Some(Url::parse("http://localhost:8545").unwrap()),
+                docker_el: Some("base-client".to_string()),
+                docker_cl: Some("base-client-cl".to_string()),
+            }]),
         }
     }
 
@@ -323,6 +354,7 @@ impl ChainConfig {
             batcher_address: overrides.batcher_address.or(base.batcher_address),
             l1_blob_target: overrides.l1_blob_target.unwrap_or(base.l1_blob_target),
             conductors: overrides.conductors.or(base.conductors),
+            validators: overrides.validators.or(base.validators),
         })
     }
 

--- a/crates/infra/basectl/src/lib.rs
+++ b/crates/infra/basectl/src/lib.rs
@@ -5,7 +5,7 @@ pub use app::{ViewId, run_app, run_app_with_view, run_flashblocks_json};
 
 mod commands;
 mod config;
-pub use config::{ChainConfig, ConductorNodeConfig};
+pub use config::{ChainConfig, ConductorNodeConfig, ValidatorNodeConfig};
 
 mod l1_client;
 mod rpc;

--- a/crates/infra/basectl/src/rpc.rs
+++ b/crates/infra/basectl/src/rpc.rs
@@ -16,7 +16,7 @@ use tokio::sync::{mpsc, watch};
 use tokio_tungstenite::connect_async;
 use tracing::warn;
 
-use crate::{config::ConductorNodeConfig, tui::Toast};
+use crate::{config::{ConductorNodeConfig, ValidatorNodeConfig}, tui::Toast};
 
 const CONCURRENT_BLOCK_FETCHES: usize = 16;
 const WS_RECONNECT_INITIAL_DELAY: Duration = Duration::from_secs(1);
@@ -944,6 +944,135 @@ pub(crate) async fn run_conductor_poller(
                     name: name.clone(),
                     is_leader: is_leader.ok(),
                     conductor_active: conductor_active.ok(),
+                    unsafe_l2_block: sync.as_ref().map(|s| s.unsafe_l2.block_info.number),
+                    unsafe_l2_hash: sync.as_ref().map(|s| s.unsafe_l2.block_info.hash),
+                    safe_l2_block: sync.as_ref().map(|s| s.safe_l2.block_info.number),
+                    safe_l2_hash: sync.as_ref().map(|s| s.safe_l2.block_info.hash),
+                    finalized_l2_block: sync.as_ref().map(|s| s.finalized_l2.block_info.number),
+                    current_l1_block: sync.as_ref().map(|s| s.current_l1.number),
+                    head_l1_block: sync.as_ref().map(|s| s.head_l1.number),
+                    cl_peer_count: cl_peer_stats.ok().map(|s| s.connected),
+                    el_block: el_block_r,
+                    el_syncing: el_syncing_r,
+                    el_peer_count: el_peers_r,
+                }
+            },
+        ))
+        .await;
+
+        if tx.send(statuses).await.is_err() {
+            break;
+        }
+    }
+}
+
+/// Live status snapshot for a single validator (non-sequencing) node.
+#[derive(Debug, Clone)]
+pub(crate) struct ValidatorNodeStatus {
+    /// Human-readable name for this node.
+    pub name: String,
+
+    // ── CL (consensus layer) ─────────────────────────────────────────────
+    /// Unsafe L2 block number from `optimism_syncStatus`.
+    pub unsafe_l2_block: Option<u64>,
+    /// Unsafe L2 block hash from `optimism_syncStatus`.
+    pub unsafe_l2_hash: Option<alloy_primitives::B256>,
+    /// Safe L2 block number from `optimism_syncStatus`.
+    pub safe_l2_block: Option<u64>,
+    /// Safe L2 block hash from `optimism_syncStatus`.
+    pub safe_l2_hash: Option<alloy_primitives::B256>,
+    /// Finalized L2 block number from `optimism_syncStatus`.
+    pub finalized_l2_block: Option<u64>,
+    /// L1 derivation cursor block number (`current_l1`).
+    pub current_l1_block: Option<u64>,
+    /// L1 chain head block number (`head_l1`).
+    pub head_l1_block: Option<u64>,
+    /// Number of connected CL libp2p peers from `opp2p_peerStats`.
+    pub cl_peer_count: Option<u32>,
+
+    // ── EL (execution layer) ─────────────────────────────────────────────
+    /// Latest block number from `eth_blockNumber`. `None` if `el_rpc` not configured.
+    pub el_block: Option<u64>,
+    /// Whether the EL is snap-syncing. `None` if not configured.
+    pub el_syncing: Option<bool>,
+    /// Number of connected EL devp2p peers from `net_peerCount`. `None` if not configured.
+    pub el_peer_count: Option<u32>,
+}
+
+/// Polls all validator nodes every 200 ms and forwards status snapshots.
+pub(crate) async fn run_validator_poller(
+    nodes: Vec<ValidatorNodeConfig>,
+    tx: mpsc::Sender<Vec<ValidatorNodeStatus>>,
+) {
+    const POLL_INTERVAL: Duration = Duration::from_millis(200);
+    const RPC_TIMEOUT: Duration = Duration::from_millis(500);
+
+    let clients: Vec<(String, _, _)> = nodes
+        .into_iter()
+        .filter_map(|node| {
+            let cl_client = HttpClientBuilder::default()
+                .request_timeout(RPC_TIMEOUT)
+                .build(node.cl_rpc.as_str())
+                .inspect_err(|e| {
+                    warn!(error = %e, node = %node.name, "failed to build validator CL HTTP client");
+                })
+                .ok()?;
+            let el_client = node.el_rpc.as_ref().and_then(|url| {
+                HttpClientBuilder::default()
+                    .request_timeout(RPC_TIMEOUT)
+                    .build(url.as_str())
+                    .inspect_err(|e| {
+                        warn!(error = %e, node = %node.name, "failed to build validator EL HTTP client");
+                    })
+                    .ok()
+            });
+            Some((node.name, cl_client, el_client))
+        })
+        .collect();
+
+    let mut interval = tokio::time::interval(POLL_INTERVAL);
+    interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+
+    loop {
+        interval.tick().await;
+
+        let statuses = futures::future::join_all(clients.iter().map(
+            |(name, cl_client, el_client)| async move {
+                let (sync, cl_peer_stats, el_block_r, el_syncing_r, el_peers_r) = tokio::join!(
+                    RollupNodeApiClient::op_sync_status(cl_client),
+                    OpP2PApiClient::opp2p_peer_stats(cl_client),
+                    async {
+                        if let Some(el) = el_client {
+                            let r: Result<alloy_primitives::U64, _> =
+                                ClientT::request(el, "eth_blockNumber", rpc_params![]).await;
+                            r.ok().map(|v| v.to::<u64>())
+                        } else {
+                            None
+                        }
+                    },
+                    async {
+                        if let Some(el) = el_client {
+                            let r: Result<serde_json::Value, _> =
+                                ClientT::request(el, "eth_syncing", rpc_params![]).await;
+                            r.ok().map(|v| !matches!(v, serde_json::Value::Bool(false)))
+                        } else {
+                            None
+                        }
+                    },
+                    async {
+                        if let Some(el) = el_client {
+                            let r: Result<alloy_primitives::U64, _> =
+                                ClientT::request(el, "net_peerCount", rpc_params![]).await;
+                            r.ok().map(|v| v.to::<u32>())
+                        } else {
+                            None
+                        }
+                    },
+                );
+
+                let sync = sync.ok();
+                ValidatorNodeStatus {
+                    name: name.clone(),
                     unsafe_l2_block: sync.as_ref().map(|s| s.unsafe_l2.block_info.number),
                     unsafe_l2_hash: sync.as_ref().map(|s| s.unsafe_l2.block_info.hash),
                     safe_l2_block: sync.as_ref().map(|s| s.safe_l2.block_info.number),

--- a/crates/infra/basectl/src/rpc.rs
+++ b/crates/infra/basectl/src/rpc.rs
@@ -16,7 +16,10 @@ use tokio::sync::{mpsc, watch};
 use tokio_tungstenite::connect_async;
 use tracing::warn;
 
-use crate::{config::{ConductorNodeConfig, ValidatorNodeConfig}, tui::Toast};
+use crate::{
+    config::{ConductorNodeConfig, ValidatorNodeConfig},
+    tui::Toast,
+};
 
 const CONCURRENT_BLOCK_FETCHES: usize = 16;
 const WS_RECONNECT_INITIAL_DELAY: Duration = Duration::from_secs(1);


### PR DESCRIPTION
## Summary

Adds a Validators section below the HA Conductor table in the basectl conductor view. Validator nodes are polled every 200ms for CL and EL stats (sync status, L1 derivation, peer counts, EL block) — the same metrics shown for sequencer instances, minus conductor-specific fields like role and active state. The devnet default config wires in base-client automatically. The feature is opt-in via a new validators field in chain config.