### PR TITLE
feat(consensus): Add Finalize Task Duration Histogram

### DIFF
--- a/crates/consensus/engine/src/metrics/mod.rs
+++ b/crates/consensus/engine/src/metrics/mod.rs
@@ -31,6 +31,8 @@ base_metrics::define_metrics! {
     engine_reset_count: counter,
     #[describe("Payloads dropped because unsafe head changed between build and seal")]
     sequencer_unsafe_head_changed_total: counter,
+    #[describe("Total duration of the finalize task in seconds")]
+    engine_finalize_duration_seconds: histogram,
 }
 
 impl Metrics {

--- a/crates/consensus/engine/src/task_queue/tasks/finalize/task.rs
+++ b/crates/consensus/engine/src/task_queue/tasks/finalize/task.rs
@@ -8,7 +8,7 @@ use base_protocol::L2BlockInfo;
 use derive_more::Constructor;
 
 use crate::{
-    EngineClient, EngineState, EngineTaskExt, FinalizeTaskError, SynchronizeTask,
+    EngineClient, EngineState, EngineTaskExt, FinalizeTaskError, Metrics, SynchronizeTask,
     state::EngineSyncStateUpdate,
 };
 
@@ -62,6 +62,8 @@ impl<EngineClient_: EngineClient> EngineTaskExt for FinalizeTask<EngineClient_> 
         .execute(state)
         .await?;
         let fcu_duration = fcu_start.elapsed();
+        let total_duration = block_fetch_start.elapsed();
+        Metrics::engine_finalize_duration_seconds().record(total_duration.as_secs_f64());
 
         info!(
             target: "engine",

--- a/deny.toml
+++ b/deny.toml
@@ -82,7 +82,6 @@ skip = [
     # Crypto crates - version differences from different crypto stacks
     "block-buffer",
     "const-oid",
-    "cpufeatures",
     "crypto-common",
     "digest",
     "sha1",
@@ -94,6 +93,7 @@ skip = [
     "socket2",
     "bitflags",
     "redox_users",
+    "redox_syscall",
 
     # Network crates
     "tungstenite",
@@ -159,7 +159,6 @@ skip = [
     "toml",
     "toml_datetime",
     "toml_edit",
-    "winnow",
 
     # etcetera version mismatch: sqlx-mysql uses 0.8.x, testcontainers uses 0.11.x
     "etcetera",


### PR DESCRIPTION
## Summary

Adds an `engine_finalize_duration_seconds` Prometheus histogram to track the total latency of `FinalizeTask::execute`, covering both the L2 block fetch and the subsequent forkchoice update. The existing `engine_method_request_duration` histogram only covers the FCU portion and aggregates all callers, making it insufficient for isolating finalization regressions. This dedicated histogram enables p99 alerting and makes L2 provider latency spikes visible in dashboards. Closes #2037.