### PR TITLE
fix(txpool-tracing): record fb_inclusion_duration only once per transaction [backport v0.8.0]

### DIFF
--- a/crates/client/txpool-tracing/src/events.rs
+++ b/crates/client/txpool-tracing/src/events.rs
@@ -48,6 +48,7 @@ pub enum Pool {
 pub struct EventLog {
     pub(crate) mempool_time: Instant,
     pub(crate) pending_time: Option<Instant>,
+    pub(crate) fb_included: bool,
     pub(crate) events: Vec<(DateTime<Local>, TxEvent)>,
     pub(crate) limit: usize,
 }
@@ -57,7 +58,13 @@ impl EventLog {
     pub fn new(t: DateTime<Local>, event: TxEvent) -> Self {
         let now = Instant::now();
         let pending_time = if event == TxEvent::Pending { Some(now) } else { None };
-        Self { mempool_time: now, pending_time, events: vec![(t, event)], limit: 10 }
+        Self {
+            mempool_time: now,
+            pending_time,
+            fb_included: false,
+            events: vec![(t, event)],
+            limit: 10,
+        }
     }
 
     /// Append a new `(timestamp, event)` tuple to the log.

--- a/crates/client/txpool-tracing/src/tracker.rs
+++ b/crates/client/txpool-tracing/src/tracker.rs
@@ -194,9 +194,18 @@ impl Tracker {
 
     /// Track a transaction being included in a flashblock. This will not remove
     /// the tx from the cache.
+    ///
+    /// The `fb_included` flag on [`EventLog`] ensures that the metric is only
+    /// recorded once per transaction, even when [`PendingBlocks`] contains
+    /// transactions from earlier flashblocks that have already been measured.
     pub fn transaction_fb_included(&mut self, tx_hash: TxHash, received_at: Instant) {
-        // Only track if we have seen this transaction before
-        if let Some(event_log) = self.txs.peek(&tx_hash) {
+        // Only track if we have seen this transaction before and it hasn't
+        // already been recorded as included in a flashblock.
+        if let Some(event_log) = self.txs.get_mut(&tx_hash) {
+            if event_log.fb_included {
+                return;
+            }
+
             // Record `fb_inclusion_duration` metric if transaction was pending
             if let Some(pending_time) = event_log.pending_time {
                 let time_pending_to_fb_inclusion = received_at.duration_since(pending_time);
@@ -210,6 +219,8 @@ impl Tracker {
                     "Transaction included in flashblock"
                 );
             }
+
+            event_log.fb_included = true;
         }
     }
 
@@ -576,6 +587,29 @@ mod tests {
         // Only one should remain
         assert_eq!(tracker.txs.len(), 1);
         assert!(tracker.txs.get(&tx_hash2).is_some());
+    }
+
+    #[test]
+    fn test_fb_inclusion_recorded_only_once() {
+        let mut tracker = Tracker::new(false);
+        let tx_hash = TxHash::random();
+
+        tracker.transaction_inserted(tx_hash, TxEvent::Pending);
+        let first_received_at = Instant::now();
+
+        // First flashblock notification should mark the tx as fb-included.
+        tracker.transaction_fb_included(tx_hash, first_received_at);
+        let event_log = tracker.txs.get(&tx_hash).expect("tx should still be in cache");
+        assert!(event_log.fb_included, "should be marked as fb-included after first call");
+
+        // Simulate a later flashblock arriving — received_at is much later.
+        let later_received_at = first_received_at + Duration::from_millis(500);
+        tracker.transaction_fb_included(tx_hash, later_received_at);
+
+        // The tx should still be present and still marked — the second call
+        // must have been a no-op (no duplicate metric recording).
+        let event_log = tracker.txs.get(&tx_hash).expect("tx should still be in cache");
+        assert!(event_log.fb_included);
     }
 
     #[tokio::test]

--- a/deny.toml
+++ b/deny.toml
@@ -94,6 +94,7 @@ skip = [
     "socket2",
     "bitflags",
     "redox_users",
+    "redox_syscall",
 
     # Network crates
     "tungstenite",


### PR DESCRIPTION
## Summary

Backport of #2094 to `releases/v0.8.0`.

- `track_flashblock_transactions` calls `get_pending_transaction_hashes()` which returns **all** tx hashes across all flashblocks in `PendingBlocks`, not just the latest delta. Without a guard, `transaction_fb_included` re-records the `fb_inclusion_duration` metric on every subsequent flashblock notification with an increasingly stale `received_at`, inflating the histogram significantly (e.g. a real 200ms inclusion gets recorded as 200, 400, 600, 800ms across successive flashblocks).
- Adds an `fb_included` flag to `EventLog` that gets set on first measurement and causes subsequent calls to early-return, ensuring each transaction's flashblock inclusion time is recorded exactly once.
- Adds `test_fb_inclusion_recorded_only_once` to verify the dedup behavior.

Cherry-picked cleanly from `hh/fix-tracing-fb-inclusion-time` (d256b516d).