### PR TITLE
ktlo(workspace): Rename Op-Prefixed Types

### DIFF
--- a/crates/builder/core/benches/state_root.rs
+++ b/crates/builder/core/benches/state_root.rs
@@ -25,8 +25,8 @@ use std::{hint::black_box, sync::Arc};
 use alloy_eips::BlockNumHash;
 use alloy_primitives::{B256, U256, keccak256};
 use base_execution_trie::{
-    MdbxProofsStorage, OpProofsInitialStateStore, OpProofsStorage,
-    provider::OpProofsStateProviderRef,
+    BaseProofsInitialStateStore, BaseProofsStorage, MdbxProofsStorage,
+    provider::BaseProofsStateProviderRef,
 };
 use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
 use rand::{Rng, SeedableRng, rngs::StdRng};
@@ -108,7 +108,7 @@ fn setup_flashblock_data(
 /// Creates an MDBX-backed proofs storage pre-populated with [`BASE_STATE_ACCOUNTS`]
 /// accounts and their storage slots. Returns the temp directory handle (must be
 /// kept alive) and the wrapped storage.
-fn create_populated_storage() -> (TempDir, OpProofsStorage<Arc<MdbxProofsStorage>>) {
+fn create_populated_storage() -> (TempDir, BaseProofsStorage<Arc<MdbxProofsStorage>>) {
     let dir = TempDir::new().expect("failed to create temp dir");
     let mdbx = Arc::new(MdbxProofsStorage::new(dir.path()).expect("failed to create MDBX storage"));
 
@@ -131,7 +131,7 @@ fn create_populated_storage() -> (TempDir, OpProofsStorage<Arc<MdbxProofsStorage
     mdbx.set_initial_state_anchor(BlockNumHash::new(0, B256::ZERO)).expect("failed to set anchor");
     mdbx.commit_initial_state().expect("failed to commit initial state");
 
-    let storage = OpProofsStorage::from(mdbx);
+    let storage = BaseProofsStorage::from(mdbx);
     (dir, storage)
 }
 
@@ -145,7 +145,7 @@ fn finalize_only_benches(c: &mut Criterion) {
         let (_deltas, full_state) = setup_flashblock_data(accounts_per_fb);
         let (_dir, storage) = create_populated_storage();
         let provider =
-            OpProofsStateProviderRef::new(Box::new(NoopProvider::default()), &storage, 0);
+            BaseProofsStateProviderRef::new(Box::new(NoopProvider::default()), &storage, 0);
 
         g.bench_function(BenchmarkId::new("accounts_per_fb", accounts_per_fb), |b| {
             b.iter(|| {
@@ -182,7 +182,7 @@ fn per_flashblock_benches(c: &mut Criterion) {
 
         let (_dir, storage) = create_populated_storage();
         let provider =
-            OpProofsStateProviderRef::new(Box::new(NoopProvider::default()), &storage, 0);
+            BaseProofsStateProviderRef::new(Box::new(NoopProvider::default()), &storage, 0);
 
         g.bench_function(BenchmarkId::new("accounts_per_fb", accounts_per_fb), |b| {
             b.iter(|| {

--- a/crates/builder/core/src/config.rs
+++ b/crates/builder/core/src/config.rs
@@ -6,7 +6,7 @@ use core::{
 };
 use std::sync::Arc;
 
-use base_execution_payload_builder::config::{GasLimitConfig, OpDAConfig};
+use base_execution_payload_builder::config::{BaseDAConfig, GasLimitConfig};
 
 use crate::{ExecutionMeteringMode, NoopMeteringProvider, RejectionCache, SharedMeteringProvider};
 
@@ -20,7 +20,7 @@ pub struct BuilderConfig {
 
     /// Data Availability configuration for the OP builder
     /// Defines constraints for the maximum size of data availability transactions.
-    pub da_config: OpDAConfig,
+    pub da_config: BaseDAConfig,
 
     /// Gas limit configuration for the payload builder
     pub gas_limit_config: GasLimitConfig,
@@ -126,7 +126,7 @@ impl Default for BuilderConfig {
         Self {
             block_time: Duration::from_secs(2),
             block_time_leeway: Duration::from_millis(500),
-            da_config: OpDAConfig::default(),
+            da_config: BaseDAConfig::default(),
             gas_limit_config: GasLimitConfig::default(),
             flashblocks_ws_addr: SocketAddr::new(Ipv4Addr::UNSPECIFIED.into(), 1111),
             flashblocks_interval: Duration::from_millis(250),

--- a/crates/builder/core/src/flashblocks/service.rs
+++ b/crates/builder/core/src/flashblocks/service.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use base_builder_publish::WebSocketPublisher;
 use base_execution_evm::BaseEvmConfig;
 use base_node_core::{
-    OpConsensusBuilder, OpExecutorBuilder, OpNetworkBuilder, node::OpPoolBuilder,
+    BaseConsensusBuilder, BaseExecutorBuilder, BaseNetworkBuilder, node::BasePoolBuilder,
 };
 use base_node_runner::{
     BaseNode, BaseNodeTypes, PayloadServiceBuilder as BasePayloadServiceBuilder,
@@ -96,11 +96,11 @@ where
 impl BasePayloadServiceBuilder for FlashblocksServiceBuilder {
     type ComponentsBuilder = ComponentsBuilder<
         BaseNodeTypes,
-        OpPoolBuilder,
+        BasePoolBuilder,
         Self,
-        OpNetworkBuilder,
-        OpExecutorBuilder,
-        OpConsensusBuilder,
+        BaseNetworkBuilder,
+        BaseExecutorBuilder,
+        BaseConsensusBuilder,
     >;
 
     fn build_components(self, base_node: &BaseNode) -> Self::ComponentsBuilder {

--- a/crates/builder/core/src/test_utils/instance.rs
+++ b/crates/builder/core/src/test_utils/instance.rs
@@ -16,7 +16,7 @@ use base_common_network::Base;
 use base_execution_chainspec::BaseChainSpec;
 use base_execution_rpc::OpEthApiBuilder;
 use base_execution_txpool::BasePooledTransaction;
-use base_node_core::{OpEngineValidatorBuilder, args::RollupArgs, node::OpPoolBuilder};
+use base_node_core::{BasePayloadValidatorBuilder, args::RollupArgs, node::BasePoolBuilder};
 use base_node_runner::{BaseNode, test_utils::init_silenced_tracing};
 use futures::{FutureExt, StreamExt};
 use nanoid::nanoid;
@@ -135,7 +135,7 @@ impl LocalInstance {
         let gas_limit_config = builder_config.gas_limit_config.clone();
         let metering_provider = Arc::clone(&builder_config.metering_provider);
 
-        let addons: base_node_runner::BaseAddOns<_, OpEthApiBuilder, OpEngineValidatorBuilder> =
+        let addons: base_node_runner::BaseAddOns<_, OpEthApiBuilder, BasePayloadValidatorBuilder> =
             base_node
                 .add_ons_builder()
                 .with_da_config(da_config.clone())
@@ -367,8 +367,8 @@ fn node_config_with_chain_spec(spec: Arc<BaseChainSpec>) -> NodeConfig<BaseChain
         .with_network(network)
 }
 
-fn pool_component() -> OpPoolBuilder<BasePooledTransaction> {
-    OpPoolBuilder::<BasePooledTransaction>::default()
+fn pool_component() -> BasePoolBuilder<BasePooledTransaction> {
+    BasePoolBuilder::<BasePooledTransaction>::default()
 }
 
 /// A utility for listening to flashblocks WebSocket messages during tests.

--- a/crates/client/flashblocks-node/src/extension.rs
+++ b/crates/client/flashblocks-node/src/extension.rs
@@ -8,7 +8,7 @@ use base_flashblocks::{
     EthApiExt, EthApiOverrideServer, EthPubSub, EthPubSubApiServer, FlashblocksConfig,
     FlashblocksSubscriber,
 };
-use base_node_core::OpEngineValidatorBuilder;
+use base_node_core::BasePayloadValidatorBuilder;
 use base_node_runner::{BaseNodeExtension, FromExtensionConfig, NodeHooks};
 use reth_chain_state::CanonStateSubscriptions;
 use tokio_stream::{StreamExt, wrappers::BroadcastStream};
@@ -48,7 +48,7 @@ impl BaseNodeExtension for FlashblocksExtension {
             let state_for_engine = Arc::clone(&state_for_start);
             hooks.add_add_ons_hook(move |add_ons| {
                 add_ons.with_engine_validator(
-                    BaseEngineValidatorBuilder::new(OpEngineValidatorBuilder::default())
+                    BaseEngineValidatorBuilder::new(BasePayloadValidatorBuilder::default())
                         .with_flashblocks_state(state_for_engine),
                 )
             })

--- a/crates/client/proofs/src/proofs.rs
+++ b/crates/client/proofs/src/proofs.rs
@@ -1,11 +1,11 @@
 use std::{sync::Arc, time::Duration};
 
-use base_execution_exex::OpProofsExEx;
+use base_execution_exex::BaseProofsExEx;
 use base_execution_rpc::{
     debug::{DebugApiExt, DebugApiOverrideServer},
     eth::proofs::{EthApiExt, EthApiOverrideServer},
 };
-use base_execution_trie::{MdbxProofsStorage, OpProofsStorage};
+use base_execution_trie::{BaseProofsStorage, MdbxProofsStorage};
 use base_node_core::args::RollupArgs;
 use base_node_runner::{BaseNodeExtension, FromExtensionConfig, NodeHooks};
 use reth_db::database_metrics::DatabaseMetrics;
@@ -57,7 +57,7 @@ impl BaseNodeExtension for ProofsHistoryExtension {
                 }
             };
             let mdbx = Arc::new(mdbx);
-            let storage: OpProofsStorage<Arc<MdbxProofsStorage>> = Arc::clone(&mdbx).into();
+            let storage: BaseProofsStorage<Arc<MdbxProofsStorage>> = Arc::clone(&mdbx).into();
 
             let storage_exec = storage.clone();
 
@@ -73,7 +73,7 @@ impl BaseNodeExtension for ProofsHistoryExtension {
 
             hooks = hooks
                 .install_exex("proofs-history", async move |exex_context| {
-                    Ok(OpProofsExEx::builder(exex_context, storage_exec)
+                    Ok(BaseProofsExEx::builder(exex_context, storage_exec)
                         .with_proofs_history_prune_interval(proofs_history_prune_interval)
                         .with_proofs_history_window(proofs_history_window)
                         .with_verification_interval(proofs_history_verification_interval)

--- a/crates/execution/cli/src/app.rs
+++ b/crates/execution/cli/src/app.rs
@@ -55,7 +55,7 @@ where
     /// [`NodeCommand`](reth_cli_commands::node::NodeCommand).
     pub fn run(
         mut self,
-        launcher: impl Launcher<crate::chainspec::OpChainSpecParser, Ext>,
+        launcher: impl Launcher<crate::chainspec::BaseChainSpecParser, Ext>,
     ) -> Result<()> {
         let runner = match self.runner.take() {
             Some(runner) => runner,
@@ -116,7 +116,7 @@ where
             Commands::ReExecute(command) => {
                 runner.run_until_ctrl_c(command.execute::<BaseNode>(components))
             }
-            Commands::OpProofs(command) => {
+            Commands::BaseProofs(command) => {
                 runner.run_blocking_until_ctrl_c(command.execute::<BaseNode>())
             }
         }

--- a/crates/execution/cli/src/chainspec.rs
+++ b/crates/execution/cli/src/chainspec.rs
@@ -6,9 +6,9 @@ use reth_cli::chainspec::{ChainSpecParser, parse_genesis};
 /// Base chain specification parser.
 #[derive(Debug, Clone, Default)]
 #[non_exhaustive]
-pub struct OpChainSpecParser;
+pub struct BaseChainSpecParser;
 
-impl ChainSpecParser for OpChainSpecParser {
+impl ChainSpecParser for BaseChainSpecParser {
     type ChainSpec = BaseChainSpec;
 
     const SUPPORTED_CHAINS: &'static [&'static str] = SUPPORTED_CHAINS;
@@ -36,9 +36,9 @@ mod tests {
 
     #[test]
     fn parse_known_chain_spec() {
-        for &chain in OpChainSpecParser::SUPPORTED_CHAINS {
+        for &chain in BaseChainSpecParser::SUPPORTED_CHAINS {
             assert!(
-                <OpChainSpecParser as ChainSpecParser>::parse(chain).is_ok(),
+                <BaseChainSpecParser as ChainSpecParser>::parse(chain).is_ok(),
                 "Failed to parse {chain}"
             );
         }

--- a/crates/execution/cli/src/commands/mod.rs
+++ b/crates/execution/cli/src/commands/mod.rs
@@ -10,7 +10,7 @@ use reth_cli_commands::{
     p2p, prune, re_execute, stage,
 };
 
-use crate::chainspec::OpChainSpecParser;
+use crate::chainspec::BaseChainSpecParser;
 
 pub mod init_state;
 pub mod op_proofs;
@@ -23,40 +23,40 @@ pub mod test_vectors;
 pub enum Commands<Ext: clap::Args + fmt::Debug = NoArgs> {
     /// Start the node
     #[command(name = "node")]
-    Node(Box<node::NodeCommand<OpChainSpecParser, Ext>>),
+    Node(Box<node::NodeCommand<BaseChainSpecParser, Ext>>),
     /// Initialize the database from a genesis file.
     #[command(name = "init")]
-    Init(init_cmd::InitCommand<OpChainSpecParser>),
+    Init(init_cmd::InitCommand<BaseChainSpecParser>),
     /// Initialize the database from a state dump file.
     #[command(name = "init-state")]
-    InitState(init_state::InitStateCommandOp<OpChainSpecParser>),
+    InitState(init_state::InitStateCommandOp<BaseChainSpecParser>),
     /// Dumps genesis block JSON configuration to stdout.
-    DumpGenesis(dump_genesis::DumpGenesisCommand<OpChainSpecParser>),
+    DumpGenesis(dump_genesis::DumpGenesisCommand<BaseChainSpecParser>),
     /// Database debugging utilities
     #[command(name = "db")]
-    Db(db::Command<OpChainSpecParser>),
+    Db(db::Command<BaseChainSpecParser>),
     /// Manipulate individual stages.
     #[command(name = "stage")]
-    Stage(Box<stage::Command<OpChainSpecParser>>),
+    Stage(Box<stage::Command<BaseChainSpecParser>>),
     /// P2P Debugging utilities
     #[command(name = "p2p")]
-    P2P(Box<p2p::Command<OpChainSpecParser>>),
+    P2P(Box<p2p::Command<BaseChainSpecParser>>),
     /// Write config to stdout
     #[command(name = "config")]
     Config(config_cmd::Command),
     /// Prune according to the configuration without any limits
     #[command(name = "prune")]
-    Prune(prune::PruneCommand<OpChainSpecParser>),
+    Prune(prune::PruneCommand<BaseChainSpecParser>),
     /// Generate Test Vectors
     #[cfg(feature = "dev")]
     #[command(name = "test-vectors")]
     TestVectors(test_vectors::Command),
     /// Re-execute blocks in parallel to verify historical sync correctness.
     #[command(name = "re-execute")]
-    ReExecute(re_execute::Command<OpChainSpecParser>),
+    ReExecute(re_execute::Command<BaseChainSpecParser>),
     /// Manage storage of historical proofs in expanded trie db in fault proof window.
     #[command(name = "proofs")]
-    OpProofs(op_proofs::Command<OpChainSpecParser>),
+    BaseProofs(op_proofs::Command<BaseChainSpecParser>),
 }
 
 impl<Ext: clap::Args + fmt::Debug> Commands<Ext> {
@@ -75,7 +75,7 @@ impl<Ext: clap::Args + fmt::Debug> Commands<Ext> {
             #[cfg(feature = "dev")]
             Self::TestVectors(_) => None,
             Self::ReExecute(cmd) => cmd.chain_spec(),
-            Self::OpProofs(cmd) => cmd.chain_spec(),
+            Self::BaseProofs(cmd) => cmd.chain_spec(),
         }
     }
 }

--- a/crates/execution/cli/src/commands/op_proofs/init.rs
+++ b/crates/execution/cli/src/commands/op_proofs/init.rs
@@ -5,7 +5,7 @@ use std::{path::PathBuf, sync::Arc};
 use base_common_consensus::BasePrimitives;
 use base_execution_chainspec::BaseChainSpec;
 use base_execution_trie::{
-    InitializationJob, OpProofsStorage, OpProofsStore, db::MdbxProofsStorage,
+    BaseProofsStorage, BaseProofsStore, InitializationJob, db::MdbxProofsStorage,
 };
 use clap::Parser;
 use reth_chainspec::ChainInfo;
@@ -48,7 +48,7 @@ impl<C: ChainSpecParser<ChainSpec = BaseChainSpec>> InitCommand<C> {
         let Environment { provider_factory, .. } = self.env.init::<N>(AccessRights::RO)?;
 
         // Create the proofs storage
-        let storage: OpProofsStorage<Arc<MdbxProofsStorage>> = Arc::new(
+        let storage: BaseProofsStorage<Arc<MdbxProofsStorage>> = Arc::new(
             MdbxProofsStorage::new(&self.storage_path)
                 .map_err(|e| eyre::eyre!("Failed to create MdbxProofsStorage: {e}"))?,
         )

--- a/crates/execution/cli/src/commands/op_proofs/prune.rs
+++ b/crates/execution/cli/src/commands/op_proofs/prune.rs
@@ -5,7 +5,7 @@ use std::{path::PathBuf, sync::Arc};
 use base_common_consensus::BasePrimitives;
 use base_execution_chainspec::BaseChainSpec;
 use base_execution_trie::{
-    OpProofStoragePruner, OpProofsStorage, OpProofsStore, db::MdbxProofsStorage,
+    BaseProofStoragePruner, BaseProofsStorage, BaseProofsStore, db::MdbxProofsStorage,
 };
 use clap::Parser;
 use reth_cli::chainspec::ChainSpecParser;
@@ -57,7 +57,7 @@ impl<C: ChainSpecParser<ChainSpec = BaseChainSpec>> PruneCommand<C> {
         // Initialize the environment with read-only access
         let Environment { provider_factory, .. } = self.env.init::<N>(AccessRights::RO)?;
 
-        let storage: OpProofsStorage<Arc<MdbxProofsStorage>> = Arc::new(
+        let storage: BaseProofsStorage<Arc<MdbxProofsStorage>> = Arc::new(
             MdbxProofsStorage::new(&self.storage_path)
                 .map_err(|e| eyre::eyre!("Failed to create MdbxProofsStorage: {e}"))?,
         )
@@ -72,7 +72,7 @@ impl<C: ChainSpecParser<ChainSpec = BaseChainSpec>> PruneCommand<C> {
             "Current proofs storage block range"
         );
 
-        let pruner = OpProofStoragePruner::new(
+        let pruner = BaseProofStoragePruner::new(
             storage,
             provider_factory,
             self.proofs_history_window,

--- a/crates/execution/cli/src/commands/op_proofs/unwind.rs
+++ b/crates/execution/cli/src/commands/op_proofs/unwind.rs
@@ -4,7 +4,7 @@ use std::{path::PathBuf, sync::Arc};
 
 use base_common_consensus::BasePrimitives;
 use base_execution_chainspec::BaseChainSpec;
-use base_execution_trie::{OpProofsStorage, OpProofsStore, db::MdbxProofsStorage};
+use base_execution_trie::{BaseProofsStorage, BaseProofsStore, db::MdbxProofsStorage};
 use clap::Parser;
 use reth_cli::chainspec::ChainSpecParser;
 use reth_cli_commands::common::{AccessRights, CliNodeTypes, Environment, EnvironmentArgs};
@@ -37,9 +37,9 @@ pub struct UnwindCommand<C: ChainSpecParser> {
 
 impl<C: ChainSpecParser> UnwindCommand<C> {
     /// Validates that the target block number is within a valid range for unwinding.
-    fn validate_unwind_range<Store: OpProofsStore>(
+    fn validate_unwind_range<Store: BaseProofsStore>(
         &self,
-        storage: &OpProofsStorage<Store>,
+        storage: &BaseProofsStorage<Store>,
     ) -> eyre::Result<bool> {
         let (Some((earliest, _)), Some((latest, _))) =
             (storage.get_earliest_block_number()?, storage.get_latest_block_number()?)
@@ -74,7 +74,7 @@ impl<C: ChainSpecParser<ChainSpec = BaseChainSpec>> UnwindCommand<C> {
         let Environment { provider_factory, .. } = self.env.init::<N>(AccessRights::RO)?;
 
         // Create the proofs storage
-        let storage: OpProofsStorage<Arc<MdbxProofsStorage>> = Arc::new(
+        let storage: BaseProofsStorage<Arc<MdbxProofsStorage>> = Arc::new(
             MdbxProofsStorage::new(&self.storage_path)
                 .map_err(|e| eyre::eyre!("Failed to create MdbxProofsStorage: {e}"))?,
         )

--- a/crates/execution/cli/src/lib.rs
+++ b/crates/execution/cli/src/lib.rs
@@ -19,7 +19,7 @@ use std::{ffi::OsString, fmt, marker::PhantomData};
 pub use app::CliApp;
 use base_execution_chainspec::BaseChainSpec;
 use base_node_core::args::RollupArgs;
-use chainspec::OpChainSpecParser;
+use chainspec::BaseChainSpecParser;
 use clap::Parser;
 use commands::Commands;
 use futures::Future;
@@ -111,7 +111,7 @@ where
     {
         let mut this = self.configure();
         this.set_runner(runner);
-        this.run(FnLauncher::new::<OpChainSpecParser, Ext>(async move |builder, chain_spec| {
+        this.run(FnLauncher::new::<BaseChainSpecParser, Ext>(async move |builder, chain_spec| {
             launcher(builder, chain_spec).await
         }))
     }
@@ -124,11 +124,11 @@ mod tests {
     use clap::Parser;
     use reth_cli_commands::{NodeCommand, node::NoArgs};
 
-    use crate::{Cli, chainspec::OpChainSpecParser, commands::Commands};
+    use crate::{Cli, chainspec::BaseChainSpecParser, commands::Commands};
 
     #[test]
     fn parse_dev() {
-        let cmd = NodeCommand::<OpChainSpecParser, NoArgs>::parse_from(["base-reth", "--dev"]);
+        let cmd = NodeCommand::<BaseChainSpecParser, NoArgs>::parse_from(["base-reth", "--dev"]);
         let chain = BASE_DEV.clone();
         assert_eq!(cmd.chain.chain, chain.chain);
         assert_eq!(cmd.chain.genesis_hash(), chain.genesis_hash());

--- a/crates/execution/exex/src/lib.rs
+++ b/crates/execution/exex/src/lib.rs
@@ -13,7 +13,7 @@ use std::{sync::Arc, time::Duration};
 use alloy_consensus::BlockHeader;
 use alloy_eips::eip1898::BlockWithParent;
 use base_execution_trie::{
-    BaseProofStoragePrunerTask, OpProofsStorage, OpProofsStore, live::LiveTrieCollector,
+    BaseProofStoragePrunerTask, BaseProofsStorage, BaseProofsStore, live::LiveTrieCollector,
     metrics::BlockMetrics,
 };
 use futures::TryStreamExt;
@@ -42,14 +42,14 @@ const DEFAULT_PRUNE_INTERVAL: Duration = Duration::from_secs(15);
 /// Default verification interval: disabled
 const DEFAULT_VERIFICATION_INTERVAL: u64 = 0; // disabled
 
-/// Builder for [`OpProofsExEx`].
+/// Builder for [`BaseProofsExEx`].
 #[derive(Debug)]
 pub struct BaseProofsExExBuilder<Node, Storage>
 where
     Node: FullNodeComponents,
 {
     ctx: ExExContext<Node>,
-    storage: OpProofsStorage<Storage>,
+    storage: BaseProofsStorage<Storage>,
     proofs_history_window: u64,
     proofs_history_prune_interval: Duration,
     verification_interval: u64,
@@ -60,7 +60,7 @@ where
     Node: FullNodeComponents,
 {
     /// Create a new builder with required parameters and defaults.
-    pub const fn new(ctx: ExExContext<Node>, storage: OpProofsStorage<Storage>) -> Self {
+    pub const fn new(ctx: ExExContext<Node>, storage: BaseProofsStorage<Storage>) -> Self {
         Self {
             ctx,
             storage,
@@ -88,9 +88,9 @@ where
         self
     }
 
-    /// Builds the [`OpProofsExEx`].
-    pub fn build(self) -> OpProofsExEx<Node, Storage> {
-        OpProofsExEx {
+    /// Builds the [`BaseProofsExEx`].
+    pub fn build(self) -> BaseProofsExEx<Node, Storage> {
+        BaseProofsExEx {
             ctx: self.ctx,
             storage: self.storage,
             proofs_history_window: self.proofs_history_window,
@@ -118,9 +118,9 @@ where
 /// use reth_node_api::NodeTypesWithDBAdapter;
 /// use reth_node_builder::{NodeBuilder, NodeConfig};
 /// use base_execution_chainspec::BASE_MAINNET;
-/// use base_execution_exex::OpProofsExEx;
+/// use base_execution_exex::BaseProofsExEx;
 /// use base_node_core::{BaseNode, args::RollupArgs};
-/// use base_execution_trie::{InMemoryProofsStorage, OpProofsStorage, db::MdbxProofsStorage};
+/// use base_execution_trie::{InMemoryProofsStorage, BaseProofsStorage, db::MdbxProofsStorage};
 /// use reth_provider::providers::BlockchainProvider;
 /// use std::{sync::Arc, time::Duration};
 ///
@@ -130,14 +130,14 @@ where
 /// let op_node = BaseNode::new(args);
 ///
 /// // Create in-memory or persistent storage
-/// let storage: OpProofsStorage<Arc<InMemoryProofsStorage>> =
+/// let storage: BaseProofsStorage<Arc<InMemoryProofsStorage>> =
 ///     Arc::new(InMemoryProofsStorage::new()).into();
 ///
 /// // Example for creating persistent storage
 /// # let temp_dir = tempfile::tempdir().expect("Failed to create temp dir");
 /// # let storage_path = temp_dir.path().join("proofs_storage");
 ///
-/// # let storage: OpProofsStorage<Arc<MdbxProofsStorage>> = Arc::new(
+/// # let storage: BaseProofsStorage<Arc<MdbxProofsStorage>> = Arc::new(
 /// #    MdbxProofsStorage::new(&storage_path).expect("Failed to create MdbxProofsStorage"),
 /// # ).into();
 ///
@@ -155,7 +155,7 @@ where
 ///     .with_types_and_provider::<BaseNode, BlockchainProvider<NodeTypesWithDBAdapter<BaseNode, _>>>()
 ///     .with_components(op_node.components())
 ///     .install_exex("proofs-history", move |exex_context| async move {
-///         Ok(OpProofsExEx::builder(exex_context, storage_exec)
+///         Ok(BaseProofsExEx::builder(exex_context, storage_exec)
 ///             .with_proofs_history_window(proofs_history_window)
 ///             .with_proofs_history_prune_interval(proofs_history_prune_interval)
 ///             .with_verification_interval(verification_interval)
@@ -167,7 +167,7 @@ where
 ///     .check_launch();
 /// ```
 #[derive(Debug)]
-pub struct OpProofsExEx<Node, Storage>
+pub struct BaseProofsExEx<Node, Storage>
 where
     Node: FullNodeComponents,
 {
@@ -175,7 +175,7 @@ where
     /// events.
     ctx: ExExContext<Node>,
     /// The type of storage DB.
-    storage: OpProofsStorage<Storage>,
+    storage: BaseProofsStorage<Storage>,
     /// The window to span blocks for proofs history. Value is the number of blocks, received as
     /// cli arg.
     proofs_history_window: u64,
@@ -187,29 +187,29 @@ where
     verification_interval: u64,
 }
 
-impl<Node, Storage> OpProofsExEx<Node, Storage>
+impl<Node, Storage> BaseProofsExEx<Node, Storage>
 where
     Node: FullNodeComponents,
 {
-    /// Create a new `OpProofsExEx` instance.
-    pub fn new(ctx: ExExContext<Node>, storage: OpProofsStorage<Storage>) -> Self {
+    /// Create a new `BaseProofsExEx` instance.
+    pub fn new(ctx: ExExContext<Node>, storage: BaseProofsStorage<Storage>) -> Self {
         BaseProofsExExBuilder::new(ctx, storage).build()
     }
 
-    /// Create a new builder for `OpProofsExEx`.
+    /// Create a new builder for `BaseProofsExEx`.
     pub const fn builder(
         ctx: ExExContext<Node>,
-        storage: OpProofsStorage<Storage>,
+        storage: BaseProofsStorage<Storage>,
     ) -> BaseProofsExExBuilder<Node, Storage> {
         BaseProofsExExBuilder::new(ctx, storage)
     }
 }
 
-impl<Node, Storage, Primitives> OpProofsExEx<Node, Storage>
+impl<Node, Storage, Primitives> BaseProofsExEx<Node, Storage>
 where
     Node: FullNodeComponents<Types: NodeTypes<Primitives = Primitives>>,
     Primitives: NodePrimitives,
-    Storage: OpProofsStore + Clone + 'static,
+    Storage: BaseProofsStore + Clone + 'static,
 {
     /// Main execution loop for the `ExEx`
     pub async fn run(mut self) -> eyre::Result<()> {
@@ -331,7 +331,7 @@ where
 
     async fn sync_loop(
         sync_target: Arc<SyncTarget>,
-        storage: OpProofsStorage<Storage>,
+        storage: BaseProofsStorage<Storage>,
         provider: Node::Provider,
         collector: &LiveTrieCollector<'_, Node::Evm, Node::Provider, Storage>,
         verification_interval: u64,
@@ -378,7 +378,7 @@ where
     }
 
     fn handle_revert(
-        storage: &OpProofsStorage<Storage>,
+        storage: &BaseProofsStorage<Storage>,
         collector: &LiveTrieCollector<'_, Node::Evm, Node::Provider, Storage>,
         revert_to: BlockWithParent,
     ) {
@@ -413,7 +413,7 @@ where
 
     async fn sync_forward(
         sync_target: &SyncTarget,
-        storage: &OpProofsStorage<Storage>,
+        storage: &BaseProofsStorage<Storage>,
         provider: &Node::Provider,
         collector: &LiveTrieCollector<'_, Node::Evm, Node::Provider, Storage>,
         verification_interval: u64,
@@ -689,7 +689,7 @@ mod tests {
     use alloy_consensus::private::alloy_primitives::B256;
     use alloy_eips::{BlockNumHash, NumHash, eip1898::BlockWithParent};
     use base_execution_trie::{
-        BlockStateDiff, OpProofsStorage, OpProofsStore, db::MdbxProofsStorage,
+        BaseProofsStorage, BaseProofsStore, BlockStateDiff, db::MdbxProofsStorage,
     };
     use reth_db::test_utils::tempdir_path;
     use reth_ethereum_primitives::{Block, Receipt};
@@ -758,7 +758,7 @@ mod tests {
     }
 
     /// Store blocks directly into proofs storage (bypasses the sync loop).
-    fn store_blocks<S: OpProofsStore>(from: u64, to: u64, storage: &OpProofsStorage<S>) {
+    fn store_blocks<S: BaseProofsStore>(from: u64, to: u64, storage: &BaseProofsStorage<S>) {
         for n in from..=to {
             let chain = mk_chain_with_updates(n, n, None);
             let block = chain.blocks().get(&n).unwrap();
@@ -768,7 +768,7 @@ mod tests {
         }
     }
 
-    fn init_storage<S: OpProofsStore>(storage: OpProofsStorage<S>) {
+    fn init_storage<S: BaseProofsStore>(storage: BaseProofsStorage<S>) {
         let genesis_block = NumHash::new(0, b256(0x00));
         storage
             .set_earliest_block_number(genesis_block.number, genesis_block.hash)
@@ -784,13 +784,13 @@ mod tests {
     // Initialize exex with config
     fn build_test_exex<NodeT, Store>(
         ctx: ExExContext<NodeT>,
-        storage: OpProofsStorage<Store>,
-    ) -> OpProofsExEx<NodeT, Store>
+        storage: BaseProofsStorage<Store>,
+    ) -> BaseProofsExEx<NodeT, Store>
     where
         NodeT: FullNodeComponents,
-        Store: OpProofsStore + Clone + 'static,
+        Store: BaseProofsStore + Clone + 'static,
     {
-        OpProofsExEx::builder(ctx, storage)
+        BaseProofsExEx::builder(ctx, storage)
             .with_proofs_history_window(20)
             .with_proofs_history_prune_interval(Duration::from_secs(3600))
             .with_verification_interval(1000)
@@ -802,7 +802,7 @@ mod tests {
         // MDBX proofs storage
         let dir = tempdir_path();
         let store = Arc::new(MdbxProofsStorage::new(dir.as_path()).expect("env"));
-        let proofs: OpProofsStorage<Arc<MdbxProofsStorage>> = Arc::clone(&store).into();
+        let proofs: BaseProofsStorage<Arc<MdbxProofsStorage>> = Arc::clone(&store).into();
 
         init_storage(proofs.clone());
 
@@ -829,7 +829,7 @@ mod tests {
         // MDBX proofs storage
         let dir = tempdir_path();
         let store = Arc::new(MdbxProofsStorage::new(dir.as_path()).expect("env"));
-        let proofs: OpProofsStorage<Arc<MdbxProofsStorage>> = Arc::clone(&store).into();
+        let proofs: BaseProofsStorage<Arc<MdbxProofsStorage>> = Arc::clone(&store).into();
 
         init_storage(proofs.clone());
 
@@ -863,7 +863,7 @@ mod tests {
         // MDBX proofs storage
         let dir = tempdir_path();
         let store = Arc::new(MdbxProofsStorage::new(dir.as_path()).expect("env"));
-        let proofs: OpProofsStorage<Arc<MdbxProofsStorage>> = Arc::clone(&store).into();
+        let proofs: BaseProofsStorage<Arc<MdbxProofsStorage>> = Arc::clone(&store).into();
 
         init_storage(proofs.clone());
         store_blocks(1, 10, &proofs);
@@ -907,7 +907,7 @@ mod tests {
         // MDBX proofs storage
         let dir = tempdir_path();
         let store = Arc::new(MdbxProofsStorage::new(dir.as_path()).expect("env"));
-        let proofs: OpProofsStorage<Arc<MdbxProofsStorage>> = Arc::clone(&store).into();
+        let proofs: BaseProofsStorage<Arc<MdbxProofsStorage>> = Arc::clone(&store).into();
 
         init_storage(proofs.clone());
         store_blocks(1, 10, &proofs);
@@ -947,7 +947,7 @@ mod tests {
         // MDBX proofs storage
         let dir = tempdir_path();
         let store = Arc::new(MdbxProofsStorage::new(dir.as_path()).expect("env"));
-        let proofs: OpProofsStorage<Arc<MdbxProofsStorage>> = Arc::clone(&store).into();
+        let proofs: BaseProofsStorage<Arc<MdbxProofsStorage>> = Arc::clone(&store).into();
 
         init_storage(proofs.clone());
         store_blocks(1, 10, &proofs);
@@ -985,7 +985,7 @@ mod tests {
         // MDBX proofs storage
         let dir = tempdir_path();
         let store = Arc::new(MdbxProofsStorage::new(dir.as_path()).expect("env"));
-        let proofs: OpProofsStorage<Arc<MdbxProofsStorage>> = Arc::clone(&store).into();
+        let proofs: BaseProofsStorage<Arc<MdbxProofsStorage>> = Arc::clone(&store).into();
 
         init_storage(proofs.clone());
         store_blocks(1, 5, &proofs);
@@ -1023,7 +1023,7 @@ mod tests {
         // MDBX proofs storage
         let dir = tempdir_path();
         let store = Arc::new(MdbxProofsStorage::new(dir.as_path()).expect("env"));
-        let proofs: OpProofsStorage<Arc<MdbxProofsStorage>> = Arc::clone(&store).into();
+        let proofs: BaseProofsStorage<Arc<MdbxProofsStorage>> = Arc::clone(&store).into();
 
         let (ctx, _handle) =
             reth_exex_test_utils::test_exex_context().await.expect("exex test context");
@@ -1037,7 +1037,7 @@ mod tests {
         // MDBX proofs storage
         let dir = tempdir_path();
         let store = Arc::new(MdbxProofsStorage::new(dir.as_path()).expect("env"));
-        let proofs: OpProofsStorage<Arc<MdbxProofsStorage>> = Arc::clone(&store).into();
+        let proofs: BaseProofsStorage<Arc<MdbxProofsStorage>> = Arc::clone(&store).into();
 
         init_storage(proofs.clone());
 
@@ -1065,7 +1065,7 @@ mod tests {
         // MDBX proofs storage
         let dir = tempdir_path();
         let store = Arc::new(MdbxProofsStorage::new(dir.as_path()).expect("env"));
-        let proofs: OpProofsStorage<Arc<MdbxProofsStorage>> = Arc::clone(&store).into();
+        let proofs: BaseProofsStorage<Arc<MdbxProofsStorage>> = Arc::clone(&store).into();
 
         init_storage(proofs.clone());
 
@@ -1081,7 +1081,7 @@ mod tests {
         // MDBX proofs storage
         let dir = tempdir_path();
         let store = Arc::new(MdbxProofsStorage::new(dir.as_path()).expect("env"));
-        let proofs: OpProofsStorage<Arc<MdbxProofsStorage>> = Arc::clone(&store).into();
+        let proofs: BaseProofsStorage<Arc<MdbxProofsStorage>> = Arc::clone(&store).into();
 
         init_storage(proofs.clone());
 

--- a/crates/execution/node/src/node.rs
+++ b/crates/execution/node/src/node.rs
@@ -13,16 +13,16 @@ use base_execution_evm::{BaseEvmConfig, OpRethReceiptBuilder};
 use base_execution_payload_builder::{
     Attributes, OpBuiltPayload, PayloadPrimitives,
     builder::BasePayloadTransactions,
-    config::{BaseBuilderConfig, GasLimitConfig, OpDAConfig},
+    config::{BaseBuilderConfig, BaseDAConfig, GasLimitConfig},
 };
 use base_execution_rpc::{
     MinerApiExtServer,
     config::{BaseEthConfigApiServer, BaseEthConfigHandler},
     eth::OpEthApiBuilder,
-    miner::OpMinerExtApi,
-    witness::OpDebugWitnessApi,
+    miner::BaseMinerExtApi,
+    witness::BaseDebugWitnessApi,
 };
-use base_execution_storage::OpStorage;
+use base_execution_storage::BaseStorage;
 use base_execution_txpool::{
     BaseOrdering, BasePooledTransaction, BaseTransactionPool, OpPooledTx, OpTransactionValidator,
     TimestampedTransaction,
@@ -86,7 +86,7 @@ pub trait BaseFullNodeTypes:
     NodeTypes<
         ChainSpec = BaseChainSpec,
         Primitives: PayloadPrimitives,
-        Storage = OpStorage,
+        Storage = BaseStorage,
         Payload: EngineTypes<ExecutionData = ExecutionData>,
     >
 {
@@ -96,7 +96,7 @@ impl<N> BaseFullNodeTypes for N where
     N: NodeTypes<
             ChainSpec = BaseChainSpec,
             Primitives: PayloadPrimitives,
-            Storage = OpStorage,
+            Storage = BaseStorage,
             Payload: EngineTypes<ExecutionData = ExecutionData>,
         >
 {
@@ -182,7 +182,7 @@ pub struct BaseNode {
     /// the `miner_` api).
     ///
     /// By default no throttling is applied.
-    pub da_config: OpDAConfig,
+    pub da_config: BaseDAConfig,
     /// Gas limit configuration for the OP builder.
     /// Used to control the gas limit of the blocks produced by the OP builder.(configured by the
     /// batcher via the `miner_` api)
@@ -190,23 +190,27 @@ pub struct BaseNode {
 }
 
 /// A [`ComponentsBuilder`] with its generic arguments set to a stack of Base-specific builders.
-pub type OpNodeComponentBuilder<Node, Payload = OpPayloadBuilder> = ComponentsBuilder<
+pub type BaseNodeComponentBuilder<Node, Payload = OpPayloadBuilder> = ComponentsBuilder<
     Node,
-    OpPoolBuilder,
+    BasePoolBuilder,
     BasicPayloadServiceBuilder<Payload>,
-    OpNetworkBuilder,
-    OpExecutorBuilder,
-    OpConsensusBuilder,
+    BaseNetworkBuilder,
+    BaseExecutorBuilder,
+    BaseConsensusBuilder,
 >;
 
 impl BaseNode {
     /// Creates a new instance of the Base node type.
     pub fn new(args: RollupArgs) -> Self {
-        Self { args, da_config: OpDAConfig::default(), gas_limit_config: GasLimitConfig::default() }
+        Self {
+            args,
+            da_config: BaseDAConfig::default(),
+            gas_limit_config: GasLimitConfig::default(),
+        }
     }
 
     /// Configure the data availability configuration for the OP builder.
-    pub fn with_da_config(mut self, da_config: OpDAConfig) -> Self {
+    pub fn with_da_config(mut self, da_config: BaseDAConfig) -> Self {
         self.da_config = da_config;
         self
     }
@@ -218,7 +222,7 @@ impl BaseNode {
     }
 
     /// Returns the components for the given [`RollupArgs`].
-    pub fn components<Node>(&self) -> OpNodeComponentBuilder<Node>
+    pub fn components<Node>(&self) -> BaseNodeComponentBuilder<Node>
     where
         Node: FullNodeTypes<Types: BaseNodeTypes>,
     {
@@ -235,20 +239,20 @@ impl BaseNode {
         };
         ComponentsBuilder::default()
             .node_types::<Node>()
-            .executor(OpExecutorBuilder::default())
-            .pool(OpPoolBuilder::default().with_ordering(ordering))
+            .executor(BaseExecutorBuilder::default())
+            .pool(BasePoolBuilder::default().with_ordering(ordering))
             .payload(BasicPayloadServiceBuilder::new(
                 OpPayloadBuilder::new(compute_pending_block)
                     .with_da_config(self.da_config.clone())
                     .with_gas_limit_config(self.gas_limit_config.clone()),
             ))
-            .network(OpNetworkBuilder::new(disable_txpool_gossip, !discovery_v4))
-            .consensus(OpConsensusBuilder::default())
+            .network(BaseNetworkBuilder::new(disable_txpool_gossip, !discovery_v4))
+            .consensus(BaseConsensusBuilder::default())
     }
 
-    /// Returns [`OpAddOnsBuilder`] with configured arguments.
-    pub fn add_ons_builder<NetworkT: RpcTypes>(&self) -> OpAddOnsBuilder<NetworkT> {
-        OpAddOnsBuilder::default()
+    /// Returns [`BaseAddOnsBuilder`] with configured arguments.
+    pub fn add_ons_builder<NetworkT: RpcTypes>(&self) -> BaseAddOnsBuilder<NetworkT> {
+        BaseAddOnsBuilder::default()
             .with_sequencer(self.args.sequencer.clone())
             .with_sequencer_headers(self.args.sequencer_headers.clone())
             .with_da_config(self.da_config.clone())
@@ -302,19 +306,19 @@ where
 {
     type ComponentsBuilder = ComponentsBuilder<
         N,
-        OpPoolBuilder,
+        BasePoolBuilder,
         BasicPayloadServiceBuilder<OpPayloadBuilder>,
-        OpNetworkBuilder,
-        OpExecutorBuilder,
-        OpConsensusBuilder,
+        BaseNetworkBuilder,
+        BaseExecutorBuilder,
+        BaseConsensusBuilder,
     >;
 
-    type AddOns = OpAddOns<
+    type AddOns = BaseAddOns<
         NodeAdapter<N, <Self::ComponentsBuilder as NodeComponentsBuilder<N>>::Components>,
         OpEthApiBuilder,
-        OpEngineValidatorBuilder,
-        OpEngineApiBuilder<OpEngineValidatorBuilder>,
-        BasicEngineValidatorBuilder<OpEngineValidatorBuilder>,
+        BasePayloadValidatorBuilder,
+        OpEngineApiBuilder<BasePayloadValidatorBuilder>,
+        BasicEngineValidatorBuilder<BasePayloadValidatorBuilder>,
     >;
 
     fn components_builder(&self) -> Self::ComponentsBuilder {
@@ -346,7 +350,7 @@ where
 impl NodeTypes for BaseNode {
     type Primitives = BasePrimitives;
     type ChainSpec = BaseChainSpec;
-    type Storage = OpStorage;
+    type Storage = BaseStorage;
     type Payload = OpEngineTypes;
 }
 
@@ -355,7 +359,7 @@ impl NodeTypes for BaseNode {
 /// This type provides Base-specific addons to the node and exposes the RPC server and engine
 /// API.
 #[derive(Debug)]
-pub struct OpAddOns<
+pub struct BaseAddOns<
     N: FullNodeComponents,
     EthB: EthApiBuilder<N>,
     PVB,
@@ -367,7 +371,7 @@ pub struct OpAddOns<
     /// and eth-api.
     pub rpc_add_ons: RpcAddOns<N, EthB, PVB, EB, EVB, RpcMiddleware>,
     /// Data availability configuration for the OP builder.
-    pub da_config: OpDAConfig,
+    pub da_config: BaseDAConfig,
     /// Gas limit configuration for the OP builder.
     pub gas_limit_config: GasLimitConfig,
     /// Sequencer client, configured to forward submitted transactions to sequencer of given OP
@@ -378,7 +382,7 @@ pub struct OpAddOns<
     min_suggested_priority_fee: u64,
 }
 
-impl<N, EthB, PVB, EB, EVB, RpcMiddleware> OpAddOns<N, EthB, PVB, EB, EVB, RpcMiddleware>
+impl<N, EthB, PVB, EB, EVB, RpcMiddleware> BaseAddOns<N, EthB, PVB, EB, EVB, RpcMiddleware>
 where
     N: FullNodeComponents,
     EthB: EthApiBuilder<N>,
@@ -387,7 +391,7 @@ where
     #[allow(clippy::too_many_arguments)]
     pub const fn new(
         rpc_add_ons: RpcAddOns<N, EthB, PVB, EB, EVB, RpcMiddleware>,
-        da_config: OpDAConfig,
+        da_config: BaseDAConfig,
         gas_limit_config: GasLimitConfig,
         sequencer_url: Option<String>,
         sequencer_headers: Vec<String>,
@@ -404,7 +408,7 @@ where
     }
 }
 
-impl<N> Default for OpAddOns<N, OpEthApiBuilder, OpEngineValidatorBuilder>
+impl<N> Default for BaseAddOns<N, OpEthApiBuilder, BasePayloadValidatorBuilder>
 where
     N: FullNodeComponents<Types: BaseNodeTypes>,
     OpEthApiBuilder: EthApiBuilder<N>,
@@ -415,24 +419,24 @@ where
 }
 
 impl<N, NetworkT, RpcMiddleware>
-    OpAddOns<
+    BaseAddOns<
         N,
         OpEthApiBuilder<NetworkT>,
-        OpEngineValidatorBuilder,
-        OpEngineApiBuilder<OpEngineValidatorBuilder>,
+        BasePayloadValidatorBuilder,
+        OpEngineApiBuilder<BasePayloadValidatorBuilder>,
         RpcMiddleware,
     >
 where
     N: FullNodeComponents<Types: BaseNodeTypes>,
     OpEthApiBuilder<NetworkT>: EthApiBuilder<N>,
 {
-    /// Build a [`OpAddOns`] using [`OpAddOnsBuilder`].
-    pub fn builder() -> OpAddOnsBuilder<NetworkT> {
-        OpAddOnsBuilder::default()
+    /// Build a [`BaseAddOns`] using [`BaseAddOnsBuilder`].
+    pub fn builder() -> BaseAddOnsBuilder<NetworkT> {
+        BaseAddOnsBuilder::default()
     }
 }
 
-impl<N, EthB, PVB, EB, EVB, RpcMiddleware> OpAddOns<N, EthB, PVB, EB, EVB, RpcMiddleware>
+impl<N, EthB, PVB, EB, EVB, RpcMiddleware> BaseAddOns<N, EthB, PVB, EB, EVB, RpcMiddleware>
 where
     N: FullNodeComponents,
     EthB: EthApiBuilder<N>,
@@ -441,7 +445,7 @@ where
     pub fn with_engine_api<T>(
         self,
         engine_api_builder: T,
-    ) -> OpAddOns<N, EthB, PVB, T, EVB, RpcMiddleware> {
+    ) -> BaseAddOns<N, EthB, PVB, T, EVB, RpcMiddleware> {
         let Self {
             rpc_add_ons,
             da_config,
@@ -451,7 +455,7 @@ where
             min_suggested_priority_fee,
             ..
         } = self;
-        OpAddOns::new(
+        BaseAddOns::new(
             rpc_add_ons.with_engine_api(engine_api_builder),
             da_config,
             gas_limit_config,
@@ -465,7 +469,7 @@ where
     pub fn with_payload_validator<T>(
         self,
         payload_validator_builder: T,
-    ) -> OpAddOns<N, EthB, T, EB, EVB, RpcMiddleware> {
+    ) -> BaseAddOns<N, EthB, T, EB, EVB, RpcMiddleware> {
         let Self {
             rpc_add_ons,
             da_config,
@@ -475,7 +479,7 @@ where
             min_suggested_priority_fee,
             ..
         } = self;
-        OpAddOns::new(
+        BaseAddOns::new(
             rpc_add_ons.with_payload_validator(payload_validator_builder),
             da_config,
             gas_limit_config,
@@ -492,7 +496,7 @@ where
     /// layer, allowing you to intercept, modify, or enhance RPC request processing.
     ///
     /// See also [`RpcAddOns::with_rpc_middleware`].
-    pub fn with_rpc_middleware<T>(self, rpc_middleware: T) -> OpAddOns<N, EthB, PVB, EB, EVB, T> {
+    pub fn with_rpc_middleware<T>(self, rpc_middleware: T) -> BaseAddOns<N, EthB, PVB, EB, EVB, T> {
         let Self {
             rpc_add_ons,
             da_config,
@@ -502,7 +506,7 @@ where
             min_suggested_priority_fee,
             ..
         } = self;
-        OpAddOns::new(
+        BaseAddOns::new(
             rpc_add_ons.with_rpc_middleware(rpc_middleware),
             da_config,
             gas_limit_config,
@@ -534,7 +538,7 @@ where
 }
 
 impl<N, EthB, PVB, EB, EVB, Attrs, RpcMiddleware> NodeAddOns<N>
-    for OpAddOns<N, EthB, PVB, EB, EVB, RpcMiddleware>
+    for BaseAddOns<N, EthB, PVB, EB, EVB, RpcMiddleware>
 where
     N: FullNodeComponents<
             Types: BaseNodeTypes
@@ -568,12 +572,12 @@ where
             ctx.node.evm_config().clone(),
         );
         // install additional OP specific rpc methods
-        let debug_ext = OpDebugWitnessApi::<_, _, _, Attrs>::new(
+        let debug_ext = BaseDebugWitnessApi::<_, _, _, Attrs>::new(
             ctx.node.provider().clone(),
             Box::new(ctx.node.task_executor().clone()),
             builder,
         );
-        let miner_ext = OpMinerExtApi::new(da_config, gas_limit_config);
+        let miner_ext = BaseMinerExtApi::new(da_config, gas_limit_config);
 
         rpc_add_ons
             .launch_add_ons_with(ctx, move |container| {
@@ -610,7 +614,7 @@ where
 }
 
 impl<N, EthB, PVB, EB, EVB, Attrs, RpcMiddleware> RethRpcAddOns<N>
-    for OpAddOns<N, EthB, PVB, EB, EVB, RpcMiddleware>
+    for BaseAddOns<N, EthB, PVB, EB, EVB, RpcMiddleware>
 where
     N: FullNodeComponents<
             Types: BaseNodeTypes
@@ -636,7 +640,7 @@ where
 }
 
 impl<N, EthB, PVB, EB, EVB, RpcMiddleware> EngineValidatorAddOn<N>
-    for OpAddOns<N, EthB, PVB, EB, EVB, RpcMiddleware>
+    for BaseAddOns<N, EthB, PVB, EB, EVB, RpcMiddleware>
 where
     N: FullNodeComponents,
     EthB: EthApiBuilder<N>,
@@ -655,14 +659,14 @@ where
 /// A regular Base EVM and executor builder.
 #[derive(Debug, Clone)]
 #[non_exhaustive]
-pub struct OpAddOnsBuilder<NetworkT, RpcMiddleware = Identity> {
+pub struct BaseAddOnsBuilder<NetworkT, RpcMiddleware = Identity> {
     /// Sequencer client, configured to forward submitted transactions to sequencer of given OP
     /// network.
     sequencer_url: Option<String>,
     /// Headers to use for the sequencer client requests.
     sequencer_headers: Vec<String>,
     /// Data availability configuration for the OP builder.
-    da_config: Option<OpDAConfig>,
+    da_config: Option<BaseDAConfig>,
     /// Gas limit configuration for the OP builder.
     gas_limit_config: Option<GasLimitConfig>,
     /// Marker for network types.
@@ -675,7 +679,7 @@ pub struct OpAddOnsBuilder<NetworkT, RpcMiddleware = Identity> {
     tokio_runtime: Option<tokio::runtime::Handle>,
 }
 
-impl<NetworkT> Default for OpAddOnsBuilder<NetworkT> {
+impl<NetworkT> Default for BaseAddOnsBuilder<NetworkT> {
     fn default() -> Self {
         Self {
             sequencer_url: None,
@@ -690,7 +694,7 @@ impl<NetworkT> Default for OpAddOnsBuilder<NetworkT> {
     }
 }
 
-impl<NetworkT, RpcMiddleware> OpAddOnsBuilder<NetworkT, RpcMiddleware> {
+impl<NetworkT, RpcMiddleware> BaseAddOnsBuilder<NetworkT, RpcMiddleware> {
     /// With a [`SequencerClient`].
     pub fn with_sequencer(mut self, sequencer_client: Option<String>) -> Self {
         self.sequencer_url = sequencer_client;
@@ -704,7 +708,7 @@ impl<NetworkT, RpcMiddleware> OpAddOnsBuilder<NetworkT, RpcMiddleware> {
     }
 
     /// Configure the data availability configuration for the OP builder.
-    pub fn with_da_config(mut self, da_config: OpDAConfig) -> Self {
+    pub fn with_da_config(mut self, da_config: BaseDAConfig) -> Self {
         self.da_config = Some(da_config);
         self
     }
@@ -730,7 +734,7 @@ impl<NetworkT, RpcMiddleware> OpAddOnsBuilder<NetworkT, RpcMiddleware> {
     }
 
     /// Configure the RPC middleware to use
-    pub fn with_rpc_middleware<T>(self, rpc_middleware: T) -> OpAddOnsBuilder<NetworkT, T> {
+    pub fn with_rpc_middleware<T>(self, rpc_middleware: T) -> BaseAddOnsBuilder<NetworkT, T> {
         let Self {
             sequencer_url,
             sequencer_headers,
@@ -741,7 +745,7 @@ impl<NetworkT, RpcMiddleware> OpAddOnsBuilder<NetworkT, RpcMiddleware> {
             _nt,
             ..
         } = self;
-        OpAddOnsBuilder {
+        BaseAddOnsBuilder {
             sequencer_url,
             sequencer_headers,
             da_config,
@@ -754,11 +758,11 @@ impl<NetworkT, RpcMiddleware> OpAddOnsBuilder<NetworkT, RpcMiddleware> {
     }
 }
 
-impl<NetworkT, RpcMiddleware> OpAddOnsBuilder<NetworkT, RpcMiddleware> {
-    /// Builds an instance of [`OpAddOns`].
+impl<NetworkT, RpcMiddleware> BaseAddOnsBuilder<NetworkT, RpcMiddleware> {
+    /// Builds an instance of [`BaseAddOns`].
     pub fn build<N, PVB, EB, EVB>(
         self,
-    ) -> OpAddOns<N, OpEthApiBuilder<NetworkT>, PVB, EB, EVB, RpcMiddleware>
+    ) -> BaseAddOns<N, OpEthApiBuilder<NetworkT>, PVB, EB, EVB, RpcMiddleware>
     where
         N: FullNodeComponents<Types: NodeTypes>,
         OpEthApiBuilder<NetworkT>: EthApiBuilder<N>,
@@ -777,7 +781,7 @@ impl<NetworkT, RpcMiddleware> OpAddOnsBuilder<NetworkT, RpcMiddleware> {
             ..
         } = self;
 
-        OpAddOns::new(
+        BaseAddOns::new(
             RpcAddOns::new(
                 OpEthApiBuilder::default()
                     .with_sequencer(sequencer_url.clone())
@@ -801,9 +805,9 @@ impl<NetworkT, RpcMiddleware> OpAddOnsBuilder<NetworkT, RpcMiddleware> {
 /// A regular Base EVM and executor builder.
 #[derive(Debug, Copy, Clone, Default)]
 #[non_exhaustive]
-pub struct OpExecutorBuilder;
+pub struct BaseExecutorBuilder;
 
-impl<Node> ExecutorBuilder<Node> for OpExecutorBuilder
+impl<Node> ExecutorBuilder<Node> for BaseExecutorBuilder
 where
     Node: FullNodeTypes<Types: BaseNodeTypes>,
 {
@@ -824,7 +828,7 @@ where
 /// This contains various settings that can be configured and take precedence over the node's
 /// config.
 #[derive(Debug)]
-pub struct OpPoolBuilder<T = BasePooledTransaction> {
+pub struct BasePoolBuilder<T = BasePooledTransaction> {
     /// Enforced overrides that are applied to the pool config.
     pub pool_config_overrides: PoolBuilderConfigOverrides,
     /// The ordering strategy for the transaction pool.
@@ -833,7 +837,7 @@ pub struct OpPoolBuilder<T = BasePooledTransaction> {
     _pd: core::marker::PhantomData<T>,
 }
 
-impl<T> Default for OpPoolBuilder<T> {
+impl<T> Default for BasePoolBuilder<T> {
     fn default() -> Self {
         Self {
             pool_config_overrides: Default::default(),
@@ -843,7 +847,7 @@ impl<T> Default for OpPoolBuilder<T> {
     }
 }
 
-impl<T> Clone for OpPoolBuilder<T> {
+impl<T> Clone for BasePoolBuilder<T> {
     fn clone(&self) -> Self {
         Self {
             pool_config_overrides: self.pool_config_overrides.clone(),
@@ -853,7 +857,7 @@ impl<T> Clone for OpPoolBuilder<T> {
     }
 }
 
-impl<T> OpPoolBuilder<T> {
+impl<T> BasePoolBuilder<T> {
     /// Sets the [`PoolBuilderConfigOverrides`] on the pool builder.
     pub fn with_pool_config_overrides(
         mut self,
@@ -870,7 +874,7 @@ impl<T> OpPoolBuilder<T> {
     }
 }
 
-impl<Node, T, Evm> PoolBuilder<Node, Evm> for OpPoolBuilder<T>
+impl<Node, T, Evm> PoolBuilder<Node, Evm> for BasePoolBuilder<T>
 where
     Node: FullNodeTypes<Types: BaseNodeTypes>,
     T: EthPoolTransaction<Consensus = TxTy<Node::Types>> + OpPooledTx + TimestampedTransaction,
@@ -941,7 +945,7 @@ pub struct OpPayloadBuilder<Txs = ()> {
     pub best_transactions: Txs,
     /// This data availability configuration specifies constraints for the payload builder
     /// when assembling payloads
-    pub da_config: OpDAConfig,
+    pub da_config: BaseDAConfig,
     /// Gas limit configuration for the OP builder.
     /// This is used to configure gas limit related constraints for the payload builder.
     pub gas_limit_config: GasLimitConfig,
@@ -954,13 +958,13 @@ impl OpPayloadBuilder {
         Self {
             compute_pending_block,
             best_transactions: (),
-            da_config: OpDAConfig::default(),
+            da_config: BaseDAConfig::default(),
             gas_limit_config: GasLimitConfig::default(),
         }
     }
 
     /// Configure the data availability configuration for the OP payload builder.
-    pub fn with_da_config(mut self, da_config: OpDAConfig) -> Self {
+    pub fn with_da_config(mut self, da_config: BaseDAConfig) -> Self {
         self.da_config = da_config;
         self
     }
@@ -1032,30 +1036,30 @@ where
 
 /// A basic Base network builder.
 #[derive(Debug, Default)]
-pub struct OpNetworkBuilder {
+pub struct BaseNetworkBuilder {
     /// Disable transaction pool gossip
     pub disable_txpool_gossip: bool,
     /// Disable discovery v4
     pub disable_discovery_v4: bool,
 }
 
-impl Clone for OpNetworkBuilder {
+impl Clone for BaseNetworkBuilder {
     fn clone(&self) -> Self {
         Self::new(self.disable_txpool_gossip, self.disable_discovery_v4)
     }
 }
 
-impl OpNetworkBuilder {
-    /// Creates a new `OpNetworkBuilder`.
+impl BaseNetworkBuilder {
+    /// Creates a new `BaseNetworkBuilder`.
     pub const fn new(disable_txpool_gossip: bool, disable_discovery_v4: bool) -> Self {
         Self { disable_txpool_gossip, disable_discovery_v4 }
     }
 }
 
-impl OpNetworkBuilder {
+impl BaseNetworkBuilder {
     /// Returns the [`NetworkConfig`] that contains the settings to launch the p2p network.
     ///
-    /// This applies the configured [`OpNetworkBuilder`] settings.
+    /// This applies the configured [`BaseNetworkBuilder`] settings.
     pub fn network_config<Node, NetworkP>(
         &self,
         ctx: &BuilderContext<Node>,
@@ -1102,7 +1106,7 @@ impl OpNetworkBuilder {
     }
 }
 
-impl<Node, Pool> NetworkBuilder<Node, Pool> for OpNetworkBuilder
+impl<Node, Pool> NetworkBuilder<Node, Pool> for BaseNetworkBuilder
 where
     Node: FullNodeTypes<Types: NodeTypes<ChainSpec: Hardforks>>,
     Pool: TransactionPool<Transaction: PoolTransaction<Consensus = TxTy<Node::Types>>>
@@ -1129,9 +1133,9 @@ where
 /// A basic Base consensus builder.
 #[derive(Debug, Default, Clone)]
 #[non_exhaustive]
-pub struct OpConsensusBuilder;
+pub struct BaseConsensusBuilder;
 
-impl<Node> ConsensusBuilder<Node> for OpConsensusBuilder
+impl<Node> ConsensusBuilder<Node> for BaseConsensusBuilder
 where
     Node: FullNodeTypes<Types: BaseNodeTypes>,
 {
@@ -1145,9 +1149,9 @@ where
 /// Builder for [`OpEngineValidator`].
 #[derive(Debug, Default, Clone)]
 #[non_exhaustive]
-pub struct OpEngineValidatorBuilder;
+pub struct BasePayloadValidatorBuilder;
 
-impl<Node> PayloadValidatorBuilder<Node> for OpEngineValidatorBuilder
+impl<Node> PayloadValidatorBuilder<Node> for BasePayloadValidatorBuilder
 where
     Node: FullNodeComponents<
         Types: NodeTypes<ChainSpec: Upgrades, Payload: PayloadTypes<ExecutionData = ExecutionData>>,

--- a/crates/execution/node/src/proof_history.rs
+++ b/crates/execution/node/src/proof_history.rs
@@ -3,12 +3,12 @@
 use std::{sync::Arc, time::Duration};
 
 use base_execution_chainspec::BaseChainSpec;
-use base_execution_exex::OpProofsExEx;
+use base_execution_exex::BaseProofsExEx;
 use base_execution_rpc::{
     debug::{DebugApiExt, DebugApiOverrideServer},
     eth::proofs::{EthApiExt, EthApiOverrideServer},
 };
-use base_execution_trie::{OpProofsStorage, db::MdbxProofsStorage};
+use base_execution_trie::{BaseProofsStorage, db::MdbxProofsStorage};
 use eyre::ErrReport;
 use futures::FutureExt;
 use reth_db::DatabaseEnv;
@@ -49,7 +49,7 @@ pub async fn launch_node_with_proof_history(
             MdbxProofsStorage::new(&path)
                 .map_err(|e| eyre::eyre!("Failed to create MdbxProofsStorage: {e}"))?,
         );
-        let storage: OpProofsStorage<Arc<MdbxProofsStorage>> = Arc::clone(&mdbx).into();
+        let storage: BaseProofsStorage<Arc<MdbxProofsStorage>> = Arc::clone(&mdbx).into();
 
         let storage_exec = storage.clone();
 
@@ -63,7 +63,7 @@ pub async fn launch_node_with_proof_history(
                 Ok(())
             })
             .install_exex("proofs-history", async move |exex_context| {
-                Ok(OpProofsExEx::builder(exex_context, storage_exec)
+                Ok(BaseProofsExEx::builder(exex_context, storage_exec)
                     .with_proofs_history_window(proofs_history_window)
                     .with_proofs_history_prune_interval(proofs_history_prune_interval)
                     .with_verification_interval(proofs_history_verification_interval)

--- a/crates/execution/node/src/rpc.rs
+++ b/crates/execution/node/src/rpc.rs
@@ -17,7 +17,7 @@
 //! };
 //! use base_execution_chainspec::BASE_SEPOLIA;
 //! use base_execution_evm::BaseEvmConfig;
-//! use base_node_core::{BaseNetworkPrimitives, OpExecutorBuilder, BaseNode};
+//! use base_node_core::{BaseNetworkPrimitives, BaseExecutorBuilder, BaseNode};
 //! use base_execution_rpc::OpEthApiBuilder;
 //! use base_execution_txpool::BasePooledTransaction;
 //! use reth_provider::providers::BlockchainProvider;
@@ -52,7 +52,7 @@
 //!             ComponentsBuilder::default()
 //!                 .node_types::<RethFullAdapter<_, BaseNode>>()
 //!                 .noop_pool::<BasePooledTransaction>()
-//!                 .executor(OpExecutorBuilder::default())
+//!                 .executor(BaseExecutorBuilder::default())
 //!                 .noop_consensus()
 //!                 .noop_network::<BaseNetworkPrimitives>()
 //!                 .noop_payload(),

--- a/crates/execution/node/tests/it/priority.rs
+++ b/crates/execution/node/tests/it/priority.rs
@@ -13,8 +13,8 @@ use base_node_core::{
     BaseNode,
     args::RollupArgs,
     node::{
-        BaseNodeTypes, OpConsensusBuilder, OpExecutorBuilder, OpNetworkBuilder,
-        OpNodeComponentBuilder, OpPayloadBuilder, OpPoolBuilder,
+        BaseConsensusBuilder, BaseExecutorBuilder, BaseNetworkBuilder, BaseNodeComponentBuilder,
+        BaseNodeTypes, BasePoolBuilder, OpPayloadBuilder,
     },
     utils::optimism_payload_attributes,
 };
@@ -89,7 +89,7 @@ impl BasePayloadTransactions<BasePooledTransaction> for CustomTxPriority {
 /// Builds the node with custom transaction priority service within default payload builder.
 fn build_components<Node>(
     chain_id: ChainId,
-) -> OpNodeComponentBuilder<Node, OpPayloadBuilder<CustomTxPriority>>
+) -> BaseNodeComponentBuilder<Node, OpPayloadBuilder<CustomTxPriority>>
 where
     Node: FullNodeTypes<Types: BaseNodeTypes>,
 {
@@ -97,14 +97,14 @@ where
         RollupArgs::default();
     ComponentsBuilder::default()
         .node_types::<Node>()
-        .pool(OpPoolBuilder::default())
-        .executor(OpExecutorBuilder::default())
+        .pool(BasePoolBuilder::default())
+        .executor(BaseExecutorBuilder::default())
         .payload(BasicPayloadServiceBuilder::new(
             OpPayloadBuilder::new(compute_pending_block)
                 .with_transactions(CustomTxPriority { chain_id }),
         ))
-        .network(OpNetworkBuilder::new(disable_txpool_gossip, !discovery_v4))
-        .consensus(OpConsensusBuilder::default())
+        .network(BaseNetworkBuilder::new(disable_txpool_gossip, !discovery_v4))
+        .consensus(BaseConsensusBuilder::default())
 }
 
 #[tokio::test]

--- a/crates/execution/payload/src/config.rs
+++ b/crates/execution/payload/src/config.rs
@@ -6,20 +6,20 @@ use std::sync::{Arc, atomic::AtomicU64};
 #[derive(Debug, Clone, Default)]
 pub struct BaseBuilderConfig {
     /// Data availability configuration for the OP builder.
-    pub da_config: OpDAConfig,
+    pub da_config: BaseDAConfig,
     /// Gas limit configuration for the OP builder.
     pub gas_limit_config: GasLimitConfig,
 }
 
 impl BaseBuilderConfig {
     /// Creates a new OP builder configuration with the given data availability configuration.
-    pub const fn new(da_config: OpDAConfig, gas_limit_config: GasLimitConfig) -> Self {
+    pub const fn new(da_config: BaseDAConfig, gas_limit_config: GasLimitConfig) -> Self {
         Self { da_config, gas_limit_config }
     }
 
     /// Returns the Data Availability configuration for the OP builder, if it has configured
     /// constraints.
-    pub fn constrained_da_config(&self) -> Option<&OpDAConfig> {
+    pub fn constrained_da_config(&self) -> Option<&BaseDAConfig> {
         if self.da_config.is_empty() { None } else { Some(&self.da_config) }
     }
 }
@@ -29,11 +29,11 @@ impl BaseBuilderConfig {
 /// This type is shareable and can be used to update the DA configuration for the OP payload
 /// builder.
 #[derive(Debug, Clone, Default)]
-pub struct OpDAConfig {
-    inner: Arc<OpDAConfigInner>,
+pub struct BaseDAConfig {
+    inner: Arc<BaseDAConfigInner>,
 }
 
-impl OpDAConfig {
+impl BaseDAConfig {
     /// Creates a new Data Availability configuration with the given maximum sizes.
     pub fn new(max_da_tx_size: u64, max_da_block_size: u64) -> Self {
         let this = Self::default();
@@ -78,7 +78,7 @@ impl OpDAConfig {
 }
 
 #[derive(Debug, Default)]
-struct OpDAConfigInner {
+struct BaseDAConfigInner {
     /// Don't include any transactions with data availability size larger than this in any built
     /// block
     ///
@@ -126,7 +126,7 @@ mod tests {
 
     #[test]
     fn test_da() {
-        let da = OpDAConfig::default();
+        let da = BaseDAConfig::default();
         assert_eq!(da.max_da_tx_size(), None);
         assert_eq!(da.max_da_block_size(), None);
         da.set_max_da_size(100, 200);

--- a/crates/execution/rpc/src/debug.rs
+++ b/crates/execution/rpc/src/debug.rs
@@ -13,7 +13,7 @@ use base_execution_payload_builder::{
     Attributes, PayloadPrimitives,
     builder::{Builder, OpPayloadBuilderCtx},
 };
-use base_execution_trie::{OpProofsStorage, OpProofsStore};
+use base_execution_trie::{BaseProofsStorage, BaseProofsStore};
 use base_execution_txpool::BasePooledTransaction;
 use jsonrpsee::proc_macros::rpc;
 use jsonrpsee_core::RpcResult;
@@ -79,7 +79,7 @@ impl<Eth, Storage, Provider, EvmConfig, Attrs> DebugApiExt<Eth, Storage, Provide
 where
     Eth: FullEthApi + Send + Sync + 'static,
     ErrorObject<'static>: From<Eth::Error>,
-    Storage: OpProofsStore + Clone + 'static,
+    Storage: BaseProofsStore + Clone + 'static,
     Provider: BlockReaderIdExt + NodePrimitivesProvider<Primitives: PayloadPrimitives>,
     EvmConfig: ConfigureEvm<Primitives = Provider::Primitives> + 'static,
 {
@@ -87,7 +87,7 @@ where
     pub fn new(
         provider: Provider,
         eth_api: Eth,
-        preimage_store: OpProofsStorage<Storage>,
+        preimage_store: BaseProofsStorage<Storage>,
         task_spawner: Box<dyn TaskSpawner>,
         evm_config: EvmConfig,
     ) -> Self {
@@ -108,7 +108,7 @@ where
 pub struct DebugApiExtInner<Eth: FullEthApi, Storage, Provider, EvmConfig, Attrs> {
     provider: Provider,
     eth_api: Eth,
-    storage: OpProofsStorage<Storage>,
+    storage: BaseProofsStorage<Storage>,
     state_provider_factory: BaseStateProviderFactory<Eth, Storage>,
     evm_config: EvmConfig,
     task_spawner: Box<dyn TaskSpawner>,
@@ -120,13 +120,13 @@ impl<Eth, P, Provider, EvmConfig, Attrs> DebugApiExtInner<Eth, P, Provider, EvmC
 where
     Eth: FullEthApi + Send + Sync + 'static,
     ErrorObject<'static>: From<Eth::Error>,
-    P: OpProofsStore + Clone + 'static,
+    P: BaseProofsStore + Clone + 'static,
     Provider: NodePrimitivesProvider<Primitives: PayloadPrimitives>,
 {
     fn new(
         provider: Provider,
         eth_api: Eth,
-        storage: OpProofsStorage<P>,
+        storage: BaseProofsStorage<P>,
         task_spawner: Box<dyn TaskSpawner>,
         evm_config: EvmConfig,
     ) -> Self {
@@ -147,7 +147,7 @@ impl<Eth, P, Provider, EvmConfig, Attrs> DebugApiExt<Eth, P, Provider, EvmConfig
 where
     Eth: FullEthApi + Send + Sync + 'static,
     ErrorObject<'static>: From<Eth::Error>,
-    P: OpProofsStore + Clone + 'static,
+    P: BaseProofsStore + Clone + 'static,
     Provider: BlockReaderIdExt
         + NodePrimitivesProvider<Primitives: PayloadPrimitives>
         + HeaderProvider<Header = <Provider::Primitives as NodePrimitives>::BlockHeader>,
@@ -169,7 +169,7 @@ impl<Eth, P, Provider, EvmConfig, Attrs, N> DebugApiOverrideServer<Attrs::RpcPay
 where
     Eth: FullEthApi + Send + Sync + 'static,
     ErrorObject<'static>: From<Eth::Error>,
-    P: OpProofsStore + Clone + 'static,
+    P: BaseProofsStore + Clone + 'static,
     Attrs: Attributes<Transaction = TxTy<EvmConfig::Primitives>>,
     N: PayloadPrimitives,
     EvmConfig: ConfigureEvm<

--- a/crates/execution/rpc/src/eth/mod.rs
+++ b/crates/execution/rpc/src/eth/mod.rs
@@ -40,7 +40,7 @@ use reth_tasks::{
 
 use crate::{
     OpEthApiError, SequencerClient,
-    eth::{receipt::BaseReceiptConverter, transaction::OpTxInfoMapper},
+    eth::{receipt::BaseReceiptConverter, transaction::BaseTxInfoMapper},
 };
 
 /// Adapter for [`EthApiInner`], which holds all the data required to serve core `eth_` API.
@@ -293,7 +293,7 @@ pub type BaseRpcConvert<N, NetworkT> = RpcConverter<
     <N as FullNodeComponents>::Evm,
     BaseReceiptConverter<<N as FullNodeTypes>::Provider>,
     (),
-    OpTxInfoMapper<<N as FullNodeTypes>::Provider>,
+    BaseTxInfoMapper<<N as FullNodeTypes>::Provider>,
 >;
 
 /// Builds [`OpEthApi`] for Base.
@@ -368,7 +368,7 @@ where
         let Self { sequencer_url, sequencer_headers, min_suggested_priority_fee, .. } = self;
         let rpc_converter =
             RpcConverter::new(BaseReceiptConverter::new(ctx.components.provider().clone()))
-                .with_mapper(OpTxInfoMapper::new(ctx.components.provider().clone()));
+                .with_mapper(BaseTxInfoMapper::new(ctx.components.provider().clone()));
 
         let sequencer_client = if let Some(url) = sequencer_url {
             Some(

--- a/crates/execution/rpc/src/eth/proofs.rs
+++ b/crates/execution/rpc/src/eth/proofs.rs
@@ -7,7 +7,7 @@ use alloy_primitives::Address;
 use alloy_rpc_types_eth::EIP1186AccountProofResponse;
 use alloy_serde::JsonStorageKey;
 use async_trait::async_trait;
-use base_execution_trie::{OpProofsStorage, OpProofsStore};
+use base_execution_trie::{BaseProofsStorage, BaseProofsStore};
 use jsonrpsee::proc_macros::rpc;
 use jsonrpsee_core::RpcResult;
 use jsonrpsee_types::error::ErrorObject;
@@ -40,10 +40,10 @@ impl<Eth, P> EthApiExt<Eth, P>
 where
     Eth: FullEthApi + Send + Sync + 'static,
     ErrorObject<'static>: From<Eth::Error>,
-    P: OpProofsStore + Clone + 'static,
+    P: BaseProofsStore + Clone + 'static,
 {
     /// Creates a new instance of the `EthApiExt`.
-    pub const fn new(eth_api: Eth, preimage_store: OpProofsStorage<P>) -> Self {
+    pub const fn new(eth_api: Eth, preimage_store: BaseProofsStorage<P>) -> Self {
         Self { state_provider_factory: BaseStateProviderFactory::new(eth_api, preimage_store) }
     }
 }
@@ -53,7 +53,7 @@ impl<Eth, P> EthApiOverrideServer for EthApiExt<Eth, P>
 where
     Eth: FullEthApi + Send + Sync + 'static,
     ErrorObject<'static>: From<Eth::Error>,
-    P: OpProofsStore + Clone + 'static,
+    P: BaseProofsStore + Clone + 'static,
 {
     async fn get_proof(
         &self,

--- a/crates/execution/rpc/src/eth/transaction.rs
+++ b/crates/execution/rpc/src/eth/transaction.rs
@@ -195,30 +195,30 @@ where
 ///
 /// For deposits, receipt is fetched to extract `deposit_nonce` and `deposit_receipt_version`.
 /// Otherwise, it works like regular Ethereum implementation, i.e. uses [`TransactionInfo`].
-pub struct OpTxInfoMapper<Provider> {
+pub struct BaseTxInfoMapper<Provider> {
     provider: Provider,
 }
 
-impl<Provider: Clone> Clone for OpTxInfoMapper<Provider> {
+impl<Provider: Clone> Clone for BaseTxInfoMapper<Provider> {
     fn clone(&self) -> Self {
         Self { provider: self.provider.clone() }
     }
 }
 
-impl<Provider> Debug for OpTxInfoMapper<Provider> {
+impl<Provider> Debug for BaseTxInfoMapper<Provider> {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("OpTxInfoMapper").finish()
+        f.debug_struct("BaseTxInfoMapper").finish()
     }
 }
 
-impl<Provider> OpTxInfoMapper<Provider> {
-    /// Creates [`OpTxInfoMapper`] that uses [`ReceiptProvider`] borrowed from given `eth_api`.
+impl<Provider> BaseTxInfoMapper<Provider> {
+    /// Creates [`BaseTxInfoMapper`] that uses [`ReceiptProvider`] borrowed from given `eth_api`.
     pub const fn new(provider: Provider) -> Self {
         Self { provider }
     }
 }
 
-impl<T, Provider> TxInfoMapper<T> for OpTxInfoMapper<Provider>
+impl<T, Provider> TxInfoMapper<T> for BaseTxInfoMapper<Provider>
 where
     T: BaseTransaction + SignedTransaction,
     Provider: ReceiptProvider<Receipt: DepositReceiptExt>,

--- a/crates/execution/rpc/src/miner.rs
+++ b/crates/execution/rpc/src/miner.rs
@@ -1,7 +1,7 @@
 //! Miner API extension for OP.
 
 use alloy_primitives::U64;
-use base_execution_payload_builder::config::{GasLimitConfig, OpDAConfig};
+use base_execution_payload_builder::config::{BaseDAConfig, GasLimitConfig};
 use jsonrpsee::proc_macros::rpc;
 use jsonrpsee_core::{RpcResult, async_trait};
 use tracing::debug;
@@ -39,21 +39,21 @@ base_metrics::define_metrics! {
 /// Miner API extension for OP, exposes settings for the data availability configuration via the
 /// `miner_` API.
 #[derive(Debug, Clone)]
-pub struct OpMinerExtApi {
-    da_config: OpDAConfig,
+pub struct BaseMinerExtApi {
+    da_config: BaseDAConfig,
     gas_limit_config: GasLimitConfig,
 }
 
-impl OpMinerExtApi {
+impl BaseMinerExtApi {
     /// Instantiate the miner API extension with the given, sharable data availability
     /// configuration.
-    pub const fn new(da_config: OpDAConfig, gas_limit_config: GasLimitConfig) -> Self {
+    pub const fn new(da_config: BaseDAConfig, gas_limit_config: GasLimitConfig) -> Self {
         Self { da_config, gas_limit_config }
     }
 }
 
 #[async_trait]
-impl MinerApiExtServer for OpMinerExtApi {
+impl MinerApiExtServer for BaseMinerExtApi {
     /// Handler for `miner_setMaxDASize` RPC method.
     async fn set_max_da_size(&self, max_tx_size: U64, max_block_size: U64) -> RpcResult<bool> {
         debug!(target: "rpc", max_tx_size = %max_tx_size, max_block_size = %max_block_size, "Setting max DA size");

--- a/crates/execution/rpc/src/state.rs
+++ b/crates/execution/rpc/src/state.rs
@@ -1,7 +1,9 @@
 //! State provider factory for OP Proofs `ExEx`.
 
 use alloy_eips::BlockId;
-use base_execution_trie::{OpProofsStorage, OpProofsStore, provider::OpProofsStateProviderRef};
+use base_execution_trie::{
+    BaseProofsStorage, BaseProofsStore, provider::BaseProofsStateProviderRef,
+};
 use jsonrpsee_types::error::ErrorObject;
 use reth_provider::{BlockIdReader, ProviderError, ProviderResult, StateProvider};
 use reth_rpc_api::eth::helpers::FullEthApi;
@@ -11,12 +13,12 @@ use reth_rpc_eth_types::EthApiError;
 #[derive(Debug)]
 pub struct BaseStateProviderFactory<Eth, P> {
     eth_api: Eth,
-    preimage_store: OpProofsStorage<P>,
+    preimage_store: BaseProofsStorage<P>,
 }
 
 impl<Eth, P> BaseStateProviderFactory<Eth, P> {
     /// Creates a new state provider factory.
-    pub const fn new(eth_api: Eth, preimage_store: OpProofsStorage<P>) -> Self {
+    pub const fn new(eth_api: Eth, preimage_store: BaseProofsStorage<P>) -> Self {
         Self { eth_api, preimage_store }
     }
 }
@@ -25,7 +27,7 @@ impl<'a, Eth, P> BaseStateProviderFactory<Eth, P>
 where
     Eth: FullEthApi + Send + Sync + 'static,
     ErrorObject<'static>: From<Eth::Error>,
-    P: OpProofsStore + Clone + 'a,
+    P: BaseProofsStore + Clone + 'a,
 {
     /// Creates a state provider for the given block id.
     pub async fn state_provider(
@@ -60,8 +62,11 @@ where
             return Err(ProviderError::StateForNumberNotFound(block_number));
         }
 
-        let external_overlay_provider =
-            OpProofsStateProviderRef::new(historical_provider, &self.preimage_store, block_number);
+        let external_overlay_provider = BaseProofsStateProviderRef::new(
+            historical_provider,
+            &self.preimage_store,
+            block_number,
+        );
 
         Ok(Box::new(external_overlay_provider))
     }

--- a/crates/execution/rpc/src/witness.rs
+++ b/crates/execution/rpc/src/witness.rs
@@ -23,24 +23,24 @@ use reth_transaction_pool::TransactionPool;
 use tokio::sync::{Semaphore, oneshot};
 
 /// An extension to the `debug_` namespace of the RPC API.
-pub struct OpDebugWitnessApi<Pool, Provider, EvmConfig, Attrs> {
-    inner: Arc<OpDebugWitnessApiInner<Pool, Provider, EvmConfig, Attrs>>,
+pub struct BaseDebugWitnessApi<Pool, Provider, EvmConfig, Attrs> {
+    inner: Arc<BaseDebugWitnessApiInner<Pool, Provider, EvmConfig, Attrs>>,
 }
 
-impl<Pool, Provider, EvmConfig, Attrs> OpDebugWitnessApi<Pool, Provider, EvmConfig, Attrs> {
-    /// Creates a new instance of the `OpDebugWitnessApi`.
+impl<Pool, Provider, EvmConfig, Attrs> BaseDebugWitnessApi<Pool, Provider, EvmConfig, Attrs> {
+    /// Creates a new instance of the `BaseDebugWitnessApi`.
     pub fn new(
         provider: Provider,
         task_spawner: Box<dyn TaskSpawner>,
         builder: OpPayloadBuilder<Pool, Provider, EvmConfig, (), Attrs>,
     ) -> Self {
         let semaphore = Arc::new(Semaphore::new(3));
-        let inner = OpDebugWitnessApiInner { provider, builder, task_spawner, semaphore };
+        let inner = BaseDebugWitnessApiInner { provider, builder, task_spawner, semaphore };
         Self { inner: Arc::new(inner) }
     }
 }
 
-impl<Pool, Provider, EvmConfig, Attrs> OpDebugWitnessApi<Pool, Provider, EvmConfig, Attrs>
+impl<Pool, Provider, EvmConfig, Attrs> BaseDebugWitnessApi<Pool, Provider, EvmConfig, Attrs>
 where
     EvmConfig: ConfigureEvm,
     Provider: NodePrimitivesProvider<Primitives: NodePrimitives<BlockHeader = Provider::Header>>
@@ -60,7 +60,7 @@ where
 
 #[async_trait]
 impl<Pool, Provider, EvmConfig, Attrs> DebugExecutionWitnessApiServer<Attrs::RpcPayloadAttributes>
-    for OpDebugWitnessApi<Pool, Provider, EvmConfig, Attrs>
+    for BaseDebugWitnessApi<Pool, Provider, EvmConfig, Attrs>
 where
     Pool: TransactionPool<
             Transaction: OpPooledTx<Consensus = <Provider::Primitives as NodePrimitives>::SignedTx>,
@@ -100,21 +100,21 @@ where
 }
 
 impl<Pool, Provider, EvmConfig, Attrs> Clone
-    for OpDebugWitnessApi<Pool, Provider, EvmConfig, Attrs>
+    for BaseDebugWitnessApi<Pool, Provider, EvmConfig, Attrs>
 {
     fn clone(&self) -> Self {
         Self { inner: Arc::clone(&self.inner) }
     }
 }
 impl<Pool, Provider, EvmConfig, Attrs> Debug
-    for OpDebugWitnessApi<Pool, Provider, EvmConfig, Attrs>
+    for BaseDebugWitnessApi<Pool, Provider, EvmConfig, Attrs>
 {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("OpDebugWitnessApi").finish_non_exhaustive()
+        f.debug_struct("BaseDebugWitnessApi").finish_non_exhaustive()
     }
 }
 
-struct OpDebugWitnessApiInner<Pool, Provider, EvmConfig, Attrs> {
+struct BaseDebugWitnessApiInner<Pool, Provider, EvmConfig, Attrs> {
     provider: Provider,
     builder: OpPayloadBuilder<Pool, Provider, EvmConfig, (), Attrs>,
     task_spawner: Box<dyn TaskSpawner>,

--- a/crates/execution/runner/src/add_ons.rs
+++ b/crates/execution/runner/src/add_ons.rs
@@ -2,17 +2,17 @@ use std::marker::PhantomData;
 
 use base_execution_payload_builder::{
     Attributes, PayloadPrimitives,
-    config::{GasLimitConfig, OpDAConfig},
+    config::{BaseDAConfig, GasLimitConfig},
 };
 use base_execution_rpc::{
     MinerApiExtServer,
     config::{BaseEthConfigApiServer, BaseEthConfigHandler},
     eth::OpEthApiBuilder,
-    miner::OpMinerExtApi,
-    witness::OpDebugWitnessApi,
+    miner::BaseMinerExtApi,
+    witness::BaseDebugWitnessApi,
 };
 use base_execution_txpool::OpPooledTx;
-use base_node_core::{BaseNodeTypes, OpEngineApiBuilder, OpEngineValidatorBuilder};
+use base_node_core::{BaseNodeTypes, BasePayloadValidatorBuilder, OpEngineApiBuilder};
 use reth_evm::ConfigureEvm;
 use reth_node_api::{BuildNextEnv, FullNodeComponents, HeaderTy, NodeAddOns, PayloadTypes, TxTy};
 use reth_node_builder::{
@@ -47,7 +47,7 @@ pub struct BaseAddOns<
     /// and eth-api.
     pub rpc_add_ons: RpcAddOns<N, EthB, PVB, EB, EVB, RpcMiddleware>,
     /// Data availability configuration for the OP builder.
-    pub da_config: OpDAConfig,
+    pub da_config: BaseDAConfig,
     /// Gas limit configuration for the OP builder.
     pub gas_limit_config: GasLimitConfig,
 }
@@ -61,14 +61,14 @@ where
     #[allow(clippy::too_many_arguments)]
     pub const fn new(
         rpc_add_ons: RpcAddOns<N, EthB, PVB, EB, EVB, RpcMiddleware>,
-        da_config: OpDAConfig,
+        da_config: BaseDAConfig,
         gas_limit_config: GasLimitConfig,
     ) -> Self {
         Self { rpc_add_ons, da_config, gas_limit_config }
     }
 }
 
-impl<N> Default for BaseAddOns<N, OpEthApiBuilder, OpEngineValidatorBuilder>
+impl<N> Default for BaseAddOns<N, OpEthApiBuilder, BasePayloadValidatorBuilder>
 where
     N: FullNodeComponents<Types: BaseNodeTypes>,
     OpEthApiBuilder: EthApiBuilder<N>,
@@ -82,15 +82,15 @@ impl<N, NetworkT, RpcMiddleware>
     BaseAddOns<
         N,
         OpEthApiBuilder<NetworkT>,
-        OpEngineValidatorBuilder,
-        OpEngineApiBuilder<OpEngineValidatorBuilder>,
+        BasePayloadValidatorBuilder,
+        OpEngineApiBuilder<BasePayloadValidatorBuilder>,
         RpcMiddleware,
     >
 where
     N: FullNodeComponents<Types: BaseNodeTypes>,
     OpEthApiBuilder<NetworkT>: EthApiBuilder<N>,
 {
-    /// Build a [`OpAddOns`] using [`BaseAddOnsBuilder`].
+    /// Build a [`BaseAddOns`] using [`BaseAddOnsBuilder`].
     pub fn builder() -> BaseAddOnsBuilder<NetworkT> {
         BaseAddOnsBuilder::default()
     }
@@ -216,12 +216,12 @@ where
             ctx.node.evm_config().clone(),
         );
         // install additional OP specific rpc methods
-        let debug_ext = OpDebugWitnessApi::<_, _, _, Attrs>::new(
+        let debug_ext = BaseDebugWitnessApi::<_, _, _, Attrs>::new(
             ctx.node.provider().clone(),
             Box::new(ctx.node.task_executor().clone()),
             builder,
         );
-        let miner_ext = OpMinerExtApi::new(da_config, gas_limit_config);
+        let miner_ext = BaseMinerExtApi::new(da_config, gas_limit_config);
 
         rpc_add_ons
             .launch_add_ons_with(ctx, move |container| {
@@ -314,7 +314,7 @@ pub struct BaseAddOnsBuilder<NetworkT, RpcMiddleware = Identity> {
     /// Headers to use for the sequencer client requests.
     sequencer_headers: Vec<String>,
     /// Data availability configuration for the OP builder.
-    da_config: Option<OpDAConfig>,
+    da_config: Option<BaseDAConfig>,
     /// Gas limit configuration for the OP builder.
     gas_limit_config: Option<GasLimitConfig>,
     /// Marker for network types.
@@ -356,7 +356,7 @@ impl<NetworkT, RpcMiddleware> BaseAddOnsBuilder<NetworkT, RpcMiddleware> {
     }
 
     /// Configure the data availability configuration for the OP builder.
-    pub fn with_da_config(mut self, da_config: OpDAConfig) -> Self {
+    pub fn with_da_config(mut self, da_config: BaseDAConfig) -> Self {
         self.da_config = Some(da_config);
         self
     }
@@ -407,7 +407,7 @@ impl<NetworkT, RpcMiddleware> BaseAddOnsBuilder<NetworkT, RpcMiddleware> {
 }
 
 impl<NetworkT, RpcMiddleware> BaseAddOnsBuilder<NetworkT, RpcMiddleware> {
-    /// Builds an instance of [`OpAddOns`].
+    /// Builds an instance of [`BaseAddOns`].
     pub fn build<N, PVB, EB, EVB>(
         self,
     ) -> BaseAddOns<N, OpEthApiBuilder<NetworkT>, PVB, EB, EVB, RpcMiddleware>

--- a/crates/execution/runner/src/builder.rs
+++ b/crates/execution/runner/src/builder.rs
@@ -14,39 +14,39 @@ use reth_node_builder::{
     rpc::{RethRpcAddOns, RpcContext},
 };
 
-use crate::types::{BaseNodeTypes, OpAddOns, OpComponentsBuilder};
+use crate::types::{BaseComponentsBuilder, BaseNodeTypes, ConcreteBaseAddOns};
 
 /// Alias for the default OP components type.
-type BaseComponents = <OpComponentsBuilder as NodeComponentsBuilder<BaseNodeTypes>>::Components;
+type BaseComponents = <BaseComponentsBuilder as NodeComponentsBuilder<BaseNodeTypes>>::Components;
 
 /// Convenience alias for the OP node adapter type used by the reth builder.
 ///
 /// Because `Components` depends only on pool, network, executor, and consensus builders (not the
 /// payload service builder), this type is identical regardless of which payload service is used.
-pub type OpNodeAdapter = NodeAdapter<BaseNodeTypes, BaseComponents>;
+pub type BaseNodeAdapter = NodeAdapter<BaseNodeTypes, BaseComponents>;
 
 /// Convenience alias for the OP Eth API type exposed by the reth RPC add-ons.
-type OpEthApi = <OpAddOns as RethRpcAddOns<OpNodeAdapter>>::EthApi;
+type OpEthApi = <ConcreteBaseAddOns as RethRpcAddOns<BaseNodeAdapter>>::EthApi;
 
 /// Convenience alias for the full OP node handle produced after launch.
-type OpFullNode = FullNode<OpNodeAdapter, OpAddOns>;
+type BaseFullNode = FullNode<BaseNodeAdapter, ConcreteBaseAddOns>;
 
 /// Alias for the RPC context used by Base extensions.
-pub type BaseRpcContext<'a> = RpcContext<'a, OpNodeAdapter, OpEthApi>;
+pub type BaseRpcContext<'a> = RpcContext<'a, BaseNodeAdapter, OpEthApi>;
 
 /// Hook type for extending RPC modules.
 type RpcModuleHook = Box<dyn FnOnce(&mut BaseRpcContext<'_>) -> Result<()> + Send + 'static>;
 
 /// Hook type for extending add-ons.
-type AddOnsHook = Box<dyn FnOnce(OpAddOns) -> OpAddOns>;
+type AddOnsHook = Box<dyn FnOnce(ConcreteBaseAddOns) -> ConcreteBaseAddOns>;
 
 /// Hook type for node-started callbacks.
-type NodeStartedHook = Box<dyn FnOnce(OpFullNode) -> Result<()> + Send + 'static>;
+type NodeStartedHook = Box<dyn FnOnce(BaseFullNode) -> Result<()> + Send + 'static>;
 
 /// Type-erased `ExEx` factory.
 type BoxExExFactory = Box<
     dyn FnOnce(
-            ExExContext<OpNodeAdapter>,
+            ExExContext<BaseNodeAdapter>,
         ) -> BoxFuture<'static, eyre::Result<BoxFuture<'static, eyre::Result<()>>>>
         + Send
         + 'static,
@@ -57,7 +57,7 @@ type BoxExExFactory = Box<
 /// This is generic over the `NodeComponentsBuilder` (`CB`) so that both the default payload and
 /// the flashblocks payload service can be used interchangeably.
 pub type RethNodeBuilder<CB> =
-    WithLaunchContext<NodeBuilderWithComponents<BaseNodeTypes, CB, OpAddOns>>;
+    WithLaunchContext<NodeBuilderWithComponents<BaseNodeTypes, CB, ConcreteBaseAddOns>>;
 
 /// Pure hook accumulator for the Base node builder.
 ///
@@ -97,7 +97,8 @@ impl NodeHooks {
 
         // Install ExEx hooks
         for (id, factory) in exex_hooks {
-            builder = builder.install_exex(id, move |ctx: ExExContext<OpNodeAdapter>| factory(ctx));
+            builder =
+                builder.install_exex(id, move |ctx: ExExContext<BaseNodeAdapter>| factory(ctx));
         }
 
         for hook in add_ons_hooks {
@@ -116,7 +117,7 @@ impl NodeHooks {
 
         // Install node-started hooks
         if !node_started_hooks.is_empty() {
-            builder = builder.on_node_started(move |full_node: OpFullNode| {
+            builder = builder.on_node_started(move |full_node: BaseFullNode| {
                 for hook in node_started_hooks {
                     hook(full_node.clone())?;
                 }
@@ -139,7 +140,7 @@ impl NodeHooks {
     /// Adds an add-ons hook that will run when the add-ons are configured.
     pub fn add_add_ons_hook<F>(mut self, hook: F) -> Self
     where
-        F: FnOnce(OpAddOns) -> OpAddOns + Send + 'static,
+        F: FnOnce(ConcreteBaseAddOns) -> ConcreteBaseAddOns + Send + 'static,
     {
         self.add_ons_hooks.push(Box::new(hook));
         self
@@ -148,7 +149,7 @@ impl NodeHooks {
     /// Adds a node-started hook that will run after the node has started.
     pub fn add_node_started_hook<F>(mut self, hook: F) -> Self
     where
-        F: FnOnce(OpFullNode) -> Result<()> + Send + 'static,
+        F: FnOnce(BaseFullNode) -> Result<()> + Send + 'static,
     {
         self.node_started_hooks.push(Box::new(hook));
         self
@@ -157,7 +158,7 @@ impl NodeHooks {
     /// Installs an `ExEx` extension with the given name and closure.
     pub fn install_exex<F, R, E>(mut self, exex_id: impl Into<String>, exex: F) -> Self
     where
-        F: FnOnce(ExExContext<OpNodeAdapter>) -> R + Send + 'static,
+        F: FnOnce(ExExContext<BaseNodeAdapter>) -> R + Send + 'static,
         R: Future<Output = eyre::Result<E>> + Send,
         E: Future<Output = eyre::Result<()>> + Send + 'static,
     {

--- a/crates/execution/runner/src/lib.rs
+++ b/crates/execution/runner/src/lib.rs
@@ -8,7 +8,7 @@
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
 
 mod builder;
-pub use builder::{BaseRpcContext, NodeHooks, OpNodeAdapter, RethNodeBuilder};
+pub use builder::{BaseNodeAdapter, BaseRpcContext, NodeHooks, RethNodeBuilder};
 
 mod extension;
 pub use extension::{BaseNodeExtension, FromExtensionConfig};
@@ -20,7 +20,7 @@ mod service;
 pub use service::{DefaultPayloadServiceBuilder, PayloadServiceBuilder};
 
 mod types;
-pub use types::{BaseNodeBuilder, BaseNodeTypes, BaseProvider, OpAddOns, OpComponentsBuilder};
+pub use types::{BaseComponentsBuilder, BaseNodeBuilder, BaseNodeTypes, BaseProvider};
 
 mod node;
 pub use node::BaseNode;

--- a/crates/execution/runner/src/node.rs
+++ b/crates/execution/runner/src/node.rs
@@ -3,14 +3,14 @@
 use base_common_consensus::BasePrimitives;
 use base_engine_tree::BaseEngineValidatorBuilder;
 use base_execution_chainspec::BaseChainSpec;
-use base_execution_payload_builder::config::{GasLimitConfig, OpDAConfig};
+use base_execution_payload_builder::config::{BaseDAConfig, GasLimitConfig};
 use base_execution_rpc::eth::OpEthApiBuilder;
-use base_execution_storage::OpStorage;
+use base_execution_storage::BaseStorage;
 use base_node_core::{
-    BaseNodeTypes, OpConsensusBuilder, OpEngineApiBuilder, OpEngineTypes, OpEngineValidatorBuilder,
-    OpExecutorBuilder, OpNetworkBuilder, OpNodeComponentBuilder,
+    BaseConsensusBuilder, BaseExecutorBuilder, BaseNetworkBuilder, BaseNodeComponentBuilder,
+    BaseNodeTypes, BasePayloadValidatorBuilder, OpEngineApiBuilder, OpEngineTypes,
     args::RollupArgs,
-    node::{OpPayloadBuilder, OpPoolBuilder},
+    node::{BasePoolBuilder, OpPayloadBuilder},
 };
 use reth_node_builder::{
     Node, NodeAdapter, NodeComponentsBuilder,
@@ -34,7 +34,7 @@ pub struct BaseNode {
     /// the `miner_` api).
     ///
     /// By default no throttling is applied.
-    pub da_config: OpDAConfig,
+    pub da_config: BaseDAConfig,
     /// Gas limit configuration for the OP builder.
     /// Used to control the gas limit of the blocks produced by the OP builder. (configured by the
     /// batcher via the `miner_` api)
@@ -44,11 +44,15 @@ pub struct BaseNode {
 impl BaseNode {
     /// Creates a new instance of the Base node type.
     pub fn new(args: RollupArgs) -> Self {
-        Self { args, da_config: OpDAConfig::default(), gas_limit_config: GasLimitConfig::default() }
+        Self {
+            args,
+            da_config: BaseDAConfig::default(),
+            gas_limit_config: GasLimitConfig::default(),
+        }
     }
 
     /// Configure the data availability configuration for the OP builder.
-    pub fn with_da_config(mut self, da_config: OpDAConfig) -> Self {
+    pub fn with_da_config(mut self, da_config: BaseDAConfig) -> Self {
         self.da_config = da_config;
         self
     }
@@ -60,7 +64,7 @@ impl BaseNode {
     }
 
     /// Returns the components for the given [`RollupArgs`].
-    pub fn components<Node>(&self) -> OpNodeComponentBuilder<Node>
+    pub fn components<Node>(&self) -> BaseNodeComponentBuilder<Node>
     where
         Node: FullNodeTypes<Types: BaseNodeTypes>,
     {
@@ -68,15 +72,15 @@ impl BaseNode {
             self.args;
         ComponentsBuilder::default()
             .node_types::<Node>()
-            .pool(OpPoolBuilder::default())
-            .executor(OpExecutorBuilder::default())
+            .pool(BasePoolBuilder::default())
+            .executor(BaseExecutorBuilder::default())
             .payload(BasicPayloadServiceBuilder::new(
                 OpPayloadBuilder::new(compute_pending_block)
                     .with_da_config(self.da_config.clone())
                     .with_gas_limit_config(self.gas_limit_config.clone()),
             ))
-            .network(OpNetworkBuilder::new(disable_txpool_gossip, !discovery_v4))
-            .consensus(OpConsensusBuilder::default())
+            .network(BaseNetworkBuilder::new(disable_txpool_gossip, !discovery_v4))
+            .consensus(BaseConsensusBuilder::default())
     }
 
     /// Returns [`BaseAddOnsBuilder`] with configured arguments.
@@ -145,19 +149,19 @@ where
 {
     type ComponentsBuilder = ComponentsBuilder<
         N,
-        OpPoolBuilder,
+        BasePoolBuilder,
         BasicPayloadServiceBuilder<OpPayloadBuilder>,
-        OpNetworkBuilder,
-        OpExecutorBuilder,
-        OpConsensusBuilder,
+        BaseNetworkBuilder,
+        BaseExecutorBuilder,
+        BaseConsensusBuilder,
     >;
 
     type AddOns = BaseAddOns<
         NodeAdapter<N, <Self::ComponentsBuilder as NodeComponentsBuilder<N>>::Components>,
         OpEthApiBuilder,
-        OpEngineValidatorBuilder,
-        OpEngineApiBuilder<OpEngineValidatorBuilder>,
-        BaseEngineValidatorBuilder<OpEngineValidatorBuilder>,
+        BasePayloadValidatorBuilder,
+        OpEngineApiBuilder<BasePayloadValidatorBuilder>,
+        BaseEngineValidatorBuilder<BasePayloadValidatorBuilder>,
     >;
 
     fn components_builder(&self) -> Self::ComponentsBuilder {
@@ -172,6 +176,6 @@ where
 impl NodeTypes for BaseNode {
     type Primitives = BasePrimitives;
     type ChainSpec = BaseChainSpec;
-    type Storage = OpStorage;
+    type Storage = BaseStorage;
     type Payload = OpEngineTypes;
 }

--- a/crates/execution/runner/src/runner.rs
+++ b/crates/execution/runner/src/runner.rs
@@ -2,7 +2,7 @@
 
 use std::fmt;
 
-use base_execution_payload_builder::config::OpDAConfig;
+use base_execution_payload_builder::config::BaseDAConfig;
 use base_node_core::args::RollupArgs;
 use eyre::Result;
 use reth_node_builder::{Node, NodeHandle, NodeHandleFor};
@@ -26,7 +26,7 @@ pub struct BaseNodeRunner<SB: PayloadServiceBuilder = DefaultPayloadServiceBuild
     /// Payload service builder.
     service_builder: SB,
     /// Shared DA configuration for the node and metering extension.
-    da_config: Option<OpDAConfig>,
+    da_config: Option<BaseDAConfig>,
     /// Binary-owned callbacks to run after the node has started.
     started_callbacks: Vec<StartedCallback>,
 }
@@ -57,7 +57,7 @@ impl<SB: PayloadServiceBuilder> fmt::Debug for BaseNodeRunner<SB> {
 
 impl<SB: PayloadServiceBuilder> BaseNodeRunner<SB> {
     /// Sets the shared DA configuration.
-    pub fn with_da_config(mut self, da_config: OpDAConfig) -> Self {
+    pub fn with_da_config(mut self, da_config: BaseDAConfig) -> Self {
         self.da_config = Some(da_config);
         self
     }
@@ -107,7 +107,7 @@ impl<SB: PayloadServiceBuilder> BaseNodeRunner<SB> {
         rollup_args: RollupArgs,
         extensions: Vec<Box<dyn BaseNodeExtension>>,
         service_builder: SB,
-        da_config: Option<OpDAConfig>,
+        da_config: Option<BaseDAConfig>,
         started_callbacks: Vec<StartedCallback>,
         builder: BaseNodeBuilder,
     ) -> Result<NodeHandleFor<BaseNode>> {

--- a/crates/execution/runner/src/service.rs
+++ b/crates/execution/runner/src/service.rs
@@ -1,8 +1,8 @@
 //! Trait for customizing the payload service used by the node.
 
 use base_node_core::{
-    OpConsensusBuilder, OpExecutorBuilder, OpNetworkBuilder,
-    node::{OpPayloadBuilder, OpPoolBuilder},
+    BaseConsensusBuilder, BaseExecutorBuilder, BaseNetworkBuilder,
+    node::{BasePoolBuilder, OpPayloadBuilder},
 };
 use reth_node_builder::{
     NodeComponentsBuilder,
@@ -11,7 +11,7 @@ use reth_node_builder::{
 
 use crate::{
     node::BaseNode,
-    types::{BaseNodeTypes, OpComponentsBuilder},
+    types::{BaseComponentsBuilder, BaseNodeTypes},
 };
 
 /// Trait for customizing the payload service used by the node.
@@ -25,7 +25,7 @@ pub trait PayloadServiceBuilder: Send + 'static {
     /// The component builder type this produces.
     type ComponentsBuilder: NodeComponentsBuilder<
             BaseNodeTypes,
-            Components = <OpComponentsBuilder as NodeComponentsBuilder<BaseNodeTypes>>::Components,
+            Components = <BaseComponentsBuilder as NodeComponentsBuilder<BaseNodeTypes>>::Components,
         >;
 
     /// Build components using the given [`BaseNode`] configuration.
@@ -39,11 +39,11 @@ pub struct DefaultPayloadServiceBuilder;
 impl PayloadServiceBuilder for DefaultPayloadServiceBuilder {
     type ComponentsBuilder = ComponentsBuilder<
         BaseNodeTypes,
-        OpPoolBuilder,
+        BasePoolBuilder,
         BasicPayloadServiceBuilder<OpPayloadBuilder>,
-        OpNetworkBuilder,
-        OpExecutorBuilder,
-        OpConsensusBuilder,
+        BaseNetworkBuilder,
+        BaseExecutorBuilder,
+        BaseConsensusBuilder,
     >;
 
     fn build_components(self, base_node: &BaseNode) -> Self::ComponentsBuilder {

--- a/crates/execution/runner/src/types.rs
+++ b/crates/execution/runner/src/types.rs
@@ -12,9 +12,9 @@ use crate::node::BaseNode;
 /// Alias for the OP node type adapter used by the runner.
 pub type BaseNodeTypes = FullNodeTypesAdapter<BaseNode, DatabaseEnv, BaseProvider>;
 /// Internal alias for the OP node components builder (default payload service).
-pub type OpComponentsBuilder = <BaseNode as Node<BaseNodeTypes>>::ComponentsBuilder;
-/// Internal alias for the OP node add-ons.
-pub type OpAddOns = <BaseNode as Node<BaseNodeTypes>>::AddOns;
+pub type BaseComponentsBuilder = <BaseNode as Node<BaseNodeTypes>>::ComponentsBuilder;
+/// Internal alias for the Base node add-ons (all generics resolved).
+pub(crate) type ConcreteBaseAddOns = <BaseNode as Node<BaseNodeTypes>>::AddOns;
 
 /// A [`BlockchainProvider`] instance.
 pub type BaseProvider = BlockchainProvider<NodeTypesWithDBAdapter<BaseNode, DatabaseEnv>>;

--- a/crates/execution/storage/src/chain.rs
+++ b/crates/execution/storage/src/chain.rs
@@ -3,4 +3,4 @@ use base_common_consensus::BaseTransactionSigned;
 use reth_storage_api::EmptyBodyStorage;
 
 /// Base storage implementation.
-pub type OpStorage<T = BaseTransactionSigned, H = Header> = EmptyBodyStorage<T, H>;
+pub type BaseStorage<T = BaseTransactionSigned, H = Header> = EmptyBodyStorage<T, H>;

--- a/crates/execution/storage/src/lib.rs
+++ b/crates/execution/storage/src/lib.rs
@@ -9,7 +9,7 @@
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
 
 mod chain;
-pub use chain::OpStorage;
+pub use chain::BaseStorage;
 
 #[cfg(test)]
 mod tests {

--- a/crates/execution/trie/src/api.rs
+++ b/crates/execution/trie/src/api.rs
@@ -16,7 +16,7 @@ use reth_trie_common::{
 };
 
 use crate::{
-    OpProofsStorageResult,
+    BaseProofsStorageResult,
     db::{HashedStorageKey, StorageTrieKey},
 };
 
@@ -68,7 +68,7 @@ pub struct OperationDurations {
 /// Only leaf nodes and some branch nodes are stored. The bottom layer of branch nodes
 /// are not stored to reduce write amplification. This matches Reth's non-historical trie storage.
 #[auto_impl(Arc)]
-pub trait OpProofsStore: Send + Sync + Debug {
+pub trait BaseProofsStore: Send + Sync + Debug {
     /// Cursor for iterating over trie branches.
     type StorageTrieCursor<'tx>: TrieStorageCursor + 'tx
     where
@@ -93,36 +93,36 @@ pub trait OpProofsStore: Send + Sync + Debug {
     ///
     /// This is used to determine the block number of trie nodes with block number 0.
     /// All earliest block numbers are stored in 0 to reduce updates required to prune trie nodes.
-    fn get_earliest_block_number(&self) -> OpProofsStorageResult<Option<(u64, B256)>>;
+    fn get_earliest_block_number(&self) -> BaseProofsStorageResult<Option<(u64, B256)>>;
 
     /// Get the latest block number and hash that has been stored
-    fn get_latest_block_number(&self) -> OpProofsStorageResult<Option<(u64, B256)>>;
+    fn get_latest_block_number(&self) -> BaseProofsStorageResult<Option<(u64, B256)>>;
 
     /// Get a trie cursor for the storage backend
     fn storage_trie_cursor<'tx>(
         &self,
         hashed_address: B256,
         max_block_number: u64,
-    ) -> OpProofsStorageResult<Self::StorageTrieCursor<'tx>>;
+    ) -> BaseProofsStorageResult<Self::StorageTrieCursor<'tx>>;
 
     /// Get a trie cursor for the account backend
     fn account_trie_cursor<'tx>(
         &self,
         max_block_number: u64,
-    ) -> OpProofsStorageResult<Self::AccountTrieCursor<'tx>>;
+    ) -> BaseProofsStorageResult<Self::AccountTrieCursor<'tx>>;
 
     /// Get a storage cursor for the storage backend
     fn storage_hashed_cursor<'tx>(
         &self,
         hashed_address: B256,
         max_block_number: u64,
-    ) -> OpProofsStorageResult<Self::StorageCursor<'tx>>;
+    ) -> BaseProofsStorageResult<Self::StorageCursor<'tx>>;
 
     /// Get an account hashed cursor for the storage backend
     fn account_hashed_cursor<'tx>(
         &self,
         max_block_number: u64,
-    ) -> OpProofsStorageResult<Self::AccountHashedCursor<'tx>>;
+    ) -> BaseProofsStorageResult<Self::AccountHashedCursor<'tx>>;
 
     /// Store a batch of trie updates.
     ///
@@ -132,32 +132,35 @@ pub trait OpProofsStore: Send + Sync + Debug {
         &self,
         block_ref: BlockWithParent,
         block_state_diff: BlockStateDiff,
-    ) -> OpProofsStorageResult<WriteCounts>;
+    ) -> BaseProofsStorageResult<WriteCounts>;
 
     /// Fetch all updates for a given block number.
-    fn fetch_trie_updates(&self, block_number: u64) -> OpProofsStorageResult<BlockStateDiff>;
+    fn fetch_trie_updates(&self, block_number: u64) -> BaseProofsStorageResult<BlockStateDiff>;
 
     /// Applies [`BlockStateDiff`] to the earliest state (updating/deleting nodes) and updates the
     /// earliest block number.
     fn prune_earliest_state(
         &self,
         new_earliest_block_ref: BlockWithParent,
-    ) -> OpProofsStorageResult<WriteCounts>;
+    ) -> BaseProofsStorageResult<WriteCounts>;
 
     /// Remove account, storage and trie updates from historical storage for all blocks till
     /// the specified block (inclusive).
-    fn unwind_history(&self, to: BlockWithParent) -> OpProofsStorageResult<()>;
+    fn unwind_history(&self, to: BlockWithParent) -> BaseProofsStorageResult<()>;
 
     /// Deletes all updates > `latest_common_block` and replaces them with the new updates.
     fn replace_updates(
         &self,
         latest_common_block: BlockNumHash,
         blocks_to_add: Vec<(BlockWithParent, BlockStateDiff)>,
-    ) -> OpProofsStorageResult<()>;
+    ) -> BaseProofsStorageResult<()>;
 
     /// Set the earliest block number and hash that has been stored
-    fn set_earliest_block_number(&self, block_number: u64, hash: B256)
-    -> OpProofsStorageResult<()>;
+    fn set_earliest_block_number(
+        &self,
+        block_number: u64,
+        hash: B256,
+    ) -> BaseProofsStorageResult<()>;
 }
 
 /// Status of the initial state anchor.
@@ -192,42 +195,42 @@ pub struct InitialStateAnchor {
 
 /// Trait for storing and retrieving the initial state anchor.
 #[auto_impl(Arc)]
-pub trait OpProofsInitialStateStore: Send + Sync + Debug {
+pub trait BaseProofsInitialStateStore: Send + Sync + Debug {
     /// Read the current anchor.
-    fn initial_state_anchor(&self) -> OpProofsStorageResult<InitialStateAnchor>;
+    fn initial_state_anchor(&self) -> BaseProofsStorageResult<InitialStateAnchor>;
 
     /// Create the anchor if it doesn't exist.
     /// Returns `Err` if an anchor already exists (prevents accidental overwrite).
-    fn set_initial_state_anchor(&self, anchor: BlockNumHash) -> OpProofsStorageResult<()>;
+    fn set_initial_state_anchor(&self, anchor: BlockNumHash) -> BaseProofsStorageResult<()>;
 
     /// Store a batch of account trie branches. Used for saving existing state. For live state
-    /// capture, use [store_trie_updates](OpProofsStore::store_trie_updates).
+    /// capture, use [store_trie_updates](BaseProofsStore::store_trie_updates).
     fn store_account_branches(
         &self,
         account_nodes: Vec<(Nibbles, Option<BranchNodeCompact>)>,
-    ) -> OpProofsStorageResult<()>;
+    ) -> BaseProofsStorageResult<()>;
 
     /// Store a batch of storage trie branches. Used for saving existing state.
     fn store_storage_branches(
         &self,
         hashed_address: B256,
         storage_nodes: Vec<(Nibbles, Option<BranchNodeCompact>)>,
-    ) -> OpProofsStorageResult<()>;
+    ) -> BaseProofsStorageResult<()>;
 
     /// Store a batch of account trie leaf nodes. Used for saving existing state.
     fn store_hashed_accounts(
         &self,
         accounts: Vec<(B256, Option<Account>)>,
-    ) -> OpProofsStorageResult<()>;
+    ) -> BaseProofsStorageResult<()>;
 
     /// Store a batch of storage trie leaf nodes. Used for saving existing state.
     fn store_hashed_storages(
         &self,
         hashed_address: B256,
         storages: Vec<(B256, U256)>,
-    ) -> OpProofsStorageResult<()>;
+    ) -> BaseProofsStorageResult<()>;
 
     /// Commit the initial state - mark the anchor as completed and also set the earliest block
     /// number to anchor.
-    fn commit_initial_state(&self) -> OpProofsStorageResult<BlockNumHash>;
+    fn commit_initial_state(&self) -> BaseProofsStorageResult<BlockNumHash>;
 }

--- a/crates/execution/trie/src/cursor.rs
+++ b/crates/execution/trie/src/cursor.rs
@@ -1,5 +1,5 @@
 //! Implementation of [`HashedCursor`] and [`TrieCursor`] for
-//! [`OpProofsStorage`](crate::OpProofsStorage).
+//! [`BaseProofsStorage`](crate::BaseProofsStorage).
 
 use alloy_primitives::{B256, U256};
 use derive_more::Constructor;
@@ -13,9 +13,9 @@ use reth_trie_common::{BranchNodeCompact, Nibbles};
 
 /// Manages reading storage or account trie nodes from [`TrieCursor`].
 #[derive(Debug, Clone, Constructor)]
-pub struct OpProofsTrieCursor<C>(pub C);
+pub struct BaseProofsTrieCursor<C>(pub C);
 
-impl<C> TrieCursor for OpProofsTrieCursor<C>
+impl<C> TrieCursor for BaseProofsTrieCursor<C>
 where
     C: TrieCursor,
 {
@@ -51,7 +51,7 @@ where
     }
 }
 
-impl<C> TrieStorageCursor for OpProofsTrieCursor<C>
+impl<C> TrieStorageCursor for BaseProofsTrieCursor<C>
 where
     C: TrieStorageCursor,
 {
@@ -63,9 +63,9 @@ where
 
 /// Manages reading hashed account nodes from external storage.
 #[derive(Debug, Clone, Constructor)]
-pub struct OpProofsHashedAccountCursor<C>(pub C);
+pub struct BaseProofsHashedAccountCursor<C>(pub C);
 
-impl<C> HashedCursor for OpProofsHashedAccountCursor<C>
+impl<C> HashedCursor for BaseProofsHashedAccountCursor<C>
 where
     C: HashedCursor<Value = Account> + Send + Sync,
 {
@@ -89,9 +89,9 @@ where
 
 /// Manages reading hashed storage nodes from external storage.
 #[derive(Debug, Clone, Constructor)]
-pub struct OpProofsHashedStorageCursor<C>(pub C);
+pub struct BaseProofsHashedStorageCursor<C>(pub C);
 
-impl<C> HashedCursor for OpProofsHashedStorageCursor<C>
+impl<C> HashedCursor for BaseProofsHashedStorageCursor<C>
 where
     C: HashedCursor<Value = U256> + Send + Sync,
 {
@@ -113,7 +113,7 @@ where
     }
 }
 
-impl<C> HashedStorageCursor for OpProofsHashedStorageCursor<C>
+impl<C> HashedStorageCursor for BaseProofsHashedStorageCursor<C>
 where
     C: HashedStorageCursor<Value = U256> + Send + Sync,
 {

--- a/crates/execution/trie/src/cursor_factory.rs
+++ b/crates/execution/trie/src/cursor_factory.rs
@@ -1,4 +1,4 @@
-//! Implements [`TrieCursorFactory`] and [`HashedCursorFactory`] for [`OpProofsStore`] types.
+//! Implements [`TrieCursorFactory`] and [`HashedCursorFactory`] for [`BaseProofsStore`] types.
 
 use std::marker::PhantomData;
 
@@ -7,40 +7,40 @@ use reth_db::DatabaseError;
 use reth_trie::{hashed_cursor::HashedCursorFactory, trie_cursor::TrieCursorFactory};
 
 use crate::{
-    OpProofsHashedAccountCursor, OpProofsHashedStorageCursor, OpProofsStorage, OpProofsStore,
-    OpProofsTrieCursor,
+    BaseProofsHashedAccountCursor, BaseProofsHashedStorageCursor, BaseProofsStorage,
+    BaseProofsStore, BaseProofsTrieCursor,
 };
 
-/// Factory for creating trie cursors for [`OpProofsStore`].
+/// Factory for creating trie cursors for [`BaseProofsStore`].
 #[derive(Debug, Clone)]
-pub struct OpProofsTrieCursorFactory<'tx, S: OpProofsStore> {
-    storage: &'tx OpProofsStorage<S>,
+pub struct BaseProofsTrieCursorFactory<'tx, S: BaseProofsStore> {
+    storage: &'tx BaseProofsStorage<S>,
     block_number: u64,
     _marker: PhantomData<&'tx ()>,
 }
 
-impl<'tx, S: OpProofsStore> OpProofsTrieCursorFactory<'tx, S> {
-    /// Initializes new `OpProofsTrieCursorFactory`
-    pub const fn new(storage: &'tx OpProofsStorage<S>, block_number: u64) -> Self {
+impl<'tx, S: BaseProofsStore> BaseProofsTrieCursorFactory<'tx, S> {
+    /// Initializes new `BaseProofsTrieCursorFactory`
+    pub const fn new(storage: &'tx BaseProofsStorage<S>, block_number: u64) -> Self {
         Self { storage, block_number, _marker: PhantomData }
     }
 }
 
-impl<'tx, S> TrieCursorFactory for OpProofsTrieCursorFactory<'tx, S>
+impl<'tx, S> TrieCursorFactory for BaseProofsTrieCursorFactory<'tx, S>
 where
-    for<'a> S: OpProofsStore + 'tx,
+    for<'a> S: BaseProofsStore + 'tx,
 {
     type AccountTrieCursor<'a>
-        = OpProofsTrieCursor<S::AccountTrieCursor<'a>>
+        = BaseProofsTrieCursor<S::AccountTrieCursor<'a>>
     where
         Self: 'a;
     type StorageTrieCursor<'a>
-        = OpProofsTrieCursor<S::StorageTrieCursor<'a>>
+        = BaseProofsTrieCursor<S::StorageTrieCursor<'a>>
     where
         Self: 'a;
 
     fn account_trie_cursor(&self) -> Result<Self::AccountTrieCursor<'_>, DatabaseError> {
-        Ok(OpProofsTrieCursor::new(
+        Ok(BaseProofsTrieCursor::new(
             self.storage
                 .account_trie_cursor(self.block_number)
                 .map_err(Into::<DatabaseError>::into)?,
@@ -51,7 +51,7 @@ where
         &self,
         hashed_address: B256,
     ) -> Result<Self::StorageTrieCursor<'_>, DatabaseError> {
-        Ok(OpProofsTrieCursor::new(
+        Ok(BaseProofsTrieCursor::new(
             self.storage
                 .storage_trie_cursor(hashed_address, self.block_number)
                 .map_err(Into::<DatabaseError>::into)?,
@@ -59,43 +59,45 @@ where
     }
 }
 
-/// Factory for creating hashed account cursors for [`OpProofsStore`].
+/// Factory for creating hashed account cursors for [`BaseProofsStore`].
 #[derive(Debug, Clone)]
-pub struct OpProofsHashedAccountCursorFactory<'tx, S: OpProofsStore> {
-    storage: &'tx OpProofsStorage<S>,
+pub struct BaseProofsHashedAccountCursorFactory<'tx, S: BaseProofsStore> {
+    storage: &'tx BaseProofsStorage<S>,
     block_number: u64,
     _marker: PhantomData<&'tx ()>,
 }
 
-impl<'tx, S: OpProofsStore> OpProofsHashedAccountCursorFactory<'tx, S> {
-    /// Creates a new `OpProofsHashedAccountCursorFactory` instance.
-    pub const fn new(storage: &'tx OpProofsStorage<S>, block_number: u64) -> Self {
+impl<'tx, S: BaseProofsStore> BaseProofsHashedAccountCursorFactory<'tx, S> {
+    /// Creates a new `BaseProofsHashedAccountCursorFactory` instance.
+    pub const fn new(storage: &'tx BaseProofsStorage<S>, block_number: u64) -> Self {
         Self { storage, block_number, _marker: PhantomData }
     }
 }
 
-impl<'tx, S> HashedCursorFactory for OpProofsHashedAccountCursorFactory<'tx, S>
+impl<'tx, S> HashedCursorFactory for BaseProofsHashedAccountCursorFactory<'tx, S>
 where
-    S: OpProofsStore + 'tx,
+    S: BaseProofsStore + 'tx,
 {
     type AccountCursor<'a>
-        = OpProofsHashedAccountCursor<S::AccountHashedCursor<'a>>
+        = BaseProofsHashedAccountCursor<S::AccountHashedCursor<'a>>
     where
         Self: 'a;
     type StorageCursor<'a>
-        = OpProofsHashedStorageCursor<S::StorageCursor<'a>>
+        = BaseProofsHashedStorageCursor<S::StorageCursor<'a>>
     where
         Self: 'a;
 
     fn hashed_account_cursor(&self) -> Result<Self::AccountCursor<'_>, DatabaseError> {
-        Ok(OpProofsHashedAccountCursor::new(self.storage.account_hashed_cursor(self.block_number)?))
+        Ok(BaseProofsHashedAccountCursor::new(
+            self.storage.account_hashed_cursor(self.block_number)?,
+        ))
     }
 
     fn hashed_storage_cursor(
         &self,
         hashed_address: B256,
     ) -> Result<Self::StorageCursor<'_>, DatabaseError> {
-        Ok(OpProofsHashedStorageCursor::new(
+        Ok(BaseProofsHashedStorageCursor::new(
             self.storage.storage_hashed_cursor(hashed_address, self.block_number)?,
         ))
     }

--- a/crates/execution/trie/src/db/cursor.rs
+++ b/crates/execution/trie/src/db/cursor.rs
@@ -15,7 +15,7 @@ use reth_trie::{
 use reth_trie_common::{BranchNodeCompact, Nibbles, StoredNibbles};
 
 use crate::{
-    OpProofsStorageResult,
+    BaseProofsStorageResult,
     db::{
         AccountTrieHistory, HashedAccountHistory, HashedStorageHistory, HashedStorageKey,
         MaybeDeleted, StorageTrieHistory, StorageTrieKey, VersionedValue,
@@ -45,7 +45,7 @@ where
     }
 
     /// Check if the cursor is currently positioned at a valid row.
-    fn is_positioned(&mut self) -> OpProofsStorageResult<bool> {
+    fn is_positioned(&mut self) -> BaseProofsStorageResult<bool> {
         Ok(self.cursor.current()?.is_some())
     }
 
@@ -60,7 +60,7 @@ where
     fn latest_version_for_key(
         &mut self,
         key: T::Key,
-    ) -> OpProofsStorageResult<Option<(T::Key, T::Value)>> {
+    ) -> BaseProofsStorageResult<Option<(T::Key, T::Value)>> {
         // First dup with subkey >= max_block_number
         let seek_res = self.cursor.seek_by_key_subkey(key.clone(), self.max_block_number)?;
 
@@ -86,7 +86,7 @@ where
     }
 
     /// Returns a non-deleted latest version for exactly `key`, if any.
-    fn seek_exact(&mut self, key: T::Key) -> OpProofsStorageResult<Option<(T::Key, V)>> {
+    fn seek_exact(&mut self, key: T::Key) -> BaseProofsStorageResult<Option<(T::Key, V)>> {
         if let Some((latest_key, latest_value)) = self.latest_version_for_key(key)?
             && let MaybeDeleted(Some(v)) = latest_value.value
         {
@@ -100,7 +100,7 @@ where
     fn next_live_from(
         &mut self,
         mut first_key: T::Key,
-    ) -> OpProofsStorageResult<Option<(T::Key, V)>> {
+    ) -> BaseProofsStorageResult<Option<(T::Key, V)>> {
         loop {
             // Compute latest version ≤ max for this key
             if let Some((k, v)) = self.seek_exact(first_key.clone())? {
@@ -120,7 +120,7 @@ where
     /// Logic:
     /// - Try exact key first (above). If alive, return it.
     /// - Otherwise hop to next distinct key and repeat until we find a live version or hit EOF.
-    fn seek(&mut self, start_key: T::Key) -> OpProofsStorageResult<Option<(T::Key, V)>> {
+    fn seek(&mut self, start_key: T::Key) -> BaseProofsStorageResult<Option<(T::Key, V)>> {
         // Position MDBX at first key >= start_key
         if let Some((first_key, _)) = self.cursor.seek(start_key)? {
             return self.next_live_from(first_key);
@@ -131,7 +131,7 @@ where
     /// Advance to the next distinct key from the current MDBX position
     /// and return its non-deleted latest version, if any.
     /// Next distinct key; if not positioned, start from `T::Key::default()`.
-    fn next(&mut self) -> OpProofsStorageResult<Option<(T::Key, V)>>
+    fn next(&mut self) -> BaseProofsStorageResult<Option<(T::Key, V)>>
     where
         T::Key: Default,
     {

--- a/crates/execution/trie/src/db/mod.rs
+++ b/crates/execution/trie/src/db/mod.rs
@@ -1,7 +1,7 @@
-//! MDBX implementation of [`OpProofsStore`](crate::OpProofsStore).
+//! MDBX implementation of [`BaseProofsStore`](crate::BaseProofsStore).
 //!
 //! This module provides a complete MDBX implementation of the
-//! [`OpProofsStore`](crate::OpProofsStore) trait. It uses the [`reth_db`]
+//! [`BaseProofsStore`](crate::BaseProofsStore) trait. It uses the [`reth_db`]
 //! crate for database interactions and defines the necessary tables and models for storing trie
 //! branches, accounts, and storage leaves.
 

--- a/crates/execution/trie/src/db/models/mod.rs
+++ b/crates/execution/trie/src/db/models/mod.rs
@@ -1,7 +1,7 @@
-//! MDBX implementation of [`OpProofsStore`](crate::OpProofsStore).
+//! MDBX implementation of [`BaseProofsStore`](crate::BaseProofsStore).
 //!
 //! This module provides a complete MDBX implementation of the
-//! [`OpProofsStore`](crate::OpProofsStore) trait. It uses the [`reth_db`] crate for
+//! [`BaseProofsStore`](crate::BaseProofsStore) trait. It uses the [`reth_db`] crate for
 //! database interactions and defines the necessary tables and models for storing trie branches,
 //! accounts, and storage leaves.
 

--- a/crates/execution/trie/src/db/store.rs
+++ b/crates/execution/trie/src/db/store.rs
@@ -24,10 +24,10 @@ use tracing::error;
 
 use super::{BlockNumberHash, ProofWindow, ProofWindowKey, Tables};
 use crate::{
-    BlockStateDiff, OpProofsStorageError,
-    OpProofsStorageError::NoBlocksFound,
-    OpProofsStorageResult, OpProofsStore,
-    api::{InitialStateAnchor, InitialStateStatus, OpProofsInitialStateStore, WriteCounts},
+    BaseProofsStorageError,
+    BaseProofsStorageError::NoBlocksFound,
+    BaseProofsStorageResult, BaseProofsStore, BlockStateDiff,
+    api::{BaseProofsInitialStateStore, InitialStateAnchor, InitialStateStatus, WriteCounts},
     db::{
         MdbxAccountCursor, MdbxStorageCursor, MdbxTrieCursor,
         cursor::Dup,
@@ -39,7 +39,7 @@ use crate::{
     },
 };
 
-/// MDBX implementation of [`OpProofsStore`].
+/// MDBX implementation of [`BaseProofsStore`].
 #[derive(Debug)]
 pub struct MdbxProofsStorage {
     env: DatabaseEnv,
@@ -71,7 +71,7 @@ struct HistoryDeleteBatch {
 
 impl MdbxProofsStorage {
     /// Creates a new [`MdbxProofsStorage`] instance with the given path.
-    pub fn new(path: &Path) -> Result<Self, OpProofsStorageError> {
+    pub fn new(path: &Path) -> Result<Self, BaseProofsStorageError> {
         let env = init_db_for::<_, Tables>(path, DatabaseArguments::default())
             .map_err(|e| DatabaseError::Other(format!("Failed to open database: {e}")))?;
         Ok(Self { env })
@@ -80,7 +80,7 @@ impl MdbxProofsStorage {
     fn inner_get_latest_block_number_hash(
         &self,
         tx: &impl DbTx,
-    ) -> OpProofsStorageResult<Option<(u64, B256)>> {
+    ) -> BaseProofsStorageResult<Option<(u64, B256)>> {
         let block = self.inner_get_block_number_hash(tx, ProofWindowKey::LatestBlock)?;
         if block.is_some() {
             return Ok(block);
@@ -93,7 +93,7 @@ impl MdbxProofsStorage {
         &self,
         tx: &impl DbTx,
         key: ProofWindowKey,
-    ) -> OpProofsStorageResult<Option<(u64, B256)>> {
+    ) -> BaseProofsStorageResult<Option<(u64, B256)>> {
         let mut cursor = tx.cursor_read::<ProofWindow>()?;
         let value = cursor.seek_exact(key)?;
         Ok(value.map(|(_, val)| (val.number(), *val.hash())))
@@ -102,7 +102,7 @@ impl MdbxProofsStorage {
     fn inner_get_proof_window(
         &self,
         tx: &impl DbTx,
-    ) -> OpProofsStorageResult<Option<ProofWindowValue>> {
+    ) -> BaseProofsStorageResult<Option<ProofWindowValue>> {
         let mut cursor = tx.cursor_read::<ProofWindow>()?;
 
         let earliest = match cursor.seek_exact(ProofWindowKey::EarliestBlock)? {
@@ -122,7 +122,7 @@ impl MdbxProofsStorage {
         &self,
         block_number: u64,
         hash: B256,
-    ) -> OpProofsStorageResult<()> {
+    ) -> BaseProofsStorageResult<()> {
         let _ = self.env.update(|tx| {
             Self::inner_set_earliest_block_number(tx, block_number, hash)?;
             Ok::<(), DatabaseError>(())
@@ -135,7 +135,7 @@ impl MdbxProofsStorage {
         tx: &(impl DbTxMut + DbTx),
         block_number: u64,
         hash: B256,
-    ) -> OpProofsStorageResult<()> {
+    ) -> BaseProofsStorageResult<()> {
         let mut cursor = tx.cursor_write::<ProofWindow>()?;
         cursor.upsert(ProofWindowKey::EarliestBlock, &BlockNumberHash::new(block_number, hash))?;
         Ok(())
@@ -146,7 +146,7 @@ impl MdbxProofsStorage {
         tx: &(impl DbTxMut + DbTx),
         block_number: u64,
         hash: B256,
-    ) -> OpProofsStorageResult<()> {
+    ) -> BaseProofsStorageResult<()> {
         let mut cursor = tx.cursor_write::<ProofWindow>()?;
         cursor.upsert(ProofWindowKey::LatestBlock, &BlockNumberHash::new(block_number, hash))?;
         Ok(())
@@ -171,7 +171,7 @@ impl MdbxProofsStorage {
         block_number: T::SubKey,
         items: I,
         append_mode: bool,
-    ) -> OpProofsStorageResult<Vec<T::Key>>
+    ) -> BaseProofsStorageResult<Vec<T::Key>>
     where
         T: Table<Value = VersionedValue<V>> + DupSort<SubKey = u64>,
         T::Key: Clone,
@@ -234,7 +234,7 @@ impl MdbxProofsStorage {
         &self,
         tx: &(impl DbTxMut + DbTx),
         items: I,
-    ) -> OpProofsStorageResult<()>
+    ) -> BaseProofsStorageResult<()>
     where
         T: Table<Value = VersionedValue<V>> + DupSort<SubKey = u64>,
         T::Key: Clone,
@@ -255,7 +255,10 @@ impl MdbxProofsStorage {
 
     /// Phase 1 of pruning: Calculate survivors.
     /// Scans change sets to find the LATEST update for every key in the range.
-    fn calculate_prune_plan(&self, target_block: u64) -> OpProofsStorageResult<Option<PrunePlan>> {
+    fn calculate_prune_plan(
+        &self,
+        target_block: u64,
+    ) -> BaseProofsStorageResult<Option<PrunePlan>> {
         self.env.view(|tx| {
             let Some((earliest, _)) =
                 self.inner_get_block_number_hash(tx, ProofWindowKey::EarliestBlock)?
@@ -331,7 +334,7 @@ impl MdbxProofsStorage {
         &self,
         tx: &(impl DbTxMut + DbTx),
         cutoff_items: Vec<(T::Key, u64)>,
-    ) -> OpProofsStorageResult<u64>
+    ) -> BaseProofsStorageResult<u64>
     where
         T: Table<Value = VersionedValue<V>> + DupSort<SubKey = u64>,
         T::Key: Clone + Ord,
@@ -391,10 +394,10 @@ impl MdbxProofsStorage {
         block_number: u64,
         hashed_address: B256,
         mut next: Next,
-    ) -> OpProofsStorageResult<Vec<T::Key>>
+    ) -> BaseProofsStorageResult<Vec<T::Key>>
     where
         T: Table<Value = VersionedValue<V>> + DupSort,
-        Next: FnMut() -> OpProofsStorageResult<Option<(K, VV)>>,
+        Next: FnMut() -> BaseProofsStorageResult<Option<(K, VV)>>,
         (B256, K, Option<V>): IntoKV<T>,
         T::Key: Clone,
     {
@@ -416,7 +419,7 @@ impl MdbxProofsStorage {
         &self,
         tx: &impl DbTx,
         block_range: impl RangeBounds<u64>,
-    ) -> OpProofsStorageResult<HistoryDeleteBatch> {
+    ) -> BaseProofsStorageResult<HistoryDeleteBatch> {
         let mut history = HistoryDeleteBatch::default();
         let mut change_set_cursor = tx.cursor_read::<BlockChangeSet>()?;
         let mut walker = change_set_cursor.walk_range(block_range)?;
@@ -452,7 +455,7 @@ impl MdbxProofsStorage {
         tx: &(impl DbTxMut + DbTx),
         block_range: impl RangeBounds<u64>,
         history: HistoryDeleteBatch,
-    ) -> OpProofsStorageResult<WriteCounts> {
+    ) -> BaseProofsStorageResult<WriteCounts> {
         let mut change_set_cursor = tx.cursor_write::<BlockChangeSet>()?;
         let mut walker = change_set_cursor.walk_range(block_range)?;
 
@@ -481,7 +484,7 @@ impl MdbxProofsStorage {
         block_number: u64,
         block_state_diff: BlockStateDiff,
         append_mode: bool,
-    ) -> OpProofsStorageResult<ChangeSet> {
+    ) -> BaseProofsStorageResult<ChangeSet> {
         let BlockStateDiff { sorted_trie_updates, sorted_post_state } = block_state_diff;
 
         let storage_trie_len = sorted_trie_updates.storage_tries_ref().len();
@@ -569,7 +572,7 @@ impl MdbxProofsStorage {
         tx: &<DatabaseEnv as Database>::TXMut,
         block_ref: BlockWithParent,
         block_state_diff: BlockStateDiff,
-    ) -> OpProofsStorageResult<WriteCounts> {
+    ) -> BaseProofsStorageResult<WriteCounts> {
         let block_number = block_ref.block.number;
 
         // Check the latest stored block is the parent of the incoming block
@@ -577,7 +580,7 @@ impl MdbxProofsStorage {
             self.inner_get_latest_block_number_hash(tx)?.map_or(B256::ZERO, |(_num, hash)| hash);
 
         if latest_block_hash != block_ref.parent {
-            return Err(OpProofsStorageError::OutOfOrder {
+            return Err(BaseProofsStorageError::OutOfOrder {
                 block_number,
                 parent_block_hash: block_ref.parent,
                 latest_block_hash,
@@ -603,7 +606,7 @@ impl MdbxProofsStorage {
     }
 
     /// Return `BlockNumHash` for the initial state anchor.
-    fn get_initial_state_anchor(&self) -> OpProofsStorageResult<Option<BlockNumHash>> {
+    fn get_initial_state_anchor(&self) -> BaseProofsStorageResult<Option<BlockNumHash>> {
         self.env.view(|tx| {
             let mut cur = tx.cursor_read::<ProofWindow>()?;
             Ok(cur.seek_exact(ProofWindowKey::InitialStateAnchor)?.map(|(_k, v)| v.into()))
@@ -611,7 +614,7 @@ impl MdbxProofsStorage {
     }
 
     /// Return latest key for a table
-    fn get_latest_key<T>(&self) -> OpProofsStorageResult<Option<T::Key>>
+    fn get_latest_key<T>(&self) -> BaseProofsStorageResult<Option<T::Key>>
     where
         T: Table,
     {
@@ -622,7 +625,7 @@ impl MdbxProofsStorage {
     }
 }
 
-impl OpProofsStore for MdbxProofsStorage {
+impl BaseProofsStore for MdbxProofsStorage {
     type StorageTrieCursor<'tx>
         = MdbxTrieCursor<StorageTrieHistory, Dup<'tx, StorageTrieHistory>>
     where
@@ -640,11 +643,11 @@ impl OpProofsStore for MdbxProofsStorage {
     where
         Self: 'tx;
 
-    fn get_earliest_block_number(&self) -> OpProofsStorageResult<Option<(u64, B256)>> {
+    fn get_earliest_block_number(&self) -> BaseProofsStorageResult<Option<(u64, B256)>> {
         self.env.view(|tx| self.inner_get_block_number_hash(tx, ProofWindowKey::EarliestBlock))?
     }
 
-    fn get_latest_block_number(&self) -> OpProofsStorageResult<Option<(u64, B256)>> {
+    fn get_latest_block_number(&self) -> BaseProofsStorageResult<Option<(u64, B256)>> {
         self.env.view(|tx| self.inner_get_latest_block_number_hash(tx))?
     }
 
@@ -652,7 +655,7 @@ impl OpProofsStore for MdbxProofsStorage {
         &self,
         hashed_address: B256,
         max_block_number: u64,
-    ) -> OpProofsStorageResult<Self::StorageTrieCursor<'tx>> {
+    ) -> BaseProofsStorageResult<Self::StorageTrieCursor<'tx>> {
         let tx = self.env.tx()?;
         let cursor = tx.cursor_dup_read::<StorageTrieHistory>()?;
 
@@ -662,7 +665,7 @@ impl OpProofsStore for MdbxProofsStorage {
     fn account_trie_cursor<'tx>(
         &self,
         max_block_number: u64,
-    ) -> OpProofsStorageResult<Self::AccountTrieCursor<'tx>> {
+    ) -> BaseProofsStorageResult<Self::AccountTrieCursor<'tx>> {
         let tx = self.env.tx()?;
         let cursor = tx.cursor_dup_read::<AccountTrieHistory>()?;
 
@@ -673,7 +676,7 @@ impl OpProofsStore for MdbxProofsStorage {
         &self,
         hashed_address: B256,
         max_block_number: u64,
-    ) -> OpProofsStorageResult<Self::StorageCursor<'tx>> {
+    ) -> BaseProofsStorageResult<Self::StorageCursor<'tx>> {
         let tx = self.env.tx()?;
         let cursor = tx.cursor_dup_read::<HashedStorageHistory>()?;
 
@@ -683,7 +686,7 @@ impl OpProofsStore for MdbxProofsStorage {
     fn account_hashed_cursor<'tx>(
         &self,
         max_block_number: u64,
-    ) -> OpProofsStorageResult<Self::AccountHashedCursor<'tx>> {
+    ) -> BaseProofsStorageResult<Self::AccountHashedCursor<'tx>> {
         let tx = self.env.tx()?;
         let cursor = tx.cursor_dup_read::<HashedAccountHistory>()?;
 
@@ -694,17 +697,17 @@ impl OpProofsStore for MdbxProofsStorage {
         &self,
         block_ref: BlockWithParent,
         block_state_diff: BlockStateDiff,
-    ) -> OpProofsStorageResult<WriteCounts> {
+    ) -> BaseProofsStorageResult<WriteCounts> {
         self.env
             .update(|tx| self.store_trie_updates_append_only(tx, block_ref, block_state_diff))?
     }
 
-    fn fetch_trie_updates(&self, block_number: u64) -> OpProofsStorageResult<BlockStateDiff> {
+    fn fetch_trie_updates(&self, block_number: u64) -> BaseProofsStorageResult<BlockStateDiff> {
         self.env.view(|tx| {
             let mut change_set_cursor = tx.cursor_read::<BlockChangeSet>()?;
             let (_, change_set) = change_set_cursor
                 .seek_exact(block_number)?
-                .ok_or(OpProofsStorageError::NoChangeSetForBlock(block_number))?;
+                .ok_or(BaseProofsStorageError::NoChangeSetForBlock(block_number))?;
 
             let mut account_trie_cursor = tx.new_cursor::<AccountTrieHistory>()?;
             let mut storage_trie_cursor = tx.new_cursor::<StorageTrieHistory>()?;
@@ -717,7 +720,7 @@ impl OpProofsStore for MdbxProofsStorage {
                     match account_trie_cursor.seek_by_key_subkey(key.clone(), block_number)? {
                         Some(v) if v.block_number == block_number => v.value.0,
                         _ => {
-                            return Err(OpProofsStorageError::MissingAccountTrieHistory(
+                            return Err(BaseProofsStorageError::MissingAccountTrieHistory(
                                 key.0,
                                 block_number,
                             ));
@@ -736,7 +739,7 @@ impl OpProofsStore for MdbxProofsStorage {
                     match storage_trie_cursor.seek_by_key_subkey(key.clone(), block_number)? {
                         Some(v) if v.block_number == block_number => v.value.0,
                         _ => {
-                            return Err(OpProofsStorageError::MissingStorageTrieHistory(
+                            return Err(BaseProofsStorageError::MissingStorageTrieHistory(
                                 key.hashed_address,
                                 key.path.0,
                                 block_number,
@@ -764,7 +767,7 @@ impl OpProofsStore for MdbxProofsStorage {
                 let entry = match hashed_account_cursor.seek_by_key_subkey(key, block_number)? {
                     Some(v) if v.block_number == block_number => v.value.0,
                     _ => {
-                        return Err(OpProofsStorageError::MissingHashedAccountHistory(
+                        return Err(BaseProofsStorageError::MissingHashedAccountHistory(
                             key,
                             block_number,
                         ));
@@ -779,7 +782,7 @@ impl OpProofsStore for MdbxProofsStorage {
                     match hashed_storage_cursor.seek_by_key_subkey(key.clone(), block_number)? {
                         Some(v) if v.block_number == block_number => v.value.0,
                         _ => {
-                            return Err(OpProofsStorageError::MissingHashedStorageHistory {
+                            return Err(BaseProofsStorageError::MissingHashedStorageHistory {
                                 hashed_address: key.hashed_address,
                                 hashed_storage_key: key.hashed_storage_key,
                                 block_number,
@@ -816,7 +819,7 @@ impl OpProofsStore for MdbxProofsStorage {
     fn prune_earliest_state(
         &self,
         new_earliest_block_ref: BlockWithParent,
-    ) -> OpProofsStorageResult<WriteCounts> {
+    ) -> BaseProofsStorageResult<WriteCounts> {
         let target_block = new_earliest_block_ref.block.number;
 
         // --- PHASE 1: READ (Calculate Deletions) ---
@@ -873,7 +876,7 @@ impl OpProofsStore for MdbxProofsStorage {
     /// Unwind the historical state to `unwind_upto_block` (inclusive), deleting all history
     /// starting from provided block. Also updates the `ProofWindow::LatestBlock` to parent of
     /// `unwind_upto_block`.
-    fn unwind_history(&self, to: BlockWithParent) -> OpProofsStorageResult<()> {
+    fn unwind_history(&self, to: BlockWithParent) -> BaseProofsStorageResult<()> {
         let history_to_delete =
             self.env.view(|tx| self.collect_history_ranged(tx, to.block.number..))??;
 
@@ -888,7 +891,7 @@ impl OpProofsStore for MdbxProofsStorage {
             }
 
             if to.block.number <= proof_window.earliest.number {
-                return Err(OpProofsStorageError::UnwindBeyondEarliest {
+                return Err(BaseProofsStorageError::UnwindBeyondEarliest {
                     unwind_block_number: to.block.number,
                     earliest_block_number: proof_window.earliest.number,
                 });
@@ -914,7 +917,7 @@ impl OpProofsStore for MdbxProofsStorage {
         &self,
         latest_common_block: BlockNumHash,
         mut blocks_to_add: Vec<(BlockWithParent, BlockStateDiff)>,
-    ) -> OpProofsStorageResult<()> {
+    ) -> BaseProofsStorageResult<()> {
         // Sort the vec list by block number
         blocks_to_add.sort_unstable_by_key(|(bwp, _)| bwp.block.number);
 
@@ -946,13 +949,13 @@ impl OpProofsStore for MdbxProofsStorage {
         &self,
         block_number: u64,
         hash: B256,
-    ) -> OpProofsStorageResult<()> {
+    ) -> BaseProofsStorageResult<()> {
         self.set_earliest_block_number_hash(block_number, hash)
     }
 }
 
-impl OpProofsInitialStateStore for MdbxProofsStorage {
-    fn initial_state_anchor(&self) -> OpProofsStorageResult<InitialStateAnchor> {
+impl BaseProofsInitialStateStore for MdbxProofsStorage {
+    fn initial_state_anchor(&self) -> BaseProofsStorageResult<InitialStateAnchor> {
         // 1) NotStarted: no anchor row
         let Some(block) = self.get_initial_state_anchor()? else {
             return Ok(InitialStateAnchor::default());
@@ -976,7 +979,7 @@ impl OpProofsInitialStateStore for MdbxProofsStorage {
         })
     }
 
-    fn set_initial_state_anchor(&self, anchor: BlockNumHash) -> OpProofsStorageResult<()> {
+    fn set_initial_state_anchor(&self, anchor: BlockNumHash) -> BaseProofsStorageResult<()> {
         self.env.update(|tx| {
             let mut cur = tx.cursor_write::<ProofWindow>()?;
             cur.insert(ProofWindowKey::InitialStateAnchor, &anchor.into())?;
@@ -987,7 +990,7 @@ impl OpProofsInitialStateStore for MdbxProofsStorage {
     fn store_account_branches(
         &self,
         account_nodes: Vec<(Nibbles, Option<BranchNodeCompact>)>,
-    ) -> OpProofsStorageResult<()> {
+    ) -> BaseProofsStorageResult<()> {
         let mut account_nodes = account_nodes;
         if account_nodes.is_empty() {
             return Ok(());
@@ -1005,7 +1008,7 @@ impl OpProofsInitialStateStore for MdbxProofsStorage {
         &self,
         hashed_address: B256,
         storage_nodes: Vec<(Nibbles, Option<BranchNodeCompact>)>,
-    ) -> OpProofsStorageResult<()> {
+    ) -> BaseProofsStorageResult<()> {
         let mut storage_nodes = storage_nodes;
         if storage_nodes.is_empty() {
             return Ok(());
@@ -1027,7 +1030,7 @@ impl OpProofsInitialStateStore for MdbxProofsStorage {
     fn store_hashed_accounts(
         &self,
         accounts: Vec<(B256, Option<Account>)>,
-    ) -> OpProofsStorageResult<()> {
+    ) -> BaseProofsStorageResult<()> {
         let mut accounts = accounts;
         if accounts.is_empty() {
             return Ok(());
@@ -1046,7 +1049,7 @@ impl OpProofsInitialStateStore for MdbxProofsStorage {
         &self,
         hashed_address: B256,
         storages: Vec<(B256, U256)>,
-    ) -> OpProofsStorageResult<()> {
+    ) -> BaseProofsStorageResult<()> {
         let mut storages = storages;
         if storages.is_empty() {
             return Ok(());
@@ -1068,7 +1071,7 @@ impl OpProofsInitialStateStore for MdbxProofsStorage {
         })?
     }
 
-    fn commit_initial_state(&self) -> OpProofsStorageResult<BlockNumHash> {
+    fn commit_initial_state(&self) -> BaseProofsStorageResult<BlockNumHash> {
         let anchor = self.get_initial_state_anchor()?.ok_or(NoBlocksFound)?;
         self.set_earliest_block_number(anchor.number, anchor.hash)?;
         Ok(anchor)
@@ -1785,7 +1788,7 @@ mod tests {
         let diff = BlockStateDiff::default();
 
         let res = store.store_trie_updates(bad_block, diff);
-        assert!(matches!(res, Err(OpProofsStorageError::OutOfOrder { .. })));
+        assert!(matches!(res, Err(BaseProofsStorageError::OutOfOrder { .. })));
         // verify nothing written: proof window still unchanged
         let latest = store.get_latest_block_number().expect("get latest");
         assert_eq!(latest.unwrap().1, existing_block.block.hash);
@@ -1872,7 +1875,7 @@ mod tests {
         let store = MdbxProofsStorage::new(dir.path()).expect("env");
 
         let res = store.fetch_trie_updates(99);
-        assert!(matches!(res, Err(OpProofsStorageError::NoChangeSetForBlock(99))));
+        assert!(matches!(res, Err(BaseProofsStorageError::NoChangeSetForBlock(99))));
     }
 
     #[test]
@@ -1913,7 +1916,7 @@ mod tests {
         }
 
         let res = store.fetch_trie_updates(1);
-        assert!(matches!(res, Err(OpProofsStorageError::MissingAccountTrieHistory(..))));
+        assert!(matches!(res, Err(BaseProofsStorageError::MissingAccountTrieHistory(..))));
     }
 
     #[test]
@@ -1949,7 +1952,7 @@ mod tests {
         // fetch block 1 -> seek will find block 2 but block_number != 1 so expect
         // MissingAccountTrieHistory
         let res = store.fetch_trie_updates(1);
-        assert!(matches!(res, Err(OpProofsStorageError::MissingAccountTrieHistory(..))));
+        assert!(matches!(res, Err(BaseProofsStorageError::MissingAccountTrieHistory(..))));
     }
 
     #[test]
@@ -1977,7 +1980,7 @@ mod tests {
         }
 
         let res = store.fetch_trie_updates(1);
-        assert!(matches!(res, Err(OpProofsStorageError::MissingStorageTrieHistory(..))));
+        assert!(matches!(res, Err(BaseProofsStorageError::MissingStorageTrieHistory(..))));
     }
 
     #[test]
@@ -2017,7 +2020,7 @@ mod tests {
         // fetch block 1 -> seek will find block 2 but block_number != 1 so expect
         // MissingStorageTrieHistory
         let res = store.fetch_trie_updates(1);
-        assert!(matches!(res, Err(OpProofsStorageError::MissingStorageTrieHistory(..))));
+        assert!(matches!(res, Err(BaseProofsStorageError::MissingStorageTrieHistory(..))));
     }
 
     #[test]
@@ -2042,7 +2045,7 @@ mod tests {
         }
 
         let res = store.fetch_trie_updates(1);
-        assert!(matches!(res, Err(OpProofsStorageError::MissingHashedAccountHistory(..))));
+        assert!(matches!(res, Err(BaseProofsStorageError::MissingHashedAccountHistory(..))));
     }
 
     #[test]
@@ -2076,7 +2079,7 @@ mod tests {
         // fetch block 1 -> seek will find block 2 but block_number != 1 so expect
         // MissingHashedAccountHistory
         let res = store.fetch_trie_updates(1);
-        assert!(matches!(res, Err(OpProofsStorageError::MissingHashedAccountHistory(..))));
+        assert!(matches!(res, Err(BaseProofsStorageError::MissingHashedAccountHistory(..))));
     }
 
     #[test]
@@ -2104,7 +2107,7 @@ mod tests {
         }
 
         let res = store.fetch_trie_updates(1);
-        assert!(matches!(res, Err(OpProofsStorageError::MissingHashedStorageHistory { .. })));
+        assert!(matches!(res, Err(BaseProofsStorageError::MissingHashedStorageHistory { .. })));
     }
 
     #[test]
@@ -2141,7 +2144,7 @@ mod tests {
         // fetch block 1 -> seek will find block 2 but block_number != 1 so expect
         // MissingHashedStorageHistory
         let res = store.fetch_trie_updates(1);
-        assert!(matches!(res, Err(OpProofsStorageError::MissingHashedStorageHistory { .. })));
+        assert!(matches!(res, Err(BaseProofsStorageError::MissingHashedStorageHistory { .. })));
     }
 
     #[test]
@@ -3329,7 +3332,7 @@ mod tests {
         let res = store.unwind_history(b1);
         // should fail as we cannot unwind past earliest block
         assert!(res.is_err(), "unwind to earliest block should error");
-        assert!(matches!(res.unwrap_err(), OpProofsStorageError::UnwindBeyondEarliest { .. }));
+        assert!(matches!(res.unwrap_err(), BaseProofsStorageError::UnwindBeyondEarliest { .. }));
     }
 
     #[test]

--- a/crates/execution/trie/src/error.rs
+++ b/crates/execution/trie/src/error.rs
@@ -1,4 +1,4 @@
-//! Errors interfacing with [`OpProofsStore`](crate::OpProofsStore) type.
+//! Errors interfacing with [`BaseProofsStore`](crate::BaseProofsStore) type.
 
 use std::sync::Arc;
 
@@ -11,7 +11,7 @@ use thiserror::Error;
 
 /// Error type for storage operations
 #[derive(Debug, Clone, Error)]
-pub enum OpProofsStorageError {
+pub enum BaseProofsStorageError {
     /// No blocks found
     #[error("No blocks found")]
     NoBlocksFound,
@@ -108,28 +108,28 @@ pub enum OpProofsStorageError {
     InitializeStorageInconsistentState,
 }
 
-impl From<BlockExecutionError> for OpProofsStorageError {
+impl From<BlockExecutionError> for BaseProofsStorageError {
     fn from(error: BlockExecutionError) -> Self {
         Self::ExecutionError(Arc::new(error))
     }
 }
 
-impl From<ProviderError> for OpProofsStorageError {
+impl From<ProviderError> for BaseProofsStorageError {
     fn from(error: ProviderError) -> Self {
         Self::ProviderError(Arc::new(error))
     }
 }
 
-impl From<OpProofsStorageError> for DatabaseError {
-    fn from(error: OpProofsStorageError) -> Self {
+impl From<BaseProofsStorageError> for DatabaseError {
+    fn from(error: BaseProofsStorageError) -> Self {
         match error {
-            OpProofsStorageError::DatabaseError(err) => err,
+            BaseProofsStorageError::DatabaseError(err) => err,
             _ => Self::Custom(Arc::new(error)),
         }
     }
 }
 
-impl From<DatabaseError> for OpProofsStorageError {
+impl From<DatabaseError> for BaseProofsStorageError {
     fn from(error: DatabaseError) -> Self {
         if let DatabaseError::Custom(ref err) = error
             && let Some(err) = err.downcast_ref::<Self>()
@@ -141,7 +141,7 @@ impl From<DatabaseError> for OpProofsStorageError {
 }
 
 /// Result type for storage operations
-pub type OpProofsStorageResult<T> = Result<T, OpProofsStorageError>;
+pub type BaseProofsStorageResult<T> = Result<T, BaseProofsStorageError>;
 
 #[cfg(test)]
 mod tests {
@@ -151,23 +151,23 @@ mod tests {
 
     #[test]
     fn test_op_proofs_store_error_to_db_error() {
-        let original_error = OpProofsStorageError::NoBlocksFound;
+        let original_error = BaseProofsStorageError::NoBlocksFound;
 
         let db_error = DatabaseError::from(original_error);
         assert!(matches!(db_error, DatabaseError::Custom(_)));
 
-        let converted_error = OpProofsStorageError::from(db_error);
-        assert!(matches!(converted_error, OpProofsStorageError::NoBlocksFound))
+        let converted_error = BaseProofsStorageError::from(db_error);
+        assert!(matches!(converted_error, BaseProofsStorageError::NoBlocksFound))
     }
 
     #[test]
     fn test_db_error_to_op_proofs_store_error() {
         let original_error = DatabaseError::Decode;
 
-        let op_proofs_store_error = OpProofsStorageError::from(original_error);
+        let op_proofs_store_error = BaseProofsStorageError::from(original_error);
         assert!(matches!(
             op_proofs_store_error,
-            OpProofsStorageError::DatabaseError(DatabaseError::Decode)
+            BaseProofsStorageError::DatabaseError(DatabaseError::Decode)
         ));
 
         let converted_error = DatabaseError::from(op_proofs_store_error);
@@ -179,18 +179,18 @@ mod tests {
         let block_execution_error =
             BlockExecutionError::Validation(BlockValidationError::IncrementBalanceFailed);
 
-        let op_proofs_store_error = OpProofsStorageError::from(block_execution_error);
+        let op_proofs_store_error = BaseProofsStorageError::from(block_execution_error);
         assert!(
-            matches!(op_proofs_store_error, OpProofsStorageError::ExecutionError(err) if matches!(*err, BlockExecutionError::Validation(BlockValidationError::IncrementBalanceFailed)))
+            matches!(op_proofs_store_error, BaseProofsStorageError::ExecutionError(err) if matches!(*err, BlockExecutionError::Validation(BlockValidationError::IncrementBalanceFailed)))
         )
     }
 
     #[test]
     fn test_conversion_from_provider_error() {
         let provider_error = ProviderError::SenderRecoveryError;
-        let op_proofs_store_error = OpProofsStorageError::from(provider_error);
+        let op_proofs_store_error = BaseProofsStorageError::from(provider_error);
         assert!(
-            matches!(op_proofs_store_error, OpProofsStorageError::ProviderError(err) if matches!(*err, ProviderError::SenderRecoveryError))
+            matches!(op_proofs_store_error, BaseProofsStorageError::ProviderError(err) if matches!(*err, ProviderError::SenderRecoveryError))
         )
     }
 }

--- a/crates/execution/trie/src/in_memory.rs
+++ b/crates/execution/trie/src/in_memory.rs
@@ -1,4 +1,4 @@
-//! In-memory implementation of [`OpProofsStore`] for testing purposes
+//! In-memory implementation of [`BaseProofsStore`] for testing purposes
 
 use std::{collections::BTreeMap, sync::Arc};
 
@@ -16,12 +16,12 @@ use reth_trie_common::{
 };
 
 use crate::{
-    BlockStateDiff, OpProofsStorageError, OpProofsStorageResult, OpProofsStore,
-    api::{InitialStateAnchor, InitialStateStatus, OpProofsInitialStateStore, WriteCounts},
+    BaseProofsStorageError, BaseProofsStorageResult, BaseProofsStore, BlockStateDiff,
+    api::{BaseProofsInitialStateStore, InitialStateAnchor, InitialStateStatus, WriteCounts},
     db::{HashedStorageKey, StorageTrieKey},
 };
 
-/// In-memory implementation of [`OpProofsStore`] for testing purposes
+/// In-memory implementation of [`BaseProofsStore`] for testing purposes
 #[derive(Debug, Clone)]
 pub struct InMemoryProofsStorage {
     /// Shared state across all instances
@@ -140,7 +140,7 @@ impl InMemoryProofsStorage {
         Self { inner: Arc::new(RwLock::new(InMemoryStorageInner::default())) }
     }
 
-    fn get_latest_account_trie_key(&self) -> OpProofsStorageResult<Option<StoredNibbles>> {
+    fn get_latest_account_trie_key(&self) -> BaseProofsStorageResult<Option<StoredNibbles>> {
         let inner = self.inner.read();
         Ok(inner
             .account_branches
@@ -152,7 +152,7 @@ impl InMemoryProofsStorage {
             .map(|((_, nibbles), _)| StoredNibbles::from(*nibbles)))
     }
 
-    fn get_latest_storage_trie_key(&self) -> OpProofsStorageResult<Option<StorageTrieKey>> {
+    fn get_latest_storage_trie_key(&self) -> BaseProofsStorageResult<Option<StorageTrieKey>> {
         let inner = self.inner.read();
         Ok(inner
             .storage_branches
@@ -166,7 +166,7 @@ impl InMemoryProofsStorage {
             }))
     }
 
-    fn get_latest_hashed_account_key(&self) -> OpProofsStorageResult<Option<B256>> {
+    fn get_latest_hashed_account_key(&self) -> BaseProofsStorageResult<Option<B256>> {
         let inner = self.inner.read();
         Ok(inner
             .hashed_accounts
@@ -178,7 +178,7 @@ impl InMemoryProofsStorage {
             .map(|((_, address), _)| *address))
     }
 
-    fn get_latest_hashed_storage_key(&self) -> OpProofsStorageResult<Option<HashedStorageKey>> {
+    fn get_latest_hashed_storage_key(&self) -> BaseProofsStorageResult<Option<HashedStorageKey>> {
         let inner = self.inner.read();
         Ok(inner
             .hashed_storages
@@ -231,7 +231,7 @@ impl InMemoryTrieCursor {
             return Ok(());
         }
 
-        let storage = self.inner.try_read().ok_or(OpProofsStorageError::TryLockError)?;
+        let storage = self.inner.try_read().ok_or(BaseProofsStorageError::TryLockError)?;
 
         // Common logic: collect latest values for each path
         let mut path_to_latest: std::collections::BTreeMap<
@@ -390,7 +390,7 @@ impl InMemoryStorageCursor {
             return Ok(());
         }
 
-        let storage = self.inner.try_read().ok_or(OpProofsStorageError::TryLockError)?;
+        let storage = self.inner.try_read().ok_or(BaseProofsStorageError::TryLockError)?;
 
         // Collect latest values for each slot
         let mut slot_to_latest: std::collections::BTreeMap<B256, (u64, U256)> =
@@ -532,18 +532,18 @@ impl HashedCursor for InMemoryAccountCursor {
     }
 }
 
-impl OpProofsStore for InMemoryProofsStorage {
+impl BaseProofsStore for InMemoryProofsStorage {
     type StorageTrieCursor<'tx> = InMemoryTrieCursor;
     type AccountTrieCursor<'tx> = InMemoryTrieCursor;
     type StorageCursor<'tx> = InMemoryStorageCursor;
     type AccountHashedCursor<'tx> = InMemoryAccountCursor;
 
-    fn get_earliest_block_number(&self) -> OpProofsStorageResult<Option<(u64, B256)>> {
+    fn get_earliest_block_number(&self) -> BaseProofsStorageResult<Option<(u64, B256)>> {
         let inner = self.inner.read();
         Ok(inner.earliest_block)
     }
 
-    fn get_latest_block_number(&self) -> OpProofsStorageResult<Option<(u64, B256)>> {
+    fn get_latest_block_number(&self) -> BaseProofsStorageResult<Option<(u64, B256)>> {
         let inner = self.inner.read();
         // Find the latest block number from trie_updates
         let latest_block = inner.trie_updates.keys().max().copied();
@@ -554,14 +554,14 @@ impl OpProofsStore for InMemoryProofsStorage {
         &self,
         hashed_address: B256,
         max_block_number: u64,
-    ) -> OpProofsStorageResult<Self::StorageTrieCursor<'tx>> {
+    ) -> BaseProofsStorageResult<Self::StorageTrieCursor<'tx>> {
         Ok(InMemoryTrieCursor::new(Arc::clone(&self.inner), Some(hashed_address), max_block_number))
     }
 
     fn account_trie_cursor<'tx>(
         &self,
         max_block_number: u64,
-    ) -> OpProofsStorageResult<Self::AccountTrieCursor<'tx>> {
+    ) -> BaseProofsStorageResult<Self::AccountTrieCursor<'tx>> {
         Ok(InMemoryTrieCursor::new(Arc::clone(&self.inner), None, max_block_number))
     }
 
@@ -569,15 +569,15 @@ impl OpProofsStore for InMemoryProofsStorage {
         &self,
         hashed_address: B256,
         max_block_number: u64,
-    ) -> OpProofsStorageResult<Self::StorageCursor<'tx>> {
+    ) -> BaseProofsStorageResult<Self::StorageCursor<'tx>> {
         Ok(InMemoryStorageCursor::new(Arc::clone(&self.inner), hashed_address, max_block_number))
     }
 
     fn account_hashed_cursor<'tx>(
         &self,
         max_block_number: u64,
-    ) -> OpProofsStorageResult<Self::AccountHashedCursor<'tx>> {
-        let inner = self.inner.try_read().ok_or(OpProofsStorageError::TryLockError)?;
+    ) -> BaseProofsStorageResult<Self::AccountHashedCursor<'tx>> {
+        let inner = self.inner.try_read().ok_or(BaseProofsStorageError::TryLockError)?;
         Ok(InMemoryAccountCursor::new(&inner, max_block_number))
     }
 
@@ -585,13 +585,13 @@ impl OpProofsStore for InMemoryProofsStorage {
         &self,
         block_ref: BlockWithParent,
         block_state_diff: BlockStateDiff,
-    ) -> OpProofsStorageResult<WriteCounts> {
+    ) -> BaseProofsStorageResult<WriteCounts> {
         let mut inner = self.inner.write();
 
         Ok(inner.store_trie_updates(block_ref.block.number, block_state_diff))
     }
 
-    fn fetch_trie_updates(&self, block_number: u64) -> OpProofsStorageResult<BlockStateDiff> {
+    fn fetch_trie_updates(&self, block_number: u64) -> BaseProofsStorageResult<BlockStateDiff> {
         let inner = self.inner.read();
 
         let trie_updates = inner.trie_updates.get(&block_number).cloned().unwrap_or_default();
@@ -603,7 +603,7 @@ impl OpProofsStore for InMemoryProofsStorage {
     fn prune_earliest_state(
         &self,
         new_earliest_block_ref: BlockWithParent,
-    ) -> OpProofsStorageResult<WriteCounts> {
+    ) -> BaseProofsStorageResult<WriteCounts> {
         let mut write_counts = WriteCounts::default();
         let mut inner = self.inner.write();
         let new_earliest = new_earliest_block_ref.block.number;
@@ -687,7 +687,7 @@ impl OpProofsStore for InMemoryProofsStorage {
         Ok(write_counts)
     }
 
-    fn unwind_history(&self, unwind_upto_block: BlockWithParent) -> OpProofsStorageResult<()> {
+    fn unwind_history(&self, unwind_upto_block: BlockWithParent) -> BaseProofsStorageResult<()> {
         let mut inner = self.inner.write();
         let unwind_upto_block_number = unwind_upto_block.block.number - 1;
 
@@ -706,7 +706,7 @@ impl OpProofsStore for InMemoryProofsStorage {
         &self,
         latest_common_block: BlockNumHash,
         blocks_to_add: Vec<(BlockWithParent, BlockStateDiff)>,
-    ) -> OpProofsStorageResult<()> {
+    ) -> BaseProofsStorageResult<()> {
         let mut inner = self.inner.write();
         let latest_common_block_number = latest_common_block.number;
 
@@ -729,15 +729,15 @@ impl OpProofsStore for InMemoryProofsStorage {
         &self,
         block_number: u64,
         hash: B256,
-    ) -> OpProofsStorageResult<()> {
+    ) -> BaseProofsStorageResult<()> {
         let mut inner = self.inner.write();
         inner.earliest_block = Some((block_number, hash));
         Ok(())
     }
 }
 
-impl OpProofsInitialStateStore for InMemoryProofsStorage {
-    fn initial_state_anchor(&self) -> OpProofsStorageResult<InitialStateAnchor> {
+impl BaseProofsInitialStateStore for InMemoryProofsStorage {
+    fn initial_state_anchor(&self) -> BaseProofsStorageResult<InitialStateAnchor> {
         let inner = self.inner.read();
 
         let Some((block_num, block_hash)) = inner.anchor_block else {
@@ -760,7 +760,7 @@ impl OpProofsInitialStateStore for InMemoryProofsStorage {
         })
     }
 
-    fn set_initial_state_anchor(&self, anchor: BlockNumHash) -> OpProofsStorageResult<()> {
+    fn set_initial_state_anchor(&self, anchor: BlockNumHash) -> BaseProofsStorageResult<()> {
         let mut inner = self.inner.write();
         inner.anchor_block = Some((anchor.number, anchor.hash));
         Ok(())
@@ -769,7 +769,7 @@ impl OpProofsInitialStateStore for InMemoryProofsStorage {
     fn store_account_branches(
         &self,
         updates: Vec<(Nibbles, Option<BranchNodeCompact>)>,
-    ) -> OpProofsStorageResult<()> {
+    ) -> BaseProofsStorageResult<()> {
         let mut inner = self.inner.write();
 
         for (path, branch) in updates {
@@ -783,7 +783,7 @@ impl OpProofsInitialStateStore for InMemoryProofsStorage {
         &self,
         hashed_address: B256,
         items: Vec<(Nibbles, Option<BranchNodeCompact>)>,
-    ) -> OpProofsStorageResult<()> {
+    ) -> BaseProofsStorageResult<()> {
         let mut inner = self.inner.write();
 
         for (path, branch) in items {
@@ -796,7 +796,7 @@ impl OpProofsInitialStateStore for InMemoryProofsStorage {
     fn store_hashed_accounts(
         &self,
         accounts: Vec<(B256, Option<Account>)>,
-    ) -> OpProofsStorageResult<()> {
+    ) -> BaseProofsStorageResult<()> {
         let mut inner = self.inner.write();
 
         for (address, account) in accounts {
@@ -810,7 +810,7 @@ impl OpProofsInitialStateStore for InMemoryProofsStorage {
         &self,
         hashed_address: B256,
         storages: Vec<(B256, U256)>,
-    ) -> OpProofsStorageResult<()> {
+    ) -> BaseProofsStorageResult<()> {
         let mut inner = self.inner.write();
 
         for (slot, value) in storages {
@@ -820,13 +820,13 @@ impl OpProofsInitialStateStore for InMemoryProofsStorage {
         Ok(())
     }
 
-    fn commit_initial_state(&self) -> OpProofsStorageResult<BlockNumHash> {
+    fn commit_initial_state(&self) -> BaseProofsStorageResult<BlockNumHash> {
         let mut inner = self.inner.write();
         if let Some((number, hash)) = inner.anchor_block {
             inner.earliest_block = Some((number, hash));
             Ok(BlockNumHash::new(number, hash))
         } else {
-            Err(OpProofsStorageError::NoBlocksFound)
+            Err(BaseProofsStorageError::NoBlocksFound)
         }
     }
 }
@@ -838,10 +838,10 @@ mod tests {
     use reth_primitives_traits::Account;
 
     use super::*;
-    use crate::OpProofsStorageError;
+    use crate::BaseProofsStorageError;
 
     #[test]
-    fn test_in_memory_storage_basic_operations() -> Result<(), OpProofsStorageError> {
+    fn test_in_memory_storage_basic_operations() -> Result<(), BaseProofsStorageError> {
         let storage = InMemoryProofsStorage::new();
 
         // Test setting earliest block
@@ -863,7 +863,7 @@ mod tests {
     }
 
     #[test]
-    fn test_trie_updates_storage() -> Result<(), OpProofsStorageError> {
+    fn test_trie_updates_storage() -> Result<(), BaseProofsStorageError> {
         let storage = InMemoryProofsStorage::new();
 
         let sorted_trie_updates = TrieUpdatesSorted::default();

--- a/crates/execution/trie/src/initialize.rs
+++ b/crates/execution/trie/src/initialize.rs
@@ -19,8 +19,8 @@ use reth_trie_common::{
 use tracing::{debug, info};
 
 use crate::{
-    OpProofsStorageError, OpProofsStore,
-    api::{InitialStateAnchor, InitialStateStatus, OpProofsInitialStateStore},
+    BaseProofsStorageError, BaseProofsStore,
+    api::{BaseProofsInitialStateStore, InitialStateAnchor, InitialStateStatus},
     db::{HashedStorageKey, StorageTrieKey},
 };
 
@@ -32,7 +32,7 @@ const INITIALIZE_LOG_THRESHOLD: usize = 100000;
 
 /// Initialization job for external storage.
 #[derive(Debug, Constructor)]
-pub struct InitializationJob<Tx: DbTx, S: OpProofsStore + Send> {
+pub struct InitializationJob<Tx: DbTx, S: BaseProofsStore + Send> {
     storage: S,
     tx: Tx,
 }
@@ -133,7 +133,7 @@ impl CompletionEstimatable for StoredNibbles {
     }
 }
 
-impl<Tx: DbTx + Sync, S: OpProofsStore + OpProofsInitialStateStore + Send>
+impl<Tx: DbTx + Sync, S: BaseProofsStore + BaseProofsInitialStateStore + Send>
     InitializationJob<Tx, S>
 {
     /// Initialize a table from a source iterator to a storage function. Handles batching and
@@ -148,7 +148,7 @@ impl<Tx: DbTx + Sync, S: OpProofsStore + OpProofsInitialStateStore + Send>
         source: I,
         storage_threshold: usize,
         log_threshold: usize,
-    ) -> Result<u64, OpProofsStorageError> {
+    ) -> Result<u64, BaseProofsStorageError> {
         info!(name = %name, "Starting initialization");
         let start_time = Instant::now();
 
@@ -218,14 +218,14 @@ impl<Tx: DbTx + Sync, S: OpProofsStore + OpProofsInitialStateStore + Send>
     fn initialize_hashed_accounts(
         &self,
         start_key: Option<B256>,
-    ) -> Result<(), OpProofsStorageError> {
+    ) -> Result<(), BaseProofsStorageError> {
         let mut start_cursor = self.tx.cursor_read::<tables::HashedAccounts>()?;
 
         if let Some(latest) = start_key {
             start_cursor
                 .seek(latest)?
                 .filter(|(k, _)| *k == latest)
-                .ok_or(OpProofsStorageError::InitializeStorageInconsistentState)?;
+                .ok_or(BaseProofsStorageError::InitializeStorageInconsistentState)?;
         }
 
         let source = HashedAccountsInit::new(start_cursor);
@@ -243,14 +243,14 @@ impl<Tx: DbTx + Sync, S: OpProofsStore + OpProofsInitialStateStore + Send>
     fn initialize_hashed_storages(
         &self,
         start_key: Option<HashedStorageKey>,
-    ) -> Result<(), OpProofsStorageError> {
+    ) -> Result<(), BaseProofsStorageError> {
         let mut start_cursor = self.tx.cursor_dup_read::<tables::HashedStorages>()?;
 
         if let Some(latest) = start_key {
             start_cursor
                 .seek_by_key_subkey(latest.hashed_address, latest.hashed_storage_key)?
                 .filter(|v| v.key == latest.hashed_storage_key)
-                .ok_or(OpProofsStorageError::InitializeStorageInconsistentState)?;
+                .ok_or(BaseProofsStorageError::InitializeStorageInconsistentState)?;
         }
 
         let source = HashedStoragesInit::new(start_cursor);
@@ -268,14 +268,14 @@ impl<Tx: DbTx + Sync, S: OpProofsStore + OpProofsInitialStateStore + Send>
     fn initialize_accounts_trie(
         &self,
         start_key: Option<StoredNibbles>,
-    ) -> Result<(), OpProofsStorageError> {
+    ) -> Result<(), BaseProofsStorageError> {
         let mut start_cursor = self.tx.cursor_read::<tables::AccountsTrie>()?;
 
         if let Some(latest_key) = start_key {
             start_cursor
                 .seek(latest_key.clone())?
                 .filter(|(k, _)| *k == latest_key)
-                .ok_or(OpProofsStorageError::InitializeStorageInconsistentState)?;
+                .ok_or(BaseProofsStorageError::InitializeStorageInconsistentState)?;
         }
 
         let source = AccountsTrieInit::new(start_cursor);
@@ -293,7 +293,7 @@ impl<Tx: DbTx + Sync, S: OpProofsStore + OpProofsInitialStateStore + Send>
     fn initialize_storages_trie(
         &self,
         start_key: Option<StorageTrieKey>,
-    ) -> Result<(), OpProofsStorageError> {
+    ) -> Result<(), BaseProofsStorageError> {
         let mut start_cursor = self.tx.cursor_dup_read::<tables::StoragesTrie>()?;
 
         if let Some(latest_key) = start_key {
@@ -303,7 +303,7 @@ impl<Tx: DbTx + Sync, S: OpProofsStore + OpProofsInitialStateStore + Send>
                     StoredNibblesSubKey::from(latest_key.path.0),
                 )?
                 .filter(|v| v.nibbles.0 == latest_key.path.0)
-                .ok_or(OpProofsStorageError::InitializeStorageInconsistentState)?;
+                .ok_or(BaseProofsStorageError::InitializeStorageInconsistentState)?;
         }
 
         let source = StoragesTrieInit::new(start_cursor);
@@ -318,7 +318,7 @@ impl<Tx: DbTx + Sync, S: OpProofsStore + OpProofsInitialStateStore + Send>
     }
 
     /// Run complete initialization of all preimage data
-    fn initialize_trie(&self, anchor: InitialStateAnchor) -> Result<(), OpProofsStorageError> {
+    fn initialize_trie(&self, anchor: InitialStateAnchor) -> Result<(), BaseProofsStorageError> {
         self.initialize_hashed_accounts(anchor.latest_hashed_account_key)?;
         self.initialize_hashed_storages(anchor.latest_hashed_storage_key)?;
         self.initialize_storages_trie(anchor.latest_storage_trie_key)?;
@@ -331,18 +331,19 @@ impl<Tx: DbTx + Sync, S: OpProofsStore + OpProofsInitialStateStore + Send>
         anchor: &InitialStateAnchor,
         best_number: u64,
         best_hash: B256,
-    ) -> Result<(), OpProofsStorageError> {
-        let block = anchor.block.ok_or(OpProofsStorageError::InitializeStorageInconsistentState)?;
+    ) -> Result<(), BaseProofsStorageError> {
+        let block =
+            anchor.block.ok_or(BaseProofsStorageError::InitializeStorageInconsistentState)?;
 
         if block.number != best_number || block.hash != best_hash {
-            return Err(OpProofsStorageError::InitializeStorageInconsistentState);
+            return Err(BaseProofsStorageError::InitializeStorageInconsistentState);
         }
 
         Ok(())
     }
 
     /// Run the initialization job.
-    pub fn run(&self, best_number: u64, best_hash: B256) -> Result<(), OpProofsStorageError> {
+    pub fn run(&self, best_number: u64, best_hash: B256) -> Result<(), BaseProofsStorageError> {
         let anchor = self.storage.initial_state_anchor()?;
 
         match anchor.status {
@@ -371,9 +372,9 @@ trait InitTable {
 
     /// Writes given entries to given storage.
     fn store_entries(
-        store: &impl OpProofsInitialStateStore,
+        store: &impl BaseProofsInitialStateStore,
         entries: impl IntoIterator<Item = (Self::Key, Self::Value)>,
-    ) -> Result<(), OpProofsStorageError>;
+    ) -> Result<(), BaseProofsStorageError>;
 }
 
 impl<C> InitTable for HashedAccountsInit<C> {
@@ -382,9 +383,9 @@ impl<C> InitTable for HashedAccountsInit<C> {
 
     /// Save mapping of hashed addresses to accounts to storage.
     fn store_entries(
-        store: &impl OpProofsInitialStateStore,
+        store: &impl BaseProofsInitialStateStore,
         entries: impl IntoIterator<Item = (Self::Key, Self::Value)>,
-    ) -> Result<(), OpProofsStorageError> {
+    ) -> Result<(), BaseProofsStorageError> {
         store.store_hashed_accounts(
             entries.into_iter().map(|(address, account)| (address, Some(account))).collect(),
         )?;
@@ -398,9 +399,9 @@ impl<C> InitTable for HashedStoragesInit<C> {
 
     /// Save mapping of hashed addresses to storage entries to storage.
     fn store_entries(
-        store: &impl OpProofsInitialStateStore,
+        store: &impl BaseProofsInitialStateStore,
         entries: impl IntoIterator<Item = (Self::Key, Self::Value)>,
-    ) -> Result<(), OpProofsStorageError> {
+    ) -> Result<(), BaseProofsStorageError> {
         let entries_iter = entries.into_iter();
         let mut by_address: HashMap<B256, Vec<(B256, U256)>> =
             HashMap::with_capacity(entries_iter.size_hint().0);
@@ -424,9 +425,9 @@ impl<C> InitTable for AccountsTrieInit<C> {
 
     /// Save mapping of account trie paths to branch nodes to storage.
     fn store_entries(
-        store: &impl OpProofsInitialStateStore,
+        store: &impl BaseProofsInitialStateStore,
         entries: impl IntoIterator<Item = (Self::Key, Self::Value)>,
-    ) -> Result<(), OpProofsStorageError> {
+    ) -> Result<(), BaseProofsStorageError> {
         store.store_account_branches(
             entries.into_iter().map(|(path, branch)| (path.0, Some(branch))).collect(),
         )?;
@@ -441,9 +442,9 @@ impl<C> InitTable for StoragesTrieInit<C> {
 
     /// Save mapping of hashed addresses to storage trie entries to storage.
     fn store_entries(
-        store: &impl OpProofsInitialStateStore,
+        store: &impl BaseProofsInitialStateStore,
         entries: impl IntoIterator<Item = (Self::Key, Self::Value)>,
-    ) -> Result<(), OpProofsStorageError> {
+    ) -> Result<(), BaseProofsStorageError> {
         let entries_iter = entries.into_iter();
         let mut by_address: HashMap<B256, Vec<(Nibbles, Option<BranchNodeCompact>)>> =
             HashMap::with_capacity(entries_iter.size_hint().0);

--- a/crates/execution/trie/src/lib.rs
+++ b/crates/execution/trie/src/lib.rs
@@ -12,7 +12,7 @@
 use reth_ethereum_primitives as _;
 
 pub mod api;
-pub use api::{BlockStateDiff, OpProofsInitialStateStore, OpProofsStore};
+pub use api::{BaseProofsInitialStateStore, BaseProofsStore, BlockStateDiff};
 
 pub mod initialize;
 pub use initialize::InitializationJob;
@@ -28,13 +28,13 @@ pub use db::{MdbxAccountCursor, MdbxProofsStorage, MdbxStorageCursor, MdbxTrieCu
 pub mod metrics;
 #[cfg(feature = "metrics")]
 pub use metrics::{
-    OpProofsHashedAccountCursor, OpProofsHashedStorageCursor, OpProofsStorage, OpProofsTrieCursor,
-    StorageMetrics,
+    BaseProofsHashedAccountCursor, BaseProofsHashedStorageCursor, BaseProofsStorage,
+    BaseProofsTrieCursor, StorageMetrics,
 };
 
 #[cfg(not(feature = "metrics"))]
-/// Alias for [`OpProofsStore`] type without metrics (`metrics` feature is disabled).
-pub type OpProofsStorage<S> = S;
+/// Alias for [`BaseProofsStore`] type without metrics (`metrics` feature is disabled).
+pub type BaseProofsStorage<S> = S;
 
 pub mod proof;
 
@@ -44,16 +44,18 @@ pub mod live;
 
 pub mod cursor;
 #[cfg(not(feature = "metrics"))]
-pub use cursor::{OpProofsHashedAccountCursor, OpProofsHashedStorageCursor, OpProofsTrieCursor};
+pub use cursor::{
+    BaseProofsHashedAccountCursor, BaseProofsHashedStorageCursor, BaseProofsTrieCursor,
+};
 
 pub mod cursor_factory;
-pub use cursor_factory::{OpProofsHashedAccountCursorFactory, OpProofsTrieCursorFactory};
+pub use cursor_factory::{BaseProofsHashedAccountCursorFactory, BaseProofsTrieCursorFactory};
 
 pub mod error;
-pub use error::{OpProofsStorageError, OpProofsStorageResult};
+pub use error::{BaseProofsStorageError, BaseProofsStorageResult};
 
 mod prune;
 pub use prune::{
-    BaseProofStoragePrunerTask, OpProofStoragePruner, OpProofStoragePrunerResult, PrunerError,
+    BaseProofStoragePruner, BaseProofStoragePrunerResult, BaseProofStoragePrunerTask, PrunerError,
     PrunerOutput,
 };

--- a/crates/execution/trie/src/live.rs
+++ b/crates/execution/trie/src/live.rs
@@ -15,10 +15,10 @@ use reth_trie_common::{HashedPostStateSorted, updates::TrieUpdatesSorted};
 use tracing::{info, warn};
 
 use crate::{
-    BlockStateDiff, OpProofsStorage, OpProofsStorageError, OpProofsStore,
+    BaseProofsStorage, BaseProofsStorageError, BaseProofsStore, BlockStateDiff,
     api::{OperationDurations, WriteCounts},
     metrics::BlockMetrics,
-    provider::OpProofsStateProviderRef,
+    provider::BaseProofsStateProviderRef,
 };
 
 /// Live trie collector for external proofs storage.
@@ -30,14 +30,14 @@ where
 {
     evm_config: Evm,
     provider: Provider,
-    storage: &'tx OpProofsStorage<PreimageStore>,
+    storage: &'tx BaseProofsStorage<PreimageStore>,
 }
 
 impl<'tx, Evm, Provider, Store> LiveTrieCollector<'tx, Evm, Provider, Store>
 where
     Evm: ConfigureEvm,
     Provider: StateReader + DatabaseProviderFactory + StateProviderFactory,
-    Store: 'tx + OpProofsStore + Clone + 'static,
+    Store: 'tx + BaseProofsStore + Clone + 'static,
 {
     fn record_storage_metrics(
         operation_durations: &OperationDurations,
@@ -53,7 +53,7 @@ where
     pub fn execute_and_store_block_updates(
         &self,
         block: &RecoveredBlock<BlockTy<Evm::Primitives>>,
-    ) -> Result<(), OpProofsStorageError> {
+    ) -> Result<(), BaseProofsStorageError> {
         let mut operation_durations = OperationDurations::default();
 
         let start = Instant::now();
@@ -61,16 +61,16 @@ where
         let (Some((earliest, _)), Some((latest, _))) =
             (self.storage.get_earliest_block_number()?, self.storage.get_latest_block_number()?)
         else {
-            return Err(OpProofsStorageError::NoBlocksFound);
+            return Err(BaseProofsStorageError::NoBlocksFound);
         };
 
         let parent_block_number = block.number() - 1;
         if parent_block_number < earliest {
-            return Err(OpProofsStorageError::UnknownParent);
+            return Err(BaseProofsStorageError::UnknownParent);
         }
 
         if parent_block_number > latest {
-            return Err(OpProofsStorageError::MissingParentBlock {
+            return Err(BaseProofsStorageError::MissingParentBlock {
                 block_number: block.number(),
                 parent_block_number,
                 latest_block_number: latest,
@@ -82,7 +82,7 @@ where
 
         // TODO: should we check block hash here?
 
-        let state_provider = OpProofsStateProviderRef::new(
+        let state_provider = BaseProofsStateProviderRef::new(
             self.provider.state_by_block_hash(block.parent_hash())?,
             self.storage,
             parent_block_number,
@@ -103,7 +103,7 @@ where
             start.elapsed() - operation_durations.execution_duration_seconds;
 
         if state_root != block.state_root() {
-            return Err(OpProofsStorageError::StateRootMismatch {
+            return Err(BaseProofsStorageError::StateRootMismatch {
                 block_number: block.number(),
                 current_state_hash: state_root,
                 expected_state_hash: block.state_root(),
@@ -141,7 +141,7 @@ where
         block: BlockWithParent,
         sorted_trie_updates: TrieUpdatesSorted,
         sorted_post_state: HashedPostStateSorted,
-    ) -> Result<(), OpProofsStorageError> {
+    ) -> Result<(), BaseProofsStorageError> {
         let start = Instant::now();
         let mut operation_durations = OperationDurations::default();
 
@@ -150,7 +150,7 @@ where
             .store_trie_updates(block, BlockStateDiff { sorted_trie_updates, sorted_post_state })
         {
             Ok(res) => res,
-            Err(OpProofsStorageError::OutOfOrder {
+            Err(BaseProofsStorageError::OutOfOrder {
                 block_number,
                 latest_block_hash,
                 parent_block_hash,
@@ -195,7 +195,7 @@ where
     pub fn unwind_and_store_block_updates(
         &self,
         block_updates: Vec<(BlockWithParent, Arc<TrieUpdatesSorted>, Arc<HashedPostStateSorted>)>,
-    ) -> Result<(), OpProofsStorageError> {
+    ) -> Result<(), BaseProofsStorageError> {
         if block_updates.is_empty() {
             return Ok(());
         }
@@ -236,7 +236,7 @@ where
 
     /// Remove account, storage and trie updates from historical storage for all blocks from
     /// the specified block (inclusive).
-    pub fn unwind_history(&self, to: BlockWithParent) -> Result<(), OpProofsStorageError> {
+    pub fn unwind_history(&self, to: BlockWithParent) -> Result<(), BaseProofsStorageError> {
         self.storage.unwind_history(to)
     }
 }

--- a/crates/execution/trie/src/metrics.rs
+++ b/crates/execution/trie/src/metrics.rs
@@ -19,26 +19,26 @@ use reth_trie::{
 use reth_trie_common::{BranchNodeCompact, Nibbles};
 
 use crate::{
-    BlockStateDiff, OpProofsStorageResult, OpProofsStore,
-    api::{InitialStateAnchor, OpProofsInitialStateStore, OperationDurations, WriteCounts},
+    BaseProofsStorageResult, BaseProofsStore, BlockStateDiff,
+    api::{BaseProofsInitialStateStore, InitialStateAnchor, OperationDurations, WriteCounts},
     cursor,
 };
 
-/// Alias for [`OpProofsStorageWithMetrics`].
-pub type OpProofsStorage<S> = OpProofsStorageWithMetrics<S>;
+/// Alias for [`BaseProofsStorageWithMetrics`].
+pub type BaseProofsStorage<S> = BaseProofsStorageWithMetrics<S>;
 
-/// Alias for [`TrieCursor`](cursor::OpProofsTrieCursor) with metrics layer.
-pub type OpProofsTrieCursor<C> = cursor::OpProofsTrieCursor<OpProofsTrieCursorWithMetrics<C>>;
+/// Alias for [`TrieCursor`](cursor::BaseProofsTrieCursor) with metrics layer.
+pub type BaseProofsTrieCursor<C> = cursor::BaseProofsTrieCursor<BaseProofsTrieCursorWithMetrics<C>>;
 
-/// Alias for [`OpProofsHashedAccountCursor`](cursor::OpProofsHashedAccountCursor) with metrics
+/// Alias for [`BaseProofsHashedAccountCursor`](cursor::BaseProofsHashedAccountCursor) with metrics
 /// layer.
-pub type OpProofsHashedAccountCursor<C> =
-    cursor::OpProofsHashedAccountCursor<OpProofsHashedCursorWithMetrics<C>>;
+pub type BaseProofsHashedAccountCursor<C> =
+    cursor::BaseProofsHashedAccountCursor<BaseProofsHashedCursorWithMetrics<C>>;
 
-/// Alias for [`OpProofsHashedStorageCursor`](cursor::OpProofsHashedStorageCursor) with metrics
+/// Alias for [`BaseProofsHashedStorageCursor`](cursor::BaseProofsHashedStorageCursor) with metrics
 /// layer.
-pub type OpProofsHashedStorageCursor<C> =
-    cursor::OpProofsHashedStorageCursor<OpProofsHashedCursorWithMetrics<C>>;
+pub type BaseProofsHashedStorageCursor<C> =
+    cursor::BaseProofsHashedStorageCursor<BaseProofsHashedCursorWithMetrics<C>>;
 
 /// Types of storage operations that can be tracked.
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Hash)]
@@ -177,12 +177,12 @@ impl StorageMetrics {
 
 /// Wrapper for [`TrieCursor`] that records metrics.
 #[derive(Debug, Constructor, Clone)]
-pub struct OpProofsTrieCursorWithMetrics<C> {
+pub struct BaseProofsTrieCursorWithMetrics<C> {
     cursor: C,
     metrics: Arc<StorageMetrics>,
 }
 
-impl<C: TrieCursor> TrieCursor for OpProofsTrieCursorWithMetrics<C> {
+impl<C: TrieCursor> TrieCursor for BaseProofsTrieCursorWithMetrics<C> {
     #[inline]
     fn seek_exact(
         &mut self,
@@ -217,7 +217,7 @@ impl<C: TrieCursor> TrieCursor for OpProofsTrieCursorWithMetrics<C> {
     }
 }
 
-impl<C: TrieStorageCursor> TrieStorageCursor for OpProofsTrieCursorWithMetrics<C> {
+impl<C: TrieStorageCursor> TrieStorageCursor for BaseProofsTrieCursorWithMetrics<C> {
     #[inline]
     fn set_hashed_address(&mut self, _hashed_address: B256) {
         self.cursor.set_hashed_address(_hashed_address)
@@ -226,12 +226,12 @@ impl<C: TrieStorageCursor> TrieStorageCursor for OpProofsTrieCursorWithMetrics<C
 
 /// Wrapper for [`HashedCursor`] type that records metrics.
 #[derive(Debug, Constructor, Clone)]
-pub struct OpProofsHashedCursorWithMetrics<C> {
+pub struct BaseProofsHashedCursorWithMetrics<C> {
     cursor: C,
     metrics: Arc<StorageMetrics>,
 }
 
-impl<C: HashedCursor> HashedCursor for OpProofsHashedCursorWithMetrics<C> {
+impl<C: HashedCursor> HashedCursor for BaseProofsHashedCursorWithMetrics<C> {
     type Value = C::Value;
 
     #[inline]
@@ -250,7 +250,7 @@ impl<C: HashedCursor> HashedCursor for OpProofsHashedCursorWithMetrics<C> {
     }
 }
 
-impl<C: HashedStorageCursor> HashedStorageCursor for OpProofsHashedCursorWithMetrics<C> {
+impl<C: HashedStorageCursor> HashedStorageCursor for BaseProofsHashedCursorWithMetrics<C> {
     #[inline]
     fn is_storage_empty(&mut self) -> Result<bool, DatabaseError> {
         self.cursor.is_storage_empty()
@@ -262,14 +262,14 @@ impl<C: HashedStorageCursor> HashedStorageCursor for OpProofsHashedCursorWithMet
     }
 }
 
-/// Wrapper around [`OpProofsStore`] type that records metrics for all operations.
+/// Wrapper around [`BaseProofsStore`] type that records metrics for all operations.
 #[derive(Debug, Clone)]
-pub struct OpProofsStorageWithMetrics<S> {
+pub struct BaseProofsStorageWithMetrics<S> {
     storage: S,
     metrics: Arc<StorageMetrics>,
 }
 
-impl<S> OpProofsStorageWithMetrics<S> {
+impl<S> BaseProofsStorageWithMetrics<S> {
     /// Initializes new [`StorageMetrics`] and wraps given storage instance.
     pub fn new(storage: S) -> Self {
         Self { storage, metrics: Arc::new(StorageMetrics) }
@@ -286,34 +286,34 @@ impl<S> OpProofsStorageWithMetrics<S> {
     }
 }
 
-impl<S> OpProofsStore for OpProofsStorageWithMetrics<S>
+impl<S> BaseProofsStore for BaseProofsStorageWithMetrics<S>
 where
-    S: OpProofsStore,
+    S: BaseProofsStore,
 {
     type StorageTrieCursor<'tx>
-        = OpProofsTrieCursorWithMetrics<S::StorageTrieCursor<'tx>>
+        = BaseProofsTrieCursorWithMetrics<S::StorageTrieCursor<'tx>>
     where
         Self: 'tx;
     type AccountTrieCursor<'tx>
-        = OpProofsTrieCursorWithMetrics<S::AccountTrieCursor<'tx>>
+        = BaseProofsTrieCursorWithMetrics<S::AccountTrieCursor<'tx>>
     where
         Self: 'tx;
     type StorageCursor<'tx>
-        = OpProofsHashedCursorWithMetrics<S::StorageCursor<'tx>>
+        = BaseProofsHashedCursorWithMetrics<S::StorageCursor<'tx>>
     where
         Self: 'tx;
     type AccountHashedCursor<'tx>
-        = OpProofsHashedCursorWithMetrics<S::AccountHashedCursor<'tx>>
+        = BaseProofsHashedCursorWithMetrics<S::AccountHashedCursor<'tx>>
     where
         Self: 'tx;
 
     #[inline]
-    fn get_earliest_block_number(&self) -> OpProofsStorageResult<Option<(u64, B256)>> {
+    fn get_earliest_block_number(&self) -> BaseProofsStorageResult<Option<(u64, B256)>> {
         self.storage.get_earliest_block_number()
     }
 
     #[inline]
-    fn get_latest_block_number(&self) -> OpProofsStorageResult<Option<(u64, B256)>> {
+    fn get_latest_block_number(&self) -> BaseProofsStorageResult<Option<(u64, B256)>> {
         self.storage.get_latest_block_number()
     }
 
@@ -322,18 +322,18 @@ where
         &self,
         hashed_address: B256,
         max_block_number: u64,
-    ) -> OpProofsStorageResult<Self::StorageTrieCursor<'tx>> {
+    ) -> BaseProofsStorageResult<Self::StorageTrieCursor<'tx>> {
         let cursor = self.storage.storage_trie_cursor(hashed_address, max_block_number)?;
-        Ok(OpProofsTrieCursorWithMetrics::new(cursor, Arc::clone(&self.metrics)))
+        Ok(BaseProofsTrieCursorWithMetrics::new(cursor, Arc::clone(&self.metrics)))
     }
 
     #[inline]
     fn account_trie_cursor<'tx>(
         &self,
         max_block_number: u64,
-    ) -> OpProofsStorageResult<Self::AccountTrieCursor<'tx>> {
+    ) -> BaseProofsStorageResult<Self::AccountTrieCursor<'tx>> {
         let cursor = self.storage.account_trie_cursor(max_block_number)?;
-        Ok(OpProofsTrieCursorWithMetrics::new(cursor, Arc::clone(&self.metrics)))
+        Ok(BaseProofsTrieCursorWithMetrics::new(cursor, Arc::clone(&self.metrics)))
     }
 
     #[inline]
@@ -341,18 +341,18 @@ where
         &self,
         hashed_address: B256,
         max_block_number: u64,
-    ) -> OpProofsStorageResult<Self::StorageCursor<'tx>> {
+    ) -> BaseProofsStorageResult<Self::StorageCursor<'tx>> {
         let cursor = self.storage.storage_hashed_cursor(hashed_address, max_block_number)?;
-        Ok(OpProofsHashedCursorWithMetrics::new(cursor, Arc::clone(&self.metrics)))
+        Ok(BaseProofsHashedCursorWithMetrics::new(cursor, Arc::clone(&self.metrics)))
     }
 
     #[inline]
     fn account_hashed_cursor<'tx>(
         &self,
         max_block_number: u64,
-    ) -> OpProofsStorageResult<Self::AccountHashedCursor<'tx>> {
+    ) -> BaseProofsStorageResult<Self::AccountHashedCursor<'tx>> {
         let cursor = self.storage.account_hashed_cursor(max_block_number)?;
-        Ok(OpProofsHashedCursorWithMetrics::new(cursor, Arc::clone(&self.metrics)))
+        Ok(BaseProofsHashedCursorWithMetrics::new(cursor, Arc::clone(&self.metrics)))
     }
 
     #[inline]
@@ -360,27 +360,27 @@ where
         &self,
         block_ref: BlockWithParent,
         block_state_diff: BlockStateDiff,
-    ) -> OpProofsStorageResult<WriteCounts> {
+    ) -> BaseProofsStorageResult<WriteCounts> {
         let result = self.storage.store_trie_updates(block_ref, block_state_diff)?;
         BlockMetrics::latest_number().set(block_ref.block.number as f64);
         Ok(result)
     }
 
     #[inline]
-    fn fetch_trie_updates(&self, block_number: u64) -> OpProofsStorageResult<BlockStateDiff> {
+    fn fetch_trie_updates(&self, block_number: u64) -> BaseProofsStorageResult<BlockStateDiff> {
         self.storage.fetch_trie_updates(block_number)
     }
     #[inline]
     fn prune_earliest_state(
         &self,
         new_earliest_block_ref: BlockWithParent,
-    ) -> OpProofsStorageResult<WriteCounts> {
+    ) -> BaseProofsStorageResult<WriteCounts> {
         BlockMetrics::earliest_number().set(new_earliest_block_ref.block.number as f64);
         self.storage.prune_earliest_state(new_earliest_block_ref)
     }
 
     #[inline]
-    fn unwind_history(&self, to: BlockWithParent) -> OpProofsStorageResult<()> {
+    fn unwind_history(&self, to: BlockWithParent) -> BaseProofsStorageResult<()> {
         self.storage.unwind_history(to)
     }
 
@@ -389,7 +389,7 @@ where
         &self,
         latest_common_block: BlockNumHash,
         blocks_to_add: Vec<(BlockWithParent, BlockStateDiff)>,
-    ) -> OpProofsStorageResult<()> {
+    ) -> BaseProofsStorageResult<()> {
         self.storage.replace_updates(latest_common_block, blocks_to_add)
     }
 
@@ -398,23 +398,23 @@ where
         &self,
         block_number: u64,
         hash: B256,
-    ) -> OpProofsStorageResult<()> {
+    ) -> BaseProofsStorageResult<()> {
         BlockMetrics::earliest_number().set(block_number as f64);
         self.storage.set_earliest_block_number(block_number, hash)
     }
 }
 
-impl<S> OpProofsInitialStateStore for OpProofsStorageWithMetrics<S>
+impl<S> BaseProofsInitialStateStore for BaseProofsStorageWithMetrics<S>
 where
-    S: OpProofsInitialStateStore,
+    S: BaseProofsInitialStateStore,
 {
     #[inline]
-    fn initial_state_anchor(&self) -> OpProofsStorageResult<InitialStateAnchor> {
+    fn initial_state_anchor(&self) -> BaseProofsStorageResult<InitialStateAnchor> {
         self.storage.initial_state_anchor()
     }
 
     #[inline]
-    fn set_initial_state_anchor(&self, anchor: BlockNumHash) -> OpProofsStorageResult<()> {
+    fn set_initial_state_anchor(&self, anchor: BlockNumHash) -> BaseProofsStorageResult<()> {
         self.storage.set_initial_state_anchor(anchor)
     }
 
@@ -422,7 +422,7 @@ where
     fn store_account_branches(
         &self,
         account_nodes: Vec<(Nibbles, Option<BranchNodeCompact>)>,
-    ) -> OpProofsStorageResult<()> {
+    ) -> BaseProofsStorageResult<()> {
         let count = account_nodes.len();
         let start = Instant::now();
         let result = self.storage.store_account_branches(account_nodes);
@@ -444,7 +444,7 @@ where
         &self,
         hashed_address: B256,
         storage_nodes: Vec<(Nibbles, Option<BranchNodeCompact>)>,
-    ) -> OpProofsStorageResult<()> {
+    ) -> BaseProofsStorageResult<()> {
         let count = storage_nodes.len();
         let start = Instant::now();
         let result = self.storage.store_storage_branches(hashed_address, storage_nodes);
@@ -465,7 +465,7 @@ where
     fn store_hashed_accounts(
         &self,
         accounts: Vec<(B256, Option<Account>)>,
-    ) -> OpProofsStorageResult<()> {
+    ) -> BaseProofsStorageResult<()> {
         let count = accounts.len();
         let start = Instant::now();
         let result = self.storage.store_hashed_accounts(accounts);
@@ -487,7 +487,7 @@ where
         &self,
         hashed_address: B256,
         storages: Vec<(B256, U256)>,
-    ) -> OpProofsStorageResult<()> {
+    ) -> BaseProofsStorageResult<()> {
         let count = storages.len();
         let start = Instant::now();
         let result = self.storage.store_hashed_storages(hashed_address, storages);
@@ -505,16 +505,16 @@ where
     }
 
     #[inline]
-    fn commit_initial_state(&self) -> OpProofsStorageResult<BlockNumHash> {
+    fn commit_initial_state(&self) -> BaseProofsStorageResult<BlockNumHash> {
         let block = self.storage.commit_initial_state()?;
         BlockMetrics::earliest_number().set(block.number as f64);
         Ok(block)
     }
 }
 
-impl<S> From<S> for OpProofsStorageWithMetrics<S>
+impl<S> From<S> for BaseProofsStorageWithMetrics<S>
 where
-    S: OpProofsStore + Clone + 'static,
+    S: BaseProofsStore + Clone + 'static,
 {
     fn from(storage: S) -> Self {
         Self::new(storage)

--- a/crates/execution/trie/src/proof.rs
+++ b/crates/execution/trie/src/proof.rs
@@ -1,4 +1,4 @@
-//! Provides proof operation implementations for [`OpProofsStorage`].
+//! Provides proof operation implementations for [`BaseProofsStorage`].
 
 use alloy_primitives::{
     Address, B256, Bytes, keccak256,
@@ -19,17 +19,18 @@ use reth_trie_common::{
 };
 
 use crate::{
-    OpProofsHashedAccountCursorFactory, OpProofsStorage, OpProofsStore, OpProofsTrieCursorFactory,
+    BaseProofsHashedAccountCursorFactory, BaseProofsStorage, BaseProofsStore,
+    BaseProofsTrieCursorFactory,
 };
 
-/// Extends [`Proof`] with operations specific for working with [`OpProofsStorage`].
+/// Extends [`Proof`] with operations specific for working with [`BaseProofsStorage`].
 pub trait DatabaseProof<'tx, S> {
     /// Creates a new `DatabaseProof` instance from external storage.
-    fn from_tx(storage: &'tx OpProofsStorage<S>, block_number: u64) -> Self;
+    fn from_tx(storage: &'tx BaseProofsStorage<S>, block_number: u64) -> Self;
 
     /// Generates the state proof for target account based on [`TrieInput`].
     fn overlay_account_proof(
-        storage: &'tx OpProofsStorage<S>,
+        storage: &'tx BaseProofsStorage<S>,
         block_number: u64,
         input: TrieInput,
         address: Address,
@@ -38,7 +39,7 @@ pub trait DatabaseProof<'tx, S> {
 
     /// Generates the state [`MultiProof`] for target hashed account and storage keys.
     fn overlay_multiproof(
-        storage: &'tx OpProofsStorage<S>,
+        storage: &'tx BaseProofsStorage<S>,
         block_number: u64,
         input: TrieInput,
         targets: MultiProofTargets,
@@ -46,21 +47,21 @@ pub trait DatabaseProof<'tx, S> {
 }
 
 impl<'tx, S> DatabaseProof<'tx, S>
-    for Proof<OpProofsTrieCursorFactory<'tx, S>, OpProofsHashedAccountCursorFactory<'tx, S>>
+    for Proof<BaseProofsTrieCursorFactory<'tx, S>, BaseProofsHashedAccountCursorFactory<'tx, S>>
 where
-    S: OpProofsStore + Clone,
+    S: BaseProofsStore + Clone,
 {
-    /// Create a new [`Proof`] instance from [`OpProofsStorage`].
-    fn from_tx(storage: &'tx OpProofsStorage<S>, block_number: u64) -> Self {
+    /// Create a new [`Proof`] instance from [`BaseProofsStorage`].
+    fn from_tx(storage: &'tx BaseProofsStorage<S>, block_number: u64) -> Self {
         Self::new(
-            OpProofsTrieCursorFactory::new(storage, block_number),
-            OpProofsHashedAccountCursorFactory::new(storage, block_number),
+            BaseProofsTrieCursorFactory::new(storage, block_number),
+            BaseProofsHashedAccountCursorFactory::new(storage, block_number),
         )
     }
 
     /// Generates the state proof for target account based on [`TrieInput`].
     fn overlay_account_proof(
-        storage: &'tx OpProofsStorage<S>,
+        storage: &'tx BaseProofsStorage<S>,
         block_number: u64,
         input: TrieInput,
         address: Address,
@@ -70,11 +71,11 @@ where
         let state_sorted = input.state.into_sorted();
         Self::from_tx(storage, block_number)
             .with_trie_cursor_factory(InMemoryTrieCursorFactory::new(
-                OpProofsTrieCursorFactory::new(storage, block_number),
+                BaseProofsTrieCursorFactory::new(storage, block_number),
                 &nodes_sorted,
             ))
             .with_hashed_cursor_factory(HashedPostStateCursorFactory::new(
-                OpProofsHashedAccountCursorFactory::new(storage, block_number),
+                BaseProofsHashedAccountCursorFactory::new(storage, block_number),
                 &state_sorted,
             ))
             .with_prefix_sets_mut(input.prefix_sets)
@@ -83,7 +84,7 @@ where
 
     /// Generates the state [`MultiProof`] for target hashed account and storage keys.
     fn overlay_multiproof(
-        storage: &'tx OpProofsStorage<S>,
+        storage: &'tx BaseProofsStorage<S>,
         block_number: u64,
         input: TrieInput,
         targets: MultiProofTargets,
@@ -92,11 +93,11 @@ where
         let state_sorted = input.state.into_sorted();
         Self::from_tx(storage, block_number)
             .with_trie_cursor_factory(InMemoryTrieCursorFactory::new(
-                OpProofsTrieCursorFactory::new(storage, block_number),
+                BaseProofsTrieCursorFactory::new(storage, block_number),
                 &nodes_sorted,
             ))
             .with_hashed_cursor_factory(HashedPostStateCursorFactory::new(
-                OpProofsHashedAccountCursorFactory::new(storage, block_number),
+                BaseProofsHashedAccountCursorFactory::new(storage, block_number),
                 &state_sorted,
             ))
             .with_prefix_sets_mut(input.prefix_sets)
@@ -104,14 +105,14 @@ where
     }
 }
 
-/// Extends [`StorageProof`] with operations specific for working with [`OpProofsStorage`].
+/// Extends [`StorageProof`] with operations specific for working with [`BaseProofsStorage`].
 pub trait DatabaseStorageProof<'tx, S> {
-    /// Create a new [`StorageProof`] from [`OpProofsStorage`] and account address.
-    fn from_tx(storage: &'tx OpProofsStorage<S>, block_number: u64, address: Address) -> Self;
+    /// Create a new [`StorageProof`] from [`BaseProofsStorage`] and account address.
+    fn from_tx(storage: &'tx BaseProofsStorage<S>, block_number: u64, address: Address) -> Self;
 
     /// Generates the storage proof for target slot based on [`TrieInput`].
     fn overlay_storage_proof(
-        storage: &'tx OpProofsStorage<S>,
+        storage: &'tx BaseProofsStorage<S>,
         block_number: u64,
         address: Address,
         slot: B256,
@@ -120,7 +121,7 @@ pub trait DatabaseStorageProof<'tx, S> {
 
     /// Generates the storage multiproof for target slots based on [`TrieInput`].
     fn overlay_storage_multiproof(
-        storage: &'tx OpProofsStorage<S>,
+        storage: &'tx BaseProofsStorage<S>,
         block_number: u64,
         address: Address,
         slots: &[B256],
@@ -131,23 +132,23 @@ pub trait DatabaseStorageProof<'tx, S> {
 impl<'tx, S> DatabaseStorageProof<'tx, S>
     for proof::StorageProof<
         'static,
-        OpProofsTrieCursorFactory<'tx, S>,
-        OpProofsHashedAccountCursorFactory<'tx, S>,
+        BaseProofsTrieCursorFactory<'tx, S>,
+        BaseProofsHashedAccountCursorFactory<'tx, S>,
     >
 where
-    S: OpProofsStore + 'tx + Clone,
+    S: BaseProofsStore + 'tx + Clone,
 {
-    /// Create a new [`StorageProof`] from [`OpProofsStorage`] and account address.
-    fn from_tx(storage: &'tx OpProofsStorage<S>, block_number: u64, address: Address) -> Self {
+    /// Create a new [`StorageProof`] from [`BaseProofsStorage`] and account address.
+    fn from_tx(storage: &'tx BaseProofsStorage<S>, block_number: u64, address: Address) -> Self {
         Self::new(
-            OpProofsTrieCursorFactory::new(storage, block_number),
-            OpProofsHashedAccountCursorFactory::new(storage, block_number),
+            BaseProofsTrieCursorFactory::new(storage, block_number),
+            BaseProofsHashedAccountCursorFactory::new(storage, block_number),
             address,
         )
     }
 
     fn overlay_storage_proof(
-        storage: &'tx OpProofsStorage<S>,
+        storage: &'tx BaseProofsStorage<S>,
         block_number: u64,
         address: Address,
         slot: B256,
@@ -161,7 +162,7 @@ where
         );
         Self::from_tx(storage, block_number, address)
             .with_hashed_cursor_factory(HashedPostStateCursorFactory::new(
-                OpProofsHashedAccountCursorFactory::new(storage, block_number),
+                BaseProofsHashedAccountCursorFactory::new(storage, block_number),
                 &state_sorted,
             ))
             .with_prefix_set_mut(prefix_set)
@@ -169,7 +170,7 @@ where
     }
 
     fn overlay_storage_multiproof(
-        storage: &'tx OpProofsStorage<S>,
+        storage: &'tx BaseProofsStorage<S>,
         block_number: u64,
         address: Address,
         slots: &[B256],
@@ -184,7 +185,7 @@ where
         );
         Self::from_tx(storage, block_number, address)
             .with_hashed_cursor_factory(HashedPostStateCursorFactory::new(
-                OpProofsHashedAccountCursorFactory::new(storage, block_number),
+                BaseProofsHashedAccountCursorFactory::new(storage, block_number),
                 &state_sorted,
             ))
             .with_prefix_set_mut(prefix_set)
@@ -192,8 +193,8 @@ where
     }
 }
 
-/// Extends [`StateRoot`] with operations specific for working with [`OpProofsStorage`].
-pub trait DatabaseStateRoot<'tx, S: OpProofsStore + 'tx + Clone>: Sized {
+/// Extends [`StateRoot`] with operations specific for working with [`BaseProofsStorage`].
+pub trait DatabaseStateRoot<'tx, S: BaseProofsStore + 'tx + Clone>: Sized {
     /// Calculate the state root for this [`HashedPostState`].
     /// Internally, this method retrieves prefixsets and uses them
     /// to calculate incremental state root.
@@ -202,7 +203,7 @@ pub trait DatabaseStateRoot<'tx, S: OpProofsStore + 'tx + Clone>: Sized {
     ///
     /// The state root for this [`HashedPostState`].
     fn overlay_root(
-        storage: &'tx OpProofsStorage<S>,
+        storage: &'tx BaseProofsStorage<S>,
         block_number: u64,
         post_state: HashedPostState,
     ) -> Result<B256, StateRootError>;
@@ -210,14 +211,14 @@ pub trait DatabaseStateRoot<'tx, S: OpProofsStore + 'tx + Clone>: Sized {
     /// Calculates the state root for this [`HashedPostState`] and returns it alongside trie
     /// updates. See [`Self::overlay_root`] for more info.
     fn overlay_root_with_updates(
-        storage: &'tx OpProofsStorage<S>,
+        storage: &'tx BaseProofsStorage<S>,
         block_number: u64,
         post_state: HashedPostState,
     ) -> Result<(B256, TrieUpdates), StateRootError>;
 
     /// Calculates the state root for provided [`HashedPostState`] using cached intermediate nodes.
     fn overlay_root_from_nodes(
-        storage: &'tx OpProofsStorage<S>,
+        storage: &'tx BaseProofsStorage<S>,
         block_number: u64,
         input: TrieInput,
     ) -> Result<B256, StateRootError>;
@@ -225,28 +226,28 @@ pub trait DatabaseStateRoot<'tx, S: OpProofsStore + 'tx + Clone>: Sized {
     /// Calculates the state root and trie updates for provided [`HashedPostState`] using
     /// cached intermediate nodes.
     fn overlay_root_from_nodes_with_updates(
-        storage: &'tx OpProofsStorage<S>,
+        storage: &'tx BaseProofsStorage<S>,
         block_number: u64,
         input: TrieInput,
     ) -> Result<(B256, TrieUpdates), StateRootError>;
 }
 
 impl<'tx, S> DatabaseStateRoot<'tx, S>
-    for StateRoot<OpProofsTrieCursorFactory<'tx, S>, OpProofsHashedAccountCursorFactory<'tx, S>>
+    for StateRoot<BaseProofsTrieCursorFactory<'tx, S>, BaseProofsHashedAccountCursorFactory<'tx, S>>
 where
-    S: OpProofsStore + 'tx + Clone,
+    S: BaseProofsStore + 'tx + Clone,
 {
     fn overlay_root(
-        storage: &'tx OpProofsStorage<S>,
+        storage: &'tx BaseProofsStorage<S>,
         block_number: u64,
         post_state: HashedPostState,
     ) -> Result<B256, StateRootError> {
         let prefix_sets = post_state.construct_prefix_sets().freeze();
         let state_sorted = post_state.into_sorted();
         StateRoot::new(
-            OpProofsTrieCursorFactory::new(storage, block_number),
+            BaseProofsTrieCursorFactory::new(storage, block_number),
             HashedPostStateCursorFactory::new(
-                OpProofsHashedAccountCursorFactory::new(storage, block_number),
+                BaseProofsHashedAccountCursorFactory::new(storage, block_number),
                 &state_sorted,
             ),
         )
@@ -255,16 +256,16 @@ where
     }
 
     fn overlay_root_with_updates(
-        storage: &'tx OpProofsStorage<S>,
+        storage: &'tx BaseProofsStorage<S>,
         block_number: u64,
         post_state: HashedPostState,
     ) -> Result<(B256, TrieUpdates), StateRootError> {
         let prefix_sets = post_state.construct_prefix_sets().freeze();
         let state_sorted = post_state.into_sorted();
         StateRoot::new(
-            OpProofsTrieCursorFactory::new(storage, block_number),
+            BaseProofsTrieCursorFactory::new(storage, block_number),
             HashedPostStateCursorFactory::new(
-                OpProofsHashedAccountCursorFactory::new(storage, block_number),
+                BaseProofsHashedAccountCursorFactory::new(storage, block_number),
                 &state_sorted,
             ),
         )
@@ -273,7 +274,7 @@ where
     }
 
     fn overlay_root_from_nodes(
-        storage: &'tx OpProofsStorage<S>,
+        storage: &'tx BaseProofsStorage<S>,
         block_number: u64,
         input: TrieInput,
     ) -> Result<B256, StateRootError> {
@@ -281,11 +282,11 @@ where
         let nodes_sorted = input.nodes.into_sorted();
         StateRoot::new(
             InMemoryTrieCursorFactory::new(
-                OpProofsTrieCursorFactory::new(storage, block_number),
+                BaseProofsTrieCursorFactory::new(storage, block_number),
                 &nodes_sorted,
             ),
             HashedPostStateCursorFactory::new(
-                OpProofsHashedAccountCursorFactory::new(storage, block_number),
+                BaseProofsHashedAccountCursorFactory::new(storage, block_number),
                 &state_sorted,
             ),
         )
@@ -294,7 +295,7 @@ where
     }
 
     fn overlay_root_from_nodes_with_updates(
-        storage: &'tx OpProofsStorage<S>,
+        storage: &'tx BaseProofsStorage<S>,
         block_number: u64,
         input: TrieInput,
     ) -> Result<(B256, TrieUpdates), StateRootError> {
@@ -302,11 +303,11 @@ where
         let nodes_sorted = input.nodes.into_sorted();
         StateRoot::new(
             InMemoryTrieCursorFactory::new(
-                OpProofsTrieCursorFactory::new(storage, block_number),
+                BaseProofsTrieCursorFactory::new(storage, block_number),
                 &nodes_sorted,
             ),
             HashedPostStateCursorFactory::new(
-                OpProofsHashedAccountCursorFactory::new(storage, block_number),
+                BaseProofsHashedAccountCursorFactory::new(storage, block_number),
                 &state_sorted,
             ),
         )
@@ -315,11 +316,11 @@ where
     }
 }
 
-/// Extends [`StorageRoot`] with operations specific for working with [`OpProofsStorage`].
-pub trait DatabaseStorageRoot<'tx, S: OpProofsStore + 'tx + Clone> {
+/// Extends [`StorageRoot`] with operations specific for working with [`BaseProofsStorage`].
+pub trait DatabaseStorageRoot<'tx, S: BaseProofsStore + 'tx + Clone> {
     /// Calculates the storage root for provided [`HashedStorage`].
     fn overlay_root(
-        storage: &'tx OpProofsStorage<S>,
+        storage: &'tx BaseProofsStorage<S>,
         block_number: u64,
         address: Address,
         hashed_storage: HashedStorage,
@@ -327,12 +328,15 @@ pub trait DatabaseStorageRoot<'tx, S: OpProofsStore + 'tx + Clone> {
 }
 
 impl<'tx, S> DatabaseStorageRoot<'tx, S>
-    for StorageRoot<OpProofsTrieCursorFactory<'tx, S>, OpProofsHashedAccountCursorFactory<'tx, S>>
+    for StorageRoot<
+        BaseProofsTrieCursorFactory<'tx, S>,
+        BaseProofsHashedAccountCursorFactory<'tx, S>,
+    >
 where
-    S: OpProofsStore + 'tx + Clone,
+    S: BaseProofsStore + 'tx + Clone,
 {
     fn overlay_root(
-        storage: &'tx OpProofsStorage<S>,
+        storage: &'tx BaseProofsStorage<S>,
         block_number: u64,
         address: Address,
         hashed_storage: HashedStorage,
@@ -341,9 +345,9 @@ where
         let state_sorted =
             HashedPostState::from_hashed_storage(keccak256(address), hashed_storage).into_sorted();
         StorageRoot::new(
-            OpProofsTrieCursorFactory::new(storage, block_number),
+            BaseProofsTrieCursorFactory::new(storage, block_number),
             HashedPostStateCursorFactory::new(
-                OpProofsHashedAccountCursorFactory::new(storage, block_number),
+                BaseProofsHashedAccountCursorFactory::new(storage, block_number),
                 &state_sorted,
             ),
             address,
@@ -354,14 +358,14 @@ where
     }
 }
 
-/// Extends [`TrieWitness`] with operations specific for working with [`OpProofsStorage`].
-pub trait DatabaseTrieWitness<'tx, S: OpProofsStore + 'tx + Clone> {
-    /// Creates a new [`TrieWitness`] instance from [`OpProofsStorage`].
-    fn from_tx(storage: &'tx OpProofsStorage<S>, block_number: u64) -> Self;
+/// Extends [`TrieWitness`] with operations specific for working with [`BaseProofsStorage`].
+pub trait DatabaseTrieWitness<'tx, S: BaseProofsStore + 'tx + Clone> {
+    /// Creates a new [`TrieWitness`] instance from [`BaseProofsStorage`].
+    fn from_tx(storage: &'tx BaseProofsStorage<S>, block_number: u64) -> Self;
 
     /// Generates the trie witness for the target state based on [`TrieInput`].
     fn overlay_witness(
-        storage: &'tx OpProofsStorage<S>,
+        storage: &'tx BaseProofsStorage<S>,
         block_number: u64,
         input: TrieInput,
         target: HashedPostState,
@@ -369,19 +373,22 @@ pub trait DatabaseTrieWitness<'tx, S: OpProofsStore + 'tx + Clone> {
 }
 
 impl<'tx, S> DatabaseTrieWitness<'tx, S>
-    for TrieWitness<OpProofsTrieCursorFactory<'tx, S>, OpProofsHashedAccountCursorFactory<'tx, S>>
+    for TrieWitness<
+        BaseProofsTrieCursorFactory<'tx, S>,
+        BaseProofsHashedAccountCursorFactory<'tx, S>,
+    >
 where
-    S: OpProofsStore + 'tx + Clone,
+    S: BaseProofsStore + 'tx + Clone,
 {
-    fn from_tx(storage: &'tx OpProofsStorage<S>, block_number: u64) -> Self {
+    fn from_tx(storage: &'tx BaseProofsStorage<S>, block_number: u64) -> Self {
         Self::new(
-            OpProofsTrieCursorFactory::new(storage, block_number),
-            OpProofsHashedAccountCursorFactory::new(storage, block_number),
+            BaseProofsTrieCursorFactory::new(storage, block_number),
+            BaseProofsHashedAccountCursorFactory::new(storage, block_number),
         )
     }
 
     fn overlay_witness(
-        storage: &'tx OpProofsStorage<S>,
+        storage: &'tx BaseProofsStorage<S>,
         block_number: u64,
         input: TrieInput,
         target: HashedPostState,
@@ -390,11 +397,11 @@ where
         let state_sorted = input.state.into_sorted();
         Self::from_tx(storage, block_number)
             .with_trie_cursor_factory(InMemoryTrieCursorFactory::new(
-                OpProofsTrieCursorFactory::new(storage, block_number),
+                BaseProofsTrieCursorFactory::new(storage, block_number),
                 &nodes_sorted,
             ))
             .with_hashed_cursor_factory(HashedPostStateCursorFactory::new(
-                OpProofsHashedAccountCursorFactory::new(storage, block_number),
+                BaseProofsHashedAccountCursorFactory::new(storage, block_number),
                 &state_sorted,
             ))
             .with_prefix_sets_mut(input.prefix_sets)

--- a/crates/execution/trie/src/provider.rs
+++ b/crates/execution/trie/src/provider.rs
@@ -25,7 +25,7 @@ use reth_trie_common::{
 };
 
 use crate::{
-    OpProofsStorage, OpProofsStorageError, OpProofsStore,
+    BaseProofsStorage, BaseProofsStorageError, BaseProofsStore,
     proof::{
         DatabaseProof, DatabaseStateRoot, DatabaseStorageProof, DatabaseStorageRoot,
         DatabaseTrieWitness,
@@ -34,36 +34,36 @@ use crate::{
 
 /// State provider for external proofs storage.
 #[derive(Constructor)]
-pub struct OpProofsStateProviderRef<'a, Storage: OpProofsStore> {
+pub struct BaseProofsStateProviderRef<'a, Storage: BaseProofsStore> {
     /// Historical state provider for non-state related tasks.
     latest: Box<dyn StateProvider + Send + 'a>,
 
     /// Storage provider for state lookups.
-    storage: &'a OpProofsStorage<Storage>,
+    storage: &'a BaseProofsStorage<Storage>,
 
     /// Max block number that can be used for state lookups.
     block_number: BlockNumber,
 }
 
-impl<'a, Storage> Debug for OpProofsStateProviderRef<'a, Storage>
+impl<'a, Storage> Debug for BaseProofsStateProviderRef<'a, Storage>
 where
-    Storage: OpProofsStore + 'a + Debug,
+    Storage: BaseProofsStore + 'a + Debug,
 {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("OpProofsStateProviderRef")
+        f.debug_struct("BaseProofsStateProviderRef")
             .field("storage", &self.storage)
             .field("block_number", &self.block_number)
             .finish()
     }
 }
 
-impl From<OpProofsStorageError> for ProviderError {
-    fn from(error: OpProofsStorageError) -> Self {
+impl From<BaseProofsStorageError> for ProviderError {
+    fn from(error: BaseProofsStorageError) -> Self {
         Self::other(error)
     }
 }
 
-impl<'a, Storage: OpProofsStore> BlockHashReader for OpProofsStateProviderRef<'a, Storage> {
+impl<'a, Storage: BaseProofsStore> BlockHashReader for BaseProofsStateProviderRef<'a, Storage> {
     fn block_hash(&self, number: BlockNumber) -> ProviderResult<Option<B256>> {
         self.latest.block_hash(number)
     }
@@ -77,8 +77,8 @@ impl<'a, Storage: OpProofsStore> BlockHashReader for OpProofsStateProviderRef<'a
     }
 }
 
-impl<'a, Storage: OpProofsStore + Clone> StateRootProvider
-    for OpProofsStateProviderRef<'a, Storage>
+impl<'a, Storage: BaseProofsStore + Clone> StateRootProvider
+    for BaseProofsStateProviderRef<'a, Storage>
 {
     fn state_root(&self, state: HashedPostState) -> ProviderResult<B256> {
         Ok(StateRoot::overlay_root(self.storage, self.block_number, state)?)
@@ -103,8 +103,8 @@ impl<'a, Storage: OpProofsStore + Clone> StateRootProvider
     }
 }
 
-impl<'a, Storage: OpProofsStore + Clone> StorageRootProvider
-    for OpProofsStateProviderRef<'a, Storage>
+impl<'a, Storage: BaseProofsStore + Clone> StorageRootProvider
+    for BaseProofsStateProviderRef<'a, Storage>
 {
     fn storage_root(&self, address: Address, storage: HashedStorage) -> ProviderResult<B256> {
         StorageRoot::overlay_root(self.storage, self.block_number, address, storage)
@@ -144,8 +144,8 @@ impl<'a, Storage: OpProofsStore + Clone> StorageRootProvider
     }
 }
 
-impl<'a, Storage: OpProofsStore + Clone> StateProofProvider
-    for OpProofsStateProviderRef<'a, Storage>
+impl<'a, Storage: BaseProofsStore + Clone> StateProofProvider
+    for BaseProofsStateProviderRef<'a, Storage>
 {
     fn proof(
         &self,
@@ -173,13 +173,15 @@ impl<'a, Storage: OpProofsStore + Clone> StateProofProvider
     }
 }
 
-impl<'a, Storage: OpProofsStore> HashedPostStateProvider for OpProofsStateProviderRef<'a, Storage> {
+impl<'a, Storage: BaseProofsStore> HashedPostStateProvider
+    for BaseProofsStateProviderRef<'a, Storage>
+{
     fn hashed_post_state(&self, bundle_state: &BundleState) -> HashedPostState {
         HashedPostState::from_bundle_state::<KeccakKeyHasher>(bundle_state.state())
     }
 }
 
-impl<'a, Storage: OpProofsStore> AccountReader for OpProofsStateProviderRef<'a, Storage> {
+impl<'a, Storage: BaseProofsStore> AccountReader for BaseProofsStateProviderRef<'a, Storage> {
     fn basic_account(&self, address: &Address) -> ProviderResult<Option<Account>> {
         let hashed_key = keccak256(address.0);
         Ok(self
@@ -192,9 +194,9 @@ impl<'a, Storage: OpProofsStore> AccountReader for OpProofsStateProviderRef<'a, 
     }
 }
 
-impl<'a, Storage> StateProvider for OpProofsStateProviderRef<'a, Storage>
+impl<'a, Storage> StateProvider for BaseProofsStateProviderRef<'a, Storage>
 where
-    Storage: OpProofsStore + Clone,
+    Storage: BaseProofsStore + Clone,
 {
     fn storage(&self, address: Address, storage_key: B256) -> ProviderResult<Option<StorageValue>> {
         let hashed_key = keccak256(storage_key);
@@ -216,7 +218,7 @@ where
     }
 }
 
-impl<'a, Storage: OpProofsStore> BytecodeReader for OpProofsStateProviderRef<'a, Storage> {
+impl<'a, Storage: BaseProofsStore> BytecodeReader for BaseProofsStateProviderRef<'a, Storage> {
     fn bytecode_by_hash(&self, code_hash: &B256) -> ProviderResult<Option<Bytecode>> {
         self.latest.bytecode_by_hash(code_hash)
     }
@@ -232,15 +234,15 @@ mod tests {
     #[test]
     fn test_op_proofs_state_provider_ref_debug() {
         let latest: Box<dyn StateProvider + Send> = Box::new(NoopProvider::default());
-        let storage: crate::OpProofsStorage<InMemoryProofsStorage> =
+        let storage: crate::BaseProofsStorage<InMemoryProofsStorage> =
             InMemoryProofsStorage::new().into();
         let block_number = 42u64;
 
-        let provider = OpProofsStateProviderRef::new(latest, &storage, block_number);
+        let provider = BaseProofsStateProviderRef::new(latest, &storage, block_number);
 
         assert_eq!(
             format!("{:?}", provider),
-            "OpProofsStateProviderRef { storage: InMemoryProofsStorage { inner: RwLock { data: InMemoryStorageInner { account_branches: {}, storage_branches: {}, hashed_accounts: {}, hashed_storages: {}, trie_updates: {}, post_states: {}, earliest_block: None, anchor_block: None } } }, block_number: 42 }"
+            "BaseProofsStateProviderRef { storage: InMemoryProofsStorage { inner: RwLock { data: InMemoryStorageInner { account_branches: {}, storage_branches: {}, hashed_accounts: {}, hashed_storages: {}, trie_updates: {}, post_states: {}, earliest_block: None, anchor_block: None } } }, block_number: 42 }"
         );
     }
 }

--- a/crates/execution/trie/src/prune/error.rs
+++ b/crates/execution/trie/src/prune/error.rs
@@ -8,10 +8,10 @@ use reth_provider::ProviderError;
 use strum::Display;
 use thiserror::Error;
 
-use crate::{OpProofsStorageError, api::WriteCounts};
+use crate::{BaseProofsStorageError, api::WriteCounts};
 
-/// Result of [`OpProofStoragePruner::run`](crate::OpProofStoragePruner::run) execution.
-pub type OpProofStoragePrunerResult = Result<PrunerOutput, PrunerError>;
+/// Result of [`BaseProofStoragePruner::run`](crate::BaseProofStoragePruner::run) execution.
+pub type BaseProofStoragePrunerResult = Result<PrunerOutput, PrunerError>;
 
 /// Successful prune summary.
 #[derive(Debug, Clone, Default, Eq, PartialEq)]
@@ -64,8 +64,8 @@ impl PrunerOutput {
 /// Error returned by the pruner.
 #[derive(Debug, Error, Display)]
 pub enum PrunerError {
-    /// Wrapped error from the underlying `OpProofStorage` layer.
-    Storage(#[from] OpProofsStorageError),
+    /// Wrapped error from the underlying `BaseProofStorage` layer.
+    Storage(#[from] BaseProofsStorageError),
 
     /// Wrapped error from the reth db provider.
     Provider(#[from] ProviderError),

--- a/crates/execution/trie/src/prune/mod.rs
+++ b/crates/execution/trie/src/prune/mod.rs
@@ -1,10 +1,10 @@
 //! Proof storage pruner for removing stale trie data.
 
 mod error;
-pub use error::{OpProofStoragePrunerResult, PrunerError, PrunerOutput};
+pub use error::{BaseProofStoragePrunerResult, PrunerError, PrunerOutput};
 
 mod pruner;
-pub use pruner::OpProofStoragePruner;
+pub use pruner::BaseProofStoragePruner;
 
 mod metrics;
 

--- a/crates/execution/trie/src/prune/pruner.rs
+++ b/crates/execution/trie/src/prune/pruner.rs
@@ -6,18 +6,18 @@ use tokio::time::Instant;
 use tracing::{error, info, trace};
 
 use crate::{
-    OpProofsStorage, OpProofsStore,
+    BaseProofsStorage, BaseProofsStore,
     prune::{
-        error::{OpProofStoragePrunerResult, PrunerError, PrunerOutput},
+        error::{BaseProofStoragePrunerResult, PrunerError, PrunerOutput},
         metrics::Metrics,
     },
 };
 
 /// Prunes the proof storage by calling `prune_earliest_state` on the storage provider.
 #[derive(Debug)]
-pub struct OpProofStoragePruner<P, H> {
+pub struct BaseProofStoragePruner<P, H> {
     /// Database provider for the prune
-    provider: OpProofsStorage<P>,
+    provider: BaseProofsStorage<P>,
     /// Reader to fetch block hash by block number
     block_hash_reader: H,
     /// Keep at least these many recent blocks
@@ -26,10 +26,10 @@ pub struct OpProofStoragePruner<P, H> {
     prune_batch_size: u64,
 }
 
-impl<P, H> OpProofStoragePruner<P, H> {
+impl<P, H> BaseProofStoragePruner<P, H> {
     /// Create a new pruner.
     pub const fn new(
-        provider: OpProofsStorage<P>,
+        provider: BaseProofsStorage<P>,
         block_hash_reader: H,
         min_block_interval: u64,
         prune_batch_size: u64,
@@ -38,12 +38,12 @@ impl<P, H> OpProofStoragePruner<P, H> {
     }
 }
 
-impl<P, H> OpProofStoragePruner<P, H>
+impl<P, H> BaseProofStoragePruner<P, H>
 where
-    P: OpProofsStore,
+    P: BaseProofsStore,
     H: BlockHashReader,
 {
-    fn run_inner(&self) -> OpProofStoragePrunerResult {
+    fn run_inner(&self) -> BaseProofStoragePrunerResult {
         let latest_block_opt = self.provider.get_latest_block_number()?;
         if latest_block_opt.is_none() {
             trace!(target: "trie::pruner", "No latest blocks in the proof storage");
@@ -218,8 +218,8 @@ mod tests {
     async fn run_inner_and_and_verify_updated_state() {
         // --- env/store ---
         let dir = TempDir::new().unwrap();
-        let store: OpProofsStorage<Arc<MdbxProofsStorage>> =
-            OpProofsStorage::from(Arc::new(MdbxProofsStorage::new(dir.path()).expect("env")));
+        let store: BaseProofsStorage<Arc<MdbxProofsStorage>> =
+            BaseProofsStorage::from(Arc::new(MdbxProofsStorage::new(dir.path()).expect("env")));
 
         store.set_earliest_block_number(0, B256::ZERO).expect("set earliest");
 
@@ -417,7 +417,7 @@ mod tests {
             .withf(move |block_num| *block_num == 3)
             .returning(move |_| Ok(Some(b256(3))));
 
-        let pruner = OpProofStoragePruner::new(store.clone(), block_hash_reader, 1, 1000);
+        let pruner = BaseProofStoragePruner::new(store.clone(), block_hash_reader, 1, 1000);
         let out = pruner.run_inner().expect("pruner ok");
         assert_eq!(out.start_block, 0);
         assert_eq!(out.end_block, 4, "pruned up to 4 (inclusive); new earliest is 4");
@@ -506,8 +506,8 @@ mod tests {
     #[tokio::test]
     async fn run_inner_where_latest_block_is_none() {
         let dir = TempDir::new().unwrap();
-        let store: OpProofsStorage<Arc<MdbxProofsStorage>> =
-            OpProofsStorage::from(Arc::new(MdbxProofsStorage::new(dir.path()).expect("env")));
+        let store: BaseProofsStorage<Arc<MdbxProofsStorage>> =
+            BaseProofsStorage::from(Arc::new(MdbxProofsStorage::new(dir.path()).expect("env")));
 
         let earliest = store.get_earliest_block_number().unwrap();
         let latest = store.get_latest_block_number().unwrap();
@@ -515,7 +515,7 @@ mod tests {
         assert!(latest.is_none());
 
         let block_hash_reader = MockBlockHashReader::new();
-        let pruner = OpProofStoragePruner::new(store, block_hash_reader, 10, 1000);
+        let pruner = BaseProofStoragePruner::new(store, block_hash_reader, 10, 1000);
         let out = pruner.run_inner().expect("ok");
         assert_eq!(out, PrunerOutput::default(), "should early-return default output");
     }
@@ -524,8 +524,8 @@ mod tests {
     #[tokio::test]
     async fn run_inner_earliest_none_real_db() {
         let dir = TempDir::new().unwrap();
-        let store: OpProofsStorage<Arc<MdbxProofsStorage>> =
-            OpProofsStorage::from(Arc::new(MdbxProofsStorage::new(dir.path()).expect("env")));
+        let store: BaseProofsStorage<Arc<MdbxProofsStorage>> =
+            BaseProofsStorage::from(Arc::new(MdbxProofsStorage::new(dir.path()).expect("env")));
 
         // Write a single block to set *latest* only.
         store
@@ -538,7 +538,7 @@ mod tests {
         assert_eq!(latest.unwrap().0, 3);
 
         let block_hash_reader = MockBlockHashReader::new();
-        let pruner = OpProofStoragePruner::new(store, block_hash_reader, 1, 1000);
+        let pruner = BaseProofStoragePruner::new(store, block_hash_reader, 1, 1000);
         let out = pruner.run_inner().expect("ok");
         assert_eq!(out, PrunerOutput::default(), "should early-return default output");
     }
@@ -547,8 +547,8 @@ mod tests {
     #[tokio::test]
     async fn run_inner_interval_too_small_real_db() {
         let dir = TempDir::new().unwrap();
-        let store: OpProofsStorage<Arc<MdbxProofsStorage>> =
-            OpProofsStorage::from(Arc::new(MdbxProofsStorage::new(dir.path()).expect("env")));
+        let store: BaseProofsStorage<Arc<MdbxProofsStorage>> =
+            BaseProofsStorage::from(Arc::new(MdbxProofsStorage::new(dir.path()).expect("env")));
 
         // Set earliest=4 explicitly
         let earliest_num = 4u64;
@@ -567,7 +567,7 @@ mod tests {
 
         // Require min_block_interval=2 (or greater) so interval < min
         let block_hash_reader = MockBlockHashReader::new();
-        let pruner = OpProofStoragePruner::new(store, block_hash_reader, 2, 1000);
+        let pruner = BaseProofStoragePruner::new(store, block_hash_reader, 2, 1000);
         let out = pruner.run_inner().expect("ok");
         assert_eq!(out, PrunerOutput::default(), "no pruning should occur");
     }

--- a/crates/execution/trie/src/prune/task.rs
+++ b/crates/execution/trie/src/prune/task.rs
@@ -6,32 +6,36 @@ use tokio::{
 };
 use tracing::info;
 
-use crate::{OpProofsStorage, OpProofsStore, prune::OpProofStoragePruner};
+use crate::{BaseProofsStorage, BaseProofsStore, prune::BaseProofStoragePruner};
 
 const PRUNE_BATCH_SIZE: u64 = 200;
 
 /// Periodic pruner task: constructs the pruner and runs it every interval.
 #[derive(Debug)]
 pub struct BaseProofStoragePrunerTask<P, H> {
-    pruner: OpProofStoragePruner<P, H>,
+    pruner: BaseProofStoragePruner<P, H>,
     min_block_interval: u64,
     task_run_interval: Duration,
 }
 
 impl<P, H> BaseProofStoragePrunerTask<P, H>
 where
-    P: OpProofsStore,
+    P: BaseProofsStore,
     H: BlockHashReader,
 {
     /// Initialize a new [`BaseProofStoragePrunerTask`]
     pub const fn new(
-        provider: OpProofsStorage<P>,
+        provider: BaseProofsStorage<P>,
         hash_reader: H,
         min_block_interval: u64,
         task_run_interval: Duration,
     ) -> Self {
-        let pruner =
-            OpProofStoragePruner::new(provider, hash_reader, min_block_interval, PRUNE_BATCH_SIZE);
+        let pruner = BaseProofStoragePruner::new(
+            provider,
+            hash_reader,
+            min_block_interval,
+            PRUNE_BATCH_SIZE,
+        );
         Self { pruner, min_block_interval, task_run_interval }
     }
 

--- a/crates/execution/trie/tests/lib.rs
+++ b/crates/execution/trie/tests/lib.rs
@@ -1,12 +1,12 @@
-//! Common test suite for [`OpProofsStore`] implementations.
+//! Common test suite for [`BaseProofsStore`] implementations.
 
 use std::sync::Arc;
 
 use alloy_eips::{BlockNumHash, NumHash, eip1898::BlockWithParent};
 use alloy_primitives::{B256, U256};
 use base_execution_trie::{
-    BlockStateDiff, InMemoryProofsStorage, OpProofsInitialStateStore, OpProofsStorageError,
-    OpProofsStore, db::MdbxProofsStorage,
+    BaseProofsInitialStateStore, BaseProofsStorageError, BaseProofsStore, BlockStateDiff,
+    InMemoryProofsStorage, db::MdbxProofsStorage,
 };
 use reth_primitives_traits::Account;
 use reth_trie::{
@@ -81,9 +81,9 @@ fn create_mdbx_proofs_storage() -> MdbxProofsStorage {
 #[test_case(InMemoryProofsStorage::new(); "InMemory")]
 #[test_case(create_mdbx_proofs_storage(); "Mdbx")]
 #[serial]
-fn test_earliest_block_operations<S: OpProofsStore + OpProofsInitialStateStore>(
+fn test_earliest_block_operations<S: BaseProofsStore + BaseProofsInitialStateStore>(
     storage: S,
-) -> Result<(), OpProofsStorageError> {
+) -> Result<(), BaseProofsStorageError> {
     // Initially should be None
     let earliest = storage.get_earliest_block_number()?;
     assert!(earliest.is_none());
@@ -103,9 +103,9 @@ fn test_earliest_block_operations<S: OpProofsStore + OpProofsInitialStateStore>(
 #[test_case(InMemoryProofsStorage::new(); "InMemory")]
 #[test_case(create_mdbx_proofs_storage(); "Mdbx")]
 #[serial]
-fn test_trie_updates_operations<S: OpProofsStore + OpProofsInitialStateStore>(
+fn test_trie_updates_operations<S: BaseProofsStore + BaseProofsInitialStateStore>(
     storage: S,
-) -> Result<(), OpProofsStorageError> {
+) -> Result<(), BaseProofsStorageError> {
     let block_ref = BlockWithParent::new(B256::ZERO, NumHash::new(50, B256::repeat_byte(0x96)));
     let sorted_trie_updates = TrieUpdatesSorted::default();
     let sorted_post_state = HashedPostStateSorted::default();
@@ -133,9 +133,9 @@ fn test_trie_updates_operations<S: OpProofsStore + OpProofsInitialStateStore>(
 #[test_case(InMemoryProofsStorage::new(); "InMemory")]
 #[test_case(create_mdbx_proofs_storage(); "Mdbx")]
 #[serial]
-fn test_cursor_empty_trie<S: OpProofsStore + OpProofsInitialStateStore>(
+fn test_cursor_empty_trie<S: BaseProofsStore + BaseProofsInitialStateStore>(
     storage: S,
-) -> Result<(), OpProofsStorageError> {
+) -> Result<(), BaseProofsStorageError> {
     let mut cursor = storage.account_trie_cursor(100)?;
 
     // All operations should return None on empty trie
@@ -151,9 +151,9 @@ fn test_cursor_empty_trie<S: OpProofsStore + OpProofsInitialStateStore>(
 #[test_case(InMemoryProofsStorage::new(); "InMemory")]
 #[test_case(create_mdbx_proofs_storage(); "Mdbx")]
 #[serial]
-fn test_cursor_single_entry<S: OpProofsStore + OpProofsInitialStateStore>(
+fn test_cursor_single_entry<S: BaseProofsStore + BaseProofsInitialStateStore>(
     storage: S,
-) -> Result<(), OpProofsStorageError> {
+) -> Result<(), BaseProofsStorageError> {
     let path = nibbles_from(vec![1, 2, 3]);
     let branch = create_test_branch();
 
@@ -179,9 +179,9 @@ fn test_cursor_single_entry<S: OpProofsStore + OpProofsInitialStateStore>(
 #[test_case(InMemoryProofsStorage::new(); "InMemory")]
 #[test_case(create_mdbx_proofs_storage(); "Mdbx")]
 #[serial]
-fn test_cursor_multiple_entries<S: OpProofsStore + OpProofsInitialStateStore>(
+fn test_cursor_multiple_entries<S: BaseProofsStore + BaseProofsInitialStateStore>(
     storage: S,
-) -> Result<(), OpProofsStorageError> {
+) -> Result<(), BaseProofsStorageError> {
     let paths = vec![
         nibbles_from(vec![1]),
         nibbles_from(vec![1, 2]),
@@ -220,9 +220,9 @@ fn test_cursor_multiple_entries<S: OpProofsStore + OpProofsInitialStateStore>(
 #[test_case(InMemoryProofsStorage::new(); "InMemory")]
 #[test_case(create_mdbx_proofs_storage(); "Mdbx")]
 #[serial]
-fn test_seek_exact_existing_path<S: OpProofsStore + OpProofsInitialStateStore>(
+fn test_seek_exact_existing_path<S: BaseProofsStore + BaseProofsInitialStateStore>(
     storage: S,
-) -> Result<(), OpProofsStorageError> {
+) -> Result<(), BaseProofsStorageError> {
     let path = nibbles_from(vec![1, 2, 3]);
     let branch = create_test_branch();
 
@@ -239,9 +239,9 @@ fn test_seek_exact_existing_path<S: OpProofsStore + OpProofsInitialStateStore>(
 #[test_case(InMemoryProofsStorage::new(); "InMemory")]
 #[test_case(create_mdbx_proofs_storage(); "Mdbx")]
 #[serial]
-fn test_seek_exact_non_existing_path<S: OpProofsStore + OpProofsInitialStateStore>(
+fn test_seek_exact_non_existing_path<S: BaseProofsStore + BaseProofsInitialStateStore>(
     storage: S,
-) -> Result<(), OpProofsStorageError> {
+) -> Result<(), BaseProofsStorageError> {
     let path = nibbles_from(vec![1, 2, 3]);
     let branch = create_test_branch();
 
@@ -258,9 +258,9 @@ fn test_seek_exact_non_existing_path<S: OpProofsStore + OpProofsInitialStateStor
 #[test_case(InMemoryProofsStorage::new(); "InMemory")]
 #[test_case(create_mdbx_proofs_storage(); "Mdbx")]
 #[serial]
-fn test_seek_exact_empty_path<S: OpProofsStore + OpProofsInitialStateStore>(
+fn test_seek_exact_empty_path<S: BaseProofsStore + BaseProofsInitialStateStore>(
     storage: S,
-) -> Result<(), OpProofsStorageError> {
+) -> Result<(), BaseProofsStorageError> {
     let path = nibbles_from(vec![]);
     let branch = create_test_branch();
 
@@ -277,9 +277,9 @@ fn test_seek_exact_empty_path<S: OpProofsStore + OpProofsInitialStateStore>(
 #[test_case(InMemoryProofsStorage::new(); "InMemory")]
 #[test_case(create_mdbx_proofs_storage(); "Mdbx")]
 #[serial]
-fn test_seek_to_existing_path<S: OpProofsStore + OpProofsInitialStateStore>(
+fn test_seek_to_existing_path<S: BaseProofsStore + BaseProofsInitialStateStore>(
     storage: S,
-) -> Result<(), OpProofsStorageError> {
+) -> Result<(), BaseProofsStorageError> {
     let path = nibbles_from(vec![1, 2, 3]);
     let branch = create_test_branch();
 
@@ -296,9 +296,9 @@ fn test_seek_to_existing_path<S: OpProofsStore + OpProofsInitialStateStore>(
 #[test_case(InMemoryProofsStorage::new(); "InMemory")]
 #[test_case(create_mdbx_proofs_storage(); "Mdbx")]
 #[serial]
-fn test_seek_between_existing_nodes<S: OpProofsStore + OpProofsInitialStateStore>(
+fn test_seek_between_existing_nodes<S: BaseProofsStore + BaseProofsInitialStateStore>(
     storage: S,
-) -> Result<(), OpProofsStorageError> {
+) -> Result<(), BaseProofsStorageError> {
     let path1 = nibbles_from(vec![1]);
     let path2 = nibbles_from(vec![3]);
     let branch = create_test_branch();
@@ -319,9 +319,9 @@ fn test_seek_between_existing_nodes<S: OpProofsStore + OpProofsInitialStateStore
 #[test_case(InMemoryProofsStorage::new(); "InMemory")]
 #[test_case(create_mdbx_proofs_storage(); "Mdbx")]
 #[serial]
-fn test_seek_after_all_nodes<S: OpProofsStore + OpProofsInitialStateStore>(
+fn test_seek_after_all_nodes<S: BaseProofsStore + BaseProofsInitialStateStore>(
     storage: S,
-) -> Result<(), OpProofsStorageError> {
+) -> Result<(), BaseProofsStorageError> {
     let path = nibbles_from(vec![1]);
     let branch = create_test_branch();
 
@@ -339,9 +339,9 @@ fn test_seek_after_all_nodes<S: OpProofsStore + OpProofsInitialStateStore>(
 #[test_case(InMemoryProofsStorage::new(); "InMemory")]
 #[test_case(create_mdbx_proofs_storage(); "Mdbx")]
 #[serial]
-fn test_seek_before_all_nodes<S: OpProofsStore + OpProofsInitialStateStore>(
+fn test_seek_before_all_nodes<S: BaseProofsStore + BaseProofsInitialStateStore>(
     storage: S,
-) -> Result<(), OpProofsStorageError> {
+) -> Result<(), BaseProofsStorageError> {
     let path = nibbles_from(vec![5]);
     let branch = create_test_branch();
 
@@ -364,9 +364,9 @@ fn test_seek_before_all_nodes<S: OpProofsStore + OpProofsInitialStateStore>(
 #[test_case(InMemoryProofsStorage::new(); "InMemory")]
 #[test_case(create_mdbx_proofs_storage(); "Mdbx")]
 #[serial]
-fn test_next_without_prior_seek<S: OpProofsStore + OpProofsInitialStateStore>(
+fn test_next_without_prior_seek<S: BaseProofsStore + BaseProofsInitialStateStore>(
     storage: S,
-) -> Result<(), OpProofsStorageError> {
+) -> Result<(), BaseProofsStorageError> {
     let path = nibbles_from(vec![1, 2]);
     let branch = create_test_branch();
 
@@ -384,9 +384,9 @@ fn test_next_without_prior_seek<S: OpProofsStore + OpProofsInitialStateStore>(
 #[test_case(InMemoryProofsStorage::new(); "InMemory")]
 #[test_case(create_mdbx_proofs_storage(); "Mdbx")]
 #[serial]
-fn test_next_after_seek<S: OpProofsStore + OpProofsInitialStateStore>(
+fn test_next_after_seek<S: BaseProofsStore + BaseProofsInitialStateStore>(
     storage: S,
-) -> Result<(), OpProofsStorageError> {
+) -> Result<(), BaseProofsStorageError> {
     let path1 = nibbles_from(vec![1]);
     let path2 = nibbles_from(vec![2]);
     let branch = create_test_branch();
@@ -408,9 +408,9 @@ fn test_next_after_seek<S: OpProofsStore + OpProofsInitialStateStore>(
 #[test_case(InMemoryProofsStorage::new(); "InMemory")]
 #[test_case(create_mdbx_proofs_storage(); "Mdbx")]
 #[serial]
-fn test_next_at_end_of_trie<S: OpProofsStore + OpProofsInitialStateStore>(
+fn test_next_at_end_of_trie<S: BaseProofsStore + BaseProofsInitialStateStore>(
     storage: S,
-) -> Result<(), OpProofsStorageError> {
+) -> Result<(), BaseProofsStorageError> {
     let path = nibbles_from(vec![1]);
     let branch = create_test_branch();
 
@@ -429,9 +429,9 @@ fn test_next_at_end_of_trie<S: OpProofsStore + OpProofsInitialStateStore>(
 #[test_case(InMemoryProofsStorage::new(); "InMemory")]
 #[test_case(create_mdbx_proofs_storage(); "Mdbx")]
 #[serial]
-fn test_multiple_consecutive_next<S: OpProofsStore + OpProofsInitialStateStore>(
+fn test_multiple_consecutive_next<S: BaseProofsStore + BaseProofsInitialStateStore>(
     storage: S,
-) -> Result<(), OpProofsStorageError> {
+) -> Result<(), BaseProofsStorageError> {
     let paths = vec![nibbles_from(vec![1]), nibbles_from(vec![2]), nibbles_from(vec![3])];
     let branch = create_test_branch();
 
@@ -457,9 +457,9 @@ fn test_multiple_consecutive_next<S: OpProofsStore + OpProofsInitialStateStore>(
 #[test_case(InMemoryProofsStorage::new(); "InMemory")]
 #[test_case(create_mdbx_proofs_storage(); "Mdbx")]
 #[serial]
-fn test_current_after_operations<S: OpProofsStore + OpProofsInitialStateStore>(
+fn test_current_after_operations<S: BaseProofsStore + BaseProofsInitialStateStore>(
     storage: S,
-) -> Result<(), OpProofsStorageError> {
+) -> Result<(), BaseProofsStorageError> {
     let path1 = nibbles_from(vec![1]);
     let path2 = nibbles_from(vec![2]);
     let branch = create_test_branch();
@@ -487,9 +487,9 @@ fn test_current_after_operations<S: OpProofsStore + OpProofsInitialStateStore>(
 #[test_case(InMemoryProofsStorage::new(); "InMemory")]
 #[test_case(create_mdbx_proofs_storage(); "Mdbx")]
 #[serial]
-fn test_current_no_prior_operations<S: OpProofsStore + OpProofsInitialStateStore>(
+fn test_current_no_prior_operations<S: BaseProofsStore + BaseProofsInitialStateStore>(
     storage: S,
-) -> Result<(), OpProofsStorageError> {
+) -> Result<(), BaseProofsStorageError> {
     let mut cursor = storage.account_trie_cursor(100)?;
 
     // Current should be None when no operations performed
@@ -506,9 +506,9 @@ fn test_current_no_prior_operations<S: OpProofsStore + OpProofsInitialStateStore
 #[test_case(InMemoryProofsStorage::new(); "InMemory")]
 #[test_case(create_mdbx_proofs_storage(); "Mdbx")]
 #[serial]
-fn test_same_path_different_blocks<S: OpProofsStore + OpProofsInitialStateStore>(
+fn test_same_path_different_blocks<S: BaseProofsStore + BaseProofsInitialStateStore>(
     storage: S,
-) -> Result<(), OpProofsStorageError> {
+) -> Result<(), BaseProofsStorageError> {
     let path = nibbles_from(vec![1, 2]);
     let branch1 = create_test_branch();
     let branch2 = create_test_branch_variant();
@@ -534,9 +534,9 @@ fn test_same_path_different_blocks<S: OpProofsStore + OpProofsInitialStateStore>
 #[test_case(InMemoryProofsStorage::new(); "InMemory")]
 #[test_case(create_mdbx_proofs_storage(); "Mdbx")]
 #[serial]
-fn test_deleted_branch_nodes<S: OpProofsStore + OpProofsInitialStateStore>(
+fn test_deleted_branch_nodes<S: BaseProofsStore + BaseProofsInitialStateStore>(
     storage: S,
-) -> Result<(), OpProofsStorageError> {
+) -> Result<(), BaseProofsStorageError> {
     let path = nibbles_from(vec![1, 2]);
     let branch = create_test_branch();
     let block_ref = BlockWithParent::new(B256::ZERO, NumHash::new(100, B256::repeat_byte(0x96)));
@@ -571,9 +571,9 @@ fn test_deleted_branch_nodes<S: OpProofsStore + OpProofsInitialStateStore>(
 #[test_case(InMemoryProofsStorage::new(); "InMemory")]
 #[test_case(create_mdbx_proofs_storage(); "Mdbx")]
 #[serial]
-fn test_account_specific_cursor<S: OpProofsStore + OpProofsInitialStateStore>(
+fn test_account_specific_cursor<S: BaseProofsStore + BaseProofsInitialStateStore>(
     storage: S,
-) -> Result<(), OpProofsStorageError> {
+) -> Result<(), BaseProofsStorageError> {
     let path = nibbles_from(vec![1, 2]);
     let addr1 = B256::repeat_byte(0x01);
     let addr2 = B256::repeat_byte(0x02);
@@ -608,9 +608,9 @@ fn test_account_specific_cursor<S: OpProofsStore + OpProofsInitialStateStore>(
 #[test_case(InMemoryProofsStorage::new(); "InMemory")]
 #[test_case(create_mdbx_proofs_storage(); "Mdbx")]
 #[serial]
-fn test_state_trie_cursor<S: OpProofsStore + OpProofsInitialStateStore>(
+fn test_state_trie_cursor<S: BaseProofsStore + BaseProofsInitialStateStore>(
     storage: S,
-) -> Result<(), OpProofsStorageError> {
+) -> Result<(), BaseProofsStorageError> {
     let path = nibbles_from(vec![1, 2]);
     let addr = B256::repeat_byte(0x01);
     let branch = create_test_branch();
@@ -640,9 +640,9 @@ fn test_state_trie_cursor<S: OpProofsStore + OpProofsInitialStateStore>(
 #[test_case(InMemoryProofsStorage::new(); "InMemory")]
 #[test_case(create_mdbx_proofs_storage(); "Mdbx")]
 #[serial]
-fn test_mixed_account_state_data<S: OpProofsStore + OpProofsInitialStateStore>(
+fn test_mixed_account_state_data<S: BaseProofsStore + BaseProofsInitialStateStore>(
     storage: S,
-) -> Result<(), OpProofsStorageError> {
+) -> Result<(), BaseProofsStorageError> {
     let path1 = nibbles_from(vec![1]);
     let path2 = nibbles_from(vec![2]);
     let addr = B256::repeat_byte(0x01);
@@ -681,9 +681,9 @@ fn test_mixed_account_state_data<S: OpProofsStore + OpProofsInitialStateStore>(
 #[test_case(InMemoryProofsStorage::new(); "InMemory")]
 #[test_case(create_mdbx_proofs_storage(); "Mdbx")]
 #[serial]
-fn test_lexicographic_ordering<S: OpProofsStore + OpProofsInitialStateStore>(
+fn test_lexicographic_ordering<S: BaseProofsStore + BaseProofsInitialStateStore>(
     storage: S,
-) -> Result<(), OpProofsStorageError> {
+) -> Result<(), BaseProofsStorageError> {
     let paths = vec![
         nibbles_from(vec![3, 1]),
         nibbles_from(vec![1, 2]),
@@ -720,9 +720,9 @@ fn test_lexicographic_ordering<S: OpProofsStore + OpProofsInitialStateStore>(
 #[test_case(InMemoryProofsStorage::new(); "InMemory")]
 #[test_case(create_mdbx_proofs_storage(); "Mdbx")]
 #[serial]
-fn test_path_prefix_scenarios<S: OpProofsStore + OpProofsInitialStateStore>(
+fn test_path_prefix_scenarios<S: BaseProofsStore + BaseProofsInitialStateStore>(
     storage: S,
-) -> Result<(), OpProofsStorageError> {
+) -> Result<(), BaseProofsStorageError> {
     let paths = vec![
         nibbles_from(vec![1]),       // Prefix of next
         nibbles_from(vec![1, 2]),    // Extends first
@@ -754,9 +754,9 @@ fn test_path_prefix_scenarios<S: OpProofsStore + OpProofsInitialStateStore>(
 #[test_case(InMemoryProofsStorage::new(); "InMemory")]
 #[test_case(create_mdbx_proofs_storage(); "Mdbx")]
 #[serial]
-fn test_complex_nibble_combinations<S: OpProofsStore + OpProofsInitialStateStore>(
+fn test_complex_nibble_combinations<S: BaseProofsStore + BaseProofsInitialStateStore>(
     storage: S,
-) -> Result<(), OpProofsStorageError> {
+) -> Result<(), BaseProofsStorageError> {
     // Test various nibble patterns including edge values
     let paths = vec![
         nibbles_from(vec![0]),
@@ -796,9 +796,9 @@ fn test_complex_nibble_combinations<S: OpProofsStore + OpProofsInitialStateStore
 #[test_case(InMemoryProofsStorage::new(); "InMemory")]
 #[test_case(create_mdbx_proofs_storage(); "Mdbx")]
 #[serial]
-fn test_store_and_retrieve_single_account<S: OpProofsStore + OpProofsInitialStateStore>(
+fn test_store_and_retrieve_single_account<S: BaseProofsStore + BaseProofsInitialStateStore>(
     storage: S,
-) -> Result<(), OpProofsStorageError> {
+) -> Result<(), BaseProofsStorageError> {
     let account_key = B256::repeat_byte(0x01);
     let account = create_test_account();
 
@@ -821,9 +821,9 @@ fn test_store_and_retrieve_single_account<S: OpProofsStore + OpProofsInitialStat
 #[test_case(InMemoryProofsStorage::new(); "InMemory")]
 #[test_case(create_mdbx_proofs_storage(); "Mdbx")]
 #[serial]
-fn test_account_cursor_navigation<S: OpProofsStore + OpProofsInitialStateStore>(
+fn test_account_cursor_navigation<S: BaseProofsStore + BaseProofsInitialStateStore>(
     storage: S,
-) -> Result<(), OpProofsStorageError> {
+) -> Result<(), BaseProofsStorageError> {
     let accounts = [
         (B256::repeat_byte(0x01), create_test_account()),
         (B256::repeat_byte(0x03), create_test_account()),
@@ -859,9 +859,9 @@ fn test_account_cursor_navigation<S: OpProofsStore + OpProofsInitialStateStore>(
 #[test_case(InMemoryProofsStorage::new(); "InMemory")]
 #[test_case(create_mdbx_proofs_storage(); "Mdbx")]
 #[serial]
-fn test_account_block_versioning<S: OpProofsStore + OpProofsInitialStateStore>(
+fn test_account_block_versioning<S: BaseProofsStore + BaseProofsInitialStateStore>(
     storage: S,
-) -> Result<(), OpProofsStorageError> {
+) -> Result<(), BaseProofsStorageError> {
     let account_key = B256::repeat_byte(0x01);
     let account_v1 = create_test_account_with_values(1, 100, 0xBB);
     let account_v2 = create_test_account_with_values(2, 200, 0xDD);
@@ -890,9 +890,9 @@ fn test_account_block_versioning<S: OpProofsStore + OpProofsInitialStateStore>(
 #[test_case(InMemoryProofsStorage::new(); "InMemory")]
 #[test_case(create_mdbx_proofs_storage(); "Mdbx")]
 
-fn test_store_and_retrieve_storage<S: OpProofsStore + OpProofsInitialStateStore>(
+fn test_store_and_retrieve_storage<S: BaseProofsStore + BaseProofsInitialStateStore>(
     storage: S,
-) -> Result<(), OpProofsStorageError> {
+) -> Result<(), BaseProofsStorageError> {
     let hashed_address = B256::repeat_byte(0x01);
     let storage_slots = vec![
         (B256::repeat_byte(0x10), U256::from(100)),
@@ -920,9 +920,9 @@ fn test_store_and_retrieve_storage<S: OpProofsStore + OpProofsInitialStateStore>
 #[test_case(InMemoryProofsStorage::new(); "InMemory")]
 #[test_case(create_mdbx_proofs_storage(); "Mdbx")]
 #[serial]
-fn test_storage_cursor_navigation<S: OpProofsStore + OpProofsInitialStateStore>(
+fn test_storage_cursor_navigation<S: BaseProofsStore + BaseProofsInitialStateStore>(
     storage: S,
-) -> Result<(), OpProofsStorageError> {
+) -> Result<(), BaseProofsStorageError> {
     let hashed_address = B256::repeat_byte(0x01);
     let storage_slots = vec![
         (B256::repeat_byte(0x10), U256::from(100)),
@@ -952,9 +952,9 @@ fn test_storage_cursor_navigation<S: OpProofsStore + OpProofsInitialStateStore>(
 #[test_case(InMemoryProofsStorage::new(); "InMemory")]
 #[test_case(create_mdbx_proofs_storage(); "Mdbx")]
 #[serial]
-fn test_storage_account_isolation<S: OpProofsStore + OpProofsInitialStateStore>(
+fn test_storage_account_isolation<S: BaseProofsStore + BaseProofsInitialStateStore>(
     storage: S,
-) -> Result<(), OpProofsStorageError> {
+) -> Result<(), BaseProofsStorageError> {
     let address1 = B256::repeat_byte(0x01);
     let address2 = B256::repeat_byte(0x02);
     let storage_key = B256::repeat_byte(0x10);
@@ -987,9 +987,9 @@ fn test_storage_account_isolation<S: OpProofsStore + OpProofsInitialStateStore>(
 #[test_case(InMemoryProofsStorage::new(); "InMemory")]
 #[test_case(create_mdbx_proofs_storage(); "Mdbx")]
 #[serial]
-fn test_storage_block_versioning<S: OpProofsStore + OpProofsInitialStateStore>(
+fn test_storage_block_versioning<S: BaseProofsStore + BaseProofsInitialStateStore>(
     storage: S,
-) -> Result<(), OpProofsStorageError> {
+) -> Result<(), BaseProofsStorageError> {
     let hashed_address = B256::repeat_byte(0x01);
     let storage_key = B256::repeat_byte(0x10);
 
@@ -1014,9 +1014,9 @@ fn test_storage_block_versioning<S: OpProofsStore + OpProofsInitialStateStore>(
 #[test_case(InMemoryProofsStorage::new(); "InMemory")]
 #[test_case(create_mdbx_proofs_storage(); "Mdbx")]
 #[serial]
-fn test_storage_zero_value_deletion<S: OpProofsStore + OpProofsInitialStateStore>(
+fn test_storage_zero_value_deletion<S: BaseProofsStore + BaseProofsInitialStateStore>(
     storage: S,
-) -> Result<(), OpProofsStorageError> {
+) -> Result<(), BaseProofsStorageError> {
     let hashed_address = B256::repeat_byte(0x01);
     let storage_key = B256::repeat_byte(0x10);
 
@@ -1053,9 +1053,9 @@ fn test_storage_zero_value_deletion<S: OpProofsStore + OpProofsInitialStateStore
 #[test_case(InMemoryProofsStorage::new(); "InMemory")]
 #[test_case(create_mdbx_proofs_storage(); "Mdbx")]
 #[serial]
-fn test_storage_cursor_skips_zero_values<S: OpProofsStore + OpProofsInitialStateStore>(
+fn test_storage_cursor_skips_zero_values<S: BaseProofsStore + BaseProofsInitialStateStore>(
     storage: S,
-) -> Result<(), OpProofsStorageError> {
+) -> Result<(), BaseProofsStorageError> {
     let hashed_address = B256::repeat_byte(0x01);
 
     // Create a mix of non-zero and zero value storage slots
@@ -1102,9 +1102,9 @@ fn test_storage_cursor_skips_zero_values<S: OpProofsStore + OpProofsInitialState
 #[test_case(InMemoryProofsStorage::new(); "InMemory")]
 #[test_case(create_mdbx_proofs_storage(); "Mdbx")]
 #[serial]
-fn test_empty_cursors<S: OpProofsStore + OpProofsInitialStateStore>(
+fn test_empty_cursors<S: BaseProofsStore + BaseProofsInitialStateStore>(
     storage: S,
-) -> Result<(), OpProofsStorageError> {
+) -> Result<(), BaseProofsStorageError> {
     // Test empty account cursor
     let mut account_cursor = storage.account_hashed_cursor(100)?;
     assert!(account_cursor.seek(B256::repeat_byte(0x01))?.is_none());
@@ -1122,9 +1122,9 @@ fn test_empty_cursors<S: OpProofsStore + OpProofsInitialStateStore>(
 #[test_case(InMemoryProofsStorage::new(); "InMemory")]
 #[test_case(create_mdbx_proofs_storage(); "Mdbx")]
 #[serial]
-fn test_cursor_boundary_conditions<S: OpProofsStore + OpProofsInitialStateStore>(
+fn test_cursor_boundary_conditions<S: BaseProofsStore + BaseProofsInitialStateStore>(
     storage: S,
-) -> Result<(), OpProofsStorageError> {
+) -> Result<(), BaseProofsStorageError> {
     let account_key = B256::repeat_byte(0x80); // Middle value
     let account = create_test_account();
 
@@ -1151,9 +1151,9 @@ fn test_cursor_boundary_conditions<S: OpProofsStore + OpProofsInitialStateStore>
 #[test_case(InMemoryProofsStorage::new(); "InMemory")]
 #[test_case(create_mdbx_proofs_storage(); "Mdbx")]
 #[serial]
-fn test_large_batch_operations<S: OpProofsStore + OpProofsInitialStateStore>(
+fn test_large_batch_operations<S: BaseProofsStore + BaseProofsInitialStateStore>(
     storage: S,
-) -> Result<(), OpProofsStorageError> {
+) -> Result<(), BaseProofsStorageError> {
     // Create large batch of accounts
     let mut accounts = Vec::new();
     for i in 0..100 {
@@ -1189,9 +1189,9 @@ fn test_large_batch_operations<S: OpProofsStore + OpProofsInitialStateStore>(
 #[test_case(InMemoryProofsStorage::new(); "InMemory")]
 #[test_case(create_mdbx_proofs_storage(); "Mdbx")]
 #[serial]
-fn test_store_trie_updates_with_wiped_storage<S: OpProofsStore + OpProofsInitialStateStore>(
+fn test_store_trie_updates_with_wiped_storage<S: BaseProofsStore + BaseProofsInitialStateStore>(
     storage: S,
-) -> Result<(), OpProofsStorageError> {
+) -> Result<(), BaseProofsStorageError> {
     use reth_trie::HashedStorage;
 
     let hashed_address = B256::repeat_byte(0x01);
@@ -1277,9 +1277,9 @@ fn test_store_trie_updates_with_wiped_storage<S: OpProofsStore + OpProofsInitial
 #[test_case(InMemoryProofsStorage::new(); "InMemory")]
 #[test_case(create_mdbx_proofs_storage(); "Mdbx")]
 #[serial]
-fn test_store_trie_updates_comprehensive<S: OpProofsStore + OpProofsInitialStateStore>(
+fn test_store_trie_updates_comprehensive<S: BaseProofsStore + BaseProofsInitialStateStore>(
     storage: S,
-) -> Result<(), OpProofsStorageError> {
+) -> Result<(), BaseProofsStorageError> {
     use reth_trie::{HashedStorage, updates::StorageTrieUpdates};
 
     let block_ref = BlockWithParent::new(B256::ZERO, NumHash::new(100, B256::repeat_byte(0x96)));
@@ -1451,9 +1451,9 @@ fn test_store_trie_updates_comprehensive<S: OpProofsStore + OpProofsInitialState
 #[test_case(InMemoryProofsStorage::new(); "InMemory")]
 #[test_case(create_mdbx_proofs_storage(); "Mdbx")]
 #[serial]
-fn test_replace_updates_applies_all_updates<S: OpProofsStore + OpProofsInitialStateStore>(
+fn test_replace_updates_applies_all_updates<S: BaseProofsStore + BaseProofsInitialStateStore>(
     storage: S,
-) -> Result<(), OpProofsStorageError> {
+) -> Result<(), BaseProofsStorageError> {
     use reth_trie::{HashedStorage, updates::StorageTrieUpdates};
 
     let block_ref_50 = BlockWithParent::new(B256::ZERO, NumHash::new(50, B256::repeat_byte(0x96)));
@@ -1718,9 +1718,9 @@ fn test_replace_updates_applies_all_updates<S: OpProofsStore + OpProofsInitialSt
 #[test_case(InMemoryProofsStorage::new(); "InMemory")]
 #[test_case(create_mdbx_proofs_storage(); "Mdbx")]
 #[serial]
-fn test_pure_deletions_stored_correctly<S: OpProofsStore + OpProofsInitialStateStore>(
+fn test_pure_deletions_stored_correctly<S: BaseProofsStore + BaseProofsInitialStateStore>(
     storage: S,
-) -> Result<(), OpProofsStorageError> {
+) -> Result<(), BaseProofsStorageError> {
     use reth_trie::updates::StorageTrieUpdates;
 
     // ========== Setup: Store initial branch nodes at block 50 ==========
@@ -1852,9 +1852,9 @@ fn test_pure_deletions_stored_correctly<S: OpProofsStore + OpProofsInitialStateS
 #[test_case(InMemoryProofsStorage::new(); "InMemory")]
 #[test_case(create_mdbx_proofs_storage(); "Mdbx")]
 #[serial]
-fn test_updates_take_precedence_over_removals<S: OpProofsStore + OpProofsInitialStateStore>(
+fn test_updates_take_precedence_over_removals<S: BaseProofsStore + BaseProofsInitialStateStore>(
     storage: S,
-) -> Result<(), OpProofsStorageError> {
+) -> Result<(), BaseProofsStorageError> {
     use reth_trie::updates::StorageTrieUpdates;
 
     // ========== Setup: Store initial branch nodes at block 50 ==========

--- a/crates/execution/trie/tests/live.rs
+++ b/crates/execution/trie/tests/live.rs
@@ -6,7 +6,7 @@ use alloy_consensus::{BlockHeader, Header, TxEip2930, constants::ETH_TO_WEI};
 use alloy_genesis::{Genesis, GenesisAccount};
 use alloy_primitives::{Address, B256, TxKind, U256, keccak256};
 use base_execution_trie::{
-    MdbxProofsStorage, OpProofsStorage, OpProofsStorageError, initialize::InitializationJob,
+    BaseProofsStorage, BaseProofsStorageError, MdbxProofsStorage, initialize::InitializationJob,
     live::LiveTrieCollector,
 };
 use derive_more::Constructor;
@@ -220,7 +220,7 @@ fn run_test_scenario<N>(
     provider_factory: ProviderFactory<N>,
     chain_spec: Arc<ChainSpec>,
     key_pair: Keypair,
-    storage: OpProofsStorage<Arc<MdbxProofsStorage>>,
+    storage: BaseProofsStorage<Arc<MdbxProofsStorage>>,
 ) -> eyre::Result<()>
 where
     N: ProviderNodeTypes<
@@ -331,7 +331,7 @@ fn test_execute_and_store_block_updates() {
 #[test]
 fn test_execute_and_store_block_updates_missing_parent_block() {
     let dir = TempDir::new().unwrap();
-    let storage: OpProofsStorage<Arc<MdbxProofsStorage>> =
+    let storage: BaseProofsStorage<Arc<MdbxProofsStorage>> =
         Arc::new(MdbxProofsStorage::new(dir.path()).expect("env")).into();
 
     let secp = Secp256k1::new();
@@ -379,13 +379,13 @@ fn test_execute_and_store_block_updates_missing_parent_block() {
     // EXPECT: MissingParentBlock
     let err = collector.execute_and_store_block_updates(&incorrect_block).unwrap_err();
 
-    assert!(matches!(err, OpProofsStorageError::MissingParentBlock { .. }));
+    assert!(matches!(err, BaseProofsStorageError::MissingParentBlock { .. }));
 }
 
 #[test]
 fn test_execute_and_store_block_updates_state_root_mismatch() {
     let dir = TempDir::new().unwrap();
-    let storage: OpProofsStorage<Arc<MdbxProofsStorage>> =
+    let storage: BaseProofsStorage<Arc<MdbxProofsStorage>> =
         Arc::new(MdbxProofsStorage::new(dir.path()).expect("env")).into();
 
     let secp = Secp256k1::new();
@@ -443,7 +443,7 @@ fn test_execute_and_store_block_updates_state_root_mismatch() {
     // EXPECT: StateRootMismatch
     let err = collector.execute_and_store_block_updates(&block).unwrap_err();
 
-    assert!(matches!(err, OpProofsStorageError::StateRootMismatch { .. }));
+    assert!(matches!(err, BaseProofsStorageError::StateRootMismatch { .. }));
 }
 
 /// Test with multiple blocks before and after initialization

--- a/crates/execution/txpool/src/lib.rs
+++ b/crates/execution/txpool/src/lib.rs
@@ -8,7 +8,7 @@
 #![cfg_attr(docsrs, feature(doc_cfg))]
 
 mod validator;
-pub use validator::{OpL1BlockInfo, OpTransactionValidator};
+pub use validator::{BaseL1BlockInfo, OpTransactionValidator};
 
 mod transaction;
 pub use transaction::{

--- a/crates/execution/txpool/src/validator.rs
+++ b/crates/execution/txpool/src/validator.rs
@@ -24,14 +24,14 @@ use crate::OpPooledTx;
 
 /// Tracks additional infos for the current block.
 #[derive(Debug, Default)]
-pub struct OpL1BlockInfo {
+pub struct BaseL1BlockInfo {
     /// The current L1 block info.
     l1_block_info: RwLock<L1BlockInfo>,
     /// Current block timestamp.
     timestamp: AtomicU64,
 }
 
-impl OpL1BlockInfo {
+impl BaseL1BlockInfo {
     /// Returns the most recent timestamp
     pub fn timestamp(&self) -> u64 {
         self.timestamp.load(Ordering::Relaxed)
@@ -44,7 +44,7 @@ pub struct OpTransactionValidator<Client, Tx, Evm> {
     /// The type that performs the actual validation.
     inner: Arc<EthTransactionValidator<Client, Tx, Evm>>,
     /// Additional block info required for validation.
-    block_info: Arc<OpL1BlockInfo>,
+    block_info: Arc<BaseL1BlockInfo>,
     /// If true, ensure that the transaction's sender has enough balance to cover the L1 gas fee
     /// derived from the tracked L1 block info that is extracted from the first transaction in the
     /// L2 block.
@@ -91,7 +91,7 @@ where
 {
     /// Create a new [`OpTransactionValidator`].
     pub fn new(inner: EthTransactionValidator<Client, Tx, Evm>) -> Self {
-        let this = Self::with_block_info(inner, OpL1BlockInfo::default());
+        let this = Self::with_block_info(inner, BaseL1BlockInfo::default());
         if let Ok(Some(block)) =
             this.inner.client().block_by_number_or_tag(alloy_eips::BlockNumberOrTag::Latest)
         {
@@ -107,10 +107,10 @@ where
         this
     }
 
-    /// Create a new [`OpTransactionValidator`] with the given [`OpL1BlockInfo`].
+    /// Create a new [`OpTransactionValidator`] with the given [`BaseL1BlockInfo`].
     pub fn with_block_info(
         inner: EthTransactionValidator<Client, Tx, Evm>,
-        block_info: OpL1BlockInfo,
+        block_info: BaseL1BlockInfo,
     ) -> Self {
         Self {
             inner: Arc::new(inner),

--- a/devnet/src/l2/in_process_builder.rs
+++ b/devnet/src/l2/in_process_builder.rs
@@ -12,7 +12,7 @@ use alloy_rpc_types_engine::JwtSecret;
 use base_builder_core::{BuilderConfig, FlashblocksServiceBuilder, test_utils::get_available_port};
 use base_execution_chainspec::BaseChainSpec;
 use base_execution_txpool::{BasePooledTransaction, BuilderApiImpl, BuilderApiServer};
-use base_node_core::{args::RollupArgs, node::OpPoolBuilder};
+use base_node_core::{args::RollupArgs, node::BasePoolBuilder};
 use base_node_runner::BaseNode;
 use eyre::{Result, WrapErr, eyre};
 use nanoid::nanoid;
@@ -125,7 +125,7 @@ impl InProcessBuilder {
         let addons: base_node_runner::BaseAddOns<
             _,
             base_execution_rpc::OpEthApiBuilder,
-            base_node_core::OpEngineValidatorBuilder,
+            base_node_core::BasePayloadValidatorBuilder,
         > = base_node
             .add_ons_builder()
             .with_sequencer(rollup_args.sequencer.clone())
@@ -350,6 +350,6 @@ fn create_test_db(data_path: &std::path::Path) -> Result<(DatabaseEnv, PathBuf)>
     Ok((db, db_path))
 }
 
-fn pool_component(_rollup_args: &RollupArgs) -> OpPoolBuilder<BasePooledTransaction> {
-    OpPoolBuilder::<BasePooledTransaction>::default()
+fn pool_component(_rollup_args: &RollupArgs) -> BasePoolBuilder<BasePooledTransaction> {
+    BasePoolBuilder::<BasePooledTransaction>::default()
 }


### PR DESCRIPTION
## Summary

Renames ~37 locally-defined Op-prefixed types across the execution layer to use the Base prefix, continuing the migration away from OP Stack naming conventions. All renamed types are locally defined with no external dependency conflicts. OpEngineValidatorBuilder was renamed to BasePayloadValidatorBuilder to avoid a collision with the pre-existing BaseEngineValidatorBuilder in base-engine-tree.