### PR TITLE
feat(basectl): Add Proofs Monitoring View

### DIFF
--- a/crates/infra/basectl/src/app/core.rs
+++ b/crates/infra/basectl/src/app/core.rs
@@ -51,6 +51,7 @@ impl App {
             self.resources.toasts.poll();
             self.resources.conductor.poll();
             self.resources.validators.poll();
+            self.resources.proofs.poll();
             // When a conductor cluster is configured, bridge the Raft leader's
             // safe head into the DA tracker each tick.  The conductor poller
             // already queries `op_sync_status` from every node's CL, so the

--- a/crates/infra/basectl/src/app/resources.rs
+++ b/crates/infra/basectl/src/app/resources.rs
@@ -9,7 +9,7 @@ use crate::{
     config::{ChainConfig, ConductorNodeConfig},
     rpc::{
         BacklogFetchResult, BlockDaInfo, ConductorNodeStatus, L1BlockInfo, L1ConnectionMode,
-        TimestampedFlashblock, ValidatorNodeStatus,
+        ProofsSnapshot, TimestampedFlashblock, ValidatorNodeStatus,
     },
     tui::ToastState,
 };
@@ -112,6 +112,29 @@ impl ValidatorState {
     }
 }
 
+/// State for proof system monitoring (dispute games, anchor state).
+#[derive(Debug, Default)]
+pub(crate) struct ProofsState {
+    /// Most recent proof system snapshot.
+    pub snapshot: Option<ProofsSnapshot>,
+    rx: Option<mpsc::Receiver<ProofsSnapshot>>,
+}
+
+impl ProofsState {
+    /// Sets the channel for receiving proof system snapshots.
+    pub(crate) fn set_channel(&mut self, rx: mpsc::Receiver<ProofsSnapshot>) {
+        self.rx = Some(rx);
+    }
+
+    /// Drains the latest snapshot from the background poller.
+    pub(crate) fn poll(&mut self) {
+        let Some(ref mut rx) = self.rx else { return };
+        while let Ok(snapshot) = rx.try_recv() {
+            self.snapshot = Some(snapshot);
+        }
+    }
+}
+
 /// Shared resources available to all TUI views.
 #[derive(Debug)]
 pub(crate) struct Resources {
@@ -127,6 +150,8 @@ pub(crate) struct Resources {
     pub conductor: ConductorState,
     /// Validator node monitoring state.
     pub validators: ValidatorState,
+    /// Proof system monitoring state.
+    pub proofs: ProofsState,
     /// L1 system config fetched from the contract.
     pub system_config: Option<SystemConfig>,
     sys_config_rx: Option<mpsc::Receiver<SystemConfig>>,
@@ -186,6 +211,7 @@ impl Resources {
             toasts: ToastState::new(),
             conductor: ConductorState::default(),
             validators: ValidatorState::default(),
+            proofs: ProofsState::default(),
             system_config: None,
             sys_config_rx: None,
         }

--- a/crates/infra/basectl/src/app/router.rs
+++ b/crates/infra/basectl/src/app/router.rs
@@ -13,6 +13,8 @@ pub enum ViewId {
     Config,
     /// HA conductor cluster status monitor.
     Conductor,
+    /// Proof system monitor (dispute games, anchor state).
+    Proofs,
 }
 
 /// Manages view navigation history and the current active view.

--- a/crates/infra/basectl/src/app/runner.rs
+++ b/crates/infra/basectl/src/app/runner.rs
@@ -11,9 +11,10 @@ use crate::{
     l1_client::fetch_full_system_config,
     rpc::{
         BacklogFetchResult, BlockDaInfo, ConductorNodeStatus, L1BlockInfo, L1ConnectionMode,
-        TimestampedFlashblock, ValidatorNodeStatus, fetch_initial_backlog_with_progress,
-        run_block_fetcher, run_conductor_poller, run_flashblock_ws, run_flashblock_ws_timestamped,
-        run_l1_blob_watcher, run_safe_head_poller, run_validator_poller,
+        ProofsSnapshot, TimestampedFlashblock, ValidatorNodeStatus,
+        fetch_initial_backlog_with_progress, run_block_fetcher, run_conductor_poller,
+        run_flashblock_ws, run_flashblock_ws_timestamped, run_l1_blob_watcher,
+        run_proofs_poller, run_safe_head_poller, run_validator_poller,
     },
     tui::Toast,
 };
@@ -96,6 +97,7 @@ fn start_background_services(config: &ChainConfig, resources: &mut Resources) {
 
     tokio::spawn(fetch_initial_backlog_with_progress(config.rpc.to_string(), backlog_tx));
 
+    let proofs_toast_tx = toast_tx.clone();
     tokio::spawn(run_safe_head_poller(config.rpc.to_string(), sync_tx, toast_tx));
 
     let (sys_config_tx, sys_config_rx) = mpsc::channel::<SystemConfig>(1);
@@ -126,6 +128,18 @@ fn start_background_services(config: &ChainConfig, resources: &mut Resources) {
         let (validator_tx, validator_rx) = mpsc::channel::<Vec<ValidatorNodeStatus>>(4);
         resources.validators.set_channel(validator_rx);
         tokio::spawn(run_validator_poller(validator_nodes, validator_tx));
+    }
+
+    if let Some(proofs_config) = config.proofs.clone() {
+        let (proofs_tx, proofs_rx) = mpsc::channel::<ProofsSnapshot>(4);
+        resources.proofs.set_channel(proofs_rx);
+        tokio::spawn(run_proofs_poller(
+            proofs_config,
+            config.l1_rpc.clone(),
+            config.rpc.clone(),
+            proofs_tx,
+            proofs_toast_tx,
+        ));
     }
 }
 

--- a/crates/infra/basectl/src/app/runner.rs
+++ b/crates/infra/basectl/src/app/runner.rs
@@ -13,8 +13,8 @@ use crate::{
         BacklogFetchResult, BlockDaInfo, ConductorNodeStatus, L1BlockInfo, L1ConnectionMode,
         ProofsSnapshot, TimestampedFlashblock, ValidatorNodeStatus,
         fetch_initial_backlog_with_progress, run_block_fetcher, run_conductor_poller,
-        run_flashblock_ws, run_flashblock_ws_timestamped, run_l1_blob_watcher,
-        run_proofs_poller, run_safe_head_poller, run_validator_poller,
+        run_flashblock_ws, run_flashblock_ws_timestamped, run_l1_blob_watcher, run_proofs_poller,
+        run_safe_head_poller, run_validator_poller,
     },
     tui::Toast,
 };

--- a/crates/infra/basectl/src/app/views/factory.rs
+++ b/crates/infra/basectl/src/app/views/factory.rs
@@ -1,5 +1,6 @@
 use super::{
     CommandCenterView, ConductorView, ConfigView, DaMonitorView, FlashblocksView, HomeView,
+    ProofsView,
 };
 use crate::app::{View, ViewId};
 
@@ -12,5 +13,6 @@ pub(crate) fn create_view(view_id: ViewId) -> Box<dyn View> {
         ViewId::DaMonitor => Box::new(DaMonitorView::new()),
         ViewId::Flashblocks => Box::new(FlashblocksView::new()),
         ViewId::Config => Box::new(ConfigView::new()),
+        ViewId::Proofs => Box::new(ProofsView::new()),
     }
 }

