### PR TITLE
ktlo(repo): Add Missing Doc Comments

### DIFF
--- a/crates/consensus/engine/src/test_utils/mod.rs
+++ b/crates/consensus/engine/src/test_utils/mod.rs
@@ -1,3 +1,5 @@
+//! Test utilities for the consensus engine including mock clients and builders.
+
 mod attributes;
 pub use attributes::TestAttributesBuilder;
 

--- a/crates/consensus/service/src/actors/derivation/delegate_l2/mod.rs
+++ b/crates/consensus/service/src/actors/derivation/delegate_l2/mod.rs
@@ -1,3 +1,5 @@
+//! L2 delegation derivation actor and its RPC client.
+
 mod actor;
 pub use actor::DelegateL2DerivationActor;
 

--- a/crates/consensus/service/src/actors/derivation/delegated/mod.rs
+++ b/crates/consensus/service/src/actors/derivation/delegated/mod.rs
@@ -1,3 +1,5 @@
+//! Delegated derivation actor and its RPC client.
+
 mod actor;
 pub use actor::DelegateDerivationActor;
 

--- a/crates/consensus/service/src/actors/derivation/mod.rs
+++ b/crates/consensus/service/src/actors/derivation/mod.rs
@@ -1,3 +1,5 @@
+//! Derivation actors including direct, delegated, and L2-delegate variants.
+
 mod actor;
 pub use actor::{DerivationActor, DerivationError};
 

--- a/crates/consensus/service/src/actors/l1_watcher/mod.rs
+++ b/crates/consensus/service/src/actors/l1_watcher/mod.rs
@@ -1,3 +1,5 @@
+//! L1 watcher actor, block stream, derivation client, and error types.
+
 mod actor;
 pub use actor::{L1WatcherActor, LogRetrier};
 

--- a/crates/consensus/service/src/actors/rpc/mod.rs
+++ b/crates/consensus/service/src/actors/rpc/mod.rs
@@ -1,3 +1,5 @@
+//! RPC actor and engine/sequencer RPC client wrappers.
+
 mod actor;
 pub use actor::{RpcActor, RpcContext};
 

--- a/crates/consensus/service/src/actors/sequencer/tests/mod.rs
+++ b/crates/consensus/service/src/actors/sequencer/tests/mod.rs
@@ -1,3 +1,5 @@
+//! Integration tests for the sequencer actor and admin API.
+
 mod actor_test;
 mod admin_api_impl_test;
 

--- a/crates/consensus/service/tests/actors/generator/mod.rs
+++ b/crates/consensus/service/tests/actors/generator/mod.rs
@@ -1,2 +1,4 @@
+//! Test block generator utilities including block builder and seed helpers.
+
 pub(crate) mod block_builder;
 pub(crate) mod seed;

--- a/crates/consensus/sources/src/signer/remote/mod.rs
+++ b/crates/consensus/sources/src/signer/remote/mod.rs
@@ -1,3 +1,5 @@
+//! Remote signer client, certificate handling, and request handler.
+
 mod cert;
 pub use cert::{CertificateError, ClientCert};
 mod client;

--- a/crates/core/consensus/src/extra/mod.rs
+++ b/crates/core/consensus/src/extra/mod.rs
@@ -1,3 +1,5 @@
+//! Block extra-data encodings for Holocene and Jovian fork upgrades.
+
 mod holocene;
 pub use holocene::HoloceneExtraData;
 

--- a/crates/execution/cli/src/commands/mod.rs
+++ b/crates/execution/cli/src/commands/mod.rs
@@ -1,3 +1,5 @@
+//! CLI subcommands for the execution layer node.
+
 use std::{fmt, sync::Arc};
 
 use clap::Subcommand;

--- a/crates/execution/trie/src/prune/mod.rs
+++ b/crates/execution/trie/src/prune/mod.rs
@@ -1,3 +1,5 @@
+//! Proof storage pruner for removing stale trie data.
+
 mod error;
 pub use error::{OpProofStoragePrunerResult, PrunerError, PrunerOutput};
 

