### PR TITLE
chore(workspace): Use Uint! Macro For U256 Slots

### DIFF
--- a/crates/client/metering/src/estimator.rs
+++ b/crates/client/metering/src/estimator.rs
@@ -893,11 +893,11 @@ fn usage_extractor(resource: ResourceKind) -> fn(&MeteredTransaction) -> u128 {
 
 #[cfg(test)]
 mod tests {
-    use alloy_primitives::B256;
+    use alloy_primitives::{B256, uint};
 
     use super::*;
 
-    const DEFAULT_FEE: U256 = U256::from_limbs([1, 0, 0, 0]); // 1 wei
+    const DEFAULT_FEE: U256 = uint!(1_U256); // 1 wei
 
     fn tx(priority: u64, usage: u64) -> MeteredTransaction {
         let mut hash_bytes = [0u8; 32];

--- a/crates/execution/flashblocks/src/state_builder.rs
+++ b/crates/execution/flashblocks/src/state_builder.rs
@@ -394,7 +394,7 @@ mod tests {
 
     use alloy_consensus::{Block, BlockBody, Header, Signed};
     use alloy_eips::eip4788::{BEACON_ROOTS_ADDRESS, BEACON_ROOTS_CODE};
-    use alloy_primitives::{Address, B256, TxKind, U256, address};
+    use alloy_primitives::{Address, B256, TxKind, U256, address, uint};
     use alloy_rpc_types_engine::PayloadId;
     use base_alloy_consensus::OpTxEnvelope;
     use base_alloy_flashblocks::{
@@ -527,7 +527,7 @@ mod tests {
     const L1_BLOCK_ADDRESS: Address =
         Address::new([0x42, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0x15]);
 
-    const DA_FOOTPRINT_GAS_SCALAR_SLOT: U256 = U256::from_limbs([8u64, 0, 0, 0]);
+    const DA_FOOTPRINT_GAS_SCALAR_SLOT: U256 = uint!(8_U256);
 
     fn create_legacy_tx() -> alloy_consensus::transaction::Recovered<OpTxEnvelope> {
         let tx = alloy_consensus::TxLegacy {

--- a/crates/execution/revm/src/constants.rs
+++ b/crates/execution/revm/src/constants.rs
@@ -1,5 +1,5 @@
 //! Base constants used in the Base EVM.
-use revm::primitives::{Address, U256, address};
+use revm::primitives::{Address, U256, address, uint};
 
 /// The cost of a non-zero byte in the EVM.
 pub const NON_ZERO_BYTE_COST: u64 = 16;
@@ -31,26 +31,26 @@ pub const OPERATOR_FEE_SCALAR_DECIMAL: u64 = 1_000_000;
 pub const OPERATOR_FEE_JOVIAN_MULTIPLIER: u64 = 100;
 
 /// The L1 base fee slot.
-pub const L1_BASE_FEE_SLOT: U256 = U256::from_limbs([1u64, 0, 0, 0]);
+pub const L1_BASE_FEE_SLOT: U256 = uint!(1_U256);
 /// The L1 overhead slot.
-pub const L1_OVERHEAD_SLOT: U256 = U256::from_limbs([5u64, 0, 0, 0]);
+pub const L1_OVERHEAD_SLOT: U256 = uint!(5_U256);
 /// The L1 scalar slot.
-pub const L1_SCALAR_SLOT: U256 = U256::from_limbs([6u64, 0, 0, 0]);
+pub const L1_SCALAR_SLOT: U256 = uint!(6_U256);
 
 /// [`ECOTONE_L1_BLOB_BASE_FEE_SLOT`] was added in the Ecotone upgrade and stores the L1 blobBaseFee attribute.
-pub const ECOTONE_L1_BLOB_BASE_FEE_SLOT: U256 = U256::from_limbs([7u64, 0, 0, 0]);
+pub const ECOTONE_L1_BLOB_BASE_FEE_SLOT: U256 = uint!(7_U256);
 
 /// As of the ecotone upgrade, this storage slot stores the 32-bit basefeeScalar and blobBaseFeeScalar attributes at
 /// offsets [`BASE_FEE_SCALAR_OFFSET`] and [`BLOB_BASE_FEE_SCALAR_OFFSET`] respectively.
-pub const ECOTONE_L1_FEE_SCALARS_SLOT: U256 = U256::from_limbs([3u64, 0, 0, 0]);
+pub const ECOTONE_L1_FEE_SCALARS_SLOT: U256 = uint!(3_U256);
 
 /// This storage slot stores the 32-bit operatorFeeScalar and operatorFeeConstant attributes at
 /// offsets [`OPERATOR_FEE_SCALAR_OFFSET`] and [`OPERATOR_FEE_CONSTANT_OFFSET`] respectively.
-pub const OPERATOR_FEE_SCALARS_SLOT: U256 = U256::from_limbs([8u64, 0, 0, 0]);
+pub const OPERATOR_FEE_SCALARS_SLOT: U256 = uint!(8_U256);
 
 /// As of the Jovian upgrade, this storage slot stores the 16-bit daFootprintGasScalar attribute at
 /// offset [`DA_FOOTPRINT_GAS_SCALAR_OFFSET`].
-pub const DA_FOOTPRINT_GAS_SCALAR_SLOT: U256 = U256::from_limbs([8u64, 0, 0, 0]);
+pub const DA_FOOTPRINT_GAS_SCALAR_SLOT: U256 = uint!(8_U256);
 
 /// An empty 64-bit set of scalar values.
 pub const EMPTY_SCALARS: [u8; 8] = [0u8; 8];

--- a/crates/proof/tee/nitro-attestation-prover/src/boundless.rs
+++ b/crates/proof/tee/nitro-attestation-prover/src/boundless.rs
@@ -383,7 +383,7 @@ mod tests {
     // and alert us that the string-matching needle needs updating.
 
     mod request_not_locked {
-        use alloy_primitives::U256;
+        use alloy_primitives::{U256, uint};
         use boundless_market::{
             client::ClientError,
             contracts::{
@@ -396,7 +396,7 @@ mod tests {
         use super::*;
 
         /// Arbitrary request ID used in error construction.
-        const TEST_REQUEST_ID: U256 = U256::from_limbs([42, 0, 0, 0]);
+        const TEST_REQUEST_ID: U256 = uint!(42_U256);
 
         /// Build a `ClientError` wrapping `RequestIsNotLocked` through the
         /// **production** path: `TxnErr` → `anyhow::Error` →


### PR DESCRIPTION
## Summary

Replaces `U256::from_limbs([n, 0, 0, 0])` with the `uint!(n_U256)` macro from alloy-primitives across the workspace. The macro is already used in other parts of the codebase for the same purpose; this aligns the slot constants and a handful of test locals with that convention.