--- a/crates/infra/basectl/src/app/views/home.rs
+++ b/crates/infra/basectl/src/app/views/home.rs
@@ -57,6 +57,12 @@ const MENU_ITEMS: &[MenuItem] = &[
         description: "Monitor HA conductor cluster",
         view_id: Some(ViewId::Conductor),
     },
+    MenuItem {
+        key: 'p',
+        label: "Proofs",
+        description: "Monitor dispute games and anchor state",
+        view_id: Some(ViewId::Proofs),
+    },
     MenuItem { key: 'q', label: "Quit", description: "Exit basectl", view_id: None },
 ];
 
@@ -66,6 +72,7 @@ const KEYBINDINGS: &[Keybinding] = &[
     Keybinding { key: "d", description: "DA Monitor" },
     Keybinding { key: "f", description: "Flashblocks" },
     Keybinding { key: "h", description: "HA Conductor" },
+    Keybinding { key: "p", description: "Proofs" },
     Keybinding { key: "j/k", description: "Navigate" },
     Keybinding { key: "Enter", description: "Select" },
     Keybinding { key: "q", description: "Quit" },
@@ -96,6 +103,7 @@ impl View for HomeView {
             KeyCode::Char('d') => Action::SwitchView(ViewId::DaMonitor),
             KeyCode::Char('f') => Action::SwitchView(ViewId::Flashblocks),
             KeyCode::Char('h') => Action::SwitchView(ViewId::Conductor),
+            KeyCode::Char('p') => Action::SwitchView(ViewId::Proofs),
             KeyCode::Up | KeyCode::Char('k') => {
                 self.selected_index = self.selected_index.saturating_sub(1);
                 Action::None

--- a/crates/infra/basectl/src/app/views/mod.rs
+++ b/crates/infra/basectl/src/app/views/mod.rs
@@ -19,5 +19,8 @@ pub(crate) use flashblocks::FlashblocksView;
 mod home;
 pub(crate) use home::HomeView;
 
+mod proofs;
+pub(crate) use proofs::ProofsView;
+
 mod transaction_pane;
 pub(crate) use transaction_pane::TransactionPane;

--- a/crates/infra/basectl/src/app/views/proofs.rs
+++ b/crates/infra/basectl/src/app/views/proofs.rs
@@ -64,10 +64,7 @@ fn render_unconfigured(frame: &mut Frame<'_>, area: Rect) {
             Style::default().fg(Color::DarkGray),
         )),
         Line::from(""),
-        Line::from(Span::styled(
-            "  proofs:",
-            Style::default().fg(Color::Cyan),
-        )),
+        Line::from(Span::styled("  proofs:", Style::default().fg(Color::Cyan))),
         Line::from(Span::styled(
             "    dispute_game_factory: \"0x...\"",
             Style::default().fg(Color::Cyan),
@@ -83,9 +80,7 @@ fn render_unconfigured(frame: &mut Frame<'_>, area: Rect) {
         .borders(Borders::ALL)
         .border_style(Style::default().fg(COLOR_BASE_BLUE));
 
-    let para = Paragraph::new(text)
-        .block(block)
-        .alignment(ratatui::layout::Alignment::Center);
+    let para = Paragraph::new(text).block(block).alignment(ratatui::layout::Alignment::Center);
     frame.render_widget(para, area);
 }
 
@@ -103,9 +98,7 @@ fn render_loading(frame: &mut Frame<'_>, area: Rect) {
         .borders(Borders::ALL)
         .border_style(Style::default().fg(COLOR_BASE_BLUE));
 
-    let para = Paragraph::new(text)
-        .block(block)
-        .alignment(ratatui::layout::Alignment::Center);
+    let para = Paragraph::new(text).block(block).alignment(ratatui::layout::Alignment::Center);
     frame.render_widget(para, area);
 }
 
@@ -142,20 +135,16 @@ fn render_chain_state(frame: &mut Frame<'_>, area: Rect, snapshot: &ProofsSnapsh
         kv_line("L1 block", &fmt_opt_block(snapshot.l1_block)),
         kv_line("L2 latest block", &fmt_opt_block(snapshot.l2_latest_block)),
         kv_line("L2 safe block", &fmt_opt_block(snapshot.l2_safe_block)),
-        kv_line(
-            "L2 finalized block",
-            &fmt_opt_block(snapshot.l2_finalized_block),
-        ),
+        kv_line("L2 finalized block", &fmt_opt_block(snapshot.l2_finalized_block)),
     ];
 
     frame.render_widget(Paragraph::new(lines).block(block), area);
 }
 
 fn render_anchor_state(frame: &mut Frame<'_>, area: Rect, snapshot: &ProofsSnapshot) {
-    let paused_str = snapshot.system_paused.map_or_else(
-        || "-".to_string(),
-        |p| if p { "Yes".to_string() } else { "No".to_string() },
-    );
+    let paused_str = snapshot
+        .system_paused
+        .map_or_else(|| "-".to_string(), |p| if p { "Yes".to_string() } else { "No".to_string() });
 
     let block = Block::default()
         .title(" Onchain Anchor State ")
@@ -165,25 +154,16 @@ fn render_anchor_state(frame: &mut Frame<'_>, area: Rect, snapshot: &ProofsSnaps
     let lines = vec![
         kv_line(
             "Respected game type",
-            &snapshot
-                .respected_game_type
-                .map_or_else(|| "-".to_string(), |g| g.to_string()),
+            &snapshot.respected_game_type.map_or_else(|| "-".to_string(), |g| g.to_string()),
         ),
         kv_line(
             "Total games",
-            &snapshot
-                .total_games
-                .map_or_else(|| "-".to_string(), format_number),
+            &snapshot.total_games.map_or_else(|| "-".to_string(), format_number),
         ),
-        kv_line(
-            "Anchor L2 block",
-            &fmt_opt_block(snapshot.anchor_l2_block),
-        ),
+        kv_line("Anchor L2 block", &fmt_opt_block(snapshot.anchor_l2_block)),
         kv_line(
             "Anchor root",
-            &snapshot
-                .anchor_root
-                .map_or_else(|| "-".to_string(), |r| format!("{r:#x}")),
+            &snapshot.anchor_root.map_or_else(|| "-".to_string(), |r| format!("{r:#x}")),
         ),
         kv_line("System paused", &paused_str),
     ];
@@ -248,10 +228,7 @@ fn render_sync_gaps(frame: &mut Frame<'_>, area: Rect, snapshot: &ProofsSnapshot
         .borders(Borders::ALL)
         .border_style(Style::default().fg(COLOR_BASE_BLUE));
 
-    let proposed_l2 = snapshot
-        .latest_proposal
-        .as_ref()
-        .map(|p| p.l2_block);
+    let proposed_l2 = snapshot.latest_proposal.as_ref().map(|p| p.l2_block);
     let safe = snapshot.l2_safe_block;
     let latest = snapshot.l2_latest_block;
     let anchor = snapshot.anchor_l2_block;
@@ -298,24 +275,15 @@ fn render_sync_gaps(frame: &mut Frame<'_>, area: Rect, snapshot: &ProofsSnapshot
 
 fn kv_line(label: &str, value: &str) -> Line<'static> {
     Line::from(vec![
-        Span::styled(
-            format!("  {label}: "),
-            Style::default().fg(Color::DarkGray),
-        ),
+        Span::styled(format!("  {label}: "), Style::default().fg(Color::DarkGray)),
         Span::styled(value.to_string(), Style::default().fg(Color::White)),
     ])
 }
 
 fn kv_line_colored(label: &str, value: &str, color: Color) -> Line<'static> {
     Line::from(vec![
-        Span::styled(
-            format!("  {label}: "),
-            Style::default().fg(Color::DarkGray),
-        ),
-        Span::styled(
-            value.to_string(),
-            Style::default().fg(color).add_modifier(Modifier::BOLD),
-        ),
+        Span::styled(format!("  {label}: "), Style::default().fg(Color::DarkGray)),
+        Span::styled(value.to_string(), Style::default().fg(color).add_modifier(Modifier::BOLD)),
     ])
 }
 
@@ -331,18 +299,12 @@ fn gap_line(label: &str, blocks: u64) -> Line<'static> {
     };
 
     Line::from(vec![
-        Span::styled(
-            format!("  {label}: "),
-            Style::default().fg(Color::DarkGray),
-        ),
+        Span::styled(format!("  {label}: "), Style::default().fg(Color::DarkGray)),
         Span::styled(
             format!("{} blocks", format_number(blocks)),
             Style::default().fg(color).add_modifier(Modifier::BOLD),
         ),
-        Span::styled(
-            format!("  (~{time_str})"),
-            Style::default().fg(Color::DarkGray),
-        ),
+        Span::styled(format!("  (~{time_str})"), Style::default().fg(Color::DarkGray)),
     ])
 }
 

--- a/crates/infra/basectl/src/app/views/proofs.rs
+++ b/crates/infra/basectl/src/app/views/proofs.rs
@@ -1,0 +1,382 @@
+use crossterm::event::KeyEvent;
+use ratatui::{
+    layout::{Constraint, Direction, Layout, Rect},
+    prelude::*,
+    widgets::{Block, Borders, Paragraph},
+};
+
+use crate::{
+    app::{Action, Resources, View},
+    commands::common::COLOR_BASE_BLUE,
+    rpc::{LatestProposal, ProofsSnapshot},
+    tui::Keybinding,
+};
+
+const KEYBINDINGS: &[Keybinding] = &[
+    Keybinding { key: "Esc", description: "Back to home" },
+    Keybinding { key: "?", description: "Toggle help" },
+];
+
+/// Proof system monitoring view showing dispute game state, anchor state,
+/// and sync gap analysis.
+#[derive(Debug, Default)]
+pub(crate) struct ProofsView;
+
+impl ProofsView {
+    /// Creates a new proofs view.
+    pub(crate) const fn new() -> Self {
+        Self
+    }
+}
+
+impl View for ProofsView {
+    fn keybindings(&self) -> &'static [Keybinding] {
+        KEYBINDINGS
+    }
+
+    fn handle_key(&mut self, _key: KeyEvent, _resources: &mut Resources) -> Action {
+        Action::None
+    }
+
+    fn render(&mut self, frame: &mut Frame<'_>, area: Rect, resources: &Resources) {
+        if resources.config.proofs.is_none() {
+            render_unconfigured(frame, area);
+            return;
+        }
+
+        match resources.proofs.snapshot {
+            Some(ref snapshot) => render_dashboard(frame, area, snapshot),
+            None => render_loading(frame, area),
+        }
+    }
+}
+
+fn render_unconfigured(frame: &mut Frame<'_>, area: Rect) {
+    let text = vec![
+        Line::from(""),
+        Line::from(Span::styled(
+            "Proofs monitoring is not configured.",
+            Style::default().fg(Color::DarkGray),
+        )),
+        Line::from(""),
+        Line::from(Span::styled(
+            "Add a [proofs] section to your chain config with:",
+            Style::default().fg(Color::DarkGray),
+        )),
+        Line::from(""),
+        Line::from(Span::styled(
+            "  proofs:",
+            Style::default().fg(Color::Cyan),
+        )),
+        Line::from(Span::styled(
+            "    dispute_game_factory: \"0x...\"",
+            Style::default().fg(Color::Cyan),
+        )),
+        Line::from(Span::styled(
+            "    anchor_state_registry: \"0x...\"",
+            Style::default().fg(Color::Cyan),
+        )),
+    ];
+
+    let block = Block::default()
+        .title(" Proofs ")
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(COLOR_BASE_BLUE));
+
+    let para = Paragraph::new(text)
+        .block(block)
+        .alignment(ratatui::layout::Alignment::Center);
+    frame.render_widget(para, area);
+}
+
+fn render_loading(frame: &mut Frame<'_>, area: Rect) {
+    let text = vec![
+        Line::from(""),
+        Line::from(Span::styled(
+            "Loading proof system state...",
+            Style::default().fg(Color::DarkGray),
+        )),
+    ];
+
+    let block = Block::default()
+        .title(" Proofs ")
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(COLOR_BASE_BLUE));
+
+    let para = Paragraph::new(text)
+        .block(block)
+        .alignment(ratatui::layout::Alignment::Center);
+    frame.render_widget(para, area);
+}
+
+fn render_dashboard(frame: &mut Frame<'_>, area: Rect, snapshot: &ProofsSnapshot) {
+    // 2x2 grid layout.
+    let rows = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([Constraint::Percentage(50), Constraint::Percentage(50)])
+        .split(area);
+
+    let top_cols = Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints([Constraint::Percentage(50), Constraint::Percentage(50)])
+        .split(rows[0]);
+
+    let bottom_cols = Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints([Constraint::Percentage(50), Constraint::Percentage(50)])
+        .split(rows[1]);
+
+    render_chain_state(frame, top_cols[0], snapshot);
+    render_anchor_state(frame, top_cols[1], snapshot);
+    render_latest_proposal(frame, bottom_cols[0], snapshot);
+    render_sync_gaps(frame, bottom_cols[1], snapshot);
+}
+
+fn render_chain_state(frame: &mut Frame<'_>, area: Rect, snapshot: &ProofsSnapshot) {
+    let block = Block::default()
+        .title(" Chain State ")
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(COLOR_BASE_BLUE));
+
+    let lines = vec![
+        kv_line("L1 block", &fmt_opt_block(snapshot.l1_block)),
+        kv_line("L2 latest block", &fmt_opt_block(snapshot.l2_latest_block)),
+        kv_line("L2 safe block", &fmt_opt_block(snapshot.l2_safe_block)),
+        kv_line(
+            "L2 finalized block",
+            &fmt_opt_block(snapshot.l2_finalized_block),
+        ),
+    ];
+
+    frame.render_widget(Paragraph::new(lines).block(block), area);
+}
+
+fn render_anchor_state(frame: &mut Frame<'_>, area: Rect, snapshot: &ProofsSnapshot) {
+    let paused_str = snapshot.system_paused.map_or_else(
+        || "-".to_string(),
+        |p| if p { "Yes".to_string() } else { "No".to_string() },
+    );
+
+    let block = Block::default()
+        .title(" Onchain Anchor State ")
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(COLOR_BASE_BLUE));
+
+    let lines = vec![
+        kv_line(
+            "Respected game type",
+            &snapshot
+                .respected_game_type
+                .map_or_else(|| "-".to_string(), |g| g.to_string()),
+        ),
+        kv_line(
+            "Total games",
+            &snapshot
+                .total_games
+                .map_or_else(|| "-".to_string(), format_number),
+        ),
+        kv_line(
+            "Anchor L2 block",
+            &fmt_opt_block(snapshot.anchor_l2_block),
+        ),
+        kv_line(
+            "Anchor root",
+            &snapshot
+                .anchor_root
+                .map_or_else(|| "-".to_string(), |r| format!("{r:#x}")),
+        ),
+        kv_line("System paused", &paused_str),
+    ];
+
+    frame.render_widget(Paragraph::new(lines).block(block), area);
+}
+
+fn render_latest_proposal(frame: &mut Frame<'_>, area: Rect, snapshot: &ProofsSnapshot) {
+    let title = snapshot.respected_game_type.map_or_else(
+        || " Latest Proposal ".to_string(),
+        |gt| format!(" Latest Proposal (game type {gt}) "),
+    );
+
+    let block = Block::default()
+        .title(title)
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(COLOR_BASE_BLUE));
+
+    let lines = snapshot.latest_proposal.as_ref().map_or_else(
+        || {
+            vec![Line::from(Span::styled(
+                "  No proposals found",
+                Style::default().fg(Color::DarkGray),
+            ))]
+        },
+        render_proposal_lines,
+    );
+
+    frame.render_widget(Paragraph::new(lines).block(block), area);
+}
+
+fn render_proposal_lines(proposal: &LatestProposal) -> Vec<Line<'static>> {
+    let status_str = match proposal.status {
+        0 => "IN_PROGRESS",
+        1 => "CHALLENGER_WINS",
+        2 => "DEFENDER_WINS",
+        _ => "UNKNOWN",
+    };
+
+    let status_color = match proposal.status {
+        0 => Color::Yellow,
+        1 => Color::Red,
+        2 => Color::Green,
+        _ => Color::DarkGray,
+    };
+
+    let created_str = chrono::DateTime::from_timestamp(proposal.created_at as i64, 0)
+        .map_or_else(|| "-".to_string(), |dt| dt.format("%Y-%m-%d %H:%M:%S UTC").to_string());
+
+    vec![
+        kv_line("Game address", &format!("{:#x}", proposal.game_address)),
+        kv_line("Proposed L2 block", &format_number(proposal.l2_block)),
+        kv_line("Root claim", &format!("{:#x}", proposal.root_claim)),
+        kv_line_colored("Status", status_str, status_color),
+        kv_line("Created at", &created_str),
+    ]
+}
+
+fn render_sync_gaps(frame: &mut Frame<'_>, area: Rect, snapshot: &ProofsSnapshot) {
+    let block = Block::default()
+        .title(" Sync Gaps ")
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(COLOR_BASE_BLUE));
+
+    let proposed_l2 = snapshot
+        .latest_proposal
+        .as_ref()
+        .map(|p| p.l2_block);
+    let safe = snapshot.l2_safe_block;
+    let latest = snapshot.l2_latest_block;
+    let anchor = snapshot.anchor_l2_block;
+
+    let mut lines = Vec::new();
+
+    // Proposer behind safe head.
+    if let (Some(proposed), Some(safe_block)) = (proposed_l2, safe) {
+        let gap = safe_block.saturating_sub(proposed);
+        lines.push(gap_line("Proposer behind safe head", gap));
+    }
+
+    // Proposer behind latest head.
+    if let (Some(proposed), Some(latest_block)) = (proposed_l2, latest) {
+        let gap = latest_block.saturating_sub(proposed);
+        lines.push(gap_line("Proposer behind latest head", gap));
+    }
+
+    // Anchor behind latest proposal.
+    if let (Some(anchor_block), Some(proposed)) = (anchor, proposed_l2) {
+        let gap = proposed.saturating_sub(anchor_block);
+        lines.push(gap_line("Anchor behind latest proposal", gap));
+    }
+
+    // Anchor behind safe head.
+    if let (Some(anchor_block), Some(safe_block)) = (anchor, safe) {
+        let gap = safe_block.saturating_sub(anchor_block);
+        lines.push(gap_line("Anchor behind safe head", gap));
+    }
+
+    if lines.is_empty() {
+        lines.push(Line::from(Span::styled(
+            "  Insufficient data to compute gaps",
+            Style::default().fg(Color::DarkGray),
+        )));
+    }
+
+    frame.render_widget(Paragraph::new(lines).block(block), area);
+}
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+fn kv_line(label: &str, value: &str) -> Line<'static> {
+    Line::from(vec![
+        Span::styled(
+            format!("  {label}: "),
+            Style::default().fg(Color::DarkGray),
+        ),
+        Span::styled(value.to_string(), Style::default().fg(Color::White)),
+    ])
+}
+
+fn kv_line_colored(label: &str, value: &str, color: Color) -> Line<'static> {
+    Line::from(vec![
+        Span::styled(
+            format!("  {label}: "),
+            Style::default().fg(Color::DarkGray),
+        ),
+        Span::styled(
+            value.to_string(),
+            Style::default().fg(color).add_modifier(Modifier::BOLD),
+        ),
+    ])
+}
+
+fn gap_line(label: &str, blocks: u64) -> Line<'static> {
+    let time_str = format_duration_from_blocks(blocks);
+
+    let color = if blocks > 50_000 {
+        Color::Red
+    } else if blocks > 10_000 {
+        Color::Yellow
+    } else {
+        Color::Green
+    };
+
+    Line::from(vec![
+        Span::styled(
+            format!("  {label}: "),
+            Style::default().fg(Color::DarkGray),
+        ),
+        Span::styled(
+            format!("{} blocks", format_number(blocks)),
+            Style::default().fg(color).add_modifier(Modifier::BOLD),
+        ),
+        Span::styled(
+            format!("  (~{time_str})"),
+            Style::default().fg(Color::DarkGray),
+        ),
+    ])
+}
+
+fn fmt_opt_block(val: Option<u64>) -> String {
+    val.map_or_else(|| "-".to_string(), format_number)
+}
+
+fn format_number(n: u64) -> String {
+    let s = n.to_string();
+    let mut result = String::with_capacity(s.len() + s.len() / 3);
+    for (i, c) in s.chars().rev().enumerate() {
+        if i > 0 && i % 3 == 0 {
+            result.push(',');
+        }
+        result.push(c);
+    }
+    result.chars().rev().collect()
+}
+
+/// Estimates wall-clock duration from a block count using 2-second L2 block time.
+fn format_duration_from_blocks(blocks: u64) -> String {
+    let total_seconds = blocks * 2;
+    let days = total_seconds / 86400;
+    let hours = (total_seconds % 86400) / 3600;
+    let minutes = (total_seconds % 3600) / 60;
+    let seconds = total_seconds % 60;
+
+    if days > 0 {
+        format!("{days}d {hours}h {minutes}m")
+    } else if hours > 0 {
+        format!("{hours}h {minutes}m")
+    } else if minutes > 0 {
+        format!("{minutes}m {seconds}s")
+    } else {
+        format!("{seconds}s")
+    }
+}

