### PR TITLE
refactor(batcher): eliminate redundant hash_slow() recomputation

### DIFF
--- a/crates/batcher/core/src/driver.rs
+++ b/crates/batcher/core/src/driver.rs
@@ -2,6 +2,7 @@
 
 use std::time::Duration;
 
+use alloy_primitives::B256;
 use base_alloy_consensus::BaseBlock;
 use base_batcher_encoder::{BatchPipeline, StepResult};
 use base_batcher_source::{
@@ -172,7 +173,7 @@ where
                     self.pipeline.force_close_channel();
                     draining = true;
                 }
-                DriverEvent::Block(b) => self.on_block(b),
+                DriverEvent::Block { block, hash } => self.on_block(block, hash),
                 DriverEvent::Flush => {
                     self.pipeline.force_close_channel();
                     debug!("flush signal received, force-closed channel");
@@ -244,9 +245,9 @@ where
     /// discards in-flight submissions, resets the pipeline, and restarts
     /// sequential catchup from `safe_head + 1`. The triggering block will be
     /// re-delivered by the sequential poller.
-    fn on_block(&mut self, block: Box<BaseBlock>) {
+    fn on_block(&mut self, block: Box<BaseBlock>, hash: alloy_primitives::B256) {
         let number = block.header.number;
-        match self.pipeline.add_block(*block) {
+        match self.pipeline.add_block(*block, hash) {
             Ok(()) => {
                 debug!(block = %number, "added unsafe block to pipeline");
             }
@@ -341,10 +342,10 @@ where
                 }
 
                 event = self.source.next() => match event {
-                    Ok(L2BlockEvent::Block(_) | L2BlockEvent::Flush) if self.stopped => {
+                    Ok(L2BlockEvent::Block { .. } | L2BlockEvent::Flush) if self.stopped => {
                         continue;
                     }
-                    Ok(L2BlockEvent::Block(block)) => DriverEvent::Block(block),
+                    Ok(L2BlockEvent::Block { block, hash }) => DriverEvent::Block { block, hash },
                     Ok(L2BlockEvent::Flush) => DriverEvent::Flush,
                     Ok(L2BlockEvent::Reorg { new_safe_head }) => DriverEvent::Reorg(new_safe_head),
                     Err(SourceError::Exhausted) => DriverEvent::Shutdown,

--- a/crates/batcher/core/src/event.rs
+++ b/crates/batcher/core/src/event.rs
@@ -1,5 +1,6 @@
 //! Internal driver event type produced by the `tokio::select!` I/O phase.
 
+use alloy_primitives::B256;
 use base_alloy_consensus::BaseBlock;
 use base_batcher_encoder::SubmissionId;
 use base_protocol::L2BlockInfo;
@@ -12,7 +13,9 @@ pub enum DriverEvent {
     /// Cancellation token fired, or L2 source signalled exhausted.
     Shutdown,
     /// New L2 unsafe block from the source.
-    Block(Box<BaseBlock>),
+    ///
+    /// `hash` is pre-computed from the RPC response, avoiding redundant `hash_slow()` calls.
+    Block { block: Box<BaseBlock>, hash: B256 },
     /// Source requested a force-flush of the current channel.
     Flush,
     /// L2 reorganisation; new safe head provided.

--- a/crates/batcher/core/src/test_utils/pipeline.rs
+++ b/crates/batcher/core/src/test_utils/pipeline.rs
@@ -53,7 +53,7 @@ impl TrackingPipeline {
 }
 
 impl BatchPipeline for TrackingPipeline {
-    fn add_block(&mut self, _: BaseBlock) -> Result<(), (ReorgError, Box<BaseBlock>)> {
+    fn add_block(&mut self, _: BaseBlock, _hash: alloy_primitives::B256) -> Result<(), (ReorgError, Box<BaseBlock>)> {
         Ok(())
     }
 
@@ -112,7 +112,7 @@ impl ReorgPipeline {
 }
 
 impl BatchPipeline for ReorgPipeline {
-    fn add_block(&mut self, block: BaseBlock) -> Result<(), (ReorgError, Box<BaseBlock>)> {
+    fn add_block(&mut self, block: BaseBlock, _hash: alloy_primitives::B256) -> Result<(), (ReorgError, Box<BaseBlock>)> {
         Err((
             ReorgError::ParentMismatch { expected: B256::ZERO, got: B256::with_last_byte(1) },
             Box::new(block),
@@ -164,7 +164,7 @@ impl OneReorgPipeline {
 }
 
 impl BatchPipeline for OneReorgPipeline {
-    fn add_block(&mut self, block: BaseBlock) -> Result<(), (ReorgError, Box<BaseBlock>)> {
+    fn add_block(&mut self, block: BaseBlock, _hash: alloy_primitives::B256) -> Result<(), (ReorgError, Box<BaseBlock>)> {
         if self.fail_next {
             self.fail_next = false;
             return Err((

--- a/crates/batcher/encoder/src/encoder.rs
+++ b/crates/batcher/encoder/src/encoder.rs
@@ -337,7 +337,7 @@ impl BatchEncoder {
 }
 
 impl BatchPipeline for BatchEncoder {
-    fn add_block(&mut self, block: BaseBlock) -> Result<(), (ReorgError, Box<BaseBlock>)> {
+    fn add_block(&mut self, block: BaseBlock, hash: B256) -> Result<(), (ReorgError, Box<BaseBlock>)> {
         if !self.blocks.is_empty() && block.header.parent_hash != self.tip {
             return Err((
                 ReorgError::ParentMismatch { expected: self.tip, got: block.header.parent_hash },
@@ -346,7 +346,6 @@ impl BatchPipeline for BatchEncoder {
         }
 
         let number = block.header.number;
-        let hash = block.header.hash_slow();
         self.tip = hash;
         self.blocks.push_back(block);
         BatcherMetrics::pending_blocks().increment(1.0);

--- a/crates/batcher/encoder/src/pipeline.rs
+++ b/crates/batcher/encoder/src/pipeline.rs
@@ -1,5 +1,6 @@
 //! The batcher pipeline trait.
 
+use alloy_primitives::B256;
 use base_alloy_consensus::BaseBlock;
 
 use crate::{BatchSubmission, ReorgError, StepError, StepResult, SubmissionId};
@@ -21,7 +22,7 @@ pub trait BatchPipeline: Send {
     /// current tip, giving the caller back the block so it can be re-fed after
     /// [`reset`](Self::reset). On reorg error the caller must reset the pipeline and
     /// re-add the returned block as the first block of the new chain.
-    fn add_block(&mut self, block: BaseBlock) -> Result<(), (ReorgError, Box<BaseBlock>)>;
+    fn add_block(&mut self, block: BaseBlock, hash: B256) -> Result<(), (ReorgError, Box<BaseBlock>)>;
 
     /// Advance the pipeline by one step.
     ///

--- a/crates/batcher/encoder/src/test_utils/mod.rs
+++ b/crates/batcher/encoder/src/test_utils/mod.rs
@@ -4,6 +4,7 @@ use std::collections::VecDeque;
 
 use base_alloy_consensus::BaseBlock;
 
+use alloy_primitives::B256;
 use crate::{BatchPipeline, BatchSubmission, ReorgError, StepError, StepResult, SubmissionId};
 
 /// A mock implementation of [`BatchPipeline`] for testing downstream consumers
@@ -31,7 +32,7 @@ pub struct MockBatchPipeline {
 }
 
 impl BatchPipeline for MockBatchPipeline {
-    fn add_block(&mut self, block: BaseBlock) -> Result<(), (ReorgError, Box<BaseBlock>)> {
+    fn add_block(&mut self, block: BaseBlock, _hash: B256) -> Result<(), (ReorgError, Box<BaseBlock>)> {
         self.blocks_added.push(block);
         Ok(())
     }

--- a/crates/batcher/service/src/service.rs
+++ b/crates/batcher/service/src/service.rs
@@ -4,6 +4,7 @@ use std::sync::Arc;
 
 use alloy_provider::{Provider, ProviderBuilder, RootProvider};
 use alloy_rpc_types_eth::BlockNumberOrTag;
+use alloy_primitives::B256;
 use base_alloy_consensus::BaseBlock;
 use base_alloy_network::Base;
 use base_batcher_admin::AdminServer;
@@ -60,7 +61,7 @@ enum Subscription {
 }
 
 impl BlockSubscription for Subscription {
-    fn take_stream(&mut self) -> BoxStream<'static, Result<BaseBlock, SourceError>> {
+    fn take_stream(&mut self) -> BoxStream<'static, Result<(BaseBlock, B256), SourceError>> {
         match self {
             Self::Ws(ws) => ws.take_stream(),
             Self::Null(null) => null.take_stream(),
@@ -199,9 +200,10 @@ impl BatcherService {
                         .ok_or_else(|| {
                             SourceError::Provider(format!("block {} not found", header.number))
                         })?;
+                    let hash = rpc_block.header.hash;
                     let block =
                         rpc_block.into_consensus().map_transactions(|t| t.inner.into_inner());
-                    Ok(block)
+                    Ok((block, hash))
                 }
             })
             .boxed();

--- a/crates/batcher/service/src/source.rs
+++ b/crates/batcher/service/src/source.rs
@@ -5,6 +5,7 @@ use std::sync::{Arc, Mutex};
 use alloy_provider::Provider;
 use alloy_rpc_types_eth::BlockNumberOrTag;
 use async_trait::async_trait;
+use alloy_primitives::B256;
 use base_alloy_consensus::BaseBlock;
 use base_alloy_network::Base;
 use base_batcher_source::{PollingSource, SourceError};
@@ -43,7 +44,7 @@ impl RpcPollingSource {
 
 #[async_trait]
 impl PollingSource for RpcPollingSource {
-    async fn unsafe_head(&self) -> Result<BaseBlock, SourceError> {
+    async fn unsafe_head(&self) -> Result<(BaseBlock, B256), SourceError> {
         let sequential = *self.next_sequential.lock().unwrap();
 
         if let Some(n) = sequential {
@@ -57,30 +58,30 @@ impl PollingSource for RpcPollingSource {
                 // Block n hasn't been produced yet; switch to normal polling.
                 *self.next_sequential.lock().unwrap() = None;
             } else {
-                let block = self
+                let rpc_block = self
                     .provider
                     .get_block_by_number(n.into())
                     .full()
                     .await
                     .map_err(|e| SourceError::Provider(e.to_string()))?
-                    .ok_or_else(|| SourceError::Provider(format!("block {n} not found")))?
-                    .into_consensus()
-                    .map_transactions(|t| t.inner.into_inner());
+                    .ok_or_else(|| SourceError::Provider(format!("block {n} not found")))?;
+                let hash = rpc_block.header.hash;
+                let block = rpc_block.into_consensus().map_transactions(|t| t.inner.into_inner());
                 *self.next_sequential.lock().unwrap() = Some(n + 1);
-                return Ok(block);
+                return Ok((block, hash));
             }
         }
 
-        let block = self
+        let rpc_block = self
             .provider
             .get_block_by_number(BlockNumberOrTag::Latest)
             .full()
             .await
             .map_err(|e| SourceError::Provider(e.to_string()))?
-            .ok_or_else(|| SourceError::Provider("latest block not found".to_string()))?
-            .into_consensus()
-            .map_transactions(|t| t.inner.into_inner());
-        Ok(block)
+            .ok_or_else(|| SourceError::Provider("latest block not found".to_string()))?;
+        let hash = rpc_block.header.hash;
+        let block = rpc_block.into_consensus().map_transactions(|t| t.inner.into_inner());
+        Ok((block, hash))
     }
 
     fn reset_catchup(&self, start_from: u64) {

--- a/crates/batcher/service/src/subscription.rs
+++ b/crates/batcher/service/src/subscription.rs
@@ -2,6 +2,7 @@
 
 use std::sync::Arc;
 
+use alloy_primitives::B256;
 use base_alloy_consensus::BaseBlock;
 use base_batcher_source::{BlockSubscription, SourceError};
 use futures::{StreamExt, stream::BoxStream};
@@ -23,7 +24,7 @@ pub struct WsBlockSubscription {
     #[debug(skip)]
     _provider: Arc<dyn std::any::Any + Send + Sync>,
     #[debug("{:?}", stream.as_ref().map(|_| "<stream>"))]
-    stream: Option<BoxStream<'static, Result<BaseBlock, SourceError>>>,
+    stream: Option<BoxStream<'static, Result<(BaseBlock, B256), SourceError>>>,
 }
 
 impl WsBlockSubscription {
@@ -33,14 +34,14 @@ impl WsBlockSubscription {
     /// WS root provider returned by [`ProviderBuilder::connect`].
     pub fn new<P: std::any::Any + Send + Sync + 'static>(
         provider: Arc<P>,
-        stream: BoxStream<'static, Result<BaseBlock, SourceError>>,
+        stream: BoxStream<'static, Result<(BaseBlock, B256), SourceError>>,
     ) -> Self {
         Self { _provider: provider, stream: Some(stream) }
     }
 }
 
 impl BlockSubscription for WsBlockSubscription {
-    fn take_stream(&mut self) -> BoxStream<'static, Result<BaseBlock, SourceError>> {
+    fn take_stream(&mut self) -> BoxStream<'static, Result<(BaseBlock, B256), SourceError>> {
         self.stream.take().expect("take_stream called more than once")
     }
 }
@@ -55,7 +56,7 @@ impl BlockSubscription for WsBlockSubscription {
 pub struct NullSubscription;
 
 impl BlockSubscription for NullSubscription {
-    fn take_stream(&mut self) -> BoxStream<'static, Result<BaseBlock, SourceError>> {
+    fn take_stream(&mut self) -> BoxStream<'static, Result<(BaseBlock, B256), SourceError>> {
         futures::stream::pending().boxed()
     }
 }

--- a/crates/batcher/source/src/event.rs
+++ b/crates/batcher/source/src/event.rs
@@ -7,7 +7,10 @@ use base_protocol::L2BlockInfo;
 #[derive(Debug, Clone)]
 pub enum L2BlockEvent {
     /// A new unsafe L2 block arrived.
-    Block(Box<BaseBlock>),
+    ///
+    /// `hash` is the block hash pre-computed from the RPC response, avoiding
+    /// a redundant `hash_slow()` (full RLP-encode + keccak256) in downstream consumers.
+    Block { block: Box<BaseBlock>, hash: alloy_primitives::B256 },
     /// An L2 reorg was detected; all state should be rewound to `new_safe_head`.
     Reorg {
         /// The new safe head after the reorg.

--- a/crates/batcher/source/src/hybrid.rs
+++ b/crates/batcher/source/src/hybrid.rs
@@ -25,7 +25,7 @@ pub struct HybridBlockSource<S, P, C> {
     /// Declared before `_subscription` so it is dropped first, ensuring the
     /// stream's underlying transport is released before the provider is torn down.
     #[debug(skip)]
-    sub: BoxStream<'static, Result<BaseBlock, SourceError>>,
+    sub: BoxStream<'static, Result<(BaseBlock, alloy_primitives::B256), SourceError>>,
     /// The original subscription, kept alive so its resources remain open.
     #[debug(skip)]
     _subscription: S,
@@ -65,9 +65,8 @@ where
     /// Process a received block, returning an event if the block is new or a reorg.
     ///
     /// Returns `None` if the block is a duplicate (already seen with the same hash).
-    fn process(&mut self, block: BaseBlock) -> Option<L2BlockEvent> {
+    fn process(&mut self, block: BaseBlock, hash: alloy_primitives::B256) -> Option<L2BlockEvent> {
         let number = block.header.number;
-        let hash = block.header.hash_slow();
 
         // Prune entries older than 256 blocks to bound memory usage.
         let cutoff = number.saturating_sub(256);
@@ -77,7 +76,7 @@ where
             None => {
                 // New block number — insert and emit.
                 self.seen.insert(number, hash);
-                Some(L2BlockEvent::Block(Box::new(block)))
+                Some(L2BlockEvent::Block { block: Box::new(block), hash })
             }
             Some(existing_hash) if *existing_hash == hash => {
                 // Duplicate — already seen this exact block.
@@ -144,8 +143,8 @@ where
             // triggering pipeline resets that discard catchup progress.
             if self.poller.is_catching_up() {
                 match self.poller.unsafe_head().await {
-                    Ok(b) => {
-                        if let Some(event) = self.process(b) {
+                    Ok((b, hash)) => {
+                        if let Some(event) = self.process(b, hash) {
                             return Ok(event);
                         }
                         // Duplicate — continue sequential polling.
@@ -162,8 +161,8 @@ where
             tokio::select! {
                 block = self.sub.next() => {
                     match block {
-                        Some(Ok(b)) => {
-                            if let Some(event) = self.process(b) {
+                        Some(Ok((b, hash))) => {
+                            if let Some(event) = self.process(b, hash) {
                                 return Ok(event);
                             }
                             // Duplicate — loop for next event.
@@ -174,8 +173,8 @@ where
                 }
                 _ = self.interval.next() => {
                     match self.poller.unsafe_head().await {
-                        Ok(b) => {
-                            if let Some(event) = self.process(b) {
+                        Ok((b, hash)) => {
+                            if let Some(event) = self.process(b, hash) {
                                 return Ok(event);
                             }
                             // Duplicate — loop for next event.

--- a/crates/batcher/source/src/polling.rs
+++ b/crates/batcher/source/src/polling.rs
@@ -1,6 +1,7 @@
 //! Polling source trait for fetching the current unsafe head block.
 
 use async_trait::async_trait;
+use alloy_primitives::B256;
 use base_alloy_consensus::BaseBlock;
 
 use crate::SourceError;
@@ -9,7 +10,10 @@ use crate::SourceError;
 #[async_trait]
 pub trait PollingSource: Send + Sync {
     /// Fetch the current unsafe head block.
-    async fn unsafe_head(&self) -> Result<BaseBlock, SourceError>;
+    ///
+    /// Returns the block together with its hash as it was received from the RPC,
+    /// avoiding a redundant `hash_slow()` recomputation in callers.
+    async fn unsafe_head(&self) -> Result<(BaseBlock, B256), SourceError>;
 
     /// Reset the source to begin sequential catchup from `start_from`.
     ///

--- a/crates/batcher/source/src/subscription.rs
+++ b/crates/batcher/source/src/subscription.rs
@@ -1,5 +1,6 @@
 //! Block subscription trait for keepalive-aware streaming.
 
+use alloy_primitives::B256;
 use base_alloy_consensus::BaseBlock;
 use futures::stream::BoxStream;
 
@@ -19,5 +20,7 @@ pub trait BlockSubscription: Send {
     /// Extract the block stream from this subscription.
     ///
     /// Must be called at most once; implementors may panic on a second call.
-    fn take_stream(&mut self) -> BoxStream<'static, Result<BaseBlock, SourceError>>;
+    /// The stream yields `(block, hash)` pairs where `hash` is the block hash
+    /// as received from the RPC, avoiding a redundant `hash_slow()` in callers.
+    fn take_stream(&mut self) -> BoxStream<'static, Result<(BaseBlock, B256), SourceError>>;
 }

--- a/crates/batcher/source/src/test_utils/mod.rs
+++ b/crates/batcher/source/src/test_utils/mod.rs
@@ -27,7 +27,8 @@ impl InMemoryBlockSource {
 
     /// Push a block event into the queue.
     pub fn push_block(&mut self, block: BaseBlock) {
-        self.queue.push_back(L2BlockEvent::Block(Box::new(block)));
+        let hash = block.header.hash_slow();
+        self.queue.push_back(L2BlockEvent::Block { block: Box::new(block), hash });;
     }
 
     /// Push a reorg event into the queue.


### PR DESCRIPTION
## Summary

The batcher was computing `hash_slow()` (full RLP-encode + keccak256) twice per block:
1. In `hybrid.rs` for deduplication
2. In `encoder.rs` for tip tracking

The RPC response already carries the block hash. This PR threads it through the pipeline so no recomputation is needed.

## Design

- `PollingSource::unsafe_head()` now returns `(BaseBlock, B256)`
- `BlockSubscription::take_stream()` now yields `(BaseBlock, B256)`
- `L2BlockEvent::Block` and `DriverEvent::Block` carry the pre-computed hash
- `BatchPipeline::add_block()` accepts the hash as a second parameter
- `encoder.rs`: `hash_slow()` replaced with the passed-in hash
- `hybrid.rs`, `source.rs`, `service.rs`: extract `rpc_block.header.hash` before `into_consensus()`

## Result

Zero `hash_slow()` calls in production code paths. All remaining `hash_slow()` calls are in test helpers building mock blocks.

Closes #1867