### PR TITLE
perf(batcher): Parallelize L1 Block Fetching in Startup Scan

### DIFF
--- a/crates/batcher/service/src/lib.rs
+++ b/crates/batcher/service/src/lib.rs
@@ -11,7 +11,7 @@ mod config;
 pub use config::BatcherConfig;
 
 mod recent_txs;
-pub use recent_txs::{MAX_CHECK_RECENT_TXS_DEPTH, RecentTxScanner};
+pub use recent_txs::{MAX_CHECK_RECENT_TXS_DEPTH, RecentTxScanner, SCAN_FETCH_CONCURRENCY};
 
 mod source;
 pub use source::RpcPollingSource;

--- a/crates/batcher/service/src/recent_txs.rs
+++ b/crates/batcher/service/src/recent_txs.rs
@@ -7,7 +7,7 @@ use alloy_provider::{Provider, RootProvider};
 use alloy_rpc_types_eth::{BlockNumberOrTag, TransactionTrait};
 use base_consensus_genesis::RollupConfig;
 use base_protocol::{Batch, BatchReader, BlockInfo, Channel, ChannelId, Frame};
-use futures::StreamExt;
+use futures::{StreamExt, TryStreamExt};
 use tracing::{debug, info};
 
 /// Maximum depth allowed for the recent-transaction startup scan.
