### PR TITLE
chore(consensus): Move Constants Into RollupConfig Type

### DIFF
--- a/actions/harness/tests/batcher_hardfork_transitions.rs
+++ b/actions/harness/tests/batcher_hardfork_transitions.rs
@@ -6,7 +6,7 @@ use base_action_harness::{
     SharedL1Chain, TestRollupConfigBuilder,
 };
 use base_batcher_encoder::{BatchType, DaType, EncoderConfig};
-use base_consensus_genesis::{GRANITE_CHANNEL_TIMEOUT, HardForkConfig};
+use base_consensus_genesis::{HardForkConfig, RollupConfig};
 
 // ---------------------------------------------------------------------------
 // A. Span batch with non-empty hardfork transition block is rejected
@@ -257,8 +257,10 @@ async fn granite_channel_timeout_enforced() {
 
     // Verify the config has the expected timeout values.
     assert_eq!(
-        rollup_cfg.granite_channel_timeout, GRANITE_CHANNEL_TIMEOUT,
-        "granite_channel_timeout must be {GRANITE_CHANNEL_TIMEOUT}"
+        rollup_cfg.granite_channel_timeout,
+        RollupConfig::GRANITE_CHANNEL_TIMEOUT,
+        "granite_channel_timeout must be {}",
+        RollupConfig::GRANITE_CHANNEL_TIMEOUT
     );
     assert_eq!(
         rollup_cfg.channel_timeout, 300,

--- a/crates/batcher/comp/src/brotli.rs
+++ b/crates/batcher/comp/src/brotli.rs
@@ -181,7 +181,7 @@ impl ChannelCompressor for BrotliCompressor {
 #[cfg(test)]
 mod tests {
     use alloy_primitives::hex;
-    use base_consensus_genesis::MAX_RLP_BYTES_PER_CHANNEL_FJORD;
+    use base_consensus_genesis::RollupConfig;
     use base_protocol::decompress_brotli;
 
     use super::*;
@@ -226,7 +226,8 @@ mod tests {
         let compressed = compressor.get_compressed();
 
         let decompressed =
-            decompress_brotli(&compressed, MAX_RLP_BYTES_PER_CHANNEL_FJORD as usize).unwrap();
+            decompress_brotli(&compressed, RollupConfig::MAX_RLP_BYTES_PER_CHANNEL_FJORD as usize)
+                .unwrap();
         assert_eq!(decompressed, raw_batch_decompressed);
     }
 }

--- a/crates/consensus/derive/src/stages/batch/batch_queue.rs
+++ b/crates/consensus/derive/src/stages/batch/batch_queue.rs
@@ -484,9 +484,7 @@ mod tests {
     use alloy_primitives::{Address, B256, Bytes, TxKind, U256, address, b256};
     use alloy_rlp::{BytesMut, Encodable};
     use base_alloy_consensus::{OpBlock, OpTxEnvelope, OpTxType, TxDeposit};
-    use base_consensus_genesis::{
-        ChainGenesis, HardForkConfig, MAX_RLP_BYTES_PER_CHANNEL_FJORD, SystemConfig,
-    };
+    use base_consensus_genesis::{ChainGenesis, HardForkConfig, RollupConfig, SystemConfig};
     use base_protocol::{BatchReader, L1BlockInfoBedrock, L1BlockInfoTx};
     use tracing::Level;
     use tracing_subscriber::layer::SubscriberExt;
@@ -503,7 +501,7 @@ mod tests {
         let file_contents = &(&*file_contents)[..file_contents.len() - 1];
         let data = alloy_primitives::hex::decode(file_contents).unwrap();
         let bytes: alloy_primitives::Bytes = data.into();
-        BatchReader::new(bytes, MAX_RLP_BYTES_PER_CHANNEL_FJORD as usize)
+        BatchReader::new(bytes, RollupConfig::MAX_RLP_BYTES_PER_CHANNEL_FJORD as usize)
     }
 
     #[test]

--- a/crates/consensus/derive/src/stages/channel/channel_assembler.rs
+++ b/crates/consensus/derive/src/stages/channel/channel_assembler.rs
@@ -5,9 +5,7 @@ use core::fmt::Debug;
 
 use alloy_primitives::{Bytes, hex};
 use async_trait::async_trait;
-use base_consensus_genesis::{
-    MAX_RLP_BYTES_PER_CHANNEL_BEDROCK, MAX_RLP_BYTES_PER_CHANNEL_FJORD, RollupConfig,
-};
+use base_consensus_genesis::RollupConfig;
 use base_protocol::{BlockInfo, Channel};
 
 use super::{ChannelReaderProvider, NextFrameProvider};
@@ -129,9 +127,9 @@ where
             Metrics::pipeline_channel_mem().set(size);
 
             let max_rlp_bytes_per_channel = if self.cfg.is_fjord_active(origin.timestamp) {
-                MAX_RLP_BYTES_PER_CHANNEL_FJORD
+                RollupConfig::MAX_RLP_BYTES_PER_CHANNEL_FJORD
             } else {
-                MAX_RLP_BYTES_PER_CHANNEL_BEDROCK
+                RollupConfig::MAX_RLP_BYTES_PER_CHANNEL_BEDROCK
             };
             Metrics::pipeline_max_rlp_bytes().set(max_rlp_bytes_per_channel as f64);
             if channel.size() > max_rlp_bytes_per_channel as usize {
@@ -225,10 +223,7 @@ where
 mod tests {
     use alloc::{sync::Arc, vec};
 
-    use base_consensus_genesis::{
-        HardForkConfig, MAX_RLP_BYTES_PER_CHANNEL_BEDROCK, MAX_RLP_BYTES_PER_CHANNEL_FJORD,
-        RollupConfig,
-    };
+    use base_consensus_genesis::{HardForkConfig, RollupConfig};
     use base_protocol::BlockInfo;
     use tracing::Level;
     use tracing_subscriber::layer::SubscriberExt;
@@ -352,7 +347,7 @@ mod tests {
             crate::frame!(0xFF, 0, vec![0xDD; 50], false),
             crate::frame!(0xFF, 1, vec![0xDD; 50], true),
         ];
-        frames[1].data = vec![0; MAX_RLP_BYTES_PER_CHANNEL_BEDROCK as usize];
+        frames[1].data = vec![0; RollupConfig::MAX_RLP_BYTES_PER_CHANNEL_BEDROCK as usize];
         let mock = TestNextFrameProvider::new(frames.into_iter().rev().map(Ok).collect());
         let cfg = Arc::new(RollupConfig::default());
 
@@ -387,7 +382,7 @@ mod tests {
             crate::frame!(0xFF, 0, vec![0xDD; 50], false),
             crate::frame!(0xFF, 1, vec![0xDD; 50], true),
         ];
-        frames[1].data = vec![0; MAX_RLP_BYTES_PER_CHANNEL_FJORD as usize];
+        frames[1].data = vec![0; RollupConfig::MAX_RLP_BYTES_PER_CHANNEL_FJORD as usize];
         let mock = TestNextFrameProvider::new(frames.into_iter().rev().map(Ok).collect());
         let cfg = Arc::new(RollupConfig {
             hardforks: HardForkConfig { fjord_time: Some(0), ..Default::default() },

--- a/crates/consensus/derive/src/stages/channel/channel_reader.rs
+++ b/crates/consensus/derive/src/stages/channel/channel_reader.rs
@@ -6,9 +6,7 @@ use core::fmt::Debug;
 use alloy_eips::BlockNumHash;
 use alloy_primitives::Bytes;
 use async_trait::async_trait;
-use base_consensus_genesis::{
-    MAX_RLP_BYTES_PER_CHANNEL_BEDROCK, MAX_RLP_BYTES_PER_CHANNEL_FJORD, RollupConfig, SystemConfig,
-};
+use base_consensus_genesis::{RollupConfig, SystemConfig};
 use base_protocol::{Batch, BatchReader, BlockInfo};
 use tracing::{debug, warn};
 
@@ -66,9 +64,9 @@ where
 
             let origin = self.prev.origin().ok_or(PipelineError::MissingOrigin.crit())?;
             let max_rlp_bytes_per_channel = if self.cfg.is_fjord_active(origin.timestamp) {
-                MAX_RLP_BYTES_PER_CHANNEL_FJORD
+                RollupConfig::MAX_RLP_BYTES_PER_CHANNEL_FJORD
             } else {
-                MAX_RLP_BYTES_PER_CHANNEL_BEDROCK
+                RollupConfig::MAX_RLP_BYTES_PER_CHANNEL_BEDROCK
             };
 
             self.next_batch =
@@ -223,7 +221,7 @@ mod tests {
         let mut reader = ChannelReader::new(mock, Arc::new(RollupConfig::default()));
         reader.next_batch = Some(BatchReader::new(
             new_compressed_batch_data(),
-            MAX_RLP_BYTES_PER_CHANNEL_FJORD as usize,
+            RollupConfig::MAX_RLP_BYTES_PER_CHANNEL_FJORD as usize,
         ));
         reader.flush_channel().await.unwrap();
         assert!(reader.next_batch.is_none());
@@ -235,7 +233,7 @@ mod tests {
         let mut reader = ChannelReader::new(mock, Arc::new(RollupConfig::default()));
         reader.next_batch = Some(BatchReader::new(
             vec![0x00, 0x01, 0x02],
-            MAX_RLP_BYTES_PER_CHANNEL_FJORD as usize,
+            RollupConfig::MAX_RLP_BYTES_PER_CHANNEL_FJORD as usize,
         ));
         assert!(!reader.prev.reset);
         reader.reset(BlockNumHash::default(), SystemConfig::default()).await.unwrap();

--- a/crates/consensus/genesis/src/chain/config.rs
+++ b/crates/consensus/genesis/src/chain/config.rs
@@ -6,10 +6,7 @@ use alloy_chains::Chain;
 use alloy_eips::eip1559::BaseFeeParams;
 use alloy_primitives::Address;
 
-use crate::{
-    AddressList, BaseFeeConfig, ChainGenesis, GRANITE_CHANNEL_TIMEOUT, HardForkConfig, Roles,
-    RollupConfig,
-};
+use crate::{AddressList, BaseFeeConfig, ChainGenesis, HardForkConfig, Roles, RollupConfig};
 
 /// L1 chain configuration from the `alloy-genesis` crate.
 pub type L1ChainConfig = alloy_genesis::ChainConfig;
@@ -142,7 +139,7 @@ impl ChainConfig {
             protocol_versions_address: self.protocol_versions_addr.unwrap_or_default(),
             blobs_enabled_l1_timestamp: None,
             channel_timeout: 300,
-            granite_channel_timeout: GRANITE_CHANNEL_TIMEOUT,
+            granite_channel_timeout: RollupConfig::GRANITE_CHANNEL_TIMEOUT,
             chain_op_config: self.base_fee_config(),
         }
     }

--- a/crates/consensus/genesis/src/lib.rs
+++ b/crates/consensus/genesis/src/lib.rs
@@ -36,7 +36,4 @@ mod genesis;
 pub use genesis::ChainGenesis;
 
 mod rollup;
-pub use rollup::{
-    FJORD_MAX_SEQUENCER_DRIFT, GRANITE_CHANNEL_TIMEOUT, MAX_RLP_BYTES_PER_CHANNEL_BEDROCK,
-    MAX_RLP_BYTES_PER_CHANNEL_FJORD, RollupConfig,
-};
+pub use rollup::RollupConfig;

--- a/crates/consensus/genesis/src/rollup.rs
+++ b/crates/consensus/genesis/src/rollup.rs
@@ -7,23 +7,6 @@ use base_alloy_chains::{BaseChainConfig, BaseUpgrade, BaseUpgrades};
 
 use crate::{BaseFeeConfig, ChainGenesis, HardForkConfig};
 
-/// The max rlp bytes per channel for the Bedrock hardfork.
-pub const MAX_RLP_BYTES_PER_CHANNEL_BEDROCK: u64 = 10_000_000;
-
-/// The max rlp bytes per channel for the Fjord hardfork.
-pub const MAX_RLP_BYTES_PER_CHANNEL_FJORD: u64 = 100_000_000;
-
-/// The max sequencer drift when the Fjord hardfork is active.
-pub const FJORD_MAX_SEQUENCER_DRIFT: u64 = 1800;
-
-/// The channel timeout once the Granite hardfork is active.
-pub const GRANITE_CHANNEL_TIMEOUT: u64 = 50;
-
-#[cfg(feature = "serde")]
-const fn default_granite_channel_timeout() -> u64 {
-    GRANITE_CHANNEL_TIMEOUT
-}
-
 /// The Rollup configuration.
 #[derive(Debug, Clone, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
@@ -46,7 +29,10 @@ pub struct RollupConfig {
     /// Number of L1 blocks between when a channel can be opened and when it can be closed.
     pub channel_timeout: u64,
     /// The channel timeout after the Granite hardfork.
-    #[cfg_attr(feature = "serde", serde(default = "default_granite_channel_timeout"))]
+    #[cfg_attr(
+        feature = "serde",
+        serde(default = "RollupConfig::default_granite_channel_timeout")
+    )]
     pub granite_channel_timeout: u64,
     /// The L1 chain ID
     pub l1_chain_id: u64,
@@ -113,7 +99,7 @@ impl Default for RollupConfig {
             max_sequencer_drift: 0,
             seq_window_size: 0,
             channel_timeout: 0,
-            granite_channel_timeout: GRANITE_CHANNEL_TIMEOUT,
+            granite_channel_timeout: Self::GRANITE_CHANNEL_TIMEOUT,
             l1_chain_id: 0,
             l2_chain_id: Chain::from_id(0),
             hardforks: HardForkConfig::default(),
@@ -260,7 +246,7 @@ impl RollupConfig {
     /// Returns the max sequencer drift for the given timestamp.
     pub fn max_sequencer_drift(&self, timestamp: u64) -> u64 {
         if self.is_fjord_active(timestamp) {
-            FJORD_MAX_SEQUENCER_DRIFT
+            Self::FJORD_MAX_SEQUENCER_DRIFT
         } else {
             self.max_sequencer_drift
         }
@@ -269,9 +255,9 @@ impl RollupConfig {
     /// Returns the max rlp bytes per channel for the given timestamp.
     pub fn max_rlp_bytes_per_channel(&self, timestamp: u64) -> u64 {
         if self.is_fjord_active(timestamp) {
-            MAX_RLP_BYTES_PER_CHANNEL_FJORD
+            Self::MAX_RLP_BYTES_PER_CHANNEL_FJORD
         } else {
-            MAX_RLP_BYTES_PER_CHANNEL_BEDROCK
+            Self::MAX_RLP_BYTES_PER_CHANNEL_BEDROCK
         }
     }
 
@@ -394,6 +380,25 @@ impl BaseUpgrades for RollupConfig {
 }
 
 impl RollupConfig {
+    /// The max rlp bytes per channel for the Bedrock hardfork.
+    pub const MAX_RLP_BYTES_PER_CHANNEL_BEDROCK: u64 = 10_000_000;
+
+    /// The max rlp bytes per channel for the Fjord hardfork.
+    pub const MAX_RLP_BYTES_PER_CHANNEL_FJORD: u64 = 100_000_000;
+
+    /// The max sequencer drift when the Fjord hardfork is active.
+    pub const FJORD_MAX_SEQUENCER_DRIFT: u64 = 1800;
+
+    /// The channel timeout once the Granite hardfork is active.
+    pub const GRANITE_CHANNEL_TIMEOUT: u64 = 50;
+
+    /// Helper method for deserializing a default granite channel timeout.
+    #[cfg(feature = "serde")]
+    pub const fn default_granite_channel_timeout() -> u64 {
+        Self::GRANITE_CHANNEL_TIMEOUT
+    }
+
+    /// The activation banner for the Base V1 hardfork, printed when the first block of the fork is built or processed.
     const BASE_V1_ACTIVATION_BANNER: &str = include_str!("../static/base_v1_activation_banner.txt");
 
     /// Logs hardfork activation when building or processing the first block of a fork.
@@ -427,7 +432,7 @@ impl From<&BaseChainConfig> for RollupConfig {
             max_sequencer_drift: cfg.max_sequencer_drift,
             seq_window_size: cfg.seq_window_size,
             channel_timeout: cfg.channel_timeout,
-            granite_channel_timeout: GRANITE_CHANNEL_TIMEOUT,
+            granite_channel_timeout: Self::GRANITE_CHANNEL_TIMEOUT,
             l1_chain_id: cfg.l1_chain_id,
             l2_chain_id: Chain::from_id(cfg.chain_id),
             hardforks: HardForkConfig::from(cfg),
@@ -697,7 +702,7 @@ mod tests {
             ..Default::default()
         };
         assert_eq!(config.channel_timeout(0), 100);
-        assert_eq!(config.channel_timeout(10), GRANITE_CHANNEL_TIMEOUT);
+        assert_eq!(config.channel_timeout(10), RollupConfig::GRANITE_CHANNEL_TIMEOUT);
         config.hardforks.granite_time = None;
         assert_eq!(config.channel_timeout(10), 100);
     }
@@ -708,7 +713,7 @@ mod tests {
         assert_eq!(config.max_sequencer_drift(0), 100);
         config.hardforks.fjord_time = Some(10);
         assert_eq!(config.max_sequencer_drift(0), 100);
-        assert_eq!(config.max_sequencer_drift(10), FJORD_MAX_SEQUENCER_DRIFT);
+        assert_eq!(config.max_sequencer_drift(10), RollupConfig::FJORD_MAX_SEQUENCER_DRIFT);
     }
 
     #[test]
@@ -796,7 +801,7 @@ mod tests {
             max_sequencer_drift: 600,
             seq_window_size: 3600,
             channel_timeout: 300,
-            granite_channel_timeout: GRANITE_CHANNEL_TIMEOUT,
+            granite_channel_timeout: RollupConfig::GRANITE_CHANNEL_TIMEOUT,
             l1_chain_id: 3151908,
             l2_chain_id: Chain::from_id(1337),
             hardforks: HardForkConfig {

--- a/crates/consensus/protocol/src/batch/reader.rs
+++ b/crates/consensus/protocol/src/batch/reader.rs
@@ -148,9 +148,7 @@ impl BatchReader {
 
 #[cfg(test)]
 mod tests {
-    use base_consensus_genesis::{
-        HardForkConfig, MAX_RLP_BYTES_PER_CHANNEL_BEDROCK, MAX_RLP_BYTES_PER_CHANNEL_FJORD,
-    };
+    use base_consensus_genesis::{HardForkConfig, RollupConfig};
     use miniz_oxide::{
         deflate::{CompressionLevel, compress_to_vec_zlib},
         inflate::decompress_to_vec_zlib,
@@ -170,7 +168,8 @@ mod tests {
     fn test_batch_reader() {
         let raw = new_compressed_batch_data();
         let decompressed_len = decompress_to_vec_zlib(&raw).unwrap().len();
-        let mut reader = BatchReader::new(raw, MAX_RLP_BYTES_PER_CHANNEL_BEDROCK as usize);
+        let mut reader =
+            BatchReader::new(raw, RollupConfig::MAX_RLP_BYTES_PER_CHANNEL_BEDROCK as usize);
         reader.next_batch(&RollupConfig::default()).unwrap();
         assert_eq!(reader.cursor, decompressed_len);
     }
@@ -179,7 +178,8 @@ mod tests {
     fn test_batch_reader_fjord() {
         let raw = new_compressed_batch_data();
         let decompressed_len = decompress_to_vec_zlib(&raw).unwrap().len();
-        let mut reader = BatchReader::new(raw, MAX_RLP_BYTES_PER_CHANNEL_FJORD as usize);
+        let mut reader =
+            BatchReader::new(raw, RollupConfig::MAX_RLP_BYTES_PER_CHANNEL_FJORD as usize);
         reader
             .next_batch(&RollupConfig {
                 hardforks: HardForkConfig { fjord_time: Some(0), ..Default::default() },

--- a/crates/consensus/protocol/src/brotli.rs
+++ b/crates/consensus/protocol/src/brotli.rs
@@ -86,7 +86,7 @@ pub fn decompress_brotli(
 #[cfg(test)]
 mod tests {
     use alloy_primitives::hex;
-    use base_consensus_genesis::MAX_RLP_BYTES_PER_CHANNEL_FJORD;
+    use base_consensus_genesis::RollupConfig;
 
     use super::*;
 
@@ -96,7 +96,8 @@ mod tests {
         let compressed = hex!("8b048075ed184249e9bc19675e03");
 
         let decompressed =
-            decompress_brotli(&compressed, MAX_RLP_BYTES_PER_CHANNEL_FJORD as usize).unwrap();
+            decompress_brotli(&compressed, RollupConfig::MAX_RLP_BYTES_PER_CHANNEL_FJORD as usize)
+                .unwrap();
         assert_eq!(decompressed, expected);
     }
 
@@ -110,7 +111,8 @@ mod tests {
         );
 
         let decompressed =
-            decompress_brotli(&raw_batch, MAX_RLP_BYTES_PER_CHANNEL_FJORD as usize).unwrap();
+            decompress_brotli(&raw_batch, RollupConfig::MAX_RLP_BYTES_PER_CHANNEL_FJORD as usize)
+                .unwrap();
         assert_eq!(decompressed, raw_batch_decompressed);
     }
 


### PR DESCRIPTION
## Summary

Moves the four bare module-level constants (`FJORD_MAX_SEQUENCER_DRIFT`, `GRANITE_CHANNEL_TIMEOUT`, `MAX_RLP_BYTES_PER_CHANNEL_BEDROCK`, `MAX_RLP_BYTES_PER_CHANNEL_FJORD`) from the `base-consensus-genesis` public API into associated constants on `RollupConfig`. All call sites across the consensus, derive, protocol, batcher, and action test crates have been updated to use `RollupConfig::CONSTANT_NAME`.