### PR TITLE
perf(engine-rpc): parallelize RPC query processing

### DIFF
--- a/crates/consensus/service/src/actors/engine/rpc_request_processor.rs
+++ b/crates/consensus/service/src/actors/engine/rpc_request_processor.rs
@@ -65,7 +65,8 @@ where
 }
 
 /// Maximum number of engine RPC queries processed concurrently.
-const MAX_CONCURRENT_ENGINE_RPC_QUERIES: usize = 32;
+/// Bounds concurrent requests to avoid overwhelming the execution engine.
+const MAX_CONCURRENT_ENGINE_RPC_QUERIES: usize = 16;
 
 impl<EngineClient_> EngineRpcRequestReceiver for EngineRpcProcessor<EngineClient_>
 where
@@ -88,6 +89,11 @@ where
                     .await
                     .expect("semaphore is never closed");
                 let handler = Arc::clone(&this);
+                // Spawned sub-tasks are intentionally detached. On shutdown, when the
+                // request channel closes, this loop exits but in-flight sub-tasks may
+                // still be running. This is acceptable because each request sends its
+                // response through a oneshot channel that the caller has likely already
+                // dropped, so the worst case is wasted work — not incorrect behavior.
                 tokio::spawn(async move {
                     if let Err(e) = handler.handle_rpc_request(query).await {
                         error!(target: "engine", error = %e, "engine rpc request failed");

--- a/crates/consensus/service/src/actors/engine/rpc_request_processor.rs
+++ b/crates/consensus/service/src/actors/engine/rpc_request_processor.rs
@@ -15,6 +15,9 @@ use crate::{EngineError, EngineRpcRequest};
 /// under a well-thought-out interface.
 pub trait EngineRpcRequestReceiver: Send + Sync {
     /// Starts a task to handle engine queries.
+    ///
+    /// Requests are processed concurrently and may complete out-of-order.
+    /// A bounded semaphore limits the number of in-flight requests.
     fn start(
         self,
         request_channel: mpsc::Receiver<EngineRpcRequest>,
@@ -80,10 +83,15 @@ where
                     error!(target: "engine", "Engine rpc request receiver closed unexpectedly");
                     return Err(EngineError::ChannelClosed);
                 };
-                let permit = Arc::clone(&semaphore).acquire_owned().await.unwrap();
+                let permit = Arc::clone(&semaphore)
+                    .acquire_owned()
+                    .await
+                    .expect("semaphore is never closed");
                 let handler = Arc::clone(&this);
                 tokio::spawn(async move {
-                    let _ = handler.handle_rpc_request(query).await;
+                    if let Err(e) = handler.handle_rpc_request(query).await {
+                        error!(target: "engine", error = %e, "engine rpc request failed");
+                    }
                     drop(permit);
                 });
             }

--- a/crates/consensus/service/src/actors/engine/rpc_request_processor.rs
+++ b/crates/consensus/service/src/actors/engine/rpc_request_processor.rs
@@ -4,7 +4,7 @@ use base_consensus_engine::{EngineClient, EngineState};
 use base_consensus_genesis::RollupConfig;
 use derive_more::Constructor;
 use tokio::{
-    sync::{mpsc, watch},
+    sync::{Semaphore, mpsc, watch},
     task::JoinHandle,
 };
 
@@ -61,6 +61,9 @@ where
     }
 }
 
+/// Maximum number of engine RPC queries processed concurrently.
+const MAX_CONCURRENT_ENGINE_RPC_QUERIES: usize = 32;
+
 impl<EngineClient_> EngineRpcRequestReceiver for EngineRpcProcessor<EngineClient_>
 where
     EngineClient_: EngineClient + 'static,
@@ -69,13 +72,20 @@ where
         self,
         mut request_channel: mpsc::Receiver<EngineRpcRequest>,
     ) -> JoinHandle<Result<(), EngineError>> {
+        let semaphore = Arc::new(Semaphore::new(MAX_CONCURRENT_ENGINE_RPC_QUERIES));
+        let this = Arc::new(self);
         tokio::spawn(async move {
             loop {
                 let Some(query) = request_channel.recv().await else {
                     error!(target: "engine", "Engine rpc request receiver closed unexpectedly");
                     return Err(EngineError::ChannelClosed);
                 };
-                self.handle_rpc_request(query).await?;
+                let permit = Arc::clone(&semaphore).acquire_owned().await.unwrap();
+                let handler = Arc::clone(&this);
+                tokio::spawn(async move {
+                    let _ = handler.handle_rpc_request(query).await;
+                    drop(permit);
+                });
             }
         })
     }


### PR DESCRIPTION
## Summary

- Replace the sequential engine RPC processor loop with bounded concurrent processing using a semaphore (limit: 16).

## Problem

The engine RPC processor (`EngineRpcProcessor`) processes requests in a single sequential loop. Each `OutputAtBlock` query takes ~50-100ms for network calls, and cheap `State`/`Config` queries queue behind them. Under proposer recovery bursts (~500 `outputAtBlock` calls), `syncStatus` queries must wait behind the entire backlog.

## Fix

Wrap the processor in `Arc` and spawn each request handler as a separate tokio task, bounded by a semaphore (32 concurrent). This means:

- Cheap `State` queries for `syncStatus` complete in microseconds even while `OutputAtBlock` queries are in-flight
- The semaphore bound (16) prevents flooding the execution engine with too many concurrent requests
- Individual query failures no longer kill the entire processor (errors are logged, not propagated from spawned tasks)
