### PR TITLE
fix(challenger): add logging to bond discovery early returns

### DIFF
--- a/crates/proof/challenge/src/bond.rs
+++ b/crates/proof/challenge/src/bond.rs
@@ -429,12 +429,14 @@ impl BondManager {
         verifier_client: &dyn AggregateVerifierClient,
     ) -> eyre::Result<()> {
         if !self.is_enabled() {
+            warn!("bond manager is disabled, skipping discovery scan");
             return Ok(());
         }
 
         let factory_client = Arc::clone(&self.factory_client);
         let game_count = factory_client.game_count().await?;
         if game_count == 0 {
+            debug!("no games found, skipping bond discovery scan");
             return Ok(());
         }
 


### PR DESCRIPTION
## Summary
- Adds a `warn!` log when the bond manager is disabled, so operators know why the discovery scan is skipped.
- Adds a `debug!` log when the game count is 0, clarifying that no games were found to evaluate.

Closes CHAIN-3897