### PR TITLE
ktlo(base-revm): Rename OpError Type

### DIFF
--- a/crates/execution/revm/src/api.rs
+++ b/crates/execution/revm/src/api.rs
@@ -7,4 +7,4 @@ mod default_ctx;
 pub use default_ctx::{DefaultOp, OpContext};
 
 mod exec;
-pub use exec::{OpContextTr, OpError};
+pub use exec::{BaseError, OpContextTr};

--- a/crates/execution/revm/src/api/exec.rs
+++ b/crates/execution/revm/src/api/exec.rs
@@ -45,7 +45,7 @@ impl<T> OpContextTr for T where
 }
 
 /// Type alias for the error type of the `OpEvm`.
-pub type OpError<CTX> = EVMError<<<CTX as ContextTr>::Db as Database>::Error, OpTransactionError>;
+pub type BaseError<CTX> = EVMError<<<CTX as ContextTr>::Db as Database>::Error, OpTransactionError>;
 
 impl<CTX, INSP, PRECOMPILE> ExecuteEvm
     for OpEvm<CTX, INSP, EthInstructions<EthInterpreter, CTX>, PRECOMPILE>
@@ -56,7 +56,7 @@ where
     type Tx = <CTX as ContextTr>::Tx;
     type Block = <CTX as ContextTr>::Block;
     type State = EvmState;
-    type Error = OpError<CTX>;
+    type Error = BaseError<CTX>;
     type ExecutionResult = ExecutionResult<OpHaltReason>;
 
     fn set_block(&mut self, block: Self::Block) {

--- a/crates/execution/revm/src/lib.rs
+++ b/crates/execution/revm/src/lib.rs
@@ -6,7 +6,7 @@
 extern crate alloc as std;
 
 mod api;
-pub use api::{DefaultOp, DefaultOpEvm, OpBuilder, OpContext, OpContextTr, OpError};
+pub use api::{BaseError, DefaultOp, DefaultOpEvm, OpBuilder, OpContext, OpContextTr};
 
 mod constants;
 pub use constants::*;


### PR DESCRIPTION
## Summary
Renames `OpError` to `BaseError` in `base-revm` as part of the ongoing effort to replace `Op`-prefixed identifiers with `Base`-prefixed ones throughout the codebase. The type alias definition in `exec.rs` and all re-exports through `api.rs` and `lib.rs` are updated accordingly.