### PR TITLE
docs: fix L1Miner safe/finalized behavior

### DIFF
--- a/actions/README.md
+++ b/actions/README.md
@@ -110,8 +110,7 @@ The block header uses `alloy_consensus::Header` and calls `hash_slow()` to
 compute parent hashes, so the in-memory chain has a realistic hash structure
 that the derivation pipeline can traverse.
 
-Safe and finalized head pointers lag behind the latest head by 32 and 64
-blocks respectively, approximating Ethereum's post-merge consensus behaviour.
+Safe and finalized head pointers start at genesis and advance only when tests call `act_l1_safe_next`, `act_l1_finalize_next`, `act_l1_safe`, or `act_l1_finalize` on `L1Miner`.
 Tests that need more control can read `block_by_number()` directly.
 
 


### PR DESCRIPTION
The README for `L1Miner` states that safe and finalized head pointers lag behind the latest head by 32 and 64 blocks respectively, approximating Ethereum's post-merge consensus behaviour.

However, the actual implementation in miner.rs shows:
- `safe_number` and `finalized_number` are initialized to 0 when the miner is created
- `mine_block()` does not modify these pointers
- Advancement only happens through explicit calls to `act_l1_safe_next`, `act_l1_finalize_next`, `act_l1_safe, or act_l1_finalize`

Tests in `miner.rs` confirm this behaviour:
`safe_and_finalized_head_start_at_genesis`,
`explicit_safe_next_advances_pointer`, and others.