### PR TITLE
perf(l1-watcher): parallelize L1 state fetches

### DIFF
--- a/crates/consensus/service/src/actors/l1_watcher/actor.rs
+++ b/crates/consensus/service/src/actors/l1_watcher/actor.rs
@@ -254,26 +254,38 @@ where
                         L1WatcherQueries::L1State(sender) => {
                             let current_l1 = *latest_head.borrow();
 
-                            let head_l1 = match self.l1_provider.get_block(BlockId::latest()).await {
-                                    Ok(block) => block,
-                                    Err(e) => {
-                                        warn!(target: "l1_watcher", error = ?e, "failed to query l1 provider for latest head block");
-                                        None
-                                    }}.map(|block| block.into_consensus().into());
-
-                            let finalized_l1 = match self.l1_provider.get_block(BlockId::finalized()).await {
-                                    Ok(block) => block,
-                                    Err(e) => {
-                                        warn!(target: "l1_watcher", error = ?e, "failed to query l1 provider for latest finalized block");
-                                        None
-                                    }}.map(|block| block.into_consensus().into());
-
-                            let safe_l1 = match self.l1_provider.get_block(BlockId::safe()).await {
-                                    Ok(block) => block,
-                                    Err(e) => {
-                                        warn!(target: "l1_watcher", error = ?e, "failed to query l1 provider for latest safe block");
-                                        None
-                                    }}.map(|block| block.into_consensus().into());
+                            let (head_l1, finalized_l1, safe_l1) = tokio::join!(
+                                async {
+                                    match self.l1_provider.get_block(BlockId::latest()).await {
+                                        Ok(block) => block,
+                                        Err(e) => {
+                                            warn!(target: "l1_watcher", error = ?e, "failed to query l1 provider for latest head block");
+                                            None
+                                        }
+                                    }
+                                    .map(|block| block.into_consensus().into())
+                                },
+                                async {
+                                    match self.l1_provider.get_block(BlockId::finalized()).await {
+                                        Ok(block) => block,
+                                        Err(e) => {
+                                            warn!(target: "l1_watcher", error = ?e, "failed to query l1 provider for latest finalized block");
+                                            None
+                                        }
+                                    }
+                                    .map(|block| block.into_consensus().into())
+                                },
+                                async {
+                                    match self.l1_provider.get_block(BlockId::safe()).await {
+                                        Ok(block) => block,
+                                        Err(e) => {
+                                            warn!(target: "l1_watcher", error = ?e, "failed to query l1 provider for latest safe block");
+                                            None
+                                        }
+                                    }
+                                    .map(|block| block.into_consensus().into())
+                                },
+                            );
 
                             if let Err(e) = sender.send(L1State {
                                 current_l1,


### PR DESCRIPTION
## Summary

- Run the three L1 RPC calls (`latest`, `finalized`, `safe`) concurrently via `tokio::join!` instead of sequentially in the L1 watcher actor's `L1State` query handler.

## Problem

Each `L1State` query in the L1 watcher actor makes 3 sequential L1 RPC calls, each taking ~33ms. Under load (e.g., proposer recovery bursts of ~500 `outputAtBlock` calls), the sequential processing becomes a bottleneck: 500 queries × ~100ms = ~50s drain time. This causes `syncStatus` and `outputAtBlock` RPCs to time out.

## Fix

Replace the 3 sequential `get_block()` calls with `tokio::join!` to run them concurrently. This reduces per-query L1 latency from ~100ms (3 sequential round trips) to ~35ms (1 round trip, all parallel). Under 500 queued queries, total drain time drops from ~50s to ~17s.

Each individual call preserves its own error handling (warn + continue with None), so one failing fetch doesn't abort the others.

## Part of

This is PR 1 of a 5-PR series fixing RPC head-of-line blocking when the proposer does recovery scans.