### PR TITLE
ktlo(repo): Remove Base Prefix From Chain Config Types

### DIFF
--- a/crates/builder/core/src/flashblocks/context.rs
+++ b/crates/builder/core/src/flashblocks/context.rs
@@ -10,7 +10,7 @@ use alloy_evm::Database;
 use alloy_primitives::{B256, BlockHash, Bytes, TxHash, U256};
 use alloy_rpc_types_eth::Withdrawals;
 use base_access_lists::FBALBuilderDb;
-use base_common_chains::BaseUpgrades;
+use base_common_chains::Upgrades;
 use base_common_consensus::{BaseReceipt, BaseTransactionSigned, BaseTxType, DepositReceipt};
 use base_common_evm::BaseReceiptBuilder;
 use base_execution_chainspec::BaseChainSpec;

--- a/crates/builder/core/src/flashblocks/payload.rs
+++ b/crates/builder/core/src/flashblocks/payload.rs
@@ -14,7 +14,7 @@ use alloy_evm::Database;
 use alloy_primitives::{Address, B256, Bloom, U256, logs_bloom, map::foldhash::HashMap};
 use base_access_lists::{FlashblockAccessList, FlashblockAccessListBuilder};
 use base_builder_publish::WebSocketPublisher;
-use base_common_chains::BaseUpgrades;
+use base_common_chains::Upgrades;
 use base_common_consensus::{BaseReceipt, BaseTransactionSigned};
 use base_common_flashblocks::{
     ExecutionPayloadBaseV1, ExecutionPayloadFlashblockDeltaV1, FlashblocksPayloadV1,

--- a/crates/common/chains/src/chain.rs
+++ b/crates/common/chains/src/chain.rs
@@ -13,7 +13,7 @@ use EthereumHardfork::{
 use alloy_hardforks::{EthereumHardfork, EthereumHardforks, ForkCondition};
 use alloy_primitives::U256;
 
-use crate::{BaseUpgrade, BaseUpgrades};
+use crate::{BaseUpgrade, Upgrades};
 
 /// A type allowing to configure activation [`ForkCondition`]s for a given list of
 /// [`BaseUpgrade`]s.
@@ -27,13 +27,13 @@ use crate::{BaseUpgrade, BaseUpgrades};
 /// chain can undergo a [`BaseUpgrade`] without an [`EthereumHardfork`], but not the other way
 /// around.
 #[derive(Debug, Clone)]
-pub struct BaseChainUpgrades {
+pub struct ChainUpgrades {
     /// Ordered list of upgrade activations.
     forks: Vec<(BaseUpgrade, ForkCondition)>,
 }
 
-impl BaseChainUpgrades {
-    /// Creates a new [`BaseChainUpgrades`] with the given list of forks. The input list is sorted
+impl ChainUpgrades {
+    /// Creates a new [`ChainUpgrades`] with the given list of forks. The input list is sorted
     /// w.r.t. the hardcoded canonicity of [`BaseUpgrade`]s.
     pub fn new(forks: impl IntoIterator<Item = (BaseUpgrade, ForkCondition)>) -> Self {
         let mut forks = forks.into_iter().collect::<Vec<_>>();
@@ -41,33 +41,33 @@ impl BaseChainUpgrades {
         Self { forks }
     }
 
-    /// Creates a new [`BaseChainUpgrades`] with Base mainnet configuration.
+    /// Creates a new [`ChainUpgrades`] with Base mainnet configuration.
     pub fn mainnet() -> Self {
         Self::new(BaseUpgrade::mainnet())
     }
 
-    /// Creates a new [`BaseChainUpgrades`] with Base Sepolia configuration.
+    /// Creates a new [`ChainUpgrades`] with Base Sepolia configuration.
     pub fn sepolia() -> Self {
         Self::new(BaseUpgrade::sepolia())
     }
 
-    /// Creates a new [`BaseChainUpgrades`] with devnet configuration.
+    /// Creates a new [`ChainUpgrades`] with devnet configuration.
     pub fn devnet() -> Self {
         Self::new(BaseUpgrade::devnet())
     }
 
-    /// Creates a new [`BaseChainUpgrades`] with Base devnet-0-sepolia-dev-0 configuration.
+    /// Creates a new [`ChainUpgrades`] with Base devnet-0-sepolia-dev-0 configuration.
     pub fn base_devnet_0_sepolia_dev_0() -> Self {
         Self::new(BaseUpgrade::base_devnet_0_sepolia_dev_0())
     }
 
-    /// Creates a new [`BaseChainUpgrades`] with Base Zeronet configuration.
+    /// Creates a new [`ChainUpgrades`] with Base Zeronet configuration.
     pub fn zeronet() -> Self {
         Self::new(BaseUpgrade::zeronet())
     }
 }
 
-impl EthereumHardforks for BaseChainUpgrades {
+impl EthereumHardforks for ChainUpgrades {
     fn ethereum_fork_activation(&self, fork: EthereumHardfork) -> ForkCondition {
         if self.forks.is_empty() {
             return ForkCondition::Never;
@@ -85,7 +85,7 @@ impl EthereumHardforks for BaseChainUpgrades {
     }
 }
 
-impl BaseUpgrades for BaseChainUpgrades {
+impl Upgrades for ChainUpgrades {
     fn upgrade_activation(&self, fork: BaseUpgrade) -> ForkCondition {
         // check index out of bounds
         if self.forks.len() <= fork.idx() {
@@ -95,7 +95,7 @@ impl BaseUpgrades for BaseChainUpgrades {
     }
 }
 
-impl Index<BaseUpgrade> for BaseChainUpgrades {
+impl Index<BaseUpgrade> for ChainUpgrades {
     type Output = ForkCondition;
 
     fn index(&self, hf: BaseUpgrade) -> &Self::Output {
@@ -114,12 +114,12 @@ impl Index<BaseUpgrade> for BaseChainUpgrades {
     }
 }
 
-impl Index<EthereumHardfork> for BaseChainUpgrades {
+impl Index<EthereumHardfork> for ChainUpgrades {
     type Output = ForkCondition;
 
     fn index(&self, hf: EthereumHardfork) -> &Self::Output {
         match hf {
-            // Dao Hardfork is not needed for BaseChainUpgrades
+            // Dao Hardfork is not needed for ChainUpgrades
             Dao | Bpo1 | Bpo2 | Bpo3 | Bpo4 | Bpo5 | Amsterdam => &ForkCondition::Never,
             Frontier | Homestead | Tangerine | SpuriousDragon | Byzantium | Constantinople
             | Petersburg | Istanbul | MuirGlacier | Berlin => &ForkCondition::ZERO_BLOCK,
@@ -146,153 +146,153 @@ mod tests {
     use alloy_hardforks::EthereumHardfork;
 
     use super::*;
-    use crate::BaseChainConfig;
+    use crate::ChainConfig;
 
     #[test]
     fn base_mainnet_fork_conditions() {
-        let base_mainnet_forks = BaseChainUpgrades::mainnet();
+        let base_mainnet_forks = ChainUpgrades::mainnet();
         assert_eq!(
             base_mainnet_forks[Bedrock],
-            ForkCondition::Block(BaseChainConfig::mainnet().bedrock_block)
+            ForkCondition::Block(ChainConfig::mainnet().bedrock_block)
         );
         assert_eq!(
             base_mainnet_forks[Regolith],
-            ForkCondition::Timestamp(BaseChainConfig::mainnet().regolith_timestamp)
+            ForkCondition::Timestamp(ChainConfig::mainnet().regolith_timestamp)
         );
         assert_eq!(
             base_mainnet_forks[Canyon],
-            ForkCondition::Timestamp(BaseChainConfig::mainnet().canyon_timestamp)
+            ForkCondition::Timestamp(ChainConfig::mainnet().canyon_timestamp)
         );
         assert_eq!(
             base_mainnet_forks[Ecotone],
-            ForkCondition::Timestamp(BaseChainConfig::mainnet().ecotone_timestamp)
+            ForkCondition::Timestamp(ChainConfig::mainnet().ecotone_timestamp)
         );
         assert_eq!(
             base_mainnet_forks[Fjord],
-            ForkCondition::Timestamp(BaseChainConfig::mainnet().fjord_timestamp)
+            ForkCondition::Timestamp(ChainConfig::mainnet().fjord_timestamp)
         );
         assert_eq!(
             base_mainnet_forks[Granite],
-            ForkCondition::Timestamp(BaseChainConfig::mainnet().granite_timestamp)
+            ForkCondition::Timestamp(ChainConfig::mainnet().granite_timestamp)
         );
         assert_eq!(
             base_mainnet_forks[Holocene],
-            ForkCondition::Timestamp(BaseChainConfig::mainnet().holocene_timestamp)
+            ForkCondition::Timestamp(ChainConfig::mainnet().holocene_timestamp)
         );
         assert_eq!(
             base_mainnet_forks[Isthmus],
-            ForkCondition::Timestamp(BaseChainConfig::mainnet().isthmus_timestamp)
+            ForkCondition::Timestamp(ChainConfig::mainnet().isthmus_timestamp)
         );
         assert_eq!(
             base_mainnet_forks[Jovian],
-            ForkCondition::Timestamp(BaseChainConfig::mainnet().jovian_timestamp)
+            ForkCondition::Timestamp(ChainConfig::mainnet().jovian_timestamp)
         );
         assert_eq!(base_mainnet_forks[V1], ForkCondition::Never);
     }
 
     #[test]
     fn base_sepolia_fork_conditions() {
-        let base_sepolia_forks = BaseChainUpgrades::sepolia();
+        let base_sepolia_forks = ChainUpgrades::sepolia();
         assert_eq!(
             base_sepolia_forks[Bedrock],
-            ForkCondition::Block(BaseChainConfig::sepolia().bedrock_block)
+            ForkCondition::Block(ChainConfig::sepolia().bedrock_block)
         );
         assert_eq!(
             base_sepolia_forks[Regolith],
-            ForkCondition::Timestamp(BaseChainConfig::sepolia().regolith_timestamp)
+            ForkCondition::Timestamp(ChainConfig::sepolia().regolith_timestamp)
         );
         assert_eq!(
             base_sepolia_forks[Canyon],
-            ForkCondition::Timestamp(BaseChainConfig::sepolia().canyon_timestamp)
+            ForkCondition::Timestamp(ChainConfig::sepolia().canyon_timestamp)
         );
         assert_eq!(
             base_sepolia_forks[Ecotone],
-            ForkCondition::Timestamp(BaseChainConfig::sepolia().ecotone_timestamp)
+            ForkCondition::Timestamp(ChainConfig::sepolia().ecotone_timestamp)
         );
         assert_eq!(
             base_sepolia_forks[Fjord],
-            ForkCondition::Timestamp(BaseChainConfig::sepolia().fjord_timestamp)
+            ForkCondition::Timestamp(ChainConfig::sepolia().fjord_timestamp)
         );
         assert_eq!(
             base_sepolia_forks[Granite],
-            ForkCondition::Timestamp(BaseChainConfig::sepolia().granite_timestamp)
+            ForkCondition::Timestamp(ChainConfig::sepolia().granite_timestamp)
         );
         assert_eq!(
             base_sepolia_forks[Holocene],
-            ForkCondition::Timestamp(BaseChainConfig::sepolia().holocene_timestamp)
+            ForkCondition::Timestamp(ChainConfig::sepolia().holocene_timestamp)
         );
         assert_eq!(
             base_sepolia_forks[Isthmus],
-            ForkCondition::Timestamp(BaseChainConfig::sepolia().isthmus_timestamp)
+            ForkCondition::Timestamp(ChainConfig::sepolia().isthmus_timestamp)
         );
         assert_eq!(
             base_sepolia_forks.upgrade_activation(Jovian),
-            ForkCondition::Timestamp(BaseChainConfig::sepolia().jovian_timestamp)
+            ForkCondition::Timestamp(ChainConfig::sepolia().jovian_timestamp)
         );
         assert_eq!(
             base_sepolia_forks[V1],
-            ForkCondition::Timestamp(BaseChainConfig::sepolia().base_v1_timestamp.unwrap())
+            ForkCondition::Timestamp(ChainConfig::sepolia().base_v1_timestamp.unwrap())
         );
     }
 
     #[test]
     fn is_jovian_active_at_timestamp() {
-        let base_mainnet_forks = BaseChainUpgrades::mainnet();
+        let base_mainnet_forks = ChainUpgrades::mainnet();
         assert!(
             base_mainnet_forks
-                .is_jovian_active_at_timestamp(BaseChainConfig::mainnet().jovian_timestamp)
+                .is_jovian_active_at_timestamp(ChainConfig::mainnet().jovian_timestamp)
         );
         assert!(
             !base_mainnet_forks
-                .is_jovian_active_at_timestamp(BaseChainConfig::mainnet().jovian_timestamp - 1)
+                .is_jovian_active_at_timestamp(ChainConfig::mainnet().jovian_timestamp - 1)
         );
         assert!(
             base_mainnet_forks
-                .is_jovian_active_at_timestamp(BaseChainConfig::mainnet().jovian_timestamp + 1000)
+                .is_jovian_active_at_timestamp(ChainConfig::mainnet().jovian_timestamp + 1000)
         );
 
-        let base_sepolia_forks = BaseChainUpgrades::sepolia();
+        let base_sepolia_forks = ChainUpgrades::sepolia();
         assert!(
             base_sepolia_forks
-                .is_jovian_active_at_timestamp(BaseChainConfig::sepolia().jovian_timestamp)
+                .is_jovian_active_at_timestamp(ChainConfig::sepolia().jovian_timestamp)
         );
         assert!(
             !base_sepolia_forks
-                .is_jovian_active_at_timestamp(BaseChainConfig::sepolia().jovian_timestamp - 1)
+                .is_jovian_active_at_timestamp(ChainConfig::sepolia().jovian_timestamp - 1)
         );
         assert!(
             base_sepolia_forks
-                .is_jovian_active_at_timestamp(BaseChainConfig::sepolia().jovian_timestamp + 1000)
+                .is_jovian_active_at_timestamp(ChainConfig::sepolia().jovian_timestamp + 1000)
         );
     }
 
     #[test]
     fn is_base_v1_active_at_timestamp() {
         // V1 is not scheduled on mainnet yet (ForkCondition::Never)
-        let base_mainnet_forks = BaseChainUpgrades::mainnet();
+        let base_mainnet_forks = ChainUpgrades::mainnet();
         assert!(!base_mainnet_forks.is_base_v1_active_at_timestamp(0));
         assert!(!base_mainnet_forks.is_base_v1_active_at_timestamp(u64::MAX));
 
         // V1 is scheduled on sepolia at 1776708000
-        let base_sepolia_forks = BaseChainUpgrades::sepolia();
+        let base_sepolia_forks = ChainUpgrades::sepolia();
         assert!(!base_sepolia_forks.is_base_v1_active_at_timestamp(0));
         assert!(!base_sepolia_forks.is_base_v1_active_at_timestamp(1_776_707_999));
         assert!(base_sepolia_forks.is_base_v1_active_at_timestamp(1_776_708_000));
         assert!(base_sepolia_forks.is_base_v1_active_at_timestamp(u64::MAX));
 
         // V1 is active at genesis on devnet (ForkCondition::ZERO_TIMESTAMP)
-        let devnet_forks = BaseChainUpgrades::devnet();
+        let devnet_forks = ChainUpgrades::devnet();
         assert!(devnet_forks.is_base_v1_active_at_timestamp(0));
 
         // V1 is scheduled on devnet-0-sepolia-dev-0 at 1774890000
-        let devnet0_forks = BaseChainUpgrades::base_devnet_0_sepolia_dev_0();
+        let devnet0_forks = ChainUpgrades::base_devnet_0_sepolia_dev_0();
         assert!(!devnet0_forks.is_base_v1_active_at_timestamp(0));
         assert!(!devnet0_forks.is_base_v1_active_at_timestamp(1_774_889_999));
         assert!(devnet0_forks.is_base_v1_active_at_timestamp(1_774_890_000));
         assert!(devnet0_forks.is_base_v1_active_at_timestamp(u64::MAX));
 
         // V1 is scheduled on zeronet at 1775152800
-        let zeronet_forks = BaseChainUpgrades::zeronet();
+        let zeronet_forks = ChainUpgrades::zeronet();
         assert!(!zeronet_forks.is_base_v1_active_at_timestamp(0));
         assert!(!zeronet_forks.is_base_v1_active_at_timestamp(1_775_152_799));
         assert!(zeronet_forks.is_base_v1_active_at_timestamp(1_775_152_800));
@@ -301,31 +301,31 @@ mod tests {
 
     #[test]
     fn osaka_tracks_base_v1_activation() {
-        let base_mainnet_forks = BaseChainUpgrades::mainnet();
+        let base_mainnet_forks = ChainUpgrades::mainnet();
         assert_eq!(
             base_mainnet_forks.ethereum_fork_activation(EthereumHardfork::Osaka),
             ForkCondition::Never
         );
 
-        let base_sepolia_forks = BaseChainUpgrades::sepolia();
+        let base_sepolia_forks = ChainUpgrades::sepolia();
         assert_eq!(
             base_sepolia_forks.ethereum_fork_activation(EthereumHardfork::Osaka),
             ForkCondition::Timestamp(1_776_708_000)
         );
 
-        let devnet_forks = BaseChainUpgrades::devnet();
+        let devnet_forks = ChainUpgrades::devnet();
         assert_eq!(
             devnet_forks.ethereum_fork_activation(EthereumHardfork::Osaka),
             ForkCondition::ZERO_TIMESTAMP
         );
 
-        let devnet0_forks = BaseChainUpgrades::base_devnet_0_sepolia_dev_0();
+        let devnet0_forks = ChainUpgrades::base_devnet_0_sepolia_dev_0();
         assert_eq!(
             devnet0_forks.ethereum_fork_activation(EthereumHardfork::Osaka),
             ForkCondition::Timestamp(1_774_890_000)
         );
 
-        let zeronet_forks = BaseChainUpgrades::zeronet();
+        let zeronet_forks = ChainUpgrades::zeronet();
         assert_eq!(
             zeronet_forks.ethereum_fork_activation(EthereumHardfork::Osaka),
             ForkCondition::Timestamp(1_775_152_800)
@@ -334,7 +334,7 @@ mod tests {
 
     #[test]
     fn test_ethereum_fork_activation_consistency() {
-        let base_mainnet_forks = BaseChainUpgrades::mainnet();
+        let base_mainnet_forks = ChainUpgrades::mainnet();
         for ethereum_hardfork in EthereumHardfork::VARIANTS {
             let _ = base_mainnet_forks.ethereum_fork_activation(*ethereum_hardfork);
         }

--- a/crates/common/chains/src/config.rs
+++ b/crates/common/chains/src/config.rs
@@ -4,7 +4,7 @@ use alloy_primitives::{Address, B256, U256, address, b256, uint};
 
 /// Complete configuration for a Base chain
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct BaseChainConfig {
+pub struct ChainConfig {
     // Identity
     /// L2 chain ID.
     pub chain_id: u64,
@@ -102,7 +102,7 @@ pub struct BaseChainConfig {
     pub genesis_json: &'static str,
 }
 
-impl BaseChainConfig {
+impl ChainConfig {
     /// Base Mainnet chain configuration.
     pub const fn mainnet() -> &'static Self {
         &MAINNET
@@ -145,7 +145,7 @@ impl BaseChainConfig {
     }
 }
 
-const MAINNET: BaseChainConfig = BaseChainConfig {
+const MAINNET: ChainConfig = ChainConfig {
     chain_id: 8453,
     l1_chain_id: 1,
 
@@ -206,7 +206,7 @@ const MAINNET: BaseChainConfig = BaseChainConfig {
     genesis_json: include_str!("../res/genesis/base.json"),
 };
 
-const SEPOLIA: BaseChainConfig = BaseChainConfig {
+const SEPOLIA: ChainConfig = ChainConfig {
     chain_id: 84532,
     l1_chain_id: 11155111,
 
@@ -259,7 +259,7 @@ const SEPOLIA: BaseChainConfig = BaseChainConfig {
     genesis_json: include_str!("../res/genesis/sepolia_base.json"),
 };
 
-const ALPHA: BaseChainConfig = BaseChainConfig {
+const ALPHA: ChainConfig = ChainConfig {
     chain_id: 11763072,
     l1_chain_id: 11155111,
 
@@ -309,7 +309,7 @@ const ALPHA: BaseChainConfig = BaseChainConfig {
     genesis_json: include_str!("../res/genesis/devnet_0_sepolia_dev_0_base.json"),
 };
 
-const DEVNET: BaseChainConfig = BaseChainConfig {
+const DEVNET: ChainConfig = ChainConfig {
     chain_id: 1337,
     l1_chain_id: 900,
 
@@ -359,7 +359,7 @@ const DEVNET: BaseChainConfig = BaseChainConfig {
     genesis_json: include_str!("../res/genesis/dev.json"),
 };
 
-const ZERONET: BaseChainConfig = BaseChainConfig {
+const ZERONET: ChainConfig = ChainConfig {
     chain_id: 763360,
     l1_chain_id: 560048,
 

--- a/crates/common/chains/src/lib.rs
+++ b/crates/common/chains/src/lib.rs
@@ -6,13 +6,13 @@
 extern crate alloc;
 
 mod config;
-pub use config::BaseChainConfig;
+pub use config::ChainConfig;
 
 mod upgrade;
 pub use upgrade::BaseUpgrade;
 
 mod upgrades;
-pub use upgrades::BaseUpgrades;
+pub use upgrades::Upgrades;
 
 mod chain;
-pub use chain::BaseChainUpgrades;
+pub use chain::ChainUpgrades;

--- a/crates/common/chains/src/upgrade.rs
+++ b/crates/common/chains/src/upgrade.rs
@@ -1,6 +1,6 @@
 use alloy_hardforks::{ForkCondition, hardfork};
 
-use crate::BaseChainConfig;
+use crate::ChainConfig;
 
 hardfork!(
     /// The name of a Base network upgrade.
@@ -36,7 +36,7 @@ hardfork!(
 
 impl BaseUpgrade {
     /// Returns the list of upgrades with their activation conditions for the given chain config.
-    pub const fn forks_for(cfg: &BaseChainConfig) -> [(Self, ForkCondition); 10] {
+    pub const fn forks_for(cfg: &ChainConfig) -> [(Self, ForkCondition); 10] {
         let v1 = match cfg.base_v1_timestamp {
             Some(ts) => ForkCondition::Timestamp(ts),
             None => ForkCondition::Never,
@@ -57,27 +57,27 @@ impl BaseUpgrade {
 
     /// Base mainnet list of upgrades.
     pub const fn mainnet() -> [(Self, ForkCondition); 10] {
-        Self::forks_for(BaseChainConfig::mainnet())
+        Self::forks_for(ChainConfig::mainnet())
     }
 
     /// Base Sepolia list of upgrades.
     pub const fn sepolia() -> [(Self, ForkCondition); 10] {
-        Self::forks_for(BaseChainConfig::sepolia())
+        Self::forks_for(ChainConfig::sepolia())
     }
 
     /// Devnet list of upgrades.
     pub const fn devnet() -> [(Self, ForkCondition); 10] {
-        Self::forks_for(BaseChainConfig::devnet())
+        Self::forks_for(ChainConfig::devnet())
     }
 
     /// Base devnet-0-sepolia-dev-0 list of upgrades.
     pub const fn base_devnet_0_sepolia_dev_0() -> [(Self, ForkCondition); 10] {
-        Self::forks_for(BaseChainConfig::alpha())
+        Self::forks_for(ChainConfig::alpha())
     }
 
     /// Base Zeronet list of upgrades.
     pub const fn zeronet() -> [(Self, ForkCondition); 10] {
-        Self::forks_for(BaseChainConfig::zeronet())
+        Self::forks_for(ChainConfig::zeronet())
     }
 
     /// Returns index of `self` in sorted canonical array.
@@ -129,7 +129,7 @@ mod tests {
     /// Reverse lookup to find the upgrade given a chain ID and block timestamp.
     /// Returns the active upgrade at the given timestamp for the specified Base chain.
     fn upgrade_from_chain_and_timestamp(chain: Chain, timestamp: u64) -> Option<BaseUpgrade> {
-        let cfg = BaseChainConfig::by_chain_id(chain.id())?;
+        let cfg = ChainConfig::by_chain_id(chain.id())?;
         Some(match timestamp {
             _ if timestamp < cfg.canyon_timestamp => BaseUpgrade::Regolith,
             _ if timestamp < cfg.ecotone_timestamp => BaseUpgrade::Canyon,
@@ -146,36 +146,12 @@ mod tests {
     #[test]
     fn test_reverse_lookup_base_chains() {
         let test_cases = [
-            (
-                Chain::base_mainnet(),
-                BaseChainConfig::mainnet().canyon_timestamp,
-                BaseUpgrade::Canyon,
-            ),
-            (
-                Chain::base_mainnet(),
-                BaseChainConfig::mainnet().ecotone_timestamp,
-                BaseUpgrade::Ecotone,
-            ),
-            (
-                Chain::base_mainnet(),
-                BaseChainConfig::mainnet().jovian_timestamp,
-                BaseUpgrade::Jovian,
-            ),
-            (
-                Chain::base_sepolia(),
-                BaseChainConfig::sepolia().canyon_timestamp,
-                BaseUpgrade::Canyon,
-            ),
-            (
-                Chain::base_sepolia(),
-                BaseChainConfig::sepolia().ecotone_timestamp,
-                BaseUpgrade::Ecotone,
-            ),
-            (
-                Chain::base_sepolia(),
-                BaseChainConfig::sepolia().jovian_timestamp,
-                BaseUpgrade::Jovian,
-            ),
+            (Chain::base_mainnet(), ChainConfig::mainnet().canyon_timestamp, BaseUpgrade::Canyon),
+            (Chain::base_mainnet(), ChainConfig::mainnet().ecotone_timestamp, BaseUpgrade::Ecotone),
+            (Chain::base_mainnet(), ChainConfig::mainnet().jovian_timestamp, BaseUpgrade::Jovian),
+            (Chain::base_sepolia(), ChainConfig::sepolia().canyon_timestamp, BaseUpgrade::Canyon),
+            (Chain::base_sepolia(), ChainConfig::sepolia().ecotone_timestamp, BaseUpgrade::Ecotone),
+            (Chain::base_sepolia(), ChainConfig::sepolia().jovian_timestamp, BaseUpgrade::Jovian),
         ];
 
         for (chain_id, timestamp, expected) in test_cases {

--- a/crates/common/chains/src/upgrades.rs
+++ b/crates/common/chains/src/upgrades.rs
@@ -4,7 +4,7 @@ use crate::BaseUpgrade;
 
 /// Extends [`EthereumHardforks`] with Base upgrade helper methods.
 #[auto_impl::auto_impl(&, Arc)]
-pub trait BaseUpgrades: EthereumHardforks {
+pub trait Upgrades: EthereumHardforks {
     /// Retrieves [`ForkCondition`] by a [`BaseUpgrade`]. If `fork` is not present, returns
     /// [`ForkCondition::Never`].
     fn upgrade_activation(&self, fork: BaseUpgrade) -> ForkCondition;

--- a/crates/common/evm/src/canyon.rs
+++ b/crates/common/evm/src/canyon.rs
@@ -1,6 +1,6 @@
 use alloy_evm::Database;
 use alloy_primitives::{Address, B256, Bytes, address, b256, hex};
-use base_common_chains::BaseUpgrades;
+use base_common_chains::Upgrades;
 use revm::{DatabaseCommit, primitives::HashMap, state::Bytecode};
 
 /// The address of the create2 deployer
@@ -19,7 +19,7 @@ const CREATE_2_DEPLOYER_BYTECODE: [u8; 1584] = hex!(
 /// deployer contract. This is done by directly setting the code of the create2 deployer account
 /// prior to executing any transactions on the timestamp activation of the fork.
 pub fn ensure_create2_deployer<DB>(
-    chain_spec: impl BaseUpgrades,
+    chain_spec: impl Upgrades,
     timestamp: u64,
     db: &mut DB,
 ) -> Result<(), DB::Error>

--- a/crates/common/evm/src/executor.rs
+++ b/crates/common/evm/src/executor.rs
@@ -13,7 +13,7 @@ use alloy_evm::{
     eth::{EthTxResult, receipt_builder::ReceiptBuilderCtx},
 };
 use alloy_primitives::Address;
-use base_common_chains::BaseUpgrades;
+use base_common_chains::Upgrades;
 use base_common_consensus::DepositReceipt;
 use base_common_flz::tx_estimated_size_fjord as estimate_tx_compressed_size;
 use base_revm::{DEPOSIT_TRANSACTION_TYPE, L1_BLOCK_CONTRACT, L1BlockInfo};
@@ -76,7 +76,7 @@ impl<E, R, Spec> BaseBlockExecutor<E, R, Spec>
 where
     E: Evm,
     R: BaseReceiptBuilder,
-    Spec: BaseUpgrades + Clone,
+    Spec: Upgrades + Clone,
 {
     /// Creates a new [`BaseBlockExecutor`].
     pub fn new(evm: E, ctx: BaseBlockExecutionCtx, spec: Spec, receipt_builder: R) -> Self {
@@ -102,7 +102,7 @@ where
             Tx: FromRecoveredTx<R::Transaction> + FromTxWithEncoded<R::Transaction> + BaseTxEnv,
         >,
     R: BaseReceiptBuilder<Transaction: Transaction + Encodable2718, Receipt: TxReceipt>,
-    Spec: BaseUpgrades,
+    Spec: Upgrades,
 {
     fn jovian_da_footprint_estimation(
         &mut self,
@@ -137,7 +137,7 @@ where
             Tx: FromRecoveredTx<R::Transaction> + FromTxWithEncoded<R::Transaction> + BaseTxEnv,
         >,
     R: BaseReceiptBuilder<Transaction: Transaction + Encodable2718, Receipt: TxReceipt>,
-    Spec: BaseUpgrades,
+    Spec: Upgrades,
 {
     type Transaction = R::Transaction;
     type Receipt = R::Receipt;
@@ -358,7 +358,7 @@ mod tests {
     use alloy_evm::{EvmEnv, EvmFactory, ToTxEnv, block::BlockExecutorFactory};
     use alloy_hardforks::ForkCondition;
     use alloy_primitives::{Address, Signature, U256, uint};
-    use base_common_chains::{BaseChainUpgrades, BaseUpgrade};
+    use base_common_chains::{BaseUpgrade, ChainUpgrades};
     use base_common_consensus::BaseTxEnvelope;
     use base_revm::{
         BASE_FEE_SCALAR_OFFSET, Builder, DefaultOp, ECOTONE_L1_BLOB_BASE_FEE_SLOT,
@@ -381,7 +381,7 @@ mod tests {
     fn test_with_encoded() {
         let executor_factory = BaseBlockExecutorFactory::new(
             AlloyReceiptBuilder::default(),
-            BaseChainUpgrades::mainnet(),
+            ChainUpgrades::mainnet(),
             BaseEvmFactory::default(),
         );
         let mut db =
@@ -448,13 +448,13 @@ mod tests {
     fn build_executor<'a>(
         db: &'a mut revm::database::State<InMemoryDB>,
         receipt_builder: &'a AlloyReceiptBuilder,
-        op_chain_hardforks: &'a BaseChainUpgrades,
+        op_chain_hardforks: &'a ChainUpgrades,
         gas_limit: u64,
         jovian_timestamp: u64,
     ) -> BaseBlockExecutor<
         BaseEvm<&'a mut revm::database::State<InMemoryDB>, NoOpInspector>,
         &'a AlloyReceiptBuilder,
-        &'a BaseChainUpgrades,
+        &'a ChainUpgrades,
     > {
         let ctx = Context::op()
             .with_db(db)
@@ -487,7 +487,7 @@ mod tests {
         const JOVIAN_TIMESTAMP: u64 = 1746806402;
 
         let mut db = prepare_jovian_db(DA_FOOTPRINT_GAS_SCALAR);
-        let op_chain_hardforks = BaseChainUpgrades::new(
+        let op_chain_hardforks = ChainUpgrades::new(
             BaseUpgrade::mainnet()
                 .into_iter()
                 .chain(vec![(BaseUpgrade::Jovian, ForkCondition::Timestamp(JOVIAN_TIMESTAMP))]),
@@ -532,7 +532,7 @@ mod tests {
         const GAS_LIMIT: u64 = 100;
 
         let mut db = prepare_jovian_db(DA_FOOTPRINT_GAS_SCALAR);
-        let op_chain_hardforks = BaseChainUpgrades::new(
+        let op_chain_hardforks = ChainUpgrades::new(
             BaseUpgrade::mainnet()
                 .into_iter()
                 .chain(vec![(BaseUpgrade::Jovian, ForkCondition::Timestamp(JOVIAN_TIMESTAMP))]),
@@ -589,7 +589,7 @@ mod tests {
         const GAS_LIMIT: u64 = 200_000;
 
         let mut db = prepare_jovian_db(DA_FOOTPRINT_GAS_SCALAR);
-        let op_chain_hardforks = BaseChainUpgrades::new(
+        let op_chain_hardforks = ChainUpgrades::new(
             BaseUpgrade::mainnet()
                 .into_iter()
                 .chain(vec![(BaseUpgrade::Jovian, ForkCondition::Timestamp(JOVIAN_TIMESTAMP))]),

--- a/crates/common/evm/src/executor_factory.rs
+++ b/crates/common/evm/src/executor_factory.rs
@@ -4,7 +4,7 @@ use alloy_evm::{
     Database, EvmFactory, FromRecoveredTx, FromTxWithEncoded,
     block::{BlockExecutorFactory, BlockExecutorFor},
 };
-use base_common_chains::{BaseChainUpgrades, BaseUpgrades};
+use base_common_chains::{ChainUpgrades, Upgrades};
 use revm::{Inspector, database::State};
 
 use crate::{
@@ -16,7 +16,7 @@ use crate::{
 #[derive(Debug, Clone, Default, Copy)]
 pub struct BaseBlockExecutorFactory<
     R = AlloyReceiptBuilder,
-    Spec = BaseChainUpgrades,
+    Spec = ChainUpgrades,
     EvmFactory = BaseEvmFactory,
 > {
     /// Receipt builder.
@@ -53,7 +53,7 @@ impl<R, Spec, EvmFactory> BaseBlockExecutorFactory<R, Spec, EvmFactory> {
 impl<R, Spec, EvmF> BlockExecutorFactory for BaseBlockExecutorFactory<R, Spec, EvmF>
 where
     R: BaseReceiptBuilder<Transaction: Transaction + Encodable2718, Receipt: TxReceipt>,
-    Spec: BaseUpgrades,
+    Spec: Upgrades,
     EvmF: EvmFactory<
         Tx: FromRecoveredTx<R::Transaction> + FromTxWithEncoded<R::Transaction> + BaseTxEnv,
     >,

--- a/crates/common/evm/src/spec_id.rs
+++ b/crates/common/evm/src/spec_id.rs
@@ -1,9 +1,9 @@
 use alloy_consensus::BlockHeader;
-use base_common_chains::BaseUpgrades;
+use base_common_chains::Upgrades;
 use base_revm::OpSpecId;
 
 /// Map the latest active hardfork at the given header to a revm [`OpSpecId`].
-pub fn spec(chain_spec: impl BaseUpgrades, header: impl BlockHeader) -> OpSpecId {
+pub fn spec(chain_spec: impl Upgrades, header: impl BlockHeader) -> OpSpecId {
     spec_by_timestamp_after_bedrock(chain_spec, header.timestamp())
 }
 
@@ -13,7 +13,7 @@ pub fn spec(chain_spec: impl BaseUpgrades, header: impl BlockHeader) -> OpSpecId
 ///
 /// This is only intended to be used after the Bedrock, when hardforks are activated by
 /// timestamp.
-pub fn spec_by_timestamp_after_bedrock(chain_spec: impl BaseUpgrades, timestamp: u64) -> OpSpecId {
+pub fn spec_by_timestamp_after_bedrock(chain_spec: impl Upgrades, timestamp: u64) -> OpSpecId {
     if chain_spec.is_base_v1_active_at_timestamp(timestamp) {
         OpSpecId::BASE_V1
     } else if chain_spec.is_jovian_active_at_timestamp(timestamp) {

--- a/crates/common/rpc-types/src/genesis.rs
+++ b/crates/common/rpc-types/src/genesis.rs
@@ -6,14 +6,14 @@ use serde::de::Error;
 /// Container type for all Base chain-specific fields in a genesis file.
 #[derive(Default, Debug, Clone, Copy, Eq, PartialEq, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub struct BaseChainInfo {
+pub struct ChainInfo {
     /// Genesis information
-    pub genesis_info: Option<BaseGenesisInfo>,
+    pub genesis_info: Option<GenesisInfo>,
     /// Base fee information
-    pub base_fee_info: Option<BaseFeeInfo>,
+    pub base_fee_info: Option<FeeInfo>,
 }
 
-impl BaseChainInfo {
+impl ChainInfo {
     /// Extracts the Base chain-specific fields from a genesis file. These fields are expected to be
     /// contained in the `genesis.config` under `extra_fields` property.
     pub fn extract_from(others: &OtherFields) -> Option<Self> {
@@ -21,12 +21,12 @@ impl BaseChainInfo {
     }
 }
 
-impl TryFrom<&OtherFields> for BaseChainInfo {
+impl TryFrom<&OtherFields> for ChainInfo {
     type Error = serde_json::Error;
 
     fn try_from(others: &OtherFields) -> Result<Self, Self::Error> {
-        let genesis_info = BaseGenesisInfo::try_from(others).ok();
-        let base_fee_info = BaseFeeInfo::try_from(others).ok();
+        let genesis_info = GenesisInfo::try_from(others).ok();
+        let base_fee_info = FeeInfo::try_from(others).ok();
 
         Ok(Self { genesis_info, base_fee_info })
     }
@@ -35,7 +35,7 @@ impl TryFrom<&OtherFields> for BaseChainInfo {
 /// Base-specific hardfork configuration in a genesis file.
 #[derive(Default, Debug, Clone, Copy, Eq, PartialEq, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub struct BaseHardforkInfo {
+pub struct HardforkInfo {
     /// Base V1 hardfork timestamp.
     pub v1: Option<u64>,
 }
@@ -43,7 +43,7 @@ pub struct BaseHardforkInfo {
 /// The Base chain-specific genesis block specification.
 #[derive(Default, Debug, Clone, Copy, Eq, PartialEq, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub struct BaseGenesisInfo {
+pub struct GenesisInfo {
     /// bedrock block number
     pub bedrock_block: Option<u64>,
     /// regolith hardfork timestamp
@@ -64,17 +64,17 @@ pub struct BaseGenesisInfo {
     pub jovian_time: Option<u64>,
     /// Base-specific hardfork activation times.
     #[serde(default)]
-    pub base: BaseHardforkInfo,
+    pub base: HardforkInfo,
 }
 
-impl BaseGenesisInfo {
+impl GenesisInfo {
     /// Extract the Base chain-specific genesis info from a genesis file.
     pub fn extract_from(others: &OtherFields) -> Option<Self> {
         Self::try_from(others).ok()
     }
 }
 
-impl TryFrom<&OtherFields> for BaseGenesisInfo {
+impl TryFrom<&OtherFields> for GenesisInfo {
     type Error = serde_json::Error;
 
     fn try_from(others: &OtherFields) -> Result<Self, Self::Error> {
@@ -85,7 +85,7 @@ impl TryFrom<&OtherFields> for BaseGenesisInfo {
 /// The Base chain-specific base fee specification.
 #[derive(Default, Debug, Clone, Copy, Eq, PartialEq, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub struct BaseFeeInfo {
+pub struct FeeInfo {
     /// EIP-1559 elasticity
     pub eip1559_elasticity: Option<u64>,
     /// EIP-1559 denominator
@@ -94,7 +94,7 @@ pub struct BaseFeeInfo {
     pub eip1559_denominator_canyon: Option<u64>,
 }
 
-impl BaseFeeInfo {
+impl FeeInfo {
     /// Extracts the Base chain base fee info by looking for the `optimism` key. It is intended to be
     /// parsed from a genesis file.
     pub fn extract_from(others: &OtherFields) -> Option<Self> {
@@ -102,7 +102,7 @@ impl BaseFeeInfo {
     }
 }
 
-impl TryFrom<&OtherFields> for BaseFeeInfo {
+impl TryFrom<&OtherFields> for FeeInfo {
     type Error = serde_json::Error;
 
     fn try_from(others: &OtherFields) -> Result<Self, Self::Error> {
@@ -133,11 +133,11 @@ mod tests {
         "#;
 
         let others: OtherFields = serde_json::from_str(genesis_info).unwrap();
-        let genesis_info = BaseGenesisInfo::extract_from(&others).unwrap();
+        let genesis_info = GenesisInfo::extract_from(&others).unwrap();
 
         assert_eq!(
             genesis_info,
-            BaseGenesisInfo {
+            GenesisInfo {
                 bedrock_block: Some(10),
                 regolith_time: Some(12),
                 canyon_time: Some(0),
@@ -147,7 +147,7 @@ mod tests {
                 holocene_time: None,
                 isthmus_time: None,
                 jovian_time: None,
-                base: BaseHardforkInfo { v1: Some(14) },
+                base: HardforkInfo { v1: Some(14) },
             }
         );
     }
@@ -165,11 +165,11 @@ mod tests {
         "#;
 
         let others: OtherFields = serde_json::from_str(base_fee_info).unwrap();
-        let base_fee_info = BaseFeeInfo::extract_from(&others).unwrap();
+        let base_fee_info = FeeInfo::extract_from(&others).unwrap();
 
         assert_eq!(
             base_fee_info,
-            BaseFeeInfo {
+            FeeInfo {
                 eip1559_elasticity: Some(0),
                 eip1559_denominator: Some(8),
                 eip1559_denominator_canyon: Some(8),
@@ -196,12 +196,12 @@ mod tests {
         "#;
 
         let others: OtherFields = serde_json::from_str(chain_info).unwrap();
-        let chain_info = BaseChainInfo::extract_from(&others).unwrap();
+        let chain_info = ChainInfo::extract_from(&others).unwrap();
 
         assert_eq!(
             chain_info,
-            BaseChainInfo {
-                genesis_info: Some(BaseGenesisInfo {
+            ChainInfo {
+                genesis_info: Some(GenesisInfo {
                     bedrock_block: Some(10),
                     regolith_time: Some(12),
                     canyon_time: Some(0),
@@ -211,9 +211,9 @@ mod tests {
                     holocene_time: None,
                     isthmus_time: None,
                     jovian_time: None,
-                    base: BaseHardforkInfo { v1: Some(14) },
+                    base: HardforkInfo { v1: Some(14) },
                 }),
-                base_fee_info: Some(BaseFeeInfo {
+                base_fee_info: Some(FeeInfo {
                     eip1559_elasticity: None,
                     eip1559_denominator: Some(8),
                     eip1559_denominator_canyon: Some(8),
@@ -221,12 +221,12 @@ mod tests {
             }
         );
 
-        let chain_info = BaseChainInfo::try_from(&others).unwrap();
+        let chain_info = ChainInfo::try_from(&others).unwrap();
 
         assert_eq!(
             chain_info,
-            BaseChainInfo {
-                genesis_info: Some(BaseGenesisInfo {
+            ChainInfo {
+                genesis_info: Some(GenesisInfo {
                     bedrock_block: Some(10),
                     regolith_time: Some(12),
                     canyon_time: Some(0),
@@ -236,9 +236,9 @@ mod tests {
                     holocene_time: None,
                     isthmus_time: None,
                     jovian_time: None,
-                    base: BaseHardforkInfo { v1: Some(14) },
+                    base: HardforkInfo { v1: Some(14) },
                 }),
-                base_fee_info: Some(BaseFeeInfo {
+                base_fee_info: Some(FeeInfo {
                     eip1559_elasticity: None,
                     eip1559_denominator: Some(8),
                     eip1559_denominator_canyon: Some(8),
@@ -264,12 +264,12 @@ mod tests {
         "#;
 
         let others: OtherFields = serde_json::from_str(chain_info).unwrap();
-        let chain_info = BaseChainInfo::extract_from(&others).unwrap();
+        let chain_info = ChainInfo::extract_from(&others).unwrap();
 
         assert_eq!(
             chain_info,
-            BaseChainInfo {
-                genesis_info: Some(BaseGenesisInfo {
+            ChainInfo {
+                genesis_info: Some(GenesisInfo {
                     bedrock_block: Some(10),
                     regolith_time: Some(12),
                     canyon_time: Some(0),
@@ -279,7 +279,7 @@ mod tests {
                     holocene_time: Some(0),
                     isthmus_time: Some(0),
                     jovian_time: Some(0),
-                    base: BaseHardforkInfo::default(),
+                    base: HardforkInfo::default(),
                 }),
                 base_fee_info: None,
             }

--- a/crates/common/rpc-types/src/lib.rs
+++ b/crates/common/rpc-types/src/lib.rs
@@ -11,7 +11,7 @@
 extern crate alloc;
 
 mod genesis;
-pub use genesis::{BaseChainInfo, BaseFeeInfo, BaseGenesisInfo, BaseHardforkInfo};
+pub use genesis::{ChainInfo, FeeInfo, GenesisInfo, HardforkInfo};
 
 mod receipt;
 pub use receipt::{BaseTransactionReceipt, L1BlockInfo, TransactionReceiptFields};

--- a/crates/consensus/disc/src/driver.rs
+++ b/crates/consensus/disc/src/driver.rs
@@ -378,7 +378,7 @@ impl Discv5Driver {
 mod tests {
     use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 
-    use base_common_chains::BaseChainConfig;
+    use base_common_chains::ChainConfig;
     use discv5::{
         ConfigBuilder,
         enr::{CombinedKey, CombinedPublicKey},
@@ -398,13 +398,13 @@ mod tests {
         let socket = SocketAddr::new(IpAddr::V4(Ipv4Addr::UNSPECIFIED), 0);
         let discovery = Discv5Driver::builder(
             LocalNode::new(secret_key, IpAddr::V4(Ipv4Addr::UNSPECIFIED), 0, 0),
-            BaseChainConfig::sepolia().chain_id,
+            ChainConfig::sepolia().chain_id,
             ConfigBuilder::new(socket.into()).build(),
         )
         .build()
         .expect("Failed to build discovery service");
         let (handle, _) = discovery.start();
-        assert_eq!(handle.chain_id, BaseChainConfig::sepolia().chain_id);
+        assert_eq!(handle.chain_id, ChainConfig::sepolia().chain_id);
     }
 
     #[tokio::test]
@@ -420,7 +420,7 @@ mod tests {
         };
         let mut discovery = Discv5Driver::builder(
             LocalNode::new(secret_key, IpAddr::V4(Ipv4Addr::UNSPECIFIED), 0, 0),
-            BaseChainConfig::sepolia().chain_id,
+            ChainConfig::sepolia().chain_id,
             ConfigBuilder::new(socket.into()).build(),
         )
         .with_bootnodes(BootNodes::testnet())
@@ -435,7 +435,7 @@ mod tests {
         Discv5Driver::bootstrap_peers(
             discovery.bootstore,
             discovery.bootnodes,
-            BaseChainConfig::sepolia().chain_id,
+            ChainConfig::sepolia().chain_id,
             &discovery.disc,
         )
         .await;
@@ -450,9 +450,7 @@ mod tests {
             .iter()
             .filter_map(|node| match node {
                 BootNode::Enr(enr) => {
-                    if EnrValidation::validate(enr, BaseChainConfig::sepolia().chain_id)
-                        .is_invalid()
-                    {
+                    if EnrValidation::validate(enr, ChainConfig::sepolia().chain_id).is_invalid() {
                         return None;
                     }
                     Some(enr.public_key())
@@ -493,9 +491,7 @@ mod tests {
             .iter()
             .filter_map(|node| match node {
                 BootNode::Enr(enr) => {
-                    if EnrValidation::validate(enr, BaseChainConfig::mainnet().chain_id)
-                        .is_invalid()
-                    {
+                    if EnrValidation::validate(enr, ChainConfig::mainnet().chain_id).is_invalid() {
                         return None;
                     }
                     Some(enr.public_key())
@@ -520,7 +516,7 @@ mod tests {
 
         let mut discovery = Discv5Driver::builder(
             LocalNode::new(secret_key, IpAddr::V4(Ipv4Addr::UNSPECIFIED), 0, 0),
-            BaseChainConfig::mainnet().chain_id,
+            ChainConfig::mainnet().chain_id,
             ConfigBuilder::new(socket.into()).build(),
         )
         .with_bootnodes(BootNodes::mainnet())
@@ -535,7 +531,7 @@ mod tests {
         Discv5Driver::bootstrap_peers(
             discovery.bootstore,
             discovery.bootnodes,
-            BaseChainConfig::mainnet().chain_id,
+            ChainConfig::mainnet().chain_id,
             &discovery.disc,
         )
         .await;

--- a/crates/consensus/engine/src/task_queue/tasks/get_payload/task_test.rs
+++ b/crates/consensus/engine/src/task_queue/tasks/get_payload/task_test.rs
@@ -10,7 +10,7 @@ use alloy_rpc_types_engine::{
 use base_common_rpc_types_engine::{
     BaseExecutionPayload, BaseExecutionPayloadEnvelopeV5, BaseExecutionPayloadV4,
 };
-use base_consensus_genesis::{BaseHardforkConfig, HardForkConfig, RollupConfig};
+use base_consensus_genesis::{HardForkConfig, HardforkConfig, RollupConfig};
 use rstest::rstest;
 use tokio::sync::mpsc;
 
@@ -153,10 +153,7 @@ async fn test_get_payload_v5_success(#[values(true, false)] with_channel: bool) 
     // Activate Base V1 (Osaka) at the default attributes timestamp (2000) so that
     // `EngineGetPayloadVersion::V5` is selected.
     let cfg = Arc::new(RollupConfig {
-        hardforks: HardForkConfig {
-            base: BaseHardforkConfig { v1: Some(2000) },
-            ..Default::default()
-        },
+        hardforks: HardForkConfig { base: HardforkConfig { v1: Some(2000) }, ..Default::default() },
         ..Default::default()
     });
 

--- a/crates/consensus/engine/src/versions.rs
+++ b/crates/consensus/engine/src/versions.rs
@@ -110,7 +110,7 @@ impl EngineGetPayloadVersion {
 
 #[cfg(test)]
 mod tests {
-    use base_consensus_genesis::{BaseHardforkConfig, HardForkConfig};
+    use base_consensus_genesis::{HardForkConfig, HardforkConfig};
 
     use super::*;
 
@@ -119,7 +119,7 @@ mod tests {
             hardforks: HardForkConfig {
                 ecotone_time: Some(20),
                 jovian_time: Some(30),
-                base: BaseHardforkConfig { v1: Some(40) },
+                base: HardforkConfig { v1: Some(40) },
                 ..Default::default()
             },
             ..Default::default()

--- a/crates/consensus/genesis/src/chain/hardfork.rs
+++ b/crates/consensus/genesis/src/chain/hardfork.rs
@@ -3,21 +3,21 @@
 use alloc::string::{String, ToString};
 use core::fmt::Display;
 
-use base_common_chains::BaseChainConfig;
+use base_common_chains::ChainConfig;
 
 /// Hardfork configuration for Base-specific upgrades.
 #[derive(Debug, Copy, Clone, Default, Hash, Eq, PartialEq)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(deny_unknown_fields))]
-pub struct BaseHardforkConfig {
+pub struct HardforkConfig {
     /// `v1` sets the activation time for the Base V1 network upgrade.
     /// Active if `v1` != None && L2 block timestamp >= `Some(v1)`, inactive otherwise.
     #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
     pub v1: Option<u64>,
 }
 
-impl BaseHardforkConfig {
+impl HardforkConfig {
     /// Returns true if no Base-specific hardforks are configured.
     pub const fn is_empty(&self) -> bool {
         self.v1.is_none()
@@ -91,9 +91,9 @@ pub struct HardForkConfig {
     /// `base` contains Base-specific hardfork activation times.
     #[cfg_attr(
         feature = "serde",
-        serde(default, skip_serializing_if = "BaseHardforkConfig::is_empty")
+        serde(default, skip_serializing_if = "HardforkConfig::is_empty")
     )]
-    pub base: BaseHardforkConfig,
+    pub base: HardforkConfig,
 }
 
 impl Display for HardForkConfig {
@@ -131,8 +131,8 @@ impl HardForkConfig {
     }
 }
 
-impl From<&BaseChainConfig> for HardForkConfig {
-    fn from(cfg: &BaseChainConfig) -> Self {
+impl From<&ChainConfig> for HardForkConfig {
+    fn from(cfg: &ChainConfig) -> Self {
         Self {
             regolith_time: Some(cfg.regolith_timestamp),
             canyon_time: Some(cfg.canyon_timestamp),
@@ -144,7 +144,7 @@ impl From<&BaseChainConfig> for HardForkConfig {
             pectra_blob_schedule_time: cfg.pectra_blob_schedule_timestamp,
             isthmus_time: Some(cfg.isthmus_timestamp),
             jovian_time: Some(cfg.jovian_timestamp),
-            base: BaseHardforkConfig { v1: cfg.base_v1_timestamp },
+            base: HardforkConfig { v1: cfg.base_v1_timestamp },
         }
     }
 }
@@ -178,7 +178,7 @@ mod tests {
             pectra_blob_schedule_time: None,
             isthmus_time: None,
             jovian_time: None,
-            base: BaseHardforkConfig::default(),
+            base: HardforkConfig::default(),
         };
 
         let deserialized: HardForkConfig = serde_json::from_str(raw).unwrap();
@@ -225,7 +225,7 @@ mod tests {
             pectra_blob_schedule_time: None,
             isthmus_time: None,
             jovian_time: None,
-            base: BaseHardforkConfig::default(),
+            base: HardforkConfig::default(),
         };
 
         let deserialized: HardForkConfig = toml::from_str(raw).unwrap();
@@ -259,7 +259,7 @@ mod tests {
             pectra_blob_schedule_time: Some(8),
             isthmus_time: Some(9),
             jovian_time: Some(10),
-            base: BaseHardforkConfig { v1: Some(11) },
+            base: HardforkConfig { v1: Some(11) },
         };
 
         let mut iter = hardforks.iter();

--- a/crates/consensus/genesis/src/chain/mod.rs
+++ b/crates/consensus/genesis/src/chain/mod.rs
@@ -4,7 +4,7 @@ mod addresses;
 pub use addresses::AddressList;
 
 mod hardfork;
-pub use hardfork::{BaseHardforkConfig, HardForkConfig};
+pub use hardfork::{HardForkConfig, HardforkConfig};
 
 mod roles;
 pub use roles::Roles;

--- a/crates/consensus/genesis/src/genesis.rs
+++ b/crates/consensus/genesis/src/genesis.rs
@@ -1,7 +1,7 @@
 //! Genesis types.
 
 use alloy_eips::eip1898::BlockNumHash;
-use base_common_chains::BaseChainConfig;
+use base_common_chains::ChainConfig;
 
 use crate::SystemConfig;
 
@@ -20,8 +20,8 @@ pub struct ChainGenesis {
     pub system_config: Option<SystemConfig>,
 }
 
-impl From<&BaseChainConfig> for ChainGenesis {
-    fn from(cfg: &BaseChainConfig) -> Self {
+impl From<&ChainConfig> for ChainGenesis {
+    fn from(cfg: &ChainConfig) -> Self {
         Self {
             l1: BlockNumHash { hash: cfg.genesis_l1_hash, number: cfg.genesis_l1_number },
             l2: BlockNumHash { hash: cfg.genesis_l2_hash, number: cfg.genesis_l2_number },

--- a/crates/consensus/genesis/src/lib.rs
+++ b/crates/consensus/genesis/src/lib.rs
@@ -10,7 +10,7 @@
 extern crate alloc;
 
 mod params;
-pub use params::BaseFeeConfig;
+pub use params::FeeConfig;
 
 mod updates;
 pub use updates::{
@@ -28,7 +28,7 @@ pub use system::{
 };
 
 mod chain;
-pub use chain::{AddressList, BaseHardforkConfig, HardForkConfig, Roles};
+pub use chain::{AddressList, HardForkConfig, HardforkConfig, Roles};
 
 mod genesis;
 pub use genesis::ChainGenesis;

--- a/crates/consensus/genesis/src/params.rs
+++ b/crates/consensus/genesis/src/params.rs
@@ -1,13 +1,13 @@
 //! Module containing fee parameters.
 
 use alloy_eips::eip1559::BaseFeeParams;
-use base_common_chains::BaseChainConfig;
+use base_common_chains::ChainConfig;
 
 /// Base Fee Config.
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-pub struct BaseFeeConfig {
+pub struct FeeConfig {
     /// EIP 1559 Elasticity Parameter
     #[cfg_attr(
         feature = "serde",
@@ -28,8 +28,8 @@ pub struct BaseFeeConfig {
     pub eip1559_denominator_canyon: u64,
 }
 
-impl From<&BaseChainConfig> for BaseFeeConfig {
-    fn from(cfg: &BaseChainConfig) -> Self {
+impl From<&ChainConfig> for FeeConfig {
+    fn from(cfg: &ChainConfig) -> Self {
         Self {
             eip1559_elasticity: cfg.eip1559_elasticity,
             eip1559_denominator: cfg.eip1559_denominator,
@@ -38,16 +38,16 @@ impl From<&BaseChainConfig> for BaseFeeConfig {
     }
 }
 
-impl BaseFeeConfig {
-    /// Returns the [`BaseFeeConfig`] for the given chain id.
+impl FeeConfig {
+    /// Returns the [`FeeConfig`] for the given chain id.
     pub fn from_chain_id(chain_id: u64) -> Self {
-        let cfg = BaseChainConfig::by_chain_id(chain_id).unwrap_or(BaseChainConfig::mainnet());
+        let cfg = ChainConfig::by_chain_id(chain_id).unwrap_or(ChainConfig::mainnet());
         Self::from(cfg)
     }
 
     /// Returns the Base Mainnet base fee config (used as serde default).
     pub fn base_mainnet() -> Self {
-        Self::from_chain_id(BaseChainConfig::mainnet().chain_id)
+        Self::from_chain_id(ChainConfig::mainnet().chain_id)
     }
 
     /// Returns the [`BaseFeeParams`] before Canyon hardfork.
@@ -73,47 +73,41 @@ mod tests {
 
     #[test]
     fn test_base_fee_params_from_chain_id() {
-        let mainnet = BaseFeeConfig::from_chain_id(BaseChainConfig::mainnet().chain_id);
-        let sepolia = BaseFeeConfig::from_chain_id(BaseChainConfig::sepolia().chain_id);
+        let mainnet = FeeConfig::from_chain_id(ChainConfig::mainnet().chain_id);
+        let sepolia = FeeConfig::from_chain_id(ChainConfig::sepolia().chain_id);
 
         assert_eq!(
-            BaseFeeConfig::from_chain_id(BaseChainConfig::mainnet().chain_id).pre_canyon_params(),
+            FeeConfig::from_chain_id(ChainConfig::mainnet().chain_id).pre_canyon_params(),
             mainnet.pre_canyon_params()
         );
         assert_eq!(
-            BaseFeeConfig::from_chain_id(BaseChainConfig::sepolia().chain_id).pre_canyon_params(),
+            FeeConfig::from_chain_id(ChainConfig::sepolia().chain_id).pre_canyon_params(),
             sepolia.pre_canyon_params()
         );
         // Unknown chain IDs fall back to Base Mainnet params
-        assert_eq!(
-            BaseFeeConfig::from_chain_id(0).pre_canyon_params(),
-            mainnet.pre_canyon_params()
-        );
+        assert_eq!(FeeConfig::from_chain_id(0).pre_canyon_params(), mainnet.pre_canyon_params());
     }
 
     #[test]
     fn test_base_fee_params_canyon_from_chain_id() {
-        let mainnet = BaseFeeConfig::from_chain_id(BaseChainConfig::mainnet().chain_id);
-        let sepolia = BaseFeeConfig::from_chain_id(BaseChainConfig::sepolia().chain_id);
+        let mainnet = FeeConfig::from_chain_id(ChainConfig::mainnet().chain_id);
+        let sepolia = FeeConfig::from_chain_id(ChainConfig::sepolia().chain_id);
 
         assert_eq!(
-            BaseFeeConfig::from_chain_id(BaseChainConfig::mainnet().chain_id).post_canyon_params(),
+            FeeConfig::from_chain_id(ChainConfig::mainnet().chain_id).post_canyon_params(),
             mainnet.post_canyon_params()
         );
         assert_eq!(
-            BaseFeeConfig::from_chain_id(BaseChainConfig::sepolia().chain_id).post_canyon_params(),
+            FeeConfig::from_chain_id(ChainConfig::sepolia().chain_id).post_canyon_params(),
             sepolia.post_canyon_params()
         );
-        assert_eq!(
-            BaseFeeConfig::from_chain_id(0).post_canyon_params(),
-            mainnet.post_canyon_params()
-        );
+        assert_eq!(FeeConfig::from_chain_id(0).post_canyon_params(), mainnet.post_canyon_params());
     }
 
     #[test]
     #[cfg(feature = "serde")]
     fn test_base_fee_config_ser() {
-        let config = BaseFeeConfig::from_chain_id(BaseChainConfig::mainnet().chain_id);
+        let config = FeeConfig::from_chain_id(ChainConfig::mainnet().chain_id);
         let raw_str = serde_json::to_string(&config).unwrap();
         assert_eq!(
             raw_str,
@@ -126,7 +120,7 @@ mod tests {
     fn test_base_fee_config_deser() {
         let raw_str: &'static str =
             r#"{"eip1559Elasticity":6,"eip1559Denominator":50,"eip1559DenominatorCanyon":250}"#;
-        let config: BaseFeeConfig = serde_json::from_str(raw_str).unwrap();
-        assert_eq!(config, BaseFeeConfig::from_chain_id(BaseChainConfig::mainnet().chain_id));
+        let config: FeeConfig = serde_json::from_str(raw_str).unwrap();
+        assert_eq!(config, FeeConfig::from_chain_id(ChainConfig::mainnet().chain_id));
     }
 }

--- a/crates/consensus/genesis/src/rollup.rs
+++ b/crates/consensus/genesis/src/rollup.rs
@@ -3,9 +3,9 @@
 use alloy_chains::Chain;
 use alloy_hardforks::{EthereumHardfork, EthereumHardforks, ForkCondition};
 use alloy_primitives::Address;
-use base_common_chains::{BaseChainConfig, BaseUpgrade, BaseUpgrades};
+use base_common_chains::{BaseUpgrade, ChainConfig, Upgrades};
 
-use crate::{BaseFeeConfig, ChainGenesis, HardForkConfig};
+use crate::{ChainGenesis, FeeConfig, HardForkConfig};
 
 /// The Rollup configuration.
 #[derive(Debug, Clone, Eq, PartialEq)]
@@ -61,17 +61,17 @@ pub struct RollupConfig {
     )]
     pub blobs_enabled_l1_timestamp: Option<u64>,
     /// `chain_op_config` is the chain-specific EIP1559 config for the rollup.
-    #[cfg_attr(feature = "serde", serde(default = "BaseFeeConfig::base_mainnet"))]
-    pub chain_op_config: BaseFeeConfig,
+    #[cfg_attr(feature = "serde", serde(default = "FeeConfig::base_mainnet"))]
+    pub chain_op_config: FeeConfig,
 }
 
 #[cfg(feature = "arbitrary")]
 impl<'a> arbitrary::Arbitrary<'a> for RollupConfig {
     fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
-        use base_common_chains::BaseChainConfig;
+        use base_common_chains::ChainConfig;
         let chain_op_config = match u32::arbitrary(u)? % 2 {
-            0 => BaseFeeConfig::from(BaseChainConfig::mainnet()),
-            _ => BaseFeeConfig::from(BaseChainConfig::sepolia()),
+            0 => FeeConfig::from(ChainConfig::mainnet()),
+            _ => FeeConfig::from(ChainConfig::sepolia()),
         };
 
         Ok(Self {
@@ -112,7 +112,7 @@ impl Default for RollupConfig {
             l1_system_config_address: Address::ZERO,
             protocol_versions_address: Address::ZERO,
             blobs_enabled_l1_timestamp: None,
-            chain_op_config: BaseFeeConfig::from_chain_id(0),
+            chain_op_config: FeeConfig::from_chain_id(0),
         }
     }
 }
@@ -329,7 +329,7 @@ impl EthereumHardforks for RollupConfig {
     }
 }
 
-impl BaseUpgrades for RollupConfig {
+impl Upgrades for RollupConfig {
     fn upgrade_activation(&self, fork: BaseUpgrade) -> ForkCondition {
         match fork {
             BaseUpgrade::Bedrock => ForkCondition::Block(0),
@@ -428,8 +428,8 @@ impl RollupConfig {
     }
 }
 
-impl From<&BaseChainConfig> for RollupConfig {
-    fn from(cfg: &BaseChainConfig) -> Self {
+impl From<&ChainConfig> for RollupConfig {
+    fn from(cfg: &ChainConfig) -> Self {
         Self {
             genesis: ChainGenesis::from(cfg),
             block_time: cfg.block_time,
@@ -445,7 +445,7 @@ impl From<&BaseChainConfig> for RollupConfig {
             l1_system_config_address: cfg.system_config_address,
             protocol_versions_address: cfg.protocol_versions_address,
             blobs_enabled_l1_timestamp: None,
-            chain_op_config: BaseFeeConfig::from(cfg),
+            chain_op_config: FeeConfig::from(cfg),
         }
     }
 }
@@ -626,10 +626,10 @@ mod tests {
 
     #[test]
     fn test_base_v1_active() {
-        use crate::BaseHardforkConfig;
+        use crate::HardforkConfig;
         let mut config = RollupConfig::default();
         assert!(!config.is_base_v1_active(0));
-        config.hardforks.base = BaseHardforkConfig { v1: Some(10) };
+        config.hardforks.base = HardforkConfig { v1: Some(10) };
         // V1 does not cascade upward to existing forks
         assert!(!config.is_regolith_active(10));
         assert!(!config.is_canyon_active(10));
@@ -640,7 +640,7 @@ mod tests {
 
     #[test]
     fn test_is_first_fork_block() {
-        use crate::BaseHardforkConfig;
+        use crate::HardforkConfig;
         let cfg = RollupConfig {
             hardforks: HardForkConfig {
                 regolith_time: Some(10),
@@ -653,7 +653,7 @@ mod tests {
                 pectra_blob_schedule_time: Some(80),
                 isthmus_time: Some(90),
                 jovian_time: Some(100),
-                base: BaseHardforkConfig { v1: Some(110) },
+                base: HardforkConfig { v1: Some(110) },
             },
             block_time: 2,
             ..Default::default()
@@ -838,7 +838,7 @@ mod tests {
             l1_system_config_address: address!("94ee52a9d8edd72a85dea7fae3ba6d75e4bf1710"),
             protocol_versions_address: Address::ZERO,
             blobs_enabled_l1_timestamp: None,
-            chain_op_config: BaseFeeConfig::from_chain_id(0),
+            chain_op_config: FeeConfig::from_chain_id(0),
         };
 
         let deserialized: RollupConfig = serde_json::from_str(raw).unwrap();

--- a/crates/consensus/peers/src/nodes.rs
+++ b/crates/consensus/peers/src/nodes.rs
@@ -1,6 +1,6 @@
 //! Bootnodes for consensus network discovery.
 
-use base_common_chains::BaseChainConfig;
+use base_common_chains::ChainConfig;
 use derive_more::Deref;
 
 use crate::{BootNode, BootNodeParseError};
@@ -9,10 +9,10 @@ use crate::{BootNode, BootNodeParseError};
 #[derive(Debug, Clone, Deref, PartialEq, Eq, Default, derive_more::From)]
 pub struct BootNodes(pub Vec<BootNode>);
 
-impl TryFrom<&BaseChainConfig> for BootNodes {
+impl TryFrom<&ChainConfig> for BootNodes {
     type Error = BootNodeParseError;
 
-    fn try_from(config: &BaseChainConfig) -> Result<Self, Self::Error> {
+    fn try_from(config: &ChainConfig) -> Result<Self, Self::Error> {
         config
             .bootnodes
             .iter()
@@ -27,19 +27,19 @@ impl BootNodes {
     ///
     /// If the chain id is not recognized, no bootnodes are returned.
     pub fn from_chain_id(id: u64) -> Self {
-        BaseChainConfig::by_chain_id(id)
+        ChainConfig::by_chain_id(id)
             .map(|c| Self::try_from(c).expect("hardcoded bootnode should parse"))
             .unwrap_or_default()
     }
 
     /// Returns the bootnodes for the mainnet.
     pub fn mainnet() -> Self {
-        Self::try_from(BaseChainConfig::mainnet()).expect("hardcoded bootnode should parse")
+        Self::try_from(ChainConfig::mainnet()).expect("hardcoded bootnode should parse")
     }
 
     /// Returns the bootnodes for the testnet.
     pub fn testnet() -> Self {
-        Self::try_from(BaseChainConfig::sepolia()).expect("hardcoded bootnode should parse")
+        Self::try_from(ChainConfig::sepolia()).expect("hardcoded bootnode should parse")
     }
 
     /// Returns the length of the bootnodes.
@@ -55,33 +55,33 @@ impl BootNodes {
 
 #[cfg(test)]
 mod tests {
-    use base_common_chains::BaseChainConfig;
+    use base_common_chains::ChainConfig;
 
     use super::*;
 
     #[test]
     fn test_validate_bootnode_lens() {
-        assert_eq!(BaseChainConfig::mainnet().bootnodes.len(), 10);
-        assert_eq!(BaseChainConfig::sepolia().bootnodes.len(), 2);
+        assert_eq!(ChainConfig::mainnet().bootnodes.len(), 10);
+        assert_eq!(ChainConfig::sepolia().bootnodes.len(), 2);
     }
 
     #[test]
     fn test_parse_raw_bootnodes() {
-        for raw in BaseChainConfig::mainnet().bootnodes {
+        for raw in ChainConfig::mainnet().bootnodes {
             BootNode::parse_bootnode(raw).expect("hardcoded bootnode should parse");
         }
 
-        for raw in BaseChainConfig::sepolia().bootnodes {
+        for raw in ChainConfig::sepolia().bootnodes {
             BootNode::parse_bootnode(raw).expect("hardcoded bootnode should parse");
         }
     }
 
     #[test]
     fn test_bootnodes_from_chain_id() {
-        let mainnet = BootNodes::from_chain_id(BaseChainConfig::mainnet().chain_id);
+        let mainnet = BootNodes::from_chain_id(ChainConfig::mainnet().chain_id);
         assert_eq!(mainnet.len(), 10);
 
-        let testnet = BootNodes::from_chain_id(BaseChainConfig::sepolia().chain_id);
+        let testnet = BootNodes::from_chain_id(ChainConfig::sepolia().chain_id);
         assert_eq!(testnet.len(), 2);
 
         let unknown = BootNodes::from_chain_id(0);
@@ -102,7 +102,7 @@ mod tests {
         let bootnodes = BootNodes(vec![]);
         assert!(bootnodes.is_empty());
 
-        let bootnodes = BootNodes::from_chain_id(BaseChainConfig::mainnet().chain_id);
+        let bootnodes = BootNodes::from_chain_id(ChainConfig::mainnet().chain_id);
         assert!(!bootnodes.is_empty());
     }
 }

--- a/crates/consensus/registry/src/registry.rs
+++ b/crates/consensus/registry/src/registry.rs
@@ -1,25 +1,25 @@
 //! Rollup and L1 chain configuration registry.
 
 use alloy_chains::NamedChain;
-use alloy_genesis::ChainConfig;
+use alloy_genesis::ChainConfig as GenesisChainConfig;
 use alloy_primitives::{Address, map::HashMap};
-use base_common_chains::BaseChainConfig;
+use base_common_chains::ChainConfig;
 use base_consensus_genesis::RollupConfig;
 use spin::Lazy;
 
 use crate::{Holesky, Hoodi, Mainnet, Sepolia};
 
-/// Rollup configurations derived from [`BaseChainConfig`] instances.
+/// Rollup configurations derived from [`ChainConfig`] instances.
 static ROLLUP_CONFIGS: Lazy<HashMap<u64, RollupConfig>> = Lazy::new(|| {
     let mut map = HashMap::default();
-    for cfg in BaseChainConfig::all() {
+    for cfg in ChainConfig::all() {
         map.insert(cfg.chain_id, RollupConfig::from(cfg));
     }
     map
 });
 
 /// L1 chain configurations built from known L1 genesis data.
-static L1_CONFIGS: Lazy<HashMap<u64, ChainConfig>> = Lazy::new(|| {
+static L1_CONFIGS: Lazy<HashMap<u64, GenesisChainConfig>> = Lazy::new(|| {
     let mut map = HashMap::default();
     map.insert(NamedChain::Mainnet.into(), Mainnet::l1_config());
     map.insert(NamedChain::Sepolia.into(), Sepolia::l1_config());
@@ -32,7 +32,7 @@ static L1_CONFIGS: Lazy<HashMap<u64, ChainConfig>> = Lazy::new(|| {
 ///
 /// Provides access to rollup configs, L1 chain configs, and the unsafe block signer
 /// for supported chain IDs. Rollup configs are derived from the compile-time
-/// [`BaseChainConfig`] instances in `base-common-chains`.
+/// [`ChainConfig`] instances in `base-common-chains`.
 #[derive(Debug)]
 pub struct Registry;
 
@@ -47,14 +47,14 @@ impl Registry {
         ROLLUP_CONFIGS.get(&chain.id())
     }
 
-    /// Returns an [`ChainConfig`] for the given L1 chain ID.
-    pub fn l1_config(chain_id: u64) -> Option<&'static ChainConfig> {
+    /// Returns a [`GenesisChainConfig`] for the given L1 chain ID.
+    pub fn l1_config(chain_id: u64) -> Option<&'static GenesisChainConfig> {
         L1_CONFIGS.get(&chain_id)
     }
 
     /// Returns the `unsafe_block_signer` address for the given chain ID.
     pub fn unsafe_block_signer(chain_id: u64) -> Option<Address> {
-        BaseChainConfig::by_chain_id(chain_id)?.unsafe_block_signer
+        ChainConfig::by_chain_id(chain_id)?.unsafe_block_signer
     }
 }
 
@@ -65,7 +65,7 @@ mod tests {
         holesky::{HOLESKY_BPO1_TIMESTAMP, HOLESKY_BPO2_TIMESTAMP},
         sepolia::{SEPOLIA_BPO1_TIMESTAMP, SEPOLIA_BPO2_TIMESTAMP},
     };
-    use base_common_chains::BaseChainConfig;
+    use base_common_chains::ChainConfig;
 
     use super::*;
 
@@ -95,11 +95,11 @@ mod tests {
     #[test]
     fn test_rollup_config_derived_from_chain_config() {
         let mainnet = Registry::rollup_config(8453).unwrap();
-        let expected = RollupConfig::from(BaseChainConfig::mainnet());
+        let expected = RollupConfig::from(ChainConfig::mainnet());
         assert_eq!(*mainnet, expected);
 
         let sepolia = Registry::rollup_config(84532).unwrap();
-        let expected = RollupConfig::from(BaseChainConfig::sepolia());
+        let expected = RollupConfig::from(ChainConfig::sepolia());
         assert_eq!(*sepolia, expected);
     }
 
@@ -118,13 +118,13 @@ mod tests {
         let base_mainnet = Registry::rollup_config(8453).unwrap();
         assert_eq!(
             base_mainnet.hardforks.jovian_time,
-            Some(BaseChainConfig::mainnet().jovian_timestamp)
+            Some(ChainConfig::mainnet().jovian_timestamp)
         );
 
         let base_sepolia = Registry::rollup_config(84532).unwrap();
         assert_eq!(
             base_sepolia.hardforks.jovian_time,
-            Some(BaseChainConfig::sepolia().jovian_timestamp)
+            Some(ChainConfig::sepolia().jovian_timestamp)
         );
     }
 

--- a/crates/consensus/registry/src/test_utils/mod.rs
+++ b/crates/consensus/registry/src/test_utils/mod.rs
@@ -1,13 +1,13 @@
-//! Test-only module providing rollup configs derived from [`BaseChainConfig`].
+//! Test-only module providing rollup configs derived from [`ChainConfig`].
 
-use base_common_chains::BaseChainConfig;
+use base_common_chains::ChainConfig;
 use base_consensus_genesis::RollupConfig;
 use spin::Lazy;
 
-/// The [`RollupConfig`] for Base Mainnet, derived from [`BaseChainConfig::mainnet`].
+/// The [`RollupConfig`] for Base Mainnet, derived from [`ChainConfig::mainnet`].
 pub static BASE_MAINNET_ROLLUP_CONFIG: Lazy<RollupConfig> =
-    Lazy::new(|| RollupConfig::from(BaseChainConfig::mainnet()));
+    Lazy::new(|| RollupConfig::from(ChainConfig::mainnet()));
 
-/// The [`RollupConfig`] for Base Sepolia, derived from [`BaseChainConfig::sepolia`].
+/// The [`RollupConfig`] for Base Sepolia, derived from [`ChainConfig::sepolia`].
 pub static BASE_SEPOLIA_ROLLUP_CONFIG: Lazy<RollupConfig> =
-    Lazy::new(|| RollupConfig::from(BaseChainConfig::sepolia()));
+    Lazy::new(|| RollupConfig::from(ChainConfig::sepolia()));

--- a/crates/consensus/registry/tests/hardfork_consistency.rs
+++ b/crates/consensus/registry/tests/hardfork_consistency.rs
@@ -1,16 +1,16 @@
 //! Integration tests verifying that [`base_consensus_registry`] rollup configs agree with
 //! [`base_common_chains`] chain hardfork schedules for every [`BaseUpgrade`] variant.
 
-use base_common_chains::{BaseChainUpgrades, BaseUpgrade, BaseUpgrades};
+use base_common_chains::{BaseUpgrade, ChainUpgrades, Upgrades};
 use base_consensus_registry::test_utils::{BASE_MAINNET_ROLLUP_CONFIG, BASE_SEPOLIA_ROLLUP_CONFIG};
 
 #[test]
 fn mainnet_rollup_config_matches_chain_hardforks() {
-    let chain = BaseChainUpgrades::mainnet();
+    let chain = ChainUpgrades::mainnet();
     for fork in BaseUpgrade::VARIANTS {
         // Regolith activated at genesis on Base and is stored as `regolith_time: Some(0)`
         // in the derived rollup config. The `upgrade_activation` cascade returns Canyon's
-        // ForkCondition when traversing, which differs from BaseChainUpgrades'
+        // ForkCondition when traversing, which differs from ChainUpgrades'
         // explicit Timestamp(0). Skip to avoid false mismatches.
         if *fork == BaseUpgrade::Regolith {
             continue;
@@ -25,7 +25,7 @@ fn mainnet_rollup_config_matches_chain_hardforks() {
 
 #[test]
 fn sepolia_rollup_config_matches_chain_hardforks() {
-    let chain = BaseChainUpgrades::sepolia();
+    let chain = ChainUpgrades::sepolia();
     for fork in BaseUpgrade::VARIANTS {
         // See comment in mainnet test above.
         if *fork == BaseUpgrade::Regolith {

--- a/crates/consensus/service/src/service/node.rs
+++ b/crates/consensus/service/src/service/node.rs
@@ -2,9 +2,9 @@
 use std::{ops::Not as _, path::PathBuf, sync::Arc, time::Duration};
 
 use alloy_eips::BlockNumberOrTag;
-use alloy_genesis::ChainConfig;
+use alloy_genesis::ChainConfig as GenesisChainConfig;
 use alloy_provider::RootProvider;
-use base_common_chains::BaseChainConfig;
+use base_common_chains::ChainConfig;
 use base_common_network::Base;
 use base_consensus_derive::{Pipeline, SignalReceiver, StatefulAttributesBuilder};
 use base_consensus_engine::{Engine, EngineClient, EngineState};
@@ -39,7 +39,7 @@ pub const HEAD_STREAM_POLL_INTERVAL: u64 = 4;
 #[derive(Debug, Clone)]
 pub struct L1Config {
     /// The L1 chain configuration.
-    pub chain_config: Arc<ChainConfig>,
+    pub chain_config: Arc<GenesisChainConfig>,
     /// Whether to trust the L1 RPC.
     pub trust_rpc: bool,
     /// The L1 beacon client.
@@ -57,9 +57,9 @@ pub struct L1Config {
 impl L1Config {
     /// Returns the recommended finalized-block poll interval for the given L1 chain.
     pub const fn default_finalized_poll_interval(l1_chain_id: u64) -> Duration {
-        const ETH_MAINNET_L1: u64 = BaseChainConfig::mainnet().l1_chain_id;
-        const ETH_SEPOLIA_L1: u64 = BaseChainConfig::sepolia().l1_chain_id;
-        const DEVNET_L1: u64 = BaseChainConfig::devnet().l1_chain_id;
+        const ETH_MAINNET_L1: u64 = ChainConfig::mainnet().l1_chain_id;
+        const ETH_SEPOLIA_L1: u64 = ChainConfig::sepolia().l1_chain_id;
+        const DEVNET_L1: u64 = ChainConfig::devnet().l1_chain_id;
 
         match l1_chain_id {
             // Ethereum mainnet and Sepolia: poll once per L1 epoch (32 slots × 12 s).

--- a/crates/execution/chainspec/src/base.rs
+++ b/crates/execution/chainspec/src/base.rs
@@ -4,7 +4,7 @@ use alloc::{sync::Arc, vec};
 
 use alloy_chains::Chain;
 use alloy_primitives::{U256, b256};
-use base_common_chains::{BaseChainConfig, BaseUpgrade};
+use base_common_chains::{BaseUpgrade, ChainConfig};
 use base_execution_upgrades::BASE_MAINNET_UPGRADES;
 use reth_chainspec::{BaseFeeParams, BaseFeeParamsKind, ChainSpec};
 use reth_ethereum_forks::{EthereumHardfork, Hardfork};
@@ -14,7 +14,7 @@ use crate::BaseChainSpec;
 
 /// The Base mainnet spec
 pub static BASE_MAINNET: LazyLock<Arc<BaseChainSpec>> = LazyLock::new(|| {
-    let genesis = serde_json::from_str(BaseChainConfig::mainnet().genesis_json)
+    let genesis = serde_json::from_str(ChainConfig::mainnet().genesis_json)
         .expect("Can't deserialize Base genesis json");
     let hardforks = BASE_MAINNET_UPGRADES.clone();
     BaseChainSpec {

--- a/crates/execution/chainspec/src/base_devnet_0_sepolia_dev_0.rs
+++ b/crates/execution/chainspec/src/base_devnet_0_sepolia_dev_0.rs
@@ -4,7 +4,7 @@ use alloc::{sync::Arc, vec};
 
 use alloy_chains::Chain;
 use alloy_primitives::{U256, b256};
-use base_common_chains::{BaseChainConfig, BaseUpgrade};
+use base_common_chains::{BaseUpgrade, ChainConfig};
 use base_execution_upgrades::BASE_DEVNET_0_SEPOLIA_DEV_0_UPGRADES;
 use reth_chainspec::{BaseFeeParams, BaseFeeParamsKind, ChainSpec, Hardfork};
 use reth_ethereum_forks::EthereumHardfork;
@@ -14,7 +14,7 @@ use crate::BaseChainSpec;
 
 /// The Base devnet-0-sepolia-dev-0 spec
 pub static BASE_DEVNET_0_SEPOLIA_DEV_0: LazyLock<Arc<BaseChainSpec>> = LazyLock::new(|| {
-    let genesis = serde_json::from_str(BaseChainConfig::alpha().genesis_json)
+    let genesis = serde_json::from_str(ChainConfig::alpha().genesis_json)
         .expect("Can't deserialize Base devnet-0-sepolia-dev-0 genesis json");
     let hardforks = BASE_DEVNET_0_SEPOLIA_DEV_0_UPGRADES.clone();
     BaseChainSpec {

--- a/crates/execution/chainspec/src/base_sepolia.rs
+++ b/crates/execution/chainspec/src/base_sepolia.rs
@@ -4,7 +4,7 @@ use alloc::{sync::Arc, vec};
 
 use alloy_chains::Chain;
 use alloy_primitives::{U256, b256};
-use base_common_chains::{BaseChainConfig, BaseUpgrade};
+use base_common_chains::{BaseUpgrade, ChainConfig};
 use base_execution_upgrades::BASE_SEPOLIA_UPGRADES;
 use reth_chainspec::{BaseFeeParams, BaseFeeParamsKind, ChainSpec, Hardfork};
 use reth_ethereum_forks::EthereumHardfork;
@@ -14,7 +14,7 @@ use crate::BaseChainSpec;
 
 /// The Base Sepolia spec
 pub static BASE_SEPOLIA: LazyLock<Arc<BaseChainSpec>> = LazyLock::new(|| {
-    let genesis = serde_json::from_str(BaseChainConfig::sepolia().genesis_json)
+    let genesis = serde_json::from_str(ChainConfig::sepolia().genesis_json)
         .expect("Can't deserialize Base Sepolia genesis json");
     let hardforks = BASE_SEPOLIA_UPGRADES.clone();
     BaseChainSpec {

--- a/crates/execution/chainspec/src/base_zeronet.rs
+++ b/crates/execution/chainspec/src/base_zeronet.rs
@@ -4,7 +4,7 @@ use alloc::{sync::Arc, vec};
 
 use alloy_chains::Chain;
 use alloy_primitives::{U256, b256};
-use base_common_chains::{BaseChainConfig, BaseUpgrade};
+use base_common_chains::{BaseUpgrade, ChainConfig};
 use base_execution_upgrades::BASE_ZERONET_UPGRADES;
 use reth_chainspec::{BaseFeeParams, BaseFeeParamsKind, ChainSpec, Hardfork};
 use reth_ethereum_forks::EthereumHardfork;
@@ -14,7 +14,7 @@ use crate::BaseChainSpec;
 
 /// The Base zeronet spec
 pub static BASE_ZERONET: LazyLock<Arc<BaseChainSpec>> = LazyLock::new(|| {
-    let genesis = serde_json::from_str(BaseChainConfig::zeronet().genesis_json)
+    let genesis = serde_json::from_str(ChainConfig::zeronet().genesis_json)
         .expect("Can't deserialize Base zeronet genesis json");
     let hardforks = BASE_ZERONET_UPGRADES.clone();
     BaseChainSpec {

--- a/crates/execution/chainspec/src/basefee.rs
+++ b/crates/execution/chainspec/src/basefee.rs
@@ -4,7 +4,7 @@ use core::cmp::max;
 
 use alloy_consensus::BlockHeader;
 use alloy_eips::calc_next_block_base_fee;
-use base_common_chains::BaseUpgrades;
+use base_common_chains::Upgrades;
 use base_common_consensus::{EIP1559ParamError, HoloceneExtraData, JovianExtraData};
 use reth_chainspec::{BaseFeeParams, EthChainSpec};
 
@@ -14,7 +14,7 @@ use reth_chainspec::{BaseFeeParams, EthChainSpec};
 ///
 /// See also [Base fee computation](https://github.com/ethereum-optimism/specs/blob/main/specs/protocol/holocene/exec-engine.md#base-fee-computation)
 pub fn decode_holocene_base_fee<H>(
-    chain_spec: impl EthChainSpec + BaseUpgrades,
+    chain_spec: impl EthChainSpec + Upgrades,
     parent: &H,
     timestamp: u64,
 ) -> Result<u64, EIP1559ParamError>
@@ -41,7 +41,7 @@ where
 /// See also [Base fee computation](https://github.com/ethereum-optimism/specs/blob/main/specs/protocol/jovian/exec-engine.md#base-fee-computation)
 /// and [Minimum base fee in block header](https://github.com/ethereum-optimism/specs/blob/main/specs/protocol/jovian/exec-engine.md#minimum-base-fee-in-block-header)
 pub fn compute_jovian_base_fee<H>(
-    chain_spec: impl EthChainSpec + BaseUpgrades,
+    chain_spec: impl EthChainSpec + Upgrades,
     parent: &H,
     timestamp: u64,
 ) -> Result<u64, EIP1559ParamError>

--- a/crates/execution/chainspec/src/dev.rs
+++ b/crates/execution/chainspec/src/dev.rs
@@ -4,7 +4,7 @@ use alloc::sync::Arc;
 
 use alloy_chains::Chain;
 use alloy_primitives::U256;
-use base_common_chains::BaseChainConfig;
+use base_common_chains::ChainConfig;
 use base_execution_upgrades::DEV_UPGRADES;
 use reth_chainspec::{BaseFeeParams, BaseFeeParamsKind, ChainSpec};
 use reth_primitives_traits::{SealedHeader, sync::LazyLock};
@@ -16,7 +16,7 @@ use crate::BaseChainSpec;
 /// Includes 20 prefunded accounts with `10_000` ETH each derived from mnemonic "test test test test
 /// test test test test test test test junk".
 pub static BASE_DEV: LazyLock<Arc<BaseChainSpec>> = LazyLock::new(|| {
-    let genesis = serde_json::from_str(BaseChainConfig::devnet().genesis_json)
+    let genesis = serde_json::from_str(ChainConfig::devnet().genesis_json)
         .expect("Can't deserialize Dev testnet genesis json");
     let hardforks = DEV_UPGRADES.clone();
     let genesis_header =

--- a/crates/execution/chainspec/src/spec.rs
+++ b/crates/execution/chainspec/src/spec.rs
@@ -6,7 +6,7 @@ use alloy_eips::eip7840::BlobParams;
 use alloy_genesis::Genesis;
 use alloy_hardforks::Hardfork;
 use alloy_primitives::{B256, U256};
-use base_common_chains::{BaseUpgrade, BaseUpgrades};
+use base_common_chains::{BaseUpgrade, Upgrades};
 use base_execution_upgrades::BASE_MAINNET_UPGRADES;
 use base_protocol::Predeploys;
 use derive_more::{Constructor, Deref, Into};
@@ -31,7 +31,7 @@ pub const SUPPORTED_CHAINS: &[&str] =
 #[derive(Default, Debug)]
 pub struct GenesisInfo {
     /// Base chain info extracted from genesis extra fields.
-    pub optimism_chain_info: base_common_rpc_types::BaseChainInfo,
+    pub optimism_chain_info: base_common_rpc_types::ChainInfo,
     /// Base fee params derived from the genesis config.
     pub base_fee_params: BaseFeeParamsKind,
 }
@@ -40,7 +40,7 @@ impl GenesisInfo {
     /// Extracts Base genesis info from an [`alloy_genesis::Genesis`].
     pub fn extract_from(genesis: &Genesis) -> Self {
         let mut info = Self {
-            optimism_chain_info: base_common_rpc_types::BaseChainInfo::extract_from(
+            optimism_chain_info: base_common_rpc_types::ChainInfo::extract_from(
                 &genesis.config.extra_fields,
             )
             .unwrap_or_default(),
@@ -186,9 +186,9 @@ impl EthChainSpec for BaseChainSpec {
     }
 
     fn next_block_base_fee(&self, parent: &Header, target_timestamp: u64) -> Option<u64> {
-        if BaseUpgrades::is_jovian_active_at_timestamp(self, parent.timestamp()) {
+        if Upgrades::is_jovian_active_at_timestamp(self, parent.timestamp()) {
             compute_jovian_base_fee(self, parent, target_timestamp).ok()
-        } else if BaseUpgrades::is_holocene_active_at_timestamp(self, parent.timestamp()) {
+        } else if Upgrades::is_holocene_active_at_timestamp(self, parent.timestamp()) {
             decode_holocene_base_fee(self, parent, target_timestamp).ok()
         } else {
             self.inner.next_block_base_fee(parent, target_timestamp)
@@ -224,7 +224,7 @@ impl EthereumHardforks for BaseChainSpec {
     }
 }
 
-impl BaseUpgrades for BaseChainSpec {
+impl Upgrades for BaseChainSpec {
     fn upgrade_activation(&self, fork: BaseUpgrade) -> ForkCondition {
         self.fork(fork)
     }
@@ -342,11 +342,11 @@ mod tests {
     use core::str::FromStr;
 
     use alloy_consensus::proofs::storage_root_unhashed;
-    use alloy_genesis::{ChainConfig, Genesis};
+    use alloy_genesis::{ChainConfig as AlloyChainConfig, Genesis};
     use alloy_hardforks::Hardfork;
     use alloy_primitives::{B256, U256, b256, hex};
-    use base_common_chains::{BaseChainConfig, BaseUpgrade, BaseUpgrades};
-    use base_common_rpc_types::BaseFeeInfo;
+    use base_common_chains::{BaseUpgrade, ChainConfig, Upgrades};
+    use base_common_rpc_types::FeeInfo;
     use reth_chainspec::{
         BaseFeeParams, BaseFeeParamsKind, EthChainSpec, EthereumHardforks, test_fork_ids,
     };
@@ -437,13 +437,13 @@ mod tests {
                     Head { number: 0, timestamp: 1746806401, ..Default::default() },
                     ForkId {
                         hash: ForkHash([0x86, 0x72, 0x8b, 0x4e]),
-                        next: BaseChainConfig::mainnet().jovian_timestamp,
+                        next: ChainConfig::mainnet().jovian_timestamp,
                     },
                 ),
                 (
                     Head {
                         number: 0,
-                        timestamp: BaseChainConfig::mainnet().jovian_timestamp,
+                        timestamp: ChainConfig::mainnet().jovian_timestamp,
                         ..Default::default()
                     },
                     BASE_MAINNET.hardfork_fork_id(BaseUpgrade::Jovian).unwrap(),
@@ -501,13 +501,13 @@ mod tests {
                     Head { number: 0, timestamp: 1744905600, ..Default::default() },
                     ForkId {
                         hash: ForkHash([0x06, 0x0a, 0x4d, 0x1d]),
-                        next: BaseChainConfig::sepolia().jovian_timestamp,
+                        next: ChainConfig::sepolia().jovian_timestamp,
                     },
                 ),
                 (
                     Head {
                         number: 0,
-                        timestamp: BaseChainConfig::sepolia().jovian_timestamp,
+                        timestamp: ChainConfig::sepolia().jovian_timestamp,
                         ..Default::default()
                     },
                     BASE_SEPOLIA.hardfork_fork_id(BaseUpgrade::Jovian).unwrap(),
@@ -750,11 +750,11 @@ mod tests {
 
         let optimism_object = genesis.config.extra_fields.get("optimism").unwrap();
         let optimism_base_fee_info =
-            serde_json::from_value::<BaseFeeInfo>(optimism_object.clone()).unwrap();
+            serde_json::from_value::<FeeInfo>(optimism_object.clone()).unwrap();
 
         assert_eq!(
             optimism_base_fee_info,
-            BaseFeeInfo {
+            FeeInfo {
                 eip1559_elasticity: Some(6),
                 eip1559_denominator: Some(50),
                 eip1559_denominator_canyon: None,
@@ -775,7 +775,7 @@ mod tests {
     #[test]
     fn test_fork_order_base_hardforks() {
         let genesis = Genesis {
-            config: ChainConfig {
+            config: AlloyChainConfig {
                 chain_id: 0,
                 homestead_block: Some(0),
                 dao_fork_block: Some(0),
@@ -913,7 +913,7 @@ mod tests {
 
         let genesis: Genesis = serde_json::from_str(geth_genesis).unwrap();
         let chainspec = BaseChainSpec::from_genesis(genesis);
-        assert!(BaseUpgrades::is_holocene_active_at_timestamp(&chainspec, 1732633200));
+        assert!(Upgrades::is_holocene_active_at_timestamp(&chainspec, 1732633200));
     }
 
     #[test]

--- a/crates/execution/consensus/src/lib.rs
+++ b/crates/execution/consensus/src/lib.rs
@@ -16,7 +16,7 @@ use alloy_consensus::{
     BlockHeader as _, EMPTY_OMMER_ROOT_HASH, Header, constants::MAXIMUM_EXTRA_DATA_SIZE,
 };
 use alloy_primitives::B64;
-use base_common_chains::BaseUpgrades;
+use base_common_chains::Upgrades;
 use base_common_consensus::DepositReceiptExt;
 use base_execution_chainspec::BaseChainSpec;
 use reth_consensus::{Consensus, ConsensusError, FullConsensus, HeaderValidator, ReceiptRootBloom};

--- a/crates/execution/consensus/src/proof.rs
+++ b/crates/execution/consensus/src/proof.rs
@@ -6,13 +6,13 @@ use alloy_consensus::ReceiptWithBloom;
 use alloy_eips::eip2718::Encodable2718;
 use alloy_primitives::B256;
 use alloy_trie::root::ordered_trie_root_with_encoder;
-use base_common_chains::BaseUpgrades;
+use base_common_chains::Upgrades;
 use base_common_consensus::DepositReceiptExt;
 
 /// Calculates the receipt root for a header.
 pub fn calculate_receipt_root_optimism<R: DepositReceiptExt>(
     receipts: &[ReceiptWithBloom<&R>],
-    chain_spec: impl BaseUpgrades,
+    chain_spec: impl Upgrades,
     timestamp: u64,
 ) -> B256 {
     // There is a minor bug in op-geth and op-erigon where in the Regolith hardfork,
@@ -45,7 +45,7 @@ pub fn calculate_receipt_root_optimism<R: DepositReceiptExt>(
 /// NOTE: Prefer calculate receipt root optimism if you have log blooms memoized.
 pub fn calculate_receipt_root_no_memo_optimism<R: DepositReceiptExt>(
     receipts: &[R],
-    chain_spec: impl BaseUpgrades,
+    chain_spec: impl Upgrades,
     timestamp: u64,
 ) -> B256 {
     // There is a minor bug in op-geth and op-erigon where in the Regolith hardfork,

--- a/crates/execution/consensus/src/validation/mod.rs
+++ b/crates/execution/consensus/src/validation/mod.rs
@@ -9,7 +9,7 @@ use alloy_consensus::{BlockHeader, EMPTY_OMMER_ROOT_HASH, TxReceipt};
 use alloy_eips::Encodable2718;
 use alloy_primitives::{B256, Bloom, Bytes};
 use alloy_trie::EMPTY_ROOT_HASH;
-use base_common_chains::BaseUpgrades;
+use base_common_chains::Upgrades;
 use base_common_consensus::DepositReceiptExt;
 use reth_consensus::ConsensusError;
 use reth_execution_types::BlockExecutionResult;
@@ -25,7 +25,7 @@ use crate::proof::calculate_receipt_root_optimism;
 ///   - transaction root
 ///   - withdrawals root: the body's withdrawals root must only match the header's before isthmus
 pub fn validate_body_against_header_op<B, H>(
-    chain_spec: impl BaseUpgrades,
+    chain_spec: impl Upgrades,
     body: &B,
     header: &H,
 ) -> Result<(), ConsensusError>
@@ -90,7 +90,7 @@ where
 /// instead of computing them from the receipts.
 pub fn validate_block_post_execution<R: DepositReceiptExt>(
     header: impl BlockHeader,
-    chain_spec: impl BaseUpgrades,
+    chain_spec: impl Upgrades,
     result: &BlockExecutionResult<R>,
     receipt_root_bloom: Option<(B256, Bloom)>,
 ) -> Result<(), ConsensusError> {
@@ -160,7 +160,7 @@ fn verify_receipts_optimism<R: DepositReceiptExt>(
     expected_receipts_root: B256,
     expected_logs_bloom: Bloom,
     receipts: &[R],
-    chain_spec: impl BaseUpgrades,
+    chain_spec: impl Upgrades,
     timestamp: u64,
 ) -> Result<(), ConsensusError> {
     // Calculate receipts root.

--- a/crates/execution/evm/src/build.rs
+++ b/crates/execution/evm/src/build.rs
@@ -7,7 +7,7 @@ use alloy_consensus::{
 use alloy_eips::{eip7685::EMPTY_REQUESTS_HASH, merge::BEACON_NONCE};
 use alloy_evm::block::BlockExecutorFactory;
 use alloy_primitives::logs_bloom;
-use base_common_chains::BaseUpgrades;
+use base_common_chains::Upgrades;
 use base_common_consensus::DepositReceiptExt;
 use base_common_evm::BaseBlockExecutionCtx;
 use base_execution_consensus::{calculate_receipt_root_no_memo_optimism, isthmus};
@@ -30,7 +30,7 @@ impl<ChainSpec> BaseBlockAssembler<ChainSpec> {
     }
 }
 
-impl<ChainSpec: BaseUpgrades> BaseBlockAssembler<ChainSpec> {
+impl<ChainSpec: Upgrades> BaseBlockAssembler<ChainSpec> {
     /// Builds a block for `input` without any bounds on header `H`.
     pub fn assemble_block<
         F: for<'a> BlockExecutorFactory<
@@ -65,7 +65,7 @@ impl<ChainSpec: BaseUpgrades> BaseBlockAssembler<ChainSpec> {
         let mut requests_hash = None;
 
         let withdrawals_root =
-            if BaseUpgrades::is_isthmus_active_at_timestamp(&*self.chain_spec, timestamp) {
+            if Upgrades::is_isthmus_active_at_timestamp(&*self.chain_spec, timestamp) {
                 // always empty requests hash post isthmus
                 requests_hash = Some(EMPTY_REQUESTS_HASH);
 
@@ -75,18 +75,18 @@ impl<ChainSpec: BaseUpgrades> BaseBlockAssembler<ChainSpec> {
                     isthmus::withdrawals_root(bundle_state, state_provider)
                         .map_err(BlockExecutionError::other)?,
                 )
-            } else if BaseUpgrades::is_canyon_active_at_timestamp(&*self.chain_spec, timestamp) {
+            } else if Upgrades::is_canyon_active_at_timestamp(&*self.chain_spec, timestamp) {
                 Some(EMPTY_WITHDRAWALS)
             } else {
                 None
             };
 
         let (excess_blob_gas, blob_gas_used) =
-            if BaseUpgrades::is_jovian_active_at_timestamp(&*self.chain_spec, timestamp) {
+            if Upgrades::is_jovian_active_at_timestamp(&*self.chain_spec, timestamp) {
                 // In jovian, we're using the blob gas used field to store the current da
                 // footprint's value.
                 (Some(0), Some(*blob_gas_used))
-            } else if BaseUpgrades::is_ecotone_active_at_timestamp(&*self.chain_spec, timestamp) {
+            } else if Upgrades::is_ecotone_active_at_timestamp(&*self.chain_spec, timestamp) {
                 (Some(0), Some(0))
             } else {
                 (None, None)
@@ -121,11 +121,8 @@ impl<ChainSpec: BaseUpgrades> BaseBlockAssembler<ChainSpec> {
             BlockBody {
                 transactions,
                 ommers: Default::default(),
-                withdrawals: BaseUpgrades::is_canyon_active_at_timestamp(
-                    &*self.chain_spec,
-                    timestamp,
-                )
-                .then(Default::default),
+                withdrawals: Upgrades::is_canyon_active_at_timestamp(&*self.chain_spec, timestamp)
+                    .then(Default::default),
             },
         ))
     }
@@ -139,7 +136,7 @@ impl<ChainSpec> Clone for BaseBlockAssembler<ChainSpec> {
 
 impl<F, ChainSpec> BlockAssembler<F> for BaseBlockAssembler<ChainSpec>
 where
-    ChainSpec: BaseUpgrades,
+    ChainSpec: Upgrades,
     F: for<'a> BlockExecutorFactory<
             ExecutionCtx<'a> = BaseBlockExecutionCtx,
             Transaction: SignedTransaction,

--- a/crates/execution/evm/src/l1.rs
+++ b/crates/execution/evm/src/l1.rs
@@ -2,7 +2,7 @@
 
 use alloy_consensus::Transaction;
 use alloy_primitives::{U16, U256, hex};
-use base_common_chains::BaseUpgrades;
+use base_common_chains::Upgrades;
 use base_revm::{L1BlockInfo, OpSpecId};
 use reth_execution_errors::BlockExecutionError;
 use reth_primitives_traits::BlockBody;
@@ -299,9 +299,9 @@ pub fn parse_l1_info_tx_jovian(data: &[u8]) -> Result<L1BlockInfo, BaseBlockExec
     })
 }
 
-/// Returns the [`OpSpecId`] at the given timestamp using the [`BaseUpgrades`] trait from
+/// Returns the [`OpSpecId`] at the given timestamp using the [`Upgrades`] trait from
 /// `base-execution-upgrades`.
-fn op_spec_id(chain_spec: &impl BaseUpgrades, timestamp: u64) -> OpSpecId {
+fn op_spec_id(chain_spec: &impl Upgrades, timestamp: u64) -> OpSpecId {
     if chain_spec.is_base_v1_active_at_timestamp(timestamp) {
         OpSpecId::BASE_V1
     } else if chain_spec.is_jovian_active_at_timestamp(timestamp) {
@@ -337,7 +337,7 @@ pub trait RethL1BlockInfo {
     /// - `is_deposit`: Whether or not the transaction is a deposit.
     fn l1_tx_data_fee(
         &mut self,
-        chain_spec: impl BaseUpgrades,
+        chain_spec: impl Upgrades,
         timestamp: u64,
         input: &[u8],
         is_deposit: bool,
@@ -351,7 +351,7 @@ pub trait RethL1BlockInfo {
     /// - `input`: The calldata of the transaction.
     fn l1_data_gas(
         &self,
-        chain_spec: impl BaseUpgrades,
+        chain_spec: impl Upgrades,
         timestamp: u64,
         input: &[u8],
     ) -> Result<U256, BlockExecutionError>;
@@ -360,7 +360,7 @@ pub trait RethL1BlockInfo {
 impl RethL1BlockInfo for L1BlockInfo {
     fn l1_tx_data_fee(
         &mut self,
-        chain_spec: impl BaseUpgrades,
+        chain_spec: impl Upgrades,
         timestamp: u64,
         input: &[u8],
         is_deposit: bool,
@@ -375,7 +375,7 @@ impl RethL1BlockInfo for L1BlockInfo {
 
     fn l1_data_gas(
         &self,
-        chain_spec: impl BaseUpgrades,
+        chain_spec: impl Upgrades,
         timestamp: u64,
         input: &[u8],
     ) -> Result<U256, BlockExecutionError> {
@@ -389,7 +389,7 @@ mod tests {
     use alloy_consensus::{Block, BlockBody, Header};
     use alloy_eips::eip2718::Decodable2718;
     use alloy_primitives::{Bytes, hex_literal::hex, keccak256};
-    use base_common_chains::BaseUpgrades;
+    use base_common_chains::Upgrades;
     use base_common_consensus::BaseTransactionSigned;
     use base_execution_chainspec::BASE_MAINNET;
 

--- a/crates/execution/evm/src/lib.rs
+++ b/crates/execution/evm/src/lib.rs
@@ -15,7 +15,7 @@ use core::fmt::Debug;
 
 use alloy_consensus::{BlockHeader, Header};
 use alloy_evm::{EvmFactory, FromRecoveredTx, FromTxWithEncoded};
-use base_common_chains::BaseUpgrades;
+use base_common_chains::Upgrades;
 use base_common_consensus::{BasePrimitives, DepositReceiptExt, EIP1559ParamError};
 use base_common_evm::{
     BaseBlockExecutionCtx, BaseBlockExecutorFactory, BaseEvmFactory, BaseReceiptBuilder, BaseTxEnv,
@@ -58,10 +58,7 @@ mod error;
 pub use error::{BaseBlockExecutionError, L1BlockInfoError};
 
 /// Builds an [`EvmEnv`] for a given block header using [`base_common_evm`]'s spec resolution.
-fn op_evm_env(
-    header: &Header,
-    chain_spec: &(impl BaseUpgrades + EthChainSpec),
-) -> EvmEnv<OpSpecId> {
+fn op_evm_env(header: &Header, chain_spec: &(impl Upgrades + EthChainSpec)) -> EvmEnv<OpSpecId> {
     let spec = revm_spec_by_timestamp_after_bedrock(chain_spec, header.timestamp);
     let cfg_env =
         CfgEnv::new().with_chain_id(chain_spec.chain().id()).with_spec_and_mainnet_gas_params(spec);
@@ -92,7 +89,7 @@ fn op_next_evm_env(
     parent: &Header,
     attributes: &OpNextBlockEnvAttributes,
     base_fee_per_gas: u64,
-    chain_spec: &(impl BaseUpgrades + EthChainSpec),
+    chain_spec: &(impl Upgrades + EthChainSpec),
 ) -> EvmEnv<OpSpecId> {
     let spec = revm_spec_by_timestamp_after_bedrock(chain_spec, attributes.timestamp);
     let cfg_env =
@@ -147,14 +144,14 @@ impl<ChainSpec, N: NodePrimitives, R: Clone, EvmFactory: Clone> Clone
     }
 }
 
-impl<ChainSpec: BaseUpgrades> BaseEvmConfig<ChainSpec> {
+impl<ChainSpec: Upgrades> BaseEvmConfig<ChainSpec> {
     /// Creates a new [`BaseEvmConfig`] with the given chain spec for Base chains.
     pub fn optimism(chain_spec: Arc<ChainSpec>) -> Self {
         Self::new(chain_spec, OpRethReceiptBuilder::default())
     }
 }
 
-impl<ChainSpec: BaseUpgrades, N: NodePrimitives, R> BaseEvmConfig<ChainSpec, N, R> {
+impl<ChainSpec: Upgrades, N: NodePrimitives, R> BaseEvmConfig<ChainSpec, N, R> {
     /// Creates a new [`BaseEvmConfig`] with the given chain spec.
     pub fn new(chain_spec: Arc<ChainSpec>, receipt_builder: R) -> Self {
         Self {
@@ -171,7 +168,7 @@ impl<ChainSpec: BaseUpgrades, N: NodePrimitives, R> BaseEvmConfig<ChainSpec, N, 
 
 impl<ChainSpec, N, R, EvmFactory> BaseEvmConfig<ChainSpec, N, R, EvmFactory>
 where
-    ChainSpec: BaseUpgrades,
+    ChainSpec: Upgrades,
     N: NodePrimitives,
 {
     /// Returns the chain spec associated with this configuration.
@@ -182,7 +179,7 @@ where
 
 impl<ChainSpec, N, R, EvmF> ConfigureEvm for BaseEvmConfig<ChainSpec, N, R, EvmF>
 where
-    ChainSpec: EthChainSpec<Header = Header> + BaseUpgrades,
+    ChainSpec: EthChainSpec<Header = Header> + Upgrades,
     N: NodePrimitives<
             Receipt = R::Receipt,
             SignedTx = R::Transaction,
@@ -259,7 +256,7 @@ where
 #[cfg(feature = "std")]
 impl<ChainSpec, N, R> ConfigureEngineEvm<ExecutionData> for BaseEvmConfig<ChainSpec, N, R>
 where
-    ChainSpec: EthChainSpec<Header = Header> + BaseUpgrades,
+    ChainSpec: EthChainSpec<Header = Header> + Upgrades,
     N: NodePrimitives<
             Receipt = R::Receipt,
             SignedTx = R::Transaction,

--- a/crates/execution/flashblocks/src/processor.rs
+++ b/crates/execution/flashblocks/src/processor.rs
@@ -11,7 +11,7 @@ use alloy_network::TransactionResponse;
 use alloy_primitives::{Address, BlockNumber};
 use alloy_rpc_types_eth::state::StateOverride;
 use arc_swap::ArcSwapOption;
-use base_common_chains::BaseUpgrades;
+use base_common_chains::Upgrades;
 use base_common_consensus::{BaseBlock, BaseTxEnvelope};
 use base_common_flashblocks::Flashblock;
 use base_execution_evm::{BaseEvmConfig, OpNextBlockEnvAttributes};
@@ -57,7 +57,7 @@ pub struct StateProcessor<Client> {
 impl<Client> StateProcessor<Client>
 where
     Client: StateProviderFactory
-        + ChainSpecProvider<ChainSpec: EthChainSpec<Header = Header> + BaseUpgrades>
+        + ChainSpecProvider<ChainSpec: EthChainSpec<Header = Header> + Upgrades>
         + BlockReaderIdExt<Header = Header>
         + Clone
         + 'static,

--- a/crates/execution/flashblocks/src/receipt_builder.rs
+++ b/crates/execution/flashblocks/src/receipt_builder.rs
@@ -4,7 +4,7 @@
 //! transactions seamlessly, without requiring error handling at the call site.
 
 use alloy_consensus::{Eip658Value, Receipt, transaction::Recovered};
-use base_common_chains::BaseUpgrades;
+use base_common_chains::Upgrades;
 use base_common_consensus::{BaseReceipt, BaseTxEnvelope, BaseTxType, DepositReceipt};
 use reth_evm::Evm;
 use revm::{Database, context::result::ExecutionResult};
@@ -47,7 +47,7 @@ impl<C> UnifiedReceiptBuilder<C> {
     }
 }
 
-impl<C: BaseUpgrades> UnifiedReceiptBuilder<C> {
+impl<C: Upgrades> UnifiedReceiptBuilder<C> {
     /// Builds a receipt for any transaction type, handling deposit receipts internally.
     ///
     /// This method builds either a regular receipt or a deposit receipt based on

--- a/crates/execution/flashblocks/src/state.rs
+++ b/crates/execution/flashblocks/src/state.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 
 use alloy_consensus::Header;
 use arc_swap::{ArcSwapOption, Guard};
-use base_common_chains::BaseUpgrades;
+use base_common_chains::Upgrades;
 use base_common_consensus::BaseBlock;
 use base_common_flashblocks::Flashblock;
 use reth_chainspec::{ChainSpecProvider, EthChainSpec};
@@ -60,7 +60,7 @@ impl FlashblocksState {
     pub fn start<Client>(&self, client: Client)
     where
         Client: StateProviderFactory
-            + ChainSpecProvider<ChainSpec: EthChainSpec<Header = Header> + BaseUpgrades>
+            + ChainSpecProvider<ChainSpec: EthChainSpec<Header = Header> + Upgrades>
             + BlockReaderIdExt<Header = Header>
             + Clone
             + 'static,

--- a/crates/execution/flashblocks/src/state_builder.rs
+++ b/crates/execution/flashblocks/src/state_builder.rs
@@ -12,7 +12,7 @@ use alloy_evm::{
 use alloy_primitives::B256;
 use alloy_rpc_types::TransactionTrait;
 use alloy_rpc_types_eth::state::StateOverride;
-use base_common_chains::BaseUpgrades;
+use base_common_chains::Upgrades;
 use base_common_consensus::{BasePrimitives, BaseReceipt, BaseTxEnvelope};
 use base_common_evm::ensure_create2_deployer;
 use base_common_flz::tx_estimated_size_fjord as estimate_tx_compressed_size;
@@ -76,7 +76,7 @@ where
     E: Evm<DB = DB, HaltReason = OpHaltReason>,
     DB: Database + DatabaseCommit,
     E::Tx: FromRecoveredTx<BaseTxEnvelope>,
-    ChainSpec: BaseUpgrades + Clone,
+    ChainSpec: Upgrades + Clone,
 {
     /// Creates a new pending state builder.
     pub fn new(

--- a/crates/execution/node/src/engine.rs
+++ b/crates/execution/node/src/engine.rs
@@ -3,7 +3,7 @@ use std::{marker::PhantomData, sync::Arc};
 use alloy_consensus::BlockHeader;
 use alloy_primitives::B256;
 use alloy_rpc_types_engine::{ExecutionPayloadEnvelopeV2, ExecutionPayloadV1};
-use base_common_chains::BaseUpgrades;
+use base_common_chains::Upgrades;
 use base_common_consensus::BaseBlock;
 use base_common_rpc_types_engine::{
     BaseExecutionPayloadEnvelopeV3, BaseExecutionPayloadEnvelopeV4, BaseExecutionPayloadEnvelopeV5,
@@ -90,7 +90,7 @@ impl<P, Tx, ChainSpec> OpEngineValidator<P, Tx, ChainSpec> {
 impl<P, Tx, ChainSpec> Clone for OpEngineValidator<P, Tx, ChainSpec>
 where
     P: Clone,
-    ChainSpec: BaseUpgrades,
+    ChainSpec: Upgrades,
 {
     fn clone(&self) -> Self {
         Self {
@@ -104,7 +104,7 @@ where
 
 impl<P, Tx, ChainSpec> OpEngineValidator<P, Tx, ChainSpec>
 where
-    ChainSpec: BaseUpgrades,
+    ChainSpec: Upgrades,
 {
     /// Returns the chain spec used by the validator.
     #[inline]
@@ -117,7 +117,7 @@ impl<P, Tx, ChainSpec, Types> PayloadValidator<Types> for OpEngineValidator<P, T
 where
     P: StateProviderFactory + Unpin + 'static,
     Tx: SignedTransaction + Unpin + 'static,
-    ChainSpec: BaseUpgrades + Send + Sync + 'static,
+    ChainSpec: Upgrades + Send + Sync + 'static,
     Types: PayloadTypes<ExecutionData = ExecutionData>,
 {
     type Block = alloy_consensus::Block<Tx>;
@@ -169,7 +169,7 @@ where
         >,
     P: StateProviderFactory + Unpin + 'static,
     Tx: SignedTransaction + Unpin + 'static,
-    ChainSpec: BaseUpgrades + Send + Sync + 'static,
+    ChainSpec: Upgrades + Send + Sync + 'static,
 {
     fn validate_version_specific_fields(
         &self,
@@ -262,7 +262,7 @@ where
 /// Canyon activates the Shanghai EIPs, see the Canyon specs for more details:
 /// <https://github.com/ethereum-optimism/optimism/blob/ab926c5fd1e55b5c864341c44842d6d1ca679d99/specs/superchain-upgrades.md#canyon>
 pub fn validate_withdrawals_presence(
-    chain_spec: impl BaseUpgrades,
+    chain_spec: impl Upgrades,
     version: EngineApiMessageVersion,
     message_validation_kind: MessageValidationKind,
     timestamp: u64,
@@ -303,7 +303,7 @@ pub fn validate_withdrawals_presence(
 mod tests {
     use alloy_primitives::{Address, B64, B256, b64};
     use alloy_rpc_types_engine::PayloadAttributes;
-    use base_common_chains::BaseChainConfig;
+    use base_common_chains::ChainConfig;
     use base_execution_chainspec::BASE_SEPOLIA;
     use reth_provider::noop::NoopProvider;
     use reth_trie_common::KeccakKeyHasher;
@@ -449,7 +449,7 @@ mod tests {
         let attributes = get_attributes(
             Some(b64!("0000000000000000")),
             Some(1),
-            BaseChainConfig::sepolia().jovian_timestamp,
+            ChainConfig::sepolia().jovian_timestamp,
         );
 
         let result = <engine::OpEngineValidator<_, _, _> as EngineApiValidator<
@@ -467,7 +467,7 @@ mod tests {
             BASE_SEPOLIA.clone(),
             NoopProvider::default(),
         );
-        let attributes = get_attributes(None, Some(1), BaseChainConfig::sepolia().jovian_timestamp);
+        let attributes = get_attributes(None, Some(1), ChainConfig::sepolia().jovian_timestamp);
 
         let result = <engine::OpEngineValidator<_, _, _> as EngineApiValidator<
             OpEngineTypes,
@@ -504,7 +504,7 @@ mod tests {
         let attributes = get_attributes(
             Some(b64!("0000000000000000")),
             None,
-            BaseChainConfig::sepolia().jovian_timestamp,
+            ChainConfig::sepolia().jovian_timestamp,
         );
 
         let result = <engine::OpEngineValidator<_, _, _> as EngineApiValidator<

--- a/crates/execution/node/src/node.rs
+++ b/crates/execution/node/src/node.rs
@@ -4,7 +4,7 @@ use std::{marker::PhantomData, sync::Arc};
 
 use alloy_consensus::BlockHeader;
 use alloy_primitives::{Address, B64, B256};
-use base_common_chains::BaseUpgrades;
+use base_common_chains::Upgrades;
 use base_common_consensus::BasePrimitives;
 use base_common_rpc_types_engine::{BasePayloadAttributes, ExecutionData};
 use base_execution_chainspec::BaseChainSpec;
@@ -984,7 +984,7 @@ impl<Txs> OpPayloadBuilder<Txs> {
 impl<Node, Pool, Txs, Evm, Attrs> PayloadBuilderBuilder<Node, Pool, Evm> for OpPayloadBuilder<Txs>
 where
     Node: FullNodeTypes<
-            Provider: ChainSpecProvider<ChainSpec: BaseUpgrades>,
+            Provider: ChainSpecProvider<ChainSpec: Upgrades>,
             Types: NodeTypes<
                 Primitives: PayloadPrimitives,
                 Payload: PayloadTypes<
@@ -1150,10 +1150,7 @@ pub struct OpEngineValidatorBuilder;
 impl<Node> PayloadValidatorBuilder<Node> for OpEngineValidatorBuilder
 where
     Node: FullNodeComponents<
-        Types: NodeTypes<
-            ChainSpec: BaseUpgrades,
-            Payload: PayloadTypes<ExecutionData = ExecutionData>,
-        >,
+        Types: NodeTypes<ChainSpec: Upgrades, Payload: PayloadTypes<ExecutionData = ExecutionData>>,
     >,
 {
     type Validator = OpEngineValidator<

--- a/crates/execution/payload/src/builder.rs
+++ b/crates/execution/payload/src/builder.rs
@@ -6,7 +6,7 @@ use alloy_evm::Evm as AlloyEvm;
 use alloy_primitives::{B256, U256};
 use alloy_rpc_types_debug::ExecutionWitness;
 use alloy_rpc_types_engine::PayloadId;
-use base_common_chains::BaseUpgrades;
+use base_common_chains::Upgrades;
 use base_common_consensus::BaseTransaction;
 use base_execution_txpool::{OpPooledTx, estimated_da_size::DataAvailabilitySized};
 use base_protocol::Predeploys;
@@ -156,7 +156,7 @@ impl<Pool, Client, Evm, Txs, Attrs> OpPayloadBuilder<Pool, Client, Evm, Txs, Att
 impl<Pool, Client, Evm, N, T, Attrs> OpPayloadBuilder<Pool, Client, Evm, T, Attrs>
 where
     Pool: TransactionPool<Transaction: OpPooledTx<Consensus = N::SignedTx>>,
-    Client: StateProviderFactory + ChainSpecProvider<ChainSpec: BaseUpgrades>,
+    Client: StateProviderFactory + ChainSpecProvider<ChainSpec: Upgrades>,
     N: PayloadPrimitives,
     Evm: ConfigureEvm<
             Primitives = N,
@@ -240,7 +240,7 @@ impl<Pool, Client, Evm, N, Txs, Attrs> PayloadBuilder
     for OpPayloadBuilder<Pool, Client, Evm, Txs, Attrs>
 where
     N: PayloadPrimitives,
-    Client: StateProviderFactory + ChainSpecProvider<ChainSpec: BaseUpgrades> + Clone,
+    Client: StateProviderFactory + ChainSpecProvider<ChainSpec: Upgrades> + Clone,
     Pool: TransactionPool<Transaction: OpPooledTx<Consensus = N::SignedTx>>,
     Evm: ConfigureEvm<
             Primitives = N,
@@ -329,7 +329,7 @@ impl<Txs> Builder<'_, Txs> {
                 Primitives = N,
                 NextBlockEnvCtx: BuildNextEnv<Attrs, N::BlockHeader, ChainSpec>,
             >,
-        ChainSpec: EthChainSpec + BaseUpgrades,
+        ChainSpec: EthChainSpec + Upgrades,
         N: PayloadPrimitives,
         Txs:
             PayloadTransactions<Transaction: PoolTransaction<Consensus = N::SignedTx> + OpPooledTx>,
@@ -414,7 +414,7 @@ impl<Txs> Builder<'_, Txs> {
                 Primitives = N,
                 NextBlockEnvCtx: BuildNextEnv<Attrs, N::BlockHeader, ChainSpec>,
             >,
-        ChainSpec: EthChainSpec + BaseUpgrades,
+        ChainSpec: EthChainSpec + Upgrades,
         N: PayloadPrimitives,
         Txs: PayloadTransactions<Transaction: PoolTransaction<Consensus = N::SignedTx>>,
         Attrs: Attributes<Transaction = N::SignedTx>,
@@ -563,7 +563,7 @@ where
             Primitives: PayloadPrimitives,
             NextBlockEnvCtx: BuildNextEnv<Attrs, HeaderTy<Evm::Primitives>, ChainSpec>,
         >,
-    ChainSpec: EthChainSpec + BaseUpgrades,
+    ChainSpec: EthChainSpec + Upgrades,
     Attrs: Attributes<Transaction = TxTy<Evm::Primitives>>,
 {
     /// Returns the parent block the payload will be build on.

--- a/crates/execution/payload/src/payload.rs
+++ b/crates/execution/payload/src/payload.rs
@@ -12,7 +12,7 @@ use alloy_rpc_types_engine::{
     BlobsBundleV1, BlobsBundleV2, ExecutionPayloadEnvelopeV2, ExecutionPayloadFieldV2,
     ExecutionPayloadV1, ExecutionPayloadV3, PayloadId,
 };
-use base_common_chains::BaseUpgrades;
+use base_common_chains::Upgrades;
 use base_common_consensus::{
     BasePrimitives, EIP1559ParamError, HoloceneExtraData, JovianExtraData,
 };
@@ -442,7 +442,7 @@ impl<H, T, ChainSpec> BuildNextEnv<OpPayloadBuilderAttributes<T>, H, ChainSpec>
 where
     H: BlockHeader,
     T: SignedTransaction,
-    ChainSpec: EthChainSpec + BaseUpgrades,
+    ChainSpec: EthChainSpec + Upgrades,
 {
     fn build_next_env(
         attributes: &OpPayloadBuilderAttributes<T>,

--- a/crates/execution/payload/src/validator.rs
+++ b/crates/execution/payload/src/validator.rs
@@ -4,7 +4,7 @@ use alloc::sync::Arc;
 
 use alloy_consensus::Block;
 use alloy_rpc_types_engine::PayloadError;
-use base_common_chains::BaseUpgrades;
+use base_common_chains::Upgrades;
 use base_common_rpc_types_engine::{BasePayloadError, ExecutionData};
 use derive_more::{Constructor, Deref};
 use reth_payload_validator::{cancun, prague, shanghai};
@@ -20,7 +20,7 @@ pub struct OpExecutionPayloadValidator<ChainSpec> {
 
 impl<ChainSpec> OpExecutionPayloadValidator<ChainSpec>
 where
-    ChainSpec: BaseUpgrades,
+    ChainSpec: Upgrades,
 {
     /// Returns reference to chain spec.
     pub fn chain_spec(&self) -> &ChainSpec {
@@ -62,7 +62,7 @@ pub fn ensure_well_formed_payload<ChainSpec, T>(
     payload: ExecutionData,
 ) -> Result<SealedBlock<Block<T>>, BasePayloadError>
 where
-    ChainSpec: BaseUpgrades,
+    ChainSpec: Upgrades,
     T: SignedTransaction,
 {
     let ExecutionData { payload, sidecar } = payload;

--- a/crates/execution/revm/src/rollup_config.rs
+++ b/crates/execution/revm/src/rollup_config.rs
@@ -36,7 +36,7 @@ impl RollupConfigExt for RollupConfig {
 
 #[cfg(test)]
 mod tests {
-    use base_consensus_genesis::{BaseHardforkConfig, HardForkConfig, RollupConfig};
+    use base_consensus_genesis::{HardForkConfig, HardforkConfig, RollupConfig};
 
     use super::*;
 
@@ -60,10 +60,10 @@ mod tests {
         assert_eq!(config.spec_id(60), OpSpecId::ISTHMUS);
         config.hardforks.jovian_time = Some(65);
         assert_eq!(config.spec_id(65), OpSpecId::JOVIAN);
-        config.hardforks.base = BaseHardforkConfig { v1: Some(70) };
+        config.hardforks.base = HardforkConfig { v1: Some(70) };
         assert_eq!(config.spec_id(70), OpSpecId::BASE_V1);
         // V1 takes precedence over Jovian when both are active at the same timestamp
-        config.hardforks.base = BaseHardforkConfig { v1: Some(65) };
+        config.hardforks.base = HardforkConfig { v1: Some(65) };
         assert_eq!(config.spec_id(65), OpSpecId::BASE_V1);
     }
 }

--- a/crates/execution/rpc/src/config.rs
+++ b/crates/execution/rpc/src/config.rs
@@ -7,7 +7,7 @@ use alloy_eips::{
     eip7840::BlobParams,
     eip7910::{EthConfig, EthForkConfig, SystemContract},
 };
-use base_common_chains::BaseUpgrades;
+use base_common_chains::Upgrades;
 use jsonrpsee::{core::RpcResult, proc_macros::rpc};
 use reth_chainspec::{ChainSpecProvider, EthereumHardforks, Hardforks};
 use reth_evm::ConfigureEvm;
@@ -30,10 +30,7 @@ const fn zero_blob_params() -> BlobParams {
     }
 }
 
-fn sanitize_system_contracts_for_fork(
-    chain_spec: &impl BaseUpgrades,
-    fork_config: &mut EthForkConfig,
-) {
+fn sanitize_system_contracts_for_fork(chain_spec: &impl Upgrades, fork_config: &mut EthForkConfig) {
     let activation_time = fork_config.activation_time;
 
     fork_config.system_contracts.retain(|contract, _| match contract {
@@ -83,7 +80,7 @@ pub struct BaseEthConfigHandler<Provider: ChainSpecProvider, Evm> {
 
 impl<Provider, Evm> BaseEthConfigHandler<Provider, Evm>
 where
-    Provider: ChainSpecProvider<ChainSpec: Hardforks + EthereumHardforks + BaseUpgrades>
+    Provider: ChainSpecProvider<ChainSpec: Hardforks + EthereumHardforks + Upgrades>
         + BlockReaderIdExt<Header: HeaderMut>
         + Clone
         + 'static,
@@ -111,7 +108,7 @@ where
 
 impl<Provider, Evm> BaseEthConfigApiServer for BaseEthConfigHandler<Provider, Evm>
 where
-    Provider: ChainSpecProvider<ChainSpec: Hardforks + EthereumHardforks + BaseUpgrades>
+    Provider: ChainSpecProvider<ChainSpec: Hardforks + EthereumHardforks + Upgrades>
         + BlockReaderIdExt<Header: HeaderMut>
         + Clone
         + 'static,

--- a/crates/execution/rpc/src/debug.rs
+++ b/crates/execution/rpc/src/debug.rs
@@ -8,7 +8,7 @@ use alloy_primitives::B256;
 use alloy_rlp::Encodable;
 use alloy_rpc_types_debug::ExecutionWitness;
 use async_trait::async_trait;
-use base_common_chains::BaseUpgrades;
+use base_common_chains::Upgrades;
 use base_execution_payload_builder::{
     Attributes, PayloadPrimitives,
     builder::{Builder, OpPayloadBuilderCtx},
@@ -178,7 +178,7 @@ where
         > + 'static,
     Provider: BlockReaderIdExt<Header = N::BlockHeader>
         + StateProviderFactory
-        + ChainSpecProvider<ChainSpec: BaseUpgrades>
+        + ChainSpecProvider<ChainSpec: Upgrades>
         + NodePrimitivesProvider<Primitives = N>
         + HeaderProvider<Header = N::BlockHeader>
         + Clone

--- a/crates/execution/rpc/src/eth/receipt.rs
+++ b/crates/execution/rpc/src/eth/receipt.rs
@@ -5,7 +5,7 @@ use std::fmt::Debug;
 use alloy_consensus::{BlockHeader, Receipt, ReceiptWithBloom, TxReceipt};
 use alloy_eips::eip2718::Encodable2718;
 use alloy_rpc_types_eth::{Log, TransactionReceipt};
-use base_common_chains::BaseUpgrades;
+use base_common_chains::Upgrades;
 use base_common_consensus::{BaseReceipt, BaseTransaction};
 use base_common_flz::tx_estimated_size_fjord as estimate_tx_compressed_size;
 use base_common_rpc_types::{BaseTransactionReceipt, L1BlockInfo, TransactionReceiptFields};
@@ -46,10 +46,8 @@ impl<Provider> BaseReceiptConverter<Provider> {
 impl<Provider, N> ReceiptConverter<N> for BaseReceiptConverter<Provider>
 where
     N: NodePrimitives<SignedTx: BaseTransaction, Receipt = BaseReceipt>,
-    Provider: BlockReader<Block = N::Block>
-        + ChainSpecProvider<ChainSpec: BaseUpgrades>
-        + Debug
-        + 'static,
+    Provider:
+        BlockReader<Block = N::Block> + ChainSpecProvider<ChainSpec: Upgrades> + Debug + 'static,
 {
     type RpcReceipt = BaseTransactionReceipt;
     type Error = OpEthApiError;
@@ -171,7 +169,7 @@ impl ReceiptFieldsBuilder {
     /// Applies [`L1BlockInfo`](base_revm::L1BlockInfo).
     pub fn l1_block_info<T: Encodable2718 + BaseTransaction>(
         mut self,
-        chain_spec: &impl BaseUpgrades,
+        chain_spec: &impl Upgrades,
         tx: &T,
         l1_block_info: &mut base_revm::L1BlockInfo,
     ) -> Result<Self, OpEthApiError> {
@@ -283,7 +281,7 @@ pub struct BaseReceiptBuilder {
 impl BaseReceiptBuilder {
     /// Returns a new builder.
     pub fn new<N>(
-        chain_spec: &impl BaseUpgrades,
+        chain_spec: &impl Upgrades,
         input: ConvertReceiptInput<'_, N>,
         l1_block_info: &mut base_revm::L1BlockInfo,
     ) -> Result<Self, OpEthApiError>
@@ -347,7 +345,7 @@ mod tests {
     use alloy_consensus::{Block, BlockBody, Eip658Value, TxEip7702, transaction::TransactionMeta};
     use alloy_eips::eip2718::Decodable2718;
     use alloy_primitives::{Address, Bytes, Signature, U256, hex};
-    use base_common_chains::BaseChainConfig;
+    use base_common_chains::ChainConfig;
     use base_common_consensus::{BasePrimitives, BaseTransactionSigned, BaseTypedTransaction};
     use base_execution_chainspec::BASE_MAINNET;
     use reth_primitives_traits::Recovered;
@@ -415,10 +413,7 @@ mod tests {
             base_execution_evm::extract_l1_info(&block.body).expect("should extract l1 info");
 
         // test
-        assert!(BaseUpgrades::is_fjord_active_at_timestamp(
-            &*BASE_MAINNET,
-            BLOCK_124665056_TIMESTAMP
-        ));
+        assert!(Upgrades::is_fjord_active_at_timestamp(&*BASE_MAINNET, BLOCK_124665056_TIMESTAMP));
 
         let receipt_meta = ReceiptFieldsBuilder::new(BLOCK_124665056_TIMESTAMP, 124665056)
             .l1_block_info(&*BASE_MAINNET, &tx_1, &mut l1_block_info)
@@ -614,11 +609,10 @@ mod tests {
 
         let op_hardforks = &*BASE_MAINNET;
 
-        let receipt =
-            ReceiptFieldsBuilder::new(BaseChainConfig::mainnet().jovian_timestamp, u64::MAX)
-                .l1_block_info(&op_hardforks, &tx, &mut l1_block_info)
-                .expect("should parse revm l1 info")
-                .build();
+        let receipt = ReceiptFieldsBuilder::new(ChainConfig::mainnet().jovian_timestamp, u64::MAX)
+            .l1_block_info(&op_hardforks, &tx, &mut l1_block_info)
+            .expect("should parse revm l1 info")
+            .build();
 
         assert_eq!(receipt.l1_block_info.da_footprint_gas_scalar, Some(DA_FOOTPRINT_GAS_SCALAR));
     }
@@ -662,7 +656,7 @@ mod tests {
                 gas_used: 100,
                 next_log_index: 0,
                 meta: TransactionMeta {
-                    timestamp: BaseChainConfig::mainnet().jovian_timestamp,
+                    timestamp: ChainConfig::mainnet().jovian_timestamp,
                     ..Default::default()
                 },
             },
@@ -716,7 +710,7 @@ mod tests {
                 gas_used: 100,
                 next_log_index: 0,
                 meta: TransactionMeta {
-                    timestamp: BaseChainConfig::mainnet().isthmus_timestamp,
+                    timestamp: ChainConfig::mainnet().isthmus_timestamp,
                     ..Default::default()
                 },
             },

--- a/crates/execution/rpc/src/witness.rs
+++ b/crates/execution/rpc/src/witness.rs
@@ -4,7 +4,7 @@ use std::{fmt::Debug, sync::Arc};
 
 use alloy_primitives::B256;
 use alloy_rpc_types_debug::ExecutionWitness;
-use base_common_chains::BaseUpgrades;
+use base_common_chains::Upgrades;
 use base_execution_payload_builder::{Attributes, OpPayloadBuilder, PayloadPrimitives};
 use base_execution_txpool::OpPooledTx;
 use jsonrpsee_core::{RpcResult, async_trait};
@@ -68,7 +68,7 @@ where
     Provider: BlockReaderIdExt<Header = <Provider::Primitives as NodePrimitives>::BlockHeader>
         + NodePrimitivesProvider<Primitives: PayloadPrimitives>
         + StateProviderFactory
-        + ChainSpecProvider<ChainSpec: BaseUpgrades>
+        + ChainSpecProvider<ChainSpec: Upgrades>
         + Clone
         + 'static,
     EvmConfig: ConfigureEvm<

--- a/crates/execution/txpool/src/validator.rs
+++ b/crates/execution/txpool/src/validator.rs
@@ -4,7 +4,7 @@ use std::sync::{
 };
 
 use alloy_consensus::{BlockHeader, Transaction};
-use base_common_chains::BaseUpgrades;
+use base_common_chains::Upgrades;
 use base_execution_evm::RethL1BlockInfo;
 use base_revm::L1BlockInfo;
 use parking_lot::RwLock;
@@ -85,8 +85,7 @@ impl<Client, Tx, Evm> OpTransactionValidator<Client, Tx, Evm> {
 
 impl<Client, Tx, Evm> OpTransactionValidator<Client, Tx, Evm>
 where
-    Client:
-        ChainSpecProvider<ChainSpec: BaseUpgrades> + StateProviderFactory + BlockReaderIdExt + Sync,
+    Client: ChainSpecProvider<ChainSpec: Upgrades> + StateProviderFactory + BlockReaderIdExt + Sync,
     Tx: EthPoolTransaction + OpPooledTx,
     Evm: ConfigureEvm,
 {
@@ -239,8 +238,7 @@ where
 
 impl<Client, Tx, Evm> TransactionValidator for OpTransactionValidator<Client, Tx, Evm>
 where
-    Client:
-        ChainSpecProvider<ChainSpec: BaseUpgrades> + StateProviderFactory + BlockReaderIdExt + Sync,
+    Client: ChainSpecProvider<ChainSpec: Upgrades> + StateProviderFactory + BlockReaderIdExt + Sync,
     Tx: EthPoolTransaction + OpPooledTx,
     Evm: ConfigureEvm,
 {

--- a/crates/execution/upgrades/src/chain.rs
+++ b/crates/execution/upgrades/src/chain.rs
@@ -1,12 +1,12 @@
 use alloc::vec;
 
 use alloy_primitives::U256;
-use base_common_chains::{BaseChainUpgrades, BaseUpgrade};
+use base_common_chains::{BaseUpgrade, ChainUpgrades};
 use reth_ethereum_forks::{ChainHardforks, EthereumHardfork, ForkCondition, Hardfork};
 use spin::Lazy;
 
-/// Extension trait to convert alloy's [`BaseChainUpgrades`] into reth's [`ChainHardforks`].
-pub trait BaseChainUpgradesExt {
+/// Extension trait to convert alloy's [`ChainUpgrades`] into reth's [`ChainHardforks`].
+pub trait ChainUpgradesExt {
     /// Expands Base upgrades into a full [`ChainHardforks`] including implied Ethereum entries.
     ///
     /// Pre-Bedrock Ethereum hardforks are set to block 0. Paired Ethereum hardforks
@@ -15,7 +15,7 @@ pub trait BaseChainUpgradesExt {
     fn to_chain_hardforks(&self) -> ChainHardforks;
 }
 
-impl BaseChainUpgradesExt for BaseChainUpgrades {
+impl ChainUpgradesExt for ChainUpgrades {
     fn to_chain_hardforks(&self) -> ChainHardforks {
         let mut forks: vec::Vec<(Box<dyn Hardfork>, ForkCondition)> = vec![
             (EthereumHardfork::Frontier.boxed(), ForkCondition::Block(0)),
@@ -79,23 +79,23 @@ impl BaseChainUpgradesExt for BaseChainUpgrades {
 
 /// Dev chain upgrades.
 pub static DEV_UPGRADES: Lazy<ChainHardforks> =
-    Lazy::new(|| BaseChainUpgrades::devnet().to_chain_hardforks());
+    Lazy::new(|| ChainUpgrades::devnet().to_chain_hardforks());
 
 /// Base Sepolia chain upgrades.
 pub static BASE_SEPOLIA_UPGRADES: Lazy<ChainHardforks> =
-    Lazy::new(|| BaseChainUpgrades::sepolia().to_chain_hardforks());
+    Lazy::new(|| ChainUpgrades::sepolia().to_chain_hardforks());
 
 /// Base mainnet chain upgrades.
 pub static BASE_MAINNET_UPGRADES: Lazy<ChainHardforks> =
-    Lazy::new(|| BaseChainUpgrades::mainnet().to_chain_hardforks());
+    Lazy::new(|| ChainUpgrades::mainnet().to_chain_hardforks());
 
 /// Base devnet-0-sepolia-dev-0 chain upgrades.
 pub static BASE_DEVNET_0_SEPOLIA_DEV_0_UPGRADES: Lazy<ChainHardforks> =
-    Lazy::new(|| BaseChainUpgrades::base_devnet_0_sepolia_dev_0().to_chain_hardforks());
+    Lazy::new(|| ChainUpgrades::base_devnet_0_sepolia_dev_0().to_chain_hardforks());
 
 /// Base Zeronet chain upgrades.
 pub static BASE_ZERONET_UPGRADES: Lazy<ChainHardforks> =
-    Lazy::new(|| BaseChainUpgrades::zeronet().to_chain_hardforks());
+    Lazy::new(|| ChainUpgrades::zeronet().to_chain_hardforks());
 
 #[cfg(test)]
 mod tests {
@@ -104,7 +104,7 @@ mod tests {
     #[test]
     fn base_v1_expands_to_osaka() {
         let hardforks =
-            BaseChainUpgrades::new(BaseUpgrade::devnet().into_iter().map(|(fork, cond)| {
+            ChainUpgrades::new(BaseUpgrade::devnet().into_iter().map(|(fork, cond)| {
                 if fork == BaseUpgrade::V1 {
                     (fork, ForkCondition::Timestamp(1_000_000))
                 } else {

--- a/crates/execution/upgrades/src/lib.rs
+++ b/crates/execution/upgrades/src/lib.rs
@@ -13,5 +13,5 @@ extern crate alloc;
 mod chain;
 pub use chain::{
     BASE_DEVNET_0_SEPOLIA_DEV_0_UPGRADES, BASE_MAINNET_UPGRADES, BASE_SEPOLIA_UPGRADES,
-    BASE_ZERONET_UPGRADES, BaseChainUpgradesExt, DEV_UPGRADES,
+    BASE_ZERONET_UPGRADES, ChainUpgradesExt, DEV_UPGRADES,
 };

--- a/crates/infra/basectl/src/app/views/upgrades.rs
+++ b/crates/infra/basectl/src/app/views/upgrades.rs
@@ -5,7 +5,7 @@ use std::{
     time::{Duration, SystemTime, UNIX_EPOCH},
 };
 
-use base_common_chains::BaseChainConfig;
+use base_common_chains::ChainConfig;
 use chrono::{DateTime, Utc};
 use crossterm::event::{KeyCode, KeyEvent};
 use jsonrpsee::{
@@ -70,7 +70,7 @@ struct ChainUpgrades {
     specs: Vec<UpgradeSpec>,
 }
 
-fn specs_from_config(cfg: &BaseChainConfig) -> Vec<UpgradeSpec> {
+fn specs_from_config(cfg: &ChainConfig) -> Vec<UpgradeSpec> {
     vec![
         UpgradeSpec { name: "Delta", timestamp: Some(cfg.delta_timestamp) },
         UpgradeSpec { name: "Canyon", timestamp: Some(cfg.canyon_timestamp) },
@@ -104,24 +104,24 @@ fn all_chains() -> [ChainUpgrades; 4] {
         ChainUpgrades {
             display_name: "Devnet",
             rpc: user_config_rpc("alpha").or_else(|| user_config_rpc("devnet")),
-            specs: specs_from_config(BaseChainConfig::alpha()),
+            specs: specs_from_config(ChainConfig::alpha()),
         },
         ChainUpgrades {
             display_name: "Zeronet",
             rpc: user_config_rpc("zeronet"),
-            specs: specs_from_config(BaseChainConfig::zeronet()),
+            specs: specs_from_config(ChainConfig::zeronet()),
         },
         ChainUpgrades {
             display_name: "Sepolia",
             rpc: user_config_rpc("sepolia")
                 .or_else(|| Some("https://sepolia.base.org".to_string())),
-            specs: specs_from_config(BaseChainConfig::sepolia()),
+            specs: specs_from_config(ChainConfig::sepolia()),
         },
         ChainUpgrades {
             display_name: "Mainnet",
             rpc: user_config_rpc("mainnet")
                 .or_else(|| Some("https://mainnet.base.org".to_string())),
-            specs: specs_from_config(BaseChainConfig::mainnet()),
+            specs: specs_from_config(ChainConfig::mainnet()),
         },
     ]
 }

--- a/crates/proof/executor/src/util.rs
+++ b/crates/proof/executor/src/util.rs
@@ -103,7 +103,7 @@ mod test {
     use alloy_primitives::{B64, b64, bytes};
     use alloy_rpc_types_engine::PayloadAttributes;
     use base_common_rpc_types_engine::BasePayloadAttributes;
-    use base_consensus_genesis::{BaseFeeConfig, RollupConfig};
+    use base_consensus_genesis::{FeeConfig, RollupConfig};
 
     use super::decode_holocene_eip_1559_params_block_header;
     use crate::util::{
@@ -172,7 +172,7 @@ mod test {
     #[test]
     fn test_encode_holocene_eip_1559_params_missing() {
         let cfg = RollupConfig {
-            chain_op_config: BaseFeeConfig {
+            chain_op_config: FeeConfig {
                 eip1559_denominator: 50,
                 eip1559_elasticity: 64,
                 eip1559_denominator_canyon: 250,
@@ -187,7 +187,7 @@ mod test {
     #[test]
     fn test_encode_holocene_eip_1559_params_default() {
         let cfg = RollupConfig {
-            chain_op_config: BaseFeeConfig {
+            chain_op_config: FeeConfig {
                 eip1559_denominator: 50,
                 eip1559_elasticity: 64,
                 eip1559_denominator_canyon: 250,
@@ -205,7 +205,7 @@ mod test {
     #[test]
     fn test_encode_holocene_eip_1559_params() {
         let cfg = RollupConfig {
-            chain_op_config: BaseFeeConfig {
+            chain_op_config: FeeConfig {
                 eip1559_denominator: 50,
                 eip1559_elasticity: 64,
                 eip1559_denominator_canyon: 250,

--- a/crates/proof/primitives/src/per_chain_config.rs
+++ b/crates/proof/primitives/src/per_chain_config.rs
@@ -15,7 +15,7 @@ use alloy_chains::Chain;
 use alloy_eips::eip1898::BlockNumHash;
 use alloy_primitives::{Address, B256, U256, keccak256};
 use base_consensus_genesis::{
-    BaseFeeConfig, BaseHardforkConfig, ChainGenesis, HardForkConfig, RollupConfig, SystemConfig,
+    ChainGenesis, FeeConfig, HardForkConfig, HardforkConfig, RollupConfig, SystemConfig,
 };
 
 const VERSION_0: u64 = 0;
@@ -237,9 +237,9 @@ impl PerChainConfig {
                 pectra_blob_schedule_time: None,
                 isthmus_time: Some(0),
                 jovian_time: Some(0),
-                base: BaseHardforkConfig { v1: Some(0) },
+                base: HardforkConfig { v1: Some(0) },
             },
-            chain_op_config: BaseFeeConfig::base_mainnet(),
+            chain_op_config: FeeConfig::base_mainnet(),
         }
     }
 

--- a/crates/proof/tee/nitro-enclave/src/server.rs
+++ b/crates/proof/tee/nitro-enclave/src/server.rs
@@ -3,7 +3,7 @@ use std::sync::LazyLock;
 
 use alloy_primitives::{Address, B256, Bytes, keccak256, map::HashMap};
 use alloy_signer_local::PrivateKeySigner;
-use base_common_chains::BaseChainConfig;
+use base_common_chains::ChainConfig;
 use base_common_evm::BaseEvmFactory;
 use base_consensus_genesis::RollupConfig;
 use base_proof::BootInfo;
@@ -23,13 +23,13 @@ const SIGNER_KEY_ENV_VAR: &str = "OP_ENCLAVE_SIGNER_KEY";
 /// PCR0 is a SHA-384 hash (48 bytes) per the AWS Nitro Enclaves specification.
 const PCR0_LENGTH: usize = 48;
 
-/// Per-chain config hashes derived from [`BaseChainConfig::all`] at first access.
+/// Per-chain config hashes derived from [`ChainConfig::all`] at first access.
 ///
 /// Each entry is `keccak256(PerChainConfig::marshal_binary())` with defaults applied.
 /// Chains that lack a `system_config` in their rollup config are skipped.
 static CONFIG_HASHES: LazyLock<HashMap<u64, B256>> = LazyLock::new(|| {
     let mut map = HashMap::default();
-    for cfg in BaseChainConfig::all() {
+    for cfg in ChainConfig::all() {
         let rollup = RollupConfig::from(cfg);
         if let Some(mut per_chain) = PerChainConfig::from_rollup_config(&rollup) {
             per_chain.force_defaults();
@@ -295,7 +295,7 @@ mod tests {
 
     #[test]
     fn config_hashes_match_registry() {
-        for cfg in BaseChainConfig::all() {
+        for cfg in ChainConfig::all() {
             let chain_id = cfg.chain_id;
             let Some(rollup) = Registry::rollup_config(chain_id) else { continue };
             let Some(mut per_chain) = PerChainConfig::from_rollup_config(rollup) else {
@@ -315,7 +315,7 @@ mod tests {
     #[test]
     #[ignore]
     fn print_real_config_hashes() {
-        for cfg in BaseChainConfig::all() {
+        for cfg in ChainConfig::all() {
             let chain_id = cfg.chain_id;
             let rollup = match Registry::rollup_config(chain_id) {
                 Some(r) => r,


### PR DESCRIPTION
## Summary

Removes the redundant Base prefix from ten infra and chain config types across the workspace: ChainConfig, ChainUpgrades, ChainUpgradesExt, Upgrades, ChainInfo, HardforkInfo, GenesisInfo, FeeInfo, HardforkConfig, and FeeConfig. These names have no collision with alloy, reth, or revm public APIs. The rename touches 61 files but is purely mechanical with no behavior change.