### PR TITLE
fix(basectl): Run V1 Checks Before Activation

### DIFF
--- a/crates/infra/basectl/src/app/views/upgrades.rs
+++ b/crates/infra/basectl/src/app/views/upgrades.rs
@@ -67,6 +67,18 @@ struct ChainUpgrades {
     specs: Vec<UpgradeSpec>,
 }
 
+impl ChainUpgrades {
+    /// Returns `true` if the V1 upgrade has activated at or before `now`.
+    fn v1_active(&self, now: u64) -> bool {
+        self.specs
+            .iter()
+            .find(|s| s.name == "V1")
+            .and_then(|s| s.timestamp)
+            .map(|ts| ts <= now)
+            .unwrap_or(false)
+    }
+}
+
 fn specs_from_config(cfg: &BaseChainConfig) -> Vec<UpgradeSpec> {
     vec![
         UpgradeSpec { name: "Delta", timestamp: Some(cfg.delta_timestamp) },
@@ -120,12 +132,6 @@ const V1_CHECK_NAMES: &[&str] = &[
     "eth_config",
 ];
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum CheckMode {
-    Before,
-    After,
-}
-
 #[derive(Debug, Clone)]
 struct CheckResult {
     passed: Option<bool>,
@@ -146,7 +152,6 @@ enum CheckUpdate {
 struct ChecksPanel {
     /// Chain index these checks were (or are being) run for.
     chain_idx: Option<usize>,
-    mode: Option<CheckMode>,
     rpc_url: String,
     /// Name of the check currently executing.
     current: Option<String>,
@@ -158,16 +163,15 @@ struct ChecksPanel {
 }
 
 impl ChecksPanel {
-    fn start(&mut self, chain_idx: usize, rpc_url: String, mode: CheckMode) {
+    fn start(&mut self, chain_idx: usize, rpc_url: String) {
         let (tx, rx) = mpsc::channel(64);
         self.chain_idx = Some(chain_idx);
-        self.mode = Some(mode);
         self.rpc_url = rpc_url.clone();
         self.current = None;
         self.results.clear();
         self.running = true;
         self.rx = Some(rx);
-        self.handle = Some(tokio::spawn(run_v1_checks_streaming(rpc_url, mode, tx)));
+        self.handle = Some(tokio::spawn(run_v1_checks_streaming(rpc_url, tx)));
     }
 
     fn reset(&mut self) {
@@ -175,7 +179,6 @@ impl ChecksPanel {
             h.abort();
         }
         self.chain_idx = None;
-        self.mode = None;
         self.rpc_url.clear();
         self.current = None;
         self.results.clear();
@@ -306,7 +309,6 @@ impl UpgradesView {
             tick_count: 0,
             checks: ChecksPanel {
                 chain_idx: None,
-                mode: None,
                 rpc_url: String::new(),
                 current: None,
                 results: HashMap::new(),
@@ -357,18 +359,10 @@ impl View for UpgradesView {
                 }
             }
             KeyCode::Char('r') if !self.checks.running => {
-                let now = now_unix();
                 let chain = &self.chains[self.selected_chain];
-                let v1_activated = chain
-                    .specs
-                    .iter()
-                    .find(|s| s.name == "V1")
-                    .and_then(|s| s.timestamp)
-                    .map(|ts| ts <= now)
-                    .unwrap_or(false);
-                if v1_activated {
+                if chain.v1_active(now_unix()) {
                     let rpc = self.rpc_for_selected(resources);
-                    self.checks.start(self.selected_chain, rpc, CheckMode::After);
+                    self.checks.start(self.selected_chain, rpc);
                 }
             }
             _ => {}
@@ -438,15 +432,8 @@ impl View for UpgradesView {
             .constraints([Constraint::Percentage(38), Constraint::Percentage(62)])
             .split(outer[2]);
 
-        let v1_active = chain
-            .specs
-            .iter()
-            .find(|s| s.name == "V1")
-            .and_then(|s| s.timestamp)
-            .map(|ts| ts <= now)
-            .unwrap_or(false);
         render_history(frame, bottom[0], chain, now);
-        render_checks_panel(frame, bottom[1], &self.checks, self.tick_count, v1_active);
+        render_checks_panel(frame, bottom[1], &self.checks, self.tick_count, chain.v1_active(now));
         render_footer(frame, outer[3], self.checks.running);
     }
 }
@@ -672,22 +659,16 @@ fn render_checks_panel(
         return;
     }
 
-    let mode_str = match panel.mode {
-        Some(CheckMode::Before) => "before",
-        Some(CheckMode::After) => "after",
-        None => "?",
-    };
-
     let passed = panel.results.values().filter(|r| r.passed == Some(true)).count();
     let failed = panel.results.values().filter(|r| r.passed == Some(false)).count();
 
     let (title, border_color) = if panel.running {
         let spin = spinner[(tick / 2) as usize % spinner.len()];
-        (format!(" V1 Checks ({mode_str})  {spin} running… "), Color::Yellow)
+        (format!(" V1 Checks  {spin} running… "), Color::Yellow)
     } else if failed > 0 {
-        (format!(" V1 Checks ({mode_str})  ✓ {passed}  ✗ {failed} "), Color::Red)
+        (format!(" V1 Checks  ✓ {passed}  ✗ {failed} "), Color::Red)
     } else {
-        (format!(" V1 Checks ({mode_str})  ✓ {passed} passed "), Color::LightGreen)
+        (format!(" V1 Checks  ✓ {passed} passed "), Color::LightGreen)
     };
 
     let rows: Vec<Row<'static>> = V1_CHECK_NAMES
@@ -882,15 +863,6 @@ const MODEXP_OVERSIZED: &str = concat!(
     "0000000000000000000000000000000000000000000000000000000000000001",
 );
 
-fn not_activated(msg: &str) -> bool {
-    let m = msg.to_lowercase();
-    m.contains("notactivated")
-        || m.contains("invalid opcode")
-        || m.contains("undefined opcode")
-        || m.contains("opcode 0x1e")
-        || m.contains("unsupported opcode")
-}
-
 fn norm(h: &str) -> String {
     h.trim().trim_matches('"').to_lowercase()
 }
@@ -936,18 +908,10 @@ fn evaluate_opcode_check(
     _name: &str,
     result: &Result<String, String>,
     expected: &str,
-    mode: CheckMode,
 ) -> CheckResult {
-    let (passed, detail) = match (mode, result) {
-        (CheckMode::Before, Err(e)) if not_activated(e) => {
-            (true, "opcode unavailable (expected before V1)".to_string())
-        }
-        (CheckMode::Before, Err(e)) => (false, format!("unexpected error: {e}")),
-        (CheckMode::Before, Ok(actual)) => {
-            (false, format!("unexpectedly succeeded before V1: {actual}"))
-        }
-        (CheckMode::After, Err(e)) => (false, format!("call failed: {e}")),
-        (CheckMode::After, Ok(actual)) => {
+    let (passed, detail) = match result {
+        Err(e) => (false, format!("call failed: {e}")),
+        Ok(actual) => {
             if norm(actual) == norm(expected) {
                 (true, format!("→ {}", actual.get(..20).unwrap_or(actual)))
             } else {
@@ -960,9 +924,7 @@ fn evaluate_opcode_check(
 
 fn evaluate_gas_probe(
     result: &Result<String, String>,
-    mode: CheckMode,
     gas_label: &str,
-    before_desc: &str,
     after_desc: &str,
 ) -> CheckResult {
     let actual = match result {
@@ -972,27 +934,14 @@ fn evaluate_gas_probe(
     let success_val = norm(PROBE_SUCCESS);
 
     let (passed, detail) = if actual == success_val {
-        match mode {
-            CheckMode::Before => {
-                (true, format!("{gas_label} CALL succeeded ({before_desc} before V1)"))
-            }
-            CheckMode::After => (
-                false,
-                format!("{gas_label} CALL succeeded — expected OOG ({after_desc} after V1)"),
-            ),
-        }
+        (false, format!("{gas_label} CALL succeeded — expected OOG ({after_desc} after V1)"))
     } else {
-        match mode {
-            CheckMode::After => (true, format!("{gas_label} CALL OOG ({after_desc} after V1)")),
-            CheckMode::Before => {
-                (false, format!("{gas_label} CALL OOG — expected success ({before_desc})"))
-            }
-        }
+        (true, format!("{gas_label} CALL OOG ({after_desc} after V1)"))
     };
     CheckResult { passed: Some(passed), detail }
 }
 
-async fn run_v1_checks_streaming(rpc_url: String, mode: CheckMode, tx: mpsc::Sender<CheckUpdate>) {
+async fn run_v1_checks_streaming(rpc_url: String, tx: mpsc::Sender<CheckUpdate>) {
     macro_rules! send_start {
         ($name:expr) => {
             if tx.send(CheckUpdate::Starting($name.to_string())).await.is_err() {
@@ -1059,27 +1008,18 @@ async fn run_v1_checks_streaming(rpc_url: String, mode: CheckMode, tx: mpsc::Sen
         send_start!(name);
         let r =
             eth_call_override(&client, CLZ_PROBE_ADDR, calldata, CLZ_PROBE_ADDR, CLZ_RUNTIME).await;
-        send_result!(name, evaluate_opcode_check(name, &r, expected, mode));
+        send_result!(name, evaluate_opcode_check(name, &r, expected));
     }
 
     // ── MODEXP size limit ──────────────────────────────────────────────────────
     send_start!("MODEXP size limit");
     let r = eth_call(&client, MODEXP_ADDR, MODEXP_OVERSIZED).await;
-    let modexp_size = match (mode, r) {
-        (CheckMode::Before, Ok(_)) => CheckResult {
-            passed: Some(true),
-            detail: "oversized input accepted (expected before V1)".to_string(),
-        },
-        (CheckMode::Before, Err(e)) => {
-            CheckResult { passed: Some(false), detail: format!("unexpectedly rejected: {e}") }
-        }
-        (CheckMode::After, Err(_)) => CheckResult {
+    let modexp_size = match r {
+        Err(_) => CheckResult {
             passed: Some(true),
             detail: "oversized input rejected (correct)".to_string(),
         },
-        (CheckMode::After, Ok(v)) => {
-            CheckResult { passed: Some(false), detail: format!("unexpectedly accepted: {v}") }
-        }
+        Ok(v) => CheckResult { passed: Some(false), detail: format!("unexpectedly accepted: {v}") },
     };
     send_result!("MODEXP size limit", modexp_size);
 
@@ -1093,7 +1033,7 @@ async fn run_v1_checks_streaming(rpc_url: String, mode: CheckMode, tx: mpsc::Sen
         MODEXP_GAS_PROBE_RUNTIME,
     )
     .await;
-    send_result!("MODEXP min gas", evaluate_gas_probe(&r, mode, "400-gas", "min=200", "min=500"));
+    send_result!("MODEXP min gas", evaluate_gas_probe(&r, "400-gas", "min=500"));
 
     // ── P256VERIFY gas (3450 → 6900) ───────────────────────────────────────────
     send_start!("P256VERIFY gas");
@@ -1105,10 +1045,7 @@ async fn run_v1_checks_streaming(rpc_url: String, mode: CheckMode, tx: mpsc::Sen
         P256_GAS_PROBE_RUNTIME,
     )
     .await;
-    send_result!(
-        "P256VERIFY gas",
-        evaluate_gas_probe(&r, mode, "5000-gas", "cost=3450", "cost=6900")
-    );
+    send_result!("P256VERIFY gas", evaluate_gas_probe(&r, "5000-gas", "cost=6900"));
 
     // ── eth_config RPC method ──────────────────────────────────────────────────
     send_start!("eth_config");
@@ -1116,21 +1053,9 @@ async fn run_v1_checks_streaming(rpc_url: String, mode: CheckMode, tx: mpsc::Sen
         ClientT::request::<serde_json::Value, _>(&client, "eth_config", rpc_params![])
             .await
             .map_err(|e| e.to_string());
-    let eth_config_check = match (mode, cfg_result) {
-        (CheckMode::Before, Ok(_)) => CheckResult {
-            passed: Some(false),
-            detail: "unexpectedly available before V1".to_string(),
-        },
-        (CheckMode::Before, Err(_)) => CheckResult {
-            passed: Some(true),
-            detail: "unavailable before V1 (expected)".to_string(),
-        },
-        (CheckMode::After, Ok(_)) => {
-            CheckResult { passed: Some(true), detail: "available after V1".to_string() }
-        }
-        (CheckMode::After, Err(e)) => {
-            CheckResult { passed: Some(false), detail: format!("unavailable after V1: {e}") }
-        }
+    let eth_config_check = match cfg_result {
+        Ok(_) => CheckResult { passed: Some(true), detail: "available after V1".to_string() },
+        Err(e) => CheckResult { passed: Some(false), detail: format!("unavailable after V1: {e}") },
     };
     send_result!("eth_config", eth_config_check);
 }

--- a/crates/infra/basectl/src/app/views/upgrades.rs
+++ b/crates/infra/basectl/src/app/views/upgrades.rs
@@ -1004,13 +1004,10 @@ async fn run_v1_checks_streaming(rpc_url: String, tx: mpsc::Sender<CheckUpdate>)
     // ── MODEXP size limit ──────────────────────────────────────────────────────
     send_start!("MODEXP size limit");
     let r = eth_call(&client, MODEXP_ADDR, MODEXP_OVERSIZED).await;
-    let modexp_size = match r {
-        Err(_) => CheckResult {
-            passed: Some(true),
-            detail: "oversized input rejected (correct)".to_string(),
-        },
-        Ok(v) => CheckResult { passed: Some(false), detail: format!("unexpectedly accepted: {v}") },
-    };
+    let modexp_size = r.map_or_else(
+        |_| CheckResult { passed: Some(true), detail: "oversized input rejected (correct)".to_string() },
+        |v| CheckResult { passed: Some(false), detail: format!("unexpectedly accepted: {v}") },
+    );
     send_result!("MODEXP size limit", modexp_size);
 
     // ── MODEXP min gas (200 → 500) ─────────────────────────────────────────────

--- a/crates/infra/basectl/src/app/views/upgrades.rs
+++ b/crates/infra/basectl/src/app/views/upgrades.rs
@@ -1005,7 +1005,10 @@ async fn run_v1_checks_streaming(rpc_url: String, tx: mpsc::Sender<CheckUpdate>)
     send_start!("MODEXP size limit");
     let r = eth_call(&client, MODEXP_ADDR, MODEXP_OVERSIZED).await;
     let modexp_size = r.map_or_else(
-        |_| CheckResult { passed: Some(true), detail: "oversized input rejected (correct)".to_string() },
+        |_| CheckResult {
+            passed: Some(true),
+            detail: "oversized input rejected (correct)".to_string(),
+        },
         |v| CheckResult { passed: Some(false), detail: format!("unexpectedly accepted: {v}") },
     );
     send_result!("MODEXP size limit", modexp_size);

--- a/crates/infra/basectl/src/app/views/upgrades.rs
+++ b/crates/infra/basectl/src/app/views/upgrades.rs
@@ -359,11 +359,8 @@ impl View for UpgradesView {
                 }
             }
             KeyCode::Char('r') if !self.checks.running => {
-                let chain = &self.chains[self.selected_chain];
-                if chain.v1_active(now_unix()) {
-                    let rpc = self.rpc_for_selected(resources);
-                    self.checks.start(self.selected_chain, rpc);
-                }
+                let rpc = self.rpc_for_selected(resources);
+                self.checks.start(self.selected_chain, rpc);
             }
             _ => {}
         }
@@ -624,33 +621,25 @@ fn render_checks_panel(
 
     // Panel is idle and has never been run.
     if panel.chain_idx.is_none() {
-        let lines: Vec<Line<'static>> = if v1_active {
-            vec![
-                Line::from(""),
-                Line::from(Span::styled(
-                    "Press [r] to run post-upgrade checks",
-                    Style::default().fg(Color::DarkGray),
-                )),
-                Line::from(""),
-                Line::from(Span::styled(
-                    "Checks: CLZ opcode · MODEXP size/gas · P256VERIFY gas · eth_config",
-                    Style::default().fg(Color::DarkGray),
-                )),
-            ]
-        } else {
-            vec![
-                Line::from(""),
-                Line::from(Span::styled(
-                    "V1 not yet activated",
-                    Style::default().fg(Color::DarkGray),
-                )),
-                Line::from(""),
-                Line::from(Span::styled(
-                    "Checks available after V1 activates",
-                    Style::default().fg(Color::DarkGray),
-                )),
-            ]
-        };
+        let mut lines: Vec<Line<'static>> = vec![
+            Line::from(""),
+            Line::from(Span::styled(
+                "Press [r] to run post-upgrade checks",
+                Style::default().fg(Color::DarkGray),
+            )),
+            Line::from(""),
+            Line::from(Span::styled(
+                "Checks: CLZ opcode · MODEXP size/gas · P256VERIFY gas · eth_config",
+                Style::default().fg(Color::DarkGray),
+            )),
+        ];
+        if !v1_active {
+            lines.push(Line::from(""));
+            lines.push(Line::from(Span::styled(
+                "⚠ V1 not yet active — all checks will fail",
+                Style::default().fg(Color::Yellow),
+            )));
+        }
         let block = Block::default()
             .title(" V1 Checks ")
             .borders(Borders::ALL)
@@ -661,14 +650,15 @@ fn render_checks_panel(
 
     let passed = panel.results.values().filter(|r| r.passed == Some(true)).count();
     let failed = panel.results.values().filter(|r| r.passed == Some(false)).count();
+    let pre_tag = if v1_active { "" } else { "  ⚠ pre-activation" };
 
     let (title, border_color) = if panel.running {
         let spin = spinner[(tick / 2) as usize % spinner.len()];
-        (format!(" V1 Checks  {spin} running… "), Color::Yellow)
+        (format!(" V1 Checks{pre_tag}  {spin} running… "), Color::Yellow)
     } else if failed > 0 {
-        (format!(" V1 Checks  ✓ {passed}  ✗ {failed} "), Color::Red)
+        (format!(" V1 Checks{pre_tag}  ✓ {passed}  ✗ {failed} "), Color::Red)
     } else {
-        (format!(" V1 Checks  ✓ {passed} passed "), Color::LightGreen)
+        (format!(" V1 Checks{pre_tag}  ✓ {passed} passed "), Color::LightGreen)
     };
 
     let rows: Vec<Row<'static>> = V1_CHECK_NAMES

--- a/crates/infra/basectl/src/app/views/upgrades.rs
+++ b/crates/infra/basectl/src/app/views/upgrades.rs
@@ -359,14 +359,16 @@ impl View for UpgradesView {
             KeyCode::Char('r') if !self.checks.running => {
                 let now = now_unix();
                 let chain = &self.chains[self.selected_chain];
-                // Derive mode from V1's own timestamp so that a chain where V1 is
-                // active but a later fork is upcoming still runs checks in After mode.
-                if let Some(v1_ts) =
-                    chain.specs.iter().find(|s| s.name == "V1").and_then(|s| s.timestamp)
-                {
+                let v1_activated = chain
+                    .specs
+                    .iter()
+                    .find(|s| s.name == "V1")
+                    .and_then(|s| s.timestamp)
+                    .map(|ts| ts <= now)
+                    .unwrap_or(false);
+                if v1_activated {
                     let rpc = self.rpc_for_selected(resources);
-                    let mode = if v1_ts > now { CheckMode::Before } else { CheckMode::After };
-                    self.checks.start(self.selected_chain, rpc, mode);
+                    self.checks.start(self.selected_chain, rpc, CheckMode::After);
                 }
             }
             _ => {}
@@ -436,8 +438,15 @@ impl View for UpgradesView {
             .constraints([Constraint::Percentage(38), Constraint::Percentage(62)])
             .split(outer[2]);
 
+        let v1_active = chain
+            .specs
+            .iter()
+            .find(|s| s.name == "V1")
+            .and_then(|s| s.timestamp)
+            .map(|ts| ts <= now)
+            .unwrap_or(false);
         render_history(frame, bottom[0], chain, now);
-        render_checks_panel(frame, bottom[1], &self.checks, self.tick_count);
+        render_checks_panel(frame, bottom[1], &self.checks, self.tick_count, v1_active);
         render_footer(frame, outer[3], self.checks.running);
     }
 }
@@ -617,23 +626,44 @@ fn render_history(frame: &mut Frame<'_>, area: Rect, chain: &ChainUpgrades, now:
     frame.render_widget(Table::new(rows, widths).block(block).header(header), area);
 }
 
-fn render_checks_panel(frame: &mut Frame<'_>, area: Rect, panel: &ChecksPanel, tick: u64) {
+fn render_checks_panel(
+    frame: &mut Frame<'_>,
+    area: Rect,
+    panel: &ChecksPanel,
+    tick: u64,
+    v1_active: bool,
+) {
     let spinner = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
 
     // Panel is idle and has never been run.
     if panel.chain_idx.is_none() {
-        let lines: Vec<Line<'static>> = vec![
-            Line::from(""),
-            Line::from(Span::styled(
-                "Press [r] to run post-upgrade checks",
-                Style::default().fg(Color::DarkGray),
-            )),
-            Line::from(""),
-            Line::from(Span::styled(
-                "Checks: CLZ opcode · MODEXP size/gas · P256VERIFY gas · eth_config",
-                Style::default().fg(Color::DarkGray),
-            )),
-        ];
+        let lines: Vec<Line<'static>> = if v1_active {
+            vec![
+                Line::from(""),
+                Line::from(Span::styled(
+                    "Press [r] to run post-upgrade checks",
+                    Style::default().fg(Color::DarkGray),
+                )),
+                Line::from(""),
+                Line::from(Span::styled(
+                    "Checks: CLZ opcode · MODEXP size/gas · P256VERIFY gas · eth_config",
+                    Style::default().fg(Color::DarkGray),
+                )),
+            ]
+        } else {
+            vec![
+                Line::from(""),
+                Line::from(Span::styled(
+                    "V1 not yet activated",
+                    Style::default().fg(Color::DarkGray),
+                )),
+                Line::from(""),
+                Line::from(Span::styled(
+                    "Checks available after V1 activates",
+                    Style::default().fg(Color::DarkGray),
+                )),
+            ]
+        };
         let block = Block::default()
             .title(" V1 Checks ")
             .borders(Borders::ALL)


### PR DESCRIPTION
## Summary

Before V1 was activated, pressing [r] on the upgrades view ran the checks in \`CheckMode::Before\`, which validates that V1 features are not yet present — trivially passing all 8 checks and displaying a misleading green "✓ 8 passed" banner. The [r] key handler now actually runs V1 check.

Example shown below where basectl incorrectly shows post base v1 checks as "passed" despite the upgrade not being activated.

<img width="1017" height="806" alt="Screenshot 2026-04-08 at 6 33 52 PM" src="https://github.com/user-attachments/assets/ee98a996-f9fc-4010-ac14-8cd358b997b0" />

Now it shows:

<img width="1057" height="800" alt="Screenshot 2026-04-08 at 7 07 22 PM" src="https://github.com/user-attachments/assets/582fa092-da5e-4224-85c5-1470e8799d3e" />
