### PR TITLE
fix(ci): sort pub use items alphabetically in runner

### DIFF
--- a/crates/execution/runner/src/lib.rs
+++ b/crates/execution/runner/src/lib.rs
@@ -20,7 +20,7 @@ mod service;
 pub use service::{DefaultPayloadServiceBuilder, PayloadServiceBuilder};
 
 mod types;
-pub use types::{BaseNodeBuilder, BaseProvider, OpAddOns, OpComponentsBuilder, BaseNodeTypes};
+pub use types::{BaseNodeBuilder, BaseNodeTypes, BaseProvider, OpAddOns, OpComponentsBuilder};
 
 mod node;
 pub use node::BaseNode;


### PR DESCRIPTION
## Summary
- Nightly rustfmt requires alphabetical ordering for `pub use` items. The rename in #2101 left `BaseNodeTypes` after `BaseProvider`, causing Format CI to fail on all PRs.

type=routine
risk=low
impact=sev5