### PR TITLE
feat(registrar): make tx retry constants CLI-configurable

### DIFF
--- a/bin/prover-registrar/src/cli.rs
+++ b/bin/prover-registrar/src/cli.rs
@@ -640,6 +640,7 @@ mod tests {
     #[case::zero_prover_timeout("--prover-timeout-secs", "0")]
     #[case::zero_boundless_timeout("--boundless-timeout-secs", "0")]
     #[case::zero_max_concurrency("--max-concurrency", "0")]
+    #[case::zero_tx_retry_delay("--tx-retry-delay-secs", "0")]
     fn zero_duration_fails_into_config(#[case] flag: &str, #[case] value: &str) {
         let mut args = boundless_args();
         args.extend([flag, value]);

--- a/bin/prover-registrar/src/cli.rs
+++ b/bin/prover-registrar/src/cli.rs
@@ -664,6 +664,8 @@ mod tests {
         assert_eq!(config.poll_interval, Duration::from_secs(DEFAULT_POLL_INTERVAL_SECS));
         assert_eq!(config.prover_timeout, Duration::from_secs(DEFAULT_PROVER_TIMEOUT_SECS));
         assert_eq!(config.max_concurrency, DEFAULT_MAX_CONCURRENCY);
+        assert_eq!(config.max_tx_retries, DEFAULT_MAX_TX_RETRIES);
+        assert_eq!(config.tx_retry_delay, Duration::from_secs(DEFAULT_TX_RETRY_DELAY_SECS));
     }
 
     #[rstest]

--- a/bin/prover-registrar/src/cli.rs
+++ b/bin/prover-registrar/src/cli.rs
@@ -19,8 +19,8 @@ use base_proof_tee_nitro_attestation_prover::{
 };
 use base_proof_tee_registrar::{
     AwsDiscoveryConfig, AwsTargetGroupDiscovery, BoundlessConfig, DEFAULT_MAX_CONCURRENCY,
-    DriverConfig, ProverClient, ProvingConfig, RegistrarConfig, RegistrarError, RegistrarMetrics,
-    RegistrationDriver, RegistryContractClient,
+    DEFAULT_MAX_TX_RETRIES, DEFAULT_TX_RETRY_DELAY_SECS, DriverConfig, ProverClient, ProvingConfig,
+    RegistrarConfig, RegistrarError, RegistrarMetrics, RegistrationDriver, RegistryContractClient,
 };
 use base_tx_manager::{BaseTxMetrics, SignerConfig, SimpleTxManager, TxManagerConfig};
 use clap::{Args, Parser, ValueEnum};
@@ -111,6 +111,15 @@ pub(crate) struct Cli {
     /// generation, so this limits concurrent proof work.
     #[arg(long, env = cli_env!("MAX_CONCURRENCY"), default_value_t = DEFAULT_MAX_CONCURRENCY)]
     max_concurrency: usize,
+
+    // ── Tx Retry ──────────────────────────────────────────────────────────────
+    /// Maximum number of transaction submission retries for transient errors.
+    #[arg(long, env = cli_env!("MAX_TX_RETRIES"), default_value_t = DEFAULT_MAX_TX_RETRIES)]
+    max_tx_retries: u32,
+
+    /// Delay between transaction submission retries, in seconds.
+    #[arg(long, env = cli_env!("TX_RETRY_DELAY_SECS"), default_value_t = DEFAULT_TX_RETRY_DELAY_SECS)]
+    tx_retry_delay_secs: u64,
 
     // ── Health Server ─────────────────────────────────────────────────────────
     #[command(flatten)]
@@ -278,6 +287,12 @@ impl Cli {
             return Err(RegistrarError::Config("--max-concurrency must be greater than 0".into()));
         }
 
+        if self.tx_retry_delay_secs == 0 {
+            return Err(RegistrarError::Config(
+                "--tx-retry-delay-secs must be greater than 0".into(),
+            ));
+        }
+
         if self.health.port == 0 {
             return Err(RegistrarError::Config("health server port must be non-zero".into()));
         }
@@ -295,6 +310,8 @@ impl Cli {
             poll_interval: Duration::from_secs(self.poll_interval_secs),
             prover_timeout: Duration::from_secs(self.prover_timeout_secs),
             max_concurrency: self.max_concurrency,
+            max_tx_retries: self.max_tx_retries,
+            tx_retry_delay: Duration::from_secs(self.tx_retry_delay_secs),
             health_addr,
         })
     }
@@ -400,6 +417,8 @@ impl Cli {
             poll_interval: config.poll_interval,
             cancel: cancel.clone(),
             max_concurrency: config.max_concurrency,
+            max_tx_retries: config.max_tx_retries,
+            tx_retry_delay: config.tx_retry_delay,
         };
 
         // Mark the service as ready. This signals "initialised and running", not

--- a/crates/proof/tee/registrar/src/config.rs
+++ b/crates/proof/tee/registrar/src/config.rs
@@ -99,6 +99,10 @@ pub struct RegistrarConfig {
     /// registration cycle. Each instance may trigger a ~20-minute proof
     /// generation, so this limits concurrent proof work and nonce acquisition.
     pub max_concurrency: usize,
+    /// Maximum number of transaction submission retries for transient errors.
+    pub max_tx_retries: u32,
+    /// Delay between transaction submission retries.
+    pub tx_retry_delay: Duration,
     /// Health server socket address.
     pub health_addr: SocketAddr,
 }
@@ -116,6 +120,8 @@ impl std::fmt::Debug for RegistrarConfig {
             .field("poll_interval", &self.poll_interval)
             .field("prover_timeout", &self.prover_timeout)
             .field("max_concurrency", &self.max_concurrency)
+            .field("max_tx_retries", &self.max_tx_retries)
+            .field("tx_retry_delay", &self.tx_retry_delay)
             .field("health_addr", &self.health_addr)
             .finish()
     }

--- a/crates/proof/tee/registrar/src/driver.rs
+++ b/crates/proof/tee/registrar/src/driver.rs
@@ -30,6 +30,13 @@ use crate::{
 /// while keeping resource usage bounded.
 pub const DEFAULT_MAX_CONCURRENCY: usize = 4;
 
+/// Default maximum number of transaction submission retries for transient
+/// errors before giving up.
+pub const DEFAULT_MAX_TX_RETRIES: u32 = 3;
+
+/// Default delay between transaction submission retries.
+pub const DEFAULT_TX_RETRY_DELAY_SECS: u64 = 5;
+
 /// Runtime parameters for the [`RegistrationDriver`] that are not
 /// trait-based dependencies.
 #[derive(Debug, Clone)]
@@ -44,6 +51,12 @@ pub struct DriverConfig {
     /// may trigger proof generation, so this bounds concurrent proof work
     /// and nonce acquisition. Defaults to [`DEFAULT_MAX_CONCURRENCY`].
     pub max_concurrency: usize,
+    /// Maximum number of transaction submission retries for transient errors.
+    /// Defaults to [`DEFAULT_MAX_TX_RETRIES`].
+    pub max_tx_retries: u32,
+    /// Delay between transaction submission retries.
+    /// Defaults to [`DEFAULT_TX_RETRY_DELAY_SECS`] seconds.
+    pub tx_retry_delay: Duration,
 }
 
 /// Core registration loop tying together discovery, attestation polling,
@@ -399,8 +412,8 @@ where
         // reverted, insufficient funds, config errors, fee limits, etc.)
         // abort immediately since retrying with the same calldata and
         // state cannot succeed.
-        const MAX_TX_RETRIES: u32 = 3;
-        const TX_RETRY_DELAY: Duration = Duration::from_secs(5);
+        let max_tx_retries = self.config.max_tx_retries;
+        let tx_retry_delay = self.config.tx_retry_delay;
         let mut tx_retries = 0;
 
         let receipt = loop {
@@ -445,7 +458,7 @@ where
                     }
 
                     tx_retries += 1;
-                    if tx_retries > MAX_TX_RETRIES {
+                    if tx_retries > max_tx_retries {
                         return Err(RegistrarError::from(e));
                     }
 
@@ -453,7 +466,7 @@ where
                         error = %e,
                         signer = %signer_address,
                         retry = tx_retries,
-                        max_retries = MAX_TX_RETRIES,
+                        max_retries = max_tx_retries,
                         "tx submission failed, retrying with same proof"
                     );
 
@@ -464,7 +477,7 @@ where
                             debug!("shutdown requested during retry delay");
                             return Err(RegistrarError::from(e));
                         }
-                        () = tokio::time::sleep(TX_RETRY_DELAY) => {}
+                        () = tokio::time::sleep(tx_retry_delay) => {}
                     }
                 }
             }
