### PR TITLE
fix(consensus): Inconsistent Safe And Finalized Heads

### DIFF
--- a/crates/consensus/engine/src/lib.rs
+++ b/crates/consensus/engine/src/lib.rs
@@ -11,7 +11,8 @@ extern crate tracing;
 
 mod task_queue;
 pub use task_queue::{
-    BuildTask, BuildTaskError, ConsolidateInput, ConsolidateTask, ConsolidateTaskError, Engine,
+    BuildTask, BuildTaskError, ConsolidateInput, ConsolidateTask, ConsolidateTaskError,
+    DelegatedForkchoiceTask, DelegatedForkchoiceTaskError, DelegatedForkchoiceUpdate, Engine,
     EngineBuildError, EngineResetError, EngineTask, EngineTaskError, EngineTaskErrorSeverity,
     EngineTaskErrors, EngineTaskExt, FinalizeTask, FinalizeTaskError, GetPayloadTask, InsertTask,
     InsertTaskError, SealTask, SealTaskError, SynchronizeTask, SynchronizeTaskError,

--- a/crates/consensus/engine/src/metrics/mod.rs
+++ b/crates/consensus/engine/src/metrics/mod.rs
@@ -14,13 +14,29 @@ base_metrics::define_metrics! {
     #[describe("Engine tasks successfully executed")]
     #[label(
         name = "task",
-        default = ["insert", "consolidate", "build", "finalize", "seal", "get-payload"]
+        default = [
+            "insert",
+            "consolidate",
+            "delegated-forkchoice",
+            "build",
+            "finalize",
+            "seal",
+            "get-payload"
+        ]
     )]
     engine_task_count: counter,
     #[describe("Engine tasks failed")]
     #[label(
         name = "task",
-        default = ["insert", "consolidate", "build", "finalize", "seal", "get-payload"]
+        default = [
+            "insert",
+            "consolidate",
+            "delegated-forkchoice",
+            "build",
+            "finalize",
+            "seal",
+            "get-payload"
+        ]
     )]
     #[label(name = "severity", default = ["temporary", "critical", "reset", "flush"])]
     engine_task_failure: counter,
