### PR TITLE
feat(docs): Introduce Base Change Proposals

### DIFF
--- a/docs/specs/components/BCPsList.tsx
+++ b/docs/specs/components/BCPsList.tsx
@@ -1,0 +1,59 @@
+type BcpStatus = 'Draft' | 'Review' | 'Accepted' | 'Final' | 'Rejected' | 'Withdrawn' | 'Deprecated'
+
+type BcpEntry = {
+  id: string
+  title: string
+  description: string
+  status: BcpStatus
+  link: string
+}
+
+const bcps: BcpEntry[] = [
+  {
+    id: 'BCP-0000',
+    title: 'BCP Process',
+    description: 'Defines the Base Change Proposal process, format, and lifecycle.',
+    status: 'Final',
+    link: '/bcps/bcp-0000',
+  },
+]
+
+const statusColor: Record<BcpStatus, { color: string; background: string }> = {
+  Final:      { color: 'var(--vocs-color_textGreen)',  background: 'var(--vocs-color_backgroundGreenTint)' },
+  Accepted:   { color: 'var(--vocs-color_textGreen)',  background: 'var(--vocs-color_backgroundGreenTint2)' },
+  Review:     { color: 'var(--vocs-color_textBlue)',   background: 'var(--vocs-color_backgroundBlueTint)' },
+  Draft:      { color: 'var(--vocs-color_text3)',      background: 'var(--vocs-color_background3)' },
+  Rejected:   { color: 'var(--vocs-color_textRed)',    background: 'var(--vocs-color_backgroundRedTint)' },
+  Withdrawn:  { color: 'var(--vocs-color_text3)',      background: 'var(--vocs-color_background3)' },
+  Deprecated: { color: 'var(--vocs-color_text3)',      background: 'var(--vocs-color_background3)' },
+}
+
+export function BCPsList() {
+  return (
+    <div className="bcps-list">
+      {bcps.map((bcp) => (
+        <a key={bcp.id} href={bcp.link} className="bcps-list__item">
+          <div className="bcps-list__icon">
+            <svg width="15" height="15" viewBox="0 0 15 15" fill="none" xmlns="http://www.w3.org/2000/svg">
+              <path
+                d="M4.2 1H4.17741H4.1774C3.86936 0.999988 3.60368 0.999978 3.38609 1.02067C3.15576 1.04257 2.92825 1.09113 2.71625 1.22104C2.51442 1.34472 2.34473 1.51442 2.22104 1.71625C2.09113 1.92825 2.04257 2.15576 2.02067 2.38609C1.99998 2.60367 1.99999 2.86935 2 3.17738V3.1774V3.2V11.8V11.8226V11.8226C1.99999 12.1307 1.99998 12.3963 2.02067 12.6139C2.04257 12.8442 2.09113 13.0717 2.22104 13.2837C2.34473 13.4856 2.51442 13.6553 2.71625 13.779C2.92825 13.9089 3.15576 13.9574 3.38609 13.9793C3.60368 14 3.86937 14 4.17741 14H4.2H10.8H10.8226C11.1306 14 11.3963 14 11.6139 13.9793C11.8442 13.9574 12.0717 13.9089 12.2837 13.779C12.4856 13.6553 12.6553 13.4856 12.779 13.2837C12.9089 13.0717 12.9574 12.8442 12.9793 12.6139C13 12.3963 13 12.1306 13 11.8226V11.8V3.2V3.17741C13 2.86936 13 2.60368 12.9793 2.38609C12.9574 2.15576 12.9089 1.92825 12.779 1.71625C12.6553 1.51442 12.4856 1.34472 12.2837 1.22104C12.0717 1.09113 11.8442 1.04257 11.6139 1.02067C11.3963 0.999978 11.1306 0.999988 10.8226 1H10.8H4.2ZM3.23875 2.07368C3.26722 2.05623 3.32362 2.03112 3.48075 2.01618C3.64532 2.00053 3.86298 2 4.2 2H10.8C11.137 2 11.3547 2.00053 11.5193 2.01618C11.6764 2.03112 11.7328 2.05623 11.7613 2.07368C11.8285 2.11491 11.8851 2.17147 11.9263 2.23875C11.9438 2.26722 11.9689 2.32362 11.9838 2.48075C11.9995 2.64532 12 2.86298 12 3.2V11.8C12 12.137 11.9995 12.3547 11.9838 12.5193C11.9689 12.6764 11.9438 12.7328 11.9263 12.7613C11.8851 12.8285 11.8285 12.8851 11.7613 12.9263C11.7328 12.9438 11.6764 12.9689 11.5193 12.9838C11.3547 12.9995 11.137 13 10.8 13H4.2C3.86298 13 3.64532 12.9995 3.48075 12.9838C3.32362 12.9689 3.26722 12.9438 3.23875 12.9263C3.17147 12.8851 3.11491 12.8285 3.07368 12.7613C3.05624 12.7328 3.03112 12.6764 3.01618 12.5193C3.00053 12.3547 3 12.137 3 11.8V3.2C3 2.86298 3.00053 2.64532 3.01618 2.48075C3.03112 2.32362 3.05624 2.26722 3.07368 2.23875C3.11491 2.17147 3.17147 2.11491 3.23875 2.07368ZM5 10C4.72386 10 4.5 10.2239 4.5 10.5C4.5 10.7761 4.72386 11 5 11H8C8.27614 11 8.5 10.7761 8.5 10.5C8.5 10.2239 8.27614 10 8 10H5ZM4.5 7.5C4.5 7.22386 4.72386 7 5 7H10C10.2761 7 10.5 7.22386 10.5 7.5C10.5 7.77614 10.2761 8 10 8H5C4.72386 8 4.5 7.77614 4.5 7.5ZM5 4C4.72386 4 4.5 4.22386 4.5 4.5C4.5 4.77614 4.72386 5 5 5H10C10.2761 5 10.5 4.77614 10.5 4.5C10.5 4.22386 10.2761 4 10 4H5Z"
+                fill="currentColor"
+                fillRule="evenodd"
+                clipRule="evenodd"
+              />
+            </svg>
+          </div>
+          <div className="bcps-list__body">
+            <span className="bcps-list__name">
+              {bcp.id}: {bcp.title}
+            </span>
+            <span className="bcps-list__desc">{bcp.description}</span>
+          </div>
+          <span className="bcps-list__badge" style={statusColor[bcp.status]}>
+            {bcp.status}
+          </span>
+        </a>
+      ))}
+    </div>
+  )
+}

