### PR TITLE
feat(chains): activate base v1 on sepolia

### DIFF
--- a/crates/common/chains/src/chain.rs
+++ b/crates/common/chains/src/chain.rs
@@ -229,7 +229,10 @@ mod tests {
             base_sepolia_forks.upgrade_activation(Jovian),
             ForkCondition::Timestamp(BaseChainConfig::sepolia().jovian_timestamp)
         );
-        assert_eq!(base_sepolia_forks[V1], ForkCondition::Never);
+        assert_eq!(
+            base_sepolia_forks[V1],
+            ForkCondition::Timestamp(BaseChainConfig::sepolia().base_v1_timestamp.unwrap())
+        );
     }
 
     #[test]

--- a/crates/common/chains/src/chain.rs
+++ b/crates/common/chains/src/chain.rs
@@ -268,14 +268,17 @@ mod tests {
 
     #[test]
     fn is_base_v1_active_at_timestamp() {
-        // V1 is not scheduled on mainnet or sepolia yet (ForkCondition::Never)
+        // V1 is not scheduled on mainnet yet (ForkCondition::Never)
         let base_mainnet_forks = BaseChainUpgrades::mainnet();
         assert!(!base_mainnet_forks.is_base_v1_active_at_timestamp(0));
         assert!(!base_mainnet_forks.is_base_v1_active_at_timestamp(u64::MAX));
 
+        // V1 is scheduled on sepolia at 1776708000
         let base_sepolia_forks = BaseChainUpgrades::sepolia();
         assert!(!base_sepolia_forks.is_base_v1_active_at_timestamp(0));
-        assert!(!base_sepolia_forks.is_base_v1_active_at_timestamp(u64::MAX));
+        assert!(!base_sepolia_forks.is_base_v1_active_at_timestamp(1_776_707_999));
+        assert!(base_sepolia_forks.is_base_v1_active_at_timestamp(1_776_708_000));
+        assert!(base_sepolia_forks.is_base_v1_active_at_timestamp(u64::MAX));
 
         // V1 is active at genesis on devnet (ForkCondition::ZERO_TIMESTAMP)
         let devnet_forks = BaseChainUpgrades::devnet();
@@ -302,6 +305,12 @@ mod tests {
         assert_eq!(
             base_mainnet_forks.ethereum_fork_activation(EthereumHardfork::Osaka),
             ForkCondition::Never
+        );
+
+        let base_sepolia_forks = BaseChainUpgrades::sepolia();
+        assert_eq!(
+            base_sepolia_forks.ethereum_fork_activation(EthereumHardfork::Osaka),
+            ForkCondition::Timestamp(1_776_708_000)
         );
 
         let devnet_forks = BaseChainUpgrades::devnet();

--- a/crates/common/chains/src/config.rs
+++ b/crates/common/chains/src/config.rs
@@ -226,7 +226,7 @@ const SEPOLIA: BaseChainConfig = BaseChainConfig {
     pectra_blob_schedule_timestamp: Some(1_742_486_400),
     isthmus_timestamp: 1_744_905_600,
     jovian_timestamp: 1_763_568_001,
-    base_v1_timestamp: None,
+    base_v1_timestamp: Some(1_776_708_000),
 
     genesis_l1_hash: b256!("cac9a83291d4dec146d6f7f69ab2304f23f5be87b1789119a0c5b1e4482444ed"),
     genesis_l1_number: 4_370_868,

--- a/docs/specs/pages/upgrades/v1/overview.md
+++ b/docs/specs/pages/upgrades/v1/overview.md
@@ -16,7 +16,7 @@ Only `base-consensus` and `base-reth-node` will  support the Base V1 hardfork. I
 | Network | Activation timestamp |
 | --- | --- |
 | `mainnet` | TBD |
-| `sepolia` | TBD |
+| `sepolia` | `1776708000` (2026-04-20 18:00:00 UTC) |
 
 ## Execution Layer
 


### PR DESCRIPTION
Sets `base_v1_timestamp` for Base Sepolia to `1776708000`.