### PR TITLE
ktlo(repo): Move Features Sections To Bottom

### DIFF
--- a/crates/batcher/encoder/Cargo.toml
+++ b/crates/batcher/encoder/Cargo.toml
@@ -11,10 +11,6 @@ repository.workspace = true
 [lints]
 workspace = true
 
-[features]
-clap = [ "dep:clap" ]
-metrics = [ "base-metrics/metrics", "dep:metrics" ]
-
 [dependencies]
 tracing = { workspace = true, features = ["std"] }
 base-comp = { workspace = true, features = ["std"] }
@@ -32,3 +28,7 @@ clap = { workspace = true, features = ["derive"], optional = true }
 [dev-dependencies]
 alloy-consensus = { workspace = true, features = ["std"] }
 rstest.workspace = true
+
+[features]
+clap = [ "dep:clap" ]
+metrics = [ "base-metrics/metrics", "dep:metrics" ]

--- a/crates/builder/core/Cargo.toml
+++ b/crates/builder/core/Cargo.toml
@@ -11,54 +11,6 @@ repository.workspace = true
 [lints]
 workspace = true
 
-[features]
-default = [ "jemalloc", "metrics" ]
-metrics = [
-	"base-metrics/metrics",
-	"dep:metrics",
-	"reth-evm/metrics",
-	"reth-trie/metrics",
-]
-jemalloc = [ "dep:tikv-jemallocator", "reth-cli-util/jemalloc" ]
-jemalloc-prof = [
-	"jemalloc",
-	"reth-cli-util/jemalloc-prof",
-	"tikv-jemallocator?/profiling",
-]
-min-error-logs = [ "tracing/release_max_level_error" ]
-min-warn-logs = [ "tracing/release_max_level_warn" ]
-min-info-logs = [ "tracing/release_max_level_info" ]
-min-debug-logs = [ "tracing/release_max_level_debug" ]
-min-trace-logs = [ "tracing/release_max_level_trace" ]
-test-utils = [
-	"base-bundles/test-utils",
-	"base-execution-rpc/client",
-	"base-node-core/test-utils",
-	"base-node-runner/test-utils",
-	"ctor",
-	"http-body-util",
-	"hyper",
-	"hyper-util",
-	"nanoid",
-	"reth-chain-state/test-utils",
-	"reth-chainspec/test-utils",
-	"reth-db/test-utils",
-	"reth-evm/test-utils",
-	"reth-ipc",
-	"reth-node-builder/test-utils",
-	"reth-node-ethereum/test-utils",
-	"reth-payload-builder/test-utils",
-	"reth-primitives-traits/test-utils",
-	"reth-primitives/test-utils",
-	"reth-provider/test-utils",
-	"reth-revm/test-utils",
-	"reth-tasks/test-utils",
-	"reth-transaction-pool/test-utils",
-	"reth-trie/test-utils",
-	"rlimit",
-	"testcontainers",
-]
-
 [dependencies]
 # workspace
 base-bundles.workspace = true
@@ -229,3 +181,51 @@ nanoid.workspace = true
 tempfile.workspace = true
 hyper-util.workspace = true
 http-body-util.workspace = true
+
+[features]
+default = [ "jemalloc", "metrics" ]
+metrics = [
+	"base-metrics/metrics",
+	"dep:metrics",
+	"reth-evm/metrics",
+	"reth-trie/metrics",
+]
+jemalloc = [ "dep:tikv-jemallocator", "reth-cli-util/jemalloc" ]
+jemalloc-prof = [
+	"jemalloc",
+	"reth-cli-util/jemalloc-prof",
+	"tikv-jemallocator?/profiling",
+]
+min-error-logs = [ "tracing/release_max_level_error" ]
+min-warn-logs = [ "tracing/release_max_level_warn" ]
+min-info-logs = [ "tracing/release_max_level_info" ]
+min-debug-logs = [ "tracing/release_max_level_debug" ]
+min-trace-logs = [ "tracing/release_max_level_trace" ]
+test-utils = [
+	"base-bundles/test-utils",
+	"base-execution-rpc/client",
+	"base-node-core/test-utils",
+	"base-node-runner/test-utils",
+	"ctor",
+	"http-body-util",
+	"hyper",
+	"hyper-util",
+	"nanoid",
+	"reth-chain-state/test-utils",
+	"reth-chainspec/test-utils",
+	"reth-db/test-utils",
+	"reth-evm/test-utils",
+	"reth-ipc",
+	"reth-node-builder/test-utils",
+	"reth-node-ethereum/test-utils",
+	"reth-payload-builder/test-utils",
+	"reth-primitives-traits/test-utils",
+	"reth-primitives/test-utils",
+	"reth-provider/test-utils",
+	"reth-revm/test-utils",
+	"reth-tasks/test-utils",
+	"reth-transaction-pool/test-utils",
+	"reth-trie/test-utils",
+	"rlimit",
+	"testcontainers",
+]

