### PR TITLE
fix(proof): break infinite recovery loop in TEE prover registration

### DIFF
--- a/bin/prover-registrar/src/cli.rs
+++ b/bin/prover-registrar/src/cli.rs
@@ -20,8 +20,8 @@ use base_proof_tee_nitro_attestation_prover::{
 };
 use base_proof_tee_registrar::{
     AwsDiscoveryConfig, AwsTargetGroupDiscovery, BoundlessConfig, CrlConfig,
-    DEFAULT_CRL_FETCH_TIMEOUT_SECS, DEFAULT_MAX_CONCURRENCY, DEFAULT_MAX_RECOVERY_ATTEMPTS,
-    DEFAULT_MAX_TX_RETRIES, DEFAULT_TX_RETRY_DELAY_SECS,
+    DEFAULT_CRL_FETCH_TIMEOUT_SECS, DEFAULT_MAX_ATTESTATION_AGE_SECS, DEFAULT_MAX_CONCURRENCY,
+    DEFAULT_MAX_RECOVERY_ATTEMPTS, DEFAULT_MAX_TX_RETRIES, DEFAULT_TX_RETRY_DELAY_SECS,
     DEFAULT_UNHEALTHY_REGISTRATION_WINDOW_SECS, DriverConfig, ProverClient, ProvingConfig,
     RegistrarConfig, RegistrarError, RegistrarMetrics, RegistrationDriver, RegistryContractClient,
 };
@@ -204,6 +204,16 @@ struct BoundlessArgs {
     /// `NitroEnclaveVerifier` contract address for certificate caching (optional).
     #[arg(long, env = cli_env!("NITRO_VERIFIER_ADDRESS"))]
     nitro_verifier_address: Option<Address>,
+
+    /// Maximum age (in seconds) of a recovered proof's attestation timestamp
+    /// before it is considered stale. Should be slightly below the on-chain
+    /// `MAX_AGE` to account for clock skew. Defaults to 3300 s (55 minutes).
+    #[arg(
+        long,
+        env = cli_env!("MAX_ATTESTATION_AGE_SECS"),
+        default_value_t = DEFAULT_MAX_ATTESTATION_AGE_SECS
+    )]
+    max_attestation_age_secs: u64,
 }
 
 /// CRL (Certificate Revocation List) checking CLI arguments.
