### PR TITLE
rename BaseTxType back to OpTxType

### DIFF
--- a/crates/builder/core/src/flashblocks/context.rs
+++ b/crates/builder/core/src/flashblocks/context.rs
@@ -11,7 +11,7 @@ use alloy_primitives::{B256, BlockHash, Bytes, TxHash, U256};
 use alloy_rpc_types_eth::Withdrawals;
 use base_access_lists::FBALBuilderDb;
 use base_common_chains::Upgrades;
-use base_common_consensus::{BaseReceipt, BaseTransactionSigned, BaseTxType, DepositReceipt};
+use base_common_consensus::{BaseReceipt, BaseTransactionSigned, DepositReceipt, OpTxType};
 use base_common_evm::{BaseReceiptBuilder, L1BlockInfo, OpSpecId};
 use base_execution_chainspec::BaseChainSpec;
 use base_execution_evm::{BaseEvmConfig, OpNextBlockEnvAttributes};
@@ -451,7 +451,7 @@ impl OpPayloadBuilderCtx {
     /// Constructs a receipt for the given transaction.
     pub fn build_receipt<E: Evm>(
         &self,
-        ctx: ReceiptBuilderCtx<'_, BaseTxType, E>,
+        ctx: ReceiptBuilderCtx<'_, OpTxType, E>,
         deposit_nonce: Option<u64>,
     ) -> BaseReceipt {
         let receipt_builder = self.evm_config.block_executor_factory().receipt_builder();

--- a/crates/common/consensus/src/lib.rs
+++ b/crates/common/consensus/src/lib.rs
@@ -30,8 +30,8 @@ mod transaction;
 #[cfg(feature = "serde")]
 pub use transaction::serde_deposit_tx_rpc;
 pub use transaction::{
-    BasePooledTransaction, BaseTransaction, BaseTransactionInfo, BaseTxEnvelope, BaseTxType,
-    BaseTypedTransaction, DEPOSIT_TX_TYPE_ID, DepositInfo, DepositTransaction, TxDeposit,
+    BasePooledTransaction, BaseTransaction, BaseTransactionInfo, BaseTxEnvelope,
+    BaseTypedTransaction, DEPOSIT_TX_TYPE_ID, DepositInfo, DepositTransaction, OpTxType, TxDeposit,
 };
 
 mod extra;

--- a/crates/common/consensus/src/receipts/envelope.rs
+++ b/crates/common/consensus/src/receipts/envelope.rs
@@ -10,7 +10,7 @@ use alloy_eips::{
 use alloy_primitives::{Bloom, Log, logs_bloom};
 use alloy_rlp::{BufMut, Decodable, Encodable, length_of_length};
 
-use crate::{BaseTxType, DepositReceipt, DepositReceiptWithBloom};
+use crate::{DepositReceipt, DepositReceiptWithBloom, OpTxType};
 
 /// Receipt envelope, as defined in [EIP-2718], modified for Base.
 ///
@@ -57,7 +57,7 @@ impl BaseReceiptEnvelope<Log> {
         status: bool,
         cumulative_gas_used: u64,
         logs: impl IntoIterator<Item = &'a Log>,
-        tx_type: BaseTxType,
+        tx_type: OpTxType,
         deposit_nonce: Option<u64>,
         deposit_receipt_version: Option<u64>,
     ) -> Self {
@@ -66,19 +66,19 @@ impl BaseReceiptEnvelope<Log> {
         let inner_receipt =
             Receipt { status: Eip658Value::Eip658(status), cumulative_gas_used, logs };
         match tx_type {
-            BaseTxType::Legacy => {
+            OpTxType::Legacy => {
                 Self::Legacy(ReceiptWithBloom { receipt: inner_receipt, logs_bloom })
             }
-            BaseTxType::Eip2930 => {
+            OpTxType::Eip2930 => {
                 Self::Eip2930(ReceiptWithBloom { receipt: inner_receipt, logs_bloom })
             }
-            BaseTxType::Eip1559 => {
+            OpTxType::Eip1559 => {
                 Self::Eip1559(ReceiptWithBloom { receipt: inner_receipt, logs_bloom })
             }
-            BaseTxType::Eip7702 => {
+            OpTxType::Eip7702 => {
                 Self::Eip7702(ReceiptWithBloom { receipt: inner_receipt, logs_bloom })
             }
-            BaseTxType::Deposit => {
+            OpTxType::Deposit => {
                 let inner = DepositReceiptWithBloom {
                     receipt: DepositReceipt {
                         inner: inner_receipt,
@@ -94,14 +94,14 @@ impl BaseReceiptEnvelope<Log> {
 }
 
 impl<T> BaseReceiptEnvelope<T> {
-    /// Return the [`BaseTxType`] of the inner receipt.
-    pub const fn tx_type(&self) -> BaseTxType {
+    /// Return the [`OpTxType`] of the inner receipt.
+    pub const fn tx_type(&self) -> OpTxType {
         match self {
-            Self::Legacy(_) => BaseTxType::Legacy,
-            Self::Eip2930(_) => BaseTxType::Eip2930,
-            Self::Eip1559(_) => BaseTxType::Eip1559,
-            Self::Eip7702(_) => BaseTxType::Eip7702,
-            Self::Deposit(_) => BaseTxType::Deposit,
+            Self::Legacy(_) => OpTxType::Legacy,
+            Self::Eip2930(_) => OpTxType::Eip2930,
+            Self::Eip1559(_) => OpTxType::Eip1559,
+            Self::Eip7702(_) => OpTxType::Eip7702,
+            Self::Deposit(_) => OpTxType::Deposit,
         }
     }
 
@@ -276,11 +276,11 @@ impl Decodable for BaseReceiptEnvelope {
 impl Typed2718 for BaseReceiptEnvelope {
     fn ty(&self) -> u8 {
         let ty = match self {
-            Self::Legacy(_) => BaseTxType::Legacy,
-            Self::Eip2930(_) => BaseTxType::Eip2930,
-            Self::Eip1559(_) => BaseTxType::Eip1559,
-            Self::Eip7702(_) => BaseTxType::Eip7702,
-            Self::Deposit(_) => BaseTxType::Deposit,
+            Self::Legacy(_) => OpTxType::Legacy,
+            Self::Eip2930(_) => OpTxType::Eip2930,
+            Self::Eip1559(_) => OpTxType::Eip1559,
+            Self::Eip7702(_) => OpTxType::Eip7702,
+            Self::Deposit(_) => OpTxType::Deposit,
         };
         ty as u8
     }
@@ -288,7 +288,7 @@ impl Typed2718 for BaseReceiptEnvelope {
 
 impl IsTyped2718 for BaseReceiptEnvelope {
     fn is_type(type_id: u8) -> bool {
-        <BaseTxType as IsTyped2718>::is_type(type_id)
+        <OpTxType as IsTyped2718>::is_type(type_id)
     }
 }
 
@@ -314,14 +314,14 @@ impl Encodable2718 for BaseReceiptEnvelope {
 impl Decodable2718 for BaseReceiptEnvelope {
     fn typed_decode(ty: u8, buf: &mut &[u8]) -> Eip2718Result<Self> {
         match ty.try_into().map_err(|_| Eip2718Error::UnexpectedType(ty))? {
-            BaseTxType::Legacy => {
+            OpTxType::Legacy => {
                 Err(alloy_rlp::Error::Custom("type-0 eip2718 transactions are not supported")
                     .into())
             }
-            BaseTxType::Eip1559 => Ok(Self::Eip1559(Decodable::decode(buf)?)),
-            BaseTxType::Eip7702 => Ok(Self::Eip7702(Decodable::decode(buf)?)),
-            BaseTxType::Eip2930 => Ok(Self::Eip2930(Decodable::decode(buf)?)),
-            BaseTxType::Deposit => Ok(Self::Deposit(Decodable::decode(buf)?)),
+            OpTxType::Eip1559 => Ok(Self::Eip1559(Decodable::decode(buf)?)),
+            OpTxType::Eip7702 => Ok(Self::Eip7702(Decodable::decode(buf)?)),
+            OpTxType::Eip2930 => Ok(Self::Eip2930(Decodable::decode(buf)?)),
+            OpTxType::Deposit => Ok(Self::Deposit(Decodable::decode(buf)?)),
         }
     }
 
@@ -413,27 +413,21 @@ mod tests {
     #[test]
     fn legacy_receipt_from_parts() {
         let receipt =
-            BaseReceiptEnvelope::from_parts(true, 100, vec![], BaseTxType::Legacy, None, None);
+            BaseReceiptEnvelope::from_parts(true, 100, vec![], OpTxType::Legacy, None, None);
         assert!(receipt.status());
         assert_eq!(receipt.cumulative_gas_used(), 100);
         assert_eq!(receipt.logs().len(), 0);
-        assert_eq!(receipt.tx_type(), BaseTxType::Legacy);
+        assert_eq!(receipt.tx_type(), OpTxType::Legacy);
     }
 
     #[test]
     fn deposit_receipt_from_parts() {
-        let receipt = BaseReceiptEnvelope::from_parts(
-            true,
-            100,
-            vec![],
-            BaseTxType::Deposit,
-            Some(1),
-            Some(2),
-        );
+        let receipt =
+            BaseReceiptEnvelope::from_parts(true, 100, vec![], OpTxType::Deposit, Some(1), Some(2));
         assert!(receipt.status());
         assert_eq!(receipt.cumulative_gas_used(), 100);
         assert_eq!(receipt.logs().len(), 0);
-        assert_eq!(receipt.tx_type(), BaseTxType::Deposit);
+        assert_eq!(receipt.tx_type(), OpTxType::Deposit);
         assert_eq!(receipt.deposit_nonce(), Some(1));
         assert_eq!(receipt.deposit_receipt_version(), Some(2));
     }

--- a/crates/common/consensus/src/receipts/receipt.rs
+++ b/crates/common/consensus/src/receipts/receipt.rs
@@ -12,7 +12,7 @@ use alloy_primitives::{Bloom, Log};
 use alloy_rlp::{Buf, BufMut, Decodable, Encodable, Header};
 
 use super::{BaseTxReceipt, DepositReceipt};
-use crate::{BaseReceiptEnvelope, BaseTxType};
+use crate::{BaseReceiptEnvelope, OpTxType};
 
 /// Transaction receipt for Base chains.
 ///
@@ -40,14 +40,14 @@ pub enum BaseReceipt<T = Log> {
 }
 
 impl<T> BaseReceipt<T> {
-    /// Returns [`BaseTxType`] of the receipt.
-    pub const fn tx_type(&self) -> BaseTxType {
+    /// Returns [`OpTxType`] of the receipt.
+    pub const fn tx_type(&self) -> OpTxType {
         match self {
-            Self::Legacy(_) => BaseTxType::Legacy,
-            Self::Eip2930(_) => BaseTxType::Eip2930,
-            Self::Eip1559(_) => BaseTxType::Eip1559,
-            Self::Eip7702(_) => BaseTxType::Eip7702,
-            Self::Deposit(_) => BaseTxType::Deposit,
+            Self::Legacy(_) => OpTxType::Legacy,
+            Self::Eip2930(_) => OpTxType::Eip2930,
+            Self::Eip1559(_) => OpTxType::Eip1559,
+            Self::Eip7702(_) => OpTxType::Eip7702,
+            Self::Deposit(_) => OpTxType::Deposit,
         }
     }
 
@@ -145,33 +145,33 @@ impl<T> BaseReceipt<T> {
     /// network header.
     pub fn rlp_decode_inner(
         buf: &mut &[u8],
-        tx_type: BaseTxType,
+        tx_type: OpTxType,
     ) -> alloy_rlp::Result<ReceiptWithBloom<Self>>
     where
         T: Decodable,
     {
         match tx_type {
-            BaseTxType::Legacy => {
+            OpTxType::Legacy => {
                 let ReceiptWithBloom { receipt, logs_bloom } =
                     RlpDecodableReceipt::rlp_decode_with_bloom(buf)?;
                 Ok(ReceiptWithBloom { receipt: Self::Legacy(receipt), logs_bloom })
             }
-            BaseTxType::Eip2930 => {
+            OpTxType::Eip2930 => {
                 let ReceiptWithBloom { receipt, logs_bloom } =
                     RlpDecodableReceipt::rlp_decode_with_bloom(buf)?;
                 Ok(ReceiptWithBloom { receipt: Self::Eip2930(receipt), logs_bloom })
             }
-            BaseTxType::Eip1559 => {
+            OpTxType::Eip1559 => {
                 let ReceiptWithBloom { receipt, logs_bloom } =
                     RlpDecodableReceipt::rlp_decode_with_bloom(buf)?;
                 Ok(ReceiptWithBloom { receipt: Self::Eip1559(receipt), logs_bloom })
             }
-            BaseTxType::Eip7702 => {
+            OpTxType::Eip7702 => {
                 let ReceiptWithBloom { receipt, logs_bloom } =
                     RlpDecodableReceipt::rlp_decode_with_bloom(buf)?;
                 Ok(ReceiptWithBloom { receipt: Self::Eip7702(receipt), logs_bloom })
             }
-            BaseTxType::Deposit => {
+            OpTxType::Deposit => {
                 let ReceiptWithBloom { receipt, logs_bloom } =
                     RlpDecodableReceipt::rlp_decode_with_bloom(buf)?;
                 Ok(ReceiptWithBloom { receipt: Self::Deposit(receipt), logs_bloom })
@@ -238,7 +238,7 @@ impl<T> BaseReceipt<T> {
     where
         T: Decodable,
     {
-        let tx_type = BaseTxType::decode(buf)?;
+        let tx_type = OpTxType::decode(buf)?;
         let status = Decodable::decode(buf)?;
         let cumulative_gas_used = Decodable::decode(buf)?;
         let logs = Decodable::decode(buf)?;
@@ -247,7 +247,7 @@ impl<T> BaseReceipt<T> {
         let mut deposit_receipt_version = None;
 
         // For deposit receipts, try to decode nonce and version if they exist
-        if tx_type == BaseTxType::Deposit && !buf.is_empty() {
+        if tx_type == OpTxType::Deposit && !buf.is_empty() {
             deposit_nonce = Some(Decodable::decode(buf)?);
             if !buf.is_empty() {
                 deposit_receipt_version = Some(Decodable::decode(buf)?);
@@ -255,11 +255,11 @@ impl<T> BaseReceipt<T> {
         }
 
         match tx_type {
-            BaseTxType::Legacy => Ok(Self::Legacy(Receipt { status, cumulative_gas_used, logs })),
-            BaseTxType::Eip2930 => Ok(Self::Eip2930(Receipt { status, cumulative_gas_used, logs })),
-            BaseTxType::Eip1559 => Ok(Self::Eip1559(Receipt { status, cumulative_gas_used, logs })),
-            BaseTxType::Eip7702 => Ok(Self::Eip7702(Receipt { status, cumulative_gas_used, logs })),
-            BaseTxType::Deposit => Ok(Self::Deposit(DepositReceipt {
+            OpTxType::Legacy => Ok(Self::Legacy(Receipt { status, cumulative_gas_used, logs })),
+            OpTxType::Eip2930 => Ok(Self::Eip2930(Receipt { status, cumulative_gas_used, logs })),
+            OpTxType::Eip1559 => Ok(Self::Eip1559(Receipt { status, cumulative_gas_used, logs })),
+            OpTxType::Eip7702 => Ok(Self::Eip7702(Receipt { status, cumulative_gas_used, logs })),
+            OpTxType::Deposit => Ok(Self::Deposit(DepositReceipt {
                 inner: Receipt { status, cumulative_gas_used, logs },
                 deposit_nonce,
                 deposit_receipt_version,
@@ -284,12 +284,12 @@ impl<T: Encodable> Eip2718EncodableReceipt for BaseReceipt<T> {
 
 impl<T: Decodable> Eip2718DecodableReceipt for BaseReceipt<T> {
     fn typed_decode_with_bloom(ty: u8, buf: &mut &[u8]) -> Eip2718Result<ReceiptWithBloom<Self>> {
-        let tx_type = BaseTxType::try_from(ty).map_err(|_| Eip2718Error::UnexpectedType(ty))?;
+        let tx_type = OpTxType::try_from(ty).map_err(|_| Eip2718Error::UnexpectedType(ty))?;
         Ok(Self::rlp_decode_inner(buf, tx_type)?)
     }
 
     fn fallback_decode_with_bloom(buf: &mut &[u8]) -> Eip2718Result<ReceiptWithBloom<Self>> {
-        Ok(Self::rlp_decode_inner(buf, BaseTxType::Legacy)?)
+        Ok(Self::rlp_decode_inner(buf, OpTxType::Legacy)?)
     }
 }
 
@@ -323,14 +323,14 @@ impl<T: Decodable> RlpDecodableReceipt for BaseReceipt<T> {
 
         // Legacy receipt, reuse initial buffer without advancing
         if header.list {
-            return Self::rlp_decode_inner(buf, BaseTxType::Legacy);
+            return Self::rlp_decode_inner(buf, OpTxType::Legacy);
         }
 
         // Otherwise, advance the buffer and try decoding type flag followed by receipt
         *buf = *header_buf;
 
         let remaining = buf.len();
-        let tx_type = BaseTxType::decode(buf)?;
+        let tx_type = OpTxType::decode(buf)?;
         let this = Self::rlp_decode_inner(buf, tx_type)?;
 
         if buf.len() + header.payload_length != remaining {
@@ -417,7 +417,7 @@ impl<T> Typed2718 for BaseReceipt<T> {
 
 impl<T> IsTyped2718 for BaseReceipt<T> {
     fn is_type(type_id: u8) -> bool {
-        <BaseTxType as IsTyped2718>::is_type(type_id)
+        <OpTxType as IsTyped2718>::is_type(type_id)
     }
 }
 

--- a/crates/common/consensus/src/reth_compat.rs
+++ b/crates/common/consensus/src/reth_compat.rs
@@ -23,15 +23,15 @@ use reth_codecs::{
 use reth_ethereum_primitives as _;
 
 use crate::{
-    BaseBlock, BasePooledTransaction, BaseReceipt, BaseTxEnvelope, BaseTxType,
-    BaseTypedTransaction, DEPOSIT_TX_TYPE_ID, DepositReceipt, TxDeposit,
+    BaseBlock, BasePooledTransaction, BaseReceipt, BaseTxEnvelope, BaseTypedTransaction,
+    DEPOSIT_TX_TYPE_ID, DepositReceipt, OpTxType, TxDeposit,
 };
 
 // ---------------------------------------------------------------------------
 // InMemorySize (reth-primitives-traits)
 // ---------------------------------------------------------------------------
 
-impl reth_primitives_traits::InMemorySize for BaseTxType {
+impl reth_primitives_traits::InMemorySize for OpTxType {
     #[inline]
     fn size(&self) -> usize {
         core::mem::size_of::<Self>()
@@ -207,10 +207,10 @@ impl Compact for TxDeposit {
 }
 
 // ---------------------------------------------------------------------------
-// Compact – BaseTxType
+// Compact – OpTxType
 // ---------------------------------------------------------------------------
 
-impl Compact for BaseTxType {
+impl Compact for OpTxType {
     fn to_compact<B>(&self, buf: &mut B) -> usize
     where
         B: BufMut + AsMut<[u8]>,
@@ -241,10 +241,10 @@ impl Compact for BaseTxType {
                     match extended_identifier {
                         EIP7702_TX_TYPE_ID => Self::Eip7702,
                         DEPOSIT_TX_TYPE_ID => Self::Deposit,
-                        _ => panic!("Unsupported BaseTxType identifier: {extended_identifier}"),
+                        _ => panic!("Unsupported OpTxType identifier: {extended_identifier}"),
                     }
                 }
-                _ => panic!("Unknown identifier for BaseTxType: {identifier}"),
+                _ => panic!("Unknown identifier for OpTxType: {identifier}"),
             },
             buf,
         )
@@ -272,25 +272,25 @@ impl Compact for BaseTypedTransaction {
     }
 
     fn from_compact(buf: &[u8], identifier: usize) -> (Self, &[u8]) {
-        let (tx_type, buf) = BaseTxType::from_compact(buf, identifier);
+        let (tx_type, buf) = OpTxType::from_compact(buf, identifier);
         match tx_type {
-            BaseTxType::Legacy => {
+            OpTxType::Legacy => {
                 let (tx, buf) = Compact::from_compact(buf, buf.len());
                 (Self::Legacy(tx), buf)
             }
-            BaseTxType::Eip2930 => {
+            OpTxType::Eip2930 => {
                 let (tx, buf) = Compact::from_compact(buf, buf.len());
                 (Self::Eip2930(tx), buf)
             }
-            BaseTxType::Eip1559 => {
+            OpTxType::Eip1559 => {
                 let (tx, buf) = Compact::from_compact(buf, buf.len());
                 (Self::Eip1559(tx), buf)
             }
-            BaseTxType::Eip7702 => {
+            OpTxType::Eip7702 => {
                 let (tx, buf) = Compact::from_compact(buf, buf.len());
                 (Self::Eip7702(tx), buf)
             }
-            BaseTxType::Deposit => {
+            OpTxType::Deposit => {
                 let (tx, buf) = Compact::from_compact(buf, buf.len());
                 (Self::Deposit(tx), buf)
             }
@@ -315,31 +315,31 @@ impl reth_codecs::alloy::transaction::ToTxCompact for BaseTxEnvelope {
 }
 
 impl reth_codecs::alloy::transaction::FromTxCompact for BaseTxEnvelope {
-    type TxType = BaseTxType;
+    type TxType = OpTxType;
 
-    fn from_tx_compact(buf: &[u8], tx_type: BaseTxType, signature: Signature) -> (Self, &[u8]) {
+    fn from_tx_compact(buf: &[u8], tx_type: OpTxType, signature: Signature) -> (Self, &[u8]) {
         match tx_type {
-            BaseTxType::Legacy => {
+            OpTxType::Legacy => {
                 let (tx, buf) = TxLegacy::from_compact(buf, buf.len());
                 let tx = Signed::new_unhashed(tx, signature);
                 (Self::Legacy(tx), buf)
             }
-            BaseTxType::Eip2930 => {
+            OpTxType::Eip2930 => {
                 let (tx, buf) = TxEip2930::from_compact(buf, buf.len());
                 let tx = Signed::new_unhashed(tx, signature);
                 (Self::Eip2930(tx), buf)
             }
-            BaseTxType::Eip1559 => {
+            OpTxType::Eip1559 => {
                 let (tx, buf) = TxEip1559::from_compact(buf, buf.len());
                 let tx = Signed::new_unhashed(tx, signature);
                 (Self::Eip1559(tx), buf)
             }
-            BaseTxType::Eip7702 => {
+            OpTxType::Eip7702 => {
                 let (tx, buf) = TxEip7702::from_compact(buf, buf.len());
                 let tx = Signed::new_unhashed(tx, signature);
                 (Self::Eip7702(tx), buf)
             }
-            BaseTxType::Deposit => {
+            OpTxType::Deposit => {
                 let (tx, buf) = TxDeposit::from_compact(buf, buf.len());
                 let tx = Sealed::new(tx);
                 (Self::Deposit(tx), buf)
@@ -399,13 +399,13 @@ impl Compact for BaseTxEnvelope {
     decompressor = reth_zstd_compressors::with_receipt_decompressor
 )]
 struct CompactBaseReceipt<'a> {
+    tx_type: OpTxType,
     success: bool,
     cumulative_gas_used: u64,
     #[expect(clippy::owned_cow)]
     logs: Cow<'a, Vec<alloy_primitives::Log>>,
     deposit_nonce: Option<u64>,
     deposit_receipt_version: Option<u64>,
-    tx_type: BaseTxType,
 }
 
 impl<'a> From<&'a BaseReceipt> for CompactBaseReceipt<'a> {
@@ -444,11 +444,11 @@ impl From<CompactBaseReceipt<'_>> for BaseReceipt {
             Receipt { status: success.into(), cumulative_gas_used, logs: logs.into_owned() };
 
         match tx_type {
-            BaseTxType::Legacy => Self::Legacy(inner),
-            BaseTxType::Eip2930 => Self::Eip2930(inner),
-            BaseTxType::Eip1559 => Self::Eip1559(inner),
-            BaseTxType::Eip7702 => Self::Eip7702(inner),
-            BaseTxType::Deposit => {
+            OpTxType::Legacy => Self::Legacy(inner),
+            OpTxType::Eip2930 => Self::Eip2930(inner),
+            OpTxType::Eip1559 => Self::Eip1559(inner),
+            OpTxType::Eip7702 => Self::Eip7702(inner),
+            OpTxType::Deposit => {
                 Self::Deposit(DepositReceipt { inner, deposit_nonce, deposit_receipt_version })
             }
         }

--- a/crates/common/consensus/src/transaction/deposit.rs
+++ b/crates/common/consensus/src/transaction/deposit.rs
@@ -11,7 +11,7 @@ use alloy_eips::{
 use alloy_primitives::{Address, B256, Bytes, ChainId, Signature, TxHash, TxKind, U256, keccak256};
 use alloy_rlp::{BufMut, Decodable, Encodable, Header};
 
-use super::BaseTxType;
+use super::OpTxType;
 
 /// Deposit transactions, also known as deposits are initiated on L1, and executed on L2.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Default)]
@@ -139,8 +139,8 @@ impl TxDeposit {
     }
 
     /// Get the transaction type
-    pub const fn tx_type(&self) -> BaseTxType {
-        BaseTxType::Deposit
+    pub const fn tx_type(&self) -> OpTxType {
+        OpTxType::Deposit
     }
 
     /// Create an rlp header for the transaction.
@@ -197,13 +197,13 @@ impl TxDeposit {
 
 impl Typed2718 for TxDeposit {
     fn ty(&self) -> u8 {
-        BaseTxType::Deposit as u8
+        OpTxType::Deposit as u8
     }
 }
 
 impl IsTyped2718 for TxDeposit {
     fn is_type(ty: u8) -> bool {
-        BaseTxType::Deposit as u8 == ty
+        OpTxType::Deposit as u8 == ty
     }
 }
 
@@ -279,7 +279,7 @@ impl Transaction for TxDeposit {
 
 impl Encodable2718 for TxDeposit {
     fn type_flag(&self) -> Option<u8> {
-        Some(BaseTxType::Deposit as u8)
+        Some(OpTxType::Deposit as u8)
     }
 
     fn encode_2718_len(&self) -> usize {
@@ -294,8 +294,8 @@ impl Encodable2718 for TxDeposit {
 
 impl Decodable2718 for TxDeposit {
     fn typed_decode(ty: u8, data: &mut &[u8]) -> Eip2718Result<Self> {
-        let ty: BaseTxType = ty.try_into().map_err(|_| Eip2718Error::UnexpectedType(ty))?;
-        if ty != BaseTxType::Deposit as u8 {
+        let ty: OpTxType = ty.try_into().map_err(|_| Eip2718Error::UnexpectedType(ty))?;
+        if ty != OpTxType::Deposit as u8 {
             return Err(Eip2718Error::UnexpectedType(ty as u8));
         }
         let tx = Self::decode(data)?;

--- a/crates/common/consensus/src/transaction/envelope.rs
+++ b/crates/common/consensus/src/transaction/envelope.rs
@@ -24,7 +24,7 @@ use crate::{
 ///
 /// [EIP-2718]: https://eips.ethereum.org/EIPS/eip-2718
 #[derive(Debug, Clone, TransactionEnvelope)]
-#[envelope(tx_type_name = BaseTxType, typed = BaseTypedTransaction, serde_cfg(feature = "serde"))]
+#[envelope(tx_type_name = OpTxType, typed = BaseTypedTransaction, serde_cfg(feature = "serde"))]
 pub enum BaseTxEnvelope {
     /// An untagged [`TxLegacy`].
     #[envelope(ty = 0)]
@@ -405,14 +405,14 @@ impl BaseTxEnvelope {
         }
     }
 
-    /// Return the [`BaseTxType`] of the inner txn.
-    pub const fn tx_type(&self) -> BaseTxType {
+    /// Return the [`OpTxType`] of the inner txn.
+    pub const fn tx_type(&self) -> OpTxType {
         match self {
-            Self::Legacy(_) => BaseTxType::Legacy,
-            Self::Eip2930(_) => BaseTxType::Eip2930,
-            Self::Eip1559(_) => BaseTxType::Eip1559,
-            Self::Eip7702(_) => BaseTxType::Eip7702,
-            Self::Deposit(_) => BaseTxType::Deposit,
+            Self::Legacy(_) => OpTxType::Legacy,
+            Self::Eip2930(_) => OpTxType::Eip2930,
+            Self::Eip1559(_) => OpTxType::Eip1559,
+            Self::Eip7702(_) => OpTxType::Eip7702,
+            Self::Deposit(_) => OpTxType::Deposit,
         }
     }
 

--- a/crates/common/consensus/src/transaction/mod.rs
+++ b/crates/common/consensus/src/transaction/mod.rs
@@ -7,7 +7,7 @@ mod tx_type;
 pub use tx_type::DEPOSIT_TX_TYPE_ID;
 
 mod envelope;
-pub use envelope::{BaseTransaction, BaseTxEnvelope, BaseTxType};
+pub use envelope::{BaseTransaction, BaseTxEnvelope, OpTxType};
 
 mod typed;
 pub use typed::BaseTypedTransaction;

--- a/crates/common/consensus/src/transaction/tx_type.rs
+++ b/crates/common/consensus/src/transaction/tx_type.rs
@@ -4,19 +4,19 @@ use core::fmt::Display;
 
 use alloy_consensus::InMemorySize;
 
-use crate::transaction::envelope::BaseTxType;
+use crate::transaction::envelope::OpTxType;
 
 /// Identifier for a deposit transaction
 pub const DEPOSIT_TX_TYPE_ID: u8 = 126; // 0x7E
 
 #[allow(clippy::derivable_impls)]
-impl Default for BaseTxType {
+impl Default for OpTxType {
     fn default() -> Self {
         Self::Legacy
     }
 }
 
-impl Display for BaseTxType {
+impl Display for OpTxType {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {
             Self::Legacy => write!(f, "legacy"),
@@ -28,18 +28,18 @@ impl Display for BaseTxType {
     }
 }
 
-impl BaseTxType {
+impl OpTxType {
     /// List of all variants.
     pub const ALL: [Self; 5] =
         [Self::Legacy, Self::Eip2930, Self::Eip1559, Self::Eip7702, Self::Deposit];
 
-    /// Returns `true` if the type is [`BaseTxType::Deposit`].
+    /// Returns `true` if the type is [`OpTxType::Deposit`].
     pub const fn is_deposit(&self) -> bool {
         matches!(self, Self::Deposit)
     }
 }
 
-impl InMemorySize for BaseTxType {
+impl InMemorySize for OpTxType {
     #[inline]
     fn size(&self) -> usize {
         core::mem::size_of::<Self>()
@@ -56,23 +56,23 @@ mod tests {
 
     #[test]
     fn test_all_tx_types() {
-        assert_eq!(BaseTxType::ALL.len(), 5);
+        assert_eq!(OpTxType::ALL.len(), 5);
         let all = vec![
-            BaseTxType::Legacy,
-            BaseTxType::Eip2930,
-            BaseTxType::Eip1559,
-            BaseTxType::Eip7702,
-            BaseTxType::Deposit,
+            OpTxType::Legacy,
+            OpTxType::Eip2930,
+            OpTxType::Eip1559,
+            OpTxType::Eip7702,
+            OpTxType::Deposit,
         ];
-        assert_eq!(BaseTxType::ALL.to_vec(), all);
+        assert_eq!(OpTxType::ALL.to_vec(), all);
     }
 
     #[test]
     fn tx_type_roundtrip() {
-        for &tx_type in &BaseTxType::ALL {
+        for &tx_type in &OpTxType::ALL {
             let mut buf = Vec::new();
             tx_type.encode(&mut buf);
-            let decoded = BaseTxType::decode(&mut &buf[..]).unwrap();
+            let decoded = OpTxType::decode(&mut &buf[..]).unwrap();
             assert_eq!(tx_type, decoded);
         }
     }

--- a/crates/common/consensus/src/transaction/typed.rs
+++ b/crates/common/consensus/src/transaction/typed.rs
@@ -7,7 +7,7 @@ use alloy_eips::Encodable2718;
 use alloy_primitives::{B256, ChainId, Signature, TxHash, bytes::BufMut};
 
 pub use crate::transaction::envelope::BaseTypedTransaction;
-use crate::{BaseTxEnvelope, BaseTxType, TxDeposit};
+use crate::{BaseTxEnvelope, OpTxType, TxDeposit};
 
 impl From<TxLegacy> for BaseTypedTransaction {
     fn from(tx: TxLegacy) -> Self {
@@ -73,14 +73,14 @@ impl From<BaseTypedTransaction> for alloy_rpc_types_eth::TransactionRequest {
 }
 
 impl BaseTypedTransaction {
-    /// Return the [`BaseTxType`] of the inner txn.
-    pub const fn tx_type(&self) -> BaseTxType {
+    /// Return the [`OpTxType`] of the inner txn.
+    pub const fn tx_type(&self) -> OpTxType {
         match self {
-            Self::Legacy(_) => BaseTxType::Legacy,
-            Self::Eip2930(_) => BaseTxType::Eip2930,
-            Self::Eip1559(_) => BaseTxType::Eip1559,
-            Self::Eip7702(_) => BaseTxType::Eip7702,
-            Self::Deposit(_) => BaseTxType::Deposit,
+            Self::Legacy(_) => OpTxType::Legacy,
+            Self::Eip2930(_) => OpTxType::Eip2930,
+            Self::Eip1559(_) => OpTxType::Eip1559,
+            Self::Eip7702(_) => OpTxType::Eip7702,
+            Self::Deposit(_) => OpTxType::Deposit,
         }
     }
 

--- a/crates/common/evm/src/receipt_builder.rs
+++ b/crates/common/evm/src/receipt_builder.rs
@@ -5,7 +5,7 @@ use core::fmt::Debug;
 
 use alloy_consensus::{Eip658Value, TransactionEnvelope};
 use alloy_evm::{Evm, eth::receipt_builder::ReceiptBuilderCtx};
-use base_common_consensus::{BaseReceiptEnvelope, BaseTxEnvelope, BaseTxType, DepositReceipt};
+use base_common_consensus::{BaseReceiptEnvelope, BaseTxEnvelope, DepositReceipt, OpTxType};
 
 /// Type that knows how to build a receipt based on execution result.
 #[auto_impl::auto_impl(&, Arc)]
@@ -42,10 +42,10 @@ impl BaseReceiptBuilder for AlloyReceiptBuilder {
 
     fn build_receipt<'a, E: Evm>(
         &self,
-        ctx: ReceiptBuilderCtx<'a, BaseTxType, E>,
-    ) -> Result<Self::Receipt, ReceiptBuilderCtx<'a, BaseTxType, E>> {
+        ctx: ReceiptBuilderCtx<'a, OpTxType, E>,
+    ) -> Result<Self::Receipt, ReceiptBuilderCtx<'a, OpTxType, E>> {
         match ctx.tx_type {
-            BaseTxType::Deposit => Err(ctx),
+            OpTxType::Deposit => Err(ctx),
             ty => {
                 let receipt = alloy_consensus::Receipt {
                     status: Eip658Value::Eip658(ctx.result.is_success()),
@@ -55,11 +55,11 @@ impl BaseReceiptBuilder for AlloyReceiptBuilder {
                 .with_bloom();
 
                 Ok(match ty {
-                    BaseTxType::Legacy => BaseReceiptEnvelope::Legacy(receipt),
-                    BaseTxType::Eip2930 => BaseReceiptEnvelope::Eip2930(receipt),
-                    BaseTxType::Eip1559 => BaseReceiptEnvelope::Eip1559(receipt),
-                    BaseTxType::Eip7702 => BaseReceiptEnvelope::Eip7702(receipt),
-                    BaseTxType::Deposit => unreachable!(),
+                    OpTxType::Legacy => BaseReceiptEnvelope::Legacy(receipt),
+                    OpTxType::Eip2930 => BaseReceiptEnvelope::Eip2930(receipt),
+                    OpTxType::Eip1559 => BaseReceiptEnvelope::Eip1559(receipt),
+                    OpTxType::Eip7702 => BaseReceiptEnvelope::Eip7702(receipt),
+                    OpTxType::Deposit => unreachable!(),
                 })
             }
         }

--- a/crates/common/network/src/base.rs
+++ b/crates/common/network/src/base.rs
@@ -3,7 +3,7 @@ use alloy_network::Network;
 use alloy_provider::fillers::{
     ChainIdFiller, GasFiller, JoinFill, NonceFiller, RecommendedFillers,
 };
-use base_common_consensus::{BaseReceipt, BaseTxType};
+use base_common_consensus::{BaseReceipt, OpTxType};
 
 /// Types for a Base chain network.
 #[derive(Clone, Copy, Debug)]
@@ -12,7 +12,7 @@ pub struct Base {
 }
 
 impl Network for Base {
-    type TxType = BaseTxType;
+    type TxType = OpTxType;
 
     type TxEnvelope = base_common_consensus::BaseTxEnvelope;
 

--- a/crates/common/network/src/builder.rs
+++ b/crates/common/network/src/builder.rs
@@ -2,7 +2,7 @@ use alloy_consensus::TxType;
 use alloy_network::{BuildResult, TransactionBuilder, TransactionBuilderError};
 use alloy_primitives::{Address, Bytes, ChainId, TxKind, U256};
 use alloy_rpc_types_eth::AccessList;
-use base_common_consensus::{BaseTxType, BaseTypedTransaction};
+use base_common_consensus::{BaseTypedTransaction, OpTxType};
 use base_common_rpc_types::BaseTransactionRequest;
 
 use crate::Base;
@@ -104,9 +104,9 @@ impl TransactionBuilder<Base> for BaseTransactionRequest {
         self.as_mut().set_access_list(access_list);
     }
 
-    fn complete_type(&self, ty: BaseTxType) -> Result<(), Vec<&'static str>> {
+    fn complete_type(&self, ty: OpTxType) -> Result<(), Vec<&'static str>> {
         match ty {
-            BaseTxType::Deposit => Err(vec!["not implemented for deposit tx"]),
+            OpTxType::Deposit => Err(vec!["not implemented for deposit tx"]),
             _ => {
                 let ty = TxType::try_from(ty as u8).map_err(|_| vec!["unsupported tx type"])?;
                 self.as_ref().complete_type(ty)
@@ -123,22 +123,22 @@ impl TransactionBuilder<Base> for BaseTransactionRequest {
     }
 
     #[doc(alias = "output_transaction_type")]
-    fn output_tx_type(&self) -> BaseTxType {
+    fn output_tx_type(&self) -> OpTxType {
         match self.as_ref().preferred_type() {
-            TxType::Eip1559 | TxType::Eip4844 => BaseTxType::Eip1559,
-            TxType::Eip2930 => BaseTxType::Eip2930,
-            TxType::Eip7702 => BaseTxType::Eip7702,
-            TxType::Legacy => BaseTxType::Legacy,
+            TxType::Eip1559 | TxType::Eip4844 => OpTxType::Eip1559,
+            TxType::Eip2930 => OpTxType::Eip2930,
+            TxType::Eip7702 => OpTxType::Eip7702,
+            TxType::Legacy => OpTxType::Legacy,
         }
     }
 
     #[doc(alias = "output_transaction_type_checked")]
-    fn output_tx_type_checked(&self) -> Option<BaseTxType> {
+    fn output_tx_type_checked(&self) -> Option<OpTxType> {
         self.as_ref().buildable_type().map(|tx_ty| match tx_ty {
-            TxType::Eip1559 | TxType::Eip4844 => BaseTxType::Eip1559,
-            TxType::Eip2930 => BaseTxType::Eip2930,
-            TxType::Eip7702 => BaseTxType::Eip7702,
-            TxType::Legacy => BaseTxType::Legacy,
+            TxType::Eip1559 | TxType::Eip4844 => OpTxType::Eip1559,
+            TxType::Eip2930 => OpTxType::Eip2930,
+            TxType::Eip7702 => OpTxType::Eip7702,
+            TxType::Legacy => OpTxType::Legacy,
         })
     }
 
@@ -148,7 +148,7 @@ impl TransactionBuilder<Base> for BaseTransactionRequest {
 
     fn build_unsigned(self) -> BuildResult<BaseTypedTransaction, Base> {
         if let Err((tx_type, missing)) = self.as_ref().missing_keys() {
-            let tx_type = BaseTxType::try_from(tx_type as u8).map_err(|e| {
+            let tx_type = OpTxType::try_from(tx_type as u8).map_err(|e| {
                 TransactionBuilderError::<Base>::custom(e).into_unbuilt(self.clone())
             })?;
             return Err(TransactionBuilderError::InvalidTransactionRequest(tx_type, missing)
@@ -185,11 +185,11 @@ mod tests {
     }
 
     #[rstest]
-    #[case::legacy(BaseTxType::Legacy)]
-    #[case::eip2930(BaseTxType::Eip2930)]
-    #[case::eip1559(BaseTxType::Eip1559)]
-    #[case::eip7702(BaseTxType::Eip7702)]
-    fn complete_type_delegates_for_eth_types(#[case] ty: BaseTxType) {
+    #[case::legacy(OpTxType::Legacy)]
+    #[case::eip2930(OpTxType::Eip2930)]
+    #[case::eip1559(OpTxType::Eip1559)]
+    #[case::eip7702(OpTxType::Eip7702)]
+    fn complete_type_delegates_for_eth_types(#[case] ty: OpTxType) {
         let req = BaseTransactionRequest::default();
         // Should not panic — returns Ok or missing-fields Err from the inner request.
         let _ = req.complete_type(ty);
@@ -198,7 +198,7 @@ mod tests {
     #[test]
     fn complete_type_rejects_deposit() {
         let req = BaseTransactionRequest::default();
-        let err = req.complete_type(BaseTxType::Deposit).unwrap_err();
+        let err = req.complete_type(OpTxType::Deposit).unwrap_err();
         assert_eq!(err, vec!["not implemented for deposit tx"]);
     }
 
@@ -215,14 +215,14 @@ mod tests {
         let err = req.build_unsigned().unwrap_err();
         assert!(matches!(
             err.error,
-            TransactionBuilderError::InvalidTransactionRequest(BaseTxType::Eip1559, _)
+            TransactionBuilderError::InvalidTransactionRequest(OpTxType::Eip1559, _)
         ));
     }
 
     #[test]
     fn build_unsigned_returns_custom_error_for_unmappable_tx_type() {
         // Force preferred_type() to return TxType::Eip4844 (u8 = 3), which has
-        // no corresponding BaseTxType variant.
+        // no corresponding OpTxType variant.
         let mut req = BaseTransactionRequest::default();
         req.as_mut().blob_versioned_hashes = Some(vec![B256::ZERO]);
         let err = req.build_unsigned().unwrap_err();

--- a/crates/consensus/derive/src/stages/batch/batch_queue.rs
+++ b/crates/consensus/derive/src/stages/batch/batch_queue.rs
@@ -479,7 +479,7 @@ mod tests {
     use alloy_eips::{BlockNumHash, eip2718::Decodable2718};
     use alloy_primitives::{Address, B256, Bytes, TxKind, U256, address, b256};
     use alloy_rlp::{BytesMut, Encodable};
-    use base_common_consensus::{BaseBlock, BaseTxEnvelope, BaseTxType, TxDeposit};
+    use base_common_consensus::{BaseBlock, BaseTxEnvelope, OpTxType, TxDeposit};
     use base_consensus_genesis::{ChainGenesis, HardForkConfig, RollupConfig, SystemConfig};
     use base_protocol::{BatchReader, L1BlockInfoBedrock, L1BlockInfoTx};
     use tracing::Level;
@@ -1027,7 +1027,7 @@ mod tests {
         };
         let mut buf = BytesMut::new();
         tx.encode(&mut buf);
-        let prefixed = [&[BaseTxType::Deposit as u8], &buf[..]].concat();
+        let prefixed = [&[OpTxType::Deposit as u8], &buf[..]].concat();
         second_batch_txs.insert(0, Bytes::copy_from_slice(&prefixed));
         let mut mock = TestNextBatchProvider::new(batch_vec);
         let origin_check =

--- a/crates/consensus/protocol/src/attributes.rs
+++ b/crates/consensus/protocol/src/attributes.rs
@@ -1,6 +1,6 @@
 //! Base Payload attributes that reference the parent L2 block.
 
-use base_common_consensus::BaseTxType;
+use base_common_consensus::OpTxType;
 use base_common_rpc_types_engine::BasePayloadAttributes;
 
 use crate::{BlockInfo, L2BlockInfo};
@@ -66,16 +66,17 @@ impl AttributesWithParent {
         self.attributes
             .transactions
             .iter()
-            .all(|tx| tx.first().is_some_and(|tx| tx[0] == BaseTxType::Deposit as u8))
+            .all(|tx| tx.first().is_some_and(|tx| tx[0] == OpTxType::Deposit as u8))
     }
 
     /// Converts the [`AttributesWithParent`] into a deposits-only payload.
     pub fn as_deposits_only(&self) -> Self {
         let mut attributes = self.attributes.clone();
 
-        attributes.transactions.iter_mut().for_each(|txs| {
-            txs.retain(|tx| tx.first().copied() == Some(BaseTxType::Deposit as u8))
-        });
+        attributes
+            .transactions
+            .iter_mut()
+            .for_each(|txs| txs.retain(|tx| tx.first().copied() == Some(OpTxType::Deposit as u8)));
 
         Self {
             attributes,
@@ -117,11 +118,11 @@ mod tests {
     fn test_op_attributes_with_parent_as_deposits_only() {
         let attributes = BasePayloadAttributes {
             transactions: Some(vec![
-                vec![BaseTxType::Deposit as u8, 0x0, 0x10, 0x20].into(),
-                vec![BaseTxType::Legacy as u8, 0x0, 0x11, 0x21].into(),
-                vec![BaseTxType::Eip2930 as u8, 0x0, 0x12, 0x22].into(),
-                vec![BaseTxType::Eip1559 as u8, 0x0, 0x13, 0x23].into(),
-                vec![BaseTxType::Eip7702 as u8, 0x0, 0x14, 0x24].into(),
+                vec![OpTxType::Deposit as u8, 0x0, 0x10, 0x20].into(),
+                vec![OpTxType::Legacy as u8, 0x0, 0x11, 0x21].into(),
+                vec![OpTxType::Eip2930 as u8, 0x0, 0x12, 0x22].into(),
+                vec![OpTxType::Eip1559 as u8, 0x0, 0x13, 0x23].into(),
+                vec![OpTxType::Eip7702 as u8, 0x0, 0x14, 0x24].into(),
                 vec![].into(),
             ]),
             ..BasePayloadAttributes::default()
@@ -134,7 +135,7 @@ mod tests {
 
         assert_eq!(
             deposits_only_attributes.attributes().transactions,
-            Some(vec![vec![BaseTxType::Deposit as u8, 0x0, 0x10, 0x20].into()])
+            Some(vec![vec![OpTxType::Deposit as u8, 0x0, 0x10, 0x20].into()])
         );
     }
 
@@ -142,13 +143,13 @@ mod tests {
     fn test_op_attributes_with_parent_as_deposits_multi_deposits() {
         let attributes = BasePayloadAttributes {
             transactions: Some(vec![
-                vec![BaseTxType::Deposit as u8, 0x0, 0x10, 0x20].into(),
-                vec![BaseTxType::Legacy as u8, 0x0, 0x11, 0x21].into(),
-                vec![BaseTxType::Eip2930 as u8, 0x0, 0x12, 0x22].into(),
-                vec![BaseTxType::Deposit as u8, 0x98, 0x21, 0x31].into(),
-                vec![BaseTxType::Eip1559 as u8, 0x0, 0x13, 0x23].into(),
-                vec![BaseTxType::Eip7702 as u8, 0x0, 0x14, 0x24].into(),
-                vec![BaseTxType::Deposit as u8, 0x56, 0x31, 0x41].into(),
+                vec![OpTxType::Deposit as u8, 0x0, 0x10, 0x20].into(),
+                vec![OpTxType::Legacy as u8, 0x0, 0x11, 0x21].into(),
+                vec![OpTxType::Eip2930 as u8, 0x0, 0x12, 0x22].into(),
+                vec![OpTxType::Deposit as u8, 0x98, 0x21, 0x31].into(),
+                vec![OpTxType::Eip1559 as u8, 0x0, 0x13, 0x23].into(),
+                vec![OpTxType::Eip7702 as u8, 0x0, 0x14, 0x24].into(),
+                vec![OpTxType::Deposit as u8, 0x56, 0x31, 0x41].into(),
                 vec![].into(),
             ]),
             ..BasePayloadAttributes::default()
@@ -162,9 +163,9 @@ mod tests {
         assert_eq!(
             deposits_only_attributes.attributes().transactions,
             Some(vec![
-                vec![BaseTxType::Deposit as u8, 0x0, 0x10, 0x20].into(),
-                vec![BaseTxType::Deposit as u8, 0x98, 0x21, 0x31].into(),
-                vec![BaseTxType::Deposit as u8, 0x56, 0x31, 0x41].into(),
+                vec![OpTxType::Deposit as u8, 0x0, 0x10, 0x20].into(),
+                vec![OpTxType::Deposit as u8, 0x98, 0x21, 0x31].into(),
+                vec![OpTxType::Deposit as u8, 0x56, 0x31, 0x41].into(),
             ])
         );
     }
@@ -175,10 +176,10 @@ mod tests {
     fn test_op_attributes_with_parent_as_deposits_no_deposits() {
         let attributes = BasePayloadAttributes {
             transactions: Some(vec![
-                vec![BaseTxType::Legacy as u8, 0x0, 0x11, 0x21].into(),
-                vec![BaseTxType::Eip2930 as u8, 0x0, 0x12, 0x22].into(),
-                vec![BaseTxType::Eip1559 as u8, 0x0, 0x13, 0x23].into(),
-                vec![BaseTxType::Eip7702 as u8, 0x0, 0x14, 0x24].into(),
+                vec![OpTxType::Legacy as u8, 0x0, 0x11, 0x21].into(),
+                vec![OpTxType::Eip2930 as u8, 0x0, 0x12, 0x22].into(),
+                vec![OpTxType::Eip1559 as u8, 0x0, 0x13, 0x23].into(),
+                vec![OpTxType::Eip7702 as u8, 0x0, 0x14, 0x24].into(),
                 vec![].into(),
             ]),
             ..BasePayloadAttributes::default()
@@ -196,9 +197,9 @@ mod tests {
     fn test_op_attributes_with_parent_as_deposits_only_deposits() {
         let attributes = BasePayloadAttributes {
             transactions: Some(vec![
-                vec![BaseTxType::Deposit as u8, 0x0, 0x10, 0x20].into(),
-                vec![BaseTxType::Deposit as u8, 0x98, 0x21, 0x31].into(),
-                vec![BaseTxType::Deposit as u8, 0x56, 0x31, 0x41].into(),
+                vec![OpTxType::Deposit as u8, 0x0, 0x10, 0x20].into(),
+                vec![OpTxType::Deposit as u8, 0x98, 0x21, 0x31].into(),
+                vec![OpTxType::Deposit as u8, 0x56, 0x31, 0x41].into(),
                 vec![].into(),
             ]),
             ..BasePayloadAttributes::default()
@@ -212,9 +213,9 @@ mod tests {
         assert_eq!(
             deposits_only_attributes.attributes().transactions,
             Some(vec![
-                vec![BaseTxType::Deposit as u8, 0x0, 0x10, 0x20].into(),
-                vec![BaseTxType::Deposit as u8, 0x98, 0x21, 0x31].into(),
-                vec![BaseTxType::Deposit as u8, 0x56, 0x31, 0x41].into(),
+                vec![OpTxType::Deposit as u8, 0x0, 0x10, 0x20].into(),
+                vec![OpTxType::Deposit as u8, 0x98, 0x21, 0x31].into(),
+                vec![OpTxType::Deposit as u8, 0x56, 0x31, 0x41].into(),
             ])
         );
     }

--- a/crates/consensus/protocol/src/batch/single.rs
+++ b/crates/consensus/protocol/src/batch/single.rs
@@ -5,7 +5,7 @@ use alloc::vec::Vec;
 use alloy_eips::BlockNumHash;
 use alloy_primitives::{BlockHash, Bytes};
 use alloy_rlp::{RlpDecodable, RlpEncodable};
-use base_common_consensus::BaseTxType;
+use base_common_consensus::OpTxType;
 use base_consensus_genesis::RollupConfig;
 use tracing::warn;
 
@@ -170,12 +170,12 @@ impl SingleBatch {
             if tx.is_empty() {
                 return BatchValidity::Drop(BatchDropReason::EmptyTransaction);
             }
-            if tx.as_ref().first() == Some(&(BaseTxType::Deposit as u8)) {
+            if tx.as_ref().first() == Some(&(OpTxType::Deposit as u8)) {
                 return BatchValidity::Drop(BatchDropReason::DepositTransaction);
             }
             // If isthmus is not active yet and the transaction is a 7702, drop the batch.
             if !cfg.is_isthmus_active(self.timestamp)
-                && tx.as_ref().first() == Some(&(BaseTxType::Eip7702 as u8))
+                && tx.as_ref().first() == Some(&(OpTxType::Eip7702 as u8))
             {
                 return BatchValidity::Drop(BatchDropReason::Eip7702PreIsthmus);
             }

--- a/crates/consensus/protocol/src/batch/span.rs
+++ b/crates/consensus/protocol/src/batch/span.rs
@@ -9,7 +9,7 @@ use alloc::vec::Vec;
 
 use alloy_eips::eip2718::Encodable2718;
 use alloy_primitives::FixedBytes;
-use base_common_consensus::BaseTxType;
+use base_common_consensus::OpTxType;
 use base_consensus_genesis::RollupConfig;
 use tracing::{info, warn};
 
@@ -498,7 +498,7 @@ impl SpanBatch {
                     );
                     return BatchValidity::Drop(BatchDropReason::EmptyTransaction);
                 }
-                if tx.as_ref().first() == Some(&(BaseTxType::Deposit as u8)) {
+                if tx.as_ref().first() == Some(&(OpTxType::Deposit as u8)) {
                     warn!(
                         target: "batch_span",
                         "sequencers may not embed any deposits into batch data, but found tx that has one, tx_index: {}",
@@ -509,7 +509,7 @@ impl SpanBatch {
 
                 // If isthmus is not active yet and the transaction is a 7702, drop the batch.
                 if !cfg.is_isthmus_active(batch.timestamp)
-                    && tx.as_ref().first() == Some(&(BaseTxType::Eip7702 as u8))
+                    && tx.as_ref().first() == Some(&(OpTxType::Eip7702 as u8))
                 {
                     warn!(target: "batch_span", tx_index = i, "EIP-7702 transactions are not supported pre-isthmus");
                     return BatchValidity::Drop(BatchDropReason::Eip7702PreIsthmus);
@@ -1963,7 +1963,7 @@ mod tests {
         let second = SpanBatchElement {
             epoch_num: 10,
             timestamp: 20,
-            transactions: vec![Bytes::copy_from_slice(&[BaseTxType::Deposit as u8])],
+            transactions: vec![Bytes::copy_from_slice(&[OpTxType::Deposit as u8])],
         };
         let third =
             SpanBatchElement { epoch_num: 11, timestamp: 20, transactions: vec![filler_bytes] };

--- a/crates/consensus/upgrades/src/test_utils.rs
+++ b/crates/consensus/upgrades/src/test_utils.rs
@@ -2,7 +2,7 @@
 
 use alloy_eips::Encodable2718;
 use alloy_primitives::{Address, B256, keccak256};
-use base_common_consensus::{BaseTxType, TxDeposit};
+use base_common_consensus::{OpTxType, TxDeposit};
 use base_common_evm::{DefaultOp, DepositTransactionParts, OpSpecId};
 use revm::{
     Context, ExecuteCommitEvm, MainBuilder,
@@ -33,7 +33,7 @@ pub fn check_deployment_code(
             tx.enveloped_tx = Some(deployment_tx.encoded_2718().into());
 
             // Base meta
-            tx.base.tx_type = BaseTxType::Deposit as u8;
+            tx.base.tx_type = OpTxType::Deposit as u8;
             tx.base.caller = deployment_tx.from;
             tx.base.kind = deployment_tx.to;
             tx.base.value = deployment_tx.value;

--- a/crates/execution/engine-tree/src/cached_execution.rs
+++ b/crates/execution/engine-tree/src/cached_execution.rs
@@ -2,7 +2,7 @@
 
 use std::{collections::HashMap, fmt::Debug, sync::Arc};
 
-use base_common_consensus::{BaseReceipt, BaseTxEnvelope, BaseTxType};
+use base_common_consensus::{BaseReceipt, BaseTxEnvelope, OpTxType};
 use base_common_evm::{BaseBlockExecutor, BaseTxResult, OpHaltReason, OpTransaction};
 use base_execution_chainspec::BaseChainSpec;
 use base_execution_evm::OpRethReceiptBuilder;
@@ -34,7 +34,7 @@ impl<P> FlashblocksCachedExecutionProvider<P> {
     }
 }
 
-impl<P> CachedExecutionProvider<BaseTxResult<OpHaltReason, BaseTxType>>
+impl<P> CachedExecutionProvider<BaseTxResult<OpHaltReason, OpTxType>>
     for FlashblocksCachedExecutionProvider<P>
 where
     P: BlockNumReader,
@@ -45,7 +45,7 @@ where
         parent_block_hash: &B256,
         prev_cached_hash: Option<&B256>,
         tx_hash: &B256,
-    ) -> Option<BaseTxResult<OpHaltReason, BaseTxType>> {
+    ) -> Option<BaseTxResult<OpHaltReason, OpTxType>> {
         let flashblocks_state = self.flashblocks_state.as_ref()?;
 
         // if block_number is not found, we can't use cached execution
@@ -145,12 +145,12 @@ impl<'a, DB, E, C> BlockExecutor for CachedExecutor<E, C>
 where
     DB: Database + alloy_evm::Database + 'a,
     E: Evm<DB = &'a mut State<DB>, Tx = OpTransaction<TxEnv>>,
-    C: CachedExecutionProvider<BaseTxResult<E::HaltReason, BaseTxType>>,
+    C: CachedExecutionProvider<BaseTxResult<E::HaltReason, OpTxType>>,
 {
     type Transaction = BaseTxEnvelope;
     type Receipt = BaseReceipt;
     type Evm = E;
-    type Result = BaseTxResult<E::HaltReason, BaseTxType>;
+    type Result = BaseTxResult<E::HaltReason, OpTxType>;
 
     fn receipts(&self) -> &[Self::Receipt] {
         self.executor.receipts()

--- a/crates/execution/engine-tree/src/validator.rs
+++ b/crates/execution/engine-tree/src/validator.rs
@@ -18,7 +18,7 @@ use alloy_eips::eip2718::Decodable2718;
 use alloy_evm::Evm;
 use alloy_primitives::B256;
 use base_common_consensus::{
-    BaseBlock, BasePrimitives, BaseReceipt, BaseTransactionSigned, BaseTxType,
+    BaseBlock, BasePrimitives, BaseReceipt, BaseTransactionSigned, OpTxType,
 };
 use base_common_evm::{
     BaseBlockExecutor, BaseBlockExecutorFactory, BaseEvm, BaseEvmFactory, BaseTxResult,
@@ -148,7 +148,7 @@ where
                 BaseEvmFactory,
             >,
         > + 'static,
-    C: CachedExecutionProvider<BaseTxResult<OpHaltReason, BaseTxType>> + Clone,
+    C: CachedExecutionProvider<BaseTxResult<OpHaltReason, OpTxType>> + Clone,
 {
     /// Creates a new `TreePayloadValidator`.
     #[allow(clippy::too_many_arguments)]
@@ -1493,7 +1493,7 @@ where
             BuiltPayload: BuiltPayload<Primitives = BasePrimitives>,
             ExecutionData = ExecutionData,
         >,
-    C: CachedExecutionProvider<BaseTxResult<OpHaltReason, BaseTxType>>
+    C: CachedExecutionProvider<BaseTxResult<OpHaltReason, OpTxType>>
         + Clone
         + Send
         + Sync

--- a/crates/execution/evm/src/receipts.rs
+++ b/crates/execution/evm/src/receipts.rs
@@ -1,6 +1,6 @@
 use alloy_consensus::{Eip658Value, Receipt};
 use alloy_evm::eth::receipt_builder::ReceiptBuilderCtx;
-use base_common_consensus::{BaseReceipt, BaseTransactionSigned, BaseTxType};
+use base_common_consensus::{BaseReceipt, BaseTransactionSigned, OpTxType};
 use base_common_evm::BaseReceiptBuilder;
 use reth_evm::Evm;
 
@@ -16,10 +16,10 @@ impl BaseReceiptBuilder for OpRethReceiptBuilder {
 
     fn build_receipt<'a, E: Evm>(
         &self,
-        ctx: ReceiptBuilderCtx<'a, BaseTxType, E>,
-    ) -> Result<Self::Receipt, ReceiptBuilderCtx<'a, BaseTxType, E>> {
+        ctx: ReceiptBuilderCtx<'a, OpTxType, E>,
+    ) -> Result<Self::Receipt, ReceiptBuilderCtx<'a, OpTxType, E>> {
         match ctx.tx_type {
-            BaseTxType::Deposit => Err(ctx),
+            OpTxType::Deposit => Err(ctx),
             ty => {
                 let receipt = Receipt {
                     // Success flag was added in `EIP-658: Embedding transaction status code in
@@ -30,11 +30,11 @@ impl BaseReceiptBuilder for OpRethReceiptBuilder {
                 };
 
                 Ok(match ty {
-                    BaseTxType::Legacy => BaseReceipt::Legacy(receipt),
-                    BaseTxType::Eip1559 => BaseReceipt::Eip1559(receipt),
-                    BaseTxType::Eip2930 => BaseReceipt::Eip2930(receipt),
-                    BaseTxType::Eip7702 => BaseReceipt::Eip7702(receipt),
-                    BaseTxType::Deposit => unreachable!(),
+                    OpTxType::Legacy => BaseReceipt::Legacy(receipt),
+                    OpTxType::Eip1559 => BaseReceipt::Eip1559(receipt),
+                    OpTxType::Eip2930 => BaseReceipt::Eip2930(receipt),
+                    OpTxType::Eip7702 => BaseReceipt::Eip7702(receipt),
+                    OpTxType::Deposit => unreachable!(),
                 })
             }
         }

--- a/crates/execution/flashblocks/src/pending_blocks.rs
+++ b/crates/execution/flashblocks/src/pending_blocks.rs
@@ -11,7 +11,7 @@ use alloy_rpc_types::{BlockTransactions, Withdrawal, state::StateOverride};
 use alloy_rpc_types_engine::PayloadId;
 use alloy_rpc_types_eth::{Filter, Header as RPCHeader, Log};
 use arc_swap::Guard;
-use base_common_consensus::BaseTxType;
+use base_common_consensus::OpTxType;
 use base_common_evm::{BaseTxResult, OpHaltReason};
 use base_common_flashblocks::Flashblock;
 use base_common_network::Base;
@@ -351,10 +351,7 @@ impl PendingBlocks {
     }
 
     /// Returns the receipt and state for a transaction.
-    pub fn get_op_tx_result(
-        &self,
-        tx_hash: &B256,
-    ) -> Option<BaseTxResult<OpHaltReason, BaseTxType>> {
+    pub fn get_op_tx_result(&self, tx_hash: &B256) -> Option<BaseTxResult<OpHaltReason, OpTxType>> {
         let (((result, state), tx), sender) = self
             .get_transaction_result(tx_hash)
             .zip(self.get_transaction_state(tx_hash))
@@ -835,7 +832,7 @@ mod tests {
         let result = pending_blocks.get_op_tx_result(&tx_hash).expect("should return tx result");
 
         assert_eq!(result.inner.blob_gas_used, da_footprint);
-        assert_eq!(result.inner.tx_type, BaseTxType::Legacy);
+        assert_eq!(result.inner.tx_type, OpTxType::Legacy);
         assert!(!result.is_deposit);
         assert_eq!(result.sender, test_sender());
         assert_eq!(result.inner.result.result.gas_used(), 21000);
@@ -848,7 +845,7 @@ mod tests {
         let result = pending_blocks.get_op_tx_result(&tx_hash).expect("should return tx result");
 
         assert_eq!(result.inner.blob_gas_used, 0);
-        assert_eq!(result.inner.tx_type, BaseTxType::Deposit);
+        assert_eq!(result.inner.tx_type, OpTxType::Deposit);
         assert!(result.is_deposit);
         assert_eq!(result.sender, test_sender());
         assert_eq!(result.inner.result.result.gas_used(), 21000);

--- a/crates/execution/flashblocks/src/receipt_builder.rs
+++ b/crates/execution/flashblocks/src/receipt_builder.rs
@@ -5,7 +5,7 @@
 
 use alloy_consensus::{Eip658Value, Receipt, transaction::Recovered};
 use base_common_chains::Upgrades;
-use base_common_consensus::{BaseReceipt, BaseTxEnvelope, BaseTxType, DepositReceipt};
+use base_common_consensus::{BaseReceipt, BaseTxEnvelope, DepositReceipt, OpTxType};
 use reth_evm::Evm;
 use revm::{Database, context::result::ExecutionResult};
 
@@ -87,7 +87,7 @@ impl<C: Upgrades> UnifiedReceiptBuilder<C> {
             logs: result.logs().to_vec(),
         };
 
-        if tx_type == BaseTxType::Deposit {
+        if tx_type == OpTxType::Deposit {
             // Handle deposit transaction
             let is_canyon_active = self.chain_spec.is_canyon_active_at_timestamp(timestamp);
             let is_regolith_active = self.chain_spec.is_regolith_active_at_timestamp(timestamp);
@@ -113,11 +113,11 @@ impl<C: Upgrades> UnifiedReceiptBuilder<C> {
         } else {
             // Handle non-deposit transaction
             Ok(match tx_type {
-                BaseTxType::Legacy => BaseReceipt::Legacy(receipt),
-                BaseTxType::Eip2930 => BaseReceipt::Eip2930(receipt),
-                BaseTxType::Eip1559 => BaseReceipt::Eip1559(receipt),
-                BaseTxType::Eip7702 => BaseReceipt::Eip7702(receipt),
-                BaseTxType::Deposit => unreachable!(),
+                OpTxType::Legacy => BaseReceipt::Legacy(receipt),
+                OpTxType::Eip2930 => BaseReceipt::Eip2930(receipt),
+                OpTxType::Eip1559 => BaseReceipt::Eip1559(receipt),
+                OpTxType::Eip7702 => BaseReceipt::Eip7702(receipt),
+                OpTxType::Deposit => unreachable!(),
             })
         }
     }

--- a/crates/proof/driver/src/core.rs
+++ b/crates/proof/driver/src/core.rs
@@ -6,7 +6,7 @@ use core::fmt::Debug;
 use alloy_consensus::BlockBody;
 use alloy_primitives::{B256, Bytes};
 use alloy_rlp::Decodable;
-use base_common_consensus::{BaseBlock, BaseTxEnvelope, BaseTxType};
+use base_common_consensus::{BaseBlock, BaseTxEnvelope, OpTxType};
 use base_consensus_derive::{Pipeline, PipelineError, PipelineErrorKind, Signal, SignalReceiver};
 use base_consensus_genesis::RollupConfig;
 use base_proof_executor::BlockBuildingOutcome;
@@ -119,7 +119,7 @@ where
                         // Strip out all transactions that are not deposits.
                         attributes.transactions = attributes.transactions.map(|txs| {
                             txs.into_iter()
-                                .filter(|tx| !tx.is_empty() && tx[0] == BaseTxType::Deposit as u8)
+                                .filter(|tx| !tx.is_empty() && tx[0] == OpTxType::Deposit as u8)
                                 .collect::<Vec<_>>()
                         });
 


### PR DESCRIPTION
## Summary

- Renames `BaseTxType` back to `OpTxType` across the entire workspace (24 files), reverting the type name change from #2160
- Restores the `tx_type` field to its original first position in `CompactBaseReceipt` (it had been moved to last during the rename)
- All `From` impl field orderings already had `tx_type` first and remain correct