### PR TITLE
feat(consensus): Histogram Per Derivation Pipeline Step

### DIFF
--- a/crates/consensus/service/src/actors/derivation/actor.rs
+++ b/crates/consensus/service/src/actors/derivation/actor.rs
@@ -137,14 +137,12 @@ where
         // first attributes are produced. All batches at and before the safe head will be
         // dropped, so the first payload will always be the disputed one.
         loop {
-            let step_result = base_metrics::time!(
-                Metrics::derivation_pipeline_step_duration_seconds(),
-                {
+            let step_result =
+                base_metrics::time!(Metrics::derivation_pipeline_step_duration_seconds(), {
                     self.pipeline
                         .step(self.derivation_state_machine.last_confirmed_safe_head())
                         .await
-                }
-            );
+                });
             match step_result {
                 StepResult::PreparedAttributes => { /* continue; attributes will be sent off. */ }
                 StepResult::AdvancedOrigin => {

--- a/crates/consensus/service/src/actors/derivation/actor.rs
+++ b/crates/consensus/service/src/actors/derivation/actor.rs
@@ -137,8 +137,15 @@ where
         // first attributes are produced. All batches at and before the safe head will be
         // dropped, so the first payload will always be the disputed one.
         loop {
-            match self.pipeline.step(self.derivation_state_machine.last_confirmed_safe_head()).await
-            {
+            let step_result = base_metrics::time!(
+                Metrics::derivation_pipeline_step_duration_seconds(),
+                {
+                    self.pipeline
+                        .step(self.derivation_state_machine.last_confirmed_safe_head())
+                        .await
+                }
+            );
+            match step_result {
                 StepResult::PreparedAttributes => { /* continue; attributes will be sent off. */ }
                 StepResult::AdvancedOrigin => {
                     let origin =

--- a/crates/consensus/service/src/metrics/mod.rs
+++ b/crates/consensus/service/src/metrics/mod.rs
@@ -8,6 +8,8 @@ base_metrics::define_metrics! {
     derivation_l1_origin: counter,
     #[describe("Critical errors in the derivation pipeline")]
     derivation_critical_errors: counter,
+    #[describe("Wall-clock duration of a single derivation pipeline step() call")]
+    derivation_pipeline_step_duration_seconds: histogram,
     #[describe("Tracks sequencer state flags")]
     #[label(active)]
     #[label(recovery)]

--- a/deny.toml
+++ b/deny.toml
@@ -82,7 +82,6 @@ skip = [
     # Crypto crates - version differences from different crypto stacks
     "block-buffer",
     "const-oid",
-    "cpufeatures",
     "crypto-common",
     "digest",
     "sha1",
@@ -94,6 +93,7 @@ skip = [
     "socket2",
     "bitflags",
     "redox_users",
+    "redox_syscall",
 
     # Network crates
     "tungstenite",
@@ -159,7 +159,6 @@ skip = [
     "toml",
     "toml_datetime",
     "toml_edit",
-    "winnow",
 
     # etcetera version mismatch: sqlx-mysql uses 0.8.x, testcontainers uses 0.11.x
     "etcetera",


### PR DESCRIPTION
## Summary

Adds a `derivation_pipeline_step_duration_seconds` histogram metric recorded around each `pipeline.step()` call in `DerivationActor::produce_next_attributes`. This captures the wall-clock time of every step through all eight derivation stages, providing the earliest possible signal that derivation is falling behind before safe head lag or step count stagnation become apparent. The metric is defined in the service crate metrics and recorded using the existing `base_metrics::time!` macro, consistent with how `pipeline_origin_advance` and `pipeline_attributes_build_duration` are instrumented.

Closes #2043