### PR TITLE
ktlo(consensus): Base Types

### DIFF
--- a/crates/consensus/disc/src/builder.rs
+++ b/crates/consensus/disc/src/builder.rs
@@ -3,7 +3,7 @@
 use std::net::IpAddr;
 
 use alloy_rlp::Encodable;
-use base_consensus_peers::{BootNodes, BootStoreFile, OpStackEnr};
+use base_consensus_peers::{BaseEnr, BootNodes, BootStoreFile};
 use discv5::{Config, Discv5, Enr, enr::k256};
 use tokio::time::Duration;
 
@@ -50,12 +50,12 @@ impl LocalNode {
     /// [the op-node implementation](https://github.com/ethereum-optimism/optimism/blob/174e55f0a1e73b49b80a561fd3fedd4fea5770c6/op-node/p2p/discovery.go#L61-L97)
     /// for the go equivalent
     fn build_enr(self, chain_id: u64) -> Result<Enr, discv5::enr::Error> {
-        let opstack = OpStackEnr::from_chain_id(chain_id);
-        let mut opstack_data = Vec::new();
-        opstack.encode(&mut opstack_data);
+        let base_enr = BaseEnr::from_chain_id(chain_id);
+        let mut base_enr_data = Vec::new();
+        base_enr.encode(&mut base_enr_data);
 
         let mut enr_builder = Enr::builder();
-        enr_builder.add_value_rlp(OpStackEnr::OP_CL_KEY, opstack_data.into());
+        enr_builder.add_value_rlp(BaseEnr::OP_CL_KEY, base_enr_data.into());
         match self.ip {
             IpAddr::V4(addr) => {
                 enr_builder.ip4(addr).tcp4(self.tcp_port).udp4(self.udp_port);

--- a/crates/consensus/disc/src/driver.rs
+++ b/crates/consensus/disc/src/driver.rs
@@ -2,7 +2,7 @@
 
 use backon::{ExponentialBuilder, RetryableWithContext};
 use base_consensus_peers::{
-    BootNode, BootNodes, BootStore, BootStoreFile, EnrValidation, enr_to_multiaddr,
+    BootNode, BootNodes, BootStore, BootStoreFile, EnrValidation, PeerUtils,
 };
 use derive_more::Debug;
 use discv5::{Config, Discv5, Enr, enr::NodeId};
@@ -256,7 +256,7 @@ impl Discv5Driver {
                                     let enrs = self.disc.table_entries_enr();
 
                                     for enr in enrs {
-                                        let Some(multi_addr) = enr_to_multiaddr(&enr) else {
+                                        let Some(multi_addr) = PeerUtils::enr_to_multiaddr(&enr) else {
                                             continue;
                                         };
 

--- a/crates/consensus/gossip/src/driver.rs
+++ b/crates/consensus/gossip/src/driver.rs
@@ -9,7 +9,7 @@ use std::{
 use alloy_primitives::{Address, hex};
 use base_alloy_rpc_types_engine::OpNetworkPayloadEnvelope;
 use base_consensus_genesis::RollupConfig;
-use base_consensus_peers::{EnrValidation, PeerMonitoring, enr_to_multiaddr};
+use base_consensus_peers::{EnrValidation, PeerMonitoring, PeerUtils};
 use derive_more::Debug;
 use discv5::Enr;
 use futures::{AsyncReadExt, AsyncWriteExt, stream::StreamExt};
@@ -237,7 +237,7 @@ where
             trace!(target: "gossip", chain_id = %self.handler.rollup_config.l2_chain_id.id(), validation = %validation, "Invalid Base ENR");
             return;
         }
-        let Some(multiaddr) = enr_to_multiaddr(&enr) else {
+        let Some(multiaddr) = PeerUtils::enr_to_multiaddr(&enr) else {
             debug!(target: "gossip", enr = ?enr, "Failed to extract tcp socket from enr");
             Metrics::dial_peer_error("invalid_enr").increment(1.0);
             return;

--- a/crates/consensus/gossip/src/rpc/request.rs
+++ b/crates/consensus/gossip/src/rpc/request.rs
@@ -4,7 +4,7 @@ use std::{net::IpAddr, num::TryFromIntError, sync::Arc};
 
 use alloy_primitives::map::{HashMap, HashSet};
 use base_consensus_disc::Discv5Handler;
-use base_consensus_peers::OpStackEnr;
+use base_consensus_peers::BaseEnr;
 use discv5::{
     enr::{NodeId, k256::ecdsa},
     multiaddr::Protocol,
@@ -383,8 +383,8 @@ impl P2pRpcRequest {
                 .map(|(id, peer_id)| {
                     let (maybe_enr, maybe_status) = node_to_table_infos.get(id).cloned().unzip();
 
-                    let opstack_enr =
-                        maybe_enr.clone().and_then(|enr| OpStackEnr::try_from(&enr).ok());
+                    let base_enr =
+                        maybe_enr.clone().and_then(|enr| BaseEnr::try_from(&enr).ok());
 
                     let direction = maybe_status
                         .map(|status| {
@@ -419,7 +419,7 @@ impl P2pRpcRequest {
                             direction,
                             // Note: we use the chain id from the ENR if it exists, otherwise we
                             // use 0 to be consistent with op-node's behavior (`<https://github.com/ethereum-optimism/optimism/blob/6a8b2349c29c2a14f948fcb8aefb90526130acec/op-service/apis/p2p.go#L55>`).
-                            chain_id: opstack_enr.map(|enr| enr.chain_id).unwrap_or(0),
+                            chain_id: base_enr.map(|enr| enr.chain_id).unwrap_or(0),
                             gossip_blocks: peer_gossip_info.contains(peer_id),
                             protected: protected_peers.contains(peer_id),
                             latency,

--- a/crates/consensus/gossip/src/rpc/request.rs
+++ b/crates/consensus/gossip/src/rpc/request.rs
@@ -383,8 +383,7 @@ impl P2pRpcRequest {
                 .map(|(id, peer_id)| {
                     let (maybe_enr, maybe_status) = node_to_table_infos.get(id).cloned().unzip();
 
-                    let base_enr =
-                        maybe_enr.clone().and_then(|enr| BaseEnr::try_from(&enr).ok());
+                    let base_enr = maybe_enr.clone().and_then(|enr| BaseEnr::try_from(&enr).ok());
 
                     let direction = maybe_status
                         .map(|status| {

--- a/crates/consensus/peers/src/any.rs
+++ b/crates/consensus/peers/src/any.rs
@@ -4,7 +4,7 @@ use derive_more::From;
 use discv5::{Enr, enr::EnrPublicKey};
 use libp2p::swarm::dial_opts::DialOpts;
 
-use super::utils::peer_id_to_secp256k1_pubkey;
+use super::utils::PeerUtils;
 use crate::{NodeRecord, PeerId};
 
 /// A peer that can come in [`Enr`] or [`NodeRecord`] form.
@@ -41,7 +41,7 @@ impl AnyNode {
 
     /// Converts the [`AnyNode`] into [`DialOpts`].
     pub fn as_dial_opts(&self) -> Result<DialOpts, DialOptsError> {
-        let pub_key = &peer_id_to_secp256k1_pubkey(self.peer_id())
+        let pub_key = &PeerUtils::peer_id_to_secp256k1_pubkey(self.peer_id())
             .map_err(DialOptsError::InvalidPeerId)?
             .serialize();
 

--- a/crates/consensus/peers/src/boot.rs
+++ b/crates/consensus/peers/src/boot.rs
@@ -9,8 +9,8 @@ use discv5::{
 };
 use serde::{Deserialize, Serialize};
 
-use super::utils::{PeerIdConversionError, local_id_to_p2p_id};
-use crate::{NodeRecord, enr_to_multiaddr};
+use super::utils::{PeerIdConversionError, PeerUtils};
+use crate::NodeRecord;
 
 /// Errors that can occur when parsing a bootnode.
 #[derive(Debug, thiserror::Error)]
@@ -51,7 +51,7 @@ impl BootNode {
 
         multi_address.push(Protocol::Udp(udp_port));
         multi_address.push(Protocol::Tcp(tcp_port));
-        multi_address.push(Protocol::P2p(local_id_to_p2p_id(id)?));
+        multi_address.push(Protocol::P2p(PeerUtils::local_id_to_p2p_id(id)?));
 
         Ok(Self::Enode(multi_address))
     }
@@ -60,7 +60,7 @@ impl BootNode {
     pub fn to_multiaddr(&self) -> Option<Multiaddr> {
         match self {
             Self::Enode(addr) => Some(addr.clone()),
-            Self::Enr(enr) => enr_to_multiaddr(enr),
+            Self::Enr(enr) => PeerUtils::enr_to_multiaddr(enr),
         }
     }
 
@@ -89,7 +89,7 @@ mod tests {
     use rstest::rstest;
 
     use super::*;
-    use crate::utils::peer_id_to_secp256k1_pubkey;
+    use crate::PeerUtils;
 
     #[test]
     fn test_derive_bootnode_enode_multiaddr() {
@@ -103,7 +103,7 @@ mod tests {
             .to_string();
 
         let peer_id = crate::PeerId::from_str(&peer_id).unwrap();
-        let p2p_peer_id = local_id_to_p2p_id(peer_id).unwrap();
+        let p2p_peer_id = PeerUtils::local_id_to_p2p_id(peer_id).unwrap();
 
         let expected_multiaddr = Multiaddr::empty()
             .with(Protocol::Ip4(Ipv4Addr::new(34, 65, 205, 244)))
@@ -134,7 +134,7 @@ mod tests {
         let peer_id = crate::PeerId::from_str(&peer_id).unwrap();
 
         // The public key from the peer id is using the uncompressed form.
-        let pkey_secp256k1 = peer_id_to_secp256k1_pubkey(peer_id).unwrap();
+        let pkey_secp256k1 = PeerUtils::peer_id_to_secp256k1_pubkey(peer_id).unwrap();
         let p2p_public_key: discv5::libp2p_identity::secp256k1::PublicKey =
             discv5::libp2p_identity::secp256k1::PublicKey::try_from_bytes(
                 &pkey_secp256k1.serialize(),

--- a/crates/consensus/peers/src/enr.rs
+++ b/crates/consensus/peers/src/enr.rs
@@ -9,7 +9,7 @@ use unsigned_varint::{decode, encode};
 pub enum EnrValidation {
     /// Conversion error.
     #[display("Conversion error: {_0}")]
-    ConversionError(OpStackEnrError),
+    ConversionError(BaseEnrError),
     /// Invalid Chain ID.
     #[display("Invalid Chain ID: {_0}")]
     InvalidChainId(u64),
@@ -22,13 +22,13 @@ pub enum EnrValidation {
 impl EnrValidation {
     /// Validates the [`Enr`] for Base.
     pub fn validate(enr: &Enr, chain_id: u64) -> Self {
-        let opstack_enr = match OpStackEnr::try_from(enr) {
-            Ok(opstack_enr) => opstack_enr,
+        let base_enr = match BaseEnr::try_from(enr) {
+            Ok(base_enr) => base_enr,
             Err(e) => return Self::ConversionError(e),
         };
 
-        if opstack_enr.chain_id != chain_id {
-            return Self::InvalidChainId(opstack_enr.chain_id);
+        if base_enr.chain_id != chain_id {
+            return Self::InvalidChainId(base_enr.chain_id);
         }
 
         Self::Valid
@@ -48,16 +48,16 @@ impl EnrValidation {
 /// The unique L2 network identifier
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
-pub struct OpStackEnr {
+pub struct BaseEnr {
     /// Chain ID
     pub chain_id: u64,
     /// The version. Always set to 0.
     pub version: u64,
 }
 
-/// The error type that can be returned when trying to convert an [`Enr`] to an [`OpStackEnr`].
+/// The error type that can be returned when trying to convert an [`Enr`] to a [`BaseEnr`].
 #[derive(Debug, thiserror::Error, Clone, PartialEq, Eq)]
-pub enum OpStackEnrError {
+pub enum BaseEnrError {
     /// Missing Base ENR key.
     #[error("Missing Base ENR key")]
     MissingKey,
@@ -69,34 +69,34 @@ pub enum OpStackEnrError {
     InvalidVersion(u64),
 }
 
-impl TryFrom<&Enr> for OpStackEnr {
-    type Error = OpStackEnrError;
+impl TryFrom<&Enr> for BaseEnr {
+    type Error = BaseEnrError;
     fn try_from(enr: &Enr) -> Result<Self, Self::Error> {
         let Some(mut opstack) = enr.get_raw_rlp(Self::OP_CL_KEY) else {
-            return Err(OpStackEnrError::MissingKey);
+            return Err(BaseEnrError::MissingKey);
         };
-        let opstack_enr =
-            Self::decode(&mut opstack).map_err(|e| OpStackEnrError::DecodeError(e.to_string()))?;
+        let base_enr =
+            Self::decode(&mut opstack).map_err(|e| BaseEnrError::DecodeError(e.to_string()))?;
 
-        if opstack_enr.version != 0 {
-            return Err(OpStackEnrError::InvalidVersion(opstack_enr.version));
+        if base_enr.version != 0 {
+            return Err(BaseEnrError::InvalidVersion(base_enr.version));
         }
 
-        Ok(opstack_enr)
+        Ok(base_enr)
     }
 }
 
-impl OpStackEnr {
+impl BaseEnr {
     /// The [`Enr`] key literal string for the consensus layer.
     pub const OP_CL_KEY: &str = "opstack";
 
-    /// Constructs an [`OpStackEnr`] from a chain id.
+    /// Constructs a [`BaseEnr`] from a chain id.
     pub const fn from_chain_id(chain_id: u64) -> Self {
         Self { chain_id, version: 0 }
     }
 }
 
-impl Encodable for OpStackEnr {
+impl Encodable for BaseEnr {
     fn encode(&self, out: &mut dyn alloy_rlp::BufMut) {
         let mut chain_id_buf = encode::u128_buffer();
         let chain_id_slice = encode::u128(self.chain_id as u128, &mut chain_id_buf);
@@ -104,12 +104,12 @@ impl Encodable for OpStackEnr {
         let mut version_buf = encode::u128_buffer();
         let version_slice = encode::u128(self.version as u128, &mut version_buf);
 
-        let opstack = [chain_id_slice, version_slice].concat();
-        alloy_primitives::Bytes::from(opstack).encode(out);
+        let payload = [chain_id_slice, version_slice].concat();
+        alloy_primitives::Bytes::from(payload).encode(out);
     }
 }
 
-impl Decodable for OpStackEnr {
+impl Decodable for BaseEnr {
     fn decode(buf: &mut &[u8]) -> alloy_rlp::Result<Self> {
         let bytes = alloy_primitives::Bytes::decode(buf)?;
         let (chain_id, rest) = decode::u64(&bytes)
@@ -129,12 +129,12 @@ mod tests {
 
     #[test]
     #[cfg(feature = "arbitrary")]
-    fn roundtrip_op_stack_enr() {
+    fn roundtrip_base_enr() {
         arbtest::arbtest(|u| {
-            let op_stack_enr = OpStackEnr::from_chain_id(u.arbitrary()?);
-            let bytes = alloy_rlp::encode(op_stack_enr);
-            let decoded = OpStackEnr::decode(&mut &bytes[..]).unwrap();
-            assert_eq!(decoded, op_stack_enr);
+            let base_enr = BaseEnr::from_chain_id(u.arbitrary()?);
+            let bytes = alloy_rlp::encode(base_enr);
+            let decoded = BaseEnr::decode(&mut &bytes[..]).unwrap();
+            assert_eq!(decoded, base_enr);
             Ok(())
         });
     }
@@ -143,10 +143,10 @@ mod tests {
     fn test_enr_validation() {
         let key = CombinedKey::generate_secp256k1();
         let mut enr = Enr::builder().build(&key).unwrap();
-        let op_stack_enr = OpStackEnr::from_chain_id(8453);
-        let mut op_stack_bytes = Vec::new();
-        op_stack_enr.encode(&mut op_stack_bytes);
-        enr.insert_raw_rlp(OpStackEnr::OP_CL_KEY, op_stack_bytes.into(), &key).unwrap();
+        let base_enr = BaseEnr::from_chain_id(8453);
+        let mut base_enr_bytes = Vec::new();
+        base_enr.encode(&mut base_enr_bytes);
+        enr.insert_raw_rlp(BaseEnr::OP_CL_KEY, base_enr_bytes.into(), &key).unwrap();
         assert!(EnrValidation::validate(&enr, 8453).is_valid());
         assert!(EnrValidation::validate(&enr, 84532).is_invalid());
     }
@@ -155,20 +155,20 @@ mod tests {
     fn test_enr_validation_invalid_version() {
         let key = CombinedKey::generate_secp256k1();
         let mut enr = Enr::builder().build(&key).unwrap();
-        let mut op_stack_enr = OpStackEnr::from_chain_id(8453);
-        op_stack_enr.version = 1;
-        let mut op_stack_bytes = Vec::new();
-        op_stack_enr.encode(&mut op_stack_bytes);
-        enr.insert_raw_rlp(OpStackEnr::OP_CL_KEY, op_stack_bytes.into(), &key).unwrap();
+        let mut base_enr = BaseEnr::from_chain_id(8453);
+        base_enr.version = 1;
+        let mut base_enr_bytes = Vec::new();
+        base_enr.encode(&mut base_enr_bytes);
+        enr.insert_raw_rlp(BaseEnr::OP_CL_KEY, base_enr_bytes.into(), &key).unwrap();
         assert!(EnrValidation::validate(&enr, 8453).is_invalid());
     }
 
     #[test]
     fn test_base_mainnet_enr() {
-        let base_enr = OpStackEnr::from_chain_id(8453);
+        let base_enr = BaseEnr::from_chain_id(8453);
         let bytes = alloy_rlp::encode(base_enr);
         assert_eq!(Bytes::from(bytes.clone()), bytes!("83854200"));
-        let decoded = OpStackEnr::decode(&mut &bytes[..]).unwrap();
+        let decoded = BaseEnr::decode(&mut &bytes[..]).unwrap();
         assert_eq!(decoded, base_enr);
     }
 }

--- a/crates/consensus/peers/src/lib.rs
+++ b/crates/consensus/peers/src/lib.rs
@@ -23,7 +23,7 @@ mod score;
 pub use score::PeerScoreLevel;
 
 mod enr;
-pub use enr::{EnrValidation, OpStackEnr, OpStackEnrError};
+pub use enr::{BaseEnr, BaseEnrError, EnrValidation};
 
 mod any;
 pub use any::{AnyNode, DialOptsError};
@@ -35,9 +35,7 @@ mod record;
 pub use record::{NodeRecord, NodeRecordParseError};
 
 mod utils;
-pub use utils::{
-    PeerIdConversionError, enr_to_multiaddr, local_id_to_p2p_id, peer_id_to_secp256k1_pubkey,
-};
+pub use utils::{PeerIdConversionError, PeerUtils};
 
 mod monitoring;
 pub use monitoring::PeerMonitoring;

--- a/crates/consensus/peers/src/store.rs
+++ b/crates/consensus/peers/src/store.rs
@@ -128,16 +128,16 @@ impl BootStore {
     }
 
     /// Returns the number of peers in the bootstore that
-    /// have the [`crate::OpStackEnr::OP_CL_KEY`] in the ENR.
+    /// have the [`crate::BaseEnr::OP_CL_KEY`] in the ENR.
     pub fn valid_peers(&self) -> Vec<&Enr> {
         self.peers
             .iter()
-            .filter(|enr| enr.get_raw_rlp(crate::OpStackEnr::OP_CL_KEY.as_bytes()).is_some())
+            .filter(|enr| enr.get_raw_rlp(crate::BaseEnr::OP_CL_KEY.as_bytes()).is_some())
             .collect()
     }
 
     /// Returns the number of peers that contain the
-    /// [`crate::OpStackEnr::OP_CL_KEY`] in the ENR *and*
+    /// [`crate::BaseEnr::OP_CL_KEY`] in the ENR *and*
     /// have the correct chain id and version.
     pub fn valid_peers_with_chain_id(&self, chain_id: u64) -> Vec<&Enr> {
         self.peers

--- a/crates/consensus/peers/src/utils.rs
+++ b/crates/consensus/peers/src/utils.rs
@@ -9,46 +9,6 @@ use libp2p::Multiaddr;
 
 use super::PeerId;
 
-/// Converts an [`Enr`] into a [`Multiaddr`].
-pub fn enr_to_multiaddr(enr: &Enr) -> Option<Multiaddr> {
-    let mut addr = if let Some(socket) = enr.tcp4_socket() {
-        let mut addr = Multiaddr::from(*socket.ip());
-        addr.push(Protocol::Tcp(socket.port()));
-        addr
-    } else if let Some(socket) = enr.tcp6_socket() {
-        let mut addr = Multiaddr::from(*socket.ip());
-        addr.push(Protocol::Tcp(socket.port()));
-        addr
-    } else {
-        return None;
-    };
-
-    let CombinedPublicKey::Secp256k1(pub_key) = enr.public_key() else {
-        return None;
-    };
-
-    let pub_key = libp2p_identity::secp256k1::PublicKey::try_from_bytes(&pub_key.encode()).ok()?;
-    let pub_key = libp2p_identity::PublicKey::from(pub_key);
-
-    addr.push(Protocol::P2p(libp2p::PeerId::from_public_key(&pub_key)));
-
-    Some(addr)
-}
-
-/// Converts an uncompressed [`PeerId`] to a [`secp256k1::PublicKey`] by prepending the [`PeerId`]
-/// bytes with the `SECP256K1_TAG_PUBKEY_UNCOMPRESSED` tag.
-pub fn peer_id_to_secp256k1_pubkey(id: PeerId) -> Result<secp256k1::PublicKey, secp256k1::Error> {
-    /// Tags the public key as uncompressed.
-    ///
-    /// See: <https://github.com/bitcoin-core/secp256k1/blob/master/include/secp256k1.h#L211>
-    const SECP256K1_TAG_PUBKEY_UNCOMPRESSED: u8 = 4;
-
-    let mut full_pubkey = [0u8; secp256k1::constants::UNCOMPRESSED_PUBLIC_KEY_SIZE];
-    full_pubkey[0] = SECP256K1_TAG_PUBKEY_UNCOMPRESSED;
-    full_pubkey[1..].copy_from_slice(id.as_slice());
-    secp256k1::PublicKey::from_slice(&full_pubkey)
-}
-
 /// An error that can occur when converting a [`PeerId`] to a [`libp2p::PeerId`].
 #[derive(Debug, thiserror::Error)]
 pub enum PeerIdConversionError {
@@ -60,19 +20,73 @@ pub enum PeerIdConversionError {
     InvalidPublicKey(#[from] discv5::libp2p_identity::DecodingError),
 }
 
-/// Converts an uncoded [`PeerId`] to a [`libp2p::PeerId`]. These two types represent the same
-/// underlying concept (secp256k1 public key) but using different encodings (the local [`PeerId`] is
-/// the uncompressed representation of the public key, while the "p2plib" [`libp2p::PeerId`] is a
-/// more complex representation, involving protobuf encoding and bitcoin encoding,  defined here: <https://github.com/libp2p/specs/blob/master/peer-ids/peer-ids.md>).
-pub fn local_id_to_p2p_id(peer_id: PeerId) -> Result<libp2p::PeerId, PeerIdConversionError> {
-    // The libp2p library works with compressed public keys.
-    let encoded_pk_bytes = peer_id_to_secp256k1_pubkey(peer_id)
-        .map_err(PeerIdConversionError::InvalidPeerId)?
-        .serialize();
-    let pk: discv5::libp2p_identity::PublicKey =
-        discv5::libp2p_identity::secp256k1::PublicKey::try_from_bytes(&encoded_pk_bytes)?.into();
+/// Utility methods for converting between peer network identity and address types.
+#[derive(Debug)]
+pub struct PeerUtils;
 
-    Ok(pk.to_peer_id())
+impl PeerUtils {
+    /// Converts an [`Enr`] into a [`Multiaddr`].
+    pub fn enr_to_multiaddr(enr: &Enr) -> Option<Multiaddr> {
+        let mut addr = if let Some(socket) = enr.tcp4_socket() {
+            let mut addr = Multiaddr::from(*socket.ip());
+            addr.push(Protocol::Tcp(socket.port()));
+            addr
+        } else if let Some(socket) = enr.tcp6_socket() {
+            let mut addr = Multiaddr::from(*socket.ip());
+            addr.push(Protocol::Tcp(socket.port()));
+            addr
+        } else {
+            return None;
+        };
+
+        let CombinedPublicKey::Secp256k1(pub_key) = enr.public_key() else {
+            return None;
+        };
+
+        let pub_key =
+            libp2p_identity::secp256k1::PublicKey::try_from_bytes(&pub_key.encode()).ok()?;
+        let pub_key = libp2p_identity::PublicKey::from(pub_key);
+
+        addr.push(Protocol::P2p(libp2p::PeerId::from_public_key(&pub_key)));
+
+        Some(addr)
+    }
+
+    /// Converts an uncompressed [`PeerId`] to a [`secp256k1::PublicKey`] by prepending the
+    /// [`PeerId`] bytes with the `SECP256K1_TAG_PUBKEY_UNCOMPRESSED` tag.
+    ///
+    /// See: <https://github.com/bitcoin-core/secp256k1/blob/master/include/secp256k1.h#L211>
+    pub fn peer_id_to_secp256k1_pubkey(
+        id: PeerId,
+    ) -> Result<secp256k1::PublicKey, secp256k1::Error> {
+        /// Tags the public key as uncompressed.
+        const SECP256K1_TAG_PUBKEY_UNCOMPRESSED: u8 = 4;
+
+        let mut full_pubkey = [0u8; secp256k1::constants::UNCOMPRESSED_PUBLIC_KEY_SIZE];
+        full_pubkey[0] = SECP256K1_TAG_PUBKEY_UNCOMPRESSED;
+        full_pubkey[1..].copy_from_slice(id.as_slice());
+        secp256k1::PublicKey::from_slice(&full_pubkey)
+    }
+
+    /// Converts an uncoded [`PeerId`] to a [`libp2p::PeerId`]. These two types represent the same
+    /// underlying concept (secp256k1 public key) but using different encodings (the local
+    /// [`PeerId`] is the uncompressed representation of the public key, while the "libp2p"
+    /// [`libp2p::PeerId`] is a more complex representation, involving protobuf encoding and
+    /// bitcoin encoding, defined here:
+    /// <https://github.com/libp2p/specs/blob/master/peer-ids/peer-ids.md>).
+    pub fn local_id_to_p2p_id(
+        peer_id: PeerId,
+    ) -> Result<libp2p::PeerId, PeerIdConversionError> {
+        // The libp2p library works with compressed public keys.
+        let encoded_pk_bytes = Self::peer_id_to_secp256k1_pubkey(peer_id)
+            .map_err(PeerIdConversionError::InvalidPeerId)?
+            .serialize();
+        let pk: discv5::libp2p_identity::PublicKey =
+            discv5::libp2p_identity::secp256k1::PublicKey::try_from_bytes(&encoded_pk_bytes)?
+                .into();
+
+        Ok(pk.to_peer_id())
+    }
 }
 
 #[cfg(test)]
@@ -99,7 +113,7 @@ mod tests {
 
         let enr = Enr::builder().ip4(ip).tcp4(tcp_port).udp4(udp_port).build(&private_key).unwrap();
 
-        let multiaddr = enr_to_multiaddr(&enr).unwrap();
+        let multiaddr = PeerUtils::enr_to_multiaddr(&enr).unwrap();
 
         let mut received_ip = None;
         let mut received_tcp_port = None;
@@ -140,7 +154,7 @@ mod tests {
 
         let enr = Enr::builder().ip6(ip).tcp6(tcp_port).udp6(udp_port).build(&private_key).unwrap();
 
-        let multiaddr = enr_to_multiaddr(&enr).unwrap();
+        let multiaddr = PeerUtils::enr_to_multiaddr(&enr).unwrap();
 
         let mut received_ip = None;
         let mut received_tcp_port = None;
@@ -175,7 +189,7 @@ mod tests {
 
         // We need to convert the local peer id (uncompressed secp256k1 public key) to a libp2p
         // peer id (protocol buffer encoded public key).
-        let peer_id = local_id_to_p2p_id(local_peer_id).unwrap();
+        let peer_id = PeerUtils::local_id_to_p2p_id(local_peer_id).unwrap();
 
         let p2p_public_key: discv5::libp2p_identity::PublicKey =
             p2p_keypair.public().clone().into();
@@ -190,9 +204,9 @@ mod tests {
 
         // We need to convert the local peer id (uncompressed secp256k1 public key) to a libp2p
         // peer id (protocol buffer encoded public key).
-        let peer_id = local_id_to_p2p_id(pub_key).unwrap();
+        let peer_id = PeerUtils::local_id_to_p2p_id(pub_key).unwrap();
 
-        let uncompressed_pub_key = peer_id_to_secp256k1_pubkey(pub_key).unwrap();
+        let uncompressed_pub_key = PeerUtils::peer_id_to_secp256k1_pubkey(pub_key).unwrap();
 
         let p2p_public_key: discv5::libp2p_identity::PublicKey =
             discv5::libp2p_identity::secp256k1::PublicKey::try_from_bytes(

--- a/crates/consensus/peers/src/utils.rs
+++ b/crates/consensus/peers/src/utils.rs
@@ -74,9 +74,7 @@ impl PeerUtils {
     /// [`libp2p::PeerId`] is a more complex representation, involving protobuf encoding and
     /// bitcoin encoding, defined here:
     /// <https://github.com/libp2p/specs/blob/master/peer-ids/peer-ids.md>).
-    pub fn local_id_to_p2p_id(
-        peer_id: PeerId,
-    ) -> Result<libp2p::PeerId, PeerIdConversionError> {
+    pub fn local_id_to_p2p_id(peer_id: PeerId) -> Result<libp2p::PeerId, PeerIdConversionError> {
         // The libp2p library works with compressed public keys.
         let encoded_pk_bytes = Self::peer_id_to_secp256k1_pubkey(peer_id)
             .map_err(PeerIdConversionError::InvalidPeerId)?


### PR DESCRIPTION
## Summary

Renames `OpStackEnr` to `BaseEnr` and `OpStackEnrError` to `BaseEnrError` in the peers crate to align with Base stack naming conventions. Also wraps the three bare utility functions in `utils.rs` into a `PeerUtils` unit struct per codebase standards, so the public API exports types rather than loose functions.