### PR TITLE
refactor: simplify execution generics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4279,6 +4279,7 @@ dependencies = [
 name = "base-node-runner"
 version = "0.0.0"
 dependencies = [
+ "alloy-chains",
  "alloy-eips",
  "alloy-genesis",
  "alloy-primitives",
@@ -4287,7 +4288,6 @@ dependencies = [
  "alloy-rpc-types",
  "alloy-rpc-types-engine",
  "alloy-signer",
- "base-alloy-chains",
  "base-alloy-consensus",
  "base-alloy-network",
  "base-alloy-rpc-types-engine",
@@ -4304,7 +4304,6 @@ dependencies = [
  "eyre",
  "futures",
  "jsonrpsee",
- "reth-chainspec",
  "reth-db",
  "reth-evm",
  "reth-exex",

--- a/bin/builder/src/main.rs
+++ b/bin/builder/src/main.rs
@@ -9,11 +9,11 @@ use std::sync::Arc;
 
 use base_builder_core::{BuilderApiExtension, FlashblocksServiceBuilder};
 use base_builder_metering::MeteringStoreExtension;
-use base_execution_cli::{Cli, chainspec::OpChainSpecParser};
+use base_execution_cli::Cli;
 use base_node_runner::BaseNodeRunner;
 use base_txpool_rpc::{TxPoolRpcConfig, TxPoolRpcExtension};
 
-type BuilderCli = Cli<OpChainSpecParser, cli::Args>;
+type BuilderCli = Cli<cli::Args>;
 
 #[global_allocator]
 static ALLOC: reth_cli_util::allocator::Allocator = reth_cli_util::allocator::new_allocator();

--- a/bin/node/src/main.rs
+++ b/bin/node/src/main.rs
@@ -6,7 +6,7 @@
 pub mod cli;
 
 use base_bundle_extension::BundleExtension;
-use base_execution_cli::{Cli, chainspec::OpChainSpecParser};
+use base_execution_cli::Cli;
 use base_flashblocks::FlashblocksConfig;
 use base_flashblocks_node::FlashblocksExtension;
 use base_metering::{MeteringConfig, MeteringExtension, MeteringResourceLimits};
@@ -16,7 +16,7 @@ use base_tx_forwarding::TxForwardingExtension;
 use base_txpool_rpc::{TxPoolRpcConfig, TxPoolRpcExtension};
 use base_txpool_tracing::{TxPoolExtension, TxpoolConfig};
 
-type NodeCli = Cli<OpChainSpecParser, cli::Args>;
+type NodeCli = Cli<cli::Args>;
 
 #[global_allocator]
 static ALLOC: reth_cli_util::allocator::Allocator = reth_cli_util::allocator::new_allocator();

--- a/crates/execution/chainspec/src/spec.rs
+++ b/crates/execution/chainspec/src/spec.rs
@@ -123,6 +123,11 @@ impl OpChainSpec {
             _ => None,
         }
     }
+
+    /// Activates or updates the given hardfork condition in-place.
+    pub fn set_fork<H: Hardfork>(&mut self, fork: H, condition: ForkCondition) {
+        self.inner.hardforks.insert(fork, condition);
+    }
 }
 
 impl EthChainSpec for OpChainSpec {

--- a/crates/execution/cli/README.md
+++ b/crates/execution/cli/README.md
@@ -18,10 +18,10 @@ base-execution-cli = { workspace = true }
 ```
 
 ```rust,ignore
-use base_execution_cli::{Cli, OpChainSpecParser};
+use base_execution_cli::Cli;
 
 fn main() {
-    let cli = Cli::<OpChainSpecParser, _>::parse_args();
+    let cli = Cli::parse_args();
     cli.run(|builder, args| async move {
         // launch node
     });

--- a/crates/execution/cli/src/app.rs
+++ b/crates/execution/cli/src/app.rs
@@ -5,7 +5,6 @@ use base_execution_consensus::OpBeaconConsensus;
 use base_execution_evm::OpExecutorProvider;
 use base_node_core::OpNode;
 use eyre::{Result, eyre};
-use reth_cli::chainspec::ChainSpecParser;
 use reth_cli_commands::launcher::Launcher;
 use reth_cli_runner::CliRunner;
 use reth_node_core::args::{OtlpInitStatus, OtlpLogsStatus};
@@ -18,20 +17,19 @@ use crate::{Cli, Commands};
 
 /// A wrapper around a parsed CLI that handles command execution.
 #[derive(Debug)]
-pub struct CliApp<Spec: ChainSpecParser, Ext: clap::Args + fmt::Debug, Rpc: RpcModuleValidator> {
-    cli: Cli<Spec, Ext, Rpc>,
+pub struct CliApp<Ext: clap::Args + fmt::Debug, Rpc: RpcModuleValidator> {
+    cli: Cli<Ext, Rpc>,
     runner: Option<CliRunner>,
     layers: Option<Layers>,
     guard: Option<FileWorkerGuard>,
 }
 
-impl<C, Ext, Rpc> CliApp<C, Ext, Rpc>
+impl<Ext, Rpc> CliApp<Ext, Rpc>
 where
-    C: ChainSpecParser<ChainSpec = OpChainSpec>,
     Ext: clap::Args + fmt::Debug,
     Rpc: RpcModuleValidator,
 {
-    pub(crate) fn new(cli: Cli<C, Ext, Rpc>) -> Self {
+    pub(crate) fn new(cli: Cli<Ext, Rpc>) -> Self {
         Self { cli, runner: None, layers: Some(Layers::new()), guard: None }
     }
 
@@ -54,7 +52,10 @@ where
     ///
     /// This accepts a closure that is used to launch the node via the
     /// [`NodeCommand`](reth_cli_commands::node::NodeCommand).
-    pub fn run(mut self, launcher: impl Launcher<C, Ext>) -> Result<()> {
+    pub fn run(
+        mut self,
+        launcher: impl Launcher<crate::chainspec::OpChainSpecParser, Ext>,
+    ) -> Result<()> {
         let runner = match self.runner.take() {
             Some(runner) => runner,
             None => CliRunner::try_default_runtime()?,

--- a/crates/execution/cli/src/commands/mod.rs
+++ b/crates/execution/cli/src/commands/mod.rs
@@ -2,9 +2,8 @@
 
 use std::{fmt, sync::Arc};
 
+use base_execution_chainspec::OpChainSpec;
 use clap::Subcommand;
-use reth_chainspec::{EthChainSpec, EthereumHardforks, Hardforks};
-use reth_cli::chainspec::ChainSpecParser;
 use reth_cli_commands::{
     config_cmd, db, dump_genesis, init_cmd,
     node::{self, NoArgs},
@@ -21,53 +20,48 @@ pub mod test_vectors;
 
 /// Commands to be executed
 #[derive(Debug, Subcommand)]
-pub enum Commands<Spec: ChainSpecParser = OpChainSpecParser, Ext: clap::Args + fmt::Debug = NoArgs>
-{
+pub enum Commands<Ext: clap::Args + fmt::Debug = NoArgs> {
     /// Start the node
     #[command(name = "node")]
-    Node(Box<node::NodeCommand<Spec, Ext>>),
+    Node(Box<node::NodeCommand<OpChainSpecParser, Ext>>),
     /// Initialize the database from a genesis file.
     #[command(name = "init")]
-    Init(init_cmd::InitCommand<Spec>),
+    Init(init_cmd::InitCommand<OpChainSpecParser>),
     /// Initialize the database from a state dump file.
     #[command(name = "init-state")]
-    InitState(init_state::InitStateCommandOp<Spec>),
+    InitState(init_state::InitStateCommandOp<OpChainSpecParser>),
     /// Dumps genesis block JSON configuration to stdout.
-    DumpGenesis(dump_genesis::DumpGenesisCommand<Spec>),
+    DumpGenesis(dump_genesis::DumpGenesisCommand<OpChainSpecParser>),
     /// Database debugging utilities
     #[command(name = "db")]
-    Db(db::Command<Spec>),
+    Db(db::Command<OpChainSpecParser>),
     /// Manipulate individual stages.
     #[command(name = "stage")]
-    Stage(Box<stage::Command<Spec>>),
+    Stage(Box<stage::Command<OpChainSpecParser>>),
     /// P2P Debugging utilities
     #[command(name = "p2p")]
-    P2P(Box<p2p::Command<Spec>>),
+    P2P(Box<p2p::Command<OpChainSpecParser>>),
     /// Write config to stdout
     #[command(name = "config")]
     Config(config_cmd::Command),
     /// Prune according to the configuration without any limits
     #[command(name = "prune")]
-    Prune(prune::PruneCommand<Spec>),
+    Prune(prune::PruneCommand<OpChainSpecParser>),
     /// Generate Test Vectors
     #[cfg(feature = "dev")]
     #[command(name = "test-vectors")]
     TestVectors(test_vectors::Command),
     /// Re-execute blocks in parallel to verify historical sync correctness.
     #[command(name = "re-execute")]
-    ReExecute(re_execute::Command<Spec>),
+    ReExecute(re_execute::Command<OpChainSpecParser>),
     /// Manage storage of historical proofs in expanded trie db in fault proof window.
     #[command(name = "proofs")]
-    OpProofs(op_proofs::Command<Spec>),
+    OpProofs(op_proofs::Command<OpChainSpecParser>),
 }
 
-impl<
-    C: ChainSpecParser<ChainSpec: EthChainSpec + Hardforks + EthereumHardforks>,
-    Ext: clap::Args + fmt::Debug,
-> Commands<C, Ext>
-{
+impl<Ext: clap::Args + fmt::Debug> Commands<Ext> {
     /// Returns the underlying chain being used for commands
-    pub fn chain_spec(&self) -> Option<&Arc<C::ChainSpec>> {
+    pub fn chain_spec(&self) -> Option<&Arc<OpChainSpec>> {
         match self {
             Self::Node(cmd) => cmd.chain_spec(),
             Self::Init(cmd) => cmd.chain_spec(),

--- a/crates/execution/cli/src/lib.rs
+++ b/crates/execution/cli/src/lib.rs
@@ -23,7 +23,6 @@ use chainspec::OpChainSpecParser;
 use clap::Parser;
 use commands::Commands;
 use futures::Future;
-use reth_cli::chainspec::ChainSpecParser;
 use reth_cli_commands::launcher::FnLauncher;
 use reth_cli_runner::CliRunner;
 use reth_db::DatabaseEnv;
@@ -43,13 +42,12 @@ use reth_rpc_server_types::{DefaultRpcModuleValidator, RpcModuleValidator};
 #[derive(Debug, Parser)]
 #[command(author, name = version_metadata().name_client.as_ref(), version = version_metadata().short_version.as_ref(), long_version = version_metadata().long_version.as_ref(), about = "Reth", long_about = None)]
 pub struct Cli<
-    Spec: ChainSpecParser = OpChainSpecParser,
     Ext: clap::Args + fmt::Debug = RollupArgs,
     Rpc: RpcModuleValidator = DefaultRpcModuleValidator,
 > {
     /// The command to run
     #[command(subcommand)]
-    pub command: Commands<Spec, Ext>,
+    pub command: Commands<Ext>,
 
     /// The logging configuration for the CLI.
     #[command(flatten)]
@@ -80,9 +78,8 @@ impl Cli {
     }
 }
 
-impl<C, Ext, Rpc> Cli<C, Ext, Rpc>
+impl<Ext, Rpc> Cli<Ext, Rpc>
 where
-    C: ChainSpecParser<ChainSpec = OpChainSpec>,
     Ext: clap::Args + fmt::Debug,
     Rpc: RpcModuleValidator,
 {
@@ -90,7 +87,7 @@ where
     ///
     /// This method is used to prepare the CLI for execution by wrapping it in a
     /// [`CliApp`] that can be further configured before running.
-    pub fn configure(self) -> CliApp<C, Ext, Rpc> {
+    pub fn configure(self) -> CliApp<Ext, Rpc> {
         CliApp::new(self)
     }
 
@@ -100,7 +97,7 @@ where
     /// [`NodeCommand`](reth_cli_commands::node::NodeCommand).
     pub fn run<L, Fut>(self, launcher: L) -> eyre::Result<()>
     where
-        L: FnOnce(WithLaunchContext<NodeBuilder<DatabaseEnv, C::ChainSpec>>, Ext) -> Fut,
+        L: FnOnce(WithLaunchContext<NodeBuilder<DatabaseEnv, OpChainSpec>>, Ext) -> Fut,
         Fut: Future<Output = eyre::Result<()>>,
     {
         self.with_runner(CliRunner::try_default_runtime()?, launcher)
@@ -109,12 +106,12 @@ where
     /// Execute the configured cli command with the provided [`CliRunner`].
     pub fn with_runner<L, Fut>(self, runner: CliRunner, launcher: L) -> eyre::Result<()>
     where
-        L: FnOnce(WithLaunchContext<NodeBuilder<DatabaseEnv, C::ChainSpec>>, Ext) -> Fut,
+        L: FnOnce(WithLaunchContext<NodeBuilder<DatabaseEnv, OpChainSpec>>, Ext) -> Fut,
         Fut: Future<Output = eyre::Result<()>>,
     {
         let mut this = self.configure();
         this.set_runner(runner);
-        this.run(FnLauncher::new::<C, Ext>(async move |builder, chain_spec| {
+        this.run(FnLauncher::new::<OpChainSpecParser, Ext>(async move |builder, chain_spec| {
             launcher(builder, chain_spec).await
         }))
     }
@@ -154,7 +151,7 @@ mod tests {
         // to a value accepted by reth's OtlpProtocol enum.
         // SAFETY: this is a single-test context; no other thread concurrently reads this var.
         unsafe { std::env::set_var("OTEL_EXPORTER_OTLP_PROTOCOL", "http") };
-        let cmd = Cli::<OpChainSpecParser, RollupArgs>::parse_from([
+        let cmd = Cli::<RollupArgs>::parse_from([
             "base-reth",
             "node",
             "--chain",

--- a/crates/execution/consensus/Cargo.toml
+++ b/crates/execution/consensus/Cargo.toml
@@ -14,7 +14,6 @@ workspace = true
 [dependencies]
 # reth
 reth-consensus.workspace = true
-reth-chainspec.workspace = true
 reth-storage-api.workspace = true
 reth-trie-common.workspace = true
 reth-execution-types.workspace = true
@@ -40,6 +39,7 @@ thiserror.workspace = true
 base-execution-chainspec.workspace = true
 
 [dev-dependencies]
+reth-chainspec.workspace = true
 reth-trie.workspace = true
 reth-revm.workspace = true
 base-node-core.workspace = true
@@ -61,7 +61,6 @@ std = [
 	"base-alloy-consensus/std",
 	"base-execution-chainspec/std",
 	"base-protocol/std",
-	"reth-chainspec/std",
 	"reth-consensus-common/std",
 	"reth-consensus/std",
 	"reth-execution-types/std",

--- a/crates/execution/consensus/src/lib.rs
+++ b/crates/execution/consensus/src/lib.rs
@@ -11,15 +11,14 @@
 extern crate alloc;
 
 use alloc::{format, sync::Arc};
-use core::fmt::Debug;
 
 use alloy_consensus::{
-    BlockHeader as _, EMPTY_OMMER_ROOT_HASH, constants::MAXIMUM_EXTRA_DATA_SIZE,
+    BlockHeader as _, EMPTY_OMMER_ROOT_HASH, Header, constants::MAXIMUM_EXTRA_DATA_SIZE,
 };
 use alloy_primitives::B64;
 use base_alloy_chains::BaseUpgrades;
 use base_alloy_consensus::DepositReceipt;
-use reth_chainspec::EthChainSpec;
+use base_execution_chainspec::OpChainSpec;
 use reth_consensus::{Consensus, ConsensusError, FullConsensus, HeaderValidator, ReceiptRootBloom};
 use reth_consensus_common::validation::{
     validate_against_parent_eip1559_base_fee, validate_against_parent_hash_number,
@@ -28,8 +27,7 @@ use reth_consensus_common::validation::{
 };
 use reth_execution_types::BlockExecutionResult;
 use reth_primitives_traits::{
-    Block, BlockBody, BlockHeader, GotExpected, NodePrimitives, RecoveredBlock, SealedBlock,
-    SealedHeader,
+    Block, BlockBody, GotExpected, NodePrimitives, RecoveredBlock, SealedBlock, SealedHeader,
 };
 
 mod proof;
@@ -45,16 +43,16 @@ pub use error::OpConsensusError;
 ///
 /// Provides basic checks as outlined in the execution specs.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct OpBeaconConsensus<ChainSpec> {
+pub struct OpBeaconConsensus {
     /// Configuration
-    chain_spec: Arc<ChainSpec>,
+    chain_spec: Arc<OpChainSpec>,
     /// Maximum allowed extra data size in bytes
     max_extra_data_size: usize,
 }
 
-impl<ChainSpec> OpBeaconConsensus<ChainSpec> {
+impl OpBeaconConsensus {
     /// Create a new instance of [`OpBeaconConsensus`]
-    pub const fn new(chain_spec: Arc<ChainSpec>) -> Self {
+    pub const fn new(chain_spec: Arc<OpChainSpec>) -> Self {
         Self { chain_spec, max_extra_data_size: MAXIMUM_EXTRA_DATA_SIZE }
     }
 
@@ -70,10 +68,9 @@ impl<ChainSpec> OpBeaconConsensus<ChainSpec> {
     }
 }
 
-impl<N, ChainSpec> FullConsensus<N> for OpBeaconConsensus<ChainSpec>
+impl<N> FullConsensus<N> for OpBeaconConsensus
 where
-    N: NodePrimitives<Receipt: DepositReceipt>,
-    ChainSpec: EthChainSpec<Header = N::BlockHeader> + BaseUpgrades + Debug + Send + Sync,
+    N: NodePrimitives<BlockHeader = Header, Receipt: DepositReceipt>,
 {
     fn validate_block_post_execution(
         &self,
@@ -85,10 +82,9 @@ where
     }
 }
 
-impl<B, ChainSpec> Consensus<B> for OpBeaconConsensus<ChainSpec>
+impl<B> Consensus<B> for OpBeaconConsensus
 where
-    B: Block,
-    ChainSpec: EthChainSpec<Header = B::Header> + BaseUpgrades + Debug + Send + Sync,
+    B: Block<Header = Header>,
 {
     fn validate_body_against_header(
         &self,
@@ -150,12 +146,8 @@ where
     }
 }
 
-impl<H, ChainSpec> HeaderValidator<H> for OpBeaconConsensus<ChainSpec>
-where
-    H: BlockHeader,
-    ChainSpec: EthChainSpec<Header = H> + BaseUpgrades + Debug + Send + Sync,
-{
-    fn validate_header(&self, header: &SealedHeader<H>) -> Result<(), ConsensusError> {
+impl HeaderValidator<Header> for OpBeaconConsensus {
+    fn validate_header(&self, header: &SealedHeader<Header>) -> Result<(), ConsensusError> {
         let header = header.header();
 
         if header.nonce() != Some(B64::ZERO) {
@@ -182,8 +174,8 @@ where
 
     fn validate_header_against_parent(
         &self,
-        header: &SealedHeader<H>,
-        parent: &SealedHeader<H>,
+        header: &SealedHeader<Header>,
+        parent: &SealedHeader<Header>,
     ) -> Result<(), ConsensusError> {
         validate_against_parent_hash_number(header.header(), parent)?;
 
@@ -240,7 +232,7 @@ mod tests {
         HoloceneExtraData, JovianExtraData, OpPrimitives, OpReceipt, OpTransactionSigned,
         OpTypedTransaction,
     };
-    use base_execution_chainspec::{BASE_MAINNET, OpChainSpec, OpChainSpecBuilder};
+    use base_execution_chainspec::{BASE_MAINNET, OpChainSpecBuilder};
     use reth_chainspec::BaseFeeParams;
     use reth_consensus::{Consensus, ConsensusError, FullConsensus, HeaderValidator};
     use reth_primitives_traits::{RecoveredBlock, SealedBlock, SealedHeader, proofs};
@@ -403,12 +395,13 @@ mod tests {
 
         let block = RecoveredBlock::new_sealed(block, vec![Address::default()]);
 
-        let post_execution = <OpBeaconConsensus<OpChainSpec> as FullConsensus<OpPrimitives>>::validate_block_post_execution(
-            &beacon_consensus,
-            &block,
-            &result,
-            None,
-        );
+        let post_execution =
+            <OpBeaconConsensus as FullConsensus<OpPrimitives>>::validate_block_post_execution(
+                &beacon_consensus,
+                &block,
+                &result,
+                None,
+            );
 
         // validate blob, it should pass blob gas used validation
         assert!(post_execution.is_ok());
@@ -473,12 +466,13 @@ mod tests {
 
         let block = RecoveredBlock::new_sealed(block, vec![Address::default()]);
 
-        let post_execution = <OpBeaconConsensus<OpChainSpec> as FullConsensus<OpPrimitives>>::validate_block_post_execution(
-            &beacon_consensus,
-            &block,
-            &result,
-            None,
-        );
+        let post_execution =
+            <OpBeaconConsensus as FullConsensus<OpPrimitives>>::validate_block_post_execution(
+                &beacon_consensus,
+                &block,
+                &result,
+                None,
+            );
 
         // validate blob, it should fail blob gas used validation post execution.
         assert!(matches!(

--- a/crates/execution/consensus/src/validation/mod.rs
+++ b/crates/execution/consensus/src/validation/mod.rs
@@ -212,12 +212,11 @@ mod tests {
 
     use alloy_consensus::Header;
     use alloy_eips::eip7685::Requests;
-    use alloy_primitives::{Bytes, U256, b256, hex};
+    use alloy_primitives::{Bytes, b256, hex};
     use base_alloy_chains::BaseUpgrade;
     use base_alloy_consensus::{OpReceipt, OpTxEnvelope};
     use base_execution_chainspec::{BASE_SEPOLIA, OpChainSpec};
-    use base_execution_forks::BASE_SEPOLIA_HARDFORKS;
-    use reth_chainspec::{BaseFeeParams, ChainSpec, EthChainSpec, ForkCondition, Hardfork};
+    use reth_chainspec::{BaseFeeParams, EthChainSpec, ForkCondition};
 
     use super::*;
 
@@ -227,38 +226,20 @@ mod tests {
     const BLOCK_TIME_SECONDS: u64 = 2;
 
     fn holocene_chainspec() -> Arc<OpChainSpec> {
-        let mut hardforks = BASE_SEPOLIA_HARDFORKS.clone();
-        hardforks
-            .insert(BaseUpgrade::Holocene.boxed(), ForkCondition::Timestamp(HOLOCENE_TIMESTAMP));
-        Arc::new(OpChainSpec {
-            inner: ChainSpec {
-                chain: BASE_SEPOLIA.inner.chain,
-                genesis: BASE_SEPOLIA.inner.genesis.clone(),
-                genesis_header: BASE_SEPOLIA.inner.genesis_header.clone(),
-                paris_block_and_final_difficulty: Some((0, U256::from(0))),
-                hardforks,
-                base_fee_params: BASE_SEPOLIA.inner.base_fee_params.clone(),
-                prune_delete_limit: 10000,
-                ..Default::default()
-            },
-        })
+        let mut chainspec = BASE_SEPOLIA.as_ref().clone();
+        chainspec.set_fork(BaseUpgrade::Holocene, ForkCondition::Timestamp(HOLOCENE_TIMESTAMP));
+        Arc::new(chainspec)
     }
 
     fn isthmus_chainspec() -> OpChainSpec {
         let mut chainspec = BASE_SEPOLIA.as_ref().clone();
-        chainspec
-            .inner
-            .hardforks
-            .insert(BaseUpgrade::Isthmus.boxed(), ForkCondition::Timestamp(ISTHMUS_TIMESTAMP));
+        chainspec.set_fork(BaseUpgrade::Isthmus, ForkCondition::Timestamp(ISTHMUS_TIMESTAMP));
         chainspec
     }
 
     fn jovian_chainspec() -> OpChainSpec {
         let mut chainspec = BASE_SEPOLIA.as_ref().clone();
-        chainspec
-            .inner
-            .hardforks
-            .insert(BaseUpgrade::Jovian.boxed(), ForkCondition::Timestamp(JOVIAN_TIMESTAMP));
+        chainspec.set_fork(BaseUpgrade::Jovian, ForkCondition::Timestamp(JOVIAN_TIMESTAMP));
         chainspec
     }
 

--- a/crates/execution/node/src/node.rs
+++ b/crates/execution/node/src/node.rs
@@ -5,7 +5,7 @@ use std::{marker::PhantomData, sync::Arc};
 use alloy_consensus::BlockHeader;
 use alloy_primitives::{Address, B64, B256};
 use base_alloy_chains::BaseUpgrades;
-use base_alloy_consensus::{DepositReceipt, OpPooledTransaction, OpPrimitives};
+use base_alloy_consensus::{OpPooledTransaction, OpPrimitives};
 use base_alloy_rpc_types_engine::{OpExecutionData, OpPayloadAttributes};
 use base_execution_chainspec::OpChainSpec;
 use base_execution_consensus::OpBeaconConsensus;
@@ -26,9 +26,7 @@ use base_txpool::{
     BaseOrdering, BasePooledTransaction, BaseTransactionPool, OpPooledTx, OpTransactionValidator,
     TimestampedTransaction,
 };
-use reth_chainspec::{
-    BaseFeeParams, ChainSpecProvider, EthChainSpec, EthereumHardforks, Hardforks,
-};
+use reth_chainspec::{BaseFeeParams, ChainSpecProvider, EthChainSpec, Hardforks};
 use reth_evm::ConfigureEvm;
 use reth_network::{
     NetworkConfig, NetworkHandle, NetworkManager, NetworkPrimitives, PeersInfo,
@@ -72,16 +70,12 @@ use crate::{
 
 /// Marker trait for Base node types with standard engine, chain spec, and primitives.
 pub trait OpNodeTypes:
-    NodeTypes<Payload = OpEngineTypes, ChainSpec: BaseUpgrades + Hardforks, Primitives = OpPrimitives>
+    NodeTypes<Payload = OpEngineTypes, ChainSpec = OpChainSpec, Primitives = OpPrimitives>
 {
 }
 /// Blanket impl for all node types that conform to the Base spec.
 impl<N> OpNodeTypes for N where
-    N: NodeTypes<
-            Payload = OpEngineTypes,
-            ChainSpec: BaseUpgrades + Hardforks,
-            Primitives = OpPrimitives,
-        >
+    N: NodeTypes<Payload = OpEngineTypes, ChainSpec = OpChainSpec, Primitives = OpPrimitives>
 {
 }
 
@@ -89,7 +83,7 @@ impl<N> OpNodeTypes for N where
 /// data.
 pub trait BaseFullNodeTypes:
     NodeTypes<
-        ChainSpec: BaseUpgrades,
+        ChainSpec = OpChainSpec,
         Primitives: OpPayloadPrimitives,
         Storage = OpStorage,
         Payload: EngineTypes<ExecutionData = OpExecutionData>,
@@ -99,7 +93,7 @@ pub trait BaseFullNodeTypes:
 
 impl<N> BaseFullNodeTypes for N where
     N: NodeTypes<
-            ChainSpec: BaseUpgrades,
+            ChainSpec = OpChainSpec,
             Primitives: OpPayloadPrimitives,
             Storage = OpStorage,
             Payload: EngineTypes<ExecutionData = OpExecutionData>,
@@ -546,17 +540,9 @@ impl<N, EthB, PVB, EB, EVB, Attrs, RpcMiddleware> NodeAddOns<N>
     for OpAddOns<N, EthB, PVB, EB, EVB, RpcMiddleware>
 where
     N: FullNodeComponents<
-            Types: NodeTypes<
-                ChainSpec: BaseUpgrades + EthereumHardforks + Hardforks,
-                Primitives: OpPayloadPrimitives,
-                Payload: PayloadTypes<PayloadBuilderAttributes = Attrs>,
-            >,
+            Types: OpNodeTypes + NodeTypes<Payload: PayloadTypes<PayloadBuilderAttributes = Attrs>>,
             Evm: ConfigureEvm<
-                NextBlockEnvCtx: BuildNextEnv<
-                    Attrs,
-                    HeaderTy<N::Types>,
-                    <N::Types as NodeTypes>::ChainSpec,
-                >,
+                NextBlockEnvCtx: BuildNextEnv<Attrs, HeaderTy<N::Types>, OpChainSpec>,
             >,
             Pool: TransactionPool<Transaction: OpPooledTx>,
         >,
@@ -629,17 +615,9 @@ impl<N, EthB, PVB, EB, EVB, Attrs, RpcMiddleware> RethRpcAddOns<N>
     for OpAddOns<N, EthB, PVB, EB, EVB, RpcMiddleware>
 where
     N: FullNodeComponents<
-            Types: NodeTypes<
-                ChainSpec: BaseUpgrades + EthereumHardforks + Hardforks,
-                Primitives: OpPayloadPrimitives,
-                Payload: PayloadTypes<PayloadBuilderAttributes = Attrs>,
-            >,
+            Types: OpNodeTypes + NodeTypes<Payload: PayloadTypes<PayloadBuilderAttributes = Attrs>>,
             Evm: ConfigureEvm<
-                NextBlockEnvCtx: BuildNextEnv<
-                    Attrs,
-                    HeaderTy<N::Types>,
-                    <N::Types as NodeTypes>::ChainSpec,
-                >,
+                NextBlockEnvCtx: BuildNextEnv<Attrs, HeaderTy<N::Types>, OpChainSpec>,
             >,
         >,
     <<N as FullNodeComponents>::Pool as TransactionPool>::Transaction: OpPooledTx,
@@ -828,7 +806,7 @@ pub struct OpExecutorBuilder;
 
 impl<Node> ExecutorBuilder<Node> for OpExecutorBuilder
 where
-    Node: FullNodeTypes<Types: NodeTypes<ChainSpec: BaseUpgrades, Primitives = OpPrimitives>>,
+    Node: FullNodeTypes<Types: OpNodeTypes>,
 {
     type EVM =
         OpEvmConfig<<Node::Types as NodeTypes>::ChainSpec, <Node::Types as NodeTypes>::Primitives>;
@@ -893,7 +871,7 @@ impl<T> OpPoolBuilder<T> {
 
 impl<Node, T, Evm> PoolBuilder<Node, Evm> for OpPoolBuilder<T>
 where
-    Node: FullNodeTypes<Types: NodeTypes<ChainSpec: BaseUpgrades>>,
+    Node: FullNodeTypes<Types: OpNodeTypes>,
     T: EthPoolTransaction<Consensus = TxTy<Node::Types>> + OpPooledTx + TimestampedTransaction,
     Evm: ConfigureEvm<Primitives = PrimitivesTy<Node::Types>> + Clone + 'static,
 {
@@ -1154,14 +1132,9 @@ pub struct OpConsensusBuilder;
 
 impl<Node> ConsensusBuilder<Node> for OpConsensusBuilder
 where
-    Node: FullNodeTypes<
-        Types: NodeTypes<
-            ChainSpec: BaseUpgrades,
-            Primitives: NodePrimitives<Receipt: DepositReceipt>,
-        >,
-    >,
+    Node: FullNodeTypes<Types: OpNodeTypes>,
 {
-    type Consensus = Arc<OpBeaconConsensus<<Node::Types as NodeTypes>::ChainSpec>>;
+    type Consensus = Arc<OpBeaconConsensus>;
 
     async fn build_consensus(self, ctx: &BuilderContext<Node>) -> eyre::Result<Self::Consensus> {
         Ok(Arc::new(OpBeaconConsensus::new(ctx.chain_spec())))

--- a/crates/execution/runner/Cargo.toml
+++ b/crates/execution/runner/Cargo.toml
@@ -25,7 +25,6 @@ reth-tracing.workspace = true
 reth-provider.workspace = true
 reth-node-api.workspace = true
 reth-rpc-api.workspace = true
-reth-chainspec.workspace = true
 reth-node-builder.workspace = true
 reth-primitives-traits.workspace = true
 reth-rpc-server-types.workspace = true
@@ -44,6 +43,7 @@ base-execution-chainspec.workspace = true
 base-execution-payload-builder.workspace = true
 
 # alloy
+alloy-chains = { workspace = true, optional = true }
 alloy-eips = { workspace = true, optional = true, features = ["std"] }
 alloy-signer = { workspace = true, optional = true }
 alloy-genesis = { workspace = true, optional = true, features = ["std"] }
@@ -51,10 +51,11 @@ alloy-provider = { workspace = true, optional = true }
 alloy-rpc-types = { workspace = true, optional = true }
 alloy-primitives = { workspace = true, optional = true }
 alloy-rpc-client = { workspace = true, optional = true }
-alloy-rpc-types-engine = { workspace = true, optional = true, features = ["std"] }
+alloy-rpc-types-engine = { workspace = true, optional = true, features = [
+  "std",
+] }
 
 # base-alloy
-base-alloy-chains.workspace = true
 base-alloy-network = { workspace = true, optional = true }
 base-alloy-consensus = { workspace = true, features = ["reth"] }
 base-alloy-rpc-types-engine = { workspace = true, optional = true }
@@ -78,6 +79,7 @@ tracing-subscriber = { workspace = true, optional = true }
 [features]
 test-utils = [
 	"base-node-core/test-utils",
+	"dep:alloy-chains",
 	"dep:alloy-eips",
 	"dep:alloy-genesis",
 	"dep:alloy-primitives",
@@ -98,7 +100,6 @@ test-utils = [
 	"dep:tower",
 	"dep:tracing-subscriber",
 	"dep:url",
-	"reth-chainspec/test-utils",
 	"reth-db/test-utils",
 	"reth-evm/test-utils",
 	"reth-node-builder/test-utils",

--- a/crates/execution/runner/src/add_ons.rs
+++ b/crates/execution/runner/src/add_ons.rs
@@ -1,6 +1,5 @@
 use std::marker::PhantomData;
 
-use base_alloy_chains::BaseUpgrades;
 use base_execution_payload_builder::{
     OpAttributes, OpPayloadPrimitives,
     config::{OpDAConfig, OpGasLimitConfig},
@@ -13,7 +12,6 @@ use base_execution_rpc::{
 };
 use base_node_core::{OpEngineApiBuilder, OpEngineValidatorBuilder, OpNodeTypes};
 use base_txpool::OpPooledTx;
-use reth_chainspec::{EthereumHardforks, Hardforks};
 use reth_evm::ConfigureEvm;
 use reth_node_api::{BuildNextEnv, FullNodeComponents, HeaderTy, NodeAddOns, PayloadTypes, TxTy};
 use reth_node_builder::{
@@ -182,16 +180,12 @@ impl<N, EthB, PVB, EB, EVB, Attrs, RpcMiddleware> NodeAddOns<N>
     for BaseAddOns<N, EthB, PVB, EB, EVB, RpcMiddleware>
 where
     N: FullNodeComponents<
-            Types: NodeTypes<
-                ChainSpec: BaseUpgrades + EthereumHardforks + Hardforks,
-                Primitives: OpPayloadPrimitives,
-                Payload: PayloadTypes<PayloadBuilderAttributes = Attrs>,
-            >,
+            Types: OpNodeTypes + NodeTypes<Payload: PayloadTypes<PayloadBuilderAttributes = Attrs>>,
             Evm: ConfigureEvm<
                 NextBlockEnvCtx: BuildNextEnv<
                     Attrs,
                     HeaderTy<N::Types>,
-                    <N::Types as NodeTypes>::ChainSpec,
+                    base_execution_chainspec::OpChainSpec,
                 >,
             >,
             Pool: TransactionPool<Transaction: OpPooledTx>,
@@ -265,16 +259,12 @@ impl<N, EthB, PVB, EB, EVB, Attrs, RpcMiddleware> RethRpcAddOns<N>
     for BaseAddOns<N, EthB, PVB, EB, EVB, RpcMiddleware>
 where
     N: FullNodeComponents<
-            Types: NodeTypes<
-                ChainSpec: BaseUpgrades + EthereumHardforks + Hardforks,
-                Primitives: OpPayloadPrimitives,
-                Payload: PayloadTypes<PayloadBuilderAttributes = Attrs>,
-            >,
+            Types: OpNodeTypes + NodeTypes<Payload: PayloadTypes<PayloadBuilderAttributes = Attrs>>,
             Evm: ConfigureEvm<
                 NextBlockEnvCtx: BuildNextEnv<
                     Attrs,
                     HeaderTy<N::Types>,
-                    <N::Types as NodeTypes>::ChainSpec,
+                    base_execution_chainspec::OpChainSpec,
                 >,
             >,
         >,

--- a/crates/execution/runner/src/node.rs
+++ b/crates/execution/runner/src/node.rs
@@ -131,7 +131,7 @@ impl BaseNode {
 
 impl<N> Node<N> for BaseNode
 where
-    N: FullNodeTypes<Types: OpNodeTypes<ChainSpec = OpChainSpec>>,
+    N: FullNodeTypes<Types: OpNodeTypes>,
 {
     type ComponentsBuilder = ComponentsBuilder<
         N,

--- a/crates/execution/runner/src/test_utils/constants.rs
+++ b/crates/execution/runner/src/test_utils/constants.rs
@@ -1,7 +1,7 @@
 //! Shared constants used across integration tests.
 
+pub use alloy_chains::NamedChain;
 use alloy_primitives::{B256, Bytes, b256, bytes};
-pub use reth_chainspec::NamedChain;
 
 // Block Building
 

--- a/crates/execution/runner/src/test_utils/harness.rs
+++ b/crates/execution/runner/src/test_utils/harness.rs
@@ -13,9 +13,8 @@ use base_alloy_network::Base;
 use base_alloy_rpc_types_engine::OpPayloadAttributes;
 use base_execution_chainspec::OpChainSpec;
 use eyre::{Result, eyre};
-use reth_chainspec::ChainSpecProvider;
 use reth_primitives_traits::{Block as BlockT, RecoveredBlock};
-use reth_provider::{BlockNumReader, BlockReader};
+use reth_provider::{BlockNumReader, BlockReader, ChainSpecProvider};
 use tokio::time::sleep;
 
 use crate::{


### PR DESCRIPTION
### Description
Remove the OpChainSpec[Parser] as generic options. These are never going to vary.