### PR TITLE
chore(consensus): Base Protocol Type Rename

### DIFF
--- a/actions/harness/src/l2.rs
+++ b/actions/harness/src/l2.rs
@@ -17,7 +17,7 @@ use base_alloy_rpc_types_engine::{OpExecutionPayload, OpNetworkPayloadEnvelope, 
 use base_consensus_genesis::{RollupConfig, SystemConfig};
 use base_execution_chainspec::OpChainSpecBuilder;
 use base_execution_evm::OpEvmConfig;
-use base_protocol::{BlockInfo, L1BlockInfoTx, L2BlockInfo, AttributesWithParent};
+use base_protocol::{AttributesWithParent, BlockInfo, L1BlockInfoTx, L2BlockInfo};
 use base_revm::OpTransaction;
 use reth_evm::{ConfigureEvm, Evm as _, FromRecoveredTx};
 use revm::{

--- a/actions/harness/src/l2.rs
+++ b/actions/harness/src/l2.rs
@@ -17,7 +17,7 @@ use base_alloy_rpc_types_engine::{OpExecutionPayload, OpNetworkPayloadEnvelope, 
 use base_consensus_genesis::{RollupConfig, SystemConfig};
 use base_execution_chainspec::OpChainSpecBuilder;
 use base_execution_evm::OpEvmConfig;
-use base_protocol::{BlockInfo, L1BlockInfoTx, L2BlockInfo, OpAttributesWithParent};
+use base_protocol::{BlockInfo, L1BlockInfoTx, L2BlockInfo, AttributesWithParent};
 use base_revm::OpTransaction;
 use reth_evm::{ConfigureEvm, Evm as _, FromRecoveredTx};
 use revm::{
@@ -642,7 +642,7 @@ impl StatefulL2Executor {
     /// mirror the sequencer's block-by-block execution.
     pub fn execute_attrs(
         &mut self,
-        attrs: &OpAttributesWithParent,
+        attrs: &AttributesWithParent,
         block_number: u64,
         parent_hash: B256,
     ) -> Result<B256, L2SequencerError> {

--- a/actions/harness/src/node.rs
+++ b/actions/harness/src/node.rs
@@ -19,7 +19,7 @@ use base_consensus_genesis::RollupConfig;
 use base_consensus_safedb::{
     SafeDB, SafeDBError, SafeDBReader, SafeHeadListener, SafeHeadResponse,
 };
-use base_protocol::{BlockInfo, L1BlockInfoTx, L2BlockInfo, AttributesWithParent};
+use base_protocol::{AttributesWithParent, BlockInfo, L1BlockInfoTx, L2BlockInfo};
 
 use crate::{
     ActionBlobDataSource, ActionDataSource, ActionEngineClient, ActionL1ChainProvider,

--- a/actions/harness/src/node.rs
+++ b/actions/harness/src/node.rs
@@ -19,7 +19,7 @@ use base_consensus_genesis::RollupConfig;
 use base_consensus_safedb::{
     SafeDB, SafeDBError, SafeDBReader, SafeHeadListener, SafeHeadResponse,
 };
-use base_protocol::{BlockInfo, L1BlockInfoTx, L2BlockInfo, OpAttributesWithParent};
+use base_protocol::{BlockInfo, L1BlockInfoTx, L2BlockInfo, AttributesWithParent};
 
 use crate::{
     ActionBlobDataSource, ActionDataSource, ActionEngineClient, ActionL1ChainProvider,
@@ -643,7 +643,7 @@ impl<P: Pipeline + SignalReceiver + Debug + Send> TestRollupNode<P> {
     /// the call returns.
     ///
     /// [`derived_block`]: TestRollupNode::derived_block
-    async fn execute_and_advance(&mut self, attrs: OpAttributesWithParent) {
+    async fn execute_and_advance(&mut self, attrs: AttributesWithParent) {
         let block_number = attrs.block_number();
         let parent_hash = self.safe_head.block_info.hash;
         let timestamp = attrs.attributes.payload_attributes.timestamp;
@@ -798,7 +798,7 @@ impl<P: Pipeline + SignalReceiver + Debug + Send> TestRollupNode<P> {
     }
 
     /// Decode the L1 epoch from the first deposit transaction in derived attributes.
-    pub fn l1_origin_from_attrs(&self, attrs: &OpAttributesWithParent) -> Option<BlockNumHash> {
+    pub fn l1_origin_from_attrs(&self, attrs: &AttributesWithParent) -> Option<BlockNumHash> {
         let txs = attrs.attributes.transactions.as_ref()?;
         self.l1_origin_from_transactions(txs)
     }
@@ -815,8 +815,8 @@ impl<P: Pipeline + SignalReceiver + Debug + Send> TestRollupNode<P> {
     }
 
     /// Decode the full [`L1BlockInfoTx`] from the first deposit transaction in
-    /// derived [`OpAttributesWithParent`].
-    fn l1_info_from_attrs(&self, attrs: &OpAttributesWithParent) -> Option<L1BlockInfoTx> {
+    /// derived [`AttributesWithParent`].
+    fn l1_info_from_attrs(&self, attrs: &AttributesWithParent) -> Option<L1BlockInfoTx> {
         let txs = attrs.attributes.transactions.as_ref()?;
         Self::decode_deposit_l1_info(txs.first()?)
     }

--- a/crates/consensus/derive/src/pipeline/core.rs
+++ b/crates/consensus/derive/src/pipeline/core.rs
@@ -6,7 +6,7 @@ use core::fmt::Debug;
 use alloy_eips::BlockNumHash;
 use async_trait::async_trait;
 use base_consensus_genesis::{RollupConfig, SystemConfig};
-use base_protocol::{BatchValidationProvider, BlockInfo, L2BlockInfo, AttributesWithParent};
+use base_protocol::{AttributesWithParent, BatchValidationProvider, BlockInfo, L2BlockInfo};
 
 use crate::{
     ActivationSignal, L2ChainProvider, Metrics, NextAttributes, OriginAdvancer, OriginProvider,
@@ -257,7 +257,7 @@ mod tests {
     use alloy_rpc_types_engine::PayloadAttributes;
     use base_alloy_rpc_types_engine::OpPayloadAttributes;
     use base_consensus_genesis::{RollupConfig, SystemConfig};
-    use base_protocol::{L2BlockInfo, AttributesWithParent};
+    use base_protocol::{AttributesWithParent, L2BlockInfo};
 
     use super::*;
     use crate::{

--- a/crates/consensus/derive/src/pipeline/core.rs
+++ b/crates/consensus/derive/src/pipeline/core.rs
@@ -6,7 +6,7 @@ use core::fmt::Debug;
 use alloy_eips::BlockNumHash;
 use async_trait::async_trait;
 use base_consensus_genesis::{RollupConfig, SystemConfig};
-use base_protocol::{BatchValidationProvider, BlockInfo, L2BlockInfo, OpAttributesWithParent};
+use base_protocol::{BatchValidationProvider, BlockInfo, L2BlockInfo, AttributesWithParent};
 
 use crate::{
     ActivationSignal, L2ChainProvider, Metrics, NextAttributes, OriginAdvancer, OriginProvider,
@@ -24,9 +24,9 @@ where
     /// A handle to the next attributes.
     pub attributes: S,
     /// Reset provider for the pipeline.
-    /// A list of prepared [`OpAttributesWithParent`] to be used by the derivation pipeline
+    /// A list of prepared [`AttributesWithParent`] to be used by the derivation pipeline
     /// consumer.
-    pub prepared: VecDeque<OpAttributesWithParent>,
+    pub prepared: VecDeque<AttributesWithParent>,
     /// The rollup config.
     pub rollup_config: Arc<RollupConfig>,
     /// The L2 Chain Provider used to fetch the system config on reset.
@@ -104,7 +104,7 @@ where
     S: NextAttributes + StageReset + OriginProvider + OriginAdvancer + Debug + Send + Sync,
     P: L2ChainProvider + Send + Sync + Debug,
 {
-    type Item = OpAttributesWithParent;
+    type Item = AttributesWithParent;
 
     fn next(&mut self) -> Option<Self::Item> {
         Metrics::pipeline_payload_attributes_buffer()
@@ -177,8 +177,8 @@ where
     S: NextAttributes + StageReset + OriginProvider + OriginAdvancer + Debug + Send + Sync,
     P: L2ChainProvider + Send + Sync + Debug,
 {
-    /// Peeks at the next prepared [`OpAttributesWithParent`] from the pipeline.
-    fn peek(&self) -> Option<&OpAttributesWithParent> {
+    /// Peeks at the next prepared [`AttributesWithParent`] from the pipeline.
+    fn peek(&self) -> Option<&AttributesWithParent> {
         self.prepared.front()
     }
 
@@ -257,7 +257,7 @@ mod tests {
     use alloy_rpc_types_engine::PayloadAttributes;
     use base_alloy_rpc_types_engine::OpPayloadAttributes;
     use base_consensus_genesis::{RollupConfig, SystemConfig};
-    use base_protocol::{L2BlockInfo, OpAttributesWithParent};
+    use base_protocol::{L2BlockInfo, AttributesWithParent};
 
     use super::*;
     use crate::{
@@ -265,8 +265,8 @@ mod tests {
         test_utils::{TestL2ChainProvider, TestNextAttributes, new_test_pipeline},
     };
 
-    fn default_test_payload_attributes() -> OpAttributesWithParent {
-        OpAttributesWithParent {
+    fn default_test_payload_attributes() -> AttributesWithParent {
+        AttributesWithParent {
             attributes: OpPayloadAttributes {
                 payload_attributes: PayloadAttributes {
                     timestamp: 0,

--- a/crates/consensus/derive/src/stages/attributes_queue.rs
+++ b/crates/consensus/derive/src/stages/attributes_queue.rs
@@ -7,7 +7,7 @@ use alloy_eips::BlockNumHash;
 use async_trait::async_trait;
 use base_alloy_rpc_types_engine::OpPayloadAttributes;
 use base_consensus_genesis::{RollupConfig, SystemConfig};
-use base_protocol::{BlockInfo, L2BlockInfo, OpAttributesWithParent, SingleBatch};
+use base_protocol::{BlockInfo, L2BlockInfo, AttributesWithParent, SingleBatch};
 
 use crate::{
     Metrics,
@@ -70,11 +70,11 @@ where
         self.batch.as_ref().cloned().ok_or(PipelineError::Eof.temp())
     }
 
-    /// Returns the next [`OpAttributesWithParent`] from the current batch.
+    /// Returns the next [`AttributesWithParent`] from the current batch.
     pub async fn next_attributes(
         &mut self,
         parent: L2BlockInfo,
-    ) -> PipelineResult<OpAttributesWithParent> {
+    ) -> PipelineResult<AttributesWithParent> {
         let batch = match self.load_batch(parent).await {
             Ok(batch) => batch,
             Err(e) => {
@@ -92,7 +92,7 @@ where
         };
         let origin = self.origin().ok_or(PipelineError::MissingOrigin.crit())?;
         let populated_attributes =
-            OpAttributesWithParent::new(attributes, parent, Some(origin), self.is_last_in_span);
+            AttributesWithParent::new(attributes, parent, Some(origin), self.is_last_in_span);
         timer.stop();
 
         // Clear out the local state once payload attributes are prepared.
@@ -163,7 +163,7 @@ where
     async fn next_attributes(
         &mut self,
         parent: L2BlockInfo,
-    ) -> PipelineResult<OpAttributesWithParent> {
+    ) -> PipelineResult<AttributesWithParent> {
         self.next_attributes(parent).await
     }
 }
@@ -412,7 +412,7 @@ mod tests {
         // It should also reset the last in span flag and clear the batch.
         let attributes = aq.next_attributes(L2BlockInfo::default()).await.unwrap();
         pa.no_tx_pool = Some(true);
-        let populated_attributes = OpAttributesWithParent {
+        let populated_attributes = AttributesWithParent {
             attributes: pa,
             parent: L2BlockInfo::default(),
             derived_from: Some(BlockInfo::default()),

--- a/crates/consensus/derive/src/stages/attributes_queue.rs
+++ b/crates/consensus/derive/src/stages/attributes_queue.rs
@@ -7,7 +7,7 @@ use alloy_eips::BlockNumHash;
 use async_trait::async_trait;
 use base_alloy_rpc_types_engine::OpPayloadAttributes;
 use base_consensus_genesis::{RollupConfig, SystemConfig};
-use base_protocol::{BlockInfo, L2BlockInfo, AttributesWithParent, SingleBatch};
+use base_protocol::{AttributesWithParent, BlockInfo, L2BlockInfo, SingleBatch};
 
 use crate::{
     Metrics,

--- a/crates/consensus/derive/src/test_utils/pipeline.rs
+++ b/crates/consensus/derive/src/test_utils/pipeline.rs
@@ -5,7 +5,7 @@ use alloc::{boxed::Box, sync::Arc};
 
 use alloy_eips::BlockNumHash;
 use base_consensus_genesis::{RollupConfig, SystemConfig};
-use base_protocol::{BlockInfo, L2BlockInfo, OpAttributesWithParent};
+use base_protocol::{BlockInfo, L2BlockInfo, AttributesWithParent};
 
 // Re-export these types used internally to the test pipeline.
 use crate::{
@@ -22,8 +22,8 @@ use crate::{
 /// A fully custom [`NextAttributes`].
 #[derive(Default, Debug, Clone)]
 pub struct TestNextAttributes {
-    /// The next [`OpAttributesWithParent`] to return.
-    pub next_attributes: Option<OpAttributesWithParent>,
+    /// The next [`AttributesWithParent`] to return.
+    pub next_attributes: Option<AttributesWithParent>,
 }
 
 #[async_trait::async_trait]
@@ -63,8 +63,8 @@ impl OriginAdvancer for TestNextAttributes {
 
 #[async_trait::async_trait]
 impl NextAttributes for TestNextAttributes {
-    /// Returns the next valid [`OpAttributesWithParent`].
-    async fn next_attributes(&mut self, _: L2BlockInfo) -> PipelineResult<OpAttributesWithParent> {
+    /// Returns the next valid [`AttributesWithParent`].
+    async fn next_attributes(&mut self, _: L2BlockInfo) -> PipelineResult<AttributesWithParent> {
         self.next_attributes.take().ok_or(PipelineError::Eof.temp())
     }
 }

--- a/crates/consensus/derive/src/test_utils/pipeline.rs
+++ b/crates/consensus/derive/src/test_utils/pipeline.rs
@@ -5,7 +5,7 @@ use alloc::{boxed::Box, sync::Arc};
 
 use alloy_eips::BlockNumHash;
 use base_consensus_genesis::{RollupConfig, SystemConfig};
-use base_protocol::{BlockInfo, L2BlockInfo, AttributesWithParent};
+use base_protocol::{AttributesWithParent, BlockInfo, L2BlockInfo};
 
 // Re-export these types used internally to the test pipeline.
 use crate::{

--- a/crates/consensus/derive/src/traits/attributes.rs
+++ b/crates/consensus/derive/src/traits/attributes.rs
@@ -6,7 +6,7 @@ use core::fmt::Debug;
 use alloy_eips::BlockNumHash;
 use async_trait::async_trait;
 use base_alloy_rpc_types_engine::OpPayloadAttributes;
-use base_protocol::{L2BlockInfo, OpAttributesWithParent, SingleBatch};
+use base_protocol::{L2BlockInfo, AttributesWithParent, SingleBatch};
 
 use crate::PipelineResult;
 
@@ -26,11 +26,11 @@ pub trait AttributesProvider {
 /// the top level `AttributesQueue` stage of the pipeline.
 #[async_trait]
 pub trait NextAttributes {
-    /// Returns the next [`OpAttributesWithParent`] from the current batch.
+    /// Returns the next [`AttributesWithParent`] from the current batch.
     async fn next_attributes(
         &mut self,
         parent: L2BlockInfo,
-    ) -> PipelineResult<OpAttributesWithParent>;
+    ) -> PipelineResult<AttributesWithParent>;
 }
 
 /// The [`AttributesBuilder`] is responsible for preparing [`OpPayloadAttributes`]

--- a/crates/consensus/derive/src/traits/attributes.rs
+++ b/crates/consensus/derive/src/traits/attributes.rs
@@ -6,7 +6,7 @@ use core::fmt::Debug;
 use alloy_eips::BlockNumHash;
 use async_trait::async_trait;
 use base_alloy_rpc_types_engine::OpPayloadAttributes;
-use base_protocol::{L2BlockInfo, AttributesWithParent, SingleBatch};
+use base_protocol::{AttributesWithParent, L2BlockInfo, SingleBatch};
 
 use crate::PipelineResult;
 

--- a/crates/consensus/derive/src/traits/pipeline.rs
+++ b/crates/consensus/derive/src/traits/pipeline.rs
@@ -5,7 +5,7 @@ use core::iter::Iterator;
 
 use async_trait::async_trait;
 use base_consensus_genesis::{RollupConfig, SystemConfig};
-use base_protocol::{L2BlockInfo, AttributesWithParent};
+use base_protocol::{AttributesWithParent, L2BlockInfo};
 
 use crate::{OriginProvider, PipelineErrorKind, StepResult};
 

--- a/crates/consensus/derive/src/traits/pipeline.rs
+++ b/crates/consensus/derive/src/traits/pipeline.rs
@@ -5,15 +5,15 @@ use core::iter::Iterator;
 
 use async_trait::async_trait;
 use base_consensus_genesis::{RollupConfig, SystemConfig};
-use base_protocol::{L2BlockInfo, OpAttributesWithParent};
+use base_protocol::{L2BlockInfo, AttributesWithParent};
 
 use crate::{OriginProvider, PipelineErrorKind, StepResult};
 
 /// This trait defines the interface for interacting with the derivation pipeline.
 #[async_trait]
-pub trait Pipeline: OriginProvider + Iterator<Item = OpAttributesWithParent> {
-    /// Peeks at the next [`OpAttributesWithParent`] from the pipeline.
-    fn peek(&self) -> Option<&OpAttributesWithParent>;
+pub trait Pipeline: OriginProvider + Iterator<Item = AttributesWithParent> {
+    /// Peeks at the next [`AttributesWithParent`] from the pipeline.
+    fn peek(&self) -> Option<&AttributesWithParent>;
 
     /// Attempts to progress the pipeline.
     async fn step(&mut self, cursor: L2BlockInfo) -> StepResult;

--- a/crates/consensus/engine/src/attributes.rs
+++ b/crates/consensus/engine/src/attributes.rs
@@ -7,7 +7,7 @@ use alloy_rpc_types_eth::{Block, BlockTransactions, Withdrawals};
 use base_alloy_consensus::{EIP1559ParamError, HoloceneExtraData, JovianExtraData, OpTxEnvelope};
 use base_alloy_rpc_types::Transaction;
 use base_consensus_genesis::RollupConfig;
-use base_protocol::OpAttributesWithParent;
+use base_protocol::AttributesWithParent;
 
 /// Result of validating payload attributes against an execution layer block.
 ///
@@ -20,7 +20,7 @@ use base_protocol::OpAttributesWithParent;
 /// ```rust,ignore
 /// use base_consensus_engine::AttributesMatch;
 /// use base_consensus_genesis::RollupConfig;
-/// use base_protocol::OpAttributesWithParent;
+/// use base_protocol::AttributesWithParent;
 ///
 /// let config = RollupConfig::default();
 /// let match_result = AttributesMatch::check_withdrawals(&config, &attributes, &block);
@@ -51,7 +51,7 @@ impl AttributesMatch {
     /// Checks that withdrawals for a block and attributes match.
     pub fn check_withdrawals(
         config: &RollupConfig,
-        attributes: &OpAttributesWithParent,
+        attributes: &AttributesWithParent,
         block: &Block<Transaction>,
     ) -> Self {
         let attr_withdrawals = attributes.attributes().payload_attributes.withdrawals.as_ref();
@@ -170,7 +170,7 @@ impl AttributesMatch {
     /// Validates and compares EIP1559 parameters for consolidation.
     fn check_eip1559(
         config: &RollupConfig,
-        attributes: &OpAttributesWithParent,
+        attributes: &AttributesWithParent,
         block: &Block<Transaction>,
     ) -> Self {
         // We can assume that the EIP-1559 params are set iff holocene is active.
@@ -251,12 +251,12 @@ impl AttributesMatch {
         Self::Match
     }
 
-    /// Checks if the specified [`OpAttributesWithParent`] matches the specified [`Block`].
+    /// Checks if the specified [`AttributesWithParent`] matches the specified [`Block`].
     /// Returns [`AttributesMatch::Match`] if they match, otherwise returns
     /// [`AttributesMatch::Mismatch`].
     pub fn check(
         config: &RollupConfig,
-        attributes: &OpAttributesWithParent,
+        attributes: &AttributesWithParent,
         block: &Block<Transaction>,
     ) -> Self {
         if attributes.parent.block_info.hash != block.header.inner.parent_hash {
@@ -334,7 +334,7 @@ impl AttributesMatch {
     }
 }
 
-/// An enum over the type of mismatch between [`OpAttributesWithParent`]
+/// An enum over the type of mismatch between [`AttributesWithParent`]
 /// and a [`Block`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum AttributesMismatch {
@@ -354,7 +354,7 @@ pub enum AttributesMismatch {
     TransactionLen(usize, usize),
     /// A mismatch in the content of some transactions contained in the attributes and the block.
     TransactionContent(B256, B256),
-    /// The EIP1559 payload for the [`OpAttributesWithParent`] is missing when holocene is active.
+    /// The EIP1559 payload for the [`AttributesWithParent`] is missing when holocene is active.
     MissingAttributesEIP1559,
     /// The EIP1559 payload for the block is missing when holocene is active.
     MissingBlockEIP1559,
@@ -370,7 +370,7 @@ pub enum AttributesMismatch {
     Transactions(u64, u64),
     /// The gas limit of the block does not match the gas limit of the attributes.
     GasLimit(u64, u64),
-    /// The gas limit for the [`OpAttributesWithParent`] is missing.
+    /// The gas limit for the [`AttributesWithParent`] is missing.
     MissingAttributesGasLimit,
     /// The fee recipient of the block does not match the fee recipient of the attributes.
     FeeRecipient(Address, Address),
@@ -407,8 +407,8 @@ mod tests {
     use super::*;
     use crate::AttributesMismatch::EIP1559Parameters;
 
-    fn default_attributes() -> OpAttributesWithParent {
-        OpAttributesWithParent {
+    fn default_attributes() -> AttributesWithParent {
+        AttributesWithParent {
             attributes: OpPayloadAttributes::default(),
             parent: L2BlockInfo::default(),
             derived_from: Some(BlockInfo::default()),
@@ -553,7 +553,7 @@ mod tests {
             .collect()
     }
 
-    fn test_transactions_match_helper() -> (OpAttributesWithParent, Block<Transaction>) {
+    fn test_transactions_match_helper() -> (AttributesWithParent, Block<Transaction>) {
         const NUM_TXS: usize = 10;
 
         let transactions = generate_txs(NUM_TXS);
@@ -739,7 +739,7 @@ mod tests {
         assert_eq!(check, expected);
     }
 
-    fn eip1559_test_setup() -> (RollupConfig, OpAttributesWithParent, Block<Transaction>) {
+    fn eip1559_test_setup() -> (RollupConfig, AttributesWithParent, Block<Transaction>) {
         let mut cfg = default_rollup_config().clone();
 
         // We need to activate holocene to make sure it works! We set the activation time to zero to

--- a/crates/consensus/engine/src/task_queue/tasks/build/task.rs
+++ b/crates/consensus/engine/src/task_queue/tasks/build/task.rs
@@ -4,7 +4,7 @@ use std::{sync::Arc, time::Instant};
 use alloy_rpc_types_engine::{PayloadId, PayloadStatusEnum};
 use async_trait::async_trait;
 use base_consensus_genesis::RollupConfig;
-use base_protocol::OpAttributesWithParent;
+use base_protocol::AttributesWithParent;
 use derive_more::Constructor;
 use tokio::sync::mpsc;
 
@@ -32,8 +32,8 @@ pub struct BuildTask<EngineClient_: EngineClient> {
     pub engine: Arc<EngineClient_>,
     /// The [`RollupConfig`].
     pub cfg: Arc<RollupConfig>,
-    /// The [`OpAttributesWithParent`] to instruct the execution layer to build.
-    pub attributes: OpAttributesWithParent,
+    /// The [`AttributesWithParent`] to instruct the execution layer to build.
+    pub attributes: AttributesWithParent,
     /// The optional sender through which [`PayloadId`] will be sent after the
     /// block build has been started.
     pub payload_id_tx: Option<mpsc::Sender<PayloadId>>,
@@ -88,7 +88,7 @@ impl<EngineClient_: EngineClient> BuildTask<EngineClient_> {
         &self,
         state: &EngineState,
         engine_client: &EngineClient_,
-        attributes_envelope: OpAttributesWithParent,
+        attributes_envelope: AttributesWithParent,
     ) -> Result<PayloadId, BuildTaskError> {
         // Sanity check if the head is behind the finalized head. If it is, this is a critical
         // error.

--- a/crates/consensus/engine/src/task_queue/tasks/consolidate/task.rs
+++ b/crates/consensus/engine/src/task_queue/tasks/consolidate/task.rs
@@ -6,7 +6,7 @@ use alloy_rpc_types_eth::Block;
 use async_trait::async_trait;
 use base_alloy_rpc_types::Transaction;
 use base_consensus_genesis::RollupConfig;
-use base_protocol::{L2BlockInfo, OpAttributesWithParent};
+use base_protocol::{L2BlockInfo, AttributesWithParent};
 
 use crate::{
     ConsolidateTaskError, EngineClient, EngineState, EngineTaskExt, SynchronizeTask,
@@ -17,7 +17,7 @@ use crate::{
 #[derive(Debug, Clone)]
 pub enum ConsolidateInput {
     /// Consolidate based on derived attributes.
-    Attributes(Box<OpAttributesWithParent>),
+    Attributes(Box<AttributesWithParent>),
     /// Derivation Delegation: consolidate based on safe L2 block info.
     BlockInfo(L2BlockInfo),
 }
@@ -28,8 +28,8 @@ impl From<L2BlockInfo> for ConsolidateInput {
     }
 }
 
-impl From<OpAttributesWithParent> for ConsolidateInput {
-    fn from(v: OpAttributesWithParent) -> Self {
+impl From<AttributesWithParent> for ConsolidateInput {
+    fn from(v: AttributesWithParent) -> Self {
         Self::Attributes(Box::new(v))
     }
 }
@@ -89,7 +89,7 @@ impl<EngineClient_: EngineClient> ConsolidateTask<EngineClient_> {
     async fn execute_build_and_seal_tasks(
         &self,
         state: &mut EngineState,
-        attributes: &OpAttributesWithParent,
+        attributes: &AttributesWithParent,
     ) -> Result<(), ConsolidateTaskError> {
         build_and_seal(
             state,

--- a/crates/consensus/engine/src/task_queue/tasks/consolidate/task.rs
+++ b/crates/consensus/engine/src/task_queue/tasks/consolidate/task.rs
@@ -6,7 +6,7 @@ use alloy_rpc_types_eth::Block;
 use async_trait::async_trait;
 use base_alloy_rpc_types::Transaction;
 use base_consensus_genesis::RollupConfig;
-use base_protocol::{L2BlockInfo, AttributesWithParent};
+use base_protocol::{AttributesWithParent, L2BlockInfo};
 
 use crate::{
     ConsolidateTaskError, EngineClient, EngineState, EngineTaskExt, SynchronizeTask,

--- a/crates/consensus/engine/src/task_queue/tasks/get_payload/task.rs
+++ b/crates/consensus/engine/src/task_queue/tasks/get_payload/task.rs
@@ -5,7 +5,7 @@ use alloy_rpc_types_engine::{ExecutionPayload, PayloadId};
 use async_trait::async_trait;
 use base_alloy_rpc_types_engine::{OpExecutionPayload, OpExecutionPayloadEnvelope};
 use base_consensus_genesis::RollupConfig;
-use base_protocol::OpAttributesWithParent;
+use base_protocol::AttributesWithParent;
 use derive_more::Constructor;
 use tokio::sync::mpsc;
 
@@ -29,8 +29,8 @@ pub struct GetPayloadTask<EngineClient_: EngineClient> {
     pub cfg: Arc<RollupConfig>,
     /// The [`PayloadId`] to fetch.
     pub payload_id: PayloadId,
-    /// The [`OpAttributesWithParent`] used for version selection and parent validation.
-    pub attributes: OpAttributesWithParent,
+    /// The [`AttributesWithParent`] used for version selection and parent validation.
+    pub attributes: AttributesWithParent,
     /// An optional sender to convey the sealed [`OpExecutionPayloadEnvelope`]
     /// or the [`SealTaskError`] that occurred during fetching.
     pub result_tx: Option<mpsc::Sender<Result<OpExecutionPayloadEnvelope, SealTaskError>>>,
@@ -46,7 +46,7 @@ impl<EngineClient_: EngineClient> GetPayloadTask<EngineClient_> {
         cfg: &RollupConfig,
         engine: &EngineClient_,
         payload_id: PayloadId,
-        payload_attrs: &OpAttributesWithParent,
+        payload_attrs: &AttributesWithParent,
     ) -> Result<OpExecutionPayloadEnvelope, SealTaskError> {
         let payload_timestamp = payload_attrs.attributes().payload_attributes.timestamp;
 

--- a/crates/consensus/engine/src/task_queue/tasks/seal/task.rs
+++ b/crates/consensus/engine/src/task_queue/tasks/seal/task.rs
@@ -5,7 +5,7 @@ use alloy_rpc_types_engine::{ExecutionPayload, PayloadId};
 use async_trait::async_trait;
 use base_alloy_rpc_types_engine::{OpExecutionPayload, OpExecutionPayloadEnvelope};
 use base_consensus_genesis::RollupConfig;
-use base_protocol::{L2BlockInfo, OpAttributesWithParent};
+use base_protocol::{L2BlockInfo, AttributesWithParent};
 use derive_more::Constructor;
 use tokio::sync::mpsc;
 
@@ -37,8 +37,8 @@ pub struct SealTask<EngineClient_: EngineClient> {
     pub cfg: Arc<RollupConfig>,
     /// The [`PayloadId`] being sealed.
     pub payload_id: PayloadId,
-    /// The [`OpAttributesWithParent`] to instruct the execution layer to build.
-    pub attributes: OpAttributesWithParent,
+    /// The [`AttributesWithParent`] to instruct the execution layer to build.
+    pub attributes: AttributesWithParent,
     /// Whether or not the payload was derived, or created by the sequencer.
     pub is_attributes_derived: bool,
     /// An optional sender to convey success/failure result of the built
@@ -63,7 +63,7 @@ impl<EngineClient_: EngineClient> SealTask<EngineClient_> {
         cfg: &RollupConfig,
         engine: &EngineClient_,
         payload_id: PayloadId,
-        payload_attrs: OpAttributesWithParent,
+        payload_attrs: AttributesWithParent,
     ) -> Result<OpExecutionPayloadEnvelope, SealTaskError> {
         let payload_timestamp = payload_attrs.attributes().payload_attributes.timestamp;
 

--- a/crates/consensus/engine/src/task_queue/tasks/seal/task.rs
+++ b/crates/consensus/engine/src/task_queue/tasks/seal/task.rs
@@ -5,7 +5,7 @@ use alloy_rpc_types_engine::{ExecutionPayload, PayloadId};
 use async_trait::async_trait;
 use base_alloy_rpc_types_engine::{OpExecutionPayload, OpExecutionPayloadEnvelope};
 use base_consensus_genesis::RollupConfig;
-use base_protocol::{L2BlockInfo, AttributesWithParent};
+use base_protocol::{AttributesWithParent, L2BlockInfo};
 use derive_more::Constructor;
 use tokio::sync::mpsc;
 

--- a/crates/consensus/engine/src/task_queue/tasks/util.rs
+++ b/crates/consensus/engine/src/task_queue/tasks/util.rs
@@ -3,7 +3,7 @@
 use std::sync::Arc;
 
 use base_consensus_genesis::RollupConfig;
-use base_protocol::OpAttributesWithParent;
+use base_protocol::AttributesWithParent;
 
 use super::{BuildTask, BuildTaskError, EngineTaskExt, SealTask, SealTaskError};
 use crate::{EngineClient, EngineState};
@@ -39,7 +39,7 @@ pub(in crate::task_queue) async fn build_and_seal<EngineClient_: EngineClient>(
     state: &mut EngineState,
     engine: Arc<EngineClient_>,
     cfg: Arc<RollupConfig>,
-    attributes: OpAttributesWithParent,
+    attributes: AttributesWithParent,
     is_attributes_derived: bool,
 ) -> Result<(), BuildAndSealError> {
     // Execute the build task

--- a/crates/consensus/engine/src/test_utils/attributes.rs
+++ b/crates/consensus/engine/src/test_utils/attributes.rs
@@ -1,9 +1,9 @@
 use alloy_eips::BlockNumHash;
 use alloy_primitives::{B256, b256};
 use base_alloy_rpc_types_engine::OpPayloadAttributes;
-use base_protocol::{BlockInfo, L2BlockInfo, OpAttributesWithParent};
+use base_protocol::{BlockInfo, L2BlockInfo, AttributesWithParent};
 
-/// Builder for creating test `OpAttributesWithParent` instances with sensible defaults
+/// Builder for creating test `AttributesWithParent` instances with sensible defaults
 #[derive(Debug)]
 pub struct TestAttributesBuilder {
     timestamp: u64,
@@ -78,8 +78,8 @@ impl TestAttributesBuilder {
         self
     }
 
-    /// Builds the `OpAttributesWithParent`
-    pub fn build(self) -> OpAttributesWithParent {
+    /// Builds the `AttributesWithParent`
+    pub fn build(self) -> AttributesWithParent {
         let attributes = OpPayloadAttributes {
             payload_attributes: alloy_rpc_types_engine::PayloadAttributes {
                 timestamp: self.timestamp,
@@ -95,7 +95,7 @@ impl TestAttributesBuilder {
             min_base_fee: self.min_base_fee,
         };
 
-        OpAttributesWithParent::new(
+        AttributesWithParent::new(
             attributes,
             self.parent,
             self.derived_from,

--- a/crates/consensus/engine/src/test_utils/attributes.rs
+++ b/crates/consensus/engine/src/test_utils/attributes.rs
@@ -1,7 +1,7 @@
 use alloy_eips::BlockNumHash;
 use alloy_primitives::{B256, b256};
 use base_alloy_rpc_types_engine::OpPayloadAttributes;
-use base_protocol::{BlockInfo, L2BlockInfo, AttributesWithParent};
+use base_protocol::{AttributesWithParent, BlockInfo, L2BlockInfo};
 
 /// Builder for creating test `AttributesWithParent` instances with sensible defaults
 #[derive(Debug)]
@@ -95,12 +95,7 @@ impl TestAttributesBuilder {
             min_base_fee: self.min_base_fee,
         };
 
-        AttributesWithParent::new(
-            attributes,
-            self.parent,
-            self.derived_from,
-            self.is_last_in_span,
-        )
+        AttributesWithParent::new(attributes, self.parent, self.derived_from, self.is_last_in_span)
     }
 }
 

--- a/crates/consensus/protocol/src/attributes.rs
+++ b/crates/consensus/protocol/src/attributes.rs
@@ -8,7 +8,7 @@ use crate::{BlockInfo, L2BlockInfo};
 /// Base Payload Attributes with parent block reference and the L1 origin block.
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-pub struct OpAttributesWithParent {
+pub struct AttributesWithParent {
     /// The payload attributes.
     pub attributes: OpPayloadAttributes,
     /// The parent block reference.
@@ -19,8 +19,8 @@ pub struct OpAttributesWithParent {
     pub is_last_in_span: bool,
 }
 
-impl OpAttributesWithParent {
-    /// Create a new [`OpAttributesWithParent`] instance.
+impl AttributesWithParent {
+    /// Create a new [`AttributesWithParent`] instance.
     pub const fn new(
         attributes: OpPayloadAttributes,
         parent: L2BlockInfo,
@@ -69,7 +69,7 @@ impl OpAttributesWithParent {
             .all(|tx| tx.first().is_some_and(|tx| tx[0] == OpTxType::Deposit as u8))
     }
 
-    /// Converts the [`OpAttributesWithParent`] into a deposits-only payload.
+    /// Converts the [`AttributesWithParent`] into a deposits-only payload.
     pub fn as_deposits_only(&self) -> Self {
         let mut attributes = self.attributes.clone();
 
@@ -104,7 +104,7 @@ mod tests {
         let parent = L2BlockInfo::default();
         let is_last_in_span = true;
         let op_attributes_with_parent =
-            OpAttributesWithParent::new(attributes.clone(), parent, None, is_last_in_span);
+            AttributesWithParent::new(attributes.clone(), parent, None, is_last_in_span);
 
         assert_eq!(op_attributes_with_parent.attributes(), &attributes);
         assert_eq!(op_attributes_with_parent.parent(), &parent);
@@ -112,7 +112,7 @@ mod tests {
         assert_eq!(op_attributes_with_parent.derived_from(), None);
     }
 
-    /// Test that the [`OpAttributesWithParent::as_deposits_only`] method strips out all
+    /// Test that the [`AttributesWithParent::as_deposits_only`] method strips out all
     /// transactions that are not deposits.
     #[test]
     fn test_op_attributes_with_parent_as_deposits_only() {
@@ -130,7 +130,7 @@ mod tests {
         let parent = L2BlockInfo::default();
         let is_last_in_span = true;
         let op_attributes_with_parent =
-            OpAttributesWithParent::new(attributes, parent, None, is_last_in_span);
+            AttributesWithParent::new(attributes, parent, None, is_last_in_span);
         let deposits_only_attributes = op_attributes_with_parent.as_deposits_only();
 
         assert_eq!(
@@ -157,7 +157,7 @@ mod tests {
         let parent = L2BlockInfo::default();
         let is_last_in_span = true;
         let op_attributes_with_parent =
-            OpAttributesWithParent::new(attributes, parent, None, is_last_in_span);
+            AttributesWithParent::new(attributes, parent, None, is_last_in_span);
         let deposits_only_attributes = op_attributes_with_parent.as_deposits_only();
 
         assert_eq!(
@@ -170,7 +170,7 @@ mod tests {
         );
     }
 
-    /// Test that the [`OpAttributesWithParent::as_deposits_only`] method strips out all
+    /// Test that the [`AttributesWithParent::as_deposits_only`] method strips out all
     /// transactions that are not deposits.
     #[test]
     fn test_op_attributes_with_parent_as_deposits_no_deposits() {
@@ -187,7 +187,7 @@ mod tests {
         let parent = L2BlockInfo::default();
         let is_last_in_span = true;
         let op_attributes_with_parent =
-            OpAttributesWithParent::new(attributes, parent, None, is_last_in_span);
+            AttributesWithParent::new(attributes, parent, None, is_last_in_span);
         let deposits_only_attributes = op_attributes_with_parent.as_deposits_only();
 
         assert_eq!(deposits_only_attributes.attributes().transactions, Some(vec![]));
@@ -207,7 +207,7 @@ mod tests {
         let parent = L2BlockInfo::default();
         let is_last_in_span = true;
         let op_attributes_with_parent =
-            OpAttributesWithParent::new(attributes, parent, None, is_last_in_span);
+            AttributesWithParent::new(attributes, parent, None, is_last_in_span);
         let deposits_only_attributes = op_attributes_with_parent.as_deposits_only();
 
         assert_eq!(
@@ -227,7 +227,7 @@ mod tests {
         let parent = L2BlockInfo::default();
         let is_last_in_span = true;
         let op_attributes_with_parent =
-            OpAttributesWithParent::new(attributes, parent, None, is_last_in_span);
+            AttributesWithParent::new(attributes, parent, None, is_last_in_span);
         let deposits_only_attributes = op_attributes_with_parent.as_deposits_only();
 
         assert_eq!(deposits_only_attributes.attributes().transactions, None);

--- a/crates/consensus/protocol/src/lib.rs
+++ b/crates/consensus/protocol/src/lib.rs
@@ -25,7 +25,7 @@ mod brotli;
 pub use brotli::{BrotliDecompressionError, decompress_brotli};
 
 mod attributes;
-pub use attributes::OpAttributesWithParent;
+pub use attributes::AttributesWithParent;
 
 mod errors;
 pub use errors::BaseBlockConversionError;

--- a/crates/consensus/providers-alloy/src/pipeline.rs
+++ b/crates/consensus/providers-alloy/src/pipeline.rs
@@ -11,7 +11,7 @@ use base_consensus_derive::{
     Signal, SignalReceiver, StatefulAttributesBuilder, StepResult,
 };
 use base_consensus_genesis::{RollupConfig, SystemConfig};
-use base_protocol::{BlockInfo, L2BlockInfo, AttributesWithParent};
+use base_protocol::{AttributesWithParent, BlockInfo, L2BlockInfo};
 
 use crate::{AlloyChainProvider, AlloyL2ChainProvider, OnlineBeaconClient, OnlineBlobProvider};
 

--- a/crates/consensus/providers-alloy/src/pipeline.rs
+++ b/crates/consensus/providers-alloy/src/pipeline.rs
@@ -11,7 +11,7 @@ use base_consensus_derive::{
     Signal, SignalReceiver, StatefulAttributesBuilder, StepResult,
 };
 use base_consensus_genesis::{RollupConfig, SystemConfig};
-use base_protocol::{BlockInfo, L2BlockInfo, OpAttributesWithParent};
+use base_protocol::{BlockInfo, L2BlockInfo, AttributesWithParent};
 
 use crate::{AlloyChainProvider, AlloyL2ChainProvider, OnlineBeaconClient, OnlineBlobProvider};
 
@@ -170,7 +170,7 @@ impl OriginProvider for OnlinePipeline {
 }
 
 impl Iterator for OnlinePipeline {
-    type Item = OpAttributesWithParent;
+    type Item = AttributesWithParent;
 
     fn next(&mut self) -> Option<Self::Item> {
         match self {
@@ -182,8 +182,8 @@ impl Iterator for OnlinePipeline {
 
 #[async_trait]
 impl Pipeline for OnlinePipeline {
-    /// Peeks at the next [`OpAttributesWithParent`] from the pipeline.
-    fn peek(&self) -> Option<&OpAttributesWithParent> {
+    /// Peeks at the next [`AttributesWithParent`] from the pipeline.
+    fn peek(&self) -> Option<&AttributesWithParent> {
         match self {
             Self::Polled(pipeline) => pipeline.peek(),
             Self::Managed(pipeline) => pipeline.peek(),

--- a/crates/consensus/service/src/actors/derivation/actor.rs
+++ b/crates/consensus/service/src/actors/derivation/actor.rs
@@ -9,7 +9,7 @@ use base_consensus_derive::{
     SignalReceiver, StepResult,
 };
 use base_consensus_safedb::SafeHeadListener;
-use base_protocol::{BlockInfo, AttributesWithParent};
+use base_protocol::{AttributesWithParent, BlockInfo};
 use thiserror::Error;
 use tokio::{select, sync::mpsc};
 use tokio_util::sync::{CancellationToken, WaitForCancellationFuture};

--- a/crates/consensus/service/src/actors/derivation/actor.rs
+++ b/crates/consensus/service/src/actors/derivation/actor.rs
@@ -9,7 +9,7 @@ use base_consensus_derive::{
     SignalReceiver, StepResult,
 };
 use base_consensus_safedb::SafeHeadListener;
-use base_protocol::{BlockInfo, OpAttributesWithParent};
+use base_protocol::{BlockInfo, AttributesWithParent};
 use thiserror::Error;
 use tokio::{select, sync::mpsc};
 use tokio_util::sync::{CancellationToken, WaitForCancellationFuture};
@@ -132,7 +132,7 @@ where
 
     /// Attempts to step the derivation pipeline forward as much as possible in order to produce the
     /// next safe payload.
-    async fn produce_next_attributes(&mut self) -> Result<OpAttributesWithParent, DerivationError> {
+    async fn produce_next_attributes(&mut self) -> Result<AttributesWithParent, DerivationError> {
         // As we start the safe head at the disputed block's parent, we step the pipeline until the
         // first attributes are produced. All batches at and before the safe head will be
         // dropped, so the first payload will always be the disputed one.

--- a/crates/consensus/service/src/actors/derivation/engine_client.rs
+++ b/crates/consensus/service/src/actors/derivation/engine_client.rs
@@ -8,7 +8,7 @@ use tokio::sync::mpsc;
 use crate::{EngineActorRequest, EngineClientError, EngineClientResult, ResetRequest};
 
 /// Client to use to interact with the engine.
-#[cfg_attr(test, mockall::automock(type SafeL2Signal = OpAttributesWithParent;))]
+#[cfg_attr(test, mockall::automock(type SafeL2Signal = AttributesWithParent;))]
 #[async_trait]
 pub trait DerivationEngineClient: Debug + Send + Sync {
     /// Resets the engine's forkchoice.

--- a/crates/consensus/service/src/actors/derivation/finalizer.rs
+++ b/crates/consensus/service/src/actors/derivation/finalizer.rs
@@ -2,7 +2,7 @@
 
 use std::collections::BTreeMap;
 
-use base_protocol::{BlockInfo, OpAttributesWithParent};
+use base_protocol::{BlockInfo, AttributesWithParent};
 
 /// An internal type alias for L1 block numbers.
 type L1BlockNumber = u64;
@@ -18,17 +18,17 @@ type L2BlockNumber = u64;
 #[derive(Debug, Default)]
 pub struct L2Finalizer {
     /// A map of `L1 block number -> highest derived L2 block number` within the L1 epoch, used to
-    /// track derived [`OpAttributesWithParent`] awaiting finalization. When a new finalized L1
+    /// track derived [`AttributesWithParent`] awaiting finalization. When a new finalized L1
     /// block is received, the highest L2 block whose inputs are contained within the finalized
     /// L1 chain is finalized.
     awaiting_finalization: BTreeMap<L1BlockNumber, L2BlockNumber>,
 }
 
 impl L2Finalizer {
-    /// Enqueues a derived [`OpAttributesWithParent`] for finalization. When a new finalized L1
-    /// block is observed that is `>=` the height of [`OpAttributesWithParent::derived_from`], the
+    /// Enqueues a derived [`AttributesWithParent`] for finalization. When a new finalized L1
+    /// block is observed that is `>=` the height of [`AttributesWithParent::derived_from`], the
     /// L2 block associated with the payload attributes will be finalized.
-    pub(crate) fn enqueue_for_finalization(&mut self, attributes: &OpAttributesWithParent) {
+    pub(crate) fn enqueue_for_finalization(&mut self, attributes: &AttributesWithParent) {
         self.awaiting_finalization
             .entry(
                 attributes.derived_from.map(|b| b.number).expect(
@@ -75,20 +75,20 @@ mod tests {
 
     use alloy_eips::BlockNumHash;
     use base_alloy_rpc_types_engine::OpPayloadAttributes;
-    use base_protocol::{BlockInfo, L2BlockInfo, OpAttributesWithParent};
+    use base_protocol::{BlockInfo, L2BlockInfo, AttributesWithParent};
 
     use super::L2Finalizer;
 
-    /// Build a minimal [`OpAttributesWithParent`] whose derived L2 block number is
+    /// Build a minimal [`AttributesWithParent`] whose derived L2 block number is
     /// `l2_parent_number + 1` and whose L1 origin is `l1_origin_number`.
-    fn attrs(l2_parent_number: u64, l1_origin_number: u64) -> OpAttributesWithParent {
+    fn attrs(l2_parent_number: u64, l1_origin_number: u64) -> AttributesWithParent {
         let parent = L2BlockInfo {
             block_info: BlockInfo { number: l2_parent_number, ..Default::default() },
             l1_origin: BlockNumHash::default(),
             seq_num: 0,
         };
         let derived_from = BlockInfo { number: l1_origin_number, ..Default::default() };
-        OpAttributesWithParent::new(
+        AttributesWithParent::new(
             OpPayloadAttributes::default(),
             parent,
             Some(derived_from),

--- a/crates/consensus/service/src/actors/derivation/finalizer.rs
+++ b/crates/consensus/service/src/actors/derivation/finalizer.rs
@@ -2,7 +2,7 @@
 
 use std::collections::BTreeMap;
 
-use base_protocol::{BlockInfo, AttributesWithParent};
+use base_protocol::{AttributesWithParent, BlockInfo};
 
 /// An internal type alias for L1 block numbers.
 type L1BlockNumber = u64;
@@ -75,7 +75,7 @@ mod tests {
 
     use alloy_eips::BlockNumHash;
     use base_alloy_rpc_types_engine::OpPayloadAttributes;
-    use base_protocol::{BlockInfo, L2BlockInfo, AttributesWithParent};
+    use base_protocol::{AttributesWithParent, BlockInfo, L2BlockInfo};
 
     use super::L2Finalizer;
 
@@ -88,12 +88,7 @@ mod tests {
             seq_num: 0,
         };
         let derived_from = BlockInfo { number: l1_origin_number, ..Default::default() };
-        AttributesWithParent::new(
-            OpPayloadAttributes::default(),
-            parent,
-            Some(derived_from),
-            false,
-        )
+        AttributesWithParent::new(OpPayloadAttributes::default(), parent, Some(derived_from), false)
     }
 
     /// Build a [`BlockInfo`] representing a finalized L1 block at `number`.

--- a/crates/consensus/service/src/actors/derivation/state_machine.rs
+++ b/crates/consensus/service/src/actors/derivation/state_machine.rs
@@ -1,4 +1,4 @@
-use base_protocol::{L2BlockInfo, AttributesWithParent};
+use base_protocol::{AttributesWithParent, L2BlockInfo};
 use derive_more::PartialEq;
 use thiserror::Error;
 use tracing::info;
@@ -222,7 +222,7 @@ mod tests {
     use alloy_eips::BlockNumHash;
     use alloy_primitives::{BlockHash, b256};
     use base_alloy_rpc_types_engine::OpPayloadAttributes;
-    use base_protocol::{BlockInfo, AttributesWithParent};
+    use base_protocol::{AttributesWithParent, BlockInfo};
     use rstest::rstest;
 
     use super::{

--- a/crates/consensus/service/src/actors/derivation/state_machine.rs
+++ b/crates/consensus/service/src/actors/derivation/state_machine.rs
@@ -1,4 +1,4 @@
-use base_protocol::{L2BlockInfo, OpAttributesWithParent};
+use base_protocol::{L2BlockInfo, AttributesWithParent};
 use derive_more::PartialEq;
 use thiserror::Error;
 use tracing::info;
@@ -12,7 +12,7 @@ pub enum DerivationState {
     AwaitingELSyncCompletion,
     /// The [`crate::DerivationActor`] is idle awaiting data.
     AwaitingL1Data,
-    /// [`base_protocol::OpAttributesWithParent`] were sent to the [`crate::EngineActor`], and the
+    /// [`base_protocol::AttributesWithParent`] were sent to the [`crate::EngineActor`], and the
     /// [`crate::DerivationActor`] is waiting for confirmation that they were processed into a safe
     /// head.
     AwaitingSafeHeadConfirmation,
@@ -37,9 +37,9 @@ pub enum DerivationStateUpdate {
     L1DataReceived,
     /// Further derivation is not possible without additional L1 data becoming available.
     MoreDataNeeded,
-    /// Derivation has produced new [`base_protocol::OpAttributesWithParent`].
-    NewAttributesDerived(Box<OpAttributesWithParent>),
-    /// The EL has confirmed the derived [`base_protocol::OpAttributesWithParent`] as the new safe
+    /// Derivation has produced new [`base_protocol::AttributesWithParent`].
+    NewAttributesDerived(Box<AttributesWithParent>),
+    /// The EL has confirmed the derived [`base_protocol::AttributesWithParent`] as the new safe
     /// head.
     NewAttributesConfirmed(Box<L2BlockInfo>),
     /// A [`base_consensus_derive::Signal`] is necessary to update the derivation pipeline in order to
@@ -149,9 +149,9 @@ fn transition(
 /// 2. Derivation may not happen until the Engine L2 safe head is known
 ///
 /// ## Derive -> Message EL -> Receive confirmation
-/// When new [`base_protocol::OpAttributesWithParent`] are derived, they must be sent to the EL,
+/// When new [`base_protocol::AttributesWithParent`] are derived, they must be sent to the EL,
 /// and the EL must confirm them by creating a new L2 safe head from them prior to further
-/// derivation. There will be at most one [`base_protocol::OpAttributesWithParent`] awaiting
+/// derivation. There will be at most one [`base_protocol::AttributesWithParent`] awaiting
 /// confirmation at any given time.
 ///
 /// ## Signal handling
@@ -222,7 +222,7 @@ mod tests {
     use alloy_eips::BlockNumHash;
     use alloy_primitives::{BlockHash, b256};
     use base_alloy_rpc_types_engine::OpPayloadAttributes;
-    use base_protocol::{BlockInfo, OpAttributesWithParent};
+    use base_protocol::{BlockInfo, AttributesWithParent};
     use rstest::rstest;
 
     use super::{
@@ -244,9 +244,9 @@ mod tests {
         }
     }
 
-    /// Creates a dummy `OpAttributesWithParent` for testing
-    fn dummy_op_attributes() -> OpAttributesWithParent {
-        OpAttributesWithParent {
+    /// Creates a dummy `AttributesWithParent` for testing
+    fn dummy_op_attributes() -> AttributesWithParent {
+        AttributesWithParent {
             attributes: OpPayloadAttributes::default(),
             parent: dummy_l2_block_info(),
             derived_from: None,
@@ -255,7 +255,7 @@ mod tests {
     }
 
     // This is just here to shrink the #[case(...)] statements below for readability.
-    fn attrs() -> Box<OpAttributesWithParent> {
+    fn attrs() -> Box<AttributesWithParent> {
         Box::new(dummy_op_attributes())
     }
 

--- a/crates/consensus/service/src/actors/engine/request.rs
+++ b/crates/consensus/service/src/actors/engine/request.rs
@@ -1,7 +1,7 @@
 use alloy_rpc_types_engine::PayloadId;
 use base_alloy_rpc_types_engine::OpExecutionPayloadEnvelope;
 use base_consensus_engine::{BuildTaskError, ConsolidateInput, EngineQueries, SealTaskError};
-use base_protocol::OpAttributesWithParent;
+use base_protocol::AttributesWithParent;
 use thiserror::Error;
 use tokio::sync::mpsc;
 
@@ -70,8 +70,8 @@ pub enum EngineRpcRequest {
 /// Contains the attributes to build and a channel to send back the resulting `PayloadId`.
 #[derive(Debug)]
 pub struct BuildRequest {
-    /// The [`OpAttributesWithParent`] from which the block build should be started.
-    pub attributes: OpAttributesWithParent,
+    /// The [`AttributesWithParent`] from which the block build should be started.
+    pub attributes: AttributesWithParent,
     /// The channel on which the result, successful or not, will be sent.
     pub result_tx: mpsc::Sender<PayloadId>,
 }
@@ -92,7 +92,7 @@ pub struct SealRequest {
     /// The `PayloadId` to seal and canonicalize.
     pub payload_id: PayloadId,
     /// The attributes necessary for the seal operation.
-    pub attributes: OpAttributesWithParent,
+    pub attributes: AttributesWithParent,
     /// The channel on which the result, successful or not, will be sent.
     pub result_tx: mpsc::Sender<Result<OpExecutionPayloadEnvelope, SealTaskError>>,
 }
@@ -104,7 +104,7 @@ pub struct GetPayloadRequest {
     /// The `PayloadId` to fetch.
     pub payload_id: PayloadId,
     /// The attributes associated with the payload.
-    pub attributes: OpAttributesWithParent,
+    pub attributes: AttributesWithParent,
     /// The channel on which the result, successful or not, will be sent.
     pub result_tx: mpsc::Sender<Result<OpExecutionPayloadEnvelope, SealTaskError>>,
 }

--- a/crates/consensus/service/src/actors/sequencer/build.rs
+++ b/crates/consensus/service/src/actors/sequencer/build.rs
@@ -9,7 +9,7 @@ use std::{sync::Arc, time::Instant};
 use alloy_rpc_types_engine::PayloadId;
 use base_consensus_derive::{AttributesBuilder, PipelineErrorKind};
 use base_consensus_genesis::RollupConfig;
-use base_protocol::{BlockInfo, L2BlockInfo, OpAttributesWithParent};
+use base_protocol::{BlockInfo, L2BlockInfo, AttributesWithParent};
 
 use crate::{
     Metrics, PoolActivation,
@@ -27,8 +27,8 @@ use crate::{
 pub struct UnsealedPayloadHandle {
     /// The [`PayloadId`] of the unsealed payload.
     pub payload_id: PayloadId,
-    /// The [`OpAttributesWithParent`] used to start block building.
-    pub attributes_with_parent: OpAttributesWithParent,
+    /// The [`AttributesWithParent`] used to start block building.
+    pub attributes_with_parent: AttributesWithParent,
 }
 
 /// Drives payload attribute preparation and block build initiation.
@@ -144,7 +144,7 @@ impl<A: AttributesBuilder, O: OriginSelector, E: SequencerEngineClient> PayloadB
         Ok(Some(l1_origin))
     }
 
-    /// Builds the `OpAttributesWithParent` for the next block.
+    /// Builds the `AttributesWithParent` for the next block.
     ///
     /// Returns `Ok(None)` if no attributes could be built at this time but future
     /// attempts may succeed.
@@ -152,7 +152,7 @@ impl<A: AttributesBuilder, O: OriginSelector, E: SequencerEngineClient> PayloadB
         &mut self,
         unsafe_head: L2BlockInfo,
         l1_origin: BlockInfo,
-    ) -> Result<Option<OpAttributesWithParent>, SequencerActorError> {
+    ) -> Result<Option<AttributesWithParent>, SequencerActorError> {
         let mut attributes = match self
             .attributes_builder
             .prepare_payload_attributes(unsafe_head, l1_origin.id())
@@ -197,7 +197,7 @@ impl<A: AttributesBuilder, O: OriginSelector, E: SequencerEngineClient> PayloadB
         attributes.no_tx_pool =
             Some(!activator.is_enabled(self.recovery_mode.get(), l1_origin, &attributes));
 
-        let attrs_with_parent = OpAttributesWithParent::new(attributes, unsafe_head, None, false);
+        let attrs_with_parent = AttributesWithParent::new(attributes, unsafe_head, None, false);
         Ok(Some(attrs_with_parent))
     }
 }

--- a/crates/consensus/service/src/actors/sequencer/build.rs
+++ b/crates/consensus/service/src/actors/sequencer/build.rs
@@ -9,7 +9,7 @@ use std::{sync::Arc, time::Instant};
 use alloy_rpc_types_engine::PayloadId;
 use base_consensus_derive::{AttributesBuilder, PipelineErrorKind};
 use base_consensus_genesis::RollupConfig;
-use base_protocol::{BlockInfo, L2BlockInfo, AttributesWithParent};
+use base_protocol::{AttributesWithParent, BlockInfo, L2BlockInfo};
 
 use crate::{
     Metrics, PoolActivation,

--- a/crates/consensus/service/src/actors/sequencer/engine_client.rs
+++ b/crates/consensus/service/src/actors/sequencer/engine_client.rs
@@ -3,7 +3,7 @@ use std::{fmt::Debug, sync::Arc};
 use alloy_rpc_types_engine::PayloadId;
 use async_trait::async_trait;
 use base_alloy_rpc_types_engine::OpExecutionPayloadEnvelope;
-use base_protocol::{L2BlockInfo, OpAttributesWithParent};
+use base_protocol::{L2BlockInfo, AttributesWithParent};
 use derive_more::Constructor;
 use tokio::sync::{mpsc, watch};
 
@@ -26,7 +26,7 @@ pub trait SequencerEngineClient: Debug + Send + Sync {
     /// Returns a `PayloadId` that can be used to seal the block later.
     async fn start_build_block(
         &self,
-        attributes: OpAttributesWithParent,
+        attributes: AttributesWithParent,
     ) -> EngineClientResult<PayloadId>;
 
     /// Fetches the sealed payload envelope from the engine WITHOUT inserting it.
@@ -34,7 +34,7 @@ pub trait SequencerEngineClient: Debug + Send + Sync {
     async fn get_sealed_payload(
         &self,
         payload_id: PayloadId,
-        attributes: OpAttributesWithParent,
+        attributes: AttributesWithParent,
     ) -> EngineClientResult<OpExecutionPayloadEnvelope>;
 
     /// Fire-and-forget: submits the sealed payload to the engine for insertion (`new_payload` + FCU).
@@ -61,7 +61,7 @@ impl<T: SequencerEngineClient> SequencerEngineClient for Arc<T> {
 
     async fn start_build_block(
         &self,
-        attributes: OpAttributesWithParent,
+        attributes: AttributesWithParent,
     ) -> EngineClientResult<PayloadId> {
         (**self).start_build_block(attributes).await
     }
@@ -69,7 +69,7 @@ impl<T: SequencerEngineClient> SequencerEngineClient for Arc<T> {
     async fn get_sealed_payload(
         &self,
         payload_id: PayloadId,
-        attributes: OpAttributesWithParent,
+        attributes: AttributesWithParent,
     ) -> EngineClientResult<OpExecutionPayloadEnvelope> {
         (**self).get_sealed_payload(payload_id, attributes).await
     }
@@ -123,7 +123,7 @@ impl SequencerEngineClient for QueuedSequencerEngineClient {
 
     async fn start_build_block(
         &self,
-        attributes: OpAttributesWithParent,
+        attributes: AttributesWithParent,
     ) -> EngineClientResult<PayloadId> {
         let (payload_id_tx, mut payload_id_rx) = mpsc::channel(1);
 
@@ -152,7 +152,7 @@ impl SequencerEngineClient for QueuedSequencerEngineClient {
     async fn get_sealed_payload(
         &self,
         payload_id: PayloadId,
-        attributes: OpAttributesWithParent,
+        attributes: AttributesWithParent,
     ) -> EngineClientResult<OpExecutionPayloadEnvelope> {
         let (result_tx, mut result_rx) = mpsc::channel(1);
 

--- a/crates/consensus/service/src/actors/sequencer/engine_client.rs
+++ b/crates/consensus/service/src/actors/sequencer/engine_client.rs
@@ -3,7 +3,7 @@ use std::{fmt::Debug, sync::Arc};
 use alloy_rpc_types_engine::PayloadId;
 use async_trait::async_trait;
 use base_alloy_rpc_types_engine::OpExecutionPayloadEnvelope;
-use base_protocol::{L2BlockInfo, AttributesWithParent};
+use base_protocol::{AttributesWithParent, L2BlockInfo};
 use derive_more::Constructor;
 use tokio::sync::{mpsc, watch};
 

--- a/crates/consensus/service/src/actors/sequencer/tests/actor_test.rs
+++ b/crates/consensus/service/src/actors/sequencer/tests/actor_test.rs
@@ -7,7 +7,7 @@ use base_alloy_rpc_types_engine::{
 };
 use base_consensus_derive::{BuilderError, PipelineErrorKind, test_utils::TestAttributesBuilder};
 use base_consensus_engine::SealTaskError;
-use base_protocol::{BlockInfo, L2BlockInfo, AttributesWithParent};
+use base_protocol::{AttributesWithParent, BlockInfo, L2BlockInfo};
 use jsonrpsee::core::ClientError;
 use rstest::rstest;
 

--- a/crates/consensus/service/src/actors/sequencer/tests/actor_test.rs
+++ b/crates/consensus/service/src/actors/sequencer/tests/actor_test.rs
@@ -7,7 +7,7 @@ use base_alloy_rpc_types_engine::{
 };
 use base_consensus_derive::{BuilderError, PipelineErrorKind, test_utils::TestAttributesBuilder};
 use base_consensus_engine::SealTaskError;
-use base_protocol::{BlockInfo, L2BlockInfo, OpAttributesWithParent};
+use base_protocol::{BlockInfo, L2BlockInfo, AttributesWithParent};
 use jsonrpsee::core::ClientError;
 use rstest::rstest;
 
@@ -48,8 +48,8 @@ fn conductor_rpc_error() -> ConductorError {
     ConductorError::Rpc(ClientError::Custom("test conductor error".to_string()))
 }
 
-fn dummy_attributes_with_parent() -> OpAttributesWithParent {
-    OpAttributesWithParent::new(OpPayloadAttributes::default(), L2BlockInfo::default(), None, false)
+fn dummy_attributes_with_parent() -> AttributesWithParent {
+    AttributesWithParent::new(OpPayloadAttributes::default(), L2BlockInfo::default(), None, false)
 }
 
 fn handle_with_parent_number(number: u64) -> UnsealedPayloadHandle {
@@ -63,7 +63,7 @@ fn handle_with_parent(number: u64, hash: B256) -> UnsealedPayloadHandle {
     };
     UnsealedPayloadHandle {
         payload_id: Default::default(),
-        attributes_with_parent: OpAttributesWithParent::new(
+        attributes_with_parent: AttributesWithParent::new(
             OpPayloadAttributes::default(),
             parent,
             None,

--- a/crates/proof/driver/src/pipeline.rs
+++ b/crates/proof/driver/src/pipeline.rs
@@ -11,7 +11,7 @@ use base_consensus_derive::{
     ActivationSignal, Pipeline, PipelineError, PipelineErrorKind, ResetError, ResetSignal,
     SignalReceiver, StepResult,
 };
-use base_protocol::{L2BlockInfo, AttributesWithParent};
+use base_protocol::{AttributesWithParent, L2BlockInfo};
 
 /// High-level abstraction for the driver's derivation pipeline.
 ///

--- a/crates/proof/driver/src/pipeline.rs
+++ b/crates/proof/driver/src/pipeline.rs
@@ -11,7 +11,7 @@ use base_consensus_derive::{
     ActivationSignal, Pipeline, PipelineError, PipelineErrorKind, ResetError, ResetSignal,
     SignalReceiver, StepResult,
 };
-use base_protocol::{L2BlockInfo, OpAttributesWithParent};
+use base_protocol::{L2BlockInfo, AttributesWithParent};
 
 /// High-level abstraction for the driver's derivation pipeline.
 ///
@@ -31,7 +31,7 @@ where
     async fn produce_payload(
         &mut self,
         l2_safe_head: L2BlockInfo,
-    ) -> Result<OpAttributesWithParent, PipelineErrorKind> {
+    ) -> Result<AttributesWithParent, PipelineErrorKind> {
         // As we start the safe head at the disputed block's parent, we step the pipeline until the
         // first attributes are produced. All batches at and before the safe head will be
         // dropped, so the first payload will always be the disputed one.

--- a/crates/proof/proof/src/l1/pipeline.rs
+++ b/crates/proof/proof/src/l1/pipeline.rs
@@ -16,7 +16,7 @@ use base_consensus_genesis::{RollupConfig, SystemConfig};
 use base_proof_driver::{DriverPipeline, PipelineCursor};
 use base_proof_executor::TrieDBProvider;
 use base_proof_preimage::{CommsClient, FlushableCache};
-use base_protocol::{BatchValidationProvider, BlockInfo, L2BlockInfo, AttributesWithParent};
+use base_protocol::{AttributesWithParent, BatchValidationProvider, BlockInfo, L2BlockInfo};
 use spin::RwLock;
 
 use crate::{

--- a/crates/proof/proof/src/l1/pipeline.rs
+++ b/crates/proof/proof/src/l1/pipeline.rs
@@ -16,7 +16,7 @@ use base_consensus_genesis::{RollupConfig, SystemConfig};
 use base_proof_driver::{DriverPipeline, PipelineCursor};
 use base_proof_executor::TrieDBProvider;
 use base_proof_preimage::{CommsClient, FlushableCache};
-use base_protocol::{BatchValidationProvider, BlockInfo, L2BlockInfo, OpAttributesWithParent};
+use base_protocol::{BatchValidationProvider, BlockInfo, L2BlockInfo, AttributesWithParent};
 use spin::RwLock;
 
 use crate::{
@@ -202,7 +202,7 @@ where
     L2: L2ChainProvider + Send + Sync + Debug + Clone,
     DA: DataAvailabilityProvider + Send + Sync + Debug + Clone,
 {
-    type Item = OpAttributesWithParent;
+    type Item = AttributesWithParent;
 
     fn next(&mut self) -> Option<Self::Item> {
         self.pipeline.next()
@@ -217,8 +217,8 @@ where
     L2: L2ChainProvider + Send + Sync + Debug + Clone,
     DA: DataAvailabilityProvider + Send + Sync + Debug + Clone,
 {
-    /// Peeks at the next [`OpAttributesWithParent`] from the pipeline.
-    fn peek(&self) -> Option<&OpAttributesWithParent> {
+    /// Peeks at the next [`AttributesWithParent`] from the pipeline.
+    fn peek(&self) -> Option<&AttributesWithParent> {
         self.pipeline.peek()
     }
 


### PR DESCRIPTION
## Summary

Renames `OpAttributesWithParent` and `OpBlockConversionError` in the `base-protocol` crate to `AttributesWithParent` and `BaseBlockConversionError`, aligning them with the project's `Base`-prefixed naming convention. The rename is purely mechanical with no behavioral changes. All 31 affected files across consensus, derive, engine, service, proof, and test harness crates have been updated.