### PR TITLE
refactor(tee): deduplicate MockRegistry test helper in nitro-host

### DIFF
--- a/crates/proof/tee/nitro-host/src/health.rs
+++ b/crates/proof/tee/nitro-host/src/health.rs
@@ -69,8 +69,10 @@ mod tests {
     use base_proof_contracts::TEEProverRegistryClient;
 
     use super::*;
-    use crate::test_utils::{MockRegistry, TEST_SIGNER};
-    use crate::transport::NitroTransport;
+    use crate::{
+        test_utils::{MockRegistry, TEST_SIGNER},
+        transport::NitroTransport,
+    };
 
     fn test_healthz_with_mock(
         registry: impl TEEProverRegistryClient + 'static,

--- a/crates/proof/tee/nitro-host/src/health.rs
+++ b/crates/proof/tee/nitro-host/src/health.rs
@@ -64,65 +64,13 @@ impl HealthzApiServer for RegistrationHealthzRpc {
 
 #[cfg(test)]
 mod tests {
-    use std::sync::{
-        Arc,
-        atomic::{AtomicBool, AtomicUsize, Ordering},
-    };
+    use std::sync::{Arc, atomic::Ordering};
 
-    use alloy_primitives::{Address, address};
     use base_proof_contracts::TEEProverRegistryClient;
-    use jsonrpsee::core::async_trait;
 
     use super::*;
+    use crate::test_utils::{MockRegistry, TEST_SIGNER};
     use crate::transport::NitroTransport;
-
-    #[derive(Clone)]
-    struct MockRegistry {
-        valid: Arc<AtomicBool>,
-        call_count: Arc<AtomicUsize>,
-        should_fail: Arc<AtomicBool>,
-    }
-
-    impl MockRegistry {
-        fn new(valid: bool) -> Self {
-            Self {
-                valid: Arc::new(AtomicBool::new(valid)),
-                call_count: Arc::new(AtomicUsize::new(0)),
-                should_fail: Arc::new(AtomicBool::new(false)),
-            }
-        }
-    }
-
-    #[async_trait]
-    impl TEEProverRegistryClient for MockRegistry {
-        async fn is_valid_signer(
-            &self,
-            _signer: Address,
-        ) -> Result<bool, base_proof_contracts::ContractError> {
-            self.call_count.fetch_add(1, Ordering::Relaxed);
-            if self.should_fail.load(Ordering::Relaxed) {
-                return Err(base_proof_contracts::ContractError::Validation(
-                    "mock RPC failure".into(),
-                ));
-            }
-            Ok(self.valid.load(Ordering::Relaxed))
-        }
-
-        async fn is_registered_signer(
-            &self,
-            _signer: Address,
-        ) -> Result<bool, base_proof_contracts::ContractError> {
-            unimplemented!()
-        }
-
-        async fn get_registered_signers(
-            &self,
-        ) -> Result<Vec<Address>, base_proof_contracts::ContractError> {
-            unimplemented!()
-        }
-    }
-
-    const TEST_SIGNER: Address = address!("f39Fd6e51aad88F6F4ce6aB8827279cffFb92266");
 
     fn test_healthz_with_mock(
         registry: impl TEEProverRegistryClient + 'static,

--- a/crates/proof/tee/nitro-host/src/lib.rs
+++ b/crates/proof/tee/nitro-host/src/lib.rs
@@ -22,3 +22,6 @@ pub use transport::NitroTransport;
 mod vsock;
 #[cfg(target_os = "linux")]
 pub use vsock::VsockTransport;
+
+#[cfg(test)]
+pub mod test_utils;

--- a/crates/proof/tee/nitro-host/src/registration.rs
+++ b/crates/proof/tee/nitro-host/src/registration.rs
@@ -181,66 +181,15 @@ impl RegistrationChecker {
 #[cfg(test)]
 mod tests {
     use std::{
-        sync::{
-            Arc,
-            atomic::{AtomicBool, AtomicUsize, Ordering},
-        },
+        sync::{Arc, atomic::Ordering},
         time::Instant,
     };
 
-    use alloy_primitives::{Address, address};
+    use alloy_primitives::Address;
     use base_proof_contracts::TEEProverRegistryClient;
-    use jsonrpsee::core::async_trait;
 
     use super::*;
-
-    #[derive(Clone)]
-    struct MockRegistry {
-        valid: Arc<AtomicBool>,
-        call_count: Arc<AtomicUsize>,
-        should_fail: Arc<AtomicBool>,
-    }
-
-    impl MockRegistry {
-        fn new(valid: bool) -> Self {
-            Self {
-                valid: Arc::new(AtomicBool::new(valid)),
-                call_count: Arc::new(AtomicUsize::new(0)),
-                should_fail: Arc::new(AtomicBool::new(false)),
-            }
-        }
-    }
-
-    #[async_trait]
-    impl TEEProverRegistryClient for MockRegistry {
-        async fn is_valid_signer(
-            &self,
-            _signer: Address,
-        ) -> Result<bool, base_proof_contracts::ContractError> {
-            self.call_count.fetch_add(1, Ordering::Relaxed);
-            if self.should_fail.load(Ordering::Relaxed) {
-                return Err(base_proof_contracts::ContractError::Validation(
-                    "mock RPC failure".into(),
-                ));
-            }
-            Ok(self.valid.load(Ordering::Relaxed))
-        }
-
-        async fn is_registered_signer(
-            &self,
-            _signer: Address,
-        ) -> Result<bool, base_proof_contracts::ContractError> {
-            unimplemented!()
-        }
-
-        async fn get_registered_signers(
-            &self,
-        ) -> Result<Vec<Address>, base_proof_contracts::ContractError> {
-            unimplemented!()
-        }
-    }
-
-    const TEST_SIGNER: Address = address!("f39Fd6e51aad88F6F4ce6aB8827279cffFb92266");
+    use crate::test_utils::{MockRegistry, TEST_SIGNER};
 
     fn test_checker_with_mock(
         registry: impl TEEProverRegistryClient + 'static,

--- a/crates/proof/tee/nitro-host/src/test_utils.rs
+++ b/crates/proof/tee/nitro-host/src/test_utils.rs
@@ -44,9 +44,7 @@ impl TEEProverRegistryClient for MockRegistry {
     ) -> Result<bool, base_proof_contracts::ContractError> {
         self.call_count.fetch_add(1, Ordering::Relaxed);
         if self.should_fail.load(Ordering::Relaxed) {
-            return Err(base_proof_contracts::ContractError::Validation(
-                "mock RPC failure".into(),
-            ));
+            return Err(base_proof_contracts::ContractError::Validation("mock RPC failure".into()));
         }
         Ok(self.valid.load(Ordering::Relaxed))
     }

--- a/crates/proof/tee/nitro-host/src/test_utils.rs
+++ b/crates/proof/tee/nitro-host/src/test_utils.rs
@@ -1,0 +1,66 @@
+//! Shared test utilities for the `base-proof-tee-nitro-host` crate.
+
+use std::sync::{
+    Arc,
+    atomic::{AtomicBool, AtomicUsize, Ordering},
+};
+
+use alloy_primitives::{Address, address};
+use base_proof_contracts::TEEProverRegistryClient;
+use jsonrpsee::core::async_trait;
+
+/// Well-known test signer address (Hardhat account #0).
+pub const TEST_SIGNER: Address = address!("f39Fd6e51aad88F6F4ce6aB8827279cffFb92266");
+
+/// In-memory mock of [`TEEProverRegistryClient`] for unit tests.
+///
+/// Tracks call counts and supports injecting failures via [`should_fail`](Self::should_fail).
+#[derive(Debug, Clone)]
+pub struct MockRegistry {
+    /// Whether `is_valid_signer` returns `true`.
+    pub valid: Arc<AtomicBool>,
+    /// Number of times `is_valid_signer` has been called.
+    pub call_count: Arc<AtomicUsize>,
+    /// When `true`, `is_valid_signer` returns a [`ContractError::Validation`] error.
+    pub should_fail: Arc<AtomicBool>,
+}
+
+impl MockRegistry {
+    /// Creates a new mock with the given initial validity and zero call count.
+    pub fn new(valid: bool) -> Self {
+        Self {
+            valid: Arc::new(AtomicBool::new(valid)),
+            call_count: Arc::new(AtomicUsize::new(0)),
+            should_fail: Arc::new(AtomicBool::new(false)),
+        }
+    }
+}
+
+#[async_trait]
+impl TEEProverRegistryClient for MockRegistry {
+    async fn is_valid_signer(
+        &self,
+        _signer: Address,
+    ) -> Result<bool, base_proof_contracts::ContractError> {
+        self.call_count.fetch_add(1, Ordering::Relaxed);
+        if self.should_fail.load(Ordering::Relaxed) {
+            return Err(base_proof_contracts::ContractError::Validation(
+                "mock RPC failure".into(),
+            ));
+        }
+        Ok(self.valid.load(Ordering::Relaxed))
+    }
+
+    async fn is_registered_signer(
+        &self,
+        _signer: Address,
+    ) -> Result<bool, base_proof_contracts::ContractError> {
+        unimplemented!()
+    }
+
+    async fn get_registered_signers(
+        &self,
+    ) -> Result<Vec<Address>, base_proof_contracts::ContractError> {
+        unimplemented!()
+    }
+}


### PR DESCRIPTION
## Summary

Extract the duplicated `MockRegistry` test struct into a shared `test_utils` module in `base-proof-tee-nitro-host`.

## Motivation

Both `registration.rs` and `health.rs` contained identical ~40-line `MockRegistry` implementations (struct + `TEEProverRegistryClient` impl). This duplication meant any change to the mock interface had to be made in two places.

## Changes

- **New:** `crates/proof/tee/nitro-host/src/test_utils.rs` — shared `MockRegistry` and `TEST_SIGNER` constant
- **Updated:** `registration.rs` tests — import from `crate::test_utils` instead of defining inline
- **Updated:** `health.rs` tests — same
- **Updated:** `lib.rs` — added `#[cfg(test)] pub mod test_utils`

Net result: **-108 lines duplicated → +66 lines shared**, removing 42 lines overall.

## Testing

```
cargo check -p base-proof-tee-nitro-host
cargo test -p base-proof-tee-nitro-host
cargo clippy -p base-proof-tee-nitro-host
```