### PR TITLE
[backport] feat(rpc): add concurrency limit to RPC server (#2190)

### DIFF
--- a/crates/client/cli/src/rpc.rs
+++ b/crates/client/cli/src/rpc.rs
@@ -42,6 +42,13 @@ pub struct RpcArgs {
     /// HTTP request timeout in seconds for the RPC server.
     #[arg(long = "rpc.timeout", default_value = "60", env = "BASE_NODE_RPC_TIMEOUT")]
     pub http_timeout_secs: u64,
+    /// Maximum number of concurrent in-flight RPC requests.
+    #[arg(
+        long = "rpc.max-concurrent",
+        default_value = "256",
+        env = "BASE_NODE_RPC_MAX_CONCURRENT"
+    )]
+    pub max_concurrent_requests: usize,
 }
 
 impl Default for RpcArgs {
@@ -65,6 +72,7 @@ impl From<RpcArgs> for Option<RpcBuilder> {
             ws_enabled: args.ws_enabled,
             dev_enabled: args.dev_enabled,
             http_timeout: Duration::from_secs(args.http_timeout_secs),
+            max_concurrent_requests: args.max_concurrent_requests,
         })
     }
 }

--- a/crates/client/cli/src/rpc.rs
+++ b/crates/client/cli/src/rpc.rs
@@ -46,7 +46,7 @@ pub struct RpcArgs {
     /// Maximum number of concurrent in-flight RPC requests.
     #[arg(
         long = "rpc.max-concurrent",
-        default_value = "256",
+        default_value = "1024",
         env = "BASE_NODE_RPC_MAX_CONCURRENT",
         value_parser = clap::value_parser!(NonZeroUsize),
     )]

--- a/crates/client/cli/src/rpc.rs
+++ b/crates/client/cli/src/rpc.rs
@@ -47,9 +47,10 @@ pub struct RpcArgs {
     #[arg(
         long = "rpc.max-concurrent",
         default_value = "256",
-        env = "BASE_NODE_RPC_MAX_CONCURRENT"
+        env = "BASE_NODE_RPC_MAX_CONCURRENT",
+        value_parser = clap::value_parser!(NonZeroUsize),
     )]
-    pub max_concurrent_requests: usize,
+    pub max_concurrent_requests: NonZeroUsize,
 }
 
 impl Default for RpcArgs {
@@ -73,8 +74,7 @@ impl From<RpcArgs> for Option<RpcBuilder> {
             ws_enabled: args.ws_enabled,
             dev_enabled: args.dev_enabled,
             http_timeout: Duration::from_secs(args.http_timeout_secs),
-            max_concurrent_requests: NonZeroUsize::new(args.max_concurrent_requests)
-                .expect("max_concurrent_requests must be > 0"),
+            max_concurrent_requests: args.max_concurrent_requests,
         })
     }
 }

--- a/crates/client/cli/src/rpc.rs
+++ b/crates/client/cli/src/rpc.rs
@@ -4,6 +4,7 @@
 
 use std::{
     net::{IpAddr, SocketAddr},
+    num::NonZeroUsize,
     path::PathBuf,
     time::Duration,
 };
@@ -72,7 +73,8 @@ impl From<RpcArgs> for Option<RpcBuilder> {
             ws_enabled: args.ws_enabled,
             dev_enabled: args.dev_enabled,
             http_timeout: Duration::from_secs(args.http_timeout_secs),
-            max_concurrent_requests: args.max_concurrent_requests,
+            max_concurrent_requests: NonZeroUsize::new(args.max_concurrent_requests)
+                .expect("max_concurrent_requests must be > 0"),
         })
     }
 }

