### PR TITLE
feat(challenger): add failure metrics to bond game evaluation

### DIFF
--- a/crates/proof/challenge/src/bond.rs
+++ b/crates/proof/challenge/src/bond.rs
@@ -247,6 +247,10 @@ impl BondManager {
             Ok(g) => g,
             Err(e) => {
                 warn!(index, error = %e, "failed to fetch game at index");
+                ChallengerMetrics::bond_evaluation_errors_total(
+                    ChallengerMetrics::EVAL_ERROR_GAME_FETCH,
+                )
+                .increment(1);
                 return None;
             }
         };
@@ -264,6 +268,10 @@ impl BondManager {
                     error = %e,
                     "failed to read bondRecipient/zkProver"
                 );
+                ChallengerMetrics::bond_evaluation_errors_total(
+                    ChallengerMetrics::EVAL_ERROR_BOND_READ,
+                )
+                .increment(1);
                 return None;
             }
         };
@@ -290,6 +298,10 @@ impl BondManager {
                     error = %e,
                     "failed to determine bond phase"
                 );
+                ChallengerMetrics::bond_evaluation_errors_total(
+                    ChallengerMetrics::EVAL_ERROR_PHASE_READ,
+                )
+                .increment(1);
                 return None;
             }
         };

--- a/crates/proof/challenge/src/metrics.rs
+++ b/crates/proof/challenge/src/metrics.rs
@@ -89,6 +89,10 @@ base_metrics::define_metrics! {
 
     #[describe("Total claimable games found by bond discovery")]
     bond_discovery_games_found_total: counter,
+
+    #[describe("Total bond evaluation failures by error type")]
+    #[label(error_type)]
+    bond_evaluation_errors_total: counter,
 }
 
 impl ChallengerMetrics {
@@ -104,4 +108,13 @@ impl ChallengerMetrics {
     /// Label value when a resolve was skipped because the game was already
     /// resolved on-chain (e.g. by another actor).
     pub const STATUS_ALREADY_RESOLVED: &str = "already_resolved";
+
+    /// Label value for a game fetch failure during bond evaluation.
+    pub const EVAL_ERROR_GAME_FETCH: &str = "game_fetch";
+
+    /// Label value for a bond recipient/zk prover read failure.
+    pub const EVAL_ERROR_BOND_READ: &str = "bond_read";
+
+    /// Label value for a bond phase determination failure.
+    pub const EVAL_ERROR_PHASE_READ: &str = "phase_read";
 }


### PR DESCRIPTION
## Summary

- Adds a `bond_evaluation_errors_total` counter (labeled by `error_type`) to track RPC failures in `evaluate_game_for_bonds`
- Increments the counter on `game_at_index` fetch failures (`game_fetch`) and `bondRecipient`/`zkProver` read failures (`bond_read`)
- Enables alerting on unexpected spikes in bond evaluation failures

Closes CHAIN-3896