### PR TITLE
fix(load-tests): add TLS support and block timestamp fallback 

### DIFF
--- a/crates/infra/load-tests/Cargo.toml
+++ b/crates/infra/load-tests/Cargo.toml
@@ -51,6 +51,6 @@ tokio-util.workspace = true
 parking_lot.workspace = true
 serde_json.workspace = true
 serde_yaml.workspace = true
-tokio-tungstenite.workspace = true
+tokio-tungstenite = { workspace = true, features = ["native-tls"] }
 
 [dev-dependencies]

--- a/crates/infra/load-tests/examples/sepolia.yaml
+++ b/crates/infra/load-tests/examples/sepolia.yaml
@@ -4,8 +4,11 @@
 
 rpc: https://sepolia.base.org
 
-# WebSocket endpoints for latency tracking
-rpc_ws_url: "wss://sepolia.base.org"
+# Block latency is tracked via block timestamps (no WebSocket required).
+# For more precise timing via WebSocket subscription, configure rpc_ws_url with a
+# provider that supports WebSocket (the public sepolia.base.org does not).
+#
+# rpc_ws_url: "wss://your-provider.example/ws"
 flashblocks_ws_url: "wss://sepolia.flashblocks.base.org/ws"
 
 sender_count: 10

--- a/crates/infra/load-tests/src/bin/load_test.rs
+++ b/crates/infra/load-tests/src/bin/load_test.rs
@@ -183,6 +183,10 @@ async fn run_load_test(args: Vec<String>) -> Result<()> {
         println!("Gas: total={}  avg/tx={}", summary.gas.total_gas, summary.gas.avg_gas);
     }
 
+    // Brief cooldown so in-flight load-test transactions can land and
+    // mempool state settles before we query balances for the drain.
+    tokio::time::sleep(Duration::from_secs(2)).await;
+
     println!();
     println!("Draining accounts back to funder...");
     match runner.drain_accounts(funding_key).await {

--- a/crates/infra/load-tests/src/config/test_config.rs
+++ b/crates/infra/load-tests/src/config/test_config.rs
@@ -115,12 +115,12 @@ pub struct TestConfig {
     #[serde(default)]
     pub looper_contract: Option<String>,
 
-    /// WebSocket JSON-RPC endpoint URL for block subscription.
-    #[serde(default = "default_rpc_ws_url", alias = "ws_url")]
-    pub rpc_ws_url: Url,
-    /// WebSocket URL for flashblocks subscription.
-    #[serde(default = "default_flashblocks_ws_url", alias = "flashblocks_url")]
-    pub flashblocks_ws_url: Url,
+    /// WebSocket JSON-RPC endpoint URL for block subscription (enables block latency tracking).
+    #[serde(default, alias = "ws_url")]
+    pub rpc_ws_url: Option<Url>,
+    /// WebSocket URL for flashblocks subscription (enables flashblock latency tracking).
+    #[serde(default, alias = "flashblocks_url")]
+    pub flashblocks_ws_url: Option<Url>,
 }
 
 impl Default for TestConfig {
@@ -138,8 +138,8 @@ impl Default for TestConfig {
             chain_id: None,
             transactions: vec![WeightedTxType { weight: 100, tx_type: TxTypeConfig::Transfer }],
             looper_contract: None,
-            rpc_ws_url: default_rpc_ws_url(),
-            flashblocks_ws_url: default_flashblocks_ws_url(),
+            rpc_ws_url: None,
+            flashblocks_ws_url: None,
         }
     }
 }
@@ -241,14 +241,6 @@ const fn default_iterations() -> u32 {
     1
 }
 
