### PR TITLE
refactor(challenger): general clean up

### DIFF
--- a/crates/proof/challenge/Cargo.toml
+++ b/crates/proof/challenge/Cargo.toml
@@ -15,11 +15,29 @@ workspace = true
 # Alloy
 alloy-rlp.workspace = true
 alloy-provider.workspace = true
-alloy-consensus.workspace = true
 alloy-primitives.workspace = true
 alloy-signer-local.workspace = true
 alloy-rpc-types-eth.workspace = true
 alloy-trie = { workspace = true, features = ["std"] }
+alloy-consensus = { workspace = true, optional = true }
+
+# Tx Manager
+base-tx-manager.workspace = true
+
+# Balance Monitor
+base-balance-monitor.workspace = true
+
+# Proof
+base-proof-rpc.workspace = true
+base-zk-client.workspace = true
+base-proof-contracts.workspace = true
+base-proof-primitives = { workspace = true, features = ["rpc-client"] }
+
+# Protocol
+base-protocol.workspace = true
+
+# JSON-RPC
+jsonrpsee.workspace = true
 
 # Async
 tokio.workspace = true
@@ -40,30 +58,6 @@ thiserror.workspace = true
 base-cli-utils.workspace = true
 clap = { workspace = true, features = ["derive", "env"] }
 
-# Contracts
-base-proof-contracts.workspace = true
-
-# Transaction management
-base-tx-manager.workspace = true
-
-# Balance Monitor
-base-balance-monitor.workspace = true
-
-# RPC
-base-proof-rpc.workspace = true
-
-# ZK proof client
-base-zk-client.workspace = true
-
-# Protocol
-base-protocol.workspace = true
-
-# Proof
-base-proof-primitives = { workspace = true, features = ["serde", "std", "rpc-client"] }
-
-# JSON-RPC
-jsonrpsee.workspace = true
-
 # Metrics
 base-metrics.workspace = true
 metrics = { workspace = true, optional = true }
@@ -72,21 +66,17 @@ metrics = { workspace = true, optional = true }
 rustls = { workspace = true, features = ["ring"] }
 
 # Runtime
-base-runtime = { workspace = true, features = ["tokio"] }
-
-# Shutdown
 tokio-util.workspace = true
+base-runtime = { workspace = true, features = ["tokio"] }
 
 # Health
 base-health = { workspace = true, features = ["axum-server"] }
-
-# Derive
-derive_more = { workspace = true, features = ["debug"] }
 
 # Misc
 url.workspace = true
 humantime.workspace = true
 uuid = { workspace = true, features = ["v5"] }
+derive_more = { workspace = true, features = ["debug"] }
 
 # Test utilities (optional)
 serde_json = { workspace = true, optional = true }
@@ -98,4 +88,4 @@ base-challenger = { path = ".", features = ["test-utils"] }
 
 [features]
 metrics = [ "base-metrics/metrics", "base-tx-manager/metrics", "dep:metrics" ]
-test-utils = [ "base-protocol/test-utils", "serde_json" ]
+test-utils = [ "alloy-consensus", "base-protocol/test-utils", "serde_json" ]

--- a/crates/proof/challenge/README.md
+++ b/crates/proof/challenge/README.md
@@ -7,13 +7,19 @@ ZK-proof dispute game challenger.
 
 ## Overview
 
-- **Scanner**: Reads the `DisputeGameFactory` for new dispute games, filtering by `IN_PROGRESS` status and unchallenged state (`zkProver == zero`) to produce `CandidateGame`s for downstream processing.
+- **Driver**: Main polling loop that ties together scanning, validation, proof requests, and dispute submission.
+- **Scanner**: Scans the `DisputeGameFactory` for `IN_PROGRESS` dispute games and classifies each into a `GameCategory` (`InvalidTeeProposal`, `FraudulentZkChallenge`, or `InvalidZkProposal`) based on prover state.
 - **Validator**: Verifies final and intermediate output roots for each `CandidateGame` by fetching L2 block headers and `L2ToL1MessagePasser` storage proofs, recomputing expected roots via `OutputRoot`, and comparing them against onchain claims.
-- **Service**: Lifecycle orchestration for the challenger (init, health, metrics, shutdown).
-- **Config**: Validated runtime configuration with CLI argument parsing.
-- **Health**: HTTP liveness (`/healthz`) and readiness (`/readyz`) probes.
-- **Metrics**: Prometheus metric definitions and recording.
-- **CLI**: Command-line argument parsing and configuration validation.
+- **Pending**: Tracks in-flight proof sessions through a `ProofPhase` lifecycle (`AwaitingProof` → `ReadyToSubmit` or `NeedsRetry`).
+- **Submitter**: Submits dispute transactions onchain (`nullify()` / `challenge()`) for invalid games.
+- **Bond**: Multi-phase bond credit claim lifecycle (`NeedsResolve` → `NeedsUnlock` → `AwaitingDelay` → `NeedsWithdraw`).
+- **Tee**: `L1HeadProvider` trait for resolving L1 block numbers from hashes.
+- **Verify**: Account proof verification against a state root using Merkle Patricia Trie proofs.
+- **Error**: Challenge submission error types.
+- **Service**: Full challenger service lifecycle (init, wiring, driver loop, shutdown).
+- **Config**: Configuration types and validation.
+- **CLI**: CLI argument definitions (`BASE_CHALLENGER_` env-var prefix).
+- **Metrics**: Prometheus metric definitions.
 
 ## Usage
 

