### PR TITLE
ktlo(repo): Remove Allow-Lint Suppressions

### DIFF
--- a/crates/client/flashblocks-node/benches/pending_state.rs
+++ b/crates/client/flashblocks-node/benches/pending_state.rs
@@ -1,4 +1,4 @@
-#![allow(missing_docs)]
+//! Benchmarks for [`FlashblocksState`] pending state building.
 
 use std::{
     sync::{Arc, Once},

--- a/crates/client/flashblocks-node/benches/sender_recovery.rs
+++ b/crates/client/flashblocks-node/benches/sender_recovery.rs
@@ -1,5 +1,3 @@
-#![allow(missing_docs)]
-
 //! Benchmark for sender recovery performance.
 //!
 //! Compares sequential vs parallel ECDSA sender recovery

--- a/crates/execution/payload/src/builder.rs
+++ b/crates/execution/payload/src/builder.rs
@@ -679,12 +679,14 @@ where
         Builder: BlockBuilder<Primitives = Evm::Primitives>,
         <<Builder::Executor as BlockExecutor>::Evm as AlloyEvm>::DB: Database,
     {
-        let mut block_gas_limit = builder.evm_mut().block().gas_limit();
-        if let Some(gas_limit_config) = self.builder_config.gas_limit_config.gas_limit() {
-            // If a gas limit is configured, use that limit as target if it's smaller, otherwise use
-            // the block's actual gas limit.
-            block_gas_limit = gas_limit_config.min(block_gas_limit);
-        };
+        let gas_limit = builder.evm_mut().block().gas_limit();
+        // If a gas limit is configured, use that limit as target if it's smaller, otherwise use
+        // the block's actual gas limit.
+        let block_gas_limit = self
+            .builder_config
+            .gas_limit_config
+            .gas_limit()
+            .map_or(gas_limit, |cfg| cfg.min(gas_limit));
         let block_da_limit = self.builder_config.da_config.max_da_block_size();
         let tx_da_limit = self.builder_config.da_config.max_da_tx_size();
         let base_fee = builder.evm_mut().block().basefee();

--- a/crates/execution/payload/src/lib.rs
+++ b/crates/execution/payload/src/lib.rs
@@ -6,7 +6,6 @@
 )]
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
 #![cfg_attr(docsrs, feature(doc_cfg))]
-#![allow(clippy::useless_let_if_seq)]
 
 extern crate alloc;
 

--- a/crates/proof/mpt/benches/trie_node.rs
+++ b/crates/proof/mpt/benches/trie_node.rs
@@ -1,3 +1,4 @@
+#![allow(missing_docs)]
 //! Benchmarks for the [`TrieNode`].
 
 use alloy_trie::Nibbles;

--- a/crates/proof/mpt/benches/trie_node.rs
+++ b/crates/proof/mpt/benches/trie_node.rs
@@ -1,4 +1,3 @@
-#![allow(missing_docs)]
 //! Benchmarks for the [`TrieNode`].
 
 use alloy_trie::Nibbles;


### PR DESCRIPTION
## Summary

Several files were suppressing clippy and rustdoc warnings with `#![allow(...)]` attributes instead of addressing the root cause, which is prohibited by the project's coding standards. The `useless_let_if_seq` pattern in `builder.rs` has been refactored to use an idiomatic `map_or` expression, eliminating the need for the crate-level allow in `lib.rs`. The three bench files had their `#![allow(missing_docs)]` attributes removed; files missing a crate-level doc comment received one, and files that already had `//!` comments simply had the suppression dropped.