### PR TITLE
fix(challenger): make scanner stateless and validate dual-proof games [backport v0.8.0]

### DIFF
--- a/crates/proof/challenge/src/bond.rs
+++ b/crates/proof/challenge/src/bond.rs
@@ -1156,7 +1156,7 @@ mod tests {
             verifier_games.insert(addr(i), state);
         }
         let factory: Arc<dyn DisputeGameFactoryClient> = Arc::new(MockDisputeGameFactory { games });
-        let verifier = Arc::new(MockAggregateVerifier { games: verifier_games });
+        let verifier = Arc::new(MockAggregateVerifier::new(verifier_games));
         (factory, verifier)
     }
 
@@ -1243,7 +1243,7 @@ mod tests {
         verifier_games.insert(addr(0), state);
 
         let factory: Arc<dyn DisputeGameFactoryClient> = Arc::new(MockDisputeGameFactory { games });
-        let verifier = Arc::new(MockAggregateVerifier { games: verifier_games });
+        let verifier = Arc::new(MockAggregateVerifier::new(verifier_games));
 
         let clock = fixed_clock(0);
         let mut mgr = BondManager::new(
@@ -1390,7 +1390,7 @@ mod tests {
 
         let mut verifier_games = HashMap::new();
         verifier_games.insert(game, state);
-        let verifier = Arc::new(MockAggregateVerifier { games: verifier_games });
+        let verifier = Arc::new(MockAggregateVerifier::new(verifier_games));
 
         let clock = fixed_clock(500);
         let phase = BondManager::determine_phase(&*verifier, game, &clock).await.unwrap().unwrap();
@@ -1414,7 +1414,7 @@ mod tests {
 
         let mut verifier_games = HashMap::new();
         verifier_games.insert(game, state);
-        let verifier = Arc::new(MockAggregateVerifier { games: verifier_games });
+        let verifier = Arc::new(MockAggregateVerifier::new(verifier_games));
 
         let clock = fixed_clock(500);
         let mut mgr = BondManager::new(
@@ -1457,7 +1457,7 @@ mod tests {
             clock,
         );
 
-        let verifier = Arc::new(MockAggregateVerifier { games: HashMap::new() });
+        let verifier = Arc::new(MockAggregateVerifier::new(HashMap::new()));
         mgr.discover_claimable_games(&*verifier).await.unwrap();
         assert_eq!(mgr.tracked_count(), 0);
         assert_eq!(mgr.bond_scan_head, 0);

--- a/crates/proof/challenge/src/driver.rs
+++ b/crates/proof/challenge/src/driver.rs
@@ -4,13 +4,16 @@
 //! invalid dispute games, validating output roots, requesting proofs, and
 //! submitting dispute transactions — into a single polling loop.
 //!
-//! Three dispute paths are supported:
+//! Four dispute paths are supported:
 //!
 //! 1. **Wrong TEE proof** — nullify with a TEE proof (`nullify()`) or
 //!    challenge with a ZK proof (`challenge()`).
 //! 2. **Correct TEE proof challenged with a wrong ZK proof** — nullify
 //!    the fraudulent ZK challenge with a ZK proof (`nullify()`).
 //! 3. **Wrong ZK proposal** — nullify with a ZK proof (`nullify()`).
+//! 4. **Wrong dual proposal (TEE + ZK, no challenge)** — nullify with a
+//!    TEE proof first (`nullify()`), falling back to ZK `nullify()`.
+//!    After the TEE proof is nullified, the game is re-scanned as Path 3.
 
 use std::{
     sync::{
@@ -271,7 +274,7 @@ impl<L2: L2Provider, P: ZkProofProvider, T: TxManager, C: Clock> Driver<L2, P, T
             GameCategory::FraudulentZkChallenge { challenged_index } => {
                 self.process_fraudulent_zk_challenge(candidate, challenged_index).await
             }
-            GameCategory::InvalidZkProposal => {
+            GameCategory::InvalidZkProposal | GameCategory::InvalidDualProposal => {
                 self.process_invalid_proposal(candidate, DisputeIntent::Nullify).await
             }
         }
@@ -325,7 +328,8 @@ impl<L2: L2Provider, P: ZkProofProvider, T: TxManager, C: Clock> Driver<L2, P, T
     }
 
     /// Processes a game whose proposal may contain an invalid intermediate
-    /// root (Path 1: wrong TEE proof, Path 3: wrong ZK proof).
+    /// root (Path 1: wrong TEE proof, Path 3: wrong ZK proof, Path 4:
+    /// wrong dual proposal).
     ///
     /// Validates the intermediate roots against the local L2 node. If a
     /// mismatch is found, initiates a proof with the given `intent`.
@@ -360,12 +364,18 @@ impl<L2: L2Provider, P: ZkProofProvider, T: TxManager, C: Clock> Driver<L2, P, T
             "invalid intermediate root detected, requesting proof"
         );
 
-        match candidate.category {
+        let try_tee_first = match candidate.category {
             GameCategory::InvalidTeeProposal => {
                 ChallengerMetrics::invalid_tee_proposal_detected_total().increment(1);
+                true
             }
             GameCategory::InvalidZkProposal => {
                 ChallengerMetrics::invalid_zk_proposal_detected_total().increment(1);
+                false
+            }
+            GameCategory::InvalidDualProposal => {
+                ChallengerMetrics::invalid_dual_proposal_detected_total().increment(1);
+                true
             }
             GameCategory::FraudulentZkChallenge { .. } => {
                 error!(
@@ -383,9 +393,9 @@ impl<L2: L2Provider, P: ZkProofProvider, T: TxManager, C: Clock> Driver<L2, P, T
                     candidate.category
                 ));
             }
-        }
+        };
 
-        self.initiate_proof(candidate, invalid_index, expected_root, intent).await
+        self.initiate_proof(candidate, invalid_index, expected_root, intent, try_tee_first).await
     }
 
     /// Processes a game whose correct TEE proposal has been challenged with
@@ -477,23 +487,30 @@ impl<L2: L2Provider, P: ZkProofProvider, T: TxManager, C: Clock> Driver<L2, P, T
 
     /// Attempts TEE-first proof sourcing with ZK fallback.
     ///
-    /// The `intent` determines the on-chain action. For Path 1
-    /// ([`DisputeIntent::Challenge`]) the ZK proof targets `challenge()`.
+    /// The `intent` determines the on-chain action for the ZK fallback path.
     /// TEE proofs always use `nullify()` regardless of `intent`.
+    ///
+    /// When `try_tee_first` is `true` and the game has a non-zero TEE prover,
+    /// a synchronous TEE proof is attempted before falling back to ZK.
+    /// Path 1 (`InvalidTeeProposal`) sets `try_tee_first = true` with
+    /// `intent = Challenge`; Path 4 (`InvalidDualProposal`) sets
+    /// `try_tee_first = true` with `intent = Nullify` so the ZK fallback
+    /// also calls `nullify()`.
     async fn initiate_proof(
         &mut self,
         candidate: CandidateGame,
         invalid_index: u64,
         expected_root: B256,
         intent: DisputeIntent,
+        try_tee_first: bool,
     ) -> eyre::Result<()> {
         let game_address = candidate.factory.proxy;
 
-        // TEE-first: try if game has a TEE prover and we have a TEE config.
-        // TEE proofs only make sense when the intent is to challenge a TEE
-        // proposal — TEE nullification replaces the bad TEE proof.
+        // TEE-first: try if the game has a TEE prover, we have a TEE config,
+        // and the caller opted in. Path 1 (InvalidTeeProposal) and Path 4
+        // (InvalidDualProposal) set `try_tee_first = true`.
         if candidate.tee_prover != Address::ZERO
-            && intent == DisputeIntent::Challenge
+            && try_tee_first
             && let Some(tee) = &self.tee
         {
             ChallengerMetrics::tee_proof_attempts_total().increment(1);

--- a/crates/proof/challenge/src/driver.rs
+++ b/crates/proof/challenge/src/driver.rs
@@ -125,8 +125,6 @@ where
     pub cancel: CancellationToken,
     /// Indicates whether the driver has completed its first scan.
     pub ready: Arc<AtomicBool>,
-    /// The last L1 block number that was scanned.
-    pub last_scanned: Option<u64>,
 }
 
 impl<L2: L2Provider, P: ZkProofProvider, T: TxManager, C: Clock> std::fmt::Debug
@@ -136,7 +134,6 @@ impl<L2: L2Provider, P: ZkProofProvider, T: TxManager, C: Clock> std::fmt::Debug
         f.debug_struct("Driver")
             .field("pending_proofs", &self.pending_proofs.len())
             .field("poll_interval", &self.poll_interval)
-            .field("last_scanned", &self.last_scanned)
             .finish_non_exhaustive()
     }
 }
@@ -159,7 +156,6 @@ impl<L2: L2Provider, P: ZkProofProvider, T: TxManager, C: Clock> Driver<L2, P, T
             poll_interval: config.poll_interval,
             cancel: config.cancel,
             ready: config.ready,
-            last_scanned: None,
         }
     }
 