--- a/crates/proof/challenge/src/bond.rs
+++ b/crates/proof/challenge/src/bond.rs
@@ -317,18 +317,21 @@ impl<C: Clock> BondManager<C> {
     /// eligibility, returning one entry per evaluated game.
     async fn evaluate_bond_range(
         range: std::ops::Range<u64>,
-        factory_client: &Arc<dyn DisputeGameFactoryClient>,
+        factory_client: &dyn DisputeGameFactoryClient,
         verifier_client: &dyn AggregateVerifierClient,
         claim_addresses: &HashSet<Address>,
         clock: &C,
     ) -> Vec<Option<(Address, Address, Option<BondPhase>)>> {
         stream::iter(range)
-            .map(|i| {
-                let fc = &**factory_client;
-                async move {
-                    Self::evaluate_game_for_bonds(i, fc, verifier_client, claim_addresses, clock)
-                        .await
-                }
+            .map(|i| async move {
+                Self::evaluate_game_for_bonds(
+                    i,
+                    factory_client,
+                    verifier_client,
+                    claim_addresses,
+                    clock,
+                )
+                .await
             })
             .buffer_unordered(GameScanner::SCAN_CONCURRENCY)
             .collect()
@@ -358,8 +361,7 @@ impl<C: Clock> BondManager<C> {
             return Ok(());
         }
 
-        let factory_client = Arc::clone(&self.factory_client);
-        let game_count = factory_client.game_count().await?;
+        let game_count = self.factory_client.game_count().await?;
         if game_count == 0 {
             info!("no games in factory, skipping bond startup scan");
             return Ok(());
@@ -370,27 +372,22 @@ impl<C: Clock> BondManager<C> {
 
         let results = Self::evaluate_bond_range(
             start_index..game_count,
-            &factory_client,
+            &*self.factory_client,
             verifier_client,
             &self.claim_addresses,
             &self.clock,
         )
         .await;
 
-        // Process results sequentially: insert tracked games and resolve the
-        // WETH delay from the first relevant game.
-        for (game_address, bond_recipient, phase) in results.into_iter().flatten() {
-            // Resolve the WETH delay from the first available game,
-            // including already-claimed ones, so that the delay is
-            // bootstrapped as early as possible.
-            if self.weth_delay.is_none()
-                && let Err(e) = self.resolve_weth_delay(verifier_client, game_address).await
-            {
-                warn!(error = %e, "failed to read DelayedWETH delay, will retry later");
-            }
+        // Resolve the WETH delay from the first available game so the
+        // delay is bootstrapped as early as possible.
+        if let Some((game_address, _, _)) = results.iter().flatten().next() {
+            self.ensure_weth_delay(verifier_client, *game_address).await;
+        }
 
+        for (game_address, bond_recipient, phase) in results.into_iter().flatten() {
             let Some(phase) = phase else {
-                continue; // already claimed, skip
+                continue;
             };
 
             info!(
@@ -402,8 +399,6 @@ impl<C: Clock> BondManager<C> {
             self.tracked.insert(game_address, TrackedGame { phase, bond_recipient });
         }
 
-        // Set the discovery watermark so continuous scanning starts from
-        // where startup left off.
         self.bond_scan_head = game_count;
         self.last_full_scan = self.clock.now();
 
@@ -432,8 +427,7 @@ impl<C: Clock> BondManager<C> {
             return Ok(());
         }
 
-        let factory_client = Arc::clone(&self.factory_client);
-        let game_count = factory_client.game_count().await?;
+        let game_count = self.factory_client.game_count().await?;
         if game_count == 0 {
             debug!("no games found, skipping bond discovery scan");
             return Ok(());
@@ -487,7 +481,7 @@ impl<C: Clock> BondManager<C> {
 
         let results = Self::evaluate_bond_range(
             scan_start..scan_end,
-            &factory_client,
+            &*self.factory_client,
             verifier_client,
             &self.claim_addresses,
             &self.clock,
@@ -497,7 +491,6 @@ impl<C: Clock> BondManager<C> {
         let mut discovered = 0u64;
 
         for (game_address, bond_recipient, phase) in results.into_iter().flatten() {
-            // Skip games already being tracked.
             if self.tracked.contains_key(&game_address) {
                 continue;
             }
@@ -505,12 +498,6 @@ impl<C: Clock> BondManager<C> {
             let Some(phase) = phase else {
                 continue;
             };
-
-            if self.weth_delay.is_none()
-                && let Err(e) = self.resolve_weth_delay(verifier_client, game_address).await
-            {
-                warn!(error = %e, "failed to read DelayedWETH delay, will retry later");
-            }
 
             info!(
                 game = %game_address,
@@ -523,8 +510,6 @@ impl<C: Clock> BondManager<C> {
             discovered += 1;
         }
 
-        // Advance watermark to the end of the scanned range (which may
-        // be less than `game_count` when the span was capped).
         self.bond_scan_head = scan_end;
 
         if is_full_rescan {
@@ -556,9 +541,8 @@ impl<C: Clock> BondManager<C> {
         // Lazily resolve the DelayedWETH delay if not yet known.
         if self.weth_delay.is_none()
             && let Some(&game_address) = self.tracked.keys().next()
-            && let Err(e) = self.resolve_weth_delay(verifier_client, game_address).await
         {
-            warn!(error = %e, "failed to resolve DelayedWETH delay, will retry next poll");
+            self.ensure_weth_delay(verifier_client, game_address).await;
         }
 
         let addresses: Vec<Address> = self.tracked.keys().copied().collect();
@@ -619,8 +603,7 @@ impl<C: Clock> BondManager<C> {
                 self.try_unlock(game_address, verifier_client, submitter).await
             }
             BondPhase::AwaitingDelay { unlocked_at } => {
-                let unlocked_at = *unlocked_at;
-                self.check_delay(game_address, unlocked_at)
+                self.check_delay(game_address, *unlocked_at)
             }
             BondPhase::NeedsWithdraw => {
                 self.try_withdraw(game_address, verifier_client, submitter).await
@@ -642,53 +625,52 @@ impl<C: Clock> BondManager<C> {
         verifier_client: &dyn AggregateVerifierClient,
         submitter: &dyn BondTransactionSubmitter,
     ) -> eyre::Result<Option<RemovalReason>> {
-        // Check if already resolved onchain (e.g., someone else called it).
         let status = verifier_client.status(game_address).await?;
-        if status != GameScanner::STATUS_IN_PROGRESS {
+
+        if status == GameScanner::STATUS_IN_PROGRESS {
+            let game_over = verifier_client.game_over(game_address).await?;
+            if !game_over {
+                debug!(game = %game_address, "game dispute period not yet elapsed");
+                return Ok(None);
+            }
+
+            let calldata = encode_resolve_calldata();
+            info!(game = %game_address, "submitting resolve transaction");
+            match submitter.send_bond_tx(game_address, calldata).await {
+                Ok(tx_hash) => {
+                    info!(
+                        game = %game_address,
+                        tx_hash = %tx_hash,
+                        "resolve transaction confirmed"
+                    );
+                    ChallengerMetrics::resolve_tx_outcome_total(ChallengerMetrics::STATUS_SUCCESS)
+                        .increment(1);
+                }
+                Err(e) => {
+                    warn!(
+                        game = %game_address,
+                        error = %e,
+                        "resolve transaction failed, will retry"
+                    );
+                    ChallengerMetrics::resolve_tx_outcome_total(ChallengerMetrics::STATUS_ERROR)
+                        .increment(1);
+                    return Ok(None);
+                }
+            }
+        } else {
             ChallengerMetrics::resolve_tx_outcome_total(ChallengerMetrics::STATUS_ALREADY_RESOLVED)
                 .increment(1);
-
-            // Re-read the onchain bondRecipient — resolve may have changed
-            // it (e.g. to the challenger on CHALLENGER_WINS). If it is no
-            // longer in our claim set, stop tracking this game.
-            if !self.is_bond_claimable(verifier_client, game_address).await? {
-                return Ok(Some(RemovalReason::NotClaimable));
-            }
-
-            info!(game = %game_address, status, "game already resolved, advancing to unlock phase");
-            self.set_phase(game_address, BondPhase::NeedsUnlock);
-            return Ok(None);
+            info!(game = %game_address, status, "game already resolved");
         }
 
-        // Check if the game is ready to resolve.
-        let game_over = verifier_client.game_over(game_address).await?;
-        if !game_over {
-            debug!(game = %game_address, "game dispute period not yet elapsed");
-            return Ok(None);
+        // Re-read the onchain bondRecipient — resolve may have changed it
+        // (e.g. to the challenger on CHALLENGER_WINS). If it is no longer
+        // in our claim set, stop tracking this game.
+        if !self.is_bond_claimable(verifier_client, game_address).await? {
+            return Ok(Some(RemovalReason::NotClaimable));
         }
 
-        // Submit resolve transaction.
-        let calldata = encode_resolve_calldata();
-        info!(game = %game_address, "submitting resolve transaction");
-        match submitter.send_bond_tx(game_address, calldata).await {
-            Ok(tx_hash) => {
-                info!(game = %game_address, tx_hash = %tx_hash, "resolve transaction confirmed");
-                ChallengerMetrics::resolve_tx_outcome_total(ChallengerMetrics::STATUS_SUCCESS)
-                    .increment(1);
-
-                // Re-read bondRecipient to verify it's in our claim set.
-                if !self.is_bond_claimable(verifier_client, game_address).await? {
-                    return Ok(Some(RemovalReason::NotClaimable));
-                }
-
-                self.set_phase(game_address, BondPhase::NeedsUnlock);
-            }
-            Err(e) => {
-                warn!(game = %game_address, error = %e, "resolve transaction failed, will retry");
-                ChallengerMetrics::resolve_tx_outcome_total(ChallengerMetrics::STATUS_ERROR)
-                    .increment(1);
-            }
-        }
+        self.set_phase(game_address, BondPhase::NeedsUnlock);
         Ok(None)
     }
 
@@ -729,20 +711,12 @@ impl<C: Clock> BondManager<C> {
         verifier_client: &dyn AggregateVerifierClient,
         submitter: &dyn BondTransactionSubmitter,
     ) -> eyre::Result<Option<RemovalReason>> {
-        // Check if already unlocked onchain.
-        let unlocked = verifier_client.bond_unlocked(game_address).await?;
+        let (unlocked, resolved_at) = futures::try_join!(
+            verifier_client.bond_unlocked(game_address),
+            verifier_client.resolved_at(game_address),
+        )?;
         if unlocked {
-            // Use `resolved_at` as a conservative lower bound for the unlock
-            // time. The unlock must have occurred after resolve, so this may
-            // cause one early withdrawal attempt that reverts, but is strictly
-            // better than resetting to "now" (which would re-impose the full
-            // delay after every restart).
-            let resolved_at = verifier_client.resolved_at(game_address).await?;
-            let unlocked_at = Self::unix_to_monotonic(
-                &self.clock,
-                resolved_at,
-                self.clock.wall_clock_unix_secs(),
-            );
+            let unlocked_at = Self::estimate_unlock_time(&self.clock, resolved_at);
             info!(
                 game = %game_address,
                 resolved_at,
@@ -772,7 +746,7 @@ impl<C: Clock> BondManager<C> {
         // succeed earlier than expected. If longer, the attempt will revert
         // and be retried on the next poll tick.
         let delay = self.weth_delay.unwrap_or_else(|| {
-            warn!(game = %game_address, "WETH delay not yet known, using default 7 days");
+            debug!(game = %game_address, "WETH delay not yet known, using default 7 days");
             Self::DEFAULT_WETH_DELAY
         });
 
@@ -803,11 +777,9 @@ impl<C: Clock> BondManager<C> {
         verifier_client: &dyn AggregateVerifierClient,
         submitter: &dyn BondTransactionSubmitter,
     ) -> eyre::Result<Option<RemovalReason>> {
-        // Check if already claimed onchain.
         let claimed = verifier_client.bond_claimed(game_address).await?;
         if claimed {
             info!(game = %game_address, "bond already claimed");
-            self.set_phase(game_address, BondPhase::Completed);
             return Ok(Some(RemovalReason::Completed));
         }
 
@@ -876,6 +848,15 @@ impl<C: Clock> BondManager<C> {
         clock.now().saturating_sub(age)
     }
 
+    /// Estimates when the bond was unlocked using `resolved_at` as a
+    /// conservative lower bound. The unlock must have occurred after
+    /// resolve, so this may cause one early withdrawal attempt that
+    /// reverts, but is strictly better than resetting to "now" (which
+    /// would re-impose the full delay after every restart).
+    fn estimate_unlock_time(clock: &C, resolved_at: u64) -> Duration {
+        Self::unix_to_monotonic(clock, resolved_at, clock.wall_clock_unix_secs())
+    }
+
     /// Determines the bond phase from onchain state.
     ///
     /// Returns `None` if the bond has already been fully claimed. Otherwise
@@ -888,22 +869,16 @@ impl<C: Clock> BondManager<C> {
         game_address: Address,
         clock: &C,
     ) -> eyre::Result<Option<BondPhase>> {
-        let bond_claimed = verifier_client.bond_claimed(game_address).await?;
+        let (bond_claimed, resolved_at, bond_unlocked) = futures::try_join!(
+            verifier_client.bond_claimed(game_address),
+            verifier_client.resolved_at(game_address),
+            verifier_client.bond_unlocked(game_address),
+        )?;
         if bond_claimed {
             return Ok(None);
         }
-
-        let resolved_at = verifier_client.resolved_at(game_address).await?;
-
-        let bond_unlocked = verifier_client.bond_unlocked(game_address).await?;
         if bond_unlocked {
-            // Use `resolved_at` as a conservative lower bound for the unlock
-            // time. The unlock must have occurred after resolve, so this may
-            // cause one early withdrawal attempt that reverts, but is strictly
-            // better than resetting to "now" (which would re-impose the full
-            // delay after every restart).
-            let unlocked_at =
-                Self::unix_to_monotonic(clock, resolved_at, clock.wall_clock_unix_secs());
+            let unlocked_at = Self::estimate_unlock_time(clock, resolved_at);
             return Ok(Some(BondPhase::AwaitingDelay { unlocked_at }));
         }
 
@@ -912,6 +887,19 @@ impl<C: Clock> BondManager<C> {
         }
 
         Ok(Some(BondPhase::NeedsResolve))
+    }
+
+    /// Resolves the `DelayedWETH` delay if not yet known, logging on failure.
+    async fn ensure_weth_delay(
+        &mut self,
+        verifier_client: &dyn AggregateVerifierClient,
+        game_address: Address,
+    ) {
+        if self.weth_delay.is_none()
+            && let Err(e) = self.resolve_weth_delay(verifier_client, game_address).await
+        {
+            warn!(error = %e, "failed to read DelayedWETH delay, will retry later");
+        }
     }
 
     /// Reads the `DelayedWETH` address from a game proxy and fetches the delay.
@@ -951,7 +939,10 @@ mod tests {
     use futures::stream::BoxStream;
 
     use super::*;
-    use crate::test_utils::{MockDisputeGameFactory, TEST_DISCOVERY_INTERVAL, empty_factory};
+    use crate::test_utils::{
+        MockAggregateVerifier, MockBondTransactionSubmitter, MockDisputeGameFactory,
+        TEST_DISCOVERY_INTERVAL, addr, empty_factory, factory_game, mock_state,
+    };
 
     /// A deterministic clock that always returns fixed values.
     ///
@@ -1148,10 +1139,6 @@ mod tests {
     }
 
     // ---- discover_claimable_games tests ----
-
-    use crate::test_utils::{
-        MockAggregateVerifier, MockBondTransactionSubmitter, addr, factory_game, mock_state,
-    };
 
     /// Builds a factory and verifier pair where each game has the given
     /// `bond_recipient` and `zk_prover`. All games are `IN_PROGRESS` (status 0)

--- a/crates/proof/challenge/src/config.rs
+++ b/crates/proof/challenge/src/config.rs
@@ -74,7 +74,7 @@ pub enum ConfigError {
     Metrics(&'static str),
     /// Invalid signing configuration.
     #[error("invalid signing config: {0}")]
-    Signer(#[from] base_tx_manager::ConfigError),
+    Signer(base_tx_manager::ConfigError),
     /// Invalid transaction manager configuration.
     #[error("invalid tx manager config: {0}")]
     TxManager(base_tx_manager::ConfigError),
@@ -194,7 +194,7 @@ impl ChallengerConfig {
             ));
         }
 
-        let signing = SignerConfig::try_from(cli.challenger.signer)?;
+        let signing = SignerConfig::try_from(cli.challenger.signer).map_err(ConfigError::Signer)?;
 
         let tx_manager =
             TxManagerConfig::try_from(cli.challenger.tx_manager).map_err(ConfigError::TxManager)?;

--- a/crates/proof/challenge/src/error.rs
+++ b/crates/proof/challenge/src/error.rs
@@ -7,8 +7,8 @@ use thiserror::Error;
 /// Errors that can occur when submitting a challenge transaction.
 #[derive(Debug, Error)]
 pub enum ChallengeSubmitError {
-    /// The nullify transaction was mined but reverted on-chain.
-    #[error("nullify transaction reverted: {tx_hash}")]
+    /// A transaction was mined but reverted on-chain.
+    #[error("transaction reverted: {tx_hash}")]
     TxReverted {
         /// Hash of the reverted transaction.
         tx_hash: B256,

--- a/crates/proof/challenge/src/lib.rs
+++ b/crates/proof/challenge/src/lib.rs
@@ -34,7 +34,7 @@ mod submitter;
 pub use submitter::ChallengeSubmitter;
 
 mod tee;
-pub use tee::{L1HeadProvider, RpcL1HeadProvider};
+pub use tee::L1HeadProvider;
 
 mod validator;
 pub use validator::{
@@ -42,7 +42,7 @@ pub use validator::{
 };
 
 mod verify;
-pub use verify::{AccountProofError, verify_account_proof};
+pub use verify::{AccountProofError, AccountProofVerifier};
 
 mod bond;
 pub use bond::{BondManager, BondPhase, BondTransactionSubmitter, RemovalReason, TrackedGame};

--- a/crates/proof/challenge/src/pending.rs
+++ b/crates/proof/challenge/src/pending.rs
@@ -10,14 +10,12 @@
 use std::collections::HashMap;
 
 use alloy_primitives::{Address, B256, Bytes};
+use base_proof_primitives::PROOF_TYPE_ZK;
 use base_zk_client::{
     GetProofRequest, ProofJobStatus, ProveBlockRequest, ReceiptType, ZkProofProvider,
 };
 use tracing::warn;
 use uuid::Uuid;
-
-/// Proof type byte for ZK proofs (matches `AggregateVerifier.nullify` discriminator: `0` = TEE, `1` = ZK).
-const ZK_PROOF_TYPE_BYTE: u8 = 0x01;
 
 /// The kind of proof being generated.
 #[derive(Debug, Clone)]
@@ -154,22 +152,6 @@ impl PendingProof {
         }
     }
 
-    /// Returns the session ID if the proof is in the `AwaitingProof` phase.
-    pub fn session_id(&self) -> Option<&str> {
-        match &self.phase {
-            ProofPhase::AwaitingProof { session_id } => Some(session_id),
-            _ => None,
-        }
-    }
-
-    /// Returns the proof bytes if the proof is in the `ReadyToSubmit` phase.
-    pub const fn proof_bytes(&self) -> Option<&Bytes> {
-        match &self.phase {
-            ProofPhase::ReadyToSubmit { proof_bytes } => Some(proof_bytes),
-            _ => None,
-        }
-    }
-
     /// Returns `true` if the proof is in the `ReadyToSubmit` phase.
     pub const fn is_ready(&self) -> bool {
         matches!(self.phase, ProofPhase::ReadyToSubmit { .. })
@@ -177,7 +159,7 @@ impl PendingProof {
 }
 
 /// Collection of in-flight proof sessions keyed by dispute-game address.
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Default)]
 pub struct PendingProofs(HashMap<Address, PendingProof>);
 
 impl PendingProofs {
@@ -273,13 +255,14 @@ impl PendingProofs {
         let update = match status {
             ProofJobStatus::Succeeded => {
                 let mut raw = Vec::with_capacity(1 + response.receipt.len());
-                raw.push(ZK_PROOF_TYPE_BYTE);
+                raw.push(PROOF_TYPE_ZK);
                 raw.extend_from_slice(&response.receipt);
                 let proof_bytes = Bytes::from(raw);
+                let update = ProofUpdate::Ready(proof_bytes.clone());
 
-                pending.phase = ProofPhase::ReadyToSubmit { proof_bytes: proof_bytes.clone() };
+                pending.phase = ProofPhase::ReadyToSubmit { proof_bytes };
 
-                ProofUpdate::Ready(proof_bytes)
+                update
             }
             ProofJobStatus::Failed => {
                 warn!(game = %game, error_message = ?response.error_message, "proof job failed");

--- a/crates/proof/challenge/src/scanner.rs
+++ b/crates/proof/challenge/src/scanner.rs
@@ -202,15 +202,12 @@ impl GameScanner {
             }
         }
 
-        candidates.sort_by_key(|c| c.index);
+        candidates.sort_unstable_by_key(|c| c.index);
 
         ChallengerMetrics::games_scanned_total().increment(games_to_scan);
 
-        let new_last_scanned = match lowest_error {
-            Some(0) => last_scanned,
-            Some(e) => Some(e - 1),
-            None => Some(end),
-        };
+        let new_last_scanned =
+            lowest_error.map_or(Some(end), |e| e.checked_sub(1).or(last_scanned));
 
         if let Some(head) = new_last_scanned {
             ChallengerMetrics::scan_head().set(head as f64);
@@ -241,30 +238,30 @@ impl GameScanner {
             return Ok(None);
         }
 
-        // Phase 1: fetch only the fields needed for classification.
+        // Fetch classification fields only for in-progress games.
         let (zk_prover, tee_prover, countered_index) = tokio::try_join!(
             self.verifier_client.zk_prover(factory.proxy),
             self.verifier_client.tee_prover(factory.proxy),
             self.verifier_client.countered_index(factory.proxy),
         )?;
 
-        // Classify the game based on its prover state. Return early for
-        // non-actionable games to avoid the remaining RPC calls.
-        let category = Self::classify(index, tee_prover, zk_prover, countered_index);
-        let category = match category {
+        let category = match Self::classify(index, tee_prover, zk_prover, countered_index) {
             Some(c) => c,
             None => return Ok(None),
         };
 
-        // Phase 2: fetch the remaining fields only for actionable games.
-        let (info, starting_block_number, l1_head) = tokio::try_join!(
-            self.verifier_client.game_info(factory.proxy),
-            self.verifier_client.starting_block_number(factory.proxy),
-            self.verifier_client.l1_head(factory.proxy),
+        // Fetch remaining fields only for actionable games.
+        let ((info, starting_block_number, l1_head), intermediate_block_interval) = tokio::try_join!(
+            async {
+                tokio::try_join!(
+                    self.verifier_client.game_info(factory.proxy),
+                    self.verifier_client.starting_block_number(factory.proxy),
+                    self.verifier_client.l1_head(factory.proxy),
+                )
+                .map_err(Into::into)
+            },
+            self.resolve_intermediate_block_interval(factory.game_type),
         )?;
-
-        let intermediate_block_interval =
-            self.resolve_intermediate_block_interval(factory.game_type).await?;
 
         Ok(Some(CandidateGame {
             index,
@@ -293,9 +290,14 @@ impl GameScanner {
             // Path 1: TEE-proposed, unchallenged.
             (true, false, 0) => Some(GameCategory::InvalidTeeProposal),
 
-            // Path 2: TEE-proposed and challenged by ZK.
-            (true, true, ci) if ci > 0 => {
-                Some(GameCategory::FraudulentZkChallenge { challenged_index: ci - 1 })
+            // TEE-only game with a non-zero countered_index — unexpected state.
+            (true, false, ci) => {
+                debug!(
+                    index = index,
+                    countered_index = ci,
+                    "skipping TEE-only game with unexpected non-zero countered_index"
+                );
+                None
             }
 
             // TEE + ZK present but no countered index — second proof was added
@@ -305,12 +307,17 @@ impl GameScanner {
                 None
             }
 
+            // Path 2: TEE-proposed and challenged by ZK.
+            (true, true, ci) => {
+                debug_assert!(ci > 0, "ci == 0 should be handled by (true, true, 0) arm");
+                Some(GameCategory::FraudulentZkChallenge { challenged_index: ci - 1 })
+            }
+
             // Path 3: ZK-proposed, unchallenged.
             (false, true, 0) => Some(GameCategory::InvalidZkProposal),
 
             // ZK-only game with a non-zero countered_index — unexpected state.
-            // A ZK-proposed game should not have a challenge counter set.
-            (false, true, ci) if ci > 0 => {
+            (false, true, ci) => {
                 debug!(
                     index = index,
                     countered_index = ci,
@@ -322,18 +329,6 @@ impl GameScanner {
             // Both provers zeroed — already nullified.
             (false, false, _) => {
                 debug!(index = index, "skipping nullified game (both provers zeroed)");
-                None
-            }
-
-            // Defensive catch-all for any state not covered above.
-            _ => {
-                debug!(
-                    index = index,
-                    has_tee = has_tee,
-                    has_zk = has_zk,
-                    countered_index = countered_index,
-                    "skipping game in unexpected state"
-                );
                 None
             }
         }

--- a/crates/proof/challenge/src/service.rs
+++ b/crates/proof/challenge/src/service.rs
@@ -5,7 +5,7 @@ use std::sync::{
     atomic::{AtomicBool, Ordering},
 };
 
-use alloy_provider::{Provider, ProviderBuilder, RootProvider};
+use alloy_provider::{Provider, ProviderBuilder};
 use base_balance_monitor::BalanceMonitorLayer;
 use base_cli_utils::RuntimeManager;
 use base_health::HealthServer;
@@ -13,7 +13,7 @@ use base_proof_contracts::{
     AggregateVerifierClient, AggregateVerifierContractClient, DisputeGameFactoryClient,
     DisputeGameFactoryContractClient,
 };
-use base_proof_rpc::{L2Client, L2ClientConfig};
+use base_proof_rpc::{L1Client, L1ClientConfig, L2Client, L2ClientConfig};
 use base_runtime::TokioRuntime;
 use base_tx_manager::{BaseTxMetrics, SimpleTxManager};
 use base_zk_client::{ZkProofClient, ZkProofClientConfig};
@@ -74,26 +74,24 @@ impl ChallengerService {
         // ── 3. Construct tx-manager and challenge submitter ──────────────────
         let signer_config = config.signing;
         let sender_addr = signer_config.address();
+        let l1_rpc_url = config.l1_eth_rpc.as_ref().clone();
         let l1_provider = if config.metrics.enabled {
-            let (layer, balance_rx) = BalanceMonitorLayer::new(
+            let (layer, mut balance_rx) = BalanceMonitorLayer::new(
                 sender_addr,
                 cancel.clone(),
                 BalanceMonitorLayer::DEFAULT_POLL_INTERVAL,
             );
-            let provider = ProviderBuilder::new()
-                .layer(layer)
-                .connect_http(config.l1_eth_rpc.as_ref().clone());
+            let provider = ProviderBuilder::new().layer(layer).connect_http(l1_rpc_url.clone());
             tokio::spawn(async move {
-                let mut rx = balance_rx;
-                while rx.changed().await.is_ok() {
+                while balance_rx.changed().await.is_ok() {
                     ChallengerMetrics::account_balance_wei()
-                        .set(f64::from(*rx.borrow_and_update()));
+                        .set(f64::from(*balance_rx.borrow_and_update()));
                 }
             });
             info!(%sender_addr, "Balance monitor started");
             provider
         } else {
-            ProviderBuilder::new().connect_http(config.l1_eth_rpc.as_ref().clone())
+            ProviderBuilder::new().connect_http(l1_rpc_url.clone())
         };
         let chain_id = l1_provider
             .get_chain_id()
@@ -113,15 +111,14 @@ impl ChallengerService {
         // ── 4. Contract clients and onchain config ───────────────────────────
         let factory_client = DisputeGameFactoryContractClient::new(
             config.dispute_game_factory_addr,
-            config.l1_eth_rpc.as_ref().clone(),
+            l1_rpc_url.clone(),
         )?;
         info!(
             address = %config.dispute_game_factory_addr,
             "DisputeGameFactory client initialized"
         );
 
-        let verifier_client =
-            AggregateVerifierContractClient::new(config.l1_eth_rpc.as_ref().clone())?;
+        let verifier_client = AggregateVerifierContractClient::new(l1_rpc_url.clone())?;
 
         let factory_client = Arc::new(factory_client);
         let verifier_client: Arc<dyn AggregateVerifierClient> = Arc::new(verifier_client);
@@ -141,7 +138,7 @@ impl ChallengerService {
         info!(endpoint = %config.zk_rpc_url, "ZK proof client initialized");
 
         // ── 6b. TEE proof client (optional) ─────────────────────────────────
-        let tee: Option<crate::TeeConfig> = if let Some(ref tee_url) = config.tee_rpc_url {
+        let tee = if let Some(ref tee_url) = config.tee_rpc_url {
             let request_timeout = config.tee_request_timeout.ok_or_else(|| {
                 eyre::eyre!("tee_request_timeout must be set when tee_rpc_url is configured")
             })?;
@@ -150,10 +147,12 @@ impl ChallengerService {
                 .build(tee_url.as_str())
                 .map_err(|e| eyre::eyre!("failed to create TEE RPC client: {e}"))?;
             info!(endpoint = %tee_url, "TEE proof client initialized");
-            let tee_l1_provider = RootProvider::new_http(config.l1_eth_rpc.as_ref().clone());
+            let l1_config = L1ClientConfig::new(l1_rpc_url.clone());
+            let l1_client = L1Client::new(l1_config)
+                .map_err(|e| eyre::eyre!("failed to create TEE L1 client: {e}"))?;
             Some(crate::TeeConfig {
                 provider: Arc::new(client),
-                l1_head_provider: Arc::new(crate::RpcL1HeadProvider::new(tee_l1_provider)),
+                l1_head_provider: Arc::new(l1_client),
                 request_timeout,
             })
         } else {
@@ -166,7 +165,6 @@ impl ChallengerService {
 
         // ── 7b. Bond manager (optional) ─────────────────────────────────────
         let bond_manager = if !config.bond_claim_addresses.is_empty() {
-            let l1_rpc_url = config.l1_eth_rpc.as_ref().clone();
             let mut bm = BondManager::new(
                 config.bond_claim_addresses,
                 l1_rpc_url,

--- a/crates/proof/challenge/src/submitter.rs
+++ b/crates/proof/challenge/src/submitter.rs
@@ -13,7 +13,7 @@ use std::time::Instant;
 use alloy_primitives::{Address, B256, Bytes, U256};
 use base_proof_contracts::{encode_challenge_calldata, encode_nullify_calldata};
 use base_tx_manager::{TxCandidate, TxManager};
-use tracing::info;
+use tracing::{debug, info};
 
 use crate::{BondTransactionSubmitter, ChallengeSubmitError, ChallengerMetrics, DisputeIntent};
 
@@ -84,7 +84,7 @@ impl<T: TxManager> ChallengeSubmitter<T> {
             ..Default::default()
         };
 
-        info!(
+        debug!(
             tx = ?candidate,
             "sending tx candidate",
         );
@@ -94,10 +94,10 @@ impl<T: TxManager> ChallengeSubmitter<T> {
         let result = self.tx_manager.send(candidate).await;
         let latency = start.elapsed();
 
-        let status_label = match &result {
-            Ok(receipt) if receipt.inner.status() => ChallengerMetrics::STATUS_SUCCESS,
-            Ok(_) => ChallengerMetrics::STATUS_REVERTED,
-            Err(_) => ChallengerMetrics::STATUS_ERROR,
+        let (status_label, succeeded) = match &result {
+            Ok(receipt) if receipt.inner.status() => (ChallengerMetrics::STATUS_SUCCESS, true),
+            Ok(_) => (ChallengerMetrics::STATUS_REVERTED, false),
+            Err(_) => (ChallengerMetrics::STATUS_ERROR, false),
         };
         intent.record_outcome(status_label);
         intent.record_latency(latency.as_secs_f64());
@@ -105,7 +105,7 @@ impl<T: TxManager> ChallengeSubmitter<T> {
         let receipt = result?;
         let tx_hash = receipt.transaction_hash;
 
-        if !receipt.inner.status() {
+        if !succeeded {
             return Err(ChallengeSubmitError::TxReverted { tx_hash });
         }
 

--- a/crates/proof/challenge/src/tee.rs
+++ b/crates/proof/challenge/src/tee.rs
@@ -1,37 +1,22 @@
-//! L1 head provider abstraction for fetching L1 block information.
+//! L1 head provider abstraction for resolving block numbers from hashes.
 
 use alloy_primitives::B256;
-use alloy_provider::{Provider, RootProvider};
 use async_trait::async_trait;
+use base_proof_rpc::L1Provider;
 
-/// Trait for fetching L1 block information.
+/// Trait for resolving an L1 block number from its hash.
 #[async_trait]
 pub trait L1HeadProvider: Send + Sync + std::fmt::Debug {
     /// Returns the block number for the given L1 block hash.
     async fn block_number_by_hash(&self, hash: B256) -> eyre::Result<u64>;
 }
 
-/// [`L1HeadProvider`] backed by an RPC [`RootProvider`].
-#[derive(Debug)]
-pub struct RpcL1HeadProvider {
-    provider: RootProvider,
-}
-
-impl RpcL1HeadProvider {
-    /// Creates a new provider wrapping the given RPC root provider.
-    pub const fn new(provider: RootProvider) -> Self {
-        Self { provider }
-    }
-}
-
+/// Blanket implementation: any [`L1Provider`] that is also [`Debug`] can serve
+/// as an [`L1HeadProvider`] by delegating to [`L1Provider::header_by_hash`].
 #[async_trait]
-impl L1HeadProvider for RpcL1HeadProvider {
+impl<T: L1Provider + std::fmt::Debug> L1HeadProvider for T {
     async fn block_number_by_hash(&self, hash: B256) -> eyre::Result<u64> {
-        let block = self
-            .provider
-            .get_block_by_hash(hash)
-            .await?
-            .ok_or_else(|| eyre::eyre!("L1 block not found for hash {hash}"))?;
-        Ok(block.header.number)
+        let header = self.header_by_hash(hash).await?;
+        Ok(header.number)
     }
 }

--- a/crates/proof/challenge/src/test_utils.rs
+++ b/crates/proof/challenge/src/test_utils.rs
@@ -332,7 +332,7 @@ impl DisputeGameFactoryClient for ErrorOnIndexFactory {
 /// Returns pre-configured headers by block number and account proofs by
 /// block hash. Block numbers in `error_blocks` will return a
 /// [`RpcError::BlockNotFound`] to simulate missing blocks.
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct MockL2Provider {
     /// Headers keyed by block number.
     pub headers: HashMap<u64, RpcHeader>,
@@ -345,7 +345,7 @@ pub struct MockL2Provider {
 impl MockL2Provider {
     /// Creates a new empty mock L2 provider.
     pub fn new() -> Self {
-        Self { headers: HashMap::new(), proofs: HashMap::new(), error_blocks: Vec::new() }
+        Self::default()
     }
 
     /// Inserts a block header and corresponding account proof.
@@ -363,12 +363,6 @@ impl MockL2Provider {
             RpcHeader { hash: block_hash, inner: consensus_header, ..Default::default() };
         self.headers.insert(block_number, rpc_header);
         self.proofs.insert(block_hash, account_result);
-    }
-}
-
-impl Default for MockL2Provider {
-    fn default() -> Self {
-        Self::new()
     }
 }
 
@@ -410,16 +404,29 @@ impl L2Provider for MockL2Provider {
 }
 
 /// Mock ZK proof provider for testing the driver.
-#[derive(Debug, Default)]
+#[derive(Debug)]
 pub struct MockZkProofProvider {
     /// Session ID returned by [`prove_block`](ZkProofProvider::prove_block).
     pub session_id: String,
+    /// Mutable proof state returned by [`get_proof`](ZkProofProvider::get_proof).
+    pub state: Mutex<MockZkProofState>,
+}
+
+/// Mutable state for [`MockZkProofProvider`].
+#[derive(Debug, Default, Clone)]
+pub struct MockZkProofState {
     /// Proof job status returned by [`get_proof`](ZkProofProvider::get_proof).
-    pub proof_status: Mutex<i32>,
+    pub proof_status: i32,
     /// Proof receipt bytes returned when status is `Succeeded`.
-    pub receipt: Mutex<Vec<u8>>,
+    pub receipt: Vec<u8>,
     /// Error message returned when status is `Failed`.
-    pub error_message: Mutex<Option<String>>,
+    pub error_message: Option<String>,
+}
+
+impl Default for MockZkProofProvider {
+    fn default() -> Self {
+        Self { session_id: String::new(), state: Mutex::new(MockZkProofState::default()) }
+    }
 }
 
 #[async_trait]
@@ -432,10 +439,12 @@ impl ZkProofProvider for MockZkProofProvider {
     }
 
     async fn get_proof(&self, _request: GetProofRequest) -> Result<GetProofResponse, ZkProofError> {
-        let status = *self.proof_status.lock().unwrap();
-        let receipt = self.receipt.lock().unwrap().clone();
-        let error_message = self.error_message.lock().unwrap().clone();
-        Ok(GetProofResponse { status, receipt, error_message })
+        let state = self.state.lock().unwrap().clone();
+        Ok(GetProofResponse {
+            status: state.proof_status,
+            receipt: state.receipt,
+            error_message: state.error_message,
+        })
     }
 }
 
@@ -449,16 +458,12 @@ pub struct MockTeeProofProvider {
 impl MockTeeProofProvider {
     /// Creates a mock that returns a single successful result.
     pub fn success(result: ProofResult) -> Self {
-        let mut q = VecDeque::new();
-        q.push_back(Ok(result));
-        Self { results: Mutex::new(q) }
+        Self { results: Mutex::new(VecDeque::from([Ok(result)])) }
     }
 
     /// Creates a mock that returns a single error.
     pub fn failure(msg: &str) -> Self {
-        let mut q = VecDeque::new();
-        q.push_back(Err(msg.into()));
-        Self { results: Mutex::new(q) }
+        Self { results: Mutex::new(VecDeque::from([Err(msg.into())])) }
     }
 }
 
@@ -486,16 +491,14 @@ impl MockL1HeadProvider {
     /// Creates a mock whose [`block_number_by_hash`](L1HeadProvider::block_number_by_hash)
     /// returns `number` and asserts it is called with `hash`.
     pub fn success(hash: B256, number: u64) -> Self {
-        let mut bq = VecDeque::new();
-        bq.push_back((Some(hash), Ok(number)));
-        Self { block_number_results: Mutex::new(bq) }
+        Self { block_number_results: Mutex::new(VecDeque::from([(Some(hash), Ok(number))])) }
     }
 
     /// Creates a mock that returns a single error.
     pub fn failure(msg: &str) -> Self {
-        let mut bq = VecDeque::new();
-        bq.push_back((None, Err(eyre::eyre!("{msg}"))));
-        Self { block_number_results: Mutex::new(bq) }
+        Self {
+            block_number_results: Mutex::new(VecDeque::from([(None, Err(eyre::eyre!("{msg}")))])),
+        }
     }
 }
 
@@ -528,9 +531,7 @@ pub struct MockTxManager {
 impl MockTxManager {
     /// Creates a new mock with a single pre-configured response.
     pub fn new(response: SendResponse) -> Self {
-        let mut q = VecDeque::new();
-        q.push_back(response);
-        Self { responses: Mutex::new(q) }
+        Self { responses: Mutex::new(VecDeque::from([response])) }
     }
 
     /// Creates a new mock with multiple responses returned in order.
@@ -630,9 +631,7 @@ pub struct MockBondTransactionSubmitter {
 impl MockBondTransactionSubmitter {
     /// Creates a mock that returns a single successful transaction hash.
     pub fn success(tx_hash: B256) -> Self {
-        let mut q = VecDeque::new();
-        q.push_back(Ok(tx_hash));
-        Self { responses: Mutex::new(q), calls: Mutex::new(Vec::new()) }
+        Self { responses: Mutex::new(VecDeque::from([Ok(tx_hash)])), calls: Mutex::new(Vec::new()) }
     }
 
     /// Creates a mock with multiple responses returned in order.
@@ -666,7 +665,7 @@ impl crate::BondTransactionSubmitter for MockBondTransactionSubmitter {
 mod tests {
 
     use super::*;
-    use crate::scanner::{GameScanner, ScannerConfig};
+    use crate::scanner::{GameCategory, GameScanner, ScannerConfig};
 
     /// Happy path: mixed games, only `IN_PROGRESS` / unchallenged returned.
     #[tokio::test]
@@ -941,8 +940,6 @@ mod tests {
     /// returned as a [`GameCategory::FraudulentZkChallenge`] candidate.
     #[tokio::test]
     async fn test_scan_challenged_game_returns_fraudulent_zk_challenge() {
-        use crate::scanner::GameCategory;
-
         let tee_addr = Address::repeat_byte(0xEE);
         let zk_addr = Address::repeat_byte(0xCC);
 
@@ -969,8 +966,6 @@ mod tests {
     /// returned as a [`GameCategory::InvalidZkProposal`] candidate.
     #[tokio::test]
     async fn test_scan_zk_proposal_returns_invalid_zk_proposal() {
-        use crate::scanner::GameCategory;
-
         let zk_addr = Address::repeat_byte(0xCC);
 
         let factory = Arc::new(MockDisputeGameFactory { games: vec![factory_game(0, 1)] });
@@ -992,8 +987,6 @@ mod tests {
     /// [`GameCategory::InvalidTeeProposal`].
     #[tokio::test]
     async fn test_scan_tee_proposal_returns_invalid_tee_proposal() {
-        use crate::scanner::GameCategory;
-
         let factory = Arc::new(MockDisputeGameFactory { games: vec![factory_game(0, 1)] });
 
         let mut verifier_games = HashMap::new();

--- a/crates/proof/challenge/src/validator.rs
+++ b/crates/proof/challenge/src/validator.rs
@@ -6,7 +6,7 @@
 //! [`OutputRoot`](base_protocol::OutputRoot), and compares them against the
 //! onchain claims.
 
-use std::{sync::Arc, time::Instant};
+use std::sync::Arc;
 
 use alloy_primitives::{Address, B256};
 use base_proof_rpc::{L2Provider, RpcError};
@@ -15,7 +15,7 @@ use futures::stream::{self, StreamExt};
 use thiserror::Error;
 use tracing::{info, warn};
 
-use crate::{ChallengerMetrics, verify_account_proof};
+use crate::{AccountProofVerifier, ChallengerMetrics};
 
 /// Errors that can occur during output root validation.
 #[derive(Debug, Error)]
@@ -132,15 +132,6 @@ struct Checkpoint {
     claimed_root: B256,
 }
 
-/// RAII guard that records the validation latency histogram on drop.
-struct RecordOnDrop(Instant);
-
-impl Drop for RecordOnDrop {
-    fn drop(&mut self) {
-        ChallengerMetrics::validation_latency_seconds().record(self.0.elapsed().as_secs_f64());
-    }
-}
-
 /// Validates output roots for candidate dispute games.
 ///
 /// Fetches L2 block headers and `L2ToL1MessagePasser` storage proofs to
@@ -210,9 +201,9 @@ impl<L2: L2Provider> OutputValidator<L2> {
         let account_result =
             self.l2_provider.get_proof(Predeploys::L2_TO_L1_MESSAGE_PASSER, rpc_hash).await?;
 
-        verify_account_proof(&account_result, consensus_header.state_root).map_err(|e| {
-            ValidatorError::AccountProofFailed { block_number, reason: e.to_string() }
-        })?;
+        AccountProofVerifier::verify(&account_result, consensus_header.state_root).map_err(
+            |e| ValidatorError::AccountProofFailed { block_number, reason: e.to_string() },
+        )?;
 
         let storage_root = account_result.storage_hash;
         let output_root =
@@ -231,7 +222,7 @@ impl<L2: L2Provider> OutputValidator<L2> {
         game_address: Address,
         checkpoints: &[Checkpoint],
     ) -> Result<Option<(usize, B256)>, ValidatorError> {
-        let _latency = RecordOnDrop(Instant::now());
+        let _latency = base_metrics::timed!(ChallengerMetrics::validation_latency_seconds());
 
         let mut stream = stream::iter(checkpoints.iter().enumerate())
             .map(|(idx, cp)| async move { (idx, cp, self.compute_output_root(cp.block).await) })

--- a/crates/proof/challenge/src/verify.rs
+++ b/crates/proof/challenge/src/verify.rs
@@ -1,48 +1,53 @@
 //! Account proof verification utilities.
 //!
-//! Provides [`verify_account_proof`] for verifying `eth_getProof` responses
+//! Provides [`AccountProofVerifier`] for verifying `eth_getProof` responses
 //! against a state root using Merkle Patricia Trie proofs.
 
 use alloy_primitives::{B256, keccak256};
+use alloy_rlp::Encodable;
 use alloy_rpc_types_eth::EIP1186AccountProofResponse;
-use alloy_trie::{Nibbles, TrieAccount, proof::verify_proof};
+use alloy_trie::{
+    Nibbles, TrieAccount,
+    proof::{ProofVerificationError, verify_proof},
+};
 use thiserror::Error;
 
 /// Errors from account proof verification.
-#[derive(Debug, Clone, Eq, PartialEq, Error)]
+#[derive(Debug, Eq, PartialEq, Error)]
 pub enum AccountProofError {
     /// The Merkle proof does not match the expected account state.
     #[error("account proof verification failed: {0}")]
-    VerificationFailed(String),
+    VerificationFailed(#[from] ProofVerificationError),
 }
 
-/// Verifies an `eth_getProof` response against a state root.
-///
-/// Checks that the account proof is valid against the given `state_root`
-/// by RLP-encoding the account fields (nonce, balance, storage root, code
-/// hash) and verifying the Merkle Patricia Trie proof.
-///
-/// # Errors
-///
-/// Returns [`AccountProofError::VerificationFailed`] if:
-/// - The proof is invalid against the state root
-/// - The account data doesn't match the proof
-pub fn verify_account_proof(
-    response: &EIP1186AccountProofResponse,
-    state_root: B256,
-) -> Result<(), AccountProofError> {
-    let key = Nibbles::unpack(keccak256(response.address));
+/// Verifies `eth_getProof` responses against state roots.
+#[derive(Debug)]
+pub struct AccountProofVerifier;
 
-    let account = TrieAccount {
-        nonce: response.nonce,
-        balance: response.balance,
-        storage_root: response.storage_hash,
-        code_hash: response.code_hash,
-    };
+impl AccountProofVerifier {
+    /// Verifies an `eth_getProof` response against a state root.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AccountProofError::VerificationFailed`] if the proof is
+    /// invalid or the account data doesn't match.
+    pub fn verify(
+        response: &EIP1186AccountProofResponse,
+        state_root: B256,
+    ) -> Result<(), AccountProofError> {
+        let key = Nibbles::unpack(keccak256(response.address));
 
-    let mut expected_value = Vec::new();
-    alloy_rlp::Encodable::encode(&account, &mut expected_value);
+        let account = TrieAccount {
+            nonce: response.nonce,
+            balance: response.balance,
+            storage_root: response.storage_hash,
+            code_hash: response.code_hash,
+        };
 
-    verify_proof(state_root, key, Some(expected_value), &response.account_proof)
-        .map_err(|e| AccountProofError::VerificationFailed(e.to_string()))
+        let mut encoded = Vec::with_capacity(account.length());
+        account.encode(&mut encoded);
+
+        verify_proof(state_root, key, Some(encoded), &response.account_proof)?;
+        Ok(())
+    }
 }

--- a/crates/proof/challenge/tests/driver.rs
+++ b/crates/proof/challenge/tests/driver.rs
@@ -12,10 +12,11 @@ use base_challenger::{
     GameScanner, L1HeadProvider, OutputValidator, PendingProof, ProofPhase, ScannerConfig,
     TeeConfig,
     test_utils::{
-        MockAggregateVerifier, MockBondTransactionSubmitter, MockDisputeGameFactory, MockGameState,
-        MockL1HeadProvider, MockL2Provider, MockTeeProofProvider, MockTxManager,
-        MockZkProofProvider, TEST_DISCOVERY_INTERVAL, addr, build_test_header_and_account,
-        empty_factory, factory_game, mock_state, mock_state_with_tee, receipt_with_status,
+        DEFAULT_L1_HEAD, DEFAULT_TEE_PROVER, MockAggregateVerifier, MockBondTransactionSubmitter,
+        MockDisputeGameFactory, MockGameState, MockL1HeadProvider, MockL2Provider,
+        MockTeeProofProvider, MockTxManager, MockZkProofProvider, MockZkProofState,
+        TEST_DISCOVERY_INTERVAL, addr, build_test_header_and_account, empty_factory, factory_game,
+        mock_state, mock_state_with_tee, receipt_with_status,
     },
 };
 use base_proof_contracts::{AggregateVerifierClient, ContractError, GameAtIndex};
@@ -25,6 +26,32 @@ use base_runtime::TokioRuntime;
 use base_tx_manager::TxManagerError;
 use base_zk_client::{ProofJobStatus, ProofType, ProveBlockRequest};
 use tokio_util::sync::CancellationToken;
+
+const STORAGE_HASH: B256 = B256::repeat_byte(0xBB);
+const ZK_PROVER_ADDR: Address = Address::new([0xCC; 20]);
+const DEFAULT_TX_HASH: B256 = B256::repeat_byte(0xDD);
+const BOGUS_ROOT: B256 = B256::repeat_byte(0xFF);
+const BOGUS_CLAIM: B256 = B256::repeat_byte(0x01);
+
+/// Returns a base [`MockGameState`] with standard test defaults.
+/// Override individual fields with struct update syntax:
+/// `MockGameState { tee_prover: DEFAULT_TEE_PROVER, ..game_state(20) }`.
+fn game_state(l2_block_number: u64) -> MockGameState {
+    MockGameState {
+        game_info: base_proof_contracts::GameInfo {
+            root_claim: BOGUS_CLAIM,
+            l2_block_number,
+            parent_index: 0,
+        },
+        starting_block_number: 10,
+        l1_head: DEFAULT_L1_HEAD,
+        ..Default::default()
+    }
+}
+
+fn empty_verifier() -> Arc<MockAggregateVerifier> {
+    Arc::new(MockAggregateVerifier { games: HashMap::new() })
+}
 
 /// Builds a test driver with the given mocks.
 fn test_driver(
@@ -82,18 +109,87 @@ fn default_tx_manager() -> MockTxManager {
     MockTxManager::new(Ok(receipt_with_status(true, B256::repeat_byte(0xAA))))
 }
 
-fn default_prove_request() -> ProveBlockRequest {
+fn default_l2() -> Arc<MockL2Provider> {
+    Arc::new(MockL2Provider::new())
+}
+
+fn single_game_factory() -> Arc<MockDisputeGameFactory> {
+    Arc::new(MockDisputeGameFactory { games: vec![factory_game(0, 1)] })
+}
+
+fn single_game_verifier(state: MockGameState) -> Arc<MockAggregateVerifier> {
+    Arc::new(MockAggregateVerifier { games: HashMap::from([(addr(0), state)]) })
+}
+
+fn tee_config(
+    provider: Arc<dyn ProverClient>,
+    l1_head_provider: Arc<dyn L1HeadProvider>,
+) -> TeeConfig {
+    TeeConfig { provider, l1_head_provider, request_timeout: Duration::from_secs(30) }
+}
+
+fn default_ready_proof(intent: DisputeIntent) -> PendingProof {
     let session_id = PendingProof::derive_session_id(addr(0), 1);
 
-    ProveBlockRequest {
+    let request = ProveBlockRequest {
         start_block_number: 15,
         number_of_blocks_to_prove: 5,
         sequence_window: None,
         proof_type: ProofType::GenericZkvmClusterSnarkGroth16.into(),
         session_id: Some(session_id),
         prover_address: Some(format!("{:#x}", addr(0))),
-        l1_head: Some(format!("{:#x}", B256::repeat_byte(0xAA))),
-    }
+        l1_head: Some(format!("{DEFAULT_L1_HEAD:#x}")),
+    };
+
+    PendingProof::ready(
+        Bytes::from_static(&[0x01, 0xDE, 0xAD]),
+        1,
+        B256::repeat_byte(0xEE),
+        request,
+        intent,
+    )
+}
+
+fn succeeded_zk_prover(session_id: &str, receipt: Vec<u8>) -> Arc<MockZkProofProvider> {
+    Arc::new(MockZkProofProvider {
+        session_id: session_id.to_string(),
+        state: Mutex::new(MockZkProofState {
+            proof_status: ProofJobStatus::Succeeded as i32,
+            receipt,
+            ..Default::default()
+        }),
+    })
+}
+
+fn failed_zk_prover(session_id: &str) -> Arc<MockZkProofProvider> {
+    Arc::new(MockZkProofProvider {
+        session_id: session_id.to_string(),
+        state: Mutex::new(MockZkProofState {
+            proof_status: ProofJobStatus::Failed as i32,
+            ..Default::default()
+        }),
+    })
+}
+
+/// Builds the common L2 provider, factory, and output roots shared by most
+/// invalid-game test scenarios. Layout: starting=10, `l2_block=20`,
+/// interval=5, checkpoints at blocks 15 and 20.
+fn base_game_mocks() -> (Arc<MockL2Provider>, Arc<MockDisputeGameFactory>, B256, B256) {
+    let (header_15, account_15) = build_test_header_and_account(15, STORAGE_HASH);
+    let root_15 =
+        OutputRoot::from_parts(header_15.state_root, STORAGE_HASH, header_15.hash_slow()).hash();
+    let (header_20, account_20) = build_test_header_and_account(20, STORAGE_HASH);
+    let root_20 =
+        OutputRoot::from_parts(header_20.state_root, STORAGE_HASH, header_20.hash_slow()).hash();
+
+    let mut l2 = MockL2Provider::new();
+    l2.insert_block(15, header_15, account_15);
+    l2.insert_block(20, header_20, account_20);
+    let l2 = Arc::new(l2);
+
+    let factory = single_game_factory();
+
+    (l2, factory, root_15, root_20)
 }
 
 /// Builds the common L2, factory, and verifier mocks for an invalid-game
@@ -101,36 +197,13 @@ fn default_prove_request() -> ProveBlockRequest {
 /// 20 with a correct root at 15 and a bogus root at 20 (invalid index 1).
 fn invalid_game_mocks()
 -> (Arc<MockL2Provider>, Arc<MockDisputeGameFactory>, Arc<MockAggregateVerifier>) {
-    let storage_hash = B256::repeat_byte(0xBB);
-    let (header_15, account_15) = build_test_header_and_account(15, storage_hash);
-    let root_15 =
-        OutputRoot::from_parts(header_15.state_root, storage_hash, header_15.hash_slow()).hash();
-    let (header_20, account_20) = build_test_header_and_account(20, storage_hash);
+    let (l2, factory, root_15, _root_20) = base_game_mocks();
 
-    let mut l2 = MockL2Provider::new();
-    l2.insert_block(15, header_15, account_15);
-    l2.insert_block(20, header_20, account_20);
-    let l2 = Arc::new(l2);
-
-    let factory = Arc::new(MockDisputeGameFactory { games: vec![factory_game(0, 1)] });
-    let mut verifier_games = HashMap::new();
-    let tee_addr = Address::repeat_byte(0xEE);
-    verifier_games.insert(
-        addr(0),
-        MockGameState {
-            tee_prover: tee_addr,
-            game_info: base_proof_contracts::GameInfo {
-                root_claim: B256::repeat_byte(0x01),
-                l2_block_number: 20,
-                parent_index: 0,
-            },
-            starting_block_number: 10,
-            l1_head: B256::repeat_byte(0xAA),
-            intermediate_output_roots: vec![root_15, B256::repeat_byte(0xFF)],
-            ..Default::default()
-        },
-    );
-    let verifier = Arc::new(MockAggregateVerifier { games: verifier_games });
+    let verifier = single_game_verifier(MockGameState {
+        tee_prover: DEFAULT_TEE_PROVER,
+        intermediate_output_roots: vec![root_15, BOGUS_ROOT],
+        ..game_state(20)
+    });
 
     (l2, factory, verifier)
 }
@@ -140,131 +213,67 @@ fn invalid_game_mocks()
 fn driver_with_ready_proof(
     game_state: MockGameState,
 ) -> Driver<MockL2Provider, MockZkProofProvider, MockTxManager> {
-    let (l2, factory, _verifier) = invalid_game_mocks();
-    let verifier_games = HashMap::from([(addr(0), game_state)]);
-    let verifier = Arc::new(MockAggregateVerifier { games: verifier_games });
+    let factory = single_game_factory();
+    let verifier = single_game_verifier(game_state);
+    let l2 = default_l2();
     let mut driver = test_driver(factory, verifier, l2, default_zk_prover(), default_tx_manager());
-    driver.pending_proofs.insert(
-        addr(0),
-        PendingProof::ready(
-            Bytes::from_static(&[0x01, 0xDE, 0xAD]),
-            1,
-            B256::repeat_byte(0xEE),
-            default_prove_request(),
-            DisputeIntent::Challenge,
-        ),
-    );
+    driver.pending_proofs.insert(addr(0), default_ready_proof(DisputeIntent::Challenge));
     driver
 }
 
 #[tokio::test]
 async fn test_step_no_candidates() {
     let factory = Arc::new(MockDisputeGameFactory { games: vec![] });
-    let verifier = Arc::new(MockAggregateVerifier { games: HashMap::new() });
-    let l2 = Arc::new(MockL2Provider::new());
+    let verifier = empty_verifier();
+    let l2 = default_l2();
 
     let mut driver = test_driver(factory, verifier, l2, default_zk_prover(), default_tx_manager());
 
     driver.step().await.unwrap();
-    // No error, no panic — empty scan is fine.
 }
 
 #[tokio::test]
 async fn test_step_valid_game_skipped() {
-    // Game with valid intermediate roots → no proof requested.
-    // We set up a game that will pass validation because intermediate_roots is empty
-    // and l2_block_number - starting_block_number < intermediate_block_interval
-    // so expected_count = 0 → trivially valid.
-    let factory = Arc::new(MockDisputeGameFactory { games: vec![factory_game(0, 1)] });
-    let mut verifier_games = HashMap::new();
-    let tee_addr = Address::repeat_byte(0xEE);
-    verifier_games.insert(
-        addr(0),
-        MockGameState {
-            tee_prover: tee_addr,
-            game_info: base_proof_contracts::GameInfo {
-                root_claim: B256::repeat_byte(0x01),
-                l2_block_number: 14,
-                parent_index: 0,
-            },
-            starting_block_number: 10,
-            l1_head: B256::repeat_byte(0xAA),
-            ..Default::default()
-        },
-    );
-    let verifier = Arc::new(MockAggregateVerifier { games: verifier_games });
-    let l2 = Arc::new(MockL2Provider::new());
+    // l2_block_number - starting_block_number < intermediate_block_interval
+    // → expected_count = 0 → trivially valid, no proof requested.
+    let factory = single_game_factory();
+    let verifier =
+        single_game_verifier(MockGameState { tee_prover: DEFAULT_TEE_PROVER, ..game_state(14) });
+    let l2 = default_l2();
 
-    // The ZK prover should NOT be called since the game is valid.
-    let zk = Arc::new(MockZkProofProvider {
-        session_id: "should-not-be-called".to_string(),
-        ..Default::default()
-    });
-
-    let mut driver = test_driver(factory, verifier, l2, zk, default_tx_manager());
+    let mut driver = test_driver(factory, verifier, l2, default_zk_prover(), default_tx_manager());
 
     driver.step().await.unwrap();
-    // If the ZK prover were called, the test would still pass, but the game
-    // being valid means process_candidate returns early.
 }
 
 #[tokio::test]
 async fn test_step_validation_error_blocks_not_available() {
     // Game with intermediate roots, but checkpoint blocks are unavailable.
     // Validator returns BlockNotAvailable → process_candidate skips gracefully.
-    let factory = Arc::new(MockDisputeGameFactory { games: vec![factory_game(0, 1)] });
-    let mut verifier_games = HashMap::new();
-    let tee_addr = Address::repeat_byte(0xEE);
-    verifier_games.insert(
-        addr(0),
-        MockGameState {
-            status: 0,
-            zk_prover: Address::ZERO,
-            tee_prover: tee_addr,
-            game_info: base_proof_contracts::GameInfo {
-                root_claim: B256::repeat_byte(0x01),
-                l2_block_number: 20,
-                parent_index: 0,
-            },
-            starting_block_number: 10,
-            l1_head: B256::repeat_byte(0xAA),
-            intermediate_output_roots: vec![B256::repeat_byte(0xFF), B256::repeat_byte(0xEE)],
-            ..Default::default()
-        },
-    );
-    let verifier = Arc::new(MockAggregateVerifier { games: verifier_games });
+    let factory = single_game_factory();
+    let verifier = single_game_verifier(MockGameState {
+        tee_prover: DEFAULT_TEE_PROVER,
+        intermediate_output_roots: vec![BOGUS_ROOT, B256::repeat_byte(0xEE)],
+        ..game_state(20)
+    });
 
-    // Checkpoint blocks are not available → validator returns BlockNotAvailable.
     let mut l2 = MockL2Provider::new();
     l2.error_blocks.push(15);
     l2.error_blocks.push(20);
     let l2 = Arc::new(l2);
 
-    let zk = Arc::new(MockZkProofProvider {
-        session_id: "test-session".to_string(),
-        ..Default::default()
-    });
+    let mut driver = test_driver(factory, verifier, l2, default_zk_prover(), default_tx_manager());
 
-    let mut driver = test_driver(factory, verifier, l2, zk, default_tx_manager());
-
-    // step succeeds — BlockNotAvailable causes process_candidate to skip
     driver.step().await.unwrap();
 }
 
 #[tokio::test]
 async fn test_step_invalid_game_proof_succeeded() {
-    // Proof succeeds → nullification submitted.
     let (l2, factory, verifier) = invalid_game_mocks();
 
-    let zk = Arc::new(MockZkProofProvider {
-        session_id: "proof-123".to_string(),
-        proof_status: Mutex::new(ProofJobStatus::Succeeded as i32),
-        receipt: Mutex::new(vec![0xDE, 0xAD]),
-        ..Default::default()
-    });
+    let zk = succeeded_zk_prover("proof-123", vec![0xDE, 0xAD]);
 
-    let tx_hash = B256::repeat_byte(0xCC);
-    let tx_manager = MockTxManager::new(Ok(receipt_with_status(true, tx_hash)));
+    let tx_manager = default_tx_manager();
 
     let mut driver = test_driver(factory, verifier, l2, zk, tx_manager);
 
@@ -285,16 +294,10 @@ async fn test_step_invalid_game_proof_succeeded() {
 
 #[tokio::test]
 async fn test_step_invalid_game_proof_failed() {
-    // ZK prover returns Failed → entry retained and re-initiated with retry_count == 1.
     let (l2, factory, verifier) = invalid_game_mocks();
 
-    let zk = Arc::new(MockZkProofProvider {
-        session_id: "proof-fail".to_string(),
-        proof_status: Mutex::new(ProofJobStatus::Failed as i32),
-        ..Default::default()
-    });
+    let zk = failed_zk_prover("proof-fail");
 
-    // tx_manager should NOT be called (proof failed → no submission)
     let tx_manager = default_tx_manager();
 
     let mut driver = test_driver(factory, verifier, l2, zk, tx_manager);
@@ -321,47 +324,7 @@ async fn test_step_invalid_game_proof_failed() {
 }
 
 #[tokio::test]
-async fn test_step_validation_error_skipped() {
-    // Game where validator returns an error (e.g., BlockNotAvailable)
-    // → process_candidate logs and returns Ok.
-    let factory = Arc::new(MockDisputeGameFactory { games: vec![factory_game(0, 1)] });
-    let mut verifier_games = HashMap::new();
-    let tee_addr = Address::repeat_byte(0xEE);
-    verifier_games.insert(
-        addr(0),
-        MockGameState {
-            status: 0,
-            zk_prover: Address::ZERO,
-            tee_prover: tee_addr,
-            game_info: base_proof_contracts::GameInfo {
-                root_claim: B256::repeat_byte(0x01),
-                l2_block_number: 20,
-                parent_index: 0,
-            },
-            starting_block_number: 10,
-            l1_head: B256::repeat_byte(0xAA),
-            // 2 roots expected at interval=5, provide 2 so count matches
-            intermediate_output_roots: vec![B256::ZERO, B256::ZERO],
-            ..Default::default()
-        },
-    );
-    let verifier = Arc::new(MockAggregateVerifier { games: verifier_games });
-
-    // L2 provider has no blocks → validator returns BlockNotAvailable
-    let l2 = Arc::new(MockL2Provider::new());
-
-    let mut driver = test_driver(factory, verifier, l2, default_zk_prover(), default_tx_manager());
-
-    // step succeeds — validation error is skipped
-    driver.step().await.unwrap();
-}
-
-#[tokio::test]
 async fn test_step_scan_error_propagated() {
-    // Use ErrorOnIndexFactory where game_count succeeds but game_at_index
-    // errors. But scan itself catches per-game errors. To get scan to fail,
-    // we need game_count to fail, which requires a custom factory.
-
     /// Factory that always fails on `game_count`.
     #[derive(Debug)]
     struct FailingFactory;
@@ -389,14 +352,14 @@ async fn test_step_scan_error_propagated() {
     }
 
     let factory = Arc::new(FailingFactory);
-    let verifier = Arc::new(MockAggregateVerifier { games: HashMap::new() });
+    let verifier = empty_verifier();
     let scanner = GameScanner::new(
         factory,
         Arc::clone(&verifier) as Arc<dyn AggregateVerifierClient>,
         ScannerConfig { lookback_games: 1000 },
     );
 
-    let l2 = Arc::new(MockL2Provider::new());
+    let l2 = default_l2();
     let validator = OutputValidator::new(l2);
     let submitter = ChallengeSubmitter::new(default_tx_manager());
 
@@ -425,19 +388,14 @@ async fn test_step_scan_error_propagated() {
 
 #[tokio::test]
 async fn test_step_pending_proof_skips_prove_block() {
-    // First step: proof initiated (status=Unspecified via Default, not ready).
-    // Second step: same game re-discovered → polls existing session,
-    // proof succeeds, nullification submitted.
     let (l2, factory, verifier) = invalid_game_mocks();
 
     let zk = Arc::new(MockZkProofProvider {
         session_id: "pending-session".to_string(),
-        receipt: Mutex::new(vec![0xBE, 0xEF]),
-        ..Default::default()
+        state: Mutex::new(MockZkProofState { receipt: vec![0xBE, 0xEF], ..Default::default() }),
     });
 
-    let tx_hash = B256::repeat_byte(0xDD);
-    let tx_manager = MockTxManager::new(Ok(receipt_with_status(true, tx_hash)));
+    let tx_manager = default_tx_manager();
 
     let mut driver = test_driver(factory, verifier, l2, Arc::clone(&zk), tx_manager);
 
@@ -449,7 +407,7 @@ async fn test_step_pending_proof_skips_prove_block() {
     );
 
     // Simulate the proof completing before the next poll.
-    *zk.proof_status.lock().unwrap() = ProofJobStatus::Succeeded as i32;
+    zk.state.lock().unwrap().proof_status = ProofJobStatus::Succeeded as i32;
 
     // Step 2: same game re-discovered → polls existing session, proof succeeds,
     // challenge tx submitted, session removed from pending_proofs.
@@ -462,22 +420,14 @@ async fn test_step_pending_proof_skips_prove_block() {
 
 #[tokio::test]
 async fn test_step_nullification_failure_preserves_proof() {
-    // Proof succeeds on the second step but nullification tx fails.
-    // The entry should stay in pending_proofs as ReadyToSubmit.
-    // On the next step the tx succeeds without re-proving.
     let (l2, factory, verifier) = invalid_game_mocks();
 
-    let zk = Arc::new(MockZkProofProvider {
-        session_id: "proof-ok".to_string(),
-        proof_status: Mutex::new(ProofJobStatus::Succeeded as i32),
-        receipt: Mutex::new(vec![0xDE, 0xAD]),
-        ..Default::default()
-    });
+    let zk = succeeded_zk_prover("proof-ok", vec![0xDE, 0xAD]);
 
     // First tx call fails (NonceTooLow), second succeeds.
     let tx_manager = MockTxManager::with_responses(vec![
         Err(TxManagerError::NonceTooLow),
-        Ok(receipt_with_status(true, B256::repeat_byte(0xCC))),
+        Ok(receipt_with_status(true, DEFAULT_TX_HASH)),
     ]);
 
     let mut driver = test_driver(factory, verifier, l2, zk, tx_manager);
@@ -520,7 +470,7 @@ async fn test_poll_or_submit_drops_resolved_game() {
 async fn test_poll_or_submit_drops_already_challenged_game() {
     // Game is still IN_PROGRESS but already challenged (zk_prover != ZERO)
     // — driver should drop the pending proof.
-    let mut driver = driver_with_ready_proof(mock_state(0, Address::repeat_byte(0xCC), 20));
+    let mut driver = driver_with_ready_proof(mock_state(0, ZK_PROVER_ADDR, 20));
     driver.step().await.unwrap();
     assert!(
         !driver.pending_proofs.contains_key(&addr(0)),
@@ -544,41 +494,12 @@ async fn test_poll_or_submit_drops_nullified_game() {
 #[tokio::test]
 async fn test_run_cancellation() {
     let factory = Arc::new(MockDisputeGameFactory { games: vec![] });
-    let verifier = Arc::new(MockAggregateVerifier { games: HashMap::new() });
-    let l2 = Arc::new(MockL2Provider::new());
+    let verifier = empty_verifier();
+    let l2 = default_l2();
 
-    let scanner = GameScanner::new(
-        Arc::clone(&factory) as Arc<dyn base_proof_contracts::DisputeGameFactoryClient>,
-        Arc::clone(&verifier) as Arc<dyn AggregateVerifierClient>,
-        ScannerConfig { lookback_games: 1000 },
-    );
-    let validator = OutputValidator::new(l2);
-    let submitter = ChallengeSubmitter::new(default_tx_manager());
-    let cancel = CancellationToken::new();
+    let driver = test_driver(factory, verifier, l2, default_zk_prover(), default_tx_manager());
+    driver.cancel.cancel();
 
-    let config = DriverConfig {
-        poll_interval: Duration::from_secs(60), // long poll so it blocks
-        cancel: cancel.clone(),
-        ready: Arc::new(AtomicBool::new(false)),
-    };
-
-    let driver = Driver::new(
-        config,
-        DriverComponents {
-            scanner,
-            validator,
-            zk_prover: default_zk_prover(),
-            submitter,
-            tee: None,
-            verifier_client: verifier as Arc<dyn AggregateVerifierClient>,
-            bond_manager: None::<BondManager<TokioRuntime>>,
-        },
-    );
-
-    // Cancel immediately
-    cancel.cancel();
-
-    // run() should return promptly
     tokio::time::timeout(Duration::from_secs(2), driver.run())
         .await
         .expect("driver.run() should exit promptly after cancellation");
@@ -586,20 +507,18 @@ async fn test_run_cancellation() {
 
 #[tokio::test]
 async fn test_step_proof_retry_succeeds() {
-    // Proof is initiated on the first tick, fails on the second tick
-    // (NeedsRetry), then re-initiated prove_block returns a new session.
-    // On the third tick the proof succeeds and challenge tx is submitted.
     let (l2, factory, verifier) = invalid_game_mocks();
 
     let zk = Arc::new(MockZkProofProvider {
         session_id: "retry-session".to_string(),
-        proof_status: Mutex::new(ProofJobStatus::Failed as i32),
-        receipt: Mutex::new(vec![0xBE, 0xEF]),
-        ..Default::default()
+        state: Mutex::new(MockZkProofState {
+            proof_status: ProofJobStatus::Failed as i32,
+            receipt: vec![0xBE, 0xEF],
+            ..Default::default()
+        }),
     });
 
-    let tx_hash = B256::repeat_byte(0xDD);
-    let tx_manager = MockTxManager::new(Ok(receipt_with_status(true, tx_hash)));
+    let tx_manager = default_tx_manager();
 
     let mut driver = test_driver(factory, verifier, l2, Arc::clone(&zk), tx_manager);
 
@@ -621,7 +540,7 @@ async fn test_step_proof_retry_succeeds() {
     assert_eq!(entry.retry_count, 1);
 
     // Simulate proof succeeding on the retry session.
-    *zk.proof_status.lock().unwrap() = ProofJobStatus::Succeeded as i32;
+    zk.state.lock().unwrap().proof_status = ProofJobStatus::Succeeded as i32;
 
     // Step 3: proof succeeds, challenge tx submitted, entry removed.
     driver.step().await.unwrap();
@@ -633,14 +552,9 @@ async fn test_step_proof_retry_succeeds() {
 
 #[tokio::test]
 async fn test_step_proof_exceeds_max_retries() {
-    // Proof keeps failing → entry dropped after MAX_PROOF_RETRIES + 1 failures.
     let (l2, factory, verifier) = invalid_game_mocks();
 
-    let zk = Arc::new(MockZkProofProvider {
-        session_id: "fail-forever".to_string(),
-        proof_status: Mutex::new(ProofJobStatus::Failed as i32),
-        ..Default::default()
-    });
+    let zk = failed_zk_prover("fail-forever");
 
     let tx_manager = default_tx_manager();
     let mut driver = test_driver(factory, verifier, l2, zk, tx_manager);
@@ -671,40 +585,25 @@ async fn test_step_proof_exceeds_max_retries() {
 
 // ── TEE-first proof sourcing tests ─────────────────────────────────────────
 
-/// Builds the common mocks for a TEE-eligible invalid-game scenario.
-///
-/// The game at `addr(0)` has `tee_prover = 0xEE..EE` and the same block
-/// layout as `invalid_game_mocks()`.
 #[tokio::test]
 async fn test_step_invalid_game_tee_fails_zk_fallback() {
-    // Game has a TEE prover, TEE provider is configured, but the TEE proof
-    // attempt fails (L1 provider is unreachable with dummy). The driver
-    // should fall back to ZK and initiate a ZK proof session.
+    // TEE proof attempt fails → driver falls back to ZK.
     let (l2, factory, verifier) = invalid_game_mocks();
 
     let tee = Arc::new(MockTeeProofProvider::failure("enclave unreachable"));
-    let zk = Arc::new(MockZkProofProvider {
-        session_id: "zk-fallback".to_string(),
-        ..Default::default()
-    });
 
     let tx_manager = default_tx_manager();
     let mut driver = test_driver_with_tee(
         factory,
         verifier,
         l2,
-        zk,
+        default_zk_prover(),
         tx_manager,
-        Some(TeeConfig {
-            provider: tee as Arc<dyn ProverClient>,
-            l1_head_provider: Arc::new(MockL1HeadProvider::failure("dummy")),
-            request_timeout: Duration::from_secs(30),
-        }),
+        Some(tee_config(tee, Arc::new(MockL1HeadProvider::failure("dummy")))),
     );
 
     driver.step().await.unwrap();
 
-    // The TEE attempt fails, so a ZK proof session should be initiated.
     let entry =
         driver.pending_proofs.get(&addr(0)).expect("ZK proof should be pending after TEE fallback");
     assert!(
@@ -715,18 +614,11 @@ async fn test_step_invalid_game_tee_fails_zk_fallback() {
 
 #[tokio::test]
 async fn test_step_invalid_game_no_tee_provider_zk_only() {
-    // Game has a TEE prover, but the driver has no TEE provider configured
-    // (tee-rpc-url was not set). Should go straight to ZK.
+    // No TEE provider configured → go straight to ZK.
     let (l2, factory, verifier) = invalid_game_mocks();
 
-    let zk = Arc::new(MockZkProofProvider {
-        session_id: "zk-no-provider".to_string(),
-        ..Default::default()
-    });
-
     let tx_manager = default_tx_manager();
-    // No TEE provider (None).
-    let mut driver = test_driver(factory, verifier, l2, zk, tx_manager);
+    let mut driver = test_driver(factory, verifier, l2, default_zk_prover(), tx_manager);
 
     driver.step().await.unwrap();
 
@@ -739,20 +631,12 @@ async fn test_step_invalid_game_no_tee_provider_zk_only() {
 
 #[tokio::test]
 async fn test_step_invalid_game_tee_fails_zk_succeeds() {
-    // Game has a TEE prover, TEE proof attempt fails, driver falls back to
-    // ZK, ZK proof succeeds on the next poll, challenge tx submitted.
     let (l2, factory, verifier) = invalid_game_mocks();
 
     let tee = Arc::new(MockTeeProofProvider::failure("L1 unreachable"));
-    let zk = Arc::new(MockZkProofProvider {
-        session_id: "zk-after-tee-fail".to_string(),
-        proof_status: Mutex::new(ProofJobStatus::Succeeded as i32),
-        receipt: Mutex::new(vec![0xDE, 0xAD]),
-        ..Default::default()
-    });
+    let zk = succeeded_zk_prover("zk-after-tee-fail", vec![0xDE, 0xAD]);
 
-    let tx_hash = B256::repeat_byte(0xCC);
-    let tx_manager = MockTxManager::new(Ok(receipt_with_status(true, tx_hash)));
+    let tx_manager = default_tx_manager();
 
     let mut driver = test_driver_with_tee(
         factory,
@@ -760,11 +644,7 @@ async fn test_step_invalid_game_tee_fails_zk_succeeds() {
         l2,
         zk,
         tx_manager,
-        Some(TeeConfig {
-            provider: tee as Arc<dyn ProverClient>,
-            l1_head_provider: Arc::new(MockL1HeadProvider::failure("dummy")),
-            request_timeout: Duration::from_secs(30),
-        }),
+        Some(tee_config(tee, Arc::new(MockL1HeadProvider::failure("dummy")))),
     );
 
     // Step 1: TEE path is attempted (fails due to provider error), falls back
@@ -785,53 +665,22 @@ async fn test_step_invalid_game_tee_fails_zk_succeeds() {
 
 #[tokio::test]
 async fn test_step_invalid_game_tee_proof_succeeds() {
-    // Game has a TEE prover, L1 head provider returns a valid hash, TEE proof
-    // provider returns a valid proof with the correct output root. The driver
-    // should submit the TEE proof directly without initiating a ZK session.
-    let storage_hash = B256::repeat_byte(0xBB);
-    let (header_15, account_15) = build_test_header_and_account(15, storage_hash);
-    let root_15 =
-        OutputRoot::from_parts(header_15.state_root, storage_hash, header_15.hash_slow()).hash();
-    let (header_20, account_20) = build_test_header_and_account(20, storage_hash);
-    let root_20 =
-        OutputRoot::from_parts(header_20.state_root, storage_hash, header_20.hash_slow()).hash();
+    // TEE proof succeeds → submitted directly without ZK.
+    let (l2, factory, root_15, root_20) = base_game_mocks();
 
-    let mut l2 = MockL2Provider::new();
-    l2.insert_block(15, header_15, account_15);
-    l2.insert_block(20, header_20, account_20);
-    let l2 = Arc::new(l2);
+    let verifier = single_game_verifier(MockGameState {
+        tee_prover: DEFAULT_TEE_PROVER,
+        // root_15 is correct, index 1 is bogus — invalid_index == 1
+        intermediate_output_roots: vec![root_15, BOGUS_ROOT],
+        ..game_state(20)
+    });
 
-    let l1_hash = B256::repeat_byte(0xAA);
-
-    let factory = Arc::new(MockDisputeGameFactory { games: vec![factory_game(0, 1)] });
-    let tee_addr = Address::repeat_byte(0xEE);
-    let mut verifier_games = HashMap::new();
-    verifier_games.insert(
-        addr(0),
-        MockGameState {
-            status: 0,
-            zk_prover: Address::ZERO,
-            tee_prover: tee_addr,
-            game_info: base_proof_contracts::GameInfo {
-                root_claim: B256::repeat_byte(0x01),
-                l2_block_number: 20,
-                parent_index: 0,
-            },
-            starting_block_number: 10,
-            l1_head: l1_hash,
-            // root_15 is correct, index 1 is bogus — invalid_index == 1
-            intermediate_output_roots: vec![root_15, B256::repeat_byte(0xFF)],
-            ..Default::default()
-        },
-    );
-    let verifier = Arc::new(MockAggregateVerifier { games: verifier_games });
-
-    let l1_head = Arc::new(MockL1HeadProvider::success(l1_hash, 100));
+    let l1_head = Arc::new(MockL1HeadProvider::success(DEFAULT_L1_HEAD, 100));
 
     let aggregate_proposal = Proposal {
         output_root: root_20,
         signature: Bytes::from(vec![0u8; 65]),
-        l1_origin_hash: l1_hash,
+        l1_origin_hash: DEFAULT_L1_HEAD,
         l1_origin_number: 1000,
         l2_block_number: 20,
         prev_output_root: root_15,
@@ -842,31 +691,19 @@ async fn test_step_invalid_game_tee_proof_succeeds() {
         proposals: vec![],
     }));
 
-    let tx_hash = B256::repeat_byte(0xDD);
-    let tx_manager = MockTxManager::new(Ok(receipt_with_status(true, tx_hash)));
-
-    // ZK prover should NOT be called since TEE proof succeeds.
-    let zk = Arc::new(MockZkProofProvider {
-        session_id: "should-not-be-called".to_string(),
-        ..Default::default()
-    });
+    let tx_manager = default_tx_manager();
 
     let mut driver = test_driver_with_tee(
         factory,
         verifier,
         l2,
-        zk,
+        default_zk_prover(),
         tx_manager,
-        Some(TeeConfig {
-            provider: tee_provider as Arc<dyn ProverClient>,
-            l1_head_provider: l1_head as Arc<dyn L1HeadProvider>,
-            request_timeout: Duration::from_secs(30),
-        }),
+        Some(tee_config(tee_provider, l1_head)),
     );
 
     driver.step().await.unwrap();
 
-    // TEE proof was submitted directly — no pending ZK proof.
     assert!(
         !driver.pending_proofs.contains_key(&addr(0)),
         "no pending ZK proof should exist after successful TEE submission"
@@ -875,49 +712,14 @@ async fn test_step_invalid_game_tee_proof_succeeds() {
 
 #[tokio::test]
 async fn test_step_nullified_game_not_reprocessed() {
-    // Simulate the post-nullification on-chain state: game is still
-    // IN_PROGRESS but both teeProver and zkProver are address(0).
-    // The scanner should filter it out and no proof should be initiated.
-    let storage_hash = B256::repeat_byte(0xBB);
-    let (header_15, account_15) = build_test_header_and_account(15, storage_hash);
-    let root_15 =
-        OutputRoot::from_parts(header_15.state_root, storage_hash, header_15.hash_slow()).hash();
-    let (header_20, account_20) = build_test_header_and_account(20, storage_hash);
+    // Both provers zeroed (post-nullification) → scanner filters it out.
+    let (l2, factory, root_15, _root_20) = base_game_mocks();
 
-    let mut l2 = MockL2Provider::new();
-    l2.insert_block(15, header_15, account_15);
-    l2.insert_block(20, header_20, account_20);
-    let l2 = Arc::new(l2);
-
-    let factory = Arc::new(MockDisputeGameFactory { games: vec![factory_game(0, 1)] });
-    let mut verifier_games = HashMap::new();
-    verifier_games.insert(
-        addr(0),
-        MockGameState {
-            status: 0,
-            zk_prover: Address::ZERO,
-            // Both provers zeroed — this is the state after TEE nullification.
-            game_info: base_proof_contracts::GameInfo {
-                root_claim: B256::repeat_byte(0x01),
-                l2_block_number: 20,
-                parent_index: 0,
-            },
-            starting_block_number: 10,
-            l1_head: B256::repeat_byte(0xAA),
-            intermediate_output_roots: vec![root_15, B256::repeat_byte(0xFF)],
-            ..Default::default()
-        },
-    );
-    let verifier = Arc::new(MockAggregateVerifier { games: verifier_games });
-
-    // Neither the ZK prover nor the tx manager should be called.
-    let zk = Arc::new(MockZkProofProvider {
-        session_id: "should-not-be-called".to_string(),
-        ..Default::default()
+    let verifier = single_game_verifier(MockGameState {
+        intermediate_output_roots: vec![root_15, BOGUS_ROOT],
+        ..game_state(20)
     });
-    let tx_manager = default_tx_manager();
-
-    let mut driver = test_driver(factory, verifier, l2, zk, tx_manager);
+    let mut driver = test_driver(factory, verifier, l2, default_zk_prover(), default_tx_manager());
 
     // Run two steps — the game should be filtered by the scanner on both.
     driver.step().await.unwrap();
@@ -935,30 +737,17 @@ async fn test_poll_or_submit_nullify_intent_not_dropped_when_zk_prover_set() {
     // A pending proof with DisputeIntent::Nullify should NOT be dropped
     // when zkProver is non-zero (unlike DisputeIntent::Challenge, which
     // requires zkProver == ZERO).
-    let tee_addr = Address::repeat_byte(0xEE);
-    let zk_addr = Address::repeat_byte(0xCC);
-
-    let (l2, factory, _verifier) = invalid_game_mocks();
-    let mut game_state = mock_state_with_tee(0, zk_addr, tee_addr, 20);
+    let factory = single_game_factory();
+    let l2 = default_l2();
+    let mut game_state = mock_state_with_tee(0, ZK_PROVER_ADDR, DEFAULT_TEE_PROVER, 20);
     game_state.countered_index = 2; // challenged at 0-based index 1
-    let verifier_games = HashMap::from([(addr(0), game_state)]);
-    let verifier = Arc::new(MockAggregateVerifier { games: verifier_games });
+    let verifier = single_game_verifier(game_state);
 
     let mut driver = test_driver(factory, verifier, l2, default_zk_prover(), default_tx_manager());
-    driver.pending_proofs.insert(
-        addr(0),
-        PendingProof::ready(
-            Bytes::from_static(&[0x01, 0xDE, 0xAD]),
-            1,
-            B256::repeat_byte(0xEE),
-            default_prove_request(),
-            DisputeIntent::Nullify,
-        ),
-    );
+    driver.pending_proofs.insert(addr(0), default_ready_proof(DisputeIntent::Nullify));
 
     driver.step().await.unwrap();
 
-    // The pending proof should have been submitted (and removed), not dropped.
     assert!(
         !driver.pending_proofs.contains_key(&addr(0)),
         "nullify intent should be submitted, not dropped due to zk_prover"
@@ -969,26 +758,14 @@ async fn test_poll_or_submit_nullify_intent_not_dropped_when_zk_prover_set() {
 async fn test_poll_or_submit_challenge_intent_dropped_when_zk_prover_set() {
     // A pending proof with DisputeIntent::Challenge should be dropped
     // when zkProver is non-zero (game already challenged).
-    let tee_addr = Address::repeat_byte(0xEE);
-    let zk_addr = Address::repeat_byte(0xCC);
-
-    let (l2, factory, _verifier) = invalid_game_mocks();
-    let game_state = mock_state_with_tee(0, zk_addr, tee_addr, 20);
-    let verifier_games = HashMap::from([(addr(0), game_state)]);
-    let verifier = Arc::new(MockAggregateVerifier { games: verifier_games });
+    let factory = single_game_factory();
+    let l2 = default_l2();
+    let verifier =
+        single_game_verifier(mock_state_with_tee(0, ZK_PROVER_ADDR, DEFAULT_TEE_PROVER, 20));
 
     let tx = MockTxManager::new(Err(TxManagerError::NonceTooLow)); // Should never be called
     let mut driver = test_driver(factory, verifier, l2, default_zk_prover(), tx);
-    driver.pending_proofs.insert(
-        addr(0),
-        PendingProof::ready(
-            Bytes::from_static(&[0x01, 0xDE, 0xAD]),
-            1,
-            B256::repeat_byte(0xEE),
-            default_prove_request(),
-            DisputeIntent::Challenge,
-        ),
-    );
+    driver.pending_proofs.insert(addr(0), default_ready_proof(DisputeIntent::Challenge));
 
     driver.step().await.unwrap();
 
@@ -1012,45 +789,16 @@ async fn test_poll_or_submit_challenge_intent_dropped_when_zk_prover_set() {
 fn fraudulent_zk_challenge_mocks(
     correct_root_at_20: bool,
 ) -> (Arc<MockL2Provider>, Arc<MockDisputeGameFactory>, Arc<MockAggregateVerifier>) {
-    let storage_hash = B256::repeat_byte(0xBB);
-    let (header_15, account_15) = build_test_header_and_account(15, storage_hash);
-    let root_15 =
-        OutputRoot::from_parts(header_15.state_root, storage_hash, header_15.hash_slow()).hash();
-    let (header_20, account_20) = build_test_header_and_account(20, storage_hash);
-    let root_20 =
-        OutputRoot::from_parts(header_20.state_root, storage_hash, header_20.hash_slow()).hash();
+    let (l2, factory, root_15, root_20) = base_game_mocks();
+    let onchain_root_at_20 = if correct_root_at_20 { root_20 } else { BOGUS_ROOT };
 
-    let mut l2 = MockL2Provider::new();
-    l2.insert_block(15, header_15, account_15);
-    l2.insert_block(20, header_20, account_20);
-    let l2 = Arc::new(l2);
-
-    let tee_addr = Address::repeat_byte(0xEE);
-    let zk_addr = Address::repeat_byte(0xCC);
-    let factory = Arc::new(MockDisputeGameFactory { games: vec![factory_game(0, 1)] });
-
-    let onchain_root_at_20 = if correct_root_at_20 { root_20 } else { B256::repeat_byte(0xFF) };
-
-    let mut verifier_games = HashMap::new();
-    verifier_games.insert(
-        addr(0),
-        MockGameState {
-            status: 0,
-            zk_prover: zk_addr,
-            tee_prover: tee_addr,
-            game_info: base_proof_contracts::GameInfo {
-                root_claim: B256::repeat_byte(0x01),
-                l2_block_number: 20,
-                parent_index: 0,
-            },
-            starting_block_number: 10,
-            l1_head: B256::repeat_byte(0xAA),
-            intermediate_output_roots: vec![root_15, onchain_root_at_20],
-            countered_index: 2, // 1-based → challenged_index = 1
-            ..Default::default()
-        },
-    );
-    let verifier = Arc::new(MockAggregateVerifier { games: verifier_games });
+    let verifier = single_game_verifier(MockGameState {
+        zk_prover: ZK_PROVER_ADDR,
+        tee_prover: DEFAULT_TEE_PROVER,
+        intermediate_output_roots: vec![root_15, onchain_root_at_20],
+        countered_index: 2, // 1-based → challenged_index = 1
+        ..game_state(20)
+    });
 
     (l2, factory, verifier)
 }
@@ -1062,12 +810,7 @@ async fn test_step_fraudulent_zk_challenge_legitimate_skips() {
     // a proof.
     let (l2, factory, verifier) = fraudulent_zk_challenge_mocks(false);
 
-    let zk = Arc::new(MockZkProofProvider {
-        session_id: "should-not-be-called".to_string(),
-        ..Default::default()
-    });
-
-    let mut driver = test_driver(factory, verifier, l2, zk, default_tx_manager());
+    let mut driver = test_driver(factory, verifier, l2, default_zk_prover(), default_tx_manager());
     driver.step().await.unwrap();
 
     assert!(
@@ -1083,12 +826,7 @@ async fn test_step_fraudulent_zk_challenge_nullifies() {
     // with DisputeIntent::Nullify.
     let (l2, factory, verifier) = fraudulent_zk_challenge_mocks(true);
 
-    let zk = Arc::new(MockZkProofProvider {
-        session_id: "nullify-fraudulent".to_string(),
-        ..Default::default()
-    });
-
-    let mut driver = test_driver(factory, verifier, l2, zk, default_tx_manager());
+    let mut driver = test_driver(factory, verifier, l2, default_zk_prover(), default_tx_manager());
     driver.step().await.unwrap();
 
     let entry = driver
@@ -1111,50 +849,19 @@ async fn test_step_invalid_zk_proposal_initiates_zk_nullification() {
     // A game proposed with a ZK proof (tee_prover == ZERO, zk_prover != ZERO)
     // with invalid intermediate roots should trigger a ZK proof with
     // DisputeIntent::Nullify.
-    let storage_hash = B256::repeat_byte(0xBB);
-    let (header_15, _account_15) = build_test_header_and_account(15, storage_hash);
-    let root_15 =
-        OutputRoot::from_parts(header_15.state_root, storage_hash, header_15.hash_slow()).hash();
-    let (header_20, account_20) = build_test_header_and_account(20, storage_hash);
+    let (l2, factory, root_15, _root_20) = base_game_mocks();
 
-    let mut l2 = MockL2Provider::new();
-    l2.insert_block(15, header_15, account_20.clone());
-    l2.insert_block(20, header_20, account_20);
-    let l2 = Arc::new(l2);
-
-    let zk_addr = Address::repeat_byte(0xCC);
-    let factory = Arc::new(MockDisputeGameFactory { games: vec![factory_game(0, 1)] });
-    let mut verifier_games = HashMap::new();
-    verifier_games.insert(
-        addr(0),
-        MockGameState {
-            status: 0,
-            zk_prover: zk_addr,
-            game_info: base_proof_contracts::GameInfo {
-                root_claim: B256::repeat_byte(0x01),
-                l2_block_number: 20,
-                parent_index: 0,
-            },
-            starting_block_number: 10,
-            l1_head: B256::repeat_byte(0xAA),
-            intermediate_output_roots: vec![root_15, B256::repeat_byte(0xFF)],
-            ..Default::default()
-        },
-    );
-    let verifier = Arc::new(MockAggregateVerifier { games: verifier_games });
-
-    let zk = Arc::new(MockZkProofProvider {
-        session_id: "zk-nullify-session".to_string(),
-        ..Default::default()
+    let verifier = single_game_verifier(MockGameState {
+        zk_prover: ZK_PROVER_ADDR,
+        intermediate_output_roots: vec![root_15, BOGUS_ROOT],
+        ..game_state(20)
     });
 
-    let mut driver = test_driver(factory, verifier, l2, zk, default_tx_manager());
+    let mut driver = test_driver(factory, verifier, l2, default_zk_prover(), default_tx_manager());
     driver.step().await.unwrap();
 
-    // A pending proof should have been created with Nullify intent.
-    let entry = driver.pending_proofs.get(&addr(0));
-    assert!(entry.is_some(), "ZK nullification proof should be pending");
-    let entry = entry.unwrap();
+    let entry =
+        driver.pending_proofs.get(&addr(0)).expect("ZK nullification proof should be pending");
     assert_eq!(entry.intent, DisputeIntent::Nullify, "intent should be Nullify for ZK proposals");
 }
 
@@ -1162,33 +869,12 @@ async fn test_step_invalid_zk_proposal_initiates_zk_nullification() {
 async fn test_step_valid_zk_proposal_skipped() {
     // A ZK-proposed game with valid intermediate roots should not trigger
     // any action.
-    let factory = Arc::new(MockDisputeGameFactory { games: vec![factory_game(0, 1)] });
-    let zk_addr = Address::repeat_byte(0xCC);
-    let mut verifier_games = HashMap::new();
-    verifier_games.insert(
-        addr(0),
-        MockGameState {
-            status: 0,
-            zk_prover: zk_addr,
-            game_info: base_proof_contracts::GameInfo {
-                root_claim: B256::repeat_byte(0x01),
-                l2_block_number: 14,
-                parent_index: 0,
-            },
-            starting_block_number: 10,
-            l1_head: B256::repeat_byte(0xAA),
-            ..Default::default()
-        },
-    );
-    let verifier = Arc::new(MockAggregateVerifier { games: verifier_games });
-    let l2 = Arc::new(MockL2Provider::new());
+    let factory = single_game_factory();
+    let verifier =
+        single_game_verifier(MockGameState { zk_prover: ZK_PROVER_ADDR, ..game_state(14) });
+    let l2 = default_l2();
 
-    let zk = Arc::new(MockZkProofProvider {
-        session_id: "should-not-be-called".to_string(),
-        ..Default::default()
-    });
-
-    let mut driver = test_driver(factory, verifier, l2, zk, default_tx_manager());
+    let mut driver = test_driver(factory, verifier, l2, default_zk_prover(), default_tx_manager());
     driver.step().await.unwrap();
 
     assert!(driver.pending_proofs.is_empty(), "valid ZK proposal should not trigger any proof");
@@ -1197,6 +883,29 @@ async fn test_step_valid_zk_proposal_skipped() {
 // ──────────────────────────────────────────────────────────────────────────
 // Bond lifecycle integration tests
 // ──────────────────────────────────────────────────────────────────────────
+
+const fn bond_test_state(claim_addr: Address) -> MockGameState {
+    let mut state = mock_state(1, Address::ZERO, 100);
+    state.bond_recipient = claim_addr;
+    state
+}
+
+fn bond_test_verifier(claim_addr: Address) -> Arc<MockAggregateVerifier> {
+    single_game_verifier(bond_test_state(claim_addr))
+}
+
+fn default_bond_manager(claim_addr: Address) -> BondManager<TokioRuntime> {
+    let mut mgr = BondManager::new(
+        vec![claim_addr],
+        "http://localhost:8545".parse().unwrap(),
+        empty_factory(),
+        1000,
+        TEST_DISCOVERY_INTERVAL,
+        TokioRuntime::new(),
+    );
+    mgr.set_weth_delay(Duration::from_secs(0));
+    mgr
+}
 
 #[tokio::test]
 async fn test_bond_manager_full_lifecycle() {
@@ -1207,36 +916,18 @@ async fn test_bond_manager_full_lifecycle() {
     // status=1 (CHALLENGER_WINS) to represent a game that has already been
     // resolved on-chain. The manager detects this and advances directly
     // to NeedsUnlock without submitting a resolve transaction.
-    let claim_addr = Address::repeat_byte(0xCC);
+    let claim_addr = ZK_PROVER_ADDR;
     let game_addr = addr(0);
-    let tx_hash = B256::repeat_byte(0xDD);
+    let tx_hash = DEFAULT_TX_HASH;
+    let verifier = bond_test_verifier(claim_addr);
 
-    // Set up verifier mock: status=1 (CHALLENGER_WINS), bond_unlocked=false,
-    // bond_claimed=false.
-    let mut verifier_games = HashMap::new();
-    let mut state = mock_state(1, Address::ZERO, 100);
-    state.bond_recipient = claim_addr;
-    verifier_games.insert(game_addr, state);
-    let verifier = Arc::new(MockAggregateVerifier { games: verifier_games });
-
-    // Mock submitter with enough responses for unlock + withdraw.
-    // No resolve tx needed since the game is already resolved.
     let submitter = MockBondTransactionSubmitter::with_responses(vec![
         Ok(tx_hash), // claimCredit (unlock) tx
         Ok(tx_hash), // claimCredit (withdraw) tx
     ]);
 
-    let mut mgr = BondManager::new(
-        vec![claim_addr],
-        "http://localhost:8545".parse().unwrap(),
-        empty_factory(),
-        1000,
-        TEST_DISCOVERY_INTERVAL,
-        TokioRuntime::new(),
-    );
-    mgr.set_weth_delay(Duration::from_secs(0)); // instant delay for testing
+    let mut mgr = default_bond_manager(claim_addr);
 
-    // Track the game.
     assert!(mgr.track_game(game_addr, claim_addr));
     assert_eq!(mgr.tracked_count(), 1);
 
@@ -1267,86 +958,21 @@ async fn test_bond_manager_full_lifecycle() {
 }
 
 #[tokio::test]
-async fn test_bond_manager_skips_already_resolved_game() {
-    // When a game is already resolved on-chain (status != 0), the manager
-    // should skip resolve and advance directly to NeedsUnlock.
-    let claim_addr = Address::repeat_byte(0xCC);
-    let game_addr = addr(0);
-    let tx_hash = B256::repeat_byte(0xDD);
-
-    let mut verifier_games = HashMap::new();
-    let mut state = mock_state(1, Address::ZERO, 100); // status=1 (CHALLENGER_WINS)
-    state.bond_recipient = claim_addr;
-    verifier_games.insert(game_addr, state);
-    let verifier = Arc::new(MockAggregateVerifier { games: verifier_games });
-
-    // Only need 2 responses: unlock + withdraw (no resolve since already resolved).
-    let submitter = MockBondTransactionSubmitter::with_responses(vec![
-        Ok(tx_hash), // claimCredit (unlock) tx
-        Ok(tx_hash), // claimCredit (withdraw) tx
-    ]);
-
-    let mut mgr = BondManager::new(
-        vec![claim_addr],
-        "http://localhost:8545".parse().unwrap(),
-        empty_factory(),
-        1000,
-        TEST_DISCOVERY_INTERVAL,
-        TokioRuntime::new(),
-    );
-    mgr.set_weth_delay(Duration::from_secs(0));
-    mgr.track_game(game_addr, claim_addr);
-
-    // Poll 1: NeedsResolve → sees status != 0 → advances to NeedsUnlock (no tx).
-    mgr.poll(&*verifier, &submitter).await;
-    assert_eq!(mgr.tracked_count(), 1);
-
-    // Poll 2: NeedsUnlock → submits unlock tx → AwaitingDelay.
-    mgr.poll(&*verifier, &submitter).await;
-    assert_eq!(mgr.tracked_count(), 1);
-
-    // Poll 3: AwaitingDelay (delay=0) → NeedsWithdraw.
-    mgr.poll(&*verifier, &submitter).await;
-    assert_eq!(mgr.tracked_count(), 1);
-
-    // Poll 4: NeedsWithdraw → submits withdraw tx → Completed → removed.
-    mgr.poll(&*verifier, &submitter).await;
-    assert_eq!(mgr.tracked_count(), 0);
-
-    // Only 2 transactions submitted (no resolve).
-    assert_eq!(submitter.recorded_calls().len(), 2);
-}
-
-#[tokio::test]
 async fn test_bond_manager_skips_already_unlocked_game() {
-    // When the bond is already unlocked on-chain, the manager should skip
-    // to AwaitingDelay.
-    let claim_addr = Address::repeat_byte(0xCC);
+    let claim_addr = ZK_PROVER_ADDR;
     let game_addr = addr(0);
-    let tx_hash = B256::repeat_byte(0xDD);
+    let tx_hash = DEFAULT_TX_HASH;
 
-    let mut verifier_games = HashMap::new();
-    let mut state = mock_state(1, Address::ZERO, 100);
-    state.bond_recipient = claim_addr;
+    let mut state = bond_test_state(claim_addr);
     state.bond_unlocked = true;
     state.resolved_at = 1_000_000;
-    verifier_games.insert(game_addr, state);
-    let verifier = Arc::new(MockAggregateVerifier { games: verifier_games });
+    let verifier = single_game_verifier(state);
 
-    // Only need 1 response: withdraw (resolve and unlock already done).
     let submitter = MockBondTransactionSubmitter::with_responses(vec![
-        Ok(tx_hash), // claimCredit (withdraw) tx
+        Ok(tx_hash), // withdraw
     ]);
 
-    let mut mgr = BondManager::new(
-        vec![claim_addr],
-        "http://localhost:8545".parse().unwrap(),
-        empty_factory(),
-        1000,
-        TEST_DISCOVERY_INTERVAL,
-        TokioRuntime::new(),
-    );
-    mgr.set_weth_delay(Duration::from_secs(0));
+    let mut mgr = default_bond_manager(claim_addr);
     mgr.track_game(game_addr, claim_addr);
 
     // Poll 1: NeedsResolve → status != 0 → NeedsUnlock (no tx).
@@ -1370,42 +996,24 @@ async fn test_bond_manager_skips_already_unlocked_game() {
 
 #[tokio::test]
 async fn test_bond_manager_skips_already_claimed_game() {
-    // When the bond is already claimed on-chain, the manager should skip
-    // and complete immediately.
-    let claim_addr = Address::repeat_byte(0xCC);
+    let claim_addr = ZK_PROVER_ADDR;
     let game_addr = addr(0);
 
-    let mut verifier_games = HashMap::new();
-    let mut state = mock_state(1, Address::ZERO, 100);
-    state.bond_recipient = claim_addr;
+    let mut state = bond_test_state(claim_addr);
     state.bond_unlocked = true;
     state.bond_claimed = true;
     state.resolved_at = 1_000_000;
-    verifier_games.insert(game_addr, state);
-    let verifier = Arc::new(MockAggregateVerifier { games: verifier_games });
+    let verifier = single_game_verifier(state);
 
-    // No responses needed — no transactions should be submitted.
     let submitter = MockBondTransactionSubmitter::with_responses(vec![]);
 
-    let mut mgr = BondManager::new(
-        vec![claim_addr],
-        "http://localhost:8545".parse().unwrap(),
-        empty_factory(),
-        1000,
-        TEST_DISCOVERY_INTERVAL,
-        TokioRuntime::new(),
-    );
-    mgr.set_weth_delay(Duration::from_secs(0));
+    let mut mgr = default_bond_manager(claim_addr);
     mgr.track_game(game_addr, claim_addr);
 
-    // Poll 1: NeedsResolve → status != 0 → NeedsUnlock.
-    mgr.poll(&*verifier, &submitter).await;
-
-    // Poll 2: NeedsUnlock → bond_unlocked=true → AwaitingDelay.
-    mgr.poll(&*verifier, &submitter).await;
-
-    // Poll 3: AwaitingDelay (delay=0) → NeedsWithdraw.
-    mgr.poll(&*verifier, &submitter).await;
+    // Polls 1-3: NeedsResolve → NeedsUnlock → AwaitingDelay → NeedsWithdraw (no txs).
+    for _ in 0..3 {
+        mgr.poll(&*verifier, &submitter).await;
+    }
 
     // Poll 4: NeedsWithdraw → bond_claimed=true → Completed → removed.
     mgr.poll(&*verifier, &submitter).await;
@@ -1419,34 +1027,17 @@ async fn test_bond_manager_skips_already_claimed_game() {
 
 #[tokio::test]
 async fn test_bond_manager_tx_failure_retries() {
-    // When a bond transaction fails, the manager should retry on the next
-    // poll tick. Tests claimCredit (unlock) failure and retry from the
-    // NeedsUnlock phase.
-    let claim_addr = Address::repeat_byte(0xCC);
+    let claim_addr = ZK_PROVER_ADDR;
     let game_addr = addr(0);
-    let tx_hash = B256::repeat_byte(0xDD);
+    let tx_hash = DEFAULT_TX_HASH;
+    let verifier = bond_test_verifier(claim_addr);
 
-    let mut verifier_games = HashMap::new();
-    let mut state = mock_state(1, Address::ZERO, 100); // status=1 (CHALLENGER_WINS)
-    state.bond_recipient = claim_addr;
-    verifier_games.insert(game_addr, state);
-    let verifier = Arc::new(MockAggregateVerifier { games: verifier_games });
-
-    // First claimCredit attempt fails, second succeeds.
     let submitter = MockBondTransactionSubmitter::with_responses(vec![
         Err(base_tx_manager::TxManagerError::NonceTooLow.into()),
         Ok(tx_hash), // retry succeeds
     ]);
 
-    let mut mgr = BondManager::new(
-        vec![claim_addr],
-        "http://localhost:8545".parse().unwrap(),
-        empty_factory(),
-        1000,
-        TEST_DISCOVERY_INTERVAL,
-        TokioRuntime::new(),
-    );
-    mgr.set_weth_delay(Duration::from_secs(0));
+    let mut mgr = default_bond_manager(claim_addr);
     mgr.track_game(game_addr, claim_addr);
 
     // Poll 1: NeedsResolve → status=1 (already resolved, CHALLENGER_WINS) → NeedsUnlock.
@@ -1466,54 +1057,32 @@ async fn test_bond_manager_tx_failure_retries() {
 
 #[tokio::test]
 async fn test_bond_manager_ignores_non_claim_addresses() {
-    // Games whose bondRecipient is not in the claim addresses should not
-    // be tracked.
-    let claim_addr = Address::repeat_byte(0xCC);
+    let claim_addr = ZK_PROVER_ADDR;
     let other_addr = Address::repeat_byte(0xDD);
     let game_addr = addr(0);
 
-    let mut mgr = BondManager::new(
-        vec![claim_addr],
-        "http://localhost:8545".parse().unwrap(),
-        empty_factory(),
-        1000,
-        TEST_DISCOVERY_INTERVAL,
-        TokioRuntime::new(),
-    );
+    let mut mgr = default_bond_manager(claim_addr);
     assert!(!mgr.track_game(game_addr, other_addr));
     assert_eq!(mgr.tracked_count(), 0);
 }
 
 #[tokio::test]
 async fn test_bond_manager_keeps_defender_wins_when_recipient_is_claimable() {
-    // When a game resolves as DEFENDER_WINS and the on-chain bondRecipient
-    // is in our claim addresses (i.e. we are the proposer), the manager
-    // should keep the game and advance it to NeedsUnlock — the bond is ours.
-    let claim_addr = Address::repeat_byte(0xCC);
+    // DEFENDER_WINS but bondRecipient is ours → keep and advance to NeedsUnlock.
+    let claim_addr = ZK_PROVER_ADDR;
     let game_addr = addr(0);
 
-    let mut verifier_games = HashMap::new();
-    let mut state = mock_state(2, Address::ZERO, 100); // status=2 (DEFENDER_WINS)
-    state.bond_recipient = claim_addr;
-    verifier_games.insert(game_addr, state);
-    let verifier = Arc::new(MockAggregateVerifier { games: verifier_games });
+    let mut state = bond_test_state(claim_addr);
+    state.status = 2; // DEFENDER_WINS
+    let verifier = single_game_verifier(state);
 
     let submitter = MockBondTransactionSubmitter::with_responses(vec![]);
 
-    let mut mgr = BondManager::new(
-        vec![claim_addr],
-        "http://localhost:8545".parse().unwrap(),
-        empty_factory(),
-        1000,
-        TEST_DISCOVERY_INTERVAL,
-        TokioRuntime::new(),
-    );
-    mgr.set_weth_delay(Duration::from_secs(0));
+    let mut mgr = default_bond_manager(claim_addr);
     mgr.track_game(game_addr, claim_addr);
     assert_eq!(mgr.tracked_count(), 1);
 
-    // Poll 1: NeedsResolve → status=2 (already resolved) → bondRecipient
-    // is in claim set → advance to NeedsUnlock (not removed).
+    // Poll 1: NeedsResolve → resolved, bondRecipient in claim set → NeedsUnlock.
     mgr.poll(&*verifier, &submitter).await;
     assert_eq!(
         mgr.tracked_count(),
@@ -1524,37 +1093,23 @@ async fn test_bond_manager_keeps_defender_wins_when_recipient_is_claimable() {
 
 #[tokio::test]
 async fn test_bond_manager_removes_game_when_recipient_not_claimable() {
-    // When a game is resolved and the on-chain bondRecipient is NOT in our
-    // claim addresses, the manager should remove the game from tracking.
-    // This covers the case where we matched via zkProver during the startup
-    // scan, but after resolve the bond goes to someone else.
-    let claim_addr = Address::repeat_byte(0xCC);
+    // bondRecipient not in claim set → removed from tracking.
+    let claim_addr = ZK_PROVER_ADDR;
     let other_addr = Address::repeat_byte(0xDD);
     let game_addr = addr(0);
 
-    let mut verifier_games = HashMap::new();
-    let mut state = mock_state(2, Address::ZERO, 100); // status=2 (DEFENDER_WINS)
+    let mut state = bond_test_state(claim_addr);
+    state.status = 2; // DEFENDER_WINS
     state.bond_recipient = other_addr; // bond goes to someone else
-    verifier_games.insert(game_addr, state);
-    let verifier = Arc::new(MockAggregateVerifier { games: verifier_games });
+    let verifier = single_game_verifier(state);
 
-    // No responses needed — no transactions should be submitted.
     let submitter = MockBondTransactionSubmitter::with_responses(vec![]);
 
-    let mut mgr = BondManager::new(
-        vec![claim_addr],
-        "http://localhost:8545".parse().unwrap(),
-        empty_factory(),
-        1000,
-        TEST_DISCOVERY_INTERVAL,
-        TokioRuntime::new(),
-    );
-    mgr.set_weth_delay(Duration::from_secs(0));
+    let mut mgr = default_bond_manager(claim_addr);
     mgr.track_game(game_addr, claim_addr);
     assert_eq!(mgr.tracked_count(), 1);
 
-    // Poll 1: NeedsResolve → already resolved → bondRecipient not in
-    // claim set → removed from tracking.
+    // Poll 1: NeedsResolve → resolved, bondRecipient not in claim set → removed.
     mgr.poll(&*verifier, &submitter).await;
     assert_eq!(
         mgr.tracked_count(),
@@ -1570,58 +1125,18 @@ async fn test_bond_manager_removes_game_when_recipient_not_claimable() {
 
 #[tokio::test]
 async fn test_driver_tracks_bond_after_successful_challenge() {
-    // After a successful challenge() submission, the driver should register
-    // the game with the bond manager.
     let (l2, factory, verifier) = invalid_game_mocks();
     let sender_addr = Address::ZERO; // MockTxManager returns ZERO as sender_address
 
-    let zk = Arc::new(MockZkProofProvider {
-        session_id: "bond-track".to_string(),
-        proof_status: Mutex::new(base_zk_client::ProofJobStatus::Succeeded as i32),
-        receipt: Mutex::new(vec![0xDE, 0xAD]),
-        ..Default::default()
-    });
+    let zk = succeeded_zk_prover("bond-track", vec![0xDE, 0xAD]);
 
-    let tx_hash = B256::repeat_byte(0xCC);
-    let tx_manager = MockTxManager::new(Ok(receipt_with_status(true, tx_hash)));
+    let tx_manager = default_tx_manager();
 
-    let scanner = GameScanner::new(
-        Arc::clone(&factory) as Arc<dyn base_proof_contracts::DisputeGameFactoryClient>,
-        Arc::clone(&verifier) as Arc<dyn AggregateVerifierClient>,
-        ScannerConfig { lookback_games: 1000 },
-    );
-    let validator = OutputValidator::new(l2);
-    let submitter = ChallengeSubmitter::new(tx_manager);
-
-    let config = DriverConfig {
-        poll_interval: Duration::from_millis(10),
-        cancel: CancellationToken::new(),
-        ready: Arc::new(AtomicBool::new(false)),
-    };
-
-    // Bond manager with the sender address as a claim address.
-    let mut bond_manager = BondManager::new(
-        vec![sender_addr],
-        "http://localhost:8545".parse().unwrap(),
-        empty_factory(),
-        1000,
-        TEST_DISCOVERY_INTERVAL,
-        TokioRuntime::new(),
-    );
+    let mut bond_manager = default_bond_manager(sender_addr);
     bond_manager.set_weth_delay(Duration::from_secs(3600));
 
-    let mut driver = Driver::new(
-        config,
-        DriverComponents {
-            scanner,
-            validator,
-            zk_prover: zk,
-            submitter,
-            tee: None,
-            verifier_client: verifier as Arc<dyn AggregateVerifierClient>,
-            bond_manager: Some(bond_manager),
-        },
-    );
+    let mut driver = test_driver(factory, verifier, l2, zk, tx_manager);
+    driver.bond_manager = Some(bond_manager);
 
     // Step 1: proof initiated, not yet polled.
     driver.step().await.unwrap();
@@ -1633,7 +1148,6 @@ async fn test_driver_tracks_bond_after_successful_challenge() {
     // Step 2: proof polled → Succeeded → challenge tx submitted → bond tracked.
     driver.step().await.unwrap();
 
-    // After a successful challenge, the bond_manager should be tracking the game.
     let bond_mgr = driver.bond_manager.as_ref().expect("bond_manager should be Some");
     assert!(
         bond_mgr.is_tracking(&addr(0)),

--- a/crates/proof/primitives/src/lib.rs
+++ b/crates/proof/primitives/src/lib.rs
@@ -15,7 +15,7 @@ mod proposal;
 pub use proposal::{ECDSA_SIGNATURE_LENGTH, PROOF_JOURNAL_BASE_LENGTH, ProofJournal, Proposal};
 
 mod proof_encoder;
-pub use proof_encoder::{CryptoError, PROOF_TYPE_TEE, ProofEncoder};
+pub use proof_encoder::{CryptoError, PROOF_TYPE_TEE, PROOF_TYPE_ZK, ProofEncoder};
 
 mod prover;
 pub use prover::ProverBackend;

--- a/crates/proof/primitives/src/proof_encoder.rs
+++ b/crates/proof/primitives/src/proof_encoder.rs
@@ -13,6 +13,9 @@ const ECDSA_V_OFFSET: u8 = 27;
 /// Proof type byte for TEE proofs (matches `AggregateVerifier.ProofType.TEE`).
 pub const PROOF_TYPE_TEE: u8 = 0;
 
+/// Proof type byte for ZK proofs (matches `AggregateVerifier.ProofType.ZK`).
+pub const PROOF_TYPE_ZK: u8 = 1;
+
 /// Errors that can occur during cryptographic operations.
 #[derive(Debug, Clone, Eq, PartialEq, Error)]
 pub enum CryptoError {


### PR DESCRIPTION
## Summary

General cleanup and refactoring of the `base-challenger` crate. No behavioral changes.

### Highlights

- **Concurrency:** Batch sequential RPC calls into `futures::try_join!` in bond management (`try_unlock`, `determine_bond_phase`) and game scanning (`inspect_game`).
- **API alignment:** Convert `verify_account_proof` free function to `AccountProofVerifier::verify()` method on a unit struct per workspace conventions. Replace `RpcL1HeadProvider` with a blanket `impl<T: L1Provider + Debug> L1HeadProvider for T`.
- **Deduplication:** Extract `PROOF_TYPE_ZK` constant into `base-proof-primitives` (was duplicated as `ZK_PROOF_TYPE_BYTE`). Extract `ensure_weth_delay()` and `estimate_unlock_time()` helpers in bond manager. Centralize test mock setup into shared helpers and constants, removing ~600 lines of boilerplate.
- **Dependency hygiene:** Make `alloy-consensus` optional (test-utils only). Regroup and reorder `Cargo.toml` dependencies. Use `L1Client` from `base-proof-rpc` instead of constructing a raw `RootProvider` for TEE setup.
- **Reduced abstractions:** Remove unnecessary `Arc` indirection in `evaluate_bond_range`. Remove unused `session_id()`/`proof_bytes()` accessors and `Clone` derives. Remove `#[from]` on `ConfigError::Signer` to avoid ambiguous `From` impls.
- **Logging:** Downgrade noisy `info!`/`warn!` messages to `debug!` (tx candidate logging, unknown WETH delay).
- **Match exhaustiveness:** Remove defensive catch-all `_` arm in `classify()`, explicitly handle all prover state combinations.
- **Error messages:** Generalize `ChallengeSubmitError::TxReverted` message (used for both nullify and challenge txs). Preserve original `ProofVerificationError` in `AccountProofError` instead of stringifying.
- **Comments & docs:** Remove redundant comments throughout. Update README to reflect all current modules.