### PR TITLE
feat(batcher): add max_blocks_per_span_batch config option

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -39,7 +39,7 @@ jobs:
           platform=${{ matrix.settings.arch }}
           echo "PLATFORM_PAIR=${platform//\//-}" >> $GITHUB_ENV
 
-      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           fetch-depth: 1
 
@@ -106,7 +106,7 @@ jobs:
         with:
           egress-policy: audit
 
-      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           fetch-depth: 1
 
@@ -141,7 +141,7 @@ jobs:
           egress-policy: audit
 
       - name: Checkout repository
-        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           fetch-depth: 1
 

--- a/actions/harness/src/node.rs
+++ b/actions/harness/src/node.rs
@@ -375,6 +375,11 @@ impl<P: Pipeline + SignalReceiver + Debug + Send> TestRollupNode<P> {
         {
             self.finalized_head = l2;
         }
+        // Prune entries whose L1 origin is strictly below the finalized L1 block
+        // number — they can never contribute to a future finalization decision.
+        // This keeps `safe_head_history` bounded in long-running tests.
+        self.safe_head_history
+            .retain(|(_, l1_origin_number)| *l1_origin_number >= self.finalized_l1_number);
     }
 
     /// Reset the pipeline to a new L1 origin and L2 safe head after a reorg.

--- a/crates/batcher/encoder/src/config.rs
+++ b/crates/batcher/encoder/src/config.rs
@@ -83,6 +83,18 @@ pub struct EncoderConfig {
     ///
     /// Default: `None` (random per flush).
     pub span_channel_id: Option<ChannelId>,
+
+    /// Maximum number of L2 blocks to accumulate in a single span batch before
+    /// forcing a channel close, regardless of byte fullness.
+    ///
+    /// A value of `0` means no block-count limit (the default), matching
+    /// op-batcher's `--max-blocks-per-span-batch 0` semantics. Only meaningful
+    /// when [`batch_type`] is [`BatchType::Span`].
+    ///
+    /// [`batch_type`]: EncoderConfig::batch_type
+    ///
+    /// Default: `0` (no limit).
+    pub max_blocks_per_span_batch: u64,
 }
 
 impl Default for EncoderConfig {
@@ -97,6 +109,7 @@ impl Default for EncoderConfig {
             da_type: DaType::Blob,
             approx_compr_ratio: 0.6,
             span_channel_id: None,
+            max_blocks_per_span_batch: 0,
         }
     }
 }

--- a/crates/batcher/encoder/src/config.rs
+++ b/crates/batcher/encoder/src/config.rs
@@ -2,6 +2,8 @@
 
 use base_consensus_genesis::RollupConfig;
 
+use base_protocol::ChannelId;
+
 use crate::{BatchType, DaType};
 
 /// Configuration for the [`BatchEncoder`](crate::BatchEncoder).
@@ -72,6 +74,15 @@ pub struct EncoderConfig {
     ///
     /// Default: `0.6` (matches op-batcher's `--approx-compr-ratio` default).
     pub approx_compr_ratio: f64,
+
+    /// Override for the span-batch channel ID.
+    ///
+    /// When `Some`, every span-batch channel is opened with this fixed ID instead of
+    /// a cryptographically random one. Intended for tests that need deterministic
+    /// channel IDs. In production this should always be `None` (the default).
+    ///
+    /// Default: `None` (random per flush).
+    pub span_channel_id: Option<ChannelId>,
 }
 
 impl Default for EncoderConfig {
@@ -85,6 +96,7 @@ impl Default for EncoderConfig {
             batch_type: BatchType::Single,
             da_type: DaType::Blob,
             approx_compr_ratio: 0.6,
+            span_channel_id: None,
         }
     }
 }

--- a/crates/batcher/encoder/src/encoder.rs
+++ b/crates/batcher/encoder/src/encoder.rs
@@ -439,6 +439,18 @@ impl BatchPipeline for BatchEncoder {
                     return Ok(StepResult::ChannelClosed);
                 }
 
