### PR TITLE
fix(ci): Tolerate Disk Setup Failures

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -35,6 +35,7 @@ runs:
   steps:
     - name: Free Disk Space
       if: inputs.free-disk == 'true'
+      continue-on-error: true
       uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
       with:
         tool-cache: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -293,6 +293,7 @@ jobs:
           fetch-depth: 1
       - uses: ./.github/actions/setup
         with:
+          free-disk: "true"
           native-deps: "true"
           mold: "true"
           foundry: "true"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,8 +29,6 @@ jobs:
         with:
           fetch-depth: 1
       - uses: ./.github/actions/setup
-        with:
-          rust-cache-shared-key: "stable"
       - name: Validate Cargo.lock is up to date
         run: cargo metadata --format-version 1 --no-deps --locked >/dev/null
 
@@ -240,6 +238,7 @@ jobs:
           fetch-depth: 1
       - uses: ./.github/actions/setup
         with:
+          free-disk: "true"
           toolchain: nightly
           native-deps: "true"
           mold: "true"
@@ -274,9 +273,6 @@ jobs:
         with:
           fetch-depth: 1
       - uses: ./.github/actions/setup
-        with:
-          free-disk: "true"
-          rust-cache-shared-key: "stable"
       - run: just check-deny
 
   devnet-tests:


### PR DESCRIPTION
## Summary

The jlumbroso/free-disk-space action intermittently fails when fallocate cannot create the swapfile on runners with low /mnt space. Adding continue-on-error: true lets setup proceed with disk already freed when swap creation fails, since the large directory removals (~15 GB) complete before fallocate is attempted.

The deeper issue is that lockfile and deny were restoring the full stable build cache despite never compiling any code. cargo metadata --locked and cargo deny check only read Cargo.toml and Cargo.lock, so they gain nothing from the cache. On runners with less free disk, extracting the large workspace cache (compressed and uncompressed data sit on disk simultaneously during extraction) fills the partition and kills setup. Removing rust-cache-shared-key from both jobs makes them trivially lightweight.

This PR also adds the missing free-disk flag to devnet-tests (the only heavy job not attempting to free disk) and to udeps (nightly + native-deps + mold + foundry + cargo-udeps, the heaviest setup configuration with no disk freeing).