### PR TITLE
chore(specs): Remove BCP Metadata Table

### DIFF
--- a/docs/specs/pages/bcps/bcp-0000.md
+++ b/docs/specs/pages/bcps/bcp-0000.md
@@ -56,7 +56,7 @@ BCP is rejected or withdrawn. BCP-0000 is reserved for this process document.
 
 Each BCP is a Markdown file stored at `docs/specs/pages/bcps/bcp-{NNNN}.md` in the
 [base repository](https://github.com/base/base). It must begin with the title as an H1
-heading followed by a metadata table, then the body sections below.
+heading followed by the body sections below.
 
 ### Required Sections
 
@@ -85,7 +85,7 @@ Additional sections (e.g. **Security Considerations**, **Backwards Compatibility
    review the specification for correctness, completeness, and alignment with Base's design goals.
 3. **Accepted / Rejected** — The core team makes a final decision. If accepted, the BCP is merged
    and assigned a Final status once the implementation ships to mainnet. If rejected, the BCP is
-   merged with Rejected status and a brief rationale added to the metadata table.
+   merged with Rejected status and a brief rationale added to the BCP.
 4. **Final** — The BCP is updated to Final status when its implementation is deployed to mainnet.
 
 ## BCP Index


### PR DESCRIPTION
## Summary

Very small PR to remove the metadata table requirement from the BCP format spec. Updates the format description and the rejected-status process step to no longer reference it.