### PR TITLE
fix(metering): add missing merge_transitions call before state root calculation

### DIFF
--- a/crates/client/metering/src/block.rs
+++ b/crates/client/metering/src/block.rs
@@ -12,6 +12,7 @@ use reth_evm::{ConfigureEvm, execute::BlockBuilder};
 use reth_primitives_traits::Block as BlockT;
 use reth_provider::{HeaderProvider, StateProviderFactory};
 use reth_revm::{database::StateProviderDatabase, db::State};
+use revm_database::states::bundle_state::BundleRetention;
 
 use crate::types::{MeterBlockResponse, MeterBlockTransactions};
 
@@ -111,6 +112,10 @@ where
         }
     }
     let execution_time = evm_start.elapsed().as_micros();
+
+    // Merge transitions to ensure proper state root calculation
+    // This consolidates all state transitions from transaction execution
+    db.merge_transitions(BundleRetention::Reverts);
 
     // Calculate state root and measure time
     let state_root_start = Instant::now();


### PR DESCRIPTION
## Summary

The `meter_block` function was missing a call to `merge_transitions` before calculating the state root. Without this, the state transitions from transaction execution are not properly consolidated, which can lead to incorrect state root calculations.

## Changes

- Add import for `BundleRetention` from `revm_database`
- Call `db.merge_transitions(BundleRetention::Reverts)` after transaction execution and before state root calculation

## Why This Matters

The `merge_transitions` call is essential for proper state root calculation. It consolidates all state changes from executed transactions into the bundle state. Without it, the subsequent state root calculation may operate on incomplete or incorrect state data.

This is a bug fix that ensures accurate metering results by properly preparing the state before root calculation.

## Testing

The change follows the same pattern used elsewhere in the codebase where `merge_transitions` is called before state root calculation. The `BundleRetention::Reverts` parameter ensures that reverts are properly handled in the state transitions.