### PR TITLE
fix(consensus): Gracefully Create safedb Parent Dirs

### DIFF
--- a/crates/consensus/safedb/src/db.rs
+++ b/crates/consensus/safedb/src/db.rs
@@ -49,7 +49,14 @@ pub struct SafeDB {
 
 impl SafeDB {
     /// Opens (or creates) the safe head database at the given path.
+    ///
+    /// If the parent directory does not exist it is created automatically.
     pub fn open(path: impl AsRef<Path>) -> Result<Self, SafeDBError> {
+        let path = path.as_ref();
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)
+                .map_err(|e| SafeDBError::Database(format!("failed to create database directory: {e}")))?;
+        }
         let db = Database::create(path).map_err(|e| SafeDBError::Database(e.to_string()))?;
 
         // Ensure the table exists.

--- a/crates/consensus/safedb/src/db.rs
+++ b/crates/consensus/safedb/src/db.rs
@@ -54,8 +54,9 @@ impl SafeDB {
     pub fn open(path: impl AsRef<Path>) -> Result<Self, SafeDBError> {
         let path = path.as_ref();
         if let Some(parent) = path.parent() {
-            std::fs::create_dir_all(parent)
-                .map_err(|e| SafeDBError::Database(format!("failed to create database directory: {e}")))?;
+            std::fs::create_dir_all(parent).map_err(|e| {
+                SafeDBError::Database(format!("failed to create database directory: {e}"))
+            })?;
         }
         let db = Database::create(path).map_err(|e| SafeDBError::Database(e.to_string()))?;
 


### PR DESCRIPTION
## Summary

Fixes a bug where the safedb parent directories didn't exist so base-consensus would just abort.