### PR TITLE
refactor(challenger): simplify cli wiring

### DIFF
--- a/crates/proof/challenge/src/cli.rs
+++ b/crates/proof/challenge/src/cli.rs
@@ -18,7 +18,7 @@ base_tx_manager::define_signer_cli!("BASE_CHALLENGER");
 base_tx_manager::define_tx_manager_cli!("BASE_CHALLENGER");
 
 /// Challenger - ZK-proof dispute game challenger for Base.
-#[derive(Parser)]
+#[derive(Debug, Parser)]
 #[command(name = "challenger")]
 #[command(version, about, long_about = None)]
 #[command(styles = CliStyles::init())]
@@ -40,19 +40,8 @@ pub struct Cli {
     pub health: HealthArgs,
 }
 
-impl std::fmt::Debug for Cli {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("Cli")
-            .field("challenger", &self.challenger)
-            .field("logging", &self.logging)
-            .field("metrics", &self.metrics)
-            .field("health", &self.health)
-            .finish()
-    }
-}
-
 /// Core challenger configuration arguments.
-#[derive(Parser)]
+#[derive(Debug, Parser)]
 #[command(next_help_heading = "Challenger")]
 pub struct ChallengerArgs {
     /// URL of the L1 Ethereum RPC endpoint.
@@ -137,24 +126,4 @@ pub struct ChallengerArgs {
         value_delimiter = ','
     )]
     pub bond_claim_addresses: Vec<Address>,
-}
-
-impl std::fmt::Debug for ChallengerArgs {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("ChallengerArgs")
-            .field("l1_eth_rpc", &self.l1_eth_rpc)
-            .field("l2_eth_rpc", &self.l2_eth_rpc)
-            .field("dispute_game_factory_addr", &self.dispute_game_factory_addr)
-            .field("poll_interval", &self.poll_interval)
-            .field("zk_rpc_url", &self.zk_rpc_url)
-            .field("zk_connect_timeout", &self.zk_connect_timeout)
-            .field("zk_request_timeout", &self.zk_request_timeout)
-            .field("tee_rpc_url", &self.tee_rpc_url)
-            .field("tee_request_timeout", &self.tee_request_timeout)
-            .field("signer", &self.signer)
-            .field("tx_manager", &self.tx_manager)
-            .field("lookback_games", &self.lookback_games)
-            .field("bond_claim_addresses", &self.bond_claim_addresses)
-            .finish()
-    }
 }

