### PR TITLE
test(builder): add flashblock context progression test

### DIFF
--- a/crates/builder/core/src/flashblocks/context.rs
+++ b/crates/builder/core/src/flashblocks/context.rs
@@ -4,7 +4,7 @@ use std::{sync::Arc, time::Instant};
 use alloy_consensus::{Eip658Value, Transaction};
 use alloy_eips::{Encodable2718, Typed2718};
 use alloy_evm::Database;
-use alloy_primitives::{BlockHash, Bytes, U256};
+use alloy_primitives::{B256, BlockHash, Bytes, U256};
 use alloy_rpc_types_eth::Withdrawals;
 use base_access_lists::FBALBuilderDb;
 use base_alloy_chains::BaseUpgrades;
@@ -967,6 +967,61 @@ impl OpPayloadBuilderCtx {
             ExecutionMeteringLimitExceeded::BlockStateRootTime(_, _, _) => {
                 BuilderMetrics::block_state_root_time_exceeded_total().increment(1);
             }
+        }
+    }
+}
+
+#[cfg(any(test, feature = "test-utils"))]
+impl OpPayloadBuilderCtx {
+    /// Creates a minimal [`OpPayloadBuilderCtx`] for unit tests.
+    ///
+    /// Derives the EVM environment from the given chain spec and parent header,
+    /// using default builder attributes and a no-op cancellation token.
+    pub fn for_test(
+        chain_spec: Arc<OpChainSpec>,
+        parent: Arc<SealedHeader>,
+    ) -> Self {
+        use reth_evm::ConfigureEvm;
+
+        let evm_config = OpEvmConfig::optimism(Arc::clone(&chain_spec));
+        let timestamp = parent.timestamp + 2;
+
+        let attributes = OpPayloadBuilderAttributes {
+            payload_attributes: reth_payload_builder::EthPayloadBuilderAttributes {
+                id: PayloadId::new([0; 8]),
+                parent: parent.hash(),
+                timestamp,
+                parent_beacon_block_root: Some(B256::ZERO),
+                ..Default::default()
+            },
+            gas_limit: Some(parent.gas_limit),
+            ..Default::default()
+        };
+
+        let block_env_attributes = OpNextBlockEnvAttributes {
+            timestamp,
+            suggested_fee_recipient: Default::default(),
+            prev_randao: Default::default(),
+            gas_limit: parent.gas_limit,
+            parent_beacon_block_root: None,
+            extra_data: Default::default(),
+        };
+
+        let evm_env = evm_config
+            .next_evm_env(&parent, &block_env_attributes)
+            .expect("failed to create test evm env");
+
+        let config = PayloadConfig::new(parent, attributes);
+
+        Self {
+            evm_config,
+            chain_spec,
+            config,
+            evm_env,
+            block_env_attributes,
+            cancel: CancellationToken::new(),
+            extra: FlashblocksExtraCtx::default(),
+            builder_config: crate::BuilderConfig::default(),
         }
     }
 }

--- a/crates/builder/core/src/flashblocks/context.rs
+++ b/crates/builder/core/src/flashblocks/context.rs
@@ -1092,4 +1092,51 @@ mod tests {
         assert_eq!(diag.txs_considered, 5);
         assert_eq!(diag.txs_included, 2);
     }