-fn default_rpc_ws_url() -> Url {
-    Url::parse("ws://localhost:8546").expect("valid default rpc_ws_url")
-}
-
-fn default_flashblocks_ws_url() -> Url {
-    Url::parse("ws://localhost:7111").expect("valid default flashblocks_ws_url")
-}
-
 impl TestConfig {
     /// Loads configuration from a YAML file.
     pub fn load<P: AsRef<Path>>(path: P) -> Result<Self> {
@@ -272,7 +264,30 @@ impl TestConfig {
         if self.sender_count == 0 {
             return Err(BaselineError::Config("sender_count must be > 0".into()));
         }
+
+        if let Some(url) = &self.rpc_ws_url {
+            Self::validate_ws_url(url, "rpc_ws_url")?;
+        }
+        if let Some(url) = &self.flashblocks_ws_url {
+            Self::validate_ws_url(url, "flashblocks_ws_url")?;
+        }
+
         Ok(())
+    }
+
+    fn validate_ws_url(url: &Url, field_name: &str) -> Result<()> {
+        match url.scheme() {
+            "ws" | "wss" => Ok(()),
+            "http" => Err(BaselineError::Config(format!(
+                "{field_name} uses 'http://' scheme but requires 'ws://' for WebSocket connections"
+            ))),
+            "https" => Err(BaselineError::Config(format!(
+                "{field_name} uses 'https://' scheme but requires 'wss://' for secure WebSocket connections"
+            ))),
+            scheme => Err(BaselineError::Config(format!(
+                "{field_name} has invalid scheme '{scheme}', expected 'ws://' or 'wss://'"
+            ))),
+        }
     }
 
     /// Returns the funder key from the `FUNDER_KEY` environment variable.
@@ -544,5 +559,49 @@ transactions:
         }
 
         assert!(config.looper_contract.is_some());
+    }
+
+    #[test]
+    fn rejects_http_scheme_for_ws_url() {
+        let yaml = r#"
+rpc: http://localhost:8545
+rpc_ws_url: http://localhost:8546
+"#;
+        let err = TestConfig::from_yaml(yaml).unwrap_err();
+        assert!(err.to_string().contains("rpc_ws_url"));
+        assert!(err.to_string().contains("ws://"));
+    }
+
+    #[test]
+    fn rejects_https_scheme_for_ws_url() {
+        let yaml = r#"
+rpc: http://localhost:8545
+rpc_ws_url: https://localhost:8546
+"#;
+        let err = TestConfig::from_yaml(yaml).unwrap_err();
+        assert!(err.to_string().contains("rpc_ws_url"));
+        assert!(err.to_string().contains("wss://"));
+    }
+
+    #[test]
+    fn accepts_wss_scheme_for_ws_url() {
+        let yaml = r#"
+rpc: http://localhost:8545
+rpc_ws_url: wss://localhost:8546
+flashblocks_ws_url: wss://localhost:7111
+"#;
+        let config = TestConfig::from_yaml(yaml).unwrap();
+        assert_eq!(config.rpc_ws_url.as_ref().unwrap().scheme(), "wss");
+        assert_eq!(config.flashblocks_ws_url.as_ref().unwrap().scheme(), "wss");
+    }
+
+    #[test]
+    fn accepts_omitted_ws_urls() {
+        let yaml = r#"
+rpc: http://localhost:8545
+"#;
+        let config = TestConfig::from_yaml(yaml).unwrap();
+        assert!(config.rpc_ws_url.is_none());
+        assert!(config.flashblocks_ws_url.is_none());
     }
 }

--- a/crates/infra/load-tests/src/rpc/client.rs
+++ b/crates/infra/load-tests/src/rpc/client.rs
@@ -1,4 +1,4 @@
-use std::future::Future;
+use std::{future::Future, sync::Arc};
 
 use alloy_network::{Ethereum, EthereumWallet};
 use alloy_primitives::{Address, TxHash, U256};
@@ -9,10 +9,13 @@ use alloy_provider::{
 use alloy_rpc_types::BlockNumberOrTag;
 use base_alloy_network::Base;
 use base_common_rpc_types::OpTransactionReceipt;
+use parking_lot::RwLock;
 use tracing::instrument;
 use url::Url;
 
 use crate::utils::{BaselineError, Result};
+
+type BlockTimestampCache = Arc<RwLock<std::collections::HashMap<u64, u64>>>;
 
 /// Provider trait for fetching transaction receipts and block data.
 ///
@@ -27,6 +30,12 @@ pub trait ReceiptProvider: Send + Sync {
         &self,
         tx_hash: TxHash,
     ) -> impl Future<Output = Result<Option<OpTransactionReceipt>>> + Send;
+
+    /// Fetches the block timestamp (unix seconds) for a given block number.
+    fn get_block_timestamp(
+        &self,
+        block_number: u64,
+    ) -> impl Future<Output = Result<Option<u64>>> + Send;
 }
 
 /// Provider type with wallet signing capability for sending transactions.
