### PR TITLE
feat(consensus): Emit Engine Task Queue Depth Gauge

### DIFF
--- a/crates/consensus/engine/src/metrics/mod.rs
+++ b/crates/consensus/engine/src/metrics/mod.rs
@@ -31,6 +31,8 @@ base_metrics::define_metrics! {
     engine_reset_count: counter,
     #[describe("Payloads dropped because unsafe head changed between build and seal")]
     sequencer_unsafe_head_changed_total: counter,
+    #[describe("Number of tasks currently pending in the engine task queue")]
+    engine_task_queue_depth: gauge,
 }
 
 impl Metrics {

--- a/crates/consensus/engine/src/task_queue/core.rs
+++ b/crates/consensus/engine/src/task_queue/core.rs
@@ -69,6 +69,7 @@ impl<EngineClient_: EngineClient> Engine<EngineClient_> {
     pub fn enqueue(&mut self, task: EngineTask<EngineClient_>) {
         self.tasks.push(task);
         self.task_queue_length.send_replace(self.tasks.len());
+        Metrics::engine_task_queue_depth().set(self.tasks.len() as f64);
     }
 
     /// Resets the engine by finding a plausible sync starting point via
@@ -180,6 +181,7 @@ impl<EngineClient_: EngineClient> Engine<EngineClient_> {
             self.tasks.pop();
 
             self.task_queue_length.send_replace(self.tasks.len());
+            Metrics::engine_task_queue_depth().set(self.tasks.len() as f64);
         }
 
         Ok(())

--- a/deny.toml
+++ b/deny.toml
@@ -82,7 +82,6 @@ skip = [
     # Crypto crates - version differences from different crypto stacks
     "block-buffer",
     "const-oid",
-    "cpufeatures",
     "crypto-common",
     "digest",
     "sha1",
@@ -94,6 +93,7 @@ skip = [
     "socket2",
     "bitflags",
     "redox_users",
+    "redox_syscall",
 
     # Network crates
     "tungstenite",
@@ -159,7 +159,6 @@ skip = [
     "toml",
     "toml_datetime",
     "toml_edit",
-    "winnow",
 
     # etcetera version mismatch: sqlx-mysql uses 0.8.x, testcontainers uses 0.11.x
     "etcetera",


### PR DESCRIPTION
## Summary

Adds the `engine_task_queue_depth` Prometheus gauge to the engine metrics, emitting the current pending task count alongside the existing `task_queue_length` watch channel on every `enqueue` and post-pop `drain` call. The queue length was already computed at both sites, so this is zero-cost instrumentation. A growing queue is one of the clearest early signals that the engine is stalling, and this gauge completes the `engine_task_count` / `engine_task_failure` picture for operators monitoring throughput.

Closes #2035.