### PR TITLE
chore(proof): Rename Fpvm Types

### DIFF
--- a/crates/proof/fpvm-precompiles/src/factory.rs
+++ b/crates/proof/fpvm-precompiles/src/factory.rs
@@ -13,23 +13,23 @@ use revm::{
     inspector::NoOpInspector,
 };
 
-use crate::OpFpvmPrecompiles;
+use crate::FpvmPrecompiles;
 
 /// Factory for creating EVM instances with FPVM-accelerated precompile overrides enabled.
 #[derive(Debug, Clone)]
-pub struct FpvmOpEvmFactory<H, O> {
+pub struct FpvmEvmFactory<H, O> {
     /// The hint writer.
     hint_writer: H,
     /// The oracle reader.
     oracle_reader: O,
 }
 
-impl<H, O> FpvmOpEvmFactory<H, O>
+impl<H, O> FpvmEvmFactory<H, O>
 where
     H: HintWriterClient + Clone + Send + Sync + 'static,
     O: PreimageOracleClient + Clone + Send + Sync + 'static,
 {
-    /// Creates a new [`FpvmOpEvmFactory`].
+    /// Creates a new [`FpvmEvmFactory`].
     pub const fn new(hint_writer: H, oracle_reader: O) -> Self {
         Self { hint_writer, oracle_reader }
     }
@@ -44,18 +44,18 @@ where
         &self.oracle_reader
     }
 
-    /// Returns a new [`OpFpvmPrecompiles`] instance for the given spec.
-    pub fn create_precompiles(&self, spec: OpSpecId) -> OpFpvmPrecompiles<H, O> {
-        OpFpvmPrecompiles::new_with_spec(spec, self.hint_writer.clone(), self.oracle_reader.clone())
+    /// Returns a new [`FpvmPrecompiles`] instance for the given spec.
+    pub fn create_precompiles(&self, spec: OpSpecId) -> FpvmPrecompiles<H, O> {
+        FpvmPrecompiles::new_with_spec(spec, self.hint_writer.clone(), self.oracle_reader.clone())
     }
 }
 
-impl<H, O> EvmFactory for FpvmOpEvmFactory<H, O>
+impl<H, O> EvmFactory for FpvmEvmFactory<H, O>
 where
     H: HintWriterClient + Clone + Send + Sync + 'static,
     O: PreimageOracleClient + Clone + Send + Sync + 'static,
 {
-    type Evm<DB: Database, I: Inspector<OpContext<DB>>> = OpEvm<DB, I, OpFpvmPrecompiles<H, O>>;
+    type Evm<DB: Database, I: Inspector<OpContext<DB>>> = OpEvm<DB, I, FpvmPrecompiles<H, O>>;
     type Context<DB: Database> = OpContext<DB>;
     type Tx = OpTransaction<TxEnv>;
     type Error<DBError: core::error::Error + Send + Sync + 'static> =
@@ -63,7 +63,7 @@ where
     type HaltReason = OpHaltReason;
     type Spec = OpSpecId;
     type BlockEnv = BlockEnv;
-    type Precompiles = OpFpvmPrecompiles<H, O>;
+    type Precompiles = FpvmPrecompiles<H, O>;
 
     fn create_evm<DB: Database>(
         &self,
@@ -77,7 +77,7 @@ where
                 .with_block(input.block_env)
                 .with_cfg(input.cfg_env)
                 .build_op_with_inspector(NoOpInspector {})
-                .with_precompiles(OpFpvmPrecompiles::new_with_spec(
+                .with_precompiles(FpvmPrecompiles::new_with_spec(
                     spec_id,
                     self.hint_writer.clone(),
                     self.oracle_reader.clone(),
@@ -99,7 +99,7 @@ where
                 .with_block(input.block_env)
                 .with_cfg(input.cfg_env)
                 .build_op_with_inspector(inspector)
-                .with_precompiles(OpFpvmPrecompiles::new_with_spec(
+                .with_precompiles(FpvmPrecompiles::new_with_spec(
                     spec_id,
                     self.hint_writer.clone(),
                     self.oracle_reader.clone(),

--- a/crates/proof/fpvm-precompiles/src/lib.rs
+++ b/crates/proof/fpvm-precompiles/src/lib.rs
@@ -4,7 +4,7 @@
 extern crate alloc;
 
 mod precompiles;
-pub use precompiles::OpFpvmPrecompiles;
+pub use precompiles::FpvmPrecompiles;
 
 mod factory;
-pub use factory::FpvmOpEvmFactory;
+pub use factory::FpvmEvmFactory;

--- a/crates/proof/fpvm-precompiles/src/precompiles/mod.rs
+++ b/crates/proof/fpvm-precompiles/src/precompiles/mod.rs
@@ -4,7 +4,7 @@
 //! [`PrecompileProvider`]: revm::handler::PrecompileProvider
 
 mod provider;
-pub use provider::OpFpvmPrecompiles;
+pub use provider::FpvmPrecompiles;
 
 mod bls12_g1_add;
 mod bls12_g1_msm;

--- a/crates/proof/fpvm-precompiles/src/precompiles/provider.rs
+++ b/crates/proof/fpvm-precompiles/src/precompiles/provider.rs
@@ -17,7 +17,7 @@ use super::{ecrecover::ECRECOVER_ADDR, kzg_point_eval::KZG_POINT_EVAL_ADDR};
 
 /// The FPVM-accelerated precompiles.
 #[derive(Debug)]
-pub struct OpFpvmPrecompiles<H, O> {
+pub struct FpvmPrecompiles<H, O> {
     /// The default [`EthPrecompiles`] provider.
     inner: EthPrecompiles,
     /// The accelerated precompiles for the current [`OpSpecId`].
@@ -30,7 +30,7 @@ pub struct OpFpvmPrecompiles<H, O> {
     oracle_reader: O,
 }
 
-impl<H, O> OpFpvmPrecompiles<H, O>
+impl<H, O> FpvmPrecompiles<H, O>
 where
     H: HintWriterClient + Clone + Send + Sync + 'static,
     O: PreimageOracleClient + Clone + Send + Sync + 'static,
@@ -78,7 +78,7 @@ where
     }
 }
 
-impl<CTX, H, O> PrecompileProvider<CTX> for OpFpvmPrecompiles<H, O>
+impl<CTX, H, O> PrecompileProvider<CTX> for FpvmPrecompiles<H, O>
 where
     H: HintWriterClient + Clone + Send + Sync + 'static,
     O: PreimageOracleClient + Clone + Send + Sync + 'static,
@@ -328,8 +328,8 @@ mod tests {
     #[test]
     fn test_jovian_and_base_v1_use_different_precompile_sets() {
         let (hw, or_) = make_hw_or();
-        let jovian = OpFpvmPrecompiles::new_with_spec(OpSpecId::JOVIAN, hw.clone(), or_.clone());
-        let base_v1 = OpFpvmPrecompiles::new_with_spec(OpSpecId::BASE_V1, hw, or_);
+        let jovian = FpvmPrecompiles::new_with_spec(OpSpecId::JOVIAN, hw.clone(), or_.clone());
+        let base_v1 = FpvmPrecompiles::new_with_spec(OpSpecId::BASE_V1, hw, or_);
 
         assert!(
             !core::ptr::eq(jovian.precompiles(), base_v1.precompiles()),
@@ -340,8 +340,8 @@ mod tests {
     #[test]
     fn test_base_v1_modexp_enforces_eip7823_size_limit() {
         let (hw, or_) = make_hw_or();
-        let jovian = OpFpvmPrecompiles::new_with_spec(OpSpecId::JOVIAN, hw.clone(), or_.clone());
-        let base_v1 = OpFpvmPrecompiles::new_with_spec(OpSpecId::BASE_V1, hw, or_);
+        let jovian = FpvmPrecompiles::new_with_spec(OpSpecId::JOVIAN, hw.clone(), or_.clone());
+        let base_v1 = FpvmPrecompiles::new_with_spec(OpSpecId::BASE_V1, hw, or_);
 
         let modexp_berlin = modexp::BERLIN;
         let addr = modexp_berlin.address();


### PR DESCRIPTION
## Summary

Renames `OpFpvmPrecompiles` to `FpvmPrecompiles` and `FpvmOpEvmFactory` to `FpvmEvmFactory` in the `base-proof-fpvm-precompiles` crate as part of the broader op-prefix removal effort tracked in `big-renaming.md`. Both renames are confined to the single crate with no external call sites. The `crates/proof/` section of the renaming plan is now complete.