--- a/docs/specs/pages/bcps/bcp-0000.md
+++ b/docs/specs/pages/bcps/bcp-0000.md
@@ -55,7 +55,7 @@ BCP is rejected or withdrawn. BCP-0000 is reserved for this process document.
 ## BCP Format
 
 Each BCP is a Markdown file stored at `docs/specs/pages/bcps/bcp-{NNNN}.md` in the
-[base3 repository](https://github.com/base-org/base3). It must begin with the title as an H1
+[base repository](https://github.com/base/base). It must begin with the title as an H1
 heading followed by a metadata table, then the body sections below.
 
 ### Required Sections
@@ -79,7 +79,7 @@ Additional sections (e.g. **Security Considerations**, **Backwards Compatibility
 
 ## Process
 
-1. **Draft** — An author opens a PR to the base3 repository adding a new BCP file. The PR
+1. **Draft** — An author opens a PR to the base repository adding a new BCP file. The PR
    description should link to any relevant prior discussion.
 2. **Review** — The PR is marked ready for review. Core team members and community stakeholders
    review the specification for correctness, completeness, and alignment with Base's design goals.

--- a/docs/specs/pages/bcps/bcp-0000.md
+++ b/docs/specs/pages/bcps/bcp-0000.md
@@ -90,7 +90,7 @@ Additional sections (e.g. **Security Considerations**, **Backwards Compatibility
 
 ## BCP Index
 
-The [BCPs index page](./index.md) lists all BCPs with their current status. Authors are
+The [BCPs index page](./index.mdx) lists all BCPs with their current status. Authors are
 responsible for keeping their BCP's status up to date as it progresses.
 
 # Invariants

--- a/docs/specs/pages/bcps/bcp-0000.md
+++ b/docs/specs/pages/bcps/bcp-0000.md
@@ -1,0 +1,100 @@
+# BCP-0000: BCP Process
+
+## Abstract
+
+BCP-0000 defines the Base Change Proposal (BCP) process — the mechanism by which changes to the Base
+Chain protocol are proposed, reviewed, and accepted. A BCP is a design document providing a
+complete specification of a proposed change, serving as the source of truth for implementation.
+
+## Motivation
+
+Base Chain needs a transparent, structured process for evolving its protocol. Without a formal
+process, changes risk being underdocumented, inconsistently reviewed, or difficult to track across
+stakeholders. BCPs provide a single canonical artifact per change: a self-contained specification
+that captures the what, why, and how, from initial proposal through final acceptance.
+
+---
+
+# Specification
+
+## BCP Types
+
+There are two types of BCPs:
+
+- **Standards Track** — describes a change to the Base Chain protocol itself: execution rules,
+  consensus, bridging, fault proofs, or other on-chain behavior. Most BCPs are Standards Track.
+- **Meta** — describes a change to the BCP process or introduces governance around how the
+  protocol is evolved. BCP-0000 is a Meta BCP.
+
+## BCP Statuses
+
+A BCP moves through the following statuses over its lifetime:
+
+```
+Draft → Review → Accepted → Final
+                └→ Rejected
+       └→ Withdrawn
+```
+
+| Status | Description |
+| ------ | ----------- |
+| **Draft** | The BCP is being authored and is not yet ready for formal review. |
+| **Review** | The BCP is complete and open for community and core team feedback. |
+| **Accepted** | The BCP has been approved and is scheduled for implementation. |
+| **Final** | The BCP has been implemented and deployed to mainnet. |
+| **Rejected** | The BCP was reviewed and not accepted. |
+| **Withdrawn** | The author(s) withdrew the BCP before a decision was reached. |
+| **Deprecated** | A previously Final BCP has been superseded by a later BCP. |
+
+## BCP Numbering
+
+BCPs are assigned a number at the time of their first Draft commit. Numbers are assigned
+sequentially starting from 1 (BCP-0001). The number is permanent and is never reused, even if the
+BCP is rejected or withdrawn. BCP-0000 is reserved for this process document.
+
+## BCP Format
+
+Each BCP is a Markdown file stored at `docs/specs/pages/bcps/bcp-{NNNN}.md` in the
+[base3 repository](https://github.com/base-org/base3). It must begin with the title as an H1
+heading followed by a metadata table, then the body sections below.
+
+### Required Sections
+
+**Abstract** — A 2–4 sentence high-level summary of the proposed change.
+
+**Motivation** — An explanation of the problem this BCP solves and why the proposed approach was
+chosen over alternatives. Include links to prerequisite specs or relevant context.
+
+**Specification** — A complete description of the change: state transitions, data structures,
+encodings, interface definitions, and any invariants that must hold. The specification must be
+precise enough for an independent engineer to implement and test without inferring details.
+
+**Invariants** (if applicable) — Explicit invariants that must always hold after the change is
+applied, and critical cases the test suite must cover.
+
+### Optional Sections
+
+Additional sections (e.g. **Security Considerations**, **Backwards Compatibility**,
+**Reference Implementation**) may be added as needed.
+
+## Process
+
+1. **Draft** — An author opens a PR to the base3 repository adding a new BCP file. The PR
+   description should link to any relevant prior discussion.
+2. **Review** — The PR is marked ready for review. Core team members and community stakeholders
+   review the specification for correctness, completeness, and alignment with Base's design goals.
+3. **Accepted / Rejected** — The core team makes a final decision. If accepted, the BCP is merged
+   and assigned a Final status once the implementation ships to mainnet. If rejected, the BCP is
+   merged with Rejected status and a brief rationale added to the metadata table.
+4. **Final** — The BCP is updated to Final status when its implementation is deployed to mainnet.
+
+## BCP Index
+
+The [BCPs index page](./index.md) lists all BCPs with their current status. Authors are
+responsible for keeping their BCP's status up to date as it progresses.
+
+# Invariants
+
+- Every BCP has a unique, permanent number.
+- Every BCP that reaches Final status has a corresponding implementation deployed to mainnet.
+- A Deprecated BCP must reference the superseding BCP.

--- a/docs/specs/pages/bcps/index.mdx
+++ b/docs/specs/pages/bcps/index.mdx
@@ -1,0 +1,10 @@
+import { BCPsList } from '../../components/BCPsList'
+
+# Base Change Proposals (BCPs)
+
+BCPs are design documents that describe changes to the Base Chain protocol. Each BCP provides a
+complete specification that serves as the source of truth for implementation.
+
+---
+
+<BCPsList />

--- a/docs/specs/styles.css
+++ b/docs/specs/styles.css
@@ -1,3 +1,69 @@
+.bcps-list {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin-top: 16px;
+}
+
+.bcps-list__item {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 10px 14px;
+  border: 1px solid var(--vocs-color_border);
+  border-radius: 8px;
+  background: var(--vocs-color_background2);
+  text-decoration: none !important;
+  color: inherit;
+  transition: background 0.15s ease, border-color 0.15s ease;
+}
+
+.bcps-list__item:hover {
+  background: var(--vocs-color_background4);
+  border-color: var(--vocs-color_border2);
+}
+
+.bcps-list__icon {
+  flex-shrink: 0;
+  width: 18px;
+  height: 18px;
+  color: var(--vocs-color_textAccent);
+}
+
+.bcps-list__body {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+  flex: 1;
+  min-width: 0;
+}
+
+.bcps-list__name {
+  font-size: 14px;
+  font-weight: 600;
+  line-height: 1.2;
+  color: var(--vocs-color_heading);
+}
+
+.bcps-list__desc {
+  font-size: 13px;
+  line-height: 1.2;
+  color: var(--vocs-color_text2);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.bcps-list__badge {
+  flex-shrink: 0;
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  padding: 2px 8px;
+  border-radius: 999px;
+}
+
 .mermaid-diagram {
   margin: 1.5rem 0;
   overflow-x: auto;

--- a/docs/specs/vocs.config.ts
+++ b/docs/specs/vocs.config.ts
@@ -107,6 +107,14 @@ function sectionItem(section: string, text: string): SidebarItem {
   }
 }
 
+const bcpsSection: SidebarItem = {
+  text: 'Base Change Proposals',
+  items: [
+    { text: 'BCP List', link: '/bcps' },
+    { text: 'BCP Process', link: '/bcps/bcp-0000' },
+  ],
+}
+
 const bridgingSection: SidebarItem = {
   text: 'Bridging',
   items: [
@@ -154,6 +162,7 @@ const sidebar: SidebarItem[] = [
       { ...sectionItem('protocol/fault-proof', 'Proofs'), collapsed: true },
     ],
   },
+  bcpsSection,
   {
     text: 'Upgrades',
     items: [


### PR DESCRIPTION
## Summary

Introduces the Base Change Proposals (BCPs) framework to the specs site. Adds a BCP List index page with card-based UI, BCP-0000 defining the proposal process and lifecycle, and a new Base Change Proposals section in the sidebar above Upgrades.