### PR TITLE
[bcp]: Add BCP-0003 Virtual Address Routing

### DIFF
--- a/docs/specs/components/BCPsList.tsx
+++ b/docs/specs/components/BCPsList.tsx
@@ -16,6 +16,13 @@ const bcps: BcpEntry[] = [
     status: 'Final',
     link: '/bcps/bcp-0000',
   },
+  {
+    id: 'BCP-0003',
+    title: 'Virtual Address Deposit Routing',
+    description: 'A virtual address scheme for routing token deposits to a master address without sweep transactions.',
+    status: 'Draft',
+    link: '/bcps/bcp-0003',
+  },
 ]
 
 const statusColor: Record<BcpStatus, { color: string; background: string }> = {

--- a/docs/specs/pages/bcps/bcp-0003.md
+++ b/docs/specs/pages/bcps/bcp-0003.md
@@ -1,0 +1,249 @@
+# BCP-0003: Virtual Address Deposit Routing
+
+## Abstract
+
+This BCP proposes adopting a virtual address scheme analogous to Tempo's
+TIP-1022 for the Base stack. A virtual address is a 20-byte value whose middle
+10 bytes are a fixed magic sequence; it encodes a 4-byte master identifier and a
+6-byte per-user tag. A registry precompile maps master identifiers to master
+addresses. When a token transfer targets a virtual address, the runtime resolves
+it to the registered master and credits the master directly — no sweep
+transaction needed.
+
+**This BCP has a hard prerequisite: an enshrined Base token standard implemented
+as a precompile.** TIP-1022 works on Tempo because TIP-20 — Tempo's only token
+standard — is itself a precompile. The resolution hook lives inside that
+precompile, so all tokens on Tempo get virtual address support automatically.
+ERC-20 is bytecode; the EVM has no hook point where the runtime can intercept a
+generic `transfer(to, amount)` and rewrite `to`. Without an equivalent enshrined
+token standard on Base, the registry precompile can be deployed but virtual
+address routing does not apply to any token transfers — only to native ETH
+deposits from L1, which is too narrow to be useful in practice.
+
+## Motivation
+
+An exchange or payment processor accepting L2 deposits today must either assign
+each user a unique EOA (requiring sweep transactions to consolidate) or operate
+a shared address (requiring fragile off-chain memo attribution). Virtual
+addresses eliminate this tradeoff: a single master wallet registers once; the
+operator derives unlimited per-user deposit addresses off-chain with no on-chain
+cost. Deposits route directly to the master at the protocol layer.
+
+### Why Tempo's TIP-1022 Works End-to-End
+
+TIP-20 is Tempo's only token standard and is implemented as a precompile rather
+than deployable bytecode. Every token on Tempo — stablecoins, governance tokens,
+LP shares — goes through the TIP-20 precompile for `transfer`, `transferFrom`,
+`mint`, and equivalent operations. Because all value flow passes through a single
+precompile, TIP-1022 injects resolution logic once there and immediately covers
+the entire token ecosystem. From TIP-1022:
+
+> TIP-1022 applies only to TIP-20 precompile recipient resolution for the
+> entrypoints listed in Transfer Path Modification. Non-TIP-20 token transfers
+> (e.g. ERC-20 contracts deployed on Tempo) to virtual addresses are not
+> subject to TIP-1022 forwarding.
+
+Even on Tempo, ERC-20 bytecode contracts are out of scope. The scheme works
+precisely because the ecosystem converged on a single precompile-backed standard.
+
+### Base's Prerequisite
+
+On Base, every token — USDC, WETH, DAI — is an independently deployed bytecode
+contract. The EVM has no hook that fires when any ERC-20 contract executes
+`_transfer(from, to, amount)`. Deploying the registry precompile without an
+enshrined token standard produces a system where the address format is defined
+and the registry is live, but no token transfer ever consults it. Operators who
+issue virtual deposit addresses would silently receive nothing: token deposits
+credit the literal virtual address, which holds no balance and has no recovery
+path.
+
+The prerequisite is a Base token standard implemented as a precompile — the
+equivalent of TIP-20 on Tempo. Once that precompile exists, the resolution hook
+described in this BCP is added to its transfer path, giving all tokens on Base
+the same automatic coverage that TIP-20 gives Tempo tokens. This BCP should be
+implemented concurrently with or after that token standard, not before it.
+
+## Specification
+
+### Virtual Address Format
+
+A virtual address is a 20-byte value with the following layout (identical to
+TIP-1022):
+
+```text
+ bytes [0..4]   masterId  (4 bytes)
+ bytes [4..14]  magic     (10 bytes, all 0xFD)
+ bytes [14..20] userTag   (6 bytes)
+```
+
+Any address whose bytes `[4..14]` equal `0xFDFDFDFDFDFDFDFDFDFD` is a virtual
+address. The magic is placed in the middle (not at the start) to preserve
+visually meaningful bytes at both ends of the address in wallets and explorers.
+
+**MasterId** (4 bytes): derived from `keccak256(abi.encodePacked(caller, salt))`
+during registration. Bytes `[4..8]` of the hash become the master ID; the first
+4 bytes must be zero (32-bit proof-of-work). Collision probability remains below
+0.1% even with 4 million registered masters.
+
+**UserTag** (6 bytes): opaque value chosen off-chain by the master operator.
+~2.8 × 10^14 unique deposit addresses per master. Never interpreted by the
+protocol; exists for operator-side attribution via log indexing.
+
+### Registry Precompile
+
+A registry precompile at `0xFDC0000000000000000000000000000000000000` maintains
+`masterId → masterAddress` mappings:
+
+```solidity
+interface IAddressRegistry {
+    event MasterRegistered(bytes4 indexed masterId, address indexed masterAddress);
+
+    error MasterIdCollision();
+    error InvalidMasterAddress();
+    error ProofOfWorkFailed();
+    error VirtualAddressUnregistered();
+
+    function registerVirtualMaster(bytes32 salt) external returns (bytes4 masterId);
+    function getMaster(bytes4 masterId) external view returns (address);
+    function resolveRecipient(address to) external view returns (address effectiveRecipient);
+    function resolveVirtualAddress(address virtualAddr) external view returns (address master);
+    function isVirtualAddress(address addr) external pure returns (bool);
+    function decodeVirtualAddress(address addr)
+        external pure returns (bool isVirtual, bytes4 masterId, bytes6 userTag);
+}
+```
+
+**Registration rules:**
+- Registration hash: `keccak256(abi.encodePacked(msg.sender, salt))`
+- First 4 bytes of hash must be zero (32-bit PoW); `masterId` = bytes `[4..8]`
+- The zero address may not register
+- A virtual address (magic in bytes `[4..14]`) may not register as a master
+- Re-registration of the same `(caller, masterId)` pair is a no-op
+- `masterId` registrations are immutable: no rotation or update mechanism exists at the protocol level; operators should register to a multisig or upgradeable proxy
+
+**Storage layout** (one SLOAD per resolution during transfer):
+
+```
+slot = keccak256(abi.encode(masterId, REGISTRY_SLOT))
+value = masterAddress (20 bytes) | reserved (11 bytes) | masterType (1 byte, 0x00)
+```
+
+The address occupies the high bytes; `masterType` is the low byte, reserved for
+future extensibility.
+
+### Transfer Path Integration
+
+The enshrined Base token standard precompile MUST call `resolveRecipient(to)`
+before crediting any recipient. The following entrypoints are in scope (matching
+TIP-1022's surface): `transfer`, `transferFrom`, `mint`, and any memo or
+system variants thereof.
+
+Resolution logic:
+
+```text
+function resolveRecipient(to: address) -> address:
+    if to[4:14] != VIRTUAL_MAGIC:
+        return to
+    masterId = to[0:4]
+    master = registry.getMaster(masterId)
+    if master == address(0):
+        revert VirtualAddressUnregistered()
+    return master
+```
+
+If `to` is not virtual, it passes through unchanged with no registry lookup.
+If `to` is virtual and unregistered, the transfer reverts. The literal virtual
+address never accumulates a balance through the token precompile's transfer
+path.
+
+### Event Emission
+
+For virtual-forwarded transfers, emit two `Transfer` events in sequence:
+
+1. `Transfer(sender, virtualAddress, amount)` — shows funds arriving at the virtual address (attribution)
+2. `Transfer(virtualAddress, masterAddress, amount)` — shows funds forwarding to the master
+
+The actual balance change is applied only to `masterAddress`. Indexers watch for
+pairs where the intermediate address matches the virtual format and extract the
+`userTag` to attribute the deposit to the operator's internal user.
+
+For non-virtual recipients, event emission is unchanged.
+
+### Proof-of-Work Security Model
+
+The 32-bit PoW on registration protects against targeted masterId squatting. An
+attacker who observes a pending registration and wants to steal the same masterId
+must compute a `(attackerAddress, salt)` pair that both satisfies the PoW and
+collides on the 4-byte master ID — approximately 2^64 work. The expected cost
+for an honest operator is ~2^32 hash evaluations (~1 minute single-threaded),
+a one-time cost.
+
+## Tradeoffs
+
+**Gained.** Exchanges and custodians can issue ~2.8 × 10^14 unique deposit
+addresses per master with no per-user on-chain cost. Token deposits route
+directly to the master; no sweep transaction is required. The scheme is
+backward-compatible for senders unaware of virtual addresses. Virtual addresses
+never accumulate state, avoiding new-account creation costs.
+
+**Sacrificed.** This BCP is blocked on a prerequisite: the enshrined Base token
+standard. Until that standard exists and has meaningful token adoption, virtual
+address routing has no surface to operate on. `masterId` registrations are
+immutable at the protocol level; operators must use a multisig or proxy if they
+need key rotation. The registry is a consensus-critical system contract; bugs in
+it or in its integration with the token precompile can cause state divergence.
+Virtual addresses in policy or authorization systems must be treated as aliases
+for their master, not as independent accounts.
+
+## Estimated Impact
+
+- **On-chain state:** One 32-byte storage slot per registered master. Thousands
+  of entries at steady state; negligible footprint.
+- **Token precompile overhead:** One registry SLOAD per transfer to a virtual
+  address. Non-virtual transfers pay no cost.
+- **Consensus complexity:** The registry precompile becomes consensus-critical
+  state. Its behavior must be deterministic and identical across sequencer,
+  validators, and the proof executor.
+
+---
+
+## Appendix A: Application to base/base
+
+_Informational; not part of the protocol specification._
+
+### Existing Work (PR base/base#1839)
+
+The spike establishes production-quality foundations in `base-address-resolution`
+(`no_std`, pure types/traits, identical address format and storage layout to
+TIP-1022). The `EvmOverride` trait added to the action harness is already
+merged-quality. The `virtual-address-registry` example is a prototype with known
+issues (the `unimplemented!()` trait impls, the `is_valid_master` gap noted in
+the AI review) and should not be promoted.
+
+### Migration Path
+
+1. **Prerequisite: enshrined Base token standard.** This BCP cannot be fully
+   realized without it. The registry precompile and `base-address-resolution`
+   types can be built in parallel, but transfer-path integration waits on the
+   token standard.
+
+2. **Promote `base-address-resolution`.** No changes needed from the spike.
+   Gate on a new `BaseUpgrade` hardfork variant for activation.
+
+3. **Deploy registry precompile.** Implement the `IAddressRegistry` interface
+   in `crates/precompiles/` backed by the storage layout from the spike.
+   Deploy at genesis or via a hardfork-gated system transaction.
+
+4. **Token precompile integration.** Once the Base token standard precompile
+   exists, add the `resolveRecipient` call-through to its transfer path.
+   The registry precompile is called read-only; one SLOAD per affected transfer.
+
+### Key Crates Affected
+
+| Crate | Change |
+|---|---|
+| `base-address-resolution` | Promote from spike (no changes needed) |
+| `crates/precompiles/` | Add registry precompile implementation |
+| Base token standard precompile | Add `resolveRecipient` to transfer path |
+| `base-action-harness` | `EvmOverride` trait already added by spike |
+| Genesis config | Deploy registry at `REGISTRY_ADDRESS` |


### PR DESCRIPTION
## Summary

Adds BCP-0003 (Virtual Address Deposit Routing) to the specs site alongside existing BCPs. The proposal introduces a virtual address scheme that routes token deposits directly to a registered master address at the protocol layer, eliminating the need for sweep transactions. It carries a hard prerequisite on an enshrined Base token standard implemented as a precompile, analogous to Tempo's TIP-1022. The BCP is listed with Draft status on the BCP index page.