### PR TITLE
perf(engine): drop stale RPC queries before expensive work

### DIFF
--- a/crates/consensus/engine/src/query.rs
+++ b/crates/consensus/engine/src/query.rs
@@ -77,13 +77,25 @@ impl EngineQueries {
         let state = *state_recv.borrow();
 
         match self {
-            Self::Config(sender) => sender
-                .send((**rollup_config).clone())
-                .map_err(|_| EngineQueriesError::OutputChannelClosed),
+            Self::Config(sender) => {
+                if sender.is_closed() {
+                    return Ok(());
+                }
+                sender
+                    .send((**rollup_config).clone())
+                    .map_err(|_| EngineQueriesError::OutputChannelClosed)
+            }
             Self::State(sender) => {
+                if sender.is_closed() {
+                    return Ok(());
+                }
                 sender.send(state).map_err(|_| EngineQueriesError::OutputChannelClosed)
             }
             Self::OutputAtBlock { block, sender } => {
+                if sender.is_closed() {
+                    debug!(target: "engine", block = %block, "dropping stale OutputAtBlock query");
+                    return Ok(());
+                }
                 let output_block = client.l2_block_by_label(block).await?;
                 let output_block = output_block.ok_or(EngineQueriesError::NoL2BlockFound(block))?;
                 // Cloning the l2 block below is cheaper than sending a network request to get the
@@ -124,13 +136,26 @@ impl EngineQueries {
                     .send((output_block_info, output_response_v0, state))
                     .map_err(|_| EngineQueriesError::OutputChannelClosed)
             }
-            Self::StateReceiver(subscription) => subscription
-                .send(state_recv.clone())
-                .map_err(|_| EngineQueriesError::OutputChannelClosed),
-            Self::QueueLengthReceiver(subscription) => subscription
-                .send(queue_length_recv.clone())
-                .map_err(|_| EngineQueriesError::OutputChannelClosed),
+            Self::StateReceiver(subscription) => {
+                if subscription.is_closed() {
+                    return Ok(());
+                }
+                subscription
+                    .send(state_recv.clone())
+                    .map_err(|_| EngineQueriesError::OutputChannelClosed)
+            }
+            Self::QueueLengthReceiver(subscription) => {
+                if subscription.is_closed() {
+                    return Ok(());
+                }
+                subscription
+                    .send(queue_length_recv.clone())
+                    .map_err(|_| EngineQueriesError::OutputChannelClosed)
+            }
             Self::TaskQueueLength(sender) => {
+                if sender.is_closed() {
+                    return Ok(());
+                }
                 let queue_length = *queue_length_recv.borrow();
                 if sender.send(queue_length).is_err() {
                     warn!(target: "engine", "Failed to send task queue length response");

--- a/crates/consensus/engine/src/query.rs
+++ b/crates/consensus/engine/src/query.rs
@@ -78,17 +78,11 @@ impl EngineQueries {
 
         match self {
             Self::Config(sender) => {
-                if sender.is_closed() {
-                    return Ok(());
-                }
                 sender
                     .send((**rollup_config).clone())
                     .map_err(|_| EngineQueriesError::OutputChannelClosed)
             }
             Self::State(sender) => {
-                if sender.is_closed() {
-                    return Ok(());
-                }
                 sender.send(state).map_err(|_| EngineQueriesError::OutputChannelClosed)
             }
             Self::OutputAtBlock { block, sender } => {
@@ -98,6 +92,14 @@ impl EngineQueries {
                 }
                 let output_block = client.l2_block_by_label(block).await?;
                 let output_block = output_block.ok_or(EngineQueriesError::NoL2BlockFound(block))?;
+
+                // Re-check after the network call — the caller may have timed out while
+                // we were fetching the block.
+                if sender.is_closed() {
+                    debug!(target: "engine", block = %block, "dropping stale OutputAtBlock query after block fetch");
+                    return Ok(());
+                }
+
                 // Cloning the l2 block below is cheaper than sending a network request to get the
                 // l2 block info. Querying the `L2BlockInfo` from the client ends up
                 // fetching the full l2 block again.
@@ -137,25 +139,16 @@ impl EngineQueries {
                     .map_err(|_| EngineQueriesError::OutputChannelClosed)
             }
             Self::StateReceiver(subscription) => {
-                if subscription.is_closed() {
-                    return Ok(());
-                }
                 subscription
                     .send(state_recv.clone())
                     .map_err(|_| EngineQueriesError::OutputChannelClosed)
             }
             Self::QueueLengthReceiver(subscription) => {
-                if subscription.is_closed() {
-                    return Ok(());
-                }
                 subscription
                     .send(queue_length_recv.clone())
                     .map_err(|_| EngineQueriesError::OutputChannelClosed)
             }
             Self::TaskQueueLength(sender) => {
-                if sender.is_closed() {
-                    return Ok(());
-                }
                 let queue_length = *queue_length_recv.borrow();
                 if sender.send(queue_length).is_err() {
                     warn!(target: "engine", "Failed to send task queue length response");


### PR DESCRIPTION
## Summary

- Check `oneshot::Sender::is_closed()` before processing engine queries to skip work for timed-out clients.

## Problem

Under sustained load (e.g., proposer recovery bursts), many RPC requests time out while waiting in the engine query queue. The engine processor still performs expensive network calls (`l2_block_by_label`, `get_proof`) for these stale requests, wasting ~50-100ms each on work nobody is waiting for. This creates a self-reinforcing backlog.

## Fix

Add `sender.is_closed()` checks before processing each `EngineQueries` variant:
- **`OutputAtBlock`**: Logs a debug message and returns early, skipping expensive network calls
- **All other variants** (`Config`, `State`, `StateReceiver`, `QueueLengthReceiver`, `TaskQueueLength`): Returns early silently (these are cheap but consistency is good)

Under sustained load, stale requests now drain in <1µs instead of ~50-100ms each.

## Part of

This is PR 2 of a 5-PR series fixing RPC head-of-line blocking when the proposer does recovery scans.