--- a/crates/infra/audit/tests/common/mod.rs
+++ b/crates/infra/audit/tests/common/mod.rs
@@ -1,3 +1,5 @@
+//! Common test harness for audit integration tests with Kafka and S3 fixtures.
+
 use rdkafka::{ClientConfig, consumer::StreamConsumer, producer::FutureProducer};
 use testcontainers::runners::AsyncRunner;
 use testcontainers_modules::{kafka, kafka::Kafka, minio::MinIO};

--- a/crates/infra/basectl/src/app/mod.rs
+++ b/crates/infra/basectl/src/app/mod.rs
@@ -1,3 +1,5 @@
+//! Core application logic, actions, resources, and routing for basectl.
+
 mod action;
 pub(crate) use action::Action;
 

--- a/crates/infra/basectl/src/app/views/mod.rs
+++ b/crates/infra/basectl/src/app/views/mod.rs
@@ -1,3 +1,5 @@
+//! TUI view components for basectl panels and dashboards.
+
 mod command_center;
 pub(crate) use command_center::CommandCenterView;
 

--- a/crates/infra/basectl/src/commands/mod.rs
+++ b/crates/infra/basectl/src/commands/mod.rs
@@ -1,2 +1,4 @@
+//! CLI command implementations for the basectl tool.
+
 /// Shared types, formatters, and rendering utilities for CLI commands.
 pub(crate) mod common;

--- a/crates/infra/basectl/src/tui/mod.rs
+++ b/crates/infra/basectl/src/tui/mod.rs
@@ -1,3 +1,5 @@
+//! Terminal UI framework: frame layout, keybindings, and terminal lifecycle.
+
 /// Application frame layout and help sidebar.
 mod app_frame;
 pub(crate) use app_frame::AppFrame;

--- a/crates/infra/based/src/healthcheck/mod.rs
+++ b/crates/infra/based/src/healthcheck/mod.rs
@@ -1,3 +1,5 @@
+//! Healthcheck service for the based daemon.
+
 use std::{
     sync::{
         Arc,

--- a/crates/proof/host/src/backend/mod.rs
+++ b/crates/proof/host/src/backend/mod.rs
@@ -1,3 +1,5 @@
+//! Host backend implementations for offline and online proof generation.
+
 mod offline;
 pub use offline::OfflineHostBackend;
 

--- a/crates/proof/host/src/kv/mod.rs
+++ b/crates/proof/host/src/kv/mod.rs
@@ -1,3 +1,5 @@
+//! Key-value store implementations for the proof host preimage oracle.
+
 use std::sync::Arc;
 
 use alloy_consensus::EMPTY_ROOT_HASH;

--- a/crates/txpool/src/builder/mod.rs
+++ b/crates/txpool/src/builder/mod.rs
@@ -1,3 +1,5 @@
+//! Builder RPC API server and associated metrics.
+
 mod rpc;
 pub use rpc::{BuilderApiImpl, BuilderApiServer};
 

--- a/crates/txpool/src/consumer/mod.rs
+++ b/crates/txpool/src/consumer/mod.rs
@@ -1,3 +1,5 @@
+//! Transaction pool consumer that processes pending transactions via broadcast.
+
 use std::sync::Arc;
 
 use reth_tasks::TaskExecutor;

--- a/crates/txpool/src/forwarder/mod.rs
+++ b/crates/txpool/src/forwarder/mod.rs
@@ -1,3 +1,5 @@
+//! Transaction forwarder that relays pool transactions to a remote RPC endpoint.
+
 use std::{sync::Arc, time::Duration};
 
 use jsonrpsee::http_client::HttpClientBuilder;


### PR DESCRIPTION
## Summary

Every `mod.rs` file is required to open with a `//!` module doc comment describing its contents, but 23 files were missing this comment entirely. This adds a concise `//!` doc comment to each of the affected files across the proof, consensus, infra, txpool, and execution crates. Fixes #1882.