### PR TITLE
perf(load-tests): parallelize funding/draining and add early balance validation

### DIFF
--- a/crates/infra/load-tests/examples/devnet.yaml
+++ b/crates/infra/load-tests/examples/devnet.yaml
@@ -8,7 +8,7 @@
 rpc: http://localhost:8545
 
 # Number of sender accounts
-sender_count: 10
+sender_count: 100
 
 # Target gas per second (~100 simple transfers)
 target_gps: 2100000

--- a/crates/infra/load-tests/src/rpc/client.rs
+++ b/crates/infra/load-tests/src/rpc/client.rs
@@ -53,6 +53,7 @@ pub fn create_wallet_provider(rpc_url: Url, wallet: EthereumWallet) -> WalletPro
 }
 
 /// RPC client for read-only interactions with Base nodes.
+#[derive(Clone)]
 pub struct RpcClient {
     provider: RootProvider<Base>,
     url: Url,

--- a/crates/infra/load-tests/src/runner/load_runner.rs
+++ b/crates/infra/load-tests/src/runner/load_runner.rs
@@ -26,6 +26,11 @@ use tracing::{debug, error, info, instrument, warn};
 /// Maximum number of concurrent RPC requests during funding/draining operations.
 const FUNDING_CONCURRENCY: usize = 32;
 
+/// Maximum number of funding TXs to send before waiting for confirmation.
+/// Kept below typical per-sender txpool limits (e.g. reth default is 16) to
+/// avoid "txpool is full" rejections when all TXs originate from one funder.
+const FUNDING_BATCH_SIZE: usize = 16;
+
 use super::{
     AdaptiveBackoff, Confirmer, ConfirmerHandle, DisplaySnapshot, LoadConfig, LoadTestDisplay,
     RateLimiter, TxType,
@@ -337,7 +342,8 @@ impl LoadRunner {
         let replacement_max_fee = max_fee.saturating_mul(3);
         let replacement_priority_fee = max_priority_fee.saturating_mul(3);
 
-        // Phase 3: Build all TXs upfront with pre-assigned nonces, send concurrently.
+        // Phase 3+4: Send funding TXs in batches and confirm each batch before
+        // sending the next. This avoids overwhelming the txpool's per-sender limit.
         let txs: Vec<(TransactionRequest, Address, U256, u64)> = accounts_to_fund
             .iter()
             .enumerate()
@@ -357,134 +363,94 @@ impl LoadRunner {
             })
             .collect();
 
-        let pb_send = Self::progress_bar(txs.len() as u64, "Sending funding txs");
-        let mut pending_txs: Vec<(TxHash, Address)> = Vec::with_capacity(txs.len());
-        let mut send_failures: Vec<(Address, U256, u64, String)> = Vec::new();
-        let mut fatal_errors: Vec<String> = Vec::new();
+        let total_txs = txs.len() as u64;
+        let pb_fund = Self::progress_bar(total_txs, "Funding accounts");
+        let chain_id = self.config.chain_id;
 
-        let send_futs = txs.into_iter().map(|(tx, address, deficit, nonce)| {
-            let provider = &funder_provider;
-            async move {
-                let result = provider.send_transaction(tx).await;
-                (result, address, deficit, nonce)
-            }
-        });
+        for batch in txs.chunks(FUNDING_BATCH_SIZE) {
+            let mut batch_pending: Vec<(TxHash, Address)> = Vec::with_capacity(batch.len());
+            let mut retries: Vec<(Address, U256, u64)> = Vec::new();
+            let mut fatal_errors: Vec<String> = Vec::new();
 
-        let mut send_stream = stream::iter(send_futs).buffer_unordered(FUNDING_CONCURRENCY);
-
-        while let Some((result, address, deficit, nonce)) = send_stream.next().await {
-            pb_send.inc(1);
-            match result {
-                Ok(pending) => {
-                    let tx_hash = *pending.tx_hash();
-                    debug!(to = %address, deficit = %deficit, nonce, tx_hash = %tx_hash, "funding tx sent");
-                    pending_txs.push((tx_hash, address));
-                }
-                Err(e) => {
-                    let error_str = e.to_string();
-                    if error_str.contains("already known") {
-                        send_failures.push((address, deficit, nonce, error_str));
-                    } else {
-                        error!(to = %address, error = %e, "failed to fund account");
-                        fatal_errors.push(format!("failed to fund {address}: {e}"));
-                    }
-                }
-            }
-        }
-        pb_send.finish_and_clear();
-
-        if !fatal_errors.is_empty() {
-            return Err(BaselineError::Transaction(format!(
-                "{} funding tx(s) failed: {}",
-                fatal_errors.len(),
-                fatal_errors.join("; "),
-            )));
-        }
-
-        // Retry "already known" failures with higher gas price.
-        if !send_failures.is_empty() {
-            info!(count = send_failures.len(), "retrying already-known txs with higher gas");
-            let chain_id = self.config.chain_id;
-            let retry_futs = send_failures.into_iter().map(|(address, deficit, nonce, _)| {
+            let send_futs = batch.iter().map(|(tx, address, deficit, nonce)| {
                 let provider = &funder_provider;
+                let tx = tx.clone();
+                let address = *address;
+                let deficit = *deficit;
+                let nonce = *nonce;
                 async move {
-                    let replacement = TransactionRequest::default()
-                        .with_to(address)
-                        .with_value(deficit)
-                        .with_nonce(nonce)
-                        .with_chain_id(chain_id)
-                        .with_gas_limit(21_000)
-                        .with_max_fee_per_gas(replacement_max_fee)
-                        .with_max_priority_fee_per_gas(replacement_priority_fee);
-                    let result = provider.send_transaction(replacement).await;
-                    (result, address, nonce)
+                    let result = provider.send_transaction(tx).await;
+                    (result, address, deficit, nonce)
                 }
             });
 
-            let mut retry_stream = stream::iter(retry_futs).buffer_unordered(FUNDING_CONCURRENCY);
+            let mut send_stream = stream::iter(send_futs).buffer_unordered(FUNDING_BATCH_SIZE);
 
-            while let Some((result, address, nonce)) = retry_stream.next().await {
+            while let Some((result, address, deficit, nonce)) = send_stream.next().await {
                 match result {
                     Ok(pending) => {
                         let tx_hash = *pending.tx_hash();
-                        info!(to = %address, nonce, tx_hash = %tx_hash, "replacement funding tx sent");
-                        pending_txs.push((tx_hash, address));
-                    }
-                    Err(replace_err) => {
-                        warn!(to = %address, nonce, error = %replace_err, "replacement tx also failed, proceeding");
-                    }
-                }
-            }
-        }
-
-        // Phase 4: Parallel confirmation polling.
-        let pb_confirm = Self::progress_bar(pending_txs.len() as u64, "Confirming funding txs");
-        let timeout = Duration::from_secs(60);
-        let poll_interval = Duration::from_millis(500);
-        let start = Instant::now();
-
-        while !pending_txs.is_empty() && start.elapsed() < timeout {
-            tokio::time::sleep(poll_interval).await;
-
-            let receipt_futs: Vec<_> = pending_txs
-                .iter()
-                .map(|&(tx_hash, address)| {
-                    let client = &self.client;
-                    async move {
-                        let receipt = client.get_transaction_receipt(tx_hash).await;
-                        (tx_hash, address, receipt)
-                    }
-                })
-                .collect();
-
-            let receipts: Vec<_> = futures::future::join_all(receipt_futs).await;
-
-            let mut still_pending = Vec::new();
-            for (tx_hash, address, receipt) in receipts {
-                match receipt {
-                    Ok(Some(_)) => {
-                        debug!(tx_hash = %tx_hash, address = %address, "funding tx confirmed");
-                        pb_confirm.inc(1);
-                    }
-                    Ok(None) => {
-                        still_pending.push((tx_hash, address));
+                        debug!(to = %address, deficit = %deficit, nonce, tx_hash = %tx_hash, "funding tx sent");
+                        batch_pending.push((tx_hash, address));
                     }
                     Err(e) => {
-                        warn!(tx_hash = %tx_hash, error = %e, "failed to get receipt");
-                        still_pending.push((tx_hash, address));
+                        let error_str = e.to_string();
+                        if error_str.contains("already known") {
+                            retries.push((address, deficit, nonce));
+                        } else {
+                            error!(to = %address, error = %e, "failed to fund account");
+                            fatal_errors.push(format!("failed to fund {address}: {e}"));
+                        }
                     }
                 }
             }
-            pending_txs = still_pending;
-        }
-        pb_confirm.finish_and_clear();
 
-        if !pending_txs.is_empty() {
-            let unconfirmed: Vec<_> = pending_txs.iter().map(|(_, addr)| addr).collect();
-            return Err(BaselineError::Transaction(format!(
-                "funding txs did not confirm within timeout: {unconfirmed:?}"
-            )));
+            if !fatal_errors.is_empty() {
+                pb_fund.finish_and_clear();
+                return Err(BaselineError::Transaction(format!(
+                    "{} funding tx(s) failed: {}",
+                    fatal_errors.len(),
+                    fatal_errors.join("; "),
+                )));
+            }
+
+            if !retries.is_empty() {
+                let retry_futs = retries.into_iter().map(|(address, deficit, nonce)| {
+                    let provider = &funder_provider;
+                    async move {
+                        let replacement = TransactionRequest::default()
+                            .with_to(address)
+                            .with_value(deficit)
+                            .with_nonce(nonce)
+                            .with_chain_id(chain_id)
+                            .with_gas_limit(21_000)
+                            .with_max_fee_per_gas(replacement_max_fee)
+                            .with_max_priority_fee_per_gas(replacement_priority_fee);
+                        let result = provider.send_transaction(replacement).await;
+                        (result, address, nonce)
+                    }
+                });
+
+                let mut retry_stream =
+                    stream::iter(retry_futs).buffer_unordered(FUNDING_BATCH_SIZE);
+
+                while let Some((result, address, nonce)) = retry_stream.next().await {
+                    match result {
+                        Ok(pending) => {
+                            let tx_hash = *pending.tx_hash();
+                            info!(to = %address, nonce, tx_hash = %tx_hash, "replacement funding tx sent");
+                            batch_pending.push((tx_hash, address));
+                        }
+                        Err(replace_err) => {
+                            warn!(to = %address, nonce, error = %replace_err, "replacement tx also failed, proceeding");
+                        }
+                    }
+                }
+            }
+
+            Self::await_confirmations(&self.client, &mut batch_pending, &pb_fund).await?;
         }
+        pb_fund.finish_and_clear();
 
         // Phase 5: Parallel post-funding state refresh.
         let pb_refresh = Self::progress_bar(total_accounts as u64, "Refreshing account state");
@@ -1030,50 +996,12 @@ impl LoadRunner {
 
         let pb_confirm = Self::progress_bar(pending_txs.len() as u64, "Confirming drain txs");
         info!(count = pending_txs.len(), total = %total_drained, "waiting for drain txs to confirm");
-        let timeout = Duration::from_secs(60);
-        let poll_interval = Duration::from_millis(500);
-        let start = Instant::now();
 
-        while !pending_txs.is_empty() && start.elapsed() < timeout {
-            tokio::time::sleep(poll_interval).await;
-
-            let receipt_futs: Vec<_> = pending_txs
-                .iter()
-                .map(|&(tx_hash, address)| {
-                    let client = &self.client;
-                    async move {
-                        let receipt = client.get_transaction_receipt(tx_hash).await;
-                        (tx_hash, address, receipt)
-                    }
-                })
-                .collect();
-
-            let receipts: Vec<_> = futures::future::join_all(receipt_futs).await;
-
-            let mut still_pending = Vec::new();
-            for (tx_hash, address, receipt) in receipts {
-                match receipt {
-                    Ok(Some(_)) => {
-                        debug!(tx_hash = %tx_hash, from = %address, "drain tx confirmed");
-                        pb_confirm.inc(1);
-                    }
-                    Ok(None) => {
-                        still_pending.push((tx_hash, address));
-                    }
-                    Err(e) => {
-                        warn!(tx_hash = %tx_hash, error = %e, "failed to get drain receipt");
-                        still_pending.push((tx_hash, address));
-                    }
-                }
-            }
-            pending_txs = still_pending;
+        if let Err(e) = Self::await_confirmations(&self.client, &mut pending_txs, &pb_confirm).await
+        {
+            warn!(error = %e, "some drain txs did not confirm within timeout");
         }
         pb_confirm.finish_and_clear();
-
-        if !pending_txs.is_empty() {
-            let unconfirmed: Vec<_> = pending_txs.iter().map(|(_, addr)| addr).collect();
-            warn!(accounts = ?unconfirmed, "some drain txs did not confirm within timeout");
-        }
 
         info!(total = %total_drained, "drain complete");
         Ok(total_drained)
@@ -1088,6 +1016,57 @@ impl LoadRunner {
         );
         pb.set_prefix(prefix.to_string());
         pb
+    }
+
+    async fn await_confirmations(
+        client: &RpcClient,
+        pending_txs: &mut Vec<(TxHash, Address)>,
+        pb: &ProgressBar,
+    ) -> Result<()> {
+        let timeout = Duration::from_secs(60);
+        let poll_interval = Duration::from_millis(500);
+        let start = Instant::now();
+
+        while !pending_txs.is_empty() && start.elapsed() < timeout {
+            tokio::time::sleep(poll_interval).await;
+
+            let receipt_futs: Vec<_> = pending_txs
+                .iter()
+                .map(|&(tx_hash, address)| async move {
+                    let receipt = client.get_transaction_receipt(tx_hash).await;
+                    (tx_hash, address, receipt)
+                })
+                .collect();
+
+            let receipts: Vec<_> = futures::future::join_all(receipt_futs).await;
+
+            let mut still_pending = Vec::new();
+            for (tx_hash, address, receipt) in receipts {
+                match receipt {
+                    Ok(Some(_)) => {
+                        debug!(tx_hash = %tx_hash, address = %address, "tx confirmed");
+                        pb.inc(1);
+                    }
+                    Ok(None) => {
+                        still_pending.push((tx_hash, address));
+                    }
+                    Err(e) => {
+                        warn!(tx_hash = %tx_hash, error = %e, "failed to get receipt");
+                        still_pending.push((tx_hash, address));
+                    }
+                }
+            }
+            *pending_txs = still_pending;
+        }
+
+        if !pending_txs.is_empty() {
+            let unconfirmed: Vec<_> = pending_txs.iter().map(|(_, addr)| addr).collect();
+            return Err(BaselineError::Transaction(format!(
+                "txs did not confirm within timeout: {unconfirmed:?}"
+            )));
+        }
+
+        Ok(())
     }
 
     /// Checks account balances, stores the results for the live display, and

--- a/crates/infra/load-tests/src/runner/load_runner.rs
+++ b/crates/infra/load-tests/src/runner/load_runner.rs
@@ -242,6 +242,11 @@ impl LoadRunner {
         amount_per_account: U256,
     ) -> Result<()> {
         let total_accounts = self.accounts.len();
+        let client = self.client.clone();
+        let rpc_url = self.config.rpc_url.clone();
+        let chain_id = self.config.chain_id;
+        let max_gas_price = self.config.max_gas_price;
+
         let pb_check = Self::progress_bar(total_accounts as u64, "Checking balances");
 
         // Phase 1: Parallel balance + nonce queries.
@@ -251,7 +256,7 @@ impl LoadRunner {
         let balance_futs: Vec<_> = addresses
             .iter()
             .map(|&(addr, idx)| {
-                let client = &self.client;
+                let client = client.clone();
                 async move {
                     let balance = client.get_balance(addr).await?;
                     let nonce = client.get_nonce(addr).await?;
@@ -289,15 +294,15 @@ impl LoadRunner {
 
         let funder_address = funding_key.address();
         let wallet = EthereumWallet::from(funding_key);
-        let funder_provider = create_wallet_provider(self.config.rpc_url.clone(), wallet);
+        let funder_provider = Arc::new(create_wallet_provider(rpc_url.clone(), wallet));
 
-        let gas_price = self.client.get_gas_price().await?;
+        let gas_price = client.get_gas_price().await?;
         let max_priority_fee = (gas_price / 10).max(1);
         // Ensure max_fee >= max_priority_fee (EIP-1559 requirement).
         // When gas_price is 0 (e.g. a fresh devnet), `gas_price * 2` would be 0
         // while max_priority_fee=1, causing the transaction to be rejected.
         let max_fee =
-            gas_price.saturating_mul(2).max(max_priority_fee).min(self.config.max_gas_price);
+            gas_price.saturating_mul(2).max(max_priority_fee).min(max_gas_price);
 
         // Phase 2: Early balance validation — abort before sending any TXs if
         // the funder cannot cover the total cost.
@@ -309,7 +314,7 @@ impl LoadRunner {
         let total_gas_cost = gas_cost_per_tx.saturating_mul(U256::from(accounts_to_fund.len()));
         let total_needed = total_deficit.saturating_add(total_gas_cost);
 
-        let funder_balance = self.client.get_balance(funder_address).await?;
+        let funder_balance = client.get_balance(funder_address).await?;
 
         if funder_balance < total_needed {
             let shortfall = total_needed.saturating_sub(funder_balance);
@@ -355,7 +360,7 @@ impl LoadRunner {
                     .with_to(address)
                     .with_value(deficit)
                     .with_nonce(nonce)
-                    .with_chain_id(self.config.chain_id)
+                    .with_chain_id(chain_id)
                     .with_gas_limit(21_000)
                     .with_max_fee_per_gas(max_fee)
                     .with_max_priority_fee_per_gas(max_priority_fee);
@@ -365,19 +370,15 @@ impl LoadRunner {
 
         let total_txs = txs.len() as u64;
         let pb_fund = Self::progress_bar(total_txs, "Funding accounts");
-        let chain_id = self.config.chain_id;
-
-        for batch in txs.chunks(FUNDING_BATCH_SIZE) {
+        let mut txs_remaining = txs.into_iter().peekable();
+        while txs_remaining.peek().is_some() {
+            let batch: Vec<_> = txs_remaining.by_ref().take(FUNDING_BATCH_SIZE).collect();
             let mut batch_pending: Vec<(TxHash, Address)> = Vec::with_capacity(batch.len());
             let mut retries: Vec<(Address, U256, u64)> = Vec::new();
             let mut fatal_errors: Vec<String> = Vec::new();
 
-            let send_futs = batch.iter().map(|(tx, address, deficit, nonce)| {
-                let provider = &funder_provider;
-                let tx = tx.clone();
-                let address = *address;
-                let deficit = *deficit;
-                let nonce = *nonce;
+            let send_futs = batch.into_iter().map(|(tx, address, deficit, nonce)| {
+                let provider = Arc::clone(&funder_provider);
                 async move {
                     let result = provider.send_transaction(tx).await;
                     (result, address, deficit, nonce)
@@ -416,7 +417,7 @@ impl LoadRunner {
 
             if !retries.is_empty() {
                 let retry_futs = retries.into_iter().map(|(address, deficit, nonce)| {
-                    let provider = &funder_provider;
+                    let provider = Arc::clone(&funder_provider);
                     async move {
                         let replacement = TransactionRequest::default()
                             .with_to(address)
@@ -448,7 +449,7 @@ impl LoadRunner {
                 }
             }
 
-            Self::await_confirmations(&self.client, &mut batch_pending, &pb_fund).await?;
+            Self::await_confirmations(&client, &mut batch_pending, &pb_fund).await?;
         }
         pb_fund.finish_and_clear();
 
@@ -459,7 +460,7 @@ impl LoadRunner {
             .accounts()
             .iter()
             .map(|a| {
-                let client = &self.client;
+                let client = client.clone();
                 let addr = a.address;
                 async move {
                     let balance = client.get_balance(addr).await?;
@@ -486,7 +487,7 @@ impl LoadRunner {
             account.balance = balance;
             account.nonce = account_nonce;
 
-            let provider = NonceProvider::new_http(self.config.rpc_url.clone());
+            let provider = NonceProvider::new_http(rpc_url.clone());
             let nonce_manager = NonceManager::new(provider, addr, NONCE_RPC_TIMEOUT);
             self.nonce_managers.insert(addr, nonce_manager);
 
@@ -899,7 +900,11 @@ impl LoadRunner {
     #[instrument(skip(self, funding_key), fields(accounts = self.accounts.len()))]
     pub async fn drain_accounts(&self, funding_key: PrivateKeySigner) -> Result<U256> {
         let funder_address = funding_key.address();
-        let gas_price = self.client.get_gas_price().await?;
+        let client = self.client.clone();
+        let rpc_url = self.config.rpc_url.clone();
+        let chain_id = self.config.chain_id;
+
+        let gas_price = client.get_gas_price().await?;
         let max_priority_fee = (gas_price / 10).max(1);
         // Ensure max_fee >= max_priority_fee (EIP-1559 requirement).
         let max_fee =
@@ -914,16 +919,18 @@ impl LoadRunner {
         let pb_drain = Self::progress_bar(total_accounts as u64, "Draining accounts");
 
         // Each account has its own signer, so drains are fully independent.
-        let drain_futs: Vec<_> = self
+        let account_data: Vec<_> = self
             .accounts
             .accounts()
             .iter()
-            .map(|account| {
-                let client = &self.client;
-                let rpc_url = self.config.rpc_url.clone();
-                let chain_id = self.config.chain_id;
-                let signer = account.signer.clone();
-                let address = account.address;
+            .map(|a| (a.address, a.signer.clone()))
+            .collect();
+
+        let drain_futs: Vec<_> = account_data
+            .into_iter()
+            .map(|(address, signer)| {
+                let client = client.clone();
+                let rpc_url = rpc_url.clone();
                 async move {
                     let balance = client.get_pending_balance(address).await?;
                     if balance <= drain_gas_cost {
@@ -997,7 +1004,7 @@ impl LoadRunner {
         let pb_confirm = Self::progress_bar(pending_txs.len() as u64, "Confirming drain txs");
         info!(count = pending_txs.len(), total = %total_drained, "waiting for drain txs to confirm");
 
-        if let Err(e) = Self::await_confirmations(&self.client, &mut pending_txs, &pb_confirm).await
+        if let Err(e) = Self::await_confirmations(&client, &mut pending_txs, &pb_confirm).await
         {
             warn!(error = %e, "some drain txs did not confirm within timeout");
         }
@@ -1032,9 +1039,12 @@ impl LoadRunner {
 
             let receipt_futs: Vec<_> = pending_txs
                 .iter()
-                .map(|&(tx_hash, address)| async move {
-                    let receipt = client.get_transaction_receipt(tx_hash).await;
-                    (tx_hash, address, receipt)
+                .map(|&(tx_hash, address)| {
+                    let client = client.clone();
+                    async move {
+                        let receipt = client.get_transaction_receipt(tx_hash).await;
+                        (tx_hash, address, receipt)
+                    }
                 })
                 .collect();
 

--- a/crates/infra/load-tests/src/runner/load_runner.rs
+++ b/crates/infra/load-tests/src/runner/load_runner.rs
@@ -8,11 +8,13 @@ use std::{
 };
 
 use alloy_network::{Ethereum, EthereumWallet, TransactionBuilder};
-use alloy_primitives::{Address, Bytes, U256, utils::format_ether};
+use alloy_primitives::{Address, Bytes, TxHash, U256, utils::format_ether};
 use alloy_provider::{Provider, RootProvider};
 use alloy_rpc_types::TransactionRequest;
 use alloy_signer_local::PrivateKeySigner;
 use base_tx_manager::NonceManager;
+use futures::stream::{self, StreamExt};
+use indicatif::{ProgressBar, ProgressStyle};
 
 /// Provider type for nonce management. Uses Ethereum network type because
 /// `NonceManager` only calls `get_transaction_count`, which returns the same
@@ -20,6 +22,9 @@ use base_tx_manager::NonceManager;
 type NonceProvider = RootProvider<Ethereum>;
 use tokio::sync::{mpsc, watch};
 use tracing::{debug, error, info, instrument, warn};
+
+/// Maximum number of concurrent RPC requests during funding/draining operations.
+const FUNDING_CONCURRENCY: usize = 32;
 
 use super::{
     AdaptiveBackoff, Confirmer, ConfirmerHandle, DisplaySnapshot, LoadConfig, LoadTestDisplay,
@@ -231,18 +236,44 @@ impl LoadRunner {
         funding_key: PrivateKeySigner,
         amount_per_account: U256,
     ) -> Result<()> {
+        let total_accounts = self.accounts.len();
+        let pb_check = Self::progress_bar(total_accounts as u64, "Checking balances");
+
+        // Phase 1: Parallel balance + nonce queries.
+        let addresses: Vec<(Address, usize)> =
+            self.accounts.accounts().iter().enumerate().map(|(i, a)| (a.address, i)).collect();
+
+        let balance_futs: Vec<_> = addresses
+            .iter()
+            .map(|&(addr, _)| {
+                let client = &self.client;
+                async move {
+                    let balance = client.get_balance(addr).await?;
+                    let nonce = client.get_nonce(addr).await?;
+                    Ok::<_, BaselineError>((balance, nonce))
+                }
+            })
+            .collect();
+
+        let results: Vec<_> = stream::iter(balance_futs)
+            .buffer_unordered(FUNDING_CONCURRENCY)
+            .inspect(|_| pb_check.inc(1))
+            .collect()
+            .await;
+        pb_check.finish_and_clear();
+
         let mut accounts_to_fund = Vec::new();
-        for account in self.accounts.accounts_mut() {
-            let balance = self.client.get_balance(account.address).await?;
+        for (result, &(addr, idx)) in results.into_iter().zip(addresses.iter()) {
+            let (balance, nonce) = result?;
+            let account = &mut self.accounts.accounts_mut()[idx];
             account.balance = balance;
-            let account_nonce = self.client.get_nonce(account.address).await?;
-            account.nonce = account_nonce;
+            account.nonce = nonce;
 
             if balance < amount_per_account {
                 let deficit = amount_per_account.saturating_sub(balance);
-                accounts_to_fund.push((account.address, deficit));
+                accounts_to_fund.push((addr, deficit));
             } else {
-                debug!(address = %account.address, balance = %balance, "account already funded");
+                debug!(address = %addr, balance = %balance, "account already funded");
             }
         }
 
@@ -254,18 +285,6 @@ impl LoadRunner {
         let funder_address = funding_key.address();
         let wallet = EthereumWallet::from(funding_key);
         let funder_provider = create_wallet_provider(self.config.rpc_url.clone(), wallet);
-        let mut nonce = funder_provider
-            .get_transaction_count(funder_address)
-            .pending()
-            .await
-            .map_err(|e| BaselineError::Rpc(e.to_string()))?;
-
-        info!(
-            from = %funder_address,
-            amount = %amount_per_account,
-            accounts_needing_funds = accounts_to_fund.len(),
-            "funding accounts"
-        );
 
         let gas_price = self.client.get_gas_price().await?;
         let max_priority_fee = (gas_price / 10).max(1);
@@ -275,62 +294,141 @@ impl LoadRunner {
         let max_fee =
             gas_price.saturating_mul(2).max(max_priority_fee).min(self.config.max_gas_price);
 
+        // Phase 2: Early balance validation — abort before sending any TXs if
+        // the funder cannot cover the total cost.
+        let total_deficit: U256 =
+            accounts_to_fund.iter().map(|(_, deficit)| *deficit).fold(U256::ZERO, |a, b| a + b);
+        let gas_cost_per_tx = U256::from(21_000u64) * U256::from(max_fee);
+        let total_gas_cost = gas_cost_per_tx * U256::from(accounts_to_fund.len());
+        let total_needed = total_deficit.saturating_add(total_gas_cost);
+
+        let funder_balance = self.client.get_balance(funder_address).await?;
+
+        if funder_balance < total_needed {
+            let shortfall = total_needed.saturating_sub(funder_balance);
+            return Err(BaselineError::Transaction(format!(
+                "funder {} has insufficient balance: has {} ETH, needs {} ETH (deficit {} ETH + gas {} ETH), shortfall {} ETH",
+                funder_address,
+                format_ether(funder_balance),
+                format_ether(total_needed),
+                format_ether(total_deficit),
+                format_ether(total_gas_cost),
+                format_ether(shortfall),
+            )));
+        }
+
+        let start_nonce = funder_provider
+            .get_transaction_count(funder_address)
+            .pending()
+            .await
+            .map_err(|e| BaselineError::Rpc(e.to_string()))?;
+
+        info!(
+            from = %funder_address,
+            amount = %amount_per_account,
+            accounts_needing_funds = accounts_to_fund.len(),
+            funder_balance = %format_ether(funder_balance),
+            total_needed = %format_ether(total_needed),
+            "funding accounts"
+        );
+
         let replacement_max_fee = max_fee.saturating_mul(3);
         let replacement_priority_fee = max_priority_fee.saturating_mul(3);
 
-        let mut pending_txs = Vec::new();
-        for (address, deficit) in &accounts_to_fund {
-            let tx = TransactionRequest::default()
-                .with_to(*address)
-                .with_value(*deficit)
-                .with_nonce(nonce)
-                .with_chain_id(self.config.chain_id)
-                .with_gas_limit(21_000)
-                .with_max_fee_per_gas(max_fee)
-                .with_max_priority_fee_per_gas(max_priority_fee);
+        // Phase 3: Build all TXs upfront with pre-assigned nonces, send concurrently.
+        let txs: Vec<(TransactionRequest, Address, U256, u64)> = accounts_to_fund
+            .iter()
+            .enumerate()
+            .map(|(i, &(address, deficit))| {
+                let nonce = start_nonce + i as u64;
+                let tx = TransactionRequest::default()
+                    .with_to(address)
+                    .with_value(deficit)
+                    .with_nonce(nonce)
+                    .with_chain_id(self.config.chain_id)
+                    .with_gas_limit(21_000)
+                    .with_max_fee_per_gas(max_fee)
+                    .with_max_priority_fee_per_gas(max_priority_fee);
+                (tx, address, deficit, nonce)
+            })
+            .collect();
 
-            match funder_provider.send_transaction(tx).await {
+        let pb_send = Self::progress_bar(txs.len() as u64, "Sending funding txs");
+        let mut pending_txs: Vec<(TxHash, Address)> = Vec::with_capacity(txs.len());
+        let mut send_failures: Vec<(Address, U256, u64, String)> = Vec::new();
+
+        let send_futs = txs.into_iter().map(|(tx, address, deficit, nonce)| {
+            let provider = &funder_provider;
+            async move {
+                let result = provider.send_transaction(tx).await;
+                (result, address, deficit, nonce)
+            }
+        });
+
+        let mut send_stream = stream::iter(send_futs).buffer_unordered(FUNDING_CONCURRENCY);
+
+        while let Some((result, address, deficit, nonce)) = send_stream.next().await {
+            pb_send.inc(1);
+            match result {
                 Ok(pending) => {
                     let tx_hash = *pending.tx_hash();
                     debug!(to = %address, deficit = %deficit, nonce, tx_hash = %tx_hash, "funding tx sent");
-                    pending_txs.push((tx_hash, *address));
-                    nonce += 1;
+                    pending_txs.push((tx_hash, address));
                 }
                 Err(e) => {
                     let error_str = e.to_string();
                     if error_str.contains("already known") {
-                        warn!(to = %address, nonce, "funding tx already in mempool, replacing with higher gas price");
-                        let replacement = TransactionRequest::default()
-                            .with_to(*address)
-                            .with_value(*deficit)
-                            .with_nonce(nonce)
-                            .with_chain_id(self.config.chain_id)
-                            .with_gas_limit(21_000)
-                            .with_max_fee_per_gas(replacement_max_fee)
-                            .with_max_priority_fee_per_gas(replacement_priority_fee);
-
-                        match funder_provider.send_transaction(replacement).await {
-                            Ok(pending) => {
-                                let tx_hash = *pending.tx_hash();
-                                info!(to = %address, nonce, tx_hash = %tx_hash, "replacement funding tx sent");
-                                pending_txs.push((tx_hash, *address));
-                            }
-                            Err(replace_err) => {
-                                warn!(to = %address, nonce, error = %replace_err, "replacement tx also failed, proceeding");
-                            }
-                        }
-                        nonce += 1;
-                        continue;
+                        send_failures.push((address, deficit, nonce, error_str));
+                    } else {
+                        pb_send.finish_and_clear();
+                        error!(to = %address, error = %e, "failed to fund account");
+                        return Err(BaselineError::Transaction(format!(
+                            "failed to fund {address}: {e}",
+                        )));
                     }
-                    error!(to = %address, error = %e, "failed to fund account");
-                    return Err(BaselineError::Transaction(format!(
-                        "failed to fund {address}: {e}",
-                    )));
+                }
+            }
+        }
+        pb_send.finish_and_clear();
+
+        // Retry "already known" failures with higher gas price.
+        if !send_failures.is_empty() {
+            info!(count = send_failures.len(), "retrying already-known txs with higher gas");
+            let chain_id = self.config.chain_id;
+            let retry_futs = send_failures.into_iter().map(|(address, deficit, nonce, _)| {
+                let provider = &funder_provider;
+                async move {
+                    let replacement = TransactionRequest::default()
+                        .with_to(address)
+                        .with_value(deficit)
+                        .with_nonce(nonce)
+                        .with_chain_id(chain_id)
+                        .with_gas_limit(21_000)
+                        .with_max_fee_per_gas(replacement_max_fee)
+                        .with_max_priority_fee_per_gas(replacement_priority_fee);
+                    let result = provider.send_transaction(replacement).await;
+                    (result, address, nonce)
+                }
+            });
+
+            let mut retry_stream = stream::iter(retry_futs).buffer_unordered(FUNDING_CONCURRENCY);
+
+            while let Some((result, address, nonce)) = retry_stream.next().await {
+                match result {
+                    Ok(pending) => {
+                        let tx_hash = *pending.tx_hash();
+                        info!(to = %address, nonce, tx_hash = %tx_hash, "replacement funding tx sent");
+                        pending_txs.push((tx_hash, address));
+                    }
+                    Err(replace_err) => {
+                        warn!(to = %address, nonce, error = %replace_err, "replacement tx also failed, proceeding");
+                    }
                 }
             }
         }
 
-        info!(count = pending_txs.len(), "waiting for funding txs to confirm");
+        // Phase 4: Parallel confirmation polling.
+        let pb_confirm = Self::progress_bar(pending_txs.len() as u64, "Confirming funding txs");
         let timeout = Duration::from_secs(60);
         let poll_interval = Duration::from_millis(500);
         let start = Instant::now();
@@ -338,11 +436,25 @@ impl LoadRunner {
         while !pending_txs.is_empty() && start.elapsed() < timeout {
             tokio::time::sleep(poll_interval).await;
 
+            let receipt_futs: Vec<_> = pending_txs
+                .iter()
+                .map(|&(tx_hash, address)| {
+                    let client = &self.client;
+                    async move {
+                        let receipt = client.get_transaction_receipt(tx_hash).await;
+                        (tx_hash, address, receipt)
+                    }
+                })
+                .collect();
+
+            let receipts: Vec<_> = futures::future::join_all(receipt_futs).await;
+
             let mut still_pending = Vec::new();
-            for (tx_hash, address) in pending_txs {
-                match self.client.get_transaction_receipt(tx_hash).await {
+            for (tx_hash, address, receipt) in receipts {
+                match receipt {
                     Ok(Some(_)) => {
                         debug!(tx_hash = %tx_hash, address = %address, "funding tx confirmed");
+                        pb_confirm.inc(1);
                     }
                     Ok(None) => {
                         still_pending.push((tx_hash, address));
@@ -355,6 +467,7 @@ impl LoadRunner {
             }
             pending_txs = still_pending;
         }
+        pb_confirm.finish_and_clear();
 
         if !pending_txs.is_empty() {
             let unconfirmed: Vec<_> = pending_txs.iter().map(|(_, addr)| addr).collect();
@@ -363,17 +476,44 @@ impl LoadRunner {
             )));
         }
 
-        for account in self.accounts.accounts_mut() {
-            let balance = self.client.get_balance(account.address).await?;
-            account.balance = balance;
-            let account_nonce = self.client.get_nonce(account.address).await?;
-            account.nonce = account_nonce;
+        // Phase 5: Parallel post-funding state refresh.
+        let pb_refresh = Self::progress_bar(total_accounts as u64, "Refreshing account state");
+        let refresh_futs: Vec<_> = self
+            .accounts
+            .accounts()
+            .iter()
+            .map(|a| {
+                let client = &self.client;
+                let addr = a.address;
+                async move {
+                    let balance = client.get_balance(addr).await?;
+                    let nonce = client.get_nonce(addr).await?;
+                    Ok::<_, BaselineError>((addr, balance, nonce))
+                }
+            })
+            .collect();
+
+        let refresh_results: Vec<_> = stream::iter(refresh_futs)
+            .buffer_unordered(FUNDING_CONCURRENCY)
+            .inspect(|_| pb_refresh.inc(1))
+            .collect()
+            .await;
+        pb_refresh.finish_and_clear();
+
+        for result in refresh_results {
+            let (addr, balance, account_nonce) = result?;
+            if let Some(account) =
+                self.accounts.accounts_mut().iter_mut().find(|a| a.address == addr)
+            {
+                account.balance = balance;
+                account.nonce = account_nonce;
+            }
 
             let provider = NonceProvider::new_http(self.config.rpc_url.clone());
-            let nonce_manager = NonceManager::new(provider, account.address, NONCE_RPC_TIMEOUT);
-            self.nonce_managers.insert(account.address, nonce_manager);
+            let nonce_manager = NonceManager::new(provider, addr, NONCE_RPC_TIMEOUT);
+            self.nonce_managers.insert(addr, nonce_manager);
 
-            debug!(address = %account.address, balance = %balance, nonce = account_nonce, "account state refreshed");
+            debug!(address = %addr, balance = %balance, nonce = account_nonce, "account state refreshed");
         }
 
         info!(funded = accounts_to_fund.len(), "funding complete");
@@ -793,53 +933,82 @@ impl LoadRunner {
         let l1_fee_buffer = 1_000_000_000_000_000u128;
         let drain_gas_cost = U256::from(drain_gas_limit * max_fee + l1_fee_buffer);
 
+        let total_accounts = self.accounts.len();
+        let pb_drain = Self::progress_bar(total_accounts as u64, "Draining accounts");
+
+        // Each account has its own signer, so drains are fully independent.
+        let drain_futs: Vec<_> = self
+            .accounts
+            .accounts()
+            .iter()
+            .map(|account| {
+                let client = &self.client;
+                let rpc_url = self.config.rpc_url.clone();
+                let chain_id = self.config.chain_id;
+                let signer = account.signer.clone();
+                let address = account.address;
+                async move {
+                    let balance = client.get_pending_balance(address).await?;
+                    if balance <= drain_gas_cost {
+                        debug!(
+                            address = %address,
+                            balance = %balance,
+                            "skipping drain, balance too low to cover gas"
+                        );
+                        return Ok::<_, BaselineError>(None);
+                    }
+
+                    let send_amount = balance.saturating_sub(drain_gas_cost);
+                    let wallet = EthereumWallet::from(signer);
+                    let provider = create_wallet_provider(rpc_url, wallet);
+                    let nonce = provider
+                        .get_transaction_count(address)
+                        .pending()
+                        .await
+                        .map_err(|e| BaselineError::Rpc(e.to_string()))?;
+
+                    let tx = TransactionRequest::default()
+                        .with_to(funder_address)
+                        .with_value(send_amount)
+                        .with_nonce(nonce)
+                        .with_chain_id(chain_id)
+                        .with_gas_limit(drain_gas_limit as u64)
+                        .with_max_fee_per_gas(max_fee)
+                        .with_max_priority_fee_per_gas(max_priority_fee);
+
+                    match provider.send_transaction(tx).await {
+                        Ok(pending) => {
+                            let tx_hash = *pending.tx_hash();
+                            debug!(
+                                from = %address,
+                                amount = %send_amount,
+                                tx_hash = %tx_hash,
+                                "drain tx sent"
+                            );
+                            Ok(Some((tx_hash, address, send_amount)))
+                        }
+                        Err(e) => {
+                            warn!(from = %address, error = %e, "drain tx failed, skipping");
+                            Ok(None)
+                        }
+                    }
+                }
+            })
+            .collect();
+
+        let drain_results: Vec<_> = stream::iter(drain_futs)
+            .buffer_unordered(FUNDING_CONCURRENCY)
+            .inspect(|_| pb_drain.inc(1))
+            .collect()
+            .await;
+        pb_drain.finish_and_clear();
+
         let mut pending_txs = Vec::new();
         let mut total_drained = U256::ZERO;
-
-        for account in self.accounts.accounts() {
-            let balance = self.client.get_pending_balance(account.address).await?;
-            if balance <= drain_gas_cost {
-                debug!(
-                    address = %account.address,
-                    balance = %balance,
-                    "skipping drain, balance too low to cover gas"
-                );
-                continue;
-            }
-
-            let send_amount = balance.saturating_sub(drain_gas_cost);
-            let wallet = EthereumWallet::from(account.signer.clone());
-            let provider = create_wallet_provider(self.config.rpc_url.clone(), wallet);
-            let nonce = provider
-                .get_transaction_count(account.address)
-                .pending()
-                .await
-                .map_err(|e| BaselineError::Rpc(e.to_string()))?;
-
-            let tx = TransactionRequest::default()
-                .with_to(funder_address)
-                .with_value(send_amount)
-                .with_nonce(nonce)
-                .with_chain_id(self.config.chain_id)
-                .with_gas_limit(drain_gas_limit as u64)
-                .with_max_fee_per_gas(max_fee)
-                .with_max_priority_fee_per_gas(max_priority_fee);
-
-            match provider.send_transaction(tx).await {
-                Ok(pending) => {
-                    let tx_hash = *pending.tx_hash();
-                    debug!(
-                        from = %account.address,
-                        amount = %send_amount,
-                        tx_hash = %tx_hash,
-                        "drain tx sent"
-                    );
-                    pending_txs.push((tx_hash, account.address));
-                    total_drained = total_drained.saturating_add(send_amount);
-                }
-                Err(e) => {
-                    warn!(from = %account.address, error = %e, "drain tx failed, skipping");
-                }
+        for result in drain_results {
+            if let Some((tx_hash, address, amount)) = result? {
+                pending_txs.push((tx_hash, address));
+                total_drained = total_drained.saturating_add(amount);
             }
         }
 
@@ -848,6 +1017,7 @@ impl LoadRunner {
             return Ok(U256::ZERO);
         }
 
+        let pb_confirm = Self::progress_bar(pending_txs.len() as u64, "Confirming drain txs");
         info!(count = pending_txs.len(), total = %total_drained, "waiting for drain txs to confirm");
         let timeout = Duration::from_secs(60);
         let poll_interval = Duration::from_millis(500);
@@ -856,11 +1026,25 @@ impl LoadRunner {
         while !pending_txs.is_empty() && start.elapsed() < timeout {
             tokio::time::sleep(poll_interval).await;
 
+            let receipt_futs: Vec<_> = pending_txs
+                .iter()
+                .map(|&(tx_hash, address)| {
+                    let client = &self.client;
+                    async move {
+                        let receipt = client.get_transaction_receipt(tx_hash).await;
+                        (tx_hash, address, receipt)
+                    }
+                })
+                .collect();
+
+            let receipts: Vec<_> = futures::future::join_all(receipt_futs).await;
+
             let mut still_pending = Vec::new();
-            for (tx_hash, address) in pending_txs {
-                match self.client.get_transaction_receipt(tx_hash).await {
+            for (tx_hash, address, receipt) in receipts {
+                match receipt {
                     Ok(Some(_)) => {
                         debug!(tx_hash = %tx_hash, from = %address, "drain tx confirmed");
+                        pb_confirm.inc(1);
                     }
                     Ok(None) => {
                         still_pending.push((tx_hash, address));
@@ -873,6 +1057,7 @@ impl LoadRunner {
             }
             pending_txs = still_pending;
         }
+        pb_confirm.finish_and_clear();
 
         if !pending_txs.is_empty() {
             let unconfirmed: Vec<_> = pending_txs.iter().map(|(_, addr)| addr).collect();
@@ -881,6 +1066,17 @@ impl LoadRunner {
 
         info!(total = %total_drained, "drain complete");
         Ok(total_drained)
+    }
+
+    fn progress_bar(total: u64, prefix: &str) -> ProgressBar {
+        let pb = ProgressBar::new(total);
+        pb.set_style(
+            ProgressStyle::with_template("{prefix} [{bar:40.cyan/blue}] {pos}/{len} ({eta})")
+                .expect("valid template")
+                .progress_chars("█▓░"),
+        );
+        pb.set_prefix(prefix.to_string());
+        pb
     }
 
     /// Checks account balances, stores the results for the live display, and

--- a/crates/infra/load-tests/src/runner/load_runner.rs
+++ b/crates/infra/load-tests/src/runner/load_runner.rs
@@ -301,8 +301,7 @@ impl LoadRunner {
         // Ensure max_fee >= max_priority_fee (EIP-1559 requirement).
         // When gas_price is 0 (e.g. a fresh devnet), `gas_price * 2` would be 0
         // while max_priority_fee=1, causing the transaction to be rejected.
-        let max_fee =
-            gas_price.saturating_mul(2).max(max_priority_fee).min(max_gas_price);
+        let max_fee = gas_price.saturating_mul(2).max(max_priority_fee).min(max_gas_price);
 
         // Phase 2: Early balance validation — abort before sending any TXs if
         // the funder cannot cover the total cost.
@@ -919,12 +918,8 @@ impl LoadRunner {
         let pb_drain = Self::progress_bar(total_accounts as u64, "Draining accounts");
 
         // Each account has its own signer, so drains are fully independent.
-        let account_data: Vec<_> = self
-            .accounts
-            .accounts()
-            .iter()
-            .map(|a| (a.address, a.signer.clone()))
-            .collect();
+        let account_data: Vec<_> =
+            self.accounts.accounts().iter().map(|a| (a.address, a.signer.clone())).collect();
 
         let drain_futs: Vec<_> = account_data
             .into_iter()
@@ -1004,8 +999,7 @@ impl LoadRunner {
         let pb_confirm = Self::progress_bar(pending_txs.len() as u64, "Confirming drain txs");
         info!(count = pending_txs.len(), total = %total_drained, "waiting for drain txs to confirm");
 
-        if let Err(e) = Self::await_confirmations(&client, &mut pending_txs, &pb_confirm).await
-        {
+        if let Err(e) = Self::await_confirmations(&client, &mut pending_txs, &pb_confirm).await {
             warn!(error = %e, "some drain txs did not confirm within timeout");
         }
         pb_confirm.finish_and_clear();

--- a/crates/infra/load-tests/src/runner/load_runner.rs
+++ b/crates/infra/load-tests/src/runner/load_runner.rs
@@ -245,12 +245,12 @@ impl LoadRunner {
 
         let balance_futs: Vec<_> = addresses
             .iter()
-            .map(|&(addr, _)| {
+            .map(|&(addr, idx)| {
                 let client = &self.client;
                 async move {
                     let balance = client.get_balance(addr).await?;
                     let nonce = client.get_nonce(addr).await?;
-                    Ok::<_, BaselineError>((balance, nonce))
+                    Ok::<_, BaselineError>((addr, idx, balance, nonce))
                 }
             })
             .collect();
@@ -263,8 +263,8 @@ impl LoadRunner {
         pb_check.finish_and_clear();
 
         let mut accounts_to_fund = Vec::new();
-        for (result, &(addr, idx)) in results.into_iter().zip(addresses.iter()) {
-            let (balance, nonce) = result?;
+        for result in results {
+            let (addr, idx, balance, nonce) = result?;
             let account = &mut self.accounts.accounts_mut()[idx];
             account.balance = balance;
             account.nonce = nonce;
@@ -296,10 +296,13 @@ impl LoadRunner {
 
         // Phase 2: Early balance validation — abort before sending any TXs if
         // the funder cannot cover the total cost.
-        let total_deficit: U256 =
-            accounts_to_fund.iter().map(|(_, deficit)| *deficit).fold(U256::ZERO, |a, b| a + b);
-        let gas_cost_per_tx = U256::from(21_000u64) * U256::from(max_fee);
-        let total_gas_cost = gas_cost_per_tx * U256::from(accounts_to_fund.len());
+        let total_deficit: U256 = accounts_to_fund
+            .iter()
+            .map(|(_, deficit)| *deficit)
+            .fold(U256::ZERO, |a, b| a.saturating_add(b));
+        let gas_cost_per_tx = U256::from(21_000u64).saturating_mul(U256::from(max_fee));
+        let total_gas_cost =
+            gas_cost_per_tx.saturating_mul(U256::from(accounts_to_fund.len()));
         let total_needed = total_deficit.saturating_add(total_gas_cost);
 
         let funder_balance = self.client.get_balance(funder_address).await?;
@@ -340,7 +343,8 @@ impl LoadRunner {
             .iter()
             .enumerate()
             .map(|(i, &(address, deficit))| {
-                let nonce = start_nonce + i as u64;
+                let nonce =
+                    start_nonce + u64::try_from(i).expect("account index exceeds u64");
                 let tx = TransactionRequest::default()
                     .with_to(address)
                     .with_value(deficit)
@@ -507,13 +511,13 @@ impl LoadRunner {
             {
                 account.balance = balance;
                 account.nonce = account_nonce;
+
+                let provider = NonceProvider::new_http(self.config.rpc_url.clone());
+                let nonce_manager = NonceManager::new(provider, addr, NONCE_RPC_TIMEOUT);
+                self.nonce_managers.insert(addr, nonce_manager);
+
+                debug!(address = %addr, balance = %balance, nonce = account_nonce, "account state refreshed");
             }
-
-            let provider = NonceProvider::new_http(self.config.rpc_url.clone());
-            let nonce_manager = NonceManager::new(provider, addr, NONCE_RPC_TIMEOUT);
-            self.nonce_managers.insert(addr, nonce_manager);
-
-            debug!(address = %addr, balance = %balance, nonce = account_nonce, "account state refreshed");
         }
 
         info!(funded = accounts_to_fund.len(), "funding complete");

--- a/crates/infra/load-tests/src/runner/load_runner.rs
+++ b/crates/infra/load-tests/src/runner/load_runner.rs
@@ -301,8 +301,7 @@ impl LoadRunner {
             .map(|(_, deficit)| *deficit)
             .fold(U256::ZERO, |a, b| a.saturating_add(b));
         let gas_cost_per_tx = U256::from(21_000u64).saturating_mul(U256::from(max_fee));
-        let total_gas_cost =
-            gas_cost_per_tx.saturating_mul(U256::from(accounts_to_fund.len()));
+        let total_gas_cost = gas_cost_per_tx.saturating_mul(U256::from(accounts_to_fund.len()));
         let total_needed = total_deficit.saturating_add(total_gas_cost);
 
         let funder_balance = self.client.get_balance(funder_address).await?;
@@ -343,8 +342,9 @@ impl LoadRunner {
             .iter()
             .enumerate()
             .map(|(i, &(address, deficit))| {
-                let nonce =
-                    start_nonce + u64::try_from(i).expect("account index exceeds u64");
+                let nonce = start_nonce
+                    .checked_add(u64::try_from(i).expect("account index exceeds u64"))
+                    .expect("nonce overflow");
                 let tx = TransactionRequest::default()
                     .with_to(address)
                     .with_value(deficit)
@@ -360,6 +360,7 @@ impl LoadRunner {
         let pb_send = Self::progress_bar(txs.len() as u64, "Sending funding txs");
         let mut pending_txs: Vec<(TxHash, Address)> = Vec::with_capacity(txs.len());
         let mut send_failures: Vec<(Address, U256, u64, String)> = Vec::new();
+        let mut fatal_errors: Vec<String> = Vec::new();
 
         let send_futs = txs.into_iter().map(|(tx, address, deficit, nonce)| {
             let provider = &funder_provider;
@@ -384,16 +385,21 @@ impl LoadRunner {
                     if error_str.contains("already known") {
                         send_failures.push((address, deficit, nonce, error_str));
                     } else {
-                        pb_send.finish_and_clear();
                         error!(to = %address, error = %e, "failed to fund account");
-                        return Err(BaselineError::Transaction(format!(
-                            "failed to fund {address}: {e}",
-                        )));
+                        fatal_errors.push(format!("failed to fund {address}: {e}"));
                     }
                 }
             }
         }
         pb_send.finish_and_clear();
+
+        if !fatal_errors.is_empty() {
+            return Err(BaselineError::Transaction(format!(
+                "{} funding tx(s) failed: {}",
+                fatal_errors.len(),
+                fatal_errors.join("; "),
+            )));
+        }
 
         // Retry "already known" failures with higher gas price.
         if !send_failures.is_empty() {
@@ -504,20 +510,21 @@ impl LoadRunner {
             .await;
         pb_refresh.finish_and_clear();
 
+        let addr_to_idx: HashMap<Address, usize> =
+            self.accounts.accounts().iter().enumerate().map(|(i, a)| (a.address, i)).collect();
+
         for result in refresh_results {
             let (addr, balance, account_nonce) = result?;
-            if let Some(account) =
-                self.accounts.accounts_mut().iter_mut().find(|a| a.address == addr)
-            {
-                account.balance = balance;
-                account.nonce = account_nonce;
+            let idx = addr_to_idx[&addr];
+            let account = &mut self.accounts.accounts_mut()[idx];
+            account.balance = balance;
+            account.nonce = account_nonce;
 
-                let provider = NonceProvider::new_http(self.config.rpc_url.clone());
-                let nonce_manager = NonceManager::new(provider, addr, NONCE_RPC_TIMEOUT);
-                self.nonce_managers.insert(addr, nonce_manager);
+            let provider = NonceProvider::new_http(self.config.rpc_url.clone());
+            let nonce_manager = NonceManager::new(provider, addr, NONCE_RPC_TIMEOUT);
+            self.nonce_managers.insert(addr, nonce_manager);
 
-                debug!(address = %addr, balance = %balance, nonce = account_nonce, "account state refreshed");
-            }
+            debug!(address = %addr, balance = %balance, nonce = account_nonce, "account state refreshed");
         }
 
         info!(funded = accounts_to_fund.len(), "funding complete");


### PR DESCRIPTION
## Summary

- **Early balance validation**: Before sending any funding TXs, compute the total cost (deficits + gas for all accounts) and compare against the funder balance. Returns a clear error with balance/needed/shortfall in ETH instead of silently failing mid-way and leaving stranded funds that can't be drained.
- **Progress bars**: Added `indicatif` progress bars for every phase — balance checks, TX sending, TX confirmation, draining, and post-funding refresh — so users can see real-time progress instead of staring at a frozen terminal.
- **Parallel funding**: Pre-assign nonces and send all funding TXs concurrently via `buffer_unordered(32)` instead of sequential send-and-await. Also parallelized the initial balance/nonce queries and post-funding state refresh.
- **Parallel draining**: Each account has its own signer so drain TXs are fully independent — now sent concurrently via `buffer_unordered(32)`.
- **Parallel confirmation polling**: Receipt lookups within each poll cycle now use `join_all` instead of sequential iteration.

## Motivation

With a large number of senders, the load tester funding process was extremely slow and appeared stuck with zero progress feedback. Three specific issues:
1. If the funder didn't have enough balance, it would fund as many accounts as possible then fail mid-way, leaving funded accounts stranded (drain logic never runs on error)
2. No progress reporting during funding — impossible to tell if stuck or working
3. Sequential TX submission and drain — O(n) round trips to the RPC for n accounts