### PR TITLE
ktlo(base-alloy-rpc-jsonrpsee): Rename OpAdminApi Trait

### DIFF
--- a/crates/common/rpc-jsonrpsee/README.md
+++ b/crates/common/rpc-jsonrpsee/README.md
@@ -5,7 +5,7 @@ Base chain JSON-RPC server and client implementations.
 ## Overview
 
 Provides jsonrpsee-based JSON-RPC trait definitions for Base chain admin and miner APIs.
-`MinerApiExtServer` and `MinerApiExtClient` expose miner-side endpoints, while `OpAdminApiServer`
+`MinerApiExtServer` and `MinerApiExtClient` expose miner-side endpoints, while `BaseAdminApiServer`
 exposes admin-side RPC methods. These traits are implemented by node components to expose Base-specific
 JSON-RPC functionality over HTTP or WebSocket transports.
 
@@ -19,7 +19,7 @@ base-alloy-rpc-jsonrpsee = { workspace = true }
 ```
 
 ```rust,ignore
-use base_alloy_rpc_jsonrpsee::{MinerApiExtServer, OpAdminApiServer};
+use base_alloy_rpc_jsonrpsee::{BaseAdminApiServer, MinerApiExtServer};
 
 #[async_trait]
 impl MinerApiExtServer for MyHandler {

--- a/crates/common/rpc-jsonrpsee/src/lib.rs
+++ b/crates/common/rpc-jsonrpsee/src/lib.rs
@@ -13,5 +13,5 @@ pub use traits::EthSignerApiClient;
 #[cfg(feature = "signer")]
 pub use traits::EthSignerApiServer;
 #[cfg(feature = "client")]
-pub use traits::{MinerApiExtClient, OpAdminApiClient};
-pub use traits::{MinerApiExtServer, OpAdminApiServer};
+pub use traits::{BaseAdminApiClient, MinerApiExtClient};
+pub use traits::{BaseAdminApiServer, MinerApiExtServer};

--- a/crates/common/rpc-jsonrpsee/src/traits.rs
+++ b/crates/common/rpc-jsonrpsee/src/traits.rs
@@ -10,7 +10,7 @@ use jsonrpsee::{core::RpcResult, proc_macros::rpc};
 /// See: <https://github.com/ethereum-optimism/optimism/blob/c7ad0ebae5dca3bf8aa6f219367a95c15a15ae41/op-node/node/api.go#L28-L36>
 #[cfg_attr(not(feature = "client"), rpc(server, namespace = "admin"))]
 #[cfg_attr(feature = "client", rpc(server, client, namespace = "admin"))]
-pub trait OpAdminApi {
+pub trait BaseAdminApi {
     /// Resets the derivation pipeline.
     #[method(name = "resetDerivationPipeline")]
     async fn admin_reset_derivation_pipeline(&self) -> RpcResult<()>;

--- a/crates/consensus/rpc/src/jsonrpsee.rs
+++ b/crates/consensus/rpc/src/jsonrpsee.rs
@@ -5,7 +5,7 @@ use core::net::IpAddr;
 use alloy_eips::BlockNumberOrTag;
 use alloy_primitives::B256;
 // Re-export apis defined in `base-alloy-rpc-jsonrpsee`
-pub use base_alloy_rpc_jsonrpsee::{MinerApiExtServer, OpAdminApiServer};
+pub use base_alloy_rpc_jsonrpsee::{BaseAdminApiServer, MinerApiExtServer};
 use base_alloy_rpc_types_engine::OpExecutionPayloadEnvelope;
 use base_consensus_genesis::RollupConfig;
 use base_consensus_gossip::{PeerCount, PeerDump, PeerInfo, PeerStats};

--- a/crates/consensus/rpc/src/lib.rs
+++ b/crates/consensus/rpc/src/lib.rs
@@ -29,8 +29,8 @@ mod jsonrpsee;
 #[cfg(feature = "client")]
 pub use jsonrpsee::{AdminApiClient, ConductorApiClient, OpP2PApiClient, RollupNodeApiClient};
 pub use jsonrpsee::{
-    AdminApiServer, ConductorApiServer, DevEngineApiServer, HealthzApiServer, MinerApiExtServer,
-    OpAdminApiServer, OpP2PApiServer, RollupNodeApiServer, WsServer,
+    AdminApiServer, BaseAdminApiServer, ConductorApiServer, DevEngineApiServer, HealthzApiServer,
+    MinerApiExtServer, OpP2PApiServer, RollupNodeApiServer, WsServer,
 };
 
 mod l1_watcher;


### PR DESCRIPTION
## Summary
Renames `OpAdminApi` to `BaseAdminApi` in `base-alloy-rpc-jsonrpsee` as part of the ongoing effort to replace `Op`-prefixed identifiers with `Base`-prefixed ones throughout the codebase. The jsonrpsee proc-macro-generated server and client traits are correspondingly renamed to `BaseAdminApiServer` and `BaseAdminApiClient`. All re-exports in `base-consensus-rpc` are updated to reflect the new names.