### PR TITLE
fix(registrar): retry receipt fetch after proof fulfillment

### DIFF
--- a/crates/proof/tee/nitro-attestation-prover/src/boundless.rs
+++ b/crates/proof/tee/nitro-attestation-prover/src/boundless.rs
@@ -243,7 +243,29 @@ impl BoundlessProver {
         };
 
         info!(request_id = %request_id, "fulfillment confirmed, fetching set inclusion receipt");
-        self.fetch_and_encode_receipt(client, request_id).await
+
+        const MAX_RECEIPT_FETCH_RETRIES: u32 = 60;
+        const RECEIPT_FETCH_RETRY_DELAY: Duration = Duration::from_secs(5);
+
+        let mut receipt_retries = 0;
+        loop {
+            match self.fetch_and_encode_receipt(client, request_id).await {
+                Ok(proof) => return Ok(proof),
+                Err(e) if receipt_retries < MAX_RECEIPT_FETCH_RETRIES => {
+                    receipt_retries += 1;
+                    warn!(
+                        error = %e,
+                        request_id = %request_id,
+                        retry = receipt_retries,
+                        max_retries = MAX_RECEIPT_FETCH_RETRIES,
+                        delay = ?RECEIPT_FETCH_RETRY_DELAY,
+                        "transient receipt fetch failure, retrying"
+                    );
+                    tokio::time::sleep(RECEIPT_FETCH_RETRY_DELAY).await;
+                }
+                Err(e) => return Err(e),
+            }
+        }
     }
 
     /// Builds the Boundless [`Client`] and [`RequestParams`] from the

--- a/crates/proof/tee/nitro-attestation-prover/src/boundless.rs
+++ b/crates/proof/tee/nitro-attestation-prover/src/boundless.rs
@@ -163,19 +163,40 @@ impl BoundlessProver {
     ) -> Result<AttestationProof> {
         let image_id_bytes: [u8; 32] = Digest::from(self.image_id).into();
         let image_id_b256 = B256::from(image_id_bytes);
-        let (journal, receipt) = client
-            .fetch_set_inclusion_receipt(request_id, image_id_b256, None, None)
-            .await
-            .map_err(|e| {
-                warn!(
-                    error = %e,
-                    error_debug = ?e,
-                    request_id = %request_id,
-                    image_id = ?self.image_id,
-                    "failed to fetch set inclusion receipt"
-                );
-                ProverError::Boundless(format!("failed to fetch set inclusion receipt: {e}"))
-            })?;
+
+        // Retry only the RPC fetch — this is the transient-failure path.
+        // abi_encode_seal below is deterministic and must not be retried.
+        const MAX_RECEIPT_FETCH_RETRIES: u32 = 60;
+        const RECEIPT_FETCH_RETRY_DELAY: Duration = Duration::from_secs(5);
+
+        let mut receipt_retries = 0;
+        let (journal, receipt) = loop {
+            match client
+                .fetch_set_inclusion_receipt(request_id, image_id_b256, None, None)
+                .await
+            {
+                Ok(result) => break result,
+                Err(e) if receipt_retries < MAX_RECEIPT_FETCH_RETRIES => {
+                    receipt_retries += 1;
+                    warn!(
+                        error = %e,
+                        error_debug = ?e,
+                        request_id = %request_id,
+                        image_id = ?self.image_id,
+                        retry = receipt_retries,
+                        max_retries = MAX_RECEIPT_FETCH_RETRIES,
+                        delay = ?RECEIPT_FETCH_RETRY_DELAY,
+                        "transient receipt fetch failure, retrying"
+                    );
+                    tokio::time::sleep(RECEIPT_FETCH_RETRY_DELAY).await;
+                }
+                Err(e) => {
+                    return Err(ProverError::Boundless(format!(
+                        "failed to fetch set inclusion receipt: {e}"
+                    )));
+                }
+            }
+        };
 
         let encoded_seal = receipt.abi_encode_seal().map_err(|e| {
             warn!(
@@ -244,28 +265,7 @@ impl BoundlessProver {
 
         info!(request_id = %request_id, "fulfillment confirmed, fetching set inclusion receipt");
 
-        const MAX_RECEIPT_FETCH_RETRIES: u32 = 60;
-        const RECEIPT_FETCH_RETRY_DELAY: Duration = Duration::from_secs(5);
-
-        let mut receipt_retries = 0;
-        loop {
-            match self.fetch_and_encode_receipt(client, request_id).await {
-                Ok(proof) => return Ok(proof),
-                Err(e) if receipt_retries < MAX_RECEIPT_FETCH_RETRIES => {
-                    receipt_retries += 1;
-                    warn!(
-                        error = %e,
-                        request_id = %request_id,
-                        retry = receipt_retries,
-                        max_retries = MAX_RECEIPT_FETCH_RETRIES,
-                        delay = ?RECEIPT_FETCH_RETRY_DELAY,
-                        "transient receipt fetch failure, retrying"
-                    );
-                    tokio::time::sleep(RECEIPT_FETCH_RETRY_DELAY).await;
-                }
-                Err(e) => return Err(e),
-            }
-        }
+        self.fetch_and_encode_receipt(client, request_id).await
     }
 
     /// Builds the Boundless [`Client`] and [`RequestParams`] from the

--- a/crates/proof/tee/nitro-attestation-prover/src/boundless.rs
+++ b/crates/proof/tee/nitro-attestation-prover/src/boundless.rs
@@ -171,10 +171,7 @@ impl BoundlessProver {
 
         let mut receipt_retries = 0;
         let (journal, receipt) = loop {
-            match client
-                .fetch_set_inclusion_receipt(request_id, image_id_b256, None, None)
-                .await
-            {
+            match client.fetch_set_inclusion_receipt(request_id, image_id_b256, None, None).await {
                 Ok(result) => break result,
                 Err(e) if receipt_retries < MAX_RECEIPT_FETCH_RETRIES => {
                     receipt_retries += 1;


### PR DESCRIPTION
## Summary

- Adds a retry loop around `fetch_and_encode_receipt` in `BoundlessProver::wait_and_fetch` to handle transient RPC errors (e.g. `block range extends beyond current head block`) that occur after proof fulfillment.
- Without this fix, an expensive ~12-20 min proof is discarded when the receipt fetch fails due to an intermittent network/RPC issue, forcing a full re-prove on the next cycle.
- Retries up to 60 times with 5s delay (5 min total), matching the existing `MAX_RACE_RETRIES` pattern in the same method.

## Changes

- `crates/proof/tee/nitro-attestation-prover/src/boundless.rs`: Replace single `fetch_and_encode_receipt` call with a retry loop using local constants `MAX_RECEIPT_FETCH_RETRIES` (60) and `RECEIPT_FETCH_RETRY_DELAY` (5s).

## Testing

- All existing tests pass (`cargo test` on `base-proof-tee-nitro-attestation-prover`, `base-proof-tee-registrar`, `base-proof-tee-registrar-bin`).