### PR TITLE
feat(chains): reschedule Base V1 activation on Zeronet to 2026-04-02 13:00 EST

### DIFF
--- a/crates/core/chains/src/chain.rs
+++ b/crates/core/chains/src/chain.rs
@@ -316,7 +316,7 @@ mod tests {
         let zeronet_forks = BaseChainUpgrades::zeronet();
         assert_eq!(
             zeronet_forks.ethereum_fork_activation(EthereumHardfork::Osaka),
-            ForkCondition::Timestamp(1_775_079_000)
+            ForkCondition::Timestamp(1_775_152_800)
         );
     }
 

--- a/crates/core/chains/src/chain.rs
+++ b/crates/core/chains/src/chain.rs
@@ -285,11 +285,11 @@ mod tests {
         assert!(devnet0_forks.is_base_v1_active_at_timestamp(1_774_890_000));
         assert!(devnet0_forks.is_base_v1_active_at_timestamp(u64::MAX));
 
-        // V1 is scheduled on zeronet at 1775079000
+        // V1 is scheduled on zeronet at 1775152800
         let zeronet_forks = BaseChainUpgrades::zeronet();
         assert!(!zeronet_forks.is_base_v1_active_at_timestamp(0));
-        assert!(!zeronet_forks.is_base_v1_active_at_timestamp(1_775_078_999));
-        assert!(zeronet_forks.is_base_v1_active_at_timestamp(1_775_079_000));
+        assert!(!zeronet_forks.is_base_v1_active_at_timestamp(1_775_152_799));
+        assert!(zeronet_forks.is_base_v1_active_at_timestamp(1_775_152_800));
         assert!(zeronet_forks.is_base_v1_active_at_timestamp(u64::MAX));
     }
 

--- a/crates/core/chains/src/config.rs
+++ b/crates/core/chains/src/config.rs
@@ -379,7 +379,7 @@ const ZERONET: BaseChainConfig = BaseChainConfig {
     pectra_blob_schedule_timestamp: None,
     isthmus_timestamp: 0,
     jovian_timestamp: 0,
-    base_v1_timestamp: Some(1_775_079_000),
+    base_v1_timestamp: Some(1_775_152_800),
 
     genesis_l1_hash: b256!("b7d4b69971ff31d5179be5e1b83f5a4f438f4cd1db886a6630623b7047f32cfd"),
     genesis_l1_number: 2_450_277,


### PR DESCRIPTION
## Summary
- Moves the Base V1 activation timestamp on Zeronet from `1_775_079_000` (2026-04-01 16:30 EST) to `1_775_152_800` (2026-04-02 13:00 EST)
- Updates the corresponding test assertions in `chain.rs`

## Test plan
- [ ] Existing unit tests pass with updated timestamp bounds