### PR TITLE
builder/metering: add rejection cache overlay to not re-include in best_txs 

### DIFF
--- a/bin/builder/src/cli.rs
+++ b/bin/builder/src/cli.rs
@@ -2,7 +2,9 @@
 
 use core::{net::SocketAddr, time::Duration};
 
-use base_builder_core::{BuilderConfig, ExecutionMeteringMode, SharedMeteringProvider};
+use base_builder_core::{
+    BuilderConfig, ExecutionMeteringMode, RejectionCache, SharedMeteringProvider,
+};
 use base_builder_metering::MeteringStore;
 use base_node_core::args::RollupArgs;
 
@@ -106,6 +108,14 @@ pub struct Args {
     #[arg(long = "builder.tx-data-store-buffer-size", default_value = "10000")]
     pub tx_data_store_buffer_size: usize,
 
+    /// Maximum number of entries in the rejection cache for permanently rejected transactions
+    #[arg(long = "builder.rejection-cache-max-capacity", default_value = "100000")]
+    pub rejection_cache_max_capacity: u64,
+
+    /// TTL in seconds for entries in the rejection cache
+    #[arg(long = "builder.rejection-cache-ttl-secs", default_value = "1800")]
+    pub rejection_cache_ttl_secs: u64,
+
     /// Inverted sampling frequency in blocks. 1 - each block, 100 - every 100th block.
     #[arg(long = "telemetry.sampling-ratio", env = "SAMPLING_RATIO", default_value = "100")]
     pub sampling_ratio: u64,
@@ -142,6 +152,8 @@ impl Default for Args {
             max_uncompressed_block_size: None,
             metering_wait_duration_ms: None,
             tx_data_store_buffer_size: 10000,
+            rejection_cache_max_capacity: 100_000,
+            rejection_cache_ttl_secs: 1800,
             sampling_ratio: 100,
             flashblocks: FlashblocksArgs::default(),
         }
@@ -182,6 +194,10 @@ impl Args {
             max_uncompressed_block_size: self.max_uncompressed_block_size,
             metering_wait_duration: self.metering_wait_duration_ms.map(Duration::from_millis),
             metering_provider,
+            rejection_cache: RejectionCache::new(
+                self.rejection_cache_max_capacity,
+                Duration::from_secs(self.rejection_cache_ttl_secs),
+            ),
         })
     }
 }

--- a/crates/builder/core/src/config.rs
+++ b/crates/builder/core/src/config.rs
@@ -8,7 +8,7 @@ use std::sync::Arc;
 
 use base_execution_payload_builder::config::{OpDAConfig, OpGasLimitConfig};
 
-use crate::{ExecutionMeteringMode, NoopMeteringProvider, SharedMeteringProvider};
+use crate::{ExecutionMeteringMode, NoopMeteringProvider, RejectionCache, SharedMeteringProvider};
 
 /// Configuration values for the flashblocks builder.
 #[derive(Clone)]
@@ -79,6 +79,10 @@ pub struct BuilderConfig {
 
     /// Resource metering provider
     pub metering_provider: SharedMeteringProvider,
+
+    /// Cache of permanently rejected transaction hashes, shared across blocks.
+    /// Transactions in this cache are skipped by the iterator without re-evaluation.
+    pub rejection_cache: RejectionCache,
 }
 
 impl BuilderConfig {
@@ -112,6 +116,7 @@ impl core::fmt::Debug for BuilderConfig {
             .field("max_uncompressed_block_size", &self.max_uncompressed_block_size)
             .field("metering_wait_duration", &self.metering_wait_duration)
             .field("metering_provider", &self.metering_provider)
+            .field("rejection_cache_size", &self.rejection_cache.entry_count())
             .finish()
     }
 }
@@ -137,6 +142,7 @@ impl Default for BuilderConfig {
             max_uncompressed_block_size: None,
             metering_wait_duration: None,
             metering_provider: Arc::new(NoopMeteringProvider),
+            rejection_cache: RejectionCache::new(100_000, Duration::from_secs(1800)),
         }
     }
 }

--- a/crates/builder/core/src/execution.rs
+++ b/crates/builder/core/src/execution.rs
@@ -176,6 +176,24 @@ pub enum TxnExecutionError {
     MeteringDataPending,
 }
 
