### PR TITLE
ktlo(repo): Rename Small-Diff Types

### DIFF
--- a/crates/builder/core/src/flashblocks/context.rs
+++ b/crates/builder/core/src/flashblocks/context.rs
@@ -15,7 +15,7 @@ use base_alloy_consensus::{OpDepositReceipt, OpReceipt, OpTransactionSigned, OpT
 use base_alloy_evm::OpReceiptBuilder;
 use base_execution_chainspec::OpChainSpec;
 use base_execution_evm::{OpEvmConfig, OpNextBlockEnvAttributes};
-use base_execution_payload_builder::{OpPayloadBuilderAttributes, error::OpPayloadBuilderError};
+use base_execution_payload_builder::{OpPayloadBuilderAttributes, error::BasePayloadBuilderError};
 use base_revm::{L1BlockInfo, OpSpecId};
 use base_txpool::{
     BundleTransaction, TimestampedTransaction, estimated_da_size::DataAvailabilitySized,
@@ -493,7 +493,7 @@ impl OpPayloadBuilderCtx {
             // A sequencer's block should never contain blob transactions.
             if sequencer_tx.value().is_eip4844() {
                 return Err(PayloadBuilderError::other(
-                    OpPayloadBuilderError::BlobTransactionRejected,
+                    BasePayloadBuilderError::BlobTransactionRejected,
                 ));
             }
 
@@ -502,7 +502,7 @@ impl OpPayloadBuilderCtx {
             // Deposit transactions do not have signatures, so if the tx is a deposit, this
             // will just pull in its `from` address.
             let sequencer_tx = sequencer_tx.value().try_clone_into_recovered().map_err(|_| {
-                PayloadBuilderError::other(OpPayloadBuilderError::TransactionEcRecoverFailed)
+                PayloadBuilderError::other(BasePayloadBuilderError::TransactionEcRecoverFailed)
             })?;
 
             // Cache the depositor account prior to the state transition for the deposit nonce.
@@ -519,7 +519,7 @@ impl OpPayloadBuilderCtx {
                 })
                 .transpose()
                 .map_err(|_| {
-                    PayloadBuilderError::other(OpPayloadBuilderError::AccountLoadFailed(
+                    PayloadBuilderError::other(BasePayloadBuilderError::AccountLoadFailed(
                         sequencer_tx.signer(),
                     ))
                 })?;

--- a/crates/builder/core/src/flashblocks/context.rs
+++ b/crates/builder/core/src/flashblocks/context.rs
@@ -7,7 +7,7 @@ use std::{
 use alloy_consensus::{Eip658Value, Transaction};
 use alloy_eips::{Encodable2718, Typed2718};
 use alloy_evm::Database;
-use alloy_primitives::{BlockHash, Bytes, U256};
+use alloy_primitives::{B256, BlockHash, Bytes, U256};
 use alloy_rpc_types_eth::Withdrawals;
 use base_access_lists::FBALBuilderDb;
 use base_alloy_chains::BaseUpgrades;

--- a/crates/builder/core/src/flashblocks/context.rs
+++ b/crates/builder/core/src/flashblocks/context.rs
@@ -7,7 +7,7 @@ use std::{
 use alloy_consensus::{Eip658Value, Transaction};
 use alloy_eips::{Encodable2718, Typed2718};
 use alloy_evm::Database;
-use alloy_primitives::{B256, BlockHash, Bytes, U256};
+use alloy_primitives::{BlockHash, Bytes, U256};
 use alloy_rpc_types_eth::Withdrawals;
 use base_access_lists::FBALBuilderDb;
 use base_alloy_chains::BaseUpgrades;

--- a/crates/execution/chainspec/src/lib.rs
+++ b/crates/execution/chainspec/src/lib.rs
@@ -32,4 +32,4 @@ mod dev;
 pub use dev::BASE_DEV;
 
 mod spec;
-pub use spec::{OpChainSpec, OpGenesisInfo, SUPPORTED_CHAINS};
+pub use spec::{GenesisInfo, OpChainSpec, SUPPORTED_CHAINS};

--- a/crates/execution/chainspec/src/spec.rs
+++ b/crates/execution/chainspec/src/spec.rs
@@ -29,14 +29,14 @@ pub const SUPPORTED_CHAINS: &[&str] =
 
 /// Genesis info extracted from a Base genesis config.
 #[derive(Default, Debug)]
-pub struct OpGenesisInfo {
+pub struct GenesisInfo {
     /// Base chain info extracted from genesis extra fields.
     pub optimism_chain_info: base_common_rpc_types::BaseChainInfo,
     /// Base fee params derived from the genesis config.
     pub base_fee_params: BaseFeeParamsKind,
 }
 
-impl OpGenesisInfo {
+impl GenesisInfo {
     /// Extracts Base genesis info from an [`alloy_genesis::Genesis`].
     pub fn extract_from(genesis: &Genesis) -> Self {
         let mut info = Self {
@@ -232,7 +232,7 @@ impl BaseUpgrades for OpChainSpec {
 
 impl From<Genesis> for OpChainSpec {
     fn from(genesis: Genesis) -> Self {
-        let optimism_genesis_info = OpGenesisInfo::extract_from(&genesis);
+        let optimism_genesis_info = GenesisInfo::extract_from(&genesis);
         let genesis_info =
             optimism_genesis_info.optimism_chain_info.genesis_info.unwrap_or_default();
 

--- a/crates/execution/exex/src/lib.rs
+++ b/crates/execution/exex/src/lib.rs
@@ -12,7 +12,7 @@ use std::{sync::Arc, time::Duration};
 use alloy_consensus::BlockHeader;
 use alloy_eips::eip1898::BlockWithParent;
 use base_execution_trie::{
-    OpProofStoragePrunerTask, OpProofsStorage, OpProofsStore, live::LiveTrieCollector,
+    BaseProofStoragePrunerTask, OpProofsStorage, OpProofsStore, live::LiveTrieCollector,
     metrics::BlockMetrics,
 };
 use futures::TryStreamExt;
@@ -235,7 +235,7 @@ where
             sync_target_tx.send(best_block)?;
         }
 
-        let prune_task = OpProofStoragePrunerTask::new(
+        let prune_task = BaseProofStoragePrunerTask::new(
             self.storage.clone(),
             self.ctx.provider().clone(),
             self.proofs_history_window,

--- a/crates/execution/node/src/node.rs
+++ b/crates/execution/node/src/node.rs
@@ -12,8 +12,8 @@ use base_execution_consensus::OpBeaconConsensus;
 use base_execution_evm::{OpEvmConfig, OpRethReceiptBuilder};
 use base_execution_payload_builder::{
     OpAttributes, OpBuiltPayload, OpPayloadPrimitives,
-    builder::OpPayloadTransactions,
-    config::{OpBuilderConfig, OpDAConfig, OpGasLimitConfig},
+    builder::BasePayloadTransactions,
+    config::{BaseBuilderConfig, OpDAConfig, OpGasLimitConfig},
 };
 use base_execution_rpc::{
     config::{BaseEthConfigApiServer, BaseEthConfigHandler},
@@ -1001,7 +1001,7 @@ where
             >,
         > + 'static,
     Pool: TransactionPool<Transaction: OpPooledTx<Consensus = TxTy<Node::Types>>> + Unpin + 'static,
-    Txs: OpPayloadTransactions<Pool::Transaction>,
+    Txs: BasePayloadTransactions<Pool::Transaction>,
     Attrs: OpAttributes<Transaction = TxTy<Node::Types>>,
 {
     type PayloadBuilder =
@@ -1018,7 +1018,7 @@ where
                 pool,
                 ctx.provider().clone(),
                 evm_config,
-                OpBuilderConfig {
+                BaseBuilderConfig {
                     da_config: self.da_config.clone(),
                     gas_limit_config: self.gas_limit_config.clone(),
                 },

--- a/crates/execution/node/tests/it/priority.rs
+++ b/crates/execution/node/tests/it/priority.rs
@@ -7,7 +7,7 @@ use alloy_genesis::Genesis;
 use alloy_network::TxSignerSync;
 use alloy_primitives::{Address, ChainId, TxKind};
 use base_execution_chainspec::OpChainSpecBuilder;
-use base_execution_payload_builder::builder::OpPayloadTransactions;
+use base_execution_payload_builder::builder::BasePayloadTransactions;
 use base_node_core::{
     OpNode,
     args::RollupArgs,
@@ -43,7 +43,7 @@ struct CustomTxPriority {
     chain_id: ChainId,
 }
 
-impl OpPayloadTransactions<BasePooledTransaction> for CustomTxPriority {
+impl BasePayloadTransactions<BasePooledTransaction> for CustomTxPriority {
     fn best_transactions<Pool>(
         &self,
         pool: Pool,

--- a/crates/execution/payload/src/builder.rs
+++ b/crates/execution/payload/src/builder.rs
@@ -40,8 +40,8 @@ use revm::context::{Block, BlockEnv};
 use tracing::{debug, trace, warn};
 
 use crate::{
-    OpAttributes, OpPayloadBuilderAttributes, OpPayloadPrimitives, config::OpBuilderConfig,
-    error::OpPayloadBuilderError, payload::OpBuiltPayload,
+    OpAttributes, OpPayloadBuilderAttributes, OpPayloadPrimitives, config::BaseBuilderConfig,
+    error::BasePayloadBuilderError, payload::OpBuiltPayload,
 };
 
 /// Base payload builder
@@ -62,7 +62,7 @@ pub struct OpPayloadBuilder<
     /// Node client.
     pub client: Client,
     /// Settings for the builder, e.g. DA settings.
-    pub config: OpBuilderConfig,
+    pub config: BaseBuilderConfig,
     /// The type responsible for yielding the best transactions for the payload if mempool
     /// transactions are allowed.
     pub best_transactions: Txs,
@@ -98,12 +98,12 @@ impl<Pool, Client, Evm, Attrs> OpPayloadBuilder<Pool, Client, Evm, (), Attrs> {
         Self::with_builder_config(pool, client, evm_config, Default::default())
     }
 
-    /// Configures the builder with the given [`OpBuilderConfig`].
+    /// Configures the builder with the given [`BaseBuilderConfig`].
     pub const fn with_builder_config(
         pool: Pool,
         client: Client,
         evm_config: Evm,
-        config: OpBuilderConfig,
+        config: BaseBuilderConfig,
     ) -> Self {
         Self {
             pool,
@@ -246,7 +246,7 @@ where
             Primitives = N,
             NextBlockEnvCtx: BuildNextEnv<Attrs, N::BlockHeader, Client::ChainSpec>,
         >,
-    Txs: OpPayloadTransactions<Pool::Transaction>,
+    Txs: BasePayloadTransactions<Pool::Transaction>,
     Attrs: OpAttributes<Transaction = N::SignedTx>,
 {
     type Attributes = Attrs;
@@ -448,7 +448,7 @@ impl<Txs> OpBuilder<'_, Txs> {
 }
 
 /// A type that returns the [`PayloadTransactions`] that should be included in the pool.
-pub trait OpPayloadTransactions<Transaction>: Clone + Send + Sync + Unpin + 'static {
+pub trait BasePayloadTransactions<Transaction>: Clone + Send + Sync + Unpin + 'static {
     /// Returns an iterator that yields the transaction in the order they should get included in the
     /// new payload.
     fn best_transactions<Pool: TransactionPool<Transaction = Transaction>>(
@@ -458,7 +458,7 @@ pub trait OpPayloadTransactions<Transaction>: Clone + Send + Sync + Unpin + 'sta
     ) -> impl PayloadTransactions<Transaction = Transaction>;
 }
 
-impl<T: PoolTransaction> OpPayloadTransactions<T> for () {
+impl<T: PoolTransaction> BasePayloadTransactions<T> for () {
     fn best_transactions<Pool: TransactionPool<Transaction = T>>(
         &self,
         pool: Pool,
@@ -546,7 +546,7 @@ pub struct OpPayloadBuilderCtx<
     /// The type that knows how to perform system calls and configure the evm.
     pub evm_config: Evm,
     /// Additional config for the builder/sequencer, e.g. DA and gas limit
-    pub builder_config: OpBuilderConfig,
+    pub builder_config: BaseBuilderConfig,
     /// The chainspec
     pub chain_spec: Arc<ChainSpec>,
     /// How to build the payload.
@@ -630,7 +630,7 @@ where
             // A sequencer's block should never contain blob transactions.
             if sequencer_tx.value().is_eip4844() {
                 return Err(PayloadBuilderError::other(
-                    OpPayloadBuilderError::BlobTransactionRejected,
+                    BasePayloadBuilderError::BlobTransactionRejected,
                 ));
             }
 
@@ -639,7 +639,7 @@ where
             // Deposit transactions do not have signatures, so if the tx is a deposit, this
             // will just pull in its `from` address.
             let sequencer_tx = sequencer_tx.value().try_clone_into_recovered().map_err(|_| {
-                PayloadBuilderError::other(OpPayloadBuilderError::TransactionEcRecoverFailed)
+                PayloadBuilderError::other(BasePayloadBuilderError::TransactionEcRecoverFailed)
             })?;
 
             let gas_used = match builder.execute_transaction(sequencer_tx.clone()) {

--- a/crates/execution/payload/src/config.rs
+++ b/crates/execution/payload/src/config.rs
@@ -4,14 +4,14 @@ use std::sync::{Arc, atomic::AtomicU64};
 
 /// Settings for the OP builder.
 #[derive(Debug, Clone, Default)]
-pub struct OpBuilderConfig {
+pub struct BaseBuilderConfig {
     /// Data availability configuration for the OP builder.
     pub da_config: OpDAConfig,
     /// Gas limit configuration for the OP builder.
     pub gas_limit_config: OpGasLimitConfig,
 }
 
-impl OpBuilderConfig {
+impl BaseBuilderConfig {
     /// Creates a new OP builder configuration with the given data availability configuration.
     pub const fn new(da_config: OpDAConfig, gas_limit_config: OpGasLimitConfig) -> Self {
         Self { da_config, gas_limit_config }
@@ -139,7 +139,7 @@ mod tests {
 
     #[test]
     fn test_da_constrained() {
-        let config = OpBuilderConfig::default();
+        let config = BaseBuilderConfig::default();
         assert!(config.constrained_da_config().is_none());
     }
 

--- a/crates/execution/payload/src/error.rs
+++ b/crates/execution/payload/src/error.rs
@@ -2,7 +2,7 @@
 
 /// Base-specific payload building errors.
 #[derive(Debug, thiserror::Error)]
-pub enum OpPayloadBuilderError {
+pub enum BasePayloadBuilderError {
     /// Thrown when a transaction fails to convert to a
     /// [`alloy_consensus::transaction::Recovered`].
     #[error("failed to convert deposit transaction to RecoveredTx")]

--- a/crates/execution/revm/src/lib.rs
+++ b/crates/execution/revm/src/lib.rs
@@ -34,8 +34,8 @@ pub use spec::*;
 
 mod transaction;
 pub use transaction::{
-    DEPOSIT_TRANSACTION_TYPE, DepositTransactionParts, OpBuildError, OpTransaction,
-    OpTransactionBuilder, OpTransactionError, OpTxTr,
+    BaseTransactionBuilder, BuildError, DEPOSIT_TRANSACTION_TYPE, DepositTransactionParts,
+    OpTransaction, OpTransactionError, OpTxTr,
 };
 
 mod compat;

--- a/crates/execution/revm/src/transaction.rs
+++ b/crates/execution/revm/src/transaction.rs
@@ -1,7 +1,7 @@
 //! Contains the `[OpTransaction]` type and its implementation.
 
 mod abstraction;
-pub use abstraction::{BuildError, BaseTransactionBuilder, OpTransaction, OpTxTr};
+pub use abstraction::{BaseTransactionBuilder, BuildError, OpTransaction, OpTxTr};
 
 mod deposit;
 pub use deposit::{DEPOSIT_TRANSACTION_TYPE, DepositTransactionParts};

--- a/crates/execution/revm/src/transaction.rs
+++ b/crates/execution/revm/src/transaction.rs
@@ -1,7 +1,7 @@
 //! Contains the `[OpTransaction]` type and its implementation.
 
 mod abstraction;
-pub use abstraction::{OpBuildError, OpTransaction, OpTransactionBuilder, OpTxTr};
+pub use abstraction::{BuildError, BaseTransactionBuilder, OpTransaction, OpTxTr};
 
 mod deposit;
 pub use deposit::{DEPOSIT_TRANSACTION_TYPE, DepositTransactionParts};

--- a/crates/execution/revm/src/transaction/abstraction.rs
+++ b/crates/execution/revm/src/transaction/abstraction.rs
@@ -66,8 +66,8 @@ impl<T: Transaction> OpTransaction<T> {
 
 impl OpTransaction<TxEnv> {
     /// Create a new Base transaction.
-    pub fn builder() -> OpTransactionBuilder {
-        OpTransactionBuilder::new()
+    pub fn builder() -> BaseTransactionBuilder {
+        BaseTransactionBuilder::new()
     }
 }
 
@@ -207,13 +207,13 @@ impl<T: Transaction> OpTxTr for OpTransaction<T> {
 
 /// Builder for constructing [`OpTransaction`] instances
 #[derive(Default, Debug)]
-pub struct OpTransactionBuilder {
+pub struct BaseTransactionBuilder {
     base: TxEnvBuilder,
     enveloped_tx: Option<Bytes>,
     deposit: DepositTransactionParts,
 }
 
-impl OpTransactionBuilder {
+impl BaseTransactionBuilder {
     /// Create a new builder with default values
     pub fn new() -> Self {
         Self {
@@ -305,24 +305,24 @@ impl OpTransactionBuilder {
 
     /// Build the [`OpTransaction`] instance, return error if the transaction is not valid.
     ///
-    pub fn build(mut self) -> Result<OpTransaction<TxEnv>, OpBuildError> {
+    pub fn build(mut self) -> Result<OpTransaction<TxEnv>, BuildError> {
         let tx_type = self.base.get_tx_type();
         if tx_type.is_some() {
             if Some(DEPOSIT_TRANSACTION_TYPE) == tx_type {
                 // if tx type is deposit, check if source hash is set
                 if self.deposit.source_hash == B256::ZERO {
-                    return Err(OpBuildError::MissingSourceHashForDeposit);
+                    return Err(BuildError::MissingSourceHashForDeposit);
                 }
             } else if self.enveloped_tx.is_none() {
                 // enveloped is required for non-deposit transactions
-                return Err(OpBuildError::MissingEnvelopedTxBytes);
+                return Err(BuildError::MissingEnvelopedTxBytes);
             }
         } else if self.deposit.source_hash != B256::ZERO {
             // if type is not set and source hash is set, set the transaction type to deposit
             self.base = self.base.tx_type(Some(DEPOSIT_TRANSACTION_TYPE));
         } else if self.enveloped_tx.is_none() {
             // tx is not deposit and enveloped is required
-            return Err(OpBuildError::MissingEnvelopedTxBytes);
+            return Err(BuildError::MissingEnvelopedTxBytes);
         }
 
         let base = self.base.build()?;
@@ -334,7 +334,7 @@ impl OpTransactionBuilder {
 /// Error type for building [`TxEnv`]
 #[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-pub enum OpBuildError {
+pub enum BuildError {
     /// Base transaction build error
     Base(TxEnvBuildError),
     /// Missing enveloped transaction bytes
@@ -343,7 +343,7 @@ pub enum OpBuildError {
     MissingSourceHashForDeposit,
 }
 
-impl From<TxEnvBuildError> for OpBuildError {
+impl From<TxEnvBuildError> for BuildError {
     fn from(error: TxEnvBuildError) -> Self {
         Self::Base(error)
     }

--- a/crates/execution/rpc/src/debug.rs
+++ b/crates/execution/rpc/src/debug.rs
@@ -37,7 +37,7 @@ use tokio::sync::{Semaphore, oneshot};
 
 use crate::{
     metrics::{DebugApiExtMetrics, DebugApis},
-    state::OpStateProviderFactory,
+    state::BaseStateProviderFactory,
 };
 
 /// Represents the current proofs sync status.
@@ -109,7 +109,7 @@ pub struct DebugApiExtInner<Eth: FullEthApi, Storage, Provider, EvmConfig, Attrs
     provider: Provider,
     eth_api: Eth,
     storage: OpProofsStorage<Storage>,
-    state_provider_factory: OpStateProviderFactory<Eth, Storage>,
+    state_provider_factory: BaseStateProviderFactory<Eth, Storage>,
     evm_config: EvmConfig,
     task_spawner: Box<dyn TaskSpawner>,
     semaphore: Semaphore,
@@ -133,7 +133,7 @@ where
         Self {
             provider,
             storage: storage.clone(),
-            state_provider_factory: OpStateProviderFactory::new(eth_api.clone(), storage),
+            state_provider_factory: BaseStateProviderFactory::new(eth_api.clone(), storage),
             eth_api,
             evm_config,
             task_spawner,

--- a/crates/execution/rpc/src/eth/mod.rs
+++ b/crates/execution/rpc/src/eth/mod.rs
@@ -17,7 +17,7 @@ use std::{
 use alloy_primitives::U256;
 use base_alloy_network::Base;
 use eyre::WrapErr;
-pub use receipt::{OpReceiptBuilder, OpReceiptFieldsBuilder};
+pub use receipt::{OpReceiptBuilder, ReceiptFieldsBuilder};
 use reth_chainspec::{EthereumHardforks, Hardforks};
 use reth_evm::ConfigureEvm;
 use reth_node_api::{FullNodeComponents, FullNodeTypes, HeaderTy, NodeTypes};
@@ -40,7 +40,7 @@ use reth_tasks::{
 
 use crate::{
     OpEthApiError, SequencerClient,
-    eth::{receipt::OpReceiptConverter, transaction::OpTxInfoMapper},
+    eth::{receipt::BaseReceiptConverter, transaction::OpTxInfoMapper},
 };
 
 /// Adapter for [`EthApiInner`], which holds all the data required to serve core `eth_` API.
@@ -291,7 +291,7 @@ impl<N: RpcNodeCore, Rpc: RpcConvert> OpEthApiInner<N, Rpc> {
 pub type BaseRpcConvert<N, NetworkT> = RpcConverter<
     NetworkT,
     <N as FullNodeComponents>::Evm,
-    OpReceiptConverter<<N as FullNodeTypes>::Provider>,
+    BaseReceiptConverter<<N as FullNodeTypes>::Provider>,
     (),
     OpTxInfoMapper<<N as FullNodeTypes>::Provider>,
 >;
@@ -367,7 +367,7 @@ where
     async fn build_eth_api(self, ctx: EthApiCtx<'_, N>) -> eyre::Result<Self::EthApi> {
         let Self { sequencer_url, sequencer_headers, min_suggested_priority_fee, .. } = self;
         let rpc_converter =
-            RpcConverter::new(OpReceiptConverter::new(ctx.components.provider().clone()))
+            RpcConverter::new(BaseReceiptConverter::new(ctx.components.provider().clone()))
                 .with_mapper(OpTxInfoMapper::new(ctx.components.provider().clone()));
 
         let sequencer_client = if let Some(url) = sequencer_url {

--- a/crates/execution/rpc/src/eth/proofs.rs
+++ b/crates/execution/rpc/src/eth/proofs.rs
@@ -14,7 +14,7 @@ use jsonrpsee_types::error::ErrorObject;
 use reth_provider::StateProofProvider;
 use reth_rpc_api::eth::helpers::FullEthApi;
 
-use crate::{metrics::EthApiExtMetrics, state::OpStateProviderFactory};
+use crate::{metrics::EthApiExtMetrics, state::BaseStateProviderFactory};
 
 #[cfg_attr(not(test), rpc(server, namespace = "eth"))]
 #[cfg_attr(test, rpc(server, client, namespace = "eth"))]
@@ -33,7 +33,7 @@ pub trait EthApiOverride {
 #[derive(Debug)]
 /// Overrides applied to the `eth_` namespace of the RPC API for historical proofs `ExEx`.
 pub struct EthApiExt<Eth, P> {
-    state_provider_factory: OpStateProviderFactory<Eth, P>,
+    state_provider_factory: BaseStateProviderFactory<Eth, P>,
 }
 
 impl<Eth, P> EthApiExt<Eth, P>
@@ -44,7 +44,7 @@ where
 {
     /// Creates a new instance of the `EthApiExt`.
     pub const fn new(eth_api: Eth, preimage_store: OpProofsStorage<P>) -> Self {
-        Self { state_provider_factory: OpStateProviderFactory::new(eth_api, preimage_store) }
+        Self { state_provider_factory: BaseStateProviderFactory::new(eth_api, preimage_store) }
     }
 }
 

--- a/crates/execution/rpc/src/eth/receipt.rs
+++ b/crates/execution/rpc/src/eth/receipt.rs
@@ -32,18 +32,18 @@ where
 
 /// Converter for OP receipts.
 #[derive(Debug, Clone)]
-pub struct OpReceiptConverter<Provider> {
+pub struct BaseReceiptConverter<Provider> {
     provider: Provider,
 }
 
-impl<Provider> OpReceiptConverter<Provider> {
-    /// Creates a new [`OpReceiptConverter`].
+impl<Provider> BaseReceiptConverter<Provider> {
+    /// Creates a new [`BaseReceiptConverter`].
     pub const fn new(provider: Provider) -> Self {
         Self { provider }
     }
 }
 
-impl<Provider, N> ReceiptConverter<N> for OpReceiptConverter<Provider>
+impl<Provider, N> ReceiptConverter<N> for BaseReceiptConverter<Provider>
 where
     N: NodePrimitives<SignedTx: OpTransaction, Receipt = OpReceipt>,
     Provider: BlockReader<Block = N::Block>
@@ -110,7 +110,7 @@ where
 /// L1 fee and data gas for a non-deposit transaction, or deposit nonce and receipt version for a
 /// deposit transaction.
 #[derive(Debug, Clone)]
-pub struct OpReceiptFieldsBuilder {
+pub struct ReceiptFieldsBuilder {
     /// Block number.
     pub block_number: u64,
     /// Block timestamp.
@@ -147,7 +147,7 @@ pub struct OpReceiptFieldsBuilder {
     pub da_footprint_gas_scalar: Option<u16>,
 }
 
-impl OpReceiptFieldsBuilder {
+impl ReceiptFieldsBuilder {
     /// Returns a new builder.
     pub const fn new(block_timestamp: u64, block_number: u64) -> Self {
         Self {
@@ -324,7 +324,7 @@ impl OpReceiptBuilder {
             core_receipt.blob_gas_used = Some(da_size);
         });
 
-        let op_receipt_fields = OpReceiptFieldsBuilder::new(timestamp, block_number)
+        let op_receipt_fields = ReceiptFieldsBuilder::new(timestamp, block_number)
             .l1_block_info(chain_spec, tx_signed, l1_block_info)?
             .build();
 
@@ -420,7 +420,7 @@ mod tests {
             BLOCK_124665056_TIMESTAMP
         ));
 
-        let receipt_meta = OpReceiptFieldsBuilder::new(BLOCK_124665056_TIMESTAMP, 124665056)
+        let receipt_meta = ReceiptFieldsBuilder::new(BLOCK_124665056_TIMESTAMP, 124665056)
             .l1_block_info(&*BASE_MAINNET, &tx_1, &mut l1_block_info)
             .expect("should parse revm l1 info")
             .build();
@@ -498,7 +498,7 @@ mod tests {
             ..Default::default()
         };
 
-        let receipt_meta = OpReceiptFieldsBuilder::new(BLOCK_124665056_TIMESTAMP, 124665056)
+        let receipt_meta = ReceiptFieldsBuilder::new(BLOCK_124665056_TIMESTAMP, 124665056)
             .l1_block_info(&*BASE_MAINNET, &tx_1, &mut l1_block_info)
             .expect("should parse revm l1 info")
             .build();
@@ -522,7 +522,7 @@ mod tests {
             ..Default::default()
         };
 
-        let receipt_meta = OpReceiptFieldsBuilder::new(BLOCK_124665056_TIMESTAMP, 124665056)
+        let receipt_meta = ReceiptFieldsBuilder::new(BLOCK_124665056_TIMESTAMP, 124665056)
             .l1_block_info(&*BASE_MAINNET, &tx_1, &mut l1_block_info)
             .expect("should parse revm l1 info")
             .build();
@@ -556,7 +556,7 @@ mod tests {
         );
         let tx_1 = OpTransactionSigned::decode_2718(&mut &tx[..]).unwrap();
 
-        let receipt_meta = OpReceiptFieldsBuilder::new(1730216981, 21713817)
+        let receipt_meta = ReceiptFieldsBuilder::new(1730216981, 21713817)
             .l1_block_info(&*BASE_MAINNET, &tx_1, &mut l1_block_info)
             .expect("should parse revm l1 info")
             .build();
@@ -615,7 +615,7 @@ mod tests {
         let op_hardforks = &*BASE_MAINNET;
 
         let receipt =
-            OpReceiptFieldsBuilder::new(BaseChainConfig::mainnet().jovian_timestamp, u64::MAX)
+            ReceiptFieldsBuilder::new(BaseChainConfig::mainnet().jovian_timestamp, u64::MAX)
                 .l1_block_info(&op_hardforks, &tx, &mut l1_block_info)
                 .expect("should parse revm l1 info")
                 .build();

--- a/crates/execution/rpc/src/state.rs
+++ b/crates/execution/rpc/src/state.rs
@@ -9,19 +9,19 @@ use reth_rpc_eth_types::EthApiError;
 
 /// Creates a factory for state providers using OP Proofs external proofs storage.
 #[derive(Debug)]
-pub struct OpStateProviderFactory<Eth, P> {
+pub struct BaseStateProviderFactory<Eth, P> {
     eth_api: Eth,
     preimage_store: OpProofsStorage<P>,
 }
 
-impl<Eth, P> OpStateProviderFactory<Eth, P> {
+impl<Eth, P> BaseStateProviderFactory<Eth, P> {
     /// Creates a new state provider factory.
     pub const fn new(eth_api: Eth, preimage_store: OpProofsStorage<P>) -> Self {
         Self { eth_api, preimage_store }
     }
 }
 
-impl<'a, Eth, P> OpStateProviderFactory<Eth, P>
+impl<'a, Eth, P> BaseStateProviderFactory<Eth, P>
 where
     Eth: FullEthApi + Send + Sync + 'static,
     ErrorObject<'static>: From<Eth::Error>,

--- a/crates/execution/trie/src/lib.rs
+++ b/crates/execution/trie/src/lib.rs
@@ -54,6 +54,6 @@ pub use error::{OpProofsStorageError, OpProofsStorageResult};
 
 mod prune;
 pub use prune::{
-    OpProofStoragePruner, OpProofStoragePrunerResult, OpProofStoragePrunerTask, PrunerError,
+    BaseProofStoragePrunerTask, OpProofStoragePruner, OpProofStoragePrunerResult, PrunerError,
     PrunerOutput,
 };

--- a/crates/execution/trie/src/prune/mod.rs
+++ b/crates/execution/trie/src/prune/mod.rs
@@ -9,4 +9,4 @@ pub use pruner::OpProofStoragePruner;
 mod metrics;
 
 mod task;
-pub use task::OpProofStoragePrunerTask;
+pub use task::BaseProofStoragePrunerTask;

--- a/crates/execution/trie/src/prune/task.rs
+++ b/crates/execution/trie/src/prune/task.rs
@@ -12,18 +12,18 @@ const PRUNE_BATCH_SIZE: u64 = 200;
 
 /// Periodic pruner task: constructs the pruner and runs it every interval.
 #[derive(Debug)]
-pub struct OpProofStoragePrunerTask<P, H> {
+pub struct BaseProofStoragePrunerTask<P, H> {
     pruner: OpProofStoragePruner<P, H>,
     min_block_interval: u64,
     task_run_interval: Duration,
 }
 
-impl<P, H> OpProofStoragePrunerTask<P, H>
+impl<P, H> BaseProofStoragePrunerTask<P, H>
 where
     P: OpProofsStore,
     H: BlockHashReader,
 {
-    /// Initialize a new [`OpProofStoragePrunerTask`]
+    /// Initialize a new [`BaseProofStoragePrunerTask`]
     pub const fn new(
         provider: OpProofsStorage<P>,
         hash_reader: H,


### PR DESCRIPTION
## Summary

Renames ten low-ref-count Op-prefixed types as part of the ongoing effort to align workspace type names away from the Op namespace. Types with no external naming conflict drop the prefix entirely (GenesisInfo, BuildError, ReceiptFieldsBuilder), while types that would collide with reth or alloy names adopt the Base prefix (BaseBuilderConfig, BasePayloadBuilderError, BasePayloadTransactions, BaseTransactionBuilder, BaseReceiptConverter, BaseStateProviderFactory, BaseProofStoragePrunerTask). All twenty affected files compile cleanly with no behavior changes.