### PR TITLE
perf(batcher): Eliminate 131KB Blob Stack Copies

### DIFF
--- a/actions/harness/src/batcher/tx_manager.rs
+++ b/actions/harness/src/batcher/tx_manager.rs
@@ -272,7 +272,7 @@ impl TxManager for L1MinerTxManager {
         } else {
             Pending {
                 tx: None,
-                blobs: candidate.blobs.iter().map(|b| (B256::ZERO, Box::new(*b))).collect(),
+                blobs: candidate.blobs.iter().map(|b| (B256::ZERO, b.clone())).collect(),
                 responder,
             }
         };

--- a/actions/harness/src/miner.rs
+++ b/actions/harness/src/miner.rs
@@ -566,7 +566,7 @@ impl L1Miner {
         let blobs =
             BlobEncoder::encode_frames(frames).expect("frame data fits within blob capacity");
         for blob in blobs {
-            self.enqueue_blob(B256::ZERO, Box::new(blob));
+            self.enqueue_blob(B256::ZERO, blob);
         }
     }
 

--- a/crates/batcher/blobs/src/encoder.rs
+++ b/crates/batcher/blobs/src/encoder.rs
@@ -49,14 +49,14 @@ impl BlobEncoder {
     /// Encodes `[DERIVATION_VERSION_0] ++ frame0.encode() ++ frame1.encode() ++ …`
     /// into one blob. The derivation pipeline's `Frame::parse_frames` uses a
     /// `while offset < len` loop, so all packed frames are decoded correctly.
-    pub fn encode_packed(frames: &[Arc<Frame>]) -> Result<Blob, BlobEncodeError> {
+    pub fn encode_packed(frames: &[Arc<Frame>]) -> Result<Box<Blob>, BlobEncodeError> {
         let encoded_size: usize = frames.iter().map(|f| Self::FRAME_OVERHEAD + f.data.len()).sum();
         let mut data = Vec::with_capacity(1 + encoded_size);
         data.push(DERIVATION_VERSION_0);
         for frame in frames {
             data.extend_from_slice(&frame.encode());
         }
-        Self::encode(&data).map(|b| *b)
+        Self::encode(&data)
     }
 
     /// Encode each [`Frame`] into its own EIP-4844 [`Blob`].
@@ -66,14 +66,14 @@ impl BlobEncoder {
     ///
     /// Kept for compatibility with the action-test harness
     /// (`actions/harness/src/miner.rs`). New code should use [`encode_packed`](Self::encode_packed).
-    pub fn encode_frames(frames: &[Arc<Frame>]) -> Result<Vec<Blob>, BlobEncodeError> {
+    pub fn encode_frames(frames: &[Arc<Frame>]) -> Result<Vec<Box<Blob>>, BlobEncodeError> {
         let mut blobs = Vec::with_capacity(frames.len());
         for frame in frames {
             let encoded = frame.encode();
             let mut data = Vec::with_capacity(1 + encoded.len());
             data.push(DERIVATION_VERSION_0);
             data.extend_from_slice(&encoded);
-            blobs.push(*Self::encode(&data)?);
+            blobs.push(Self::encode(&data)?);
         }
         Ok(blobs)
     }

--- a/crates/utilities/tx-manager/src/blob.rs
+++ b/crates/utilities/tx-manager/src/blob.rs
@@ -36,13 +36,13 @@ impl BlobTxBuilder {
     /// Returns [`TxManagerError::Unsupported`] if KZG computation fails.
     pub fn build_sidecar(
         &self,
-        blobs: Arc<Vec<Blob>>,
+        blobs: Arc<Vec<Box<Blob>>>,
     ) -> Result<BlobTransactionSidecarEip7594, TxManagerError> {
         let settings = EnvKzgSettings::Default;
         let kzg = settings.get();
-        let blobs = Arc::unwrap_or_clone(blobs);
+        let unboxed: Vec<Blob> = Arc::unwrap_or_clone(blobs).into_iter().map(|b| *b).collect();
 
-        BlobTransactionSidecarEip7594::try_from_blobs_with_settings(blobs, kzg).map_err(|e| {
+        BlobTransactionSidecarEip7594::try_from_blobs_with_settings(unboxed, kzg).map_err(|e| {
             TxManagerError::Unsupported(format!("EIP-7594 cell proof computation failed: {e}"))
         })
     }
@@ -65,7 +65,8 @@ mod tests {
     #[case::six_blobs(6)]
     fn build_sidecar_n_blobs_uses_cell_proofs(#[case] n: usize) {
         let builder = builder();
-        let sidecar = builder.build_sidecar(Arc::new(vec![Blob::default(); n])).unwrap();
+        let blobs: Vec<Box<Blob>> = (0..n).map(|_| Box::default()).collect();
+        let sidecar = builder.build_sidecar(Arc::new(blobs)).unwrap();
         assert_eq!(sidecar.cell_proofs.len(), n * CELLS_PER_EXT_BLOB);
     }
 

--- a/crates/utilities/tx-manager/src/candidate.rs
+++ b/crates/utilities/tx-manager/src/candidate.rs
@@ -18,7 +18,10 @@ pub struct TxCandidate {
     /// Transaction calldata.
     pub tx_data: Bytes,
     /// EIP-4844 blobs; triggers blob tx when non-empty.
-    pub blobs: Arc<Vec<Blob>>,
+    ///
+    /// Blobs are individually boxed to avoid 131 072-byte stack copies when
+    /// moving them between collections.
+    pub blobs: Arc<Vec<Box<Blob>>>,
     /// Recipient address. `None` means contract creation.
     pub to: Option<Address>,
     /// Gas limit. `0` means auto-estimate.
@@ -44,8 +47,7 @@ mod tests {
 
     #[test]
     fn candidate_with_blobs_is_type3() {
-        let candidate =
-            TxCandidate { blobs: Arc::new(vec![Blob::default()]), ..Default::default() };
+        let candidate = TxCandidate { blobs: Arc::new(vec![Box::default()]), ..Default::default() };
 
         assert_eq!(candidate.blobs.len(), 1);
         // Struct-update preserves remaining defaults.

--- a/crates/utilities/tx-manager/tests/craft_tx.rs
+++ b/crates/utilities/tx-manager/tests/craft_tx.rs
@@ -119,7 +119,7 @@ async fn craft_tx_rejects_too_many_blobs() {
 
     let candidate = TxCandidate {
         to: Some(Address::with_last_byte(0x42)),
-        blobs: Arc::new(vec![Blob::default(); 7]),
+        blobs: Arc::new((0..7).map(|_| Box::<Blob>::default()).collect::<Vec<_>>()),
         ..Default::default()
     };
 
@@ -140,7 +140,7 @@ async fn craft_tx_rejects_blob_without_recipient() {
     let (manager, _anvil) = setup().await;
 
     let candidate =
-        TxCandidate { to: None, blobs: Arc::new(vec![Blob::default()]), ..Default::default() };
+        TxCandidate { to: None, blobs: Arc::new(vec![Box::<Blob>::default()]), ..Default::default() };
 
     let err =
         manager.craft_tx(&candidate, None).await.expect_err("should reject blob tx without to");
@@ -166,7 +166,7 @@ async fn craft_tx_produces_valid_signed_blob_transaction() {
 
     let to = Address::with_last_byte(0x42);
     let candidate =
-        TxCandidate { to: Some(to), blobs: Arc::new(vec![Blob::default()]), ..Default::default() };
+        TxCandidate { to: Some(to), blobs: Arc::new(vec![Box::<Blob>::default()]), ..Default::default() };
 
     let prepared = manager.craft_tx(&candidate, None).await.expect("should craft blob tx");
 
@@ -216,7 +216,7 @@ async fn craft_tx_produces_cell_proof_sidecar_by_default() {
 
     let to = Address::with_last_byte(0x42);
     let candidate =
-        TxCandidate { to: Some(to), blobs: Arc::new(vec![Blob::default()]), ..Default::default() };
+        TxCandidate { to: Some(to), blobs: Arc::new(vec![Box::<Blob>::default()]), ..Default::default() };
 
     let prepared =
         manager.craft_tx(&candidate, None).await.expect("should craft cell-proof blob tx");
@@ -533,7 +533,7 @@ async fn prepare_exits_immediately_on_non_retryable_error() {
 
     // Blob transactions without a recipient trigger Unsupported (non-retryable).
     let candidate =
-        TxCandidate { to: None, blobs: Arc::new(vec![Blob::default()]), ..Default::default() };
+        TxCandidate { to: None, blobs: Arc::new(vec![Box::<Blob>::default()]), ..Default::default() };
 
     let err = manager
         .prepare(&candidate, None)
@@ -861,7 +861,7 @@ async fn increase_gas_price_bumps_blob_fee_cap() {
 
     let candidate = TxCandidate {
         to: Some(Address::with_last_byte(0x42)),
-        blobs: Arc::new(vec![Blob::default()]),
+        blobs: Arc::new(vec![Box::<Blob>::default()]),
         ..Default::default()
     };
 
@@ -918,7 +918,7 @@ async fn blob_fee_bump_round_trip() {
 
     let candidate = TxCandidate {
         to: Some(Address::with_last_byte(0x42)),
-        blobs: Arc::new(vec![Blob::default()]),
+        blobs: Arc::new(vec![Box::<Blob>::default()]),
         ..Default::default()
     };
 

--- a/crates/utilities/tx-manager/tests/craft_tx.rs
+++ b/crates/utilities/tx-manager/tests/craft_tx.rs
@@ -139,8 +139,11 @@ async fn craft_tx_rejects_too_many_blobs() {
 async fn craft_tx_rejects_blob_without_recipient() {
     let (manager, _anvil) = setup().await;
 
-    let candidate =
-        TxCandidate { to: None, blobs: Arc::new(vec![Box::<Blob>::default()]), ..Default::default() };
+    let candidate = TxCandidate {
+        to: None,
+        blobs: Arc::new(vec![Box::<Blob>::default()]),
+        ..Default::default()
+    };
 
     let err =
         manager.craft_tx(&candidate, None).await.expect_err("should reject blob tx without to");
@@ -165,8 +168,11 @@ async fn craft_tx_produces_valid_signed_blob_transaction() {
     let (manager, anvil) = setup().await;
 
     let to = Address::with_last_byte(0x42);
-    let candidate =
-        TxCandidate { to: Some(to), blobs: Arc::new(vec![Box::<Blob>::default()]), ..Default::default() };
+    let candidate = TxCandidate {
+        to: Some(to),
+        blobs: Arc::new(vec![Box::<Blob>::default()]),
+        ..Default::default()
+    };
 
     let prepared = manager.craft_tx(&candidate, None).await.expect("should craft blob tx");
 
@@ -215,8 +221,11 @@ async fn craft_tx_produces_cell_proof_sidecar_by_default() {
     let (manager, anvil) = setup().await;
 
     let to = Address::with_last_byte(0x42);
-    let candidate =
-        TxCandidate { to: Some(to), blobs: Arc::new(vec![Box::<Blob>::default()]), ..Default::default() };
+    let candidate = TxCandidate {
+        to: Some(to),
+        blobs: Arc::new(vec![Box::<Blob>::default()]),
+        ..Default::default()
+    };
 
     let prepared =
         manager.craft_tx(&candidate, None).await.expect("should craft cell-proof blob tx");
@@ -532,8 +541,11 @@ async fn prepare_exits_immediately_on_non_retryable_error() {
     let (manager, _anvil) = setup().await;
 
     // Blob transactions without a recipient trigger Unsupported (non-retryable).
-    let candidate =
-        TxCandidate { to: None, blobs: Arc::new(vec![Box::<Blob>::default()]), ..Default::default() };
+    let candidate = TxCandidate {
+        to: None,
+        blobs: Arc::new(vec![Box::<Blob>::default()]),
+        ..Default::default()
+    };
 
     let err = manager
         .prepare(&candidate, None)


### PR DESCRIPTION
- Plumbs `Box<Blob>` through the encode → submit → sidecar chain instead of unboxing/reboxing at each boundary
- Eliminates ~262KB of unnecessary memcpy per blob submission (one 131KB heap→stack copy from `*box` dereference in `encode_packed`, one 131KB stack→heap copy from `vec![blob]`)
- The only remaining unboxing happens in `build_sidecar` where alloy's KZG API requires `Vec<Blob>`