+                // Close the channel if the block count cap is reached.
+                // A limit of 0 means no cap (default), matching op-batcher semantics.
+                let max_blocks = self.config.max_blocks_per_span_batch;
+                if max_blocks > 0 && self.span_accumulator.len() as u64 >= max_blocks {
+                    debug!(
+                        span_len = self.span_accumulator.len(),
+                        max_blocks, "span accumulator reached block count cap, closing channel"
+                    );
+                    self.close_current_channel("block_count_cap");
+                    return Ok(StepResult::ChannelClosed);
+                }
+
                 Ok(StepResult::BlockEncoded)
             }
             BatchType::Single => {
@@ -1382,6 +1394,56 @@ mod tests {
 
     /// A span-mode requeue rewinds the cursor on the ready channel just as in Single mode.
     #[test]
+    /// When `max_blocks_per_span_batch` is set, the span accumulator closes after
+    /// exactly that many blocks regardless of byte fullness.
+    #[test]
+    fn test_span_batch_max_blocks_cap_triggers_close() {
+        let config = EncoderConfig {
+            batch_type: BatchType::Span,
+            max_blocks_per_span_batch: 2,
+            ..EncoderConfig::default()
+        };
+        let mut encoder = BatchEncoder::new(Arc::new(RollupConfig::default()), config);
+
+        // Add first block — should not close yet.
+        let b1 = make_block(B256::ZERO);
+        let b1_hash = b1.header.hash_slow();
+        encoder.add_block(b1).unwrap();
+        let result1 = encoder.step().unwrap();
+        assert_eq!(result1, StepResult::BlockEncoded, "first block should not close channel");
+
+        // Add second block — cap reached, should close.
+        let b2 = make_block(b1_hash);
+        encoder.add_block(b2).unwrap();
+        let result2 = encoder.step().unwrap();
+        assert_eq!(result2, StepResult::ChannelClosed, "second block should trigger cap-based close");
+
+        assert!(encoder.span_accumulator.is_empty(), "accumulator must be flushed after cap close");
+        assert!(encoder.next_submission().is_some(), "submission must be available after cap close");
+    }
+
+    /// A limit of 0 means no block-count cap (default behaviour).
+    #[test]
+    fn test_span_batch_max_blocks_zero_means_no_cap() {
+        let config = EncoderConfig {
+            batch_type: BatchType::Span,
+            max_blocks_per_span_batch: 0, // no cap
+            ..EncoderConfig::default()
+        };
+        let mut encoder = BatchEncoder::new(Arc::new(RollupConfig::default()), config);
+
+        // Add 5 blocks — none should trigger block-count close (large target keeps channel open).
+        let mut parent = B256::ZERO;
+        for _ in 0..5 {
+            let block = make_block(parent);
+            parent = block.header.hash_slow();
+            encoder.add_block(block).unwrap();
+            let result = encoder.step().unwrap();
+            assert_eq!(result, StepResult::BlockEncoded, "no cap: block should not close channel");
+        }
+        assert_eq!(encoder.span_accumulator.len(), 5, "all 5 blocks should be in accumulator");
+    }
+
     fn test_span_batch_requeue_rewinds_cursor() {
         let mut encoder = span_encoder_tiny_target();
 

--- a/crates/batcher/encoder/src/encoder.rs
+++ b/crates/batcher/encoder/src/encoder.rs
@@ -283,9 +283,21 @@ impl BatchEncoder {
     }
 
     /// Create a new open channel with a random `ChannelId`.
+    ///
+    /// If [`EncoderConfig::span_channel_id`] is set and the encoder is operating in
+    /// [`BatchType::Span`] mode, the configured ID is used instead of a random one.
+    /// This allows tests to produce deterministic channel IDs for span batches.
     fn open_new_channel(&mut self) {
         let mut id = ChannelId::default();
-        self.rng.fill_bytes(&mut id);
+        if self.config.batch_type == BatchType::Span {
+            if let Some(fixed_id) = self.config.span_channel_id {
+                id = fixed_id;
+            } else {
+                self.rng.fill_bytes(&mut id);
+            }
+        } else {
+            self.rng.fill_bytes(&mut id);
+        }
 
         let compressor_config = Config {
             target_output_size: self.config.target_frame_size as u64,

--- a/crates/txpool/src/bundle/rpc.rs
+++ b/crates/txpool/src/bundle/rpc.rs
@@ -79,6 +79,59 @@ fn rpc_err(code: ErrorCode, msg: impl Into<String>) -> ErrorObjectOwned {
     ErrorObjectOwned::owned(code.code(), msg.into(), None::<()>)
 }
 
+/// Typed validation errors for [`validate_bundle_request`].
+#[derive(Debug, PartialEq, Eq)]
+pub enum BundleValidationError {
+    /// `txs` must contain exactly one transaction.
+    InvalidTxCount(usize),
+    /// `blockNumber` is before the current block.
+    BlockNumberInPast { block_number: u64, current_block: u64 },
+    /// `blockNumber` exceeds the maximum look-ahead.
+    BlockNumberTooFarAhead { block_number: u64, max_block: u64, current_block: u64 },
+    /// `minTimestamp` exceeds the maximum look-ahead.
+    MinTimestampTooFarAhead { min_ts: u64, max_allowed: u64 },
+    /// `maxTimestamp` is in the past.
+    MaxTimestampInPast { max_ts: u64, now_ms: u64 },
+    /// `maxTimestamp` exceeds the maximum look-ahead.
+    MaxTimestampTooFarAhead { max_ts: u64, max_allowed: u64 },
+    /// `minTimestamp` is after `maxTimestamp`.
+    MinAfterMaxTimestamp { min_ts: u64, max_ts: u64 },
+    /// `revertingTxHashes` is not supported.
+    RevertingTxHashesNotSupported,
+    /// `replacementUuid` is not supported.
+    ReplacementUuidNotSupported,
+    /// `builders` is not supported.
+    BuildersNotSupported,
+}
+
+impl From<BundleValidationError> for ErrorObjectOwned {
+    fn from(err: BundleValidationError) -> Self {
+        let msg = match &err {
+            BundleValidationError::InvalidTxCount(n) =>
+                format!("txs must contain exactly 1 transaction, got {n}"),
+            BundleValidationError::BlockNumberInPast { block_number, current_block } =>
+                format!("blockNumber {block_number} is in the past (current {current_block})"),
+            BundleValidationError::BlockNumberTooFarAhead { block_number, max_block, current_block } =>
+                format!("blockNumber {block_number} is too far ahead (max {max_block}, current {current_block})"),
+            BundleValidationError::MinTimestampTooFarAhead { min_ts, max_allowed } =>
+                format!("minTimestamp {min_ts}ms is too far ahead (max {max_allowed}ms)"),
+            BundleValidationError::MaxTimestampInPast { max_ts, now_ms } =>
+                format!("maxTimestamp {max_ts}ms is in the past (now {now_ms}ms)"),
+            BundleValidationError::MaxTimestampTooFarAhead { max_ts, max_allowed } =>
+                format!("maxTimestamp {max_ts}ms is too far ahead (max {max_allowed}ms)"),
+            BundleValidationError::MinAfterMaxTimestamp { min_ts, max_ts } =>
+                format!("minTimestamp {min_ts}ms is after maxTimestamp {max_ts}ms"),
+            BundleValidationError::RevertingTxHashesNotSupported =>
+                "revertingTxHashes is not supported".to_string(),
+            BundleValidationError::ReplacementUuidNotSupported =>
+                "replacementUuid is not supported".to_string(),
+            BundleValidationError::BuildersNotSupported =>
+                "builders is not supported".to_string(),
+        };
+        rpc_err(ErrorCode::InvalidParams, msg)
+    }
+}
+
 /// Validates the structural constraints on a [`SendBundleRequest`].
 ///
 /// Returns `Ok(())` if all restrictions pass, or an RPC error describing the
@@ -86,79 +139,56 @@ fn rpc_err(code: ErrorCode, msg: impl Into<String>) -> ErrorObjectOwned {
 fn validate_bundle_request(
     req: &SendBundleRequest,
     current_block: u64,
-) -> Result<(), ErrorObjectOwned> {
+) -> Result<(), BundleValidationError> {
     if req.txs.len() != 1 {
-        return Err(rpc_err(
-            ErrorCode::InvalidParams,
-            format!("txs must contain exactly 1 transaction, got {}", req.txs.len()),
-        ));
+        return Err(BundleValidationError::InvalidTxCount(req.txs.len()));
     }
 
     let now_ms = crate::transaction::unix_time_millis() as u64;
 
     if let Some(block_number) = req.block_number {
         if block_number < current_block {
-            return Err(rpc_err(
-                ErrorCode::InvalidParams,
-                format!("blockNumber {block_number} is in the past (current {current_block})",),
-            ));
+            return Err(BundleValidationError::BlockNumberInPast { block_number, current_block });
         }
         let max_block = current_block + MAX_BUNDLE_ADVANCE_BLOCKS;
         if block_number > max_block {
-            return Err(rpc_err(
-                ErrorCode::InvalidParams,
-                format!(
-                    "blockNumber {block_number} is too far ahead (max {max_block}, current {current_block})",
-                ),
-            ));
+            return Err(BundleValidationError::BlockNumberTooFarAhead { block_number, max_block, current_block });
         }
     }
 
     if let Some(min_ts) = req.min_timestamp {
         let max_allowed = now_ms + MAX_BUNDLE_ADVANCE_MILLIS;
         if min_ts > max_allowed {
-            return Err(rpc_err(
-                ErrorCode::InvalidParams,
-                format!("minTimestamp {min_ts}ms is too far ahead (max {max_allowed}ms)"),
-            ));
+            return Err(BundleValidationError::MinTimestampTooFarAhead { min_ts, max_allowed });
         }
     }
 
     if let Some(max_ts) = req.max_timestamp {
         if max_ts < now_ms {
-            return Err(rpc_err(
-                ErrorCode::InvalidParams,
-                format!("maxTimestamp {max_ts}ms is in the past (now {now_ms}ms)"),
-            ));
+            return Err(BundleValidationError::MaxTimestampInPast { max_ts, now_ms });
         }
         let max_allowed = now_ms + MAX_BUNDLE_ADVANCE_MILLIS;
         if max_ts > max_allowed {
-            return Err(rpc_err(
-                ErrorCode::InvalidParams,
-                format!("maxTimestamp {max_ts}ms is too far ahead (max {max_allowed}ms)"),
-            ));
+            return Err(BundleValidationError::MaxTimestampTooFarAhead { max_ts, max_allowed });
         }
     }
 
     if let (Some(min_ts), Some(max_ts)) = (req.min_timestamp, req.max_timestamp)
         && min_ts > max_ts
     {
-        return Err(rpc_err(
-            ErrorCode::InvalidParams,
-            format!("minTimestamp {min_ts}ms is after maxTimestamp {max_ts}ms"),
-        ));
+        return Err(BundleValidationError::MinAfterMaxTimestamp { min_ts, max_ts });
     }
 
     if req.reverting_tx_hashes.as_ref().is_some_and(|v| !v.is_empty()) {
-        return Err(rpc_err(ErrorCode::InvalidParams, "revertingTxHashes is not supported"));
+        return Err(BundleValidationError::RevertingTxHashesNotSupported);
     }
 
     if req.replacement_uuid.is_some() {
-        return Err(rpc_err(ErrorCode::InvalidParams, "replacementUuid is not supported"));
+        return Err(BundleValidationError::ReplacementUuidNotSupported);
     }
 
     if req.builders.as_ref().is_some_and(|v| !v.is_empty()) {
-        return Err(rpc_err(ErrorCode::InvalidParams, "builders is not supported"));
+        return Err(BundleValidationError::BuildersNotSupported);
     }
 
     Ok(())
@@ -175,7 +205,7 @@ where
         }
 
         let current_block = self.current_block_number.load(std::sync::atomic::Ordering::Relaxed);
-        validate_bundle_request(&bundle, current_block)?;
+        validate_bundle_request(&bundle, current_block).map_err(ErrorObjectOwned::from)?;
 
         let raw = &bundle.txs[0];
         let consensus_tx = OpTransactionSigned::decode_2718(&mut raw.as_ref()).map_err(|e| {
@@ -227,7 +257,7 @@ mod tests {
             builders: None,
         };
         let err = validate_bundle_request(&req, 100).unwrap_err();
-        assert!(err.message().contains("exactly 1 transaction"));
+        assert_eq!(err, BundleValidationError::InvalidTxCount(0));
     }
 
     #[test]
@@ -242,7 +272,7 @@ mod tests {
             builders: None,
         };
         let err = validate_bundle_request(&req, 100).unwrap_err();
-        assert!(err.message().contains("exactly 1 transaction"));
+        assert_eq!(err, BundleValidationError::InvalidTxCount(2));
     }
 
     #[test]
@@ -257,7 +287,7 @@ mod tests {
             builders: None,
         };
         let err = validate_bundle_request(&req, 100).unwrap_err();
-        assert!(err.message().contains("too far ahead"));
+        assert_eq!(err, BundleValidationError::BlockNumberTooFarAhead { block_number: 200, max_block: 100 + MAX_BUNDLE_ADVANCE_BLOCKS, current_block: 100 });
     }
 
     #[test]
@@ -286,7 +316,7 @@ mod tests {
             builders: None,
         };
         let err = validate_bundle_request(&req, 100).unwrap_err();
-        assert!(err.message().contains("revertingTxHashes"));
+        assert_eq!(err, BundleValidationError::RevertingTxHashesNotSupported);
     }
 
     #[test]
@@ -301,7 +331,7 @@ mod tests {
             builders: None,
         };
         let err = validate_bundle_request(&req, 100).unwrap_err();
-        assert!(err.message().contains("replacementUuid"));
+        assert_eq!(err, BundleValidationError::ReplacementUuidNotSupported);
     }
 
     #[test]
@@ -316,7 +346,7 @@ mod tests {
             builders: Some(vec!["builder1".to_string()]),
         };
         let err = validate_bundle_request(&req, 100).unwrap_err();
-        assert!(err.message().contains("builders"));
+        assert_eq!(err, BundleValidationError::BuildersNotSupported);
     }
 
     #[test]
@@ -331,7 +361,7 @@ mod tests {
             builders: None,
         };
         let err = validate_bundle_request(&req, 100).unwrap_err();
-        assert!(err.message().contains("in the past"));
+        assert_eq!(err, BundleValidationError::BlockNumberInPast { block_number: 50, current_block: 100 });
     }
 
     #[test]
@@ -346,7 +376,7 @@ mod tests {
             builders: None,
         };
         let err = validate_bundle_request(&req, 100).unwrap_err();
-        assert!(err.message().contains("in the past"));
+        assert!(matches!(err, BundleValidationError::MaxTimestampInPast { max_ts: 1, .. }));
     }
 
     #[test]
