### PR TITLE
fix(ci): use pull-request mode for vouch to respect branch protection

### DIFF
--- a/.github/workflows/vouch.yml
+++ b/.github/workflows/vouch.yml
@@ -42,6 +42,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      pull-requests: write
       issues: write
     steps:
       - name: Harden the runner (Audit all outbound calls)
@@ -54,5 +55,8 @@ jobs:
           repo: ${{ github.repository }}
           issue-id: ${{ github.event.issue.number }}
           comment-id: ${{ github.event.comment.id }}
+          # Branch protection requires changes go through a PR + merge queue.
+          # Direct pushes to main are rejected (GH006).
+          pull-request: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

- The `manage` job in `vouch.yml` pushes VOUCHED.td changes directly to `main`, which is rejected by branch protection (`GH006: merge queue required`). This caused `vouch @username` commands to silently fail — the action logged "Added user to vouched contributors" but the push was rejected 3 times and changes never landed.
- Switches to `pull-request: true` so the action creates a PR instead of pushing directly.
- Adds `pull-requests: write` permission to the `manage` job.

## Root cause

Confirmed by inspecting the [workflow run logs](https://github.com/base/base/actions/runs/24216835405) for the `vouch @crazywriter1` comment on issue #2062:

```
remote: error: GH006: Protected branch update failed for refs/heads/main.
remote: - Changes must be made through the merge queue
remote: - Changes must be made through a pull request.
 ! [remote rejected] main -> main (protected branch hook declined)
error: failed to push some refs
Push failed (attempt 1/3), retrying...
```

Fixes #2088