### PR TITLE
feat(genesis): split HardForkConfig into LegacyHardforkConfig + BaseHardforkConfig

### DIFF
--- a/crates/batcher/encoder/src/config.rs
+++ b/crates/batcher/encoder/src/config.rs
@@ -207,7 +207,7 @@ pub enum EncoderConfigError {
 
 #[cfg(test)]
 mod tests {
-    use base_consensus_genesis::HardForkConfig;
+    use base_consensus_genesis::LegacyHardforkConfig;
     use rstest::rstest;
 
     use super::*;
@@ -267,7 +267,7 @@ mod tests {
     fn rollup_config_with(block_time: u64, fjord_time: Option<u64>) -> RollupConfig {
         RollupConfig {
             block_time,
-            hardforks: HardForkConfig { fjord_time, ..HardForkConfig::default() },
+            hardforks: LegacyHardforkConfig { fjord_time, ..Default::default() }.into(),
             ..RollupConfig::default()
         }
     }

--- a/crates/consensus/derive/src/attributes/stateful.rs
+++ b/crates/consensus/derive/src/attributes/stateful.rs
@@ -262,7 +262,7 @@ mod tests {
 
     use alloy_consensus::Header;
     use alloy_primitives::{B256, Log, LogData, U64, U256, address};
-    use base_consensus_genesis::{CONFIG_UPDATE_TOPIC, HardForkConfig, SystemConfig};
+    use base_consensus_genesis::{CONFIG_UPDATE_TOPIC, LegacyHardforkConfig, SystemConfig};
     use base_consensus_registry::L1Config;
     use base_protocol::{BlockInfo, DepositError};
 
@@ -507,7 +507,7 @@ mod tests {
         let timestamp = 100;
         let cfg = Arc::new(RollupConfig {
             block_time,
-            hardforks: HardForkConfig { canyon_time: Some(0), ..Default::default() },
+            hardforks: LegacyHardforkConfig { canyon_time: Some(0), ..Default::default() }.into(),
             ..Default::default()
         });
         let l1_cfg = Arc::new(L1Config::sepolia().into());
@@ -559,7 +559,7 @@ mod tests {
         let timestamp = 100;
         let cfg = Arc::new(RollupConfig {
             block_time,
-            hardforks: HardForkConfig { ecotone_time: Some(102), ..Default::default() },
+            hardforks: LegacyHardforkConfig { ecotone_time: Some(102), ..Default::default() }.into(),
             ..Default::default()
         });
         let l1_cfg = Arc::new(L1Config::sepolia().into());
@@ -612,7 +612,7 @@ mod tests {
         let timestamp = 100;
         let cfg = Arc::new(RollupConfig {
             block_time,
-            hardforks: HardForkConfig { fjord_time: Some(102), ..Default::default() },
+            hardforks: LegacyHardforkConfig { fjord_time: Some(102), ..Default::default() }.into(),
             ..Default::default()
         });
         let l1_cfg = Arc::new(L1Config::sepolia().into());

--- a/crates/consensus/derive/src/sources/ethereum.rs
+++ b/crates/consensus/derive/src/sources/ethereum.rs
@@ -87,7 +87,7 @@ mod tests {
     use alloy_consensus::TxEnvelope;
     use alloy_eips::eip2718::Decodable2718;
     use alloy_primitives::{Address, address};
-    use base_consensus_genesis::{HardForkConfig, RollupConfig, SystemConfig};
+    use base_consensus_genesis::{LegacyHardforkConfig, RollupConfig, SystemConfig};
     use base_protocol::BlockInfo;
 
     use super::*;
@@ -131,7 +131,7 @@ mod tests {
         blob.data.push(BlobData { data: None, calldata: Some(Bytes::default()) });
         let calldata = CalldataSource::new(chain.clone(), Address::ZERO);
         let cfg = RollupConfig {
-            hardforks: HardForkConfig { ecotone_time: Some(0), ..Default::default() },
+            hardforks: LegacyHardforkConfig { ecotone_time: Some(0), ..Default::default() }.into(),
             ..Default::default()
         };
 

--- a/crates/consensus/derive/src/stages/batch/batch_provider.rs
+++ b/crates/consensus/derive/src/stages/batch/batch_provider.rs
@@ -220,7 +220,7 @@ mod tests {
     use alloc::{sync::Arc, vec};
 
     use alloy_eips::BlockNumHash;
-    use base_consensus_genesis::{HardForkConfig, RollupConfig, SystemConfig};
+    use base_consensus_genesis::{LegacyHardforkConfig, RollupConfig, SystemConfig};
     use base_protocol::BlockInfo;
 
     use super::BatchProvider;
@@ -235,7 +235,7 @@ mod tests {
         let provider = TestNextBatchProvider::new(vec![]);
         let l2_provider = TestL2ChainProvider::default();
         let cfg = Arc::new(RollupConfig {
-            hardforks: HardForkConfig { holocene_time: Some(0), ..Default::default() },
+            hardforks: LegacyHardforkConfig { holocene_time: Some(0), ..Default::default() }.into(),
             ..Default::default()
         });
         let mut batch_provider = BatchProvider::new(cfg, provider, l2_provider);
@@ -264,7 +264,7 @@ mod tests {
         let provider = TestNextBatchProvider::new(vec![]);
         let l2_provider = TestL2ChainProvider::default();
         let cfg = Arc::new(RollupConfig {
-            hardforks: HardForkConfig { holocene_time: Some(2), ..Default::default() },
+            hardforks: LegacyHardforkConfig { holocene_time: Some(2), ..Default::default() }.into(),
             ..Default::default()
         });
         let mut batch_provider = BatchProvider::new(cfg, provider, l2_provider);
@@ -290,7 +290,7 @@ mod tests {
         let provider = TestNextBatchProvider::new(vec![]);
         let l2_provider = TestL2ChainProvider::default();
         let cfg = Arc::new(RollupConfig {
-            hardforks: HardForkConfig { holocene_time: Some(10), ..Default::default() },
+            hardforks: LegacyHardforkConfig { holocene_time: Some(10), ..Default::default() }.into(),
             ..Default::default()
         });
         let mut batch_provider = BatchProvider::new(cfg, provider, l2_provider);
@@ -323,7 +323,7 @@ mod tests {
         let provider = TestNextBatchProvider::new(vec![]);
         let l2_provider = TestL2ChainProvider::default();
         let cfg = Arc::new(RollupConfig {
-            hardforks: HardForkConfig { holocene_time: Some(2), ..Default::default() },
+            hardforks: LegacyHardforkConfig { holocene_time: Some(2), ..Default::default() }.into(),
             ..Default::default()
         });
         let mut batch_provider = BatchProvider::new(cfg, provider, l2_provider);
@@ -373,7 +373,7 @@ mod tests {
         let provider = TestNextBatchProvider::new(vec![]);
         let l2_provider = TestL2ChainProvider::default();
         let cfg = Arc::new(RollupConfig {
-            hardforks: HardForkConfig { holocene_time: Some(0), ..Default::default() },
+            hardforks: LegacyHardforkConfig { holocene_time: Some(0), ..Default::default() }.into(),
             ..Default::default()
         });
         let mut batch_provider = BatchProvider::new(cfg, provider, l2_provider);

--- a/crates/consensus/derive/src/stages/batch/batch_queue.rs
+++ b/crates/consensus/derive/src/stages/batch/batch_queue.rs
@@ -484,7 +484,7 @@ mod tests {
     use alloy_primitives::{Address, B256, Bytes, TxKind, U256, address, b256};
     use alloy_rlp::{BytesMut, Encodable};
     use base_alloy_consensus::{OpBlock, OpTxEnvelope, OpTxType, TxDeposit};
-    use base_consensus_genesis::{ChainGenesis, HardForkConfig, RollupConfig, SystemConfig};
+    use base_consensus_genesis::{ChainGenesis, LegacyHardforkConfig, RollupConfig, SystemConfig};
     use base_protocol::{BatchReader, L1BlockInfoBedrock, L1BlockInfoTx};
     use tracing::Level;
     use tracing_subscriber::layer::SubscriberExt;
@@ -563,7 +563,7 @@ mod tests {
         // Construct a future single batch.
         let cfg = Arc::new(RollupConfig {
             max_sequencer_drift: 700,
-            hardforks: HardForkConfig { holocene_time: Some(0), ..Default::default() },
+            hardforks: LegacyHardforkConfig { holocene_time: Some(0), ..Default::default() }.into(),
             ..Default::default()
         });
         assert!(cfg.is_holocene_active(0));
@@ -600,7 +600,7 @@ mod tests {
     async fn test_holocene_add_batch_future() {
         // Construct a future single batch.
         let cfg = Arc::new(RollupConfig {
-            hardforks: HardForkConfig { holocene_time: Some(0), ..Default::default() },
+            hardforks: LegacyHardforkConfig { holocene_time: Some(0), ..Default::default() }.into(),
             ..Default::default()
         });
         assert!(cfg.is_holocene_active(0));
@@ -669,7 +669,7 @@ mod tests {
         // Construct a single batch with BatchValidity::Past.
         let cfg = Arc::new(RollupConfig {
             block_time: 2,
-            hardforks: HardForkConfig { holocene_time: Some(0), ..Default::default() },
+            hardforks: LegacyHardforkConfig { holocene_time: Some(0), ..Default::default() }.into(),
             ..Default::default()
         });
         assert!(cfg.is_holocene_active(0));
@@ -854,7 +854,7 @@ mod tests {
 
         // Construct a future single batch.
         let cfg = Arc::new(RollupConfig {
-            hardforks: HardForkConfig { holocene_time: Some(0), ..Default::default() },
+            hardforks: LegacyHardforkConfig { holocene_time: Some(0), ..Default::default() }.into(),
             ..Default::default()
         });
         assert!(cfg.is_holocene_active(0));
@@ -985,7 +985,7 @@ mod tests {
         let payload_block_hash =
             b256!("4444444444444444444444444444444444444444444444444444444444444444");
         let cfg = Arc::new(RollupConfig {
-            hardforks: HardForkConfig { delta_time: Some(0), ..Default::default() },
+            hardforks: LegacyHardforkConfig { delta_time: Some(0), ..Default::default() }.into(),
             block_time: 100,
             max_sequencer_drift: 10000000,
             seq_window_size: 10000000,

--- a/crates/consensus/derive/src/stages/batch/batch_stream.rs
+++ b/crates/consensus/derive/src/stages/batch/batch_stream.rs
@@ -265,7 +265,7 @@ mod tests {
     use alloy_eips::{BlockNumHash, NumHash};
     use alloy_primitives::{FixedBytes, b256};
     use base_alloy_consensus::OpBlock;
-    use base_consensus_genesis::{ChainGenesis, HardForkConfig, SystemConfig};
+    use base_consensus_genesis::{ChainGenesis, LegacyHardforkConfig, SystemConfig};
     use base_protocol::{SingleBatch, SpanBatchElement};
     use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 
@@ -278,7 +278,7 @@ mod tests {
     #[tokio::test]
     async fn test_batch_stream_flush() {
         let config = Arc::new(RollupConfig {
-            hardforks: HardForkConfig { holocene_time: Some(0), ..Default::default() },
+            hardforks: LegacyHardforkConfig { holocene_time: Some(0), ..Default::default() }.into(),
             ..Default::default()
         });
         let prev = TestBatchStreamProvider::new(vec![]);
@@ -295,7 +295,7 @@ mod tests {
     #[tokio::test]
     async fn test_batch_stream_reset() {
         let config = Arc::new(RollupConfig {
-            hardforks: HardForkConfig { holocene_time: Some(0), ..Default::default() },
+            hardforks: LegacyHardforkConfig { holocene_time: Some(0), ..Default::default() }.into(),
             ..Default::default()
         });
         let prev = TestBatchStreamProvider::new(vec![]);
@@ -313,7 +313,7 @@ mod tests {
     #[tokio::test]
     async fn test_batch_stream_flush_channel() {
         let config = Arc::new(RollupConfig {
-            hardforks: HardForkConfig { holocene_time: Some(0), ..Default::default() },
+            hardforks: LegacyHardforkConfig { holocene_time: Some(0), ..Default::default() }.into(),
             ..Default::default()
         });
         let prev = TestBatchStreamProvider::new(vec![]);
@@ -336,7 +336,7 @@ mod tests {
 
         let data = vec![Ok(Batch::Single(SingleBatch::default()))];
         let config = Arc::new(RollupConfig {
-            hardforks: HardForkConfig { holocene_time: Some(100), ..Default::default() },
+            hardforks: LegacyHardforkConfig { holocene_time: Some(100), ..Default::default() }.into(),
             ..Default::default()
         });
         let prev = TestBatchStreamProvider::new(data);
@@ -369,11 +369,12 @@ mod tests {
         let data = vec![Ok(Batch::Span(mock_batch.clone()))];
         let config = Arc::new(RollupConfig {
             block_time: 2,
-            hardforks: HardForkConfig {
+            hardforks: LegacyHardforkConfig {
                 delta_time: Some(0),
                 holocene_time: Some(0),
                 ..Default::default()
-            },
+            }
+            .into(),
             ..Default::default()
         });
         let prev = TestBatchStreamProvider::new(data);
@@ -443,11 +444,12 @@ mod tests {
         let config = Arc::new(RollupConfig {
             seq_window_size: 100,
             block_time: 10,
-            hardforks: HardForkConfig {
+            hardforks: LegacyHardforkConfig {
                 delta_time: Some(0),
                 holocene_time: Some(0),
                 ..Default::default()
-            },
+            }
+            .into(),
             genesis: ChainGenesis {
                 l2: BlockNumHash { number: 40, hash: parent_hash },
                 ..Default::default()
@@ -516,7 +518,7 @@ mod tests {
     async fn test_single_batch_pass_through() {
         let data = vec![Ok(Batch::Single(SingleBatch::default()))];
         let config = Arc::new(RollupConfig {
-            hardforks: HardForkConfig { holocene_time: Some(0), ..Default::default() },
+            hardforks: LegacyHardforkConfig { holocene_time: Some(0), ..Default::default() }.into(),
             ..Default::default()
         });
         let prev = TestBatchStreamProvider::new(data);
@@ -546,7 +548,7 @@ mod tests {
         let data = vec![Ok(Batch::Span(mock_batch))];
 
         let config = Arc::new(RollupConfig {
-            hardforks: HardForkConfig { holocene_time: Some(0), ..Default::default() },
+            hardforks: LegacyHardforkConfig { holocene_time: Some(0), ..Default::default() }.into(),
             ..Default::default()
         });
         let prev = TestBatchStreamProvider::new(data);

--- a/crates/consensus/derive/src/stages/batch/batch_validator.rs
+++ b/crates/consensus/derive/src/stages/batch/batch_validator.rs
@@ -333,7 +333,7 @@ mod tests {
 
     use alloy_eips::BlockNumHash;
     use alloy_primitives::B256;
-    use base_consensus_genesis::{HardForkConfig, RollupConfig, SystemConfig};
+    use base_consensus_genesis::{LegacyHardforkConfig, RollupConfig, SystemConfig};
     use base_protocol::{Batch, BlockInfo, L2BlockInfo, SingleBatch, SpanBatch};
     use tracing::Level;
     use tracing_subscriber::layer::SubscriberExt;
@@ -493,7 +493,7 @@ mod tests {
     #[tokio::test]
     async fn test_batch_validator_next_batch_valid() {
         let cfg = Arc::new(RollupConfig {
-            hardforks: HardForkConfig { holocene_time: Some(0), ..Default::default() },
+            hardforks: LegacyHardforkConfig { holocene_time: Some(0), ..Default::default() }.into(),
             block_time: 2,
             max_sequencer_drift: 700,
             ..Default::default()

--- a/crates/consensus/derive/src/stages/channel/channel_assembler.rs
+++ b/crates/consensus/derive/src/stages/channel/channel_assembler.rs
@@ -223,7 +223,7 @@ where
 mod tests {
     use alloc::{sync::Arc, vec};
 
-    use base_consensus_genesis::{HardForkConfig, RollupConfig};
+    use base_consensus_genesis::{LegacyHardforkConfig, RollupConfig};
     use base_protocol::BlockInfo;
     use tracing::Level;
     use tracing_subscriber::layer::SubscriberExt;
@@ -385,7 +385,7 @@ mod tests {
         frames[1].data = vec![0; RollupConfig::MAX_RLP_BYTES_PER_CHANNEL_FJORD as usize];
         let mock = TestNextFrameProvider::new(frames.into_iter().rev().map(Ok).collect());
         let cfg = Arc::new(RollupConfig {
-            hardforks: HardForkConfig { fjord_time: Some(0), ..Default::default() },
+            hardforks: LegacyHardforkConfig { fjord_time: Some(0), ..Default::default() }.into(),
             ..Default::default()
         });
 

--- a/crates/consensus/derive/src/stages/channel/channel_bank.rs
+++ b/crates/consensus/derive/src/stages/channel/channel_bank.rs
@@ -275,7 +275,7 @@ mod tests {
     use alloc::{vec, vec::Vec};
 
     use alloy_eips::BlockNumHash;
-    use base_consensus_genesis::{HardForkConfig, SystemConfig};
+    use base_consensus_genesis::{LegacyHardforkConfig, SystemConfig};
     use tracing::Level;
     use tracing_subscriber::layer::SubscriberExt;
 
@@ -390,7 +390,7 @@ mod tests {
     fn test_read_channel_active() {
         let mock = TestNextFrameProvider::new(vec![]);
         let cfg = Arc::new(RollupConfig {
-            hardforks: HardForkConfig { canyon_time: Some(0), ..Default::default() },
+            hardforks: LegacyHardforkConfig { canyon_time: Some(0), ..Default::default() }.into(),
             ..Default::default()
         });
         let mut channel_bank = ChannelBank::new(cfg, mock);
@@ -607,7 +607,7 @@ mod tests {
         let mut frames = crate::frames!(0xFF, 0, vec![0xDD; 50], 100000);
         let mock = TestNextFrameProvider::new(vec![]);
         let cfg = Arc::new(RollupConfig {
-            hardforks: HardForkConfig { fjord_time: Some(0), ..Default::default() },
+            hardforks: LegacyHardforkConfig { fjord_time: Some(0), ..Default::default() }.into(),
             ..Default::default()
         });
         let mut channel_bank = ChannelBank::new(cfg, mock);

--- a/crates/consensus/derive/src/stages/channel/channel_provider.rs
+++ b/crates/consensus/derive/src/stages/channel/channel_provider.rs
@@ -202,7 +202,7 @@ mod tests {
     use alloc::{sync::Arc, vec};
 
     use alloy_eips::BlockNumHash;
-    use base_consensus_genesis::{HardForkConfig, RollupConfig, SystemConfig};
+    use base_consensus_genesis::{LegacyHardforkConfig, RollupConfig, SystemConfig};
     use base_protocol::BlockInfo;
 
     use crate::{
@@ -214,7 +214,7 @@ mod tests {
     fn test_channel_provider_assembler_active() {
         let provider = TestNextFrameProvider::new(vec![]);
         let cfg = Arc::new(RollupConfig {
-            hardforks: HardForkConfig { holocene_time: Some(0), ..Default::default() },
+            hardforks: LegacyHardforkConfig { holocene_time: Some(0), ..Default::default() }.into(),
             ..Default::default()
         });
         let mut channel_provider = ChannelProvider::new(cfg, provider);
@@ -264,7 +264,7 @@ mod tests {
     fn test_channel_provider_retain_current_assembler() {
         let provider = TestNextFrameProvider::new(vec![]);
         let cfg = Arc::new(RollupConfig {
-            hardforks: HardForkConfig { holocene_time: Some(0), ..Default::default() },
+            hardforks: LegacyHardforkConfig { holocene_time: Some(0), ..Default::default() }.into(),
             ..Default::default()
         });
         let mut channel_provider = ChannelProvider::new(cfg, provider);
@@ -290,7 +290,7 @@ mod tests {
     fn test_channel_provider_transition_stage() {
         let provider = TestNextFrameProvider::new(vec![]);
         let cfg = Arc::new(RollupConfig {
-            hardforks: HardForkConfig { holocene_time: Some(2), ..Default::default() },
+            hardforks: LegacyHardforkConfig { holocene_time: Some(2), ..Default::default() }.into(),
             ..Default::default()
         });
         let mut channel_provider = ChannelProvider::new(cfg, provider);
@@ -315,7 +315,7 @@ mod tests {
     fn test_channel_provider_transition_stage_backwards() {
         let provider = TestNextFrameProvider::new(vec![]);
         let cfg = Arc::new(RollupConfig {
-            hardforks: HardForkConfig { holocene_time: Some(2), ..Default::default() },
+            hardforks: LegacyHardforkConfig { holocene_time: Some(2), ..Default::default() }.into(),
             ..Default::default()
         });
         let mut channel_provider = ChannelProvider::new(cfg, provider);
@@ -383,7 +383,7 @@ mod tests {
         ];
         let provider = TestNextFrameProvider::new(frames.into_iter().rev().map(Ok).collect());
         let cfg = Arc::new(RollupConfig {
-            hardforks: HardForkConfig { holocene_time: Some(0), ..Default::default() },
+            hardforks: LegacyHardforkConfig { holocene_time: Some(0), ..Default::default() }.into(),
             ..Default::default()
         });
         let mut channel_provider = ChannelProvider::new(Arc::clone(&cfg), provider);

--- a/crates/consensus/derive/src/stages/channel/channel_reader.rs
+++ b/crates/consensus/derive/src/stages/channel/channel_reader.rs
@@ -202,7 +202,7 @@ mod tests {
     use alloc::vec;
 
     use alloy_eips::BlockNumHash;
-    use base_consensus_genesis::{HardForkConfig, SystemConfig};
+    use base_consensus_genesis::{LegacyHardforkConfig, SystemConfig};
 
     use super::*;
     use crate::{errors::PipelineErrorKind, test_utils::TestChannelReaderProvider};
@@ -284,7 +284,7 @@ mod tests {
     async fn test_flush_post_holocene() {
         let raw = new_compressed_batch_data();
         let config = Arc::new(RollupConfig {
-            hardforks: HardForkConfig { holocene_time: Some(0), ..Default::default() },
+            hardforks: LegacyHardforkConfig { holocene_time: Some(0), ..Default::default() }.into(),
             ..Default::default()
         });
         let mock = TestChannelReaderProvider::new(vec![Ok(Some(raw))]);

--- a/crates/consensus/derive/src/stages/frame_queue.rs
+++ b/crates/consensus/derive/src/stages/frame_queue.rs
@@ -222,7 +222,7 @@ pub(crate) mod tests {
     use alloc::vec;
 
     use alloy_eips::BlockNumHash;
-    use base_consensus_genesis::{HardForkConfig, SystemConfig};
+    use base_consensus_genesis::{LegacyHardforkConfig, SystemConfig};
 
     use super::*;
     use crate::test_utils::TestFrameQueueProvider;
@@ -328,7 +328,7 @@ pub(crate) mod tests {
             crate::frame!(0xFF, 2, vec![0xDD; 50], true),
         ];
         let cfg = RollupConfig {
-            hardforks: HardForkConfig { holocene_time: Some(0), ..Default::default() },
+            hardforks: LegacyHardforkConfig { holocene_time: Some(0), ..Default::default() }.into(),
             ..Default::default()
         };
         let assert = crate::test_utils::FrameQueueBuilder::new()
@@ -345,7 +345,7 @@ pub(crate) mod tests {
     async fn test_holocene_single_frame() {
         let frames = [crate::frame!(0xFF, 1, vec![0xDD; 50], true)];
         let cfg = RollupConfig {
-            hardforks: HardForkConfig { holocene_time: Some(0), ..Default::default() },
+            hardforks: LegacyHardforkConfig { holocene_time: Some(0), ..Default::default() }.into(),
             ..Default::default()
         };
         let assert = crate::test_utils::FrameQueueBuilder::new()
@@ -371,7 +371,7 @@ pub(crate) mod tests {
             crate::frame!(0xFF, 1, vec![0xDD; 50], true),
         ];
         let cfg = RollupConfig {
-            hardforks: HardForkConfig { holocene_time: Some(0), ..Default::default() },
+            hardforks: LegacyHardforkConfig { holocene_time: Some(0), ..Default::default() }.into(),
             ..Default::default()
         };
         let assert = crate::test_utils::FrameQueueBuilder::new()
@@ -394,7 +394,7 @@ pub(crate) mod tests {
             crate::frame!(0xEE, 4, vec![0xDD; 50], false), // Dropped
         ];
         let cfg = RollupConfig {
-            hardforks: HardForkConfig { holocene_time: Some(0), ..Default::default() },
+            hardforks: LegacyHardforkConfig { holocene_time: Some(0), ..Default::default() }.into(),
             ..Default::default()
         };
         let assert = crate::test_utils::FrameQueueBuilder::new()
@@ -420,7 +420,7 @@ pub(crate) mod tests {
             crate::frame!(0xFF, 1, vec![0xDD; 50], true),
         ];
         let cfg = RollupConfig {
-            hardforks: HardForkConfig { holocene_time: Some(0), ..Default::default() },
+            hardforks: LegacyHardforkConfig { holocene_time: Some(0), ..Default::default() }.into(),
             ..Default::default()
         };
         let assert = crate::test_utils::FrameQueueBuilder::new()
@@ -449,7 +449,7 @@ pub(crate) mod tests {
             crate::frame!(0xFF, 1, vec![0xDD; 50], true),
         ];
         let cfg = RollupConfig {
-            hardforks: HardForkConfig { holocene_time: Some(0), ..Default::default() },
+            hardforks: LegacyHardforkConfig { holocene_time: Some(0), ..Default::default() }.into(),
             ..Default::default()
         };
         let assert = crate::test_utils::FrameQueueBuilder::new()
@@ -475,7 +475,7 @@ pub(crate) mod tests {
             crate::frame!(0xFF, 2, vec![0xDD; 50], true),  // Dropped
         ];
         let cfg = RollupConfig {
-            hardforks: HardForkConfig { holocene_time: Some(0), ..Default::default() },
+            hardforks: LegacyHardforkConfig { holocene_time: Some(0), ..Default::default() }.into(),
             ..Default::default()
         };
         let assert = crate::test_utils::FrameQueueBuilder::new()
@@ -502,7 +502,7 @@ pub(crate) mod tests {
             crate::frame!(0xFF, 1, vec![0xDD; 50], true),
         ];
         let cfg = RollupConfig {
-            hardforks: HardForkConfig { holocene_time: Some(0), ..Default::default() },
+            hardforks: LegacyHardforkConfig { holocene_time: Some(0), ..Default::default() }.into(),
             ..Default::default()
         };
         let assert = crate::test_utils::FrameQueueBuilder::new()
@@ -529,7 +529,7 @@ pub(crate) mod tests {
             crate::frame!(0xFF, 1, vec![0xDD; 50], true),
         ];
         let cfg = RollupConfig {
-            hardforks: HardForkConfig { holocene_time: Some(0), ..Default::default() },
+            hardforks: LegacyHardforkConfig { holocene_time: Some(0), ..Default::default() }.into(),
             ..Default::default()
         };
         let assert = crate::test_utils::FrameQueueBuilder::new()
@@ -556,7 +556,7 @@ pub(crate) mod tests {
             crate::frame!(0xFF, 1, vec![0xDD; 50], true),
         ];
         let cfg = RollupConfig {
-            hardforks: HardForkConfig { holocene_time: Some(0), ..Default::default() },
+            hardforks: LegacyHardforkConfig { holocene_time: Some(0), ..Default::default() }.into(),
             ..Default::default()
         };
         let assert = crate::test_utils::FrameQueueBuilder::new()

--- a/crates/consensus/engine/src/versions.rs
+++ b/crates/consensus/engine/src/versions.rs
@@ -110,17 +110,19 @@ impl EngineGetPayloadVersion {
 
 #[cfg(test)]
 mod tests {
-    use base_consensus_genesis::{BaseHardforkConfig, HardForkConfig};
+    use base_consensus_genesis::{BaseHardforkConfig, HardForkConfig, LegacyHardforkConfig};
 
     use super::*;
 
     fn test_rollup_config() -> RollupConfig {
         RollupConfig {
             hardforks: HardForkConfig {
-                ecotone_time: Some(20),
-                jovian_time: Some(30),
+                legacy: LegacyHardforkConfig {
+                    ecotone_time: Some(20),
+                    jovian_time: Some(30),
+                    ..Default::default()
+                },
                 base: BaseHardforkConfig { v1: Some(40) },
-                ..Default::default()
             },
             ..Default::default()
         }

--- a/crates/consensus/genesis/src/chain/hardfork.rs
+++ b/crates/consensus/genesis/src/chain/hardfork.rs
@@ -2,6 +2,7 @@
 
 use alloc::string::{String, ToString};
 use core::fmt::Display;
+use core::ops::{Deref, DerefMut};
 
 use base_alloy_chains::BaseChainConfig;
 
@@ -24,50 +25,42 @@ impl BaseHardforkConfig {
     }
 }
 
-/// Hardfork configuration.
+/// Legacy (OP Stack lineage) hardfork configuration.
 ///
-/// See: <https://github.com/ethereum-optimism/superchain-registry/blob/8ff62ada16e14dd59d0fb94ffb47761c7fa96e01/ops/internal/config/chain.go#L102-L110>
+/// Contains activation timestamps for forks from Regolith through Jovian. These fields are
+/// frozen now that Base follows its own specification after the Jovian hardfork.
 #[derive(Debug, Copy, Clone, Default, Hash, Eq, PartialEq)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "serde", serde(deny_unknown_fields))]
-pub struct HardForkConfig {
+pub struct LegacyHardforkConfig {
     /// `regolith_time` sets the activation time of the Regolith network-upgrade:
     /// a pre-mainnet Bedrock change that addresses findings of the Sherlock contest related to
     /// deposit attributes. "Regolith" is the loose deposited rock that sits on top of Bedrock.
     /// Active if `regolith_time` != None && L2 block timestamp >= `Some(regolith_time)`, inactive
     /// otherwise.
-    #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
     pub regolith_time: Option<u64>,
     /// `canyon_time` sets the activation time of the Canyon network upgrade.
     /// Active if `canyon_time` != None && L2 block timestamp >= `Some(canyon_time)`, inactive
     /// otherwise.
-    #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
     pub canyon_time: Option<u64>,
     /// `delta_time` sets the activation time of the Delta network upgrade.
     /// Active if `delta_time` != None && L2 block timestamp >= `Some(delta_time)`, inactive
     /// otherwise.
-    #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
     pub delta_time: Option<u64>,
     /// `ecotone_time` sets the activation time of the Ecotone network upgrade.
     /// Active if `ecotone_time` != None && L2 block timestamp >= `Some(ecotone_time)`, inactive
     /// otherwise.
-    #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
     pub ecotone_time: Option<u64>,
     /// `fjord_time` sets the activation time of the Fjord network upgrade.
     /// Active if `fjord_time` != None && L2 block timestamp >= `Some(fjord_time)`, inactive
     /// otherwise.
-    #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
     pub fjord_time: Option<u64>,
     /// `granite_time` sets the activation time for the Granite network upgrade.
     /// Active if `granite_time` != None && L2 block timestamp >= `Some(granite_time)`, inactive
     /// otherwise.
-    #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
     pub granite_time: Option<u64>,
     /// `holocene_time` sets the activation time for the Holocene network upgrade.
     /// Active if `holocene_time` != None && L2 block timestamp >= `Some(holocene_time)`, inactive
     /// otherwise.
-    #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
     pub holocene_time: Option<u64>,
     /// `pectra_blob_schedule_time` sets the activation time for the activation of the Pectra blob
     /// fee schedule for the L1 block info transaction. This is an optional fork, only present
@@ -76,24 +69,137 @@ pub struct HardForkConfig {
     ///
     /// Active if `pectra_blob_schedule_time` != None && L2 block timestamp >=
     /// `Some(pectra_blob_schedule_time)`, inactive otherwise.
-    #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
     pub pectra_blob_schedule_time: Option<u64>,
     /// `isthmus_time` sets the activation time for the Isthmus network upgrade.
     /// Active if `isthmus_time` != None && L2 block timestamp >= `Some(isthmus_time)`, inactive
     /// otherwise.
-    #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
     pub isthmus_time: Option<u64>,
     /// `jovian_time` sets the activation time for the Jovian network upgrade.
     /// Active if `jovian_time` != None && L2 block timestamp >= `Some(jovian_time)`, inactive
     /// otherwise.
-    #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
     pub jovian_time: Option<u64>,
-    /// `base` contains Base-specific hardfork activation times.
-    #[cfg_attr(
-        feature = "serde",
-        serde(default, skip_serializing_if = "BaseHardforkConfig::is_empty")
-    )]
+}
+
+/// Hardfork configuration.
+///
+/// Groups legacy OP Stack forks (frozen after Jovian) and Base-specific forks into separate
+/// sub-structs. The serialized wire format remains flat for backwards compatibility; a private
+/// [`RawHardForkConfig`] handles the bridging.
+///
+/// Production code that accesses legacy fork timestamps (e.g. `config.hardforks.holocene_time`)
+/// compiles unchanged via the [`Deref`] impl targeting [`LegacyHardforkConfig`].
+#[derive(Debug, Copy, Clone, Default, Hash, Eq, PartialEq)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+pub struct HardForkConfig {
+    /// Legacy (OP Stack lineage) hardfork activation times, frozen after Jovian.
+    pub legacy: LegacyHardforkConfig,
+    /// Base-specific hardfork activation times (V1+).
     pub base: BaseHardforkConfig,
+}
+
+impl Deref for HardForkConfig {
+    type Target = LegacyHardforkConfig;
+    fn deref(&self) -> &Self::Target {
+        &self.legacy
+    }
+}
+
+impl DerefMut for HardForkConfig {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.legacy
+    }
+}
+
+impl From<LegacyHardforkConfig> for HardForkConfig {
+    fn from(legacy: LegacyHardforkConfig) -> Self {
+        Self { legacy, base: BaseHardforkConfig::default() }
+    }
+}
+
+/// Private flat representation used for serde round-tripping.
+///
+/// This preserves the flat JSON/TOML field layout with `deny_unknown_fields`, bridging
+/// between the flat wire format and the nested in-memory [`HardForkConfig`].
+#[cfg(feature = "serde")]
+#[derive(serde::Serialize, serde::Deserialize)]
+#[serde(deny_unknown_fields)]
+struct RawHardForkConfig {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    regolith_time: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    canyon_time: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    delta_time: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    ecotone_time: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    fjord_time: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    granite_time: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    holocene_time: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pectra_blob_schedule_time: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    isthmus_time: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    jovian_time: Option<u64>,
+    #[serde(default, skip_serializing_if = "BaseHardforkConfig::is_empty")]
+    base: BaseHardforkConfig,
+}
+
+#[cfg(feature = "serde")]
+impl From<&HardForkConfig> for RawHardForkConfig {
+    fn from(cfg: &HardForkConfig) -> Self {
+        Self {
+            regolith_time: cfg.legacy.regolith_time,
+            canyon_time: cfg.legacy.canyon_time,
+            delta_time: cfg.legacy.delta_time,
+            ecotone_time: cfg.legacy.ecotone_time,
+            fjord_time: cfg.legacy.fjord_time,
+            granite_time: cfg.legacy.granite_time,
+            holocene_time: cfg.legacy.holocene_time,
+            pectra_blob_schedule_time: cfg.legacy.pectra_blob_schedule_time,
+            isthmus_time: cfg.legacy.isthmus_time,
+            jovian_time: cfg.legacy.jovian_time,
+            base: cfg.base,
+        }
+    }
+}
+
+#[cfg(feature = "serde")]
+impl From<RawHardForkConfig> for HardForkConfig {
+    fn from(raw: RawHardForkConfig) -> Self {
+        Self {
+            legacy: LegacyHardforkConfig {
+                regolith_time: raw.regolith_time,
+                canyon_time: raw.canyon_time,
+                delta_time: raw.delta_time,
+                ecotone_time: raw.ecotone_time,
+                fjord_time: raw.fjord_time,
+                granite_time: raw.granite_time,
+                holocene_time: raw.holocene_time,
+                pectra_blob_schedule_time: raw.pectra_blob_schedule_time,
+                isthmus_time: raw.isthmus_time,
+                jovian_time: raw.jovian_time,
+            },
+            base: raw.base,
+        }
+    }
+}
+
+#[cfg(feature = "serde")]
+impl serde::Serialize for HardForkConfig {
+    fn serialize<S: serde::Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
+        RawHardForkConfig::from(self).serialize(s)
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<'de> serde::Deserialize<'de> for HardForkConfig {
+    fn deserialize<D: serde::Deserializer<'de>>(d: D) -> Result<Self, D::Error> {
+        RawHardForkConfig::deserialize(d).map(Into::into)
+    }
 }
 
 impl Display for HardForkConfig {
@@ -115,16 +221,16 @@ impl HardForkConfig {
     /// Returns an iterator of hardfork names -> their activation times (if scheduled.)
     pub fn iter(&self) -> impl Iterator<Item = (&'static str, Option<u64>)> {
         [
-            ("Regolith", self.regolith_time),
-            ("Canyon", self.canyon_time),
-            ("Delta", self.delta_time),
-            ("Ecotone", self.ecotone_time),
-            ("Fjord", self.fjord_time),
-            ("Granite", self.granite_time),
-            ("Holocene", self.holocene_time),
-            ("Pectra Blob Schedule", self.pectra_blob_schedule_time),
-            ("Isthmus", self.isthmus_time),
-            ("Jovian", self.jovian_time),
+            ("Regolith", self.legacy.regolith_time),
+            ("Canyon", self.legacy.canyon_time),
+            ("Delta", self.legacy.delta_time),
+            ("Ecotone", self.legacy.ecotone_time),
+            ("Fjord", self.legacy.fjord_time),
+            ("Granite", self.legacy.granite_time),
+            ("Holocene", self.legacy.holocene_time),
+            ("Pectra Blob Schedule", self.legacy.pectra_blob_schedule_time),
+            ("Isthmus", self.legacy.isthmus_time),
+            ("Jovian", self.legacy.jovian_time),
             ("Base V1", self.base.v1),
         ]
         .into_iter()
@@ -134,16 +240,18 @@ impl HardForkConfig {
 impl From<&BaseChainConfig> for HardForkConfig {
     fn from(cfg: &BaseChainConfig) -> Self {
         Self {
-            regolith_time: Some(cfg.regolith_timestamp),
-            canyon_time: Some(cfg.canyon_timestamp),
-            delta_time: Some(cfg.delta_timestamp),
-            ecotone_time: Some(cfg.ecotone_timestamp),
-            fjord_time: Some(cfg.fjord_timestamp),
-            granite_time: Some(cfg.granite_timestamp),
-            holocene_time: Some(cfg.holocene_timestamp),
-            pectra_blob_schedule_time: cfg.pectra_blob_schedule_timestamp,
-            isthmus_time: Some(cfg.isthmus_timestamp),
-            jovian_time: Some(cfg.jovian_timestamp),
+            legacy: LegacyHardforkConfig {
+                regolith_time: Some(cfg.regolith_timestamp),
+                canyon_time: Some(cfg.canyon_timestamp),
+                delta_time: Some(cfg.delta_timestamp),
+                ecotone_time: Some(cfg.ecotone_timestamp),
+                fjord_time: Some(cfg.fjord_timestamp),
+                granite_time: Some(cfg.granite_timestamp),
+                holocene_time: Some(cfg.holocene_timestamp),
+                pectra_blob_schedule_time: cfg.pectra_blob_schedule_timestamp,
+                isthmus_time: Some(cfg.isthmus_timestamp),
+                jovian_time: Some(cfg.jovian_timestamp),
+            },
             base: BaseHardforkConfig { v1: cfg.base_v1_timestamp },
         }
     }
@@ -167,7 +275,7 @@ mod tests {
         }
         "#;
 
-        let hardforks = HardForkConfig {
+        let hardforks: HardForkConfig = LegacyHardforkConfig {
             regolith_time: None,
             canyon_time: Some(1699981200),
             delta_time: Some(1703203200),
@@ -178,8 +286,8 @@ mod tests {
             pectra_blob_schedule_time: None,
             isthmus_time: None,
             jovian_time: None,
-            base: BaseHardforkConfig::default(),
-        };
+        }
+        .into();
 
         let deserialized: HardForkConfig = serde_json::from_str(raw).unwrap();
         assert_eq!(hardforks, deserialized);
@@ -214,7 +322,7 @@ mod tests {
         holocene_time = 1732633200 # Tue Nov 26 15:00:00 UTC 2024
         "#;
 
-        let hardforks = HardForkConfig {
+        let hardforks: HardForkConfig = LegacyHardforkConfig {
             regolith_time: None,
             canyon_time: Some(1699981200),
             delta_time: Some(1703203200),
@@ -225,8 +333,8 @@ mod tests {
             pectra_blob_schedule_time: None,
             isthmus_time: None,
             jovian_time: None,
-            base: BaseHardforkConfig::default(),
-        };
+        }
+        .into();
 
         let deserialized: HardForkConfig = toml::from_str(raw).unwrap();
         assert_eq!(hardforks, deserialized);
@@ -249,16 +357,18 @@ mod tests {
     #[test]
     fn test_hardforks_iter() {
         let hardforks = HardForkConfig {
-            regolith_time: Some(1),
-            canyon_time: Some(2),
-            delta_time: Some(3),
-            ecotone_time: Some(4),
-            fjord_time: Some(5),
-            granite_time: Some(6),
-            holocene_time: Some(7),
-            pectra_blob_schedule_time: Some(8),
-            isthmus_time: Some(9),
-            jovian_time: Some(10),
+            legacy: LegacyHardforkConfig {
+                regolith_time: Some(1),
+                canyon_time: Some(2),
+                delta_time: Some(3),
+                ecotone_time: Some(4),
+                fjord_time: Some(5),
+                granite_time: Some(6),
+                holocene_time: Some(7),
+                pectra_blob_schedule_time: Some(8),
+                isthmus_time: Some(9),
+                jovian_time: Some(10),
+            },
             base: BaseHardforkConfig { v1: Some(11) },
         };
 

--- a/crates/consensus/genesis/src/chain/mod.rs
+++ b/crates/consensus/genesis/src/chain/mod.rs
@@ -4,7 +4,7 @@ mod addresses;
 pub use addresses::AddressList;
 
 mod hardfork;
-pub use hardfork::{BaseHardforkConfig, HardForkConfig};
+pub use hardfork::{BaseHardforkConfig, HardForkConfig, LegacyHardforkConfig};
 
 mod roles;
 pub use roles::Roles;

--- a/crates/consensus/genesis/src/lib.rs
+++ b/crates/consensus/genesis/src/lib.rs
@@ -28,7 +28,7 @@ pub use system::{
 };
 
 mod chain;
-pub use chain::{AddressList, BaseHardforkConfig, HardForkConfig, Roles};
+pub use chain::{AddressList, BaseHardforkConfig, HardForkConfig, LegacyHardforkConfig, Roles};
 
 mod genesis;
 pub use genesis::ChainGenesis;

--- a/crates/consensus/genesis/src/rollup.rs
+++ b/crates/consensus/genesis/src/rollup.rs
@@ -5,7 +5,7 @@ use alloy_hardforks::{EthereumHardfork, EthereumHardforks, ForkCondition};
 use alloy_primitives::Address;
 use base_alloy_chains::{BaseChainConfig, BaseUpgrade, BaseUpgrades};
 
-use crate::{BaseFeeConfig, ChainGenesis, HardForkConfig};
+use crate::{BaseFeeConfig, ChainGenesis, HardForkConfig, LegacyHardforkConfig};
 
 /// The Rollup configuration.
 #[derive(Debug, Clone, Eq, PartialEq)]
@@ -622,16 +622,18 @@ mod tests {
         use crate::BaseHardforkConfig;
         let cfg = RollupConfig {
             hardforks: HardForkConfig {
-                regolith_time: Some(10),
-                canyon_time: Some(20),
-                delta_time: Some(30),
-                ecotone_time: Some(40),
-                fjord_time: Some(50),
-                granite_time: Some(60),
-                holocene_time: Some(70),
-                pectra_blob_schedule_time: Some(80),
-                isthmus_time: Some(90),
-                jovian_time: Some(100),
+                legacy: LegacyHardforkConfig {
+                    regolith_time: Some(10),
+                    canyon_time: Some(20),
+                    delta_time: Some(30),
+                    ecotone_time: Some(40),
+                    fjord_time: Some(50),
+                    granite_time: Some(60),
+                    holocene_time: Some(70),
+                    pectra_blob_schedule_time: Some(80),
+                    isthmus_time: Some(90),
+                    jovian_time: Some(100),
+                },
                 base: BaseHardforkConfig { v1: Some(110) },
             },
             block_time: 2,
@@ -698,7 +700,7 @@ mod tests {
     fn test_granite_channel_timeout() {
         let mut config = RollupConfig {
             channel_timeout: 100,
-            hardforks: HardForkConfig { granite_time: Some(10), ..Default::default() },
+            hardforks: LegacyHardforkConfig { granite_time: Some(10), ..Default::default() }.into(),
             ..Default::default()
         };
         assert_eq!(config.channel_timeout(0), 100);
@@ -804,14 +806,15 @@ mod tests {
             granite_channel_timeout: RollupConfig::GRANITE_CHANNEL_TIMEOUT,
             l1_chain_id: 3151908,
             l2_chain_id: Chain::from_id(1337),
-            hardforks: HardForkConfig {
+            hardforks: LegacyHardforkConfig {
                 regolith_time: Some(0),
                 canyon_time: Some(0),
                 delta_time: Some(0),
                 ecotone_time: Some(0),
                 fjord_time: Some(0),
                 ..Default::default()
-            },
+            }
+            .into(),
             batch_inbox_address: address!("ff00000000000000000000000000000000042069"),
             deposit_contract_address: address!("08073dc48dde578137b8af042bcbc1c2491f1eb2"),
             l1_system_config_address: address!("94ee52a9d8edd72a85dea7fae3ba6d75e4bf1710"),

--- a/crates/consensus/genesis/src/system/config.rs
+++ b/crates/consensus/genesis/src/system/config.rs
@@ -229,7 +229,7 @@ mod tests {
     use alloy_primitives::{B256, LogData, address, b256, hex};
 
     use super::*;
-    use crate::{CONFIG_UPDATE_EVENT_VERSION_0, HardForkConfig};
+    use crate::{CONFIG_UPDATE_EVENT_VERSION_0, LegacyHardforkConfig};
 
     const BATCHER_UPDATE_TYPE: B256 =
         b256!("0000000000000000000000000000000000000000000000000000000000000000");
@@ -327,7 +327,7 @@ mod tests {
     #[test]
     fn test_eip_1559_params_from_system_config_some() {
         let rollup_config = RollupConfig {
-            hardforks: HardForkConfig { holocene_time: Some(0), ..Default::default() },
+            hardforks: LegacyHardforkConfig { holocene_time: Some(0), ..Default::default() }.into(),
             ..Default::default()
         };
         let sys_config = SystemConfig {
@@ -342,7 +342,7 @@ mod tests {
     #[test]
     fn test_eip_1559_params_from_system_config() {
         let rollup_config = RollupConfig {
-            hardforks: HardForkConfig { holocene_time: Some(0), ..Default::default() },
+            hardforks: LegacyHardforkConfig { holocene_time: Some(0), ..Default::default() }.into(),
             ..Default::default()
         };
         let sys_config = SystemConfig {
@@ -357,7 +357,7 @@ mod tests {
     #[test]
     fn test_default_eip_1559_params_from_system_config() {
         let rollup_config = RollupConfig {
-            hardforks: HardForkConfig { holocene_time: Some(0), ..Default::default() },
+            hardforks: LegacyHardforkConfig { holocene_time: Some(0), ..Default::default() }.into(),
             ..Default::default()
         };
         let sys_config = SystemConfig {
@@ -383,7 +383,7 @@ mod tests {
     #[test]
     fn test_default_eip_1559_params_first_block_holocene() {
         let rollup_config = RollupConfig {
-            hardforks: HardForkConfig { holocene_time: Some(2), ..Default::default() },
+            hardforks: LegacyHardforkConfig { holocene_time: Some(2), ..Default::default() }.into(),
             ..Default::default()
         };
         let sys_config = SystemConfig {

--- a/crates/consensus/protocol/src/batch/reader.rs
+++ b/crates/consensus/protocol/src/batch/reader.rs
@@ -148,7 +148,7 @@ impl BatchReader {
 
 #[cfg(test)]
 mod tests {
-    use base_consensus_genesis::{HardForkConfig, RollupConfig};
+    use base_consensus_genesis::{LegacyHardforkConfig, RollupConfig};
     use miniz_oxide::{
         deflate::{CompressionLevel, compress_to_vec_zlib},
         inflate::decompress_to_vec_zlib,
@@ -182,7 +182,7 @@ mod tests {
             BatchReader::new(raw, RollupConfig::MAX_RLP_BYTES_PER_CHANNEL_FJORD as usize);
         reader
             .next_batch(&RollupConfig {
-                hardforks: HardForkConfig { fjord_time: Some(0), ..Default::default() },
+                hardforks: LegacyHardforkConfig { fjord_time: Some(0), ..Default::default() }.into(),
                 ..Default::default()
             })
             .unwrap();

--- a/crates/consensus/protocol/src/batch/single.rs
+++ b/crates/consensus/protocol/src/batch/single.rs
@@ -194,7 +194,7 @@ mod tests {
     use alloy_primitives::{Address, Sealed, Signature, TxKind, U256};
     use alloy_rlp::{Decodable, Encodable};
     use base_alloy_consensus::{OpTxEnvelope, TxDeposit};
-    use base_consensus_genesis::HardForkConfig;
+    use base_consensus_genesis::LegacyHardforkConfig;
     use tracing::Level;
     use tracing_subscriber::layer::SubscriberExt;
 
@@ -264,7 +264,7 @@ mod tests {
     #[test]
     fn test_check_batch_timestamp_holocene_active_drop() {
         let cfg = RollupConfig {
-            hardforks: HardForkConfig { holocene_time: Some(0), ..Default::default() },
+            hardforks: LegacyHardforkConfig { holocene_time: Some(0), ..Default::default() }.into(),
             ..Default::default()
         };
         let l2_safe_head = L2BlockInfo {
@@ -282,7 +282,7 @@ mod tests {
     #[test]
     fn test_check_batch_timestamp_holocene_active_past() {
         let cfg = RollupConfig {
-            hardforks: HardForkConfig { holocene_time: Some(0), ..Default::default() },
+            hardforks: LegacyHardforkConfig { holocene_time: Some(0), ..Default::default() }.into(),
             ..Default::default()
         };
         let l2_safe_head = L2BlockInfo {
@@ -509,7 +509,7 @@ mod tests {
         // Notice: Isthmus is active.
         let cfg = RollupConfig {
             max_sequencer_drift: 1,
-            hardforks: HardForkConfig { isthmus_time: Some(0), ..Default::default() },
+            hardforks: LegacyHardforkConfig { isthmus_time: Some(0), ..Default::default() }.into(),
             ..Default::default()
         };
         let l1_blocks = vec![BlockInfo::default(), BlockInfo::default()];
@@ -619,7 +619,7 @@ mod tests {
         let cfg = RollupConfig {
             max_sequencer_drift: 1,
             block_time: 1,
-            hardforks: HardForkConfig { jovian_time: Some(1), ..Default::default() },
+            hardforks: LegacyHardforkConfig { jovian_time: Some(1), ..Default::default() }.into(),
             ..Default::default()
         };
         let l1_blocks = vec![BlockInfo::default(), BlockInfo::default()];

--- a/crates/consensus/protocol/src/batch/span.rs
+++ b/crates/consensus/protocol/src/batch/span.rs
@@ -758,7 +758,7 @@ mod tests {
     use alloy_eips::BlockNumHash;
     use alloy_primitives::{B256, Bytes, b256};
     use base_alloy_consensus::OpBlock;
-    use base_consensus_genesis::{ChainGenesis, HardForkConfig};
+    use base_consensus_genesis::{ChainGenesis, LegacyHardforkConfig};
     use tracing::Level;
     use tracing_subscriber::layer::SubscriberExt;
 
@@ -983,7 +983,7 @@ mod tests {
         let _guard = tracing::subscriber::set_default(subscriber);
 
         let cfg = RollupConfig {
-            hardforks: HardForkConfig { delta_time: Some(10), ..Default::default() },
+            hardforks: LegacyHardforkConfig { delta_time: Some(10), ..Default::default() }.into(),
             ..Default::default()
         };
         let block = BlockInfo { number: 10, timestamp: 9, ..Default::default() };
@@ -1015,7 +1015,7 @@ mod tests {
         let _guard = tracing::subscriber::set_default(subscriber);
 
         let cfg = RollupConfig {
-            hardforks: HardForkConfig { delta_time: Some(0), ..Default::default() },
+            hardforks: LegacyHardforkConfig { delta_time: Some(0), ..Default::default() }.into(),
             block_time: 10,
             ..Default::default()
         };
@@ -1048,7 +1048,7 @@ mod tests {
         let _guard = tracing::subscriber::set_default(subscriber);
 
         let cfg = RollupConfig {
-            hardforks: HardForkConfig { delta_time: Some(0), ..Default::default() },
+            hardforks: LegacyHardforkConfig { delta_time: Some(0), ..Default::default() }.into(),
             block_time: 10,
             ..Default::default()
         };
@@ -1079,7 +1079,7 @@ mod tests {
         let _guard = tracing::subscriber::set_default(subscriber);
 
         let cfg = RollupConfig {
-            hardforks: HardForkConfig { delta_time: Some(0), ..Default::default() },
+            hardforks: LegacyHardforkConfig { delta_time: Some(0), ..Default::default() }.into(),
             block_time: 10,
             max_sequencer_drift: 1000,
             ..Default::default()
@@ -1145,7 +1145,7 @@ mod tests {
         let _guard = tracing::subscriber::set_default(subscriber);
 
         let cfg = RollupConfig {
-            hardforks: HardForkConfig { delta_time: Some(0), ..Default::default() },
+            hardforks: LegacyHardforkConfig { delta_time: Some(0), ..Default::default() }.into(),
             block_time: 10,
             max_sequencer_drift: 1000,
             ..Default::default()
@@ -1224,7 +1224,7 @@ mod tests {
         let _guard = tracing::subscriber::set_default(subscriber);
 
         let cfg = RollupConfig {
-            hardforks: HardForkConfig { delta_time: Some(0), ..Default::default() },
+            hardforks: LegacyHardforkConfig { delta_time: Some(0), ..Default::default() }.into(),
             block_time: 10,
             ..Default::default()
         };
@@ -1262,7 +1262,7 @@ mod tests {
         let _guard = tracing::subscriber::set_default(subscriber);
 
         let cfg = RollupConfig {
-            hardforks: HardForkConfig { delta_time: Some(0), ..Default::default() },
+            hardforks: LegacyHardforkConfig { delta_time: Some(0), ..Default::default() }.into(),
             block_time: 10,
             ..Default::default()
         };
@@ -1294,7 +1294,7 @@ mod tests {
         let _guard = tracing::subscriber::set_default(subscriber);
 
         let cfg = RollupConfig {
-            hardforks: HardForkConfig { delta_time: Some(0), ..Default::default() },
+            hardforks: LegacyHardforkConfig { delta_time: Some(0), ..Default::default() }.into(),
             block_time: 10,
             ..Default::default()
         };
@@ -1326,7 +1326,7 @@ mod tests {
         let _guard = tracing::subscriber::set_default(subscriber);
 
         let cfg = RollupConfig {
-            hardforks: HardForkConfig { delta_time: Some(0), ..Default::default() },
+            hardforks: LegacyHardforkConfig { delta_time: Some(0), ..Default::default() }.into(),
             block_time: 10,
             ..Default::default()
         };
@@ -1361,7 +1361,7 @@ mod tests {
         let _guard = tracing::subscriber::set_default(subscriber);
 
         let cfg = RollupConfig {
-            hardforks: HardForkConfig { delta_time: Some(0), ..Default::default() },
+            hardforks: LegacyHardforkConfig { delta_time: Some(0), ..Default::default() }.into(),
             block_time: 10,
             ..Default::default()
         };
@@ -1413,7 +1413,7 @@ mod tests {
         let _guard = tracing::subscriber::set_default(subscriber);
 
         let cfg = RollupConfig {
-            hardforks: HardForkConfig { delta_time: Some(0), ..Default::default() },
+            hardforks: LegacyHardforkConfig { delta_time: Some(0), ..Default::default() }.into(),
             block_time: 10,
             ..Default::default()
         };
@@ -1462,7 +1462,7 @@ mod tests {
 
         let cfg = RollupConfig {
             seq_window_size: 100,
-            hardforks: HardForkConfig { delta_time: Some(0), ..Default::default() },
+            hardforks: LegacyHardforkConfig { delta_time: Some(0), ..Default::default() }.into(),
             block_time: 10,
             ..Default::default()
         };
@@ -1517,7 +1517,7 @@ mod tests {
 
         let cfg = RollupConfig {
             seq_window_size: 100,
-            hardforks: HardForkConfig { delta_time: Some(0), ..Default::default() },
+            hardforks: LegacyHardforkConfig { delta_time: Some(0), ..Default::default() }.into(),
             block_time: 10,
             ..Default::default()
         };
@@ -1576,7 +1576,7 @@ mod tests {
 
         let cfg = RollupConfig {
             seq_window_size: 100,
-            hardforks: HardForkConfig { delta_time: Some(0), ..Default::default() },
+            hardforks: LegacyHardforkConfig { delta_time: Some(0), ..Default::default() }.into(),
             block_time: 10,
             ..Default::default()
         };
@@ -1630,7 +1630,7 @@ mod tests {
 
         let cfg = RollupConfig {
             seq_window_size: 100,
-            hardforks: HardForkConfig { delta_time: Some(0), ..Default::default() },
+            hardforks: LegacyHardforkConfig { delta_time: Some(0), ..Default::default() }.into(),
             block_time: 10,
             ..Default::default()
         };
@@ -1688,7 +1688,7 @@ mod tests {
         let cfg = RollupConfig {
             seq_window_size: 100,
             max_sequencer_drift: 0,
-            hardforks: HardForkConfig { delta_time: Some(0), ..Default::default() },
+            hardforks: LegacyHardforkConfig { delta_time: Some(0), ..Default::default() }.into(),
             block_time: 10,
             ..Default::default()
         };
@@ -1741,7 +1741,7 @@ mod tests {
         let cfg = RollupConfig {
             seq_window_size: 100,
             max_sequencer_drift: 0,
-            hardforks: HardForkConfig { delta_time: Some(0), ..Default::default() },
+            hardforks: LegacyHardforkConfig { delta_time: Some(0), ..Default::default() }.into(),
             block_time: 10,
             ..Default::default()
         };
@@ -1799,7 +1799,7 @@ mod tests {
         let cfg = RollupConfig {
             seq_window_size: 100,
             max_sequencer_drift: 0,
-            hardforks: HardForkConfig { delta_time: Some(0), ..Default::default() },
+            hardforks: LegacyHardforkConfig { delta_time: Some(0), ..Default::default() }.into(),
             block_time: 10,
             ..Default::default()
         };
@@ -1863,7 +1863,7 @@ mod tests {
         let cfg = RollupConfig {
             seq_window_size: 100,
             max_sequencer_drift: 100,
-            hardforks: HardForkConfig { delta_time: Some(0), ..Default::default() },
+            hardforks: LegacyHardforkConfig { delta_time: Some(0), ..Default::default() }.into(),
             block_time: 10,
             ..Default::default()
         };
@@ -1931,7 +1931,7 @@ mod tests {
         let cfg = RollupConfig {
             seq_window_size: 100,
             max_sequencer_drift: 100,
-            hardforks: HardForkConfig { delta_time: Some(0), ..Default::default() },
+            hardforks: LegacyHardforkConfig { delta_time: Some(0), ..Default::default() }.into(),
             block_time: 10,
             ..Default::default()
         };
@@ -1993,7 +1993,7 @@ mod tests {
         let cfg = RollupConfig {
             seq_window_size: 100,
             max_sequencer_drift: 100,
-            hardforks: HardForkConfig { delta_time: Some(0), ..Default::default() },
+            hardforks: LegacyHardforkConfig { delta_time: Some(0), ..Default::default() }.into(),
             block_time: 10,
             ..Default::default()
         };
@@ -2058,7 +2058,7 @@ mod tests {
 
         let cfg = RollupConfig {
             seq_window_size: 100,
-            hardforks: HardForkConfig { delta_time: Some(0), ..Default::default() },
+            hardforks: LegacyHardforkConfig { delta_time: Some(0), ..Default::default() }.into(),
             block_time: 10,
             ..Default::default()
         };
@@ -2114,7 +2114,7 @@ mod tests {
 
         let cfg = RollupConfig {
             seq_window_size: 100,
-            hardforks: HardForkConfig { delta_time: Some(0), ..Default::default() },
+            hardforks: LegacyHardforkConfig { delta_time: Some(0), ..Default::default() }.into(),
             block_time: 10,
             ..Default::default()
         };
@@ -2185,7 +2185,7 @@ mod tests {
             b256!("0e2ee9abe94ee4514b170d7039d8151a7469d434a8575dbab5bd4187a27732dd");
         let cfg = RollupConfig {
             seq_window_size: 100,
-            hardforks: HardForkConfig { delta_time: Some(0), ..Default::default() },
+            hardforks: LegacyHardforkConfig { delta_time: Some(0), ..Default::default() }.into(),
             block_time: 10,
             genesis: ChainGenesis {
                 l2: BlockNumHash { number: 41, hash: payload_block_hash },
@@ -2255,7 +2255,7 @@ mod tests {
         let parent_hash = b256!("1111111111111111111111111111111111111111000000000000000000000000");
         let cfg = RollupConfig {
             seq_window_size: 100,
-            hardforks: HardForkConfig { delta_time: Some(0), ..Default::default() },
+            hardforks: LegacyHardforkConfig { delta_time: Some(0), ..Default::default() }.into(),
             block_time: 10,
             genesis: ChainGenesis {
                 l2: BlockNumHash { number: 40, hash: parent_hash },
@@ -2326,7 +2326,7 @@ mod tests {
             b256!("0e2ee9abe94ee4514b170d7039d8151a7469d434a8575dbab5bd4187a27732dd");
         let cfg = RollupConfig {
             seq_window_size: 100,
-            hardforks: HardForkConfig { delta_time: Some(0), ..Default::default() },
+            hardforks: LegacyHardforkConfig { delta_time: Some(0), ..Default::default() }.into(),
             block_time: 10,
             genesis: ChainGenesis {
                 l2: BlockNumHash { number: 41, hash: payload_block_hash },

--- a/crates/consensus/protocol/src/info/variant.rs
+++ b/crates/consensus/protocol/src/info/variant.rs
@@ -390,7 +390,7 @@ mod tests {
     use alloc::{string::ToString, vec::Vec};
 
     use alloy_primitives::{address, b256};
-    use base_consensus_genesis::HardForkConfig;
+    use base_consensus_genesis::LegacyHardforkConfig;
     use base_consensus_registry::L1Config;
     use rstest::rstest;
 
@@ -748,7 +748,7 @@ mod tests {
     #[test]
     fn test_try_new_ecotone() {
         let rollup_config = RollupConfig {
-            hardforks: HardForkConfig { ecotone_time: Some(1), ..Default::default() },
+            hardforks: LegacyHardforkConfig { ecotone_time: Some(1), ..Default::default() }.into(),
             ..Default::default()
         };
         let l1_config = L1Config::sepolia();
@@ -807,11 +807,12 @@ mod tests {
         #[case] use_wrong_params: bool,
     ) {
         let rollup_config = RollupConfig {
-            hardforks: HardForkConfig {
+            hardforks: LegacyHardforkConfig {
                 ecotone_time: Some(1),
                 pectra_blob_schedule_time: Some(2),
                 ..Default::default()
-            },
+            }
+            .into(),
             ..Default::default()
         };
         let mut l1_genesis: ChainConfig = L1Config::sepolia().into();
@@ -878,11 +879,12 @@ mod tests {
     #[test]
     fn test_try_new_isthmus_before_pectra_blob_schedule() {
         let rollup_config = RollupConfig {
-            hardforks: HardForkConfig {
+            hardforks: LegacyHardforkConfig {
                 isthmus_time: Some(1),
                 pectra_blob_schedule_time: Some(1713121140),
                 ..Default::default()
-            },
+            }
+            .into(),
             ..Default::default()
         };
         let l1_config = L1Config::sepolia();
@@ -951,7 +953,7 @@ mod tests {
     #[test]
     fn test_try_new_isthmus() {
         let rollup_config = RollupConfig {
-            hardforks: HardForkConfig { isthmus_time: Some(1), ..Default::default() },
+            hardforks: LegacyHardforkConfig { isthmus_time: Some(1), ..Default::default() }.into(),
             ..Default::default()
         };
         let l1_config = L1Config::sepolia();
@@ -1016,7 +1018,7 @@ mod tests {
     #[test]
     fn test_try_new_with_deposit_tx() {
         let rollup_config = RollupConfig {
-            hardforks: HardForkConfig { isthmus_time: Some(1), ..Default::default() },
+            hardforks: LegacyHardforkConfig { isthmus_time: Some(1), ..Default::default() }.into(),
             ..Default::default()
         };
         let l1_config = L1Config::sepolia();

--- a/crates/consensus/protocol/src/utils.rs
+++ b/crates/consensus/protocol/src/utils.rs
@@ -139,7 +139,7 @@ mod tests {
 
     use alloy_eips::eip1898::BlockNumHash;
     use alloy_primitives::{U256, address, bytes, uint};
-    use base_consensus_genesis::{ChainGenesis, HardForkConfig};
+    use base_consensus_genesis::{ChainGenesis, LegacyHardforkConfig};
 
     use super::*;
     use crate::test_utils::{RAW_BEDROCK_INFO_TX, RAW_ECOTONE_INFO_TX, RAW_ISTHMUS_INFO_TX};
@@ -307,7 +307,7 @@ mod tests {
                 l2: BlockNumHash { hash: block_hash, ..Default::default() },
                 ..Default::default()
             },
-            hardforks: HardForkConfig { holocene_time: Some(0), ..Default::default() },
+            hardforks: LegacyHardforkConfig { holocene_time: Some(0), ..Default::default() }.into(),
             ..Default::default()
         };
         assert!(rollup_config.is_holocene_active(block.header.timestamp));
@@ -356,11 +356,12 @@ mod tests {
                 l2: BlockNumHash { hash: block_hash, ..Default::default() },
                 ..Default::default()
             },
-            hardforks: HardForkConfig {
+            hardforks: LegacyHardforkConfig {
                 holocene_time: Some(0),
                 isthmus_time: Some(0),
                 ..Default::default()
-            },
+            }
+            .into(),
             ..Default::default()
         };
         assert!(rollup_config.is_holocene_active(block.header.timestamp));

--- a/crates/execution/revm/src/rollup_config.rs
+++ b/crates/execution/revm/src/rollup_config.rs
@@ -36,14 +36,14 @@ impl RollupConfigExt for RollupConfig {
 
 #[cfg(test)]
 mod tests {
-    use base_consensus_genesis::{BaseHardforkConfig, HardForkConfig, RollupConfig};
+    use base_consensus_genesis::{BaseHardforkConfig, LegacyHardforkConfig, RollupConfig};
 
     use super::*;
 
     #[test]
     fn test_spec_id() {
         let mut config = RollupConfig {
-            hardforks: HardForkConfig { regolith_time: Some(10), ..Default::default() },
+            hardforks: LegacyHardforkConfig { regolith_time: Some(10), ..Default::default() }.into(),
             ..Default::default()
         };
         assert_eq!(config.spec_id(0), OpSpecId::BEDROCK);

--- a/crates/proof/primitives/src/per_chain_config.rs
+++ b/crates/proof/primitives/src/per_chain_config.rs
@@ -15,7 +15,7 @@ use alloy_chains::Chain;
 use alloy_eips::eip1898::BlockNumHash;
 use alloy_primitives::{Address, B256, U256, keccak256};
 use base_consensus_genesis::{
-    BaseFeeConfig, BaseHardforkConfig, ChainGenesis, HardForkConfig, RollupConfig, SystemConfig,
+    BaseFeeConfig, BaseHardforkConfig, ChainGenesis, HardForkConfig, LegacyHardforkConfig, RollupConfig, SystemConfig,
 };
 
 const VERSION_0: u64 = 0;
@@ -227,16 +227,18 @@ impl PerChainConfig {
             protocol_versions_address: Address::ZERO,
             blobs_enabled_l1_timestamp: Some(0),
             hardforks: HardForkConfig {
-                regolith_time: Some(0),
-                canyon_time: Some(0),
-                delta_time: Some(0),
-                ecotone_time: Some(0),
-                fjord_time: Some(0),
-                granite_time: Some(0),
-                holocene_time: Some(0),
-                pectra_blob_schedule_time: None,
-                isthmus_time: Some(0),
-                jovian_time: Some(0),
+                legacy: LegacyHardforkConfig {
+                    regolith_time: Some(0),
+                    canyon_time: Some(0),
+                    delta_time: Some(0),
+                    ecotone_time: Some(0),
+                    fjord_time: Some(0),
+                    granite_time: Some(0),
+                    holocene_time: Some(0),
+                    pectra_blob_schedule_time: None,
+                    isthmus_time: Some(0),
+                    jovian_time: Some(0),
+                },
                 base: BaseHardforkConfig { v1: Some(0) },
             },
             chain_op_config: BaseFeeConfig::base_mainnet(),


### PR DESCRIPTION
## Summary

Splits HardForkConfig into nested LegacyHardforkConfig (10 frozen OP Stack fork timestamps from Regolith through Jovian) and BaseHardforkConfig (V1+), keeping the flat JSON/TOML wire format fully backwards-compatible.

## Design

- **LegacyHardforkConfig** - new public struct holding the 10 frozen OP Stack lineage fork activation timestamps.
- **HardForkConfig** - now composes \legacy: LegacyHardforkConfig\ + \ase: BaseHardforkConfig\.
- **\Deref\/\DerefMut\** targeting \LegacyHardforkConfig\ so that existing production code accessing \config.hardforks.holocene_time\ (etc.) compiles unchanged.
- **\From<LegacyHardforkConfig>\** for ergonomic \.into()\ construction at call sites that only set legacy fields.
- **Private \RawHardForkConfig\** serde bridge preserves the flat wire format with \deny_unknown_fields\, working around the known serde \#[serde(flatten)]\ + \deny_unknown_fields\ incompatibility.

## Changes

- 25 files changed across 7 crates (\genesis\, \derive\, \engine\, \protocol\, \atcher/encoder\, \execution/revm\, \proof/primitives\)
- ~90 call sites updated: simple patterns use \LegacyHardforkConfig { ... }.into()\, complex patterns use the full \HardForkConfig { legacy: ..., base: ... }\ form.
- Exports updated in \chain/mod.rs\ and \lib.rs\.

Closes #1917