### PR TITLE
backport: feat(builder): add execution observability for unmetered transactions (#1836)

### DIFF
--- a/crates/builder/core/src/flashblocks/context.rs
+++ b/crates/builder/core/src/flashblocks/context.rs
@@ -811,6 +811,19 @@ impl OpPayloadBuilderCtx {
             self.metrics.tx_actual_execution_time_us.record(actual_execution_time_us as f64);
             num_txs_simulated += 1;
 
+            // Record state modification counts (trie work proxy)
+            let accounts_modified = state.len();
+            let storage_slots_modified: usize = state.values().map(|a| a.storage.len()).sum();
+            self.metrics.tx_accounts_modified.record(accounts_modified as f64);
+            self.metrics.tx_storage_slots_modified.record(storage_slots_modified as f64);
+
+            // Record execution time for unmetered transactions (race condition indicator)
+            if resource_usage.is_none() {
+                self.metrics
+                    .unmetered_tx_actual_execution_time_us
+                    .record(actual_execution_time_us as f64);
+            }
+
             // Record prediction accuracy
             if let Some(predicted_us) = predicted_execution_time_us {
                 let error = predicted_us as f64 - actual_execution_time_us as f64;

--- a/crates/builder/core/src/metrics.rs
+++ b/crates/builder/core/src/metrics.rs
@@ -174,6 +174,14 @@ pub struct BuilderMetrics {
     // === State Root Time / Gas Ratio (Anomaly Detection) ===
     /// Ratio of `state_root_time_us` / `gas_used` for each transaction.
     pub state_root_time_per_gas_ratio: Histogram,
+
+    // === Execution Observability for Unmetered Transactions ===
+    /// Actual execution time for transactions without metering data (microseconds)
+    pub unmetered_tx_actual_execution_time_us: Histogram,
+    /// Number of accounts modified by a transaction (from EVM post-state)
+    pub tx_accounts_modified: Histogram,
+    /// Number of storage slots modified by a transaction (from EVM post-state)
+    pub tx_storage_slots_modified: Histogram,
 }
 
 impl BuilderMetrics {


### PR DESCRIPTION
Backport of #1836 to `releases/v0.7.0`.

type=routine
risk=low
impact=sev5