### PR TITLE
feat(tee): add registration-gated health check for nitro prover

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4725,6 +4725,7 @@ dependencies = [
  "base-proof-primitives",
  "base-proof-tee-nitro-enclave",
  "eyre",
+ "hex-literal 1.1.0",
  "jsonrpsee",
  "k256",
  "thiserror 2.0.18",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4719,17 +4719,20 @@ dependencies = [
  "alloy-primitives",
  "async-trait",
  "base-health",
+ "base-proof-contracts",
  "base-proof-host",
  "base-proof-preimage",
  "base-proof-primitives",
  "base-proof-tee-nitro-enclave",
  "eyre",
  "jsonrpsee",
+ "k256",
  "thiserror 2.0.18",
  "tokio",
  "tokio-vsock",
  "tower",
  "tracing",
+ "url",
 ]
 
 [[package]]
@@ -4934,6 +4937,7 @@ dependencies = [
 name = "base-prover-nitro-host"
 version = "0.0.0"
 dependencies = [
+ "alloy-primitives",
  "base-cli-utils",
  "base-consensus-registry",
  "base-proof-host",

--- a/bin/prover/nitro-host/Cargo.toml
+++ b/bin/prover/nitro-host/Cargo.toml
@@ -16,10 +16,10 @@ path = "src/main.rs"
 workspace = true
 
 [dependencies]
-alloy-primitives.workspace = true
 eyre.workspace = true
 tracing.workspace = true
 base-cli-utils.workspace = true
+alloy-primitives.workspace = true
 base-proof-tee-nitro-host.workspace = true
 base-consensus-registry.workspace = true
 tokio = { workspace = true, features = ["full"] }

--- a/bin/prover/nitro-host/Cargo.toml
+++ b/bin/prover/nitro-host/Cargo.toml
@@ -16,6 +16,7 @@ path = "src/main.rs"
 workspace = true
 
 [dependencies]
+alloy-primitives.workspace = true
 eyre.workspace = true
 tracing.workspace = true
 base-cli-utils.workspace = true

--- a/bin/prover/nitro-host/src/cli.rs
+++ b/bin/prover/nitro-host/src/cli.rs
@@ -14,6 +14,7 @@ use base_consensus_registry::Registry;
 use base_proof_host::ProverConfig;
 #[cfg(feature = "local")]
 use base_proof_tee_nitro_host::EnclaveServer;
+#[cfg(any(target_os = "linux", feature = "local"))]
 use base_proof_tee_nitro_host::RegistrationHealthConfig;
 #[cfg(target_os = "linux")]
 use base_proof_tee_nitro_host::VSOCK_PORT;
@@ -96,6 +97,7 @@ struct ProverServerArgs {
     tee_prover_registry_address: Option<Address>,
 }
 
+#[cfg(any(target_os = "linux", feature = "local"))]
 impl ProverServerArgs {
     fn registration_health_config(&self) -> Option<RegistrationHealthConfig> {
         self.tee_prover_registry_address.map(|address| RegistrationHealthConfig {

--- a/bin/prover/nitro-host/src/cli.rs
+++ b/bin/prover/nitro-host/src/cli.rs
@@ -6,6 +6,7 @@ use std::sync::Arc;
 #[cfg(any(target_os = "linux", feature = "local"))]
 use std::time::Duration;
 
+use alloy_primitives::Address;
 use base_cli_utils::{LogConfig, RuntimeManager};
 #[cfg(any(target_os = "linux", feature = "local"))]
 use base_consensus_registry::Registry;
@@ -13,6 +14,7 @@ use base_consensus_registry::Registry;
 use base_proof_host::ProverConfig;
 #[cfg(feature = "local")]
 use base_proof_tee_nitro_host::EnclaveServer;
+use base_proof_tee_nitro_host::RegistrationHealthConfig;
 #[cfg(target_os = "linux")]
 use base_proof_tee_nitro_host::VSOCK_PORT;
 #[cfg(any(target_os = "linux", feature = "local"))]
@@ -87,6 +89,20 @@ struct ProverServerArgs {
     /// Maximum seconds for a single proof request before it is aborted.
     #[arg(long, env = "PROOF_REQUEST_TIMEOUT_SECS", default_value = "1740", value_parser = clap::value_parser!(u64).range(1..))]
     proof_request_timeout_secs: u64,
+
+    /// `TEEProverRegistry` contract address on L1. When set, `/healthz` returns
+    /// healthy only if the enclave signer is registered on-chain.
+    #[arg(long, env = "TEE_PROVER_REGISTRY_ADDRESS")]
+    tee_prover_registry_address: Option<Address>,
+}
+
+impl ProverServerArgs {
+    fn registration_health_config(&self) -> Option<RegistrationHealthConfig> {
+        self.tee_prover_registry_address.map(|address| RegistrationHealthConfig {
+            registry_address: address,
+            l1_rpc_url: self.l1_eth_url.clone(),
+        })
+    }
 }
 
 /// Arguments for the `server` subcommand.
@@ -131,6 +147,8 @@ impl ServerArgs {
             .ok_or_else(|| eyre!("unknown L1 chain ID: {}", rollup_config.l1_chain_id))?
             .clone();
 
+        let registration_health = self.server.registration_health_config();
+
         let config = ProverConfig {
             l1_eth_url: self.server.l1_eth_url,
             l2_eth_url: self.server.l2_eth_url,
@@ -143,7 +161,10 @@ impl ServerArgs {
 
         let transport = Arc::new(NitroTransport::vsock(self.vsock_cid, VSOCK_PORT));
         let timeout = Duration::from_secs(self.server.proof_request_timeout_secs);
-        let server = NitroProverServer::new(config, transport, timeout);
+        let mut server = NitroProverServer::new(config, transport, timeout);
+        if let Some(reg) = registration_health {
+            server = server.with_registration_health(reg);
+        }
 
         info!(addr = %self.server.listen_addr, "starting nitro prover host server");
         let handle = server.run(self.server.listen_addr).await?;
@@ -171,6 +192,8 @@ impl LocalArgs {
             .ok_or_else(|| eyre!("unknown L1 chain ID: {}", rollup_config.l1_chain_id))?
             .clone();
 
+        let registration_health = self.server.registration_health_config();
+
         let prover_config = ProverConfig {
             l1_eth_url: self.server.l1_eth_url,
             l2_eth_url: self.server.l2_eth_url,
@@ -184,7 +207,10 @@ impl LocalArgs {
         let enclave_server = Arc::new(EnclaveServer::new_local()?);
         let transport = Arc::new(NitroTransport::local(enclave_server));
         let timeout = Duration::from_secs(self.server.proof_request_timeout_secs);
-        let server = NitroProverServer::new(prover_config, transport, timeout);
+        let mut server = NitroProverServer::new(prover_config, transport, timeout);
+        if let Some(reg) = registration_health {
+            server = server.with_registration_health(reg);
+        }
 
         info!(addr = %self.server.listen_addr, "starting nitro prover server (local mode)");
         let handle = server.run(self.server.listen_addr).await?;

--- a/crates/proof/tee/nitro-host/Cargo.toml
+++ b/crates/proof/tee/nitro-host/Cargo.toml
@@ -14,12 +14,11 @@ workspace = true
 [dependencies]
 # base
 base-health.workspace = true
-base-proof-contracts.workspace = true
 base-proof-host.workspace = true
 base-proof-preimage.workspace = true
+base-proof-contracts.workspace = true
 base-proof-tee-nitro-enclave.workspace = true
 base-proof-primitives = { workspace = true, features = ["std", "serde", "rpc-server"] }
-jsonrpsee = { workspace = true, features = ["server", "macros"] }
 
 # crypto
 alloy-primitives.workspace = true
@@ -35,6 +34,7 @@ eyre.workspace = true
 tower.workspace = true
 tracing.workspace = true
 thiserror.workspace = true
+jsonrpsee = { workspace = true, features = ["server", "macros"] }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 tokio-vsock.workspace = true

--- a/crates/proof/tee/nitro-host/Cargo.toml
+++ b/crates/proof/tee/nitro-host/Cargo.toml
@@ -30,16 +30,17 @@ async-trait.workspace = true
 tokio = { workspace = true, features = ["rt", "time", "io-util", "net"] }
 
 # misc
+url.workspace = true
 eyre.workspace = true
 tower.workspace = true
 tracing.workspace = true
 thiserror.workspace = true
-url.workspace = true
 
 [target.'cfg(target_os = "linux")'.dependencies]
 tokio-vsock.workspace = true
 
 [dev-dependencies]
+hex-literal.workspace = true
 tokio = { workspace = true, features = ["macros", "rt"] }
 
 [features]

--- a/crates/proof/tee/nitro-host/Cargo.toml
+++ b/crates/proof/tee/nitro-host/Cargo.toml
@@ -14,11 +14,16 @@ workspace = true
 [dependencies]
 # base
 base-health.workspace = true
+base-proof-contracts.workspace = true
 base-proof-host.workspace = true
 base-proof-preimage.workspace = true
 base-proof-tee-nitro-enclave.workspace = true
 base-proof-primitives = { workspace = true, features = ["std", "serde", "rpc-server"] }
 jsonrpsee = { workspace = true, features = ["server", "macros"] }
+
+# crypto
+alloy-primitives.workspace = true
+k256 = { workspace = true, features = ["ecdsa"] }
 
 # async
 async-trait.workspace = true
@@ -29,12 +34,12 @@ eyre.workspace = true
 tower.workspace = true
 tracing.workspace = true
 thiserror.workspace = true
+url.workspace = true
 
 [target.'cfg(target_os = "linux")'.dependencies]
 tokio-vsock.workspace = true
 
 [dev-dependencies]
-alloy-primitives.workspace = true
 tokio = { workspace = true, features = ["macros", "rt"] }
 
 [features]

--- a/crates/proof/tee/nitro-host/src/health.rs
+++ b/crates/proof/tee/nitro-host/src/health.rs
@@ -1,3 +1,5 @@
+//! Registration-gated health check for the nitro prover.
+
 use std::{
     sync::Arc,
     time::{Duration, Instant},
@@ -7,7 +9,7 @@ use alloy_primitives::{Address, keccak256};
 use base_health::{HealthzApiServer, HealthzResponse};
 use base_proof_contracts::{TEEProverRegistryClient, TEEProverRegistryContractClient};
 use jsonrpsee::core::{RpcResult, async_trait};
-use tokio::sync::RwLock;
+use tokio::sync::{OnceCell, RwLock};
 use tracing::warn;
 
 use super::transport::NitroTransport;
@@ -28,6 +30,7 @@ pub(crate) struct RegistrationHealthzRpc {
     version: &'static str,
     transport: Arc<NitroTransport>,
     registry: TEEProverRegistryContractClient,
+    signer: OnceCell<Address>,
     cache: RwLock<Option<(bool, Instant)>>,
 }
 
@@ -37,40 +40,50 @@ impl RegistrationHealthzRpc {
         transport: Arc<NitroTransport>,
         registry: TEEProverRegistryContractClient,
     ) -> Self {
-        Self { version, transport, registry, cache: RwLock::new(None) }
+        Self { version, transport, registry, signer: OnceCell::new(), cache: RwLock::new(None) }
+    }
+
+    async fn signer_address(&self) -> Result<Address, String> {
+        self.signer
+            .get_or_try_init(|| async {
+                let public_key = self
+                    .transport
+                    .signer_public_key()
+                    .await
+                    .map_err(|e| format!("failed to get signer public key: {e}"))?;
+                derive_signer_address(&public_key)
+            })
+            .await
+            .copied()
     }
 
     async fn check_registration(&self) -> Result<bool, String> {
-        // Return cached result if fresh.
         {
             let cache = self.cache.read().await;
-            if let Some((registered, checked_at)) = *cache
-                && checked_at.elapsed() < REGISTRATION_CACHE_TTL {
+            if let Some((registered, checked_at)) = *cache {
+                if checked_at.elapsed() < REGISTRATION_CACHE_TTL {
                     return Ok(registered);
                 }
+            }
         }
 
-        let public_key = self
-            .transport
-            .signer_public_key()
-            .await
-            .map_err(|e| format!("failed to get signer public key: {e}"))?;
-
-        let signer = derive_signer_address(&public_key)?;
+        let signer = self.signer_address().await?;
 
         match self.registry.is_registered_signer(signer).await {
             Ok(registered) => {
-                *self.cache.write().await = Some((registered, Instant::now()));
-                if !registered {
+                let mut cache = self.cache.write().await;
+                let was_registered = cache.map(|(r, _)| r);
+                *cache = Some((registered, Instant::now()));
+                // Only warn on state transition to unregistered, not on every cache refresh.
+                if !registered && was_registered != Some(false) {
                     warn!(signer = %signer, "signer is not registered in TEEProverRegistry");
                 }
                 Ok(registered)
             }
             Err(e) => {
-                // On L1 RPC failure, return stale cached value if within the stale limit.
                 let cache = self.cache.read().await;
-                if let Some((registered, checked_at)) = *cache
-                    && checked_at.elapsed() < REGISTRATION_STALE_LIMIT {
+                if let Some((registered, checked_at)) = *cache {
+                    if checked_at.elapsed() < REGISTRATION_STALE_LIMIT {
                         warn!(
                             error = %e,
                             signer = %signer,
@@ -79,6 +92,7 @@ impl RegistrationHealthzRpc {
                         );
                         return Ok(registered);
                     }
+                }
                 Err(format!("failed to check registration for {signer}: {e}"))
             }
         }

--- a/crates/proof/tee/nitro-host/src/health.rs
+++ b/crates/proof/tee/nitro-host/src/health.rs
@@ -191,7 +191,7 @@ mod tests {
         let rpc = test_rpc();
         *rpc.cache.write().await = Some((true, Instant::now()));
         let result = rpc.use_stale_cache_or_fail(TEST_SIGNER, "rpc down").await;
-        assert_eq!(result.unwrap(), true);
+        assert!(result.unwrap());
     }
 
     #[tokio::test]
@@ -216,7 +216,7 @@ mod tests {
         rpc.signer.set(TEST_SIGNER).unwrap();
         *rpc.cache.write().await = Some((true, Instant::now()));
         let result = rpc.check_registration().await;
-        assert_eq!(result.unwrap(), true);
+        assert!(result.unwrap());
     }
 
     #[tokio::test]
@@ -225,6 +225,6 @@ mod tests {
         rpc.signer.set(TEST_SIGNER).unwrap();
         *rpc.cache.write().await = Some((false, Instant::now()));
         let result = rpc.check_registration().await;
-        assert_eq!(result.unwrap(), false);
+        assert!(!result.unwrap());
     }
 }

--- a/crates/proof/tee/nitro-host/src/health.rs
+++ b/crates/proof/tee/nitro-host/src/health.rs
@@ -69,10 +69,10 @@ impl RegistrationHealthzRpc {
     async fn check_registration(&self) -> Result<bool, String> {
         {
             let cache = self.cache.read().await;
-            if let Some((registered, checked_at)) = *cache {
-                if checked_at.elapsed() < REGISTRATION_CACHE_TTL {
-                    return Ok(registered);
-                }
+            if let Some((registered, checked_at)) = *cache
+                && checked_at.elapsed() < REGISTRATION_CACHE_TTL
+            {
+                return Ok(registered);
             }
         }
 
@@ -92,11 +92,12 @@ impl RegistrationHealthzRpc {
             Err(e) => {
                 let cache = self.cache.read().await;
                 if let Some((registered, checked_at)) = *cache {
-                    if checked_at.elapsed() < REGISTRATION_STALE_LIMIT {
+                    let elapsed = checked_at.elapsed();
+                    if elapsed < REGISTRATION_STALE_LIMIT {
                         warn!(
                             error = %e,
                             signer = %signer,
-                            stale_secs = checked_at.elapsed().as_secs(),
+                            stale_secs = elapsed.as_secs(),
                             "L1 RPC failed, using stale cached registration status"
                         );
                         return Ok(registered);

--- a/crates/proof/tee/nitro-host/src/health.rs
+++ b/crates/proof/tee/nitro-host/src/health.rs
@@ -51,10 +51,19 @@ impl RegistrationHealthzRpc {
                     .signer_public_key()
                     .await
                     .map_err(|e| format!("failed to get signer public key: {e}"))?;
-                derive_signer_address(&public_key)
+                Self::derive_signer_address(&public_key)
             })
             .await
             .copied()
+    }
+
+    fn derive_signer_address(public_key: &[u8]) -> Result<Address, String> {
+        let key = k256::PublicKey::from_sec1_bytes(public_key)
+            .map_err(|e| format!("invalid public key: {e}"))?;
+        let uncompressed =
+            k256::elliptic_curve::sec1::ToEncodedPoint::to_encoded_point(&key, false);
+        let hash = keccak256(&uncompressed.as_bytes()[1..]);
+        Ok(Address::from_slice(&hash[12..]))
     }
 
     async fn check_registration(&self) -> Result<bool, String> {
@@ -114,10 +123,46 @@ impl HealthzApiServer for RegistrationHealthzRpc {
     }
 }
 
-fn derive_signer_address(public_key: &[u8]) -> Result<Address, String> {
-    let key = k256::PublicKey::from_sec1_bytes(public_key)
-        .map_err(|e| format!("invalid public key: {e}"))?;
-    let uncompressed = k256::elliptic_curve::sec1::ToEncodedPoint::to_encoded_point(&key, false);
-    let hash = keccak256(&uncompressed.as_bytes()[1..]);
-    Ok(Address::from_slice(&hash[12..]))
+#[cfg(test)]
+mod tests {
+    use alloy_primitives::address;
+    use hex_literal::hex;
+    use k256::ecdsa::SigningKey;
+
+    use super::*;
+
+    const HARDHAT_PRIVATE_KEY: [u8; 32] =
+        hex!("ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80");
+
+    fn hardhat_public_key() -> Vec<u8> {
+        let signing_key = SigningKey::from_slice(&HARDHAT_PRIVATE_KEY).unwrap();
+        let verifying_key = signing_key.verifying_key();
+        verifying_key.to_encoded_point(false).as_bytes().to_vec()
+    }
+
+    #[test]
+    fn derive_signer_address_hardhat_account_zero() {
+        let public_key = hardhat_public_key();
+        let derived = RegistrationHealthzRpc::derive_signer_address(&public_key).unwrap();
+        assert_eq!(derived, address!("f39Fd6e51aad88F6F4ce6aB8827279cffFb92266"));
+    }
+
+    #[test]
+    fn derive_signer_address_compressed_matches_uncompressed() {
+        let signing_key = SigningKey::from_slice(&HARDHAT_PRIVATE_KEY).unwrap();
+        let verifying_key = signing_key.verifying_key();
+        let compressed = verifying_key.to_encoded_point(true).as_bytes().to_vec();
+        let uncompressed = hardhat_public_key();
+
+        let addr_compressed = RegistrationHealthzRpc::derive_signer_address(&compressed).unwrap();
+        let addr_uncompressed =
+            RegistrationHealthzRpc::derive_signer_address(&uncompressed).unwrap();
+        assert_eq!(addr_compressed, addr_uncompressed);
+    }
+
+    #[test]
+    fn derive_signer_address_rejects_invalid_key() {
+        assert!(RegistrationHealthzRpc::derive_signer_address(&[0x04; 66]).is_err());
+        assert!(RegistrationHealthzRpc::derive_signer_address(&[]).is_err());
+    }
 }

--- a/crates/proof/tee/nitro-host/src/health.rs
+++ b/crates/proof/tee/nitro-host/src/health.rs
@@ -16,6 +16,7 @@ use super::transport::NitroTransport;
 
 const REGISTRATION_CACHE_TTL: Duration = Duration::from_secs(30);
 const REGISTRATION_STALE_LIMIT: Duration = Duration::from_secs(300);
+const REGISTRATION_CHECK_TIMEOUT: Duration = Duration::from_secs(10);
 
 /// Configuration for registration-gated health checks.
 #[derive(Debug)]
@@ -66,6 +67,23 @@ impl RegistrationHealthzRpc {
         Ok(Address::from_slice(&hash[12..]))
     }
 
+    async fn use_stale_cache_or_fail(&self, signer: Address, error: &str) -> Result<bool, String> {
+        let cache = self.cache.read().await;
+        if let Some((registered, checked_at)) = *cache {
+            let elapsed = checked_at.elapsed();
+            if elapsed < REGISTRATION_STALE_LIMIT {
+                warn!(
+                    error = %error,
+                    signer = %signer,
+                    stale_secs = elapsed.as_secs(),
+                    "L1 RPC failed, using stale cached registration status"
+                );
+                return Ok(registered);
+            }
+        }
+        Err(format!("failed to check registration for {signer}: {error}"))
+    }
+
     async fn check_registration(&self) -> Result<bool, String> {
         {
             let cache = self.cache.read().await;
@@ -78,33 +96,24 @@ impl RegistrationHealthzRpc {
 
         let signer = self.signer_address().await?;
 
-        match self.registry.is_registered_signer(signer).await {
-            Ok(registered) => {
+        let result = tokio::time::timeout(
+            REGISTRATION_CHECK_TIMEOUT,
+            self.registry.is_registered_signer(signer),
+        )
+        .await;
+
+        match result {
+            Ok(Ok(registered)) => {
                 let mut cache = self.cache.write().await;
                 let was_registered = cache.map(|(r, _)| r);
                 *cache = Some((registered, Instant::now()));
-                // Only warn on state transition to unregistered, not on every cache refresh.
                 if !registered && was_registered != Some(false) {
                     warn!(signer = %signer, "signer is not registered in TEEProverRegistry");
                 }
                 Ok(registered)
             }
-            Err(e) => {
-                let cache = self.cache.read().await;
-                if let Some((registered, checked_at)) = *cache {
-                    let elapsed = checked_at.elapsed();
-                    if elapsed < REGISTRATION_STALE_LIMIT {
-                        warn!(
-                            error = %e,
-                            signer = %signer,
-                            stale_secs = elapsed.as_secs(),
-                            "L1 RPC failed, using stale cached registration status"
-                        );
-                        return Ok(registered);
-                    }
-                }
-                Err(format!("failed to check registration for {signer}: {e}"))
-            }
+            Ok(Err(e)) => self.use_stale_cache_or_fail(signer, &e.to_string()).await,
+            Err(_) => self.use_stale_cache_or_fail(signer, "L1 RPC request timed out").await,
         }
     }
 }

--- a/crates/proof/tee/nitro-host/src/health.rs
+++ b/crates/proof/tee/nitro-host/src/health.rs
@@ -1,0 +1,109 @@
+use std::{
+    sync::Arc,
+    time::{Duration, Instant},
+};
+
+use alloy_primitives::{Address, keccak256};
+use base_health::{HealthzApiServer, HealthzResponse};
+use base_proof_contracts::{TEEProverRegistryClient, TEEProverRegistryContractClient};
+use jsonrpsee::core::{RpcResult, async_trait};
+use tokio::sync::RwLock;
+use tracing::warn;
+
+use super::transport::NitroTransport;
+
+const REGISTRATION_CACHE_TTL: Duration = Duration::from_secs(30);
+const REGISTRATION_STALE_LIMIT: Duration = Duration::from_secs(300);
+
+/// Configuration for registration-gated health checks.
+#[derive(Debug)]
+pub struct RegistrationHealthConfig {
+    /// `TEEProverRegistry` contract address on L1.
+    pub registry_address: Address,
+    /// L1 JSON-RPC endpoint URL.
+    pub l1_rpc_url: String,
+}
+
+pub(crate) struct RegistrationHealthzRpc {
+    version: &'static str,
+    transport: Arc<NitroTransport>,
+    registry: TEEProverRegistryContractClient,
+    cache: RwLock<Option<(bool, Instant)>>,
+}
+
+impl RegistrationHealthzRpc {
+    pub(crate) fn new(
+        version: &'static str,
+        transport: Arc<NitroTransport>,
+        registry: TEEProverRegistryContractClient,
+    ) -> Self {
+        Self { version, transport, registry, cache: RwLock::new(None) }
+    }
+
+    async fn check_registration(&self) -> Result<bool, String> {
+        // Return cached result if fresh.
+        {
+            let cache = self.cache.read().await;
+            if let Some((registered, checked_at)) = *cache
+                && checked_at.elapsed() < REGISTRATION_CACHE_TTL {
+                    return Ok(registered);
+                }
+        }
+
+        let public_key = self
+            .transport
+            .signer_public_key()
+            .await
+            .map_err(|e| format!("failed to get signer public key: {e}"))?;
+
+        let signer = derive_signer_address(&public_key)?;
+
+        match self.registry.is_registered_signer(signer).await {
+            Ok(registered) => {
+                *self.cache.write().await = Some((registered, Instant::now()));
+                if !registered {
+                    warn!(signer = %signer, "signer is not registered in TEEProverRegistry");
+                }
+                Ok(registered)
+            }
+            Err(e) => {
+                // On L1 RPC failure, return stale cached value if within the stale limit.
+                let cache = self.cache.read().await;
+                if let Some((registered, checked_at)) = *cache
+                    && checked_at.elapsed() < REGISTRATION_STALE_LIMIT {
+                        warn!(
+                            error = %e,
+                            signer = %signer,
+                            stale_secs = checked_at.elapsed().as_secs(),
+                            "L1 RPC failed, using stale cached registration status"
+                        );
+                        return Ok(registered);
+                    }
+                Err(format!("failed to check registration for {signer}: {e}"))
+            }
+        }
+    }
+}
+
+#[async_trait]
+impl HealthzApiServer for RegistrationHealthzRpc {
+    async fn healthz(&self) -> RpcResult<HealthzResponse> {
+        match self.check_registration().await {
+            Ok(true) => Ok(HealthzResponse { version: self.version.to_string() }),
+            Ok(false) => Err(jsonrpsee::types::ErrorObjectOwned::owned(
+                -32000,
+                "signer not registered in TEEProverRegistry",
+                None::<()>,
+            )),
+            Err(msg) => Err(jsonrpsee::types::ErrorObjectOwned::owned(-32000, msg, None::<()>)),
+        }
+    }
+}
+
+fn derive_signer_address(public_key: &[u8]) -> Result<Address, String> {
+    let key = k256::PublicKey::from_sec1_bytes(public_key)
+        .map_err(|e| format!("invalid public key: {e}"))?;
+    let uncompressed = k256::elliptic_curve::sec1::ToEncodedPoint::to_encoded_point(&key, false);
+    let hash = keccak256(&uncompressed.as_bytes()[1..]);
+    Ok(Address::from_slice(&hash[12..]))
+}

--- a/crates/proof/tee/nitro-host/src/health.rs
+++ b/crates/proof/tee/nitro-host/src/health.rs
@@ -175,4 +175,56 @@ mod tests {
         assert!(RegistrationHealthzRpc::derive_signer_address(&[0x04; 66]).is_err());
         assert!(RegistrationHealthzRpc::derive_signer_address(&[]).is_err());
     }
+
+    fn test_rpc() -> RegistrationHealthzRpc {
+        let server = Arc::new(base_proof_tee_nitro_enclave::Server::new_local().unwrap());
+        let transport = Arc::new(NitroTransport::local(server));
+        let dummy_url = url::Url::parse("http://localhost:1").unwrap();
+        let registry = TEEProverRegistryContractClient::new(Address::ZERO, dummy_url);
+        RegistrationHealthzRpc::new("0.0.0", transport, registry)
+    }
+
+    const TEST_SIGNER: Address = address!("f39Fd6e51aad88F6F4ce6aB8827279cffFb92266");
+
+    #[tokio::test]
+    async fn stale_cache_returns_cached_value_on_error() {
+        let rpc = test_rpc();
+        *rpc.cache.write().await = Some((true, Instant::now()));
+        let result = rpc.use_stale_cache_or_fail(TEST_SIGNER, "rpc down").await;
+        assert_eq!(result.unwrap(), true);
+    }
+
+    #[tokio::test]
+    async fn stale_cache_fails_when_expired() {
+        let rpc = test_rpc();
+        let expired = Instant::now() - REGISTRATION_STALE_LIMIT - Duration::from_secs(1);
+        *rpc.cache.write().await = Some((true, expired));
+        let result = rpc.use_stale_cache_or_fail(TEST_SIGNER, "rpc down").await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn stale_cache_fails_when_empty() {
+        let rpc = test_rpc();
+        let result = rpc.use_stale_cache_or_fail(TEST_SIGNER, "rpc down").await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn cache_hit_within_ttl() {
+        let rpc = test_rpc();
+        rpc.signer.set(TEST_SIGNER).unwrap();
+        *rpc.cache.write().await = Some((true, Instant::now()));
+        let result = rpc.check_registration().await;
+        assert_eq!(result.unwrap(), true);
+    }
+
+    #[tokio::test]
+    async fn cache_hit_returns_false_when_not_registered() {
+        let rpc = test_rpc();
+        rpc.signer.set(TEST_SIGNER).unwrap();
+        *rpc.cache.write().await = Some((false, Instant::now()));
+        let result = rpc.check_registration().await;
+        assert_eq!(result.unwrap(), false);
+    }
 }

--- a/crates/proof/tee/nitro-host/src/lib.rs
+++ b/crates/proof/tee/nitro-host/src/lib.rs
@@ -9,6 +9,9 @@ pub use backend::NitroBackend;
 mod convert;
 pub use convert::Convert;
 
+mod health;
+pub use health::RegistrationHealthConfig;
+
 mod server;
 pub use server::NitroProverServer;
 

--- a/crates/proof/tee/nitro-host/src/server.rs
+++ b/crates/proof/tee/nitro-host/src/server.rs
@@ -17,9 +17,17 @@ use super::{
     transport::NitroTransport,
 };
 
+/// Maximum allowed size for the `user_data` attestation field (NSM limit).
 const MAX_USER_DATA_BYTES: usize = 512;
+
+/// Maximum allowed size for the `nonce` attestation field (NSM limit).
 const MAX_NONCE_BYTES: usize = 512;
 
+/// Host-side TEE prover server exposing a JSON-RPC interface.
+///
+/// Implements two JSON-RPC namespaces:
+/// - `prover_*`: proving operations (forwarded to the enclave via transport)
+/// - `enclave_*`: signer info queries (also forwarded via transport)
 pub struct NitroProverServer {
     service: ProverService<NitroBackend>,
     transport: Arc<NitroTransport>,
@@ -34,6 +42,7 @@ impl fmt::Debug for NitroProverServer {
 }
 
 impl NitroProverServer {
+    /// Create a server with the given prover config, enclave transport, and proof request timeout.
     pub fn new(
         config: ProverConfig,
         transport: Arc<NitroTransport>,
@@ -55,6 +64,7 @@ impl NitroProverServer {
         self
     }
 
+    /// Start the JSON-RPC HTTP server on the given address.
     pub async fn run(self, addr: SocketAddr) -> eyre::Result<ServerHandle> {
         let middleware = tower::ServiceBuilder::new()
             .layer(ProxyGetRequestLayer::new([("/healthz", "healthz")])?);
@@ -71,7 +81,6 @@ impl NitroProverServer {
             .into_rpc(),
         )?;
 
-        let transport = Arc::clone(&self.transport);
         module.merge(NitroSignerRpc { transport: Arc::clone(&self.transport) }.into_rpc())?;
 
         match self.registration_health {
@@ -85,6 +94,7 @@ impl NitroProverServer {
                 let registry =
                     TEEProverRegistryContractClient::new(config.registry_address, l1_url);
                 let version = env!("CARGO_PKG_VERSION");
+                let transport = Arc::clone(&self.transport);
                 module
                     .merge(RegistrationHealthzRpc::new(version, transport, registry).into_rpc())?;
             }

--- a/crates/proof/tee/nitro-host/src/server.rs
+++ b/crates/proof/tee/nitro-host/src/server.rs
@@ -1,6 +1,7 @@
 use std::{fmt, net::SocketAddr, sync::Arc, time::Duration};
 
 use base_health::{HealthzApiServer, HealthzRpc};
+use base_proof_contracts::TEEProverRegistryContractClient;
 use base_proof_host::{ProverConfig, ProverService};
 use base_proof_primitives::{EnclaveApiServer, ProofRequest, ProofResult, ProverApiServer};
 use jsonrpsee::{
@@ -10,23 +11,20 @@ use jsonrpsee::{
 };
 use tracing::{info, warn};
 
-use super::{NitroBackend, transport::NitroTransport};
+use super::{
+    NitroBackend,
+    health::{RegistrationHealthConfig, RegistrationHealthzRpc},
+    transport::NitroTransport,
+};
 
-/// Maximum allowed size for the `user_data` attestation field (NSM limit).
 const MAX_USER_DATA_BYTES: usize = 512;
-
-/// Maximum allowed size for the `nonce` attestation field (NSM limit).
 const MAX_NONCE_BYTES: usize = 512;
 
-/// Host-side TEE prover server exposing a JSON-RPC interface.
-///
-/// Implements two JSON-RPC namespaces:
-/// - `prover_*`: proving operations (forwarded to the enclave via transport)
-/// - `enclave_*`: signer info queries (also forwarded via transport)
 pub struct NitroProverServer {
     service: ProverService<NitroBackend>,
     transport: Arc<NitroTransport>,
     proof_request_timeout: Duration,
+    registration_health: Option<RegistrationHealthConfig>,
 }
 
 impl fmt::Debug for NitroProverServer {
@@ -36,17 +34,27 @@ impl fmt::Debug for NitroProverServer {
 }
 
 impl NitroProverServer {
-    /// Create a server with the given prover config, enclave transport, and proof request timeout.
     pub fn new(
         config: ProverConfig,
         transport: Arc<NitroTransport>,
         proof_request_timeout: Duration,
     ) -> Self {
         let backend = NitroBackend::new(Arc::clone(&transport));
-        Self { service: ProverService::new(config, backend), transport, proof_request_timeout }
+        Self {
+            service: ProverService::new(config, backend),
+            transport,
+            proof_request_timeout,
+            registration_health: None,
+        }
     }
 
-    /// Start the JSON-RPC HTTP server on the given address.
+    /// Enables registration-gated health checks. When set, `/healthz` verifies
+    /// the enclave signer is registered in the `TEEProverRegistry` on L1.
+    pub fn with_registration_health(mut self, config: RegistrationHealthConfig) -> Self {
+        self.registration_health = Some(config);
+        self
+    }
+
     pub async fn run(self, addr: SocketAddr) -> eyre::Result<ServerHandle> {
         let middleware = tower::ServiceBuilder::new()
             .layer(ProxyGetRequestLayer::new([("/healthz", "healthz")])?);
@@ -62,8 +70,28 @@ impl NitroProverServer {
             }
             .into_rpc(),
         )?;
-        module.merge(NitroSignerRpc { transport: self.transport }.into_rpc())?;
-        module.merge(HealthzRpc::new(env!("CARGO_PKG_VERSION")).into_rpc())?;
+
+        let transport = Arc::clone(&self.transport);
+        module.merge(NitroSignerRpc { transport: Arc::clone(&self.transport) }.into_rpc())?;
+
+        match self.registration_health {
+            Some(config) => {
+                info!(
+                    registry = %config.registry_address,
+                    "registration-gated health check enabled"
+                );
+                let l1_url = url::Url::parse(&config.l1_rpc_url)
+                    .map_err(|e| eyre::eyre!("invalid L1 RPC URL: {e}"))?;
+                let registry =
+                    TEEProverRegistryContractClient::new(config.registry_address, l1_url);
+                let version = env!("CARGO_PKG_VERSION");
+                module
+                    .merge(RegistrationHealthzRpc::new(version, transport, registry).into_rpc())?;
+            }
+            None => {
+                module.merge(HealthzRpc::new(env!("CARGO_PKG_VERSION")).into_rpc())?;
+            }
+        }
 
         Ok(server.start(module))
     }


### PR DESCRIPTION
## What changed? Why?

Adds an opt-in registration-gated `/healthz` endpoint to the nitro prover host. When `TEE_PROVER_REGISTRY_ADDRESS` is set (via CLI flag or env var), the health check calls `isRegisteredSigner(address)` on the L1 `TEEProverRegistry` contract to verify the enclave's signer key is registered before returning healthy. This lets the AWS ALB only route traffic to provers whose signer is registered on-chain.

Key design decisions:
- **`isRegisteredSigner` over `isValidSigner`** — avoids all provers going unhealthy simultaneously during image hash rotation
- **Opt-in via runtime config** — when `TEE_PROVER_REGISTRY_ADDRESS` is absent, existing version-only health check is preserved
- **30s cache TTL with 5-min stale fallback** — avoids hammering L1 RPC on every ALB probe while remaining resilient to L1 RPC outages
- **Address derivation** — gets 65-byte uncompressed pubkey from enclave, computes `keccak256(pubkey[1..65])`, takes last 20 bytes

### Files changed:
- `crates/proof/tee/nitro-host/src/health.rs` — new module with `RegistrationHealthConfig`, `RegistrationHealthzRpc`, `derive_signer_address`
- `crates/proof/tee/nitro-host/src/server.rs` — wires registration health check into RPC server via builder pattern
- `crates/proof/tee/nitro-host/src/lib.rs` — exports new health module
- `crates/proof/tee/nitro-host/Cargo.toml` — adds `base-proof-contracts`, `alloy-primitives`, `k256`, `url` deps
- `bin/prover/nitro-host/src/cli.rs` — adds `--tee-prover-registry-address` arg, wires through for both `server` and `local` subcommands
- `bin/prover/nitro-host/Cargo.toml` — adds `alloy-primitives` dep

## Notes to reviewers

- The corresponding `base-proofs` PR to update `entrypoint-host.sh` will follow once this merges
- The `TEEProverRegistryContractClient` and address derivation pattern already exist in the registrar crate — consolidation is deferred to a follow-up
- HTTP error behavior: jsonrpsee's `ProxyGetRequestLayer` returns HTTP 500 for RPC errors on proxy routes, so the ALB correctly sees unhealthy provers as 500

## How has it been tested?

- LSP diagnostics clean on all changed files
- Existing tests in `server.rs` still pass (healthz_returns_version, signer tests)
- Manually verified `ProxyGetRequestLayer` source to confirm RPC errors → HTTP 500 on proxy routes

## Link Jira Ticket

N/A

## Change management

- **Type**: Feature
- **Risk**: Low — opt-in only, no behavior change when env var is unset
- **Impact**: Prover health check

## Backwards Compatibility

true — when `TEE_PROVER_REGISTRY_ADDRESS` is not set, behavior is identical to before.

## automerge

false