### PR TITLE
feat: add graceful shutdown to load tests

### DIFF
--- a/crates/infra/basectl/src/app/core.rs
+++ b/crates/infra/basectl/src/app/core.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, io::Stdout};
+use std::{collections::HashMap, io::Stdout, sync::atomic::Ordering, time::Duration};
 
 use anyhow::Result;
 use crossterm::event::{self, Event, KeyCode, KeyEvent, KeyModifiers};
@@ -70,6 +70,19 @@ impl App {
         let mut terminal = setup_terminal()?;
         let result = self.run_loop(&mut terminal, &mut view_factory).await;
         restore_terminal(&mut terminal)?;
+
+        if let Some(task) = self.resources.load_test_task.take() {
+            task.stop_flag.store(true, Ordering::SeqCst);
+            eprintln!("Waiting for load test to drain accounts...");
+            match tokio::time::timeout(Duration::from_secs(120), task.handle).await {
+                Ok(Ok(())) => eprintln!("Load test shutdown complete."),
+                Ok(Err(e)) => eprintln!("Load test task panicked: {e}"),
+                Err(_) => {
+                    eprintln!("Load test drain timed out. Funds may remain in test accounts.")
+                }
+            }
+        }
+
         result
     }
 

--- a/crates/infra/basectl/src/app/mod.rs
+++ b/crates/infra/basectl/src/app/mod.rs
@@ -7,7 +7,7 @@ mod core;
 pub(crate) use core::App;
 
 mod resources;
-pub(crate) use resources::Resources;
+pub(crate) use resources::{LoadTestTask, Resources};
 
 mod router;
 pub(crate) use router::Router;

--- a/crates/infra/basectl/src/app/resources.rs
+++ b/crates/infra/basectl/src/app/resources.rs
@@ -1,8 +1,14 @@
-use std::collections::{HashSet, VecDeque};
+use std::{
+    collections::{HashSet, VecDeque},
+    sync::{Arc, atomic::AtomicBool},
+};
 
 use base_alloy_flashblocks::Flashblock;
 use base_consensus_genesis::SystemConfig;
-use tokio::sync::{mpsc, watch};
+use tokio::{
+    sync::{mpsc, watch},
+    task::JoinHandle,
+};
 
 use crate::{
     commands::common::{DaTracker, FlashblockEntry, LoadingState},
@@ -135,6 +141,14 @@ impl ProofsState {
     }
 }
 
+/// Handle to a running load test task and its stop signal, used by [`super::App`]
+/// to await drain completion on shutdown so funds are returned to the funder.
+#[derive(Debug)]
+pub(crate) struct LoadTestTask {
+    pub stop_flag: Arc<AtomicBool>,
+    pub handle: JoinHandle<()>,
+}
+
 /// Shared resources available to all TUI views.
 #[derive(Debug)]
 pub(crate) struct Resources {
@@ -155,6 +169,8 @@ pub(crate) struct Resources {
     /// L1 system config fetched from the contract.
     pub system_config: Option<SystemConfig>,
     sys_config_rx: Option<mpsc::Receiver<SystemConfig>>,
+    /// Active load test task handle, set by [`super::views::LoadTestView`].
+    pub load_test_task: Option<LoadTestTask>,
 }
 
 /// State for DA (data availability) monitoring.
@@ -214,6 +230,7 @@ impl Resources {
             proofs: ProofsState::default(),
             system_config: None,
             sys_config_rx: None,
+            load_test_task: None,
         }
     }
 

--- a/crates/infra/basectl/src/app/views/load_test.rs
+++ b/crates/infra/basectl/src/app/views/load_test.rs
@@ -21,7 +21,7 @@ use tokio::sync::{mpsc, mpsc::error::TryRecvError, watch};
 use url::Url;
 
 use crate::{
-    app::{Action, Resources, View},
+    app::{Action, LoadTestTask, Resources, View},
     commands::common::COLOR_BASE_BLUE,
     tui::{Keybinding, Toast},
 };
