### PR TITLE
fix: follow mode

### DIFF
--- a/crates/consensus/service/src/actors/derivation/delegate_l2/actor.rs
+++ b/crates/consensus/service/src/actors/derivation/delegate_l2/actor.rs
@@ -373,7 +373,9 @@ where
     }
 
     async fn update_safe_and_finalized(&self) -> Result<(), DerivationError> {
-        if let Ok(safe_number) = self.l2_source.get_block_number(BlockNumberOrTag::Safe).await {
+        let safe_sent = if let Ok(safe_number) =
+            self.l2_source.get_block_number(BlockNumberOrTag::Safe).await
+        {
             let clamped_safe = safe_number.min(self.engine_head);
             if let Ok(safe_payload) = self.l2_source.get_payload_by_number(clamped_safe).await {
                 let safe_l2 = L2BlockInfo {
@@ -389,14 +391,28 @@ where
                     .engine_client
                     .send_safe_l2_signal(ConsolidateInput::BlockInfo(safe_l2))
                     .await;
+                true
+            } else {
+                false
             }
-        }
+        } else {
+            false
+        };
 
-        if let Ok(finalized_number) =
-            self.l2_source.get_block_number(BlockNumberOrTag::Finalized).await
-        {
-            let clamped_finalized = finalized_number.min(self.engine_head);
-            let _ = self.engine_client.send_finalized_l2_block(clamped_finalized).await;
+        // Only advance the finalized head when the safe signal was also sent this
+        // tick.  After a restart the engine's safe head is reset to a conservative
+        // value (seq_window_size blocks behind unsafe).  If we send a FinalizeTask
+        // before a ConsolidateTask has pushed safe past the finalized target, the
+        // engine asserts safe >= finalized and crashes with BlockNotSafe (Critical).
+        // Deferring finalized until safe is known-good prevents that condition; the
+        // next tick will retry both.
+        if safe_sent {
+            if let Ok(finalized_number) =
+                self.l2_source.get_block_number(BlockNumberOrTag::Finalized).await
+            {
+                let clamped_finalized = finalized_number.min(self.engine_head);
+                let _ = self.engine_client.send_finalized_l2_block(clamped_finalized).await;
+            }
         }
 
         Ok(())
@@ -416,7 +432,8 @@ mod tests {
 
     use super::*;
     use crate::actors::derivation::{
-        delegate_l2::client::MockL2SourceClient, engine_client::MockDerivationEngineClient,
+        delegate_l2::client::{DelegateL2ClientError, MockL2SourceClient},
+        engine_client::MockDerivationEngineClient,
     };
 
     fn dummy_l2_block_info(number: u64) -> L2BlockInfo {
@@ -619,6 +636,53 @@ mod tests {
                 other => panic!("Expected ProcessUnsafeL2BlockRequest, got {other:?}"),
             }
         }
+    }
+
+    // Regression test: after a follow-node restart the engine resets its safe
+    // head to a conservative value far behind the remote finalized head.  If
+    // `get_payload_by_number` fails for the safe block we must NOT send the
+    // finalized signal; doing so would enqueue a FinalizeTask whose target
+    // exceeds the engine's safe head, crashing with BlockNotSafe (Critical).
+    #[tokio::test]
+    async fn finalize_not_sent_when_safe_payload_unavailable() {
+        let mut engine_client = MockDerivationEngineClient::new();
+        let mut l2_source = MockL2SourceClient::new();
+
+        // Block 1 is needed for the sync loop (sent_head=0 → target=1).
+        l2_source
+            .expect_get_payload_by_number()
+            .with(eq(1))
+            .returning(|n| Ok(dummy_payload_envelope(n)));
+
+        // Safe tag returns block 3, but the payload fetch for it fails.
+        l2_source
+            .expect_get_block_number()
+            .with(eq(BlockNumberOrTag::Safe))
+            .returning(|_| Ok(3));
+        l2_source
+            .expect_get_payload_by_number()
+            .with(eq(3))
+            .returning(|n| Err(DelegateL2ClientError::BlockNotFound(format!("{n}"))));
+
+        // Neither get_block_number(Finalized) nor send_finalized_l2_block should
+        // be reached — mockall will panic if they are called unexpectedly.
+        engine_client.expect_send_safe_l2_signal().times(0);
+        engine_client.expect_send_finalized_l2_block().times(0);
+
+        // engine_head=5 so clamped_safe = 3.min(5) = 3 (exercises the payload
+        // failure branch rather than the block-number-fetch failure branch).
+        let (mut task, mut engine_rx, _) = make_sync_task(engine_client, l2_source, 5, 0, 1);
+
+        let new_head = task.sync_from_source().await.unwrap();
+        assert_eq!(new_head, 1);
+
+        // Only the unsafe insert for block 1 should have been sent.
+        let req = engine_rx.try_recv().unwrap();
+        assert!(
+            matches!(req, EngineActorRequest::ProcessUnsafeL2BlockRequest(_)),
+            "expected ProcessUnsafeL2BlockRequest, got {req:?}"
+        );
+        assert!(engine_rx.is_empty(), "unexpected extra engine requests");
     }
 
     #[tokio::test]

--- a/crates/consensus/service/src/actors/engine/engine_request_processor.rs
+++ b/crates/consensus/service/src/actors/engine/engine_request_processor.rs
@@ -643,7 +643,7 @@ mod tests {
     use alloy_rpc_types_eth::Block as RpcBlock;
     use base_common_rpc_types::Transaction as OpTransaction;
     use base_consensus_engine::{
-        Engine, EngineState,
+        Engine, EngineState, EngineTaskErrors, FinalizeTaskError,
         test_utils::{test_block_info, test_engine_client_builder},
     };
     use base_consensus_genesis::{ChainGenesis, RollupConfig, SystemConfig};
@@ -1032,6 +1032,90 @@ mod tests {
             state.sync_state.finalized_head(),
             L2BlockInfo::default(),
             "finalized head must remain zeroed"
+        );
+    }
+
+    /// Regression test: demonstrates the follow-node restart crash.
+    ///
+    /// When a follow node restarts, `EngineProcessor` boots as a [`BootstrapRole::Validator`]:
+    /// it seeds `unsafe_head` from reth's latest block but leaves `safe_head` at the default
+    /// (zero).  The first `ProcessUnsafeL2Block` eventually triggers `el_sync_finished` and a
+    /// reset, but `find_starting_forkchoice` can only establish a *conservative* safe head
+    /// (seq_window blocks behind the current tip) — much lower than the chain's actual
+    /// finalized block.
+    ///
+    /// `DelegateL2DerivationActor::update_safe_and_finalized` sends `ProcessSafeL2Signal` and
+    /// `ProcessFinalizedL2BlockNumber` in that order, but `ProcessSafeL2Signal` requires two
+    /// RPC calls to succeed (`get_block_number` **and** `get_payload_by_number`), while
+    /// `ProcessFinalizedL2BlockNumber` only requires one.  If the payload fetch fails, the
+    /// safe signal is skipped but the finalize signal is still sent.
+    ///
+    /// `FinalizeTask::execute` checks `safe_head.number >= block_number` before doing anything
+    /// else.  With `safe_head = 0` and `block_number = 50`, the check fails and returns
+    /// `FinalizeTaskError::BlockNotSafe`, which has `Critical` severity — crashing the node.
+    ///
+    /// This test reproduces that crash: it starts an `EngineProcessor` in validator/follow mode,
+    /// waits for bootstrap to complete (safe still zero), then sends
+    /// `ProcessFinalizedL2BlockNumber(50)` without a preceding `ProcessSafeL2Signal`.
+    ///
+    /// **Expected behaviour (unfixed):** the processor task exits with
+    /// `Err(EngineError::EngineTask(EngineTaskErrors::Finalize(FinalizeTaskError::BlockNotSafe)))`.
+    #[tokio::test]
+    async fn follow_node_restart_finalize_before_safe_crashes() {
+        // Validator bootstrap: bootstrap_validator seeds engine state from reth's Latest block
+        // info but sends no FCU and leaves safe_head at the default (zero).
+        let client = Arc::new(
+            test_engine_client_builder()
+                .with_block_info_by_tag(BlockNumberOrTag::Latest, test_block_info(100))
+                .build(),
+        );
+
+        // The processor crashes in drain() before any derivation client method is reached —
+        // no expectations needed.
+        let mock_derivation = MockEngineDerivationClient::new();
+
+        let (state_tx, state_rx) = watch::channel(EngineState::default());
+        let (queue_tx, _) = watch::channel(0usize);
+        let engine = Engine::new(EngineState::default(), state_tx, queue_tx);
+
+        // Follow-node / validator mode: no unsafe_head_tx, no conductor.
+        let processor = EngineProcessor::new(
+            Arc::clone(&client),
+            Arc::new(RollupConfig::default()),
+            mock_derivation,
+            engine,
+            None,
+            None,
+            false,
+        );
+
+        let (req_tx, req_rx) = mpsc::channel(8);
+        let handle = processor.start(req_rx);
+
+        // Wait for bootstrap to seed unsafe_head so the main loop is blocking on recv().
+        state_rx
+            .clone()
+            .wait_for(|s| s.sync_state.unsafe_head().block_info.number == 100)
+            .await
+            .expect("bootstrap did not complete");
+
+        // Send a finalize for block 50 — safe_head is still 0. No safe signal was sent first.
+        // FinalizeTask::execute checks `safe_head.number >= block_number` first; 0 < 50
+        // returns BlockNotSafe (Critical), which kills the processor.
+        req_tx
+            .send(EngineProcessingRequest::ProcessFinalizedL2BlockNumber(Box::new(50)))
+            .await
+            .expect("failed to send finalize request");
+
+        let result = handle.await.expect("task panicked");
+        assert!(
+            matches!(
+                result,
+                Err(crate::EngineError::EngineTask(EngineTaskErrors::Finalize(
+                    FinalizeTaskError::BlockNotSafe
+                )))
+            ),
+            "expected BlockNotSafe critical error, got {result:?}"
         );
     }
 


### PR DESCRIPTION
## Summary

After a follow node restart, the engine resets its safe head to a conservative value far behind the remote finalized head. `update_safe_and_finalized` could enqueue a FinalizeTask even when the safe payload fetch failed, causing the engine to assert safe >= finalized and crash with a critical BlockNotSafe error. This change gates the finalized signal on the safe signal being successfully sent in the same tick, so the two signals always arrive together. If the safe fetch fails, both are deferred to the next 2-second tick where they will be retried. 