+impl TxnExecutionError {
+    /// Returns `true` if this rejection is permanent — the transaction will never be includable
+    /// regardless of block/flashblock cumulative state. Permanent rejections are intrinsic to
+    /// the transaction itself (e.g. its size or predicted execution time exceeds the per-tx limit).
+    ///
+    /// Transient rejections depend on cumulative block state (gas used, DA used, etc.) and may
+    /// succeed in a future block or flashblock with different cumulative values.
+    pub const fn is_permanent(&self) -> bool {
+        matches!(
+            self,
+            Self::TransactionDASizeExceeded(_, _)
+                | Self::ExecutionMeteringLimitExceeded(
+                    ExecutionMeteringLimitExceeded::TransactionExecutionTime(_, _),
+                )
+        )
+    }
+}
+
 impl From<ExecutionMeteringLimitExceeded> for TxnExecutionError {
     fn from(err: ExecutionMeteringLimitExceeded) -> Self {
         Self::ExecutionMeteringLimitExceeded(err)

--- a/crates/builder/core/src/flashblocks/best_txs.rs
+++ b/crates/builder/core/src/flashblocks/best_txs.rs
@@ -1,10 +1,40 @@
 //! An adapter over `BestPayloadTransactions`
 
-use std::{collections::HashSet, sync::Arc};
+use std::{collections::HashSet, sync::Arc, time::Duration};
 
 use alloy_primitives::{Address, TxHash};
+use moka::sync::Cache;
 use reth_payload_util::PayloadTransactions;
 use reth_transaction_pool::{PoolTransaction, ValidPoolTransaction};
+
+/// Shared, cross-block cache of permanently rejected transaction hashes.
+///
+/// Backed by [`moka::sync::Cache`] with a TTL so entries expire if metering
+/// predictions or operator limits change.
+#[derive(Clone, Debug)]
+pub struct RejectionCache(Cache<TxHash, ()>);
+
+impl RejectionCache {
+    /// Creates a new [`RejectionCache`] with the given capacity and TTL.
+    pub fn new(max_capacity: u64, ttl: Duration) -> Self {
+        Self(Cache::builder().max_capacity(max_capacity).time_to_live(ttl).build())
+    }
+
+    /// Checks if a transaction hash is in the cache.
+    pub fn contains_key(&self, hash: &TxHash) -> bool {
+        self.0.contains_key(hash)
+    }
+
+    /// Adds a transaction hash to the cache.
+    pub fn insert(&self, hash: TxHash) {
+        self.0.insert(hash, ());
+    }
+
+    /// Returns the number of cached entries.
+    pub fn entry_count(&self) -> u64 {
+        self.0.entry_count()
+    }
+}
 
 /// An adapter over `BestPayloadTransactions` that allows to skip transactions that were already
 /// committed to the state. It also allows to refresh inner iterator on each flashblock building, to
@@ -18,6 +48,8 @@ where
     // Transactions that were already committed to the state. Using them again would cause NonceTooLow
     // so we skip them
     committed_transactions: HashSet<TxHash>,
+    // Shared cross-block rejection cache (survives across blocks, TTL-bounded)
+    rejection_cache: RejectionCache,
 }
 
 impl<T, I> std::fmt::Debug for BestFlashblocksTxs<T, I>
@@ -28,6 +60,7 @@ where
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("BestFlashblocksTxs")
             .field("committed_transactions", &self.committed_transactions)
+            .field("rejection_cache_size", &self.rejection_cache.entry_count())
             .finish_non_exhaustive()
     }
 }
