### PR TITLE
[bcp]: BCP-0001 BFT Sequencer Consensus

### DIFF
--- a/docs/specs/components/BCPsList.tsx
+++ b/docs/specs/components/BCPsList.tsx
@@ -16,6 +16,13 @@ const bcps: BcpEntry[] = [
     status: 'Final',
     link: '/bcps/bcp-0000',
   },
+  {
+    id: 'BCP-0001',
+    title: 'Byzantine-Fault-Tolerant Sequencer Consensus via Commonware Simplex',
+    description: 'Replaces op-conductor with an embedded BFT consensus engine using commonware\'s threshold_simplex protocol.',
+    status: 'Draft',
+    link: '/bcps/bcp-0001',
+  },
 ]
 
 const statusColor: Record<BcpStatus, { color: string; background: string }> = {

--- a/docs/specs/pages/bcps/bcp-0001.md
+++ b/docs/specs/pages/bcps/bcp-0001.md
@@ -1,0 +1,1009 @@
+# BCP-0001: Byzantine-Fault-Tolerant Sequencer Consensus via Commonware Simplex
+
+## Abstract
+
+op-conductor provides sequencer high availability through Raft consensus: a Go
+process co-deployed beside each `base-consensus` instance, operating a
+distributed state machine that tracks which node is the active sequencer and
+records the latest unsafe block hash. Raft is crash-fault-tolerant (CFT) — it tolerates node
+failures, not Byzantine behavior. It runs as a separate process, making it a
+single point of failure for the very failover it is meant to provide. And it
+injects a `CommitUnsafePayload` call directly into the block production
+critical path, where a degraded Raft cluster stalls block production for up to
+30 seconds per block.
+
+This BCP replaces op-conductor with a purpose-built consensus engine embedded
+in the sequencer node, using commonware's `threshold_simplex` protocol. The new
+engine provides Byzantine-fault-tolerant (BFT) leader election, VRF-based view
+rotation that is not predictable or manipulable by any participant, certified
+unsafe block attestation backed by BLS12-381 threshold signatures, and
+in-process operation that removes inter-process coordination overhead from the
+block production critical path entirely.
+
+---
+
+## 1. Status Quo
+
+### 1.1 Architecture
+
+Each sequencer deployment currently runs three processes per physical node:
+`base-reth-node` (execution layer), `base-consensus` (consensus and
+derivation), and `op-conductor` (sequencer lifecycle management). There is an
+ongoing effort to collapse `base-reth-node` and `base-consensus` into a single
+process. This BCP addresses the third process: `op-conductor`.
+
+op-conductor performs a narrow but critical function: it answers one distributed
+question — which of the N sequencer nodes is the currently active sequencer —
+and enforces that answer by starting and stopping sequencing on the local
+`base-consensus` node accordingly. It does this through Raft consensus, with
+one `op-conductor` instance per node forming a Raft cluster of typically three
+members.
+
+The integration between `op-conductor` and `base-consensus` is bidirectional
+and tightly coupled:
+
+- After sealing each block, `base-consensus` calls `conductor.commit_unsafe_payload()`
+  on its local conductor client with the sealed execution payload envelope. The
+  conductor propagates this to the Raft log with a 30-second timeout. If the
+  Raft cluster is degraded, this call blocks for the full 30 seconds before
+  failing — stalling block production for the duration.
+- On bootstrap, `base-consensus` calls `conductor.leader()` to determine whether
+  to start in `ActiveSequencer` or `ConductorFollower` mode. A non-leader result
+  causes the node to enter follower mode, running derivation but not building
+  blocks.
+- When a conductor detects that its node has become unhealthy (via its
+  `SequencerHealthMonitor`), it stops the local sequencer and calls
+  `TransferLeader()` on its Raft instance, triggering a new election. The newly
+  elected conductor starts the sequencer on its node.
+
+### 1.2 The Raft Consensus Core
+
+The conductor's Raft implementation uses `hashicorp/raft` backed by BoltDB for
+log and stable storage. The Raft finite state machine (`unsafeHeadTracker`)
+maintains exactly one piece of state: the latest committed
+`ExecutionPayloadEnvelope`. When a new leader starts sequencing, it calls
+`LatestUnsafePayload()`, which issues a Raft barrier (a linear consistency
+guarantee) and returns the most recently Raft-committed block. The new leader
+posts this block to its `base-consensus` node if needed to align the unsafe
+head before sequencing begins.
+
+The Raft FSM stores only the latest unsafe head; prior entries are compacted
+away through snapshots. Snapshot serialization is SSZ-encoded
+`ExecutionPayloadEnvelope`, with V4 and V3 fallback handling baked in to
+accommodate rolling upgrades. This creates a direct coupling between the Raft
+log format and the execution payload wire format — a coupling that has caused
+production incidents (issue #9064, Dencun upgrade) and requires
+format-version awareness in persistence code.
+
+### 1.3 Health Monitoring and the 8-State FSM
+
+The conductor's control loop evaluates three boolean dimensions —
+`leader × healthy × active` — producing eight possible states. In the
+healthy-leader-active state (normal operation), no action is taken. Any
+deviation triggers an action: stop sequencer, transfer leadership, start
+sequencer, or a combination.
+
+Health is determined by `SequencerHealthMonitor`, which checks:
+
+- Unsafe head recency (last unsafe block timestamp within configured threshold)
+- P2P peer count (above minimum)
+- Optional safe head progression
+- Optional EL P2P peer count
+- Optional rollup-boost health (with partial-health tolerance counters)
+
+Health check results are delivered to the control loop via a channel. The
+control loop dequeues actions with jittered backoff (0–2 seconds random sleep).
+This jitter prevents thundering-herd leadership elections but introduces
+non-determinism in failover timing.
+
+### 1.4 Cluster Membership
+
+Membership is managed manually through Raft's configuration API. Adding a node
+requires the operator to call `conductor_addServerAsVoter` from the current
+leader — there is no automatic discovery or join mechanism. Removing a node
+requires `conductor_removeServer`. All membership operations require passing the
+current Raft configuration version for optimistic concurrency control, and all
+require that the caller is the current Raft leader.
+
+Upgrades require pausing each node's conductor, waiting for unsafe head sync,
+then resuming. Leadership must be manually transferred away from any node being
+upgraded. The `pause` state is not persisted across restarts, which has caused
+production incidents where a newly restarted node incorrectly marked itself
+healthy before syncing its unsafe head (issue #12912).
+
+---
+
+## 2. Failure Analysis — Why op-conductor Falls Short
+
+### 2.1 Crash Fault Tolerance Is Insufficient for Decentralized Sequencing
+
+Raft is a CFT protocol. It tolerates the failure of nodes that crash but
+assumes all responding nodes are honest. In a permissioned three-node cluster
+operated by a single entity, this assumption holds. As the sequencer set moves
+toward decentralization — multiple independent operators — it breaks down. A
+single Byzantine node in a three-node Raft cluster can:
+
+- Delay elections indefinitely by responding but returning incorrect state
+- Submit crafted log entries to the FSM reporting a false unsafe head, causing
+  a new leader to begin sequencing at an incorrect block
+- Vote strategically in elections to favor specific leaders, enabling MEV
+  extraction via leader control
+
+CFT consensus cannot produce safety guarantees against any of these behaviors.
+BFT is required as soon as the sequencer operator set is no longer fully
+trusted.
+
+### 2.2 The Sidecar SPOF
+
+op-conductor is deployed as a sidecar process alongside `base-consensus`. It
+is responsible for ensuring `base-consensus`'s sequencer lifecycle is correctly
+managed — but if op-conductor itself crashes, `base-consensus` loses its
+governance. When `conductor.active()` returns false (because the conductor is
+stopped or crashed), `base-consensus` falls through to non-HA behavior and
+continues sequencing without conductor oversight. This means a crash of the
+conductor — the very component preventing two nodes from sequencing
+simultaneously — removes the safety guarantee it exists to enforce.
+
+The real failure mode: conductor crashes on node A while `base-consensus`
+continues sequencing on A; simultaneously, node B's conductor health monitor
+detects that A is unhealthy (because the conductor is down, not
+`base-consensus`) and elects B as the new leader; B starts sequencing. Two
+nodes are now sequencing simultaneously, producing an unsafe reorg.
+
+### 2.3 CommitUnsafePayload on the Critical Path
+
+The `commit_unsafe_payload()` call from `base-consensus` to op-conductor is
+synchronous after sealing every block, with a 30-second timeout. In a healthy cluster this
+takes tens of milliseconds. In a degraded cluster — where a node has just
+failed and Raft is mid-election — this call blocks for the full election
+timeout before failing.
+
+At a two-second block time, a 30-second stall is 15 consecutive missed blocks.
+Even a one-second Raft election timeout (the heartbeat default) reduces block
+production rate by 50%. The issue is structural: placing Raft's leader election
+and log commitment on the critical path of every block ties sequencer throughput
+directly to Raft availability.
+
+Production evidence: the Base Sepolia one-hour chain halt (issue #12448) was
+triggered by a `NewPayload` timeout in the execution layer that, when combined
+with a conductor leadership transfer, produced a deadlock in the sequencer actor
+— 60 minutes of downtime from a single block timeout.
+
+### 2.4 Predictable Leader Election Enables MEV Extraction
+
+Raft's leader election is not random: the first node to time out starts an
+election, and the outcome is determined by network timing and term numbers. In
+a three-node cluster with static configuration, the leader is predictable to
+any observer who knows the cluster's current term and heartbeat timeout.
+`TransferLeader()` uses Raft's built-in transfer, which selects "the most
+up-to-date follower" — a fully deterministic criterion. A strategic actor who
+knows which node will win the next election can position orders accordingly.
+Even if this is not currently being exploited, it becomes more significant as
+the sequencer moves toward decentralization and higher-value transaction
+ordering.
+
+### 2.5 Spurious Leadership Transfers Under Load
+
+Issue #17835 documents that Raft heartbeat timeouts (default 1000ms) are
+exceeded during normal operation when the conductor serves WebSocket flashblock
+streams alongside Raft P2P traffic. Exceeded heartbeat timeouts trigger
+leadership elections. Elections trigger sequencer restart on the new leader and
+sequencer stop on the old leader. A spurious election on a healthy cluster
+causes a sequencer restart with no underlying fault, introducing unnecessary
+latency spikes and unsafe head gaps.
+
+The root cause is that Raft's heartbeat and the application's data plane
+compete for the same TCP connections and processing loop — a known limitation
+of the `hashicorp/raft` implementation.
+
+### 2.6 Membership Changes Are Fragile
+
+Adding or replacing a node requires manual operator intervention:
+`AddServerAsVoter`, `AddServerAsNonVoter`, `DemoteVoter`, and `RemoveServer`
+are all operator-driven RPC calls that must be executed in the correct order
+with the correct version numbers. There is no automatic discovery, no automatic
+recovery from split membership state, and no protocol-level guarantee that
+membership changes are applied consistently across all nodes before the next
+election. The Raft leader can unilaterally add or remove any server — no other
+node's consent is required.
+
+### 2.7 The Raft Log Format Is Coupled to Execution Payload Versioning
+
+The `unsafeHeadTracker` FSM serializes `ExecutionPayloadEnvelope` via SSZ into
+the Raft log. When the execution payload format changed for the Dencun upgrade,
+the FSM required version-aware deserialization: try BlockV4, fall back to
+BlockV3. This coupling means every execution layer format upgrade potentially
+requires a corresponding conductor FSM update. Any mismatch produces
+deserialization failures during log replay — potentially at startup after a
+cluster upgrade, when the system is already in a degraded state.
+
+### 2.8 Cross-Language Operational Burden
+
+op-conductor is written in Go. The rest of the sequencer stack is converging on
+Rust. Operating a Go process alongside a Rust process introduces dual-language
+debugging, separate build pipelines, incompatible tracing and metrics
+libraries, and two memory management models to reason about during incidents.
+The conductor's BoltDB storage introduces a dependency on CGo bindings that
+complicates containerized deployments.
+
+---
+
+## 3. Prior Art — arturo
+
+### 3.1 What arturo Demonstrates
+
+`github.com/refcell/arturo` is a proof-of-concept sequencer consensus library
+in Rust, written by an author of this codebase, that integrates commonware's
+`ordered_broadcast` primitives with an OP Stack payload model. Although
+explicitly not production software, it demonstrates several correct design
+decisions:
+
+1. **The `Automaton` abstraction is the right seam.** arturo's
+   `PayloadAutomaton<P,K>` correctly implements commonware's `Automaton` trait,
+   mapping `propose` to block building and `verify` to block validation. This
+   is the right interface boundary between the consensus engine and block
+   production logic.
+
+2. **Epoch-based leader management is cleanly separable.** The `EpochManager`
+   trait (`sequencer()`, `quorum_threshold()`, `transfer_leader()`) is a clean
+   abstraction over leader selection policy. Health-based, round-robin, and
+   VRF-based strategies are each pluggable implementations of the same trait.
+
+3. **Consensus operates on compact digests, not full payloads.** arturo's
+   `OpPayload` computes its digest as SHA-256 over block hash and block number —
+   not the full payload bytes. This is the correct model: the consensus network
+   passes hashes; the execution layer owns payload storage.
+
+4. **Library embedding is the right integration model.** Being a library rather
+   than a process, arturo shows that consensus can be an actor in the node's
+   internal event bus alongside the sequencer and batcher, rather than a
+   separate process reached over RPC.
+
+### 3.2 What arturo Left Unfinished
+
+arturo's `Automaton` implementation is correct but the commonware
+`ordered_broadcast::Engine` is never instantiated — all inter-node
+communication happens over plain HTTP polling, which provides no authentication,
+no signature aggregation, and no Byzantine fault tolerance. The `acks: usize`
+counter is not backed by cryptographic verification: an acknowledgment is a bare
+HTTP POST, not a signature. The `signer` field is stored but never used.
+Split-brain is possible by design in the `HealthBasedEpochManager`. There is no
+persistence layer. `transfer_leader()` returns `NotSupported` for all real
+implementations.
+
+arturo is a sketch of the correct shape. The consensus engine that provides the
+actual guarantees — BFT safety, VRF-based leader election, threshold signature
+aggregation, cryptographic certified blocks — must come from commonware's
+`threshold_simplex` protocol, which arturo imports but does not wire up.
+
+---
+
+## 4. Proposal — Embedded Commonware Threshold Simplex Consensus
+
+### 4.1 Core Design Principles
+
+1. **In-process, not a sidecar.** The consensus engine is a crate embedded in
+   the sequencer node binary. There is no separate process to manage, no
+   inter-process RPC for the critical-path `Leader()` and
+   `CommitUnsafePayload()` calls.
+
+2. **BFT, not CFT.** The consensus protocol tolerates Byzantine nodes. In a
+   four-node cluster (minimum recommended), one Byzantine node cannot violate
+   safety. In a seven-node cluster, two Byzantine nodes cannot violate safety.
+
+3. **Off the critical path.** Block production does not wait for consensus.
+   The consensus engine certifies blocks asynchronously; the sequencer builds
+   the next block while vote collection for the current block proceeds
+   concurrently.
+
+4. **VRF-based leader rotation.** The active sequencer for view `v+1` is
+   determined by the threshold VRF embedded in view `v`'s consensus certificate
+   — knowable only after view `v` concludes, unpredictable before it, and not
+   manipulable by any coalition of fewer than `f+1` participants.
+
+5. **Threshold signatures for certified blocks.** An unsafe block is certified
+   when `2f+1` validators have co-signed a notarization certificate over its
+   hash. The certificate is compact (~240 bytes, a single BLS12-381 signature),
+   externally verifiable by anyone holding the threshold public key, and can
+   serve as a cross-chain inclusion receipt for bridges and light clients.
+
+### 4.2 Protocol Selection: threshold_simplex
+
+commonware provides four consensus dialects. The appropriate choice for this
+use case is `threshold_simplex`.
+
+`threshold_simplex` is identical to `simplex` (BFT, from the Simplex Consensus
+paper by Chan & Pass, TCC 2023) with one structural addition: every message
+carries an embedded BLS12-381 partial signature (an `attestation(v)` over the
+current view). After collecting `2f+1` messages, the full threshold signature
+`seed(v)` is recovered via Lagrange interpolation. This serves three roles
+simultaneously:
+
+**Consensus certificate.** `seed(v)` is a compact proof that `2f+1` validators
+attested to view `v`'s notarization. It is verifiable externally with a single
+pairing operation against the threshold public key, enabling bridges and light
+clients to verify sequencer attestations without running the full protocol.
+
+**VRF output.** `seed(v)` is unpredictable before view `v` concludes and
+cannot be influenced by fewer than `f+1` participants. The leader for view
+`v+1` is `validators[hash(seed(v)) mod n]`. No participant knows the next
+leader until the current view is nearly complete.
+
+**Zero message overhead.** The partial signature is carried in messages that
+must be sent for consensus to proceed anyway. There is no additional round trip
+for VRF computation. Compared to `simplex` with ed25519 multisig, certificates
+are smaller (~240 bytes vs larger aggregated ed25519 certificates) and
+verification is faster (one pairing vs O(n) ed25519 verifications).
+
+The cost of `threshold_simplex` over plain `simplex` is the DKG ceremony
+required at cluster initialization and at each validator set change. For a
+sequencer cluster of four to seven nodes changing membership infrequently, this
+cost is paid once per epoch and is fully acceptable.
+
+#### Fault Tolerance Comparison
+
+| Cluster | Protocol | Crash Faults | Byzantine Faults | Notes |
+|---|---|---|---|---|
+| 3 nodes | Raft (current) | 1 | 0 | Current op-conductor default |
+| 3 nodes | threshold_simplex | 0 | 0 | Same size; gains other properties |
+| **4 nodes** | **threshold_simplex** | **1** | **1** | **Recommended minimum** |
+| 7 nodes | threshold_simplex | 2 | 2 | Recommended for decentralized sets |
+
+A four-node `threshold_simplex` cluster tolerates strictly more failure modes
+than a three-node Raft cluster at the cost of one additional node. It tolerates
+crash faults at parity with current deployments and adds Byzantine fault
+tolerance that Raft cannot provide at any cluster size.
+
+#### Why Not simplex + ed25519?
+
+`simplex` with ed25519 is a viable lower-complexity alternative that avoids the
+DKG ceremony. Its certificates use ed25519 multisig: attributable (signer
+identity is preserved), usable as external fault evidence, and implementable
+without BLS12-381. The tradeoff: certificate size grows with validator count,
+batch verification is required for acceptable latency, leader election falls
+back to round-robin (predictable), and there is no compact external
+verifiability for bridges. `simplex` with ed25519 is appropriate as a fallback
+for small clusters (three nodes, zero Byzantine tolerance) or for operators who
+cannot accept the DKG ceremony. This BCP recommends `threshold_simplex` as the
+primary deployment target.
+
+### 4.3 Consensus Scope — What the Protocol Decides
+
+The consensus engine answers two questions and only two:
+
+**1. Who is the active sequencer for this view?** The leader for view `v` is
+determined by the `threshold_simplex` elector from `seed(v-1)`. All honest
+participants agree on the leader before the view begins. The active sequencer
+is the leader: it builds and proposes the block. Followers verify and vote.
+
+**2. What is the certified unsafe block at view `v`?** The engine certifies the
+block hash proposed by the leader. A notarization certificate over block hash
+`H_v` constitutes a `2f+1`-attested record that `H_v` was the sequencer's
+proposal at view `v` and was accepted by `2f+1` validators. A finalization
+certificate confirms that `2f+1` validators also endorsed the notarization.
+
+The consensus engine does **not** perform full block validation — it does not
+re-execute transactions, verify state roots, or check EL correctness. Validators
+verify only that the proposed block hash corresponds to a block they have
+received and that the execution layer accepted it via `new_payload`. Block
+validity is ultimately adjudicated by the L1 derivation pipeline.
+
+### 4.4 Architecture Overview
+
+```
+sequencer-node (single process)
+│
+├── ExecutionInterface
+│     ├── InProcessBackend  ──→ base-reth-node EVM execution
+│     └── HttpBackend (split deployments)
+│
+├── SequencerActor
+│     ├── BlockProducer — start_build / get_payload / new_payload
+│     └── [receives ConsensusCommand via internal channel] ←──────────────┐
+│                                                                          │
+├── ConsensusEngine (this BCP)                                             │
+│     ├── threshold_simplex::Engine                                        │
+│     │     ├── Voter          — Simplex protocol FSM                      │
+│     │     ├── Batcher        — BLS12-381 lazy signature aggregation      │
+│     │     └── Resolver       — on-demand cert/payload backfill           │
+│     ├── SequencerAutomaton (implements CertifiableAutomaton)             │
+│     │     ├── propose()  → sends ProposeBlock to SequencerActor,         │
+│     │     │               returns sealed block hash                      │
+│     │     ├── verify()   → delivers peer ExecutionPayload to EL          │
+│     │     │               via new_payload, returns EL result             │
+│     │     └── certify()  → approves notarization after 2f+1 votes       │
+│     ├── BlockRelay (implements Relay)                                    │
+│     │     └── sends full ExecutionPayload to validators post-propose     │
+│     ├── CertificateReporter (implements Reporter)                        │
+│     │     ├── on Notarization → emit NotarizedBlock event                │
+│     │     └── on Finalization → emit CertifiedBlock event ───────────────┘
+│     │           (consumed by Batcher, Proposer, HealthBus)
+│     └── P2PTransport (commonware-p2p authenticated, 5 channels)
+│           ├── channel 0: consensus votes (Notarize / Nullify / Finalize)
+│           ├── channel 1: certificates
+│           ├── channel 2: resolver (missing cert / payload backfill)
+│           ├── channel 3: block relay (full ExecutionPayload broadcast)
+│           └── channel 4: DKG coordination (epoch transitions only)
+│
+└── (Batcher, Proposer, DerivationPipeline, HealthBus, ...)
+```
+
+### 4.5 The SequencerAutomaton
+
+The `SequencerAutomaton` implements commonware's `CertifiableAutomaton` trait
+and is the integration point between the consensus engine and block production.
+
+```rust
+/// The Digest type is the block hash — consensus operates on 32-byte hashes,
+/// not full payloads. The execution layer owns payload storage.
+type Digest = alloy_primitives::B256;
+
+impl CertifiableAutomaton for SequencerAutomaton {
+    /// Called at epoch start. Returns the last finalized block hash as the
+    /// anchor for the new epoch.
+    async fn genesis(&mut self, epoch: Epoch) -> B256;
+
+    /// Called on the leader for view v. Sends ProposeBlock to SequencerActor
+    /// and returns the sealed block hash via oneshot.
+    async fn propose(&mut self, ctx: Context<B256, PublicKey>)
+        -> oneshot::Receiver<B256>;
+
+    /// Called on validators. Waits for the full ExecutionPayload to arrive
+    /// via the BlockRelay buffer (timeout: relay_timeout). Calls new_payload
+    /// on the ExecutionInterface. Returns true iff the EL returns Valid.
+    async fn verify(&mut self, ctx: Context<B256, PublicKey>, digest: B256)
+        -> oneshot::Receiver<bool>;
+
+    /// Called after 2f+1 notarizations. Returns true to broadcast a finalize
+    /// vote. Only returns false if the certified block is inconsistent with
+    /// local EL state — a condition that indicates a bug, not a policy choice.
+    async fn certify(&mut self, round: Round, digest: B256)
+        -> oneshot::Receiver<bool>;
+}
+```
+
+**`propose()` flow (leader path):**
+
+1. Sends `ConsensusCommand::ProposeBlock { view: ctx.round.view, parent: ctx.parent.1 }` to `SequencerActor` via internal channel.
+2. `SequencerActor` calls `ExecutionInterface.start_build(...)`, waits for the block interval, calls `get_payload(...)`, then `new_payload(...)` and `update_forkchoice(...)`.
+3. Returns the sealed block hash via oneshot.
+4. The `threshold_simplex` engine includes the hash in its `Notarize` vote and calls `BlockRelay.broadcast()` to push the full payload to all validators.
+
+**`verify()` flow (validator path):**
+
+1. The engine has received a `Notarize` vote from the leader containing `block_hash`.
+2. `SequencerAutomaton` waits for the corresponding `ExecutionPayload` to appear in the relay buffer (with timeout `relay_timeout`; if absent, returns `false` and a `Nullify` is broadcast).
+3. Calls `ExecutionInterface.new_payload(payload, parent_beacon_block_root)` on the local EL.
+4. Returns `true` if `new_payload` returns `Valid`, `false` otherwise.
+5. On `true`, broadcasts `Notarize` vote; on `false`, broadcasts `Nullify`.
+
+**Critical invariant:** `verify()` must be consistent across all honest
+participants. If honest validator A returns `true` for `verify(v, H)`, all
+other honest validators must also return `true`. This is guaranteed because
+`new_payload` on the execution layer is deterministic for valid blocks given
+the same pre-state. Any inconsistency indicates a pre-state divergence and must
+surface as an alert rather than a silent vote disagreement.
+
+### 4.6 Block Relay
+
+The `BlockRelay` delivers the full `ExecutionPayload` from the leader to
+validators so `verify()` can call `new_payload()` on it. The relay is a
+separate `commonware-p2p` channel (channel 3) distinct from the consensus vote
+channels for two reasons: full execution payloads are large (up to the gas
+limit in calldata and blob space), and payload delivery can be concurrent with
+vote collection rather than serialized through it.
+
+Validators buffer received payloads keyed by block hash. The `verify()`
+implementation waits up to `relay_timeout` for the payload to appear before
+returning `false`. This models the execution layer's view of block delivery:
+a block that the proposer claims exists but no validator can obtain in time is
+treated as if it does not exist.
+
+For in-process deployments (where the EL and consensus node share a process), the relay is a shared memory
+buffer — the leader's EL already holds the payload, and the relay passes a
+reference rather than serialized bytes. In split-process deployments, the relay
+sends the full payload over channel 3.
+
+### 4.7 Leader Election and Tenure
+
+#### The Simplex Default: Per-View Rotation
+
+In the baseline Simplex protocol, the leader changes every view. After
+collecting `2f+1` votes for view `v`, partial BLS signatures are combined
+to recover `seed(v)`. The leader for view `v+1` is:
+
+```
+leader(v+1) = validators[keccak256(seed(v)) mod n]
+```
+
+Properties:
+
+- **Unpredictability.** `seed(v)` requires `2f+1` of `n` secret shares to
+  reconstruct and is unknown to any party until those shares have been cast in
+  view `v`'s messages. The leader for view `v+1` is therefore unknowable until
+  view `v` is nearly complete.
+- **Manipulation resistance.** No coalition of fewer than `f+1` participants
+  can bias `seed(v)`. The threshold signature scheme guarantees this
+  cryptographically: each share is independently drawn from a secret polynomial,
+  and the recovered secret is Lagrange-interpolated from any `f+1` shares.
+- **Determinism.** All honest participants with the same threshold certificate
+  for view `v` compute the same `seed(v)` and agree on `leader(v+1)` without
+  additional communication.
+- **View 1 bootstrap.** `seed(0)` is determined by the DKG ceremony output —
+  a verifiable, multi-party-produced value that no individual controls.
+
+#### Why Per-View Rotation Is Excessive for a Sequencer
+
+Rotating the leader with every block — once every two seconds — is appropriate
+for a general BFT replicated state machine where any participant may propose
+arbitrary application state. For a sequencer it creates unnecessary friction:
+
+- Each leader change is functionally a mini-failover. The new leader must
+  confirm its EL's unsafe head aligns with the last certified block before
+  building, consuming view time in the common case.
+- Transaction pool sort order, flashblock pipeline state, and proposer cache
+  are effectively invalidated on every rotation.
+- The unpredictability guarantee does not meaningfully strengthen between a
+  1-block tenure and a 50-block tenure. An adversary who cannot forecast the
+  leader 100 seconds ahead gains nothing by learning the identity 2 seconds
+  ahead.
+- The existing op-conductor model is "sticky leader until health failure" — one
+  node builds continuously until explicitly evicted. Operator intuition and
+  tooling are built around that model.
+
+#### Leader Tenure
+
+A more natural model is a **leader tenure**: one validator serves as the active
+sequencer for `K` consecutive views before VRF rotation. The leader for all
+views in tenure `T = floor(v / K)` is determined by the threshold signature
+recovered at the end of tenure `T-1`:
+
+```
+seed_T    = seed recovered at the final certified view of tenure T-1
+leader(v) = validators[keccak256(seed_T) mod n]   for all v in [T·K, (T+1)·K)
+```
+
+The VRF unpredictability property is preserved at tenure granularity: no
+participant knows `seed_T` until tenure `T-1`'s final view concludes — the
+identity of the next leader is unknowable until `K` blocks before that tenure
+begins. For `K = 100` at a two-second block time, the next leader is unknown
+until ~200 seconds before it takes over.
+
+Within a tenure, failover is handled identically to the per-view case. Each
+view has an independent `leader_timeout`. If the active leader fails to propose
+in time, `2f+1` nullify votes advance the view. The same leader is retried for
+the next view in the tenure. If failures continue, views nullify through the
+remainder of the tenure and the VRF for the following tenure fires at the
+tenure boundary. A faulty leader loses at most one tenure before rotation —
+bounded latency, not indefinite stall.
+
+**Tenure length tradeoffs:**
+
+| Tenure (K) | Time @ 2s/block | Next leader unknown until | Failover cost (worst case) |
+|---|---|---|---|
+| 1 view | 2s | Current view completes | Immediate |
+| 25 views | 50s | ~50s before tenure | 25 view timeouts |
+| 100 views | 200s | ~200s before tenure | 100 view timeouts |
+| 300 views | 600s | ~600s before tenure | 300 view timeouts |
+
+A tenure of 50–150 blocks is a reasonable default for the current permissioned
+sequencer context. It preserves VRF unpredictability at the boundary, matches
+the "sticky sequencer" operational model, and eliminates per-block handoff
+overhead without meaningfully widening the MEV window relative to the
+alternative.
+
+#### Commonware Support for Configurable Tenure
+
+`threshold_simplex` as designed elects a new leader after each view.
+Configurable tenure requires one of:
+
+1. **`views_per_leader` parameter in the Commonware engine.** The engine caches
+   the tenure-boundary seed and calls `propose()` on the same node for
+   `views_per_leader` consecutive views. This is the cleanest path and should
+   be raised with the Commonware project early; it is a narrow change to the
+   elector component.
+
+2. **Tenure-aware `SequencerAutomaton`.** The automaton tracks the current
+   tenure boundary externally. When a new view begins within the same tenure,
+   it signals the engine via the supervisor interface to retain the current
+   leader without consuming a new seed. This avoids modifying Commonware
+   internals but couples the automaton more tightly to the supervisor API.
+
+The `views_per_leader` parameterization should be raised with Commonware before
+phase 2 begins. Phase 1 (shadow mode) can run with per-view rotation since it
+does not affect production block building. If the parameterization is not
+available by phase 2, the automaton shim is an acceptable interim solution.
+
+This replaces op-conductor's deterministic sorted-URL-order election (fully
+predictable, indefinitely) and Raft's timeout-race election (biasable by
+network timing).
+
+### 4.8 Certified Block Record and Failover
+
+When `CertificateReporter` receives a `Finalization` certificate, it:
+
+1. Appends `(view, block_hash, finalization_certificate)` to the consensus
+   journal.
+2. Emits a `CertifiedBlock` event on the node's internal event bus.
+3. Updates the `LatestCertifiedBlock` in-memory cache.
+
+On startup, the journal is replayed to recover `LatestCertifiedBlock`. When a
+newly elected leader's `propose()` is called, the `SequencerAutomaton` checks
+whether its local `LatestCertifiedBlock` matches the engine's view ancestry. If
+the local EL is behind (the node was a non-leader and missed blocks), the
+Resolver fetches missing payloads and certificates from peers before accepting
+the leader role for the first proposal.
+
+This replaces op-conductor's `compareUnsafeHead` logic, which only handles a
+single-block gap. The commonware Resolver handles arbitrary backfill by
+requesting missing certificates and payloads from peers on-demand.
+
+### 4.9 Key Management and DKG
+
+`threshold_simplex` requires a BLS12-381 threshold keypair shared across the
+validator set, established through commonware's DKG
+(`commonware-cryptography::bls12381::dkg`, implementing GJKR99 / Desmedt97).
+
+**Initial cluster setup:**
+
+1. Each of `n` nodes generates a BLS12-381 keypair and publishes its public
+   key via the bootstrap coordination tool.
+2. Each node runs the DKG as both dealer and player, broadcasting polynomial
+   commitments over the authenticated P2P channel 4.
+3. After DKG completes, each node holds a private secret share and all nodes
+   share a threshold public key `TPK`.
+4. `TPK` is published in the rollup config as `sequencer_threshold_public_key`,
+   enabling external bridges and light clients to verify threshold signatures
+   without participating in the DKG.
+
+**Epoch transitions (validator set changes):**
+
+commonware's resharing protocol transitions from one secret sharing polynomial
+to another while preserving the same `TPK`. A resharing requires `2f+1` of the
+current epoch's shareholders cooperating to issue shares to the new epoch's
+shareholders. The result: new nodes can join and old nodes can leave without
+changing the externally visible `TPK` and without a trusted coordinator. Light
+clients and bridges that hold `TPK` need no update when the sequencer set
+changes.
+
+**Share custody:** Each node's BLS12-381 secret share is stored encrypted at
+rest using `commonware-cryptography::Secret`, which zeroes memory on drop and
+prevents accidental logging. The share is loaded at startup and held in memory
+for the duration of the epoch.
+
+### 4.10 Membership and Epoch Management
+
+Epoch transitions are triggered by one of:
+
+- Scheduled advance (`views_per_epoch` threshold reached)
+- Operator-initiated membership change (add/remove validator, governed by a
+  two-phase commit: the change is proposed by any validator, then certified by
+  `2f+1` agreement)
+- Inactivity timeout (no finalization within `skip_timeout × activity_timeout`
+  views — indicates a stuck cluster)
+
+On epoch transition:
+
+1. The current `threshold_simplex` engine is cleanly shut down, draining
+   pending work and persisting its state to the journal.
+2. A resharing DKG runs among the current `2f+1`-of-`n` threshold holders
+   and any new members, over P2P channel 4.
+3. A new `threshold_simplex::Engine` is instantiated with the new validator
+   set, anchored at the last finalized block hash from the previous epoch.
+4. The engine's `genesis()` method is called with the new epoch number.
+
+Membership changes are proposed through the consensus engine itself — not
+through external RPC. A validator proposes a `MembershipPayload` type that the
+`SequencerAutomaton` recognizes as an epoch boundary trigger. This means
+membership changes require `2f+1` agreement: no single operator can unilaterally
+add or remove validators, unlike op-conductor's Raft leader with
+`AddServerAsVoter`.
+
+### 4.11 Storage and Persistence
+
+The consensus engine uses commonware's
+`journal::segmented::variable::Journal` for its write-ahead log. The journal
+stores:
+
+- All valid consensus messages received and generated (Notarize/Nullify/Finalize
+  votes) for the current activity window
+- Finalization certificates for every finalized view
+- DKG coordination messages (separate journal partition, retained only during
+  epoch transitions)
+
+The journal provides automatic crash recovery: on restart, the engine replays
+it to restore `last_finalized`, `last_notarized`, and
+`outstanding_certifications`. This replaces op-conductor's BoltDB Raft log.
+
+Critically, the journal stores 32-byte block hashes, not execution payloads.
+Execution layer format upgrades require no changes to the consensus journal.
+The execution layer owns payload storage; the consensus layer owns only the
+ordering record.
+
+### 4.12 Off-Critical-Path Certification
+
+A key design departure from op-conductor: block certification is **not on the
+block production critical path**.
+
+In the current design, `CommitUnsafePayload` is called synchronously after
+sealing every block. The block interval is effectively
+`block_build_time + raft_commit_time`. If Raft is slow, blocks are slow.
+
+In the new design:
+
+1. `propose()` is called by the consensus engine when it is the leader's turn.
+2. `propose()` triggers block production and returns the block hash when
+   sealing completes.
+3. Vote collection (`2f+1` notarize votes) happens concurrently while the next
+   block is already being built.
+4. `CertifiedBlock` events arrive asynchronously, consumed by the Batcher and
+   Proposer.
+5. Block production for view `v+1` begins immediately after `propose(v)`
+   returns — it does not wait for notarization.
+
+A view timeout (`leader_timeout`, suggested 500ms) fires only if `2f+1` votes
+are not collected in time. In that case, the engine emits a `Nullify` and the
+elector picks a new leader for the next view. The previous leader yields;
+the new leader begins block production. The view timeout is the *only* path
+by which slow consensus affects block production — and it requires a majority
+of validators to be unresponsive, not merely slow.
+
+This decouples consensus network latency from block production latency
+completely under normal operation.
+
+---
+
+## 5. Key Changes
+
+- **New crate: `crates/consensus/sequencer-consensus/`** implements
+  `SequencerAutomaton`, `BlockRelay`, `CertificateReporter`, and
+  `DKGCoordinator`. Depends on `commonware-consensus`, `commonware-cryptography`,
+  `commonware-p2p`, `commonware-storage`, `commonware-runtime`. No dependency
+  on `op-conductor`, `hashicorp/raft`, or any Go package.
+
+- **Removed process: `op-conductor` (Go).** The `op-conductor` binary, its
+  Raft consensus package (`consensus/raft.go`, `consensus/raft_fsm.go`), and
+  its BoltDB storage are retired. The `rpc/execution_proxy.go` and
+  `rpc/node_proxy.go` proxy logic is replaced by direct in-process routing in
+  the node's RPC server.
+
+- **Modified: `SequencerActor` in `crates/consensus/service/src/actors/sequencer/`.** The
+  actor gains a `ConsensusCommand` channel replacing the inbound conductor poll
+  loop:
+  - `ConsensusCommand::ProposeBlock { view, parent_hash }` — triggers block
+    production; response channel returns the sealed block hash.
+  - `ConsensusCommand::YieldLeadership` — signals view nullification; if
+    building, cancel or complete and yield the slot.
+  - `ConsensusCommand::InsertPeerBlock { payload, block_hash }` — delivers a
+    peer's execution payload for validator-path `verify()` calls; routes to
+    `ExecutionInterface.new_payload()`.
+  The `SealState` FSM in `seal.rs` is simplified: the `Sealed → Committed`
+  transition no longer calls `conductor.commit_unsafe_payload()` and the
+  `SealState::Committed` variant is removed. The conductor field on
+  `SequencerActor` is removed.
+
+- **Modified: `base-consensus` conductor interface.** The `Conductor` trait in
+  `crates/consensus/service/src/actors/sequencer/conductor.rs`
+  (`leader()`, `commit_unsafe_payload()`, `override_leader()`) is replaced by
+  in-process `ConsensusEngine` actor messaging. The `ConductorClient` HTTP
+  client and the `ConductorApi` JSON-RPC server trait are retired. The
+  `BootstrapRole::ConductorFollower` path in `EngineRequestProcessor` is
+  replaced by a query to the embedded `ConsensusEngine` actor. During migration,
+  `sequencer-consensus` exposes a compatibility JSON-RPC server implementing
+  the `conductor_` namespace so op-conductor's external tooling requires no
+  changes during phases 1 and 2.
+
+- **New: DKG bootstrap tooling.** `basectl conductor bootstrap` orchestrates
+  the initial DKG ceremony: it coordinates public key exchange between nodes,
+  runs the DKG rounds over authenticated P2P channel 4, and persists each
+  node's secret share to encrypted storage. `basectl conductor add-validator`
+  and `basectl conductor remove-validator` orchestrate the resharing ceremony
+  for epoch transitions.
+
+- **Modified: rollup config.** A `sequencer_threshold_public_key: [u8; 48]`
+  field (compressed BLS12-381 G1 point) is added to the rollup config. This
+  enables light clients and external bridges to verify threshold
+  signature certificates from the sequencer without participating in the
+  consensus protocol.
+
+- **New: `ConsensusEngine` health surface.** The node's `HealthBus` gains
+  a `ConsensusState` publisher: `last_notarized_view`, `last_finalized_view`,
+  `view_timeout_count`, `nullification_count`, `active_validators`,
+  `certification_lag_ms`. A `view_timeout_count` increase without a
+  corresponding node health event indicates network congestion and fires a
+  targeted alert distinct from the general sequencer health alert.
+
+- **Modified: Batcher and Proposer subscriptions.** Both services currently
+  poll `LatestUnsafePayload` via op-conductor RPC to determine what has been
+  certified. They are updated to subscribe to `CertifiedBlock` events on the
+  internal event bus, replacing the RPC poll with an
+  in-process push.
+
+- **Removed: `commit_unsafe_payload` call.** The synchronous
+  `conductor.commit_unsafe_payload()` call in `base-consensus`'s seal pipeline
+  (`crates/consensus/service/src/actors/sequencer/seal.rs`, `SealState::Sealed`
+  transition) is removed entirely. The consensus engine drives block proposals;
+  it does not receive sealed blocks from the sequencer actor. The sequencer
+  responds to `ProposeBlock` commands from the engine rather than pushing to the
+  engine.
+
+---
+
+## 6. Migration Path
+
+Migration proceeds in three phases, each independently rollback-able and
+observable through shadow metrics.
+
+**Phase 1 — Shadow mode.** The `sequencer-consensus` crate is deployed
+alongside op-conductor but does not control the sequencer. It observes
+op-conductor's certified unsafe heads (by intercepting the existing
+`conductor_commitUnsafePayload` call as a read-only tap), replicates them
+into its own consensus journal, and runs the full `threshold_simplex` protocol
+among a shadow validator set. Notarization and finalization certificates are
+produced and logged but not used to govern sequencer start/stop. This phase
+validates that the `threshold_simplex` engine certifies the same sequence of
+blocks that Raft certifies, without affecting production traffic.
+
+**Phase 2 — Parallel authority.** The `sequencer-consensus` engine takes over
+the `Leader()` decision for block building: the sequencer builds blocks only
+when the consensus engine designates it as leader for the current view.
+op-conductor retains the `StopSequencer` authority and continues to monitor
+health as a backstop. Certification from `threshold_simplex` replaces the
+`CommitUnsafePayload` Raft log write, eliminating the critical-path blocking
+call and the 30-second timeout hazard. This phase is the most operationally
+significant change; it is gated behind a feature flag per node.
+
+**Phase 3 — Full replacement.** op-conductor is retired. The
+`sequencer-consensus` engine has sole authority over sequencer lifecycle. Health
+monitoring is absorbed into the node's `HealthBus`. The conductor's proxy
+RPC endpoints (`eth_`, `optimism_`, `admin_` namespaces) are replaced by direct
+routing in the node's RPC server. The `overrideLeader` disaster recovery
+mechanism is replaced by `basectl conductor override`, which sets an in-process
+flag with the same semantics as op-conductor's `OverrideLeader(true)` — the
+escape hatch for operating a single-node sequencer when the cluster is fully
+unavailable.
+
+---
+
+## 7. Tradeoffs
+
+**Gained:**
+
+- **BFT safety.** A four-node cluster tolerates one Byzantine sequencer; a
+  seven-node cluster tolerates two. No coalition of `f` nodes can cause two
+  honest nodes to simultaneously believe they are the active sequencer. This is
+  a categorical safety improvement over Raft at any cluster size.
+
+- **No sidecar SPOF.** The consensus engine is embedded in the sequencer node
+  binary. A process crash cannot produce the split-sequencer scenario that
+  op-conductor's crash enables, because there is no separate conductor process
+  to crash while `base-consensus` continues running independently.
+
+- **Critical-path decoupling.** Block production no longer waits for consensus
+  network round-trips. A slow or temporarily unavailable consensus network
+  delays certificate collection — a downstream concern for the Batcher and
+  Proposer — but does not delay block sealing. The 30-second stall mode is
+  eliminated structurally.
+
+- **VRF-based leader election.** The next leader is unpredictable until the
+  current view is nearly complete and is not manipulable by any coalition of
+  fewer than `f+1` participants. MEV extraction via leader foreknowledge is
+  eliminated.
+
+- **Compact threshold certificates.** A notarization certificate is a single
+  ~240-byte BLS12-381 signature, verifiable externally with one pairing
+  operation. This enables bridges and light clients to verify certified blocks
+  without running the full consensus protocol.
+
+- **Rust throughout.** A single language for the entire sequencer stack
+  eliminates dual-language operational burden, enables unified tracing and
+  metrics, and allows the consensus engine to share memory with the block
+  producer without serialization overhead.
+
+- **Format-agnostic persistence.** The consensus journal stores 32-byte block
+  hashes. Execution layer format upgrades require no changes to consensus
+  storage. The SSZ version-aware deserialization hack in the Raft FSM is
+  removed entirely.
+
+- **BFT membership changes.** Adding or removing validators requires `2f+1`
+  agreement. No single operator can unilaterally alter cluster composition.
+
+- **Resharing without key rotation.** Validator set changes preserve the
+  threshold public key, enabling light clients and bridges to hold a stable
+  long-term verification key across all sequencer set changes.
+
+**Sacrificed:**
+
+- **DKG ceremony at initialization and membership change.** `threshold_simplex`
+  requires a distributed key generation step before the cluster can operate.
+  This is more operationally complex than Raft's single-node bootstrap.
+  Resharing for membership changes requires `2f+1` current shareholders online
+  simultaneously — more demanding than Raft's leader-driven `AddServerAsVoter`.
+
+- **Larger minimum cluster for BFT guarantees.** A three-node
+  `threshold_simplex` cluster provides no Byzantine fault tolerance (n=3f+1 →
+  f=0 for n=3). Meaningful BFT requires four nodes minimum. Operators on
+  three-node op-conductor clusters must add a fourth node to gain Byzantine
+  fault tolerance, though they gain the other architectural improvements at
+  three nodes.
+
+- **commonware is pre-production.** As of early 2026, commonware is ALPHA/BETA
+  software with Tempo as its first production deployment. Committing to
+  commonware means accepting a library that has not yet seen the production
+  volume of `hashicorp/raft`. This requires active engagement with the
+  commonware project, extensive shadow-mode validation before promotion to
+  phases 2 and 3, and acceptance that the API surface may evolve. The
+  deterministic testing runtime (which enables reproducible simulation of
+  Byzantine faults and network partitions) is a mitigation: we can run
+  the production sequencer cluster logic against simulated adversarial scenarios
+  before exposure to real traffic.
+
+- **BLS12-381 operational complexity.** BLS key management is more operationally
+  complex than ed25519. Secret share custody, share backup, and the resharing
+  ceremony require operator training and documented runbooks. A lost secret
+  share that drops the active shareholder count below `f+1` is a liveness
+  failure. Dropping below `2f+1` is a safety failure requiring emergency key
+  recovery procedures.
+
+- **`certify()` consistency invariant.** The `certify()` callback must be
+  consistent across all honest participants — a correctness invariant that must
+  be enforced by the `SequencerAutomaton` implementation. An inconsistency
+  caused by a bug in the EL's `new_payload` response handling breaks liveness.
+  This invariant is harder to test than CFT invariants and requires dedicated
+  conformance tests verifying that all honest nodes reach the same verdict on
+  the same block.
+
+- **Migration complexity.** The three-phase migration requires running both
+  op-conductor and the new consensus engine in parallel during phases 1 and 2.
+  This doubles the consensus-related operational surface area during transition.
+  Phase 2 in particular requires careful staging: a configuration mismatch
+  between which nodes have enabled parallel authority and which have not can
+  produce a disagreement about who the active sequencer is.
+
+---
+
+## 8. Estimated Impact
+
+**Safety.** The critical split-sequencer scenario — two nodes simultaneously
+sequencing due to a conductor process crash — is eliminated structurally.
+BFT guarantees are added for clusters of four or more nodes, directly
+addressing the requirements of a decentralizing sequencer set where individual
+operators cannot be assumed fully trustworthy.
+
+**Block production latency.** The `CommitUnsafePayload` blocking call is
+removed from the critical path. At observed Raft commit latencies of 20–100ms
+under normal conditions, this recovers 1–5% of a two-second block interval
+under normal operation. The multi-block stall scenario (30-second timeout on a
+degraded cluster causing 15 missed blocks) is eliminated entirely.
+
+**Failover latency.** op-conductor's Raft-based failover requires one full
+heartbeat timeout (~1s) plus the `compareUnsafeHead` alignment check (variable,
+requires at least one round trip to `base-consensus`). `threshold_simplex` failover is
+bounded by `leader_timeout` (configurable, suggested 500ms): after one timeout
+period without a leader proposal, `2f+1` nullify votes are cast and the next
+VRF-determined leader begins proposing. Because the next leader is already known
+(from the VRF), there is no additional election round — the transition is a
+single timeout with no election round-trip latency.
+
+**Leader election predictability.** Zero foreknowledge beyond the current view.
+Op-conductor's sorted-URL election is predictable indefinitely; Raft's timeout
+race is predictable to within network timing. VRF-based election provides
+cryptographic unpredictability with a one-view lookahead at most.
+
+**Certificate footprint.** A finalization certificate over an unsafe block is
+~240 bytes. This is an order of magnitude smaller than the
+SSZ-encoded `ExecutionPayloadEnvelope` currently stored in the Raft log
+(ranging from a few kilobytes to tens of kilobytes), and eliminates any
+requirement for the consensus layer to store or replicate full block payloads.
+
+**Cross-chain composability.** The threshold public key `TPK` in the rollup
+config enables bridges, light clients, and monitoring services to
+verify sequencer attestations with a single BLS12-381 pairing operation. This
+is a qualitative improvement in sequencer accountability and interoperability
+that Raft certificates cannot provide at any configuration.
+
+**Validator set decentralization.** The upgrade from CFT to BFT, combined with
+the VRF-based unpredictable leader election and the BFT-governed membership
+change protocol, directly unblocks the path to running an independent
+multi-operator sequencer set. These properties are prerequisites for
+decentralized sequencing; they cannot be layered onto Raft after the fact.


### PR DESCRIPTION
## Summary

This PR introduces BCP-0001, which proposes replacing op-conductor with a purpose-built BFT consensus engine embedded directly in the sequencer node using commonware's threshold_simplex protocol. The new design provides Byzantine-fault-tolerant leader election, VRF-based view rotation, and BLS12-381 threshold signature attestation for unsafe blocks. It also adds the BCP-0001 entry to the BCPs list component in the specs site.