### PR TITLE
test(builder): add build_block and FlashblocksExtraCtx unit tests

### DIFF
--- a/crates/builder/core/src/flashblocks/context.rs
+++ b/crates/builder/core/src/flashblocks/context.rs
@@ -1147,4 +1147,51 @@ mod tests {
         assert_eq!(diag.txs_considered, 5);
         assert_eq!(diag.txs_included, 2);
     }
+
+    /// [`FlashblocksExtraCtx::next`] must increment the flashblock index,
+    /// update all per-batch target fields to the new values, and preserve
+    /// the per-batch *limit* fields and the target flashblock count.
+    #[test]
+    fn extra_ctx_next_advances_index_and_updates_targets() {
+        let ctx = FlashblocksExtraCtx {
+            flashblock_index: 2,
+            target_flashblock_count: 10,
+            target_gas_for_batch: 1_000_000,
+            target_da_for_batch: Some(500),
+            target_da_footprint_for_batch: Some(200),
+            target_execution_time_for_batch_us: Some(100_000),
+            target_state_root_gas_for_batch: Some(50_000),
+            gas_per_batch: 3_000_000,
+            da_per_batch: Some(1_500),
+            da_footprint_per_batch: Some(600),
+            execution_time_per_batch_us: Some(300_000),
+            state_root_gas_per_batch: Some(150_000),
+        };
+
+        let next = ctx.next(
+            2_000_000,     // new gas target
+            Some(800),     // new DA target
+            Some(350),     // new DA footprint target
+            Some(200_000), // new execution time target
+            Some(80_000),  // new state root gas target
+        );
+
+        // Index incremented
+        assert_eq!(next.flashblock_index, 3);
+
+        // Target fields updated to the supplied values
+        assert_eq!(next.target_gas_for_batch, 2_000_000);
+        assert_eq!(next.target_da_for_batch, Some(800));
+        assert_eq!(next.target_da_footprint_for_batch, Some(350));
+        assert_eq!(next.target_execution_time_for_batch_us, Some(200_000));
+        assert_eq!(next.target_state_root_gas_for_batch, Some(80_000));
+
+        // Per-batch limits and target count are preserved (..self)
+        assert_eq!(next.target_flashblock_count, 10);
+        assert_eq!(next.gas_per_batch, 3_000_000);
+        assert_eq!(next.da_per_batch, Some(1_500));
+        assert_eq!(next.da_footprint_per_batch, Some(600));
+        assert_eq!(next.execution_time_per_batch_us, Some(300_000));
+        assert_eq!(next.state_root_gas_per_batch, Some(150_000));
+    }
 }

--- a/crates/builder/core/src/flashblocks/payload.rs
+++ b/crates/builder/core/src/flashblocks/payload.rs
@@ -1229,6 +1229,99 @@ mod tests {
         assert_eq!(fb_payload.diff.block_hash, payload.block().hash(), "hash mismatch");
     }
 
+    /// Verify that [`build_block`] exercises the state root calculation path
+    /// when `calculate_state_root = true`.
+    ///
+    /// With [`NoopProvider`], both `hashed_post_state` and
+    /// `state_root_with_updates` return defaults, so the state root ends up
+    /// as [`B256::ZERO`].  The important property under test is that the
+    /// `calculate_state_root = true` branch runs without error and the
+    /// resulting header carries the computed root.
+    #[test]
+    fn build_block_empty_with_state_root() {
+        let chain_spec = minimal_chain_spec();
+        let parent = genesis_header();
+        let ctx = OpPayloadBuilderCtx::for_test(chain_spec, Arc::clone(&parent));
+
+        let db = StateProviderDatabase::new(NoopProvider::default());
+        let mut state = State::builder().with_database(db).with_bundle_update().build();
+        let mut info = ExecutionInfo::default();
+
+        let (payload, _fb_payload) =
+            build_block::<_, NoopProvider>(&mut state, &ctx, &mut info, true)
+                .expect("build_block with state root should succeed");
+
+        // NoopProvider returns B256::default() for all state root queries,
+        // which equals B256::ZERO.
+        assert_eq!(
+            payload.block().state_root,
+            B256::ZERO,
+            "NoopProvider should yield a zero state root"
+        );
+
+        assert_eq!(payload.block().number, parent.number + 1);
+    }
+
+    /// [`build_block`] must return an error when the EVM environment's block
+    /// number does not match `parent.number + 1`.
+    ///
+    /// In production this would indicate a bug in context construction or a
+    /// stale parent header.  The guard at the top of `build_block` exists to
+    /// catch exactly this class of misconfiguration.
+    #[test]
+    fn build_block_rejects_block_number_mismatch() {
+        let chain_spec = minimal_chain_spec();
+        let parent = genesis_header();
+        let mut ctx = OpPayloadBuilderCtx::for_test(chain_spec, Arc::clone(&parent));
+
+        // Tamper with the EVM block number so it disagrees with parent + 1.
+        // parent.number is 0, so the expected block number is 1.
+        // Setting it to 99 should trigger the mismatch guard.
+        ctx.evm_env.block_env.number = U256::from(99);
+
+        let db = StateProviderDatabase::new(NoopProvider::default());
+        let mut state = State::builder().with_database(db).with_bundle_update().build();
+        let mut info = ExecutionInfo::default();
+
+        let err = build_block::<_, NoopProvider>(&mut state, &ctx, &mut info, false)
+            .expect_err("build_block should fail on block number mismatch");
+
+        let msg = err.to_string();
+        assert!(
+            msg.contains("block number mismatch"),
+            "error should mention block number mismatch, got: {msg}"
+        );
+    }
+
+    /// [`build_block`] must return an error when the payload attributes lack
+    /// a `parent_beacon_block_root`.
+    ///
+    /// The flashblocks payload construction unconditionally reads this field,
+    /// so a `None` value is an unrecoverable configuration error that should
+    /// surface clearly rather than panicking.
+    #[test]
+    fn build_block_rejects_missing_beacon_block_root() {
+        let chain_spec = minimal_chain_spec();
+        let parent = genesis_header();
+        let mut ctx = OpPayloadBuilderCtx::for_test(chain_spec, Arc::clone(&parent));
+
+        // Clear the parent beacon block root that for_test() sets.
+        ctx.config.attributes.payload_attributes.parent_beacon_block_root = None;
+
+        let db = StateProviderDatabase::new(NoopProvider::default());
+        let mut state = State::builder().with_database(db).with_bundle_update().build();
+        let mut info = ExecutionInfo::default();
+
+        let err = build_block::<_, NoopProvider>(&mut state, &ctx, &mut info, false)
+            .expect_err("build_block should fail without beacon block root");
+
+        let msg = err.to_string();
+        assert!(
+            msg.contains("parent beacon block root not found"),
+            "error should mention missing beacon block root, got: {msg}"
+        );
+    }
+
     /// Pin the JSON field names and structure of [`FlashblocksMetadata`].
     ///
     /// This struct is serialized into the `metadata` field of the flashblocks


### PR DESCRIPTION
Adds four stateless unit tests using the `NoopProvider` + in-memory `State` infra from #1810:

- `build_block_empty_with_state_root` — `calculate_state_root = true` path
- `build_block_rejects_block_number_mismatch` — stale parent header guard
- `build_block_rejects_missing_beacon_block_root` — missing beacon root error
- `extra_ctx_next_advances_index_and_updates_targets` — index increment, target updates, field preservation through `..self`