### PR TITLE
feat(deployer): add base-deployer CLI for devnet setup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3611,6 +3611,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "base-deployer"
+version = "0.0.0"
+dependencies = [
+ "alloy-network",
+ "alloy-primitives",
+ "alloy-provider",
+ "alloy-rpc-client",
+ "alloy-signer-local",
+ "base-cli-utils",
+ "clap",
+ "eyre",
+ "hex",
+ "rand 0.9.2",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "tokio",
+ "toml 1.0.7+spec-1.1.0",
+ "url",
+]
+
+[[package]]
 name = "base-engine-tree"
 version = "0.0.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ resolver = "2"
 members = [
   "bin/audit-archiver",
   "bin/basectl",
+  "bin/base-deployer",
   "bin/based",
   "bin/batcher",
   "bin/builder",

--- a/bin/base-deployer/Cargo.toml
+++ b/bin/base-deployer/Cargo.toml
@@ -16,7 +16,17 @@ path = "src/main.rs"
 workspace = true
 
 [dependencies]
+alloy-primitives = { workspace = true, features = ["std"] }
+alloy-signer-local = { workspace = true, features = ["mnemonic"] }
 base-cli-utils.workspace = true
 clap = { workspace = true, features = ["derive", "env"] }
 eyre.workspace = true
+hex.workspace = true
+rand.workspace = true
+serde = { workspace = true, features = ["derive", "std"] }
+serde_json = { workspace = true, features = ["std"] }
+toml = { workspace = true, features = ["parse", "serde"] }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread", "signal"] }
+
+[dev-dependencies]
+tempfile.workspace = true

--- a/bin/base-deployer/Cargo.toml
+++ b/bin/base-deployer/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "base-deployer"
+description = "Base devnet and deployment orchestration CLI"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+
+[[bin]]
+name = "base-deployer"
+path = "src/main.rs"
+
+[lints]
+workspace = true
+
+[dependencies]
+base-cli-utils.workspace = true
+clap = { workspace = true, features = ["derive", "env"] }
+eyre.workspace = true
+tokio = { workspace = true, features = ["macros", "rt-multi-thread", "signal"] }

--- a/bin/base-deployer/Cargo.toml
+++ b/bin/base-deployer/Cargo.toml
@@ -16,7 +16,10 @@ path = "src/main.rs"
 workspace = true
 
 [dependencies]
+alloy-network.workspace = true
 alloy-primitives = { workspace = true, features = ["std"] }
+alloy-provider = { workspace = true, features = ["reqwest"] }
+alloy-rpc-client.workspace = true
 alloy-signer-local = { workspace = true, features = ["mnemonic"] }
 base-cli-utils.workspace = true
 clap = { workspace = true, features = ["derive", "env"] }
@@ -27,6 +30,7 @@ serde = { workspace = true, features = ["derive", "std"] }
 serde_json = { workspace = true, features = ["std"] }
 toml = { workspace = true, features = ["parse", "serde"] }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread", "signal"] }
+url.workspace = true
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/bin/base-deployer/README.md
+++ b/bin/base-deployer/README.md
@@ -1,0 +1,3 @@
+# `base-deployer`
+
+CLI for generating Base devnet artifacts, deploying OP Stack contracts, and orchestrating local devnets.

--- a/bin/base-deployer/README.md
+++ b/bin/base-deployer/README.md
@@ -1,3 +1,152 @@
 # `base-deployer`
 
-CLI for generating Base devnet artifacts, deploying OP Stack contracts, and orchestrating local devnets.
+`base-deployer` is a CLI for:
+
+- generating L1/L2 genesis artifacts for local Base devnets
+- deploying OP Stack contracts to a live L1
+- extracting L2 genesis and rollup configs from a live deployment
+- starting and checking a local Docker Compose devnet
+
+## Commands
+
+```bash
+base-deployer genesis
+base-deployer deploy-l1 --l1-rpc http://127.0.0.1:8545
+base-deployer deploy-l2 --l1-rpc http://127.0.0.1:8545
+base-deployer devnet
+base-deployer status
+```
+
+## Local Devnet
+
+Start a fresh local devnet with Docker Compose:
+
+```bash
+cargo run -p base-deployer -- devnet
+```
+
+Check the running stack:
+
+```bash
+cargo run -p base-deployer -- status
+cargo run -p base-deployer -- status --json
+```
+
+The local `devnet` command resets `./.devnet`, rebuilds the setup/runtime images, starts the compose stack, and waits for the public RPC endpoints to respond before printing connection details.
+
+## Artifact Generation
+
+Generate a standalone artifact bundle:
+
+```bash
+cargo run -p base-deployer -- genesis --output-dir ./.artifacts/devnet
+```
+
+This writes:
+
+- `l1/el/genesis.json`
+- `l1/el/chain-config.json`
+- `l1/cl/config.yaml`
+- `l1/cl/genesis.ssz`
+- `l2/intent.toml`
+- `l2/genesis.json`
+- `l2/rollup.json`
+- `l2/rollup-conductor.json`
+- `chain-ids.json`
+- `accounts.json`
+
+## Config Files
+
+`base-deployer` accepts JSON or TOML via `--config`.
+
+Example TOML:
+
+```toml
+l1_chain_id = 1337
+l2_chain_id = 84538453
+slot_duration = 4
+l2_base_v1_block = 20
+```
+
+Example JSON:
+
+```json
+{
+  "l1_chain_id": 1337,
+  "l2_chain_id": 84538453,
+  "slot_duration": 4,
+  "l2_base_v1_block": 20
+}
+```
+
+Global flags also accept env vars:
+
+- `--output-dir` / `OUTPUT_DIR`
+- `--l1-chain-id` / `L1_CHAIN_ID`
+- `--l2-chain-id` / `L2_CHAIN_ID`
+- `--slot-duration` / `SLOT_DURATION`
+- `--genesis-time` / `GENESIS_TIME`
+- `--prefund-balance` / `PREFUND_BALANCE`
+- `--l2-base-v1-block` / `L2_BASE_V1_BLOCK`
+
+## Live Deployment
+
+Deploy OP Stack contracts to a live L1 and persist a reusable `op-deployer` workdir:
+
+```bash
+cargo run -p base-deployer -- deploy-l1 --l1-rpc https://your-l1.example
+```
+
+Then extract the L2 genesis and rollup config:
+
+```bash
+cargo run -p base-deployer -- deploy-l2 --l1-rpc https://your-l1.example
+```
+
+For external-L1 preparation in one step:
+
+```bash
+cargo run -p base-deployer -- devnet --l1-rpc https://your-l1.example
+```
+
+In that mode, `devnet` prepares the live deployment manifest plus the L2 artifact bundle and prints their paths. The long-lived local runtime flow remains the Docker Compose path described above.
+
+`deploy-l1` writes `l1/deployment-manifest.json`, including the deployed-address manifest for:
+
+- `OptimismPortal`
+- `L1CrossDomainMessenger`
+- `L1StandardBridge`
+- `SystemConfig`
+- `AddressManager`
+
+## Migration From Setup Containers
+
+The old setup flow was:
+
+- `setup-l1.sh` for L1 genesis and CL inputs
+- `setup-l2.sh` for `op-deployer` execution and L2 config extraction
+
+The new command mapping is:
+
+- `setup-l1.sh` -> `base-deployer genesis`
+- live L1 contract deployment -> `base-deployer deploy-l1`
+- `setup-l2.sh` -> `base-deployer deploy-l2`
+- `docker compose up ...` wrapper -> `base-deployer devnet`
+
+`etc/docker/docker-compose.yml` now invokes `base-deployer` inside the setup image so the compose-based devnet continues to work while moving the behavior into a typed Rust CLI.
+
+## Testing
+
+Unit tests:
+
+```bash
+cargo test -p base-deployer
+```
+
+Docker-backed integration test:
+
+```bash
+cargo test -p base-deployer --test devnet -- --ignored
+```
+
+The integration test is ignored by default because it builds images, starts long-lived containers, and needs Docker Compose plus open local ports.

--- a/bin/base-deployer/src/cli.rs
+++ b/bin/base-deployer/src/cli.rs
@@ -14,8 +14,32 @@ pub(crate) struct Cli {
     pub(crate) config: Option<PathBuf>,
 
     /// Output directory for generated artifacts.
-    #[arg(long, global = true)]
+    #[arg(long, env = "OUTPUT_DIR", global = true)]
     pub(crate) output_dir: Option<PathBuf>,
+
+    /// L1 chain ID for the devnet.
+    #[arg(long, env = "L1_CHAIN_ID", global = true)]
+    pub(crate) l1_chain_id: Option<u64>,
+
+    /// L2 chain ID for the devnet.
+    #[arg(long, env = "L2_CHAIN_ID", global = true)]
+    pub(crate) l2_chain_id: Option<u64>,
+
+    /// L1 beacon slot duration in seconds.
+    #[arg(long, env = "SLOT_DURATION", global = true)]
+    pub(crate) slot_duration: Option<u64>,
+
+    /// Unix timestamp for genesis generation.
+    #[arg(long, env = "GENESIS_TIME", global = true)]
+    pub(crate) genesis_time: Option<u64>,
+
+    /// Prefund balance for dev accounts.
+    #[arg(long, env = "PREFUND_BALANCE", global = true)]
+    pub(crate) prefund_balance: Option<String>,
+
+    /// Base V1 activation block for L2 config patching.
+    #[arg(long, env = "L2_BASE_V1_BLOCK", global = true)]
+    pub(crate) l2_base_v1_block: Option<u64>,
 
     #[command(subcommand)]
     pub(crate) command: Commands,
@@ -29,19 +53,19 @@ pub(crate) enum Commands {
     /// Deploy L1 contracts for a devnet.
     DeployL1 {
         /// Existing L1 RPC endpoint to deploy against.
-        #[arg(long)]
+        #[arg(long, env = "L1_RPC_URL")]
         l1_rpc: Option<String>,
     },
     /// Generate L2 configuration from a deployment.
     DeployL2 {
         /// Existing L1 RPC endpoint to deploy against.
-        #[arg(long)]
+        #[arg(long, env = "L1_RPC_URL")]
         l1_rpc: Option<String>,
     },
     /// Start a full local devnet.
     Devnet {
         /// Existing L1 RPC endpoint to reuse instead of starting a local L1.
-        #[arg(long)]
+        #[arg(long, env = "L1_RPC_URL")]
         l1_rpc: Option<String>,
     },
     /// Inspect the current devnet status.

--- a/bin/base-deployer/src/cli.rs
+++ b/bin/base-deployer/src/cli.rs
@@ -1,0 +1,53 @@
+//! CLI definitions for `base-deployer`.
+
+use std::path::PathBuf;
+
+use clap::{Parser, Subcommand};
+
+/// Base devnet and deployment orchestration CLI.
+#[derive(Debug, Parser)]
+#[command(name = "base-deployer")]
+#[command(about = "Generate genesis artifacts, deploy contracts, and run local Base devnets")]
+pub(crate) struct Cli {
+    /// Path to a JSON or TOML configuration file.
+    #[arg(long, global = true)]
+    pub(crate) config: Option<PathBuf>,
+
+    /// Output directory for generated artifacts.
+    #[arg(long, global = true)]
+    pub(crate) output_dir: Option<PathBuf>,
+
+    #[command(subcommand)]
+    pub(crate) command: Commands,
+}
+
+/// Supported `base-deployer` subcommands.
+#[derive(Debug, Subcommand)]
+pub(crate) enum Commands {
+    /// Generate L1 and L2 genesis artifacts for a devnet.
+    Genesis,
+    /// Deploy L1 contracts for a devnet.
+    DeployL1 {
+        /// Existing L1 RPC endpoint to deploy against.
+        #[arg(long)]
+        l1_rpc: Option<String>,
+    },
+    /// Generate L2 configuration from a deployment.
+    DeployL2 {
+        /// Existing L1 RPC endpoint to deploy against.
+        #[arg(long)]
+        l1_rpc: Option<String>,
+    },
+    /// Start a full local devnet.
+    Devnet {
+        /// Existing L1 RPC endpoint to reuse instead of starting a local L1.
+        #[arg(long)]
+        l1_rpc: Option<String>,
+    },
+    /// Inspect the current devnet status.
+    Status {
+        /// Emit machine-readable JSON output.
+        #[arg(long)]
+        json: bool,
+    },
+}

--- a/bin/base-deployer/src/config.rs
+++ b/bin/base-deployer/src/config.rs
@@ -1,0 +1,220 @@
+//! Configuration loading and resolution for `base-deployer`.
+
+use std::{
+    path::{Path, PathBuf},
+    str::FromStr,
+};
+
+use alloy_primitives::U256;
+use eyre::{Result, WrapErr, bail};
+use rand::Rng as _;
+use serde::{Deserialize, Serialize};
+
+const DEFAULT_OUTPUT_DIR: &str = "devnet";
+const DEFAULT_SLOT_DURATION: u64 = 4;
+const DEFAULT_PREFUND_BALANCE: &str = "0xd3c21bcecceda1000000";
+const L1_CHAIN_ID_MIN: u64 = 1_300_000;
+const L1_CHAIN_ID_MAX: u64 = 1_399_999;
+const L2_CHAIN_ID_MIN: u64 = 84_530_000;
+const L2_CHAIN_ID_MAX: u64 = 84_539_999;
+
+/// File-backed configuration for `base-deployer`.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(default)]
+pub(crate) struct DeployerConfig {
+    /// Output directory for generated artifacts.
+    pub(crate) output_dir: Option<PathBuf>,
+    /// L1 chain ID for the generated devnet.
+    pub(crate) l1_chain_id: Option<u64>,
+    /// L2 chain ID for the generated devnet.
+    pub(crate) l2_chain_id: Option<u64>,
+    /// L1 beacon slot duration in seconds.
+    pub(crate) slot_duration: Option<u64>,
+    /// Unix timestamp for genesis.
+    pub(crate) genesis_time: Option<u64>,
+    /// Prefund balance for dev accounts, in hex or decimal wei.
+    pub(crate) prefund_balance: Option<String>,
+    /// Optional block number used to derive Base V1 activation time.
+    pub(crate) l2_base_v1_block: Option<u64>,
+}
+
+/// Resolved runtime configuration after applying defaults.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ResolvedConfig {
+    /// Output directory for artifacts.
+    pub(crate) output_dir: PathBuf,
+    /// L1 chain ID.
+    pub(crate) l1_chain_id: u64,
+    /// L2 chain ID.
+    pub(crate) l2_chain_id: u64,
+    /// L1 beacon slot duration in seconds.
+    pub(crate) slot_duration: u64,
+    /// Unix timestamp for genesis.
+    pub(crate) genesis_time: u64,
+    /// Prefund balance for dev accounts.
+    pub(crate) prefund_balance: U256,
+    /// Optional block number used to derive Base V1 activation time.
+    pub(crate) l2_base_v1_block: Option<u64>,
+}
+
+/// Serialized chain ID metadata written alongside generated artifacts.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct ChainIds {
+    /// L1 chain ID.
+    pub(crate) l1_chain_id: u64,
+    /// L2 chain ID.
+    pub(crate) l2_chain_id: u64,
+}
+
+impl DeployerConfig {
+    /// Loads a configuration file from JSON or TOML.
+    pub(crate) fn load(path: impl AsRef<Path>) -> Result<Self> {
+        let path = path.as_ref();
+        let contents = std::fs::read_to_string(path)
+            .wrap_err_with(|| format!("Failed to read config file at {}", path.display()))?;
+
+        match path.extension().and_then(std::ffi::OsStr::to_str) {
+            Some("json") => serde_json::from_str(&contents)
+                .wrap_err_with(|| format!("Failed to parse JSON config at {}", path.display())),
+            Some("toml") => toml::from_str(&contents)
+                .wrap_err_with(|| format!("Failed to parse TOML config at {}", path.display())),
+            _ => serde_json::from_str(&contents)
+                .or_else(|_| toml::from_str(&contents))
+                .wrap_err_with(|| {
+                    format!(
+                        "Failed to parse config at {} as JSON or TOML",
+                        path.display()
+                    )
+                }),
+        }
+    }
+
+    /// Resolves defaults, random chain IDs, and output directory safety checks.
+    pub(crate) fn resolve(self, output_dir_override: Option<PathBuf>) -> Result<ResolvedConfig> {
+        let chain_ids = resolve_chain_ids(self.l1_chain_id, self.l2_chain_id);
+        let output_dir = output_dir_override
+            .or(self.output_dir)
+            .unwrap_or_else(|| PathBuf::from(DEFAULT_OUTPUT_DIR));
+
+        ensure_output_dir_is_safe(&output_dir)?;
+
+        Ok(ResolvedConfig {
+            output_dir,
+            l1_chain_id: chain_ids.l1_chain_id,
+            l2_chain_id: chain_ids.l2_chain_id,
+            slot_duration: self.slot_duration.unwrap_or(DEFAULT_SLOT_DURATION),
+            genesis_time: self.genesis_time.unwrap_or_else(current_unix_timestamp),
+            prefund_balance: parse_balance(self.prefund_balance.as_deref())?,
+            l2_base_v1_block: self.l2_base_v1_block,
+        })
+    }
+}
+
+impl ResolvedConfig {
+    /// Returns the chain ID bundle.
+    pub(crate) const fn chain_ids(&self) -> ChainIds {
+        ChainIds { l1_chain_id: self.l1_chain_id, l2_chain_id: self.l2_chain_id }
+    }
+}
+
+fn resolve_chain_ids(l1_chain_id: Option<u64>, l2_chain_id: Option<u64>) -> ChainIds {
+    let mut rng = rand::rng();
+    let l1 = l1_chain_id.unwrap_or_else(|| rng.random_range(L1_CHAIN_ID_MIN..=L1_CHAIN_ID_MAX));
+
+    let l2 = l2_chain_id.unwrap_or_else(|| {
+        loop {
+            let candidate = rng.random_range(L2_CHAIN_ID_MIN..=L2_CHAIN_ID_MAX);
+            if candidate != l1 {
+                break candidate;
+            }
+        }
+    });
+
+    ChainIds { l1_chain_id: l1, l2_chain_id: l2 }
+}
+
+fn ensure_output_dir_is_safe(output_dir: &Path) -> Result<()> {
+    if !output_dir.exists() {
+        return Ok(());
+    }
+
+    let contains_source_tree =
+        output_dir.join("Cargo.toml").exists() || output_dir.join("src").exists();
+    if contains_source_tree {
+        bail!(
+            "Refusing to write devnet artifacts into {} because it looks like a source directory. \
+Pass --output-dir to an empty or dedicated artifacts path.",
+            output_dir.display()
+        );
+    }
+
+    Ok(())
+}
+
+fn parse_balance(balance: Option<&str>) -> Result<U256> {
+    let value = balance.unwrap_or(DEFAULT_PREFUND_BALANCE);
+
+    if let Some(hex) = value.strip_prefix("0x") {
+        return U256::from_str_radix(hex, 16)
+            .wrap_err_with(|| format!("Failed to parse prefund balance `{value}` as hex wei"));
+    }
+
+    U256::from_str(value)
+        .wrap_err_with(|| format!("Failed to parse prefund balance `{value}` as decimal wei"))
+}
+
+fn current_unix_timestamp() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .expect("system clock should be after unix epoch")
+        .as_secs()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{DEFAULT_PREFUND_BALANCE, DeployerConfig};
+
+    #[test]
+    fn parses_toml_config() {
+        let config: DeployerConfig = toml::from_str(
+            r#"
+l1_chain_id = 1337
+l2_chain_id = 8453
+slot_duration = 4
+l2_base_v1_block = 20
+"#,
+        )
+        .expect("toml config should parse");
+
+        assert_eq!(config.l1_chain_id, Some(1337));
+        assert_eq!(config.l2_chain_id, Some(8453));
+        assert_eq!(config.slot_duration, Some(4));
+        assert_eq!(config.l2_base_v1_block, Some(20));
+    }
+
+    #[test]
+    fn parses_json_config() {
+        let config: DeployerConfig = serde_json::from_str(
+            r#"{
+  "l1_chain_id": 901337,
+  "l2_chain_id": 84538453,
+  "prefund_balance": "0x10"
+}"#,
+        )
+        .expect("json config should parse");
+
+        assert_eq!(config.l1_chain_id, Some(901337));
+        assert_eq!(config.l2_chain_id, Some(84538453));
+        assert_eq!(config.prefund_balance.as_deref(), Some("0x10"));
+    }
+
+    #[test]
+    fn resolves_defaults_and_random_chain_ids() {
+        let resolved = DeployerConfig::default().resolve(None).expect("config should resolve");
+
+        assert!((1_300_000..=1_399_999).contains(&resolved.l1_chain_id));
+        assert!((84_530_000..=84_539_999).contains(&resolved.l2_chain_id));
+        assert_ne!(resolved.l1_chain_id, resolved.l2_chain_id);
+        assert_eq!(format!("{:#x}", resolved.prefund_balance), DEFAULT_PREFUND_BALANCE);
+    }
+}

