### PR TITLE
chore(workspace): Bytecode Hex Macro And Boot Uint

### DIFF
--- a/crates/consensus/upgrades/src/ecotone.rs
+++ b/crates/consensus/upgrades/src/ecotone.rs
@@ -79,23 +79,17 @@ impl Ecotone {
 
     /// Returns the EIP-4788 creation data.
     pub fn eip4788_creation_data() -> Bytes {
-        hex::decode(include_str!("./bytecode/eip4788_ecotone.hex").replace('\n', ""))
-            .expect("Expected hex byte string")
-            .into()
+        bytecode_from_hex!("./bytecode/eip4788_ecotone.hex")
     }
 
     /// Returns the raw bytecode for the L1 Block deployment.
     pub fn l1_block_deployment_bytecode() -> Bytes {
-        hex::decode(include_str!("./bytecode/l1_block_ecotone.hex").replace('\n', ""))
-            .expect("Expected hex byte string")
-            .into()
+        bytecode_from_hex!("./bytecode/l1_block_ecotone.hex")
     }
 
     /// Returns the gas price oracle deployment bytecode.
     pub fn ecotone_gas_price_oracle_deployment_bytecode() -> Bytes {
-        hex::decode(include_str!("./bytecode/gpo_ecotone.hex").replace('\n', ""))
-            .expect("Expected hex byte string")
-            .into()
+        bytecode_from_hex!("./bytecode/gpo_ecotone.hex")
     }
 
     /// Returns the list of [`TxDeposit`]s for the Ecotone network upgrade.
@@ -271,24 +265,12 @@ mod tests {
         assert_eq!(ecotone_upgrade_tx.len(), 6);
 
         let expected_txs: Vec<Bytes> = vec![
-            hex::decode(include_str!("./bytecode/ecotone_tx_0.hex").replace('\n', ""))
-                .unwrap()
-                .into(),
-            hex::decode(include_str!("./bytecode/ecotone_tx_1.hex").replace('\n', ""))
-                .unwrap()
-                .into(),
-            hex::decode(include_str!("./bytecode/ecotone_tx_2.hex").replace('\n', ""))
-                .unwrap()
-                .into(),
-            hex::decode(include_str!("./bytecode/ecotone_tx_3.hex").replace('\n', ""))
-                .unwrap()
-                .into(),
-            hex::decode(include_str!("./bytecode/ecotone_tx_4.hex").replace('\n', ""))
-                .unwrap()
-                .into(),
-            hex::decode(include_str!("./bytecode/ecotone_tx_5.hex").replace('\n', ""))
-                .unwrap()
-                .into(),
+            bytecode_from_hex!("./bytecode/ecotone_tx_0.hex"),
+            bytecode_from_hex!("./bytecode/ecotone_tx_1.hex"),
+            bytecode_from_hex!("./bytecode/ecotone_tx_2.hex"),
+            bytecode_from_hex!("./bytecode/ecotone_tx_3.hex"),
+            bytecode_from_hex!("./bytecode/ecotone_tx_4.hex"),
+            bytecode_from_hex!("./bytecode/ecotone_tx_5.hex"),
         ];
         for (i, expected) in expected_txs.iter().enumerate() {
             assert_eq!(ecotone_upgrade_tx[i], *expected);

--- a/crates/consensus/upgrades/src/fjord.rs
+++ b/crates/consensus/upgrades/src/fjord.rs
@@ -52,9 +52,7 @@ impl Fjord {
 
     /// Returns the fjord gas price oracle deployment bytecode.
     pub fn gas_price_oracle_deployment_bytecode() -> alloy_primitives::Bytes {
-        hex::decode(include_str!("./bytecode/gpo_fjord.hex").replace('\n', ""))
-            .expect("Expected hex byte string")
-            .into()
+        bytecode_from_hex!("./bytecode/gpo_fjord.hex")
     }
 
     /// Returns the list of [`TxDeposit`]s for the Fjord network upgrade.
@@ -149,15 +147,9 @@ mod tests {
         assert_eq!(fjord_upgrade_tx.len(), 3);
 
         let expected_txs: Vec<Bytes> = vec![
-            hex::decode(include_str!("./bytecode/fjord_tx_0.hex").replace('\n', ""))
-                .unwrap()
-                .into(),
-            hex::decode(include_str!("./bytecode/fjord_tx_1.hex").replace('\n', ""))
-                .unwrap()
-                .into(),
-            hex::decode(include_str!("./bytecode/fjord_tx_2.hex").replace('\n', ""))
-                .unwrap()
-                .into(),
+            bytecode_from_hex!("./bytecode/fjord_tx_0.hex"),
+            bytecode_from_hex!("./bytecode/fjord_tx_1.hex"),
+            bytecode_from_hex!("./bytecode/fjord_tx_2.hex"),
         ];
         for (i, expected) in expected_txs.iter().enumerate() {
             assert_eq!(fjord_upgrade_tx[i], *expected);

--- a/crates/consensus/upgrades/src/isthmus.rs
+++ b/crates/consensus/upgrades/src/isthmus.rs
@@ -107,30 +107,22 @@ impl Isthmus {
 
     /// Returns the raw bytecode for the L1 Block deployment.
     pub fn l1_block_deployment_bytecode() -> Bytes {
-        hex::decode(include_str!("./bytecode/l1_block_isthmus.hex").replace('\n', ""))
-            .expect("Expected hex byte string")
-            .into()
+        bytecode_from_hex!("./bytecode/l1_block_isthmus.hex")
     }
 
     /// Returns the gas price oracle deployment bytecode.
     pub fn gas_price_oracle_deployment_bytecode() -> Bytes {
-        hex::decode(include_str!("./bytecode/gpo_isthmus.hex").replace('\n', ""))
-            .expect("Expected hex byte string")
-            .into()
+        bytecode_from_hex!("./bytecode/gpo_isthmus.hex")
     }
 
     /// Returns the gas price oracle deployment bytecode.
     pub fn operator_fee_vault_deployment_bytecode() -> Bytes {
-        hex::decode(include_str!("./bytecode/ofv_isthmus.hex").replace('\n', ""))
-            .expect("Expected hex byte string")
-            .into()
+        bytecode_from_hex!("./bytecode/ofv_isthmus.hex")
     }
 
     /// Returns the EIP-2935 creation data.
     pub fn eip2935_creation_data() -> Bytes {
-        hex::decode(include_str!("./bytecode/eip2935_isthmus.hex").replace('\n', ""))
-            .expect("Expected hex byte string")
-            .into()
+        bytecode_from_hex!("./bytecode/eip2935_isthmus.hex")
     }
 
     /// Returns the list of [`TxDeposit`]s for the network upgrade.
@@ -289,30 +281,14 @@ mod tests {
         assert_eq!(isthmus_upgrade_tx.len(), 8);
 
         let expected_txs: Vec<Bytes> = vec![
-            hex::decode(include_str!("./bytecode/isthmus_tx_0.hex").replace('\n', ""))
-                .unwrap()
-                .into(),
-            hex::decode(include_str!("./bytecode/isthmus_tx_1.hex").replace('\n', ""))
-                .unwrap()
-                .into(),
-            hex::decode(include_str!("./bytecode/isthmus_tx_2.hex").replace('\n', ""))
-                .unwrap()
-                .into(),
-            hex::decode(include_str!("./bytecode/isthmus_tx_3.hex").replace('\n', ""))
-                .unwrap()
-                .into(),
-            hex::decode(include_str!("./bytecode/isthmus_tx_4.hex").replace('\n', ""))
-                .unwrap()
-                .into(),
-            hex::decode(include_str!("./bytecode/isthmus_tx_5.hex").replace('\n', ""))
-                .unwrap()
-                .into(),
-            hex::decode(include_str!("./bytecode/isthmus_tx_6.hex").replace('\n', ""))
-                .unwrap()
-                .into(),
-            hex::decode(include_str!("./bytecode/isthmus_tx_7.hex").replace('\n', ""))
-                .unwrap()
-                .into(),
+            bytecode_from_hex!("./bytecode/isthmus_tx_0.hex"),
+            bytecode_from_hex!("./bytecode/isthmus_tx_1.hex"),
+            bytecode_from_hex!("./bytecode/isthmus_tx_2.hex"),
+            bytecode_from_hex!("./bytecode/isthmus_tx_3.hex"),
+            bytecode_from_hex!("./bytecode/isthmus_tx_4.hex"),
+            bytecode_from_hex!("./bytecode/isthmus_tx_5.hex"),
+            bytecode_from_hex!("./bytecode/isthmus_tx_6.hex"),
+            bytecode_from_hex!("./bytecode/isthmus_tx_7.hex"),
         ];
         for (i, expected) in expected_txs.iter().enumerate() {
             assert_eq!(isthmus_upgrade_tx[i], *expected);

--- a/crates/consensus/upgrades/src/jovian.rs
+++ b/crates/consensus/upgrades/src/jovian.rs
@@ -64,18 +64,12 @@ impl Jovian {
 
     /// Returns the raw bytecode for the L1 Block deployment.
     pub fn l1_block_deployment_bytecode() -> Bytes {
-        hex::decode(include_str!("./bytecode/jovian-l1-block-deployment.hex").replace('\n', ""))
-            .expect("Expected hex byte string")
-            .into()
+        bytecode_from_hex!("./bytecode/jovian-l1-block-deployment.hex")
     }
 
     /// Returns the gas price oracle deployment bytecode.
     pub fn gas_price_oracle_deployment_bytecode() -> Bytes {
-        hex::decode(
-            include_str!("./bytecode/jovian-gas-price-oracle-deployment.hex").replace('\n', ""),
-        )
-        .expect("Expected hex byte string")
-        .into()
+        bytecode_from_hex!("./bytecode/jovian-gas-price-oracle-deployment.hex")
     }
 
     /// Returns the bytecode to enable the gas price oracle for Jovian.

--- a/crates/consensus/upgrades/src/lib.rs
+++ b/crates/consensus/upgrades/src/lib.rs
@@ -25,6 +25,18 @@ macro_rules! upgrade_source_fn {
     };
 }
 
+/// Decodes a hex-encoded bytecode file at compile time and returns it as [`alloy_primitives::Bytes`].
+///
+/// Strips trailing newlines from the file content, hex-decodes the result,
+/// and converts it into `Bytes`. Panics at runtime if the file content is not valid hex.
+macro_rules! bytecode_from_hex {
+    ($path:expr) => {
+        hex::decode(include_str!($path).replace('\n', ""))
+            .expect("Expected hex byte string")
+            .into()
+    };
+}
+
 mod traits;
 pub use traits::Hardfork;
 

--- a/crates/consensus/upgrades/src/lib.rs
+++ b/crates/consensus/upgrades/src/lib.rs
@@ -31,9 +31,7 @@ macro_rules! upgrade_source_fn {
 /// and converts it into `Bytes`. Panics at runtime if the file content is not valid hex.
 macro_rules! bytecode_from_hex {
     ($path:expr) => {
-        hex::decode(include_str!($path).replace('\n', ""))
-            .expect("Expected hex byte string")
-            .into()
+        hex::decode(include_str!($path).replace('\n', "")).expect("Expected hex byte string").into()
     };
 }
 

--- a/crates/proof/proof/src/boot.rs
+++ b/crates/proof/proof/src/boot.rs
@@ -1,7 +1,7 @@
 //! This module contains the prologue phase of the client program, pulling in the boot information
 //! through the `PreimageOracle` ABI as local keys.
 
-use alloy_primitives::{Address, B256, U256};
+use alloy_primitives::{Address, B256, U256, uint};
 use base_consensus_genesis::{L1ChainConfig, RollupConfig};
 use base_consensus_registry::Registry;
 use base_proof_preimage::{PreimageKey, PreimageOracleClient};
@@ -14,56 +14,56 @@ use crate::errors::OracleProviderError;
 /// This key is used to retrieve the L1 block hash that contains all the data
 /// necessary to derive the disputed L2 blocks. The L1 head serves as the
 /// starting point for L1 data extraction during the derivation process.
-pub const L1_HEAD_KEY: U256 = U256::from_be_slice(&[1]);
+pub const L1_HEAD_KEY: U256 = uint!(1_U256);
 
 /// The local key identifier for the agreed L2 output root.
 ///
 /// This key retrieves the baseline L2 output root that both parties agree upon.
 /// It represents the last known good state before the disputed blocks and serves
 /// as the starting point for derivation verification.
-pub const L2_OUTPUT_ROOT_KEY: U256 = U256::from_be_slice(&[2]);
+pub const L2_OUTPUT_ROOT_KEY: U256 = uint!(2_U256);
 
 /// The local key identifier for the disputed L2 output root claim.
 ///
 /// This key retrieves the user's claimed L2 output root at the target block.
 /// The fault proof will compare the derived output root against this claim
 /// to determine if the claim is valid or invalid.
-pub const L2_CLAIM_KEY: U256 = U256::from_be_slice(&[3]);
+pub const L2_CLAIM_KEY: U256 = uint!(3_U256);
 
 /// The local key identifier for the disputed L2 block number.
 ///
 /// This key retrieves the L2 block number at which the output root disagreement
 /// occurs. The derivation process will produce blocks up to this number to
 /// verify the claim.
-pub const L2_CLAIM_BLOCK_NUMBER_KEY: U256 = U256::from_be_slice(&[4]);
+pub const L2_CLAIM_BLOCK_NUMBER_KEY: U256 = uint!(4_U256);
 
 /// The local key identifier for the L2 chain ID.
 ///
 /// This key retrieves the L2 network identifier, which is used to load the
 /// appropriate rollup configuration and ensure network-specific validation
 /// rules are applied correctly.
-pub const L2_CHAIN_ID_KEY: U256 = U256::from_be_slice(&[5]);
+pub const L2_CHAIN_ID_KEY: U256 = uint!(5_U256);
 
 /// The local key identifier for the L2 rollup configuration.
 ///
 /// This key is used as a fallback to retrieve the rollup configuration from
 /// the preimage oracle when no hardcoded configuration is available for the
 /// given chain ID. Oracle-loaded configs require additional validation.
-pub const L2_ROLLUP_CONFIG_KEY: U256 = U256::from_be_slice(&[6]);
+pub const L2_ROLLUP_CONFIG_KEY: U256 = uint!(6_U256);
 
 /// The local key identifier for the L1 chain configuration.
 ///
 /// This key is used as a fallback to retrieve the chain configuration from
 /// the preimage oracle when no hardcoded configuration is available for the
 /// given chain ID. Oracle-loaded configs require additional validation.
-pub const L1_CONFIG_KEY: U256 = U256::from_be_slice(&[7]);
+pub const L1_CONFIG_KEY: U256 = uint!(7_U256);
 
 /// The local key identifier for the proposer address.
 ///
 /// This key retrieves the address of the proposer that will submit the proof
 /// transaction on-chain. The enclave includes this address in the proof journal
 /// so on-chain verification can match it against the actual `msg.sender`.
-pub const PROPOSER_KEY: U256 = U256::from_be_slice(&[8]);
+pub const PROPOSER_KEY: U256 = uint!(8_U256);
 
 /// The local key identifier for the intermediate block interval.
 ///
@@ -71,13 +71,13 @@ pub const PROPOSER_KEY: U256 = U256::from_be_slice(&[8]);
 /// checkpoints. The enclave uses this to sample the correct intermediate roots
 /// when constructing the aggregate proof journal, matching the on-chain
 /// `AggregateVerifier`'s `INTERMEDIATE_BLOCK_INTERVAL`.
-pub const INTERMEDIATE_BLOCK_INTERVAL_KEY: U256 = U256::from_be_slice(&[9]);
+pub const INTERMEDIATE_BLOCK_INTERVAL_KEY: U256 = uint!(9_U256);
 
 /// The local key identifier for the L1 head block number.
 ///
 /// This key retrieves the block number corresponding to `L1_HEAD_KEY`, allowing
 /// the enclave to reference the L1 head number without an extra lookup.
-pub const L1_HEAD_NUMBER_KEY: U256 = U256::from_be_slice(&[10]);
+pub const L1_HEAD_NUMBER_KEY: U256 = uint!(10_U256);
 
 /// The boot information for the client program.
 ///


### PR DESCRIPTION
## Summary

Introduces a `bytecode_from_hex!` macro in `base-consensus-upgrades` that wraps the repeated hex-decode-and-convert pattern used by every bytecode-loading function and test vector across the four hardfork upgrade files. Replaces 26 identical three-line expressions with single-line macro invocations, and unifies the test vectors from `.unwrap()` to `.expect()` in the process.

Also replaces `U256::from_be_slice(&[n])` with `uint!(n_U256)` for the 10 boot info key constants in `base-proof`, aligning them with how small integer U256 constants are expressed everywhere else in the workspace.