@@ -54,13 +63,14 @@ pub fn create_wallet_provider(rpc_url: Url, wallet: EthereumWallet) -> WalletPro
 pub struct RpcClient {
     provider: RootProvider<Base>,
     url: Url,
+    block_timestamp_cache: BlockTimestampCache,
 }
 
 impl RpcClient {
     /// Creates a new RPC client.
     pub fn new(url: Url) -> Self {
         let provider = RootProvider::<Base>::new_http(url.clone());
-        Self { provider, url }
+        Self { provider, url, block_timestamp_cache: Arc::new(RwLock::new(Default::default())) }
     }
 
     /// Returns the RPC endpoint URL.
@@ -129,6 +139,30 @@ impl RpcClient {
 
         Ok(block.map(|b| b.transactions.hashes().collect()).unwrap_or_default())
     }
+
+    /// Fetches the block timestamp (unix seconds) for a given block number, with caching.
+    #[instrument(skip(self))]
+    pub async fn get_block_timestamp(&self, block_number: u64) -> Result<Option<u64>> {
+        if let Some(&ts) = self.block_timestamp_cache.read().get(&block_number) {
+            return Ok(Some(ts));
+        }
+
+        let block = self
+            .provider
+            .get_block_by_number(BlockNumberOrTag::Number(block_number))
+            .hashes()
+            .await
+            .map_err(|e| BaselineError::Rpc(e.to_string()))?;
+
+        let Some(block) = block else {
+            return Ok(None);
+        };
+
+        let timestamp = block.header.timestamp;
+        self.block_timestamp_cache.write().insert(block_number, timestamp);
+
+        Ok(Some(timestamp))
+    }
 }
 
 impl std::fmt::Debug for RpcClient {
@@ -147,5 +181,9 @@ impl ReceiptProvider for RpcClient {
         tx_hash: TxHash,
     ) -> Result<Option<OpTransactionReceipt>> {
         self.get_transaction_receipt(tx_hash).await
+    }
+
+    async fn get_block_timestamp(&self, block_number: u64) -> Result<Option<u64>> {
+        self.get_block_timestamp(block_number).await
     }
 }

--- a/crates/infra/load-tests/src/runner/config.rs
+++ b/crates/infra/load-tests/src/runner/config.rs
@@ -87,10 +87,10 @@ pub struct LoadConfig {
     pub batch_timeout: Duration,
     /// Maximum gas price cap to prevent overspending during congestion.
     pub max_gas_price: u128,
-    /// WebSocket JSON-RPC endpoint URL for block subscription.
-    pub rpc_ws_url: Url,
-    /// WebSocket URL for flashblocks subscription.
-    pub flashblocks_ws_url: Url,
+    /// WebSocket JSON-RPC endpoint URL for block subscription (enables block latency tracking).
+    pub rpc_ws_url: Option<Url>,
+    /// WebSocket URL for flashblocks subscription (enables flashblock latency tracking).
+    pub flashblocks_ws_url: Option<Url>,
 }
 
 impl LoadConfig {
@@ -110,10 +110,10 @@ impl LoadConfig {
             batch_size: 5,
             batch_timeout: Duration::from_millis(50),
             max_gas_price: DEFAULT_MAX_GAS_PRICE,
-            rpc_ws_url: "ws://localhost:8546".parse().expect("valid default rpc_ws_url"),
-            flashblocks_ws_url: "ws://localhost:7111"
-                .parse()
-                .expect("valid default flashblocks_ws_url"),
+            rpc_ws_url: Some("ws://localhost:8546".parse().expect("valid default rpc_ws_url")),
+            flashblocks_ws_url: Some(
+                "ws://localhost:7111".parse().expect("valid default flashblocks_ws_url"),
+            ),
         }
     }
 

