### PR TITLE
metric: record hit/miss metering on block inclusion

### DIFF
--- a/crates/builder/core/src/flashblocks/context.rs
+++ b/crates/builder/core/src/flashblocks/context.rs
@@ -949,6 +949,14 @@ impl OpPayloadBuilderCtx {
             let fee_u64 = miner_fee.min(u64::MAX as u128) as u64;
             diag.min_priority_fee = Some(diag.min_priority_fee.map_or(fee_u64, |m| m.min(fee_u64)));
 
+            // Record metering hit/miss only for committed transactions so the
+            // metric reflects actual payload inclusion, not speculative lookups.
+            if resource_usage.is_some() {
+                BuilderMetrics::metering_known_transaction().increment(1);
+            } else {
+                BuilderMetrics::metering_unknown_transaction().increment(1);
+            }
+
             // append sender and transaction to the respective lists
             // and increment the next txn index for the access list
             info.executed_senders.push(tx.signer());

--- a/crates/builder/core/src/flashblocks/context.rs
+++ b/crates/builder/core/src/flashblocks/context.rs
@@ -951,7 +951,7 @@ impl OpPayloadBuilderCtx {
 
             // Record metering hit/miss only for committed transactions so the
             // metric reflects actual payload inclusion, not speculative lookups.
-            if resource_usage.is_some() {
+            if self.builder_config.metering_provider.is_enabled() && resource_usage.is_some() {
                 BuilderMetrics::metering_known_transaction().increment(1);
             } else {
                 BuilderMetrics::metering_unknown_transaction().increment(1);

--- a/crates/builder/metering/src/store.rs
+++ b/crates/builder/metering/src/store.rs
@@ -60,13 +60,7 @@ impl MeteringProvider for MeteringStore {
             return None;
         }
 
-        let Some(entry) = self.cache.get(tx_hash) else {
-            BuilderMetrics::metering_unknown_transaction().increment(1);
-            return None;
-        };
-
-        BuilderMetrics::metering_known_transaction().increment(1);
-        Some(entry)
+        self.cache.get(tx_hash)
     }
 
     fn is_enabled(&self) -> bool {


### PR DESCRIPTION
- we believe that our hit rate is (way) better than reported
- fix hit/miss metric recording to only on block inclusion, not on block b