### PR TITLE
fix(common): Activate Granite Spec In EVM

### DIFF
--- a/crates/common/evm/src/rollup_config_ext.rs
+++ b/crates/common/evm/src/rollup_config_ext.rs
@@ -20,6 +20,8 @@ impl RollupConfigExt for RollupConfig {
             OpSpecId::ISTHMUS
         } else if self.is_holocene_active(timestamp) {
             OpSpecId::HOLOCENE
+        } else if self.is_granite_active(timestamp) {
+            OpSpecId::GRANITE
         } else if self.is_fjord_active(timestamp) {
             OpSpecId::FJORD
         } else if self.is_ecotone_active(timestamp) {
@@ -54,6 +56,8 @@ mod tests {
         assert_eq!(config.spec_id(30), OpSpecId::ECOTONE);
         config.hardforks.fjord_time = Some(40);
         assert_eq!(config.spec_id(40), OpSpecId::FJORD);
+        config.hardforks.granite_time = Some(45);
+        assert_eq!(config.spec_id(45), OpSpecId::GRANITE);
         config.hardforks.holocene_time = Some(50);
         assert_eq!(config.spec_id(50), OpSpecId::HOLOCENE);
         config.hardforks.isthmus_time = Some(60);

--- a/lychee.toml
+++ b/lychee.toml
@@ -16,8 +16,9 @@ exclude = [
     'foo.bar',
     'localhost',
 
-    # Links to files moved in this rename (not yet on main)
+    # Links to files moved or renamed (not yet on main)
     'https://github\.com/base/base/blob/main/crates/execution/upgrades',
+    'https://github\.com/base/base/blob/main/crates/common/evm/src/spec_id\.rs',
 
     # Shields.io badges that query live GitHub stats (flaky, not real links)
     'https://img.shields.io/github/commit-activity/w/base/base',


### PR DESCRIPTION
## Summary

\`RollupConfigExt::spec_id\` was missing a check for the Granite hardfork, jumping directly from Holocene to Fjord. Because \`RollupConfig::is_fjord_active\` cascades through \`is_granite_active\`, any timestamp in the granite era (granite active, holocene not yet active) would match the Fjord branch and return \`OpSpecId::FJORD\` instead of \`OpSpecId::GRANITE\`. This means the proof executor was using the Fjord precompile set for granite-era blocks, which lacks the BN254 pairing input size restriction introduced in Granite (\`GRANITE_MAX_INPUT_SIZE = 112,687\` bytes). This has not caused a live divergence because the full node uses \`OpSpecId::from_timestamp\` (via the \`Upgrades\` trait), which checks each fork independently without cascading, and has always correctly returned \`GRANITE\` — so no violating transaction has ever been included in the canonical chain. The fix adds the missing \`GRANITE\` branch to \`RollupConfigExt::spec_id\` and a corresponding test case.