### PR TITLE
fix: separate engine rpc processing from engine actor

### DIFF
--- a/crates/consensus/service/src/actors/engine/actor.rs
+++ b/crates/consensus/service/src/actors/engine/actor.rs
@@ -10,18 +10,19 @@ use tokio_util::{
 };
 
 use crate::{
-    EngineActorRequest, EngineError, EngineProcessingRequest, EngineRequestReceiver,
-    EngineRpcRequestReceiver, NodeActor, actors::CancellableContext,
+    EngineActorRequest, EngineError, EngineProcessingRequest, EngineRequestReceiver, NodeActor,
+    actors::CancellableContext,
 };
 
-/// The [`EngineActor`] is an intermediary that receives [`EngineActorRequest`] and delegates:
-/// - Engine RPC queries requests to the configured [`EngineRpcRequestReceiver`]
-/// - Node engine requests to the configured [`EngineRequestReceiver`].
+/// The [`EngineActor`] is an intermediary that receives [`EngineActorRequest`] and delegates
+/// engine requests to the configured [`EngineRequestReceiver`].
+///
+/// RPC queries are handled separately via a dedicated channel to the
+/// [`crate::EngineRpcProcessor`], avoiding head-of-line blocking during heavy engine processing.
 #[derive(Constructor, Debug)]
-pub struct EngineActor<EngineRequestReceiver_, RpcRequestReceiver>
+pub struct EngineActor<EngineRequestReceiver_>
 where
     EngineRequestReceiver_: EngineRequestReceiver,
-    RpcRequestReceiver: EngineRpcRequestReceiver,
 {
     /// The cancellation token shared by all tasks.
     cancellation_token: CancellationToken,
@@ -29,15 +30,11 @@ where
     inbound_request_rx: mpsc::Receiver<EngineActorRequest>,
     /// The processor for engine requests
     engine_receiver: EngineRequestReceiver_,
-    /// The processor for engine RPC requests
-    rpc_receiver: RpcRequestReceiver,
 }
 
-impl<EngineRequestReceiver_, RpcRequestReceiver> CancellableContext
-    for EngineActor<EngineRequestReceiver_, RpcRequestReceiver>
+impl<EngineRequestReceiver_> CancellableContext for EngineActor<EngineRequestReceiver_>
 where
     EngineRequestReceiver_: EngineRequestReceiver,
-    RpcRequestReceiver: EngineRpcRequestReceiver,
 {
     fn cancelled(&self) -> WaitForCancellationFuture<'_> {
         self.cancellation_token.cancelled()
@@ -45,17 +42,14 @@ where
 }
 
 #[async_trait]
-impl<EngineRequestReceiver_, RpcRequestReceiver> NodeActor
-    for EngineActor<EngineRequestReceiver_, RpcRequestReceiver>
+impl<EngineRequestReceiver_> NodeActor for EngineActor<EngineRequestReceiver_>
 where
     EngineRequestReceiver_: EngineRequestReceiver + 'static,
-    RpcRequestReceiver: EngineRpcRequestReceiver + 'static,
 {
     type Error = EngineError;
     type StartData = ();
 
     async fn start(mut self, _: Self::StartData) -> Result<(), Self::Error> {
-        let (rpc_tx, rpc_rx) = mpsc::channel(1024);
         let (engine_processing_tx, engine_processing_rx) = mpsc::channel(1024);
 
         // Helper to DRY task completion handling for RPC & Processing tasks.
@@ -86,14 +80,6 @@ where
             }
         };
 
-        let rpc_cancellation = self.cancellation_token.clone();
-        // Start the engine query server in a separate task to avoid blocking the main task.
-        let rpc_handle = self
-            .rpc_receiver
-            .start(rpc_rx)
-            .with_cancellation_token(&rpc_cancellation)
-            .then(handle_task_result("Engine query", rpc_cancellation.clone()));
-
         let processing_cancellation = self.cancellation_token.clone();
         // Start the engine processing task.
         let processing_handle = self
