### PR TITLE
feat(tee): allow registration of recently-launched unhealthy instances

### DIFF
--- a/bin/prover-registrar/src/cli.rs
+++ b/bin/prover-registrar/src/cli.rs
@@ -19,7 +19,8 @@ use base_proof_tee_nitro_attestation_prover::{
 };
 use base_proof_tee_registrar::{
     AwsDiscoveryConfig, AwsTargetGroupDiscovery, BoundlessConfig, DEFAULT_MAX_CONCURRENCY,
-    DEFAULT_MAX_TX_RETRIES, DEFAULT_TX_RETRY_DELAY_SECS, DriverConfig, ProverClient, ProvingConfig,
+    DEFAULT_MAX_TX_RETRIES, DEFAULT_TX_RETRY_DELAY_SECS,
+    DEFAULT_UNHEALTHY_REGISTRATION_WINDOW_SECS, DriverConfig, ProverClient, ProvingConfig,
     RegistrarConfig, RegistrarError, RegistrarMetrics, RegistrationDriver, RegistryContractClient,
 };
 use base_tx_manager::{BaseTxMetrics, SignerConfig, SimpleTxManager, TxManagerConfig};
@@ -120,6 +121,13 @@ pub(crate) struct Cli {
     /// Delay between transaction submission retries, in seconds.
     #[arg(long, env = cli_env!("TX_RETRY_DELAY_SECS"), default_value_t = DEFAULT_TX_RETRY_DELAY_SECS)]
     tx_retry_delay_secs: u64,
+
+    // ── Unhealthy Registration Window ─────────────────────────────────────
+    /// Duration (seconds) after EC2 launch during which unhealthy instances
+    /// are still eligible for registration. New instances may fail ALB health
+    /// checks while the application initializes. Set to 0 to disable.
+    #[arg(long, env = cli_env!("UNHEALTHY_REGISTRATION_WINDOW_SECS"), default_value_t = DEFAULT_UNHEALTHY_REGISTRATION_WINDOW_SECS)]
+    unhealthy_registration_window_secs: u64,
 
     // ── Health Server ─────────────────────────────────────────────────────────
     #[command(flatten)]
@@ -312,6 +320,9 @@ impl Cli {
             max_concurrency: self.max_concurrency,
             max_tx_retries: self.max_tx_retries,
             tx_retry_delay: Duration::from_secs(self.tx_retry_delay_secs),
+            unhealthy_registration_window: Duration::from_secs(
+                self.unhealthy_registration_window_secs,
+            ),
             health_addr,
         })
     }
@@ -419,6 +430,7 @@ impl Cli {
             max_concurrency: config.max_concurrency,
             max_tx_retries: config.max_tx_retries,
             tx_retry_delay: config.tx_retry_delay,
+            unhealthy_registration_window: config.unhealthy_registration_window,
         };
 
         // Mark the service as ready. This signals "initialised and running", not
@@ -666,6 +678,10 @@ mod tests {
         assert_eq!(config.max_concurrency, DEFAULT_MAX_CONCURRENCY);
         assert_eq!(config.max_tx_retries, DEFAULT_MAX_TX_RETRIES);
         assert_eq!(config.tx_retry_delay, Duration::from_secs(DEFAULT_TX_RETRY_DELAY_SECS));
+        assert_eq!(
+            config.unhealthy_registration_window,
+            Duration::from_secs(DEFAULT_UNHEALTHY_REGISTRATION_WINDOW_SECS),
+        );
     }
 
     #[rstest]

--- a/crates/proof/tee/registrar/src/config.rs
+++ b/crates/proof/tee/registrar/src/config.rs
@@ -103,6 +103,9 @@ pub struct RegistrarConfig {
     pub max_tx_retries: u32,
     /// Delay between transaction submission retries.
     pub tx_retry_delay: Duration,
+    /// Duration after launch during which unhealthy instances are still
+    /// eligible for registration.
+    pub unhealthy_registration_window: Duration,
     /// Health server socket address.
     pub health_addr: SocketAddr,
 }
