### PR TITLE
refactor(tee): replace Transport(String) with structured NitroHostError variants

### DIFF
--- a/crates/proof/tee/nitro-host/src/error.rs
+++ b/crates/proof/tee/nitro-host/src/error.rs
@@ -1,6 +1,6 @@
 //! Error types for host-side TEE prover operations.
 
-use base_proof_tee_nitro_enclave::NitroError;
+use base_proof_tee_nitro_enclave::{NitroError, TransportError};
 use thiserror::Error;
 
 /// Top-level error type for host-side nitro prover operations.
@@ -9,7 +9,34 @@ pub enum NitroHostError {
     /// Enclave error (propagated from the enclave crate).
     #[error(transparent)]
     Enclave(#[from] NitroError),
-    /// Transport or protocol error on the vsock channel.
-    #[error("transport: {0}")]
-    Transport(String),
+    /// Vsock connection attempt timed out.
+    #[error("connect timed out")]
+    ConnectTimeout,
+    /// Vsock connection attempt failed.
+    #[error("connect failed: {0}")]
+    ConnectFailed(std::io::Error),
+    /// Writing a frame to the transport failed.
+    #[error("frame write failed: {0}")]
+    FrameWrite(TransportError),
+    /// Reading a frame from the transport failed.
+    #[error("frame read failed: {0}")]
+    FrameRead(TransportError),
+    /// The enclave returned a response type that does not match the request.
+    #[error("unexpected response for {expected}")]
+    UnexpectedResponse {
+        /// The request kind that was sent.
+        expected: &'static str,
+    },
+    /// The enclave returned an explicit error response.
+    #[error("enclave error: {0}")]
+    EnclaveRemoteError(String),
+    /// The signer public key returned by the enclave is malformed.
+    #[error("invalid signer public key: expected 65-byte uncompressed SEC1 key")]
+    InvalidSignerKey,
+    /// A response-read timed out (distinct from connect timeout).
+    #[error("{operation} timed out")]
+    ResponseTimeout {
+        /// The operation that timed out.
+        operation: &'static str,
+    },
 }

--- a/crates/proof/tee/nitro-host/src/vsock.rs
+++ b/crates/proof/tee/nitro-host/src/vsock.rs
@@ -33,8 +33,8 @@ impl VsockTransport {
         let addr = VsockAddr::new(self.cid, self.port);
         tokio::time::timeout(CONNECT_TIMEOUT, VsockStream::connect(addr))
             .await
-            .map_err(|_| NitroHostError::Transport("connect timed out".into()))?
-            .map_err(|e| NitroHostError::Transport(format!("connect failed: {e}")))
+            .map_err(|_| NitroHostError::ConnectTimeout)?
+            .map_err(NitroHostError::ConnectFailed)
     }
 
     /// Send preimages to the enclave and return the proof result.
@@ -56,17 +56,16 @@ impl VsockTransport {
 
         Frame::write(&mut stream, &EnclaveRequest::Prove(preimages))
             .await
-            .map_err(|e| NitroHostError::Transport(format!("write failed: {e}")))?;
+            .map_err(NitroHostError::FrameWrite)?;
 
-        let response: EnclaveResponse = Frame::read(&mut stream)
-            .await
-            .map_err(|e| NitroHostError::Transport(format!("read failed: {e}")))?;
+        let response: EnclaveResponse =
+            Frame::read(&mut stream).await.map_err(NitroHostError::FrameRead)?;
 
         match response {
             EnclaveResponse::Prove(result) => Ok(*result),
-            EnclaveResponse::Error(e) => Err(NitroHostError::Transport(format!("enclave: {e}"))),
+            EnclaveResponse::Error(e) => Err(NitroHostError::EnclaveRemoteError(e)),
             EnclaveResponse::SignerPublicKey(_) | EnclaveResponse::SignerAttestation(_) => {
-                Err(NitroHostError::Transport("unexpected response for prove".into()))
+                Err(NitroHostError::UnexpectedResponse { expected: "prove" })
             }
         }
     }
@@ -77,26 +76,24 @@ impl VsockTransport {
 
         Frame::write(&mut stream, &EnclaveRequest::SignerPublicKey)
             .await
-            .map_err(|e| NitroHostError::Transport(format!("write failed: {e}")))?;
+            .map_err(NitroHostError::FrameWrite)?;
 
         let response: EnclaveResponse =
             tokio::time::timeout(SIGNER_TIMEOUT, Frame::read(&mut stream))
                 .await
-                .map_err(|_| NitroHostError::Transport("signer_public_key timed out".into()))?
-                .map_err(|e| NitroHostError::Transport(format!("read failed: {e}")))?;
+                .map_err(|_| NitroHostError::ResponseTimeout { operation: "signer_public_key" })?
+                .map_err(NitroHostError::FrameRead)?;
 
         match response {
             EnclaveResponse::SignerPublicKey(key) => {
                 if key.len() != 65 || key[0] != 0x04 {
-                    return Err(NitroHostError::Transport(
-                        "invalid signer public key: expected 65-byte uncompressed SEC1 key".into(),
-                    ));
+                    return Err(NitroHostError::InvalidSignerKey);
                 }
                 Ok(key)
             }
-            EnclaveResponse::Error(e) => Err(NitroHostError::Transport(format!("enclave: {e}"))),
+            EnclaveResponse::Error(e) => Err(NitroHostError::EnclaveRemoteError(e)),
             EnclaveResponse::Prove(_) | EnclaveResponse::SignerAttestation(_) => {
-                Err(NitroHostError::Transport("unexpected response for signer_public_key".into()))
+                Err(NitroHostError::UnexpectedResponse { expected: "signer_public_key" })
             }
         }
     }
@@ -111,19 +108,19 @@ impl VsockTransport {
 
         Frame::write(&mut stream, &EnclaveRequest::SignerAttestation { user_data, nonce })
             .await
-            .map_err(|e| NitroHostError::Transport(format!("write failed: {e}")))?;
+            .map_err(NitroHostError::FrameWrite)?;
 
         let response: EnclaveResponse =
             tokio::time::timeout(SIGNER_TIMEOUT, Frame::read(&mut stream))
                 .await
-                .map_err(|_| NitroHostError::Transport("signer_attestation timed out".into()))?
-                .map_err(|e| NitroHostError::Transport(format!("read failed: {e}")))?;
+                .map_err(|_| NitroHostError::ResponseTimeout { operation: "signer_attestation" })?
+                .map_err(NitroHostError::FrameRead)?;
 
         match response {
             EnclaveResponse::SignerAttestation(doc) => Ok(doc),
-            EnclaveResponse::Error(e) => Err(NitroHostError::Transport(format!("enclave: {e}"))),
+            EnclaveResponse::Error(e) => Err(NitroHostError::EnclaveRemoteError(e)),
             EnclaveResponse::Prove(_) | EnclaveResponse::SignerPublicKey(_) => {
-                Err(NitroHostError::Transport("unexpected response for signer_attestation".into()))
+                Err(NitroHostError::UnexpectedResponse { expected: "signer_attestation" })
             }
         }
     }


### PR DESCRIPTION
## Summary

Replace the catch-all `NitroHostError::Transport(String)` variant with structured error variants, enabling programmatic matching and better diagnostics.

## Motivation

`Transport(String)` lost error context and made it impossible to distinguish transient failures (timeouts) from permanent ones (protocol errors, invalid keys). Callers had to string-match to determine the failure mode.

## Changes

### `error.rs` — new structured variants

| Old | New |
|-----|-----|
| `Transport("connect timed out")` | `ConnectTimeout` |
| `Transport("connect failed: ...")` | `ConnectFailed(std::io::Error)` |
| `Transport("write failed: ...")` | `FrameWrite(TransportError)` |
| `Transport("read failed: ...")` | `FrameRead(TransportError)` |
| `Transport("unexpected response for ...")` | `UnexpectedResponse { expected: &'static str }` |
| `Transport("enclave: ...")` | `EnclaveRemoteError(String)` |
| `Transport("invalid signer public key: ...")` | `InvalidSignerKey` |
| `Transport("... timed out")` | `ResponseTimeout { operation: &'static str }` |

### `vsock.rs` — updated all `.map_err()` call sites

Replaced `format!()`-based error construction with direct variant construction (e.g. `.map_err(NitroHostError::FrameWrite)`).

## Testing

```
cargo check -p base-proof-tee-nitro-host
cargo test -p base-proof-tee-nitro-host
cargo clippy -p base-proof-tee-nitro-host
```