### PR TITLE
feat(basectl): Per-Hardfork Upgrade Checks

### DIFF
--- a/crates/infra/basectl/src/app/views/upgrades.rs
+++ b/crates/infra/basectl/src/app/views/upgrades.rs
@@ -153,11 +153,7 @@ const V1_CHECK_NAMES: &[&str] = &[
 ];
 
 /// Expected check names for Jovian, in execution order.
-const JOVIAN_CHECK_NAMES: &[&str] = &[
-    "bn256Pairing limit",
-    "extra data v1",
-    "GPO implementation",
-];
+const JOVIAN_CHECK_NAMES: &[&str] = &["bn256Pairing limit", "extra data v1", "GPO implementation"];
 
 fn check_names_for(hardfork: &str) -> &'static [&'static str] {
     match hardfork {
@@ -433,11 +429,8 @@ impl View for UpgradesView {
                 // Find the last hardfork that has a scheduled timestamp and has
                 // defined checks. This lets mainnet run Jovian checks instead of
                 // silently doing nothing when V1 has no timestamp.
-                if let Some(spec) = chain
-                    .specs
-                    .iter()
-                    .rev()
-                    .find(|s| s.timestamp.is_some() && !check_names_for(s.name).is_empty())
+                if let Some(spec) = target_hardfork(chain)
+                    .and_then(|name| chain.specs.iter().find(|s| s.name == name))
                 {
                     let ts = spec.timestamp.unwrap();
                     if let Some(rpc) = self.rpc_for_selected(resources) {
@@ -977,7 +970,7 @@ async fn run_checks_streaming(
 
 /// bn256Pairing precompile address (EIP-197).
 const BN256PAIRING_ADDR: &str = "0x0000000000000000000000000000000000000008";
-/// GasPriceOracle predeploy proxy address.
+/// `GasPriceOracle` predeploy proxy address.
 const GAS_PRICE_ORACLE_ADDR: &str = "0x420000000000000000000000000000000000000F";
 /// EIP-1967 logic/implementation storage slot.
 const EIP1967_IMPL_SLOT: &str =
@@ -987,19 +980,13 @@ const JOVIAN_GPO_IMPL: &str = "4f1db3c6abd250ba86e0928471a8f7db3afd88f1";
 /// Expected GPO implementation address under Isthmus (before Jovian).
 const ISTHMUS_GPO_IMPL: &str = "93e57a196454cb919193fa9946f14943cf733845";
 
-async fn eth_get_storage_at(
-    client: &HttpClient,
-    addr: &str,
-    slot: &str,
-) -> Result<String, String> {
+async fn eth_get_storage_at(client: &HttpClient, addr: &str, slot: &str) -> Result<String, String> {
     ClientT::request::<String, _>(client, "eth_getStorageAt", rpc_params![addr, slot, "latest"])
         .await
         .map_err(|e| e.to_string())
 }
 
-async fn eth_get_block_by_number_latest(
-    client: &HttpClient,
-) -> Result<serde_json::Value, String> {
+async fn eth_get_block_by_number_latest(client: &HttpClient) -> Result<serde_json::Value, String> {
     ClientT::request::<serde_json::Value, _>(
         client,
         "eth_getBlockByNumber",
@@ -1051,14 +1038,11 @@ async fn run_jovian_checks_streaming(
         }
     };
 
-    send_start!("RPC connection");
     match ClientT::request::<String, _>(&client, "eth_blockNumber", rpc_params![]).await {
         Ok(_) => {}
         Err(e) => {
-            let conn_result = CheckResult {
-                passed: Some(false),
-                detail: format!("cannot reach {rpc_url}: {e}"),
-            };
+            let conn_result =
+                CheckResult { passed: Some(false), detail: format!("cannot reach {rpc_url}: {e}") };
             send_result!("bn256Pairing limit", conn_result);
             for &name in &JOVIAN_CHECK_NAMES[1..] {
                 send_result!(
@@ -1126,41 +1110,37 @@ async fn run_jovian_checks_streaming(
 
     // ── GasPriceOracle EIP-1967 implementation slot ───────────────────────────
     send_start!("GPO implementation");
-    let gpo_check = match eth_get_storage_at(&client, GAS_PRICE_ORACLE_ADDR, EIP1967_IMPL_SLOT)
-        .await
-    {
-        Err(e) => CheckResult { passed: Some(false), detail: format!("RPC error: {e}") },
-        Ok(slot_val) => {
-            let val = norm(&slot_val);
-            // Slot value is a zero-padded 32-byte address; last 40 hex chars = address.
-            let impl_addr = if val.len() >= 40 { &val[val.len() - 40..] } else { val.as_str() };
-            let expected = match mode {
-                CheckMode::After => JOVIAN_GPO_IMPL,
-                CheckMode::Before => ISTHMUS_GPO_IMPL,
-            };
-            let label = match mode {
-                CheckMode::After => "Jovian",
-                CheckMode::Before => "Isthmus",
-            };
-            if impl_addr == expected {
-                CheckResult {
-                    passed: Some(true),
-                    detail: format!(
-                        "→ 0x{}",
-                        impl_addr.get(..8).unwrap_or(impl_addr)
-                    ),
-                }
-            } else {
-                CheckResult {
-                    passed: Some(false),
-                    detail: format!(
-                        "impl=0x{} (expected {label})",
-                        impl_addr.get(..8).unwrap_or(impl_addr)
-                    ),
+    let gpo_check =
+        match eth_get_storage_at(&client, GAS_PRICE_ORACLE_ADDR, EIP1967_IMPL_SLOT).await {
+            Err(e) => CheckResult { passed: Some(false), detail: format!("RPC error: {e}") },
+            Ok(slot_val) => {
+                let val = norm(&slot_val);
+                // Slot value is a zero-padded 32-byte address; last 40 hex chars = address.
+                let impl_addr = if val.len() >= 40 { &val[val.len() - 40..] } else { val.as_str() };
+                let expected = match mode {
+                    CheckMode::After => JOVIAN_GPO_IMPL,
+                    CheckMode::Before => ISTHMUS_GPO_IMPL,
+                };
+                let label = match mode {
+                    CheckMode::After => "Jovian",
+                    CheckMode::Before => "Isthmus",
+                };
+                if impl_addr == expected {
+                    CheckResult {
+                        passed: Some(true),
+                        detail: format!("→ 0x{}", impl_addr.get(..8).unwrap_or(impl_addr)),
+                    }
+                } else {
+                    CheckResult {
+                        passed: Some(false),
+                        detail: format!(
+                            "impl=0x{} (expected {label})",
+                            impl_addr.get(..8).unwrap_or(impl_addr)
+                        ),
+                    }
                 }
             }
-        }
-    };
+        };
     send_result!("GPO implementation", gpo_check);
 }
 
@@ -1309,7 +1289,6 @@ async fn run_v1_checks_streaming(rpc_url: String, tx: mpsc::Sender<CheckUpdate>)
     };
 
     // Verify the RPC is reachable with a quick eth_blockNumber call.
-    send_start!("RPC connection");
     match ClientT::request::<String, _>(&client, "eth_blockNumber", rpc_params![]).await {
         Ok(_) => {}
         Err(e) => {

--- a/crates/infra/basectl/src/app/views/upgrades.rs
+++ b/crates/infra/basectl/src/app/views/upgrades.rs
@@ -152,6 +152,38 @@ const V1_CHECK_NAMES: &[&str] = &[
     "eth_config",
 ];
 
+/// Expected check names for Jovian, in execution order.
+const JOVIAN_CHECK_NAMES: &[&str] = &[
+    "bn256Pairing limit",
+    "extra data v1",
+    "GPO implementation",
+];
+
+fn check_names_for(hardfork: &str) -> &'static [&'static str] {
+    match hardfork {
+        "V1" => V1_CHECK_NAMES,
+        "Jovian" => JOVIAN_CHECK_NAMES,
+        _ => &[],
+    }
+}
+
+/// Returns the last hardfork spec for a chain that has defined checks, or `None`.
+fn target_hardfork(chain: &ChainUpgrades) -> Option<&'static str> {
+    chain
+        .specs
+        .iter()
+        .rev()
+        .find(|s| s.timestamp.is_some() && !check_names_for(s.name).is_empty())
+        .map(|s| s.name)
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum CheckMode {
+    Before,
+    After,
+}
+
+
 #[derive(Debug, Clone)]
 struct CheckResult {
     passed: Option<bool>,
@@ -172,6 +204,9 @@ enum CheckUpdate {
 struct ChecksPanel {
     /// Chain index these checks were (or are being) run for.
     chain_idx: Option<usize>,
+    /// Which hardfork's checks are running.
+    hardfork: Option<&'static str>,
+    mode: Option<CheckMode>,
     rpc_url: String,
     /// Name of the check currently executing.
     current: Option<String>,
@@ -183,15 +218,23 @@ struct ChecksPanel {
 }
 
 impl ChecksPanel {
-    fn start(&mut self, chain_idx: usize, rpc_url: String) {
+    fn start(
+        &mut self,
+        chain_idx: usize,
+        rpc_url: String,
+        hardfork: &'static str,
+        mode: CheckMode,
+    ) {
         let (tx, rx) = mpsc::channel(64);
         self.chain_idx = Some(chain_idx);
+        self.hardfork = Some(hardfork);
+        self.mode = Some(mode);
         self.rpc_url = rpc_url.clone();
         self.current = None;
         self.results.clear();
         self.running = true;
         self.rx = Some(rx);
-        self.handle = Some(tokio::spawn(run_v1_checks_streaming(rpc_url, tx)));
+        self.handle = Some(tokio::spawn(run_checks_streaming(hardfork, rpc_url, mode, tx)));
     }
 
     fn reset(&mut self) {
@@ -199,6 +242,8 @@ impl ChecksPanel {
             h.abort();
         }
         self.chain_idx = None;
+        self.hardfork = None;
+        self.mode = None;
         self.rpc_url.clear();
         self.current = None;
         self.results.clear();
@@ -331,6 +376,8 @@ impl UpgradesView {
             tick_count: 0,
             checks: ChecksPanel {
                 chain_idx: None,
+                hardfork: None,
+                mode: None,
                 rpc_url: String::new(),
                 current: None,
                 results: HashMap::new(),
@@ -381,8 +428,22 @@ impl View for UpgradesView {
                 }
             }
             KeyCode::Char('r') if !self.checks.running => {
-                if let Some(rpc) = self.rpc_for_selected(resources) {
-                    self.checks.start(self.selected_chain, rpc);
+                let now = now_unix();
+                let chain = &self.chains[self.selected_chain];
+                // Find the last hardfork that has a scheduled timestamp and has
+                // defined checks. This lets mainnet run Jovian checks instead of
+                // silently doing nothing when V1 has no timestamp.
+                if let Some(spec) = chain
+                    .specs
+                    .iter()
+                    .rev()
+                    .find(|s| s.timestamp.is_some() && !check_names_for(s.name).is_empty())
+                {
+                    let ts = spec.timestamp.unwrap();
+                    if let Some(rpc) = self.rpc_for_selected(resources) {
+                        let mode = if ts > now { CheckMode::Before } else { CheckMode::After };
+                        self.checks.start(self.selected_chain, rpc, spec.name, mode);
+                    }
                 }
             }
             _ => {}
@@ -471,7 +532,8 @@ impl View for UpgradesView {
             .split(outer[2]);
 
         render_history(frame, bottom[0], chain, now);
-        render_checks_panel(frame, bottom[1], &self.checks, self.tick_count, chain.v1_active(now));
+        let active_hf = target_hardfork(chain);
+        render_checks_panel(frame, bottom[1], &self.checks, self.tick_count, active_hf);
         render_footer(frame, outer[3], self.checks.running);
     }
 }
@@ -684,53 +746,54 @@ fn render_checks_panel(
     area: Rect,
     panel: &ChecksPanel,
     tick: u64,
-    v1_active: bool,
+    active_hardfork: Option<&'static str>,
 ) {
     let spinner = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
 
     // Panel is idle and has never been run.
     if panel.chain_idx.is_none() {
-        let mut lines: Vec<Line<'static>> = vec![
+        let hf_name = active_hardfork.unwrap_or("?");
+        let check_list = check_names_for(hf_name).join(" · ");
+        let hint = format!("Press [r] to run {hf_name} post-upgrade checks");
+        let lines: Vec<Line<'static>> = vec![
+            Line::from(""),
+            Line::from(Span::styled(hint, Style::default().fg(Color::DarkGray))),
             Line::from(""),
             Line::from(Span::styled(
-                "Press [r] to run post-upgrade checks",
-                Style::default().fg(Color::DarkGray),
-            )),
-            Line::from(""),
-            Line::from(Span::styled(
-                "Checks: CLZ opcode · MODEXP size/gas · P256VERIFY gas · eth_config",
+                format!("Checks: {check_list}"),
                 Style::default().fg(Color::DarkGray),
             )),
         ];
-        if !v1_active {
-            lines.push(Line::from(""));
-            lines.push(Line::from(Span::styled(
-                "⚠ V1 not yet active — all checks will fail",
-                Style::default().fg(Color::Yellow),
-            )));
-        }
         let block = Block::default()
-            .title(" V1 Checks ")
+            .title(format!(" {hf_name} Checks "))
             .borders(Borders::ALL)
             .border_style(Style::default().fg(Color::DarkGray));
         frame.render_widget(Paragraph::new(lines).block(block).alignment(Alignment::Center), area);
         return;
     }
 
+    let hf = panel.hardfork.unwrap_or("?");
+    let check_names = check_names_for(hf);
+
+    let mode_str = match panel.mode {
+        Some(CheckMode::Before) => "before",
+        Some(CheckMode::After) => "after",
+        None => "?",
+    };
+
     let passed = panel.results.values().filter(|r| r.passed == Some(true)).count();
     let failed = panel.results.values().filter(|r| r.passed == Some(false)).count();
-    let pre_tag = if v1_active { "" } else { "  ⚠ pre-activation" };
 
     let (title, border_color) = if panel.running {
         let spin = spinner[(tick / 2) as usize % spinner.len()];
-        (format!(" V1 Checks{pre_tag}  {spin} running… "), Color::Yellow)
+        (format!(" {hf} Checks ({mode_str})  {spin} running… "), Color::Yellow)
     } else if failed > 0 {
-        (format!(" V1 Checks{pre_tag}  ✓ {passed}  ✗ {failed} "), Color::Red)
+        (format!(" {hf} Checks ({mode_str})  ✓ {passed}  ✗ {failed} "), Color::Red)
     } else {
-        (format!(" V1 Checks{pre_tag}  ✓ {passed} passed "), Color::LightGreen)
+        (format!(" {hf} Checks ({mode_str})  ✓ {passed} passed "), Color::LightGreen)
     };
 
-    let rows: Vec<Row<'static>> = V1_CHECK_NAMES
+    let rows: Vec<Row<'static>> = check_names
         .iter()
         .map(|&name| {
             panel.results.get(name).map_or_else(
@@ -892,6 +955,213 @@ fn clock_lines(
     }
     lines.push(Line::from(Span::styled(label_row, Style::default().fg(Color::DarkGray))));
     lines
+}
+
+// ── Activation checks ─────────────────────────────────────────────────────────
+
+/// Route to the correct hardfork's streaming check function.
+async fn run_checks_streaming(
+    hardfork: &'static str,
+    rpc_url: String,
+    mode: CheckMode,
+    tx: mpsc::Sender<CheckUpdate>,
+) {
+    match hardfork {
+        "V1" => run_v1_checks_streaming(rpc_url, tx).await,
+        "Jovian" => run_jovian_checks_streaming(rpc_url, mode, tx).await,
+        _ => {}
+    }
+}
+
+// ── Jovian activation checks ──────────────────────────────────────────────────
+
+/// bn256Pairing precompile address (EIP-197).
+const BN256PAIRING_ADDR: &str = "0x0000000000000000000000000000000000000008";
+/// GasPriceOracle predeploy proxy address.
+const GAS_PRICE_ORACLE_ADDR: &str = "0x420000000000000000000000000000000000000F";
+/// EIP-1967 logic/implementation storage slot.
+const EIP1967_IMPL_SLOT: &str =
+    "0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc";
+/// Expected GPO implementation address after Jovian activation.
+const JOVIAN_GPO_IMPL: &str = "4f1db3c6abd250ba86e0928471a8f7db3afd88f1";
+/// Expected GPO implementation address under Isthmus (before Jovian).
+const ISTHMUS_GPO_IMPL: &str = "93e57a196454cb919193fa9946f14943cf733845";
+
+async fn eth_get_storage_at(
+    client: &HttpClient,
+    addr: &str,
+    slot: &str,
+) -> Result<String, String> {
+    ClientT::request::<String, _>(client, "eth_getStorageAt", rpc_params![addr, slot, "latest"])
+        .await
+        .map_err(|e| e.to_string())
+}
+
+async fn eth_get_block_by_number_latest(
+    client: &HttpClient,
+) -> Result<serde_json::Value, String> {
+    ClientT::request::<serde_json::Value, _>(
+        client,
+        "eth_getBlockByNumber",
+        rpc_params!["latest", false],
+    )
+    .await
+    .map_err(|e| e.to_string())
+}
+
+async fn run_jovian_checks_streaming(
+    rpc_url: String,
+    mode: CheckMode,
+    tx: mpsc::Sender<CheckUpdate>,
+) {
+    macro_rules! send_start {
+        ($name:expr) => {
+            if tx.send(CheckUpdate::Starting($name.to_string())).await.is_err() {
+                return;
+            }
+        };
+    }
+    macro_rules! send_result {
+        ($name:expr, $result:expr) => {
+            if tx
+                .send(CheckUpdate::Completed { name: $name.to_string(), result: $result })
+                .await
+                .is_err()
+            {
+                return;
+            }
+        };
+    }
+
+    let client = match make_rpc_client(&rpc_url) {
+        Ok(c) => c,
+        Err(e) => {
+            let conn_result = CheckResult {
+                passed: Some(false),
+                detail: format!("cannot build client for {rpc_url}: {e}"),
+            };
+            send_result!("bn256Pairing limit", conn_result);
+            for &name in &JOVIAN_CHECK_NAMES[1..] {
+                send_result!(
+                    name,
+                    CheckResult { passed: None, detail: "skipped (no connection)".into() }
+                );
+            }
+            return;
+        }
+    };
+
+    send_start!("RPC connection");
+    match ClientT::request::<String, _>(&client, "eth_blockNumber", rpc_params![]).await {
+        Ok(_) => {}
+        Err(e) => {
+            let conn_result = CheckResult {
+                passed: Some(false),
+                detail: format!("cannot reach {rpc_url}: {e}"),
+            };
+            send_result!("bn256Pairing limit", conn_result);
+            for &name in &JOVIAN_CHECK_NAMES[1..] {
+                send_result!(
+                    name,
+                    CheckResult { passed: None, detail: "skipped (no connection)".into() }
+                );
+            }
+            return;
+        }
+    }
+
+    // ── bn256Pairing size limit (427 pairs = 81984 bytes is the Jovian cap) ────
+    // 428 pairs × 192 bytes = 82176 bytes, which exceeds the Jovian limit.
+    // Identity points (all-zero) are valid in bn256Pairing per EIP-197.
+    send_start!("bn256Pairing limit");
+    let oversized = format!("0x{}", "00".repeat(428 * 192));
+    let r = eth_call(&client, BN256PAIRING_ADDR, &oversized).await;
+    let bn256_check = match (mode, r) {
+        (CheckMode::Before, Ok(_)) => CheckResult {
+            passed: Some(true),
+            detail: "oversized input accepted (expected before Jovian)".to_string(),
+        },
+        (CheckMode::Before, Err(e)) => {
+            CheckResult { passed: Some(false), detail: format!("unexpectedly rejected: {e}") }
+        }
+        (CheckMode::After, Err(_)) => CheckResult {
+            passed: Some(true),
+            detail: "oversized input rejected (correct)".to_string(),
+        },
+        (CheckMode::After, Ok(v)) => CheckResult {
+            passed: Some(false),
+            detail: format!("unexpectedly accepted: {}", v.get(..20).unwrap_or(&v)),
+        },
+    };
+    send_result!("bn256Pairing limit", bn256_check);
+
+    // ── Extra data version byte (0 → 1 at Jovian) ─────────────────────────────
+    send_start!("extra data v1");
+    let extra_check = match eth_get_block_by_number_latest(&client).await {
+        Err(e) => CheckResult { passed: Some(false), detail: format!("RPC error: {e}") },
+        Ok(block) => {
+            let extra_data = block["extraData"].as_str().unwrap_or("0x");
+            let hex_bytes = extra_data.trim_start_matches("0x");
+            let first_byte =
+                hex_bytes.get(..2).and_then(|s| u8::from_str_radix(s, 16).ok()).unwrap_or(0xFF);
+            match (mode, first_byte) {
+                (CheckMode::Before, 0) => {
+                    CheckResult { passed: Some(true), detail: "version=0 (expected)".to_string() }
+                }
+                (CheckMode::Before, v) => CheckResult {
+                    passed: Some(false),
+                    detail: format!("version={v} (expected 0 before Jovian)"),
+                },
+                (CheckMode::After, 1) => {
+                    CheckResult { passed: Some(true), detail: "version=1 (expected)".to_string() }
+                }
+                (CheckMode::After, v) => CheckResult {
+                    passed: Some(false),
+                    detail: format!("version={v} (expected 1 after Jovian)"),
+                },
+            }
+        }
+    };
+    send_result!("extra data v1", extra_check);
+
+    // ── GasPriceOracle EIP-1967 implementation slot ───────────────────────────
+    send_start!("GPO implementation");
+    let gpo_check = match eth_get_storage_at(&client, GAS_PRICE_ORACLE_ADDR, EIP1967_IMPL_SLOT)
+        .await
+    {
+        Err(e) => CheckResult { passed: Some(false), detail: format!("RPC error: {e}") },
+        Ok(slot_val) => {
+            let val = norm(&slot_val);
+            // Slot value is a zero-padded 32-byte address; last 40 hex chars = address.
+            let impl_addr = if val.len() >= 40 { &val[val.len() - 40..] } else { val.as_str() };
+            let expected = match mode {
+                CheckMode::After => JOVIAN_GPO_IMPL,
+                CheckMode::Before => ISTHMUS_GPO_IMPL,
+            };
+            let label = match mode {
+                CheckMode::After => "Jovian",
+                CheckMode::Before => "Isthmus",
+            };
+            if impl_addr == expected {
+                CheckResult {
+                    passed: Some(true),
+                    detail: format!(
+                        "→ 0x{}",
+                        impl_addr.get(..8).unwrap_or(impl_addr)
+                    ),
+                }
+            } else {
+                CheckResult {
+                    passed: Some(false),
+                    detail: format!(
+                        "impl=0x{} (expected {label})",
+                        impl_addr.get(..8).unwrap_or(impl_addr)
+                    ),
+                }
+            }
+        }
+    };
+    send_result!("GPO implementation", gpo_check);
 }
 
 // ── V1 activation checks (ported from v1.py run_v1_checks) ───────────────────

--- a/crates/infra/basectl/src/app/views/upgrades.rs
+++ b/crates/infra/basectl/src/app/views/upgrades.rs
@@ -179,7 +179,6 @@ enum CheckMode {
     After,
 }
 
-
 #[derive(Debug, Clone)]
 struct CheckResult {
     passed: Option<bool>,

--- a/crates/infra/basectl/src/app/views/upgrades.rs
+++ b/crates/infra/basectl/src/app/views/upgrades.rs
@@ -70,18 +70,6 @@ struct ChainUpgrades {
     specs: Vec<UpgradeSpec>,
 }
 
-impl ChainUpgrades {
-    /// Returns `true` if the V1 upgrade has activated at or before `now`.
-    fn v1_active(&self, now: u64) -> bool {
-        self.specs
-            .iter()
-            .find(|s| s.name == "V1")
-            .and_then(|s| s.timestamp)
-            .map(|ts| ts <= now)
-            .unwrap_or(false)
-    }
-}
-
 fn specs_from_config(cfg: &BaseChainConfig) -> Vec<UpgradeSpec> {
     vec![
         UpgradeSpec { name: "Delta", timestamp: Some(cfg.delta_timestamp) },


### PR DESCRIPTION
## Summary

The upgrades view checks panel was hardcoded to V1. On mainnet where V1 has no scheduled timestamp, pressing [r] did nothing. Checks are now routed to the last hardfork with a defined check suite. Mainnet runs Jovian checks; chains with V1 scheduled continue to run V1 checks as before.

Three Jovian checks are added: bn256Pairing input size limit (428 pairs exceeds the 81984-byte Jovian cap), block extra data version byte (0 before, 1 after), and GasPriceOracle EIP-1967 implementation slot (Isthmus before, Jovian after). The panel title and idle hint text update to show the active hardfork name.

Example running jovian checks against mainnet:

<img width="1046" height="797" alt="Screenshot 2026-04-08 at 7 11 11 PM" src="https://github.com/user-attachments/assets/c019d7e7-3a89-42ba-86ed-f79df711d023" />
