### PR TITLE
fix(consensus): Handle Missing L1 Origin Block [backport to releases/v0.7.1]

### DIFF
--- a/crates/consensus/service/src/actors/sequencer/build.rs
+++ b/crates/consensus/service/src/actors/sequencer/build.rs
@@ -20,7 +20,7 @@ use crate::{
             metrics::{
                 update_attributes_build_duration_metrics, update_block_build_duration_metrics,
             },
-            origin_selector::OriginSelector,
+            origin_selector::{L1OriginSelectorError, OriginSelector},
             recovery::RecoveryModeGuard,
         },
     },
@@ -121,6 +121,15 @@ impl<A: AttributesBuilder, O: OriginSelector, E: SequencerEngineClient> PayloadB
             .await
         {
             Ok(l1_origin) => l1_origin,
+            Err(L1OriginSelectorError::OriginNotFound(hash)) => {
+                warn!(
+                    target: "sequencer",
+                    hash = %hash,
+                    "L1 origin block not found (reorg or sync lag), triggering engine reset"
+                );
+                self.engine_client.reset_engine_forkchoice().await?;
+                return Ok(None);
+            }
             Err(err) => {
                 warn!(
                     target: "sequencer",

--- a/crates/consensus/service/src/actors/sequencer/origin_selector.rs
+++ b/crates/consensus/service/src/actors/sequencer/origin_selector.rs
@@ -381,10 +381,7 @@ mod tests {
                 timestamp: 2,
                 ..Default::default()
             },
-            l1_origin: NumHash {
-                number: 0,
-                hash: B256::with_last_byte(42),
-            },
+            l1_origin: NumHash { number: 0, hash: B256::with_last_byte(42) },
             seq_num: 0,
         };
 

--- a/crates/consensus/service/src/actors/sequencer/origin_selector.rs
+++ b/crates/consensus/service/src/actors/sequencer/origin_selector.rs
@@ -71,7 +71,7 @@ impl<P: L1OriginSelectorProvider + Send + Sync> OriginSelector for L1OriginSelec
         }
 
         let Some(current) = self.current else {
-            unreachable!("Current L1 origin should always be set by `select_origins`");
+            return Err(L1OriginSelectorError::OriginNotFound(unsafe_head.l1_origin.hash));
         };
 
         let max_seq_drift = self.cfg.max_sequencer_drift(current.timestamp);
@@ -186,6 +186,9 @@ pub enum L1OriginSelectorError {
         "Waiting for more L1 data to be available to select the next L1 origin block. Current L1 origin: {0:?}"
     )]
     NotEnoughData(BlockInfo),
+    /// The L1 origin block was not found by its hash, e.g. during an L1 reorg or sync lag.
+    #[error("L1 origin block not found by hash: {0}")]
+    OriginNotFound(B256),
 }
 
 /// L1 [`BlockInfo`] provider interface for the [`L1OriginSelector`].
@@ -355,6 +358,40 @@ mod tests {
             assert_eq!(next.hash, B256::with_last_byte(expected_epoch as u8));
             assert_eq!(next.number, expected_epoch);
         }
+    }
+
+    /// Tests that [`L1OriginSelectorError::OriginNotFound`] is returned (rather than a panic)
+    /// when the L1 provider cannot find the current origin block by hash, e.g. after a reorg.
+    #[tokio::test]
+    async fn test_next_l1_origin_not_found() {
+        let cfg = Arc::new(RollupConfig {
+            block_time: 2,
+            max_sequencer_drift: 600,
+            ..Default::default()
+        });
+
+        // Provider has no blocks, simulating a block disappearing due to an L1 reorg.
+        let provider = MockOriginSelectorProvider::default();
+        let mut selector = L1OriginSelector::new(Arc::clone(&cfg), provider);
+
+        let unsafe_head = L2BlockInfo {
+            block_info: BlockInfo {
+                hash: B256::with_last_byte(1),
+                number: 1,
+                timestamp: 2,
+                ..Default::default()
+            },
+            l1_origin: NumHash {
+                number: 0,
+                hash: B256::with_last_byte(42),
+            },
+            seq_num: 0,
+        };
+
+        let err = selector.next_l1_origin(unsafe_head, false).await.unwrap_err();
+        assert!(
+            matches!(err, L1OriginSelectorError::OriginNotFound(h) if h == B256::with_last_byte(42))
+        );
     }
 
     #[tokio::test]

--- a/lychee.toml
+++ b/lychee.toml
@@ -34,6 +34,7 @@ exclude = [
 
     # Moved on main; backport branch retains the old path
     'https://github\.com/base/base/blob/main/crates/alloy/evm/src/spec_id\.rs',
+    'https://github\.com/base/base/blob/main/crates/execution/hardforks/src/chain\.rs',
 
     # Internal / staging sites not meant for link checking
     'https://rustup\.rs/',


### PR DESCRIPTION
## Summary

Backport of #2064 to `releases/v0.7.1`.

The L1 origin selector would panic with `unreachable!()` when `get_block_by_hash` returned `Ok(None)`, which can happen during an L1 reorg or sync lag when a block disappears from the provider before it is fetched. This adds an `OriginNotFound` error variant and replaces the panic with a proper error return. The sequencer's `PayloadBuilder` now handles `OriginNotFound` by triggering an engine reset, matching the same recovery pattern already used for L1 origin consistency mismatches.

**Cherry-picked commits:**
- `ccd0ca390` fix(consensus): handle missing L1 origin block instead of panicking
- `4b012e665` fix fmts

**Conflict resolution:** `build.rs` on `releases/v0.7.1` lacks the metrics imports added on `main` after the branch cut — both import groups were preserved in the merge.