### PR TITLE
fix(proof): align VerificationResult enum with onchain INitroEnclaveVerifier

### DIFF
--- a/crates/proof/tee/nitro-verifier/src/types.rs
+++ b/crates/proof/tee/nitro-verifier/src/types.rs
@@ -91,7 +91,13 @@ sol! {
     }
 
     /// Possible attestation verification results.
+    ///
+    /// `Unknown` is intentionally placed at index 0 so that uninitialized enum
+    /// variables default to a failure state rather than `Success` (fail-closed).
+    /// This ordering **must** match `INitroEnclaveVerifier.sol`.
     enum VerificationResult {
+        /// Default / uninitialized — treated as a verification failure.
+        Unknown,
         /// Attestation successfully verified.
         Success,
         /// Root certificate is not in the trusted set.


### PR DESCRIPTION
## Summary

- Adds the missing `Unknown` variant at index 0 of the Rust `VerificationResult` enum to match the Solidity `INitroEnclaveVerifier.sol` definition.
- Without this, the guest ELF ABI-encodes `Success` as `0`, but the on-chain contract expects `1` (`Unknown=0, Success=1`), causing every proof to revert with `AttestationVerificationFailed`.

## Root Cause

The Solidity enum [was intentionally changed](https://github.com/base/contracts/pull/243) to place `Unknown` at index 0 so uninitialised values default to a failure state (fail-closed). The Rust enum omitted this variant, shifting all indices by one. The guest program set `result = VerificationResult::Success` which encoded as `0`, and the on-chain `_verifyJournal` check `journal.result != VerificationResult.Success` evaluated to `0 != 1 → true`, reverting the transaction.

## Changes

- `crates/proof/tee/nitro-verifier/src/types.rs`: Add `Unknown` as the first variant of `VerificationResult` inside the `sol!` macro block.

## Testing

- All 43 existing tests in `base-proof-tee-nitro-verifier` pass.
- `cargo clippy -p base-proof-tee-nitro-verifier -- -D warnings` clean.
- Guest ELF rebuilt with the fix, new image ID deployed on-chain, and end-to-end signer registration verified on Sepolia.