--- a/bin/base-deployer/src/config.rs
+++ b/bin/base-deployer/src/config.rs
@@ -91,13 +91,62 @@ impl DeployerConfig {
 
     /// Resolves defaults, random chain IDs, and output directory safety checks.
     pub(crate) fn resolve(self, output_dir_override: Option<PathBuf>) -> Result<ResolvedConfig> {
-        let chain_ids = resolve_chain_ids(self.l1_chain_id, self.l2_chain_id);
+        let output_dir = self.output_dir(output_dir_override)?;
+        let chain_ids = self.resolve_chain_ids(&output_dir, None)?;
+        self.finish_resolution(output_dir, chain_ids)
+    }
+
+    /// Resolves defaults while pinning the L1 chain ID to a detected live value.
+    pub(crate) fn resolve_with_l1_chain_id(
+        self,
+        output_dir_override: Option<PathBuf>,
+        detected_l1_chain_id: u64,
+    ) -> Result<ResolvedConfig> {
+        let output_dir = self.output_dir(output_dir_override)?;
+        let chain_ids = self.resolve_chain_ids(&output_dir, Some(detected_l1_chain_id))?;
+        self.finish_resolution(output_dir, chain_ids)
+    }
+}
+
+impl ResolvedConfig {
+    /// Returns the chain ID bundle.
+    pub(crate) const fn chain_ids(&self) -> ChainIds {
+        ChainIds { l1_chain_id: self.l1_chain_id, l2_chain_id: self.l2_chain_id }
+    }
+}
+
+impl DeployerConfig {
+    fn output_dir(&self, output_dir_override: Option<PathBuf>) -> Result<PathBuf> {
         let output_dir = output_dir_override
-            .or(self.output_dir)
+            .or_else(|| self.output_dir.clone())
             .unwrap_or_else(|| PathBuf::from(DEFAULT_OUTPUT_DIR));
-
         ensure_output_dir_is_safe(&output_dir)?;
+        Ok(output_dir)
+    }
 
+    fn resolve_chain_ids(
+        &self,
+        output_dir: &Path,
+        detected_l1_chain_id: Option<u64>,
+    ) -> Result<ChainIds> {
+        let existing = load_existing_chain_ids(output_dir)?;
+        let explicit_l1 = self.l1_chain_id.or(existing.map(|ids| ids.l1_chain_id));
+        let explicit_l2 = self.l2_chain_id.or(existing.map(|ids| ids.l2_chain_id));
+
+        if let (Some(expected), Some(detected)) = (explicit_l1, detected_l1_chain_id)
+            && expected != detected
+        {
+            bail!(
+                "Configured L1 chain ID {} does not match detected live L1 chain ID {}",
+                expected,
+                detected
+            );
+        }
+
+        Ok(resolve_chain_ids(explicit_l1.or(detected_l1_chain_id), explicit_l2))
+    }
+
+    fn finish_resolution(self, output_dir: PathBuf, chain_ids: ChainIds) -> Result<ResolvedConfig> {
         Ok(ResolvedConfig {
             output_dir,
             l1_chain_id: chain_ids.l1_chain_id,
@@ -107,13 +156,6 @@ impl DeployerConfig {
             prefund_balance: parse_balance(self.prefund_balance.as_deref())?,
             l2_base_v1_block: self.l2_base_v1_block,
         })
-    }
-}
-
-impl ResolvedConfig {
-    /// Returns the chain ID bundle.
-    pub(crate) const fn chain_ids(&self) -> ChainIds {
-        ChainIds { l1_chain_id: self.l1_chain_id, l2_chain_id: self.l2_chain_id }
     }
 }
 
@@ -131,6 +173,20 @@ fn resolve_chain_ids(l1_chain_id: Option<u64>, l2_chain_id: Option<u64>) -> Chai
     });
 
     ChainIds { l1_chain_id: l1, l2_chain_id: l2 }
