### PR TITLE
feat(challenger): add bond lifecycle management to challenger

### DIFF
--- a/crates/proof/challenge/src/bond.rs
+++ b/crates/proof/challenge/src/bond.rs
@@ -48,6 +48,21 @@ fn unix_now() -> u64 {
         .as_secs()
 }
 
+/// A function that returns the current Unix timestamp in seconds.
+///
+/// Used as an injectable clock in [`BondManager`] so that tests can
+/// control time without relying on the real wall clock.
+pub type ClockFn = fn() -> u64;
+
+/// Reason a game was removed from tracking after [`BondManager::advance_game`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RemovalReason {
+    /// Bond was successfully claimed — the full lifecycle completed.
+    Completed,
+    /// Bond is not claimable by us (recipient changed after resolve).
+    NotClaimable,
+}
+
 /// Phase of the bond claim lifecycle for a single tracked game.
 #[derive(Debug, Clone)]
 pub enum BondPhase {
@@ -95,6 +110,10 @@ pub struct BondManager {
     /// L1 RPC URL used to instantiate the `DelayedWETH` contract client
     /// when lazily resolving the withdrawal delay.
     l1_rpc_url: url::Url,
+    /// Injectable clock for obtaining the current Unix timestamp. Defaults
+    /// to [`unix_now`] in production; tests can substitute a controlled
+    /// clock.
+    clock: ClockFn,
 }
 
 impl BondManager {
@@ -107,12 +126,25 @@ impl BondManager {
     pub fn new(claim_addresses: Vec<Address>, l1_rpc_url: url::Url) -> Self {
         let set: HashSet<Address> = claim_addresses.into_iter().collect();
         info!(count = set.len(), "bond manager initialized with claim addresses");
-        Self { tracked: HashMap::new(), claim_addresses: set, weth_delay: None, l1_rpc_url }
+        Self {
+            tracked: HashMap::new(),
+            claim_addresses: set,
+            weth_delay: None,
+            l1_rpc_url,
+            clock: unix_now,
+        }
     }
 
     /// Returns `true` if bond claiming is enabled (at least one claim address configured).
     pub fn is_enabled(&self) -> bool {
         !self.claim_addresses.is_empty()
+    }
+
+    /// Overrides the clock function used to obtain the current Unix
+    /// timestamp. Primarily useful for tests that need deterministic
+    /// time control.
+    pub fn set_clock(&mut self, clock: ClockFn) {
+        self.clock = clock;
     }
 
     /// Sets the `DelayedWETH` withdrawal delay.
@@ -337,12 +369,12 @@ impl BondManager {
         }
 
         let addresses: Vec<Address> = self.tracked.keys().copied().collect();
-        let mut completed = Vec::new();
+        let mut removed = Vec::new();
 
         for game_address in addresses {
             match self.advance_game(game_address, verifier_client, submitter).await {
-                Ok(true) => completed.push(game_address),
-                Ok(false) => {}
+                Ok(Some(reason)) => removed.push((game_address, reason)),
+                Ok(None) => {}
                 Err(e) => {
                     warn!(
                         game = %game_address,
@@ -353,29 +385,32 @@ impl BondManager {
             }
         }
 
-        for addr in &completed {
+        for (addr, reason) in &removed {
             self.tracked.remove(addr);
-            ChallengerMetrics::bonds_completed_total().increment(1);
+            if *reason == RemovalReason::Completed {
+                ChallengerMetrics::bonds_completed_total().increment(1);
+            }
         }
 
-        if !completed.is_empty() {
+        if !removed.is_empty() {
             ChallengerMetrics::bonds_tracked().set(self.tracked.len() as f64);
         }
     }
 
     /// Advances a single game through the bond lifecycle state machine.
     ///
-    /// Returns `Ok(true)` when the game reaches [`BondPhase::Completed`] and
-    /// should be removed from tracking.
+    /// Returns `Ok(Some(reason))` when the game should be removed from
+    /// tracking, or `Ok(None)` when it remains in its current or updated
+    /// phase.
     async fn advance_game(
         &mut self,
         game_address: Address,
         verifier_client: &dyn AggregateVerifierClient,
         submitter: &dyn BondTransactionSubmitter,
-    ) -> eyre::Result<bool> {
+    ) -> eyre::Result<Option<RemovalReason>> {
         let game = match self.tracked.get(&game_address) {
             Some(g) => g,
-            None => return Ok(false),
+            None => return Ok(None),
         };
 
         match &game.phase {
@@ -392,7 +427,7 @@ impl BondManager {
             BondPhase::NeedsWithdraw => {
                 self.try_withdraw(game_address, verifier_client, submitter).await
             }
-            BondPhase::Completed => Ok(true),
+            BondPhase::Completed => Ok(Some(RemovalReason::Completed)),
         }
     }
 
@@ -408,7 +443,7 @@ impl BondManager {
         game_address: Address,
         verifier_client: &dyn AggregateVerifierClient,
         submitter: &dyn BondTransactionSubmitter,
-    ) -> eyre::Result<bool> {
+    ) -> eyre::Result<Option<RemovalReason>> {
         // Check if already resolved onchain (e.g., someone else called it).
         let status = verifier_client.status(game_address).await?;
         if status != GameScanner::STATUS_IN_PROGRESS {
@@ -419,23 +454,24 @@ impl BondManager {
             // it (e.g. to the challenger on CHALLENGER_WINS). If it is no
             // longer in our claim set, stop tracking this game.
             if !self.is_bond_claimable(verifier_client, game_address).await? {
-                return Ok(true);
+                return Ok(Some(RemovalReason::NotClaimable));
             }
 
             info!(game = %game_address, status, "game already resolved, advancing to unlock phase");
             self.set_phase(game_address, BondPhase::NeedsUnlock);
-            return Ok(false);
+            return Ok(None);
         }
 
         // Check if the game is ready to resolve.
         let game_over = verifier_client.game_over(game_address).await?;
         if !game_over {
             debug!(game = %game_address, "game dispute period not yet elapsed");
-            return Ok(false);
+            return Ok(None);
         }
 
         // Submit resolve transaction.
         let calldata = encode_resolve_calldata();
+        info!(game = %game_address, "submitting resolve transaction");
         match submitter.send_bond_tx(game_address, calldata).await {
             Ok(tx_hash) => {
                 info!(game = %game_address, tx_hash = %tx_hash, "resolve transaction confirmed");
@@ -444,7 +480,7 @@ impl BondManager {
 
                 // Re-read bondRecipient to verify it's in our claim set.
                 if !self.is_bond_claimable(verifier_client, game_address).await? {
-                    return Ok(true);
+                    return Ok(Some(RemovalReason::NotClaimable));
                 }
 
                 self.set_phase(game_address, BondPhase::NeedsUnlock);
@@ -455,18 +491,28 @@ impl BondManager {
                     .increment(1);
             }
         }
-        Ok(false)
+        Ok(None)
     }
 
     /// Checks whether the onchain `bondRecipient` for the given game is in
-    /// our claim addresses. Returns `false` if not, signalling the caller
-    /// to remove the game from tracking.
+    /// our claim addresses. Also updates the tracked game's
+    /// `bond_recipient` field to reflect the current onchain value (which
+    /// may differ from the pre-resolve value). Returns `false` if the
+    /// recipient is not in the claim set, signalling the caller to remove
+    /// the game from tracking.
     async fn is_bond_claimable(
-        &self,
+        &mut self,
         verifier_client: &dyn AggregateVerifierClient,
         game_address: Address,
     ) -> eyre::Result<bool> {
         let bond_recipient = verifier_client.bond_recipient(game_address).await?;
+
+        // Update the tracked entry so logging and debugging reflect the
+        // current onchain recipient, not the stale pre-resolve value.
+        if let Some(game) = self.tracked.get_mut(&game_address) {
+            game.bond_recipient = bond_recipient;
+        }
+
         if self.claim_addresses.contains(&bond_recipient) {
             return Ok(true);
         }
@@ -484,7 +530,7 @@ impl BondManager {
         game_address: Address,
         verifier_client: &dyn AggregateVerifierClient,
         submitter: &dyn BondTransactionSubmitter,
-    ) -> eyre::Result<bool> {
+    ) -> eyre::Result<Option<RemovalReason>> {
         // Check if already unlocked onchain.
         let unlocked = verifier_client.bond_unlocked(game_address).await?;
         if unlocked {
@@ -500,20 +546,24 @@ impl BondManager {
                 "bond already unlocked, advancing to delay phase"
             );
             self.set_phase(game_address, BondPhase::AwaitingDelay { unlocked_at: resolved_at });
-            return Ok(false);
+            return Ok(None);
         }
 
         self.submit_claim_credit(
             game_address,
             submitter,
             "unlock",
-            BondPhase::AwaitingDelay { unlocked_at: unix_now() },
+            BondPhase::AwaitingDelay { unlocked_at: (self.clock)() },
         )
         .await
     }
 
     /// Checks if the `DelayedWETH` delay has elapsed since the unlock.
-    fn check_delay(&mut self, game_address: Address, unlocked_at: u64) -> eyre::Result<bool> {
+    fn check_delay(
+        &mut self,
+        game_address: Address,
+        unlocked_at: u64,
+    ) -> eyre::Result<Option<RemovalReason>> {
         // Fall back to 7 days if the onchain delay has not been read yet.
         // If the real delay is shorter, the withdraw attempt will simply
         // succeed earlier than expected. If longer, the attempt will revert
@@ -523,7 +573,7 @@ impl BondManager {
             Self::DEFAULT_WETH_DELAY
         });
 
-        let now = unix_now();
+        let now = (self.clock)();
         let elapsed = Duration::from_secs(now.saturating_sub(unlocked_at));
 
         if elapsed >= delay {
@@ -541,7 +591,7 @@ impl BondManager {
                 "waiting for DelayedWETH delay"
             );
         }
-        Ok(false)
+        Ok(None)
     }
 
     /// Attempts the second `claimCredit()` call to complete the withdrawal.
@@ -550,30 +600,31 @@ impl BondManager {
         game_address: Address,
         verifier_client: &dyn AggregateVerifierClient,
         submitter: &dyn BondTransactionSubmitter,
-    ) -> eyre::Result<bool> {
+    ) -> eyre::Result<Option<RemovalReason>> {
         // Check if already claimed onchain.
         let claimed = verifier_client.bond_claimed(game_address).await?;
         if claimed {
             info!(game = %game_address, "bond already claimed");
             self.set_phase(game_address, BondPhase::Completed);
-            return Ok(true);
+            return Ok(Some(RemovalReason::Completed));
         }
 
         self.submit_claim_credit(game_address, submitter, "withdraw", BondPhase::Completed).await
     }
 
     /// Submits a `claimCredit()` transaction and transitions to the given
-    /// phase on success. Returns `Ok(true)` when the success phase is
-    /// [`BondPhase::Completed`].
+    /// phase on success. Returns `Ok(Some(Completed))` when the success
+    /// phase is [`BondPhase::Completed`].
     async fn submit_claim_credit(
         &mut self,
         game_address: Address,
         submitter: &dyn BondTransactionSubmitter,
         step: &str,
         success_phase: BondPhase,
-    ) -> eyre::Result<bool> {
+    ) -> eyre::Result<Option<RemovalReason>> {
         let calldata = encode_claim_credit_calldata();
         ChallengerMetrics::claim_credit_tx_submitted_total().increment(1);
+        info!(game = %game_address, step, "submitting claimCredit transaction");
         match submitter.send_bond_tx(game_address, calldata).await {
             Ok(tx_hash) => {
                 info!(
@@ -586,7 +637,7 @@ impl BondManager {
                     .increment(1);
                 let completed = matches!(success_phase, BondPhase::Completed);
                 self.set_phase(game_address, success_phase);
-                Ok(completed)
+                Ok(completed.then_some(RemovalReason::Completed))
             }
             Err(e) => {
                 warn!(
@@ -597,7 +648,7 @@ impl BondManager {
                 );
                 ChallengerMetrics::claim_credit_tx_outcome_total(ChallengerMetrics::STATUS_ERROR)
                     .increment(1);
-                Ok(false)
+                Ok(None)
             }
         }
     }
@@ -704,23 +755,34 @@ mod tests {
         assert!(mgr.is_tracking(&game));
     }
 
+    /// Returns a [`ClockFn`] that always returns the given timestamp.
+    ///
+    /// Only a fixed set of test timestamps is supported; passing an
+    /// unsupported value will panic to prevent silent non-determinism.
+    fn fixed_clock(ts: u64) -> ClockFn {
+        match ts {
+            1000 => || 1000,
+            5000 => || 5000,
+            _ => panic!("unsupported test timestamp {ts} — add a new match arm"),
+        }
+    }
+
     #[test]
     fn check_delay_transitions_when_elapsed() {
         let addr = Address::repeat_byte(0x01);
         let game = Address::repeat_byte(0xAA);
 
         let mut mgr = BondManager::new(vec![addr], test_l1_rpc_url());
-        mgr.set_weth_delay(Duration::from_secs(0)); // instant delay for testing
-        let past = unix_now().saturating_sub(1);
+        mgr.set_weth_delay(Duration::from_secs(60));
+        mgr.set_clock(fixed_clock(1000));
+
+        let unlocked_at = 900; // 100 seconds ago > 60 second delay
         mgr.tracked.insert(
             game,
-            TrackedGame {
-                phase: BondPhase::AwaitingDelay { unlocked_at: past },
-                bond_recipient: addr,
-            },
+            TrackedGame { phase: BondPhase::AwaitingDelay { unlocked_at }, bond_recipient: addr },
         );
 
-        let result = mgr.check_delay(game, past);
+        let result = mgr.check_delay(game, unlocked_at);
         assert!(result.is_ok());
         assert!(matches!(mgr.tracked.get(&game).unwrap().phase, BondPhase::NeedsWithdraw));
     }
@@ -732,16 +794,15 @@ mod tests {
 
         let mut mgr = BondManager::new(vec![addr], test_l1_rpc_url());
         mgr.set_weth_delay(Duration::from_secs(3600));
-        let now = unix_now();
+        mgr.set_clock(fixed_clock(1000));
+
+        let unlocked_at = 999; // only 1 second ago < 3600 second delay
         mgr.tracked.insert(
             game,
-            TrackedGame {
-                phase: BondPhase::AwaitingDelay { unlocked_at: now },
-                bond_recipient: addr,
-            },
+            TrackedGame { phase: BondPhase::AwaitingDelay { unlocked_at }, bond_recipient: addr },
         );
 
-        let result = mgr.check_delay(game, now);
+        let result = mgr.check_delay(game, unlocked_at);
         assert!(result.is_ok());
         assert!(matches!(mgr.tracked.get(&game).unwrap().phase, BondPhase::AwaitingDelay { .. }));
     }

--- a/crates/proof/challenge/src/bond.rs
+++ b/crates/proof/challenge/src/bond.rs
@@ -470,31 +470,13 @@ impl BondManager {
             return Ok(false);
         }
 
-        // Submit first claimCredit() — triggers unlock.
-        let calldata = encode_claim_credit_calldata();
-        ChallengerMetrics::claim_credit_tx_submitted_total().increment(1);
-        match submitter.send_bond_tx(game_address, calldata).await {
-            Ok(tx_hash) => {
-                info!(
-                    game = %game_address,
-                    tx_hash = %tx_hash,
-                    "claimCredit (unlock) transaction confirmed"
-                );
-                ChallengerMetrics::claim_credit_tx_outcome_total(ChallengerMetrics::STATUS_SUCCESS)
-                    .increment(1);
-                self.set_phase(game_address, BondPhase::AwaitingDelay { unlocked_at: unix_now() });
-            }
-            Err(e) => {
-                warn!(
-                    game = %game_address,
-                    error = %e,
-                    "claimCredit (unlock) transaction failed, will retry"
-                );
-                ChallengerMetrics::claim_credit_tx_outcome_total(ChallengerMetrics::STATUS_ERROR)
-                    .increment(1);
-            }
-        }
-        Ok(false)
+        self.submit_claim_credit(
+            game_address,
+            submitter,
+            "unlock",
+            BondPhase::AwaitingDelay { unlocked_at: unix_now() },
+        )
+        .await
     }
 
     /// Checks if the `DelayedWETH` delay has elapsed since the unlock.
@@ -544,7 +526,20 @@ impl BondManager {
             return Ok(true);
         }
 
-        // Submit second claimCredit() — triggers withdraw.
+        self.submit_claim_credit(game_address, submitter, "withdraw", BondPhase::Completed)
+            .await
+    }
+
+    /// Submits a `claimCredit()` transaction and transitions to the given
+    /// phase on success. Returns `Ok(true)` when the success phase is
+    /// [`BondPhase::Completed`].
+    async fn submit_claim_credit(
+        &mut self,
+        game_address: Address,
+        submitter: &dyn BondTransactionSubmitter,
+        step: &str,
+        success_phase: BondPhase,
+    ) -> eyre::Result<bool> {
         let calldata = encode_claim_credit_calldata();
         ChallengerMetrics::claim_credit_tx_submitted_total().increment(1);
         match submitter.send_bond_tx(game_address, calldata).await {
@@ -552,24 +547,27 @@ impl BondManager {
                 info!(
                     game = %game_address,
                     tx_hash = %tx_hash,
-                    "claimCredit (withdraw) transaction confirmed"
+                    step,
+                    "claimCredit transaction confirmed"
                 );
                 ChallengerMetrics::claim_credit_tx_outcome_total(ChallengerMetrics::STATUS_SUCCESS)
                     .increment(1);
-                self.set_phase(game_address, BondPhase::Completed);
-                return Ok(true);
+                let completed = matches!(success_phase, BondPhase::Completed);
+                self.set_phase(game_address, success_phase);
+                Ok(completed)
             }
             Err(e) => {
                 warn!(
                     game = %game_address,
                     error = %e,
-                    "claimCredit (withdraw) transaction failed, will retry"
+                    step,
+                    "claimCredit transaction failed, will retry"
                 );
                 ChallengerMetrics::claim_credit_tx_outcome_total(ChallengerMetrics::STATUS_ERROR)
                     .increment(1);
+                Ok(false)
             }
         }
-        Ok(false)
     }
 
     /// Determines the bond phase from on-chain state.

--- a/crates/proof/challenge/src/bond.rs
+++ b/crates/proof/challenge/src/bond.rs
@@ -1,0 +1,739 @@
+//! Bond lifecycle management for the challenger.
+//!
+//! After the challenger successfully submits a `challenge()` transaction,
+//! the [`BondManager`] tracks the resulting game through a multi-phase
+//! credit claim lifecycle:
+//!
+//! 1. **[`NeedsResolve`](BondPhase::NeedsResolve)** — wait for the game's
+//!    dispute period to expire, then call `resolve()`.
+//! 2. **[`NeedsUnlock`](BondPhase::NeedsUnlock)** — call `claimCredit()`
+//!    to trigger `DelayedWETH.unlock()`.
+//! 3. **[`AwaitingDelay`](BondPhase::AwaitingDelay)** — wait for the
+//!    `DelayedWETH` delay to elapse.
+//! 4. **[`NeedsWithdraw`](BondPhase::NeedsWithdraw)** — call `claimCredit()`
+//!    again to complete the withdrawal.
+//!
+//! A comma-separated list of addresses is provided via the
+//! `BASE_CHALLENGER_BOND_CLAIM_ADDRESSES` env var. The manager only tracks
+//! games where the on-chain `bondRecipient` or `zkProver` matches one of
+//! those addresses. Checking `zkProver` is necessary to recover pre-resolve
+//! challenged games after a restart, since `bondRecipient` is only updated
+//! to the challenger's address during `resolve()`.
+
+use std::{
+    collections::{HashMap, HashSet},
+    time::{Duration, SystemTime},
+};
+
+use alloy_primitives::Address;
+use base_proof_contracts::{
+    AggregateVerifierClient, DelayedWETHClient, DelayedWETHContractClient,
+    DisputeGameFactoryClient, encode_claim_credit_calldata, encode_resolve_calldata,
+};
+use futures::stream::{self, StreamExt};
+use tracing::{debug, info, warn};
+
+use crate::{ChallengerMetrics, GameScanner};
+
+/// Returns the current Unix timestamp in seconds.
+fn unix_now() -> u64 {
+    SystemTime::now()
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .expect("system clock before UNIX epoch")
+        .as_secs()
+}
+
+/// Phase of the bond claim lifecycle for a single tracked game.
+#[derive(Debug, Clone)]
+pub enum BondPhase {
+    /// The game's dispute period is over; needs a `resolve()` call.
+    NeedsResolve,
+    /// The game has been resolved; needs the first `claimCredit()` call
+    /// to trigger `DelayedWETH.unlock()`.
+    NeedsUnlock,
+    /// The unlock has been submitted; waiting for the `DelayedWETH` delay
+    /// to elapse before the second `claimCredit()` call.
+    AwaitingDelay {
+        /// Unix timestamp (seconds) at which the unlock occurred.
+        unlocked_at: u64,
+    },
+    /// The delay has elapsed; needs the second `claimCredit()` call to
+    /// complete the withdrawal.
+    NeedsWithdraw,
+    /// Bond fully claimed. The entry will be removed from tracking.
+    Completed,
+}
+
+/// A game being tracked for bond lifecycle management.
+#[derive(Debug, Clone)]
+pub struct TrackedGame {
+    /// Current lifecycle phase.
+    pub phase: BondPhase,
+    /// The address that will receive the bond.
+    pub bond_recipient: Address,
+}
+
+/// Manages the bond claim lifecycle for dispute games.
+///
+/// After a successful `challenge()` submission, games are registered here.
+/// On each [`poll`](Self::poll) tick the manager checks each tracked game's
+/// on-chain state and submits the next transaction in the lifecycle.
+#[derive(Debug)]
+pub struct BondManager {
+    /// Games being tracked, keyed by proxy address.
+    tracked: HashMap<Address, TrackedGame>,
+    /// Addresses we are authorized to claim bonds on behalf of.
+    claim_addresses: HashSet<Address>,
+    /// `DelayedWETH` withdrawal delay (read from contract at init or lazily
+    /// resolved on the first poll tick that has a tracked game).
+    weth_delay: Option<Duration>,
+    /// L1 RPC URL used to instantiate the `DelayedWETH` contract client
+    /// when lazily resolving the withdrawal delay.
+    l1_rpc_url: url::Url,
+}
+
+impl BondManager {
+    /// Conservative fallback when the on-chain `DelayedWETH` delay has not
+    /// been read yet. If the real delay is shorter the withdraw will simply
+    /// succeed earlier; if longer, the attempt reverts and is retried.
+    const DEFAULT_WETH_DELAY: Duration = Duration::from_secs(7 * 24 * 60 * 60);
+
+    /// Creates a new bond manager for the given set of claim addresses.
+    pub fn new(claim_addresses: Vec<Address>, l1_rpc_url: url::Url) -> Self {
+        let set: HashSet<Address> = claim_addresses.into_iter().collect();
+        info!(count = set.len(), "bond manager initialized with claim addresses");
+        Self { tracked: HashMap::new(), claim_addresses: set, weth_delay: None, l1_rpc_url }
+    }
+
+    /// Returns `true` if bond claiming is enabled (at least one claim address configured).
+    pub fn is_enabled(&self) -> bool {
+        !self.claim_addresses.is_empty()
+    }
+
+    /// Sets the `DelayedWETH` withdrawal delay.
+    pub fn set_weth_delay(&mut self, delay: Duration) {
+        info!(delay_secs = delay.as_secs(), "DelayedWETH delay configured");
+        self.weth_delay = Some(delay);
+    }
+
+    /// Returns the number of games currently being tracked.
+    pub fn tracked_count(&self) -> usize {
+        self.tracked.len()
+    }
+
+    /// Registers a game for bond tracking if its `bond_recipient` is in the
+    /// configured claim addresses.
+    ///
+    /// Returns `true` if the game was added to tracking.
+    pub fn track_game(&mut self, game_address: Address, bond_recipient: Address) -> bool {
+        if !self.claim_addresses.contains(&bond_recipient) {
+            debug!(
+                game = %game_address,
+                recipient = %bond_recipient,
+                "skipping game — bond recipient not in claim addresses"
+            );
+            return false;
+        }
+
+        if self.tracked.contains_key(&game_address) {
+            debug!(game = %game_address, "game already tracked for bond claiming");
+            return false;
+        }
+
+        info!(
+            game = %game_address,
+            recipient = %bond_recipient,
+            "tracking game for bond claiming"
+        );
+        self.tracked
+            .insert(game_address, TrackedGame { phase: BondPhase::NeedsResolve, bond_recipient });
+        ChallengerMetrics::bonds_tracked().set(self.tracked.len() as f64);
+        true
+    }
+
+    /// Returns `true` if the given game is being tracked.
+    pub fn is_tracking(&self, game_address: &Address) -> bool {
+        self.tracked.contains_key(game_address)
+    }
+
+    /// Updates the phase of a tracked game. No-op if the game is not tracked.
+    fn set_phase(&mut self, game_address: Address, phase: BondPhase) {
+        if let Some(game) = self.tracked.get_mut(&game_address) {
+            game.phase = phase;
+        }
+    }
+
+    /// Scans recent games at startup to recover bond tracking state after a
+    /// restart.
+    ///
+    /// Iterates the last `lookback` games from the factory concurrently and
+    /// checks if any have a `bondRecipient` or `zkProver` matching our claim
+    /// addresses. The `zkProver` check is necessary because before
+    /// `resolve()`, `bondRecipient` is the game creator — only after
+    /// resolution does it update to the challenger's address. Games that are
+    /// already fully claimed are skipped.
+    ///
+    /// Also reads the `DelayedWETH` delay from the first game found, if the
+    /// delay has not been set yet.
+    pub async fn startup_scan(
+        &mut self,
+        factory_client: &dyn DisputeGameFactoryClient,
+        verifier_client: &dyn AggregateVerifierClient,
+        lookback: u64,
+    ) -> eyre::Result<()> {
+        if !self.is_enabled() {
+            return Ok(());
+        }
+
+        let game_count = factory_client.game_count().await?;
+        if game_count == 0 {
+            info!("no games in factory, skipping bond startup scan");
+            return Ok(());
+        }
+
+        let start_index = game_count.saturating_sub(lookback);
+        info!(start = start_index, end = game_count, "scanning recent games for bond recovery");
+
+        // Evaluate all games concurrently using the same pattern as the
+        // game scanner (`buffer_unordered`).
+        let claim_addresses = &self.claim_addresses;
+        let results: Vec<Option<(Address, Address, Option<BondPhase>)>> =
+            stream::iter(start_index..game_count)
+                .map(|i| async move {
+                    let game_at = match factory_client.game_at_index(i).await {
+                        Ok(g) => g,
+                        Err(e) => {
+                            warn!(index = i, error = %e, "failed to fetch game at index");
+                            return None;
+                        }
+                    };
+
+                    let game_address = game_at.proxy;
+
+                    let (bond_recipient, zk_prover) = match futures::try_join!(
+                        verifier_client.bond_recipient(game_address),
+                        verifier_client.zk_prover(game_address),
+                    ) {
+                        Ok(pair) => pair,
+                        Err(e) => {
+                            debug!(
+                                game = %game_address,
+                                error = %e,
+                                "failed to read bondRecipient/zkProver"
+                            );
+                            return None;
+                        }
+                    };
+
+                    // Check both `bondRecipient` and `zkProver` against our
+                    // claim addresses. Before `resolve()`, `bondRecipient`
+                    // is the game creator while `zkProver` is the address
+                    // that called `challenge()`. After `resolve()`,
+                    // `bondRecipient` is updated to the `zkProver`. Checking
+                    // both ensures we recover pre-resolve challenged games
+                    // after a restart.
+                    let matched_address = if claim_addresses.contains(&bond_recipient) {
+                        bond_recipient
+                    } else if zk_prover != Address::ZERO && claim_addresses.contains(&zk_prover) {
+                        zk_prover
+                    } else {
+                        return None;
+                    };
+
+                    let phase = match Self::determine_phase(verifier_client, game_address).await {
+                        Ok(phase) => phase,
+                        Err(e) => {
+                            warn!(
+                                game = %game_address,
+                                error = %e,
+                                "failed to determine bond phase"
+                            );
+                            return None;
+                        }
+                    };
+
+                    Some((game_address, matched_address, phase))
+                })
+                .buffer_unordered(GameScanner::SCAN_CONCURRENCY)
+                .collect()
+                .await;
+
+        // Process results sequentially: insert tracked games and resolve the
+        // WETH delay from the first relevant game.
+        let mut weth_delay_resolved = self.weth_delay.is_some();
+
+        for (game_address, bond_recipient, phase) in results.into_iter().flatten() {
+            // Read the WETH delay from the first relevant game if not yet set.
+            if !weth_delay_resolved {
+                if let Err(e) = self.resolve_weth_delay(verifier_client, game_address).await {
+                    warn!(error = %e, "failed to read DelayedWETH delay, will retry later");
+                } else {
+                    weth_delay_resolved = true;
+                }
+            }
+
+            let Some(phase) = phase else {
+                continue; // already claimed, skip
+            };
+
+            info!(
+                game = %game_address,
+                recipient = %bond_recipient,
+                phase = ?phase,
+                "recovered game for bond tracking"
+            );
+            self.tracked.insert(game_address, TrackedGame { phase, bond_recipient });
+        }
+
+        ChallengerMetrics::bonds_tracked().set(self.tracked.len() as f64);
+        info!(count = self.tracked.len(), "bond startup scan complete");
+        Ok(())
+    }
+
+    /// Polls all tracked games and advances each through the bond lifecycle.
+    ///
+    /// Called once per driver tick. Errors on individual games are logged and
+    /// do not abort processing of remaining games.
+    pub async fn poll(
+        &mut self,
+        verifier_client: &dyn AggregateVerifierClient,
+        submitter: &dyn BondTransactionSubmitter,
+    ) {
+        if self.tracked.is_empty() {
+            return;
+        }
+
+        // Lazily resolve the DelayedWETH delay if not yet known.
+        if self.weth_delay.is_none()
+            && let Some(&game_address) = self.tracked.keys().next()
+            && let Err(e) = self.resolve_weth_delay(verifier_client, game_address).await
+        {
+            warn!(error = %e, "failed to resolve DelayedWETH delay, will retry next poll");
+        }
+
+        let addresses: Vec<Address> = self.tracked.keys().copied().collect();
+        let mut completed = Vec::new();
+
+        for game_address in addresses {
+            match self.advance_game(game_address, verifier_client, submitter).await {
+                Ok(true) => completed.push(game_address),
+                Ok(false) => {}
+                Err(e) => {
+                    warn!(
+                        game = %game_address,
+                        error = %e,
+                        "failed to advance bond lifecycle"
+                    );
+                }
+            }
+        }
+
+        for addr in &completed {
+            self.tracked.remove(addr);
+            ChallengerMetrics::bonds_completed_total().increment(1);
+        }
+
+        if !completed.is_empty() {
+            ChallengerMetrics::bonds_tracked().set(self.tracked.len() as f64);
+        }
+    }
+
+    /// Advances a single game through the bond lifecycle state machine.
+    ///
+    /// Returns `Ok(true)` when the game reaches [`BondPhase::Completed`] and
+    /// should be removed from tracking.
+    async fn advance_game(
+        &mut self,
+        game_address: Address,
+        verifier_client: &dyn AggregateVerifierClient,
+        submitter: &dyn BondTransactionSubmitter,
+    ) -> eyre::Result<bool> {
+        let game = match self.tracked.get(&game_address) {
+            Some(g) => g,
+            None => return Ok(false),
+        };
+
+        match &game.phase {
+            BondPhase::NeedsResolve => {
+                self.try_resolve(game_address, verifier_client, submitter).await
+            }
+            BondPhase::NeedsUnlock => {
+                self.try_unlock(game_address, verifier_client, submitter).await
+            }
+            BondPhase::AwaitingDelay { unlocked_at } => {
+                let unlocked_at = *unlocked_at;
+                self.check_delay(game_address, unlocked_at)
+            }
+            BondPhase::NeedsWithdraw => {
+                self.try_withdraw(game_address, verifier_client, submitter).await
+            }
+            BondPhase::Completed => Ok(true),
+        }
+    }
+
+    /// Marks a game as completed because the defender won and the bond is not
+    /// claimable. Returns `Ok(true)` to signal removal from tracking.
+    fn complete_defender_wins(&mut self, game_address: Address, status: u8) -> eyre::Result<bool> {
+        info!(
+            game = %game_address,
+            status,
+            "game resolved as DEFENDER_WINS, bond not claimable — removing from tracking"
+        );
+        ChallengerMetrics::resolve_tx_outcome_total(ChallengerMetrics::STATUS_DEFENDER_WINS)
+            .increment(1);
+        self.set_phase(game_address, BondPhase::Completed);
+        Ok(true)
+    }
+
+    /// Attempts to resolve the game by calling `resolve()`.
+    ///
+    /// After resolution (either by us or by another actor), checks the
+    /// on-chain status to verify the game resolved as `CHALLENGER_WINS`.
+    /// If the game resolved as `DEFENDER_WINS`, the bond belongs to the
+    /// game creator and is not claimable by the challenger, so the game
+    /// is removed from tracking.
+    async fn try_resolve(
+        &mut self,
+        game_address: Address,
+        verifier_client: &dyn AggregateVerifierClient,
+        submitter: &dyn BondTransactionSubmitter,
+    ) -> eyre::Result<bool> {
+        // Check if already resolved on-chain (e.g., someone else called it).
+        let status = verifier_client.status(game_address).await?;
+        if status != GameScanner::STATUS_IN_PROGRESS {
+            ChallengerMetrics::resolve_tx_outcome_total(ChallengerMetrics::STATUS_ALREADY_RESOLVED)
+                .increment(1);
+
+            if status != GameScanner::STATUS_CHALLENGER_WINS {
+                return self.complete_defender_wins(game_address, status);
+            }
+
+            info!(game = %game_address, status, "game already resolved, advancing to unlock phase");
+            self.set_phase(game_address, BondPhase::NeedsUnlock);
+            return Ok(false);
+        }
+
+        // Check if the game is ready to resolve.
+        let game_over = verifier_client.game_over(game_address).await?;
+        if !game_over {
+            debug!(game = %game_address, "game dispute period not yet elapsed");
+            return Ok(false);
+        }
+
+        // Submit resolve transaction.
+        let calldata = encode_resolve_calldata();
+        match submitter.send_bond_tx(game_address, calldata).await {
+            Ok(tx_hash) => {
+                info!(game = %game_address, tx_hash = %tx_hash, "resolve transaction confirmed");
+                ChallengerMetrics::resolve_tx_outcome_total(ChallengerMetrics::STATUS_SUCCESS)
+                    .increment(1);
+
+                // Re-read status to verify the game resolved in our favor.
+                let post_status = verifier_client.status(game_address).await?;
+                if post_status != GameScanner::STATUS_CHALLENGER_WINS {
+                    return self.complete_defender_wins(game_address, post_status);
+                }
+
+                self.set_phase(game_address, BondPhase::NeedsUnlock);
+            }
+            Err(e) => {
+                warn!(game = %game_address, error = %e, "resolve transaction failed, will retry");
+                ChallengerMetrics::resolve_tx_outcome_total(ChallengerMetrics::STATUS_ERROR)
+                    .increment(1);
+            }
+        }
+        Ok(false)
+    }
+
+    /// Attempts the first `claimCredit()` call to trigger the unlock.
+    async fn try_unlock(
+        &mut self,
+        game_address: Address,
+        verifier_client: &dyn AggregateVerifierClient,
+        submitter: &dyn BondTransactionSubmitter,
+    ) -> eyre::Result<bool> {
+        // Check if already unlocked on-chain.
+        let unlocked = verifier_client.bond_unlocked(game_address).await?;
+        if unlocked {
+            // Use `resolved_at` as a conservative lower bound for the unlock
+            // time. The unlock must have occurred after resolve, so this may
+            // cause one early withdrawal attempt that reverts, but is strictly
+            // better than resetting to "now" (which would re-impose the full
+            // delay after every restart).
+            let resolved_at = verifier_client.resolved_at(game_address).await?;
+            info!(
+                game = %game_address,
+                resolved_at,
+                "bond already unlocked, advancing to delay phase"
+            );
+            self.set_phase(game_address, BondPhase::AwaitingDelay { unlocked_at: resolved_at });
+            return Ok(false);
+        }
+
+        // Submit first claimCredit() — triggers unlock.
+        let calldata = encode_claim_credit_calldata();
+        ChallengerMetrics::claim_credit_tx_submitted_total().increment(1);
+        match submitter.send_bond_tx(game_address, calldata).await {
+            Ok(tx_hash) => {
+                info!(
+                    game = %game_address,
+                    tx_hash = %tx_hash,
+                    "claimCredit (unlock) transaction confirmed"
+                );
+                ChallengerMetrics::claim_credit_tx_outcome_total(ChallengerMetrics::STATUS_SUCCESS)
+                    .increment(1);
+                self.set_phase(game_address, BondPhase::AwaitingDelay { unlocked_at: unix_now() });
+            }
+            Err(e) => {
+                warn!(
+                    game = %game_address,
+                    error = %e,
+                    "claimCredit (unlock) transaction failed, will retry"
+                );
+                ChallengerMetrics::claim_credit_tx_outcome_total(ChallengerMetrics::STATUS_ERROR)
+                    .increment(1);
+            }
+        }
+        Ok(false)
+    }
+
+    /// Checks if the `DelayedWETH` delay has elapsed since the unlock.
+    fn check_delay(&mut self, game_address: Address, unlocked_at: u64) -> eyre::Result<bool> {
+        // Fall back to 7 days if the on-chain delay has not been read yet.
+        // If the real delay is shorter, the withdraw attempt will simply
+        // succeed earlier than expected. If longer, the attempt will revert
+        // and be retried on the next poll tick.
+        let delay = self.weth_delay.unwrap_or_else(|| {
+            warn!(game = %game_address, "WETH delay not yet known, using default 7 days");
+            Self::DEFAULT_WETH_DELAY
+        });
+
+        let now = unix_now();
+        let elapsed = Duration::from_secs(now.saturating_sub(unlocked_at));
+
+        if elapsed >= delay {
+            info!(
+                game = %game_address,
+                elapsed_secs = elapsed.as_secs(),
+                "DelayedWETH delay elapsed, advancing to withdraw phase"
+            );
+            self.set_phase(game_address, BondPhase::NeedsWithdraw);
+        } else {
+            let remaining = delay.saturating_sub(elapsed);
+            debug!(
+                game = %game_address,
+                remaining_secs = remaining.as_secs(),
+                "waiting for DelayedWETH delay"
+            );
+        }
+        Ok(false)
+    }
+
+    /// Attempts the second `claimCredit()` call to complete the withdrawal.
+    async fn try_withdraw(
+        &mut self,
+        game_address: Address,
+        verifier_client: &dyn AggregateVerifierClient,
+        submitter: &dyn BondTransactionSubmitter,
+    ) -> eyre::Result<bool> {
+        // Check if already claimed on-chain.
+        let claimed = verifier_client.bond_claimed(game_address).await?;
+        if claimed {
+            info!(game = %game_address, "bond already claimed");
+            self.set_phase(game_address, BondPhase::Completed);
+            return Ok(true);
+        }
+
+        // Submit second claimCredit() — triggers withdraw.
+        let calldata = encode_claim_credit_calldata();
+        ChallengerMetrics::claim_credit_tx_submitted_total().increment(1);
+        match submitter.send_bond_tx(game_address, calldata).await {
+            Ok(tx_hash) => {
+                info!(
+                    game = %game_address,
+                    tx_hash = %tx_hash,
+                    "claimCredit (withdraw) transaction confirmed"
+                );
+                ChallengerMetrics::claim_credit_tx_outcome_total(ChallengerMetrics::STATUS_SUCCESS)
+                    .increment(1);
+                self.set_phase(game_address, BondPhase::Completed);
+                return Ok(true);
+            }
+            Err(e) => {
+                warn!(
+                    game = %game_address,
+                    error = %e,
+                    "claimCredit (withdraw) transaction failed, will retry"
+                );
+                ChallengerMetrics::claim_credit_tx_outcome_total(ChallengerMetrics::STATUS_ERROR)
+                    .increment(1);
+            }
+        }
+        Ok(false)
+    }
+
+    /// Determines the bond phase from on-chain state.
+    ///
+    /// Returns `None` if the bond has already been claimed, or if the game
+    /// resolved as `DEFENDER_WINS` (the bond is not claimable by the
+    /// challenger).
+    async fn determine_phase(
+        verifier_client: &dyn AggregateVerifierClient,
+        game_address: Address,
+    ) -> eyre::Result<Option<BondPhase>> {
+        let bond_claimed = verifier_client.bond_claimed(game_address).await?;
+        if bond_claimed {
+            return Ok(None);
+        }
+
+        let resolved_at = verifier_client.resolved_at(game_address).await?;
+
+        let bond_unlocked = verifier_client.bond_unlocked(game_address).await?;
+        if bond_unlocked {
+            // Use `resolved_at` as a conservative lower bound for the unlock
+            // time. The unlock must have occurred after resolve, so this may
+            // cause one early withdrawal attempt that reverts, but is strictly
+            // better than resetting to "now" (which would re-impose the full
+            // delay after every restart).
+            return Ok(Some(BondPhase::AwaitingDelay { unlocked_at: resolved_at }));
+        }
+
+        if resolved_at > 0 {
+            // The game has been resolved. Check if it resolved in the
+            // challenger's favor before tracking it for bond claiming.
+            let status = verifier_client.status(game_address).await?;
+            if status != GameScanner::STATUS_CHALLENGER_WINS {
+                debug!(
+                    game = %game_address,
+                    status,
+                    "game resolved as DEFENDER_WINS during startup scan, skipping"
+                );
+                return Ok(None);
+            }
+            return Ok(Some(BondPhase::NeedsUnlock));
+        }
+
+        Ok(Some(BondPhase::NeedsResolve))
+    }
+
+    /// Reads the `DelayedWETH` address from a game proxy and fetches the delay.
+    async fn resolve_weth_delay(
+        &mut self,
+        verifier_client: &dyn AggregateVerifierClient,
+        game_address: Address,
+    ) -> eyre::Result<()> {
+        let weth_address = verifier_client.delayed_weth(game_address).await?;
+        let weth_client = DelayedWETHContractClient::new(weth_address, self.l1_rpc_url.clone())?;
+        let delay = weth_client.delay().await?;
+        self.set_weth_delay(delay);
+        Ok(())
+    }
+}
+
+/// Trait for submitting bond lifecycle transactions (resolve, claimCredit).
+///
+/// This abstracts the transaction submission layer so the [`BondManager`]
+/// can be tested with mock submitters.
+#[async_trait::async_trait]
+pub trait BondTransactionSubmitter: Send + Sync {
+    /// Sends a transaction with the given calldata to the game address.
+    ///
+    /// Returns the transaction hash on success.
+    async fn send_bond_tx(
+        &self,
+        game_address: Address,
+        calldata: alloy_primitives::Bytes,
+    ) -> Result<alloy_primitives::B256, crate::ChallengeSubmitError>;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_l1_rpc_url() -> url::Url {
+        "http://localhost:8545".parse().unwrap()
+    }
+
+    fn make_manager(addresses: Vec<Address>) -> BondManager {
+        let mut mgr = BondManager::new(addresses, test_l1_rpc_url());
+        mgr.set_weth_delay(Duration::from_secs(60));
+        mgr
+    }
+
+    #[test]
+    fn track_game_filters_by_claim_address() {
+        let addr = Address::repeat_byte(0x01);
+        let other = Address::repeat_byte(0x02);
+        let game = Address::repeat_byte(0xAA);
+
+        let mut mgr = make_manager(vec![addr]);
+        assert!(mgr.track_game(game, addr));
+        assert!(!mgr.track_game(game, addr)); // duplicate
+        assert!(!mgr.track_game(Address::repeat_byte(0xBB), other)); // not in set
+    }
+
+    #[test]
+    fn is_tracking_returns_correct_state() {
+        let addr = Address::repeat_byte(0x01);
+        let game = Address::repeat_byte(0xAA);
+
+        let mut mgr = make_manager(vec![addr]);
+        assert!(!mgr.is_tracking(&game));
+        mgr.track_game(game, addr);
+        assert!(mgr.is_tracking(&game));
+    }
+
+    #[test]
+    fn check_delay_transitions_when_elapsed() {
+        let addr = Address::repeat_byte(0x01);
+        let game = Address::repeat_byte(0xAA);
+
+        let mut mgr = BondManager::new(vec![addr], test_l1_rpc_url());
+        mgr.set_weth_delay(Duration::from_secs(0)); // instant delay for testing
+        let past = unix_now().saturating_sub(1);
+        mgr.tracked.insert(
+            game,
+            TrackedGame {
+                phase: BondPhase::AwaitingDelay { unlocked_at: past },
+                bond_recipient: addr,
+            },
+        );
+
+        let result = mgr.check_delay(game, past);
+        assert!(result.is_ok());
+        assert!(matches!(mgr.tracked.get(&game).unwrap().phase, BondPhase::NeedsWithdraw));
+    }
+
+    #[test]
+    fn check_delay_stays_when_not_elapsed() {
+        let addr = Address::repeat_byte(0x01);
+        let game = Address::repeat_byte(0xAA);
+
+        let mut mgr = BondManager::new(vec![addr], test_l1_rpc_url());
+        mgr.set_weth_delay(Duration::from_secs(3600));
+        let now = unix_now();
+        mgr.tracked.insert(
+            game,
+            TrackedGame {
+                phase: BondPhase::AwaitingDelay { unlocked_at: now },
+                bond_recipient: addr,
+            },
+        );
+
+        let result = mgr.check_delay(game, now);
+        assert!(result.is_ok());
+        assert!(matches!(mgr.tracked.get(&game).unwrap().phase, BondPhase::AwaitingDelay { .. }));
+    }
+
+    #[test]
+    fn empty_claim_addresses_means_disabled() {
+        let mgr = BondManager::new(vec![], test_l1_rpc_url());
+        assert!(!mgr.is_enabled());
+    }
+
+    #[test]
+    fn non_empty_claim_addresses_means_enabled() {
+        let mgr = BondManager::new(vec![Address::repeat_byte(0x01)], test_l1_rpc_url());
+        assert!(mgr.is_enabled());
+    }
+}

--- a/crates/proof/challenge/src/bond.rs
+++ b/crates/proof/challenge/src/bond.rs
@@ -462,7 +462,7 @@ impl BondManager {
     /// our claim addresses. Returns `false` if not, signalling the caller
     /// to remove the game from tracking.
     async fn is_bond_claimable(
-        &mut self,
+        &self,
         verifier_client: &dyn AggregateVerifierClient,
         game_address: Address,
     ) -> eyre::Result<bool> {

--- a/crates/proof/challenge/src/bond.rs
+++ b/crates/proof/challenge/src/bond.rs
@@ -459,8 +459,8 @@ impl BondManager {
     }
 
     /// Checks whether the onchain `bondRecipient` for the given game is in
-    /// our claim addresses. If not, marks the game as completed (removing it
-    /// from tracking) and returns `false`.
+    /// our claim addresses. Returns `false` if not, signalling the caller
+    /// to remove the game from tracking.
     async fn is_bond_claimable(
         &mut self,
         verifier_client: &dyn AggregateVerifierClient,
@@ -475,7 +475,6 @@ impl BondManager {
             recipient = %bond_recipient,
             "bond recipient not in claim addresses after resolve, removing from tracking"
         );
-        self.set_phase(game_address, BondPhase::Completed);
         Ok(false)
     }
 

--- a/crates/proof/challenge/src/bond.rs
+++ b/crates/proof/challenge/src/bond.rs
@@ -526,8 +526,7 @@ impl BondManager {
             return Ok(true);
         }
 
-        self.submit_claim_credit(game_address, submitter, "withdraw", BondPhase::Completed)
-            .await
+        self.submit_claim_credit(game_address, submitter, "withdraw", BondPhase::Completed).await
     }
 
     /// Submits a `claimCredit()` transaction and transitions to the given

--- a/crates/proof/challenge/src/bond.rs
+++ b/crates/proof/challenge/src/bond.rs
@@ -1,8 +1,7 @@
-//! Bond lifecycle management for the challenger.
+//! Bond lifecycle management.
 //!
-//! After the challenger successfully submits a `challenge()` transaction,
-//! the [`BondManager`] tracks the resulting game through a multi-phase
-//! credit claim lifecycle:
+//! The [`BondManager`] tracks dispute games through a multi-phase credit
+//! claim lifecycle:
 //!
 //! 1. **[`NeedsResolve`](BondPhase::NeedsResolve)** — wait for the game's
 //!    dispute period to expire, then call `resolve()`.
@@ -14,11 +13,17 @@
 //!    again to complete the withdrawal.
 //!
 //! A comma-separated list of addresses is provided via the
-//! `BASE_CHALLENGER_BOND_CLAIM_ADDRESSES` env var. The manager only tracks
-//! games where the on-chain `bondRecipient` or `zkProver` matches one of
-//! those addresses. Checking `zkProver` is necessary to recover pre-resolve
-//! challenged games after a restart, since `bondRecipient` is only updated
-//! to the challenger's address during `resolve()`.
+//! `BASE_CHALLENGER_BOND_CLAIM_ADDRESSES` env var. The manager tracks any
+//! game whose onchain `bondRecipient` matches one of those addresses,
+//! regardless of the game's resolution outcome (`CHALLENGER_WINS` or
+//! `DEFENDER_WINS`). This allows claiming bonds both for games won by the
+//! challenger and games proposed by addresses in the claim set.
+//!
+//! During startup recovery, `zkProver` is also checked against the claim
+//! addresses to recover pre-resolve challenged games, since `bondRecipient`
+//! is only updated to the challenger's address during `resolve()`. For
+//! already-resolved games matched solely via `zkProver`, the onchain
+//! `bondRecipient` is re-verified against the claim set before tracking.
 
 use std::{
     collections::{HashMap, HashSet},
@@ -77,7 +82,7 @@ pub struct TrackedGame {
 ///
 /// After a successful `challenge()` submission, games are registered here.
 /// On each [`poll`](Self::poll) tick the manager checks each tracked game's
-/// on-chain state and submits the next transaction in the lifecycle.
+/// onchain state and submits the next transaction in the lifecycle.
 #[derive(Debug)]
 pub struct BondManager {
     /// Games being tracked, keyed by proxy address.
@@ -93,7 +98,7 @@ pub struct BondManager {
 }
 
 impl BondManager {
-    /// Conservative fallback when the on-chain `DelayedWETH` delay has not
+    /// Conservative fallback when the onchain `DelayedWETH` delay has not
     /// been read yet. If the real delay is shorter the withdraw will simply
     /// succeed earlier; if longer, the attempt reverts and is retried.
     const DEFAULT_WETH_DELAY: Duration = Duration::from_secs(7 * 24 * 60 * 60);
@@ -252,6 +257,26 @@ impl BondManager {
                         }
                     };
 
+                    // For already-resolved games, verify the current onchain
+                    // `bondRecipient` is in our claim addresses. Games matched
+                    // via `zkProver` may have a `bondRecipient` that is not in
+                    // our claim set (e.g. a game where our challenge was
+                    // nullified and the bond goes to the game creator).
+                    // Pre-resolve games are kept — `bondRecipient` will be
+                    // re-verified after resolve in `try_resolve`.
+                    if let Some(ref p) = phase
+                        && !matches!(p, BondPhase::NeedsResolve)
+                            && !claim_addresses.contains(&bond_recipient)
+                        {
+                            debug!(
+                                game = %game_address,
+                                recipient = %bond_recipient,
+                                "onchain bondRecipient not in claim addresses \
+                                 for resolved game, skipping"
+                            );
+                            return None;
+                        }
+
                     Some((game_address, matched_address, phase))
                 })
                 .buffer_unordered(GameScanner::SCAN_CONCURRENCY)
@@ -371,41 +396,30 @@ impl BondManager {
         }
     }
 
-    /// Marks a game as completed because the defender won and the bond is not
-    /// claimable. Returns `Ok(true)` to signal removal from tracking.
-    fn complete_defender_wins(&mut self, game_address: Address, status: u8) -> eyre::Result<bool> {
-        info!(
-            game = %game_address,
-            status,
-            "game resolved as DEFENDER_WINS, bond not claimable — removing from tracking"
-        );
-        ChallengerMetrics::resolve_tx_outcome_total(ChallengerMetrics::STATUS_DEFENDER_WINS)
-            .increment(1);
-        self.set_phase(game_address, BondPhase::Completed);
-        Ok(true)
-    }
-
     /// Attempts to resolve the game by calling `resolve()`.
     ///
-    /// After resolution (either by us or by another actor), checks the
-    /// on-chain status to verify the game resolved as `CHALLENGER_WINS`.
-    /// If the game resolved as `DEFENDER_WINS`, the bond belongs to the
-    /// game creator and is not claimable by the challenger, so the game
-    /// is removed from tracking.
+    /// After resolution (either by us or by another actor), re-reads the
+    /// onchain `bondRecipient` to verify it is still in our claim
+    /// addresses. `resolve()` may update `bondRecipient` (e.g. to the
+    /// challenger's address on `CHALLENGER_WINS`), so games matched via
+    /// `zkProver` before resolution may no longer be claimable by us.
     async fn try_resolve(
         &mut self,
         game_address: Address,
         verifier_client: &dyn AggregateVerifierClient,
         submitter: &dyn BondTransactionSubmitter,
     ) -> eyre::Result<bool> {
-        // Check if already resolved on-chain (e.g., someone else called it).
+        // Check if already resolved onchain (e.g., someone else called it).
         let status = verifier_client.status(game_address).await?;
         if status != GameScanner::STATUS_IN_PROGRESS {
             ChallengerMetrics::resolve_tx_outcome_total(ChallengerMetrics::STATUS_ALREADY_RESOLVED)
                 .increment(1);
 
-            if status != GameScanner::STATUS_CHALLENGER_WINS {
-                return self.complete_defender_wins(game_address, status);
+            // Re-read the onchain bondRecipient — resolve may have changed
+            // it (e.g. to the challenger on CHALLENGER_WINS). If it is no
+            // longer in our claim set, stop tracking this game.
+            if !self.is_bond_claimable(verifier_client, game_address).await? {
+                return Ok(true);
             }
 
             info!(game = %game_address, status, "game already resolved, advancing to unlock phase");
@@ -428,10 +442,9 @@ impl BondManager {
                 ChallengerMetrics::resolve_tx_outcome_total(ChallengerMetrics::STATUS_SUCCESS)
                     .increment(1);
 
-                // Re-read status to verify the game resolved in our favor.
-                let post_status = verifier_client.status(game_address).await?;
-                if post_status != GameScanner::STATUS_CHALLENGER_WINS {
-                    return self.complete_defender_wins(game_address, post_status);
+                // Re-read bondRecipient to verify it's in our claim set.
+                if !self.is_bond_claimable(verifier_client, game_address).await? {
+                    return Ok(true);
                 }
 
                 self.set_phase(game_address, BondPhase::NeedsUnlock);
@@ -445,6 +458,27 @@ impl BondManager {
         Ok(false)
     }
 
+    /// Checks whether the onchain `bondRecipient` for the given game is in
+    /// our claim addresses. If not, marks the game as completed (removing it
+    /// from tracking) and returns `false`.
+    async fn is_bond_claimable(
+        &mut self,
+        verifier_client: &dyn AggregateVerifierClient,
+        game_address: Address,
+    ) -> eyre::Result<bool> {
+        let bond_recipient = verifier_client.bond_recipient(game_address).await?;
+        if self.claim_addresses.contains(&bond_recipient) {
+            return Ok(true);
+        }
+        info!(
+            game = %game_address,
+            recipient = %bond_recipient,
+            "bond recipient not in claim addresses after resolve, removing from tracking"
+        );
+        self.set_phase(game_address, BondPhase::Completed);
+        Ok(false)
+    }
+
     /// Attempts the first `claimCredit()` call to trigger the unlock.
     async fn try_unlock(
         &mut self,
@@ -452,7 +486,7 @@ impl BondManager {
         verifier_client: &dyn AggregateVerifierClient,
         submitter: &dyn BondTransactionSubmitter,
     ) -> eyre::Result<bool> {
-        // Check if already unlocked on-chain.
+        // Check if already unlocked onchain.
         let unlocked = verifier_client.bond_unlocked(game_address).await?;
         if unlocked {
             // Use `resolved_at` as a conservative lower bound for the unlock
@@ -481,7 +515,7 @@ impl BondManager {
 
     /// Checks if the `DelayedWETH` delay has elapsed since the unlock.
     fn check_delay(&mut self, game_address: Address, unlocked_at: u64) -> eyre::Result<bool> {
-        // Fall back to 7 days if the on-chain delay has not been read yet.
+        // Fall back to 7 days if the onchain delay has not been read yet.
         // If the real delay is shorter, the withdraw attempt will simply
         // succeed earlier than expected. If longer, the attempt will revert
         // and be retried on the next poll tick.
@@ -518,7 +552,7 @@ impl BondManager {
         verifier_client: &dyn AggregateVerifierClient,
         submitter: &dyn BondTransactionSubmitter,
     ) -> eyre::Result<bool> {
-        // Check if already claimed on-chain.
+        // Check if already claimed onchain.
         let claimed = verifier_client.bond_claimed(game_address).await?;
         if claimed {
             info!(game = %game_address, "bond already claimed");
@@ -569,11 +603,13 @@ impl BondManager {
         }
     }
 
-    /// Determines the bond phase from on-chain state.
+    /// Determines the bond phase from onchain state.
     ///
-    /// Returns `None` if the bond has already been claimed, or if the game
-    /// resolved as `DEFENDER_WINS` (the bond is not claimable by the
-    /// challenger).
+    /// Returns `None` if the bond has already been fully claimed. Otherwise
+    /// returns the appropriate [`BondPhase`] based on the game's onchain
+    /// progression (resolved, unlocked, etc.). The caller is responsible
+    /// for verifying that the onchain `bondRecipient` is in the claim set
+    /// before acting on the returned phase.
     async fn determine_phase(
         verifier_client: &dyn AggregateVerifierClient,
         game_address: Address,
@@ -596,17 +632,6 @@ impl BondManager {
         }
 
         if resolved_at > 0 {
-            // The game has been resolved. Check if it resolved in the
-            // challenger's favor before tracking it for bond claiming.
-            let status = verifier_client.status(game_address).await?;
-            if status != GameScanner::STATUS_CHALLENGER_WINS {
-                debug!(
-                    game = %game_address,
-                    status,
-                    "game resolved as DEFENDER_WINS during startup scan, skipping"
-                );
-                return Ok(None);
-            }
             return Ok(Some(BondPhase::NeedsUnlock));
         }
 

--- a/crates/proof/challenge/src/bond.rs
+++ b/crates/proof/challenge/src/bond.rs
@@ -266,16 +266,16 @@ impl BondManager {
                     // re-verified after resolve in `try_resolve`.
                     if let Some(ref p) = phase
                         && !matches!(p, BondPhase::NeedsResolve)
-                            && !claim_addresses.contains(&bond_recipient)
-                        {
-                            debug!(
-                                game = %game_address,
-                                recipient = %bond_recipient,
-                                "onchain bondRecipient not in claim addresses \
-                                 for resolved game, skipping"
-                            );
-                            return None;
-                        }
+                        && !claim_addresses.contains(&bond_recipient)
+                    {
+                        debug!(
+                            game = %game_address,
+                            recipient = %bond_recipient,
+                            "onchain bondRecipient not in claim addresses \
+                             for resolved game, skipping"
+                        );
+                        return None;
+                    }
 
                     Some((game_address, matched_address, phase))
                 })

--- a/crates/proof/challenge/src/cli.rs
+++ b/crates/proof/challenge/src/cli.rs
@@ -124,6 +124,19 @@ pub struct ChallengerArgs {
     /// Number of past games to scan on startup.
     #[arg(long = "lookback-games", env = cli_env!("LOOKBACK_GAMES"), default_value = "1000")]
     pub lookback_games: u64,
+
+    /// Comma-separated list of addresses to claim bonds on behalf of.
+    ///
+    /// When set, the challenger will automatically resolve games and claim
+    /// bond credits for games where the `bondRecipient` matches any of
+    /// these addresses. Requires two `claimCredit()` calls per game with
+    /// a `DelayedWETH` delay in between.
+    #[arg(
+        long = "bond-claim-addresses",
+        env = cli_env!("BOND_CLAIM_ADDRESSES"),
+        value_delimiter = ','
+    )]
+    pub bond_claim_addresses: Vec<Address>,
 }
 
 impl std::fmt::Debug for ChallengerArgs {
@@ -141,6 +154,7 @@ impl std::fmt::Debug for ChallengerArgs {
             .field("signer", &self.signer)
             .field("tx_manager", &self.tx_manager)
             .field("lookback_games", &self.lookback_games)
+            .field("bond_claim_addresses", &self.bond_claim_addresses)
             .finish()
     }
 }

--- a/crates/proof/challenge/src/config.rs
+++ b/crates/proof/challenge/src/config.rs
@@ -109,6 +109,8 @@ pub struct ChallengerConfig {
     pub tx_manager: TxManagerConfig,
     /// Number of past games to scan on startup.
     pub lookback_games: u64,
+    /// Addresses to claim bonds on behalf of.
+    pub bond_claim_addresses: Vec<Address>,
     /// Health server socket address.
     pub health_addr: SocketAddr,
     /// Logging configuration (from base-cli-utils).
@@ -230,6 +232,7 @@ impl ChallengerConfig {
             signing,
             tx_manager,
             lookback_games: cli.challenger.lookback_games,
+            bond_claim_addresses: cli.challenger.bond_claim_addresses,
             health_addr,
             log: LogConfig::from(cli.logging),
             metrics: cli.metrics.into(),

--- a/crates/proof/challenge/src/driver.rs
+++ b/crates/proof/challenge/src/driver.rs
@@ -34,9 +34,9 @@ use tracing::{debug, info, warn};
 use uuid::Uuid;
 
 use crate::{
-    CandidateGame, ChallengeSubmitter, ChallengerMetrics, DisputeIntent, GameCategory, GameScanner,
-    IntermediateValidationParams, L1HeadProvider, OutputValidator, PendingProof, PendingProofs,
-    ProofKind, ProofPhase, ProofUpdate, ValidatorError,
+    BondManager, CandidateGame, ChallengeSubmitter, ChallengerMetrics, DisputeIntent, GameCategory,
+    GameScanner, IntermediateValidationParams, L1HeadProvider, OutputValidator, PendingProof,
+    PendingProofs, ProofKind, ProofPhase, ProofUpdate, ValidatorError,
 };
 
 /// Configuration for the challenger [`Driver`].
@@ -61,6 +61,36 @@ pub struct TeeConfig {
     pub request_timeout: Duration,
 }
 
+/// Service-layer dependencies injected into the [`Driver`].
+pub struct DriverComponents<L2: L2Provider, P: ZkProofProvider, T: TxManager> {
+    /// Scans for new dispute games on L1.
+    pub scanner: GameScanner,
+    /// Validates L2 output roots against the local node.
+    pub validator: OutputValidator<L2>,
+    /// ZK proof provider used to generate fault proofs.
+    pub zk_prover: Arc<P>,
+    /// Submits challenge transactions to L1.
+    pub submitter: ChallengeSubmitter<T>,
+    /// Optional TEE proof configuration (provider + L1 RPC client).
+    pub tee: Option<TeeConfig>,
+    /// Client for the aggregate verifier contract.
+    pub verifier_client: Arc<dyn AggregateVerifierClient>,
+    /// Bond lifecycle manager (optional; enabled when claim addresses are configured).
+    pub bond_manager: Option<BondManager>,
+}
+
+impl<L2: L2Provider, P: ZkProofProvider, T: TxManager> std::fmt::Debug
+    for DriverComponents<L2, P, T>
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("DriverComponents")
+            .field("scanner", &self.scanner)
+            .field("tee", &self.tee.as_ref().map(|_| ".."))
+            .field("bond_manager", &self.bond_manager)
+            .finish_non_exhaustive()
+    }
+}
+
 /// Orchestrates the challenger pipeline: scan, validate, prove, submit.
 pub struct Driver<L2, P, T>
 where
@@ -82,6 +112,8 @@ where
     pub verifier_client: Arc<dyn AggregateVerifierClient>,
     /// In-flight proof sessions keyed by game address.
     pub pending_proofs: PendingProofs,
+    /// Bond lifecycle manager (optional; enabled when claim addresses are configured).
+    pub bond_manager: Option<BondManager>,
     /// Interval between polling cycles.
     pub poll_interval: Duration,
     /// Token used to signal graceful shutdown.
@@ -107,23 +139,16 @@ impl<L2: L2Provider, P: ZkProofProvider, T: TxManager> Driver<L2, P, T> {
     pub const MAX_PROOF_RETRIES: u32 = 3;
 
     /// Creates a new driver with the given components.
-    pub fn new(
-        config: DriverConfig,
-        scanner: GameScanner,
-        validator: OutputValidator<L2>,
-        zk_prover: Arc<P>,
-        submitter: ChallengeSubmitter<T>,
-        tee: Option<TeeConfig>,
-        verifier_client: Arc<dyn AggregateVerifierClient>,
-    ) -> Self {
+    pub fn new(config: DriverConfig, components: DriverComponents<L2, P, T>) -> Self {
         Self {
-            scanner,
-            validator,
-            zk_prover,
-            submitter,
-            tee,
-            verifier_client,
+            scanner: components.scanner,
+            validator: components.validator,
+            zk_prover: components.zk_prover,
+            submitter: components.submitter,
+            tee: components.tee,
+            verifier_client: components.verifier_client,
             pending_proofs: PendingProofs::new(),
+            bond_manager: components.bond_manager,
             poll_interval: config.poll_interval,
             cancel: config.cancel,
             ready: config.ready,
@@ -170,10 +195,14 @@ impl<L2: L2Provider, P: ZkProofProvider, T: TxManager> Driver<L2, P, T> {
     /// Executes a single scan-validate-prove-submit cycle.
     ///
     /// First polls any in-flight proof sessions that are not in the current
-    /// scan batch, then scans for new candidates and processes them.
+    /// scan batch, then advances bond lifecycle claims, then scans for new
+    /// candidates and processes them.
     pub async fn step(&mut self) -> eyre::Result<()> {
         // Poll in-flight proof sessions before scanning for new candidates.
         self.poll_pending_proofs().await;
+
+        // Advance bond lifecycle for tracked games.
+        self.poll_bond_claims().await;
 
         let (candidates, new_last_scanned) = self.scanner.scan(self.last_scanned).await?;
         self.last_scanned = new_last_scanned;
@@ -186,6 +215,14 @@ impl<L2: L2Provider, P: ZkProofProvider, T: TxManager> Driver<L2, P, T> {
         }
 
         Ok(())
+    }
+
+    /// Polls the bond manager to advance tracked games through the bond
+    /// lifecycle (resolve → unlock → delay → withdraw).
+    async fn poll_bond_claims(&mut self) {
+        if let Some(ref mut bond_manager) = self.bond_manager {
+            bond_manager.poll(&*self.verifier_client, &self.submitter).await;
+        }
     }
 
     /// Polls all in-flight proof sessions for completion or retries submission.
@@ -688,6 +725,14 @@ impl<L2: L2Provider, P: ZkProofProvider, T: TxManager> Driver<L2, P, T> {
         match result {
             Ok(_) => {
                 self.pending_proofs.remove(&game_address);
+
+                // After a successful challenge(), register the game for bond
+                // tracking so the BondManager can resolve and claim the bond.
+                if intent == DisputeIntent::Challenge
+                    && let Some(ref mut bond_manager) = self.bond_manager
+                {
+                    bond_manager.track_game(game_address, self.submitter.sender_address());
+                }
             }
             Err(e) => {
                 warn!(

--- a/crates/proof/challenge/src/driver.rs
+++ b/crates/proof/challenge/src/driver.rs
@@ -731,7 +731,15 @@ impl<L2: L2Provider, P: ZkProofProvider, T: TxManager> Driver<L2, P, T> {
                 if intent == DisputeIntent::Challenge
                     && let Some(ref mut bond_manager) = self.bond_manager
                 {
-                    bond_manager.track_game(game_address, self.submitter.sender_address());
+                    let sender = self.submitter.sender_address();
+                    if !bond_manager.track_game(game_address, sender) {
+                        warn!(
+                            game = %game_address,
+                            sender = %sender,
+                            "bond will not be tracked — sender address is not \
+                             in --bond-claim-addresses; bond may go unclaimed"
+                        );
+                    }
                 }
             }
             Err(e) => {

--- a/crates/proof/challenge/src/lib.rs
+++ b/crates/proof/challenge/src/lib.rs
@@ -13,7 +13,7 @@ mod config;
 pub use config::{ChallengerConfig, ConfigError, UrlValidationError, Validated};
 
 mod driver;
-pub use driver::{Driver, DriverConfig, TeeConfig, derive_session_id};
+pub use driver::{Driver, DriverComponents, DriverConfig, TeeConfig, derive_session_id};
 
 mod pending;
 pub use pending::{DisputeIntent, PendingProof, PendingProofs, ProofKind, ProofPhase, ProofUpdate};
@@ -43,6 +43,9 @@ pub use validator::{
 
 mod verify;
 pub use verify::{AccountProofError, verify_account_proof};
+
+mod bond;
+pub use bond::{BondManager, BondPhase, BondTransactionSubmitter, TrackedGame};
 
 #[cfg(any(test, feature = "test-utils"))]
 pub mod test_utils;

--- a/crates/proof/challenge/src/lib.rs
+++ b/crates/proof/challenge/src/lib.rs
@@ -45,7 +45,9 @@ mod verify;
 pub use verify::{AccountProofError, verify_account_proof};
 
 mod bond;
-pub use bond::{BondManager, BondPhase, BondTransactionSubmitter, TrackedGame};
+pub use bond::{
+    BondManager, BondPhase, BondTransactionSubmitter, ClockFn, RemovalReason, TrackedGame,
+};
 
 #[cfg(any(test, feature = "test-utils"))]
 pub mod test_utils;

--- a/crates/proof/challenge/src/metrics.rs
+++ b/crates/proof/challenge/src/metrics.rs
@@ -97,8 +97,4 @@ impl ChallengerMetrics {
     /// Label value when a resolve was skipped because the game was already
     /// resolved on-chain (e.g. by another actor).
     pub const STATUS_ALREADY_RESOLVED: &str = "already_resolved";
-
-    /// Label value when a game resolved as `DEFENDER_WINS`, meaning the
-    /// bond is not claimable by the challenger.
-    pub const STATUS_DEFENDER_WINS: &str = "defender_wins";
 }

--- a/crates/proof/challenge/src/metrics.rs
+++ b/crates/proof/challenge/src/metrics.rs
@@ -62,6 +62,26 @@ base_metrics::define_metrics! {
 
     #[describe("Total number of invalid ZK proposals detected (Path 3)")]
     invalid_zk_proposal_detected_total: counter,
+
+    #[describe("Total number of resolve transaction outcomes")]
+    #[label(status)]
+    resolve_tx_outcome_total: counter,
+
+    #[describe("Total number of claimCredit transactions submitted")]
+    claim_credit_tx_submitted_total: counter,
+
+    #[describe("Total number of claimCredit transaction outcomes")]
+    #[label(status)]
+    claim_credit_tx_outcome_total: counter,
+
+    #[describe("Latency in seconds for bond transaction confirmation")]
+    bond_tx_latency_seconds: histogram,
+
+    #[describe("Number of games currently tracked for bond claiming")]
+    bonds_tracked: gauge,
+
+    #[describe("Total number of bonds successfully claimed")]
+    bonds_completed_total: counter,
 }
 
 impl ChallengerMetrics {
@@ -73,4 +93,12 @@ impl ChallengerMetrics {
 
     /// Label value for a transaction that failed to send.
     pub const STATUS_ERROR: &str = "error";
+
+    /// Label value when a resolve was skipped because the game was already
+    /// resolved on-chain (e.g. by another actor).
+    pub const STATUS_ALREADY_RESOLVED: &str = "already_resolved";
+
+    /// Label value when a game resolved as `DEFENDER_WINS`, meaning the
+    /// bond is not claimable by the challenger.
+    pub const STATUS_DEFENDER_WINS: &str = "defender_wins";
 }

--- a/crates/proof/challenge/src/scanner.rs
+++ b/crates/proof/challenge/src/scanner.rs
@@ -130,12 +130,6 @@ impl GameScanner {
     /// Game status indicating the dispute is still in progress.
     pub const STATUS_IN_PROGRESS: u8 = 0;
 
-    /// Game status indicating the challenger won the dispute.
-    pub const STATUS_CHALLENGER_WINS: u8 = 1;
-
-    /// Game status indicating the defender won the dispute.
-    pub const STATUS_DEFENDER_WINS: u8 = 2;
-
     /// Maximum number of games to evaluate concurrently during a scan.
     pub const SCAN_CONCURRENCY: usize = 32;
 

--- a/crates/proof/challenge/src/scanner.rs
+++ b/crates/proof/challenge/src/scanner.rs
@@ -130,6 +130,12 @@ impl GameScanner {
     /// Game status indicating the dispute is still in progress.
     pub const STATUS_IN_PROGRESS: u8 = 0;
 
+    /// Game status indicating the challenger won the dispute.
+    pub const STATUS_CHALLENGER_WINS: u8 = 1;
+
+    /// Game status indicating the defender won the dispute.
+    pub const STATUS_DEFENDER_WINS: u8 = 2;
+
     /// Maximum number of games to evaluate concurrently during a scan.
     pub const SCAN_CONCURRENCY: usize = 32;
 

--- a/crates/proof/challenge/src/service.rs
+++ b/crates/proof/challenge/src/service.rs
@@ -19,8 +19,8 @@ use tokio_util::sync::CancellationToken;
 use tracing::{info, warn};
 
 use crate::{
-    ChallengeSubmitter, ChallengerConfig, ChallengerMetrics, Driver, DriverConfig, GameScanner,
-    OutputValidator, ScannerConfig,
+    BondManager, ChallengeSubmitter, ChallengerConfig, ChallengerMetrics, Driver, DriverComponents,
+    DriverConfig, GameScanner, OutputValidator, ScannerConfig,
 };
 
 /// Top-level challenger service.
@@ -139,6 +139,24 @@ impl ChallengerService {
 
         // ── 7. Assemble scanner, validator, and driver ───────────────────────
         let scanner_config = ScannerConfig { lookback_games: config.lookback_games };
+
+        // ── 7b. Bond manager (optional) ─────────────────────────────────────
+        let bond_manager = if !config.bond_claim_addresses.is_empty() {
+            let l1_rpc_url = config.l1_eth_rpc.as_ref().clone();
+            let mut bm = BondManager::new(config.bond_claim_addresses, l1_rpc_url);
+            info!("starting bond recovery scan");
+            if let Err(e) =
+                bm.startup_scan(&*factory_client, &*verifier_client, config.lookback_games).await
+            {
+                warn!(error = %e, "bond startup scan failed, continuing without recovery");
+            }
+            info!(tracked = bm.tracked_count(), "bond manager ready");
+            Some(bm)
+        } else {
+            info!("bond claiming disabled (no --bond-claim-addresses)");
+            None
+        };
+
         let scanner =
             GameScanner::new(factory_client, Arc::clone(&verifier_client), scanner_config);
 
@@ -161,12 +179,15 @@ impl ChallengerService {
         };
         let driver = Driver::new(
             driver_config,
-            scanner,
-            validator,
-            zk_client,
-            submitter,
-            tee,
-            verifier_client,
+            DriverComponents {
+                scanner,
+                validator,
+                zk_prover: zk_client,
+                submitter,
+                tee,
+                verifier_client,
+                bond_manager,
+            },
         );
 
         // Drop guard ensures child tasks are cancelled even if the driver panics.

--- a/crates/proof/challenge/src/submitter.rs
+++ b/crates/proof/challenge/src/submitter.rs
@@ -129,6 +129,12 @@ impl<T: TxManager> BondTransactionSubmitter for ChallengeSubmitter<T> {
             ..Default::default()
         };
 
+        info!(
+            game = %game_address,
+            calldata_len = candidate.tx_data.len(),
+            "sending bond transaction"
+        );
+
         let start = Instant::now();
         let receipt = self.tx_manager.send(candidate).await?;
         let latency = start.elapsed();

--- a/crates/proof/challenge/src/submitter.rs
+++ b/crates/proof/challenge/src/submitter.rs
@@ -15,7 +15,7 @@ use base_proof_contracts::{encode_challenge_calldata, encode_nullify_calldata};
 use base_tx_manager::{TxCandidate, TxManager};
 use tracing::info;
 
-use crate::{ChallengeSubmitError, ChallengerMetrics, DisputeIntent};
+use crate::{BondTransactionSubmitter, ChallengeSubmitError, ChallengerMetrics, DisputeIntent};
 
 /// Submits dispute transactions (nullify or challenge) to game contracts on L1.
 #[derive(Debug)]
@@ -110,6 +110,34 @@ impl<T: TxManager> ChallengeSubmitter<T> {
         }
 
         info!(tx_hash = %tx_hash, game = %game_address, action = intent.label(), "dispute transaction confirmed");
+
+        Ok(tx_hash)
+    }
+}
+
+#[async_trait::async_trait]
+impl<T: TxManager> BondTransactionSubmitter for ChallengeSubmitter<T> {
+    async fn send_bond_tx(
+        &self,
+        game_address: Address,
+        calldata: Bytes,
+    ) -> Result<B256, ChallengeSubmitError> {
+        let candidate = TxCandidate {
+            tx_data: calldata,
+            to: Some(game_address),
+            value: U256::ZERO,
+            ..Default::default()
+        };
+
+        let start = Instant::now();
+        let receipt = self.tx_manager.send(candidate).await?;
+        let latency = start.elapsed();
+        ChallengerMetrics::bond_tx_latency_seconds().record(latency.as_secs_f64());
+        let tx_hash = receipt.transaction_hash;
+
+        if !receipt.inner.status() {
+            return Err(ChallengeSubmitError::TxReverted { tx_hash });
+        }
 
         Ok(tx_hash)
     }

--- a/crates/proof/challenge/src/test_utils.rs
+++ b/crates/proof/challenge/src/test_utils.rs
@@ -47,6 +47,48 @@ pub struct MockGameState {
     pub intermediate_output_roots: Vec<B256>,
     /// 1-based index of the challenged intermediate root (`0` = unchallenged).
     pub countered_index: u64,
+    /// Whether the game's dispute period has elapsed.
+    pub game_over: bool,
+    /// Timestamp at which the game was resolved (`0` if unresolved).
+    pub resolved_at: u64,
+    /// Address that will receive the bond.
+    pub bond_recipient: Address,
+    /// Whether the bond has been unlocked.
+    pub bond_unlocked: bool,
+    /// Whether the bond has been claimed.
+    pub bond_claimed: bool,
+    /// Expected resolution timestamp.
+    pub expected_resolution: u64,
+    /// Number of verified proofs.
+    pub proof_count: u8,
+    /// Timestamp at which the game was created.
+    pub created_at: u64,
+    /// Address of the `DelayedWETH` contract.
+    pub delayed_weth: Address,
+}
+
+impl Default for MockGameState {
+    fn default() -> Self {
+        Self {
+            status: 0,
+            zk_prover: Address::ZERO,
+            tee_prover: Address::ZERO,
+            game_info: GameInfo { root_claim: B256::ZERO, l2_block_number: 0, parent_index: 0 },
+            starting_block_number: 0,
+            l1_head: B256::ZERO,
+            intermediate_output_roots: vec![],
+            countered_index: 0,
+            game_over: false,
+            resolved_at: 0,
+            bond_recipient: Address::ZERO,
+            bond_unlocked: false,
+            bond_claimed: false,
+            expected_resolution: u64::MAX,
+            proof_count: 0,
+            created_at: 0,
+            delayed_weth: Address::ZERO,
+        }
+    }
 }
 
 /// Mock dispute game factory with configurable per-index game data.
@@ -85,48 +127,43 @@ pub struct MockAggregateVerifier {
     pub games: HashMap<Address, MockGameState>,
 }
 
+impl MockAggregateVerifier {
+    fn get<T>(
+        &self,
+        game_address: Address,
+        f: impl FnOnce(&MockGameState) -> T,
+    ) -> Result<T, ContractError> {
+        self.games
+            .get(&game_address)
+            .map(f)
+            .ok_or_else(|| ContractError::Validation(format!("unknown game {game_address}")))
+    }
+}
+
 #[async_trait]
 impl AggregateVerifierClient for MockAggregateVerifier {
     async fn game_info(&self, game_address: Address) -> Result<GameInfo, ContractError> {
-        self.games
-            .get(&game_address)
-            .map(|s| s.game_info.clone())
-            .ok_or_else(|| ContractError::Validation(format!("unknown game {game_address}")))
+        self.get(game_address, |s| s.game_info.clone())
     }
 
     async fn status(&self, game_address: Address) -> Result<u8, ContractError> {
-        self.games
-            .get(&game_address)
-            .map(|s| s.status)
-            .ok_or_else(|| ContractError::Validation(format!("unknown game {game_address}")))
+        self.get(game_address, |s| s.status)
     }
 
     async fn zk_prover(&self, game_address: Address) -> Result<Address, ContractError> {
-        self.games
-            .get(&game_address)
-            .map(|s| s.zk_prover)
-            .ok_or_else(|| ContractError::Validation(format!("unknown game {game_address}")))
+        self.get(game_address, |s| s.zk_prover)
     }
 
     async fn tee_prover(&self, game_address: Address) -> Result<Address, ContractError> {
-        self.games
-            .get(&game_address)
-            .map(|s| s.tee_prover)
-            .ok_or_else(|| ContractError::Validation(format!("unknown game {game_address}")))
+        self.get(game_address, |s| s.tee_prover)
     }
 
     async fn starting_block_number(&self, game_address: Address) -> Result<u64, ContractError> {
-        self.games
-            .get(&game_address)
-            .map(|s| s.starting_block_number)
-            .ok_or_else(|| ContractError::Validation(format!("unknown game {game_address}")))
+        self.get(game_address, |s| s.starting_block_number)
     }
 
     async fn l1_head(&self, game_address: Address) -> Result<B256, ContractError> {
-        self.games
-            .get(&game_address)
-            .map(|s| s.l1_head)
-            .ok_or_else(|| ContractError::Validation(format!("unknown game {game_address}")))
+        self.get(game_address, |s| s.l1_head)
     }
 
     async fn read_block_interval(&self, _impl_address: Address) -> Result<u64, ContractError> {
@@ -144,17 +181,47 @@ impl AggregateVerifierClient for MockAggregateVerifier {
         &self,
         game_address: Address,
     ) -> Result<Vec<B256>, ContractError> {
-        self.games
-            .get(&game_address)
-            .map(|s| s.intermediate_output_roots.clone())
-            .ok_or_else(|| ContractError::Validation(format!("unknown game {game_address}")))
+        self.get(game_address, |s| s.intermediate_output_roots.clone())
     }
 
     async fn countered_index(&self, game_address: Address) -> Result<u64, ContractError> {
-        self.games
-            .get(&game_address)
-            .map(|s| s.countered_index)
-            .ok_or_else(|| ContractError::Validation(format!("unknown game {game_address}")))
+        self.get(game_address, |s| s.countered_index)
+    }
+
+    async fn game_over(&self, game_address: Address) -> Result<bool, ContractError> {
+        self.get(game_address, |s| s.game_over)
+    }
+
+    async fn resolved_at(&self, game_address: Address) -> Result<u64, ContractError> {
+        self.get(game_address, |s| s.resolved_at)
+    }
+
+    async fn bond_recipient(&self, game_address: Address) -> Result<Address, ContractError> {
+        self.get(game_address, |s| s.bond_recipient)
+    }
+
+    async fn bond_unlocked(&self, game_address: Address) -> Result<bool, ContractError> {
+        self.get(game_address, |s| s.bond_unlocked)
+    }
+
+    async fn bond_claimed(&self, game_address: Address) -> Result<bool, ContractError> {
+        self.get(game_address, |s| s.bond_claimed)
+    }
+
+    async fn expected_resolution(&self, game_address: Address) -> Result<u64, ContractError> {
+        self.get(game_address, |s| s.expected_resolution)
+    }
+
+    async fn proof_count(&self, game_address: Address) -> Result<u8, ContractError> {
+        self.get(game_address, |s| s.proof_count)
+    }
+
+    async fn created_at(&self, game_address: Address) -> Result<u64, ContractError> {
+        self.get(game_address, |s| s.created_at)
+    }
+
+    async fn delayed_weth(&self, game_address: Address) -> Result<Address, ContractError> {
+        self.get(game_address, |s| s.delayed_weth)
     }
 }
 
@@ -208,6 +275,15 @@ pub const fn mock_state_with_tee(
         l1_head: DEFAULT_L1_HEAD,
         intermediate_output_roots: vec![],
         countered_index: 0,
+        game_over: false,
+        resolved_at: 0,
+        bond_recipient: Address::ZERO,
+        bond_unlocked: false,
+        bond_claimed: false,
+        expected_resolution: u64::MAX,
+        proof_count: 0,
+        created_at: 0,
+        delayed_weth: Address::ZERO,
     }
 }
 
@@ -529,6 +605,52 @@ pub fn build_test_header_and_account(
         storage_proof: vec![],
     };
     (header, account_result)
+}
+
+/// Mock bond transaction submitter for testing the [`BondManager`](crate::BondManager).
+///
+/// Records all submitted transactions and returns pre-configured responses.
+#[derive(Debug)]
+pub struct MockBondTransactionSubmitter {
+    /// Queue of results returned by [`send_bond_tx`](crate::BondTransactionSubmitter::send_bond_tx).
+    pub responses: Mutex<VecDeque<Result<B256, crate::ChallengeSubmitError>>>,
+    /// Recorded `(game_address, calldata)` pairs for each submitted transaction.
+    pub calls: Mutex<Vec<(Address, Bytes)>>,
+}
+
+impl MockBondTransactionSubmitter {
+    /// Creates a mock that returns a single successful transaction hash.
+    pub fn success(tx_hash: B256) -> Self {
+        let mut q = VecDeque::new();
+        q.push_back(Ok(tx_hash));
+        Self { responses: Mutex::new(q), calls: Mutex::new(Vec::new()) }
+    }
+
+    /// Creates a mock with multiple responses returned in order.
+    pub fn with_responses(responses: Vec<Result<B256, crate::ChallengeSubmitError>>) -> Self {
+        Self { responses: Mutex::new(VecDeque::from(responses)), calls: Mutex::new(Vec::new()) }
+    }
+
+    /// Returns the recorded calls.
+    pub fn recorded_calls(&self) -> Vec<(Address, Bytes)> {
+        self.calls.lock().unwrap().clone()
+    }
+}
+
+#[async_trait]
+impl crate::BondTransactionSubmitter for MockBondTransactionSubmitter {
+    async fn send_bond_tx(
+        &self,
+        game_address: Address,
+        calldata: Bytes,
+    ) -> Result<B256, crate::ChallengeSubmitError> {
+        self.calls.lock().unwrap().push((game_address, calldata));
+        self.responses
+            .lock()
+            .unwrap()
+            .pop_front()
+            .expect("MockBondTransactionSubmitter has no more responses")
+    }
 }
 
 #[cfg(test)]

--- a/crates/proof/challenge/tests/driver.rs
+++ b/crates/proof/challenge/tests/driver.rs
@@ -8,13 +8,14 @@ use std::{
 
 use alloy_primitives::{Address, B256, Bytes};
 use base_challenger::{
-    ChallengeSubmitter, DisputeIntent, Driver, DriverConfig, GameScanner, L1HeadProvider,
-    OutputValidator, PendingProof, ProofPhase, ScannerConfig, TeeConfig, derive_session_id,
+    BondManager, ChallengeSubmitter, DisputeIntent, Driver, DriverComponents, DriverConfig,
+    GameScanner, L1HeadProvider, OutputValidator, PendingProof, ProofPhase, ScannerConfig,
+    TeeConfig, derive_session_id,
     test_utils::{
-        MockAggregateVerifier, MockDisputeGameFactory, MockGameState, MockL1HeadProvider,
-        MockL2Provider, MockTeeProofProvider, MockTxManager, MockZkProofProvider, addr,
-        build_test_header_and_account, factory_game, mock_state, mock_state_with_tee,
-        receipt_with_status,
+        MockAggregateVerifier, MockBondTransactionSubmitter, MockDisputeGameFactory, MockGameState,
+        MockL1HeadProvider, MockL2Provider, MockTeeProofProvider, MockTxManager,
+        MockZkProofProvider, addr, build_test_header_and_account, factory_game, mock_state,
+        mock_state_with_tee, receipt_with_status,
     },
 };
 use base_proof_contracts::{AggregateVerifierClient, ContractError, GameAtIndex};
@@ -60,12 +61,15 @@ fn test_driver_with_tee(
 
     Driver::new(
         config,
-        scanner,
-        validator,
-        zk_prover,
-        submitter,
-        tee,
-        verifier as Arc<dyn AggregateVerifierClient>,
+        DriverComponents {
+            scanner,
+            validator,
+            zk_prover,
+            submitter,
+            tee,
+            verifier_client: verifier as Arc<dyn AggregateVerifierClient>,
+            bond_manager: None,
+        },
     )
 }
 
@@ -113,8 +117,6 @@ fn invalid_game_mocks()
     verifier_games.insert(
         addr(0),
         MockGameState {
-            status: 0,
-            zk_prover: Address::ZERO,
             tee_prover: tee_addr,
             game_info: base_proof_contracts::GameInfo {
                 root_claim: B256::repeat_byte(0x01),
@@ -124,7 +126,7 @@ fn invalid_game_mocks()
             starting_block_number: 10,
             l1_head: B256::repeat_byte(0xAA),
             intermediate_output_roots: vec![root_15, B256::repeat_byte(0xFF)],
-            countered_index: 0,
+            ..Default::default()
         },
     );
     let verifier = Arc::new(MockAggregateVerifier { games: verifier_games });
@@ -178,8 +180,6 @@ async fn test_step_valid_game_skipped() {
     verifier_games.insert(
         addr(0),
         MockGameState {
-            status: 0,
-            zk_prover: Address::ZERO,
             tee_prover: tee_addr,
             game_info: base_proof_contracts::GameInfo {
                 root_claim: B256::repeat_byte(0x01),
@@ -188,8 +188,7 @@ async fn test_step_valid_game_skipped() {
             },
             starting_block_number: 10,
             l1_head: B256::repeat_byte(0xAA),
-            intermediate_output_roots: vec![],
-            countered_index: 0,
+            ..Default::default()
         },
     );
     let verifier = Arc::new(MockAggregateVerifier { games: verifier_games });
@@ -229,7 +228,7 @@ async fn test_step_validation_error_blocks_not_available() {
             starting_block_number: 10,
             l1_head: B256::repeat_byte(0xAA),
             intermediate_output_roots: vec![B256::repeat_byte(0xFF), B256::repeat_byte(0xEE)],
-            countered_index: 0,
+            ..Default::default()
         },
     );
     let verifier = Arc::new(MockAggregateVerifier { games: verifier_games });
@@ -324,7 +323,7 @@ async fn test_step_validation_error_skipped() {
             l1_head: B256::repeat_byte(0xAA),
             // 2 roots expected at interval=5, provide 2 so count matches
             intermediate_output_roots: vec![B256::ZERO, B256::ZERO],
-            countered_index: 0,
+            ..Default::default()
         },
     );
     let verifier = Arc::new(MockAggregateVerifier { games: verifier_games });
@@ -390,12 +389,15 @@ async fn test_step_scan_error_propagated() {
 
     let mut driver = Driver::new(
         config,
-        scanner,
-        validator,
-        default_zk_prover(),
-        submitter,
-        None,
-        verifier as Arc<dyn AggregateVerifierClient>,
+        DriverComponents {
+            scanner,
+            validator,
+            zk_prover: default_zk_prover(),
+            submitter,
+            tee: None,
+            verifier_client: verifier as Arc<dyn AggregateVerifierClient>,
+            bond_manager: None,
+        },
     );
 
     let result = driver.step().await;
@@ -538,12 +540,15 @@ async fn test_run_cancellation() {
 
     let driver = Driver::new(
         config,
-        scanner,
-        validator,
-        default_zk_prover(),
-        submitter,
-        None,
-        verifier as Arc<dyn AggregateVerifierClient>,
+        DriverComponents {
+            scanner,
+            validator,
+            zk_prover: default_zk_prover(),
+            submitter,
+            tee: None,
+            verifier_client: verifier as Arc<dyn AggregateVerifierClient>,
+            bond_manager: None,
+        },
     );
 
     // Cancel immediately
@@ -776,7 +781,7 @@ async fn test_step_invalid_game_tee_proof_succeeds() {
             l1_head: l1_hash,
             // root_15 is correct, index 1 is bogus — invalid_index == 1
             intermediate_output_roots: vec![root_15, B256::repeat_byte(0xFF)],
-            countered_index: 0,
+            ..Default::default()
         },
     );
     let verifier = Arc::new(MockAggregateVerifier { games: verifier_games });
@@ -852,7 +857,6 @@ async fn test_step_nullified_game_not_reprocessed() {
             status: 0,
             zk_prover: Address::ZERO,
             // Both provers zeroed — this is the state after TEE nullification.
-            tee_prover: Address::ZERO,
             game_info: base_proof_contracts::GameInfo {
                 root_claim: B256::repeat_byte(0x01),
                 l2_block_number: 20,
@@ -861,7 +865,7 @@ async fn test_step_nullified_game_not_reprocessed() {
             starting_block_number: 10,
             l1_head: B256::repeat_byte(0xAA),
             intermediate_output_roots: vec![root_15, B256::repeat_byte(0xFF)],
-            countered_index: 0,
+            ..Default::default()
         },
     );
     let verifier = Arc::new(MockAggregateVerifier { games: verifier_games });
@@ -1003,6 +1007,7 @@ fn fraudulent_zk_challenge_mocks(
             l1_head: B256::repeat_byte(0xAA),
             intermediate_output_roots: vec![root_15, onchain_root_at_20],
             countered_index: 2, // 1-based → challenged_index = 1
+            ..Default::default()
         },
     );
     let verifier = Arc::new(MockAggregateVerifier { games: verifier_games });
@@ -1085,7 +1090,6 @@ async fn test_step_invalid_zk_proposal_initiates_zk_nullification() {
         MockGameState {
             status: 0,
             zk_prover: zk_addr,
-            tee_prover: Address::ZERO, // ZK-proposed game
             game_info: base_proof_contracts::GameInfo {
                 root_claim: B256::repeat_byte(0x01),
                 l2_block_number: 20,
@@ -1094,7 +1098,7 @@ async fn test_step_invalid_zk_proposal_initiates_zk_nullification() {
             starting_block_number: 10,
             l1_head: B256::repeat_byte(0xAA),
             intermediate_output_roots: vec![root_15, B256::repeat_byte(0xFF)],
-            countered_index: 0,
+            ..Default::default()
         },
     );
     let verifier = Arc::new(MockAggregateVerifier { games: verifier_games });
@@ -1126,7 +1130,6 @@ async fn test_step_valid_zk_proposal_skipped() {
         MockGameState {
             status: 0,
             zk_prover: zk_addr,
-            tee_prover: Address::ZERO,
             game_info: base_proof_contracts::GameInfo {
                 root_claim: B256::repeat_byte(0x01),
                 l2_block_number: 14,
@@ -1134,8 +1137,7 @@ async fn test_step_valid_zk_proposal_skipped() {
             },
             starting_block_number: 10,
             l1_head: B256::repeat_byte(0xAA),
-            intermediate_output_roots: vec![],
-            countered_index: 0,
+            ..Default::default()
         },
     );
     let verifier = Arc::new(MockAggregateVerifier { games: verifier_games });
@@ -1150,4 +1152,343 @@ async fn test_step_valid_zk_proposal_skipped() {
     driver.step().await.unwrap();
 
     assert!(driver.pending_proofs.is_empty(), "valid ZK proposal should not trigger any proof");
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Bond lifecycle integration tests
+// ──────────────────────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn test_bond_manager_full_lifecycle() {
+    // Verify the full bond lifecycle: NeedsResolve → NeedsUnlock →
+    // AwaitingDelay → NeedsWithdraw → Completed.
+    //
+    // The mock verifier uses a static game state, so we set
+    // status=1 (CHALLENGER_WINS) to represent a game that has already been
+    // resolved on-chain. The manager detects this and advances directly
+    // to NeedsUnlock without submitting a resolve transaction.
+    let claim_addr = Address::repeat_byte(0xCC);
+    let game_addr = addr(0);
+    let tx_hash = B256::repeat_byte(0xDD);
+
+    // Set up verifier mock: status=1 (CHALLENGER_WINS), bond_unlocked=false,
+    // bond_claimed=false.
+    let mut verifier_games = HashMap::new();
+    let mut state = mock_state(1, Address::ZERO, 100);
+    state.bond_recipient = claim_addr;
+    verifier_games.insert(game_addr, state);
+    let verifier = Arc::new(MockAggregateVerifier { games: verifier_games });
+
+    // Mock submitter with enough responses for unlock + withdraw.
+    // No resolve tx needed since the game is already resolved.
+    let submitter = MockBondTransactionSubmitter::with_responses(vec![
+        Ok(tx_hash), // claimCredit (unlock) tx
+        Ok(tx_hash), // claimCredit (withdraw) tx
+    ]);
+
+    let mut mgr = BondManager::new(vec![claim_addr], "http://localhost:8545".parse().unwrap());
+    mgr.set_weth_delay(Duration::from_secs(0)); // instant delay for testing
+
+    // Track the game.
+    assert!(mgr.track_game(game_addr, claim_addr));
+    assert_eq!(mgr.tracked_count(), 1);
+
+    // Poll 1: NeedsResolve → status=1 (already resolved, CHALLENGER_WINS) → NeedsUnlock.
+    mgr.poll(&*verifier, &submitter).await;
+    assert_eq!(mgr.tracked_count(), 1, "game should still be tracked after detecting resolution");
+
+    // Poll 2: NeedsUnlock → claimCredit (unlock) tx → AwaitingDelay.
+    mgr.poll(&*verifier, &submitter).await;
+    assert_eq!(mgr.tracked_count(), 1, "game should still be tracked during delay");
+
+    // Poll 3: AwaitingDelay (delay=0s, already elapsed) → NeedsWithdraw.
+    // check_delay transitions to NeedsWithdraw, but advance_game returns
+    // Ok(false), so the game is still tracked. Need one more poll.
+    mgr.poll(&*verifier, &submitter).await;
+    assert_eq!(mgr.tracked_count(), 1, "game should still be tracked after delay");
+
+    // Poll 4: NeedsWithdraw → claimCredit (withdraw) tx → Completed → removed.
+    mgr.poll(&*verifier, &submitter).await;
+    assert_eq!(mgr.tracked_count(), 0, "game should be removed after completion");
+
+    // Verify 2 transactions were submitted (unlock + withdraw, no resolve).
+    let calls = submitter.recorded_calls();
+    assert_eq!(calls.len(), 2, "expected 2 bond transactions (unlock, withdraw)");
+    for (target, _) in &calls {
+        assert_eq!(*target, game_addr, "all transactions should target the game address");
+    }
+}
+
+#[tokio::test]
+async fn test_bond_manager_skips_already_resolved_game() {
+    // When a game is already resolved on-chain (status != 0), the manager
+    // should skip resolve and advance directly to NeedsUnlock.
+    let claim_addr = Address::repeat_byte(0xCC);
+    let game_addr = addr(0);
+    let tx_hash = B256::repeat_byte(0xDD);
+
+    let mut verifier_games = HashMap::new();
+    let mut state = mock_state(1, Address::ZERO, 100); // status=1 (CHALLENGER_WINS)
+    state.bond_recipient = claim_addr;
+    verifier_games.insert(game_addr, state);
+    let verifier = Arc::new(MockAggregateVerifier { games: verifier_games });
+
+    // Only need 2 responses: unlock + withdraw (no resolve since already resolved).
+    let submitter = MockBondTransactionSubmitter::with_responses(vec![
+        Ok(tx_hash), // claimCredit (unlock) tx
+        Ok(tx_hash), // claimCredit (withdraw) tx
+    ]);
+
+    let mut mgr = BondManager::new(vec![claim_addr], "http://localhost:8545".parse().unwrap());
+    mgr.set_weth_delay(Duration::from_secs(0));
+    mgr.track_game(game_addr, claim_addr);
+
+    // Poll 1: NeedsResolve → sees status != 0 → advances to NeedsUnlock (no tx).
+    mgr.poll(&*verifier, &submitter).await;
+    assert_eq!(mgr.tracked_count(), 1);
+
+    // Poll 2: NeedsUnlock → submits unlock tx → AwaitingDelay.
+    mgr.poll(&*verifier, &submitter).await;
+    assert_eq!(mgr.tracked_count(), 1);
+
+    // Poll 3: AwaitingDelay (delay=0) → NeedsWithdraw.
+    mgr.poll(&*verifier, &submitter).await;
+    assert_eq!(mgr.tracked_count(), 1);
+
+    // Poll 4: NeedsWithdraw → submits withdraw tx → Completed → removed.
+    mgr.poll(&*verifier, &submitter).await;
+    assert_eq!(mgr.tracked_count(), 0);
+
+    // Only 2 transactions submitted (no resolve).
+    assert_eq!(submitter.recorded_calls().len(), 2);
+}
+
+#[tokio::test]
+async fn test_bond_manager_skips_already_unlocked_game() {
+    // When the bond is already unlocked on-chain, the manager should skip
+    // to AwaitingDelay.
+    let claim_addr = Address::repeat_byte(0xCC);
+    let game_addr = addr(0);
+    let tx_hash = B256::repeat_byte(0xDD);
+
+    let mut verifier_games = HashMap::new();
+    let mut state = mock_state(1, Address::ZERO, 100);
+    state.bond_recipient = claim_addr;
+    state.bond_unlocked = true;
+    state.resolved_at = 1_000_000;
+    verifier_games.insert(game_addr, state);
+    let verifier = Arc::new(MockAggregateVerifier { games: verifier_games });
+
+    // Only need 1 response: withdraw (resolve and unlock already done).
+    let submitter = MockBondTransactionSubmitter::with_responses(vec![
+        Ok(tx_hash), // claimCredit (withdraw) tx
+    ]);
+
+    let mut mgr = BondManager::new(vec![claim_addr], "http://localhost:8545".parse().unwrap());
+    mgr.set_weth_delay(Duration::from_secs(0));
+    mgr.track_game(game_addr, claim_addr);
+
+    // Poll 1: NeedsResolve → status != 0 → NeedsUnlock (no tx).
+    mgr.poll(&*verifier, &submitter).await;
+    assert_eq!(mgr.tracked_count(), 1);
+
+    // Poll 2: NeedsUnlock → bond_unlocked=true → AwaitingDelay (no tx).
+    mgr.poll(&*verifier, &submitter).await;
+    assert_eq!(mgr.tracked_count(), 1);
+
+    // Poll 3: AwaitingDelay (delay=0) → NeedsWithdraw.
+    mgr.poll(&*verifier, &submitter).await;
+    assert_eq!(mgr.tracked_count(), 1);
+
+    // Poll 4: NeedsWithdraw → submit withdraw → Completed → removed.
+    mgr.poll(&*verifier, &submitter).await;
+    assert_eq!(mgr.tracked_count(), 0);
+
+    assert_eq!(submitter.recorded_calls().len(), 1);
+}
+
+#[tokio::test]
+async fn test_bond_manager_skips_already_claimed_game() {
+    // When the bond is already claimed on-chain, the manager should skip
+    // and complete immediately.
+    let claim_addr = Address::repeat_byte(0xCC);
+    let game_addr = addr(0);
+
+    let mut verifier_games = HashMap::new();
+    let mut state = mock_state(1, Address::ZERO, 100);
+    state.bond_recipient = claim_addr;
+    state.bond_unlocked = true;
+    state.bond_claimed = true;
+    state.resolved_at = 1_000_000;
+    verifier_games.insert(game_addr, state);
+    let verifier = Arc::new(MockAggregateVerifier { games: verifier_games });
+
+    // No responses needed — no transactions should be submitted.
+    let submitter = MockBondTransactionSubmitter::with_responses(vec![]);
+
+    let mut mgr = BondManager::new(vec![claim_addr], "http://localhost:8545".parse().unwrap());
+    mgr.set_weth_delay(Duration::from_secs(0));
+    mgr.track_game(game_addr, claim_addr);
+
+    // Poll 1: NeedsResolve → status != 0 → NeedsUnlock.
+    mgr.poll(&*verifier, &submitter).await;
+
+    // Poll 2: NeedsUnlock → bond_unlocked=true → AwaitingDelay.
+    mgr.poll(&*verifier, &submitter).await;
+
+    // Poll 3: AwaitingDelay (delay=0) → NeedsWithdraw.
+    mgr.poll(&*verifier, &submitter).await;
+
+    // Poll 4: NeedsWithdraw → bond_claimed=true → Completed → removed.
+    mgr.poll(&*verifier, &submitter).await;
+    assert_eq!(mgr.tracked_count(), 0);
+
+    assert!(
+        submitter.recorded_calls().is_empty(),
+        "no transactions should be submitted for already-claimed bond"
+    );
+}
+
+#[tokio::test]
+async fn test_bond_manager_tx_failure_retries() {
+    // When a bond transaction fails, the manager should retry on the next
+    // poll tick. Tests claimCredit (unlock) failure and retry from the
+    // NeedsUnlock phase.
+    let claim_addr = Address::repeat_byte(0xCC);
+    let game_addr = addr(0);
+    let tx_hash = B256::repeat_byte(0xDD);
+
+    let mut verifier_games = HashMap::new();
+    let mut state = mock_state(1, Address::ZERO, 100); // status=1 (CHALLENGER_WINS)
+    state.bond_recipient = claim_addr;
+    verifier_games.insert(game_addr, state);
+    let verifier = Arc::new(MockAggregateVerifier { games: verifier_games });
+
+    // First claimCredit attempt fails, second succeeds.
+    let submitter = MockBondTransactionSubmitter::with_responses(vec![
+        Err(base_tx_manager::TxManagerError::NonceTooLow.into()),
+        Ok(tx_hash), // retry succeeds
+    ]);
+
+    let mut mgr = BondManager::new(vec![claim_addr], "http://localhost:8545".parse().unwrap());
+    mgr.set_weth_delay(Duration::from_secs(0));
+    mgr.track_game(game_addr, claim_addr);
+
+    // Poll 1: NeedsResolve → status=1 (already resolved, CHALLENGER_WINS) → NeedsUnlock.
+    mgr.poll(&*verifier, &submitter).await;
+    assert_eq!(mgr.tracked_count(), 1, "game should still be tracked after detecting resolution");
+
+    // Poll 2: NeedsUnlock → claimCredit tx fails → stays NeedsUnlock.
+    mgr.poll(&*verifier, &submitter).await;
+    assert_eq!(mgr.tracked_count(), 1, "game should still be tracked after tx failure");
+
+    // Poll 3: NeedsUnlock → retry → claimCredit tx succeeds → AwaitingDelay.
+    mgr.poll(&*verifier, &submitter).await;
+    assert_eq!(mgr.tracked_count(), 1, "game should still be tracked after unlock");
+
+    assert_eq!(submitter.recorded_calls().len(), 2, "expected 2 claimCredit attempts");
+}
+
+#[tokio::test]
+async fn test_bond_manager_ignores_non_claim_addresses() {
+    // Games whose bondRecipient is not in the claim addresses should not
+    // be tracked.
+    let claim_addr = Address::repeat_byte(0xCC);
+    let other_addr = Address::repeat_byte(0xDD);
+    let game_addr = addr(0);
+
+    let mut mgr = BondManager::new(vec![claim_addr], "http://localhost:8545".parse().unwrap());
+    assert!(!mgr.track_game(game_addr, other_addr));
+    assert_eq!(mgr.tracked_count(), 0);
+}
+
+#[tokio::test]
+async fn test_bond_manager_removes_defender_wins_game() {
+    // When a game resolves as DEFENDER_WINS (status=2), the bond belongs to
+    // the game creator, not the challenger. The manager should remove the
+    // game from tracking without submitting any claimCredit transactions.
+    let claim_addr = Address::repeat_byte(0xCC);
+    let game_addr = addr(0);
+
+    let mut verifier_games = HashMap::new();
+    let mut state = mock_state(2, Address::ZERO, 100); // status=2 (DEFENDER_WINS)
+    state.bond_recipient = claim_addr;
+    verifier_games.insert(game_addr, state);
+    let verifier = Arc::new(MockAggregateVerifier { games: verifier_games });
+
+    // No responses needed — no transactions should be submitted.
+    let submitter = MockBondTransactionSubmitter::with_responses(vec![]);
+
+    let mut mgr = BondManager::new(vec![claim_addr], "http://localhost:8545".parse().unwrap());
+    mgr.set_weth_delay(Duration::from_secs(0));
+    mgr.track_game(game_addr, claim_addr);
+    assert_eq!(mgr.tracked_count(), 1);
+
+    // Poll 1: NeedsResolve → status=2 (DEFENDER_WINS) → Completed → removed.
+    mgr.poll(&*verifier, &submitter).await;
+    assert_eq!(mgr.tracked_count(), 0, "game should be removed after DEFENDER_WINS detection");
+
+    assert!(
+        submitter.recorded_calls().is_empty(),
+        "no transactions should be submitted for DEFENDER_WINS game"
+    );
+}
+
+#[tokio::test]
+async fn test_driver_tracks_bond_after_successful_challenge() {
+    // After a successful challenge() submission, the driver should register
+    // the game with the bond manager.
+    let (l2, factory, verifier) = invalid_game_mocks();
+    let sender_addr = Address::ZERO; // MockTxManager returns ZERO as sender_address
+
+    let zk = Arc::new(MockZkProofProvider {
+        session_id: "bond-track".to_string(),
+        proof_status: Mutex::new(base_zk_client::ProofJobStatus::Succeeded as i32),
+        receipt: Mutex::new(vec![0xDE, 0xAD]),
+        ..Default::default()
+    });
+
+    let tx_hash = B256::repeat_byte(0xCC);
+    let tx_manager = MockTxManager::new(Ok(receipt_with_status(true, tx_hash)));
+
+    let scanner = GameScanner::new(
+        Arc::clone(&factory) as Arc<dyn base_proof_contracts::DisputeGameFactoryClient>,
+        Arc::clone(&verifier) as Arc<dyn AggregateVerifierClient>,
+        ScannerConfig { lookback_games: 1000 },
+    );
+    let validator = OutputValidator::new(l2);
+    let submitter = ChallengeSubmitter::new(tx_manager);
+
+    let config = DriverConfig {
+        poll_interval: Duration::from_millis(10),
+        cancel: CancellationToken::new(),
+        ready: Arc::new(AtomicBool::new(false)),
+    };
+
+    // Bond manager with the sender address as a claim address.
+    let mut bond_manager =
+        BondManager::new(vec![sender_addr], "http://localhost:8545".parse().unwrap());
+    bond_manager.set_weth_delay(Duration::from_secs(3600));
+
+    let mut driver = Driver::new(
+        config,
+        DriverComponents {
+            scanner,
+            validator,
+            zk_prover: zk,
+            submitter,
+            tee: None,
+            verifier_client: verifier as Arc<dyn AggregateVerifierClient>,
+            bond_manager: Some(bond_manager),
+        },
+    );
+
+    driver.step().await.unwrap();
+
+    // After a successful challenge, the bond_manager should be tracking the game.
+    let bond_mgr = driver.bond_manager.as_ref().expect("bond_manager should be Some");
+    assert!(
+        bond_mgr.is_tracking(&addr(0)),
+        "game should be tracked by bond manager after successful challenge"
+    );
 }

--- a/crates/proof/challenge/tests/driver.rs
+++ b/crates/proof/challenge/tests/driver.rs
@@ -1403,16 +1403,49 @@ async fn test_bond_manager_ignores_non_claim_addresses() {
 }
 
 #[tokio::test]
-async fn test_bond_manager_removes_defender_wins_game() {
-    // When a game resolves as DEFENDER_WINS (status=2), the bond belongs to
-    // the game creator, not the challenger. The manager should remove the
-    // game from tracking without submitting any claimCredit transactions.
+async fn test_bond_manager_keeps_defender_wins_when_recipient_is_claimable() {
+    // When a game resolves as DEFENDER_WINS and the on-chain bondRecipient
+    // is in our claim addresses (i.e. we are the proposer), the manager
+    // should keep the game and advance it to NeedsUnlock — the bond is ours.
     let claim_addr = Address::repeat_byte(0xCC);
     let game_addr = addr(0);
 
     let mut verifier_games = HashMap::new();
     let mut state = mock_state(2, Address::ZERO, 100); // status=2 (DEFENDER_WINS)
     state.bond_recipient = claim_addr;
+    verifier_games.insert(game_addr, state);
+    let verifier = Arc::new(MockAggregateVerifier { games: verifier_games });
+
+    let submitter = MockBondTransactionSubmitter::with_responses(vec![]);
+
+    let mut mgr = BondManager::new(vec![claim_addr], "http://localhost:8545".parse().unwrap());
+    mgr.set_weth_delay(Duration::from_secs(0));
+    mgr.track_game(game_addr, claim_addr);
+    assert_eq!(mgr.tracked_count(), 1);
+
+    // Poll 1: NeedsResolve → status=2 (already resolved) → bondRecipient
+    // is in claim set → advance to NeedsUnlock (not removed).
+    mgr.poll(&*verifier, &submitter).await;
+    assert_eq!(
+        mgr.tracked_count(),
+        1,
+        "game should be kept when bondRecipient is in claim addresses"
+    );
+}
+
+#[tokio::test]
+async fn test_bond_manager_removes_game_when_recipient_not_claimable() {
+    // When a game is resolved and the on-chain bondRecipient is NOT in our
+    // claim addresses, the manager should remove the game from tracking.
+    // This covers the case where we matched via zkProver during the startup
+    // scan, but after resolve the bond goes to someone else.
+    let claim_addr = Address::repeat_byte(0xCC);
+    let other_addr = Address::repeat_byte(0xDD);
+    let game_addr = addr(0);
+
+    let mut verifier_games = HashMap::new();
+    let mut state = mock_state(2, Address::ZERO, 100); // status=2 (DEFENDER_WINS)
+    state.bond_recipient = other_addr; // bond goes to someone else
     verifier_games.insert(game_addr, state);
     let verifier = Arc::new(MockAggregateVerifier { games: verifier_games });
 
@@ -1424,13 +1457,18 @@ async fn test_bond_manager_removes_defender_wins_game() {
     mgr.track_game(game_addr, claim_addr);
     assert_eq!(mgr.tracked_count(), 1);
 
-    // Poll 1: NeedsResolve → status=2 (DEFENDER_WINS) → Completed → removed.
+    // Poll 1: NeedsResolve → already resolved → bondRecipient not in
+    // claim set → removed from tracking.
     mgr.poll(&*verifier, &submitter).await;
-    assert_eq!(mgr.tracked_count(), 0, "game should be removed after DEFENDER_WINS detection");
+    assert_eq!(
+        mgr.tracked_count(),
+        0,
+        "game should be removed when bondRecipient is not in claim addresses"
+    );
 
     assert!(
         submitter.recorded_calls().is_empty(),
-        "no transactions should be submitted for DEFENDER_WINS game"
+        "no transactions should be submitted when bond is not claimable"
     );
 }
 

--- a/crates/proof/contracts/src/aggregate_verifier.rs
+++ b/crates/proof/contracts/src/aggregate_verifier.rs
@@ -83,6 +83,55 @@ sol! {
             uint256 intermediateRootIndex,
             bytes32 intermediateRootToProve
         ) external;
+
+        /// Resolves the game after a proof has been provided and enough time
+        /// has passed. Returns the resulting `GameStatus`.
+        ///
+        /// Use [`encode_resolve_calldata`] to construct ABI-encoded calldata
+        /// for this function.
+        function resolve() external returns (uint8);
+
+        /// Claims the bond credit for the bond recipient. Must be called
+        /// twice: the first call triggers `DelayedWETH.unlock()`, and the
+        /// second call (after `DELAY_SECONDS`) triggers the actual withdrawal.
+        ///
+        /// Use [`encode_claim_credit_calldata`] to construct ABI-encoded
+        /// calldata for this function.
+        function claimCredit() external;
+
+        /// Returns whether the game's finalization delay has passed
+        /// (`expectedResolution <= block.timestamp`).
+        function gameOver() external view returns (bool);
+
+        /// Returns the timestamp at which the game was resolved (`0` if unresolved).
+        function resolvedAt() external view returns (uint64);
+
+        /// Returns the address that will receive the bond.
+        ///
+        /// Defaults to the game creator; set to the ZK challenger if the
+        /// game resolves as `CHALLENGER_WINS`.
+        function bondRecipient() external view returns (address);
+
+        /// Returns whether the bond has been unlocked via `DelayedWETH.unlock()`.
+        function bondUnlocked() external view returns (bool);
+
+        /// Returns whether the bond has been fully claimed (withdrawn).
+        function bondClaimed() external view returns (bool);
+
+        /// Returns the timestamp at which the game can be resolved.
+        ///
+        /// Initialized to `type(uint64).max` (never), decreased when proofs
+        /// are verified, and increased when proofs are nullified.
+        function expectedResolution() external view returns (uint64);
+
+        /// Returns the number of verified proofs for this game.
+        function proofCount() external view returns (uint8);
+
+        /// Returns the timestamp at which the game was created.
+        function createdAt() external view returns (uint64);
+
+        /// Returns the address of the `DelayedWETH` contract used by this game.
+        function DELAYED_WETH() external view returns (address);
     }
 }
 
@@ -140,6 +189,33 @@ pub trait AggregateVerifierClient: Send + Sync {
     /// `0` means the game has not been challenged. When non-zero the
     /// actual 0-based index is `value - 1`.
     async fn countered_index(&self, game_address: Address) -> Result<u64, ContractError>;
+
+    /// Returns whether the game's finalization delay has elapsed.
+    async fn game_over(&self, game_address: Address) -> Result<bool, ContractError>;
+
+    /// Returns the timestamp at which the game was resolved (`0` if unresolved).
+    async fn resolved_at(&self, game_address: Address) -> Result<u64, ContractError>;
+
+    /// Returns the address that will receive the bond.
+    async fn bond_recipient(&self, game_address: Address) -> Result<Address, ContractError>;
+
+    /// Returns whether the bond has been unlocked via `DelayedWETH.unlock()`.
+    async fn bond_unlocked(&self, game_address: Address) -> Result<bool, ContractError>;
+
+    /// Returns whether the bond has been fully claimed (withdrawn).
+    async fn bond_claimed(&self, game_address: Address) -> Result<bool, ContractError>;
+
+    /// Returns the timestamp at which the game can be resolved.
+    async fn expected_resolution(&self, game_address: Address) -> Result<u64, ContractError>;
+
+    /// Returns the number of verified proofs for this game.
+    async fn proof_count(&self, game_address: Address) -> Result<u8, ContractError>;
+
+    /// Returns the timestamp at which the game was created.
+    async fn created_at(&self, game_address: Address) -> Result<u64, ContractError>;
+
+    /// Returns the address of the `DelayedWETH` contract used by this game.
+    async fn delayed_weth(&self, game_address: Address) -> Result<Address, ContractError>;
 }
 
 /// Concrete implementation backed by Alloy's sol-generated contract bindings.
@@ -337,6 +413,104 @@ impl AggregateVerifierClient for AggregateVerifierContractClient {
             )
         })
     }
+
+    async fn game_over(&self, game_address: Address) -> Result<bool, ContractError> {
+        let contract =
+            IAggregateVerifier::IAggregateVerifierInstance::new(game_address, &self.provider);
+
+        contract
+            .gameOver()
+            .call()
+            .await
+            .map_err(|e| ContractError::Call { context: "gameOver failed".into(), source: e })
+    }
+
+    async fn resolved_at(&self, game_address: Address) -> Result<u64, ContractError> {
+        let contract =
+            IAggregateVerifier::IAggregateVerifierInstance::new(game_address, &self.provider);
+
+        contract
+            .resolvedAt()
+            .call()
+            .await
+            .map_err(|e| ContractError::Call { context: "resolvedAt failed".into(), source: e })
+    }
+
+    async fn bond_recipient(&self, game_address: Address) -> Result<Address, ContractError> {
+        let contract =
+            IAggregateVerifier::IAggregateVerifierInstance::new(game_address, &self.provider);
+
+        contract
+            .bondRecipient()
+            .call()
+            .await
+            .map_err(|e| ContractError::Call { context: "bondRecipient failed".into(), source: e })
+    }
+
+    async fn bond_unlocked(&self, game_address: Address) -> Result<bool, ContractError> {
+        let contract =
+            IAggregateVerifier::IAggregateVerifierInstance::new(game_address, &self.provider);
+
+        contract
+            .bondUnlocked()
+            .call()
+            .await
+            .map_err(|e| ContractError::Call { context: "bondUnlocked failed".into(), source: e })
+    }
+
+    async fn bond_claimed(&self, game_address: Address) -> Result<bool, ContractError> {
+        let contract =
+            IAggregateVerifier::IAggregateVerifierInstance::new(game_address, &self.provider);
+
+        contract
+            .bondClaimed()
+            .call()
+            .await
+            .map_err(|e| ContractError::Call { context: "bondClaimed failed".into(), source: e })
+    }
+
+    async fn expected_resolution(&self, game_address: Address) -> Result<u64, ContractError> {
+        let contract =
+            IAggregateVerifier::IAggregateVerifierInstance::new(game_address, &self.provider);
+
+        contract.expectedResolution().call().await.map_err(|e| ContractError::Call {
+            context: "expectedResolution failed".into(),
+            source: e,
+        })
+    }
+
+    async fn proof_count(&self, game_address: Address) -> Result<u8, ContractError> {
+        let contract =
+            IAggregateVerifier::IAggregateVerifierInstance::new(game_address, &self.provider);
+
+        contract
+            .proofCount()
+            .call()
+            .await
+            .map_err(|e| ContractError::Call { context: "proofCount failed".into(), source: e })
+    }
+
+    async fn created_at(&self, game_address: Address) -> Result<u64, ContractError> {
+        let contract =
+            IAggregateVerifier::IAggregateVerifierInstance::new(game_address, &self.provider);
+
+        contract
+            .createdAt()
+            .call()
+            .await
+            .map_err(|e| ContractError::Call { context: "createdAt failed".into(), source: e })
+    }
+
+    async fn delayed_weth(&self, game_address: Address) -> Result<Address, ContractError> {
+        let contract =
+            IAggregateVerifier::IAggregateVerifierInstance::new(game_address, &self.provider);
+
+        contract
+            .DELAYED_WETH()
+            .call()
+            .await
+            .map_err(|e| ContractError::Call { context: "DELAYED_WETH failed".into(), source: e })
+    }
 }
 
 /// Encodes the calldata for `IAggregateVerifier.nullify()`.
@@ -370,6 +544,25 @@ pub fn encode_challenge_calldata(
         intermediateRootIndex: U256::from(intermediate_root_index),
         intermediateRootToProve: intermediate_root_to_prove,
     };
+    Bytes::from(call.abi_encode())
+}
+
+/// Encodes the calldata for `IAggregateVerifier.resolve()`.
+///
+/// Resolves the game after its dispute period has elapsed. Returns the
+/// resulting `GameStatus` on-chain.
+pub fn encode_resolve_calldata() -> Bytes {
+    let call = IAggregateVerifier::resolveCall {};
+    Bytes::from(call.abi_encode())
+}
+
+/// Encodes the calldata for `IAggregateVerifier.claimCredit()`.
+///
+/// Must be called twice: the first call unlocks the bond via
+/// `DelayedWETH.unlock()`, and the second call (after `DELAY_SECONDS`)
+/// withdraws and transfers ETH to the `bondRecipient`.
+pub fn encode_claim_credit_calldata() -> Bytes {
+    let call = IAggregateVerifier::claimCreditCall {};
     Bytes::from(call.abi_encode())
 }
 
@@ -453,6 +646,29 @@ mod tests {
             &calldata_nullify[..4],
             &calldata_challenge[..4],
             "nullify and challenge must have different selectors"
+        );
+    }
+
+    #[test]
+    fn test_encode_resolve_calldata_has_selector() {
+        let calldata = encode_resolve_calldata();
+        assert_eq!(&calldata[..4], &IAggregateVerifier::resolveCall::SELECTOR);
+    }
+
+    #[test]
+    fn test_encode_claim_credit_calldata_has_selector() {
+        let calldata = encode_claim_credit_calldata();
+        assert_eq!(&calldata[..4], &IAggregateVerifier::claimCreditCall::SELECTOR);
+    }
+
+    #[test]
+    fn test_resolve_and_claim_credit_selectors_differ() {
+        let resolve = encode_resolve_calldata();
+        let claim = encode_claim_credit_calldata();
+        assert_ne!(
+            &resolve[..4],
+            &claim[..4],
+            "resolve and claimCredit must have different selectors"
         );
     }
 }

--- a/crates/proof/contracts/src/delayed_weth.rs
+++ b/crates/proof/contracts/src/delayed_weth.rs
@@ -1,0 +1,63 @@
+//! `DelayedWETH` contract bindings.
+//!
+//! Used to read the withdrawal delay from the `DelayedWETH` contract. The
+//! bond lifecycle in `AggregateVerifier` requires waiting this delay between
+//! the first `claimCredit()` call (which triggers `unlock()`) and the second
+//! call (which triggers `withdraw()`).
+
+use std::time::Duration;
+
+use alloy_primitives::{Address, U256};
+use alloy_provider::RootProvider;
+use async_trait::async_trait;
+
+use crate::ContractError;
+
+alloy_sol_types::sol! {
+    /// `DelayedWETH` contract interface (read-only subset).
+    #[sol(rpc)]
+    interface IDelayedWETH {
+        /// Returns the withdrawal delay in seconds.
+        function delay() external view returns (uint256);
+    }
+}
+
+/// Async trait for querying the `DelayedWETH` contract.
+#[async_trait]
+pub trait DelayedWETHClient: Send + Sync {
+    /// Returns the withdrawal delay enforced between `unlock()` and `withdraw()`.
+    async fn delay(&self) -> Result<Duration, ContractError>;
+}
+
+/// Concrete implementation backed by Alloy's sol-generated contract bindings.
+#[derive(Debug)]
+pub struct DelayedWETHContractClient {
+    contract: IDelayedWETH::IDelayedWETHInstance<RootProvider>,
+}
+
+impl DelayedWETHContractClient {
+    /// Creates a new client for the `DelayedWETH` contract at the given address.
+    pub fn new(address: Address, l1_rpc_url: url::Url) -> Result<Self, ContractError> {
+        let provider = RootProvider::new_http(l1_rpc_url);
+        let contract = IDelayedWETH::IDelayedWETHInstance::new(address, provider);
+        Ok(Self { contract })
+    }
+}
+
+#[async_trait]
+impl DelayedWETHClient for DelayedWETHContractClient {
+    async fn delay(&self) -> Result<Duration, ContractError> {
+        let delay_u256: U256 = self
+            .contract
+            .delay()
+            .call()
+            .await
+            .map_err(|e| ContractError::Call { context: "delay failed".into(), source: e })?;
+
+        let delay_secs: u64 = delay_u256
+            .try_into()
+            .map_err(|_| ContractError::Validation("delay overflows u64".into()))?;
+
+        Ok(Duration::from_secs(delay_secs))
+    }
+}

--- a/crates/proof/contracts/src/lib.rs
+++ b/crates/proof/contracts/src/lib.rs
@@ -9,8 +9,11 @@
 mod aggregate_verifier;
 pub use aggregate_verifier::{
     AggregateVerifierClient, AggregateVerifierContractClient, GameInfo, encode_challenge_calldata,
-    encode_nullify_calldata,
+    encode_claim_credit_calldata, encode_nullify_calldata, encode_resolve_calldata,
 };
+
+mod delayed_weth;
+pub use delayed_weth::{DelayedWETHClient, DelayedWETHContractClient};
 
 mod anchor_state_registry;
 pub use anchor_state_registry::{

--- a/crates/proof/proposer/src/test_utils.rs
+++ b/crates/proof/proposer/src/test_utils.rs
@@ -234,6 +234,33 @@ impl AggregateVerifierClient for MockAggregateVerifier {
     async fn countered_index(&self, _: Address) -> Result<u64, ContractError> {
         Ok(0)
     }
+    async fn game_over(&self, _: Address) -> Result<bool, ContractError> {
+        Ok(false)
+    }
+    async fn resolved_at(&self, _: Address) -> Result<u64, ContractError> {
+        Ok(0)
+    }
+    async fn bond_recipient(&self, _: Address) -> Result<Address, ContractError> {
+        Ok(Address::ZERO)
+    }
+    async fn bond_unlocked(&self, _: Address) -> Result<bool, ContractError> {
+        Ok(false)
+    }
+    async fn bond_claimed(&self, _: Address) -> Result<bool, ContractError> {
+        Ok(false)
+    }
+    async fn expected_resolution(&self, _: Address) -> Result<u64, ContractError> {
+        Ok(0)
+    }
+    async fn proof_count(&self, _: Address) -> Result<u8, ContractError> {
+        Ok(0)
+    }
+    async fn created_at(&self, _: Address) -> Result<u64, ContractError> {
+        Ok(0)
+    }
+    async fn delayed_weth(&self, _: Address) -> Result<Address, ContractError> {
+        Ok(Address::ZERO)
+    }
 }
 
 pub(crate) fn test_l1_block_ref(number: u64) -> L1BlockRef {


### PR DESCRIPTION
## Summary

- Introduces a `BondManager` that tracks dispute games through a multi-phase credit claim lifecycle: **resolve → unlock → DelayedWETH delay → withdraw**.
- After a successful `challenge()` submission, the manager registers the game and automatically resolves it (once the dispute period elapses) and performs two `claimCredit()` calls (with the `DelayedWETH` withdrawal delay in between) to recover the bond. Games are tracked whenever the onchain `bondRecipient` matches a configured claim address, regardless of whether the game resolves as `CHALLENGER_WINS` or `DEFENDER_WINS`.
- Adds a startup scan that recovers in-flight games after restarts by checking both `bondRecipient` and `zkProver` against the configured `--bond-claim-addresses`.

## Changes

- **`crates/proof/challenge/src/bond.rs`** — new `BondManager` with `BondPhase` state machine, `TrackedGame` tracking, `startup_scan`, and `poll` loop.
- **`crates/proof/challenge/src/cli.rs`** / **`config.rs`** — new `--bond-claim-addresses` CLI flag and config field.
- **`crates/proof/challenge/src/driver.rs`** — integrates bond polling into the driver tick; registers games after successful challenges. Introduces `DriverComponents` to bundle injected dependencies.
- **`crates/proof/challenge/src/service.rs`** — constructs the `BondManager` when claim addresses are configured, runs the startup scan, and passes it into `DriverComponents`.
- **`crates/proof/challenge/src/submitter.rs`** — implements `BondTransactionSubmitter` for `ChallengeSubmitter<T>`.
- **`crates/proof/challenge/src/metrics.rs`** — adds bond-related metrics (resolve outcomes, claimCredit outcomes, latency, tracked count, completed count).
- **`crates/proof/challenge/src/scanner.rs`** — exposes `STATUS_CHALLENGER_WINS` and `STATUS_DEFENDER_WINS` constants.
- **`crates/proof/contracts/src/delayed_weth.rs`** — new `DelayedWETHClient` / `DelayedWETHContractClient` for reading the withdrawal delay.
- **`crates/proof/contracts/src/aggregate_verifier.rs`** — adds `resolve()` and `claimCredit()` sol declarations with `encode_resolve_calldata` and `encode_claim_credit_calldata` helpers; extends `AggregateVerifierClient` with `game_over`, `resolved_at`, `bond_recipient`, `bond_unlocked`, `bond_claimed`, `expected_resolution`, `proof_count`, `created_at`, and `delayed_weth` methods.
- **Test utilities** updated across challenge and proposer crates to support the new contract methods and bond phases.