### PR TITLE
docs(baseup): document automatic shell PATH configuration

### DIFF
--- a/baseup/README.md
+++ b/baseup/README.md
@@ -54,6 +54,22 @@ or
 ```bash
 BASE_BIN_DIR=/custom/path/bin baseup
 ```
+## Shell Configuration
+
+The installer automatically configures your shell by:
+- Creating `~/.base/env` with `export PATH="$HOME/.base/bin:$PATH"`
+- Adding `. ~/.base/env` to your shell config (`.bashrc`, `.zshrc`, `.bash_profile`, `.profile`)
+- Creating `~/.base/env.fish` for Fish shell users
+
+To apply immediately without restarting your shell, run:
+```bash
+source ~/.base/env
+```
+
+For Fish shell:
+```fish
+source ~/.base/env.fish
+```
 
 ## Hosting
 


### PR DESCRIPTION
Fixes #1995

## Summary

The `baseup/README.md` documented the installation directory but did not mention that the installer automatically configures the user's shell PATH.

The `install` script creates `~/.base/env` and appends it to shell config files (`.bashrc`, `.zshrc`, etc.), but this behavior was undocumented.

## Changes
- Added "Shell Configuration" section to `baseup/README.md`
- Documents the automatic shell config behavior
- Includes instructions to apply PATH immediately without restarting shell
- Covers both bash/zsh and Fish shell