### PR TITLE
feat: allow RPC timeout to be configurable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3470,6 +3470,7 @@ dependencies = [
  "tokio-stream",
  "tokio-util",
  "tower",
+ "tower-http",
  "tracing",
  "url",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -457,7 +457,7 @@ tower = "0.5"
 http-body = "1.0"
 hyper-util = "0.1.11"
 http-body-util = "0.1.3"
-tower-http = { version = "0.6", features = ["limit"] }
+tower-http = { version = "0.6", features = ["limit", "timeout"] }
 axum = { version = "0.8.3", default-features = false }
 
 # p2p

--- a/crates/client/cli/src/rpc.rs
+++ b/crates/client/cli/src/rpc.rs
@@ -5,6 +5,7 @@
 use std::{
     net::{IpAddr, SocketAddr},
     path::PathBuf,
+    time::Duration,
 };
 
 use base_consensus_rpc::RpcBuilder;
@@ -38,6 +39,9 @@ pub struct RpcArgs {
     /// Enables development RPC endpoints for engine state introspection
     #[arg(long = "rpc.dev-enabled", default_value = "false", env = "BASE_NODE_RPC_DEV_ENABLED")]
     pub dev_enabled: bool,
+    /// HTTP request timeout in seconds for the RPC server.
+    #[arg(long = "rpc.timeout", default_value = "60", env = "BASE_NODE_RPC_TIMEOUT")]
+    pub http_timeout_secs: u64,
 }
 
 impl Default for RpcArgs {
@@ -60,6 +64,7 @@ impl From<RpcArgs> for Option<RpcBuilder> {
             admin_persistence: args.admin_persistence,
             ws_enabled: args.ws_enabled,
             dev_enabled: args.dev_enabled,
+            http_timeout: Duration::from_secs(args.http_timeout_secs),
         })
     }
 }

--- a/crates/consensus/rpc/src/config.rs
+++ b/crates/consensus/rpc/src/config.rs
@@ -1,6 +1,6 @@
 //! Contains the RPC Configuration.
 
-use std::{net::SocketAddr, path::PathBuf};
+use std::{net::SocketAddr, path::PathBuf, time::Duration};
 
 /// The RPC configuration.
 #[derive(Debug, Clone)]
@@ -18,6 +18,8 @@ pub struct RpcBuilder {
     pub ws_enabled: bool,
     /// Enable development RPC endpoints
     pub dev_enabled: bool,
+    /// HTTP request timeout for the RPC server.
+    pub http_timeout: Duration,
 }
 
 impl RpcBuilder {

--- a/crates/consensus/service/Cargo.toml
+++ b/crates/consensus/service/Cargo.toml
@@ -68,6 +68,7 @@ http-body-util.workspace = true
 tracing = { workspace = true, features = ["std"] }
 strum = { workspace = true, features = ["derive"] }
 thiserror = { workspace = true, features = ["std"] }
+tower-http.workspace = true
 derive_more = { workspace = true, features = ["debug", "eq"] }
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
 jsonrpsee = { workspace = true, features = ["server", "http-client"] }

--- a/crates/consensus/service/src/actors/rpc/actor.rs
+++ b/crates/consensus/service/src/actors/rpc/actor.rs
@@ -1,6 +1,6 @@
 //! RPC Server Actor
 
-use std::{sync::Arc, time::Duration};
+use std::sync::Arc;
 
 use async_trait::async_trait;
 use base_consensus_gossip::P2pRpcRequest;
@@ -12,12 +12,14 @@ use base_consensus_rpc::{
 use base_consensus_safedb::SafeDBReader;
 use base_health::EthHealthCheckLayer;
 use derive_more::Constructor;
+use http::StatusCode;
 use jsonrpsee::{
     RpcModule,
     server::{Server, ServerHandle, middleware::http::ProxyGetRequestLayer},
 };
 use tokio::sync::mpsc;
 use tokio_util::sync::{CancellationToken, WaitForCancellationFuture};
+use tower_http::timeout::TimeoutLayer;
 
 use crate::{NodeActor, RpcActorError, actors::CancellableContext};
 
@@ -72,7 +74,7 @@ async fn launch(
             ProxyGetRequestLayer::new([("/healthz", "healthz")])
                 .expect("Critical: Failed to build GET method proxy"),
         )
-        .timeout(Duration::from_secs(2));
+        .layer(TimeoutLayer::with_status_code(StatusCode::REQUEST_TIMEOUT, config.http_timeout));
     let server = Server::builder().set_http_middleware(middleware).build(config.socket).await?;
 
     if let Ok(addr) = server.local_addr() {
@@ -169,7 +171,7 @@ where
 
 #[cfg(test)]
 mod tests {
-    use std::net::SocketAddr;
+    use std::{net::SocketAddr, time::Duration};
 
     use super::*;
 
@@ -182,6 +184,7 @@ mod tests {
             admin_persistence: None,
             ws_enabled: false,
             dev_enabled: false,
+            http_timeout: Duration::from_secs(60),
         };
         let result = launch(&launcher, RpcModule::new(())).await;
         assert!(result.is_ok());
@@ -196,6 +199,7 @@ mod tests {
             admin_persistence: None,
             ws_enabled: false,
             dev_enabled: false,
+            http_timeout: Duration::from_secs(60),
         };
         let mut modules = RpcModule::new(());
 

--- a/devnet/src/l2/in_process_consensus.rs
+++ b/devnet/src/l2/in_process_consensus.rs
@@ -7,6 +7,7 @@
 use std::{
     net::{IpAddr, Ipv4Addr, SocketAddr},
     sync::Arc,
+    time::Duration,
 };
 
 use alloy_genesis::ChainConfig;
@@ -158,6 +159,7 @@ impl InProcessConsensus {
             admin_persistence: None,
             ws_enabled: false,
             dev_enabled: false,
+            http_timeout: Duration::from_secs(60),
         };
 
         let mut builder = RollupNodeBuilder::new(


### PR DESCRIPTION
Makes RPC timeout configurable and uses layer that returns a status code instead of closing the connection.