### PR TITLE
ktlo(base-execution-payload-builder): Rename OpPayloadTypes Type

### DIFF
--- a/crates/execution/node/src/engine.rs
+++ b/crates/execution/node/src/engine.rs
@@ -10,7 +10,7 @@ use base_alloy_rpc_types_engine::{
     OpExecutionPayloadEnvelopeV5, OpPayloadAttributes,
 };
 use base_execution_consensus::isthmus;
-use base_execution_payload_builder::{OpExecutionPayloadValidator, OpPayloadTypes};
+use base_execution_payload_builder::{BasePayloadTypes, OpExecutionPayloadValidator};
 use base_protocol::Predeploys;
 use reth_consensus::ConsensusError;
 use reth_node_api::{
@@ -29,7 +29,7 @@ use reth_trie_common::{HashedPostState, KeyHasher};
 /// The types used in the Base beacon consensus engine.
 #[derive(Debug, Default, Clone, serde::Deserialize, serde::Serialize)]
 #[non_exhaustive]
-pub struct OpEngineTypes<T: PayloadTypes = OpPayloadTypes> {
+pub struct OpEngineTypes<T: PayloadTypes = BasePayloadTypes> {
     _marker: PhantomData<T>,
 }
 

--- a/crates/execution/payload/src/lib.rs
+++ b/crates/execution/payload/src/lib.rs
@@ -20,6 +20,6 @@ pub use payload::{
 mod traits;
 pub use traits::*;
 mod types;
-pub use types::OpPayloadTypes;
+pub use types::BasePayloadTypes;
 pub mod validator;
 pub use validator::OpExecutionPayloadValidator;

--- a/crates/execution/payload/src/types.rs
+++ b/crates/execution/payload/src/types.rs
@@ -8,9 +8,9 @@ use crate::{OpBuiltPayload, OpPayloadAttributes, OpPayloadBuilderAttributes};
 /// ZST that aggregates Base [`PayloadTypes`].
 #[derive(Debug, Default, Clone, serde::Deserialize, serde::Serialize)]
 #[non_exhaustive]
-pub struct OpPayloadTypes<N: NodePrimitives = OpPrimitives>(core::marker::PhantomData<N>);
+pub struct BasePayloadTypes<N: NodePrimitives = OpPrimitives>(core::marker::PhantomData<N>);
 
-impl<N: NodePrimitives> PayloadTypes for OpPayloadTypes<N>
+impl<N: NodePrimitives> PayloadTypes for BasePayloadTypes<N>
 where
     OpBuiltPayload<N>: BuiltPayload,
 {


### PR DESCRIPTION
## Summary
Renames `OpPayloadTypes` to `BasePayloadTypes` in `base-execution-payload-builder` as part of the ongoing effort to replace `Op`-prefixed identifiers with `Base`-prefixed ones throughout the codebase. The struct definition and re-export in the payload crate are updated, as well as the usage as the default type parameter for `OpEngineTypes` in `base-node-core`.