### PR TITLE
fix(tracing): Interpolated Log Strings

### DIFF
--- a/crates/builder/core/src/test_utils/apis.rs
+++ b/crates/builder/core/src/test_utils/apis.rs
@@ -237,7 +237,7 @@ pub fn generate_genesis(output: Option<String>) -> eyre::Result<()> {
     // Write the result to the output file
     if let Some(output) = output {
         std::fs::write(&output, serde_json::to_string_pretty(&genesis)?)?;
-        info!("Generated genesis file at: {output}");
+        info!(output = %output, "Generated genesis file at");
     } else {
         println!("{}", serde_json::to_string_pretty(&genesis)?);
     }

--- a/crates/execution/engine-tree/src/validator.rs
+++ b/crates/execution/engine-tree/src/validator.rs
@@ -667,12 +667,12 @@ where
     #[instrument(level = "debug", target = "engine::tree::payload_validator", skip_all)]
     fn validate_block_inner(&self, block: &SealedBlock<OpBlock>) -> Result<(), ConsensusError> {
         if let Err(e) = self.consensus.validate_header(block.sealed_header()) {
-            error!(target: "engine::tree::payload_validator", ?block, "Failed to validate header {}: {e}", block.hash());
+            error!(target: "engine::tree::payload_validator", ?block, hash = %block.hash(), error = %e, "Failed to validate header");
             return Err(e);
         }
 
         if let Err(e) = self.consensus.validate_block_pre_execution(block) {
-            error!(target: "engine::tree::payload_validator", ?block, "Failed to validate block {}: {e}", block.hash());
+            error!(target: "engine::tree::payload_validator", ?block, hash = %block.hash(), error = %e, "Failed to validate block");
             return Err(e);
         }
 
@@ -1079,7 +1079,7 @@ where
         if let Err(e) =
             self.consensus.validate_header_against_parent(block.sealed_header(), parent_block)
         {
-            warn!(target: "engine::tree::payload_validator", ?block, "Failed to validate header {} against parent: {e}", block.hash());
+            warn!(target: "engine::tree::payload_validator", ?block, hash = %block.hash(), error = %e, "Failed to validate header against parent");
             return Err(e.into());
         }
         drop(_enter);


### PR DESCRIPTION
## Summary
Five tracing calls in the execution engine validator and builder test utilities were using interpolated format strings in the message argument instead of structured key=value fields. Each call has been updated so the message is a static string and all dynamic data (block hash, error) is passed as named fields using the \`%\` Display formatter. This follows the project convention that variable data must never appear inline in the tracing message string.

Closes #1877.