### PR TITLE
fix(consensus): Backport L2 Chain ID Fix

### DIFF
--- a/crates/consensus/genesis/src/rollup.rs
+++ b/crates/consensus/genesis/src/rollup.rs
@@ -51,6 +51,13 @@ pub struct RollupConfig {
     /// The L1 chain ID
     pub l1_chain_id: u64,
     /// The L2 chain ID
+    #[cfg_attr(
+        feature = "serde",
+        serde(
+            serialize_with = "chain_id_as_u64",
+            deserialize_with = "chain_id_from_u64"
+        )
+    )]
     pub l2_chain_id: Chain,
     /// Hardfork timestamps.
     #[cfg_attr(feature = "serde", serde(flatten))]
@@ -417,6 +424,23 @@ impl RollupConfig {
             tracing::info!(target: "upgrades", block_number, "Activating base v1 upgrade");
         }
     }
+}
+
+/// Serializes a [`Chain`] as its numeric chain ID.
+///
+/// `alloy_chains::Chain` serializes named chains (e.g. Base Sepolia) as a string like
+/// `"base-sepolia"`, but external consumers such as op-batcher expect a plain integer.
+/// This helper forces numeric serialization for all chains.
+#[cfg(feature = "serde")]
+fn chain_id_as_u64<S: serde::Serializer>(chain: &Chain, serializer: S) -> Result<S::Ok, S::Error> {
+    serializer.serialize_u64(chain.id())
+}
+
+/// Deserializes a [`Chain`] from its numeric chain ID.
+#[cfg(feature = "serde")]
+fn chain_id_from_u64<'de, D: serde::Deserializer<'de>>(deserializer: D) -> Result<Chain, D::Error> {
+    let id = <u64 as serde::Deserialize>::deserialize(deserializer)?;
+    Ok(Chain::from_id(id))
 }
 
 #[cfg(test)]
@@ -844,6 +868,28 @@ mod tests {
 
         let err = serde_json::from_str::<RollupConfig>(raw).unwrap_err();
         assert_eq!(err.classify(), serde_json::error::Category::Data);
+    }
+
+    #[test]
+    #[cfg(feature = "serde")]
+    fn test_l2_chain_id_serializes_as_number() {
+        // Named chains (e.g. Base Sepolia, ID 84532) must serialize as a numeric JSON value,
+        // not as the string "base-sepolia". op-batcher and other Go consumers expect *big.Int.
+        let cfg = RollupConfig {
+            l2_chain_id: Chain::from_id(84532),
+            ..Default::default()
+        };
+        let json = serde_json::to_value(&cfg).unwrap();
+        assert!(
+            json["l2_chain_id"].is_number(),
+            "l2_chain_id must serialize as a number, got: {}",
+            json["l2_chain_id"]
+        );
+        assert_eq!(json["l2_chain_id"], 84532u64);
+
+        // Round-trip: deserializing from a numeric l2_chain_id must also work.
+        let round_tripped: RollupConfig = serde_json::from_value(json).unwrap();
+        assert_eq!(round_tripped.l2_chain_id.id(), 84532);
     }
 
     #[test]

--- a/crates/consensus/genesis/src/rollup.rs
+++ b/crates/consensus/genesis/src/rollup.rs
@@ -53,10 +53,7 @@ pub struct RollupConfig {
     /// The L2 chain ID
     #[cfg_attr(
         feature = "serde",
-        serde(
-            serialize_with = "chain_id_as_u64",
-            deserialize_with = "chain_id_from_u64"
-        )
+        serde(serialize_with = "chain_id_as_u64", deserialize_with = "chain_id_from_u64")
     )]
     pub l2_chain_id: Chain,
     /// Hardfork timestamps.
@@ -875,10 +872,7 @@ mod tests {
     fn test_l2_chain_id_serializes_as_number() {
         // Named chains (e.g. Base Sepolia, ID 84532) must serialize as a numeric JSON value,
         // not as the string "base-sepolia". op-batcher and other Go consumers expect *big.Int.
-        let cfg = RollupConfig {
-            l2_chain_id: Chain::from_id(84532),
-            ..Default::default()
-        };
+        let cfg = RollupConfig { l2_chain_id: Chain::from_id(84532), ..Default::default() };
         let json = serde_json::to_value(&cfg).unwrap();
         assert!(
             json["l2_chain_id"].is_number(),


### PR DESCRIPTION
## Summary

This backports the fix for RollupConfig serializing l2_chain_id as a string (e.g. "base-sepolia") rather than a numeric ID when using a named alloy chain. op-batcher and other Go consumers deserialize this field into a *big.Int and fail with a parse error on the string form. The fix adds custom serde helpers so l2_chain_id always serializes and deserializes as a plain u64 integer.