### PR TITLE
chore(consensus): Move Fee Params To Methods

### DIFF
--- a/crates/consensus/genesis/src/chain/config.rs
+++ b/crates/consensus/genesis/src/chain/config.rs
@@ -8,7 +8,7 @@ use alloy_primitives::Address;
 
 use crate::{
     AddressList, BaseFeeConfig, ChainGenesis, GRANITE_CHANNEL_TIMEOUT, HardForkConfig, Roles,
-    RollupConfig, base_fee_params, base_fee_params_canyon, params::base_fee_config,
+    RollupConfig,
 };
 
 /// L1 chain configuration from the `alloy-genesis` crate.
@@ -99,7 +99,7 @@ impl ChainConfig {
         self.optimism
             .as_ref()
             .map(|op| op.pre_canyon_params())
-            .unwrap_or_else(|| base_fee_params(self.chain_id))
+            .unwrap_or_else(|| BaseFeeConfig::from_chain_id(self.chain_id).pre_canyon_params())
     }
 
     /// Returns the canyon base fee params for the chain.
@@ -107,12 +107,15 @@ impl ChainConfig {
         self.optimism
             .as_ref()
             .map(|op| op.post_canyon_params())
-            .unwrap_or_else(|| base_fee_params_canyon(self.chain_id))
+            .unwrap_or_else(|| BaseFeeConfig::from_chain_id(self.chain_id).post_canyon_params())
     }
 
     /// Returns the base fee config for the chain.
     pub fn base_fee_config(&self) -> BaseFeeConfig {
-        self.optimism.as_ref().map(|op| *op).unwrap_or_else(|| base_fee_config(self.chain_id))
+        self.optimism
+            .as_ref()
+            .copied()
+            .unwrap_or_else(|| BaseFeeConfig::from_chain_id(self.chain_id))
     }
 
     /// Loads the rollup config for the Base chain given the chain config and address list.

--- a/crates/consensus/genesis/src/lib.rs
+++ b/crates/consensus/genesis/src/lib.rs
@@ -10,7 +10,7 @@
 extern crate alloc;
 
 mod params;
-pub use params::{BaseFeeConfig, base_fee_config, base_fee_params, base_fee_params_canyon};
+pub use params::BaseFeeConfig;
 
 mod updates;
 pub use updates::{

--- a/crates/consensus/genesis/src/params.rs
+++ b/crates/consensus/genesis/src/params.rs
@@ -75,7 +75,10 @@ mod tests {
             sepolia.pre_canyon_params()
         );
         // Unknown chain IDs fall back to Base Mainnet params
-        assert_eq!(BaseFeeConfig::from_chain_id(0).pre_canyon_params(), mainnet.pre_canyon_params());
+        assert_eq!(
+            BaseFeeConfig::from_chain_id(0).pre_canyon_params(),
+            mainnet.pre_canyon_params()
+        );
     }
 
     #[test]
@@ -91,7 +94,10 @@ mod tests {
             BaseFeeConfig::from_chain_id(BaseChainConfig::sepolia().chain_id).post_canyon_params(),
             sepolia.post_canyon_params()
         );
-        assert_eq!(BaseFeeConfig::from_chain_id(0).post_canyon_params(), mainnet.post_canyon_params());
+        assert_eq!(
+            BaseFeeConfig::from_chain_id(0).post_canyon_params(),
+            mainnet.post_canyon_params()
+        );
     }
 
     #[test]

--- a/crates/consensus/genesis/src/params.rs
+++ b/crates/consensus/genesis/src/params.rs
@@ -3,22 +3,6 @@
 use alloy_eips::eip1559::BaseFeeParams;
 use base_alloy_chains::BaseChainConfig;
 
