### PR TITLE
fix(ci): Free Disk Space Reliably

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -33,14 +33,25 @@ inputs:
 runs:
   using: composite
   steps:
+    - name: Free Disk Space (fast pre-clean)
+      if: inputs.free-disk == 'true'
+      shell: bash
+      run: |
+        sudo rm -rf /usr/local/lib/android
+        sudo rm -rf /usr/share/dotnet
+        sudo rm -rf /opt/ghc
+        sudo rm -rf /usr/local/share/boost
+        sudo rm -rf /opt/hostedtoolcache/CodeQL
+        df -h
+
     - name: Free Disk Space
       if: inputs.free-disk == 'true'
       continue-on-error: true
       uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
       with:
         tool-cache: false
-        android: true
-        dotnet: true
+        android: false
+        dotnet: false
         haskell: true
         large-packages: false
         swap-storage: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,8 +97,6 @@ jobs:
         with:
           fetch-depth: 1
       - uses: ./.github/actions/setup
-        with:
-          rust-cache-shared-key: "stable"
       - name: Install musl toolchain
         run: |
           sudo apt-get update && sudo apt-get install -y musl-tools


### PR DESCRIPTION
## Summary

Two separate failure modes were causing no-space-left crashes on CI runners. First, the jlumbroso/free-disk-space action uses apt-get internally and silently fails when the disk is already critically full, leaving nothing freed before cache restoration or compilation. This is fixed by adding a fast rm -rf pre-clean step that removes Android SDK, .NET, GHC, Boost, and CodeQL (~15-20 GB) before apt-based cleanup runs. Second, the test-musl-sigsegv job was restoring the shared stable Rust cache, a multi-GB artifact set it has no use for given it only builds one package for a specific target. Removing that cache key eliminates the root cause of its failures.