### PR TITLE
fix(proposer): lower and make recovery scan concurrency configurable

### DIFF
--- a/crates/proof/proposer/src/cli.rs
+++ b/crates/proof/proposer/src/cli.rs
@@ -7,6 +7,8 @@ use base_cli_utils::CliStyles;
 use clap::Parser;
 use url::Url;
 
+use crate::constants::RECOVERY_SCAN_CONCURRENCY;
+
 base_cli_utils::define_cli_env!("BASE_PROPOSER");
 base_cli_utils::define_log_args!("BASE_PROPOSER");
 base_cli_utils::define_metrics_args!("BASE_PROPOSER", 7300);
@@ -154,7 +156,7 @@ pub struct ProposerArgs {
     #[arg(
         long = "recovery-scan-concurrency",
         env = cli_env!("RECOVERY_SCAN_CONCURRENCY"),
-        default_value = "8"
+        default_value_t = RECOVERY_SCAN_CONCURRENCY
     )]
     pub recovery_scan_concurrency: usize,
 

--- a/crates/proof/proposer/src/cli.rs
+++ b/crates/proof/proposer/src/cli.rs
@@ -156,7 +156,8 @@ pub struct ProposerArgs {
     #[arg(
         long = "recovery-scan-concurrency",
         env = cli_env!("RECOVERY_SCAN_CONCURRENCY"),
-        default_value_t = RECOVERY_SCAN_CONCURRENCY
+        default_value_t = RECOVERY_SCAN_CONCURRENCY,
+        value_parser = clap::value_parser!(usize).range(1..)
     )]
     pub recovery_scan_concurrency: usize,
 

--- a/crates/proof/proposer/src/cli.rs
+++ b/crates/proof/proposer/src/cli.rs
@@ -150,6 +150,14 @@ pub struct ProposerArgs {
     )]
     pub max_parallel_proofs: usize,
 
+    /// Maximum number of concurrent RPC calls during the recovery scan.
+    #[arg(
+        long = "recovery-scan-concurrency",
+        env = cli_env!("RECOVERY_SCAN_CONCURRENCY"),
+        default_value = "8"
+    )]
+    pub recovery_scan_concurrency: usize,
+
     /// Address of the `TEEProverRegistry` contract on L1.
     /// When set, the proposer validates signers before on-chain submission.
     #[arg(

--- a/crates/proof/proposer/src/cli.rs
+++ b/crates/proof/proposer/src/cli.rs
@@ -156,8 +156,7 @@ pub struct ProposerArgs {
     #[arg(
         long = "recovery-scan-concurrency",
         env = cli_env!("RECOVERY_SCAN_CONCURRENCY"),
-        default_value_t = RECOVERY_SCAN_CONCURRENCY,
-        value_parser = clap::value_parser!(usize).range(1..)
+        default_value_t = RECOVERY_SCAN_CONCURRENCY
     )]
     pub recovery_scan_concurrency: usize,
 

--- a/crates/proof/proposer/src/config.rs
+++ b/crates/proof/proposer/src/config.rs
@@ -85,6 +85,8 @@ pub struct ProposerConfig {
     /// Maximum number of concurrent proof tasks.
     /// When > 1, uses the parallel proving pipeline instead of the sequential driver.
     pub max_parallel_proofs: usize,
+    /// Maximum number of concurrent RPC calls during the recovery scan.
+    pub recovery_scan_concurrency: usize,
     /// Optional address of the `TEEProverRegistry` contract on L1.
     /// When set, the proposer validates signers before on-chain submission.
     pub tee_prover_registry_address: Option<Address>,
@@ -103,6 +105,14 @@ impl ProposerConfig {
         if proposer.max_parallel_proofs == 0 {
             return Err(ConfigError::OutOfRange {
                 field: "max-parallel-proofs",
+                constraint: "at least 1",
+                value: "0",
+            });
+        }
+
+        if proposer.recovery_scan_concurrency == 0 {
+            return Err(ConfigError::OutOfRange {
+                field: "recovery-scan-concurrency",
                 constraint: "at least 1",
                 value: "0",
             });
@@ -184,6 +194,7 @@ impl ProposerConfig {
             signing,
             tx_manager,
             max_parallel_proofs: proposer.max_parallel_proofs,
+            recovery_scan_concurrency: proposer.recovery_scan_concurrency,
             tee_prover_registry_address: proposer.tee_prover_registry_address,
         })
     }
@@ -252,6 +263,7 @@ mod tests {
                     signer_address: None,
                 },
                 max_parallel_proofs: 1,
+                recovery_scan_concurrency: 8,
                 tee_prover_registry_address: None,
                 tx_manager: TxManagerCli::default(),
             },