@@ -467,7 +467,7 @@ impl LoadTestView {
         let (snap_tx, snap_rx) = watch::channel(DisplaySnapshot::default());
         let (done_tx, done_rx) = mpsc::channel(1);
 
-        tokio::spawn(async move {
+        let task_handle = tokio::spawn(async move {
             // Fetch chain_id from the network's RPC — required for transaction signing.
             let client = RpcClient::new(cfg.rpc.clone());
             let chain_id = client.chain_id().await.ok();
@@ -558,6 +558,9 @@ impl LoadTestView {
 
             let _ = done_tx.send(result.map_err(|e| e.to_string())).await;
         });
+
+        resources.load_test_task =
+            Some(LoadTestTask { stop_flag: Arc::clone(&stop_flag), handle: task_handle });
 
         self.state = RunState::Running {
             start: Instant::now(),
@@ -854,6 +857,7 @@ impl View for LoadTestView {
                         self.state = RunState::Idle;
                         self.start_run(run_count + 1, resources);
                     } else {
+                        resources.load_test_task = None;
                         resources.toasts.push(Toast::info(format!(
                             "Load test complete in {:.1}s — {:.1} TPS / {:.0} GPS",
                             elapsed.as_secs_f64(),
@@ -864,6 +868,7 @@ impl View for LoadTestView {
                     }
                 }
                 Err(e) => {
+                    resources.load_test_task = None;
                     resources.toasts.push(Toast::warning(format!("Load test error: {e}")));
                     self.state = RunState::Error(e);
                 }
@@ -1340,13 +1345,25 @@ fn render_live_metrics(frame: &mut Frame<'_>, area: Rect, snap: &DisplaySnapshot
     lines.push(Line::from(""));
 
     // Latency.
-    lines.push(Line::from(Span::styled("  LATENCY (rolling 30s)", label)));
+    lines.push(Line::from(Span::styled("  BLOCK LATENCY (rolling 30s)", label)));
     lines.push(Line::from(vec![
         Span::styled("    p50  ", label),
         Span::styled(fmt_dur(snap.p50_latency), value),
         Span::styled("    p99  ", label),
         Span::styled(fmt_dur(snap.p99_latency), value),
     ]));
+    if snap.flashblocks_p50_latency > Duration::ZERO
+        || snap.flashblocks_p99_latency > Duration::ZERO
+    {
+        lines.push(Line::from(""));
+        lines.push(Line::from(Span::styled("  FLASHBLOCKS LATENCY (rolling 30s)", label)));
+        lines.push(Line::from(vec![
+            Span::styled("    p50  ", label),
+            Span::styled(fmt_dur(snap.flashblocks_p50_latency), value),
+            Span::styled("    p99  ", label),
+            Span::styled(fmt_dur(snap.flashblocks_p99_latency), value),
+        ]));
+    }
 
     lines.push(Line::from(""));
 

--- a/crates/infra/load-tests/Cargo.toml
+++ b/crates/infra/load-tests/Cargo.toml
@@ -42,7 +42,7 @@ eyre.workspace = true
 rand.workspace = true
 revm.workspace = true
 serde.workspace = true
-tokio.workspace = true
+tokio = { workspace = true, features = ["signal"] }
 futures.workspace = true
 tracing.workspace = true
 humantime.workspace = true

--- a/crates/infra/load-tests/README.md
+++ b/crates/infra/load-tests/README.md
@@ -45,6 +45,8 @@ Example minimal config:
 
 ```yaml
 rpc: http://localhost:8545
+rpc_ws_url: "ws://localhost:8546"
+flashblocks_ws_url: "ws://localhost:7111"
 sender_count: 10
 target_gps: 2100000
 duration: "30s"

--- a/crates/infra/load-tests/src/bin/load_test.rs
+++ b/crates/infra/load-tests/src/bin/load_test.rs
@@ -3,10 +3,14 @@
 //! Also provides a `rescue` subcommand for recovering stranded funds from
 //! test accounts after failed or interrupted load test runs.
 
-use std::{path::PathBuf, time::Duration, sync::{
-    Arc,
-    atomic::{AtomicBool, Ordering},
-},};
+use std::{
+    path::PathBuf,
+    sync::{
+        Arc,
+        atomic::{AtomicBool, Ordering},
+    },
+    time::Duration,
+};
 
 use alloy_network::{EthereumWallet, ReceiptResponse, TransactionBuilder};
 use alloy_primitives::{Address, TxHash, U256, utils::format_ether};

--- a/crates/infra/load-tests/src/bin/load_test.rs
+++ b/crates/infra/load-tests/src/bin/load_test.rs
@@ -3,7 +3,10 @@
 //! Also provides a `rescue` subcommand for recovering stranded funds from
 //! test accounts after failed or interrupted load test runs.
 
-use std::{path::PathBuf, time::Duration};
+use std::{path::PathBuf, time::Duration, sync::{
+    Arc,
+    atomic::{AtomicBool, Ordering},
+},};
 
 use alloy_network::{EthereumWallet, ReceiptResponse, TransactionBuilder};
 use alloy_primitives::{Address, TxHash, U256, utils::format_ether};
@@ -53,10 +56,12 @@ async fn run_load_test(args: Vec<String>) -> Result<()> {
 
     let mut config_path: Option<PathBuf> = None;
     let mut continuous = false;
+    let mut drain_only = false;
 
     for arg in &args {
         match arg.as_str() {
             "--continuous" => continuous = true,
+            "--drain-only" => drain_only = true,
             other => {
                 if config_path.is_none() {
                     config_path = Some(PathBuf::from(other));
@@ -70,13 +75,13 @@ async fn run_load_test(args: Vec<String>) -> Result<()> {
             option_env!("CARGO_MANIFEST_DIR")
                 .map(|dir| PathBuf::from(dir).join("examples/devnet.yaml"))
         })
-        .ok_or_else(|| eyre::eyre!("usage: base-load-test [--continuous] <config.yaml>"))?;
+        .ok_or_else(|| {
+            eyre::eyre!("usage: base-load-test [--continuous] [--drain-only] <config.yaml>")
+        })?;
 
     if !config_path.exists() {
         bail!("config file not found: {}", config_path.display());
     }
-
-    println!("=== Base Load Test Runner ===");
 
     let test_config = TestConfig::load(&config_path)?;
 
@@ -88,6 +93,25 @@ async fn run_load_test(args: Vec<String>) -> Result<()> {
         let cfg = test_config.to_load_config(rpc_chain_id)?;
         if continuous { cfg.with_continuous() } else { cfg }
     };
+
+    let funding_key = TestConfig::funder_key()?;
+
+    // Drain-only mode: recover funds from a previous interrupted run.
+    if drain_only {
+        println!("=== Drain-Only Mode ===");
+        println!(
+            "Re-deriving {} accounts from config and draining to funder...",
+            load_config.account_count
+        );
+        let runner = LoadRunner::new(load_config)?;
+        match runner.drain_accounts(funding_key).await {
+            Ok(drained) => println!("Drained {} ETH back to funder.", format_ether(drained)),
+            Err(e) => bail!("drain failed: {e}"),
+        }
+        return Ok(());
+    }
+
+    println!("=== Base Load Test Runner ===");
 
     println!(
         "Config: {} | RPC: {} | Chain: {}",
@@ -103,10 +127,15 @@ async fn run_load_test(args: Vec<String>) -> Result<()> {
     );
     println!();
 
-    let funding_key = TestConfig::funder_key()?;
     let funding_amount = test_config.parse_funding_amount()?;
 
     let mut runner = LoadRunner::new(load_config.clone())?;
+
+    // Install signal handler before any long-running work. First signal sets
+    // the stop flag so `run()` exits its loop gracefully and the drain sequence
+    // runs. A second signal force-exits.
+    let stop_flag = runner.stop_flag();
+    install_signal_handler(stop_flag);
 
     println!("Funding test accounts...");
     runner.fund_accounts(funding_key.clone(), funding_amount).await?;
@@ -120,40 +149,79 @@ async fn run_load_test(args: Vec<String>) -> Result<()> {
     let display = LoadTestDisplay::new(&mp, load_config.duration);
     runner.set_display(display);
 
-    let summary = runner.run().await?;
+    let run_result = runner.run().await;
+
+    if let Ok(ref summary) = run_result {
+        println!();
+        println!("=== Results ===");
+        println!(
+            "Submitted: {} | Confirmed: {} | Failed: {}",
+            summary.throughput.total_submitted,
+            summary.throughput.total_confirmed,
+            summary.throughput.total_failed
+        );
+        println!(
+            "TPS: {:.2} | GPS: {:.0} | Success: {:.1}%",
+            summary.throughput.tps,
+            summary.throughput.gps,
+            summary.throughput.success_rate()
+        );
+        let fb = &summary.flashblocks_latency;
+        println!(
+            "Flashblocks Latency: p50={:.1?}  p90={:.1?}  p99={:.1?}  (n={})",
+            fb.p50, fb.p90, fb.p99, fb.count
+        );
+        let bl = &summary.block_latency;
+        println!(
+            "Block Latency: min={:.1?}  p50={:.1?}  mean={:.1?}  p99={:.1?}  max={:.1?}",
+            bl.min, bl.p50, bl.mean, bl.p99, bl.max
+        );
+        println!("Gas: total={}  avg/tx={}", summary.gas.total_gas, summary.gas.avg_gas);
+    }
 
     println!();
-    println!("=== Results ===");
-    println!(
-        "Submitted: {} | Confirmed: {} | Failed: {}",
-        summary.throughput.total_submitted,
-        summary.throughput.total_confirmed,
-        summary.throughput.total_failed
-    );
-    println!(
-        "TPS: {:.2} | GPS: {:.0} | Success: {:.1}%",
-        summary.throughput.tps,
-        summary.throughput.gps,
-        summary.throughput.success_rate()
-    );
-    let fb = &summary.flashblocks_latency;
-    println!(
-        "Flashblocks Latency: p50={:.1?}  p90={:.1?}  p99={:.1?}  (n={})",
-        fb.p50, fb.p90, fb.p99, fb.count
-    );
-    let bl = &summary.block_latency;
-    println!(
-        "Block Latency: min={:.1?}  p50={:.1?}  mean={:.1?}  p99={:.1?}  max={:.1?}",
-        bl.min, bl.p50, bl.mean, bl.p99, bl.max
-    );
-    println!("Gas: total={}  avg/tx={}", summary.gas.total_gas, summary.gas.avg_gas);
-    println!();
-
     println!("Draining accounts back to funder...");
-    let drained = runner.drain_accounts(funding_key).await?;
-    println!("Drained {} ETH back to funder.", format_ether(drained));
+    match runner.drain_accounts(funding_key).await {
+        Ok(drained) => println!("Drained {} ETH back to funder.", format_ether(drained)),
+        Err(e) => eprintln!("Warning: drain failed: {e}"),
+    }
+
+    run_result?;
 
     Ok(())
+}
+
+/// Spawns a background task that converts OS signals into a cooperative stop
+/// via the shared [`AtomicBool`]. A second signal force-exits the process.
+fn install_signal_handler(stop_flag: Arc<AtomicBool>) {
+    tokio::spawn(async move {
+        wait_for_shutdown_signal().await;
+        eprintln!("\nReceived signal, stopping gracefully. Send again to force exit.");
+        stop_flag.store(true, Ordering::SeqCst);
+
+        wait_for_shutdown_signal().await;
+        eprintln!("\nForcing exit. Funds may remain in test accounts.");
+        std::process::exit(1);
+    });
+}
+
+/// Waits for either SIGINT (Ctrl-C) or SIGTERM (Unix only).
+async fn wait_for_shutdown_signal() {
+    #[cfg(unix)]
+    {
+        use tokio::signal::unix::{SignalKind, signal};
+
+        let mut sigterm =
+            signal(SignalKind::terminate()).expect("failed to register SIGTERM handler");
+        tokio::select! {
+            _ = tokio::signal::ctrl_c() => {}
+            _ = sigterm.recv() => {}
+        }
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = tokio::signal::ctrl_c().await;
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/utilities/metrics/src/lib.rs
+++ b/crates/utilities/metrics/src/lib.rs
@@ -30,7 +30,7 @@ pub use registry::register_initializer;
 #[cfg(not(feature = "metrics"))]
 #[inline(always)]
 /// Initializes all registered metrics. No-op when the `metrics` feature is disabled.
-pub fn initialize_registered_metrics() {}
+pub const fn initialize_registered_metrics() {}
 
 #[cfg(feature = "metrics")]
 mod timer;


### PR DESCRIPTION
- Graceful shutdown on SIGINT/SIGTERM: Signal handler converts OS signals into a cooperative stop via the existing stop_flag, letting run() land in-flight transactions before draining accounts back to the funder. Second signal force-exits.
- Always-drain in the binary: drain_accounts() now runs regardless of whether run() succeeded or failed, matching the pattern the TUI already had.
- TUI shutdown coordination: The load test task's JoinHandle is stored on Resources so App::run can await drain completion (up to 120s) when the user quits mid-test, instead of killing the task and stranding funds.
- Live flashblocks latency in TUI: Rolling 30s flashblocks p50/p99 latency now displays during the run alongside block latency