### PR TITLE
chore(tee): use alloy_signer for public key to address derivation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4684,6 +4684,7 @@ name = "base-proof-tee-nitro-host"
 version = "0.0.0"
 dependencies = [
  "alloy-primitives",
+ "alloy-signer",
  "async-trait",
  "base-health",
  "base-proof-contracts",
@@ -4692,7 +4693,6 @@ dependencies = [
  "base-proof-primitives",
  "base-proof-tee-nitro-enclave",
  "eyre",
- "hex-literal 1.1.0",
  "jsonrpsee",
  "k256",
  "thiserror 2.0.18",
@@ -4727,6 +4727,7 @@ dependencies = [
  "alloy-consensus",
  "alloy-primitives",
  "alloy-rpc-types-eth",
+ "alloy-signer",
  "alloy-signer-local",
  "alloy-sol-types",
  "async-trait",

--- a/bin/prover/nitro-host/Cargo.toml
+++ b/bin/prover/nitro-host/Cargo.toml
@@ -20,8 +20,8 @@ eyre.workspace = true
 tracing.workspace = true
 base-cli-utils.workspace = true
 alloy-primitives.workspace = true
-base-proof-tee-nitro-host.workspace = true
 base-consensus-registry.workspace = true
+base-proof-tee-nitro-host.workspace = true
 tokio = { workspace = true, features = ["full"] }
 clap = { workspace = true, features = ["derive", "env"] }
 serde = { workspace = true, features = ["derive", "std"] }

--- a/crates/proof/tee/nitro-host/Cargo.toml
+++ b/crates/proof/tee/nitro-host/Cargo.toml
@@ -21,6 +21,7 @@ base-proof-tee-nitro-enclave.workspace = true
 base-proof-primitives = { workspace = true, features = ["std", "serde", "rpc-server"] }
 
 # crypto
+alloy-signer.workspace = true
 alloy-primitives.workspace = true
 k256 = { workspace = true, features = ["ecdsa"] }
 
@@ -40,7 +41,6 @@ jsonrpsee = { workspace = true, features = ["server", "macros"] }
 tokio-vsock.workspace = true
 
 [dev-dependencies]
-hex-literal.workspace = true
 tokio = { workspace = true, features = ["macros", "rt"] }
 
 [features]

--- a/crates/proof/tee/nitro-host/src/health.rs
+++ b/crates/proof/tee/nitro-host/src/health.rs
@@ -5,10 +5,12 @@ use std::{
     time::{Duration, Instant},
 };
 
-use alloy_primitives::{Address, keccak256};
+use alloy_primitives::Address;
+use alloy_signer::utils::public_key_to_address;
 use base_health::{HealthzApiServer, HealthzResponse};
 use base_proof_contracts::{TEEProverRegistryClient, TEEProverRegistryContractClient};
 use jsonrpsee::core::{RpcResult, async_trait};
+use k256::ecdsa::VerifyingKey;
 use tokio::sync::{OnceCell, RwLock};
 use tracing::warn;
 
@@ -52,19 +54,12 @@ impl RegistrationHealthzRpc {
                     .signer_public_key()
                     .await
                     .map_err(|e| format!("failed to get signer public key: {e}"))?;
-                Self::derive_signer_address(&public_key)
+                let verifying_key = VerifyingKey::from_sec1_bytes(&public_key)
+                    .map_err(|e| format!("invalid public key: {e}"))?;
+                Ok(public_key_to_address(&verifying_key))
             })
             .await
             .copied()
-    }
-
-    fn derive_signer_address(public_key: &[u8]) -> Result<Address, String> {
-        let key = k256::PublicKey::from_sec1_bytes(public_key)
-            .map_err(|e| format!("invalid public key: {e}"))?;
-        let uncompressed =
-            k256::elliptic_curve::sec1::ToEncodedPoint::to_encoded_point(&key, false);
-        let hash = keccak256(&uncompressed.as_bytes()[1..]);
-        Ok(Address::from_slice(&hash[12..]))
     }
 
     async fn use_stale_cache_or_fail(&self, signer: Address, error: &str) -> Result<bool, String> {
@@ -136,45 +131,8 @@ impl HealthzApiServer for RegistrationHealthzRpc {
 #[cfg(test)]
 mod tests {
     use alloy_primitives::address;
-    use hex_literal::hex;
-    use k256::ecdsa::SigningKey;
 
     use super::*;
-
-    const HARDHAT_PRIVATE_KEY: [u8; 32] =
-        hex!("ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80");
-
-    fn hardhat_public_key() -> Vec<u8> {
-        let signing_key = SigningKey::from_slice(&HARDHAT_PRIVATE_KEY).unwrap();
-        let verifying_key = signing_key.verifying_key();
-        verifying_key.to_encoded_point(false).as_bytes().to_vec()
-    }
-
-    #[test]
-    fn derive_signer_address_hardhat_account_zero() {
-        let public_key = hardhat_public_key();
-        let derived = RegistrationHealthzRpc::derive_signer_address(&public_key).unwrap();
-        assert_eq!(derived, address!("f39Fd6e51aad88F6F4ce6aB8827279cffFb92266"));
-    }
-
-    #[test]
-    fn derive_signer_address_compressed_matches_uncompressed() {
-        let signing_key = SigningKey::from_slice(&HARDHAT_PRIVATE_KEY).unwrap();
-        let verifying_key = signing_key.verifying_key();
-        let compressed = verifying_key.to_encoded_point(true).as_bytes().to_vec();
-        let uncompressed = hardhat_public_key();
-
-        let addr_compressed = RegistrationHealthzRpc::derive_signer_address(&compressed).unwrap();
-        let addr_uncompressed =
-            RegistrationHealthzRpc::derive_signer_address(&uncompressed).unwrap();
-        assert_eq!(addr_compressed, addr_uncompressed);
-    }
-
-    #[test]
-    fn derive_signer_address_rejects_invalid_key() {
-        assert!(RegistrationHealthzRpc::derive_signer_address(&[0x04; 66]).is_err());
-        assert!(RegistrationHealthzRpc::derive_signer_address(&[]).is_err());
-    }
 
     fn test_rpc() -> RegistrationHealthzRpc {
         let server = Arc::new(base_proof_tee_nitro_enclave::Server::new_local().unwrap());

--- a/crates/proof/tee/nitro-host/src/health.rs
+++ b/crates/proof/tee/nitro-host/src/health.rs
@@ -8,7 +8,7 @@ use std::{
 use alloy_primitives::Address;
 use alloy_signer::utils::public_key_to_address;
 use base_health::{HealthzApiServer, HealthzResponse};
-use base_proof_contracts::{TEEProverRegistryClient, TEEProverRegistryContractClient};
+use base_proof_contracts::TEEProverRegistryClient;
 use jsonrpsee::core::{RpcResult, async_trait};
 use k256::ecdsa::VerifyingKey;
 use tokio::sync::{OnceCell, RwLock};
@@ -20,6 +20,31 @@ const REGISTRATION_CACHE_TTL: Duration = Duration::from_secs(30);
 const REGISTRATION_STALE_LIMIT: Duration = Duration::from_secs(300);
 const REGISTRATION_CHECK_TIMEOUT: Duration = Duration::from_secs(10);
 
+/// Errors from the registration health check.
+#[derive(Debug, thiserror::Error)]
+pub enum RegistrationHealthError {
+    /// Failed to retrieve the signer public key from the enclave.
+    #[error("failed to get signer public key: {0}")]
+    SignerKey(eyre::Report),
+    /// The public key bytes are not a valid secp256k1 point.
+    #[error("invalid public key: {0}")]
+    InvalidPublicKey(String),
+    /// The L1 RPC call to check registration status failed.
+    #[error("L1 RPC call failed: {0}")]
+    L1Rpc(base_proof_contracts::ContractError),
+    /// The L1 RPC request timed out.
+    #[error("L1 RPC request timed out")]
+    Timeout,
+    /// Registration check failed and stale cache has expired.
+    #[error("registration check failed for {signer}: {reason}")]
+    StaleExpired {
+        /// The signer address that was being checked.
+        signer: Address,
+        /// The underlying reason the registration check failed.
+        reason: String,
+    },
+}
+
 /// Configuration for registration-gated health checks.
 #[derive(Debug)]
 pub struct RegistrationHealthConfig {
@@ -29,40 +54,52 @@ pub struct RegistrationHealthConfig {
     pub l1_rpc_url: String,
 }
 
-pub(crate) struct RegistrationHealthzRpc {
+/// JSON-RPC handler for registration-gated health checks.
+pub struct RegistrationHealthzRpc {
     version: &'static str,
     transport: Arc<NitroTransport>,
-    registry: TEEProverRegistryContractClient,
+    registry: Box<dyn TEEProverRegistryClient>,
     signer: OnceCell<Address>,
     cache: RwLock<Option<(bool, Instant)>>,
 }
 
 impl RegistrationHealthzRpc {
-    pub(crate) fn new(
+    /// Creates a new health check handler.
+    pub fn new(
         version: &'static str,
         transport: Arc<NitroTransport>,
-        registry: TEEProverRegistryContractClient,
+        registry: impl TEEProverRegistryClient + 'static,
     ) -> Self {
-        Self { version, transport, registry, signer: OnceCell::new(), cache: RwLock::new(None) }
+        Self {
+            version,
+            transport,
+            registry: Box::new(registry),
+            signer: OnceCell::new(),
+            cache: RwLock::new(None),
+        }
     }
 
-    async fn signer_address(&self) -> Result<Address, String> {
+    async fn signer_address(&self) -> Result<Address, RegistrationHealthError> {
         self.signer
             .get_or_try_init(|| async {
                 let public_key = self
                     .transport
                     .signer_public_key()
                     .await
-                    .map_err(|e| format!("failed to get signer public key: {e}"))?;
+                    .map_err(|e| RegistrationHealthError::SignerKey(e.into()))?;
                 let verifying_key = VerifyingKey::from_sec1_bytes(&public_key)
-                    .map_err(|e| format!("invalid public key: {e}"))?;
+                    .map_err(|e| RegistrationHealthError::InvalidPublicKey(e.to_string()))?;
                 Ok(public_key_to_address(&verifying_key))
             })
             .await
             .copied()
     }
 
-    async fn use_stale_cache_or_fail(&self, signer: Address, error: &str) -> Result<bool, String> {
+    async fn use_stale_cache_or_fail(
+        &self,
+        signer: Address,
+        error: &(dyn std::fmt::Display + Sync),
+    ) -> Result<bool, RegistrationHealthError> {
         let cache = self.cache.read().await;
         if let Some((registered, checked_at)) = *cache {
             let elapsed = checked_at.elapsed();
@@ -76,10 +113,10 @@ impl RegistrationHealthzRpc {
                 return Ok(registered);
             }
         }
-        Err(format!("failed to check registration for {signer}: {error}"))
+        Err(RegistrationHealthError::StaleExpired { signer, reason: error.to_string() })
     }
 
-    async fn check_registration(&self) -> Result<bool, String> {
+    async fn check_registration(&self) -> Result<bool, RegistrationHealthError> {
         {
             let cache = self.cache.read().await;
             if let Some((registered, checked_at)) = *cache
@@ -107,9 +144,22 @@ impl RegistrationHealthzRpc {
                 }
                 Ok(registered)
             }
-            Ok(Err(e)) => self.use_stale_cache_or_fail(signer, &e.to_string()).await,
-            Err(_) => self.use_stale_cache_or_fail(signer, "L1 RPC request timed out").await,
+            Ok(Err(e)) => {
+                let error = RegistrationHealthError::L1Rpc(e);
+                self.use_stale_cache_or_fail(signer, &error).await
+            }
+            Err(_) => self.use_stale_cache_or_fail(signer, &RegistrationHealthError::Timeout).await,
         }
+    }
+}
+
+impl std::fmt::Debug for RegistrationHealthzRpc {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("RegistrationHealthzRpc")
+            .field("version", &self.version)
+            .field("registry", &"dyn TEEProverRegistryClient")
+            .field("signer", &self.signer.get())
+            .finish()
     }
 }
 
@@ -123,23 +173,83 @@ impl HealthzApiServer for RegistrationHealthzRpc {
                 "signer not registered in TEEProverRegistry",
                 None::<()>,
             )),
-            Err(msg) => Err(jsonrpsee::types::ErrorObjectOwned::owned(-32000, msg, None::<()>)),
+            Err(e) => {
+                Err(jsonrpsee::types::ErrorObjectOwned::owned(-32000, e.to_string(), None::<()>))
+            }
         }
     }
 }
 
 #[cfg(test)]
 mod tests {
+    use std::sync::{
+        Arc,
+        atomic::{AtomicBool, AtomicUsize, Ordering},
+    };
+
     use alloy_primitives::address;
+    use base_proof_contracts::TEEProverRegistryContractClient;
 
     use super::*;
 
-    fn test_rpc() -> RegistrationHealthzRpc {
+    #[derive(Clone)]
+    struct MockRegistry {
+        registered: Arc<AtomicBool>,
+        call_count: Arc<AtomicUsize>,
+        should_fail: Arc<AtomicBool>,
+    }
+
+    impl MockRegistry {
+        fn new(registered: bool) -> Self {
+            Self {
+                registered: Arc::new(AtomicBool::new(registered)),
+                call_count: Arc::new(AtomicUsize::new(0)),
+                should_fail: Arc::new(AtomicBool::new(false)),
+            }
+        }
+    }
+
+    #[async_trait]
+    impl TEEProverRegistryClient for MockRegistry {
+        async fn is_valid_signer(
+            &self,
+            _signer: Address,
+        ) -> Result<bool, base_proof_contracts::ContractError> {
+            unimplemented!("not used in health checks")
+        }
+
+        async fn is_registered_signer(
+            &self,
+            _signer: Address,
+        ) -> Result<bool, base_proof_contracts::ContractError> {
+            self.call_count.fetch_add(1, Ordering::Relaxed);
+            if self.should_fail.load(Ordering::Relaxed) {
+                return Err(base_proof_contracts::ContractError::Validation(
+                    "mock RPC failure".into(),
+                ));
+            }
+            Ok(self.registered.load(Ordering::Relaxed))
+        }
+
+        async fn get_registered_signers(
+            &self,
+        ) -> Result<Vec<Address>, base_proof_contracts::ContractError> {
+            unimplemented!("not used in health checks")
+        }
+    }
+
+    fn test_rpc_with_mock(
+        registry: impl TEEProverRegistryClient + 'static,
+    ) -> RegistrationHealthzRpc {
         let server = Arc::new(base_proof_tee_nitro_enclave::Server::new_local().unwrap());
         let transport = Arc::new(NitroTransport::local(server));
+        RegistrationHealthzRpc::new("0.0.0", transport, registry)
+    }
+
+    fn test_rpc() -> RegistrationHealthzRpc {
         let dummy_url = url::Url::parse("http://localhost:1").unwrap();
         let registry = TEEProverRegistryContractClient::new(Address::ZERO, dummy_url);
-        RegistrationHealthzRpc::new("0.0.0", transport, registry)
+        test_rpc_with_mock(registry)
     }
 
     const TEST_SIGNER: Address = address!("f39Fd6e51aad88F6F4ce6aB8827279cffFb92266");
@@ -148,7 +258,7 @@ mod tests {
     async fn stale_cache_returns_cached_value_on_error() {
         let rpc = test_rpc();
         *rpc.cache.write().await = Some((true, Instant::now()));
-        let result = rpc.use_stale_cache_or_fail(TEST_SIGNER, "rpc down").await;
+        let result = rpc.use_stale_cache_or_fail(TEST_SIGNER, &"rpc down").await;
         assert!(result.unwrap());
     }
 
@@ -157,14 +267,14 @@ mod tests {
         let rpc = test_rpc();
         let expired = Instant::now() - REGISTRATION_STALE_LIMIT - Duration::from_secs(1);
         *rpc.cache.write().await = Some((true, expired));
-        let result = rpc.use_stale_cache_or_fail(TEST_SIGNER, "rpc down").await;
+        let result = rpc.use_stale_cache_or_fail(TEST_SIGNER, &"rpc down").await;
         assert!(result.is_err());
     }
 
     #[tokio::test]
     async fn stale_cache_fails_when_empty() {
         let rpc = test_rpc();
-        let result = rpc.use_stale_cache_or_fail(TEST_SIGNER, "rpc down").await;
+        let result = rpc.use_stale_cache_or_fail(TEST_SIGNER, &"rpc down").await;
         assert!(result.is_err());
     }
 
@@ -184,5 +294,54 @@ mod tests {
         *rpc.cache.write().await = Some((false, Instant::now()));
         let result = rpc.check_registration().await;
         assert!(!result.unwrap());
+    }
+
+    #[tokio::test]
+    async fn check_registration_cache_miss_calls_rpc() {
+        let registry = MockRegistry::new(true);
+        let call_count = Arc::clone(&registry.call_count);
+        let rpc = test_rpc_with_mock(registry);
+        rpc.signer.set(TEST_SIGNER).unwrap();
+
+        let result = rpc.check_registration().await;
+        assert!(result.unwrap());
+        assert_eq!(call_count.load(Ordering::Relaxed), 1);
+    }
+
+    #[tokio::test]
+    async fn check_registration_populates_cache_after_rpc() {
+        let rpc = test_rpc_with_mock(MockRegistry::new(true));
+        rpc.signer.set(TEST_SIGNER).unwrap();
+
+        let result = rpc.check_registration().await;
+        assert!(result.unwrap());
+
+        let result = rpc.check_registration().await;
+        assert!(result.unwrap());
+    }
+
+    #[tokio::test]
+    async fn check_registration_rpc_failure_uses_stale_cache() {
+        let failing = MockRegistry::new(false);
+        failing.should_fail.store(true, Ordering::Relaxed);
+        let rpc = test_rpc_with_mock(failing);
+        rpc.signer.set(TEST_SIGNER).unwrap();
+
+        let stale_time = Instant::now() - REGISTRATION_CACHE_TTL - Duration::from_secs(1);
+        *rpc.cache.write().await = Some((true, stale_time));
+
+        let result = rpc.check_registration().await;
+        assert!(result.unwrap());
+    }
+
+    #[tokio::test]
+    async fn check_registration_rpc_failure_no_cache_returns_error() {
+        let failing = MockRegistry::new(false);
+        failing.should_fail.store(true, Ordering::Relaxed);
+        let rpc = test_rpc_with_mock(failing);
+        rpc.signer.set(TEST_SIGNER).unwrap();
+
+        let result = rpc.check_registration().await;
+        assert!(result.is_err());
     }
 }

--- a/crates/proof/tee/nitro-host/src/lib.rs
+++ b/crates/proof/tee/nitro-host/src/lib.rs
@@ -10,7 +10,7 @@ mod convert;
 pub use convert::Convert;
 
 mod health;
-pub use health::RegistrationHealthConfig;
+pub use health::{RegistrationHealthConfig, RegistrationHealthError, RegistrationHealthzRpc};
 
 mod server;
 pub use server::NitroProverServer;

--- a/crates/proof/tee/registrar/Cargo.toml
+++ b/crates/proof/tee/registrar/Cargo.toml
@@ -12,6 +12,7 @@ workspace = true
 
 [dependencies]
 # Alloy
+alloy-signer.workspace = true
 alloy-sol-types.workspace = true
 alloy-primitives.workspace = true
 alloy-signer-local.workspace = true
@@ -21,8 +22,8 @@ aws-sdk-ec2.workspace = true
 aws-sdk-elasticloadbalancingv2.workspace = true
 
 # Crypto
-k256.workspace = true
 rand.workspace = true
+k256 = { workspace = true, features = ["ecdsa"] }
 
 # Contracts
 base-proof-contracts.workspace = true
@@ -61,7 +62,6 @@ rstest.workspace = true
 hex-literal.workspace = true
 alloy-consensus.workspace = true
 alloy-rpc-types-eth.workspace = true
-k256 = { workspace = true, features = ["ecdsa"] }
 tokio = { workspace = true, features = ["rt", "macros", "test-util"] }
 
 [features]

--- a/crates/proof/tee/registrar/src/prover.rs
+++ b/crates/proof/tee/registrar/src/prover.rs
@@ -2,11 +2,12 @@
 
 use std::{collections::HashMap, sync::Mutex, time::Duration};
 
-use alloy_primitives::{Address, keccak256};
+use alloy_primitives::Address;
+use alloy_signer::utils::public_key_to_address;
 use async_trait::async_trait;
 use base_proof_primitives::EnclaveApiClient;
 use jsonrpsee::http_client::{HttpClient, HttpClientBuilder};
-use k256::elliptic_curve::sec1::ToEncodedPoint;
+use k256::ecdsa::VerifyingKey;
 use tracing::debug;
 use url::Url;
 
@@ -21,8 +22,6 @@ use crate::{RegistrarError, Result, SignerClient};
 /// across poll cycles. The `timeout` is configured once at construction and
 /// applied to all requests.
 ///
-/// Also provides [`derive_address`](Self::derive_address), a pure-crypto helper
-/// that derives an Ethereum address from a SEC1-encoded public key.
 pub struct ProverClient {
     /// Timeout applied to all JSON-RPC requests.
     timeout: Duration,
@@ -74,17 +73,11 @@ impl ProverClient {
 
     /// Derives an Ethereum [`Address`] from a SEC1-encoded public key.
     ///
-    /// Validates that the bytes represent a valid point on the secp256k1 curve
-    /// (via [`k256::PublicKey::from_sec1_bytes`]), then computes the address as
-    /// `keccak256(uncompressed_point[1..])[12..]`.
-    ///
     /// Accepts both compressed (33-byte) and uncompressed (65-byte) SEC1 formats.
     pub fn derive_address(public_key: &[u8]) -> Result<Address> {
-        let key = k256::PublicKey::from_sec1_bytes(public_key)
+        let verifying_key = VerifyingKey::from_sec1_bytes(public_key)
             .map_err(|e| RegistrarError::InvalidPublicKey(e.to_string()))?;
-        let uncompressed = key.to_encoded_point(false);
-        let hash = keccak256(&uncompressed.as_bytes()[1..]);
-        Ok(Address::from_slice(&hash[12..]))
+        Ok(public_key_to_address(&verifying_key))
     }
 }
 


### PR DESCRIPTION
## Summary

Follow-up to #1871.

- Replace hand-rolled `keccak256(uncompressed[1..])[12..]` address derivation with `alloy_signer::utils::public_key_to_address` in both `nitro-host` and `registrar`
- Remove the duplicated `derive_signer_address` / `derive_address` helper functions
- Remove `hex-literal` dev-dep from nitro-host (derive tests removed; cache tests retained)
- Remove redundant `k256` dev-dep override from registrar (now in regular deps with `ecdsa` feature)