@@ -431,6 +443,25 @@ mod tests {
         cli.proposer.max_parallel_proofs = 8;
         let config = ProposerConfig::from_cli(cli).unwrap();
         assert_eq!(config.max_parallel_proofs, 8);
+    }
+
+    #[test]
+    fn test_recovery_scan_concurrency_zero_rejected() {
+        let mut cli = minimal_cli();
+        cli.proposer.recovery_scan_concurrency = 0;
+        let result = ProposerConfig::from_cli(cli);
+        assert!(matches!(
+            result,
+            Err(ConfigError::OutOfRange { field: "recovery-scan-concurrency", .. })
+        ));
+    }
+
+    #[test]
+    fn test_recovery_scan_concurrency_custom() {
+        let mut cli = minimal_cli();
+        cli.proposer.recovery_scan_concurrency = 4;
+        let config = ProposerConfig::from_cli(cli).unwrap();
+        assert_eq!(config.recovery_scan_concurrency, 4);
     }
 
     #[test]

--- a/crates/proof/proposer/src/config.rs
+++ b/crates/proof/proposer/src/config.rs
@@ -110,14 +110,6 @@ impl ProposerConfig {
             });
         }
 
-        if proposer.recovery_scan_concurrency == 0 {
-            return Err(ConfigError::OutOfRange {
-                field: "recovery-scan-concurrency",
-                constraint: "at least 1",
-                value: "0",
-            });
-        }
-
         // A zero address would be indistinguishable from an unconfigured value,
         // and is used as the "no parent" sentinel for the first game from anchor state.
         if proposer.anchor_state_registry_addr == Address::ZERO {

--- a/crates/proof/proposer/src/config.rs
+++ b/crates/proof/proposer/src/config.rs
@@ -110,6 +110,14 @@ impl ProposerConfig {
             });
         }
 
