### PR TITLE
fix(common): Rename Hardfork Files To Upgrade

### DIFF
--- a/crates/common/chains/README.md
+++ b/crates/common/chains/README.md
@@ -5,7 +5,7 @@ Single source of truth for Base chain configuration and network upgrade bindings
 ## Overview
 
 Defines `BaseChainConfig` — a compile-time struct containing all chain parameters (chain IDs,
-hardfork timestamps, genesis data, base fee params, contract addresses, and embedded genesis JSON).
+upgrade timestamps, genesis data, base fee params, contract addresses, and embedded genesis JSON).
 Const instances `BASE_MAINNET`, `BASE_SEPOLIA`, and `BASE_DEVNET_0_SEPOLIA_DEV_0` eliminate
 duplicated configuration across the workspace.
 

--- a/crates/common/chains/src/chain.rs
+++ b/crates/common/chains/src/chain.rs
@@ -4,7 +4,7 @@ use core::ops::Index;
 use BaseUpgrade::{
     Bedrock, Canyon, Ecotone, Fjord, Granite, Holocene, Isthmus, Jovian, Regolith, V1,
 };
-// Production imports for hardfork implementations
+// Production imports for upgrade implementations
 use EthereumHardfork::{
     Amsterdam, ArrowGlacier, Berlin, Bpo1, Bpo2, Bpo3, Bpo4, Bpo5, Byzantium, Cancun,
     Constantinople, Dao, Frontier, GrayGlacier, Homestead, Istanbul, London, MuirGlacier, Osaka,
@@ -28,7 +28,7 @@ use crate::{BaseUpgrade, BaseUpgrades};
 /// around.
 #[derive(Debug, Clone)]
 pub struct BaseChainUpgrades {
-    /// Ordered list of hardfork activations.
+    /// Ordered list of upgrade activations.
     forks: Vec<(BaseUpgrade, ForkCondition)>,
 }
 

--- a/crates/common/chains/src/lib.rs
+++ b/crates/common/chains/src/lib.rs
@@ -8,11 +8,11 @@ extern crate alloc;
 mod config;
 pub use config::BaseChainConfig;
 
-mod hardfork;
-pub use hardfork::BaseUpgrade;
+mod upgrade;
+pub use upgrade::BaseUpgrade;
 
-mod hardforks;
-pub use hardforks::BaseUpgrades;
+mod upgrades;
+pub use upgrades::BaseUpgrades;
 
 mod chain;
 pub use chain::BaseChainUpgrades;

--- a/crates/common/chains/src/upgrade.rs
+++ b/crates/common/chains/src/upgrade.rs
@@ -5,7 +5,7 @@ use crate::BaseChainConfig;
 hardfork!(
     /// The name of a Base network upgrade.
     ///
-    /// When building a list of hardforks for a chain, it's still expected to zip with
+    /// When building a list of upgrades for a chain, it's still expected to zip with
     /// [`EthereumHardfork`](alloy_hardforks::EthereumHardfork).
     #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
     #[derive(Default)]
@@ -35,7 +35,7 @@ hardfork!(
 );
 
 impl BaseUpgrade {
-    /// Returns the list of hardforks with their activation conditions for the given chain config.
+    /// Returns the list of upgrades with their activation conditions for the given chain config.
     pub const fn forks_for(cfg: &BaseChainConfig) -> [(Self, ForkCondition); 10] {
         let v1 = match cfg.base_v1_timestamp {
             Some(ts) => ForkCondition::Timestamp(ts),
@@ -55,27 +55,27 @@ impl BaseUpgrade {
         ]
     }
 
-    /// Base mainnet list of hardforks.
+    /// Base mainnet list of upgrades.
     pub const fn mainnet() -> [(Self, ForkCondition); 10] {
         Self::forks_for(BaseChainConfig::mainnet())
     }
 
-    /// Base Sepolia list of hardforks.
+    /// Base Sepolia list of upgrades.
     pub const fn sepolia() -> [(Self, ForkCondition); 10] {
         Self::forks_for(BaseChainConfig::sepolia())
     }
 
-    /// Devnet list of hardforks.
+    /// Devnet list of upgrades.
     pub const fn devnet() -> [(Self, ForkCondition); 10] {
         Self::forks_for(BaseChainConfig::devnet())
     }
 
-    /// Base devnet-0-sepolia-dev-0 list of hardforks.
+    /// Base devnet-0-sepolia-dev-0 list of upgrades.
     pub const fn base_devnet_0_sepolia_dev_0() -> [(Self, ForkCondition); 10] {
         Self::forks_for(BaseChainConfig::alpha())
     }
 
-    /// Base Zeronet list of hardforks.
+    /// Base Zeronet list of upgrades.
     pub const fn zeronet() -> [(Self, ForkCondition); 10] {
         Self::forks_for(BaseChainConfig::zeronet())
     }
@@ -97,12 +97,12 @@ mod tests {
     extern crate alloc;
 
     #[test]
-    fn check_base_hardfork_from_str() {
-        let hardfork_str = [
+    fn check_base_upgrade_from_str() {
+        let upgrade_str = [
             "beDrOck", "rEgOlITH", "cAnYoN", "eCoToNe", "FJorD", "GRaNiTe", "hOlOcEnE", "isthMUS",
             "jOvIaN", "v1",
         ];
-        let expected_hardforks = [
+        let expected_upgrades = [
             BaseUpgrade::Bedrock,
             BaseUpgrade::Regolith,
             BaseUpgrade::Canyon,
@@ -115,15 +115,15 @@ mod tests {
             BaseUpgrade::V1,
         ];
 
-        let hardforks: alloc::vec::Vec<BaseUpgrade> =
-            hardfork_str.iter().map(|h| BaseUpgrade::from_str(h).unwrap()).collect();
+        let upgrades: alloc::vec::Vec<BaseUpgrade> =
+            upgrade_str.iter().map(|h| BaseUpgrade::from_str(h).unwrap()).collect();
 
-        assert_eq!(hardforks, expected_hardforks);
+        assert_eq!(upgrades, expected_upgrades);
     }
 
     #[test]
-    fn check_nonexistent_hardfork_from_str() {
-        assert!(BaseUpgrade::from_str("not a hardfork").is_err());
+    fn check_nonexistent_upgrade_from_str() {
+        assert!(BaseUpgrade::from_str("not an upgrade").is_err());
     }
 
     /// Reverse lookup to find the upgrade given a chain ID and block timestamp.

--- a/crates/common/chains/src/upgrades.rs
+++ b/crates/common/chains/src/upgrades.rs
@@ -2,7 +2,7 @@ use alloy_hardforks::{EthereumHardforks, ForkCondition};
 
 use crate::BaseUpgrade;
 
-/// Extends [`EthereumHardforks`] with Base hardfork helper methods.
+/// Extends [`EthereumHardforks`] with Base upgrade helper methods.
 #[auto_impl::auto_impl(&, Arc)]
 pub trait BaseUpgrades: EthereumHardforks {
     /// Retrieves [`ForkCondition`] by a [`BaseUpgrade`]. If `fork` is not present, returns

--- a/docs/guides/UPGRADES.md
+++ b/docs/guides/UPGRADES.md
@@ -20,7 +20,7 @@ Upgrade activation flows through three layers:
 
 ### 1. Add the variant to the `BaseUpgrade` enum
 
-**File:** [`crates/common/chains/src/hardfork.rs`](../../crates/common/chains/src/hardfork.rs)
+**File:** [`crates/common/chains/src/upgrade.rs`](../../crates/common/chains/src/upgrade.rs)
 
 Inside the `hardfork!` macro, append the new variant after the current last entry:
 
@@ -196,7 +196,7 @@ For **cascading** upgrades, replace the previous arm's `unwrap_or(ForkCondition:
 
 ### 5. Add the trait method
 
-**File:** [`crates/common/chains/src/hardforks.rs`](../../crates/common/chains/src/hardforks.rs)
+**File:** [`crates/common/chains/src/upgrades.rs`](../../crates/common/chains/src/upgrades.rs)
 
 ```rust
 /// Returns `true` if [`V1`](BaseUpgrade::V1) is active at given block timestamp.
@@ -210,7 +210,7 @@ fn is_base_v1_active_at_timestamp(&self, timestamp: u64) -> bool {
 ### 6. Update timestamp constants and test fixtures
 
 **Files:**
-- [`crates/common/chains/src/hardfork.rs`](../../crates/common/chains/src/hardfork.rs) (mainnet, sepolia, devnet constants)
+- [`crates/common/chains/src/upgrade.rs`](../../crates/common/chains/src/upgrade.rs) (mainnet, sepolia, devnet constants)
 - [`crates/common/chains/src/lib.rs`](../../crates/common/chains/src/lib.rs)
 - [`crates/consensus/registry/src/test_utils/mod.rs`](https://github.com/base/base/blob/main/crates/consensus/registry/src/test_utils/mod.rs)
 
@@ -378,9 +378,9 @@ forks.push((BaseUpgrade::V1.boxed(), self[BaseUpgrade::V1]));  // <-- add
 
 ### Always required
 
-- [ ] `BaseUpgrade` variant added in `hardfork.rs`; all four chain arrays updated
+- [ ] `BaseUpgrade` variant added in `upgrade.rs`; all four chain arrays updated
 - [ ] `Index<BaseUpgrade>` arm added in `chain.rs`
-- [ ] Config field (flat or nested struct) added to `HardForkConfig` in `hardfork.rs`; `iter()` updated; new types re-exported
+- [ ] Config field (flat or nested struct) added to `HardForkConfig` in `upgrade.rs`; `iter()` updated; new types re-exported
 - [ ] `is_X_active` + `is_first_X_block` added to `RollupConfig`; `upgrade_activation` arm added; previous terminal upgrade cascades to new one (unless standalone)
 - [ ] `is_X_active_at_timestamp` added to `BaseUpgrades` trait
 - [ ] Timestamp constants added to `mainnet.rs`, `sepolia.rs`, `devnet_0_sepolia_dev_0.rs`; re-exported from `lib.rs`


### PR DESCRIPTION
## Summary

Renames `hardfork.rs` and `hardforks.rs` in `base-alloy-chains` to `upgrade.rs` and `upgrades.rs` to align file names with the types they define (`BaseUpgrade`, `BaseUpgrades`). Doc comments in `chain.rs`, `README.md`, and the renamed files are updated to prefer "upgrade" over "hardfork" throughout. No behavior or public API is changed.