@@ -122,6 +125,7 @@ impl std::fmt::Debug for RegistrarConfig {
             .field("max_concurrency", &self.max_concurrency)
             .field("max_tx_retries", &self.max_tx_retries)
             .field("tx_retry_delay", &self.tx_retry_delay)
+            .field("unhealthy_registration_window", &self.unhealthy_registration_window)
             .field("health_addr", &self.health_addr)
             .finish()
     }

--- a/crates/proof/tee/registrar/src/discovery.rs
+++ b/crates/proof/tee/registrar/src/discovery.rs
@@ -1,6 +1,9 @@
 //! AWS ALB target group instance discovery.
 
-use std::collections::HashMap;
+use std::{
+    collections::HashMap,
+    time::{Duration, SystemTime},
+};
 
 use async_trait::async_trait;
 use aws_sdk_ec2::Client as Ec2Client;
@@ -35,26 +38,28 @@ impl AwsTargetGroupDiscovery {
         Self { elb_client, ec2_client, target_group_arn, port }
     }
 
-    /// Assembles [`ProverInstance`] objects from ELB target data and EC2 IP data.
+    /// Assembles [`ProverInstance`] objects from ELB target data and EC2 instance
+    /// data.
     ///
     /// Returns **all** discovered instances regardless of health status.
     /// The caller (registration driver) decides which instances to act on based on
     /// [`InstanceHealthStatus::should_register`].
     ///
