### PR TITLE
feat(batcher): Add Stopped Flag For Paused Start

### DIFF
--- a/bin/batcher/src/cli.rs
+++ b/bin/batcher/src/cli.rs
@@ -194,7 +194,7 @@ pub(crate) struct BatcherArgs {
     #[arg(long = "admin-port", env = "BATCHER_ADMIN_PORT")]
     pub admin_port: Option<u16>,
 
-    /// Start in a paused state, deferring batch submission until `admin_startBatcher` is called.
+    /// Start in a stopped state, deferring batch submission until `admin_startBatcher` is called.
     ///
     /// The batcher connects to all endpoints and is fully observable but will not
     /// submit any batches until activated via the admin API. Useful for staged

--- a/bin/batcher/src/cli.rs
+++ b/bin/batcher/src/cli.rs
@@ -223,7 +223,6 @@ impl BatcherArgs {
             batch_type: self.batch_type.into(),
             da_type: self.da_type,
             approx_compr_ratio: self.approx_compr_ratio,
-            ..base_batcher_encoder::EncoderConfig::default()
         };
         encoder_config.validate()?;
         Ok(BatcherConfig {

--- a/bin/batcher/src/cli.rs
+++ b/bin/batcher/src/cli.rs
@@ -194,6 +194,14 @@ pub(crate) struct BatcherArgs {
     #[arg(long = "admin-port", env = "BATCHER_ADMIN_PORT")]
     pub admin_port: Option<u16>,
 
+    /// Start in a paused state, deferring batch submission until `admin_startBatcher` is called.
+    ///
+    /// The batcher connects to all endpoints and is fully observable but will not
+    /// submit any batches until activated via the admin API. Useful for staged
+    /// rollouts, controlled restarts, and debugging.
+    #[arg(long = "stopped", env = "BATCHER_STOPPED")]
+    pub stopped: bool,
+
     /// Logging configuration.
     #[command(flatten)]
     pub logging: LogArgs,
@@ -241,6 +249,7 @@ impl BatcherArgs {
             },
             check_recent_txs_depth: self.check_recent_txs_depth,
             admin_addr: self.admin_port.map(|port| SocketAddr::new(self.admin_addr, port)),
+            stopped: self.stopped,
         })
     }
 
@@ -341,5 +350,21 @@ mod tests {
         args.extend_from_slice(["--data-availability-type", "auto"].as_slice());
 
         assert!(Cli::try_parse_from(args).is_err());
+    }
+
+    #[test]
+    fn stopped_defaults_to_false() {
+        let cli = parse_cli(&[]);
+        let config = cli.args.into_config().expect("config should build");
+
+        assert!(!config.stopped);
+    }
+
+    #[test]
+    fn stopped_flag_sets_stopped_in_config() {
+        let cli = parse_cli(&["--stopped"]);
+        let config = cli.args.into_config().expect("config should build");
+
+        assert!(config.stopped);
     }
 }

--- a/crates/batcher/core/src/admin.rs
+++ b/crates/batcher/core/src/admin.rs
@@ -15,8 +15,8 @@ pub const ADMIN_CHANNEL_CAPACITY: usize = 32;
 /// Serialised directly as the `admin_getBatcherStatus` JSON-RPC response.
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct BatcherStatus {
-    /// Whether block ingestion is currently paused via the admin API.
-    pub paused: bool,
+    /// Whether block ingestion is currently stopped (paused via admin or `--stopped` flag).
+    pub stopped: bool,
     /// Number of L1 transactions submitted but not yet confirmed.
     pub in_flight: usize,
     /// Estimated unsubmitted DA backlog in bytes.

--- a/crates/batcher/core/src/driver.rs
+++ b/crates/batcher/core/src/driver.rs
@@ -123,6 +123,17 @@ where
         self
     }
 
+    /// Start the driver in a paused state, deferring block ingestion until
+    /// [`AdminCommand::Resume`] is received via the admin API.
+    ///
+    /// Equivalent to the batcher starting normally and immediately receiving
+    /// a pause command, but without discarding any in-flight submissions.
+    /// Use this when the `--stopped` flag is set at startup.
+    pub const fn with_paused(mut self, paused: bool) -> Self {
+        self.paused = paused;
+        self
+    }
+
     /// Run the batch driver loop.
     ///
     /// Each iteration has two phases:
@@ -132,6 +143,12 @@ where
     /// When draining (after cancellation or source exhaustion), the I/O phase is
     /// replaced by a bounded drain of all in-flight receipts.
     pub async fn run(mut self) -> Result<(), BatchDriverError> {
+        if self.paused {
+            info!(
+                paused = true,
+                "batcher starting in paused state; call admin_startBatcher to begin submission"
+            );
+        }
         let mut draining = false;
         loop {
             self.drain_encoding()?;

--- a/crates/batcher/core/src/driver.rs
+++ b/crates/batcher/core/src/driver.rs
@@ -55,8 +55,8 @@ where
     /// Maximum wall-clock time to wait for in-flight submissions to settle
     /// when draining on cancellation or source exhaustion.
     drain_timeout: Duration,
-    /// Whether block ingestion is currently paused via the admin API.
-    paused: bool,
+    /// Whether block ingestion is currently stopped (paused via admin or `--stopped` flag).
+    stopped: bool,
     /// Admin command channel, wired in via [`Self::with_admin_rx`].
     admin_rx: Option<mpsc::Receiver<AdminCommand>>,
 }
@@ -98,7 +98,7 @@ where
             l1_head_source: Some(l1_head_source),
             safe_head_rx: None,
             drain_timeout: config.drain_timeout,
-            paused: false,
+            stopped: false,
             admin_rx: None,
         }
     }
@@ -123,14 +123,14 @@ where
         self
     }
 
-    /// Start the driver in a paused state, deferring block ingestion until
+    /// Start the driver in a stopped state, deferring block ingestion until
     /// [`AdminCommand::Resume`] is received via the admin API.
     ///
     /// Equivalent to the batcher starting normally and immediately receiving
     /// a pause command, but without discarding any in-flight submissions.
     /// Use this when the `--stopped` flag is set at startup.