@@ -310,6 +320,9 @@ impl Cli {
                     timeout: Duration::from_secs(self.boundless.boundless_timeout_secs),
                     nitro_verifier_address: self.boundless.nitro_verifier_address,
                     max_recovery_attempts: self.boundless.boundless_max_recovery_attempts,
+                    max_attestation_age: Duration::from_secs(
+                        self.boundless.max_attestation_age_secs,
+                    ),
                 }))
             }
             ProvingMode::Direct => {
@@ -495,7 +508,9 @@ impl Cli {
                 timeout: boundless.timeout,
                 trusted_certs_prefix_len: DEFAULT_TRUSTED_CERTS_PREFIX,
                 max_recovery_attempts: boundless.max_recovery_attempts,
+                max_attestation_age: boundless.max_attestation_age,
                 submit_lock: Arc::new(tokio::sync::Mutex::new(())),
+                recovery_blocked: Arc::new(std::sync::Mutex::new(std::collections::HashSet::new())),
             }),
             ProvingConfig::Direct { ref elf_path } => {
                 let elf = std::fs::read(elf_path).map_err(|e| {

--- a/crates/proof/tee/nitro-attestation-prover/src/boundless.rs
+++ b/crates/proof/tee/nitro-attestation-prover/src/boundless.rs
@@ -17,11 +17,11 @@
 //! [`generate_proof_for_signer`](AttestationProofProvider::generate_proof_for_signer)
 //! override on [`BoundlessProver`] for details.
 
-use std::{fmt, sync::Arc, time::Duration};
+use std::{collections::HashSet, fmt, sync::Arc, time::Duration};
 
 use alloy_primitives::{Address, B256, Bytes, keccak256};
 use alloy_signer_local::PrivateKeySigner;
-use base_proof_tee_nitro_verifier::VerifierInput;
+use base_proof_tee_nitro_verifier::{VerifierInput, VerifierJournal};
 // `boundless-market` re-exports `alloy` (`pub use alloy`) but does not
 // re-export `DynProvider` directly — access it via the SDK's alloy so
 // the type in our alias matches the one inside `Client`.
@@ -77,11 +77,22 @@ pub struct BoundlessProver {
     /// Maximum number of deterministic request-ID slots to probe when
     /// recovering in-flight proofs after an instance rotation.
     pub max_recovery_attempts: u32,
+    /// Maximum age of an attestation timestamp for a recovered proof to
+    /// be considered fresh enough for on-chain submission. Proofs whose
+    /// journal timestamp is older than this are skipped during recovery.
+    /// Should be set slightly below the on-chain `MAX_AGE` to account
+    /// for clock skew and processing time.
+    pub max_attestation_age: Duration,
     /// Serialises the `submit_onchain` call so that concurrent proof
     /// requests do not race on the Boundless wallet nonce. The lock is
     /// released immediately after submission, allowing the long-running
     /// fulfillment poll to proceed concurrently.
     pub submit_lock: Arc<Mutex<()>>,
+    /// Signers whose recovered proofs have been rejected on-chain.
+    /// When a signer is in this set, recovery is skipped and a fresh
+    /// proof is generated instead. Cleared on process restart, giving
+    /// recovered proofs one new attempt after each restart.
+    pub recovery_blocked: Arc<std::sync::Mutex<HashSet<Address>>>,
 }
 
 impl fmt::Debug for BoundlessProver {
@@ -98,6 +109,7 @@ impl fmt::Debug for BoundlessProver {
             .field("timeout", &self.timeout)
             .field("trusted_certs_prefix_len", &self.trusted_certs_prefix_len)
             .field("max_recovery_attempts", &self.max_recovery_attempts)
+            .field("max_attestation_age", &self.max_attestation_age)
             .finish()
     }
 }
@@ -312,6 +324,39 @@ impl BoundlessProver {
         on_chain_expiry.map_or(timeout_at, |e| e.min(timeout_at))
     }
 
+    /// Returns `true` if the proof's attestation timestamp is within
+    /// [`max_attestation_age`](Self::max_attestation_age) of the current
+    /// wall-clock time. Returns `false` (stale) when the journal cannot
+    /// be decoded, since an undecodable proof is unlikely to verify
+    /// on-chain.
+    fn is_journal_fresh(&self, proof: &AttestationProof) -> bool {
+        let journal = match VerifierJournal::decode(&proof.output) {
+            Ok(j) => j,
+            Err(e) => {
+                warn!(error = %e, "failed to decode VerifierJournal from recovered proof, treating as stale");
+                return false;
+            }
+        };
+
+        let now_ms = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_millis() as u64;
+        let age = Duration::from_millis(now_ms.saturating_sub(journal.timestamp));
+
+        if age > self.max_attestation_age {
+            info!(
+                age_secs = age.as_secs(),
+                max_age_secs = self.max_attestation_age.as_secs(),
+                timestamp_ms = journal.timestamp,
+                "recovered proof attestation is stale, skipping"
+            );
+            return false;
+        }
+
+        true
+    }
+
     /// Acquires the submit lock, submits a proof request on-chain, then
     /// waits for fulfillment and fetches the set inclusion receipt.
     ///
@@ -391,6 +436,19 @@ impl AttestationProofProvider for BoundlessProver {
     ) -> Result<AttestationProof> {
         let (client, params) = self.build_client_and_params(attestation_bytes).await?;
 
+        let recovery_is_blocked = self
+            .recovery_blocked
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .contains(&signer_address);
+
+        if recovery_is_blocked {
+            info!(
+                target_signer = %signer_address,
+                "recovery blocked for signer, will skip recovered proofs"
+            );
+        }
+
         // Probe deterministic request-ID slots for recovery.
         let mut first_unknown_attempt: Option<u32> = None;
         for attempt in 0..self.max_recovery_attempts {
@@ -425,8 +483,19 @@ impl AttestationProofProvider for BoundlessProver {
                     // requestDeadline calls, causing a
                     // RequestIsNotLocked revert. Treat this as
                     // evidence the request is in-flight/fulfilled and
-                    // jump directly to wait_and_fetch.
+                    // jump directly to wait_and_fetch — unless
+                    // recovery is blocked.
                     if Self::is_request_not_locked_error(&e) {
+                        if recovery_is_blocked {
+                            debug!(
+                                attempt,
+                                request_id = %request_id,
+                                target_signer = %signer_address,
+                                "RequestIsNotLocked during scan, \
+                                 skipping (recovery blocked)"
+                            );
+                            continue;
+                        }
                         info!(
                             attempt,
                             request_id = %request_id,
@@ -464,6 +533,15 @@ impl AttestationProofProvider for BoundlessProver {
 
             match status {
                 RequestStatus::Locked => {
+                    if recovery_is_blocked {
+                        debug!(
+                            attempt,
+                            request_id = %request_id,
+                            target_signer = %signer_address,
+                            "slot is Locked, skipping (recovery blocked)"
+                        );
+                        continue;
+                    }
                     info!(
                         attempt,
                         request_id = %request_id,
@@ -486,14 +564,15 @@ impl AttestationProofProvider for BoundlessProver {
                     }
                 }
                 RequestStatus::Fulfilled => {
-                    // Safety: the recovered proof is guaranteed to match
-                    // the current `attestation_bytes` because the request-
-                    // ID slots are keyed on `signer_address`, which is
-                    // derived from the enclave's key pair. If the enclave
-                    // restarts it gets a new key pair → new signer address
-                    // → entirely different slots. Same signer address
-                    // therefore implies the same enclave instance and the
-                    // same attestation document.
+                    if recovery_is_blocked {
+                        debug!(
+                            attempt,
+                            request_id = %request_id,
+                            target_signer = %signer_address,
+                            "slot is Fulfilled, skipping (recovery blocked)"
+                        );
+                        continue;
+                    }
                     info!(
                         attempt,
                         request_id = %request_id,
@@ -501,7 +580,12 @@ impl AttestationProofProvider for BoundlessProver {
                         "recovered fulfilled proof, fetching receipt"
                     );
                     match self.fetch_and_encode_receipt(&client, request_id).await {
-                        Ok(proof) => return Ok(proof),
+                        Ok(proof) => {
+                            if !self.is_journal_fresh(&proof) {
+                                continue;
+                            }
+                            return Ok(proof);
+                        }
                         Err(e) => {
                             warn!(
                                 error = %e,
@@ -586,6 +670,14 @@ impl AttestationProofProvider for BoundlessProver {
 
         self.submit_and_wait(&client, params).await
     }
+
+    fn block_recovery_for_signer(&self, signer: Address) {
+        info!(
+            signer = %signer,
+            "blocking proof recovery for signer after on-chain rejection"
+        );
+        self.recovery_blocked.lock().unwrap_or_else(|e| e.into_inner()).insert(signer);
+    }
 }
 
 #[cfg(test)]
@@ -608,6 +700,8 @@ mod tests {
     const DEFAULT_TRUSTED_PREFIX: u8 = 1;
     const TEST_MAX_RECOVERY_ATTEMPTS: u32 = 5;
 
+    const TEST_MAX_ATTESTATION_AGE: Duration = Duration::from_secs(3300);
+
     #[fixture]
     fn prover() -> BoundlessProver {
         BoundlessProver {
@@ -619,7 +713,9 @@ mod tests {
             timeout: TEST_TIMEOUT,
             trusted_certs_prefix_len: DEFAULT_TRUSTED_PREFIX,
             max_recovery_attempts: TEST_MAX_RECOVERY_ATTEMPTS,
+            max_attestation_age: TEST_MAX_ATTESTATION_AGE,
             submit_lock: Arc::new(Mutex::new(())),
+            recovery_blocked: Arc::new(std::sync::Mutex::new(HashSet::new())),
         }
     }
 

--- a/crates/proof/tee/nitro-attestation-prover/src/types.rs
+++ b/crates/proof/tee/nitro-attestation-prover/src/types.rs
@@ -39,6 +39,17 @@ pub trait AttestationProofProvider: Send + Sync {
     ) -> Result<AttestationProof> {
         self.generate_proof(attestation_bytes).await
     }
+
+    /// Marks a signer's recovered proof as failed on-chain.
+    ///
+    /// Called by the driver when a recovered proof for `signer` is rejected
+    /// by the on-chain contract (e.g. `ExecutionReverted`). Implementations
+    /// that support proof recovery should skip recovery for this signer on
+    /// subsequent calls and instead generate a fresh proof.
+    ///
+    /// The default implementation is a no-op for backends that do not
+    /// support recovery (e.g. `DirectProver`).
+    fn block_recovery_for_signer(&self, _signer: Address) {}
 }
 
 #[async_trait]
@@ -53,6 +64,10 @@ impl AttestationProofProvider for Box<dyn AttestationProofProvider> {
         signer_address: Address,
     ) -> Result<AttestationProof> {
         (**self).generate_proof_for_signer(attestation_bytes, signer_address).await
+    }
+
+    fn block_recovery_for_signer(&self, signer: Address) {
+        (**self).block_recovery_for_signer(signer);
     }
 }
 

--- a/crates/proof/tee/registrar/src/config.rs
+++ b/crates/proof/tee/registrar/src/config.rs
@@ -25,6 +25,13 @@ pub struct AwsDiscoveryConfig {
 /// recovering in-flight Boundless proofs after an instance rotation.
 pub const DEFAULT_MAX_RECOVERY_ATTEMPTS: u32 = 5;
 
+/// Default maximum age (in seconds) of a recovered proof's attestation
+/// timestamp before it is considered stale and skipped.
+///
+/// Set to 3300 s (55 minutes), slightly under the on-chain `MAX_AGE` of
+/// 60 minutes, to account for clock skew and processing delays.
+pub const DEFAULT_MAX_ATTESTATION_AGE_SECS: u64 = 3300;
+
 /// Boundless Network configuration for ZK proof generation.
 #[derive(Clone)]
 pub struct BoundlessConfig {
@@ -46,6 +53,10 @@ pub struct BoundlessConfig {
     /// Maximum number of deterministic request-ID slots to probe when
     /// recovering in-flight proofs after an instance rotation.
     pub max_recovery_attempts: u32,
+    /// Maximum age of a recovered proof's attestation timestamp before it
+    /// is considered stale and skipped. Should be set slightly below the
+    /// on-chain `MAX_AGE` to account for clock skew.
+    pub max_attestation_age: Duration,
 }
 
 impl std::fmt::Debug for BoundlessConfig {
@@ -59,6 +70,7 @@ impl std::fmt::Debug for BoundlessConfig {
             .field("timeout", &self.timeout)
             .field("nitro_verifier_address", &self.nitro_verifier_address)
             .field("max_recovery_attempts", &self.max_recovery_attempts)
+            .field("max_attestation_age", &self.max_attestation_age)
             .finish()
     }
 }

--- a/crates/proof/tee/registrar/src/driver.rs
+++ b/crates/proof/tee/registrar/src/driver.rs
@@ -12,7 +12,7 @@ use alloy_sol_types::SolCall;
 use base_proof_contracts::{INitroEnclaveVerifier, ITEEProverRegistry};
 use base_proof_tee_nitro_attestation_prover::AttestationProofProvider;
 use base_proof_tee_nitro_verifier::AttestationReport;
-use base_tx_manager::{TxCandidate, TxManager};
+use base_tx_manager::{TxCandidate, TxManager, TxManagerError};
 use futures::stream::StreamExt;
 use rand::random;
 use tokio_util::sync::CancellationToken;
@@ -579,6 +579,18 @@ where
                     // funds, config errors, fee limits, etc.) cannot be
                     // resolved by retrying with the same calldata.
                     if !e.is_retryable() {
+                        // If the contract reverted execution, the proof
+                        // itself is likely invalid (wrong image ID, stale
+                        // attestation, etc.). Block recovery for this
+                        // signer so the next cycle generates a fresh
+                        // proof instead of re-recovering the same one.
+                        if matches!(e, TxManagerError::ExecutionReverted { .. }) {
+                            warn!(
+                                signer = %signer_address,
+                                "execution reverted, blocking proof recovery for signer"
+                            );
+                            self.proof_provider.block_recovery_for_signer(signer_address);
+                        }
                         return Err(RegistrarError::from(e));
                     }
 

--- a/crates/proof/tee/registrar/src/lib.rs
+++ b/crates/proof/tee/registrar/src/lib.rs
@@ -3,8 +3,8 @@
 
 mod config;
 pub use config::{
-    AwsDiscoveryConfig, BoundlessConfig, CrlConfig, DEFAULT_MAX_RECOVERY_ATTEMPTS, ProvingConfig,
-    RegistrarConfig,
+    AwsDiscoveryConfig, BoundlessConfig, CrlConfig, DEFAULT_MAX_ATTESTATION_AGE_SECS,
+    DEFAULT_MAX_RECOVERY_ATTEMPTS, ProvingConfig, RegistrarConfig,
 };
 
 mod crl;


### PR DESCRIPTION
## Summary

- Fix infinite loop where the TEE registrar repeatedly recovers and resubmits the same invalid Boundless proof every 30 seconds after an `ExecutionReverted` on-chain rejection
- Add in-memory recovery blocking: when `registerSigner()` reverts, mark the signer so subsequent cycles skip recovery and generate a fresh proof instead (resets on restart, giving recovered proofs one new chance per process lifecycle)
- Add attestation freshness check: before submitting a recovered proof, decode the `VerifierJournal` and verify the timestamp is within `--max-attestation-age-secs` (default 3300s / 55min, under the on-chain 60min `MAX_AGE`), skipping stale proofs without hitting the chain

## Changes

| File | What |
|------|------|
| `types.rs` | Add `block_recovery_for_signer()` default no-op method to `AttestationProofProvider` trait + `Box<dyn>` forwarding |
| `boundless.rs` | Add `recovery_blocked` set + `max_attestation_age` field + `is_journal_fresh()` helper; update recovery scan to skip blocked signers and stale proofs |
| `driver.rs` | Call `block_recovery_for_signer()` on `ExecutionReverted` before returning the error |
| `config.rs` | Add `max_attestation_age: Duration` to `BoundlessConfig` + `DEFAULT_MAX_ATTESTATION_AGE_SECS` constant |
| `lib.rs` | Re-export `DEFAULT_MAX_ATTESTATION_AGE_SECS` |
| `cli.rs` | Add `--max-attestation-age-secs` CLI arg, wire into config and `BoundlessProver` construction |

## Testing

- All 193 existing tests pass (50 attestation-prover + 110 registrar + 33 CLI)
- `cargo fmt --check`, `cargo clippy -- -D warnings`, and `cargo check` all clean