--- a/crates/infra/basectl/src/config.rs
+++ b/crates/infra/basectl/src/config.rs
@@ -8,6 +8,15 @@ use base_consensus_registry::Registry;
 use serde::{Deserialize, Serialize};
 use url::Url;
 
+/// Configuration for proof system monitoring (proposer + dispute games).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ProofsConfig {
+    /// Address of the `DisputeGameFactory` contract on L1.
+    pub dispute_game_factory: Address,
+    /// Address of the `AnchorStateRegistry` contract on L1.
+    pub anchor_state_registry: Address,
+}
+
 /// Configuration for a single validator (non-sequencing) node in the local devnet.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ValidatorNodeConfig {
@@ -108,6 +117,9 @@ pub struct ChainConfig {
     /// Validator (non-sequencing) nodes to monitor alongside the conductor cluster.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub validators: Option<Vec<ValidatorNodeConfig>>,
+    /// Proof system monitoring configuration (dispute games, anchor state).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub proofs: Option<ProofsConfig>,
 }
 
 impl ChainConfig {
@@ -148,6 +160,7 @@ struct ChainConfigOverride {
     l1_blob_target: Option<u64>,
     conductors: Option<Vec<ConductorNodeConfig>>,
     validators: Option<Vec<ValidatorNodeConfig>>,
+    proofs: Option<ProofsConfig>,
 }
 
 impl ChainConfig {
@@ -166,6 +179,7 @@ impl ChainConfig {
             l1_blob_target: 14,
             conductors: None,
             validators: None,
+            proofs: None,
         }
     }
 
@@ -184,6 +198,7 @@ impl ChainConfig {
             l1_blob_target: 14,
             conductors: None,
             validators: None,
+            proofs: None,
         }
     }
 
