### PR TITLE
feat(metering): replace state root time with state root gas in priority fee estimation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4987,6 +4987,7 @@ name = "base-reth-node"
 version = "0.0.0"
 dependencies = [
  "base-bundle-extension",
+ "base-bundles",
  "base-cli-utils",
  "base-execution-cli",
  "base-flashblocks",

--- a/bin/node/Cargo.toml
+++ b/bin/node/Cargo.toml
@@ -17,6 +17,7 @@ workspace = true
 
 [dependencies]
 # workspace
+base-bundles.workspace = true
 base-metering.workspace = true
 base-cli-utils.workspace = true
 base-txpool-rpc.workspace = true

--- a/bin/node/src/cli.rs
+++ b/bin/node/src/cli.rs
@@ -8,7 +8,7 @@ use base_tx_forwarding::{
 use url::Url;
 
 /// CLI Arguments
-#[derive(Debug, Clone, PartialEq, Eq, clap::Args)]
+#[derive(Debug, Clone, clap::Args)]
 #[command(next_help_heading = "Rollup")]
 pub struct Args {
     /// Rollup arguments
@@ -60,12 +60,20 @@ pub struct Args {
     #[arg(long = "metering.execution-time-us", requires = "enable_metering")]
     pub metering_execution_time_us: Option<u64>,
 
-    /// Whole-block state root computation budget in microseconds for priority fee estimation.
+    /// Block-level state root gas limit for priority fee estimation.
     #[arg(
-        long = "metering.state-root-time-us",
+        long = "metering.state-root-gas-limit",
         requires_all = ["enable_metering", "metering_target_flashblocks_per_block"]
     )]
-    pub metering_state_root_time_us: Option<u64>,
+    pub metering_state_root_gas_limit: Option<u64>,
+
+    /// State root gas coefficient (K) for priority fee estimation.
+    #[arg(long = "metering.state-root-gas-coefficient", default_value = "0.02")]
+    pub metering_state_root_gas_coefficient: f64,
+
+    /// State root gas anchor in microseconds for priority fee estimation.
+    #[arg(long = "metering.state-root-gas-anchor-us", default_value = "5000")]
+    pub metering_state_root_gas_anchor_us: u128,
 
     /// Whole-block data availability byte budget for priority fee estimation.
     #[arg(
@@ -77,7 +85,7 @@ pub struct Args {
     /// Target number of tx-pool flashblocks the builder budgets per block.
     ///
     /// This excludes the base flashblock at index `0` and is required when gas, state root
-    /// time, or DA estimation is enabled.
+    /// gas, or DA estimation is enabled.
     #[arg(long = "metering.target-flashblocks-per-block", requires = "enable_metering")]
     pub metering_target_flashblocks_per_block: Option<usize>,
 

--- a/bin/node/src/main.rs
+++ b/bin/node/src/main.rs
@@ -6,6 +6,7 @@
 pub mod cli;
 
 use base_bundle_extension::BundleExtension;
+use base_bundles::StateRootGasConfig;
 use base_execution_cli::{Cli, chainspec::OpChainSpecParser};
 use base_flashblocks::FlashblocksConfig;
 use base_flashblocks_node::FlashblocksExtension;
@@ -45,14 +46,19 @@ fn main() {
         let resource_limits = MeteringResourceLimits {
             gas_limit: args.metering_gas_limit,
             execution_time_us: args.metering_execution_time_us,
-            state_root_time_us: args.metering_state_root_time_us,
+            state_root_gas: args.metering_state_root_gas_limit,
             da_bytes: args.metering_da_bytes,
+        };
+        let state_root_gas_config = StateRootGasConfig {
+            coefficient: args.metering_state_root_gas_coefficient,
+            anchor_us: args.metering_state_root_gas_anchor_us,
         };
         let metering_config = if args.enable_metering {
             let mut config = flashblocks_config
                 .clone()
                 .map_or_else(MeteringConfig::enabled, MeteringConfig::with_flashblocks)
-                .with_resource_limits(resource_limits);
+                .with_resource_limits(resource_limits)
+                .with_state_root_gas_config(state_root_gas_config);
             if let Some(target_flashblocks_per_block) = args.metering_target_flashblocks_per_block {
                 config = config.with_target_flashblocks_per_block(target_flashblocks_per_block);
             }

--- a/crates/builder/core/src/flashblocks/context.rs
+++ b/crates/builder/core/src/flashblocks/context.rs
@@ -716,14 +716,14 @@ impl OpPayloadBuilderCtx {
             // Compute state root gas from metering data:
             // sr_gas = gas_used × (1 + K × max(0, SR_ms - anchor_ms))
             let state_root_gas = resource_usage.as_ref().map(|m| {
-                let gas_used = m.total_gas_used;
-                let sr_us = m.state_root_time_us;
-                let anchor_us = self.builder_config.state_root_gas_anchor_us;
-                let k = self.builder_config.state_root_gas_coefficient;
-                let excess_us = sr_us.saturating_sub(anchor_us);
-                let excess_ms = excess_us as f64 / 1000.0;
-                let multiplier = 1.0 + k * excess_ms;
-                (gas_used as f64 * multiplier) as u64
+                base_bundles::compute_state_root_gas(
+                    m.total_gas_used,
+                    m.state_root_time_us,
+                    &base_bundles::StateRootGasConfig {
+                        coefficient: self.builder_config.state_root_gas_coefficient,
+                        anchor_us: self.builder_config.state_root_gas_anchor_us,
+                    },
+                )
             });
 
             // Build tx resources struct

--- a/crates/client/metering/src/cache.rs
+++ b/crates/client/metering/src/cache.rs
@@ -18,8 +18,8 @@ pub struct MeteredTransaction {
     pub gas_used: u64,
     /// Execution time in microseconds.
     pub execution_time_us: u128,
-    /// State root computation time in microseconds.
-    pub state_root_time_us: u128,
+    /// State root gas (synthetic resource derived from gas used and SR time).
+    pub state_root_gas: u64,
     /// Data availability bytes.
     pub data_availability_bytes: u64,
 }
@@ -32,7 +32,7 @@ impl MeteredTransaction {
             priority_fee_per_gas: U256::ZERO,
             gas_used: 0,
             execution_time_us: 0,
-            state_root_time_us: 0,
+            state_root_gas: 0,
             data_availability_bytes: 0,
         }
     }
@@ -45,8 +45,8 @@ pub struct ResourceTotals {
     pub gas_used: u64,
     /// Total execution time in microseconds.
     pub execution_time_us: u128,
-    /// Total state root time in microseconds.
-    pub state_root_time_us: u128,
+    /// Total state root gas.
+    pub state_root_gas: u64,
     /// Total data availability bytes.
     pub data_availability_bytes: u64,
 }
@@ -55,7 +55,7 @@ impl ResourceTotals {
     const fn accumulate(&mut self, tx: &MeteredTransaction) {
         self.gas_used = self.gas_used.saturating_add(tx.gas_used);
         self.execution_time_us = self.execution_time_us.saturating_add(tx.execution_time_us);
-        self.state_root_time_us = self.state_root_time_us.saturating_add(tx.state_root_time_us);
+        self.state_root_gas = self.state_root_gas.saturating_add(tx.state_root_gas);
         self.data_availability_bytes =
             self.data_availability_bytes.saturating_add(tx.data_availability_bytes);
     }
@@ -274,7 +274,7 @@ mod tests {
             priority_fee_per_gas: U256::from(priority),
             gas_used: 10,
             execution_time_us: 5,
-            state_root_time_us: 7,
+            state_root_gas: 7,
             data_availability_bytes: 20,
         }
     }

--- a/crates/client/metering/src/collector.rs
+++ b/crates/client/metering/src/collector.rs
@@ -5,6 +5,7 @@ use std::{collections::HashMap, fmt, sync::Arc};
 use alloy_consensus::BlockHeader;
 use alloy_primitives::{Bytes, U256, keccak256};
 use base_alloy_flz::flz_compress_len;
+use base_bundles::{StateRootGasConfig, compute_state_root_gas};
 use base_flashblocks::PendingBlocks;
 use parking_lot::RwLock;
 use tokio::sync::broadcast;
@@ -29,6 +30,7 @@ impl FlashblockPosition {
 pub struct MeteringCollector {
     cache: Arc<RwLock<MeteringCache>>,
     state_root_cache: Arc<RwLock<PendingStateRootTimes>>,
+    state_root_gas_config: StateRootGasConfig,
     flashblock_rx: broadcast::Receiver<Arc<PendingBlocks>>,
     last_earliest_block: Option<u64>,
     last_processed: Option<FlashblockPosition>,
@@ -48,11 +50,13 @@ impl MeteringCollector {
     pub const fn new(
         cache: Arc<RwLock<MeteringCache>>,
         state_root_cache: Arc<RwLock<PendingStateRootTimes>>,
+        state_root_gas_config: StateRootGasConfig,
         flashblock_rx: broadcast::Receiver<Arc<PendingBlocks>>,
     ) -> Self {
         Self {
             cache,
             state_root_cache,
+            state_root_gas_config,
             flashblock_rx,
             last_earliest_block: None,
             last_processed: None,
@@ -208,12 +212,15 @@ impl MeteringCollector {
                 .or_else(|| self.state_root_cache.write().pop(&tx_hash))
                 .unwrap_or(0);
 
+            let state_root_gas =
+                compute_state_root_gas(gas_used, state_root_time_us, &self.state_root_gas_config);
+
             metered_transactions.push(MeteredTransaction {
                 tx_hash,
                 priority_fee_per_gas: U256::from(priority_fee),
                 gas_used,
                 execution_time_us,
-                state_root_time_us,
+                state_root_gas,
                 data_availability_bytes: da_bytes,
             });
         }
@@ -462,7 +469,12 @@ mod tests {
             Arc::new(RwLock::new(PendingStateRootTimes::new(NonZeroUsize::new(8).unwrap())));
         let (_, rx) = broadcast::channel::<Arc<PendingBlocks>>(1);
 
-        let mut collector = MeteringCollector::new(Arc::clone(&cache), state_root_cache, rx);
+        let mut collector = MeteringCollector::new(
+            Arc::clone(&cache),
+            state_root_cache,
+            StateRootGasConfig::default(),
+            rx,
+        );
         collector.handle_pending_blocks(&pending);
 
         assert!(cache.read().contains_block(100));
@@ -484,8 +496,12 @@ mod tests {
         state_root_cache.write().push(tx_hash, 1234);
 
         let (_, rx) = broadcast::channel::<Arc<PendingBlocks>>(1);
-        let mut collector =
-            MeteringCollector::new(Arc::clone(&cache), Arc::clone(&state_root_cache), rx);
+        let mut collector = MeteringCollector::new(
+            Arc::clone(&cache),
+            Arc::clone(&state_root_cache),
+            StateRootGasConfig::default(),
+            rx,
+        );
         collector.handle_pending_blocks(&pending);
 
         // State root cache entry should have been consumed
@@ -505,7 +521,12 @@ mod tests {
             Arc::new(RwLock::new(PendingStateRootTimes::new(NonZeroUsize::new(8).unwrap())));
         let (_, rx) = broadcast::channel::<Arc<PendingBlocks>>(1);
 
-        let mut collector = MeteringCollector::new(Arc::clone(&cache), state_root_cache, rx);
+        let mut collector = MeteringCollector::new(
+            Arc::clone(&cache),
+            state_root_cache,
+            StateRootGasConfig::default(),
+            rx,
+        );
 
         // Process once
         collector.handle_pending_blocks(&pending);
@@ -562,7 +583,12 @@ mod tests {
         let state_root_cache =
             Arc::new(RwLock::new(PendingStateRootTimes::new(NonZeroUsize::new(8).unwrap())));
         let (_, rx) = broadcast::channel::<Arc<PendingBlocks>>(1);
-        let mut collector = MeteringCollector::new(Arc::clone(&cache), state_root_cache, rx);
+        let mut collector = MeteringCollector::new(
+            Arc::clone(&cache),
+            state_root_cache,
+            StateRootGasConfig::default(),
+            rx,
+        );
 
         collector.handle_pending_blocks(&pending_0);
         collector.handle_pending_blocks(&pending_2);
@@ -613,7 +639,12 @@ mod tests {
         let state_root_cache =
             Arc::new(RwLock::new(PendingStateRootTimes::new(NonZeroUsize::new(8).unwrap())));
         let (_, rx) = broadcast::channel::<Arc<PendingBlocks>>(1);
-        let mut collector = MeteringCollector::new(Arc::clone(&cache), state_root_cache, rx);
+        let mut collector = MeteringCollector::new(
+            Arc::clone(&cache),
+            state_root_cache,
+            StateRootGasConfig::default(),
+            rx,
+        );
 
         collector.handle_pending_blocks(&pending_1);
         collector.handle_pending_blocks(&pending_0);

--- a/crates/client/metering/src/estimator.rs
+++ b/crates/client/metering/src/estimator.rs
@@ -34,7 +34,7 @@ pub enum EstimateError {
 ///
 /// Execution time resets for each flashblock, matching the builder's
 /// `flashblock_execution_time_limit_us` and `reset_flashblock_execution_time()`.
-/// Gas, DA bytes, and state root time accumulate across the block against
+/// Gas, DA bytes, and state root gas accumulate across the block against
 /// cumulative per-flashblock targets derived from the whole-block budget.
 #[derive(Debug, Clone, Copy, Default)]
 pub struct ResourceLimits {
@@ -42,8 +42,8 @@ pub struct ResourceLimits {
     pub gas_used: Option<u64>,
     /// Execution time budget per flashblock in microseconds.
     pub execution_time_us: Option<u128>,
-    /// State root computation budget for the whole block in microseconds.
-    pub state_root_time_us: Option<u128>,
+    /// State root gas budget for the whole block.
+    pub state_root_gas: Option<u64>,
     /// Data availability byte budget for the whole block.
     pub data_availability_bytes: Option<u64>,
 }
@@ -54,7 +54,7 @@ impl ResourceLimits {
         match resource {
             ResourceKind::GasUsed => self.gas_used.map(|v| v as u128),
             ResourceKind::ExecutionTime => self.execution_time_us,
-            ResourceKind::StateRootTime => self.state_root_time_us,
+            ResourceKind::StateRootGas => self.state_root_gas.map(|v| v as u128),
             ResourceKind::DataAvailability => self.data_availability_bytes.map(|v| v as u128),
         }
     }
@@ -67,8 +67,8 @@ pub enum ResourceKind {
     GasUsed,
     /// Execution time.
     ExecutionTime,
-    /// State root computation time.
-    StateRootTime,
+    /// State root gas (synthetic resource derived from gas used and SR time).
+    StateRootGas,
     /// Data availability bytes.
     DataAvailability,
 }
@@ -82,18 +82,18 @@ enum ResourceBudgetBehavior {
 impl ResourceKind {
     /// Returns all resource kinds in a fixed order.
     pub const fn all() -> [Self; 4] {
-        [Self::GasUsed, Self::ExecutionTime, Self::StateRootTime, Self::DataAvailability]
+        [Self::GasUsed, Self::ExecutionTime, Self::StateRootGas, Self::DataAvailability]
     }
 
     /// Returns how this resource budget behaves in the builder.
     ///
-    /// Execution time resets each flashblock, while gas, DA bytes, and state root time
+    /// Execution time resets each flashblock, while gas, DA bytes, and state root gas
     /// accumulate across the block against growing cumulative targets in the tx-pool
     /// flashblock loop.
     const fn budget_behavior(self) -> ResourceBudgetBehavior {
         match self {
             Self::ExecutionTime => ResourceBudgetBehavior::ResetsEachFlashblock,
-            Self::GasUsed | Self::StateRootTime | Self::DataAvailability => {
+            Self::GasUsed | Self::StateRootGas | Self::DataAvailability => {
                 ResourceBudgetBehavior::AccumulatesUntilBlockEnd
             }
         }
@@ -104,7 +104,7 @@ impl ResourceKind {
         match self {
             Self::GasUsed => "gas",
             Self::ExecutionTime => "execution time",
-            Self::StateRootTime => "state root time",
+            Self::StateRootGas => "state root gas",
             Self::DataAvailability => "data availability",
         }
     }
@@ -114,7 +114,7 @@ impl ResourceKind {
         match self {
             Self::GasUsed => "gasUsed",
             Self::ExecutionTime => "executionTime",
-            Self::StateRootTime => "stateRootTime",
+            Self::StateRootGas => "stateRootGas",
             Self::DataAvailability => "dataAvailability",
         }
     }
@@ -127,8 +127,8 @@ pub struct ResourceDemand {
     pub gas_used: Option<u64>,
     /// Execution time demand in microseconds.
     pub execution_time_us: Option<u128>,
-    /// State root time demand in microseconds.
-    pub state_root_time_us: Option<u128>,
+    /// State root gas demand.
+    pub state_root_gas: Option<u64>,
     /// Data availability bytes demand.
     pub data_availability_bytes: Option<u64>,
 }
@@ -139,7 +139,7 @@ impl ResourceDemand {
         match resource {
             ResourceKind::GasUsed => self.gas_used.map(|v| v as u128),
             ResourceKind::ExecutionTime => self.execution_time_us,
-            ResourceKind::StateRootTime => self.state_root_time_us,
+            ResourceKind::StateRootGas => self.state_root_gas.map(|v| v as u128),
             ResourceKind::DataAvailability => self.data_availability_bytes.map(|v| v as u128),
         }
     }
@@ -175,8 +175,8 @@ pub struct ResourceEstimates {
     pub gas_used: Option<ResourceEstimate>,
     /// Execution time estimate.
     pub execution_time: Option<ResourceEstimate>,
-    /// State root time estimate.
-    pub state_root_time: Option<ResourceEstimate>,
+    /// State root gas estimate.
+    pub state_root_gas: Option<ResourceEstimate>,
     /// Data availability estimate.
     pub data_availability: Option<ResourceEstimate>,
 }
@@ -187,7 +187,7 @@ impl ResourceEstimates {
         match kind {
             ResourceKind::GasUsed => self.gas_used.as_ref(),
             ResourceKind::ExecutionTime => self.execution_time.as_ref(),
-            ResourceKind::StateRootTime => self.state_root_time.as_ref(),
+            ResourceKind::StateRootGas => self.state_root_gas.as_ref(),
             ResourceKind::DataAvailability => self.data_availability.as_ref(),
         }
     }
@@ -197,7 +197,7 @@ impl ResourceEstimates {
         match kind {
             ResourceKind::GasUsed => self.gas_used = Some(estimate),
             ResourceKind::ExecutionTime => self.execution_time = Some(estimate),
-            ResourceKind::StateRootTime => self.state_root_time = Some(estimate),
+            ResourceKind::StateRootGas => self.state_root_gas = Some(estimate),
             ResourceKind::DataAvailability => self.data_availability = Some(estimate),
         }
     }
@@ -207,7 +207,7 @@ impl ResourceEstimates {
         [
             (ResourceKind::GasUsed, &self.gas_used),
             (ResourceKind::ExecutionTime, &self.execution_time),
-            (ResourceKind::StateRootTime, &self.state_root_time),
+            (ResourceKind::StateRootGas, &self.state_root_gas),
             (ResourceKind::DataAvailability, &self.data_availability),
         ]
         .into_iter()
@@ -884,7 +884,7 @@ fn usage_extractor(resource: ResourceKind) -> fn(&MeteredTransaction) -> u128 {
     match resource {
         ResourceKind::GasUsed => |tx: &MeteredTransaction| tx.gas_used as u128,
         ResourceKind::ExecutionTime => |tx: &MeteredTransaction| tx.execution_time_us,
-        ResourceKind::StateRootTime => |tx: &MeteredTransaction| tx.state_root_time_us,
+        ResourceKind::StateRootGas => |tx: &MeteredTransaction| tx.state_root_gas as u128,
         ResourceKind::DataAvailability => {
             |tx: &MeteredTransaction| tx.data_availability_bytes as u128
         }
@@ -907,7 +907,7 @@ mod tests {
             priority_fee_per_gas: U256::from(priority),
             gas_used: usage,
             execution_time_us: usage as u128,
-            state_root_time_us: usage as u128,
+            state_root_gas: usage,
             data_availability_bytes: usage,
         }
     }
@@ -917,7 +917,7 @@ mod tests {
         priority: u64,
         gas: u64,
         exec_us: u128,
-        state_root_us: u128,
+        state_root_gas: u64,
         da_bytes: u64,
     ) -> MeteredTransaction {
         let mut hash_bytes = [0u8; 32];
@@ -927,7 +927,7 @@ mod tests {
             priority_fee_per_gas: U256::from(priority),
             gas_used: gas,
             execution_time_us: exec_us,
-            state_root_time_us: state_root_us,
+            state_root_gas,
             data_availability_bytes: da_bytes,
         }
     }
@@ -1091,7 +1091,7 @@ mod tests {
     const DEFAULT_LIMITS: ResourceLimits = ResourceLimits {
         gas_used: Some(25),
         execution_time_us: Some(100),
-        state_root_time_us: None,
+        state_root_gas: None,
         data_availability_bytes: Some(100),
     };
 
@@ -1280,7 +1280,7 @@ mod tests {
         let limits = ResourceLimits {
             gas_used: Some(50),
             execution_time_us: Some(200),
-            state_root_time_us: None,
+            state_root_gas: None,
             data_availability_bytes: Some(200),
         };
         let (cache, estimator) = setup_estimator(limits);
@@ -1359,7 +1359,7 @@ mod tests {
         let limits = ResourceLimits {
             gas_used: None,
             execution_time_us: Some(30),
-            state_root_time_us: None,
+            state_root_gas: None,
             data_availability_bytes: None,
         };
         let (cache, estimator) = setup_estimator_with_target(limits, 2);
@@ -1396,7 +1396,7 @@ mod tests {
         let limits = ResourceLimits {
             gas_used: None,
             execution_time_us: Some(100),
-            state_root_time_us: None,
+            state_root_gas: None,
             data_availability_bytes: None,
         };
         let (cache, estimator) = setup_estimator_with_target(limits, 4);
@@ -1422,7 +1422,7 @@ mod tests {
         let limits = ResourceLimits {
             gas_used: None,
             execution_time_us: Some(100),
-            state_root_time_us: None,
+            state_root_gas: None,
             data_availability_bytes: None,
         };
         let (cache, estimator) = setup_estimator_with_target(limits, 4);
@@ -1447,7 +1447,7 @@ mod tests {
         let limits = ResourceLimits {
             gas_used: Some(100),
             execution_time_us: None,
-            state_root_time_us: None,
+            state_root_gas: None,
             data_availability_bytes: None,
         };
         let (cache, estimator) = setup_estimator_with_target(limits, 4);
@@ -1480,7 +1480,7 @@ mod tests {
         let limits = ResourceLimits {
             gas_used: Some(100),
             execution_time_us: None,
-            state_root_time_us: None,
+            state_root_gas: None,
             data_availability_bytes: None,
         };
         let (cache, estimator) = setup_estimator_with_target(limits, 4);
@@ -1506,7 +1506,7 @@ mod tests {
         let limits = ResourceLimits {
             gas_used: Some(20),
             execution_time_us: None,
-            state_root_time_us: None,
+            state_root_gas: None,
             data_availability_bytes: None,
         };
         let (cache, estimator) = setup_estimator(limits);

--- a/crates/client/metering/src/extension.rs
+++ b/crates/client/metering/src/extension.rs
@@ -4,6 +4,7 @@
 use std::{num::NonZeroUsize, sync::Arc};
 
 use alloy_primitives::U256;
+use base_bundles::StateRootGasConfig;
 use base_flashblocks::{FlashblocksAPI, FlashblocksConfig, FlashblocksState};
 use base_node_runner::{BaseNodeExtension, FromExtensionConfig, NodeHooks};
 use parking_lot::RwLock;
@@ -32,11 +33,11 @@ pub struct MeteringResourceLimits {
     /// This matches the builder's flashblock execution budget, which resets each
     /// flashblock instead of accumulating across the block.
     pub execution_time_us: Option<u64>,
-    /// Total state root computation budget for the block in microseconds.
+    /// Block-level state root gas limit.
     ///
     /// Like the builder, the estimator treats this as a cumulative budget that
     /// later flashblocks can consume if earlier ones underuse it.
-    pub state_root_time_us: Option<u64>,
+    pub state_root_gas: Option<u64>,
     /// Total data-availability byte budget for the block.
     pub da_bytes: Option<u64>,
 }
@@ -47,14 +48,14 @@ impl MeteringResourceLimits {
         ResourceLimits {
             gas_used: self.gas_limit,
             execution_time_us: self.execution_time_us.map(|v| v as u128),
-            state_root_time_us: self.state_root_time_us.map(|v| v as u128),
+            state_root_gas: self.state_root_gas,
             data_availability_bytes: self.da_bytes,
         }
     }
 
     /// Returns true if any resource uses the builder's cumulative multi-flashblock budget.
     const fn uses_accumulating_resource_limits(&self) -> bool {
-        self.gas_limit.is_some() || self.state_root_time_us.is_some() || self.da_bytes.is_some()
+        self.gas_limit.is_some() || self.state_root_gas.is_some() || self.da_bytes.is_some()
     }
 }
 
@@ -67,6 +68,8 @@ pub struct MeteringExtension {
     pub flashblocks_config: Option<FlashblocksConfig>,
     /// Resource limits for priority fee estimation.
     pub resource_limits: MeteringResourceLimits,
+    /// Configuration for computing state root gas from state root time.
+    pub state_root_gas_config: StateRootGasConfig,
     /// Percentile for priority fee estimation (e.g., 0.5 for median).
     pub priority_fee_percentile: f64,
     /// Default priority fee when resources are uncongested (in wei).
@@ -78,7 +81,7 @@ pub struct MeteringExtension {
     /// Target number of tx-pool flashblocks the builder budgets each block against.
     ///
     /// This excludes the initial base flashblock at index `0`.
-    /// Must be greater than zero when set. Required when gas, state root time,
+    /// Must be greater than zero when set. Required when gas, state root gas,
     /// or DA priority fee estimation is enabled.
     pub target_flashblocks_per_block: Option<usize>,
 }
@@ -89,6 +92,7 @@ impl Default for MeteringExtension {
             enabled: false,
             flashblocks_config: None,
             resource_limits: MeteringResourceLimits::default(),
+            state_root_gas_config: StateRootGasConfig::default(),
             priority_fee_percentile: 0.5,
             uncongested_priority_fee: 1_000_000,
             cache_size: 12,
@@ -106,9 +110,10 @@ impl MeteringExtension {
             resource_limits: MeteringResourceLimits {
                 gas_limit: None,
                 execution_time_us: None,
-                state_root_time_us: None,
+                state_root_gas: None,
                 da_bytes: None,
             },
+            state_root_gas_config: StateRootGasConfig { coefficient: 0.02, anchor_us: 5000 },
             priority_fee_percentile: 0.5,
             uncongested_priority_fee: 1_000_000,
             cache_size: 12,
@@ -147,11 +152,17 @@ impl MeteringExtension {
         self
     }
 
+    /// Sets the state root gas configuration.
+    pub const fn with_state_root_gas_config(mut self, config: StateRootGasConfig) -> Self {
+        self.state_root_gas_config = config;
+        self
+    }
+
     /// Returns true if priority fee estimation is configured (has resource limits).
     const fn has_estimator_config(&self) -> bool {
         self.resource_limits.gas_limit.is_some()
             || self.resource_limits.execution_time_us.is_some()
-            || self.resource_limits.state_root_time_us.is_some()
+            || self.resource_limits.state_root_gas.is_some()
             || self.resource_limits.da_bytes.is_some()
     }
 
@@ -169,7 +180,7 @@ impl MeteringExtension {
             }
             None if requires_target_flashblocks => {
                 panic!(
-                    "target_flashblocks_per_block must be configured when gas, state root time, or data availability priority fee estimation is enabled"
+                    "target_flashblocks_per_block must be configured when gas, state root gas, or data availability priority fee estimation is enabled"
                 )
             }
             None => 1,
@@ -187,6 +198,7 @@ impl BaseNodeExtension for MeteringExtension {
         let has_estimator = self.has_estimator_config();
         let requires_target_flashblocks = self.resource_limits.uses_accumulating_resource_limits();
         let resource_limits = self.resource_limits.to_resource_limits();
+        let state_root_gas_config = self.state_root_gas_config;
         let percentile = self.priority_fee_percentile;
         let default_fee = U256::from(self.uncongested_priority_fee);
         let cache_size = has_estimator.then(|| self.resolved_cache_size());
@@ -233,6 +245,7 @@ impl BaseNodeExtension for MeteringExtension {
                     let collector = MeteringCollector::new(
                         Arc::clone(&cache),
                         Arc::clone(&state_root_cache),
+                        state_root_gas_config,
                         flashblock_rx,
                     );
                     let collector_handle = tokio::spawn(collector.run());
@@ -254,6 +267,7 @@ impl BaseNodeExtension for MeteringExtension {
                     fb_state,
                     estimator,
                     state_root_cache,
+                    state_root_gas_config,
                 )
             } else {
                 info!(message = "Starting Metering RPC (priority fee estimation disabled)");
@@ -276,6 +290,8 @@ pub struct MeteringConfig {
     pub flashblocks_config: Option<FlashblocksConfig>,
     /// Resource limits for priority fee estimation.
     pub resource_limits: MeteringResourceLimits,
+    /// Configuration for computing state root gas from state root time.
+    pub state_root_gas_config: StateRootGasConfig,
     /// Percentile for priority fee estimation.
     pub priority_fee_percentile: f64,
     /// Default priority fee when uncongested.
@@ -286,7 +302,7 @@ pub struct MeteringConfig {
     pub cache_size: usize,
     /// Target number of tx-pool flashblocks the builder budgets per block.
     ///
-    /// Must be greater than zero when set. Required when gas, state root time,
+    /// Must be greater than zero when set. Required when gas, state root gas,
     /// or DA priority fee estimation is enabled.
     pub target_flashblocks_per_block: Option<usize>,
 }
@@ -305,9 +321,10 @@ impl MeteringConfig {
             resource_limits: MeteringResourceLimits {
                 gas_limit: None,
                 execution_time_us: None,
-                state_root_time_us: None,
+                state_root_gas: None,
                 da_bytes: None,
             },
+            state_root_gas_config: StateRootGasConfig { coefficient: 0.02, anchor_us: 5000 },
             priority_fee_percentile: 0.5,
             uncongested_priority_fee: 1_000_000,
             cache_size: 12,
@@ -323,9 +340,10 @@ impl MeteringConfig {
             resource_limits: MeteringResourceLimits {
                 gas_limit: None,
                 execution_time_us: None,
-                state_root_time_us: None,
+                state_root_gas: None,
                 da_bytes: None,
             },
+            state_root_gas_config: StateRootGasConfig { coefficient: 0.02, anchor_us: 5000 },
             priority_fee_percentile: 0.5,
             uncongested_priority_fee: 1_000_000,
             cache_size: 12,
@@ -363,6 +381,12 @@ impl MeteringConfig {
         self.target_flashblocks_per_block = Some(count);
         self
     }
+
+    /// Sets the state root gas configuration.
+    pub const fn with_state_root_gas_config(mut self, config: StateRootGasConfig) -> Self {
+        self.state_root_gas_config = config;
+        self
+    }
 }
 
 impl FromExtensionConfig for MeteringExtension {
@@ -374,6 +398,7 @@ impl FromExtensionConfig for MeteringExtension {
             enabled: config.enabled,
             flashblocks_config: config.flashblocks_config,
             resource_limits: config.resource_limits,
+            state_root_gas_config: config.state_root_gas_config,
             priority_fee_percentile: config.priority_fee_percentile,
             uncongested_priority_fee: config.uncongested_priority_fee,
             cache_size: config.cache_size,
@@ -402,7 +427,7 @@ mod tests {
 
     #[test]
     #[should_panic(
-        expected = "target_flashblocks_per_block must be configured when gas, state root time, or data availability priority fee estimation is enabled"
+        expected = "target_flashblocks_per_block must be configured when gas, state root gas, or data availability priority fee estimation is enabled"
     )]
     fn missing_required_target_flashblocks_panics() {
         let extension = MeteringExtension::default();

--- a/crates/client/metering/src/rpc.rs
+++ b/crates/client/metering/src/rpc.rs
@@ -10,7 +10,9 @@ use alloy_eips::BlockNumberOrTag;
 use alloy_primitives::{B256, TxHash, U256};
 use base_alloy_consensus::BaseBlock;
 use base_alloy_flz::flz_compress_len;
-use base_bundles::{Bundle, MeterBundleResponse, ParsedBundle};
+use base_bundles::{
+    Bundle, MeterBundleResponse, ParsedBundle, StateRootGasConfig, compute_state_root_gas,
+};
 use base_execution_chainspec::OpChainSpec;
 use base_execution_evm::extract_l1_info_from_tx;
 use base_flashblocks::{FlashblocksAPI, PendingBlocksAPI};
@@ -40,6 +42,8 @@ pub struct MeteringApiImpl<Provider, FB> {
     priority_fee_estimator: Option<Arc<PriorityFeeEstimator>>,
     /// Shared cache for externally-submitted state root times.
     state_root_cache: Option<Arc<RwLock<PendingStateRootTimes>>>,
+    /// Configuration for computing state root gas from state root time.
+    state_root_gas_config: StateRootGasConfig,
     /// Whether metering data collection is enabled.
     metering_enabled: Arc<AtomicBool>,
 }
@@ -70,6 +74,7 @@ where
             pending_trie_cache: PendingTrieCache::new(),
             priority_fee_estimator: None,
             state_root_cache: None,
+            state_root_gas_config: StateRootGasConfig::default(),
             metering_enabled: Arc::new(AtomicBool::new(true)),
         }
     }
@@ -80,6 +85,7 @@ where
         flashblocks_api: Arc<FB>,
         estimator: Arc<PriorityFeeEstimator>,
         state_root_cache: Arc<RwLock<PendingStateRootTimes>>,
+        state_root_gas_config: StateRootGasConfig,
     ) -> Self {
         Self {
             provider,
@@ -87,6 +93,7 @@ where
             pending_trie_cache: PendingTrieCache::new(),
             priority_fee_estimator: Some(estimator),
             state_root_cache: Some(state_root_cache),
+            state_root_gas_config,
             metering_enabled: Arc::new(AtomicBool::new(true)),
         }
     }
@@ -383,7 +390,8 @@ where
         let meter_bundle_response = self.meter_bundle(bundle.clone()).await?;
 
         // Compute resource demand from metering results
-        let demand = compute_resource_demand(&bundle, &meter_bundle_response);
+        let demand =
+            compute_resource_demand(&bundle, &meter_bundle_response, &self.state_root_gas_config);
 
         // Get rolling estimate from the estimator
         let rolling_estimate = estimator.estimate_rolling(demand).map_err(|e| {
@@ -512,15 +520,25 @@ where
 }
 
 /// Computes resource demand from bundle metering results.
-fn compute_resource_demand(bundle: &Bundle, meter_result: &MeterBundleResponse) -> ResourceDemand {
+fn compute_resource_demand(
+    bundle: &Bundle,
+    meter_result: &MeterBundleResponse,
+    state_root_gas_config: &StateRootGasConfig,
+) -> ResourceDemand {
     // Calculate DA bytes from bundle transactions
     let da_bytes: u64 =
         bundle.txs.iter().fold(0u64, |acc, tx| acc.saturating_add(flz_compress_len(tx) as u64));
 
+    let state_root_gas = compute_state_root_gas(
+        meter_result.total_gas_used,
+        meter_result.state_root_time_us,
+        state_root_gas_config,
+    );
+
     ResourceDemand {
         gas_used: Some(meter_result.total_gas_used),
         execution_time_us: Some(meter_result.total_execution_time_us),
-        state_root_time_us: Some(meter_result.state_root_time_us),
+        state_root_gas: Some(state_root_gas),
         data_availability_bytes: Some(da_bytes),
     }
 }
@@ -1076,7 +1094,7 @@ mod tests {
             .with_resource_limits(MeteringResourceLimits {
                 gas_limit: Some(30_000_000),
                 execution_time_us: Some(1_000_000),
-                state_root_time_us: None,
+                state_root_gas: None,
                 da_bytes: Some(1_000_000),
             })
             .with_target_flashblocks_per_block(4);
@@ -1086,7 +1104,7 @@ mod tests {
     }
 
     #[test]
-    fn compute_resource_demand_preserves_execution_and_state_root_dimensions() {
+    fn compute_resource_demand_computes_state_root_gas() {
         let tx = Bytes::from_static(&[0x02, 0x01, 0x02, 0x03]);
         let bundle = create_bundle(vec![tx.clone()], 0, None);
         let meter_result = MeterBundleResponse {
@@ -1098,11 +1116,13 @@ mod tests {
             ..Default::default()
         };
 
-        let demand = compute_resource_demand(&bundle, &meter_result);
+        let config = StateRootGasConfig::default();
+        let demand = compute_resource_demand(&bundle, &meter_result, &config);
 
         assert_eq!(demand.gas_used, Some(21_000));
         assert_eq!(demand.execution_time_us, Some(123));
-        assert_eq!(demand.state_root_time_us, Some(45));
+        // SR time 45us is below default anchor of 5000us, so sr_gas == gas_used
+        assert_eq!(demand.state_root_gas, Some(21_000));
         assert_eq!(demand.data_availability_bytes, Some(flz_compress_len(&tx) as u64));
     }
 

--- a/crates/common/bundles/src/lib.rs
+++ b/crates/common/bundles/src/lib.rs
@@ -17,7 +17,9 @@ mod cancel;
 pub use cancel::{BundleHash, CancelBundle};
 
 mod meter;
-pub use meter::{MeterBundleResponse, TransactionResult};
+pub use meter::{
+    MeterBundleResponse, StateRootGasConfig, TransactionResult, compute_state_root_gas,
+};
 
 mod parsed;
 pub use parsed::ParsedBundle;

--- a/crates/common/bundles/src/meter.rs
+++ b/crates/common/bundles/src/meter.rs
@@ -3,6 +3,41 @@
 use alloy_primitives::{Address, B256, TxHash, U256};
 use serde::{Deserialize, Serialize};
 
+/// Configuration for computing state root gas from state root time.
+///
+/// State root gas is a synthetic resource that penalizes transactions whose
+/// simulated state root cost is disproportionate to their gas usage:
+/// `sr_gas = gas_used × (1 + K × max(0, SR_ms - anchor_ms))`.
+#[derive(Debug, Clone, Copy)]
+pub struct StateRootGasConfig {
+    /// Coefficient K. Controls how aggressively excess SR time inflates the
+    /// state root gas cost. Default: 0.02.
+    pub coefficient: f64,
+    /// Anchor threshold in microseconds. SR time below this produces no
+    /// penalty (multiplier = 1.0). Default: 5000 (5 ms).
+    pub anchor_us: u128,
+}
+
+impl Default for StateRootGasConfig {
+    fn default() -> Self {
+        Self { coefficient: 0.02, anchor_us: 5000 }
+    }
+}
+
+/// Computes state root gas from gas used and state root time.
+///
+/// `sr_gas = gas_used × (1 + K × max(0, SR_ms - anchor_ms))`
+pub fn compute_state_root_gas(
+    gas_used: u64,
+    state_root_time_us: u128,
+    config: &StateRootGasConfig,
+) -> u64 {
+    let excess_us = state_root_time_us.saturating_sub(config.anchor_us);
+    let excess_ms = excess_us as f64 / 1000.0;
+    let multiplier = 1.0 + config.coefficient * excess_ms;
+    (gas_used as f64 * multiplier) as u64
+}
+
 /// Result of simulating a single transaction within a bundle.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]


### PR DESCRIPTION
## Summary

- Aligns `meteredPriorityFeePerGas` with the builder's state root gas model (`sr_gas = gas_used × (1 + K × max(0, SR_ms - anchor_ms))`) instead of using raw state root time as the resource dimension
- Adds shared `compute_state_root_gas` and `StateRootGasConfig` to `base-bundles` so both builder and metering use one implementation
- Renames `ResourceKind::StateRootTime` → `StateRootGas`, updates cache, collector, estimator, extension, and node CLI accordingly
- New CLI args: `--metering.state-root-gas-limit`, `--metering.state-root-gas-coefficient`, `--metering.state-root-gas-anchor-us`

## Test plan

- [x] All 86 `base-metering` lib tests pass
- [x] All 47 `base-builder-core` lib tests pass
- [x] All 36 `base-bundles` tests pass
- [x] Clippy and fmt clean
- [ ] Verify priority fee estimation behavior on devnet with state root gas limits configured

type=routine
risk=low
impact=sev5