### PR TITLE
ktlo(base-node-runner): Rename OpProvider Type

### DIFF
--- a/crates/execution/runner/src/lib.rs
+++ b/crates/execution/runner/src/lib.rs
@@ -20,7 +20,7 @@ mod service;
 pub use service::{DefaultPayloadServiceBuilder, PayloadServiceBuilder};
 
 mod types;
-pub use types::{BaseNodeBuilder, OpNodeTypes, OpProvider};
+pub use types::{BaseNodeBuilder, BaseProvider, OpNodeTypes};
 
 mod node;
 pub use node::BaseNode;

--- a/crates/execution/runner/src/test_utils/node.rs
+++ b/crates/execution/runner/src/test_utils/node.rs
@@ -21,11 +21,11 @@ use reth_provider::providers::BlockchainProvider;
 use reth_tasks::Runtime;
 
 use crate::{
-    BaseNodeExtension, NodeHooks, OpProvider, node::BaseNode, test_utils::engine::EngineApi,
+    BaseNodeExtension, BaseProvider, NodeHooks, node::BaseNode, test_utils::engine::EngineApi,
 };
 
 /// Convenience alias for the local blockchain provider type.
-pub type LocalNodeProvider = OpProvider;
+pub type LocalNodeProvider = BaseProvider;
 
 /// Handle to a launched local node along with the resources required to keep it alive.
 pub struct LocalNode {

--- a/crates/execution/runner/src/types.rs
+++ b/crates/execution/runner/src/types.rs
@@ -10,14 +10,14 @@ use reth_provider::providers::BlockchainProvider;
 use crate::node::BaseNode;
 
 /// Alias for the OP node type adapter used by the runner.
-pub type OpNodeTypes = FullNodeTypesAdapter<BaseNode, DatabaseEnv, OpProvider>;
+pub type OpNodeTypes = FullNodeTypesAdapter<BaseNode, DatabaseEnv, BaseProvider>;
 /// Internal alias for the OP node components builder (default payload service).
 pub(crate) type OpComponentsBuilder = <BaseNode as Node<OpNodeTypes>>::ComponentsBuilder;
 /// Internal alias for the OP node add-ons.
 pub(crate) type OpAddOns = <BaseNode as Node<OpNodeTypes>>::AddOns;
 
 /// A [`BlockchainProvider`] instance.
-pub type OpProvider = BlockchainProvider<NodeTypesWithDBAdapter<BaseNode, DatabaseEnv>>;
+pub type BaseProvider = BlockchainProvider<NodeTypesWithDBAdapter<BaseNode, DatabaseEnv>>;
 
 /// Convenience alias for the Base node builder type.
 pub type BaseNodeBuilder = WithLaunchContext<NodeBuilder<DatabaseEnv, OpChainSpec>>;


### PR DESCRIPTION
## Summary
Renames `OpProvider` to `BaseProvider` in `base-node-runner` as part of the ongoing effort to replace `Op`-prefixed identifiers with `Base`-prefixed ones throughout the codebase. The type alias definition in `types.rs`, its usage in test utilities, and the re-export from `lib.rs` are all updated.