### PR TITLE
feat(basectl): Dull Stale Hardfork Banners

### DIFF
--- a/crates/infra/basectl/src/app/views/upgrades.rs
+++ b/crates/infra/basectl/src/app/views/upgrades.rs
@@ -238,6 +238,8 @@ const fn zone_message(remaining_secs: i64) -> &'static str {
     }
 }
 
+const SECS_FOUR_WEEKS: u64 = 28 * SECS_PER_DAY;
+
 const CYCLE_COLORS: &[Color] =
     &[Color::LightGreen, Color::Green, Color::Cyan, Color::Yellow, Color::LightGreen];
 
@@ -409,6 +411,23 @@ impl View for UpgradesView {
             ])
             .split(area);
 
+        // Dull the activated banner if the hardfork is stale (> 4 weeks old) or if a
+        // newer hardfork is already active on any other chain, meaning this network is
+        // running behind the frontier.
+        let dull = if let Some((_, lat_ts)) = latest_activated {
+            let stale = now.saturating_sub(lat_ts) > SECS_FOUR_WEEKS;
+            let superseded = self.chains.iter().enumerate().any(|(i, c)| {
+                i != self.selected_chain
+                    && c.specs
+                        .iter()
+                        .filter_map(|s| s.timestamp.filter(|&ts| ts > 0 && ts <= now))
+                        .any(|ts| ts > lat_ts)
+            });
+            stale || superseded
+        } else {
+            false
+        };
+
         render_chain_tabs(frame, outer[0], &self.chains, self.selected_chain);
 
         match upcoming {
@@ -425,6 +444,7 @@ impl View for UpgradesView {
                         ts,
                         now.saturating_sub(ts),
                         self.tick_count,
+                        dull,
                     );
                 }
                 None => render_tbd(frame, outer[1]),
@@ -526,7 +546,35 @@ fn render_activated(
     ts: u64,
     elapsed_secs: u64,
     tick: u64,
+    dull: bool,
 ) {
+    if dull {
+        let lines: Vec<Line<'static>> = vec![
+            Line::from(""),
+            Line::from(""),
+            Line::from(Span::styled(
+                "✓  activated",
+                Style::default().fg(Color::DarkGray).add_modifier(Modifier::BOLD),
+            )),
+            Line::from(""),
+            Line::from(Span::styled(
+                format!("{name} is live"),
+                Style::default().fg(Color::DarkGray),
+            )),
+            Line::from(Span::styled(
+                format!("activated {}  ·  {}", fmt_timestamp(ts), fmt_elapsed(elapsed_secs)),
+                Style::default().fg(Color::DarkGray),
+            )),
+        ];
+        let block = Block::default()
+            .title(format!(" BASE {name} UPGRADE "))
+            .title_style(Style::default().fg(Color::DarkGray))
+            .borders(Borders::ALL)
+            .border_style(Style::default().fg(Color::DarkGray));
+        frame.render_widget(Paragraph::new(lines).block(block).alignment(Alignment::Center), area);
+        return;
+    }
+
     let cycle_color = CYCLE_COLORS[(tick / 4) as usize % CYCLE_COLORS.len()];
     let n = CONFETTI.len();
     let phase = (tick / 4) as usize;


### PR DESCRIPTION
## Summary

The activated banner in the upgrade view was equally celebratory for hardforks activated months ago, making it hard to tell at a glance whether a network was at the current frontier. The banner is now dulled (gray, no confetti, no animation) when a hardfork is more than 4 weeks old or when a newer hardfork is already active on another network. The full celebration treatment is preserved for fresh activations.

<img width="968" height="747" alt="Screenshot 2026-04-08 at 6 48 20 PM" src="https://github.com/user-attachments/assets/f94fee54-1d94-4dea-aed0-43a0b3377aa8" />
<img width="968" height="747" alt="Screenshot 2026-04-08 at 6 48 30 PM" src="https://github.com/user-attachments/assets/ab1e863e-e25d-4e59-a19c-899d3de7ac7c" />


