### PR TITLE
fix(challenger): metrics

### DIFF
--- a/crates/proof/challenge/src/driver.rs
+++ b/crates/proof/challenge/src/driver.rs
@@ -31,7 +31,7 @@ use base_tx_manager::TxManager;
 use base_zk_client::{ProofType, ProveBlockRequest, ZkProofProvider};
 use tokio::select;
 use tokio_util::sync::CancellationToken;
-use tracing::{debug, info, warn};
+use tracing::{debug, error, info, warn};
 
 use crate::{
     BondManager, CandidateGame, ChallengeSubmitter, ChallengerMetrics, DisputeIntent, GameCategory,
@@ -373,11 +373,20 @@ impl<L2: L2Provider, P: ZkProofProvider, T: TxManager, C: Clock> Driver<L2, P, T
                 ChallengerMetrics::invalid_zk_proposal_detected_total().increment(1);
             }
             GameCategory::FraudulentZkChallenge { .. } => {
+                error!(
+                    category = ?candidate.category,
+                    game = %game_address,
+                    "unexpected category in process_invalid_proposal"
+                );
                 debug_assert!(
                     false,
                     "unexpected category in process_invalid_proposal: {:?}",
                     candidate.category
                 );
+                return Err(eyre::eyre!(
+                    "unexpected category in process_invalid_proposal: {:?}",
+                    candidate.category
+                ));
             }
         }
 

--- a/crates/proof/challenge/src/driver.rs
+++ b/crates/proof/challenge/src/driver.rs
@@ -365,8 +365,14 @@ impl<L2: L2Provider, P: ZkProofProvider, T: TxManager, C: Clock> Driver<L2, P, T
             "invalid intermediate root detected, requesting proof"
         );
 
-        if intent == DisputeIntent::Nullify {
-            ChallengerMetrics::invalid_zk_proposal_detected_total().increment(1);
+        match candidate.category {
+            GameCategory::InvalidTeeProposal => {
+                ChallengerMetrics::invalid_tee_proposal_detected_total().increment(1);
+            }
+            GameCategory::InvalidZkProposal => {
+                ChallengerMetrics::invalid_zk_proposal_detected_total().increment(1);
+            }
+            _ => {}
         }
 
         self.initiate_proof(candidate, invalid_index, expected_root, intent).await

--- a/crates/proof/challenge/src/driver.rs
+++ b/crates/proof/challenge/src/driver.rs
@@ -372,7 +372,13 @@ impl<L2: L2Provider, P: ZkProofProvider, T: TxManager, C: Clock> Driver<L2, P, T
             GameCategory::InvalidZkProposal => {
                 ChallengerMetrics::invalid_zk_proposal_detected_total().increment(1);
             }
-            _ => {}
+            GameCategory::FraudulentZkChallenge { .. } => {
+                debug_assert!(
+                    false,
+                    "unexpected category in process_invalid_proposal: {:?}",
+                    candidate.category
+                );
+            }
         }
 
         self.initiate_proof(candidate, invalid_index, expected_root, intent).await

--- a/crates/proof/challenge/src/metrics.rs
+++ b/crates/proof/challenge/src/metrics.rs
@@ -57,6 +57,9 @@ base_metrics::define_metrics! {
     #[describe("Total number of TEE proof failures that fell back to ZK")]
     tee_proof_fallback_total: counter,
 
+    #[describe("Total number of invalid TEE proposals detected (Path 1)")]
+    invalid_tee_proposal_detected_total: counter,
+
     #[describe("Total number of fraudulent ZK challenges detected (Path 2)")]
     fraudulent_zk_challenge_detected_total: counter,
 


### PR DESCRIPTION
## Summary

- Add missing `invalid_tee_proposal_detected_total` metric counter so Path 1 (invalid TEE proposals) is tracked separately from Path 3 (invalid ZK proposals)
- Replace the broad `DisputeIntent::Nullify` check with an exhaustive `match` on `GameCategory` in `process_invalid_proposal`, ensuring each category increments the correct metric and the unexpected `FraudulentZkChallenge` variant is caught with an error