### PR TITLE
feat(nitro-host): check prover validity before witness generation

### DIFF
--- a/crates/proof/tee/nitro-host/src/health.rs
+++ b/crates/proof/tee/nitro-host/src/health.rs
@@ -1,24 +1,24 @@
 //! Registration-gated health check for the nitro prover.
+//!
+//! Delegates signer validity checks to [`RegistrationChecker`], which is shared
+//! with the proving guard in `server.rs`.
 
-use std::{
-    sync::Arc,
-    time::{Duration, Instant},
-};
+use std::sync::Arc;
 
 use alloy_primitives::Address;
-use alloy_signer::utils::public_key_to_address;
 use base_health::{HealthzApiServer, HealthzResponse};
-use base_proof_contracts::TEEProverRegistryClient;
 use jsonrpsee::core::{RpcResult, async_trait};
-use k256::ecdsa::VerifyingKey;
-use tokio::sync::{OnceCell, RwLock};
-use tracing::warn;
 
-use super::transport::NitroTransport;
+use super::registration::RegistrationChecker;
 
-const REGISTRATION_CACHE_TTL: Duration = Duration::from_secs(30);
-const REGISTRATION_STALE_LIMIT: Duration = Duration::from_secs(300);
-const REGISTRATION_CHECK_TIMEOUT: Duration = Duration::from_secs(10);
+/// Configuration for registration-gated health checks.
+#[derive(Debug)]
+pub struct RegistrationHealthConfig {
+    /// `TEEProverRegistry` contract address on L1.
+    pub registry_address: Address,
+    /// L1 JSON-RPC endpoint URL.
+    pub l1_rpc_url: String,
+}
 
 /// Errors from the registration health check.
 #[derive(Debug, thiserror::Error)]
@@ -45,111 +45,20 @@ pub enum RegistrationHealthError {
     },
 }
 
-/// Configuration for registration-gated health checks.
-#[derive(Debug)]
-pub struct RegistrationHealthConfig {
-    /// `TEEProverRegistry` contract address on L1.
-    pub registry_address: Address,
-    /// L1 JSON-RPC endpoint URL.
-    pub l1_rpc_url: String,
-}
-
 /// JSON-RPC handler for registration-gated health checks.