@@ -38,8 +71,11 @@ where
     I: Iterator<Item = Arc<ValidPoolTransaction<T>>>,
 {
     /// Creates a new [`BestFlashblocksTxs`] wrapping the given payload transaction iterator.
-    pub fn new(inner: reth_payload_util::BestPayloadTransactions<T, I>) -> Self {
-        Self { inner, committed_transactions: Default::default() }
+    pub fn new(
+        inner: reth_payload_util::BestPayloadTransactions<T, I>,
+        rejection_cache: RejectionCache,
+    ) -> Self {
+        Self { inner, committed_transactions: Default::default(), rejection_cache }
     }
 
     /// Replaces current iterator with new one. We use it on new flashblock building, to refresh
@@ -51,6 +87,15 @@ where
     /// Remove transaction from next iteration since it is already in the state
     pub fn mark_committed(&mut self, txs: &[TxHash]) {
         self.committed_transactions.extend(txs);
+    }
+
+    /// Mark transactions as permanently rejected. They will be skipped in all
+    /// subsequent flashblocks within this block and across future blocks via
+    /// the shared rejection cache.
+    pub fn mark_rejected(&mut self, tx_hashes: &[TxHash]) {
+        for hash in tx_hashes {
+            self.rejection_cache.insert(*hash);
+        }
     }
 }
 
@@ -64,8 +109,13 @@ where
     fn next(&mut self, ctx: ()) -> Option<Self::Transaction> {
         loop {
             let tx = self.inner.next(ctx)?;
-            // Skip transaction we already included
-            if self.committed_transactions.contains(tx.hash()) {
+            let hash = *tx.hash();
+
+            if self.committed_transactions.contains(&hash) {
+                continue;
+            }
+
+            if self.rejection_cache.contains_key(&hash) {
                 continue;
             }
 
@@ -81,7 +131,7 @@ where
 
 #[cfg(test)]
 mod tests {
-    use std::sync::Arc;
+    use std::{sync::Arc, time::Duration};
 
     use alloy_consensus::Transaction;
     use alloy_eips::eip1559::MIN_PROTOCOL_BASE_FEE;
@@ -92,7 +142,11 @@ mod tests {
         test_utils::{MockTransaction, MockTransactionFactory},
     };
 
-    use crate::flashblocks::best_txs::BestFlashblocksTxs;
+    use crate::flashblocks::best_txs::{BestFlashblocksTxs, RejectionCache};
+
+    fn test_rejection_cache() -> RejectionCache {
+        RejectionCache::new(1000, Duration::from_secs(60))
+    }
 
     #[test]
     fn test_simple_case() {
@@ -108,7 +162,10 @@ mod tests {
         pool.add_transaction(Arc::new(tx_3), 0);
 
         // Create iterator
-        let mut iterator = BestFlashblocksTxs::new(BestPayloadTransactions::new(pool.best()));
+        let mut iterator = BestFlashblocksTxs::new(
+            BestPayloadTransactions::new(pool.best()),
+            test_rejection_cache(),
+        );
         // ### First flashblock
         iterator.refresh_iterator(BestPayloadTransactions::new(pool.best()));
         // Accept first tx
@@ -190,7 +247,10 @@ mod tests {
         pool.add_transaction(Arc::new(f.validated(tx_a.clone())), 0);
 
         // === FLASHBLOCK 1 ===
-        let mut iterator = BestFlashblocksTxs::new(BestPayloadTransactions::new(pool.best()));
+        let mut iterator = BestFlashblocksTxs::new(
+            BestPayloadTransactions::new(pool.best()),
+            test_rejection_cache(),
+        );
 
         // Simulate: Flashblock 1 starts building
         // Start consuming txns from the txpool
@@ -303,5 +363,76 @@ mod tests {
             count += 1;
         }
         assert_eq!(count, 3);
+    }
+
+    /// Rejected transactions are skipped across flashblock boundaries within the same block.
+    #[test]
+    fn test_rejected_txs_persist_across_refresh() {
+        let mut pool = PendingPool::new(CoinbaseTipOrdering::<MockTransaction>::default());
+        let mut f = MockTransactionFactory::default();
+
+        let tx_1 = f.create_eip1559();
+        let tx_2 = f.create_eip1559();
+        let tx_3 = f.create_eip1559();
+        let tx_2_hash = *tx_2.hash();
+        pool.add_transaction(Arc::new(tx_1), 0);
+        pool.add_transaction(Arc::new(tx_2), 0);
+        pool.add_transaction(Arc::new(tx_3), 0);
+
+        let mut iterator = BestFlashblocksTxs::new(
+            BestPayloadTransactions::new(pool.best()),
+            test_rejection_cache(),
+        );
+
+        // FB1: consume first tx, reject second permanently
+        let _tx1 = iterator.next(()).unwrap();
+        let _tx2 = iterator.next(()).unwrap();
+        iterator.mark_rejected(&[tx_2_hash]);
+        let _tx3 = iterator.next(()).unwrap();
+        assert!(iterator.next(()).is_none());
+
+        // FB2: refresh iterator — tx2 should still be skipped
+        iterator.refresh_iterator(BestPayloadTransactions::new(pool.best()));
+        let mut seen_hashes = Vec::new();
+        while let Some(tx) = iterator.next(()) {
+            seen_hashes.push(*tx.hash());
+        }
+        assert!(!seen_hashes.contains(&tx_2_hash), "rejected tx should not reappear after refresh");
+        assert_eq!(seen_hashes.len(), 2, "only non-rejected txs should appear");
+    }
+
+    /// Rejected transactions in the shared cache are skipped by a new iterator instance
+    /// (simulating cross-block persistence).
+    #[test]
+    fn test_rejection_cache_persists_across_blocks() {
+        let mut pool = PendingPool::new(CoinbaseTipOrdering::<MockTransaction>::default());
+        let mut f = MockTransactionFactory::default();
+
+        let tx_1 = f.create_eip1559();
+        let tx_2 = f.create_eip1559();
+        let tx_2_hash = *tx_2.hash();
+        pool.add_transaction(Arc::new(tx_1), 0);
+        pool.add_transaction(Arc::new(tx_2), 0);
+
+        let cache = test_rejection_cache();
+
+        // Block 1: reject tx_2
+        let mut iter1 =
+            BestFlashblocksTxs::new(BestPayloadTransactions::new(pool.best()), cache.clone());
+        let _tx1 = iter1.next(()).unwrap();
+        let _tx2 = iter1.next(()).unwrap();
+        iter1.mark_rejected(&[tx_2_hash]);
+
+        // Block 2: new iterator, same cache — tx_2 should be skipped
+        let mut iter2 = BestFlashblocksTxs::new(BestPayloadTransactions::new(pool.best()), cache);
+        let mut seen_hashes = Vec::new();
+        while let Some(tx) = iter2.next(()) {
+            seen_hashes.push(*tx.hash());
+        }
+        assert!(
+            !seen_hashes.contains(&tx_2_hash),
+            "tx rejected in block 1 should be skipped in block 2"
+        );
+        assert_eq!(seen_hashes.len(), 1, "only non-rejected tx should appear");
     }
 }

--- a/crates/builder/core/src/flashblocks/best_txs.rs
+++ b/crates/builder/core/src/flashblocks/best_txs.rs
@@ -7,6 +7,8 @@ use moka::sync::Cache;
 use reth_payload_util::PayloadTransactions;
 use reth_transaction_pool::{PoolTransaction, ValidPoolTransaction};
 
+use crate::BuilderMetrics;
+
 /// Shared, cross-block cache of permanently rejected transaction hashes.
 ///
 /// Backed by [`moka::sync::Cache`] with a TTL so entries expire if metering
@@ -33,6 +35,12 @@ impl RejectionCache {
     /// Returns the number of cached entries.
     pub fn entry_count(&self) -> u64 {
         self.0.entry_count()
+    }
+
+    /// Flushes pending cache maintenance tasks (evictions, TTL expiry).
+    #[cfg(any(test, feature = "test-utils"))]
+    pub fn run_pending_tasks(&self) {
+        self.0.run_pending_tasks();
     }
 }
 
@@ -96,6 +104,7 @@ where
         for hash in tx_hashes {
             self.rejection_cache.insert(*hash);
         }
+        BuilderMetrics::rejection_cache_size().set(self.rejection_cache.entry_count() as f64);
     }
 }
 
@@ -116,6 +125,7 @@ where
             }
 
             if self.rejection_cache.contains_key(&hash) {
+                BuilderMetrics::rejection_cache_hits().increment(1);
                 continue;
             }
 
@@ -434,5 +444,41 @@ mod tests {
             "tx rejected in block 1 should be skipped in block 2"
         );
         assert_eq!(seen_hashes.len(), 1, "only non-rejected tx should appear");
+    }
+
+    /// A rejected transaction becomes eligible again after the cache TTL expires.
+    #[test]
+    fn test_rejected_tx_eligible_after_ttl_expiry() {
+        let mut pool = PendingPool::new(CoinbaseTipOrdering::<MockTransaction>::default());
+        let mut f = MockTransactionFactory::default();
+
+        let tx_1 = f.create_eip1559();
+        let tx_2 = f.create_eip1559();
+        let tx_2_hash = *tx_2.hash();
+        pool.add_transaction(Arc::new(tx_1), 0);
+        pool.add_transaction(Arc::new(tx_2), 0);
+
+        // TTL is short, 1ms
+        let cache = RejectionCache::new(1000, Duration::from_millis(1));
+
+        // Reject tx_2
+        let mut iter1 =
+            BestFlashblocksTxs::new(BestPayloadTransactions::new(pool.best()), cache.clone());
+        let _tx1 = iter1.next(()).unwrap();
+        let _tx2 = iter1.next(()).unwrap();
+        iter1.mark_rejected(&[tx_2_hash]);
+
+        // Wait for TTL to expire and flush pending evictions
+        std::thread::sleep(Duration::from_millis(50));
+        cache.run_pending_tasks();
+
+        // New iterator — tx_2 should be back
+        let mut iter2 = BestFlashblocksTxs::new(BestPayloadTransactions::new(pool.best()), cache);
+        let mut seen_hashes = Vec::new();
+        while let Some(tx) = iter2.next(()) {
+            seen_hashes.push(*tx.hash());
+        }
+        assert!(seen_hashes.contains(&tx_2_hash), "tx should be eligible again after TTL expiry");
+        assert_eq!(seen_hashes.len(), 2, "both txs should appear");
     }
 }

--- a/crates/builder/core/src/flashblocks/best_txs.rs
+++ b/crates/builder/core/src/flashblocks/best_txs.rs
@@ -104,6 +104,7 @@ where
         for hash in tx_hashes {
             self.rejection_cache.insert(*hash);
         }
+        BuilderMetrics::rejection_cache_insertions().increment(tx_hashes.len() as u64);
         BuilderMetrics::rejection_cache_size().set(self.rejection_cache.entry_count() as f64);
     }
 }

