### PR TITLE
ktlo(infra): add base- prefix to infra crate names

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -236,13 +236,13 @@ base-execution-payload-builder = { path = "crates/execution/payload" }
 base-revm = { path = "crates/execution/revm", default-features = false }
 
 # Infra
-based = { path = "crates/infra/based" }
-basectl-cli = { path = "crates/infra/basectl" }
+base-based = { path = "crates/infra/based" }
+base-basectl-cli = { path = "crates/infra/basectl" }
 base-load-tests = { path = "crates/infra/load-tests" }
-audit-archiver-lib = { path = "crates/infra/audit" }
-ingress-rpc-lib = { path = "crates/infra/ingress-rpc" }
-websocket-proxy = { path = "crates/infra/websocket-proxy" }
-mempool-rebroadcaster = { path = "crates/infra/mempool-rebroadcaster" }
+base-audit-archiver-lib = { path = "crates/infra/audit" }
+base-ingress-rpc-lib = { path = "crates/infra/ingress-rpc" }
+base-websocket-proxy = { path = "crates/infra/websocket-proxy" }
+base-mempool-rebroadcaster = { path = "crates/infra/mempool-rebroadcaster" }
 
 # Proof
 base-zk-db = { path = "crates/proof/zk/db" }

--- a/bin/audit-archiver/Cargo.toml
+++ b/bin/audit-archiver/Cargo.toml
@@ -24,6 +24,6 @@ rdkafka.workspace = true
 aws-config.workspace = true
 aws-sdk-s3.workspace = true
 base-cli-utils.workspace = true
-audit-archiver-lib.workspace = true
+base-audit-archiver-lib.workspace = true
 aws-credential-types.workspace = true
 tracing = { workspace = true, features = ["std"] }

--- a/bin/basectl/Cargo.toml
+++ b/bin/basectl/Cargo.toml
@@ -13,7 +13,7 @@ workspace = true
 
 [dependencies]
 anyhow = { workspace = true }
-basectl-cli = { workspace = true }
+base-basectl-cli = { workspace = true }
 rustls = { workspace = true, features = ["ring"] }
 clap = { workspace = true, features = ["derive"] }
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }

--- a/bin/ingress-rpc/Cargo.toml
+++ b/bin/ingress-rpc/Cargo.toml
@@ -25,7 +25,7 @@ jsonrpsee.workspace = true
 base-bundles.workspace = true
 alloy-provider.workspace = true
 base-cli-utils.workspace = true
-ingress-rpc-lib.workspace = true
+base-ingress-rpc-lib.workspace = true
 base-common-network.workspace = true
-audit-archiver-lib.workspace = true
+base-audit-archiver-lib.workspace = true
 tracing = { workspace = true, features = ["std"] }

--- a/crates/infra/audit/Cargo.toml
+++ b/crates/infra/audit/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "audit-archiver-lib"
+name = "base-audit-archiver-lib"
 version.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/infra/basectl/Cargo.toml
+++ b/crates/infra/basectl/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "basectl-cli"
+name = "base-basectl-cli"
 version.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/crates/infra/based/Cargo.toml
+++ b/crates/infra/based/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "based"
+name = "base-based"
 version.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/crates/infra/ingress-rpc/Cargo.toml
+++ b/crates/infra/ingress-rpc/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "ingress-rpc-lib"
+name = "base-ingress-rpc-lib"
 version.workspace = true
 rust-version.workspace = true
 license.workspace = true
@@ -18,7 +18,7 @@ base-bundles.workspace = true
 alloy-signer-local.workspace = true
 base-execution-evm.workspace = true
 base-common-network.workspace = true
-audit-archiver-lib.workspace = true
+base-audit-archiver-lib.workspace = true
 reth-rpc-eth-types.workspace = true
 uuid = { workspace = true, features = ["v5"] }
 metrics = { workspace = true, optional = true }

--- a/crates/infra/mempool-rebroadcaster/Cargo.toml
+++ b/crates/infra/mempool-rebroadcaster/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "mempool-rebroadcaster"
+name = "base-mempool-rebroadcaster"
 version.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/crates/infra/websocket-proxy/Cargo.toml
+++ b/crates/infra/websocket-proxy/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "websocket-proxy"
+name = "base-websocket-proxy"
 description = "WebSocket Proxy"
 version.workspace = true
 edition.workspace = true


### PR DESCRIPTION
Fixes #2053

Six crates in crates/infra/ were missing the required base- prefix per CLAUDE.md conventions. Updated crate names and all references in workspace Cargo.toml and dependent bin Cargo.toml files.