### PR TITLE
fix(proof): use JoinSet for server task to ensure cleanup on drop

### DIFF
--- a/crates/proof/host/src/host.rs
+++ b/crates/proof/host/src/host.rs
@@ -100,7 +100,8 @@ impl Host {
             HintReader::new(hint_chan.host),
             Arc::clone(&backend),
         );
-        let mut server_task = task::spawn(
+        let mut tasks = tokio::task::JoinSet::new();
+        tasks.spawn(
             async move { server.start().await }.instrument(info_span!("preimage_server")),
         );
 
@@ -115,20 +116,17 @@ impl Host {
         });
 
         tokio::select! {
-            result = &mut server_task => {
+            result = tasks.join_next() => {
                 return match result {
-                    Err(e) => Err(HostError::ServerPanicked(e)),
-                    Ok(Err(e)) => Err(e),
-                    Ok(Ok(())) => Err(HostError::ServerExitedUnexpectedly),
+                    Some(Err(e)) => Err(HostError::ServerPanicked(e)),
+                    Some(Ok(Err(e))) => Err(e),
+                    Some(Ok(Ok(()))) | None => Err(HostError::ServerExitedUnexpectedly),
                 };
             }
             result = client_task => {
                 result.map_err(|e| HostError::ProofProgram(Box::new(e)))?;
             }
         }
-
-        server_task.abort();
-        let _ = (&mut server_task).await;
 
         witness.finalize()?;
         let preimage_count = witness.preimage_count()?;

--- a/crates/proof/host/src/host.rs
+++ b/crates/proof/host/src/host.rs
@@ -100,7 +100,7 @@ impl Host {
             HintReader::new(hint_chan.host),
             Arc::clone(&backend),
         );
-        let mut tasks = tokio::task::JoinSet::new();
+        let mut tasks = task::JoinSet::new();
         tasks.spawn(async move { server.start().await }.instrument(info_span!("preimage_server")));
 
         let recording = RecordingOracle::new(

--- a/crates/proof/host/src/host.rs
+++ b/crates/proof/host/src/host.rs
@@ -101,9 +101,7 @@ impl Host {
             Arc::clone(&backend),
         );
         let mut tasks = tokio::task::JoinSet::new();
-        tasks.spawn(
-            async move { server.start().await }.instrument(info_span!("preimage_server")),
-        );
+        tasks.spawn(async move { server.start().await }.instrument(info_span!("preimage_server")));
 
         let recording = RecordingOracle::new(
             OracleReader::new(preimage_chan.client),


### PR DESCRIPTION
## Summary
- Replace direct `task::spawn` with `tokio::task::JoinSet` for the preimage server task in the nitro host
- `JoinSet` automatically aborts all spawned tasks when dropped, eliminating the need for manual `abort()` + `await` cleanup after the `tokio::select!` block
- Ensures the server task is reliably cleaned up even if the host function exits via an early return or panic