### PR TITLE
fix(builder): drop wall-clock fallback for execution time budget

### DIFF
--- a/crates/builder/core/src/flashblocks/context.rs
+++ b/crates/builder/core/src/flashblocks/context.rs
@@ -900,9 +900,10 @@ impl OpPayloadBuilderCtx {
             info.cumulative_da_bytes_used += tx_da_size;
             // record uncompressed tx size
             info.cumulative_uncompressed_bytes += tx_uncompressed_size;
-            // record execution time (use predicted time if available, fall back to actual)
-            info.flashblock_execution_time_us +=
-                predicted_execution_time_us.unwrap_or(actual_execution_time_us);
+            // record execution time (only from predictions; unmetered txs count as zero)
+            if let Some(execution_time) = predicted_execution_time_us {
+                info.flashblock_execution_time_us += execution_time;
+            }
             // record state root gas (only from predictions)
             if let Some(sr_gas) = state_root_gas {
                 info.cumulative_state_root_gas += sr_gas;


### PR DESCRIPTION
## Summary
- When `predicted_execution_time_us` is `None` (metering data hasn't arrived), count the transaction as zero for execution time budget purposes instead of falling back to `actual_execution_time_us` (wall-clock time)
- Consistent with `is_tx_over_limits` which already skips the execution time check entirely when `tx.execution_time_us` is `None`
- The wall-clock fallback inflated cumulative execution time by 2-100x vs simulation predictions (median 2.4x vs state root, 70x vs execution time), causing spurious budget exceedances — especially in flashblock 1 where 12.9% of transactions hit the race condition between arrival and async MeteringStore population

type=routine
risk=low
impact=sev5