-/// Returns the [`BaseFeeParams`] for the given chain id.
-pub fn base_fee_params(chain_id: u64) -> BaseFeeParams {
-    base_fee_config(chain_id).pre_canyon_params()
-}
-
-/// Returns the [`BaseFeeParams`] for the given chain id, for Canyon hardfork.
-pub fn base_fee_params_canyon(chain_id: u64) -> BaseFeeParams {
-    base_fee_config(chain_id).post_canyon_params()
-}
-
-/// Returns the [`BaseFeeConfig`] for the given chain id.
-pub fn base_fee_config(chain_id: u64) -> BaseFeeConfig {
-    let cfg = BaseChainConfig::by_chain_id(chain_id).unwrap_or(BaseChainConfig::mainnet());
-    BaseFeeConfig::from(cfg)
-}
-
 /// Base Fee Config.
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
@@ -45,9 +29,15 @@ pub struct BaseFeeConfig {
 }
 
 impl BaseFeeConfig {
+    /// Returns the [`BaseFeeConfig`] for the given chain id.
+    pub fn from_chain_id(chain_id: u64) -> Self {
+        let cfg = BaseChainConfig::by_chain_id(chain_id).unwrap_or(BaseChainConfig::mainnet());
+        Self::from(cfg)
+    }
+
     /// Returns the Base Mainnet base fee config (used as serde default).
     pub fn base_mainnet() -> Self {
-        base_fee_config(BaseChainConfig::mainnet().chain_id)
+        Self::from_chain_id(BaseChainConfig::mainnet().chain_id)
     }
 
     /// Returns the [`BaseFeeParams`] before Canyon hardfork.
@@ -73,41 +63,41 @@ mod tests {
 
     #[test]
     fn test_base_fee_params_from_chain_id() {
-        let mainnet = base_fee_config(BaseChainConfig::mainnet().chain_id);
-        let sepolia = base_fee_config(BaseChainConfig::sepolia().chain_id);
+        let mainnet = BaseFeeConfig::from_chain_id(BaseChainConfig::mainnet().chain_id);
+        let sepolia = BaseFeeConfig::from_chain_id(BaseChainConfig::sepolia().chain_id);
 
         assert_eq!(
-            base_fee_params(BaseChainConfig::mainnet().chain_id),
+            BaseFeeConfig::from_chain_id(BaseChainConfig::mainnet().chain_id).pre_canyon_params(),
             mainnet.pre_canyon_params()
         );
         assert_eq!(
-            base_fee_params(BaseChainConfig::sepolia().chain_id),
+            BaseFeeConfig::from_chain_id(BaseChainConfig::sepolia().chain_id).pre_canyon_params(),
             sepolia.pre_canyon_params()
         );
         // Unknown chain IDs fall back to Base Mainnet params
-        assert_eq!(base_fee_params(0), mainnet.pre_canyon_params());
+        assert_eq!(BaseFeeConfig::from_chain_id(0).pre_canyon_params(), mainnet.pre_canyon_params());
     }
 
     #[test]
     fn test_base_fee_params_canyon_from_chain_id() {
-        let mainnet = base_fee_config(BaseChainConfig::mainnet().chain_id);
-        let sepolia = base_fee_config(BaseChainConfig::sepolia().chain_id);
+        let mainnet = BaseFeeConfig::from_chain_id(BaseChainConfig::mainnet().chain_id);
+        let sepolia = BaseFeeConfig::from_chain_id(BaseChainConfig::sepolia().chain_id);
 
         assert_eq!(
-            base_fee_params_canyon(BaseChainConfig::mainnet().chain_id),
+            BaseFeeConfig::from_chain_id(BaseChainConfig::mainnet().chain_id).post_canyon_params(),
             mainnet.post_canyon_params()
         );
         assert_eq!(
-            base_fee_params_canyon(BaseChainConfig::sepolia().chain_id),
+            BaseFeeConfig::from_chain_id(BaseChainConfig::sepolia().chain_id).post_canyon_params(),
             sepolia.post_canyon_params()
         );
-        assert_eq!(base_fee_params_canyon(0), mainnet.post_canyon_params());
+        assert_eq!(BaseFeeConfig::from_chain_id(0).post_canyon_params(), mainnet.post_canyon_params());
     }
 
     #[test]
     #[cfg(feature = "serde")]
     fn test_base_fee_config_ser() {
-        let config = base_fee_config(BaseChainConfig::mainnet().chain_id);
+        let config = BaseFeeConfig::from_chain_id(BaseChainConfig::mainnet().chain_id);
         let raw_str = serde_json::to_string(&config).unwrap();
         assert_eq!(
             raw_str,
@@ -121,6 +111,6 @@ mod tests {
         let raw_str: &'static str =
             r#"{"eip1559Elasticity":6,"eip1559Denominator":50,"eip1559DenominatorCanyon":250}"#;
         let config: BaseFeeConfig = serde_json::from_str(raw_str).unwrap();
-        assert_eq!(config, base_fee_config(BaseChainConfig::mainnet().chain_id));
+        assert_eq!(config, BaseFeeConfig::from_chain_id(BaseChainConfig::mainnet().chain_id));
     }
 }

--- a/crates/consensus/genesis/src/rollup.rs
+++ b/crates/consensus/genesis/src/rollup.rs
@@ -5,7 +5,7 @@ use alloy_hardforks::{EthereumHardfork, EthereumHardforks, ForkCondition};
 use alloy_primitives::Address;
 use base_alloy_chains::{BaseUpgrade, BaseUpgrades};
 
-use crate::{BaseFeeConfig, ChainGenesis, HardForkConfig, base_fee_config};
+use crate::{BaseFeeConfig, ChainGenesis, HardForkConfig};
 
 /// The max rlp bytes per channel for the Bedrock hardfork.
 pub const MAX_RLP_BYTES_PER_CHANNEL_BEDROCK: u64 = 10_000_000;
@@ -122,7 +122,7 @@ impl Default for RollupConfig {
             l1_system_config_address: Address::ZERO,
             protocol_versions_address: Address::ZERO,
             blobs_enabled_l1_timestamp: None,
-            chain_op_config: base_fee_config(0),
+            chain_op_config: BaseFeeConfig::from_chain_id(0),
         }
     }
 }
@@ -790,7 +790,7 @@ mod tests {
             l1_system_config_address: address!("94ee52a9d8edd72a85dea7fae3ba6d75e4bf1710"),
             protocol_versions_address: Address::ZERO,
             blobs_enabled_l1_timestamp: None,
-            chain_op_config: base_fee_config(0),
+            chain_op_config: BaseFeeConfig::from_chain_id(0),
         };
 
         let deserialized: RollupConfig = serde_json::from_str(raw).unwrap();


### PR DESCRIPTION
## Summary

Replaces the three free-floating functions `base_fee_config`, `base_fee_params`, and `base_fee_params_canyon` in the genesis crate with a single `BaseFeeConfig::from_chain_id` method. Call sites in `ChainConfig` and `RollupConfig` are updated accordingly and the functions are removed from the public re-exports.