### PR TITLE
ktlo(base-txpool): Rename OpTransactionPool Type

### DIFF
--- a/crates/execution/node/src/node.rs
+++ b/crates/execution/node/src/node.rs
@@ -23,7 +23,7 @@ use base_execution_rpc::{
 };
 use base_execution_storage::OpStorage;
 use base_txpool::{
-    BaseOrdering, BasePooledTransaction, OpPooledTx, OpTransactionPool, OpTransactionValidator,
+    BaseOrdering, BasePooledTransaction, BaseTransactionPool, OpPooledTx, OpTransactionValidator,
     TimestampedTransaction,
 };
 use reth_chainspec::{
@@ -897,7 +897,7 @@ where
     T: EthPoolTransaction<Consensus = TxTy<Node::Types>> + OpPooledTx + TimestampedTransaction,
     Evm: ConfigureEvm<Primitives = PrimitivesTy<Node::Types>> + Clone + 'static,
 {
-    type Pool = OpTransactionPool<Node::Provider, DiskFileBlobStore, Evm, T, BaseOrdering<T>>;
+    type Pool = BaseTransactionPool<Node::Provider, DiskFileBlobStore, Evm, T, BaseOrdering<T>>;
 
     async fn build_pool(
         self,

--- a/crates/txpool/README.md
+++ b/crates/txpool/README.md
@@ -20,7 +20,7 @@ base-txpool = { workspace = true }
 ```
 
 ```rust,ignore
-use base_txpool::{OpTransactionPool, OpTransactionValidator, BaseOrdering};
+use base_txpool::{BaseTransactionPool, OpTransactionValidator, BaseOrdering};
 
 let pool = Pool::new(
     OpTransactionValidator::new(client, evm),

--- a/crates/txpool/src/lib.rs
+++ b/crates/txpool/src/lib.rs
@@ -42,5 +42,5 @@ pub mod estimated_da_size;
 use reth_transaction_pool::{Pool, TransactionValidationTaskExecutor};
 
 /// Type alias for default Base transaction pool
-pub type OpTransactionPool<Client, S, Evm, T = BasePooledTransaction, O = BaseOrdering<T>> =
+pub type BaseTransactionPool<Client, S, Evm, T = BasePooledTransaction, O = BaseOrdering<T>> =
     Pool<TransactionValidationTaskExecutor<OpTransactionValidator<Client, T, Evm>>, O, S>;


### PR DESCRIPTION
## Summary
Renames `OpTransactionPool` to `BaseTransactionPool` in `base-txpool` as part of the ongoing effort to replace `Op`-prefixed identifiers with `Base`-prefixed ones throughout the codebase. The type alias definition in `base-txpool` and its usage as the `Pool` associated type in `base-node-core` are both updated.