-    pub const fn with_paused(mut self, paused: bool) -> Self {
-        self.paused = paused;
+    pub const fn with_stopped(mut self, stopped: bool) -> Self {
+        self.stopped = stopped;
         self
     }
 
@@ -143,10 +143,10 @@ where
     /// When draining (after cancellation or source exhaustion), the I/O phase is
     /// replaced by a bounded drain of all in-flight receipts.
     pub async fn run(mut self) -> Result<(), BatchDriverError> {
-        if self.paused {
+        if self.stopped {
             info!(
-                paused = true,
-                "batcher starting in paused state; call admin_startBatcher to begin submission"
+                stopped = true,
+                "batcher starting in stopped state; call admin_startBatcher to begin submission"
             );
         }
         let mut draining = false;
@@ -295,8 +295,8 @@ where
                         AdminCommand::Pause => {
                             self.submissions.discard();
                             self.pipeline.reset();
-                            self.paused = true;
-                            info!(paused = true, "batcher paused via admin");
+                            self.stopped = true;
+                            info!(stopped = true, "batcher paused via admin");
                         }
                         AdminCommand::Resume => {
                             let safe_head =
@@ -304,14 +304,14 @@ where
                             if let Some(n) = safe_head {
                                 self.source.reset_catchup(n + 1);
                                 info!(
-                                    paused = false,
+                                    stopped = false,
                                     catchup_from = %(n + 1),
                                     "batcher resumed via admin, catching up from safe head"
                                 );
                             } else {
-                                info!(paused = false, "batcher resumed via admin");
+                                info!(stopped = false, "batcher resumed via admin");
                             }
-                            self.paused = false;
+                            self.stopped = false;
                         }
                         AdminCommand::SetThrottle { strategy, config } => {
                             self.throttle.set_controller(
@@ -330,7 +330,7 @@ where
                         }
                         AdminCommand::GetStatus { reply } => {
                             let _ = reply.send(BatcherStatus {
-                                paused: self.paused,
+                                stopped: self.stopped,
                                 in_flight: self.submissions.in_flight_count(),
                                 da_backlog_bytes: self.pipeline.da_backlog_bytes(),
                             });
@@ -341,7 +341,7 @@ where
                 }
 
                 event = self.source.next() => match event {
-                    Ok(L2BlockEvent::Block(_) | L2BlockEvent::Flush) if self.paused => {
+                    Ok(L2BlockEvent::Block(_) | L2BlockEvent::Flush) if self.stopped => {
                         continue;
                     }
                     Ok(L2BlockEvent::Block(block)) => DriverEvent::Block(block),

--- a/crates/batcher/service/src/config.rs
+++ b/crates/batcher/service/src/config.rs
@@ -65,7 +65,7 @@ pub struct BatcherConfig {
     /// When set, the batcher exposes the `admin_*` RPC namespace on this address.
     /// When `None` (the default), the admin server is disabled.
     pub admin_addr: Option<SocketAddr>,
-    /// If `true`, start in a paused state and defer batch submission until
+    /// If `true`, start in a stopped state and defer batch submission until
     /// `admin_startBatcher` is called via the admin API.
     ///
     /// Matches op-batcher's `--stopped` / `OP_BATCHER_STOPPED` behaviour (env: `BATCHER_STOPPED`).

--- a/crates/batcher/service/src/config.rs
+++ b/crates/batcher/service/src/config.rs
@@ -65,6 +65,11 @@ pub struct BatcherConfig {
     /// When set, the batcher exposes the `admin_*` RPC namespace on this address.
     /// When `None` (the default), the admin server is disabled.
     pub admin_addr: Option<SocketAddr>,
+    /// If `true`, start in a paused state and defer batch submission until
+    /// `admin_startBatcher` is called via the admin API.
+    ///
+    /// Matches op-batcher's `--stopped` / `OP_BATCHER_STOPPED` behaviour (env: `BATCHER_STOPPED`).
+    pub stopped: bool,
 }
 
 impl Default for BatcherConfig {
@@ -84,6 +89,7 @@ impl Default for BatcherConfig {
             throttle: Some(ThrottleConfig::default()),
             check_recent_txs_depth: 0,
             admin_addr: None,
+            stopped: false,
         }
     }
 }

--- a/crates/batcher/service/src/service.rs
+++ b/crates/batcher/service/src/service.rs
@@ -259,7 +259,7 @@ impl BatcherService {
 
         if self.config.stopped && self.config.admin_addr.is_none() {
             eyre::bail!(
-                "--stopped requires --admin-port: the batcher would start paused with no way to \
+                "--stopped requires --admin-port: the batcher would start stopped with no way to \
                  resume because the admin JSON-RPC server is not enabled"
             );
         }
@@ -475,7 +475,7 @@ impl BatcherService {
             l1_head_source,
         )
         .with_safe_head_rx(safe_head_rx)
-        .with_paused(self.config.stopped);
+        .with_stopped(self.config.stopped);
 
         let admin_server = match self.config.admin_addr {
             Some(addr) => {

--- a/crates/batcher/service/src/service.rs
+++ b/crates/batcher/service/src/service.rs
@@ -257,6 +257,13 @@ impl BatcherService {
     pub async fn setup(self, runtime: TokioRuntime) -> eyre::Result<ReadyBatcher> {
         self.config.encoder_config.validate()?;
 
+        if self.config.stopped && self.config.admin_addr.is_none() {
+            eyre::bail!(
+                "--stopped requires --admin-port: the batcher would start paused with no way to \
+                 resume because the admin JSON-RPC server is not enabled"
+            );
+        }
+
         info!(
             l1_rpc = %self.config.l1_rpc_url,
             l2_rpc = %self.config.l2_rpc_url,
@@ -467,7 +474,8 @@ impl BatcherService {
             DaThrottle::new(throttle, throttle_client),
             l1_head_source,
         )
-        .with_safe_head_rx(safe_head_rx);
+        .with_safe_head_rx(safe_head_rx)
+        .with_paused(self.config.stopped);
 
         let admin_server = match self.config.admin_addr {
             Some(addr) => {

--- a/docs/guides/UPGRADES.md
+++ b/docs/guides/UPGRADES.md
@@ -392,6 +392,6 @@ forks.push((BaseUpgrade::V1.boxed(), self[BaseUpgrade::V1]));  // <-- add
 
 - [ ] `OpSpecId` variant added with `into_eth_spec`, `FromStr`, `From<&str>`, `name::X`
 - [ ] Precompile match arm updated (or new precompile set added)
-- [ ] `spec_by_timestamp_after_bedrock` updated (`alloy/evm/src/spec_id.rs`)
+- [ ] `spec_by_timestamp_after_bedrock` updated (`core/evm/src/spec_id.rs`)
 - [ ] `RollupConfig::spec_id` updated (`consensus/genesis/src/rollup.rs`)
 - [ ] `to_chain_hardforks` updated (`execution/hardforks/src/chain.rs`)


### PR DESCRIPTION
## Summary

Adds a `--stopped` flag (`OP_BATCHER_STOPPED` env var) to the batcher binary that starts the service in a paused state, deferring batch submission until `admin_startBatcher` is called via the admin API. The flag propagates from CLI args through `BatcherConfig.stopped` to a new `BatchDriver::with_paused` builder method. This matches the reference op-batcher behavior and is useful for staged rollouts, controlled restarts, and debugging where the process needs to be observable before producing on-chain effects.

Closes #1608.