--- a/crates/client/flashblocks-node/Cargo.toml
+++ b/crates/client/flashblocks-node/Cargo.toml
@@ -11,33 +11,6 @@ repository.workspace = true
 [lints]
 workspace = true
 
-[features]
-test-utils = [
-	"base-node-core/test-utils",
-	"base-node-runner/test-utils",
-	"dep:alloy-consensus",
-	"dep:alloy-eips",
-	"dep:alloy-primitives",
-	"dep:alloy-rpc-types-engine",
-	"dep:base-alloy-consensus",
-	"dep:base-alloy-flashblocks",
-	"dep:base-execution-chainspec",
-	"dep:base-execution-primitives",
-	"dep:derive_more",
-	"dep:eyre",
-	"dep:reth-chainspec",
-	"dep:reth-primitives-traits",
-	"dep:reth-provider",
-	"dep:reth-transaction-pool",
-	"reth-chain-state/test-utils",
-	"reth-chainspec/test-utils",
-	"reth-evm/test-utils",
-	"reth-primitives-traits?/test-utils",
-	"reth-provider/test-utils",
-	"reth-revm/test-utils",
-	"reth-transaction-pool/test-utils",
-]
-
 [dependencies]
 # workspace
 base-node-core.workspace = true
@@ -123,6 +96,33 @@ rand.workspace = true
 rayon.workspace = true
 serde_json = { workspace = true, features = ["std"] }
 criterion = { workspace = true, features = ["async_tokio"] }
+
+[features]
+test-utils = [
+	"base-node-core/test-utils",
+	"base-node-runner/test-utils",
+	"dep:alloy-consensus",
+	"dep:alloy-eips",
+	"dep:alloy-primitives",
+	"dep:alloy-rpc-types-engine",
+	"dep:base-alloy-consensus",
+	"dep:base-alloy-flashblocks",
+	"dep:base-execution-chainspec",
+	"dep:base-execution-primitives",
+	"dep:derive_more",
+	"dep:eyre",
+	"dep:reth-chainspec",
+	"dep:reth-primitives-traits",
+	"dep:reth-provider",
+	"dep:reth-transaction-pool",
+	"reth-chain-state/test-utils",
+	"reth-chainspec/test-utils",
+	"reth-evm/test-utils",
+	"reth-primitives-traits?/test-utils",
+	"reth-provider/test-utils",
+	"reth-revm/test-utils",
+	"reth-transaction-pool/test-utils",
+]
 
 [[bench]]
 name = "pending_state"

--- a/crates/core/bundles/Cargo.toml
+++ b/crates/core/bundles/Cargo.toml
@@ -11,9 +11,6 @@ repository.workspace = true
 [lints]
 workspace = true
 
-[features]
-test-utils = [ "dep:alloy-signer-local", "dep:base-alloy-rpc-types" ]
-
 [dependencies]
 # alloy
 alloy-serde = { workspace = true, features = ["std"] }
@@ -42,3 +39,6 @@ base-alloy-rpc-types = { workspace = true, features = ["std"] }
 
 # misc
 serde_json = { workspace = true, features = ["std"] }
+
+[features]
+test-utils = [ "dep:alloy-signer-local", "dep:base-alloy-rpc-types" ]

--- a/crates/utilities/jwt/Cargo.toml
+++ b/crates/utilities/jwt/Cargo.toml
@@ -11,20 +11,6 @@ repository.workspace = true
 [lints]
 workspace = true
 
-[features]
-test-utils = [ "base-consensus-engine?/test-utils" ]
-engine-validation = [
-	"dep:alloy-provider",
-	"dep:alloy-transport-http",
-	"dep:backon",
-	"dep:base-alloy-network",
-	"dep:base-alloy-provider",
-	"dep:base-consensus-engine",
-	"dep:eyre",
-	"dep:tracing",
-	"dep:url",
-]
-
 [dependencies]
 # alloy
 alloy-primitives.workspace = true
@@ -43,3 +29,17 @@ base-alloy-provider = { workspace = true, optional = true }
 alloy-transport-http = { workspace = true, optional = true }
 base-consensus-engine = { workspace = true, optional = true }
 tracing = { workspace = true, optional = true, features = ["std"] }
+
+[features]
+test-utils = [ "base-consensus-engine?/test-utils" ]
+engine-validation = [
+	"dep:alloy-provider",
+	"dep:alloy-transport-http",
+	"dep:backon",
+	"dep:base-alloy-network",
+	"dep:base-alloy-provider",
+	"dep:base-consensus-engine",
+	"dep:eyre",
+	"dep:tracing",
+	"dep:url",
+]


### PR DESCRIPTION
## Summary

Several crate manifests placed the `[features]` section above `[dependencies]`, conflicting with the project convention that features sections go at the bottom of the manifest. This moves `[features]` to after the last dependency section in each of the five affected files: `base-builder-core`, `base-batcher-encoder`, `base-jwt`, `base-flashblocks-node`, and `base-bundles`. Fixes #1883.