### PR TITLE
fix(node): accept comma-delimited values for --builder-rpc-urls [backport v0.7.0]

### DIFF
--- a/bin/node/src/cli.rs
+++ b/bin/node/src/cli.rs
@@ -93,6 +93,7 @@ pub struct Args {
     #[arg(
         long = "builder-rpc-urls",
         value_name = "BUILDER_RPC_URLS",
+        value_delimiter = ',',
         requires = "enable_tx_forwarding"
     )]
     pub builder_rpc_urls: Vec<Url>,


### PR DESCRIPTION
## Summary
- Backport of #2006 to `releases/v0.7.0`
- Adds `value_delimiter = ','` to the `--builder-rpc-urls` clap arg so comma-separated URLs (e.g. from a single env var) are correctly parsed as individual URLs instead of being treated as one malformed URL.
- Without this, passing `RETH_BUILDER_RPC_URLS="http://a:8545,http://b:8545"` fails with `invalid port number` because the entire string is parsed as a single URL.

## Context
Deploying mempool v2 on devnet. The builder RPC URLs are injected via a Helm values YAML as a single env var, which clap reads as one value. This one-liner unblocks the deployment.