### PR TITLE
fix(tee): pass intermediate_block_interval in nitro-local test script

### DIFF
--- a/etc/scripts/local/test-nitro-prover.sh
+++ b/etc/scripts/local/test-nitro-prover.sh
@@ -141,7 +141,9 @@ payload=$(cat <<EOF
         "agreed_l2_head_hash": "$AGREED_L2_HEAD_HASH",
         "agreed_l2_output_root": "$AGREED_L2_OUTPUT_ROOT",
         "claimed_l2_output_root": "$CLAIMED_L2_OUTPUT_ROOT",
-        "claimed_l2_block_number": $CLAIMED_L2_BLOCK_NUMBER
+        "claimed_l2_block_number": $CLAIMED_L2_BLOCK_NUMBER,
+        "intermediate_block_interval": $BLOCK_RANGE,
+        "l1_head_number": $L1_HEAD_NUMBER
     }]
 }
 EOF


### PR DESCRIPTION
## Summary

- The `test-nitro-prover.sh` script was omitting `intermediate_block_interval` and `l1_head_number` from the `prover_prove` JSON-RPC request payload, causing both to serde-default to `0`.
- The enclave rejected multi-block proofs with `"intermediate_block_interval must not be zero"`.
- Sets `intermediate_block_interval` to `BLOCK_RANGE` (one checkpoint at end of range) and `l1_head_number` to the already-computed `L1_HEAD_NUMBER`.