@@ -65,32 +65,31 @@ impl RecentTxScanner {
         let mut highest_l2: Option<u64> = None;
 
         // Fetch blocks in parallel with bounded concurrency, preserving L1 order.
-        // RootProvider is cheaply cloneable (inner Arc), so we clone once up-front.
-        let provider = l1_provider.clone();
-        let fetched: Vec<_> = futures::stream::iter(scan_start..=current_l1)
+        // Each future returns a `Result`, and `try_collect` short-circuits on
+        // the first RPC failure — matching the original sequential behavior
+        // instead of waiting for all in-flight requests to complete or time out.
+        let fetched: Vec<(u64, _)> = futures::stream::iter(scan_start..=current_l1)
             .map(|block_num| {
-                let provider = provider.clone();
+                let provider = l1_provider.clone();
                 async move {
-                    let result = provider
+                    let block = provider
                         .get_block_by_number(BlockNumberOrTag::Number(block_num))
                         .full()
-                        .await;
-                    (block_num, result)
+                        .await
+                        .map_err(|e| eyre::eyre!("failed to fetch L1 block {block_num}: {e}"))?;
+                    eyre::Ok((block_num, block))
                 }
             })
             .buffered(16)
-            .collect()
-            .await;
+            .try_collect()
+            .await?;
 
-        for (block_num, result) in fetched {
-            let block = match result {
-                Ok(Some(b)) => b,
-                Ok(None) => {
+        for (block_num, block) in fetched {
+            let block = match block {
+                Some(b) => b,
+                None => {
                     debug!(block = %block_num, "L1 block not found during recent tx scan");
                     continue;
-                }
-                Err(e) => {
-                    return Err(eyre::eyre!("failed to fetch L1 block {block_num}: {e}"));
                 }
             };
 

--- a/crates/batcher/service/src/recent_txs.rs
+++ b/crates/batcher/service/src/recent_txs.rs
@@ -15,6 +15,12 @@ use tracing::{debug, info};
 /// Matches the limit used by op-batcher's `--check-recent-txs-depth` flag.
 pub const MAX_CHECK_RECENT_TXS_DEPTH: u64 = 128;
 
+/// Maximum number of L1 block fetches in flight during the startup scan.
+///
+/// Bounds peak memory to roughly this many full L1 blocks while still
+/// achieving significant speedup over sequential fetching.
+pub const SCAN_FETCH_CONCURRENCY: usize = 16;
+
 /// Scans recent L1 blocks on startup to find the highest submitted L2 block.
 ///
 /// When the batcher restarts after an unclean shutdown, in-memory channel state
@@ -80,7 +86,7 @@ impl RecentTxScanner {
                     eyre::Ok((block_num, block))
                 }
             })
-            .buffered(16);
+            .buffered(SCAN_FETCH_CONCURRENCY);
         futures::pin_mut!(block_stream);
 
         while let Some(result) = block_stream.next().await {

--- a/crates/batcher/service/src/recent_txs.rs
+++ b/crates/batcher/service/src/recent_txs.rs
@@ -7,7 +7,7 @@ use alloy_provider::{Provider, RootProvider};
 use alloy_rpc_types_eth::{BlockNumberOrTag, TransactionTrait};
 use base_consensus_genesis::RollupConfig;
 use base_protocol::{Batch, BatchReader, BlockInfo, Channel, ChannelId, Frame};
-use futures::{StreamExt, TryStreamExt};
+use futures::StreamExt;
 use tracing::{debug, info};
 
 /// Maximum depth allowed for the recent-transaction startup scan.
@@ -65,10 +65,10 @@ impl RecentTxScanner {
         let mut highest_l2: Option<u64> = None;
 
         // Fetch blocks in parallel with bounded concurrency, preserving L1 order.
-        // Each future returns a `Result`, and `try_collect` short-circuits on
-        // the first RPC failure — matching the original sequential behavior
-        // instead of waiting for all in-flight requests to complete or time out.
-        let fetched: Vec<(u64, _)> = futures::stream::iter(scan_start..=current_l1)
+        // Blocks are processed as the stream yields them so peak memory is
+        // bounded by the concurrency limit (~16 blocks) rather than the full
+        // scan depth (~128 blocks).
+        let block_stream = futures::stream::iter(scan_start..=current_l1)
             .map(|block_num| {
                 let provider = l1_provider.clone();
                 async move {
@@ -80,11 +80,11 @@ impl RecentTxScanner {
                     eyre::Ok((block_num, block))
                 }
             })
-            .buffered(16)
-            .try_collect()
-            .await?;
+            .buffered(16);
+        futures::pin_mut!(block_stream);
 
-        for (block_num, block) in fetched {
+        while let Some(result) = block_stream.next().await {
+            let (block_num, block) = result?;
             let block = match block {
                 Some(b) => b,
                 None => {

--- a/crates/batcher/service/src/recent_txs.rs
+++ b/crates/batcher/service/src/recent_txs.rs
@@ -7,6 +7,7 @@ use alloy_provider::{Provider, RootProvider};
 use alloy_rpc_types_eth::{BlockNumberOrTag, TransactionTrait};
 use base_consensus_genesis::RollupConfig;
 use base_protocol::{Batch, BatchReader, BlockInfo, Channel, ChannelId, Frame};
+use futures::StreamExt;
 use tracing::{debug, info};
 
 /// Maximum depth allowed for the recent-transaction startup scan.
@@ -63,15 +64,34 @@ impl RecentTxScanner {
         let mut channels: HashMap<ChannelId, Channel> = HashMap::new();
         let mut highest_l2: Option<u64> = None;
 
-        for block_num in scan_start..=current_l1 {
-            let Some(block) = l1_provider
-                .get_block_by_number(BlockNumberOrTag::Number(block_num))
-                .full()
-                .await
-                .map_err(|e| eyre::eyre!("failed to fetch L1 block {block_num}: {e}"))?
-            else {
-                debug!(block = %block_num, "L1 block not found during recent tx scan");
-                continue;
+        // Fetch blocks in parallel with bounded concurrency, preserving L1 order.
+        // RootProvider is cheaply cloneable (inner Arc), so we clone once up-front.
+        let provider = l1_provider.clone();
+        let fetched: Vec<_> = futures::stream::iter(scan_start..=current_l1)
+            .map(|block_num| {
+                let provider = provider.clone();
+                async move {
+                    let result = provider
+                        .get_block_by_number(BlockNumberOrTag::Number(block_num))
+                        .full()
+                        .await;
+                    (block_num, result)
+                }
+            })
+            .buffered(16)
+            .collect()
+            .await;
+
+        for (block_num, result) in fetched {
+            let block = match result {
+                Ok(Some(b)) => b,
+                Ok(None) => {
+                    debug!(block = %block_num, "L1 block not found during recent tx scan");
+                    continue;
+                }
+                Err(e) => {
+                    return Err(eyre::eyre!("failed to fetch L1 block {block_num}: {e}"));
+                }
             };
 
             let block_info = BlockInfo {


### PR DESCRIPTION
- Replaces the sequential `for` loop in `RecentTxScanner` with `futures::stream::buffered(16)` to fetch up to 16 L1 blocks concurrently during the startup scan
- Block processing (frame parsing, channel assembly, channel decoding) remains sequential to preserve correctness — only the RPC fetch phase is parallelized
- Reduces startup scan latency from ~128×RTT (~6.4s at 50ms/RPC) to ~8×RTT (~0.4s) — approximately 16× faster