### PR TITLE
ktlo(rename): Drop Prefix From Workspace Types

### DIFF
--- a/crates/builder/core/src/config.rs
+++ b/crates/builder/core/src/config.rs
@@ -6,7 +6,7 @@ use core::{
 };
 use std::sync::Arc;
 
-use base_execution_payload_builder::config::{OpDAConfig, OpGasLimitConfig};
+use base_execution_payload_builder::config::{OpDAConfig, GasLimitConfig};
 
 use crate::{ExecutionMeteringMode, NoopMeteringProvider, SharedMeteringProvider};
 
@@ -23,7 +23,7 @@ pub struct BuilderConfig {
     pub da_config: OpDAConfig,
 
     /// Gas limit configuration for the payload builder
-    pub gas_limit_config: OpGasLimitConfig,
+    pub gas_limit_config: GasLimitConfig,
 
     /// Extra time allowed for payload building before garbage collection.
     pub block_time_leeway: Duration,
@@ -122,7 +122,7 @@ impl Default for BuilderConfig {
             block_time: Duration::from_secs(2),
             block_time_leeway: Duration::from_millis(500),
             da_config: OpDAConfig::default(),
-            gas_limit_config: OpGasLimitConfig::default(),
+            gas_limit_config: GasLimitConfig::default(),
             flashblocks_ws_addr: SocketAddr::new(Ipv4Addr::UNSPECIFIED.into(), 1111),
             flashblocks_interval: Duration::from_millis(250),
             flashblocks_leeway_time: Duration::from_millis(50),

--- a/crates/builder/core/src/config.rs
+++ b/crates/builder/core/src/config.rs
@@ -6,7 +6,7 @@ use core::{
 };
 use std::sync::Arc;
 
-use base_execution_payload_builder::config::{OpDAConfig, GasLimitConfig};
+use base_execution_payload_builder::config::{GasLimitConfig, OpDAConfig};
 
 use crate::{ExecutionMeteringMode, NoopMeteringProvider, SharedMeteringProvider};
 

--- a/crates/builder/core/src/flashblocks/generator.rs
+++ b/crates/builder/core/src/flashblocks/generator.rs
@@ -526,9 +526,7 @@ mod tests {
     use alloy_eips::eip7685::Requests;
     use alloy_primitives::U256;
     use base_alloy_consensus::OpPrimitives;
-    use base_execution_payload_builder::{
-        PayloadPrimitives, payload::OpPayloadBuilderAttributes,
-    };
+    use base_execution_payload_builder::{PayloadPrimitives, payload::OpPayloadBuilderAttributes};
     use rand::rng;
     use reth_node_api::{BuiltPayloadExecutedBlock, NodePrimitives};
     use reth_primitives::SealedBlock;

--- a/crates/builder/core/src/flashblocks/generator.rs
+++ b/crates/builder/core/src/flashblocks/generator.rs
@@ -527,7 +527,7 @@ mod tests {
     use alloy_primitives::U256;
     use base_alloy_consensus::OpPrimitives;
     use base_execution_payload_builder::{
-        OpPayloadPrimitives, payload::OpPayloadBuilderAttributes,
+        PayloadPrimitives, payload::OpPayloadBuilderAttributes,
     };
     use rand::rng;
     use reth_node_api::{BuiltPayloadExecutedBlock, NodePrimitives};
@@ -670,7 +670,7 @@ mod tests {
     #[async_trait::async_trait]
     impl<N> PayloadBuilder for MockBuilder<N>
     where
-        N: OpPayloadPrimitives,
+        N: PayloadPrimitives,
     {
         type Attributes = OpPayloadBuilderAttributes<N::SignedTx>;
         type BuiltPayload = MockPayload;

--- a/crates/client/proofs/src/proofs.rs
+++ b/crates/client/proofs/src/proofs.rs
@@ -34,7 +34,7 @@ impl ProofsHistoryExtension {
 impl BaseNodeExtension for ProofsHistoryExtension {
     /// Applies the extension to the supplied hooks.
     fn apply(self: Box<Self>, mut hooks: NodeHooks) -> NodeHooks {
-        // TODO: if NodeHooks exposes the underlying OpBuilder, we can call launch_node_with_proof_history
+        // TODO: if NodeHooks exposes the underlying Builder, we can call launch_node_with_proof_history
         let args = self.config;
         let proofs_history_enabled = args.proofs_history;
         let proofs_history_window = args.proofs_history_window;

--- a/crates/common/evm/src/executor.rs
+++ b/crates/common/evm/src/executor.rs
@@ -359,9 +359,9 @@ mod tests {
     use base_alloy_chains::{BaseChainUpgrades, BaseUpgrade};
     use base_alloy_consensus::OpTxEnvelope;
     use base_revm::{
-        BASE_FEE_SCALAR_OFFSET, DefaultOp, ECOTONE_L1_BLOB_BASE_FEE_SLOT,
+        BASE_FEE_SCALAR_OFFSET, Builder, DefaultOp, ECOTONE_L1_BLOB_BASE_FEE_SLOT,
         ECOTONE_L1_FEE_SCALARS_SLOT, L1_BASE_FEE_SLOT, L1_BLOCK_CONTRACT, L1BlockInfo,
-        OPERATOR_FEE_SCALARS_SLOT, Builder, OpSpecId,
+        OPERATOR_FEE_SCALARS_SLOT, OpSpecId,
     };
     use revm::{
         Context,

--- a/crates/common/evm/src/executor.rs
+++ b/crates/common/evm/src/executor.rs
@@ -361,7 +361,7 @@ mod tests {
     use base_revm::{
         BASE_FEE_SCALAR_OFFSET, DefaultOp, ECOTONE_L1_BLOB_BASE_FEE_SLOT,
         ECOTONE_L1_FEE_SCALARS_SLOT, L1_BASE_FEE_SLOT, L1_BLOCK_CONTRACT, L1BlockInfo,
-        OPERATOR_FEE_SCALARS_SLOT, OpBuilder, OpSpecId,
+        OPERATOR_FEE_SCALARS_SLOT, Builder, OpSpecId,
     };
     use revm::{
         Context,

--- a/crates/common/evm/src/factory.rs
+++ b/crates/common/evm/src/factory.rs
@@ -1,6 +1,6 @@
 use alloy_evm::{Database, EvmEnv, EvmFactory, precompiles::PrecompilesMap};
 use base_revm::{
-    BasePrecompiles, DefaultOp, Builder, OpContext, OpHaltReason, OpSpecId, OpTransaction,
+    BasePrecompiles, Builder, DefaultOp, OpContext, OpHaltReason, OpSpecId, OpTransaction,
     OpTransactionError,
 };
 use revm::{

--- a/crates/common/evm/src/factory.rs
+++ b/crates/common/evm/src/factory.rs
@@ -1,6 +1,6 @@
 use alloy_evm::{Database, EvmEnv, EvmFactory, precompiles::PrecompilesMap};
 use base_revm::{
-    BasePrecompiles, DefaultOp, OpBuilder, OpContext, OpHaltReason, OpSpecId, OpTransaction,
+    BasePrecompiles, DefaultOp, Builder, OpContext, OpHaltReason, OpSpecId, OpTransaction,
     OpTransactionError,
 };
 use revm::{

--- a/crates/execution/consensus/src/error.rs
+++ b/crates/execution/consensus/src/error.rs
@@ -6,7 +6,7 @@ use reth_storage_errors::provider::ProviderError;
 
 /// Base consensus error.
 #[derive(Debug, Clone, thiserror::Error)]
-pub enum OpConsensusError {
+pub enum BaseConsensusError {
     /// Block body has non-empty withdrawals list (l1 withdrawals).
     #[error("non-empty block body withdrawals list")]
     WithdrawalsNonEmpty,

--- a/crates/execution/consensus/src/lib.rs
+++ b/crates/execution/consensus/src/lib.rs
@@ -37,7 +37,7 @@ pub mod validation;
 pub use validation::{canyon, isthmus, validate_block_post_execution};
 
 pub mod error;
-pub use error::OpConsensusError;
+pub use error::BaseConsensusError;
 
 /// Base consensus implementation.
 ///

--- a/crates/execution/consensus/src/validation/canyon.rs
+++ b/crates/execution/consensus/src/validation/canyon.rs
@@ -5,7 +5,7 @@ use alloy_trie::EMPTY_ROOT_HASH;
 use reth_consensus::ConsensusError;
 use reth_primitives_traits::{BlockBody, GotExpected};
 
-use crate::OpConsensusError;
+use crate::BaseConsensusError;
 
 /// Verifies that withdrawals root in block header (Shanghai) is always [`EMPTY_ROOT_HASH`] in
 /// Canyon.
@@ -28,13 +28,13 @@ pub fn ensure_empty_withdrawals_root<H: BlockHeader>(header: &H) -> Result<(), C
 /// Verifies that withdrawals in block body (Shanghai) is always empty in Canyon.
 /// <https://specs.optimism.io/protocol/rollup-node-p2p.html#block-validation>
 #[inline]
-pub fn ensure_empty_shanghai_withdrawals<T: BlockBody>(body: &T) -> Result<(), OpConsensusError> {
+pub fn ensure_empty_shanghai_withdrawals<T: BlockBody>(body: &T) -> Result<(), BaseConsensusError> {
     // Shanghai rule
     let withdrawals = body.withdrawals().ok_or(ConsensusError::BodyWithdrawalsMissing)?;
 
     //  Canyon rule
     if !withdrawals.as_ref().is_empty() {
-        return Err(OpConsensusError::WithdrawalsNonEmpty);
+        return Err(BaseConsensusError::WithdrawalsNonEmpty);
     }
 
     Ok(())

--- a/crates/execution/consensus/src/validation/isthmus.rs
+++ b/crates/execution/consensus/src/validation/isthmus.rs
@@ -9,14 +9,14 @@ use reth_trie_common::HashedStorage;
 use revm::database::BundleState;
 use tracing::warn;
 
-use crate::OpConsensusError;
+use crate::BaseConsensusError;
 
 /// Verifies that `withdrawals_root` (i.e. `l2tol1-msg-passer` storage root since Isthmus) field is
 /// set in block header.
 pub fn ensure_withdrawals_storage_root_is_some<H: BlockHeader>(
     header: H,
-) -> Result<(), OpConsensusError> {
-    header.withdrawals_root().ok_or(OpConsensusError::L2WithdrawalsRootMissing)?;
+) -> Result<(), BaseConsensusError> {
+    header.withdrawals_root().ok_or(BaseConsensusError::L2WithdrawalsRootMissing)?;
 
     Ok(())
 }
@@ -66,16 +66,16 @@ pub fn verify_withdrawals_root<DB, H>(
     state_updates: &BundleState,
     state: DB,
     header: H,
-) -> Result<(), OpConsensusError>
+) -> Result<(), BaseConsensusError>
 where
     DB: StorageRootProvider,
     H: BlockHeader,
 {
     let header_storage_root =
-        header.withdrawals_root().ok_or(OpConsensusError::L2WithdrawalsRootMissing)?;
+        header.withdrawals_root().ok_or(BaseConsensusError::L2WithdrawalsRootMissing)?;
 
     let storage_root = withdrawals_root(state_updates, state)
-        .map_err(OpConsensusError::L2WithdrawalsRootCalculationFail)?;
+        .map_err(BaseConsensusError::L2WithdrawalsRootCalculationFail)?;
 
     if storage_root == EMPTY_ROOT_HASH {
         // if there was no MessagePasser contract storage, something is wrong
@@ -84,7 +84,7 @@ where
     }
 
     if header_storage_root != storage_root {
-        return Err(OpConsensusError::L2WithdrawalsRootMismatch {
+        return Err(BaseConsensusError::L2WithdrawalsRootMismatch {
             header: header_storage_root,
             exec_res: storage_root,
         });
@@ -104,19 +104,19 @@ pub fn verify_withdrawals_root_prehashed<DB, H>(
     hashed_storage_updates: HashedStorage,
     state: DB,
     header: H,
-) -> Result<(), OpConsensusError>
+) -> Result<(), BaseConsensusError>
 where
     DB: StorageRootProvider,
     H: BlockHeader,
 {
     let header_storage_root =
-        header.withdrawals_root().ok_or(OpConsensusError::L2WithdrawalsRootMissing)?;
+        header.withdrawals_root().ok_or(BaseConsensusError::L2WithdrawalsRootMissing)?;
 
     let storage_root = withdrawals_root_prehashed(hashed_storage_updates, state)
-        .map_err(OpConsensusError::L2WithdrawalsRootCalculationFail)?;
+        .map_err(BaseConsensusError::L2WithdrawalsRootCalculationFail)?;
 
     if header_storage_root != storage_root {
-        return Err(OpConsensusError::L2WithdrawalsRootMismatch {
+        return Err(BaseConsensusError::L2WithdrawalsRootMismatch {
             header: header_storage_root,
             exec_res: storage_root,
         });

--- a/crates/execution/node/src/node.rs
+++ b/crates/execution/node/src/node.rs
@@ -13,7 +13,7 @@ use base_execution_evm::{OpEvmConfig, OpRethReceiptBuilder};
 use base_execution_payload_builder::{
     Attributes, OpBuiltPayload, PayloadPrimitives,
     builder::OpPayloadTransactions,
-    config::{BaseBuilderConfig, OpDAConfig, GasLimitConfig},
+    config::{BaseBuilderConfig, GasLimitConfig, OpDAConfig},
 };
 use base_execution_rpc::{
     config::{BaseEthConfigApiServer, BaseEthConfigHandler},
@@ -201,11 +201,7 @@ pub type OpNodeComponentBuilder<Node, Payload = OpPayloadBuilder> = ComponentsBu
 impl OpNode {
     /// Creates a new instance of the Base node type.
     pub fn new(args: RollupArgs) -> Self {
-        Self {
-            args,
-            da_config: OpDAConfig::default(),
-            gas_limit_config: GasLimitConfig::default(),
-        }
+        Self { args, da_config: OpDAConfig::default(), gas_limit_config: GasLimitConfig::default() }
     }
 
     /// Configure the data availability configuration for the OP builder.

--- a/crates/execution/node/src/node.rs
+++ b/crates/execution/node/src/node.rs
@@ -11,9 +11,9 @@ use base_execution_chainspec::OpChainSpec;
 use base_execution_consensus::OpBeaconConsensus;
 use base_execution_evm::{OpEvmConfig, OpRethReceiptBuilder};
 use base_execution_payload_builder::{
-    OpAttributes, OpBuiltPayload, OpPayloadPrimitives,
+    Attributes, OpBuiltPayload, PayloadPrimitives,
     builder::OpPayloadTransactions,
-    config::{OpBuilderConfig, OpDAConfig, OpGasLimitConfig},
+    config::{BaseBuilderConfig, OpDAConfig, GasLimitConfig},
 };
 use base_execution_rpc::{
     config::{BaseEthConfigApiServer, BaseEthConfigHandler},
@@ -84,7 +84,7 @@ impl<N> OpNodeTypes for N where
 pub trait BaseFullNodeTypes:
     NodeTypes<
         ChainSpec = OpChainSpec,
-        Primitives: OpPayloadPrimitives,
+        Primitives: PayloadPrimitives,
         Storage = OpStorage,
         Payload: EngineTypes<ExecutionData = OpExecutionData>,
     >
@@ -94,7 +94,7 @@ pub trait BaseFullNodeTypes:
 impl<N> BaseFullNodeTypes for N where
     N: NodeTypes<
             ChainSpec = OpChainSpec,
-            Primitives: OpPayloadPrimitives,
+            Primitives: PayloadPrimitives,
             Storage = OpStorage,
             Payload: EngineTypes<ExecutionData = OpExecutionData>,
         >
@@ -185,7 +185,7 @@ pub struct OpNode {
     /// Gas limit configuration for the OP builder.
     /// Used to control the gas limit of the blocks produced by the OP builder.(configured by the
     /// batcher via the `miner_` api)
-    pub gas_limit_config: OpGasLimitConfig,
+    pub gas_limit_config: GasLimitConfig,
 }
 
 /// A [`ComponentsBuilder`] with its generic arguments set to a stack of Base-specific builders.
@@ -204,7 +204,7 @@ impl OpNode {
         Self {
             args,
             da_config: OpDAConfig::default(),
-            gas_limit_config: OpGasLimitConfig::default(),
+            gas_limit_config: GasLimitConfig::default(),
         }
     }
 
@@ -215,7 +215,7 @@ impl OpNode {
     }
 
     /// Configure the gas limit configuration for the OP builder.
-    pub fn with_gas_limit_config(mut self, gas_limit_config: OpGasLimitConfig) -> Self {
+    pub fn with_gas_limit_config(mut self, gas_limit_config: GasLimitConfig) -> Self {
         self.gas_limit_config = gas_limit_config;
         self
     }
@@ -372,7 +372,7 @@ pub struct OpAddOns<
     /// Data availability configuration for the OP builder.
     pub da_config: OpDAConfig,
     /// Gas limit configuration for the OP builder.
-    pub gas_limit_config: OpGasLimitConfig,
+    pub gas_limit_config: GasLimitConfig,
     /// Sequencer client, configured to forward submitted transactions to sequencer of given OP
     /// network.
     pub sequencer_url: Option<String>,
@@ -391,7 +391,7 @@ where
     pub const fn new(
         rpc_add_ons: RpcAddOns<N, EthB, PVB, EB, EVB, RpcMiddleware>,
         da_config: OpDAConfig,
-        gas_limit_config: OpGasLimitConfig,
+        gas_limit_config: GasLimitConfig,
         sequencer_url: Option<String>,
         sequencer_headers: Vec<String>,
         min_suggested_priority_fee: u64,
@@ -551,8 +551,8 @@ where
     EB: EngineApiBuilder<N>,
     EVB: EngineValidatorBuilder<N>,
     RpcMiddleware: RethRpcMiddleware,
-    Attrs: OpAttributes<Transaction = TxTy<N::Types>, RpcPayloadAttributes: DeserializeOwned>,
-    <N::Types as NodeTypes>::Primitives: OpPayloadPrimitives<_Header: HeaderMut>,
+    Attrs: Attributes<Transaction = TxTy<N::Types>, RpcPayloadAttributes: DeserializeOwned>,
+    <N::Types as NodeTypes>::Primitives: PayloadPrimitives<_Header: HeaderMut>,
 {
     type Handle = RpcHandle<N, EthB::EthApi>;
 
@@ -626,8 +626,8 @@ where
     EB: EngineApiBuilder<N>,
     EVB: EngineValidatorBuilder<N>,
     RpcMiddleware: RethRpcMiddleware,
-    Attrs: OpAttributes<Transaction = TxTy<N::Types>, RpcPayloadAttributes: DeserializeOwned>,
-    <N::Types as NodeTypes>::Primitives: OpPayloadPrimitives<_Header: HeaderMut>,
+    Attrs: Attributes<Transaction = TxTy<N::Types>, RpcPayloadAttributes: DeserializeOwned>,
+    <N::Types as NodeTypes>::Primitives: PayloadPrimitives<_Header: HeaderMut>,
 {
     type EthApi = EthB::EthApi;
 
@@ -665,7 +665,7 @@ pub struct OpAddOnsBuilder<NetworkT, RpcMiddleware = Identity> {
     /// Data availability configuration for the OP builder.
     da_config: Option<OpDAConfig>,
     /// Gas limit configuration for the OP builder.
-    gas_limit_config: Option<OpGasLimitConfig>,
+    gas_limit_config: Option<GasLimitConfig>,
     /// Marker for network types.
     _nt: PhantomData<NetworkT>,
     /// Minimum suggested priority fee (tip)
@@ -711,7 +711,7 @@ impl<NetworkT, RpcMiddleware> OpAddOnsBuilder<NetworkT, RpcMiddleware> {
     }
 
     /// Configure the gas limit configuration for the OP payload builder.
-    pub fn with_gas_limit_config(mut self, gas_limit_config: OpGasLimitConfig) -> Self {
+    pub fn with_gas_limit_config(mut self, gas_limit_config: GasLimitConfig) -> Self {
         self.gas_limit_config = Some(gas_limit_config);
         self
     }
@@ -943,7 +943,7 @@ pub struct OpPayloadBuilder<Txs = ()> {
     pub da_config: OpDAConfig,
     /// Gas limit configuration for the OP builder.
     /// This is used to configure gas limit related constraints for the payload builder.
-    pub gas_limit_config: OpGasLimitConfig,
+    pub gas_limit_config: GasLimitConfig,
 }
 
 impl OpPayloadBuilder {
@@ -954,7 +954,7 @@ impl OpPayloadBuilder {
             compute_pending_block,
             best_transactions: (),
             da_config: OpDAConfig::default(),
-            gas_limit_config: OpGasLimitConfig::default(),
+            gas_limit_config: GasLimitConfig::default(),
         }
     }
 
@@ -965,7 +965,7 @@ impl OpPayloadBuilder {
     }
 
     /// Configure the gas limit configuration for the OP payload builder.
-    pub fn with_gas_limit_config(mut self, gas_limit_config: OpGasLimitConfig) -> Self {
+    pub fn with_gas_limit_config(mut self, gas_limit_config: GasLimitConfig) -> Self {
         self.gas_limit_config = gas_limit_config;
         self
     }
@@ -985,7 +985,7 @@ where
     Node: FullNodeTypes<
             Provider: ChainSpecProvider<ChainSpec: BaseUpgrades>,
             Types: NodeTypes<
-                Primitives: OpPayloadPrimitives,
+                Primitives: PayloadPrimitives,
                 Payload: PayloadTypes<
                     BuiltPayload = OpBuiltPayload<PrimitivesTy<Node::Types>>,
                     PayloadBuilderAttributes = Attrs,
@@ -1002,7 +1002,7 @@ where
         > + 'static,
     Pool: TransactionPool<Transaction: OpPooledTx<Consensus = TxTy<Node::Types>>> + Unpin + 'static,
     Txs: OpPayloadTransactions<Pool::Transaction>,
-    Attrs: OpAttributes<Transaction = TxTy<Node::Types>>,
+    Attrs: Attributes<Transaction = TxTy<Node::Types>>,
 {
     type PayloadBuilder =
         base_execution_payload_builder::OpPayloadBuilder<Pool, Node::Provider, Evm, Txs, Attrs>;
@@ -1018,7 +1018,7 @@ where
                 pool,
                 ctx.provider().clone(),
                 evm_config,
-                OpBuilderConfig {
+                BaseBuilderConfig {
                     da_config: self.da_config.clone(),
                     gas_limit_config: self.gas_limit_config.clone(),
                 },

--- a/crates/execution/payload/src/builder.rs
+++ b/crates/execution/payload/src/builder.rs
@@ -40,7 +40,7 @@ use revm::context::{Block, BlockEnv};
 use tracing::{debug, trace, warn};
 
 use crate::{
-    OpAttributes, OpPayloadBuilderAttributes, OpPayloadPrimitives, config::OpBuilderConfig,
+    Attributes, OpPayloadBuilderAttributes, PayloadPrimitives, config::BaseBuilderConfig,
     error::OpPayloadBuilderError, payload::OpBuiltPayload,
 };
 
@@ -62,7 +62,7 @@ pub struct OpPayloadBuilder<
     /// Node client.
     pub client: Client,
     /// Settings for the builder, e.g. DA settings.
-    pub config: OpBuilderConfig,
+    pub config: BaseBuilderConfig,
     /// The type responsible for yielding the best transactions for the payload if mempool
     /// transactions are allowed.
     pub best_transactions: Txs,
@@ -98,12 +98,12 @@ impl<Pool, Client, Evm, Attrs> OpPayloadBuilder<Pool, Client, Evm, (), Attrs> {
         Self::with_builder_config(pool, client, evm_config, Default::default())
     }
 
-    /// Configures the builder with the given [`OpBuilderConfig`].
+    /// Configures the builder with the given [`BaseBuilderConfig`].
     pub const fn with_builder_config(
         pool: Pool,
         client: Client,
         evm_config: Evm,
-        config: OpBuilderConfig,
+        config: BaseBuilderConfig,
     ) -> Self {
         Self {
             pool,
@@ -157,12 +157,12 @@ impl<Pool, Client, Evm, N, T, Attrs> OpPayloadBuilder<Pool, Client, Evm, T, Attr
 where
     Pool: TransactionPool<Transaction: OpPooledTx<Consensus = N::SignedTx>>,
     Client: StateProviderFactory + ChainSpecProvider<ChainSpec: BaseUpgrades>,
-    N: OpPayloadPrimitives,
+    N: PayloadPrimitives,
     Evm: ConfigureEvm<
             Primitives = N,
             NextBlockEnvCtx: BuildNextEnv<Attrs, N::BlockHeader, Client::ChainSpec>,
         >,
-    Attrs: OpAttributes<Transaction = TxTy<Evm::Primitives>>,
+    Attrs: Attributes<Transaction = TxTy<Evm::Primitives>>,
 {
     /// Constructs a Base payload from the transactions sent via the
     /// Payload attributes by the sequencer. If the `no_tx_pool` argument is passed in
@@ -192,7 +192,7 @@ where
             best_payload,
         };
 
-        let builder = OpBuilder::new(best);
+        let builder = Builder::new(best);
 
         let state_provider = self.client.state_by_block_hash(ctx.parent().hash())?;
         let state = StateProviderDatabase::new(&state_provider);
@@ -230,7 +230,7 @@ where
 
         let state_provider = self.client.state_by_block_hash(ctx.parent().hash())?;
 
-        let builder = OpBuilder::new(|_| NoopPayloadTransactions::<Pool::Transaction>::default());
+        let builder = Builder::new(|_| NoopPayloadTransactions::<Pool::Transaction>::default());
         builder.witness(state_provider, &ctx)
     }
 }
@@ -239,7 +239,7 @@ where
 impl<Pool, Client, Evm, N, Txs, Attrs> PayloadBuilder
     for OpPayloadBuilder<Pool, Client, Evm, Txs, Attrs>
 where
-    N: OpPayloadPrimitives,
+    N: PayloadPrimitives,
     Client: StateProviderFactory + ChainSpecProvider<ChainSpec: BaseUpgrades> + Clone,
     Pool: TransactionPool<Transaction: OpPooledTx<Consensus = N::SignedTx>>,
     Evm: ConfigureEvm<
@@ -247,7 +247,7 @@ where
             NextBlockEnvCtx: BuildNextEnv<Attrs, N::BlockHeader, Client::ChainSpec>,
         >,
     Txs: OpPayloadTransactions<Pool::Transaction>,
-    Attrs: OpAttributes<Transaction = N::SignedTx>,
+    Attrs: Attributes<Transaction = N::SignedTx>,
 {
     type Attributes = Attrs;
     type BuiltPayload = OpBuiltPayload<N>;
@@ -303,20 +303,20 @@ where
 /// And finally
 /// 5. build the block: compute all roots (txs, state)
 #[derive(derive_more::Debug)]
-pub struct OpBuilder<'a, Txs> {
+pub struct Builder<'a, Txs> {
     /// Yields the best transaction to include if transactions from the mempool are allowed.
     #[debug(skip)]
     best: Box<dyn FnOnce(BestTransactionsAttributes) -> Txs + 'a>,
 }
 
-impl<'a, Txs> OpBuilder<'a, Txs> {
-    /// Creates a new [`OpBuilder`].
+impl<'a, Txs> Builder<'a, Txs> {
+    /// Creates a new [`Builder`].
     pub fn new(best: impl FnOnce(BestTransactionsAttributes) -> Txs + Send + Sync + 'a) -> Self {
         Self { best: Box::new(best) }
     }
 }
 
-impl<Txs> OpBuilder<'_, Txs> {
+impl<Txs> Builder<'_, Txs> {
     /// Builds the payload on top of the state.
     pub fn build<Evm, ChainSpec, N, Attrs>(
         self,
@@ -330,10 +330,10 @@ impl<Txs> OpBuilder<'_, Txs> {
                 NextBlockEnvCtx: BuildNextEnv<Attrs, N::BlockHeader, ChainSpec>,
             >,
         ChainSpec: EthChainSpec + BaseUpgrades,
-        N: OpPayloadPrimitives,
+        N: PayloadPrimitives,
         Txs:
             PayloadTransactions<Transaction: PoolTransaction<Consensus = N::SignedTx> + OpPooledTx>,
-        Attrs: OpAttributes<Transaction = N::SignedTx>,
+        Attrs: Attributes<Transaction = N::SignedTx>,
     {
         let Self { best } = self;
         debug!(target: "payload_builder", id=%ctx.payload_id(), parent_header = ?ctx.parent().hash(), parent_number = ctx.parent().number(), "building new payload");
@@ -415,9 +415,9 @@ impl<Txs> OpBuilder<'_, Txs> {
                 NextBlockEnvCtx: BuildNextEnv<Attrs, N::BlockHeader, ChainSpec>,
             >,
         ChainSpec: EthChainSpec + BaseUpgrades,
-        N: OpPayloadPrimitives,
+        N: PayloadPrimitives,
         Txs: PayloadTransactions<Transaction: PoolTransaction<Consensus = N::SignedTx>>,
-        Attrs: OpAttributes<Transaction = N::SignedTx>,
+        Attrs: Attributes<Transaction = N::SignedTx>,
     {
         let mut db = State::builder()
             .with_database(StateProviderDatabase::new(&state_provider))
@@ -546,7 +546,7 @@ pub struct OpPayloadBuilderCtx<
     /// The type that knows how to perform system calls and configure the evm.
     pub evm_config: Evm,
     /// Additional config for the builder/sequencer, e.g. DA and gas limit
-    pub builder_config: OpBuilderConfig,
+    pub builder_config: BaseBuilderConfig,
     /// The chainspec
     pub chain_spec: Arc<ChainSpec>,
     /// How to build the payload.
@@ -560,11 +560,11 @@ pub struct OpPayloadBuilderCtx<
 impl<Evm, ChainSpec, Attrs> OpPayloadBuilderCtx<Evm, ChainSpec, Attrs>
 where
     Evm: ConfigureEvm<
-            Primitives: OpPayloadPrimitives,
+            Primitives: PayloadPrimitives,
             NextBlockEnvCtx: BuildNextEnv<Attrs, HeaderTy<Evm::Primitives>, ChainSpec>,
         >,
     ChainSpec: EthChainSpec + BaseUpgrades,
-    Attrs: OpAttributes<Transaction = TxTy<Evm::Primitives>>,
+    Attrs: Attributes<Transaction = TxTy<Evm::Primitives>>,
 {
     /// Returns the parent block the payload will be build on.
     pub fn parent(&self) -> &SealedHeaderFor<Evm::Primitives> {

--- a/crates/execution/payload/src/config.rs
+++ b/crates/execution/payload/src/config.rs
@@ -4,16 +4,16 @@ use std::sync::{Arc, atomic::AtomicU64};
 
 /// Settings for the OP builder.
 #[derive(Debug, Clone, Default)]
-pub struct OpBuilderConfig {
+pub struct BaseBuilderConfig {
     /// Data availability configuration for the OP builder.
     pub da_config: OpDAConfig,
     /// Gas limit configuration for the OP builder.
-    pub gas_limit_config: OpGasLimitConfig,
+    pub gas_limit_config: GasLimitConfig,
 }
 
-impl OpBuilderConfig {
+impl BaseBuilderConfig {
     /// Creates a new OP builder configuration with the given data availability configuration.
-    pub const fn new(da_config: OpDAConfig, gas_limit_config: OpGasLimitConfig) -> Self {
+    pub const fn new(da_config: OpDAConfig, gas_limit_config: GasLimitConfig) -> Self {
         Self { da_config, gas_limit_config }
     }
 
@@ -95,14 +95,14 @@ struct OpDAConfigInner {
 /// This type is shareable and can be used to update the Gas Limit configuration for the OP payload
 /// builder.
 #[derive(Debug, Clone, Default)]
-pub struct OpGasLimitConfig {
+pub struct GasLimitConfig {
     /// Gas limit for a transaction
     ///
     /// 0 means use the default gas limit.
     gas_limit: Arc<AtomicU64>,
 }
 
-impl OpGasLimitConfig {
+impl GasLimitConfig {
     /// Creates a new Gas Limit configuration with the given maximum gas limit.
     pub fn new(max_gas_limit: u64) -> Self {
         let this = Self::default();
@@ -139,13 +139,13 @@ mod tests {
 
     #[test]
     fn test_da_constrained() {
-        let config = OpBuilderConfig::default();
+        let config = BaseBuilderConfig::default();
         assert!(config.constrained_da_config().is_none());
     }
 
     #[test]
     fn test_gas_limit() {
-        let gas_limit = OpGasLimitConfig::default();
+        let gas_limit = GasLimitConfig::default();
         assert_eq!(gas_limit.gas_limit(), None);
         gas_limit.set_gas_limit(50000);
         assert_eq!(gas_limit.gas_limit(), Some(50000));

--- a/crates/execution/payload/src/traits.rs
+++ b/crates/execution/payload/src/traits.rs
@@ -6,7 +6,7 @@ use reth_primitives_traits::{FullBlockHeader, NodePrimitives, SignedTransaction,
 use crate::OpPayloadBuilderAttributes;
 
 /// Helper trait to encapsulate common bounds on [`NodePrimitives`] for OP payload builder.
-pub trait OpPayloadPrimitives:
+pub trait PayloadPrimitives:
     NodePrimitives<
         Receipt: DepositReceipt,
         SignedTx = Self::_TX,
@@ -20,7 +20,7 @@ pub trait OpPayloadPrimitives:
     type _Header: FullBlockHeader;
 }
 
-impl<Tx, T, Header> OpPayloadPrimitives for T
+impl<Tx, T, Header> PayloadPrimitives for T
 where
     Tx: SignedTransaction + OpTransaction,
     T: NodePrimitives<
@@ -36,7 +36,7 @@ where
 }
 
 /// Attributes for the OP payload builder.
-pub trait OpAttributes: PayloadBuilderAttributes {
+pub trait Attributes: PayloadBuilderAttributes {
     /// Primitive transaction type.
     type Transaction: SignedTransaction;
 
@@ -47,7 +47,7 @@ pub trait OpAttributes: PayloadBuilderAttributes {
     fn sequencer_transactions(&self) -> &[WithEncoded<Self::Transaction>];
 }
 
-impl<T: SignedTransaction> OpAttributes for OpPayloadBuilderAttributes<T> {
+impl<T: SignedTransaction> Attributes for OpPayloadBuilderAttributes<T> {
     type Transaction = T;
 
     fn no_tx_pool(&self) -> bool {

--- a/crates/execution/revm/src/api.rs
+++ b/crates/execution/revm/src/api.rs
@@ -1,7 +1,7 @@
 //! Base API types.
 
 mod builder;
-pub use builder::{DefaultOpEvm, OpBuilder};
+pub use builder::{Builder, DefaultOpEvm};
 
 mod default_ctx;
 pub use default_ctx::{DefaultOp, OpContext};

--- a/crates/execution/revm/src/api/builder.rs
+++ b/crates/execution/revm/src/api/builder.rs
@@ -1,4 +1,4 @@
-//! Base builder trait [`OpBuilder`] used to build [`OpEvm`].
+//! Base builder trait [`Builder`] used to build [`OpEvm`].
 use revm::{
     Context, Database,
     context::Cfg,
@@ -15,7 +15,7 @@ pub type DefaultOpEvm<CTX, INSP = ()> =
     OpEvm<CTX, INSP, EthInstructions<EthInterpreter, CTX>, BasePrecompiles>;
 
 /// Trait that allows for Base `OpEvm` to be built.
-pub trait OpBuilder: Sized {
+pub trait Builder: Sized {
     /// Type of the context.
     type Context;
 
@@ -26,7 +26,7 @@ pub trait OpBuilder: Sized {
     fn build_op_with_inspector<INSP>(self, inspector: INSP) -> DefaultOpEvm<Self::Context, INSP>;
 }
 
-impl<BLOCK, TX, CFG, DB, JOURNAL> OpBuilder for Context<BLOCK, TX, CFG, DB, JOURNAL, L1BlockInfo>
+impl<BLOCK, TX, CFG, DB, JOURNAL> Builder for Context<BLOCK, TX, CFG, DB, JOURNAL, L1BlockInfo>
 where
     BLOCK: Block,
     TX: OpTxTr,

--- a/crates/execution/revm/src/api/default_ctx.rs
+++ b/crates/execution/revm/src/api/default_ctx.rs
@@ -34,7 +34,7 @@ mod tests {
     };
 
     use super::*;
-    use crate::OpBuilder;
+    use crate::Builder;
 
     #[test]
     fn default_run_op() {

--- a/crates/execution/revm/src/api/exec.rs
+++ b/crates/execution/revm/src/api/exec.rs
@@ -187,7 +187,7 @@ mod tests {
         database::{InMemoryDB, State},
     };
 
-    use crate::{DefaultOp, Builder, OpContext};
+    use crate::{Builder, DefaultOp, OpContext};
 
     /// Verifies that the system call caller is loaded into the EVM state cache so it appears in the
     /// execution witness.

--- a/crates/execution/revm/src/api/exec.rs
+++ b/crates/execution/revm/src/api/exec.rs
@@ -187,7 +187,7 @@ mod tests {
         database::{InMemoryDB, State},
     };
 
-    use crate::{DefaultOp, OpBuilder, OpContext};
+    use crate::{DefaultOp, Builder, OpContext};
 
     /// Verifies that the system call caller is loaded into the EVM state cache so it appears in the
     /// execution witness.
@@ -205,7 +205,7 @@ mod tests {
         let contract = Address::repeat_byte(0xAB);
 
         // Use State with bundle tracking, mirroring the witness generation path in
-        // OpBuilder::witness and debug_executionWitness.
+        // Builder::witness and debug_executionWitness.
         let state =
             State::builder().with_database(InMemoryDB::default()).with_bundle_update().build();
 

--- a/crates/execution/revm/src/handler.rs
+++ b/crates/execution/revm/src/handler.rs
@@ -405,7 +405,7 @@ mod tests {
 
     use super::*;
     use crate::{
-        DefaultOp, OpBuilder, OpContext, OpTransaction,
+        DefaultOp, Builder, OpContext, OpTransaction,
         constants::{
             BASE_FEE_SCALAR_OFFSET, ECOTONE_L1_BLOB_BASE_FEE_SLOT, ECOTONE_L1_FEE_SCALARS_SLOT,
             L1_BASE_FEE_SLOT, L1_BLOCK_CONTRACT, OPERATOR_FEE_SCALARS_SLOT,

--- a/crates/execution/revm/src/handler.rs
+++ b/crates/execution/revm/src/handler.rs
@@ -405,7 +405,7 @@ mod tests {
 
     use super::*;
     use crate::{
-        DefaultOp, Builder, OpContext, OpTransaction,
+        Builder, DefaultOp, OpContext, OpTransaction,
         constants::{
             BASE_FEE_SCALAR_OFFSET, ECOTONE_L1_BLOB_BASE_FEE_SLOT, ECOTONE_L1_FEE_SCALARS_SLOT,
             L1_BASE_FEE_SLOT, L1_BLOCK_CONTRACT, OPERATOR_FEE_SCALARS_SLOT,

--- a/crates/execution/revm/src/lib.rs
+++ b/crates/execution/revm/src/lib.rs
@@ -6,7 +6,7 @@
 extern crate alloc as std;
 
 mod api;
-pub use api::{BaseError, DefaultOp, DefaultOpEvm, OpBuilder, OpContext, OpContextTr};
+pub use api::{BaseError, Builder, DefaultOp, DefaultOpEvm, OpContext, OpContextTr};
 
 mod constants;
 pub use constants::*;

--- a/crates/execution/revm/src/transaction.rs
+++ b/crates/execution/revm/src/transaction.rs
@@ -20,7 +20,7 @@ mod tests {
     };
     use rstest::rstest;
 
-    use crate::{DefaultOp, OpBuilder, OpTransaction};
+    use crate::{DefaultOp, Builder, OpTransaction};
 
     #[rstest]
     #[case::short_hex(bytes!("FACADE"))]

--- a/crates/execution/revm/src/transaction.rs
+++ b/crates/execution/revm/src/transaction.rs
@@ -20,7 +20,7 @@ mod tests {
     };
     use rstest::rstest;
 
-    use crate::{DefaultOp, Builder, OpTransaction};
+    use crate::{Builder, DefaultOp, OpTransaction};
 
     #[rstest]
     #[case::short_hex(bytes!("FACADE"))]

--- a/crates/execution/rpc/src/debug.rs
+++ b/crates/execution/rpc/src/debug.rs
@@ -10,8 +10,8 @@ use alloy_rpc_types_debug::ExecutionWitness;
 use async_trait::async_trait;
 use base_alloy_chains::BaseUpgrades;
 use base_execution_payload_builder::{
-    OpAttributes, OpPayloadPrimitives,
-    builder::{OpBuilder, OpPayloadBuilderCtx},
+    Attributes, PayloadPrimitives,
+    builder::{Builder, OpPayloadBuilderCtx},
 };
 use base_execution_trie::{OpProofsStorage, OpProofsStore};
 use base_txpool::BasePooledTransaction;
@@ -80,7 +80,7 @@ where
     Eth: FullEthApi + Send + Sync + 'static,
     ErrorObject<'static>: From<Eth::Error>,
     Storage: OpProofsStore + Clone + 'static,
-    Provider: BlockReaderIdExt + NodePrimitivesProvider<Primitives: OpPayloadPrimitives>,
+    Provider: BlockReaderIdExt + NodePrimitivesProvider<Primitives: PayloadPrimitives>,
     EvmConfig: ConfigureEvm<Primitives = Provider::Primitives> + 'static,
 {
     /// Creates a new instance of the `DebugApiExt`.
@@ -121,7 +121,7 @@ where
     Eth: FullEthApi + Send + Sync + 'static,
     ErrorObject<'static>: From<Eth::Error>,
     P: OpProofsStore + Clone + 'static,
-    Provider: NodePrimitivesProvider<Primitives: OpPayloadPrimitives>,
+    Provider: NodePrimitivesProvider<Primitives: PayloadPrimitives>,
 {
     fn new(
         provider: Provider,
@@ -149,7 +149,7 @@ where
     ErrorObject<'static>: From<Eth::Error>,
     P: OpProofsStore + Clone + 'static,
     Provider: BlockReaderIdExt
-        + NodePrimitivesProvider<Primitives: OpPayloadPrimitives>
+        + NodePrimitivesProvider<Primitives: PayloadPrimitives>
         + HeaderProvider<Header = <Provider::Primitives as NodePrimitives>::BlockHeader>,
 {
     fn parent_header(
@@ -170,8 +170,8 @@ where
     Eth: FullEthApi + Send + Sync + 'static,
     ErrorObject<'static>: From<Eth::Error>,
     P: OpProofsStore + Clone + 'static,
-    Attrs: OpAttributes<Transaction = TxTy<EvmConfig::Primitives>>,
-    N: OpPayloadPrimitives,
+    Attrs: Attributes<Transaction = TxTy<EvmConfig::Primitives>>,
+    N: PayloadPrimitives,
     EvmConfig: ConfigureEvm<
             Primitives = N,
             NextBlockEnvCtx: BuildNextEnv<Attrs, N::BlockHeader, Provider::ChainSpec>,
@@ -184,8 +184,8 @@ where
         + Clone
         + 'static,
     base_alloy_consensus::OpPooledTransaction:
-        TryFrom<<N as OpPayloadPrimitives>::_TX, Error: core::error::Error>,
-    <N as OpPayloadPrimitives>::_TX: From<base_alloy_consensus::OpPooledTransaction>,
+        TryFrom<<N as PayloadPrimitives>::_TX, Error: core::error::Error>,
+    <N as PayloadPrimitives>::_TX: From<base_alloy_consensus::OpPooledTransaction>,
 {
     async fn execute_payload(
         &self,
@@ -222,10 +222,10 @@ where
                         .await
                         .map_err(PayloadBuilderError::other)?;
 
-                    let builder = OpBuilder::new(|_| {
+                    let builder = Builder::new(|_| {
                         NoopPayloadTransactions::<
                             BasePooledTransaction<
-                                <N as OpPayloadPrimitives>::_TX,
+                                <N as PayloadPrimitives>::_TX,
                                 base_alloy_consensus::OpPooledTransaction,
                             >,
                         >::default()

--- a/crates/execution/rpc/src/miner.rs
+++ b/crates/execution/rpc/src/miner.rs
@@ -2,7 +2,7 @@
 
 use alloy_primitives::U64;
 pub use base_alloy_rpc_jsonrpsee::MinerApiExtServer;
-use base_execution_payload_builder::config::{OpDAConfig, OpGasLimitConfig};
+use base_execution_payload_builder::config::{OpDAConfig, GasLimitConfig};
 use jsonrpsee_core::{RpcResult, async_trait};
 use tracing::debug;
 
@@ -22,13 +22,13 @@ base_metrics::define_metrics! {
 #[derive(Debug, Clone)]
 pub struct OpMinerExtApi {
     da_config: OpDAConfig,
-    gas_limit_config: OpGasLimitConfig,
+    gas_limit_config: GasLimitConfig,
 }
 
 impl OpMinerExtApi {
     /// Instantiate the miner API extension with the given, sharable data availability
     /// configuration.
-    pub const fn new(da_config: OpDAConfig, gas_limit_config: OpGasLimitConfig) -> Self {
+    pub const fn new(da_config: OpDAConfig, gas_limit_config: GasLimitConfig) -> Self {
         Self { da_config, gas_limit_config }
     }
 }

--- a/crates/execution/rpc/src/miner.rs
+++ b/crates/execution/rpc/src/miner.rs
@@ -2,7 +2,7 @@
 
 use alloy_primitives::U64;
 pub use base_alloy_rpc_jsonrpsee::MinerApiExtServer;
-use base_execution_payload_builder::config::{OpDAConfig, GasLimitConfig};
+use base_execution_payload_builder::config::{GasLimitConfig, OpDAConfig};
 use jsonrpsee_core::{RpcResult, async_trait};
 use tracing::debug;
 

--- a/crates/execution/rpc/src/witness.rs
+++ b/crates/execution/rpc/src/witness.rs
@@ -5,7 +5,7 @@ use std::{fmt::Debug, sync::Arc};
 use alloy_primitives::B256;
 use alloy_rpc_types_debug::ExecutionWitness;
 use base_alloy_chains::BaseUpgrades;
-use base_execution_payload_builder::{OpAttributes, OpPayloadBuilder, OpPayloadPrimitives};
+use base_execution_payload_builder::{Attributes, OpPayloadBuilder, PayloadPrimitives};
 use base_txpool::OpPooledTx;
 use jsonrpsee_core::{RpcResult, async_trait};
 use reth_chainspec::ChainSpecProvider;
@@ -66,7 +66,7 @@ where
             Transaction: OpPooledTx<Consensus = <Provider::Primitives as NodePrimitives>::SignedTx>,
         > + 'static,
     Provider: BlockReaderIdExt<Header = <Provider::Primitives as NodePrimitives>::BlockHeader>
-        + NodePrimitivesProvider<Primitives: OpPayloadPrimitives>
+        + NodePrimitivesProvider<Primitives: PayloadPrimitives>
         + StateProviderFactory
         + ChainSpecProvider<ChainSpec: BaseUpgrades>
         + Clone
@@ -75,7 +75,7 @@ where
             Primitives = Provider::Primitives,
             NextBlockEnvCtx: BuildNextEnv<Attrs, Provider::Header, Provider::ChainSpec>,
         > + 'static,
-    Attrs: OpAttributes<Transaction = TxTy<EvmConfig::Primitives>>,
+    Attrs: Attributes<Transaction = TxTy<EvmConfig::Primitives>>,
 {
     async fn execute_payload(
         &self,

--- a/crates/execution/runner/src/add_ons.rs
+++ b/crates/execution/runner/src/add_ons.rs
@@ -2,7 +2,7 @@ use std::marker::PhantomData;
 
 use base_execution_payload_builder::{
     Attributes, PayloadPrimitives,
-    config::{OpDAConfig, GasLimitConfig},
+    config::{GasLimitConfig, OpDAConfig},
 };
 use base_execution_rpc::{
     config::{BaseEthConfigApiServer, BaseEthConfigHandler},

--- a/crates/execution/runner/src/add_ons.rs
+++ b/crates/execution/runner/src/add_ons.rs
@@ -1,8 +1,8 @@
 use std::marker::PhantomData;
 
 use base_execution_payload_builder::{
-    OpAttributes, OpPayloadPrimitives,
-    config::{OpDAConfig, OpGasLimitConfig},
+    Attributes, PayloadPrimitives,
+    config::{OpDAConfig, GasLimitConfig},
 };
 use base_execution_rpc::{
     config::{BaseEthConfigApiServer, BaseEthConfigHandler},
@@ -48,7 +48,7 @@ pub struct BaseAddOns<
     /// Data availability configuration for the OP builder.
     pub da_config: OpDAConfig,
     /// Gas limit configuration for the OP builder.
-    pub gas_limit_config: OpGasLimitConfig,
+    pub gas_limit_config: GasLimitConfig,
 }
 
 impl<N, EthB, PVB, EB, EVB, RpcMiddleware> BaseAddOns<N, EthB, PVB, EB, EVB, RpcMiddleware>
@@ -61,7 +61,7 @@ where
     pub const fn new(
         rpc_add_ons: RpcAddOns<N, EthB, PVB, EB, EVB, RpcMiddleware>,
         da_config: OpDAConfig,
-        gas_limit_config: OpGasLimitConfig,
+        gas_limit_config: GasLimitConfig,
     ) -> Self {
         Self { rpc_add_ons, da_config, gas_limit_config }
     }
@@ -195,8 +195,8 @@ where
     EB: EngineApiBuilder<N>,
     EVB: EngineValidatorBuilder<N>,
     RpcMiddleware: RethRpcMiddleware,
-    Attrs: OpAttributes<Transaction = TxTy<N::Types>, RpcPayloadAttributes: DeserializeOwned>,
-    <N::Types as NodeTypes>::Primitives: OpPayloadPrimitives<_Header: HeaderMut>,
+    Attrs: Attributes<Transaction = TxTy<N::Types>, RpcPayloadAttributes: DeserializeOwned>,
+    <N::Types as NodeTypes>::Primitives: PayloadPrimitives<_Header: HeaderMut>,
 {
     type Handle = RpcHandle<N, EthB::EthApi>;
 
@@ -274,8 +274,8 @@ where
     EB: EngineApiBuilder<N>,
     EVB: EngineValidatorBuilder<N>,
     RpcMiddleware: RethRpcMiddleware,
-    Attrs: OpAttributes<Transaction = TxTy<N::Types>, RpcPayloadAttributes: DeserializeOwned>,
-    <N::Types as NodeTypes>::Primitives: OpPayloadPrimitives<_Header: HeaderMut>,
+    Attrs: Attributes<Transaction = TxTy<N::Types>, RpcPayloadAttributes: DeserializeOwned>,
+    <N::Types as NodeTypes>::Primitives: PayloadPrimitives<_Header: HeaderMut>,
 {
     type EthApi = EthB::EthApi;
 
@@ -313,7 +313,7 @@ pub struct BaseAddOnsBuilder<NetworkT, RpcMiddleware = Identity> {
     /// Data availability configuration for the OP builder.
     da_config: Option<OpDAConfig>,
     /// Gas limit configuration for the OP builder.
-    gas_limit_config: Option<OpGasLimitConfig>,
+    gas_limit_config: Option<GasLimitConfig>,
     /// Marker for network types.
     _nt: PhantomData<NetworkT>,
     /// Minimum suggested priority fee (tip)
@@ -359,7 +359,7 @@ impl<NetworkT, RpcMiddleware> BaseAddOnsBuilder<NetworkT, RpcMiddleware> {
     }
 
     /// Configure the gas limit configuration for the OP payload builder.
-    pub fn with_gas_limit_config(mut self, gas_limit_config: OpGasLimitConfig) -> Self {
+    pub fn with_gas_limit_config(mut self, gas_limit_config: GasLimitConfig) -> Self {
         self.gas_limit_config = Some(gas_limit_config);
         self
     }

--- a/crates/execution/runner/src/node.rs
+++ b/crates/execution/runner/src/node.rs
@@ -3,7 +3,7 @@
 use base_alloy_consensus::OpPrimitives;
 use base_engine_tree::BaseEngineValidatorBuilder;
 use base_execution_chainspec::OpChainSpec;
-use base_execution_payload_builder::config::{OpDAConfig, OpGasLimitConfig};
+use base_execution_payload_builder::config::{OpDAConfig, GasLimitConfig};
 use base_execution_rpc::eth::OpEthApiBuilder;
 use base_execution_storage::OpStorage;
 use base_node_core::{
@@ -38,7 +38,7 @@ pub struct BaseNode {
     /// Gas limit configuration for the OP builder.
     /// Used to control the gas limit of the blocks produced by the OP builder. (configured by the
     /// batcher via the `miner_` api)
-    pub gas_limit_config: OpGasLimitConfig,
+    pub gas_limit_config: GasLimitConfig,
 }
 
 impl BaseNode {
@@ -47,7 +47,7 @@ impl BaseNode {
         Self {
             args,
             da_config: OpDAConfig::default(),
-            gas_limit_config: OpGasLimitConfig::default(),
+            gas_limit_config: GasLimitConfig::default(),
         }
     }
 
@@ -58,7 +58,7 @@ impl BaseNode {
     }
 
     /// Configure the gas limit configuration for the OP builder.
-    pub fn with_gas_limit_config(mut self, gas_limit_config: OpGasLimitConfig) -> Self {
+    pub fn with_gas_limit_config(mut self, gas_limit_config: GasLimitConfig) -> Self {
         self.gas_limit_config = gas_limit_config;
         self
     }

--- a/crates/execution/runner/src/node.rs
+++ b/crates/execution/runner/src/node.rs
@@ -3,7 +3,7 @@
 use base_alloy_consensus::OpPrimitives;
 use base_engine_tree::BaseEngineValidatorBuilder;
 use base_execution_chainspec::OpChainSpec;
-use base_execution_payload_builder::config::{OpDAConfig, GasLimitConfig};
+use base_execution_payload_builder::config::{GasLimitConfig, OpDAConfig};
 use base_execution_rpc::eth::OpEthApiBuilder;
 use base_execution_storage::OpStorage;
 use base_node_core::{
@@ -44,11 +44,7 @@ pub struct BaseNode {
 impl BaseNode {
     /// Creates a new instance of the Base node type.
     pub fn new(args: RollupArgs) -> Self {
-        Self {
-            args,
-            da_config: OpDAConfig::default(),
-            gas_limit_config: GasLimitConfig::default(),
-        }
+        Self { args, da_config: OpDAConfig::default(), gas_limit_config: GasLimitConfig::default() }
     }
 
     /// Configure the data availability configuration for the OP builder.

--- a/crates/proof/fpvm-precompiles/src/factory.rs
+++ b/crates/proof/fpvm-precompiles/src/factory.rs
@@ -4,7 +4,7 @@ use alloy_evm::{Database, EvmEnv, EvmFactory};
 use base_alloy_evm::OpEvm;
 use base_proof_preimage::{HintWriterClient, PreimageOracleClient};
 use base_revm::{
-    DefaultOp, Builder, OpContext, OpHaltReason, OpSpecId, OpTransaction, OpTransactionError,
+    Builder, DefaultOp, OpContext, OpHaltReason, OpSpecId, OpTransaction, OpTransactionError,
 };
 use revm::{
     Context, Inspector,

--- a/crates/proof/fpvm-precompiles/src/factory.rs
+++ b/crates/proof/fpvm-precompiles/src/factory.rs
@@ -4,7 +4,7 @@ use alloy_evm::{Database, EvmEnv, EvmFactory};
 use base_alloy_evm::OpEvm;
 use base_proof_preimage::{HintWriterClient, PreimageOracleClient};
 use base_revm::{
-    DefaultOp, OpBuilder, OpContext, OpHaltReason, OpSpecId, OpTransaction, OpTransactionError,
+    DefaultOp, Builder, OpContext, OpHaltReason, OpSpecId, OpTransaction, OpTransactionError,
 };
 use revm::{
     Context, Inspector,


### PR DESCRIPTION
## Summary

Continues the Op→Base/no-prefix renaming effort started in #1978. This tier covers OpConsensusError→BaseConsensusError (to avoid conflict with reth's ConsensusError), OpBuilder trait and struct→Builder, OpPayloadPrimitives→PayloadPrimitives, OpAttributes→Attributes, OpGasLimitConfig→GasLimitConfig, and OpBuilderConfig→BaseBuilderConfig. All changes are mechanical renames with no behavioral modifications.