+
+    /// [`FlashblocksExtraCtx::next`] must increment the flashblock index,
+    /// update all per-batch target fields to the new values, and preserve
+    /// the per-batch *limit* fields and the target flashblock count.
+    #[test]
+    fn extra_ctx_next_advances_index_and_updates_targets() {
+        let ctx = FlashblocksExtraCtx {
+            flashblock_index: 2,
+            target_flashblock_count: 10,
+            target_gas_for_batch: 1_000_000,
+            target_da_for_batch: Some(500),
+            target_da_footprint_for_batch: Some(200),
+            target_execution_time_for_batch_us: Some(100_000),
+            target_state_root_time_for_batch_us: Some(50_000),
+            gas_per_batch: 3_000_000,
+            da_per_batch: Some(1_500),
+            da_footprint_per_batch: Some(600),
+            execution_time_per_batch_us: Some(300_000),
+            state_root_time_per_batch_us: Some(150_000),
+        };
+
+        let next = ctx.next(
+            2_000_000,     // new gas target
+            Some(800),     // new DA target
+            Some(350),     // new DA footprint target
+            Some(200_000), // new execution time target
+            Some(80_000),  // new state root time target
+        );
+
+        // Index incremented
+        assert_eq!(next.flashblock_index, 3);
+
+        // Target fields updated to the supplied values
+        assert_eq!(next.target_gas_for_batch, 2_000_000);
+        assert_eq!(next.target_da_for_batch, Some(800));
+        assert_eq!(next.target_da_footprint_for_batch, Some(350));
+        assert_eq!(next.target_execution_time_for_batch_us, Some(200_000));
+        assert_eq!(next.target_state_root_time_for_batch_us, Some(80_000));
+
+        // Per-batch limits and target count are preserved (..self)
+        assert_eq!(next.target_flashblock_count, 10);
+        assert_eq!(next.gas_per_batch, 3_000_000);
+        assert_eq!(next.da_per_batch, Some(1_500));
+        assert_eq!(next.da_footprint_per_batch, Some(600));
+        assert_eq!(next.execution_time_per_batch_us, Some(300_000));
+        assert_eq!(next.state_root_time_per_batch_us, Some(150_000));
+    }
 }

