### PR TITLE
chore(consensus): Move Constants To Associated Types

### DIFF
--- a/actions/harness/src/miner.rs
+++ b/actions/harness/src/miner.rs
@@ -6,7 +6,7 @@ use alloy_primitives::{Address, B256, Bytes, Log, LogData, U256};
 use base_batcher_encoder::FrameEncoder;
 use base_blobs::BlobEncoder;
 use base_consensus_genesis::{CONFIG_UPDATE_EVENT_VERSION_0, CONFIG_UPDATE_TOPIC};
-use base_protocol::{BlockInfo, DEPOSIT_EVENT_ABI_HASH, DEPOSIT_EVENT_VERSION_0, Frame};
+use base_protocol::{BlockInfo, Deposits, Frame};
 use tracing::info;
 
 use crate::Action;
@@ -360,10 +360,10 @@ impl L1Miner {
             address: deposit.deposit_contract,
             data: LogData::new_unchecked(
                 vec![
-                    DEPOSIT_EVENT_ABI_HASH,
+                    Deposits::EVENT_ABI_HASH,
                     B256::from(from_topic),
                     B256::from(to_topic),
-                    DEPOSIT_EVENT_VERSION_0,
+                    Deposits::EVENT_VERSION_0,
                 ],
                 log_data.into(),
             ),

--- a/crates/consensus/derive/src/attributes/stateful.rs
+++ b/crates/consensus/derive/src/attributes/stateful.rs
@@ -225,7 +225,7 @@ where
 ///
 /// Successful deposits must be emitted by the deposit contract and have the correct event
 /// signature. So the receipt address must equal the specified deposit contract and the first topic
-/// must be the [`DEPOSIT_EVENT_ABI_HASH`].
+/// must be the [`Deposits::EVENT_ABI_HASH`].
 async fn derive_deposits(
     block_hash: B256,
     receipts: &[Receipt],
@@ -297,7 +297,7 @@ mod tests {
             address: deposit_contract,
             data: LogData::new_unchecked(
                 vec![
-                    DEPOSIT_EVENT_ABI_HASH,
+                    Deposits::EVENT_ABI_HASH,
                     B256::from_slice(&from_bytes),
                     B256::from_slice(&to_bytes),
                     B256::default(),
@@ -352,7 +352,7 @@ mod tests {
         let deposit_contract = address!("1111111111111111111111111111111111111111");
         let mut invalid = generate_valid_receipt();
         invalid.logs[0].data =
-            LogData::new_unchecked(vec![DEPOSIT_EVENT_ABI_HASH], Bytes::default());
+            LogData::new_unchecked(vec![Deposits::EVENT_ABI_HASH], Bytes::default());
         let receipts = vec![generate_valid_receipt(), generate_valid_receipt(), invalid];
         let result = derive_deposits(B256::default(), &receipts, deposit_contract).await;
         let downcasted = result.unwrap_err();

--- a/crates/consensus/derive/src/attributes/stateful.rs
+++ b/crates/consensus/derive/src/attributes/stateful.rs
@@ -11,9 +11,7 @@ use async_trait::async_trait;
 use base_alloy_rpc_types_engine::OpPayloadAttributes;
 use base_consensus_genesis::{L1ChainConfig, RollupConfig};
 use base_consensus_upgrades::{Hardfork, Hardforks};
-use base_protocol::{
-    DEPOSIT_EVENT_ABI_HASH, L1BlockInfoTx, L2BlockInfo, Predeploys, decode_deposit,
-};
+use base_protocol::{Deposits, L1BlockInfoTx, L2BlockInfo, Predeploys};
 use tracing::warn;
 
 use crate::{
@@ -242,13 +240,13 @@ async fn derive_deposits(
         for l in &r.logs {
             let curr_index = global_index;
             global_index += 1;
-            if l.data.topics().first().is_none_or(|i| *i != DEPOSIT_EVENT_ABI_HASH) {
+            if l.data.topics().first().is_none_or(|i| *i != Deposits::EVENT_ABI_HASH) {
                 continue;
             }
             if l.address != deposit_contract {
                 continue;
             }
-            let decoded = decode_deposit(block_hash, curr_index, l)?;
+            let decoded = Deposits::decode(block_hash, curr_index, l)?;
             res.push(decoded);
         }
     }
@@ -263,7 +261,7 @@ mod tests {
     use alloy_primitives::{B256, Log, LogData, U64, U256, address};
     use base_consensus_genesis::{CONFIG_UPDATE_TOPIC, HardForkConfig, SystemConfig};
     use base_consensus_registry::L1Config;
-    use base_protocol::{BlockInfo, DepositError};
+    use base_protocol::{BlockInfo, DepositDecodeError};
 
     use super::*;
     use crate::{
@@ -358,7 +356,7 @@ mod tests {
         let receipts = vec![generate_valid_receipt(), generate_valid_receipt(), invalid];
         let result = derive_deposits(B256::default(), &receipts, deposit_contract).await;
         let downcasted = result.unwrap_err();
-        assert_eq!(downcasted, DepositError::UnexpectedTopicsLen(1).into());
+        assert_eq!(downcasted, DepositDecodeError::UnexpectedTopicsLen(1).into());
     }
 
     #[tokio::test]

--- a/crates/consensus/derive/src/errors/pipeline.rs
+++ b/crates/consensus/derive/src/errors/pipeline.rs
@@ -428,7 +428,8 @@ mod tests {
 
     #[test]
     fn test_pipeline_encoding_error_source() {
-        let err = PipelineEncodingError::DepositDecodeError(DepositDecodeError::UnexpectedTopicsLen(0));
+        let err =
+            PipelineEncodingError::DepositDecodeError(DepositDecodeError::UnexpectedTopicsLen(0));
         assert!(err.source().is_some());
 
         let err = SpanBatchError::TooBigSpanBatchSize;

--- a/crates/consensus/derive/src/errors/pipeline.rs
+++ b/crates/consensus/derive/src/errors/pipeline.rs
@@ -5,7 +5,7 @@ use alloc::string::String;
 use alloy_eips::BlockId;
 use alloy_primitives::B256;
 use base_consensus_genesis::SystemConfigUpdateError;
-use base_protocol::{DepositError, SpanBatchError};
+use base_protocol::{DepositDecodeError, SpanBatchError};
 use thiserror::Error;
 
 use crate::BuilderError;
@@ -380,7 +380,7 @@ pub enum PipelineEncodingError {
     EmptyBuffer,
     /// Deposit decoding error.
     #[error("Error decoding deposit: {0}")]
-    DepositError(#[from] DepositError),
+    DepositDecodeError(#[from] DepositDecodeError),
     /// Alloy RLP Encoding Error.
     #[error("RLP error: {0}")]
     AlloyRlpError(alloy_rlp::Error),
@@ -428,7 +428,7 @@ mod tests {
 
     #[test]
     fn test_pipeline_encoding_error_source() {
-        let err = PipelineEncodingError::DepositError(DepositError::UnexpectedTopicsLen(0));
+        let err = PipelineEncodingError::DepositDecodeError(DepositDecodeError::UnexpectedTopicsLen(0));
         assert!(err.source().is_some());
 
         let err = SpanBatchError::TooBigSpanBatchSize;

--- a/crates/consensus/derive/src/stages/channel/channel_bank.rs
+++ b/crates/consensus/derive/src/stages/channel/channel_bank.rs
@@ -568,11 +568,11 @@ mod tests {
         assert!(channel_bank.channels.is_empty());
         assert_eq!(trace_store.lock().iter().filter(|(l, _)| matches!(l, &Level::WARN)).count(), 0);
         assert_eq!(channel_bank.ingest_frame(frame.clone()), Ok(()));
-        assert_eq!(channel_bank.size(), base_protocol::FRAME_OVERHEAD);
+        assert_eq!(channel_bank.size(), base_protocol::Frame::OVERHEAD);
         assert_eq!(channel_bank.channels.len(), 1);
         // This should fail since the frame is already ingested.
         assert_eq!(channel_bank.ingest_frame(frame), Ok(()));
-        assert_eq!(channel_bank.size(), base_protocol::FRAME_OVERHEAD);
+        assert_eq!(channel_bank.size(), base_protocol::Frame::OVERHEAD);
         assert_eq!(channel_bank.channels.len(), 1);
         assert_eq!(trace_store.lock().iter().filter(|(l, _)| matches!(l, &Level::WARN)).count(), 1);
     }

--- a/crates/consensus/protocol/src/channel.rs
+++ b/crates/consensus/protocol/src/channel.rs
@@ -6,19 +6,8 @@ use alloy_primitives::{Bytes, map::HashMap};
 
 use crate::{BlockInfo, Frame};
 
-/// [`CHANNEL_ID_LENGTH`] is the length of the channel ID.
-pub const CHANNEL_ID_LENGTH: usize = 16;
-
 /// [`ChannelId`] is an opaque identifier for a channel.
-pub type ChannelId = [u8; CHANNEL_ID_LENGTH];
-
-/// [`MAX_RLP_BYTES_PER_CHANNEL`] is the maximum amount of bytes that will be read from
-/// a channel. This limit is set when decoding the RLP.
-pub const MAX_RLP_BYTES_PER_CHANNEL: u64 = 10_000_000;
-
-/// [`FJORD_MAX_RLP_BYTES_PER_CHANNEL`] is the maximum amount of bytes that will be read from
-/// a channel when the Fjord Hardfork is activated. This limit is set when decoding the RLP.
-pub const FJORD_MAX_RLP_BYTES_PER_CHANNEL: u64 = 100_000_000;
+pub type ChannelId = [u8; Channel::ID_LENGTH];
 
 /// An error returned when adding a frame to a channel.
 #[derive(Debug, thiserror::Error, Clone, Copy, PartialEq, Eq, Hash)]
@@ -64,6 +53,17 @@ pub struct Channel {
 }
 
 impl Channel {
+    /// Length of the channel ID in bytes.
+    pub const ID_LENGTH: usize = 16;
+
+    /// Maximum amount of bytes that will be read from a channel. This limit is set when decoding
+    /// the RLP.
+    pub const MAX_RLP_BYTES: u64 = 10_000_000;
+
+    /// Maximum amount of bytes that will be read from a channel when the Fjord hardfork is
+    /// activated. This limit is set when decoding the RLP.
+    pub const FJORD_MAX_RLP_BYTES: u64 = 100_000_000;
+
     /// Create a new [`Channel`] with the given [`ChannelId`] and [`BlockInfo`].
     pub fn new(id: ChannelId, open_block: BlockInfo) -> Self {
         Self { id, open_block, inputs: HashMap::default(), ..Default::default() }

--- a/crates/consensus/protocol/src/deposits.rs
+++ b/crates/consensus/protocol/src/deposits.rs
@@ -94,7 +94,9 @@ impl Deposits {
         // The next 32 bytes indicate the length of the opaqueData content.
         let opaque_content_len: U256 = U256::from_be_slice(&log.data.data[32..64]);
         let opaque_content_len: u64 = opaque_content_len.try_into().map_err(|_| {
-            DepositDecodeError::OpaqueContentOverflow(Bytes::copy_from_slice(&log.data.data[32..64]))
+            DepositDecodeError::OpaqueContentOverflow(Bytes::copy_from_slice(
+                &log.data.data[32..64],
+            ))
         })?;
 
         let opaque_data_ceil_32: u64 =
@@ -283,7 +285,10 @@ mod tests {
             ),
         };
         let err: DepositDecodeError = Deposits::decode(B256::default(), 0, &log).unwrap_err();
-        assert_eq!(err, DepositDecodeError::InvalidSelector(Deposits::EVENT_ABI_HASH, B256::default()));
+        assert_eq!(
+            err,
+            DepositDecodeError::InvalidSelector(Deposits::EVENT_ABI_HASH, B256::default())
+        );
     }
 
     #[test]
@@ -471,7 +476,9 @@ mod tests {
         let err = Deposits::decode(B256::default(), 0, &log).unwrap_err();
         assert_eq!(
             err,
-            DepositDecodeError::OpaqueContentOverflow(Bytes::from(data.get(32..64).unwrap().to_vec()))
+            DepositDecodeError::OpaqueContentOverflow(Bytes::from(
+                data.get(32..64).unwrap().to_vec()
+            ))
         );
     }
 
@@ -596,7 +603,9 @@ mod tests {
         let err = Deposits::decode(B256::default(), 0, &log).unwrap_err();
         assert_eq!(
             err,
-            DepositDecodeError::InvalidOpaqueDataPadding(Bytes::from(data.get(191..).unwrap().to_vec()))
+            DepositDecodeError::InvalidOpaqueDataPadding(Bytes::from(
+                data.get(191..).unwrap().to_vec()
+            ))
         );
     }
 

--- a/crates/consensus/protocol/src/deposits.rs
+++ b/crates/consensus/protocol/src/deposits.rs
@@ -6,22 +6,153 @@ use alloy_eips::eip2718::Encodable2718;
 use alloy_primitives::{Address, B256, Bytes, Log, TxKind, U256, b256};
 use base_alloy_consensus::{TxDeposit, UserDepositSource};
 
-/// Deposit log event abi signature.
-pub const DEPOSIT_EVENT_ABI: &str = "TransactionDeposited(address,address,uint256,bytes)";
+/// Deposit transaction utilities.
+#[derive(Debug)]
+pub struct Deposits;
 
-/// Deposit event abi hash.
-///
-/// This is the keccak256 hash of the deposit event ABI signature.
-/// `keccak256("TransactionDeposited(address,address,uint256,bytes)")`
-pub const DEPOSIT_EVENT_ABI_HASH: B256 =
-    b256!("b3813568d9991fc951961fcb4c784893574240a28925604d09fc577c55bb7c32");
+impl Deposits {
+    /// Deposit log event ABI signature.
+    pub const EVENT_ABI: &'static str = "TransactionDeposited(address,address,uint256,bytes)";
 
-/// The initial version of the deposit event log.
-pub const DEPOSIT_EVENT_VERSION_0: B256 = B256::ZERO;
+    /// Deposit event ABI hash.
+    ///
+    /// This is the keccak256 hash of the deposit event ABI signature.
+    /// `keccak256("TransactionDeposited(address,address,uint256,bytes)")`
+    pub const EVENT_ABI_HASH: B256 =
+        b256!("b3813568d9991fc951961fcb4c784893574240a28925604d09fc577c55bb7c32");
+
+    /// The initial version of the deposit event log.
+    pub const EVENT_VERSION_0: B256 = B256::ZERO;
+
+    /// Derives a deposit transaction from an EVM log event emitted by the deposit contract.
+    ///
+    /// The emitted log must be in format:
+    /// ```solidity
+    /// event TransactionDeposited(
+    ///    address indexed from,
+    ///    address indexed to,
+    ///    uint256 indexed version,
+    ///    bytes opaqueData
+    /// );
+    /// ```
+    pub fn decode(block_hash: B256, index: usize, log: &Log) -> Result<Bytes, DepositDecodeError> {
+        let topics = log.data.topics();
+        if topics.len() != 4 {
+            return Err(DepositDecodeError::UnexpectedTopicsLen(topics.len()));
+        }
+        if topics[0] != Self::EVENT_ABI_HASH {
+            return Err(DepositDecodeError::InvalidSelector(Self::EVENT_ABI_HASH, topics[0]));
+        }
+        if log.data.data.len() < 64 {
+            return Err(DepositDecodeError::IncompleteOpaqueData(log.data.data.len()));
+        }
+        if log.data.data.len() % 32 != 0 {
+            return Err(DepositDecodeError::UnalignedData(log.data.data.len()));
+        }
+
+        // Validate the `from` address.
+        let mut from_bytes = [0u8; 20];
+        from_bytes.copy_from_slice(&topics[1].as_slice()[12..]);
+        if topics[1].iter().take(12).any(|&b| b != 0) {
+            return Err(DepositDecodeError::FromDecode(topics[1]));
+        }
+
+        // Validate the `to` address.
+        let mut to_bytes = [0u8; 20];
+        to_bytes.copy_from_slice(&topics[2].as_slice()[12..]);
+        if topics[2].iter().take(12).any(|&b| b != 0) {
+            return Err(DepositDecodeError::ToDecode(topics[2]));
+        }
+
+        let from = Address::from(from_bytes);
+        let to = Address::from(to_bytes);
+        let version = log.data.topics()[3];
+
+        // Solidity serializes the event's Data field as follows:
+        //
+        // ```solidity
+        // abi.encode(abi.encodPacked(uint256 mint, uint256 value, uint64 gasLimit, uint8 isCreation, bytes data))
+        // ```
+        //
+        // The opaqueData will be packed as shown below:
+        //
+        // ------------------------------------------------------------
+        // | offset | 256 byte content                                |
+        // ------------------------------------------------------------
+        // | 0      | [0; 24] . {U64 big endian, hex encoded offset}  |
+        // ------------------------------------------------------------
+        // | 32     | [0; 24] . {U64 big endian, hex encoded length}  |
+        // ------------------------------------------------------------
+
+        let opaque_content_offset: U256 = U256::from_be_slice(&log.data.data[0..32]);
+        if opaque_content_offset != U256::from(32) {
+            return Err(DepositDecodeError::InvalidOpaqueDataOffset(Bytes::copy_from_slice(
+                &log.data.data[0..32],
+            )));
+        }
+
+        // The next 32 bytes indicate the length of the opaqueData content.
+        let opaque_content_len: U256 = U256::from_be_slice(&log.data.data[32..64]);
+        let opaque_content_len: u64 = opaque_content_len.try_into().map_err(|_| {
+            DepositDecodeError::OpaqueContentOverflow(Bytes::copy_from_slice(&log.data.data[32..64]))
+        })?;
+
+        let opaque_data_ceil_32: u64 =
+            (opaque_content_len.saturating_add(31) / 32).saturating_mul(32);
+
+        // Ensure that the remaining data is only zeros.
+        // The padding ends at the next multiple of 32 after the opaque data.
+        let Some(padding_end): Option<u64> = 64_u64.checked_add(opaque_data_ceil_32) else {
+            return Err(DepositDecodeError::OpaqueDataPaddingOverflow);
+        };
+
+        // The remaining data is the opaqueData which is tightly packed and then padded to 32 bytes
+        // by the EVM.
+        let Some(opaque_data) = &log.data.data.get(64..64 + opaque_content_len as usize) else {
+            return Err(DepositDecodeError::InvalidOpaqueDataLength {
+                expected: opaque_content_len as usize,
+                actual: log.data.data.len().saturating_sub(64),
+            });
+        };
+
+        if !(opaque_content_len.is_multiple_of(32)
+            || log
+                .data
+                .data
+                .get((64 + opaque_content_len) as usize..padding_end as usize)
+                .is_some_and(|data| data.iter().all(|&b| b == 0)))
+        {
+            return Err(DepositDecodeError::InvalidOpaqueDataPadding(Bytes::copy_from_slice(
+                &log.data.data[(64 + opaque_content_len) as usize..],
+            )));
+        }
+
+        let source = UserDepositSource::new(block_hash, index as u64);
+
+        let mut deposit_tx = TxDeposit {
+            from,
+            is_system_transaction: false,
+            source_hash: source.source_hash(),
+            ..Default::default()
+        };
+
+        // Can only handle version 0 for now
+        if !version.is_zero() {
+            return Err(DepositDecodeError::InvalidVersion(version));
+        }
+
+        Self::unmarshal_v0(&mut deposit_tx, to, opaque_data)?;
+
+        // Re-encode the deposit transaction
+        let mut buffer = Vec::with_capacity(deposit_tx.eip2718_encoded_length());
+        deposit_tx.encode_2718(&mut buffer);
+        Ok(Bytes::from(buffer))
+    }
+}
 
 /// An [`TxDeposit`] validation error.
 #[derive(Debug, thiserror::Error, PartialEq, Eq)]
-pub enum DepositError {
+pub enum DepositDecodeError {
     /// Unexpected number of deposit event log topics.
     #[error("Unexpected number of deposit event log topics: {0}")]
     UnexpectedTopicsLen(usize),
@@ -83,177 +214,55 @@ pub enum DepositError {
     GasDecode(Bytes),
 }
 
-/// Derives a deposit transaction from an EVM log event emitted by the deposit contract.
-///
-/// The emitted log must be in format:
-/// ```solidity
-/// event TransactionDeposited(
-///    address indexed from,
-///    address indexed to,
-///    uint256 indexed version,
-///    bytes opaqueData
-/// );
-/// ```
-pub fn decode_deposit(block_hash: B256, index: usize, log: &Log) -> Result<Bytes, DepositError> {
-    let topics = log.data.topics();
-    if topics.len() != 4 {
-        return Err(DepositError::UnexpectedTopicsLen(topics.len()));
+impl Deposits {
+    /// Unmarshals a deposit transaction from the opaque data.
+    pub fn unmarshal_v0(
+        tx: &mut TxDeposit,
+        to: Address,
+        data: &[u8],
+    ) -> Result<(), DepositDecodeError> {
+        if data.len() < 32 + 32 + 8 + 1 {
+            return Err(DepositDecodeError::UnexpectedOpaqueDataLen(data.len()));
+        }
+
+        let mut offset = 0;
+
+        let raw_mint: [u8; 16] = data[offset + 16..offset + 32].try_into().map_err(|_| {
+            DepositDecodeError::MintDecode(Bytes::copy_from_slice(&data[offset + 16..offset + 32]))
+        })?;
+        tx.mint = u128::from_be_bytes(raw_mint);
+        offset += 32;
+
+        // uint256 value
+        tx.value = U256::from_be_slice(&data[offset..offset + 32]);
+        offset += 32;
+
+        // uint64 gas
+        let raw_gas: [u8; 8] = data[offset..offset + 8].try_into().map_err(|_| {
+            DepositDecodeError::GasDecode(Bytes::copy_from_slice(&data[offset..offset + 8]))
+        })?;
+        tx.gas_limit = u64::from_be_bytes(raw_gas);
+        offset += 8;
+
+        // uint8 isCreation
+        // isCreation: If the boolean byte is 1 then dep.To will stay nil,
+        // and it will create a contract using L2 account nonce to determine the created address.
+        if data[offset] == 0 {
+            tx.to = TxKind::Call(to);
+        } else {
+            tx.to = TxKind::Create;
+        }
+        offset += 1;
+
+        // The remainder of the opaqueData is the transaction data (without length prefix).
+        // The data may be padded to a multiple of 32 bytes
+        let tx_data_len = data.len() - offset;
+
+        // Remaining bytes fill the data
+        tx.input = Bytes::copy_from_slice(&data[offset..offset + tx_data_len]);
+
+        Ok(())
     }
-    if topics[0] != DEPOSIT_EVENT_ABI_HASH {
-        return Err(DepositError::InvalidSelector(DEPOSIT_EVENT_ABI_HASH, topics[0]));
-    }
-    if log.data.data.len() < 64 {
-        return Err(DepositError::IncompleteOpaqueData(log.data.data.len()));
-    }
-    if log.data.data.len() % 32 != 0 {
-        return Err(DepositError::UnalignedData(log.data.data.len()));
-    }
-
-    // Validate the `from` address.
-    let mut from_bytes = [0u8; 20];
-    from_bytes.copy_from_slice(&topics[1].as_slice()[12..]);
-    if topics[1].iter().take(12).any(|&b| b != 0) {
-        return Err(DepositError::FromDecode(topics[1]));
-    }
-
-    // Validate the `to` address.
-    let mut to_bytes = [0u8; 20];
-    to_bytes.copy_from_slice(&topics[2].as_slice()[12..]);
-    if topics[2].iter().take(12).any(|&b| b != 0) {
-        return Err(DepositError::ToDecode(topics[2]));
-    }
-
-    let from = Address::from(from_bytes);
-    let to = Address::from(to_bytes);
-    let version = log.data.topics()[3];
-
-    // Solidity serializes the event's Data field as follows:
-    //
-    // ```solidity
-    // abi.encode(abi.encodPacked(uint256 mint, uint256 value, uint64 gasLimit, uint8 isCreation, bytes data))
-    // ```
-    //
-    // The opaqueData will be packed as shown below:
-    //
-    // ------------------------------------------------------------
-    // | offset | 256 byte content                                |
-    // ------------------------------------------------------------
-    // | 0      | [0; 24] . {U64 big endian, hex encoded offset}  |
-    // ------------------------------------------------------------
-    // | 32     | [0; 24] . {U64 big endian, hex encoded length}  |
-    // ------------------------------------------------------------
-
-    let opaque_content_offset: U256 = U256::from_be_slice(&log.data.data[0..32]);
-    if opaque_content_offset != U256::from(32) {
-        return Err(DepositError::InvalidOpaqueDataOffset(Bytes::copy_from_slice(
-            &log.data.data[0..32],
-        )));
-    }
-
-    // The next 32 bytes indicate the length of the opaqueData content.
-    let opaque_content_len: U256 = U256::from_be_slice(&log.data.data[32..64]);
-    let opaque_content_len: u64 = opaque_content_len.try_into().map_err(|_| {
-        DepositError::OpaqueContentOverflow(Bytes::copy_from_slice(&log.data.data[32..64]))
-    })?;
-
-    let opaque_data_ceil_32: u64 = (opaque_content_len.saturating_add(31) / 32).saturating_mul(32);
-
-    // Ensure that the remaining data is only zeros.
-    // The padding ends at the next multiple of 32 after the opaque data.
-    let Some(padding_end): Option<u64> = 64_u64.checked_add(opaque_data_ceil_32) else {
-        return Err(DepositError::OpaqueDataPaddingOverflow);
-    };
-
-    // The remaining data is the opaqueData which is tightly packed and then padded to 32 bytes by
-    // the EVM.
-    let Some(opaque_data) = &log.data.data.get(64..64 + opaque_content_len as usize) else {
-        return Err(DepositError::InvalidOpaqueDataLength {
-            expected: opaque_content_len as usize,
-            actual: log.data.data.len().saturating_sub(64),
-        });
-    };
-
-    if !(opaque_content_len.is_multiple_of(32)
-        || log
-            .data
-            .data
-            .get((64 + opaque_content_len) as usize..padding_end as usize)
-            .is_some_and(|data| data.iter().all(|&b| b == 0)))
-    {
-        return Err(DepositError::InvalidOpaqueDataPadding(Bytes::copy_from_slice(
-            &log.data.data[(64 + opaque_content_len) as usize..],
-        )));
-    }
-
-    let source = UserDepositSource::new(block_hash, index as u64);
-
-    let mut deposit_tx = TxDeposit {
-        from,
-        is_system_transaction: false,
-        source_hash: source.source_hash(),
-        ..Default::default()
-    };
-
-    // Can only handle version 0 for now
-    if !version.is_zero() {
-        return Err(DepositError::InvalidVersion(version));
-    }
-
-    unmarshal_deposit_version0(&mut deposit_tx, to, opaque_data)?;
-
-    // Re-encode the deposit transaction
-    let mut buffer = Vec::with_capacity(deposit_tx.eip2718_encoded_length());
-    deposit_tx.encode_2718(&mut buffer);
-    Ok(Bytes::from(buffer))
-}
-
-/// Unmarshals a deposit transaction from the opaque data.
-pub(crate) fn unmarshal_deposit_version0(
-    tx: &mut TxDeposit,
-    to: Address,
-    data: &[u8],
-) -> Result<(), DepositError> {
-    if data.len() < 32 + 32 + 8 + 1 {
-        return Err(DepositError::UnexpectedOpaqueDataLen(data.len()));
-    }
-
-    let mut offset = 0;
-
-    let raw_mint: [u8; 16] = data[offset + 16..offset + 32].try_into().map_err(|_| {
-        DepositError::MintDecode(Bytes::copy_from_slice(&data[offset + 16..offset + 32]))
-    })?;
-    tx.mint = u128::from_be_bytes(raw_mint);
-    offset += 32;
-
-    // uint256 value
-    tx.value = U256::from_be_slice(&data[offset..offset + 32]);
-    offset += 32;
-
-    // uint64 gas
-    let raw_gas: [u8; 8] = data[offset..offset + 8]
-        .try_into()
-        .map_err(|_| DepositError::GasDecode(Bytes::copy_from_slice(&data[offset..offset + 8])))?;
-    tx.gas_limit = u64::from_be_bytes(raw_gas);
-    offset += 8;
-
-    // uint8 isCreation
-    // isCreation: If the boolean byte is 1 then dep.To will stay nil,
-    // and it will create a contract using L2 account nonce to determine the created address.
-    if data[offset] == 0 {
-        tx.to = TxKind::Call(to);
-    } else {
-        tx.to = TxKind::Create;
-    }
-    offset += 1;
-
-    // The remainder of the opaqueData is the transaction data (without length prefix).
-    // The data may be padded to a multiple of 32 bytes
-    let tx_data_len = data.len() - offset;
-
-    // Remaining bytes fill the data
-    tx.input = Bytes::copy_from_slice(&data[offset..offset + tx_data_len]);
-
-    Ok(())
 }
 
 #[cfg(test)]
@@ -273,8 +282,8 @@ mod tests {
                 Bytes::default(),
             ),
         };
-        let err: DepositError = decode_deposit(B256::default(), 0, &log).unwrap_err();
-        assert_eq!(err, DepositError::InvalidSelector(DEPOSIT_EVENT_ABI_HASH, B256::default()));
+        let err: DepositDecodeError = Deposits::decode(B256::default(), 0, &log).unwrap_err();
+        assert_eq!(err, DepositDecodeError::InvalidSelector(Deposits::EVENT_ABI_HASH, B256::default()));
     }
 
     #[test]
@@ -282,12 +291,12 @@ mod tests {
         let log = Log {
             address: Address::default(),
             data: LogData::new_unchecked(
-                vec![DEPOSIT_EVENT_ABI_HASH, B256::default(), B256::default(), B256::default()],
+                vec![Deposits::EVENT_ABI_HASH, B256::default(), B256::default(), B256::default()],
                 Bytes::from(vec![0u8; 63]),
             ),
         };
-        let err = decode_deposit(B256::default(), 0, &log).unwrap_err();
-        assert_eq!(err, DepositError::IncompleteOpaqueData(63));
+        let err = Deposits::decode(B256::default(), 0, &log).unwrap_err();
+        assert_eq!(err, DepositDecodeError::IncompleteOpaqueData(63));
     }
 
     #[test]
@@ -295,12 +304,12 @@ mod tests {
         let log = Log {
             address: Address::default(),
             data: LogData::new_unchecked(
-                vec![DEPOSIT_EVENT_ABI_HASH, B256::default(), B256::default(), B256::default()],
+                vec![Deposits::EVENT_ABI_HASH, B256::default(), B256::default(), B256::default()],
                 Bytes::from(vec![0u8; 65]),
             ),
         };
-        let err = decode_deposit(B256::default(), 0, &log).unwrap_err();
-        assert_eq!(err, DepositError::UnalignedData(65));
+        let err = Deposits::decode(B256::default(), 0, &log).unwrap_err();
+        assert_eq!(err, DepositDecodeError::UnalignedData(65));
     }
 
     #[test]
@@ -310,12 +319,12 @@ mod tests {
         let log = Log {
             address: Address::default(),
             data: LogData::new_unchecked(
-                vec![DEPOSIT_EVENT_ABI_HASH, invalid_from, B256::default(), B256::default()],
+                vec![Deposits::EVENT_ABI_HASH, invalid_from, B256::default(), B256::default()],
                 Bytes::from(vec![0u8; 64]),
             ),
         };
-        let err = decode_deposit(B256::default(), 0, &log).unwrap_err();
-        assert_eq!(err, DepositError::FromDecode(invalid_from));
+        let err = Deposits::decode(B256::default(), 0, &log).unwrap_err();
+        assert_eq!(err, DepositDecodeError::FromDecode(invalid_from));
     }
 
     #[test]
@@ -324,12 +333,12 @@ mod tests {
         let log = Log {
             address: Address::default(),
             data: LogData::new_unchecked(
-                vec![DEPOSIT_EVENT_ABI_HASH, B256::default(), invalid_to, B256::default()],
+                vec![Deposits::EVENT_ABI_HASH, B256::default(), invalid_to, B256::default()],
                 Bytes::from(vec![0u8; 64]),
             ),
         };
-        let err = decode_deposit(B256::default(), 0, &log).unwrap_err();
-        assert_eq!(err, DepositError::ToDecode(invalid_to));
+        let err = Deposits::decode(B256::default(), 0, &log).unwrap_err();
+        assert_eq!(err, DepositDecodeError::ToDecode(invalid_to));
     }
 
     #[test]
@@ -337,12 +346,12 @@ mod tests {
         let log = Log {
             address: Address::default(),
             data: LogData::new_unchecked(
-                vec![DEPOSIT_EVENT_ABI_HASH, B256::default(), B256::default(), B256::default()],
+                vec![Deposits::EVENT_ABI_HASH, B256::default(), B256::default(), B256::default()],
                 Bytes::from(vec![0u8; 64]),
             ),
         };
-        let err = decode_deposit(B256::default(), 0, &log).unwrap_err();
-        assert_eq!(err, DepositError::InvalidOpaqueDataOffset(Bytes::from(vec![0u8; 32])));
+        let err = Deposits::decode(B256::default(), 0, &log).unwrap_err();
+        assert_eq!(err, DepositDecodeError::InvalidOpaqueDataOffset(Bytes::from(vec![0u8; 32])));
     }
 
     #[test]
@@ -357,12 +366,12 @@ mod tests {
         let log = Log {
             address: Address::default(),
             data: LogData::new_unchecked(
-                vec![DEPOSIT_EVENT_ABI_HASH, B256::default(), B256::default(), B256::default()],
+                vec![Deposits::EVENT_ABI_HASH, B256::default(), B256::default(), B256::default()],
                 Bytes::from(data),
             ),
         };
-        let err = decode_deposit(B256::default(), 0, &log).unwrap_err();
-        assert_eq!(err, DepositError::InvalidOpaqueDataLength { expected: 128, actual: 64 });
+        let err = Deposits::decode(B256::default(), 0, &log).unwrap_err();
+        assert_eq!(err, DepositDecodeError::InvalidOpaqueDataLength { expected: 128, actual: 64 });
     }
 
     #[test]
@@ -375,12 +384,12 @@ mod tests {
         let log = Log {
             address: Address::default(),
             data: LogData::new_unchecked(
-                vec![DEPOSIT_EVENT_ABI_HASH, B256::default(), B256::default(), B256::default()],
+                vec![Deposits::EVENT_ABI_HASH, B256::default(), B256::default(), B256::default()],
                 Bytes::from(data),
             ),
         };
-        let err = decode_deposit(B256::default(), 0, &log).unwrap_err();
-        assert_eq!(err, DepositError::UnexpectedOpaqueDataLen(64));
+        let err = Deposits::decode(B256::default(), 0, &log).unwrap_err();
+        assert_eq!(err, DepositDecodeError::UnexpectedOpaqueDataLen(64));
     }
 
     #[test]
@@ -394,12 +403,12 @@ mod tests {
         let log = Log {
             address: Address::default(),
             data: LogData::new_unchecked(
-                vec![DEPOSIT_EVENT_ABI_HASH, B256::default(), B256::default(), version],
+                vec![Deposits::EVENT_ABI_HASH, B256::default(), B256::default(), version],
                 Bytes::from(data),
             ),
         };
-        let err = decode_deposit(B256::default(), 0, &log).unwrap_err();
-        assert_eq!(err, DepositError::InvalidVersion(version));
+        let err = Deposits::decode(B256::default(), 0, &log).unwrap_err();
+        assert_eq!(err, DepositDecodeError::InvalidVersion(version));
     }
 
     #[test]
@@ -414,11 +423,11 @@ mod tests {
         let log = Log {
             address: Address::default(),
             data: LogData::new_unchecked(
-                vec![DEPOSIT_EVENT_ABI_HASH, valid_from, valid_to, B256::default()],
+                vec![Deposits::EVENT_ABI_HASH, valid_from, valid_to, B256::default()],
                 Bytes::from(data),
             ),
         };
-        let tx = decode_deposit(B256::default(), 0, &log).unwrap();
+        let tx = Deposits::decode(B256::default(), 0, &log).unwrap();
         let raw_hex = hex!(
             "7ef887a0ed428e1c45e1d9561b62834e1a2d3015a0caae3bfdc16b4da059ac885b01a14594ffffffffffffffffffffffffffffffffffffffff94bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb80808080b700000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
         );
@@ -436,13 +445,13 @@ mod tests {
         let log = Log {
             address: Address::default(),
             data: LogData::new_unchecked(
-                vec![DEPOSIT_EVENT_ABI_HASH, B256::default(), B256::default(), B256::default()],
+                vec![Deposits::EVENT_ABI_HASH, B256::default(), B256::default(), B256::default()],
                 Bytes::from(data.clone()),
             ),
         };
-        let err = decode_deposit(B256::default(), 0, &log).unwrap_err();
+        let err = Deposits::decode(B256::default(), 0, &log).unwrap_err();
         let bytes = Bytes::from(data.get(0..32).unwrap().to_vec());
-        assert_eq!(err, DepositError::InvalidOpaqueDataOffset(bytes));
+        assert_eq!(err, DepositDecodeError::InvalidOpaqueDataOffset(bytes));
     }
 
     #[test]
@@ -455,14 +464,14 @@ mod tests {
         let log = Log {
             address: Address::default(),
             data: LogData::new_unchecked(
-                vec![DEPOSIT_EVENT_ABI_HASH, B256::default(), B256::default(), B256::default()],
+                vec![Deposits::EVENT_ABI_HASH, B256::default(), B256::default(), B256::default()],
                 Bytes::from(data.clone()),
             ),
         };
-        let err = decode_deposit(B256::default(), 0, &log).unwrap_err();
+        let err = Deposits::decode(B256::default(), 0, &log).unwrap_err();
         assert_eq!(
             err,
-            DepositError::OpaqueContentOverflow(Bytes::from(data.get(32..64).unwrap().to_vec()))
+            DepositDecodeError::OpaqueContentOverflow(Bytes::from(data.get(32..64).unwrap().to_vec()))
         );
     }
 
@@ -494,7 +503,7 @@ mod tests {
             address: Address::default(),
             data: LogData::new_unchecked(
                 vec![
-                    DEPOSIT_EVENT_ABI_HASH,
+                    Deposits::EVENT_ABI_HASH,
                     B256::from_slice(&from_bytes),
                     B256::from_slice(&to_bytes),
                     B256::default(),
@@ -502,8 +511,8 @@ mod tests {
                 Bytes::from(data),
             ),
         };
-        let err = decode_deposit(B256::default(), 0, &log).unwrap_err();
-        assert_eq!(err, DepositError::InvalidOpaqueDataLength { expected: 129, actual: 128 });
+        let err = Deposits::decode(B256::default(), 0, &log).unwrap_err();
+        assert_eq!(err, DepositDecodeError::InvalidOpaqueDataLength { expected: 129, actual: 128 });
     }
 
     #[test]
@@ -534,7 +543,7 @@ mod tests {
             address: Address::default(),
             data: LogData::new_unchecked(
                 vec![
-                    DEPOSIT_EVENT_ABI_HASH,
+                    Deposits::EVENT_ABI_HASH,
                     B256::from_slice(&from_bytes),
                     B256::from_slice(&to_bytes),
                     B256::default(),
@@ -542,8 +551,8 @@ mod tests {
                 Bytes::from(data.clone()),
             ),
         };
-        let err = decode_deposit(B256::default(), 0, &log).unwrap_err();
-        assert_eq!(err, DepositError::OpaqueDataPaddingOverflow);
+        let err = Deposits::decode(B256::default(), 0, &log).unwrap_err();
+        assert_eq!(err, DepositDecodeError::OpaqueDataPaddingOverflow);
     }
 
     #[test]
@@ -576,7 +585,7 @@ mod tests {
             address: Address::default(),
             data: LogData::new_unchecked(
                 vec![
-                    DEPOSIT_EVENT_ABI_HASH,
+                    Deposits::EVENT_ABI_HASH,
                     B256::from_slice(&from_bytes),
                     B256::from_slice(&to_bytes),
                     B256::default(),
@@ -584,10 +593,10 @@ mod tests {
                 Bytes::from(data.clone()),
             ),
         };
-        let err = decode_deposit(B256::default(), 0, &log).unwrap_err();
+        let err = Deposits::decode(B256::default(), 0, &log).unwrap_err();
         assert_eq!(
             err,
-            DepositError::InvalidOpaqueDataPadding(Bytes::from(data.get(191..).unwrap().to_vec()))
+            DepositDecodeError::InvalidOpaqueDataPadding(Bytes::from(data.get(191..).unwrap().to_vec()))
         );
     }
 
@@ -619,7 +628,7 @@ mod tests {
             address: Address::default(),
             data: LogData::new_unchecked(
                 vec![
-                    DEPOSIT_EVENT_ABI_HASH,
+                    Deposits::EVENT_ABI_HASH,
                     B256::from_slice(&from_bytes),
                     B256::from_slice(&to_bytes),
                     B256::default(),
@@ -627,7 +636,7 @@ mod tests {
                 Bytes::from(data),
             ),
         };
-        let tx = decode_deposit(B256::default(), 0, &log).unwrap();
+        let tx = Deposits::decode(B256::default(), 0, &log).unwrap();
         let raw_hex = hex!(
             "7ef875a0ed428e1c45e1d9561b62834e1a2d3015a0caae3bfdc16b4da059ac885b01a145941111111111111111111111111111111111111111800a648203e880b700000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
         );
@@ -640,18 +649,18 @@ mod tests {
         let data = vec![0u8; 72];
         let mut tx = TxDeposit::default();
         let to = address!("5555555555555555555555555555555555555555");
-        let err = unmarshal_deposit_version0(&mut tx, to, &data).unwrap_err();
-        assert_eq!(err, DepositError::UnexpectedOpaqueDataLen(72));
+        let err = Deposits::unmarshal_v0(&mut tx, to, &data).unwrap_err();
+        assert_eq!(err, DepositDecodeError::UnexpectedOpaqueDataLen(72));
 
         // Data must have at least length 73
         let data = vec![0u8; 73];
         let mut tx = TxDeposit::default();
         let to = address!("5555555555555555555555555555555555555555");
-        unmarshal_deposit_version0(&mut tx, to, &data).unwrap();
+        Deposits::unmarshal_v0(&mut tx, to, &data).unwrap();
     }
 
     #[test]
-    fn test_unmarshal_deposit_version0() {
+    fn test_unmarshal_v0() {
         let mut data = vec![0u8; 192];
         let offset: [u8; 8] = U64::from(32).to_be_bytes();
         data[24..32].copy_from_slice(&offset);
@@ -677,7 +686,7 @@ mod tests {
             ..Default::default()
         };
         let to = address!("5555555555555555555555555555555555555555");
-        unmarshal_deposit_version0(&mut tx, to, &data).unwrap();
+        Deposits::unmarshal_v0(&mut tx, to, &data).unwrap();
         assert_eq!(tx.to, TxKind::Call(address!("5555555555555555555555555555555555555555")));
     }
 }

--- a/crates/consensus/protocol/src/frame.rs
+++ b/crates/consensus/protocol/src/frame.rs
@@ -37,26 +37,6 @@ use crate::ChannelId;
 /// ensure compatibility and enable future protocol upgrades.
 pub const DERIVATION_VERSION_0: u8 = 0;
 
-/// Overhead estimation for frame metadata and tagging information.
-///
-/// This constant provides an estimate of the additional bytes required
-/// for frame metadata (channel ID, frame number, data length, flags) and
-/// L1 transaction overhead. Used for buffer size calculations and gas
-/// estimation when planning frame transmission.
-pub const FRAME_OVERHEAD: usize = 200;
-
-/// Maximum allowed size for a single frame in bytes.
-///
-/// While typical L1 transactions carrying frames are around 128 KB due to
-/// network conditions and gas limits, this larger limit provides headroom
-/// for future growth as L1 gas limits and network conditions improve.
-///
-/// The 1MB limit balances:
-/// - **Transmission efficiency**: Larger frames reduce overhead
-/// - **Network compatibility**: Must fit within reasonable L1 transaction sizes
-/// - **Memory constraints**: Avoid excessive memory usage during processing
-pub const MAX_FRAME_LEN: usize = 1_000_000;
-
 /// A frame decoding error.
 #[derive(Debug, thiserror::Error, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum FrameDecodingError {
@@ -172,6 +152,26 @@ pub struct Frame {
 }
 
 impl Frame {
+    /// Overhead estimation for frame metadata and tagging information.
+    ///
+    /// This constant provides an estimate of the additional bytes required
+    /// for frame metadata (channel ID, frame number, data length, flags) and
+    /// L1 transaction overhead. Used for buffer size calculations and gas
+    /// estimation when planning frame transmission.
+    pub const OVERHEAD: usize = 200;
+
+    /// Maximum allowed size for a single frame in bytes.
+    ///
+    /// While typical L1 transactions carrying frames are around 128 KB due to
+    /// network conditions and gas limits, this larger limit provides headroom
+    /// for future growth as L1 gas limits and network conditions improve.
+    ///
+    /// The 1MB limit balances:
+    /// - **Transmission efficiency**: Larger frames reduce overhead
+    /// - **Network compatibility**: Must fit within reasonable L1 transaction sizes
+    /// - **Memory constraints**: Avoid excessive memory usage during processing
+    pub const MAX_LEN: usize = 1_000_000;
+
     /// Creates a new [`Frame`].
     pub const fn new(id: ChannelId, number: u16, data: Vec<u8>, is_last: bool) -> Self {
         Self { id, number, data, is_last }
@@ -204,7 +204,7 @@ impl Frame {
             encoded[18..22].try_into().map_err(|_| FrameDecodingError::InvalidDataLength)?,
         ) as usize;
 
-        if data_len > MAX_FRAME_LEN || data_len >= encoded.len() - (BASE_FRAME_LEN - 1) {
+        if data_len > Self::MAX_LEN || data_len >= encoded.len() - (BASE_FRAME_LEN - 1) {
             return Err(FrameDecodingError::DataTooLarge(data_len));
         }
 
@@ -260,7 +260,7 @@ impl Frame {
     /// of each frame in a channel determines the channel's size. The sum of the channel sizes
     /// is used for pruning & compared against the max channel bank size.
     pub const fn size(&self) -> usize {
-        self.data.len() + FRAME_OVERHEAD
+        self.data.len() + Self::OVERHEAD
     }
 }
 
@@ -290,11 +290,11 @@ mod tests {
         let frame = Frame {
             id: [0xFF; 16],
             number: 0xEE,
-            data: vec![0xDD; MAX_FRAME_LEN + 1],
+            data: vec![0xDD; Frame::MAX_LEN + 1],
             is_last: true,
         };
         let err = Frame::decode(&frame.encode()).unwrap_err();
-        assert_eq!(err, FrameDecodingError::DataTooLarge(MAX_FRAME_LEN + 1));
+        assert_eq!(err, FrameDecodingError::DataTooLarge(Frame::MAX_LEN + 1));
     }
 
     #[test]

--- a/crates/consensus/protocol/src/lib.rs
+++ b/crates/consensus/protocol/src/lib.rs
@@ -34,24 +34,16 @@ mod block;
 pub use block::{BlockInfo, FromBlockError, L2BlockInfo};
 
 mod frame;
-pub use frame::{
-    DERIVATION_VERSION_0, FRAME_OVERHEAD, Frame, FrameDecodingError, FrameParseError, MAX_FRAME_LEN,
-};
+pub use frame::{DERIVATION_VERSION_0, Frame, FrameDecodingError, FrameParseError};
 
 mod utils;
 pub use utils::{read_tx_data, to_system_config};
 
 mod channel;
-pub use channel::{
-    CHANNEL_ID_LENGTH, Channel, ChannelError, ChannelId, FJORD_MAX_RLP_BYTES_PER_CHANNEL,
-    MAX_RLP_BYTES_PER_CHANNEL,
-};
+pub use channel::{Channel, ChannelError, ChannelId};
 
 mod deposits;
-pub use deposits::{
-    DEPOSIT_EVENT_ABI, DEPOSIT_EVENT_ABI_HASH, DEPOSIT_EVENT_VERSION_0, DepositError,
-    decode_deposit,
-};
+pub use deposits::{DepositDecodeError, Deposits};
 
 mod info;
 pub use info::{


### PR DESCRIPTION
## Summary

Moves module-level constants in the consensus protocol crate onto their associated types as impl-block constants. Frame::OVERHEAD and Frame::MAX_LEN replace FRAME_OVERHEAD and MAX_FRAME_LEN. Channel::ID_LENGTH, Channel::MAX_RLP_BYTES, and Channel::FJORD_MAX_RLP_BYTES replace the bare channel constants. The Deposits unit struct gains EVENT_ABI, EVENT_ABI_HASH, and EVENT_VERSION_0 as associated constants, with decode_deposit and unmarshal_deposit_version0 becoming Deposits::decode and Deposits::unmarshal_v0. DepositError is renamed to DepositDecodeError.