### PR TITLE
fix(proof): include hint in prefetch error log

### DIFF
--- a/crates/proof/host/src/backend/online.rs
+++ b/crates/proof/host/src/backend/online.rs
@@ -87,7 +87,7 @@ impl PreimageFetcher for OnlineHostBackend {
                         .await;
 
                 if let Err(e) = value {
-                    error!(target: "host_backend", error = %e, "failed to prefetch hint");
+                    error!(target: "host_backend", error = %e, hint = ?hint, "failed to prefetch hint");
                     continue;
                 }
 


### PR DESCRIPTION
## Summary

- Add `hint` as a structured tracing field to the "failed to prefetch hint" error log in `OnlineHostBackend`, so operators can see which hint failed during prefetch.