--- a/crates/consensus/rpc/src/config.rs
+++ b/crates/consensus/rpc/src/config.rs
@@ -20,6 +20,8 @@ pub struct RpcBuilder {
     pub dev_enabled: bool,
     /// HTTP request timeout for the RPC server.
     pub http_timeout: Duration,
+    /// Maximum number of concurrent in-flight RPC requests.
+    pub max_concurrent_requests: usize,
 }
 
 impl RpcBuilder {

--- a/crates/consensus/rpc/src/config.rs
+++ b/crates/consensus/rpc/src/config.rs
@@ -1,6 +1,6 @@
 //! Contains the RPC Configuration.
 
-use std::{net::SocketAddr, path::PathBuf, time::Duration};
+use std::{net::SocketAddr, num::NonZeroUsize, path::PathBuf, time::Duration};
 
 /// The RPC configuration.
 #[derive(Debug, Clone)]
@@ -21,7 +21,7 @@ pub struct RpcBuilder {
     /// HTTP request timeout for the RPC server.
     pub http_timeout: Duration,
     /// Maximum number of concurrent in-flight RPC requests.
-    pub max_concurrent_requests: usize,
+    pub max_concurrent_requests: NonZeroUsize,
 }
 
 impl RpcBuilder {

--- a/crates/consensus/service/Cargo.toml
+++ b/crates/consensus/service/Cargo.toml
@@ -52,7 +52,7 @@ serde.workspace = true
 url.workspace = true
 futures.workspace = true
 http.workspace = true
-tower = { workspace = true, features = ["limit"] }
+tower = { workspace = true, features = ["limit", "load-shed"] }
 bytes.workspace = true
 discv5.workspace = true
 http-body.workspace = true

--- a/crates/consensus/service/Cargo.toml
+++ b/crates/consensus/service/Cargo.toml
@@ -52,7 +52,7 @@ serde.workspace = true
 url.workspace = true
 futures.workspace = true
 http.workspace = true
-tower.workspace = true
+tower = { workspace = true, features = ["limit"] }
 bytes.workspace = true
 discv5.workspace = true
 http-body.workspace = true

--- a/crates/consensus/service/src/actors/rpc/actor.rs
+++ b/crates/consensus/service/src/actors/rpc/actor.rs
@@ -74,6 +74,7 @@ async fn launch(
             ProxyGetRequestLayer::new([("/healthz", "healthz")])
                 .expect("Critical: Failed to build GET method proxy"),
         )
+        .layer(tower::limit::ConcurrencyLimitLayer::new(256))
         .layer(TimeoutLayer::with_status_code(StatusCode::REQUEST_TIMEOUT, config.http_timeout));
     let server = Server::builder().set_http_middleware(middleware).build(config.socket).await?;
 

--- a/crates/consensus/service/src/actors/rpc/actor.rs
+++ b/crates/consensus/service/src/actors/rpc/actor.rs
@@ -75,8 +75,8 @@ async fn launch(
                 .expect("Critical: Failed to build GET method proxy"),
         )
         .layer(TimeoutLayer::with_status_code(StatusCode::REQUEST_TIMEOUT, config.http_timeout))
-        .layer(tower::load_shed::LoadShedLayer::new())
-        .layer(tower::limit::ConcurrencyLimitLayer::new(config.max_concurrent_requests));
+        .layer(tower::limit::ConcurrencyLimitLayer::new(config.max_concurrent_requests.get()))
+        .layer(tower::load_shed::LoadShedLayer::new());
     let server = Server::builder().set_http_middleware(middleware).build(config.socket).await?;
 
     if let Ok(addr) = server.local_addr() {
@@ -173,7 +173,7 @@ where
 
 #[cfg(test)]
 mod tests {
-    use std::{net::SocketAddr, time::Duration};
+    use std::{net::SocketAddr, num::NonZeroUsize, time::Duration};
 
     use super::*;
 
@@ -187,7 +187,7 @@ mod tests {
             ws_enabled: false,
             dev_enabled: false,
             http_timeout: Duration::from_secs(60),
-            max_concurrent_requests: 256,
+            max_concurrent_requests: NonZeroUsize::new(256).expect("nonzero"),
         };
         let result = launch(&launcher, RpcModule::new(())).await;
         assert!(result.is_ok());
@@ -203,7 +203,7 @@ mod tests {
             ws_enabled: false,
             dev_enabled: false,
             http_timeout: Duration::from_secs(60),
-            max_concurrent_requests: 256,
+            max_concurrent_requests: NonZeroUsize::new(256).expect("nonzero"),
         };
         let mut modules = RpcModule::new(());
 

--- a/crates/consensus/service/src/actors/rpc/actor.rs
+++ b/crates/consensus/service/src/actors/rpc/actor.rs
@@ -187,7 +187,7 @@ mod tests {
             ws_enabled: false,
             dev_enabled: false,
             http_timeout: Duration::from_secs(60),
-            max_concurrent_requests: NonZeroUsize::new(256).expect("nonzero"),
+            max_concurrent_requests: NonZeroUsize::new(1024).expect("nonzero"),
         };
         let result = launch(&launcher, RpcModule::new(())).await;
         assert!(result.is_ok());
@@ -203,7 +203,7 @@ mod tests {
             ws_enabled: false,
             dev_enabled: false,
             http_timeout: Duration::from_secs(60),
-            max_concurrent_requests: NonZeroUsize::new(256).expect("nonzero"),
+            max_concurrent_requests: NonZeroUsize::new(1024).expect("nonzero"),
         };
         let mut modules = RpcModule::new(());
 

--- a/crates/consensus/service/src/actors/rpc/actor.rs
+++ b/crates/consensus/service/src/actors/rpc/actor.rs
@@ -75,8 +75,8 @@ async fn launch(
                 .expect("Critical: Failed to build GET method proxy"),
         )
         .layer(TimeoutLayer::with_status_code(StatusCode::REQUEST_TIMEOUT, config.http_timeout))
-        .layer(tower::limit::ConcurrencyLimitLayer::new(config.max_concurrent_requests))
-        .layer(tower::load_shed::LoadShedLayer::new());
+        .layer(tower::load_shed::LoadShedLayer::new())
+        .layer(tower::limit::ConcurrencyLimitLayer::new(config.max_concurrent_requests));
     let server = Server::builder().set_http_middleware(middleware).build(config.socket).await?;
 
     if let Ok(addr) = server.local_addr() {

--- a/crates/consensus/service/src/actors/rpc/actor.rs
+++ b/crates/consensus/service/src/actors/rpc/actor.rs
@@ -69,14 +69,14 @@ async fn launch(
     module: RpcModule<()>,
 ) -> Result<ServerHandle, std::io::Error> {
     let middleware = tower::ServiceBuilder::new()
+        .layer(TimeoutLayer::with_status_code(StatusCode::REQUEST_TIMEOUT, config.http_timeout))
+        .layer(tower::limit::ConcurrencyLimitLayer::new(config.max_concurrent_requests.get()))
+        .layer(tower::load_shed::LoadShedLayer::new())
         .layer(EthHealthCheckLayer)
         .layer(
             ProxyGetRequestLayer::new([("/healthz", "healthz")])
                 .expect("Critical: Failed to build GET method proxy"),
-        )
-        .layer(TimeoutLayer::with_status_code(StatusCode::REQUEST_TIMEOUT, config.http_timeout))
-        .layer(tower::limit::ConcurrencyLimitLayer::new(config.max_concurrent_requests.get()))
-        .layer(tower::load_shed::LoadShedLayer::new());
+        );
     let server = Server::builder().set_http_middleware(middleware).build(config.socket).await?;
 
     if let Ok(addr) = server.local_addr() {

--- a/crates/consensus/service/src/actors/rpc/actor.rs
+++ b/crates/consensus/service/src/actors/rpc/actor.rs
@@ -74,8 +74,9 @@ async fn launch(
             ProxyGetRequestLayer::new([("/healthz", "healthz")])
                 .expect("Critical: Failed to build GET method proxy"),
         )
-        .layer(tower::limit::ConcurrencyLimitLayer::new(256))
-        .layer(TimeoutLayer::with_status_code(StatusCode::REQUEST_TIMEOUT, config.http_timeout));
+        .layer(TimeoutLayer::with_status_code(StatusCode::REQUEST_TIMEOUT, config.http_timeout))
+        .layer(tower::limit::ConcurrencyLimitLayer::new(config.max_concurrent_requests))
+        .layer(tower::load_shed::LoadShedLayer::new());
     let server = Server::builder().set_http_middleware(middleware).build(config.socket).await?;
 
     if let Ok(addr) = server.local_addr() {
@@ -186,6 +187,7 @@ mod tests {
             ws_enabled: false,
             dev_enabled: false,
             http_timeout: Duration::from_secs(60),
+            max_concurrent_requests: 256,
         };
         let result = launch(&launcher, RpcModule::new(())).await;
         assert!(result.is_ok());
@@ -201,6 +203,7 @@ mod tests {
             ws_enabled: false,
             dev_enabled: false,
             http_timeout: Duration::from_secs(60),
+            max_concurrent_requests: 256,
         };
         let mut modules = RpcModule::new(());
 

--- a/devnet/src/l2/in_process_consensus.rs
+++ b/devnet/src/l2/in_process_consensus.rs
@@ -159,6 +159,7 @@ impl InProcessConsensus {
             ws_enabled: false,
             dev_enabled: false,
             http_timeout: Duration::from_secs(60),
+            max_concurrent_requests: 256,
         };
 
         let mut builder = RollupNodeBuilder::new(

--- a/devnet/src/l2/in_process_consensus.rs
+++ b/devnet/src/l2/in_process_consensus.rs
@@ -6,6 +6,7 @@
 
 use std::{
     net::{IpAddr, Ipv4Addr, SocketAddr},
+    num::NonZeroUsize,
     sync::Arc,
     time::Duration,
 };
@@ -159,7 +160,7 @@ impl InProcessConsensus {
             ws_enabled: false,
             dev_enabled: false,
             http_timeout: Duration::from_secs(60),
-            max_concurrent_requests: 256,
+            max_concurrent_requests: NonZeroUsize::new(256).expect("nonzero"),
         };
 
         let mut builder = RollupNodeBuilder::new(

--- a/devnet/src/l2/in_process_consensus.rs
+++ b/devnet/src/l2/in_process_consensus.rs
@@ -160,7 +160,7 @@ impl InProcessConsensus {
             ws_enabled: false,
             dev_enabled: false,
             http_timeout: Duration::from_secs(60),
-            max_concurrent_requests: NonZeroUsize::new(256).expect("nonzero"),
+            max_concurrent_requests: NonZeroUsize::new(1024).expect("nonzero"),
         };
 
         let mut builder = RollupNodeBuilder::new(


### PR DESCRIPTION
## Summary
- Backport of #2190 to `releases/v0.7.4`
- Adds concurrency limit and load shedding to the RPC server
- Resolved two Cargo.toml merge conflicts (tower features + existing deps on the release branch)