### PR TITLE
cherry-pick: rename BaseTxType back to OpTxType and restore CompactBaseReceipt field order (#2165)

### DIFF
--- a/crates/alloy/consensus/src/transaction/deposit.rs
+++ b/crates/alloy/consensus/src/transaction/deposit.rs
@@ -139,7 +139,7 @@ impl TxDeposit {
     }
 
     /// Get the transaction type
-    pub(crate) const fn tx_type(&self) -> OpTxType {
+    pub const fn tx_type(&self) -> OpTxType {
         OpTxType::Deposit
     }
 


### PR DESCRIPTION

Reverts the BaseTxType rename introduced in #2160, restoring the original OpTxType name across the workspace. Also moves the tx_type field back to its original first position in CompactBaseReceipt.