### PR TITLE
chore(workspace): Upgrade Source Hash Macro

### DIFF
--- a/crates/consensus/upgrades/src/ecotone.rs
+++ b/crates/consensus/upgrades/src/ecotone.rs
@@ -1,10 +1,10 @@
 //! Module containing a [`TxDeposit`] builder for the Ecotone network upgrade transactions.
 
-use alloc::{string::String, vec::Vec};
+use alloc::vec::Vec;
 
 use alloy_eips::eip2718::Encodable2718;
 use alloy_primitives::{Address, B256, Bytes, TxKind, U256, address, hex};
-use base_alloy_consensus::{TxDeposit, UpgradeDepositSource};
+use base_alloy_consensus::TxDeposit;
 use base_protocol::{Deployers, Predeploys, SystemAddresses};
 
 use crate::{Hardfork, UpgradeCalldata};
@@ -41,42 +41,41 @@ impl Ecotone {
         "0x8b71360ea773b4cfaf1ae6d2bd15464a4e1e2e360f786e475f63aeaed8da0ae5"
     );
 
-    /// Returns the source hash for the deployment of the l1 block contract.
-    pub fn deploy_l1_block_source() -> B256 {
-        UpgradeDepositSource { intent: String::from("Ecotone: L1 Block Deployment") }.source_hash()
-    }
+    upgrade_source_fn!(
+        /// Returns the source hash for the deployment of the l1 block contract.
+        deploy_l1_block_source,
+        "Ecotone: L1 Block Deployment"
+    );
 
-    /// Returns the source hash for the deployment of the gas price oracle contract.
-    pub fn deploy_gas_price_oracle_source() -> B256 {
-        UpgradeDepositSource { intent: String::from("Ecotone: Gas Price Oracle Deployment") }
-            .source_hash()
-    }
+    upgrade_source_fn!(
+        /// Returns the source hash for the deployment of the gas price oracle contract.
+        deploy_gas_price_oracle_source,
+        "Ecotone: Gas Price Oracle Deployment"
+    );
 
-    /// Returns the source hash for the update of the l1 block proxy.
-    pub fn update_l1_block_source() -> B256 {
-        UpgradeDepositSource { intent: String::from("Ecotone: L1 Block Proxy Update") }
-            .source_hash()
-    }
+    upgrade_source_fn!(
+        /// Returns the source hash for the update of the l1 block proxy.
+        update_l1_block_source,
+        "Ecotone: L1 Block Proxy Update"
+    );
 
-    /// Returns the source hash for the update of the gas price oracle proxy.
-    pub fn update_gas_price_oracle_source() -> B256 {
-        UpgradeDepositSource { intent: String::from("Ecotone: Gas Price Oracle Proxy Update") }
-            .source_hash()
-    }
+    upgrade_source_fn!(
+        /// Returns the source hash for the update of the gas price oracle proxy.
+        update_gas_price_oracle_source,
+        "Ecotone: Gas Price Oracle Proxy Update"
+    );
 
-    /// Returns the source hash for the Ecotone Beacon Block Roots Contract deployment.
-    pub fn beacon_roots_source() -> B256 {
-        UpgradeDepositSource {
-            intent: String::from("Ecotone: beacon block roots contract deployment"),
-        }
-        .source_hash()
-    }
+    upgrade_source_fn!(
+        /// Returns the source hash for the Ecotone Beacon Block Roots Contract deployment.
+        beacon_roots_source,
+        "Ecotone: beacon block roots contract deployment"
+    );
 