@@ -116,7 +102,6 @@ where
                 _ = self.cancellation_token.cancelled() => {
                     warn!(target: "engine", "EngineActor received shutdown signal. Awaiting task completion.");
 
-                    rpc_handle.await?;
                     processing_handle.await?;
 
                     return Ok(());
@@ -131,13 +116,6 @@ where
 
                     // Route the request to the appropriate channel.
                     match request {
-                        EngineActorRequest::RpcRequest(rpc_req) => {
-                            rpc_tx.send(*rpc_req).await.map_err(|_| {
-                                error!(target: "engine", "Engine RPC request handler channel closed unexpectedly");
-                                self.cancellation_token.cancel();
-                                EngineError::ChannelClosed
-                            })?;
-                        }
                         EngineActorRequest::BuildRequest(build_req) => {
                             send_engine_processing_request(EngineProcessingRequest::Build(build_req)).await?;
                         }

--- a/crates/consensus/service/src/actors/engine/request.rs
+++ b/crates/consensus/service/src/actors/engine/request.rs
@@ -53,8 +53,6 @@ pub enum EngineActorRequest {
     ProcessUnsafeL2BlockRequest(Box<BaseExecutionPayloadEnvelope>),
     /// Request to reset engine forkchoice.
     ResetRequest(Box<ResetRequest>),
-    /// Request for the engine to process the provided RPC request.
-    RpcRequest(Box<EngineRpcRequest>),
     /// Request to seal the block with the provided details.
     SealRequest(Box<SealRequest>),
 }

--- a/crates/consensus/service/src/actors/rpc/engine_rpc_client.rs
+++ b/crates/consensus/service/src/actors/rpc/engine_rpc_client.rs
@@ -13,15 +13,15 @@ use jsonrpsee::{
 };
 use tokio::sync::{mpsc, oneshot, watch};
 
-use crate::{EngineActorRequest, EngineRpcRequest};
+use crate::EngineRpcRequest;
 
-/// Queue-based implementation of the [`EngineRpcClient`] trait. This handles all channel-based
-/// operations, providing a nice facade for callers. This also exposes only a subset of the
-/// supported [`EngineActorRequest`] operations to limit the power of callers to RPC-type requests.
+/// Queue-based implementation of the [`EngineRpcClient`] trait. Sends RPC queries directly to the
+/// [`crate::EngineRpcProcessor`] via a dedicated channel, bypassing the [`crate::EngineActor`] to
+/// avoid head-of-line blocking during heavy engine processing.
 #[derive(Clone, Constructor, Debug)]
 pub struct QueuedEngineRpcClient {
-    /// A channel to use to send the `EngineActor` requests.
-    pub engine_actor_request_tx: mpsc::Sender<EngineActorRequest>,
+    /// A channel to send RPC requests directly to the [`crate::EngineRpcProcessor`].
+    pub engine_rpc_request_tx: mpsc::Sender<EngineRpcRequest>,
 }
 
 #[async_trait]
@@ -29,10 +29,8 @@ impl EngineRpcClient for QueuedEngineRpcClient {
     async fn get_config(&self) -> RpcResult<RollupConfig> {
         let (config_tx, config_rx) = oneshot::channel();
 
-        self.engine_actor_request_tx
-            .send(EngineActorRequest::RpcRequest(Box::new(EngineRpcRequest::EngineQuery(
-                Box::new(EngineQueries::Config(config_tx)),
-            ))))
+        self.engine_rpc_request_tx
+            .send(EngineRpcRequest::EngineQuery(Box::new(EngineQueries::Config(config_tx))))
             .await
             .map_err(|_| ErrorObject::from(ErrorCode::InternalError))?;
 
@@ -45,10 +43,8 @@ impl EngineRpcClient for QueuedEngineRpcClient {
     async fn get_state(&self) -> RpcResult<EngineState> {
         let (state_tx, state_rx) = oneshot::channel();
 
-        self.engine_actor_request_tx
-            .send(EngineActorRequest::RpcRequest(Box::new(EngineRpcRequest::EngineQuery(
-                Box::new(EngineQueries::State(state_tx)),
-            ))))
+        self.engine_rpc_request_tx
+            .send(EngineRpcRequest::EngineQuery(Box::new(EngineQueries::State(state_tx))))
             .await
             .map_err(|_| ErrorObject::from(ErrorCode::InternalError))?;
 
@@ -64,10 +60,11 @@ impl EngineRpcClient for QueuedEngineRpcClient {
     ) -> RpcResult<(L2BlockInfo, OutputRoot, EngineState)> {
         let (output_tx, output_rx) = oneshot::channel();
 
-        self.engine_actor_request_tx
-            .send(EngineActorRequest::RpcRequest(Box::new(EngineRpcRequest::EngineQuery(
-                Box::new(EngineQueries::OutputAtBlock { block, sender: output_tx }),
-            ))))
+        self.engine_rpc_request_tx
+            .send(EngineRpcRequest::EngineQuery(Box::new(EngineQueries::OutputAtBlock {
+                block,
+                sender: output_tx,
+            })))
             .await
             .map_err(|_| ErrorObject::from(ErrorCode::InternalError))?;
 
@@ -80,9 +77,9 @@ impl EngineRpcClient for QueuedEngineRpcClient {
     async fn dev_get_task_queue_length(&self) -> RpcResult<usize> {
         let (length_tx, length_rx) = oneshot::channel();
 
-        self.engine_actor_request_tx
-            .send(EngineActorRequest::RpcRequest(Box::new(EngineRpcRequest::EngineQuery(
-                Box::new(EngineQueries::TaskQueueLength(length_tx)),
+        self.engine_rpc_request_tx
+            .send(EngineRpcRequest::EngineQuery(Box::new(EngineQueries::TaskQueueLength(
+                length_tx,
             ))))
             .await
             .map_err(|_| ErrorObject::from(ErrorCode::InternalError))?;
@@ -96,9 +93,9 @@ impl EngineRpcClient for QueuedEngineRpcClient {
     async fn dev_subscribe_to_engine_queue_length(&self) -> RpcResult<watch::Receiver<usize>> {
         let (sub_tx, sub_rx) = oneshot::channel();
 
-        self.engine_actor_request_tx
-            .send(EngineActorRequest::RpcRequest(Box::new(EngineRpcRequest::EngineQuery(
-                Box::new(EngineQueries::QueueLengthReceiver(sub_tx)),
+        self.engine_rpc_request_tx
+            .send(EngineRpcRequest::EngineQuery(Box::new(EngineQueries::QueueLengthReceiver(
+                sub_tx,
             ))))
             .await
             .map_err(|_| ErrorObject::from(ErrorCode::InternalError))?;
@@ -111,10 +108,8 @@ impl EngineRpcClient for QueuedEngineRpcClient {
     async fn dev_subscribe_to_engine_state(&self) -> RpcResult<watch::Receiver<EngineState>> {
         let (sub_tx, sub_rx) = oneshot::channel();
 
-        self.engine_actor_request_tx
-            .send(EngineActorRequest::RpcRequest(Box::new(EngineRpcRequest::EngineQuery(
-                Box::new(EngineQueries::StateReceiver(sub_tx)),
-            ))))
+        self.engine_rpc_request_tx
+            .send(EngineRpcRequest::EngineQuery(Box::new(EngineQueries::StateReceiver(sub_tx))))
             .await
             .map_err(|_| ErrorObject::from(ErrorCode::InternalError))?;
 

--- a/crates/consensus/service/src/service/follow.rs
+++ b/crates/consensus/service/src/service/follow.rs
@@ -12,10 +12,10 @@ use tokio_util::sync::CancellationToken;
 
 use crate::{
     AlloyL1BlockFetcher, BlockStream, DelegateL2Client, DelegateL2DerivationActor, EngineActor,
-    EngineActorRequest, EngineConfig, EngineProcessor, EngineRpcProcessor, L1Config,
-    L1WatcherActor, NodeActor, QueuedDerivationEngineClient, QueuedEngineDerivationClient,
-    QueuedEngineRpcClient, QueuedL1WatcherDerivationClient, RpcActor, RpcContext,
-    service::node::HEAD_STREAM_POLL_INTERVAL,
+    EngineActorRequest, EngineConfig, EngineProcessor, EngineRpcProcessor,
+    EngineRpcRequestReceiver, L1Config, L1WatcherActor, NodeActor, QueuedDerivationEngineClient,
+    QueuedEngineDerivationClient, QueuedEngineRpcClient, QueuedL1WatcherDerivationClient, RpcActor,
+    RpcContext, service::node::HEAD_STREAM_POLL_INTERVAL,
 };
 
 /// A lightweight node that follows another L2 node by polling its execution
@@ -76,7 +76,7 @@ impl FollowNode {
         cancellation_token: CancellationToken,
         engine_request_rx: mpsc::Receiver<EngineActorRequest>,
         derivation_client: QueuedEngineDerivationClient,
-    ) -> EngineActor<EngineProcessor<E, QueuedEngineDerivationClient>, EngineRpcProcessor<E>> {
+    ) -> (EngineActor<EngineProcessor<E, QueuedEngineDerivationClient>>, EngineRpcProcessor<E>) {
         let engine_state = EngineState::default();
         let (engine_state_tx, engine_state_rx) = watch::channel(engine_state);
         let (engine_queue_length_tx, engine_queue_length_rx) = watch::channel(0);
@@ -99,12 +99,13 @@ impl FollowNode {
             engine_queue_length_rx,
         );
 
-        EngineActor::new(
+        let engine_actor = EngineActor::new(
             cancellation_token,
             engine_request_rx,
             engine_processor,
-            engine_rpc_processor,
-        )
+        );
+
+        (engine_actor, engine_rpc_processor)
     }
 
     /// Starts the follow node.
@@ -131,13 +132,16 @@ impl FollowNode {
 
         let (derivation_actor_request_tx, derivation_actor_request_rx) = mpsc::channel(1024);
         let (engine_actor_request_tx, engine_actor_request_rx) = mpsc::channel(1024);
+        let (engine_rpc_tx, engine_rpc_rx) = mpsc::channel(1024);
 
-        let engine_actor = self.create_engine_actor(
+        let (engine_actor, engine_rpc_processor) = self.create_engine_actor(
             engine_client,
             cancellation.clone(),
             engine_actor_request_rx,
             QueuedEngineDerivationClient::new(derivation_actor_request_tx.clone()),
         );
+
+        let _engine_rpc_handle = engine_rpc_processor.start(engine_rpc_rx);
 
         let derivation = DelegateL2DerivationActor::<_>::new(
             QueuedDerivationEngineClient {
@@ -152,14 +156,10 @@ impl FollowNode {
         .with_proofs(self.proofs_enabled)
         .with_proofs_max_blocks_ahead(self.proofs_max_blocks_ahead);
 
-        // Create the RPC server actor if configured.
         let rpc = self.rpc_builder.clone().map(|b| {
-            // Follow nodes do not run derivation, so they never produce confirmed safe
-            // heads to record. Safe head tracking is disabled; the RPC endpoint returns
-            // an error if queried.
             RpcActor::new(
                 b,
-                QueuedEngineRpcClient::new(engine_actor_request_tx.clone()),
+                QueuedEngineRpcClient::new(engine_rpc_tx),
                 None::<crate::QueuedSequencerAdminAPIClient>,
                 Arc::new(DisabledSafeDB) as Arc<dyn SafeDBReader>,
             )

--- a/crates/consensus/service/src/service/node.rs
+++ b/crates/consensus/service/src/service/node.rs
@@ -23,11 +23,11 @@ use crate::{
     AlloyL1BlockFetcher, Conductor, ConductorClient, DelayedL1OriginSelectorProvider,
     DelegateDerivationActor, DerivationActor, DerivationDelegateClient, DerivationError,
     EngineActor, EngineActorRequest, EngineConfig, EngineProcessor, EngineRpcProcessor,
-    L1OriginSelector, L1WatcherActor, NetworkActor, NetworkBuilder, NetworkConfig, NodeActor,
-    NodeMode, PayloadBuilder, QueuedDerivationEngineClient, QueuedEngineDerivationClient,
-    QueuedEngineRpcClient, QueuedL1WatcherDerivationClient, QueuedNetworkEngineClient,
-    QueuedSequencerAdminAPIClient, QueuedSequencerEngineClient, RecoveryModeGuard, RpcActor,
-    RpcContext, SequencerActor, SequencerConfig,
+    EngineRpcRequestReceiver, L1OriginSelector, L1WatcherActor, NetworkActor, NetworkBuilder,
+    NetworkConfig, NodeActor, NodeMode, PayloadBuilder, QueuedDerivationEngineClient,
+    QueuedEngineDerivationClient, QueuedEngineRpcClient, QueuedL1WatcherDerivationClient,
+    QueuedNetworkEngineClient, QueuedSequencerAdminAPIClient, QueuedSequencerEngineClient,
+    RecoveryModeGuard, RpcActor, RpcContext, SequencerActor, SequencerConfig,
     actors::{BlockStream, NetworkInboundData, QueuedUnsafePayloadGossipClient},
 };
 
@@ -218,7 +218,8 @@ impl RollupNode {
         derivation_client: QueuedEngineDerivationClient,
         unsafe_head_tx: watch::Sender<L2BlockInfo>,
         conductor: Option<Arc<dyn Conductor>>,
-    ) -> EngineActor<EngineProcessor<E, QueuedEngineDerivationClient>, EngineRpcProcessor<E>> {
+    ) -> (EngineActor<EngineProcessor<E, QueuedEngineDerivationClient>>, EngineRpcProcessor<E>)
+    {
         let engine_state = EngineState::default();
         let (engine_state_tx, engine_state_rx) = watch::channel(engine_state);
         let (engine_queue_length_tx, engine_queue_length_rx) = watch::channel(0);
@@ -241,12 +242,10 @@ impl RollupNode {
             engine_queue_length_rx,
         );
 
-        EngineActor::new(
-            cancellation_token,
-            engine_request_rx,
-            engine_processor,
-            engine_rpc_processor,
-        )
+        let engine_actor =
+            EngineActor::new(cancellation_token, engine_request_rx, engine_processor);
+
+        (engine_actor, engine_rpc_processor)
     }
 
     /// Starts the rollup node service.
@@ -342,6 +341,7 @@ impl RollupNode {
         let (derivation_actor_request_tx, derivation_actor_request_rx) = mpsc::channel(1024);
 
         let (engine_actor_request_tx, engine_actor_request_rx) = mpsc::channel(1024);
+        let (engine_rpc_tx, engine_rpc_rx) = mpsc::channel(1024);
         let (unsafe_head_tx, unsafe_head_rx) = watch::channel(L2BlockInfo::default());
 
         // Create the conductor client early — the engine processor needs it for the
@@ -357,7 +357,7 @@ impl RollupNode {
         let engine_conductor: Option<Arc<dyn Conductor>> =
             conductor.clone().map(|c| Arc::new(c) as Arc<dyn Conductor>);
 
-        let engine_actor = self.create_engine_actor(
+        let (engine_actor, engine_rpc_processor) = self.create_engine_actor(
             engine_client,
             cancellation.clone(),
             engine_actor_request_rx,
@@ -365,6 +365,8 @@ impl RollupNode {
             unsafe_head_tx,
             engine_conductor,
         );
+
+        let _engine_rpc_handle = engine_rpc_processor.start(engine_rpc_rx);
 
         // Select the concrete derivation actor implementation based on
         // RollupNode configuration.
@@ -498,7 +500,7 @@ impl RollupNode {
         let rpc = self.rpc_builder().map(|b| {
             RpcActor::new(
                 b,
-                QueuedEngineRpcClient::new(engine_actor_request_tx.clone()),
+                QueuedEngineRpcClient::new(engine_rpc_tx),
                 sequencer_admin_client,
                 safe_db_reader,
             )


### PR DESCRIPTION
Separates the RPC processing from the engine actor so updating L2 unsafe doesn't block RPC requests from being processed.

Tested locally by running RPC requests.