@@ -251,6 +266,7 @@ impl ChainConfig {
                 docker_el: Some("base-client".to_string()),
                 docker_cl: Some("base-client-cl".to_string()),
             }]),
+            proofs: None,
         }
     }
 
@@ -355,6 +371,7 @@ impl ChainConfig {
             l1_blob_target: overrides.l1_blob_target.unwrap_or(base.l1_blob_target),
             conductors: overrides.conductors.or(base.conductors),
             validators: overrides.validators.or(base.validators),
+            proofs: overrides.proofs.or(base.proofs),
         })
     }
 

--- a/crates/infra/basectl/src/lib.rs
+++ b/crates/infra/basectl/src/lib.rs
@@ -5,7 +5,7 @@ pub use app::{ViewId, run_app, run_app_with_view, run_flashblocks_json};
 
 mod commands;
 mod config;
-pub use config::{ChainConfig, ConductorNodeConfig, ValidatorNodeConfig};
+pub use config::{ChainConfig, ConductorNodeConfig, ProofsConfig, ValidatorNodeConfig};
 
 mod l1_client;
 mod rpc;

--- a/crates/infra/basectl/src/rpc.rs
+++ b/crates/infra/basectl/src/rpc.rs
@@ -5,6 +5,7 @@ use alloy_eips::eip2718::{Decodable2718, Encodable2718};
 use alloy_primitives::{Address, B256, Bytes};
 use alloy_provider::{Provider, ProviderBuilder, network::TransactionResponse};
 use alloy_rpc_types_eth::BlockNumberOrTag;
