### PR TITLE
infra/ingress-rpc,audit: performance and stability improvements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1849,6 +1849,7 @@ dependencies = [
  "alloy-consensus",
  "alloy-primitives",
  "anyhow",
+ "async-channel",
  "async-trait",
  "aws-config",
  "aws-sdk-s3",

--- a/bin/audit-archiver/src/main.rs
+++ b/bin/audit-archiver/src/main.rs
@@ -9,8 +9,7 @@ use aws_credential_types::Credentials;
 use aws_sdk_s3::{Client as S3Client, config::Builder as S3ConfigBuilder};
 use base_cli_utils::LogConfig;
 use clap::{Parser, ValueEnum};
-use rdkafka::consumer::Consumer;
-use tracing::info;
+use tracing::{error, info, warn};
 
 base_cli_utils::define_log_args!("TIPS_AUDIT");
 base_cli_utils::define_metrics_args!("TIPS_AUDIT", 9002);
@@ -88,7 +87,6 @@ async fn main() -> Result<()> {
     );
 
     let consumer = create_kafka_consumer(&args.kafka_properties_file)?;
-    consumer.subscribe(&[&args.kafka_topic])?;
 
     let reader = KafkaAuditLogReader::new(consumer, args.kafka_topic.clone())?;
 
@@ -106,7 +104,23 @@ async fn main() -> Result<()> {
 
     info!("Audit archiver initialized, starting main loop");
 
-    archiver.run().await
+    tokio::select! {
+        result = archiver.run() => {
+            if let Err(e) = result {
+                error!(error = %e, "Archiver loop exited with error");
+            }
+        }
+        _ = tokio::signal::ctrl_c() => {
+            warn!("Received shutdown signal, flushing offsets");
+        }
+    }
+
+    if let Err(e) = archiver.shutdown() {
+        error!(error = %e, "Failed to flush offsets during shutdown");
+    }
+
+    info!("Audit archiver shut down cleanly");
+    Ok(())
 }
 
 async fn create_s3_client(args: &Args) -> Result<S3Client> {

--- a/bin/audit-archiver/src/main.rs
+++ b/bin/audit-archiver/src/main.rs
@@ -126,7 +126,7 @@ async fn main() -> Result<()> {
         }
     }
 
-    if let Err(e) = archiver.shutdown() {
+    if let Err(e) = archiver.shutdown().await {
         error!(error = %e, "Failed to flush offsets during shutdown");
     }
 

--- a/bin/audit-archiver/src/main.rs
+++ b/bin/audit-archiver/src/main.rs
@@ -2,7 +2,8 @@
 
 use anyhow::Result;
 use audit_archiver_lib::{
-    KafkaAuditArchiver, KafkaAuditLogReader, S3EventReaderWriter, create_kafka_consumer,
+    KafkaAuditArchiver, KafkaAuditLogReader, S3EventReaderWriter, S3RetryConfig,
+    create_kafka_consumer,
 };
 use aws_config::{BehaviorVersion, Region};
 use aws_credential_types::Credentials;
@@ -61,6 +62,12 @@ struct Args {
 
     #[arg(long, env = "TIPS_AUDIT_NOOP_ARCHIVE", default_value = "false")]
     noop_archive: bool,
+
+    #[arg(long, env = "TIPS_AUDIT_S3_MAX_RETRIES", default_value = "5")]
+    s3_max_retries: usize,
+
+    #[arg(long, env = "TIPS_AUDIT_S3_RETRY_BASE_DELAY_MS", default_value = "100")]
+    s3_retry_base_delay_ms: u64,
 }
 
 #[tokio::main]
@@ -92,7 +99,11 @@ async fn main() -> Result<()> {
 
     let s3_client = create_s3_client(&args).await?;
     let s3_bucket = args.s3_bucket.clone();
-    let writer = S3EventReaderWriter::new(s3_client, s3_bucket);
+    let retry_config = S3RetryConfig {
+        max_retries: args.s3_max_retries,
+        base_delay_ms: args.s3_retry_base_delay_ms,
+    };
+    let writer = S3EventReaderWriter::with_retry_config(s3_client, s3_bucket, retry_config);
 
     let mut archiver = KafkaAuditArchiver::new(
         reader,

--- a/bin/ingress-rpc/src/main.rs
+++ b/bin/ingress-rpc/src/main.rs
@@ -89,7 +89,7 @@ async fn main() -> anyhow::Result<()> {
 
     let audit_publisher =
         KafkaBundleEventPublisher::new(audit_producer, config.audit_topic.clone());
-    let (audit_tx, audit_rx) = mpsc::unbounded_channel::<BundleEvent>();
+    let (audit_tx, audit_rx) = mpsc::channel::<BundleEvent>(config.audit_channel_capacity);
     AuditConnector::connect(audit_rx, audit_publisher);
 
     let (builder_tx, _) =

--- a/crates/infra/audit/Cargo.toml
+++ b/crates/infra/audit/Cargo.toml
@@ -15,6 +15,7 @@ bytes.workspace = true
 futures.workspace = true
 base-bundles.workspace = true
 async-trait.workspace = true
+async-channel.workspace = true
 metrics = { workspace = true, optional = true }
 base-metrics = { workspace = true, features = ["metrics"] }
 tokio = { workspace = true, features = ["full"] }

--- a/crates/infra/audit/src/archiver.rs
+++ b/crates/infra/audit/src/archiver.rs
@@ -148,4 +148,9 @@ where
             }
         }
     }
+
+    /// Flushes the last committed offset and leaves the consumer group.
+    pub fn shutdown(&mut self) -> Result<()> {
+        self.reader.shutdown()
+    }
 }

--- a/crates/infra/audit/src/archiver.rs
+++ b/crates/infra/audit/src/archiver.rs
@@ -1,15 +1,12 @@
 use std::{
     fmt,
     marker::PhantomData,
-    sync::Arc,
     time::{Duration, Instant, SystemTime, UNIX_EPOCH},
 };
 
 use anyhow::Result;
-use tokio::{
-    sync::{Mutex, mpsc},
-    time::sleep,
-};
+use async_channel::Sender;
+use tokio::time::sleep;
 use tracing::{error, info};
 
 use crate::{
@@ -25,7 +22,7 @@ where
     W: EventWriter + Clone + Send + 'static,
 {
     reader: R,
-    event_tx: mpsc::Sender<Event>,
+    event_tx: Sender<Event>,
     _phantom: PhantomData<W>,
 }
 
@@ -52,7 +49,7 @@ where
         channel_buffer_size: usize,
         noop_archive: bool,
     ) -> Self {
-        let (event_tx, event_rx) = mpsc::channel(channel_buffer_size);
+        let (event_tx, event_rx) = async_channel::bounded(channel_buffer_size);
 
         Self::spawn_workers(writer, event_rx, worker_pool_size, noop_archive);
 
@@ -61,25 +58,18 @@ where
 
     fn spawn_workers(
         writer: W,
-        event_rx: mpsc::Receiver<Event>,
+        event_rx: async_channel::Receiver<Event>,
         worker_pool_size: usize,
         noop_archive: bool,
     ) {
-        let event_rx = Arc::new(Mutex::new(event_rx));
-
         for worker_id in 0..worker_pool_size {
             let writer = writer.clone();
-            let event_rx = Arc::clone(&event_rx);
+            let event_rx = event_rx.clone();
 
             tokio::spawn(async move {
                 loop {
-                    let event = {
-                        let mut rx = event_rx.lock().await;
-                        rx.recv().await
-                    };
-
-                    match event {
-                        Some(event) => {
+                    match event_rx.recv().await {
+                        Ok(event) => {
                             let archive_start = Instant::now();
                             // tmp: only use this to clear kafka consumer offset
                             // TODO: use debug! later
@@ -105,7 +95,7 @@ where
                             }
                             Metrics::in_flight_archive_tasks().decrement(1.0);
                         }
-                        None => {
+                        Err(_) => {
                             info!(worker_id, "Worker stopped - channel closed");
                             break;
                         }

--- a/crates/infra/audit/src/archiver.rs
+++ b/crates/infra/audit/src/archiver.rs
@@ -6,8 +6,8 @@ use std::{
 
 use anyhow::Result;
 use async_channel::Sender;
-use tokio::time::sleep;
-use tracing::{error, info};
+use tokio::{task::JoinHandle, time::sleep};
+use tracing::{error, info, warn};
 
 use crate::{
     metrics::Metrics,
@@ -23,6 +23,7 @@ where
 {
     reader: R,
     event_tx: Sender<Event>,
+    worker_handles: Vec<JoinHandle<()>>,
     _phantom: PhantomData<W>,
 }
 
@@ -51,9 +52,9 @@ where
     ) -> Self {
         let (event_tx, event_rx) = async_channel::bounded(channel_buffer_size);
 
-        Self::spawn_workers(writer, event_rx, worker_pool_size, noop_archive);
+        let worker_handles = Self::spawn_workers(writer, event_rx, worker_pool_size, noop_archive);
 
-        Self { reader, event_tx, _phantom: PhantomData }
+        Self { reader, event_tx, worker_handles, _phantom: PhantomData }
     }
 
     fn spawn_workers(
@@ -61,12 +62,13 @@ where
         event_rx: async_channel::Receiver<Event>,
         worker_pool_size: usize,
         noop_archive: bool,
-    ) {
+    ) -> Vec<JoinHandle<()>> {
+        let mut handles = Vec::with_capacity(worker_pool_size);
         for worker_id in 0..worker_pool_size {
             let writer = writer.clone();
             let event_rx = event_rx.clone();
 
-            tokio::spawn(async move {
+            let handle = tokio::spawn(async move {
                 loop {
                     match event_rx.recv().await {
                         Ok(event) => {
@@ -102,7 +104,9 @@ where
                     }
                 }
             });
+            handles.push(handle);
         }
+        handles
     }
 
     /// Runs the archiver loop, reading events and writing them to storage.
@@ -140,8 +144,18 @@ where
         }
     }
 
-    /// Flushes the last committed offset and leaves the consumer group.
-    pub fn shutdown(&mut self) -> Result<()> {
+    /// Closes the event channel, waits for in-flight S3 writes to finish,
+    /// then flushes the last committed offset and leaves the consumer group.
+    pub async fn shutdown(&mut self) -> Result<()> {
+        self.event_tx.close();
+
+        for handle in self.worker_handles.drain(..) {
+            if let Err(e) = handle.await {
+                warn!(error = %e, "Worker task panicked during shutdown");
+            }
+        }
+
+        info!("All workers drained, flushing Kafka offsets");
         self.reader.shutdown()
     }
 }

--- a/crates/infra/audit/src/archiver.rs
+++ b/crates/infra/audit/src/archiver.rs
@@ -97,6 +97,7 @@ where
                             }
                             if let Err(e) = writer.archive_event(event).await {
                                 error!(worker_id, error = %e, "Failed to write event");
+                                Metrics::failed_archive_tasks().increment(1);
                             } else {
                                 Metrics::archive_event_duration()
                                     .record(archive_start.elapsed().as_secs_f64());

--- a/crates/infra/audit/src/lib.rs
+++ b/crates/infra/audit/src/lib.rs
@@ -21,7 +21,8 @@ pub use publisher::{BundleEventPublisher, KafkaBundleEventPublisher, LoggingBund
 
 mod reader;
 pub use reader::{
-    Event, EventReader, KafkaAuditLogReader, assign_topic_partition, create_kafka_consumer,
+    Event, EventReader, KafkaAuditLogReader, SeekToLatestContext, assign_topic_partition,
+    create_kafka_consumer,
 };
 
 mod storage;

--- a/crates/infra/audit/src/lib.rs
+++ b/crates/infra/audit/src/lib.rs
@@ -27,7 +27,7 @@ pub use reader::{
 mod storage;
 pub use storage::{
     BundleEventS3Reader, BundleHistory, BundleHistoryEvent, EventWriter, S3EventReaderWriter,
-    S3Key, TransactionMetadata,
+    S3Key, S3RetryConfig, TransactionMetadata,
 };
 
 mod types;
@@ -41,7 +41,7 @@ pub struct AuditConnector;
 
 impl AuditConnector {
     /// Connects a bundle event receiver to a publisher, spawning a task to forward events.
-    pub fn connect<P>(event_rx: mpsc::UnboundedReceiver<BundleEvent>, publisher: P)
+    pub fn connect<P>(event_rx: mpsc::Receiver<BundleEvent>, publisher: P)
     where
         P: BundleEventPublisher + 'static,
     {

--- a/crates/infra/audit/src/reader.rs
+++ b/crates/infra/audit/src/reader.rs
@@ -47,6 +47,9 @@ pub trait EventReader {
     async fn read_event(&mut self) -> Result<Event>;
     /// Commits the last read message.
     async fn commit(&mut self) -> Result<()>;
+    /// Performs a synchronous commit of the last read offset and leaves the consumer group.
+    /// Called during graceful shutdown to ensure the next consumer starts from a clean offset.
+    fn shutdown(&mut self) -> Result<()>;
 }
 
 /// Reads bundle audit events from Kafka.
@@ -131,6 +134,25 @@ impl EventReader for KafkaAuditLogReader {
             tpl.add_partition_offset(&self.topic, partition, rdkafka::Offset::Offset(offset + 1))?;
             self.consumer.commit(&tpl, rdkafka::consumer::CommitMode::Async)?;
         }
+        Ok(())
+    }
+
+    fn shutdown(&mut self) -> Result<()> {
+        if let (Some(offset), Some(partition)) =
+            (self.last_message_offset, self.last_message_partition)
+        {
+            let mut tpl = TopicPartitionList::new();
+            tpl.add_partition_offset(&self.topic, partition, rdkafka::Offset::Offset(offset + 1))?;
+            info!(
+                offset = offset + 1,
+                partition,
+                topic = %self.topic,
+                "Flushing final offset before shutdown"
+            );
+            self.consumer.commit(&tpl, rdkafka::consumer::CommitMode::Sync)?;
+        }
+        self.consumer.unsubscribe();
+        info!(topic = %self.topic, "Unsubscribed from consumer group");
         Ok(())
     }
 }

--- a/crates/infra/audit/src/reader.rs
+++ b/crates/infra/audit/src/reader.rs
@@ -3,21 +3,56 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use anyhow::Result;
 use async_trait::async_trait;
 use rdkafka::{
-    Timestamp, TopicPartitionList,
+    ClientContext, Offset, Timestamp, TopicPartitionList,
     config::ClientConfig,
-    consumer::{Consumer, StreamConsumer},
+    consumer::{Consumer, ConsumerContext, Rebalance, StreamConsumer, base_consumer::BaseConsumer},
     message::Message,
 };
 use tokio::time::sleep;
-use tracing::{error, info};
+use tracing::{error, info, warn};
 
 use crate::{load_kafka_config_from_file, types::BundleEvent};
 
-/// Creates a Kafka consumer from a properties file.
-pub fn create_kafka_consumer(kafka_properties_file: &str) -> Result<StreamConsumer> {
+/// Consumer context that seeks all assigned partitions to the latest offset on rebalance.
+#[derive(Debug)]
+pub struct SeekToLatestContext;
+
+impl ClientContext for SeekToLatestContext {}
+
+impl ConsumerContext for SeekToLatestContext {
+    fn post_rebalance(&self, consumer: &BaseConsumer<Self>, rebalance: &Rebalance<'_>) {
+        if let Rebalance::Assign(tpl) = rebalance {
+            for element in tpl.elements() {
+                if let Err(e) = consumer.seek(
+                    element.topic(),
+                    element.partition(),
+                    Offset::End,
+                    Duration::from_secs(5),
+                ) {
+                    warn!(
+                        topic = element.topic(),
+                        partition = element.partition(),
+                        error = %e,
+                        "Failed to seek partition to end"
+                    );
+                }
+            }
+            info!(
+                partitions = tpl.elements().len(),
+                "Seeked all assigned partitions to latest offset"
+            );
+        }
+    }
+}
+
+/// Creates a Kafka consumer from a properties file with seek-to-latest behavior.
+pub fn create_kafka_consumer(
+    kafka_properties_file: &str,
+) -> Result<StreamConsumer<SeekToLatestContext>> {
     let client_config: ClientConfig =
         ClientConfig::from_iter(load_kafka_config_from_file(kafka_properties_file)?);
-    let consumer: StreamConsumer = client_config.create()?;
+    let consumer: StreamConsumer<SeekToLatestContext> =
+        client_config.create_with_context(SeekToLatestContext)?;
     Ok(consumer)
 }
 
@@ -53,14 +88,14 @@ pub trait EventReader {
 }
 
 /// Reads bundle audit events from Kafka.
-pub struct KafkaAuditLogReader {
-    consumer: StreamConsumer,
+pub struct KafkaAuditLogReader<C: ConsumerContext + 'static = SeekToLatestContext> {
+    consumer: StreamConsumer<C>,
     topic: String,
     last_message_offset: Option<i64>,
     last_message_partition: Option<i32>,
 }
 
-impl std::fmt::Debug for KafkaAuditLogReader {
+impl<C: ConsumerContext + 'static> std::fmt::Debug for KafkaAuditLogReader<C> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("KafkaAuditLogReader")
             .field("topic", &self.topic)
@@ -70,16 +105,16 @@ impl std::fmt::Debug for KafkaAuditLogReader {
     }
 }
 
-impl KafkaAuditLogReader {
+impl<C: ConsumerContext + 'static> KafkaAuditLogReader<C> {
     /// Creates a new Kafka audit log reader.
-    pub fn new(consumer: StreamConsumer, topic: String) -> Result<Self> {
+    pub fn new(consumer: StreamConsumer<C>, topic: String) -> Result<Self> {
         consumer.subscribe(&[&topic])?;
         Ok(Self { consumer, topic, last_message_offset: None, last_message_partition: None })
     }
 }
 
 #[async_trait]
-impl EventReader for KafkaAuditLogReader {
+impl<C: ConsumerContext + 'static> EventReader for KafkaAuditLogReader<C> {
     async fn read_event(&mut self) -> Result<Event> {
         match self.consumer.recv().await {
             Ok(message) => {
@@ -131,7 +166,7 @@ impl EventReader for KafkaAuditLogReader {
             (self.last_message_offset, self.last_message_partition)
         {
             let mut tpl = TopicPartitionList::new();
-            tpl.add_partition_offset(&self.topic, partition, rdkafka::Offset::Offset(offset + 1))?;
+            tpl.add_partition_offset(&self.topic, partition, Offset::Offset(offset + 1))?;
             self.consumer.commit(&tpl, rdkafka::consumer::CommitMode::Async)?;
         }
         Ok(())
@@ -142,7 +177,7 @@ impl EventReader for KafkaAuditLogReader {
             (self.last_message_offset, self.last_message_partition)
         {
             let mut tpl = TopicPartitionList::new();
-            tpl.add_partition_offset(&self.topic, partition, rdkafka::Offset::Offset(offset + 1))?;
+            tpl.add_partition_offset(&self.topic, partition, Offset::Offset(offset + 1))?;
             info!(
                 offset = offset + 1,
                 partition,
@@ -157,7 +192,7 @@ impl EventReader for KafkaAuditLogReader {
     }
 }
 
-impl KafkaAuditLogReader {
+impl<C: ConsumerContext + 'static> KafkaAuditLogReader<C> {
     /// Returns the topic this reader is subscribed to.
     pub fn topic(&self) -> &str {
         &self.topic

--- a/crates/infra/audit/src/storage.rs
+++ b/crates/infra/audit/src/storage.rs
@@ -216,7 +216,7 @@ pub trait BundleEventS3Reader {
 /// Retry configuration for S3 conditional writes.
 #[derive(Clone, Debug)]
 pub struct S3RetryConfig {
-    /// Maximum number of retry attempts on ETag conflict.
+    /// Maximum number of retry attempts on `ETag` conflict.
     pub max_retries: usize,
     /// Base delay in milliseconds for exponential backoff.
     pub base_delay_ms: u64,
@@ -243,7 +243,7 @@ impl S3EventReaderWriter {
     }
 
     /// Creates a new S3 event reader/writer with the given retry config.
-    pub fn with_retry_config(
+    pub const fn with_retry_config(
         s3_client: S3Client,
         bucket: String,
         retry_config: S3RetryConfig,

--- a/crates/infra/audit/src/storage.rs
+++ b/crates/infra/audit/src/storage.rs
@@ -213,17 +213,42 @@ pub trait BundleEventS3Reader {
     ) -> Result<Option<TransactionMetadata>>;
 }
 
+/// Retry configuration for S3 conditional writes.
+#[derive(Clone, Debug)]
+pub struct S3RetryConfig {
+    /// Maximum number of retry attempts on ETag conflict.
+    pub max_retries: usize,
+    /// Base delay in milliseconds for exponential backoff.
+    pub base_delay_ms: u64,
+}
+
+impl Default for S3RetryConfig {
+    fn default() -> Self {
+        Self { max_retries: 5, base_delay_ms: 100 }
+    }
+}
+
 /// S3-backed event reader and writer.
 #[derive(Clone, Debug)]
 pub struct S3EventReaderWriter {
     s3_client: S3Client,
     bucket: String,
+    retry_config: S3RetryConfig,
 }
 
 impl S3EventReaderWriter {
-    /// Creates a new S3 event reader/writer.
-    pub const fn new(s3_client: S3Client, bucket: String) -> Self {
-        Self { s3_client, bucket }
+    /// Creates a new S3 event reader/writer with default retry config.
+    pub fn new(s3_client: S3Client, bucket: String) -> Self {
+        Self { s3_client, bucket, retry_config: S3RetryConfig::default() }
+    }
+
+    /// Creates a new S3 event reader/writer with the given retry config.
+    pub fn with_retry_config(
+        s3_client: S3Client,
+        bucket: String,
+        retry_config: S3RetryConfig,
+    ) -> Self {
+        Self { s3_client, bucket, retry_config }
     }
 
     async fn update_bundle_history(&self, event: Event) -> Result<()> {
@@ -254,10 +279,10 @@ impl S3EventReaderWriter {
         T: for<'de> Deserialize<'de> + Serialize + Default + Debug,
         F: FnMut(T) -> Option<T>,
     {
-        const MAX_RETRIES: usize = 5;
-        const BASE_DELAY_MS: u64 = 100;
+        let max_retries = self.retry_config.max_retries;
+        let base_delay_ms = self.retry_config.base_delay_ms;
 
-        for attempt in 0..MAX_RETRIES {
+        for attempt in 0..max_retries {
             let get_start = Instant::now();
             let (current_value, etag) = self.get_object_with_etag::<T>(key).await?;
             Metrics::s3_get_duration().record(get_start.elapsed().as_secs_f64());
@@ -295,8 +320,8 @@ impl S3EventReaderWriter {
                         Err(e) => {
                             Metrics::s3_put_duration().record(put_start.elapsed().as_secs_f64());
 
-                            if attempt < MAX_RETRIES - 1 {
-                                let delay = BASE_DELAY_MS * 2_u64.pow(attempt as u32);
+                            if attempt < max_retries - 1 {
+                                let delay = base_delay_ms * 2_u64.pow(attempt as u32);
                                 info!(
                                     s3_key = %key,
                                     attempt = attempt + 1,
@@ -307,7 +332,7 @@ impl S3EventReaderWriter {
                                 tokio::time::sleep(tokio::time::Duration::from_millis(delay)).await;
                             } else {
                                 return Err(anyhow::anyhow!(
-                                    "Failed to write after {MAX_RETRIES} attempts: {e}"
+                                    "Failed to write after {max_retries} attempts: {e}"
                                 ));
                             }
                         }

--- a/crates/infra/ingress-rpc/src/lib.rs
+++ b/crates/infra/ingress-rpc/src/lib.rs
@@ -144,6 +144,10 @@ pub struct Config {
     /// Enable sending to builder
     #[arg(long, env = "TIPS_INGRESS_SEND_TO_BUILDER", default_value = "false")]
     pub send_to_builder: bool,
+
+    /// Maximum number of audit events to buffer before dropping
+    #[arg(long, env = "TIPS_INGRESS_AUDIT_CHANNEL_CAPACITY", default_value = "10000")]
+    pub audit_channel_capacity: usize,
 }
 
 /// Connects ingress metering data to builder RPCs.

--- a/crates/infra/ingress-rpc/src/service.rs
+++ b/crates/infra/ingress-rpc/src/service.rs
@@ -53,7 +53,7 @@ pub struct IngressService<Q: MessageQueue> {
     raw_tx_forward_provider: Option<Arc<RootProvider<Base>>>,
     tx_submission_method: TxSubmissionMethod,
     bundle_queue_publisher: BundleQueuePublisher<Q>,
-    audit_channel: mpsc::UnboundedSender<BundleEvent>,
+    audit_channel: mpsc::Sender<BundleEvent>,
     send_transaction_default_lifetime_seconds: u64,
     block_time_milliseconds: u64,
     meter_bundle_timeout_ms: u64,
@@ -73,7 +73,7 @@ impl<Q: MessageQueue> IngressService<Q> {
     pub fn new(
         providers: Providers,
         queue: Q,
-        audit_channel: mpsc::UnboundedSender<BundleEvent>,
+        audit_channel: mpsc::Sender<BundleEvent>,
         builder_tx: broadcast::Sender<MeterBundleResponse>,
         config: Config,
     ) -> Self {
@@ -309,12 +309,20 @@ impl<Q: MessageQueue> IngressService<Q> {
             bundle_id: *accepted_bundle.uuid(),
             bundle: Box::new(accepted_bundle.clone()),
         };
-        if let Err(e) = self.audit_channel.send(audit_event) {
-            warn!(
-                message = "failed to send audit event",
-                bundle_hash = %bundle_hash,
-                error = %e
-            );
+        match self.audit_channel.try_send(audit_event) {
+            Ok(()) => {}
+            Err(mpsc::error::TrySendError::Full(_)) => {
+                warn!(
+                    bundle_hash = %bundle_hash,
+                    "Audit channel full, dropping event"
+                );
+            }
+            Err(mpsc::error::TrySendError::Closed(_)) => {
+                warn!(
+                    bundle_hash = %bundle_hash,
+                    "Audit channel closed, dropping event"
+                );
+            }
         }
     }
 }
@@ -366,6 +374,7 @@ mod tests {
             chain_id: 11,
             bundle_cache_ttl: 20,
             send_to_builder: false,
+            audit_channel_capacity: 10_000,
         }
     }
 
@@ -443,7 +452,7 @@ mod tests {
             raw_tx_forward: None,
         };
 
-        let (audit_tx, _audit_rx) = mpsc::unbounded_channel();
+        let (audit_tx, _audit_rx) = mpsc::channel(1000);
         let (builder_tx, _builder_rx) = broadcast::channel(1);
 
         let service = IngressService::new(providers, MockQueue, audit_tx, builder_tx, config);
@@ -497,7 +506,7 @@ mod tests {
             raw_tx_forward: Some(RootProvider::new_http(forward_server.uri().parse().unwrap())),
         };
 
-        let (audit_tx, _audit_rx) = mpsc::unbounded_channel();
+        let (audit_tx, _audit_rx) = mpsc::channel(1000);
         let (builder_tx, _builder_rx) = broadcast::channel(1);
 
         let service = IngressService::new(providers, MockQueue, audit_tx, builder_tx, config);


### PR DESCRIPTION
- Removed double subscribe from audit. According to claude, duplicate subsribes triggers "an unnecessary consumer group rebalance"
- Added graceful shutdown to audit
- Replaced `Arc<Mutex<mpsc::Receiver>>` with `async_channel::bounded`. The Mutex was a hot contention that caused workers to compete with 1 lock. Now, each work gets it own Receiver clone (the clone is supposedly cheap, as it's just an `Arc::clone`)
- Changed all unbounded queues to bounded. This was probably the cause of some OOM's. The bounded size is configurable via CLI. 
- send_audit_event uses try_send() — drops audit events with a warning when channel is full instead of growing memory unbounded. This will be a follow up PR to later improve the handling and avoid dropping anything. However, it's less important right now because we can just make the queue larger while we deal with a restart/re-deploy
- Added S3EventReaderWriter::with_retry_config() constructor; existing ::new() uses defaults