### PR TITLE
fix(docs): Use Canonical Specs

### DIFF
--- a/crates/consensus/genesis/README.md
+++ b/crates/consensus/genesis/README.md
@@ -1,7 +1,7 @@
 # `base-consensus-genesis`
 
 <a href="https://crates.io/crates/base-consensus-genesis"><img src="https://img.shields.io/crates/v/base-consensus-genesis.svg" alt="base-consensus-genesis crate"></a>
-<a href="https://rollup.yoga"><img src="https://img.shields.io/badge/Docs-854a15?style=flat&labelColor=1C2C2E&color=BEC5C9&logo=mdBook&logoColor=BEC5C9" alt="Docs" /></a>
+<a href="https://specs.base.org"><img src="https://img.shields.io/badge/Docs-854a15?style=flat&labelColor=1C2C2E&color=BEC5C9&logo=mdBook&logoColor=BEC5C9" alt="Docs" /></a>
 
 ## Overview
 

--- a/crates/consensus/registry/README.md
+++ b/crates/consensus/registry/README.md
@@ -1,7 +1,7 @@
 # `base-consensus-registry`
 
 <a href="https://crates.io/crates/base-consensus-registry"><img src="https://img.shields.io/crates/v/base-consensus-registry.svg?label=base-consensus-registry&labelColor=2a2f35" alt="base-consensus-registry"></a>
-<a href="https://rollup.yoga"><img src="https://img.shields.io/badge/Docs-854a15?style=flat&labelColor=1C2C2E&color=BEC5C9&logo=mdBook&logoColor=BEC5C9" alt="Docs" /></a>
+<a href="https://specs.base.org"><img src="https://img.shields.io/badge/Docs-854a15?style=flat&labelColor=1C2C2E&color=BEC5C9&logo=mdBook&logoColor=BEC5C9" alt="Docs" /></a>
 
 ## Overview
 

--- a/crates/consensus/service/README.md
+++ b/crates/consensus/service/README.md
@@ -1,7 +1,7 @@
 # `base-consensus-node`
 
 <a href="https://crates.io/crates/base-consensus-node"><img src="https://img.shields.io/crates/v/base-consensus-node.svg" alt="base-consensus-node crate"></a>
-<a href="https://rollup.yoga"><img src="https://img.shields.io/badge/Docs-854a15?style=flat&labelColor=1C2C2E&color=BEC5C9&logo=mdBook&logoColor=BEC5C9" alt="Docs" /></a>
+<a href="https://specs.base.org"><img src="https://img.shields.io/badge/Docs-854a15?style=flat&labelColor=1C2C2E&color=BEC5C9&logo=mdBook&logoColor=BEC5C9" alt="Docs" /></a>
 
 An implementation of the Base [RollupNode][rn-spec] service.
 

--- a/crates/consensus/sources/README.md
+++ b/crates/consensus/sources/README.md
@@ -1,7 +1,7 @@
 # `base-consensus-sources`
 
 <a href="https://crates.io/crates/base-consensus-sources"><img src="https://img.shields.io/crates/v/base-consensus-sources.svg" alt="base-consensus-sources crate"></a>
-<a href="https://rollup.yoga"><img src="https://img.shields.io/badge/Docs-854a15?style=flat&labelColor=1C2C2E&color=BEC5C9&logo=mdBook&logoColor=BEC5C9" alt="Docs" /></a>
+<a href="https://specs.base.org"><img src="https://img.shields.io/badge/Docs-854a15?style=flat&labelColor=1C2C2E&color=BEC5C9&logo=mdBook&logoColor=BEC5C9" alt="Docs" /></a>
 
 Data source types and utilities for the base-consensus-node.
 

--- a/crates/consensus/upgrades/README.md
+++ b/crates/consensus/upgrades/README.md
@@ -1,7 +1,7 @@
 # `base-consensus-upgrades`
 
 <a href="https://crates.io/crates/base-consensus-upgrades"><img src="https://img.shields.io/crates/v/base-consensus-upgrades.svg" alt="base-consensus-upgrades crate"></a>
-<a href="https://rollup.yoga"><img src="https://img.shields.io/badge/Docs-854a15?style=flat&labelColor=1C2C2E&color=BEC5C9&logo=mdBook&logoColor=BEC5C9" alt="Docs" /></a>
+<a href="https://specs.base.org"><img src="https://img.shields.io/badge/Docs-854a15?style=flat&labelColor=1C2C2E&color=BEC5C9&logo=mdBook&logoColor=BEC5C9" alt="Docs" /></a>
 
 Consensus layer hardfork types for Base including network upgrade transactions.
 


### PR DESCRIPTION
## Summary

Replaces legacy `rollup.yoga` badge links with the canonical `specs.base.org` URL across five consensus crate READMEs. The `rollup.yoga` domain is an OP Stack holdover and no longer the correct destination for Base specs documentation.