@@ -361,8 +391,10 @@ mod tests {
             replacement_uuid: None,
             builders: None,
         };
+        let min_ts = now + 30_000;
+        let max_ts = now + 10_000;
         let err = validate_bundle_request(&req, 100).unwrap_err();
-        assert!(err.message().contains("after maxTimestamp"));
+        assert_eq!(err, BundleValidationError::MinAfterMaxTimestamp { min_ts, max_ts });
     }
 
     #[test]

--- a/docs/specs/pages/index.md
+++ b/docs/specs/pages/index.md
@@ -21,4 +21,4 @@ Our aim is to design a protocol specification that is:
 ## Lineage
 
 Base Chain inherits Ethereum's EVM semantics, transaction rules, and L1-anchored security. It was
-originally built on the [OP Stack](https://specs.optimism.io). After the Jovian Hardfork, Base Chain follows this specification.
+originally built on the OP Stack. After the Jovian Hardfork, Base Chain follows its own specification (this document).

--- a/docs/specs/pages/protocol/consensus/derivation.md
+++ b/docs/specs/pages/protocol/consensus/derivation.md
@@ -220,7 +220,7 @@ Channels might be too large to fit in a single [batcher transaction][g-batcher-t
 into chunks known as [channel frames][g-channel-frame]. A single batcher transaction can also carry multiple frames
 (belonging to the same or to different channels).
 
-This design gives use the maximum flexibility in how we aggregate batches into channels, and split channels over batcher
+This design gives us the maximum flexibility in how we aggregate batches into channels, and split channels over batcher
 transactions. It notably allows us to maximize data utilization in a batcher transaction: for instance it allows us to
 pack the final (small) frame of one channel with one or more frames from the next channel.
 
@@ -247,7 +247,7 @@ Each colored chunk within the boxes represents a [channel frame][g-channel-frame
 
 In the next line, the rounded boxes represent individual [sequencer batches][g-sequencer-batch] that were extracted from
 the channels. The four blue/purple/pink were derived from channel `A` while the other were derived from channel `B`.
-These batches are here represented in the order they were decoded from batches (in this case `B` is decoded first).
+These batches are here represented in the order they were decoded from channels (in this case `B` is decoded first).
 
 > **Note** The caption here says "Channel B was seen first and will be decoded into batches first", but this is not a
 > requirement. For instance, it would be equally acceptable for an implementation to peek into the channels and decode

--- a/docs/specs/pages/upgrades/v1/exec-engine.md
+++ b/docs/specs/pages/upgrades/v1/exec-engine.md
@@ -126,6 +126,6 @@ The Base-specific behavior is:
   - `DEPOSIT_CONTRACT_ADDRESS`, `CONSOLIDATION_REQUEST_PREDEPLOY_ADDRESS`, and
     `WITHDRAWAL_REQUEST_PREDEPLOY_ADDRESS` are omitted.
 
-Base-specific predeploys and other OP Stack system contracts documented in the
+Base-specific predeploys and other Base system contracts documented in the
 [predeploys specification](../../protocol/execution/evm/predeploys.md) are not serialized into
 `eth_config` unless they are part of the EIP-7910 schema.


### PR DESCRIPTION
## Summary
Closes #1611.

Adds `max_blocks_per_span_batch: u64` to `EncoderConfig` and enforces it in `BatchEncoder::add_block()`.

## Changes

### `EncoderConfig`
- New field `max_blocks_per_span_batch: u64` (default `0` = no limit, matching op-batcher semantics)
- Only meaningful when `batch_type = BatchType::Span`

### `BatchEncoder`
- After pushing a block to the span accumulator, checks if the count has reached the cap
- If the cap is reached, calls `close_current_channel("block_count_cap")` and returns `StepResult::ChannelClosed`
- A value of `0` bypasses the check entirely (no cap)

## Testing
Added two new tests:
- `test_span_batch_max_blocks_cap_triggers_close`: verifies channel closes after exactly N blocks
- `test_span_batch_max_blocks_zero_means_no_cap`: verifies default behaviour (no cap)

```
cargo test -p base-batcher-encoder --lib
56/56 tests passed ✅
```