### PR TITLE
refactor(batcher): remove legacy encode_frames in favor of encode_packed

### DIFF
--- a/actions/harness/src/miner.rs
+++ b/actions/harness/src/miner.rs
@@ -575,9 +575,9 @@ impl L1Miner {
     ///
     /// [`mine_block`]: L1Miner::mine_block
     pub fn submit_blob_frames(&mut self, frames: &[Arc<Frame>]) {
-        let blobs =
-            BlobEncoder::encode_frames(frames).expect("frame data fits within blob capacity");
-        for blob in blobs {
+        for frame in frames {
+            let blob = BlobEncoder::encode_packed(core::slice::from_ref(frame))
+                .expect("frame data fits within blob capacity");
             self.enqueue_blob(B256::ZERO, blob);
         }
     }

--- a/crates/batcher/blobs/src/encoder.rs
+++ b/crates/batcher/blobs/src/encoder.rs
@@ -59,25 +59,6 @@ impl BlobEncoder {
         Self::encode(&data)
     }
 
-    /// Encode each [`Frame`] into its own EIP-4844 [`Blob`].
-    ///
-    /// Each frame is prefixed with [`DERIVATION_VERSION_0`] before encoding.
-    /// Returns a blob per frame in the same order.
-    ///
-    /// Kept for compatibility with the action-test harness
-    /// (`actions/harness/src/miner.rs`). New code should use [`encode_packed`](Self::encode_packed).
-    pub fn encode_frames(frames: &[Arc<Frame>]) -> Result<Vec<Box<Blob>>, BlobEncodeError> {
-        let mut blobs = Vec::with_capacity(frames.len());
-        for frame in frames {
-            let encoded = frame.encode();
-            let mut data = Vec::with_capacity(1 + encoded.len());
-            data.push(DERIVATION_VERSION_0);
-            data.extend_from_slice(&encoded);
-            blobs.push(Self::encode(&data)?);
-        }
-        Ok(blobs)
-    }
-
     /// Encode `data` into a single EIP-4844 [`Blob`].
     ///
     /// Returns a [`BlobEncodeError::DataTooLarge`] if the input exceeds

--- a/crates/batcher/core/src/driver.rs
+++ b/crates/batcher/core/src/driver.rs
@@ -504,7 +504,7 @@ mod tests {
     /// never pruned. The driver must call requeue so the encoder can unwind that state.
     #[test]
     fn test_blob_encoding_failure_requeues_submission() {
-        // encode_frames feeds: DERIVATION_VERSION_0 (1) + frame.encode() (23 + data.len())
+        // encode_packed feeds: DERIVATION_VERSION_0 (1) + frame.encode() (23 + data.len())
         // = 24 + data.len() bytes into BlobEncoder::encode. It fails when > BLOB_MAX_DATA_SIZE
         // (130_044), so data.len() >= 130_021 guarantees DataTooLarge.
         const OVERSIZED: usize = 130_021;

--- a/crates/batcher/encoder/README.md
+++ b/crates/batcher/encoder/README.md
@@ -56,4 +56,4 @@ pipeline expects: `[DERIVATION_VERSION_0] ++ frame.encode()`. Both `BatchDriver`
 production async driver in `base-batcher-core`) and the action-test `Batcher` harness use
 this shared implementation so the framing logic is defined exactly once.
 
-For EIP-4844 blob submission, use `base_blobs::BlobEncoder::encode_frames(&frames)`.
+For EIP-4844 blob submission, use `base_blobs::BlobEncoder::encode_packed(&frames)`.


### PR DESCRIPTION
## Summary

- Remove `BlobEncoder::encode_frames()`, a legacy compatibility shim that encoded one frame per blob via a separate code path from the standard `encode_packed`
- Migrate the sole caller (`L1Miner::submit_blob_frames`) to use `encode_packed(slice::from_ref(frame))` per frame, preserving identical one-frame-per-blob semantics
- Net -19 lines, no logic changes