-    /// Targets with no matching IP entry are silently dropped (this can happen if
-    /// an instance was terminated between the ELB and EC2 calls).
+    /// Targets with no matching entry in `instance_data` are silently dropped
+    /// (this can happen if an instance was terminated between the ELB and EC2
+    /// calls).
     ///
     /// This function is a pure transformation — no AWS SDK calls are made — which
     /// makes it straightforwardly unit-testable without SDK mocks.
     pub fn assemble_prover_instances(
         targets: &[(String, InstanceHealthStatus)],
-        instance_ips: &HashMap<String, String>,
+        instance_data: &HashMap<String, (String, Option<SystemTime>)>,
         port: u16,
     ) -> Vec<ProverInstance> {
         targets
             .iter()
             .filter_map(|(instance_id, health_status)| {
-                let private_ip = instance_ips.get(instance_id)?;
+                let (private_ip, launch_time) = instance_data.get(instance_id)?;
                 let raw = format!("http://{private_ip}:{port}");
                 let endpoint = match Url::parse(&raw) {
                     Ok(url) => url,
@@ -72,12 +77,14 @@ impl AwsTargetGroupDiscovery {
                     instance_id = %instance_id,
                     endpoint = %endpoint,
                     health = ?health_status,
+                    launch_time = ?launch_time,
                     "discovered AWS prover instance"
                 );
                 Some(ProverInstance {
                     instance_id: instance_id.clone(),
                     endpoint,
                     health_status: *health_status,
+                    launch_time: *launch_time,
                 })
             })
             .collect()
@@ -151,26 +158,30 @@ impl InstanceDiscovery for AwsTargetGroupDiscovery {
             .await
             .map_err(|e| RegistrarError::Discovery(Box::new(e)))?;
 
-        let instance_ips: HashMap<String, String> = ec2_resp
+        let instance_data: HashMap<String, (String, Option<SystemTime>)> = ec2_resp
             .reservations()
             .iter()
             .flat_map(|r| r.instances())
             .filter_map(|i| {
                 let id = i.instance_id()?.to_string();
                 let ip = i.private_ip_address()?.to_string();
-                Some((id, ip))
+                let launch_time = i
+                    .launch_time()
+                    .and_then(|dt| u64::try_from(dt.secs()).ok())
+                    .map(|secs| SystemTime::UNIX_EPOCH + Duration::from_secs(secs));
+                Some((id, (ip, launch_time)))
             })
             .collect();
 
         // Warn about instances that the EC2 call didn't return
         // (e.g. terminated between the ELB and EC2 calls, or missing a private IP).
         for (id, _) in &targets {
-            if !instance_ips.contains_key(id) {
+            if !instance_data.contains_key(id) {
                 warn!(instance_id = %id, "instance missing from EC2 response, skipping");
             }
         }
 
-        Ok(Self::assemble_prover_instances(&targets, &instance_ips, self.port))
+        Ok(Self::assemble_prover_instances(&targets, &instance_data, self.port))
     }
 }
 
@@ -180,8 +191,8 @@ mod tests {
 
     use super::*;
 
-    fn make_ips(pairs: &[(&str, &str)]) -> HashMap<String, String> {
-        pairs.iter().map(|(id, ip)| (id.to_string(), ip.to_string())).collect()
+    fn make_instance_data(pairs: &[(&str, &str)]) -> HashMap<String, (String, Option<SystemTime>)> {
+        pairs.iter().map(|(id, ip)| (id.to_string(), (ip.to_string(), None))).collect()
     }
 
     fn make_targets(pairs: &[(&str, InstanceHealthStatus)]) -> Vec<(String, InstanceHealthStatus)> {
@@ -203,19 +214,20 @@ mod tests {
         #[case] status: InstanceHealthStatus,
     ) {
         let targets = make_targets(&[(id, status)]);
-        let ips = make_ips(&[(id, ip)]);
-        let instances = AwsTargetGroupDiscovery::assemble_prover_instances(&targets, &ips, 8000);
+        let data = make_instance_data(&[(id, ip)]);
+        let instances = AwsTargetGroupDiscovery::assemble_prover_instances(&targets, &data, 8000);
         assert_eq!(instances.len(), 1);
         assert_eq!(instances[0].instance_id, id);
         assert_eq!(instances[0].endpoint, expected_url(ip, 8000));
         assert_eq!(instances[0].health_status, status);
+        assert!(instances[0].launch_time.is_none());
     }
 
     #[test]
-    fn assemble_drops_instance_missing_from_ip_map() {
+    fn assemble_drops_instance_missing_from_data_map() {
         let targets = make_targets(&[("i-005", InstanceHealthStatus::Healthy)]);
-        let ips = HashMap::new();
-        let instances = AwsTargetGroupDiscovery::assemble_prover_instances(&targets, &ips, 8000);
+        let data = HashMap::new();
+        let instances = AwsTargetGroupDiscovery::assemble_prover_instances(&targets, &data, 8000);
         assert!(instances.is_empty());
     }
 
@@ -229,8 +241,8 @@ mod tests {
     #[test]
     fn assemble_port_appears_in_endpoint() {
         let targets = make_targets(&[("i-006", InstanceHealthStatus::Healthy)]);
-        let ips = make_ips(&[("i-006", "10.0.0.6")]);
-        let instances = AwsTargetGroupDiscovery::assemble_prover_instances(&targets, &ips, 9999);
+        let data = make_instance_data(&[("i-006", "10.0.0.6")]);
+        let instances = AwsTargetGroupDiscovery::assemble_prover_instances(&targets, &data, 9999);
         assert_eq!(instances[0].endpoint, expected_url("10.0.0.6", 9999));
     }
 
@@ -242,13 +254,23 @@ mod tests {
             ("i-012", InstanceHealthStatus::Unhealthy),
             ("i-013", InstanceHealthStatus::Draining),
         ]);
-        let ips = make_ips(&[
+        let data = make_instance_data(&[
             ("i-010", "10.0.1.0"),
             ("i-011", "10.0.1.1"),
             ("i-012", "10.0.1.2"),
             ("i-013", "10.0.1.3"),
         ]);
-        let instances = AwsTargetGroupDiscovery::assemble_prover_instances(&targets, &ips, 8000);
+        let instances = AwsTargetGroupDiscovery::assemble_prover_instances(&targets, &data, 8000);
         assert_eq!(instances.len(), 4);
+    }
+
+    #[test]
+    fn assemble_preserves_launch_time() {
+        let launch = SystemTime::UNIX_EPOCH + Duration::from_secs(1_700_000_000);
+        let targets = make_targets(&[("i-020", InstanceHealthStatus::Healthy)]);
+        let data = HashMap::from([("i-020".to_string(), ("10.0.2.0".to_string(), Some(launch)))]);
+        let instances = AwsTargetGroupDiscovery::assemble_prover_instances(&targets, &data, 8000);
+        assert_eq!(instances.len(), 1);
+        assert_eq!(instances[0].launch_time, Some(launch));
     }
 }

--- a/crates/proof/tee/registrar/src/driver.rs
+++ b/crates/proof/tee/registrar/src/driver.rs
@@ -37,6 +37,15 @@ pub const DEFAULT_MAX_TX_RETRIES: u32 = 3;
 /// Default delay between transaction submission retries.
 pub const DEFAULT_TX_RETRY_DELAY_SECS: u64 = 5;
 
+/// Default duration (in seconds) after launch during which unhealthy
+/// instances are still eligible for registration.
+///
+/// New EC2 instances may fail ALB health checks while the application is
+/// still initializing. This window allows the registrar to attempt
+/// registration during that warm-up period rather than waiting for the
+/// instance to become healthy. Set to 0 to disable.
+pub const DEFAULT_UNHEALTHY_REGISTRATION_WINDOW_SECS: u64 = 3600;
+
 /// Runtime parameters for the [`RegistrationDriver`] that are not
 /// trait-based dependencies.
 #[derive(Debug, Clone)]
@@ -57,6 +66,11 @@ pub struct DriverConfig {
     /// Delay between transaction submission retries.
     /// Defaults to [`DEFAULT_TX_RETRY_DELAY_SECS`] seconds.
     pub tx_retry_delay: Duration,
+    /// Duration after launch during which unhealthy instances are still
+    /// eligible for registration. New instances may fail ALB health checks
+    /// while the application is still initializing. Set to zero to disable.
+    /// Defaults to [`DEFAULT_UNHEALTHY_REGISTRATION_WINDOW_SECS`] seconds.
+    pub unhealthy_registration_window: Duration,
 }
 
 /// Core registration loop tying together discovery, attestation polling,
@@ -255,6 +269,34 @@ where
         Ok(())
     }
 
+    /// Returns `true` if the instance is [`InstanceHealthStatus::Unhealthy`]
+    /// and was launched within the configured
+    /// [`DriverConfig::unhealthy_registration_window`].
+    ///
+    /// New EC2 instances may fail ALB health checks while the application is
+    /// still initializing. This predicate lets the registrar attempt
+    /// registration during that warm-up period rather than waiting for the
+    /// instance to become healthy.
+    ///
+    /// Returns `false` if:
+    /// - The instance is not `Unhealthy` (other statuses have their own rules).
+    /// - The window is zero (feature disabled).
+    /// - The instance has no launch time (e.g. discovery didn't return one).
+    /// - The launch time is in the future (clock skew — treated as unknown).
+    fn is_recently_launched_unhealthy(&self, instance: &ProverInstance) -> bool {
+        use crate::InstanceHealthStatus;
+
+        if instance.health_status != InstanceHealthStatus::Unhealthy {
+            return false;
+        }
+        if self.config.unhealthy_registration_window.is_zero() {
+            return false;
+        }
+        instance.launch_time.is_some_and(|lt| {
+            lt.elapsed().is_ok_and(|elapsed| elapsed < self.config.unhealthy_registration_window)
+        })
+    }
+
     /// Resolves signer addresses from an instance and attempts registration.
     ///
     /// Returns the derived signer addresses regardless of whether registration
@@ -273,13 +315,26 @@ where
         // Non-registerable instances (Draining, Unhealthy) still contribute
         // their addresses to the active signer set to prevent premature
         // deregistration.
+        //
+        // Exception: recently-launched Unhealthy instances are allowed through
+        // when they fall within the configured unhealthy_registration_window.
+        // New instances may fail ALB health checks during startup while the
+        // application is still initializing.
         if !instance.health_status.should_register() {
-            debug!(
-                status = ?instance.health_status,
+            if !self.is_recently_launched_unhealthy(instance) {
+                debug!(
+                    status = ?instance.health_status,
+                    instance = %instance.instance_id,
+                    "instance not registerable, skipping registration"
+                );
+                return Ok(addresses);
+            }
+            info!(
                 instance = %instance.instance_id,
-                "instance not registerable, skipping registration"
+                launch_time = ?instance.launch_time,
+                window = ?self.config.unhealthy_registration_window,
+                "unhealthy instance recently launched, attempting registration"
             );
-            return Ok(addresses);
         }
 
         // Fetch attestations once for all enclaves before the registration
@@ -645,6 +700,7 @@ mod tests {
             Arc, Mutex,
             atomic::{AtomicU32, AtomicUsize, Ordering},
         },
+        time::SystemTime,
     };
 
     use alloy_consensus::{Eip658Value, Receipt, ReceiptEnvelope, ReceiptWithBloom};
@@ -749,10 +805,32 @@ mod tests {
 
     /// Builds a [`ProverInstance`] with the given host:port and health status.
     ///
-    /// Prepends `http://` to form a valid URL automatically.
+    /// Prepends `http://` to form a valid URL automatically. The `launch_time`
+    /// defaults to `None` — use [`instance_with_launch_time`] for tests that
+    /// need a specific launch time.
     fn instance(host_port: &str, status: InstanceHealthStatus) -> ProverInstance {
         let endpoint = Url::parse(&format!("http://{host_port}")).unwrap();
-        ProverInstance { instance_id: format!("i-{host_port}"), endpoint, health_status: status }
+        ProverInstance {
+            instance_id: format!("i-{host_port}"),
+            endpoint,
+            health_status: status,
+            launch_time: None,
+        }
+    }
+
+    /// Builds a [`ProverInstance`] with an explicit `launch_time`.
+    fn instance_with_launch_time(
+        host_port: &str,
+        status: InstanceHealthStatus,
+        launch_time: Option<SystemTime>,
+    ) -> ProverInstance {
+        let endpoint = Url::parse(&format!("http://{host_port}")).unwrap();
+        ProverInstance {
+            instance_id: format!("i-{host_port}"),
+            endpoint,
+            health_status: status,
+            launch_time,
+        }
     }
 
     // ── Mock implementations ────────────────────────────────────────────
@@ -973,6 +1051,9 @@ mod tests {
             max_concurrency: DEFAULT_MAX_CONCURRENCY,
             max_tx_retries: DEFAULT_MAX_TX_RETRIES,
             tx_retry_delay: Duration::from_secs(DEFAULT_TX_RETRY_DELAY_SECS),
+            unhealthy_registration_window: Duration::from_secs(
+                DEFAULT_UNHEALTHY_REGISTRATION_WINDOW_SECS,
+            ),
         }
     }
 
@@ -1363,6 +1444,156 @@ mod tests {
 
         assert_eq!(addrs, vec![HARDHAT_ACCOUNT]);
         assert_eq!(tx.sent_calldata().len(), expected_txs);
+    }
+
+    // ── Unhealthy registration window tests ────────────────────────────
+
+    #[tokio::test]
+    async fn process_instance_unhealthy_recently_launched_attempts_registration() {
+        // An Unhealthy instance launched 10 minutes ago (within the default
+        // 60-minute window) should be registered.
+        let launch_time = Some(SystemTime::now() - Duration::from_secs(600));
+        let signer_client = MockSignerClient::from_keys(&[(EP1, &HARDHAT_KEY_0)]);
+        let tx = SharedTxManager::new();
+        let driver = step_driver(
+            vec![],
+            signer_client,
+            MockRegistry::with_signers(vec![]),
+            tx.clone(),
+            CancellationToken::new(),
+        );
+
+        let inst = instance_with_launch_time(EP1, InstanceHealthStatus::Unhealthy, launch_time);
+        let addrs = driver.process_instance(&inst).await.unwrap();
+
+        assert_eq!(addrs, vec![HARDHAT_ACCOUNT]);
+        assert_eq!(tx.sent_calldata().len(), 1, "recently-launched unhealthy should register");
+    }
+
+    #[tokio::test]
+    async fn process_instance_unhealthy_old_launch_skips_registration() {
+        // An Unhealthy instance launched 2 hours ago (outside the 60-minute
+        // window) should NOT be registered.
+        let launch_time = Some(SystemTime::now() - Duration::from_secs(7200));
+        let signer_client = MockSignerClient::from_keys(&[(EP1, &HARDHAT_KEY_0)]);
+        let tx = SharedTxManager::new();
+        let driver = step_driver(
+            vec![],
+            signer_client,
+            MockRegistry::with_signers(vec![]),
+            tx.clone(),
+            CancellationToken::new(),
+        );
+
+        let inst = instance_with_launch_time(EP1, InstanceHealthStatus::Unhealthy, launch_time);
+        let addrs = driver.process_instance(&inst).await.unwrap();
+
+        assert_eq!(addrs, vec![HARDHAT_ACCOUNT]);
+        assert!(tx.sent_calldata().is_empty(), "old unhealthy should not register");
+    }
+
+    #[tokio::test]
+    async fn process_instance_unhealthy_no_launch_time_skips_registration() {
+        // An Unhealthy instance with no launch_time should NOT be registered
+        // (we can't determine age, so we default to the safe path).
+        let signer_client = MockSignerClient::from_keys(&[(EP1, &HARDHAT_KEY_0)]);
+        let tx = SharedTxManager::new();
+        let driver = step_driver(
+            vec![],
+            signer_client,
+            MockRegistry::with_signers(vec![]),
+            tx.clone(),
+            CancellationToken::new(),
+        );
+
+        let inst = instance(EP1, InstanceHealthStatus::Unhealthy);
+        let addrs = driver.process_instance(&inst).await.unwrap();
+
+        assert_eq!(addrs, vec![HARDHAT_ACCOUNT]);
+        assert!(tx.sent_calldata().is_empty(), "unhealthy with no launch_time should not register");
+    }
+
+    #[tokio::test]
+    async fn process_instance_draining_recently_launched_still_skips_registration() {
+        // A Draining instance launched 10 minutes ago should NOT be registered.
+        // The grace period only applies to Unhealthy, never Draining.
+        let launch_time = Some(SystemTime::now() - Duration::from_secs(600));
+        let signer_client = MockSignerClient::from_keys(&[(EP1, &HARDHAT_KEY_0)]);
+        let tx = SharedTxManager::new();
+        let driver = step_driver(
+            vec![],
+            signer_client,
+            MockRegistry::with_signers(vec![]),
+            tx.clone(),
+            CancellationToken::new(),
+        );
+
+        let inst = instance_with_launch_time(EP1, InstanceHealthStatus::Draining, launch_time);
+        let addrs = driver.process_instance(&inst).await.unwrap();
+
+        assert_eq!(addrs, vec![HARDHAT_ACCOUNT]);
+        assert!(tx.sent_calldata().is_empty(), "draining should never register even if recent");
+    }
+
+    #[tokio::test]
+    async fn process_instance_unhealthy_window_zero_disables_feature() {
+        // Setting unhealthy_registration_window to zero disables the feature
+        // entirely — even a freshly-launched Unhealthy instance is skipped.
+        let launch_time = Some(SystemTime::now() - Duration::from_secs(10));
+        let signer_client = MockSignerClient::from_keys(&[(EP1, &HARDHAT_KEY_0)]);
+        let tx = SharedTxManager::new();
+
+        let cancel = CancellationToken::new();
+        let mut config = default_config(cancel);
+        config.unhealthy_registration_window = Duration::ZERO;
+
+        let driver = RegistrationDriver::new(
+            MockDiscovery { instances: vec![] },
+            StubProofProvider,
+            MockRegistry::with_signers(vec![]),
+            tx.clone(),
+            signer_client,
+            config,
+        );
+
+        let inst = instance_with_launch_time(EP1, InstanceHealthStatus::Unhealthy, launch_time);
+        let addrs = driver.process_instance(&inst).await.unwrap();
+
+        assert_eq!(addrs, vec![HARDHAT_ACCOUNT]);
+        assert!(tx.sent_calldata().is_empty(), "window=0 should disable unhealthy registration");
+    }
+
+    #[tokio::test]
+    async fn step_unhealthy_recently_launched_registers_and_contributes_to_active_set() {
+        // A recently-launched Unhealthy instance should be registered AND
+        // contribute its signer to active_signers (preventing deregistration).
+        let addr = ProverClient::derive_address(&public_key_from_private(&HARDHAT_KEY_0)).unwrap();
+        let launch_time = Some(SystemTime::now() - Duration::from_secs(300));
+
+        let instances =
+            vec![instance_with_launch_time(EP1, InstanceHealthStatus::Unhealthy, launch_time)];
+        let signer_client = MockSignerClient::from_keys(&[(EP1, &HARDHAT_KEY_0)]);
+
+        let tx = SharedTxManager::new();
+        let driver = step_driver(
+            instances,
+            signer_client,
+            // addr is already on-chain; without active_signers it would be deregistered.
+            MockRegistry::with_signers(vec![addr]),
+            tx.clone(),
+            CancellationToken::new(),
+        );
+
+        driver.step().await.unwrap();
+
+        let sent = tx.sent_calldata();
+        // The signer is already on-chain (MockRegistry has it), so try_register
+        // sees is_registered=true and skips registration. But no deregistration
+        // should happen because the signer is in active_signers.
+        assert!(
+            sent.is_empty(),
+            "already-registered signer should not be re-registered or deregistered"
+        );
     }
 
     // ── step() tests ────────────────────────────────────────────────────

--- a/crates/proof/tee/registrar/src/driver.rs
+++ b/crates/proof/tee/registrar/src/driver.rs
@@ -18,8 +18,8 @@ use tokio_util::sync::CancellationToken;
 use tracing::{Instrument, debug, error, info, info_span, warn};
 
 use crate::{
-    InstanceDiscovery, ProverClient, ProverInstance, RegistrarError, RegistrarMetrics,
-    RegistryClient, Result, SignerClient,
+    InstanceDiscovery, InstanceHealthStatus, ProverClient, ProverInstance, RegistrarError,
+    RegistrarMetrics, RegistryClient, Result, SignerClient,
 };
 
 /// Default maximum number of instances processed concurrently.
@@ -284,8 +284,6 @@ where
     /// - The instance has no launch time (e.g. discovery didn't return one).
     /// - The launch time is in the future (clock skew — treated as unknown).
     fn is_recently_launched_unhealthy(&self, instance: &ProverInstance) -> bool {
-        use crate::InstanceHealthStatus;
-
         if instance.health_status != InstanceHealthStatus::Unhealthy {
             return false;
         }

--- a/crates/proof/tee/registrar/src/lib.rs
+++ b/crates/proof/tee/registrar/src/lib.rs
@@ -9,8 +9,8 @@ pub use discovery::AwsTargetGroupDiscovery;
 
 mod driver;
 pub use driver::{
-    DEFAULT_MAX_CONCURRENCY, DEFAULT_MAX_TX_RETRIES, DEFAULT_TX_RETRY_DELAY_SECS, DriverConfig,
-    RegistrationDriver,
+    DEFAULT_MAX_CONCURRENCY, DEFAULT_MAX_TX_RETRIES, DEFAULT_TX_RETRY_DELAY_SECS,
+    DEFAULT_UNHEALTHY_REGISTRATION_WINDOW_SECS, DriverConfig, RegistrationDriver,
 };
 
 mod error;

--- a/crates/proof/tee/registrar/src/types.rs
+++ b/crates/proof/tee/registrar/src/types.rs
@@ -1,3 +1,5 @@
+use std::time::SystemTime;
+
 use alloy_primitives::{Address, B256};
 use url::Url;
 
@@ -10,6 +12,9 @@ pub struct ProverInstance {
     pub endpoint: Url,
     /// Current health status of the instance.
     pub health_status: InstanceHealthStatus,
+    /// EC2 launch time of the instance. Used to determine if recently-launched
+    /// unhealthy instances should still be eligible for registration.
+    pub launch_time: Option<SystemTime>,
 }
 
 /// Health status of a discovered prover instance.


### PR DESCRIPTION
## Summary

- Adds a configurable time window (default 60 minutes) during which `Unhealthy` EC2 instances are still eligible for TEE signer registration, allowing the registrar to register instances during ALB health check warm-up instead of waiting
- Extracts EC2 `launch_time` from the existing `describe_instances` API call — no new API calls, SDK dependencies, or IAM permissions required
- Setting the window to 0 disables the feature; only `Unhealthy` instances get the grace period (never `Draining`)

## Motivation

New EC2 instances may fail ALB health checks while the prover application is still initializing. Previously, the registrar would skip these instances entirely, delaying registration until the instance became healthy. This change allows proactive registration during the warm-up period, reducing time-to-first-proof for new instances.

## Changes

### Library crate (`base-proof-tee-registrar`)

- **`types.rs`**: Added `launch_time: Option<SystemTime>` field to `ProverInstance`
- **`discovery.rs`**: Updated `assemble_prover_instances` to accept and propagate EC2 launch times from the existing `describe_instances` response; added `assemble_preserves_launch_time` test
- **`config.rs`**: Added `unhealthy_registration_window: Duration` to `RegistrarConfig` with Debug impl
- **`driver.rs`**: Added `DEFAULT_UNHEALTHY_REGISTRATION_WINDOW_SECS` constant (3600), `unhealthy_registration_window` field on `DriverConfig`, `is_recently_launched_unhealthy()` method, and updated `process_instance()` health gate with 6 new tests covering: recently-launched registration, old-launch skip, no-launch-time skip, draining exclusion, window=0 disable, and step-level active set contribution
- **`lib.rs`**: Re-exports `DEFAULT_UNHEALTHY_REGISTRATION_WINDOW_SECS`

### Binary crate (`base-proof-tee-registrar-bin`)

- **`cli.rs`**: Added `--unhealthy-registration-window-secs` CLI arg with `cli_env!("UNHEALTHY_REGISTRATION_WINDOW_SECS")` (default 3600), wired through `RegistrarConfig` → `DriverConfig`, updated `default_durations_and_concurrency` test

## Config pipeline

```
CLI: --unhealthy-registration-window-secs / BASE_REGISTRAR_UNHEALTHY_REGISTRATION_WINDOW_SECS
  → RegistrarConfig.unhealthy_registration_window: Duration
  → DriverConfig.unhealthy_registration_window: Duration
  → is_recently_launched_unhealthy() check in process_instance()
```

## Test coverage

- **81 library tests** (6 new for the unhealthy window feature)
- **28 CLI tests** (1 updated to assert the new default)
- All passing locally with `cargo test -p base-proof-tee-registrar` and `cargo test -p base-proof-tee-registrar-bin`