### PR TITLE
fix(metering): add missing merge_transitions in block metering

### DIFF
--- a/crates/client/metering/src/block.rs
+++ b/crates/client/metering/src/block.rs
@@ -112,6 +112,9 @@ where
     }
     let execution_time = evm_start.elapsed().as_micros();
 
+    // Merge execution state transitions into bundle state
+    db.merge_transitions(revm_database::states::bundle_state::BundleRetention::Reverts);
+
     // Calculate state root and measure time
     let state_root_start = Instant::now();
     let hashed_state = state_provider.hashed_post_state(&db.bundle_state);


### PR DESCRIPTION
Add missing `merge_transitions()` call before computing state root in `meter_block`.

Without it, `db.bundle_state` is empty and state root calculation is incorrect.

This aligns with the correct pattern in `meter.rs` (added in a51b99ee).