### PR TITLE
ktlo(base-execution-evm): Rename OpExecutorProvider Type

### DIFF
--- a/crates/execution/cli/src/app.rs
+++ b/crates/execution/cli/src/app.rs
@@ -2,7 +2,7 @@ use std::{fmt, sync::Arc};
 
 use base_execution_chainspec::OpChainSpec;
 use base_execution_consensus::OpBeaconConsensus;
-use base_execution_evm::OpExecutorProvider;
+use base_execution_evm::BaseExecutorProvider;
 use base_node_core::OpNode;
 use eyre::{Result, eyre};
 use reth_cli::chainspec::ChainSpecParser;
@@ -74,7 +74,7 @@ where
 
         let components = |spec: Arc<OpChainSpec>| {
             (
-                OpExecutorProvider::optimism(Arc::clone(&spec)),
+                BaseExecutorProvider::optimism(Arc::clone(&spec)),
                 Arc::new(OpBeaconConsensus::new(spec)),
             )
         };

--- a/crates/execution/evm/src/execute.rs
+++ b/crates/execution/evm/src/execute.rs
@@ -1,7 +1,7 @@
 //! Base block execution strategy.
 
 /// Helper type with backwards compatible methods to obtain executor providers.
-pub type OpExecutorProvider = crate::OpEvmConfig;
+pub type BaseExecutorProvider = crate::OpEvmConfig;
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
## Summary
Renames `OpExecutorProvider` to `BaseExecutorProvider` in `base-execution-evm` as part of the ongoing effort to replace `Op`-prefixed identifiers with `Base`-prefixed ones throughout the codebase. The type alias in `execute.rs` and its usage in `base-execution-cli` are both updated.