### PR TITLE
fix(tee): increase tokio worker thread stack size for nitro-host

### DIFF
--- a/bin/batcher/src/cli.rs
+++ b/bin/batcher/src/cli.rs
@@ -38,7 +38,7 @@ impl Cli {
         base_cli_utils::MetricsConfig::from(self.args.metrics.clone()).init_with(|| {
             base_cli_utils::register_version_metrics!();
         })?;
-        RuntimeManager::run_until_ctrl_c(self.args.exec())
+        RuntimeManager::new().run_until_ctrl_c(self.args.exec())
     }
 }
 

--- a/bin/challenger/src/cli.rs
+++ b/bin/challenger/src/cli.rs
@@ -15,8 +15,7 @@ impl Cli {
     /// Run the challenger service.
     pub(crate) fn run(self) -> eyre::Result<()> {
         let config = base_challenger::ChallengerConfig::from_cli(self.args)?;
-        base_cli_utils::RuntimeManager::run_until_ctrl_c(base_challenger::ChallengerService::run(
-            config,
-        ))
+        base_cli_utils::RuntimeManager::new()
+            .run_until_ctrl_c(base_challenger::ChallengerService::run(config))
     }
 }

--- a/bin/consensus/src/cli.rs
+++ b/bin/consensus/src/cli.rs
@@ -142,7 +142,7 @@ impl Follow {
         })?;
 
         // Run the subcommand.
-        RuntimeManager::run_until_ctrl_c(self.exec())
+        RuntimeManager::new().run_until_ctrl_c(self.exec())
     }
 
     /// Run the Follow subcommand.
@@ -302,7 +302,7 @@ impl Node {
         })?;
 
         // Run the subcommand.
-        RuntimeManager::run_until_ctrl_c(self.exec())
+        RuntimeManager::new().run_until_ctrl_c(self.exec())
     }
 
     /// Returns the signer [`Address`] from the rollup config for the given l2 chain id.

--- a/bin/prover/nitro-host/src/cli.rs
+++ b/bin/prover/nitro-host/src/cli.rs
@@ -127,14 +127,16 @@ impl Cli {
         base_cli_utils::MetricsConfig::from(metrics).init_with(|| {
             base_cli_utils::register_version_metrics!();
         })?;
-        RuntimeManager::run_until_ctrl_c(async move {
-            match command {
-                #[cfg(target_os = "linux")]
-                Command::Server(args) => args.run().await,
-                #[cfg(feature = "local")]
-                Command::Local(args) => args.run().await,
-            }
-        })
+        RuntimeManager::new()
+            .with_thread_stack_size(8 * 1024 * 1024)
+            .run_until_ctrl_c(async move {
+                match command {
+                    #[cfg(target_os = "linux")]
+                    Command::Server(args) => args.run().await,
+                    #[cfg(feature = "local")]
+                    Command::Local(args) => args.run().await,
+                }
+            })
     }
 }
 

--- a/bin/prover/nitro-host/src/cli.rs
+++ b/bin/prover/nitro-host/src/cli.rs
@@ -127,16 +127,14 @@ impl Cli {
         base_cli_utils::MetricsConfig::from(metrics).init_with(|| {
             base_cli_utils::register_version_metrics!();
         })?;
-        RuntimeManager::new()
-            .with_thread_stack_size(8 * 1024 * 1024)
-            .run_until_ctrl_c(async move {
-                match command {
-                    #[cfg(target_os = "linux")]
-                    Command::Server(args) => args.run().await,
-                    #[cfg(feature = "local")]
-                    Command::Local(args) => args.run().await,
-                }
-            })
+        RuntimeManager::new().with_thread_stack_size(8 * 1024 * 1024).run_until_ctrl_c(async move {
+            match command {
+                #[cfg(target_os = "linux")]
+                Command::Server(args) => args.run().await,
+                #[cfg(feature = "local")]
+                Command::Local(args) => args.run().await,
+            }
+        })
     }
 }
 

--- a/bin/prover/zk/src/cli.rs
+++ b/bin/prover/zk/src/cli.rs
@@ -125,7 +125,7 @@ impl Cli {
         base_cli_utils::MetricsConfig::from(metrics).init_with(|| {
             base_cli_utils::register_version_metrics!();
         })?;
-        RuntimeManager::run_until_ctrl_c(async move { args.run().await })
+        RuntimeManager::new().run_until_ctrl_c(async move { args.run().await })
     }
 }
 