--- a/crates/builder/core/src/flashblocks/context.rs
+++ b/crates/builder/core/src/flashblocks/context.rs
@@ -7,7 +7,7 @@ use std::{
 use alloy_consensus::{Eip658Value, Transaction};
 use alloy_eips::{Encodable2718, Typed2718};
 use alloy_evm::Database;
-use alloy_primitives::{B256, BlockHash, Bytes, U256};
+use alloy_primitives::{B256, BlockHash, Bytes, TxHash, U256};
 use alloy_rpc_types_eth::Withdrawals;
 use base_access_lists::FBALBuilderDb;
 use base_alloy_chains::BaseUpgrades;
@@ -124,6 +124,10 @@ pub struct FlashblockDiagnostics {
     pub txs_rejected_other: u64,
     /// Minimum effective priority fee (tip per gas) among included transactions.
     pub min_priority_fee: Option<u64>,
+    /// Transaction hashes permanently rejected due to per-tx intrinsic limits
+    /// (e.g. tx DA size exceeded, tx execution time exceeded). These will never
+    /// be includable and should be evicted from the pool.
+    pub permanently_rejected_txs: Vec<TxHash>,
 }
 
 impl FlashblockDiagnostics {
@@ -761,6 +765,9 @@ impl OpPayloadBuilderCtx {
                     if !dry_run {
                         diag.record_rejection(&err);
                         record_rejected_tx_priority_fee(&err, priority_fee);
+                        if err.is_permanent() {
+                            diag.permanently_rejected_txs.push(tx_hash);
+                        }
                         log_txn(Err(err));
                         best_txs.mark_invalid(tx.signer(), tx.nonce());
                         continue;
@@ -773,6 +780,9 @@ impl OpPayloadBuilderCtx {
                     let priority_fee = tx.effective_tip_per_gas(base_fee).unwrap_or(0) as f64;
                     record_rejected_tx_priority_fee(&err, priority_fee);
 
+                    if err.is_permanent() {
+                        diag.permanently_rejected_txs.push(tx_hash);
+                    }
                     log_txn(Err(err));
                     best_txs.mark_invalid(tx.signer(), tx.nonce());
                     continue;

--- a/crates/builder/core/src/flashblocks/mod.rs
+++ b/crates/builder/core/src/flashblocks/mod.rs
@@ -1,7 +1,7 @@
 //! Flashblocks builder types.
 
 mod best_txs;
-pub use best_txs::BestFlashblocksTxs;
+pub use best_txs::{BestFlashblocksTxs, RejectionCache};
 
 mod generator;
 pub use generator::{

--- a/crates/builder/core/src/flashblocks/payload.rs
+++ b/crates/builder/core/src/flashblocks/payload.rs
@@ -368,9 +368,12 @@ where
         ctx = ctx.with_cancel(fb_cancel.clone()).with_extra_ctx(extra);
 
         // Create best_transaction iterator
-        let mut best_txs = BestFlashblocksTxs::new(BestPayloadTransactions::new(
-            self.pool.best_transactions_with_attributes(ctx.best_transaction_attributes()),
-        ));
+        let mut best_txs = BestFlashblocksTxs::new(
+            BestPayloadTransactions::new(
+                self.pool.best_transactions_with_attributes(ctx.best_transaction_attributes()),
+            ),
+            self.config.rejection_cache.clone(),
+        );
         let interval = self.config.flashblocks_interval;
         let (tx, mut rx) = mpsc::channel((self.config.flashblocks_per_block() + 1) as usize);
 
@@ -581,6 +584,21 @@ where
         let diag = ctx
             .execute_best_transactions(info, state, best_txs, &limits)
             .wrap_err("failed to execute best transactions")?;
+
+        // Evict permanently rejected transactions from the iterator and pool.
+        // The rejection cache (inside best_txs) prevents re-entry on P2P re-gossip.
+        if !diag.permanently_rejected_txs.is_empty() {
+            let rejected_count = diag.permanently_rejected_txs.len();
+            best_txs.mark_rejected(&diag.permanently_rejected_txs);
+            self.config.metering_provider.remove(&diag.permanently_rejected_txs);
+            self.pool.remove_transactions(diag.permanently_rejected_txs.clone());
+            info!(
+                target: "payload_builder",
+                count = rejected_count,
+                "evicted permanently rejected transactions from pool",
+            );
+        }
+
         // Extract last transactions
         let new_transactions = info.executed_transactions[info.extra.last_flashblock_index..]
             .iter()

--- a/crates/builder/core/src/lib.rs
+++ b/crates/builder/core/src/lib.rs
@@ -33,7 +33,7 @@ pub use flashblocks::{
     BestFlashblocksTxs, BlockCell, BlockPayloadJob, BlockPayloadJobGenerator, BuildArguments,
     FlashblockDiagnostics, FlashblockSelectionOutcome, FlashblocksExecutionInfo,
     FlashblocksExtraCtx, FlashblocksServiceBuilder, OpPayloadBuilderCtx, PayloadBuilder,
-    PayloadHandler, ResolvePayload, WaitForValue,
+    PayloadHandler, RejectionCache, ResolvePayload, WaitForValue,
 };
 
 mod extension;

--- a/crates/builder/core/src/metrics.rs
+++ b/crates/builder/core/src/metrics.rs
@@ -100,6 +100,10 @@ base_metrics::define_metrics! {
     metering_store_lru_evictions: counter,
     #[describe("Size of MeteringStore")]
     metering_store_size: gauge,
+    #[describe("Transactions skipped by the rejection cache")]
+    rejection_cache_hits: counter,
+    #[describe("Number of entries in the rejection cache")]
+    rejection_cache_size: gauge,
     #[describe("Transactions skipped because metering data has not yet arrived")]
     metering_data_pending_skip: counter,
     #[describe("Transactions rejected by per-tx DA size limit")]

--- a/crates/builder/core/src/metrics.rs
+++ b/crates/builder/core/src/metrics.rs
@@ -100,7 +100,9 @@ base_metrics::define_metrics! {
     metering_store_lru_evictions: counter,
     #[describe("Size of MeteringStore")]
     metering_store_size: gauge,
-    #[describe("Transactions skipped by the rejection cache")]
+    #[describe("Transactions inserted into the rejection cache")]
+    rejection_cache_insertions: counter,
+    #[describe("Transactions skipped by the rejection cache (P2P re-insertion prevented)")]
     rejection_cache_hits: counter,
     #[describe("Number of entries in the rejection cache")]
     rejection_cache_size: gauge,


### PR DESCRIPTION
Closes: CHAIN-3730

- A tx that breaches the resource metering budgets (i.e., per-tx execution time) is `mark_invalid` in the current `best_txs` iteration. That discards it from any consideration when building the _current_ flashblock.
- However, it does **not** discard it from subsequent flashblocks and even canonical blocks 
- Even though we have txpool lifetime limits, these txs getting added are `TxOrigin::Local` and those are never evicted from the local mempool
- Until mempool_v2 goes live, this is the simplest patch for resource metering
- The idea is a shared cache across canonical blocks of txs that have breached the budget. These should never be included again

Some edge cases:
- We set a high TTL so that when it gets evicted the tx may be considered again but should fail early/fast due to simple checks like nonce errors
- The tx is still gonna sit in the mempool, which takes up space (mempool_v2 fixes this though)

Notes:
- RejectionCache size / TTL are both CLI configurable and will need adequate tuning 