### PR TITLE
fix(revm): replace expect() with proper error propagation in deposit handler

### DIFF
--- a/crates/execution/revm/src/handler.rs
+++ b/crates/execution/revm/src/handler.rs
@@ -116,7 +116,7 @@ where
 
             let effective_balance_spending = tx
                 .effective_balance_spending(basefee, blob_price)
-                .expect("Deposit transaction effective balance spending overflow")
+                .map_err(|e| ERROR::from(OpTransactionError::from(e)))?
                 - tx.value();
 
             // Mind value should be added first before subtracting the effective balance spending.


### PR DESCRIPTION
## Summary

In `validate_against_state_and_deduct_caller`, the deposit transaction branch calls `effective_balance_spending()` with `expect()` which can panic and crash the node on `Err`.

## Fix

Replace `expect()` with `map_err + ?` to propagate the error as a normal transaction rejection:

```rust
// Before
.expect("Deposit transaction effective balance spending overflow")

// After  
.map_err(|e| ERROR::from(OpTransactionError::from(e)))?
```

The enclosing function already returns `Result` and the same `OpTransactionError` conversion pattern is used elsewhere in this handler (lines 90, 97).

## Impact

Prevents a potential node panic/DoS when deposit transaction validation fails via this path.

Closes #1974