### PR TITLE
feat(builder): track late metering signals

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2855,6 +2855,8 @@ dependencies = [
  "base-bundles",
  "base-node-runner",
  "jsonrpsee",
+ "metrics",
+ "metrics-exporter-prometheus",
  "moka",
  "tracing",
 ]

--- a/crates/builder/core/src/flashblocks/context.rs
+++ b/crates/builder/core/src/flashblocks/context.rs
@@ -7,7 +7,9 @@ use std::{
 use alloy_consensus::{Eip658Value, Transaction};
 use alloy_eips::{Encodable2718, Typed2718};
 use alloy_evm::Database;
-use alloy_primitives::{B256, BlockHash, Bytes, TxHash, U256};
+#[cfg(any(test, feature = "test-utils"))]
+use alloy_primitives::B256;
+use alloy_primitives::{BlockHash, Bytes, TxHash, U256};
 use alloy_rpc_types_eth::Withdrawals;
 use base_access_lists::FBALBuilderDb;
 use base_common_chains::Upgrades;
@@ -703,6 +705,7 @@ impl OpPayloadBuilderCtx {
                 let tx_age_ms = now_ms.saturating_sub(tx_received_at_ms);
                 if tx_age_ms < wait_duration.as_millis() {
                     log_txn(Err(TxnExecutionError::MeteringDataPending));
+                    self.builder_config.metering_provider.mark_metering_data_pending(tx_hash);
                     BuilderMetrics::metering_data_pending_skip().increment(1);
                     best_txs.mark_invalid(tx.signer(), tx.nonce());
                     continue;

--- a/crates/builder/core/src/flashblocks/payload.rs
+++ b/crates/builder/core/src/flashblocks/payload.rs
@@ -613,7 +613,7 @@ where
             .map(|tx| tx.tx_hash())
             .collect::<Vec<_>>();
         best_txs.mark_committed(&new_transactions);
-        self.config.metering_provider.remove(&new_transactions);
+        self.config.metering_provider.mark_payload_included(&new_transactions);
         self.pool.prune_transactions(new_transactions);
 
         // Track executed nonces incrementally for the next flashblock's update_accounts call.

--- a/crates/builder/core/src/metering.rs
+++ b/crates/builder/core/src/metering.rs
@@ -25,6 +25,12 @@ pub trait MeteringProvider: Debug + Send + Sync + 'static {
     /// the cached metering entries.
     fn remove(&self, _tx_hashes: &[TxHash]) {}
 
+    /// Marks that metering data was needed for a transaction but not yet available.
+    ///
+    /// Implementations can use this hook to measure how long metering arrives after the builder
+    /// first encounters a `MeteringDataPending` decision.
+    fn mark_metering_data_pending(&self, _tx_hash: TxHash) {}
+
     /// Marks transactions as included in the current payload and evicts their metering data.
     ///
     /// Implementations can use this hook to observe metering updates that arrive after payload

--- a/crates/builder/core/src/metering.rs
+++ b/crates/builder/core/src/metering.rs
@@ -21,10 +21,18 @@ pub trait MeteringProvider: Debug + Send + Sync + 'static {
 
     /// Removes metering data for the given transaction hashes.
     ///
-    /// Used to eagerly evict entries for transactions that have been included in
-    /// a flashblock so they don't occupy LRU slots that should go to pending
-    /// transactions.
+    /// Used for generic eviction paths where the builder no longer wants to retain
+    /// the cached metering entries.
     fn remove(&self, _tx_hashes: &[TxHash]) {}
+
+    /// Marks transactions as included in the current payload and evicts their metering data.
+    ///
+    /// Implementations can use this hook to observe metering updates that arrive after payload
+    /// inclusion without conflating them with other evictions, such as permanently rejected
+    /// transactions.
+    fn mark_payload_included(&self, tx_hashes: &[TxHash]) {
+        self.remove(tx_hashes);
+    }
 
     /// Clears all stored metering data.
     fn clear(&self) {}

--- a/crates/builder/core/src/metrics.rs
+++ b/crates/builder/core/src/metrics.rs
@@ -108,6 +108,8 @@ base_metrics::define_metrics! {
     rejection_cache_size: gauge,
     #[describe("Transactions skipped because metering data has not yet arrived")]
     metering_data_pending_skip: counter,
+    #[describe("Metering updates that arrived after the transaction was already included in a payload")]
+    metering_data_arrived_after_payload_inclusion: counter,
     #[describe("Transactions rejected by per-tx DA size limit")]
     tx_da_size_exceeded_total: counter,
     #[describe("Transactions rejected by block DA size limit")]

--- a/crates/builder/core/src/metrics.rs
+++ b/crates/builder/core/src/metrics.rs
@@ -110,6 +110,8 @@ base_metrics::define_metrics! {
     metering_data_pending_skip: counter,
     #[describe("Metering updates that arrived after the transaction was already included in a payload")]
     metering_data_arrived_after_payload_inclusion: counter,
+    #[describe("Milliseconds between payload inclusion and late metering arrival")]
+    metering_data_arrived_after_payload_inclusion_latency_ms: histogram,
     #[describe("Transactions rejected by per-tx DA size limit")]
     tx_da_size_exceeded_total: counter,
     #[describe("Transactions rejected by block DA size limit")]

--- a/crates/builder/core/src/metrics.rs
+++ b/crates/builder/core/src/metrics.rs
@@ -108,10 +108,10 @@ base_metrics::define_metrics! {
     rejection_cache_size: gauge,
     #[describe("Transactions skipped because metering data has not yet arrived")]
     metering_data_pending_skip: counter,
+    #[describe("Milliseconds between first MeteringDataPending skip and metering data arrival")]
+    metering_data_pending_lateness_ms: histogram,
     #[describe("Metering updates that arrived after the transaction was already included in a payload")]
     metering_data_arrived_after_payload_inclusion: counter,
-    #[describe("Milliseconds between payload inclusion and late metering arrival")]
-    metering_data_arrived_after_payload_inclusion_latency_ms: histogram,
     #[describe("Transactions rejected by per-tx DA size limit")]
     tx_da_size_exceeded_total: counter,
     #[describe("Transactions rejected by block DA size limit")]

--- a/crates/builder/metering/Cargo.toml
+++ b/crates/builder/metering/Cargo.toml
@@ -21,3 +21,5 @@ base-builder-core.workspace = true
 moka = { workspace = true, features = ["sync"] }
 
 [dev-dependencies]
+metrics.workspace = true
+metrics-exporter-prometheus.workspace = true

--- a/crates/builder/metering/src/store.rs
+++ b/crates/builder/metering/src/store.rs
@@ -18,9 +18,11 @@ use moka::{notification::RemovalCause, sync::Cache};
 pub struct MeteringStore {
     /// LRU cache mapping transaction hash to metering data.
     cache: Cache<TxHash, MeterBundleResponse>,
-    /// Recently included transaction hashes and inclusion times used to detect late metering
-    /// updates.
-    recently_included: Cache<TxHash, Instant>,
+    /// Recently included transaction hashes used to detect metering that arrived too late to help
+    /// the current payload.
+    recently_included: Cache<TxHash, ()>,
+    /// First observed `MeteringDataPending` timestamp for each transaction.
+    pending_since: Cache<TxHash, Instant>,
     /// Whether resource metering is enabled.
     metering_enabled: AtomicBool,
 }
@@ -30,6 +32,7 @@ impl core::fmt::Debug for MeteringStore {
         f.debug_struct("MeteringStore")
             .field("entries", &self.cache.entry_count())
             .field("recently_included", &self.recently_included.entry_count())
+            .field("pending_since", &self.pending_since.entry_count())
             .field("metering_enabled", &self.metering_enabled.load(Ordering::Relaxed))
             .finish()
     }
@@ -37,6 +40,7 @@ impl core::fmt::Debug for MeteringStore {
 
 impl MeteringStore {
     const RECENTLY_INCLUDED_TTL: Duration = Duration::from_secs(60);
+    const PENDING_SINCE_TTL: Duration = Duration::from_secs(60);
 
     /// Creates a new [`MeteringStore`] with the given metering flag and max capacity.
     pub fn new(enable_resource_metering: bool, max_capacity: usize) -> Self {
@@ -52,10 +56,15 @@ impl MeteringStore {
             .max_capacity(max_capacity as u64)
             .time_to_live(Self::RECENTLY_INCLUDED_TTL)
             .build();
+        let pending_since = Cache::builder()
+            .max_capacity(max_capacity as u64)
+            .time_to_live(Self::PENDING_SINCE_TTL)
+            .build();
 
         Self {
             cache,
             recently_included,
+            pending_since,
             metering_enabled: AtomicBool::new(enable_resource_metering),
         }
     }
@@ -85,11 +94,14 @@ impl MeteringProvider for MeteringStore {
     }
 
     fn insert(&self, tx_hash: TxHash, metering: MeterBundleResponse) {
-        if let Some(included_at) = self.recently_included.get(&tx_hash) {
+        if self.recently_included.contains_key(&tx_hash) {
             self.recently_included.invalidate(&tx_hash);
             BuilderMetrics::metering_data_arrived_after_payload_inclusion().increment(1);
-            BuilderMetrics::metering_data_arrived_after_payload_inclusion_latency_ms()
-                .record(included_at.elapsed().as_secs_f64() * 1000.0);
+        }
+        if let Some(pending_since) = self.pending_since.get(&tx_hash) {
+            self.pending_since.invalidate(&tx_hash);
+            BuilderMetrics::metering_data_pending_lateness_ms()
+                .record(pending_since.elapsed().as_secs_f64() * 1000.0);
         }
         self.cache.insert(tx_hash, metering);
         BuilderMetrics::metering_store_size().set(self.cache.entry_count() as f64);
@@ -98,15 +110,20 @@ impl MeteringProvider for MeteringStore {
     fn remove(&self, tx_hashes: &[TxHash]) {
         for hash in tx_hashes {
             self.cache.invalidate(hash);
+            self.pending_since.invalidate(hash);
+            self.recently_included.invalidate(hash);
         }
         BuilderMetrics::metering_store_size().set(self.cache.entry_count() as f64);
     }
 
+    fn mark_metering_data_pending(&self, tx_hash: TxHash) {
+        self.pending_since.entry_by_ref(&tx_hash).or_insert_with(Instant::now);
+    }
+
     fn mark_payload_included(&self, tx_hashes: &[TxHash]) {
-        let included_at = Instant::now();
         for hash in tx_hashes {
             self.cache.invalidate(hash);
-            self.recently_included.insert(*hash, included_at);
+            self.recently_included.insert(*hash, ());
         }
         BuilderMetrics::metering_store_size().set(self.cache.entry_count() as f64);
     }
@@ -114,6 +131,7 @@ impl MeteringProvider for MeteringStore {
     fn clear(&self) {
         self.cache.invalidate_all();
         self.recently_included.invalidate_all();
+        self.pending_since.invalidate_all();
         BuilderMetrics::metering_store_size().set(0.0);
     }
 
@@ -266,7 +284,6 @@ mod tests {
 
         metrics::with_local_recorder(&recorder, || {
             store.mark_payload_included(&[tx_hash]);
-            std::thread::sleep(Duration::from_millis(10));
             store.insert(tx_hash, create_test_metering(1000));
         });
 
@@ -274,16 +291,32 @@ mod tests {
 
         let rendered = handle.render();
         assert!(rendered.contains("base_builder_metering_data_arrived_after_payload_inclusion 1"));
-        assert!(rendered.contains(
-            "base_builder_metering_data_arrived_after_payload_inclusion_latency_ms_count 1"
-        ));
+        assert!(
+            !rendered.contains("base_builder_metering_data_pending_lateness_ms"),
+            "payload inclusion alone should not emit the pending-lateness histogram"
+        );
+    }
+
+    #[test]
+    fn test_late_metering_after_pending_skip_records_lateness_histogram() {
+        let recorder = PrometheusBuilder::new().build_recorder();
+        let handle = recorder.handle();
+        let store = MeteringStore::new(true, 100);
+        let tx_hash = TxHash::random();
+
+        metrics::with_local_recorder(&recorder, || {
+            store.mark_metering_data_pending(tx_hash);
+            std::thread::sleep(Duration::from_millis(10));
+            store.mark_payload_included(&[tx_hash]);
+            std::thread::sleep(Duration::from_millis(10));
+            store.insert(tx_hash, create_test_metering(1000));
+        });
+
+        let rendered = handle.render();
+        assert!(rendered.contains("base_builder_metering_data_pending_lateness_ms_count 1"));
         let latency_sum_line = rendered
             .lines()
-            .find(|line| {
-                line.starts_with(
-                    "base_builder_metering_data_arrived_after_payload_inclusion_latency_ms_sum ",
-                )
-            })
+            .find(|line| line.starts_with("base_builder_metering_data_pending_lateness_ms_sum "))
             .expect("latency histogram sum line should be present");
         let latency_sum_ms = latency_sum_line
             .rsplit(' ')
@@ -291,7 +324,36 @@ mod tests {
             .expect("histogram sum line should have a value")
             .parse::<f64>()
             .expect("histogram sum should be a number");
-        assert!(latency_sum_ms >= 5.0, "expected late metering latency >= 5ms");
+        assert!(latency_sum_ms >= 15.0, "expected pending lateness >= 15ms");
+    }
+
+    #[test]
+    fn test_repeated_pending_marks_preserve_first_timestamp() {
+        let recorder = PrometheusBuilder::new().build_recorder();
+        let handle = recorder.handle();
+        let store = MeteringStore::new(true, 100);
+        let tx_hash = TxHash::random();
+
+        metrics::with_local_recorder(&recorder, || {
+            store.mark_metering_data_pending(tx_hash);
+            std::thread::sleep(Duration::from_millis(10));
+            store.mark_metering_data_pending(tx_hash);
+            std::thread::sleep(Duration::from_millis(10));
+            store.insert(tx_hash, create_test_metering(1000));
+        });
+
+        let rendered = handle.render();
+        let latency_sum_line = rendered
+            .lines()
+            .find(|line| line.starts_with("base_builder_metering_data_pending_lateness_ms_sum "))
+            .expect("latency histogram sum line should be present");
+        let latency_sum_ms = latency_sum_line
+            .rsplit(' ')
+            .next()
+            .expect("histogram sum line should have a value")
+            .parse::<f64>()
+            .expect("histogram sum should be a number");
+        assert!(latency_sum_ms >= 15.0, "expected first pending timestamp to be preserved");
     }
 
     #[test]
@@ -302,6 +364,7 @@ mod tests {
         let tx_hash = TxHash::random();
 
         metrics::with_local_recorder(&recorder, || {
+            store.mark_metering_data_pending(tx_hash);
             store.remove(&[tx_hash]);
             store.insert(tx_hash, create_test_metering(1000));
         });
@@ -312,9 +375,8 @@ mod tests {
             "permanent rejections should not be counted as payload-inclusion races"
         );
         assert!(
-            !rendered
-                .contains("base_builder_metering_data_arrived_after_payload_inclusion_latency_ms"),
-            "permanent rejections should not emit the late metering latency histogram"
+            !rendered.contains("base_builder_metering_data_pending_lateness_ms"),
+            "permanent rejections should not emit the pending-lateness histogram"
         );
     }
 }

--- a/crates/builder/metering/src/store.rs
+++ b/crates/builder/metering/src/store.rs
@@ -6,7 +6,7 @@
 
 use std::{
     sync::atomic::{AtomicBool, Ordering},
-    time::Duration,
+    time::{Duration, Instant},
 };
 
 use alloy_primitives::TxHash;
@@ -18,8 +18,9 @@ use moka::{notification::RemovalCause, sync::Cache};
 pub struct MeteringStore {
     /// LRU cache mapping transaction hash to metering data.
     cache: Cache<TxHash, MeterBundleResponse>,
-    /// Recently included transaction hashes used to detect late metering updates.
-    recently_included: Cache<TxHash, ()>,
+    /// Recently included transaction hashes and inclusion times used to detect late metering
+    /// updates.
+    recently_included: Cache<TxHash, Instant>,
     /// Whether resource metering is enabled.
     metering_enabled: AtomicBool,
 }
@@ -84,8 +85,11 @@ impl MeteringProvider for MeteringStore {
     }
 
     fn insert(&self, tx_hash: TxHash, metering: MeterBundleResponse) {
-        if self.recently_included.contains_key(&tx_hash) {
+        if let Some(included_at) = self.recently_included.get(&tx_hash) {
+            self.recently_included.invalidate(&tx_hash);
             BuilderMetrics::metering_data_arrived_after_payload_inclusion().increment(1);
+            BuilderMetrics::metering_data_arrived_after_payload_inclusion_latency_ms()
+                .record(included_at.elapsed().as_secs_f64() * 1000.0);
         }
         self.cache.insert(tx_hash, metering);
         BuilderMetrics::metering_store_size().set(self.cache.entry_count() as f64);
@@ -99,9 +103,10 @@ impl MeteringProvider for MeteringStore {
     }
 
     fn mark_payload_included(&self, tx_hashes: &[TxHash]) {
+        let included_at = Instant::now();
         for hash in tx_hashes {
             self.cache.invalidate(hash);
-            self.recently_included.insert(*hash, ());
+            self.recently_included.insert(*hash, included_at);
         }
         BuilderMetrics::metering_store_size().set(self.cache.entry_count() as f64);
     }
@@ -127,6 +132,7 @@ impl Default for MeteringStore {
 mod tests {
     use alloy_primitives::{B256, TxHash, U256};
     use metrics_exporter_prometheus::PrometheusBuilder;
+    use std::time::Duration;
 
     use super::*;
 
@@ -260,15 +266,32 @@ mod tests {
 
         metrics::with_local_recorder(&recorder, || {
             store.mark_payload_included(&[tx_hash]);
+            std::thread::sleep(Duration::from_millis(10));
             store.insert(tx_hash, create_test_metering(1000));
         });
 
         assert!(store.get(&tx_hash).is_some(), "late metering should preserve existing behavior");
 
         let rendered = handle.render();
-        assert!(
-            rendered.contains("base_builder_metering_data_arrived_after_payload_inclusion 1")
-        );
+        assert!(rendered.contains("base_builder_metering_data_arrived_after_payload_inclusion 1"));
+        assert!(rendered.contains(
+            "base_builder_metering_data_arrived_after_payload_inclusion_latency_ms_count 1"
+        ));
+        let latency_sum_line = rendered
+            .lines()
+            .find(|line| {
+                line.starts_with(
+                    "base_builder_metering_data_arrived_after_payload_inclusion_latency_ms_sum ",
+                )
+            })
+            .expect("latency histogram sum line should be present");
+        let latency_sum_ms = latency_sum_line
+            .rsplit(' ')
+            .next()
+            .expect("histogram sum line should have a value")
+            .parse::<f64>()
+            .expect("histogram sum should be a number");
+        assert!(latency_sum_ms >= 5.0, "expected late metering latency >= 5ms");
     }
 
     #[test]
@@ -287,6 +310,11 @@ mod tests {
         assert!(
             !rendered.contains("base_builder_metering_data_arrived_after_payload_inclusion"),
             "permanent rejections should not be counted as payload-inclusion races"
+        );
+        assert!(
+            !rendered
+                .contains("base_builder_metering_data_arrived_after_payload_inclusion_latency_ms"),
+            "permanent rejections should not emit the late metering latency histogram"
         );
     }
 }

--- a/crates/builder/metering/src/store.rs
+++ b/crates/builder/metering/src/store.rs
@@ -4,7 +4,10 @@
 //! to bound memory usage. Uses [`moka`] for the LRU cache that promotes
 //! entries on access, preventing premature eviction of frequently-read data.
 
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::{
+    sync::atomic::{AtomicBool, Ordering},
+    time::Duration,
+};
 
 use alloy_primitives::TxHash;
 use base_builder_core::{BuilderMetrics, MeteringProvider};
@@ -15,6 +18,8 @@ use moka::{notification::RemovalCause, sync::Cache};
 pub struct MeteringStore {
     /// LRU cache mapping transaction hash to metering data.
     cache: Cache<TxHash, MeterBundleResponse>,
+    /// Recently included transaction hashes used to detect late metering updates.
+    recently_included: Cache<TxHash, ()>,
     /// Whether resource metering is enabled.
     metering_enabled: AtomicBool,
 }
@@ -23,12 +28,15 @@ impl core::fmt::Debug for MeteringStore {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         f.debug_struct("MeteringStore")
             .field("entries", &self.cache.entry_count())
+            .field("recently_included", &self.recently_included.entry_count())
             .field("metering_enabled", &self.metering_enabled.load(Ordering::Relaxed))
             .finish()
     }
 }
 
 impl MeteringStore {
+    const RECENTLY_INCLUDED_TTL: Duration = Duration::from_secs(60);
+
     /// Creates a new [`MeteringStore`] with the given metering flag and max capacity.
     pub fn new(enable_resource_metering: bool, max_capacity: usize) -> Self {
         let cache = Cache::builder()
@@ -39,8 +47,16 @@ impl MeteringStore {
                 }
             })
             .build();
+        let recently_included = Cache::builder()
+            .max_capacity(max_capacity as u64)
+            .time_to_live(Self::RECENTLY_INCLUDED_TTL)
+            .build();
 
-        Self { cache, metering_enabled: AtomicBool::new(enable_resource_metering) }
+        Self {
+            cache,
+            recently_included,
+            metering_enabled: AtomicBool::new(enable_resource_metering),
+        }
     }
 
     /// Returns the number of stored entries.
@@ -68,6 +84,9 @@ impl MeteringProvider for MeteringStore {
     }
 
     fn insert(&self, tx_hash: TxHash, metering: MeterBundleResponse) {
+        if self.recently_included.contains_key(&tx_hash) {
+            BuilderMetrics::metering_data_arrived_after_payload_inclusion().increment(1);
+        }
         self.cache.insert(tx_hash, metering);
         BuilderMetrics::metering_store_size().set(self.cache.entry_count() as f64);
     }
@@ -79,8 +98,17 @@ impl MeteringProvider for MeteringStore {
         BuilderMetrics::metering_store_size().set(self.cache.entry_count() as f64);
     }
 
+    fn mark_payload_included(&self, tx_hashes: &[TxHash]) {
+        for hash in tx_hashes {
+            self.cache.invalidate(hash);
+            self.recently_included.insert(*hash, ());
+        }
+        BuilderMetrics::metering_store_size().set(self.cache.entry_count() as f64);
+    }
+
     fn clear(&self) {
         self.cache.invalidate_all();
+        self.recently_included.invalidate_all();
         BuilderMetrics::metering_store_size().set(0.0);
     }
 
@@ -98,6 +126,7 @@ impl Default for MeteringStore {
 #[cfg(test)]
 mod tests {
     use alloy_primitives::{B256, TxHash, U256};
+    use metrics_exporter_prometheus::PrometheusBuilder;
 
     use super::*;
 
@@ -219,6 +248,45 @@ mod tests {
         assert!(
             store.get(&promoted).is_some(),
             "frequently accessed entry should survive eviction"
+        );
+    }
+
+    #[test]
+    fn test_late_metering_after_payload_inclusion_records_metric() {
+        let recorder = PrometheusBuilder::new().build_recorder();
+        let handle = recorder.handle();
+        let store = MeteringStore::new(true, 100);
+        let tx_hash = TxHash::random();
+
+        metrics::with_local_recorder(&recorder, || {
+            store.mark_payload_included(&[tx_hash]);
+            store.insert(tx_hash, create_test_metering(1000));
+        });
+
+        assert!(store.get(&tx_hash).is_some(), "late metering should preserve existing behavior");
+
+        let rendered = handle.render();
+        assert!(
+            rendered.contains("base_builder_metering_data_arrived_after_payload_inclusion 1")
+        );
+    }
+
+    #[test]
+    fn test_non_payload_eviction_does_not_record_late_metering_metric() {
+        let recorder = PrometheusBuilder::new().build_recorder();
+        let handle = recorder.handle();
+        let store = MeteringStore::new(true, 100);
+        let tx_hash = TxHash::random();
+
+        metrics::with_local_recorder(&recorder, || {
+            store.remove(&[tx_hash]);
+            store.insert(tx_hash, create_test_metering(1000));
+        });
+
+        let rendered = handle.render();
+        assert!(
+            !rendered.contains("base_builder_metering_data_arrived_after_payload_inclusion"),
+            "permanent rejections should not be counted as payload-inclusion races"
         );
     }
 }


### PR DESCRIPTION
## Summary
- add a `MeteringProvider::mark_metering_data_pending` hook at the first `MeteringDataPending` skip point
- record `metering_data_pending_lateness_ms` from the first pending skip until metering arrives so we can tune `metering_wait_duration`
- keep `metering_data_arrived_after_payload_inclusion` as a separate counter for metering that arrived too late to help the current payload
- cover both signals with metering-store tests, including repeated pending marks and non-payload removals

## Testing
- cargo test -p base-builder-metering
- cargo check -p base-builder-core --lib