--- a/crates/proof/challenge/src/config.rs
+++ b/crates/proof/challenge/src/config.rs
@@ -54,12 +54,10 @@ impl<T: fmt::Display> fmt::Display for Validated<T> {
 #[derive(Debug, Error)]
 pub enum ConfigError {
     /// Invalid URL format.
-    #[error("invalid {field} URL: {reason}")]
+    #[error("invalid {field} URL: missing host")]
     InvalidUrl {
         /// The field name that contains the invalid URL.
         field: &'static str,
-        /// The reason the URL is invalid.
-        reason: String,
     },
     /// A field value is out of the allowed range.
     #[error("{field} must be {constraint}, got {value}")]
@@ -69,11 +67,11 @@ pub enum ConfigError {
         /// The constraint description.
         constraint: &'static str,
         /// The actual value.
-        value: String,
+        value: &'static str,
     },
     /// Invalid metrics configuration.
     #[error("invalid metrics config: {0}")]
-    Metrics(String),
+    Metrics(&'static str),
     /// Invalid signing configuration.
     #[error("invalid signing config: {0}")]
     Signer(#[from] base_tx_manager::ConfigError),
@@ -135,89 +133,67 @@ impl ChallengerConfig {
     ///
     /// Returns [`ConfigError`] if any validation check fails.
     pub fn from_cli(cli: Cli) -> Result<Self, ConfigError> {
-        let validate = |url: Url, field: &'static str| -> Result<Validated<Url>, ConfigError> {
-            Validated::try_from(url)
-                .map_err(|e| ConfigError::InvalidUrl { field, reason: e.to_string() })
+        let validate_url = |url: Url, field: &'static str| -> Result<Validated<Url>, ConfigError> {
+            Validated::try_from(url).map_err(|_| ConfigError::InvalidUrl { field })
         };
 
-        // Validate URLs have scheme and host
-        let l1_eth_rpc = validate(cli.challenger.l1_eth_rpc, "l1-eth-rpc")?;
-        let l2_eth_rpc = validate(cli.challenger.l2_eth_rpc, "l2-eth-rpc")?;
-        let zk_rpc_url = validate(cli.challenger.zk_rpc_url, "zk-rpc-url")?;
+        let require_nonzero = |value: u64, field: &'static str| -> Result<(), ConfigError> {
+            if value == 0 {
+                return Err(ConfigError::OutOfRange {
+                    field,
+                    constraint: "greater than 0",
+                    value: "0",
+                });
+            }
+            Ok(())
+        };
+
+        let require_nonzero_duration =
+            |d: Duration, field: &'static str| -> Result<(), ConfigError> {
+                if d.is_zero() {
+                    return Err(ConfigError::OutOfRange {
+                        field,
+                        constraint: "greater than 0",
+                        value: "0",
+                    });
+                }
+                Ok(())
+            };
+
+        let l1_eth_rpc = validate_url(cli.challenger.l1_eth_rpc, "l1-eth-rpc")?;
+        let l2_eth_rpc = validate_url(cli.challenger.l2_eth_rpc, "l2-eth-rpc")?;
+        let zk_rpc_url = validate_url(cli.challenger.zk_rpc_url, "zk-rpc-url")?;
         let tee_rpc_url =
-            cli.challenger.tee_rpc_url.map(|url| validate(url, "tee-rpc-url")).transpose()?;
+            cli.challenger.tee_rpc_url.map(|url| validate_url(url, "tee-rpc-url")).transpose()?;
 
-        // Validate poll_interval > 0
-        if cli.challenger.poll_interval.is_zero() {
-            return Err(ConfigError::OutOfRange {
-                field: "poll-interval",
-                constraint: "greater than 0",
-                value: "0".to_string(),
-            });
-        }
+        require_nonzero_duration(cli.challenger.poll_interval, "poll-interval")?;
+        require_nonzero_duration(cli.challenger.zk_connect_timeout, "zk-connect-timeout")?;
+        require_nonzero_duration(cli.challenger.zk_request_timeout, "zk-request-timeout")?;
 
-        // Validate zk_connect_timeout > 0
-        if cli.challenger.zk_connect_timeout.is_zero() {
-            return Err(ConfigError::OutOfRange {
-                field: "zk-connect-timeout",
-                constraint: "greater than 0",
-                value: "0".to_string(),
-            });
-        }
+        let tee_request_timeout = if tee_rpc_url.is_some() {
+            require_nonzero_duration(cli.challenger.tee_request_timeout, "tee-request-timeout")?;
+            Some(cli.challenger.tee_request_timeout)
+        } else {
+            None
+        };
 
-        // Validate zk_request_timeout > 0
-        if cli.challenger.zk_request_timeout.is_zero() {
-            return Err(ConfigError::OutOfRange {
-                field: "zk-request-timeout",
-                constraint: "greater than 0",
-                value: "0".to_string(),
-            });
-        }
+        require_nonzero(cli.challenger.lookback_games, "lookback-games")?;
 
-        // Validate tee_request_timeout > 0 when TEE is enabled
-        if tee_rpc_url.is_some() && cli.challenger.tee_request_timeout.is_zero() {
-            return Err(ConfigError::OutOfRange {
-                field: "tee-request-timeout",
-                constraint: "greater than 0",
-                value: "0".to_string(),
-            });
-        }
+        // Health server is always started, so the port must be valid.
+        require_nonzero(cli.health.port.into(), "health.port")?;
 
-        // Validate lookback_games > 0
-        if cli.challenger.lookback_games == 0 {
-            return Err(ConfigError::OutOfRange {
-                field: "lookback-games",
-                constraint: "greater than 0",
-                value: "0".to_string(),
-            });
-        }
-
-        // Validate health port (health server is always started)
-        if cli.health.port == 0 {
-            return Err(ConfigError::OutOfRange {
-                field: "health.port",
-                constraint: "greater than 0",
-                value: "0".to_string(),
-            });
-        }
-
-        // Validate metrics port when enabled
         if cli.metrics.enabled && cli.metrics.port == 0 {
             return Err(ConfigError::Metrics(
-                "metrics port must be non-zero when metrics are enabled".to_string(),
+                "metrics port must be non-zero when metrics are enabled",
             ));
         }
 
-        // Validate and extract signing config
         let signing = SignerConfig::try_from(cli.challenger.signer)?;
 
-        // Validate and extract tx manager config
         let tx_manager =
             TxManagerConfig::try_from(cli.challenger.tx_manager).map_err(ConfigError::TxManager)?;
 
         let health_addr = cli.health.socket_addr();
-
-        let tee_request_timeout = tee_rpc_url.as_ref().map(|_| cli.challenger.tee_request_timeout);
 
         Ok(Self {
             l1_eth_rpc,
@@ -384,15 +360,15 @@ mod tests {
 
     #[rstest]
     #[case::invalid_url(
-        ConfigError::InvalidUrl { field: "l1-eth-rpc", reason: "missing host".to_string() },
+        ConfigError::InvalidUrl { field: "l1-eth-rpc" },
         "invalid l1-eth-rpc URL: missing host"
     )]
     #[case::out_of_range(
-        ConfigError::OutOfRange { field: "poll-interval", constraint: "greater than 0", value: "0".to_string() },
+        ConfigError::OutOfRange { field: "poll-interval", constraint: "greater than 0", value: "0" },
         "poll-interval must be greater than 0, got 0"
     )]
     #[case::metrics(
-        ConfigError::Metrics("port must be non-zero".to_string()),
+        ConfigError::Metrics("port must be non-zero"),
         "invalid metrics config: port must be non-zero"
     )]
     fn test_config_error_display(#[case] error: ConfigError, #[case] expected: &str) {


### PR DESCRIPTION
### What changed? Why?

Simplifies the challenger CLI module by removing boilerplate and unnecessary heap allocations:

- **Derive `Debug` instead of hand-rolling it** — `Cli` and `ChallengerArgs` had manual `Debug` impls that simply listed every field; replaced with `#[derive(Debug)]` on both structs.
- **Extract shared validation helpers** — Repetitive zero-check `if` blocks in `ChallengerConfig::from_cli` are replaced by `require_nonzero` and `require_nonzero_duration` closures, cutting duplicated validation logic.
- **Eliminate needless `String` allocations in `ConfigError`** — The `reason`, `value`, and `Metrics` payloads were always string literals, so they are now `&'static str`. The `InvalidUrl` variant no longer carries a separate `reason` field (it was always "missing host").
- **Rename `validate` closure to `validate_url`** for clarity.
- **Remove stale inline comments** that just restated the code (`// Validate URLs have scheme and host`, etc.).

### Notes to reviewers

Pure refactor — no behavioral changes. All existing tests pass with updated error construction (literals instead of `.to_string()`).

### How has it been tested?

Existing unit tests in `config.rs` (updated to match the new `&'static str` error variants).

### Change management ([definitions](http://go/change-management))

type=routine<!--routine,nonroutine,emergency-->
risk=low<!--low,medium,high-->
impact=sev5<!--sev5,sev4,sev3,sev2,sev1-->

### Backwards Compatibility ([learn more](http://go/backwards-compatibility))

backwards_compatible=true<!-- true false -->

<!-- Automatically merge your PR once the necessary approvals have been received (you probably want this) -->

automerge=false