### PR TITLE
chore(consensus): BaseEngineClient Rename

### DIFF
--- a/crates/consensus/engine/src/client.rs
+++ b/crates/consensus/engine/src/client.rs
@@ -92,11 +92,11 @@ pub trait EngineClient: OpEngineApi<Base, Http<HyperAuthClient>> + Send + Sync {
 
 /// An Engine API client that provides authenticated HTTP communication with an execution layer.
 ///
-/// The [`OpEngineClient`] handles JWT authentication and manages connections to both L1 and L2
+/// The [`BaseEngineClient`] handles JWT authentication and manages connections to both L1 and L2
 /// execution layers. It automatically selects the appropriate Engine API version based on the
 /// rollup configuration and block timestamps.
 #[derive(Clone, Debug)]
-pub struct OpEngineClient<L1Provider, L2Provider>
+pub struct BaseEngineClient<L1Provider, L2Provider>
 where
     L1Provider: Provider,
     L2Provider: Provider<Base>,
@@ -109,7 +109,7 @@ where
     cfg: Arc<RollupConfig>,
 }
 
-impl<L1Provider, L2Provider> OpEngineClient<L1Provider, L2Provider>
+impl<L1Provider, L2Provider> BaseEngineClient<L1Provider, L2Provider>
 where
     L1Provider: Provider,
     L2Provider: Provider<Base>,
@@ -126,7 +126,7 @@ where
     }
 }
 
