### PR TITLE
chore(consensus): Parameterize Tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3350,6 +3350,7 @@ dependencies = [
  "base-alloy-chains",
  "derive_more",
  "rand 0.9.2",
+ "rstest",
  "serde",
  "serde_json",
  "thiserror 2.0.18",

--- a/actions/harness/src/miner.rs
+++ b/actions/harness/src/miner.rs
@@ -5,7 +5,7 @@ use alloy_eips::eip4844::Blob;
 use alloy_primitives::{Address, B256, Bytes, Log, LogData, U256};
 use base_batcher_encoder::FrameEncoder;
 use base_blobs::BlobEncoder;
-use base_consensus_genesis::{CONFIG_UPDATE_EVENT_VERSION_0, CONFIG_UPDATE_TOPIC};
+use base_consensus_genesis::SystemConfigUpdate;
 use base_protocol::{BlockInfo, Deposits, Frame};
 use tracing::info;
 
@@ -255,7 +255,7 @@ impl L1Miner {
         self.enqueue_log(Log {
             address: l1_sys_cfg_addr,
             data: LogData::new_unchecked(
-                vec![CONFIG_UPDATE_TOPIC, CONFIG_UPDATE_EVENT_VERSION_0, B256::ZERO],
+                vec![SystemConfigUpdate::TOPIC, SystemConfigUpdate::EVENT_VERSION_0, B256::ZERO],
                 data.into(),
             ),
         });
@@ -281,7 +281,11 @@ impl L1Miner {
         self.enqueue_log(Log {
             address: l1_sys_cfg_addr,
             data: LogData::new_unchecked(
-                vec![CONFIG_UPDATE_TOPIC, CONFIG_UPDATE_EVENT_VERSION_0, B256::from(update_type)],
+                vec![
+                    SystemConfigUpdate::TOPIC,
+                    SystemConfigUpdate::EVENT_VERSION_0,
+                    B256::from(update_type),
+                ],
                 data.into(),
             ),
         });
@@ -298,7 +302,11 @@ impl L1Miner {
         self.enqueue_log(Log {
             address: l1_sys_cfg_addr,
             data: LogData::new_unchecked(
-                vec![CONFIG_UPDATE_TOPIC, CONFIG_UPDATE_EVENT_VERSION_0, B256::from(update_type)],
+                vec![
+                    SystemConfigUpdate::TOPIC,
+                    SystemConfigUpdate::EVENT_VERSION_0,
+                    B256::from(update_type),
+                ],
                 data.into(),
             ),
         });
@@ -323,7 +331,11 @@ impl L1Miner {
         self.enqueue_log(Log {
             address: l1_sys_cfg_addr,
             data: LogData::new_unchecked(
-                vec![CONFIG_UPDATE_TOPIC, CONFIG_UPDATE_EVENT_VERSION_0, B256::from(update_type)],
+                vec![
+                    SystemConfigUpdate::TOPIC,
+                    SystemConfigUpdate::EVENT_VERSION_0,
+                    B256::from(update_type),
+                ],
                 data.into(),
             ),
         });

--- a/crates/consensus/derive/src/attributes/stateful.rs
+++ b/crates/consensus/derive/src/attributes/stateful.rs
@@ -260,7 +260,7 @@ mod tests {
 
     use alloy_consensus::Header;
     use alloy_primitives::{B256, Log, LogData, U64, U256, address};
-    use base_consensus_genesis::{CONFIG_UPDATE_TOPIC, HardForkConfig, SystemConfig};
+    use base_consensus_genesis::{HardForkConfig, SystemConfig, SystemConfigUpdate};
     use base_consensus_registry::Sepolia;
     use base_protocol::{BlockInfo, DepositDecodeError};
 
@@ -680,7 +680,7 @@ mod tests {
         // causing update_with_receipts to return an error.
         let bad_log = Log {
             address: sys_config_addr,
-            data: LogData::new_unchecked(vec![CONFIG_UPDATE_TOPIC], Bytes::default()),
+            data: LogData::new_unchecked(vec![SystemConfigUpdate::TOPIC], Bytes::default()),
         };
         let bad_receipt = Receipt {
             status: Eip658Value::Eip658(true),

--- a/crates/consensus/derive/src/stages/traversal/indexed.rs
+++ b/crates/consensus/derive/src/stages/traversal/indexed.rs
@@ -161,7 +161,7 @@ mod tests {
     use alloy_consensus::Receipt;
     use alloy_eips::BlockNumHash;
     use alloy_primitives::{B256, Bytes, Log, LogData, U256, address, b256};
-    use base_consensus_genesis::{CONFIG_UPDATE_EVENT_VERSION_0, CONFIG_UPDATE_TOPIC};
+    use base_consensus_genesis::SystemConfigUpdate;
 
     use super::*;
     use crate::{errors::PipelineErrorKind, test_utils::TestChainProvider};
@@ -178,7 +178,7 @@ mod tests {
         Log {
             address: L1_SYS_CONFIG_ADDR,
             data: LogData::new_unchecked(
-                vec![CONFIG_UPDATE_TOPIC, CONFIG_UPDATE_EVENT_VERSION_0, B256::ZERO],
+                vec![SystemConfigUpdate::TOPIC, SystemConfigUpdate::EVENT_VERSION_0, B256::ZERO],
                 data.into(),
             ),
         }
@@ -193,7 +193,7 @@ mod tests {
             Receipt { status: alloy_consensus::Eip658Value::Eip658(true), ..Receipt::default() };
         let bad = Log::new(
             Address::from([2; 20]),
-            vec![CONFIG_UPDATE_TOPIC, B256::default()],
+            vec![SystemConfigUpdate::TOPIC, B256::default()],
             Bytes::default(),
         )
         .unwrap();
@@ -354,7 +354,7 @@ mod tests {
         Log {
             address: L1_SYS_CONFIG_ADDR,
             data: LogData::new_unchecked(
-                vec![CONFIG_UPDATE_TOPIC, CONFIG_UPDATE_EVENT_VERSION_0, update_type],
+                vec![SystemConfigUpdate::TOPIC, SystemConfigUpdate::EVENT_VERSION_0, update_type],
                 data.into(),
             ),
         }

--- a/crates/consensus/derive/src/test_utils/traversal.rs
+++ b/crates/consensus/derive/src/test_utils/traversal.rs
@@ -4,7 +4,7 @@ use alloc::{sync::Arc, vec};
 
 use alloy_consensus::Receipt;
 use alloy_primitives::{Address, B256, Bytes, Log, LogData, address, hex};
-use base_consensus_genesis::{CONFIG_UPDATE_EVENT_VERSION_0, CONFIG_UPDATE_TOPIC, RollupConfig};
+use base_consensus_genesis::{RollupConfig, SystemConfigUpdate};
 use base_protocol::BlockInfo;
 
 use crate::{PollingTraversal, test_utils::TestChainProvider};
@@ -23,8 +23,8 @@ impl TraversalTestHelper {
             address: Self::L1_SYS_CONFIG_ADDR,
             data: LogData::new_unchecked(
                 vec![
-                    CONFIG_UPDATE_TOPIC,
-                    CONFIG_UPDATE_EVENT_VERSION_0,
+                    SystemConfigUpdate::TOPIC,
+                    SystemConfigUpdate::EVENT_VERSION_0,
                     B256::ZERO, // Update type
                 ],
                 hex!("00000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000beef").into()
@@ -38,7 +38,7 @@ impl TraversalTestHelper {
             Receipt { status: alloy_consensus::Eip658Value::Eip658(true), ..Receipt::default() };
         let bad = Log::new(
             Address::from([2; 20]),
-            vec![CONFIG_UPDATE_TOPIC, B256::default()],
+            vec![SystemConfigUpdate::TOPIC, B256::default()],
             Bytes::default(),
         )
         .unwrap();

--- a/crates/consensus/genesis/Cargo.toml
+++ b/crates/consensus/genesis/Cargo.toml
@@ -35,7 +35,8 @@ arbitrary = { workspace = true, features = ["derive"], optional = true }
 serde = { workspace = true, optional = true }
 
 [dev-dependencies]
-serde_json.workspace = true
+rstest.workspace = true
+serde_json = { workspace = true, features = ["std"] }
 rand = { workspace = true, features = ["thread_rng"] }
 arbitrary = { workspace = true, features = ["derive"] }
 toml = { workspace = true, features = ["parse", "serde"] }

--- a/crates/consensus/genesis/src/chain/addresses.rs
+++ b/crates/consensus/genesis/src/chain/addresses.rs
@@ -107,6 +107,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "serde")]
     fn test_addresses_deserialize() {
         let raw: &str = r#"
         {
@@ -157,6 +158,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "serde")]
     fn test_addresses_unknown_field_json() {
         let raw: &str = r#"
         {

--- a/crates/consensus/genesis/src/lib.rs
+++ b/crates/consensus/genesis/src/lib.rs
@@ -20,11 +20,10 @@ pub use updates::{
 
 mod system;
 pub use system::{
-    BatcherUpdateError, CONFIG_UPDATE_EVENT_VERSION_0, CONFIG_UPDATE_TOPIC,
-    DaFootprintGasScalarUpdateError, EIP1559UpdateError, GasConfigUpdateError, GasLimitUpdateError,
-    LogProcessingError, MinBaseFeeUpdateError, OperatorFeeUpdateError, SystemConfig,
-    SystemConfigLog, SystemConfigUpdate, SystemConfigUpdateError, SystemConfigUpdateKind,
-    UnsafeBlockSignerUpdateError,
+    BatcherUpdateError, DaFootprintGasScalarUpdateError, EIP1559UpdateError, GasConfigUpdateError,
+    GasLimitUpdateError, LogProcessingError, MinBaseFeeUpdateError, OperatorFeeUpdateError,
+    SystemConfig, SystemConfigLog, SystemConfigUpdate, SystemConfigUpdateError,
+    SystemConfigUpdateKind, UnsafeBlockSignerUpdateError,
 };
 
 mod chain;

--- a/crates/consensus/genesis/src/rollup.rs
+++ b/crates/consensus/genesis/src/rollup.rs
@@ -825,6 +825,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "serde")]
     fn test_rollup_config_unknown_field() {
         let raw: &str = r#"
         {

--- a/crates/consensus/genesis/src/system/config.rs
+++ b/crates/consensus/genesis/src/system/config.rs
@@ -8,7 +8,7 @@ use alloy_primitives::B256;
 use alloy_primitives::{Address, B64, Log, U256};
 
 use crate::{
-    CONFIG_UPDATE_TOPIC, RollupConfig, SystemConfigLog, SystemConfigUpdateError,
+    RollupConfig, SystemConfigLog, SystemConfigUpdate, SystemConfigUpdateError,
     SystemConfigUpdateKind,
 };
 
@@ -141,7 +141,7 @@ impl SystemConfig {
                 let topics = log.topics();
                 log.address == l1_system_config_address
                     && !topics.is_empty()
-                    && topics[0] == CONFIG_UPDATE_TOPIC
+                    && topics[0] == SystemConfigUpdate::TOPIC
             })
             .map(|log| self.process_config_update_log(log, ecotone_active))
             .fold((Vec::new(), Vec::new()), |(mut updates, mut errors), result| {
@@ -229,7 +229,7 @@ mod tests {
     use alloy_primitives::{B256, LogData, address, b256, hex};
 
     use super::*;
-    use crate::{CONFIG_UPDATE_EVENT_VERSION_0, HardForkConfig};
+    use crate::{HardForkConfig, SystemConfigUpdate};
 
     const BATCHER_UPDATE_TYPE: B256 =
         b256!("0000000000000000000000000000000000000000000000000000000000000000");
@@ -419,8 +419,8 @@ mod tests {
             address: Address::ZERO,
             data: LogData::new_unchecked(
                 vec![
-                    CONFIG_UPDATE_TOPIC,
-                    CONFIG_UPDATE_EVENT_VERSION_0,
+                    SystemConfigUpdate::TOPIC,
+                    SystemConfigUpdate::EVENT_VERSION_0,
                     BATCHER_UPDATE_TYPE,
                 ],
                 hex!("00000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000beef").into()
@@ -455,8 +455,8 @@ mod tests {
             address: Address::ZERO,
             data: LogData::new_unchecked(
                 vec![
-                    CONFIG_UPDATE_TOPIC,
-                    CONFIG_UPDATE_EVENT_VERSION_0,
+                    SystemConfigUpdate::TOPIC,
+                    SystemConfigUpdate::EVENT_VERSION_0,
                     BATCHER_UPDATE_TYPE,
                 ],
                 hex!("00000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000beef").into()
@@ -480,8 +480,8 @@ mod tests {
             address: Address::ZERO,
             data: LogData::new_unchecked(
                 vec![
-                    CONFIG_UPDATE_TOPIC,
-                    CONFIG_UPDATE_EVENT_VERSION_0,
+                    SystemConfigUpdate::TOPIC,
+                    SystemConfigUpdate::EVENT_VERSION_0,
                     GAS_CONFIG_UPDATE_TYPE,
                 ],
                 hex!("00000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000040000000000000000000000000000000000000000000000000000000000000babe000000000000000000000000000000000000000000000000000000000000beef").into()
@@ -503,8 +503,8 @@ mod tests {
             address: Address::ZERO,
             data: LogData::new_unchecked(
                 vec![
-                    CONFIG_UPDATE_TOPIC,
-                    CONFIG_UPDATE_EVENT_VERSION_0,
+                    SystemConfigUpdate::TOPIC,
+                    SystemConfigUpdate::EVENT_VERSION_0,
                     GAS_CONFIG_UPDATE_TYPE,
                 ],
                 hex!("00000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000040000000000000000000000000000000000000000000000000000000000000babe000000000000000000000000000000000000000000000000000000000000beef").into()
@@ -526,8 +526,8 @@ mod tests {
             address: Address::ZERO,
             data: LogData::new_unchecked(
                 vec![
-                    CONFIG_UPDATE_TOPIC,
-                    CONFIG_UPDATE_EVENT_VERSION_0,
+                    SystemConfigUpdate::TOPIC,
+                    SystemConfigUpdate::EVENT_VERSION_0,
                     GAS_LIMIT_UPDATE_TYPE,
                 ],
                 hex!("00000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000beef").into()
@@ -547,8 +547,8 @@ mod tests {
             address: Address::ZERO,
             data: LogData::new_unchecked(
                 vec![
-                    CONFIG_UPDATE_TOPIC,
-                    CONFIG_UPDATE_EVENT_VERSION_0,
+                    SystemConfigUpdate::TOPIC,
+                    SystemConfigUpdate::EVENT_VERSION_0,
                     EIP1559_UPDATE_TYPE,
                 ],
                 hex!("000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000babe0000beef").into()
@@ -569,8 +569,8 @@ mod tests {
             address: Address::ZERO,
             data: LogData::new_unchecked(
                 vec![
-                    CONFIG_UPDATE_TOPIC,
-                    CONFIG_UPDATE_EVENT_VERSION_0,
+                    SystemConfigUpdate::TOPIC,
+                    SystemConfigUpdate::EVENT_VERSION_0,
                     OPERATOR_FEE_UPDATE_TYPE,
                 ],
                 hex!("0000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000babe000000000000beef").into()
@@ -594,8 +594,8 @@ mod tests {
             address: Address::ZERO,
             data: LogData::new_unchecked(
                 vec![
-                    CONFIG_UPDATE_TOPIC,
-                    CONFIG_UPDATE_EVENT_VERSION_0,
+                    SystemConfigUpdate::TOPIC,
+                    SystemConfigUpdate::EVENT_VERSION_0,
                     BATCHER_UPDATE_TYPE,
                 ],
                 // ABI-encoded address with dirty upper bytes — will fail address decoding
@@ -608,8 +608,8 @@ mod tests {
             address: Address::ZERO,
             data: LogData::new_unchecked(
                 vec![
-                    CONFIG_UPDATE_TOPIC,
-                    CONFIG_UPDATE_EVENT_VERSION_0,
+                    SystemConfigUpdate::TOPIC,
+                    SystemConfigUpdate::EVENT_VERSION_0,
                     GAS_LIMIT_UPDATE_TYPE,
                 ],
                 hex!("00000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000beef").into()

--- a/crates/consensus/genesis/src/system/log.rs
+++ b/crates/consensus/genesis/src/system/log.rs
@@ -3,9 +3,9 @@
 use alloy_primitives::Log;
 
 use crate::{
-    BatcherUpdate, CONFIG_UPDATE_EVENT_VERSION_0, CONFIG_UPDATE_TOPIC, Eip1559Update,
-    GasConfigUpdate, GasLimitUpdate, LogProcessingError, OperatorFeeUpdate, SystemConfigUpdate,
-    SystemConfigUpdateError, SystemConfigUpdateKind, UnsafeBlockSignerUpdate,
+    BatcherUpdate, Eip1559Update, GasConfigUpdate, GasLimitUpdate, LogProcessingError,
+    OperatorFeeUpdate, SystemConfigUpdate, SystemConfigUpdateError, SystemConfigUpdateKind,
+    UnsafeBlockSignerUpdate,
     updates::{DaFootprintGasScalarUpdate, MinBaseFeeUpdate},
 };
 
@@ -40,7 +40,7 @@ impl SystemConfigLog {
         if self.log.topics().len() < 3 {
             return Err(LogProcessingError::InvalidTopicLen(self.log.topics().len()));
         }
-        if self.log.topics()[0] != CONFIG_UPDATE_TOPIC {
+        if self.log.topics()[0] != SystemConfigUpdate::TOPIC {
             return Err(LogProcessingError::InvalidTopic);
         }
         Ok(())
@@ -49,7 +49,7 @@ impl SystemConfigLog {
     /// Validate the config update version.
     pub fn validate_version(&self) -> Result<(), LogProcessingError> {
         let version = self.log.topics()[1];
-        if version != CONFIG_UPDATE_EVENT_VERSION_0 {
+        if version != SystemConfigUpdate::EVENT_VERSION_0 {
             return Err(LogProcessingError::UnsupportedVersion(version));
         }
         Ok(())

--- a/crates/consensus/genesis/src/system/mod.rs
+++ b/crates/consensus/genesis/src/system/mod.rs
@@ -1,14 +1,5 @@
 //! Contains types related to the [`SystemConfig`].
 
-use alloy_primitives::{B256, b256};
-
-/// `keccak256("ConfigUpdate(uint256,uint8,bytes)")`
-pub const CONFIG_UPDATE_TOPIC: B256 =
-    b256!("1d2b0bda21d56b8bd12d4f94ebacffdfb35f5e226f84b461103bb8beab6353be");
-
-/// The initial version of the system config event log.
-pub const CONFIG_UPDATE_EVENT_VERSION_0: B256 = B256::ZERO;
-
 mod config;
 pub use config::SystemConfig;
 

--- a/crates/consensus/genesis/src/system/update.rs
+++ b/crates/consensus/genesis/src/system/update.rs
@@ -1,6 +1,7 @@
 //! Contains the [`SystemConfigUpdate`].
 
 use alloy_primitives::{B256, b256};
+
 use crate::{
     BatcherUpdate, Eip1559Update, GasConfigUpdate, GasLimitUpdate, OperatorFeeUpdate, SystemConfig,
     SystemConfigUpdateKind, UnsafeBlockSignerUpdate,

--- a/crates/consensus/genesis/src/system/update.rs
+++ b/crates/consensus/genesis/src/system/update.rs
@@ -1,5 +1,6 @@
 //! Contains the [`SystemConfigUpdate`].
 
+use alloy_primitives::{B256, b256};
 use crate::{
     BatcherUpdate, Eip1559Update, GasConfigUpdate, GasLimitUpdate, OperatorFeeUpdate, SystemConfig,
     SystemConfigUpdateKind, UnsafeBlockSignerUpdate,
@@ -30,6 +31,13 @@ pub enum SystemConfigUpdate {
 }
 
 impl SystemConfigUpdate {
+    /// `keccak256("ConfigUpdate(uint256,uint8,bytes)")`
+    pub const TOPIC: B256 =
+        b256!("1d2b0bda21d56b8bd12d4f94ebacffdfb35f5e226f84b461103bb8beab6353be");
+
+    /// The initial version of the system config event log.
+    pub const EVENT_VERSION_0: B256 = B256::ZERO;
+
     /// Applies the update to the [`SystemConfig`].
     pub const fn apply(&self, config: &mut SystemConfig) {
         match self {

--- a/crates/consensus/genesis/src/updates/batcher.rs
+++ b/crates/consensus/genesis/src/updates/batcher.rs
@@ -80,7 +80,10 @@ mod tests {
         let log =
             Log { address: Address::ZERO, data: LogData::new_unchecked(vec![], Bytes::default()) };
         let system_log = SystemConfigLog::new(log, false);
-        assert_eq!(BatcherUpdate::try_from(&system_log).unwrap_err(), BatcherUpdateError::InvalidDataLen(0));
+        assert_eq!(
+            BatcherUpdate::try_from(&system_log).unwrap_err(),
+            BatcherUpdateError::InvalidDataLen(0)
+        );
     }
 
     #[rstest]

--- a/crates/consensus/genesis/src/updates/batcher.rs
+++ b/crates/consensus/genesis/src/updates/batcher.rs
@@ -56,29 +56,23 @@ mod tests {
     use alloc::vec;
 
     use alloy_primitives::{B256, Bytes, Log, LogData, address, hex};
+    use rstest::rstest;
 
     use super::*;
-    use crate::{CONFIG_UPDATE_EVENT_VERSION_0, CONFIG_UPDATE_TOPIC};
+    use crate::SystemConfigUpdate;
 
     #[test]
     fn test_batcher_update_try_from() {
-        let update_type = B256::ZERO;
-
         let log = Log {
             address: Address::ZERO,
             data: LogData::new_unchecked(
-                vec![
-                    CONFIG_UPDATE_TOPIC,
-                    CONFIG_UPDATE_EVENT_VERSION_0,
-                    update_type,
-                ],
+                vec![SystemConfigUpdate::TOPIC, SystemConfigUpdate::EVENT_VERSION_0, B256::ZERO],
                 hex!("00000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000beef").into()
             )
         };
-
         let system_log = SystemConfigLog::new(log, false);
         let update = BatcherUpdate::try_from(&system_log).unwrap();
-        assert_eq!(update.batcher_address, address!("000000000000000000000000000000000000bEEF"),);
+        assert_eq!(update.batcher_address, address!("000000000000000000000000000000000000bEEF"));
     }
 
     #[test]
@@ -86,102 +80,24 @@ mod tests {
         let log =
             Log { address: Address::ZERO, data: LogData::new_unchecked(vec![], Bytes::default()) };
         let system_log = SystemConfigLog::new(log, false);
-        let err = BatcherUpdate::try_from(&system_log).unwrap_err();
-        assert_eq!(err, BatcherUpdateError::InvalidDataLen(0));
+        assert_eq!(BatcherUpdate::try_from(&system_log).unwrap_err(), BatcherUpdateError::InvalidDataLen(0));
     }
 
-    #[test]
-    fn test_batcher_update_pointer_decoding_error() {
+    #[rstest]
+    #[case(hex!("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF00000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000babe0000beef"), BatcherUpdateError::PointerDecodingError)]
+    #[case(hex!("000000000000000000000000000000000000000000000000000000000000002100000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000babe0000beef"), BatcherUpdateError::InvalidDataPointer(33))]
+    #[case(hex!("0000000000000000000000000000000000000000000000000000000000000020FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF0000000000000000000000000000000000000000000000000000babe0000beef"), BatcherUpdateError::LengthDecodingError)]
+    #[case(hex!("000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000210000000000000000000000000000000000000000000000000000babe0000beef"), BatcherUpdateError::InvalidDataLength(33))]
+    #[case(hex!("00000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000020FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF"), BatcherUpdateError::BatcherAddressDecodingError)]
+    fn test_batcher_update_errors(#[case] data: [u8; 96], #[case] expected: BatcherUpdateError) {
         let log = Log {
             address: Address::ZERO,
             data: LogData::new_unchecked(
-                vec![
-                    CONFIG_UPDATE_TOPIC,
-                    CONFIG_UPDATE_EVENT_VERSION_0,
-                    B256::ZERO,
-                ],
-                hex!("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF00000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000babe0000beef").into()
-            )
+                vec![SystemConfigUpdate::TOPIC, SystemConfigUpdate::EVENT_VERSION_0, B256::ZERO],
+                data.into(),
+            ),
         };
-
         let system_log = SystemConfigLog::new(log, false);
-        let err = BatcherUpdate::try_from(&system_log).unwrap_err();
-        assert_eq!(err, BatcherUpdateError::PointerDecodingError);
-    }
-
-    #[test]
-    fn test_batcher_update_invalid_pointer_length() {
-        let log = Log {
-            address: Address::ZERO,
-            data: LogData::new_unchecked(
-                vec![
-                    CONFIG_UPDATE_TOPIC,
-                    CONFIG_UPDATE_EVENT_VERSION_0,
-                    B256::ZERO,
-                ],
-                hex!("000000000000000000000000000000000000000000000000000000000000002100000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000babe0000beef").into()
-            )
-        };
-
-        let system_log = SystemConfigLog::new(log, false);
-        let err = BatcherUpdate::try_from(&system_log).unwrap_err();
-        assert_eq!(err, BatcherUpdateError::InvalidDataPointer(33));
-    }
-
-    #[test]
-    fn test_batcher_update_length_decoding_error() {
-        let log = Log {
-            address: Address::ZERO,
-            data: LogData::new_unchecked(
-                vec![
-                    CONFIG_UPDATE_TOPIC,
-                    CONFIG_UPDATE_EVENT_VERSION_0,
-                    B256::ZERO,
-                ],
-                hex!("0000000000000000000000000000000000000000000000000000000000000020FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF0000000000000000000000000000000000000000000000000000babe0000beef").into()
-            )
-        };
-
-        let system_log = SystemConfigLog::new(log, false);
-        let err = BatcherUpdate::try_from(&system_log).unwrap_err();
-        assert_eq!(err, BatcherUpdateError::LengthDecodingError);
-    }
-
-    #[test]
-    fn test_batcher_update_invalid_data_length() {
-        let log = Log {
-            address: Address::ZERO,
-            data: LogData::new_unchecked(
-                vec![
-                    CONFIG_UPDATE_TOPIC,
-                    CONFIG_UPDATE_EVENT_VERSION_0,
-                    B256::ZERO,
-                ],
-                hex!("000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000210000000000000000000000000000000000000000000000000000babe0000beef").into()
-            )
-        };
-
-        let system_log = SystemConfigLog::new(log, false);
-        let err = BatcherUpdate::try_from(&system_log).unwrap_err();
-        assert_eq!(err, BatcherUpdateError::InvalidDataLength(33));
-    }
-
-    #[test]
-    fn test_batcher_update_batcher_decoding_error() {
-        let log = Log {
-            address: Address::ZERO,
-            data: LogData::new_unchecked(
-                vec![
-                    CONFIG_UPDATE_TOPIC,
-                    CONFIG_UPDATE_EVENT_VERSION_0,
-                    B256::ZERO,
-                ],
-                hex!("00000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000020FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF").into()
-            )
-        };
-
-        let system_log = SystemConfigLog::new(log, false);
-        let err = BatcherUpdate::try_from(&system_log).unwrap_err();
-        assert_eq!(err, BatcherUpdateError::BatcherAddressDecodingError);
+        assert_eq!(BatcherUpdate::try_from(&system_log).unwrap_err(), expected);
     }
 }

--- a/crates/consensus/genesis/src/updates/da_footprint_gas_scalar.rs
+++ b/crates/consensus/genesis/src/updates/da_footprint_gas_scalar.rs
@@ -68,30 +68,22 @@ mod tests {
     use alloc::vec;
 
     use alloy_primitives::{Address, B256, Bytes, Log, LogData, hex};
+    use rstest::rstest;
 
     use super::*;
-    use crate::{CONFIG_UPDATE_EVENT_VERSION_0, CONFIG_UPDATE_TOPIC};
+    use crate::SystemConfigUpdate;
 
     #[test]
     fn test_da_footprint_update_try_from() {
-        let update_type = B256::ZERO;
-
         let log = Log {
             address: Address::ZERO,
             data: LogData::new_unchecked(
-                vec![
-                    CONFIG_UPDATE_TOPIC,
-                    CONFIG_UPDATE_EVENT_VERSION_0,
-                    update_type,
-                ],
+                vec![SystemConfigUpdate::TOPIC, SystemConfigUpdate::EVENT_VERSION_0, B256::ZERO],
                 hex!("00000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000beef").into()
             )
         };
-
         let system_log = SystemConfigLog::new(log, false);
-        let update = DaFootprintGasScalarUpdate::try_from(&system_log).unwrap();
-
-        assert_eq!(update.da_footprint_gas_scalar, 0xbeef_u16);
+        assert_eq!(DaFootprintGasScalarUpdate::try_from(&system_log).unwrap().da_footprint_gas_scalar, 0xbeef_u16);
     }
 
     #[test]
@@ -99,102 +91,24 @@ mod tests {
         let log =
             Log { address: Address::ZERO, data: LogData::new_unchecked(vec![], Bytes::default()) };
         let system_log = SystemConfigLog::new(log, false);
-        let err = DaFootprintGasScalarUpdate::try_from(&system_log).unwrap_err();
-        assert_eq!(err, DaFootprintGasScalarUpdateError::InvalidDataLen(0));
+        assert_eq!(DaFootprintGasScalarUpdate::try_from(&system_log).unwrap_err(), DaFootprintGasScalarUpdateError::InvalidDataLen(0));
     }
 
-    #[test]
-    fn test_da_footprint_update_pointer_decoding_error() {
+    #[rstest]
+    #[case(hex!("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF00000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000babe0000beef"), DaFootprintGasScalarUpdateError::PointerDecodingError)]
+    #[case(hex!("000000000000000000000000000000000000000000000000000000000000002100000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000babe0000beef"), DaFootprintGasScalarUpdateError::InvalidDataPointer(33))]
+    #[case(hex!("0000000000000000000000000000000000000000000000000000000000000020FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF0000000000000000000000000000000000000000000000000000babe0000beef"), DaFootprintGasScalarUpdateError::LengthDecodingError)]
+    #[case(hex!("000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000210000000000000000000000000000000000000000000000000000babe0000beef"), DaFootprintGasScalarUpdateError::InvalidDataLength(33))]
+    #[case(hex!("00000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000020FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF"), DaFootprintGasScalarUpdateError::DaFootprintGasScalarDecodingError)]
+    fn test_da_footprint_update_errors(#[case] data: [u8; 96], #[case] expected: DaFootprintGasScalarUpdateError) {
         let log = Log {
             address: Address::ZERO,
             data: LogData::new_unchecked(
-                vec![
-                    CONFIG_UPDATE_TOPIC,
-                    CONFIG_UPDATE_EVENT_VERSION_0,
-                    B256::ZERO,
-                ],
-                hex!("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF00000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000babe0000beef").into()
-            )
+                vec![SystemConfigUpdate::TOPIC, SystemConfigUpdate::EVENT_VERSION_0, B256::ZERO],
+                data.into(),
+            ),
         };
-
         let system_log = SystemConfigLog::new(log, false);
-        let err = DaFootprintGasScalarUpdate::try_from(&system_log).unwrap_err();
-        assert_eq!(err, DaFootprintGasScalarUpdateError::PointerDecodingError);
-    }
-
-    #[test]
-    fn test_da_footprint_update_invalid_pointer_length() {
-        let log = Log {
-            address: Address::ZERO,
-            data: LogData::new_unchecked(
-                vec![
-                    CONFIG_UPDATE_TOPIC,
-                    CONFIG_UPDATE_EVENT_VERSION_0,
-                    B256::ZERO,
-                ],
-                hex!("000000000000000000000000000000000000000000000000000000000000002100000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000babe0000beef").into()
-            )
-        };
-
-        let system_log = SystemConfigLog::new(log, false);
-        let err = DaFootprintGasScalarUpdate::try_from(&system_log).unwrap_err();
-        assert_eq!(err, DaFootprintGasScalarUpdateError::InvalidDataPointer(33));
-    }
-
-    #[test]
-    fn test_da_footprint_update_length_decoding_error() {
-        let log = Log {
-            address: Address::ZERO,
-            data: LogData::new_unchecked(
-                vec![
-                    CONFIG_UPDATE_TOPIC,
-                    CONFIG_UPDATE_EVENT_VERSION_0,
-                    B256::ZERO,
-                ],
-                hex!("0000000000000000000000000000000000000000000000000000000000000020FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF0000000000000000000000000000000000000000000000000000babe0000beef").into()
-            )
-        };
-
-        let system_log = SystemConfigLog::new(log, false);
-        let err = DaFootprintGasScalarUpdate::try_from(&system_log).unwrap_err();
-        assert_eq!(err, DaFootprintGasScalarUpdateError::LengthDecodingError);
-    }
-
-    #[test]
-    fn test_da_footprint_update_invalid_data_length() {
-        let log = Log {
-            address: Address::ZERO,
-            data: LogData::new_unchecked(
-                vec![
-                    CONFIG_UPDATE_TOPIC,
-                    CONFIG_UPDATE_EVENT_VERSION_0,
-                    B256::ZERO,
-                ],
-                hex!("000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000210000000000000000000000000000000000000000000000000000babe0000beef").into()
-            )
-        };
-
-        let system_log = SystemConfigLog::new(log, false);
-        let err = DaFootprintGasScalarUpdate::try_from(&system_log).unwrap_err();
-        assert_eq!(err, DaFootprintGasScalarUpdateError::InvalidDataLength(33));
-    }
-
-    #[test]
-    fn test_da_footprint_update_da_footprint_decoding_error() {
-        let log = Log {
-            address: Address::ZERO,
-            data: LogData::new_unchecked(
-                vec![
-                    CONFIG_UPDATE_TOPIC,
-                    CONFIG_UPDATE_EVENT_VERSION_0,
-                    B256::ZERO,
-                ],
-                hex!("00000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000020FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF").into()
-            )
-        };
-
-        let system_log = SystemConfigLog::new(log, false);
-        let err = DaFootprintGasScalarUpdate::try_from(&system_log).unwrap_err();
-        assert_eq!(err, DaFootprintGasScalarUpdateError::DaFootprintGasScalarDecodingError);
+        assert_eq!(DaFootprintGasScalarUpdate::try_from(&system_log).unwrap_err(), expected);
     }
 }

--- a/crates/consensus/genesis/src/updates/da_footprint_gas_scalar.rs
+++ b/crates/consensus/genesis/src/updates/da_footprint_gas_scalar.rs
@@ -83,7 +83,10 @@ mod tests {
             )
         };
         let system_log = SystemConfigLog::new(log, false);
-        assert_eq!(DaFootprintGasScalarUpdate::try_from(&system_log).unwrap().da_footprint_gas_scalar, 0xbeef_u16);
+        assert_eq!(
+            DaFootprintGasScalarUpdate::try_from(&system_log).unwrap().da_footprint_gas_scalar,
+            0xbeef_u16
+        );
     }
 
     #[test]
@@ -91,7 +94,10 @@ mod tests {
         let log =
             Log { address: Address::ZERO, data: LogData::new_unchecked(vec![], Bytes::default()) };
         let system_log = SystemConfigLog::new(log, false);
-        assert_eq!(DaFootprintGasScalarUpdate::try_from(&system_log).unwrap_err(), DaFootprintGasScalarUpdateError::InvalidDataLen(0));
+        assert_eq!(
+            DaFootprintGasScalarUpdate::try_from(&system_log).unwrap_err(),
+            DaFootprintGasScalarUpdateError::InvalidDataLen(0)
+        );
     }
 
     #[rstest]
@@ -100,7 +106,10 @@ mod tests {
     #[case(hex!("0000000000000000000000000000000000000000000000000000000000000020FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF0000000000000000000000000000000000000000000000000000babe0000beef"), DaFootprintGasScalarUpdateError::LengthDecodingError)]
     #[case(hex!("000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000210000000000000000000000000000000000000000000000000000babe0000beef"), DaFootprintGasScalarUpdateError::InvalidDataLength(33))]
     #[case(hex!("00000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000020FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF"), DaFootprintGasScalarUpdateError::DaFootprintGasScalarDecodingError)]
-    fn test_da_footprint_update_errors(#[case] data: [u8; 96], #[case] expected: DaFootprintGasScalarUpdateError) {
+    fn test_da_footprint_update_errors(
+        #[case] data: [u8; 96],
+        #[case] expected: DaFootprintGasScalarUpdateError,
+    ) {
         let log = Log {
             address: Address::ZERO,
             data: LogData::new_unchecked(

--- a/crates/consensus/genesis/src/updates/eip1559.rs
+++ b/crates/consensus/genesis/src/updates/eip1559.rs
@@ -87,7 +87,10 @@ mod tests {
         let log =
             Log { address: Address::ZERO, data: LogData::new_unchecked(vec![], Bytes::default()) };
         let system_log = SystemConfigLog::new(log, false);
-        assert_eq!(Eip1559Update::try_from(&system_log).unwrap_err(), EIP1559UpdateError::InvalidDataLen(0));
+        assert_eq!(
+            Eip1559Update::try_from(&system_log).unwrap_err(),
+            EIP1559UpdateError::InvalidDataLen(0)
+        );
     }
 
     #[rstest]

--- a/crates/consensus/genesis/src/updates/eip1559.rs
+++ b/crates/consensus/genesis/src/updates/eip1559.rs
@@ -62,29 +62,22 @@ mod tests {
     use alloc::vec;
 
     use alloy_primitives::{Address, B256, Bytes, Log, LogData, hex};
+    use rstest::rstest;
 
     use super::*;
-    use crate::{CONFIG_UPDATE_EVENT_VERSION_0, CONFIG_UPDATE_TOPIC};
+    use crate::SystemConfigUpdate;
 
     #[test]
     fn test_eip1559_update_try_from() {
-        let update_type = B256::ZERO;
-
         let log = Log {
             address: Address::ZERO,
             data: LogData::new_unchecked(
-                vec![
-                    CONFIG_UPDATE_TOPIC,
-                    CONFIG_UPDATE_EVENT_VERSION_0,
-                    update_type,
-                ],
+                vec![SystemConfigUpdate::TOPIC, SystemConfigUpdate::EVENT_VERSION_0, B256::ZERO],
                 hex!("000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000babe0000beef").into()
             )
         };
-
         let system_log = SystemConfigLog::new(log, false);
         let update = Eip1559Update::try_from(&system_log).unwrap();
-
         assert_eq!(update.eip1559_denominator, 0xbabe_u32);
         assert_eq!(update.eip1559_elasticity, 0xbeef_u32);
     }
@@ -94,102 +87,24 @@ mod tests {
         let log =
             Log { address: Address::ZERO, data: LogData::new_unchecked(vec![], Bytes::default()) };
         let system_log = SystemConfigLog::new(log, false);
-        let err = Eip1559Update::try_from(&system_log).unwrap_err();
-        assert_eq!(err, EIP1559UpdateError::InvalidDataLen(0));
+        assert_eq!(Eip1559Update::try_from(&system_log).unwrap_err(), EIP1559UpdateError::InvalidDataLen(0));
     }
 
-    #[test]
-    fn test_eip1559_update_pointer_decoding_error() {
+    #[rstest]
+    #[case(hex!("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF00000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000babe0000beef"), EIP1559UpdateError::PointerDecodingError)]
+    #[case(hex!("000000000000000000000000000000000000000000000000000000000000002100000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000babe0000beef"), EIP1559UpdateError::InvalidDataPointer(33))]
+    #[case(hex!("0000000000000000000000000000000000000000000000000000000000000020FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF0000000000000000000000000000000000000000000000000000babe0000beef"), EIP1559UpdateError::LengthDecodingError)]
+    #[case(hex!("000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000210000000000000000000000000000000000000000000000000000babe0000beef"), EIP1559UpdateError::InvalidDataLength(33))]
+    #[case(hex!("00000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000020FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF"), EIP1559UpdateError::EIP1559DecodingError)]
+    fn test_eip1559_update_errors(#[case] data: [u8; 96], #[case] expected: EIP1559UpdateError) {
         let log = Log {
             address: Address::ZERO,
             data: LogData::new_unchecked(
-                vec![
-                    CONFIG_UPDATE_TOPIC,
-                    CONFIG_UPDATE_EVENT_VERSION_0,
-                    B256::ZERO,
-                ],
-                hex!("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF00000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000babe0000beef").into()
-            )
+                vec![SystemConfigUpdate::TOPIC, SystemConfigUpdate::EVENT_VERSION_0, B256::ZERO],
+                data.into(),
+            ),
         };
-
         let system_log = SystemConfigLog::new(log, false);
-        let err = Eip1559Update::try_from(&system_log).unwrap_err();
-        assert_eq!(err, EIP1559UpdateError::PointerDecodingError);
-    }
-
-    #[test]
-    fn test_eip1559_update_invalid_pointer_length() {
-        let log = Log {
-            address: Address::ZERO,
-            data: LogData::new_unchecked(
-                vec![
-                    CONFIG_UPDATE_TOPIC,
-                    CONFIG_UPDATE_EVENT_VERSION_0,
-                    B256::ZERO,
-                ],
-                hex!("000000000000000000000000000000000000000000000000000000000000002100000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000babe0000beef").into()
-            )
-        };
-
-        let system_log = SystemConfigLog::new(log, false);
-        let err = Eip1559Update::try_from(&system_log).unwrap_err();
-        assert_eq!(err, EIP1559UpdateError::InvalidDataPointer(33));
-    }
-
-    #[test]
-    fn test_eip1559_update_length_decoding_error() {
-        let log = Log {
-            address: Address::ZERO,
-            data: LogData::new_unchecked(
-                vec![
-                    CONFIG_UPDATE_TOPIC,
-                    CONFIG_UPDATE_EVENT_VERSION_0,
-                    B256::ZERO,
-                ],
-                hex!("0000000000000000000000000000000000000000000000000000000000000020FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF0000000000000000000000000000000000000000000000000000babe0000beef").into()
-            )
-        };
-
-        let system_log = SystemConfigLog::new(log, false);
-        let err = Eip1559Update::try_from(&system_log).unwrap_err();
-        assert_eq!(err, EIP1559UpdateError::LengthDecodingError);
-    }
-
-    #[test]
-    fn test_eip1559_update_invalid_data_length() {
-        let log = Log {
-            address: Address::ZERO,
-            data: LogData::new_unchecked(
-                vec![
-                    CONFIG_UPDATE_TOPIC,
-                    CONFIG_UPDATE_EVENT_VERSION_0,
-                    B256::ZERO,
-                ],
-                hex!("000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000210000000000000000000000000000000000000000000000000000babe0000beef").into()
-            )
-        };
-
-        let system_log = SystemConfigLog::new(log, false);
-        let err = Eip1559Update::try_from(&system_log).unwrap_err();
-        assert_eq!(err, EIP1559UpdateError::InvalidDataLength(33));
-    }
-
-    #[test]
-    fn test_eip1559_update_eip1559_decoding_error() {
-        let log = Log {
-            address: Address::ZERO,
-            data: LogData::new_unchecked(
-                vec![
-                    CONFIG_UPDATE_TOPIC,
-                    CONFIG_UPDATE_EVENT_VERSION_0,
-                    B256::ZERO,
-                ],
-                hex!("00000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000020FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF").into()
-            )
-        };
-
-        let system_log = SystemConfigLog::new(log, false);
-        let err = Eip1559Update::try_from(&system_log).unwrap_err();
-        assert_eq!(err, EIP1559UpdateError::EIP1559DecodingError);
+        assert_eq!(Eip1559Update::try_from(&system_log).unwrap_err(), expected);
     }
 }

--- a/crates/consensus/genesis/src/updates/gas_config.rs
+++ b/crates/consensus/genesis/src/updates/gas_config.rs
@@ -76,29 +76,22 @@ mod tests {
     use alloc::vec;
 
     use alloy_primitives::{Address, B256, Bytes, Log, LogData, hex, uint};
+    use rstest::rstest;
 
     use super::*;
-    use crate::{CONFIG_UPDATE_EVENT_VERSION_0, CONFIG_UPDATE_TOPIC};
+    use crate::SystemConfigUpdate;
 
     #[test]
     fn test_gas_config_update_try_from() {
-        let update_type = B256::ZERO;
-
         let log = Log {
             address: Address::ZERO,
             data: LogData::new_unchecked(
-                vec![
-                    CONFIG_UPDATE_TOPIC,
-                    CONFIG_UPDATE_EVENT_VERSION_0,
-                    update_type,
-                ],
+                vec![SystemConfigUpdate::TOPIC, SystemConfigUpdate::EVENT_VERSION_0, B256::ZERO],
                 hex!("00000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000040000000000000000000000000000000000000000000000000000000000000babe000000000000000000000000000000000000000000000000000000000000beef").into()
             )
         };
-
         let system_log = SystemConfigLog::new(log, false);
         let update = GasConfigUpdate::try_from(&system_log).unwrap();
-
         assert_eq!(update.overhead, Some(uint!(0xbabe_U256)));
         assert_eq!(update.scalar, Some(uint!(0xbeef_U256)));
     }
@@ -108,118 +101,37 @@ mod tests {
         let log =
             Log { address: Address::ZERO, data: LogData::new_unchecked(vec![], Bytes::default()) };
         let system_log = SystemConfigLog::new(log, false);
-        let err = GasConfigUpdate::try_from(&system_log).unwrap_err();
-        assert_eq!(err, GasConfigUpdateError::InvalidDataLen(0));
+        assert_eq!(GasConfigUpdate::try_from(&system_log).unwrap_err(), GasConfigUpdateError::InvalidDataLen(0));
     }
 
-    #[test]
-    fn test_gas_config_update_pointer_decoding_error() {
+    #[rstest]
+    #[case(hex!("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF0000000000000000000000000000000000000000000000000000000000000040000000000000000000000000000000000000000000000000000000000000babe000000000000000000000000000000000000000000000000000000000000beef"), GasConfigUpdateError::PointerDecodingError)]
+    #[case(hex!("00000000000000000000000000000000000000000000000000000000000000210000000000000000000000000000000000000000000000000000000000000040000000000000000000000000000000000000000000000000000000000000babe000000000000000000000000000000000000000000000000000000000000beef"), GasConfigUpdateError::InvalidDataPointer(33))]
+    #[case(hex!("0000000000000000000000000000000000000000000000000000000000000020FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF000000000000000000000000000000000000000000000000000000000000babe000000000000000000000000000000000000000000000000000000000000beef"), GasConfigUpdateError::LengthDecodingError)]
+    #[case(hex!("00000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000041000000000000000000000000000000000000000000000000000000000000babe000000000000000000000000000000000000000000000000000000000000beef"), GasConfigUpdateError::InvalidDataLength(65))]
+    fn test_gas_config_update_errors(#[case] data: [u8; 128], #[case] expected: GasConfigUpdateError) {
         let log = Log {
             address: Address::ZERO,
             data: LogData::new_unchecked(
-                vec![
-                    CONFIG_UPDATE_TOPIC,
-                    CONFIG_UPDATE_EVENT_VERSION_0,
-                    B256::ZERO,
-                ],
-                hex!("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF0000000000000000000000000000000000000000000000000000000000000040000000000000000000000000000000000000000000000000000000000000babe000000000000000000000000000000000000000000000000000000000000beef").into()
-            )
+                vec![SystemConfigUpdate::TOPIC, SystemConfigUpdate::EVENT_VERSION_0, B256::ZERO],
+                data.into(),
+            ),
         };
-
         let system_log = SystemConfigLog::new(log, false);
-        let err = GasConfigUpdate::try_from(&system_log).unwrap_err();
-        assert_eq!(err, GasConfigUpdateError::PointerDecodingError);
+        assert_eq!(GasConfigUpdate::try_from(&system_log).unwrap_err(), expected);
     }
 
-    #[test]
-    fn test_gas_config_update_invalid_pointer_length() {
+    #[rstest]
+    #[case(hex!("00000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000040FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF000000000000000000000000000000000000000000000000000000000000beef"))]
+    #[case(hex!("00000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000040000000000000000000000000000000000000000000000000000000000000babeFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF"))]
+    fn test_gas_config_update_max_u256_succeeds(#[case] data: [u8; 128]) {
         let log = Log {
             address: Address::ZERO,
             data: LogData::new_unchecked(
-                vec![
-                    CONFIG_UPDATE_TOPIC,
-                    CONFIG_UPDATE_EVENT_VERSION_0,
-                    B256::ZERO,
-                ],
-                hex!("00000000000000000000000000000000000000000000000000000000000000210000000000000000000000000000000000000000000000000000000000000040000000000000000000000000000000000000000000000000000000000000babe000000000000000000000000000000000000000000000000000000000000beef").into()
-            )
+                vec![SystemConfigUpdate::TOPIC, SystemConfigUpdate::EVENT_VERSION_0, B256::ZERO],
+                data.into(),
+            ),
         };
-
-        let system_log = SystemConfigLog::new(log, false);
-        let err = GasConfigUpdate::try_from(&system_log).unwrap_err();
-        assert_eq!(err, GasConfigUpdateError::InvalidDataPointer(33));
-    }
-
-    #[test]
-    fn test_gas_config_update_length_decoding_error() {
-        let log = Log {
-            address: Address::ZERO,
-            data: LogData::new_unchecked(
-                vec![
-                    CONFIG_UPDATE_TOPIC,
-                    CONFIG_UPDATE_EVENT_VERSION_0,
-                    B256::ZERO,
-                ],
-                hex!("0000000000000000000000000000000000000000000000000000000000000020FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF000000000000000000000000000000000000000000000000000000000000babe000000000000000000000000000000000000000000000000000000000000beef").into()
-            )
-        };
-
-        let system_log = SystemConfigLog::new(log, false);
-        let err = GasConfigUpdate::try_from(&system_log).unwrap_err();
-        assert_eq!(err, GasConfigUpdateError::LengthDecodingError);
-    }
-
-    #[test]
-    fn test_gas_config_update_invalid_data_length() {
-        let log = Log {
-            address: Address::ZERO,
-            data: LogData::new_unchecked(
-                vec![
-                    CONFIG_UPDATE_TOPIC,
-                    CONFIG_UPDATE_EVENT_VERSION_0,
-                    B256::ZERO,
-                ],
-                hex!("00000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000041000000000000000000000000000000000000000000000000000000000000babe000000000000000000000000000000000000000000000000000000000000beef").into()
-            )
-        };
-
-        let system_log = SystemConfigLog::new(log, false);
-        let err = GasConfigUpdate::try_from(&system_log).unwrap_err();
-        assert_eq!(err, GasConfigUpdateError::InvalidDataLength(65));
-    }
-
-    #[test]
-    fn test_gas_config_update_overhead_decoding_succeeds_max_u256() {
-        let log = Log {
-            address: Address::ZERO,
-            data: LogData::new_unchecked(
-                vec![
-                    CONFIG_UPDATE_TOPIC,
-                    CONFIG_UPDATE_EVENT_VERSION_0,
-                    B256::ZERO,
-                ],
-                hex!("00000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000040FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF000000000000000000000000000000000000000000000000000000000000beef").into()
-            )
-        };
-
-        let system_log = SystemConfigLog::new(log, false);
-        assert!(GasConfigUpdate::try_from(&system_log).is_ok());
-    }
-
-    #[test]
-    fn test_gas_config_update_scalar_decoding_succeeds_max_u256() {
-        let log = Log {
-            address: Address::ZERO,
-            data: LogData::new_unchecked(
-                vec![
-                    CONFIG_UPDATE_TOPIC,
-                    CONFIG_UPDATE_EVENT_VERSION_0,
-                    B256::ZERO,
-                ],
-                hex!("00000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000040000000000000000000000000000000000000000000000000000000000000babeFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF").into()
-            )
-        };
-
         let system_log = SystemConfigLog::new(log, false);
         assert!(GasConfigUpdate::try_from(&system_log).is_ok());
     }

--- a/crates/consensus/genesis/src/updates/gas_config.rs
+++ b/crates/consensus/genesis/src/updates/gas_config.rs
@@ -101,7 +101,10 @@ mod tests {
         let log =
             Log { address: Address::ZERO, data: LogData::new_unchecked(vec![], Bytes::default()) };
         let system_log = SystemConfigLog::new(log, false);
-        assert_eq!(GasConfigUpdate::try_from(&system_log).unwrap_err(), GasConfigUpdateError::InvalidDataLen(0));
+        assert_eq!(
+            GasConfigUpdate::try_from(&system_log).unwrap_err(),
+            GasConfigUpdateError::InvalidDataLen(0)
+        );
     }
 
     #[rstest]
@@ -109,7 +112,10 @@ mod tests {
     #[case(hex!("00000000000000000000000000000000000000000000000000000000000000210000000000000000000000000000000000000000000000000000000000000040000000000000000000000000000000000000000000000000000000000000babe000000000000000000000000000000000000000000000000000000000000beef"), GasConfigUpdateError::InvalidDataPointer(33))]
     #[case(hex!("0000000000000000000000000000000000000000000000000000000000000020FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF000000000000000000000000000000000000000000000000000000000000babe000000000000000000000000000000000000000000000000000000000000beef"), GasConfigUpdateError::LengthDecodingError)]
     #[case(hex!("00000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000041000000000000000000000000000000000000000000000000000000000000babe000000000000000000000000000000000000000000000000000000000000beef"), GasConfigUpdateError::InvalidDataLength(65))]
-    fn test_gas_config_update_errors(#[case] data: [u8; 128], #[case] expected: GasConfigUpdateError) {
+    fn test_gas_config_update_errors(
+        #[case] data: [u8; 128],
+        #[case] expected: GasConfigUpdateError,
+    ) {
         let log = Log {
             address: Address::ZERO,
             data: LogData::new_unchecked(

--- a/crates/consensus/genesis/src/updates/gas_limit.rs
+++ b/crates/consensus/genesis/src/updates/gas_limit.rs
@@ -85,7 +85,10 @@ mod tests {
         let log =
             Log { address: Address::ZERO, data: LogData::new_unchecked(vec![], Bytes::default()) };
         let system_log = SystemConfigLog::new(log, false);
-        assert_eq!(GasLimitUpdate::try_from(&system_log).unwrap_err(), GasLimitUpdateError::InvalidDataLen(0));
+        assert_eq!(
+            GasLimitUpdate::try_from(&system_log).unwrap_err(),
+            GasLimitUpdateError::InvalidDataLen(0)
+        );
     }
 
     #[rstest]

--- a/crates/consensus/genesis/src/updates/gas_limit.rs
+++ b/crates/consensus/genesis/src/updates/gas_limit.rs
@@ -62,30 +62,22 @@ mod tests {
     use alloc::vec;
 
     use alloy_primitives::{Address, B256, Bytes, Log, LogData, hex};
+    use rstest::rstest;
 
     use super::*;
-    use crate::{CONFIG_UPDATE_EVENT_VERSION_0, CONFIG_UPDATE_TOPIC};
+    use crate::SystemConfigUpdate;
 
     #[test]
     fn test_gas_limit_update_try_from() {
-        let update_type = B256::ZERO;
-
         let log = Log {
             address: Address::ZERO,
             data: LogData::new_unchecked(
-                vec![
-                    CONFIG_UPDATE_TOPIC,
-                    CONFIG_UPDATE_EVENT_VERSION_0,
-                    update_type,
-                ],
+                vec![SystemConfigUpdate::TOPIC, SystemConfigUpdate::EVENT_VERSION_0, B256::ZERO],
                 hex!("00000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000beef").into()
             )
         };
-
         let system_log = SystemConfigLog::new(log, false);
-        let update = GasLimitUpdate::try_from(&system_log).unwrap();
-
-        assert_eq!(update.gas_limit, 0xbeef_u64);
+        assert_eq!(GasLimitUpdate::try_from(&system_log).unwrap().gas_limit, 0xbeef_u64);
     }
 
     #[test]
@@ -93,102 +85,24 @@ mod tests {
         let log =
             Log { address: Address::ZERO, data: LogData::new_unchecked(vec![], Bytes::default()) };
         let system_log = SystemConfigLog::new(log, false);
-        let err = GasLimitUpdate::try_from(&system_log).unwrap_err();
-        assert_eq!(err, GasLimitUpdateError::InvalidDataLen(0));
+        assert_eq!(GasLimitUpdate::try_from(&system_log).unwrap_err(), GasLimitUpdateError::InvalidDataLen(0));
     }
 
-    #[test]
-    fn test_gas_limit_update_pointer_decoding_error() {
+    #[rstest]
+    #[case(hex!("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF00000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000babe0000beef"), GasLimitUpdateError::PointerDecodingError)]
+    #[case(hex!("000000000000000000000000000000000000000000000000000000000000002100000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000babe0000beef"), GasLimitUpdateError::InvalidDataPointer(33))]
+    #[case(hex!("0000000000000000000000000000000000000000000000000000000000000020FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF0000000000000000000000000000000000000000000000000000babe0000beef"), GasLimitUpdateError::LengthDecodingError)]
+    #[case(hex!("000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000210000000000000000000000000000000000000000000000000000babe0000beef"), GasLimitUpdateError::InvalidDataLength(33))]
+    #[case(hex!("00000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000020FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF"), GasLimitUpdateError::GasLimitDecodingError)]
+    fn test_gas_limit_update_errors(#[case] data: [u8; 96], #[case] expected: GasLimitUpdateError) {
         let log = Log {
             address: Address::ZERO,
             data: LogData::new_unchecked(
-                vec![
-                    CONFIG_UPDATE_TOPIC,
-                    CONFIG_UPDATE_EVENT_VERSION_0,
-                    B256::ZERO,
-                ],
-                hex!("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF00000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000babe0000beef").into()
-            )
+                vec![SystemConfigUpdate::TOPIC, SystemConfigUpdate::EVENT_VERSION_0, B256::ZERO],
+                data.into(),
+            ),
         };
-
         let system_log = SystemConfigLog::new(log, false);
-        let err = GasLimitUpdate::try_from(&system_log).unwrap_err();
-        assert_eq!(err, GasLimitUpdateError::PointerDecodingError);
-    }
-
-    #[test]
-    fn test_gas_limit_update_invalid_pointer_length() {
-        let log = Log {
-            address: Address::ZERO,
-            data: LogData::new_unchecked(
-                vec![
-                    CONFIG_UPDATE_TOPIC,
-                    CONFIG_UPDATE_EVENT_VERSION_0,
-                    B256::ZERO,
-                ],
-                hex!("000000000000000000000000000000000000000000000000000000000000002100000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000babe0000beef").into()
-            )
-        };
-
-        let system_log = SystemConfigLog::new(log, false);
-        let err = GasLimitUpdate::try_from(&system_log).unwrap_err();
-        assert_eq!(err, GasLimitUpdateError::InvalidDataPointer(33));
-    }
-
-    #[test]
-    fn test_gas_limit_update_length_decoding_error() {
-        let log = Log {
-            address: Address::ZERO,
-            data: LogData::new_unchecked(
-                vec![
-                    CONFIG_UPDATE_TOPIC,
-                    CONFIG_UPDATE_EVENT_VERSION_0,
-                    B256::ZERO,
-                ],
-                hex!("0000000000000000000000000000000000000000000000000000000000000020FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF0000000000000000000000000000000000000000000000000000babe0000beef").into()
-            )
-        };
-
-        let system_log = SystemConfigLog::new(log, false);
-        let err = GasLimitUpdate::try_from(&system_log).unwrap_err();
-        assert_eq!(err, GasLimitUpdateError::LengthDecodingError);
-    }
-
-    #[test]
-    fn test_gas_limit_update_invalid_data_length() {
-        let log = Log {
-            address: Address::ZERO,
-            data: LogData::new_unchecked(
-                vec![
-                    CONFIG_UPDATE_TOPIC,
-                    CONFIG_UPDATE_EVENT_VERSION_0,
-                    B256::ZERO,
-                ],
-                hex!("000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000210000000000000000000000000000000000000000000000000000babe0000beef").into()
-            )
-        };
-
-        let system_log = SystemConfigLog::new(log, false);
-        let err = GasLimitUpdate::try_from(&system_log).unwrap_err();
-        assert_eq!(err, GasLimitUpdateError::InvalidDataLength(33));
-    }
-
-    #[test]
-    fn test_gas_limit_update_gas_limit_decoding_error() {
-        let log = Log {
-            address: Address::ZERO,
-            data: LogData::new_unchecked(
-                vec![
-                    CONFIG_UPDATE_TOPIC,
-                    CONFIG_UPDATE_EVENT_VERSION_0,
-                    B256::ZERO,
-                ],
-                hex!("00000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000020FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF").into()
-            )
-        };
-
-        let system_log = SystemConfigLog::new(log, false);
-        let err = GasLimitUpdate::try_from(&system_log).unwrap_err();
-        assert_eq!(err, GasLimitUpdateError::GasLimitDecodingError);
+        assert_eq!(GasLimitUpdate::try_from(&system_log).unwrap_err(), expected);
     }
 }

--- a/crates/consensus/genesis/src/updates/min_base_fee.rs
+++ b/crates/consensus/genesis/src/updates/min_base_fee.rs
@@ -79,7 +79,10 @@ mod tests {
         let log =
             Log { address: Address::ZERO, data: LogData::new_unchecked(vec![], Bytes::default()) };
         let system_log = SystemConfigLog::new(log, false);
-        assert_eq!(MinBaseFeeUpdate::try_from(&system_log).unwrap_err(), MinBaseFeeUpdateError::InvalidDataLen(0));
+        assert_eq!(
+            MinBaseFeeUpdate::try_from(&system_log).unwrap_err(),
+            MinBaseFeeUpdateError::InvalidDataLen(0)
+        );
     }
 
     #[rstest]
@@ -88,7 +91,10 @@ mod tests {
     #[case(hex!("0000000000000000000000000000000000000000000000000000000000000020FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF0000000000000000000000000000000000000000000000000000babe0000beef"), MinBaseFeeUpdateError::LengthDecodingError)]
     #[case(hex!("000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000210000000000000000000000000000000000000000000000000000babe0000beef"), MinBaseFeeUpdateError::InvalidDataLength(33))]
     #[case(hex!("00000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000020FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF"), MinBaseFeeUpdateError::MinBaseFeeDecodingError)]
-    fn test_min_base_fee_update_errors(#[case] data: [u8; 96], #[case] expected: MinBaseFeeUpdateError) {
+    fn test_min_base_fee_update_errors(
+        #[case] data: [u8; 96],
+        #[case] expected: MinBaseFeeUpdateError,
+    ) {
         let log = Log {
             address: Address::ZERO,
             data: LogData::new_unchecked(

--- a/crates/consensus/genesis/src/updates/min_base_fee.rs
+++ b/crates/consensus/genesis/src/updates/min_base_fee.rs
@@ -56,30 +56,22 @@ mod tests {
     use alloc::vec;
 
     use alloy_primitives::{Address, B256, Bytes, Log, LogData, hex};
+    use rstest::rstest;
 
     use super::*;
-    use crate::{CONFIG_UPDATE_EVENT_VERSION_0, CONFIG_UPDATE_TOPIC};
+    use crate::SystemConfigUpdate;
 
     #[test]
     fn test_min_base_fee_update_try_from() {
-        let update_type = B256::ZERO;
-
         let log = Log {
             address: Address::ZERO,
             data: LogData::new_unchecked(
-                vec![
-                    CONFIG_UPDATE_TOPIC,
-                    CONFIG_UPDATE_EVENT_VERSION_0,
-                    update_type,
-                ],
+                vec![SystemConfigUpdate::TOPIC, SystemConfigUpdate::EVENT_VERSION_0, B256::ZERO],
                 hex!("00000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000beef").into()
             )
         };
-
         let system_log = SystemConfigLog::new(log, false);
-        let update = MinBaseFeeUpdate::try_from(&system_log).unwrap();
-
-        assert_eq!(update.min_base_fee, 0xbeef_u64);
+        assert_eq!(MinBaseFeeUpdate::try_from(&system_log).unwrap().min_base_fee, 0xbeef_u64);
     }
 
     #[test]
@@ -87,102 +79,24 @@ mod tests {
         let log =
             Log { address: Address::ZERO, data: LogData::new_unchecked(vec![], Bytes::default()) };
         let system_log = SystemConfigLog::new(log, false);
-        let err = MinBaseFeeUpdate::try_from(&system_log).unwrap_err();
-        assert_eq!(err, MinBaseFeeUpdateError::InvalidDataLen(0));
+        assert_eq!(MinBaseFeeUpdate::try_from(&system_log).unwrap_err(), MinBaseFeeUpdateError::InvalidDataLen(0));
     }
 
-    #[test]
-    fn test_min_base_fee_update_pointer_decoding_error() {
+    #[rstest]
+    #[case(hex!("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF00000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000babe0000beef"), MinBaseFeeUpdateError::PointerDecodingError)]
+    #[case(hex!("000000000000000000000000000000000000000000000000000000000000002100000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000babe0000beef"), MinBaseFeeUpdateError::InvalidDataPointer(33))]
+    #[case(hex!("0000000000000000000000000000000000000000000000000000000000000020FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF0000000000000000000000000000000000000000000000000000babe0000beef"), MinBaseFeeUpdateError::LengthDecodingError)]
+    #[case(hex!("000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000210000000000000000000000000000000000000000000000000000babe0000beef"), MinBaseFeeUpdateError::InvalidDataLength(33))]
+    #[case(hex!("00000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000020FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF"), MinBaseFeeUpdateError::MinBaseFeeDecodingError)]
+    fn test_min_base_fee_update_errors(#[case] data: [u8; 96], #[case] expected: MinBaseFeeUpdateError) {
         let log = Log {
             address: Address::ZERO,
             data: LogData::new_unchecked(
-                vec![
-                    CONFIG_UPDATE_TOPIC,
-                    CONFIG_UPDATE_EVENT_VERSION_0,
-                    B256::ZERO,
-                ],
-                hex!("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF00000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000babe0000beef").into()
-            )
+                vec![SystemConfigUpdate::TOPIC, SystemConfigUpdate::EVENT_VERSION_0, B256::ZERO],
+                data.into(),
+            ),
         };
-
         let system_log = SystemConfigLog::new(log, false);
-        let err = MinBaseFeeUpdate::try_from(&system_log).unwrap_err();
-        assert_eq!(err, MinBaseFeeUpdateError::PointerDecodingError);
-    }
-
-    #[test]
-    fn test_min_base_fee_update_invalid_pointer_length() {
-        let log = Log {
-            address: Address::ZERO,
-            data: LogData::new_unchecked(
-                vec![
-                    CONFIG_UPDATE_TOPIC,
-                    CONFIG_UPDATE_EVENT_VERSION_0,
-                    B256::ZERO,
-                ],
-                hex!("000000000000000000000000000000000000000000000000000000000000002100000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000babe0000beef").into()
-            )
-        };
-
-        let system_log = SystemConfigLog::new(log, false);
-        let err = MinBaseFeeUpdate::try_from(&system_log).unwrap_err();
-        assert_eq!(err, MinBaseFeeUpdateError::InvalidDataPointer(33));
-    }
-
-    #[test]
-    fn test_min_base_fee_update_length_decoding_error() {
-        let log = Log {
-            address: Address::ZERO,
-            data: LogData::new_unchecked(
-                vec![
-                    CONFIG_UPDATE_TOPIC,
-                    CONFIG_UPDATE_EVENT_VERSION_0,
-                    B256::ZERO,
-                ],
-                hex!("0000000000000000000000000000000000000000000000000000000000000020FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF0000000000000000000000000000000000000000000000000000babe0000beef").into()
-            )
-        };
-
-        let system_log = SystemConfigLog::new(log, false);
-        let err = MinBaseFeeUpdate::try_from(&system_log).unwrap_err();
-        assert_eq!(err, MinBaseFeeUpdateError::LengthDecodingError);
-    }
-
-    #[test]
-    fn test_min_base_fee_update_invalid_data_length() {
-        let log = Log {
-            address: Address::ZERO,
-            data: LogData::new_unchecked(
-                vec![
-                    CONFIG_UPDATE_TOPIC,
-                    CONFIG_UPDATE_EVENT_VERSION_0,
-                    B256::ZERO,
-                ],
-                hex!("000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000210000000000000000000000000000000000000000000000000000babe0000beef").into()
-            )
-        };
-
-        let system_log = SystemConfigLog::new(log, false);
-        let err = MinBaseFeeUpdate::try_from(&system_log).unwrap_err();
-        assert_eq!(err, MinBaseFeeUpdateError::InvalidDataLength(33));
-    }
-
-    #[test]
-    fn test_min_base_fee_update_min_base_fee_decoding_error() {
-        let log = Log {
-            address: Address::ZERO,
-            data: LogData::new_unchecked(
-                vec![
-                    CONFIG_UPDATE_TOPIC,
-                    CONFIG_UPDATE_EVENT_VERSION_0,
-                    B256::ZERO,
-                ],
-                hex!("00000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000020FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF").into()
-            )
-        };
-
-        let system_log = SystemConfigLog::new(log, false);
-        let err = MinBaseFeeUpdate::try_from(&system_log).unwrap_err();
-        assert_eq!(err, MinBaseFeeUpdateError::MinBaseFeeDecodingError);
+        assert_eq!(MinBaseFeeUpdate::try_from(&system_log).unwrap_err(), expected);
     }
 }

--- a/crates/consensus/genesis/src/updates/operator_fee.rs
+++ b/crates/consensus/genesis/src/updates/operator_fee.rs
@@ -97,7 +97,10 @@ mod tests {
         let log =
             Log { address: Address::ZERO, data: LogData::new_unchecked(vec![], Bytes::default()) };
         let system_log = SystemConfigLog::new(log, false);
-        assert_eq!(OperatorFeeUpdate::try_from(&system_log).unwrap_err(), OperatorFeeUpdateError::InvalidDataLen(0));
+        assert_eq!(
+            OperatorFeeUpdate::try_from(&system_log).unwrap_err(),
+            OperatorFeeUpdateError::InvalidDataLen(0)
+        );
     }
 
     #[rstest]
@@ -105,7 +108,10 @@ mod tests {
     #[case(hex!("000000000000000000000000000000000000000000000000000000000000002100000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000babe0000beef"), OperatorFeeUpdateError::InvalidDataPointer(33))]
     #[case(hex!("0000000000000000000000000000000000000000000000000000000000000020FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF0000000000000000000000000000000000000000000000000000babe0000beef"), OperatorFeeUpdateError::LengthDecodingError)]
     #[case(hex!("000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000210000000000000000000000000000000000000000000000000000babe0000beef"), OperatorFeeUpdateError::InvalidDataLength(33))]
-    fn test_operator_fee_update_errors(#[case] data: [u8; 96], #[case] expected: OperatorFeeUpdateError) {
+    fn test_operator_fee_update_errors(
+        #[case] data: [u8; 96],
+        #[case] expected: OperatorFeeUpdateError,
+    ) {
         let log = Log {
             address: Address::ZERO,
             data: LogData::new_unchecked(

--- a/crates/consensus/genesis/src/updates/operator_fee.rs
+++ b/crates/consensus/genesis/src/updates/operator_fee.rs
@@ -72,9 +72,10 @@ mod tests {
     use alloc::vec;
 
     use alloy_primitives::{Address, B256, Bytes, Log, LogData, hex};
+    use rstest::rstest;
 
     use super::*;
-    use crate::{CONFIG_UPDATE_EVENT_VERSION_0, CONFIG_UPDATE_TOPIC};
+    use crate::SystemConfigUpdate;
 
     #[test]
     fn test_operator_fee_update_try_from() {
@@ -85,10 +86,8 @@ mod tests {
                 hex!("0000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000babe000000000000beef").into()
             )
         };
-
         let system_log = SystemConfigLog::new(log, false);
         let update = OperatorFeeUpdate::try_from(&system_log).unwrap();
-
         assert_eq!(update.operator_fee_scalar, 0xbabe_u32);
         assert_eq!(update.operator_fee_constant, 0xbeef_u64);
     }
@@ -98,83 +97,23 @@ mod tests {
         let log =
             Log { address: Address::ZERO, data: LogData::new_unchecked(vec![], Bytes::default()) };
         let system_log = SystemConfigLog::new(log, false);
-        let err = OperatorFeeUpdate::try_from(&system_log).unwrap_err();
-        assert_eq!(err, OperatorFeeUpdateError::InvalidDataLen(0));
+        assert_eq!(OperatorFeeUpdate::try_from(&system_log).unwrap_err(), OperatorFeeUpdateError::InvalidDataLen(0));
     }
 
-    #[test]
-    fn test_operator_fee_update_pointer_decoding_error() {
+    #[rstest]
+    #[case(hex!("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF00000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000babe0000beef"), OperatorFeeUpdateError::PointerDecodingError)]
+    #[case(hex!("000000000000000000000000000000000000000000000000000000000000002100000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000babe0000beef"), OperatorFeeUpdateError::InvalidDataPointer(33))]
+    #[case(hex!("0000000000000000000000000000000000000000000000000000000000000020FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF0000000000000000000000000000000000000000000000000000babe0000beef"), OperatorFeeUpdateError::LengthDecodingError)]
+    #[case(hex!("000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000210000000000000000000000000000000000000000000000000000babe0000beef"), OperatorFeeUpdateError::InvalidDataLength(33))]
+    fn test_operator_fee_update_errors(#[case] data: [u8; 96], #[case] expected: OperatorFeeUpdateError) {
         let log = Log {
             address: Address::ZERO,
             data: LogData::new_unchecked(
-                vec![
-                    CONFIG_UPDATE_TOPIC,
-                    CONFIG_UPDATE_EVENT_VERSION_0,
-                    B256::ZERO,
-                ],
-                hex!("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF00000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000babe0000beef").into()
-            )
+                vec![SystemConfigUpdate::TOPIC, SystemConfigUpdate::EVENT_VERSION_0, B256::ZERO],
+                data.into(),
+            ),
         };
-
         let system_log = SystemConfigLog::new(log, false);
-        let err = OperatorFeeUpdate::try_from(&system_log).unwrap_err();
-        assert_eq!(err, OperatorFeeUpdateError::PointerDecodingError);
-    }
-
-    #[test]
-    fn test_operator_fee_update_invalid_pointer_length() {
-        let log = Log {
-            address: Address::ZERO,
-            data: LogData::new_unchecked(
-                vec![
-                    CONFIG_UPDATE_TOPIC,
-                    CONFIG_UPDATE_EVENT_VERSION_0,
-                    B256::ZERO,
-                ],
-                hex!("000000000000000000000000000000000000000000000000000000000000002100000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000babe0000beef").into()
-            )
-        };
-
-        let system_log = SystemConfigLog::new(log, false);
-        let err = OperatorFeeUpdate::try_from(&system_log).unwrap_err();
-        assert_eq!(err, OperatorFeeUpdateError::InvalidDataPointer(33));
-    }
-
-    #[test]
-    fn test_operator_fee_update_length_decoding_error() {
-        let log = Log {
-            address: Address::ZERO,
-            data: LogData::new_unchecked(
-                vec![
-                    CONFIG_UPDATE_TOPIC,
-                    CONFIG_UPDATE_EVENT_VERSION_0,
-                    B256::ZERO,
-                ],
-                hex!("0000000000000000000000000000000000000000000000000000000000000020FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF0000000000000000000000000000000000000000000000000000babe0000beef").into()
-            )
-        };
-
-        let system_log = SystemConfigLog::new(log, false);
-        let err = OperatorFeeUpdate::try_from(&system_log).unwrap_err();
-        assert_eq!(err, OperatorFeeUpdateError::LengthDecodingError);
-    }
-
-    #[test]
-    fn test_operator_fee_update_invalid_data_length() {
-        let log = Log {
-            address: Address::ZERO,
-            data: LogData::new_unchecked(
-                vec![
-                    CONFIG_UPDATE_TOPIC,
-                    CONFIG_UPDATE_EVENT_VERSION_0,
-                    B256::ZERO,
-                ],
-                hex!("000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000210000000000000000000000000000000000000000000000000000babe0000beef").into()
-            )
-        };
-
-        let system_log = SystemConfigLog::new(log, false);
-        let err = OperatorFeeUpdate::try_from(&system_log).unwrap_err();
-        assert_eq!(err, OperatorFeeUpdateError::InvalidDataLength(33));
+        assert_eq!(OperatorFeeUpdate::try_from(&system_log).unwrap_err(), expected);
     }
 }

--- a/crates/consensus/genesis/src/updates/signer.rs
+++ b/crates/consensus/genesis/src/updates/signer.rs
@@ -54,32 +54,23 @@ mod tests {
     use alloc::vec;
 
     use alloy_primitives::{B256, Bytes, Log, LogData, address, hex};
+    use rstest::rstest;
 
     use super::*;
-    use crate::{CONFIG_UPDATE_EVENT_VERSION_0, CONFIG_UPDATE_TOPIC};
+    use crate::SystemConfigUpdate;
 
     #[test]
     fn test_signer_update_try_from() {
-        let update_type = B256::ZERO;
-
         let log = Log {
             address: Address::ZERO,
             data: LogData::new_unchecked(
-                vec![
-                    CONFIG_UPDATE_TOPIC,
-                    CONFIG_UPDATE_EVENT_VERSION_0,
-                    update_type,
-                ],
+                vec![SystemConfigUpdate::TOPIC, SystemConfigUpdate::EVENT_VERSION_0, B256::ZERO],
                 hex!("00000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000beef").into()
             )
         };
-
         let system_log = SystemConfigLog::new(log, false);
         let update = UnsafeBlockSignerUpdate::try_from(&system_log).unwrap();
-        assert_eq!(
-            update.unsafe_block_signer,
-            address!("000000000000000000000000000000000000bEEF"),
-        );
+        assert_eq!(update.unsafe_block_signer, address!("000000000000000000000000000000000000bEEF"));
     }
 
     #[test]
@@ -87,102 +78,24 @@ mod tests {
         let log =
             Log { address: Address::ZERO, data: LogData::new_unchecked(vec![], Bytes::default()) };
         let system_log = SystemConfigLog::new(log, false);
-        let err = UnsafeBlockSignerUpdate::try_from(&system_log).unwrap_err();
-        assert_eq!(err, UnsafeBlockSignerUpdateError::InvalidDataLen(0));
+        assert_eq!(UnsafeBlockSignerUpdate::try_from(&system_log).unwrap_err(), UnsafeBlockSignerUpdateError::InvalidDataLen(0));
     }
 
-    #[test]
-    fn test_signer_update_pointer_decoding_error() {
+    #[rstest]
+    #[case(hex!("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF00000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000babe0000beef"), UnsafeBlockSignerUpdateError::PointerDecodingError)]
+    #[case(hex!("000000000000000000000000000000000000000000000000000000000000002100000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000babe0000beef"), UnsafeBlockSignerUpdateError::InvalidDataPointer(33))]
+    #[case(hex!("0000000000000000000000000000000000000000000000000000000000000020FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF0000000000000000000000000000000000000000000000000000babe0000beef"), UnsafeBlockSignerUpdateError::LengthDecodingError)]
+    #[case(hex!("000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000210000000000000000000000000000000000000000000000000000babe0000beef"), UnsafeBlockSignerUpdateError::InvalidDataLength(33))]
+    #[case(hex!("00000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000020FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF"), UnsafeBlockSignerUpdateError::UnsafeBlockSignerAddressDecodingError)]
+    fn test_signer_update_errors(#[case] data: [u8; 96], #[case] expected: UnsafeBlockSignerUpdateError) {
         let log = Log {
             address: Address::ZERO,
             data: LogData::new_unchecked(
-                vec![
-                    CONFIG_UPDATE_TOPIC,
-                    CONFIG_UPDATE_EVENT_VERSION_0,
-                    B256::ZERO,
-                ],
-                hex!("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF00000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000babe0000beef").into()
-            )
+                vec![SystemConfigUpdate::TOPIC, SystemConfigUpdate::EVENT_VERSION_0, B256::ZERO],
+                data.into(),
+            ),
         };
-
         let system_log = SystemConfigLog::new(log, false);
-        let err = UnsafeBlockSignerUpdate::try_from(&system_log).unwrap_err();
-        assert_eq!(err, UnsafeBlockSignerUpdateError::PointerDecodingError);
-    }
-
-    #[test]
-    fn test_signer_update_invalid_pointer_length() {
-        let log = Log {
-            address: Address::ZERO,
-            data: LogData::new_unchecked(
-                vec![
-                    CONFIG_UPDATE_TOPIC,
-                    CONFIG_UPDATE_EVENT_VERSION_0,
-                    B256::ZERO,
-                ],
-                hex!("000000000000000000000000000000000000000000000000000000000000002100000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000babe0000beef").into()
-            )
-        };
-
-        let system_log = SystemConfigLog::new(log, false);
-        let err = UnsafeBlockSignerUpdate::try_from(&system_log).unwrap_err();
-        assert_eq!(err, UnsafeBlockSignerUpdateError::InvalidDataPointer(33));
-    }
-
-    #[test]
-    fn test_signer_update_length_decoding_error() {
-        let log = Log {
-            address: Address::ZERO,
-            data: LogData::new_unchecked(
-                vec![
-                    CONFIG_UPDATE_TOPIC,
-                    CONFIG_UPDATE_EVENT_VERSION_0,
-                    B256::ZERO,
-                ],
-                hex!("0000000000000000000000000000000000000000000000000000000000000020FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF0000000000000000000000000000000000000000000000000000babe0000beef").into()
-            )
-        };
-
-        let system_log = SystemConfigLog::new(log, false);
-        let err = UnsafeBlockSignerUpdate::try_from(&system_log).unwrap_err();
-        assert_eq!(err, UnsafeBlockSignerUpdateError::LengthDecodingError);
-    }
-
-    #[test]
-    fn test_signer_update_invalid_data_length() {
-        let log = Log {
-            address: Address::ZERO,
-            data: LogData::new_unchecked(
-                vec![
-                    CONFIG_UPDATE_TOPIC,
-                    CONFIG_UPDATE_EVENT_VERSION_0,
-                    B256::ZERO,
-                ],
-                hex!("000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000210000000000000000000000000000000000000000000000000000babe0000beef").into()
-            )
-        };
-
-        let system_log = SystemConfigLog::new(log, false);
-        let err = UnsafeBlockSignerUpdate::try_from(&system_log).unwrap_err();
-        assert_eq!(err, UnsafeBlockSignerUpdateError::InvalidDataLength(33));
-    }
-
-    #[test]
-    fn test_signer_update_address_decoding_error() {
-        let log = Log {
-            address: Address::ZERO,
-            data: LogData::new_unchecked(
-                vec![
-                    CONFIG_UPDATE_TOPIC,
-                    CONFIG_UPDATE_EVENT_VERSION_0,
-                    B256::ZERO,
-                ],
-                hex!("00000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000020FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF").into()
-            )
-        };
-
-        let system_log = SystemConfigLog::new(log, false);
-        let err = UnsafeBlockSignerUpdate::try_from(&system_log).unwrap_err();
-        assert_eq!(err, UnsafeBlockSignerUpdateError::UnsafeBlockSignerAddressDecodingError);
+        assert_eq!(UnsafeBlockSignerUpdate::try_from(&system_log).unwrap_err(), expected);
     }
 }

--- a/crates/consensus/genesis/src/updates/signer.rs
+++ b/crates/consensus/genesis/src/updates/signer.rs
@@ -70,7 +70,10 @@ mod tests {
         };
         let system_log = SystemConfigLog::new(log, false);
         let update = UnsafeBlockSignerUpdate::try_from(&system_log).unwrap();
-        assert_eq!(update.unsafe_block_signer, address!("000000000000000000000000000000000000bEEF"));
+        assert_eq!(
+            update.unsafe_block_signer,
+            address!("000000000000000000000000000000000000bEEF")
+        );
     }
 
     #[test]
@@ -78,7 +81,10 @@ mod tests {
         let log =
             Log { address: Address::ZERO, data: LogData::new_unchecked(vec![], Bytes::default()) };
         let system_log = SystemConfigLog::new(log, false);
-        assert_eq!(UnsafeBlockSignerUpdate::try_from(&system_log).unwrap_err(), UnsafeBlockSignerUpdateError::InvalidDataLen(0));
+        assert_eq!(
+            UnsafeBlockSignerUpdate::try_from(&system_log).unwrap_err(),
+            UnsafeBlockSignerUpdateError::InvalidDataLen(0)
+        );
     }
 
     #[rstest]
@@ -87,7 +93,10 @@ mod tests {
     #[case(hex!("0000000000000000000000000000000000000000000000000000000000000020FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF0000000000000000000000000000000000000000000000000000babe0000beef"), UnsafeBlockSignerUpdateError::LengthDecodingError)]
     #[case(hex!("000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000210000000000000000000000000000000000000000000000000000babe0000beef"), UnsafeBlockSignerUpdateError::InvalidDataLength(33))]
     #[case(hex!("00000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000020FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF"), UnsafeBlockSignerUpdateError::UnsafeBlockSignerAddressDecodingError)]
-    fn test_signer_update_errors(#[case] data: [u8; 96], #[case] expected: UnsafeBlockSignerUpdateError) {
+    fn test_signer_update_errors(
+        #[case] data: [u8; 96],
+        #[case] expected: UnsafeBlockSignerUpdateError,
+    ) {
         let log = Log {
             address: Address::ZERO,
             data: LogData::new_unchecked(

--- a/crates/consensus/protocol/src/batch/transactions.rs
+++ b/crates/consensus/protocol/src/batch/transactions.rs
@@ -424,59 +424,24 @@ mod tests {
         assert_eq!(err, SpanBatchError::Decoding(SpanDecodingError::InvalidTransactionData));
     }
 
-    #[test]
-    fn test_span_batch_transactions_add_eip2930_tx() {
-        let sig = Signature::test_signature();
-        let to = address!("0123456789012345678901234567890123456789");
-        let tx = TxEnvelope::Eip2930(Signed::new_unchecked(
-            TxEip2930 { to: TxKind::Call(to), chain_id: 1, ..Default::default() },
-            sig,
-            Default::default(),
-        ));
+    #[rstest::rstest]
+    #[case::eip2930(TxEnvelope::Eip2930(Signed::new_unchecked(
+        TxEip2930 { to: TxKind::Call(address!("0123456789012345678901234567890123456789")), chain_id: 1, ..Default::default() },
+        Signature::test_signature(), Default::default(),
+    )))]
+    #[case::eip1559(TxEnvelope::Eip1559(Signed::new_unchecked(
+        TxEip1559 { to: TxKind::Call(address!("0123456789012345678901234567890123456789")), chain_id: 1, ..Default::default() },
+        Signature::test_signature(), Default::default(),
+    )))]
+    #[case::eip7702(TxEnvelope::Eip7702(Signed::new_unchecked(
+        TxEip7702 { to: address!("0123456789012345678901234567890123456789"), chain_id: 1, ..Default::default() },
+        Signature::test_signature(), Default::default(),
+    )))]
+    fn test_span_batch_transactions_add_tx(#[case] tx: TxEnvelope) {
         let mut span_batch_txs = SpanBatchTransactions::default();
         let mut buf = vec![];
         tx.encode(&mut buf);
-        let txs = vec![Bytes::from(buf)];
-        let chain_id = 1;
-        let result = span_batch_txs.add_txs(txs, chain_id);
-        assert_eq!(result, Ok(()));
-        assert_eq!(span_batch_txs.total_block_tx_count, 1);
-    }
-
-    #[test]
-    fn test_span_batch_transactions_add_eip1559_tx() {
-        let sig = Signature::test_signature();
-        let to = address!("0123456789012345678901234567890123456789");
-        let tx = TxEnvelope::Eip1559(Signed::new_unchecked(
-            TxEip1559 { to: TxKind::Call(to), chain_id: 1, ..Default::default() },
-            sig,
-            Default::default(),
-        ));
-        let mut span_batch_txs = SpanBatchTransactions::default();
-        let mut buf = vec![];
-        tx.encode(&mut buf);
-        let txs = vec![Bytes::from(buf)];
-        let chain_id = 1;
-        let result = span_batch_txs.add_txs(txs, chain_id);
-        assert_eq!(result, Ok(()));
-        assert_eq!(span_batch_txs.total_block_tx_count, 1);
-    }
-
-    #[test]
-    fn test_span_batch_transactions_add_eip7702_tx() {
-        let sig = Signature::test_signature();
-        let to = address!("0123456789012345678901234567890123456789");
-        let tx = TxEnvelope::Eip7702(Signed::new_unchecked(
-            TxEip7702 { to, chain_id: 1, ..Default::default() },
-            sig,
-            Default::default(),
-        ));
-        let mut span_batch_txs = SpanBatchTransactions::default();
-        let mut buf = vec![];
-        tx.encode(&mut buf);
-        let txs = vec![Bytes::from(buf)];
-        let chain_id = 1;
-        let result = span_batch_txs.add_txs(txs, chain_id);
+        let result = span_batch_txs.add_txs(vec![Bytes::from(buf)], 1);
         assert_eq!(result, Ok(()));
         assert_eq!(span_batch_txs.total_block_tx_count, 1);
     }

--- a/crates/consensus/upgrades/src/ecotone.rs
+++ b/crates/consensus/upgrades/src/ecotone.rs
@@ -206,7 +206,11 @@ mod tests {
     #[rstest]
     #[case(0, Ecotone::NEW_L1_BLOCK, Ecotone::L1_BLOCK_DEPLOYER_CODE_HASH)]
     #[case(1, Ecotone::GAS_PRICE_ORACLE, Ecotone::GAS_PRICE_ORACLE_CODE_HASH)]
-    fn test_ecotone_deployment_code_hashes(#[case] tx_idx: usize, #[case] addr: Address, #[case] code_hash: B256) {
+    fn test_ecotone_deployment_code_hashes(
+        #[case] tx_idx: usize,
+        #[case] addr: Address,
+        #[case] code_hash: B256,
+    ) {
         let txs = Ecotone::deposits().collect::<Vec<_>>();
         check_deployment_code(txs[tx_idx].clone(), addr, code_hash);
     }

--- a/crates/consensus/upgrades/src/ecotone.rs
+++ b/crates/consensus/upgrades/src/ecotone.rs
@@ -187,76 +187,28 @@ impl Hardfork for Ecotone {
 mod tests {
     use alloc::vec;
 
+    use rstest::rstest;
+
     use super::*;
     use crate::test_utils::check_deployment_code;
 
-    #[test]
-    fn test_deploy_l1_block_source() {
-        assert_eq!(
-            Ecotone::deploy_l1_block_source(),
-            hex!("877a6077205782ea15a6dc8699fa5ebcec5e0f4389f09cb8eda09488231346f8")
-        );
+    #[rstest]
+    #[case(Ecotone::deploy_l1_block_source(), hex!("877a6077205782ea15a6dc8699fa5ebcec5e0f4389f09cb8eda09488231346f8"))]
+    #[case(Ecotone::deploy_gas_price_oracle_source(), hex!("a312b4510adf943510f05fcc8f15f86995a5066bd83ce11384688ae20e6ecf42"))]
+    #[case(Ecotone::update_l1_block_source(), hex!("18acb38c5ff1c238a7460ebc1b421fa49ec4874bdf1e0a530d234104e5e67dbc"))]
+    #[case(Ecotone::update_gas_price_oracle_source(), hex!("ee4f9385eceef498af0be7ec5862229f426dec41c8d42397c7257a5117d9230a"))]
+    #[case(Ecotone::enable_ecotone_source(), hex!("0c1cb38e99dbc9cbfab3bb80863380b0905290b37eb3d6ab18dc01c1f3e75f93"))]
+    #[case(Ecotone::beacon_roots_source(), hex!("69b763c48478b9dc2f65ada09b3d92133ec592ea715ec65ad6e7f3dc519dc00c"))]
+    fn test_ecotone_source_hashes(#[case] actual: B256, #[case] expected: [u8; 32]) {
+        assert_eq!(actual, expected);
     }
-    #[test]
-    fn test_verify_ecotone_l1_deployment_code_hash() {
+
+    #[rstest]
+    #[case(0, Ecotone::NEW_L1_BLOCK, Ecotone::L1_BLOCK_DEPLOYER_CODE_HASH)]
+    #[case(1, Ecotone::GAS_PRICE_ORACLE, Ecotone::GAS_PRICE_ORACLE_CODE_HASH)]
+    fn test_ecotone_deployment_code_hashes(#[case] tx_idx: usize, #[case] addr: Address, #[case] code_hash: B256) {
         let txs = Ecotone::deposits().collect::<Vec<_>>();
-
-        check_deployment_code(
-            txs[0].clone(),
-            Ecotone::NEW_L1_BLOCK,
-            Ecotone::L1_BLOCK_DEPLOYER_CODE_HASH,
-        );
-    }
-
-    #[test]
-    fn test_verify_ecotone_gas_price_oracle_deployment_code_hash() {
-        let txs = Ecotone::deposits().collect::<Vec<_>>();
-
-        check_deployment_code(
-            txs[1].clone(),
-            Ecotone::GAS_PRICE_ORACLE,
-            Ecotone::GAS_PRICE_ORACLE_CODE_HASH,
-        );
-    }
-
-    #[test]
-    fn test_deploy_gas_price_oracle_source() {
-        assert_eq!(
-            Ecotone::deploy_gas_price_oracle_source(),
-            hex!("a312b4510adf943510f05fcc8f15f86995a5066bd83ce11384688ae20e6ecf42")
-        );
-    }
-
-    #[test]
-    fn test_update_l1_block_source() {
-        assert_eq!(
-            Ecotone::update_l1_block_source(),
-            hex!("18acb38c5ff1c238a7460ebc1b421fa49ec4874bdf1e0a530d234104e5e67dbc")
-        );
-    }
-
-    #[test]
-    fn test_update_gas_price_oracle_source() {
-        assert_eq!(
-            Ecotone::update_gas_price_oracle_source(),
-            hex!("ee4f9385eceef498af0be7ec5862229f426dec41c8d42397c7257a5117d9230a")
-        );
-    }
-
-    #[test]
-    fn test_enable_ecotone_source() {
-        assert_eq!(
-            Ecotone::enable_ecotone_source(),
-            hex!("0c1cb38e99dbc9cbfab3bb80863380b0905290b37eb3d6ab18dc01c1f3e75f93")
-        );
-    }
-
-    #[test]
-    fn test_beacon_block_roots_source() {
-        assert_eq!(
-            Ecotone::beacon_roots_source(),
-            hex!("69b763c48478b9dc2f65ada09b3d92133ec592ea715ec65ad6e7f3dc519dc00c")
-        );
+        check_deployment_code(txs[tx_idx].clone(), addr, code_hash);
     }
 
     #[test]

--- a/crates/consensus/upgrades/src/fjord.rs
+++ b/crates/consensus/upgrades/src/fjord.rs
@@ -114,31 +114,17 @@ impl Hardfork for Fjord {
 mod tests {
     use alloc::vec;
 
+    use rstest::rstest;
+
     use super::*;
     use crate::test_utils::check_deployment_code;
 
-    #[test]
-    fn test_deploy_fjord_gas_price_oracle_source() {
-        assert_eq!(
-            Fjord::deploy_fjord_gas_price_oracle_source(),
-            hex!("86122c533fdcb89b16d8713174625e44578a89751d96c098ec19ab40a51a8ea3")
-        );
-    }
-
-    #[test]
-    fn test_update_fjord_gas_price_oracle_source() {
-        assert_eq!(
-            Fjord::update_fjord_gas_price_oracle_source(),
-            hex!("1e6bb0c28bfab3dc9b36ffb0f721f00d6937f33577606325692db0965a7d58c6")
-        );
-    }
-
-    #[test]
-    fn test_enable_fjord_source() {
-        assert_eq!(
-            Fjord::enable_fjord_source(),
-            hex!("bac7bb0d5961cad209a345408b0280a0d4686b1b20665e1b0f9cdafd73b19b6b")
-        );
+    #[rstest]
+    #[case(Fjord::deploy_fjord_gas_price_oracle_source(), hex!("86122c533fdcb89b16d8713174625e44578a89751d96c098ec19ab40a51a8ea3"))]
+    #[case(Fjord::update_fjord_gas_price_oracle_source(), hex!("1e6bb0c28bfab3dc9b36ffb0f721f00d6937f33577606325692db0965a7d58c6"))]
+    #[case(Fjord::enable_fjord_source(), hex!("bac7bb0d5961cad209a345408b0280a0d4686b1b20665e1b0f9cdafd73b19b6b"))]
+    fn test_fjord_source_hashes(#[case] actual: B256, #[case] expected: [u8; 32]) {
+        assert_eq!(actual, expected);
     }
 
     #[test]

--- a/crates/consensus/upgrades/src/isthmus.rs
+++ b/crates/consensus/upgrades/src/isthmus.rs
@@ -269,7 +269,11 @@ mod tests {
     #[case(0, Isthmus::NEW_L1_BLOCK, Isthmus::L1_BLOCK_DEPLOYER_CODE_HASH)]
     #[case(1, Isthmus::GAS_PRICE_ORACLE, Isthmus::GAS_PRICE_ORACLE_CODE_HASH)]
     #[case(2, Isthmus::OPERATOR_FEE_VAULT, Isthmus::OPERATOR_FEE_VAULT_CODE_HASH)]
-    fn test_isthmus_deployment_code_hashes(#[case] tx_idx: usize, #[case] addr: Address, #[case] code_hash: B256) {
+    fn test_isthmus_deployment_code_hashes(
+        #[case] tx_idx: usize,
+        #[case] addr: Address,
+        #[case] code_hash: B256,
+    ) {
         let txs = Isthmus::deposits().collect::<Vec<_>>();
         check_deployment_code(txs[tx_idx].clone(), addr, code_hash);
     }

--- a/crates/consensus/upgrades/src/isthmus.rs
+++ b/crates/consensus/upgrades/src/isthmus.rs
@@ -229,50 +229,21 @@ mod tests {
     use alloc::vec;
 
     use alloy_primitives::b256;
+    use rstest::rstest;
 
     use super::*;
     use crate::test_utils::check_deployment_code;
 
-    #[test]
-    fn test_l1_block_source_hash() {
-        let expected = b256!("3b2d0821ca2411ad5cd3595804d1213d15737188ae4cbd58aa19c821a6c211bf");
-        assert_eq!(Isthmus::deploy_l1_block_source(), expected);
-    }
-
-    #[test]
-    fn test_gas_price_oracle_source_hash() {
-        let expected = b256!("fc70b48424763fa3fab9844253b4f8d508f91eb1f7cb11a247c9baec0afb8035");
-        assert_eq!(Isthmus::deploy_gas_price_oracle_source(), expected);
-    }
-
-    #[test]
-    fn test_operator_fee_vault_source_hash() {
-        let expected = b256!("107a570d3db75e6110817eb024f09f3172657e920634111ce9875d08a16daa96");
-        assert_eq!(Isthmus::deploy_operator_fee_vault_source(), expected);
-    }
-
-    #[test]
-    fn test_l1_block_update_source_hash() {
-        let expected = b256!("ebe8b5cb10ca47e0d8bda8f5355f2d66711a54ddeb0ef1d30e29418c9bf17a0e");
-        assert_eq!(Isthmus::update_l1_block_source(), expected);
-    }
-
-    #[test]
-    fn test_gas_price_oracle_update_source_hash() {
-        let expected = b256!("ecf2d9161d26c54eda6b7bfdd9142719b1e1199a6e5641468d1bf705bc531ab0");
-        assert_eq!(Isthmus::update_gas_price_oracle_source(), expected);
-    }
-
-    #[test]
-    fn test_operator_fee_vault_update_source_hash() {
-        let expected = b256!("ad74e1adb877ccbe176b8fa1cc559388a16e090ddbe8b512f5b37d07d887a927");
-        assert_eq!(Isthmus::update_operator_fee_vault_source(), expected);
-    }
-
-    #[test]
-    fn test_enable_isthmus_source() {
-        let expected = b256!("3ddf4b1302548dd92939826e970f260ba36167f4c25f18390a5e8b194b295319");
-        assert_eq!(Isthmus::enable_isthmus_source(), expected);
+    #[rstest]
+    #[case(Isthmus::deploy_l1_block_source(), b256!("3b2d0821ca2411ad5cd3595804d1213d15737188ae4cbd58aa19c821a6c211bf"))]
+    #[case(Isthmus::deploy_gas_price_oracle_source(), b256!("fc70b48424763fa3fab9844253b4f8d508f91eb1f7cb11a247c9baec0afb8035"))]
+    #[case(Isthmus::deploy_operator_fee_vault_source(), b256!("107a570d3db75e6110817eb024f09f3172657e920634111ce9875d08a16daa96"))]
+    #[case(Isthmus::update_l1_block_source(), b256!("ebe8b5cb10ca47e0d8bda8f5355f2d66711a54ddeb0ef1d30e29418c9bf17a0e"))]
+    #[case(Isthmus::update_gas_price_oracle_source(), b256!("ecf2d9161d26c54eda6b7bfdd9142719b1e1199a6e5641468d1bf705bc531ab0"))]
+    #[case(Isthmus::update_operator_fee_vault_source(), b256!("ad74e1adb877ccbe176b8fa1cc559388a16e090ddbe8b512f5b37d07d887a927"))]
+    #[case(Isthmus::enable_isthmus_source(), b256!("3ddf4b1302548dd92939826e970f260ba36167f4c25f18390a5e8b194b295319"))]
+    fn test_isthmus_source_hashes(#[case] actual: B256, #[case] expected: B256) {
+        assert_eq!(actual, expected);
     }
 
     #[test]
@@ -294,33 +265,12 @@ mod tests {
             assert_eq!(isthmus_upgrade_tx[i], *expected);
         }
     }
-    #[test]
-    fn test_verify_isthmus_l1_block_deployment_code_hash() {
+    #[rstest]
+    #[case(0, Isthmus::NEW_L1_BLOCK, Isthmus::L1_BLOCK_DEPLOYER_CODE_HASH)]
+    #[case(1, Isthmus::GAS_PRICE_ORACLE, Isthmus::GAS_PRICE_ORACLE_CODE_HASH)]
+    #[case(2, Isthmus::OPERATOR_FEE_VAULT, Isthmus::OPERATOR_FEE_VAULT_CODE_HASH)]
+    fn test_isthmus_deployment_code_hashes(#[case] tx_idx: usize, #[case] addr: Address, #[case] code_hash: B256) {
         let txs = Isthmus::deposits().collect::<Vec<_>>();
-        check_deployment_code(
-            txs[0].clone(),
-            Isthmus::NEW_L1_BLOCK,
-            Isthmus::L1_BLOCK_DEPLOYER_CODE_HASH,
-        );
-    }
-    #[test]
-    fn test_verify_isthmus_gas_price_oracle_deployment_code_hash() {
-        let txs = Isthmus::deposits().collect::<Vec<_>>();
-
-        check_deployment_code(
-            txs[1].clone(),
-            Isthmus::GAS_PRICE_ORACLE,
-            Isthmus::GAS_PRICE_ORACLE_CODE_HASH,
-        );
-    }
-    #[test]
-    fn test_verify_isthmus_operator_fee_vault_deployment_code_hash() {
-        let txs = Isthmus::deposits().collect::<Vec<_>>();
-
-        check_deployment_code(
-            txs[2].clone(),
-            Isthmus::OPERATOR_FEE_VAULT,
-            Isthmus::OPERATOR_FEE_VAULT_CODE_HASH,
-        );
+        check_deployment_code(txs[tx_idx].clone(), addr, code_hash);
     }
 }

--- a/crates/consensus/upgrades/src/jovian.rs
+++ b/crates/consensus/upgrades/src/jovian.rs
@@ -150,81 +150,40 @@ impl Hardfork for Jovian {
 
 #[cfg(test)]
 mod tests {
-    use alloy_primitives::b256;
+    use alloy_primitives::{B256, b256};
+    use rstest::rstest;
 
     use super::*;
     use crate::test_utils::check_deployment_code;
 
-    #[test]
-    fn test_l1_block_source_hash() {
-        let expected = b256!("bb1a656f65401240fac3db12e7a79ebb954b11e62f7626eb11691539b798d3bf");
-        assert_eq!(Jovian::deploy_l1_block_source(), expected);
+    #[rstest]
+    #[case(Jovian::deploy_l1_block_source(), b256!("bb1a656f65401240fac3db12e7a79ebb954b11e62f7626eb11691539b798d3bf"))]
+    #[case(Jovian::l1_block_proxy_update(), b256!("f3275f829340521028f9ad5bce4ecb1c64a45d448794effa2a77674627338e76"))]
+    #[case(Jovian::gas_price_oracle(), b256!("239b7021a6c2cf3a918481242bbb5a9499057f24501539467536c691bb133962"))]
+    #[case(Jovian::gas_price_oracle_proxy_update(), b256!("a70c60aa53b8c1c0d52b39b1e901e7d7c09f7819595cb24048a6bb1983b401ff"))]
+    #[case(Jovian::gas_price_oracle_enable_jovian(), b256!("e836db6a959371756f8941be3e962d000f7e12a32e49e2c9ca42ba177a92716c"))]
+    fn test_jovian_source_hashes(#[case] actual: B256, #[case] expected: B256) {
+        assert_eq!(actual, expected);
     }
 
-    #[test]
-    fn test_l1_block_proxy_update_source_hash() {
-        let expected = b256!("f3275f829340521028f9ad5bce4ecb1c64a45d448794effa2a77674627338e76");
-        assert_eq!(Jovian::l1_block_proxy_update(), expected);
+    #[rstest]
+    #[case(Jovian::gas_price_oracle_address(), hex!("0x3659cfe60000000000000000000000004f1db3c6abd250ba86e0928471a8f7db3afd88f1"))]
+    #[case(Jovian::l1_block_address(), hex!("0x3659cfe60000000000000000000000003ba4007f5c922fbb33c454b41ea7a1f11e83df2c"))]
+    fn test_upgrade_calldata(#[case] addr: Address, #[case] expected: [u8; 36]) {
+        assert_eq!(**UpgradeCalldata::build(addr), expected);
     }
 
-    #[test]
-    fn test_gas_price_oracle_source_hash() {
-        let expected = b256!("239b7021a6c2cf3a918481242bbb5a9499057f24501539467536c691bb133962");
-        assert_eq!(Jovian::gas_price_oracle(), expected);
-    }
-
-    #[test]
-    fn test_upgrade_to_calldata_for_gas_price_oracle() {
-        assert_eq!(
-            **UpgradeCalldata::build(Jovian::gas_price_oracle_address()),
-            hex!("0x3659cfe60000000000000000000000004f1db3c6abd250ba86e0928471a8f7db3afd88f1")
-        );
-    }
-
-    #[test]
-    fn test_upgrade_to_calldata_for_l1_block_proxy_update() {
-        assert_eq!(
-            **UpgradeCalldata::build(Jovian::l1_block_address()),
-            hex!("0x3659cfe60000000000000000000000003ba4007f5c922fbb33c454b41ea7a1f11e83df2c")
-        );
-    }
-
-    #[test]
-    fn test_gas_price_oracle_proxy_update_source_hash() {
-        let expected = b256!("a70c60aa53b8c1c0d52b39b1e901e7d7c09f7819595cb24048a6bb1983b401ff");
-        assert_eq!(Jovian::gas_price_oracle_proxy_update(), expected);
-    }
-
-    #[test]
-    fn test_gas_price_oracle_enable_jovian_source_hash() {
-        let expected = b256!("e836db6a959371756f8941be3e962d000f7e12a32e49e2c9ca42ba177a92716c");
-        assert_eq!(Jovian::gas_price_oracle_enable_jovian(), expected);
-    }
-
-    #[test]
-    fn test_verify_jovian_l1_block_deployment_code_hash() {
+    #[rstest]
+    #[case(0, Jovian::l1_block_address(), hex!("5f885ca815d2cf27a203123e50b8ae204fdca910b6995d90b2d7700cbb9240d1").into())]
+    #[case(2, Jovian::gas_price_oracle_address(), hex!("e9fc7c96c4db0d6078e3d359d7e8c982c350a513cb2c31121adf5e1e8a446614").into())]
+    fn test_jovian_deployment_code_hashes(#[case] tx_idx: usize, #[case] addr: Address, #[case] code_hash: B256) {
         let txs = Jovian::deposits().collect::<Vec<_>>();
-        check_deployment_code(
-            txs[0].clone(),
-            Jovian::l1_block_address(),
-            hex!("5f885ca815d2cf27a203123e50b8ae204fdca910b6995d90b2d7700cbb9240d1").into(),
-        );
+        check_deployment_code(txs[tx_idx].clone(), addr, code_hash);
     }
 
     #[test]
     fn test_verify_set_jovian() {
         let hash = &keccak256("setJovian()")[..4];
         assert_eq!(hash, hex!("0xb3d72079"))
-    }
-
-    #[test]
-    fn test_verify_jovian_gas_price_oracle_deployment_code_hash() {
-        let txs = Jovian::deposits().collect::<Vec<_>>();
-
-        check_deployment_code(
-            txs[2].clone(),
-            Jovian::gas_price_oracle_address(),
-            hex!("e9fc7c96c4db0d6078e3d359d7e8c982c350a513cb2c31121adf5e1e8a446614").into(),
-        );
     }
 }

--- a/crates/consensus/upgrades/src/jovian.rs
+++ b/crates/consensus/upgrades/src/jovian.rs
@@ -176,7 +176,11 @@ mod tests {
     #[rstest]
     #[case(0, Jovian::l1_block_address(), hex!("5f885ca815d2cf27a203123e50b8ae204fdca910b6995d90b2d7700cbb9240d1").into())]
     #[case(2, Jovian::gas_price_oracle_address(), hex!("e9fc7c96c4db0d6078e3d359d7e8c982c350a513cb2c31121adf5e1e8a446614").into())]
-    fn test_jovian_deployment_code_hashes(#[case] tx_idx: usize, #[case] addr: Address, #[case] code_hash: B256) {
+    fn test_jovian_deployment_code_hashes(
+        #[case] tx_idx: usize,
+        #[case] addr: Address,
+        #[case] code_hash: B256,
+    ) {
         let txs = Jovian::deposits().collect::<Vec<_>>();
         check_deployment_code(txs[tx_idx].clone(), addr, code_hash);
     }


### PR DESCRIPTION
## Summary

Collapses repetitive single-case error tests across genesis update modules (batcher, signer, eip1559, gas_limit, gas_config, da_footprint_gas_scalar, min_base_fee, operator_fee) and the upgrades crates (ecotone, fjord, isthmus, jovian) into rstest parameterized tables, removing roughly 850 lines of boilerplate. Also moves CONFIG_UPDATE_TOPIC and CONFIG_UPDATE_EVENT_VERSION_0 from standalone module-level exports onto SystemConfigUpdate as associated constants, updating all call sites in genesis, derive, and stateful attributes. Missing serde feature gates are added to tests in addresses.rs and rollup.rs that require Deserialize bounds.