@@ -958,6 +971,8 @@ mod tests {
             poll_interval: Duration::from_secs(1),
             cancel,
             max_concurrency: DEFAULT_MAX_CONCURRENCY,
+            max_tx_retries: DEFAULT_MAX_TX_RETRIES,
+            tx_retry_delay: Duration::from_secs(DEFAULT_TX_RETRY_DELAY_SECS),
         }
     }
 
@@ -1009,9 +1024,8 @@ mod tests {
 
     // ── Configurable mock types for retry tests ────────────────────────
 
-    /// Maximum number of tx submission retries in `try_register`.
-    /// Mirrors the constant in production code.
-    const MAX_TX_RETRIES: u32 = 3;
+    /// Maximum number of tx submission retries used by `default_config`.
+    const MAX_TX_RETRIES: u32 = DEFAULT_MAX_TX_RETRIES;
 
     /// Proof provider that counts `generate_proof` invocations.
     ///

--- a/crates/proof/tee/registrar/src/lib.rs
+++ b/crates/proof/tee/registrar/src/lib.rs
@@ -8,7 +8,10 @@ mod discovery;
 pub use discovery::AwsTargetGroupDiscovery;
 
 mod driver;
-pub use driver::{DEFAULT_MAX_CONCURRENCY, DriverConfig, RegistrationDriver};
+pub use driver::{
+    DEFAULT_MAX_CONCURRENCY, DEFAULT_MAX_TX_RETRIES, DEFAULT_TX_RETRY_DELAY_SECS, DriverConfig,
+    RegistrationDriver,
+};
 
 mod error;
 pub use error::{RegistrarError, Result};


### PR DESCRIPTION
## Summary

- Replace hardcoded `MAX_TX_RETRIES` (3) and `TX_RETRY_DELAY` (5s) in `try_register()` with `DriverConfig` fields, wired through `RegistrarConfig` to new CLI flags.
- Adds `--max-tx-retries` / `BASE_REGISTRAR_MAX_TX_RETRIES` and `--tx-retry-delay-secs` / `BASE_REGISTRAR_TX_RETRY_DELAY_SECS` with the same defaults as the previous hardcoded values.
- Existing tests updated to use the new defaults; all 72 tests pass.

## Changes

| File | What |
|------|------|
| `driver.rs` | `DEFAULT_MAX_TX_RETRIES`, `DEFAULT_TX_RETRY_DELAY_SECS` constants; `max_tx_retries` + `tx_retry_delay` fields on `DriverConfig`; retry loop reads from config |
| `config.rs` | `max_tx_retries` + `tx_retry_delay` fields on `RegistrarConfig` + `Debug` impl |
| `lib.rs` | Re-export new constants |
| `cli.rs` | New CLI args, validation (`tx_retry_delay_secs > 0`), wiring in `into_config()` + `run()` |