### PR TITLE
feat(genesis): introduce LegacyHardforkConfig and refactor HardForkConfig

### DIFF
--- a/crates/consensus/derive/src/attributes/stateful.rs
+++ b/crates/consensus/derive/src/attributes/stateful.rs
@@ -260,7 +260,7 @@ mod tests {
 
     use alloy_consensus::Header;
     use alloy_primitives::{B256, Log, LogData, U64, U256, address};
-    use base_consensus_genesis::{CONFIG_UPDATE_TOPIC, HardForkConfig, SystemConfig};
+    use base_consensus_genesis::{CONFIG_UPDATE_TOPIC, HardForkConfig, LegacyHardforkConfig, SystemConfig};
     use base_consensus_registry::L1Config;
     use base_protocol::{BlockInfo, DepositDecodeError};
 
@@ -505,7 +505,7 @@ mod tests {
         let timestamp = 100;
         let cfg = Arc::new(RollupConfig {
             block_time,
-            hardforks: HardForkConfig { canyon_time: Some(0), ..Default::default() },
+            hardforks: LegacyHardforkConfig { canyon_time: Some(0), ..Default::default() }.into(),
             ..Default::default()
         });
         let l1_cfg = Arc::new(L1Config::sepolia().into());
@@ -557,7 +557,7 @@ mod tests {
         let timestamp = 100;
         let cfg = Arc::new(RollupConfig {
             block_time,
-            hardforks: HardForkConfig { ecotone_time: Some(102), ..Default::default() },
+            hardforks: LegacyHardforkConfig { ecotone_time: Some(102), ..Default::default() }.into(),
             ..Default::default()
         });
         let l1_cfg = Arc::new(L1Config::sepolia().into());
@@ -610,7 +610,7 @@ mod tests {
         let timestamp = 100;
         let cfg = Arc::new(RollupConfig {
             block_time,
-            hardforks: HardForkConfig { fjord_time: Some(102), ..Default::default() },
+            hardforks: LegacyHardforkConfig { fjord_time: Some(102), ..Default::default() }.into(),
             ..Default::default()
         });
         let l1_cfg = Arc::new(L1Config::sepolia().into());

--- a/crates/consensus/derive/src/sources/ethereum.rs
+++ b/crates/consensus/derive/src/sources/ethereum.rs
@@ -39,13 +39,13 @@ where
         calldata_source: CalldataSource<C>,
         cfg: &RollupConfig,
     ) -> Self {
-        Self { ecotone_timestamp: cfg.hardforks.ecotone_time, blob_source, calldata_source }
+        Self { ecotone_timestamp: cfg.hardforks.legacy.ecotone_time, blob_source, calldata_source }
     }
 
     /// Instantiates a new [`EthereumDataSource`] from parts.
     pub fn new_from_parts(provider: C, blobs: B, cfg: &RollupConfig) -> Self {
         Self {
-            ecotone_timestamp: cfg.hardforks.ecotone_time,
+            ecotone_timestamp: cfg.hardforks.legacy.ecotone_time,
             blob_source: BlobSource::new(provider.clone(), blobs, cfg.batch_inbox_address),
             calldata_source: CalldataSource::new(provider, cfg.batch_inbox_address),
         }
@@ -87,7 +87,7 @@ mod tests {
     use alloy_consensus::TxEnvelope;
     use alloy_eips::eip2718::Decodable2718;
     use alloy_primitives::{Address, address};
-    use base_consensus_genesis::{HardForkConfig, RollupConfig, SystemConfig};
+    use base_consensus_genesis::{HardForkConfig, LegacyHardforkConfig, RollupConfig, SystemConfig};
     use base_protocol::BlockInfo;
 
     use super::*;
@@ -131,7 +131,7 @@ mod tests {
         blob.data.push(BlobData { data: None, calldata: Some(Bytes::default()) });
         let calldata = CalldataSource::new(chain.clone(), Address::ZERO);
         let cfg = RollupConfig {
-            hardforks: HardForkConfig { ecotone_time: Some(0), ..Default::default() },
+            hardforks: LegacyHardforkConfig { ecotone_time: Some(0), ..Default::default() }.into(),
             ..Default::default()
         };
 

--- a/crates/consensus/derive/src/stages/batch/batch_provider.rs
+++ b/crates/consensus/derive/src/stages/batch/batch_provider.rs
@@ -220,7 +220,7 @@ mod tests {
     use alloc::{sync::Arc, vec};
 
     use alloy_eips::BlockNumHash;
-    use base_consensus_genesis::{HardForkConfig, RollupConfig, SystemConfig};
+    use base_consensus_genesis::{HardForkConfig, LegacyHardforkConfig, RollupConfig, SystemConfig};
     use base_protocol::BlockInfo;
 
     use super::BatchProvider;
@@ -235,7 +235,7 @@ mod tests {
         let provider = TestNextBatchProvider::new(vec![]);
         let l2_provider = TestL2ChainProvider::default();
         let cfg = Arc::new(RollupConfig {
-            hardforks: HardForkConfig { holocene_time: Some(0), ..Default::default() },
+            hardforks: LegacyHardforkConfig { holocene_time: Some(0), ..Default::default() }.into(),
             ..Default::default()
         });
         let mut batch_provider = BatchProvider::new(cfg, provider, l2_provider);
@@ -264,7 +264,7 @@ mod tests {
         let provider = TestNextBatchProvider::new(vec![]);
         let l2_provider = TestL2ChainProvider::default();
         let cfg = Arc::new(RollupConfig {
-            hardforks: HardForkConfig { holocene_time: Some(2), ..Default::default() },
+            hardforks: LegacyHardforkConfig { holocene_time: Some(2), ..Default::default() }.into(),
             ..Default::default()
         });
         let mut batch_provider = BatchProvider::new(cfg, provider, l2_provider);
@@ -290,7 +290,7 @@ mod tests {
         let provider = TestNextBatchProvider::new(vec![]);
         let l2_provider = TestL2ChainProvider::default();
         let cfg = Arc::new(RollupConfig {
-            hardforks: HardForkConfig { holocene_time: Some(10), ..Default::default() },
+            hardforks: LegacyHardforkConfig { holocene_time: Some(10), ..Default::default() }.into(),
             ..Default::default()
         });
         let mut batch_provider = BatchProvider::new(cfg, provider, l2_provider);
@@ -323,7 +323,7 @@ mod tests {
         let provider = TestNextBatchProvider::new(vec![]);
         let l2_provider = TestL2ChainProvider::default();
         let cfg = Arc::new(RollupConfig {
-            hardforks: HardForkConfig { holocene_time: Some(2), ..Default::default() },
+            hardforks: LegacyHardforkConfig { holocene_time: Some(2), ..Default::default() }.into(),
             ..Default::default()
         });
         let mut batch_provider = BatchProvider::new(cfg, provider, l2_provider);
@@ -373,7 +373,7 @@ mod tests {
         let provider = TestNextBatchProvider::new(vec![]);
         let l2_provider = TestL2ChainProvider::default();
         let cfg = Arc::new(RollupConfig {
-            hardforks: HardForkConfig { holocene_time: Some(0), ..Default::default() },
+            hardforks: LegacyHardforkConfig { holocene_time: Some(0), ..Default::default() }.into(),
             ..Default::default()
         });
         let mut batch_provider = BatchProvider::new(cfg, provider, l2_provider);

--- a/crates/consensus/derive/src/stages/batch/batch_queue.rs
+++ b/crates/consensus/derive/src/stages/batch/batch_queue.rs
@@ -484,7 +484,7 @@ mod tests {
     use alloy_primitives::{Address, B256, Bytes, TxKind, U256, address, b256};
     use alloy_rlp::{BytesMut, Encodable};
     use base_alloy_consensus::{BaseBlock, OpTxEnvelope, OpTxType, TxDeposit};
-    use base_consensus_genesis::{ChainGenesis, HardForkConfig, RollupConfig, SystemConfig};
+    use base_consensus_genesis::{ChainGenesis, HardForkConfig, LegacyHardforkConfig, RollupConfig, SystemConfig};
     use base_protocol::{BatchReader, L1BlockInfoBedrock, L1BlockInfoTx};
     use tracing::Level;
     use tracing_subscriber::layer::SubscriberExt;
@@ -563,7 +563,7 @@ mod tests {
         // Construct a future single batch.
         let cfg = Arc::new(RollupConfig {
             max_sequencer_drift: 700,
-            hardforks: HardForkConfig { holocene_time: Some(0), ..Default::default() },
+            hardforks: LegacyHardforkConfig { holocene_time: Some(0), ..Default::default() }.into(),
             ..Default::default()
         });
         assert!(cfg.is_holocene_active(0));
@@ -600,7 +600,7 @@ mod tests {
     async fn test_holocene_add_batch_future() {
         // Construct a future single batch.
         let cfg = Arc::new(RollupConfig {
-            hardforks: HardForkConfig { holocene_time: Some(0), ..Default::default() },
+            hardforks: LegacyHardforkConfig { holocene_time: Some(0), ..Default::default() }.into(),
             ..Default::default()
         });
         assert!(cfg.is_holocene_active(0));
@@ -669,7 +669,7 @@ mod tests {
         // Construct a single batch with BatchValidity::Past.
         let cfg = Arc::new(RollupConfig {
             block_time: 2,
-            hardforks: HardForkConfig { holocene_time: Some(0), ..Default::default() },
+            hardforks: LegacyHardforkConfig { holocene_time: Some(0), ..Default::default() }.into(),
             ..Default::default()
         });
         assert!(cfg.is_holocene_active(0));
@@ -854,7 +854,7 @@ mod tests {
 
         // Construct a future single batch.
         let cfg = Arc::new(RollupConfig {
-            hardforks: HardForkConfig { holocene_time: Some(0), ..Default::default() },
+            hardforks: LegacyHardforkConfig { holocene_time: Some(0), ..Default::default() }.into(),
             ..Default::default()
         });
         assert!(cfg.is_holocene_active(0));
@@ -985,7 +985,7 @@ mod tests {
         let payload_block_hash =
             b256!("4444444444444444444444444444444444444444444444444444444444444444");
         let cfg = Arc::new(RollupConfig {
-            hardforks: HardForkConfig { delta_time: Some(0), ..Default::default() },
+            hardforks: LegacyHardforkConfig { delta_time: Some(0), ..Default::default() }.into(),
             block_time: 100,
             max_sequencer_drift: 10000000,
             seq_window_size: 10000000,

--- a/crates/consensus/derive/src/stages/batch/batch_stream.rs
+++ b/crates/consensus/derive/src/stages/batch/batch_stream.rs
@@ -265,7 +265,7 @@ mod tests {
     use alloy_eips::{BlockNumHash, NumHash};
     use alloy_primitives::{FixedBytes, b256};
     use base_alloy_consensus::BaseBlock;
-    use base_consensus_genesis::{ChainGenesis, HardForkConfig, SystemConfig};
+    use base_consensus_genesis::{ChainGenesis, HardForkConfig, LegacyHardforkConfig, SystemConfig};
     use base_protocol::{SingleBatch, SpanBatchElement};
     use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 
@@ -278,7 +278,7 @@ mod tests {
     #[tokio::test]
     async fn test_batch_stream_flush() {
         let config = Arc::new(RollupConfig {
-            hardforks: HardForkConfig { holocene_time: Some(0), ..Default::default() },
+            hardforks: LegacyHardforkConfig { holocene_time: Some(0), ..Default::default() }.into(),
             ..Default::default()
         });
         let prev = TestBatchStreamProvider::new(vec![]);
@@ -295,7 +295,7 @@ mod tests {
     #[tokio::test]
     async fn test_batch_stream_reset() {
         let config = Arc::new(RollupConfig {
-            hardforks: HardForkConfig { holocene_time: Some(0), ..Default::default() },
+            hardforks: LegacyHardforkConfig { holocene_time: Some(0), ..Default::default() }.into(),
             ..Default::default()
         });
         let prev = TestBatchStreamProvider::new(vec![]);
@@ -313,7 +313,7 @@ mod tests {
     #[tokio::test]
     async fn test_batch_stream_flush_channel() {
         let config = Arc::new(RollupConfig {
-            hardforks: HardForkConfig { holocene_time: Some(0), ..Default::default() },
+            hardforks: LegacyHardforkConfig { holocene_time: Some(0), ..Default::default() }.into(),
             ..Default::default()
         });
         let prev = TestBatchStreamProvider::new(vec![]);
@@ -336,7 +336,7 @@ mod tests {
 
         let data = vec![Ok(Batch::Single(SingleBatch::default()))];
         let config = Arc::new(RollupConfig {
-            hardforks: HardForkConfig { holocene_time: Some(100), ..Default::default() },
+            hardforks: LegacyHardforkConfig { holocene_time: Some(100), ..Default::default() }.into(),
             ..Default::default()
         });
         let prev = TestBatchStreamProvider::new(data);
@@ -369,11 +369,10 @@ mod tests {
         let data = vec![Ok(Batch::Span(mock_batch.clone()))];
         let config = Arc::new(RollupConfig {
             block_time: 2,
-            hardforks: HardForkConfig {
+            hardforks: LegacyHardforkConfig {
                 delta_time: Some(0),
                 holocene_time: Some(0),
-                ..Default::default()
-            },
+                ..Default::default() }.into(),
             ..Default::default()
         });
         let prev = TestBatchStreamProvider::new(data);
@@ -443,11 +442,10 @@ mod tests {
         let config = Arc::new(RollupConfig {
             seq_window_size: 100,
             block_time: 10,
-            hardforks: HardForkConfig {
+            hardforks: LegacyHardforkConfig {
                 delta_time: Some(0),
                 holocene_time: Some(0),
-                ..Default::default()
-            },
+                ..Default::default() }.into(),
             genesis: ChainGenesis {
                 l2: BlockNumHash { number: 40, hash: parent_hash },
                 ..Default::default()
@@ -516,7 +514,7 @@ mod tests {
     async fn test_single_batch_pass_through() {
         let data = vec![Ok(Batch::Single(SingleBatch::default()))];
         let config = Arc::new(RollupConfig {
-            hardforks: HardForkConfig { holocene_time: Some(0), ..Default::default() },
+            hardforks: LegacyHardforkConfig { holocene_time: Some(0), ..Default::default() }.into(),
             ..Default::default()
         });
         let prev = TestBatchStreamProvider::new(data);
@@ -546,7 +544,7 @@ mod tests {
         let data = vec![Ok(Batch::Span(mock_batch))];
 
         let config = Arc::new(RollupConfig {
-            hardforks: HardForkConfig { holocene_time: Some(0), ..Default::default() },
+            hardforks: LegacyHardforkConfig { holocene_time: Some(0), ..Default::default() }.into(),
             ..Default::default()
         });
         let prev = TestBatchStreamProvider::new(data);

--- a/crates/consensus/derive/src/stages/batch/batch_validator.rs
+++ b/crates/consensus/derive/src/stages/batch/batch_validator.rs
@@ -333,7 +333,7 @@ mod tests {
 
     use alloy_eips::BlockNumHash;
     use alloy_primitives::B256;
-    use base_consensus_genesis::{HardForkConfig, RollupConfig, SystemConfig};
+    use base_consensus_genesis::{HardForkConfig, LegacyHardforkConfig, RollupConfig, SystemConfig};
     use base_protocol::{Batch, BlockInfo, L2BlockInfo, SingleBatch, SpanBatch};
     use tracing::Level;
     use tracing_subscriber::layer::SubscriberExt;
@@ -493,7 +493,7 @@ mod tests {
     #[tokio::test]
     async fn test_batch_validator_next_batch_valid() {
         let cfg = Arc::new(RollupConfig {
-            hardforks: HardForkConfig { holocene_time: Some(0), ..Default::default() },
+            hardforks: LegacyHardforkConfig { holocene_time: Some(0), ..Default::default() }.into(),
             block_time: 2,
             max_sequencer_drift: 700,
             ..Default::default()

--- a/crates/consensus/derive/src/stages/channel/channel_assembler.rs
+++ b/crates/consensus/derive/src/stages/channel/channel_assembler.rs
@@ -223,7 +223,7 @@ where
 mod tests {
     use alloc::{sync::Arc, vec};
 
-    use base_consensus_genesis::{HardForkConfig, RollupConfig};
+    use base_consensus_genesis::{HardForkConfig, LegacyHardforkConfig, RollupConfig};
     use base_protocol::BlockInfo;
     use tracing::Level;
     use tracing_subscriber::layer::SubscriberExt;
@@ -385,7 +385,7 @@ mod tests {
         frames[1].data = vec![0; RollupConfig::MAX_RLP_BYTES_PER_CHANNEL_FJORD as usize];
         let mock = TestNextFrameProvider::new(frames.into_iter().rev().map(Ok).collect());
         let cfg = Arc::new(RollupConfig {
-            hardforks: HardForkConfig { fjord_time: Some(0), ..Default::default() },
+            hardforks: LegacyHardforkConfig { fjord_time: Some(0), ..Default::default() }.into(),
             ..Default::default()
         });
 

--- a/crates/consensus/derive/src/stages/channel/channel_bank.rs
+++ b/crates/consensus/derive/src/stages/channel/channel_bank.rs
@@ -275,7 +275,7 @@ mod tests {
     use alloc::{vec, vec::Vec};
 
     use alloy_eips::BlockNumHash;
-    use base_consensus_genesis::{HardForkConfig, SystemConfig};
+    use base_consensus_genesis::{HardForkConfig, LegacyHardforkConfig, SystemConfig};
     use tracing::Level;
     use tracing_subscriber::layer::SubscriberExt;
 
@@ -390,7 +390,7 @@ mod tests {
     fn test_read_channel_active() {
         let mock = TestNextFrameProvider::new(vec![]);
         let cfg = Arc::new(RollupConfig {
-            hardforks: HardForkConfig { canyon_time: Some(0), ..Default::default() },
+            hardforks: LegacyHardforkConfig { canyon_time: Some(0), ..Default::default() }.into(),
             ..Default::default()
         });
         let mut channel_bank = ChannelBank::new(cfg, mock);
@@ -607,7 +607,7 @@ mod tests {
         let mut frames = crate::frames!(0xFF, 0, vec![0xDD; 50], 100000);
         let mock = TestNextFrameProvider::new(vec![]);
         let cfg = Arc::new(RollupConfig {
-            hardforks: HardForkConfig { fjord_time: Some(0), ..Default::default() },
+            hardforks: LegacyHardforkConfig { fjord_time: Some(0), ..Default::default() }.into(),
             ..Default::default()
         });
         let mut channel_bank = ChannelBank::new(cfg, mock);

--- a/crates/consensus/derive/src/stages/channel/channel_provider.rs
+++ b/crates/consensus/derive/src/stages/channel/channel_provider.rs
@@ -202,7 +202,7 @@ mod tests {
     use alloc::{sync::Arc, vec};
 
     use alloy_eips::BlockNumHash;
-    use base_consensus_genesis::{HardForkConfig, RollupConfig, SystemConfig};
+    use base_consensus_genesis::{HardForkConfig, LegacyHardforkConfig, RollupConfig, SystemConfig};
     use base_protocol::BlockInfo;
 
     use crate::{
@@ -214,7 +214,7 @@ mod tests {
     fn test_channel_provider_assembler_active() {
         let provider = TestNextFrameProvider::new(vec![]);
         let cfg = Arc::new(RollupConfig {
-            hardforks: HardForkConfig { holocene_time: Some(0), ..Default::default() },
+            hardforks: LegacyHardforkConfig { holocene_time: Some(0), ..Default::default() }.into(),
             ..Default::default()
         });
         let mut channel_provider = ChannelProvider::new(cfg, provider);
@@ -264,7 +264,7 @@ mod tests {
     fn test_channel_provider_retain_current_assembler() {
         let provider = TestNextFrameProvider::new(vec![]);
         let cfg = Arc::new(RollupConfig {
-            hardforks: HardForkConfig { holocene_time: Some(0), ..Default::default() },
+            hardforks: LegacyHardforkConfig { holocene_time: Some(0), ..Default::default() }.into(),
             ..Default::default()
         });
         let mut channel_provider = ChannelProvider::new(cfg, provider);
@@ -290,7 +290,7 @@ mod tests {
     fn test_channel_provider_transition_stage() {
         let provider = TestNextFrameProvider::new(vec![]);
         let cfg = Arc::new(RollupConfig {
-            hardforks: HardForkConfig { holocene_time: Some(2), ..Default::default() },
+            hardforks: LegacyHardforkConfig { holocene_time: Some(2), ..Default::default() }.into(),
             ..Default::default()
         });
         let mut channel_provider = ChannelProvider::new(cfg, provider);
@@ -315,7 +315,7 @@ mod tests {
     fn test_channel_provider_transition_stage_backwards() {
         let provider = TestNextFrameProvider::new(vec![]);
         let cfg = Arc::new(RollupConfig {
-            hardforks: HardForkConfig { holocene_time: Some(2), ..Default::default() },
+            hardforks: LegacyHardforkConfig { holocene_time: Some(2), ..Default::default() }.into(),
             ..Default::default()
         });
         let mut channel_provider = ChannelProvider::new(cfg, provider);
@@ -383,7 +383,7 @@ mod tests {
         ];
         let provider = TestNextFrameProvider::new(frames.into_iter().rev().map(Ok).collect());
         let cfg = Arc::new(RollupConfig {
-            hardforks: HardForkConfig { holocene_time: Some(0), ..Default::default() },
+            hardforks: LegacyHardforkConfig { holocene_time: Some(0), ..Default::default() }.into(),
             ..Default::default()
         });
         let mut channel_provider = ChannelProvider::new(Arc::clone(&cfg), provider);

--- a/crates/consensus/derive/src/stages/channel/channel_reader.rs
+++ b/crates/consensus/derive/src/stages/channel/channel_reader.rs
@@ -202,7 +202,7 @@ mod tests {
     use alloc::vec;
 
     use alloy_eips::BlockNumHash;
-    use base_consensus_genesis::{HardForkConfig, SystemConfig};
+    use base_consensus_genesis::{HardForkConfig, LegacyHardforkConfig, SystemConfig};
 
     use super::*;
     use crate::{errors::PipelineErrorKind, test_utils::TestChannelReaderProvider};
@@ -284,7 +284,7 @@ mod tests {
     async fn test_flush_post_holocene() {
         let raw = new_compressed_batch_data();
         let config = Arc::new(RollupConfig {
-            hardforks: HardForkConfig { holocene_time: Some(0), ..Default::default() },
+            hardforks: LegacyHardforkConfig { holocene_time: Some(0), ..Default::default() }.into(),
             ..Default::default()
         });
         let mock = TestChannelReaderProvider::new(vec![Ok(Some(raw))]);

--- a/crates/consensus/derive/src/stages/frame_queue.rs
+++ b/crates/consensus/derive/src/stages/frame_queue.rs
@@ -222,7 +222,7 @@ pub(crate) mod tests {
     use alloc::vec;
 
     use alloy_eips::BlockNumHash;
-    use base_consensus_genesis::{HardForkConfig, SystemConfig};
+    use base_consensus_genesis::{HardForkConfig, LegacyHardforkConfig, SystemConfig};
 
     use super::*;
     use crate::test_utils::TestFrameQueueProvider;
@@ -328,7 +328,7 @@ pub(crate) mod tests {
             crate::frame!(0xFF, 2, vec![0xDD; 50], true),
         ];
         let cfg = RollupConfig {
-            hardforks: HardForkConfig { holocene_time: Some(0), ..Default::default() },
+            hardforks: LegacyHardforkConfig { holocene_time: Some(0), ..Default::default() }.into(),
             ..Default::default()
         };
         let assert = crate::test_utils::FrameQueueBuilder::new()
@@ -345,7 +345,7 @@ pub(crate) mod tests {
     async fn test_holocene_single_frame() {
         let frames = [crate::frame!(0xFF, 1, vec![0xDD; 50], true)];
         let cfg = RollupConfig {
-            hardforks: HardForkConfig { holocene_time: Some(0), ..Default::default() },
+            hardforks: LegacyHardforkConfig { holocene_time: Some(0), ..Default::default() }.into(),
             ..Default::default()
         };
         let assert = crate::test_utils::FrameQueueBuilder::new()
@@ -371,7 +371,7 @@ pub(crate) mod tests {
             crate::frame!(0xFF, 1, vec![0xDD; 50], true),
         ];
         let cfg = RollupConfig {
-            hardforks: HardForkConfig { holocene_time: Some(0), ..Default::default() },
+            hardforks: LegacyHardforkConfig { holocene_time: Some(0), ..Default::default() }.into(),
             ..Default::default()
         };
         let assert = crate::test_utils::FrameQueueBuilder::new()
@@ -394,7 +394,7 @@ pub(crate) mod tests {
             crate::frame!(0xEE, 4, vec![0xDD; 50], false), // Dropped
         ];
         let cfg = RollupConfig {
-            hardforks: HardForkConfig { holocene_time: Some(0), ..Default::default() },
+            hardforks: LegacyHardforkConfig { holocene_time: Some(0), ..Default::default() }.into(),
             ..Default::default()
         };
         let assert = crate::test_utils::FrameQueueBuilder::new()
@@ -420,7 +420,7 @@ pub(crate) mod tests {
             crate::frame!(0xFF, 1, vec![0xDD; 50], true),
         ];
         let cfg = RollupConfig {
-            hardforks: HardForkConfig { holocene_time: Some(0), ..Default::default() },
+            hardforks: LegacyHardforkConfig { holocene_time: Some(0), ..Default::default() }.into(),
             ..Default::default()
         };
         let assert = crate::test_utils::FrameQueueBuilder::new()
@@ -449,7 +449,7 @@ pub(crate) mod tests {
             crate::frame!(0xFF, 1, vec![0xDD; 50], true),
         ];
         let cfg = RollupConfig {
-            hardforks: HardForkConfig { holocene_time: Some(0), ..Default::default() },
+            hardforks: LegacyHardforkConfig { holocene_time: Some(0), ..Default::default() }.into(),
             ..Default::default()
         };
         let assert = crate::test_utils::FrameQueueBuilder::new()
@@ -475,7 +475,7 @@ pub(crate) mod tests {
             crate::frame!(0xFF, 2, vec![0xDD; 50], true),  // Dropped
         ];
         let cfg = RollupConfig {
-            hardforks: HardForkConfig { holocene_time: Some(0), ..Default::default() },
+            hardforks: LegacyHardforkConfig { holocene_time: Some(0), ..Default::default() }.into(),
             ..Default::default()
         };
         let assert = crate::test_utils::FrameQueueBuilder::new()
@@ -502,7 +502,7 @@ pub(crate) mod tests {
             crate::frame!(0xFF, 1, vec![0xDD; 50], true),
         ];
         let cfg = RollupConfig {
-            hardforks: HardForkConfig { holocene_time: Some(0), ..Default::default() },
+            hardforks: LegacyHardforkConfig { holocene_time: Some(0), ..Default::default() }.into(),
             ..Default::default()
         };
         let assert = crate::test_utils::FrameQueueBuilder::new()
@@ -529,7 +529,7 @@ pub(crate) mod tests {
             crate::frame!(0xFF, 1, vec![0xDD; 50], true),
         ];
         let cfg = RollupConfig {
-            hardforks: HardForkConfig { holocene_time: Some(0), ..Default::default() },
+            hardforks: LegacyHardforkConfig { holocene_time: Some(0), ..Default::default() }.into(),
             ..Default::default()
         };
         let assert = crate::test_utils::FrameQueueBuilder::new()
@@ -556,7 +556,7 @@ pub(crate) mod tests {
             crate::frame!(0xFF, 1, vec![0xDD; 50], true),
         ];
         let cfg = RollupConfig {
-            hardforks: HardForkConfig { holocene_time: Some(0), ..Default::default() },
+            hardforks: LegacyHardforkConfig { holocene_time: Some(0), ..Default::default() }.into(),
             ..Default::default()
         };
         let assert = crate::test_utils::FrameQueueBuilder::new()

--- a/crates/consensus/genesis/src/chain/hardfork.rs
+++ b/crates/consensus/genesis/src/chain/hardfork.rs
@@ -1,7 +1,10 @@
 //! Contains the hardfork configuration for the chain.
 
 use alloc::string::{String, ToString};
-use core::fmt::Display;
+use core::{
+    fmt::Display,
+    ops::{Deref, DerefMut},
+};
 
 use base_alloy_chains::BaseChainConfig;
 
@@ -12,7 +15,6 @@ use base_alloy_chains::BaseChainConfig;
 #[cfg_attr(feature = "serde", serde(deny_unknown_fields))]
 pub struct BaseHardforkConfig {
     /// `v1` sets the activation time for the Base V1 network upgrade.
-    /// Active if `v1` != None && L2 block timestamp >= `Some(v1)`, inactive otherwise.
     #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
     pub v1: Option<u64>,
 }
@@ -24,76 +26,125 @@ impl BaseHardforkConfig {
     }
 }
 
-/// Hardfork configuration.
-///
-/// See: <https://github.com/ethereum-optimism/superchain-registry/blob/8ff62ada16e14dd59d0fb94ffb47761c7fa96e01/ops/internal/config/chain.go#L102-L110>
+/// Legacy (OP-lineage) hardfork configuration. Frozen after Jovian.
 #[derive(Debug, Copy, Clone, Default, Hash, Eq, PartialEq)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "serde", serde(deny_unknown_fields))]
-pub struct HardForkConfig {
-    /// `regolith_time` sets the activation time of the Regolith network-upgrade:
-    /// a pre-mainnet Bedrock change that addresses findings of the Sherlock contest related to
-    /// deposit attributes. "Regolith" is the loose deposited rock that sits on top of Bedrock.
-    /// Active if `regolith_time` != None && L2 block timestamp >= `Some(regolith_time)`, inactive
-    /// otherwise.
-    #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
+pub struct LegacyHardforkConfig {
     pub regolith_time: Option<u64>,
-    /// `canyon_time` sets the activation time of the Canyon network upgrade.
-    /// Active if `canyon_time` != None && L2 block timestamp >= `Some(canyon_time)`, inactive
-    /// otherwise.
-    #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
     pub canyon_time: Option<u64>,
-    /// `delta_time` sets the activation time of the Delta network upgrade.
-    /// Active if `delta_time` != None && L2 block timestamp >= `Some(delta_time)`, inactive
-    /// otherwise.
-    #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
     pub delta_time: Option<u64>,
-    /// `ecotone_time` sets the activation time of the Ecotone network upgrade.
-    /// Active if `ecotone_time` != None && L2 block timestamp >= `Some(ecotone_time)`, inactive
-    /// otherwise.
-    #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
     pub ecotone_time: Option<u64>,
-    /// `fjord_time` sets the activation time of the Fjord network upgrade.
-    /// Active if `fjord_time` != None && L2 block timestamp >= `Some(fjord_time)`, inactive
-    /// otherwise.
-    #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
     pub fjord_time: Option<u64>,
-    /// `granite_time` sets the activation time for the Granite network upgrade.
-    /// Active if `granite_time` != None && L2 block timestamp >= `Some(granite_time)`, inactive
-    /// otherwise.
-    #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
     pub granite_time: Option<u64>,
-    /// `holocene_time` sets the activation time for the Holocene network upgrade.
-    /// Active if `holocene_time` != None && L2 block timestamp >= `Some(holocene_time)`, inactive
-    /// otherwise.
-    #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
     pub holocene_time: Option<u64>,
-    /// `pectra_blob_schedule_time` sets the activation time for the activation of the Pectra blob
-    /// fee schedule for the L1 block info transaction. This is an optional fork, only present
-    /// on Base sepolia chains that observed the L1 Pectra network upgrade with `op-node`
-    /// <=v1.11.1 sequencing the network.
-    ///
-    /// Active if `pectra_blob_schedule_time` != None && L2 block timestamp >=
-    /// `Some(pectra_blob_schedule_time)`, inactive otherwise.
-    #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
     pub pectra_blob_schedule_time: Option<u64>,
-    /// `isthmus_time` sets the activation time for the Isthmus network upgrade.
-    /// Active if `isthmus_time` != None && L2 block timestamp >= `Some(isthmus_time)`, inactive
-    /// otherwise.
-    #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
     pub isthmus_time: Option<u64>,
-    /// `jovian_time` sets the activation time for the Jovian network upgrade.
-    /// Active if `jovian_time` != None && L2 block timestamp >= `Some(jovian_time)`, inactive
-    /// otherwise.
-    #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
     pub jovian_time: Option<u64>,
-    /// `base` contains Base-specific hardfork activation times.
-    #[cfg_attr(
-        feature = "serde",
-        serde(default, skip_serializing_if = "BaseHardforkConfig::is_empty")
-    )]
+}
+
+/// Hardfork configuration.
+#[derive(Debug, Copy, Clone, Default, Hash, Eq, PartialEq)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+pub struct HardForkConfig {
+    pub legacy: LegacyHardforkConfig,
     pub base: BaseHardforkConfig,
+}
+
+impl Deref for HardForkConfig {
+    type Target = LegacyHardforkConfig;
+    fn deref(&self) -> &Self::Target { &self.legacy }
+}
+
+impl DerefMut for HardForkConfig {
+    fn deref_mut(&mut self) -> &mut Self::Target { &mut self.legacy }
+}
+
+impl From<LegacyHardforkConfig> for HardForkConfig {
+    fn from(legacy: LegacyHardforkConfig) -> Self {
+        Self { legacy, base: BaseHardforkConfig::default() }
+    }
+}
+
+#[cfg(feature = "serde")]
+#[derive(serde::Serialize, serde::Deserialize)]
+#[serde(deny_unknown_fields)]
+struct RawHardForkConfig {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    regolith_time: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    canyon_time: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    delta_time: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    ecotone_time: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    fjord_time: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    granite_time: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    holocene_time: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pectra_blob_schedule_time: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    isthmus_time: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    jovian_time: Option<u64>,
+    #[serde(default, skip_serializing_if = "BaseHardforkConfig::is_empty")]
+    base: BaseHardforkConfig,
+}
+
+#[cfg(feature = "serde")]
+impl From<&HardForkConfig> for RawHardForkConfig {
+    fn from(cfg: &HardForkConfig) -> Self {
+        Self {
+            regolith_time: cfg.legacy.regolith_time,
+            canyon_time: cfg.legacy.canyon_time,
+            delta_time: cfg.legacy.delta_time,
+            ecotone_time: cfg.legacy.ecotone_time,
+            fjord_time: cfg.legacy.fjord_time,
+            granite_time: cfg.legacy.granite_time,
+            holocene_time: cfg.legacy.holocene_time,
+            pectra_blob_schedule_time: cfg.legacy.pectra_blob_schedule_time,
+            isthmus_time: cfg.legacy.isthmus_time,
+            jovian_time: cfg.legacy.jovian_time,
+            base: cfg.base,
+        }
+    }
+}
+
+#[cfg(feature = "serde")]
+impl From<RawHardForkConfig> for HardForkConfig {
+    fn from(raw: RawHardForkConfig) -> Self {
+        Self {
+            legacy: LegacyHardforkConfig {
+                regolith_time: raw.regolith_time,
+                canyon_time: raw.canyon_time,
+                delta_time: raw.delta_time,
+                ecotone_time: raw.ecotone_time,
+                fjord_time: raw.fjord_time,
+                granite_time: raw.granite_time,
+                holocene_time: raw.holocene_time,
+                pectra_blob_schedule_time: raw.pectra_blob_schedule_time,
+                isthmus_time: raw.isthmus_time,
+                jovian_time: raw.jovian_time,
+            },
+            base: raw.base,
+        }
+    }
+}
+
+#[cfg(feature = "serde")]
+impl serde::Serialize for HardForkConfig {
+    fn serialize<S: serde::Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
+        RawHardForkConfig::from(self).serialize(s)
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<'de> serde::Deserialize<'de> for HardForkConfig {
+    fn deserialize<D: serde::Deserializer<'de>>(d: D) -> Result<Self, D::Error> {
+        RawHardForkConfig::deserialize(d).map(Into::into)
+    }
 }
 
 impl Display for HardForkConfig {
@@ -102,7 +153,6 @@ impl Display for HardForkConfig {
         fn fmt_time(t: Option<u64>) -> String {
             t.map(|t| t.to_string()).unwrap_or_else(|| "Not scheduled".to_string())
         }
-
         writeln!(f, "🍴 Scheduled Hardforks:")?;
         for (name, time) in self.iter() {
             writeln!(f, "-> {} Activation Time: {}", name, fmt_time(time))?;
@@ -112,19 +162,18 @@ impl Display for HardForkConfig {
 }
 
 impl HardForkConfig {
-    /// Returns an iterator of hardfork names -> their activation times (if scheduled.)
     pub fn iter(&self) -> impl Iterator<Item = (&'static str, Option<u64>)> {
         [
-            ("Regolith", self.regolith_time),
-            ("Canyon", self.canyon_time),
-            ("Delta", self.delta_time),
-            ("Ecotone", self.ecotone_time),
-            ("Fjord", self.fjord_time),
-            ("Granite", self.granite_time),
-            ("Holocene", self.holocene_time),
-            ("Pectra Blob Schedule", self.pectra_blob_schedule_time),
-            ("Isthmus", self.isthmus_time),
-            ("Jovian", self.jovian_time),
+            ("Regolith", self.legacy.regolith_time),
+            ("Canyon", self.legacy.canyon_time),
+            ("Delta", self.legacy.delta_time),
+            ("Ecotone", self.legacy.ecotone_time),
+            ("Fjord", self.legacy.fjord_time),
+            ("Granite", self.legacy.granite_time),
+            ("Holocene", self.legacy.holocene_time),
+            ("Pectra Blob Schedule", self.legacy.pectra_blob_schedule_time),
+            ("Isthmus", self.legacy.isthmus_time),
+            ("Jovian", self.legacy.jovian_time),
             ("Base V1", self.base.v1),
         ]
         .into_iter()
@@ -134,16 +183,18 @@ impl HardForkConfig {
 impl From<&BaseChainConfig> for HardForkConfig {
     fn from(cfg: &BaseChainConfig) -> Self {
         Self {
-            regolith_time: Some(cfg.regolith_timestamp),
-            canyon_time: Some(cfg.canyon_timestamp),
-            delta_time: Some(cfg.delta_timestamp),
-            ecotone_time: Some(cfg.ecotone_timestamp),
-            fjord_time: Some(cfg.fjord_timestamp),
-            granite_time: Some(cfg.granite_timestamp),
-            holocene_time: Some(cfg.holocene_timestamp),
-            pectra_blob_schedule_time: cfg.pectra_blob_schedule_timestamp,
-            isthmus_time: Some(cfg.isthmus_timestamp),
-            jovian_time: Some(cfg.jovian_timestamp),
+            legacy: LegacyHardforkConfig {
+                regolith_time: Some(cfg.regolith_timestamp),
+                canyon_time: Some(cfg.canyon_timestamp),
+                delta_time: Some(cfg.delta_timestamp),
+                ecotone_time: Some(cfg.ecotone_timestamp),
+                fjord_time: Some(cfg.fjord_timestamp),
+                granite_time: Some(cfg.granite_timestamp),
+                holocene_time: Some(cfg.holocene_timestamp),
+                pectra_blob_schedule_time: cfg.pectra_blob_schedule_timestamp,
+                isthmus_time: Some(cfg.isthmus_timestamp),
+                jovian_time: Some(cfg.jovian_timestamp),
+            },
             base: BaseHardforkConfig { v1: cfg.base_v1_timestamp },
         }
     }
@@ -153,6 +204,24 @@ impl From<&BaseChainConfig> for HardForkConfig {
 #[cfg(feature = "serde")]
 mod tests {
     use super::*;
+
+    fn make_hardfork() -> HardForkConfig {
+        HardForkConfig {
+            legacy: LegacyHardforkConfig {
+                regolith_time: None,
+                canyon_time: Some(1699981200),
+                delta_time: Some(1703203200),
+                ecotone_time: Some(1708534800),
+                fjord_time: Some(1716998400),
+                granite_time: Some(1723478400),
+                holocene_time: Some(1732633200),
+                pectra_blob_schedule_time: None,
+                isthmus_time: None,
+                jovian_time: None,
+            },
+            base: BaseHardforkConfig::default(),
+        }
+    }
 
     #[test]
     fn test_hardforks_deserialize_json() {
@@ -166,23 +235,8 @@ mod tests {
             "holocene_time":1732633200
         }
         "#;
-
-        let hardforks = HardForkConfig {
-            regolith_time: None,
-            canyon_time: Some(1699981200),
-            delta_time: Some(1703203200),
-            ecotone_time: Some(1708534800),
-            fjord_time: Some(1716998400),
-            granite_time: Some(1723478400),
-            holocene_time: Some(1732633200),
-            pectra_blob_schedule_time: None,
-            isthmus_time: None,
-            jovian_time: None,
-            base: BaseHardforkConfig::default(),
-        };
-
         let deserialized: HardForkConfig = serde_json::from_str(raw).unwrap();
-        assert_eq!(hardforks, deserialized);
+        assert_eq!(make_hardfork(), deserialized);
     }
 
     #[test]
@@ -198,7 +252,6 @@ mod tests {
             "new_field": 0
         }
         "#;
-
         let err = serde_json::from_str::<HardForkConfig>(raw).unwrap_err();
         assert_eq!(err.classify(), serde_json::error::Category::Data);
     }
@@ -206,42 +259,23 @@ mod tests {
     #[test]
     fn test_hardforks_deserialize_toml() {
         let raw: &str = r#"
-        canyon_time =  1699981200 # Tue 14 Nov 2023 17:00:00 UTC
-        delta_time =   1703203200 # Fri 22 Dec 2023 00:00:00 UTC
-        ecotone_time = 1708534800 # Wed 21 Feb 2024 17:00:00 UTC
-        fjord_time =   1716998400 # Wed 29 May 2024 16:00:00 UTC
-        granite_time = 1723478400 # Mon Aug 12 16:00:00 UTC 2024
-        holocene_time = 1732633200 # Tue Nov 26 15:00:00 UTC 2024
+        canyon_time =  1699981200
+        delta_time =   1703203200
+        ecotone_time = 1708534800
+        fjord_time =   1716998400
+        granite_time = 1723478400
+        holocene_time = 1732633200
         "#;
-
-        let hardforks = HardForkConfig {
-            regolith_time: None,
-            canyon_time: Some(1699981200),
-            delta_time: Some(1703203200),
-            ecotone_time: Some(1708534800),
-            fjord_time: Some(1716998400),
-            granite_time: Some(1723478400),
-            holocene_time: Some(1732633200),
-            pectra_blob_schedule_time: None,
-            isthmus_time: None,
-            jovian_time: None,
-            base: BaseHardforkConfig::default(),
-        };
-
         let deserialized: HardForkConfig = toml::from_str(raw).unwrap();
-        assert_eq!(hardforks, deserialized);
+        assert_eq!(make_hardfork(), deserialized);
     }
 
     #[test]
     fn test_hardforks_deserialize_new_field_fail_toml() {
         let raw: &str = r#"
-        canyon_time =  1699981200 # Tue 14 Nov 2023 17:00:00 UTC
-        delta_time =   1703203200 # Fri 22 Dec 2023 00:00:00 UTC
-        ecotone_time = 1708534800 # Wed 21 Feb 2024 17:00:00 UTC
-        fjord_time =   1716998400 # Wed 29 May 2024 16:00:00 UTC
-        granite_time = 1723478400 # Mon Aug 12 16:00:00 UTC 2024
-        holocene_time = 1732633200 # Tue Nov 26 15:00:00 UTC 2024
-        new_field_time = 1732633200 # Tue Nov 26 15:00:00 UTC 2024
+        canyon_time =  1699981200
+        holocene_time = 1732633200
+        new_field_time = 1732633200
         "#;
         toml::from_str::<HardForkConfig>(raw).unwrap_err();
     }
@@ -249,19 +283,20 @@ mod tests {
     #[test]
     fn test_hardforks_iter() {
         let hardforks = HardForkConfig {
-            regolith_time: Some(1),
-            canyon_time: Some(2),
-            delta_time: Some(3),
-            ecotone_time: Some(4),
-            fjord_time: Some(5),
-            granite_time: Some(6),
-            holocene_time: Some(7),
-            pectra_blob_schedule_time: Some(8),
-            isthmus_time: Some(9),
-            jovian_time: Some(10),
+            legacy: LegacyHardforkConfig {
+                regolith_time: Some(1),
+                canyon_time: Some(2),
+                delta_time: Some(3),
+                ecotone_time: Some(4),
+                fjord_time: Some(5),
+                granite_time: Some(6),
+                holocene_time: Some(7),
+                pectra_blob_schedule_time: Some(8),
+                isthmus_time: Some(9),
+                jovian_time: Some(10),
+            },
             base: BaseHardforkConfig { v1: Some(11) },
         };
-
         let mut iter = hardforks.iter();
         assert_eq!(iter.next(), Some(("Regolith", Some(1))));
         assert_eq!(iter.next(), Some(("Canyon", Some(2))));

--- a/crates/consensus/genesis/src/chain/mod.rs
+++ b/crates/consensus/genesis/src/chain/mod.rs
@@ -4,7 +4,7 @@ mod addresses;
 pub use addresses::AddressList;
 
 mod hardfork;
-pub use hardfork::{BaseHardforkConfig, HardForkConfig};
+pub use hardfork::{BaseHardforkConfig, HardForkConfig, LegacyHardforkConfig};
 
 mod roles;
 pub use roles::Roles;

--- a/crates/consensus/genesis/src/lib.rs
+++ b/crates/consensus/genesis/src/lib.rs
@@ -28,7 +28,7 @@ pub use system::{
 };
 
 mod chain;
-pub use chain::{AddressList, BaseHardforkConfig, HardForkConfig, Roles};
+pub use chain::{AddressList, BaseHardforkConfig, HardForkConfig, LegacyHardforkConfig, Roles};
 
 mod genesis;
 pub use genesis::ChainGenesis;

--- a/crates/consensus/genesis/src/rollup.rs
+++ b/crates/consensus/genesis/src/rollup.rs
@@ -5,7 +5,7 @@ use alloy_hardforks::{EthereumHardfork, EthereumHardforks, ForkCondition};
 use alloy_primitives::Address;
 use base_alloy_chains::{BaseChainConfig, BaseUpgrade, BaseUpgrades};
 
-use crate::{BaseFeeConfig, ChainGenesis, HardForkConfig};
+use crate::{BaseFeeConfig, ChainGenesis, HardForkConfig, LegacyHardforkConfig};
 
 /// The Rollup configuration.
 #[derive(Debug, Clone, Eq, PartialEq)]
@@ -605,7 +605,7 @@ mod tests {
 
     #[test]
     fn test_base_v1_active() {
-        use crate::BaseHardforkConfig;
+        use crate::{BaseHardforkConfig, LegacyHardforkConfig};
         let mut config = RollupConfig::default();
         assert!(!config.is_base_v1_active(0));
         config.hardforks.base = BaseHardforkConfig { v1: Some(10) };
@@ -619,19 +619,21 @@ mod tests {
 
     #[test]
     fn test_is_first_fork_block() {
-        use crate::BaseHardforkConfig;
+        use crate::{BaseHardforkConfig, LegacyHardforkConfig};
         let cfg = RollupConfig {
             hardforks: HardForkConfig {
-                regolith_time: Some(10),
-                canyon_time: Some(20),
-                delta_time: Some(30),
-                ecotone_time: Some(40),
-                fjord_time: Some(50),
-                granite_time: Some(60),
-                holocene_time: Some(70),
-                pectra_blob_schedule_time: Some(80),
-                isthmus_time: Some(90),
-                jovian_time: Some(100),
+                legacy: LegacyHardforkConfig {
+                    regolith_time: Some(10),
+                    canyon_time: Some(20),
+                    delta_time: Some(30),
+                    ecotone_time: Some(40),
+                    fjord_time: Some(50),
+                    granite_time: Some(60),
+                    holocene_time: Some(70),
+                    pectra_blob_schedule_time: Some(80),
+                    isthmus_time: Some(90),
+                    jovian_time: Some(100),
+                },
                 base: BaseHardforkConfig { v1: Some(110) },
             },
             block_time: 2,
@@ -698,7 +700,7 @@ mod tests {
     fn test_granite_channel_timeout() {
         let mut config = RollupConfig {
             channel_timeout: 100,
-            hardforks: HardForkConfig { granite_time: Some(10), ..Default::default() },
+            hardforks: LegacyHardforkConfig { granite_time: Some(10), ..Default::default() }.into(),
             ..Default::default()
         };
         assert_eq!(config.channel_timeout(0), 100);
@@ -805,11 +807,14 @@ mod tests {
             l1_chain_id: 3151908,
             l2_chain_id: Chain::from_id(1337),
             hardforks: HardForkConfig {
-                regolith_time: Some(0),
-                canyon_time: Some(0),
-                delta_time: Some(0),
-                ecotone_time: Some(0),
-                fjord_time: Some(0),
+                legacy: LegacyHardforkConfig {
+                    regolith_time: Some(0),
+                    canyon_time: Some(0),
+                    delta_time: Some(0),
+                    ecotone_time: Some(0),
+                    fjord_time: Some(0),
+                    ..Default::default()
+                },
                 ..Default::default()
             },
             batch_inbox_address: address!("ff00000000000000000000000000000000042069"),

--- a/crates/consensus/genesis/src/system/config.rs
+++ b/crates/consensus/genesis/src/system/config.rs
@@ -229,7 +229,7 @@ mod tests {
     use alloy_primitives::{B256, LogData, address, b256, hex};
 
     use super::*;
-    use crate::{CONFIG_UPDATE_EVENT_VERSION_0, HardForkConfig};
+    use crate::{CONFIG_UPDATE_EVENT_VERSION_0, HardForkConfig, LegacyHardforkConfig};
 
     const BATCHER_UPDATE_TYPE: B256 =
         b256!("0000000000000000000000000000000000000000000000000000000000000000");
@@ -327,7 +327,7 @@ mod tests {
     #[test]
     fn test_eip_1559_params_from_system_config_some() {
         let rollup_config = RollupConfig {
-            hardforks: HardForkConfig { holocene_time: Some(0), ..Default::default() },
+            hardforks: LegacyHardforkConfig { holocene_time: Some(0), ..Default::default() }.into(),
             ..Default::default()
         };
         let sys_config = SystemConfig {
@@ -342,7 +342,7 @@ mod tests {
     #[test]
     fn test_eip_1559_params_from_system_config() {
         let rollup_config = RollupConfig {
-            hardforks: HardForkConfig { holocene_time: Some(0), ..Default::default() },
+            hardforks: LegacyHardforkConfig { holocene_time: Some(0), ..Default::default() }.into(),
             ..Default::default()
         };
         let sys_config = SystemConfig {
@@ -357,7 +357,7 @@ mod tests {
     #[test]
     fn test_default_eip_1559_params_from_system_config() {
         let rollup_config = RollupConfig {
-            hardforks: HardForkConfig { holocene_time: Some(0), ..Default::default() },
+            hardforks: LegacyHardforkConfig { holocene_time: Some(0), ..Default::default() }.into(),
             ..Default::default()
         };
         let sys_config = SystemConfig {
@@ -383,7 +383,7 @@ mod tests {
     #[test]
     fn test_default_eip_1559_params_first_block_holocene() {
         let rollup_config = RollupConfig {
-            hardforks: HardForkConfig { holocene_time: Some(2), ..Default::default() },
+            hardforks: LegacyHardforkConfig { holocene_time: Some(2), ..Default::default() }.into(),
             ..Default::default()
         };
         let sys_config = SystemConfig {

--- a/crates/consensus/protocol/src/batch/reader.rs
+++ b/crates/consensus/protocol/src/batch/reader.rs
@@ -182,7 +182,7 @@ mod tests {
             BatchReader::new(raw, RollupConfig::MAX_RLP_BYTES_PER_CHANNEL_FJORD as usize);
         reader
             .next_batch(&RollupConfig {
-                hardforks: HardForkConfig { fjord_time: Some(0), ..Default::default() },
+                hardforks: LegacyHardforkConfig { fjord_time: Some(0), ..Default::default() }.into(),
                 ..Default::default()
             })
             .unwrap();

--- a/crates/consensus/protocol/src/batch/single.rs
+++ b/crates/consensus/protocol/src/batch/single.rs
@@ -264,7 +264,7 @@ mod tests {
     #[test]
     fn test_check_batch_timestamp_holocene_active_drop() {
         let cfg = RollupConfig {
-            hardforks: HardForkConfig { holocene_time: Some(0), ..Default::default() },
+            hardforks: LegacyHardforkConfig { holocene_time: Some(0), ..Default::default() }.into(),
             ..Default::default()
         };
         let l2_safe_head = L2BlockInfo {
@@ -282,7 +282,7 @@ mod tests {
     #[test]
     fn test_check_batch_timestamp_holocene_active_past() {
         let cfg = RollupConfig {
-            hardforks: HardForkConfig { holocene_time: Some(0), ..Default::default() },
+            hardforks: LegacyHardforkConfig { holocene_time: Some(0), ..Default::default() }.into(),
             ..Default::default()
         };
         let l2_safe_head = L2BlockInfo {
@@ -509,7 +509,7 @@ mod tests {
         // Notice: Isthmus is active.
         let cfg = RollupConfig {
             max_sequencer_drift: 1,
-            hardforks: HardForkConfig { isthmus_time: Some(0), ..Default::default() },
+            hardforks: LegacyHardforkConfig { isthmus_time: Some(0), ..Default::default() }.into(),
             ..Default::default()
         };
         let l1_blocks = vec![BlockInfo::default(), BlockInfo::default()];
@@ -619,7 +619,7 @@ mod tests {
         let cfg = RollupConfig {
             max_sequencer_drift: 1,
             block_time: 1,
-            hardforks: HardForkConfig { jovian_time: Some(1), ..Default::default() },
+            hardforks: LegacyHardforkConfig { jovian_time: Some(1), ..Default::default() }.into(),
             ..Default::default()
         };
         let l1_blocks = vec![BlockInfo::default(), BlockInfo::default()];

--- a/crates/consensus/protocol/src/batch/span.rs
+++ b/crates/consensus/protocol/src/batch/span.rs
@@ -983,7 +983,7 @@ mod tests {
         let _guard = tracing::subscriber::set_default(subscriber);
 
         let cfg = RollupConfig {
-            hardforks: HardForkConfig { delta_time: Some(10), ..Default::default() },
+            hardforks: LegacyHardforkConfig { delta_time: Some(10), ..Default::default() }.into(),
             ..Default::default()
         };
         let block = BlockInfo { number: 10, timestamp: 9, ..Default::default() };
@@ -1015,7 +1015,7 @@ mod tests {
         let _guard = tracing::subscriber::set_default(subscriber);
 
         let cfg = RollupConfig {
-            hardforks: HardForkConfig { delta_time: Some(0), ..Default::default() },
+            hardforks: LegacyHardforkConfig { delta_time: Some(0), ..Default::default() }.into(),
             block_time: 10,
             ..Default::default()
         };
@@ -1048,7 +1048,7 @@ mod tests {
         let _guard = tracing::subscriber::set_default(subscriber);
 
         let cfg = RollupConfig {
-            hardforks: HardForkConfig { delta_time: Some(0), ..Default::default() },
+            hardforks: LegacyHardforkConfig { delta_time: Some(0), ..Default::default() }.into(),
             block_time: 10,
             ..Default::default()
         };
@@ -1079,7 +1079,7 @@ mod tests {
         let _guard = tracing::subscriber::set_default(subscriber);
 
         let cfg = RollupConfig {
-            hardforks: HardForkConfig { delta_time: Some(0), ..Default::default() },
+            hardforks: LegacyHardforkConfig { delta_time: Some(0), ..Default::default() }.into(),
             block_time: 10,
             max_sequencer_drift: 1000,
             ..Default::default()
@@ -1145,7 +1145,7 @@ mod tests {
         let _guard = tracing::subscriber::set_default(subscriber);
 
         let cfg = RollupConfig {
-            hardforks: HardForkConfig { delta_time: Some(0), ..Default::default() },
+            hardforks: LegacyHardforkConfig { delta_time: Some(0), ..Default::default() }.into(),
             block_time: 10,
             max_sequencer_drift: 1000,
             ..Default::default()
@@ -1224,7 +1224,7 @@ mod tests {
         let _guard = tracing::subscriber::set_default(subscriber);
 
         let cfg = RollupConfig {
-            hardforks: HardForkConfig { delta_time: Some(0), ..Default::default() },
+            hardforks: LegacyHardforkConfig { delta_time: Some(0), ..Default::default() }.into(),
             block_time: 10,
             ..Default::default()
         };
@@ -1262,7 +1262,7 @@ mod tests {
         let _guard = tracing::subscriber::set_default(subscriber);
 
         let cfg = RollupConfig {
-            hardforks: HardForkConfig { delta_time: Some(0), ..Default::default() },
+            hardforks: LegacyHardforkConfig { delta_time: Some(0), ..Default::default() }.into(),
             block_time: 10,
             ..Default::default()
         };
@@ -1294,7 +1294,7 @@ mod tests {
         let _guard = tracing::subscriber::set_default(subscriber);
 
         let cfg = RollupConfig {
-            hardforks: HardForkConfig { delta_time: Some(0), ..Default::default() },
+            hardforks: LegacyHardforkConfig { delta_time: Some(0), ..Default::default() }.into(),
             block_time: 10,
             ..Default::default()
         };
@@ -1326,7 +1326,7 @@ mod tests {
         let _guard = tracing::subscriber::set_default(subscriber);
 
         let cfg = RollupConfig {
-            hardforks: HardForkConfig { delta_time: Some(0), ..Default::default() },
+            hardforks: LegacyHardforkConfig { delta_time: Some(0), ..Default::default() }.into(),
             block_time: 10,
             ..Default::default()
         };
@@ -1361,7 +1361,7 @@ mod tests {
         let _guard = tracing::subscriber::set_default(subscriber);
 
         let cfg = RollupConfig {
-            hardforks: HardForkConfig { delta_time: Some(0), ..Default::default() },
+            hardforks: LegacyHardforkConfig { delta_time: Some(0), ..Default::default() }.into(),
             block_time: 10,
             ..Default::default()
         };
@@ -1413,7 +1413,7 @@ mod tests {
         let _guard = tracing::subscriber::set_default(subscriber);
 
         let cfg = RollupConfig {
-            hardforks: HardForkConfig { delta_time: Some(0), ..Default::default() },
+            hardforks: LegacyHardforkConfig { delta_time: Some(0), ..Default::default() }.into(),
             block_time: 10,
             ..Default::default()
         };
@@ -1462,7 +1462,7 @@ mod tests {
 
         let cfg = RollupConfig {
             seq_window_size: 100,
-            hardforks: HardForkConfig { delta_time: Some(0), ..Default::default() },
+            hardforks: LegacyHardforkConfig { delta_time: Some(0), ..Default::default() }.into(),
             block_time: 10,
             ..Default::default()
         };
@@ -1517,7 +1517,7 @@ mod tests {
 
         let cfg = RollupConfig {
             seq_window_size: 100,
-            hardforks: HardForkConfig { delta_time: Some(0), ..Default::default() },
+            hardforks: LegacyHardforkConfig { delta_time: Some(0), ..Default::default() }.into(),
             block_time: 10,
             ..Default::default()
         };
@@ -1576,7 +1576,7 @@ mod tests {
 
         let cfg = RollupConfig {
             seq_window_size: 100,
-            hardforks: HardForkConfig { delta_time: Some(0), ..Default::default() },
+            hardforks: LegacyHardforkConfig { delta_time: Some(0), ..Default::default() }.into(),
             block_time: 10,
             ..Default::default()
         };
@@ -1630,7 +1630,7 @@ mod tests {
 
         let cfg = RollupConfig {
             seq_window_size: 100,
-            hardforks: HardForkConfig { delta_time: Some(0), ..Default::default() },
+            hardforks: LegacyHardforkConfig { delta_time: Some(0), ..Default::default() }.into(),
             block_time: 10,
             ..Default::default()
         };
@@ -1688,7 +1688,7 @@ mod tests {
         let cfg = RollupConfig {
             seq_window_size: 100,
             max_sequencer_drift: 0,
-            hardforks: HardForkConfig { delta_time: Some(0), ..Default::default() },
+            hardforks: LegacyHardforkConfig { delta_time: Some(0), ..Default::default() }.into(),
             block_time: 10,
             ..Default::default()
         };
@@ -1741,7 +1741,7 @@ mod tests {
         let cfg = RollupConfig {
             seq_window_size: 100,
             max_sequencer_drift: 0,
-            hardforks: HardForkConfig { delta_time: Some(0), ..Default::default() },
+            hardforks: LegacyHardforkConfig { delta_time: Some(0), ..Default::default() }.into(),
             block_time: 10,
             ..Default::default()
         };
@@ -1799,7 +1799,7 @@ mod tests {
         let cfg = RollupConfig {
             seq_window_size: 100,
             max_sequencer_drift: 0,
-            hardforks: HardForkConfig { delta_time: Some(0), ..Default::default() },
+            hardforks: LegacyHardforkConfig { delta_time: Some(0), ..Default::default() }.into(),
             block_time: 10,
             ..Default::default()
         };
@@ -1863,7 +1863,7 @@ mod tests {
         let cfg = RollupConfig {
             seq_window_size: 100,
             max_sequencer_drift: 100,
-            hardforks: HardForkConfig { delta_time: Some(0), ..Default::default() },
+            hardforks: LegacyHardforkConfig { delta_time: Some(0), ..Default::default() }.into(),
             block_time: 10,
             ..Default::default()
         };
@@ -1931,7 +1931,7 @@ mod tests {
         let cfg = RollupConfig {
             seq_window_size: 100,
             max_sequencer_drift: 100,
-            hardforks: HardForkConfig { delta_time: Some(0), ..Default::default() },
+            hardforks: LegacyHardforkConfig { delta_time: Some(0), ..Default::default() }.into(),
             block_time: 10,
             ..Default::default()
         };
@@ -1993,7 +1993,7 @@ mod tests {
         let cfg = RollupConfig {
             seq_window_size: 100,
             max_sequencer_drift: 100,
-            hardforks: HardForkConfig { delta_time: Some(0), ..Default::default() },
+            hardforks: LegacyHardforkConfig { delta_time: Some(0), ..Default::default() }.into(),
             block_time: 10,
             ..Default::default()
         };
@@ -2058,7 +2058,7 @@ mod tests {
 
         let cfg = RollupConfig {
             seq_window_size: 100,
-            hardforks: HardForkConfig { delta_time: Some(0), ..Default::default() },
+            hardforks: LegacyHardforkConfig { delta_time: Some(0), ..Default::default() }.into(),
             block_time: 10,
             ..Default::default()
         };
@@ -2114,7 +2114,7 @@ mod tests {
 
         let cfg = RollupConfig {
             seq_window_size: 100,
-            hardforks: HardForkConfig { delta_time: Some(0), ..Default::default() },
+            hardforks: LegacyHardforkConfig { delta_time: Some(0), ..Default::default() }.into(),
             block_time: 10,
             ..Default::default()
         };
@@ -2185,7 +2185,7 @@ mod tests {
             b256!("0e2ee9abe94ee4514b170d7039d8151a7469d434a8575dbab5bd4187a27732dd");
         let cfg = RollupConfig {
             seq_window_size: 100,
-            hardforks: HardForkConfig { delta_time: Some(0), ..Default::default() },
+            hardforks: LegacyHardforkConfig { delta_time: Some(0), ..Default::default() }.into(),
             block_time: 10,
             genesis: ChainGenesis {
                 l2: BlockNumHash { number: 41, hash: payload_block_hash },
@@ -2255,7 +2255,7 @@ mod tests {
         let parent_hash = b256!("1111111111111111111111111111111111111111000000000000000000000000");
         let cfg = RollupConfig {
             seq_window_size: 100,
-            hardforks: HardForkConfig { delta_time: Some(0), ..Default::default() },
+            hardforks: LegacyHardforkConfig { delta_time: Some(0), ..Default::default() }.into(),
             block_time: 10,
             genesis: ChainGenesis {
                 l2: BlockNumHash { number: 40, hash: parent_hash },
@@ -2326,7 +2326,7 @@ mod tests {
             b256!("0e2ee9abe94ee4514b170d7039d8151a7469d434a8575dbab5bd4187a27732dd");
         let cfg = RollupConfig {
             seq_window_size: 100,
-            hardforks: HardForkConfig { delta_time: Some(0), ..Default::default() },
+            hardforks: LegacyHardforkConfig { delta_time: Some(0), ..Default::default() }.into(),
             block_time: 10,
             genesis: ChainGenesis {
                 l2: BlockNumHash { number: 41, hash: payload_block_hash },

--- a/crates/consensus/protocol/src/info/variant.rs
+++ b/crates/consensus/protocol/src/info/variant.rs
@@ -748,7 +748,7 @@ mod tests {
     #[test]
     fn test_try_new_ecotone() {
         let rollup_config = RollupConfig {
-            hardforks: HardForkConfig { ecotone_time: Some(1), ..Default::default() },
+            hardforks: LegacyHardforkConfig { ecotone_time: Some(1), ..Default::default() }.into(),
             ..Default::default()
         };
         let l1_config = L1Config::sepolia();
@@ -807,11 +807,10 @@ mod tests {
         #[case] use_wrong_params: bool,
     ) {
         let rollup_config = RollupConfig {
-            hardforks: HardForkConfig {
+            hardforks: LegacyHardforkConfig {
                 ecotone_time: Some(1),
                 pectra_blob_schedule_time: Some(2),
-                ..Default::default()
-            },
+                ..Default::default() }.into(),
             ..Default::default()
         };
         let mut l1_genesis: ChainConfig = L1Config::sepolia().into();
@@ -878,11 +877,10 @@ mod tests {
     #[test]
     fn test_try_new_isthmus_before_pectra_blob_schedule() {
         let rollup_config = RollupConfig {
-            hardforks: HardForkConfig {
+            hardforks: LegacyHardforkConfig {
                 isthmus_time: Some(1),
                 pectra_blob_schedule_time: Some(1713121140),
-                ..Default::default()
-            },
+                ..Default::default() }.into(),
             ..Default::default()
         };
         let l1_config = L1Config::sepolia();
@@ -951,7 +949,7 @@ mod tests {
     #[test]
     fn test_try_new_isthmus() {
         let rollup_config = RollupConfig {
-            hardforks: HardForkConfig { isthmus_time: Some(1), ..Default::default() },
+            hardforks: LegacyHardforkConfig { isthmus_time: Some(1), ..Default::default() }.into(),
             ..Default::default()
         };
         let l1_config = L1Config::sepolia();
@@ -1016,7 +1014,7 @@ mod tests {
     #[test]
     fn test_try_new_with_deposit_tx() {
         let rollup_config = RollupConfig {
-            hardforks: HardForkConfig { isthmus_time: Some(1), ..Default::default() },
+            hardforks: LegacyHardforkConfig { isthmus_time: Some(1), ..Default::default() }.into(),
             ..Default::default()
         };
         let l1_config = L1Config::sepolia();

--- a/crates/consensus/protocol/src/utils.rs
+++ b/crates/consensus/protocol/src/utils.rs
@@ -307,7 +307,7 @@ mod tests {
                 l2: BlockNumHash { hash: block_hash, ..Default::default() },
                 ..Default::default()
             },
-            hardforks: HardForkConfig { holocene_time: Some(0), ..Default::default() },
+            hardforks: LegacyHardforkConfig { holocene_time: Some(0), ..Default::default() }.into(),
             ..Default::default()
         };
         assert!(rollup_config.is_holocene_active(block.header.timestamp));
@@ -356,11 +356,10 @@ mod tests {
                 l2: BlockNumHash { hash: block_hash, ..Default::default() },
                 ..Default::default()
             },
-            hardforks: HardForkConfig {
+            hardforks: LegacyHardforkConfig {
                 holocene_time: Some(0),
                 isthmus_time: Some(0),
-                ..Default::default()
-            },
+                ..Default::default() }.into(),
             ..Default::default()
         };
         assert!(rollup_config.is_holocene_active(block.header.timestamp));

--- a/crates/execution/revm/src/rollup_config.rs
+++ b/crates/execution/revm/src/rollup_config.rs
@@ -43,7 +43,7 @@ mod tests {
     #[test]
     fn test_spec_id() {
         let mut config = RollupConfig {
-            hardforks: HardForkConfig { regolith_time: Some(10), ..Default::default() },
+            hardforks: LegacyHardforkConfig { regolith_time: Some(10), ..Default::default() }.into(),
             ..Default::default()
         };
         assert_eq!(config.spec_id(0), OpSpecId::BEDROCK);


### PR DESCRIPTION
## Summary

Collapse the frozen OP-lineage fields (`regolith_time` through `jovian_time`, plus `pectra_blob_schedule_time`) into a new `LegacyHardforkConfig` struct, mirroring how `BaseHardforkConfig` already groups Base-specific forks.

## Design

- **`LegacyHardforkConfig`** — new public struct holding the 10 frozen OP Stack lineage fork activation timestamps
- **`HardForkConfig`** — now composes `legacy: LegacyHardforkConfig` + `base: BaseHardforkConfig`
- **`Deref`/`DerefMut`** targeting `LegacyHardforkConfig` so existing production code accessing `config.hardforks.holocene_time` compiles unchanged
- **`From<LegacyHardforkConfig>`** for ergonomic `.into()` construction at call sites that only set legacy fields
- **Private `RawHardForkConfig`** serde bridge preserves flat wire format with `deny_unknown_fields`, working around the known serde `#[serde(flatten)]` + `deny_unknown_fields` incompatibility

## Changes

- 22 files changed across 5 crates (`genesis`, `derive`, `protocol`, `execution/revm`, `batcher/encoder`)
- ~90 call sites updated to use `LegacyHardforkConfig { ... }.into()`
- Exports updated in `chain/mod.rs` and `lib.rs`
- All existing serde tests pass without modification

Closes #1917