### PR TITLE
fix(execution): Remove Pub Crate Visibility

### DIFF
--- a/crates/execution/cli/src/app.rs
+++ b/crates/execution/cli/src/app.rs
@@ -29,7 +29,8 @@ where
     Ext: clap::Args + fmt::Debug,
     Rpc: RpcModuleValidator,
 {
-    pub(crate) fn new(cli: Cli<Ext, Rpc>) -> Self {
+    /// Creates a new [`CliApp`] wrapping the given parsed CLI.
+    pub fn new(cli: Cli<Ext, Rpc>) -> Self {
         Self { cli, runner: None, layers: Some(Layers::new()), guard: None }
     }
 

--- a/crates/execution/consensus/src/lib.rs
+++ b/crates/execution/consensus/src/lib.rs
@@ -31,7 +31,7 @@ use reth_primitives_traits::{
 };
 
 mod proof;
-pub use proof::calculate_receipt_root_no_memo_optimism;
+pub use proof::{calculate_receipt_root_no_memo_optimism, calculate_receipt_root_optimism};
 
 pub mod validation;
 pub use validation::{canyon, isthmus, validate_block_post_execution};

--- a/crates/execution/consensus/src/proof.rs
+++ b/crates/execution/consensus/src/proof.rs
@@ -10,7 +10,7 @@ use base_alloy_chains::BaseUpgrades;
 use base_alloy_consensus::DepositReceipt;
 
 /// Calculates the receipt root for a header.
-pub(crate) fn calculate_receipt_root_optimism<R: DepositReceipt>(
+pub fn calculate_receipt_root_optimism<R: DepositReceipt>(
     receipts: &[ReceiptWithBloom<&R>],
     chain_spec: impl BaseUpgrades,
     timestamp: u64,

--- a/crates/execution/node/src/utils.rs
+++ b/crates/execution/node/src/utils.rs
@@ -16,7 +16,7 @@ use tokio::sync::Mutex;
 use crate::OpNode as OtherOpNode;
 
 /// Base Node Helper type
-pub(crate) type OpNode =
+pub type OpNode =
     NodeHelperType<OtherOpNode, BlockchainProvider<NodeTypesWithDBAdapter<OtherOpNode, TmpDB>>>;
 
 /// Creates the initial setup with `num_nodes` of the node config, started and connected.

--- a/crates/execution/payload/src/payload.rs
+++ b/crates/execution/payload/src/payload.rs
@@ -170,13 +170,13 @@ impl<OpTransactionSigned> From<EthPayloadBuilderAttributes>
 #[derive(Debug, Clone)]
 pub struct OpBuiltPayload<N: NodePrimitives = OpPrimitives> {
     /// Identifier of the payload
-    pub(crate) id: PayloadId,
+    pub id: PayloadId,
     /// Sealed block
-    pub(crate) block: Arc<SealedBlock<N::Block>>,
+    pub block: Arc<SealedBlock<N::Block>>,
     /// Block execution data for the payload, if any.
-    pub(crate) executed_block: Option<BuiltPayloadExecutedBlock<N>>,
+    pub executed_block: Option<BuiltPayloadExecutedBlock<N>>,
     /// The fees of the block
-    pub(crate) fees: U256,
+    pub fees: U256,
 }
 
 // === impl BuiltPayload ===

--- a/crates/execution/rpc/src/lib.rs
+++ b/crates/execution/rpc/src/lib.rs
@@ -25,4 +25,4 @@ pub use engine::{OP_ENGINE_CAPABILITIES, OpEngineApi, OpEngineApiServer};
 pub use error::{OpEthApiError, OpInvalidTransactionError, SequencerClientError};
 pub use eth::{OpEthApi, OpEthApiBuilder, OpReceiptBuilder};
 pub use metrics::{DebugApiExtMetrics, DebugApis, EthApiExtMetrics, SequencerMetrics};
-pub use sequencer::SequencerClient;
+pub use sequencer::{SequencerClient, SequencerClientInner};

--- a/crates/execution/rpc/src/sequencer.rs
+++ b/crates/execution/rpc/src/sequencer.rs
@@ -47,7 +47,7 @@ pub struct SequencerClient {
 
 impl SequencerClientInner {
     /// Creates a new instance with the given endpoint and client.
-    pub(crate) const fn new(sequencer_endpoint: String, client: Client) -> Self {
+    pub const fn new(sequencer_endpoint: String, client: Client) -> Self {
         Self { sequencer_endpoint, client }
     }
 }
@@ -165,12 +165,13 @@ impl SequencerClient {
     }
 }
 
+/// Inner state of a [`SequencerClient`].
 #[derive(Debug)]
-struct SequencerClientInner {
+pub struct SequencerClientInner {
     /// The endpoint of the sequencer
-    sequencer_endpoint: String,
-    /// The client
-    client: Client,
+    pub sequencer_endpoint: String,
+    /// The RPC client
+    pub client: Client,
 }
 
 #[cfg(test)]

--- a/crates/execution/runner/src/builder.rs
+++ b/crates/execution/runner/src/builder.rs
@@ -23,7 +23,7 @@ type BaseComponents = <OpComponentsBuilder as NodeComponentsBuilder<OpNodeTypes>
 ///
 /// Because `Components` depends only on pool, network, executor, and consensus builders (not the
 /// payload service builder), this type is identical regardless of which payload service is used.
-pub(crate) type OpNodeAdapter = NodeAdapter<OpNodeTypes, BaseComponents>;
+pub type OpNodeAdapter = NodeAdapter<OpNodeTypes, BaseComponents>;
 
 /// Convenience alias for the OP Eth API type exposed by the reth RPC add-ons.
 type OpEthApi = <OpAddOns as RethRpcAddOns<OpNodeAdapter>>::EthApi;
@@ -56,7 +56,7 @@ type BoxExExFactory = Box<
 ///
 /// This is generic over the `NodeComponentsBuilder` (`CB`) so that both the default payload and
 /// the flashblocks payload service can be used interchangeably.
-pub(crate) type RethNodeBuilder<CB> =
+pub type RethNodeBuilder<CB> =
     WithLaunchContext<NodeBuilderWithComponents<OpNodeTypes, CB, OpAddOns>>;
 
 /// Pure hook accumulator for the Base node builder.

--- a/crates/execution/runner/src/lib.rs
+++ b/crates/execution/runner/src/lib.rs
@@ -8,7 +8,7 @@
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
 
 mod builder;
-pub use builder::{BaseRpcContext, NodeHooks};
+pub use builder::{BaseRpcContext, NodeHooks, OpNodeAdapter, RethNodeBuilder};
 
 mod extension;
 pub use extension::{BaseNodeExtension, FromExtensionConfig};
@@ -20,7 +20,7 @@ mod service;
 pub use service::{DefaultPayloadServiceBuilder, PayloadServiceBuilder};
 
 mod types;
-pub use types::{BaseNodeBuilder, BaseProvider, OpNodeTypes};
+pub use types::{BaseNodeBuilder, BaseProvider, OpAddOns, OpComponentsBuilder, OpNodeTypes};
 
 mod node;
 pub use node::BaseNode;

--- a/crates/execution/runner/src/test_utils/node.rs
+++ b/crates/execution/runner/src/test_utils/node.rs
@@ -29,9 +29,11 @@ pub type LocalNodeProvider = BaseProvider;
 
 /// Handle to a launched local node along with the resources required to keep it alive.
 pub struct LocalNode {
-    pub(crate) http_api_addr: SocketAddr,
+    /// HTTP API address of the local node.
+    pub http_api_addr: SocketAddr,
     engine_ipc_path: String,
-    pub(crate) ws_api_addr: SocketAddr,
+    /// WebSocket API address of the local node.
+    pub ws_api_addr: SocketAddr,
     provider: LocalNodeProvider,
     _node_exit_future: NodeExitFuture,
     _node: Box<dyn Any + Sync + Send>,

--- a/crates/execution/runner/src/types.rs
+++ b/crates/execution/runner/src/types.rs
@@ -12,9 +12,9 @@ use crate::node::BaseNode;
 /// Alias for the OP node type adapter used by the runner.
 pub type OpNodeTypes = FullNodeTypesAdapter<BaseNode, DatabaseEnv, BaseProvider>;
 /// Internal alias for the OP node components builder (default payload service).
-pub(crate) type OpComponentsBuilder = <BaseNode as Node<OpNodeTypes>>::ComponentsBuilder;
+pub type OpComponentsBuilder = <BaseNode as Node<OpNodeTypes>>::ComponentsBuilder;
 /// Internal alias for the OP node add-ons.
-pub(crate) type OpAddOns = <BaseNode as Node<OpNodeTypes>>::AddOns;
+pub type OpAddOns = <BaseNode as Node<OpNodeTypes>>::AddOns;
 
 /// A [`BlockchainProvider`] instance.
 pub type BaseProvider = BlockchainProvider<NodeTypesWithDBAdapter<BaseNode, DatabaseEnv>>;

--- a/crates/execution/trie/src/db/cursor.rs
+++ b/crates/execution/trie/src/db/cursor.rs
@@ -23,7 +23,7 @@ use crate::{
 };
 
 /// Generic alias for dup cursor for T
-pub(crate) type Dup<'tx, T> = <<DatabaseEnv as Database>::TX as DbTx>::DupCursor<T>;
+pub type Dup<'tx, T> = <<DatabaseEnv as Database>::TX as DbTx>::DupCursor<T>;
 
 /// Iterates versioned dup-sorted rows and returns the latest value (<= `max_block_number`),
 /// skipping tombstones.

--- a/crates/execution/trie/src/db/mod.rs
+++ b/crates/execution/trie/src/db/mod.rs
@@ -13,5 +13,5 @@ pub use store::MdbxProofsStorage;
 
 mod cursor;
 pub use cursor::{
-    BlockNumberVersionedCursor, MdbxAccountCursor, MdbxStorageCursor, MdbxTrieCursor,
+    BlockNumberVersionedCursor, Dup, MdbxAccountCursor, MdbxStorageCursor, MdbxTrieCursor,
 };

--- a/crates/execution/trie/src/db/models/mod.rs
+++ b/crates/execution/trie/src/db/models/mod.rs
@@ -12,7 +12,7 @@ pub use version::*;
 mod storage;
 pub use storage::*;
 mod change_set;
-pub(crate) mod kv;
+mod kv;
 use std::fmt;
 
 use alloy_primitives::B256;

--- a/crates/execution/trie/src/db/store.rs
+++ b/crates/execution/trie/src/db/store.rs
@@ -33,8 +33,8 @@ use crate::{
         cursor::Dup,
         models::{
             AccountTrieHistory, BlockChangeSet, ChangeSet, HashedAccountHistory,
-            HashedStorageHistory, HashedStorageKey, MaybeDeleted, StorageTrieHistory,
-            StorageTrieKey, StorageValue, VersionedValue, kv::IntoKV,
+            HashedStorageHistory, HashedStorageKey, IntoKV, MaybeDeleted, StorageTrieHistory,
+            StorageTrieKey, StorageValue, VersionedValue,
         },
     },
 };


### PR DESCRIPTION
## Summary

Several execution crates used `pub(crate)` visibility on types, functions, and struct fields, violating the workspace rule that all items must be `pub` with no `pub(crate)`. This change converts all such items to `pub` and ensures they are re-exported from their respective `lib.rs` files where appropriate. `SequencerClientInner` was also made public since its constructor was being exposed, and the `kv` submodule in the trie models was corrected to a private module with items re-exported via `pub use kv::*` per the modules-must-not-be-pub convention.

Closes #2060