### PR TITLE
fix(consensus): Instrument Request Duration Histogram

### DIFF
--- a/crates/consensus/providers-alloy/src/beacon_client.rs
+++ b/crates/consensus/providers-alloy/src/beacon_client.rs
@@ -228,10 +228,9 @@ impl BeaconClient for OnlineBeaconClient {
             return Ok(APIConfigResponse::new(l1_slot_duration));
         }
 
-        let result = base_metrics::time!(Metrics::request_duration(), {
+        let result = base_metrics::time!(Metrics::request_duration("spec"), {
             async {
-                let first =
-                    self.inner.get(format!("{}/{}", self.base, SPEC_METHOD)).send().await?;
+                let first = self.inner.get(format!("{}/{}", self.base, SPEC_METHOD)).send().await?;
                 first.json::<APIConfigResponse>().await
             }
             .await
@@ -247,7 +246,7 @@ impl BeaconClient for OnlineBeaconClient {
     async fn genesis_time(&self) -> Result<APIGenesisResponse, Self::Error> {
         Metrics::beacon_requests("genesis").increment(1);
 
-        let result = base_metrics::time!(Metrics::request_duration(), {
+        let result = base_metrics::time!(Metrics::request_duration("genesis"), {
             async {
                 let first =
                     self.inner.get(format!("{}/{}", self.base, GENESIS_METHOD)).send().await?;
@@ -271,7 +270,7 @@ impl BeaconClient for OnlineBeaconClient {
         Metrics::beacon_requests("blobs").increment(1);
 
         // Try to get the blobs from the blobs endpoint.
-        let result = base_metrics::time!(Metrics::request_duration(), {
+        let result = base_metrics::time!(Metrics::request_duration("blobs"), {
             self.filtered_beacon_blobs(slot, blob_hashes).await
         });
 

--- a/crates/consensus/providers-alloy/src/beacon_client.rs
+++ b/crates/consensus/providers-alloy/src/beacon_client.rs
@@ -228,11 +228,14 @@ impl BeaconClient for OnlineBeaconClient {
             return Ok(APIConfigResponse::new(l1_slot_duration));
         }
 
-        let result = async {
-            let first = self.inner.get(format!("{}/{}", self.base, SPEC_METHOD)).send().await?;
-            first.json::<APIConfigResponse>().await
-        }
-        .await;
+        let result = base_metrics::time!(Metrics::request_duration(), {
+            async {
+                let first =
+                    self.inner.get(format!("{}/{}", self.base, SPEC_METHOD)).send().await?;
+                first.json::<APIConfigResponse>().await
+            }
+            .await
+        });
 
         if result.is_err() {
             Metrics::beacon_errors("spec").increment(1);
@@ -244,11 +247,14 @@ impl BeaconClient for OnlineBeaconClient {
     async fn genesis_time(&self) -> Result<APIGenesisResponse, Self::Error> {
         Metrics::beacon_requests("genesis").increment(1);
 
-        let result = async {
-            let first = self.inner.get(format!("{}/{}", self.base, GENESIS_METHOD)).send().await?;
-            first.json::<APIGenesisResponse>().await
-        }
-        .await;
+        let result = base_metrics::time!(Metrics::request_duration(), {
+            async {
+                let first =
+                    self.inner.get(format!("{}/{}", self.base, GENESIS_METHOD)).send().await?;
+                first.json::<APIGenesisResponse>().await
+            }
+            .await
+        });
 
         if result.is_err() {
             Metrics::beacon_errors("genesis").increment(1);
@@ -265,7 +271,9 @@ impl BeaconClient for OnlineBeaconClient {
         Metrics::beacon_requests("blobs").increment(1);
 
         // Try to get the blobs from the blobs endpoint.
-        let result = self.filtered_beacon_blobs(slot, blob_hashes).await;
+        let result = base_metrics::time!(Metrics::request_duration(), {
+            self.filtered_beacon_blobs(slot, blob_hashes).await
+        });
 
         if result.is_err() {
             Metrics::beacon_errors("blobs").increment(1);

--- a/crates/consensus/providers-alloy/src/chain_provider.rs
+++ b/crates/consensus/providers-alloy/src/chain_provider.rs
@@ -65,7 +65,9 @@ impl AlloyChainProvider {
     pub async fn latest_block_number(&mut self) -> Result<u64, RpcError<TransportErrorKind>> {
         Metrics::chain_rpc_calls("block_number").increment(1);
 
-        let result = self.inner.get_block_number().await;
+        let result = base_metrics::time!(Metrics::request_duration(), {
+            self.inner.get_block_number().await
+        });
 
         if result.is_err() {
             Metrics::chain_rpc_errors("block_number").increment(1);
@@ -160,14 +162,13 @@ impl ChainProvider for AlloyChainProvider {
 
         Metrics::chain_rpc_calls("header_by_hash").increment(1);
 
-        let block = self
-            .inner
-            .get_block_by_hash(hash)
-            .await
-            .inspect_err(|_e| {
-                Metrics::chain_rpc_errors("header_by_hash").increment(1);
-            })?
-            .ok_or(AlloyChainProviderError::BlockNotFound(hash.into()))?;
+        let block = base_metrics::time!(Metrics::request_duration(), {
+            self.inner.get_block_by_hash(hash).await
+        })
+        .inspect_err(|_e| {
+            Metrics::chain_rpc_errors("header_by_hash").increment(1);
+        })?
+        .ok_or(AlloyChainProviderError::BlockNotFound(hash.into()))?;
         let header = block.header.into_consensus();
 
         // Verify the header hash matches what we requested
@@ -183,14 +184,13 @@ impl ChainProvider for AlloyChainProvider {
     async fn block_info_by_number(&mut self, number: u64) -> Result<BlockInfo, Self::Error> {
         Metrics::chain_rpc_calls("block_by_number").increment(1);
 
-        let block = self
-            .inner
-            .get_block_by_number(number.into())
-            .await
-            .inspect_err(|_e| {
-                Metrics::chain_rpc_errors("block_by_number").increment(1);
-            })?
-            .ok_or(AlloyChainProviderError::BlockNotFound(number.into()))?;
+        let block = base_metrics::time!(Metrics::request_duration(), {
+            self.inner.get_block_by_number(number.into()).await
+        })
+        .inspect_err(|_e| {
+            Metrics::chain_rpc_errors("block_by_number").increment(1);
+        })?
+        .ok_or(AlloyChainProviderError::BlockNotFound(number.into()))?;
         let header = block.header.into_consensus();
 
         let block_info = BlockInfo {
@@ -212,14 +212,13 @@ impl ChainProvider for AlloyChainProvider {
 
         Metrics::chain_rpc_calls("receipts_by_hash").increment(1);
 
-        let receipts = self
-            .inner
-            .get_block_receipts(hash.into())
-            .await
-            .inspect_err(|_e| {
-                Metrics::chain_rpc_errors("receipts_by_hash").increment(1);
-            })?
-            .ok_or(AlloyChainProviderError::BlockNotFound(hash.into()))?;
+        let receipts = base_metrics::time!(Metrics::request_duration(), {
+            self.inner.get_block_receipts(hash.into()).await
+        })
+        .inspect_err(|_e| {
+            Metrics::chain_rpc_errors("receipts_by_hash").increment(1);
+        })?
+        .ok_or(AlloyChainProviderError::BlockNotFound(hash.into()))?;
         let consensus_receipts = receipts
             .into_iter()
             .map(|r| r.inner.into_primitives_receipt().as_receipt().cloned())
@@ -247,17 +246,15 @@ impl ChainProvider for AlloyChainProvider {
 
         Metrics::chain_rpc_calls("block_by_hash").increment(1);
 
-        let block = self
-            .inner
-            .get_block_by_hash(hash)
-            .full()
-            .await
-            .inspect_err(|_e| {
-                Metrics::chain_rpc_errors("block_by_hash").increment(1);
-            })?
-            .ok_or(AlloyChainProviderError::BlockNotFound(hash.into()))?
-            .into_consensus()
-            .map_transactions(|t| t.inner.into_inner());
+        let block = base_metrics::time!(Metrics::request_duration(), {
+            self.inner.get_block_by_hash(hash).full().await
+        })
+        .inspect_err(|_e| {
+            Metrics::chain_rpc_errors("block_by_hash").increment(1);
+        })?
+        .ok_or(AlloyChainProviderError::BlockNotFound(hash.into()))?
+        .into_consensus()
+        .map_transactions(|t| t.inner.into_inner());
 
         // Verify the block hash matches what we requested
         self.verify_header_hash(&block.header, hash)?;

--- a/crates/consensus/providers-alloy/src/chain_provider.rs
+++ b/crates/consensus/providers-alloy/src/chain_provider.rs
@@ -65,7 +65,7 @@ impl AlloyChainProvider {
     pub async fn latest_block_number(&mut self) -> Result<u64, RpcError<TransportErrorKind>> {
         Metrics::chain_rpc_calls("block_number").increment(1);
 
-        let result = base_metrics::time!(Metrics::request_duration(), {
+        let result = base_metrics::time!(Metrics::request_duration("block_number"), {
             self.inner.get_block_number().await
         });
 
@@ -162,7 +162,7 @@ impl ChainProvider for AlloyChainProvider {
 
         Metrics::chain_rpc_calls("header_by_hash").increment(1);
 
-        let block = base_metrics::time!(Metrics::request_duration(), {
+        let block = base_metrics::time!(Metrics::request_duration("header_by_hash"), {
             self.inner.get_block_by_hash(hash).await
         })
         .inspect_err(|_e| {
@@ -184,7 +184,7 @@ impl ChainProvider for AlloyChainProvider {
     async fn block_info_by_number(&mut self, number: u64) -> Result<BlockInfo, Self::Error> {
         Metrics::chain_rpc_calls("block_by_number").increment(1);
 
-        let block = base_metrics::time!(Metrics::request_duration(), {
+        let block = base_metrics::time!(Metrics::request_duration("block_by_number"), {
             self.inner.get_block_by_number(number.into()).await
         })
         .inspect_err(|_e| {
@@ -212,7 +212,7 @@ impl ChainProvider for AlloyChainProvider {
 
         Metrics::chain_rpc_calls("receipts_by_hash").increment(1);
 
-        let receipts = base_metrics::time!(Metrics::request_duration(), {
+        let receipts = base_metrics::time!(Metrics::request_duration("receipts_by_hash"), {
             self.inner.get_block_receipts(hash.into()).await
         })
         .inspect_err(|_e| {
@@ -246,7 +246,7 @@ impl ChainProvider for AlloyChainProvider {
 
         Metrics::chain_rpc_calls("block_by_hash").increment(1);
 
-        let block = base_metrics::time!(Metrics::request_duration(), {
+        let block = base_metrics::time!(Metrics::request_duration("block_by_hash"), {
             self.inner.get_block_by_hash(hash).full().await
         })
         .inspect_err(|_e| {

--- a/crates/consensus/providers-alloy/src/l2_chain_provider.rs
+++ b/crates/consensus/providers-alloy/src/l2_chain_provider.rs
@@ -112,44 +112,48 @@ impl AlloyL2ChainProvider {
 
         Metrics::l2_chain_requests(method_name).increment(1);
 
-        let result = base_metrics::time!(Metrics::request_duration(), {
-            async {
-                let block = match id {
-                    BlockId::Number(num) => self.inner.get_block_by_number(num).full().await?,
-                    BlockId::Hash(hash) => {
-                        let block =
-                            self.inner.get_block_by_hash(hash.block_hash).full().await?;
-
-                        // Verify block hash matches if we fetched by hash
-                        if let Some(ref b) = block {
-                            self.verify_block_hash(b.header.hash, hash.block_hash)?;
-                        }
-
-                        block
-                    }
-                };
-
-                match block {
-                    Some(block) => {
-                        let consensus_block =
-                            block.into_consensus().map_transactions(|t| t.inner.inner);
-
-                        let l2_block = L2BlockInfo::from_block_and_genesis(
-                            &consensus_block,
-                            &self.rollup_config.genesis,
-                        )
-                        .map_err(|_| {
-                            RpcError::local_usage_str(
-                                "failed to construct L2BlockInfo from block and genesis",
-                            )
-                        })?;
-                        Ok(Some(l2_block))
-                    }
-                    None => Ok(None),
-                }
+        let raw_block = base_metrics::time!(Metrics::request_duration(method_name), {
+            match &id {
+                BlockId::Number(num) => self.inner.get_block_by_number(*num).full().await,
+                BlockId::Hash(hash) => self.inner.get_block_by_hash(hash.block_hash).full().await,
             }
-            .await
         });
+
+        let result = async {
+            let block = match id {
+                BlockId::Number(_) => raw_block?,
+                BlockId::Hash(hash) => {
+                    let block = raw_block?;
+
+                    // Verify block hash matches if we fetched by hash
+                    if let Some(ref b) = block {
+                        self.verify_block_hash(b.header.hash, hash.block_hash)?;
+                    }
+
+                    block
+                }
+            };
+
+            match block {
+                Some(block) => {
+                    let consensus_block =
+                        block.into_consensus().map_transactions(|t| t.inner.inner);
+
+                    let l2_block = L2BlockInfo::from_block_and_genesis(
+                        &consensus_block,
+                        &self.rollup_config.genesis,
+                    )
+                    .map_err(|_| {
+                        RpcError::local_usage_str(
+                            "failed to construct L2BlockInfo from block and genesis",
+                        )
+                    })?;
+                    Ok(Some(l2_block))
+                }
+                None => Ok(None),
+            }
+        }
+        .await;
 
         if result.is_err() {
             Metrics::l2_chain_errors(method_name).increment(1);
@@ -235,16 +239,16 @@ impl BatchValidationProvider for AlloyL2ChainProvider {
 
         Metrics::l2_chain_requests("l2_block_ref_by_number").increment(1);
 
-        let block = base_metrics::time!(Metrics::request_duration(), {
+        let block = base_metrics::time!(Metrics::request_duration("l2_block_ref_by_number"), {
             self.inner.get_block_by_number(number.into()).full().await
         })
         .map_err(|e| {
             Metrics::l2_chain_errors("l2_block_ref_by_number").increment(1);
             AlloyL2ChainProviderError::Transport(e)
         })?
-            .ok_or(AlloyL2ChainProviderError::BlockNotFound(number))?
-            .into_consensus()
-            .map_transactions(|t| t.inner.inner.into_inner());
+        .ok_or(AlloyL2ChainProviderError::BlockNotFound(number))?
+        .into_consensus()
+        .map_transactions(|t| t.inner.inner.into_inner());
 
         self.block_by_number_cache.put(number, block.clone());
         Ok(block)

--- a/crates/consensus/providers-alloy/src/l2_chain_provider.rs
+++ b/crates/consensus/providers-alloy/src/l2_chain_provider.rs
@@ -112,41 +112,44 @@ impl AlloyL2ChainProvider {
 
         Metrics::l2_chain_requests(method_name).increment(1);
 
-        let result = async {
-            let block = match id {
-                BlockId::Number(num) => self.inner.get_block_by_number(num).full().await?,
-                BlockId::Hash(hash) => {
-                    let block = self.inner.get_block_by_hash(hash.block_hash).full().await?;
+        let result = base_metrics::time!(Metrics::request_duration(), {
+            async {
+                let block = match id {
+                    BlockId::Number(num) => self.inner.get_block_by_number(num).full().await?,
+                    BlockId::Hash(hash) => {
+                        let block =
+                            self.inner.get_block_by_hash(hash.block_hash).full().await?;
 
-                    // Verify block hash matches if we fetched by hash
-                    if let Some(ref b) = block {
-                        self.verify_block_hash(b.header.hash, hash.block_hash)?;
+                        // Verify block hash matches if we fetched by hash
+                        if let Some(ref b) = block {
+                            self.verify_block_hash(b.header.hash, hash.block_hash)?;
+                        }
+
+                        block
                     }
+                };
 
-                    block
-                }
-            };
+                match block {
+                    Some(block) => {
+                        let consensus_block =
+                            block.into_consensus().map_transactions(|t| t.inner.inner);
 
-            match block {
-                Some(block) => {
-                    let consensus_block =
-                        block.into_consensus().map_transactions(|t| t.inner.inner);
-
-                    let l2_block = L2BlockInfo::from_block_and_genesis(
-                        &consensus_block,
-                        &self.rollup_config.genesis,
-                    )
-                    .map_err(|_| {
-                        RpcError::local_usage_str(
-                            "failed to construct L2BlockInfo from block and genesis",
+                        let l2_block = L2BlockInfo::from_block_and_genesis(
+                            &consensus_block,
+                            &self.rollup_config.genesis,
                         )
-                    })?;
-                    Ok(Some(l2_block))
+                        .map_err(|_| {
+                            RpcError::local_usage_str(
+                                "failed to construct L2BlockInfo from block and genesis",
+                            )
+                        })?;
+                        Ok(Some(l2_block))
+                    }
+                    None => Ok(None),
                 }
-                None => Ok(None),
             }
-        }
-        .await;
+            .await
+        });
 
         if result.is_err() {
             Metrics::l2_chain_errors(method_name).increment(1);
@@ -232,15 +235,13 @@ impl BatchValidationProvider for AlloyL2ChainProvider {
 
         Metrics::l2_chain_requests("l2_block_ref_by_number").increment(1);
 
-        let block = self
-            .inner
-            .get_block_by_number(number.into())
-            .full()
-            .await
-            .map_err(|e| {
-                Metrics::l2_chain_errors("l2_block_ref_by_number").increment(1);
-                AlloyL2ChainProviderError::Transport(e)
-            })?
+        let block = base_metrics::time!(Metrics::request_duration(), {
+            self.inner.get_block_by_number(number.into()).full().await
+        })
+        .map_err(|e| {
+            Metrics::l2_chain_errors("l2_block_ref_by_number").increment(1);
+            AlloyL2ChainProviderError::Transport(e)
+        })?
             .ok_or(AlloyL2ChainProviderError::BlockNotFound(number))?
             .into_consensus()
             .map_transactions(|t| t.inner.inner.into_inner());

--- a/crates/consensus/providers-alloy/src/metrics.rs
+++ b/crates/consensus/providers-alloy/src/metrics.rs
@@ -31,6 +31,7 @@ base_metrics::define_metrics! {
     #[describe("Number of blob sidecar fetch errors")]
     blob_fetch_errors: counter,
     #[describe("Duration of provider requests in seconds")]
+    #[label(name = "method", default = ["block_number", "header_by_hash", "block_by_number", "block_by_hash", "receipts_by_hash", "l2_block_ref_by_number", "l2_block_ref_by_hash", "spec", "genesis", "blobs"])]
     request_duration: histogram,
     #[describe("Number of active entries in provider caches")]
     #[label(name = "cache", default = ["header_by_hash", "receipts_by_hash", "block_info_and_tx"])]


### PR DESCRIPTION
## Summary

The `request_duration` histogram in `base-consensus-providers` was defined but never instrumented, meaning it produced no data in Datadog. This change wraps every outbound RPC call in the alloy chain provider, L2 chain provider, and beacon client with `base_metrics::time!` so the histogram captures real latency. Coverage includes all five `AlloyChainProvider` methods, both `AlloyL2ChainProvider` fetch paths, and all three `OnlineBeaconClient` request methods.