+///
+/// Uses the shared [`RegistrationChecker`] with a fail-open stale-cache policy:
+/// if L1 is temporarily unreachable, the last cached status is returned as long
+/// as it is not older than the stale limit.
 pub struct RegistrationHealthzRpc {
     version: &'static str,
-    transport: Arc<NitroTransport>,
-    registry: Box<dyn TEEProverRegistryClient>,
-    signer: OnceCell<Address>,
-    cache: RwLock<Option<(bool, Instant)>>,
+    checker: Arc<RegistrationChecker>,
 }
 
 impl RegistrationHealthzRpc {
-    /// Creates a new health check handler.
-    pub fn new(
-        version: &'static str,
-        transport: Arc<NitroTransport>,
-        registry: impl TEEProverRegistryClient + 'static,
-    ) -> Self {
-        Self {
-            version,
-            transport,
-            registry: Box::new(registry),
-            signer: OnceCell::new(),
-            cache: RwLock::new(None),
-        }
-    }
-
-    async fn signer_address(&self) -> Result<Address, RegistrationHealthError> {
-        self.signer
-            .get_or_try_init(|| async {
-                let public_key = self
-                    .transport
-                    .signer_public_key()
-                    .await
-                    .map_err(|e| RegistrationHealthError::SignerKey(e.into()))?;
-                let verifying_key = VerifyingKey::from_sec1_bytes(&public_key)
-                    .map_err(|e| RegistrationHealthError::InvalidPublicKey(e.to_string()))?;
-                Ok(public_key_to_address(&verifying_key))
-            })
-            .await
-            .copied()
-    }
-
-    async fn use_stale_cache_or_fail(
-        &self,
-        signer: Address,
-        error: &(dyn std::fmt::Display + Sync),
-    ) -> Result<bool, RegistrationHealthError> {
-        let cache = self.cache.read().await;
-        if let Some((registered, checked_at)) = *cache {
-            let elapsed = checked_at.elapsed();
-            if elapsed < REGISTRATION_STALE_LIMIT {
-                warn!(
-                    error = %error,
-                    signer = %signer,
-                    stale_secs = elapsed.as_secs(),
-                    "L1 RPC failed, using stale cached registration status"
-                );
-                return Ok(registered);
-            }
-        }
-        Err(RegistrationHealthError::StaleExpired { signer, reason: error.to_string() })
-    }
-
-    async fn check_registration(&self) -> Result<bool, RegistrationHealthError> {
-        {
-            let cache = self.cache.read().await;
-            if let Some((registered, checked_at)) = *cache
-                && checked_at.elapsed() < REGISTRATION_CACHE_TTL
-            {
-                return Ok(registered);
-            }
-        }
-
-        let signer = self.signer_address().await?;
-
-        let result = tokio::time::timeout(
-            REGISTRATION_CHECK_TIMEOUT,
-            self.registry.is_registered_signer(signer),
-        )
-        .await;
-
-        match result {
-            Ok(Ok(registered)) => {
-                let mut cache = self.cache.write().await;
-                let was_registered = cache.map(|(r, _)| r);
-                *cache = Some((registered, Instant::now()));
-                if !registered && was_registered != Some(false) {
-                    warn!(signer = %signer, "signer is not registered in TEEProverRegistry");
-                }
-                Ok(registered)
-            }
-            Ok(Err(e)) => {
-                let error = RegistrationHealthError::L1Rpc(e);
-                self.use_stale_cache_or_fail(signer, &error).await
-            }
-            Err(_) => self.use_stale_cache_or_fail(signer, &RegistrationHealthError::Timeout).await,
-        }
+    /// Creates a new health check handler backed by the shared checker.
+    pub const fn new(version: &'static str, checker: Arc<RegistrationChecker>) -> Self {
+        Self { version, checker }
     }
 }
 
@@ -157,16 +66,14 @@ impl std::fmt::Debug for RegistrationHealthzRpc {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("RegistrationHealthzRpc")
             .field("version", &self.version)
-            .field("registry", &"dyn TEEProverRegistryClient")
-            .field("signer", &self.signer.get())
-            .finish()
+            .finish_non_exhaustive()
     }
 }
 
 #[async_trait]
 impl HealthzApiServer for RegistrationHealthzRpc {
     async fn healthz(&self) -> RpcResult<HealthzResponse> {
-        match self.check_registration().await {
+        match self.checker.is_valid_signer_or_stale().await {
             Ok(true) => Ok(HealthzResponse { version: self.version.to_string() }),
             Ok(false) => Err(jsonrpsee::types::ErrorObjectOwned::owned(
                 -32000,
@@ -174,7 +81,7 @@ impl HealthzApiServer for RegistrationHealthzRpc {
                 None::<()>,
             )),
             Err(e) => {
-                Err(jsonrpsee::types::ErrorObjectOwned::owned(-32000, e.to_string(), None::<()>))
+                Err(jsonrpsee::types::ErrorObjectOwned::owned(-32000, e, None::<()>))
             }
         }
     }
@@ -182,27 +89,35 @@ impl HealthzApiServer for RegistrationHealthzRpc {
 
 #[cfg(test)]
 mod tests {
-    use std::sync::{
-        Arc,
-        atomic::{AtomicBool, AtomicUsize, Ordering},
+    use std::{
+        sync::{
+            Arc,
+            atomic::{AtomicBool, AtomicUsize, Ordering},
+        },
+        time::{Duration, Instant},
     };
 
-    use alloy_primitives::address;
-    use base_proof_contracts::TEEProverRegistryContractClient;
+    use alloy_primitives::{Address, address};
+    use base_proof_contracts::TEEProverRegistryClient;
+    use jsonrpsee::core::async_trait;
 
     use super::*;
+    use crate::{
+        registration::{CACHE_TTL, STALE_LIMIT},
+        transport::NitroTransport,
+    };
 
     #[derive(Clone)]
     struct MockRegistry {
-        registered: Arc<AtomicBool>,
+        valid: Arc<AtomicBool>,
         call_count: Arc<AtomicUsize>,
         should_fail: Arc<AtomicBool>,
     }
 
     impl MockRegistry {
-        fn new(registered: bool) -> Self {
+        fn new(valid: bool) -> Self {
             Self {
-                registered: Arc::new(AtomicBool::new(registered)),
+                valid: Arc::new(AtomicBool::new(valid)),
                 call_count: Arc::new(AtomicUsize::new(0)),
                 should_fail: Arc::new(AtomicBool::new(false)),
             }
@@ -215,20 +130,20 @@ mod tests {
             &self,
             _signer: Address,
         ) -> Result<bool, base_proof_contracts::ContractError> {
-            unimplemented!("not used in health checks")
-        }
-
-        async fn is_registered_signer(
-            &self,
-            _signer: Address,
-        ) -> Result<bool, base_proof_contracts::ContractError> {
             self.call_count.fetch_add(1, Ordering::Relaxed);
             if self.should_fail.load(Ordering::Relaxed) {
                 return Err(base_proof_contracts::ContractError::Validation(
                     "mock RPC failure".into(),
                 ));
             }
-            Ok(self.registered.load(Ordering::Relaxed))
+            Ok(self.valid.load(Ordering::Relaxed))
+        }
+
+        async fn is_registered_signer(
+            &self,
+            _signer: Address,
+        ) -> Result<bool, base_proof_contracts::ContractError> {
+            unimplemented!("not used — RegistrationChecker uses is_valid_signer")
         }
 
         async fn get_registered_signers(
@@ -238,110 +153,85 @@ mod tests {
         }
     }
 
-    fn test_rpc_with_mock(
-        registry: impl TEEProverRegistryClient + 'static,
-    ) -> RegistrationHealthzRpc {
-        let server = Arc::new(base_proof_tee_nitro_enclave::Server::new_local().unwrap());
-        let transport = Arc::new(NitroTransport::local(server));
-        RegistrationHealthzRpc::new("0.0.0", transport, registry)
-    }
-
-    fn test_rpc() -> RegistrationHealthzRpc {
-        let dummy_url = url::Url::parse("http://localhost:1").unwrap();
-        let registry = TEEProverRegistryContractClient::new(Address::ZERO, dummy_url);
-        test_rpc_with_mock(registry)
-    }
-
     const TEST_SIGNER: Address = address!("f39Fd6e51aad88F6F4ce6aB8827279cffFb92266");
 
-    #[tokio::test]
-    async fn stale_cache_returns_cached_value_on_error() {
-        let rpc = test_rpc();
-        *rpc.cache.write().await = Some((true, Instant::now()));
-        let result = rpc.use_stale_cache_or_fail(TEST_SIGNER, &"rpc down").await;
-        assert!(result.unwrap());
+    fn test_checker_with_mock(
+        registry: impl TEEProverRegistryClient + 'static,
+    ) -> Arc<RegistrationChecker> {
+        let server = Arc::new(base_proof_tee_nitro_enclave::Server::new_local().unwrap());
+        let transport = Arc::new(NitroTransport::local(server));
+        Arc::new(RegistrationChecker::new(transport, registry))
+    }
+
+    fn test_healthz_with_mock(
+        registry: impl TEEProverRegistryClient + 'static,
+    ) -> (Arc<RegistrationChecker>, RegistrationHealthzRpc) {
+        let checker = test_checker_with_mock(registry);
+        let rpc = RegistrationHealthzRpc::new("0.0.0", Arc::clone(&checker));
+        (checker, rpc)
     }
 
     #[tokio::test]
-    async fn stale_cache_fails_when_expired() {
-        let rpc = test_rpc();
-        let expired = Instant::now() - REGISTRATION_STALE_LIMIT - Duration::from_secs(1);
-        *rpc.cache.write().await = Some((true, expired));
-        let result = rpc.use_stale_cache_or_fail(TEST_SIGNER, &"rpc down").await;
+    async fn healthz_returns_ok_when_valid() {
+        let (checker, rpc) = test_healthz_with_mock(MockRegistry::new(true));
+        checker.set_signer_for_test(TEST_SIGNER);
+        let result = HealthzApiServer::healthz(&rpc).await;
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap().version, "0.0.0");
+    }
+
+    #[tokio::test]
+    async fn healthz_returns_error_when_not_valid() {
+        let (checker, rpc) = test_healthz_with_mock(MockRegistry::new(false));
+        checker.set_signer_for_test(TEST_SIGNER);
+        let result = HealthzApiServer::healthz(&rpc).await;
         assert!(result.is_err());
     }
 
     #[tokio::test]
-    async fn stale_cache_fails_when_empty() {
-        let rpc = test_rpc();
-        let result = rpc.use_stale_cache_or_fail(TEST_SIGNER, &"rpc down").await;
+    async fn healthz_cache_hit_within_ttl() {
+        let (checker, rpc) = test_healthz_with_mock(MockRegistry::new(true));
+        checker.set_signer_for_test(TEST_SIGNER);
+        checker.set_cache_for_test(Some((true, Instant::now()))).await;
+        let result = HealthzApiServer::healthz(&rpc).await;
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn healthz_uses_stale_cache_on_rpc_failure() {
+        let failing = MockRegistry::new(false);
+        failing.should_fail.store(true, Ordering::Relaxed);
+        let (checker, rpc) = test_healthz_with_mock(failing);
+        checker.set_signer_for_test(TEST_SIGNER);
+        let stale_time = Instant::now() - CACHE_TTL - Duration::from_secs(1);
+        checker.set_cache_for_test(Some((true, stale_time))).await;
+        let result = HealthzApiServer::healthz(&rpc).await;
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn healthz_fails_when_stale_cache_expired() {
+        let failing = MockRegistry::new(false);
+        failing.should_fail.store(true, Ordering::Relaxed);
+        let (checker, rpc) = test_healthz_with_mock(failing);
+        checker.set_signer_for_test(TEST_SIGNER);
+        let expired = Instant::now() - STALE_LIMIT - Duration::from_secs(1);
+        checker.set_cache_for_test(Some((true, expired))).await;
+        let result = HealthzApiServer::healthz(&rpc).await;
         assert!(result.is_err());
     }
 
     #[tokio::test]
-    async fn cache_hit_within_ttl() {
-        let rpc = test_rpc();
-        rpc.signer.set(TEST_SIGNER).unwrap();
-        *rpc.cache.write().await = Some((true, Instant::now()));
-        let result = rpc.check_registration().await;
-        assert!(result.unwrap());
-    }
-
-    #[tokio::test]
-    async fn cache_hit_returns_false_when_not_registered() {
-        let rpc = test_rpc();
-        rpc.signer.set(TEST_SIGNER).unwrap();
-        *rpc.cache.write().await = Some((false, Instant::now()));
-        let result = rpc.check_registration().await;
-        assert!(!result.unwrap());
-    }
-
-    #[tokio::test]
-    async fn check_registration_cache_miss_calls_rpc() {
+    async fn healthz_rpc_call_count() {
         let registry = MockRegistry::new(true);
         let call_count = Arc::clone(&registry.call_count);
-        let rpc = test_rpc_with_mock(registry);
-        rpc.signer.set(TEST_SIGNER).unwrap();
+        let (checker, rpc) = test_healthz_with_mock(registry);
+        checker.set_signer_for_test(TEST_SIGNER);
 
-        let result = rpc.check_registration().await;
-        assert!(result.unwrap());
+        let _ = HealthzApiServer::healthz(&rpc).await;
         assert_eq!(call_count.load(Ordering::Relaxed), 1);
-    }
 
-    #[tokio::test]
-    async fn check_registration_populates_cache_after_rpc() {
-        let rpc = test_rpc_with_mock(MockRegistry::new(true));
-        rpc.signer.set(TEST_SIGNER).unwrap();
-
-        let result = rpc.check_registration().await;
-        assert!(result.unwrap());
-
-        let result = rpc.check_registration().await;
-        assert!(result.unwrap());
-    }
-
-    #[tokio::test]
-    async fn check_registration_rpc_failure_uses_stale_cache() {
-        let failing = MockRegistry::new(false);
-        failing.should_fail.store(true, Ordering::Relaxed);
-        let rpc = test_rpc_with_mock(failing);
-        rpc.signer.set(TEST_SIGNER).unwrap();
-
-        let stale_time = Instant::now() - REGISTRATION_CACHE_TTL - Duration::from_secs(1);
-        *rpc.cache.write().await = Some((true, stale_time));
-
-        let result = rpc.check_registration().await;
-        assert!(result.unwrap());
-    }
-
-    #[tokio::test]
-    async fn check_registration_rpc_failure_no_cache_returns_error() {
-        let failing = MockRegistry::new(false);
-        failing.should_fail.store(true, Ordering::Relaxed);
-        let rpc = test_rpc_with_mock(failing);
-        rpc.signer.set(TEST_SIGNER).unwrap();
-
-        let result = rpc.check_registration().await;
-        assert!(result.is_err());
+        let _ = HealthzApiServer::healthz(&rpc).await;
+        assert_eq!(call_count.load(Ordering::Relaxed), 1);
     }
 }

--- a/crates/proof/tee/nitro-host/src/health.rs
+++ b/crates/proof/tee/nitro-host/src/health.rs
@@ -20,31 +20,6 @@ pub struct RegistrationHealthConfig {
     pub l1_rpc_url: String,
 }
 
-/// Errors from the registration health check.
-#[derive(Debug, thiserror::Error)]
-pub enum RegistrationHealthError {
-    /// Failed to retrieve the signer public key from the enclave.
-    #[error("failed to get signer public key: {0}")]
-    SignerKey(eyre::Report),
-    /// The public key bytes are not a valid secp256k1 point.
-    #[error("invalid public key: {0}")]
-    InvalidPublicKey(String),
-    /// The L1 RPC call to check registration status failed.
-    #[error("L1 RPC call failed: {0}")]
-    L1Rpc(base_proof_contracts::ContractError),
-    /// The L1 RPC request timed out.
-    #[error("L1 RPC request timed out")]
-    Timeout,
-    /// Registration check failed and stale cache has expired.
-    #[error("registration check failed for {signer}: {reason}")]
-    StaleExpired {
-        /// The signer address that was being checked.
-        signer: Address,
-        /// The underlying reason the registration check failed.
-        reason: String,
-    },
-}
-
 /// JSON-RPC handler for registration-gated health checks.
 ///
 /// Uses the shared [`RegistrationChecker`] with a fail-open stale-cache policy:
@@ -77,11 +52,11 @@ impl HealthzApiServer for RegistrationHealthzRpc {
             Ok(true) => Ok(HealthzResponse { version: self.version.to_string() }),
             Ok(false) => Err(jsonrpsee::types::ErrorObjectOwned::owned(
                 -32000,
-                "signer not registered in TEEProverRegistry",
+                "signer is not a valid signer in TEEProverRegistry",
                 None::<()>,
             )),
             Err(e) => {
-                Err(jsonrpsee::types::ErrorObjectOwned::owned(-32000, e, None::<()>))
+                Err(jsonrpsee::types::ErrorObjectOwned::owned(-32000, e.to_string(), None::<()>))
             }
         }
     }

--- a/crates/proof/tee/nitro-host/src/health.rs
+++ b/crates/proof/tee/nitro-host/src/health.rs
@@ -22,9 +22,9 @@ pub struct RegistrationHealthConfig {
 
 /// JSON-RPC handler for registration-gated health checks.
 ///
-/// Uses the shared [`RegistrationChecker`] with a fail-open stale-cache policy:
-/// if L1 is temporarily unreachable, the last cached status is returned as long
-/// as it is not older than the stale limit.
+/// Uses the shared [`RegistrationChecker`] with a latching policy: once the
+/// signer has been confirmed valid, health stays healthy forever (avoids ASG
+/// replacement on transient L1 failures).
 pub struct RegistrationHealthzRpc {
     version: &'static str,
     checker: Arc<RegistrationChecker>,
@@ -48,7 +48,7 @@ impl std::fmt::Debug for RegistrationHealthzRpc {
 #[async_trait]
 impl HealthzApiServer for RegistrationHealthzRpc {
     async fn healthz(&self) -> RpcResult<HealthzResponse> {
-        match self.checker.is_valid_signer_or_stale().await {
+        match self.checker.check_health().await {
             Ok(true) => Ok(HealthzResponse { version: self.version.to_string() }),
             Ok(false) => Err(jsonrpsee::types::ErrorObjectOwned::owned(
                 -32000,
@@ -64,12 +64,9 @@ impl HealthzApiServer for RegistrationHealthzRpc {
 
 #[cfg(test)]
 mod tests {
-    use std::{
-        sync::{
-            Arc,
-            atomic::{AtomicBool, AtomicUsize, Ordering},
-        },
-        time::{Duration, Instant},
+    use std::sync::{
+        Arc,
+        atomic::{AtomicBool, AtomicUsize, Ordering},
     };
 
     use alloy_primitives::{Address, address};
@@ -77,10 +74,7 @@ mod tests {
     use jsonrpsee::core::async_trait;
 
     use super::*;
-    use crate::{
-        registration::{CACHE_TTL, STALE_LIMIT},
-        transport::NitroTransport,
-    };
+    use crate::transport::NitroTransport;
 
     #[derive(Clone)]
     struct MockRegistry {
@@ -118,30 +112,24 @@ mod tests {
             &self,
             _signer: Address,
         ) -> Result<bool, base_proof_contracts::ContractError> {
-            unimplemented!("not used — RegistrationChecker uses is_valid_signer")
+            unimplemented!()
         }
 
         async fn get_registered_signers(
             &self,
         ) -> Result<Vec<Address>, base_proof_contracts::ContractError> {
-            unimplemented!("not used in health checks")
+            unimplemented!()
         }
     }
 
     const TEST_SIGNER: Address = address!("f39Fd6e51aad88F6F4ce6aB8827279cffFb92266");
 
-    fn test_checker_with_mock(
-        registry: impl TEEProverRegistryClient + 'static,
-    ) -> Arc<RegistrationChecker> {
-        let server = Arc::new(base_proof_tee_nitro_enclave::Server::new_local().unwrap());
-        let transport = Arc::new(NitroTransport::local(server));
-        Arc::new(RegistrationChecker::new(transport, registry))
-    }
-
     fn test_healthz_with_mock(
         registry: impl TEEProverRegistryClient + 'static,
     ) -> (Arc<RegistrationChecker>, RegistrationHealthzRpc) {
-        let checker = test_checker_with_mock(registry);
+        let server = Arc::new(base_proof_tee_nitro_enclave::Server::new_local().unwrap());
+        let transport = Arc::new(NitroTransport::local(server));
+        let checker = Arc::new(RegistrationChecker::new(transport, registry));
         let rpc = RegistrationHealthzRpc::new("0.0.0", Arc::clone(&checker));
         (checker, rpc)
     }
@@ -164,34 +152,28 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn healthz_cache_hit_within_ttl() {
-        let (checker, rpc) = test_healthz_with_mock(MockRegistry::new(true));
+    async fn healthz_latches_after_first_success() {
+        let registry = MockRegistry::new(true);
+        let (checker, rpc) = test_healthz_with_mock(registry.clone());
         checker.set_signer_for_test(TEST_SIGNER);
-        checker.set_cache_for_test(Some((true, Instant::now()))).await;
+
+        let result = HealthzApiServer::healthz(&rpc).await;
+        assert!(result.is_ok());
+
+        registry.valid.store(false, Ordering::Relaxed);
+        registry.should_fail.store(true, Ordering::Relaxed);
+        checker.set_cache_for_test(None).await;
+
         let result = HealthzApiServer::healthz(&rpc).await;
         assert!(result.is_ok());
     }
 
     #[tokio::test]
-    async fn healthz_uses_stale_cache_on_rpc_failure() {
-        let failing = MockRegistry::new(false);
-        failing.should_fail.store(true, Ordering::Relaxed);
-        let (checker, rpc) = test_healthz_with_mock(failing);
+    async fn healthz_errors_on_rpc_failure_before_latch() {
+        let registry = MockRegistry::new(false);
+        registry.should_fail.store(true, Ordering::Relaxed);
+        let (checker, rpc) = test_healthz_with_mock(registry);
         checker.set_signer_for_test(TEST_SIGNER);
-        let stale_time = Instant::now() - CACHE_TTL - Duration::from_secs(1);
-        checker.set_cache_for_test(Some((true, stale_time))).await;
-        let result = HealthzApiServer::healthz(&rpc).await;
-        assert!(result.is_ok());
-    }
-
-    #[tokio::test]
-    async fn healthz_fails_when_stale_cache_expired() {
-        let failing = MockRegistry::new(false);
-        failing.should_fail.store(true, Ordering::Relaxed);
-        let (checker, rpc) = test_healthz_with_mock(failing);
-        checker.set_signer_for_test(TEST_SIGNER);
-        let expired = Instant::now() - STALE_LIMIT - Duration::from_secs(1);
-        checker.set_cache_for_test(Some((true, expired))).await;
         let result = HealthzApiServer::healthz(&rpc).await;
         assert!(result.is_err());
     }

--- a/crates/proof/tee/nitro-host/src/lib.rs
+++ b/crates/proof/tee/nitro-host/src/lib.rs
@@ -10,10 +10,10 @@ mod convert;
 pub use convert::Convert;
 
 mod registration;
-pub use registration::RegistrationChecker;
+pub use registration::{RegistrationChecker, RegistrationError};
 
 mod health;
-pub use health::{RegistrationHealthConfig, RegistrationHealthError, RegistrationHealthzRpc};
+pub use health::{RegistrationHealthConfig, RegistrationHealthzRpc};
 
 mod server;
 pub use server::NitroProverServer;

--- a/crates/proof/tee/nitro-host/src/lib.rs
+++ b/crates/proof/tee/nitro-host/src/lib.rs
@@ -9,6 +9,9 @@ pub use backend::NitroBackend;
 mod convert;
 pub use convert::Convert;
 
+mod registration;
+pub use registration::RegistrationChecker;
+
 mod health;
 pub use health::{RegistrationHealthConfig, RegistrationHealthError, RegistrationHealthzRpc};
 

--- a/crates/proof/tee/nitro-host/src/registration.rs
+++ b/crates/proof/tee/nitro-host/src/registration.rs
@@ -97,17 +97,17 @@ impl RegistrationChecker {
             .copied()
     }
 
-    async fn fetch_validity(&self) -> Result<bool, RegistrationError> {
+    async fn fetch_validity(&self) -> Result<(bool, Address), RegistrationError> {
+        let signer = self.signer_address().await?;
+
         {
             let cache = self.cache.read().await;
             if let Some((valid, checked_at)) = *cache
                 && checked_at.elapsed() < CACHE_TTL
             {
-                return Ok(valid);
+                return Ok((valid, signer));
             }
         }
-
-        let signer = self.signer_address().await?;
 
         let result =
             tokio::time::timeout(CHECK_TIMEOUT, self.registry.is_valid_signer(signer)).await;
@@ -120,7 +120,7 @@ impl RegistrationChecker {
                 if !valid && was_valid != Some(false) {
                     warn!(signer = %signer, "signer is not a valid signer in TEEProverRegistry");
                 }
-                Ok(valid)
+                Ok((valid, signer))
             }
             Ok(Err(e)) => Err(RegistrationError::Rpc { signer, reason: e.to_string() }),
             Err(_) => Err(RegistrationError::Rpc { signer, reason: "request timed out".into() }),
@@ -136,7 +136,7 @@ impl RegistrationChecker {
         if self.healthy.get().is_some() {
             return Ok(true);
         }
-        let valid = self.fetch_validity().await?;
+        let (valid, _) = self.fetch_validity().await?;
         if valid {
             let _ = self.healthy.set(());
         }
@@ -149,11 +149,8 @@ impl RegistrationChecker {
     /// proof request is rejected.
     pub async fn require_valid_signer(&self) -> Result<(), RegistrationError> {
         match self.fetch_validity().await {
-            Ok(true) => Ok(()),
-            Ok(false) => {
-                let signer = self.signer_address().await?;
-                Err(RegistrationError::NotValid { signer })
-            }
+            Ok((true, _)) => Ok(()),
+            Ok((false, signer)) => Err(RegistrationError::NotValid { signer }),
             Err(e) => Err(e),
         }
     }

--- a/crates/proof/tee/nitro-host/src/registration.rs
+++ b/crates/proof/tee/nitro-host/src/registration.rs
@@ -148,33 +148,45 @@ impl RegistrationChecker {
             Err(e @ (RegistrationError::SignerKey(_) | RegistrationError::InvalidPublicKey(_))) => {
                 Err(e)
             }
-            Err(ref rpc_err) => {
-                let signer = match rpc_err {
-                    RegistrationError::L1Rpc { signer, .. }
-                    | RegistrationError::Timeout { signer } => *signer,
-                    _ => unreachable!(),
-                };
-                let cache = self.cache.read().await;
-                if let Some((valid, checked_at)) = *cache {
-                    let elapsed = checked_at.elapsed();
-                    if elapsed < STALE_LIMIT {
-                        warn!(
-                            error = %rpc_err,
-                            signer = %signer,
-                            stale_secs = elapsed.as_secs(),
-                            "L1 RPC failed, using stale cached registration status"
-                        );
-                        return Ok(valid);
-                    }
-                }
-                Err(RegistrationError::StaleExpired {
-                    signer,
-                    stale_secs: cache
-                        .map(|(_, checked_at)| checked_at.elapsed().as_secs())
-                        .unwrap_or(0),
-                })
+            Err(RegistrationError::L1Rpc { signer, reason }) => {
+                self.use_stale_cache_or_fail(signer, RegistrationError::L1Rpc { signer, reason })
+                    .await
+            }
+            Err(RegistrationError::Timeout { signer }) => {
+                self.use_stale_cache_or_fail(signer, RegistrationError::Timeout { signer }).await
+            }
+            Err(
+                e @ (RegistrationError::NotValid { .. } | RegistrationError::StaleExpired { .. }),
+            ) => Err(e),
+        }
+    }
+
+    async fn use_stale_cache_or_fail(
+        &self,
+        signer: Address,
+        rpc_err: RegistrationError,
+    ) -> Result<bool, RegistrationError> {
+        let cache = self.cache.read().await;
+        if let Some((valid, checked_at)) = *cache {
+            let elapsed = checked_at.elapsed();
+            if elapsed < STALE_LIMIT {
+                warn!(
+                    error = %rpc_err,
+                    signer = %signer,
+                    stale_secs = elapsed.as_secs(),
+                    "L1 RPC failed, using stale cached registration status"
+                );
+                return Ok(valid);
             }
         }
+        let stale_secs = cache.map(|(_, checked_at)| checked_at.elapsed().as_secs()).unwrap_or(0);
+        warn!(
+            error = %rpc_err,
+            signer = %signer,
+            stale_secs,
+            "stale cache expired, cannot verify signer"
+        );
+        Err(RegistrationError::StaleExpired { signer, stale_secs })
     }
 
     /// Fails the request unless the signer is currently valid.

--- a/crates/proof/tee/nitro-host/src/registration.rs
+++ b/crates/proof/tee/nitro-host/src/registration.rs
@@ -1,7 +1,10 @@
-//! Shared signer-registration checker backed by the on-chain `TEEProverRegistry`.
+//! Shared signer-validity checker backed by the on-chain `TEEProverRegistry`.
 //!
-//! Used by both the health endpoint (fail-open with stale cache) and the
-//! proving guard (fail-closed) to avoid duplicating L1 contract queries.
+//! Two consumers, two policies:
+//! - **Health endpoint** — latching: once valid, stays healthy forever (avoids
+//!   ASG replacement on transient L1 failures).
+//! - **Proving guard** — fail-closed with a TTL cache: rejects proof requests
+//!   when the signer is invalid or L1 is unreachable.
 
 use std::{
     sync::Arc,
@@ -20,57 +23,41 @@ use super::transport::NitroTransport;
 
 pub(crate) const CACHE_TTL: Duration = Duration::from_secs(30);
 const CHECK_TIMEOUT: Duration = Duration::from_secs(10);
-pub(crate) const STALE_LIMIT: Duration = Duration::from_secs(300);
 
-/// Structured error type for signer-registration checks.
+/// Errors from signer-validity checks.
 #[derive(Debug, Error)]
 pub enum RegistrationError {
-    /// Failed to retrieve the signer public key from the enclave.
-    #[error("failed to get signer public key: {0}")]
-    SignerKey(String),
-    /// The public key bytes are not a valid secp256k1 point.
-    #[error("invalid public key: {0}")]
-    InvalidPublicKey(String),
-    /// The L1 RPC call to check registration status failed.
-    #[error("L1 RPC call failed for signer {signer}: {reason}")]
-    L1Rpc {
+    /// Enclave signer key could not be retrieved or parsed.
+    #[error("signer setup failed: {0}")]
+    Setup(String),
+    /// L1 RPC call failed or timed out.
+    #[error("L1 RPC failed for signer {signer}: {reason}")]
+    Rpc {
         /// The signer address that was being checked.
         signer: Address,
-        /// The underlying RPC error message.
+        /// The underlying error message.
         reason: String,
     },
-    /// The L1 RPC request timed out.
-    #[error("L1 RPC request timed out for signer {signer}")]
-    Timeout {
-        /// The signer address that was being checked.
-        signer: Address,
-    },
-    /// The signer is registered but its image hash does not match, or it is
-    /// not registered at all.
+    /// The signer is not a valid signer in `TEEProverRegistry`.
     #[error("signer {signer} is not a valid signer in TEEProverRegistry")]
     NotValid {
         /// The signer address that failed validation.
         signer: Address,
-    },
-    /// Registration check failed and the stale cache has expired.
-    #[error("registration check failed for {signer}: stale cache expired after {stale_secs}s")]
-    StaleExpired {
-        /// The signer address that was being checked.
-        signer: Address,
-        /// How many seconds the stale cache entry had been held.
-        stale_secs: u64,
     },
 }
 
 /// Checks whether the enclave signer is a **valid** signer in the on-chain
 /// `TEEProverRegistry` (registered AND matching the current image hash).
 ///
-/// Results are cached for [`CACHE_TTL`] to avoid hitting L1 on every request.
+/// Validity results are cached for [`CACHE_TTL`] to avoid hitting L1 on every
+/// request.  A separate latching flag tracks whether the signer has *ever*
+/// been valid — once set, [`check_health`](Self::check_health) always succeeds.
 pub struct RegistrationChecker {
     transport: Arc<NitroTransport>,
     registry: Box<dyn TEEProverRegistryClient>,
     signer: OnceCell<Address>,
     cache: RwLock<Option<(bool, Instant)>>,
+    healthy: OnceCell<()>,
 }
 
 impl std::fmt::Debug for RegistrationChecker {
@@ -90,6 +77,7 @@ impl RegistrationChecker {
             registry: Box::new(registry),
             signer: OnceCell::new(),
             cache: RwLock::new(None),
+            healthy: OnceCell::new(),
         }
     }
 
@@ -100,9 +88,9 @@ impl RegistrationChecker {
                     .transport
                     .signer_public_key()
                     .await
-                    .map_err(|e| RegistrationError::SignerKey(e.to_string()))?;
+                    .map_err(|e| RegistrationError::Setup(format!("signer public key: {e}")))?;
                 let verifying_key = VerifyingKey::from_sec1_bytes(&public_key)
-                    .map_err(|e| RegistrationError::InvalidPublicKey(e.to_string()))?;
+                    .map_err(|e| RegistrationError::Setup(format!("invalid public key: {e}")))?;
                 Ok(public_key_to_address(&verifying_key))
             })
             .await
@@ -134,65 +122,31 @@ impl RegistrationChecker {
                 }
                 Ok(valid)
             }
-            Ok(Err(e)) => Err(RegistrationError::L1Rpc { signer, reason: e.to_string() }),
-            Err(_) => Err(RegistrationError::Timeout { signer }),
+            Ok(Err(e)) => Err(RegistrationError::Rpc { signer, reason: e.to_string() }),
+            Err(_) => Err(RegistrationError::Rpc { signer, reason: "request timed out".into() }),
         }
     }
 
-    /// Returns the cached validity, falling back to stale cache within
-    /// [`STALE_LIMIT`] when L1 is unreachable.  Used by the health endpoint
-    /// (fail-open).
-    pub async fn is_valid_signer_or_stale(&self) -> Result<bool, RegistrationError> {
-        match self.fetch_validity().await {
-            Ok(valid) => Ok(valid),
-            Err(e @ (RegistrationError::SignerKey(_) | RegistrationError::InvalidPublicKey(_))) => {
-                Err(e)
-            }
-            Err(RegistrationError::L1Rpc { signer, reason }) => {
-                self.use_stale_cache_or_fail(signer, RegistrationError::L1Rpc { signer, reason })
-                    .await
-            }
-            Err(RegistrationError::Timeout { signer }) => {
-                self.use_stale_cache_or_fail(signer, RegistrationError::Timeout { signer }).await
-            }
-            Err(
-                e @ (RegistrationError::NotValid { .. } | RegistrationError::StaleExpired { .. }),
-            ) => Err(e),
+    /// Latching health check: returns `true` once the signer has ever been
+    /// confirmed valid, and stays `true` forever after.
+    ///
+    /// Before the first successful validation, delegates to
+    /// [`fetch_validity`](Self::fetch_validity) and returns its result.
+    pub async fn check_health(&self) -> Result<bool, RegistrationError> {
+        if self.healthy.get().is_some() {
+            return Ok(true);
         }
-    }
-
-    async fn use_stale_cache_or_fail(
-        &self,
-        signer: Address,
-        rpc_err: RegistrationError,
-    ) -> Result<bool, RegistrationError> {
-        let cache = self.cache.read().await;
-        if let Some((valid, checked_at)) = *cache {
-            let elapsed = checked_at.elapsed();
-            if elapsed < STALE_LIMIT {
-                warn!(
-                    error = %rpc_err,
-                    signer = %signer,
-                    stale_secs = elapsed.as_secs(),
-                    "L1 RPC failed, using stale cached registration status"
-                );
-                return Ok(valid);
-            }
+        let valid = self.fetch_validity().await?;
+        if valid {
+            let _ = self.healthy.set(());
         }
-        let stale_secs = cache.map(|(_, checked_at)| checked_at.elapsed().as_secs()).unwrap_or(0);
-        warn!(
-            error = %rpc_err,
-            signer = %signer,
-            stale_secs,
-            "stale cache expired, cannot verify signer"
-        );
-        Err(RegistrationError::StaleExpired { signer, stale_secs })
+        Ok(valid)
     }
 
     /// Fails the request unless the signer is currently valid.
     ///
-    /// Fail-closed: does **not** fall back to stale cache.  If L1 is
-    /// unreachable the proof request is rejected.
+    /// Fail-closed: if L1 is unreachable or the signer is not valid, the
+    /// proof request is rejected.
     pub async fn require_valid_signer(&self) -> Result<(), RegistrationError> {
         match self.fetch_validity().await {
             Ok(true) => Ok(()),
@@ -219,11 +173,75 @@ impl RegistrationChecker {
 
 #[cfg(test)]
 mod tests {
-    use std::time::Instant;
+    use std::{
+        sync::{
+            Arc,
+            atomic::{AtomicBool, AtomicUsize, Ordering},
+        },
+        time::Instant,
+    };
 
-    use alloy_primitives::address;
+    use alloy_primitives::{Address, address};
+    use base_proof_contracts::TEEProverRegistryClient;
+    use jsonrpsee::core::async_trait;
 
     use super::*;
+
+    #[derive(Clone)]
+    struct MockRegistry {
+        valid: Arc<AtomicBool>,
+        call_count: Arc<AtomicUsize>,
+        should_fail: Arc<AtomicBool>,
+    }
+
+    impl MockRegistry {
+        fn new(valid: bool) -> Self {
+            Self {
+                valid: Arc::new(AtomicBool::new(valid)),
+                call_count: Arc::new(AtomicUsize::new(0)),
+                should_fail: Arc::new(AtomicBool::new(false)),
+            }
+        }
+    }
+
+    #[async_trait]
+    impl TEEProverRegistryClient for MockRegistry {
+        async fn is_valid_signer(
+            &self,
+            _signer: Address,
+        ) -> Result<bool, base_proof_contracts::ContractError> {
+            self.call_count.fetch_add(1, Ordering::Relaxed);
+            if self.should_fail.load(Ordering::Relaxed) {
+                return Err(base_proof_contracts::ContractError::Validation(
+                    "mock RPC failure".into(),
+                ));
+            }
+            Ok(self.valid.load(Ordering::Relaxed))
+        }
+
+        async fn is_registered_signer(
+            &self,
+            _signer: Address,
+        ) -> Result<bool, base_proof_contracts::ContractError> {
+            unimplemented!()
+        }
+
+        async fn get_registered_signers(
+            &self,
+        ) -> Result<Vec<Address>, base_proof_contracts::ContractError> {
+            unimplemented!()
+        }
+    }
+
+    const TEST_SIGNER: Address = address!("f39Fd6e51aad88F6F4ce6aB8827279cffFb92266");
+
+    fn test_checker_with_mock(
+        registry: impl TEEProverRegistryClient + 'static,
+    ) -> RegistrationChecker {
+        let server = Arc::new(base_proof_tee_nitro_enclave::Server::new_local().unwrap());
+        let transport = Arc::new(NitroTransport::local(server));
+        RegistrationChecker::new(transport, registry)
+    }
 
     fn test_checker() -> RegistrationChecker {
         let server = Arc::new(base_proof_tee_nitro_enclave::Server::new_local().unwrap());
@@ -234,86 +252,108 @@ mod tests {
         RegistrationChecker::new(transport, registry)
     }
 
-    const TEST_SIGNER: Address = address!("f39Fd6e51aad88F6F4ce6aB8827279cffFb92266");
-
     #[tokio::test]
-    async fn stale_cache_returns_cached_value_on_rpc_error() {
-        let checker = test_checker();
-        checker.signer.set(TEST_SIGNER).unwrap();
-        let just_expired = Instant::now() - CACHE_TTL - Duration::from_secs(1);
-        *checker.cache.write().await = Some((true, just_expired));
-        let result = checker.is_valid_signer_or_stale().await;
-        assert!(result.unwrap());
+    async fn health_returns_true_when_valid() {
+        let checker = test_checker_with_mock(MockRegistry::new(true));
+        checker.set_signer_for_test(TEST_SIGNER);
+        assert!(checker.check_health().await.unwrap());
     }
 
     #[tokio::test]
-    async fn stale_cache_fails_when_expired() {
-        let checker = test_checker();
-        checker.signer.set(TEST_SIGNER).unwrap();
-        let expired = Instant::now() - STALE_LIMIT - Duration::from_secs(1);
-        *checker.cache.write().await = Some((true, expired));
-        let result = checker.is_valid_signer_or_stale().await;
-        assert!(result.is_err());
+    async fn health_returns_false_when_not_valid() {
+        let checker = test_checker_with_mock(MockRegistry::new(false));
+        checker.set_signer_for_test(TEST_SIGNER);
+        assert!(!checker.check_health().await.unwrap());
     }
 
     #[tokio::test]
-    async fn stale_cache_fails_when_empty() {
-        let checker = test_checker();
-        checker.signer.set(TEST_SIGNER).unwrap();
-        let result = checker.is_valid_signer_or_stale().await;
-        assert!(result.is_err());
+    async fn health_latches_after_first_success() {
+        let registry = MockRegistry::new(true);
+        let checker = test_checker_with_mock(registry.clone());
+        checker.set_signer_for_test(TEST_SIGNER);
+
+        assert!(checker.check_health().await.unwrap());
+
+        registry.valid.store(false, Ordering::Relaxed);
+        registry.should_fail.store(true, Ordering::Relaxed);
+        checker.set_cache_for_test(None).await;
+
+        assert!(checker.check_health().await.unwrap());
     }
 
     #[tokio::test]
-    async fn cache_hit_within_ttl_returns_valid() {
-        let checker = test_checker();
-        checker.signer.set(TEST_SIGNER).unwrap();
-        *checker.cache.write().await = Some((true, Instant::now()));
-        let result = checker.is_valid_signer_or_stale().await;
-        assert!(result.unwrap());
+    async fn health_errors_on_rpc_failure_before_latch() {
+        let registry = MockRegistry::new(false);
+        registry.should_fail.store(true, Ordering::Relaxed);
+        let checker = test_checker_with_mock(registry);
+        checker.set_signer_for_test(TEST_SIGNER);
+        assert!(checker.check_health().await.is_err());
     }
 
     #[tokio::test]
-    async fn cache_hit_returns_false_when_not_valid() {
-        let checker = test_checker();
-        checker.signer.set(TEST_SIGNER).unwrap();
-        *checker.cache.write().await = Some((false, Instant::now()));
-        let result = checker.is_valid_signer_or_stale().await;
-        assert!(!result.unwrap());
+    async fn health_ok_on_rpc_failure_after_latch() {
+        let registry = MockRegistry::new(true);
+        let checker = test_checker_with_mock(registry.clone());
+        checker.set_signer_for_test(TEST_SIGNER);
+        assert!(checker.check_health().await.unwrap());
+
+        registry.should_fail.store(true, Ordering::Relaxed);
+        checker.set_cache_for_test(None).await;
+        assert!(checker.check_health().await.unwrap());
     }
 
     #[tokio::test]
     async fn require_valid_signer_ok_when_cached_valid() {
         let checker = test_checker();
-        checker.signer.set(TEST_SIGNER).unwrap();
-        *checker.cache.write().await = Some((true, Instant::now()));
+        checker.set_signer_for_test(TEST_SIGNER);
+        checker.set_cache_for_test(Some((true, Instant::now()))).await;
         assert!(checker.require_valid_signer().await.is_ok());
     }
 
     #[tokio::test]
     async fn require_valid_signer_rejects_when_cached_invalid() {
         let checker = test_checker();
-        checker.signer.set(TEST_SIGNER).unwrap();
-        *checker.cache.write().await = Some((false, Instant::now()));
-        let err = checker.require_valid_signer().await.unwrap_err();
-        assert!(matches!(err, RegistrationError::NotValid { .. }));
+        checker.set_signer_for_test(TEST_SIGNER);
+        checker.set_cache_for_test(Some((false, Instant::now()))).await;
+        assert!(matches!(
+            checker.require_valid_signer().await.unwrap_err(),
+            RegistrationError::NotValid { .. }
+        ));
     }
 
     #[tokio::test]
     async fn require_valid_signer_rejects_on_rpc_error() {
         let checker = test_checker();
-        checker.signer.set(TEST_SIGNER).unwrap();
-        let err = checker.require_valid_signer().await.unwrap_err();
-        assert!(matches!(err, RegistrationError::L1Rpc { .. } | RegistrationError::Timeout { .. }));
+        checker.set_signer_for_test(TEST_SIGNER);
+        assert!(matches!(
+            checker.require_valid_signer().await.unwrap_err(),
+            RegistrationError::Rpc { .. }
+        ));
     }
 
     #[tokio::test]
-    async fn require_valid_signer_rejects_on_stale_cache() {
+    async fn require_valid_signer_rejects_on_expired_cache() {
         let checker = test_checker();
-        checker.signer.set(TEST_SIGNER).unwrap();
+        checker.set_signer_for_test(TEST_SIGNER);
         let expired = Instant::now() - CACHE_TTL - Duration::from_secs(1);
-        *checker.cache.write().await = Some((true, expired));
-        let err = checker.require_valid_signer().await.unwrap_err();
-        assert!(matches!(err, RegistrationError::L1Rpc { .. } | RegistrationError::Timeout { .. }));
+        checker.set_cache_for_test(Some((true, expired))).await;
+        assert!(matches!(
+            checker.require_valid_signer().await.unwrap_err(),
+            RegistrationError::Rpc { .. }
+        ));
+    }
+
+    #[tokio::test]
+    async fn cache_hit_within_ttl() {
+        let registry = MockRegistry::new(true);
+        let call_count = Arc::clone(&registry.call_count);
+        let checker = test_checker_with_mock(registry);
+        checker.set_signer_for_test(TEST_SIGNER);
+
+        assert!(checker.require_valid_signer().await.is_ok());
+        assert_eq!(call_count.load(Ordering::Relaxed), 1);
+
+        assert!(checker.require_valid_signer().await.is_ok());
+        assert_eq!(call_count.load(Ordering::Relaxed), 1);
     }
 }

--- a/crates/proof/tee/nitro-host/src/registration.rs
+++ b/crates/proof/tee/nitro-host/src/registration.rs
@@ -5,6 +5,17 @@
 //!   ASG replacement on transient L1 failures).
 //! - **Proving guard** — fail-closed with a TTL cache: rejects proof requests
 //!   when the signer is invalid or L1 is unreachable.
+//!
+//! # Trade-off: latching health after deregistration
+//!
+//! After a signer deregistration or image rotation the health latch stays set
+//! while the proving guard rejects every request.  The prover will continue
+//! receiving traffic from the load balancer (because `/healthz` returns 200)
+//! but respond with `-32001` errors.  This is intentional: the ASG must not
+//! terminate the instance on a transient L1 blip, and proof-request callers
+//! already retry on other nodes.  If `/healthz` is ever the **sole** LB
+//! signal with no retry layer, switch to a bounded latch (e.g. stay healthy
+//! for N minutes after the last successful validation).
 
 use std::{
     sync::Arc,
@@ -128,10 +139,9 @@ impl RegistrationChecker {
     }
 
     /// Latching health check: returns `true` once the signer has ever been
-    /// confirmed valid, and stays `true` forever after.
-    ///
-    /// Before the first successful validation, delegates to
-    /// [`fetch_validity`](Self::fetch_validity) and returns its result.
+    /// confirmed valid, and stays `true` forever after — even if the signer
+    /// is later deregistered.  See the [module-level docs](self) for the
+    /// trade-off this implies.
     pub async fn check_health(&self) -> Result<bool, RegistrationError> {
         if self.healthy.get().is_some() {
             return Ok(true);

--- a/crates/proof/tee/nitro-host/src/registration.rs
+++ b/crates/proof/tee/nitro-host/src/registration.rs
@@ -1,0 +1,259 @@
+//! Shared signer-registration checker backed by the on-chain `TEEProverRegistry`.
+//!
+//! Used by both the health endpoint (fail-open with stale cache) and the
+//! proving guard (fail-closed) to avoid duplicating L1 contract queries.
+
+use std::{
+    sync::Arc,
+    time::{Duration, Instant},
+};
+
+use alloy_primitives::Address;
+use alloy_signer::utils::public_key_to_address;
+use base_proof_contracts::TEEProverRegistryClient;
+use k256::ecdsa::VerifyingKey;
+use tokio::sync::{OnceCell, RwLock};
+use tracing::warn;
+
+use super::transport::NitroTransport;
+
+pub(crate) const CACHE_TTL: Duration = Duration::from_secs(30);
+const CHECK_TIMEOUT: Duration = Duration::from_secs(10);
+pub(crate) const STALE_LIMIT: Duration = Duration::from_secs(300);
+
+/// Checks whether the enclave signer is a **valid** signer in the on-chain
+/// `TEEProverRegistry` (registered AND matching the current image hash).
+///
+/// Results are cached for [`CACHE_TTL`] to avoid hitting L1 on every request.
+pub struct RegistrationChecker {
+    transport: Arc<NitroTransport>,
+    registry: Box<dyn TEEProverRegistryClient>,
+    signer: OnceCell<Address>,
+    cache: RwLock<Option<(bool, Instant)>>,
+}
+
+impl std::fmt::Debug for RegistrationChecker {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("RegistrationChecker").finish_non_exhaustive()
+    }
+}
+
+impl RegistrationChecker {
+    /// Creates a new checker for the given transport and registry client.
+    pub fn new(
+        transport: Arc<NitroTransport>,
+        registry: impl TEEProverRegistryClient + 'static,
+    ) -> Self {
+        Self {
+            transport,
+            registry: Box::new(registry),
+            signer: OnceCell::new(),
+            cache: RwLock::new(None),
+        }
+    }
+
+    async fn signer_address(&self) -> Result<Address, String> {
+        self.signer
+            .get_or_try_init(|| async {
+                let public_key = self
+                    .transport
+                    .signer_public_key()
+                    .await
+                    .map_err(|e| format!("failed to get signer public key: {e}"))?;
+                let verifying_key = VerifyingKey::from_sec1_bytes(&public_key)
+                    .map_err(|e| format!("invalid public key: {e}"))?;
+                Ok(public_key_to_address(&verifying_key))
+            })
+            .await
+            .copied()
+    }
+
+    async fn fetch_validity(&self) -> Result<bool, FetchError> {
+        {
+            let cache = self.cache.read().await;
+            if let Some((valid, checked_at)) = *cache
+                && checked_at.elapsed() < CACHE_TTL
+            {
+                return Ok(valid);
+            }
+        }
+
+        let signer = self.signer_address().await.map_err(FetchError::Setup)?;
+
+        let result =
+            tokio::time::timeout(CHECK_TIMEOUT, self.registry.is_valid_signer(signer)).await;
+
+        match result {
+            Ok(Ok(valid)) => {
+                let mut cache = self.cache.write().await;
+                let was_valid = cache.map(|(v, _)| v);
+                *cache = Some((valid, Instant::now()));
+                if !valid && was_valid != Some(false) {
+                    warn!(signer = %signer, "signer is not a valid signer in TEEProverRegistry");
+                }
+                Ok(valid)
+            }
+            Ok(Err(e)) => Err(FetchError::Rpc { signer, reason: e.to_string() }),
+            Err(_) => Err(FetchError::Rpc { signer, reason: "L1 RPC request timed out".into() }),
+        }
+    }
+
+    /// Returns the cached validity, falling back to stale cache within
+    /// [`STALE_LIMIT`] when L1 is unreachable.  Used by the health endpoint
+    /// (fail-open).
+    pub async fn is_valid_signer_or_stale(&self) -> Result<bool, String> {
+        match self.fetch_validity().await {
+            Ok(valid) => Ok(valid),
+            Err(FetchError::Setup(msg)) => Err(msg),
+            Err(FetchError::Rpc { signer, reason }) => {
+                let cache = self.cache.read().await;
+                if let Some((valid, checked_at)) = *cache {
+                    let elapsed = checked_at.elapsed();
+                    if elapsed < STALE_LIMIT {
+                        warn!(
+                            error = %reason,
+                            signer = %signer,
+                            stale_secs = elapsed.as_secs(),
+                            "L1 RPC failed, using stale cached registration status"
+                        );
+                        return Ok(valid);
+                    }
+                }
+                Err(format!("failed to check registration for {signer}: {reason}"))
+            }
+        }
+    }
+
+    /// Fails the request unless the signer is currently valid.
+    ///
+    /// Fail-closed: does **not** fall back to stale cache.  If L1 is
+    /// unreachable the proof request is rejected.
+    pub async fn require_valid_signer(&self) -> Result<(), String> {
+        match self.fetch_validity().await {
+            Ok(true) => Ok(()),
+            Ok(false) => Err("signer is not a valid signer in TEEProverRegistry".into()),
+            Err(FetchError::Setup(msg)) => Err(msg),
+            Err(FetchError::Rpc { signer, reason }) => {
+                Err(format!("failed to verify signer {signer}: {reason}"))
+            }
+        }
+    }
+}
+
+enum FetchError {
+    Setup(String),
+    Rpc { signer: Address, reason: String },
+}
+
+impl RegistrationChecker {
+    #[cfg(test)]
+    pub(crate) fn set_signer_for_test(&self, signer: Address) {
+        let _ = self.signer.set(signer);
+    }
+
+    #[cfg(test)]
+    pub(crate) async fn set_cache_for_test(&self, value: Option<(bool, Instant)>) {
+        *self.cache.write().await = value;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Instant;
+
+    use alloy_primitives::address;
+
+    use super::*;
+
+    fn test_checker() -> RegistrationChecker {
+        let server = Arc::new(base_proof_tee_nitro_enclave::Server::new_local().unwrap());
+        let transport = Arc::new(NitroTransport::local(server));
+        let dummy_url = url::Url::parse("http://localhost:1").unwrap();
+        let registry =
+            base_proof_contracts::TEEProverRegistryContractClient::new(Address::ZERO, dummy_url);
+        RegistrationChecker::new(transport, registry)
+    }
+
+    const TEST_SIGNER: Address = address!("f39Fd6e51aad88F6F4ce6aB8827279cffFb92266");
+
+    #[tokio::test]
+    async fn stale_cache_returns_cached_value_on_rpc_error() {
+        let checker = test_checker();
+        checker.signer.set(TEST_SIGNER).unwrap();
+        let just_expired = Instant::now() - CACHE_TTL - Duration::from_secs(1);
+        *checker.cache.write().await = Some((true, just_expired));
+        let result = checker.is_valid_signer_or_stale().await;
+        assert!(result.unwrap());
+    }
+
+    #[tokio::test]
+    async fn stale_cache_fails_when_expired() {
+        let checker = test_checker();
+        checker.signer.set(TEST_SIGNER).unwrap();
+        let expired = Instant::now() - STALE_LIMIT - Duration::from_secs(1);
+        *checker.cache.write().await = Some((true, expired));
+        let result = checker.is_valid_signer_or_stale().await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn stale_cache_fails_when_empty() {
+        let checker = test_checker();
+        checker.signer.set(TEST_SIGNER).unwrap();
+        let result = checker.is_valid_signer_or_stale().await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn cache_hit_within_ttl_returns_valid() {
+        let checker = test_checker();
+        checker.signer.set(TEST_SIGNER).unwrap();
+        *checker.cache.write().await = Some((true, Instant::now()));
+        let result = checker.is_valid_signer_or_stale().await;
+        assert!(result.unwrap());
+    }
+
+    #[tokio::test]
+    async fn cache_hit_returns_false_when_not_valid() {
+        let checker = test_checker();
+        checker.signer.set(TEST_SIGNER).unwrap();
+        *checker.cache.write().await = Some((false, Instant::now()));
+        let result = checker.is_valid_signer_or_stale().await;
+        assert!(!result.unwrap());
+    }
+
+    #[tokio::test]
+    async fn require_valid_signer_ok_when_cached_valid() {
+        let checker = test_checker();
+        checker.signer.set(TEST_SIGNER).unwrap();
+        *checker.cache.write().await = Some((true, Instant::now()));
+        assert!(checker.require_valid_signer().await.is_ok());
+    }
+
+    #[tokio::test]
+    async fn require_valid_signer_rejects_when_cached_invalid() {
+        let checker = test_checker();
+        checker.signer.set(TEST_SIGNER).unwrap();
+        *checker.cache.write().await = Some((false, Instant::now()));
+        let err = checker.require_valid_signer().await.unwrap_err();
+        assert!(err.contains("not a valid signer"));
+    }
+
+    #[tokio::test]
+    async fn require_valid_signer_rejects_on_rpc_error() {
+        let checker = test_checker();
+        checker.signer.set(TEST_SIGNER).unwrap();
+        let err = checker.require_valid_signer().await.unwrap_err();
+        assert!(err.contains("failed to verify signer"));
+    }
+
+    #[tokio::test]
+    async fn require_valid_signer_rejects_on_stale_cache() {
+        let checker = test_checker();
+        checker.signer.set(TEST_SIGNER).unwrap();
+        let expired = Instant::now() - CACHE_TTL - Duration::from_secs(1);
+        *checker.cache.write().await = Some((true, expired));
+        let err = checker.require_valid_signer().await.unwrap_err();
+        assert!(err.contains("failed to verify signer"));
+    }
+}

--- a/crates/proof/tee/nitro-host/src/registration.rs
+++ b/crates/proof/tee/nitro-host/src/registration.rs
@@ -12,6 +12,7 @@ use alloy_primitives::Address;
 use alloy_signer::utils::public_key_to_address;
 use base_proof_contracts::TEEProverRegistryClient;
 use k256::ecdsa::VerifyingKey;
+use thiserror::Error;
 use tokio::sync::{OnceCell, RwLock};
 use tracing::warn;
 
@@ -20,6 +21,46 @@ use super::transport::NitroTransport;
 pub(crate) const CACHE_TTL: Duration = Duration::from_secs(30);
 const CHECK_TIMEOUT: Duration = Duration::from_secs(10);
 pub(crate) const STALE_LIMIT: Duration = Duration::from_secs(300);
+
+/// Structured error type for signer-registration checks.
+#[derive(Debug, Error)]
+pub enum RegistrationError {
+    /// Failed to retrieve the signer public key from the enclave.
+    #[error("failed to get signer public key: {0}")]
+    SignerKey(String),
+    /// The public key bytes are not a valid secp256k1 point.
+    #[error("invalid public key: {0}")]
+    InvalidPublicKey(String),
+    /// The L1 RPC call to check registration status failed.
+    #[error("L1 RPC call failed for signer {signer}: {reason}")]
+    L1Rpc {
+        /// The signer address that was being checked.
+        signer: Address,
+        /// The underlying RPC error message.
+        reason: String,
+    },
+    /// The L1 RPC request timed out.
+    #[error("L1 RPC request timed out for signer {signer}")]
+    Timeout {
+        /// The signer address that was being checked.
+        signer: Address,
+    },
+    /// The signer is registered but its image hash does not match, or it is
+    /// not registered at all.
+    #[error("signer {signer} is not a valid signer in TEEProverRegistry")]
+    NotValid {
+        /// The signer address that failed validation.
+        signer: Address,
+    },
+    /// Registration check failed and the stale cache has expired.
+    #[error("registration check failed for {signer}: stale cache expired after {stale_secs}s")]
+    StaleExpired {
+        /// The signer address that was being checked.
+        signer: Address,
+        /// How many seconds the stale cache entry had been held.
+        stale_secs: u64,
+    },
+}
 
 /// Checks whether the enclave signer is a **valid** signer in the on-chain
 /// `TEEProverRegistry` (registered AND matching the current image hash).
@@ -52,23 +93,23 @@ impl RegistrationChecker {
         }
     }
 
-    async fn signer_address(&self) -> Result<Address, String> {
+    async fn signer_address(&self) -> Result<Address, RegistrationError> {
         self.signer
             .get_or_try_init(|| async {
                 let public_key = self
                     .transport
                     .signer_public_key()
                     .await
-                    .map_err(|e| format!("failed to get signer public key: {e}"))?;
+                    .map_err(|e| RegistrationError::SignerKey(e.to_string()))?;
                 let verifying_key = VerifyingKey::from_sec1_bytes(&public_key)
-                    .map_err(|e| format!("invalid public key: {e}"))?;
+                    .map_err(|e| RegistrationError::InvalidPublicKey(e.to_string()))?;
                 Ok(public_key_to_address(&verifying_key))
             })
             .await
             .copied()
     }
 
-    async fn fetch_validity(&self) -> Result<bool, FetchError> {
+    async fn fetch_validity(&self) -> Result<bool, RegistrationError> {
         {
             let cache = self.cache.read().await;
             if let Some((valid, checked_at)) = *cache
@@ -78,7 +119,7 @@ impl RegistrationChecker {
             }
         }
 
-        let signer = self.signer_address().await.map_err(FetchError::Setup)?;
+        let signer = self.signer_address().await?;
 
         let result =
             tokio::time::timeout(CHECK_TIMEOUT, self.registry.is_valid_signer(signer)).await;
@@ -93,25 +134,32 @@ impl RegistrationChecker {
                 }
                 Ok(valid)
             }
-            Ok(Err(e)) => Err(FetchError::Rpc { signer, reason: e.to_string() }),
-            Err(_) => Err(FetchError::Rpc { signer, reason: "L1 RPC request timed out".into() }),
+            Ok(Err(e)) => Err(RegistrationError::L1Rpc { signer, reason: e.to_string() }),
+            Err(_) => Err(RegistrationError::Timeout { signer }),
         }
     }
 
     /// Returns the cached validity, falling back to stale cache within
     /// [`STALE_LIMIT`] when L1 is unreachable.  Used by the health endpoint
     /// (fail-open).
-    pub async fn is_valid_signer_or_stale(&self) -> Result<bool, String> {
+    pub async fn is_valid_signer_or_stale(&self) -> Result<bool, RegistrationError> {
         match self.fetch_validity().await {
             Ok(valid) => Ok(valid),
-            Err(FetchError::Setup(msg)) => Err(msg),
-            Err(FetchError::Rpc { signer, reason }) => {
+            Err(e @ (RegistrationError::SignerKey(_) | RegistrationError::InvalidPublicKey(_))) => {
+                Err(e)
+            }
+            Err(ref rpc_err) => {
+                let signer = match rpc_err {
+                    RegistrationError::L1Rpc { signer, .. }
+                    | RegistrationError::Timeout { signer } => *signer,
+                    _ => unreachable!(),
+                };
                 let cache = self.cache.read().await;
                 if let Some((valid, checked_at)) = *cache {
                     let elapsed = checked_at.elapsed();
                     if elapsed < STALE_LIMIT {
                         warn!(
-                            error = %reason,
+                            error = %rpc_err,
                             signer = %signer,
                             stale_secs = elapsed.as_secs(),
                             "L1 RPC failed, using stale cached registration status"
@@ -119,7 +167,12 @@ impl RegistrationChecker {
                         return Ok(valid);
                     }
                 }
-                Err(format!("failed to check registration for {signer}: {reason}"))
+                Err(RegistrationError::StaleExpired {
+                    signer,
+                    stale_secs: cache
+                        .map(|(_, checked_at)| checked_at.elapsed().as_secs())
+                        .unwrap_or(0),
+                })
             }
         }
     }
@@ -128,21 +181,16 @@ impl RegistrationChecker {
     ///
     /// Fail-closed: does **not** fall back to stale cache.  If L1 is
     /// unreachable the proof request is rejected.
-    pub async fn require_valid_signer(&self) -> Result<(), String> {
+    pub async fn require_valid_signer(&self) -> Result<(), RegistrationError> {
         match self.fetch_validity().await {
             Ok(true) => Ok(()),
-            Ok(false) => Err("signer is not a valid signer in TEEProverRegistry".into()),
-            Err(FetchError::Setup(msg)) => Err(msg),
-            Err(FetchError::Rpc { signer, reason }) => {
-                Err(format!("failed to verify signer {signer}: {reason}"))
+            Ok(false) => {
+                let signer = self.signer_address().await?;
+                Err(RegistrationError::NotValid { signer })
             }
+            Err(e) => Err(e),
         }
     }
-}
-
-enum FetchError {
-    Setup(String),
-    Rpc { signer: Address, reason: String },
 }
 
 impl RegistrationChecker {
@@ -236,7 +284,7 @@ mod tests {
         checker.signer.set(TEST_SIGNER).unwrap();
         *checker.cache.write().await = Some((false, Instant::now()));
         let err = checker.require_valid_signer().await.unwrap_err();
-        assert!(err.contains("not a valid signer"));
+        assert!(matches!(err, RegistrationError::NotValid { .. }));
     }
 
     #[tokio::test]
@@ -244,7 +292,7 @@ mod tests {
         let checker = test_checker();
         checker.signer.set(TEST_SIGNER).unwrap();
         let err = checker.require_valid_signer().await.unwrap_err();
-        assert!(err.contains("failed to verify signer"));
+        assert!(matches!(err, RegistrationError::L1Rpc { .. } | RegistrationError::Timeout { .. }));
     }
 
     #[tokio::test]
@@ -254,6 +302,6 @@ mod tests {
         let expired = Instant::now() - CACHE_TTL - Duration::from_secs(1);
         *checker.cache.write().await = Some((true, expired));
         let err = checker.require_valid_signer().await.unwrap_err();
-        assert!(err.contains("failed to verify signer"));
+        assert!(matches!(err, RegistrationError::L1Rpc { .. } | RegistrationError::Timeout { .. }));
     }
 }

--- a/crates/proof/tee/nitro-host/src/server.rs
+++ b/crates/proof/tee/nitro-host/src/server.rs
@@ -14,6 +14,7 @@ use tracing::{info, warn};
 use super::{
     NitroBackend,
     health::{RegistrationHealthConfig, RegistrationHealthzRpc},
+    registration::RegistrationChecker,
     transport::NitroTransport,
 };
 
@@ -73,35 +74,41 @@ impl NitroProverServer {
         info!(addr = %addr, "nitro rpc server started");
 
         let mut module = RpcModule::new(());
-        module.merge(
-            NitroProverRpc {
-                service: self.service,
-                proof_request_timeout: self.proof_request_timeout,
-            }
-            .into_rpc(),
-        )?;
 
-        module.merge(NitroSignerRpc { transport: Arc::clone(&self.transport) }.into_rpc())?;
-
-        match self.registration_health {
+        let checker = match self.registration_health {
             Some(config) => {
                 info!(
                     registry = %config.registry_address,
-                    "registration-gated health check enabled"
+                    "registration-gated health and proving guard enabled"
                 );
                 let l1_url = url::Url::parse(&config.l1_rpc_url)
                     .map_err(|e| eyre::eyre!("invalid L1 RPC URL: {e}"))?;
                 let registry =
                     TEEProverRegistryContractClient::new(config.registry_address, l1_url);
-                let version = env!("CARGO_PKG_VERSION");
-                let transport = Arc::clone(&self.transport);
-                module
-                    .merge(RegistrationHealthzRpc::new(version, transport, registry).into_rpc())?;
+                let checker =
+                    Arc::new(RegistrationChecker::new(Arc::clone(&self.transport), registry));
+                module.merge(
+                    RegistrationHealthzRpc::new(env!("CARGO_PKG_VERSION"), Arc::clone(&checker))
+                        .into_rpc(),
+                )?;
+                Some(checker)
             }
             None => {
                 module.merge(HealthzRpc::new(env!("CARGO_PKG_VERSION")).into_rpc())?;
+                None
             }
-        }
+        };
+
+        module.merge(
+            NitroProverRpc {
+                service: self.service,
+                proof_request_timeout: self.proof_request_timeout,
+                checker,
+            }
+            .into_rpc(),
+        )?;
+
+        module.merge(NitroSignerRpc { transport: Arc::clone(&self.transport) }.into_rpc())?;
 
         Ok(server.start(module))
     }
@@ -111,11 +118,19 @@ impl NitroProverServer {
 struct NitroProverRpc {
     service: ProverService<NitroBackend>,
     proof_request_timeout: Duration,
+    checker: Option<Arc<RegistrationChecker>>,
 }
 
 #[async_trait]
 impl ProverApiServer for NitroProverRpc {
     async fn prove(&self, request: ProofRequest) -> RpcResult<ProofResult> {
+        if let Some(checker) = &self.checker {
+            checker.require_valid_signer().await.map_err(|reason| {
+                warn!(error = %reason, "rejecting proof request: signer validation failed");
+                jsonrpsee::types::ErrorObjectOwned::owned(-32001, reason, None::<()>)
+            })?;
+        }
+
         let l2_block = request.claimed_l2_block_number;
         let timeout = self.proof_request_timeout;
 

--- a/crates/proof/tee/nitro-host/src/server.rs
+++ b/crates/proof/tee/nitro-host/src/server.rs
@@ -125,9 +125,9 @@ struct NitroProverRpc {
 impl ProverApiServer for NitroProverRpc {
     async fn prove(&self, request: ProofRequest) -> RpcResult<ProofResult> {
         if let Some(checker) = &self.checker {
-            checker.require_valid_signer().await.map_err(|reason| {
-                warn!(error = %reason, "rejecting proof request: signer validation failed");
-                jsonrpsee::types::ErrorObjectOwned::owned(-32001, reason, None::<()>)
+            checker.require_valid_signer().await.map_err(|e| {
+                warn!(error = %e, "rejecting proof request: signer validation failed");
+                jsonrpsee::types::ErrorObjectOwned::owned(-32001, e.to_string(), None::<()>)
             })?;
         }
 


### PR DESCRIPTION
## Summary

- Adds a registration guard to the nitro-host proving path that calls `isValidSigner` on the `TEEProverRegistry` **before** expensive witness generation, saving minutes of wasted work during prover switchovers and image rotations.
- Extracts shared `RegistrationChecker` into `registration.rs` so both the health endpoint and the proving guard reuse the same cached L1 contract query.
- **Proving guard** — fail-closed: if L1 is unreachable or the signer is invalid, proof requests are rejected immediately with `-32001`.
- **Health endpoint** — latching: once the signer has been confirmed valid, `/healthz` returns 200 forever (avoids ASG replacement on transient L1 failures). See module docs for the trade-off this implies after deregistration.

## Motivation

During prover switchovers, the old prover continues receiving proof requests and performs full witness generation (L1/L2 RPC calls, fault-proof replay, preimage capture) only for the resulting proof to be rejected downstream by the proposer's own `isValidSigner` check. This wastes significant time and resources. By checking validity upfront, we short-circuit immediately.

## Changes

| File | What |
|------|------|
| `registration.rs` | **New** — `RegistrationChecker` with `isValidSigner` caching, `require_valid_signer` (fail-closed), `check_health` (latching). `RegistrationError` with 3 variants: `Setup`, `Rpc`, `NotValid`. |
| `health.rs` | Simplified to delegate to `RegistrationChecker::check_health()` |
| `server.rs` | `NitroProverRpc::prove` guards with `require_valid_signer()` before `prove_block()` |
| `lib.rs` | Exports `RegistrationChecker` and `RegistrationError` |

## Testing

- 24 tests passing (11 in `registration.rs`, 5 in `health.rs`, 8 existing in `server.rs`/`backend.rs`/`convert.rs`)
- `cargo check -p base-proof-tee-nitro-host` — zero warnings
- `cargo check -p base-prover-nitro-host --features local` — binary compiles