### PR TITLE
ktlo(execution): Remove Allow Missing Docs

### DIFF
--- a/crates/execution/node/tests/e2e-testsuite/main.rs
+++ b/crates/execution/node/tests/e2e-testsuite/main.rs
@@ -1,4 +1,4 @@
-#![allow(missing_docs)]
+//! E2E integration tests for the execution node.
 
 mod p2p;
 mod testsuite;

--- a/crates/execution/node/tests/e2e-testsuite/p2p.rs
+++ b/crates/execution/node/tests/e2e-testsuite/p2p.rs
@@ -1,3 +1,5 @@
+//! P2P sync integration tests for the execution node.
+
 use std::sync::Arc;
 
 use base_node_core::utils::{advance_chain, setup};

--- a/crates/execution/node/tests/e2e-testsuite/testsuite.rs
+++ b/crates/execution/node/tests/e2e-testsuite/testsuite.rs
@@ -1,3 +1,5 @@
+//! Reth e2e testsuite integration tests for the execution node.
+
 use std::sync::Arc;
 
 use alloy_primitives::{Address, B64, B256};

--- a/crates/execution/node/tests/it/main.rs
+++ b/crates/execution/node/tests/it/main.rs
@@ -1,4 +1,4 @@
-#![allow(missing_docs)]
+//! Integration tests for the execution node.
 
 mod priority;
 


### PR DESCRIPTION
## Summary

Removes the `#![allow(missing_docs)]` suppression from the two execution integration test entry points and replaces it with proper `//!` module doc comments, as required by CLAUDE.md.

Closes #2058