### PR TITLE
refactor(tx-manager): general clean up

### DIFF
--- a/crates/batcher/core/src/submissions.rs
+++ b/crates/batcher/core/src/submissions.rs
@@ -113,7 +113,7 @@ impl<TM: TxManager> SubmissionQueue<TM> {
                         tx_data: Bytes::new(),
                         value: U256::ZERO,
                         gas_limit: 0,
-                        blobs: Arc::new(vec![blob]),
+                        blobs: Arc::from(vec![blob]),
                     },
                     Err(e) => {
                         warn!(error = %e, "failed to encode frames to blob, requeueing");

--- a/crates/utilities/tx-manager/Cargo.toml
+++ b/crates/utilities/tx-manager/Cargo.toml
@@ -24,15 +24,15 @@ alloy-eips = { workspace = true, features = ["std", "kzg"] }
 alloy-rpc-types-eth = { workspace = true, features = ["std"] }
 
 # base
+base-metrics.workspace = true
 base-alloy-signer.workspace = true
 
 # misc
 url.workspace = true
 backon.workspace = true
 thiserror.workspace = true
-tracing = { workspace = true, features = ["std"] }
-base-metrics.workspace = true
 metrics = { workspace = true, optional = true }
+tracing = { workspace = true, features = ["std"] }
 tokio = { workspace = true, features = ["sync", "time"] }
 
 [dev-dependencies]

--- a/crates/utilities/tx-manager/README.md
+++ b/crates/utilities/tx-manager/README.md
@@ -7,89 +7,80 @@ Transaction lifecycle management for Base onchain components.
 
 ## Overview
 
-- **`TxManagerError`**: Error types for transaction management, categorized as critical
-  (non-retryable), fee/replacement (retryable via fee bumps), and infrastructure (transient/retryable).
-- **`RpcErrorClassifier`**: Classifies alloy `TransportError`s into structured `TxManagerError`
-  variants using the `ErrorPayload`'s structured fields and ordered substring matching.
-- **`TxManagerResult<T>`**: Result type alias for transaction manager operations.
-- **`TxCandidate`**: Input to the send pipeline. With empty `blobs` it produces a regular
-  EIP-1559 (type-2) transaction; with non-empty `blobs` it produces an EIP-4844 (type-3)
-  blob-carrying transaction. Carries calldata, optional recipient, gas limit, and value.
-- **`PreparedTx`**: A signed transaction together with the fee values (`gas_tip_cap`,
-  `gas_fee_cap`) that were applied during construction. Returned by `prepare()` and
-  `craft_tx()` so callers can track the actual on-wire fees without a redundant gas price
-  query.
-- **`GasPriceCaps`**: Intermediate fee estimates (tip cap, base fee cap, optional blob fee cap)
-  passed between fee calculation and transaction construction.
-- **`FeeCalculator`**: Pure, deterministic fee arithmetic engine operating on `u128` values
-  with saturating math. Provides EIP-1559 fee cap calculation (`calc_gas_fee_cap`), blob fee
-  cap calculation (`calc_blob_fee_cap`), geth-compatible replacement thresholds
-  (`calc_threshold_value`), four-case fee update logic (`update_fees`), and configurable fee
-  ceiling enforcement (`check_limits`).
-- **`SendResponse`**: Type alias (`TxManagerResult<TransactionReceipt>`) returned by async
-  send operations.
-- **`SendHandle`**: Future returned by `send_async` that resolves directly to a
-  `SendResponse`, mapping a closed channel into `TxManagerError::ChannelClosed` so callers
-  avoid a two-layer `Result`.
-- **`SendState`**: State machine the send loop uses to decide whether to continue retrying,
-  bump fees, or abort. Tracks mined transaction hashes, nonce-too-low error counts, mempool
-  deadline expiry, successful publish counts, and fee bump state. Uses `std::sync::Mutex`
-  for thread-safe interior mutability (all critical sections are CPU-bound with no `.await`
-  points). `SendState::new` returns `TxManagerResult<Self>` and rejects a zero
-  `safe_abort_nonce_too_low_count` threshold with
-  `TxManagerError::InvalidSafeAbortNonceTooLowCount`. The `critical_error()` method
-  evaluates abort conditions in priority order: mined tx suppression, already-reserved,
-  pre-publish nonce-too-low, threshold nonce-too-low, and mempool deadline expiry.
-- **`TxManagerCli`**: Clap-based CLI argument struct with environment variable fallbacks
-  (prefix `BASE_TX_MANAGER`). Captures all tunable tx-manager parameters and is designed
-  to be `#[command(flatten)]`-ed into parent CLI structs. Generates `Default` and
-  `TryFrom<TxManagerCli> for TxManagerConfig` impls.
-- **`TxManagerConfig`**: Validated runtime configuration with public fields. Can be
-  constructed directly and validated via `validate()`, or converted from `TxManagerCli`
-  via `TryFrom`.
-- **`ConfigError`**: Validation error enum returned by the `TryFrom<TxManagerCli>`
-  conversion when configuration values are out of range or gwei strings are invalid.
-- **`GweiParser`**: Unit struct with `parse` method for converting decimal gwei strings
-  to `u128` wei via `alloy_primitives::utils::parse_units`.
-- **`TxManager`**: Trait defining the public API — `send` (blocking), `send_async` (returns
-  a `SendHandle`), and `sender_address`. Requires `Send + Sync`.
-- **`NonceManager`**: Manages nonce allocation and tracking with lazy initialization from
-  chain state. Wraps a `tokio::sync::Mutex` around a cached nonce, fetching the initial
-  value via `get_transaction_count()` on first use and incrementing locally on subsequent
-  calls. Returns a [`NonceGuard`] from `next_nonce()` that holds the lock for the duration
-  of signing. `reset()` clears the cache, forcing a fresh chain fetch on the next call.
-- **`NonceGuard`**: RAII guard holding a reserved nonce and the nonce mutex lock. Drop the
-  guard after successful signing to release the lock, or call `rollback()` on failure to
-  restore the nonce for reuse. Uses `OwnedMutexGuard` so the guard is `Send` and can cross
-  task spawn boundaries.
-- **`SignerConfig`**: Describes how to construct an `EthereumWallet` — either from a local
-  private key (`Local`) or a remote signer endpoint (`Remote`). Passed to `SimpleTxManager::new`
-  to centralise wallet construction.
-- **`SimpleTxManager`**: Default `TxManager` implementation. Holds a `RootProvider`,
-  `EthereumWallet`, `TxManagerConfig`, `NonceManager`, chain ID, and a shutdown flag.
-  `new()` builds the wallet from a `SignerConfig`, validates the config, and cross-checks
-  the chain ID against the provider. `from_wallet()` accepts a pre-built `EthereumWallet`
-  directly, which is useful for tests or custom signers.
-  `prepare()` wraps `craft_tx()` in a `backon` retry loop (up to 30 attempts, 2-second
-  fixed delay) that retries only on transient errors and exits immediately when closed.
-  Both methods accept optional fee overrides `(tip, fee_cap)` and return a `PreparedTx`
-  containing the RLP-encoded raw bytes and the actual fees applied. `craft_tx()` queries
-  gas price caps, applies fee overrides as a floor via `max(network_fee, override)`,
-  enforces fee limits, builds a `TransactionRequest` with all fields set manually (no
-  alloy fillers), estimates or validates gas, assigns a nonce via `NonceManager`, and
-  signs via `NetworkWallet`.
-  `suggest_gas_price_caps()` queries the provider for tip cap and base fee, enforces
-  configured minimums, and returns a `GasPriceCaps`. Blob transactions are not yet
-  supported and are rejected with an error.
-- **`TxQueue`**: Queue for ordering and batching transactions.
-- **`TxMetrics`**: Metrics collection for transaction operations.
-- **`BlobTxBuilder`**: Builder for EIP-4844 blob-carrying transactions.
+Manages the full lifecycle of EIP-1559 and EIP-4844 blob transactions: fee
+estimation, construction, signing, submission, fee bumping, and receipt
+confirmation.
 
-## Error Handling
+### Core types
+
+- **`TxManager`** — trait defining the public API (`send`, `send_async`, `cancel_tx`,
+  `sender_address`).
+- **`SimpleTxManager`** — default `TxManager` implementation. Handles gas estimation,
+  nonce management, signing, submission with fee bumps, and receipt polling.
+- **`TxCandidate`** — input to the send pipeline (calldata, recipient, gas limit, value,
+  optional blobs).
+- **`PreparedTx`** — signed transaction bytes and the fees, gas limit, nonce, and sidecar
+  that were applied.
+- **`TxQueue`** — bounded async send queue with semaphore-based backpressure.
+- **`SendResult`** — pairs a caller-supplied ID with a transaction send outcome.
+
+### Fee calculation
+
+- **`FeeCalculator`** — pure arithmetic for EIP-1559/EIP-4844 fee caps, replacement
+  thresholds, fee bumps, and fee limit enforcement.
+- **`GasPriceCaps`** — intermediate fee estimates passed between estimation and construction.
+- **`FeeOverride`** — optional per-field fee and gas-limit overrides applied as a floor.
+- **`BumpedFees`** — result of a fee bump calculation.
+
+### Error handling
+
+- **`TxManagerError`** — error variants categorized as critical (non-retryable),
+  fee/replacement (retryable via fee bumps), or infrastructure (transient/retryable).
+- **`RpcErrorClassifier`** — classifies alloy `TransportError`s into `TxManagerError` variants.
+- **`RevertDisplay`** — display wrapper for decoded revert reasons.
+- **`TxManagerResult<T>`** — result type alias.
+
+### Nonce management
+
+- **`NonceManager`** — lazy-initialized nonce cache with mutex-guarded allocation.
+- **`NonceGuard`** — RAII guard holding a reserved nonce; drop consumes it, or
+  call `rollback()` on failure to return it for reuse.
+- **`NonceState`** — snapshot of the current nonce state.
+
+### Send state
+
+- **`SendState`** — state machine tracking mined hashes, nonce errors, fee bumps, and
+  mempool deadlines to decide whether to retry, bump, or abort.
+- **`SendHandle`** — future returned by `send_async` that resolves to a `SendResponse`.
+- **`SendResponse`** — type alias for `TxManagerResult<TransactionReceipt>`.
+
+### Blob support
+
+- **`BlobTxBuilder`** — builds EIP-7594 cell-proof sidecars from raw blobs.
+- **`MAX_BLOBS_PER_TX`** — maximum blobs per transaction (Fusaka limit).
+
+### Config types
+
+- **`TxManagerConfig`** — validated runtime configuration with public fields.
+- **`ConfigError`** — validation error for out-of-range or invalid config values.
+- **`GweiParser`** — converts decimal gwei strings to `u128` wei.
+- **`define_tx_manager_cli!`** — macro that generates a `TxManagerCli` clap struct with
+  env var fallbacks and `TryFrom<TxManagerCli> for TxManagerConfig`.
+- **`define_signer_cli!`** — macro that generates a signer CLI struct.
+- **`SignerConfig`** — describes wallet construction (local `PrivateKeySigner` or remote
+  signer endpoint).
+
+### Metrics
+
+- **`TxMetrics`** — trait for transaction metrics collection.
+- **`BaseTxMetrics`** — production implementation backed by the `metrics` crate.
+- **`NoopTxMetrics`** — no-op implementation for tests.
+- **`TxManagerMetrics`** — raw metrics struct generated by `define_metrics!`.
+
+## Error Classification
 
 `TxManagerError` variants are classified to let the send loop decide whether to retry,
-bump fees, or abort. Use `is_retryable()` and `is_already_known()` to branch on error
-type:
+bump fees, or abort. Use `is_retryable()` and `is_already_known()` to branch:
 
 ```rust,ignore
 use base_tx_manager::{RpcErrorClassifier, TxManagerError};
@@ -106,63 +97,25 @@ fn handle_rpc_error(transport_err: &alloy_transport::TransportError) {
 }
 ```
 
-`ChannelClosed` is returned by [`SendHandle`] when the background send task drops
-its sender before delivering a result (panic or cancellation). It is non-retryable.
-
-`FeeLimitExceeded` is returned by `FeeCalculator::check_limits` when the proposed fee
-exceeds `fee_limit_multiplier × suggested_fee` and the suggested fee is at or above
-`fee_limit_threshold`. It is non-retryable.
-
-`InvalidSafeAbortNonceTooLowCount` is returned by `SendState::new` when the
-`safe_abort_nonce_too_low_count` threshold is zero. A zero threshold would abort on the very
-first nonce-too-low error after a successful publish, making fee bumps impossible. It is
-non-retryable.
-
-`RpcErrorClassifier::classify_rpc_error` accepts an alloy `TransportError` and, for
-server error responses, matches against the `ErrorPayload`'s `message` field using known
-geth substrings in a fixed order (e.g., `"replacement transaction underpriced"` before
-`"transaction underpriced"`). For `"execution reverted"` errors, revert data is extracted
-via `ErrorPayload::as_revert_data` and decoded with `alloy_sol_types::decode_revert_reason`.
-Non-server errors and unrecognised messages fall through to the `TxManagerError::Rpc`
-fallback, which is conservatively treated as retryable — callers must enforce bounded
-retry counts.
-
-For custom error matching beyond the built-in classification, use
-`RpcErrorClassifier::err_string_contains_any`.
-
 ## Configuration
 
-`TxManagerConfig` is the validated runtime configuration. All fields are
-public, so you can construct it directly and call `validate()` to check
-invariants. Alternatively, convert from `TxManagerCli` via `TryFrom`
-which parses CLI/env arguments and validates automatically.
+`TxManagerConfig` can be constructed directly and validated via `validate()`, or
+converted from a macro-generated `TxManagerCli` via `TryFrom`.
 
-### CLI parsing and validation
-
-`TxManagerCli` is a `clap::Parser` struct designed to be `#[command(flatten)]`-ed
-into parent CLI structs. All fields use `BASE_TX_MANAGER_` environment variable
-fallbacks. The macro also generates `Default` and
-`TryFrom<TxManagerCli> for TxManagerConfig` impls:
+### CLI parsing
 
 ```rust,ignore
 use base_tx_manager::TxManagerConfig;
 
 base_tx_manager::define_tx_manager_cli!("BASE_TX_MANAGER");
 
-// Parse from CLI args (typically done by the parent binary).
 let cli = TxManagerCli::try_parse().unwrap();
-
 let config = TxManagerConfig::try_from(cli)?;
 ```
 
 ### Custom env var prefix
 
-Consumer crates that need a different env var prefix (e.g.
-`BASE_CHALLENGER_TX_MANAGER` instead of `BASE_TX_MANAGER`) can invoke
-the `define_tx_manager_cli!` macro directly:
-
 ```rust,ignore
-// In your crate — generates a local `TxManagerCli` with custom env vars.
 base_tx_manager::define_tx_manager_cli!("BASE_CHALLENGER_TX_MANAGER");
 
 #[derive(clap::Parser)]
@@ -174,28 +127,10 @@ struct Cli {
 let config = TxManagerConfig::try_from(cli.tx)?;
 ```
 
-> **Note:** The macro expands to absolute paths (`::clap::Parser` and
-> `::humantime::parse_duration`), so consumer crates must add `clap`
-> (with `derive` + `env` features) and `humantime` to their own
-> `Cargo.toml`.
-
-### Fee limit checks
-
-Use `FeeCalculator::check_limits` with the multiplier and threshold from
-the config:
-
-```rust,ignore
-FeeCalculator::check_limits(
-    proposed_fee,
-    suggested_fee,
-    config.fee_limit_multiplier,
-    config.fee_limit_threshold,
-)?;
-```
+> **Note:** Consumer crates must add `clap` (with `derive` + `env` features) and
+> `humantime` to their own `Cargo.toml`.
 
 ## Usage
-
-Add the dependency to your `Cargo.toml`:
 
 ```toml
 [dependencies]
@@ -205,16 +140,18 @@ base-tx-manager = { git = "https://github.com/base/base" }
 ```rust,ignore
 use std::sync::Arc;
 
-use alloy_primitives::{bytes, Address, B256, U256};
+use alloy_primitives::{bytes, Address, U256};
 use alloy_provider::RootProvider;
-use base_tx_manager::{BaseTxMetrics, SignerConfig, SimpleTxManager, TxCandidate, TxManager, TxManagerConfig};
+use alloy_signer_local::PrivateKeySigner;
+use base_tx_manager::{
+    BaseTxMetrics, SignerConfig, SimpleTxManager, TxCandidate, TxManagerConfig,
+};
 
-// Create a SimpleTxManager with a provider, signer config, and tx-manager config.
 let provider = RootProvider::new_http("http://localhost:8545".parse()?);
-let signer_config = SignerConfig::local(B256::repeat_byte(0x01));
+let signer_config = SignerConfig::local("0x0101010101010101010101010101010101010101010101010101010101010101".parse::<PrivateKeySigner>()?);
 let config = TxManagerConfig::default();
-let chain_id = 1;
-let manager = SimpleTxManager::new(provider, signer_config, config, chain_id, Arc::new(BaseTxMetrics::new("my_service"))).await?;
+let metrics = Arc::new(BaseTxMetrics::new("my_service"));
+let manager = SimpleTxManager::new(provider, signer_config, config, 1, metrics).await?;
 
 // Build a regular (type-2) transaction candidate.
 let candidate = TxCandidate {
@@ -225,14 +162,12 @@ let candidate = TxCandidate {
     ..Default::default()
 };
 
-// Construct and sign the transaction (with automatic retry on transient errors).
-// Returns a PreparedTx containing the raw bytes and the fees that were applied.
+// Construct and sign with automatic retry on transient errors.
 let prepared = manager.prepare(&candidate, None).await?;
 let raw_tx = prepared.raw_tx;
 
-// Or use craft_tx() directly for a single attempt without retry.
+// Or use craft_tx() for a single attempt without retry.
 let prepared = manager.craft_tx(&candidate, None).await?;
-let raw_tx = prepared.raw_tx;
 ```
 
 ## License

--- a/crates/utilities/tx-manager/src/blob.rs
+++ b/crates/utilities/tx-manager/src/blob.rs
@@ -1,13 +1,11 @@
-//! EIP-4844 blob transaction sidecar construction.
+//! EIP-7594 blob transaction sidecar construction.
 //!
 //! [`BlobTxBuilder`] wraps alloy's KZG sidecar API to produce
 //! [`BlobTransactionSidecarEip7594`] sidecars
 //! (cell proofs, 128 proofs/blob) on all supported networks.
 
-use std::sync::Arc;
-
 use alloy_eips::{
-    eip4844::{Blob, env_settings::EnvKzgSettings},
+    eip4844::Blob,
     eip7594::{BlobTransactionSidecarEip7594, MAX_BLOBS_PER_TX_FUSAKA},
 };
 
@@ -18,31 +16,22 @@ use crate::TxManagerError;
 /// Set to [`MAX_BLOBS_PER_TX_FUSAKA`] (6), the Fusaka per-transaction limit.
 pub const MAX_BLOBS_PER_TX: usize = MAX_BLOBS_PER_TX_FUSAKA as usize;
 
-/// Builder for Osaka-era EIP-4844 blob sidecars.
-#[derive(Debug, Clone, Copy, Default)]
+/// Builder for EIP-7594 blob sidecars.
+#[derive(Debug)]
 pub struct BlobTxBuilder;
 
 impl BlobTxBuilder {
-    /// Creates a new [`BlobTxBuilder`].
-    #[must_use]
-    pub const fn new() -> Self {
-        Self
-    }
-
-    /// Builds an Osaka-era EIP-7594 cell-proof sidecar.
+    /// Builds an EIP-7594 cell-proof sidecar from boxed blobs.
     ///
     /// # Errors
     ///
     /// Returns [`TxManagerError::Unsupported`] if KZG computation fails.
     pub fn build_sidecar(
-        &self,
-        blobs: Arc<Vec<Box<Blob>>>,
+        blobs: &[Box<Blob>],
     ) -> Result<BlobTransactionSidecarEip7594, TxManagerError> {
-        let settings = EnvKzgSettings::Default;
-        let kzg = settings.get();
-        let unboxed: Vec<Blob> = Arc::unwrap_or_clone(blobs).into_iter().map(|b| *b).collect();
+        let unboxed: Vec<Blob> = blobs.iter().map(|b| *b.as_ref()).collect();
 
-        BlobTransactionSidecarEip7594::try_from_blobs_with_settings(unboxed, kzg).map_err(|e| {
+        BlobTransactionSidecarEip7594::try_from_blobs(unboxed).map_err(|e| {
             TxManagerError::Unsupported(format!("EIP-7594 cell proof computation failed: {e}"))
         })
     }
@@ -55,24 +44,13 @@ mod tests {
 
     use super::*;
 
-    fn builder() -> BlobTxBuilder {
-        BlobTxBuilder::new()
-    }
-
     #[rstest]
     #[case::single_blob(1)]
     #[case::two_blobs(2)]
     #[case::six_blobs(6)]
     fn build_sidecar_n_blobs_uses_cell_proofs(#[case] n: usize) {
-        let builder = builder();
         let blobs: Vec<Box<Blob>> = (0..n).map(|_| Box::default()).collect();
-        let sidecar = builder.build_sidecar(Arc::new(blobs)).unwrap();
+        let sidecar = BlobTxBuilder::build_sidecar(&blobs).unwrap();
         assert_eq!(sidecar.cell_proofs.len(), n * CELLS_PER_EXT_BLOB);
-    }
-
-    #[test]
-    fn blob_tx_builder_is_send_and_sync() {
-        fn assert_send_sync<T: Send + Sync>() {}
-        assert_send_sync::<BlobTxBuilder>();
     }
 }

--- a/crates/utilities/tx-manager/src/candidate.rs
+++ b/crates/utilities/tx-manager/src/candidate.rs
@@ -10,24 +10,28 @@ use alloy_primitives::{Address, Bytes, U256};
 /// When `blobs` is empty, the candidate produces a regular EIP-1559 (type-2)
 /// transaction. When `blobs` is non-empty, it produces an EIP-4844 (type-3)
 /// blob-carrying transaction.
-///
-/// Blobs are wrapped in [`Arc`] so that cloning a `TxCandidate` is cheap
-/// (reference-count bump) rather than deep-copying 131 072 bytes per blob.
 #[derive(Debug, Clone, Default)]
 pub struct TxCandidate {
     /// Transaction calldata.
     pub tx_data: Bytes,
     /// EIP-4844 blobs; triggers blob tx when non-empty.
     ///
-    /// Blobs are individually boxed to avoid 131 072-byte stack copies when
-    /// moving them between collections.
-    pub blobs: Arc<Vec<Box<Blob>>>,
+    /// Wrapped in [`Arc`] for cheap cloning; individually boxed to keep
+    /// 131 072-byte blobs off the stack.
+    pub blobs: Arc<[Box<Blob>]>,
     /// Recipient address. `None` means contract creation.
     pub to: Option<Address>,
     /// Gas limit. `0` means auto-estimate.
     pub gas_limit: u64,
     /// ETH value to send.
     pub value: U256,
+}
+
+impl TxCandidate {
+    /// Returns `true` when this candidate carries blobs (EIP-4844 type-3 tx).
+    pub fn is_blob(&self) -> bool {
+        !self.blobs.is_empty()
+    }
 }
 
 #[cfg(test)]
@@ -47,14 +51,10 @@ mod tests {
 
     #[test]
     fn candidate_with_blobs_is_type3() {
-        let candidate = TxCandidate { blobs: Arc::new(vec![Box::default()]), ..Default::default() };
+        let candidate =
+            TxCandidate { blobs: Arc::from(vec![Box::default()]), ..Default::default() };
 
         assert_eq!(candidate.blobs.len(), 1);
-        // Struct-update preserves remaining defaults.
-        assert!(candidate.tx_data.is_empty());
-        assert!(candidate.to.is_none());
-        assert_eq!(candidate.gas_limit, 0);
-        assert_eq!(candidate.value, U256::ZERO);
     }
 
     #[test]

--- a/crates/utilities/tx-manager/src/config.rs
+++ b/crates/utilities/tx-manager/src/config.rs
@@ -59,6 +59,14 @@ pub struct GweiParser;
 impl GweiParser {
     /// Parses a gwei decimal string to wei (`u128`).
     ///
+    /// Suitable for use as a clap `value_parser`. Error context (which
+    /// flag failed) is provided by clap automatically.
+    pub fn parse_value(gwei: &str) -> Result<u128, ConfigError> {
+        Self::parse(gwei, "value")
+    }
+
+    /// Parses a gwei decimal string to wei (`u128`).
+    ///
     /// # Errors
     ///
     /// Returns [`ConfigError::InvalidGwei`] if the string is not a valid
@@ -152,62 +160,38 @@ impl TxManagerConfig {
     /// - `receipt_query_interval` must be > 0
     /// - `confirmation_timeout` must be > 0
     pub fn validate(&self) -> Result<(), ConfigError> {
-        if self.num_confirmations == 0 {
-            return Err(ConfigError::OutOfRange {
-                field: "num_confirmations",
-                constraint: ">= 1",
-                value: "0".to_string(),
-            });
+        macro_rules! reject_zero {
+            ($($field:ident),+ $(,)?) => {$(
+                if self.$field == 0 {
+                    return Err(ConfigError::OutOfRange {
+                        field: stringify!($field),
+                        constraint: ">= 1",
+                        value: "0".to_string(),
+                    });
+                }
+            )+};
         }
-        if self.safe_abort_nonce_too_low_count == 0 {
-            return Err(ConfigError::OutOfRange {
-                field: "safe_abort_nonce_too_low_count",
-                constraint: ">= 1",
-                value: "0".to_string(),
-            });
+
+        macro_rules! reject_zero_duration {
+            ($($field:ident),+ $(,)?) => {$(
+                if self.$field.is_zero() {
+                    return Err(ConfigError::OutOfRange {
+                        field: stringify!($field),
+                        constraint: "> 0",
+                        value: "0s".to_string(),
+                    });
+                }
+            )+};
         }
-        if self.fee_limit_multiplier == 0 {
-            return Err(ConfigError::OutOfRange {
-                field: "fee_limit_multiplier",
-                constraint: ">= 1",
-                value: "0".to_string(),
-            });
-        }
-        if self.network_timeout.is_zero() {
-            return Err(ConfigError::OutOfRange {
-                field: "network_timeout",
-                constraint: "> 0",
-                value: "0s".to_string(),
-            });
-        }
-        if self.resubmission_timeout.is_zero() {
-            return Err(ConfigError::OutOfRange {
-                field: "resubmission_timeout",
-                constraint: "> 0",
-                value: "0s".to_string(),
-            });
-        }
-        if self.receipt_query_interval.is_zero() {
-            return Err(ConfigError::OutOfRange {
-                field: "receipt_query_interval",
-                constraint: "> 0",
-                value: "0s".to_string(),
-            });
-        }
-        if self.confirmation_timeout.is_zero() {
-            return Err(ConfigError::OutOfRange {
-                field: "confirmation_timeout",
-                constraint: "> 0",
-                value: "0s".to_string(),
-            });
-        }
-        if self.min_blob_fee == 0 {
-            return Err(ConfigError::OutOfRange {
-                field: "min_blob_fee",
-                constraint: ">= 1",
-                value: "0".to_string(),
-            });
-        }
+
+        reject_zero!(num_confirmations, safe_abort_nonce_too_low_count, fee_limit_multiplier);
+        reject_zero_duration!(
+            network_timeout,
+            resubmission_timeout,
+            receipt_query_interval,
+            confirmation_timeout,
+        );
+        reject_zero!(min_blob_fee);
         Ok(())
     }
 }

--- a/crates/utilities/tx-manager/src/error.rs
+++ b/crates/utilities/tx-manager/src/error.rs
@@ -16,7 +16,7 @@ const REVERT_DATA_DISPLAY_LIMIT: usize = 128;
 ///   [`REVERT_DATA_DISPLAY_LIMIT`] bytes).
 /// - Empty string when neither is available.
 #[derive(Debug)]
-pub(crate) struct RevertDisplay<'a>(Option<&'a str>, Option<&'a Bytes>);
+pub struct RevertDisplay<'a>(Option<&'a str>, Option<&'a Bytes>);
 
 impl std::fmt::Display for RevertDisplay<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -287,7 +287,7 @@ impl RpcErrorClassifier {
             return TxManagerError::Rpc(error.to_string());
         };
 
-        let lowered = payload.message.to_lowercase();
+        let lowered = payload.message.to_ascii_lowercase();
 
         if lowered.contains("replacement transaction underpriced") {
             return TxManagerError::ReplacementUnderpriced;
@@ -307,35 +307,16 @@ impl RpcErrorClassifier {
         if lowered.contains("intrinsic gas too low") {
             return TxManagerError::IntrinsicGasTooLow;
         }
-        if lowered.contains("execution reverted") {
-            // Use alloy's structured revert data extraction from the
-            // ErrorPayload's JSON data field, then decode with alloy's
-            // standard decoder (handles Error(string), Panic(uint256),
-            // and Vyper UTF-8 reverts).
+        if let Some(pos) = lowered.find("execution reverted") {
             if let Some(data) = payload.as_revert_data() {
                 let reason = alloy_sol_types::decode_revert_reason(&data);
                 return TxManagerError::ExecutionReverted { reason, data: Some(data) };
             }
-            // No structured data — extract a plain-text reason from the
-            // message text after the "execution reverted" marker.
-            // Search the original message case-insensitively to preserve
-            // the original casing of the reason string (e.g.
-            // "GameAlreadyExists") while avoiding byte-offset mismatches
-            // that `to_lowercase()` can introduce for non-ASCII input.
-            const MARKER: &str = "execution reverted";
-            let reason = payload
-                .message
-                .char_indices()
-                .find(|&(i, _)| {
-                    payload.message[i..]
-                        .get(..MARKER.len())
-                        .is_some_and(|s| s.eq_ignore_ascii_case(MARKER))
-                })
-                .and_then(|(pos, _)| {
-                    let after = &payload.message[pos + MARKER.len()..];
-                    let after = after.trim_start_matches(':').trim();
-                    if after.is_empty() { None } else { Some(after.to_string()) }
-                });
+            // `to_ascii_lowercase()` is byte-offset-preserving, so
+            // offsets from `lowered` are safe to index `payload.message`.
+            let after = &payload.message[pos + "execution reverted".len()..];
+            let after = after.trim_start_matches(':').trim();
+            let reason = if after.is_empty() { None } else { Some(after.to_string()) };
             return TxManagerError::ExecutionReverted { reason, data: None };
         }
         if lowered.contains("fee too low") {
@@ -344,10 +325,7 @@ impl RpcErrorClassifier {
         if lowered.contains("max fee per gas less than block base fee") {
             return TxManagerError::MaxFeePerGasTooLow;
         }
-        if lowered.contains("already known") {
-            return TxManagerError::AlreadyKnown;
-        }
-        if lowered.contains("transaction already in pool") {
+        if lowered.contains("already known") || lowered.contains("transaction already in pool") {
             return TxManagerError::AlreadyKnown;
         }
 

--- a/crates/utilities/tx-manager/src/fees.rs
+++ b/crates/utilities/tx-manager/src/fees.rs
@@ -33,7 +33,7 @@ impl FeeCalculator {
     /// This is the inverse of [`calc_gas_fee_cap`](Self::calc_gas_fee_cap):
     /// given `fee_cap = tip + 2 × base_fee`, returns `(fee_cap - tip) / 2`.
     #[must_use]
-    pub fn base_fee_from_caps(gas_fee_cap: u128, gas_tip_cap: u128) -> u128 {
+    pub const fn base_fee_from_caps(gas_fee_cap: u128, gas_tip_cap: u128) -> u128 {
         debug_assert!(gas_fee_cap >= gas_tip_cap);
         gas_fee_cap.saturating_sub(gas_tip_cap) / 2
     }
@@ -86,17 +86,11 @@ impl FeeCalculator {
     /// Selects final `(tip, fee_cap)` values that satisfy geth's replacement
     /// rules while preferring fresher network estimates.
     ///
-    /// Four cases are evaluated:
-    ///
-    /// 1. **Both above threshold** — use the new tip and recalculated fee cap.
-    /// 2. **Tip above, fee cap below** — use the new tip but keep the
-    ///    threshold fee cap (clamped to at least `new_tip`).
-    /// 3. **Fee cap above, tip below** — use the threshold tip and
-    ///    recalculate the fee cap from the threshold tip.
-    /// 4. **Both below** — use both threshold values (fee cap clamped to at least threshold tip).
-    ///
-    /// The returned fee cap always reflects the tip that was selected so that
-    /// the EIP-1559 relationship `fee_cap >= tip` is maintained.
+    /// The tip is the greater of the new network tip and the replacement
+    /// threshold. If the fresh network fee cap clears the threshold it is
+    /// recalculated from the chosen tip; otherwise the threshold fee cap is
+    /// used, clamped to at least the chosen tip so that the EIP-1559
+    /// relationship `fee_cap >= tip` is maintained.
     ///
     /// # Note
     ///
@@ -117,34 +111,21 @@ impl FeeCalculator {
 
         let new_fee_cap = Self::calc_gas_fee_cap(new_base_fee, new_tip);
 
-        let tip_above = new_tip >= threshold_tip;
-        let cap_above = new_fee_cap >= threshold_fee_cap;
+        // Pick the tip that satisfies the replacement threshold.
+        let tip = if new_tip >= threshold_tip { new_tip } else { threshold_tip };
 
-        match (tip_above, cap_above) {
-            // Case 1: both above threshold → use new values
-            (true, true) => (new_tip, new_fee_cap),
-            // Case 2: tip above, fee cap below → new tip + threshold fee cap
-            // Clamp fee_cap to at least new_tip to maintain fee_cap >= tip invariant.
-            (true, false) => {
-                let fee_cap = if threshold_fee_cap > new_tip { threshold_fee_cap } else { new_tip };
-                (new_tip, fee_cap)
-            }
-            // Case 3: fee cap above, tip below → threshold tip + recalculated fee cap
-            (false, true) => {
-                let recalculated = Self::calc_gas_fee_cap(new_base_fee, threshold_tip);
-                (threshold_tip, recalculated)
-            }
-            // Case 4: both below → both threshold values
-            // Clamp fee_cap to at least threshold_tip to maintain fee_cap >= tip invariant.
-            (false, false) => {
-                let fee_cap = if threshold_fee_cap > threshold_tip {
-                    threshold_fee_cap
-                } else {
-                    threshold_tip
-                };
-                (threshold_tip, fee_cap)
-            }
-        }
+        // If the fresh network fee cap already clears the threshold,
+        // recalculate from the chosen tip to keep tip/base-fee consistent.
+        // Otherwise fall back to the threshold fee cap, clamped to >= tip.
+        let fee_cap = if new_fee_cap >= threshold_fee_cap {
+            Self::calc_gas_fee_cap(new_base_fee, tip)
+        } else if threshold_fee_cap > tip {
+            threshold_fee_cap
+        } else {
+            tip
+        };
+
+        (tip, fee_cap)
     }
 
     /// Enforces a configurable fee ceiling.
@@ -243,12 +224,26 @@ pub struct BumpedFees {
     pub caps: GasPriceCaps,
 }
 
+impl BumpedFees {
+    /// Converts the bumped fees into a [`FeeOverride`] suitable for
+    /// [`SimpleTxManager::prepare`](crate::SimpleTxManager::prepare).
+    ///
+    /// `gas_limit_floor` prevents the gas limit from decreasing across
+    /// replacement attempts.
+    #[must_use]
+    pub fn to_fee_override(&self, gas_limit_floor: u64) -> FeeOverride {
+        let fo = FeeOverride::new(self.gas_tip_cap, self.gas_fee_cap)
+            .with_gas_limit_floor(gas_limit_floor);
+        self.blob_fee_cap.map_or(fo, |blob_cap| fo.with_blob_fee_cap(blob_cap))
+    }
+}
+
 /// Intermediate fee estimates computed during gas price suggestion.
 ///
 /// Used between fee calculation and transaction construction to carry
 /// the tip cap, base fee cap, and optional blob fee cap.
 #[non_exhaustive]
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Copy, Default)]
 pub struct GasPriceCaps {
     /// Maximum priority fee per gas (tip).
     pub gas_tip_cap: u128,

--- a/crates/utilities/tx-manager/src/lib.rs
+++ b/crates/utilities/tx-manager/src/lib.rs
@@ -8,7 +8,7 @@
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
 
 mod error;
-pub use error::{RpcErrorClassifier, TxManagerError, TxManagerResult};
+pub use error::{RevertDisplay, RpcErrorClassifier, TxManagerError, TxManagerResult};
 
 mod candidate;
 pub use candidate::TxCandidate;
@@ -47,3 +47,5 @@ pub use blob::{BlobTxBuilder, MAX_BLOBS_PER_TX};
 
 #[cfg(test)]
 pub mod test_utils;
+#[cfg(test)]
+pub use test_utils::StubReceipt;

--- a/crates/utilities/tx-manager/src/macros.rs
+++ b/crates/utilities/tx-manager/src/macros.rs
@@ -71,30 +71,36 @@ macro_rules! define_tx_manager_cli {
 
             /// Minimum suggested fee (in gwei) at which the fee-limit check
             /// activates. Accepts decimal strings (e.g. `"100"`, `"1.5"`).
+            /// Stored as wei after parsing.
             #[arg(
                 long = "tx-manager.fee-limit-threshold",
                 env = concat!($prefix, "_", "FEE_LIMIT_THRESHOLD"),
-                default_value = "100"
+                default_value = "100",
+                value_parser = $crate::GweiParser::parse_value
             )]
-            pub fee_limit_threshold_gwei: String,
+            pub fee_limit_threshold: u128,
 
             /// Minimum tip cap (in gwei) to use for transactions. Accepts
             /// decimal strings (e.g. `"0"`, `"1.5"`).
+            /// Stored as wei after parsing.
             #[arg(
                 long = "tx-manager.min-tip-cap",
                 env = concat!($prefix, "_", "MIN_TIP_CAP"),
-                default_value = "0"
+                default_value = "0",
+                value_parser = $crate::GweiParser::parse_value
             )]
-            pub min_tip_cap_gwei: String,
+            pub min_tip_cap: u128,
 
             /// Minimum basefee (in gwei) to use for transactions. Accepts
             /// decimal strings (e.g. `"0"`, `"0.25"`).
+            /// Stored as wei after parsing.
             #[arg(
                 long = "tx-manager.min-basefee",
                 env = concat!($prefix, "_", "MIN_BASEFEE"),
-                default_value = "0"
+                default_value = "0",
+                value_parser = $crate::GweiParser::parse_value
             )]
-            pub min_basefee_gwei: String,
+            pub min_basefee: u128,
 
             /// Timeout for network requests (e.g., "10s", "1m").
             #[arg(
@@ -155,13 +161,14 @@ macro_rules! define_tx_manager_cli {
 
             /// Minimum blob base fee (in gwei) to use for blob transactions.
             /// Accepts decimal strings (e.g. `"1"`, `"0.5"`).
+            /// Stored as wei after parsing.
             #[arg(
                 long = "tx-manager.min-blob-fee",
                 env = concat!($prefix, "_", "MIN_BLOB_FEE"),
-                default_value = "1"
+                default_value = "1",
+                value_parser = $crate::GweiParser::parse_value
             )]
-            pub min_blob_fee_gwei: String,
-
+            pub min_blob_fee: u128,
         }
 
         impl Default for TxManagerCli {
@@ -174,29 +181,20 @@ macro_rules! define_tx_manager_cli {
             type Error = $crate::ConfigError;
 
             fn try_from(cli: TxManagerCli) -> Result<Self, Self::Error> {
-                let fee_limit_threshold =
-                    $crate::GweiParser::parse(&cli.fee_limit_threshold_gwei, "fee_limit_threshold")?;
-                let min_tip_cap =
-                    $crate::GweiParser::parse(&cli.min_tip_cap_gwei, "min_tip_cap")?;
-                let min_basefee =
-                    $crate::GweiParser::parse(&cli.min_basefee_gwei, "min_basefee")?;
-                let min_blob_fee =
-                    $crate::GweiParser::parse(&cli.min_blob_fee_gwei, "min_blob_fee")?;
-
                 let config = $crate::TxManagerConfig {
                     num_confirmations: cli.num_confirmations,
                     safe_abort_nonce_too_low_count: cli.safe_abort_nonce_too_low_count,
                     fee_limit_multiplier: cli.fee_limit_multiplier,
-                    fee_limit_threshold,
-                    min_tip_cap,
-                    min_basefee,
+                    fee_limit_threshold: cli.fee_limit_threshold,
+                    min_tip_cap: cli.min_tip_cap,
+                    min_basefee: cli.min_basefee,
                     network_timeout: cli.network_timeout,
                     resubmission_timeout: cli.resubmission_timeout,
                     receipt_query_interval: cli.receipt_query_interval,
                     tx_send_timeout: cli.tx_send_timeout,
                     tx_not_in_mempool_timeout: cli.tx_not_in_mempool_timeout,
                     confirmation_timeout: cli.confirmation_timeout,
-                    min_blob_fee,
+                    min_blob_fee: cli.min_blob_fee,
                 };
                 config.validate()?;
                 Ok(config)

--- a/crates/utilities/tx-manager/src/manager.rs
+++ b/crates/utilities/tx-manager/src/manager.rs
@@ -170,8 +170,6 @@ pub struct SimpleTxManager<P> {
     closed: Arc<AtomicBool>,
     /// Metrics collector for transaction lifecycle events.
     metrics: Arc<dyn TxMetrics>,
-    /// Builder for EIP-4844 blob transaction sidecars.
-    blob_builder: BlobTxBuilder,
 }
 
 impl<P> SimpleTxManager<P>
@@ -244,7 +242,6 @@ where
 
         let address = <EthereumWallet as NetworkWallet<Ethereum>>::default_signer_address(&wallet);
         let nonce_manager = NonceManager::new(provider.clone(), address, config.network_timeout);
-        let blob_builder = BlobTxBuilder::new();
         Ok(Self {
             provider,
             wallet,
@@ -253,7 +250,6 @@ where
             chain_id,
             closed: Arc::new(AtomicBool::new(false)),
             metrics,
-            blob_builder,
         })
     }
 
@@ -330,6 +326,25 @@ where
             self.config.fee_limit_multiplier,
             self.config.fee_limit_threshold,
         )
+    }
+
+    /// Checks both gas and blob fee ceilings relative to the raw provider
+    /// estimates in `caps`.
+    ///
+    /// Calls [`check_fee_limit`](Self::check_fee_limit) for the gas fee cap,
+    /// and when `blob_fee_cap` is `Some`, also checks the blob fee cap
+    /// against [`raw_blob_baseline`](Self::raw_blob_baseline).
+    fn check_fee_limits(
+        &self,
+        fee_cap: u128,
+        blob_fee_cap: Option<u128>,
+        caps: &GasPriceCaps,
+    ) -> TxManagerResult<()> {
+        self.check_fee_limit(fee_cap, caps.raw_gas_fee_cap)?;
+        if let Some(blob_cap) = blob_fee_cap {
+            self.check_fee_limit(blob_cap, self.raw_blob_baseline(caps)?)?;
+        }
+        Ok(())
     }
 
     /// Returns the raw (pre-minimum) blob fee cap from `caps`.
@@ -568,9 +583,11 @@ where
         old_fee_cap: u128,
         old_blob_fee_cap: Option<u128>,
     ) -> TxManagerResult<BumpedFees> {
+        let is_blob = candidate.is_blob();
+
         // Validate consistency: old_blob_fee_cap must be Some for blob txs
         // and None for non-blob txs.
-        if old_blob_fee_cap.is_some() == candidate.blobs.is_empty() {
+        if old_blob_fee_cap.is_some() != is_blob {
             return Err(TxManagerError::Unsupported(
                 "old_blob_fee_cap must be Some for blob transactions and None for non-blob transactions"
                     .into(),
@@ -578,13 +595,12 @@ where
         }
 
         // Step 1: Fetch fresh network fees.
-        let caps = self.suggest_gas_price_caps_for(!candidate.blobs.is_empty()).await?;
+        let caps = self.suggest_gas_price_caps_for(is_blob).await?;
 
         // Step 2: Derive effective base fee from the caps.
         let new_base_fee = FeeCalculator::base_fee_from_caps(caps.gas_fee_cap, caps.gas_tip_cap);
 
         // Step 3: Compute bumped tip and fee cap.
-        let is_blob = !candidate.blobs.is_empty();
         let (bumped_tip, bumped_fee_cap) = FeeCalculator::update_fees(
             old_tip,
             old_fee_cap,
@@ -593,25 +609,14 @@ where
             is_blob,
         );
 
-        // Step 4: Enforce fee ceiling.
-        self.check_fee_limit(bumped_fee_cap, caps.raw_gas_fee_cap)?;
+        // Step 4: Bump blob fee cap separately with 100% minimum.
+        let blob_fee_cap = old_blob_fee_cap.map(|old_blob| {
+            let threshold = FeeCalculator::calc_threshold_value(old_blob, true);
+            caps.blob_fee_cap.map_or(threshold, |network_blob| threshold.max(network_blob))
+        });
 
-        // Step 5: Bump blob fee cap separately with 100% minimum.
-        let blob_fee_cap = match old_blob_fee_cap {
-            Some(old_blob) => {
-                let threshold = FeeCalculator::calc_threshold_value(old_blob, true);
-                let bumped_blob =
-                    caps.blob_fee_cap.map_or(threshold, |network_blob| threshold.max(network_blob));
-
-                // Enforce fee ceiling on blob fee cap using the raw
-                // (pre-minimum) blob fee cap as the baseline, mirroring
-                // the gas fee cap ceiling in Step 4.
-                self.check_fee_limit(bumped_blob, self.raw_blob_baseline(&caps)?)?;
-
-                Some(bumped_blob)
-            }
-            None => None,
-        };
+        // Step 5: Enforce fee ceilings on gas and blob fee caps.
+        self.check_fee_limits(bumped_fee_cap, blob_fee_cap, &caps)?;
 
         info!(
             %old_tip,
@@ -679,7 +684,7 @@ where
         nonce_override: Option<u64>,
         cached_sidecar: Option<Arc<BlobTransactionSidecarEip7594>>,
     ) -> TxManagerResult<PreparedTx> {
-        let is_blob = !candidate.blobs.is_empty();
+        let is_blob = candidate.is_blob();
 
         // Blob transactions must have a recipient address (no contract creation).
         if is_blob && candidate.to.is_none() {
@@ -715,16 +720,7 @@ where
                 (caps.gas_tip_cap.max(fo.gas_tip_cap), caps.gas_fee_cap.max(fo.gas_fee_cap))
             });
 
-        // Step 3: Check fee limits.
-        //
-        // The `suggested` parameter is the raw gas_fee_cap computed from
-        // the provider's values before enforcing our configured minimums
-        // (`min_tip_cap`, `min_basefee`). This detects when enforced
-        // minimums or fee overrides inflate the fee cap beyond
-        // `fee_limit_multiplier × raw_provider_fee_cap`.
-        self.check_fee_limit(fee_cap, caps.raw_gas_fee_cap)?;
-
-        // Step 3b: Compute blob fee cap with config minimum and override floor.
+        // Step 3: Compute blob fee cap with config minimum and override floor.
         let blob_fee_cap = if is_blob {
             let network = caps.blob_fee_cap.ok_or_else(|| {
                 TxManagerError::Unsupported(
@@ -737,10 +733,14 @@ where
             None
         };
 
-        // Step 3c: Enforce blob fee ceiling (mirrors Step 3 for gas fee cap).
-        if let Some(blob_cap) = blob_fee_cap {
-            self.check_fee_limit(blob_cap, self.raw_blob_baseline(&caps)?)?;
-        }
+        // Step 3b: Check fee limits.
+        //
+        // The `suggested` parameter is the raw gas_fee_cap computed from
+        // the provider's values before enforcing our configured minimums
+        // (`min_tip_cap`, `min_basefee`). This detects when enforced
+        // minimums or fee overrides inflate the fee cap beyond
+        // `fee_limit_multiplier × raw_provider_fee_cap`.
+        self.check_fee_limits(fee_cap, blob_fee_cap, &caps)?;
 
         // Step 4: Build TransactionRequest.
         let from = self.sender_address();
@@ -765,7 +765,7 @@ where
         let built_sidecar = if is_blob {
             let sidecar = match cached_sidecar {
                 Some(cached) => cached,
-                None => Arc::new(self.blob_builder.build_sidecar(Arc::clone(&candidate.blobs))?),
+                None => Arc::new(BlobTxBuilder::build_sidecar(&candidate.blobs)?),
             };
             tx_request.sidecar = Some((*sidecar).clone().into());
             tx_request.populate_blob_hashes();
@@ -992,7 +992,7 @@ where
             // For other errors, reset only if nothing was ever published.
             // Once a transaction is pending, the next send_tx will re-sync
             // via the chain's pending nonce anyway.
-            Err(_) => send_state.successful_publish_count() == 0,
+            Err(_) => !send_state.has_published(),
         }
     }
 
@@ -1018,7 +1018,7 @@ where
             // nonce is re-fetched, but advance_nonce() pops
             // returned_nonces first, reissuing the same invalid value.
             Ok(_) | Err(TxManagerError::NonceTooHigh | TxManagerError::NonceTooLow) => false,
-            Err(_) => send_state.successful_publish_count() == 0,
+            Err(_) => !send_state.has_published(),
         }
     }
 
@@ -1085,19 +1085,11 @@ where
                 return Ok(receipt);
             }
 
-            // Respond immediately to the should_bump_fees flag set by
-            // process_send_error on retryable errors (e.g. Underpriced,
-            // ReplacementUnderpriced), rather than waiting for the next
-            // resubmission timer tick.
-            //
-            // Clear the flag before attempting the bump so that a failed
-            // attempt (e.g. RPC timeout) does not immediately re-trigger
-            // on the next loop iteration — instead, the loop falls through
-            // to tokio::select! which waits for the resubmission timer or
-            // a receipt, providing natural backoff. If a new retryable
-            // error occurs later, process_send_error will re-set the flag.
-            if send_state.should_bump_fees() {
-                send_state.clear_bump_fees();
+            // Respond immediately to the bump-fees flag set by
+            // process_send_error on retryable errors, rather than waiting
+            // for the next resubmission timer tick. take_bump_fees clears
+            // the flag atomically so a failed bump does not re-trigger.
+            if send_state.take_bump_fees() {
                 if let Some(abort) =
                     self.try_fee_bump(candidate, send_state, &receipt_tx, &mut bump).await
                 {
@@ -1238,14 +1230,7 @@ where
         let bumped =
             self.increase_gas_price(candidate, old.tip, old.fee_cap, old.blob_fee_cap).await?;
 
-        // Build fee overrides including blob fee cap and gas limit floor.
-        // The gas limit floor ensures the limit never decreases across bumps,
-        // avoiding a full candidate clone.
-        let mut fee_override = FeeOverride::new(bumped.gas_tip_cap, bumped.gas_fee_cap)
-            .with_gas_limit_floor(old.gas_limit);
-        if let Some(blob_cap) = bumped.blob_fee_cap {
-            fee_override = fee_override.with_blob_fee_cap(blob_cap);
-        }
+        let fee_override = bumped.to_fee_override(old.gas_limit);
 
         // Rebuild transaction with bumped fees as overrides and the fresh
         // caps to avoid a redundant provider round-trip.
@@ -1267,10 +1252,10 @@ where
 
         // Record the bump and log only after the transaction has been
         // successfully published to avoid inflating the count on failure.
-        send_state.record_fee_bump();
+        let bump_count = send_state.record_fee_bump();
         self.metrics.record_gas_bump();
         info!(
-            bump_count = %send_state.bump_count(),
+            bump_count = %bump_count,
             old_tip = %old.tip,
             new_tip = %prepared.gas_tip_cap,
             old_fee_cap = %old.fee_cap,
@@ -1361,7 +1346,7 @@ where
 
                 // AlreadyKnown on resubmission is a success — the tx is in
                 // the mempool from a prior publish. Return the previous hash.
-                if classified.is_already_known() && send_state.successful_publish_count() > 0 {
+                if classified.is_already_known() && send_state.has_published() {
                     let hash = last_tx_hash.ok_or_else(|| {
                         TxManagerError::InvalidConfig(
                             "AlreadyKnown but no prior tx hash available — caller must track the hash from publish_tx".into(),
@@ -1973,7 +1958,7 @@ mod tests {
         };
 
         let prepared = manager
-            .prepare_with_initial_caps(&candidate, None, Some(caps.clone()), None, None)
+            .prepare_with_initial_caps(&candidate, None, Some(caps), None, None)
             .await
             .expect("should prepare tx using supplied caps");
         let tx = decode_eip1559(&prepared);

--- a/crates/utilities/tx-manager/src/queue.rs
+++ b/crates/utilities/tx-manager/src/queue.rs
@@ -149,7 +149,7 @@ mod tests {
     use tokio::sync::{Notify, mpsc};
 
     use super::*;
-    use crate::{SendHandle, TxManagerError, test_utils::stub_receipt};
+    use crate::{SendHandle, TxManagerError, test_utils::StubReceipt};
 
     fn stub_candidate() -> TxCandidate {
         TxCandidate::default()
@@ -171,13 +171,13 @@ mod tests {
 
     impl TxManager for MockTxManager {
         async fn send(&self, _candidate: TxCandidate) -> SendResponse {
-            Ok(stub_receipt())
+            Ok(StubReceipt::success())
         }
 
         async fn send_async(&self, _candidate: TxCandidate) -> SendHandle {
             self.call_count.fetch_add(1, Ordering::SeqCst);
             let (tx, rx) = tokio::sync::oneshot::channel();
-            tx.send(Ok(stub_receipt())).expect("receiver not dropped");
+            tx.send(Ok(StubReceipt::success())).expect("receiver not dropped");
             SendHandle::new(rx)
         }
 
@@ -211,7 +211,7 @@ mod tests {
 
     impl TxManager for GatedMockTxManager {
         async fn send(&self, _candidate: TxCandidate) -> SendResponse {
-            Ok(stub_receipt())
+            Ok(StubReceipt::success())
         }
 
         async fn send_async(&self, _candidate: TxCandidate) -> SendHandle {
@@ -220,7 +220,7 @@ mod tests {
             let (tx, rx) = tokio::sync::oneshot::channel();
             tokio::spawn(async move {
                 gate.notified().await;
-                let _ = tx.send(Ok(stub_receipt()));
+                let _ = tx.send(Ok(StubReceipt::success()));
             });
             SendHandle::new(rx)
         }

--- a/crates/utilities/tx-manager/src/send_state.rs
+++ b/crates/utilities/tx-manager/src/send_state.rs
@@ -5,22 +5,14 @@
 //! [`std::sync::Mutex`] (not `tokio`) since critical sections are CPU-bound
 //! with no `.await` points.
 
-use std::{collections::HashSet, sync::Mutex, time::Instant};
+use std::{sync::Mutex, time::Instant};
 
 use alloy_primitives::B256;
 
 use crate::{TxManagerError, TxManagerResult};
 
 /// Tracks the publication state of a single logical transaction through its
-/// lifecycle.
-///
-/// `SendState` is the state machine the send loop uses to decide whether to
-/// continue retrying, bump fees, or abort. It tracks mined transaction hashes,
-/// nonce-too-low error counts, mempool deadline expiry, successful publish
-/// counts, fee bump state, and the already-reserved flag.
-///
-/// All mutable fields are wrapped in a [`std::sync::Mutex`] (not `tokio`)
-/// since all critical sections are CPU-bound with no `.await` points.
+/// lifecycle: mined hashes, nonce errors, fee bumps, and mempool deadlines.
 #[derive(Debug)]
 pub struct SendState {
     /// Mutable interior state protected by a std Mutex.
@@ -30,27 +22,15 @@ pub struct SendState {
     safe_abort_nonce_too_low_count: u64,
 }
 
-/// Interior mutable state for [`SendState`], protected by a [`Mutex`].
-///
-/// This type is intentionally private — it is an implementation detail behind
-/// the Mutex with no standalone meaning.
 #[derive(Debug)]
 struct SendStateInner {
-    /// Hashes of transactions that have been observed onchain.
-    mined_txs: HashSet<B256>,
-    /// Number of times the transaction was successfully published.
-    successful_publish_count: u64,
-    /// Number of nonce-too-low errors encountered.
+    mined_txs: Vec<B256>,
+    has_published: bool,
     nonce_too_low_count: u64,
-    /// Whether a nonce-too-high error was encountered.
     nonce_too_high: bool,
-    /// Whether the nonce slot was already reserved by another sender.
     already_reserved: bool,
-    /// Whether the next send attempt should bump fees.
     bump_fees: bool,
-    /// Number of fee bumps performed.
     bump_count: u64,
-    /// Optional deadline for mempool inclusion.
     mempool_deadline: Option<Instant>,
 }
 
@@ -63,14 +43,14 @@ impl SendState {
     /// `safe_abort_nonce_too_low_count` is 0. A zero threshold would cause the
     /// send loop to abort on the very first nonce-too-low error after a
     /// successful publish, making fee bumps impossible.
-    pub fn new(safe_abort_nonce_too_low_count: u64) -> TxManagerResult<Self> {
+    pub const fn new(safe_abort_nonce_too_low_count: u64) -> TxManagerResult<Self> {
         if safe_abort_nonce_too_low_count == 0 {
             return Err(TxManagerError::InvalidSafeAbortNonceTooLowCount);
         }
         Ok(Self {
             inner: Mutex::new(SendStateInner {
-                mined_txs: HashSet::new(),
-                successful_publish_count: 0,
+                mined_txs: Vec::new(),
+                has_published: false,
                 nonce_too_low_count: 0,
                 nonce_too_high: false,
                 already_reserved: false,
@@ -115,7 +95,9 @@ impl SendState {
     /// onchain.
     pub fn tx_mined(&self, tx_hash: B256) {
         let mut inner = self.inner.lock().expect("SendState mutex poisoned");
-        inner.mined_txs.insert(tx_hash);
+        if !inner.mined_txs.contains(&tx_hash) {
+            inner.mined_txs.push(tx_hash);
+        }
     }
 
     /// Records that a previously-mined transaction is no longer onchain
@@ -127,9 +109,11 @@ impl SendState {
     /// removals of hashes that were never tracked.
     pub fn tx_not_mined(&self, tx_hash: B256) {
         let mut inner = self.inner.lock().expect("SendState mutex poisoned");
-        let was_present = inner.mined_txs.remove(&tx_hash);
-        if was_present && inner.mined_txs.is_empty() {
-            inner.nonce_too_low_count = 0;
+        if let Some(idx) = inner.mined_txs.iter().position(|h| *h == tx_hash) {
+            inner.mined_txs.swap_remove(idx);
+            if inner.mined_txs.is_empty() {
+                inner.nonce_too_low_count = 0;
+            }
         }
     }
 
@@ -152,43 +136,30 @@ impl SendState {
     /// 7. Otherwise, returns `None`.
     #[must_use]
     pub fn critical_error(&self) -> Option<TxManagerError> {
+        let now = Instant::now();
         let inner = self.inner.lock().expect("SendState mutex poisoned");
 
-        // 1. Mined tx suppression: a tx is onchain, wait for confirmation.
         if !inner.mined_txs.is_empty() {
             return None;
         }
-
-        // 2. Nonce slot already reserved by another sender.
         if inner.already_reserved {
             return Some(TxManagerError::AlreadyReserved);
         }
-
-        // 3. Nonce too high: the nonce is ahead of chain state. No tx
-        //    entered the mempool, so retry is pointless without a reset.
         if inner.nonce_too_high {
             return Some(TxManagerError::NonceTooHigh);
         }
-
-        // 4. Pre-publish immediate abort: nonce consumed before any successful
-        //    publish.
-        if inner.successful_publish_count == 0 && inner.nonce_too_low_count > 0 {
+        if !inner.has_published && inner.nonce_too_low_count > 0 {
             return Some(TxManagerError::NonceTooLow);
         }
-
-        // 5. Nonce-too-low threshold reached after successful publishes.
         if inner.nonce_too_low_count >= self.safe_abort_nonce_too_low_count {
             return Some(TxManagerError::NonceTooLow);
         }
-
-        // 6. Mempool deadline expired.
         if let Some(deadline) = inner.mempool_deadline
-            && Instant::now() >= deadline
+            && now >= deadline
         {
             return Some(TxManagerError::MempoolDeadlineExpired);
         }
 
-        // 7. No critical error — continue sending.
         None
     }
 
@@ -199,42 +170,33 @@ impl SendState {
         !inner.mined_txs.is_empty()
     }
 
-    /// Records a successful transaction publication.
+    /// Records that a transaction was successfully published.
     pub fn record_successful_publish(&self) {
         let mut inner = self.inner.lock().expect("SendState mutex poisoned");
-        inner.successful_publish_count += 1;
+        inner.has_published = true;
     }
 
     /// Records that a fee bump was performed, incrementing the bump counter
-    /// and clearing the bump-fees flag.
-    pub fn record_fee_bump(&self) {
+    /// and returning the new count.
+    pub fn record_fee_bump(&self) -> u64 {
         let mut inner = self.inner.lock().expect("SendState mutex poisoned");
         inner.bump_count += 1;
-        inner.bump_fees = false;
+        inner.bump_count
     }
 
-    /// Returns `true` if the next send attempt should bump fees.
-    #[must_use]
-    pub fn should_bump_fees(&self) -> bool {
-        let inner = self.inner.lock().expect("SendState mutex poisoned");
-        inner.bump_fees
-    }
-
-    /// Clears the bump-fees flag without incrementing the bump counter.
+    /// Atomically reads and clears the bump-fees flag. Returns `true` if
+    /// fees should be bumped.
     ///
-    /// Called before attempting a fee bump so that a failed attempt
-    /// (e.g., RPC timeout in [`suggest_gas_price_caps`]) does not
-    /// immediately re-trigger the bump on the next loop iteration. If
-    /// the bump succeeds, [`record_fee_bump`] will also clear the flag
-    /// (a harmless no-op) and increment the counter. If a new retryable
-    /// error occurs later, [`process_send_error`] will re-set the flag.
+    /// Clearing eagerly prevents a failed bump attempt (e.g. RPC timeout)
+    /// from immediately re-triggering on the next loop iteration. If a new
+    /// retryable error occurs later, [`process_send_error`] will re-set the
+    /// flag.
     ///
-    /// [`suggest_gas_price_caps`]: crate::SimpleTxManager::suggest_gas_price_caps
-    /// [`record_fee_bump`]: Self::record_fee_bump
     /// [`process_send_error`]: Self::process_send_error
-    pub fn clear_bump_fees(&self) {
+    #[must_use]
+    pub fn take_bump_fees(&self) -> bool {
         let mut inner = self.inner.lock().expect("SendState mutex poisoned");
-        inner.bump_fees = false;
+        std::mem::take(&mut inner.bump_fees)
     }
 
     /// Sets the mempool inclusion deadline.
@@ -243,18 +205,11 @@ impl SendState {
         inner.mempool_deadline = Some(deadline);
     }
 
-    /// Returns the number of fee bumps performed so far.
+    /// Returns `true` if at least one transaction was successfully published.
     #[must_use]
-    pub fn bump_count(&self) -> u64 {
+    pub fn has_published(&self) -> bool {
         let inner = self.inner.lock().expect("SendState mutex poisoned");
-        inner.bump_count
-    }
-
-    /// Returns the number of successful transaction publications.
-    #[must_use]
-    pub fn successful_publish_count(&self) -> u64 {
-        let inner = self.inner.lock().expect("SendState mutex poisoned");
-        inner.successful_publish_count
+        inner.has_published
     }
 }
 
@@ -302,13 +257,13 @@ mod tests {
     #[test]
     fn fresh_state_should_not_bump_fees() {
         let state = SendState::new(3).unwrap();
-        assert!(!state.should_bump_fees());
+        assert!(!state.take_bump_fees());
     }
 
     #[test]
-    fn fresh_state_bump_count_is_zero() {
+    fn fresh_state_has_not_published() {
         let state = SendState::new(3).unwrap();
-        assert_eq!(state.bump_count(), 0);
+        assert!(!state.has_published());
     }
 
     // ── Nonce-too-low threshold ─────────────────────────────────────────
@@ -551,7 +506,7 @@ mod tests {
     fn nonce_too_high_does_not_set_bump_fees() {
         let state = SendState::new(3).unwrap();
         state.process_send_error(&TxManagerError::NonceTooHigh);
-        assert!(!state.should_bump_fees());
+        assert!(!state.take_bump_fees());
     }
 
     // ── AlreadyReserved ─────────────────────────────────────────────────
@@ -616,77 +571,65 @@ mod tests {
     #[case::rpc(TxManagerError::Rpc("any rpc error".to_string()))]
     fn retryable_error_sets_bump_fees(#[case] err: TxManagerError) {
         let state = SendState::new(3).unwrap();
-        assert!(!state.should_bump_fees());
+        assert!(!state.take_bump_fees());
         state.process_send_error(&err);
-        assert!(state.should_bump_fees());
+        assert!(state.take_bump_fees());
     }
 
     #[test]
-    fn record_fee_bump_clears_flag_and_increments_count() {
+    fn record_fee_bump_increments_and_returns_count() {
         let state = SendState::new(3).unwrap();
-        state.process_send_error(&TxManagerError::Underpriced);
-        assert!(state.should_bump_fees());
-        assert_eq!(state.bump_count(), 0);
-
-        state.record_fee_bump();
-        assert!(!state.should_bump_fees());
-        assert_eq!(state.bump_count(), 1);
+        assert_eq!(state.record_fee_bump(), 1);
+        assert_eq!(state.record_fee_bump(), 2);
     }
 
     #[test]
     fn nonce_too_low_does_not_set_bump_fees() {
         let state = SendState::new(3).unwrap();
         state.process_send_error(&TxManagerError::NonceTooLow);
-        assert!(!state.should_bump_fees());
+        assert!(!state.take_bump_fees());
     }
 
     #[test]
     fn non_retryable_error_does_not_set_bump_fees() {
         let state = SendState::new(3).unwrap();
         state.process_send_error(&TxManagerError::InsufficientFunds);
-        assert!(!state.should_bump_fees());
+        assert!(!state.take_bump_fees());
     }
 
     #[test]
-    fn clear_bump_fees_clears_flag_without_incrementing_count() {
+    fn take_bump_fees_clears_flag() {
         let state = SendState::new(3).unwrap();
         state.process_send_error(&TxManagerError::Underpriced);
-        assert!(state.should_bump_fees());
-        assert_eq!(state.bump_count(), 0);
 
-        // clear_bump_fees clears the flag but does not touch the counter.
-        state.clear_bump_fees();
-        assert!(!state.should_bump_fees());
-        assert_eq!(state.bump_count(), 0, "bump_count should not increment on clear");
+        assert!(state.take_bump_fees());
+        assert!(!state.take_bump_fees());
     }
 
     #[test]
-    fn clear_bump_fees_allows_flag_to_be_re_set() {
+    fn take_bump_fees_allows_flag_to_be_re_set() {
         let state = SendState::new(3).unwrap();
         state.process_send_error(&TxManagerError::Underpriced);
-        assert!(state.should_bump_fees());
-
-        state.clear_bump_fees();
-        assert!(!state.should_bump_fees());
+        assert!(state.take_bump_fees());
 
         // A new retryable error re-sets the flag.
         state.process_send_error(&TxManagerError::ReplacementUnderpriced);
-        assert!(state.should_bump_fees());
+        assert!(state.take_bump_fees());
     }
 
-    // ── successful_publish_count ─────────────────────────────────────────
+    // ── has_published ───────────────────────────────────────────────────
 
     #[test]
-    fn successful_publish_count_tracks_publications() {
+    fn has_published_tracks_publication() {
         let state = SendState::new(3).unwrap();
-        assert_eq!(state.successful_publish_count(), 0);
+        assert!(!state.has_published());
 
         state.record_successful_publish();
-        assert_eq!(state.successful_publish_count(), 1);
+        assert!(state.has_published());
 
+        // Idempotent.
         state.record_successful_publish();
-        state.record_successful_publish();
-        assert_eq!(state.successful_publish_count(), 3);
+        assert!(state.has_published());
     }
 
     // ── is_waiting_for_confirmation ─────────────────────────────────────

--- a/crates/utilities/tx-manager/src/test_utils.rs
+++ b/crates/utilities/tx-manager/src/test_utils.rs
@@ -4,28 +4,34 @@ use alloy_consensus::{Eip658Value, Receipt, ReceiptEnvelope, ReceiptWithBloom};
 use alloy_primitives::{Address, B256, Bloom};
 use alloy_rpc_types_eth::TransactionReceipt;
 
-/// Helper to build a minimal `TransactionReceipt` for tests.
-pub fn stub_receipt() -> TransactionReceipt {
-    let inner = ReceiptEnvelope::Legacy(ReceiptWithBloom {
-        receipt: Receipt {
-            status: Eip658Value::Eip658(true),
-            cumulative_gas_used: 21_000,
-            logs: vec![],
-        },
-        logs_bloom: Bloom::ZERO,
-    });
-    TransactionReceipt {
-        inner,
-        transaction_hash: B256::ZERO,
-        transaction_index: Some(0),
-        block_hash: Some(B256::ZERO),
-        block_number: Some(1),
-        gas_used: 21_000,
-        effective_gas_price: 1_000_000_000,
-        blob_gas_used: None,
-        blob_gas_price: None,
-        from: Address::ZERO,
-        to: Some(Address::ZERO),
-        contract_address: None,
+/// Helpers for building test transaction receipts.
+#[derive(Debug)]
+pub struct StubReceipt;
+
+impl StubReceipt {
+    /// Builds a minimal successful `TransactionReceipt`.
+    pub fn success() -> TransactionReceipt {
+        let inner = ReceiptEnvelope::Legacy(ReceiptWithBloom {
+            receipt: Receipt {
+                status: Eip658Value::success(),
+                cumulative_gas_used: 21_000,
+                logs: vec![],
+            },
+            logs_bloom: Bloom::ZERO,
+        });
+        TransactionReceipt {
+            inner,
+            transaction_hash: B256::ZERO,
+            transaction_index: Some(0),
+            block_hash: Some(B256::ZERO),
+            block_number: Some(1),
+            gas_used: 21_000,
+            effective_gas_price: 1_000_000_000,
+            blob_gas_used: None,
+            blob_gas_price: None,
+            from: Address::ZERO,
+            to: Some(Address::ZERO),
+            contract_address: None,
+        }
     }
 }

--- a/crates/utilities/tx-manager/src/traits.rs
+++ b/crates/utilities/tx-manager/src/traits.rs
@@ -38,12 +38,9 @@ impl Future for SendHandle {
     type Output = SendResponse;
 
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-        // `oneshot::Receiver` is `Unpin`, so direct polling is safe.
-        match Pin::new(&mut self.get_mut().rx).poll(cx) {
-            Poll::Ready(Ok(result)) => Poll::Ready(result),
-            Poll::Ready(Err(_)) => Poll::Ready(Err(TxManagerError::ChannelClosed)),
-            Poll::Pending => Poll::Pending,
-        }
+        Pin::new(&mut self.get_mut().rx)
+            .poll(cx)
+            .map(|res| res.unwrap_or(Err(TxManagerError::ChannelClosed)))
     }
 }
 
@@ -73,8 +70,8 @@ pub trait TxManager: Send + Sync + Debug {
     /// The default implementation is a no-op that immediately returns `Ok(())`,
     /// suitable for test managers and environments where txpool management is
     /// not needed.
-    fn cancel_tx(&self) -> impl Future<Output = Result<(), TxManagerError>> + Send {
-        async { Ok(()) }
+    fn cancel_tx(&self) -> impl Future<Output = TxManagerResult<()>> + Send {
+        std::future::ready(Ok(()))
     }
 }
 
@@ -83,13 +80,13 @@ mod tests {
     use tokio::sync::oneshot;
 
     use super::*;
-    use crate::{TxManagerError, test_utils::stub_receipt};
+    use crate::{TxManagerError, test_utils::StubReceipt};
 
     #[tokio::test]
     async fn send_handle_yields_ok_on_success() {
         let (tx, rx) = oneshot::channel();
         let handle = SendHandle::new(rx);
-        let receipt = stub_receipt();
+        let receipt = StubReceipt::success();
         tx.send(Ok(receipt.clone())).unwrap();
         let result = handle.await;
         assert_eq!(result.unwrap(), receipt);

--- a/crates/utilities/tx-manager/tests/common/mod.rs
+++ b/crates/utilities/tx-manager/tests/common/mod.rs
@@ -1,0 +1,114 @@
+//! Shared test helpers for tx-manager integration tests.
+//!
+//! Each integration test compiles this module independently, so not every
+//! binary uses every item.
+#![allow(dead_code, unreachable_pub)]
+
+use std::sync::Arc;
+
+use alloy_consensus::SignableTransaction;
+use alloy_network::{EthereumWallet, TxSigner};
+use alloy_node_bindings::Anvil;
+use alloy_primitives::{Address, B256, Bytes, Signature, U256};
+use alloy_provider::{Provider, RootProvider};
+use alloy_signer_local::PrivateKeySigner;
+use async_trait::async_trait;
+use base_tx_manager::{NoopTxMetrics, SendState, SimpleTxManager, TxCandidate, TxManagerConfig};
+
+pub const TEST_RECIPIENT: Address = Address::with_last_byte(0x42);
+pub const SAFE_ABORT_DEPTH: u64 = 3;
+
+/// Spawns an Anvil instance and returns the provider, default wallet, and
+/// instance handle.
+pub fn setup_anvil() -> (RootProvider, EthereumWallet, alloy_node_bindings::AnvilInstance) {
+    let anvil = Anvil::new().spawn();
+    let provider = RootProvider::new_http(anvil.endpoint_url());
+    let signer: PrivateKeySigner = anvil.keys()[0].clone().into();
+    let wallet = EthereumWallet::from(signer);
+    (provider, wallet, anvil)
+}
+
+/// Creates a [`SimpleTxManager`] backed by a fresh Anvil instance.
+pub async fn setup_with_config(
+    config: TxManagerConfig,
+) -> (SimpleTxManager<RootProvider>, alloy_node_bindings::AnvilInstance) {
+    let (provider, wallet, anvil) = setup_anvil();
+    let manager = SimpleTxManager::from_wallet(
+        provider,
+        wallet,
+        config,
+        anvil.chain_id(),
+        Arc::new(NoopTxMetrics),
+    )
+    .await
+    .expect("should create manager");
+    (manager, anvil)
+}
+
+/// Force-mine a block on Anvil so receipts are committed before queries.
+pub async fn mine_block(provider: &RootProvider) {
+    provider
+        .raw_request::<(), String>("evm_mine".into(), ())
+        .await
+        .expect("evm_mine should succeed");
+}
+
+/// Value-transfer candidate with the given amount.
+pub fn value_transfer(value: u64) -> TxCandidate {
+    TxCandidate { to: Some(TEST_RECIPIENT), value: U256::from(value), ..Default::default() }
+}
+
+/// Simple value-transfer candidate reused across tests.
+pub fn simple_tx_candidate() -> TxCandidate {
+    value_transfer(1_000)
+}
+
+/// Publishes a simple value-transfer tx and returns the hash, send state,
+/// and raw transaction bytes.
+pub async fn publish_simple_tx(
+    manager: &SimpleTxManager<RootProvider>,
+) -> (B256, SendState, Bytes) {
+    let candidate = simple_tx_candidate();
+    let prepared = manager.craft_tx(&candidate, None).await.expect("should craft tx");
+    let send_state = SendState::new(SAFE_ABORT_DEPTH).expect("should create send state");
+    let raw_tx = prepared.raw_tx;
+    let tx_hash = manager.publish_tx(&send_state, &raw_tx, None).await.expect("should publish tx");
+    (tx_hash, send_state, raw_tx)
+}
+
+/// A signer that always fails, for testing error paths.
+pub struct FailingSigner {
+    pub address: Address,
+}
+
+#[async_trait]
+impl TxSigner<Signature> for FailingSigner {
+    fn address(&self) -> Address {
+        self.address
+    }
+
+    async fn sign_transaction(
+        &self,
+        _tx: &mut dyn SignableTransaction<Signature>,
+    ) -> alloy_signer::Result<Signature> {
+        Err(alloy_signer::Error::other("deliberately failing signer"))
+    }
+}
+
+/// Creates a [`SimpleTxManager`] whose wallet always fails to sign.
+pub async fn setup_with_failing_signer(
+    config: TxManagerConfig,
+) -> (SimpleTxManager<RootProvider>, alloy_node_bindings::AnvilInstance) {
+    let (provider, _, anvil) = setup_anvil();
+    let wallet = EthereumWallet::from(FailingSigner { address: anvil.addresses()[0] });
+    let manager = SimpleTxManager::from_wallet(
+        provider,
+        wallet,
+        config,
+        anvil.chain_id(),
+        Arc::new(NoopTxMetrics),
+    )
+    .await
+    .expect("should create manager with failing signer");
+    (manager, anvil)
+}

--- a/crates/utilities/tx-manager/tests/craft_tx.rs
+++ b/crates/utilities/tx-manager/tests/craft_tx.rs
@@ -1,48 +1,27 @@
 //! Integration tests for [`SimpleTxManager`] transaction construction with Anvil.
 
+mod common;
+
 use std::sync::Arc;
 
-use alloy_consensus::{SignableTransaction, TxEip1559, TxEip4844Variant, TxEnvelope};
+use alloy_consensus::{TxEip1559, TxEip4844Variant, TxEnvelope};
 use alloy_eips::{eip4844::Blob, eip7594::CELLS_PER_EXT_BLOB};
-use alloy_network::{EthereumWallet, TxSigner};
 use alloy_node_bindings::Anvil;
-use alloy_primitives::{Address, Bytes, Signature, TxKind, U256};
+use alloy_primitives::{Bytes, TxKind, U256};
 use alloy_provider::RootProvider;
 use alloy_signer_local::PrivateKeySigner;
-use async_trait::async_trait;
 use base_tx_manager::{
-    FeeCalculator, FeeOverride, GasPriceCaps, NoopTxMetrics, PreparedTx, SignerConfig,
-    SimpleTxManager, TxCandidate, TxManager, TxManagerConfig, TxManagerError,
+    FeeCalculator, FeeOverride, NoopTxMetrics, PreparedTx, SignerConfig, SimpleTxManager,
+    TxCandidate, TxManager, TxManagerConfig, TxManagerError,
+};
+use common::{
+    TEST_RECIPIENT, setup_anvil, setup_with_config, setup_with_failing_signer, value_transfer,
 };
 
-/// Helper: spawns an Anvil instance and returns a [`SimpleTxManager`]
-/// configured with the given [`TxManagerConfig`].
-async fn setup_with_config(
-    config: TxManagerConfig,
-) -> (SimpleTxManager<RootProvider>, alloy_node_bindings::AnvilInstance) {
-    let anvil = Anvil::new().spawn();
-    let url = anvil.endpoint_url();
-    let provider = RootProvider::new_http(url);
-    let signer: PrivateKeySigner = anvil.keys()[0].clone().into();
-    let wallet = EthereumWallet::from(signer);
-    let chain_id = anvil.chain_id();
-    let manager =
-        SimpleTxManager::from_wallet(provider, wallet, config, chain_id, Arc::new(NoopTxMetrics))
-            .await
-            .expect("should create manager");
-    (manager, anvil)
-}
-
-/// Helper: spawns an Anvil instance and returns a [`SimpleTxManager`]
-/// with the default [`TxManagerConfig`].
 async fn setup() -> (SimpleTxManager<RootProvider>, alloy_node_bindings::AnvilInstance) {
     setup_with_config(TxManagerConfig::default()).await
 }
 
-/// Decodes a [`PreparedTx`] into the inner [`TxEip1559`].
-///
-/// Panics if the bytes are not a valid EIP-2718 envelope or the
-/// transaction type is not EIP-1559.
 fn decode_eip1559(prepared: &PreparedTx) -> TxEip1559 {
     match prepared.to_envelope().expect("should decode as valid TxEnvelope") {
         TxEnvelope::Eip1559(signed) => signed.strip_signature(),
@@ -50,24 +29,25 @@ fn decode_eip1559(prepared: &PreparedTx) -> TxEip1559 {
     }
 }
 
+fn single_blob_candidate() -> TxCandidate {
+    TxCandidate {
+        to: Some(TEST_RECIPIENT),
+        blobs: Arc::from(vec![Box::<Blob>::default()]),
+        ..Default::default()
+    }
+}
+
 #[tokio::test]
 async fn craft_tx_produces_valid_signed_eip1559_transaction() {
     let (manager, anvil) = setup().await;
 
-    let to = Address::with_last_byte(0x42);
-    let value = U256::from(1_000_000_000u64);
-    let candidate = TxCandidate {
-        to: Some(to),
-        value,
-        gas_limit: 0, // auto-estimate
-        ..Default::default()
-    };
+    let candidate = value_transfer(1_000_000_000);
 
     let prepared = manager.craft_tx(&candidate, None).await.expect("should craft tx");
     let tx = decode_eip1559(&prepared);
 
-    assert_eq!(tx.to, TxKind::Call(to));
-    assert_eq!(tx.value, value);
+    assert_eq!(tx.to, TxKind::Call(TEST_RECIPIENT));
+    assert_eq!(tx.value, U256::from(1_000_000_000u64));
     assert_eq!(tx.chain_id, anvil.chain_id());
     assert_eq!(tx.nonce, 0, "first tx should have nonce 0");
     assert_eq!(tx.gas_limit, 21_000, "plain value transfer intrinsic gas should be 21,000");
@@ -78,7 +58,6 @@ async fn craft_tx_produces_valid_signed_eip1559_transaction() {
         prepared.gas_fee_cap > prepared.gas_tip_cap,
         "PreparedTx gas_fee_cap should exceed gas_tip_cap",
     );
-    // PreparedTx fees must match the fees encoded in the signed transaction.
     assert_eq!(
         prepared.gas_tip_cap, tx.max_priority_fee_per_gas,
         "PreparedTx gas_tip_cap should match decoded max_priority_fee_per_gas",
@@ -93,23 +72,12 @@ async fn craft_tx_produces_valid_signed_eip1559_transaction() {
 async fn craft_tx_with_explicit_gas_limit_above_estimate() {
     let (manager, _anvil) = setup().await;
 
-    // Use a gas_limit well above the 21,000 intrinsic gas for a simple
-    // value transfer.  estimate_gas returns ~21,000, so the
-    // `candidate.gas_limit.max(estimated)` floor logic must produce
-    // 100,000 — not the estimate.
-    let candidate = TxCandidate {
-        to: Some(Address::with_last_byte(0x42)),
-        value: U256::from(1_000u64),
-        gas_limit: 100_000,
-        ..Default::default()
-    };
+    let candidate = TxCandidate { gas_limit: 100_000, ..value_transfer(1_000) };
 
     let prepared =
         manager.craft_tx(&candidate, None).await.expect("should craft tx with explicit gas");
     let tx = decode_eip1559(&prepared);
 
-    // The decoded gas_limit must equal the caller's explicit value,
-    // proving it was used as a floor above the provider estimate.
     assert_eq!(tx.gas_limit, 100_000);
 }
 
@@ -118,21 +86,16 @@ async fn craft_tx_rejects_too_many_blobs() {
     let (manager, _anvil) = setup().await;
 
     let candidate = TxCandidate {
-        to: Some(Address::with_last_byte(0x42)),
-        blobs: Arc::new((0..7).map(|_| Box::<Blob>::default()).collect::<Vec<_>>()),
+        to: Some(TEST_RECIPIENT),
+        blobs: Arc::from((0..7).map(|_| Box::<Blob>::default()).collect::<Vec<_>>()),
         ..Default::default()
     };
 
     let err = manager.craft_tx(&candidate, None).await.expect_err("should reject too many blobs");
-    match &err {
-        TxManagerError::Unsupported(msg) => {
-            assert!(
-                msg.contains("exceeds maximum"),
-                "expected blob count exceeded message, got: {msg}",
-            );
-        }
-        other => panic!("expected TxManagerError::Unsupported, got {other:?}"),
-    }
+    assert!(
+        matches!(&err, TxManagerError::Unsupported(msg) if msg.contains("exceeds maximum")),
+        "expected TxManagerError::Unsupported with 'exceeds maximum', got {err:?}",
+    );
 }
 
 #[tokio::test]
@@ -141,21 +104,16 @@ async fn craft_tx_rejects_blob_without_recipient() {
 
     let candidate = TxCandidate {
         to: None,
-        blobs: Arc::new(vec![Box::<Blob>::default()]),
+        blobs: Arc::from(vec![Box::<Blob>::default()]),
         ..Default::default()
     };
 
     let err =
         manager.craft_tx(&candidate, None).await.expect_err("should reject blob tx without to");
-    match &err {
-        TxManagerError::Unsupported(msg) => {
-            assert!(
-                msg.contains("recipient address"),
-                "expected recipient address rejection message, got: {msg}",
-            );
-        }
-        other => panic!("expected TxManagerError::Unsupported, got {other:?}"),
-    }
+    assert!(
+        matches!(&err, TxManagerError::Unsupported(msg) if msg.contains("recipient address")),
+        "expected TxManagerError::Unsupported with 'recipient address', got {err:?}",
+    );
 }
 
 #[tokio::test]
@@ -167,48 +125,31 @@ async fn craft_tx_produces_valid_signed_blob_transaction() {
     // would fail at craft_tx.
     let (manager, anvil) = setup().await;
 
-    let to = Address::with_last_byte(0x42);
-    let candidate = TxCandidate {
-        to: Some(to),
-        blobs: Arc::new(vec![Box::<Blob>::default()]),
-        ..Default::default()
-    };
+    let candidate = single_blob_candidate();
 
     let prepared = manager.craft_tx(&candidate, None).await.expect("should craft blob tx");
-
-    // Decode the raw transaction bytes.
     let envelope = prepared.to_envelope().expect("should decode TxEnvelope");
-
-    // Must be EIP-4844 type.
     assert!(envelope.is_eip4844(), "expected EIP-4844 transaction, got {envelope:?}");
 
     let signed = envelope.as_eip4844().expect("should be EIP-4844");
     let variant = signed.tx();
-
-    // The inner tx must have blob-specific fields populated.
     let inner = variant.tx();
-    assert_eq!(inner.to, to, "recipient should match");
+    assert_eq!(inner.to, TEST_RECIPIENT, "recipient should match");
     assert_eq!(inner.chain_id, anvil.chain_id(), "chain_id should match");
     assert!(!inner.blob_versioned_hashes.is_empty(), "blob_versioned_hashes should be populated");
     assert_eq!(inner.blob_versioned_hashes.len(), 1, "should have one versioned hash for one blob",);
     assert!(inner.max_fee_per_blob_gas > 0, "max_fee_per_blob_gas should be non-zero");
-
-    // Versioned hashes must use the 0x01 version byte.
     for hash in &inner.blob_versioned_hashes {
         assert_eq!(hash.0[0], 0x01, "versioned hash should start with 0x01, got: {hash}");
     }
-
-    // The sidecar must be present (TxEip4844WithSidecar variant).
     assert!(
         matches!(variant, TxEip4844Variant::TxEip4844WithSidecar(_)),
         "expected TxEip4844WithSidecar variant, got standalone TxEip4844",
     );
-
-    // PreparedTx must carry the blob fee cap.
-    assert!(prepared.blob_fee_cap.is_some(), "PreparedTx blob_fee_cap should be Some");
-    assert!(prepared.blob_fee_cap.unwrap() > 0, "PreparedTx blob_fee_cap should be non-zero");
-
-    // PreparedTx blob fee cap must match the max_fee_per_blob_gas in the signed tx.
+    assert!(
+        prepared.blob_fee_cap.is_some_and(|v| v > 0),
+        "PreparedTx blob_fee_cap should be Some and non-zero",
+    );
     assert_eq!(
         prepared.blob_fee_cap.unwrap(),
         inner.max_fee_per_blob_gas,
@@ -218,33 +159,21 @@ async fn craft_tx_produces_valid_signed_blob_transaction() {
 
 #[tokio::test]
 async fn craft_tx_produces_cell_proof_sidecar_by_default() {
-    let (manager, anvil) = setup().await;
+    let (manager, _anvil) = setup().await;
 
-    let to = Address::with_last_byte(0x42);
-    let candidate = TxCandidate {
-        to: Some(to),
-        blobs: Arc::new(vec![Box::<Blob>::default()]),
-        ..Default::default()
-    };
+    let candidate = single_blob_candidate();
 
     let prepared =
         manager.craft_tx(&candidate, None).await.expect("should craft cell-proof blob tx");
 
-    // The cached sidecar must use Osaka-era cell proofs.
     assert_eq!(
         prepared.sidecar.as_ref().expect("sidecar should be Some for blob tx").cell_proofs.len(),
         CELLS_PER_EXT_BLOB,
     );
 
-    // On the wire it is still EIP-4844 type — cell proofs are sidecar-internal.
+    // Cell proofs are sidecar-internal; on the wire it is still EIP-4844 type.
     let envelope = prepared.to_envelope().expect("should decode TxEnvelope");
     assert!(envelope.is_eip4844(), "expected EIP-4844 transaction type");
-
-    let signed = envelope.as_eip4844().expect("should be EIP-4844");
-    let inner = signed.tx().tx();
-    assert_eq!(inner.to, to, "recipient should match");
-    assert_eq!(inner.chain_id, anvil.chain_id(), "chain_id should match");
-    assert!(!inner.blob_versioned_hashes.is_empty(), "blob_versioned_hashes should be populated");
 }
 
 #[tokio::test]
@@ -270,21 +199,15 @@ async fn craft_tx_contract_creation() {
 async fn suggest_gas_price_caps_returns_valid_estimates() {
     let (manager, _anvil) = setup().await;
 
-    let caps: GasPriceCaps =
-        manager.suggest_gas_price_caps().await.expect("should return gas price caps");
+    let caps = manager.suggest_gas_price_caps().await.expect("should return gas price caps");
 
-    // On an Anvil instance, tip and fee cap should be non-zero.
     assert!(caps.gas_tip_cap > 0, "tip_cap should be non-zero");
-    // gas_fee_cap = tip + 2 * base_fee, which is always > tip alone.
     assert!(caps.gas_fee_cap > caps.gas_tip_cap, "fee_cap should exceed tip_cap");
-    // raw_gas_fee_cap (from provider values before enforcing minimums) should
-    // be <= gas_fee_cap (after enforcing minimums) and non-zero on Anvil.
     assert!(caps.raw_gas_fee_cap > 0, "raw_gas_fee_cap should be non-zero");
     assert!(
         caps.raw_gas_fee_cap <= caps.gas_fee_cap,
         "raw_gas_fee_cap should be <= gas_fee_cap after enforcing minimums",
     );
-    // Blob fee cap should be None for non-blob transactions.
     assert!(caps.blob_fee_cap.is_none(), "blob_fee_cap should be None");
 }
 
@@ -292,19 +215,12 @@ async fn suggest_gas_price_caps_returns_valid_estimates() {
 async fn prepare_produces_valid_signed_transaction() {
     let (manager, _anvil) = setup().await;
 
-    let to = Address::with_last_byte(0x42);
-    let candidate = TxCandidate {
-        to: Some(to),
-        value: U256::from(1_000u64),
-        gas_limit: 0,
-        ..Default::default()
-    };
+    let candidate = value_transfer(1_000);
 
     let prepared = manager.prepare(&candidate, None).await.expect("should prepare tx");
     let tx = decode_eip1559(&prepared);
 
-    // Confirm the candidate's fields survive the retry wrapper.
-    assert_eq!(tx.to, TxKind::Call(to));
+    assert_eq!(tx.to, TxKind::Call(TEST_RECIPIENT));
     assert_eq!(tx.value, U256::from(1_000u64));
 }
 
@@ -314,11 +230,7 @@ async fn prepare_returns_channel_closed_when_manager_is_closed() {
 
     manager.close();
 
-    let candidate = TxCandidate {
-        to: Some(Address::with_last_byte(0x42)),
-        value: U256::ZERO,
-        ..Default::default()
-    };
+    let candidate = value_transfer(0);
 
     let err = manager.prepare(&candidate, None).await.expect_err("should fail");
     assert_eq!(err, TxManagerError::ChannelClosed);
@@ -345,14 +257,8 @@ async fn is_closed_reflects_manager_state() {
 async fn sequential_craft_tx_increments_nonce() {
     let (manager, _anvil) = setup().await;
 
-    let candidate = TxCandidate {
-        to: Some(Address::with_last_byte(0x42)),
-        value: U256::from(1u64),
-        gas_limit: 0,
-        ..Default::default()
-    };
+    let candidate = value_transfer(1);
 
-    // Craft two transactions — nonces should be sequential.
     let prepared1 = manager.craft_tx(&candidate, None).await.expect("first tx");
     let prepared2 = manager.craft_tx(&candidate, None).await.expect("second tx");
 
@@ -379,40 +285,27 @@ async fn new_with_signer_config_local_creates_functional_manager() {
     .await
     .expect("should create manager via SignerConfig::Local");
 
-    // Sender address should match the Anvil account derived from the key.
     assert_eq!(manager.sender_address(), anvil.addresses()[0]);
 }
 
 #[tokio::test]
 async fn new_rejects_chain_id_mismatch() {
-    let anvil = Anvil::new().spawn();
-    let url = anvil.endpoint_url();
-    let provider = RootProvider::new_http(url);
-    let signer: PrivateKeySigner = anvil.keys()[0].clone().into();
-    let wallet = EthereumWallet::from(signer);
-    let config = TxManagerConfig::default();
+    let (provider, wallet, _anvil) = setup_anvil();
 
-    // Anvil uses chain_id 31337 by default; supply a wrong one.
-    let wrong_chain_id = 999;
     let err = SimpleTxManager::from_wallet(
         provider,
         wallet,
-        config,
-        wrong_chain_id,
+        TxManagerConfig::default(),
+        999, // wrong chain_id
         Arc::new(NoopTxMetrics),
     )
     .await
     .expect_err("should reject mismatched chain_id");
 
-    match &err {
-        TxManagerError::InvalidConfig(msg) => {
-            assert!(
-                msg.contains("chain_id mismatch"),
-                "expected chain_id mismatch error, got: {msg}",
-            );
-        }
-        other => panic!("expected TxManagerError::InvalidConfig, got {other:?}"),
-    }
+    assert!(
+        matches!(&err, TxManagerError::InvalidConfig(msg) if msg.contains("chain_id mismatch")),
+        "expected TxManagerError::InvalidConfig with 'chain_id mismatch', got {err:?}",
+    );
 }
 
 #[tokio::test]
@@ -421,7 +314,7 @@ async fn craft_tx_preserves_calldata() {
 
     let calldata = Bytes::from_static(&[0xde, 0xad, 0xbe, 0xef]);
     let candidate = TxCandidate {
-        to: Some(Address::with_last_byte(0x42)),
+        to: Some(TEST_RECIPIENT),
         tx_data: calldata.clone(),
         value: U256::ZERO,
         gas_limit: 0,
@@ -436,10 +329,9 @@ async fn craft_tx_preserves_calldata() {
 
 #[tokio::test]
 async fn suggest_gas_price_caps_enforces_min_tip_cap_and_min_basefee() {
-    // Set minimums well above what Anvil returns (Anvil tip is ~1 gwei,
-    // base fee ~1 gwei) so the .max() enforcement is exercised.
-    let high_min_tip = 50_000_000_000u128; // 50 gwei
-    let high_min_basefee = 100_000_000_000u128; // 100 gwei
+    // Minimums well above Anvil defaults (~1 gwei) to exercise the .max() path.
+    let high_min_tip = 50_000_000_000u128;
+    let high_min_basefee = 100_000_000_000u128;
     let config = TxManagerConfig {
         min_tip_cap: high_min_tip,
         min_basefee: high_min_basefee,
@@ -450,22 +342,18 @@ async fn suggest_gas_price_caps_enforces_min_tip_cap_and_min_basefee() {
 
     let caps = manager.suggest_gas_price_caps().await.expect("should return caps");
 
-    // Tip cap should be at least the configured minimum.
     assert!(
         caps.gas_tip_cap >= high_min_tip,
         "gas_tip_cap {} should be >= min_tip_cap {high_min_tip}",
         caps.gas_tip_cap,
     );
-    // Fee cap should reflect the enforced minimum base fee:
-    // gas_fee_cap = tip + 2 * base_fee >= high_min_tip + 2 * high_min_basefee.
+    // gas_fee_cap = tip + 2 * base_fee
     let expected_min_fee_cap = high_min_tip + 2 * high_min_basefee;
     assert!(
         caps.gas_fee_cap >= expected_min_fee_cap,
         "gas_fee_cap {} should be >= {expected_min_fee_cap} (min_tip + 2 * min_basefee)",
         caps.gas_fee_cap,
     );
-    // raw_gas_fee_cap should be strictly less than gas_fee_cap since we
-    // inflated both tip and base fee above the Anvil defaults.
     assert!(
         caps.raw_gas_fee_cap < caps.gas_fee_cap,
         "raw_gas_fee_cap {} should be < gas_fee_cap {} when minimums are enforced",
@@ -476,33 +364,22 @@ async fn suggest_gas_price_caps_enforces_min_tip_cap_and_min_basefee() {
 
 #[tokio::test]
 async fn new_rejects_invalid_config() {
-    let anvil = Anvil::new().spawn();
-    let url = anvil.endpoint_url();
-    let provider = RootProvider::new_http(url);
-    let signer: PrivateKeySigner = anvil.keys()[0].clone().into();
-    let wallet = EthereumWallet::from(signer);
-
-    let invalid_config = TxManagerConfig { num_confirmations: 0, ..TxManagerConfig::default() };
+    let (provider, wallet, anvil) = setup_anvil();
 
     let err = SimpleTxManager::from_wallet(
         provider,
         wallet,
-        invalid_config,
+        TxManagerConfig { num_confirmations: 0, ..TxManagerConfig::default() },
         anvil.chain_id(),
         Arc::new(NoopTxMetrics),
     )
     .await
     .expect_err("should reject invalid config");
 
-    match &err {
-        TxManagerError::InvalidConfig(msg) => {
-            assert!(
-                msg.contains("num_confirmations"),
-                "expected num_confirmations validation error, got: {msg}",
-            );
-        }
-        other => panic!("expected TxManagerError::InvalidConfig, got {other:?}"),
-    }
+    assert!(
+        matches!(&err, TxManagerError::InvalidConfig(msg) if msg.contains("num_confirmations")),
+        "expected TxManagerError::InvalidConfig with 'num_confirmations', got {err:?}",
+    );
 }
 
 #[tokio::test]
@@ -521,11 +398,7 @@ async fn craft_tx_returns_fee_limit_exceeded_when_minimums_inflate_beyond_multip
 
     let (manager, _anvil) = setup_with_config(config).await;
 
-    let candidate = TxCandidate {
-        to: Some(Address::with_last_byte(0x42)),
-        value: U256::from(1u64),
-        ..Default::default()
-    };
+    let candidate = value_transfer(1);
 
     let err = manager.craft_tx(&candidate, None).await.expect_err("should exceed fee limit");
     assert!(
@@ -543,7 +416,7 @@ async fn prepare_exits_immediately_on_non_retryable_error() {
     // Blob transactions without a recipient trigger Unsupported (non-retryable).
     let candidate = TxCandidate {
         to: None,
-        blobs: Arc::new(vec![Box::<Blob>::default()]),
+        blobs: Arc::from(vec![Box::<Blob>::default()]),
         ..Default::default()
     };
 
@@ -558,66 +431,12 @@ async fn prepare_exits_immediately_on_non_retryable_error() {
     );
 }
 
-/// A signer that always fails, used to test nonce rollback on sign failure.
-///
-/// Delegates `address()` to a real signer so the `EthereumWallet` routes
-/// signing requests correctly, then returns an error in `sign_transaction`.
-struct FailingSigner {
-    /// The address this signer claims to own.
-    address: Address,
-}
-
-#[async_trait]
-impl TxSigner<Signature> for FailingSigner {
-    fn address(&self) -> Address {
-        self.address
-    }
-
-    async fn sign_transaction(
-        &self,
-        _tx: &mut dyn SignableTransaction<Signature>,
-    ) -> alloy_signer::Result<Signature> {
-        Err(alloy_signer::Error::other("deliberately failing signer"))
-    }
-}
-
-/// Helper: spawns an Anvil instance and returns a [`SimpleTxManager`]
-/// whose wallet uses a [`FailingSigner`], causing all signing attempts
-/// to fail. The `FailingSigner` claims the same address as Anvil's first
-/// account so the rest of the pipeline (gas estimation, nonce) works.
-async fn setup_with_failing_signer()
--> (SimpleTxManager<RootProvider>, alloy_node_bindings::AnvilInstance) {
-    let anvil = Anvil::new().spawn();
-    let url = anvil.endpoint_url();
-    let provider = RootProvider::new_http(url);
-    let address = anvil.addresses()[0];
-    let wallet = EthereumWallet::from(FailingSigner { address });
-    let chain_id = anvil.chain_id();
-    let manager = SimpleTxManager::from_wallet(
-        provider,
-        wallet,
-        TxManagerConfig::default(),
-        chain_id,
-        Arc::new(NoopTxMetrics),
-    )
-    .await
-    .expect("should create manager with failing signer");
-    (manager, anvil)
-}
-
 #[tokio::test]
 async fn accessors_return_expected_values() {
     let (manager, anvil) = setup().await;
 
     assert_eq!(manager.chain_id(), anvil.chain_id());
-    assert_eq!(
-        manager.sender_address(),
-        anvil.addresses()[0],
-        "sender_address should match the first Anvil account",
-    );
-    // config() returns the default config used in setup().
     assert_eq!(manager.config().num_confirmations, TxManagerConfig::default().num_confirmations);
-    // provider() and wallet() are opaque, but we can verify they are accessible.
     let _ = manager.provider();
     let _ = manager.wallet();
     let _ = manager.nonce_manager();
@@ -632,26 +451,15 @@ async fn accessors_return_expected_values() {
 /// the nonce would advance to 1.
 #[tokio::test]
 async fn craft_tx_rolls_back_nonce_on_sign_failure() {
-    let (failing_manager, _anvil) = setup_with_failing_signer().await;
+    let (failing_manager, _anvil) = setup_with_failing_signer(TxManagerConfig::default()).await;
 
-    let candidate = TxCandidate {
-        to: Some(Address::with_last_byte(0x42)),
-        value: U256::from(1u64),
-        gas_limit: 0,
-        ..Default::default()
-    };
+    let candidate = value_transfer(1);
 
-    // First call: signing fails, nonce should be rolled back.
     let err = failing_manager.craft_tx(&candidate, None).await.expect_err("should fail to sign");
     assert!(matches!(err, TxManagerError::Sign(_)), "expected TxManagerError::Sign, got {err:?}",);
 
-    // Query the same NonceManager directly. If rollback worked the
-    // cached nonce is still 0; if it didn't, it would have advanced
-    // to 1 (the nonce after 0 was "consumed").
     let guard = failing_manager.nonce_manager().next_nonce().await.expect("should reserve nonce");
     assert_eq!(guard.nonce(), 0, "nonce should be 0 — rollback must have restored it");
-    // Drop the guard so the nonce is consumed (prevents test pollution).
-    drop(guard);
 }
 
 /// When fee overrides are above network fees, the [`PreparedTx`] must use the
@@ -660,17 +468,11 @@ async fn craft_tx_rolls_back_nonce_on_sign_failure() {
 async fn craft_tx_with_fee_overrides_uses_overrides_when_above_network() {
     let (manager, _anvil) = setup().await;
 
-    // Learn current network fees so we can set overrides above them.
     let caps = manager.suggest_gas_price_caps().await.expect("should get caps");
-    let override_tip = caps.gas_tip_cap + 50_000_000_000; // +50 gwei
-    let override_fee_cap = caps.gas_fee_cap + 100_000_000_000; // +100 gwei
+    let override_tip = caps.gas_tip_cap + 50_000_000_000;
+    let override_fee_cap = caps.gas_fee_cap + 100_000_000_000;
 
-    let candidate = TxCandidate {
-        to: Some(Address::with_last_byte(0x42)),
-        value: U256::from(1_000u64),
-        gas_limit: 0,
-        ..Default::default()
-    };
+    let candidate = value_transfer(1_000);
 
     let overrides = FeeOverride::new(override_tip, override_fee_cap);
     let prepared = manager
@@ -678,17 +480,9 @@ async fn craft_tx_with_fee_overrides_uses_overrides_when_above_network() {
         .await
         .expect("should craft tx with fee overrides");
 
-    // PreparedTx must reflect the overrides since they exceed network fees.
-    assert_eq!(
-        prepared.gas_tip_cap, override_tip,
-        "gas_tip_cap should equal the override when it exceeds the network fee",
-    );
-    assert_eq!(
-        prepared.gas_fee_cap, override_fee_cap,
-        "gas_fee_cap should equal the override when it exceeds the network fee",
-    );
+    assert_eq!(prepared.gas_tip_cap, override_tip);
+    assert_eq!(prepared.gas_fee_cap, override_fee_cap);
 
-    // The signed transaction must also carry the override fees.
     let tx = decode_eip1559(&prepared);
     assert_eq!(tx.max_priority_fee_per_gas, override_tip);
     assert_eq!(tx.max_fee_per_gas, override_fee_cap);
@@ -700,67 +494,17 @@ async fn craft_tx_with_fee_overrides_uses_overrides_when_above_network() {
 async fn craft_tx_with_fee_overrides_uses_network_when_overrides_below() {
     let (manager, _anvil) = setup().await;
 
-    // Learn current network fees.
-    let caps = manager.suggest_gas_price_caps().await.expect("should get caps");
+    let candidate = value_transfer(1_000);
 
-    // Set overrides well below network fees (1 wei each).
-    let override_tip = 1u128;
-    let override_fee_cap = 1u128;
-
-    let candidate = TxCandidate {
-        to: Some(Address::with_last_byte(0x42)),
-        value: U256::from(1_000u64),
-        gas_limit: 0,
-        ..Default::default()
-    };
-
-    let overrides = FeeOverride::new(override_tip, override_fee_cap);
+    // 1 wei overrides are far below any real network fee.
+    let overrides = FeeOverride::new(1, 1);
     let prepared = manager
         .craft_tx(&candidate, Some(overrides))
         .await
         .expect("should craft tx with low fee overrides");
 
-    // PreparedTx must use network fees since they exceed the overrides.
-    assert_eq!(
-        prepared.gas_tip_cap, caps.gas_tip_cap,
-        "gas_tip_cap should use network fee, not the low override",
-    );
-    assert_eq!(
-        prepared.gas_fee_cap, caps.gas_fee_cap,
-        "gas_fee_cap should use network fee, not the low override",
-    );
-}
-
-/// Verifies that the [`PreparedTx`] fee fields are always consistent with the
-/// fees encoded in the signed transaction — the core invariant that
-/// [`PreparedTx`] is designed to guarantee.
-#[tokio::test]
-async fn prepared_tx_fees_match_decoded_transaction_with_overrides() {
-    let (manager, _anvil) = setup().await;
-
-    let caps = manager.suggest_gas_price_caps().await.expect("should get caps");
-    let override_tip = caps.gas_tip_cap + 10_000_000_000;
-    let override_fee_cap = caps.gas_fee_cap + 20_000_000_000;
-
-    let candidate = TxCandidate {
-        to: Some(Address::with_last_byte(0x42)),
-        value: U256::from(1_000u64),
-        gas_limit: 0,
-        ..Default::default()
-    };
-
-    let overrides = FeeOverride::new(override_tip, override_fee_cap);
-    let prepared = manager.craft_tx(&candidate, Some(overrides)).await.expect("should craft tx");
-    let tx = decode_eip1559(&prepared);
-
-    assert_eq!(
-        prepared.gas_tip_cap, tx.max_priority_fee_per_gas,
-        "PreparedTx gas_tip_cap must match decoded max_priority_fee_per_gas",
-    );
-    assert_eq!(
-        prepared.gas_fee_cap, tx.max_fee_per_gas,
-        "PreparedTx gas_fee_cap must match decoded max_fee_per_gas",
-    );
+    assert!(prepared.gas_tip_cap > 1, "network tip should override the 1-wei override");
+    assert!(prepared.gas_fee_cap > 1, "network fee cap should override the 1-wei override");
 }
 
 #[test]
@@ -775,12 +519,7 @@ fn simple_tx_manager_is_send_and_sync() {
 async fn increase_gas_price_bumps_above_threshold() {
     let (manager, _anvil) = setup().await;
 
-    let candidate = TxCandidate {
-        to: Some(Address::with_last_byte(0x42)),
-        value: U256::from(1_000u64),
-        gas_limit: 0,
-        ..Default::default()
-    };
+    let candidate = value_transfer(1_000);
 
     // Use the initial on-wire fees as the "old" values.
     let prepared = manager.craft_tx(&candidate, None).await.expect("should craft initial tx");
@@ -820,12 +559,7 @@ async fn increase_gas_price_fee_limit_exceeded() {
 
     let (manager, _anvil) = setup_with_config(config).await;
 
-    let candidate = TxCandidate {
-        to: Some(Address::with_last_byte(0x42)),
-        value: U256::from(1_000u64),
-        gas_limit: 0,
-        ..Default::default()
-    };
+    let candidate = value_transfer(1_000);
 
     // Use high old fees that will bump above the ceiling. The 10% bump
     // on a fee_cap of 500 gwei will produce ~550 gwei, which exceeds
@@ -845,38 +579,10 @@ async fn increase_gas_price_fee_limit_exceeded() {
 }
 
 #[tokio::test]
-async fn increase_gas_price_preserves_none_blob_fee_cap() {
-    let (manager, _anvil) = setup().await;
-
-    let candidate = TxCandidate {
-        to: Some(Address::with_last_byte(0x42)),
-        value: U256::from(1_000u64),
-        gas_limit: 0,
-        ..Default::default()
-    };
-
-    let caps = manager.suggest_gas_price_caps().await.expect("should get caps");
-
-    let bumped = manager
-        .increase_gas_price(&candidate, caps.gas_tip_cap, caps.gas_fee_cap, None)
-        .await
-        .expect("should compute bumped fees");
-
-    assert!(
-        bumped.blob_fee_cap.is_none(),
-        "blob_fee_cap should remain None when old_blob_fee_cap is None",
-    );
-}
-
-#[tokio::test]
 async fn increase_gas_price_bumps_blob_fee_cap() {
     let (manager, _anvil) = setup().await;
 
-    let candidate = TxCandidate {
-        to: Some(Address::with_last_byte(0x42)),
-        blobs: Arc::new(vec![Box::<Blob>::default()]),
-        ..Default::default()
-    };
+    let candidate = single_blob_candidate();
 
     // Use craft_tx to get valid initial fees for a blob transaction.
     let initial = manager.craft_tx(&candidate, None).await.expect("should craft initial blob tx");
@@ -911,8 +617,7 @@ async fn increase_gas_price_rejects_blob_fee_cap_mismatch() {
     let (manager, _anvil) = setup().await;
 
     // Non-blob candidate with old_blob_fee_cap = Some should be rejected.
-    let non_blob_candidate =
-        TxCandidate { to: Some(Address::with_last_byte(0x42)), ..Default::default() };
+    let non_blob_candidate = value_transfer(0);
 
     let err = manager
         .increase_gas_price(&non_blob_candidate, 1_000, 2_000, Some(500))
@@ -929,18 +634,12 @@ async fn increase_gas_price_rejects_blob_fee_cap_mismatch() {
 async fn blob_fee_bump_round_trip() {
     let (manager, _anvil) = setup().await;
 
-    let candidate = TxCandidate {
-        to: Some(Address::with_last_byte(0x42)),
-        blobs: Arc::new(vec![Box::<Blob>::default()]),
-        ..Default::default()
-    };
+    let candidate = single_blob_candidate();
 
-    // Step 1: Craft the initial blob transaction.
     let initial = manager.craft_tx(&candidate, None).await.expect("should craft initial blob tx");
     let initial_blob_fee = initial.blob_fee_cap.expect("initial tx should have blob_fee_cap");
     assert!(initial_blob_fee > 0, "initial blob_fee_cap should be non-zero");
 
-    // Step 2: Simulate a fee bump — compute bumped fees from the initial values.
     let bumped = manager
         .increase_gas_price(
             &candidate,
@@ -957,7 +656,6 @@ async fn blob_fee_bump_round_trip() {
         "bumped blob_fee_cap {bumped_blob_fee} should be >= initial {initial_blob_fee}",
     );
 
-    // Step 3: Re-craft the transaction with the bumped fee overrides.
     let fee_override = FeeOverride::new(bumped.gas_tip_cap, bumped.gas_fee_cap)
         .with_blob_fee_cap(bumped_blob_fee)
         .with_gas_limit_floor(initial.gas_limit);
@@ -967,7 +665,6 @@ async fn blob_fee_bump_round_trip() {
         .await
         .expect("should craft replacement blob tx");
 
-    // Step 4: Verify the replacement transaction.
     let replacement_blob_fee =
         replacement.blob_fee_cap.expect("replacement tx should have blob_fee_cap");
     assert!(
@@ -987,7 +684,6 @@ async fn blob_fee_bump_round_trip() {
         bumped.gas_tip_cap,
     );
 
-    // Decode and verify the replacement is still a valid EIP-4844 tx with sidecar.
     let envelope = replacement.to_envelope().expect("should decode replacement TxEnvelope");
     assert!(envelope.is_eip4844(), "replacement should be EIP-4844");
 

--- a/crates/utilities/tx-manager/tests/custom_prefix.rs
+++ b/crates/utilities/tx-manager/tests/custom_prefix.rs
@@ -13,7 +13,6 @@ struct TestCli {
 #[test]
 fn env_vars_use_custom_prefix() {
     let cmd = TestCli::command();
-    let args: Vec<_> = cmd.get_arguments().collect();
 
     let cases = [
         ("tx-manager.num-confirmations", "CUSTOM_PREFIX_NUM_CONFIRMATIONS"),
@@ -35,8 +34,8 @@ fn env_vars_use_custom_prefix() {
     ];
 
     for (long_name, expected_env) in cases {
-        let arg = args
-            .iter()
+        let arg = cmd
+            .get_arguments()
             .find(|a| a.get_long() == Some(long_name))
             .unwrap_or_else(|| panic!("{long_name} arg should exist"));
         assert_eq!(

--- a/crates/utilities/tx-manager/tests/reorg.rs
+++ b/crates/utilities/tx-manager/tests/reorg.rs
@@ -5,18 +5,23 @@
 //! [`SendState`], and [`NonceManager`] behave correctly when blocks are
 //! reorged out.
 
+mod common;
+
 use std::{sync::Arc, time::Duration};
 
 use alloy_network::EthereumWallet;
-use alloy_primitives::{Address, B256, U256};
+use alloy_primitives::{B256, U256};
 use alloy_provider::{Provider, RootProvider};
 use alloy_signer_local::PrivateKeySigner;
-use base_tx_manager::{NoopTxMetrics, SendState, SimpleTxManager, TxCandidate, TxManagerConfig};
+use base_tx_manager::{NoopTxMetrics, SendState, SimpleTxManager, TxManagerConfig};
+use common::{mine_block, publish_simple_tx, setup_with_config};
 
 // ── Helpers ────────────────────────────────────────────────────────────
 
 const QUERY_TIMEOUT: Duration = Duration::from_secs(10);
 
+/// Creates a [`SimpleTxManager`] from an existing Anvil instance, needed
+/// for tests that customize Anvil flags (e.g. `--no-mining`).
 async fn manager_from_anvil(
     anvil: &alloy_node_bindings::AnvilInstance,
     config: TxManagerConfig,
@@ -33,21 +38,6 @@ async fn manager_from_anvil(
     )
     .await
     .expect("should create manager")
-}
-
-async fn setup_with_config(
-    config: TxManagerConfig,
-) -> (SimpleTxManager<RootProvider>, alloy_node_bindings::AnvilInstance) {
-    let anvil = alloy_node_bindings::Anvil::new().spawn();
-    let manager = manager_from_anvil(&anvil, config).await;
-    (manager, anvil)
-}
-
-async fn mine_block(provider: &RootProvider) {
-    provider
-        .raw_request::<(), String>("evm_mine".into(), ())
-        .await
-        .expect("evm_mine should succeed");
 }
 
 async fn mine_blocks(provider: &RootProvider, n: usize) {
@@ -71,31 +61,16 @@ async fn revert(provider: &RootProvider, id: U256) {
     assert!(success, "evm_revert should return true");
 }
 
-async fn publish_simple_tx(manager: &SimpleTxManager<RootProvider>) -> (B256, SendState) {
-    let candidate = TxCandidate {
-        to: Some(Address::with_last_byte(0x42)),
-        value: U256::from(1_000u64),
-        gas_limit: 0,
-        ..Default::default()
-    };
-    let prepared = manager.craft_tx(&candidate, None).await.expect("should craft tx");
-    let send_state = SendState::new(3).expect("should create send state");
-    let tx_hash =
-        manager.publish_tx(&send_state, &prepared.raw_tx, None).await.expect("should publish tx");
-    (tx_hash, send_state)
-}
-
 async fn query(
     send_state: &SendState,
     manager: &SimpleTxManager<RootProvider>,
     tx_hash: B256,
-    confirmations: u64,
 ) -> Option<alloy_rpc_types_eth::TransactionReceipt> {
     SimpleTxManager::query_receipt(
         send_state,
         manager.provider(),
         tx_hash,
-        confirmations,
+        manager.config().num_confirmations,
         QUERY_TIMEOUT,
     )
     .await
@@ -110,26 +85,18 @@ async fn query_receipt_returns_none_after_reorg_removes_tx() {
     let config = TxManagerConfig { num_confirmations: 1, ..TxManagerConfig::default() };
     let (manager, _anvil) = setup_with_config(config).await;
 
-    // Snapshot before sending tx.
     let snap = snapshot(manager.provider()).await;
-
-    // Send tx, auto-mine includes it.
-    let (tx_hash, send_state) = publish_simple_tx(&manager).await;
-
-    // Mine extra block for confirmation depth.
+    let (tx_hash, send_state, _) = publish_simple_tx(&manager).await;
     mine_block(manager.provider()).await;
 
-    let receipt = query(&send_state, &manager, tx_hash, 1).await;
+    let receipt = query(&send_state, &manager, tx_hash).await;
     assert!(receipt.is_some(), "receipt should exist before reorg");
     assert!(send_state.is_waiting_for_confirmation());
 
-    // Revert to pre-tx snapshot (simulates reorg removing tx's block).
     revert(manager.provider(), snap).await;
-
-    // Mine a new empty block on the reorged chain.
     mine_block(manager.provider()).await;
 
-    let receipt = query(&send_state, &manager, tx_hash, 1).await;
+    let receipt = query(&send_state, &manager, tx_hash).await;
     assert!(receipt.is_none(), "receipt should be gone after reorg");
     assert!(
         !send_state.is_waiting_for_confirmation(),
@@ -145,22 +112,10 @@ async fn query_receipt_returns_receipt_after_reorg_reinclusion() {
     let anvil = alloy_node_bindings::Anvil::new().arg("--no-mining").spawn();
     let manager = manager_from_anvil(&anvil, config).await;
 
-    // Craft and publish tx (sits in mempool since automine is off).
-    let candidate = TxCandidate {
-        to: Some(Address::with_last_byte(0x42)),
-        value: U256::from(1_000u64),
-        gas_limit: 0,
-        ..Default::default()
-    };
-    let prepared = manager.craft_tx(&candidate, None).await.expect("should craft tx");
-    let send_state = SendState::new(3).expect("should create send state");
-    let tx_hash =
-        manager.publish_tx(&send_state, &prepared.raw_tx, None).await.expect("should publish tx");
+    // Tx sits in mempool since automine is off.
+    let (tx_hash, send_state, raw_tx) = publish_simple_tx(&manager).await;
 
-    // Snapshot while tx is in mempool.
     let snap = snapshot(manager.provider()).await;
-
-    // Mine block — tx gets included.
     mine_block(manager.provider()).await;
 
     let receipt = manager
@@ -171,20 +126,13 @@ async fn query_receipt_returns_receipt_after_reorg_reinclusion() {
         .expect("receipt should exist");
     let original_block_hash = receipt.block_hash.expect("should have block hash");
 
-    // Revert to snapshot — chain state back to pre-mine.
     revert(manager.provider(), snap).await;
 
-    // Re-submit the same raw tx (Anvil may not restore the mempool on revert).
-    let _ = manager
-        .provider()
-        .send_raw_transaction(&prepared.raw_tx)
-        .await
-        .expect("re-submit should succeed");
+    // Anvil may not restore the mempool on revert, so re-submit.
+    let _ =
+        manager.provider().send_raw_transaction(&raw_tx).await.expect("re-submit should succeed");
 
-    // Mine block again — tx re-included in a new block with different hash.
     mine_block(manager.provider()).await;
-
-    // Mine confirmation block.
     mine_block(manager.provider()).await;
 
     let new_receipt = manager
@@ -202,7 +150,7 @@ async fn query_receipt_returns_receipt_after_reorg_reinclusion() {
 
     // query_receipt validates the receipt's block hash against the canonical
     // chain. The re-included tx is on the canonical chain, so it should pass.
-    let result = query(&send_state, &manager, tx_hash, 1).await;
+    let result = query(&send_state, &manager, tx_hash).await;
     assert!(result.is_some(), "receipt should exist after reinclusion");
 }
 
@@ -214,18 +162,16 @@ async fn nonce_manager_recovers_correct_nonce_after_reorg() {
     let (manager, anvil) = setup_with_config(config).await;
     let address = anvil.addresses()[0];
 
-    // Snapshot before sending tx.
     let snap = snapshot(manager.provider()).await;
 
-    // Send tx (consumes nonce 0), auto-mine includes it.
-    publish_simple_tx(&manager).await;
+    // Consumes nonce 0.
+    let _ = publish_simple_tx(&manager).await;
     mine_block(manager.provider()).await;
 
     let chain_nonce =
         manager.provider().get_transaction_count(address).await.expect("should get tx count");
     assert_eq!(chain_nonce, 1, "chain nonce should be 1 after tx");
 
-    // Revert to pre-tx snapshot.
     revert(manager.provider(), snap).await;
     mine_block(manager.provider()).await;
 
@@ -233,10 +179,8 @@ async fn nonce_manager_recovers_correct_nonce_after_reorg() {
         manager.provider().get_transaction_count(address).await.expect("should get tx count");
     assert_eq!(chain_nonce, 0, "chain nonce should be 0 after reorg");
 
-    // Reset nonce manager to clear stale cache.
     manager.nonce_manager().reset().await;
 
-    // next_nonce should return 0 (correct chain nonce after reset).
     let guard = manager.nonce_manager().next_nonce().await.expect("should get nonce");
     assert_eq!(guard.nonce(), 0, "nonce should match chain state after reorg and reset");
 }
@@ -248,23 +192,18 @@ async fn reserved_nonce_high_water_mark_survives_reorg() {
     let config = TxManagerConfig::default();
     let (manager, _anvil) = setup_with_config(config).await;
 
-    // Snapshot before reserving nonces.
     let snap = snapshot(manager.provider()).await;
 
-    // Reserve nonces 0 and 1.
     let n0 = manager.nonce_manager().reserve_nonce().await.expect("should reserve nonce 0");
     let n1 = manager.nonce_manager().reserve_nonce().await.expect("should reserve nonce 1");
     assert_eq!(n0, 0);
     assert_eq!(n1, 1);
 
-    // Revert and mine an empty block.
     revert(manager.provider(), snap).await;
     mine_block(manager.provider()).await;
 
-    // Reset nonce manager to clear stale cache.
     manager.nonce_manager().reset().await;
 
-    // High-water mark (2) prevents reissue of nonces 0 and 1.
     let guard = manager.nonce_manager().next_nonce().await.expect("should get nonce");
     assert_eq!(guard.nonce(), 2, "high-water mark should prevent reissue of reserved nonces");
 }
@@ -276,31 +215,19 @@ async fn deep_reorg_past_confirmation_depth_removes_receipt() {
     let config = TxManagerConfig { num_confirmations: 3, ..TxManagerConfig::default() };
     let (manager, _anvil) = setup_with_config(config).await;
 
-    // Snapshot before sending tx.
     let snap = snapshot(manager.provider()).await;
 
-    // Send tx. Force-mine one block immediately to flush Anvil's auto-mine,
-    // which may not have committed the tx under CI load. After this call the
-    // tx is guaranteed to be in a block regardless of whether auto-mine fired
-    // synchronously or was deferred.
-    let (tx_hash, send_state) = publish_simple_tx(&manager).await;
-    mine_block(manager.provider()).await;
+    let (tx_hash, send_state, _) = publish_simple_tx(&manager).await;
+    // 4 blocks: 1 to flush auto-mine (may be deferred under CI load) + 3 confirmations.
+    mine_blocks(manager.provider(), 4).await;
 
-    // Mine 3 more blocks so the confirmation check has a 1-block margin.
-    // After the flush the tx is at block B; tip reaches B+3, so
-    // tx_block + 3 <= tip + 1 holds (B+3 <= B+4) for any value of B.
-    mine_blocks(manager.provider(), 3).await;
-
-    let receipt = query(&send_state, &manager, tx_hash, 3).await;
+    let receipt = query(&send_state, &manager, tx_hash).await;
     assert!(receipt.is_some(), "receipt should be fully confirmed before reorg");
 
-    // Revert to pre-tx snapshot (deep reorg past confirmation depth).
     revert(manager.provider(), snap).await;
-
-    // Mine new empty blocks.
     mine_blocks(manager.provider(), 3).await;
 
-    let receipt = query(&send_state, &manager, tx_hash, 3).await;
+    let receipt = query(&send_state, &manager, tx_hash).await;
     assert!(receipt.is_none(), "receipt should be gone after deep reorg");
     assert!(
         !send_state.is_waiting_for_confirmation(),
@@ -314,24 +241,18 @@ async fn shallow_reorg_preserves_deeply_confirmed_tx() {
     let config = TxManagerConfig { num_confirmations: 3, ..TxManagerConfig::default() };
     let (manager, _anvil) = setup_with_config(config).await;
 
-    // Send tx, auto-mine includes it.
-    let (tx_hash, send_state) = publish_simple_tx(&manager).await;
+    let (tx_hash, send_state, _) = publish_simple_tx(&manager).await;
 
-    // Mine 3 more blocks (tx is 4 blocks deep).
+    // Tx is 4 blocks deep after these mines.
     mine_blocks(manager.provider(), 3).await;
 
-    // Snapshot at this point.
+    // Snapshot here; the revert only removes the 2 blocks mined after it.
     let snap = snapshot(manager.provider()).await;
-
-    // Mine 2 more blocks.
     mine_blocks(manager.provider(), 2).await;
 
-    // Revert to snapshot (removes last 2 blocks, but tx's block survives).
     revert(manager.provider(), snap).await;
-
-    // Mine 2 replacement empty blocks.
     mine_blocks(manager.provider(), 2).await;
 
-    let receipt = query(&send_state, &manager, tx_hash, 3).await;
+    let receipt = query(&send_state, &manager, tx_hash).await;
     assert!(receipt.is_some(), "deeply confirmed tx should survive shallow reorg");
 }

--- a/crates/utilities/tx-manager/tests/send_lifecycle.rs
+++ b/crates/utilities/tx-manager/tests/send_lifecycle.rs
@@ -4,36 +4,23 @@
 //! [`SimpleTxManager::query_receipt`] — the methods that drive a transaction
 //! from publication through confirmation.
 
+mod common;
+
 use std::{
     sync::{Arc, atomic::AtomicBool},
     time::Duration,
 };
 
-use alloy_consensus::{SignableTransaction, Transaction};
-use alloy_network::{EthereumWallet, TxSigner};
-use alloy_node_bindings::Anvil;
-use alloy_primitives::{Address, B256, Signature, U256};
+use alloy_consensus::Transaction;
+use alloy_primitives::B256;
 use alloy_provider::{Provider, RootProvider};
-use alloy_signer_local::PrivateKeySigner;
-use async_trait::async_trait;
-use base_tx_manager::{
-    NoopTxMetrics, SendState, SimpleTxManager, TxCandidate, TxManager, TxManagerConfig,
-    TxManagerError,
+use base_tx_manager::{SendState, SimpleTxManager, TxManager, TxManagerConfig, TxManagerError};
+use common::{
+    SAFE_ABORT_DEPTH, mine_block, publish_simple_tx, setup_with_config, setup_with_failing_signer,
+    simple_tx_candidate,
 };
 use rstest::rstest;
 use tokio::sync::mpsc;
-
-/// Force-mine a block on Anvil so receipts are committed before queries.
-///
-/// Under CI load Anvil's auto-mine may not have flushed yet, causing
-/// `query_receipt` to see stale tip heights or missing receipts.
-async fn mine_block(manager: &SimpleTxManager<RootProvider>) {
-    manager
-        .provider()
-        .raw_request::<(), String>("evm_mine".into(), ())
-        .await
-        .expect("evm_mine should succeed");
-}
 
 /// Returns a config with fast polling suitable for tests.
 fn fast_polling_config() -> TxManagerConfig {
@@ -44,79 +31,30 @@ fn fast_polling_config() -> TxManagerConfig {
     }
 }
 
-/// Helper: spawns an Anvil instance and returns a [`SimpleTxManager`]
-/// configured with the given [`TxManagerConfig`].
-async fn setup_with_config(
-    config: TxManagerConfig,
-) -> (SimpleTxManager<RootProvider>, alloy_node_bindings::AnvilInstance) {
-    let anvil = Anvil::new().spawn();
-    let url = anvil.endpoint_url();
-    let provider = RootProvider::new_http(url);
-    let signer: PrivateKeySigner = anvil.keys()[0].clone().into();
-    let wallet = EthereumWallet::from(signer);
-    let chain_id = anvil.chain_id();
-    let manager =
-        SimpleTxManager::from_wallet(provider, wallet, config, chain_id, Arc::new(NoopTxMetrics))
-            .await
-            .expect("should create manager");
-    (manager, anvil)
-}
-
-/// Config optimized for fast test execution: single confirmation, fast
-/// receipt polling, and a long resubmission timeout to prevent fee bumps
-/// during the test.
+/// Config optimized for fast test execution: builds on
+/// [`fast_polling_config`] with a slower polling interval and a long
+/// resubmission timeout to prevent fee bumps during the test.
 fn fast_send_config() -> TxManagerConfig {
     TxManagerConfig {
-        num_confirmations: 1,
         receipt_query_interval: Duration::from_millis(100),
         resubmission_timeout: Duration::from_secs(60),
+        ..fast_polling_config()
+    }
+}
+
+/// Config that requires many confirmations so mining never satisfies it,
+/// useful for testing shutdown and timeout exit paths.
+fn unconfirmable_config() -> TxManagerConfig {
+    TxManagerConfig {
+        num_confirmations: 100,
+        receipt_query_interval: Duration::from_millis(50),
         ..TxManagerConfig::default()
     }
 }
 
-/// A signer that always fails so `send()` exits before any publish.
-struct FailingSigner {
-    address: Address,
-}
-
-#[async_trait]
-impl TxSigner<Signature> for FailingSigner {
-    fn address(&self) -> Address {
-        self.address
-    }
-
-    async fn sign_transaction(
-        &self,
-        _tx: &mut dyn SignableTransaction<Signature>,
-    ) -> alloy_signer::Result<Signature> {
-        Err(alloy_signer::Error::other("deliberately failing signer"))
-    }
-}
-
-async fn setup_with_failing_signer_config(
-    config: TxManagerConfig,
-) -> (SimpleTxManager<RootProvider>, alloy_node_bindings::AnvilInstance) {
-    let anvil = Anvil::new().spawn();
-    let url = anvil.endpoint_url();
-    let provider = RootProvider::new_http(url);
-    let address = anvil.addresses()[0];
-    let wallet = EthereumWallet::from(FailingSigner { address });
-    let chain_id = anvil.chain_id();
-    let manager =
-        SimpleTxManager::from_wallet(provider, wallet, config, chain_id, Arc::new(NoopTxMetrics))
-            .await
-            .expect("should create manager with failing signer");
-    (manager, anvil)
-}
-
 async fn assert_send_error_resets_nonce(config: TxManagerConfig) {
-    let (manager, _anvil) = setup_with_failing_signer_config(config).await;
-    let candidate = TxCandidate {
-        to: Some(Address::with_last_byte(0x42)),
-        value: U256::from(1u64),
-        gas_limit: 0,
-        ..Default::default()
-    };
+    let (manager, _anvil) = setup_with_failing_signer(config).await;
+    let candidate = simple_tx_candidate();
 
     let err = manager.send(candidate).await.expect_err("send should fail before publish");
     assert!(matches!(err, TxManagerError::Sign(_)), "expected sign error, got {err:?}");
@@ -133,17 +71,11 @@ async fn assert_send_error_resets_nonce(config: TxManagerConfig) {
 async fn send_confirms_simple_value_transfer() {
     let (manager, _anvil) = setup_with_config(fast_send_config()).await;
 
-    let candidate = TxCandidate {
-        to: Some(Address::with_last_byte(0x42)),
-        value: U256::from(1_000u64),
-        gas_limit: 0,
-        ..Default::default()
-    };
-
-    let receipt = tokio::time::timeout(Duration::from_secs(10), manager.send(candidate))
-        .await
-        .expect("send should complete within 10 s")
-        .expect("send should succeed");
+    let receipt =
+        tokio::time::timeout(Duration::from_secs(10), manager.send(simple_tx_candidate()))
+            .await
+            .expect("send should complete within 10 s")
+            .expect("send should succeed");
 
     assert!(receipt.block_number.is_some(), "receipt should have a block number");
     assert_ne!(receipt.transaction_hash, B256::ZERO, "tx hash should be non-zero");
@@ -155,14 +87,7 @@ async fn send_confirms_simple_value_transfer() {
 async fn send_async_confirms_simple_value_transfer() {
     let (manager, _anvil) = setup_with_config(fast_send_config()).await;
 
-    let candidate = TxCandidate {
-        to: Some(Address::with_last_byte(0x42)),
-        value: U256::from(1_000u64),
-        gas_limit: 0,
-        ..Default::default()
-    };
-
-    let handle = manager.send_async(candidate).await;
+    let handle = manager.send_async(simple_tx_candidate()).await;
 
     let receipt = tokio::time::timeout(Duration::from_secs(10), handle)
         .await
@@ -188,22 +113,10 @@ async fn send_resets_nonce_manager_on_pre_publish_failure(#[case] tx_send_timeou
 #[tokio::test]
 async fn publish_tx_success_returns_hash_and_records_publish() {
     let (manager, _anvil) = setup_with_config(TxManagerConfig::default()).await;
-
-    let candidate = TxCandidate {
-        to: Some(Address::with_last_byte(0x42)),
-        value: U256::from(1_000u64),
-        gas_limit: 0,
-        ..Default::default()
-    };
-
-    let prepared = manager.craft_tx(&candidate, None).await.expect("should craft tx");
-    let send_state = SendState::new(3).expect("should create send state");
-
-    let tx_hash =
-        manager.publish_tx(&send_state, &prepared.raw_tx, None).await.expect("should publish tx");
+    let (tx_hash, send_state, _) = publish_simple_tx(&manager).await;
 
     assert_ne!(tx_hash, B256::ZERO, "published tx hash should be non-zero");
-    assert_eq!(send_state.successful_publish_count(), 1, "should record one successful publish");
+    assert!(send_state.has_published(), "should record a successful publish");
 }
 
 // ── query_receipt() ───────────────────────────────────────────────────
@@ -214,7 +127,7 @@ async fn publish_tx_success_returns_hash_and_records_publish() {
 async fn query_receipt_returns_none_for_unknown_tx() {
     let (manager, _anvil) = setup_with_config(TxManagerConfig::default()).await;
 
-    let send_state = SendState::new(3).expect("should create send state");
+    let send_state = SendState::new(SAFE_ABORT_DEPTH).expect("should create send state");
     let fake_hash = B256::with_last_byte(0xFF);
 
     let result = SimpleTxManager::query_receipt(
@@ -239,27 +152,12 @@ async fn query_receipt_returns_none_for_unknown_tx() {
 #[tokio::test]
 async fn query_receipt_returns_confirmed_receipt() {
     let (manager, _anvil) = setup_with_config(TxManagerConfig::default()).await;
-
-    let candidate = TxCandidate {
-        to: Some(Address::with_last_byte(0x42)),
-        value: U256::from(1_000u64),
-        gas_limit: 0,
-        ..Default::default()
-    };
-
-    // Craft, publish, and let Anvil auto-mine.
-    let prepared = manager.craft_tx(&candidate, None).await.expect("should craft tx");
-    let send_state = SendState::new(3).expect("should create send state");
-    let tx_hash =
-        manager.publish_tx(&send_state, &prepared.raw_tx, None).await.expect("should publish tx");
+    let (tx_hash, send_state, _) = publish_simple_tx(&manager).await;
 
     // Mine an extra block so tip_height is strictly ahead of the tx block.
-    // query_receipt fetches tip_height and receipt in parallel, so under CI
-    // load the tip may be stale on a single-call test.
-    mine_block(&manager).await;
+    // Under CI load, query_receipt may see a stale tip on a single-block test.
+    mine_block(manager.provider()).await;
 
-    // With num_confirmations = 1 and the extra block mined above,
-    // the formula tx_block + 1 <= tip + 1 is satisfied.
     let result = SimpleTxManager::query_receipt(
         &send_state,
         manager.provider(),
@@ -273,7 +171,6 @@ async fn query_receipt_returns_confirmed_receipt() {
     let receipt = result.expect("should return a receipt for a mined tx");
     assert_eq!(receipt.transaction_hash, tx_hash, "receipt hash should match");
     assert!(receipt.block_number.is_some(), "receipt should have a block number");
-    // tx_mined should have been called.
     assert!(send_state.is_waiting_for_confirmation(), "tx should be tracked as mined",);
 }
 
@@ -283,22 +180,10 @@ async fn query_receipt_returns_confirmed_receipt() {
 #[tokio::test]
 async fn query_receipt_returns_none_when_not_enough_confirmations() {
     let (manager, _anvil) = setup_with_config(TxManagerConfig::default()).await;
+    let (tx_hash, send_state, _) = publish_simple_tx(&manager).await;
 
-    let candidate = TxCandidate {
-        to: Some(Address::with_last_byte(0x42)),
-        value: U256::from(1_000u64),
-        gas_limit: 0,
-        ..Default::default()
-    };
-
-    let prepared = manager.craft_tx(&candidate, None).await.expect("should craft tx");
-    let send_state = SendState::new(3).expect("should create send state");
-    let tx_hash =
-        manager.publish_tx(&send_state, &prepared.raw_tx, None).await.expect("should publish tx");
-
-    // Mine an extra block so the receipt is available before we query.
     // Under CI load Anvil's auto-mine may not have committed yet.
-    mine_block(&manager).await;
+    mine_block(manager.provider()).await;
 
     // Require 100 confirmations — far more than the single block Anvil
     // has mined. The receipt exists but is not sufficiently confirmed.
@@ -313,7 +198,6 @@ async fn query_receipt_returns_none_when_not_enough_confirmations() {
     .expect("query should not error");
 
     assert!(result.is_none(), "should return None when not enough confirmations");
-    // The tx should still be tracked as mined even though not yet confirmed.
     assert!(
         send_state.is_waiting_for_confirmation(),
         "tx should be tracked as mined despite insufficient confirmations",
@@ -322,32 +206,21 @@ async fn query_receipt_returns_none_when_not_enough_confirmations() {
 
 // ── wait_mined() ──────────────────────────────────────────────────────
 
-/// Helper: publishes a simple value-transfer tx and returns the hash.
-async fn publish_simple_tx(manager: &SimpleTxManager<RootProvider>) -> (B256, SendState) {
-    let candidate = TxCandidate {
-        to: Some(Address::with_last_byte(0x42)),
-        value: U256::from(1_000u64),
-        gas_limit: 0,
-        ..Default::default()
-    };
-    let prepared = manager.craft_tx(&candidate, None).await.expect("should craft tx");
-    let send_state = SendState::new(3).expect("should create send state");
-    let tx_hash =
-        manager.publish_tx(&send_state, &prepared.raw_tx, None).await.expect("should publish tx");
-    (tx_hash, send_state)
-}
-
 /// `wait_mined` returns a confirmed receipt for a mined transaction.
 #[tokio::test]
 async fn wait_mined_returns_confirmed_receipt() {
-    let config = fast_polling_config();
-    let (manager, _anvil) = setup_with_config(config.clone()).await;
-    let (tx_hash, send_state) = publish_simple_tx(&manager).await;
+    let (manager, _anvil) = setup_with_config(fast_polling_config()).await;
+    let (tx_hash, send_state, _) = publish_simple_tx(&manager).await;
     let closed = AtomicBool::new(false);
 
-    let receipt =
-        SimpleTxManager::wait_mined(&send_state, manager.provider(), tx_hash, &config, &closed)
-            .await;
+    let receipt = SimpleTxManager::wait_mined(
+        &send_state,
+        manager.provider(),
+        tx_hash,
+        manager.config(),
+        &closed,
+    )
+    .await;
 
     let receipt = receipt.expect("should return a receipt");
     assert_eq!(receipt.transaction_hash, tx_hash, "receipt hash should match");
@@ -356,18 +229,18 @@ async fn wait_mined_returns_confirmed_receipt() {
 /// `wait_mined` returns `None` when the manager is shut down.
 #[tokio::test]
 async fn wait_mined_returns_none_on_shutdown() {
-    let config = TxManagerConfig {
-        num_confirmations: 100,
-        receipt_query_interval: Duration::from_millis(50),
-        ..TxManagerConfig::default()
-    };
-    let (manager, _anvil) = setup_with_config(config.clone()).await;
-    let (tx_hash, send_state) = publish_simple_tx(&manager).await;
+    let (manager, _anvil) = setup_with_config(unconfirmable_config()).await;
+    let (tx_hash, send_state, _) = publish_simple_tx(&manager).await;
     let closed = AtomicBool::new(true);
 
-    let receipt =
-        SimpleTxManager::wait_mined(&send_state, manager.provider(), tx_hash, &config, &closed)
-            .await;
+    let receipt = SimpleTxManager::wait_mined(
+        &send_state,
+        manager.provider(),
+        tx_hash,
+        manager.config(),
+        &closed,
+    )
+    .await;
 
     assert!(receipt.is_none(), "should return None when closed");
 }
@@ -376,18 +249,21 @@ async fn wait_mined_returns_none_on_shutdown() {
 #[tokio::test]
 async fn wait_mined_returns_none_on_timeout() {
     let config = TxManagerConfig {
-        num_confirmations: 100,
-        receipt_query_interval: Duration::from_millis(50),
         confirmation_timeout: Duration::from_millis(200),
-        ..TxManagerConfig::default()
+        ..unconfirmable_config()
     };
-    let (manager, _anvil) = setup_with_config(config.clone()).await;
-    let (tx_hash, send_state) = publish_simple_tx(&manager).await;
+    let (manager, _anvil) = setup_with_config(config).await;
+    let (tx_hash, send_state, _) = publish_simple_tx(&manager).await;
     let closed = AtomicBool::new(false);
 
-    let receipt =
-        SimpleTxManager::wait_mined(&send_state, manager.provider(), tx_hash, &config, &closed)
-            .await;
+    let receipt = SimpleTxManager::wait_mined(
+        &send_state,
+        manager.provider(),
+        tx_hash,
+        manager.config(),
+        &closed,
+    )
+    .await;
 
     assert!(receipt.is_none(), "should return None when timeout exceeded");
 }
@@ -397,9 +273,8 @@ async fn wait_mined_returns_none_on_timeout() {
 /// `wait_for_tx` delivers a receipt through the mpsc channel.
 #[tokio::test]
 async fn wait_for_tx_delivers_receipt() {
-    let config = fast_polling_config();
-    let (manager, _anvil) = setup_with_config(config.clone()).await;
-    let (tx_hash, send_state) = publish_simple_tx(&manager).await;
+    let (manager, _anvil) = setup_with_config(fast_polling_config()).await;
+    let (tx_hash, send_state, _) = publish_simple_tx(&manager).await;
     let closed = Arc::new(AtomicBool::new(false));
     let (receipt_tx, mut receipt_rx) = mpsc::channel(1);
 
@@ -407,7 +282,7 @@ async fn wait_for_tx_delivers_receipt() {
         Arc::new(send_state),
         manager.provider().clone(),
         tx_hash,
-        config,
+        manager.config().clone(),
         receipt_tx,
         closed,
     );
@@ -422,13 +297,8 @@ async fn wait_for_tx_delivers_receipt() {
 /// `wait_for_tx` closes the channel when the manager shuts down.
 #[tokio::test]
 async fn wait_for_tx_closes_channel_on_shutdown() {
-    let config = TxManagerConfig {
-        num_confirmations: 100,
-        receipt_query_interval: Duration::from_millis(50),
-        ..TxManagerConfig::default()
-    };
-    let (manager, _anvil) = setup_with_config(config.clone()).await;
-    let (tx_hash, send_state) = publish_simple_tx(&manager).await;
+    let (manager, _anvil) = setup_with_config(unconfirmable_config()).await;
+    let (tx_hash, send_state, _) = publish_simple_tx(&manager).await;
     let closed = Arc::new(AtomicBool::new(true));
     let (receipt_tx, mut receipt_rx) = mpsc::channel(1);
 
@@ -436,7 +306,7 @@ async fn wait_for_tx_closes_channel_on_shutdown() {
         Arc::new(send_state),
         manager.provider().clone(),
         tx_hash,
-        config,
+        manager.config().clone(),
         receipt_tx,
         closed,
     );
@@ -451,9 +321,8 @@ async fn wait_for_tx_closes_channel_on_shutdown() {
 /// dropped before the task delivers a receipt.
 #[tokio::test]
 async fn wait_for_tx_does_not_panic_on_dropped_receiver() {
-    let config = fast_polling_config();
-    let (manager, _anvil) = setup_with_config(config.clone()).await;
-    let (tx_hash, send_state) = publish_simple_tx(&manager).await;
+    let (manager, _anvil) = setup_with_config(fast_polling_config()).await;
+    let (tx_hash, send_state, _) = publish_simple_tx(&manager).await;
     let closed = Arc::new(AtomicBool::new(false));
     let (receipt_tx, receipt_rx) = mpsc::channel(1);
 
@@ -461,15 +330,13 @@ async fn wait_for_tx_does_not_panic_on_dropped_receiver() {
         Arc::new(send_state),
         manager.provider().clone(),
         tx_hash,
-        config,
+        manager.config().clone(),
         receipt_tx,
         closed,
     );
 
-    // Drop receiver immediately — task should exit cleanly.
     drop(receipt_rx);
 
-    // Await the handle to confirm the task exits without panic.
     tokio::time::timeout(Duration::from_secs(5), handle)
         .await
         .expect("task should not time out")
@@ -484,7 +351,7 @@ async fn query_receipt_returns_error_on_unreachable_provider() {
     // Port 1 is never listening — connection refused is immediate and deterministic.
     let provider = RootProvider::new_http("http://127.0.0.1:1".parse().expect("valid url"));
 
-    let send_state = SendState::new(3).expect("should create send state");
+    let send_state = SendState::new(SAFE_ABORT_DEPTH).expect("should create send state");
     let fake_hash = B256::with_last_byte(0xFF);
 
     let result = SimpleTxManager::query_receipt(
@@ -510,19 +377,10 @@ async fn send_async_preserves_call_order_nonces() {
     let count = 5;
     let mut handles = Vec::with_capacity(count);
 
-    // Call send_async sequentially — each call pre-reserves a nonce before
-    // spawning, so the nonce assignment matches call order.
     for _ in 0..count {
-        let candidate = TxCandidate {
-            to: Some(Address::with_last_byte(0x42)),
-            value: U256::from(1u64),
-            gas_limit: 0,
-            ..Default::default()
-        };
-        handles.push(manager.send_async(candidate).await);
+        handles.push(manager.send_async(simple_tx_candidate()).await);
     }
 
-    // Collect receipts (order may differ from send order).
     let mut nonces: Vec<u64> = Vec::with_capacity(count);
     for handle in handles {
         let receipt = tokio::time::timeout(Duration::from_secs(30), handle)
@@ -539,8 +397,6 @@ async fn send_async_preserves_call_order_nonces() {
         nonces.push(tx.inner.nonce());
     }
 
-    // Nonces should form a contiguous, monotonically increasing sequence
-    // starting from 0.
     let expected: Vec<u64> = (0..count as u64).collect();
     assert_eq!(nonces, expected, "send_async nonces should match call order");
 }
@@ -549,16 +405,9 @@ async fn send_async_preserves_call_order_nonces() {
 /// pre-reserved nonce is returned for reuse by subsequent calls.
 #[tokio::test]
 async fn send_async_failure_returns_nonce_for_reuse() {
-    let (manager, _anvil) = setup_with_failing_signer_config(fast_send_config()).await;
-    let candidate = TxCandidate {
-        to: Some(Address::with_last_byte(0x42)),
-        value: U256::from(1u64),
-        gas_limit: 0,
-        ..Default::default()
-    };
+    let (manager, _anvil) = setup_with_failing_signer(fast_send_config()).await;
 
-    // send_async reserves nonce 0, spawned task fails at signing.
-    let handle = manager.send_async(candidate).await;
+    let handle = manager.send_async(simple_tx_candidate()).await;
     let err = tokio::time::timeout(Duration::from_secs(30), handle)
         .await
         .expect("send_async should complete")
@@ -566,7 +415,6 @@ async fn send_async_failure_returns_nonce_for_reuse() {
 
     assert!(matches!(err, TxManagerError::Sign(_)), "expected sign error, got {err:?}");
 
-    // The nonce should have been returned. Next nonce should be 0, not 1.
     let guard = manager.nonce_manager().next_nonce().await.expect("should get nonce");
     assert_eq!(guard.nonce(), 0, "returned nonce should be reused after send_async failure");
 }

--- a/crates/utilities/tx-manager/tests/signer_prefix.rs
+++ b/crates/utilities/tx-manager/tests/signer_prefix.rs
@@ -4,6 +4,10 @@ use clap::{CommandFactory, Parser};
 
 base_tx_manager::define_signer_cli!("TEST_SIGNER");
 
+const TEST_KEY: &str = "ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80";
+const TEST_ADDRESS: &str = "0x1234567890123456789012345678901234567890";
+const TEST_ENDPOINT: &str = "http://localhost:8546";
+
 #[derive(Parser)]
 struct TestCli {
     #[command(flatten)]
@@ -13,7 +17,6 @@ struct TestCli {
 #[test]
 fn env_vars_use_custom_prefix() {
     let cmd = TestCli::command();
-    let args: Vec<_> = cmd.get_arguments().collect();
 
     let cases = [
         ("private-key", "TEST_SIGNER_PRIVATE_KEY"),
@@ -22,8 +25,8 @@ fn env_vars_use_custom_prefix() {
     ];
 
     for (long_name, expected_env) in cases {
-        let arg = args
-            .iter()
+        let arg = cmd
+            .get_arguments()
             .find(|a| a.get_long() == Some(long_name))
             .unwrap_or_else(|| panic!("{long_name} arg should exist"));
         assert_eq!(
@@ -35,29 +38,13 @@ fn env_vars_use_custom_prefix() {
 }
 
 #[test]
-fn local_signer_with_0x_prefix() {
-    let cli = TestCli::try_parse_from([
-        "test",
-        "--private-key",
-        "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80",
-    ])
-    .unwrap();
-
-    let config = base_tx_manager::SignerConfig::try_from(cli.signer).unwrap();
-    assert!(matches!(config, base_tx_manager::SignerConfig::Local { .. }));
-}
-
-#[test]
-fn local_signer_without_0x_prefix() {
-    let cli = TestCli::try_parse_from([
-        "test",
-        "--private-key",
-        "ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80",
-    ])
-    .unwrap();
-
-    let config = base_tx_manager::SignerConfig::try_from(cli.signer).unwrap();
-    assert!(matches!(config, base_tx_manager::SignerConfig::Local { .. }));
+fn local_signer_accepts_key_with_and_without_0x() {
+    let prefixed = format!("0x{TEST_KEY}");
+    for key in [prefixed.as_str(), TEST_KEY] {
+        let cli = TestCli::try_parse_from(["test", "--private-key", key]).unwrap();
+        let config = base_tx_manager::SignerConfig::try_from(cli.signer).unwrap();
+        assert!(matches!(config, base_tx_manager::SignerConfig::Local(..)));
+    }
 }
 
 #[test]
@@ -65,9 +52,9 @@ fn remote_signer() {
     let cli = TestCli::try_parse_from([
         "test",
         "--signer-endpoint",
-        "http://localhost:8546",
+        TEST_ENDPOINT,
         "--signer-address",
-        "0x1234567890123456789012345678901234567890",
+        TEST_ADDRESS,
     ])
     .unwrap();
 
@@ -78,13 +65,8 @@ fn remote_signer() {
 #[test]
 fn no_signer_returns_error() {
     let cli = TestCli::try_parse_from(["test"]).unwrap();
-    let result = base_tx_manager::SignerConfig::try_from(cli.signer);
-    assert!(result.is_err());
-    let err = result.unwrap_err();
-    assert!(
-        err.to_string().contains("must be provided"),
-        "error should mention 'must be provided', got: {err}"
-    );
+    let err = base_tx_manager::SignerConfig::try_from(cli.signer).unwrap_err();
+    assert!(matches!(err, base_tx_manager::ConfigError::InvalidValue { field: "signer", .. }));
 }
 
 #[test]
@@ -92,30 +74,35 @@ fn conflicting_args_rejected_by_clap() {
     let result = TestCli::try_parse_from([
         "test",
         "--private-key",
-        "ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80",
+        TEST_KEY,
         "--signer-endpoint",
-        "http://localhost:8546",
+        TEST_ENDPOINT,
         "--signer-address",
-        "0x1234567890123456789012345678901234567890",
+        TEST_ADDRESS,
     ]);
     assert!(result.is_err(), "clap should reject conflicting args");
 }
 
 #[test]
 fn endpoint_without_address_rejected_by_clap() {
-    let result = TestCli::try_parse_from(["test", "--signer-endpoint", "http://localhost:8546"]);
+    let result = TestCli::try_parse_from(["test", "--signer-endpoint", TEST_ENDPOINT]);
     assert!(result.is_err(), "clap should reject endpoint without address");
+}
+
+#[test]
+fn address_without_endpoint_rejected_by_clap() {
+    let result = TestCli::try_parse_from(["test", "--signer-address", TEST_ADDRESS]);
+    assert!(result.is_err(), "clap should reject address without endpoint");
 }
 
 #[test]
 fn invalid_hex_returns_config_error() {
     let cli = TestCli::try_parse_from(["test", "--private-key", "not-a-hex-string"]).unwrap();
     let result = base_tx_manager::SignerConfig::try_from(cli.signer);
-    assert!(result.is_err());
     assert!(matches!(
         result.unwrap_err(),
         base_tx_manager::ConfigError::InvalidValue { field: "private-key", .. }
-    ),);
+    ));
 }
 
 #[test]
@@ -125,26 +112,20 @@ fn endpoint_without_host_returns_config_error() {
         "--signer-endpoint",
         "file:///some/path",
         "--signer-address",
-        "0x1234567890123456789012345678901234567890",
+        TEST_ADDRESS,
     ])
     .unwrap();
 
     let result = base_tx_manager::SignerConfig::try_from(cli.signer);
-    assert!(result.is_err());
     assert!(matches!(
         result.unwrap_err(),
         base_tx_manager::ConfigError::InvalidValue { field: "signer-endpoint", .. }
-    ),);
+    ));
 }
 
 #[test]
 fn debug_redacts_private_key() {
-    let cli = TestCli::try_parse_from([
-        "test",
-        "--private-key",
-        "ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80",
-    ])
-    .unwrap();
+    let cli = TestCli::try_parse_from(["test", "--private-key", TEST_KEY]).unwrap();
 
     let debug_output = format!("{:?}", cli.signer);
     assert!(
@@ -152,7 +133,7 @@ fn debug_redacts_private_key() {
         "debug output should contain [REDACTED], got: {debug_output}"
     );
     assert!(
-        !debug_output.contains("ac0974bec"),
+        !debug_output.contains(TEST_KEY),
         "debug output should not contain the key, got: {debug_output}"
     );
 }

--- a/deny.toml
+++ b/deny.toml
@@ -93,6 +93,7 @@ skip = [
     # System/platform crates
     "socket2",
     "bitflags",
+    "redox_syscall",
     "redox_users",
 
     # Network crates


### PR DESCRIPTION
## Summary

General cleanup and simplification of `base-tx-manager`. No behavioral changes.

- Simplify `BlobTxBuilder` to a unit struct with a static `build_sidecar(&[Box<Blob>])` method, removing instance state and `Arc` ownership transfer
- Change `TxCandidate.blobs` from `Arc<Vec<Box<Blob>>>` to `Arc<[Box<Blob>]>` and add `TxCandidate::is_blob()` convenience method
- Consolidate fee limit checks into `SimpleTxManager::check_fee_limits()`, reducing duplicated gas + blob ceiling logic in `craft_tx` and `increase_gas_price`
- Flatten `FeeCalculator::update_fees` from a 4-arm match into two sequential decisions (same logic, less branching)
- Replace repetitive config validation with `reject_zero!` / `reject_zero_duration!` macros
- Move gwei-to-wei parsing from `TryFrom<TxManagerCli>` into clap `value_parser` via `GweiParser::parse_value`, so CLI fields are stored as `u128` wei directly
- Simplify `SendState`: `successful_publish_count` (u64) → `has_published` (bool), merge `should_bump_fees()`/`clear_bump_fees()` into `take_bump_fees()`, use `Vec` instead of `HashSet` for mined txs
- Add `BumpedFees::to_fee_override()` to consolidate fee override construction after bumps
- Derive `Copy` on `GasPriceCaps`, make `base_fee_from_caps` and `SendState::new` `const fn`
- Make `RevertDisplay` public and re-export from `lib.rs`
- Use `to_ascii_lowercase()` in RPC error classification, simplifying the "execution reverted" reason extraction
- Deduplicate integration tests: extract shared helpers (`setup_anvil`, `mine_block`, `value_transfer`, `FailingSigner`, etc.) into `tests/common/mod.rs`
- Rewrite README with categorized sections, shorter descriptions, and updated code examples