### PR TITLE
feat(challenger): add bonds_not_claimable_total metric counter

### DIFF
--- a/crates/proof/challenge/src/bond.rs
+++ b/crates/proof/challenge/src/bond.rs
@@ -565,10 +565,13 @@ impl<C: Clock> BondManager<C> {
 
         for (addr, reason) in &removed {
             self.tracked.remove(addr);
-            if *reason == RemovalReason::Completed {
-                ChallengerMetrics::bonds_completed_total().increment(1);
-            } else if *reason == RemovalReason::NotClaimable {
-                ChallengerMetrics::bonds_not_claimable_total().increment(1);
+            match reason {
+                RemovalReason::Completed => {
+                    ChallengerMetrics::bonds_completed_total().increment(1);
+                }
+                RemovalReason::NotClaimable => {
+                    ChallengerMetrics::bonds_not_claimable_total().increment(1);
+                }
             }
         }
 

--- a/crates/proof/challenge/src/bond.rs
+++ b/crates/proof/challenge/src/bond.rs
@@ -567,6 +567,8 @@ impl<C: Clock> BondManager<C> {
             self.tracked.remove(addr);
             if *reason == RemovalReason::Completed {
                 ChallengerMetrics::bonds_completed_total().increment(1);
+            } else if *reason == RemovalReason::NotClaimable {
+                ChallengerMetrics::bonds_not_claimable_total().increment(1);
             }
         }
 

--- a/crates/proof/challenge/src/metrics.rs
+++ b/crates/proof/challenge/src/metrics.rs
@@ -83,6 +83,9 @@ base_metrics::define_metrics! {
     #[describe("Total number of bonds successfully claimed")]
     bonds_completed_total: counter,
 
+    #[describe("Total number of bonds dropped because recipient changed after resolve")]
+    bonds_not_claimable_total: counter,
+
     #[describe("Total bond discovery scans performed")]
     #[label(scan_type)]
     bond_discovery_scans_total: counter,


### PR DESCRIPTION
## Summary

- Adds a `bonds_not_claimable_total` Prometheus counter that increments when a game is removed from bond tracking because the bond recipient changed after resolve (`NotClaimable`)
- Previously there was no metric for this path — operators had to grep logs to detect it

Closes CHAIN-3859

Follow-up from PR #1894 [review comment](https://github.com/base/base/pull/1894) by @leopoldjoy.