### PR TITLE
fix(builder): populate access_list in flashblock metadata when Base v1 is active

### DIFF
--- a/crates/builder/core/src/flashblocks/payload.rs
+++ b/crates/builder/core/src/flashblocks/payload.rs
@@ -1112,13 +1112,13 @@ where
 
     // finalize and build the FAL
     let fal_builder = std::mem::take(&mut info.extra.access_list_builder);
-    let _access_list = fal_builder.build(min_tx_index, max_tx_index);
+    let access_list = fal_builder.build(min_tx_index, max_tx_index);
 
     let metadata: FlashblocksMetadata =
         if ctx.chain_spec.is_base_v1_active_at_timestamp(ctx.attributes().timestamp()) {
             FlashblocksMetadata {
                 block_number: ctx.parent().number + 1,
-                access_list: None,
+                access_list: Some(access_list),
                 receipts: None,
                 new_account_balances: None,
             }

--- a/crates/builder/core/tests/flashblocks.rs
+++ b/crates/builder/core/tests/flashblocks.rs
@@ -143,8 +143,8 @@ async fn test_flashblock_metadata_post_base_v1() -> eyre::Result<()> {
             "post-V1 flashblock metadata must not contain new_account_balances"
         );
         assert!(
-            fb.metadata.get("access_list").is_none(),
-            "post-V1 flashblock metadata must not contain access_list"
+            fb.metadata.get("access_list").is_some(),
+            "post-V1 flashblock metadata must contain access_list"
         );
     }
 


### PR DESCRIPTION
## Summary

- The `FlashblocksMetadata` access list was being built from the `FBALBuilderDb` but immediately discarded (assigned to `_access_list`) instead of included in the metadata payload when Base v1 is active. Changed to `Some(access_list)` in the v1 branch so it's actually sent downstream.
- Fixed the `test_flashblock_metadata_post_base_v1` integration test which incorrectly asserted `access_list` was `None` post-v1 — updated to assert `is_some()` to match the intended behavior.

## Details

The access list builder is correctly accumulated throughout block building:
1. `execute_sequencer_transactions` initializes it via direct assignment (first phase, nothing prior to merge with)
2. `execute_best_transactions` merges into it (preserving sequencer data across flashblock rounds)
3. `build_block` finalizes with `.build()` — but was discarding the result

Only the final assignment in `build_block` was broken. The pre-v1 branch correctly keeps `access_list: None`.