--- a/crates/builder/core/src/flashblocks/context.rs
+++ b/crates/builder/core/src/flashblocks/context.rs
@@ -977,12 +977,7 @@ impl OpPayloadBuilderCtx {
     ///
     /// Derives the EVM environment from the given chain spec and parent header,
     /// using default builder attributes and a no-op cancellation token.
-    pub fn for_test(
-        chain_spec: Arc<OpChainSpec>,
-        parent: Arc<SealedHeader>,
-    ) -> Self {
-        use reth_evm::ConfigureEvm;
-
+    pub fn for_test(chain_spec: Arc<OpChainSpec>, parent: Arc<SealedHeader>) -> Self {
         let evm_config = OpEvmConfig::optimism(Arc::clone(&chain_spec));
         let timestamp = parent.timestamp + 2;
 
@@ -1003,7 +998,7 @@ impl OpPayloadBuilderCtx {
             suggested_fee_recipient: Default::default(),
             prev_randao: Default::default(),
             gas_limit: parent.gas_limit,
-            parent_beacon_block_root: None,
+            parent_beacon_block_root: Some(B256::ZERO),
             extra_data: Default::default(),
         };
 

--- a/crates/builder/core/src/flashblocks/payload.rs
+++ b/crates/builder/core/src/flashblocks/payload.rs
@@ -1197,7 +1197,7 @@ mod tests {
     use reth_provider::noop::NoopProvider;
     use reth_revm::{State, database::StateProviderDatabase};
 
-    use super::FlashblocksMetadata;
+    use super::{FlashblocksMetadata, build_block};
     use crate::{ExecutionInfo, flashblocks::context::OpPayloadBuilderCtx};
 
     /// Creates a minimal [`OpChainSpec`] with all L1 hardforks through Cancun
@@ -1214,22 +1214,15 @@ mod tests {
         });
         let genesis = serde_json::from_value(genesis).expect("valid genesis");
 
-        let inner = ChainSpec::builder()
-            .chain(901.into())
-            .genesis(genesis)
-            .cancun_activated()
-            .build();
+        let inner =
+            ChainSpec::builder().chain(901.into()).genesis(genesis).cancun_activated().build();
 
         Arc::new(OpChainSpec { inner })
     }
 
     /// Builds a sealed genesis header consistent with [`minimal_chain_spec`].
     fn genesis_header() -> Arc<SealedHeader> {
-        let header = Header {
-            gas_limit: 30_000_000,
-            timestamp: 0,
-            ..Default::default()
-        };
+        let header = Header { gas_limit: 30_000_000, timestamp: 0, ..Default::default() };
         Arc::new(SealedHeader::seal_slow(header))
     }
 
@@ -1241,8 +1234,6 @@ mod tests {
     /// no node, no disk, no network.
     #[test]
     fn build_block_empty_no_state_root() {
-        use super::build_block;
-
         let chain_spec = minimal_chain_spec();
         let parent = genesis_header();
         let ctx = OpPayloadBuilderCtx::for_test(chain_spec, Arc::clone(&parent));
@@ -1256,11 +1247,7 @@ mod tests {
                 .expect("build_block should succeed for an empty block");
 
         // Block number must be parent + 1.
-        assert_eq!(
-            payload.block().number,
-            parent.number + 1,
-            "block number should be parent + 1"
-        );
+        assert_eq!(payload.block().number, parent.number + 1, "block number should be parent + 1");
 
         // No transactions were executed, so gas used must be zero.
         assert_eq!(payload.block().gas_used, 0, "empty block should use zero gas");

--- a/crates/builder/core/src/flashblocks/payload.rs
+++ b/crates/builder/core/src/flashblocks/payload.rs
@@ -1256,6 +1256,99 @@ mod tests {
         assert_eq!(fb_payload.diff.block_hash, payload.block().hash(), "hash mismatch");
     }
 
+    /// Verify that [`build_block`] exercises the state root calculation path
+    /// when `calculate_state_root = true`.
+    ///
+    /// With [`NoopProvider`], both `hashed_post_state` and
+    /// `state_root_with_updates` return defaults, so the state root ends up
+    /// as [`B256::ZERO`].  The important property under test is that the
+    /// `calculate_state_root = true` branch runs without error and the
+    /// resulting header carries the computed root.
+    #[test]
+    fn build_block_empty_with_state_root() {
+        let chain_spec = minimal_chain_spec();
+        let parent = genesis_header();
+        let ctx = OpPayloadBuilderCtx::for_test(chain_spec, Arc::clone(&parent));
+
+        let db = StateProviderDatabase::new(NoopProvider::default());
+        let mut state = State::builder().with_database(db).with_bundle_update().build();
+        let mut info = ExecutionInfo::default();
+
+        let (payload, _fb_payload) =
+            build_block::<_, NoopProvider>(&mut state, &ctx, &mut info, true)
+                .expect("build_block with state root should succeed");
+
+        // NoopProvider returns B256::default() for all state root queries,
+        // which equals B256::ZERO.
+        assert_eq!(
+            payload.block().state_root,
+            B256::ZERO,
+            "NoopProvider should yield a zero state root"
+        );
+
+        assert_eq!(payload.block().number, parent.number + 1);
+    }
+
+    /// [`build_block`] must return an error when the EVM environment's block
+    /// number does not match `parent.number + 1`.
+    ///
+    /// In production this would indicate a bug in context construction or a
+    /// stale parent header.  The guard at the top of `build_block` exists to
+    /// catch exactly this class of misconfiguration.
+    #[test]
+    fn build_block_rejects_block_number_mismatch() {
+        let chain_spec = minimal_chain_spec();
+        let parent = genesis_header();
+        let mut ctx = OpPayloadBuilderCtx::for_test(chain_spec, Arc::clone(&parent));
+
+        // Tamper with the EVM block number so it disagrees with parent + 1.
+        // parent.number is 0, so the expected block number is 1.
+        // Setting it to 99 should trigger the mismatch guard.
+        ctx.evm_env.block_env.number = U256::from(99);
+
+        let db = StateProviderDatabase::new(NoopProvider::default());
+        let mut state = State::builder().with_database(db).with_bundle_update().build();
+        let mut info = ExecutionInfo::default();
+
+        let err = build_block::<_, NoopProvider>(&mut state, &ctx, &mut info, false)
+            .expect_err("build_block should fail on block number mismatch");
+
+        let msg = err.to_string();
+        assert!(
+            msg.contains("block number mismatch"),
+            "error should mention block number mismatch, got: {msg}"
+        );
+    }
+
+    /// [`build_block`] must return an error when the payload attributes lack
+    /// a `parent_beacon_block_root`.
+    ///
+    /// The flashblocks payload construction unconditionally reads this field,
+    /// so a `None` value is an unrecoverable configuration error that should
+    /// surface clearly rather than panicking.
+    #[test]
+    fn build_block_rejects_missing_beacon_block_root() {
+        let chain_spec = minimal_chain_spec();
+        let parent = genesis_header();
+        let mut ctx = OpPayloadBuilderCtx::for_test(chain_spec, Arc::clone(&parent));
+
+        // Clear the parent beacon block root that for_test() sets.
+        ctx.config.attributes.payload_attributes.parent_beacon_block_root = None;
+
+        let db = StateProviderDatabase::new(NoopProvider::default());
+        let mut state = State::builder().with_database(db).with_bundle_update().build();
+        let mut info = ExecutionInfo::default();
+
+        let err = build_block::<_, NoopProvider>(&mut state, &ctx, &mut info, false)
+            .expect_err("build_block should fail without beacon block root");
+
+        let msg = err.to_string();
+        assert!(
+            msg.contains("parent beacon block root not found"),
+            "error should mention missing beacon block root, got: {msg}"
+        );
+    }
+
     /// Pin the JSON field names and structure of [`FlashblocksMetadata`].
     ///
     /// This struct is serialized into the `metadata` field of the flashblocks

--- a/crates/builder/core/src/flashblocks/payload.rs
+++ b/crates/builder/core/src/flashblocks/payload.rs
@@ -899,7 +899,7 @@ struct FlashblocksMetadata {
     access_list: Option<FlashblockAccessList>,
 }
 
-fn execute_pre_steps<DB>(
+pub(crate) fn execute_pre_steps<DB>(
     state: &mut State<DB>,
     ctx: &OpPayloadBuilderCtx,
 ) -> Result<ExecutionInfo, PayloadBuilderError>
@@ -918,7 +918,7 @@ where
     Ok(info)
 }
 
-pub(super) fn build_block<DB, P>(
+pub(crate) fn build_block<DB, P>(
     state: &mut State<DB>,
     ctx: &OpPayloadBuilderCtx,
     info: &mut ExecutionInfo,
@@ -1185,12 +1185,89 @@ where
 
 #[cfg(test)]
 mod tests {
-    use alloy_consensus::Receipt;
+    use std::sync::Arc;
+
+    use alloy_consensus::{Header, Receipt};
     use alloy_primitives::{Address, B256, Log, U256, map::foldhash::HashMap};
     use base_alloy_consensus::OpReceipt;
     use base_alloy_flashblocks::Metadata;
+    use base_execution_chainspec::OpChainSpec;
+    use reth_chainspec::ChainSpec;
+    use reth_primitives_traits::SealedHeader;
+    use reth_provider::noop::NoopProvider;
+    use reth_revm::{State, database::StateProviderDatabase};
 
     use super::FlashblocksMetadata;
+    use crate::{ExecutionInfo, flashblocks::context::OpPayloadBuilderCtx};
+
+    /// Creates a minimal [`OpChainSpec`] with all L1 hardforks through Cancun
+    /// active at genesis but **no** OP-specific hardforks (Bedrock, Canyon,
+    /// Ecotone, Holocene, Isthmus, Jovian are all absent).
+    ///
+    /// This keeps `build_block` on the simplest code paths: no blob fields,
+    /// default extra data, no withdrawals root calculation.
+    fn minimal_chain_spec() -> Arc<OpChainSpec> {
+        let genesis: serde_json::Value = serde_json::json!({
+            "config": { "chainId": 901 },
+            "gasLimit": "0x1C9C380",
+            "timestamp": "0x0"
+        });
+        let genesis = serde_json::from_value(genesis).expect("valid genesis");
+
+        let inner = ChainSpec::builder()
+            .chain(901.into())
+            .genesis(genesis)
+            .cancun_activated()
+            .build();
+
+        Arc::new(OpChainSpec { inner })
+    }
+
+    /// Builds a sealed genesis header consistent with [`minimal_chain_spec`].
+    fn genesis_header() -> Arc<SealedHeader> {
+        let header = Header {
+            gas_limit: 30_000_000,
+            timestamp: 0,
+            ..Default::default()
+        };
+        Arc::new(SealedHeader::seal_slow(header))
+    }
+
+    /// Verify that [`build_block`] produces a valid empty block when called
+    /// with no transactions and `calculate_state_root = false`.
+    ///
+    /// This exercises the full block-assembly path (receipts root, logs bloom,
+    /// header construction, flashblocks payload) using only in-memory state —
+    /// no node, no disk, no network.
+    #[test]
+    fn build_block_empty_no_state_root() {
+        use super::build_block;
+
+        let chain_spec = minimal_chain_spec();
+        let parent = genesis_header();
+        let ctx = OpPayloadBuilderCtx::for_test(chain_spec, Arc::clone(&parent));
+
+        let db = StateProviderDatabase::new(NoopProvider::default());
+        let mut state = State::builder().with_database(db).with_bundle_update().build();
+        let mut info = ExecutionInfo::default();
+
+        let (payload, fb_payload) =
+            build_block::<_, NoopProvider>(&mut state, &ctx, &mut info, false)
+                .expect("build_block should succeed for an empty block");
+
+        // Block number must be parent + 1.
+        assert_eq!(
+            payload.block().number,
+            parent.number + 1,
+            "block number should be parent + 1"
+        );
+
+        // No transactions were executed, so gas used must be zero.
+        assert_eq!(payload.block().gas_used, 0, "empty block should use zero gas");
+
+        // The flashblocks payload must reference the same block.
+        assert_eq!(fb_payload.diff.block_hash, payload.block().hash(), "hash mismatch");
+    }
 
     /// Pin the JSON field names and structure of [`FlashblocksMetadata`].
     ///

--- a/crates/builder/core/src/test_utils/instance.rs
+++ b/crates/builder/core/src/test_utils/instance.rs
@@ -296,7 +296,9 @@ pub fn default_node_config() -> NodeConfig<OpChainSpec> {
     node_config_with_chain_spec(chain_spec())
 }
 
-fn chain_spec() -> Arc<OpChainSpec> {
+/// Returns the default test chain spec, lazily initialized from the embedded
+/// genesis template.
+pub fn chain_spec() -> Arc<OpChainSpec> {
     static CHAIN_SPEC: LazyLock<Arc<OpChainSpec>> = LazyLock::new(|| {
         let genesis = include_str!("./artifacts/genesis.json.tmpl");
         let genesis = serde_json::from_str(genesis).expect("invalid genesis JSON");


### PR DESCRIPTION
Stacked on #1823.

## Summary

- Add `extra_ctx_next_advances_index_and_updates_targets` — verifies that `FlashblocksExtraCtx::next()` increments the flashblock index, updates all per-batch target fields, and preserves the per-batch limit fields and target count

This catches the case where a new field is added to `FlashblocksExtraCtx` but not carried through the `..self` struct update in `next()`.

Standalone in-memory test with no external dependencies.

## Test plan

```
cargo test -p base-builder-core --lib
# 48 passed, 0 failed
cargo clippy -p base-builder-core --tests
# 0 warnings
```