### PR TITLE
ktlo(base-alloy-rpc-types): Rename OpTransactionFields Type

### DIFF
--- a/crates/common/rpc-types/README.md
+++ b/crates/common/rpc-types/README.md
@@ -6,7 +6,7 @@ Base chain RPC types.
 
 Defines the JSON-RPC request and response types specific to Base chains, including genesis and
 chain info types (`OpGenesisInfo`, `OpChainInfo`, `OpBaseFeeInfo`), transaction types
-(`OpTransactionFields`, `OpTransactionRequest`, `Transaction`), receipt types
+(`BaseTransactionFields`, `OpTransactionRequest`, `Transaction`), receipt types
 (`OpTransactionReceipt`, `OpTransactionReceiptFields`), and `L1BlockInfo` for fee data. These
 types are used to serialize and deserialize Base-specific RPC payloads.
 

--- a/crates/common/rpc-types/src/lib.rs
+++ b/crates/common/rpc-types/src/lib.rs
@@ -17,7 +17,7 @@ mod receipt;
 pub use receipt::{L1BlockInfo, OpTransactionReceipt, OpTransactionReceiptFields};
 
 mod transaction;
-pub use transaction::{OpTransactionFields, OpTransactionRequest, Transaction};
+pub use transaction::{BaseTransactionFields, OpTransactionRequest, Transaction};
 
 #[cfg(feature = "reth")]
 mod reth;

--- a/crates/common/rpc-types/src/transaction.rs
+++ b/crates/common/rpc-types/src/transaction.rs
@@ -171,7 +171,7 @@ impl<T: TransactionTrait + Encodable2718> alloy_network_primitives::TransactionR
 /// Base chain-specific transaction fields
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub struct OpTransactionFields {
+pub struct BaseTransactionFields {
     /// The ETH value to mint on L2
     #[serde(default, skip_serializing_if = "Option::is_none", with = "alloy_serde::quantity::opt")]
     pub mint: Option<u128>,
@@ -187,10 +187,10 @@ pub struct OpTransactionFields {
     pub deposit_receipt_version: Option<u64>,
 }
 
-impl TryFrom<OpTransactionFields> for OtherFields {
+impl TryFrom<BaseTransactionFields> for OtherFields {
     type Error = serde_json::Error;
 
-    fn try_from(value: OpTransactionFields) -> Result<Self, Self::Error> {
+    fn try_from(value: BaseTransactionFields) -> Result<Self, Self::Error> {
         serde_json::to_value(value)?.try_into()
     }
 }


### PR DESCRIPTION
## Summary
Renames `OpTransactionFields` to `BaseTransactionFields` in `base-alloy-rpc-types` as part of the ongoing effort to replace `Op`-prefixed identifiers with `Base`-prefixed ones throughout the codebase. The struct definition, its `TryFrom` implementation, and the re-export from `lib.rs` are all updated.