+use alloy_sol_types::sol;
 use anyhow::Result;
 use base_alloy_consensus::OpTxEnvelope;
 use base_alloy_flashblocks::Flashblock;
@@ -15,8 +16,6 @@ use jsonrpsee::{core::client::ClientT, http_client::HttpClientBuilder, rpc_param
 use tokio::sync::{mpsc, watch};
 use tokio_tungstenite::connect_async;
 use tracing::warn;
-
-use alloy_sol_types::sol;
 use url::Url;
 
 use crate::{
@@ -1320,14 +1319,8 @@ pub(crate) async fn run_proofs_poller(
         }
     };
 
-    let asr = IAnchorStateRegistry::new(
-        proofs_config.anchor_state_registry,
-        &*l1_provider,
-    );
-    let factory = IDisputeGameFactory::new(
-        proofs_config.dispute_game_factory,
-        &*l1_provider,
-    );
+    let asr = IAnchorStateRegistry::new(proofs_config.anchor_state_registry, &*l1_provider);
+    let factory = IDisputeGameFactory::new(proofs_config.dispute_game_factory, &*l1_provider);
 
     let mut interval = tokio::time::interval(Duration::from_secs(10));
     loop {
@@ -1373,9 +1366,7 @@ async fn fetch_proofs_snapshot<P: Provider + Clone>(
         respected_game_type: respected_type,
         system_paused: paused,
         total_games,
-        anchor_l2_block: anchor.as_ref().map(|a| {
-            a.l2SequenceNumber.try_into().unwrap_or(0)
-        }),
+        anchor_l2_block: anchor.as_ref().map(|a| a.l2SequenceNumber.try_into().unwrap_or(0)),
         anchor_root: anchor.map(|a| a.root),
         latest_proposal,
     }
@@ -1428,11 +1419,7 @@ async fn find_latest_proposal<P: Provider + Clone>(
     let scan_end = count.saturating_sub(50);
 
     for idx in (scan_end..=scan_start).rev() {
-        let game = factory
-            .gameAtIndex(alloy_primitives::U256::from(idx))
-            .call()
-            .await
-            .ok()?;
+        let game = factory.gameAtIndex(alloy_primitives::U256::from(idx)).call().await.ok()?;
 
         if game.gameType != game_type {
             continue;
@@ -1449,9 +1436,7 @@ async fn find_latest_proposal<P: Provider + Clone>(
 
         return Some(LatestProposal {
             game_address: game.proxy,
-            l2_block: l2_seq
-                .and_then(|s| s.try_into().ok())
-                .unwrap_or(0),
+            l2_block: l2_seq.and_then(|s| s.try_into().ok()).unwrap_or(0),
             root_claim: root_claim.unwrap_or_default(),
             status: status.unwrap_or(0),
             created_at: game.timestamp,

--- a/crates/infra/basectl/src/rpc.rs
+++ b/crates/infra/basectl/src/rpc.rs
@@ -16,8 +16,11 @@ use tokio::sync::{mpsc, watch};
 use tokio_tungstenite::connect_async;
 use tracing::warn;
 
+use alloy_sol_types::sol;
+use url::Url;
+
 use crate::{
-    config::{ConductorNodeConfig, ValidatorNodeConfig},
+    config::{ConductorNodeConfig, ProofsConfig, ValidatorNodeConfig},
     tui::Toast,
 };
 
@@ -1220,6 +1223,242 @@ pub(crate) async fn run_validator_poller(
             break;
         }
     }
+}
+
+// =============================================================================
+// Proof system contract interfaces
+// =============================================================================
+
+sol! {
+    #[sol(rpc)]
+    interface IAnchorStateRegistry {
+        function getAnchorRoot() external view returns (bytes32 root, uint256 l2SequenceNumber);
+        function respectedGameType() external view returns (uint32);
+        function paused() external view returns (bool);
+    }
+
+    #[sol(rpc)]
+    interface IDisputeGameFactory {
+        function gameCount() external view returns (uint256);
+        function gameAtIndex(uint256 index) external view returns (
+            uint32 gameType, uint64 timestamp, address proxy
+        );
+    }
+
+    #[sol(rpc)]
+    interface IAggregateVerifier {
+        function rootClaim() external pure returns (bytes32);
+        function l2SequenceNumber() external pure returns (uint256);
+        function status() external view returns (uint8);
+    }
+}
+
+/// Snapshot of proof system state, fetched periodically.
+#[derive(Debug, Clone)]
+pub(crate) struct ProofsSnapshot {
+    /// Current L1 block number.
+    pub l1_block: Option<u64>,
+    /// Current L2 latest (unsafe) block number.
+    pub l2_latest_block: Option<u64>,
+    /// Current L2 safe block number.
+    pub l2_safe_block: Option<u64>,
+    /// Current L2 finalized block number.
+    pub l2_finalized_block: Option<u64>,
+    /// Respected game type from the `AnchorStateRegistry`.
+    pub respected_game_type: Option<u32>,
+    /// Whether the proof system is paused.
+    pub system_paused: Option<bool>,
+    /// Total number of dispute games created.
+    pub total_games: Option<u64>,
+    /// Anchor L2 block number (latest finalized anchor).
+    pub anchor_l2_block: Option<u64>,
+    /// Anchor output root hash.
+    pub anchor_root: Option<B256>,
+    /// Most recent dispute game proposal.
+    pub latest_proposal: Option<LatestProposal>,
+}
+
+/// Information about the most recent dispute game proposal.
+#[derive(Debug, Clone)]
+pub(crate) struct LatestProposal {
+    /// Address of the dispute game proxy contract.
+    pub game_address: Address,
+    /// L2 block number proposed.
+    pub l2_block: u64,
+    /// Output root claimed by the proposal.
+    pub root_claim: B256,
+    /// Game status: `0`=`IN_PROGRESS`, `1`=`CHALLENGER_WINS`, `2`=`DEFENDER_WINS`.
+    pub status: u8,
+    /// L1 timestamp when the game was created.
+    pub created_at: u64,
+}
+
+/// Polls proof system state (anchor state, dispute games, chain heads) at regular
+/// intervals and sends snapshots to the TUI.
+pub(crate) async fn run_proofs_poller(
+    proofs_config: ProofsConfig,
+    l1_rpc: Url,
+    l2_rpc: Url,
+    tx: mpsc::Sender<ProofsSnapshot>,
+    toast_tx: mpsc::Sender<Toast>,
+) {
+    let l1_provider = match ProviderBuilder::new().connect(l1_rpc.as_str()).await {
+        Ok(p) => Arc::new(p),
+        Err(e) => {
+            warn!(error = %e, "Failed to connect to L1 RPC for proofs poller");
+            let _ = toast_tx.try_send(Toast::warning("Proofs: L1 connection failed"));
+            return;
+        }
+    };
+
+    let l2_provider = match ProviderBuilder::new().connect(l2_rpc.as_str()).await {
+        Ok(p) => p,
+        Err(e) => {
+            warn!(error = %e, "Failed to connect to L2 RPC for proofs poller");
+            let _ = toast_tx.try_send(Toast::warning("Proofs: L2 connection failed"));
+            return;
+        }
+    };
+
+    let asr = IAnchorStateRegistry::new(
+        proofs_config.anchor_state_registry,
+        &*l1_provider,
+    );
+    let factory = IDisputeGameFactory::new(
+        proofs_config.dispute_game_factory,
+        &*l1_provider,
+    );
+
+    let mut interval = tokio::time::interval(Duration::from_secs(10));
+    loop {
+        interval.tick().await;
+
+        let snapshot = fetch_proofs_snapshot(&asr, &factory, &l1_provider, &l2_provider).await;
+
+        if tx.send(snapshot).await.is_err() {
+            break;
+        }
+    }
+}
+
+async fn fetch_proofs_snapshot<P: Provider + Clone>(
+    asr: &IAnchorStateRegistry::IAnchorStateRegistryInstance<&P>,
+    factory: &IDisputeGameFactory::IDisputeGameFactoryInstance<&P>,
+    l1_provider: &P,
+    l2_provider: &impl Provider,
+) -> ProofsSnapshot {
+    // Fetch chain state and contract state concurrently.
+    let (chain, anchor, game_type, paused, game_count) = tokio::join!(
+        fetch_chain_heads(l1_provider, l2_provider),
+        async { asr.getAnchorRoot().call().await.ok() },
+        async { asr.respectedGameType().call().await.ok() },
+        async { asr.paused().call().await.ok() },
+        async { factory.gameCount().call().await.ok() },
+    );
+
+    let (l1_block, l2_latest, l2_safe, l2_finalized) = chain;
+
+    let total_games: Option<u64> = game_count.and_then(|c| c.try_into().ok());
+    let respected_type = game_type;
+
+    // Find and query the latest proposal for the respected game type.
+    let latest_proposal =
+        find_latest_proposal(factory, l1_provider, respected_type, total_games).await;
+
+    ProofsSnapshot {
+        l1_block,
+        l2_latest_block: l2_latest,
+        l2_safe_block: l2_safe,
+        l2_finalized_block: l2_finalized,
+        respected_game_type: respected_type,
+        system_paused: paused,
+        total_games,
+        anchor_l2_block: anchor.as_ref().map(|a| {
+            a.l2SequenceNumber.try_into().unwrap_or(0)
+        }),
+        anchor_root: anchor.map(|a| a.root),
+        latest_proposal,
+    }
+}
+
+async fn fetch_chain_heads(
+    l1: &impl Provider,
+    l2: &impl Provider,
+) -> (Option<u64>, Option<u64>, Option<u64>, Option<u64>) {
+    let (l1_block, l2_latest, l2_safe, l2_finalized) = tokio::join!(
+        async { l1.get_block_number().await.ok() },
+        async {
+            l2.get_block_by_number(BlockNumberOrTag::Latest)
+                .await
+                .ok()
+                .flatten()
+                .map(|b| b.header.number)
+        },
+        async {
+            l2.get_block_by_number(BlockNumberOrTag::Safe)
+                .await
+                .ok()
+                .flatten()
+                .map(|b| b.header.number)
+        },
+        async {
+            l2.get_block_by_number(BlockNumberOrTag::Finalized)
+                .await
+                .ok()
+                .flatten()
+                .map(|b| b.header.number)
+        },
+    );
+    (l1_block, l2_latest, l2_safe, l2_finalized)
+}
+
+/// Scans the most recent games in the factory to find the latest one matching the
+/// respected game type, then queries its details from the `AggregateVerifier`.
+async fn find_latest_proposal<P: Provider + Clone>(
+    factory: &IDisputeGameFactory::IDisputeGameFactoryInstance<&P>,
+    l1_provider: &P,
+    respected_type: Option<u32>,
+    total_games: Option<u64>,
+) -> Option<LatestProposal> {
+    let game_type = respected_type?;
+    let count = total_games.filter(|&c| c > 0)?;
+
+    // Scan backwards from the most recent game (max 50 games).
+    let scan_start = count - 1;
+    let scan_end = count.saturating_sub(50);
+
+    for idx in (scan_end..=scan_start).rev() {
+        let game = factory
+            .gameAtIndex(alloy_primitives::U256::from(idx))
+            .call()
+            .await
+            .ok()?;
+
+        if game.gameType != game_type {
+            continue;
+        }
+
+        // Found a matching game — query its details.
+        let verifier = IAggregateVerifier::new(game.proxy, l1_provider);
+
+        let (root_claim, l2_seq, status) = tokio::join!(
+            async { verifier.rootClaim().call().await.ok() },
+            async { verifier.l2SequenceNumber().call().await.ok() },
+            async { verifier.status().call().await.ok() },
+        );
+
+        return Some(LatestProposal {
+            game_address: game.proxy,
+            l2_block: l2_seq
+                .and_then(|s| s.try_into().ok())
+                .unwrap_or(0),
+            root_claim: root_claim.unwrap_or_default(),
+            status: status.unwrap_or(0),
+            created_at: game.timestamp,
+        });
+    }
+
+    None
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

Adds a proof system monitoring view to basectl. A background poller queries the `AnchorStateRegistry` and `DisputeGameFactory` contracts on L1 alongside L2 chain heads every 10 seconds. The new `ProofsView` renders a 2×2 dashboard showing chain state, onchain anchor state, the latest dispute game proposal with status coloring, and sync gap analysis between the proposer, anchor, safe head, and latest head. The view is gated behind an optional `[proofs]` section in the chain config — if unconfigured, a setup hint is shown instead.

<img width="1040" height="739" alt="Screenshot 2026-04-03 at 9 04 00 AM" src="https://github.com/user-attachments/assets/d627c54a-fe8f-44c3-8640-5c3eb6f96abb" />