+}
+
+/// Loads chain IDs from an existing artifact bundle, if present.
+pub(crate) fn load_existing_chain_ids(output_dir: &Path) -> Result<Option<ChainIds>> {
+    let path = output_dir.join("chain-ids.json");
+    if !path.exists() {
+        return Ok(None);
+    }
+
+    let contents = std::fs::read_to_string(&path)
+        .wrap_err_with(|| format!("Failed to read existing chain IDs at {}", path.display()))?;
+    serde_json::from_str(&contents)
+        .map(Some)
+        .wrap_err_with(|| format!("Failed to parse existing chain IDs at {}", path.display()))
 }
 
 fn ensure_output_dir_is_safe(output_dir: &Path) -> Result<()> {

--- a/bin/base-deployer/src/deploy.rs
+++ b/bin/base-deployer/src/deploy.rs
@@ -1,0 +1,450 @@
+//! Live L1 deployment and L2 artifact extraction.
+
+use std::{
+    fs,
+    path::{Path, PathBuf},
+    process::Command,
+};
+
+use alloy_network::Ethereum;
+use alloy_provider::{Provider, RootProvider};
+use alloy_rpc_client::RpcClient;
+use eyre::{Result, WrapErr, bail};
+use serde::Serialize;
+use serde_json::Value;
+use url::Url;
+
+use crate::{
+    config::DeployerConfig,
+    devnet::{BUILDER_ENODE_ID, l2_intent_toml, role_accounts, sequencer_p2p_keys},
+    external::{capture_stdout_to_path, run_command},
+    genesis::{patch_base_v1_activation_files, write_rollup_conductor_file},
+};
+
+/// Output metadata for a live L1 deployment.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct DeployL1Output {
+    /// Manifest file describing the live deployment.
+    pub(crate) manifest_path: PathBuf,
+    /// Persisted `op-deployer` workdir.
+    pub(crate) workdir: PathBuf,
+    /// Raw L1 address output from `op-deployer inspect l1`.
+    pub(crate) l1_addresses_path: PathBuf,
+}
+
+/// Output metadata for extracted L2 artifacts.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct DeployL2Output {
+    /// Generated L2 genesis file.
+    pub(crate) genesis_path: PathBuf,
+    /// Generated rollup config.
+    pub(crate) rollup_path: PathBuf,
+    /// Generated rollup config for op-conductor.
+    pub(crate) rollup_conductor_path: PathBuf,
+    /// Raw L1 address output from `op-deployer inspect l1`.
+    pub(crate) l1_addresses_path: PathBuf,
+}
+
+/// Deploys OP Stack L1 contracts to a live L1.
+pub(crate) async fn deploy_l1(
+    config: DeployerConfig,
+    output_dir_override: Option<PathBuf>,
+    l1_rpc: &str,
+) -> Result<DeployL1Output> {
+    let l1 = inspect_l1_rpc(l1_rpc).await?;
+    let resolved = config.resolve_with_l1_chain_id(output_dir_override, l1.chain_id)?;
+    let paths = DeploymentPaths::new(&resolved.output_dir);
+    paths.create_directories()?;
+    paths.write_chain_ids(resolved.chain_ids())?;
+    ensure_live_intent(&paths.l2_intent, resolved.l1_chain_id, resolved.l2_chain_id)?;
+
+    if !paths.live_state.exists() {
+        if paths.live_workdir.exists() {
+            fs::remove_dir_all(&paths.live_workdir)
+                .wrap_err_with(|| format!("Failed to remove {}", paths.live_workdir.display()))?;
+        }
+        fs::create_dir_all(&paths.live_workdir)
+            .wrap_err_with(|| format!("Failed to create {}", paths.live_workdir.display()))?;
+
+        run_command(
+            Command::new("op-deployer")
+                .arg("init")
+                .arg("--l1-chain-id")
+                .arg(resolved.l1_chain_id.to_string())
+                .arg("--l2-chain-ids")
+                .arg(resolved.l2_chain_id.to_string())
+                .arg("--intent-type")
+                .arg("custom")
+                .arg("--workdir")
+                .arg(&paths.live_workdir),
+            "initialize live op-deployer workdir",
+        )?;
+
+        fs::copy(&paths.l2_intent, paths.live_workdir.join("intent.toml"))
+            .wrap_err("Failed to copy intent.toml into live op-deployer workdir")?;
+
+        run_command(
+            Command::new("op-deployer")
+                .arg("apply")
+                .arg("--workdir")
+                .arg(&paths.live_workdir)
+                .arg("--deployment-target")
+                .arg("live")
+                .arg("--l1-rpc-url")
+                .arg(l1_rpc)
+                .arg("--private-key")
+                .arg(paths.deployer_private_key_hex()),
+            "deploy OP Stack contracts to L1",
+        )?;
+    }
+
+    capture_stdout_to_path(
+        Command::new("op-deployer")
+            .arg("inspect")
+            .arg("l1")
+            .arg("--workdir")
+            .arg(&paths.live_workdir)
+            .arg(resolved.l2_chain_id.to_string()),
+        &paths.l1_addresses,
+        "inspect deployed L1 addresses",
+    )?;
+
+    let addresses = read_json(&paths.l1_addresses)?;
+    let manifest = DeploymentManifest::new(
+        l1_rpc,
+        l1.chain_id,
+        resolved.l2_chain_id,
+        &paths,
+        addresses,
+    );
+    write_json(&paths.deployment_manifest, &manifest)?;
+
+    Ok(DeployL1Output {
+        manifest_path: paths.deployment_manifest,
+        workdir: paths.live_workdir,
+        l1_addresses_path: paths.l1_addresses,
+    })
+}
+
+/// Extracts L2 genesis and rollup configuration from a live deployment workdir.
+pub(crate) async fn deploy_l2(
+    config: DeployerConfig,
+    output_dir_override: Option<PathBuf>,
+    l1_rpc: Option<&str>,
+) -> Result<DeployL2Output> {
+    let resolved = match l1_rpc {
+        Some(url) => {
+            let l1 = inspect_l1_rpc(url).await?;
+            config
+                .clone()
+                .resolve_with_l1_chain_id(output_dir_override.clone(), l1.chain_id)?
+        }
+        None => config.clone().resolve(output_dir_override.clone())?,
+    };
+
+    let paths = DeploymentPaths::new(&resolved.output_dir);
+    paths.create_directories()?;
+
+    if !paths.live_state.exists() {
+        if let Some(url) = l1_rpc {
+            deploy_l1(config, output_dir_override, url).await?;
+        } else {
+            bail!(
+                "No live deployment state found at {}. Run `base-deployer deploy-l1 --l1-rpc <url>` first.",
+                paths.live_workdir.display()
+            );
+        }
+    }
+
+    capture_stdout_to_path(
+        Command::new("op-deployer")
+            .arg("inspect")
+            .arg("genesis")
+            .arg("--workdir")
+            .arg(&paths.live_workdir)
+            .arg(resolved.l2_chain_id.to_string()),
+        &paths.l2_genesis,
+        "inspect live L2 genesis",
+    )?;
+    capture_stdout_to_path(
+        Command::new("op-deployer")
+            .arg("inspect")
+            .arg("rollup")
+            .arg("--workdir")
+            .arg(&paths.live_workdir)
+            .arg(resolved.l2_chain_id.to_string()),
+        &paths.l2_rollup,
+        "inspect live rollup config",
+    )?;
+    capture_stdout_to_path(
+        Command::new("op-deployer")
+            .arg("inspect")
+            .arg("l1")
+            .arg("--workdir")
+            .arg(&paths.live_workdir)
+            .arg(resolved.l2_chain_id.to_string()),
+        &paths.l1_addresses,
+        "inspect deployed L1 addresses",
+    )?;
+
+    if let Some(base_v1_block) = resolved.l2_base_v1_block {
+        patch_base_v1_activation_files(&paths.l2_rollup, &paths.l2_genesis, base_v1_block)?;
+    }
+    write_rollup_conductor_file(&paths.l2_rollup, &paths.l2_rollup_conductor)?;
+    write_p2p_material(&paths)?;
+
+    Ok(DeployL2Output {
+        genesis_path: paths.l2_genesis,
+        rollup_path: paths.l2_rollup,
+        rollup_conductor_path: paths.l2_rollup_conductor,
+        l1_addresses_path: paths.l1_addresses,
+    })
+}
+
+#[derive(Debug, Clone)]
+struct DeploymentPaths {
+    l1_dir: PathBuf,
+    l2_dir: PathBuf,
+    op_deployer_dir: PathBuf,
+    live_workdir: PathBuf,
+    live_state: PathBuf,
+    deployment_manifest: PathBuf,
+    l1_addresses: PathBuf,
+    l2_intent: PathBuf,
+    l2_genesis: PathBuf,
+    l2_rollup: PathBuf,
+    l2_rollup_conductor: PathBuf,
+    chain_ids: PathBuf,
+    builder_p2p_key: PathBuf,
+    builder_enode_id: PathBuf,
+    sequencer1_p2p_key: PathBuf,
+    sequencer2_p2p_key: PathBuf,
+}
+
+impl DeploymentPaths {
+    fn new(output_dir: &Path) -> Self {
+        let l1_dir = output_dir.join("l1");
+        let l2_dir = output_dir.join("l2");
+        let op_deployer_dir = output_dir.join("op-deployer");
+        let live_workdir = op_deployer_dir.join("live");
+
+        Self {
+            l1_dir: l1_dir.clone(),
+            l2_dir: l2_dir.clone(),
+            op_deployer_dir: op_deployer_dir.clone(),
+            live_workdir: live_workdir.clone(),
+            live_state: live_workdir.join("state.json"),
+            deployment_manifest: l1_dir.join("deployment-manifest.json"),
+            l1_addresses: l2_dir.join("l1-addresses.json"),
+            l2_intent: l2_dir.join("intent.toml"),
+            l2_genesis: l2_dir.join("genesis.json"),
+            l2_rollup: l2_dir.join("rollup.json"),
+            l2_rollup_conductor: l2_dir.join("rollup-conductor.json"),
+            chain_ids: output_dir.join("chain-ids.json"),
+            builder_p2p_key: l2_dir.join("builder-p2p-key.txt"),
+            builder_enode_id: l2_dir.join("builder-enode-id.txt"),
+            sequencer1_p2p_key: l2_dir.join("sequencer-1-p2p-key.txt"),
+            sequencer2_p2p_key: l2_dir.join("sequencer-2-p2p-key.txt"),
+        }
+    }
+
+    fn create_directories(&self) -> Result<()> {
+        fs::create_dir_all(&self.l1_dir)
+            .wrap_err_with(|| format!("Failed to create {}", self.l1_dir.display()))?;
+        fs::create_dir_all(&self.l2_dir)
+            .wrap_err_with(|| format!("Failed to create {}", self.l2_dir.display()))?;
+        fs::create_dir_all(&self.op_deployer_dir)
+            .wrap_err_with(|| format!("Failed to create {}", self.op_deployer_dir.display()))?;
+        Ok(())
+    }
+
+    fn write_chain_ids(&self, chain_ids: crate::config::ChainIds) -> Result<()> {
+        write_json(&self.chain_ids, &chain_ids)
+    }
+
+    fn deployer_private_key_hex(&self) -> String {
+        format!("0x{}", hex::encode(role_accounts().deployer.private_key))
+    }
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct DeploymentManifest {
+    l1_rpc_url: String,
+    l1_chain_id: u64,
+    l2_chain_id: u64,
+    deployer_address: String,
+    workdir: String,
+    contracts: StandardContracts,
+    addresses: Value,
+}
+
+impl DeploymentManifest {
+    fn new(
+        l1_rpc_url: &str,
+        l1_chain_id: u64,
+        l2_chain_id: u64,
+        paths: &DeploymentPaths,
+        addresses: Value,
+    ) -> Self {
+        Self {
+            l1_rpc_url: l1_rpc_url.to_string(),
+            l1_chain_id,
+            l2_chain_id,
+            deployer_address: format!("{:#x}", role_accounts().deployer.address),
+            workdir: paths.live_workdir.display().to_string(),
+            contracts: StandardContracts::from_addresses(&addresses),
+            addresses,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Default, Serialize)]
+struct StandardContracts {
+    optimism_portal: Option<String>,
+    l1_cross_domain_messenger: Option<String>,
+    l1_standard_bridge: Option<String>,
+    system_config: Option<String>,
+    address_manager: Option<String>,
+}
+
+impl StandardContracts {
+    fn from_addresses(addresses: &Value) -> Self {
+        Self {
+            optimism_portal: find_address(addresses, &["OptimismPortalProxy", "OptimismPortal"]),
+            l1_cross_domain_messenger: find_address(
+                addresses,
+                &["L1CrossDomainMessengerProxy", "L1CrossDomainMessenger"],
+            ),
+            l1_standard_bridge: find_address(
+                addresses,
+                &["L1StandardBridgeProxy", "L1StandardBridge"],
+            ),
+            system_config: find_address(addresses, &["SystemConfigProxy", "SystemConfig"]),
+            address_manager: find_address(addresses, &["AddressManager"]),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct L1RpcInfo {
+    chain_id: u64,
+}
+
+async fn inspect_l1_rpc(l1_rpc: &str) -> Result<L1RpcInfo> {
+    let url: Url = l1_rpc.parse().wrap_err("Failed to parse --l1-rpc URL")?;
+    let provider = RootProvider::<Ethereum>::new(RpcClient::builder().http(url));
+    let chain_id = provider
+        .get_chain_id()
+        .await
+        .wrap_err("Failed to query chain ID from L1 RPC")?;
+
+    provider
+        .get_block_number()
+        .await
+        .wrap_err("Failed to query latest block from L1 RPC")?;
+
+    Ok(L1RpcInfo { chain_id })
+}
+
+fn ensure_live_intent(path: &Path, l1_chain_id: u64, l2_chain_id: u64) -> Result<()> {
+    fs::write(path, l2_intent_toml(l1_chain_id, l2_chain_id))
+        .wrap_err_with(|| format!("Failed to write {}", path.display()))
+}
+
+fn write_p2p_material(paths: &DeploymentPaths) -> Result<()> {
+    let roles = role_accounts();
+    let [seq1_key, seq2_key] = sequencer_p2p_keys();
+    fs::write(&paths.builder_p2p_key, format!("{:#x}\n", roles.builder.private_key))
+        .wrap_err_with(|| format!("Failed to write {}", paths.builder_p2p_key.display()))?;
+    fs::write(&paths.builder_enode_id, format!("{BUILDER_ENODE_ID}\n"))
+        .wrap_err_with(|| format!("Failed to write {}", paths.builder_enode_id.display()))?;
+    fs::write(&paths.sequencer1_p2p_key, format!("{:#x}\n", seq1_key))
+        .wrap_err_with(|| format!("Failed to write {}", paths.sequencer1_p2p_key.display()))?;
+    fs::write(&paths.sequencer2_p2p_key, format!("{:#x}\n", seq2_key))
+        .wrap_err_with(|| format!("Failed to write {}", paths.sequencer2_p2p_key.display()))?;
+    Ok(())
+}
+
+fn find_address(addresses: &Value, candidates: &[&str]) -> Option<String> {
+    let object = addresses.as_object()?;
+
+    for candidate in candidates {
+        if let Some(address) = object.get(*candidate).and_then(extract_address) {
+            return Some(address);
+        }
+    }
+
+    for (key, value) in object {
+        let normalized_key = key.to_ascii_lowercase();
+        if candidates
+            .iter()
+            .any(|candidate| normalized_key.contains(&candidate.to_ascii_lowercase()))
+        {
+            if let Some(address) = extract_address(value) {
+                return Some(address);
+            }
+        }
+    }
+
+    None
+}
+
+fn extract_address(value: &Value) -> Option<String> {
+    match value {
+        Value::String(address) if address.starts_with("0x") => Some(address.clone()),
+        Value::Object(object) => object.get("address").and_then(Value::as_str).map(str::to_owned),
+        _ => None,
+    }
+}
+
+fn read_json(path: &Path) -> Result<Value> {
+    let contents = fs::read_to_string(path)
+        .wrap_err_with(|| format!("Failed to read {}", path.display()))?;
+    serde_json::from_str(&contents)
+        .wrap_err_with(|| format!("Failed to parse JSON at {}", path.display()))
+}
+
+fn write_json(path: &Path, value: &impl Serialize) -> Result<()> {
+    let contents = serde_json::to_string_pretty(value).wrap_err("Failed to serialize JSON")?;
+    fs::write(path, format!("{contents}\n"))
+        .wrap_err_with(|| format!("Failed to write {}", path.display()))
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::StandardContracts;
+
+    #[test]
+    fn extracts_standard_contracts_from_addresses() {
+        let contracts = StandardContracts::from_addresses(&json!({
+            "OptimismPortalProxy": "0x1000000000000000000000000000000000000001",
+            "L1CrossDomainMessengerProxy": "0x1000000000000000000000000000000000000002",
+            "L1StandardBridgeProxy": "0x1000000000000000000000000000000000000003",
+            "SystemConfigProxy": "0x1000000000000000000000000000000000000004",
+            "AddressManager": "0x1000000000000000000000000000000000000005",
+        }));
+
+        assert_eq!(
+            contracts.optimism_portal.as_deref(),
+            Some("0x1000000000000000000000000000000000000001")
+        );
+        assert_eq!(
+            contracts.l1_cross_domain_messenger.as_deref(),
+            Some("0x1000000000000000000000000000000000000002")
+        );
+        assert_eq!(
+            contracts.l1_standard_bridge.as_deref(),
+            Some("0x1000000000000000000000000000000000000003")
+        );
+        assert_eq!(
+            contracts.system_config.as_deref(),
+            Some("0x1000000000000000000000000000000000000004")
+        );
+        assert_eq!(
+            contracts.address_manager.as_deref(),
+            Some("0x1000000000000000000000000000000000000005")
+        );
+    }
+}

--- a/bin/base-deployer/src/devnet.rs
+++ b/bin/base-deployer/src/devnet.rs
@@ -1,0 +1,290 @@
+//! Local devnet primitives reused across the `base-deployer` commands.
+
+use alloy_primitives::{Address, B256, FixedBytes, U256, address};
+use alloy_signer_local::{MnemonicBuilder, coins_bip39::English};
+use serde_json::{Map, Value, json};
+
+const PREFUND_CONTRACT_ADDRESS: Address = address!("4e59b44847b379578588920cA78FbF26c0B4956C");
+const PREFUND_CONTRACT_CODE: &str = "0x7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe03601600081602082378035828234f58015156039578182fd5b8082525050506014600cf3";
+
+/// Standard mnemonic used for local devnets.
+pub(crate) const TEST_MNEMONIC: &str = "test test test test test test test test test test test junk";
+
+/// Derived devnet account.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct Account {
+    /// Account address.
+    pub(crate) address: Address,
+    /// Account private key.
+    pub(crate) private_key: B256,
+}
+
+/// Role-specific account aliases for the generated devnet.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct RoleAccounts {
+    /// Deployer account.
+    pub(crate) deployer: Account,
+    /// Sequencer account.
+    pub(crate) sequencer: Account,
+    /// Batcher account.
+    pub(crate) batcher: Account,
+    /// Proposer account.
+    pub(crate) proposer: Account,
+    /// Challenger account.
+    pub(crate) challenger: Account,
+    /// Builder account.
+    pub(crate) builder: Account,
+}
+
+/// Returns the default derived devnet accounts.
+pub(crate) fn derived_accounts() -> Vec<Account> {
+    (0..10).map(derive_account).collect()
+}
+
+/// Returns the default role account aliases.
+pub(crate) fn role_accounts() -> RoleAccounts {
+    let accounts = derived_accounts();
+    RoleAccounts {
+        deployer: accounts[0],
+        sequencer: accounts[5],
+        batcher: accounts[6],
+        proposer: accounts[7],
+        challenger: accounts[8],
+        builder: accounts[9],
+    }
+}
+
+/// Generates the L1 execution layer genesis JSON.
+pub(crate) fn l1_el_genesis(chain_id: u64, genesis_time: u64, account_balance: U256) -> Value {
+    let balance_hex = format!("{account_balance:#x}");
+    let genesis_time_hex = format!("{:#x}", U256::from(genesis_time));
+    let alloc = Value::Object(alloc_from_accounts(&derived_accounts(), &balance_hex));
+
+    json!({
+        "config": {
+            "chainId": chain_id,
+            "homesteadBlock": 0,
+            "eip150Block": 0,
+            "eip155Block": 0,
+            "eip158Block": 0,
+            "byzantiumBlock": 0,
+            "constantinopleBlock": 0,
+            "petersburgBlock": 0,
+            "istanbulBlock": 0,
+            "berlinBlock": 0,
+            "londonBlock": 0,
+            "arrowGlacierBlock": 0,
+            "grayGlacierBlock": 0,
+            "terminalTotalDifficulty": 0,
+            "shanghaiTime": 0,
+            "cancunTime": 0,
+            "pragueTime": 0,
+            "osakaTime": 0,
+            "blobSchedule": {
+                "cancun": { "target": 3, "max": 6, "baseFeeUpdateFraction": 3338477 },
+                "prague": { "target": 6, "max": 9, "baseFeeUpdateFraction": 5007716 },
+                "osaka": { "target": 9, "max": 12, "baseFeeUpdateFraction": 5007716 },
+                "bpo1": { "target": 10, "max": 15, "baseFeeUpdateFraction": 5007716 },
+                "bpo2": { "target": 14, "max": 21, "baseFeeUpdateFraction": 5007716 }
+            },
+            "bpo1Time": 0,
+            "bpo2Time": 0
+        },
+        "nonce": "0x0",
+        "timestamp": genesis_time_hex,
+        "extraData": "0x",
+        "gasLimit": "0x1c9c380",
+        "difficulty": "0x0",
+        "mixHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+        "coinbase": "0x0000000000000000000000000000000000000000",
+        "alloc": alloc,
+        "baseFeePerGas": "0x3b9aca00",
+        "blobGasUsed": "0x0",
+        "excessBlobGas": "0x0"
+    })
+}
+
+/// Generates the L1 beacon configuration YAML.
+pub(crate) fn l1_beacon_config_yaml(chain_id: u64, genesis_time: u64, slot_duration: u64) -> String {
+    format!(
+        r#"# Extends the minimal preset
+PRESET_BASE: minimal
+CONFIG_NAME: devnet
+
+# Terminal PoW block
+TERMINAL_TOTAL_DIFFICULTY: 0
+TERMINAL_BLOCK_HASH: 0x0000000000000000000000000000000000000000000000000000000000000000
+TERMINAL_BLOCK_HASH_ACTIVATION_EPOCH: 18446744073709551615
+
+# Genesis
+MIN_GENESIS_ACTIVE_VALIDATOR_COUNT: 1
+MIN_GENESIS_TIME: {genesis_time}
+GENESIS_FORK_VERSION: 0x10000000
+GENESIS_DELAY: 0
+
+# Forking
+ALTAIR_FORK_VERSION: 0x20000000
+ALTAIR_FORK_EPOCH: 0
+BELLATRIX_FORK_VERSION: 0x30000000
+BELLATRIX_FORK_EPOCH: 0
+CAPELLA_FORK_VERSION: 0x40000000
+CAPELLA_FORK_EPOCH: 0
+DENEB_FORK_VERSION: 0x50000000
+DENEB_FORK_EPOCH: 0
+ELECTRA_FORK_VERSION: 0x60000000
+ELECTRA_FORK_EPOCH: 0
+FULU_FORK_VERSION: 0x70000000
+FULU_FORK_EPOCH: 0
+
+# Time parameters
+SECONDS_PER_SLOT: {slot_duration}
+SECONDS_PER_ETH1_BLOCK: 14
+MIN_VALIDATOR_WITHDRAWABILITY_DELAY: 256
+SHARD_COMMITTEE_PERIOD: 64
+ETH1_FOLLOW_DISTANCE: 16
+
+# Validator cycle
+INACTIVITY_SCORE_BIAS: 4
+INACTIVITY_SCORE_RECOVERY_RATE: 16
+EJECTION_BALANCE: 16000000000
+MIN_PER_EPOCH_CHURN_LIMIT: 2
+CHURN_LIMIT_QUOTIENT: 32
+MAX_PER_EPOCH_ACTIVATION_CHURN_LIMIT: 4
+
+# Fork choice
+PROPOSER_SCORE_BOOST: 40
+REORG_HEAD_WEIGHT_THRESHOLD: 20
+REORG_PARENT_WEIGHT_THRESHOLD: 160
+REORG_MAX_EPOCHS_SINCE_FINALIZATION: 2
+
+# Deposit contract
+DEPOSIT_CHAIN_ID: {chain_id}
+DEPOSIT_NETWORK_ID: {chain_id}
+DEPOSIT_CONTRACT_ADDRESS: 0x0000000000000000000000000000000000000000
+
+# Networking
+MAX_PAYLOAD_SIZE: 10485760
+MAX_REQUEST_BLOCKS: 1024
+EPOCHS_PER_SUBNET_SUBSCRIPTION: 256
+MIN_EPOCHS_FOR_BLOCK_REQUESTS: 272
+ATTESTATION_PROPAGATION_SLOT_RANGE: 32
+MAXIMUM_GOSSIP_CLOCK_DISPARITY: 500
+MESSAGE_DOMAIN_INVALID_SNAPPY: 0x00000000
+MESSAGE_DOMAIN_VALID_SNAPPY: 0x01000000
+SUBNETS_PER_NODE: 2
+ATTESTATION_SUBNET_COUNT: 64
+ATTESTATION_SUBNET_EXTRA_BITS: 0
+ATTESTATION_SUBNET_PREFIX_BITS: 6
+
+# Deneb
+MAX_REQUEST_BLOCKS_DENEB: 128
+MIN_EPOCHS_FOR_BLOB_SIDECARS_REQUESTS: 4096
+BLOB_SIDECAR_SUBNET_COUNT: 6
+MAX_BLOBS_PER_BLOCK: 6
+MAX_REQUEST_BLOB_SIDECARS: 768
+
+# Electra
+MAX_BLOBS_PER_BLOCK_ELECTRA: 9
+BLOB_SIDECAR_SUBNET_COUNT_ELECTRA: 9
+MAX_REQUEST_BLOB_SIDECARS_ELECTRA: 1152
+MAX_EFFECTIVE_BALANCE_ELECTRA: 2048000000000
+MIN_ACTIVATION_BALANCE: 32000000000
+MIN_SLASHING_PENALTY_QUOTIENT_ELECTRA: 4096
+WHISTLEBLOWER_REWARD_QUOTIENT_ELECTRA: 4096
+MAX_ATTESTER_SLASHINGS_ELECTRA: 1
+MAX_ATTESTATIONS_ELECTRA: 8
+MAX_PENDING_PARTIALS_PER_WITHDRAWALS_SWEEP: 8
+MAX_PENDING_DEPOSITS_PER_EPOCH: 16
+PENDING_DEPOSITS_LIMIT: 134217728
+PENDING_PARTIAL_WITHDRAWALS_LIMIT: 134217728
+PENDING_CONSOLIDATIONS_LIMIT: 262144
+MIN_PER_EPOCH_CHURN_LIMIT_ELECTRA: 128000000000
+MAX_PER_EPOCH_ACTIVATION_EXIT_CHURN_LIMIT: 256000000000
+
+# Fulu (with BPO2 parameters: target 14, max 21)
+MAX_BLOBS_PER_BLOCK_FULU: 21
+BLOB_SIDECAR_SUBNET_COUNT_FULU: 21
+MAX_REQUEST_BLOB_SIDECARS_FULU: 2688
+"#,
+    )
+}
+
+/// Generates the L2 intent configuration for `op-deployer`.
+pub(crate) fn l2_intent_toml(l1_chain_id: u64, l2_chain_id: u64) -> String {
+    let roles = role_accounts();
+    let l2_chain_id_hex = format!("{l2_chain_id:#x}");
+    let deployer = format!("{:#x}", roles.deployer.address);
+    let sequencer = format!("{:#x}", roles.sequencer.address);
+    let batcher = format!("{:#x}", roles.batcher.address);
+    let proposer = format!("{:#x}", roles.proposer.address);
+    let challenger = format!("{:#x}", roles.challenger.address);
+
+    format!(
+        r#"configType = "custom"
+l1ChainID = {l1_chain_id}
+fundDevAccounts = true
+l1ContractsLocator = "embedded"
+l2ContractsLocator = "embedded"
+
+[superchainRoles]
+  SuperchainProxyAdminOwner = "{deployer}"
+  SuperchainGuardian = "{deployer}"
+  ProtocolVersionsOwner = "{deployer}"
+  Challenger = "{challenger}"
+
+[[chains]]
+  id = "{l2_chain_id_hex}"
+  baseFeeVaultRecipient = "{deployer}"
+  l1FeeVaultRecipient = "{deployer}"
+  sequencerFeeVaultRecipient = "{deployer}"
+  operatorFeeVaultRecipient = "{deployer}"
+  eip1559DenominatorCanyon = 250
+  eip1559Denominator = 50
+  eip1559Elasticity = 6
+  gasLimit = 60000000
+  operatorFeeScalar = 0
+  operatorFeeConstant = 0
+  chainFeesRecipient = "{deployer}"
+  minBaseFee = 1000000000
+  daFootprintGasScalar = 0
+  [chains.roles]
+    l1ProxyAdminOwner = "{deployer}"
+    l2ProxyAdminOwner = "{deployer}"
+    systemConfigOwner = "{deployer}"
+    unsafeBlockSigner = "{sequencer}"
+    batcher = "{batcher}"
+    proposer = "{proposer}"
+    challenger = "{challenger}"
+"#,
+    )
+}
+
+fn derive_account(index: u32) -> Account {
+    let path = format!("m/44'/60'/0'/0/{index}");
+    let signer = MnemonicBuilder::<English>::default()
+        .phrase(TEST_MNEMONIC)
+        .derivation_path(&path)
+        .expect("valid derivation path")
+        .build()
+        .expect("valid mnemonic signer");
+    let key_bytes = FixedBytes::<32>::from_slice(signer.credential().to_bytes().as_slice());
+    Account { address: signer.address(), private_key: B256::from(key_bytes) }
+}
+
+fn alloc_from_accounts(accounts: &[Account], balance_hex: &str) -> Map<String, Value> {
+    let mut alloc = Map::new();
+
+    for account in accounts {
+        alloc.insert(format!("{:#x}", account.address), json!({ "balance": balance_hex }));
+    }
+
+    alloc.insert(
+        format!("{:#x}", PREFUND_CONTRACT_ADDRESS),
+        json!({
+            "balance": "0x0",
+            "code": PREFUND_CONTRACT_CODE,
+        }),
+    );
+
+    alloc
+}

--- a/bin/base-deployer/src/devnet.rs
+++ b/bin/base-deployer/src/devnet.rs
@@ -9,6 +9,8 @@ const PREFUND_CONTRACT_CODE: &str = "0x7ffffffffffffffffffffffffffffffffffffffff
 
 /// Standard mnemonic used for local devnets.
 pub(crate) const TEST_MNEMONIC: &str = "test test test test test test test test test test test junk";
+/// Deterministic builder enode ID used by the existing devnet setup.
+pub(crate) const BUILDER_ENODE_ID: &str = "3255458e24278e31d5940f304b16300fdff3f6efd3e2a030b5818310ac67af45e28d057e6a332d07e0c5ab09d6947fd4eed1a646edbf224e2d2fec6f49f90abc";
 
 /// Derived devnet account.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -52,6 +54,12 @@ pub(crate) fn role_accounts() -> RoleAccounts {
         challenger: accounts[8],
         builder: accounts[9],
     }
+}
+
+/// Returns the deterministic sequencer P2P keys used by the docker devnet.
+pub(crate) fn sequencer_p2p_keys() -> [B256; 2] {
+    let accounts = derived_accounts();
+    [accounts[3].private_key, accounts[4].private_key]
 }
 
 /// Generates the L1 execution layer genesis JSON.

--- a/bin/base-deployer/src/external.rs
+++ b/bin/base-deployer/src/external.rs
@@ -1,0 +1,36 @@
+//! Helpers for invoking external command-line tooling.
+
+use std::{
+    path::Path,
+    process::{Command, Stdio},
+};
+
+use eyre::{Result, WrapErr, ensure};
+
+/// Runs a command and returns an error when it exits unsuccessfully.
+pub(crate) fn run_command(command: &mut Command, purpose: &str) -> Result<()> {
+    command.stdout(Stdio::null()).stderr(Stdio::piped());
+    let output = command.output().wrap_err_with(|| format!("Failed to {purpose}"))?;
+    ensure!(
+        output.status.success(),
+        "{purpose} failed: {}",
+        String::from_utf8_lossy(&output.stderr).trim()
+    );
+    Ok(())
+}
+
+/// Captures a command's stdout into a file.
+pub(crate) fn capture_stdout_to_path(
+    command: &mut Command,
+    path: &Path,
+    purpose: &str,
+) -> Result<()> {
+    let output = command.output().wrap_err_with(|| format!("Failed to {purpose}"))?;
+    ensure!(
+        output.status.success(),
+        "{purpose} failed: {}",
+        String::from_utf8_lossy(&output.stderr).trim()
+    );
+    std::fs::write(path, output.stdout)
+        .wrap_err_with(|| format!("Failed to write {}", path.display()))
+}

--- a/bin/base-deployer/src/genesis.rs
+++ b/bin/base-deployer/src/genesis.rs
@@ -1,0 +1,608 @@
+//! Genesis artifact generation for `base-deployer`.
+
+use std::{
+    fs,
+    path::{Path, PathBuf},
+    process::{Command, Stdio},
+};
+
+use eyre::{ContextCompat, Result, WrapErr, ensure};
+use serde::Serialize;
+use serde_json::{Value, json};
+
+use crate::config::{ChainIds, ResolvedConfig};
+use crate::devnet::{
+    TEST_MNEMONIC, derived_accounts, l1_beacon_config_yaml, l1_el_genesis, l2_intent_toml,
+};
+
+/// Paths to genesis artifacts produced by `base-deployer genesis`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct GenesisArtifacts {
+    /// Root output directory.
+    pub(crate) output_dir: PathBuf,
+    /// L1 EL genesis file.
+    pub(crate) l1_el_genesis: PathBuf,
+    /// L1 chain config file.
+    pub(crate) l1_chain_config: PathBuf,
+    /// L1 CL config file.
+    pub(crate) l1_cl_config: PathBuf,
+    /// L1 CL genesis state.
+    pub(crate) l1_cl_genesis: PathBuf,
+    /// L2 intent file.
+    pub(crate) l2_intent: PathBuf,
+    /// L2 genesis file.
+    pub(crate) l2_genesis: PathBuf,
+    /// L2 rollup config.
+    pub(crate) l2_rollup: PathBuf,
+    /// L2 rollup config for op-conductor.
+    pub(crate) l2_rollup_conductor: PathBuf,
+    /// L1 contract address manifest.
+    pub(crate) l1_addresses: PathBuf,
+    /// JWT secret file.
+    pub(crate) jwt_secret: PathBuf,
+    /// Chain IDs metadata.
+    pub(crate) chain_ids: PathBuf,
+    /// Funded account manifest.
+    pub(crate) accounts_manifest: PathBuf,
+}
+
+/// Generates devnet genesis artifacts using the default command-based tooling backend.
+pub(crate) fn generate_genesis(config: &ResolvedConfig) -> Result<GenesisArtifacts> {
+    generate_genesis_with_tooling(config, &CommandTooling)
+}
+
+fn generate_genesis_with_tooling(
+    config: &ResolvedConfig,
+    tooling: &impl GenesisTooling,
+) -> Result<GenesisArtifacts> {
+    let paths = GenesisPaths::new(&config.output_dir);
+    paths.create_directories()?;
+
+    write_chain_ids(&paths.chain_ids, config.chain_ids())?;
+    write_accounts_manifest(&paths.accounts_manifest)?;
+    write_jwt_secret(&paths.jwt_secret)?;
+    write_l1_execution_genesis(config, &paths.l1_el_genesis, &paths.l1_chain_config)?;
+    write_l1_consensus_inputs(config, &paths.l1_cl_config, &paths.l1_mnemonics)?;
+    write_l2_intent(config, &paths.l2_intent)?;
+
+    tooling.generate_l1_consensus_artifacts(&paths)?;
+    tooling.generate_l2_genesis_artifacts(config, &paths)?;
+    patch_base_v1_activation(config, &paths)?;
+    write_rollup_conductor(&paths)?;
+
+    Ok(paths.into_artifacts())
+}
+
+#[derive(Debug, Clone)]
+struct GenesisPaths {
+    output_dir: PathBuf,
+    l1_cl_dir: PathBuf,
+    l1_el_dir: PathBuf,
+    l2_dir: PathBuf,
+    l1_el_genesis: PathBuf,
+    l1_chain_config: PathBuf,
+    l1_cl_config: PathBuf,
+    l1_cl_genesis: PathBuf,
+    l1_mnemonics: PathBuf,
+    l2_intent: PathBuf,
+    l2_genesis: PathBuf,
+    l2_rollup: PathBuf,
+    l2_rollup_conductor: PathBuf,
+    l1_addresses: PathBuf,
+    jwt_secret: PathBuf,
+    chain_ids: PathBuf,
+    accounts_manifest: PathBuf,
+}
+
+impl GenesisPaths {
+    fn new(output_dir: &Path) -> Self {
+        let l1_dir = output_dir.join("l1");
+        let l1_el_dir = l1_dir.join("el");
+        let l1_cl_dir = l1_dir.join("cl");
+        let l2_dir = output_dir.join("l2");
+
+        Self {
+            output_dir: output_dir.to_path_buf(),
+            l1_cl_dir: l1_cl_dir.clone(),
+            l1_el_dir: l1_el_dir.clone(),
+            l2_dir: l2_dir.clone(),
+            l1_el_genesis: l1_el_dir.join("genesis.json"),
+            l1_chain_config: l1_el_dir.join("chain-config.json"),
+            l1_cl_config: l1_cl_dir.join("config.yaml"),
+            l1_cl_genesis: l1_cl_dir.join("genesis.ssz"),
+            l1_mnemonics: l1_cl_dir.join("mnemonics.yaml"),
+            l2_intent: l2_dir.join("intent.toml"),
+            l2_genesis: l2_dir.join("genesis.json"),
+            l2_rollup: l2_dir.join("rollup.json"),
+            l2_rollup_conductor: l2_dir.join("rollup-conductor.json"),
+            l1_addresses: l2_dir.join("l1-addresses.json"),
+            jwt_secret: l1_dir.join("jwt.hex"),
+            chain_ids: output_dir.join("chain-ids.json"),
+            accounts_manifest: output_dir.join("accounts.json"),
+        }
+    }
+
+    fn create_directories(&self) -> Result<()> {
+        fs::create_dir_all(&self.l1_el_dir)
+            .wrap_err_with(|| format!("Failed to create {}", self.l1_el_dir.display()))?;
+        fs::create_dir_all(&self.l1_cl_dir)
+            .wrap_err_with(|| format!("Failed to create {}", self.l1_cl_dir.display()))?;
+        fs::create_dir_all(&self.l2_dir)
+            .wrap_err_with(|| format!("Failed to create {}", self.l2_dir.display()))?;
+        Ok(())
+    }
+
+    fn into_artifacts(self) -> GenesisArtifacts {
+        GenesisArtifacts {
+            output_dir: self.output_dir,
+            l1_el_genesis: self.l1_el_genesis,
+            l1_chain_config: self.l1_chain_config,
+            l1_cl_config: self.l1_cl_config,
+            l1_cl_genesis: self.l1_cl_genesis,
+            l2_intent: self.l2_intent,
+            l2_genesis: self.l2_genesis,
+            l2_rollup: self.l2_rollup,
+            l2_rollup_conductor: self.l2_rollup_conductor,
+            l1_addresses: self.l1_addresses,
+            jwt_secret: self.jwt_secret,
+            chain_ids: self.chain_ids,
+            accounts_manifest: self.accounts_manifest,
+        }
+    }
+}
+
+trait GenesisTooling {
+    fn generate_l1_consensus_artifacts(&self, paths: &GenesisPaths) -> Result<()>;
+
+    fn generate_l2_genesis_artifacts(
+        &self,
+        config: &ResolvedConfig,
+        paths: &GenesisPaths,
+    ) -> Result<()>;
+}
+
+struct CommandTooling;
+
+impl GenesisTooling for CommandTooling {
+    fn generate_l1_consensus_artifacts(&self, paths: &GenesisPaths) -> Result<()> {
+        run_command(
+            Command::new("eth-genesis-state-generator")
+                .arg("beaconchain")
+                .arg("--eth1-config")
+                .arg(&paths.l1_el_genesis)
+                .arg("--config")
+                .arg(&paths.l1_cl_config)
+                .arg("--mnemonics")
+                .arg(&paths.l1_mnemonics)
+                .arg("--state-output")
+                .arg(&paths.l1_cl_genesis),
+            "generate L1 beacon genesis state",
+        )?;
+
+        let validator_keys_dir = paths.l1_cl_dir.join("validator_keys");
+        let validator_data_dir = paths.l1_cl_dir.join("validator_data");
+
+        if validator_keys_dir.exists() {
+            fs::remove_dir_all(&validator_keys_dir)
+                .wrap_err_with(|| format!("Failed to remove {}", validator_keys_dir.display()))?;
+        }
+        if validator_data_dir.exists() {
+            fs::remove_dir_all(&validator_data_dir)
+                .wrap_err_with(|| format!("Failed to remove {}", validator_data_dir.display()))?;
+        }
+
+        run_command(
+            Command::new("eth2-val-tools")
+                .arg("keystores")
+                .arg("--insecure")
+                .arg(format!("--source-mnemonic={TEST_MNEMONIC}"))
+                .arg("--source-min=0")
+                .arg("--source-max=1")
+                .arg(format!("--out-loc={}", validator_keys_dir.display())),
+            "generate validator keystores",
+        )?;
+
+        reorganize_validator_data(&validator_keys_dir, &validator_data_dir)?;
+        fs::write(paths.l1_cl_dir.join("deploy_block.txt"), "0\n")
+            .wrap_err("Failed to write deploy_block.txt")?;
+        fs::write(paths.l1_cl_dir.join("deposit_contract_block.txt"), "0\n")
+            .wrap_err("Failed to write deposit_contract_block.txt")?;
+
+        Ok(())
+    }
+
+    fn generate_l2_genesis_artifacts(
+        &self,
+        config: &ResolvedConfig,
+        paths: &GenesisPaths,
+    ) -> Result<()> {
+        let workdir = paths.output_dir.join(".op-deployer-genesis");
+        if workdir.exists() {
+            fs::remove_dir_all(&workdir)
+                .wrap_err_with(|| format!("Failed to remove {}", workdir.display()))?;
+        }
+        fs::create_dir_all(&workdir)
+            .wrap_err_with(|| format!("Failed to create {}", workdir.display()))?;
+
+        run_command(
+            Command::new("op-deployer")
+                .arg("init")
+                .arg("--l1-chain-id")
+                .arg(config.l1_chain_id.to_string())
+                .arg("--l2-chain-ids")
+                .arg(config.l2_chain_id.to_string())
+                .arg("--intent-type")
+                .arg("custom")
+                .arg("--workdir")
+                .arg(&workdir),
+            "initialize op-deployer workdir",
+        )?;
+
+        fs::copy(&paths.l2_intent, workdir.join("intent.toml"))
+            .wrap_err("Failed to copy intent.toml into op-deployer workdir")?;
+
+        run_command(
+            Command::new("op-deployer")
+                .arg("apply")
+                .arg("--workdir")
+                .arg(&workdir)
+                .arg("--deployment-target")
+                .arg("genesis"),
+            "generate offline L2 deployment artifacts",
+        )?;
+
+        capture_stdout_to_path(
+            Command::new("op-deployer")
+                .arg("inspect")
+                .arg("genesis")
+                .arg("--workdir")
+                .arg(&workdir)
+                .arg(config.l2_chain_id.to_string()),
+            &paths.l2_genesis,
+            "inspect L2 genesis",
+        )?;
+        capture_stdout_to_path(
+            Command::new("op-deployer")
+                .arg("inspect")
+                .arg("rollup")
+                .arg("--workdir")
+                .arg(&workdir)
+                .arg(config.l2_chain_id.to_string()),
+            &paths.l2_rollup,
+            "inspect rollup config",
+        )?;
+        capture_stdout_to_path(
+            Command::new("op-deployer")
+                .arg("inspect")
+                .arg("l1")
+                .arg("--workdir")
+                .arg(&workdir)
+                .arg(config.l2_chain_id.to_string()),
+            &paths.l1_addresses,
+            "inspect L1 contract addresses",
+        )?;
+
+        Ok(())
+    }
+}
+
+fn write_chain_ids(path: &Path, chain_ids: ChainIds) -> Result<()> {
+    write_json(path, &chain_ids)
+}
+
+fn write_accounts_manifest(path: &Path) -> Result<()> {
+    #[derive(Serialize)]
+    struct AccountEntry {
+        name: &'static str,
+        address: String,
+        private_key: String,
+    }
+
+    #[derive(Serialize)]
+    struct AccountsManifest {
+        mnemonic: &'static str,
+        funded_accounts: Vec<AccountEntry>,
+    }
+
+    let accounts = derived_accounts();
+    let funded_accounts = [
+        ("deployer", accounts[0]),
+        ("account-1", accounts[1]),
+        ("account-2", accounts[2]),
+        ("account-3", accounts[3]),
+        ("account-4", accounts[4]),
+        ("sequencer", accounts[5]),
+        ("batcher", accounts[6]),
+        ("proposer", accounts[7]),
+        ("challenger", accounts[8]),
+        ("builder", accounts[9]),
+    ]
+    .into_iter()
+    .map(|(name, account)| AccountEntry {
+        name,
+        address: format!("{:#x}", account.address),
+        private_key: format!("0x{}", hex::encode(account.private_key)),
+    })
+    .collect();
+
+    let manifest = AccountsManifest { mnemonic: TEST_MNEMONIC, funded_accounts };
+    write_json(path, &manifest)
+}
+
+fn write_jwt_secret(path: &Path) -> Result<()> {
+    let secret: [u8; 32] = rand::random();
+    fs::write(path, format!("{}\n", hex::encode(secret)))
+        .wrap_err_with(|| format!("Failed to write {}", path.display()))
+}
+
+fn write_l1_execution_genesis(
+    config: &ResolvedConfig,
+    genesis_path: &Path,
+    chain_config_path: &Path,
+) -> Result<()> {
+    let genesis = l1_el_genesis(config.l1_chain_id, config.genesis_time, config.prefund_balance);
+    let chain_config = genesis
+        .get("config")
+        .cloned()
+        .context("Generated L1 genesis is missing the `config` field")?;
+
+    write_json(genesis_path, &genesis)?;
+    write_json(chain_config_path, &chain_config)?;
+    Ok(())
+}
+
+fn write_l1_consensus_inputs(
+    config: &ResolvedConfig,
+    beacon_config_path: &Path,
+    mnemonics_path: &Path,
+) -> Result<()> {
+    let beacon_config =
+        l1_beacon_config_yaml(config.l1_chain_id, config.genesis_time, config.slot_duration);
+    fs::write(beacon_config_path, beacon_config)
+        .wrap_err_with(|| format!("Failed to write {}", beacon_config_path.display()))?;
+    fs::write(
+        mnemonics_path,
+        format!("- mnemonic: \"{TEST_MNEMONIC}\"\n  count: 1\n"),
+    )
+    .wrap_err_with(|| format!("Failed to write {}", mnemonics_path.display()))
+}
+
+fn write_l2_intent(config: &ResolvedConfig, path: &Path) -> Result<()> {
+    let intent = l2_intent_toml(config.l1_chain_id, config.l2_chain_id);
+    fs::write(path, intent).wrap_err_with(|| format!("Failed to write {}", path.display()))
+}
+
+fn patch_base_v1_activation(config: &ResolvedConfig, paths: &GenesisPaths) -> Result<()> {
+    let Some(base_v1_block) = config.l2_base_v1_block else {
+        return Ok(());
+    };
+
+    let mut rollup: Value = read_json(&paths.l2_rollup)?;
+    let mut genesis: Value = read_json(&paths.l2_genesis)?;
+
+    let block_time = rollup
+        .get("block_time")
+        .and_then(Value::as_u64)
+        .context("rollup.json is missing `block_time`")?;
+    let l2_genesis_time = rollup
+        .get("genesis")
+        .and_then(Value::as_object)
+        .and_then(|genesis| genesis.get("l2_time"))
+        .and_then(Value::as_u64)
+        .context("rollup.json is missing `genesis.l2_time`")?;
+
+    let base_v1_time = l2_genesis_time + (block_time * base_v1_block);
+    let rollup_base = rollup
+        .as_object_mut()
+        .expect("rollup config should be a JSON object")
+        .entry("base")
+        .or_insert_with(|| json!({}));
+    rollup_base
+        .as_object_mut()
+        .expect("rollup base config should be an object")
+        .insert("v1".to_string(), Value::from(base_v1_time));
+
+    let genesis_config = genesis
+        .get_mut("config")
+        .and_then(Value::as_object_mut)
+        .context("genesis.json is missing `config`")?;
+    genesis_config.insert("osakaTime".to_string(), Value::from(base_v1_time));
+    let base_config = genesis_config.entry("base".to_string()).or_insert_with(|| json!({}));
+    base_config
+        .as_object_mut()
+        .expect("genesis base config should be an object")
+        .insert("v1".to_string(), Value::from(base_v1_time));
+
+    write_json(&paths.l2_rollup, &rollup)?;
+    write_json(&paths.l2_genesis, &genesis)?;
+    Ok(())
+}
+
+fn write_rollup_conductor(paths: &GenesisPaths) -> Result<()> {
+    let mut rollup: Value = read_json(&paths.l2_rollup)?;
+    if let Some(object) = rollup.as_object_mut() {
+        object.remove("base");
+    }
+    write_json(&paths.l2_rollup_conductor, &rollup)
+}
+
+fn write_json(path: &Path, value: &impl Serialize) -> Result<()> {
+    let contents = serde_json::to_string_pretty(value).wrap_err("Failed to serialize JSON")?;
+    fs::write(path, format!("{contents}\n"))
+        .wrap_err_with(|| format!("Failed to write {}", path.display()))
+}
+
+fn read_json(path: &Path) -> Result<Value> {
+    let contents = fs::read_to_string(path)
+        .wrap_err_with(|| format!("Failed to read {}", path.display()))?;
+    serde_json::from_str(&contents)
+        .wrap_err_with(|| format!("Failed to parse JSON at {}", path.display()))
+}
+
+fn reorganize_validator_data(validator_keys_dir: &Path, validator_data_dir: &Path) -> Result<()> {
+    let validators_dir = validator_data_dir.join("validators");
+    let secrets_dir = validator_data_dir.join("secrets");
+    fs::create_dir_all(&validators_dir)
+        .wrap_err_with(|| format!("Failed to create {}", validators_dir.display()))?;
+    fs::create_dir_all(&secrets_dir)
+        .wrap_err_with(|| format!("Failed to create {}", secrets_dir.display()))?;
+
+    let keys_root = validator_keys_dir.join("keys");
+    let secrets_root = validator_keys_dir.join("secrets");
+
+    for entry in fs::read_dir(&keys_root)
+        .wrap_err_with(|| format!("Failed to read {}", keys_root.display()))?
+    {
+        let entry = entry.wrap_err("Failed to read validator key entry")?;
+        let key_dir = entry.path();
+        if !key_dir.is_dir() {
+            continue;
+        }
+
+        let pubkey = entry.file_name();
+        let pubkey_str = pubkey.to_string_lossy();
+        let validator_dir = validators_dir.join(pubkey_str.as_ref());
+        fs::create_dir_all(&validator_dir)
+            .wrap_err_with(|| format!("Failed to create {}", validator_dir.display()))?;
+
+        fs::copy(key_dir.join("voting-keystore.json"), validator_dir.join("voting-keystore.json"))
+            .wrap_err("Failed to copy voting-keystore.json")?;
+
+        let secret_src = secrets_root.join(pubkey_str.as_ref());
+        if secret_src.exists() {
+            fs::copy(&secret_src, secrets_dir.join(pubkey_str.as_ref()))
+                .wrap_err("Failed to copy validator password")?;
+        }
+    }
+
+    Ok(())
+}
+
+fn run_command(command: &mut Command, purpose: &str) -> Result<()> {
+    command.stdout(Stdio::null()).stderr(Stdio::piped());
+    let output = command.output().wrap_err_with(|| format!("Failed to {purpose}"))?;
+    ensure!(
+        output.status.success(),
+        "{purpose} failed: {}",
+        String::from_utf8_lossy(&output.stderr).trim()
+    );
+    Ok(())
+}
+
+fn capture_stdout_to_path(command: &mut Command, path: &Path, purpose: &str) -> Result<()> {
+    let output = command.output().wrap_err_with(|| format!("Failed to {purpose}"))?;
+    ensure!(
+        output.status.success(),
+        "{purpose} failed: {}",
+        String::from_utf8_lossy(&output.stderr).trim()
+    );
+    fs::write(path, output.stdout).wrap_err_with(|| format!("Failed to write {}", path.display()))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+
+    use serde_json::Value;
+    use tempfile::TempDir;
+
+    use super::{GenesisPaths, generate_genesis_with_tooling, read_json};
+    use crate::config::{DeployerConfig, ResolvedConfig};
+
+    struct FakeTooling;
+
+    impl super::GenesisTooling for FakeTooling {
+        fn generate_l1_consensus_artifacts(&self, paths: &GenesisPaths) -> eyre::Result<()> {
+            fs::write(&paths.l1_cl_genesis, "fake-ssz")?;
+            let validator_dir = paths.l1_cl_dir.join("validator_data/validators/fakepubkey");
+            let secrets_dir = paths.l1_cl_dir.join("validator_data/secrets");
+            fs::create_dir_all(&validator_dir)?;
+            fs::create_dir_all(&secrets_dir)?;
+            fs::write(validator_dir.join("voting-keystore.json"), "{}")?;
+            fs::write(secrets_dir.join("fakepubkey"), "password")?;
+            fs::write(paths.l1_cl_dir.join("deploy_block.txt"), "0\n")?;
+            fs::write(paths.l1_cl_dir.join("deposit_contract_block.txt"), "0\n")?;
+            Ok(())
+        }
+
+        fn generate_l2_genesis_artifacts(
+            &self,
+            config: &ResolvedConfig,
+            paths: &GenesisPaths,
+        ) -> eyre::Result<()> {
+            fs::write(
+                &paths.l2_genesis,
+                serde_json::to_string_pretty(&serde_json::json!({
+                    "config": {
+                        "chainId": config.l2_chain_id,
+                        "osakaTime": 0,
+                    }
+                }))?,
+            )?;
+            fs::write(
+                &paths.l2_rollup,
+                serde_json::to_string_pretty(&serde_json::json!({
+                    "block_time": 2,
+                    "genesis": {
+                        "l2_time": config.genesis_time,
+                    }
+                }))?,
+            )?;
+            fs::write(
+                &paths.l1_addresses,
+                serde_json::to_string_pretty(&serde_json::json!({
+                    "OptimismPortalProxy": format!("{:#x}", crate::devnet::role_accounts().deployer.address),
+                    "SystemConfigProxy": format!("{:#x}", crate::devnet::role_accounts().sequencer.address),
+                }))?,
+            )?;
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn generates_expected_artifacts() {
+        let tempdir = TempDir::new().expect("tempdir should be created");
+        let config = DeployerConfig {
+            output_dir: Some(tempdir.path().join("artifacts")),
+            l1_chain_id: Some(1337),
+            l2_chain_id: Some(84538453),
+            slot_duration: Some(4),
+            genesis_time: Some(1_715_000_000),
+            prefund_balance: Some("0x10".to_string()),
+            l2_base_v1_block: Some(20),
+        }
+        .resolve(None)
+        .expect("config should resolve");
+
+        let artifacts =
+            generate_genesis_with_tooling(&config, &FakeTooling).expect("genesis should succeed");
+
+        assert!(artifacts.l1_el_genesis.exists());
+        assert!(artifacts.l1_cl_config.exists());
+        assert!(artifacts.l1_cl_genesis.exists());
+        assert!(artifacts.l2_intent.exists());
+        assert!(artifacts.l2_genesis.exists());
+        assert!(artifacts.l2_rollup.exists());
+        assert!(artifacts.l2_rollup_conductor.exists());
+        assert!(artifacts.l1_addresses.exists());
+        assert!(artifacts.jwt_secret.exists());
+
+        let l1_genesis = read_json(&artifacts.l1_el_genesis).expect("l1 genesis should parse");
+        let alloc = l1_genesis
+            .get("alloc")
+            .and_then(Value::as_object)
+            .expect("alloc should exist");
+        assert!(alloc.contains_key("0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266"));
+
+        let chain_ids = read_json(&artifacts.chain_ids).expect("chain ids should parse");
+        assert_eq!(chain_ids["l1_chain_id"], 1337);
+        assert_eq!(chain_ids["l2_chain_id"], 84538453);
+
+        let rollup = read_json(&artifacts.l2_rollup).expect("rollup should parse");
+        assert_eq!(rollup["base"]["v1"], 1_715_000_040u64);
+
+        let rollup_conductor =
+            read_json(&artifacts.l2_rollup_conductor).expect("rollup conductor should parse");
+        assert!(rollup_conductor.get("base").is_none());
+    }
+}

--- a/bin/base-deployer/src/genesis.rs
+++ b/bin/base-deployer/src/genesis.rs
@@ -3,10 +3,10 @@
 use std::{
     fs,
     path::{Path, PathBuf},
-    process::{Command, Stdio},
+    process::Command,
 };
 
-use eyre::{ContextCompat, Result, WrapErr, ensure};
+use eyre::{ContextCompat, Result, WrapErr};
 use serde::Serialize;
 use serde_json::{Value, json};
 
@@ -14,6 +14,7 @@ use crate::config::{ChainIds, ResolvedConfig};
 use crate::devnet::{
     TEST_MNEMONIC, derived_accounts, l1_beacon_config_yaml, l1_el_genesis, l2_intent_toml,
 };
+use crate::external::{capture_stdout_to_path, run_command};
 
 /// Paths to genesis artifacts produced by `base-deployer genesis`.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -377,53 +378,11 @@ fn patch_base_v1_activation(config: &ResolvedConfig, paths: &GenesisPaths) -> Re
         return Ok(());
     };
 
-    let mut rollup: Value = read_json(&paths.l2_rollup)?;
-    let mut genesis: Value = read_json(&paths.l2_genesis)?;
-
-    let block_time = rollup
-        .get("block_time")
-        .and_then(Value::as_u64)
-        .context("rollup.json is missing `block_time`")?;
-    let l2_genesis_time = rollup
-        .get("genesis")
-        .and_then(Value::as_object)
-        .and_then(|genesis| genesis.get("l2_time"))
-        .and_then(Value::as_u64)
-        .context("rollup.json is missing `genesis.l2_time`")?;
-
-    let base_v1_time = l2_genesis_time + (block_time * base_v1_block);
-    let rollup_base = rollup
-        .as_object_mut()
-        .expect("rollup config should be a JSON object")
-        .entry("base")
-        .or_insert_with(|| json!({}));
-    rollup_base
-        .as_object_mut()
-        .expect("rollup base config should be an object")
-        .insert("v1".to_string(), Value::from(base_v1_time));
-
-    let genesis_config = genesis
-        .get_mut("config")
-        .and_then(Value::as_object_mut)
-        .context("genesis.json is missing `config`")?;
-    genesis_config.insert("osakaTime".to_string(), Value::from(base_v1_time));
-    let base_config = genesis_config.entry("base".to_string()).or_insert_with(|| json!({}));
-    base_config
-        .as_object_mut()
-        .expect("genesis base config should be an object")
-        .insert("v1".to_string(), Value::from(base_v1_time));
-
-    write_json(&paths.l2_rollup, &rollup)?;
-    write_json(&paths.l2_genesis, &genesis)?;
-    Ok(())
+    patch_base_v1_activation_files(&paths.l2_rollup, &paths.l2_genesis, base_v1_block)
 }
 
 fn write_rollup_conductor(paths: &GenesisPaths) -> Result<()> {
-    let mut rollup: Value = read_json(&paths.l2_rollup)?;
-    if let Some(object) = rollup.as_object_mut() {
-        object.remove("base");
-    }
-    write_json(&paths.l2_rollup_conductor, &rollup)
+    write_rollup_conductor_file(&paths.l2_rollup, &paths.l2_rollup_conductor)
 }
 
 fn write_json(path: &Path, value: &impl Serialize) -> Result<()> {
@@ -478,25 +437,62 @@ fn reorganize_validator_data(validator_keys_dir: &Path, validator_data_dir: &Pat
     Ok(())
 }
 
-fn run_command(command: &mut Command, purpose: &str) -> Result<()> {
-    command.stdout(Stdio::null()).stderr(Stdio::piped());
-    let output = command.output().wrap_err_with(|| format!("Failed to {purpose}"))?;
-    ensure!(
-        output.status.success(),
-        "{purpose} failed: {}",
-        String::from_utf8_lossy(&output.stderr).trim()
-    );
-    Ok(())
+/// Applies the optional Base V1 activation timestamp to rollup and genesis files.
+pub(crate) fn patch_base_v1_activation_files(
+    rollup_path: &Path,
+    genesis_path: &Path,
+    base_v1_block: u64,
+) -> Result<()> {
+    let mut rollup: Value = read_json(rollup_path)?;
+    let mut genesis: Value = read_json(genesis_path)?;
+
+    let block_time = rollup
+        .get("block_time")
+        .and_then(Value::as_u64)
+        .context("rollup.json is missing `block_time`")?;
+    let l2_genesis_time = rollup
+        .get("genesis")
+        .and_then(Value::as_object)
+        .and_then(|genesis| genesis.get("l2_time"))
+        .and_then(Value::as_u64)
+        .context("rollup.json is missing `genesis.l2_time`")?;
+
+    let base_v1_time = l2_genesis_time + (block_time * base_v1_block);
+    let rollup_base = rollup
+        .as_object_mut()
+        .expect("rollup config should be a JSON object")
+        .entry("base")
+        .or_insert_with(|| json!({}));
+    rollup_base
+        .as_object_mut()
+        .expect("rollup base config should be an object")
+        .insert("v1".to_string(), Value::from(base_v1_time));
+
+    let genesis_config = genesis
+        .get_mut("config")
+        .and_then(Value::as_object_mut)
+        .context("genesis.json is missing `config`")?;
+    genesis_config.insert("osakaTime".to_string(), Value::from(base_v1_time));
+    let base_config = genesis_config.entry("base".to_string()).or_insert_with(|| json!({}));
+    base_config
+        .as_object_mut()
+        .expect("genesis base config should be an object")
+        .insert("v1".to_string(), Value::from(base_v1_time));
+
+    write_json(rollup_path, &rollup)?;
+    write_json(genesis_path, &genesis)
 }
 
-fn capture_stdout_to_path(command: &mut Command, path: &Path, purpose: &str) -> Result<()> {
-    let output = command.output().wrap_err_with(|| format!("Failed to {purpose}"))?;
-    ensure!(
-        output.status.success(),
-        "{purpose} failed: {}",
-        String::from_utf8_lossy(&output.stderr).trim()
-    );
-    fs::write(path, output.stdout).wrap_err_with(|| format!("Failed to write {}", path.display()))
+/// Writes an op-conductor compatible rollup config by stripping Base-specific fields.
+pub(crate) fn write_rollup_conductor_file(
+    rollup_path: &Path,
+    conductor_path: &Path,
+) -> Result<()> {
+    let mut rollup: Value = read_json(rollup_path)?;
+    if let Some(object) = rollup.as_object_mut() {
+        object.remove("base");
+    }
+    write_json(conductor_path, &rollup)
 }
 
 #[cfg(test)]

--- a/bin/base-deployer/src/main.rs
+++ b/bin/base-deployer/src/main.rs
@@ -6,10 +6,12 @@
 mod cli;
 mod config;
 mod devnet;
+mod deploy;
+mod external;
 mod genesis;
 
 use clap::Parser;
-use eyre::{Result, WrapErr, bail};
+use eyre::{ContextCompat, Result, WrapErr, bail};
 
 use self::cli::{Cli, Commands};
 
@@ -35,8 +37,27 @@ async fn run() -> Result<()> {
             println!("Generated devnet genesis artifacts in {}", artifacts.output_dir.display());
             Ok(())
         }
-        Commands::DeployL1 { .. } => bail!("`base-deployer deploy-l1` is not implemented yet"),
-        Commands::DeployL2 { .. } => bail!("`base-deployer deploy-l2` is not implemented yet"),
+        Commands::DeployL1 { l1_rpc } => {
+            let l1_rpc = l1_rpc.context("`base-deployer deploy-l1` requires --l1-rpc")?;
+            let output = deploy::deploy_l1(config, cli.output_dir, &l1_rpc)
+                .await
+                .wrap_err("Failed to deploy L1 contracts")?;
+            println!(
+                "Deployed L1 contracts. Manifest: {}",
+                output.manifest_path.display()
+            );
+            Ok(())
+        }
+        Commands::DeployL2 { l1_rpc } => {
+            let output = deploy::deploy_l2(config, cli.output_dir, l1_rpc.as_deref())
+                .await
+                .wrap_err("Failed to extract L2 deployment artifacts")?;
+            println!(
+                "Generated L2 deployment artifacts. Genesis: {}",
+                output.genesis_path.display()
+            );
+            Ok(())
+        }
         Commands::Devnet { .. } => bail!("`base-deployer devnet` is not implemented yet"),
         Commands::Status { .. } => bail!("`base-deployer status` is not implemented yet"),
     }

--- a/bin/base-deployer/src/main.rs
+++ b/bin/base-deployer/src/main.rs
@@ -9,9 +9,10 @@ mod devnet;
 mod deploy;
 mod external;
 mod genesis;
+mod runtime;
 
 use clap::Parser;
-use eyre::{ContextCompat, Result, WrapErr, bail};
+use eyre::{ContextCompat, Result, WrapErr};
 
 use self::cli::{Cli, Commands};
 
@@ -27,7 +28,7 @@ async fn main() {
 
 async fn run() -> Result<()> {
     let cli = Cli::parse();
-    let config = load_config(cli.config.as_deref())?;
+    let config = apply_cli_overrides(load_config(cli.config.as_deref())?, &cli);
 
     match cli.command {
         Commands::Genesis => {
@@ -58,11 +59,69 @@ async fn run() -> Result<()> {
             );
             Ok(())
         }
-        Commands::Devnet { .. } => bail!("`base-deployer devnet` is not implemented yet"),
-        Commands::Status { .. } => bail!("`base-deployer status` is not implemented yet"),
+        Commands::Devnet { l1_rpc } => {
+            match runtime::start_devnet(config, l1_rpc.as_deref())
+                .await
+                .wrap_err("Failed to start devnet")?
+            {
+                runtime::DevnetStartResult::Local(report) => {
+                    println!("{}", runtime::format_local_report(&report));
+                }
+                runtime::DevnetStartResult::External(report) => {
+                    println!(
+                        "Prepared external-L1 deployment artifacts.\nManifest: {}\nGenesis: {}\nRollup: {}",
+                        report.manifest_path.display(),
+                        report.genesis_path.display(),
+                        report.rollup_path.display(),
+                    );
+                }
+            }
+            Ok(())
+        }
+        Commands::Status { json } => {
+            let status = runtime::collect_status()
+                .await
+                .wrap_err("Failed to inspect devnet status")?;
+            if json {
+                println!(
+                    "{}",
+                    serde_json::to_string_pretty(&status)
+                        .wrap_err("Failed to serialize status report")?
+                );
+            } else {
+                println!("{}", runtime::format_local_report(&status));
+            }
+            Ok(())
+        }
     }
 }
 
 fn load_config(path: Option<&std::path::Path>) -> Result<config::DeployerConfig> {
     path.map(config::DeployerConfig::load).transpose().map(Option::unwrap_or_default)
+}
+
+fn apply_cli_overrides(mut config: config::DeployerConfig, cli: &Cli) -> config::DeployerConfig {
+    if let Some(l1_chain_id) = cli.l1_chain_id {
+        config.l1_chain_id = Some(l1_chain_id);
+    }
+    if let Some(l2_chain_id) = cli.l2_chain_id {
+        config.l2_chain_id = Some(l2_chain_id);
+    }
+    if let Some(slot_duration) = cli.slot_duration {
+        config.slot_duration = Some(slot_duration);
+    }
+    if let Some(genesis_time) = cli.genesis_time {
+        config.genesis_time = Some(genesis_time);
+    }
+    if let Some(ref prefund_balance) = cli.prefund_balance {
+        config.prefund_balance = Some(prefund_balance.clone());
+    }
+    if let Some(l2_base_v1_block) = cli.l2_base_v1_block {
+        config.l2_base_v1_block = Some(l2_base_v1_block);
+    }
+    if let Some(ref output_dir) = cli.output_dir {
+        config.output_dir = Some(output_dir.clone());
+    }
+
+    config
 }

--- a/bin/base-deployer/src/main.rs
+++ b/bin/base-deployer/src/main.rs
@@ -1,0 +1,33 @@
+#![doc = include_str!("../README.md")]
+#![doc(issue_tracker_base_url = "https://github.com/base/base/issues/")]
+#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
+#![cfg_attr(not(test), warn(unused_crate_dependencies))]
+
+mod cli;
+
+use clap::Parser;
+use eyre::{Result, bail};
+
+use self::cli::{Cli, Commands};
+
+#[tokio::main]
+async fn main() {
+    base_cli_utils::init_common!();
+
+    if let Err(err) = run().await {
+        eprintln!("Error: {err:?}");
+        std::process::exit(1);
+    }
+}
+
+async fn run() -> Result<()> {
+    let cli = Cli::parse();
+
+    match cli.command {
+        Commands::Genesis => bail!("`base-deployer genesis` is not implemented yet"),
+        Commands::DeployL1 { .. } => bail!("`base-deployer deploy-l1` is not implemented yet"),
+        Commands::DeployL2 { .. } => bail!("`base-deployer deploy-l2` is not implemented yet"),
+        Commands::Devnet { .. } => bail!("`base-deployer devnet` is not implemented yet"),
+        Commands::Status { .. } => bail!("`base-deployer status` is not implemented yet"),
+    }
+}

--- a/bin/base-deployer/src/main.rs
+++ b/bin/base-deployer/src/main.rs
@@ -4,9 +4,12 @@
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
 
 mod cli;
+mod config;
+mod devnet;
+mod genesis;
 
 use clap::Parser;
-use eyre::{Result, bail};
+use eyre::{Result, WrapErr, bail};
 
 use self::cli::{Cli, Commands};
 
@@ -22,12 +25,23 @@ async fn main() {
 
 async fn run() -> Result<()> {
     let cli = Cli::parse();
+    let config = load_config(cli.config.as_deref())?;
 
     match cli.command {
-        Commands::Genesis => bail!("`base-deployer genesis` is not implemented yet"),
+        Commands::Genesis => {
+            let resolved = config.resolve(cli.output_dir)?;
+            let artifacts = genesis::generate_genesis(&resolved)
+                .wrap_err("Failed to generate devnet genesis artifacts")?;
+            println!("Generated devnet genesis artifacts in {}", artifacts.output_dir.display());
+            Ok(())
+        }
         Commands::DeployL1 { .. } => bail!("`base-deployer deploy-l1` is not implemented yet"),
         Commands::DeployL2 { .. } => bail!("`base-deployer deploy-l2` is not implemented yet"),
         Commands::Devnet { .. } => bail!("`base-deployer devnet` is not implemented yet"),
         Commands::Status { .. } => bail!("`base-deployer status` is not implemented yet"),
     }
+}
+
+fn load_config(path: Option<&std::path::Path>) -> Result<config::DeployerConfig> {
+    path.map(config::DeployerConfig::load).transpose().map(Option::unwrap_or_default)
 }

--- a/bin/base-deployer/src/runtime.rs
+++ b/bin/base-deployer/src/runtime.rs
@@ -1,0 +1,333 @@
+//! Docker Compose-based devnet orchestration and status checks.
+
+use std::{
+    collections::BTreeMap,
+    fs,
+    path::{Path, PathBuf},
+    process::Command,
+    time::Duration,
+};
+
+use alloy_network::Ethereum;
+use alloy_provider::{Provider, RootProvider};
+use alloy_rpc_client::RpcClient;
+use eyre::{Result, WrapErr, bail, ensure};
+use serde::Serialize;
+use tokio::time::{sleep, timeout};
+use url::Url;
+
+use crate::{config::DeployerConfig, deploy, devnet::role_accounts};
+
+const DOCKER_COMPOSE_FILE: &str = "etc/docker/docker-compose.yml";
+const DEVNET_ENV_FILE: &str = "etc/docker/devnet-env";
+const DEVNET_DATA_DIR: &str = ".devnet";
+const CONTAINER_START_TIMEOUT: Duration = Duration::from_secs(300);
+const PROBE_INTERVAL: Duration = Duration::from_secs(2);
+
+/// Result of starting a devnet.
+#[derive(Debug, Clone)]
+pub(crate) enum DevnetStartResult {
+    /// Local Docker Compose devnet is running.
+    Local(StatusReport),
+    /// External L1 artifacts were prepared successfully.
+    External(ExternalArtifactsReport),
+}
+
+/// Summary of artifacts generated for an external L1.
+#[derive(Debug, Clone, Serialize)]
+pub(crate) struct ExternalArtifactsReport {
+    /// Path to the live deployment manifest.
+    pub(crate) manifest_path: PathBuf,
+    /// Path to the generated L2 genesis file.
+    pub(crate) genesis_path: PathBuf,
+    /// Path to the generated rollup config.
+    pub(crate) rollup_path: PathBuf,
+}
+
+/// Summary of the local devnet runtime status.
+#[derive(Debug, Clone, Serialize)]
+pub(crate) struct StatusReport {
+    /// Running Docker Compose services.
+    pub(crate) running_services: Vec<String>,
+    /// L1 RPC probe result.
+    pub(crate) l1: RpcEndpointStatus,
+    /// L2 builder RPC probe result.
+    pub(crate) l2_builder: RpcEndpointStatus,
+    /// L2 client RPC probe result.
+    pub(crate) l2_client: RpcEndpointStatus,
+}
+
+/// Health and chain information for an RPC endpoint.
+#[derive(Debug, Clone, Serialize)]
+pub(crate) struct RpcEndpointStatus {
+    /// Endpoint label.
+    pub(crate) name: String,
+    /// Endpoint URL.
+    pub(crate) url: String,
+    /// Whether the endpoint responded successfully.
+    pub(crate) reachable: bool,
+    /// Chain ID when the probe succeeded.
+    pub(crate) chain_id: Option<u64>,
+    /// Latest block number when the probe succeeded.
+    pub(crate) block_number: Option<u64>,
+    /// Human-readable error when the probe failed.
+    pub(crate) error: Option<String>,
+}
+
+/// Starts a devnet locally or prepares artifacts for an external L1.
+pub(crate) async fn start_devnet(
+    config: DeployerConfig,
+    l1_rpc: Option<&str>,
+) -> Result<DevnetStartResult> {
+    if let Some(l1_rpc) = l1_rpc {
+        let l1 = deploy::deploy_l1(config.clone(), None, l1_rpc).await?;
+        let l2 = deploy::deploy_l2(config, None, Some(l1_rpc)).await?;
+        return Ok(DevnetStartResult::External(ExternalArtifactsReport {
+            manifest_path: l1.manifest_path,
+            genesis_path: l2.genesis_path,
+            rollup_path: l2.rollup_path,
+        }));
+    }
+
+    let repo_root = find_repo_root()?;
+    let devnet_dir = repo_root.join(DEVNET_DATA_DIR);
+
+    run_best_effort(
+        Command::new("docker")
+            .current_dir(&repo_root)
+            .args(compose_args())
+            .arg("down"),
+    );
+    reset_devnet_data_dir(&repo_root, &devnet_dir)?;
+
+    run_checked(
+        Command::new("docker")
+            .current_dir(&repo_root)
+            .args(compose_args())
+            .arg("up")
+            .arg("-d")
+            .arg("--build")
+            .arg("--scale")
+            .arg("contender=0"),
+        "start local devnet with Docker Compose",
+    )?;
+
+    let status = timeout(CONTAINER_START_TIMEOUT, async {
+        loop {
+            let status = collect_status().await?;
+            if status.l1.reachable && status.l2_builder.reachable && status.l2_client.reachable {
+                return Ok::<_, eyre::Error>(status);
+            }
+            sleep(PROBE_INTERVAL).await;
+        }
+    })
+    .await
+    .wrap_err("Timed out waiting for the local devnet to become healthy")??;
+
+    Ok(DevnetStartResult::Local(status))
+}
+
+/// Collects the current local devnet status from Docker and the public RPC endpoints.
+pub(crate) async fn collect_status() -> Result<StatusReport> {
+    let repo_root = find_repo_root()?;
+    let env = read_env_file(&repo_root.join(DEVNET_ENV_FILE))?;
+    let running_services = running_services(&repo_root)?;
+
+    Ok(StatusReport {
+        running_services,
+        l1: probe_rpc("l1", env_value(&env, "L1_RPC_URL")?).await,
+        l2_builder: probe_rpc("l2_builder", env_value(&env, "L2_BUILDER_RPC_URL")?).await,
+        l2_client: probe_rpc("l2_client", env_value(&env, "L2_CLIENT_RPC_URL")?).await,
+    })
+}
+
+fn find_repo_root() -> Result<PathBuf> {
+    let mut current = std::env::current_dir().wrap_err("Failed to read current directory")?;
+
+    loop {
+        if current.join(DOCKER_COMPOSE_FILE).exists() && current.join("Cargo.toml").exists() {
+            return Ok(current);
+        }
+        if !current.pop() {
+            break;
+        }
+    }
+
+    bail!("Could not find repository root containing {DOCKER_COMPOSE_FILE}")
+}
+
+fn compose_args() -> [&'static str; 5] {
+    ["compose", "--env-file", DEVNET_ENV_FILE, "-f", DOCKER_COMPOSE_FILE]
+}
+
+fn running_services(repo_root: &Path) -> Result<Vec<String>> {
+    let output = Command::new("docker")
+        .current_dir(repo_root)
+        .args(compose_args())
+        .arg("ps")
+        .arg("--services")
+        .arg("--status")
+        .arg("running")
+        .output()
+        .wrap_err("Failed to query Docker Compose status")?;
+
+    ensure!(
+        output.status.success(),
+        "docker compose ps failed: {}",
+        String::from_utf8_lossy(&output.stderr).trim()
+    );
+
+    Ok(String::from_utf8_lossy(&output.stdout)
+        .lines()
+        .filter(|line| !line.trim().is_empty())
+        .map(str::to_owned)
+        .collect())
+}
+
+fn reset_devnet_data_dir(repo_root: &Path, devnet_dir: &Path) -> Result<()> {
+    ensure!(
+        devnet_dir.starts_with(repo_root),
+        "Refusing to clear {} because it is outside the repository root",
+        devnet_dir.display()
+    );
+
+    if devnet_dir.exists() {
+        fs::remove_dir_all(devnet_dir)
+            .wrap_err_with(|| format!("Failed to remove {}", devnet_dir.display()))?;
+    }
+    fs::create_dir_all(devnet_dir)
+        .wrap_err_with(|| format!("Failed to create {}", devnet_dir.display()))
+}
+
+fn run_best_effort(command: &mut Command) {
+    let _ = command.status();
+}
+
+fn run_checked(command: &mut Command, purpose: &str) -> Result<()> {
+    let output = command.output().wrap_err_with(|| format!("Failed to {purpose}"))?;
+    ensure!(
+        output.status.success(),
+        "{purpose} failed: {}",
+        String::from_utf8_lossy(&output.stderr).trim()
+    );
+    Ok(())
+}
+
+fn read_env_file(path: &Path) -> Result<BTreeMap<String, String>> {
+    let contents =
+        fs::read_to_string(path).wrap_err_with(|| format!("Failed to read {}", path.display()))?;
+    let mut values = BTreeMap::new();
+
+    for line in contents.lines() {
+        let trimmed = line.trim();
+        if trimmed.is_empty() || trimmed.starts_with('#') {
+            continue;
+        }
+
+        if let Some((key, value)) = trimmed.split_once('=') {
+            values.insert(key.trim().to_string(), value.trim().trim_matches('"').to_string());
+        }
+    }
+
+    Ok(values)
+}
+
+fn env_value<'a>(env: &'a BTreeMap<String, String>, key: &str) -> Result<&'a str> {
+    env.get(key)
+        .map(String::as_str)
+        .ok_or_else(|| eyre::eyre!("Missing `{key}` in {DEVNET_ENV_FILE}"))
+}
+
+async fn probe_rpc(name: &str, url: &str) -> RpcEndpointStatus {
+    let parsed = match url.parse::<Url>() {
+        Ok(url) => url,
+        Err(err) => {
+            return RpcEndpointStatus {
+                name: name.to_string(),
+                url: url.to_string(),
+                reachable: false,
+                chain_id: None,
+                block_number: None,
+                error: Some(format!("invalid URL: {err}")),
+            };
+        }
+    };
+
+    let provider = RootProvider::<Ethereum>::new(RpcClient::builder().http(parsed));
+    match provider.get_chain_id().await {
+        Ok(chain_id) => match provider.get_block_number().await {
+            Ok(block_number) => RpcEndpointStatus {
+                name: name.to_string(),
+                url: url.to_string(),
+                reachable: true,
+                chain_id: Some(chain_id),
+                block_number: Some(block_number),
+                error: None,
+            },
+            Err(err) => RpcEndpointStatus {
+                name: name.to_string(),
+                url: url.to_string(),
+                reachable: false,
+                chain_id: Some(chain_id),
+                block_number: None,
+                error: Some(err.to_string()),
+            },
+        },
+        Err(err) => RpcEndpointStatus {
+            name: name.to_string(),
+            url: url.to_string(),
+            reachable: false,
+            chain_id: None,
+            block_number: None,
+            error: Some(err.to_string()),
+        },
+    }
+}
+
+/// Returns a short, human-readable summary of local devnet connection details.
+pub(crate) fn format_local_report(report: &StatusReport) -> String {
+    let roles = role_accounts();
+    format!(
+        "Services: {}\nL1 RPC: {} (chain {}, block {})\nL2 Builder RPC: {} (chain {}, block {})\nL2 Client RPC: {} (chain {}, block {})\nFunded deployer: {:#x}\nFunded sequencer: {:#x}",
+        report.running_services.join(", "),
+        report.l1.url,
+        report.l1.chain_id.unwrap_or_default(),
+        report.l1.block_number.unwrap_or_default(),
+        report.l2_builder.url,
+        report.l2_builder.chain_id.unwrap_or_default(),
+        report.l2_builder.block_number.unwrap_or_default(),
+        report.l2_client.url,
+        report.l2_client.chain_id.unwrap_or_default(),
+        report.l2_client.block_number.unwrap_or_default(),
+        roles.deployer.address,
+        roles.sequencer.address,
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+
+    use tempfile::TempDir;
+
+    use super::read_env_file;
+
+    #[test]
+    fn parses_env_file() {
+        let tempdir = TempDir::new().expect("tempdir should exist");
+        let env_path = tempdir.path().join("devnet-env");
+        fs::write(
+            &env_path,
+            "\
+# comment
+L1_RPC_URL=http://localhost:4545
+L2_BUILDER_RPC_URL=http://localhost:7545
+",
+        )
+        .expect("env file should be written");
+
+        let values = read_env_file(&env_path).expect("env file should parse");
+        assert_eq!(values["L1_RPC_URL"], "http://localhost:4545");
+        assert_eq!(values["L2_BUILDER_RPC_URL"], "http://localhost:7545");
+    }
+}

--- a/bin/base-deployer/tests/devnet.rs
+++ b/bin/base-deployer/tests/devnet.rs
@@ -1,0 +1,82 @@
+//! Integration tests for the `base-deployer` binary.
+
+use std::{
+    fs,
+    path::{Path, PathBuf},
+    process::Command,
+};
+
+#[test]
+#[ignore = "requires docker compose, image builds, and open local ports"]
+fn starts_local_devnet_and_reports_status() -> Result<(), Box<dyn std::error::Error>> {
+    let repo_root = repo_root();
+    let binary = env!("CARGO_BIN_EXE_base-deployer");
+
+    cleanup_devnet(&repo_root);
+
+    let start = Command::new(binary).current_dir(&repo_root).arg("devnet").output()?;
+    if !start.status.success() {
+        return Err(format!(
+            "base-deployer devnet failed\nstdout:\n{}\nstderr:\n{}",
+            String::from_utf8_lossy(&start.stdout),
+            String::from_utf8_lossy(&start.stderr)
+        )
+        .into());
+    }
+
+    let status = Command::new(binary)
+        .current_dir(&repo_root)
+        .args(["status", "--json"])
+        .output()?;
+
+    cleanup_devnet(&repo_root);
+
+    if !status.status.success() {
+        return Err(format!(
+            "base-deployer status failed\nstdout:\n{}\nstderr:\n{}",
+            String::from_utf8_lossy(&status.stdout),
+            String::from_utf8_lossy(&status.stderr)
+        )
+        .into());
+    }
+
+    let report: serde_json::Value = serde_json::from_slice(&status.stdout)?;
+    assert!(
+        report["running_services"]
+            .as_array()
+            .is_some_and(|services| !services.is_empty()),
+        "expected running services in status report"
+    );
+    assert_eq!(report["l1"]["reachable"].as_bool(), Some(true));
+    assert_eq!(report["l2_builder"]["reachable"].as_bool(), Some(true));
+    assert_eq!(report["l2_client"]["reachable"].as_bool(), Some(true));
+
+    Ok(())
+}
+
+fn repo_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .ancestors()
+        .nth(2)
+        .expect("workspace root should exist")
+        .to_path_buf()
+}
+
+fn cleanup_devnet(repo_root: &Path) {
+    let _ = Command::new("docker")
+        .current_dir(repo_root)
+        .args([
+            "compose",
+            "--env-file",
+            "etc/docker/devnet-env",
+            "-f",
+            "etc/docker/docker-compose.yml",
+            "down",
+        ])
+        .status();
+
+    let devnet_dir = repo_root.join(".devnet");
+    if devnet_dir.exists() {
+        let _ = fs::remove_dir_all(devnet_dir);
+    }
+}

--- a/etc/docker/Dockerfile.devnet
+++ b/etc/docker/Dockerfile.devnet
@@ -33,14 +33,25 @@ RUN git clone https://github.com/protolambda/eth2-val-tools.git --branch "${ETH2
     test "$(git rev-parse HEAD)" = "${ETH2_VAL_TOOLS_COMMIT}"
 RUN go build -o /go/bin/eth2-val-tools .
 
-FROM public.ecr.aws/docker/library/alpine:3.21.3
+FROM public.ecr.aws/docker/library/rust:1.93-trixie AS rust-builder
+WORKDIR /app
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends pkg-config libssl-dev && \
+    rm -rf /var/lib/apt/lists/*
+COPY . .
+RUN cargo build --release -p base-deployer
 
-RUN apk add --no-cache bash jq openssl curl gettext
+FROM public.ecr.aws/docker/library/debian:trixie-slim
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends ca-certificates bash jq openssl curl gettext-base && \
+    rm -rf /var/lib/apt/lists/*
 
 # Copy the built binaries
 COPY --from=builder /go/bin/eth-genesis-state-generator /usr/local/bin/
 COPY --from=builder /go/bin/eth2-val-tools /usr/local/bin/
 COPY --from=builder /go/bin/op-deployer /usr/local/bin/
+COPY --from=rust-builder /app/target/release/base-deployer /usr/local/bin/
 
 # Create working directories
 RUN mkdir -p /config /output /shared /templates

--- a/etc/docker/README.md
+++ b/etc/docker/README.md
@@ -6,7 +6,7 @@ This directory contains the Dockerfiles and Compose configuration for the Base n
 
 `Dockerfile.rust-services` is the shared multi-target Dockerfile for the Debian-based Rust services. It provides `client`, `builder`, `consensus`, `proposer`, `websocket-proxy`, `ingress-rpc`, `audit-archiver`, and `batcher` targets.
 
-`Dockerfile.devnet` builds a utility image containing genesis generation tools (`eth-genesis-state-generator`, `eth2-val-tools`, `op-deployer`) and setup scripts. This image bootstraps L1 and L2 chain configurations for local development.
+`Dockerfile.devnet` builds a utility image containing genesis generation tools (`eth-genesis-state-generator`, `eth2-val-tools`, `op-deployer`) plus the `base-deployer` binary. This image bootstraps L1 and L2 chain configurations for local development.
 
 `Dockerfile.nitro-enclave` and `Dockerfile.proxyd` remain separate because they have different toolchains and runtime requirements.
 
@@ -20,6 +20,8 @@ The `docker-compose.yml` orchestrates a complete local devnet environment with b
 - The `base-batcher` for submitting L2 data to L1
 
 All services read configuration from `devnet-env` in this directory. The devnet stores chain data in `.devnet/` which is created on first run.
+
+The `setup-l1` and `setup-l2` services now invoke `base-deployer genesis` and `base-deployer deploy-l2` respectively, replacing the older shell-script entrypoints with the Rust CLI while keeping the same helper tool image.
 
 ## Usage
 

--- a/etc/docker/docker-compose.yml
+++ b/etc/docker/docker-compose.yml
@@ -13,16 +13,17 @@ services:
     container_name: setup-l1
     env_file: devnet-env
     volumes:
-      - ../../.devnet/l1/configs:/output
+      - ../../.devnet:/output
       - ../../.devnet/l1/reth:/data/l1-reth
       - ../../.devnet/l1/lighthouse:/data/l1-lighthouse
     environment:
-      - CHAIN_ID=${L1_CHAIN_ID}
+      - L1_CHAIN_ID=${L1_CHAIN_ID}
+      - L2_CHAIN_ID=${L2_CHAIN_ID}
       - SLOT_DURATION=4
       - OUTPUT_DIR=/output
       - SHARED_DIR=/output
       - L1_DATA_DIR=/data
-    entrypoint: ["/usr/local/bin/setup-l1.sh"]
+    entrypoint: ["/usr/local/bin/base-deployer", "genesis"]
 
   l1-el:
     image: ghcr.io/paradigmxyz/reth:v1.11.3
@@ -37,7 +38,7 @@ services:
       - "${L1_P2P_PORT}:${L1_P2P_PORT}"     # P2P
     volumes:
       - ../../.devnet/l1/reth:/data
-      - ../../.devnet/l1/configs:/genesis:ro
+      - ../../.devnet/l1:/genesis:ro
     entrypoint: /usr/local/bin/reth
     command:
       - node
@@ -80,7 +81,7 @@ services:
       - "${L1_CL_P2P_PORT}:${L1_CL_P2P_PORT}/udp"   # P2P UDP
     volumes:
       - ../../.devnet/l1/lighthouse:/data
-      - ../../.devnet/l1/configs:/genesis:ro
+      - ../../.devnet/l1:/genesis:ro
     command:
       - lighthouse
       - bn
@@ -120,7 +121,7 @@ services:
       l1-cl:
         condition: service_healthy
     volumes:
-      - ../../.devnet/l1/configs:/genesis
+      - ../../.devnet/l1:/genesis
     command:
       - lighthouse
       - vc
@@ -152,7 +153,7 @@ services:
       - L1_CHAIN_ID=${L1_CHAIN_ID}
       - L2_CHAIN_ID=${L2_CHAIN_ID}
       - L2_BASE_V1_BLOCK=${L2_BASE_V1_BLOCK-}
-      - OUTPUT_DIR=/devnet/l2/configs
+      - OUTPUT_DIR=/devnet
       - L2_DATA_DIR=/data
       - DEPLOYER_ADDR=${DEPLOYER_ADDR}
       - DEPLOYER_KEY=${DEPLOYER_KEY}
@@ -162,7 +163,7 @@ services:
       - CHALLENGER_ADDR=${CHALLENGER_ADDR}
       - BUILDER_P2P_KEY=${BUILDER_P2P_KEY}
       - BUILDER_ENODE_ID=${BUILDER_ENODE_ID}
-    entrypoint: ["/usr/local/bin/setup-l2.sh"]
+    entrypoint: ["/usr/local/bin/base-deployer", "deploy-l2"]
 
   base-builder:
     image: base-builder:local
@@ -182,8 +183,8 @@ services:
       - "${L2_BUILDER_METRICS_PORT}:${L2_BUILDER_METRICS_PORT}"     # Metrics
     volumes:
       - ../../.devnet/l2/builder:/data
-      - ../../.devnet/l1/configs:/genesis:ro
-      - ../../.devnet/l2/configs:/genesis/l2:ro
+      - ../../.devnet/l1:/genesis:ro
+      - ../../.devnet/l2:/genesis/l2:ro
     environment:
       - OTEL_SERVICE_NAME=base-builder
     entrypoint: /app/base-builder
@@ -246,8 +247,8 @@ services:
       - "${L2_BUILDER_CL_METRICS_PORT}:${L2_BUILDER_CL_METRICS_PORT}"  # Metrics
     volumes:
       - ../../.devnet/l2/builder-cl:/data
-      - ../../.devnet/l1/configs:/genesis:ro
-      - ../../.devnet/l2/configs:/genesis/l2:ro
+      - ../../.devnet/l1:/genesis:ro
+      - ../../.devnet/l2:/genesis/l2:ro
     entrypoint: /app/base-consensus
     command:
       - node
@@ -352,8 +353,8 @@ services:
       - "${L2_CLIENT_METRICS_PORT}:${L2_CLIENT_METRICS_PORT}"  # Metrics
     volumes:
       - ../../.devnet/l2/client:/data
-      - ../../.devnet/l1/configs:/genesis:ro
-      - ../../.devnet/l2/configs:/genesis/l2:ro
+      - ../../.devnet/l1:/genesis:ro
+      - ../../.devnet/l2:/genesis/l2:ro
     environment:
       - OTEL_SERVICE_NAME=base-client
     entrypoint: /app/base-client
@@ -422,8 +423,8 @@ services:
       - "${L2_CLIENT_CL_METRICS_PORT}:${L2_CLIENT_CL_METRICS_PORT}"  # Metrics
     volumes:
       - ../../.devnet/l2/client-cl:/data
-      - ../../.devnet/l1/configs:/genesis:ro
-      - ../../.devnet/l2/configs:/genesis/l2:ro
+      - ../../.devnet/l1:/genesis:ro
+      - ../../.devnet/l2:/genesis/l2:ro
     entrypoint: /app/base-consensus
     command:
       - node


### PR DESCRIPTION
## Summary
- add a new `base-deployer` crate with `genesis`, `deploy-l1`, `deploy-l2`, `devnet`, and `status` subcommands
- generate devnet genesis artifacts, persist live `op-deployer` state, and emit deployment manifests plus L2 rollup/genesis bundles
- add Docker Compose-based local devnet orchestration/status and switch the setup image/compose flow to invoke `base-deployer`
- document usage and the migration path away from `setup-l1` / `setup-l2`

## Why
Issue #1454 asks for a dedicated Base deployer binary that can replace the existing setup containers and provide a clearer entry point for local devnets and longer-lived deployment flows.

This PR moves the current setup behavior into a typed Rust CLI while keeping the existing compose-driven local devnet path working. The goal is to make the deployment flow easier to extend, test, and eventually evolve beyond the shell/container bootstrap scripts.

## Testing
- `cargo test -p base-deployer`
- Docker-backed integration test added at `bin/base-deployer/tests/devnet.rs` (ignored by default)

## Notes
- This is a first pass for issue #1454.
- `base-deployer devnet --l1-rpc ...` currently prepares the external-L1 deployment/artifact bundle rather than starting the full long-lived remote runtime stack.

Refs #1454