-    /// Returns the source hash for the Ecotone Gas Price Oracle activation.
-    pub fn enable_ecotone_source() -> B256 {
-        UpgradeDepositSource { intent: String::from("Ecotone: Gas Price Oracle Set Ecotone") }
-            .source_hash()
-    }
+    upgrade_source_fn!(
+        /// Returns the source hash for the Ecotone Gas Price Oracle activation.
+        enable_ecotone_source,
+        "Ecotone: Gas Price Oracle Set Ecotone"
+    );
 
     /// Returns the EIP-4788 creation data.
     pub fn eip4788_creation_data() -> Bytes {

--- a/crates/consensus/upgrades/src/fjord.rs
+++ b/crates/consensus/upgrades/src/fjord.rs
@@ -1,10 +1,10 @@
 //! Module containing a [`TxDeposit`] builder for the Fjord network upgrade transactions.
 
-use alloc::{string::String, vec::Vec};
+use alloc::vec::Vec;
 
 use alloy_eips::eip2718::Encodable2718;
 use alloy_primitives::{Address, B256, Bytes, TxKind, U256, address, hex};
-use base_alloy_consensus::{TxDeposit, UpgradeDepositSource};
+use base_alloy_consensus::TxDeposit;
 use base_protocol::{Deployers, Predeploys, SystemAddresses};
 
 use crate::{Hardfork, UpgradeCalldata};
@@ -32,23 +32,23 @@ impl Fjord {
         "0xa88fa50a2745b15e6794247614b5298483070661adacb8d32d716434ed24c6b2"
     );
 
-    /// Returns the source hash for the deployment of the Fjord Gas Price Oracle.
-    pub fn deploy_fjord_gas_price_oracle_source() -> B256 {
-        UpgradeDepositSource { intent: String::from("Fjord: Gas Price Oracle Deployment") }
-            .source_hash()
-    }
+    upgrade_source_fn!(
+        /// Returns the source hash for the deployment of the Fjord Gas Price Oracle.
+        deploy_fjord_gas_price_oracle_source,
+        "Fjord: Gas Price Oracle Deployment"
+    );
 
-    /// Returns the source hash for the update of the Fjord Gas Price Oracle.
-    pub fn update_fjord_gas_price_oracle_source() -> B256 {
-        UpgradeDepositSource { intent: String::from("Fjord: Gas Price Oracle Proxy Update") }
-            .source_hash()
-    }
+    upgrade_source_fn!(
+        /// Returns the source hash for the update of the Fjord Gas Price Oracle.
+        update_fjord_gas_price_oracle_source,
+        "Fjord: Gas Price Oracle Proxy Update"
+    );
 
-    /// [`UpgradeDepositSource`] for setting the Fjord Gas Price Oracle.
-    pub fn enable_fjord_source() -> B256 {
-        UpgradeDepositSource { intent: String::from("Fjord: Gas Price Oracle Set Fjord") }
-            .source_hash()
-    }
+    upgrade_source_fn!(
+        /// Returns the source hash for setting the Fjord Gas Price Oracle.
+        enable_fjord_source,
+        "Fjord: Gas Price Oracle Set Fjord"
+    );
 
     /// Returns the fjord gas price oracle deployment bytecode.
     pub fn gas_price_oracle_deployment_bytecode() -> alloy_primitives::Bytes {

--- a/crates/consensus/upgrades/src/isthmus.rs
+++ b/crates/consensus/upgrades/src/isthmus.rs
@@ -4,11 +4,11 @@
 //!
 //! [specs]: https://specs.optimism.io/protocol/isthmus/derivation.html#network-upgrade-automation-transactions
 
-use alloc::{string::String, vec::Vec};
+use alloc::vec::Vec;
 
 use alloy_eips::eip2718::Encodable2718;
 use alloy_primitives::{Address, B256, Bytes, TxKind, U256, address, hex};
-use base_alloy_consensus::{TxDeposit, UpgradeDepositSource};
+use base_alloy_consensus::TxDeposit;
 use base_protocol::{Deployers, Predeploys, SystemAddresses};
 
 use crate::{Hardfork, UpgradeCalldata};
@@ -57,52 +57,53 @@ impl Isthmus {
     pub const OPERATOR_FEE_VAULT_CODE_HASH: B256 = alloy_primitives::b256!(
         "0x57dc55c9c09ca456fa728f253fe7b895d3e6aae0706104935fe87c7721001971"
     );
-    /// Returns the source hash for the Isthmus Gas Price Oracle activation.
-    pub fn enable_isthmus_source() -> B256 {
-        UpgradeDepositSource { intent: String::from("Isthmus: Gas Price Oracle Set Isthmus") }
-            .source_hash()
-    }
+    upgrade_source_fn!(
+        /// Returns the source hash for the Isthmus Gas Price Oracle activation.
+        enable_isthmus_source,
+        "Isthmus: Gas Price Oracle Set Isthmus"
+    );
 
-    /// Returns the source hash for the EIP-2935 block hash history contract deployment.
-    pub fn block_hash_history_contract_source() -> B256 {
-        UpgradeDepositSource { intent: String::from("Isthmus: EIP-2935 Contract Deployment") }
-            .source_hash()
-    }
+    upgrade_source_fn!(
+        /// Returns the source hash for the EIP-2935 block hash history contract deployment.
+        block_hash_history_contract_source,
+        "Isthmus: EIP-2935 Contract Deployment"
+    );
 
-    /// Returns the source hash for the deployment of the gas price oracle contract.
-    pub fn deploy_gas_price_oracle_source() -> B256 {
-        UpgradeDepositSource { intent: String::from("Isthmus: Gas Price Oracle Deployment") }
-            .source_hash()
-    }
+    upgrade_source_fn!(
+        /// Returns the source hash for the deployment of the gas price oracle contract.
+        deploy_gas_price_oracle_source,
+        "Isthmus: Gas Price Oracle Deployment"
+    );
 
-    /// Returns the source hash for the deployment of the l1 block contract.
-    pub fn deploy_l1_block_source() -> B256 {
-        UpgradeDepositSource { intent: String::from("Isthmus: L1 Block Deployment") }.source_hash()
-    }
+    upgrade_source_fn!(
+        /// Returns the source hash for the deployment of the l1 block contract.
+        deploy_l1_block_source,
+        "Isthmus: L1 Block Deployment"
+    );
 
-    /// Returns the source hash for the deployment of the operator fee vault contract.
-    pub fn deploy_operator_fee_vault_source() -> B256 {
-        UpgradeDepositSource { intent: String::from("Isthmus: Operator Fee Vault Deployment") }
-            .source_hash()
-    }
+    upgrade_source_fn!(
+        /// Returns the source hash for the deployment of the operator fee vault contract.
+        deploy_operator_fee_vault_source,
+        "Isthmus: Operator Fee Vault Deployment"
+    );
 
-    /// Returns the source hash for the update of the l1 block proxy.
-    pub fn update_l1_block_source() -> B256 {
-        UpgradeDepositSource { intent: String::from("Isthmus: L1 Block Proxy Update") }
-            .source_hash()
-    }
+    upgrade_source_fn!(
+        /// Returns the source hash for the update of the l1 block proxy.
+        update_l1_block_source,
+        "Isthmus: L1 Block Proxy Update"
+    );
 
-    /// Returns the source hash for the update of the gas price oracle proxy.
-    pub fn update_gas_price_oracle_source() -> B256 {
-        UpgradeDepositSource { intent: String::from("Isthmus: Gas Price Oracle Proxy Update") }
-            .source_hash()
-    }
+    upgrade_source_fn!(
+        /// Returns the source hash for the update of the gas price oracle proxy.
+        update_gas_price_oracle_source,
+        "Isthmus: Gas Price Oracle Proxy Update"
+    );
 
-    /// Returns the source hash for the update of the operator fee vault proxy.
-    pub fn update_operator_fee_vault_source() -> B256 {
-        UpgradeDepositSource { intent: String::from("Isthmus: Operator Fee Vault Proxy Update") }
-            .source_hash()
-    }
+    upgrade_source_fn!(
+        /// Returns the source hash for the update of the operator fee vault proxy.
+        update_operator_fee_vault_source,
+        "Isthmus: Operator Fee Vault Proxy Update"
+    );
 
     /// Returns the raw bytecode for the L1 Block deployment.
     pub fn l1_block_deployment_bytecode() -> Bytes {

--- a/crates/consensus/upgrades/src/jovian.rs
+++ b/crates/consensus/upgrades/src/jovian.rs
@@ -4,11 +4,11 @@
 //!
 //! [specs]: https://specs.optimism.io/protocol/jovian/derivation.html#network-upgrade-automation-transactions
 
-use alloc::{string::String, vec::Vec};
+use alloc::vec::Vec;
 
 use alloy_eips::eip2718::Encodable2718;
-use alloy_primitives::{Address, B256, Bytes, TxKind, U256, hex, keccak256};
-use base_alloy_consensus::{TxDeposit, UpgradeDepositSource};
+use alloy_primitives::{Address, Bytes, TxKind, U256, hex, keccak256};
+use base_alloy_consensus::TxDeposit;
 use base_protocol::{Deployers, Predeploys, SystemAddresses};
 
 use crate::{Hardfork, UpgradeCalldata};
@@ -18,27 +18,29 @@ use crate::{Hardfork, UpgradeCalldata};
 pub struct Jovian;
 
 impl Jovian {
-    /// Returns the source hash for the deployment of the l1 block contract.
-    pub fn deploy_l1_block_source() -> B256 {
-        UpgradeDepositSource { intent: String::from("Jovian: L1 Block Deployment") }.source_hash()
-    }
+    upgrade_source_fn!(
+        /// Returns the source hash for the deployment of the l1 block contract.
+        deploy_l1_block_source,
+        "Jovian: L1 Block Deployment"
+    );
 
-    /// Returns the source hash for the deployment of the gas price oracle contract.
-    pub fn l1_block_proxy_update() -> B256 {
-        UpgradeDepositSource { intent: String::from("Jovian: L1 Block Proxy Update") }.source_hash()
-    }
+    upgrade_source_fn!(
+        /// Returns the source hash for the l1 block proxy update.
+        l1_block_proxy_update,
+        "Jovian: L1 Block Proxy Update"
+    );
 
-    /// Returns the source hash for the deployment of the operator fee vault contract.
-    pub fn gas_price_oracle() -> B256 {
-        UpgradeDepositSource { intent: String::from("Jovian: Gas Price Oracle Deployment") }
-            .source_hash()
-    }
+    upgrade_source_fn!(
+        /// Returns the source hash for the deployment of the gas price oracle contract.
+        gas_price_oracle,
+        "Jovian: Gas Price Oracle Deployment"
+    );
 
-    /// Returns the source hash for the update of the l1 block proxy.
-    pub fn gas_price_oracle_proxy_update() -> B256 {
-        UpgradeDepositSource { intent: String::from("Jovian: Gas Price Oracle Proxy Update") }
-            .source_hash()
-    }
+    upgrade_source_fn!(
+        /// Returns the source hash for the gas price oracle proxy update.
+        gas_price_oracle_proxy_update,
+        "Jovian: Gas Price Oracle Proxy Update"
+    );
 
     /// The Jovian L1 Block Address
     /// This is computed by using `Address::create` function,
@@ -54,11 +56,11 @@ impl Jovian {
         Deployers::JOVIAN_GAS_PRICE_ORACLE.create(0)
     }
 
-    /// Returns the source hash to the enable the gas price oracle for Jovian.
-    pub fn gas_price_oracle_enable_jovian() -> B256 {
-        UpgradeDepositSource { intent: String::from("Jovian: Gas Price Oracle Set Jovian") }
-            .source_hash()
-    }
+    upgrade_source_fn!(
+        /// Returns the source hash to enable the gas price oracle for Jovian.
+        gas_price_oracle_enable_jovian,
+        "Jovian: Gas Price Oracle Set Jovian"
+    );
 
     /// Returns the raw bytecode for the L1 Block deployment.
     pub fn l1_block_deployment_bytecode() -> Bytes {

--- a/crates/consensus/upgrades/src/lib.rs
+++ b/crates/consensus/upgrades/src/lib.rs
@@ -9,6 +9,22 @@
 
 extern crate alloc;
 
+/// Generates a `pub fn $name() -> B256` that constructs an [`UpgradeDepositSource`] from the
+/// given intent string and returns its source hash. Accepts optional doc attributes.
+///
+/// [`UpgradeDepositSource`]: base_alloy_consensus::UpgradeDepositSource
+macro_rules! upgrade_source_fn {
+    ($(#[$attr:meta])* $name:ident, $intent:literal) => {
+        $(#[$attr])*
+        pub fn $name() -> ::alloy_primitives::B256 {
+            ::base_alloy_consensus::UpgradeDepositSource {
+                intent: ::alloc::string::String::from($intent),
+            }
+            .source_hash()
+        }
+    };
+}
+
 mod traits;
 pub use traits::Hardfork;
 


### PR DESCRIPTION
## Summary

Introduces an internal `upgrade_source_fn!` macro in `base-consensus-upgrades` that generates the boilerplate `pub fn $name() -> B256` functions that each hardfork impl block repeats to compute `UpgradeDepositSource` hashes from intent strings. Replaces 22 identically-structured functions across ecotone, fjord, isthmus, and jovian with macro invocations, keeping the doc comments and the intent strings co-located in a single line each. The macro uses fully-qualified paths so call sites have no new scope requirements.