### PR TITLE
feat(tee): add just recipes for remote enclave inspection

### DIFF
--- a/bin/prover/nitro-host/README.md
+++ b/bin/prover/nitro-host/README.md
@@ -12,6 +12,17 @@ TEE prover host server for AWS Nitro Enclaves.
 **Remotely (from your local machine):**
 
 ```bash
+# Get the enclave signer's Ethereum address
+just tee signer-address https://<PROVER_RPC_URL>
+
+# Get PCR0 and teeImageHash (requires: pip3 install cbor2)
+just tee remote-pcr0 https://<PROVER_RPC_URL>
+```
+
+<details>
+<summary>Manual steps (what the recipes do under the hood)</summary>
+
+```bash
 # Get the enclave's signer public key
 cast rpc enclave_signerPublicKey -r https://<PROVER_RPC_URL>
 
@@ -29,6 +40,8 @@ python3 -c "import cbor2; data=bytes([<PASTE_BYTE_ARRAY>]); _, _, payload, _ = c
 # Compute the teeImageHash (keccak of raw PCR0 bytes)
 cast keccak 0x<PCR0_HEX>
 ```
+
+</details>
 
 **Via SSH (on the EC2 host):**
 

--- a/crates/proof/tee/Justfile
+++ b/crates/proof/tee/Justfile
@@ -35,6 +35,43 @@ nitro-local *args:
 config-hashes:
     cargo test -p base-enclave print_real_config_hashes -- --nocapture --ignored
 
+# Get the enclave signer's Ethereum address from a remote prover
+signer-address url:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    command -v cast >/dev/null 2>&1 || { echo "Error: 'cast' (foundry) is required. Install: https://book.getfoundry.sh/getting-started/installation"; exit 1; }
+    command -v python3 >/dev/null 2>&1 || { echo "Error: 'python3' is required."; exit 1; }
+
+    # Fetch the 65-byte uncompressed public key (0x04 || x || y),
+    # strip the prefix byte, keccak-hash, and take the last 20 bytes.
+    PUB_KEY_HEX=$(cast rpc enclave_signerPublicKey -r "{{ url }}" \
+        | python3 -c "import json, sys; data = json.load(sys.stdin)[0]; print('0x' + bytes(data[1:]).hex())")
+
+    HASH=$(cast keccak "$PUB_KEY_HEX")
+    ADDR=$(cast to-check-sum-address "0x${HASH: -40}")
+    echo "Signer address: $ADDR"
+
+# Get PCR0 and teeImageHash from a remote prover's attestation document
+remote-pcr0 url:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    command -v cast >/dev/null 2>&1 || { echo "Error: 'cast' (foundry) is required. Install: https://book.getfoundry.sh/getting-started/installation"; exit 1; }
+    command -v python3 >/dev/null 2>&1 || { echo "Error: 'python3' is required."; exit 1; }
+    python3 -c "import cbor2" 2>/dev/null || {
+        echo "Error: python3 'cbor2' package is required."
+        echo "Install with: pip3 install cbor2"
+        exit 1
+    }
+
+    # Fetch the COSE_Sign1 attestation document, decode the CBOR payload,
+    # and extract PCR0 (the enclave image measurement).
+    PCR0=$(cast rpc enclave_signerAttestation -r "{{ url }}" \
+        | python3 -c "import cbor2,json,sys; data=bytes(json.load(sys.stdin)[0]); _,_,payload,_=cbor2.loads(data); doc=cbor2.loads(payload); print(doc['pcrs'][0].hex())")
+
+    TEE_IMAGE_HASH=$(cast keccak "0x$PCR0")
+    echo "PCR0:         $PCR0"
+    echo "teeImageHash: $TEE_IMAGE_HASH"
+
 # Build EIF and extract it (via --target describe)
 build-eif *args="":
     #!/usr/bin/env bash


### PR DESCRIPTION
## Summary

- Adds two new Justfile recipes (`signer-address` and `remote-pcr0`) that collapse the multi-step, copy-paste-heavy remote enclave inspection workflows into single commands that just take a prover URL.
- `just tee signer-address <url>` fetches the enclave's public key and derives the checksummed Ethereum signer address.
- `just tee remote-pcr0 <url>` fetches the attestation document, extracts the PCR0, and prints both the raw PCR0 hex and the on-chain `teeImageHash` (`keccak256(pcr0)`).
- Dependencies (`cast`, `python3`, `cbor2`) are checked up front with clear error messages rather than silently installing anything.
- Updates the nitro-host README to surface the one-liner commands, with the original manual steps preserved in a collapsible details block.