### PR TITLE
ktlo(workspace): Gitignore Dotenvs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ docs/specs/dist/
 docs/specs/.vocs/
 *.log
 .vscode/
+*.env


### PR DESCRIPTION
## Summary

Very small PR to gitignore all dotenv files so we can place `FUNDER_KEY` (load testing) env vars among others in dotenv files.