### PR TITLE
ci: add vouch contributor trust system

### DIFF
--- a/.github/VOUCHED.td
+++ b/.github/VOUCHED.td
@@ -1,0 +1,14 @@
+# The list of vouched (or actively denounced) users for this repository.
+#
+# Only vouched users can open pull requests. Issues remain open to everyone.
+# Org collaborators with write access bypass this check automatically.
+#
+# Syntax:
+# - One handle per line (without @). Sorted alphabetically.
+# - Optionally specify platform: `platform:username` (e.g., `github:mitchellh`).
+# - To denounce a user, prefix with minus: `-username` or `-platform:username`.
+# - Optionally, add details after a space following the handle.
+#
+# Maintainers can vouch for new contributors by commenting "vouch" on an
+# issue by the author. Maintainers can denounce users by commenting
+# "denounce" or "denounce [username]" on an issue or PR.

--- a/.github/workflows/vouch.yml
+++ b/.github/workflows/vouch.yml
@@ -32,7 +32,12 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   manage:
-    if: github.event_name == 'issue_comment'
+    if: >-
+      github.event_name == 'issue_comment' && (
+        contains(github.event.comment.body, 'vouch') ||
+        contains(github.event.comment.body, 'denounce') ||
+        contains(github.event.comment.body, 'unvouch')
+      )
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/vouch.yml
+++ b/.github/workflows/vouch.yml
@@ -18,6 +18,7 @@ jobs:
     if: github.event_name == 'pull_request_target'
     runs-on: ubuntu-latest
     permissions:
+      contents: read
       pull-requests: write
     steps:
       - name: Harden the runner (Audit all outbound calls)

--- a/.github/workflows/vouch.yml
+++ b/.github/workflows/vouch.yml
@@ -7,20 +7,24 @@ on:
     types: [created]
 
 concurrency:
-  group: vouch-manage
+  group: vouch-${{ github.event.pull_request.number || github.event.issue.number }}
   cancel-in-progress: false
 
 permissions:
-  contents: write
-  issues: write
-  pull-requests: write
+  contents: read
 
 jobs:
   check-pr:
     if: github.event_name == 'pull_request_target'
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
     steps:
-      - uses: mitchellh/vouch/action/check-pr@v1
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@95d9a5deda9de15063e7595e9719c11c38c90ae2 # v2.13.2
+        with:
+          egress-policy: audit
+      - uses: mitchellh/vouch/action/check-pr@c6d80ead49839655b61b422700b7a3bc9d0804a9 # v1
         with:
           pr-number: ${{ github.event.pull_request.number }}
           auto-close: true
@@ -30,9 +34,16 @@ jobs:
   manage:
     if: github.event_name == 'issue_comment'
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      issues: write
     steps:
-      - uses: actions/checkout@v4
-      - uses: mitchellh/vouch/action/manage-by-issue@v1
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@95d9a5deda9de15063e7595e9719c11c38c90ae2 # v2.13.2
+        with:
+          egress-policy: audit
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: mitchellh/vouch/action/manage-by-issue@c6d80ead49839655b61b422700b7a3bc9d0804a9 # v1
         with:
           repo: ${{ github.repository }}
           issue-id: ${{ github.event.issue.number }}

--- a/.github/workflows/vouch.yml
+++ b/.github/workflows/vouch.yml
@@ -1,0 +1,41 @@
+name: Vouch
+
+on:
+  pull_request_target:
+    types: [opened, reopened]
+  issue_comment:
+    types: [created]
+
+concurrency:
+  group: vouch-manage
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+
+jobs:
+  check-pr:
+    if: github.event_name == 'pull_request_target'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: mitchellh/vouch/action/check-pr@v1
+        with:
+          pr-number: ${{ github.event.pull_request.number }}
+          auto-close: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  manage:
+    if: github.event_name == 'issue_comment'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: mitchellh/vouch/action/manage-by-issue@v1
+        with:
+          repo: ${{ github.repository }}
+          issue-id: ${{ github.event.issue.number }}
+          comment-id: ${{ github.event.comment.id }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,6 +4,24 @@ Thanks for your interest in improving Base.
 
 This document will help you get started. **Do not let this document intimidate you**. It should be considered as a guide to help you navigate the process.
 
+## Contributor Trust System
+
+We use [vouch](https://github.com/mitchellh/vouch) to manage contributor trust. This helps us maintain code quality by gating pull requests behind an explicit trust list.
+
+**What this means for you:**
+
+- **Issues** are open to everyone — no restrictions.
+- **Pull requests** require you to be vouched. PRs from unvouched users are auto-closed.
+- **Org collaborators** with write access bypass this check automatically.
+
+**How to get vouched:**
+
+1. Open an issue describing the bug or feature you'd like to work on.
+2. A maintainer will review and comment `vouch` to add you to the trust list.
+3. Once vouched, you can open pull requests.
+
+The trust list lives in [`.github/VOUCHED.td`](.github/VOUCHED.td).
+
 ## Ways to Contribute
 
 There are three ways an individual can contribute:


### PR DESCRIPTION
## Summary

Integrate [mitchellh/vouch](https://github.com/mitchellh/vouch) to gate PRs behind an explicit contributor trust list. Issues remain open to everyone so maintainers can evaluate and vouch for new contributors. Org collaborators with write access are unaffected.

- **`.github/VOUCHED.td`** — empty trust list, seeded as external contributors are vouched
- **`.github/workflows/vouch.yml`** — `check-pr` (auto-close unvouched PRs) + `manage` (vouch/denounce via issue comments)
- **`CONTRIBUTING.md`** — added section explaining the trust system

Closes #1849