### PR TITLE
Remove per-tx state root simulation from flashblocks processor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4042,7 +4042,6 @@ dependencies = [
  "reth-rpc-convert",
  "reth-rpc-eth-api",
  "reth-rpc-eth-types",
- "reth-trie-common",
  "revm",
  "revm-database",
  "rstest",

--- a/crates/client/flashblocks-node/src/extension.rs
+++ b/crates/client/flashblocks-node/src/extension.rs
@@ -59,11 +59,8 @@ impl BaseNodeExtension for FlashblocksExtension {
 
         // Start state processor, subscriber, and canonical subscription after node is started
         let hooks = hooks.add_node_started_hook(move |ctx| {
-            info!(
-                message = "Starting Flashblocks state processor",
-                simulate_state_root = cfg.simulate_state_root
-            );
-            state_for_start.start_with_options(ctx.provider().clone(), cfg.simulate_state_root);
+            info!(message = "Starting Flashblocks state processor");
+            state_for_start.start(ctx.provider().clone());
             subscriber.start();
 
             let mut canonical_stream =

--- a/crates/execution/flashblocks/Cargo.toml
+++ b/crates/execution/flashblocks/Cargo.toml
@@ -26,7 +26,6 @@ reth-chainspec.workspace = true
 reth-primitives.workspace = true
 reth-rpc-convert.workspace = true
 reth-rpc-eth-api.workspace = true
-reth-trie-common.workspace = true
 base-execution-evm.workspace = true
 base-execution-rpc.workspace = true
 reth-rpc-eth-types.workspace = true

--- a/crates/execution/flashblocks/src/config.rs
+++ b/crates/execution/flashblocks/src/config.rs
@@ -15,8 +15,6 @@ pub struct FlashblocksConfig {
     pub cached_execution: bool,
     /// Shared Flashblocks state.
     pub state: Arc<FlashblocksState>,
-    /// Whether to compute per-transaction state roots during flashblock processing.
-    pub simulate_state_root: bool,
 }
 
 impl FlashblocksConfig {
@@ -28,13 +26,6 @@ impl FlashblocksConfig {
             max_pending_blocks_depth,
             cached_execution: false,
             state,
-            simulate_state_root: false,
         }
-    }
-
-    /// Enables per-transaction state root simulation during flashblock processing.
-    pub const fn with_simulate_state_root(mut self, enabled: bool) -> Self {
-        self.simulate_state_root = enabled;
-        self
     }
 }

--- a/crates/execution/flashblocks/src/config.rs
+++ b/crates/execution/flashblocks/src/config.rs
@@ -21,11 +21,6 @@ impl FlashblocksConfig {
     /// Create a new Flashblocks configuration.
     pub fn new(websocket_url: Url, max_pending_blocks_depth: u64) -> Self {
         let state = Arc::new(FlashblocksState::new(max_pending_blocks_depth));
-        Self {
-            websocket_url,
-            max_pending_blocks_depth,
-            cached_execution: false,
-            state,
-        }
+        Self { websocket_url, max_pending_blocks_depth, cached_execution: false, state }
     }
 }

--- a/crates/execution/flashblocks/src/processor.rs
+++ b/crates/execution/flashblocks/src/processor.rs
@@ -21,7 +21,6 @@ use reth_evm::ConfigureEvm;
 use reth_primitives::RecoveredBlock;
 use reth_provider::{BlockReaderIdExt, StateProviderFactory};
 use reth_revm::{State, database::StateProviderDatabase};
-use reth_trie_common::TrieInput;
 use revm_database::states::bundle_state::BundleRetention;
 use tokio::sync::{Mutex, broadcast::Sender, mpsc::UnboundedReceiver};
 
@@ -50,7 +49,6 @@ pub struct StateProcessor<Client> {
     rx: Arc<Mutex<UnboundedReceiver<StateUpdate>>>,
     pending_blocks: Arc<ArcSwapOption<PendingBlocks>>,
     max_depth: u64,
-    simulate_state_root: bool,
     client: Client,
     sender: Sender<Arc<PendingBlocks>>,
     cache: Arc<Mutex<FlashblockCache>>,
@@ -69,7 +67,6 @@ where
         client: Client,
         pending_blocks: Arc<ArcSwapOption<PendingBlocks>>,
         max_depth: u64,
-        simulate_state_root: bool,
         rx: Arc<Mutex<UnboundedReceiver<StateUpdate>>>,
         sender: Sender<Arc<PendingBlocks>>,
     ) -> Self {
@@ -81,7 +78,6 @@ where
             pending_blocks,
             client,
             max_depth,
-            simulate_state_root,
             rx,
             sender,
             cache: Arc::new(Mutex::new(cache)),
@@ -458,11 +454,8 @@ where
             pending_state_builder
                 .apply_pre_execution_changes(parent_hash, parent_beacon_block_root)?;
 
-            let mut cached_trie = None;
-
             for (idx, (transaction, sender)) in txs_with_senders.into_iter().enumerate() {
                 let tx_hash = transaction.tx_hash();
-                let is_deposit = transaction.is_deposit();
 
                 pending_blocks_builder.with_transaction_sender(tx_hash, sender);
                 pending_blocks_builder.increment_nonce(sender);
@@ -474,43 +467,6 @@ where
 
                 if let Some(time_us) = executed_transaction.execution_time_us {
                     pending_blocks_builder.with_execution_time(tx_hash, time_us);
-                }
-
-                // Per-tx state root simulation is best-effort instrumentation:
-                // compute the state root after each non-deposit transaction while
-                // accumulating trie nodes across txs, but do not fail flashblock
-                // processing if the measurement itself errors.
-                if self.simulate_state_root && !is_deposit {
-                    let db = pending_state_builder.db_mut();
-                    db.merge_transitions(BundleRetention::Reverts);
-                    let state_provider = db.database.as_ref();
-                    let hashed_state = state_provider.hashed_post_state(&db.bundle_state);
-
-                    let start = Instant::now();
-                    let trie_result = if let Some((prev_updates, prev_hashed)) = cached_trie.take()
-                    {
-                        let mut trie_input = TrieInput::from_state(hashed_state.clone());
-                        trie_input.prepend_cached(prev_updates, prev_hashed);
-                        state_provider.state_root_from_nodes_with_updates(trie_input)
-                    } else {
-                        state_provider.state_root_with_updates(hashed_state.clone())
-                    };
-                    let state_root_time_us = start.elapsed().as_micros();
-
-                    match trie_result {
-                        Ok((_, trie_updates)) => {
-                            cached_trie = Some((trie_updates, hashed_state));
-                            pending_blocks_builder
-                                .with_state_root_time(tx_hash, state_root_time_us);
-                        }
-                        Err(error) => {
-                            warn!(
-                                tx_hash = %tx_hash,
-                                error = %error,
-                                "state root simulation failed; skipping timing for this transaction"
-                            );
-                        }
-                    }
                 }
 
                 for (address, account) in &executed_transaction.state {
@@ -530,12 +486,11 @@ where
             last_block_header = block_header;
         }
 
-        // Extract the accumulated bundle state for state root calculation.
-        // When simulate_state_root is enabled, transitions for non-deposit txs
-        // are already merged per-tx; this merge picks up any remaining deposit
-        // transitions and is otherwise a no-op.
+        // Extract the accumulated bundle state for pending block serving.
         db.merge_transitions(BundleRetention::Reverts);
-        pending_blocks_builder.with_bundle_state(db.take_bundle());
+        let bundle_state = db.take_bundle();
+
+        pending_blocks_builder.with_bundle_state(bundle_state);
         pending_blocks_builder.with_state_overrides(state_overrides);
 
         Ok(Some(Arc::new(pending_blocks_builder.build()?)))

--- a/crates/execution/flashblocks/src/processor.rs
+++ b/crates/execution/flashblocks/src/processor.rs
@@ -481,9 +481,7 @@ where
 
         // Extract the accumulated bundle state for pending block serving.
         db.merge_transitions(BundleRetention::Reverts);
-        let bundle_state = db.take_bundle();
-
-        pending_blocks_builder.with_bundle_state(bundle_state);
+        pending_blocks_builder.with_bundle_state(db.take_bundle());
         pending_blocks_builder.with_state_overrides(state_overrides);
 
         Ok(Some(Arc::new(pending_blocks_builder.build()?)))

--- a/crates/execution/flashblocks/src/processor.rs
+++ b/crates/execution/flashblocks/src/processor.rs
@@ -74,14 +74,7 @@ where
             .best_block_number()
             .map_or_else(|_| FlashblockCache::new(0), FlashblockCache::new);
 
-        Self {
-            pending_blocks,
-            client,
-            max_depth,
-            rx,
-            sender,
-            cache: Arc::new(Mutex::new(cache)),
-        }
+        Self { pending_blocks, client, max_depth, rx, sender, cache: Arc::new(Mutex::new(cache)) }
     }
 
     /// Processes updates from the queue until the channel closes.

--- a/crates/execution/flashblocks/src/state.rs
+++ b/crates/execution/flashblocks/src/state.rs
@@ -65,26 +65,10 @@ impl FlashblocksState {
             + Clone
             + 'static,
     {
-        self.start_with_options(client, false);
-    }
-
-    /// Starts the flashblocks state processor with per-transaction state root simulation.
-    ///
-    /// When `simulate_state_root` is true, the processor computes a state root after
-    /// each non-deposit transaction, storing the timing for metering purposes.
-    pub fn start_with_options<Client>(&self, client: Client, simulate_state_root: bool)
-    where
-        Client: StateProviderFactory
-            + ChainSpecProvider<ChainSpec: EthChainSpec<Header = Header> + BaseUpgrades>
-            + BlockReaderIdExt<Header = Header>
-            + Clone
-            + 'static,
-    {
         let state_processor = StateProcessor::new(
             client,
             Arc::clone(&self.pending_blocks),
             self.max_pending_blocks_depth,
-            simulate_state_root,
             Arc::clone(&self.rx),
             self.flashblock_sender.clone(),
         );

--- a/crates/execution/flashblocks/src/state_builder.rs
+++ b/crates/execution/flashblocks/src/state_builder.rs
@@ -550,7 +550,7 @@ mod tests {
     }
 
     #[test]
-    fn cached_execute_transaction_preserves_execution_time_from_prev_pending_blocks() {
+    fn cached_execute_transaction_preserves_timing_from_prev_pending_blocks() {
         let chain_spec = Arc::new(OpChainSpecBuilder::base_mainnet().build());
         let evm_config = OpEvmConfig::optimism(Arc::clone(&chain_spec));
 


### PR DESCRIPTION
## Summary
- Remove the `simulate_state_root` code path from the flashblocks processor that computed a trie root after every non-deposit transaction
- The cumulative cost of per-tx state root computation far exceeded single-pass payload finalization, making it impractical for third-party RPC nodes
- The metering pipeline is shifting to a slots-modified model ("state root gas") that doesn't need inline trie computation

## Details
- Removes all trie helper functions, cached trie plumbing, and the `simulate_state_root` config/field
- Removes `PendingTrieInput` and trie caching from `PendingBlocks`
- Removes `state_root_time_us` forwarding from `ExecutedPendingTransaction` (was always `None` without the simulation)
- `state_root_times` HashMap in `PendingBlocks` and the metering collector's `get_state_root_time` plumbing remain — they'll be cleaned up when the metering code moves to slots
- Drops the `reth-trie-common` dependency from the flashblocks crate

type=routine
risk=low
impact=sev5