### PR TITLE
docs(bcps): add missing metadata table to bcp-0000

### DIFF
--- a/docs/specs/pages/bcps/bcp-0000.md
+++ b/docs/specs/pages/bcps/bcp-0000.md
@@ -1,5 +1,11 @@
 # BCP-0000: BCP Process
-
+| Field | Value |
+|-------|-------|
+| BCP | 0000 |
+| Title | BCP Process |
+| Status | Final |
+| Type | Meta |
+| Author | Base Team |
 ## Abstract
 
 BCP-0000 defines the Base Change Proposal (BCP) process — the mechanism by which changes to the Base


### PR DESCRIPTION
Fixes #1965

## Summary
BCP-0000 defines that every BCP must begin with an H1 heading followed by a metadata table, but `bcp-0000.md` itself was missing this table — violating its own format requirement.

## Changes
- `docs/specs/pages/bcps/bcp-0000.md`: Added required metadata table after H1 heading