### PR TITLE
fix(repo): Justfile Help Menu

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -24,13 +24,13 @@ alias wt := watch-test
 alias wc := watch-check
 alias ldc := load-test-devnet-continuous
 
+# Default to display help menu
+default:
+    @just --list
+
 # Load test devnet in continuous mode (Ctrl-C to stop)
 load-test-devnet-continuous:
     just load-test devnet-continuous
-
-# Default to display help menu
-default:
-    @just --list --list-submodules
 
 # Runs the specs docs locally
 specs:


### PR DESCRIPTION
## Summary

Fixes the `Justfile` to properly show the help menu by default instead of running load tests.

Also updates submodule listing to not show submodules in the help menu to avoid bloated help menu. To show submodule commands, you just run the submodule like `just devnet`