--- a/crates/utilities/cli/src/runtime.rs
+++ b/crates/utilities/cli/src/runtime.rs
@@ -12,13 +12,37 @@ use tracing::info;
 
 /// A runtime manager.
 #[derive(Debug, Clone, Copy)]
-pub struct RuntimeManager;
+pub struct RuntimeManager {
+    /// Worker thread stack size override.
+    thread_stack_size: Option<usize>,
+}
+
+impl Default for RuntimeManager {
+    fn default() -> Self {
+        Self::new()
+    }
+}
 
 impl RuntimeManager {
+    /// Creates a new [`RuntimeManager`] with default settings.
+    pub const fn new() -> Self {
+        Self { thread_stack_size: None }
+    }
+
+    /// Sets the worker thread stack size (in bytes).
+    pub const fn with_thread_stack_size(mut self, size: usize) -> Self {
+        self.thread_stack_size = Some(size);
+        self
+    }
+
     /// Creates a new default tokio multi-thread [Runtime](tokio::runtime::Runtime) with all
     /// features enabled.
-    pub fn tokio_runtime() -> Result<tokio::runtime::Runtime, std::io::Error> {
-        tokio::runtime::Builder::new_multi_thread().enable_all().build()
+    pub fn tokio_runtime(&self) -> Result<tokio::runtime::Runtime, std::io::Error> {
+        let mut builder = tokio::runtime::Builder::new_multi_thread();
+        if let Some(size) = self.thread_stack_size {
+            builder.thread_stack_size(size);
+        }
+        builder.enable_all().build()
     }
 
     /// Installs SIGTERM + SIGINT handlers that cancel the given token.
@@ -56,11 +80,11 @@ impl RuntimeManager {
     }
 
     /// Run a fallible future until ctrl-c is pressed.
-    pub fn run_until_ctrl_c<F>(fut: F) -> eyre::Result<()>
+    pub fn run_until_ctrl_c<F>(&self, fut: F) -> eyre::Result<()>
     where
         F: Future<Output = eyre::Result<()>>,
     {
-        let rt = Self::tokio_runtime().map_err(|e| eyre::eyre!(e))?;
+        let rt = self.tokio_runtime().map_err(|e| eyre::eyre!(e))?;
         rt.block_on(async move {
             tokio::select! {
                 biased;


### PR DESCRIPTION
## Summary

- Convert `RuntimeManager` from a unit struct to a builder pattern so callers can optionally configure the tokio worker thread stack size
- Set 8 MiB stack size for the nitro-host binary to prevent stack overflow during EVM execution in the fault proof driver
- All other callers (`batcher`, `consensus`, `challenger`, `zk`) use `RuntimeManager::new()` with the OS default — no behavior change

## Problem

The nitro-host prover hits a stack overflow during EVM execution because tokio's default worker thread stack size (2 MiB on Linux, 512 KiB on macOS) is too small for the deeply nested generic call chain:

`run_until_ctrl_c` → `prove_block` → `build_witness` → `run_client` → `FaultProofDriver::execute` → `Driver::advance_to_target` → EVM execution

## Solution

Add a builder-pattern API on `RuntimeManager`:

```rust
// Default (no change for existing callers)
RuntimeManager::new().run_until_ctrl_c(fut)

// Nitro-host with 8 MiB stack
RuntimeManager::new()
    .with_thread_stack_size(8 * 1024 * 1024)
    .run_until_ctrl_c(fut)
```

## Changes

- `crates/utilities/cli/src/runtime.rs` — `RuntimeManager` gains `thread_stack_size: Option<usize>` field, `new()`, `Default`, and `with_thread_stack_size()` builder method. `tokio_runtime()` and `run_until_ctrl_c()` become `&self` methods.
- `bin/prover/nitro-host/src/cli.rs` — Uses `.with_thread_stack_size(8 * 1024 * 1024)`
- `bin/{batcher,challenger,consensus,prover/zk}/src/cli.rs` — Updated to `RuntimeManager::new().run_until_ctrl_c(...)`