### PR TITLE
ktlo(docs): Port Stale References

### DIFF
--- a/crates/consensus/safedb/README.md
+++ b/crates/consensus/safedb/README.md
@@ -1,6 +1,6 @@
 # base-consensus-safedb
 
-Persistent safe head tracking for the OP Stack derivation pipeline.
+Persistent safe head tracking for the Base derivation pipeline.
 
 This crate provides traits and a [redb](https://docs.rs/redb)-backed implementation for recording
 which L2 safe head was derived from each L1 block. The RPC layer queries this store to answer

--- a/docs/specs/pages/protocol/consensus/p2p.md
+++ b/docs/specs/pages/protocol/consensus/p2p.md
@@ -46,7 +46,7 @@ Common representations of network identity:
 
 #### Consensus Layer Structure
 
-The Ethereum Node Record (ENR) for an Optimism rollup node must contain the following values, identified by unique keys:
+The Ethereum Node Record (ENR) for a Base rollup node must contain the following values, identified by unique keys:
 
 - An IPv4 address (`ip` field) and/or IPv6 address (`ip6` field).
 - A TCP port (`tcp` field) representing the local libp2p listening port.
@@ -62,7 +62,7 @@ Note that DiscV5 is a shared DHT (Distributed Hash Table): the L1 consensus and 
 as well as testnet nodes, and even external IOT nodes, all communicate records in this large common DHT.
 This makes it more difficult to censor the discovery of node records.
 
-The discovery process in Optimism is a pipeline of node records:
+The discovery process in Base is a pipeline of node records:
 
 1. Fill the table with `FINDNODES` if necessary (Performed by Discv5 library)
 2. Pull additional records with searches to random Node IDs if necessary

--- a/docs/specs/pages/protocol/execution/evm/predeploys.md
+++ b/docs/specs/pages/protocol/execution/evm/predeploys.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-[Predeployed smart contracts](../../../reference/glossary.md#predeployed-contract-predeploy) exist on Optimism
+[Predeployed smart contracts](../../../reference/glossary.md#predeployed-contract-predeploy) exist on Base
 at predetermined addresses in the genesis state. They are similar to precompiles but instead run
 directly in the EVM instead of running native code outside of the EVM.
 
@@ -122,9 +122,9 @@ This contract is deprecated and its usage should be avoided.
 
 Address: `0x4200000000000000000000000000000000000006`
 
-`WETH9` is the standard implementation of Wrapped Ether on Optimism. It is a
+`WETH9` is the standard implementation of Wrapped Ether on Base. It is a
 commonly used contract and is placed as a predeploy so that it is at a
-deterministic address across Optimism based networks.
+deterministic address across Base networks.
 
 ## L2CrossDomainMessenger
 

--- a/docs/specs/pages/protocol/execution/evm/preinstalls.md
+++ b/docs/specs/pages/protocol/execution/evm/preinstalls.md
@@ -2,10 +2,10 @@
 
 ## Overview
 
-[Preinstalled smart contracts](../../../reference/glossary.md#preinstalled-contract-preinstall) exist on Optimism
+[Preinstalled smart contracts](../../../reference/glossary.md#preinstalled-contract-preinstall) exist on Base
 at predetermined addresses in the genesis state. They are similar to precompiles but instead run
 directly in the EVM instead of running native code outside of the EVM and are developed by third
-parties unaffiliated with the Optimism Collective.
+parties unaffiliated with Base.
 
 These preinstalls are commonly deployed smart contracts that are being placed at genesis for convenience.
 It's important to note that these contracts do not have the same security guarantees

--- a/docs/specs/pages/protocol/execution/index.md
+++ b/docs/specs/pages/protocol/execution/index.md
@@ -485,6 +485,6 @@ For the Ecotone upgrade, this entails that:
 
 ## P2P Modifications
 
-The Ethereum Node Record (ENR) for an Optimism execution node must contain an `opel` key-value pair where the key is
+The Ethereum Node Record (ENR) for a Base execution node must contain an `opel` key-value pair where the key is
 `opel` and the value is a [EIP-2124](https://eips.ethereum.org/EIPS/eip-2124) fork id.
 The EL uses a different key from the CL in order to stop EL and CL nodes from connecting to each other.


### PR DESCRIPTION
## Summary

Several documentation files across the specs and crate READMEs still described the stack using "Optimism" in a conceptual rather than technical sense. This updates those references to "Base" to reflect that this is now the Base stack, not the OP Stack. Technical identifiers such as RPC method names, contract names, and ENR field keys are left unchanged. The Lineage section of the spec index is also left as-is since it accurately describes historical origins.