+        if proposer.recovery_scan_concurrency == 0 {
+            return Err(ConfigError::OutOfRange {
+                field: "recovery-scan-concurrency",
+                constraint: "at least 1",
+                value: "0",
+            });
+        }
+
         // A zero address would be indistinguishable from an unconfigured value,
         // and is used as the "no parent" sentinel for the first game from anchor state.
         if proposer.anchor_state_registry_addr == Address::ZERO {

--- a/crates/proof/proposer/src/constants.rs
+++ b/crates/proof/proposer/src/constants.rs
@@ -8,9 +8,8 @@ pub const PROPOSAL_TIMEOUT: Duration = Duration::from_mins(10);
 /// Timeout for prover server RPC calls.
 pub const PROVER_TIMEOUT: Duration = Duration::from_mins(30);
 
-/// Maximum number of concurrent `game_at_index` RPC calls during the recovery
-/// scan.
-pub const RECOVERY_SCAN_CONCURRENCY: usize = 32;
+/// Default maximum number of concurrent RPC calls during the recovery scan.
+pub const RECOVERY_SCAN_CONCURRENCY: usize = 8;
 
 /// Maximum retries for a single proof range before a full pipeline reset.
 pub const MAX_PROOF_RETRIES: u32 = 3;

--- a/crates/proof/proposer/src/driver.rs
+++ b/crates/proof/proposer/src/driver.rs
@@ -279,6 +279,7 @@ mod tests {
             PipelineConfig {
                 max_parallel_proofs: 2,
                 max_retries: 3,
+                recovery_scan_concurrency: 8,
                 tee_prover_registry_address: None,
                 driver: DriverConfig {
                     poll_interval: Duration::from_secs(3600),

--- a/crates/proof/proposer/src/pipeline.rs
+++ b/crates/proof/proposer/src/pipeline.rs
@@ -49,7 +49,7 @@ use tracing::{debug, error, info, instrument, warn};
 
 use crate::{
     Metrics,
-    constants::{PROPOSAL_TIMEOUT, RECOVERY_SCAN_CONCURRENCY},
+    constants::PROPOSAL_TIMEOUT,
     driver::{DriverConfig, RecoveredState},
     error::ProposerError,
     output_proposer::OutputProposer,
@@ -62,6 +62,8 @@ pub struct PipelineConfig {
     pub max_parallel_proofs: usize,
     /// Maximum retries for a single proof range before full pipeline reset.
     pub max_retries: u32,
+    /// Maximum number of concurrent RPC calls during the recovery scan.
+    pub recovery_scan_concurrency: usize,
     /// Base driver configuration.
     pub driver: DriverConfig,
     /// Optional address of the `TEEProverRegistry` contract on L1.
@@ -873,7 +875,7 @@ where
                         .map_err(ProposerError::Rpc)
                 }
             })
-            .buffered(RECOVERY_SCAN_CONCURRENCY)
+            .buffered(self.config.recovery_scan_concurrency)
             .try_collect()
             .await
     }
@@ -1403,6 +1405,7 @@ mod tests {
             PipelineConfig {
                 max_parallel_proofs: 1,
                 max_retries: 1,
+                recovery_scan_concurrency: 8,
                 tee_prover_registry_address: None,
                 driver: DriverConfig {
                     game_type: TEST_GAME_TYPE,
@@ -1432,6 +1435,7 @@ mod tests {
             PipelineConfig {
                 max_parallel_proofs: 2,
                 max_retries: 3,
+                recovery_scan_concurrency: 8,
                 tee_prover_registry_address: None,
                 driver: DriverConfig {
                     poll_interval: Duration::from_secs(3600),
@@ -1458,6 +1462,7 @@ mod tests {
             PipelineConfig {
                 max_parallel_proofs: 2,
                 max_retries: 3,
+                recovery_scan_concurrency: 8,
                 tee_prover_registry_address: None,
                 driver: DriverConfig {
                     poll_interval: Duration::from_millis(100),
@@ -1592,6 +1597,7 @@ mod tests {
             PipelineConfig {
                 max_parallel_proofs: 1,
                 max_retries: 1,
+                recovery_scan_concurrency: 8,
                 tee_prover_registry_address: None,
                 driver: DriverConfig {
                     game_type: TEST_GAME_TYPE,

--- a/crates/proof/proposer/src/service.rs
+++ b/crates/proof/proposer/src/service.rs
@@ -204,6 +204,7 @@ impl ProposerService {
         let pipeline_config = PipelineConfig {
             max_parallel_proofs: config.max_parallel_proofs,
             max_retries: MAX_PROOF_RETRIES,
+            recovery_scan_concurrency: config.recovery_scan_concurrency,
             tee_prover_registry_address: config.tee_prover_registry_address,
             driver: DriverConfig {
                 poll_interval: config.poll_interval,


### PR DESCRIPTION
## Summary

- Lower the default `RECOVERY_SCAN_CONCURRENCY` from 32 to 8 to prevent the proposer recovery scan from overwhelming `base-consensus` with concurrent `outputAtBlock` RPCs during startup recovery.
- Make the concurrency configurable via `--recovery-scan-concurrency` CLI flag (env: `BASE_PROPOSER_RECOVERY_SCAN_CONCURRENCY`).
- Thread the config value from `ProposerConfig` through `PipelineConfig` to the `.buffered()` call in the recovery scan stream.

## Context

Part of a series of fixes for consensus RPC unresponsiveness under proposer recovery load:
- #2187 — Parallelize L1 state fetches
- #2188 — Drop stale engine queries
- #2189 — Parallelize engine RPC processing
- #2190 — Add RPC server concurrency limit
- **This PR** — Lower proposer recovery concurrency (demand side)

## Testing

- Added `test_recovery_scan_concurrency_zero_rejected` — validates zero is rejected.
- Added `test_recovery_scan_concurrency_custom` — validates custom value threads through.
- All existing tests updated and passing (70 tests).