### PR TITLE
feat(builder): add execution observability for unmetered transactions

### DIFF
--- a/crates/builder/core/src/flashblocks/context.rs
+++ b/crates/builder/core/src/flashblocks/context.rs
@@ -841,6 +841,19 @@ impl OpPayloadBuilderCtx {
             BuilderMetrics::tx_actual_execution_time_us().record(actual_execution_time_us as f64);
             num_txs_simulated += 1;
 
+            // Record state modification counts (trie work proxy)
+            let accounts_modified = state.len();
+            let storage_slots_modified: usize =
+                state.values().map(|a| a.storage.len()).sum();
+            BuilderMetrics::tx_accounts_modified().record(accounts_modified as f64);
+            BuilderMetrics::tx_storage_slots_modified().record(storage_slots_modified as f64);
+
+            // Record execution time for unmetered transactions (race condition indicator)
+            if resource_usage.is_none() {
+                BuilderMetrics::unmetered_tx_actual_execution_time_us()
+                    .record(actual_execution_time_us as f64);
+            }
+
             // Record prediction accuracy
             if let Some(predicted_us) = predicted_execution_time_us {
                 let error = predicted_us as f64 - actual_execution_time_us as f64;

--- a/crates/builder/core/src/flashblocks/context.rs
+++ b/crates/builder/core/src/flashblocks/context.rs
@@ -843,8 +843,7 @@ impl OpPayloadBuilderCtx {
 
             // Record state modification counts (trie work proxy)
             let accounts_modified = state.len();
-            let storage_slots_modified: usize =
-                state.values().map(|a| a.storage.len()).sum();
+            let storage_slots_modified: usize = state.values().map(|a| a.storage.len()).sum();
             BuilderMetrics::tx_accounts_modified().record(accounts_modified as f64);
             BuilderMetrics::tx_storage_slots_modified().record(storage_slots_modified as f64);
 

--- a/crates/builder/core/src/metrics.rs
+++ b/crates/builder/core/src/metrics.rs
@@ -185,6 +185,12 @@ base_metrics::define_metrics! {
     #[describe("Priority fee of rejected transactions")]
     #[label(reason)]
     rejected_tx_priority_fee: histogram,
+    #[describe("Actual execution time for transactions without metering data (microseconds)")]
+    unmetered_tx_actual_execution_time_us: histogram,
+    #[describe("Number of accounts modified by a transaction (from EVM post-state)")]
+    tx_accounts_modified: histogram,
+    #[describe("Number of storage slots modified by a transaction (from EVM post-state)")]
+    tx_storage_slots_modified: histogram,
 }
 
 impl BuilderMetrics {


### PR DESCRIPTION
## Summary

- Add `unmetered_tx_actual_execution_time_us` histogram for transactions without metering data — directly measures the metering pipeline race condition
- Add `tx_accounts_modified` and `tx_storage_slots_modified` histograms from EVM post-state as a cheap proxy for trie work

## Context

Enforcement testing on Base Sepolia revealed that TIPS ingress often can't deliver metering data before the builder includes expensive transactions. The `metering_unknown_transaction` metric showed a 1,063-count spike during one blake2f test — the builder evaluated 10 transactions ~100 times each across flashblocks with no metering data.

These metrics let us identify expensive transactions that bypass the metering check, and estimate their state root cost from the EVM state changeset (same pattern used in `crates/client/metering/src/meter.rs`).

type=routine
risk=low
impact=sev5