### PR TITLE
chore(grafana): rename op-node panel titles to consensus node

### DIFF
--- a/etc/scripts/devnet/grafana/dashboards/devnet.json
+++ b/etc/scripts/devnet/grafana/dashboards/devnet.json
@@ -408,7 +408,7 @@
           "refId": "A"
         }
       ],
-      "title": "getPayload Duration P99 (op-node)",
+      "title": "getPayload Duration P99 (consensus node)",
       "type": "barchart"
     },
     {
@@ -497,7 +497,7 @@
           "refId": "A"
         }
       ],
-      "title": "getPayload Duration P90 (op-node)",
+      "title": "getPayload Duration P90 (consensus node)",
       "type": "barchart"
     },
     {
@@ -586,7 +586,7 @@
           "refId": "A"
         }
       ],
-      "title": "getPayload Duration P50 (op-node)",
+      "title": "getPayload Duration P50 (consensus node)",
       "type": "barchart"
     },
     {


### PR DESCRIPTION
This updates three getPayload panel titles in the devnet Grafana dashboard to use consensus node wording, and it keeps the underlying op_node metric queries unchanged.