### PR TITLE
feat(challenger): make bond discovery interval configurable

### DIFF
--- a/crates/proof/challenge/src/bond.rs
+++ b/crates/proof/challenge/src/bond.rs
@@ -118,6 +118,9 @@ pub struct BondManager<C: Clock> {
     last_full_scan: Duration,
     /// Number of games to look back during periodic full rescans.
     lookback: u64,
+    /// How often a full rescan of the lookback window is performed to catch
+    /// state transitions (games challenged or resolved by other actors).
+    discovery_interval: Duration,
 }
 
 impl<C: Clock> BondManager<C> {
@@ -126,16 +129,13 @@ impl<C: Clock> BondManager<C> {
     /// succeed earlier; if longer, the attempt reverts and is retried.
     const DEFAULT_WETH_DELAY: Duration = Duration::from_secs(7 * 24 * 60 * 60);
 
-    /// How often a full rescan of the lookback window is performed to catch
-    /// state transitions (games challenged or resolved by other actors).
-    const BOND_DISCOVERY_INTERVAL: Duration = Duration::from_secs(300);
-
     /// Creates a new bond manager for the given set of claim addresses.
     pub fn new(
         claim_addresses: Vec<Address>,
         l1_rpc_url: url::Url,
         factory_client: Arc<dyn DisputeGameFactoryClient>,
         lookback: u64,
+        discovery_interval: Duration,
         clock: C,
     ) -> Self {
         let last_full_scan = clock.now();
@@ -151,6 +151,7 @@ impl<C: Clock> BondManager<C> {
             bond_scan_head: 0,
             last_full_scan,
             lookback,
+            discovery_interval,
         }
     }
 
@@ -418,7 +419,7 @@ impl<C: Clock> BondManager<C> {
     /// handful of games per tick, costing a single `game_count()` RPC
     /// when idle.
     ///
-    /// **Periodic full rescan** (every [`BOND_DISCOVERY_INTERVAL`](Self::BOND_DISCOVERY_INTERVAL)):
+    /// **Periodic full rescan** (every `discovery_interval`):
     /// resets the watermark backward by `lookback` to re-evaluate games
     /// whose state may have changed (e.g. challenged or resolved by
     /// another actor since the last scan).
@@ -441,7 +442,7 @@ impl<C: Clock> BondManager<C> {
         // Periodic full rescan: reset watermark to re-evaluate the
         // lookback window and catch state transitions on older games.
         let elapsed = self.clock.now().saturating_sub(self.last_full_scan);
-        let is_full_rescan = elapsed >= Self::BOND_DISCOVERY_INTERVAL;
+        let is_full_rescan = elapsed >= self.discovery_interval;
         if is_full_rescan {
             let new_head = game_count.saturating_sub(self.lookback);
             debug!(
@@ -950,7 +951,7 @@ mod tests {
     use futures::stream::BoxStream;
 
     use super::*;
-    use crate::test_utils::{MockDisputeGameFactory, empty_factory};
+    use crate::test_utils::{MockDisputeGameFactory, TEST_DISCOVERY_INTERVAL, empty_factory};
 
     /// A deterministic clock that always returns fixed values.
     ///
@@ -992,7 +993,14 @@ mod tests {
 
     fn make_manager(addresses: Vec<Address>) -> BondManager<FixedClock> {
         let clock = fixed_clock(0);
-        let mut mgr = BondManager::new(addresses, test_l1_rpc_url(), empty_factory(), 1000, clock);
+        let mut mgr = BondManager::new(
+            addresses,
+            test_l1_rpc_url(),
+            empty_factory(),
+            1000,
+            TEST_DISCOVERY_INTERVAL,
+            clock,
+        );
         mgr.set_weth_delay(Duration::from_secs(60));
         mgr
     }
@@ -1026,7 +1034,14 @@ mod tests {
         let game = Address::repeat_byte(0xAA);
 
         let clock = fixed_clock(1000);
-        let mut mgr = BondManager::new(vec![addr], test_l1_rpc_url(), empty_factory(), 1000, clock);
+        let mut mgr = BondManager::new(
+            vec![addr],
+            test_l1_rpc_url(),
+            empty_factory(),
+            1000,
+            TEST_DISCOVERY_INTERVAL,
+            clock,
+        );
         mgr.set_weth_delay(Duration::from_secs(60));
 
         // 100 seconds ago > 60 second delay
@@ -1047,7 +1062,14 @@ mod tests {
         let game = Address::repeat_byte(0xAA);
 
         let clock = fixed_clock(1000);
-        let mut mgr = BondManager::new(vec![addr], test_l1_rpc_url(), empty_factory(), 1000, clock);
+        let mut mgr = BondManager::new(
+            vec![addr],
+            test_l1_rpc_url(),
+            empty_factory(),
+            1000,
+            TEST_DISCOVERY_INTERVAL,
+            clock,
+        );
         mgr.set_weth_delay(Duration::from_secs(3600));
 
         // only 1 second ago < 3600 second delay
@@ -1100,7 +1122,14 @@ mod tests {
     #[test]
     fn empty_claim_addresses_means_disabled() {
         let clock = fixed_clock(0);
-        let mgr = BondManager::new(vec![], test_l1_rpc_url(), empty_factory(), 1000, clock);
+        let mgr = BondManager::new(
+            vec![],
+            test_l1_rpc_url(),
+            empty_factory(),
+            1000,
+            TEST_DISCOVERY_INTERVAL,
+            clock,
+        );
         assert!(!mgr.is_enabled());
     }
 
@@ -1112,6 +1141,7 @@ mod tests {
             test_l1_rpc_url(),
             empty_factory(),
             1000,
+            TEST_DISCOVERY_INTERVAL,
             clock,
         );
         assert!(mgr.is_enabled());
@@ -1149,7 +1179,14 @@ mod tests {
         let (factory, verifier) = discovery_mocks(3, claim_addr, Address::ZERO);
 
         let clock = fixed_clock(0);
-        let mut mgr = BondManager::new(vec![claim_addr], test_l1_rpc_url(), factory, 1000, clock);
+        let mut mgr = BondManager::new(
+            vec![claim_addr],
+            test_l1_rpc_url(),
+            factory,
+            1000,
+            TEST_DISCOVERY_INTERVAL,
+            clock,
+        );
         mgr.set_weth_delay(Duration::from_secs(60));
 
         // bond_scan_head defaults to 0, so the first call should scan all 3.
@@ -1167,7 +1204,14 @@ mod tests {
         let (factory, verifier) = discovery_mocks(2, other_recipient, claim_addr);
 
         let clock = fixed_clock(0);
-        let mut mgr = BondManager::new(vec![claim_addr], test_l1_rpc_url(), factory, 1000, clock);
+        let mut mgr = BondManager::new(
+            vec![claim_addr],
+            test_l1_rpc_url(),
+            factory,
+            1000,
+            TEST_DISCOVERY_INTERVAL,
+            clock,
+        );
         mgr.set_weth_delay(Duration::from_secs(60));
 
         mgr.discover_claimable_games(&*verifier).await.unwrap();
@@ -1180,7 +1224,14 @@ mod tests {
         let (factory, verifier) = discovery_mocks(2, claim_addr, Address::ZERO);
 
         let clock = fixed_clock(0);
-        let mut mgr = BondManager::new(vec![claim_addr], test_l1_rpc_url(), factory, 1000, clock);
+        let mut mgr = BondManager::new(
+            vec![claim_addr],
+            test_l1_rpc_url(),
+            factory,
+            1000,
+            TEST_DISCOVERY_INTERVAL,
+            clock,
+        );
         mgr.set_weth_delay(Duration::from_secs(60));
 
         // Pre-track game 0.
@@ -1208,7 +1259,14 @@ mod tests {
         let verifier = Arc::new(MockAggregateVerifier { games: verifier_games });
 
         let clock = fixed_clock(0);
-        let mut mgr = BondManager::new(vec![claim_addr], test_l1_rpc_url(), factory, 1000, clock);
+        let mut mgr = BondManager::new(
+            vec![claim_addr],
+            test_l1_rpc_url(),
+            factory,
+            1000,
+            TEST_DISCOVERY_INTERVAL,
+            clock,
+        );
         mgr.set_weth_delay(Duration::from_secs(60));
 
         mgr.discover_claimable_games(&*verifier).await.unwrap();
@@ -1221,7 +1279,14 @@ mod tests {
         let (factory, verifier) = discovery_mocks(5, claim_addr, Address::ZERO);
 
         let clock = fixed_clock(0);
-        let mut mgr = BondManager::new(vec![claim_addr], test_l1_rpc_url(), factory, 1000, clock);
+        let mut mgr = BondManager::new(
+            vec![claim_addr],
+            test_l1_rpc_url(),
+            factory,
+            1000,
+            TEST_DISCOVERY_INTERVAL,
+            clock,
+        );
         mgr.set_weth_delay(Duration::from_secs(60));
 
         // Start from index 3 so only indices 3 and 4 are scanned.
@@ -1237,7 +1302,14 @@ mod tests {
         let (factory, verifier) = discovery_mocks(5, claim_addr, Address::ZERO);
 
         let clock = fixed_clock(0);
-        let mut mgr = BondManager::new(vec![claim_addr], test_l1_rpc_url(), factory, 1000, clock);
+        let mut mgr = BondManager::new(
+            vec![claim_addr],
+            test_l1_rpc_url(),
+            factory,
+            1000,
+            TEST_DISCOVERY_INTERVAL,
+            clock,
+        );
         mgr.set_weth_delay(Duration::from_secs(60));
 
         // Watermark already at game_count — nothing new to scan.
@@ -1259,6 +1331,7 @@ mod tests {
             test_l1_rpc_url(),
             factory,
             5, // lookback = 5
+            TEST_DISCOVERY_INTERVAL,
             clock,
         );
         mgr.set_weth_delay(Duration::from_secs(60));
@@ -1268,8 +1341,7 @@ mod tests {
 
         // Force the full rescan by backdating `last_full_scan` past the
         // discovery interval.
-        mgr.last_full_scan = Duration::from_secs(1000)
-            .saturating_sub(BondManager::<FixedClock>::BOND_DISCOVERY_INTERVAL);
+        mgr.last_full_scan = Duration::from_secs(1000).saturating_sub(TEST_DISCOVERY_INTERVAL);
 
         mgr.discover_claimable_games(&*verifier).await.unwrap();
         // Full rescan should have reset watermark to 10 - 5 = 5
@@ -1283,7 +1355,14 @@ mod tests {
         let (_, verifier) = discovery_mocks(5, Address::repeat_byte(0xCC), Address::ZERO);
 
         let clock = fixed_clock(0);
-        let mut mgr = BondManager::new(vec![], test_l1_rpc_url(), empty_factory(), 1000, clock);
+        let mut mgr = BondManager::new(
+            vec![],
+            test_l1_rpc_url(),
+            empty_factory(),
+            1000,
+            TEST_DISCOVERY_INTERVAL,
+            clock,
+        );
 
         mgr.discover_claimable_games(&*verifier).await.unwrap();
         assert_eq!(mgr.tracked_count(), 0);
@@ -1297,7 +1376,14 @@ mod tests {
         let (factory, verifier) = discovery_mocks(3, other, Address::ZERO);
 
         let clock = fixed_clock(0);
-        let mut mgr = BondManager::new(vec![claim_addr], test_l1_rpc_url(), factory, 1000, clock);
+        let mut mgr = BondManager::new(
+            vec![claim_addr],
+            test_l1_rpc_url(),
+            factory,
+            1000,
+            TEST_DISCOVERY_INTERVAL,
+            clock,
+        );
         mgr.set_weth_delay(Duration::from_secs(60));
 
         mgr.discover_claimable_games(&*verifier).await.unwrap();
@@ -1344,8 +1430,14 @@ mod tests {
         let verifier = Arc::new(MockAggregateVerifier { games: verifier_games });
 
         let clock = fixed_clock(500);
-        let mut mgr =
-            BondManager::new(vec![claim_addr], test_l1_rpc_url(), empty_factory(), 1000, clock);
+        let mut mgr = BondManager::new(
+            vec![claim_addr],
+            test_l1_rpc_url(),
+            empty_factory(),
+            1000,
+            TEST_DISCOVERY_INTERVAL,
+            clock,
+        );
         mgr.set_weth_delay(Duration::from_secs(60));
         mgr.track_game(game, claim_addr);
 
@@ -1369,8 +1461,14 @@ mod tests {
         let claim_addr = Address::repeat_byte(0xCC);
 
         let clock = fixed_clock(0);
-        let mut mgr =
-            BondManager::new(vec![claim_addr], test_l1_rpc_url(), empty_factory(), 1000, clock);
+        let mut mgr = BondManager::new(
+            vec![claim_addr],
+            test_l1_rpc_url(),
+            empty_factory(),
+            1000,
+            TEST_DISCOVERY_INTERVAL,
+            clock,
+        );
 
         let verifier = Arc::new(MockAggregateVerifier { games: HashMap::new() });
         mgr.discover_claimable_games(&*verifier).await.unwrap();
@@ -1388,8 +1486,14 @@ mod tests {
         let (factory, verifier) = discovery_mocks(game_count, claim_addr, Address::ZERO);
 
         let clock = fixed_clock(0);
-        let mut mgr =
-            BondManager::new(vec![claim_addr], test_l1_rpc_url(), factory, lookback, clock);
+        let mut mgr = BondManager::new(
+            vec![claim_addr],
+            test_l1_rpc_url(),
+            factory,
+            lookback,
+            TEST_DISCOVERY_INTERVAL,
+            clock,
+        );
         mgr.set_weth_delay(Duration::from_secs(60));
 
         // bond_scan_head starts at 0, game_count = 1200, span = 1200 > lookback.
@@ -1411,8 +1515,14 @@ mod tests {
         let (factory, verifier) = discovery_mocks(game_count, claim_addr, Address::ZERO);
 
         let clock = fixed_clock(0);
-        let mut mgr =
-            BondManager::new(vec![claim_addr], test_l1_rpc_url(), factory, lookback, clock);
+        let mut mgr = BondManager::new(
+            vec![claim_addr],
+            test_l1_rpc_url(),
+            factory,
+            lookback,
+            TEST_DISCOVERY_INTERVAL,
+            clock,
+        );
         mgr.set_weth_delay(Duration::from_secs(60));
 
         // First tick: scans 0..500, watermark = 500.
@@ -1434,8 +1544,14 @@ mod tests {
         let (factory, verifier) = discovery_mocks(game_count, claim_addr, Address::ZERO);
 
         let clock = fixed_clock(0);
-        let mut mgr =
-            BondManager::new(vec![claim_addr], test_l1_rpc_url(), factory, lookback, clock);
+        let mut mgr = BondManager::new(
+            vec![claim_addr],
+            test_l1_rpc_url(),
+            factory,
+            lookback,
+            TEST_DISCOVERY_INTERVAL,
+            clock,
+        );
         mgr.set_weth_delay(Duration::from_secs(60));
 
         mgr.discover_claimable_games(&*verifier).await.unwrap();

--- a/crates/proof/challenge/src/cli.rs
+++ b/crates/proof/challenge/src/cli.rs
@@ -114,6 +114,16 @@ pub struct ChallengerArgs {
     #[arg(long = "lookback-games", env = cli_env!("LOOKBACK_GAMES"), default_value = "1000")]
     pub lookback_games: u64,
 
+    /// How often a full rescan of the bond lookback window is performed to
+    /// catch state transitions (games challenged or resolved by other actors).
+    #[arg(
+        long = "bond-discovery-interval",
+        env = cli_env!("BOND_DISCOVERY_INTERVAL"),
+        default_value = "300s",
+        value_parser = humantime::parse_duration
+    )]
+    pub bond_discovery_interval: Duration,
+
     /// Comma-separated list of addresses to claim bonds on behalf of.
     ///
     /// When set, the challenger will automatically resolve games and claim

--- a/crates/proof/challenge/src/config.rs
+++ b/crates/proof/challenge/src/config.rs
@@ -107,6 +107,8 @@ pub struct ChallengerConfig {
     pub tx_manager: TxManagerConfig,
     /// Number of past games to scan on startup.
     pub lookback_games: u64,
+    /// How often a full rescan of the bond lookback window is performed.
+    pub bond_discovery_interval: Duration,
     /// Addresses to claim bonds on behalf of.
     pub bond_claim_addresses: Vec<Address>,
     /// Health server socket address.
@@ -178,6 +180,10 @@ impl ChallengerConfig {
         };
 
         require_nonzero(cli.challenger.lookback_games, "lookback-games")?;
+        require_nonzero_duration(
+            cli.challenger.bond_discovery_interval,
+            "bond-discovery-interval",
+        )?;
 
         // Health server is always started, so the port must be valid.
         require_nonzero(cli.health.port.into(), "health.port")?;
@@ -208,6 +214,7 @@ impl ChallengerConfig {
             signing,
             tx_manager,
             lookback_games: cli.challenger.lookback_games,
+            bond_discovery_interval: cli.challenger.bond_discovery_interval,
             bond_claim_addresses: cli.challenger.bond_claim_addresses,
             health_addr,
             log: LogConfig::from(cli.logging),
@@ -272,6 +279,7 @@ mod tests {
         assert_eq!(config.zk_connect_timeout, Duration::from_secs(10));
         assert_eq!(config.zk_request_timeout, Duration::from_secs(30));
         assert_eq!(config.lookback_games, 1000);
+        assert_eq!(config.bond_discovery_interval, Duration::from_secs(300));
         assert_eq!(config.health_addr, "0.0.0.0:8080".parse::<SocketAddr>().unwrap());
         assert!(matches!(config.signing, SignerConfig::Remote { .. }));
         assert_eq!(config.tx_manager.num_confirmations, 10);
@@ -284,6 +292,7 @@ mod tests {
     #[case::zk_connect_timeout("--zk-connect-timeout", "0s", "zk-connect-timeout")]
     #[case::zk_request_timeout("--zk-request-timeout", "0s", "zk-request-timeout")]
     #[case::lookback_games("--lookback-games", "0", "lookback-games")]
+    #[case::bond_discovery_interval("--bond-discovery-interval", "0s", "bond-discovery-interval")]
     fn test_zero_value_rejected(#[case] flag: &str, #[case] value: &str, #[case] field: &str) {
         let all_args = [&LOCAL_SIGNER_ARGS[..], &[flag, value]].concat();
         let cli = cli_from_args(&all_args);

--- a/crates/proof/challenge/src/service.rs
+++ b/crates/proof/challenge/src/service.rs
@@ -150,6 +150,7 @@ impl ChallengerService {
                 l1_rpc_url,
                 Arc::clone(&factory_client) as Arc<dyn DisputeGameFactoryClient>,
                 config.lookback_games,
+                config.bond_discovery_interval,
                 TokioRuntime::new(),
             );
             info!("starting bond recovery scan");

--- a/crates/proof/challenge/src/test_utils.rs
+++ b/crates/proof/challenge/src/test_utils.rs
@@ -4,6 +4,7 @@
 use std::{
     collections::{HashMap, VecDeque},
     sync::{Arc, Mutex},
+    time::Duration,
 };
 
 use alloy_consensus::{
@@ -27,6 +28,9 @@ use base_zk_client::{
 };
 
 use crate::L1HeadProvider;
+
+/// Discovery interval used in tests (5 minutes).
+pub const TEST_DISCOVERY_INTERVAL: Duration = Duration::from_secs(300);
 
 /// Per-game state for the mock verifier.
 #[derive(Debug, Clone)]

--- a/crates/proof/challenge/tests/driver.rs
+++ b/crates/proof/challenge/tests/driver.rs
@@ -14,8 +14,8 @@ use base_challenger::{
     test_utils::{
         MockAggregateVerifier, MockBondTransactionSubmitter, MockDisputeGameFactory, MockGameState,
         MockL1HeadProvider, MockL2Provider, MockTeeProofProvider, MockTxManager,
-        MockZkProofProvider, addr, build_test_header_and_account, empty_factory, factory_game,
-        mock_state, mock_state_with_tee, receipt_with_status,
+        MockZkProofProvider, TEST_DISCOVERY_INTERVAL, addr, build_test_header_and_account,
+        empty_factory, factory_game, mock_state, mock_state_with_tee, receipt_with_status,
     },
 };
 use base_proof_contracts::{AggregateVerifierClient, ContractError, GameAtIndex};
@@ -1231,6 +1231,7 @@ async fn test_bond_manager_full_lifecycle() {
         "http://localhost:8545".parse().unwrap(),
         empty_factory(),
         1000,
+        TEST_DISCOVERY_INTERVAL,
         TokioRuntime::new(),
     );
     mgr.set_weth_delay(Duration::from_secs(0)); // instant delay for testing
@@ -1290,6 +1291,7 @@ async fn test_bond_manager_skips_already_resolved_game() {
         "http://localhost:8545".parse().unwrap(),
         empty_factory(),
         1000,
+        TEST_DISCOVERY_INTERVAL,
         TokioRuntime::new(),
     );
     mgr.set_weth_delay(Duration::from_secs(0));
@@ -1341,6 +1343,7 @@ async fn test_bond_manager_skips_already_unlocked_game() {
         "http://localhost:8545".parse().unwrap(),
         empty_factory(),
         1000,
+        TEST_DISCOVERY_INTERVAL,
         TokioRuntime::new(),
     );
     mgr.set_weth_delay(Duration::from_secs(0));
@@ -1389,6 +1392,7 @@ async fn test_bond_manager_skips_already_claimed_game() {
         "http://localhost:8545".parse().unwrap(),
         empty_factory(),
         1000,
+        TEST_DISCOVERY_INTERVAL,
         TokioRuntime::new(),
     );
     mgr.set_weth_delay(Duration::from_secs(0));
@@ -1439,6 +1443,7 @@ async fn test_bond_manager_tx_failure_retries() {
         "http://localhost:8545".parse().unwrap(),
         empty_factory(),
         1000,
+        TEST_DISCOVERY_INTERVAL,
         TokioRuntime::new(),
     );
     mgr.set_weth_delay(Duration::from_secs(0));
@@ -1472,6 +1477,7 @@ async fn test_bond_manager_ignores_non_claim_addresses() {
         "http://localhost:8545".parse().unwrap(),
         empty_factory(),
         1000,
+        TEST_DISCOVERY_INTERVAL,
         TokioRuntime::new(),
     );
     assert!(!mgr.track_game(game_addr, other_addr));
@@ -1499,6 +1505,7 @@ async fn test_bond_manager_keeps_defender_wins_when_recipient_is_claimable() {
         "http://localhost:8545".parse().unwrap(),
         empty_factory(),
         1000,
+        TEST_DISCOVERY_INTERVAL,
         TokioRuntime::new(),
     );
     mgr.set_weth_delay(Duration::from_secs(0));
@@ -1539,6 +1546,7 @@ async fn test_bond_manager_removes_game_when_recipient_not_claimable() {
         "http://localhost:8545".parse().unwrap(),
         empty_factory(),
         1000,
+        TEST_DISCOVERY_INTERVAL,
         TokioRuntime::new(),
     );
     mgr.set_weth_delay(Duration::from_secs(0));
@@ -1597,6 +1605,7 @@ async fn test_driver_tracks_bond_after_successful_challenge() {
         "http://localhost:8545".parse().unwrap(),
         empty_factory(),
         1000,
+        TEST_DISCOVERY_INTERVAL,
         TokioRuntime::new(),
     );
     bond_manager.set_weth_delay(Duration::from_secs(3600));


### PR DESCRIPTION
## Summary

- Replaces the hardcoded `BOND_DISCOVERY_INTERVAL` constant (300s) in `BondManager` with a configurable `--bond-discovery-interval` CLI flag, allowing operators to tune how frequently the bond manager rescans the lookback window for state transitions (games challenged or resolved by other actors).
- Threads the new `discovery_interval` parameter through `ChallengerConfig`, `ChallengerArgs`, `BondManager::new`, and all test call sites.
- Adds zero-value validation for the new flag consistent with other duration parameters.