### PR TITLE
docs(devnet): replace stale op-node references

### DIFF
--- a/etc/docker/README.md
+++ b/etc/docker/README.md
@@ -16,7 +16,7 @@ The `docker-compose.yml` orchestrates a complete local devnet environment with b
 
 - An L1 execution client (Reth) and consensus client (Lighthouse) with a validator
 - The Base builder and client nodes on L2
-- Base consensus layer nodes (`op-node`) for both builder and client
+- Base consensus layer nodes (`base-consensus`) for both builder and client
 - The `base-batcher` for submitting L2 data to L1
 
 All services read configuration from `devnet-env` in this directory. The devnet stores chain data in `.devnet/` which is created on first run.

--- a/etc/scripts/devnet/setup-l2.sh
+++ b/etc/scripts/devnet/setup-l2.sh
@@ -187,7 +187,7 @@ echo "Rollup.json L1 hash:    $ROLLUP_L1_HASH"
 
 if [ "$L1_HASH" != "$ROLLUP_L1_HASH" ]; then
   echo "WARNING: L1 genesis hash mismatch!"
-  echo "This might cause issues with the op-node."
+  echo "This might cause issues with the consensus node."
 else
   echo "L1 genesis hash matches!"
 fi


### PR DESCRIPTION
Update stale devnet wording that still references op-node, aligning docs and runtime warnings with the current base-consensus topology.