@@ -209,8 +205,7 @@ impl<L2: L2Provider, P: ZkProofProvider, T: TxManager, C: Clock> Driver<L2, P, T
         self.discover_claimable_bonds().await;
         self.poll_bond_claims().await;
 
-        let (candidates, new_last_scanned) = self.scanner.scan(self.last_scanned).await?;
-        self.last_scanned = new_last_scanned;
+        let candidates = self.scanner.scan().await?;
 
         for candidate in candidates {
             let index = candidate.index;

--- a/crates/proof/challenge/src/metrics.rs
+++ b/crates/proof/challenge/src/metrics.rs
@@ -66,6 +66,9 @@ base_metrics::define_metrics! {
     #[describe("Total number of invalid ZK proposals detected (Path 3)")]
     invalid_zk_proposal_detected_total: counter,
 
+    #[describe("Total number of invalid dual proposals detected (Path 4)")]
+    invalid_dual_proposal_detected_total: counter,
+
     #[describe("Total number of resolve transaction outcomes")]
     #[label(name = "status", default = ["success", "reverted", "error", "already_resolved"])]
     resolve_tx_outcome_total: counter,

--- a/crates/proof/challenge/src/scanner.rs
+++ b/crates/proof/challenge/src/scanner.rs
@@ -21,6 +21,13 @@
 //!    The driver validates the intermediate roots and, if invalid,
 //!    nullifies with a ZK proof.
 //!
+//! Games where both TEE and ZK proofs are present but no challenge has
+//! been filed (`counteredByIntermediateRootIndexPlusOne == 0`) are
+//! classified as [`InvalidZkProposal`](GameCategory::InvalidZkProposal)
+//! so that both proofs are validated. If the roots are invalid, the ZK
+//! proof is nullified first; the subsequent scan then handles the TEE
+//! proof.
+//!
 //! Games that are not `IN_PROGRESS` or have been fully nullified (both
 //! provers zero) are skipped.
 
@@ -108,10 +115,11 @@ impl CandidateGame {
     }
 }
 
-/// Scans the `DisputeGameFactory` for new dispute games that need validation.
+/// Scans the `DisputeGameFactory` for dispute games that need validation.
 ///
-/// The scanner is stateless across restarts — `last_scanned_index` is ephemeral
-/// and recomputed from the lookback window on startup.
+/// The scanner is fully stateless — every call re-evaluates the entire
+/// lookback window so that on-chain state changes (new proofs added,
+/// challenges filed) are always detected.
 pub struct GameScanner {
     factory_client: Arc<dyn DisputeGameFactoryClient>,
     verifier_client: Arc<dyn AggregateVerifierClient>,
@@ -142,43 +150,28 @@ impl GameScanner {
         Self { factory_client, verifier_client, config, interval_cache: Mutex::new(HashMap::new()) }
     }
 
-    /// Scans for new candidate games since `last_scanned`.
+    /// Scans the lookback window for candidate games that need validation.
     ///
-    /// Returns a tuple of `(candidates, new_last_scanned)` where `new_last_scanned`
-    /// is the latest factory index that was evaluated. The caller is responsible
-    /// for tracking `last_scanned` between calls.
-    ///
-    /// On a fresh start, pass `None` as `last_scanned` and the lookback window will
-    /// determine the scan range.
+    /// Every call re-evaluates the full lookback window so that on-chain state
+    /// changes (new proofs added, challenges filed) are always detected. Games
+    /// that are not `IN_PROGRESS` or have been fully nullified are filtered out
+    /// cheaply via a single `status()` RPC call.
     ///
     /// Individual game query failures are logged and skipped so that a transient
-    /// RPC error on one game does not abort the entire scan. After evaluation,
-    /// the `base_challenger_games_scanned_total` counter and
+    /// RPC error on one game does not abort the entire scan. Errored games are
+    /// naturally retried on the next tick. After evaluation, the
+    /// `base_challenger_games_scanned_total` counter and
     /// `base_challenger_scan_head` gauge are updated.
-    pub async fn scan(
-        &self,
-        last_scanned: Option<u64>,
-    ) -> Result<(Vec<CandidateGame>, Option<u64>)> {
+    pub async fn scan(&self) -> Result<Vec<CandidateGame>> {
         let game_count = self.factory_client.game_count().await?;
 
         if game_count == 0 {
             debug!("factory has no games");
-            return Ok((vec![], last_scanned));
+            return Ok(vec![]);
         }
 
         let end = game_count - 1;
-        let lookback_start = game_count.saturating_sub(self.config.lookback_games);
-        let start =
-            last_scanned.map_or(lookback_start, |idx| idx.saturating_add(1).max(lookback_start));
-
-        if start > end {
-            debug!(
-                last_scanned = ?last_scanned,
-                game_count = game_count,
-                "no new games since last scan"
-            );
-            return Ok((vec![], last_scanned));
-        }
+        let start = game_count.saturating_sub(self.config.lookback_games);
 
         let games_to_scan = end - start + 1;
 
@@ -189,7 +182,6 @@ impl GameScanner {
             .await;
 
         let mut candidates = Vec::new();
-        let mut lowest_error: Option<u64> = None;
 
         for (i, result) in results {
             match result {
@@ -197,7 +189,6 @@ impl GameScanner {
                 Ok(None) => {}
                 Err(e) => {
                     warn!(error = %e, index = i, "failed to query game, skipping");
-                    lowest_error = lowest_error.map_or(Some(i), |prev| Some(prev.min(i)));
                 }
             }
         }
@@ -205,22 +196,16 @@ impl GameScanner {
         candidates.sort_unstable_by_key(|c| c.index);
 
         ChallengerMetrics::games_scanned_total().increment(games_to_scan);
-
-        let new_last_scanned =
-            lowest_error.map_or(Some(end), |e| e.checked_sub(1).or(last_scanned));
-
-        if let Some(head) = new_last_scanned {
-            ChallengerMetrics::scan_head().set(head as f64);
-        }
+        ChallengerMetrics::scan_head().set(end as f64);
 
         info!(
             games_found = candidates.len(),
-            scan_head = ?new_last_scanned,
+            scan_head = end,
             games_scanned = games_to_scan,
             "scan complete"
         );
 
-        Ok((candidates, new_last_scanned))
+        Ok(candidates)
     }
 
     /// Evaluates a single game at the given factory index.
@@ -301,10 +286,13 @@ impl GameScanner {
             }
 
             // TEE + ZK present but no countered index — second proof was added
-            // via `verifyProposalProof`, not via `challenge`. Skip.
+            // via `verifyProposalProof`, not via `challenge`. Both proofs may
+            // still verify an incorrect root, so validate the ZK proof first.
+            // After ZK nullification the game becomes (true, false, 0) and
+            // will be re-classified as `InvalidTeeProposal` on the next scan.
             (true, true, 0) => {
-                debug!(index = index, "skipping game with both proofs verified (no challenge)");
-                None
+                debug!(index = index, "dual-proof game selected for validation");
+                Some(GameCategory::InvalidZkProposal)
             }
 
             // Path 2: TEE-proposed and challenged by ZK.

--- a/crates/proof/challenge/src/scanner.rs
+++ b/crates/proof/challenge/src/scanner.rs
@@ -2,7 +2,7 @@
 //!
 //! Scans the [`DisputeGameFactory`](base_proof_contracts::DisputeGameFactoryClient)
 //! for dispute games that require action. Each game is classified into one
-//! of three [`GameCategory`] variants based on its on-chain state:
+//! of four [`GameCategory`] variants based on its on-chain state:
 //!
 //! 1. **[`InvalidTeeProposal`](GameCategory::InvalidTeeProposal)** —
 //!    TEE-proposed game (`teeProver != 0`, `zkProver == 0`). The driver
@@ -21,12 +21,13 @@
 //!    The driver validates the intermediate roots and, if invalid,
 //!    nullifies with a ZK proof.
 //!
-//! Games where both TEE and ZK proofs are present but no challenge has
-//! been filed (`counteredByIntermediateRootIndexPlusOne == 0`) are
-//! classified as [`InvalidZkProposal`](GameCategory::InvalidZkProposal)
-//! so that both proofs are validated. If the roots are invalid, the ZK
-//! proof is nullified first; the subsequent scan then handles the TEE
-//! proof.
+//! 4. **[`InvalidDualProposal`](GameCategory::InvalidDualProposal)** —
+//!    Both TEE and ZK proofs are present but no challenge has been filed
+//!    (`counteredByIntermediateRootIndexPlusOne == 0`). The driver
+//!    nullifies the TEE proof first (fast, synchronous) and falls back to
+//!    ZK nullification if TEE proving is unavailable. After the TEE proof
+//!    is nullified, the subsequent scan reclassifies the game as
+//!    [`InvalidZkProposal`](GameCategory::InvalidZkProposal).
 //!
 //! Games that are not `IN_PROGRESS` or have been fully nullified (both
 //! provers zero) are skipped.
@@ -79,6 +80,17 @@ pub enum GameCategory {
     /// The driver validates the intermediate roots. If invalid it submits
     /// a ZK proof via `nullify()` to nullify the incorrect ZK proposal.
     InvalidZkProposal,
+
+    /// Path 4: Both TEE and ZK proofs present with no challenge
+    /// (`countered_index == 0`). The second proof was added via
+    /// `verifyProposalProof`, not via `challenge`.
+    ///
+    /// Both proofs may still verify an incorrect root. The driver
+    /// nullifies the TEE proof first (fast, synchronous) and falls back
+    /// to ZK nullification if TEE proving is unavailable or fails.
+    /// After TEE nullification the game becomes `(false, true, 0)` and
+    /// will be re-classified as [`InvalidZkProposal`] on the next scan.
+    InvalidDualProposal,
 }
 
 /// A dispute game that has been identified as a candidate for action.
@@ -211,7 +223,7 @@ impl GameScanner {
     /// Evaluates a single game at the given factory index.
     ///
     /// Returns `Some(CandidateGame)` if the game is `IN_PROGRESS` and
-    /// matches one of the three [`GameCategory`] variants. Returns `None`
+    /// matches one of the four [`GameCategory`] variants. Returns `None`
     /// if the game should be skipped (resolved, fully nullified, or in
     /// an unrecognized state).
     pub async fn evaluate_game(&self, index: u64) -> Result<Option<CandidateGame>> {
@@ -287,12 +299,11 @@ impl GameScanner {
 
             // TEE + ZK present but no countered index — second proof was added
             // via `verifyProposalProof`, not via `challenge`. Both proofs may
-            // still verify an incorrect root, so validate the ZK proof first.
-            // After ZK nullification the game becomes (true, false, 0) and
-            // will be re-classified as `InvalidTeeProposal` on the next scan.
+            // still verify an incorrect root. Nullify the TEE proof first
+            // (fast) then the ZK proof on the next scan.
             (true, true, 0) => {
                 debug!(index = index, "dual-proof game selected for validation");
-                Some(GameCategory::InvalidZkProposal)
+                Some(GameCategory::InvalidDualProposal)
             }
 
             // Path 2: TEE-proposed and challenged by ZK.

--- a/crates/proof/challenge/src/test_utils.rs
+++ b/crates/proof/challenge/src/test_utils.rs
@@ -715,7 +715,7 @@ mod tests {
         // Game 0: type 1, IN_PROGRESS, TEE only -> candidate (InvalidTeeProposal)
         // Game 1: type 99, IN_PROGRESS, TEE only -> candidate (all types scanned)
         // Game 2: type 1, status=1 (not in progress) -> skipped
-        // Game 3: type 1, IN_PROGRESS, TEE + ZK (dual proof) -> candidate (InvalidZkProposal)
+        // Game 3: type 1, IN_PROGRESS, TEE + ZK (dual proof) -> candidate (InvalidDualProposal)
         // Game 4: type 1, IN_PROGRESS, TEE only -> candidate (InvalidTeeProposal)
         let factory = Arc::new(MockDisputeGameFactory {
             games: vec![
@@ -754,7 +754,7 @@ mod tests {
         assert_eq!(candidates[1].factory.game_type, 99);
         assert_eq!(candidates[1].info.l2_block_number, 150);
         assert_eq!(candidates[2].index, 3);
-        assert_eq!(candidates[2].category, GameCategory::InvalidZkProposal);
+        assert_eq!(candidates[2].category, GameCategory::InvalidDualProposal);
         assert_eq!(candidates[3].index, 4);
         assert_eq!(candidates[3].factory.game_type, 1);
         assert_eq!(candidates[3].info.l2_block_number, 400);
@@ -770,11 +770,11 @@ mod tests {
         });
 
         let mut verifier_games = HashMap::new();
-        // Game 0: TEE + ZK (dual proof, no challenge) -> candidate (InvalidZkProposal)
+        // Game 0: TEE + ZK (dual proof, no challenge) -> candidate (InvalidDualProposal)
         verifier_games.insert(addr(0), mock_state(0, zk_addr, 100));
         // Game 1: TEE only -> candidate (InvalidTeeProposal)
         verifier_games.insert(addr(1), mock_state(0, Address::ZERO, 200));
-        // Game 2: TEE + ZK (dual proof, no challenge) -> candidate (InvalidZkProposal)
+        // Game 2: TEE + ZK (dual proof, no challenge) -> candidate (InvalidDualProposal)
         verifier_games.insert(addr(2), mock_state(0, zk_addr, 300));
 
         let verifier = Arc::new(MockAggregateVerifier::new(verifier_games));
@@ -785,11 +785,11 @@ mod tests {
 
         assert_eq!(candidates.len(), 3);
         assert_eq!(candidates[0].index, 0);
-        assert_eq!(candidates[0].category, GameCategory::InvalidZkProposal);
+        assert_eq!(candidates[0].category, GameCategory::InvalidDualProposal);
         assert_eq!(candidates[1].index, 1);
         assert_eq!(candidates[1].category, GameCategory::InvalidTeeProposal);
         assert_eq!(candidates[2].index, 2);
-        assert_eq!(candidates[2].category, GameCategory::InvalidZkProposal);
+        assert_eq!(candidates[2].category, GameCategory::InvalidDualProposal);
     }
 
     /// Empty factory returns empty vec without error.
@@ -996,7 +996,7 @@ mod tests {
         let candidates = scanner.scan().await.unwrap();
 
         assert_eq!(candidates.len(), 1, "dual-proof game should be a candidate");
-        assert_eq!(candidates[0].category, GameCategory::InvalidZkProposal);
+        assert_eq!(candidates[0].category, GameCategory::InvalidDualProposal);
     }
 
     /// Games with both `teeProver` and `zkProver` at `Address::ZERO` are

--- a/crates/proof/challenge/src/test_utils.rs
+++ b/crates/proof/challenge/src/test_utils.rs
@@ -151,7 +151,7 @@ pub struct MockAggregateVerifier {
 
 impl MockAggregateVerifier {
     /// Creates a new mock verifier from a pre-built game state map.
-    pub fn new(games: HashMap<Address, MockGameState>) -> Self {
+    pub const fn new(games: HashMap<Address, MockGameState>) -> Self {
         Self { games: Mutex::new(games) }
     }
 

--- a/crates/proof/challenge/src/test_utils.rs
+++ b/crates/proof/challenge/src/test_utils.rs
@@ -138,19 +138,39 @@ impl DisputeGameFactoryClient for MockDisputeGameFactory {
 }
 
 /// Mock aggregate verifier with configurable per-address game state.
+///
+/// Uses interior mutability (`Mutex`) so that multi-step driver tests can
+/// update game state between steps to simulate on-chain effects (e.g.
+/// setting `status = 1` after a successful challenge transaction).
 #[derive(Debug)]
 pub struct MockAggregateVerifier {
-    /// Per-address game state lookup.
-    pub games: HashMap<Address, MockGameState>,
+    /// Per-address game state lookup, wrapped in a `Mutex` for interior
+    /// mutability in multi-step tests.
+    pub games: Mutex<HashMap<Address, MockGameState>>,
 }
 
 impl MockAggregateVerifier {
+    /// Creates a new mock verifier from a pre-built game state map.
+    pub fn new(games: HashMap<Address, MockGameState>) -> Self {
+        Self { games: Mutex::new(games) }
+    }
+
+    /// Updates the state for a specific game address.
+    ///
+    /// Multi-step driver tests call this between steps to simulate on-chain
+    /// state changes (e.g. marking a game as resolved after proof submission).
+    pub fn update_game(&self, address: Address, state: MockGameState) {
+        self.games.lock().unwrap().insert(address, state);
+    }
+
     fn get<T>(
         &self,
         game_address: Address,
         f: impl FnOnce(&MockGameState) -> T,
     ) -> Result<T, ContractError> {
         self.games
+            .lock()
+            .unwrap()
             .get(&game_address)
             .map(f)
             .ok_or_else(|| ContractError::Validation(format!("unknown game {game_address}")))
@@ -689,14 +709,14 @@ mod tests {
     use super::*;
     use crate::scanner::{GameCategory, GameScanner, ScannerConfig};
 
-    /// Happy path: mixed games, only `IN_PROGRESS` / unchallenged returned.
+    /// Happy path: mixed games, only `IN_PROGRESS` / non-nullified returned.
     #[tokio::test]
     async fn test_scan_happy_path() {
-        // Game 0: type 1, IN_PROGRESS, unchallenged -> candidate
-        // Game 1: type 99, IN_PROGRESS, unchallenged -> candidate (all types scanned)
+        // Game 0: type 1, IN_PROGRESS, TEE only -> candidate (InvalidTeeProposal)
+        // Game 1: type 99, IN_PROGRESS, TEE only -> candidate (all types scanned)
         // Game 2: type 1, status=1 (not in progress) -> skipped
-        // Game 3: type 1, IN_PROGRESS, already challenged -> skipped
-        // Game 4: type 1, IN_PROGRESS, unchallenged -> candidate
+        // Game 3: type 1, IN_PROGRESS, TEE + ZK (dual proof) -> candidate (InvalidZkProposal)
+        // Game 4: type 1, IN_PROGRESS, TEE only -> candidate (InvalidTeeProposal)
         let factory = Arc::new(MockDisputeGameFactory {
             games: vec![
                 factory_game(0, 1),
@@ -715,91 +735,74 @@ mod tests {
         verifier_games.insert(addr(3), mock_state(0, challenger_addr, 300));
         verifier_games.insert(addr(4), mock_state(0, Address::ZERO, 400));
 
-        let verifier = Arc::new(MockAggregateVerifier { games: verifier_games });
+        let verifier = Arc::new(MockAggregateVerifier::new(verifier_games));
 
         let scanner = GameScanner::new(factory, verifier, ScannerConfig { lookback_games: 1000 });
 
-        let (candidates, new_last_scanned) = scanner.scan(None).await.unwrap();
+        let candidates = scanner.scan().await.unwrap();
 
-        // last_scanned=None, start = max(0, 5-1000) = 0, so games 0..=4 scanned
-        // Game 0: candidate. Game 1: candidate. Game 2: status != 0.
-        // Game 3: challenged. Game 4: candidate.
-        assert_eq!(candidates.len(), 3);
+        // start = max(0, 5-1000) = 0, so games 0..=4 scanned
+        // Game 0: TEE only -> candidate. Game 1: TEE only -> candidate.
+        // Game 2: status != 0 -> skipped.
+        // Game 3: dual proof (TEE+ZK, no challenge) -> candidate.
+        // Game 4: TEE only -> candidate.
+        assert_eq!(candidates.len(), 4);
         assert_eq!(candidates[0].index, 0);
         assert_eq!(candidates[0].factory.game_type, 1);
         assert_eq!(candidates[0].info.l2_block_number, 100);
         assert_eq!(candidates[1].index, 1);
         assert_eq!(candidates[1].factory.game_type, 99);
         assert_eq!(candidates[1].info.l2_block_number, 150);
-        assert_eq!(candidates[2].index, 4);
-        assert_eq!(candidates[2].factory.game_type, 1);
-        assert_eq!(candidates[2].info.l2_block_number, 400);
-        assert_eq!(new_last_scanned, Some(4));
+        assert_eq!(candidates[2].index, 3);
+        assert_eq!(candidates[2].category, GameCategory::InvalidZkProposal);
+        assert_eq!(candidates[3].index, 4);
+        assert_eq!(candidates[3].factory.game_type, 1);
+        assert_eq!(candidates[3].info.l2_block_number, 400);
     }
 
-    /// Already-challenged games (zkProver != zero) are filtered out.
+    /// Dual-proof games (TEE + ZK, no challenge) are now candidates.
     #[tokio::test]
-    async fn test_scan_filters_challenged_games() {
-        let challenger_addr = Address::repeat_byte(0xAA);
+    async fn test_scan_dual_proof_games_are_candidates() {
+        let zk_addr = Address::repeat_byte(0xAA);
 
         let factory = Arc::new(MockDisputeGameFactory {
             games: vec![factory_game(0, 1), factory_game(1, 1), factory_game(2, 1)],
         });
 
         let mut verifier_games = HashMap::new();
-        // All IN_PROGRESS but index 0 and 2 are already challenged
-        verifier_games.insert(addr(0), mock_state(0, challenger_addr, 100));
+        // Game 0: TEE + ZK (dual proof, no challenge) -> candidate (InvalidZkProposal)
+        verifier_games.insert(addr(0), mock_state(0, zk_addr, 100));
+        // Game 1: TEE only -> candidate (InvalidTeeProposal)
         verifier_games.insert(addr(1), mock_state(0, Address::ZERO, 200));
-        verifier_games.insert(addr(2), mock_state(0, challenger_addr, 300));
+        // Game 2: TEE + ZK (dual proof, no challenge) -> candidate (InvalidZkProposal)
+        verifier_games.insert(addr(2), mock_state(0, zk_addr, 300));
 
-        let verifier = Arc::new(MockAggregateVerifier { games: verifier_games });
+        let verifier = Arc::new(MockAggregateVerifier::new(verifier_games));
 
         let scanner = GameScanner::new(factory, verifier, ScannerConfig { lookback_games: 1000 });
 
-        // Scan from the beginning (last_scanned=None, lookback covers all)
-        // start = max(0, 3-1000) = 0, end = 2
-        // Game 0: challenged -> skip. Game 1: unchallenged -> candidate. Game 2: challenged -> skip.
-        let (candidates, new_last_scanned) = scanner.scan(None).await.unwrap();
+        let candidates = scanner.scan().await.unwrap();
 
-        assert_eq!(candidates.len(), 1);
-        assert_eq!(candidates[0].index, 1);
-        assert_eq!(new_last_scanned, Some(2));
+        assert_eq!(candidates.len(), 3);
+        assert_eq!(candidates[0].index, 0);
+        assert_eq!(candidates[0].category, GameCategory::InvalidZkProposal);
+        assert_eq!(candidates[1].index, 1);
+        assert_eq!(candidates[1].category, GameCategory::InvalidTeeProposal);
+        assert_eq!(candidates[2].index, 2);
+        assert_eq!(candidates[2].category, GameCategory::InvalidZkProposal);
     }
 
     /// Empty factory returns empty vec without error.
     #[tokio::test]
     async fn test_scan_empty_factory() {
         let factory = Arc::new(MockDisputeGameFactory { games: vec![] });
-        let verifier = Arc::new(MockAggregateVerifier { games: HashMap::new() });
+        let verifier = Arc::new(MockAggregateVerifier::new(HashMap::new()));
 
         let scanner = GameScanner::new(factory, verifier, ScannerConfig { lookback_games: 1000 });
 
-        let (candidates, new_last_scanned) = scanner.scan(None).await.unwrap();
+        let candidates = scanner.scan().await.unwrap();
 
         assert!(candidates.is_empty());
-        assert_eq!(new_last_scanned, None);
-    }
-
-    /// No new games since last scan returns empty vec.
-    #[tokio::test]
-    async fn test_scan_no_new_games() {
-        let factory = Arc::new(MockDisputeGameFactory {
-            games: vec![factory_game(0, 1), factory_game(1, 1)],
-        });
-
-        let mut verifier_games = HashMap::new();
-        verifier_games.insert(addr(0), mock_state(0, Address::ZERO, 100));
-        verifier_games.insert(addr(1), mock_state(0, Address::ZERO, 200));
-
-        let verifier = Arc::new(MockAggregateVerifier { games: verifier_games });
-
-        let scanner = GameScanner::new(factory, verifier, ScannerConfig { lookback_games: 1000 });
-
-        // last_scanned = Some(1) (gameCount - 1), so start = 2 > end = 1
-        let (candidates, new_last_scanned) = scanner.scan(Some(1)).await.unwrap();
-
-        assert!(candidates.is_empty());
-        assert_eq!(new_last_scanned, Some(1));
     }
 
     /// Lookback window: on fresh start with large factory, only `lookback_games` are scanned.
@@ -815,23 +818,22 @@ mod tests {
         }
 
         let factory = Arc::new(MockDisputeGameFactory { games });
-        let verifier = Arc::new(MockAggregateVerifier { games: verifier_games });
+        let verifier = Arc::new(MockAggregateVerifier::new(verifier_games));
 
         let scanner = GameScanner::new(factory, verifier, ScannerConfig { lookback_games: 3 });
 
-        // Fresh start: last_scanned = None
-        // start = max(0, 100-3) = 97, end = 99
-        let (candidates, new_last_scanned) = scanner.scan(None).await.unwrap();
+        // start = 100-3 = 97, end = 99
+        let candidates = scanner.scan().await.unwrap();
 
         assert_eq!(candidates.len(), 3);
         assert_eq!(candidates[0].index, 97);
         assert_eq!(candidates[1].index, 98);
         assert_eq!(candidates[2].index, 99);
-        assert_eq!(new_last_scanned, Some(99));
     }
 
     /// Error resilience: a per-game error is logged and skipped, other games still returned.
-    /// `new_last_scanned` is set to one before the errored index so it will be retried.
+    /// Errored games are naturally retried on the next scan since the full lookback
+    /// window is always evaluated.
     #[tokio::test]
     async fn test_scan_skips_errored_games() {
         // 3 games: index 1 will error, indices 0 and 2 are valid candidates
@@ -847,61 +849,16 @@ mod tests {
         // index 1 won't be queried on the verifier because the factory errors first
         verifier_games.insert(addr(2), mock_state(0, Address::ZERO, 300));
 
-        let verifier = Arc::new(MockAggregateVerifier { games: verifier_games });
+        let verifier = Arc::new(MockAggregateVerifier::new(verifier_games));
 
         let scanner = GameScanner::new(factory, verifier, ScannerConfig { lookback_games: 1000 });
 
-        // start = max(0, 3-1000) = 0, end = 2
         // Index 0 -> candidate. Index 1 errors -> skipped. Index 2 -> candidate.
-        // new_last_scanned = lowest_error(1) - 1 = 0, so next scan retries from index 1.
-        let (candidates, new_last_scanned) = scanner.scan(None).await.unwrap();
+        let candidates = scanner.scan().await.unwrap();
 
         assert_eq!(candidates.len(), 2);
         assert_eq!(candidates[0].index, 0);
         assert_eq!(candidates[1].index, 2);
-        assert_eq!(new_last_scanned, Some(0));
-    }
-
-    /// Retry: errored games are retried on the next scan when the error clears.
-    #[tokio::test]
-    async fn test_scan_retries_errored_games() {
-        // Phase 1: index 1 errors, so new_last_scanned = Some(0)
-        let factory = Arc::new(ErrorOnIndexFactory {
-            inner: MockDisputeGameFactory {
-                games: vec![factory_game(0, 1), factory_game(1, 1), factory_game(2, 1)],
-            },
-            error_indices: vec![1],
-        });
-
-        let mut verifier_games = HashMap::new();
-        verifier_games.insert(addr(0), mock_state(0, Address::ZERO, 100));
-        verifier_games.insert(addr(1), mock_state(0, Address::ZERO, 200));
-        verifier_games.insert(addr(2), mock_state(0, Address::ZERO, 300));
-
-        let verifier = Arc::new(MockAggregateVerifier { games: verifier_games.clone() });
-
-        let scanner = GameScanner::new(factory, verifier, ScannerConfig { lookback_games: 1000 });
-
-        let (_, new_last_scanned) = scanner.scan(None).await.unwrap();
-        assert_eq!(new_last_scanned, Some(0));
-
-        // Phase 2: no errors, pass last_scanned = Some(0) to retry from index 1
-        let factory2 = Arc::new(MockDisputeGameFactory {
-            games: vec![factory_game(0, 1), factory_game(1, 1), factory_game(2, 1)],
-        });
-
-        let verifier2 = Arc::new(MockAggregateVerifier { games: verifier_games });
-
-        let scanner2 =
-            GameScanner::new(factory2, verifier2, ScannerConfig { lookback_games: 1000 });
-
-        let (candidates, new_last_scanned) = scanner2.scan(Some(0)).await.unwrap();
-
-        // Indices 1 and 2 are now scanned successfully
-        assert_eq!(candidates.len(), 2);
-        assert_eq!(candidates[0].index, 1);
-        assert_eq!(candidates[1].index, 2);
-        assert_eq!(new_last_scanned, Some(2));
     }
 
     /// Games with a non-zero TEE prover but zero ZK prover are still candidates.
@@ -923,19 +880,18 @@ mod tests {
         // Game 1: IN_PROGRESS, no ZK prover, has default TEE prover -> candidate
         verifier_games.insert(addr(1), mock_state(0, Address::ZERO, 200));
 
-        let verifier = Arc::new(MockAggregateVerifier { games: verifier_games });
+        let verifier = Arc::new(MockAggregateVerifier::new(verifier_games));
 
         let scanner = GameScanner::new(factory, verifier, ScannerConfig { lookback_games: 1000 });
 
-        let (candidates, new_last_scanned) = scanner.scan(None).await.unwrap();
+        let candidates = scanner.scan().await.unwrap();
 
         assert_eq!(candidates.len(), 2);
         assert_eq!(candidates[0].index, 0);
         assert_eq!(candidates[1].index, 1);
-        assert_eq!(new_last_scanned, Some(1));
     }
 
-    /// Error at the first index (0) with `last_scanned = None` preserves fresh-start semantics.
+    /// Error at the first index (0) skips that game, rest still returned.
     #[tokio::test]
     async fn test_scan_error_at_first_index() {
         let factory = Arc::new(ErrorOnIndexFactory {
@@ -946,16 +902,14 @@ mod tests {
         let mut verifier_games = HashMap::new();
         verifier_games.insert(addr(1), mock_state(0, Address::ZERO, 200));
 
-        let verifier = Arc::new(MockAggregateVerifier { games: verifier_games });
+        let verifier = Arc::new(MockAggregateVerifier::new(verifier_games));
 
         let scanner = GameScanner::new(factory, verifier, ScannerConfig { lookback_games: 1000 });
 
-        // last_scanned = None, lowest_error = 0 -> preserves None (fresh-start semantics)
-        let (candidates, new_last_scanned) = scanner.scan(None).await.unwrap();
+        let candidates = scanner.scan().await.unwrap();
 
         assert_eq!(candidates.len(), 1);
         assert_eq!(candidates[0].index, 1);
-        assert_eq!(new_last_scanned, None);
     }
 
     /// A challenged game (TEE + ZK provers non-zero, `countered_index` > 0) is
@@ -972,10 +926,10 @@ mod tests {
         state.countered_index = 3; // 1-based: challenged at 0-based index 2
         verifier_games.insert(addr(0), state);
 
-        let verifier = Arc::new(MockAggregateVerifier { games: verifier_games });
+        let verifier = Arc::new(MockAggregateVerifier::new(verifier_games));
         let scanner = GameScanner::new(factory, verifier, ScannerConfig { lookback_games: 1000 });
 
-        let (candidates, _) = scanner.scan(None).await.unwrap();
+        let candidates = scanner.scan().await.unwrap();
 
         assert_eq!(candidates.len(), 1);
         assert_eq!(
@@ -996,10 +950,10 @@ mod tests {
         // tee_prover == ZERO, zk_prover != ZERO, countered_index == 0
         verifier_games.insert(addr(0), mock_state_with_tee(0, zk_addr, Address::ZERO, 100));
 
-        let verifier = Arc::new(MockAggregateVerifier { games: verifier_games });
+        let verifier = Arc::new(MockAggregateVerifier::new(verifier_games));
         let scanner = GameScanner::new(factory, verifier, ScannerConfig { lookback_games: 1000 });
 
-        let (candidates, _) = scanner.scan(None).await.unwrap();
+        let candidates = scanner.scan().await.unwrap();
 
         assert_eq!(candidates.len(), 1);
         assert_eq!(candidates[0].category, GameCategory::InvalidZkProposal);
@@ -1014,18 +968,19 @@ mod tests {
         let mut verifier_games = HashMap::new();
         verifier_games.insert(addr(0), mock_state(0, Address::ZERO, 100));
 
-        let verifier = Arc::new(MockAggregateVerifier { games: verifier_games });
+        let verifier = Arc::new(MockAggregateVerifier::new(verifier_games));
         let scanner = GameScanner::new(factory, verifier, ScannerConfig { lookback_games: 1000 });
 
-        let (candidates, _) = scanner.scan(None).await.unwrap();
+        let candidates = scanner.scan().await.unwrap();
 
         assert_eq!(candidates.len(), 1);
         assert_eq!(candidates[0].category, GameCategory::InvalidTeeProposal);
     }
 
-    /// A game with both proofs verified (TEE + ZK, no challenge) is skipped.
+    /// A game with both proofs verified (TEE + ZK, no challenge) is a
+    /// candidate for validation. Both proofs may verify a wrong root.
     #[tokio::test]
-    async fn test_scan_both_proofs_verified_skipped() {
+    async fn test_scan_both_proofs_verified_is_candidate() {
         let tee_addr = Address::repeat_byte(0xEE);
         let zk_addr = Address::repeat_byte(0xCC);
 
@@ -1035,12 +990,13 @@ mod tests {
         // Both provers non-zero, countered_index == 0 (added via verifyProposalProof)
         verifier_games.insert(addr(0), mock_state_with_tee(0, zk_addr, tee_addr, 100));
 
-        let verifier = Arc::new(MockAggregateVerifier { games: verifier_games });
+        let verifier = Arc::new(MockAggregateVerifier::new(verifier_games));
         let scanner = GameScanner::new(factory, verifier, ScannerConfig { lookback_games: 1000 });
 
-        let (candidates, _) = scanner.scan(None).await.unwrap();
+        let candidates = scanner.scan().await.unwrap();
 
-        assert!(candidates.is_empty(), "game with both proofs should be skipped");
+        assert_eq!(candidates.len(), 1, "dual-proof game should be a candidate");
+        assert_eq!(candidates[0].category, GameCategory::InvalidZkProposal);
     }
 
     /// Games with both `teeProver` and `zkProver` at `Address::ZERO` are
@@ -1062,14 +1018,13 @@ mod tests {
         // Game 2: both provers zeroed (nullified) → filtered out
         verifier_games.insert(addr(2), mock_state_with_tee(0, Address::ZERO, Address::ZERO, 300));
 
-        let verifier = Arc::new(MockAggregateVerifier { games: verifier_games });
+        let verifier = Arc::new(MockAggregateVerifier::new(verifier_games));
 
         let scanner = GameScanner::new(factory, verifier, ScannerConfig { lookback_games: 1000 });
 
-        let (candidates, new_last_scanned) = scanner.scan(None).await.unwrap();
+        let candidates = scanner.scan().await.unwrap();
 
         assert_eq!(candidates.len(), 1, "only the non-nullified game should be a candidate");
         assert_eq!(candidates[0].index, 1);
-        assert_eq!(new_last_scanned, Some(2));
     }
 }

--- a/crates/proof/challenge/tests/driver.rs
+++ b/crates/proof/challenge/tests/driver.rs
@@ -913,10 +913,10 @@ async fn test_step_valid_zk_proposal_skipped() {
 // ──────────────────────────────────────────────────────────────────────────
 
 #[tokio::test]
-async fn test_step_dual_proof_invalid_initiates_zk_nullification() {
+async fn test_step_dual_proof_invalid_without_tee_config_falls_back_to_zk_nullify() {
     // A game with both TEE and ZK proofs verified (via verifyProposalProof,
-    // not challenge) where the output roots are invalid should trigger a
-    // ZK proof with DisputeIntent::Nullify to nullify the ZK proof first.
+    // not challenge) where the output roots are invalid and no TEE config is
+    // available should fall back to a ZK proof with DisputeIntent::Nullify.
     let (l2, factory, root_15, _root_20) = base_game_mocks();
 
     let verifier = single_game_verifier(MockGameState {
@@ -936,7 +936,58 @@ async fn test_step_dual_proof_invalid_initiates_zk_nullification() {
     assert_eq!(
         entry.intent,
         DisputeIntent::Nullify,
-        "dual-proof game should use Nullify intent to nullify ZK proof first"
+        "dual-proof game without TEE config should fall back to ZK Nullify"
+    );
+}
+
+#[tokio::test]
+async fn test_step_dual_proof_invalid_with_tee_config_nullifies_tee_first() {
+    // A game with both TEE and ZK proofs verified where output roots are
+    // invalid and a TEE config is available should attempt TEE nullification
+    // first (fast path). After TEE nullification the game will be rescanned
+    // as InvalidZkProposal on the next tick.
+    let (l2, factory, root_15, root_20) = base_game_mocks();
+
+    let verifier = single_game_verifier(MockGameState {
+        tee_prover: DEFAULT_TEE_PROVER,
+        zk_prover: ZK_PROVER_ADDR,
+        intermediate_output_roots: vec![root_15, BOGUS_ROOT],
+        ..game_state(20)
+    });
+
+    let l1_head = Arc::new(MockL1HeadProvider::success(DEFAULT_L1_HEAD, 100));
+
+    let aggregate_proposal = Proposal {
+        output_root: root_20,
+        signature: Bytes::from(vec![0u8; 65]),
+        l1_origin_hash: DEFAULT_L1_HEAD,
+        l1_origin_number: 1000,
+        l2_block_number: 20,
+        prev_output_root: root_15,
+        config_hash: B256::ZERO,
+    };
+    let tee_provider = Arc::new(MockTeeProofProvider::success(ProofResult::Tee {
+        aggregate_proposal,
+        proposals: vec![],
+    }));
+
+    let tx_manager = default_tx_manager();
+
+    let mut driver = test_driver_with_tee(
+        factory,
+        verifier,
+        l2,
+        default_zk_prover(),
+        tx_manager,
+        Some(tee_config(tee_provider, l1_head)),
+    );
+
+    driver.step().await.unwrap();
+
+    // TEE proof was submitted synchronously; no pending ZK proof should remain.
+    assert!(
+        !driver.pending_proofs.contains_key(&addr(0)),
+        "TEE proof should have been submitted directly for dual-proof game"
     );
 }
 
@@ -956,6 +1007,43 @@ async fn test_step_dual_proof_valid_skipped() {
     driver.step().await.unwrap();
 
     assert!(driver.pending_proofs.is_empty(), "valid dual-proof game should not trigger any proof");
+}
+
+#[tokio::test]
+async fn test_step_dual_proof_tee_fails_falls_back_to_zk_nullify() {
+    // A dual-proof game where the TEE proof fails should fall back to ZK
+    // with DisputeIntent::Nullify (not Challenge).
+    let (l2, factory, root_15, _root_20) = base_game_mocks();
+
+    let verifier = single_game_verifier(MockGameState {
+        tee_prover: DEFAULT_TEE_PROVER,
+        zk_prover: ZK_PROVER_ADDR,
+        intermediate_output_roots: vec![root_15, BOGUS_ROOT],
+        ..game_state(20)
+    });
+
+    let tee = Arc::new(MockTeeProofProvider::failure("enclave unreachable"));
+
+    let mut driver = test_driver_with_tee(
+        factory,
+        verifier,
+        l2,
+        default_zk_prover(),
+        default_tx_manager(),
+        Some(tee_config(tee, Arc::new(MockL1HeadProvider::failure("dummy")))),
+    );
+
+    driver.step().await.unwrap();
+
+    let entry = driver
+        .pending_proofs
+        .get(&addr(0))
+        .expect("ZK proof should be pending after TEE fallback for dual-proof game");
+    assert_eq!(
+        entry.intent,
+        DisputeIntent::Nullify,
+        "dual-proof TEE fallback must use Nullify intent, not Challenge"
+    );
 }
 
 // ──────────────────────────────────────────────────────────────────────────

--- a/crates/proof/challenge/tests/driver.rs
+++ b/crates/proof/challenge/tests/driver.rs
@@ -50,7 +50,7 @@ fn game_state(l2_block_number: u64) -> MockGameState {
 }
 
 fn empty_verifier() -> Arc<MockAggregateVerifier> {
-    Arc::new(MockAggregateVerifier { games: HashMap::new() })
+    Arc::new(MockAggregateVerifier::new(HashMap::new()))
 }
 
 /// Builds a test driver with the given mocks.
@@ -118,7 +118,7 @@ fn single_game_factory() -> Arc<MockDisputeGameFactory> {
 }
 
 fn single_game_verifier(state: MockGameState) -> Arc<MockAggregateVerifier> {
-    Arc::new(MockAggregateVerifier { games: HashMap::from([(addr(0), state)]) })
+    Arc::new(MockAggregateVerifier::new(HashMap::from([(addr(0), state)])))
 }
 
 fn tee_config(
@@ -275,7 +275,8 @@ async fn test_step_invalid_game_proof_succeeded() {
 
     let tx_manager = default_tx_manager();
 
-    let mut driver = test_driver(factory, verifier, l2, zk, tx_manager);
+    let mut driver =
+        test_driver(factory, Arc::clone(&verifier), l2, zk, tx_manager);
 
     // Step 1: proof initiated, not yet polled.
     driver.step().await.unwrap();
@@ -283,6 +284,9 @@ async fn test_step_invalid_game_proof_succeeded() {
         driver.pending_proofs.contains_key(&addr(0)),
         "proof should be pending after initiation"
     );
+
+    // Simulate the on-chain effect of a successful challenge: game is resolved.
+    verifier.update_game(addr(0), MockGameState { status: 1, ..game_state(20) });
 
     // Step 2: proof polled → Succeeded → nullification submitted → entry removed.
     driver.step().await.unwrap();
@@ -406,7 +410,8 @@ async fn test_step_pending_proof_skips_prove_block() {
 
     let tx_manager = default_tx_manager();
 
-    let mut driver = test_driver(factory, verifier, l2, Arc::clone(&zk), tx_manager);
+    let mut driver =
+        test_driver(factory, Arc::clone(&verifier), l2, Arc::clone(&zk), tx_manager);
 
     // Step 1: proof is initiated but not ready (Unspecified) → session stored.
     driver.step().await.unwrap();
@@ -417,6 +422,9 @@ async fn test_step_pending_proof_skips_prove_block() {
 
     // Simulate the proof completing before the next poll.
     zk.state.lock().unwrap().proof_status = ProofJobStatus::Succeeded as i32;
+
+    // Simulate the on-chain effect: game is resolved after challenge tx.
+    verifier.update_game(addr(0), MockGameState { status: 1, ..game_state(20) });
 
     // Step 2: same game re-discovered → polls existing session, proof succeeds,
     // challenge tx submitted, session removed from pending_proofs.
@@ -439,7 +447,8 @@ async fn test_step_nullification_failure_preserves_proof() {
         Ok(receipt_with_status(true, DEFAULT_TX_HASH)),
     ]);
 
-    let mut driver = test_driver(factory, verifier, l2, zk, tx_manager);
+    let mut driver =
+        test_driver(factory, Arc::clone(&verifier), l2, zk, tx_manager);
 
     // Step 1: proof initiated but not yet polled.
     driver.step().await.unwrap();
@@ -454,6 +463,9 @@ async fn test_step_nullification_failure_preserves_proof() {
     // Entry must still be in pending_proofs as ReadyToSubmit.
     let entry = driver.pending_proofs.get(&addr(0)).expect("proof should be preserved");
     assert!(entry.is_ready(), "phase should be ReadyToSubmit after tx failure");
+
+    // Simulate the on-chain effect of a successful challenge: game is resolved.
+    verifier.update_game(addr(0), MockGameState { status: 1, ..game_state(20) });
 
     // Step 3: poll_pending_proofs re-submits the challenge tx, now it succeeds.
     driver.step().await.unwrap();
@@ -529,7 +541,8 @@ async fn test_step_proof_retry_succeeds() {
 
     let tx_manager = default_tx_manager();
 
-    let mut driver = test_driver(factory, verifier, l2, Arc::clone(&zk), tx_manager);
+    let mut driver =
+        test_driver(factory, Arc::clone(&verifier), l2, Arc::clone(&zk), tx_manager);
 
     // Step 1: proof initiated, not yet polled.
     driver.step().await.unwrap();
@@ -551,6 +564,9 @@ async fn test_step_proof_retry_succeeds() {
     // Simulate proof succeeding on the retry session.
     zk.state.lock().unwrap().proof_status = ProofJobStatus::Succeeded as i32;
 
+    // Simulate the on-chain effect of a successful challenge: game is resolved.
+    verifier.update_game(addr(0), MockGameState { status: 1, ..game_state(20) });
+
     // Step 3: proof succeeds, challenge tx submitted, entry removed.
     driver.step().await.unwrap();
     assert!(
@@ -566,7 +582,8 @@ async fn test_step_proof_exceeds_max_retries() {
     let zk = failed_zk_prover("fail-forever");
 
     let tx_manager = default_tx_manager();
-    let mut driver = test_driver(factory, verifier, l2, zk, tx_manager);
+    let mut driver =
+        test_driver(factory, Arc::clone(&verifier), l2, zk, tx_manager);
 
     // Step 1: proof initiated, not yet polled.
     driver.step().await.unwrap();
@@ -582,6 +599,10 @@ async fn test_step_proof_exceeds_max_retries() {
         let entry = driver.pending_proofs.get(&addr(0)).expect("entry should exist during retries");
         assert_eq!(entry.retry_count, i + 1);
     }
+
+    // Simulate the on-chain effect: mark the game as resolved so the
+    // stateless scanner does not re-discover it after the entry is dropped.
+    verifier.update_game(addr(0), MockGameState { status: 1, ..game_state(20) });
 
     // One more step: poll returns Failed → retry_count becomes max_retries + 1,
     // handle_proof_retry sees retry_count > MAX_PROOF_RETRIES and drops the entry.
@@ -649,7 +670,7 @@ async fn test_step_invalid_game_tee_fails_zk_succeeds() {
 
     let mut driver = test_driver_with_tee(
         factory,
-        verifier,
+        Arc::clone(&verifier),
         l2,
         zk,
         tx_manager,
@@ -663,6 +684,9 @@ async fn test_step_invalid_game_tee_fails_zk_succeeds() {
         driver.pending_proofs.contains_key(&addr(0)),
         "ZK proof should be pending after TEE fallback"
     );
+
+    // Simulate the on-chain effect of a successful challenge: game is resolved.
+    verifier.update_game(addr(0), MockGameState { status: 1, ..game_state(20) });
 
     // Step 2: proof polled → Succeeded → challenge tx submitted → entry removed.
     driver.step().await.unwrap();
@@ -887,6 +911,56 @@ async fn test_step_valid_zk_proposal_skipped() {
     driver.step().await.unwrap();
 
     assert!(driver.pending_proofs.is_empty(), "valid ZK proposal should not trigger any proof");
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Dual-proof games: both TEE and ZK proofs verified (no challenge)
+// ──────────────────────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn test_step_dual_proof_invalid_initiates_zk_nullification() {
+    // A game with both TEE and ZK proofs verified (via verifyProposalProof,
+    // not challenge) where the output roots are invalid should trigger a
+    // ZK proof with DisputeIntent::Nullify to nullify the ZK proof first.
+    let (l2, factory, root_15, _root_20) = base_game_mocks();
+
+    let verifier = single_game_verifier(MockGameState {
+        tee_prover: DEFAULT_TEE_PROVER,
+        zk_prover: ZK_PROVER_ADDR,
+        intermediate_output_roots: vec![root_15, BOGUS_ROOT],
+        ..game_state(20)
+    });
+
+    let mut driver = test_driver(factory, verifier, l2, default_zk_prover(), default_tx_manager());
+    driver.step().await.unwrap();
+
+    let entry = driver
+        .pending_proofs
+        .get(&addr(0))
+        .expect("ZK nullification proof should be pending for dual-proof game");
+    assert_eq!(
+        entry.intent,
+        DisputeIntent::Nullify,
+        "dual-proof game should use Nullify intent to nullify ZK proof first"
+    );
+}
+
+#[tokio::test]
+async fn test_step_dual_proof_valid_skipped() {
+    // A game with both TEE and ZK proofs verified where output roots are
+    // valid should not trigger any action.
+    let factory = single_game_factory();
+    let verifier = single_game_verifier(MockGameState {
+        tee_prover: DEFAULT_TEE_PROVER,
+        zk_prover: ZK_PROVER_ADDR,
+        ..game_state(14)
+    });
+    let l2 = default_l2();
+
+    let mut driver = test_driver(factory, verifier, l2, default_zk_prover(), default_tx_manager());
+    driver.step().await.unwrap();
+
+    assert!(driver.pending_proofs.is_empty(), "valid dual-proof game should not trigger any proof");
 }
 
 // ──────────────────────────────────────────────────────────────────────────

--- a/crates/proof/challenge/tests/driver.rs
+++ b/crates/proof/challenge/tests/driver.rs
@@ -275,8 +275,7 @@ async fn test_step_invalid_game_proof_succeeded() {
 
     let tx_manager = default_tx_manager();
 
-    let mut driver =
-        test_driver(factory, Arc::clone(&verifier), l2, zk, tx_manager);
+    let mut driver = test_driver(factory, Arc::clone(&verifier), l2, zk, tx_manager);
 
     // Step 1: proof initiated, not yet polled.
     driver.step().await.unwrap();
@@ -410,8 +409,7 @@ async fn test_step_pending_proof_skips_prove_block() {
 
     let tx_manager = default_tx_manager();
 
-    let mut driver =
-        test_driver(factory, Arc::clone(&verifier), l2, Arc::clone(&zk), tx_manager);
+    let mut driver = test_driver(factory, Arc::clone(&verifier), l2, Arc::clone(&zk), tx_manager);
 
     // Step 1: proof is initiated but not ready (Unspecified) → session stored.
     driver.step().await.unwrap();
@@ -447,8 +445,7 @@ async fn test_step_nullification_failure_preserves_proof() {
         Ok(receipt_with_status(true, DEFAULT_TX_HASH)),
     ]);
 
-    let mut driver =
-        test_driver(factory, Arc::clone(&verifier), l2, zk, tx_manager);
+    let mut driver = test_driver(factory, Arc::clone(&verifier), l2, zk, tx_manager);
 
     // Step 1: proof initiated but not yet polled.
     driver.step().await.unwrap();
@@ -541,8 +538,7 @@ async fn test_step_proof_retry_succeeds() {
 
     let tx_manager = default_tx_manager();
 
-    let mut driver =
-        test_driver(factory, Arc::clone(&verifier), l2, Arc::clone(&zk), tx_manager);
+    let mut driver = test_driver(factory, Arc::clone(&verifier), l2, Arc::clone(&zk), tx_manager);
 
     // Step 1: proof initiated, not yet polled.
     driver.step().await.unwrap();
@@ -582,8 +578,7 @@ async fn test_step_proof_exceeds_max_retries() {
     let zk = failed_zk_prover("fail-forever");
 
     let tx_manager = default_tx_manager();
-    let mut driver =
-        test_driver(factory, Arc::clone(&verifier), l2, zk, tx_manager);
+    let mut driver = test_driver(factory, Arc::clone(&verifier), l2, zk, tx_manager);
 
     // Step 1: proof initiated, not yet polled.
     driver.step().await.unwrap();


### PR DESCRIPTION
## Summary
Backport of #2213 to `releases/v0.8.0`.

- Makes the challenger scanner fully stateless so every tick re-evaluates the entire lookback window, ensuring on-chain state changes (e.g. ZK proof added after TEE nullification) are always detected
- Games with both TEE and ZK proofs (dual-proof) are now classified as `InvalidZkProposal` instead of being skipped, ensuring both proofs are validated