-/// The builder for the [`OpEngineClient`].
+/// The builder for the [`BaseEngineClient`].
 #[derive(Debug, Clone)]
 pub struct EngineClientBuilder {
     /// The L2 Engine API endpoint URL.
@@ -140,24 +140,24 @@ pub struct EngineClientBuilder {
 }
 
 impl EngineClientBuilder {
-    /// Creates a new [`OpEngineClient`] with authenticated HTTP connections.
+    /// Creates a new [`BaseEngineClient`] with authenticated HTTP connections.
     ///
     /// Sets up JWT-authenticated connections to the Engine API endpoint along with an
     /// unauthenticated connection to the L1 chain.
-    pub fn build(self) -> OpEngineClient<RootProvider, RootProvider<Base>> {
-        let engine = OpEngineClient::<RootProvider, RootProvider<Base>>::rpc_client::<Base>(
+    pub fn build(self) -> BaseEngineClient<RootProvider, RootProvider<Base>> {
+        let engine = BaseEngineClient::<RootProvider, RootProvider<Base>>::rpc_client::<Base>(
             self.l2,
             self.l2_jwt,
         );
 
         let l1_provider = RootProvider::new_http(self.l1_rpc);
 
-        OpEngineClient { engine, l1_provider, cfg: self.cfg }
+        BaseEngineClient { engine, l1_provider, cfg: self.cfg }
     }
 }
 
 #[async_trait]
-impl<L1Provider, L2Provider> EngineClient for OpEngineClient<L1Provider, L2Provider>
+impl<L1Provider, L2Provider> EngineClient for BaseEngineClient<L1Provider, L2Provider>
 where
     L1Provider: Provider,
     L2Provider: Provider<Base>,
@@ -207,7 +207,7 @@ where
 
 #[async_trait::async_trait]
 impl<L1Provider, L2Provider> OpEngineApi<Base, Http<HyperAuthClient>>
-    for OpEngineClient<L1Provider, L2Provider>
+    for BaseEngineClient<L1Provider, L2Provider>
 where
     L1Provider: Provider,
     L2Provider: Provider<Base>,

--- a/crates/consensus/engine/src/lib.rs
+++ b/crates/consensus/engine/src/lib.rs
@@ -22,7 +22,7 @@ pub use attributes::{AttributesMatch, AttributesMismatch};
 
 mod client;
 pub use client::{
-    EngineClient, EngineClientBuilder, EngineClientError, HyperAuthClient, BaseEngineClient,
+    BaseEngineClient, EngineClient, EngineClientBuilder, EngineClientError, HyperAuthClient,
 };
 
 mod versions;

--- a/crates/consensus/engine/src/lib.rs
+++ b/crates/consensus/engine/src/lib.rs
@@ -22,7 +22,7 @@ pub use attributes::{AttributesMatch, AttributesMismatch};
 
 mod client;
 pub use client::{
-    EngineClient, EngineClientBuilder, EngineClientError, HyperAuthClient, OpEngineClient,
+    EngineClient, EngineClientBuilder, EngineClientError, HyperAuthClient, BaseEngineClient,
 };
 
 mod versions;

--- a/crates/consensus/service/src/actors/engine/config.rs
+++ b/crates/consensus/service/src/actors/engine/config.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use alloy_provider::RootProvider;
 use alloy_rpc_types_engine::JwtSecret;
 use base_alloy_network::Base;
-use base_consensus_engine::{EngineClientBuilder, BaseEngineClient};
+use base_consensus_engine::{BaseEngineClient, EngineClientBuilder};
 use base_consensus_genesis::RollupConfig;
 use url::Url;
 

--- a/crates/consensus/service/src/actors/engine/config.rs
+++ b/crates/consensus/service/src/actors/engine/config.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use alloy_provider::RootProvider;
 use alloy_rpc_types_engine::JwtSecret;
 use base_alloy_network::Base;
-use base_consensus_engine::{EngineClientBuilder, OpEngineClient};
+use base_consensus_engine::{EngineClientBuilder, BaseEngineClient};
 use base_consensus_genesis::RollupConfig;
 use url::Url;
 
@@ -30,8 +30,8 @@ pub struct EngineConfig {
 }
 
 impl EngineConfig {
-    /// Builds and returns the [`OpEngineClient`].
-    pub fn build_engine_client(self) -> OpEngineClient<RootProvider, RootProvider<Base>> {
+    /// Builds and returns the [`BaseEngineClient`].
+    pub fn build_engine_client(self) -> BaseEngineClient<RootProvider, RootProvider<Base>> {
         EngineClientBuilder {
             l2: self.l2_url.clone(),
             l2_jwt: self.l2_jwt_secret,

--- a/crates/utilities/jwt/src/validator.rs
+++ b/crates/utilities/jwt/src/validator.rs
@@ -79,7 +79,7 @@ impl JwtValidator {
         use backon::{ExponentialBuilder, Retryable};
         use base_alloy_network::Base;
         use base_alloy_provider::OpEngineApi;
-        use base_consensus_engine::{HyperAuthClient, BaseEngineClient};
+        use base_consensus_engine::{BaseEngineClient, HyperAuthClient};
         use tracing::{debug, error};
 
         // Convert WebSocket URLs to HTTP for validation.

--- a/crates/utilities/jwt/src/validator.rs
+++ b/crates/utilities/jwt/src/validator.rs
@@ -79,7 +79,7 @@ impl JwtValidator {
         use backon::{ExponentialBuilder, Retryable};
         use base_alloy_network::Base;
         use base_alloy_provider::OpEngineApi;
-        use base_consensus_engine::{HyperAuthClient, OpEngineClient};
+        use base_consensus_engine::{HyperAuthClient, BaseEngineClient};
         use tracing::{debug, error};
 
         // Convert WebSocket URLs to HTTP for validation.
@@ -87,7 +87,7 @@ impl JwtValidator {
         // ws:// -> http:// and wss:// -> https:// for the capability exchange.
         let http_url = Self::normalize_engine_url(engine_url)?;
 
-        let engine = OpEngineClient::<RootProvider, RootProvider<Base>>::rpc_client::<Base>(
+        let engine = BaseEngineClient::<RootProvider, RootProvider<Base>>::rpc_client::<Base>(
             http_url,
             self.secret,
         );


### PR DESCRIPTION
## Summary

Renames the concrete engine client struct from `OpEngineClient` to `BaseEngineClient` as part of the broader op-prefix removal tracked in `big-renaming.md`. The plain `EngineClient` name was unavailable since it is already used by the trait in the same module that the struct implements. Updates the four files that reference the struct directly: the definition in `engine/src/client.rs`, the re-export in `engine/src/lib.rs`, the engine actor config, and the JWT validator.