### PR TITLE
chore(ci): skip Vercel deploy when docs/specs is unchanged

### DIFF
--- a/docs/specs/vercel.json
+++ b/docs/specs/vercel.json
@@ -1,0 +1,3 @@
+{
+  "ignoreCommand": "git diff HEAD^ HEAD --quiet -- docs/specs/"
+}


### PR DESCRIPTION
The specs site (`docs/specs/`) is fully self-contained with no dependencies on the rest of the repo. Currently Vercel triggers a build on every PR regardless of what changed.

Adds a `vercel.json` with an `ignoreCommand` that skips the build when `docs/specs/` hasn't been modified in the commit, avoiding unnecessary build time on unrelated PRs.