### PR TITLE
ktlo(base-consensus-rpc): Rename OpP2PApi Trait

### DIFF
--- a/crates/consensus/rpc/src/jsonrpsee.rs
+++ b/crates/consensus/rpc/src/jsonrpsee.rs
@@ -55,7 +55,7 @@ pub trait RollupNodeApi {
 /// The opp2p namespace handles peer interactions.
 #[cfg_attr(not(feature = "client"), rpc(server, namespace = "opp2p"))]
 #[cfg_attr(feature = "client", rpc(server, client, namespace = "opp2p"))]
-pub trait OpP2PApi {
+pub trait BaseP2PApi {
     /// Returns information of node
     #[method(name = "self")]
     async fn opp2p_self(&self) -> RpcResult<PeerInfo>;

--- a/crates/consensus/rpc/src/lib.rs
+++ b/crates/consensus/rpc/src/lib.rs
@@ -27,10 +27,10 @@ pub use health::{HealthzResponse, HealthzRpc};
 
 mod jsonrpsee;
 #[cfg(feature = "client")]
-pub use jsonrpsee::{AdminApiClient, ConductorApiClient, OpP2PApiClient, RollupNodeApiClient};
+pub use jsonrpsee::{AdminApiClient, BaseP2PApiClient, ConductorApiClient, RollupNodeApiClient};
 pub use jsonrpsee::{
-    AdminApiServer, ConductorApiServer, DevEngineApiServer, HealthzApiServer, MinerApiExtServer,
-    OpAdminApiServer, OpP2PApiServer, RollupNodeApiServer, WsServer,
+    AdminApiServer, BaseP2PApiServer, ConductorApiServer, DevEngineApiServer, HealthzApiServer,
+    MinerApiExtServer, OpAdminApiServer, RollupNodeApiServer, WsServer,
 };
 
 mod l1_watcher;

--- a/crates/consensus/rpc/src/net.rs
+++ b/crates/consensus/rpc/src/net.rs
@@ -7,7 +7,7 @@ type P2pReqSender = tokio::sync::mpsc::Sender<P2pRpcRequest>;
 
 /// `P2pRpc`
 ///
-/// This is a server implementation of [`crate::OpP2PApiServer`].
+/// This is a server implementation of [`crate::BaseP2PApiServer`].
 #[derive(Debug)]
 pub struct P2pRpc {
     /// The channel to send [`P2pRpcRequest`]s.

--- a/crates/consensus/rpc/src/p2p.rs
+++ b/crates/consensus/rpc/src/p2p.rs
@@ -16,10 +16,10 @@ use jsonrpsee::{
     types::{ErrorCode, ErrorObject},
 };
 
-use crate::{OpP2PApiServer, net::P2pRpc};
+use crate::{BaseP2PApiServer, net::P2pRpc};
 
 #[async_trait]
-impl OpP2PApiServer for P2pRpc {
+impl BaseP2PApiServer for P2pRpc {
     async fn opp2p_self(&self) -> RpcResult<PeerInfo> {
         Metrics::rpc_calls("opp2p_self").increment(1.0);
         let (tx, rx) = tokio::sync::oneshot::channel();

--- a/crates/consensus/service/src/actors/rpc/actor.rs
+++ b/crates/consensus/service/src/actors/rpc/actor.rs
@@ -5,8 +5,8 @@ use std::{sync::Arc, time::Duration};
 use async_trait::async_trait;
 use base_consensus_gossip::P2pRpcRequest;
 use base_consensus_rpc::{
-    AdminApiServer, AdminRpc, DevEngineApiServer, DevEngineRpc, EngineRpcClient, HealthzApiServer,
-    HealthzRpc, L1WatcherQueries, NetworkAdminQuery, OpP2PApiServer, P2pRpc, RollupNodeApiServer,
+    AdminApiServer, AdminRpc, BaseP2PApiServer, DevEngineApiServer, DevEngineRpc, EngineRpcClient,
+    HealthzApiServer, HealthzRpc, L1WatcherQueries, NetworkAdminQuery, P2pRpc, RollupNodeApiServer,
     RollupRpc, RpcBuilder, SequencerAdminAPIClient, WsRPC, WsServer,
 };
 use base_consensus_safedb::SafeDBReader;

--- a/crates/infra/basectl/src/rpc.rs
+++ b/crates/infra/basectl/src/rpc.rs
@@ -10,7 +10,7 @@ use anyhow::Result;
 use base_alloy_consensus::OpTxEnvelope;
 use base_alloy_flashblocks::Flashblock;
 use base_alloy_network::Base;
-use base_consensus_rpc::{ConductorApiClient, OpP2PApiClient, RollupNodeApiClient};
+use base_consensus_rpc::{BaseP2PApiClient, ConductorApiClient, RollupNodeApiClient};
 use futures::{StreamExt, stream};
 use jsonrpsee::{core::client::ClientT, http_client::HttpClientBuilder, rpc_params};
 use tokio::sync::{mpsc, watch};
@@ -875,13 +875,13 @@ pub(crate) async fn pause_sequencer_node(
             .map_err(|e| anyhow::anyhow!("{e}"))?;
 
         // Snapshot connected CL peers before disconnecting so we can restore them.
-        let dump = OpP2PApiClient::opp2p_peers(&cl_client, true)
+        let dump = BaseP2PApiClient::opp2p_peers(&cl_client, true)
             .await
             .map_err(|e| anyhow::anyhow!("opp2p_peers: {e}"))?;
 
         let mut cl_addrs = Vec::new();
         for (peer_id, info) in dump.peers {
-            let _ = OpP2PApiClient::opp2p_disconnect_peer(&cl_client, peer_id).await;
+            let _ = BaseP2PApiClient::opp2p_disconnect_peer(&cl_client, peer_id).await;
             if let Some(addr) = info.addresses.into_iter().next() {
                 cl_addrs.push(addr);
             }
@@ -939,7 +939,7 @@ pub(crate) async fn unpause_sequencer_node(
 
         let mut cl_ok = 0usize;
         for addr in &peers.cl_addrs {
-            if OpP2PApiClient::opp2p_connect_peer(&cl_client, addr.clone()).await.is_ok() {
+            if BaseP2PApiClient::opp2p_connect_peer(&cl_client, addr.clone()).await.is_ok() {
                 cl_ok += 1;
             }
         }
@@ -1038,7 +1038,7 @@ pub(crate) async fn run_conductor_poller(
                     ConductorApiClient::conductor_leader(conductor_client),
                     ConductorApiClient::conductor_active(conductor_client),
                     RollupNodeApiClient::op_sync_status(cl_client),
-                    OpP2PApiClient::opp2p_peer_stats(cl_client),
+                    BaseP2PApiClient::opp2p_peer_stats(cl_client),
                     async {
                         if let Some(el) = el_client {
                             let r: Result<alloy_primitives::U64, _> =
@@ -1169,7 +1169,7 @@ pub(crate) async fn run_validator_poller(
             |(name, cl_client, el_client)| async move {
                 let (sync, cl_peer_stats, el_block_r, el_syncing_r, el_peers_r) = tokio::join!(
                     RollupNodeApiClient::op_sync_status(cl_client),
-                    OpP2PApiClient::opp2p_peer_stats(cl_client),
+                    BaseP2PApiClient::opp2p_peer_stats(cl_client),
                     async {
                         if let Some(el) = el_client {
                             let r: Result<alloy_primitives::U64, _> =

--- a/devnet/src/l2/in_process_consensus.rs
+++ b/devnet/src/l2/in_process_consensus.rs
@@ -20,7 +20,7 @@ use base_consensus_node::{
     EngineConfig, L1ConfigBuilder, NetworkConfig, NodeMode, RollupNodeBuilder, SequencerConfig,
 };
 use base_consensus_peers::{PeerScoreLevel, SecretKeyLoader};
-use base_consensus_rpc::{AdminApiClient, OpP2PApiClient, RollupNodeApiClient, RpcBuilder};
+use base_consensus_rpc::{AdminApiClient, BaseP2PApiClient, RollupNodeApiClient, RpcBuilder};
 use base_consensus_sources::BlockSigner;
 use eyre::{Result, WrapErr};
 use jsonrpsee::http_client::HttpClientBuilder;


### PR DESCRIPTION
## Summary
Renames `OpP2PApi` to `BaseP2PApi` in `base-consensus-rpc` as part of the ongoing effort to replace `Op`-prefixed identifiers with `Base`-prefixed ones throughout the codebase. The jsonrpsee proc-macro-generated server and client traits are renamed to `BaseP2PApiServer` and `BaseP2PApiClient` accordingly. The `opp2p` RPC namespace is hardcoded so all wire-level method names remain unchanged.