### PR TITLE
ktlo(base-node-core): Rename Op Node Types

### DIFF
--- a/crates/execution/node/src/node.rs
+++ b/crates/execution/node/src/node.rs
@@ -87,7 +87,7 @@ impl<N> OpNodeTypes for N where
 
 /// Helper trait for Base node types with full configuration including storage and execution
 /// data.
-pub trait OpFullNodeTypes:
+pub trait BaseFullNodeTypes:
     NodeTypes<
         ChainSpec: BaseUpgrades,
         Primitives: OpPayloadPrimitives,
@@ -97,7 +97,7 @@ pub trait OpFullNodeTypes:
 {
 }
 
-impl<N> OpFullNodeTypes for N where
+impl<N> BaseFullNodeTypes for N where
     N: NodeTypes<
             ChainSpec: BaseUpgrades,
             Primitives: OpPayloadPrimitives,
@@ -307,7 +307,7 @@ impl OpNode {
 
 impl<N> Node<N> for OpNode
 where
-    N: FullNodeTypes<Types: OpFullNodeTypes + OpNodeTypes>,
+    N: FullNodeTypes<Types: BaseFullNodeTypes + OpNodeTypes>,
 {
     type ComponentsBuilder = ComponentsBuilder<
         N,
@@ -1197,4 +1197,4 @@ where
 }
 
 /// Network primitive types used by Base networks.
-pub type OpNetworkPrimitives = BasicNetworkPrimitives<OpPrimitives, OpPooledTransaction>;
+pub type BaseNetworkPrimitives = BasicNetworkPrimitives<OpPrimitives, OpPooledTransaction>;

--- a/crates/execution/node/src/rpc.rs
+++ b/crates/execution/node/src/rpc.rs
@@ -17,7 +17,7 @@
 //! };
 //! use base_execution_chainspec::BASE_SEPOLIA;
 //! use base_execution_evm::OpEvmConfig;
-//! use base_node_core::{OpExecutorBuilder, OpNetworkPrimitives, OpNode};
+//! use base_node_core::{BaseNetworkPrimitives, OpExecutorBuilder, OpNode};
 //! use base_execution_rpc::OpEthApiBuilder;
 //! use base_txpool::BasePooledTransaction;
 //! use reth_provider::providers::BlockchainProvider;
@@ -54,7 +54,7 @@
 //!                 .noop_pool::<BasePooledTransaction>()
 //!                 .executor(OpExecutorBuilder::default())
 //!                 .noop_consensus()
-//!                 .noop_network::<OpNetworkPrimitives>()
+//!                 .noop_network::<BaseNetworkPrimitives>()
 //!                 .noop_payload(),
 //!             Box::new(()) as Box<dyn OnComponentInitializedHook<_>>,
 //!         )


### PR DESCRIPTION
## Summary
Renames `OpFullNodeTypes` to `BaseFullNodeTypes` and `OpNetworkPrimitives` to `BaseNetworkPrimitives` in `base-node-core` as part of the ongoing effort to replace `Op`-prefixed identifiers with `Base`-prefixed ones throughout the codebase. All usages in `node.rs` and the doc comments in `rpc.rs` are updated accordingly.