### PR TITLE
fix(infra): remove pub(crate) visibility in basectl and websocket-proxy

### DIFF
--- a/crates/infra/basectl/src/app/action.rs
+++ b/crates/infra/basectl/src/app/action.rs
@@ -2,7 +2,7 @@ use super::ViewId;
 
 /// An action returned by a view in response to user input or a tick.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) enum Action {
+pub enum Action {
     /// No action to take.
     None,
     /// Quit the application.

--- a/crates/infra/basectl/src/app/core.rs
+++ b/crates/infra/basectl/src/app/core.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, io::Stdout, sync::atomic::Ordering, time::Duration};
+use std::{collections::HashMap, fmt, io::Stdout, sync::atomic::Ordering, time::Duration};
 
 use anyhow::Result;
 use crossterm::event::{self, Event, KeyCode, KeyEvent, KeyModifiers};
@@ -47,6 +47,19 @@ pub struct App {
     network_picker: Option<NetworkPicker>,
     /// Pending async network-load result. `Some` while a switch is in flight.
     pending_network: Option<oneshot::Receiver<anyhow::Result<ChainConfig>>>,
+}
+
+impl fmt::Debug for App {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("App")
+            .field("router", &self.router)
+            .field("resources", &self.resources)
+            .field("show_help", &self.show_help)
+            .field("view_cache", &format_args!("({} views)", self.view_cache.len()))
+            .field("network_picker", &self.network_picker.as_ref().map(|_| ".."))
+            .field("pending_network", &self.pending_network.is_some())
+            .finish()
+    }
 }
 
 impl App {

--- a/crates/infra/basectl/src/app/core.rs
+++ b/crates/infra/basectl/src/app/core.rs
@@ -11,7 +11,7 @@ use tokio::sync::oneshot;
 
 use super::{Action, Resources, Router, View, ViewId, runner::start_background_services};
 use crate::{
-    commands::common::{COLOR_BASE_BLUE, EVENT_POLL_TIMEOUT},
+    commands::{COLOR_BASE_BLUE, EVENT_POLL_TIMEOUT},
     config::ChainConfig,
     tui::{AppFrame, Toast, restore_terminal, setup_terminal},
 };

--- a/crates/infra/basectl/src/app/core.rs
+++ b/crates/infra/basectl/src/app/core.rs
@@ -38,7 +38,7 @@ impl NetworkPicker {
 // ---------------------------------------------------------------------------
 
 /// Main TUI application that manages views, routing, and the event loop.
-pub(crate) struct App {
+pub struct App {
     router: Router,
     resources: Resources,
     show_help: bool,
@@ -51,7 +51,7 @@ pub(crate) struct App {
 
 impl App {
     /// Creates a new application with the given resources and initial view.
-    pub(crate) fn new(resources: Resources, initial_view: ViewId) -> Self {
+    pub fn new(resources: Resources, initial_view: ViewId) -> Self {
         Self {
             router: Router::new(initial_view),
             resources,
@@ -63,7 +63,7 @@ impl App {
     }
 
     /// Runs the application event loop using the given view factory.
-    pub(crate) async fn run<F>(mut self, mut view_factory: F) -> Result<()>
+    pub async fn run<F>(mut self, mut view_factory: F) -> Result<()>
     where
         F: FnMut(ViewId) -> Box<dyn View>,
     {

--- a/crates/infra/basectl/src/app/mod.rs
+++ b/crates/infra/basectl/src/app/mod.rs
@@ -12,8 +12,7 @@ pub use resources::{
 };
 
 mod router;
-pub use router::Router;
-pub use router::ViewId;
+pub use router::{Router, ViewId};
 
 mod runner;
 pub use runner::{run_app, run_flashblocks_json, start_background_services};

--- a/crates/infra/basectl/src/app/mod.rs
+++ b/crates/infra/basectl/src/app/mod.rs
@@ -1,23 +1,23 @@
 //! Core application logic, actions, resources, and routing for basectl.
 
 mod action;
-pub(crate) use action::Action;
+pub use action::Action;
 
 mod core;
-pub(crate) use core::App;
+pub use core::App;
 
 mod resources;
-pub(crate) use resources::{LoadTestTask, Resources};
+pub use resources::{LoadTestTask, Resources};
 
 mod router;
-pub(crate) use router::Router;
+pub use router::Router;
 pub use router::ViewId;
 
 mod runner;
 pub use runner::{run_app, run_flashblocks_json};
 
 mod view;
-pub(crate) use view::View;
+pub use view::View;
 
 /// TUI view implementations.
 mod views;

--- a/crates/infra/basectl/src/app/mod.rs
+++ b/crates/infra/basectl/src/app/mod.rs
@@ -22,4 +22,7 @@ pub use view::View;
 
 /// TUI view implementations.
 mod views;
-pub use views::*;
+pub use views::{
+    CommandCenterView, ConductorView, ConfigView, DaMonitorView, FlashblocksView, HomeView,
+    LoadTestView, ProofsView, TransactionPane, UpgradesView, create_view,
+};

--- a/crates/infra/basectl/src/app/mod.rs
+++ b/crates/infra/basectl/src/app/mod.rs
@@ -7,17 +7,20 @@ mod core;
 pub use core::App;
 
 mod resources;
-pub use resources::{LoadTestTask, Resources};
+pub use resources::{
+    ConductorState, DaState, FlashState, LoadTestTask, ProofsState, Resources, ValidatorState,
+};
 
 mod router;
 pub use router::Router;
 pub use router::ViewId;
 
 mod runner;
-pub use runner::{run_app, run_flashblocks_json};
+pub use runner::{run_app, run_flashblocks_json, start_background_services};
 
 mod view;
 pub use view::View;
 
 /// TUI view implementations.
 mod views;
+pub use views::*;

--- a/crates/infra/basectl/src/app/resources.rs
+++ b/crates/infra/basectl/src/app/resources.rs
@@ -25,7 +25,7 @@ const MAX_RECENT_DA_FLASHBLOCK_IDS: usize = 512;
 
 /// State for HA conductor cluster monitoring.
 #[derive(Debug, Default)]
-pub(crate) struct ConductorState {
+pub struct ConductorState {
     /// Most recent status snapshot for each conductor node.
     pub nodes: Vec<ConductorNodeStatus>,
     /// Original per-node configs, used to look up each node's `flashblocks_ws` URL.
@@ -41,7 +41,7 @@ pub(crate) struct ConductorState {
 
 impl ConductorState {
     /// Sets the channel for receiving conductor status updates.
-    pub(crate) fn set_channel(&mut self, rx: mpsc::Receiver<Vec<ConductorNodeStatus>>) {
+    pub fn set_channel(&mut self, rx: mpsc::Receiver<Vec<ConductorNodeStatus>>) {
         self.rx = Some(rx);
     }
 
@@ -49,7 +49,7 @@ impl ConductorState {
     ///
     /// After this is called, every `poll` will push the leader's `flashblocks_ws`
     /// URL into `tx` whenever it changes — replacing the separate polling task.
-    pub(crate) fn set_url_sender(
+    pub fn set_url_sender(
         &mut self,
         nodes_config: Vec<ConductorNodeConfig>,
         tx: watch::Sender<String>,
@@ -60,7 +60,7 @@ impl ConductorState {
 
     /// Drains the latest status snapshot from the background poller, then
     /// pushes the leader's flashblocks URL into the watch channel if it changed.
-    pub(crate) fn poll(&mut self) {
+    pub fn poll(&mut self) {
         let Some(ref mut rx) = self.rx else { return };
         // Drain all pending updates, keeping only the most recent snapshot.
         while let Ok(statuses) = rx.try_recv() {
@@ -70,7 +70,7 @@ impl ConductorState {
     }
 
     /// Returns the safe L2 block number reported by the current Raft leader, if known.
-    pub(crate) fn leader_safe_l2_block(&self) -> Option<u64> {
+    pub fn leader_safe_l2_block(&self) -> Option<u64> {
         self.nodes.iter().find(|n| n.is_leader == Some(true)).and_then(|n| n.safe_l2_block)
     }
 
@@ -97,7 +97,7 @@ impl ConductorState {
 
 /// State for validator node monitoring.
 #[derive(Debug, Default)]
-pub(crate) struct ValidatorState {
+pub struct ValidatorState {
     /// Most recent status snapshot for each validator node.
     pub nodes: Vec<ValidatorNodeStatus>,
     rx: Option<mpsc::Receiver<Vec<ValidatorNodeStatus>>>,
@@ -105,12 +105,12 @@ pub(crate) struct ValidatorState {
 
 impl ValidatorState {
     /// Sets the channel for receiving validator status updates.
-    pub(crate) fn set_channel(&mut self, rx: mpsc::Receiver<Vec<ValidatorNodeStatus>>) {
+    pub fn set_channel(&mut self, rx: mpsc::Receiver<Vec<ValidatorNodeStatus>>) {
         self.rx = Some(rx);
     }
 
     /// Drains the latest status snapshot from the background poller.
-    pub(crate) fn poll(&mut self) {
+    pub fn poll(&mut self) {
         let Some(ref mut rx) = self.rx else { return };
         while let Ok(statuses) = rx.try_recv() {
             self.nodes = statuses;
@@ -120,7 +120,7 @@ impl ValidatorState {
 
 /// State for proof system monitoring (dispute games, anchor state).
 #[derive(Debug, Default)]
-pub(crate) struct ProofsState {
+pub struct ProofsState {
     /// Most recent proof system snapshot.
     pub snapshot: Option<ProofsSnapshot>,
     rx: Option<mpsc::Receiver<ProofsSnapshot>>,
@@ -128,12 +128,12 @@ pub(crate) struct ProofsState {
 
 impl ProofsState {
     /// Sets the channel for receiving proof system snapshots.
-    pub(crate) fn set_channel(&mut self, rx: mpsc::Receiver<ProofsSnapshot>) {
+    pub fn set_channel(&mut self, rx: mpsc::Receiver<ProofsSnapshot>) {
         self.rx = Some(rx);
     }
 
     /// Drains the latest snapshot from the background poller.
-    pub(crate) fn poll(&mut self) {
+    pub fn poll(&mut self) {
         let Some(ref mut rx) = self.rx else { return };
         while let Ok(snapshot) = rx.try_recv() {
             self.snapshot = Some(snapshot);
@@ -144,14 +144,14 @@ impl ProofsState {
 /// Handle to a running load test task and its stop signal, used by [`super::App`]
 /// to await drain completion on shutdown so funds are returned to the funder.
 #[derive(Debug)]
-pub(crate) struct LoadTestTask {
+pub struct LoadTestTask {
     pub stop_flag: Arc<AtomicBool>,
     pub handle: JoinHandle<()>,
 }
 
 /// Shared resources available to all TUI views.
 #[derive(Debug)]
-pub(crate) struct Resources {
+pub struct Resources {
     /// Active chain configuration.
     pub config: ChainConfig,
     /// Data availability monitoring state.
@@ -175,7 +175,7 @@ pub(crate) struct Resources {
 
 /// State for DA (data availability) monitoring.
 #[derive(Debug)]
-pub(crate) struct DaState {
+pub struct DaState {
     /// Tracks L2 block DA contributions and backlog.
     pub tracker: DaTracker,
     /// Current backlog loading progress, if still loading.
@@ -199,7 +199,7 @@ pub(crate) struct DaState {
 
 /// State for the flashblocks stream display.
 #[derive(Debug)]
-pub(crate) struct FlashState {
+pub struct FlashState {
     /// Recent flashblock entries shown in the table.
     pub entries: VecDeque<FlashblockEntry>,
     /// Current block gas limit.
@@ -219,7 +219,7 @@ pub(crate) struct FlashState {
 
 impl Resources {
     /// Creates new resources with the given chain configuration.
-    pub(crate) fn new(config: ChainConfig) -> Self {
+    pub fn new(config: ChainConfig) -> Self {
         Self {
             config,
             da: DaState::new(),
@@ -235,17 +235,17 @@ impl Resources {
     }
 
     /// Returns the configured chain name.
-    pub(crate) fn chain_name(&self) -> &str {
+    pub fn chain_name(&self) -> &str {
         &self.config.name
     }
 
     /// Sets the channel for receiving L1 system config updates.
-    pub(crate) fn set_sys_config_channel(&mut self, rx: mpsc::Receiver<SystemConfig>) {
+    pub fn set_sys_config_channel(&mut self, rx: mpsc::Receiver<SystemConfig>) {
         self.sys_config_rx = Some(rx);
     }
 
     /// Polls for a new system config from the background task.
-    pub(crate) fn poll_sys_config(&mut self) {
+    pub fn poll_sys_config(&mut self) {
         if let Some(ref mut rx) = self.sys_config_rx
             && let Ok(cfg) = rx.try_recv()
         {
@@ -262,7 +262,7 @@ impl Default for DaState {
 
 impl DaState {
     /// Creates a new empty DA state.
-    pub(crate) fn new() -> Self {
+    pub fn new() -> Self {
         Self {
             tracker: DaTracker::new(),
             loading: None,
@@ -283,7 +283,7 @@ impl DaState {
     }
 
     /// Sets the channels used for receiving DA monitoring data.
-    pub(crate) fn set_channels(
+    pub fn set_channels(
         &mut self,
         fb_rx: mpsc::Receiver<Flashblock>,
         sync_rx: mpsc::Receiver<u64>,
@@ -301,7 +301,7 @@ impl DaState {
     }
 
     /// Sets the channel for receiving L1 connection mode updates.
-    pub(crate) fn set_l1_mode_channel(&mut self, rx: mpsc::Receiver<L1ConnectionMode>) {
+    pub fn set_l1_mode_channel(&mut self, rx: mpsc::Receiver<L1ConnectionMode>) {
         self.l1_mode_rx = Some(rx);
     }
 
@@ -310,7 +310,7 @@ impl DaState {
     /// Called each tick when a conductor cluster is configured so the DA
     /// tracker does not have to wait for sequencer-0's EL to P2P-sync
     /// new blocks produced by whichever sequencer currently holds leadership.
-    pub(crate) fn apply_conductor_safe_head(&mut self, safe_block: u64) {
+    pub fn apply_conductor_safe_head(&mut self, safe_block: u64) {
         if self.loaded {
             self.tracker.update_safe_head(safe_block);
         } else {
@@ -319,7 +319,7 @@ impl DaState {
     }
 
     /// Drains all pending messages from background channels and updates state.
-    pub(crate) fn poll(&mut self) {
+    pub fn poll(&mut self) {
         let backlog_results: Vec<_> = self
             .backlog_rx
             .as_mut()
@@ -486,7 +486,7 @@ impl Default for FlashState {
 
 impl FlashState {
     /// Creates a new empty flashblock state.
-    pub(crate) fn new() -> Self {
+    pub fn new() -> Self {
         Self {
             entries: VecDeque::with_capacity(MAX_FLASH_BLOCKS * 10),
             current_gas_limit: 0,
@@ -501,7 +501,7 @@ impl FlashState {
     }
 
     /// Sets the channel for receiving timestamped flashblocks.
-    pub(crate) fn set_channel(&mut self, fb_rx: mpsc::Receiver<TimestampedFlashblock>) {
+    pub fn set_channel(&mut self, fb_rx: mpsc::Receiver<TimestampedFlashblock>) {
         self.fb_rx = Some(fb_rx);
     }
 
@@ -512,12 +512,12 @@ impl FlashState {
     /// `last_flashblock` so the first flashblock from the new leader is not
     /// compared against the previous leader's index, preventing spurious
     /// missed-flashblock counts.
-    pub(crate) fn set_url_rx(&mut self, rx: watch::Receiver<String>) {
+    pub fn set_url_rx(&mut self, rx: watch::Receiver<String>) {
         self.url_rx = Some(rx);
     }
 
     /// Drains pending flashblocks from the channel unless paused.
-    pub(crate) fn poll(&mut self) {
+    pub fn poll(&mut self) {
         // Reset missed-flashblock tracking when the flashblocks endpoint changes
         // (i.e. leadership transferred to a different sequencer).  Each clone of
         // the watch receiver tracks its own "seen" state independently, so this
@@ -563,7 +563,7 @@ impl FlashState {
     }
 
     /// Processes a received flashblock and updates tracking state.
-    pub(crate) fn add_flashblock(&mut self, tsf: TimestampedFlashblock) {
+    pub fn add_flashblock(&mut self, tsf: TimestampedFlashblock) {
         let TimestampedFlashblock { flashblock: fb, received_at } = tsf;
 
         self.message_count += 1;

--- a/crates/infra/basectl/src/app/resources.rs
+++ b/crates/infra/basectl/src/app/resources.rs
@@ -145,7 +145,9 @@ impl ProofsState {
 /// to await drain completion on shutdown so funds are returned to the funder.
 #[derive(Debug)]
 pub struct LoadTestTask {
+    /// Flag to signal the load test to stop.
     pub stop_flag: Arc<AtomicBool>,
+    /// Handle to the running load test task.
     pub handle: JoinHandle<()>,
 }
 

--- a/crates/infra/basectl/src/app/resources.rs
+++ b/crates/infra/basectl/src/app/resources.rs
@@ -11,7 +11,7 @@ use tokio::{
 };
 
 use crate::{
-    commands::common::{DaTracker, FlashblockEntry, LoadingState},
+    commands::{DaTracker, FlashblockEntry, LoadingState},
     config::{ChainConfig, ConductorNodeConfig},
     rpc::{
         BacklogFetchResult, BlockDaInfo, ConductorNodeStatus, L1BlockInfo, L1ConnectionMode,

--- a/crates/infra/basectl/src/app/router.rs
+++ b/crates/infra/basectl/src/app/router.rs
@@ -23,24 +23,24 @@ pub enum ViewId {
 
 /// Manages view navigation history and the current active view.
 #[derive(Debug)]
-pub(crate) struct Router {
+pub struct Router {
     current: ViewId,
     history: Vec<ViewId>,
 }
 
 impl Router {
     /// Creates a new router starting at the given view.
-    pub(crate) const fn new(initial: ViewId) -> Self {
+    pub const fn new(initial: ViewId) -> Self {
         Self { current: initial, history: Vec::new() }
     }
 
     /// Returns the currently active view identifier.
-    pub(crate) const fn current(&self) -> ViewId {
+    pub const fn current(&self) -> ViewId {
         self.current
     }
 
     /// Switches to the given view, pushing the current view onto history.
-    pub(crate) fn switch_to(&mut self, view: ViewId) {
+    pub fn switch_to(&mut self, view: ViewId) {
         if view != self.current {
             self.history.push(self.current);
             self.current = view;

--- a/crates/infra/basectl/src/app/runner.rs
+++ b/crates/infra/basectl/src/app/runner.rs
@@ -34,7 +34,7 @@ pub async fn run_app(initial_view: ViewId, network: &str) -> Result<()> {
 /// safe-head polling, system config fetching, conductor polling, validator polling,
 /// and proof monitoring. All tasks communicate back through channels stored in
 /// `resources`.
-pub(crate) fn start_background_services(config: &ChainConfig, resources: &mut Resources) {
+pub fn start_background_services(config: &ChainConfig, resources: &mut Resources) {
     let (fb_tx, fb_rx) = mpsc::channel::<TimestampedFlashblock>(100);
     let (da_fb_tx, da_fb_rx) = mpsc::channel::<Flashblock>(100);
     let (sync_tx, sync_rx) = mpsc::channel::<u64>(10);

--- a/crates/infra/basectl/src/app/view.rs
+++ b/crates/infra/basectl/src/app/view.rs
@@ -5,7 +5,7 @@ use super::{Action, Resources};
 use crate::tui::Keybinding;
 
 /// Trait implemented by each TUI view screen.
-pub(crate) trait View {
+pub trait View {
     /// Returns the keybindings available in this view.
     fn keybindings(&self) -> &'static [Keybinding];
 

--- a/crates/infra/basectl/src/app/views/command_center.rs
+++ b/crates/infra/basectl/src/app/views/command_center.rs
@@ -10,7 +10,7 @@ use ratatui::{
 
 use crate::{
     app::{Action, Resources, View, views::TransactionPane},
-    commands::common::{
+    commands::{
         COLOR_BASE_BLUE, COLOR_BURN, COLOR_GROWTH, COLOR_ROW_HIGHLIGHTED, COLOR_ROW_SELECTED,
         L1_BLOCK_WINDOW, L1BlockFilter, L1BlocksTableParams, RATE_WINDOW_2M, backlog_size_color,
         block_color, block_color_bright, build_gas_bar, format_bytes, format_duration, format_gwei,

--- a/crates/infra/basectl/src/app/views/command_center.rs
+++ b/crates/infra/basectl/src/app/views/command_center.rs
@@ -44,7 +44,7 @@ enum Panel {
 
 /// Combined monitoring view with flashblocks, DA, and L1 block panels.
 #[derive(Debug)]
-pub(crate) struct CommandCenterView {
+pub struct CommandCenterView {
     focused_panel: Panel,
     da_table_state: TableState,
     flash_table_state: TableState,
@@ -63,7 +63,7 @@ impl Default for CommandCenterView {
 
 impl CommandCenterView {
     /// Creates a new command center view with default panel selection.
-    pub(crate) fn new() -> Self {
+    pub fn new() -> Self {
         let mut da_table_state = TableState::default();
         da_table_state.select(Some(0));
         let mut flash_table_state = TableState::default();

--- a/crates/infra/basectl/src/app/views/conductor.rs
+++ b/crates/infra/basectl/src/app/views/conductor.rs
@@ -39,7 +39,7 @@ type PauseRx = Option<(String, mpsc::Receiver<Result<(String, PausedPeers), Stri
 /// the available key bindings. When no conductor configuration is present
 /// (e.g. mainnet), a placeholder message is shown instead.
 #[derive(Debug, Default)]
-pub(crate) struct ConductorView {
+pub struct ConductorView {
     selected: usize,
     op_pending: bool,
     /// In-flight result channel for transfer / restart operations.
@@ -56,7 +56,7 @@ pub(crate) struct ConductorView {
 
 impl ConductorView {
     /// Creates a new conductor view.
-    pub(crate) fn new() -> Self {
+    pub fn new() -> Self {
         Self::default()
     }
 

--- a/crates/infra/basectl/src/app/views/conductor.rs
+++ b/crates/infra/basectl/src/app/views/conductor.rs
@@ -10,7 +10,7 @@ use tokio::sync::mpsc;
 
 use crate::{
     app::{Action, Resources, View},
-    commands::common::COLOR_BASE_BLUE,
+    commands::COLOR_BASE_BLUE,
     rpc::{
         ConductorNodeStatus, PausedPeers, ValidatorNodeStatus, pause_sequencer_node,
         restart_conductor_node, transfer_conductor_leader, unpause_sequencer_node,

--- a/crates/infra/basectl/src/app/views/config.rs
+++ b/crates/infra/basectl/src/app/views/config.rs
@@ -7,7 +7,7 @@ use ratatui::{
 
 use crate::{
     app::{Action, Resources, View},
-    commands::common::COLOR_BASE_BLUE,
+    commands::COLOR_BASE_BLUE,
     tui::Keybinding,
 };
 

--- a/crates/infra/basectl/src/app/views/config.rs
+++ b/crates/infra/basectl/src/app/views/config.rs
@@ -19,7 +19,7 @@ const KEYBINDINGS: &[Keybinding] = &[
 
 /// View displaying chain configuration and L1 system config parameters.
 #[derive(Debug)]
-pub(crate) struct ConfigView {
+pub struct ConfigView {
     needs_refresh: bool,
 }
 
@@ -31,7 +31,7 @@ impl Default for ConfigView {
 
 impl ConfigView {
     /// Creates a new config view.
-    pub(crate) const fn new() -> Self {
+    pub const fn new() -> Self {
         Self { needs_refresh: true }
     }
 }

--- a/crates/infra/basectl/src/app/views/da_monitor.rs
+++ b/crates/infra/basectl/src/app/views/da_monitor.rs
@@ -40,7 +40,7 @@ enum Panel {
 
 /// View for monitoring data availability backlog and L1 blob submissions.
 #[derive(Debug)]
-pub(crate) struct DaMonitorView {
+pub struct DaMonitorView {
     selected_panel: Panel,
     l2_table_state: TableState,
     l1_table_state: TableState,
@@ -56,7 +56,7 @@ impl Default for DaMonitorView {
 
 impl DaMonitorView {
     /// Creates a new DA monitor view with default panel selection.
-    pub(crate) fn new() -> Self {
+    pub fn new() -> Self {
         let mut l2_table_state = TableState::default();
         l2_table_state.select(Some(0));
         let mut l1_table_state = TableState::default();

--- a/crates/infra/basectl/src/app/views/da_monitor.rs
+++ b/crates/infra/basectl/src/app/views/da_monitor.rs
@@ -9,7 +9,7 @@ use ratatui::{
 
 use crate::{
     app::{Action, Resources, View, views::TransactionPane},
-    commands::common::{
+    commands::{
         COLOR_BASE_BLUE, COLOR_BURN, COLOR_GROWTH, L1_BLOCK_WINDOW, L1BlockFilter,
         L1BlocksTableParams, RATE_WINDOW_2M, RATE_WINDOW_5M, RATE_WINDOW_30S, format_duration,
         format_rate, render_da_backlog_bar, render_l1_blocks_table, target_usage_color,
@@ -404,7 +404,7 @@ fn render_blocks_panel(
 ) {
     use ratatui::widgets::{Cell, Row, Table};
 
-    use crate::commands::common::{
+    use crate::commands::{
         COLOR_ROW_SELECTED, block_color, format_bytes as fmt_bytes, format_duration as fmt_dur,
     };
 

--- a/crates/infra/basectl/src/app/views/factory.rs
+++ b/crates/infra/basectl/src/app/views/factory.rs
@@ -5,7 +5,7 @@ use super::{
 use crate::app::{View, ViewId};
 
 /// Creates a boxed view instance for the given view identifier.
-pub(crate) fn create_view(view_id: ViewId) -> Box<dyn View> {
+pub fn create_view(view_id: ViewId) -> Box<dyn View> {
     match view_id {
         ViewId::Home => Box::new(HomeView::new()),
         ViewId::CommandCenter => Box::new(CommandCenterView::new()),

--- a/crates/infra/basectl/src/app/views/flashblocks.rs
+++ b/crates/infra/basectl/src/app/views/flashblocks.rs
@@ -35,6 +35,7 @@ const KEYBINDINGS: &[Keybinding] = &[
 ];
 
 /// View for displaying the live flashblocks stream with gas usage.
+#[derive(Debug)]
 pub struct FlashblocksView {
     table_state: TableState,
     auto_scroll: bool,

--- a/crates/infra/basectl/src/app/views/flashblocks.rs
+++ b/crates/infra/basectl/src/app/views/flashblocks.rs
@@ -8,7 +8,7 @@ use ratatui::{
 
 use crate::{
     app::{Action, Resources, View, views::TransactionPane},
-    commands::common::{
+    commands::{
         COLOR_ACTIVE_BORDER, COLOR_ROW_HIGHLIGHTED, COLOR_ROW_SELECTED, block_color,
         block_color_bright, build_gas_bar, format_gas, format_gwei, render_gas_usage_bar,
         time_diff_color, truncate_block_number,

--- a/crates/infra/basectl/src/app/views/flashblocks.rs
+++ b/crates/infra/basectl/src/app/views/flashblocks.rs
@@ -35,7 +35,7 @@ const KEYBINDINGS: &[Keybinding] = &[
 ];
 
 /// View for displaying the live flashblocks stream with gas usage.
-pub(crate) struct FlashblocksView {
+pub struct FlashblocksView {
     table_state: TableState,
     auto_scroll: bool,
     tx_pane: Option<TransactionPane>,
@@ -50,7 +50,7 @@ impl Default for FlashblocksView {
 
 impl FlashblocksView {
     /// Creates a new flashblocks view with auto-scroll enabled.
-    pub(crate) fn new() -> Self {
+    pub fn new() -> Self {
         let mut table_state = TableState::default();
         table_state.select(Some(0));
         Self { table_state, auto_scroll: true, tx_pane: None, focused_on_txns: false }

--- a/crates/infra/basectl/src/app/views/home.rs
+++ b/crates/infra/basectl/src/app/views/home.rs
@@ -94,13 +94,13 @@ const KEYBINDINGS: &[Keybinding] = &[
 
 /// Main menu view with navigation to all other views.
 #[derive(Debug, Default)]
-pub(crate) struct HomeView {
+pub struct HomeView {
     selected_index: usize,
 }
 
 impl HomeView {
     /// Creates a new home view with the first menu item selected.
-    pub(crate) const fn new() -> Self {
+    pub const fn new() -> Self {
         Self { selected_index: 0 }
     }
 }

--- a/crates/infra/basectl/src/app/views/home.rs
+++ b/crates/infra/basectl/src/app/views/home.rs
@@ -7,7 +7,7 @@ use ratatui::{
 
 use crate::{
     app::{Action, Resources, View, ViewId},
-    commands::common::COLOR_BASE_BLUE,
+    commands::COLOR_BASE_BLUE,
     tui::Keybinding,
 };
 

--- a/crates/infra/basectl/src/app/views/load_test.rs
+++ b/crates/infra/basectl/src/app/views/load_test.rs
@@ -359,6 +359,12 @@ pub struct LoadTestView {
     funder_key_override: Option<String>,
 }
 
+impl Default for LoadTestView {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl LoadTestView {
     /// Creates a new load test view. Config discovery is deferred to the first tick.
     pub const fn new() -> Self {

--- a/crates/infra/basectl/src/app/views/load_test.rs
+++ b/crates/infra/basectl/src/app/views/load_test.rs
@@ -22,7 +22,7 @@ use url::Url;
 
 use crate::{
     app::{Action, LoadTestTask, Resources, View},
-    commands::common::COLOR_BASE_BLUE,
+    commands::COLOR_BASE_BLUE,
     tui::{Keybinding, Toast},
 };
 

--- a/crates/infra/basectl/src/app/views/load_test.rs
+++ b/crates/infra/basectl/src/app/views/load_test.rs
@@ -337,7 +337,7 @@ struct EditModal {
 /// Live [`DisplaySnapshot`] updates stream in via a watch channel pushed by
 /// the runner every 500 ms. `s` stops the current run cleanly.
 #[derive(Debug)]
-pub(crate) struct LoadTestView {
+pub struct LoadTestView {
     /// Discovered (name, config) pairs. Populated lazily on first tick.
     configs: Vec<(String, TestConfig)>,
     /// Index of the currently selected config.
@@ -361,7 +361,7 @@ pub(crate) struct LoadTestView {
 
 impl LoadTestView {
     /// Creates a new load test view. Config discovery is deferred to the first tick.
-    pub(crate) const fn new() -> Self {
+    pub const fn new() -> Self {
         Self {
             configs: Vec::new(),
             overrides: Vec::new(),

--- a/crates/infra/basectl/src/app/views/mod.rs
+++ b/crates/infra/basectl/src/app/views/mod.rs
@@ -1,34 +1,34 @@
 //! TUI view components for basectl panels and dashboards.
 
 mod command_center;
-pub(crate) use command_center::CommandCenterView;
+pub use command_center::CommandCenterView;
 
 mod conductor;
-pub(crate) use conductor::ConductorView;
+pub use conductor::ConductorView;
 
 mod config;
-pub(crate) use config::ConfigView;
+pub use config::ConfigView;
 
 mod da_monitor;
-pub(crate) use da_monitor::DaMonitorView;
+pub use da_monitor::DaMonitorView;
 
 mod factory;
-pub(crate) use factory::create_view;
+pub use factory::create_view;
 
 mod flashblocks;
-pub(crate) use flashblocks::FlashblocksView;
+pub use flashblocks::FlashblocksView;
 
 mod home;
-pub(crate) use home::HomeView;
+pub use home::HomeView;
 
 mod load_test;
-pub(crate) use load_test::LoadTestView;
+pub use load_test::LoadTestView;
 
 mod proofs;
-pub(crate) use proofs::ProofsView;
+pub use proofs::ProofsView;
 
 mod transaction_pane;
-pub(crate) use transaction_pane::TransactionPane;
+pub use transaction_pane::TransactionPane;
 
 mod upgrades;
-pub(crate) use upgrades::UpgradesView;
+pub use upgrades::UpgradesView;

--- a/crates/infra/basectl/src/app/views/proofs.rs
+++ b/crates/infra/basectl/src/app/views/proofs.rs
@@ -7,7 +7,7 @@ use ratatui::{
 
 use crate::{
     app::{Action, Resources, View},
-    commands::common::COLOR_BASE_BLUE,
+    commands::COLOR_BASE_BLUE,
     rpc::{LatestProposal, ProofsSnapshot},
     tui::Keybinding,
 };

--- a/crates/infra/basectl/src/app/views/proofs.rs
+++ b/crates/infra/basectl/src/app/views/proofs.rs
@@ -20,11 +20,11 @@ const KEYBINDINGS: &[Keybinding] = &[
 /// Proof system monitoring view showing dispute game state, anchor state,
 /// and sync gap analysis.
 #[derive(Debug, Default)]
-pub(crate) struct ProofsView;
+pub struct ProofsView;
 
 impl ProofsView {
     /// Creates a new proofs view.
-    pub(crate) const fn new() -> Self {
+    pub const fn new() -> Self {
         Self
     }
 }

--- a/crates/infra/basectl/src/app/views/transaction_pane.rs
+++ b/crates/infra/basectl/src/app/views/transaction_pane.rs
@@ -122,11 +122,7 @@ impl TransactionPane {
     ///
     /// DA block inspection intentionally avoids relying on streamed flashblock
     /// caches, which may be incomplete after reconnects or message gaps.
-    pub fn for_block(
-        block_number: u64,
-        l2_rpc: &str,
-        explorer_base_url: Option<&str>,
-    ) -> Self {
+    pub fn for_block(block_number: u64, l2_rpc: &str, explorer_base_url: Option<&str>) -> Self {
         // DA block inspection should default to authoritative RPC data.
         // Streamed flashblock caches can be incomplete during reconnects or gaps.
         Self::new(block_number, format!("Block {block_number}"), l2_rpc, None, explorer_base_url)

--- a/crates/infra/basectl/src/app/views/transaction_pane.rs
+++ b/crates/infra/basectl/src/app/views/transaction_pane.rs
@@ -19,7 +19,7 @@ use crate::{
 /// Fetches and displays the transactions for a single L2 block, with keyboard
 /// navigation, clipboard copy support, and focused/unfocused rendering states.
 #[derive(Debug)]
-pub(crate) struct TransactionPane {
+pub struct TransactionPane {
     /// The block number whose transactions are displayed.
     pub block_number: u64,
     /// Display title (e.g. "Block 123" or "Flashblock `123::2`").
@@ -63,7 +63,7 @@ impl TransactionPane {
     ///
     /// If `tx_range` is provided, only the specified slice of the block's transactions
     /// will be displayed (used for flashblock-specific views).
-    pub(crate) fn new(
+    pub fn new(
         block_number: u64,
         title_prefix: String,
         l2_rpc: &str,
@@ -95,7 +95,7 @@ impl TransactionPane {
     }
 
     /// Creates a pane with pre-decoded transaction data.
-    pub(crate) fn with_data(
+    pub fn with_data(
         block_number: u64,
         title_prefix: String,
         transactions: Vec<TxSummary>,
@@ -122,7 +122,7 @@ impl TransactionPane {
     ///
     /// DA block inspection intentionally avoids relying on streamed flashblock
     /// caches, which may be incomplete after reconnects or message gaps.
-    pub(crate) fn for_block(
+    pub fn for_block(
         block_number: u64,
         l2_rpc: &str,
         explorer_base_url: Option<&str>,
@@ -133,7 +133,7 @@ impl TransactionPane {
     }
 
     /// Polls background fetch channels for results.
-    pub(crate) fn poll(&mut self) {
+    pub fn poll(&mut self) {
         if let Some(ref mut rx) = self.rx
             && let Ok(txns) = rx.try_recv()
         {
@@ -162,7 +162,7 @@ impl TransactionPane {
     /// Returns `true` when the pane should be closed (Esc was pressed).
     /// The `toast_tx` callback is invoked to push toast notifications (e.g. after
     /// copying a transaction hash to the clipboard).
-    pub(crate) fn handle_key(&mut self, key: KeyEvent, toast_tx: &mut impl FnMut(Toast)) -> bool {
+    pub fn handle_key(&mut self, key: KeyEvent, toast_tx: &mut impl FnMut(Toast)) -> bool {
         let len = self.transactions.len();
 
         match key.code {
@@ -232,7 +232,7 @@ impl TransactionPane {
     ///
     /// When `is_focused` is true the border is highlighted and the selected row
     /// receives a distinct background color.
-    pub(crate) fn render(&mut self, frame: &mut Frame<'_>, area: Rect, is_focused: bool) {
+    pub fn render(&mut self, frame: &mut Frame<'_>, area: Rect, is_focused: bool) {
         let border_color = if is_focused { COLOR_ACTIVE_BORDER } else { Color::DarkGray };
 
         let title = if self.loading {

--- a/crates/infra/basectl/src/app/views/transaction_pane.rs
+++ b/crates/infra/basectl/src/app/views/transaction_pane.rs
@@ -9,7 +9,7 @@ use ratatui::{
 use tokio::sync::mpsc;
 
 use crate::{
-    commands::common::{COLOR_ACTIVE_BORDER, COLOR_ROW_SELECTED},
+    commands::{COLOR_ACTIVE_BORDER, COLOR_ROW_SELECTED},
     rpc::TxSummary,
     tui::Toast,
 };

--- a/crates/infra/basectl/src/app/views/upgrades.rs
+++ b/crates/infra/basectl/src/app/views/upgrades.rs
@@ -24,7 +24,7 @@ use url::Url;
 
 use crate::{
     app::{Action, Resources, View},
-    commands::common::COLOR_BASE_BLUE,
+    commands::COLOR_BASE_BLUE,
     tui::Keybinding,
 };
 

--- a/crates/infra/basectl/src/app/views/upgrades.rs
+++ b/crates/infra/basectl/src/app/views/upgrades.rs
@@ -337,7 +337,7 @@ const KEYBINDINGS: &[Keybinding] = &[
 
 /// Network upgrade activation countdown and history view.
 #[derive(Debug)]
-pub(crate) struct UpgradesView {
+pub struct UpgradesView {
     chains: [ChainUpgrades; 4],
     selected_chain: usize,
     tick_count: u64,
@@ -352,7 +352,7 @@ impl Default for UpgradesView {
 
 impl UpgradesView {
     /// Creates a new upgrades view.
-    pub(crate) fn new() -> Self {
+    pub fn new() -> Self {
         Self {
             chains: all_chains(),
             selected_chain: 0,

--- a/crates/infra/basectl/src/commands/common.rs
+++ b/crates/infra/basectl/src/commands/common.rs
@@ -411,12 +411,7 @@ impl DaTracker {
     }
 
     /// Updates an existing block's DA bytes with accurate data from a full fetch.
-    pub fn update_block_info(
-        &mut self,
-        block_number: u64,
-        accurate_da_bytes: u64,
-        timestamp: u64,
-    ) {
+    pub fn update_block_info(&mut self, block_number: u64, accurate_da_bytes: u64, timestamp: u64) {
         for contrib in &mut self.block_contributions {
             if contrib.block_number == block_number {
                 let diff = accurate_da_bytes as i64 - contrib.da_bytes as i64;
@@ -582,10 +577,7 @@ impl DaTracker {
     }
 
     /// Returns an iterator over L1 blocks matching the given filter.
-    pub fn filtered_l1_blocks(
-        &self,
-        filter: L1BlockFilter,
-    ) -> impl Iterator<Item = &L1Block> {
+    pub fn filtered_l1_blocks(&self, filter: L1BlockFilter) -> impl Iterator<Item = &L1Block> {
         self.l1_blocks.iter().filter(move |b| match filter {
             L1BlockFilter::All => true,
             L1BlockFilter::WithBlobs => b.has_blobs(),

--- a/crates/infra/basectl/src/commands/common.rs
+++ b/crates/infra/basectl/src/commands/common.rs
@@ -13,9 +13,9 @@ use ratatui::{
 use crate::rpc::{L1BlockInfo, L1ConnectionMode, TxSummary};
 
 /// Size of a single blob in bytes (128 `KiB`).
-pub(crate) const BLOB_SIZE: u64 = 128 * 1024;
+pub const BLOB_SIZE: u64 = 128 * 1024;
 /// Maximum number of entries retained in history buffers.
-pub(crate) const MAX_HISTORY: usize = 1000;
+pub const MAX_HISTORY: usize = 1000;
 
 const BLOCK_COLORS: [Color; 24] = [
     Color::Rgb(0, 82, 255),
@@ -51,38 +51,38 @@ const EIGHTH_BLOCKS: [char; 8] = ['▏', '▎', '▍', '▌', '▋', '▊', '▉
 // =============================================================================
 
 /// Primary Base blue color.
-pub(crate) const COLOR_BASE_BLUE: Color = Color::Rgb(0, 82, 255);
+pub const COLOR_BASE_BLUE: Color = Color::Rgb(0, 82, 255);
 /// Active border highlight color.
-pub(crate) const COLOR_ACTIVE_BORDER: Color = Color::Rgb(100, 180, 255);
+pub const COLOR_ACTIVE_BORDER: Color = Color::Rgb(100, 180, 255);
 
 /// Background color for the currently selected table row.
-pub(crate) const COLOR_ROW_SELECTED: Color = Color::Rgb(60, 60, 80);
+pub const COLOR_ROW_SELECTED: Color = Color::Rgb(60, 60, 80);
 /// Background color for a highlighted (cross-referenced) table row.
-pub(crate) const COLOR_ROW_HIGHLIGHTED: Color = Color::Rgb(40, 40, 60);
+pub const COLOR_ROW_HIGHLIGHTED: Color = Color::Rgb(40, 40, 60);
 
 /// Color for DA growth rate indicators.
-pub(crate) const COLOR_GROWTH: Color = Color::Rgb(255, 180, 100);
+pub const COLOR_GROWTH: Color = Color::Rgb(255, 180, 100);
 /// Color for DA burn rate indicators.
-pub(crate) const COLOR_BURN: Color = Color::Rgb(100, 200, 100);
+pub const COLOR_BURN: Color = Color::Rgb(100, 200, 100);
 /// Color for gas target markers.
-pub(crate) const COLOR_TARGET: Color = Color::Rgb(255, 200, 100);
+pub const COLOR_TARGET: Color = Color::Rgb(255, 200, 100);
 /// Color for gas bar fill below target.
-pub(crate) const COLOR_GAS_FILL: Color = Color::Rgb(100, 180, 255);
+pub const COLOR_GAS_FILL: Color = Color::Rgb(100, 180, 255);
 
 // =============================================================================
 // Duration Constants
 // =============================================================================
 
 /// Timeout for terminal event polling.
-pub(crate) const EVENT_POLL_TIMEOUT: Duration = Duration::from_millis(100);
+pub const EVENT_POLL_TIMEOUT: Duration = Duration::from_millis(100);
 /// Rate calculation window of 30 seconds.
-pub(crate) const RATE_WINDOW_30S: Duration = Duration::from_secs(30);
+pub const RATE_WINDOW_30S: Duration = Duration::from_secs(30);
 /// Rate calculation window of 2 minutes.
-pub(crate) const RATE_WINDOW_2M: Duration = Duration::from_secs(120);
+pub const RATE_WINDOW_2M: Duration = Duration::from_secs(120);
 /// Rate calculation window of 5 minutes.
-pub(crate) const RATE_WINDOW_5M: Duration = Duration::from_secs(300);
+pub const RATE_WINDOW_5M: Duration = Duration::from_secs(300);
 /// Number of recent L1 blocks used for blob share and target usage calculations.
-pub(crate) const L1_BLOCK_WINDOW: usize = 10;
+pub const L1_BLOCK_WINDOW: usize = 10;
 
 // =============================================================================
 // Shared Data Types
@@ -90,7 +90,7 @@ pub(crate) const L1_BLOCK_WINDOW: usize = 10;
 
 /// A single flashblock entry displayed in the TUI.
 #[derive(Clone, Debug)]
-pub(crate) struct FlashblockEntry {
+pub struct FlashblockEntry {
     /// L2 block number.
     pub block_number: u64,
     /// Flashblock index within the block.
@@ -117,7 +117,7 @@ impl FlashblockEntry {
     /// Decodes the raw transaction bytes into summaries on demand.
     ///
     /// This avoids the expensive k256 ECDSA signer recovery on the hot path.
-    pub(crate) fn decode_txs(&self) -> Vec<TxSummary> {
+    pub fn decode_txs(&self) -> Vec<TxSummary> {
         crate::rpc::decode_flashblock_transactions(
             &self.raw_txs,
             self.base_fee.and_then(|f| u64::try_from(f).ok()),
@@ -127,7 +127,7 @@ impl FlashblockEntry {
 
 /// An L2 block's data availability contribution.
 #[derive(Clone, Debug)]
-pub(crate) struct BlockContribution {
+pub struct BlockContribution {
     /// L2 block number.
     pub block_number: u64,
     /// DA bytes contributed by this block.
@@ -140,7 +140,7 @@ pub(crate) struct BlockContribution {
 
 impl BlockContribution {
     /// Returns the age of this block in seconds since its timestamp.
-    pub(crate) fn age_seconds(&self) -> u64 {
+    pub fn age_seconds(&self) -> u64 {
         let now = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
             .unwrap_or_default()
@@ -151,7 +151,7 @@ impl BlockContribution {
 
 /// An L1 block with blob and attribution data.
 #[derive(Clone, Debug)]
-pub(crate) struct L1Block {
+pub struct L1Block {
     /// L1 block number.
     pub block_number: u64,
     /// Unix timestamp of the L1 block.
@@ -170,7 +170,7 @@ pub(crate) struct L1Block {
 
 impl L1Block {
     /// Creates a new `L1Block` from raw L1 block info.
-    pub(crate) const fn from_info(info: L1BlockInfo) -> Self {
+    pub const fn from_info(info: L1BlockInfo) -> Self {
         Self {
             block_number: info.block_number,
             timestamp: info.timestamp,
@@ -183,32 +183,32 @@ impl L1Block {
     }
 
     /// Returns true if this L1 block contains any blobs.
-    pub(crate) const fn has_blobs(&self) -> bool {
+    pub const fn has_blobs(&self) -> bool {
         self.total_blobs > 0
     }
 
     /// Returns true if this L1 block contains blobs from the Base batcher.
-    pub(crate) const fn has_base_blobs(&self) -> bool {
+    pub const fn has_base_blobs(&self) -> bool {
         self.base_blobs > 0
     }
 
     /// Returns a formatted string of base/total blob counts.
-    pub(crate) fn blobs_display(&self) -> String {
+    pub fn blobs_display(&self) -> String {
         format!("{}/{}", self.base_blobs, self.total_blobs)
     }
 
     /// Returns the block number truncated to fit within `max_width` characters.
-    pub(crate) fn block_display(&self, max_width: usize) -> String {
+    pub fn block_display(&self, max_width: usize) -> String {
         truncate_block_number(self.block_number, max_width)
     }
 
     /// Returns the number of attributed L2 blocks as a display string.
-    pub(crate) fn l2_blocks_display(&self) -> String {
+    pub fn l2_blocks_display(&self) -> String {
         self.l2_blocks_submitted.map_or_else(|| "-".to_string(), |n| n.to_string())
     }
 
     /// Returns the DA-to-L1 compression ratio, if data is available.
-    pub(crate) fn compression_ratio(&self) -> Option<f64> {
+    pub fn compression_ratio(&self) -> Option<f64> {
         let da_bytes = self.l2_da_bytes?;
         if self.base_blobs == 0 {
             return None;
@@ -218,12 +218,12 @@ impl L1Block {
     }
 
     /// Returns the compression ratio as a formatted display string.
-    pub(crate) fn compression_display(&self) -> String {
+    pub fn compression_display(&self) -> String {
         self.compression_ratio().map_or_else(|| "-".to_string(), |r| format!("{r:.2}x"))
     }
 
     /// Returns the age of this L1 block in seconds.
-    pub(crate) fn age_seconds(&self) -> u64 {
+    pub fn age_seconds(&self) -> u64 {
         let now = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
             .map(|d| d.as_secs())
@@ -232,14 +232,14 @@ impl L1Block {
     }
 
     /// Returns the block age as a human-readable duration string.
-    pub(crate) fn age_display(&self) -> String {
+    pub fn age_display(&self) -> String {
         format_duration(Duration::from_secs(self.age_seconds()))
     }
 }
 
 /// Filter mode for the L1 blocks table display.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Default)]
-pub(crate) enum L1BlockFilter {
+pub enum L1BlockFilter {
     /// Show all L1 blocks.
     #[default]
     All,
@@ -251,7 +251,7 @@ pub(crate) enum L1BlockFilter {
 
 impl L1BlockFilter {
     /// Returns the next filter in the cycle.
-    pub(crate) const fn next(self) -> Self {
+    pub const fn next(self) -> Self {
         match self {
             Self::All => Self::WithBlobs,
             Self::WithBlobs => Self::WithBaseBlobs,
@@ -260,7 +260,7 @@ impl L1BlockFilter {
     }
 
     /// Returns a short label for this filter mode.
-    pub(crate) const fn label(self) -> &'static str {
+    pub const fn label(self) -> &'static str {
         match self {
             Self::All => "All",
             Self::WithBlobs => "Blobs",
@@ -271,7 +271,7 @@ impl L1BlockFilter {
 
 /// Tracks byte rate samples over a sliding time window.
 #[derive(Debug)]
-pub(crate) struct RateTracker {
+pub struct RateTracker {
     samples: VecDeque<(Instant, u64)>,
 }
 
@@ -283,12 +283,12 @@ impl Default for RateTracker {
 
 impl RateTracker {
     /// Creates a new rate tracker with an empty sample buffer.
-    pub(crate) fn new() -> Self {
+    pub fn new() -> Self {
         Self { samples: VecDeque::with_capacity(300) }
     }
 
     /// Records a byte count sample at the current instant.
-    pub(crate) fn add_sample(&mut self, bytes: u64) {
+    pub fn add_sample(&mut self, bytes: u64) {
         let now = Instant::now();
         self.samples.push_back((now, bytes));
         let cutoff = now - Duration::from_secs(300);
@@ -298,7 +298,7 @@ impl RateTracker {
     }
 
     /// Computes the byte rate (bytes/sec) over the given duration window.
-    pub(crate) fn rate_over(&self, duration: Duration) -> Option<f64> {
+    pub fn rate_over(&self, duration: Duration) -> Option<f64> {
         let now = Instant::now();
         let cutoff = now - duration;
 
@@ -324,7 +324,7 @@ impl RateTracker {
 
 /// Progress state during initial backlog loading.
 #[derive(Debug)]
-pub(crate) struct LoadingState {
+pub struct LoadingState {
     /// Number of blocks fetched so far.
     pub current_block: u64,
     /// Total number of blocks to fetch.
@@ -337,7 +337,7 @@ pub(crate) struct LoadingState {
 
 /// Tracks DA backlog state, L2 block contributions, and L1 blob data.
 #[derive(Debug)]
-pub(crate) struct DaTracker {
+pub struct DaTracker {
     /// Latest safe L2 block number.
     pub safe_l2_block: u64,
     /// Total DA bytes in the backlog (unsafe minus safe).
@@ -365,7 +365,7 @@ impl Default for DaTracker {
 
 impl DaTracker {
     /// Creates a new empty DA tracker.
-    pub(crate) fn new() -> Self {
+    pub fn new() -> Self {
         Self {
             safe_l2_block: 0,
             da_backlog_bytes: 0,
@@ -379,14 +379,14 @@ impl DaTracker {
     }
 
     /// Sets the initial backlog state from the safe block and total DA bytes.
-    pub(crate) const fn set_initial_backlog(&mut self, safe_block: u64, da_bytes: u64) {
+    pub const fn set_initial_backlog(&mut self, safe_block: u64, da_bytes: u64) {
         self.safe_l2_block = safe_block;
         self.da_backlog_bytes = da_bytes;
         self.last_attributed_safe_l2 = safe_block;
     }
 
     /// Adds a block from the initial backlog fetch.
-    pub(crate) fn add_backlog_block(&mut self, block_number: u64, da_bytes: u64, timestamp: u64) {
+    pub fn add_backlog_block(&mut self, block_number: u64, da_bytes: u64, timestamp: u64) {
         let contribution = BlockContribution { block_number, da_bytes, timestamp, tx_count: 0 };
         self.block_contributions.push_front(contribution);
         if self.block_contributions.len() > MAX_HISTORY {
@@ -395,7 +395,7 @@ impl DaTracker {
     }
 
     /// Records a new L2 block and adds its DA bytes to the backlog.
-    pub(crate) fn add_block(&mut self, block_number: u64, da_bytes: u64, timestamp: u64) {
+    pub fn add_block(&mut self, block_number: u64, da_bytes: u64, timestamp: u64) {
         if block_number <= self.safe_l2_block {
             return;
         }
@@ -411,7 +411,7 @@ impl DaTracker {
     }
 
     /// Updates an existing block's DA bytes with accurate data from a full fetch.
-    pub(crate) fn update_block_info(
+    pub fn update_block_info(
         &mut self,
         block_number: u64,
         accurate_da_bytes: u64,
@@ -456,7 +456,7 @@ impl DaTracker {
     }
 
     /// Updates the safe head and subtracts newly safe block bytes from the backlog.
-    pub(crate) fn update_safe_head(&mut self, safe_block: u64) {
+    pub fn update_safe_head(&mut self, safe_block: u64) {
         if safe_block <= self.safe_l2_block {
             return;
         }
@@ -478,7 +478,7 @@ impl DaTracker {
     }
 
     /// Records a new L1 block and attempts to attribute L2 blocks to it.
-    pub(crate) fn record_l1_block(&mut self, info: L1BlockInfo) {
+    pub fn record_l1_block(&mut self, info: L1BlockInfo) {
         if self.l1_blocks.iter().any(|b| b.block_number == info.block_number) {
             return;
         }
@@ -582,7 +582,7 @@ impl DaTracker {
     }
 
     /// Returns an iterator over L1 blocks matching the given filter.
-    pub(crate) fn filtered_l1_blocks(
+    pub fn filtered_l1_blocks(
         &self,
         filter: L1BlockFilter,
     ) -> impl Iterator<Item = &L1Block> {
@@ -594,7 +594,7 @@ impl DaTracker {
     }
 
     /// Returns the Base batcher's share of total blobs over the last `n` L1 blocks.
-    pub(crate) fn base_blob_share(&self, n: usize) -> Option<f64> {
+    pub fn base_blob_share(&self, n: usize) -> Option<f64> {
         let blocks: Vec<_> = self.l1_blocks.iter().take(n).collect();
         if blocks.is_empty() {
             return None;
@@ -605,7 +605,7 @@ impl DaTracker {
     }
 
     /// Returns the blob target usage ratio over the last `n` L1 blocks.
-    pub(crate) fn blob_target_usage(&self, n: usize, l1_blob_target: u64) -> Option<f64> {
+    pub fn blob_target_usage(&self, n: usize, l1_blob_target: u64) -> Option<f64> {
         let blocks: Vec<_> = self.l1_blocks.iter().take(n).collect();
         if blocks.is_empty() || l1_blob_target == 0 {
             return None;
@@ -621,7 +621,7 @@ impl DaTracker {
 // =============================================================================
 
 /// Formats a byte count into a human-readable string (e.g. "1.5M").
-pub(crate) fn format_bytes(bytes: u64) -> String {
+pub fn format_bytes(bytes: u64) -> String {
     if bytes >= 1_000_000_000 {
         format!("{:.1}G", bytes as f64 / 1_000_000_000.0)
     } else if bytes >= 1_000_000 {
@@ -634,7 +634,7 @@ pub(crate) fn format_bytes(bytes: u64) -> String {
 }
 
 /// Formats a gas value into a human-readable string (e.g. "30.0M").
-pub(crate) fn format_gas(gas: u64) -> String {
+pub fn format_gas(gas: u64) -> String {
     if gas >= 1_000_000 {
         format!("{:.1}M", gas as f64 / 1_000_000.0)
     } else if gas >= 1_000 {
@@ -645,13 +645,13 @@ pub(crate) fn format_gas(gas: u64) -> String {
 }
 
 /// Truncates a block number to fit within `max_width` characters.
-pub(crate) fn truncate_block_number(block_number: u64, max_width: usize) -> String {
+pub fn truncate_block_number(block_number: u64, max_width: usize) -> String {
     let s = block_number.to_string();
     if s.len() <= max_width { s } else { format!("…{}", &s[s.len() - (max_width - 1)..]) }
 }
 
 /// Formats a duration into a compact human-readable string (e.g. "2m30s").
-pub(crate) fn format_duration(d: Duration) -> String {
+pub fn format_duration(d: Duration) -> String {
     let secs = d.as_secs();
     if secs >= 3600 {
         format!("{}h{}m", secs / 3600, (secs % 3600) / 60)
@@ -663,7 +663,7 @@ pub(crate) fn format_duration(d: Duration) -> String {
 }
 
 /// Formats a byte rate into a human-readable string (e.g. "1.2K/s").
-pub(crate) fn format_rate(rate: Option<f64>) -> String {
+pub fn format_rate(rate: Option<f64>) -> String {
     match rate {
         Some(r) if r >= 1_000_000.0 => format!("{:.1}M/s", r / 1_000_000.0),
         Some(r) if r >= 1_000.0 => format!("{:.1}K/s", r / 1_000.0),
@@ -673,7 +673,7 @@ pub(crate) fn format_rate(rate: Option<f64>) -> String {
 }
 
 /// Formats a wei value as gwei with appropriate precision.
-pub(crate) fn format_gwei(wei: u128) -> String {
+pub fn format_gwei(wei: u128) -> String {
     let gwei = wei as f64 / 1_000_000_000.0;
     if gwei >= 1.0 { format!("{gwei:.2} gwei") } else { format!("{gwei:.4} gwei") }
 }
@@ -688,7 +688,7 @@ const BACKLOG_THRESHOLDS: &[(u64, Color)] = &[
 ];
 
 /// Returns a color indicating backlog severity based on byte count.
-pub(crate) fn backlog_size_color(bytes: u64) -> Color {
+pub fn backlog_size_color(bytes: u64) -> Color {
     BACKLOG_THRESHOLDS
         .iter()
         .find(|(threshold, _)| bytes < *threshold)
@@ -696,12 +696,12 @@ pub(crate) fn backlog_size_color(bytes: u64) -> Color {
 }
 
 /// Returns a unique color for the given block number.
-pub(crate) const fn block_color(block_number: u64) -> Color {
+pub const fn block_color(block_number: u64) -> Color {
     BLOCK_COLORS[(block_number as usize) % BLOCK_COLORS.len()]
 }
 
 /// Returns a brightened version of the block color for emphasis.
-pub(crate) const fn block_color_bright(block_number: u64) -> Color {
+pub const fn block_color_bright(block_number: u64) -> Color {
     let Color::Rgb(r, g, b) = BLOCK_COLORS[(block_number as usize) % BLOCK_COLORS.len()] else {
         unreachable!()
     };
@@ -723,7 +723,7 @@ const GAS_COLOR_WARM: (u8, u8, u8) = (255, 200, 80);
 const GAS_COLOR_HOT: (u8, u8, u8) = (255, 60, 60);
 
 /// Builds a styled gas usage bar line with target marker.
-pub(crate) fn build_gas_bar(
+pub fn build_gas_bar(
     gas_used: u64,
     gas_limit: u64,
     elasticity: u64,
@@ -797,7 +797,7 @@ pub(crate) fn build_gas_bar(
 
 /// Parameters for rendering the L1 blocks table.
 #[derive(Debug)]
-pub(crate) struct L1BlocksTableParams<'a, I: Iterator<Item = &'a L1Block>> {
+pub struct L1BlocksTableParams<'a, I: Iterator<Item = &'a L1Block>> {
     /// Iterator over L1 blocks to display.
     pub l1_blocks: I,
     /// Whether this panel is the active (focused) panel.
@@ -813,7 +813,7 @@ pub(crate) struct L1BlocksTableParams<'a, I: Iterator<Item = &'a L1Block>> {
 }
 
 /// Renders the L1 blocks table panel.
-pub(crate) fn render_l1_blocks_table<'a>(
+pub fn render_l1_blocks_table<'a>(
     f: &mut Frame<'_>,
     area: Rect,
     params: L1BlocksTableParams<'a, impl Iterator<Item = &'a L1Block>>,
@@ -893,7 +893,7 @@ pub(crate) fn render_l1_blocks_table<'a>(
 }
 
 /// Renders a horizontal bar showing the DA backlog with per-block coloring.
-pub(crate) fn render_da_backlog_bar(
+pub fn render_da_backlog_bar(
     f: &mut Frame<'_>,
     area: Rect,
     tracker: &DaTracker,
@@ -1003,7 +1003,7 @@ pub(crate) fn render_da_backlog_bar(
 }
 
 /// Renders a horizontal bar showing aggregate gas usage across recent blocks.
-pub(crate) fn render_gas_usage_bar(
+pub fn render_gas_usage_bar(
     f: &mut Frame<'_>,
     area: Rect,
     entries: &VecDeque<FlashblockEntry>,
@@ -1133,7 +1133,7 @@ pub(crate) fn render_gas_usage_bar(
 const TARGET_USAGE_MAX: f64 = 1.5;
 
 /// Returns a color representing how close usage is to the target (blue to red).
-pub(crate) fn target_usage_color(usage: f64) -> Color {
+pub fn target_usage_color(usage: f64) -> Color {
     let t = usage.clamp(0.0, TARGET_USAGE_MAX);
     if t <= 1.0 {
         lerp_rgb((0, 100, 255), (255, 255, 0), t)
@@ -1154,7 +1154,7 @@ const FLASHBLOCK_TARGET_MS: i64 = 200;
 const FLASHBLOCK_TOLERANCE_MS: i64 = 50;
 
 /// Returns a color indicating how close a time delta is to the 200ms target.
-pub(crate) fn time_diff_color(ms: i64) -> Color {
+pub fn time_diff_color(ms: i64) -> Color {
     let target = FLASHBLOCK_TARGET_MS;
     let tol = FLASHBLOCK_TOLERANCE_MS;
     if (target - tol..=target + tol).contains(&ms) {

--- a/crates/infra/basectl/src/commands/mod.rs
+++ b/crates/infra/basectl/src/commands/mod.rs
@@ -1,4 +1,14 @@
 //! CLI command implementations for the basectl tool.
 
 /// Shared types, formatters, and rendering utilities for CLI commands.
-pub mod common;
+mod common;
+pub use common::{
+    BLOB_SIZE, BlockContribution, COLOR_ACTIVE_BORDER, COLOR_BASE_BLUE, COLOR_BURN, COLOR_GAS_FILL,
+    COLOR_GROWTH, COLOR_ROW_HIGHLIGHTED, COLOR_ROW_SELECTED, COLOR_TARGET, DaTracker,
+    EVENT_POLL_TIMEOUT, FlashblockEntry, L1_BLOCK_WINDOW, L1Block, L1BlockFilter,
+    L1BlocksTableParams, LoadingState, MAX_HISTORY, RATE_WINDOW_2M, RATE_WINDOW_5M,
+    RATE_WINDOW_30S, RateTracker, backlog_size_color, block_color, block_color_bright,
+    build_gas_bar, format_bytes, format_duration, format_gas, format_gwei, format_rate,
+    render_da_backlog_bar, render_gas_usage_bar, render_l1_blocks_table, target_usage_color,
+    time_diff_color, truncate_block_number,
+};

--- a/crates/infra/basectl/src/commands/mod.rs
+++ b/crates/infra/basectl/src/commands/mod.rs
@@ -1,4 +1,4 @@
 //! CLI command implementations for the basectl tool.
 
 /// Shared types, formatters, and rendering utilities for CLI commands.
-pub(crate) mod common;
+pub mod common;

--- a/crates/infra/basectl/src/l1_client.rs
+++ b/crates/infra/basectl/src/l1_client.rs
@@ -24,7 +24,7 @@ sol! {
 ///
 /// Uses Multicall3 via `CallBatchLayer` to batch all calls into a single RPC request.
 /// Fields that are absent on older contract versions fall back to their defaults.
-pub(crate) async fn fetch_full_system_config(
+pub async fn fetch_full_system_config(
     l1_rpc_url: &str,
     system_config_address: Address,
 ) -> Result<SystemConfig> {

--- a/crates/infra/basectl/src/lib.rs
+++ b/crates/infra/basectl/src/lib.rs
@@ -1,12 +1,19 @@
 #![doc = include_str!("../README.md")]
 
 mod app;
-pub use app::{ViewId, run_app, run_flashblocks_json};
+pub use app::*;
 
 mod commands;
+pub use commands::*;
+
 mod config;
 pub use config::{ChainConfig, ConductorNodeConfig, ProofsConfig, ValidatorNodeConfig};
 
 mod l1_client;
+pub use l1_client::*;
+
 mod rpc;
+pub use rpc::*;
+
 mod tui;
+pub use tui::*;

--- a/crates/infra/basectl/src/lib.rs
+++ b/crates/infra/basectl/src/lib.rs
@@ -1,19 +1,44 @@
 #![doc = include_str!("../README.md")]
 
 mod app;
-pub use app::*;
+pub use app::{
+    Action, App, CommandCenterView, ConductorState, ConductorView, ConfigView, DaMonitorView,
+    DaState, FlashState, FlashblocksView, HomeView, LoadTestTask, LoadTestView, ProofsState,
+    ProofsView, Resources, Router, TransactionPane, UpgradesView, ValidatorState, View, ViewId,
+    create_view, run_app, run_flashblocks_json, start_background_services,
+};
 
 mod commands;
-pub use commands::*;
+pub use commands::{
+    BLOB_SIZE, BlockContribution, COLOR_ACTIVE_BORDER, COLOR_BASE_BLUE, COLOR_BURN, COLOR_GAS_FILL,
+    COLOR_GROWTH, COLOR_ROW_HIGHLIGHTED, COLOR_ROW_SELECTED, COLOR_TARGET, DaTracker,
+    EVENT_POLL_TIMEOUT, FlashblockEntry, L1_BLOCK_WINDOW, L1Block, L1BlockFilter,
+    L1BlocksTableParams, LoadingState, MAX_HISTORY, RATE_WINDOW_2M, RATE_WINDOW_5M,
+    RATE_WINDOW_30S, RateTracker, backlog_size_color, block_color, block_color_bright,
+    build_gas_bar, format_bytes, format_duration, format_gas, format_gwei, format_rate,
+    render_da_backlog_bar, render_gas_usage_bar, render_l1_blocks_table, target_usage_color,
+    time_diff_color, truncate_block_number,
+};
 
 mod config;
 pub use config::{ChainConfig, ConductorNodeConfig, ProofsConfig, ValidatorNodeConfig};
 
 mod l1_client;
-pub use l1_client::*;
+pub use l1_client::fetch_full_system_config;
 
 mod rpc;
-pub use rpc::*;
+pub use rpc::{
+    BacklogBlock, BacklogFetchResult, BacklogProgress, BlockDaInfo, ConductorNodeStatus,
+    InitialBacklog, L1BlockInfo, L1ConnectionMode, LatestProposal, PausedPeers, ProofsSnapshot,
+    TimestampedFlashblock, TxSummary, ValidatorNodeStatus, decode_flashblock_transactions,
+    fetch_block_transactions, fetch_initial_backlog_with_progress, fetch_safe_and_latest,
+    pause_sequencer_node, restart_conductor_node, run_block_fetcher, run_conductor_poller,
+    run_flashblock_ws, run_flashblock_ws_timestamped, run_l1_blob_watcher, run_proofs_poller,
+    run_safe_head_poller, run_validator_poller, transfer_conductor_leader, unpause_sequencer_node,
+};
 
 mod tui;
-pub use tui::*;
+pub use tui::{
+    AppFrame, AppLayout, Keybinding, Toast, ToastLevel, ToastState, restore_terminal,
+    setup_terminal,
+};

--- a/crates/infra/basectl/src/rpc.rs
+++ b/crates/infra/basectl/src/rpc.rs
@@ -28,7 +28,7 @@ const WS_RECONNECT_INITIAL_DELAY: Duration = Duration::from_secs(1);
 const WS_RECONNECT_MAX_DELAY: Duration = Duration::from_secs(30);
 
 /// Fetches the safe and latest L2 block numbers.
-pub(crate) async fn fetch_safe_and_latest(l2_rpc: &str) -> Result<(u64, u64)> {
+pub async fn fetch_safe_and_latest(l2_rpc: &str) -> Result<(u64, u64)> {
     let provider = ProviderBuilder::new().connect(l2_rpc).await?;
 
     let safe_block = provider
@@ -63,7 +63,7 @@ async fn fetch_raw_block_info<P: Provider<Base>>(
 }
 
 /// Polls the L2 safe head block number at regular intervals.
-pub(crate) async fn run_safe_head_poller(
+pub async fn run_safe_head_poller(
     l2_rpc: String,
     tx: mpsc::Sender<u64>,
     toast_tx: mpsc::Sender<Toast>,
@@ -187,7 +187,7 @@ async fn run_flashblock_ws_inner<T: Send + 'static>(
 }
 
 /// Subscribes to flashblocks via WebSocket and forwards raw flashblocks.
-pub(crate) async fn run_flashblock_ws(
+pub async fn run_flashblock_ws(
     mut url_rx: watch::Receiver<String>,
     tx: mpsc::Sender<Flashblock>,
     toast_tx: mpsc::Sender<Toast>,
@@ -197,7 +197,7 @@ pub(crate) async fn run_flashblock_ws(
 
 /// A flashblock paired with its local receive timestamp.
 #[derive(Debug)]
-pub(crate) struct TimestampedFlashblock {
+pub struct TimestampedFlashblock {
     /// The decoded flashblock.
     pub flashblock: Flashblock,
     /// Local time when this flashblock was received.
@@ -205,7 +205,7 @@ pub(crate) struct TimestampedFlashblock {
 }
 
 /// Subscribes to flashblocks via WebSocket and forwards timestamped flashblocks.
-pub(crate) async fn run_flashblock_ws_timestamped(
+pub async fn run_flashblock_ws_timestamped(
     mut url_rx: watch::Receiver<String>,
     tx: mpsc::Sender<TimestampedFlashblock>,
     toast_tx: mpsc::Sender<Toast>,
@@ -224,7 +224,7 @@ pub(crate) async fn run_flashblock_ws_timestamped(
 /// The task exits immediately if no such nodes exist.
 /// Summary of the initial DA backlog between safe and latest blocks.
 #[derive(Debug, Clone)]
-pub(crate) struct InitialBacklog {
+pub struct InitialBacklog {
     /// Safe L2 block number.
     pub safe_block: u64,
     /// Total DA bytes across all backlog blocks.
@@ -233,7 +233,7 @@ pub(crate) struct InitialBacklog {
 
 /// Progress update during initial backlog fetch.
 #[derive(Debug, Clone)]
-pub(crate) struct BacklogProgress {
+pub struct BacklogProgress {
     /// Number of blocks fetched so far.
     pub current_block: u64,
     /// Total number of blocks to fetch.
@@ -242,7 +242,7 @@ pub(crate) struct BacklogProgress {
 
 /// Individual block data from backlog fetch.
 #[derive(Debug, Clone)]
-pub(crate) struct BacklogBlock {
+pub struct BacklogBlock {
     /// L2 block number.
     pub block_number: u64,
     /// DA bytes contributed by this block.
@@ -253,7 +253,7 @@ pub(crate) struct BacklogBlock {
 
 /// Result of initial backlog fetch - either progress or complete.
 #[derive(Debug, Clone)]
-pub(crate) enum BacklogFetchResult {
+pub enum BacklogFetchResult {
     /// Incremental progress update.
     Progress(BacklogProgress),
     /// A single fetched block.
@@ -265,7 +265,7 @@ pub(crate) enum BacklogFetchResult {
 }
 
 /// Fetches the initial DA backlog, sending progress updates and block data.
-pub(crate) async fn fetch_initial_backlog_with_progress(
+pub async fn fetch_initial_backlog_with_progress(
     l2_rpc: String,
     progress_tx: tokio::sync::mpsc::Sender<BacklogFetchResult>,
 ) {
@@ -342,7 +342,7 @@ pub(crate) async fn fetch_initial_backlog_with_progress(
 
 /// DA and gas information for a single L2 block.
 #[derive(Debug, Clone)]
-pub(crate) struct BlockDaInfo {
+pub struct BlockDaInfo {
     /// L2 block number.
     pub block_number: u64,
     /// Total DA bytes from all transactions.
@@ -352,7 +352,7 @@ pub(crate) struct BlockDaInfo {
 }
 
 /// Fetches DA info for requested block numbers and sends results back.
-pub(crate) async fn run_block_fetcher(
+pub async fn run_block_fetcher(
     l2_rpc: String,
     mut request_rx: mpsc::Receiver<u64>,
     result_tx: mpsc::Sender<BlockDaInfo>,
@@ -389,7 +389,7 @@ pub(crate) async fn run_block_fetcher(
 
 /// Information about an L1 block and its blob counts.
 #[derive(Debug, Clone)]
-pub(crate) struct L1BlockInfo {
+pub struct L1BlockInfo {
     /// L1 block number.
     pub block_number: u64,
     /// Unix timestamp of the L1 block.
@@ -402,7 +402,7 @@ pub(crate) struct L1BlockInfo {
 
 /// How the L1 watcher connects to the L1 node.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) enum L1ConnectionMode {
+pub enum L1ConnectionMode {
     /// Connected via WebSocket subscription.
     WebSocket,
     /// Connected via HTTP polling.
@@ -414,7 +414,7 @@ fn http_to_ws(url: &str) -> String {
 }
 
 /// Watches L1 blocks for blob transactions, preferring WebSocket with polling fallback.
-pub(crate) async fn run_l1_blob_watcher(
+pub async fn run_l1_blob_watcher(
     l1_rpc: String,
     batcher_address: Address,
     result_tx: mpsc::Sender<L1BlockInfo>,
@@ -564,7 +564,7 @@ fn extract_l1_block_info(
 
 /// Summary of a single transaction within a block.
 #[derive(Debug, Clone)]
-pub(crate) struct TxSummary {
+pub struct TxSummary {
     /// Transaction hash.
     pub hash: B256,
     /// Sender address.
@@ -590,7 +590,7 @@ fn effective_priority_fee_per_gas(
 /// Decodes raw EIP-2718 encoded transaction bytes into summaries.
 ///
 /// Used to extract transaction details from flashblock stream data without RPC calls.
-pub(crate) fn decode_flashblock_transactions(
+pub fn decode_flashblock_transactions(
     raw_txs: &[Bytes],
     base_fee_per_gas: Option<u64>,
 ) -> Vec<TxSummary> {
@@ -623,7 +623,7 @@ pub(crate) fn decode_flashblock_transactions(
 }
 
 /// Fetches all transactions for a given block and sends summaries through the channel.
-pub(crate) async fn fetch_block_transactions(
+pub async fn fetch_block_transactions(
     l2_rpc: String,
     block_number: u64,
     tx: mpsc::Sender<Result<Vec<TxSummary>, String>>,
@@ -678,7 +678,7 @@ pub(crate) async fn fetch_block_transactions(
 
 /// Live status snapshot for a single node in an HA conductor cluster.
 #[derive(Debug, Clone)]
-pub(crate) struct ConductorNodeStatus {
+pub struct ConductorNodeStatus {
     /// Human-readable name for this node.
     pub name: String,
 
@@ -724,7 +724,7 @@ pub(crate) struct ConductorNodeStatus {
 /// is transferred to the named node via `conductor_transferLeaderToServer`.
 ///
 /// The result — `Ok(description)` or `Err(message)` — is sent to `result_tx`.
-pub(crate) async fn transfer_conductor_leader(
+pub async fn transfer_conductor_leader(
     nodes: Vec<ConductorNodeConfig>,
     target_name: Option<String>,
     result_tx: mpsc::Sender<Result<String, String>>,
@@ -783,7 +783,7 @@ pub(crate) async fn transfer_conductor_leader(
 /// waiting for each to become healthy before starting the next. This prevents
 /// op-conductor from crashing on startup because it tries to connect to the EL
 /// before the EL has bound its port.
-pub(crate) async fn restart_conductor_node(
+pub async fn restart_conductor_node(
     node: ConductorNodeConfig,
     result_tx: mpsc::Sender<Result<String, String>>,
 ) {
@@ -850,7 +850,7 @@ pub(crate) async fn restart_conductor_node(
 
 /// Peers saved when a sequencer node is paused, used to restore connectivity on unpause.
 #[derive(Debug, Clone, Default)]
-pub(crate) struct PausedPeers {
+pub struct PausedPeers {
     /// Multiaddrs of the CL peers that were connected before pausing.
     /// Used to reconnect them on unpause via `opp2p_connectPeer`.
     pub cl_addrs: Vec<String>,
@@ -862,7 +862,7 @@ pub(crate) struct PausedPeers {
 /// Disconnects all p2p peers from the CL and EL of a node so that neither layer
 /// can advance.  Returns the saved peer addresses so they can be restored later
 /// via [`unpause_sequencer_node`].
-pub(crate) async fn pause_sequencer_node(
+pub async fn pause_sequencer_node(
     node: ConductorNodeConfig,
     result_tx: mpsc::Sender<Result<(String, PausedPeers), String>>,
 ) {
@@ -924,7 +924,7 @@ pub(crate) async fn pause_sequencer_node(
 
 /// Reconnects the CL and EL peers that were saved by [`pause_sequencer_node`],
 /// allowing the node to resume syncing to tip.
-pub(crate) async fn unpause_sequencer_node(
+pub async fn unpause_sequencer_node(
     node: ConductorNodeConfig,
     peers: PausedPeers,
     result_tx: mpsc::Sender<Result<String, String>>,
@@ -979,7 +979,7 @@ pub(crate) async fn unpause_sequencer_node(
 /// fires all per-node requests concurrently via [`futures::future::join_all`].
 /// Any individual RPC that times out or errors yields `None` for that field —
 /// the node is shown as offline when `is_leader` is `None`.
-pub(crate) async fn run_conductor_poller(
+pub async fn run_conductor_poller(
     nodes: Vec<ConductorNodeConfig>,
     tx: mpsc::Sender<Vec<ConductorNodeStatus>>,
 ) {
@@ -1097,7 +1097,7 @@ pub(crate) async fn run_conductor_poller(
 
 /// Live status snapshot for a single validator (non-sequencing) node.
 #[derive(Debug, Clone)]
-pub(crate) struct ValidatorNodeStatus {
+pub struct ValidatorNodeStatus {
     /// Human-readable name for this node.
     pub name: String,
 
@@ -1129,7 +1129,7 @@ pub(crate) struct ValidatorNodeStatus {
 }
 
 /// Polls all validator nodes every 200 ms and forwards status snapshots.
-pub(crate) async fn run_validator_poller(
+pub async fn run_validator_poller(
     nodes: Vec<ValidatorNodeConfig>,
     tx: mpsc::Sender<Vec<ValidatorNodeStatus>>,
 ) {
@@ -1254,7 +1254,7 @@ sol! {
 
 /// Snapshot of proof system state, fetched periodically.
 #[derive(Debug, Clone)]
-pub(crate) struct ProofsSnapshot {
+pub struct ProofsSnapshot {
     /// Current L1 block number.
     pub l1_block: Option<u64>,
     /// Current L2 latest (unsafe) block number.
@@ -1279,7 +1279,7 @@ pub(crate) struct ProofsSnapshot {
 
 /// Information about the most recent dispute game proposal.
 #[derive(Debug, Clone)]
-pub(crate) struct LatestProposal {
+pub struct LatestProposal {
     /// Address of the dispute game proxy contract.
     pub game_address: Address,
     /// L2 block number proposed.
@@ -1294,7 +1294,7 @@ pub(crate) struct LatestProposal {
 
 /// Polls proof system state (anchor state, dispute games, chain heads) at regular
 /// intervals and sends snapshots to the TUI.
-pub(crate) async fn run_proofs_poller(
+pub async fn run_proofs_poller(
     proofs_config: ProofsConfig,
     l1_rpc: Url,
     l2_rpc: Url,

--- a/crates/infra/basectl/src/tui/app_frame.rs
+++ b/crates/infra/basectl/src/tui/app_frame.rs
@@ -11,7 +11,7 @@ const HELP_SIDEBAR_WIDTH: u16 = 30;
 
 /// Layout regions produced by splitting the terminal area.
 #[derive(Debug)]
-pub(crate) struct AppLayout {
+pub struct AppLayout {
     /// Main content area for the active view.
     pub content: Rect,
     /// Optional help sidebar area.
@@ -20,11 +20,11 @@ pub(crate) struct AppLayout {
 
 /// Handles the top-level application frame layout and help sidebar rendering.
 #[derive(Debug)]
-pub(crate) struct AppFrame;
+pub struct AppFrame;
 
 impl AppFrame {
     /// Splits the terminal area into content and optional help sidebar.
-    pub(crate) fn split_layout(area: Rect, show_help: bool) -> AppLayout {
+    pub fn split_layout(area: Rect, show_help: bool) -> AppLayout {
         if show_help && area.width > HELP_SIDEBAR_WIDTH + 20 {
             let chunks = Layout::default()
                 .direction(Direction::Horizontal)
@@ -38,7 +38,7 @@ impl AppFrame {
     }
 
     /// Renders the network badge (always) and the help sidebar (when visible).
-    pub(crate) fn render(
+    pub fn render(
         f: &mut Frame<'_>,
         layout: &AppLayout,
         config_name: &str,

--- a/crates/infra/basectl/src/tui/app_frame.rs
+++ b/crates/infra/basectl/src/tui/app_frame.rs
@@ -5,7 +5,7 @@ use ratatui::{
 };
 
 use super::Keybinding;
-use crate::commands::common::COLOR_BASE_BLUE;
+use crate::commands::COLOR_BASE_BLUE;
 
 const HELP_SIDEBAR_WIDTH: u16 = 30;
 

--- a/crates/infra/basectl/src/tui/keybinding.rs
+++ b/crates/infra/basectl/src/tui/keybinding.rs
@@ -1,6 +1,6 @@
 /// A keybinding with its key and description for display in help.
 #[derive(Debug, Clone, Copy)]
-pub(crate) struct Keybinding {
+pub struct Keybinding {
     /// Key or key combination label (e.g. "Esc", "↑/↓").
     pub key: &'static str,
     /// Human-readable description of the action.

--- a/crates/infra/basectl/src/tui/mod.rs
+++ b/crates/infra/basectl/src/tui/mod.rs
@@ -2,16 +2,16 @@
 
 /// Application frame layout and help sidebar.
 mod app_frame;
-pub(crate) use app_frame::AppFrame;
+pub use app_frame::AppFrame;
 
 /// Keybinding display types.
 mod keybinding;
-pub(crate) use keybinding::Keybinding;
+pub use keybinding::Keybinding;
 
 /// Terminal setup and teardown utilities.
 mod terminal;
-pub(crate) use terminal::{restore_terminal, setup_terminal};
+pub use terminal::{restore_terminal, setup_terminal};
 
 /// Toast notification system.
 mod toast;
-pub(crate) use toast::{Toast, ToastState};
+pub use toast::{Toast, ToastState};

--- a/crates/infra/basectl/src/tui/mod.rs
+++ b/crates/infra/basectl/src/tui/mod.rs
@@ -2,7 +2,7 @@
 
 /// Application frame layout and help sidebar.
 mod app_frame;
-pub use app_frame::AppFrame;
+pub use app_frame::{AppFrame, AppLayout};
 
 /// Keybinding display types.
 mod keybinding;
@@ -14,4 +14,4 @@ pub use terminal::{restore_terminal, setup_terminal};
 
 /// Toast notification system.
 mod toast;
-pub use toast::{Toast, ToastState};
+pub use toast::{Toast, ToastLevel, ToastState};

--- a/crates/infra/basectl/src/tui/terminal.rs
+++ b/crates/infra/basectl/src/tui/terminal.rs
@@ -9,7 +9,7 @@ use crossterm::{
 use ratatui::prelude::*;
 
 /// Initializes the terminal in raw mode with an alternate screen.
-pub(crate) fn setup_terminal() -> Result<Terminal<CrosstermBackend<Stdout>>> {
+pub fn setup_terminal() -> Result<Terminal<CrosstermBackend<Stdout>>> {
     enable_raw_mode()?;
     let mut stdout = io::stdout();
     execute!(stdout, EnterAlternateScreen, DisableMouseCapture)?;
@@ -19,7 +19,7 @@ pub(crate) fn setup_terminal() -> Result<Terminal<CrosstermBackend<Stdout>>> {
 }
 
 /// Restores the terminal to its original state.
-pub(crate) fn restore_terminal(terminal: &mut Terminal<CrosstermBackend<Stdout>>) -> Result<()> {
+pub fn restore_terminal(terminal: &mut Terminal<CrosstermBackend<Stdout>>) -> Result<()> {
     disable_raw_mode()?;
     execute!(terminal.backend_mut(), LeaveAlternateScreen, DisableMouseCapture)?;
     Ok(())

--- a/crates/infra/basectl/src/tui/toast.rs
+++ b/crates/infra/basectl/src/tui/toast.rs
@@ -12,7 +12,7 @@ const TOAST_DURATION: Duration = Duration::from_secs(5);
 
 /// Toast severity level.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) enum ToastLevel {
+pub enum ToastLevel {
     /// Informational message.
     Info,
     /// Warning message.
@@ -37,7 +37,7 @@ impl ToastLevel {
 
 /// A toast notification message.
 #[derive(Debug, Clone)]
-pub(crate) struct Toast {
+pub struct Toast {
     /// Severity level of this toast.
     pub level: ToastLevel,
     /// Display message text.
@@ -48,17 +48,17 @@ pub(crate) struct Toast {
 
 impl Toast {
     /// Creates a new toast with the given level and message.
-    pub(crate) fn new(level: ToastLevel, message: impl Into<String>) -> Self {
+    pub fn new(level: ToastLevel, message: impl Into<String>) -> Self {
         Self { level, message: message.into(), created_at: Instant::now() }
     }
 
     /// Creates an informational toast.
-    pub(crate) fn info(message: impl Into<String>) -> Self {
+    pub fn info(message: impl Into<String>) -> Self {
         Self::new(ToastLevel::Info, message)
     }
 
     /// Creates a warning toast.
-    pub(crate) fn warning(message: impl Into<String>) -> Self {
+    pub fn warning(message: impl Into<String>) -> Self {
         Self::new(ToastLevel::Warning, message)
     }
 
@@ -69,7 +69,7 @@ impl Toast {
 
 /// State for managing toast notifications
 #[derive(Debug)]
-pub(crate) struct ToastState {
+pub struct ToastState {
     toasts: Vec<Toast>,
     rx: Option<mpsc::Receiver<Toast>>,
 }
@@ -82,17 +82,17 @@ impl Default for ToastState {
 
 impl ToastState {
     /// Creates a new empty toast state.
-    pub(crate) const fn new() -> Self {
+    pub const fn new() -> Self {
         Self { toasts: Vec::new(), rx: None }
     }
 
     /// Sets the channel for receiving toast notifications from background tasks.
-    pub(crate) fn set_channel(&mut self, rx: mpsc::Receiver<Toast>) {
+    pub fn set_channel(&mut self, rx: mpsc::Receiver<Toast>) {
         self.rx = Some(rx);
     }
 
     /// Poll for new toasts and remove expired ones
-    pub(crate) fn poll(&mut self) {
+    pub fn poll(&mut self) {
         // Receive new toasts
         if let Some(ref mut rx) = self.rx {
             while let Ok(toast) = rx.try_recv() {
@@ -105,17 +105,17 @@ impl ToastState {
     }
 
     /// Pushes a toast notification directly.
-    pub(crate) fn push(&mut self, toast: Toast) {
+    pub fn push(&mut self, toast: Toast) {
         self.toasts.push(toast);
     }
 
     /// Returns the most recent active toast, if any.
-    pub(crate) fn current(&self) -> Option<&Toast> {
+    pub fn current(&self) -> Option<&Toast> {
         self.toasts.last()
     }
 
     /// Render toasts in the bottom-right corner of the given area
-    pub(crate) fn render(&self, frame: &mut Frame<'_>, area: Rect) {
+    pub fn render(&self, frame: &mut Frame<'_>, area: Rect) {
         let Some(toast) = self.current() else {
             return;
         };

--- a/crates/infra/websocket-proxy/src/client.rs
+++ b/crates/infra/websocket-proxy/src/client.rs
@@ -8,7 +8,7 @@ use crate::{filter::FilterType, rate_limit::Ticket};
 pub struct ClientConnection {
     client_addr: IpAddr,
     _ticket: Ticket,
-    pub(crate) websocket: WebSocket,
+    pub websocket: WebSocket,
     /// The event filter this client is subscribed to.
     pub filter: FilterType,
 }

--- a/crates/infra/websocket-proxy/src/client.rs
+++ b/crates/infra/websocket-proxy/src/client.rs
@@ -8,6 +8,7 @@ use crate::{filter::FilterType, rate_limit::Ticket};
 pub struct ClientConnection {
     client_addr: IpAddr,
     _ticket: Ticket,
+    /// The WebSocket connection for this client.
     pub websocket: WebSocket,
     /// The event filter this client is subscribed to.
     pub filter: FilterType,


### PR DESCRIPTION
Closes #2062

## Summary
- Replace all pub(crate) with pub across basectl (28 files) and websocket-proxy (1 file)
- Re-export all newly public items from lib.rs per CLAUDE.md conventions
- Fix clippy warnings (unreachable_pub, missing_docs, missing Debug/Default impls)

Previous PR #2083 was closed by the vouch bot. Rebased onto latest main and all clippy warnings resolved.
