### PR TITLE
chore(consensus): Reduce Gossipsub Warnings

### DIFF
--- a/bin/consensus/src/cli.rs
+++ b/bin/consensus/src/cli.rs
@@ -134,7 +134,10 @@ impl Follow {
     /// Runs the CLI.
     pub fn run(self) -> eyre::Result<()> {
         // Initialize logging from global arguments.
-        LogConfig::from(self.logging.clone()).init_tracing_subscriber()?;
+        base_cli_utils::init_tracing!(
+            LogConfig::from(self.logging.clone()),
+            ["libp2p_gossipsub=error"]
+        )?;
 
         // Initialize unified metrics for the follow-node subsystems.
         base_cli_utils::MetricsConfig::from(self.metrics.clone()).init_with(|| {
@@ -294,7 +297,10 @@ impl Node {
     /// Runs the CLI.
     pub fn run(self) -> eyre::Result<()> {
         // Initialize logging from global arguments.
-        LogConfig::from(self.logging.clone()).init_tracing_subscriber()?;
+        base_cli_utils::init_tracing!(
+            LogConfig::from(self.logging.clone()),
+            ["libp2p_gossipsub=error"]
+        )?;
 
         // Initialize unified metrics
         base_cli_utils::MetricsConfig::from(self.metrics.clone()).init_with(|| {

--- a/crates/consensus/gossip/src/config.rs
+++ b/crates/consensus/gossip/src/config.rs
@@ -87,6 +87,7 @@ pub fn default_config_builder() -> ConfigBuilder {
         .support_floodsub()
         .max_transmit_size(MAX_GOSSIP_SIZE)
         .duplicate_cache_time(Duration::from_secs(120))
+        .connection_handler_queue_len(MAX_OUTBOUND_QUEUE)
         .validation_mode(libp2p::gossipsub::ValidationMode::None)
         .validate_messages()
         .message_id_fn(compute_message_id);

--- a/crates/utilities/cli/src/macros.rs
+++ b/crates/utilities/cli/src/macros.rs
@@ -1,3 +1,25 @@
+/// Initializes the tracing subscriber for a binary, with optional application-specific
+/// noise-suppression directives appended on top of the workspace defaults.
+///
+/// # Usage
+///
+/// ```rust,ignore
+/// // Default workspace suppressions only (e.g. discv5=error):
+/// base_cli_utils::init_tracing!(log_config)?;
+///
+/// // With additional binary-specific suppressions:
+/// base_cli_utils::init_tracing!(log_config, ["libp2p_gossipsub=error"])?;
+/// ```
+#[macro_export]
+macro_rules! init_tracing {
+    ($log_config:expr) => {
+        $log_config.init_tracing_subscriber()
+    };
+    ($log_config:expr, [$($directive:literal),+ $(,)?]) => {
+        $log_config.init_tracing_subscriber_with_directives(&[$($directive),+])
+    };
+}
+
 /// Generates a `MetricsArgs` struct with Prometheus metrics configuration,
 /// parameterized by env var prefix and default port at compile time.
 ///

--- a/crates/utilities/cli/src/tracing.rs
+++ b/crates/utilities/cli/src/tracing.rs
@@ -83,10 +83,7 @@ impl LogConfig {
     /// directives appended on top of the workspace defaults (e.g., `discv5=error`).
     ///
     /// This sets the global default subscriber. Should only be called once.
-    pub fn init_tracing_subscriber_with_directives(
-        &self,
-        directives: &[&str],
-    ) -> eyre::Result<()> {
+    pub fn init_tracing_subscriber_with_directives(&self, directives: &[&str]) -> eyre::Result<()> {
         let mut filter = EnvFilter::builder()
             .with_default_directive(self.global_level.into())
             .from_env_lossy()

--- a/crates/utilities/cli/src/tracing.rs
+++ b/crates/utilities/cli/src/tracing.rs
@@ -76,12 +76,26 @@ impl LogConfig {
     ///
     /// Includes default noise suppression for overly verbose crates (e.g., `discv5=error`).
     pub fn init_tracing_subscriber(&self) -> eyre::Result<()> {
-        // Build base filter from config, allowing env override
-        let filter = EnvFilter::builder()
+        self.init_tracing_subscriber_with_directives(&[])
+    }
+
+    /// Initialize the tracing subscriber with additional application-specific noise-suppression
+    /// directives appended on top of the workspace defaults (e.g., `discv5=error`).
+    ///
+    /// This sets the global default subscriber. Should only be called once.
+    pub fn init_tracing_subscriber_with_directives(
+        &self,
+        directives: &[&str],
+    ) -> eyre::Result<()> {
+        let mut filter = EnvFilter::builder()
             .with_default_directive(self.global_level.into())
             .from_env_lossy()
             // Suppress noisy discovery logs by default
             .add_directive("discv5=error".parse().expect("valid directive"));
+
+        for directive in directives {
+            filter = filter.add_directive(directive.parse().expect("valid directive"));
+        }
 
         self.init_tracing_subscriber_with_filter(filter)
     }


### PR DESCRIPTION
## Summary

- Reduces gossipsub warnings from base-cosnensus misconfiguration.
- Cleans up the tracing utilities to provide a nice macro to initialize directives