### PR TITLE
chore(consensus): Cleanup RPC Methods

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3566,6 +3566,7 @@ dependencies = [
  "ipnet",
  "jsonrpsee",
  "libp2p",
+ "rstest",
  "serde",
  "serde_json",
  "thiserror 2.0.18",

--- a/crates/batcher/service/src/safe_head_poller.rs
+++ b/crates/batcher/service/src/safe_head_poller.rs
@@ -9,7 +9,7 @@ use tracing::warn;
 /// Fetches the current safe L2 head block number from the rollup node.
 ///
 /// The canonical implementation delegates to
-/// [`RollupNodeApiClient::op_sync_status`](base_consensus_rpc::RollupNodeApiClient).
+/// [`RollupNodeApiClient::sync_status`](base_consensus_rpc::RollupNodeApiClient).
 pub trait SafeHeadProvider: Send + Sync + 'static {
     /// Return the current safe L2 head block number.
     fn safe_l2_number(
@@ -20,7 +20,7 @@ pub trait SafeHeadProvider: Send + Sync + 'static {
 impl SafeHeadProvider for jsonrpsee::http_client::HttpClient {
     async fn safe_l2_number(&self) -> Result<u64, Box<dyn std::error::Error + Send + Sync>> {
         use base_consensus_rpc::RollupNodeApiClient;
-        let status = self.op_sync_status().await?;
+        let status = self.sync_status().await?;
         Ok(status.safe_l2.block_info.number)
     }
 }

--- a/crates/batcher/service/src/service.rs
+++ b/crates/batcher/service/src/service.rs
@@ -297,7 +297,7 @@ impl BatcherService {
         info!(rollup_rpc = %self.config.rollup_rpc_url, "fetching rollup config");
         let rollup_config = Arc::new(
             rollup_client
-                .op_rollup_config()
+                .rollup_config()
                 .await
                 .map_err(|e| eyre::eyre!("optimism_rollupConfig RPC failed: {e}"))?,
         );
@@ -308,7 +308,7 @@ impl BatcherService {
 
         // Fetch sync status to determine the safe L2 head for startup backfill.
         let sync_status = rollup_client
-            .op_sync_status()
+            .sync_status()
             .await
             .map_err(|e| eyre::eyre!("optimism_syncStatus RPC failed: {e}"))?;
         let safe_l2_number = sync_status.safe_l2.block_info.number;

--- a/crates/consensus/rpc/Cargo.toml
+++ b/crates/consensus/rpc/Cargo.toml
@@ -41,6 +41,7 @@ getrandom = { workspace = true, features = ["wasm_js"] }
 jsonrpsee = { workspace = true, features = ["macros", "server"] }
 
 [dev-dependencies]
+rstest.workspace = true
 serde_json = { workspace = true, features = ["std"] }
 
 [features]

--- a/crates/consensus/rpc/README.md
+++ b/crates/consensus/rpc/README.md
@@ -43,7 +43,7 @@ struct MyRpcHandler;
 
 #[async_trait::async_trait]
 impl SyncStatusApiServer for MyRpcHandler {
-    async fn op_sync_status(&self) -> RpcResult<SyncStatus> {
+    async fn sync_status(&self) -> RpcResult<SyncStatus> {
         // Return current sync status
         Ok(SyncStatus::default())
     }
@@ -66,7 +66,7 @@ use jsonrpsee::http_client::HttpClientBuilder;
 let client = HttpClientBuilder::default()
     .build("http://localhost:8545")?;
 
-let status = client.op_sync_status().await?;
+let status = client.sync_status().await?;
 ```
 
 ## License

--- a/crates/consensus/rpc/src/jsonrpsee.rs
+++ b/crates/consensus/rpc/src/jsonrpsee.rs
@@ -28,27 +28,26 @@ use crate::{OutputResponse, health::HealthzResponse};
 pub trait RollupNodeApi {
     /// Get the output root at a specific block.
     #[method(name = "outputAtBlock")]
-    async fn op_output_at_block(&self, block_number: BlockNumberOrTag)
-    -> RpcResult<OutputResponse>;
+    async fn output_at_block(&self, block_number: BlockNumberOrTag) -> RpcResult<OutputResponse>;
 
     /// Gets the safe head at an L1 block height.
     #[method(name = "safeHeadAtL1Block")]
-    async fn op_safe_head_at_l1_block(
+    async fn safe_head_at_l1_block(
         &self,
         block_number: BlockNumberOrTag,
     ) -> RpcResult<SafeHeadResponse>;
 
     /// Get the synchronization status.
     #[method(name = "syncStatus")]
-    async fn op_sync_status(&self) -> RpcResult<SyncStatus>;
+    async fn sync_status(&self) -> RpcResult<SyncStatus>;
 
     /// Get the rollup configuration parameters.
     #[method(name = "rollupConfig")]
-    async fn op_rollup_config(&self) -> RpcResult<RollupConfig>;
+    async fn rollup_config(&self) -> RpcResult<RollupConfig>;
 
     /// Get the software version.
     #[method(name = "version")]
-    async fn op_version(&self) -> RpcResult<String>;
+    async fn version(&self) -> RpcResult<String>;
 }
 
 /// The opp2p namespace handles peer interactions.
@@ -251,4 +250,353 @@ pub trait ConductorApi {
         server_id: String,
         raft_addr: String,
     ) -> RpcResult<()>;
+}
+
+#[cfg(test)]
+mod tests {
+    use core::net::IpAddr;
+
+    use alloy_eips::BlockNumberOrTag;
+    use alloy_primitives::B256;
+    use async_trait::async_trait;
+    use base_common_rpc_types_engine::BaseExecutionPayloadEnvelope;
+    use base_consensus_genesis::RollupConfig;
+    use base_consensus_gossip::{PeerCount, PeerDump, PeerInfo, PeerStats};
+    use base_consensus_safedb::SafeHeadResponse;
+    use base_protocol::SyncStatus;
+    use ipnet::IpNet;
+    use jsonrpsee::{
+        PendingSubscriptionSink,
+        core::{RpcResult, SubscriptionResult},
+    };
+    use rstest::rstest;
+
+    use super::{
+        AdminApiServer, BaseP2PApiServer, ConductorApiServer, DevEngineApiServer, HealthzApiServer,
+        RollupNodeApiServer, WsServer,
+    };
+    use crate::{OutputResponse, health::HealthzResponse};
+
+    struct StubRollupNodeApi;
+
+    #[async_trait]
+    impl RollupNodeApiServer for StubRollupNodeApi {
+        async fn output_at_block(&self, _: BlockNumberOrTag) -> RpcResult<OutputResponse> {
+            unimplemented!()
+        }
+
+        async fn safe_head_at_l1_block(&self, _: BlockNumberOrTag) -> RpcResult<SafeHeadResponse> {
+            unimplemented!()
+        }
+
+        async fn sync_status(&self) -> RpcResult<SyncStatus> {
+            unimplemented!()
+        }
+
+        async fn rollup_config(&self) -> RpcResult<RollupConfig> {
+            unimplemented!()
+        }
+
+        async fn version(&self) -> RpcResult<String> {
+            unimplemented!()
+        }
+    }
+
+    #[rstest]
+    #[case("optimism_outputAtBlock")]
+    #[case("optimism_safeHeadAtL1Block")]
+    #[case("optimism_syncStatus")]
+    #[case("optimism_rollupConfig")]
+    #[case("optimism_version")]
+    fn rollup_node_api_wire_names(#[case] expected: &str) {
+        let module = StubRollupNodeApi.into_rpc();
+        let names: Vec<&str> = module.method_names().collect();
+        assert!(names.contains(&expected), "missing method {expected}, got: {names:?}");
+    }
+
+    struct StubBaseP2PApi;
+
+    #[async_trait]
+    impl BaseP2PApiServer for StubBaseP2PApi {
+        async fn opp2p_self(&self) -> RpcResult<PeerInfo> {
+            unimplemented!()
+        }
+
+        async fn opp2p_peer_count(&self) -> RpcResult<PeerCount> {
+            unimplemented!()
+        }
+
+        async fn opp2p_peers(&self, _: bool) -> RpcResult<PeerDump> {
+            unimplemented!()
+        }
+
+        async fn opp2p_peer_stats(&self) -> RpcResult<PeerStats> {
+            unimplemented!()
+        }
+
+        async fn opp2p_discovery_table(&self) -> RpcResult<Vec<String>> {
+            unimplemented!()
+        }
+
+        async fn opp2p_block_peer(&self, _: String) -> RpcResult<()> {
+            unimplemented!()
+        }
+
+        async fn opp2p_unblock_peer(&self, _: String) -> RpcResult<()> {
+            unimplemented!()
+        }
+
+        async fn opp2p_list_blocked_peers(&self) -> RpcResult<Vec<String>> {
+            unimplemented!()
+        }
+
+        async fn opp2p_block_addr(&self, _: IpAddr) -> RpcResult<()> {
+            unimplemented!()
+        }
+
+        async fn opp2p_unblock_addr(&self, _: IpAddr) -> RpcResult<()> {
+            unimplemented!()
+        }
+
+        async fn opp2p_list_blocked_addrs(&self) -> RpcResult<Vec<IpAddr>> {
+            unimplemented!()
+        }
+
+        async fn opp2p_block_subnet(&self, _: IpNet) -> RpcResult<()> {
+            unimplemented!()
+        }
+
+        async fn opp2p_unblock_subnet(&self, _: IpNet) -> RpcResult<()> {
+            unimplemented!()
+        }
+
+        async fn opp2p_list_blocked_subnets(&self) -> RpcResult<Vec<IpNet>> {
+            unimplemented!()
+        }
+
+        async fn opp2p_protect_peer(&self, _: String) -> RpcResult<()> {
+            unimplemented!()
+        }
+
+        async fn opp2p_unprotect_peer(&self, _: String) -> RpcResult<()> {
+            unimplemented!()
+        }
+
+        async fn opp2p_connect_peer(&self, _: String) -> RpcResult<()> {
+            unimplemented!()
+        }
+
+        async fn opp2p_disconnect_peer(&self, _: String) -> RpcResult<()> {
+            unimplemented!()
+        }
+    }
+
+    #[rstest]
+    #[case("opp2p_self")]
+    #[case("opp2p_peerCount")]
+    #[case("opp2p_peers")]
+    #[case("opp2p_peerStats")]
+    #[case("opp2p_discoveryTable")]
+    #[case("opp2p_blockPeer")]
+    #[case("opp2p_unblockPeer")]
+    #[case("opp2p_listBlockedPeers")]
+    #[case("opp2p_blockAddr")]
+    #[case("opp2p_unblockAddr")]
+    #[case("opp2p_listBlockedAddrs")]
+    #[case("opp2p_blockSubnet")]
+    #[case("opp2p_unblockSubnet")]
+    #[case("opp2p_listBlockedSubnets")]
+    #[case("opp2p_protectPeer")]
+    #[case("opp2p_unprotectPeer")]
+    #[case("opp2p_connectPeer")]
+    #[case("opp2p_disconnectPeer")]
+    fn p2p_api_wire_names(#[case] expected: &str) {
+        let module = StubBaseP2PApi.into_rpc();
+        let names: Vec<&str> = module.method_names().collect();
+        assert!(names.contains(&expected), "missing method {expected}, got: {names:?}");
+    }
+
+    struct StubWs;
+
+    #[async_trait]
+    impl WsServer for StubWs {
+        async fn ws_finalized_head_updates(
+            &self,
+            sink: PendingSubscriptionSink,
+        ) -> SubscriptionResult {
+            drop(sink);
+            Ok(())
+        }
+
+        async fn ws_safe_head_updates(&self, sink: PendingSubscriptionSink) -> SubscriptionResult {
+            drop(sink);
+            Ok(())
+        }
+
+        async fn ws_unsafe_head_updates(
+            &self,
+            sink: PendingSubscriptionSink,
+        ) -> SubscriptionResult {
+            drop(sink);
+            Ok(())
+        }
+    }
+
+    #[rstest]
+    #[case("ws_subscribe_finalized_head")]
+    #[case("ws_subscribe_safe_head")]
+    #[case("ws_subscribe_unsafe_head")]
+    fn ws_api_wire_names(#[case] expected: &str) {
+        let module = StubWs.into_rpc();
+        let names: Vec<&str> = module.method_names().collect();
+        assert!(names.contains(&expected), "missing method {expected}, got: {names:?}");
+    }
+
+    struct StubDevEngineApi;
+
+    #[async_trait]
+    impl DevEngineApiServer for StubDevEngineApi {
+        async fn dev_subscribe_engine_queue_length(
+            &self,
+            sink: PendingSubscriptionSink,
+        ) -> SubscriptionResult {
+            drop(sink);
+            Ok(())
+        }
+
+        async fn dev_task_queue_length(&self) -> RpcResult<usize> {
+            unimplemented!()
+        }
+    }
+
+    #[rstest]
+    #[case("dev_subscribe_engine_queue_size")]
+    #[case("dev_taskQueueLength")]
+    fn dev_engine_api_wire_names(#[case] expected: &str) {
+        let module = StubDevEngineApi.into_rpc();
+        let names: Vec<&str> = module.method_names().collect();
+        assert!(names.contains(&expected), "missing method {expected}, got: {names:?}");
+    }
+
+    struct StubAdminApi;
+
+    #[async_trait]
+    impl AdminApiServer for StubAdminApi {
+        async fn admin_post_unsafe_payload(
+            &self,
+            _: BaseExecutionPayloadEnvelope,
+        ) -> RpcResult<()> {
+            unimplemented!()
+        }
+
+        async fn admin_sequencer_active(&self) -> RpcResult<bool> {
+            unimplemented!()
+        }
+
+        async fn admin_start_sequencer(&self, _: B256) -> RpcResult<()> {
+            unimplemented!()
+        }
+
+        async fn admin_stop_sequencer(&self) -> RpcResult<B256> {
+            unimplemented!()
+        }
+
+        async fn admin_conductor_enabled(&self) -> RpcResult<bool> {
+            unimplemented!()
+        }
+
+        async fn admin_recover_mode(&self) -> RpcResult<bool> {
+            unimplemented!()
+        }
+
+        async fn admin_set_recover_mode(&self, _: bool) -> RpcResult<()> {
+            unimplemented!()
+        }
+
+        async fn admin_override_leader(&self) -> RpcResult<()> {
+            unimplemented!()
+        }
+
+        async fn admin_reset_derivation_pipeline(&self) -> RpcResult<()> {
+            unimplemented!()
+        }
+    }
+
+    #[rstest]
+    #[case("admin_postUnsafePayload")]
+    #[case("admin_sequencerActive")]
+    #[case("admin_startSequencer")]
+    #[case("admin_stopSequencer")]
+    #[case("admin_conductorEnabled")]
+    #[case("admin_adminRecoverMode")]
+    #[case("admin_setRecoverMode")]
+    #[case("admin_overrideLeader")]
+    #[case("admin_resetDerivationPipeline")]
+    fn admin_api_wire_names(#[case] expected: &str) {
+        let module = StubAdminApi.into_rpc();
+        let names: Vec<&str> = module.method_names().collect();
+        assert!(names.contains(&expected), "missing method {expected}, got: {names:?}");
+    }
+
+    struct StubHealthzApi;
+
+    #[async_trait]
+    impl HealthzApiServer for StubHealthzApi {
+        async fn healthz(&self) -> RpcResult<HealthzResponse> {
+            unimplemented!()
+        }
+    }
+
+    #[rstest]
+    #[case("healthz")]
+    fn healthz_api_wire_names(#[case] expected: &str) {
+        let module = StubHealthzApi.into_rpc();
+        let names: Vec<&str> = module.method_names().collect();
+        assert!(names.contains(&expected), "missing method {expected}, got: {names:?}");
+    }
+
+    struct StubConductorApi;
+
+    #[async_trait]
+    impl ConductorApiServer for StubConductorApi {
+        async fn conductor_leader(&self) -> RpcResult<bool> {
+            unimplemented!()
+        }
+
+        async fn conductor_active(&self) -> RpcResult<bool> {
+            unimplemented!()
+        }
+
+        async fn conductor_commit_unsafe_payload(
+            &self,
+            _: BaseExecutionPayloadEnvelope,
+        ) -> RpcResult<()> {
+            unimplemented!()
+        }
+
+        async fn conductor_override_leader(&self) -> RpcResult<()> {
+            unimplemented!()
+        }
+
+        async fn conductor_transfer_leader(&self) -> RpcResult<()> {
+            unimplemented!()
+        }
+
+        async fn conductor_transfer_leader_to_server(&self, _: String, _: String) -> RpcResult<()> {
+            unimplemented!()
+        }
+    }
+
+    #[rstest]
+    #[case("conductor_leader")]
+    #[case("conductor_active")]
+    #[case("conductor_commitUnsafePayload")]
+    #[case("conductor_overrideLeader")]
+    #[case("conductor_transferLeader")]
+    #[case("conductor_transferLeaderToServer")]
+    fn conductor_api_wire_names(#[case] expected: &str) {
+        let module = StubConductorApi.into_rpc();
+        let names: Vec<&str> = module.method_names().collect();
+        assert!(names.contains(&expected), "missing method {expected}, got: {names:?}");
+    }
 }

--- a/crates/consensus/rpc/src/rollup.rs
+++ b/crates/consensus/rpc/src/rollup.rs
@@ -67,7 +67,7 @@ impl<EngineRpcClient_: EngineRpcClient> RollupRpc<EngineRpcClient_> {
 impl<EngineRpcClient_: EngineRpcClient + 'static> RollupNodeApiServer
     for RollupRpc<EngineRpcClient_>
 {
-    async fn op_output_at_block(&self, block_num: BlockNumberOrTag) -> RpcResult<OutputResponse> {
+    async fn output_at_block(&self, block_num: BlockNumberOrTag) -> RpcResult<OutputResponse> {
         Metrics::rpc_calls("op_outputAtBlock").increment(1.0);
 
         let (l1_sync_status_send, l1_sync_status_recv) = tokio::sync::oneshot::channel();
@@ -87,7 +87,7 @@ impl<EngineRpcClient_: EngineRpcClient + 'static> RollupNodeApiServer
         Ok(OutputResponse::from_v0(output_root, sync_status, l2_block_info))
     }
 
-    async fn op_safe_head_at_l1_block(
+    async fn safe_head_at_l1_block(
         &self,
         block_num: BlockNumberOrTag,
     ) -> RpcResult<SafeHeadResponse> {
@@ -118,7 +118,7 @@ impl<EngineRpcClient_: EngineRpcClient + 'static> RollupNodeApiServer
         })
     }
 
-    async fn op_sync_status(&self) -> RpcResult<SyncStatus> {
+    async fn sync_status(&self) -> RpcResult<SyncStatus> {
         Metrics::rpc_calls("op_syncStatus").increment(1.0);
 
         let (l1_sync_status_send, l1_sync_status_recv) = tokio::sync::oneshot::channel();
@@ -138,13 +138,13 @@ impl<EngineRpcClient_: EngineRpcClient + 'static> RollupNodeApiServer
         return Ok(Self::sync_status_from_actor_queries(l1_sync_status, l2_sync_status));
     }
 
-    async fn op_rollup_config(&self) -> RpcResult<RollupConfig> {
+    async fn rollup_config(&self) -> RpcResult<RollupConfig> {
         Metrics::rpc_calls("op_rollupConfig").increment(1.0);
 
         self.engine_client.get_config().await
     }
 
-    async fn op_version(&self) -> RpcResult<String> {
+    async fn version(&self) -> RpcResult<String> {
         Metrics::rpc_calls("op_version").increment(1.0);
 
         const RPC_VERSION: &str = env!("CARGO_PKG_VERSION");

--- a/crates/consensus/rpc/src/sync.rs
+++ b/crates/consensus/rpc/src/sync.rs
@@ -7,5 +7,32 @@ use jsonrpsee::{core::RpcResult, proc_macros::rpc};
 pub trait SyncStatusApi {
     /// Returns the current [`SyncStatus`] of the node.
     #[method(name = "syncStatus")]
-    async fn op_sync_status(&self) -> RpcResult<SyncStatus>;
+    async fn sync_status(&self) -> RpcResult<SyncStatus>;
+}
+
+#[cfg(test)]
+mod tests {
+    use async_trait::async_trait;
+    use base_protocol::SyncStatus;
+    use jsonrpsee::core::RpcResult;
+    use rstest::rstest;
+
+    use super::SyncStatusApiServer;
+
+    struct StubSyncStatusApi;
+
+    #[async_trait]
+    impl SyncStatusApiServer for StubSyncStatusApi {
+        async fn sync_status(&self) -> RpcResult<SyncStatus> {
+            unimplemented!()
+        }
+    }
+
+    #[rstest]
+    #[case("optimism_syncStatus")]
+    fn sync_status_api_wire_names(#[case] expected: &str) {
+        let module = StubSyncStatusApi.into_rpc();
+        let names: Vec<&str> = module.method_names().collect();
+        assert!(names.contains(&expected), "missing method {expected}, got: {names:?}");
+    }
 }

--- a/crates/consensus/service/src/actors/derivation/delegated/client.rs
+++ b/crates/consensus/service/src/actors/derivation/delegated/client.rs
@@ -52,6 +52,6 @@ impl DerivationDelegateClient {
     ///
     /// Calls `optimism_syncStatus` RPC method.
     pub async fn fetch_sync_status(&self) -> Result<SyncStatus, DerivationDelegateClientError> {
-        Ok(self.derivation_client.op_sync_status().await?)
+        Ok(self.derivation_client.sync_status().await?)
     }
 }

--- a/crates/infra/basectl/src/app/core.rs
+++ b/crates/infra/basectl/src/app/core.rs
@@ -118,7 +118,7 @@ impl App {
             self.resources.proofs.poll();
             // When a conductor cluster is configured, bridge the Raft leader's
             // safe head into the DA tracker each tick.  The conductor poller
-            // already queries `op_sync_status` from every node's CL, so the
+            // already queries `sync_status` from every node's CL, so the
             // leader's value is available here without an extra RPC.  This
             // ensures the DA monitor advances even before sequencer-0's EL has
             // P2P-synced blocks that were produced by a different leader.

--- a/crates/infra/basectl/src/rpc.rs
+++ b/crates/infra/basectl/src/rpc.rs
@@ -1037,7 +1037,7 @@ pub async fn run_conductor_poller(
                 ) = tokio::join!(
                     ConductorApiClient::conductor_leader(conductor_client),
                     ConductorApiClient::conductor_active(conductor_client),
-                    RollupNodeApiClient::op_sync_status(cl_client),
+                    RollupNodeApiClient::sync_status(cl_client),
                     BaseP2PApiClient::opp2p_peer_stats(cl_client),
                     async {
                         if let Some(el) = el_client {
@@ -1168,7 +1168,7 @@ pub async fn run_validator_poller(
         let statuses = futures::future::join_all(clients.iter().map(
             |(name, cl_client, el_client)| async move {
                 let (sync, cl_peer_stats, el_block_r, el_syncing_r, el_peers_r) = tokio::join!(
-                    RollupNodeApiClient::op_sync_status(cl_client),
+                    RollupNodeApiClient::sync_status(cl_client),
                     BaseP2PApiClient::opp2p_peer_stats(cl_client),
                     async {
                         if let Some(el) = el_client {

--- a/devnet/src/l2/in_process_consensus.rs
+++ b/devnet/src/l2/in_process_consensus.rs
@@ -245,7 +245,7 @@ impl InProcessConsensus {
         // (non-zero unsafe head hash), then pass the real value.
         let mut unsafe_head = B256::ZERO;
         for _ in 0..40 {
-            match client.op_sync_status().await {
+            match client.sync_status().await {
                 Ok(status) if status.unsafe_l2.block_info.hash != B256::ZERO => {
                     unsafe_head = status.unsafe_l2.block_info.hash;
                     break;

--- a/devnet/src/rpc.rs
+++ b/devnet/src/rpc.rs
@@ -88,16 +88,13 @@ impl DevnetRpcClient {
     /// Get sync status from L2 builder op-node.
     pub async fn l2_builder_sync_status(&self) -> Result<SyncStatus> {
         self.l2_builder_op_client
-            .op_sync_status()
+            .sync_status()
             .await
             .wrap_err("Failed to get L2 builder sync status")
     }
 
     /// Get sync status from L2 client op-node.
     pub async fn l2_client_sync_status(&self) -> Result<SyncStatus> {
-        self.l2_client_op_client
-            .op_sync_status()
-            .await
-            .wrap_err("Failed to get L2 client sync status")
+        self.l2_client_op_client.sync_status().await.wrap_err("Failed to get L2 client sync status")
     }
 }


### PR DESCRIPTION
## Summary

Renames the five `op_`-prefixed Rust methods in the `RollupNodeApi` and `SyncStatusApi` traits to drop the legacy OP Stack prefix as part of the broader op-prefix removal effort tracked in `big-renaming.md`. The wire-level RPC method names (e.g. `optimism_syncStatus`) are unchanged, so this is a purely internal Rust API rename. All call sites across the workspace have been updated accordingly.