### PR TITLE
fix: error if state unavailable instead of OOMing

### DIFF
--- a/crates/execution/rpc/src/state.rs
+++ b/crates/execution/rpc/src/state.rs
@@ -52,12 +52,12 @@ where
                 .get_earliest_block_number()
                 .map_err(|e| ProviderError::Database(e.into()))?,
         ) else {
-            // if no earliest block, db is empty - use historical provider
-            return Ok(historical_provider);
+            // if no earliest block, db is empty, return error
+            return Err(ProviderError::StateForNumberNotFound(block_number));
         };
 
         if block_number < earliest_block_number || block_number > latest_block_number {
-            return Ok(historical_provider);
+            return Err(ProviderError::StateForNumberNotFound(block_number));
         }
 
         let external_overlay_provider =


### PR DESCRIPTION
Error instead of falling back to historical provider if state unavailable. Historical provider usage for state root-related method is extremely bad and can cause an OOM. There is an existing `rpc.eth-proof-window` arg that is checked for the existing endpoint implementations, but not for the overrides for these endpoints on the proofs ExEx.

Since the proofs ExEx should always allow a longer proof window than the normal proof window, we should just error instead of trying to fallback to the previous implementation.