### PR TITLE
fix(ci): use sccache to resolve disk space exhaustion

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -84,6 +84,9 @@ runs:
       if: inputs.mold == 'true'
       uses: rui314/setup-mold@725a8794d15fc7563f59595bd9556495c0564878 # v1
 
+    - name: Setup sccache
+      uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # v0.0.9
+
     - name: Rust cache
       if: inputs.rust-cache-shared-key != ''
       uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2.8.2
@@ -91,6 +94,7 @@ runs:
         cache-on-failure: true
         shared-key: ${{ inputs.rust-cache-shared-key }}
         save-if: ${{ inputs.rust-cache-save }}
+        cache-targets: "false"
 
     - name: Install just
       uses: extractions/setup-just@e33e0265a09d6d736e2ee1e0eb685ef1de4669ff # v3

--- a/.github/workflows/action-tests.yml
+++ b/.github/workflows/action-tests.yml
@@ -12,6 +12,8 @@ concurrency:
 
 env:
   CARGO_TERM_COLOR: always
+  SCCACHE_GHA_ENABLED: "true"
+  RUSTC_WRAPPER: "sccache"
 
 permissions:
   contents: read

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -9,6 +9,8 @@ concurrency:
 
 env:
   CARGO_TERM_COLOR: always
+  SCCACHE_GHA_ENABLED: "true"
+  RUSTC_WRAPPER: "sccache"
   BENCHMARK_REPO: "base/benchmark"
   BENCHMARK_REF: "48f0e0405fc9df31bd8b3e59d686374695e06d64"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,8 @@ concurrency:
 
 env:
   CARGO_TERM_COLOR: always
+  SCCACHE_GHA_ENABLED: "true"
+  RUSTC_WRAPPER: "sccache"
 
 permissions:
   contents: read

--- a/.github/workflows/no-std.yml
+++ b/.github/workflows/no-std.yml
@@ -12,6 +12,8 @@ concurrency:
 
 env:
   CARGO_TERM_COLOR: always
+  SCCACHE_GHA_ENABLED: "true"
+  RUSTC_WRAPPER: "sccache"
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary

- Switch to `sccache` for Rust compilation caching to fix CI failures caused by disk space exhaustion during cache restoration
- Disable `target/` caching in `Swatinem/rust-cache` (`cache-targets: false`), keeping only cargo registry/index caching

## Problem

The Rust `target/` cache has grown to **~9.6 GB** (compressed). `ubuntu-latest` runners have ~14 GB free, so restoring this cache fills the disk before the build even starts:

```
/usr/bin/tar: target/ci/deps/liblibp2p_stream-5ea9ed6c0483e7b6.rlib: Cannot write: No space left on device
```

## Solution

Adopt `mozilla-actions/sccache-action` (same approach as [reth](https://github.com/paradigmxyz/reth)), which caches individual compilation units via the GitHub Actions cache API instead of storing the entire `target/` directory as a monolithic blob. This keeps cache sizes in the 1-2 GB range instead of 9.6 GB.

The existing bloated caches can be manually deleted to unblock immediately:
```bash
gh api -X DELETE "repos/base/base/actions/caches?key=v0-rust-stable-Linux-x64-fd51ecf3-fca35d41"
gh api -X DELETE "repos/base/base/actions/caches?key=v0-rust-stable-Linux-x64-fd51ecf3-3f4ec5e4"
```