### PR TITLE
fix(proof): remove hint_trie_node call in Blinded collapse

### DIFF
--- a/crates/proof/executor/src/db/mod.rs
+++ b/crates/proof/executor/src/db/mod.rs
@@ -178,7 +178,7 @@ where
 
             // If the account was destroyed, delete it from the trie.
             if bundle_account.was_destroyed() {
-                self.root_node.delete(&account_path, &self.fetcher, &self.hinter)?;
+                self.root_node.delete(&account_path, &self.fetcher)?;
                 self.storage_roots.remove(address);
                 continue;
             }
@@ -209,13 +209,7 @@ where
             sorted_storage.sort_by_key(|(slot, _)| *slot);
 
             sorted_storage.into_iter().try_for_each(|(hashed_key, value)| {
-                Self::change_storage(
-                    acc_storage_root,
-                    hashed_key,
-                    value,
-                    &self.fetcher,
-                    &self.hinter,
-                )
+                Self::change_storage(acc_storage_root, hashed_key, value, &self.fetcher)
             })?;
 
             // Recompute the account storage root.
@@ -239,7 +233,6 @@ where
         hashed_key: B256,
         value: &StorageSlot,
         fetcher: &F,
-        hinter: &H,
     ) -> TrieDBResult<()> {
         if !value.is_changed() {
             return Ok(());
@@ -248,7 +241,7 @@ where
         let hashed_slot_key = Nibbles::unpack(hashed_key.as_slice());
         if value.present_value.is_zero() {
             // If the storage slot is being set to zero, prune it from the trie.
-            storage_root.delete(&hashed_slot_key, fetcher, hinter)?;
+            storage_root.delete(&hashed_slot_key, fetcher)?;
         } else {
             // RLP encode the storage slot value and update the trie.
             let mut rlp_buf = Vec::with_capacity(value.present_value.length());

--- a/crates/proof/mpt/benches/trie_node.rs
+++ b/crates/proof/mpt/benches/trie_node.rs
@@ -2,7 +2,7 @@
 //! Benchmarks for the [`TrieNode`].
 
 use alloy_trie::Nibbles;
-use base_proof_mpt::{NoopTrieHinter, NoopTrieProvider, TrieNode};
+use base_proof_mpt::{NoopTrieProvider, TrieNode};
 use criterion::{Criterion, criterion_group, criterion_main};
 use rand::{Rng, SeedableRng, rngs::StdRng, seq::IteratorRandom};
 
@@ -55,7 +55,7 @@ fn trie(c: &mut Criterion) {
         b.iter(|| {
             let trie = &mut trie.clone();
             for key in &keys_to_delete {
-                trie.delete(key, &NoopTrieProvider, &NoopTrieHinter).unwrap();
+                trie.delete(key, &NoopTrieProvider).unwrap();
             }
         });
     });
@@ -75,7 +75,7 @@ fn trie(c: &mut Criterion) {
         b.iter(|| {
             let trie = &mut trie.clone();
             for key in &keys_to_delete {
-                trie.delete(key, &NoopTrieProvider, &NoopTrieHinter).unwrap();
+                trie.delete(key, &NoopTrieProvider).unwrap();
             }
         });
     });

--- a/crates/proof/mpt/src/node.rs
+++ b/crates/proof/mpt/src/node.rs
@@ -8,7 +8,7 @@ use alloy_rlp::{Buf, Decodable, EMPTY_STRING_CODE, Encodable, Header, length_of_
 use alloy_trie::{EMPTY_ROOT_HASH, Nibbles};
 
 use crate::{
-    TrieHinter, TrieNodeError, TrieProvider,
+    TrieNodeError, TrieProvider,
     errors::TrieNodeResult,
     util::{rlp_list_element_length, unpack_path_to_nibbles},
 };
@@ -313,12 +313,7 @@ impl TrieNode {
     /// ## Returns
     /// - `Err(_)` - Could not delete the node at the given path in the trie.
     /// - `Ok(())` - The node was successfully deleted at the given path.
-    pub fn delete<F: TrieProvider, H: TrieHinter>(
-        &mut self,
-        path: &Nibbles,
-        fetcher: &F,
-        hinter: &H,
-    ) -> TrieNodeResult<()> {
+    pub fn delete<F: TrieProvider>(&mut self, path: &Nibbles, fetcher: &F) -> TrieNodeResult<()> {
         match self {
             Self::Empty => Err(TrieNodeError::KeyNotFound),
             Self::Leaf { prefix, .. } => {
@@ -338,21 +333,21 @@ impl TrieNode {
                     return Ok(());
                 }
 
-                node.delete(&path.slice(prefix.len()..), fetcher, hinter)?;
+                node.delete(&path.slice(prefix.len()..), fetcher)?;
 
                 // Simplify extension if possible after the deletion
-                self.collapse_if_possible(fetcher, hinter)
+                self.collapse_if_possible(fetcher)
             }
             Self::Branch { stack } => {
                 let branch_nibble = path.get(0).ok_or(TrieNodeError::PathTooShort)? as usize;
-                stack[branch_nibble].delete(&path.slice(BRANCH_NODE_NIBBLES..), fetcher, hinter)?;
+                stack[branch_nibble].delete(&path.slice(BRANCH_NODE_NIBBLES..), fetcher)?;
 
                 // Simplify the branch if possible after the deletion
-                self.collapse_if_possible(fetcher, hinter)
+                self.collapse_if_possible(fetcher)
             }
             Self::Blinded { .. } => {
                 self.unblind(fetcher)?;
-                self.delete(path, fetcher, hinter)
+                self.delete(path, fetcher)
             }
         }
     }
@@ -365,11 +360,7 @@ impl TrieNode {
     /// ## Returns
     /// - `Ok(())` - The node was successfully collapsed
     /// - `Err(_)` - Could not collapse the node
-    fn collapse_if_possible<F: TrieProvider, H: TrieHinter>(
-        &mut self,
-        fetcher: &F,
-        hinter: &H,
-    ) -> TrieNodeResult<()> {
+    fn collapse_if_possible<F: TrieProvider>(&mut self, fetcher: &F) -> TrieNodeResult<()> {
         match self {
             Self::Extension { prefix, node } => match node.as_mut() {
                 Self::Extension { prefix: child_prefix, node: child_node } => {
@@ -429,7 +420,7 @@ impl TrieNode {
                         }
                         Self::Blinded { .. } => {
                             non_empty_node.unblind(fetcher)?;
-                            self.collapse_if_possible(fetcher, hinter)?;
+                            self.collapse_if_possible(fetcher)?;
                         }
                         _ => {}
                     };
@@ -621,8 +612,7 @@ mod tests {
 
     use super::*;
     use crate::{
-        NoopTrieHinter, NoopTrieProvider, TrieNode, ordered_trie_with_encoder,
-        test_util::TrieNodeProvider,
+        NoopTrieProvider, TrieNode, ordered_trie_with_encoder, test_util::TrieNodeProvider,
     };
 
     #[test]
@@ -833,7 +823,7 @@ mod tests {
 
             // Delete the keys that were randomly selected from the trie node.
             for deleted_key in deleted_keys {
-                node.delete(&Nibbles::unpack(deleted_key), &NoopTrieProvider, &NoopTrieHinter)
+                node.delete(&Nibbles::unpack(deleted_key), &NoopTrieProvider)
                     .unwrap();
             }
 

--- a/crates/proof/mpt/src/node.rs
+++ b/crates/proof/mpt/src/node.rs
@@ -427,14 +427,7 @@ impl TrieNode {
                                 node: Box::new(non_empty_node.clone()),
                             };
                         }
-                        Self::Blinded { commitment } => {
-                            // In this special case, we need to send a hint to fetch the preimage of
-                            // the blinded node, since it is outside of the paths that have been
-                            // traversed so far.
-                            hinter
-                                .hint_trie_node(*commitment)
-                                .map_err(|e| TrieNodeError::Provider(e.to_string()))?;
-
+                        Self::Blinded { .. } => {
                             non_empty_node.unblind(fetcher)?;
                             self.collapse_if_possible(fetcher, hinter)?;
                         }


### PR DESCRIPTION
## Summary

Remove `hint_trie_node` call from the `Blinded` branch in `TrieNode::collapse_if_possible`. The `unblind` call that follows fetches the node directly since it's populated already by `debug_executePayload`.

## Testing

Local testing