### PR TITLE
fix(justfile): fix submodule recipe listing and add --list-submodules

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -26,7 +26,7 @@ alias ldc := load-test-devnet-continuous
 
 # Default to display help menu
 default:
-    @just --list
+    @just --list --list-submodules
 
 # Load test devnet in continuous mode (Ctrl-C to stop)
 load-test-devnet-continuous:

--- a/crates/infra/load-tests/Justfile
+++ b/crates/infra/load-tests/Justfile
@@ -11,7 +11,7 @@ set working-directory := '../../..'
 
 # Show load-test commands
 default:
-    @just load-test --list
+    @just --justfile {{source_file()}} --list
 
 # Run load test against devnet (local) - uses Anvil Account #1
 devnet *args:

--- a/etc/docker/Justfile
+++ b/etc/docker/Justfile
@@ -7,7 +7,7 @@ _env := "--env-file etc/docker/devnet-env"
 
 # Show devnet commands
 default:
-    @just devnet --list
+    @just --justfile {{source_file()}} --list
 
 # Stops devnet, deletes data, and starts fresh (3-node HA conductor cluster)
 up: down _build-setup-image (_build-rust-images "devnet" "dev")


### PR DESCRIPTION
## Summary
- Fix child Justfiles (load-test, devnet) whose `default` recipes passed `--list` as a positional arg to the recipe instead of a flag to `just`, breaking `just load-test` and standalone `just` in those directories.
- Use `just --justfile {{source_file()}} --list` so each child correctly lists its own recipes regardless of `set working-directory`.
- Add `--list-submodules` to the root `default` recipe so `just --list` shows submodule recipes.

## Diff

Before:
```
❯ just load-test
error: Justfile does not contain recipe `load-test --list`
error: Recipe `default` failed on line 16 with exit code 1
```

After:
```
❯ just load-test
Available recipes:
    default           # Show load-test commands
    devnet *args      # Run load test against devnet (local) - uses Anvil Account #1
    devnet-continuous # Run load test against devnet indefinitely (Ctrl-C to stop)
    sepolia *args     # Run load test against sepolia network (requires FUNDER_KEY env var)
```