@@ -49,6 +65,8 @@ impl Metrics {
     pub const INSERT_TASK_LABEL: &str = "insert";
     /// Consolidate task label.
     pub const CONSOLIDATE_TASK_LABEL: &str = "consolidate";
+    /// Delegated forkchoice task label.
+    pub const DELEGATED_FORKCHOICE_TASK_LABEL: &str = "delegated-forkchoice";
     /// Forkchoice task label.
     pub const FORKCHOICE_TASK_LABEL: &str = "forkchoice-update";
     /// Build task label.

--- a/crates/consensus/engine/src/task_queue/tasks/delegated_forkchoice/error.rs
+++ b/crates/consensus/engine/src/task_queue/tasks/delegated_forkchoice/error.rs
@@ -1,0 +1,28 @@
+//! Error types for the delegated forkchoice task.
+
+use thiserror::Error;
+
+use crate::{
+    ConsolidateTaskError, EngineTaskError, FinalizeTaskError,
+    task_queue::tasks::task::EngineTaskErrorSeverity,
+};
+
+/// An error returned by the delegated follow-node forkchoice task.
+#[derive(Debug, Error)]
+pub enum DelegatedForkchoiceTaskError {
+    /// Consolidation failed while applying the delegated safe head.
+    #[error(transparent)]
+    Consolidate(#[from] ConsolidateTaskError),
+    /// Finalization failed while advancing the delegated finalized head.
+    #[error(transparent)]
+    Finalize(#[from] FinalizeTaskError),
+}
+
+impl EngineTaskError for DelegatedForkchoiceTaskError {
+    fn severity(&self) -> EngineTaskErrorSeverity {
+        match self {
+            Self::Consolidate(inner) => inner.severity(),
+            Self::Finalize(inner) => inner.severity(),
+        }
+    }
+}

--- a/crates/consensus/engine/src/task_queue/tasks/delegated_forkchoice/mod.rs
+++ b/crates/consensus/engine/src/task_queue/tasks/delegated_forkchoice/mod.rs
@@ -1,0 +1,10 @@
+//! Follow-node delegated forkchoice task and its associated types.
+
+mod error;
+pub use error::DelegatedForkchoiceTaskError;
+
+mod task;
+pub use task::{DelegatedForkchoiceTask, DelegatedForkchoiceUpdate};
+
+#[cfg(test)]
+mod task_test;

--- a/crates/consensus/engine/src/task_queue/tasks/delegated_forkchoice/task.rs
+++ b/crates/consensus/engine/src/task_queue/tasks/delegated_forkchoice/task.rs
@@ -1,0 +1,73 @@
+//! A follow-node task that applies delegated safe and finalized labels together.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use base_consensus_genesis::RollupConfig;
+use base_protocol::L2BlockInfo;
+use derive_more::Constructor;
+
+use crate::{
+    ConsolidateInput, ConsolidateTask, DelegatedForkchoiceTaskError, EngineClient, EngineState,
+    EngineTaskExt, FinalizeTask,
+};
+
+/// Delegated forkchoice labels from a remote follow source.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct DelegatedForkchoiceUpdate {
+    /// The delegated safe L2 block.
+    pub safe_l2: L2BlockInfo,
+    /// The delegated finalized L2 block number, if available.
+    pub finalized_l2_number: Option<u64>,
+}
+
+/// Applies delegated safe and finalized labels in engine-state order.
+#[derive(Debug, Clone, Constructor)]
+pub struct DelegatedForkchoiceTask<EngineClient_: EngineClient> {
+    /// The engine client.
+    pub client: Arc<EngineClient_>,
+    /// The rollup config.
+    pub cfg: Arc<RollupConfig>,
+    /// The delegated labels to apply.
+    pub update: DelegatedForkchoiceUpdate,
+}
+
+#[async_trait]
+impl<EngineClient_: EngineClient> EngineTaskExt for DelegatedForkchoiceTask<EngineClient_> {
+    type Output = ();
+    type Error = DelegatedForkchoiceTaskError;
+
+    async fn execute(&self, state: &mut EngineState) -> Result<(), Self::Error> {
+        ConsolidateTask::new(
+            Arc::clone(&self.client),
+            Arc::clone(&self.cfg),
+            ConsolidateInput::BlockInfo(self.update.safe_l2),
+        )
+        .execute(state)
+        .await?;
+
+        let actual_safe = state.sync_state.safe_head().block_info.number;
+        let Some(remote_finalized) = self.update.finalized_l2_number else {
+            return Ok(());
+        };
+
+        let finalized_target = remote_finalized.min(actual_safe);
+        let current_finalized = state.sync_state.finalized_head().block_info.number;
+        if finalized_target <= current_finalized {
+            debug!(
+                target: "engine",
+                actual_safe,
+                current_finalized,
+                finalized_target,
+                "Skipping delegated finalized update"
+            );
+            return Ok(());
+        }
+
+        FinalizeTask::new(Arc::clone(&self.client), Arc::clone(&self.cfg), finalized_target)
+            .execute(state)
+            .await?;
+
+        Ok(())
+    }
+}

--- a/crates/consensus/engine/src/task_queue/tasks/delegated_forkchoice/task_test.rs
+++ b/crates/consensus/engine/src/task_queue/tasks/delegated_forkchoice/task_test.rs
@@ -1,0 +1,87 @@
+//! Tests for [`DelegatedForkchoiceTask::execute`].
+
+use std::sync::Arc;
+
+use alloy_eips::BlockNumberOrTag;
+use alloy_primitives::B256;
+use alloy_rpc_types_engine::{ForkchoiceUpdated, PayloadStatus, PayloadStatusEnum};
+use alloy_rpc_types_eth::Block as RpcBlock;
+use base_common_rpc_types::Transaction as OpTransaction;
+use base_consensus_genesis::RollupConfig;
+use base_protocol::{BlockInfo, L2BlockInfo};
+
+use crate::{
+    DelegatedForkchoiceTask, DelegatedForkchoiceUpdate, EngineTaskExt,
+    test_utils::{TestEngineStateBuilder, test_block_info, test_engine_client_builder},
+};
+
+fn syncing_fcu() -> ForkchoiceUpdated {
+    ForkchoiceUpdated {
+        payload_status: PayloadStatus {
+            status: PayloadStatusEnum::Syncing,
+            latest_valid_hash: None,
+        },
+        payload_id: None,
+    }
+}
+
+fn block_with_hash(number: u64, hash: B256) -> RpcBlock<OpTransaction> {
+    let mut block = RpcBlock::<OpTransaction>::default();
+    block.header.hash = hash;
+    block.header.inner.number = number;
+    block.header.inner.timestamp = number * 2;
+    block
+}
+
+#[tokio::test]
+async fn syncing_safe_update_skips_finalization_beyond_actual_safe() {
+    let delegated_safe_number = 80;
+    let delegated_safe_hash = B256::from([0x11; 32]);
+    let delegated_safe = L2BlockInfo {
+        block_info: BlockInfo {
+            hash: delegated_safe_hash,
+            number: delegated_safe_number,
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+
+    let client = Arc::new(
+        test_engine_client_builder()
+            .with_l2_block_by_label(
+                BlockNumberOrTag::Number(delegated_safe_number),
+                block_with_hash(delegated_safe_number, delegated_safe_hash),
+            )
+            .with_fork_choice_updated_v3_response(syncing_fcu())
+            .build(),
+    );
+
+    let mut state = TestEngineStateBuilder::new()
+        .with_unsafe_head(test_block_info(100))
+        .with_safe_head(L2BlockInfo::default())
+        .with_finalized_head(L2BlockInfo::default())
+        .with_el_sync_finished(false)
+        .build();
+
+    let task = DelegatedForkchoiceTask::new(
+        client,
+        Arc::new(RollupConfig::default()),
+        DelegatedForkchoiceUpdate {
+            safe_l2: delegated_safe,
+            finalized_l2_number: Some(delegated_safe_number),
+        },
+    );
+
+    task.execute(&mut state).await.expect("delegated forkchoice should not fail");
+
+    assert_eq!(
+        state.sync_state.safe_head(),
+        L2BlockInfo::default(),
+        "safe head must remain unchanged when safe FCU returns Syncing",
+    );
+    assert_eq!(
+        state.sync_state.finalized_head(),
+        L2BlockInfo::default(),
+        "finalized head must not advance past the actual safe head",
+    );
+}

--- a/crates/consensus/engine/src/task_queue/tasks/mod.rs
+++ b/crates/consensus/engine/src/task_queue/tasks/mod.rs
@@ -23,6 +23,11 @@ pub use get_payload::GetPayloadTask;
 mod consolidate;
 pub use consolidate::{ConsolidateInput, ConsolidateTask, ConsolidateTaskError};
 
+mod delegated_forkchoice;
+pub use delegated_forkchoice::{
+    DelegatedForkchoiceTask, DelegatedForkchoiceTaskError, DelegatedForkchoiceUpdate,
+};
+
 mod finalize;
 pub use finalize::{FinalizeTask, FinalizeTaskError};
 

--- a/crates/consensus/engine/src/task_queue/tasks/task.rs
+++ b/crates/consensus/engine/src/task_queue/tasks/task.rs
@@ -9,10 +9,12 @@ use derive_more::Display;
 use thiserror::Error;
 use tokio::task::yield_now;
 
-use super::{BuildTask, ConsolidateTask, FinalizeTask, GetPayloadTask, InsertTask};
+use super::{
+    BuildTask, ConsolidateTask, DelegatedForkchoiceTask, FinalizeTask, GetPayloadTask, InsertTask,
+};
 use crate::{
-    BuildTaskError, ConsolidateTaskError, EngineClient, EngineState, FinalizeTaskError,
-    InsertTaskError, Metrics,
+    BuildTaskError, ConsolidateTaskError, DelegatedForkchoiceTaskError, EngineClient, EngineState,
+    FinalizeTaskError, InsertTaskError, Metrics,
     task_queue::{SealTask, SealTaskError},
 };
 
@@ -72,6 +74,9 @@ pub enum EngineTaskErrors {
     /// An error that occurred while consolidating the engine state.
     #[error(transparent)]
     Consolidate(#[from] ConsolidateTaskError),
+    /// An error that occurred while applying delegated follow-node forkchoice labels.
+    #[error(transparent)]
+    DelegatedForkchoice(#[from] DelegatedForkchoiceTaskError),
     /// An error that occurred while finalizing an L2 block.
     #[error(transparent)]
     Finalize(#[from] FinalizeTaskError),
@@ -96,6 +101,7 @@ impl EngineTaskError for EngineTaskErrors {
             Self::Build(inner) => inner.severity(),
             Self::Seal(inner) => inner.severity(),
             Self::Consolidate(inner) => inner.severity(),
+            Self::DelegatedForkchoice(inner) => inner.severity(),
             Self::Finalize(inner) => inner.severity(),
         }
     }
@@ -118,6 +124,8 @@ pub enum EngineTask<EngineClient_: EngineClient> {
     /// Performs consolidation on the engine state, reverting to payload attribute processing
     /// via the [`BuildTask`] if consolidation fails.
     Consolidate(Box<ConsolidateTask<EngineClient_>>),
+    /// Applies delegated safe and finalized labels for follow mode.
+    DelegatedForkchoice(Box<DelegatedForkchoiceTask<EngineClient_>>),
     /// Finalizes an L2 block
     Finalize(Box<FinalizeTask<EngineClient_>>),
 }
@@ -130,6 +138,7 @@ impl<EngineClient_: EngineClient> EngineTask<EngineClient_> {
             Self::Seal(task) => task.execute(state).await?,
             Self::GetPayload(task) => task.execute(state).await?,
             Self::Consolidate(task) => task.execute(state).await?,
+            Self::DelegatedForkchoice(task) => task.execute(state).await?,
             Self::Finalize(task) => task.execute(state).await?,
             Self::Build(task) => {
                 task.execute(state).await?;
@@ -143,6 +152,7 @@ impl<EngineClient_: EngineClient> EngineTask<EngineClient_> {
         match self {
             Self::Insert(_) => Metrics::INSERT_TASK_LABEL,
             Self::Consolidate(_) => Metrics::CONSOLIDATE_TASK_LABEL,
+            Self::DelegatedForkchoice(_) => Metrics::DELEGATED_FORKCHOICE_TASK_LABEL,
             Self::Build(_) => Metrics::BUILD_TASK_LABEL,
             Self::Seal(_) => Metrics::SEAL_TASK_LABEL,
             Self::GetPayload(_) => Metrics::GET_PAYLOAD_TASK_LABEL,
@@ -160,6 +170,7 @@ impl<EngineClient_: EngineClient> PartialEq for EngineTask<EngineClient_> {
                 | (Self::Seal(_), Self::Seal(_))
                 | (Self::GetPayload(_), Self::GetPayload(_))
                 | (Self::Consolidate(_), Self::Consolidate(_))
+                | (Self::DelegatedForkchoice(_), Self::DelegatedForkchoice(_))
                 | (Self::Finalize(_), Self::Finalize(_))
         )
     }
@@ -190,6 +201,7 @@ impl<EngineClient_: EngineClient> Ord for EngineTask<EngineClient_> {
             // Same variant cases
             (Self::Insert(_), Self::Insert(_))
             | (Self::Consolidate(_), Self::Consolidate(_))
+            | (Self::DelegatedForkchoice(_), Self::DelegatedForkchoice(_))
             | (Self::Build(_), Self::Build(_))
             | (Self::Seal(_), Self::Seal(_))
             | (Self::GetPayload(_), Self::GetPayload(_))
@@ -213,9 +225,16 @@ impl<EngineClient_: EngineClient> Ord for EngineTask<EngineClient_> {
             (Self::Insert(_), _) => Ordering::Greater,
             (_, Self::Insert(_)) => Ordering::Less,
 
-            // Consolidate tasks are prioritized over Finalize tasks
-            (Self::Consolidate(_), _) => Ordering::Greater,
-            (_, Self::Consolidate(_)) => Ordering::Less,
+            // Consolidate-style tasks are prioritized over Finalize tasks.
+            (Self::Consolidate(_) | Self::DelegatedForkchoice(_), Self::Finalize(_)) => {
+                Ordering::Greater
+            }
+            (Self::Finalize(_), Self::Consolidate(_) | Self::DelegatedForkchoice(_)) => {
+                Ordering::Less
+            }
+
+            // Consolidate and delegated forkchoice share equal priority.
+            (Self::Consolidate(_) | Self::DelegatedForkchoice(_), _) => Ordering::Equal,
         }
     }
 }

--- a/crates/consensus/service/src/actors/derivation/delegate_l2/actor.rs
+++ b/crates/consensus/service/src/actors/derivation/delegate_l2/actor.rs
@@ -315,7 +315,7 @@ where
     DerivationEngineClient_: DerivationEngineClient,
     L2Source: L2SourceClient,
 {
-    pub(super) fn new(
+    pub(super) const fn new(
         engine_client: Arc<DerivationEngineClient_>,
         engine_actor_request_tx: mpsc::Sender<EngineActorRequest>,
         cancellation_token: CancellationToken,
@@ -398,16 +398,15 @@ where
         // Detect hash mismatch between source and local EL for the delegated safe block.
         if let Ok(Some(local_block)) =
             self.local_l2_provider.get_block_by_number(clamped_safe.into()).await
+            && local_block.header.hash != source_hash
         {
-            if local_block.header.hash != source_hash {
-                warn!(
-                    target: "derivation",
-                    block_number = clamped_safe,
-                    local_hash = %local_block.header.hash,
-                    source_hash = %source_hash,
-                    "Delegated safe block hash mismatch between source and local EL"
-                );
-            }
+            warn!(
+                target: "derivation",
+                block_number = clamped_safe,
+                local_hash = %local_block.header.hash,
+                source_hash = %source_hash,
+                "Delegated safe block hash mismatch between source and local EL"
+            );
         }
 
         let safe_l2 = L2BlockInfo {

--- a/crates/consensus/service/src/actors/derivation/delegate_l2/actor.rs
+++ b/crates/consensus/service/src/actors/derivation/delegate_l2/actor.rs
@@ -183,17 +183,22 @@ where
 
                     let target_block = match self.determine_target_block().await {
                         Ok(Some(target)) => target,
-                        Ok(None) => continue,
+                        Ok(None) => {
+                            warn!(target: "derivation", sent_head = self.sent_head, "Target is behind already sent head, skipping sync");
+                            continue;
+                        },
                         Err(e) => {
                             warn!(target: "derivation", error = %e, "Failed to determine target block");
                             continue;
                         }
                     };
+                    info!(target: "derivation", target_block, sent_head = self.sent_head, "Starting sync from L2 source");
 
                     let cancellation_token = self.cancellation_token.clone();
                     let l2_source = Arc::clone(&self.l2_source);
                     let engine_client = Arc::clone(&self.engine_client);
                     let engine_actor_request_tx = self.engine_actor_request_tx.clone();
+                    let local_l2_provider = self.local_l2_provider.clone();
                     let sent_head = self.sent_head;
 
                     sync_task = Some(tokio::spawn(async move {
@@ -201,6 +206,7 @@ where
                             engine_client,
                             engine_actor_request_tx,
                             cancellation_token,
+                            local_l2_provider,
                             sent_head,
                             target_block,
                             l2_source,
@@ -298,6 +304,7 @@ pub(super) struct SyncFromSourceTask<DerivationEngineClient_, L2Source> {
     engine_client: Arc<DerivationEngineClient_>,
     engine_actor_request_tx: mpsc::Sender<EngineActorRequest>,
     cancellation_token: CancellationToken,
+    local_l2_provider: RootProvider<Base>,
     sent_head: u64,
     target_block: u64,
     l2_source: Arc<L2Source>,
@@ -308,10 +315,11 @@ where
     DerivationEngineClient_: DerivationEngineClient,
     L2Source: L2SourceClient,
 {
-    pub(super) const fn new(
+    pub(super) fn new(
         engine_client: Arc<DerivationEngineClient_>,
         engine_actor_request_tx: mpsc::Sender<EngineActorRequest>,
         cancellation_token: CancellationToken,
+        local_l2_provider: RootProvider<Base>,
         sent_head: u64,
         target_block: u64,
         l2_source: Arc<L2Source>,
@@ -320,6 +328,7 @@ where
             engine_client,
             engine_actor_request_tx,
             cancellation_token,
+            local_l2_provider,
             sent_head,
             target_block,
             l2_source,
@@ -384,9 +393,26 @@ where
             return Ok(());
         };
 
+        let source_hash = safe_payload.execution_payload.block_hash();
+
+        // Detect hash mismatch between source and local EL for the delegated safe block.
+        if let Ok(Some(local_block)) =
+            self.local_l2_provider.get_block_by_number(clamped_safe.into()).await
+        {
+            if local_block.header.hash != source_hash {
+                warn!(
+                    target: "derivation",
+                    block_number = clamped_safe,
+                    local_hash = %local_block.header.hash,
+                    source_hash = %source_hash,
+                    "Delegated safe block hash mismatch between source and local EL"
+                );
+            }
+        }
+
         let safe_l2 = L2BlockInfo {
             block_info: base_protocol::BlockInfo {
-                hash: safe_payload.execution_payload.block_hash(),
+                hash: source_hash,
                 number: clamped_safe,
                 ..Default::default()
             },
@@ -503,10 +529,14 @@ mod tests {
         let cancel = CancellationToken::new();
         let (engine_tx, engine_rx) = mpsc::channel(16);
 
+        let local_l2_provider =
+            RootProvider::<Base>::new_http("http://localhost:1234".parse().unwrap());
+
         let task = SyncFromSourceTask::new(
             Arc::new(engine_client),
             engine_tx,
             cancel.clone(),
+            local_l2_provider,
             sent_head,
             target_block,
             Arc::new(l2_source),

--- a/crates/consensus/service/src/actors/derivation/delegate_l2/actor.rs
+++ b/crates/consensus/service/src/actors/derivation/delegate_l2/actor.rs
@@ -4,7 +4,7 @@ use alloy_eips::BlockNumberOrTag;
 use alloy_provider::{Provider, RootProvider};
 use async_trait::async_trait;
 use base_common_network::Base;
-use base_consensus_engine::ConsolidateInput;
+use base_consensus_engine::DelegatedForkchoiceUpdate;
 use base_protocol::L2BlockInfo;
 use futures::future::OptionFuture;
 use serde::Deserialize;
@@ -31,7 +31,7 @@ struct ProofsSyncStatus {
 /// engine via `ProcessUnsafeL2BlockRequest` (`NewPayload` + FCU) rather than
 /// running the full derivation pipeline.
 ///
-/// Safe and finalized head updates are forwarded separately.
+/// Safe and finalized head updates are forwarded together as delegated labels.
 #[derive(Debug)]
 pub struct DelegateL2DerivationActor<DerivationEngineClient_, L2Source = super::DelegateL2Client>
 where
@@ -45,7 +45,6 @@ where
     local_l2_provider: RootProvider<Base>,
     l2_source: Arc<L2Source>,
     sent_head: u64,
-    engine_head: u64,
     proofs_enabled: bool,
     proofs_max_blocks_ahead: u64,
 }
@@ -83,7 +82,6 @@ where
             local_l2_provider,
             l2_source: Arc::new(l2_source),
             sent_head: 0,
-            engine_head: 0,
             proofs_enabled: false,
             proofs_max_blocks_ahead: DEFAULT_PROOFS_MAX_BLOCKS_AHEAD,
         }
@@ -135,7 +133,6 @@ where
                 .await
                 .map_err(|e| DerivationError::Sender(Box::new(e)))?;
             self.sent_head = head;
-            self.engine_head = head;
         }
 
         info!(target: "derivation", head = self.sent_head, "Starting L2 delegate derivation");
@@ -197,7 +194,6 @@ where
                     let l2_source = Arc::clone(&self.l2_source);
                     let engine_client = Arc::clone(&self.engine_client);
                     let engine_actor_request_tx = self.engine_actor_request_tx.clone();
-                    let engine_head = self.engine_head;
                     let sent_head = self.sent_head;
 
                     sync_task = Some(tokio::spawn(async move {
@@ -205,7 +201,6 @@ where
                             engine_client,
                             engine_actor_request_tx,
                             cancellation_token,
-                            engine_head,
                             sent_head,
                             target_block,
                             l2_source,
@@ -271,17 +266,23 @@ where
     }
 
     async fn handle_request(
-        &mut self,
+        &self,
         request_type: DerivationActorRequest,
     ) -> Result<(), DerivationError> {
         match request_type {
             DerivationActorRequest::ProcessEngineSafeHeadUpdateRequest(safe_head) => {
-                debug!(target: "derivation", safe_head = ?*safe_head, "Received safe head from engine.");
-                self.engine_head = safe_head.block_info.number;
+                debug!(
+                    target: "derivation",
+                    safe_head = ?*safe_head,
+                    "Ignoring engine safe head update in L2 delegate mode"
+                );
             }
             DerivationActorRequest::ProcessEngineSyncCompletionRequest(safe_head) => {
-                info!(target: "derivation", head = safe_head.block_info.number, "Engine sync completed.");
-                self.engine_head = safe_head.block_info.number;
+                info!(
+                    target: "derivation",
+                    head = safe_head.block_info.number,
+                    "Ignoring engine sync completion in L2 delegate mode"
+                );
             }
             DerivationActorRequest::ProcessEngineSignalRequest(_)
             | DerivationActorRequest::ProcessFinalizedL1Block(_)
@@ -297,7 +298,6 @@ pub(super) struct SyncFromSourceTask<DerivationEngineClient_, L2Source> {
     engine_client: Arc<DerivationEngineClient_>,
     engine_actor_request_tx: mpsc::Sender<EngineActorRequest>,
     cancellation_token: CancellationToken,
-    engine_head: u64,
     sent_head: u64,
     target_block: u64,
     l2_source: Arc<L2Source>,
@@ -312,7 +312,6 @@ where
         engine_client: Arc<DerivationEngineClient_>,
         engine_actor_request_tx: mpsc::Sender<EngineActorRequest>,
         cancellation_token: CancellationToken,
-        engine_head: u64,
         sent_head: u64,
         target_block: u64,
         l2_source: Arc<L2Source>,
@@ -321,7 +320,6 @@ where
             engine_client,
             engine_actor_request_tx,
             cancellation_token,
-            engine_head,
             sent_head,
             target_block,
             l2_source,
@@ -373,31 +371,41 @@ where
     }
 
     async fn update_safe_and_finalized(&self) -> Result<(), DerivationError> {
-        if let Ok(safe_number) = self.l2_source.get_block_number(BlockNumberOrTag::Safe).await {
-            let clamped_safe = safe_number.min(self.engine_head);
-            if let Ok(safe_payload) = self.l2_source.get_payload_by_number(clamped_safe).await {
-                let safe_l2 = L2BlockInfo {
-                    block_info: base_protocol::BlockInfo {
-                        hash: safe_payload.execution_payload.block_hash(),
-                        number: clamped_safe,
-                        ..Default::default()
-                    },
-                    ..Default::default()
-                };
+        let Ok(safe_number) = self.l2_source.get_block_number(BlockNumberOrTag::Safe).await else {
+            return Ok(());
+        };
+        // Delegated labels must never point past blocks we have already forwarded to the local
+        // engine, but they must not be clamped to the engine's current safe head. On a fresh
+        // follow node the engine safe head starts at genesis, and clamping to it would pin both
+        // delegated safe and finalized labels at block 0 forever.
+        let local_tip = self.sent_head;
+        let clamped_safe = safe_number.min(local_tip);
+        let Ok(safe_payload) = self.l2_source.get_payload_by_number(clamped_safe).await else {
+            return Ok(());
+        };
 
-                let _ = self
-                    .engine_client
-                    .send_safe_l2_signal(ConsolidateInput::BlockInfo(safe_l2))
-                    .await;
-            }
-        }
+        let safe_l2 = L2BlockInfo {
+            block_info: base_protocol::BlockInfo {
+                hash: safe_payload.execution_payload.block_hash(),
+                number: clamped_safe,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let finalized_l2_number = self
+            .l2_source
+            .get_block_number(BlockNumberOrTag::Finalized)
+            .await
+            .ok()
+            .map(|number| number.min(local_tip));
 
-        if let Ok(finalized_number) =
-            self.l2_source.get_block_number(BlockNumberOrTag::Finalized).await
-        {
-            let clamped_finalized = finalized_number.min(self.engine_head);
-            let _ = self.engine_client.send_finalized_l2_block(clamped_finalized).await;
-        }
+        let _ = self
+            .engine_client
+            .send_delegated_forkchoice_update(DelegatedForkchoiceUpdate {
+                safe_l2,
+                finalized_l2_number,
+            })
+            .await;
 
         Ok(())
     }
@@ -410,13 +418,14 @@ mod tests {
     use alloy_rpc_types_engine::ExecutionPayloadV1;
     use base_common_rpc_types_engine::{BaseExecutionPayload, BaseExecutionPayloadEnvelope};
     use base_protocol::{BlockInfo, L2BlockInfo};
-    use mockall::predicate::*;
+    use mockall::{Sequence, predicate::*};
     use tokio::sync::mpsc;
     use tokio_util::sync::CancellationToken;
 
     use super::*;
     use crate::actors::derivation::{
-        delegate_l2::client::MockL2SourceClient, engine_client::MockDerivationEngineClient,
+        delegate_l2::client::{DelegateL2ClientError, MockL2SourceClient},
+        engine_client::MockDerivationEngineClient,
     };
 
     fn dummy_l2_block_info(number: u64) -> L2BlockInfo {
@@ -484,7 +493,6 @@ mod tests {
     fn make_sync_task(
         engine_client: MockDerivationEngineClient,
         l2_source: MockL2SourceClient,
-        engine_head: u64,
         sent_head: u64,
         target_block: u64,
     ) -> (
@@ -499,7 +507,6 @@ mod tests {
             Arc::new(engine_client),
             engine_tx,
             cancel.clone(),
-            engine_head,
             sent_head,
             target_block,
             Arc::new(l2_source),
@@ -512,9 +519,7 @@ mod tests {
     async fn handle_sync_completion_enables_sync() {
         let engine_client = MockDerivationEngineClient::new();
         let l2_source = MockL2SourceClient::new();
-        let (mut actor, _, _, _) = make_actor(engine_client, l2_source);
-
-        assert_eq!(actor.engine_head, 0);
+        let (actor, _, _, _) = make_actor(engine_client, l2_source);
 
         let safe_head = dummy_l2_block_info(42);
         actor
@@ -523,15 +528,13 @@ mod tests {
             )))
             .await
             .unwrap();
-
-        assert_eq!(actor.engine_head, 42);
     }
 
     #[tokio::test]
     async fn handle_safe_head_update_sets_local_head() {
         let engine_client = MockDerivationEngineClient::new();
         let l2_source = MockL2SourceClient::new();
-        let (mut actor, _, _, _) = make_actor(engine_client, l2_source);
+        let (actor, _, _, _) = make_actor(engine_client, l2_source);
 
         let safe_head = dummy_l2_block_info(100);
         actor
@@ -540,15 +543,13 @@ mod tests {
             )))
             .await
             .unwrap();
-
-        assert_eq!(actor.engine_head, 100);
     }
 
     #[tokio::test]
     async fn handle_irrelevant_requests_noop() {
         let engine_client = MockDerivationEngineClient::new();
         let l2_source = MockL2SourceClient::new();
-        let (mut actor, _, _, _) = make_actor(engine_client, l2_source);
+        let (actor, _, _, _) = make_actor(engine_client, l2_source);
 
         actor
             .handle_request(DerivationActorRequest::ProcessL1HeadUpdateRequest(Box::default()))
@@ -559,8 +560,6 @@ mod tests {
             .handle_request(DerivationActorRequest::ProcessFinalizedL1Block(Box::default()))
             .await
             .unwrap();
-
-        assert_eq!(actor.engine_head, 0);
     }
 
     #[tokio::test]
@@ -568,7 +567,7 @@ mod tests {
         let engine_client = MockDerivationEngineClient::new();
         let l2_source = MockL2SourceClient::new();
 
-        let (mut task, _, _) = make_sync_task(engine_client, l2_source, 0, 10, 5);
+        let (mut task, _, _) = make_sync_task(engine_client, l2_source, 10, 5);
 
         let new_head = task.sync_from_source().await.unwrap();
         assert_eq!(new_head, 10);
@@ -602,10 +601,13 @@ mod tests {
             .with(eq(BlockNumberOrTag::Finalized))
             .returning(|_| Ok(1));
 
-        engine_client.expect_send_safe_l2_signal().returning(|_| Ok(()));
-        engine_client.expect_send_finalized_l2_block().returning(|_| Ok(()));
+        engine_client.expect_send_delegated_forkchoice_update().returning(|update| {
+            assert_eq!(update.safe_l2.block_info.number, 2);
+            assert_eq!(update.finalized_l2_number, Some(1));
+            Ok(())
+        });
 
-        let (mut task, mut engine_rx, _) = make_sync_task(engine_client, l2_source, 2, 0, 3);
+        let (mut task, mut engine_rx, _) = make_sync_task(engine_client, l2_source, 0, 3);
 
         let new_head = task.sync_from_source().await.unwrap();
         assert_eq!(new_head, 3);
@@ -622,11 +624,89 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn delegated_forkchoice_uses_inserted_head_when_engine_safe_head_is_zero() {
+        let mut engine_client = MockDerivationEngineClient::new();
+        let mut l2_source = MockL2SourceClient::new();
+
+        l2_source
+            .expect_get_payload_by_number()
+            .with(eq(1))
+            .returning(|n| Ok(dummy_payload_envelope(n)));
+        l2_source
+            .expect_get_payload_by_number()
+            .with(eq(2))
+            .returning(|n| Ok(dummy_payload_envelope(n)));
+        l2_source
+            .expect_get_payload_by_number()
+            .with(eq(3))
+            .returning(|n| Ok(dummy_payload_envelope(n)));
+
+        l2_source.expect_get_block_number().with(eq(BlockNumberOrTag::Safe)).returning(|_| Ok(2));
+        l2_source
+            .expect_get_payload_by_number()
+            .with(eq(2))
+            .returning(|n| Ok(dummy_payload_envelope(n)));
+        l2_source
+            .expect_get_block_number()
+            .with(eq(BlockNumberOrTag::Finalized))
+            .returning(|_| Ok(1));
+
+        engine_client.expect_send_delegated_forkchoice_update().returning(|update| {
+            assert_eq!(update.safe_l2.block_info.number, 2);
+            assert_eq!(update.finalized_l2_number, Some(1));
+            Ok(())
+        });
+
+        let (mut task, _engine_rx, _) = make_sync_task(engine_client, l2_source, 0, 3);
+
+        let new_head = task.sync_from_source().await.unwrap();
+        assert_eq!(new_head, 3);
+    }
+
+    #[tokio::test]
+    async fn delegated_forkchoice_not_sent_when_safe_payload_unavailable() {
+        let mut engine_client = MockDerivationEngineClient::new();
+        let mut l2_source = MockL2SourceClient::new();
+        let mut sequence = Sequence::new();
+
+        l2_source
+            .expect_get_payload_by_number()
+            .with(eq(1))
+            .times(1)
+            .in_sequence(&mut sequence)
+            .returning(|n| Ok(dummy_payload_envelope(n)));
+
+        l2_source.expect_get_block_number().with(eq(BlockNumberOrTag::Safe)).returning(|_| Ok(1));
+        l2_source
+            .expect_get_payload_by_number()
+            .with(eq(1))
+            .times(1)
+            .in_sequence(&mut sequence)
+            .returning(|n| Err(DelegateL2ClientError::BlockNotFound(format!("{n}"))));
+
+        engine_client.expect_send_delegated_forkchoice_update().times(0);
+        engine_client.expect_send_safe_l2_signal().times(0);
+        engine_client.expect_send_finalized_l2_block().times(0);
+
+        let (mut task, mut engine_rx, _) = make_sync_task(engine_client, l2_source, 0, 1);
+
+        let new_head = task.sync_from_source().await.unwrap();
+        assert_eq!(new_head, 1);
+
+        let req = engine_rx.try_recv().unwrap();
+        assert!(
+            matches!(req, EngineActorRequest::ProcessUnsafeL2BlockRequest(_)),
+            "expected ProcessUnsafeL2BlockRequest, got {req:?}"
+        );
+        assert!(engine_rx.is_empty(), "unexpected extra engine requests");
+    }
+
+    #[tokio::test]
     async fn sync_aborts_on_cancellation() {
         let engine_client = MockDerivationEngineClient::new();
         let l2_source = MockL2SourceClient::new();
 
-        let (mut task, engine_rx, cancel) = make_sync_task(engine_client, l2_source, 0, 0, 100);
+        let (mut task, engine_rx, cancel) = make_sync_task(engine_client, l2_source, 0, 100);
 
         cancel.cancel();
         let new_head = task.sync_from_source().await.unwrap();

--- a/crates/consensus/service/src/actors/derivation/engine_client.rs
+++ b/crates/consensus/service/src/actors/derivation/engine_client.rs
@@ -1,7 +1,7 @@
 use std::fmt::Debug;
 
 use async_trait::async_trait;
-use base_consensus_engine::ConsolidateInput;
+use base_consensus_engine::{ConsolidateInput, DelegatedForkchoiceUpdate};
 use derive_more::Constructor;
 use tokio::sync::mpsc;
 
@@ -13,6 +13,14 @@ use crate::{EngineActorRequest, EngineClientError, EngineClientResult, ResetRequ
 pub trait DerivationEngineClient: Debug + Send + Sync {
     /// Resets the engine's forkchoice.
     async fn reset_engine_forkchoice(&self) -> EngineClientResult<()>;
+
+    /// Sends follow-node delegated safe/finalized labels to the engine.
+    ///
+    /// Note: This does not wait for the engine to process the request.
+    async fn send_delegated_forkchoice_update(
+        &self,
+        update: DelegatedForkchoiceUpdate,
+    ) -> EngineClientResult<()>;
 
     /// Sends a request to finalize the L2 block at the provided block number.
     /// Note: This does not wait for the engine to process it.
@@ -54,6 +62,24 @@ impl DerivationEngineClient for QueuedDerivationEngineClient {
                 error!(target: "derivation_engine_client", "Failed to receive forkchoice reset result");
                 EngineClientError::ResponseError("response channel closed.".to_string())
             })?
+    }
+
+    async fn send_delegated_forkchoice_update(
+        &self,
+        update: DelegatedForkchoiceUpdate,
+    ) -> EngineClientResult<()> {
+        trace!(
+            target: "derivation",
+            safe_number = update.safe_l2.block_info.number,
+            finalized_number = ?update.finalized_l2_number,
+            "Sending delegated forkchoice update to engine"
+        );
+        self.engine_actor_request_tx
+            .send(EngineActorRequest::ProcessDelegatedForkchoiceUpdateRequest(Box::new(update)))
+            .await
+            .map_err(|_| EngineClientError::RequestError("request channel closed.".to_string()))?;
+
+        Ok(())
     }
 
     async fn send_finalized_l2_block(&self, block_number: u64) -> EngineClientResult<()> {

--- a/crates/consensus/service/src/actors/engine/actor.rs
+++ b/crates/consensus/service/src/actors/engine/actor.rs
@@ -144,6 +144,9 @@ where
                         EngineActorRequest::ProcessSafeL2SignalRequest(signal) => {
                             send_engine_processing_request(EngineProcessingRequest::ProcessSafeL2Signal(signal)).await?;
                         }
+                        EngineActorRequest::ProcessDelegatedForkchoiceUpdateRequest(update) => {
+                            send_engine_processing_request(EngineProcessingRequest::ProcessDelegatedForkchoiceUpdate(update)).await?;
+                        }
                         EngineActorRequest::ProcessFinalizedL2BlockNumberRequest(block_number) => {
                             send_engine_processing_request(EngineProcessingRequest::ProcessFinalizedL2BlockNumber(block_number)).await?;
                         }

--- a/crates/consensus/service/src/actors/engine/engine_request_processor.rs
+++ b/crates/consensus/service/src/actors/engine/engine_request_processor.rs
@@ -4,9 +4,9 @@ use alloy_eips::BlockNumberOrTag;
 use base_common_rpc_types_engine::BaseExecutionPayloadEnvelope;
 use base_consensus_derive::{ResetSignal, Signal};
 use base_consensus_engine::{
-    BuildTask, ConsolidateInput, ConsolidateTask, Engine, EngineClient, EngineSyncStateUpdate,
-    EngineTask, EngineTaskError, EngineTaskErrorSeverity, FinalizeTask, GetPayloadTask, InsertTask,
-    SealTask,
+    BuildTask, ConsolidateInput, ConsolidateTask, DelegatedForkchoiceTask,
+    DelegatedForkchoiceUpdate, Engine, EngineClient, EngineSyncStateUpdate, EngineTask,
+    EngineTaskError, EngineTaskErrorSeverity, FinalizeTask, GetPayloadTask, InsertTask, SealTask,
 };
 use base_consensus_genesis::RollupConfig;
 use base_protocol::L2BlockInfo;
@@ -40,6 +40,8 @@ pub enum EngineProcessingRequest {
     GetPayload(Box<GetPayloadRequest>),
     /// Request to process a Safe signal, which can be derived attributes or delegated block info.
     ProcessSafeL2Signal(ConsolidateInput),
+    /// Request to apply delegated safe/finalized labels together for follow mode.
+    ProcessDelegatedForkchoiceUpdate(Box<DelegatedForkchoiceUpdate>),
     /// Request to process the finalized L2 block with the provided block number.
     ProcessFinalizedL2BlockNumber(Box<u64>),
     /// Request to process a received unsafe L2 block.
@@ -556,6 +558,16 @@ where
                             Arc::clone(&self.rollup),
                             safe_signal,
                         )));
+                        self.engine.enqueue(task);
+                    }
+                    EngineProcessingRequest::ProcessDelegatedForkchoiceUpdate(update) => {
+                        let task = EngineTask::DelegatedForkchoice(Box::new(
+                            DelegatedForkchoiceTask::new(
+                                Arc::clone(&self.client),
+                                Arc::clone(&self.rollup),
+                                *update,
+                            ),
+                        ));
                         self.engine.enqueue(task);
                     }
                     EngineProcessingRequest::ProcessFinalizedL2BlockNumber(

--- a/crates/consensus/service/src/actors/engine/request.rs
+++ b/crates/consensus/service/src/actors/engine/request.rs
@@ -1,6 +1,8 @@
 use alloy_rpc_types_engine::PayloadId;
 use base_common_rpc_types_engine::BaseExecutionPayloadEnvelope;
-use base_consensus_engine::{BuildTaskError, ConsolidateInput, EngineQueries, SealTaskError};
+use base_consensus_engine::{
+    BuildTaskError, ConsolidateInput, DelegatedForkchoiceUpdate, EngineQueries, SealTaskError,
+};
 use base_protocol::AttributesWithParent;
 use thiserror::Error;
 use tokio::sync::mpsc;
@@ -47,6 +49,8 @@ pub enum EngineActorRequest {
     /// Request to consolidate using a safe L2 signal from attributes or delegated safe-block
     /// derivation
     ProcessSafeL2SignalRequest(ConsolidateInput),
+    /// Request to apply delegated follow-node safe/finalized labels together.
+    ProcessDelegatedForkchoiceUpdateRequest(Box<DelegatedForkchoiceUpdate>),
     /// Request to finalize the L2 block at the provided block number.
     ProcessFinalizedL2BlockNumberRequest(Box<u64>),
     /// Request to insert the provided unsafe block.

--- a/crates/consensus/service/tests/actors/engine.rs
+++ b/crates/consensus/service/tests/actors/engine.rs
@@ -1,0 +1,152 @@
+//! Integration tests for the engine processing path.
+
+use std::sync::Arc;
+
+use alloy_primitives::B256;
+use alloy_rpc_types_engine::{ForkchoiceUpdated, PayloadStatus, PayloadStatusEnum};
+use alloy_rpc_types_eth::Block as RpcBlock;
+use async_trait::async_trait;
+use base_common_rpc_types::Transaction as OpTransaction;
+use base_consensus_engine::{
+    DelegatedForkchoiceUpdate, Engine,
+    test_utils::{TestEngineStateBuilder, test_block_info, test_engine_client_builder},
+};
+use base_consensus_genesis::RollupConfig;
+use base_consensus_node::{
+    EngineDerivationClient, EngineError, EngineProcessingRequest, EngineProcessor,
+    EngineRequestReceiver,
+};
+use base_protocol::{BlockInfo, L2BlockInfo};
+use tokio::sync::{mpsc, watch};
+
+#[derive(Debug, Default)]
+struct NoopDerivationClient;
+
+#[async_trait]
+impl EngineDerivationClient for NoopDerivationClient {
+    async fn notify_sync_completed(
+        &self,
+        _: L2BlockInfo,
+    ) -> Result<(), base_consensus_node::DerivationClientError> {
+        Ok(())
+    }
+
+    async fn send_new_engine_safe_head(
+        &self,
+        _: L2BlockInfo,
+    ) -> Result<(), base_consensus_node::DerivationClientError> {
+        Ok(())
+    }
+
+    async fn send_signal(
+        &self,
+        _: base_consensus_derive::Signal,
+    ) -> Result<(), base_consensus_node::DerivationClientError> {
+        Ok(())
+    }
+}
+
+const fn syncing_fcu() -> ForkchoiceUpdated {
+    ForkchoiceUpdated {
+        payload_status: PayloadStatus {
+            status: PayloadStatusEnum::Syncing,
+            latest_valid_hash: None,
+        },
+        payload_id: None,
+    }
+}
+
+fn mismatched_block(number: u64) -> RpcBlock<OpTransaction> {
+    let mut block = RpcBlock::<OpTransaction>::default();
+    block.header.hash = B256::from([0xabu8; 32]);
+    block.header.inner.number = number;
+    block.header.inner.timestamp = number * 2;
+    block
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn follow_restart_delegated_forkchoice_does_not_finalize_past_actual_safe_head() {
+    let unsafe_head = test_block_info(100);
+    let delegated_safe_number = 80;
+
+    let initial_state = TestEngineStateBuilder::new()
+        .with_unsafe_head(unsafe_head)
+        .with_safe_head(L2BlockInfo::default())
+        .with_finalized_head(L2BlockInfo::default())
+        .with_el_sync_finished(false)
+        .build();
+
+    let client = Arc::new(
+        test_engine_client_builder()
+            .with_block_info_by_tag(alloy_eips::BlockNumberOrTag::Latest, unsafe_head)
+            .with_l2_block_by_label(
+                alloy_eips::BlockNumberOrTag::Number(delegated_safe_number),
+                mismatched_block(delegated_safe_number),
+            )
+            .with_fork_choice_updated_v3_response(syncing_fcu())
+            .build(),
+    );
+
+    let delegated_safe = L2BlockInfo {
+        block_info: BlockInfo {
+            number: delegated_safe_number,
+            hash: B256::from([0xcdu8; 32]),
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+
+    let (state_tx, state_rx) = watch::channel(initial_state);
+    let (queue_tx, _) = watch::channel(0usize);
+    let engine = Engine::new(initial_state, state_tx, queue_tx);
+
+    let processor = EngineProcessor::new(
+        Arc::clone(&client),
+        Arc::new(RollupConfig::default()),
+        NoopDerivationClient,
+        engine,
+        None,
+        None,
+        false,
+    );
+
+    let (req_tx, req_rx) = mpsc::channel(8);
+    let handle = processor.start(req_rx);
+
+    state_rx
+        .clone()
+        .wait_for(|state| {
+            state.sync_state.unsafe_head().block_info.number == unsafe_head.block_info.number
+        })
+        .await
+        .expect("bootstrap did not seed unsafe head");
+
+    req_tx
+        .send(EngineProcessingRequest::ProcessDelegatedForkchoiceUpdate(Box::new(
+            DelegatedForkchoiceUpdate {
+                safe_l2: delegated_safe,
+                finalized_l2_number: Some(delegated_safe_number),
+            },
+        )))
+        .await
+        .expect("failed to send delegated forkchoice update");
+
+    drop(req_tx);
+    let result = handle.await.expect("processor task panicked");
+    assert!(
+        matches!(result, Err(EngineError::ChannelClosed)),
+        "expected ChannelClosed after request channel shutdown, got {result:?}"
+    );
+
+    let state = *state_rx.borrow();
+    assert_eq!(
+        state.sync_state.safe_head(),
+        L2BlockInfo::default(),
+        "safe head should remain unchanged when the delegated safe FCU returns Syncing",
+    );
+    assert_eq!(
+        state.sync_state.finalized_head(),
+        L2BlockInfo::default(),
+        "finalized head must not advance past the actual engine safe head",
+    );
+}

--- a/crates/consensus/service/tests/actors/mod.rs
+++ b/crates/consensus/service/tests/actors/mod.rs
@@ -1,4 +1,5 @@
 //! Integration tests for the node actors.
 
+mod engine;
 pub(crate) mod generator;
 mod network;


### PR DESCRIPTION
## Summary

This change fixes a follow-node-only inconsistency between delegated safe and finalized updates. Before this patch, the L2 delegate actor sent safe and finalized signals as separate fire-and-forget requests, so a restart could leave the engine on a conservative safe head while the delegate path still enqueued a newer finalized target. If the safe forkchoice update returned Syncing, the engine's actual safe head did not advance, but the separate finalize request could still arrive and trip the invariant that finalized blocks must already be safe.

The fix adds a dedicated delegated forkchoice path for follow mode that applies delegated safe and finalized labels together inside the engine. The new task consolidates the delegated safe head first and then derives the finalized target from the engine's real post-consolidation safe head, which prevents follow nodes from finalizing past what the local EL has actually accepted while leaving validator and sequencer behavior unchanged. The PR also adds engine and service regressions covering the restart path and the case where delegated safe data is unavailable.
