### PR TITLE
chore(batcher): Use Auto Impl For ThrottleClient

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2595,6 +2595,7 @@ dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
  "async-trait",
+ "auto_impl",
  "base-batcher-encoder",
  "base-batcher-source",
  "base-blobs",

--- a/crates/batcher/core/Cargo.toml
+++ b/crates/batcher/core/Cargo.toml
@@ -22,6 +22,7 @@ base-runtime = { workspace = true, features = ["tokio"] }
 base-common-consensus = { workspace = true, features = ["std"] }
 
 # external
+auto_impl.workspace = true
 futures.workspace = true
 tracing = { workspace = true, features = ["std"] }
 thiserror = { workspace = true, features = ["std"] }

--- a/crates/batcher/core/src/throttle_client.rs
+++ b/crates/batcher/core/src/throttle_client.rs
@@ -1,7 +1,6 @@
 //! Throttle client trait for applying DA limits to the block builder.
 
-use std::sync::Arc;
-
+use auto_impl::auto_impl;
 use futures::future::BoxFuture;
 
 /// Applies throttle parameters to a block-builder endpoint.
@@ -9,6 +8,7 @@ use futures::future::BoxFuture;
 /// The canonical implementation calls the `miner_setMaxDASize` RPC method
 /// on the L2 execution client, which instructs the sequencer to limit the
 /// amount of DA-eligible data it accepts per transaction and per block.
+#[auto_impl(Arc)]
 pub trait ThrottleClient: Send + Sync + 'static {
     /// Set the maximum DA sizes on the block builder.
     ///
@@ -19,16 +19,6 @@ pub trait ThrottleClient: Send + Sync + 'static {
         max_tx_size: u64,
         max_block_size: u64,
     ) -> BoxFuture<'_, Result<(), Box<dyn std::error::Error + Send + Sync>>>;
-}
-
-impl<T: ThrottleClient> ThrottleClient for Arc<T> {
-    fn set_max_da_size(
-        &self,
-        max_tx_size: u64,
-        max_block_size: u64,
-    ) -> BoxFuture<'_, Result<(), Box<dyn std::error::Error + Send + Sync>>> {
-        (**self).set_max_da_size(max_tx_size, max_block_size)
-    }
 }
 
 /// No-op [`ThrottleClient`] that silently discards all DA limit calls.


### PR DESCRIPTION
## Summary

Replaces the manual `impl<T: ThrottleClient> ThrottleClient for Arc<T>` forwarding block with `#[auto_impl(Arc)]` on the trait. The trait uses `BoxFuture` directly rather than `async_trait`, which makes it fully compatible with `auto_impl`. This removes 11 lines of mechanical boilerplate while preserving identical runtime behavior.