--- a/crates/infra/load-tests/src/runner/confirmer.rs
+++ b/crates/infra/load-tests/src/runner/confirmer.rs
@@ -1,10 +1,10 @@
 use std::{
-    collections::{BTreeMap, HashMap, HashSet},
+    collections::{HashMap, HashSet},
     sync::{
         Arc,
         atomic::{AtomicBool, AtomicU64, Ordering},
     },
-    time::{Duration, Instant},
+    time::{Duration, Instant, SystemTime},
 };
 
 use alloy_primitives::{Address, TxHash};
@@ -41,6 +41,7 @@ pub struct Confirmer {
     flashblock_times: FlashblockTimes,
     block_first_seen: BlockFirstSeen,
     deferred_block_latencies: Vec<DeferredBlockLatency>,
+    block_ws_enabled: bool,
 }
 
 /// A confirmed tx whose block latency could not be computed yet because
@@ -49,6 +50,7 @@ struct DeferredBlockLatency {
     metrics: TransactionMetrics,
     block_number: u64,
     submit_time: Instant,
+    submit_timestamp: u64,
     deferred_at: Instant,
 }
 
@@ -71,8 +73,7 @@ struct PendingTx {
     tx_hash: TxHash,
     from: Address,
     submit_time: Instant,
-    /// Set when the tx is first seen in a pending/latest block.
-    /// Triggers eager receipt fetching rather than waiting for straggler timeout.
+    submit_timestamp: u64,
     included_at: Option<Instant>,
 }
 
@@ -93,7 +94,17 @@ impl ConfirmerHandle {
         }
         self.total_in_flight.fetch_add(1, Ordering::SeqCst);
 
