### PR TITLE
[bcp]: BCP-0002 Feather Client

### DIFF
--- a/docs/specs/components/BCPsList.tsx
+++ b/docs/specs/components/BCPsList.tsx
@@ -16,6 +16,13 @@ const bcps: BcpEntry[] = [
     status: 'Final',
     link: '/bcps/bcp-0000',
   },
+  {
+    id: 'BCP-0002',
+    title: 'Feather Client',
+    description: 'Gossip-driven safe/finalized head attestations enabling full EL+CL nodes with no L1 RPC or Beacon API.',
+    status: 'Draft',
+    link: '/bcps/bcp-0002',
+  },
 ]
 
 const statusColor: Record<BcpStatus, { color: string; background: string }> = {

--- a/docs/specs/pages/bcps/bcp-0002.md
+++ b/docs/specs/pages/bcps/bcp-0002.md
@@ -1,0 +1,246 @@
+# BCP-0002: Feather Client
+
+## Motivation
+
+Every node that participates in the L2 network today — even one that only wants to execute
+transactions and serve RPC — must run the full derivation pipeline, which requires an L1 RPC
+endpoint and a Beacon API URL. These dependencies exist because the derivation pipeline is the only
+component that knows the current L2 safe and finalized heads, and without those heads, the node
+cannot call `engine_forkchoiceUpdated` on its execution layer.
+
+This is a deployment burden that does not reflect a fundamental security requirement for all node
+operators. An operator who accepts the sequencer's trust model for unsafe blocks — which is every
+non-derivation node today — has no principled reason to require L1 RPC just to track forkchoice.
+
+The existing unsafe block gossip already demonstrates the alternative: unsafe blocks are signed by
+the sequencer and gossiped over libp2p, allowing any peer to sync the L2 chain by verifying a
+single ECDSA signature against the sequencer address from the rollup config. The EL advances its
+state via `engine_newPayload` as each gossiped block arrives. No L1 contact is required for any
+part of this. The only missing piece is the safe and finalized hashes within that call.
+`engine_forkchoiceUpdated` accepts a `forkchoiceState` with `headBlockHash`, `safeBlockHash`, and
+`finalizedBlockHash`. Without derivation, a node must set `safeBlockHash` and `finalizedBlockHash`
+to zero or a stale genesis value, because those values are only known to the derivation pipeline.
+
+This BCP closes that gap. By gossiping safe and finalized head attestations signed with the same
+sequencer key, any node can drive `engine_forkchoiceUpdated` from gossip alone. The result is a
+**feather client**: a full EL+CL stack — executing transactions, maintaining chain state, serving
+L2 RPC — with no L1 RPC URL and no Beacon API URL.
+
+## What a Feather Client Is
+
+A feather client is a consensus layer implementation that consists of exactly two behaviors:
+
+1. **Unsafe block handling** — subscribe to the existing `/optimism/{chain_id}/blocks/v3` gossip
+   topic, verify the sequencer signature, forward each block to the EL via `engine_newPayload`.
+   This already works today.
+
+2. **Forkchoice tracking** — subscribe to two new attestation topics (defined below), verify the
+   sequencer signature on each attestation, and call `engine_forkchoiceUpdated` on the EL when the
+   safe or finalized head advances.
+
+There is no derivation pipeline. There is no L1 RPC. There is no Beacon API. The feather client
+requires only: a connection to one gossip peer, an EL node, and the rollup config (a ~1 KB file
+that can be embedded at compile time).
+
+## Proposal
+
+Add two new gossip topics for safe and finalized head attestations, using the `/base/` topic prefix
+to distinguish them as Base-specific extensions rather than OP Stack protocol topics:
+
+- `/base/{chain_id}/safe_heads/v1`
+- `/base/{chain_id}/finalized_heads/v1`
+
+Whenever the sequencer's safe head advances, it signs a compact attestation and publishes it on the
+safe heads topic. Finalized head advancement triggers a separate attestation on the finalized heads
+topic.
+
+Both topics use the sequencer's existing unsafe block signer key, so receivers can verify them
+against the `unsafe_block_signer` address from the rollup config with zero infrastructure. The
+signing for both attestation types happens exclusively in the `SequencerActor` — the only actor
+that holds the private key. The `SequencerActor` observes safe and finalized head advancement via
+the engine state watch channel it already monitors; the finalizer actor in
+`crates/consensus/service/src/actors/derivation/finalizer.rs` communicates finalized head
+advancement through that same channel rather than signing directly. No new cross-actor wiring or
+key distribution is required.
+
+### Attestation Message Format
+
+```
+SafeHeadAttestation {
+    l2_block_hash:    B256,   // 32 bytes
+    l2_block_number:  u64,    //  8 bytes
+    l1_origin_hash:   B256,   // 32 bytes
+    l1_origin_number: u64,    //  8 bytes
+    timestamp:        u64,    //  8 bytes
+    signature:        [u8;65] // 65 bytes
+}
+// Total: ~145 bytes per attestation
+```
+
+`FinalizedHeadAttestation` has the same layout on a separate topic.
+
+The message hash covers all fields except the signature:
+`keccak256(l2_block_hash || l2_block_number || l1_origin_hash || l1_origin_number || timestamp
+           || chain_id)`. The `chain_id` domain separator prevents cross-chain replay. The signer
+address is not included in the message — it is recovered from the signature and compared against
+the rollup config's `unsafe_block_signer`, matching how block gossip validation works today.
+
+A receiver validates:
+1. `ECDSA_recover(signature, message_hash) == unsafe_block_signer` — from rollup config, no
+   network contact required
+2. `l2_block_number > last_seen_l2_number` — strictly increasing L2 head
+3. `l1_origin_number >= last_seen_l1_origin` — monotonically non-decreasing L1 origin
+4. `now - 60s <= timestamp <= now + 5s` — not from the future and not stale; the future bound
+   matches existing block gossip, the 60-second lower bound supplements gossipsub's message cache
+   TTL to guard against replayed attestations on a fresh node
+5. Deduplicate by `(l2_block_number, l2_block_hash)`: if an attestation arrives with the same
+   `l2_block_number` and `l2_block_hash` as one already seen, drop as a benign gossip duplicate
+6. Equivocation detection: if an attestation arrives with the same `l2_block_number` but a
+   different `l2_block_hash` from a previously accepted attestation, treat this as sequencer
+   equivocation — apply the maximum peer penalty via `invalid_message_deliveries`, emit a local
+   critical-level alert, and do not advance the head or propagate the message
+
+That is the complete verification. Rules 1–5 are structurally identical to how unsafe block gossip
+works today; rule 6 is specific to the forkchoice semantics of safe and finalized heads.
+
+## Trust Model
+
+The sequencer ECDSA signature proves the attestation came from the sequencer. It does not prove the
+sequencer derived the safe head honestly from the canonical L1 chain.
+
+This is the same trust already extended to unsafe blocks. Every node that follows unsafe block
+gossip today trusts the sequencer's signature to advance its chain. The feather client extends that
+same trust to safe and finalized head tracking. No new trust assumption is introduced.
+
+### "Attested Safe" vs. "Derived Safe"
+
+There is a meaningful distinction that operators should understand:
+
+- **Derived safe** means a full node has run the derivation pipeline against L1 data it has fetched
+  independently and confirmed this L2 block follows from the canonical L1 chain.
+- **Attested safe** means the sequencer has signed a message claiming this L2 block is its current
+  safe head.
+
+A feather client tracks attested safe and finalized heads, not derived ones. The `l1_origin_hash`
+and `l1_origin_number` fields are included in the attestation for context and for use with optional
+L1 anchoring (see below), but the feather client does not verify them against L1.
+
+For most node operators — those serving L2 RPC, executing transactions, running monitoring, or
+operating wallets — attested safe is sufficient. For bridge operators, proof generators, or anyone
+whose security model requires independent derivation verification, full derivation is still
+required.
+
+### What a Feather Client Cannot Do
+
+- **Verify deposit transactions.** The derivation pipeline's core function is ensuring that L1
+  deposit transactions (bridge deposits) are correctly included in L2 blocks in the right order. A
+  feather client has no way to verify this. A sequencer that attests a safe head that omits or
+  misorients a deposit would not be detected by feather clients.
+
+- **Detect a lying sequencer independently.** A feather client cannot tell whether the sequencer's
+  attested safe head reflects honest derivation from canonical L1. It can detect a signature that
+  fails to verify against the rollup config key, but not a valid signature on an incorrect
+  attestation.
+
+- **Participate in the fault dispute system.** Fault proofs require deriving the L2 state from L1
+  inputs. A feather client does not have those inputs.
+
+### Multi-Node Quorum (Extended Mode)
+
+For operators who want stronger guarantees without running full derivation, a quorum mode is
+available. Any full node running derivation can gossip attestations signed with its libp2p identity
+key. A feather client configured with a set of trusted peer ENRs advances its safe head view only
+when a threshold of those peers (e.g., 3 of 5) have gossiped consistent attestations for the same
+`(l2_block_number, l2_block_hash)` pair.
+
+In quorum mode, a lying sequencer is detectable without L1 contact: if the sequencer gossips a
+safe head that no honest full node corroborates, the feather client sees the disagreement in the
+gossip stream directly. This requires knowing a small set of trusted peer ENRs at startup — a
+one-time bootstrap step.
+
+### Optional L1 Anchoring
+
+For applications that require L1-grounded finality, the L1 RPC surface can be reduced to a single
+`eth_getBlockByNumber("finalized")` call at whatever cadence the application's security model
+allows — once per epoch, once per day, or once per week. The feather client accepts attestations
+whose `l1_origin_number` falls within the anchored range and rejects anything that claims an L1
+origin beyond the last verified anchor. This reduces L1 RPC calls by approximately four orders of
+magnitude versus per-block polling while retaining cryptographic finality guarantees bounded by the
+anchor update interval.
+
+Note that this guarantee is conditional on the sequencer reporting `l1_origin_number` honestly. A
+sequencer intending to advance the attested safe head past the anchor window could underreport its
+`l1_origin_number` in the attestation, since the feather client has no L1 to verify it against.
+The anchoring mechanism bounds drift under an honest sequencer but does not provide cryptographic
+proof that the reported L1 origin is canonical.
+
+## Who Still Needs Full Derivation
+
+| Node type | Full derivation required? | Reason |
+|---|---|---|
+| Sequencer | Yes | Must derive to produce valid batches and output proposals |
+| Fault proof / dispute participant | Yes | Proofs require L1-derived execution traces |
+| Bridge operator (L1→L2 security) | Yes | Must independently verify deposit inclusion |
+| General RPC node (feather client) | No | Attested safe is sufficient for tx execution and state serving |
+| Monitoring / alerting | No | Attested safe/finalized head tracking is sufficient |
+| Wallet / light client | No | Attested finalized head is sufficient for confirmation |
+
+## Key Changes
+
+- A new `SafeHeadAttestation` message type is added to `crates/consensus/gossip/`.
+- A new `SafeHeadHandler` implements the `Handler` trait alongside `BlockHandler`, subscribed to
+  `/base/{chain_id}/safe_heads/v1`.
+- `SequencerActor` in `crates/consensus/service/` gains an attestation emission step: when the
+  engine state watch channel signals a new safe or finalized head, the actor signs a
+  `SafeHeadAttestation` or `FinalizedHeadAttestation` with the existing unsafe block signer private
+  key and submits it to the gossip driver. The finalizer actor communicates finalized head
+  advancement through the existing engine state channel; the `SequencerActor` remains the sole
+  signer. No new key management or cross-actor wiring is required.
+- A symmetric `FinalizedHeadAttestation` message type and `/base/{chain_id}/finalized_heads/v1`
+  topic are added, mirroring the safe head structure exactly.
+- A new `FeatherClient` CL implementation subscribes to the unsafe block topic and both attestation
+  topics, verifies signatures, and drives `engine_forkchoiceUpdated` on the local EL. It exposes no
+  derivation pipeline and requires no L1 RPC or Beacon API URL in its configuration. When
+  `engine_forkchoiceUpdated` returns `{status: SYNCING}` — indicating the EL does not yet have the
+  referenced block — the feather client retains the pending forkchoice state and retries after each
+  subsequent successful `engine_newPayload`. Since safe attestations trail unsafe block delivery by
+  the L1 confirmation window, this condition should be rare in practice but must be handled to
+  avoid permanently stale safe/finalized heads after a partition or restart.
+- Peer scoring penalizes invalid attestations (wrong signature, non-increasing `l2_block_number`,
+  equivocation) using the existing `invalid_message_deliveries` penalty path.
+- Full derivation nodes that opt into quorum mode gain a `QuorumAttestationEmitter` component:
+  when the derivation pipeline advances the safe or finalized head, the node signs a
+  `SafeHeadAttestation` or `FinalizedHeadAttestation` using its libp2p identity key (the Secp256k1
+  key in its ENR) and publishes it on the same attestation topics. This is a separate signing path
+  from the `SequencerActor` — derivation nodes sign with their ENR key, not the sequencer key, so
+  feather clients in quorum mode must distinguish the two and apply thresholds only to ENR-signed
+  attestations from their configured trusted peer set.
+
+## Tradeoffs
+
+**Gained:** Full EL+CL nodes can operate with no L1 RPC and no Beacon API. Operators who accept
+the sequencer trust model for unsafe blocks — which is the existing baseline — can now also track
+safe and finalized heads under the same model. Deployment complexity drops significantly for the
+majority of node operators who do not need to independently verify derivation. The gossip network
+becomes a lightweight finality oracle for the entire ecosystem.
+
+**Sacrificed:** Feather client nodes cannot independently verify deposit inclusion or detect a
+lying sequencer without quorum mode. They track attested safe/finalized heads rather than derived
+ones. Operators who require derivation-grade guarantees must still run the full pipeline.
+
+## Estimated Impact
+
+- **Infrastructure reduction:** A node that today requires L1 RPC + Beacon API for forkchoice
+  tracking needs only gossip network connectivity. The L1 RPC and Beacon URL fields become optional
+  in the node configuration, required only when derivation is enabled.
+- **Latency:** Safe head updates propagate via gossip within one or two gossipsub mesh hops
+  (typically < 500ms on a well-connected network), compared to polling delays of 1–4 seconds in
+  current RPC-based approaches.
+- **Message overhead:** Safe head attestations fire roughly once per L1 block (~12 seconds on
+  mainnet), as the safe head advances with each new batch derived from L1. Finalized head
+  attestations fire roughly once per Casper FFG finalization cycle (~12 minutes on mainnet). Both
+  are 145 bytes each — negligible gossip bandwidth at either rate.
+- **Complexity:** Low. The attestation structure mirrors the unsafe block gossip pattern exactly.
+  The `Handler` trait abstraction means adding a new topic is a well-defined bounded change. The
+  `FeatherClient` CL implementation is substantially simpler than the derivation pipeline — it has
+  no L1 data fetching, no channel bank, no batch decoder, and no attribute builder.


### PR DESCRIPTION
## Summary

This PR adds BCP-0002, the Feather Client proposal, to the Base specs. The BCP defines gossip-driven safe and finalized head attestations that allow a full EL+CL node to operate without an L1 RPC endpoint or Beacon API URL. It also registers the proposal on the BCP List page as a Draft.