### PR TITLE
[backport] feat(chains): schedule Base V1 activation on Zeronet

### DIFF
--- a/crates/alloy/chains/src/chain.rs
+++ b/crates/alloy/chains/src/chain.rs
@@ -284,6 +284,13 @@ mod tests {
         assert!(!devnet0_forks.is_base_v1_active_at_timestamp(1_774_889_999));
         assert!(devnet0_forks.is_base_v1_active_at_timestamp(1_774_890_000));
         assert!(devnet0_forks.is_base_v1_active_at_timestamp(u64::MAX));
+
+        // V1 is scheduled on zeronet at 1775079000
+        let zeronet_forks = BaseChainUpgrades::zeronet();
+        assert!(!zeronet_forks.is_base_v1_active_at_timestamp(0));
+        assert!(!zeronet_forks.is_base_v1_active_at_timestamp(1_775_078_999));
+        assert!(zeronet_forks.is_base_v1_active_at_timestamp(1_775_079_000));
+        assert!(zeronet_forks.is_base_v1_active_at_timestamp(u64::MAX));
     }
 
     #[test]
@@ -304,6 +311,12 @@ mod tests {
         assert_eq!(
             devnet0_forks.ethereum_fork_activation(EthereumHardfork::Osaka),
             ForkCondition::Timestamp(1_774_890_000)
+        );
+
+        let zeronet_forks = BaseChainUpgrades::zeronet();
+        assert_eq!(
+            zeronet_forks.ethereum_fork_activation(EthereumHardfork::Osaka),
+            ForkCondition::Timestamp(1_775_079_000)
         );
     }
 

--- a/crates/alloy/chains/src/config.rs
+++ b/crates/alloy/chains/src/config.rs
@@ -379,7 +379,7 @@ const ZERONET: BaseChainConfig = BaseChainConfig {
     pectra_blob_schedule_timestamp: None,
     isthmus_timestamp: 0,
     jovian_timestamp: 0,
-    base_v1_timestamp: None,
+    base_v1_timestamp: Some(1_775_079_000),
 
     genesis_l1_hash: b256!("b7d4b69971ff31d5179be5e1b83f5a4f438f4cd1db886a6630623b7047f32cfd"),
     genesis_l1_number: 2_450_277,


### PR DESCRIPTION
Schedule Base V1 activation on base-zeronet at timestamp 1775079000 (Wednesday April 1, 2026 4:30pm ET).

Backport of #1844 onto `releases/v0.7.0`.