-        let pending = PendingTx { tx_hash, from, submit_time: Instant::now(), included_at: None };
+        let submit_timestamp = SystemTime::now()
+            .duration_since(SystemTime::UNIX_EPOCH)
+            .map(|d| d.as_secs())
+            .unwrap_or(0);
+        let pending = PendingTx {
+            tx_hash,
+            from,
+            submit_time: Instant::now(),
+            submit_timestamp,
+            included_at: None,
+        };
 
         if self.pending_tx.send(pending).await.is_err() {
             if let Some(counter) = self.in_flight_per_sender.get(&from) {
@@ -123,31 +134,18 @@ impl ConfirmerHandle {
 }
 
 impl Confirmer {
-    /// Creates a confirmer without shared timing data.
+    /// Creates a confirmer with shared timing data.
     ///
-    /// Block and flashblock latencies will always be `None`. Use
-    /// [`with_timing_data`](Self::with_timing_data) to enable latency tracking.
+    /// Set `block_ws_enabled` to `true` when the `BlockWatcher` is running (WebSocket
+    /// available). When `false`, block latency is calculated from block timestamps
+    /// fetched via RPC.
     pub fn new(
-        sender_addresses: &[Address],
-        metrics_tx: mpsc::Sender<TransactionMetrics>,
-        stop_flag: Arc<AtomicBool>,
-    ) -> Self {
-        Self::with_timing_data(
-            sender_addresses,
-            metrics_tx,
-            stop_flag,
-            Arc::new(RwLock::new(HashMap::new())),
-            Arc::new(RwLock::new(BTreeMap::new())),
-        )
-    }
-
-    /// Creates a confirmer with shared timing data from the WebSocket watchers.
-    pub fn with_timing_data(
         sender_addresses: &[Address],
         metrics_tx: mpsc::Sender<TransactionMetrics>,
         stop_flag: Arc<AtomicBool>,
         flashblock_times: FlashblockTimes,
         block_first_seen: BlockFirstSeen,
+        block_ws_enabled: bool,
     ) -> Self {
         let mut in_flight_map = HashMap::new();
         for addr in sender_addresses {
@@ -170,6 +168,7 @@ impl Confirmer {
             flashblock_times,
             block_first_seen,
             deferred_block_latencies: Vec::new(),
+            block_ws_enabled,
         }
     }
 
@@ -243,7 +242,7 @@ impl Confirmer {
     }
 
     async fn poll_confirmations(&mut self, client: &impl ReceiptProvider, draining: bool) {
-        self.resolve_deferred_block_latencies(draining).await;
+        self.resolve_deferred_block_latencies(client, draining).await;
 
         if self.pending.is_empty() {
             return;
@@ -364,6 +363,7 @@ impl Confirmer {
                             metrics,
                             block_number: bn,
                             submit_time: pending.submit_time,
+                            submit_timestamp: pending.submit_timestamp,
                             deferred_at: Instant::now(),
                         });
                     } else {
@@ -386,7 +386,11 @@ impl Confirmer {
         }
     }
 
-    async fn resolve_deferred_block_latencies(&mut self, flush: bool) {
+    async fn resolve_deferred_block_latencies(
+        &mut self,
+        client: &impl ReceiptProvider,
+        flush: bool,
+    ) {
         if self.deferred_block_latencies.is_empty() {
             return;
         }
@@ -395,10 +399,11 @@ impl Confirmer {
         let mut still_pending = Vec::new();
         let mut to_send = Vec::new();
 
-        {
-            let block_times = self.block_first_seen.read();
-            for mut deferred in self.deferred_block_latencies.drain(..) {
-                let block_latency = block_times
+        for mut deferred in self.deferred_block_latencies.drain(..) {
+            if self.block_ws_enabled {
+                let block_latency = self
+                    .block_first_seen
+                    .read()
                     .get(&deferred.block_number)
                     .and_then(|&t| t.checked_duration_since(deferred.submit_time));
 
@@ -408,7 +413,7 @@ impl Confirmer {
                         tx_hash = %deferred.metrics.tx_hash,
                         block = deferred.block_number,
                         block_latency_ms = latency.as_millis(),
-                        "deferred block latency resolved"
+                        "deferred block latency resolved via websocket"
                     );
                     to_send.push(deferred.metrics);
                 } else if flush
@@ -422,6 +427,56 @@ impl Confirmer {
                     to_send.push(deferred.metrics);
                 } else {
                     still_pending.push(deferred);
+                }
+            } else {
+                match client.get_block_timestamp(deferred.block_number).await {
+                    Ok(Some(block_ts)) if block_ts >= deferred.submit_timestamp => {
+                        let latency = Duration::from_secs(block_ts - deferred.submit_timestamp);
+                        deferred.metrics.block_latency = Some(latency);
+                        debug!(
+                            tx_hash = %deferred.metrics.tx_hash,
+                            block = deferred.block_number,
+                            block_latency_ms = latency.as_millis(),
+                            "block latency resolved via block timestamp"
+                        );
+                        to_send.push(deferred.metrics);
+                    }
+                    Ok(Some(block_ts)) => {
+                        debug!(
+                            tx_hash = %deferred.metrics.tx_hash,
+                            block = deferred.block_number,
+                            block_ts,
+                            submit_ts = deferred.submit_timestamp,
+                            "block timestamp before submit time (clock skew)"
+                        );
+                        to_send.push(deferred.metrics);
+                    }
+                    Ok(None)
+                        if flush
+                            || now.duration_since(deferred.deferred_at)
+                                > BLOCK_LATENCY_DEFER_TIMEOUT =>
+                    {
+                        to_send.push(deferred.metrics);
+                    }
+                    Ok(None) => {
+                        still_pending.push(deferred);
+                    }
+                    Err(e) => {
+                        warn!(
+                            tx_hash = %deferred.metrics.tx_hash,
+                            block = deferred.block_number,
+                            error = %e,
+                            "failed to fetch block timestamp"
+                        );
+                        if flush
+                            || now.duration_since(deferred.deferred_at)
+                                > BLOCK_LATENCY_DEFER_TIMEOUT
+                        {
+                            to_send.push(deferred.metrics);
+                        } else {
+                            still_pending.push(deferred);
+                        }
+                    }
                 }
             }
         }

--- a/crates/infra/load-tests/src/runner/load_runner.rs
+++ b/crates/infra/load-tests/src/runner/load_runner.rs
@@ -535,29 +535,45 @@ impl LoadRunner {
         let flashblock_times: FlashblockTimes = Arc::new(RwLock::new(HashMap::new()));
         let block_first_seen: BlockFirstSeen = Arc::new(RwLock::new(BTreeMap::new()));
 
-        info!(url = %self.config.flashblocks_ws_url, "starting flashblock tracker");
-        let flashblock_tracker_task = FlashblockTracker::new(
-            self.config.flashblocks_ws_url.clone(),
-            Arc::clone(&flashblock_times),
-            self.cancel_token.clone(),
-        )
-        .start();
+        let flashblock_tracker_task = if let Some(url) = &self.config.flashblocks_ws_url {
+            info!(url = %url, "starting flashblock tracker");
+            Some(
+                FlashblockTracker::new(
+                    url.clone(),
+                    Arc::clone(&flashblock_times),
+                    self.cancel_token.clone(),
+                )
+                .start(),
+            )
+        } else {
+            info!("flashblocks_ws_url not configured, flashblock latency tracking disabled");
+            None
+        };
 
-        info!(url = %self.config.rpc_ws_url, "starting block watcher");
-        let block_watcher_task = BlockWatcher::new(
-            self.config.rpc_ws_url.clone(),
-            Arc::clone(&block_first_seen),
-            self.cancel_token.clone(),
-        )
-        .start();
+        let block_watcher_task = if let Some(url) = &self.config.rpc_ws_url {
+            info!(url = %url, "starting block watcher");
+            Some(
+                BlockWatcher::new(
+                    url.clone(),
+                    Arc::clone(&block_first_seen),
+                    self.cancel_token.clone(),
+                )
+                .start(),
+            )
+        } else {
+            info!("rpc_ws_url not configured, using block timestamps for latency");
+            None
+        };
 
         let sender_addresses: Vec<_> = self.accounts.accounts().iter().map(|a| a.address).collect();
-        let mut confirmer = Confirmer::with_timing_data(
+        let block_ws_enabled = block_watcher_task.is_some();
+        let mut confirmer = Confirmer::new(
             &sender_addresses,
             metrics_tx,
             Arc::clone(&self.stop_flag),
             Arc::clone(&flashblock_times),
             Arc::clone(&block_first_seen),
+            block_ws_enabled,
         );
         let confirmer_handle = confirmer.handle();
         let confirmer_handle_for_run = confirmer_handle.clone();
@@ -816,13 +832,17 @@ impl LoadRunner {
         // Now safe to stop WebSocket tasks — confirmer is done.
         self.cancel_token.cancel();
 
-        match tokio::time::timeout(Duration::from_secs(2), flashblock_tracker_task).await {
-            Ok(Err(e)) if e.is_panic() => warn!(error = %e, "flashblock tracker panicked"),
-            _ => {}
+        if let Some(task) = flashblock_tracker_task {
+            match tokio::time::timeout(Duration::from_secs(2), task).await {
+                Ok(Err(e)) if e.is_panic() => warn!(error = %e, "flashblock tracker panicked"),
+                _ => {}
+            }
         }
-        match tokio::time::timeout(Duration::from_secs(2), block_watcher_task).await {
-            Ok(Err(e)) if e.is_panic() => warn!(error = %e, "block watcher panicked"),
-            _ => {}
+        if let Some(task) = block_watcher_task {
+            match tokio::time::timeout(Duration::from_secs(2), task).await {
+                Ok(Err(e)) if e.is_panic() => warn!(error = %e, "block watcher panicked"),
+                _ => {}
+            }
         }
 
         let confirmed = self.collector.confirmed_count();


### PR DESCRIPTION
- Add native-tls feature to tokio-tungstenite for wss:// support
- Make rpc_ws_url and flashblocks_ws_url optional in config
- Implement block timestamp fallback when WebSocket is unavailable for block latency
- Cache block timestamps to minimize RPC calls
