### PR TITLE
[SPIKE]: Virtual Address Resolution Abstractions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2547,6 +2547,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "base-address-resolution"
+version = "0.0.0"
+dependencies = [
+ "alloy-primitives",
+]
+
+[[package]]
 name = "base-alloy-chains"
 version = "0.0.0"
 dependencies = [
@@ -20690,6 +20697,22 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "virtual-address-registry"
+version = "0.0.0"
+dependencies = [
+ "alloy-primitives",
+ "alloy-sol-types",
+ "base-action-harness",
+ "base-address-resolution",
+ "base-alloy-consensus",
+ "base-batcher-encoder",
+ "base-consensus-genesis",
+ "base-protocol",
+ "revm",
+ "tokio",
+]
 
 [[package]]
 name = "virtue"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,6 +68,7 @@ members = [
   "etc/tools/*",
   "devnet",
   "actions/harness",
+  "examples/virtual-address-registry",
 ]
 default-members = [
   "bin/based",
@@ -185,6 +186,7 @@ base-alloy-rpc-jsonrpsee = { path = "crates/core/rpc-jsonrpsee" }
 base-alloy-evm = { path = "crates/core/evm", default-features = false }
 base-alloy-flz = { path = "crates/core/flz", default-features = false }
 base-alloy-consensus = { path = "crates/core/consensus", default-features = false }
+base-address-resolution = { path = "crates/core/address-resolution", default-features = false }
 base-alloy-rpc-types-engine = { path = "crates/core/rpc-types-engine", default-features = false }
 
 # Builder

--- a/Justfile
+++ b/Justfile
@@ -12,6 +12,8 @@ mod actions 'actions'
 mod devnet 'etc/docker'
 # Load testing for networks
 mod load-test 'crates/infra/load-tests'
+# Workspace examples
+mod examples 'examples'
 
 alias t := test
 alias f := fix

--- a/actions/harness/src/engine.rs
+++ b/actions/harness/src/engine.rs
@@ -34,7 +34,7 @@ use base_consensus_engine::{EngineClient, EngineClientError, HyperAuthClient};
 use base_consensus_genesis::RollupConfig;
 use base_protocol::{BlockInfo, L2BlockInfo};
 
-use crate::{SharedBlockHashRegistry, SharedL1Chain, StatefulL2Executor};
+use crate::{EvmOverride, SharedBlockHashRegistry, SharedL1Chain, StatefulL2Executor};
 
 /// A payload built in-process during sequencer mode, waiting to be fetched via `get_payload`.
 #[derive(Debug)]
@@ -102,6 +102,30 @@ impl ActionEngineClient {
         l1_chain: SharedL1Chain,
     ) -> Self {
         let executor = StatefulL2Executor::new((*rollup_config).clone());
+        let inner = Arc::new(Mutex::new(ActionEngineClientInner {
+            executor,
+            canonical_head,
+            executed_headers: HashMap::new(),
+            pending_payloads: HashMap::new(),
+            payload_counter: 0,
+        }));
+        Self { inner, rollup_config, block_registry, l1_chain }
+    }
+
+    /// Create a new `ActionEngineClient` with a custom [`EvmOverride`].
+    ///
+    /// The override is applied to the internal [`StatefulL2Executor`] so that
+    /// re-execution during derivation uses the same custom precompile
+    /// providers as the sequencer.
+    pub fn with_evm_override(
+        rollup_config: Arc<RollupConfig>,
+        canonical_head: L2BlockInfo,
+        block_registry: SharedBlockHashRegistry,
+        l1_chain: SharedL1Chain,
+        evm_override: Box<dyn EvmOverride>,
+    ) -> Self {
+        let executor =
+            StatefulL2Executor::with_evm_override((*rollup_config).clone(), evm_override);
         let inner = Arc::new(Mutex::new(ActionEngineClientInner {
             executor,
             canonical_head,

--- a/actions/harness/src/harness.rs
+++ b/actions/harness/src/harness.rs
@@ -8,8 +8,8 @@ use base_protocol::{BlockInfo, L1BlockInfoTx, L2BlockInfo};
 
 use crate::{
     ActionBlobDataSource, ActionDataSource, ActionEngineClient, ActionL1ChainProvider,
-    ActionL2ChainProvider, ActionL2Source, ActionPipeline, BlobVerifierPipeline, L1Miner,
-    L1MinerConfig, L2Sequencer, SharedL1Chain, TestGossipTransport, TestRollupNode,
+    ActionL2ChainProvider, ActionL2Source, ActionPipeline, BlobVerifierPipeline, EvmOverride,
+    L1Miner, L1MinerConfig, L2Sequencer, SharedL1Chain, TestGossipTransport, TestRollupNode,
     VerifierPipeline, block_info_from,
 };
 
@@ -257,6 +257,41 @@ impl ActionTestHarness {
         let system_config = self.rollup_config.genesis.system_config.unwrap_or_default();
 
         L2Sequencer::new(genesis_head, l1_chain, self.rollup_config.clone(), system_config)
+    }
+
+    /// Create an [`L2Sequencer`] with a custom [`EvmOverride`].
+    ///
+    /// Same as [`create_l2_sequencer`] but the returned sequencer uses the
+    /// given override for EVM execution, allowing custom precompile providers.
+    ///
+    /// [`create_l2_sequencer`]: Self::create_l2_sequencer
+    pub fn create_l2_sequencer_with_evm_override(
+        &self,
+        l1_chain: SharedL1Chain,
+        evm_override: Box<dyn EvmOverride>,
+    ) -> L2Sequencer {
+        let l1_genesis_hash = l1_chain.get_block(0).map(|b| b.hash()).unwrap_or_default();
+
+        let genesis_head = L2BlockInfo {
+            block_info: BlockInfo {
+                hash: self.rollup_config.genesis.l2.hash,
+                number: self.rollup_config.genesis.l2.number,
+                parent_hash: Default::default(),
+                timestamp: self.rollup_config.genesis.l2_time,
+            },
+            l1_origin: BlockNumHash { number: 0, hash: l1_genesis_hash },
+            seq_num: 0,
+        };
+
+        let system_config = self.rollup_config.genesis.system_config.unwrap_or_default();
+
+        L2Sequencer::with_evm_override(
+            genesis_head,
+            l1_chain,
+            self.rollup_config.clone(),
+            system_config,
+            evm_override,
+        )
     }
 
     /// Decode the [`L1BlockInfoTx`] from the first deposit transaction of an

--- a/actions/harness/src/l2.rs
+++ b/actions/harness/src/l2.rs
@@ -344,8 +344,7 @@ impl L2Sequencer {
         evm_override: Box<dyn EvmOverride>,
     ) -> Self {
         let test_account = Arc::new(Mutex::new(TestAccount::new(TEST_ACCOUNT_KEY)));
-        let executor =
-            StatefulL2Executor::with_evm_override(rollup_config.clone(), evm_override);
+        let executor = StatefulL2Executor::with_evm_override(rollup_config.clone(), evm_override);
 
         Self {
             head,
@@ -386,7 +385,7 @@ impl L2Sequencer {
     ///
     /// Callers can pre-seed account state (e.g. registry entries, sentinel
     /// bytecode) before building blocks.
-    pub fn db_mut(&mut self) -> &mut InMemoryDB {
+    pub const fn db_mut(&mut self) -> &mut InMemoryDB {
         self.executor.db_mut()
     }
 
@@ -689,7 +688,10 @@ impl StatefulL2Executor {
     ///
     /// The override replaces the default `OpEvmConfig::optimism()` execution
     /// path, allowing injection of custom precompile providers.
-    pub fn with_evm_override(rollup_config: RollupConfig, evm_override: Box<dyn EvmOverride>) -> Self {
+    pub fn with_evm_override(
+        rollup_config: RollupConfig,
+        evm_override: Box<dyn EvmOverride>,
+    ) -> Self {
         let mut db = InMemoryDB::default();
         db.insert_account_info(
             TEST_ACCOUNT_ADDRESS,
@@ -702,7 +704,7 @@ impl StatefulL2Executor {
     ///
     /// Callers can pre-seed account state (e.g. sentinel bytecode for
     /// precompile addresses) before executing transactions.
-    pub fn db_mut(&mut self) -> &mut InMemoryDB {
+    pub const fn db_mut(&mut self) -> &mut InMemoryDB {
         &mut self.db
     }
 
@@ -791,8 +793,7 @@ impl StatefulL2Executor {
         timestamp: u64,
         parent_hash: B256,
     ) -> Result<(B256, u64), L2SequencerError> {
-        let mut spec_builder =
-            OpChainSpecBuilder::base_mainnet().chain(rollup_config.l2_chain_id);
+        let mut spec_builder = OpChainSpecBuilder::base_mainnet().chain(rollup_config.l2_chain_id);
 
         if let Some(ts) = rollup_config.hardforks.base.v1 {
             spec_builder = spec_builder.with_fork(BaseUpgrade::V1, ForkCondition::Timestamp(ts));

--- a/actions/harness/src/l2.rs
+++ b/actions/harness/src/l2.rs
@@ -28,6 +28,28 @@ use revm::{
 
 use crate::{L2BlockProvider, SharedL1Chain, SupervisedP2P};
 
+/// Override for custom EVM execution in the test harness.
+///
+/// Implement this trait to inject custom precompile providers or other
+/// EVM modifications into the [`StatefulL2Executor`]. When set on an
+/// executor, this replaces the default `OpEvmConfig::optimism()` execution path.
+pub trait EvmOverride: core::fmt::Debug + Send + Sync {
+    /// Execute `transactions` against `db` and return `(state_root, cumulative_gas_used)`.
+    ///
+    /// Implementors have full control over EVM construction (including
+    /// precompile selection) and must commit state changes to `db` and
+    /// compute the state root via [`compute_state_root`].
+    fn execute_transactions(
+        &self,
+        db: &mut InMemoryDB,
+        rollup_config: &RollupConfig,
+        transactions: &[OpTxEnvelope],
+        block_number: u64,
+        timestamp: u64,
+        parent_hash: B256,
+    ) -> Result<(B256, u64), L2SequencerError>;
+}
+
 /// Hardcoded private key for the test account used across all action tests.
 ///
 /// The corresponding address is deterministic: derive it via
@@ -310,6 +332,35 @@ impl L2Sequencer {
         }
     }
 
+    /// Create a new sequencer with a custom [`EvmOverride`].
+    ///
+    /// The override replaces the default EVM execution path, allowing
+    /// injection of custom precompile providers for testing.
+    pub fn with_evm_override(
+        head: L2BlockInfo,
+        l1_chain: SharedL1Chain,
+        rollup_config: RollupConfig,
+        system_config: SystemConfig,
+        evm_override: Box<dyn EvmOverride>,
+    ) -> Self {
+        let test_account = Arc::new(Mutex::new(TestAccount::new(TEST_ACCOUNT_KEY)));
+        let executor =
+            StatefulL2Executor::with_evm_override(rollup_config.clone(), evm_override);
+
+        Self {
+            head,
+            l1_chain,
+            rollup_config,
+            l1_chain_config: L1ChainConfig::default(),
+            system_config,
+            test_account,
+            executor,
+            l1_origin_pin: None,
+            block_hashes: SharedBlockHashRegistry::new(),
+            supervised_p2p: None,
+        }
+    }
+
     /// Return the current unsafe L2 head.
     pub const fn head(&self) -> L2BlockInfo {
         self.head
@@ -329,6 +380,14 @@ impl L2Sequencer {
     /// transactions.
     pub const fn db(&self) -> &InMemoryDB {
         self.executor.db()
+    }
+
+    /// Returns a mutable reference to the sequencer's in-memory EVM database.
+    ///
+    /// Callers can pre-seed account state (e.g. registry entries, sentinel
+    /// bytecode) before building blocks.
+    pub fn db_mut(&mut self) -> &mut InMemoryDB {
+        self.executor.db_mut()
     }
 
     /// Return the sequencer's shared block-hash registry.
@@ -608,6 +667,8 @@ pub fn decode_raw_transactions(raw_txs: &[Bytes]) -> Result<Vec<OpTxEnvelope>, L
 pub struct StatefulL2Executor {
     db: InMemoryDB,
     rollup_config: RollupConfig,
+    /// Optional EVM override for custom precompile providers.
+    evm_override: Option<Box<dyn EvmOverride>>,
 }
 
 impl StatefulL2Executor {
@@ -621,7 +682,28 @@ impl StatefulL2Executor {
             TEST_ACCOUNT_ADDRESS,
             AccountInfo { balance: TEST_ACCOUNT_BALANCE, ..Default::default() },
         );
-        Self { db, rollup_config }
+        Self { db, rollup_config, evm_override: None }
+    }
+
+    /// Create a new executor with a custom [`EvmOverride`].
+    ///
+    /// The override replaces the default `OpEvmConfig::optimism()` execution
+    /// path, allowing injection of custom precompile providers.
+    pub fn with_evm_override(rollup_config: RollupConfig, evm_override: Box<dyn EvmOverride>) -> Self {
+        let mut db = InMemoryDB::default();
+        db.insert_account_info(
+            TEST_ACCOUNT_ADDRESS,
+            AccountInfo { balance: TEST_ACCOUNT_BALANCE, ..Default::default() },
+        );
+        Self { db, rollup_config, evm_override: Some(evm_override) }
+    }
+
+    /// Returns a mutable reference to the internal EVM database.
+    ///
+    /// Callers can pre-seed account state (e.g. sentinel bytecode for
+    /// precompile addresses) before executing transactions.
+    pub fn db_mut(&mut self) -> &mut InMemoryDB {
+        &mut self.db
     }
 
     /// Returns a reference to the internal EVM database.
@@ -667,10 +749,52 @@ impl StatefulL2Executor {
         timestamp: u64,
         parent_hash: B256,
     ) -> Result<(B256, u64), L2SequencerError> {
-        let mut spec_builder =
-            OpChainSpecBuilder::base_mainnet().chain(self.rollup_config.l2_chain_id);
+        // Delegate to the custom override when one is configured.
+        if let Some(evm_override) = &self.evm_override {
+            // Clone the override ref to satisfy the borrow checker (we need &mut self.db).
+            let evm_override = evm_override.as_ref();
 
-        if let Some(ts) = self.rollup_config.hardforks.base.v1 {
+            // Safety: we need to reborrow because evm_override borrows self immutably
+            // while execute_transactions needs &mut self.db. Work around by reading
+            // the config first.
+            let rollup_config = self.rollup_config.clone();
+            return evm_override.execute_transactions(
+                &mut self.db,
+                &rollup_config,
+                transactions,
+                block_number,
+                timestamp,
+                parent_hash,
+            );
+        }
+
+        Self::default_execute_transactions(
+            &mut self.db,
+            &self.rollup_config,
+            transactions,
+            block_number,
+            timestamp,
+            parent_hash,
+        )
+    }
+
+    /// Default EVM execution using `OpEvmConfig::optimism()`.
+    ///
+    /// This is the standard execution path used when no [`EvmOverride`] is set.
+    /// It is also available as a public function so that custom overrides can
+    /// delegate to it for transactions they do not need to intercept.
+    pub fn default_execute_transactions(
+        db: &mut InMemoryDB,
+        rollup_config: &RollupConfig,
+        transactions: &[OpTxEnvelope],
+        block_number: u64,
+        timestamp: u64,
+        parent_hash: B256,
+    ) -> Result<(B256, u64), L2SequencerError> {
+        let mut spec_builder =
+            OpChainSpecBuilder::base_mainnet().chain(rollup_config.l2_chain_id);
+
+        if let Some(ts) = rollup_config.hardforks.base.v1 {
             spec_builder = spec_builder.with_fork(BaseUpgrade::V1, ForkCondition::Timestamp(ts));
         }
 
@@ -693,11 +817,11 @@ impl StatefulL2Executor {
 
             let evm_env =
                 evm_config.evm_env(&header).map_err(|e| L2SequencerError::Evm(e.to_string()))?;
-            let mut evm = evm_config.evm_with_env(&mut self.db, evm_env);
+            let mut evm = evm_config.evm_with_env(&mut *db, evm_env);
             match evm.transact(op_tx) {
                 Ok(ResultAndState { state, result }) => {
                     cumulative_gas_used = cumulative_gas_used.saturating_add(result.gas_used());
-                    self.db.commit(state);
+                    db.commit(state);
                 }
                 Err(e) => {
                     return Err(L2SequencerError::Evm(format!("{e:?}")));
@@ -705,6 +829,6 @@ impl StatefulL2Executor {
             }
         }
 
-        Ok((compute_state_root(&self.db), cumulative_gas_used))
+        Ok((compute_state_root(db), cumulative_gas_used))
     }
 }

--- a/actions/harness/src/lib.rs
+++ b/actions/harness/src/lib.rs
@@ -13,9 +13,9 @@ pub use miner::{
 
 mod l2;
 pub use l2::{
-    ActionL2Source, BlockHashInner, L2Sequencer, L2SequencerError, SharedBlockHashRegistry,
-    StatefulL2Executor, TEST_ACCOUNT_ADDRESS, TEST_ACCOUNT_KEY, TestAccount, compute_state_root,
-    decode_raw_transactions,
+    ActionL2Source, BlockHashInner, EvmOverride, L2Sequencer, L2SequencerError,
+    SharedBlockHashRegistry, StatefulL2Executor, TEST_ACCOUNT_ADDRESS, TEST_ACCOUNT_KEY,
+    TestAccount, compute_state_root, decode_raw_transactions,
 };
 
 mod harness;

--- a/crates/core/address-resolution/Cargo.toml
+++ b/crates/core/address-resolution/Cargo.toml
@@ -16,5 +16,5 @@ workspace = true
 alloy-primitives = { workspace = true, default-features = false }
 
 [features]
-default = ["std"]
-std = ["alloy-primitives/std"]
+default = [ "std" ]
+std = [ "alloy-primitives/std" ]

--- a/crates/core/address-resolution/Cargo.toml
+++ b/crates/core/address-resolution/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "base-address-resolution"
+description = "Virtual address resolution types and traits for deposit forwarding"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+exclude.workspace = true
+
+[lints]
+workspace = true
+
+[dependencies]
+alloy-primitives = { workspace = true, default-features = false }
+
+[features]
+default = ["std"]
+std = ["alloy-primitives/std"]

--- a/crates/core/address-resolution/README.md
+++ b/crates/core/address-resolution/README.md
@@ -1,0 +1,35 @@
+# base-address-resolution
+
+Types and traits for virtual address resolution, enabling deposit forwarding
+to master wallets without sweep transactions or state bloat.
+
+## Overview
+
+This crate provides the building blocks for virtual address schemes where a
+specially formatted 20-byte address encodes a lookup key (`masterId`) and a
+per-user tag (`userTag`). A registry maps each `masterId` to a master address.
+Token contracts can call the registry to resolve a virtual recipient to its
+master before crediting, eliminating per-user sweep transactions.
+
+## Address Format
+
+A virtual address is 20 bytes laid out as:
+
+```text
+[4-byte masterId] [10-byte VIRTUAL_MAGIC] [6-byte userTag]
+```
+
+The 10-byte magic `0xFDFDFDFDFDFDFDFDFDFD` in the middle distinguishes
+virtual addresses from regular addresses.
+
+## Usage
+
+```rust,ignore
+use base_address_resolution::{VirtualAddress, MasterId, UserTag};
+
+let addr: Address = /* ... */;
+if VirtualAddress::is_virtual(addr) {
+    let (master_id, user_tag) = VirtualAddress::decode(addr).unwrap();
+    // look up master_id in a registry to get the effective recipient
+}
+```

--- a/crates/core/address-resolution/src/lib.rs
+++ b/crates/core/address-resolution/src/lib.rs
@@ -1,0 +1,11 @@
+#![doc = include_str!("../README.md")]
+#![cfg_attr(not(feature = "std"), no_std)]
+
+mod types;
+pub use types::{MasterId, REGISTRY_ADDRESS, RegistryError, UserTag, VIRTUAL_MAGIC};
+
+mod virtual_addr;
+pub use virtual_addr::VirtualAddress;
+
+mod traits;
+pub use traits::{AddressResolver, MasterRegistry};

--- a/crates/core/address-resolution/src/traits.rs
+++ b/crates/core/address-resolution/src/traits.rs
@@ -1,0 +1,44 @@
+//! Traits for virtual address registration and resolution.
+
+use alloy_primitives::{Address, B256};
+
+use crate::MasterId;
+
+/// Resolves an address to its effective recipient.
+///
+/// Implementations detect virtual addresses and return the registered master.
+/// Non-virtual addresses pass through unchanged.
+pub trait AddressResolver {
+    /// The error type returned by this resolver.
+    type Error;
+
+    /// Resolve `addr` to the effective recipient.
+    ///
+    /// - If `addr` is a virtual address with a registered master, returns the master.
+    /// - If `addr` is not a virtual address, returns `addr` unchanged.
+    /// - If `addr` is virtual but unregistered, returns an error.
+    fn resolve_recipient(&self, addr: Address) -> Result<Address, Self::Error>;
+}
+
+/// Registry mapping master IDs to master addresses.
+///
+/// Implementors manage the storage of `MasterId → Address` mappings and enforce
+/// registration invariants (proof-of-work, collision detection, address validity).
+pub trait MasterRegistry {
+    /// The error type returned by this registry.
+    type Error;
+
+    /// Register the caller as a virtual-address master.
+    ///
+    /// Computes `masterId` from `keccak256(abi.encodePacked(caller, salt))`,
+    /// validates the 32-bit proof-of-work, checks for collisions, and stores
+    /// the mapping.
+    ///
+    /// Returns the newly registered [`MasterId`].
+    fn register(&mut self, caller: Address, salt: B256) -> Result<MasterId, Self::Error>;
+
+    /// Look up the master address for a given `MasterId`.
+    ///
+    /// Returns `None` if the `MasterId` is not registered.
+    fn get_master(&self, master_id: MasterId) -> Result<Option<Address>, Self::Error>;
+}

--- a/crates/core/address-resolution/src/types.rs
+++ b/crates/core/address-resolution/src/types.rs
@@ -1,0 +1,55 @@
+//! Core types for virtual address resolution.
+
+use alloy_primitives::{Address, FixedBytes};
+
+/// A 4-byte master identifier derived from `keccak256(abi.encodePacked(caller, salt))`.
+///
+/// The registration process requires a 32-bit proof-of-work: the first 4 bytes of the
+/// hash must be zero, and the `MasterId` is extracted from bytes `[4..8]`.
+pub type MasterId = FixedBytes<4>;
+
+/// A 6-byte opaque per-user tag embedded in a virtual address.
+///
+/// Derived offchain by the master. 48 bits provides ~2.8 × 10¹⁴ unique deposit
+/// addresses per master.
+pub type UserTag = FixedBytes<6>;
+
+/// 10-byte magic sequence placed at bytes `[4..14]` of a virtual address.
+///
+/// Any 20-byte address whose bytes `[4..14]` match this constant is treated as virtual.
+pub const VIRTUAL_MAGIC: [u8; 10] = [0xFD; 10];
+
+/// Reserved address for the virtual-address registry precompile / contract.
+pub const REGISTRY_ADDRESS: Address = Address::new([
+    0xFD, 0xC0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00,
+]);
+
+/// Errors that can occur during virtual address registration or resolution.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RegistryError {
+    /// The first 4 bytes of the registration hash are not zero.
+    ProofOfWorkFailed,
+    /// A different master address is already registered for this `MasterId`.
+    MasterIdCollision(Address),
+    /// The supplied master address is not valid (zero, virtual, or reserved).
+    InvalidMasterAddress,
+    /// The virtual address references an unregistered `MasterId`.
+    VirtualAddressUnregistered,
+}
+
+impl core::fmt::Display for RegistryError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::ProofOfWorkFailed => write!(f, "proof-of-work failed: first 4 bytes must be zero"),
+            Self::MasterIdCollision(addr) => {
+                write!(f, "master ID collision: already registered to {addr}")
+            }
+            Self::InvalidMasterAddress => write!(f, "invalid master address"),
+            Self::VirtualAddressUnregistered => write!(f, "virtual address unregistered"),
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for RegistryError {}

--- a/crates/core/address-resolution/src/types.rs
+++ b/crates/core/address-resolution/src/types.rs
@@ -21,8 +21,8 @@ pub const VIRTUAL_MAGIC: [u8; 10] = [0xFD; 10];
 
 /// Reserved address for the virtual-address registry precompile / contract.
 pub const REGISTRY_ADDRESS: Address = Address::new([
-    0xFD, 0xC0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-    0x00, 0x00, 0x00, 0x00, 0x00,
+    0xFD, 0xC0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00,
 ]);
 
 /// Errors that can occur during virtual address registration or resolution.
@@ -41,7 +41,9 @@ pub enum RegistryError {
 impl core::fmt::Display for RegistryError {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {
-            Self::ProofOfWorkFailed => write!(f, "proof-of-work failed: first 4 bytes must be zero"),
+            Self::ProofOfWorkFailed => {
+                write!(f, "proof-of-work failed: first 4 bytes must be zero")
+            }
             Self::MasterIdCollision(addr) => {
                 write!(f, "master ID collision: already registered to {addr}")
             }

--- a/crates/core/address-resolution/src/virtual_addr.rs
+++ b/crates/core/address-resolution/src/virtual_addr.rs
@@ -1,0 +1,173 @@
+//! Virtual address encoding, decoding, and validation.
+
+use alloy_primitives::{Address, B256, FixedBytes, keccak256};
+
+use crate::{MasterId, RegistryError, UserTag, VIRTUAL_MAGIC};
+
+/// Utilities for working with virtual addresses.
+///
+/// A virtual address is a 20-byte address with the layout:
+///
+/// ```text
+/// [4-byte masterId] [10-byte VIRTUAL_MAGIC] [6-byte userTag]
+/// ```
+///
+/// The 10-byte magic in the middle identifies the address as virtual. The
+/// `masterId` is a registry lookup key, and the `userTag` is an opaque
+/// per-user identifier.
+#[derive(Debug)]
+pub struct VirtualAddress;
+
+impl VirtualAddress {
+    /// Returns `true` if `addr` matches the virtual address format.
+    ///
+    /// Checks whether bytes `[4..14]` equal [`VIRTUAL_MAGIC`].
+    pub fn is_virtual(addr: Address) -> bool {
+        addr.as_slice()[4..14] == VIRTUAL_MAGIC
+    }
+
+    /// Decode a virtual address into its `(MasterId, UserTag)` components.
+    ///
+    /// Returns `None` if the address is not virtual.
+    pub fn decode(addr: Address) -> Option<(MasterId, UserTag)> {
+        if !Self::is_virtual(addr) {
+            return None;
+        }
+        let bytes = addr.as_slice();
+        let master_id = MasterId::from_slice(&bytes[..4]);
+        let user_tag = UserTag::from_slice(&bytes[14..]);
+        Some((master_id, user_tag))
+    }
+
+    /// Encode a `(MasterId, UserTag)` pair into a virtual address.
+    pub fn encode(master_id: MasterId, user_tag: UserTag) -> Address {
+        let mut bytes = [0u8; 20];
+        bytes[..4].copy_from_slice(master_id.as_slice());
+        bytes[4..14].copy_from_slice(&VIRTUAL_MAGIC);
+        bytes[14..].copy_from_slice(user_tag.as_slice());
+        Address::new(bytes)
+    }
+
+    /// Compute the `MasterId` for a given `(caller, salt)` pair.
+    ///
+    /// The registration hash is `keccak256(abi.encodePacked(caller, salt))`.
+    /// The first 4 bytes of the hash **must** be zero (32-bit proof-of-work).
+    /// The `MasterId` is extracted from bytes `[4..8]`.
+    pub fn compute_master_id(caller: Address, salt: B256) -> Result<MasterId, RegistryError> {
+        let hash = Self::registration_hash(caller, salt);
+        // Proof-of-work: first 4 bytes must be zero.
+        if hash[..4] != [0u8; 4] {
+            return Err(RegistryError::ProofOfWorkFailed);
+        }
+        Ok(FixedBytes::from_slice(&hash[4..8]))
+    }
+
+    /// Compute the raw registration hash without validating proof-of-work.
+    pub fn registration_hash(caller: Address, salt: B256) -> B256 {
+        let mut preimage = [0u8; 52];
+        preimage[..20].copy_from_slice(caller.as_slice());
+        preimage[20..].copy_from_slice(salt.as_slice());
+        keccak256(preimage)
+    }
+
+    /// Returns `true` if `addr` is a valid master address.
+    ///
+    /// A valid master address must not be:
+    /// - The zero address
+    /// - A virtual address (matching [`VIRTUAL_MAGIC`])
+    pub fn is_valid_master(addr: Address) -> bool {
+        !addr.is_zero() && !Self::is_virtual(addr)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloy_primitives::{Address, B256, address, b256};
+
+    use super::*;
+
+    #[test]
+    fn roundtrip_encode_decode() {
+        let master_id = MasterId::from_slice(&[0xAB, 0xCD, 0x12, 0x34]);
+        let user_tag = UserTag::from_slice(&[0x01, 0x02, 0x03, 0x04, 0x05, 0x06]);
+
+        let addr = VirtualAddress::encode(master_id, user_tag);
+        assert!(VirtualAddress::is_virtual(addr));
+
+        let (decoded_mid, decoded_ut) = VirtualAddress::decode(addr).unwrap();
+        assert_eq!(decoded_mid, master_id);
+        assert_eq!(decoded_ut, user_tag);
+    }
+
+    #[test]
+    fn non_virtual_address_returns_none() {
+        let addr = address!("d8dA6BF26964aF9D7eEd9e03E53415D37aA96045");
+        assert!(!VirtualAddress::is_virtual(addr));
+        assert!(VirtualAddress::decode(addr).is_none());
+    }
+
+    #[test]
+    fn zero_address_is_not_valid_master() {
+        assert!(!VirtualAddress::is_valid_master(Address::ZERO));
+    }
+
+    #[test]
+    fn virtual_address_is_not_valid_master() {
+        let master_id = MasterId::from_slice(&[0x00, 0x00, 0x00, 0x01]);
+        let user_tag = UserTag::from_slice(&[0x00; 6]);
+        let virtual_addr = VirtualAddress::encode(master_id, user_tag);
+        assert!(!VirtualAddress::is_valid_master(virtual_addr));
+    }
+
+    #[test]
+    fn regular_address_is_valid_master() {
+        let addr = address!("d8dA6BF26964aF9D7eEd9e03E53415D37aA96045");
+        assert!(VirtualAddress::is_valid_master(addr));
+    }
+
+    #[test]
+    fn compute_master_id_extracts_correct_bytes() {
+        // Verify that when the first 4 bytes of the hash are zero,
+        // compute_master_id returns bytes [4..8] as the MasterId.
+        let caller = address!("f39Fd6e51aad88F6F4ce6aB8827279cffFb92266");
+        let salt = B256::ZERO;
+        let hash = VirtualAddress::registration_hash(caller, salt);
+
+        // The hash is deterministic. Check whether it passes PoW.
+        if hash[..4] == [0u8; 4] {
+            // Lucky — first 4 bytes are zero. Verify extraction.
+            let mid = VirtualAddress::compute_master_id(caller, salt).unwrap();
+            assert_eq!(mid.as_slice(), &hash[4..8]);
+        } else {
+            // Expected path — PoW fails for this salt.
+            assert_eq!(
+                VirtualAddress::compute_master_id(caller, salt),
+                Err(RegistryError::ProofOfWorkFailed)
+            );
+        }
+    }
+
+    #[test]
+    fn registration_hash_is_deterministic() {
+        let caller = address!("f39Fd6e51aad88F6F4ce6aB8827279cffFb92266");
+        let salt = b256!("0000000000000000000000000000000000000000000000000000000000000001");
+
+        let h1 = VirtualAddress::registration_hash(caller, salt);
+        let h2 = VirtualAddress::registration_hash(caller, salt);
+        assert_eq!(h1, h2);
+
+        // Different salt produces different hash.
+        let salt2 = b256!("0000000000000000000000000000000000000000000000000000000000000002");
+        let h3 = VirtualAddress::registration_hash(caller, salt2);
+        assert_ne!(h1, h3);
+    }
+
+    #[test]
+    fn invalid_proof_of_work_rejected() {
+        let caller = address!("f39Fd6e51aad88F6F4ce6aB8827279cffFb92266");
+        // A salt of all zeros is extremely unlikely to pass PoW.
+        let salt = b256!("ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
+        let result = VirtualAddress::compute_master_id(caller, salt);
+        assert_eq!(result, Err(RegistryError::ProofOfWorkFailed));
+    }
+}

--- a/examples/Justfile
+++ b/examples/Justfile
@@ -1,0 +1,21 @@
+# Recipes for the examples directory.
+# Import this module from the root Justfile with:
+#   mod examples 'examples'
+
+# Run all examples by default
+default: all
+
+# Run all examples
+all:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    for dir in */; do
+        [ -f "$dir/Cargo.toml" ] || continue
+        crate=$(basename "$dir")
+        echo "── $crate ──"
+        cargo test -p "$crate"
+    done
+
+# Run the virtual address registry example
+virtual-address-registry:
+    cargo test -p virtual-address-registry

--- a/examples/virtual-address-registry/Cargo.toml
+++ b/examples/virtual-address-registry/Cargo.toml
@@ -1,0 +1,31 @@
+[package]
+name = "virtual-address-registry"
+description = "Example: virtual address registry precompile with e2e integration test"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+publish = false
+
+[lints]
+workspace = true
+
+[dependencies]
+base-address-resolution = { workspace = true, features = ["std"] }
+base-action-harness.workspace = true
+base-alloy-consensus.workspace = true
+base-consensus-genesis = { workspace = true, features = ["std"] }
+
+# revm
+revm.workspace = true
+
+# alloy
+alloy-sol-types = { workspace = true, features = ["std"] }
+alloy-primitives.workspace = true
+
+[dev-dependencies]
+base-batcher-encoder.workspace = true
+base-protocol.workspace = true
+tokio = { workspace = true, features = ["rt", "macros"] }

--- a/examples/virtual-address-registry/README.md
+++ b/examples/virtual-address-registry/README.md
@@ -1,0 +1,25 @@
+# Virtual Address Registry Example
+
+End-to-end demonstration of TIP-1022 virtual address resolution on the Base
+stack. Shows how to implement a stateful precompile that resolves virtual
+deposit addresses to registered master wallets, eliminating sweep transactions.
+
+## What This Demonstrates
+
+1. **Custom `EvmOverride`** — Injects a registry precompile into the test
+   harness EVM, intercepting calls to the registry address with full storage
+   access.
+
+2. **Stateful precompile** — The registry stores `masterId → masterAddress`
+   mappings in EVM storage slots, supporting registration (with 32-bit
+   proof-of-work) and resolution.
+
+3. **Full e2e flow** — From RPC-style transaction submission through EVM
+   execution to verified balance changes, batched and derived through the
+   consensus pipeline.
+
+## Running
+
+```sh
+cargo test -p virtual-address-registry
+```

--- a/examples/virtual-address-registry/src/abi.rs
+++ b/examples/virtual-address-registry/src/abi.rs
@@ -1,0 +1,29 @@
+//! ABI definitions for the virtual address registry precompile.
+
+use alloy_sol_types::sol;
+
+sol! {
+    /// Interface for the virtual address registry.
+    #[derive(Debug)]
+    interface IAddressRegistry {
+        /// Register the caller as a virtual-address master.
+        /// The `salt` must satisfy the 32-bit proof-of-work requirement.
+        function registerVirtualMaster(bytes32 salt) external returns (bytes4 masterId);
+
+        /// Return the master address for a given master ID.
+        function getMaster(bytes4 masterId) external view returns (address);
+
+        /// Resolve an address: if virtual, return the registered master; otherwise return the input.
+        function resolveRecipient(address to) external view returns (address);
+
+        /// Check whether an address matches the virtual address format.
+        function isVirtualAddress(address addr) external pure returns (bool);
+
+        event MasterRegistered(bytes4 indexed masterId, address indexed masterAddress);
+
+        error MasterIdCollision(address existing);
+        error InvalidMasterAddress();
+        error ProofOfWorkFailed();
+        error VirtualAddressUnregistered();
+    }
+}

--- a/examples/virtual-address-registry/src/contracts.rs
+++ b/examples/virtual-address-registry/src/contracts.rs
@@ -1,0 +1,41 @@
+//! Compiled bytecodes for test contracts.
+//!
+//! These are minimal EVM bytecode snippets used in integration tests. For
+//! a production deployment, these would be compiled from Solidity source.
+
+use alloy_primitives::{Address, U256};
+
+/// A minimal ERC-20 token contract that resolves virtual addresses via the
+/// registry before crediting the recipient.
+///
+/// For simplicity in this example, the "contract" logic is implemented in
+/// Rust and executed via the [`RegistryEvmOverride`]. In a real deployment,
+/// this would be a Solidity contract that calls `resolveRecipient()` on the
+/// registry precompile.
+///
+/// Storage layout:
+/// - `keccak256(abi.encode(address, 0))` → balance of `address`
+/// - slot 1 → total supply
+#[derive(Debug)]
+pub struct ResolverErc20;
+
+impl ResolverErc20 {
+    /// Compute the storage slot for a given address's balance.
+    pub fn balance_slot(addr: Address) -> U256 {
+        use alloy_primitives::keccak256;
+        let mut data = [0u8; 64];
+        data[12..32].copy_from_slice(addr.as_slice());
+        // slot 0 for balances mapping
+        U256::from_be_bytes(keccak256(data).0)
+    }
+
+    /// Read the balance of `addr` from the EVM database.
+    pub fn balance_of(db: &revm::database::InMemoryDB, token: Address, addr: Address) -> U256 {
+        let slot = Self::balance_slot(addr);
+        db.cache
+            .accounts
+            .get(&token)
+            .and_then(|acct| acct.storage.get(&slot).copied())
+            .unwrap_or(U256::ZERO)
+    }
+}

--- a/examples/virtual-address-registry/src/evm_override.rs
+++ b/examples/virtual-address-registry/src/evm_override.rs
@@ -10,8 +10,7 @@ use base_alloy_consensus::OpTxEnvelope;
 use base_consensus_genesis::RollupConfig;
 use revm::database::InMemoryDB;
 
-use crate::StorageBackedRegistry;
-use crate::abi::IAddressRegistry;
+use crate::{StorageBackedRegistry, abi::IAddressRegistry};
 
 /// EVM override that intercepts calls to the virtual address registry.
 ///
@@ -93,13 +92,12 @@ impl RegistryEvmOverride {
 
         let selector: [u8; 4] = input[..4].try_into().unwrap();
 
-        if selector == IAddressRegistry::registerVirtualMasterCall::SELECTOR {
-            if let Ok(call) =
+        if selector == IAddressRegistry::registerVirtualMasterCall::SELECTOR
+            && let Ok(call) =
                 <IAddressRegistry::registerVirtualMasterCall as SolCall>::abi_decode(&input[4..])
             {
                 let _ = StorageBackedRegistry::register(db, caller, B256::from(call.salt));
             }
-        }
         // Other selectors (resolveRecipient, getMaster, etc.) are read-only and
         // don't need special handling in this simplified example.
 
@@ -124,7 +122,7 @@ fn tx_input(tx: &OpTxEnvelope) -> Bytes {
 }
 
 /// Determine the sender address for a transaction.
-fn tx_sender(tx: &OpTxEnvelope) -> Address {
+const fn tx_sender(tx: &OpTxEnvelope) -> Address {
     match tx {
         OpTxEnvelope::Deposit(sealed) => sealed.inner().from,
         _ => TEST_ACCOUNT_ADDRESS,

--- a/examples/virtual-address-registry/src/evm_override.rs
+++ b/examples/virtual-address-registry/src/evm_override.rs
@@ -1,0 +1,132 @@
+//! Custom EVM override that adds the virtual address registry precompile.
+
+use alloy_primitives::{Address, B256, Bytes, TxKind, U256};
+use alloy_sol_types::SolCall;
+use base_action_harness::{
+    EvmOverride, L2SequencerError, StatefulL2Executor, TEST_ACCOUNT_ADDRESS, compute_state_root,
+};
+use base_address_resolution::REGISTRY_ADDRESS;
+use base_alloy_consensus::OpTxEnvelope;
+use base_consensus_genesis::RollupConfig;
+use revm::database::InMemoryDB;
+
+use crate::StorageBackedRegistry;
+use crate::abi::IAddressRegistry;
+
+/// EVM override that intercepts calls to the virtual address registry.
+///
+/// When a transaction targets [`REGISTRY_ADDRESS`], this override decodes the
+/// ABI calldata and executes the registry operation directly against the EVM
+/// database. All other transactions are executed normally via the default
+/// `OpEvmConfig::optimism()` path.
+#[derive(Debug)]
+pub struct RegistryEvmOverride;
+
+impl EvmOverride for RegistryEvmOverride {
+    fn execute_transactions(
+        &self,
+        db: &mut InMemoryDB,
+        rollup_config: &RollupConfig,
+        transactions: &[OpTxEnvelope],
+        block_number: u64,
+        timestamp: u64,
+        parent_hash: B256,
+    ) -> Result<(B256, u64), L2SequencerError> {
+        // Split transactions: registry calls are handled here, everything else
+        // is delegated to the default execution path.
+        let mut non_registry_txs: Vec<OpTxEnvelope> = Vec::new();
+        let mut registry_gas = 0u64;
+
+        for tx in transactions {
+            if is_registry_call(tx) {
+                let sender = tx_sender(tx);
+                let input = tx_input(tx);
+                let gas = Self::handle_registry_call(db, sender, &input);
+                registry_gas = registry_gas.saturating_add(gas);
+
+                // Advance the sender's nonce and debit gas cost.
+                if let Some(acct) = db.cache.accounts.get_mut(&sender) {
+                    acct.info.nonce += 1;
+                    acct.info.balance = acct
+                        .info
+                        .balance
+                        .saturating_sub(U256::from(gas) * U256::from(1_000_000_000u64));
+                }
+            } else {
+                non_registry_txs.push(tx.clone());
+            }
+        }
+
+        // Execute non-registry transactions via the default path.
+        let (_state_root, default_gas) = StatefulL2Executor::default_execute_transactions(
+            db,
+            rollup_config,
+            &non_registry_txs,
+            block_number,
+            timestamp,
+            parent_hash,
+        )?;
+
+        // The state root from default_execute_transactions already accounts for
+        // the registry writes we made above (they're in the db). But gas needs
+        // to be combined.
+        //
+        // Note: recompute state root to include registry writes that happened
+        // before the default execution.
+        let final_root = compute_state_root(db);
+
+        Ok((final_root, default_gas.saturating_add(registry_gas)))
+    }
+}
+
+impl RegistryEvmOverride {
+    /// Handle a call to the registry address by decoding the ABI selector and
+    /// executing the appropriate registry operation.
+    ///
+    /// Returns the gas consumed.
+    fn handle_registry_call(db: &mut InMemoryDB, caller: Address, input: &[u8]) -> u64 {
+        const REGISTRY_GAS: u64 = 50_000;
+
+        if input.len() < 4 {
+            return REGISTRY_GAS;
+        }
+
+        let selector: [u8; 4] = input[..4].try_into().unwrap();
+
+        if selector == IAddressRegistry::registerVirtualMasterCall::SELECTOR {
+            if let Ok(call) =
+                <IAddressRegistry::registerVirtualMasterCall as SolCall>::abi_decode(&input[4..])
+            {
+                let _ = StorageBackedRegistry::register(db, caller, B256::from(call.salt));
+            }
+        }
+        // Other selectors (resolveRecipient, getMaster, etc.) are read-only and
+        // don't need special handling in this simplified example.
+
+        REGISTRY_GAS
+    }
+}
+
+/// Check if a transaction targets the registry address.
+fn is_registry_call(tx: &OpTxEnvelope) -> bool {
+    match tx {
+        OpTxEnvelope::Eip1559(signed) => signed.tx().to == TxKind::Call(REGISTRY_ADDRESS),
+        _ => false,
+    }
+}
+
+/// Extract the input (calldata) from a transaction.
+fn tx_input(tx: &OpTxEnvelope) -> Bytes {
+    match tx {
+        OpTxEnvelope::Eip1559(signed) => signed.tx().input.clone(),
+        _ => Bytes::new(),
+    }
+}
+
+/// Determine the sender address for a transaction.
+fn tx_sender(tx: &OpTxEnvelope) -> Address {
+    match tx {
+        OpTxEnvelope::Deposit(sealed) => sealed.inner().from,
+        _ => TEST_ACCOUNT_ADDRESS,
+    }
+}

--- a/examples/virtual-address-registry/src/lib.rs
+++ b/examples/virtual-address-registry/src/lib.rs
@@ -1,0 +1,14 @@
+#![doc = include_str!("../README.md")]
+#![cfg_attr(not(test), warn(unused_crate_dependencies))]
+
+mod abi;
+pub use abi::IAddressRegistry;
+
+mod registry;
+pub use registry::StorageBackedRegistry;
+
+mod evm_override;
+pub use evm_override::RegistryEvmOverride;
+
+/// Compiled EVM bytecode for the test contracts.
+pub mod contracts;

--- a/examples/virtual-address-registry/src/registry.rs
+++ b/examples/virtual-address-registry/src/registry.rs
@@ -1,0 +1,137 @@
+//! Storage-backed virtual address registry.
+//!
+//! Implements the `MasterRegistry` and `AddressResolver` traits using raw EVM
+//! storage slot reads and writes against a revm `InMemoryDB`.
+
+use alloy_primitives::{Address, B256, U256, keccak256};
+use base_address_resolution::{
+    AddressResolver, MasterId, MasterRegistry, REGISTRY_ADDRESS, RegistryError, VirtualAddress,
+};
+use revm::{DatabaseCommit, database::InMemoryDB, state::AccountInfo};
+
+/// Base storage slot for the registry mapping.
+///
+/// `slot = keccak256(abi.encode(masterId, REGISTRY_SLOT))` stores the packed
+/// `masterAddress | reserved(11) | masterType(1)` value.
+const REGISTRY_SLOT: U256 = U256::ZERO;
+
+/// A virtual address registry backed by revm `InMemoryDB` storage.
+///
+/// Stores `masterId → masterAddress` mappings in storage slots under the
+/// [`REGISTRY_ADDRESS`]. Compatible with the Tempo TIP-1022 storage layout.
+#[derive(Debug)]
+pub struct StorageBackedRegistry;
+
+impl StorageBackedRegistry {
+    /// Compute the storage slot for a given `MasterId`.
+    fn slot_for(master_id: MasterId) -> U256 {
+        // slot = keccak256(abi.encode(masterId, REGISTRY_SLOT))
+        let mut data = [0u8; 64];
+        // masterId is left-padded to 32 bytes (bytes4 in the high bits of a bytes32)
+        data[..4].copy_from_slice(master_id.as_slice());
+        // REGISTRY_SLOT in the second 32-byte word
+        data[32..].copy_from_slice(&REGISTRY_SLOT.to_be_bytes::<32>());
+        U256::from_be_bytes(keccak256(data).0)
+    }
+
+    /// Read the master address stored for a `MasterId` from the database.
+    pub fn read_master(db: &InMemoryDB, master_id: MasterId) -> Option<Address> {
+        let slot = Self::slot_for(master_id);
+        let value = db
+            .cache
+            .accounts
+            .get(&REGISTRY_ADDRESS)
+            .and_then(|acct| acct.storage.get(&slot).copied())
+            .unwrap_or(U256::ZERO);
+
+        if value.is_zero() {
+            return None;
+        }
+
+        // The address is stored in the high 20 bytes of the 32-byte slot.
+        let bytes = value.to_be_bytes::<32>();
+        Some(Address::from_slice(&bytes[..20]))
+    }
+
+    /// Write a `masterId → masterAddress` mapping into the database.
+    pub fn write_master(db: &mut InMemoryDB, master_id: MasterId, master: Address) {
+        // Ensure the registry account exists.
+        if db.cache.accounts.get(&REGISTRY_ADDRESS).is_none() {
+            db.insert_account_info(REGISTRY_ADDRESS, AccountInfo::default());
+        }
+
+        let slot = Self::slot_for(master_id);
+
+        // Pack: address (20 bytes) | reserved (11 bytes) | type (1 byte = 0x00)
+        let mut packed = [0u8; 32];
+        packed[..20].copy_from_slice(master.as_slice());
+        let value = U256::from_be_bytes(packed);
+
+        // Commit the storage write.
+        let mut state = revm::state::EvmState::default();
+        let mut account = revm::state::Account::default();
+        account.storage.insert(
+            slot,
+            revm::state::EvmStorageSlot::new_changed(U256::ZERO, value, 0),
+        );
+        account.mark_touch();
+        state.insert(REGISTRY_ADDRESS, account);
+        db.commit(state);
+    }
+
+    /// Execute a `registerVirtualMaster` call against the database.
+    pub fn register(
+        db: &mut InMemoryDB,
+        caller: Address,
+        salt: B256,
+    ) -> Result<MasterId, RegistryError> {
+        if !VirtualAddress::is_valid_master(caller) {
+            return Err(RegistryError::InvalidMasterAddress);
+        }
+
+        let master_id = VirtualAddress::compute_master_id(caller, salt)?;
+
+        // Check collision.
+        if let Some(existing) = Self::read_master(db, master_id) {
+            if existing != caller {
+                return Err(RegistryError::MasterIdCollision(existing));
+            }
+            // Re-registering the same address is a no-op.
+            return Ok(master_id);
+        }
+
+        Self::write_master(db, master_id, caller);
+        Ok(master_id)
+    }
+
+    /// Resolve an address: if virtual and registered, return the master.
+    pub fn resolve(db: &InMemoryDB, addr: Address) -> Result<Address, RegistryError> {
+        let Some((master_id, _user_tag)) = VirtualAddress::decode(addr) else {
+            return Ok(addr);
+        };
+
+        Self::read_master(db, master_id).ok_or(RegistryError::VirtualAddressUnregistered)
+    }
+}
+
+impl MasterRegistry for StorageBackedRegistry {
+    type Error = RegistryError;
+
+    fn register(&mut self, _caller: Address, _salt: B256) -> Result<MasterId, Self::Error> {
+        // This trait impl cannot be used directly because it requires &mut InMemoryDB.
+        // Use the static methods instead.
+        unimplemented!("use StorageBackedRegistry::register(db, caller, salt) instead")
+    }
+
+    fn get_master(&self, _master_id: MasterId) -> Result<Option<Address>, Self::Error> {
+        unimplemented!("use StorageBackedRegistry::read_master(db, master_id) instead")
+    }
+}
+
+impl AddressResolver for StorageBackedRegistry {
+    type Error = RegistryError;
+
+    fn resolve_recipient(&self, _addr: Address) -> Result<Address, Self::Error> {
+        unimplemented!("use StorageBackedRegistry::resolve(db, addr) instead")
+    }
+}

--- a/examples/virtual-address-registry/src/registry.rs
+++ b/examples/virtual-address-registry/src/registry.rs
@@ -70,10 +70,9 @@ impl StorageBackedRegistry {
         // Commit the storage write.
         let mut state = revm::state::EvmState::default();
         let mut account = revm::state::Account::default();
-        account.storage.insert(
-            slot,
-            revm::state::EvmStorageSlot::new_changed(U256::ZERO, value, 0),
-        );
+        account
+            .storage
+            .insert(slot, revm::state::EvmStorageSlot::new_changed(U256::ZERO, value, 0));
         account.mark_touch();
         state.insert(REGISTRY_ADDRESS, account);
         db.commit(state);

--- a/examples/virtual-address-registry/tests/e2e.rs
+++ b/examples/virtual-address-registry/tests/e2e.rs
@@ -1,0 +1,207 @@
+//! End-to-end integration test for the virtual address registry.
+//!
+//! Demonstrates the full flow:
+//! 1. Register a virtual master via a transaction to the registry address
+//! 2. Verify the registration in storage
+//! 3. Construct a virtual address and verify resolution
+//! 4. Build blocks containing registry interactions
+//! 5. Batch all blocks and submit to L1
+
+use alloy_primitives::{Bytes, TxKind, U256, address};
+use alloy_sol_types::SolCall;
+use base_action_harness::{
+    ActionL2Source, ActionTestHarness, Batcher, BatcherConfig, L1MinerConfig, SharedL1Chain,
+    TEST_ACCOUNT_ADDRESS, TestRollupConfigBuilder,
+};
+use base_address_resolution::{MasterId, REGISTRY_ADDRESS, UserTag, VirtualAddress};
+use base_batcher_encoder::{DaType, EncoderConfig};
+use virtual_address_registry::{IAddressRegistry, RegistryEvmOverride, StorageBackedRegistry};
+
+/// Virtual address registry: register, resolve, and batch.
+#[tokio::test]
+async fn virtual_address_registry_e2e() {
+    let batcher_cfg = BatcherConfig {
+        encoder: EncoderConfig { da_type: DaType::Calldata, ..EncoderConfig::default() },
+        ..Default::default()
+    };
+
+    // Use through_isthmus + jovian_at(0) so we're on a recent hardfork.
+    let rollup_cfg = TestRollupConfigBuilder::base_mainnet(&batcher_cfg)
+        .through_isthmus()
+        .with_jovian_at(0)
+        .build();
+    let chain_id = rollup_cfg.l2_chain_id.id();
+    let mut h = ActionTestHarness::new(L1MinerConfig::default(), rollup_cfg);
+
+    let l1_chain = SharedL1Chain::from_blocks(h.l1.chain().to_vec());
+    let mut builder = h.create_l2_sequencer_with_evm_override(
+        l1_chain,
+        Box::new(RegistryEvmOverride),
+    );
+
+    let account = builder.test_account();
+
+    // ── Step 1: Pre-seed registry state ────────────────────────────────
+    //
+    // Write a registration directly into the sequencer's EVM database.
+    // In production, this would happen via a registerVirtualMaster transaction
+    // that passes the 32-bit PoW. For testing, we bypass PoW and write directly.
+    let master_address = TEST_ACCOUNT_ADDRESS;
+    let master_id = MasterId::from_slice(&[0xDE, 0xAD, 0xBE, 0xEF]);
+    StorageBackedRegistry::write_master(builder.db_mut(), master_id, master_address);
+
+    // ── Step 2: Verify registration ────────────────────────────────────
+    {
+        let resolved = StorageBackedRegistry::read_master(builder.db(), master_id);
+        assert_eq!(
+            resolved,
+            Some(master_address),
+            "master must be registered after write"
+        );
+    }
+
+    // ── Step 3: Verify virtual address resolution ──────────────────────
+    let user_tag = UserTag::from_slice(&[0x01, 0x02, 0x03, 0x04, 0x05, 0x06]);
+    let virtual_addr = VirtualAddress::encode(master_id, user_tag);
+
+    assert!(
+        VirtualAddress::is_virtual(virtual_addr),
+        "encoded address must be recognized as virtual"
+    );
+
+    {
+        let resolved = StorageBackedRegistry::resolve(builder.db(), virtual_addr);
+        assert_eq!(
+            resolved,
+            Ok(master_address),
+            "virtual address must resolve to registered master"
+        );
+    }
+
+    // Non-virtual address passes through unchanged.
+    {
+        let regular_addr = address!("d8dA6BF26964aF9D7eEd9e03E53415D37aA96045");
+        let resolved = StorageBackedRegistry::resolve(builder.db(), regular_addr);
+        assert_eq!(
+            resolved,
+            Ok(regular_addr),
+            "non-virtual address must pass through unchanged"
+        );
+    }
+
+    // ── Step 4: Build blocks with transactions ─────────────────────────
+    //
+    // Block 1: empty (advances the chain past genesis).
+    let block1 = builder.build_empty_block();
+
+    // Block 2: user transfer (exercises default EVM execution via override).
+    let tx = {
+        let mut acct = account.lock().expect("test account lock");
+        acct.create_tx(
+            chain_id,
+            TxKind::Call(alloy_primitives::Address::ZERO),
+            Bytes::new(),
+            U256::from(1),
+            21_000,
+        )
+    };
+    let block2 = builder.build_next_block_with_transactions(vec![tx]);
+
+    // Block 3: send a registerVirtualMaster call to the registry address.
+    // This exercises the EvmOverride's interception of registry calls.
+    let register_calldata = IAddressRegistry::registerVirtualMasterCall {
+        salt: alloy_primitives::FixedBytes::ZERO,
+    }
+    .abi_encode();
+
+    let registry_tx = {
+        let mut acct = account.lock().expect("test account lock");
+        acct.create_tx(
+            chain_id,
+            TxKind::Call(REGISTRY_ADDRESS),
+            Bytes::from(register_calldata),
+            U256::ZERO,
+            100_000,
+        )
+    };
+    let block3 = builder.build_next_block_with_transactions(vec![registry_tx]);
+
+    // ── Step 5: Verify post-execution state ────────────────────────────
+    //
+    // The registry write from step 1 should still be present.
+    {
+        let resolved = StorageBackedRegistry::read_master(builder.db(), master_id);
+        assert_eq!(
+            resolved,
+            Some(master_address),
+            "registry mapping must survive block execution"
+        );
+    }
+
+    // Virtual address resolution still works after blocks.
+    {
+        let resolved = StorageBackedRegistry::resolve(builder.db(), virtual_addr);
+        assert_eq!(
+            resolved,
+            Ok(master_address),
+            "virtual address must still resolve after block execution"
+        );
+    }
+
+    // ── Step 6: Batch blocks and submit to L1 ──────────────────────────
+    let mut batcher = Batcher::new(ActionL2Source::new(), &h.rollup_config, batcher_cfg.clone());
+    let l1_chain_for_batcher = SharedL1Chain::from_blocks(h.l1.chain().to_vec());
+
+    for block in [block1, block2, block3] {
+        batcher.push_block(block);
+        batcher.advance(&mut h.l1).await;
+    }
+
+    // Verify that L1 blocks were mined containing batch data.
+    assert!(
+        h.l1.latest_number() >= 3,
+        "L1 should have mined blocks for the batch submissions"
+    );
+
+    // Verify the batcher produced valid L1 transactions.
+    let mut found_batch_tx = false;
+    for i in 1..=h.l1.latest_number() {
+        let block = h.l1.block_by_number(i).expect("L1 block must exist");
+        if !block.batcher_txs.is_empty() {
+            found_batch_tx = true;
+        }
+    }
+    assert!(found_batch_tx, "at least one L1 block must contain a batcher transaction");
+}
+
+/// Virtual address format: encode/decode roundtrip with resolution.
+#[test]
+fn virtual_address_roundtrip() {
+    let master_id = MasterId::from_slice(&[0xCA, 0xFE, 0xBA, 0xBE]);
+    let user_tag = UserTag::from_slice(&[0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF]);
+
+    let addr = VirtualAddress::encode(master_id, user_tag);
+    assert!(VirtualAddress::is_virtual(addr));
+
+    let (decoded_mid, decoded_ut) = VirtualAddress::decode(addr).unwrap();
+    assert_eq!(decoded_mid, master_id);
+    assert_eq!(decoded_ut, user_tag);
+}
+
+/// Unregistered virtual address resolution returns an error.
+#[test]
+fn unregistered_virtual_address_reverts() {
+    use revm::database::InMemoryDB;
+
+    let master_id = MasterId::from_slice(&[0xFF, 0xFF, 0xFF, 0xFF]);
+    let user_tag = UserTag::from_slice(&[0x00; 6]);
+    let addr = VirtualAddress::encode(master_id, user_tag);
+
+    let db = InMemoryDB::default();
+    let result = StorageBackedRegistry::resolve(&db, addr);
+    assert_eq!(
+        result,
+        Err(base_address_resolution::RegistryError::VirtualAddressUnregistered),
+        "unregistered virtual address must return error"
+    );
+}

--- a/examples/virtual-address-registry/tests/e2e.rs
+++ b/examples/virtual-address-registry/tests/e2e.rs
@@ -34,10 +34,8 @@ async fn virtual_address_registry_e2e() {
     let mut h = ActionTestHarness::new(L1MinerConfig::default(), rollup_cfg);
 
     let l1_chain = SharedL1Chain::from_blocks(h.l1.chain().to_vec());
-    let mut builder = h.create_l2_sequencer_with_evm_override(
-        l1_chain,
-        Box::new(RegistryEvmOverride),
-    );
+    let mut builder =
+        h.create_l2_sequencer_with_evm_override(l1_chain, Box::new(RegistryEvmOverride));
 
     let account = builder.test_account();
 
@@ -53,11 +51,7 @@ async fn virtual_address_registry_e2e() {
     // ── Step 2: Verify registration ────────────────────────────────────
     {
         let resolved = StorageBackedRegistry::read_master(builder.db(), master_id);
-        assert_eq!(
-            resolved,
-            Some(master_address),
-            "master must be registered after write"
-        );
+        assert_eq!(resolved, Some(master_address), "master must be registered after write");
     }
 
     // ── Step 3: Verify virtual address resolution ──────────────────────
@@ -82,11 +76,7 @@ async fn virtual_address_registry_e2e() {
     {
         let regular_addr = address!("d8dA6BF26964aF9D7eEd9e03E53415D37aA96045");
         let resolved = StorageBackedRegistry::resolve(builder.db(), regular_addr);
-        assert_eq!(
-            resolved,
-            Ok(regular_addr),
-            "non-virtual address must pass through unchanged"
-        );
+        assert_eq!(resolved, Ok(regular_addr), "non-virtual address must pass through unchanged");
     }
 
     // ── Step 4: Build blocks with transactions ─────────────────────────
@@ -109,10 +99,9 @@ async fn virtual_address_registry_e2e() {
 
     // Block 3: send a registerVirtualMaster call to the registry address.
     // This exercises the EvmOverride's interception of registry calls.
-    let register_calldata = IAddressRegistry::registerVirtualMasterCall {
-        salt: alloy_primitives::FixedBytes::ZERO,
-    }
-    .abi_encode();
+    let register_calldata =
+        IAddressRegistry::registerVirtualMasterCall { salt: alloy_primitives::FixedBytes::ZERO }
+            .abi_encode();
 
     let registry_tx = {
         let mut acct = account.lock().expect("test account lock");
@@ -131,11 +120,7 @@ async fn virtual_address_registry_e2e() {
     // The registry write from step 1 should still be present.
     {
         let resolved = StorageBackedRegistry::read_master(builder.db(), master_id);
-        assert_eq!(
-            resolved,
-            Some(master_address),
-            "registry mapping must survive block execution"
-        );
+        assert_eq!(resolved, Some(master_address), "registry mapping must survive block execution");
     }
 
     // Virtual address resolution still works after blocks.
@@ -150,7 +135,7 @@ async fn virtual_address_registry_e2e() {
 
     // ── Step 6: Batch blocks and submit to L1 ──────────────────────────
     let mut batcher = Batcher::new(ActionL2Source::new(), &h.rollup_config, batcher_cfg.clone());
-    let l1_chain_for_batcher = SharedL1Chain::from_blocks(h.l1.chain().to_vec());
+    let _l1_chain_for_batcher = SharedL1Chain::from_blocks(h.l1.chain().to_vec());
 
     for block in [block1, block2, block3] {
         batcher.push_block(block);
@@ -158,10 +143,7 @@ async fn virtual_address_registry_e2e() {
     }
 
     // Verify that L1 blocks were mined containing batch data.
-    assert!(
-        h.l1.latest_number() >= 3,
-        "L1 should have mined blocks for the batch submissions"
-    );
+    assert!(h.l1.latest_number() >= 3, "L1 should have mined blocks for the batch submissions");
 
     // Verify the batcher produced valid L1 transactions.
     let mut found_batch_tx = false;


### PR DESCRIPTION
## Summary

Spike exploring TIP-1022-style virtual address deposit forwarding for the base stack. Adds a `base-address-resolution` crate with pure types and traits for virtual address encoding, decoding, registration, and resolution. Genericizes the action test harness with an `EvmOverride` trait so custom precompile providers can be injected without modifying protocol code. Includes a complete `virtual-address-registry` example with an e2e integration test exercising registration, resolution, block building, and batch submission via `just examples`.